### PR TITLE
Bump up kotlin 2.1.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,8 +91,8 @@ subprojects {
             languageVersion.set(JavaLanguageVersion.of(21))
         }
         compilerOptions {
-            languageVersion.set(KotlinVersion.KOTLIN_2_0)
-            apiVersion.set(KotlinVersion.KOTLIN_2_0)
+            languageVersion.set(KotlinVersion.KOTLIN_2_1)
+            apiVersion.set(KotlinVersion.KOTLIN_2_1)
             freeCompilerArgs = listOf(
                 "-Xjsr305=strict",
                 "-Xjvm-default=all",

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 kotlin {
     compilerOptions {
-        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0)
-        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0)
+        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_1)
+        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_1)
     }
 }

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -6,7 +6,7 @@ object Plugins {
 
     object Versions {
         const val dokka = "1.9.20"      // https://mvnrepository.com/artifact/org.jetbrains.dokka/dokka-gradle-plugin
-        const val detekt = "1.23.6"     // https://mvnrepository.com/artifact/io.gitlab.arturbosch.detekt/detekt-gradle-plugin
+        const val detekt = "1.23.7"     // https://mvnrepository.com/artifact/io.gitlab.arturbosch.detekt/detekt-gradle-plugin
         const val dependency_management = "1.1.6"  // https://mvnrepository.com/artifact/io.spring.gradle/dependency-management-plugin
         const val jooq = "9.0"       // https://mvnrepository.com/artifact/nu.studer.jooq/jooq-gradle-plugin
         const val protobuf = "0.9.4"    // https://mvnrepository.com/artifact/com.google.protobuf/protobuf-gradle-plugin
@@ -16,7 +16,7 @@ object Plugins {
         const val jarTest = "1.0.1"
         const val testLogger = "4.0.0"
         const val shadow = "7.1.2"
-        const val kotlinx_benchmark = "0.4.12" // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-benchmark-plugin
+        const val kotlinx_benchmark = "0.4.13" // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-benchmark-plugin
 
         const val spring_boot = "3.3.5"  // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies
         const val docker_compose = "0.16.12"
@@ -51,7 +51,7 @@ object Plugins {
 
 object Versions {
 
-    const val kotlin = "2.0.21"                 // https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib
+    const val kotlin = "2.1.0"                  // https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib
     const val kotlinx_coroutines = "1.9.0"      // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core
     const val kotlinx_serialization = "1.7.3"   // https://mvnrepository.com/search?q=kotlinx-serialization
 
@@ -82,9 +82,9 @@ object Versions {
     const val netty = "4.1.115.Final"  // https://mvnrepository.com/artifact/io.netty/netty-all
 
     const val aws = "1.12.772"    // https://mvnrepository.com/artifact/com.amazonaws
-    const val aws2 = "2.29.14"   // https://mvnrepository.com/artifact/software.amazon.awssdk/aws-sdk-java
-    const val aws2_crt = "0.33.0" // https://mvnrepository.com/artifact/software.amazon.awssdk.crt
-    const val aws_kotlin = "1.3.60" // https://mvnrepository.com/artifact/aws.sdk.kotlin
+    const val aws2 = "2.29.22"   // https://mvnrepository.com/artifact/software.amazon.awssdk/aws-sdk-java
+    const val aws2_crt = "0.33.3" // https://mvnrepository.com/artifact/software.amazon.awssdk.crt
+    const val aws_kotlin = "1.3.83" // https://mvnrepository.com/artifact/aws.sdk.kotlin
 
     const val grpc = "1.68.1"       // https://mvnrepository.com/artifact/io.grpc/grpc-stub
     const val grpc_kotlin = "1.4.1" // https://mvnrepository.com/artifact/io.grpc/grpc-kotlin-stub
@@ -114,7 +114,7 @@ object Versions {
     // NOTE: 이 경우 기존 javax 를 사용하는 버전과 충돌이 생길 수 있으니 조심하세요
     // https://mvnrepository.com/artifact/org.hibernate.orm/hibernate-core
 
-    const val hibernate = "6.6.2.Final"           // https://mvnrepository.com/artifact/org.hibernate.orm/hibernate-core
+    const val hibernate = "6.6.3.Final"           // https://mvnrepository.com/artifact/org.hibernate.orm/hibernate-core
     const val hibernate_reactive = "2.4.2.Final"  // https://mvnrepository.com/artifact/org.hibernate.reactive/hibernate-reactive-core
     const val hibernate_validator = "8.0.1.Final" // https://mvnrepository.com/artifact/org.hibernate.validator/hibernate-validator
     const val querydsl = "5.1.0"                  // https://mvnrepository.com/artifact/com.querydsl/querydsl-jpa

--- a/data/hibernate-reactive/build.gradle.kts
+++ b/data/hibernate-reactive/build.gradle.kts
@@ -21,8 +21,11 @@ kapt {
     showProcessorStats = true
 
     arguments {
-        arg("querydsl.entityAccessors", "true")
+        arg("querydsl.entityAccessors", "true")  // Association의 property는 getter/setter를 사용하도록 합니다.
         arg("querydsl.kotlinCodegen", "true") // QueryDSL Kotlin Codegen 활성화
+    }
+    javacOptions {
+        option("--add-modules", "java.base")
     }
 }
 
@@ -54,7 +57,6 @@ dependencies {
     api(Libs.hibernate_reactive_core)
 
     // hibernate-reactive 는 querydsl 을 사용하지 못한다. 대신 jpamodelgen 을 사용합니다.
-    // hibernate 6.3.0+ 는 hibernate-jpamodelgen 예서 예외가 발생합니다. (6.2.x 를 사용하세요)
     kapt(Libs.hibernate_jpamodelgen)
     kaptTest(Libs.hibernate_jpamodelgen)
 

--- a/data/hibernate/build.gradle.kts
+++ b/data/hibernate/build.gradle.kts
@@ -30,6 +30,14 @@ idea {
 kapt {
     correctErrorTypes = true
     showProcessorStats = true
+
+    arguments {
+        arg("querydsl.entityAccessors", "true")  // Association의 property는 getter/setter를 사용하도록 합니다.
+        arg("querydsl.kotlinCodegen", "true") // QueryDSL Kotlin Codegen 활성화
+    }
+    javacOptions {
+        option("--add-modules", "java.base")
+    }
 }
 
 configurations {
@@ -54,17 +62,16 @@ dependencies {
     api(project(":bluetape4k-io"))
     testImplementation(project(":bluetape4k-junit5"))
 
-    // NOTE: Java 9+ 환경에서 kapt가 제대로 동작하려면 javax.annotation-api 를 참조해야 합니다.
     api(Libs.jakarta_annotation_api)
-
     api(Libs.jakarta_persistence_api)
+
     api(Libs.hibernate_core)
     api(Libs.hibernate_micrometer)
     testImplementation(Libs.hibernate_testing)
 
-    // NOTE: hibernate 6.3.0+ 는 hibernate-jpamodelgen 예서 예외가 발생합니다. (6.2.x 를 사용하세요)
-    kapt(Libs.hibernate_jpamodelgen)
-    kaptTest(Libs.hibernate_jpamodelgen)
+    // Kotlin 2.1.0 에서 QueryDSL 5.1.0 과 같이 사용하는 경우 예에가 발생한다. (QueryDSL만 사용하는 것을 추천합니다)
+    // kapt(Libs.hibernate_jpamodelgen)
+    // kaptTest(Libs.hibernate_jpamodelgen)
 
     // Querydsl
     // Hibernate 6+ jakarta 용은 claasifier로 ":jpa" 대신 ":jakarta" 를 사용해야 합니다.

--- a/examples/jpa-querydsl/build.gradle.kts
+++ b/examples/jpa-querydsl/build.gradle.kts
@@ -16,9 +16,16 @@ allOpen {
 }
 
 kapt {
-    // showProcessorStats = true
-    // kapt 가 제대로 동작하지 않는 경우, 해당 클래스를 약간 수정해보세요. (Comments 추가 등으로)
-    // correctErrorTypes = true
+    correctErrorTypes = true
+    showProcessorStats = true
+
+    arguments {
+        arg("querydsl.entityAccessors", "true")  // Association의 property는 getter/setter를 사용하도록 합니다.
+        arg("querydsl.kotlinCodegen", "true") // QueryDSL Kotlin Codegen 활성화
+    }
+    javacOptions {
+        option("--add-modules", "java.base")
+    }
 }
 
 // NOTE: implementation 로 지정된 Dependency를 testImplementation 으로도 지정하도록 합니다.
@@ -30,11 +37,7 @@ dependencies {
     implementation(project(":bluetape4k-hibernate"))
     testImplementation(project(":bluetape4k-junit5"))
 
-    // NOTE: Java 9+ 환경에서 kapt가 제대로 동작하려면 javax.annotation-api 를 참조해야 합니다.
-    // api(Libs.javax_annotation_api)
     api(Libs.jakarta_annotation_api)
-
-    // api(Libs.javax_persistence_api)
     api(Libs.jakarta_persistence_api)
     api(Libs.hibernate_core)
 

--- a/examples/jpa-querydsl/src/main/kotlin/io/bluetape4k/examples/jpa/querydsl/domain/repository/MemberRepositoryImpl.kt
+++ b/examples/jpa-querydsl/src/main/kotlin/io/bluetape4k/examples/jpa/querydsl/domain/repository/MemberRepositoryImpl.kt
@@ -39,7 +39,7 @@ class MemberRepositoryImpl: QuerydslRepositorySupport(Member::class.java), Membe
         return queryFactory
             .select(projection)
             .from(qmember)
-            .leftJoin(qmember.team, qteam)
+            .leftJoin(qmember.team(), qteam)
             .where(*whereClauses.toTypedArray())
             .fetch()
     }

--- a/examples/jpa-querydsl/src/test/kotlin/io/bluetape4k/examples/jpa/querydsl/examples/QuerydslExamples.kt
+++ b/examples/jpa-querydsl/src/test/kotlin/io/bluetape4k/examples/jpa/querydsl/examples/QuerydslExamples.kt
@@ -248,7 +248,7 @@ class QuerydslExamples: AbstractQuerydslTest() {
         val results = queryFactory
             .select(qteam.name, qmember.age.avg().`as`(avgAge))
             .from(qmember)
-            .join(qmember.team, qteam)
+            .join(qmember.team(), qteam)
             .groupBy(qteam.name)
             .fetch()
 
@@ -271,7 +271,7 @@ class QuerydslExamples: AbstractQuerydslTest() {
         val results = queryFactory
             .select(qteam.name, avgAgeExpr.`as`(avgAge))
             .from(qmember)
-            .join(qmember.team, qteam)
+            .join(qmember.team(), qteam)
             .groupBy(qteam.name)
             .having(avgAgeExpr.gt(20))
             .fetch()
@@ -286,7 +286,7 @@ class QuerydslExamples: AbstractQuerydslTest() {
     fun `right outer join`() {
         val members = queryFactory
             .selectFrom(qmember)
-            .rightJoin(qmember.team, qteam)
+            .rightJoin(qmember.team(), qteam)
             .where(qteam.name.eq("teamA"))
             .fetch()
 
@@ -318,7 +318,7 @@ class QuerydslExamples: AbstractQuerydslTest() {
         val tuples = queryFactory
             .select(qmember, qteam)
             .from(qmember)
-            .join(qmember.team, qteam).on(qteam.name.eq("teamA"))
+            .join(qmember.team(), qteam).on(qteam.name.eq("teamA"))
             .fetch()
 
         tuples.forEach {
@@ -354,7 +354,7 @@ class QuerydslExamples: AbstractQuerydslTest() {
         val memberDtos = queryFactory
             .select(projections)
             .from(qmember)
-            .join(qmember.team, qteam)
+            .join(qmember.team(), qteam)
             .fetch()
 
         memberDtos shouldHaveSize MEMBER_COUNT
@@ -408,7 +408,7 @@ class QuerydslExamples: AbstractQuerydslTest() {
     fun `many-to-one lazy loading + fetchJoin 시 fetch join 수행`() {
         val member = queryFactory
             .selectFrom(qmember)
-            .join(qmember.team, qteam).fetchJoin()
+            .join(qmember.team(), qteam).fetchJoin()
             .where(qmember.name.eq("member-1"))
             .fetchOne()!!
 
@@ -693,7 +693,7 @@ class QuerydslExamples: AbstractQuerydslTest() {
                 )
             )
             .from(qmember)
-            .join(qmember.team, qteam)
+            .join(qmember.team(), qteam)
             .fetch()
 
         memberTeamVos.forEach {

--- a/spring/jpa/build.gradle.kts
+++ b/spring/jpa/build.gradle.kts
@@ -17,9 +17,16 @@ allOpen {
 }
 
 kapt {
-    showProcessorStats = true
-    // kapt 가 제대로 동작하지 않는 경우, 아래 옵션을 제거해보세요.
     correctErrorTypes = true
+    showProcessorStats = true
+
+    arguments {
+        arg("querydsl.entityAccessors", "true")  // Association의 property는 getter/setter를 사용하도록 합니다.
+        arg("querydsl.kotlinCodegen", "true") // QueryDSL Kotlin Codegen 활성화
+    }
+    javacOptions {
+        option("--add-modules", "java.base")
+    }
 }
 
 idea {
@@ -49,10 +56,6 @@ dependencies {
     api(Libs.jakarta_persistence_api)
     api(Libs.hibernate_core)
     testImplementation(Libs.hibernate_testing)
-
-    // NOTE: Querydsl 과 같이 사용할 시에 가끔 예외를 일으킨다. 
-    // kapt(Libs.hibernate_jpamodelgen)
-    // kaptTest(Libs.hibernate_jpamodelgen)
 
     // Querydsl
     // Hibernate 6+ jakarta 용은 claasifier로 ":jpa" 대신 ":jakarta" 를 사용해야 합니다.


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: Bump up kotlin 2.1.0

### 원문 선행 내용

* Bump up kotlin 2.1.0
* Kotlin 2.1.0 kapt 와 hibernate jpa model gen 과 querydsl 이 충돌되는 버그 수정

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

* Bump up kotlin 2.1.0
* Kotlin 2.1.0 kapt 와 hibernate jpa model gen 과 querydsl 이 충돌되는 버그 수정

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #4, head `6c44e2fbe52bd8d303aa6545fcd1def36bdc2451`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feature/kotlin-2.1.0`
- Labels: `enhancement`
- State: `MERGED`, merge commit `b2c93061f31620798f8ba5f03130a5c99972c91c`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #4 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `b2c93061f31620798f8ba5f03130a5c99972c91c`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
