### PR TITLE
Bump up cassandra java driver (4.18.1)

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -18,7 +18,7 @@ object Plugins {
         const val shadow = "7.1.2"
         const val kotlinx_benchmark = "0.4.13" // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-benchmark-plugin
 
-        const val spring_boot = "3.3.5"  // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies
+        const val spring_boot = "3.4.0"  // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies
         const val docker_compose = "0.16.12"
     }
 

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -60,7 +60,7 @@ object Versions {
     const val kotlinx_benchmark = Plugins.Versions.kotlinx_benchmark
 
     const val spring_boot = Plugins.Versions.spring_boot
-    const val spring_cloud = "2023.0.3"     // https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-dependencies
+    const val spring_cloud = "2023.0.4"     // https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-dependencies
     const val spring_integration = "6.3.5"  // https://mvnrepository.com/artifact/org.springframework.integration/spring-integration-core
     const val reactor_bom = "2024.0.0"      // https://mvnrepository.com/artifact/io.projectreactor/reactor-bom
     const val spring_statemachine = "4.0.0" // https://mvnrepository.com/artifact/org.springframework.statemachine/spring-statemachine-core
@@ -149,7 +149,7 @@ object Versions {
     const val ignite = "2.16.0"             // https://mvnrepository.com/artifact/org.apache.ignite/ignite-core
     const val hazelcast = "5.5.0"           // https://mvnrepository.com/artifact/com.hazelcast/hazelcast
 
-    const val cassandra = "4.17.0"          // https://mvnrepository.com/artifact/com.datastax.oss/java-driver-core
+    const val cassandra = "4.18.1"          // https://mvnrepository.com/artifact/org.apache.cassandra/java-driver-core
     const val scylla_java = "4.13.0.0"
     const val elasticsearch = "8.16.0"       // https://mvnrepository.com/artifact/org.elasticsearch.client/elasticsearch-rest-client
 
@@ -959,7 +959,7 @@ object Libs {
 
     // Cassandra
     fun cassandra(module: String, version: String = Versions.cassandra): String =
-        "com.datastax.oss:java-driver-$module:$version"
+        "org.apache.cassandra:java-driver-$module:$version"
 
     val cassandra_java_driver_core = cassandra("core")
     val cassandra_java_driver_core_shaded = cassandra("core-shaded")

--- a/spring/cassandra/build.gradle.kts
+++ b/spring/cassandra/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     kotlin("plugin.spring")
     kotlin("plugin.noarg")
     kotlin("plugin.allopen")
+    kotlin("kapt")
 }
 allOpen {
     annotation("com.datastax.oss.driver.api.mapper.annotations.Entity")
@@ -30,8 +31,8 @@ dependencies {
 
     // cassandra 의 @Mapper, @Dao 를 활용할 때 사용합니다.
     // 참고: https://docs.datastax.com/en/developer/java-driver/4.13/manual/mapper/
-//    kapt(Libs.cassandra_java_driver_mapper_processor)
-//    kaptTest(Libs.cassandra_java_driver_mapper_processor)
+    kapt(Libs.cassandra_java_driver_mapper_processor)
+    kaptTest(Libs.cassandra_java_driver_mapper_processor)
 
     compileOnly(Libs.springBoot("autoconfigure"))
     compileOnly(Libs.springBoot("configuration-processor"))

--- a/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/cql/OptionsSupport.kt
+++ b/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/cql/OptionsSupport.kt
@@ -30,8 +30,8 @@ inline fun deleteOptions(initializer: DeleteOptions.DeleteOptionsBuilder.() -> U
 fun Insert.addWriteOptions(writeOptions: WriteOptions): Insert {
     var applied = this
 
-    if (!writeOptions.ttl.isNegative) {
-        applied = applied.usingTtl(writeOptions.ttl.seconds.toInt())
+    if (writeOptions.isPositiveTtl) {
+        applied = applied.usingTtl(writeOptions.ttl!!.seconds.toInt())
     }
     writeOptions.timestamp?.run {
         applied = applied.usingTimestamp(this)
@@ -43,8 +43,8 @@ fun Update.addWriteOptions(writeOptions: WriteOptions): Update {
     var applied = this
 
     if (applied is UpdateStart) {
-        if (!writeOptions.ttl.isNegative) {
-            applied = applied.usingTtl(writeOptions.ttl.seconds.toInt()) as Update
+        if (writeOptions.isPositiveTtl) {
+            applied = applied.usingTtl(writeOptions.ttl!!.seconds.toInt()) as Update
         }
         if (writeOptions.timestamp != null) {
             applied = (applied as UpdateStart).usingTimestamp(writeOptions.timestamp!!) as Update

--- a/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/cql/OptionsSupport.kt
+++ b/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/cql/OptionsSupport.kt
@@ -61,3 +61,5 @@ fun Delete.addWriteOptions(writeOptions: WriteOptions): Delete {
     }
     return applied
 }
+
+val WriteOptions.isPositiveTtl: Boolean get() = ttl != null && !ttl!!.isNegative


### PR DESCRIPTION
## Summary

Closes #5

- PR 제목: Bump up cassandra java driver (4.18.1)

### 원문 선행 내용

cassandra java driver 의 group Id 가 달라지고, interface 도 변경됨

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

cassandra java driver 의 group Id 가 달라지고, interface 도 변경됨

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #5, milestone 없음, assignee `debop`
- PR: #6, head `88a0f2169e8325f672625533882da08f1af1bc1f`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `5-bump-up-cassandra-driver-4181`
- Labels: `enhancement`
- State: `MERGED`, merge commit `5ea1b36f00d1355551d82822a4ef3df86a82c7cd`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #6 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `5ea1b36f00d1355551d82822a4ef3df86a82c7cd`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
