### PR TITLE
Add javers modules

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -122,8 +122,8 @@ object Versions {
 
     const val agroal = "2.5"          // https://mvnrepository.com/artifact/io.agroal/agroal-api
 
-    const val blaze_persistence = "3.14.1" // https://mvnrepository.com/artifact/io.quarkus.platform/quarkus-blaze-persistence-bom
-    const val javers = "7.6.1"             // https://mvnrepository.com/artifact/org.javers/javers-core
+    const val blaze_persistence = "3.17.3" // https://mvnrepository.com/artifact/io.quarkus.platform/quarkus-blaze-persistence-bom
+    const val javers = "7.6.3"             // https://mvnrepository.com/artifact/org.javers/javers-core
 
     const val slf4j = "2.0.16"      // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
     const val logback = "1.5.12"     // https://mvnrepository.com/artifact/ch.qos.logback/logback-classic
@@ -1113,7 +1113,7 @@ object Libs {
     val blaze_persistence_integration_entity_view_spring = blazePersistenceIntegration("entity-view-spring")
 
     // Javers (https://javers.org - Java Audit library)
-    fun javers(module: String) = "org.javers:javers-$module:${Versions.javers}"
+    fun javers(module: String, version: String = Versions.javers) = "org.javers:javers-$module:$version"
     val javers_core = javers("core")
     val javers_spring = javers("spring")
     val javers_spring_jpa = javers("spring-jpa")

--- a/javers/README.md
+++ b/javers/README.md
@@ -1,0 +1,15 @@
+# Module bluetape4k javers modules
+
+[Javers](https://javers.org) 는 객체에 대한 Audit과 Diff 를 지원해주는 Framework 입니다. 기본적으로 메모리, MongoDB, JDBC 에 Audit 정보를 저장할 수 있는
+기능을 제공합니다.
+
+Bluetape4k Javers 에서는 위의 저장소 이외에, Redis 와 Kafka 를 통해 Event Sourcing 방식으로 CDC 를 지원할 수 있도록 해줍니다. 유사한 기능으로 Hibernate Enver
+가 있습니다
+
+## 참고 자료
+
+- [Javers](https://javers.org)
+- [Javers Feature Overview](https://javers.org/features)
+- [Javers VS Envers Comparison](https://javers.org/blog/2017/12/javers-vs-envers-comparision.html)
+- [Using JaVers for Data Model Auditing in Spring Data](https://www.baeldung.com/spring-data-javers-audit)
+- [Spring Data에서 데이터 모델 감사를 위해 JaVers 사용](https://recordsoflife.tistory.com/486)

--- a/javers/core/README.md
+++ b/javers/core/README.md
@@ -1,0 +1,4 @@
+# Module bluetape4k-javers-core
+
+[Javers](https://javers.org) is a Java library for **object auditing and diff**.
+Javers helps you to **keep your data consistent** and **audit-proof**.

--- a/javers/core/build.gradle.kts
+++ b/javers/core/build.gradle.kts
@@ -1,0 +1,48 @@
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+    create("testJar")
+}
+
+// 테스트 코드를 Jar로 만들어서 다른 프로젝트에서 참조할 수 있도록 합니다.
+tasks.register<Jar>("testJar") {
+    dependsOn(tasks.testClasses)
+    archiveClassifier.set("test")
+    from(sourceSets.test.get().output)
+}
+
+artifacts {
+    add("testJar", tasks["testJar"])
+}
+
+dependencies {
+    api(project(":bluetape4k-io"))
+    api(project(":bluetape4k-jackson"))
+    api(project(":bluetape4k-idgenerators"))
+    compileOnly(project(":bluetape4k-hibernate"))
+    compileOnly(project(":bluetape4k-redis"))
+    compileOnly(project(":bluetape4k-cache"))
+
+    testImplementation(project(":bluetape4k-junit5"))
+    testImplementation(project(":bluetape4k-testcontainers"))
+
+    api(Libs.javers_core)
+    testImplementation(Libs.guava)
+
+    // Cache for Javers repository
+    compileOnly(Libs.caffeine)
+    compileOnly(Libs.caffeine_jcache)
+    compileOnly(Libs.cache2k_core)
+
+    // Mongo
+    compileOnly(Libs.mongo_bson)
+    compileOnly(Libs.mongodb_driver_sync)
+
+    // Codec
+    compileOnly(Libs.kryo)
+    compileOnly(Libs.fury)
+
+    // Compression
+    compileOnly(Libs.lz4_java)
+    compileOnly(Libs.snappy_java)
+    compileOnly(Libs.zstd_jni)
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/CdoExtensions.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/CdoExtensions.kt
@@ -1,0 +1,6 @@
+package io.bluetape4k.javers
+
+import org.javers.core.graph.Cdo
+import kotlin.jvm.optionals.getOrNull
+
+fun Cdo.getWrappedOrNull(): Any? = this.wrappedCdo.getOrNull()

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/JaversExtensions.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/JaversExtensions.kt
@@ -1,0 +1,54 @@
+package io.bluetape4k.javers
+
+import org.javers.core.Javers
+import org.javers.core.diff.Diff
+import org.javers.core.metamodel.`object`.CdoSnapshot
+import org.javers.core.metamodel.`object`.InstanceId
+import org.javers.core.metamodel.type.EntityType
+import org.javers.core.metamodel.type.ValueObjectType
+import org.javers.repository.jql.JqlQuery
+import org.javers.shadow.Shadow
+import org.javers.shadow.ShadowFactory
+import kotlin.jvm.optionals.getOrNull
+import kotlin.reflect.KClass
+import kotlin.streams.asSequence
+
+inline fun <reified T: Any> Javers.getEntityTypeMapping(): EntityType =
+    this.getTypeMapping(T::class.java)
+
+inline fun <reified T: Any> Javers.getValueObjectTypeMapping(): ValueObjectType =
+    this.getTypeMapping(T::class.java)
+
+inline fun <reified T: Any> Javers.createEntityInstanceId(entity: T): InstanceId =
+    this.getEntityTypeMapping<T>().createIdFromInstance(entity)
+
+
+inline fun <reified T: Any> Javers.createEntityInstanceIdByEntityId(localId: Any): InstanceId =
+    this.getEntityTypeMapping<T>().createIdFromInstanceId(localId)
+
+inline fun <reified T: Any> Javers.compareCollections(oldVersion: Collection<T>, newVersion: Collection<T>): Diff =
+    this.compareCollections(oldVersion, newVersion, T::class.java)
+
+fun Javers.latestSnapshotOrNull(localId: Any, entityClass: KClass<*>): CdoSnapshot? =
+    getLatestSnapshot(localId, entityClass.java).getOrNull()
+
+inline fun <reified T: Any> Javers.latestSnapshotOrNull(localId: Any): CdoSnapshot? =
+    getLatestSnapshot(localId, T::class.java).getOrNull()
+
+/**
+ * Snapshot을 시스템에서 사용하는 실제 Entity를 가진 Shadow로 변환합니다.
+ *
+ * @param T business entity type
+ * @param snapshot snapshot 정보
+ * @return `Shadow<T>` 인스턴스
+ */
+@Suppress("UNCHECKED_CAST")
+fun <T> Javers.getShadow(snapshot: CdoSnapshot): Shadow<T> {
+    return shadowFactory.createShadow(snapshot, snapshot.commitMetadata, null) as Shadow<T>
+}
+
+val Javers.shadowFactory: ShadowFactory
+    get() = ShadowProvider.getShadowFactory(this)
+
+fun <T: Any> Javers.findShadowsAndSequence(jql: JqlQuery): Sequence<Shadow<T>> =
+    findShadowsAndStream<T>(jql).asSequence()

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/QueryParamsExtensions.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/QueryParamsExtensions.kt
@@ -1,0 +1,15 @@
+package io.bluetape4k.javers
+
+import org.javers.repository.api.QueryParams
+import java.time.LocalDateTime
+import kotlin.jvm.optionals.getOrNull
+
+fun QueryParams.isDateInRange(date: LocalDateTime): Boolean {
+    if (from().getOrNull()?.isAfter(date) == true) {
+        return false
+    }
+    if (to().getOrNull()?.isBefore(date) == true) {
+        return false
+    }
+    return true
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/ShadowProvider.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/ShadowProvider.kt
@@ -1,0 +1,39 @@
+package io.bluetape4k.javers
+
+import io.bluetape4k.logging.KLogging
+import org.javers.core.Javers
+import org.javers.core.metamodel.type.TypeMapper
+import org.javers.shadow.ShadowFactory
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * [ShadowFactory]를 제공하는 Provider 입니다.
+ */
+object ShadowProvider: KLogging() {
+
+    private val typeMappers = ConcurrentHashMap<Javers, TypeMapper>()
+    private val shadowFactories = ConcurrentHashMap<Javers, ShadowFactory>()
+
+    /**
+     * 지정한 `javers`의 내부 내용을 기반으로 [ShadowFactory]를 제공합니다.
+     */
+    fun getShadowFactory(javers: Javers): ShadowFactory {
+        return shadowFactories.computeIfAbsent(javers) {
+            ShadowFactory(javers.jsonConverter, getTypeMapper(javers))
+        }
+    }
+
+    /**
+     * [Javers] 내부의 [TypeMapper]를 Reflection을 통해 제공합니다.
+     *
+     * @param javers [Javers] 인스턴스
+     * @return
+     */
+    private fun getTypeMapper(javers: Javers): TypeMapper {
+        return typeMappers.computeIfAbsent(javers) {
+            val field = javers.javaClass.declaredFields.find { it.name == "typeMapper" }!!
+            field.isAccessible = true
+            field.get(javers) as TypeMapper
+        }
+    }
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/base/EntityEnvelop.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/base/EntityEnvelop.kt
@@ -1,0 +1,30 @@
+package io.bluetape4k.javers.base
+
+import java.io.Serializable
+
+/**
+ * 엔티티 상태 정보 변경에 따른 Dispatch 시에 봉투 역할을 수행합니다.
+ *
+ * @property entity 상태가 변경된 Entity (Save 시에만 가능
+ */
+data class EntityEnvelop(
+    val entity: Any? = null,
+    val entityId: Any? = null,
+    val entityType: Class<*>,
+    val eventType: EntityEventType = EntityEventType.SAVED,
+): Serializable {
+
+    constructor(entity: Any): this(entity = entity, entityType = entity.javaClass)
+    constructor(entityId: Any, entityType: Class<*>): this(null, entityId, entityType, EntityEventType.DELETED)
+
+    private val headers = hashMapOf<String, String>()
+
+    fun addHeader(key: String, value: String) {
+        headers[key] = value
+    }
+
+    fun getHeader(key: String): String? = headers[key]
+
+    val isSavedEntity: Boolean get() = eventType == EntityEventType.SAVED
+    val isDeletedEntity: Boolean get() = eventType == EntityEventType.DELETED
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/base/EntityEventType.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/base/EntityEventType.kt
@@ -1,0 +1,17 @@
+package io.bluetape4k.javers.base
+
+enum class EntityEventType(val status: String) {
+    UNKNOWN("UNKNOWN"),
+    SAVED("SAVED"),
+    DELETED("DELETED");
+
+    override fun toString(): String = status
+
+    companion object {
+        val VALS: Array<EntityEventType> = values()
+
+        fun valueOf(status: String): EntityEventType? {
+            return VALS.firstOrNull { it.status == status }
+        }
+    }
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/BinaryGsonCodec.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/BinaryGsonCodec.kt
@@ -1,0 +1,24 @@
+package io.bluetape4k.javers.codecs
+
+import com.google.gson.JsonObject
+import io.bluetape4k.io.serializer.BinarySerializer
+import io.bluetape4k.logging.KLogging
+
+class BinaryGsonCodec(
+    private val serializer: BinarySerializer,
+): GsonCodec<ByteArray> {
+
+    companion object: KLogging()
+
+    private val mapCodec: MapGsonCodec = MapGsonCodec()
+
+    override fun encode(jsonElement: JsonObject): ByteArray {
+        val map: Map<String, Any?> = mapCodec.encode(jsonElement)
+        return serializer.serialize(map)
+    }
+
+    override fun decode(encodedData: ByteArray): JsonObject? {
+        val map: Map<String, Any?>? = serializer.deserialize(encodedData)
+        return map?.let { mapCodec.decode(it) }
+    }
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/CompressableBinaryGsonCodec.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/CompressableBinaryGsonCodec.kt
@@ -1,0 +1,19 @@
+package io.bluetape4k.javers.codecs
+
+import com.google.gson.JsonObject
+import io.bluetape4k.io.compressor.Compressor
+
+
+class CompressableBinaryGsonCodec(
+    private val innerCodec: BinaryGsonCodec,
+    private val compressor: Compressor,
+): GsonCodec<ByteArray> {
+
+    override fun encode(jsonElement: JsonObject): ByteArray {
+        return compressor.compress(innerCodec.encode(jsonElement))
+    }
+
+    override fun decode(encodedData: ByteArray): JsonObject? {
+        return innerCodec.decode(compressor.decompress(encodedData))
+    }
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/CompressableStringGsonCodec.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/CompressableStringGsonCodec.kt
@@ -1,0 +1,18 @@
+package io.bluetape4k.javers.codecs
+
+import com.google.gson.JsonObject
+import io.bluetape4k.io.compressor.Compressor
+
+class CompressableStringGsonCodec(
+    private val innerCodec: StringGsonCodec,
+    private val compressor: Compressor,
+): GsonCodec<String> {
+
+    override fun encode(jsonElement: JsonObject): String {
+        return compressor.compress(innerCodec.encode(jsonElement))
+    }
+
+    override fun decode(encodedData: String): JsonObject? {
+        return innerCodec.decode(compressor.decompress(encodedData))
+    }
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/GsonCodec.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/GsonCodec.kt
@@ -1,0 +1,11 @@
+package io.bluetape4k.javers.codecs
+
+import com.google.gson.JsonObject
+
+interface GsonCodec<T: Any> {
+
+    fun encode(jsonElement: JsonObject): T
+
+    fun decode(encodedData: T): JsonObject?
+
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/GsonCodecs.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/GsonCodecs.kt
@@ -1,0 +1,34 @@
+package io.bluetape4k.javers.codecs
+
+import io.bluetape4k.io.compressor.Compressors
+import io.bluetape4k.io.serializer.BinarySerializers
+import io.bluetape4k.support.unsafeLazy
+
+
+object GsonCodecs {
+
+    val Default by unsafeLazy { String }
+
+    // String Codecs
+
+    val String by unsafeLazy { StringGsonCodec() }
+
+    val GZipString by unsafeLazy { CompressableStringGsonCodec(String, Compressors.GZip) }
+    val DeflateString by unsafeLazy { CompressableStringGsonCodec(String, Compressors.Deflate) }
+    val LZ4String by unsafeLazy { CompressableStringGsonCodec(String, Compressors.LZ4) }
+    val SnappyString by unsafeLazy { CompressableStringGsonCodec(String, Compressors.Snappy) }
+    val ZstdString by unsafeLazy { CompressableStringGsonCodec(String, Compressors.Zstd) }
+
+    // Binary Codecs
+
+    val Kryo by unsafeLazy { BinaryGsonCodec(BinarySerializers.Kryo) }
+
+    val GZipKryo by unsafeLazy { CompressableBinaryGsonCodec(Kryo, Compressors.GZip) }
+    val DeflateKryo by unsafeLazy { CompressableBinaryGsonCodec(Kryo, Compressors.Deflate) }
+    val LZ4Kryo by unsafeLazy { CompressableBinaryGsonCodec(Kryo, Compressors.LZ4) }
+    val SnappyKryo by unsafeLazy { CompressableBinaryGsonCodec(Kryo, Compressors.Snappy) }
+    val ZstdKryo by unsafeLazy { CompressableBinaryGsonCodec(Kryo, Compressors.Zstd) }
+
+    // Map
+    val Map by unsafeLazy { MapGsonCodec() }
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/GsonElementConverter.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/GsonElementConverter.kt
@@ -1,0 +1,91 @@
+package io.bluetape4k.javers.codecs
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonNull
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+import java.math.BigDecimal
+
+internal object GsonElementConverter {
+
+    fun fromJsonObject(jsonObject: JsonObject): Map<String, Any?> {
+        val map = mutableMapOf<String, Any?>()
+        jsonObject.entrySet().forEach { (key, jsonElement) ->
+            map[key] = extractValue(jsonElement)
+        }
+        return map
+    }
+
+    fun toJsonObject(map: Map<String, Any?>): JsonObject {
+        val jsonObject = JsonObject()
+        map.forEach { (key, value) ->
+            jsonObject.add(key, createJsonElement(value))
+        }
+        return jsonObject
+    }
+
+    private fun extractValue(element: JsonElement): Any? {
+        if (element == JsonNull.INSTANCE) {
+            return null
+        }
+        if (element is JsonObject) {
+            return fromJsonObject(element)
+        }
+        if (element is JsonPrimitive) {
+            if (element.isString) {
+                return element.asString
+            }
+            if (element.isNumber && element.asNumber is BigDecimal) {
+                val value = element.asNumber as BigDecimal
+                return try {
+                    value.longValueExact()
+                } catch (e: ArithmeticException) {
+                    value.toDouble()
+                }
+            }
+            if (element.isNumber) {
+                return element.asNumber
+            }
+            if (element.isBoolean) {
+                return element.asBoolean
+            }
+        }
+        if (element is JsonArray) {
+            return mutableListOf<Any?>().apply {
+                element.forEach { elem ->
+                    add(extractValue(elem))
+                }
+            }
+        }
+
+        throw IllegalArgumentException("unsupported JsonElement type - ${element.javaClass.simpleName}")
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun createJsonElement(value: Any?): JsonElement {
+        if (value == null) {
+            return JsonNull.INSTANCE
+        }
+        if (value is Map<*, *>) {
+            return toJsonObject(value as Map<String, Any?>)
+        }
+        if (value is String) {
+            return JsonPrimitive(value)
+        }
+        if (value is Number) {
+            return JsonPrimitive(value)
+        }
+        if (value is Boolean) {
+            return JsonPrimitive(value)
+        }
+        if (value is List<*>) {
+            return JsonArray().apply {
+                value.forEach { item ->
+                    add(createJsonElement(item))
+                }
+            }
+        }
+        throw IllegalArgumentException("unsupported object type - ${value.javaClass.simpleName}")
+    }
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/MapGsonCodec.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/MapGsonCodec.kt
@@ -1,0 +1,14 @@
+package io.bluetape4k.javers.codecs
+
+import com.google.gson.JsonObject
+
+class MapGsonCodec: GsonCodec<Map<String, Any?>> {
+
+    override fun encode(jsonElement: JsonObject): Map<String, Any?> {
+        return GsonElementConverter.fromJsonObject(jsonElement)
+    }
+
+    override fun decode(encodedData: Map<String, Any?>): JsonObject {
+        return GsonElementConverter.toJsonObject(encodedData)
+    }
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/StringGsonCodec.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/StringGsonCodec.kt
@@ -1,0 +1,15 @@
+package io.bluetape4k.javers.codecs
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+
+open class StringGsonCodec: GsonCodec<String> {
+
+    override fun encode(jsonElement: JsonObject): String {
+        return jsonElement.toString()
+    }
+
+    override fun decode(encodedData: String): JsonObject? {
+        return runCatching { JsonParser.parseString(encodedData) as JsonObject }.getOrNull()
+    }
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/commit/CommitMetadataExtensions.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/commit/CommitMetadataExtensions.kt
@@ -1,0 +1,11 @@
+package io.bluetape4k.javers.commit
+
+import org.javers.core.commit.CommitId
+import org.javers.core.commit.CommitMetadata
+
+val CommitId.version: Pair<Long, Int> get() = Pair(majorId, minorId)
+
+operator fun CommitMetadata.compareTo(that: CommitMetadata): Int =
+    this.id.compareTo(that.id)
+
+val CommitMetadata.commitTimestamp: Long get() = commitDateInstant.toEpochMilli()

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/commit/SnowflakeCommitIdGenerator.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/commit/SnowflakeCommitIdGenerator.kt
@@ -1,0 +1,30 @@
+package io.bluetape4k.javers.commit
+
+import io.bluetape4k.idgenerators.snowflake.Snowflake
+import io.bluetape4k.idgenerators.snowflake.Snowflakers
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.locks.ReentrantLock
+import kotlinx.atomicfu.locks.withLock
+import org.javers.core.commit.CommitId
+import java.util.function.Supplier
+
+class SnowflakeCommitIdGenerator(
+    private val snowflake: Snowflake = Snowflakers.Global,
+): Supplier<CommitId> {
+
+    private val commits = mutableMapOf<CommitId, Int>()
+    private val counter = atomic(0)
+    private val lock = ReentrantLock()
+
+    fun getSeq(commitId: CommitId): Int =
+        commits[commitId] ?: throw NoSuchElementException("Not found commitId [$commitId]")
+
+    override fun get(): CommitId = lock.withLock {
+        counter.incrementAndGet()
+        val next = CommitId(nextId(), 0)
+        commits[next] = counter.value
+        next
+    }
+
+    private fun nextId(): Long = snowflake.nextId()
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/diff/ChangeExtensions.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/diff/ChangeExtensions.kt
@@ -1,0 +1,25 @@
+package io.bluetape4k.javers.diff
+
+import org.javers.core.Changes
+import org.javers.core.diff.Change
+import org.javers.core.diff.changetype.NewObject
+import org.javers.core.diff.changetype.ObjectRemoved
+import org.javers.core.diff.changetype.ReferenceChange
+import org.javers.core.diff.changetype.ValueChange
+import org.javers.core.diff.changetype.container.ArrayChange
+import org.javers.core.diff.changetype.container.ListChange
+import org.javers.core.diff.changetype.container.SetChange
+import org.javers.core.diff.changetype.map.MapChange
+
+inline fun <reified T: Change> Changes.filterByType(): List<T> =
+    this.getChangesByType(T::class.java)
+
+val Change.isArrayChange: Boolean get() = this is ArrayChange
+val Change.isListChange: Boolean get() = this is ListChange
+val Change.isMapChange: Boolean get() = this is MapChange<*>
+val Change.isSetChange: Boolean get() = this is SetChange
+val Change.isReferenceChange: Boolean get() = this is ReferenceChange
+val Change.isValueChange: Boolean get() = this is ValueChange
+
+val Change.isNewObject: Boolean get() = this is NewObject
+val Change.isObjectRemoved: Boolean get() = this is ObjectRemoved

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/diff/DiffExtensions.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/diff/DiffExtensions.kt
@@ -1,0 +1,10 @@
+package io.bluetape4k.javers.diff
+
+import org.javers.core.diff.Change
+import org.javers.core.diff.Diff
+
+inline fun <reified T: Change> Diff.objectsByChangeType(): MutableList<Any?> =
+    getObjectsByChangeType(T::class.java)
+
+inline fun <reified T: Change> Diff.changesByType(): MutableList<T> =
+    getChangesByType(T::class.java)

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/dispatcher/JaversDispatcher.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/dispatcher/JaversDispatcher.kt
@@ -1,0 +1,38 @@
+package io.bluetape4k.javers.dispatcher
+
+/**
+ * Domain Object의 Save, Delete 시에 외부로 event sourcing 을 수행하도록 합니다.
+ */
+interface JaversDispatcher {
+
+    /**
+     * Domain Object 에 대해 Save (Create/Update) 시에 호출되는 메소드입니다. 이를 event sourcing으로 외부에 알립니다.
+     *
+     * @param domainObject 저장된 domain object
+     */
+    fun sendSaved(domainObject: Any)
+
+    /**
+     * Domain Object 삭제 시에 호출되는 메소드
+     *
+     * @param domainObject
+     */
+    fun sendDeleted(domainObject: Any)
+
+    /**
+     * Domain Object를 Id로 삭제하는 경우 호출되는 메소드
+     *
+     * @param domainObjectId 삭제된 domain object의 id
+     * @param domainType domain object의 type 정보
+     */
+    fun sendDeletedById(domainObjectId: Any, domainType: Class<*>)
+}
+
+/**
+ * Domain Object를 Id로 삭제하는 경우 호출되는 메소드
+ *
+ * @param domainObjectId 삭제된 domain object의 id
+ */
+inline fun <reified T> JaversDispatcher.sendDeletedById(domainObjectId: Any) {
+    sendDeletedById(domainObjectId, T::class.java)
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/dispatcher/internal/CompositeDispatcher.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/dispatcher/internal/CompositeDispatcher.kt
@@ -1,0 +1,28 @@
+package io.bluetape4k.javers.dispatcher.internal
+
+import io.bluetape4k.collections.forEachCatching
+import io.bluetape4k.javers.dispatcher.JaversDispatcher
+
+
+open class CompositeDispatcher(
+    val dispatchers: Collection<JaversDispatcher>,
+): JaversDispatcher {
+
+    override fun sendSaved(domainObject: Any) {
+        dispatchers.forEachCatching { dispatcher ->
+            dispatcher.sendSaved(domainObject)
+        }
+    }
+
+    override fun sendDeleted(domainObject: Any) {
+        dispatchers.forEachCatching { dispatcher ->
+            dispatcher.sendDeleted(domainObject)
+        }
+    }
+
+    override fun sendDeletedById(domainObjectId: Any, domainType: Class<*>) {
+        dispatchers.forEachCatching { dispatcher ->
+            dispatcher.sendDeletedById(domainObjectId, domainType)
+        }
+    }
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/dispatcher/internal/ConsoleDispatcher.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/dispatcher/internal/ConsoleDispatcher.kt
@@ -1,0 +1,23 @@
+package io.bluetape4k.javers.dispatcher.internal
+
+import io.bluetape4k.javers.dispatcher.JaversDispatcher
+
+/**
+ * Domain Object의 변화를 Console로 출력하는 [JaversDispatcher] 입니다.
+ *
+ * @property logger slf4j logger
+ */
+class ConsoleDispatcher: JaversDispatcher {
+
+    override fun sendSaved(domainObject: Any) {
+        println("Send saved domain object. $domainObject")
+    }
+
+    override fun sendDeleted(domainObject: Any) {
+        println("Send deleted domain object. $domainObject")
+    }
+
+    override fun sendDeletedById(domainObjectId: Any, domainType: Class<*>) {
+        println("Send deleted domain object by id. id=$domainObjectId, type=$domainType")
+    }
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/dispatcher/internal/DebugDispacher.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/dispatcher/internal/DebugDispacher.kt
@@ -1,0 +1,43 @@
+package io.bluetape4k.javers.dispatcher.internal
+
+import io.bluetape4k.javers.dispatcher.JaversDispatcher
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * 디버그를 위해 Dispatcher에 호출되는 Domain Object를 보관하도록 합니다.
+ *
+ * @param dispatchers 실제로 외부로 event 를 보내는 [JaversDispatcher]의 컬렉션
+ */
+class DebugDispacher(dispatchers: Collection<JaversDispatcher>): CompositeDispatcher(dispatchers) {
+
+    data class DeletedById(val id: Any, val domainType: Class<*>)
+
+    private val savedObjects = CopyOnWriteArrayList<Any>()
+    private val deletedObjects = CopyOnWriteArrayList<Any>()
+    private val deletedByIds = CopyOnWriteArrayList<DeletedById>()
+
+    override fun sendSaved(domainObject: Any) {
+        savedObjects.add(domainObject)
+        super.sendSaved(domainObject)
+    }
+
+    override fun sendDeleted(domainObject: Any) {
+        deletedObjects.add(domainObject)
+        super.sendDeleted(domainObject)
+    }
+
+    override fun sendDeletedById(domainObjectId: Any, domainType: Class<*>) {
+        deletedByIds.add(DeletedById(domainObjectId, domainType))
+        super.sendDeletedById(domainObjectId, domainType)
+    }
+
+    fun isSaved(domainObject: Any): Boolean = savedObjects.contains(domainObject)
+    fun isDeleted(domainObject: Any): Boolean = deletedObjects.contains(domainObject)
+    fun isDeletedById(id: Any, domainType: Class<*>): Boolean = deletedByIds.contains(DeletedById(id, domainType))
+
+    fun clear() {
+        savedObjects.clear()
+        deletedObjects.clear()
+        deletedByIds.clear()
+    }
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/dispatcher/internal/Slf4jDispatcher.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/dispatcher/internal/Slf4jDispatcher.kt
@@ -1,0 +1,24 @@
+package io.bluetape4k.javers.dispatcher.internal
+
+import io.bluetape4k.javers.dispatcher.JaversDispatcher
+import io.bluetape4k.logging.info
+
+/**
+ * Domain Object의 변화를 [org.slf4j.Logger]로 출력하는 [JaversDispatcher] 입니다.
+ *
+ * @property logger slf4j logger
+ */
+class Slf4jDispatcher(private val logger: org.slf4j.Logger): JaversDispatcher {
+
+    override fun sendSaved(domainObject: Any) {
+        logger.info { "Send saved domain object. $domainObject" }
+    }
+
+    override fun sendDeleted(domainObject: Any) {
+        logger.info { "Send deleted domain object. $domainObject" }
+    }
+
+    override fun sendDeletedById(domainObjectId: Any, domainType: Class<*>) {
+        logger.info { "Send deleted domain object by id. id=$domainObjectId, type=$domainType" }
+    }
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/metamodel/CdoSnapshotSupport.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/metamodel/CdoSnapshotSupport.kt
@@ -1,0 +1,55 @@
+package io.bluetape4k.javers.metamodel
+
+import io.bluetape4k.javers.isDateInRange
+import org.javers.core.commit.CommitId
+import org.javers.core.metamodel.`object`.CdoSnapshot
+import org.javers.core.metamodel.`object`.SnapshotType
+import org.javers.repository.api.QueryParams
+
+
+fun <R> CdoSnapshot.mapProperties(mapper: (key: String, value: Any?) -> R): List<R> =
+    this.state.mapProperties(mapper)
+
+fun <R> CdoSnapshot.forEachProperties(consumer: (key: String, value: Any?) -> Unit): Unit =
+    this.state.forEachProperty(consumer)
+
+fun Sequence<CdoSnapshot>.filterByToCommitId(commitId: CommitId): Sequence<CdoSnapshot> =
+    filter { it.commitId.isBeforeOrEqual(commitId) }
+
+fun Sequence<CdoSnapshot>.filterByCommitIds(commitIds: Collection<CommitId>): Sequence<CdoSnapshot> =
+    filter { commitIds.contains(it.commitId) }
+
+fun Sequence<CdoSnapshot>.filterByVersion(version: Long): Sequence<CdoSnapshot> =
+    filter { it.version == version }
+
+fun Sequence<CdoSnapshot>.filterByAuthor(author: String): Sequence<CdoSnapshot> =
+    filter { it.commitMetadata.author == author }
+
+fun Sequence<CdoSnapshot>.filterByCommitDate(queryParams: QueryParams): Sequence<CdoSnapshot> =
+    filter { queryParams.isDateInRange(it.commitMetadata.commitDate) }
+
+fun Sequence<CdoSnapshot>.filterByChangedPropertyName(propertyName: String): Sequence<CdoSnapshot> =
+    filter { it.hasChangeAt(propertyName) }
+
+fun Sequence<CdoSnapshot>.filterByChangedPropertyNames(propertyNames: Set<String>): Sequence<CdoSnapshot> =
+    filter { snapshot ->
+        propertyNames.any { propertyName ->
+            snapshot.hasChangeAt(propertyName)
+        }
+    }
+
+fun Sequence<CdoSnapshot>.filterByType(snapshotType: SnapshotType): Sequence<CdoSnapshot> =
+    filter { it.type == snapshotType }
+
+fun Sequence<CdoSnapshot>.filterByCommitProperties(
+    commitProperties: Map<String, Collection<String>>,
+): Sequence<CdoSnapshot> =
+    filter {
+        val props = it.commitMetadata.properties
+        commitProperties.all { (key, values) ->
+            props.containsKey(key) && values.contains(props[key])
+        }
+    }
+
+fun Sequence<CdoSnapshot>.trimToRequestedSlice(skip: Int, limit: Int): List<CdoSnapshot> =
+    drop(skip).take(limit).toList()

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/metamodel/GlobalIdExtensions.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/metamodel/GlobalIdExtensions.kt
@@ -1,0 +1,21 @@
+package io.bluetape4k.javers.metamodel
+
+import org.javers.core.metamodel.`object`.GlobalId
+import org.javers.core.metamodel.`object`.InstanceId
+import org.javers.core.metamodel.`object`.ValueObjectId
+import org.javers.core.metamodel.type.EntityType
+import org.javers.core.metamodel.type.ManagedType
+
+fun GlobalId.isParent(childCandidate: GlobalId): Boolean {
+    if (this !is InstanceId || childCandidate !is ValueObjectId) {
+        return false
+    }
+    return childCandidate.ownerId == this
+}
+
+fun GlobalId.isChild(parentCandidate: ManagedType): Boolean {
+    if (parentCandidate !is EntityType || this !is ValueObjectId) {
+        return false
+    }
+    return this.ownerId == parentCandidate
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/AbstractCdoSnapshotRepository.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/AbstractCdoSnapshotRepository.kt
@@ -1,0 +1,222 @@
+package io.bluetape4k.javers.repository
+
+import com.google.gson.JsonObject
+import io.bluetape4k.idgenerators.snowflake.Snowflake
+import io.bluetape4k.idgenerators.snowflake.Snowflakers
+import io.bluetape4k.javers.codecs.GsonCodec
+import io.bluetape4k.javers.metamodel.filterByAuthor
+import io.bluetape4k.javers.metamodel.filterByChangedPropertyNames
+import io.bluetape4k.javers.metamodel.filterByCommitDate
+import io.bluetape4k.javers.metamodel.filterByCommitIds
+import io.bluetape4k.javers.metamodel.filterByCommitProperties
+import io.bluetape4k.javers.metamodel.filterByToCommitId
+import io.bluetape4k.javers.metamodel.filterByType
+import io.bluetape4k.javers.metamodel.filterByVersion
+import io.bluetape4k.javers.metamodel.isChild
+import io.bluetape4k.javers.metamodel.isParent
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.trace
+import io.bluetape4k.support.toOptional
+import org.javers.core.commit.Commit
+import org.javers.core.commit.CommitId
+import org.javers.core.json.JsonConverter
+import org.javers.core.metamodel.`object`.CdoSnapshot
+import org.javers.core.metamodel.`object`.GlobalId
+import org.javers.core.metamodel.`object`.ValueObjectId
+import org.javers.core.metamodel.type.EntityType
+import org.javers.core.metamodel.type.ManagedType
+import org.javers.repository.api.QueryParams
+import org.javers.repository.api.SnapshotIdentifier
+import java.util.*
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+import kotlin.jvm.optionals.getOrNull
+
+/**
+ * [CdoSnapshotRepository] 를 구현한 최상위 추상화 클래스입니다.
+ * [CdoSnapshot] 을 저장소에 저장하고, 로드하는 역할을 수행합니다.
+ *
+ * @param T
+ * @property codec 저장소에 저장할 때 [CdoSnapshot] 을 인코딩할 codec
+ * @property commitIdSupplier snapshot.commitMetadata.id 값을 제공하는 [Snowflake]
+ */
+abstract class AbstractCdoSnapshotRepository<T: Any>(
+    protected val codec: GsonCodec<T>,
+    protected val commitIdSupplier: Snowflake = Snowflakers.Global,
+): CdoSnapshotRepository {
+
+    companion object: KLogging()
+
+    private var jsonConverter: JsonConverter? = null
+    private val lock = ReentrantLock()
+
+    fun getJsonConverter(): JsonConverter? = jsonConverter
+
+    override fun setJsonConverter(jsonConverter: JsonConverter?) {
+        this.jsonConverter = jsonConverter
+    }
+
+    protected abstract fun getKeys(): List<String>
+    protected abstract fun contains(globalIdValue: String): Boolean
+    protected fun contains(globalId: GlobalId): Boolean = contains(globalId.value())
+
+    protected abstract fun getSeq(commitId: CommitId): Long
+    protected abstract fun updateCommitId(commitId: CommitId, sequence: Long)
+
+    protected abstract fun getSnapshotSize(globalIdValue: String): Int
+    protected fun getSnapshotSize(globalId: GlobalId): Int = getSnapshotSize(globalId.value())
+
+    protected var head: CommitId? = null
+
+    protected fun encode(snapshot: CdoSnapshot): T {
+        val jsonObject = jsonConverter?.toJsonElement(snapshot) as JsonObject
+        return doEncode(jsonObject)
+    }
+
+    protected fun decode(data: T): CdoSnapshot? {
+        val jsonObject = doDecode(data)
+        return jsonObject?.let { jsonConverter?.fromJson(it, CdoSnapshot::class.java) }
+    }
+
+    protected fun doEncode(jsonObject: JsonObject): T = codec.encode(jsonObject)
+    protected fun doDecode(data: T): JsonObject? = codec.decode(data)
+
+    protected fun getAll(): List<CdoSnapshot> {
+        return getKeys()
+            .flatMap {
+                loadSnapshots(it)
+            }.sortedByDescending { getSeq(it.commitMetadata.id) }
+            .apply {
+                log.debug { "load all snapshot. size=${this.size}" }
+            }
+    }
+
+    override fun ensureSchema() {
+        // Nothing to do.
+    }
+
+    override fun getLatest(globalId: GlobalId): Optional<CdoSnapshot> = when {
+        contains(globalId) -> loadSnapshots(globalId).firstOrNull().toOptional()
+        else               -> Optional.empty()
+    }
+
+    override fun getLatest(globalIds: MutableCollection<GlobalId>): MutableList<CdoSnapshot> {
+        return globalIds.mapNotNull { getLatest(it).getOrNull() }.toMutableList()
+    }
+
+    override fun getStateHistory(globalId: GlobalId, queryParams: QueryParams): MutableList<CdoSnapshot> {
+        val filtered = mutableListOf<CdoSnapshot>()
+        getAll().forEach snapshot@{ snapshot ->
+            if (snapshot.globalId == globalId) {
+                filtered.add(snapshot)
+                return@snapshot
+            }
+            if (queryParams.isAggregate && globalId.isParent(snapshot.globalId)) {
+                filtered.add(snapshot)
+                return@snapshot
+            }
+        }
+        return applyQueryParams(filtered.asSequence(), queryParams)
+    }
+
+    override fun getStateHistory(
+        givenClasses: MutableSet<ManagedType>,
+        queryParams: QueryParams,
+    ): MutableList<CdoSnapshot> {
+        val filtered = mutableListOf<CdoSnapshot>()
+
+        getAll().forEach snapshot@{ snapshot ->
+            givenClasses.forEach classes@{ givenClass ->
+                if (snapshot.globalId.isTypeOf(givenClass)) {
+                    filtered.add(snapshot)
+                    return@classes
+                }
+                if (queryParams.isAggregate && snapshot.globalId.isChild(givenClass)) {
+                    filtered.add(snapshot)
+                    return@classes
+                }
+            }
+        }
+        return applyQueryParams(filtered.asSequence(), queryParams)
+    }
+
+    override fun getValueObjectStateHistory(
+        ownerEntity: EntityType,
+        path: String,
+        queryParams: QueryParams,
+    ): MutableList<CdoSnapshot> {
+        val result = getAll().filter { snapshot ->
+            val id = snapshot.globalId
+            id is ValueObjectId && id.hasOwnerOfType(ownerEntity) && id.fragment.equals(path)
+        }
+        return applyQueryParams(result.asSequence(), queryParams)
+    }
+
+    override fun getSnapshots(queryParams: QueryParams): MutableList<CdoSnapshot> {
+        return applyQueryParams(getAll().asSequence(), queryParams)
+    }
+
+    override fun getSnapshots(snapshotIdentifiers: MutableCollection<SnapshotIdentifier>): List<CdoSnapshot> {
+        log.trace { "get snapshots by identifiers. $snapshotIdentifiers" }
+        return getPersistedIdentifiers(snapshotIdentifiers)
+            .map { snapshot ->
+                val objectSnapshots = loadSnapshots(snapshot.globalId)
+                objectSnapshots[objectSnapshots.size - snapshot.version.toInt()]
+            }
+    }
+
+    override fun persist(commit: Commit?) {
+        if (commit == null) {
+            return
+        }
+        lock.withLock {
+            commit.snapshots.forEach {
+                saveSnapshot(it)
+            }
+            log.trace { "${commit.snapshots.size} snapshot(s) persisted" }
+            head = commit.id
+            head?.let {
+                updateCommitId(it, commitIdSupplier.nextId())
+            }
+        }
+    }
+
+    override fun getHeadId(): CommitId? = head
+
+    private fun applyQueryParams(snapshots: Sequence<CdoSnapshot>, queryParams: QueryParams): MutableList<CdoSnapshot> {
+        var results = snapshots
+        if (queryParams.commitIds().isNotEmpty()) {
+            results = results.filterByCommitIds(queryParams.commitIds())
+        }
+        if (queryParams.toCommitId().isPresent) {
+            results = results.filterByToCommitId(queryParams.toCommitId().get())
+        }
+        if (queryParams.version().isPresent) {
+            results = results.filterByVersion(queryParams.version().get())
+        }
+        if (queryParams.author().isPresent) {
+            results = results.filterByAuthor(queryParams.author().get())
+        }
+        if (queryParams.from().isPresent || queryParams.to().isPresent) {
+            results = results.filterByCommitDate(queryParams)
+        }
+        if (queryParams.changedProperties().isNotEmpty()) {
+            results = results.filterByChangedPropertyNames(queryParams.changedProperties())
+        }
+        if (queryParams.snapshotType().isPresent) {
+            results = results.filterByType(queryParams.snapshotType().get())
+        }
+
+        results = results.filterByCommitProperties(queryParams.commitProperties())
+
+        return results.drop(queryParams.skip()).take(queryParams.limit()).toMutableList()
+    }
+
+    private fun getPersistedIdentifiers(snapshotIdentifiers: Collection<SnapshotIdentifier>): List<SnapshotIdentifier> {
+        return snapshotIdentifiers
+            .filter {
+                contains(it.globalId) && it.version <= getSnapshotSize(it.globalId)
+            }
+    }
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/CdoSnapshotRepository.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/CdoSnapshotRepository.kt
@@ -1,0 +1,17 @@
+package io.bluetape4k.javers.repository
+
+import org.javers.core.metamodel.`object`.CdoSnapshot
+import org.javers.core.metamodel.`object`.GlobalId
+import org.javers.repository.api.JaversRepository
+
+/**
+ * [JaversRepository]를 상속받아 [CdoSnapshot]을 저장소에 저장, 로드하는 기본 Repository
+ */
+interface CdoSnapshotRepository: JaversRepository {
+
+    fun saveSnapshot(snapshot: CdoSnapshot)
+
+    fun loadSnapshots(globalIdValue: String): List<CdoSnapshot>
+
+    fun loadSnapshots(globalId: GlobalId): List<CdoSnapshot> = loadSnapshots(globalId.value())
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/cache2k/Cache2KCdoSnapshotRepository.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/cache2k/Cache2KCdoSnapshotRepository.kt
@@ -1,0 +1,73 @@
+package io.bluetape4k.javers.repository.cache2k
+
+import io.bluetape4k.cache.cache2k.cache2k
+import io.bluetape4k.javers.codecs.GsonCodec
+import io.bluetape4k.javers.codecs.GsonCodecs
+import io.bluetape4k.javers.repository.AbstractCdoSnapshotRepository
+import io.bluetape4k.logging.KLogging
+import kotlinx.atomicfu.locks.ReentrantLock
+import org.cache2k.Cache
+import org.javers.core.commit.CommitId
+import org.javers.core.metamodel.`object`.CdoSnapshot
+import kotlin.concurrent.withLock
+
+/**
+ * [CdoSnapshot] 저장소로 [io.bluetape4k.cache.cache2k.cache2k] 를 사용하는 Repository 입니다.
+ *
+ * @param codec [CdoSnapshot] 변환을 위한 [GsonCodec] 인스턴스
+ */
+class Cache2KCdoSnapshotRepository(
+    codec: GsonCodec<String> = GsonCodecs.LZ4String,
+): AbstractCdoSnapshotRepository<String>(codec) {
+
+    companion object: KLogging()
+
+    private val lock = ReentrantLock()
+
+    private val snapshotCache: Cache<String, MutableList<String>> by lazy {
+        cache2k<String, MutableList<String>> {
+            this.entryCapacity(100_000)
+            this.storeByReference(true)
+            this.eternal(true)
+        }.build()
+    }
+
+    private val commitSeqCache: Cache<CommitId, Long> by lazy {
+        cache2k<CommitId, Long> {
+            this.entryCapacity(100_000)
+            this.eternal(true)
+        }.build()
+    }
+
+    override fun getKeys(): List<String> {
+        return snapshotCache.keys().toList()
+    }
+
+    override fun contains(globalIdValue: String): Boolean {
+        return snapshotCache.containsKey(globalIdValue)
+    }
+
+    override fun getSeq(commitId: CommitId): Long = commitSeqCache[commitId] ?: 0L
+
+    override fun updateCommitId(commitId: CommitId, sequence: Long) {
+        commitSeqCache.put(commitId, sequence)
+    }
+
+    override fun getSnapshotSize(globalIdValue: String): Int {
+        return snapshotCache[globalIdValue]?.size ?: 0
+    }
+
+    override fun saveSnapshot(snapshot: CdoSnapshot) {
+        lock.withLock {
+            val globalIdValue = snapshot.globalId.value()
+            val snapshots = snapshotCache.computeIfAbsent(globalIdValue) { mutableListOf() }
+            val encoded = encode(snapshot)
+            snapshots.add(0, encoded)
+        }
+    }
+
+    override fun loadSnapshots(globalIdValue: String): List<CdoSnapshot> {
+        return snapshotCache[globalIdValue]?.mapNotNull { decode(it) } ?: emptyList()
+    }
+
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/caffeine/CaffeineCdoSnapshotRepository.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/caffeine/CaffeineCdoSnapshotRepository.kt
@@ -1,0 +1,75 @@
+package io.bluetape4k.javers.repository.caffeine
+
+import com.github.benmanes.caffeine.cache.Cache
+import io.bluetape4k.cache.caffeine.caffeine
+import io.bluetape4k.javers.codecs.GsonCodec
+import io.bluetape4k.javers.codecs.GsonCodecs
+import io.bluetape4k.javers.repository.AbstractCdoSnapshotRepository
+import io.bluetape4k.logging.KLogging
+import org.javers.core.commit.CommitId
+import org.javers.core.metamodel.`object`.CdoSnapshot
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * [CdoSnapshot] 저장소로 [com.github.benmanes.caffeine.cache.Cache] 를 사용하는 Repository 입니다.
+ *
+ * @param codec [CdoSnapshot] 변환을 위한 [GsonCodec] 인스턴스
+ */
+class CaffeineCdoSnapshotRepository(
+    codec: GsonCodec<String> = GsonCodecs.LZ4String,
+): AbstractCdoSnapshotRepository<String>(codec) {
+
+    companion object: KLogging()
+
+    private val lock = ReentrantLock()
+
+    /**
+     * [CdoSnapshot] 컬렉션을 저장하는 Cache (key=globalId, value=collection of encoded snapshot)
+     */
+    private val snapshotCache: Cache<String, MutableList<String>> by lazy {
+        caffeine {
+            initialCapacity(1_000)
+        }.build()
+    }
+
+    /**
+     * [CommitId] - Sequence Number를 캐시합니다.
+     */
+    private val commitSeqCache: Cache<CommitId, Long> by lazy {
+        caffeine {
+            initialCapacity(1_000)
+        }.build()
+    }
+
+    override fun getKeys(): List<String> {
+        return snapshotCache.asMap().map { it.key }
+    }
+
+    override fun contains(globalIdValue: String): Boolean {
+        return snapshotCache.getIfPresent(globalIdValue) != null
+    }
+
+    override fun getSeq(commitId: CommitId): Long = commitSeqCache.getIfPresent(commitId) ?: 0L
+
+    override fun updateCommitId(commitId: CommitId, sequence: Long) {
+        commitSeqCache.put(commitId, sequence)
+    }
+
+    override fun getSnapshotSize(globalIdValue: String): Int {
+        return snapshotCache.getIfPresent(globalIdValue)?.size ?: 0
+    }
+
+    override fun saveSnapshot(snapshot: CdoSnapshot) {
+        lock.withLock {
+            val globalIdValue = snapshot.globalId.value()
+            val snapshots = snapshotCache.get(globalIdValue) { _ -> mutableListOf() }
+            val encoded = encode(snapshot)
+            snapshots.add(0, encoded)
+        }
+    }
+
+    override fun loadSnapshots(globalIdValue: String): List<CdoSnapshot> {
+        return snapshotCache.getIfPresent(globalIdValue)?.mapNotNull { decode(it) } ?: emptyList()
+    }
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/jcache/JCacheCdoSnapshotRepository.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/jcache/JCacheCdoSnapshotRepository.kt
@@ -1,0 +1,73 @@
+package io.bluetape4k.javers.repository.jcache
+
+import io.bluetape4k.cache.jcache.getOrCreate
+import io.bluetape4k.javers.codecs.GsonCodec
+import io.bluetape4k.javers.codecs.GsonCodecs
+import io.bluetape4k.javers.repository.AbstractCdoSnapshotRepository
+import io.bluetape4k.logging.KLogging
+import org.javers.core.commit.CommitId
+import org.javers.core.metamodel.`object`.CdoSnapshot
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * [CdoSnapshot] 저장소로 [javax.cache.Cache] 를 사용하는 Repository 입니다.
+ *
+ * @param prefix  cache name prefix
+ * @param cacheManager [javax.cache.CacheManager] 인스턴스
+ * @param codec [CdoSnapshot] 변환을 위한 [GsonCodec] 인스턴스
+ */
+class JCacheCdoSnapshotRepository(
+    prefix: String,
+    cacheManager: javax.cache.CacheManager,
+    codec: GsonCodec<String> = GsonCodecs.LZ4String,
+): AbstractCdoSnapshotRepository<String>(codec) {
+
+    companion object: KLogging() {
+        private const val SNAPSHOT_SUFFIX = "-snapshots"
+        private const val COMMIT_SEQ_SUFFIX = "-commit_seq"
+    }
+
+    private val lock = ReentrantLock()
+
+    private val snapshotCacheName = prefix + SNAPSHOT_SUFFIX
+    private val commitSeqCacheName = prefix + COMMIT_SEQ_SUFFIX
+
+    private val snapshotCache: javax.cache.Cache<String, MutableList<String>> =
+        cacheManager.getOrCreate(snapshotCacheName)
+    private val commitSeqCache: javax.cache.Cache<CommitId, Long> = cacheManager.getOrCreate(commitSeqCacheName)
+
+    override fun getKeys(): List<String> {
+        return snapshotCache.map { it.key }
+    }
+
+    override fun contains(globalIdValue: String): Boolean {
+        return snapshotCache.containsKey(globalIdValue)
+    }
+
+    override fun getSeq(commitId: CommitId): Long = commitSeqCache[commitId] ?: 0L
+
+    override fun updateCommitId(commitId: CommitId, sequence: Long) {
+        commitSeqCache.put(commitId, sequence)
+    }
+
+    override fun getSnapshotSize(globalIdValue: String): Int {
+        return snapshotCache[globalIdValue]?.size ?: 0
+    }
+
+    override fun saveSnapshot(snapshot: CdoSnapshot) {
+        lock.withLock {
+            val globalIdValue = snapshot.globalId.value()
+
+            // NOTE: JCache 는 Reference 가 아닌 Value 를 저장해야 하므로, 매번 Replace 형식이 되어야 한다
+            val snapshots = snapshotCache.get(globalIdValue) ?: mutableListOf()
+            val encoded = encode(snapshot)
+            snapshots.add(0, encoded)
+            snapshotCache.put(globalIdValue, snapshots)
+        }
+    }
+
+    override fun loadSnapshots(globalIdValue: String): List<CdoSnapshot> {
+        return snapshotCache[globalIdValue]?.mapNotNull { decode(it) } ?: emptyList()
+    }
+}

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/jql/JqlQueryExtensions.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/jql/JqlQueryExtensions.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.javers.repository.jql
+
+import org.javers.core.Changes
+import org.javers.core.Javers
+import org.javers.core.metamodel.`object`.CdoSnapshot
+import org.javers.repository.jql.JqlQuery
+import org.javers.shadow.Shadow
+import java.util.stream.Stream
+import kotlin.streams.asSequence
+
+// TODO: 필요없을 것 같다.
+
+inline fun <reified T: Any> JqlQuery.findShadows(javers: Javers): MutableList<Shadow<T>> =
+    javers.findShadows(this)
+
+inline fun <reified T: Any> JqlQuery.findShadowsAndStream(javers: Javers): Stream<Shadow<T>> =
+    javers.findShadowsAndStream(this)
+
+inline fun <reified T: Any> JqlQuery.findShadowsAndSequence(javers: Javers): Sequence<Shadow<T>> =
+    javers.findShadowsAndStream<T>(this).asSequence()
+
+fun JqlQuery.findSnapshots(javers: Javers): MutableList<CdoSnapshot> =
+    javers.findSnapshots(this)
+
+fun JqlQuery.findChanges(javers: Javers): Changes =
+    javers.findChanges(this)

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/jql/QueryBuilderExtensions.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/jql/QueryBuilderExtensions.kt
@@ -1,0 +1,83 @@
+package io.bluetape4k.javers.repository.jql
+
+import org.javers.repository.jql.JqlQuery
+import org.javers.repository.jql.QueryBuilder
+import kotlin.reflect.KClass
+
+inline fun queryAnyDomainObject(
+    initializer: QueryBuilder.() -> Unit = {},
+): JqlQuery {
+    return QueryBuilder.anyDomainObject().apply(initializer).build()
+}
+
+inline fun <reified T: Any> query(
+    initializer: QueryBuilder.() -> Unit,
+): JqlQuery {
+    return QueryBuilder.byClass(T::class.java).apply(initializer).build()
+}
+
+inline fun <reified T: Any> queryByInstance(
+    instance: T,
+    initializer: QueryBuilder.() -> Unit = {},
+): JqlQuery {
+    return QueryBuilder.byInstance(instance).apply(initializer).build()
+}
+
+inline fun <reified T: Any> queryByInstanceId(
+    localId: Any,
+    initializer: QueryBuilder.() -> Unit = {},
+): JqlQuery {
+    return QueryBuilder.byInstanceId(localId, T::class.java).apply(initializer).build()
+}
+
+inline fun <reified T: Any> queryByValueObject(
+    path: String,
+    initializer: QueryBuilder.() -> Unit = {},
+): JqlQuery {
+    return QueryBuilder.byValueObject(T::class.java, path).apply(initializer).build()
+}
+
+inline fun <reified T: Any> queryByValueObjectId(
+    ownerLocalId: Any,
+    path: String,
+    initializer: QueryBuilder.() -> Unit = {},
+): JqlQuery {
+    return QueryBuilder.byValueObjectId(ownerLocalId, T::class.java, path).apply(initializer).build()
+}
+
+inline fun <reified T: Any> queryByClass(
+    initializer: QueryBuilder.() -> Unit = {},
+): JqlQuery {
+    return QueryBuilder.byClass(T::class.java).apply(initializer).build()
+}
+
+@JvmName("queryByClassesCollection")
+inline fun queryByClasses(
+    classes: Collection<Class<*>>,
+    initializer: QueryBuilder.() -> Unit = {},
+): JqlQuery {
+    return QueryBuilder.byClass(*classes.toTypedArray()).apply(initializer).build()
+}
+
+@JvmName("queryByClassesArray")
+inline fun queryByClasses(
+    vararg classes: Class<*>,
+    initializer: QueryBuilder.() -> Unit = {},
+): JqlQuery {
+    return QueryBuilder.byClass(*classes).apply(initializer).build()
+}
+
+
+inline fun queryByClasses(
+    kclasses: Collection<KClass<*>>,
+    initializer: QueryBuilder.() -> Unit = {},
+): JqlQuery {
+    return QueryBuilder.byClass(*kclasses.map { it.java }.toTypedArray()).apply(initializer).build()
+}
+
+inline fun queryByClasses(
+    vararg kclasses: KClass<*>,
+    initializer: QueryBuilder.() -> Unit = {},
+): JqlQuery {
+    return QueryBuilder.byClass(*kclasses.map { it.java }.toTypedArray()).apply(initializer).build()
+}

--- a/javers/core/src/test/kotlin/io/bluetape4k/javers/JaversExtensionsTest.kt
+++ b/javers/core/src/test/kotlin/io/bluetape4k/javers/JaversExtensionsTest.kt
@@ -1,0 +1,9 @@
+package io.bluetape4k.javers
+
+import io.bluetape4k.logging.KLogging
+
+class JaversExtensionsTest {
+
+    companion object: KLogging()
+
+}

--- a/javers/core/src/test/kotlin/io/bluetape4k/javers/SnapshotToShadowTest.kt
+++ b/javers/core/src/test/kotlin/io/bluetape4k/javers/SnapshotToShadowTest.kt
@@ -1,0 +1,37 @@
+package io.bluetape4k.javers
+
+import io.bluetape4k.javers.repository.caffeine.CaffeineCdoSnapshotRepository
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.javers.core.Javers
+import org.javers.core.JaversBuilder
+import org.javers.core.model.SnapshotEntity
+import org.javers.core.repository.AbstractJaversCommitTest
+import org.junit.jupiter.api.Test
+
+class SnapshotToShadowTest: AbstractJaversCommitTest() {
+
+    override fun newJavers(): Javers =
+        JaversBuilder.javers()
+            .registerJaversRepository(CaffeineCdoSnapshotRepository())
+            .build()
+
+    val javers by lazy { newJavers() }
+
+    @Test
+    fun `convert snapshot to shadow`() {
+        val entity = SnapshotEntity(1).apply { intProperty = 1 }
+        // 엔티티의 변경을 snapshot 을 생성한다
+        val snapshot = javers.commit("a", entity).snapshots.first()
+
+        // snapshot 으로부터 원본 entity를 가지고 올 수 있도록 해주는 Shadow을 만든다
+        val shadow = javers.getShadow<SnapshotEntity>(snapshot)
+
+        shadow.shouldNotBeNull()
+        shadow.get() shouldBeEqualTo entity
+
+        repeat(100) {
+            javers.getShadow<SnapshotEntity>(snapshot).get() shouldBeEqualTo entity
+        }
+    }
+}

--- a/javers/core/src/test/kotlin/io/bluetape4k/javers/codecs/GsonCodecTest.kt
+++ b/javers/core/src/test/kotlin/io/bluetape4k/javers/codecs/GsonCodecTest.kt
@@ -1,0 +1,106 @@
+package io.bluetape4k.javers.codecs
+
+import com.google.gson.JsonObject
+import io.bluetape4k.javers.repository.jql.queryByInstanceId
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import kotlinx.atomicfu.atomic
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldContainSame
+import org.amshove.kluent.shouldNotBeNull
+import org.javers.core.JaversBuilder
+import org.javers.core.model.ShallowPhone
+import org.javers.core.model.SnapshotEntity
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+class GsonCodecTest {
+
+    companion object: KLogging()
+
+    private val javers = JaversBuilder.javers().build()
+
+    private fun getStringCodecs() = listOf(
+        GsonCodecs.String,
+        GsonCodecs.GZipString,
+        GsonCodecs.SnappyString,
+        GsonCodecs.LZ4String,
+        GsonCodecs.SnappyString,
+        GsonCodecs.ZstdString,
+    )
+
+    private fun getBinaryCodecs() = listOf(
+        GsonCodecs.Kryo,
+        GsonCodecs.GZipKryo,
+        GsonCodecs.SnappyKryo,
+        GsonCodecs.LZ4Kryo,
+        GsonCodecs.SnappyKryo,
+        GsonCodecs.ZstdKryo,
+    )
+
+    private val idSeq = atomic(0)
+
+    @ParameterizedTest(name = "GsonCodec={0}")
+    @MethodSource("getStringCodecs")
+    fun `string codec`(codec: GsonCodec<String>) {
+        val entity = SnapshotEntity(idSeq.incrementAndGet()).apply { intProperty = 1 }
+        javers.commit("a", entity)
+
+        entity.shallowPhone = ShallowPhone(42)
+        javers.commit("a", entity)
+
+        entity.entityRef = SnapshotEntity(42)
+        javers.commit("a", entity)
+
+        val query = queryByInstanceId<SnapshotEntity>(idSeq.value)
+
+        val snapshots = javers.findSnapshots(query)
+        snapshots.forEach { log.debug { "snapshot=$it" } }
+        snapshots.size shouldBeGreaterThan 1
+
+        val jsonConverter = javers.jsonConverter
+
+        snapshots.forEach { snapshot ->
+            val jsonElement = jsonConverter.toJsonElement(snapshot) as JsonObject
+
+            val encodedData = codec.encode(jsonElement)
+            val decoded = codec.decode(encodedData)
+
+            decoded.shouldNotBeNull()
+            decoded.toString() shouldBeEqualTo jsonElement.toString()
+        }
+    }
+
+    @ParameterizedTest(name = "GsonCodec={0}")
+    @MethodSource("getBinaryCodecs")
+    fun `binary codec`(codec: GsonCodec<ByteArray>) {
+        val entity = SnapshotEntity(idSeq.incrementAndGet()).apply { intProperty = 1 }
+        javers.commit("a", entity)
+
+        entity.shallowPhone = ShallowPhone(43)
+        javers.commit("a", entity)
+
+        entity.entityRef = SnapshotEntity(43)
+        javers.commit("a", entity)
+
+        val query = queryByInstanceId<SnapshotEntity>(idSeq.value)
+
+        val snapshots = javers.findSnapshots(query)
+        snapshots.forEach { log.debug { "snapshot=$it" } }
+        snapshots.size shouldBeGreaterThan 1
+
+        val jsonConverter = javers.jsonConverter
+        snapshots.forEach { snapshot ->
+            val jsonElement = jsonConverter.toJsonElement(snapshot) as JsonObject
+
+            val encodedData = codec.encode(jsonElement)
+            val decoded = codec.decode(encodedData)
+
+            decoded.shouldNotBeNull()
+            val decodedMap = GsonElementConverter.fromJsonObject(decoded)
+            val jsonMap = GsonElementConverter.fromJsonObject(jsonElement)
+            decodedMap shouldContainSame jsonMap
+        }
+    }
+}

--- a/javers/core/src/test/kotlin/io/bluetape4k/javers/examples/CommitAndQueryExamples.kt
+++ b/javers/core/src/test/kotlin/io/bluetape4k/javers/examples/CommitAndQueryExamples.kt
@@ -1,0 +1,42 @@
+package io.bluetape4k.javers.examples
+
+import io.bluetape4k.javers.repository.jql.queryByInstanceId
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import org.amshove.kluent.shouldHaveSize
+import org.javers.core.JaversBuilder
+import org.junit.jupiter.api.Test
+
+class CommitAndQueryExamples {
+
+    companion object: KLogging()
+
+    val javers = JaversBuilder.javers().build()
+
+    @Test
+    fun `Javers 저장소에 commit 하고 변화를 조회하기`() {
+        val robert = Person("bob", "Robert Martin")
+        javers.commit("user", robert)
+
+        robert.name = "Robert C."
+        robert.position = Position.Developer
+        javers.commit("user", robert)
+
+        val query = queryByInstanceId<Person>("bob")
+
+        val shadows = javers.findShadows<Person>(query)
+        log.debug { "shadows" }
+        shadows.forEach { log.debug { it } }
+        shadows shouldHaveSize 2
+
+        val snapshots = javers.findSnapshots(query)
+        log.debug { "snapshots" }
+        snapshots.forEach { log.debug { it } }
+        snapshots shouldHaveSize 2
+
+        val changes = javers.findChanges(query)
+        log.debug { "changes" }
+        changes.forEach { log.debug { it } }
+        changes shouldHaveSize 5
+    }
+}

--- a/javers/core/src/test/kotlin/io/bluetape4k/javers/examples/MappingExamples.kt
+++ b/javers/core/src/test/kotlin/io/bluetape4k/javers/examples/MappingExamples.kt
@@ -1,0 +1,116 @@
+package io.bluetape4k.javers.examples
+
+import io.bluetape4k.javers.createEntityInstanceId
+import io.bluetape4k.javers.getEntityTypeMapping
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldNotBeEqualTo
+import org.javers.core.Javers
+import org.javers.core.JaversBuilder
+import org.javers.core.diff.custom.CustomValueComparator
+import org.javers.core.metamodel.annotation.Id
+import org.javers.core.metamodel.annotation.TypeName
+import org.javers.core.metamodel.`object`.InstanceId
+import org.javers.core.metamodel.type.EntityType
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.Serializable
+
+@Suppress("UNUSED_VARIABLE")
+class MappingExamples {
+
+    companion object: KLogging()
+
+    private lateinit var javers: Javers
+
+    @BeforeEach
+    fun beforeEach() {
+        javers = JaversBuilder.javers().build()
+    }
+
+    @TypeName("Person")
+    data class Person(
+        @Id var namme: String? = null,
+        var position: String? = null,
+    ): Serializable
+
+
+    @Test
+    fun `@TypeName 이 적용된 클래스는 EntityType으로 매핑됩니다`() {
+        val personType = javers.getTypeMapping<EntityType>(Person::class.java)
+        val personType2 = javers.getEntityTypeMapping<Person>()
+
+        val bob = Person("Bob", "Dev")
+        val bobId = personType.createIdFromInstance(bob)
+
+        log.debug { "EntityType of Person\n${personType.prettyPrint()}" }
+        log.debug { "Id of bob=${bobId.value()}" }
+
+        bobId.value() shouldBeEqualTo "Person/Bob"
+        bobId shouldBeInstanceOf InstanceId::class
+    }
+
+    @TypeName("Entity")
+    data class Entity(@Id var id: Point, var data: String? = null)
+
+    class Point(val x: Double = 0.0, val y: Double = 0.0) {
+        fun myToString(): String = "(${x.toInt()},${y.toInt()})"
+    }
+
+    class PointComparator: CustomValueComparator<Point> {
+        override fun equals(a: Point, b: Point): Boolean = a.myToString() == b.myToString()
+        override fun toString(value: Point): String = value.myToString()
+    }
+
+    @Test
+    fun `comprex id 를 비교할 때 toString() 을 사용합니다`() {
+        val p1 = Point(1.0, 3.0)
+        val p2 = Point(1.0, 3.0)
+
+        val entity1 = Entity(p1)
+        val entity2 = Entity(p2)
+
+        // toString() 값으로 비교하는데, data class 가 아니라 메모리 주소가 포함되므로, 둘은 같지 않다
+        log.debug { "p1 == p2 ?" + (p1 == p2) }
+        p1 shouldNotBeEqualTo p2
+
+        val globalId1 = javers.createEntityInstanceId(entity1).value()  // Entity/1.0,3.0
+        val globalId2 = javers.createEntityInstanceId(entity2).value()  // Entity/1.0,3.0
+
+        log.debug { "InstanceId of entity1 = $globalId1" }
+        log.debug { "InstanceId of entity2 = $globalId2" }
+
+        globalId1 shouldBeEqualTo globalId2
+
+        // Javers 에서 2개의 엔틴티의 변화를 찾을 수 있습니다.
+        javers.compare(entity1, entity2).changes.shouldBeEmpty()
+    }
+
+    @Test
+    fun `complex id 를 custom 하게 생성하기 위해 CustomValueComparator 을 사용할 수 있습니다`() {
+        val entity = Entity(Point(1.0 / 3, 4.0 / 3))
+
+        // Javers 기본 reflectToString function 사용 시
+        val id = javers.createEntityInstanceId(entity)
+        log.debug { "id.value=${id.value()}" }
+        id.value() shouldBeEqualTo "Entity/0.3333333333333333,1.3333333333333333"
+
+        // Custom toString 함수를 제공하면, 2개의 entity 값을 custom 하게 비교할 수 있습니다.
+        val customJavers = JaversBuilder.javers()
+            .registerValue(Point::class.java, PointComparator())
+            .build()
+
+        val entity2 = Entity(Point(1.1 / 3, 4.1 / 3))
+
+        val id2 = customJavers.createEntityInstanceId(entity2)
+        log.debug { "id2.value=${id2.value()}" }
+        id2.value() shouldBeEqualTo "Entity/(0,1)"
+
+        val diff = customJavers.compare(entity, entity2)
+        log.debug { "diff=${diff.prettyPrint()}" }
+        diff.changes.shouldBeEmpty()
+    }
+}

--- a/javers/core/src/test/kotlin/io/bluetape4k/javers/examples/Models.kt
+++ b/javers/core/src/test/kotlin/io/bluetape4k/javers/examples/Models.kt
@@ -1,0 +1,51 @@
+package io.bluetape4k.javers.examples
+
+import org.javers.core.metamodel.annotation.Id
+import org.javers.core.metamodel.annotation.TypeName
+import java.time.ZonedDateTime
+
+enum class Position {
+    Assistant,
+    Secretary,
+    Developer,
+    Specialist,
+    Saleswoman,
+    ScrumMaster,
+    Townsman,
+    Hero
+}
+
+data class Address(var city: String, var street: String = "")
+
+@TypeName("Person")
+data class Person(@Id val login: String, var name: String) {
+    val addresses: MutableList<Address> = mutableListOf()
+    val addressMap: MutableMap<String, Address> = mutableMapOf()
+    var position: Position? = null
+}
+
+@TypeName("Employee")
+data class Employee(@Id val name: String, var salary: Int = 1000, val position: Position = Position.Developer) {
+
+    var age: Int? = null
+
+    var boss: Employee? = null
+    val subordinates: MutableList<Employee> = mutableListOf()
+
+    var primaryAddress: Address? = null
+    var postalAddress: Address? = null
+    val skills: MutableSet<String> = mutableSetOf()
+    val performance: MutableMap<Int, String> = mutableMapOf()
+    var lastPromotionDate: ZonedDateTime? = null
+
+    fun addSubordinates(vararg emps: Employee) {
+        subordinates.addAll(emps)
+        emps.forEach { it.boss = this }
+    }
+}
+
+
+@TypeName("Boss")
+data class Boss(@Id val name: String) {
+    val suordinates: MutableCollection<Person> = mutableListOf()
+}

--- a/javers/core/src/test/kotlin/io/bluetape4k/javers/examples/ObjectDiffExamples.kt
+++ b/javers/core/src/test/kotlin/io/bluetape4k/javers/examples/ObjectDiffExamples.kt
@@ -1,0 +1,211 @@
+package io.bluetape4k.javers.examples
+
+import io.bluetape4k.javers.diff.changesByType
+import io.bluetape4k.javers.diff.isListChange
+import io.bluetape4k.javers.diff.isNewObject
+import io.bluetape4k.javers.diff.isObjectRemoved
+import io.bluetape4k.javers.diff.objectsByChangeType
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContainSame
+import org.amshove.kluent.shouldHaveSize
+import org.javers.core.JaversBuilder
+import org.javers.core.diff.changetype.NewObject
+import org.javers.core.diff.changetype.ObjectRemoved
+import org.javers.core.diff.changetype.ReferenceChange
+import org.javers.core.diff.changetype.ValueChange
+import org.javers.core.diff.changetype.container.ListChange
+import org.junit.jupiter.api.Test
+
+class ObjectDiffExamples {
+
+    companion object: KLogging()
+
+    private val javers = JaversBuilder.javers().build()
+
+    @Test
+    fun `두 객체의 변화를 찾습니다`() {
+        val tommyOld = Person("tommy", "Tommy Smart")
+        val tommyNew = Person("tommy", "Tommy C. Smart")
+
+        // 두 객체의 차이를 찾습니다.
+        val diff = javers.compare(tommyOld, tommyNew)
+        log.debug { diff.prettyPrint() }
+
+        diff.changes shouldHaveSize 1  // name 변경
+
+        val change = diff.changes.first()
+        change shouldBeInstanceOf ValueChange::class
+        val valueChange = change as ValueChange
+
+        valueChange.left shouldBeEqualTo tommyOld.name
+        valueChange.right shouldBeEqualTo tommyNew.name
+    }
+
+    @Test
+    fun `엔티티의 컬레션에 요소를 추가하는 변화를 감지합니다`() {
+        val oldBoss = Employee("Big Boss").apply {
+            addSubordinates(Employee("Great Developer"))
+        }
+        val newBoss = Employee("Big Boss").apply {
+            addSubordinates(Employee("Great Developer"))
+            addSubordinates(Employee("Hired First"))
+            addSubordinates(Employee("Hired Second"))
+        }
+
+        val diff = javers.compare(oldBoss, newBoss)
+        log.debug { diff.prettyPrint() }
+
+        diff.objectsByChangeType<NewObject>() shouldContainSame listOf(
+            Employee("Hired First"),
+            Employee("Hired Second")
+        )
+
+        diff.changes shouldHaveSize 11
+        diff.changes.forEachIndexed { index, change ->
+            log.debug { "change[$index]=$change" }
+        }
+        diff.changes[0].isNewObject.shouldBeTrue()
+        diff.changes[1].isNewObject.shouldBeTrue()
+        diff.changes[10].isListChange.shouldBeTrue()
+    }
+
+    @Test
+    fun `엔티티의 컬레션에 요소를 삭제하는 변화를 감지합니다`() {
+        val oldBoss = Employee("Big Boss").apply {
+            addSubordinates(
+                Employee("Great Developer"),
+                Employee("Team Leader").apply {
+                    addSubordinates(
+                        Employee("Another Dev"),
+                        Employee("To Be Fired")
+                    )
+                }
+            )
+        }
+        val newBoss = Employee("Big Boss").apply {
+            addSubordinates(
+                Employee("Great Developer"),
+                Employee("Team Leader").apply {
+                    addSubordinates(Employee("Another Dev"))
+                }
+            )
+        }
+
+        val diff = javers.compare(oldBoss, newBoss)
+        log.debug { diff.prettyPrint() }
+
+        diff.changes.forEachIndexed { index, change ->
+            log.debug { "change[$index]=$change" }
+        }
+        diff.changes.first().isObjectRemoved.shouldBeTrue()
+
+        val removed = diff.changesByType<ObjectRemoved>()
+        removed shouldHaveSize 1
+        removed[0].affectedObject.isPresent.shouldBeTrue()
+        removed[0].affectedObject.get() shouldBeEqualTo Employee("To Be Fired")
+
+        val removedObjects = diff.objectsByChangeType<ObjectRemoved>()
+        removedObjects shouldHaveSize 1
+        removedObjects[0] shouldBeEqualTo Employee("To Be Fired")
+    }
+
+    @Test
+    fun `속성이 변경된 것을 감지합니다`() {
+        val oldBoss = Employee("Big Boss").apply {
+            addSubordinates(
+                Employee("Noisy Manager"),
+                Employee("Great Developer", 10_000),
+            )
+        }
+        val newBoss = Employee("Big Boss").apply {
+            addSubordinates(
+                Employee("Noisy Manager"),
+                Employee("Great Developer", 20_000),
+            )
+        }
+
+        val diff = javers.compare(oldBoss, newBoss)
+        log.debug { diff.prettyPrint() }
+
+        val valueChanges = diff.changesByType<ValueChange>()
+        valueChanges shouldHaveSize 1
+
+        with(valueChanges.first()) {
+            affectedLocalId shouldBeEqualTo "Great Developer"
+            propertyName shouldBeEqualTo "salary"
+            left shouldBeEqualTo 10_000
+            right shouldBeEqualTo 20_000
+        }
+    }
+
+    @Test
+    fun `부모 엔티티가 변경된 것을 감지합니다`() {
+        val oldBoss = Employee("Big Boss").apply {
+            addSubordinates(
+                Employee("Manager One").apply {
+                    addSubordinates(Employee("Great Developer"))
+                },
+                Employee("Manager Two")
+            )
+        }
+        val newBoss = Employee("Big Boss").apply {
+            addSubordinates(
+                Employee("Manager One"),
+                Employee("Manager Two").apply {
+                    addSubordinates(Employee("Great Developer"))
+                }
+            )
+        }
+
+        val diff = javers.compare(oldBoss, newBoss)
+        log.debug { diff.prettyPrint() }
+
+        val changes = diff.changesByType<ReferenceChange>()
+        changes shouldHaveSize 1
+
+        with(changes[0]) {
+            affectedLocalId shouldBeEqualTo "Great Developer"
+            left.value() shouldBeEqualTo "Employee/Manager One"
+            right.value() shouldBeEqualTo "Employee/Manager Two"
+        }
+    }
+
+    @Test
+    fun `@TypeName이 적용되지 않은 일반 클래스도 변화를 감지한다`() {
+        val address1 = Address("New York", "5th Avenue")
+        val address2 = Address("New York", "6th Avenue")
+
+        val diff = javers.compare(address1, address2)
+        log.debug { diff.prettyPrint() }
+
+        diff.changes shouldHaveSize 1
+        val changes = diff.changesByType<ValueChange>()
+        with(changes[0]) {
+            affectedGlobalId.value() shouldBeEqualTo "${Address::class.java.name}/"
+            propertyName shouldBeEqualTo "street"
+            left shouldBeEqualTo "5th Avenue"
+            right shouldBeEqualTo "6th Avenue"
+        }
+    }
+
+    @Test
+    fun `최상위 컬렉션을 비교합니다`() {
+        val oldList = listOf(Person("Tommy", "Tommy Smart"))
+        val newList = listOf(Person("Tommy", "Tommy C. Smart"))
+
+        val diff = javers.compare(oldList, newList)
+        log.debug { diff.prettyPrint() }
+        diff.changes shouldHaveSize 1
+
+        val change = diff.changesByType<ListChange>().first()
+        log.debug { change }
+
+        change.changes shouldHaveSize 1
+        change.left shouldBeEqualTo oldList
+        change.right shouldBeEqualTo newList
+    }
+}

--- a/javers/core/src/test/kotlin/io/bluetape4k/javers/repository/Cache2kCommitTest.kt
+++ b/javers/core/src/test/kotlin/io/bluetape4k/javers/repository/Cache2kCommitTest.kt
@@ -1,0 +1,14 @@
+package io.bluetape4k.javers.repository
+
+import io.bluetape4k.javers.repository.cache2k.Cache2KCdoSnapshotRepository
+import org.javers.core.Javers
+import org.javers.core.JaversBuilder
+import org.javers.core.repository.AbstractJaversCommitTest
+
+class Cache2kCommitTest: AbstractJaversCommitTest() {
+
+    override fun newJavers(): Javers =
+        JaversBuilder.javers()
+            .registerJaversRepository(Cache2KCdoSnapshotRepository())
+            .build()
+}

--- a/javers/core/src/test/kotlin/io/bluetape4k/javers/repository/Cache2kJaversShadowTest.kt
+++ b/javers/core/src/test/kotlin/io/bluetape4k/javers/repository/Cache2kJaversShadowTest.kt
@@ -1,0 +1,11 @@
+package io.bluetape4k.javers.repository
+
+import io.bluetape4k.javers.repository.cache2k.Cache2KCdoSnapshotRepository
+import org.javers.repository.api.JaversRepository
+import org.javers.repository.jql.AbstractJaversShadowTest
+
+class Cache2kJaversShadowTest: AbstractJaversShadowTest() {
+
+    override fun prepareJaversRepository(): JaversRepository =
+        Cache2KCdoSnapshotRepository()
+}

--- a/javers/core/src/test/kotlin/io/bluetape4k/javers/repository/CaffeineCommitTest.kt
+++ b/javers/core/src/test/kotlin/io/bluetape4k/javers/repository/CaffeineCommitTest.kt
@@ -1,0 +1,14 @@
+package io.bluetape4k.javers.repository
+
+import io.bluetape4k.javers.repository.caffeine.CaffeineCdoSnapshotRepository
+import org.javers.core.Javers
+import org.javers.core.JaversBuilder
+import org.javers.core.repository.AbstractJaversCommitTest
+
+class CaffeineCommitTest: AbstractJaversCommitTest() {
+
+    override fun newJavers(): Javers =
+        JaversBuilder.javers()
+            .registerJaversRepository(CaffeineCdoSnapshotRepository())
+            .build()
+}

--- a/javers/core/src/test/kotlin/io/bluetape4k/javers/repository/CaffeineJaversShadowTest.kt
+++ b/javers/core/src/test/kotlin/io/bluetape4k/javers/repository/CaffeineJaversShadowTest.kt
@@ -1,0 +1,11 @@
+package io.bluetape4k.javers.repository
+
+import io.bluetape4k.javers.repository.caffeine.CaffeineCdoSnapshotRepository
+import org.javers.repository.api.JaversRepository
+import org.javers.repository.jql.AbstractJaversShadowTest
+
+class CaffeineJaversShadowTest: AbstractJaversShadowTest() {
+
+    override fun prepareJaversRepository(): JaversRepository =
+        CaffeineCdoSnapshotRepository()
+}

--- a/javers/core/src/test/kotlin/io/bluetape4k/javers/repository/JCacheJaversShadowTest.kt
+++ b/javers/core/src/test/kotlin/io/bluetape4k/javers/repository/JCacheJaversShadowTest.kt
@@ -1,0 +1,15 @@
+package io.bluetape4k.javers.repository
+
+import io.bluetape4k.cache.jcache.JCaching
+import io.bluetape4k.javers.repository.jcache.JCacheCdoSnapshotRepository
+import org.javers.repository.api.JaversRepository
+import org.javers.repository.jql.AbstractJaversShadowTest
+import java.util.*
+
+class JCacheJaversShadowTest: AbstractJaversShadowTest() {
+
+    override fun prepareJaversRepository(): JaversRepository {
+        val cacheManager = JCaching.Caffeine.cacheManager
+        return JCacheCdoSnapshotRepository("jcache-${UUID.randomUUID()}", cacheManager)
+    }
+}

--- a/javers/core/src/test/kotlin/org/javers/core/AbstractJaversRepositoryTest.kt
+++ b/javers/core/src/test/kotlin/org/javers/core/AbstractJaversRepositoryTest.kt
@@ -1,0 +1,519 @@
+package org.javers.core
+
+import io.bluetape4k.javers.commit.SnowflakeCommitIdGenerator
+import io.bluetape4k.javers.diff.filterByType
+import io.bluetape4k.javers.latestSnapshotOrNull
+import io.bluetape4k.javers.repository.jql.queryAnyDomainObject
+import io.bluetape4k.javers.repository.jql.queryByClass
+import io.bluetape4k.javers.repository.jql.queryByInstance
+import io.bluetape4k.javers.repository.jql.queryByInstanceId
+import io.bluetape4k.javers.repository.jql.queryByValueObject
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.trace
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldBeLessOrEqualTo
+import org.amshove.kluent.shouldContainSame
+import org.amshove.kluent.shouldNotBeNull
+import org.javers.common.date.DateProvider
+import org.javers.core.commit.CommitMetadata
+import org.javers.core.diff.changetype.ValueChange
+import org.javers.core.diff.changetype.container.CollectionChange
+import org.javers.core.diff.changetype.container.ValueAdded
+import org.javers.core.model.ConcreteWithActualType
+import org.javers.core.model.DummyAddress
+import org.javers.core.model.DummyUser
+import org.javers.core.model.DummyUserDetails
+import org.javers.core.model.NewEntityWithTypeAlias
+import org.javers.core.model.NewValueObjectWithTypeAlias
+import org.javers.core.model.PrimitiveEntity
+import org.javers.core.model.SnapshotEntity
+import org.javers.repository.api.JaversRepository
+import org.javers.repository.jql.JqlQuery
+import org.javers.repository.jql.QueryBuilder
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+import java.util.*
+import java.util.stream.Stream
+import kotlin.math.absoluteValue
+
+abstract class AbstractJaversRepositoryTest {
+
+    companion object: KLogging()
+
+    protected lateinit var javers: Javers
+    protected lateinit var repository: JaversRepository
+    protected lateinit var dateProvider: DateProvider
+    protected var commitIdGenerator: SnowflakeCommitIdGenerator? = null
+
+    abstract fun prepareJaversRepository(): JaversRepository
+    protected open fun useCustomCommitIdSupplier(): Boolean = true
+
+    @BeforeEach
+    open fun beforeEach() {
+        buildJaversInstance()
+    }
+
+    protected open fun buildJaversInstance() {
+        dateProvider = prepareDateProvider()
+        repository = prepareJaversRepository()
+
+        val javersBuilder = JaversBuilder.javers()
+            .withDateTimeProvider(dateProvider)
+            .registerJaversRepository(repository)
+
+        if (useCustomCommitIdSupplier()) {
+            commitIdGenerator = SnowflakeCommitIdGenerator()
+
+            // NOTE: withCustomCommitIdGenerator 가 internal 함수라서 이 클래스의 package name 을 동일하게 해주었습니다.
+            javersBuilder.withCustomCommitIdGenerator(commitIdGenerator)
+        }
+
+        javers = javersBuilder.build()
+    }
+
+    protected open fun commitSeq(commit: CommitMetadata): Int = when {
+        useCustomCommitIdSupplier() -> commitIdGenerator!!.getSeq(commit.id)
+        else                        -> commit.id.majorId.toInt()
+    }
+
+    protected open fun prepareDateProvider(): DateProvider = when {
+        useCustomCommitIdSupplier() -> TikDateProvider()
+        else                        -> FakeDateProvider()
+    }
+
+    protected open fun setNow(dateTime: ZonedDateTime) {
+        when (val provider = this.dateProvider) {
+            is TikDateProvider -> provider.set(dateTime)
+            is FakeDateProvider -> provider.set(dateTime)
+        }
+    }
+
+    @Test
+    fun `CommitMetadata에 현재 LocalDateTime과 Instant를 사용한다`() {
+        // GIVEN
+        val now = ZonedDateTime.now()
+        setNow(now)
+
+        // WHEN
+        javers.commit("author", SnapshotEntity(1))
+        val snapshot = javers.latestSnapshotOrNull<SnapshotEntity>(1)
+
+        // THEN
+        snapshot.shouldNotBeNull()
+        snapshot.commitMetadata.author shouldBeEqualTo "author"
+        snapshot.commitMetadata.commitDateInstant shouldBeEqualTo now.toInstant()
+        ChronoUnit.MILLIS.between(
+            snapshot.commitMetadata.commitDate,
+            now.toLocalDateTime()
+        ).absoluteValue shouldBeLessOrEqualTo 1
+    }
+
+
+    @Test
+    fun `다양한 primitive 수형을 commit 합니다`() {
+        // GIVEN
+        val s = PrimitiveEntity("1")
+
+        // WHEN
+        javers.commit("author", s)
+
+        s.intField = 10
+        s.longField = 10L
+        s.doubleField = 1.1
+        s.floatField = 1.1F
+        s.charField = 'c'
+        s.byteField = 10.toByte()
+        s.shortField = 10.toShort()
+        s.booleanField = true
+        s.IntegerField = 10
+        s.LongField = 10
+        s.DoubleField = 1.1
+        s.FloatField = 1.1F
+        s.CharField = 'c'
+        s.ByteField = 10.toByte()
+        s.ShortField = 10.toShort()
+        s.BooleanField = true
+
+        javers.commit("author", s)
+
+        // THEN
+        val changes = javers.findChanges(queryAnyDomainObject())
+        changes.size shouldBeEqualTo 18
+
+        val valueChanges = changes.filterByType<ValueChange>()
+        valueChanges.size shouldBeEqualTo 17
+        valueChanges.forEach { change ->
+            log.debug { "old=${change.left}, new=${change.right}" }
+        }
+    }
+
+    @Test
+    fun `ValueObject를 소유한 Entity의 snapshot으로부터 ValueObject 변경을 조회`() {
+        // GIVEN
+        val data = listOf(
+            DummyUserDetails(1, DummyAddress(city = "London")),
+            DummyUserDetails(1, DummyAddress(city = "Paris")),
+            SnapshotEntity(1, valueObjectRef = DummyAddress("London")),
+            SnapshotEntity(1, valueObjectRef = DummyAddress("Paris")),
+            SnapshotEntity(2, valueObjectRef = DummyAddress("Rome")),
+            SnapshotEntity(2, valueObjectRef = DummyAddress("Paris")),
+            // Noise
+            SnapshotEntity(2, valueObjectRef = DummyAddress("Paris")).apply {
+                arrayOfValueObjects = arrayOf(DummyAddress("Luton"))
+            }
+        )
+
+        data.forEach { javers.commit("author", it) }
+
+        // WHEN
+        val changes = javers.findChanges(queryByValueObject<SnapshotEntity>("valueObjectRef"))
+
+        // THEN
+        log.debug { changes.prettyPrint() }
+        changes.forEach {
+            log.debug { "change=$it" }
+            it.affectedGlobalId.typeName shouldBeEqualTo DummyAddress::class.java.name
+        }
+        changes.size shouldBeEqualTo 4
+        commitSeq(changes[0].commitMetadata.get()) shouldBeEqualTo 6
+    }
+
+    @Test
+    fun `JaversRepository로 Reference Object 변화 이력을 저장합니다`() {
+        // GIVEN
+        val ref = SnapshotEntity(id = 2)
+        val cdo = SnapshotEntity(id = 1).apply {
+            entityRef = ref
+            arrayOfIntegers = intArrayOf(1, 2)
+            listOfDates = mutableListOf(LocalDate.of(2001, 1, 1), LocalDate.of(2001, 1, 2))
+            mapOfValues[LocalDate.of(2001, 1, 1)] = BigDecimal(1.1)
+            mapOfGenericValues["enumSet"] = EnumSet.of(SnapshotEntity.DummyEnum.val1, SnapshotEntity.DummyEnum.val2)
+        }
+
+        javers.commit("author", cdo)    // v. 1
+        cdo.intProperty = 5
+        javers.commit("author2", cdo)   // v. 2
+
+        // WHEN
+        val snapshots = javers.findSnapshots(queryByInstanceId<SnapshotEntity>(1))
+
+        // THEN
+//        val refId = GlobalIdTestBuilder.instanceId(2, SnapshotEntity::class)
+//        log.trace { "refId=$refId" }
+//
+//        val snapshot = snapshots.find { (it.globalId as InstanceId).cdoId == 1 }
+//        log.trace { "majorId = ${snapshot!!.commitMetadata.id.majorId}" }
+//        commitSeq(snapshot!!.commitMetadata) shouldBeEqualTo 2
+//
+//        snapshot.getPropertyValue("id") shouldBeEqualTo 1
+//        snapshot.getPropertyValue("entityRef") shouldBeEqualTo refId
+//        (snapshot.getPropertyValue("arrayOfIntegers") as IntArray) shouldContainSame intArrayOf(1, 2)
+//
+//        with(snapshots[0]) {
+//            commitSeq(commitMetadata) shouldBeEqualTo 2
+//            commitMetadata.author shouldBeEqualTo "author2"
+//            changed.size shouldBeEqualTo 1
+//            changed[0] shouldBeEqualTo "intProperty"
+//            isInitial.shouldBeFalse()
+//
+//            log.debug { "Snapshot commitId: ${this.commitId}" }
+//            state.forEachProperty { name, value ->
+//                log.debug { "property name=$name, value=$value" }
+//            }
+//            log.debug { "Json= ${javers.jsonConverter.toJson(this)}" }
+//        }
+//
+//        with(snapshots[1]) {
+//            commitSeq(commitMetadata) shouldBeEqualTo 1
+//            commitMetadata.author shouldBeEqualTo "author"
+//            getPropertyValue("intProperty").shouldBeNull()
+//            isInitial.shouldBeTrue()
+//
+//            log.debug { "Snapshot commitId: ${this.commitId}" }
+//            state.forEachProperty { name, value ->
+//                log.debug { "property name=$name, value=$value" }
+//            }
+//
+//            log.debug { "Json= ${javers.jsonConverter.toJson(this)}" }
+//        }
+//
+//        val changes = javers.findChanges(queryByInstanceId<SnapshotEntity>(1))
+//
+//        log.debug { "Changes=${changes.prettyPrint()}" }
+//        log.debug { "Changes Json = ${javers.jsonConverter.toJson(changes)}" }
+    }
+
+    @Test
+    fun `엔티티 속성을 Repository의 가장 최신 것과 비교하기`() {
+        //GIVEN
+        val user = DummyUser(name = "John").apply { age = 18 }
+        javers.commit("login", user)
+
+        // WHEN
+        user.age = 19
+        javers.commit("login", user)
+
+        val history = javers.findChanges(queryByInstanceId<DummyUser>("John"))
+
+        // THEN
+        with(history[0]) {
+
+            log.trace { "change=${javers.jsonConverter.toJson(this)}" }
+
+            this shouldBeInstanceOf ValueChange::class.java
+//            affectedGlobalId shouldBeEqualTo GlobalIdTestBuilder.instanceId("John", DummyUser::class)
+//
+//            with(this as ValueChange) {
+//                propertyName shouldBeEqualTo "age"
+//                left shouldBeEqualTo 18
+//                right shouldBeEqualTo 19
+//            }
+        }
+    }
+
+    @Test
+    fun `Repository로부터 온전한 엔티티인 Shadow를 가져온다`() {
+        //GIVEN
+        val user = DummyUser(name = "John").apply { age = 18 }
+        javers.commit("login", user)
+
+        // WHEN
+        user.age = 19
+        javers.commit("login", user)
+
+        // Shadows는 저장된 Snapshot 변경이력으로부터, 원하는 객체 재구성해준다
+        val shadows = javers.findShadows<DummyUser>(queryByInstance(user))
+
+        // THEN
+        shadows.size shouldBeEqualTo 2
+
+        val newUser = shadows[0].get()
+        val oldUser = shadows[1].get()
+
+        newUser.age shouldBeEqualTo 19
+        oldUser.age shouldBeEqualTo 18
+
+        shadows[0].commitMetadata.id.majorId shouldBeGreaterThan shadows[1].commitMetadata.id.majorId
+    }
+
+    @Test
+    fun `Repository에 복수의 snapshots을 연속으로 commit하고 read하기`() {
+        val cdo = SnapshotEntity(id = 1)
+
+        (1..25).forEach {
+            cdo.intProperty = it
+            javers.commit("login", cdo)
+
+            val snapshot = javers.findSnapshots(queryByInstanceId<SnapshotEntity>(1)).first()
+            snapshot.getPropertyValue("intProperty") shouldBeEqualTo it
+        }
+    }
+
+    @Test
+    fun `부모클래스의 Generic 필드에 대한 변화를 Commit하기`() {
+        // GIVEN
+        javers.commit("author", ConcreteWithActualType("a", listOf("1")))
+        javers.commit("author", ConcreteWithActualType("a", listOf("1", "2")))
+
+        // WHEN
+        val changes = javers.findChanges(queryByClass<ConcreteWithActualType>())
+
+        // THEN
+        val change = changes[0]
+
+        Assumptions.assumeTrue { change is CollectionChange<*> }
+        change shouldBeInstanceOf CollectionChange::class.java
+        if (change is CollectionChange<*>) {
+            val elementChange = change.changes[0]
+            elementChange shouldBeInstanceOf ValueAdded::class.java
+
+            if (elementChange is ValueAdded) {
+                elementChange.index shouldBeEqualTo 1
+                elementChange.addedValue shouldBeInstanceOf String::class
+                elementChange.addedValue shouldBeEqualTo "2"
+            }
+        }
+    }
+
+    @Test
+    fun `ValueObject와 소유권자인 Entity 를 ValueObject 쿼리로 조회하기`() {
+        // GIVEN
+        javers.commit(
+            "author",
+            NewEntityWithTypeAlias(1.toBigDecimal()).apply { valueObject = NewValueObjectWithTypeAlias(5) })
+        javers.commit(
+            "author",
+            NewEntityWithTypeAlias(1.toBigDecimal()).apply { valueObject = NewValueObjectWithTypeAlias(6) })
+
+        // WHEN
+        val changes = javers.findChanges(queryByValueObject<NewEntityWithTypeAlias>("valueObject"))
+
+        // THEN
+        changes.size shouldBeEqualTo 2
+
+        val valueChange = changes.find { it is ValueChange && it.propertyName == "some" } as ValueChange
+
+        valueChange.left shouldBeEqualTo 5
+        valueChange.right shouldBeEqualTo 6
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTimeRangeQuery")
+    fun `Entity Snapshot을 기간으로 검색하기`(query: JqlQuery, expectedCommitDates: List<LocalDateTime>) {
+        // GIVEN:
+        repeat(5) {
+            val index = it + 1
+            val entity = SnapshotEntity(1).apply { intProperty = index }
+            val now = ZonedDateTime.of(2015, 1, 1, index, 0, 0, 0, ZoneOffset.UTC)
+            setNow(now)
+            javers.commit("author", entity)
+        }
+
+        // WHEN
+        val snapshots = javers.findSnapshots(query)
+        val commitDates = snapshots.map { it.commitMetadata.commitDate }
+
+        // THEN
+        commitDates shouldContainSame expectedCommitDates
+    }
+
+    private fun getTimeRangeQuery(): Stream<Arguments> =
+        Stream.of(
+            Arguments.of(
+                QueryBuilder
+                    .byInstanceId(1, SnapshotEntity::class.java)
+                    .from(LocalDateTime.of(2015, 1, 1, 3, 0))
+                    .build(),
+                (5 downTo 3).map { LocalDateTime.of(2015, 1, 1, it, 0) }
+            ),
+            Arguments.of(
+                QueryBuilder
+                    .byInstanceId(1, SnapshotEntity::class.java)
+                    .to(LocalDateTime.of(2015, 1, 1, 3, 0))
+                    .build(),
+                (3 downTo 1).map { LocalDateTime.of(2015, 1, 1, it, 0) }
+            ),
+
+            Arguments.of(
+                QueryBuilder
+                    .byInstanceId(1, SnapshotEntity::class.java)
+                    .from(LocalDateTime.of(2015, 1, 1, 2, 0))
+                    .to(LocalDateTime.of(2015, 1, 1, 4, 0))
+                    .build(),
+                (4 downTo 2).map { LocalDateTime.of(2015, 1, 1, it, 0) }
+            )
+        )
+
+    @Test
+    fun `Entity snapshot version 은 증가됩니다`() {
+        // WHEN
+        val entity = SnapshotEntity(id = 1).apply { intProperty = 11 }
+        javers.commit("author", entity)
+        javers.commit("author", entity.apply { intProperty = 22 })
+        javers.commit("author", entity.apply { intProperty = 33 })
+        javers.commit("author", entity.apply { intProperty = 44 })
+
+        // THEN
+        val snapshots = javers.findSnapshots(queryByInstanceId<SnapshotEntity>(1))
+        snapshots.size shouldBeEqualTo 4
+        snapshots.forEach {
+            log.debug { "version=${it.version}" }
+        }
+        snapshots[0].version shouldBeEqualTo 4
+        snapshots[1].version shouldBeEqualTo 3
+        snapshots[2].version shouldBeEqualTo 2
+        snapshots[3].version shouldBeEqualTo 1
+    }
+
+
+    @RepeatedTest(3)
+    fun `200개의 다른 snapshot들을 조회한다`() {
+        // GIVEN:
+        repeat(200) {
+            javers.commit("author", SnapshotEntity(id = 1).apply { intProperty = it + 1 })
+        }
+
+        // val instanceId = JaversTestBuilder.javersTestAssembly().instanceId(SnapshotEntity(id = 1))
+        // val snapshotIdentifiers = List(200) { SnapshotIdentifier(instanceId, it + 1L) }
+
+        // WHEN:
+        // val snapshots = repository.getSnapshots(snapshotIdentifiers)
+
+        // THEN:
+        // snapshots.size shouldBeEqualTo snapshotIdentifiers.size
+    }
+
+    @Test
+    fun `Commited properties 를 commit 하고 read 하기`() {
+        val commitProperties = mapOf(
+            "tenant" to "ACME",
+            "sessionId" to "1234567890",
+            "device" to "smartwatch",
+            "yet another property name" to "yet another property value"
+        )
+        javers.commit("author", SnapshotEntity(id = 1), commitProperties)
+
+        // WHEN
+        val snapshot = javers.findSnapshots(queryByInstanceId<SnapshotEntity>(1)).first()
+
+        // THEN
+        snapshot.commitMetadata.properties shouldContainSame commitProperties
+    }
+
+    @Test
+    fun `cluster-friendly commitId generator 지원하기`() {
+        val threads = 10
+        val javersRepo = prepareJaversRepository()
+
+        List(threads) { it }
+            .parallelStream()
+            .map {
+                it to JaversBuilder.javers()
+                    .registerJaversRepository(javersRepo)
+                    .withCommitIdGenerator(CommitIdGenerator.RANDOM)
+                    .build()
+            }.forEach {
+                val commit = it.second.commit("author", SnapshotEntity(id = it.first))
+                log.debug { "Commit entity. commit=$commit" }
+            }
+
+        val javers = JaversBuilder.javers().registerJaversRepository(javersRepo).build()
+        val snapshots = javers.findSnapshots(queryAnyDomainObject())
+
+        snapshots.map { it.commitId }.toSet().size shouldBeEqualTo threads
+    }
+
+    @Test
+    fun `변경이 없는 zero snapshots 은 commit 되지 않습니다`() {
+        // GIVEN
+        val anEntity = SnapshotEntity(1).apply { intProperty = 100 }
+
+        // WHEN
+        val commit = javers.commit("author", anEntity)
+        val snapshots = javers.findSnapshots(queryByInstanceId<SnapshotEntity>(1))
+
+        // THEN
+        snapshots.size shouldBeEqualTo 1
+        repository.headId shouldBeEqualTo commit.id
+
+        // WHEN: 변경이 없는 엔티티는 저장되면 안됩니다
+        javers.commit("author", anEntity)
+
+        // THEN: 저장되지 않았으므로 headId의 변화가 없다
+        repository.headId shouldBeEqualTo commit.id
+    }
+}

--- a/javers/core/src/test/kotlin/org/javers/core/FakeDateProvider.kt
+++ b/javers/core/src/test/kotlin/org/javers/core/FakeDateProvider.kt
@@ -1,0 +1,15 @@
+package org.javers.core
+
+import org.javers.common.date.DateProvider
+import java.time.ZonedDateTime
+
+class FakeDateProvider(private var dateTime: ZonedDateTime? = null): DateProvider {
+
+    override fun now(): ZonedDateTime {
+        return dateTime ?: ZonedDateTime.now()
+    }
+
+    fun set(dateTime: ZonedDateTime?) {
+        this.dateTime = dateTime
+    }
+}

--- a/javers/core/src/test/kotlin/org/javers/core/GlobalIdTestBuilder.kt
+++ b/javers/core/src/test/kotlin/org/javers/core/GlobalIdTestBuilder.kt
@@ -1,0 +1,17 @@
+package org.javers.core
+
+object GlobalIdTestBuilder {
+
+    val javersTestBuilder = JaversTestBuilder.javersTestAssembly()
+
+//    fun instanceId(instance: Any): InstanceId = javersTestBuilder.instanceId(instance)
+//
+//    fun <T: Any> instanceId(localId: Any, kclass: KClass<T>): InstanceId =
+//        javersTestBuilder.instanceId(localId, kclass)
+//
+//    fun <E: Any> valueObjectId(localId: Any, owningEntityKClass: KClass<E>, fragment: String): ValueObjectId =
+//        ValueObjectId("?", instanceId(localId, owningEntityKClass), fragment)
+//
+//    inline fun <reified V: Any> unboundedValueObjectId(): UnboundedValueObjectId =
+//        javersTestBuilder.unboundedValueObjectId<V>()
+}

--- a/javers/core/src/test/kotlin/org/javers/core/JaversTestBuilder.kt
+++ b/javers/core/src/test/kotlin/org/javers/core/JaversTestBuilder.kt
@@ -1,0 +1,82 @@
+package org.javers.core
+
+import org.javers.common.date.DateProvider
+import org.javers.repository.api.JaversRepository
+
+class JaversTestBuilder(val builder: JaversBuilder = JaversBuilder()) {
+
+    fun javers(): Javers = builder.getContainerComponent(Javers::class.java)
+
+    companion object {
+        fun javersTestAssembly() = JaversTestBuilder().apply {
+            builder.withMappingStyle(MappingStyle.FIELD).build()
+        }
+
+        fun javersTestAssembly(packageToScan: String) = JaversTestBuilder().apply {
+            builder.withPackagesToScan(packageToScan).build()
+        }
+
+        fun javersTestAssembly(classToScan: Class<*>) = JaversTestBuilder().apply {
+            builder.scanTypeName(classToScan).build()
+        }
+
+        fun javersTestAssembly(mappingStyle: MappingStyle) = JaversTestBuilder().apply {
+            builder.withMappingStyle(mappingStyle).build()
+        }
+
+        fun javersTestAssembly(dateProvider: DateProvider) = JaversTestBuilder().apply {
+            builder.withDateTimeProvider(dateProvider).build()
+        }
+
+        fun javersTestAssembly(repository: JaversRepository) = JaversTestBuilder().apply {
+            builder.registerJaversRepository(repository).build()
+        }
+
+        fun newInstance(): Javers = javersTestAssembly().javers()
+    }
+
+//    internal inline fun <reified T: Any> getComponent(): T = builder.getContainerComponent(T::class.java)
+
+//    val snapshotFactory: SnapshotFactory by lazy { getComponent<SnapshotFactory>() }
+//    val javersRepository: JaversRepository by lazy { getComponent<JaversRepository>() }
+//    val typeMapper: TypeMapper by lazy { getComponent<TypeMapper>() }
+//    val queryRunner: QueryRunner by lazy { getComponent<QueryRunner>() }
+//    val globalIdFactory: GlobalIdFactory by lazy { getComponent<GlobalIdFactory>() }
+//    val liveCdoSnapshot: LiveCdoFactory by lazy { getComponent<LiveCdoFactory>() }
+//    val commitFactory: CommitFactory by lazy { getComponent<CommitFactory>() }
+//    val jsonConverter: JsonConverter by lazy { getComponent<JsonConverter>() }
+//    val shadowFactory: ShadowFactory by lazy { getComponent<ShadowFactory>() }
+
+//    inline fun <reified T> getManagedType(): ManagedType =
+//        typeMapper.getJaversManagedType(T::class.java)
+//
+//    inline fun <reified T> getProperty(propertyName: String): Property =
+//        getManagedType<T>().getProperty(propertyName)
+//
+//    fun getProperty(type: KClass<*>, propertyName: String): Property =
+//        typeMapper.getJaversManagedType(type.java).getProperty(propertyName)
+
+//    fun getJsonConvertBuilder(): JsonConverterBuilder = getComponent<JsonConverterBuilder>()
+
+//    fun hash(obj: Any): String {
+//        val jsonState = jsonConverter.toJson(javers().commit("", obj).snapshots.first().state)
+//        return ShaDigest.longDigest(jsonState)
+//    }
+
+//    fun addressHash(city: String): String = hash(DummyAddress(city = city))
+//
+//    fun instanceId(instance: Any): InstanceId =
+//        globalIdFactory.createIdFromInstance(instance)
+//
+//    fun <T: Any> instanceId(localId: Any, entityKClass: KClass<T>): InstanceId =
+//        globalIdFactory.createInstanceId(localId, entityKClass.java)
+//
+//    inline fun <reified T: Any> instanceId(localId: Any): InstanceId =
+//        globalIdFactory.createInstanceId(localId, T::class.java)
+//
+//    inline fun <reified V: Any> unboundedValueObjectId(): UnboundedValueObjectId =
+//        globalIdFactory.createUnboundedValueObjectId(V::class.java)
+//
+//    fun <V: Any> unboundedValueObjectId(valueObjectKClass: KClass<V>): UnboundedValueObjectId =
+//        globalIdFactory.createUnboundedValueObjectId(valueObjectKClass.java)
+}

--- a/javers/core/src/test/kotlin/org/javers/core/RandomCommitIdGenerator.kt
+++ b/javers/core/src/test/kotlin/org/javers/core/RandomCommitIdGenerator.kt
@@ -1,0 +1,34 @@
+package org.javers.core
+
+import io.bluetape4k.idgenerators.snowflake.Snowflakers
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.trace
+import kotlinx.atomicfu.locks.ReentrantLock
+import org.javers.core.commit.CommitId
+import java.util.function.Supplier
+import kotlin.concurrent.withLock
+
+class RandomCommitIdGenerator: Supplier<CommitId> {
+
+    companion object: KLogging()
+
+    private val commits = hashMapOf<CommitId, Int>()
+    private val snowflake = Snowflakers.Global
+    private var counter = 0
+    private val lock = ReentrantLock()
+
+    fun getSeq(commitId: CommitId): Int =
+        commits[commitId] ?: throw NoSuchElementException("Not found commitId[$commitId]")
+
+    override fun get(): CommitId {
+        lock.withLock {
+            counter++
+            val next = CommitId(snowflake.nextId(), 0)
+            commits[next] = counter
+
+            log.trace { "Generate random CommitId. next commitId=$next, counter=$counter" }
+            return next
+        }
+    }
+
+}

--- a/javers/core/src/test/kotlin/org/javers/core/TikDateProvider.kt
+++ b/javers/core/src/test/kotlin/org/javers/core/TikDateProvider.kt
@@ -1,0 +1,19 @@
+package org.javers.core
+
+import org.javers.common.date.DateProvider
+import java.time.ZonedDateTime
+
+class TikDateProvider(
+    private var dateTime: ZonedDateTime = ZonedDateTime.now(),
+): DateProvider {
+
+    override fun now(): ZonedDateTime {
+        val now = dateTime
+        dateTime = dateTime.plusSeconds(1)
+        return now
+    }
+
+    fun set(dateTime: ZonedDateTime) {
+        this.dateTime = dateTime
+    }
+}

--- a/javers/core/src/test/kotlin/org/javers/core/model/Category.kt
+++ b/javers/core/src/test/kotlin/org/javers/core/model/Category.kt
@@ -1,0 +1,50 @@
+package org.javers.core.model
+
+import org.javers.core.metamodel.annotation.Id
+import org.javers.core.metamodel.annotation.ShallowReference
+
+abstract class AbstractCategory @JvmOverloads constructor(var name: String? = null) {
+
+    var parent: AbstractCategory? = null
+    val categories: MutableList<AbstractCategory> = mutableListOf()
+
+    fun addChild(child: AbstractCategory) {
+        child.parent = this
+        this.categories.add(child)
+    }
+}
+
+class CategoryC @JvmOverloads constructor(
+    var id: Long,
+    name: String = "name",
+): AbstractCategory("$name$id")
+
+data class CategoryVo(var name: String? = null) {
+
+    var parent: CategoryVo? = null
+    val children: MutableList<CategoryVo> = mutableListOf()
+
+    fun addChild(child: CategoryVo) {
+        child.parent = this
+        children.add(child)
+    }
+}
+
+data class PhoneWithShallowCategory(@Id var id: Long) {
+
+    var number: String = "123"
+    var deepCategory: CategoryC? = null
+
+    @ShallowReference
+    var shallowCategory: CategoryC? = null
+
+    @ShallowReference
+    var shallowCategories: MutableSet<CategoryC> = mutableSetOf()
+
+    @ShallowReference
+    var shallowCategoryList: MutableList<CategoryC> = mutableListOf()
+
+    @ShallowReference
+    var shallowCategoryMap: MutableMap<String, CategoryC> = mutableMapOf()
+
+}

--- a/javers/core/src/test/kotlin/org/javers/core/model/ConcreteWithActualType.kt
+++ b/javers/core/src/test/kotlin/org/javers/core/model/ConcreteWithActualType.kt
@@ -1,0 +1,7 @@
+package org.javers.core.model
+
+import org.javers.core.metamodel.annotation.Id
+
+abstract class AbstractGeneric<ID, V>(@Id var id: ID, var value: V)
+
+class ConcreteWithActualType(id: String, value: List<String>): AbstractGeneric<String, List<String>>(id, value)

--- a/javers/core/src/test/kotlin/org/javers/core/model/DummyAddress.kt
+++ b/javers/core/src/test/kotlin/org/javers/core/model/DummyAddress.kt
@@ -1,0 +1,30 @@
+package org.javers.core.model
+
+abstract class AbstractDummyAddress {
+    var inheritedInt: Int? = null
+}
+
+data class DummyAddress(val city: String, val street: String? = null): AbstractDummyAddress() {
+
+    companion object {
+        @JvmField
+        var staticInt: Int? = null
+    }
+
+    var kind: Kind? = null
+    var networkAddress: DummyNetworkAddress? = null
+
+    @Transient
+    var someTransientField: Int? = null
+
+    enum class Kind {
+        HOME, OFFICE
+    }
+}
+
+data class DummyNetworkAddress(var address: String? = null) {
+
+    var version: Version? = null
+
+    enum class Version { IPv4, IPv6 }
+}

--- a/javers/core/src/test/kotlin/org/javers/core/model/DummyUser.kt
+++ b/javers/core/src/test/kotlin/org/javers/core/model/DummyUser.kt
@@ -1,0 +1,162 @@
+package org.javers.core.model
+
+import org.javers.core.metamodel.annotation.DiffIgnore
+import org.javers.core.metamodel.annotation.Id
+import org.javers.core.metamodel.annotation.PropertyName
+import java.time.LocalDateTime
+
+abstract class AbstractDummyUser {
+    var inhertedInt: Int? = null
+}
+
+class DummyUser(@Id val name: String, var surname: String? = null): AbstractDummyUser() {
+
+    enum class SEX { FEMALE, MALE, OCCASIONALLY }
+
+    companion object {
+        fun dummyUser(name: String = "name") = DummyUser(name)
+    }
+
+    @field:Transient
+    var someTransientField: Int = 0
+
+    @field:Transient
+    var propertyWithTransientAnn: Int = 0
+
+    @DiffIgnore
+    var propertyWithDiffIgnoreAnn: Int = 0
+
+    var propertyWithDiffIgnoredType: DummyIgnoredType? = null
+    var propertyWithDiffIgnoredSubType: IgnoredSubType? = null
+
+    // primitives and primitive boxes
+    var flag: Boolean = false
+    var boxedFlag: Boolean? = null
+    var age: Int = 0
+    var _char: Char = 0.toChar()
+
+    var sex: SEX? = null
+    var largeInt: Int? = null
+
+    // collections
+    var stringSet: MutableSet<String> = mutableSetOf()
+    var stringList: MutableList<String> = mutableListOf()
+    var integerList: MutableList<Int> = mutableListOf()
+    var primitiveMap: MutableMap<String, LocalDateTime> = mutableMapOf()
+    var valueMap: MutableMap<String, LocalDateTime> = mutableMapOf()
+
+    var objectMap: MutableMap<String, DummyUserDetails> = mutableMapOf()   // not supported
+
+    // array
+    var intArray: IntArray? = null
+    var dateTimes: Array<LocalDateTime>? = null
+
+    // reference
+    var supervisor: DummyUser? = null
+    var dummyUserDetails: DummyUserDetails? = null
+    var dummyUserDetailsList: MutableList<DummyUserDetails> = mutableListOf()
+    var employeesList: MutableList<DummyUser> = mutableListOf()
+
+    fun addEmployee(employee: DummyUser) {
+        employeesList.add(employee)
+        employee.supervisor = this
+    }
+
+    fun withDetails(id: Int = 1) = apply {
+        dummyUserDetails = DummyUserDetails(id)
+    }
+
+    fun withAddress(city: String) = apply {
+        if (dummyUserDetails == null) {
+            withDetails()
+        }
+        dummyUserDetails!!.dummyAddress = DummyAddress(city = city)
+    }
+
+    fun withAddresses(vararg addresses: DummyAddress) = apply {
+        if (dummyUserDetails == null) {
+            withDetails()
+        }
+        dummyUserDetails!!.addressList.addAll(addresses)
+    }
+
+    fun withSex(sex: SEX) = apply { this.sex = sex }
+
+    fun withPrimitiveMap(map: MutableMap<String, LocalDateTime>) = apply {
+        this.primitiveMap = map
+    }
+
+    fun withValueMap(map: MutableMap<String, LocalDateTime>) = apply {
+        this.valueMap = map
+    }
+
+    fun withStringsSet(strings: MutableSet<String>) = apply {
+        this.stringSet = strings
+    }
+
+    fun withIntegerList(list: MutableList<Int>) = apply {
+        this.integerList = list
+    }
+
+    fun withAge(age: Int) = apply { this.age = age }
+
+    fun withBoxedFlag(boxedFlag: Boolean) = apply { this.boxedFlag = boxedFlag }
+
+    fun withInteger(largeInt: Int) = apply { this.largeInt = largeInt }
+
+    fun withFlag(flag: Boolean) = apply { this.flag = flag }
+
+    fun withSupervisor(supervisorName: String) = apply {
+        this.supervisor = DummyUser(name = supervisorName)
+    }
+
+    fun withSupervisor(supervisor: DummyUser) = apply {
+        this.supervisor = supervisor
+    }
+
+    fun withEmployees(numberOfEmployees: Int) = apply {
+        repeat(numberOfEmployees) {
+            this.addEmployee(DummyUser(name = "EM${it + 1}"))
+        }
+    }
+
+    fun withEmployees(employees: List<DummyUser>) = apply {
+        employees.forEach { this.addEmployee(it) }
+    }
+
+    fun withDetailsList(numberOfDetailsList: Int) = apply {
+        this.dummyUserDetailsList = List(numberOfDetailsList) { DummyUserDetails(id = it) }.toMutableList()
+    }
+
+    fun withIntArray(ints: List<Int>) = apply {
+        this.intArray = ints.toIntArray()
+    }
+}
+
+data class DummyUserDetails(
+    @Id val id: Int = DEFAULT_ID,
+    var dummyAddress: DummyAddress? = null,
+) {
+
+    companion object {
+        const val DEFAULT_ID = 1
+    }
+
+    var someValue: String? = null
+    var isTrue: Boolean? = null
+    val addressList: MutableList<DummyAddress> = mutableListOf()
+    val interList: MutableList<Int> = mutableListOf()
+
+    @PropertyName("Customized Property")
+    var customizedProperty: String? = null
+
+    fun withAddress(street: String, city: String) = apply {
+        this.dummyAddress = DummyAddress(city, street)
+    }
+
+    fun withAddress() = apply { this.dummyAddress = DummyAddress("city", "street") }
+
+    fun withAddresses(vararg dummyAddresses: DummyAddress) = apply {
+        this.addressList.addAll(dummyAddresses)
+    }
+}

--- a/javers/core/src/test/kotlin/org/javers/core/model/Ignored.kt
+++ b/javers/core/src/test/kotlin/org/javers/core/model/Ignored.kt
@@ -1,0 +1,8 @@
+package org.javers.core.model
+
+import org.javers.core.metamodel.annotation.DiffIgnore
+
+@DiffIgnore
+open class DummyIgnoredType
+
+open class IgnoredSubType: DummyIgnoredType()

--- a/javers/core/src/test/kotlin/org/javers/core/model/NewEntity.kt
+++ b/javers/core/src/test/kotlin/org/javers/core/model/NewEntity.kt
@@ -1,0 +1,25 @@
+package org.javers.core.model
+
+import org.javers.core.metamodel.annotation.Entity
+import org.javers.core.metamodel.annotation.Id
+import org.javers.core.metamodel.annotation.TypeName
+import java.math.BigDecimal
+
+@TypeName("org.javers.core.model.OldEntity")
+data class NewEntity(
+    @Id val id: Int,
+    val value: Int = 0,
+    val newValue: Int = 0,
+)
+
+@TypeName("myName")
+@Entity
+class NewEntityWithTypeAlias(@Id var id: BigDecimal) {
+
+    var value: Int = 0
+
+    var valueObject: NewValueObjectWithTypeAlias? = null
+}
+
+@TypeName("myValueObject")
+class NewValueObjectWithTypeAlias(var some: Int)

--- a/javers/core/src/test/kotlin/org/javers/core/model/OldEntity.kt
+++ b/javers/core/src/test/kotlin/org/javers/core/model/OldEntity.kt
@@ -1,0 +1,19 @@
+package org.javers.core.model
+
+import org.javers.core.metamodel.annotation.Entity
+import org.javers.core.metamodel.annotation.Id
+import org.javers.core.metamodel.annotation.TypeName
+
+data class OldEntity(
+    @Id val id: Int,
+    val value: Int = 0,
+    val oldValue: Int = 0,
+)
+
+@TypeName("myName")
+@Entity
+data class OldEntityWithTypeAlias(
+    @get:Id val id: Int,
+    val value: Int = 0,
+    val oldValue: Int = 0,
+)

--- a/javers/core/src/test/kotlin/org/javers/core/model/PrimitiveEntity.kt
+++ b/javers/core/src/test/kotlin/org/javers/core/model/PrimitiveEntity.kt
@@ -1,0 +1,29 @@
+package org.javers.core.model
+
+import org.javers.core.metamodel.annotation.Id
+
+enum class SomeEnum { A, B }
+
+data class PrimitiveEntity(@Id val id: String = "a") {
+
+    var intField: Int = 0
+    var longField: Long = 0L
+    var doubleField: Double = 0.0
+    var floatField: Float = 0.0F
+    var charField: Char = 0.toChar()
+    var byteField: Byte = 0.toByte()
+    var shortField: Short = 0.toShort()
+    var booleanField: Boolean = false
+
+    var IntegerField: Int? = null
+    var LongField: Long? = null
+    var DoubleField: Double? = null
+    var FloatField: Float? = null
+    var CharField: Char? = null
+    var ByteField: Byte? = null
+    var ShortField: Short? = null
+    var BooleanField: Boolean? = null
+
+    var someEnum: SomeEnum? = null
+
+}

--- a/javers/core/src/test/kotlin/org/javers/core/model/SnapshotEntity.kt
+++ b/javers/core/src/test/kotlin/org/javers/core/model/SnapshotEntity.kt
@@ -1,0 +1,76 @@
+package org.javers.core.model
+
+import com.google.common.collect.Multimap
+import com.google.common.collect.Multiset
+import org.javers.core.metamodel.annotation.Id
+import org.javers.core.metamodel.annotation.ShallowReference
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.*
+
+@ShallowReference
+data class ShallowPhone(
+    @Id var id: Long,
+    var number: String? = null,
+    var category: CategoryC? = null,
+)
+
+data class SnapshotEntity(
+    @Id var id: Int,
+    var entityRef: SnapshotEntity? = null,
+    var valueObjectRef: DummyAddress? = null,
+) {
+
+    enum class DummyEnum { val1, val2, val3 }
+
+    var dob: LocalDate? = null
+
+    var intProperty: Int? = null
+
+    var arrayOfIntegers: IntArray? = null
+    var arrayOfDates: Array<LocalDate>? = null
+    var arrayOfEntities: Array<SnapshotEntity>? = null
+    var arrayOfValueObjects: Array<DummyAddress>? = null
+
+    var listOfIntegers: MutableList<Int> = mutableListOf()
+    var listOfDates: MutableList<LocalDate> = mutableListOf()
+    val listOfEntities: MutableList<SnapshotEntity> = mutableListOf()
+    var listOfValueObjects: MutableList<DummyAddress> = mutableListOf()
+    var polymorficList: MutableList<Any?> = mutableListOf()
+
+    var setOfIntegers: MutableSet<Int> = mutableSetOf()
+    var setOfDates: MutableSet<LocalDate> = mutableSetOf()
+    var setOfValueObjects: MutableSet<DummyAddress> = mutableSetOf()
+    var polymorficset: MutableSet<Any?> = mutableSetOf()
+
+    var optionalInt: Optional<Int> = Optional.empty()
+    var optionalDate: Optional<LocalDate> = Optional.empty()
+    var optionalEntity: Optional<SnapshotEntity> = Optional.empty()
+    var optionalValueObject: Optional<DummyAddress> = Optional.empty()
+
+    var multiSetOfPrimitives: Multiset<String>? = null
+    var multiSetOfValueObject: Multiset<DummyAddress>? = null
+    var multiSetOfEntities: Multiset<SnapshotEntity>? = null
+
+    var multiMapOfPrimitives: Multimap<String, String>? = null
+    var multiMapPrimitiveToValueObject: Multimap<String, DummyAddress>? = null
+    var multiMapPrimitiveToEntity: Multimap<String, SnapshotEntity>? = null
+    var multiMapEntityToEntity: Multimap<SnapshotEntity, SnapshotEntity>? = null
+    //    var multiMapValueObjectToValueObject: Multimap<DummyAddress, DummyAddress>? = null // not supported
+
+    val mapOfPrimitives: MutableMap<String, Int> = mutableMapOf()
+    val mapOfValues: MutableMap<LocalDate, BigDecimal> = mutableMapOf()
+    val mapPrimitiveToVO: MutableMap<String, DummyAddress> = mutableMapOf()
+    val mapPrimitiveToEntity: MutableMap<String, SnapshotEntity> = mutableMapOf()
+    val polymorficMap: MutableMap<Any, Any?> = mutableMapOf()
+    val mapOfGenericValues: MutableMap<String, EnumSet<DummyEnum>> = mutableMapOf()
+
+    var shallowPhone: ShallowPhone? = null
+    var shallowPhones: MutableSet<ShallowPhone> = mutableSetOf()
+    var shallowPhonesList: MutableList<ShallowPhone> = mutableListOf()
+    var shallowPhonesMap: MutableMap<String, ShallowPhone> = mutableMapOf()
+
+    //    val mapVoToPrimitive: MutableMap<DummyAddress, String> = mutableMapOf()  // not supported
+    //    var nonParameterizedMap: Map<*, *>? = null                                       // not supported
+
+}

--- a/javers/core/src/test/kotlin/org/javers/core/repository/AbstractJaversCommitTest.kt
+++ b/javers/core/src/test/kotlin/org/javers/core/repository/AbstractJaversCommitTest.kt
@@ -1,0 +1,65 @@
+package org.javers.core.repository
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import org.amshove.kluent.shouldBeEqualTo
+import org.javers.core.Javers
+import org.javers.core.model.CategoryC
+import org.javers.core.model.PhoneWithShallowCategory
+import org.javers.core.model.ShallowPhone
+import org.javers.core.model.SnapshotEntity
+import org.junit.jupiter.api.Test
+
+abstract class AbstractJaversCommitTest {
+
+    companion object: KLogging()
+
+    abstract fun newJavers(): Javers
+
+    @Test
+    fun `ShallowReferenceType 엔티티의 snapshot은 commit하지 않습니다`() {
+        val javers = newJavers()
+        val reference = ShallowPhone(1L, "123", CategoryC(1, "some"))
+        val entity = SnapshotEntity(id = 1).apply {
+            shallowPhone = reference
+            shallowPhones = mutableSetOf(reference)
+            shallowPhonesList = mutableListOf(reference)
+            shallowPhonesMap = mutableMapOf("key" to reference)
+        }
+
+        // WHEN
+        var commit = javers.commit("", entity)
+
+        // THEN
+        commit.snapshots.forEach { log.debug { it } }
+        commit.snapshots.size shouldBeEqualTo 1
+
+        reference.number = "other"
+
+        commit = javers.commit("", entity)
+
+        commit.snapshots.forEach { log.debug { it } }
+        commit.snapshots.isEmpty()
+    }
+
+    @Test
+    fun `@ShallowReference가 지정된 property의 변화는 snapshot으로 commit되지 않습니다`() {
+        val javers = newJavers()
+        val entity = PhoneWithShallowCategory(1).apply {
+            shallowCategory = CategoryC(1, "old shallow")
+        }
+
+        var commit = javers.commit("", entity)
+
+        commit.snapshots.forEach { log.debug { it } }
+        commit.snapshots.size shouldBeEqualTo 1
+
+        entity.shallowCategory?.name = "new shallow"
+
+        commit = javers.commit("", entity)
+
+        commit.snapshots.forEach { log.debug { it } }
+        commit.snapshots.isEmpty()
+
+    }
+}

--- a/javers/core/src/test/kotlin/org/javers/core/repository/InMemoryCommitTest.kt
+++ b/javers/core/src/test/kotlin/org/javers/core/repository/InMemoryCommitTest.kt
@@ -1,0 +1,13 @@
+package org.javers.core.repository
+
+import org.javers.core.Javers
+import org.javers.core.JaversBuilder
+import org.javers.repository.inmemory.InMemoryRepository
+
+class InMemoryCommitTest: AbstractJaversCommitTest() {
+
+    override fun newJavers(): Javers =
+        JaversBuilder.javers()
+            .registerJaversRepository(InMemoryRepository())
+            .build()
+}

--- a/javers/core/src/test/kotlin/org/javers/jql/AbstractJaversShadowTest.kt
+++ b/javers/core/src/test/kotlin/org/javers/jql/AbstractJaversShadowTest.kt
@@ -1,0 +1,262 @@
+package org.javers.repository.jql
+
+import io.bluetape4k.javers.repository.jql.queryByInstance
+import io.bluetape4k.javers.repository.jql.queryByInstanceId
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.javers.common.exception.JaversException
+import org.javers.core.AbstractJaversRepositoryTest
+import org.javers.core.commit.CommitId
+import org.javers.core.model.CategoryC
+import org.javers.core.model.ShallowPhone
+import org.javers.core.model.SnapshotEntity
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+abstract class AbstractJaversShadowTest: AbstractJaversRepositoryTest() {
+
+    companion object: KLogging()
+
+    @Test
+    fun `shadow를 조회하여 stream으로 받을 수 있다`() {
+        // GIVEN
+        val entity = SnapshotEntity(1).apply { intProperty = 1 }
+        javers.commit("a", entity)
+        entity.intProperty = 2
+        javers.commit("a", entity)
+
+        // WHEN
+        val query = queryByInstanceId<SnapshotEntity>(1)
+        val shadows = javers.findShadowsAndStream<SnapshotEntity>(query).map { it.get() }.toList()
+
+        // THEN
+        shadows.size shouldBeEqualTo 2
+        with(shadows[0] as SnapshotEntity) {
+            id shouldBeEqualTo 1
+            intProperty shouldBeEqualTo 2
+        }
+        with(shadows[1] as SnapshotEntity) {
+            id shouldBeEqualTo 1
+            intProperty shouldBeEqualTo 1
+        }
+    }
+
+    @Test
+    fun `shadow 쿼리 시 지연된 결과 반환을 수행`() {
+        // GIVEN
+        val entity = SnapshotEntity(1).apply { intProperty = 1 }
+        repeat(20) {
+            entity.intProperty = it
+            javers.commit("a", entity)
+        }
+
+        // WHEN
+        val query = queryByInstanceId<SnapshotEntity>(1) { limit(5) }
+        val shadows = javers.findShadowsAndStream<SnapshotEntity>(query)
+            .limit(12)
+            .toList()
+
+        // THEN
+        shadows.size shouldBeEqualTo 5
+        repeat(5) {
+            commitSeq(shadows[it].commitMetadata) shouldBeEqualTo 20 - it
+            shadows[it].get().id shouldBeEqualTo 1
+            shadows[it].get().intProperty shouldBeEqualTo 19 - it
+        }
+
+        // 쿼리 통계도 지원한다 (ShadowQueryRunner 가 internal class 라서 package name을 맞춰줘야 한다.
+        val stats = query.firstFrameStats().get()
+        stats.dbQueriesCount shouldBeEqualTo 1
+        stats.allSnapshotsCount shouldBeEqualTo 20
+        stats.shallowSnapshotsCount shouldBeEqualTo 20
+    }
+
+    @Test
+    fun `query stream 이 skip 하기`() {
+        val query = queryByInstanceId<SnapshotEntity>(1) { skip(5) }
+        log.debug { "query=$query" }
+        val shadows = javers.findShadowsAndStream<SnapshotEntity>(query).toList()
+        shadows.forEach { shadow ->
+            log.debug { "shadow=$shadow" }
+        }
+        shadows.shouldBeEmpty()
+    }
+
+    @Test
+    fun `Stream 조회한 entity를 재사용하기`() {
+        // GIVEN
+        val ref = SnapshotEntity(id = 2)
+        javers.commit("a", ref)
+
+        val e = SnapshotEntity(id = 1, entityRef = ref)
+        repeat(15) {
+            e.intProperty = it
+            javers.commit("a", e)
+        }
+
+        // WHEN
+        val query = queryByInstanceId<SnapshotEntity>(1) {
+            limit(5)
+            withScopeDeepPlus(1)
+        }
+        val shadows = javers.findShadowsAndStream<SnapshotEntity>(query).map { it.get() }.toList()
+
+        // THEN
+        shadows.size shouldBeEqualTo 5
+        shadows.first().intProperty shouldBeEqualTo 14
+        shadows.last().intProperty shouldBeEqualTo 10
+
+        shadows.forEach {
+            log.debug { "snapshot entity=$it" }
+            (it.entityRef?.id ?: -1) shouldBeEqualTo 2
+        }
+    }
+
+    @Test
+    fun `존재하지 않는 commitId를 조회하면 아무것도 반환하지 않습니다`() {
+        // GIVEN
+        val ref1 = SnapshotEntity(id = 2)
+        val ref2 = SnapshotEntity(id = 3)
+        javers.commit("a", ref1)
+        javers.commit("a", ref2)
+
+        val entity = SnapshotEntity(id = 1).apply { listOfEntities.addAll(listOf(ref1, ref2)) }
+        javers.commit("a", entity)
+
+        // WHEN
+        val query = queryByInstanceId<SnapshotEntity>(1) {
+            withScopeDeepPlus(1)
+            withCommitId(CommitId.valueOf("543434.0")) // non-existing commitId
+        }
+
+        val snapshots = javers.findSnapshots(query)
+        val shadows = javers.findShadows<SnapshotEntity>(query)
+
+        snapshots.shouldBeEmpty()
+        shadows.shouldBeEmpty()
+    }
+
+    @Test
+    fun `COMMIT_DEEP scope와 DEEP_PLUS scope를 같이 쓰면 안됩니다`() {
+        val eRef = SnapshotEntity(id = 2).apply { intProperty = 2 }
+        val e = SnapshotEntity(id = 1).apply { intProperty = 1; entityRef = eRef }
+        javers.commit("a", e)
+
+        e.intProperty = 30
+        eRef.intProperty = 3
+        javers.commit("a", eRef)
+        javers.commit("a", e)
+
+        e.intProperty = 33
+        eRef.intProperty = 4
+        javers.commit("a", eRef)
+        javers.commit("a", e)
+
+        // WHEN
+        assertThrows<JaversException> {
+            val query = queryByInstance(e) {
+                withScopeDeepPlus()
+                withScopeCommitDeep()
+            }
+            javers.findShadows<SnapshotEntity>(query)
+        }
+
+        val query = QueryBuilder.byInstance(e).withScopeDeepPlus().build()
+        val shadows = javers.findShadows<SnapshotEntity>(query)
+
+        with(shadows[0].get()) { entityRef?.intProperty shouldBeEqualTo 4 }
+        with(shadows[1].get()) { entityRef?.intProperty shouldBeEqualTo 3 }
+        with(shadows[2].get()) { entityRef?.intProperty shouldBeEqualTo 2 }
+    }
+
+    @Test
+    fun `DEEP_PLUS scope에서는 refs 를 prefetch 합니다`() {
+        // GIVEN
+        val ref = SnapshotEntity(id = 2)
+        val entity = SnapshotEntity(id = 1, entityRef = ref)
+
+        repeat(4) {
+            ref.intProperty = it
+            entity.intProperty = it
+            javers.commit("a", ref)
+            javers.commit("a", entity)
+        }
+
+        // WHEN
+        val query = queryByInstanceId<SnapshotEntity>(1) { withScopeDeepPlus() }
+        val shadows = javers.findShadows<SnapshotEntity>(query).map { it.get() }
+
+        // THEN
+        with(query.streamStats().get()) {
+            dbQueriesCount shouldBeEqualTo 2
+            allSnapshotsCount shouldBeEqualTo 8
+            deepPlusSnapshotsCount shouldBeEqualTo 4
+        }
+
+        repeat(4) {
+            with(shadows[it]) {
+                intProperty shouldBeEqualTo 3 - it
+                entityRef?.intProperty shouldBeEqualTo 3 - it
+            }
+        }
+    }
+
+    @Test
+    fun `ShallowReferenceType 엔티티의 thin shadows 를 로드합니다`() {
+        // GIVEN
+        // ShallowPhone 은 `@ShallowReference` 가 적용되어 로드하지 않는다
+        val reference = ShallowPhone(id = 2L, number = "123", category = CategoryC(2, "some"))
+        val entity = SnapshotEntity(1).apply {
+            shallowPhone = reference
+            shallowPhones = mutableSetOf(reference)
+            shallowPhonesList = mutableListOf(reference)
+            shallowPhonesMap = mutableMapOf("key" to reference)
+        }
+
+        // entity만 commit 하고, reference는 commit하지 않는다
+        javers.commit("a", entity)
+
+        // WHEN
+        val query = queryByInstanceId<SnapshotEntity>(1) { withScopeDeepPlus() }
+        val shadows = javers.findShadows<SnapshotEntity>(query).map { it.get() }
+
+        // THEN
+        log.debug { "shadow=${shadows.first()}" }
+        shadows.size shouldBeEqualTo 1
+
+        assertThinShadowOfPhone(shadows.first().shallowPhone)
+        assertThinShadowOfPhone(shadows.first().shallowPhones.first())
+        assertThinShadowOfPhone(shadows.first().shallowPhonesList.first())
+        assertThinShadowOfPhone(shadows.first().shallowPhonesMap["key"])
+
+        // WHEN
+        javers.commit("a", reference)
+        javers.commit("a", entity)
+
+        val shadows2 = javers.findShadows<SnapshotEntity>(query).map { it.get() }
+        shadows2.size shouldBeEqualTo 1
+
+        // THEN
+        log.debug { "shadow2 = ${shadows2.first()}" }
+        assertThinShadowOfPhone(shadows2.first().shallowPhone)
+        assertThinShadowOfPhone(shadows2.first().shallowPhones.first())
+        assertThinShadowOfPhone(shadows2.first().shallowPhonesList.first())
+        assertThinShadowOfPhone(shadows2.first().shallowPhonesMap["key"])
+    }
+
+    private fun assertThinShadowOfPhone(shadow: Any?) {
+        shadow.shouldNotBeNull()
+        shadow shouldBeInstanceOf ShallowPhone::class.java
+
+        if (shadow is ShallowPhone) {
+            shadow.id shouldBeEqualTo 2L
+            shadow.number.shouldBeNull()
+            shadow.category.shouldBeNull()
+        }
+    }
+}

--- a/javers/core/src/test/kotlin/org/javers/jql/InMemoryJaversShadowTest.kt
+++ b/javers/core/src/test/kotlin/org/javers/jql/InMemoryJaversShadowTest.kt
@@ -1,0 +1,9 @@
+package org.javers.repository.jql
+
+import org.javers.repository.api.JaversRepository
+import org.javers.repository.inmemory.InMemoryRepository
+
+class InMemoryJaversShadowTest: AbstractJaversShadowTest() {
+
+    override fun prepareJaversRepository(): JaversRepository = InMemoryRepository()
+}

--- a/javers/core/src/test/resources/junit-platform.properties
+++ b/javers/core/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/javers/core/src/test/resources/logback-test.xml
+++ b/javers/core/src/test/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <!-- @formatter:off -->
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%32.32t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <!-- @formatter:on -->
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.javers" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+
+</configuration>

--- a/javers/persistence-kafka/build.gradle.kts
+++ b/javers/persistence-kafka/build.gradle.kts
@@ -1,0 +1,36 @@
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+
+    api(project(":bluetape4k-core"))
+    api(project(":bluetape4k-jackson"))
+    api(project(":bluetape4k-kafka"))
+    api(project(":bluetape4k-idgenerators"))
+
+    testImplementation(project(":bluetape4k-junit5"))
+    testImplementation(project(":bluetape4k-testcontainers"))
+    testImplementation(Libs.testcontainers_kafka)
+
+    // Javers
+    api(project(":bluetape4k-javers-core"))
+    // bluetape4k-javers-core 의 테스트 코드를 재활용하기 위해 참조합니다.
+    testImplementation(project(path = ":bluetape4k-javers-core", configuration = "testJar"))
+
+    api(Libs.javers_core)
+    testImplementation(Libs.guava)
+
+    // Kafka
+    api(Libs.kafka_clients)
+    compileOnly(Libs.spring_kafka)
+
+    // Codec
+    api(Libs.kryo)
+    api(Libs.fury)
+
+    // Compressor
+    api(Libs.lz4_java)
+    compileOnly(Libs.snappy_java)
+    compileOnly(Libs.zstd_jni)
+}

--- a/javers/persistence-kafka/src/main/kotlin/io/bluetape4k/javers/persistence/kafka/repository/KafkaCdoSnapshotRepository.kt
+++ b/javers/persistence-kafka/src/main/kotlin/io/bluetape4k/javers/persistence/kafka/repository/KafkaCdoSnapshotRepository.kt
@@ -1,0 +1,48 @@
+package io.bluetape4k.javers.persistence.kafka.repository
+
+import io.bluetape4k.javers.codecs.GsonCodecs
+import io.bluetape4k.javers.repository.AbstractCdoSnapshotRepository
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.error
+import io.bluetape4k.logging.trace
+import org.javers.core.commit.CommitId
+import org.javers.core.metamodel.`object`.CdoSnapshot
+import org.springframework.kafka.core.KafkaTemplate
+
+/**
+ * Javers 의 Audit 정보를 Kafka 로 발행합니다.
+ * 저장소로 쓰이는 것이 아니므로, 저장 역할만 가능하고, 조회 기능은 없습니다.
+ *
+ * @property kafkaOperations [KafkaTemplate] 인스턴스
+ */
+class KafkaCdoSnapshotRepository(
+    private val kafkaOperations: KafkaTemplate<String, String>,
+): AbstractCdoSnapshotRepository<String>(GsonCodecs.String) {
+
+    companion object: KLogging()
+
+    override fun getKeys(): List<String> = emptyList()
+
+    override fun contains(globalIdValue: String): Boolean = false
+
+    override fun getSeq(commitId: CommitId): Long = 0L
+
+    override fun updateCommitId(commitId: CommitId, sequence: Long) {
+        // Nothing to do.
+    }
+
+    override fun getSnapshotSize(globalIdValue: String): Int = 0
+
+    override fun saveSnapshot(snapshot: CdoSnapshot) {
+        runCatching {
+            val key = snapshot.globalId.value()
+            val value = encode(snapshot)
+            log.trace { "Produce snapshot. key=$key, value=$value" }
+            kafkaOperations.sendDefault(key, value)
+        }.onFailure { error ->
+            log.error(error) { "Fail to procude snapshot. key=${snapshot.globalId.value()}" }
+        }
+    }
+
+    override fun loadSnapshots(globalIdValue: String): List<CdoSnapshot> = emptyList()
+}

--- a/javers/persistence-kafka/src/test/kotlin/io/bluetape4k/javers/persistence/kafka/repository/KafkaCdoSnapshotRepositoryTest.kt
+++ b/javers/persistence-kafka/src/test/kotlin/io/bluetape4k/javers/persistence/kafka/repository/KafkaCdoSnapshotRepositoryTest.kt
@@ -1,0 +1,72 @@
+package io.bluetape4k.javers.persistence.kafka.repository
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.javers.core.Javers
+import org.javers.core.JaversBuilder
+import org.javers.core.metamodel.`object`.SnapshotType
+import org.javers.core.model.PrimitiveEntity
+import org.javers.core.model.SnapshotEntity
+import org.javers.core.repository.AbstractJaversCommitTest
+import org.junit.jupiter.api.Test
+
+/**
+ * NOTE: **Redis나 MongoDB와 같이 테스트는 할 수 없고, snapshot 저장을 수행하는 테스트만 해야 한다**
+ * Consumer 를 통한 검증을 수행해야 하는데, 귀찮아서 로그보고 확인했습니다. ㅋㅋ
+ */
+class KafkaCdoSnapshotRepositoryTest: AbstractJaversCommitTest() {
+
+    companion object: KLogging()
+
+    private val kafkaRepository by lazy {
+        KafkaCdoSnapshotRepository(KafkaProvider.kafkaTemplate)
+    }
+
+    override fun newJavers(): Javers =
+        JaversBuilder.javers()
+            .registerJaversRepository(kafkaRepository)
+            .build()
+
+    val javers = newJavers()
+
+    @Test
+    fun `CommitMetadata에 현재 LocalDateTime과 Instant를 사용한다`() {
+        val commit = javers.commit("author", SnapshotEntity(1))
+        commit.snapshots.size shouldBeEqualTo 1
+        val snapshot = commit.snapshots.first()
+        snapshot.type shouldBeEqualTo SnapshotType.INITIAL
+    }
+
+    @Test
+    fun `다양한 Primitive 수형 변화를 Commit한다`() {
+        // GIVEN
+        val s = PrimitiveEntity("1")
+
+        // WHEN
+        javers.commit("author", s)
+
+        s.intField = 10
+        s.longField = 10L
+        s.doubleField = 1.1
+        s.floatField = 1.1F
+        s.charField = 'c'
+        s.byteField = 10.toByte()
+        s.shortField = 10.toShort()
+        s.booleanField = true
+        s.IntegerField = 10
+        s.LongField = 10
+        s.DoubleField = 1.1
+        s.FloatField = 1.1F
+        s.CharField = 'c'
+        s.ByteField = 10.toByte()
+        s.ShortField = 10.toShort()
+        s.BooleanField = true
+
+        val commit = javers.commit("author", s)
+
+        val snapshot = commit.snapshots.first()
+
+        snapshot.state.getPropertyValue("floatField") shouldBeEqualTo 1.1F
+        snapshot.state.getPropertyValue("LongField") shouldBeEqualTo 10L
+    }
+}

--- a/javers/persistence-kafka/src/test/kotlin/io/bluetape4k/javers/persistence/kafka/repository/KafkaProvider.kt
+++ b/javers/persistence-kafka/src/test/kotlin/io/bluetape4k/javers/persistence/kafka/repository/KafkaProvider.kt
@@ -1,0 +1,57 @@
+package io.bluetape4k.javers.persistence.kafka.repository
+
+import io.bluetape4k.testcontainers.mq.KafkaServer
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.common.serialization.StringSerializer
+import org.springframework.kafka.core.ConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.core.ProducerFactory
+import java.util.*
+
+internal object KafkaProvider {
+
+    const val TEST_TOPIC = "javers.test-topic.1"
+
+    val kafka: KafkaServer = KafkaServer.Launcher.kafka
+
+    val producerProperties: Map<String, Any?> by lazy {
+        mapOf(
+            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to kafka.bootstrapServers,
+            ProducerConfig.CLIENT_ID_CONFIG to UUID.randomUUID().toString()
+        )
+    }
+
+    val producerFactory: ProducerFactory<String, String> by lazy {
+        DefaultKafkaProducerFactory(
+            producerProperties,
+            StringSerializer(),
+            StringSerializer()
+        )
+    }
+
+    val consumerProperties: Map<String, Any?> by lazy {
+        mapOf(
+            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG to kafka.bootstrapServers,
+            ConsumerConfig.GROUP_ID_CONFIG to "tc-" + UUID.randomUUID().toString(),
+            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest"
+        )
+    }
+
+    val consumerFactory: ConsumerFactory<String, String> by lazy {
+        DefaultKafkaConsumerFactory(
+            consumerProperties,
+            StringDeserializer(),
+            StringDeserializer()
+        )
+    }
+
+    val kafkaTemplate: KafkaTemplate<String, String> by lazy {
+        KafkaTemplate(producerFactory, true).apply {
+            defaultTopic = TEST_TOPIC
+        }
+    }
+}

--- a/javers/persistence-kafka/src/test/resources/junit-platform.properties
+++ b/javers/persistence-kafka/src/test/resources/junit-platform.properties
@@ -1,0 +1,7 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+# \uB9E4 \uD14C\uC2A4\uD2B8\uB9C8\uB2E4 Redis \uC800\uC7A5\uC18C\uB97C \uCD08\uAE30\uD654 \uD574\uC57C \uD574\uC11C Sequential \uD558\uAC8C \uC218\uD589\uD574\uC57C \uD569\uB2C8\uB2E4.
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/javers/persistence-kafka/src/test/resources/logback-test.xml
+++ b/javers/persistence-kafka/src/test/resources/logback-test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <!-- @formatter:off -->
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%.24t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <!-- @formatter:on -->
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.javers" level="TRACE"/>
+
+    <logger name="org.javers.core" level="DEBUG"/>
+    <logger name="org.javers.repository" level="DEBUG"/>
+    <logger name="org.javers.JQL" level="DEBUG"/>
+    <logger name="org.javers.TypeMapper" level="DEBUG"/>
+
+    <root level="DEBUG">
+        <appender-ref ref="Console"/>
+    </root>
+</configuration>

--- a/javers/persistence-redis/build.gradle.kts
+++ b/javers/persistence-redis/build.gradle.kts
@@ -1,0 +1,36 @@
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+
+    api(project(":bluetape4k-core"))
+    api(project(":bluetape4k-jackson"))
+    api(project(":bluetape4k-idgenerators"))
+    compileOnly(project(":bluetape4k-hibernate"))
+    compileOnly(project(":bluetape4k-cache"))
+
+    testImplementation(project(":bluetape4k-junit5"))
+    testImplementation(project(":bluetape4k-testcontainers"))
+
+    // Javers
+    api(project(":bluetape4k-javers-core"))
+    // bluetape4k-javers-core 의 테스트 코드를 재활용하기 위해 참조합니다.
+    testImplementation(project(path = ":bluetape4k-javers-core", configuration = "testJar"))
+    api(Libs.javers_core)
+    testImplementation(Libs.guava)
+
+    // Redis
+    api(project(":bluetape4k-redis"))
+    compileOnly(Libs.lettuce_core)
+    compileOnly(Libs.redisson)
+
+    // Codec
+    compileOnly(Libs.kryo)
+    compileOnly(Libs.fury)
+
+    // Compressor
+    compileOnly(Libs.lz4_java)
+    compileOnly(Libs.snappy_java)
+    compileOnly(Libs.zstd_jni)
+}

--- a/javers/persistence-redis/src/main/kotlin/io/bluetape4k/javers/persistence/redis/repository/LettuceCdoSnapshotRepository.kt
+++ b/javers/persistence-redis/src/main/kotlin/io/bluetape4k/javers/persistence/redis/repository/LettuceCdoSnapshotRepository.kt
@@ -1,0 +1,114 @@
+package io.bluetape4k.javers.persistence.redis.repository
+
+import io.bluetape4k.javers.codecs.GsonCodec
+import io.bluetape4k.javers.codecs.GsonCodecs
+import io.bluetape4k.javers.repository.AbstractCdoSnapshotRepository
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.error
+import io.bluetape4k.logging.trace
+import io.bluetape4k.redis.lettuce.LettuceClients
+import io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodecs
+import io.bluetape4k.support.asByteArray
+import io.bluetape4k.support.asInt
+import io.bluetape4k.support.asLongOrNull
+import io.lettuce.core.RedisClient
+import org.javers.core.commit.CommitId
+import org.javers.core.metamodel.`object`.CdoSnapshot
+
+/**
+ * JaVers [CdoSnapshot] 을 Lettuce Library를 이용하여
+ * Redis Server에 저장, 로드하는 기능을 제공하는 [AbstractCdoSnapshotRepository] 구현체입니다.
+ *
+ * @param name repository name
+ * @param client Lettuce [RedisClient] 인스턴스
+ * @param codec [CdoSnapshot]을 encode/decode 할 [GsonCodec] 인스턴스
+ */
+class LettuceCdoSnapshotRepository(
+    val name: String,
+    private val client: RedisClient,
+    codec: GsonCodec<ByteArray> = GsonCodecs.LZ4Kryo,
+): AbstractCdoSnapshotRepository<ByteArray>(codec) {
+
+    companion object: KLogging() {
+        private const val CACHE_KEY_SET = "globalId:set"
+        private const val SEQUENCE_SET = "sequence:set"
+        private const val SNAPSHOT_SUFFIX = "snapshots:"
+    }
+
+    // Cache Key에 해당하는 [GlobalId.value()] 값을 저장하는 Set
+    private val cacheSetKey: String = "javers:$name:$CACHE_KEY_SET"
+
+    // HSET CommitId SEQUENCE NO 를 보관하는 Set
+    private val sequenceSetKey: String = "javers:$name:$SEQUENCE_SET"
+
+    // [CdoSnapshot]을 저장할 Redis LIST Key 값의 prefix 입니다.
+    // globalId 마다 List<CdoSnapshot> 을 저장합니다.
+    private val snapshotPrefix = "javers:$name:$SNAPSHOT_SUFFIX"
+
+    private val commands by lazy {
+        LettuceClients.commands(client, LettuceBinaryCodecs.Default)
+    }
+
+    override fun getKeys(): List<String> {
+        return commands.hkeys(cacheSetKey).apply {
+            log.trace { "load keys. size=${size}" }
+        }
+    }
+
+    override fun contains(globalIdValue: String): Boolean {
+        return commands.hexists(cacheSetKey, globalIdValue) ?: false
+    }
+
+    override fun getSeq(commitId: CommitId): Long {
+        val seq = commands.hget(sequenceSetKey, commitId.value())?.asLongOrNull() ?: 0L
+        log.trace { "get seq. commitId=${commitId.value()}, seq=$seq" }
+        return seq
+    }
+
+    override fun updateCommitId(commitId: CommitId, sequence: Long) {
+        commands.hset(sequenceSetKey, commitId.value(), sequence.toString())
+    }
+
+    override fun getSnapshotSize(globalIdValue: String): Int {
+        val snapshotSize = commands.llen(makeSnapshotKey(globalIdValue)).asInt()
+        log.trace { "Get snapshot size=${snapshotSize}, globalId=$globalIdValue" }
+        return snapshotSize
+    }
+
+    override fun saveSnapshot(snapshot: CdoSnapshot) {
+        val key = makeSnapshotKey(snapshot.globalId.value())
+        val value = encode(snapshot)
+
+        try {
+            commands.multi()
+            // 최신 Snapshot 을 저장합니다.
+            commands.lpush(key, value)
+            // 전체 Cache Item의 GlobalId 를 빠르게 조회하기 위해 따로 저장한다
+            commands.hset(cacheSetKey, snapshot.globalId.value(), snapshot.version)
+            commands.exec()
+            log.debug { "Save snapshot key=$key, version=${snapshot.version}" }
+        } catch (e: Exception) {
+            log.error(e) { "Fail to save snapshot. snapshot globalId=${snapshot.globalId.value()}" }
+            commands.discard()
+        }
+    }
+
+    override fun loadSnapshots(globalIdValue: String): List<CdoSnapshot> {
+        val snapshots = commands
+            .lrange(makeSnapshotKey(globalIdValue), 0, -1)
+            .mapNotNull { decode(it.asByteArray()) }
+        log.trace { "Load snapshots. globalId=$globalIdValue, size=${snapshots.size}" }
+        return snapshots
+    }
+
+    /**
+     * Make snapshot key (eg. `javers:user:snapshots:id`)
+     *
+     * @param id [CdoSnapshot]의 GlobalId 값 (eg. `User/1` )
+     * @return Snapshot 을 기록하는 Redis List 의 Key 값 (eg. `javers:user:snapshots:User/1`)
+     */
+    private fun makeSnapshotKey(id: String): String {
+        return snapshotPrefix + id
+    }
+}

--- a/javers/persistence-redis/src/main/kotlin/io/bluetape4k/javers/persistence/redis/repository/RedissonCdoSnapshotRepository.kt
+++ b/javers/persistence-redis/src/main/kotlin/io/bluetape4k/javers/persistence/redis/repository/RedissonCdoSnapshotRepository.kt
@@ -1,0 +1,95 @@
+package io.bluetape4k.javers.persistence.redis.repository
+
+import io.bluetape4k.javers.codecs.GsonCodec
+import io.bluetape4k.javers.codecs.GsonCodecs
+import io.bluetape4k.javers.repository.AbstractCdoSnapshotRepository
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.trace
+import org.javers.core.commit.CommitId
+import org.javers.core.metamodel.`object`.CdoSnapshot
+import org.redisson.api.RListMultimap
+import org.redisson.api.RMap
+import org.redisson.api.RedissonClient
+import org.redisson.client.codec.ByteArrayCodec
+import org.redisson.client.codec.LongCodec
+import org.redisson.client.codec.StringCodec
+import org.redisson.codec.CompositeCodec
+
+/**
+ * JaVers [CdoSnapshot] 을 Redisson Library를 이용하여
+ * Redis Server에 저장, 로드하는 기능을 제공하는 [AbstractCdoSnapshotRepository] 구현체입니다.
+ *
+ * @param name repository name
+ * @param redisson [RedissonClient] 인스턴스
+ * @param codec [CdoSnapshot]을 encode/decode 할 [GsonCodec] 인스턴스
+ */
+class RedissonCdoSnapshotRepository(
+    val name: String,
+    private val redisson: RedissonClient,
+    codec: GsonCodec<ByteArray> = GsonCodecs.LZ4Kryo,
+): AbstractCdoSnapshotRepository<ByteArray>(codec) {
+
+    companion object: KLogging() {
+        private const val SEQUENCE_SUFFIX = "sequence"
+        private const val SNAPSHOT_SUFFIX = "snapshots"
+    }
+
+    private val sequenceName: String = "javers:$SEQUENCE_SUFFIX:$name"
+    private val snapshotName: String = "javers:$SNAPSHOT_SUFFIX:$name"
+
+    /**
+     * GlobalId 별로 Snapshot 컬렉션을 매핑합니다.
+     */
+    private val snapshots: RListMultimap<String, ByteArray> =
+        redisson.getListMultimap(snapshotName, CompositeCodec(StringCodec(), ByteArrayCodec(), ByteArrayCodec()))
+
+    /**
+     * CommitId: Sequence Number 매핑을 저장하는 Map
+     */
+    private val commitIdSequences: RMap<String, Long> =
+        redisson.getMap(sequenceName, LongCodec())
+
+    override fun getKeys(): List<String> {
+        return snapshots.keySet().sorted().apply {
+            log.trace { "load keys. size=$size" }
+        }
+    }
+
+    override fun contains(globalIdValue: String): Boolean {
+        return snapshots.containsKey(globalIdValue)
+    }
+
+    override fun getSeq(commitId: CommitId): Long {
+        val seq = commitIdSequences.getOrDefault(commitId.value(), 0L)
+        log.trace { "get seq. commitId=${commitId.value()}, seq=$seq" }
+        return seq
+    }
+
+    override fun updateCommitId(commitId: CommitId, sequence: Long) {
+        commitIdSequences.fastPut(commitId.value(), sequence)
+    }
+
+    override fun getSnapshotSize(globalIdValue: String): Int {
+        return snapshots[globalIdValue].size
+    }
+
+    override fun saveSnapshot(snapshot: CdoSnapshot) {
+        val key = snapshot.globalId.value()
+        val value = encode(snapshot)
+        val saved = snapshots.put(key, value)
+        log.trace { "Save snapshot [$saved]. key=[$key], version=[${snapshot.version}]" }
+    }
+
+    override fun loadSnapshots(globalIdValue: String): List<CdoSnapshot> {
+        // NOTE: 최신 데이터가 처음에 오도록 역순 정렬이 필요합니다. (Stack처럼 사용합니다)
+        val loaded = snapshots.getAll(globalIdValue)
+            .mapNotNull { value ->
+                log.debug { "value size=${value.size}" }
+                if (value.isNotEmpty()) decode(value) else null
+            }
+            .reversed()
+        log.trace { "Load snapshots. globalId=$globalIdValue, size=${loaded.size}" }
+        return loaded
+    }
+}

--- a/javers/persistence-redis/src/test/kotlin/io/bluetape4k/javers/persistence/redis/AbstractJaversTest.kt
+++ b/javers/persistence-redis/src/test/kotlin/io/bluetape4k/javers/persistence/redis/AbstractJaversTest.kt
@@ -1,0 +1,20 @@
+package io.bluetape4k.javers.persistence.redis
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.storage.RedisServer
+
+abstract class AbstractJaversTest {
+
+    companion object: KLogging() {
+        val redis = RedisServer.Launcher.redis
+    }
+
+    protected val lettuceClient: io.lettuce.core.RedisClient by lazy {
+        RedisServer.Launcher.LettuceLib.getRedisClient(redis.host, redis.port)
+    }
+
+    protected val redisson by lazy {
+        RedisServer.Launcher.RedissonLib.getRedisson(redis.url)
+    }
+
+}

--- a/javers/persistence-redis/src/test/kotlin/io/bluetape4k/javers/persistence/redis/RedisServerTest.kt
+++ b/javers/persistence-redis/src/test/kotlin/io/bluetape4k/javers/persistence/redis/RedisServerTest.kt
@@ -1,0 +1,35 @@
+package io.bluetape4k.javers.persistence.redis
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.redisson.api.redisnode.RedisNode
+import org.redisson.api.redisnode.RedisNodes
+
+class RedisServerTest: AbstractJaversTest() {
+
+    companion object: KLogging()
+
+    @Test
+    fun `Lettuce Client 접속 테스트`() {
+        lettuceClient.shouldNotBeNull()
+
+        lettuceClient.connect().use { conn ->
+            val commands = conn.sync()
+            commands.ping() shouldBeEqualTo "PONG"
+            log.debug { "Redis info=${commands.info()}" }
+        }
+    }
+
+    @Test
+    fun `Redisson 으로 접속 테스트`() {
+        redisson.shouldNotBeNull()
+
+        val instance = redisson.getRedisNodes(RedisNodes.SINGLE).instance
+        instance.ping().shouldBeTrue()
+        log.debug { "Redis info=${instance.info(RedisNode.InfoSection.ALL)}" }
+    }
+}

--- a/javers/persistence-redis/src/test/kotlin/io/bluetape4k/javers/persistence/redis/repository/LettuceJaversCommitTest.kt
+++ b/javers/persistence-redis/src/test/kotlin/io/bluetape4k/javers/persistence/redis/repository/LettuceJaversCommitTest.kt
@@ -1,0 +1,24 @@
+package io.bluetape4k.javers.persistence.redis.repository
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.storage.RedisServer
+import org.javers.core.Javers
+import org.javers.core.JaversBuilder
+import org.javers.core.repository.AbstractJaversCommitTest
+
+class LettuceJaversCommitTest: AbstractJaversCommitTest() {
+
+    companion object: KLogging()
+
+    override fun newJavers(): Javers {
+        // NOTE: 각각의 테스트가 Javers를 매번 새롭게 만들고, Snapshot정보를 clear해야 하므로 Redis를 Flush합니다.
+        val lettuceClient = RedisServer.Launcher.LettuceLib.getRedisClient()
+        lettuceClient.connect().sync().flushdb()
+
+        val repository = LettuceCdoSnapshotRepository("kommons:lettuce", lettuceClient)
+
+        return JaversBuilder.javers()
+            .registerJaversRepository(repository)
+            .build()
+    }
+}

--- a/javers/persistence-redis/src/test/kotlin/io/bluetape4k/javers/persistence/redis/repository/LettuceJaversShadowTest.kt
+++ b/javers/persistence-redis/src/test/kotlin/io/bluetape4k/javers/persistence/redis/repository/LettuceJaversShadowTest.kt
@@ -1,0 +1,18 @@
+package io.bluetape4k.javers.persistence.redis.repository
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.storage.RedisServer
+import org.javers.repository.api.JaversRepository
+import org.javers.repository.jql.AbstractJaversShadowTest
+
+class LettuceJaversShadowTest: AbstractJaversShadowTest() {
+
+    companion object: KLogging()
+
+    override fun prepareJaversRepository(): JaversRepository {
+        // NOTE: 각각의 테스트가 Javers를 매번 새롭게 만들고, Snapshot정보를 clear해야 하므로 Redis를 Flush합니다.
+        val lettuceClient = RedisServer.Launcher.LettuceLib.getRedisClient()
+        lettuceClient.connect().sync().flushdb()
+        return LettuceCdoSnapshotRepository("kommons:lettuce", lettuceClient)
+    }
+}

--- a/javers/persistence-redis/src/test/kotlin/io/bluetape4k/javers/persistence/redis/repository/RedissonJaversCommitTest.kt
+++ b/javers/persistence-redis/src/test/kotlin/io/bluetape4k/javers/persistence/redis/repository/RedissonJaversCommitTest.kt
@@ -1,0 +1,24 @@
+package io.bluetape4k.javers.persistence.redis.repository
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.storage.RedisServer
+import org.javers.core.Javers
+import org.javers.core.JaversBuilder
+import org.javers.core.repository.AbstractJaversCommitTest
+
+class RedissonJaversCommitTest: AbstractJaversCommitTest() {
+
+    companion object: KLogging()
+
+    override fun newJavers(): Javers {
+        // NOTE: 각각의 테스트가 Javers를 매번 새롭게 만들고, Snapshot정보를 clear해야 하므로 Redis를 Flush합니다.
+        val redisson = RedisServer.Launcher.RedissonLib.getRedisson()
+        redisson.keys.flushdb()
+
+        val repository = RedissonCdoSnapshotRepository("kommons:redisson", redisson)
+
+        return JaversBuilder.javers()
+            .registerJaversRepository(repository)
+            .build()
+    }
+}

--- a/javers/persistence-redis/src/test/kotlin/io/bluetape4k/javers/persistence/redis/repository/RedissonJaversShadowTest.kt
+++ b/javers/persistence-redis/src/test/kotlin/io/bluetape4k/javers/persistence/redis/repository/RedissonJaversShadowTest.kt
@@ -1,0 +1,19 @@
+package io.bluetape4k.javers.persistence.redis.repository
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.storage.RedisServer
+import org.javers.repository.api.JaversRepository
+import org.javers.repository.jql.AbstractJaversShadowTest
+
+class RedissonJaversShadowTest: AbstractJaversShadowTest() {
+
+    companion object: KLogging()
+
+    override fun prepareJaversRepository(): JaversRepository {
+        // NOTE: 각각의 테스트가 Javers를 매번 새롭게 만들고, Snapshot정보를 clear해야 하므로 Redis를 Flush합니다.
+        val redisson = RedisServer.Launcher.RedissonLib.getRedisson()
+        redisson.keys.flushdb()
+
+        return RedissonCdoSnapshotRepository("kommons:redisson", redisson)
+    }
+}

--- a/javers/persistence-redis/src/test/resources/junit-platform.properties
+++ b/javers/persistence-redis/src/test/resources/junit-platform.properties
@@ -1,0 +1,7 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+# \uB9E4 \uD14C\uC2A4\uD2B8\uB9C8\uB2E4 Redis \uC800\uC7A5\uC18C\uB97C \uCD08\uAE30\uD654 \uD574\uC57C \uD574\uC11C Sequential \uD558\uAC8C \uC218\uD589\uD574\uC57C \uD569\uB2C8\uB2E4.
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/javers/persistence-redis/src/test/resources/logback-test.xml
+++ b/javers/persistence-redis/src/test/resources/logback-test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <!-- @formatter:off -->
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%.24t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <!-- @formatter:on -->
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.javers" level="DEBUG"/>
+
+    <logger name="org.javers.core" level="DEBUG"/>
+    <logger name="org.javers.repository" level="DEBUG"/>
+    <logger name="org.javers.JQL" level="DEBUG"/>
+    <logger name="org.javers.TypeMapper" level="DEBUG"/>
+
+    <root level="DEBUG">
+        <appender-ref ref="Console"/>
+    </root>
+</configuration>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,7 +21,7 @@ includeModules("aws-kotlin", withBaseDir = true)
 includeModules("data", withBaseDir = false)
 includeModules("infra", withBaseDir = false)
 includeModules("io", withBaseDir = false)
-
+includeModules("javers", withBaseDir = true)
 includeModules("spring", withBaseDir = true)
 includeModules("tokenizer", withBaseDir = true)
 includeModules("testing", withBaseDir = false)


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: Add javers modules

### 원문 선행 내용

[Javers](https://javers.org) 는 객체에 대한 Audit과 Diff 를 지원해주는 Framework 입니다. 기본적으로 메모리, MongoDB, JDBC 에 Audit 정보를 저장할 수 있는
기능을 제공합니다.

이를 위한 기본 기능, Audit 정보를 Kafka 로 발송하는 기능 (CDC), Redis 에 저장하는 기능을 제공합니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 모듈 설명

- bluetape4k.javers.core (Javers 의 기본 기능 및 Kotlin supports)
- bluetape4k.javers-persistence-kafka - Audit 정보를 Kafka로 발행
- bluetape4k.javers.persistence-redis  - Audit 정보를 Redis에 저장 (속도 때문)

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #9, head `d1d0502263020e8e190460690ca1054d1d8073de`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feature/javers`
- Labels: `enhancement`
- State: `MERGED`, merge commit `a9a2b5d9da6ed5b4f7ab45e8b79eb191d75b9068`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #9 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `a9a2b5d9da6ed5b4f7ab45e8b79eb191d75b9068`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
