### PR TITLE
Add new JacksonToml for TomlMapper

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -848,6 +848,7 @@ object Libs {
     val jackson_dataformat_csv = jacksonDataFormat("csv")
     val jackson_dataformat_properties = jacksonDataFormat("properties")
     val jackson_dataformat_yaml = jacksonDataFormat("yaml")
+    val jackson_dataformat_toml = jacksonDataFormat("toml")
 
     fun jacksonModule(module: String, version: String = Versions.jackson) = jackson("module", module, version)
     val jackson_module_kotlin = jacksonModule("kotlin")

--- a/io/jackson-text/build.gradle.kts
+++ b/io/jackson-text/build.gradle.kts
@@ -11,19 +11,15 @@ configurations {
 
 dependencies {
     api(project(":bluetape4k-io"))
-    compileOnly(project(":bluetape4k-jackson"))
     testImplementation(project(":bluetape4k-junit5"))
 
-    api(Libs.jackson_core)
-    api(Libs.jackson_databind)
-    api(Libs.jackson_module_kotlin)
-    api(Libs.jackson_module_parameter_names)
-    api(Libs.jackson_module_blackbird)
-
+    // Jackson
+    api(project(":bluetape4k-jackson"))
     // Jackson Dataformats Text
-    api(Libs.jackson_dataformat_csv)
-    api(Libs.jackson_dataformat_properties)
-    api(Libs.jackson_dataformat_yaml)
+    compileOnly(Libs.jackson_dataformat_csv)
+    compileOnly(Libs.jackson_dataformat_properties)
+    compileOnly(Libs.jackson_dataformat_yaml)
+    compileOnly(Libs.jackson_dataformat_toml)
 
     testImplementation(Libs.jsonpath)
     testImplementation(Libs.jsonassert)

--- a/io/jackson-text/src/main/kotlin/io/bluetape4k/jackson/text/csv/JacksonCsv.kt
+++ b/io/jackson-text/src/main/kotlin/io/bluetape4k/jackson/text/csv/JacksonCsv.kt
@@ -1,0 +1,42 @@
+package io.bluetape4k.jackson.text.csv
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.dataformat.csv.CsvFactory
+import com.fasterxml.jackson.dataformat.csv.CsvMapper
+import io.bluetape4k.jackson.Jackson
+
+object JacksonCsv {
+
+    val defaultCsvMapper: CsvMapper by lazy {
+        CsvMapper.builder()
+            .findAndAddModules()
+            .enable(
+                JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT,
+                JsonGenerator.Feature.IGNORE_UNKNOWN,
+                JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN,
+            )
+            .disable(
+                SerializationFeature.FAIL_ON_EMPTY_BEANS
+            )
+
+            // Deserialization feature
+            .enable(
+                DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT,
+                DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY,
+                DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL,
+                DeserializationFeature.READ_ENUMS_USING_TO_STRING,
+            )
+            .disable(
+                DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES,
+                DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+            )
+            .build()
+    }
+
+    val defaultCsvFactory: CsvFactory by lazy { CsvFactory() }
+
+    val defaultJsonMapper: JsonMapper by lazy { Jackson.defaultJsonMapper }
+}

--- a/io/jackson-text/src/main/kotlin/io/bluetape4k/jackson/text/toml/JacksonToml.kt
+++ b/io/jackson-text/src/main/kotlin/io/bluetape4k/jackson/text/toml/JacksonToml.kt
@@ -1,0 +1,41 @@
+package io.bluetape4k.jackson.text.toml
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.dataformat.toml.TomlFactory
+import com.fasterxml.jackson.dataformat.toml.TomlMapper
+import io.bluetape4k.jackson.Jackson
+
+object JacksonToml {
+
+    val defaultTomlMapper: TomlMapper by lazy {
+        TomlMapper.builder()
+            .findAndAddModules()
+            .enable(
+                JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT,
+                JsonGenerator.Feature.IGNORE_UNKNOWN,
+                JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN,
+            )
+            .disable(
+                SerializationFeature.FAIL_ON_EMPTY_BEANS
+            )
+            // Deserialization feature
+            .enable(
+                DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT,
+                DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY,
+                DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL,
+                DeserializationFeature.READ_ENUMS_USING_TO_STRING,
+            )
+            .disable(
+                DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES,
+                DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+            )
+            .build()
+    }
+
+    val defaultTomlFactory: TomlFactory by lazy { TomlFactory() }
+
+    val defaultJsonMapper: JsonMapper by lazy { Jackson.defaultJsonMapper }
+}

--- a/io/jackson-text/src/test/kotlin/io/bluetape4k/jackson/text/toml/TomlMapperTest.kt
+++ b/io/jackson-text/src/test/kotlin/io/bluetape4k/jackson/text/toml/TomlMapperTest.kt
@@ -1,0 +1,153 @@
+package io.bluetape4k.jackson.text.toml
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.bluetape4k.jackson.text.AbstractJacksonTextTest
+import io.bluetape4k.jackson.text.FiveMinuteUser
+import io.bluetape4k.jackson.text.Gender
+import io.bluetape4k.jackson.text.Point
+import io.bluetape4k.jackson.text.Rectangle
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.support.asDouble
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class TomlMapperTest: AbstractJacksonTextTest() {
+
+    companion object: KLogging()
+
+    private val tomlMapper = JacksonToml.defaultTomlMapper
+    private val tomlFactory = JacksonToml.defaultTomlFactory
+    private val jsonMapper = JacksonToml.defaultJsonMapper
+
+    class MapWrapper {
+        var map: MutableMap<String, String> = mutableMapOf()
+    }
+
+    @Nested
+    inner class Parsing {
+        @Test
+        fun `parse from text`() {
+            val toml =
+                """
+                |[map]
+                |name = "name"
+                |b = "b"
+                |xyz = "xyz"
+                """.trimMargin()
+
+            val wrapper = tomlMapper.readValue<MapWrapper>(toml)
+
+            wrapper.map.forEach { (k, v) ->
+                log.debug { "key=$k, value=$v" }
+            }
+
+            wrapper.map.shouldNotBeNull()
+            wrapper.map.size shouldBeEqualTo 3
+        }
+
+
+    }
+
+    @Nested
+    inner class Serialization {
+        @Test
+        fun `serialize simple employee`() {
+            val input = FiveMinuteUser(
+                faker.name().firstName(),
+                faker.name().lastName(),
+                false,
+                Gender.MALE,
+                byteArrayOf(1, 2, 3, 4)
+            )
+
+            val output = tomlMapper.writeValueAsString(input)
+            log.debug { "output=\n$output\n----------" }
+
+            val expected = """
+                |firstName = '${input.firstName}'
+                |lastName = '${input.lastName}'
+                |verified = false
+                |gender = 'MALE'
+                |userImage = 'AQIDBA=='
+                |
+                """.trimMargin()
+
+            output shouldBeEqualTo expected
+        }
+
+        @Test
+        fun `deserialize simple POJO`() {
+            val input =
+                """
+                |firstName = "Bob"
+                |lastName = "Palmer"
+                |verified = true
+                |gender = "FEMALE"
+                |userImage = "AQIDBA=="  # base64 encoded byte array
+                """.trimMargin()
+
+            val expected = FiveMinuteUser("Bob", "Palmer", true, Gender.FEMALE, byteArrayOf(1, 2, 3, 4))
+
+            val actual = tomlMapper.readValue<FiveMinuteUser>(input)
+            actual shouldBeEqualTo expected
+        }
+
+        @Test
+        fun `serialize rectangle`() {
+            val input = Rectangle(Point(1, -2), Point(5, 10))
+            val output = tomlMapper.writeValueAsString(input)
+            log.debug { "output=\n$output\n------" }
+
+            val expected = """
+                |topLeft.x = 1
+                |topLeft.y = -2
+                |bottomRight.x = 5
+                |bottomRight.y = 10
+                |
+                """.trimMargin()
+
+            output shouldBeEqualTo expected
+
+            val rectangle = tomlMapper.readValue<Rectangle>(output)
+            rectangle shouldBeEqualTo input
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        @Test
+        fun `deserialize sections`() {
+            val input = """
+                # 데이터베이스 설정
+                [database]
+                host = "localhost"
+                port = 5432
+                username = "db_user"
+                password = "secure_password"
+                max_connections = 100
+                timeout = 30.5 # 초 단위
+
+                # 서버 설정
+                [server]
+                ip = "192.168.1.1"
+                port = 8080
+                
+                """.trimIndent()
+
+            val map = tomlMapper.readValue<Map<String, Any?>>(input)
+            log.debug { "map=$map" }
+            map.size shouldBeEqualTo 2      // database, server
+
+            val database = map["database"] as Map<*, *>
+            database.size shouldBeEqualTo 6
+            database["port"] shouldBeEqualTo 5432
+            database["timeout"].asDouble() shouldBeEqualTo 30.5
+
+            val server = map["server"] as Map<*, *>
+            server.size shouldBeEqualTo 2
+            server["ip"] shouldBeEqualTo "192.168.1.1"
+            server["port"] shouldBeEqualTo 8080
+        }
+    }
+}

--- a/io/jackson-text/src/test/resources/configuration.toml
+++ b/io/jackson-text/src/test/resources/configuration.toml
@@ -1,0 +1,58 @@
+# 기본 정보
+title = "TOML 파일 예제"
+version = "1.0.0"
+date = 2024-12-22T00:00:00Z # ISO 8601 형식의 날짜와 시간
+
+# 사용자 정보
+[author]
+name = "홍길동"
+email = "honggildong@example.com"
+active = true
+
+# 프로젝트 설정
+[project]
+name = "Sample Project"
+description = "TOML 형식을 설명하기 위한 예제 프로젝트"
+license = "MIT"
+
+# 데이터베이스 설정
+[database]
+host = "localhost"
+port = 5432
+username = "db_user"
+password = "secure_password"
+max_connections = 100
+timeout = 30.5 # 초 단위
+
+# 서버 설정
+[server]
+ip = "192.168.1.1"
+port = 8080
+
+# 로그 레벨 설정 (배열)
+log_levels = ["DEBUG", "INFO", "WARN", "ERROR"]
+
+# 환경별 설정
+[environments.production]
+url = "https://example.com"
+debug = false
+
+[environments.development]
+url = "http://localhost:3000"
+debug = true
+
+# 배열과 테이블 배열
+[[users]]
+id = 1
+name = "Alice"
+roles = ["admin", "editor"]
+
+[[users]]
+id = 2
+name = "Bob"
+roles = ["viewer"]
+
+[[users]]
+id = 3
+name = "Charlie"
+roles = ["editor"]


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: Add new JacksonToml for TomlMapper

### 원문 선행 내용

Toml 형식의 정보를 파싱하거나 직렬화하기 위한 Jackson의 TomlMapper 를 제공해주는 object 추가

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

Toml 형식의 정보를 파싱하거나 직렬화하기 위한 Jackson의 TomlMapper 를 제공해주는 object 추가

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #15, head `f8891eb1571c550e702e1d31cdd4c550342f5707`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feature/jackson-text-toml`
- Labels: `enhancement`
- State: `MERGED`, merge commit `ef669ef4c7ca48a5688a7d361decf3eb2b2057e9`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #15 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `ef669ef4c7ca48a5688a7d361decf3eb2b2057e9`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
