### PR TITLE
AWS Kotlin Client 함수들을 inline 로 변경

### DIFF
--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/DynamoDbClientExtensions.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/DynamoDbClientExtensions.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.withTimeout
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
-private val log by lazy { KotlinLogging.logger { } }
+val log by lazy { KotlinLogging.logger { } }
 
 /**
  * [DynamoDbClient]를 생성합니다.
@@ -45,12 +45,12 @@ private val log by lazy { KotlinLogging.logger { } }
  *
  * @return [DynamoDbClient] 인스턴스
  */
-fun dynamoDbClientOf(
+inline fun dynamoDbClientOf(
     endpointUrl: String? = null,
     region: String? = null,
     credentialsProvider: CredentialsProvider? = null,
     httpClientEngine: HttpClientEngine = defaultCrtHttpEngineOf(),
-    configurer: DynamoDbClient.Config.Builder.() -> Unit = {},
+    crossinline configurer: DynamoDbClient.Config.Builder.() -> Unit = {},
 ): DynamoDbClient {
     endpointUrl.requireNotBlank("endpoint")
 
@@ -59,6 +59,7 @@ fun dynamoDbClientOf(
         region?.let { this.region = it }
         credentialsProvider?.let { this.credentialsProvider = it }
         httpClient = httpClientEngine
+
         configurer()
     }
 }
@@ -66,13 +67,13 @@ fun dynamoDbClientOf(
 /**
  * DynamoDB 테이블을 생성합니다.
  */
-suspend fun DynamoDbClient.createTable(
+suspend inline fun DynamoDbClient.createTable(
     tableName: String,
     keySchema: List<KeySchemaElement>? = null,
     attributeDefinitions: List<AttributeDefinition>? = null,
     readCapacityUnits: Long? = null,
     writeCapacityUnits: Long? = null,
-    configurer: CreateTableRequest.Builder.() -> Unit = {},
+    crossinline configurer: CreateTableRequest.Builder.() -> Unit = {},
 ): CreateTableResponse {
     tableName.requireNotBlank("tableName")
 
@@ -142,10 +143,10 @@ suspend fun DynamoDbClient.waitForTableReady(name: String, timeout: Duration = 6
 }
 
 
-suspend fun DynamoDbClient.putItem(
+suspend inline fun DynamoDbClient.putItem(
     tableName: String,
     item: Map<String, Any?>,
-    configurer: PutItemRequest.Builder.() -> Unit = {},
+    crossinline configurer: PutItemRequest.Builder.() -> Unit = {},
 ): PutItemResponse {
     tableName.requireNotBlank("tableName")
 
@@ -157,11 +158,11 @@ suspend fun DynamoDbClient.putItem(
     }
 }
 
-fun DynamoDbClient.scanPaginated(
+inline fun DynamoDbClient.scanPaginated(
     tableName: String,
     exclusiveStartKey: Map<String, Any?>,
     limit: Int = 1,
-    configurer: ScanRequest.Builder.() -> Unit = {},
+    crossinline configurer: ScanRequest.Builder.() -> Unit = {},
 ): Flow<ScanResponse> {
     tableName.requireNotBlank("tableName")
 

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/AttributeValueUpdate.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/AttributeValueUpdate.kt
@@ -4,17 +4,17 @@ import aws.sdk.kotlin.services.dynamodb.model.AttributeAction
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValueUpdate
 
-fun <T> attributeValueUpdateOf(
+inline fun <T> attributeValueUpdateOf(
     value: T,
     action: AttributeAction,
-    configurer: AttributeValueUpdate.Builder.() -> Unit = {},
+    crossinline configurer: AttributeValueUpdate.Builder.() -> Unit = {},
 ): AttributeValueUpdate =
     attributeValueUpdateOf(value.toAttributeValue(), action, configurer)
 
-fun attributeValueUpdateOf(
+inline fun attributeValueUpdateOf(
     value: AttributeValue,
     action: AttributeAction,
-    configurer: AttributeValueUpdate.Builder.() -> Unit = {},
+    crossinline configurer: AttributeValueUpdate.Builder.() -> Unit = {},
 ): AttributeValueUpdate {
     return AttributeValueUpdate {
         this.value = value

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/BatchExecuteStatement.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/BatchExecuteStatement.kt
@@ -4,10 +4,11 @@ import aws.sdk.kotlin.services.dynamodb.model.BatchExecuteStatementRequest
 import aws.sdk.kotlin.services.dynamodb.model.BatchStatementRequest
 import aws.sdk.kotlin.services.dynamodb.model.ReturnConsumedCapacity
 
-fun batchExecutionStatementRequestOf(
+@JvmName("batchExecutionStatementRequestOfList")
+inline fun batchExecutionStatementRequestOf(
     returnConsumedCapacity: ReturnConsumedCapacity? = null,
     statements: List<BatchStatementRequest>? = null,
-    configurer: BatchExecuteStatementRequest.Builder.() -> Unit = {},
+    crossinline configurer: BatchExecuteStatementRequest.Builder.() -> Unit = {},
 ): BatchExecuteStatementRequest {
     return BatchExecuteStatementRequest.invoke {
         this.returnConsumedCapacity = returnConsumedCapacity
@@ -17,10 +18,11 @@ fun batchExecutionStatementRequestOf(
     }
 }
 
-fun batchExecutionStatementRequestOf(
+@JvmName("batchExecutionStatementRequestOfArray")
+inline fun batchExecutionStatementRequestOf(
     returnConsumedCapacity: ReturnConsumedCapacity? = null,
     vararg statements: BatchStatementRequest,
-    configurer: BatchExecuteStatementRequest.Builder.() -> Unit = {},
+    crossinline configurer: BatchExecuteStatementRequest.Builder.() -> Unit = {},
 ): BatchExecuteStatementRequest {
     return BatchExecuteStatementRequest.invoke {
         this.returnConsumedCapacity = returnConsumedCapacity

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/BatchGetItem.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/BatchGetItem.kt
@@ -5,10 +5,10 @@ import aws.sdk.kotlin.services.dynamodb.model.KeysAndAttributes
 import aws.sdk.kotlin.services.dynamodb.model.ReturnConsumedCapacity
 import io.bluetape4k.support.requireNotEmpty
 
-fun batchGetItemRequestOf(
+inline fun batchGetItemRequestOf(
     requestItems: Map<String, KeysAndAttributes>,
     returnConsumedCapacity: ReturnConsumedCapacity? = null,
-    configurer: BatchGetItemRequest.Builder.() -> Unit = {},
+    crossinline configurer: BatchGetItemRequest.Builder.() -> Unit = {},
 ): BatchGetItemRequest {
     requestItems.requireNotEmpty("requestItems")
 

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/BatchStatement.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/BatchStatement.kt
@@ -6,12 +6,12 @@ import aws.sdk.kotlin.services.dynamodb.model.ReturnValuesOnConditionCheckFailur
 import io.bluetape4k.support.requireNotBlank
 
 @JvmName("batchStatementRequestOfAttributeValue")
-fun batchStatementRequestOf(
+inline fun batchStatementRequestOf(
     statement: String,
     parameters: List<AttributeValue>? = null,
     consistentRead: Boolean? = null,
     returnValuesOnConditionCheckFailure: ReturnValuesOnConditionCheckFailure? = null,
-    configurer: BatchStatementRequest.Builder.() -> Unit = {},
+    crossinline configurer: BatchStatementRequest.Builder.() -> Unit = {},
 ): BatchStatementRequest {
     statement.requireNotBlank("statement")
 
@@ -20,17 +20,18 @@ fun batchStatementRequestOf(
         this.parameters = parameters
         this.consistentRead = consistentRead
         this.returnValuesOnConditionCheckFailure = returnValuesOnConditionCheckFailure
+
         configurer()
     }
 }
 
 @JvmName("batchStatementRequestOfAny")
-fun batchStatementRequestOf(
+inline fun batchStatementRequestOf(
     statement: String,
     parameters: List<Any?>? = null,
     consistentRead: Boolean? = null,
     returnValuesOnConditionCheckFailure: ReturnValuesOnConditionCheckFailure? = null,
-    configurer: BatchStatementRequest.Builder.() -> Unit = {},
+    crossinline configurer: BatchStatementRequest.Builder.() -> Unit = {},
 ): BatchStatementRequest {
     statement.requireNotBlank("statement")
 
@@ -39,6 +40,7 @@ fun batchStatementRequestOf(
         this.parameters = parameters?.map { it.toAttributeValue() }
         this.consistentRead = consistentRead
         this.returnValuesOnConditionCheckFailure = returnValuesOnConditionCheckFailure
+
         configurer()
     }
 }

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/BatchWriteItem.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/BatchWriteItem.kt
@@ -5,10 +5,10 @@ import aws.sdk.kotlin.services.dynamodb.model.ReturnConsumedCapacity
 import aws.sdk.kotlin.services.dynamodb.model.WriteRequest
 import io.bluetape4k.support.requireNotEmpty
 
-fun batchWriteItemRequestOf(
+inline fun batchWriteItemRequestOf(
     requestItems: Map<String, List<WriteRequest>>,
     returnConsumedCapacity: ReturnConsumedCapacity? = null,
-    configurer: BatchWriteItemRequest.Builder.() -> Unit = {},
+    crossinline configurer: BatchWriteItemRequest.Builder.() -> Unit = {},
 ): BatchWriteItemRequest {
     requestItems.requireNotEmpty("requestItems")
     return BatchWriteItemRequest {

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/Capacity.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/Capacity.kt
@@ -3,11 +3,11 @@ package io.bluetape4k.aws.kotlin.dynamodb.model
 import aws.sdk.kotlin.services.dynamodb.model.Capacity
 import io.bluetape4k.support.requirePositiveNumber
 
-fun capacityOf(
+inline fun capacityOf(
     capacityUnits: Double? = null,
     readCapacityUnits: Double? = null,
     writeCapacityUnits: Double? = null,
-    configurer: Capacity.Builder.() -> Unit = {},
+    crossinline configurer: Capacity.Builder.() -> Unit = {},
 ): Capacity {
     capacityUnits?.requirePositiveNumber("capacityUnits")
     readCapacityUnits?.requirePositiveNumber("readCapacityUnits")
@@ -17,6 +17,7 @@ fun capacityOf(
         this.capacityUnits = capacityUnits
         this.readCapacityUnits = readCapacityUnits
         this.writeCapacityUnits = writeCapacityUnits
+
         configurer()
     }
 }

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/Condition.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/Condition.kt
@@ -5,10 +5,10 @@ import aws.sdk.kotlin.services.dynamodb.model.ComparisonOperator
 import aws.sdk.kotlin.services.dynamodb.model.Condition
 
 @JvmName("conditionOfAttributeValue")
-fun conditionOf(
+inline fun conditionOf(
     comparisonOperator: ComparisonOperator,
     attributeValueList: List<AttributeValue>,
-    configurer: Condition.Builder.() -> Unit = {},
+    crossinline configurer: Condition.Builder.() -> Unit = {},
 ): Condition {
 
     return Condition.invoke {
@@ -20,10 +20,10 @@ fun conditionOf(
 }
 
 @JvmName("conditionOfAny")
-fun conditionOf(
+inline fun conditionOf(
     comparisonOperator: ComparisonOperator,
     attributeValueList: List<Any?>,
-    configurer: Condition.Builder.() -> Unit = {},
+    crossinline configurer: Condition.Builder.() -> Unit = {},
 ): Condition {
 
     return Condition.invoke {

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/ConditionCheck.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/ConditionCheck.kt
@@ -4,12 +4,12 @@ import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
 import aws.sdk.kotlin.services.dynamodb.model.ConditionCheck
 
 @JvmName("conditionCheckOfAttributeValue")
-fun conditionCheckOf(
+inline fun conditionCheckOf(
     conditionExpression: String? = null,
     expressionAttributeNames: Map<String, String>? = null,
     expressionAttributeValues: Map<String, AttributeValue>? = null,
     key: Map<String, AttributeValue>? = null,
-    configurer: ConditionCheck.Builder.() -> Unit = {},
+    crossinline configurer: ConditionCheck.Builder.() -> Unit = {},
 ): ConditionCheck {
 
     return ConditionCheck {
@@ -23,12 +23,12 @@ fun conditionCheckOf(
 }
 
 @JvmName("conditionCheckOfAny")
-fun conditionCheckOf(
+inline fun conditionCheckOf(
     conditionExpression: String? = null,
     expressionAttributeNames: Map<String, String>? = null,
     expressionAttributeValues: Map<String, Any?>? = null,
     key: Map<String, Any?>? = null,
-    configurer: ConditionCheck.Builder.() -> Unit = {},
+    crossinline configurer: ConditionCheck.Builder.() -> Unit = {},
 ): ConditionCheck {
 
     return ConditionCheck {

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/CreateBackup.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/CreateBackup.kt
@@ -3,10 +3,10 @@ package io.bluetape4k.aws.kotlin.dynamodb.model
 import aws.sdk.kotlin.services.dynamodb.model.CreateBackupRequest
 import io.bluetape4k.support.requireNotBlank
 
-fun createBackupRequestOf(
+inline fun createBackupRequestOf(
     tableName: String,
     backupName: String,
-    configurer: CreateBackupRequest.Builder.() -> Unit = {},
+    crossinline configurer: CreateBackupRequest.Builder.() -> Unit = {},
 ): CreateBackupRequest {
     tableName.requireNotBlank("tableName")
     backupName.requireNotBlank("backupName")
@@ -14,6 +14,7 @@ fun createBackupRequestOf(
     return CreateBackupRequest {
         this.tableName = tableName
         this.backupName = backupName
+
         configurer()
     }
 }

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/CreateGlobalTable.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/CreateGlobalTable.kt
@@ -4,10 +4,10 @@ import aws.sdk.kotlin.services.dynamodb.model.CreateGlobalTableRequest
 import aws.sdk.kotlin.services.dynamodb.model.Replica
 import io.bluetape4k.support.requireNotBlank
 
-fun createGlobalTableRequestOf(
+inline fun createGlobalTableRequestOf(
     globalTableName: String,
     replicationGroup: List<Replica>? = null,
-    configurer: CreateGlobalTableRequest.Builder.() -> Unit = {},
+    crossinline configurer: CreateGlobalTableRequest.Builder.() -> Unit = {},
 ): CreateGlobalTableRequest {
     globalTableName.requireNotBlank("globalTableName")
 

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/CreateTable.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/CreateTable.kt
@@ -6,12 +6,12 @@ import aws.sdk.kotlin.services.dynamodb.model.TableClass
 import aws.sdk.kotlin.services.dynamodb.model.Tag
 import io.bluetape4k.support.requireNotBlank
 
-fun createTableRequestOf(
+inline fun createTableRequestOf(
     tableName: String,
     tableClass: TableClass = TableClass.Standard,
     tags: List<Tag>? = null,
     streamSpecification: StreamSpecification? = null,
-    configurer: CreateTableRequest.Builder.() -> Unit = {},
+    crossinline configurer: CreateTableRequest.Builder.() -> Unit = {},
 ): CreateTableRequest {
     tableName.requireNotBlank("tableName")
 
@@ -20,6 +20,7 @@ fun createTableRequestOf(
         this.tableClass = tableClass
         this.tags = tags
         this.streamSpecification = streamSpecification
+
         configurer()
     }
 }

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/Delete.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/Delete.kt
@@ -7,10 +7,10 @@ import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requireNotEmpty
 
 @JvmName("deleteOfAttributeValue")
-fun deleteOf(
+inline fun deleteOf(
     tableName: String,
     key: Map<String, AttributeValue>? = null,
-    configurer: Delete.Builder.() -> Unit = {},
+    crossinline configurer: Delete.Builder.() -> Unit = {},
 ): Delete {
     tableName.requireNotBlank("tableName")
 
@@ -23,10 +23,10 @@ fun deleteOf(
 }
 
 @JvmName("deleteOfAny")
-fun deleteOf(
+inline fun deleteOf(
     tableName: String,
     key: Map<String, Any?>? = null,
-    configurer: Delete.Builder.() -> Unit = {},
+    crossinline configurer: Delete.Builder.() -> Unit = {},
 ): Delete {
     tableName.requireNotBlank("tableName")
 
@@ -39,9 +39,9 @@ fun deleteOf(
 }
 
 @JvmName("deleteRequestOfAttributeValue")
-fun deleteRequestOf(
+inline fun deleteRequestOf(
     key: Map<String, AttributeValue>,
-    configurer: DeleteRequest.Builder.() -> Unit = {},
+    crossinline configurer: DeleteRequest.Builder.() -> Unit = {},
 ): DeleteRequest {
     key.requireNotEmpty("key")
 
@@ -52,9 +52,9 @@ fun deleteRequestOf(
 }
 
 @JvmName("deleteRequestOfAny")
-fun deleteRequestOf(
+inline fun deleteRequestOf(
     key: Map<String, Any?>,
-    configurer: DeleteRequest.Builder.() -> Unit = {},
+    crossinline configurer: DeleteRequest.Builder.() -> Unit = {},
 ): DeleteRequest {
     key.requireNotEmpty("key")
 

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/DeleteBackup.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/DeleteBackup.kt
@@ -3,9 +3,9 @@ package io.bluetape4k.aws.kotlin.dynamodb.model
 import aws.sdk.kotlin.services.dynamodb.model.DeleteBackupRequest
 import io.bluetape4k.support.requireNotBlank
 
-fun deleteBackupRequestOf(
+inline fun deleteBackupRequestOf(
     backupArn: String,
-    configurer: DeleteBackupRequest.Builder.() -> Unit = {},
+    crossinline configurer: DeleteBackupRequest.Builder.() -> Unit = {},
 ): DeleteBackupRequest {
     backupArn.requireNotBlank("backupArn")
 

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/DeleteTable.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/DeleteTable.kt
@@ -3,9 +3,9 @@ package io.bluetape4k.aws.kotlin.dynamodb.model
 import aws.sdk.kotlin.services.dynamodb.model.DeleteTableRequest
 import io.bluetape4k.support.requireNotBlank
 
-fun deleteTableRequest(
+inline fun deleteTableRequest(
     tableName: String,
-    configurer: DeleteTableRequest.Builder.() -> Unit = {},
+    crossinline configurer: DeleteTableRequest.Builder.() -> Unit = {},
 ): DeleteTableRequest {
     tableName.requireNotBlank("tableName")
 

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/ExecuteStatement.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/ExecuteStatement.kt
@@ -21,6 +21,7 @@ inline fun executeStatementRequestOf(
         this.consistentRead = consistentRead
         this.limit = limit
         this.nextToken = nextToken
+
         configurer()
     }
 }

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/ExecuteTransaction.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/ExecuteTransaction.kt
@@ -5,11 +5,11 @@ import aws.sdk.kotlin.services.dynamodb.model.ParameterizedStatement
 import aws.sdk.kotlin.services.dynamodb.model.ReturnConsumedCapacity
 import io.bluetape4k.support.requireNotEmpty
 
-fun executeTransactionRequestOf(
+inline fun executeTransactionRequestOf(
     transactionStatements: List<ParameterizedStatement>,
     clientRequestToken: String? = null,
     returnConsumedCapacity: ReturnConsumedCapacity? = null,
-    configurer: ExecuteTransactionRequest.Builder.() -> Unit = {},
+    crossinline configurer: ExecuteTransactionRequest.Builder.() -> Unit = {},
 ): ExecuteTransactionRequest {
     transactionStatements.requireNotEmpty("transactionStatements")
 
@@ -17,6 +17,7 @@ fun executeTransactionRequestOf(
         this.transactStatements = transactionStatements
         this.clientRequestToken = clientRequestToken
         this.returnConsumedCapacity = returnConsumedCapacity
+
         configurer()
     }
 }

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/Get.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/Get.kt
@@ -31,11 +31,11 @@ inline fun getOf(
     projectionExpression: String? = null,
     crossinline configurer: Get.Builder.() -> Unit = {},
 ): Get {
-    return getOf(
-        tableName,
-        key?.mapValues { it.toAttributeValue() },
-        expressionAttributeNames,
-        projectionExpression,
-        configurer,
-    )
+    return Get {
+        this.tableName = tableName
+        this.key = key?.mapValues { it.toAttributeValue() }
+        this.expressionAttributeNames = expressionAttributeNames
+        this.projectionExpression = projectionExpression
+        configurer()
+    }
 }

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/GetItem.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/GetItem.kt
@@ -3,13 +3,12 @@ package io.bluetape4k.aws.kotlin.dynamodb.model
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
 import aws.sdk.kotlin.services.dynamodb.model.GetItemRequest
 
-fun getItemRequestOf(
+inline fun getItemRequestOf(
     attributesToGet: List<String>,
     consistentRead: Boolean? = null,
     expressionAttributeNames: Map<String, String>? = null,
     key: Map<String, AttributeValue>? = null,
-
-    configurer: GetItemRequest.Builder.() -> Unit = {},
+    crossinline configurer: GetItemRequest.Builder.() -> Unit = {},
 ): GetItemRequest {
 
     return GetItemRequest.invoke {

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/KeysAndAttributes.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/KeysAndAttributes.kt
@@ -18,12 +18,14 @@ inline fun keysAndAttributesOf(
 }
 
 @JvmName("keysAndAttributesOfAny")
-fun keysAndAttributesOf(
+inline fun keysAndAttributesOf(
     keys: List<Map<String, Any?>>,
-    configurer: KeysAndAttributes.Builder.() -> Unit = {},
+    crossinline configurer: KeysAndAttributes.Builder.() -> Unit = {},
 ): KeysAndAttributes {
-    return keysAndAttributesOf(
-        keys.map { it.mapValues { it.toAttributeValue() } },
-        configurer,
-    )
+    keys.requireNotEmpty("keys")
+
+    return KeysAndAttributes {
+        this.keys = keys.map { it.mapValues { it.toAttributeValue() } }
+        configurer()
+    }
 }

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/ListGlobalTables.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/ListGlobalTables.kt
@@ -2,11 +2,11 @@ package io.bluetape4k.aws.kotlin.dynamodb.model
 
 import aws.sdk.kotlin.services.dynamodb.model.ListGlobalTablesRequest
 
-fun listGlobalTableRequestOf(
+inline fun listGlobalTableRequestOf(
     exclusiveStartGlobalTableName: String? = null,
     regionName: String? = null,
     limit: Int? = null,
-    configurer: ListGlobalTablesRequest.Builder.() -> Unit = {},
+    crossinline configurer: ListGlobalTablesRequest.Builder.() -> Unit = {},
 ): ListGlobalTablesRequest {
     return ListGlobalTablesRequest {
         this.exclusiveStartGlobalTableName = exclusiveStartGlobalTableName

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/ListTables.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/ListTables.kt
@@ -2,10 +2,10 @@ package io.bluetape4k.aws.kotlin.dynamodb.model
 
 import aws.sdk.kotlin.services.dynamodb.model.ListTablesRequest
 
-fun listTablesRequestOf(
+inline fun listTablesRequestOf(
     exclusiveStartTableName: String? = null,
     limit: Int? = null,
-    configurer: ListTablesRequest.Builder.() -> Unit = {},
+    crossinline configurer: ListTablesRequest.Builder.() -> Unit = {},
 ): ListTablesRequest {
     return ListTablesRequest.invoke {
         this.exclusiveStartTableName = exclusiveStartTableName

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/ListTagsOfResource.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/ListTagsOfResource.kt
@@ -3,10 +3,10 @@ package io.bluetape4k.aws.kotlin.dynamodb.model
 import aws.sdk.kotlin.services.dynamodb.model.ListTagsOfResourceRequest
 import io.bluetape4k.support.requireNotBlank
 
-fun listTagsOfResourceRequestOf(
+inline fun listTagsOfResourceRequestOf(
     resourceArn: String,
     nextToken: String? = null,
-    configurer: ListTagsOfResourceRequest.Builder.() -> Unit = {},
+    crossinline configurer: ListTagsOfResourceRequest.Builder.() -> Unit = {},
 ): ListTagsOfResourceRequest {
     resourceArn.requireNotBlank("resourceArn")
 

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/Projection.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/Projection.kt
@@ -12,12 +12,15 @@ import aws.sdk.kotlin.services.dynamodb.model.ProjectionType
  *
  * @param projectionType 프로젝션 타입
  * @param nonKeyAttributes 프로젝션에 포함할 속성 목록
+ * @param configurer 프로젝션 설정
  * @return [Projection] 인스턴스
  */
-fun projectionOf(
+inline fun projectionOf(
     projectionType: ProjectionType,
     nonKeyAttributes: List<String>? = null,
-): Projection = Projection.invoke {
+    crossinline configurer: Projection.Builder.() -> Unit = {},
+): Projection = Projection {
     this.projectionType = projectionType
     this.nonKeyAttributes = nonKeyAttributes
+    configurer()
 }

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/RestoreTable.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/RestoreTable.kt
@@ -3,15 +3,15 @@ package io.bluetape4k.aws.kotlin.dynamodb.model
 import aws.sdk.kotlin.services.dynamodb.model.RestoreTableFromBackupRequest
 import io.bluetape4k.support.requireNotBlank
 
-fun restoreTableFromBackupRequestOf(
+inline fun restoreTableFromBackupRequestOf(
     backupArn: String,
     targetTableName: String,
-    configurer: RestoreTableFromBackupRequest.Builder.() -> Unit = {},
+    crossinline configurer: RestoreTableFromBackupRequest.Builder.() -> Unit = {},
 ): RestoreTableFromBackupRequest {
     backupArn.requireNotBlank("backupArn")
     targetTableName.requireNotBlank("targetTableName")
 
-    return RestoreTableFromBackupRequest.invoke {
+    return RestoreTableFromBackupRequest {
         this.backupArn = backupArn
         this.targetTableName = targetTableName
 
@@ -19,15 +19,15 @@ fun restoreTableFromBackupRequestOf(
     }
 }
 
-fun restoreTableToPointInTimeRequestOf(
+inline fun restoreTableToPointInTimeRequestOf(
     backupArn: String,
     targetTableName: String,
-    configurer: RestoreTableFromBackupRequest.Builder.() -> Unit,
+    crossinline configurer: RestoreTableFromBackupRequest.Builder.() -> Unit,
 ): RestoreTableFromBackupRequest {
     backupArn.requireNotBlank("backupArn")
     targetTableName.requireNotBlank("targetTableName")
 
-    return RestoreTableFromBackupRequest.invoke {
+    return RestoreTableFromBackupRequest {
         this.backupArn = backupArn
         this.targetTableName = targetTableName
 

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/Scan.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/Scan.kt
@@ -32,11 +32,14 @@ inline fun scanRequestOf(
     indexName: String? = null,
     crossinline configurer: ScanRequest.Builder.() -> Unit = {},
 ): ScanRequest {
-    return scanRequestOf(
-        tableName,
-        attributesToGet,
-        exclusiveStartKey?.mapValues { it.toAttributeValue() },
-        indexName,
-        configurer,
-    )
+    tableName.requireNotBlank("tableName")
+
+    return ScanRequest {
+        this.tableName = tableName
+        this.attributesToGet = attributesToGet
+        this.exclusiveStartKey = exclusiveStartKey?.mapValues { it.toAttributeValue() }
+        this.indexName = indexName
+
+        configurer()
+    }
 }

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/StreamSpecification.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/StreamSpecification.kt
@@ -3,10 +3,10 @@ package io.bluetape4k.aws.kotlin.dynamodb.model
 import aws.sdk.kotlin.services.dynamodb.model.StreamSpecification
 import aws.sdk.kotlin.services.dynamodb.model.StreamViewType
 
-fun streamSpecificationOf(
+inline fun streamSpecificationOf(
     streamEnabled: Boolean? = null,
     streamViewType: StreamViewType? = null,
-    configurer: StreamSpecification.Builder.() -> Unit = {},
+    crossinline configurer: StreamSpecification.Builder.() -> Unit = {},
 ): StreamSpecification {
 
     return StreamSpecification {

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/TagResource.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/TagResource.kt
@@ -4,20 +4,34 @@ import aws.sdk.kotlin.services.dynamodb.model.Tag
 import aws.sdk.kotlin.services.dynamodb.model.TagResourceRequest
 import io.bluetape4k.support.requireNotBlank
 
-fun tagResourceRequestOf(
+@JvmName("tagResourceRequestOfTagList")
+inline fun tagResourceRequestOf(
     resourceArn: String,
     tags: List<Tag>? = null,
-    configurer: TagResourceRequest.Builder.() -> Unit = {},
+    crossinline configurer: TagResourceRequest.Builder.() -> Unit = {},
 ): TagResourceRequest {
     resourceArn.requireNotBlank("resourceArn")
 
     return TagResourceRequest {
         this.resourceArn = resourceArn
         this.tags = tags
+
         configurer()
     }
 }
 
-fun tagResourceRequestOf(resourceArn: String, vararg tags: Tag): TagResourceRequest {
-    return tagResourceRequestOf(resourceArn, tags.toList())
+@JvmName("tagResourceRequestOfTagArray")
+inline fun tagResourceRequestOf(
+    resourceArn: String,
+    vararg tags: Tag,
+    crossinline configurer: TagResourceRequest.Builder.() -> Unit = {},
+): TagResourceRequest {
+    resourceArn.requireNotBlank("resourceArn")
+
+    return TagResourceRequest {
+        this.resourceArn = resourceArn
+        this.tags = tags.toList()
+
+        configurer()
+    }
 }

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/TransactGetItem.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/TransactGetItem.kt
@@ -6,8 +6,8 @@ import aws.sdk.kotlin.services.dynamodb.model.TransactGetItem
 import aws.sdk.kotlin.services.dynamodb.model.TransactGetItemsRequest
 import io.bluetape4k.support.requireNotEmpty
 
-fun transactGetItemOf(get: Get): TransactGetItem {
-    return TransactGetItem { this.get = get }
+fun transactGetItemOf(get: Get): TransactGetItem = TransactGetItem {
+    this.get = get
 }
 
 

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/TransactWriteItem.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/TransactWriteItem.kt
@@ -1,11 +1,26 @@
 package io.bluetape4k.aws.kotlin.dynamodb.model
 
+import aws.sdk.kotlin.services.dynamodb.model.ConditionCheck
+import aws.sdk.kotlin.services.dynamodb.model.Delete
 import aws.sdk.kotlin.services.dynamodb.model.Put
 import aws.sdk.kotlin.services.dynamodb.model.TransactWriteItem
+import aws.sdk.kotlin.services.dynamodb.model.Update
 
-fun transactWriteItemOf(put: Put): TransactWriteItem {
-    return TransactWriteItem {
-        this.put = put
+fun transactWriteItemOf(put: Put): TransactWriteItem = TransactWriteItem {
+    this.put = put
+}
 
-    }
+inline fun transactWriteItemOf(
+    conditionCheck: ConditionCheck? = null,
+    delete: Delete? = null,
+    put: Put? = null,
+    update: Update? = null,
+    crossinline configurer: TransactWriteItem.Builder.() -> Unit = {},
+): TransactWriteItem = TransactWriteItem {
+    this.conditionCheck = conditionCheck
+    this.put = put
+    this.update = update
+    this.delete = delete
+
+    configurer()
 }

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/Write.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/model/Write.kt
@@ -5,9 +5,10 @@ import aws.sdk.kotlin.services.dynamodb.model.DeleteRequest
 import aws.sdk.kotlin.services.dynamodb.model.PutRequest
 import aws.sdk.kotlin.services.dynamodb.model.WriteRequest
 
-fun writeRequestOf(
+inline fun writeRequestOf(
     putRequest: PutRequest? = null,
     deleteRequest: DeleteRequest? = null,
+    crossinline configurer: WriteRequest.Builder.() -> Unit = {},
 ): WriteRequest {
     require(putRequest != null || deleteRequest != null) {
         "Either putRequest or deleteRequest must be provided"
@@ -16,14 +17,18 @@ fun writeRequestOf(
     return WriteRequest {
         this.putRequest = putRequest
         this.deleteRequest = deleteRequest
+
+        configurer()
     }
 }
 
 @JvmName("putRequestOfMap")
-fun writePutRequestOf(item: Map<String, Any?>): WriteRequest = writeRequestOf(putRequestOf(item))
+fun writePutRequestOf(item: Map<String, Any?>): WriteRequest =
+    writeRequestOf(putRequestOf(item))
 
 @JvmName("putRequestOfAttributeValue")
-fun writePutRequestOf(item: Map<String, AttributeValue>): WriteRequest = writeRequestOf(putRequestOf(item))
+fun writePutRequestOf(item: Map<String, AttributeValue>): WriteRequest =
+    writeRequestOf(putRequestOf(item))
 
 @JvmName("deleteRequestOfMap")
 fun writeDeleteRequestOf(key: Map<String, Any?>): WriteRequest =

--- a/aws-kotlin/s3/src/main/kotlin/io/bluetape4k/aws/kotlin/s3/S3ClientCopy.kt
+++ b/aws-kotlin/s3/src/main/kotlin/io/bluetape4k/aws/kotlin/s3/S3ClientCopy.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.aws.kotlin.s3
 
 import aws.sdk.kotlin.services.s3.S3Client
+import aws.sdk.kotlin.services.s3.model.CopyObjectRequest
 import aws.sdk.kotlin.services.s3.model.CopyObjectResponse
 import io.bluetape4k.aws.kotlin.s3.model.copyObjectRequestOf
 
@@ -17,12 +18,13 @@ import io.bluetape4k.aws.kotlin.s3.model.copyObjectRequestOf
  * @param destKey 대상 객체 키
  * @return [CopyObjectResponse] 인스턴스
  */
-suspend fun S3Client.copy(
+suspend inline fun S3Client.copy(
     srcBucket: String,
     srcKey: String,
     destBucket: String,
     destKey: String,
+    crossinline configurer: CopyObjectRequest.Builder.() -> Unit = {},
 ): CopyObjectResponse {
-    val request = copyObjectRequestOf(srcBucket, srcKey, destBucket, destKey)
+    val request = copyObjectRequestOf(srcBucket, srcKey, destBucket, destKey, configurer = configurer)
     return copyObject(request)
 }

--- a/aws-kotlin/s3/src/main/kotlin/io/bluetape4k/aws/kotlin/s3/S3ClientDelete.kt
+++ b/aws-kotlin/s3/src/main/kotlin/io/bluetape4k/aws/kotlin/s3/S3ClientDelete.kt
@@ -2,14 +2,13 @@ package io.bluetape4k.aws.kotlin.s3
 
 import aws.sdk.kotlin.services.s3.S3Client
 import aws.sdk.kotlin.services.s3.deleteObjects
+import aws.sdk.kotlin.services.s3.model.Delete
+import aws.sdk.kotlin.services.s3.model.DeleteObjectsRequest
 import aws.sdk.kotlin.services.s3.model.DeleteObjectsResponse
 import io.bluetape4k.aws.kotlin.s3.model.deleteOf
-import io.bluetape4k.logging.KotlinLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requireNotEmpty
-
-private val log by lazy { KotlinLogging.logger { } }
 
 /**
  * S3 Bucket 에서 여러 Object 를 삭제합니다.
@@ -22,15 +21,16 @@ private val log by lazy { KotlinLogging.logger { } }
  * @param keys 삭제할 Object 의 키 목록
  * @return [DeleteObjectsResponse] 인스턴스
  */
-suspend fun S3Client.deleteAll(
+suspend inline fun S3Client.deleteAll(
     bucket: String,
     vararg keys: String,
+    crossinline block: Delete.Builder.() -> Unit = {},
 ): DeleteObjectsResponse {
     bucket.requireNotBlank("bucketName")
 
     return deleteObjects {
         this.bucket = bucket
-        this.delete = deleteOf(false, *keys)
+        this.delete = deleteOf(*keys, block = block)
     }
 }
 
@@ -45,9 +45,10 @@ suspend fun S3Client.deleteAll(
  * @param keys 삭제할 Object 의 키 목록
  * @return [DeleteObjectsResponse] 인스턴스
  */
-suspend fun S3Client.deleteAll(
+suspend inline fun S3Client.deleteAll(
     bucket: String,
     keys: Collection<String>,
+    crossinline block: Delete.Builder.() -> Unit = {},
 ): DeleteObjectsResponse {
     bucket.requireNotBlank("bucketName")
     keys.requireNotEmpty("keys")
@@ -55,6 +56,35 @@ suspend fun S3Client.deleteAll(
 
     return deleteObjects {
         this.bucket = bucket
-        this.delete = deleteOf(false, keys)
+        this.delete = deleteOf(keys, block = block)
+    }
+}
+
+/**
+ * S3 Bucket 에서 여러 Object 를 삭제합니다.
+ *
+ * ```
+ * val keys = listOf("key-1", "key-2")
+ * val response = s3Client.deleteAll("bucket-1") {
+ *      delete {
+ *             quiet = true
+ *             this.objects = keys.map { it.toObjectIdentifier() }
+ *      }
+ * }
+ * ```
+ *
+ * @param bucket 삭제할 Object 가 있는 버킷 이름
+ * @param configurer [DeleteObjectsRequest.Builder]를 통해 [DeleteObjectsRequest]를 설정합니다.
+ * @return [DeleteObjectsResponse] 인스턴스
+ */
+suspend inline fun S3Client.deleteAll(
+    bucket: String,
+    crossinline configurer: DeleteObjectsRequest.Builder.() -> Unit,
+): DeleteObjectsResponse {
+    bucket.requireNotBlank("bucketName")
+
+    return deleteObjects {
+        this.bucket = bucket
+        configurer()
     }
 }

--- a/aws-kotlin/s3/src/main/kotlin/io/bluetape4k/aws/kotlin/s3/S3ClientLogger.kt
+++ b/aws-kotlin/s3/src/main/kotlin/io/bluetape4k/aws/kotlin/s3/S3ClientLogger.kt
@@ -1,0 +1,5 @@
+package io.bluetape4k.aws.kotlin.s3
+
+import io.bluetape4k.logging.KotlinLogging
+
+val log by lazy { KotlinLogging.logger {} }

--- a/aws-kotlin/s3/src/main/kotlin/io/bluetape4k/aws/kotlin/s3/S3ClientMove.kt
+++ b/aws-kotlin/s3/src/main/kotlin/io/bluetape4k/aws/kotlin/s3/S3ClientMove.kt
@@ -20,13 +20,14 @@ import aws.sdk.kotlin.services.s3.model.DeleteObjectRequest
  * @param destKey 이동할 Object 의 키
  * @return [CopyObjectResponse] 인스턴스
  */
-suspend fun S3Client.move(
+suspend inline fun S3Client.move(
     srcBucket: String,
     srcKey: String,
     destBucket: String,
     destKey: String,
+    crossinline configurer: CopyObjectRequest.Builder.() -> Unit = {},
 ): CopyObjectResponse {
-    val response = copy(srcBucket, srcKey, destBucket, destKey)
+    val response = copy(srcBucket, srcKey, destBucket, destKey, configurer)
 
     if (response.copyObjectResult?.eTag?.isNotBlank() == true) {
         deleteObject {
@@ -57,9 +58,9 @@ suspend fun S3Client.move(
  * @param deleteRequestBuilder [DeleteObjectRequest.Builder] 를 통해 [DeleteObjectRequest] 를 설정합니다.
  * @return [CopyObjectResponse] 인스턴스
  */
-suspend fun S3Client.move(
-    copyRequestBuilder: (CopyObjectRequest.Builder) -> Unit,
-    deleteRequestBuilder: (DeleteObjectRequest.Builder) -> Unit,
+suspend inline fun S3Client.move(
+    crossinline copyRequestBuilder: (CopyObjectRequest.Builder) -> Unit,
+    crossinline deleteRequestBuilder: (DeleteObjectRequest.Builder) -> Unit,
 ): CopyObjectResponse {
     val response = copyObject(copyRequestBuilder)
 

--- a/aws-kotlin/s3/src/main/kotlin/io/bluetape4k/aws/kotlin/s3/S3ClientPut.kt
+++ b/aws-kotlin/s3/src/main/kotlin/io/bluetape4k/aws/kotlin/s3/S3ClientPut.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.aws.kotlin.s3
 
 import aws.sdk.kotlin.services.s3.S3Client
+import aws.sdk.kotlin.services.s3.model.ObjectCannedAcl
 import aws.sdk.kotlin.services.s3.model.PutObjectRequest
 import aws.sdk.kotlin.services.s3.model.PutObjectResponse
 import aws.smithy.kotlin.runtime.content.ByteStream
@@ -33,14 +34,16 @@ import java.nio.file.Path
  * @param configurer [PutObjectRequest.Builder] 를 통해 [PutObjectRequest] 를 설정합니다.
  * @return [PutObjectResponse] 인스턴스
  */
-suspend fun S3Client.put(
+suspend inline fun S3Client.put(
     bucketName: String,
     key: String,
     body: ByteStream? = null,
     metadata: Map<String, String>? = null,
-    configurer: PutObjectRequest.Builder.() -> Unit = {},
+    acl: ObjectCannedAcl? = null,
+    contentType: String? = null,
+    crossinline configurer: PutObjectRequest.Builder.() -> Unit = {},
 ): PutObjectResponse {
-    val request = putObjectRequestOf(bucketName, key, body, metadata) { configurer() }
+    val request = putObjectRequestOf(bucketName, key, body, metadata, acl, contentType, configurer)
     return putObject(request)
 }
 
@@ -58,14 +61,16 @@ suspend fun S3Client.put(
  * @param configurer [PutObjectRequest.Builder] 를 통해 [PutObjectRequest] 를 설정합니다.
  * @return [PutObjectResponse] 인스턴스
  */
-suspend fun S3Client.putFromByteArray(
+suspend inline fun S3Client.putFromByteArray(
     bucketName: String,
     key: String,
     bytes: ByteArray,
     metadata: Map<String, String>? = null,
-    configurer: PutObjectRequest.Builder.() -> Unit = {},
+    acl: ObjectCannedAcl? = null,
+    contentType: String? = null,
+    crossinline configurer: PutObjectRequest.Builder.() -> Unit = {},
 ): PutObjectResponse {
-    return put(bucketName, key, ByteStream.fromBytes(bytes), metadata, configurer)
+    return put(bucketName, key, ByteStream.fromBytes(bytes), metadata, acl, contentType, configurer)
 }
 
 /**
@@ -81,14 +86,16 @@ suspend fun S3Client.putFromByteArray(
  * @param configurer [PutObjectRequest.Builder] 를 통해 [PutObjectRequest] 를 설정합니다.
  * @return [PutObjectResponse] 인스턴스
  */
-suspend fun S3Client.putFromString(
+suspend inline fun S3Client.putFromString(
     bucketName: String,
     key: String,
     text: String,
     metadata: Map<String, String>? = null,
-    configurer: PutObjectRequest.Builder.() -> Unit = {},
+    acl: ObjectCannedAcl? = null,
+    contentType: String? = null,
+    crossinline configurer: PutObjectRequest.Builder.() -> Unit = {},
 ): PutObjectResponse {
-    return put(bucketName, key, ByteStream.fromString(text), metadata, configurer)
+    return put(bucketName, key, ByteStream.fromString(text), metadata, acl, contentType, configurer)
 }
 
 /**
@@ -106,15 +113,17 @@ suspend fun S3Client.putFromString(
  * @throws IllegalArgumentException 파일이 존재하지 않을 경우
  * @see putFromPath
  */
-suspend fun S3Client.putFromFile(
+suspend inline fun S3Client.putFromFile(
     bucketName: String,
     key: String,
     file: File,
     metadata: Map<String, String>? = null,
-    configurer: PutObjectRequest.Builder.() -> Unit = {},
+    acl: ObjectCannedAcl? = null,
+    contentType: String? = null,
+    crossinline configurer: PutObjectRequest.Builder.() -> Unit = {},
 ): PutObjectResponse {
     require(file.exists()) { "File not found: $file" }
-    return put(bucketName, key, ByteStream.fromFile(file), metadata, configurer)
+    return put(bucketName, key, ByteStream.fromFile(file), metadata, acl, contentType, configurer)
 }
 
 /**
@@ -132,15 +141,17 @@ suspend fun S3Client.putFromFile(
  * @throws IllegalArgumentException 파일이 존재하지 않을 경우
  * @see putFromFile
  */
-suspend fun S3Client.putFromPath(
+suspend inline fun S3Client.putFromPath(
     bucketName: String,
     key: String,
     path: Path,
     metadata: Map<String, String>? = null,
-    configurer: PutObjectRequest.Builder.() -> Unit = {},
+    acl: ObjectCannedAcl? = null,
+    contentType: String? = null,
+    crossinline configurer: PutObjectRequest.Builder.() -> Unit = {},
 ): PutObjectResponse {
     require(path.exists()) { "File not found: $path" }
-    return put(bucketName, key, ByteStream.fromFile(path.toFile()), metadata, configurer)
+    return put(bucketName, key, ByteStream.fromFile(path.toFile()), metadata, acl, contentType, configurer)
 }
 
 /**

--- a/aws-kotlin/s3/src/main/kotlin/io/bluetape4k/aws/kotlin/s3/model/Delete.kt
+++ b/aws-kotlin/s3/src/main/kotlin/io/bluetape4k/aws/kotlin/s3/model/Delete.kt
@@ -13,10 +13,16 @@ import aws.sdk.kotlin.services.s3.model.Delete
  * @param keys 삭제할 Object 의 키 목록
  * @return [Delete] 인스턴스
  */
-fun deleteOf(quiet: Boolean, vararg keys: String): Delete {
+@JvmName("deleteOfArray")
+inline fun deleteOf(
+    vararg keys: String,
+    quiet: Boolean? = null,
+    crossinline block: Delete.Builder.() -> Unit = {},
+): Delete {
     return Delete {
         this.objects = keys.map { it.toObjectIdentifier() }
         this.quiet = quiet
+        block()
     }
 }
 
@@ -31,9 +37,15 @@ fun deleteOf(quiet: Boolean, vararg keys: String): Delete {
  * @param keys 삭제할 Object 의 키 목록
  * @return [Delete] 인스턴스
  */
-fun deleteOf(quiet: Boolean, keys: Collection<String>): Delete {
+@JvmName("deleteOfCollection")
+inline fun deleteOf(
+    keys: Collection<String>,
+    quiet: Boolean? = null,
+    crossinline block: Delete.Builder.() -> Unit = {},
+): Delete {
     return Delete {
         this.objects = keys.map { it.toObjectIdentifier() }
         this.quiet = quiet
+        block()
     }
 }

--- a/aws-kotlin/s3/src/main/kotlin/io/bluetape4k/aws/kotlin/s3/model/ObjectIdentifier.kt
+++ b/aws-kotlin/s3/src/main/kotlin/io/bluetape4k/aws/kotlin/s3/model/ObjectIdentifier.kt
@@ -15,11 +15,17 @@ import io.bluetape4k.support.requireNotBlank
  *
  * @return [ObjectIdentifier] 인스턴스
  */
-fun objectIdentifierOf(key: String, versionId: String? = null): ObjectIdentifier {
+inline fun objectIdentifierOf(
+    key: String,
+    versionId: String? = null,
+    crossinline block: ObjectIdentifier.Builder.() -> Unit = {},
+): ObjectIdentifier {
     key.requireNotBlank("key")
+
     return ObjectIdentifier {
         this.key = key
         this.versionId = versionId
+        block()
     }
 }
 
@@ -35,5 +41,9 @@ fun objectIdentifierOf(key: String, versionId: String? = null): ObjectIdentifier
  *
  * @return [ObjectIdentifier] 인스턴스
  */
-fun String.toObjectIdentifier(versionId: String? = null): ObjectIdentifier =
-    objectIdentifierOf(this, versionId)
+fun String.toObjectIdentifier(
+    versionId: String? = null,
+    block: ObjectIdentifier.Builder.() -> Unit = {},
+): ObjectIdentifier {
+    return objectIdentifierOf(this, versionId, block)
+}

--- a/aws-kotlin/s3/src/test/kotlin/io/bluetape4k/aws/kotlin/s3/examples/BasicExamples.kt
+++ b/aws-kotlin/s3/src/test/kotlin/io/bluetape4k/aws/kotlin/s3/examples/BasicExamples.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldContainSame
 import org.amshove.kluent.shouldNotBeEmpty
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Test
@@ -57,6 +58,7 @@ class BasicExamples: AbstractKotlinS3Test() {
 
     @Test
     fun `Bucket의 모든 Object를 조회합니다`() = runSuspendIO {
+
         log.debug { "Bucket의 모든 Object를 조회합니다 ..." }
 
         // 테스트용 Bucket 생성
@@ -77,7 +79,7 @@ class BasicExamples: AbstractKotlinS3Test() {
         objects.forEach {
             log.debug { "Object info. key=${it.key}, size=${it.size}, owner=${it.owner}" }
         }
-        objects.map { it.key!! }.sorted() shouldBeEqualTo keys
+        objects.map { it.key!! } shouldContainSame keys
 
         s3Client.forceDeleteBucket(bucketName)
     }

--- a/aws-kotlin/ses/src/main/kotlin/io/bluetape4k/aws/kotlin/ses/SesClientExtensions.kt
+++ b/aws-kotlin/ses/src/main/kotlin/io/bluetape4k/aws/kotlin/ses/SesClientExtensions.kt
@@ -38,12 +38,12 @@ import io.bluetape4k.utils.ShutdownQueue
  * @param configurer SNS client 설정 빌더
  * @return [SnsClient] 인스턴스
  */
-fun snsClientOf(
+inline fun snsClientOf(
     endpoint: String? = null,
     region: String? = null,
     credentialsProvider: CredentialsProvider? = null,
     httpClientEngine: HttpClientEngine = defaultCrtHttpEngineOf(),
-    configurer: SesClient.Config.Builder.() -> Unit = {},
+    crossinline configurer: SesClient.Config.Builder.() -> Unit = {},
 ): SesClient = SesClient {
     endpoint?.let { this.endpointUrl = Url.parse(it) }
     region?.let { this.region = it }

--- a/aws-kotlin/ses/src/main/kotlin/io/bluetape4k/aws/kotlin/ses/model/Destination.kt
+++ b/aws-kotlin/ses/src/main/kotlin/io/bluetape4k/aws/kotlin/ses/model/Destination.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.aws.kotlin.ses.model
+
+import aws.sdk.kotlin.services.ses.model.Destination
+
+inline fun destinationOf(
+    vararg toAddress: String,
+    crossinline configurer: Destination.Builder.() -> Unit = {},
+): Destination {
+    return Destination {
+        this.toAddresses = toAddress.toList()
+
+        configurer()
+    }
+}
+
+fun destinationOf(
+    toAddresses: List<String>? = null,
+    ccAddresses: List<String>? = null,
+    bccAddresses: List<String>? = null,
+): Destination {
+    return Destination {
+        toAddresses?.let { this.toAddresses = it }
+        ccAddresses?.let { this.ccAddresses = it }
+        bccAddresses?.let { this.bccAddresses = it }
+    }
+}

--- a/aws-kotlin/ses/src/main/kotlin/io/bluetape4k/aws/kotlin/ses/model/Message.kt
+++ b/aws-kotlin/ses/src/main/kotlin/io/bluetape4k/aws/kotlin/ses/model/Message.kt
@@ -1,0 +1,52 @@
+package io.bluetape4k.aws.kotlin.ses.model
+
+import aws.sdk.kotlin.services.ses.model.Body
+import aws.sdk.kotlin.services.ses.model.Content
+import aws.sdk.kotlin.services.ses.model.Message
+
+inline fun contentOf(
+    data: String,
+    charset: String = Charsets.UTF_8.name(),
+    crossinline configurer: Content.Builder.() -> Unit = {},
+): Content {
+    return Content {
+        this.data = data
+        this.charset = charset
+
+        configurer()
+    }
+}
+
+inline fun htmlBodyOf(
+    html: Content? = null,
+    crossinline configurer: Body.Builder.() -> Unit = {},
+): Body {
+    return Body {
+        html?.let { this.html = it }
+        configurer()
+    }
+}
+
+inline fun textBodyOf(
+    text: Content? = null,
+    crossinline configurer: Body.Builder.() -> Unit = {},
+): Body {
+    return Body {
+        text?.let { this.text = it }
+        configurer()
+    }
+}
+
+
+inline fun messageOf(
+    subject: Content,
+    body: Body,
+    crossinline configurer: Message.Builder.() -> Unit = {},
+): Message {
+    return Message {
+        this.subject = subject
+        this.body = body
+
+        configurer()
+    }
+}

--- a/aws-kotlin/ses/src/main/kotlin/io/bluetape4k/aws/kotlin/ses/model/RawMessage.kt
+++ b/aws-kotlin/ses/src/main/kotlin/io/bluetape4k/aws/kotlin/ses/model/RawMessage.kt
@@ -1,0 +1,11 @@
+package io.bluetape4k.aws.kotlin.ses.model
+
+import aws.sdk.kotlin.services.ses.model.RawMessage
+
+fun rawMessageOf(
+    data: ByteArray,
+): RawMessage {
+    return RawMessage {
+        this.data = data
+    }
+}

--- a/aws-kotlin/ses/src/main/kotlin/io/bluetape4k/aws/kotlin/ses/model/SendEmailRequest.kt
+++ b/aws-kotlin/ses/src/main/kotlin/io/bluetape4k/aws/kotlin/ses/model/SendEmailRequest.kt
@@ -1,0 +1,17 @@
+package io.bluetape4k.aws.kotlin.ses.model
+
+import aws.sdk.kotlin.services.ses.model.Destination
+import aws.sdk.kotlin.services.ses.model.Message
+import aws.sdk.kotlin.services.ses.model.SendEmailRequest
+
+inline fun sendMailRequestOf(
+    source: String,
+    destination: Destination,
+    message: Message,
+    crossinline configurer: SendEmailRequest.Builder.() -> Unit = {},
+): SendEmailRequest = SendEmailRequest {
+    this.source = source
+    this.destination = destination
+    this.message = message
+    configurer()
+}

--- a/aws-kotlin/ses/src/main/kotlin/io/bluetape4k/aws/kotlin/ses/model/SendRawEmailRequest.kt
+++ b/aws-kotlin/ses/src/main/kotlin/io/bluetape4k/aws/kotlin/ses/model/SendRawEmailRequest.kt
@@ -1,0 +1,12 @@
+package io.bluetape4k.aws.kotlin.ses.model
+
+import aws.sdk.kotlin.services.ses.model.RawMessage
+import aws.sdk.kotlin.services.ses.model.SendRawEmailRequest
+
+inline fun sendRawEmailRequestOf(
+    rawMessage: RawMessage,
+    crossinline configurer: SendRawEmailRequest.Builder.() -> Unit = {},
+): SendRawEmailRequest = SendRawEmailRequest {
+    this.rawMessage = rawMessage
+    configurer()
+}

--- a/aws-kotlin/sns/src/main/kotlin/io/bluetape4k/aws/kotlin/sns/SnsClientExtensions.kt
+++ b/aws-kotlin/sns/src/main/kotlin/io/bluetape4k/aws/kotlin/sns/SnsClientExtensions.kt
@@ -52,12 +52,12 @@ import io.bluetape4k.utils.ShutdownQueue
  * @param configurer SNS client 설정 빌더
  * @return [SnsClient] 인스턴스
  */
-fun snsClientOf(
+inline fun snsClientOf(
     endpoint: String? = null,
     region: String? = null,
     credentialsProvider: CredentialsProvider? = null,
     httpClientEngine: HttpClientEngine = defaultCrtHttpEngineOf(),
-    configurer: SnsClient.Config.Builder.() -> Unit = {},
+    crossinline configurer: SnsClient.Config.Builder.() -> Unit = {},
 ): SnsClient = SnsClient {
     endpoint?.let { this.endpointUrl = Url.parse(it) }
     region?.let { this.region = it }
@@ -83,10 +83,10 @@ fun snsClientOf(
  * @param configurer 플랫폼 엔드포인트 생성 설정 빌더
  * @return [CreatePlatformEndpointResponse] 인스턴스
  */
-suspend fun SnsClient.createPlatformEndpoint(
+suspend inline fun SnsClient.createPlatformEndpoint(
     token: String,
     platformApplicationArn: String,
-    configurer: CreatePlatformEndpointRequest.Builder.() -> Unit = {},
+    crossinline configurer: CreatePlatformEndpointRequest.Builder.() -> Unit = {},
 ): CreatePlatformEndpointResponse {
     token.requireNotBlank("token")
     platformApplicationArn.requireNotBlank("platformApplicationArn")
@@ -112,10 +112,10 @@ suspend fun SnsClient.createPlatformEndpoint(
  * @param attributes topic 속성
  * @param configurer [CreateTopicRequest]를 빌드하는 람다 함수
  */
-suspend fun SnsClient.createTopic(
+suspend inline fun SnsClient.createTopic(
     topicName: String,
     attributes: Map<String, String>? = null,
-    configurer: CreateTopicRequest.Builder.() -> Unit = {},
+    crossinline configurer: CreateTopicRequest.Builder.() -> Unit = {},
 ): CreateTopicResponse {
     topicName.requireNotBlank("topicName")
 
@@ -140,10 +140,10 @@ suspend fun SnsClient.createTopic(
  * @param attributes topic 속성
  * @param configurer [CreateTopicRequest]를 빌드하는 람다 함수
  */
-suspend fun SnsClient.createFifoTopic(
+suspend inline fun SnsClient.createFifoTopic(
     topicName: String,
     attributes: MutableMap<String, String> = mutableMapOf(),
-    configurer: CreateTopicRequest.Builder.() -> Unit = {},
+    crossinline configurer: CreateTopicRequest.Builder.() -> Unit = {},
 ): CreateTopicResponse {
     topicName.requireNotBlank("topicName")
     require(topicName.endsWithIgnoreCase(".fifo")) { "FIFO topic name must end with .fifo" }
@@ -174,12 +174,12 @@ suspend fun SnsClient.createFifoTopic(
  * @param returnSubscriptionArn 구독 ARN 반환 여부
  * @param configurer [SubscribeRequest]를 빌드하는 람다 함수
  */
-suspend fun SnsClient.subscribe(
+suspend inline fun SnsClient.subscribe(
     topicArn: String,
     endpoint: String,
     protocol: String = "sms",
     returnSubscriptionArn: Boolean = true,
-    configurer: SubscribeRequest.Builder.() -> Unit = {},
+    crossinline configurer: SubscribeRequest.Builder.() -> Unit = {},
 ): SubscribeResponse {
     return subscribe {
         this.topicArn = topicArn
@@ -202,9 +202,9 @@ suspend fun SnsClient.subscribe(
  * @param configurer [CheckIfPhoneNumberIsOptedOutRequest]를 빌드하는 람다 함수
  * @return [CheckIfPhoneNumberIsOptedOutResponse] 인스턴스
  */
-suspend fun SnsClient.checkIfPhoneNumberIsOptedOut(
+suspend inline fun SnsClient.checkIfPhoneNumberIsOptedOut(
     phoneNumber: String,
-    configurer: CheckIfPhoneNumberIsOptedOutRequest.Builder.() -> Unit = {},
+    crossinline configurer: CheckIfPhoneNumberIsOptedOutRequest.Builder.() -> Unit = {},
 ): CheckIfPhoneNumberIsOptedOutResponse {
     phoneNumber.requireNotBlank("phoneNumber")
 
@@ -230,11 +230,11 @@ suspend fun SnsClient.checkIfPhoneNumberIsOptedOut(
  *
  * @return [PublishResponse] 인스턴스
  */
-suspend fun SnsClient.publish(
+suspend inline fun SnsClient.publish(
     topicArn: String,
     message: String,
     subject: String? = null,
-    configurer: PublishRequest.Builder.() -> Unit = {},
+    crossinline configurer: PublishRequest.Builder.() -> Unit = {},
 ): PublishResponse {
     topicArn.requireNotBlank("topicArn")
     message.requireNotBlank("message")
@@ -276,10 +276,10 @@ suspend fun SnsClient.publish(
  *
  * @return [PublishBatchResponse] 인스턴스
  */
-suspend fun SnsClient.publishBatch(
+suspend inline fun SnsClient.publishBatch(
     topicArn: String,
     entries: List<PublishBatchRequestEntry>,
-    configurer: PublishBatchRequest.Builder.() -> Unit = {},
+    crossinline configurer: PublishBatchRequest.Builder.() -> Unit = {},
 ): PublishBatchResponse {
     topicArn.requireNotBlank("topicArn")
 
@@ -302,9 +302,9 @@ suspend fun SnsClient.publishBatch(
  * @param configurer [UnsubscribeRequest]를 빌드하는 람다 함수
  * @return [UnsubscribeResponse] 인스턴스
  */
-suspend fun SnsClient.unsubscribe(
+suspend inline fun SnsClient.unsubscribe(
     subscriptionArn: String,
-    configurer: UnsubscribeRequest.Builder.() -> Unit = {},
+    crossinline configurer: UnsubscribeRequest.Builder.() -> Unit = {},
 ): UnsubscribeResponse {
     subscriptionArn.requireNotBlank("subscriptionArn")
 
@@ -325,9 +325,9 @@ suspend fun SnsClient.unsubscribe(
  * @param configurer [DeleteTopicRequest]를 빌드하는 람다 함수
  * @return [DeleteTopicResponse] 인스턴스
  */
-suspend fun SnsClient.deleteTopic(
+suspend inline fun SnsClient.deleteTopic(
     topicArn: String,
-    configurer: DeleteTopicRequest.Builder.() -> Unit = {},
+    crossinline configurer: DeleteTopicRequest.Builder.() -> Unit = {},
 ): DeleteTopicResponse {
     topicArn.requireNotBlank("topicArn")
 

--- a/aws-kotlin/sns/src/main/kotlin/io/bluetape4k/aws/kotlin/sns/model/GetTopicAttributes.kt
+++ b/aws-kotlin/sns/src/main/kotlin/io/bluetape4k/aws/kotlin/sns/model/GetTopicAttributes.kt
@@ -15,9 +15,9 @@ import io.bluetape4k.support.requireNotBlank
  * @param configurer [GetTopicAttributesRequest.Builder]를 통해 추가적인 설정을 할 수 있는 람다 함수
  * @return [GetTopicAttributesRequest] 인스턴스
  */
-fun getTopicAttributesRequestOf(
+inline fun getTopicAttributesRequestOf(
     topicArn: String,
-    configurer: GetTopicAttributesRequest.Builder.() -> Unit = {},
+    crossinline configurer: GetTopicAttributesRequest.Builder.() -> Unit = {},
 ): GetTopicAttributesRequest {
     topicArn.requireNotBlank("topicArn")
 

--- a/aws-kotlin/sns/src/main/kotlin/io/bluetape4k/aws/kotlin/sns/model/ListSubscriptions.kt
+++ b/aws-kotlin/sns/src/main/kotlin/io/bluetape4k/aws/kotlin/sns/model/ListSubscriptions.kt
@@ -15,9 +15,9 @@ import io.bluetape4k.support.requireNotBlank
  * @param configurer [ListSubscriptionsRequest.Builder]를 통해 추가적인 설정을 할 수 있는 람다 함수
  * @return [ListSubscriptionsRequest] 인스턴스
  */
-fun listSubscriptinosRequestOf(
+inline fun listSubscriptinosRequestOf(
     nextToken: String,
-    configurer: ListSubscriptionsRequest.Builder.() -> Unit = {},
+    crossinline configurer: ListSubscriptionsRequest.Builder.() -> Unit = {},
 ): ListSubscriptionsRequest {
     nextToken.requireNotBlank("nextToken")
 

--- a/aws-kotlin/sns/src/main/kotlin/io/bluetape4k/aws/kotlin/sns/model/ListTopics.kt
+++ b/aws-kotlin/sns/src/main/kotlin/io/bluetape4k/aws/kotlin/sns/model/ListTopics.kt
@@ -15,9 +15,9 @@ import io.bluetape4k.support.requireNotBlank
  * @param configurer [ListTopicsRequest.Builder]를 통해 추가적인 설정을 할 수 있는 람다 함수
  * @return [ListTopicsRequest] 인스턴스
  */
-fun listTopicsRequestOf(
+inline fun listTopicsRequestOf(
     nextToken: String,
-    configurer: ListTopicsRequest.Builder.() -> Unit = {},
+    crossinline configurer: ListTopicsRequest.Builder.() -> Unit = {},
 ): ListTopicsRequest {
     nextToken.requireNotBlank("nextToken")
 

--- a/aws-kotlin/sns/src/main/kotlin/io/bluetape4k/aws/kotlin/sns/model/MessageAttributeValue.kt
+++ b/aws-kotlin/sns/src/main/kotlin/io/bluetape4k/aws/kotlin/sns/model/MessageAttributeValue.kt
@@ -13,9 +13,9 @@ import aws.sdk.kotlin.services.sns.model.MessageAttributeValue
  * @param configurer [MessageAttributeValue.Builder]를 설정하는 람다
  * @return [MessageAttributeValue] 인스턴스
  */
-fun messageAttributeValueOf(
+inline fun messageAttributeValueOf(
     stringValue: String,
-    configurer: MessageAttributeValue.Builder.() -> Unit = {},
+    crossinline configurer: MessageAttributeValue.Builder.() -> Unit = {},
 ): MessageAttributeValue = MessageAttributeValue {
     this.stringValue = stringValue
     this.dataType = "String"
@@ -33,9 +33,9 @@ fun messageAttributeValueOf(
  * @param configurer [MessageAttributeValue.Builder]를 설정하는 람다
  * @return [MessageAttributeValue] 인스턴스
  */
-fun messageAttributeValueOf(
+inline fun messageAttributeValueOf(
     binaryValue: ByteArray,
-    configurer: MessageAttributeValue.Builder.() -> Unit = {},
+    crossinline configurer: MessageAttributeValue.Builder.() -> Unit = {},
 ): MessageAttributeValue = MessageAttributeValue {
     this.binaryValue = binaryValue
     this.dataType = "Binary"
@@ -53,9 +53,9 @@ fun messageAttributeValueOf(
  * @param configurer [MessageAttributeValue.Builder]를 설정하는 람다
  * @return [MessageAttributeValue] 인스턴스
  */
-fun <T: Number> messageAttributeValueOf(
+inline fun <T: Number> messageAttributeValueOf(
     numberValue: T,
-    configurer: MessageAttributeValue.Builder.() -> Unit = {},
+    crossinline configurer: MessageAttributeValue.Builder.() -> Unit = {},
 ): MessageAttributeValue = MessageAttributeValue {
     this.stringValue = numberValue.toString()
     this.dataType = "Number"

--- a/aws-kotlin/sns/src/main/kotlin/io/bluetape4k/aws/kotlin/sns/model/Publish.kt
+++ b/aws-kotlin/sns/src/main/kotlin/io/bluetape4k/aws/kotlin/sns/model/Publish.kt
@@ -26,7 +26,7 @@ import io.bluetape4k.support.requireNotBlank
  * @param configurer [PublishRequest.Builder]를 통해 추가적인 설정을 할 수 있는 람다 함수
  * @return [PublishRequest] 인스턴스
  */
-fun publishRequestOf(
+inline fun publishRequestOf(
     topicArn: String,
     phoneNumber: String,
     message: String,
@@ -35,7 +35,7 @@ fun publishRequestOf(
     messageAttributes: Map<String, MessageAttributeValue>? = null,
     messageDeduplicationId: String? = null,
     messageGroupId: String? = null,
-    configurer: PublishRequest.Builder.() -> Unit = {},
+    crossinline configurer: PublishRequest.Builder.() -> Unit = {},
 ): PublishRequest {
     topicArn.requireNotBlank("topicArn")
     phoneNumber.requireNotBlank("phoneNumber")
@@ -54,13 +54,13 @@ fun publishRequestOf(
     }
 }
 
-fun publishBatchRequestEntryOf(
+inline fun publishBatchRequestEntryOf(
     id: String,
     message: String,
     messageAttributes: Map<String, MessageAttributeValue>? = null,
     messageDeduplicationId: String? = null,
     messageGroupId: String? = null,
-    configurer: PublishBatchRequestEntry.Builder.() -> Unit = {},
+    crossinline configurer: PublishBatchRequestEntry.Builder.() -> Unit = {},
 ): PublishBatchRequestEntry {
     id.requireNotBlank("id")
     message.requireNotBlank("message")

--- a/aws-kotlin/sns/src/main/kotlin/io/bluetape4k/aws/kotlin/sns/model/Subscribe.kt
+++ b/aws-kotlin/sns/src/main/kotlin/io/bluetape4k/aws/kotlin/sns/model/Subscribe.kt
@@ -22,11 +22,11 @@ import io.bluetape4k.support.requireNotBlank
  * @param configurer [SubscribeRequest.Builder]를 통해 추가적인 설정을 할 수 있는 람다 함수
  * @return [SubscribeRequest] 인스턴스
  */
-fun subscribeRequestOf(
+inline fun subscribeRequestOf(
     topicArn: String,
     endpoint: String,
     protocol: String = "sms",
-    configurer: SubscribeRequest.Builder.() -> Unit = {},
+    crossinline configurer: SubscribeRequest.Builder.() -> Unit = {},
 ): SubscribeRequest {
     topicArn.requireNotBlank("topicArn")
     protocol.requireNotBlank("protocol")
@@ -52,9 +52,9 @@ fun subscribeRequestOf(
  * @param configurer [UnsubscribeRequest.Builder]를 통해 추가적인 설정을 할 수 있는 람다 함수
  * @return [UnsubscribeRequest] 인스턴스
  */
-fun unsubscribeRequestOf(
+inline fun unsubscribeRequestOf(
     subscriptionArn: String,
-    configurer: UnsubscribeRequest.Builder.() -> Unit,
+    crossinline configurer: UnsubscribeRequest.Builder.() -> Unit = {},
 ): UnsubscribeRequest {
     subscriptionArn.requireNotBlank("subscriptionArn")
 

--- a/aws-kotlin/sns/src/main/kotlin/io/bluetape4k/aws/kotlin/sns/model/Topic.kt
+++ b/aws-kotlin/sns/src/main/kotlin/io/bluetape4k/aws/kotlin/sns/model/Topic.kt
@@ -19,11 +19,11 @@ import io.bluetape4k.support.requireNotBlank
  * @param configurer [CreateTopicRequest.Builder] 를 통해 추가적인 설정을 할 수 있는 람다 함수
  * @return [CreateTopicRequest] 인스턴스
  */
-fun createTopicRequestOf(
+inline fun createTopicRequestOf(
     name: String,
     tags: List<Tag>? = null,
     attributes: Map<String, String>? = null,
-    configurer: CreateTopicRequest.Builder.() -> Unit = {},
+    crossinline configurer: CreateTopicRequest.Builder.() -> Unit = {},
 ): CreateTopicRequest {
     name.requireNotBlank("name")
 
@@ -48,9 +48,9 @@ fun createTopicRequestOf(
  * @param configurer [DeleteTopicRequest.Builder] 를 통해 추가적인 설정을 할 수 있는 람다 함수
  * @return [DeleteTopicRequest] 인스턴스
  */
-fun deleteTopicRequestOf(
+inline fun deleteTopicRequestOf(
     topicArn: String,
-    configurer: DeleteTopicRequest.Builder.() -> Unit = {},
+    crossinline configurer: DeleteTopicRequest.Builder.() -> Unit = {},
 ): DeleteTopicRequest {
     topicArn.requireNotBlank("topicArn")
 

--- a/aws-kotlin/sqs/src/main/kotlin/io/bluetape4k/aws/kotlin/sqs/model/DeleteMessage.kt
+++ b/aws-kotlin/sqs/src/main/kotlin/io/bluetape4k/aws/kotlin/sqs/model/DeleteMessage.kt
@@ -12,10 +12,10 @@ import io.bluetape4k.support.requireNotBlank
  * @param receiptHandle 삭제할 메시지와 연관된 영수증 핸들입니다.
  * @param configurer DeleteMessageRequest.Builder를 사용하여 DeleteMessageRequest를 구성하는 람다입니다.
  */
-fun deleteMessageRequestOf(
+inline fun deleteMessageRequestOf(
     queueUrl: String,
     receiptHandle: String? = null,
-    configurer: DeleteMessageRequest.Builder.() -> Unit = {},
+    crossinline configurer: DeleteMessageRequest.Builder.() -> Unit = {},
 ): DeleteMessageRequest {
     queueUrl.requireNotBlank("queueUrl")
 
@@ -33,15 +33,18 @@ fun deleteMessageRequestOf(
  * @param receiptHandle 삭제할 메시지와 연관된 영수증 핸들입니다.
  * @return DeleteMessageBatchRequestEntry 인스턴스를 반환합니다.
  */
-fun deleteMessageBatchRequestEntryOf(
+inline fun deleteMessageBatchRequestEntryOf(
     id: String,
     receiptHandle: String? = null,
+    crossinline configurer: DeleteMessageBatchRequestEntry.Builder.() -> Unit = {},
 ): DeleteMessageBatchRequestEntry {
     id.requireNotBlank("id")
 
     return DeleteMessageBatchRequestEntry {
         this.id = id
         receiptHandle?.let { this.receiptHandle = it }
+
+        configurer()
     }
 }
 
@@ -52,15 +55,18 @@ fun deleteMessageBatchRequestEntryOf(
  * @param entries DeleteMessageBatchRequestEntry 인스턴스의 컬렉션입니다.
  * @return DeleteMessageBatchRequest 인스턴스를 반환합니다.
  */
-fun deleteMessageBatchRequestOf(
+inline fun deleteMessageBatchRequestOf(
     queueUrl: String,
     entries: Collection<DeleteMessageBatchRequestEntry>,
+    crossinline configurer: DeleteMessageBatchRequest.Builder.() -> Unit = {},
 ): DeleteMessageBatchRequest {
     queueUrl.requireNotBlank("queueUrl")
 
     return DeleteMessageBatchRequest {
         this.queueUrl = queueUrl
         this.entries = entries.toList()
+
+        configurer()
     }
 }
 
@@ -71,14 +77,17 @@ fun deleteMessageBatchRequestOf(
  * @param entries DeleteMessageBatchRequestEntry 인스턴스의 컬렉션입니다.
  * @return DeleteMessageBatchRequest 인스턴스를 반환합니다.
  */
-fun deleteMessageBatchRequestOf(
+inline fun deleteMessageBatchRequestOf(
     queueUrl: String,
     vararg entries: DeleteMessageBatchRequestEntry,
+    crossinline configurer: DeleteMessageBatchRequest.Builder.() -> Unit = {},
 ): DeleteMessageBatchRequest {
     queueUrl.requireNotBlank("queueUrl")
 
     return DeleteMessageBatchRequest {
         this.queueUrl = queueUrl
         this.entries = entries.toList()
+
+        configurer()
     }
 }

--- a/aws-kotlin/sqs/src/main/kotlin/io/bluetape4k/aws/kotlin/sqs/model/MessageAttributeValue.kt
+++ b/aws-kotlin/sqs/src/main/kotlin/io/bluetape4k/aws/kotlin/sqs/model/MessageAttributeValue.kt
@@ -3,25 +3,44 @@ package io.bluetape4k.aws.kotlin.sqs.model
 import aws.sdk.kotlin.services.sqs.model.MessageAttributeValue
 
 @JvmName("messageAttributeValueOfNullableString")
-fun messageAttributeValueOf(value: String?): MessageAttributeValue =
+inline fun messageAttributeValueOf(
+    value: String?,
+    crossinline configurer: MessageAttributeValue.Builder.() -> Unit = {},
+): MessageAttributeValue =
     MessageAttributeValue {
         stringValue = value
+        configurer()
     }
 
 @JvmName("messageAttributeValueOfNullableStringList")
-fun messageAttributeValueOf(values: List<String>?): MessageAttributeValue =
+inline fun messageAttributeValueOf(
+    values: List<String>?,
+    crossinline configurer: MessageAttributeValue.Builder.() -> Unit = {},
+): MessageAttributeValue =
     MessageAttributeValue {
         stringListValues = values
+
+        configurer()
     }
 
 @JvmName("messageAttributeValueOfNullableByteArray")
-fun messageAttributeValueOf(value: ByteArray?): MessageAttributeValue =
+inline fun messageAttributeValueOf(
+    value: ByteArray?,
+    crossinline configurer: MessageAttributeValue.Builder.() -> Unit = {},
+): MessageAttributeValue =
     MessageAttributeValue {
         binaryValue = value
+
+        configurer()
     }
 
 @JvmName("messageAttributeValueOfNullableByteArrayList")
-fun messageAttributeValueOf(values: List<ByteArray>?): MessageAttributeValue =
+inline fun messageAttributeValueOf(
+    values: List<ByteArray>?,
+    crossinline configurer: MessageAttributeValue.Builder.() -> Unit = {},
+): MessageAttributeValue =
     MessageAttributeValue {
         binaryListValues = values
+
+        configurer()
     }

--- a/aws-kotlin/sqs/src/main/kotlin/io/bluetape4k/aws/kotlin/sqs/model/MessageVisibility.kt
+++ b/aws-kotlin/sqs/src/main/kotlin/io/bluetape4k/aws/kotlin/sqs/model/MessageVisibility.kt
@@ -13,10 +13,11 @@ import io.bluetape4k.support.requireNotBlank
  * @param visibilityTimeout 메시지의 새로운 VisibilityTimeout(초)입니다. 기본값은 null입니다.
  * @return [ChangeMessageVisibilityRequest] 인스턴스를 반환합니다.
  */
-fun changeMessageVisibilityRequestOf(
+inline fun changeMessageVisibilityRequestOf(
     queueUrl: String,
     receiptHandle: String,
     visibilityTimeout: Int? = null,
+    crossinline configurer: ChangeMessageVisibilityRequest.Builder.() -> Unit = {},
 ): ChangeMessageVisibilityRequest {
     queueUrl.requireNotBlank("queueUrl")
     receiptHandle.requireNotBlank("receiptHandle")
@@ -25,6 +26,8 @@ fun changeMessageVisibilityRequestOf(
         this.queueUrl = queueUrl
         this.receiptHandle = receiptHandle
         this.visibilityTimeout = visibilityTimeout
+
+        configurer()
     }
 }
 
@@ -36,10 +39,11 @@ fun changeMessageVisibilityRequestOf(
  * @param receiptHandle Visibility를 변경할 메시지와 연관된 영수증 핸들입니다.
  * @param visibilityTimeout 메시지의 새로운 VisibilityTimeout(초)입니다. 기본값은 null입니다.
  */
-fun changeMessageVisibilityBatchRequestEntryOf(
+inline fun changeMessageVisibilityBatchRequestEntryOf(
     id: String,
     receiptHandle: String,
     visibilityTimeout: Int? = null,
+    crossinline configurer: ChangeMessageVisibilityBatchRequestEntry.Builder.() -> Unit = {},
 ): ChangeMessageVisibilityBatchRequestEntry {
     id.requireNotBlank("id")
     receiptHandle.requireNotBlank("receiptHandle")
@@ -48,6 +52,8 @@ fun changeMessageVisibilityBatchRequestEntryOf(
         this.id = id
         this.receiptHandle = receiptHandle
         this.visibilityTimeout = visibilityTimeout
+
+        configurer()
     }
 }
 
@@ -58,15 +64,19 @@ fun changeMessageVisibilityBatchRequestEntryOf(
  * @param entries ChangeMessageVisibilityBatchRequestEntry 인스턴스의 컬렉션입니다.
  * @return [ChangeMessageVisibilityBatchRequest] 인스턴스를 반환합니다.
  */
-fun changeMessageVisibilityBatchRequestOf(
+@JvmName("changeMessageVisibilityBatchRequestOfCollection")
+inline fun changeMessageVisibilityBatchRequestOf(
     queueUrl: String,
     entries: Collection<ChangeMessageVisibilityBatchRequestEntry>,
+    crossinline configurer: ChangeMessageVisibilityBatchRequest.Builder.() -> Unit = {},
 ): ChangeMessageVisibilityBatchRequest {
     queueUrl.requireNotBlank("queueUrl")
 
     return ChangeMessageVisibilityBatchRequest {
         this.queueUrl = queueUrl
         this.entries = entries.toList()
+
+        configurer()
     }
 }
 
@@ -78,14 +88,18 @@ fun changeMessageVisibilityBatchRequestOf(
  * @param entries ChangeMessageVisibilityBatchRequestEntry 인스턴스의 컬렉션입니다.
  * @return [ChangeMessageVisibilityBatchRequest] 인스턴스를 반환합니다.
  */
-fun changeMessageVisibilityBatchRequestOf(
+@JvmName("changeMessageVisibilityBatchRequestOfVararg")
+inline fun changeMessageVisibilityBatchRequestOf(
     queueUrl: String,
     vararg entries: ChangeMessageVisibilityBatchRequestEntry,
+    crossinline configurer: ChangeMessageVisibilityBatchRequest.Builder.() -> Unit = {},
 ): ChangeMessageVisibilityBatchRequest {
     queueUrl.requireNotBlank("queueUrl")
 
     return ChangeMessageVisibilityBatchRequest {
         this.queueUrl = queueUrl
         this.entries = entries.toList()
+
+        configurer()
     }
 }

--- a/aws-kotlin/sqs/src/main/kotlin/io/bluetape4k/aws/kotlin/sqs/model/ReceiveMessage.kt
+++ b/aws-kotlin/sqs/src/main/kotlin/io/bluetape4k/aws/kotlin/sqs/model/ReceiveMessage.kt
@@ -15,13 +15,13 @@ import io.bluetape4k.support.requirePositiveNumber
  * @param configurer ReceiveMessageRequest.Builder를 초기화하는 람다입니다. 기본값은 빈 람다입니다.
  * @return ReceiveMessageRequest 인스턴스를 반환합니다.
  */
-fun receiveMessageRequestOf(
+inline fun receiveMessageRequestOf(
     queueUrl: String,
     maxNumberOfMessages: Int = 3,
     waitTimeSeconds: Int = 30,
     visibilityTimeout: Int? = null,
     attributeNames: Collection<String>? = null,
-    configurer: ReceiveMessageRequest.Builder.() -> Unit = {},
+    crossinline configurer: ReceiveMessageRequest.Builder.() -> Unit = {},
 ): ReceiveMessageRequest {
     queueUrl.requireNotBlank("queueUrl")
     maxNumberOfMessages.requirePositiveNumber("maxNumberOfMessages")

--- a/aws-kotlin/sqs/src/main/kotlin/io/bluetape4k/aws/kotlin/sqs/model/SendMessage.kt
+++ b/aws-kotlin/sqs/src/main/kotlin/io/bluetape4k/aws/kotlin/sqs/model/SendMessage.kt
@@ -13,11 +13,11 @@ import io.bluetape4k.support.requireNotBlank
  * @param delaySeconds 메시지를 보내기 전 대기할 시간(초)입니다. 기본값은 null입니다.
  * @param configurer SendMessageRequest.Builder를 초기화하는 람다입니다. 기본값은 빈 람다입니다.
  */
-fun sendMessageRequestOf(
+inline fun sendMessageRequestOf(
     queueUrl: String,
     messageBody: String,
     delaySeconds: Int? = null,
-    configurer: SendMessageRequest.Builder.() -> Unit = {},
+    crossinline configurer: SendMessageRequest.Builder.() -> Unit = {},
 ): SendMessageRequest {
     queueUrl.requireNotBlank("queueUrl")
     messageBody.requireNotBlank("messageBody")
@@ -42,12 +42,12 @@ fun sendMessageRequestOf(
  *
  * @return SendMessageBatchRequestEntry 인스턴스를 반환합니다.
  */
-fun sendMessageBatchRequestEntryOf(
+inline fun sendMessageBatchRequestEntryOf(
     id: String,
     messageBody: String,
     messageGroupId: String? = null,
     delaySeconds: Int? = null,
-    configurer: SendMessageBatchRequestEntry.Builder.() -> Unit = {},
+    crossinline configurer: SendMessageBatchRequestEntry.Builder.() -> Unit = {},
 ): SendMessageBatchRequestEntry {
     id.requireNotBlank("id")
     messageBody.requireNotBlank("messageBody")
@@ -69,15 +69,19 @@ fun sendMessageBatchRequestEntryOf(
  * @param entries SendMessageBatchRequestEntry 인스턴스의 컬렉션입니다.
  * @return SendMessageBatchRequest 인스턴스를 반환합니다.
  */
-fun sendMessageBatchRequestOf(
+@JvmName("sendMessageBatchRequestOfCollection")
+inline fun sendMessageBatchRequestOf(
     queueUrl: String,
     entries: Collection<SendMessageBatchRequestEntry>,
+    crossinline configurer: SendMessageBatchRequest.Builder.() -> Unit = {},
 ): SendMessageBatchRequest {
     queueUrl.requireNotBlank("queueUrl")
 
     return SendMessageBatchRequest {
         this.queueUrl = queueUrl
         this.entries = entries.toList()
+
+        configurer()
     }
 }
 
@@ -88,14 +92,18 @@ fun sendMessageBatchRequestOf(
  * @param entries SendMessageBatchRequestEntry 인스턴스의 배열입니다.
  * @return SendMessageBatchRequest 인스턴스를 반환합니다.
  */
-fun sendMessageBatchRequestOf(
+@JvmName("sendMessageBatchRequestOfArray")
+inline fun sendMessageBatchRequestOf(
     queueUrl: String,
     vararg entries: SendMessageBatchRequestEntry,
+    crossinline configurer: SendMessageBatchRequest.Builder.() -> Unit = {},
 ): SendMessageBatchRequest {
     queueUrl.requireNotBlank("queueUrl")
 
     return SendMessageBatchRequest {
         this.queueUrl = queueUrl
         this.entries = entries.toList()
+
+        configurer()
     }
 }

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -95,10 +95,10 @@ object Versions {
     const val resilience4j = "2.2.0"   // https://mvnrepository.com/artifact/io.github.resilience4j/resilience4j-bom
     const val netty = "4.1.115.Final"  // https://mvnrepository.com/artifact/io.netty/netty-all
 
-    const val aws = "1.12.772"    // https://mvnrepository.com/artifact/com.amazonaws
-    const val aws2 = "2.29.26"   // https://mvnrepository.com/artifact/software.amazon.awssdk/aws-sdk-java
-    const val aws2_crt = "0.33.5" // https://mvnrepository.com/artifact/software.amazon.awssdk.crt
-    const val aws_kotlin = "1.3.87" // https://mvnrepository.com/artifact/aws.sdk.kotlin
+    const val aws = "1.12.782"      // https://mvnrepository.com/artifact/com.amazonaws
+    const val aws2 = "2.30.33"      // https://mvnrepository.com/artifact/software.amazon.awssdk/aws-sdk-java
+    const val aws2_crt = "0.36.1"   // https://mvnrepository.com/artifact/software.amazon.awssdk.crt
+    const val aws_kotlin = "1.4.34" // https://mvnrepository.com/artifact/aws.sdk.kotlin
     const val aws_smithy_kotlin = "1.3.28" // https://mvnrepository.com/artifact/aws.smithy.kotlin/http-client-engine-crt-jvm
 
     const val grpc = "1.68.2"       // https://mvnrepository.com/artifact/io.grpc/grpc-stub


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: AWS Kotlin Client 함수들을 inline 로 변경

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #24, head `cecb3ecaaa2292ff80c682c578ca17047608f12d`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feature/aws-kotlin`
- Labels: `enhancement`
- State: `MERGED`, merge commit `9f10f4d4b16f9b569ccc188151285cf1473d2833`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #24 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9f10f4d4b16f9b569ccc188151285cf1473d2833`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
