### PR TITLE
Spring Modultih Event 관리를 Exposed 를 사용하는 방식 제공 

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -66,6 +66,7 @@ object Versions {
     const val spring_integration = "6.4.1"  // https://mvnrepository.com/artifact/org.springframework.integration/spring-integration-core
     const val reactor_bom = "2024.0.1"      // https://mvnrepository.com/artifact/io.projectreactor/reactor-bom
     const val spring_statemachine = "4.0.0" // https://mvnrepository.com/artifact/org.springframework.statemachine/spring-statemachine-core
+    const val spring_modulith = "1.3.3"     // https://mvnrepository.com/artifact/org.springframework.modulith/spring-modulith-bom
 
     // https://mvnrepository.com/artifact/de.codecentric/chaos-monkey-spring-boot
     const val chaos_monkey = "3.0.2"
@@ -457,12 +458,49 @@ object Libs {
     val spring_integration_xmpp = springIntegration("xmpp")
     val spring_integration_zookeeper = springIntegration("zookeeper")
 
-
     fun springStatemachine(module: String) =
         "org.springframework.statemachine:spring-statemachine-$module:${Versions.spring_statemachine}"
 
     val spring_statemachine_bom = springStatemachine("bom")
     val spring_statemachine_core = springStatemachine("core")
+
+    // Spring Modulith
+    fun springModulith(module: String) = "org.springframework.modulith:spring-modulith-$module:${Versions.spring_modulith}"
+    fun springModulithEvents(module: String) = springModulith("events-$module")
+    fun springModulithStarter(module: String) = springModulith("starter-$module")
+
+    val spring_modulith_bom = springModulith("bom")
+
+    val spring_modulith_actuator = springModulith("actuator")
+    val spring_modulith_api = springModulith("api")
+    val spring_modulith_apt = springModulith("apt")
+    val spring_modulith_core = springModulith("core")
+    val spring_modulith_docs = springModulith("docs")
+    val spring_modulith_junit = springModulith("junit")
+    val spring_modulith_moments = springModulith("moments")
+    val spring_modulith_observability = springModulith("observability")
+    val spring_modulith_test = springModulith("test")
+
+    val spring_modulith_events_amqp = springModulithEvents("amqp")
+    val spring_modulith_events_api = springModulithEvents("api")
+    val spring_modulith_events_aws_sns = springModulithEvents("aws-sns")
+    val spring_modulith_events_aws_sqs = springModulithEvents("aws-sqs")
+    val spring_modulith_events_core = springModulithEvents("core")
+    val spring_modulith_events_jackson = springModulithEvents("jackson")
+    val spring_modulith_events_jpa = springModulithEvents("jpa")
+    val spring_modulith_events_kafka = springModulithEvents("kafka")
+    val spring_modulith_events_messaging = springModulithEvents("messaging")
+    val spring_modulith_events_mongodb = springModulithEvents("mongodb")
+    val spring_modulith_events_tests = springModulithEvents("tests")
+
+    val spring_modulith_starter_core = springModulithStarter("core")
+    val spring_modulith_starter_insight = springModulithStarter("insight")
+    val spring_modulith_starter_jdbc = springModulithStarter("jdbc")
+    val spring_modulith_starter_jpa = springModulithStarter("jpa")
+    val spring_modulith_starter_mongodb = springModulithStarter("mongodb")
+    val spring_modulith_starter_neo4j = springModulithStarter("neo4j")
+    val spring_modulith_starter_test = springModulithStarter("test")
+
 
     // Chaos Monkey (https://github.com/codecentric/chaos-monkey-spring-boot)
     const val chaos_monkey_spring_boot = "de.codecentric:chaos-monkey-spring-boot:${Versions.chaos_monkey}"

--- a/data/exposed-spring-modulith-events/README.md
+++ b/data/exposed-spring-modulith-events/README.md
@@ -1,0 +1,4 @@
+# Module exposed-spring-modulith-events
+
+Spring Modulith 의 Events 를 관리하는 방식 중 DB를 사용하는 방식은 공식적으로 JDBC, JPA 방식을 지원합니다. 여기서는 JDBC, JPA 대신 Jetbrains Exposed 를 사용하여
+DB에 Events 를 저장하는 방법을 제공합니다.

--- a/data/exposed-spring-modulith-events/build.gradle.kts
+++ b/data/exposed-spring-modulith-events/build.gradle.kts
@@ -1,0 +1,24 @@
+@file:Suppress("UnstableApiUsage")
+
+plugins {
+    kotlin("kapt")
+    kotlin("plugin.noarg")
+    kotlin("plugin.allopen")
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+
+    // Spring Modulith
+    implementation(platform(Libs.spring_modulith_bom))
+    api(Libs.spring_modulith_events_core)
+
+    implementation(Libs.springBoot("autoconfigure"))
+
+    // Exposed
+
+
+}


### PR DESCRIPTION
## Summary

Refs #25

- PR 제목: Spring Modultih Event 관리를 Exposed 를 사용하는 방식 제공

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #25, milestone 없음, assignee `debop`
- PR: #26, head `45271846fb214628dfad3112e4f512ed9dc370c9`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feature/exposed-spring-modulith`
- Labels: `enhancement`
- State: `CLOSED`, merge commit `N/A`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #26 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: CLOSED (not merged; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
