### PR TITLE
fix: ZipKin, Pulsar, RabbitMQ 의 버전을 낮춰서 제대로 실행되게 했습니다.

### DIFF
--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ZipkinServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ZipkinServer.kt
@@ -27,7 +27,7 @@ class ZipkinServer private constructor(
     companion object: KLogging() {
         const val IMAGE = "openzipkin/zipkin-slim"
         const val NAME = "zipkin"
-        const val TAG = "3"
+        const val TAG = "2.23"      // NOTE: 2.24 이상에서는 예외가 발생합니다. 꼭 2.23으로 고정하세요!!!
         const val PORT = 9411
 
         @JvmStatic
@@ -57,9 +57,7 @@ class ZipkinServer private constructor(
         addExposedPorts(PORT)
         withReuse(reuse)
 
-        withCreateContainerCmdModifier { cmd ->
-            cmd.withPlatform("linux/arm64")  // for Apple Silicon
-        }
+//        withEnv("JAVA_OPTS", "--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED -XX:+UnlockExperimentalVMOptions")
 
         setWaitStrategy(Wait.forListeningPort())
 

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/PulsarServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/PulsarServer.kt
@@ -37,7 +37,7 @@ class PulsarServer private constructor(
 
     companion object: KLogging() {
         const val IMAGE = "apachepulsar/pulsar"
-        const val TAG = "4.0.2"
+        const val TAG = "3.3.5"                    // NOTE: 4.+ 버전은 Java 17 이상 필요하다고 예외가 발생한다.
         const val NAME = "pulsar"
         const val PORT = BROKER_PORT
         const val HTTP_PORT = BROKER_HTTP_PORT

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/RabbitMQServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/RabbitMQServer.kt
@@ -26,7 +26,7 @@ class RabbitMQServer private constructor(
 
     companion object: KLogging() {
         const val IMAGE = "rabbitmq"
-        const val TAG = "4"
+        const val TAG = "3.13"           // NOTE: 4 이상을 실행하면 예외가 발생합니다.
 
         const val NAME = "rabbitmq"
 

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/mq/RabbitMQServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/mq/RabbitMQServerTest.kt
@@ -10,7 +10,6 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
@@ -38,8 +37,7 @@ class RabbitMQServerTest {
         @Test
         fun `connect to rabbitmq server`() {
             rabbitMQ.isRunning.shouldBeTrue()
-            log.debug { "host=${rabbitMQ.host}" }
-            log.debug { "port=${rabbitMQ.port}" }
+            log.debug { "host=${rabbitMQ.host}, port=${rabbitMQ.port}" }
 
             val factory = ConnectionFactory().apply {
                 host = rabbitMQ.host
@@ -85,7 +83,6 @@ class RabbitMQServerTest {
         }
     }
 
-    @Disabled("Local에서 Default 와 Docker 를 동시에 실행하면 테스트가 실패합니다.")
     @Nested
     inner class Default {
         @Test


### PR DESCRIPTION
## Summary

Closes #22, #23

- PR 제목: fix: ZipKin, Pulsar, RabbitMQ 의 버전을 낮춰서 제대로 실행되게 했습니다.

### 원문 선행 내용

ZipKin (2.23), Pulsar (3.3.5), RabbitMQ (3.13) 로 버전을 낮춰서 Mac M4 에서 실행되는 것을 확인했습니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

ZipKin (2.23), Pulsar (3.3.5), RabbitMQ (3.13) 로 버전을 낮춰서 Mac M4 에서 실행되는 것을 확인했습니다.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #22, #23, milestone 없음, assignee `debop`
- PR: #28, head `d5acea67f5ae3535ffd4810d7872307a2a674a28`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feature/testcontainers`
- Labels: `enhancement`
- State: `MERGED`, merge commit `6af4eaf52755f5b4d26f26974915f36b351baa8c`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #28 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `6af4eaf52755f5b4d26f26974915f36b351baa8c`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
