### PR TITLE
docs/test: bluetape4k-aws-kotlin-kms 코드 리뷰 및 개선

### DIFF
--- a/aws-kotlin/kms/README.md
+++ b/aws-kotlin/kms/README.md
@@ -1,3 +1,189 @@
 # Module bluetape4k-aws-kotlin-kms
 
-AWS SDK for Kotlin KMS 사용을 위한 확장 라이브러리입니다.
+AWS SDK for Kotlin KMS(Key Management Service) 사용을 위한 확장 라이브러리입니다.
+
+## 개요
+
+AWS KMS는 암호화 키를 생성하고 관리하는 AWS 관리형 서비스입니다.
+이 모듈은 AWS SDK for Kotlin의 `KmsClient`를 보다 편리하게 생성하고 사용할 수 있도록
+Kotlin 스타일의 DSL 팩토리 함수를 제공합니다.
+
+## 주요 기능
+
+- `kmsClientOf()` - Kotlin DSL 스타일의 `KmsClient` 팩토리 함수
+- LocalStack 기반 통합 테스트 지원 (`AbstractKmsTest`)
+
+## 의존성
+
+```kotlin
+dependencies {
+    implementation("io.bluetape4k:bluetape4k-aws-kotlin-kms:$version")
+}
+```
+
+## 사용 방법
+
+### KmsClient 생성
+
+```kotlin
+import aws.smithy.kotlin.runtime.net.url.Url
+import io.bluetape4k.aws.kotlin.kms.kmsClientOf
+
+// 기본 사용 (환경 변수 또는 IAM Role로 자동 인증)
+val client = kmsClientOf(
+    region = "ap-northeast-2"
+)
+
+// 엔드포인트 직접 지정 (LocalStack 등 로컬 환경)
+val localClient = kmsClientOf(
+    endpointUrl = Url.parse("http://localhost:4566"),
+    region = "us-east-1",
+    credentialsProvider = myCredentialsProvider
+)
+
+// 추가 설정이 필요한 경우 builder 람다 활용
+val customClient = kmsClientOf(
+    region = "ap-northeast-2"
+) {
+    retryStrategy = myRetryStrategy
+}
+```
+
+### 대칭 키 생성 및 암호화/복호화
+
+```kotlin
+import aws.sdk.kotlin.services.kms.createKey
+import aws.sdk.kotlin.services.kms.encrypt
+import aws.sdk.kotlin.services.kms.decrypt
+import aws.sdk.kotlin.services.kms.model.KeySpec
+import aws.sdk.kotlin.services.kms.model.KeyUsageType
+import io.bluetape4k.support.toUtf8Bytes
+import io.bluetape4k.support.toUtf8String
+
+// 대칭 키 생성
+val createResp = client.createKey {
+    keySpec = KeySpec.SymmetricDefault
+    keyUsage = KeyUsageType.EncryptDecrypt
+    description = "애플리케이션 데이터 암호화 키"
+}
+val keyId = createResp.keyMetadata?.keyId!!
+
+// 데이터 암호화
+val plaintext = "민감한 데이터"
+val encryptResp = client.encrypt {
+    this.keyId = keyId
+    this.plaintext = plaintext.toUtf8Bytes()
+}
+val ciphertext = encryptResp.ciphertextBlob!!
+
+// 데이터 복호화
+val decryptResp = client.decrypt {
+    this.keyId = keyId
+    this.ciphertextBlob = ciphertext
+}
+val decrypted = decryptResp.plaintext!!.toUtf8String()
+```
+
+### Alias(별칭) 관리
+
+```kotlin
+import aws.sdk.kotlin.services.kms.createAlias
+import aws.sdk.kotlin.services.kms.listAliases
+import aws.sdk.kotlin.services.kms.deleteAlias
+
+// Alias 생성 (반드시 "alias/" 접두사 필요)
+client.createAlias {
+    aliasName = "alias/my-app-key"
+    targetKeyId = keyId
+}
+
+// Alias 목록 조회
+val aliases = client.listAliases { limit = 100 }.aliases
+
+// Alias 삭제
+client.deleteAlias { aliasName = "alias/my-app-key" }
+```
+
+### Grant(권한 위임) 관리
+
+```kotlin
+import aws.sdk.kotlin.services.kms.createGrant
+import aws.sdk.kotlin.services.kms.listGrants
+import aws.sdk.kotlin.services.kms.revokeGrant
+import aws.sdk.kotlin.services.kms.model.GrantOperation
+
+// Grant 생성
+val grantResp = client.createGrant {
+    this.keyId = keyId
+    granteePrincipal = "arn:aws:iam::123456789012:role/MyAppRole"
+    operations = listOf(GrantOperation.Encrypt, GrantOperation.Decrypt)
+}
+val grantId = grantResp.grantId!!
+
+// Grant 목록 조회
+val grants = client.listGrants {
+    this.keyId = keyId
+    limit = 100
+}.grants
+
+// Grant 취소
+client.revokeGrant {
+    this.keyId = keyId
+    this.grantId = grantId
+}
+```
+
+### 키 정책(Key Policy) 설정
+
+```kotlin
+import aws.sdk.kotlin.services.kms.putKeyPolicy
+
+val policy = """
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+                "Action": "kms:*",
+                "Resource": "*"
+            }
+        ]
+    }
+""".trimIndent()
+
+client.putKeyPolicy {
+    this.keyId = keyId
+    policyName = "default"
+    this.policy = policy
+}
+```
+
+## 테스트
+
+이 모듈은 [LocalStack](https://localstack.cloud/)을 사용한 통합 테스트를 제공합니다.
+테스트 실행 시 Docker가 설치되어 있어야 합니다.
+
+```bash
+# 특정 모듈 테스트 실행
+./gradlew :bluetape4k-aws-kotlin-kms:test
+
+# 특정 테스트 클래스 실행
+./gradlew :bluetape4k-aws-kotlin-kms:test --tests "io.bluetape4k.aws.kotlin.kms.KmsClientTest"
+```
+
+## 관련 모듈
+
+| 모듈 | 설명 |
+|------|------|
+| `bluetape4k-aws-kotlin-core` | AWS Kotlin SDK 공통 유틸리티 |
+| `bluetape4k-aws-kotlin-tests` | AWS Kotlin SDK 테스트 지원 (LocalStack) |
+| `bluetape4k-aws-kms` | AWS Java SDK v2 기반 KMS 확장 (동기/비동기 클라이언트) |
+
+## Java SDK vs Kotlin SDK 비교
+
+| 기능 | `bluetape4k-aws-kms` (Java SDK) | `bluetape4k-aws-kotlin-kms` (Kotlin SDK) |
+|------|------|------|
+| 클라이언트 | `KmsClient`, `KmsAsyncClient` | `KmsClient` (단일 suspend 기반) |
+| 비동기 방식 | `CompletableFuture` + `.await()` | Native suspend function |
+| 코루틴 통합 | 별도 `kotlinx-coroutines-jdk8` 필요 | 기본 제공 |

--- a/aws-kotlin/kms/src/main/kotlin/io/bluetape4k/aws/kotlin/kms/KmsClientSupport.kt
+++ b/aws-kotlin/kms/src/main/kotlin/io/bluetape4k/aws/kotlin/kms/KmsClientSupport.kt
@@ -6,6 +6,28 @@ import aws.smithy.kotlin.runtime.http.engine.HttpClientEngine
 import aws.smithy.kotlin.runtime.net.url.Url
 import io.bluetape4k.aws.kotlin.http.HttpClientEngineProvider
 
+/**
+ * AWS Kotlin SDK KMS 클라이언트를 생성합니다.
+ *
+ * AWS Key Management Service(KMS)는 암호화 키를 생성하고 관리하며,
+ * 광범위한 AWS 서비스 및 애플리케이션에서 사용할 수 있는 관리형 서비스입니다.
+ *
+ * 예시:
+ * ```kotlin
+ * val client = kmsClientOf(
+ *     endpointUrl = Url.parse("http://localhost:4566"),
+ *     region = "us-east-1",
+ *     credentialsProvider = myCredentialsProvider
+ * )
+ * ```
+ *
+ * @param endpointUrl KMS 서비스 엔드포인트 URL. null이면 기본 AWS 엔드포인트를 사용합니다.
+ * @param region AWS 리전. null이면 환경 설정에서 자동으로 감지합니다.
+ * @param credentialsProvider AWS 인증 정보 제공자. null이면 기본 자격 증명 체인을 사용합니다.
+ * @param httpClient HTTP 클라이언트 엔진. 기본값은 [HttpClientEngineProvider.defaultHttpEngine]입니다.
+ * @param builder [KmsClient.Config.Builder]에 대한 추가 설정 람다.
+ * @return 설정된 [KmsClient] 인스턴스.
+ */
 inline fun kmsClientOf(
     endpointUrl: Url? = null,
     region: String? = null,

--- a/aws-kotlin/kms/src/test/kotlin/io/bluetape4k/aws/kotlin/kms/AbstractKmsTest.kt
+++ b/aws-kotlin/kms/src/test/kotlin/io/bluetape4k/aws/kotlin/kms/AbstractKmsTest.kt
@@ -9,6 +9,26 @@ import io.bluetape4k.junit5.faker.Fakers
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import org.testcontainers.containers.localstack.LocalStackContainer
 
+/**
+ * AWS Kotlin SDK KMS 테스트를 위한 추상 기반 클래스.
+ *
+ * LocalStack을 사용하여 로컬 환경에서 AWS KMS API를 테스트합니다.
+ * [LocalStackContainer]를 통해 KMS 서비스 컨테이너를 자동으로 시작하고,
+ * [KmsClient]를 생성하여 테스트에서 재사용할 수 있도록 제공합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * class MyKmsTest : AbstractKmsTest() {
+ *     @Test
+ *     fun `키 생성 테스트`() = runTest {
+ *         val response = client.createKey {
+ *             description = "테스트 키"
+ *         }
+ *         // assertions ...
+ *     }
+ * }
+ * ```
+ */
 abstract class AbstractKmsTest {
 
     companion object: KLoggingChannel() {


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: docs/test: bluetape4k-aws-kotlin-kms 코드 리뷰 및 개선

- `KmsClientSupport.kt`: public API `kmsClientOf()` 함수에 KDoc 추가 (파라미터 설명 및 사용 예시 포함)
- `AbstractKmsTest.kt`: 테스트 기반 클래스 레벨 KDoc 추가
- `KmsClientTest.kt`: 테스트 메소드명 개선 및 검증 로직 보강
- `README.md`: 상세 사용 가이드 작성

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 변경 상세

### 코드 품질 개선 (`KmsClientTest.kt`)

| 기존 | 수정 | 이유 |
|------|------|------|
| `Grant 갱신하기` | `Grant 취소` | `revokeGrant`는 취소/철회 의미 |
| `Key Polish 주입` | `키 정책 설정` | `putKeyPolicy`의 올바른 표현 |
| `create KmsClient instance` 등 | 한국어 통일 | 프로젝트 컨벤션 준수 |
| 검증 없음 | `algorithm.shouldNotBeEmpty()` | 암호화 알고리즘 검증 보강 |

### README.md 주요 내용

- 모듈 개요 및 의존성 설정
- `KmsClient` 생성 방법 (기본, 로컬 환경, 커스텀 설정)
- 대칭 키 생성, 암호화/복호화 예시
- Alias 관리, Grant 관리, 키 정책 설정 예시
- 테스트 실행 방법
- Java SDK vs Kotlin SDK 비교표

### 기존 섹션: Test plan

- [ ] `./gradlew :bluetape4k-aws-kotlin-kms:compileKotlin :bluetape4k-aws-kotlin-kms:compileTestKotlin` 빌드 성공 확인
- [ ] `./gradlew :bluetape4k-aws-kotlin-kms:test` 실행 (Docker/LocalStack 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #45, head `91bd5c7136e724a08dad0473c0214dcfaaf4768a`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `claude/determined-moser`
- Labels: 없음
- State: `MERGED`, merge commit `fe39cb86fcc88564bec15e5ab4e3cff84d145786`
- CI: - [ ] `./gradlew :bluetape4k-aws-kotlin-kms:compileKotlin :bluetape4k-aws-kotlin-kms:compileTestKotlin` 빌드 성공 확인 / - [ ] `./gradlew :bluetape4k-aws-kotlin-kms:test` 실행 (Docker/LocalStack 필요)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #45 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `fe39cb86fcc88564bec15e5ab4e3cff84d145786`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
