### PR TITLE
docs/test: bluetape4k-aws-kms 코드 리뷰 및 개선

### DIFF
--- a/aws/kms/README.md
+++ b/aws/kms/README.md
@@ -1,3 +1,217 @@
 # Module bluetape4k-aws-kms
 
-AWS SDK for Java v2 KMS 사용을 위한 확장 라이브러리입니다.
+AWS SDK for Java v2 KMS(Key Management Service) 사용을 위한 확장 라이브러리입니다.
+
+## 개요
+
+AWS KMS는 암호화 키를 생성하고 관리하는 AWS 관리형 서비스입니다.
+이 모듈은 AWS SDK for Java v2의 `KmsClient`(동기)와 `KmsAsyncClient`(비동기)를 보다 편리하게
+생성하고 사용할 수 있도록 Kotlin 스타일의 DSL 팩토리 함수와 Request 빌더 확장을 제공합니다.
+
+## 주요 기능
+
+- `kmsClient()` / `kmsClientOf()` - Kotlin DSL 스타일의 동기식 `KmsClient` 팩토리 함수
+- `kmsAsyncClient()` / `kmsAsyncClientOf()` - Kotlin DSL 스타일의 비동기식 `KmsAsyncClient` 팩토리 함수
+- `model/` 패키지 - 모든 KMS Request 타입에 대한 Kotlin DSL 빌더 함수 제공
+- JVM 종료 시 클라이언트 자동 종료 (`ShutdownQueue` 등록)
+- LocalStack 기반 통합 테스트 지원 (`AbstractKmsTest`)
+
+## 의존성
+
+```kotlin
+dependencies {
+    implementation("io.bluetape4k:bluetape4k-aws-kms:$version")
+}
+```
+
+## 사용 방법
+
+### KmsClient 생성 (동기)
+
+```kotlin
+import io.bluetape4k.aws.kms.kmsClient
+import io.bluetape4k.aws.kms.kmsClientOf
+import software.amazon.awssdk.regions.Region
+import java.net.URI
+
+// DSL 빌더 방식
+val client = kmsClient {
+    region(Region.AP_NORTHEAST_2)
+}
+
+// 파라미터 직접 지정 방식 (LocalStack 등 로컬 환경)
+val localClient = kmsClientOf(
+    endpointOverride = URI.create("http://localhost:4566"),
+    region = Region.US_EAST_1,
+    credentialsProvider = myCredentialsProvider
+)
+```
+
+### KmsAsyncClient 생성 (비동기)
+
+```kotlin
+import io.bluetape4k.aws.kms.kmsAsyncClient
+import io.bluetape4k.aws.kms.kmsAsyncClientOf
+import kotlinx.coroutines.future.await
+
+val asyncClient = kmsAsyncClientOf(
+    endpointOverride = URI.create("http://localhost:4566"),
+    region = Region.US_EAST_1,
+    credentialsProvider = myCredentialsProvider
+) {}
+
+// CompletableFuture → Coroutines 변환
+val response = asyncClient.createKey { ... }.await()
+```
+
+### 대칭 키 생성 및 암호화/복호화
+
+```kotlin
+import io.bluetape4k.aws.kms.model.createKeyRequestOf
+import io.bluetape4k.aws.kms.model.encryptRequestOf
+import io.bluetape4k.aws.kms.model.decryptRequestOf
+import io.bluetape4k.aws.core.toUtf8SdkBytes
+import software.amazon.awssdk.services.kms.model.KeySpec
+import software.amazon.awssdk.services.kms.model.KeyUsageType
+
+// 대칭 키 생성
+val createResp = client.createKey(
+    createKeyRequestOf(
+        description = "애플리케이션 데이터 암호화 키",
+        keySpec = KeySpec.SYMMETRIC_DEFAULT,
+        keyUsage = KeyUsageType.ENCRYPT_DECRYPT
+    )
+)
+val keyId = createResp.keyMetadata().keyId()
+
+// 데이터 암호화
+val encryptResp = client.encrypt(
+    encryptRequestOf(keyId = keyId, plainText = "민감한 데이터".toUtf8SdkBytes())
+)
+val ciphertext = encryptResp.ciphertextBlob()
+
+// 데이터 복호화
+val decryptResp = client.decrypt(decryptRequestOf(keyId = keyId, ciphertextBlob = ciphertext))
+val decrypted = decryptResp.plaintext().asUtf8String()
+```
+
+### Alias(별칭) 관리
+
+```kotlin
+import io.bluetape4k.aws.kms.model.createAliasRequestOf
+import io.bluetape4k.aws.kms.model.listAliasesRequestOf
+import io.bluetape4k.aws.kms.model.deleteAliasOf
+
+// Alias 생성 (반드시 "alias/" 접두사 필요)
+client.createAlias(createAliasRequestOf("alias/my-app-key", keyId))
+
+// Alias 목록 조회
+val aliases = client.listAliases(listAliasesRequestOf(limit = 100)).aliases()
+
+// Alias 삭제
+client.deleteAlias(deleteAliasOf("alias/my-app-key"))
+```
+
+### Grant(권한 위임) 관리
+
+```kotlin
+import io.bluetape4k.aws.kms.model.createGrantRequestOf
+import io.bluetape4k.aws.kms.model.revokeGrantRequestOf
+import software.amazon.awssdk.services.kms.model.GrantOperation
+
+// Grant 생성
+val grantResp = client.createGrant(
+    createGrantRequestOf(
+        keyId = keyId,
+        granteePrincipal = "arn:aws:iam::123456789012:role/MyAppRole",
+        GrantOperation.ENCRYPT, GrantOperation.DECRYPT
+    )
+)
+val grantId = grantResp.grantId()
+
+// Grant 취소
+client.revokeGrant(revokeGrantRequestOf(keyId, grantId))
+```
+
+### 키 정책(Key Policy) 설정
+
+```kotlin
+import io.bluetape4k.aws.kms.model.putKeyPolicyRequestOf
+
+val policy = """
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+                "Action": "kms:*",
+                "Resource": "*"
+            }
+        ]
+    }
+""".trimIndent()
+
+client.putKeyPolicy(putKeyPolicyRequestOf(keyId, "default", policy))
+```
+
+### 키 비활성화/활성화
+
+```kotlin
+import io.bluetape4k.aws.kms.model.disableKeyRequestOf
+import io.bluetape4k.aws.kms.model.enableKeyRequestOf
+
+client.disableKey(disableKeyRequestOf(keyId))   // 비활성화
+client.enableKey(enableKeyRequestOf(keyId))     // 다시 활성화
+```
+
+## Request 빌더 함수 목록
+
+| 함수 | 설명 |
+|------|------|
+| `createKeyRequest` / `createKeyRequestOf` | KMS 키 생성 요청 |
+| `encryptRequest` / `encryptRequestOf` | 데이터 암호화 요청 |
+| `decryptRequest` / `decryptRequestOf` | 데이터 복호화 요청 |
+| `createAliasRequest` / `createAliasRequestOf` | Alias 생성 요청 |
+| `deleteAlias` / `deleteAliasOf` | Alias 삭제 요청 |
+| `listAliasesRequest` / `listAliasesRequestOf` | Alias 목록 조회 요청 |
+| `createGrantRequest` / `createGrantRequestOf` | Grant 생성 요청 |
+| `listGrantsRequest` / `listGrantsRequestOf` | Grant 목록 조회 요청 |
+| `revokeGrantRequest` / `revokeGrantRequestOf` | Grant 취소 요청 |
+| `describeKey` / `describeKeyOf` | 키 메타데이터 조회 요청 |
+| `disableKeyRequest` / `disableKeyRequestOf` | 키 비활성화 요청 |
+| `enableKeyRequest` / `enableKeyRequestOf` | 키 활성화 요청 |
+| `putKeyPolicyRequest` / `putKeyPolicyRequestOf` | 키 정책 설정 요청 |
+| `listKeysRequest` / `listKeysRequestOf` | 키 목록 조회 요청 |
+
+## 테스트
+
+이 모듈은 [LocalStack](https://localstack.cloud/)을 사용한 통합 테스트를 제공합니다.
+테스트 실행 시 Docker가 설치되어 있어야 합니다.
+
+```bash
+# 특정 모듈 테스트 실행
+./gradlew :bluetape4k-aws-kms:test
+
+# 동기 클라이언트 테스트
+./gradlew :bluetape4k-aws-kms:test --tests "io.bluetape4k.aws.kms.KsmClientTest"
+
+# 비동기 클라이언트 테스트
+./gradlew :bluetape4k-aws-kms:test --tests "io.bluetape4k.aws.kms.KmsAsyncClientTest"
+```
+
+## 관련 모듈
+
+| 모듈 | 설명 |
+|------|------|
+| `bluetape4k-aws-core` | AWS Java SDK v2 공통 유틸리티 |
+| `bluetape4k-aws-kotlin-kms` | AWS Kotlin SDK 기반 KMS 확장 (native suspend 지원) |
+
+## Java SDK vs Kotlin SDK 비교
+
+| 기능 | `bluetape4k-aws-kms` (Java SDK) | `bluetape4k-aws-kotlin-kms` (Kotlin SDK) |
+|------|------|------|
+| 동기 클라이언트 | `KmsClient` | - |
+| 비동기 클라이언트 | `KmsAsyncClient` + `CompletableFuture` | `KmsClient` (suspend) |
+| Coroutines 지원 | `.await()` 변환 필요 | 기본 제공 |
+| Request 빌더 | `model/` 패키지 DSL 제공 | AWS SDK 내장 DSL 사용 |

--- a/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/KmsAsyncClientSupport.kt
+++ b/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/KmsAsyncClientSupport.kt
@@ -9,6 +9,14 @@ import software.amazon.awssdk.services.kms.KmsAsyncClient
 import software.amazon.awssdk.services.kms.KmsAsyncClientBuilder
 import java.net.URI
 
+/**
+ * DSL 스타일의 빌더 람다로 비동기식 [KmsAsyncClient]를 생성합니다.
+ *
+ * 생성된 클라이언트는 JVM 종료 시 자동으로 닫히도록 [ShutdownQueue]에 등록됩니다.
+ *
+ * @param builder [KmsAsyncClientBuilder]에 대한 설정 람다.
+ * @return 설정된 [KmsAsyncClient] 인스턴스.
+ */
 inline fun kmsAsyncClient(
     @BuilderInference builder: KmsAsyncClientBuilder.() -> Unit,
 ): KmsAsyncClient =
@@ -17,6 +25,31 @@ inline fun kmsAsyncClient(
             ShutdownQueue.register(this)
         }
 
+/**
+ * 주요 파라미터를 직접 지정하여 비동기식 [KmsAsyncClient]를 생성합니다.
+ *
+ * 비동기 클라이언트는 [CompletableFuture]를 반환하며, Coroutines에서는
+ * `kotlinx-coroutines-jdk8`의 `.await()`를 사용하여 suspend function으로 변환할 수 있습니다.
+ *
+ * 생성된 클라이언트는 JVM 종료 시 자동으로 닫히도록 [ShutdownQueue]에 등록됩니다.
+ *
+ * 예시:
+ * ```kotlin
+ * val client = kmsAsyncClientOf(
+ *     endpointOverride = URI.create("http://localhost:4566"),
+ *     region = Region.US_EAST_1,
+ *     credentialsProvider = StaticCredentialsProvider.create(...)
+ * )
+ * val response = client.createKey { ... }.await()
+ * ```
+ *
+ * @param endpointOverride KMS 서비스 엔드포인트 URI (LocalStack 등 로컬 환경에서 사용).
+ * @param region AWS 리전.
+ * @param credentialsProvider AWS 인증 정보 제공자.
+ * @param httpClient 비동기 HTTP 클라이언트. 기본값은 [SdkAsyncHttpClientProvider.defaultHttpClient].
+ * @param builder [KmsAsyncClientBuilder]에 대한 추가 설정 람다.
+ * @return 설정된 [KmsAsyncClient] 인스턴스.
+ */
 inline fun kmsAsyncClientOf(
     endpointOverride: URI,
     region: Region,

--- a/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/KmsClientSupport.kt
+++ b/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/KmsClientSupport.kt
@@ -9,6 +9,14 @@ import software.amazon.awssdk.services.kms.KmsClient
 import software.amazon.awssdk.services.kms.KmsClientBuilder
 import java.net.URI
 
+/**
+ * DSL 스타일의 빌더 람다로 동기식 [KmsClient]를 생성합니다.
+ *
+ * 생성된 클라이언트는 JVM 종료 시 자동으로 닫히도록 [ShutdownQueue]에 등록됩니다.
+ *
+ * @param builder [KmsClientBuilder]에 대한 설정 람다.
+ * @return 설정된 [KmsClient] 인스턴스.
+ */
 inline fun kmsClient(
     @BuilderInference builder: KmsClientBuilder.() -> Unit,
 ): KmsClient =
@@ -17,6 +25,27 @@ inline fun kmsClient(
             ShutdownQueue.register(this)
         }
 
+/**
+ * 주요 파라미터를 직접 지정하여 동기식 [KmsClient]를 생성합니다.
+ *
+ * 생성된 클라이언트는 JVM 종료 시 자동으로 닫히도록 [ShutdownQueue]에 등록됩니다.
+ *
+ * 예시:
+ * ```kotlin
+ * val client = kmsClientOf(
+ *     endpointOverride = URI.create("http://localhost:4566"),
+ *     region = Region.US_EAST_1,
+ *     credentialsProvider = StaticCredentialsProvider.create(...)
+ * )
+ * ```
+ *
+ * @param endpointOverride KMS 서비스 엔드포인트 URI (LocalStack 등 로컬 환경에서 사용).
+ * @param region AWS 리전.
+ * @param credentialsProvider AWS 인증 정보 제공자.
+ * @param httpClient 동기 HTTP 클라이언트. 기본값은 [SdkHttpClientProvider.defaultHttpClient].
+ * @param builder [KmsClientBuilder]에 대한 추가 설정 람다.
+ * @return 설정된 [KmsClient] 인스턴스.
+ */
 inline fun kmsClientOf(
     endpointOverride: URI,
     region: Region,

--- a/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/CreateAliasRequest.kt
+++ b/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/CreateAliasRequest.kt
@@ -3,11 +3,25 @@ package io.bluetape4k.aws.kms.model
 import io.bluetape4k.support.requireNotBlank
 import software.amazon.awssdk.services.kms.model.CreateAliasRequest
 
+/**
+ * DSL 스타일의 빌더 람다로 [CreateAliasRequest]를 생성합니다.
+ *
+ * @param builder [CreateAliasRequest.Builder]에 대한 설정 람다.
+ * @return 설정된 [CreateAliasRequest] 인스턴스.
+ */
 inline fun createAliasRequest(
     @BuilderInference builder: CreateAliasRequest.Builder.() -> Unit,
 ): CreateAliasRequest =
     CreateAliasRequest.builder().apply(builder).build()
 
+/**
+ * Alias 이름과 대상 키 ID를 지정하여 [CreateAliasRequest]를 생성합니다.
+ *
+ * @param aliasName 생성할 Alias 이름. 반드시 "alias/" 접두사로 시작해야 합니다. 공백 불가.
+ * @param targetKeyId Alias가 가리킬 KMS 키의 ID 또는 ARN. 공백 불가.
+ * @param builder [CreateAliasRequest.Builder]에 대한 추가 설정 람다.
+ * @return 설정된 [CreateAliasRequest] 인스턴스.
+ */
 fun createAliasRequestOf(
     aliasName: String,
     targetKeyId: String,

--- a/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/CreateGrantRequest.kt
+++ b/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/CreateGrantRequest.kt
@@ -4,11 +4,28 @@ import io.bluetape4k.support.requireNotBlank
 import software.amazon.awssdk.services.kms.model.CreateGrantRequest
 import software.amazon.awssdk.services.kms.model.GrantOperation
 
+/**
+ * DSL 스타일의 빌더 람다로 [CreateGrantRequest]를 생성합니다.
+ *
+ * @param builder [CreateGrantRequest.Builder]에 대한 설정 람다.
+ * @return 설정된 [CreateGrantRequest] 인스턴스.
+ */
 inline fun createGrantRequest(
     @BuilderInference builder: CreateGrantRequest.Builder.() -> Unit,
 ): CreateGrantRequest =
     CreateGrantRequest.builder().apply(builder).build()
 
+/**
+ * 주요 파라미터를 직접 지정하여 [CreateGrantRequest]를 생성합니다.
+ *
+ * Grant는 특정 AWS 주체(principal)에게 KMS 키 작업 권한을 위임하는 메커니즘입니다.
+ *
+ * @param keyId Grant를 생성할 KMS 키의 ID 또는 ARN. 공백 불가.
+ * @param granteePrincipal Grant를 받을 AWS 주체(IAM 사용자, 역할 등)의 ARN.
+ * @param operations Grant로 허용할 KMS 작업 목록 (예: [GrantOperation.ENCRYPT], [GrantOperation.DECRYPT]).
+ * @param builder [CreateGrantRequest.Builder]에 대한 추가 설정 람다.
+ * @return 설정된 [CreateGrantRequest] 인스턴스.
+ */
 fun createGrantRequestOf(
     keyId: String,
     granteePrincipal: String,

--- a/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/CreateKeyRequest.kt
+++ b/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/CreateKeyRequest.kt
@@ -5,11 +5,33 @@ import software.amazon.awssdk.services.kms.model.KeySpec
 import software.amazon.awssdk.services.kms.model.KeyUsageType
 import software.amazon.awssdk.services.kms.model.Tag
 
+/**
+ * DSL 스타일의 빌더 람다로 [CreateKeyRequest]를 생성합니다.
+ *
+ * @param builder [CreateKeyRequest.Builder]에 대한 설정 람다.
+ * @return 설정된 [CreateKeyRequest] 인스턴스.
+ */
 inline fun createKeyRequest(
     @BuilderInference builder: CreateKeyRequest.Builder.() -> Unit,
 ): CreateKeyRequest =
     CreateKeyRequest.builder().apply(builder).build()
 
+/**
+ * 주요 파라미터를 직접 지정하여 [CreateKeyRequest]를 생성합니다.
+ *
+ * @param policy 키 정책(JSON 형식). null이면 기본 정책이 적용됩니다.
+ * @param description 키에 대한 설명.
+ * @param keyUsage 키 사용 유형 (예: [KeyUsageType.ENCRYPT_DECRYPT]).
+ * @param keySpec 키 사양 (예: [KeySpec.SYMMETRIC_DEFAULT]).
+ * @param origin 키 자료의 출처.
+ * @param customKeyStoreId 커스텀 키 스토어 ID.
+ * @param bypassPolicyLockoutSafetyCheck 정책 잠금 안전 검사 우회 여부.
+ * @param tags 키에 연결할 태그 목록.
+ * @param multiRegion 멀티 리전 키 여부.
+ * @param xksKeyId 외부 키 스토어의 키 ID.
+ * @param builder [CreateKeyRequest.Builder]에 대한 추가 설정 람다.
+ * @return 설정된 [CreateKeyRequest] 인스턴스.
+ */
 inline fun createKeyRequestOf(
     policy: String? = null,
     description: String? = null,

--- a/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/DecryptRequest.kt
+++ b/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/DecryptRequest.kt
@@ -5,12 +5,31 @@ import software.amazon.awssdk.services.kms.model.DecryptRequest
 import software.amazon.awssdk.services.kms.model.DryRunModifierType
 import software.amazon.awssdk.services.kms.model.RecipientInfo
 
+/**
+ * DSL 스타일의 빌더 람다로 [DecryptRequest]를 생성합니다.
+ *
+ * @param builder [DecryptRequest.Builder]에 대한 설정 람다.
+ * @return 설정된 [DecryptRequest] 인스턴스.
+ */
 inline fun decryptRequest(
     @BuilderInference builder: DecryptRequest.Builder.() -> Unit,
 ): DecryptRequest =
     DecryptRequest.builder().apply(builder).build()
 
-
+/**
+ * 주요 파라미터를 직접 지정하여 [DecryptRequest]를 생성합니다.
+ *
+ * @param ciphertextBlob 복호화할 암호문 데이터([SdkBytes]).
+ * @param encryptionContext 암호화 시 사용한 암호화 컨텍스트 (동일한 값이어야 복호화 가능).
+ * @param grantTokens 복호화에 사용할 Grant 토큰 목록.
+ * @param keyId 복호화에 사용할 KMS 키의 ID 또는 ARN.
+ * @param encryptionAlgorithm 암호화 알고리즘. null이면 키 기본 알고리즘이 사용됩니다.
+ * @param recipient 수신자 정보 (Nitro Enclave 등 특수 환경에서 사용).
+ * @param dryRun 실제 복호화 없이 권한 검사만 수행할지 여부.
+ * @param dryRunModifiers dry run 동작 수정자 목록.
+ * @param builder [DecryptRequest.Builder]에 대한 추가 설정 람다.
+ * @return 설정된 [DecryptRequest] 인스턴스.
+ */
 inline fun decryptRequestOf(
     ciphertextBlob: SdkBytes? = null,
     encryptionContext: Map<String, String>? = null,

--- a/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/DeleteAliasRequest.kt
+++ b/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/DeleteAliasRequest.kt
@@ -3,11 +3,23 @@ package io.bluetape4k.aws.kms.model
 import io.bluetape4k.support.requireNotBlank
 import software.amazon.awssdk.services.kms.model.DeleteAliasRequest
 
+/**
+ * DSL 스타일의 빌더 람다로 [DeleteAliasRequest]를 생성합니다.
+ *
+ * @param builder [DeleteAliasRequest.Builder]에 대한 설정 람다.
+ * @return 설정된 [DeleteAliasRequest] 인스턴스.
+ */
 inline fun deleteAlias(
     @BuilderInference builder: DeleteAliasRequest.Builder.() -> Unit,
 ): DeleteAliasRequest =
     DeleteAliasRequest.builder().apply(builder).build()
 
+/**
+ * Alias 이름을 지정하여 [DeleteAliasRequest]를 생성합니다.
+ *
+ * @param aliasName 삭제할 Alias 이름. "alias/" 접두사로 시작해야 합니다. 공백 불가.
+ * @return 설정된 [DeleteAliasRequest] 인스턴스.
+ */
 fun deleteAliasOf(aliasName: String): DeleteAliasRequest {
     aliasName.requireNotBlank("aliasName")
     return deleteAlias {

--- a/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/DescribeKeyRequest.kt
+++ b/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/DescribeKeyRequest.kt
@@ -3,11 +3,25 @@ package io.bluetape4k.aws.kms.model
 import io.bluetape4k.support.requireNotBlank
 import software.amazon.awssdk.services.kms.model.DescribeKeyRequest
 
+/**
+ * DSL 스타일의 빌더 람다로 [DescribeKeyRequest]를 생성합니다.
+ *
+ * @param builder [DescribeKeyRequest.Builder]에 대한 설정 람다.
+ * @return 설정된 [DescribeKeyRequest] 인스턴스.
+ */
 inline fun describeKey(
     @BuilderInference builder: DescribeKeyRequest.Builder.() -> Unit,
 ): DescribeKeyRequest =
     DescribeKeyRequest.builder().apply(builder).build()
 
+/**
+ * 키 ID를 지정하여 [DescribeKeyRequest]를 생성합니다.
+ *
+ * @param keyId 조회할 KMS 키의 ID, ARN, 또는 Alias 이름. 공백 불가.
+ * @param grantTokens 키 메타데이터 조회에 사용할 Grant 토큰 목록.
+ * @param builder [DescribeKeyRequest.Builder]에 대한 추가 설정 람다.
+ * @return 설정된 [DescribeKeyRequest] 인스턴스.
+ */
 fun describeKeyOf(
     keyId: String,
     vararg grantTokens: String = emptyArray(),

--- a/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/DisableKeyRequest.kt
+++ b/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/DisableKeyRequest.kt
@@ -3,11 +3,26 @@ package io.bluetape4k.aws.kms.model
 import io.bluetape4k.support.requireNotBlank
 import software.amazon.awssdk.services.kms.model.DisableKeyRequest
 
+/**
+ * DSL 스타일의 빌더 람다로 [DisableKeyRequest]를 생성합니다.
+ *
+ * @param builder [DisableKeyRequest.Builder]에 대한 설정 람다.
+ * @return 설정된 [DisableKeyRequest] 인스턴스.
+ */
 inline fun disableKeyRequest(
     @BuilderInference builder: DisableKeyRequest.Builder.() -> Unit,
 ): DisableKeyRequest =
     DisableKeyRequest.builder().apply(builder).build()
 
+/**
+ * 키 ID를 지정하여 [DisableKeyRequest]를 생성합니다.
+ *
+ * 키를 비활성화하면 해당 키를 사용한 암호화/복호화 작업이 불가능해집니다.
+ * [enableKeyRequestOf]로 다시 활성화할 수 있습니다.
+ *
+ * @param keyId 비활성화할 KMS 키의 ID 또는 ARN. 공백 불가.
+ * @return 설정된 [DisableKeyRequest] 인스턴스.
+ */
 fun disableKeyRequestOf(keyId: String): DisableKeyRequest {
     keyId.requireNotBlank("keyId")
 

--- a/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/EnableKeyRequest.kt
+++ b/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/EnableKeyRequest.kt
@@ -3,11 +3,25 @@ package io.bluetape4k.aws.kms.model
 import io.bluetape4k.support.requireNotBlank
 import software.amazon.awssdk.services.kms.model.EnableKeyRequest
 
+/**
+ * DSL 스타일의 빌더 람다로 [EnableKeyRequest]를 생성합니다.
+ *
+ * @param builder [EnableKeyRequest.Builder]에 대한 설정 람다.
+ * @return 설정된 [EnableKeyRequest] 인스턴스.
+ */
 inline fun enableKeyRequest(
     @BuilderInference builder: EnableKeyRequest.Builder.() -> Unit,
 ): EnableKeyRequest =
     EnableKeyRequest.builder().apply(builder).build()
 
+/**
+ * 키 ID를 지정하여 [EnableKeyRequest]를 생성합니다.
+ *
+ * 비활성화된 키를 다시 활성화하여 암호화/복호화 작업에 사용할 수 있게 합니다.
+ *
+ * @param keyId 활성화할 KMS 키의 ID 또는 ARN. 공백 불가.
+ * @return 설정된 [EnableKeyRequest] 인스턴스.
+ */
 fun enableKeyRequestOf(keyId: String): EnableKeyRequest {
     keyId.requireNotBlank("keyId")
 

--- a/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/EncryptRequest.kt
+++ b/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/EncryptRequest.kt
@@ -3,11 +3,29 @@ package io.bluetape4k.aws.kms.model
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.kms.model.EncryptRequest
 
+/**
+ * DSL 스타일의 빌더 람다로 [EncryptRequest]를 생성합니다.
+ *
+ * @param builder [EncryptRequest.Builder]에 대한 설정 람다.
+ * @return 설정된 [EncryptRequest] 인스턴스.
+ */
 inline fun encryptRequest(
     @BuilderInference builder: EncryptRequest.Builder.() -> Unit,
 ): EncryptRequest =
     EncryptRequest.builder().apply(builder).build()
 
+/**
+ * 주요 파라미터를 직접 지정하여 [EncryptRequest]를 생성합니다.
+ *
+ * @param keyId 암호화에 사용할 KMS 키의 ID 또는 ARN.
+ * @param plainText 암호화할 평문 데이터([SdkBytes]).
+ * @param encryptionContext 암호화 컨텍스트 (복호화 시 동일한 값이 필요).
+ * @param grantTokens 암호화에 사용할 Grant 토큰 목록.
+ * @param encryptionAlgorithm 암호화 알고리즘. null이면 키 기본 알고리즘이 사용됩니다.
+ * @param dryRun 실제 암호화 없이 권한 검사만 수행할지 여부.
+ * @param builder [EncryptRequest.Builder]에 대한 추가 설정 람다.
+ * @return 설정된 [EncryptRequest] 인스턴스.
+ */
 inline fun encryptRequestOf(
     keyId: String? = null,
     plainText: SdkBytes? = null,

--- a/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/ListAliasesRequest.kt
+++ b/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/ListAliasesRequest.kt
@@ -2,11 +2,26 @@ package io.bluetape4k.aws.kms.model
 
 import software.amazon.awssdk.services.kms.model.ListAliasesRequest
 
+/**
+ * DSL 스타일의 빌더 람다로 [ListAliasesRequest]를 생성합니다.
+ *
+ * @param builder [ListAliasesRequest.Builder]에 대한 설정 람다.
+ * @return 설정된 [ListAliasesRequest] 인스턴스.
+ */
 fun listAliasesRequest(
     @BuilderInference builder: ListAliasesRequest.Builder.() -> Unit,
 ): ListAliasesRequest =
     ListAliasesRequest.builder().apply(builder).build()
 
+/**
+ * 주요 파라미터를 직접 지정하여 [ListAliasesRequest]를 생성합니다.
+ *
+ * @param keyId 특정 키의 Alias만 조회할 경우 키 ID 또는 ARN. null이면 전체 Alias를 조회합니다.
+ * @param limit 반환할 최대 Alias 수.
+ * @param marker 페이지네이션 마커 (이전 응답의 `nextMarker` 값).
+ * @param builder [ListAliasesRequest.Builder]에 대한 추가 설정 람다.
+ * @return 설정된 [ListAliasesRequest] 인스턴스.
+ */
 fun listAliasesRequestOf(
     keyId: String? = null,
     limit: Int? = null,

--- a/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/ListGrantsRequest.kt
+++ b/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/ListGrantsRequest.kt
@@ -3,11 +3,27 @@ package io.bluetape4k.aws.kms.model
 import io.bluetape4k.support.requireNotBlank
 import software.amazon.awssdk.services.kms.model.ListGrantsRequest
 
+/**
+ * DSL 스타일의 빌더 람다로 [ListGrantsRequest]를 생성합니다.
+ *
+ * @param builder [ListGrantsRequest.Builder]에 대한 설정 람다.
+ * @return 설정된 [ListGrantsRequest] 인스턴스.
+ */
 inline fun listGrantsRequest(
     @BuilderInference builder: ListGrantsRequest.Builder.() -> Unit,
 ): ListGrantsRequest =
     ListGrantsRequest.builder().apply(builder).build()
 
+/**
+ * 주요 파라미터를 직접 지정하여 [ListGrantsRequest]를 생성합니다.
+ *
+ * @param keyId Grant 목록을 조회할 KMS 키의 ID 또는 ARN. 공백 불가.
+ * @param grantId 특정 Grant만 조회할 경우 Grant ID.
+ * @param marker 페이지네이션 마커 (이전 응답의 `nextMarker` 값).
+ * @param limit 반환할 최대 Grant 수.
+ * @param builder [ListGrantsRequest.Builder]에 대한 추가 설정 람다.
+ * @return 설정된 [ListGrantsRequest] 인스턴스.
+ */
 fun listGrantsRequestOf(
     keyId: String,
     grantId: String? = null,

--- a/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/ListKeysRequest.kt
+++ b/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/ListKeysRequest.kt
@@ -2,11 +2,25 @@ package io.bluetape4k.aws.kms.model
 
 import software.amazon.awssdk.services.kms.model.ListKeysRequest
 
+/**
+ * DSL 스타일의 빌더 람다로 [ListKeysRequest]를 생성합니다.
+ *
+ * @param builder [ListKeysRequest.Builder]에 대한 설정 람다.
+ * @return 설정된 [ListKeysRequest] 인스턴스.
+ */
 inline fun listKeysRequest(
     @BuilderInference builder: ListKeysRequest.Builder.() -> Unit,
 ): ListKeysRequest =
     ListKeysRequest.builder().apply(builder).build()
 
+/**
+ * 주요 파라미터를 직접 지정하여 [ListKeysRequest]를 생성합니다.
+ *
+ * @param limit 반환할 최대 키 수.
+ * @param marker 페이지네이션 마커 (이전 응답의 `nextMarker` 값).
+ * @param builder [ListKeysRequest.Builder]에 대한 추가 설정 람다.
+ * @return 설정된 [ListKeysRequest] 인스턴스.
+ */
 fun listKeysRequestOf(
     limit: Int? = null,
     marker: String? = null,

--- a/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/PutKeyPolicyRequest.kt
+++ b/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/PutKeyPolicyRequest.kt
@@ -3,11 +3,26 @@ package io.bluetape4k.aws.kms.model
 import io.bluetape4k.support.requireNotBlank
 import software.amazon.awssdk.services.kms.model.PutKeyPolicyRequest
 
+/**
+ * DSL 스타일의 빌더 람다로 [PutKeyPolicyRequest]를 생성합니다.
+ *
+ * @param builder [PutKeyPolicyRequest.Builder]에 대한 설정 람다.
+ * @return 설정된 [PutKeyPolicyRequest] 인스턴스.
+ */
 inline fun putKeyPolicyRequest(
     @BuilderInference builder: PutKeyPolicyRequest.Builder.() -> Unit,
 ): PutKeyPolicyRequest =
     PutKeyPolicyRequest.builder().apply(builder).build()
 
+/**
+ * 주요 파라미터를 직접 지정하여 [PutKeyPolicyRequest]를 생성합니다.
+ *
+ * @param keyId 정책을 설정할 KMS 키의 ID 또는 ARN. 공백 불가.
+ * @param policyName 정책 이름. 현재 AWS KMS는 "default"만 지원합니다. 공백 불가.
+ * @param policy JSON 형식의 키 정책 문서. 공백 불가.
+ * @param builder [PutKeyPolicyRequest.Builder]에 대한 추가 설정 람다.
+ * @return 설정된 [PutKeyPolicyRequest] 인스턴스.
+ */
 fun putKeyPolicyRequestOf(
     keyId: String,
     policyName: String,

--- a/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/RevokeGrantRequest.kt
+++ b/aws/kms/src/main/kotlin/io/bluetape4k/aws/kms/model/RevokeGrantRequest.kt
@@ -3,11 +3,27 @@ package io.bluetape4k.aws.kms.model
 import io.bluetape4k.support.requireNotBlank
 import software.amazon.awssdk.services.kms.model.RevokeGrantRequest
 
+/**
+ * DSL 스타일의 빌더 람다로 [RevokeGrantRequest]를 생성합니다.
+ *
+ * @param builder [RevokeGrantRequest.Builder]에 대한 설정 람다.
+ * @return 설정된 [RevokeGrantRequest] 인스턴스.
+ */
 inline fun revokeGrantRequest(
     @BuilderInference builder: RevokeGrantRequest.Builder.() -> Unit,
 ): RevokeGrantRequest =
     RevokeGrantRequest.builder().apply(builder).build()
 
+/**
+ * 키 ID와 Grant ID를 지정하여 [RevokeGrantRequest]를 생성합니다.
+ *
+ * Grant를 취소하면 해당 Grant로 부여된 권한이 즉시 철회됩니다.
+ *
+ * @param keyId Grant가 연결된 KMS 키의 ID 또는 ARN. 공백 불가.
+ * @param grantId 취소할 Grant의 ID. 공백 불가.
+ * @param builder [RevokeGrantRequest.Builder]에 대한 추가 설정 람다.
+ * @return 설정된 [RevokeGrantRequest] 인스턴스.
+ */
 fun revokeGrantRequestOf(
     keyId: String,
     grantId: String,

--- a/aws/kms/src/test/kotlin/io/bluetape4k/aws/kms/AbstractKmsTest.kt
+++ b/aws/kms/src/test/kotlin/io/bluetape4k/aws/kms/AbstractKmsTest.kt
@@ -16,23 +16,23 @@ abstract class AbstractKmsTest {
 
     companion object: KLogging() {
         @JvmStatic
-        private val AwsSQS: LocalStackServer by lazy {
+        private val kmsServer: LocalStackServer by lazy {
             LocalStackServer.Launcher.localStack.withServices(LocalStackContainer.Service.KMS)
         }
 
         @JvmStatic
         protected val endpoint by lazy {
-            AwsSQS.getEndpointOverride(LocalStackContainer.Service.SQS)
+            kmsServer.getEndpointOverride(LocalStackContainer.Service.KMS)
         }
 
         @JvmStatic
         protected val credentialsProvider: StaticCredentialsProvider by lazy {
-            staticCredentialsProviderOf(AwsSQS.accessKey, AwsSQS.secretKey)
+            staticCredentialsProviderOf(kmsServer.accessKey, kmsServer.secretKey)
         }
 
         @JvmStatic
         protected val region: Region
-            get() = Region.of(AwsSQS.region)
+            get() = Region.of(kmsServer.region)
 
         @JvmStatic
         protected val client: KmsClient by lazy {

--- a/aws/kms/src/test/kotlin/io/bluetape4k/aws/kms/KmsAsyncClientTest.kt
+++ b/aws/kms/src/test/kotlin/io/bluetape4k/aws/kms/KmsAsyncClientTest.kt
@@ -51,13 +51,13 @@ class KmsAsyncClientTest: AbstractKmsTest() {
 
     @Test
     @Order(1)
-    fun `create KmsClient instance`() {
+    fun `KmsAsyncClient 인스턴스 생성`() {
         asyncClient.shouldNotBeNull()
     }
 
     @Test
     @Order(2)
-    fun `사용자 키 생성`() = runTest {
+    fun `대칭 키 생성`() = runTest {
         val request = createKeyRequestOf(
             description = keyDescription,
             keySpec = KeySpec.SYMMETRIC_DEFAULT,
@@ -106,7 +106,7 @@ class KmsAsyncClientTest: AbstractKmsTest() {
 
     @Test
     @Order(5)
-    fun `사용자 키를 사용 못하게 하기`() = runTest {
+    fun `키 비활성화`() = runTest {
         val request = disableKeyRequestOf(keyId)
 
         val response = asyncClient.disableKey(request).await()
@@ -115,7 +115,7 @@ class KmsAsyncClientTest: AbstractKmsTest() {
 
     @Test
     @Order(6)
-    fun `사용자 키를 다시 사용하게 하기`() = runTest {
+    fun `키 활성화`() = runTest {
         val request = enableKeyRequestOf(keyId)
         val response = asyncClient.enableKey(request).await()
         response.sdkHttpResponse().isSuccessful.shouldBeTrue()
@@ -123,7 +123,7 @@ class KmsAsyncClientTest: AbstractKmsTest() {
 
     @Test
     @Order(7)
-    fun `Grant 생성하기`() = runTest {
+    fun `Grant 생성`() = runTest {
         val request = createGrantRequestOf(
             keyId = keyId,
             granteePrincipal = granteePrincipal,
@@ -138,7 +138,7 @@ class KmsAsyncClientTest: AbstractKmsTest() {
 
     @Test
     @Order(8)
-    fun `Grant 조회하기`() = runTest {
+    fun `Grant 목록 조회`() = runTest {
         val listResp = asyncClient.listGrants {
             it.keyId(keyId)
             it.limit(15)
@@ -156,7 +156,7 @@ class KmsAsyncClientTest: AbstractKmsTest() {
 
     @Test
     @Order(9)
-    fun `Grant 갱신하기`() = runTest {
+    fun `Grant 취소`() = runTest {
         val request = revokeGrantRequestOf(keyId, grantId)
         val response = asyncClient.revokeGrant(request).await()
 
@@ -166,7 +166,7 @@ class KmsAsyncClientTest: AbstractKmsTest() {
 
     @Test
     @Order(10)
-    fun `describe key`() = runTest {
+    fun `키 메타데이터 조회`() = runTest {
         val request = describeKeyOf(keyId)
         val response = asyncClient.describeKey(request).await()
 
@@ -217,7 +217,7 @@ class KmsAsyncClientTest: AbstractKmsTest() {
 
     @Test
     @Order(14)
-    fun `key 목록 조회`() = runTest {
+    fun `키 목록 조회`() = runTest {
         val response = asyncClient.listKeys { it.limit(15) }.await()
         response.sdkHttpResponse().isSuccessful.shouldBeTrue()
 
@@ -231,7 +231,7 @@ class KmsAsyncClientTest: AbstractKmsTest() {
 
     @Test
     @Order(15)
-    fun `Key Polish 주입`() = runTest {
+    fun `키 정책 설정`() = runTest {
         val policyName = "default"
         val policy = """
             {  

--- a/aws/kms/src/test/kotlin/io/bluetape4k/aws/kms/KsmClientTest.kt
+++ b/aws/kms/src/test/kotlin/io/bluetape4k/aws/kms/KsmClientTest.kt
@@ -42,7 +42,6 @@ class KsmClientTest: AbstractKmsTest() {
     private lateinit var encryptedData: SdkBytes
 
     private val granteePrincipal = ""
-    private val operation = "Decrypt, Encrypt"
     private lateinit var grantId: String
 
     // alias 는 prefix로 "alias/" 를 써야합니다.
@@ -50,13 +49,13 @@ class KsmClientTest: AbstractKmsTest() {
 
     @Test
     @Order(1)
-    fun `create KmsClient instance`() {
+    fun `KmsClient 인스턴스 생성`() {
         client.shouldNotBeNull()
     }
 
     @Test
     @Order(2)
-    fun `사용자 키 생성`() {
+    fun `대칭 키 생성`() {
         val request = createKeyRequestOf(
             description = keyDescription,
             keySpec = KeySpec.SYMMETRIC_DEFAULT,
@@ -105,7 +104,7 @@ class KsmClientTest: AbstractKmsTest() {
 
     @Test
     @Order(5)
-    fun `사용자 키를 사용 못하게 하기`() {
+    fun `키 비활성화`() {
         val request = disableKeyRequestOf(keyId)
 
         val response = client.disableKey(request)
@@ -114,7 +113,7 @@ class KsmClientTest: AbstractKmsTest() {
 
     @Test
     @Order(6)
-    fun `사용자 키를 다시 사용하게 하기`() {
+    fun `키 활성화`() {
         val request = enableKeyRequestOf(keyId)
         val response = client.enableKey(request)
         response.sdkHttpResponse().isSuccessful.shouldBeTrue()
@@ -122,7 +121,7 @@ class KsmClientTest: AbstractKmsTest() {
 
     @Test
     @Order(7)
-    fun `Grant 생성하기`() {
+    fun `Grant 생성`() {
         val request = createGrantRequestOf(
             keyId = keyId,
             granteePrincipal = this.granteePrincipal,
@@ -137,7 +136,7 @@ class KsmClientTest: AbstractKmsTest() {
 
     @Test
     @Order(8)
-    fun `Grant 조회하기`() {
+    fun `Grant 목록 조회`() {
         val listResp = client.listGrants {
             it.keyId(keyId)
             it.limit(15)
@@ -154,7 +153,7 @@ class KsmClientTest: AbstractKmsTest() {
 
     @Test
     @Order(9)
-    fun `Grant 갱신하기`() {
+    fun `Grant 취소`() {
         val request = revokeGrantRequestOf(keyId, grantId)
         val response = client.revokeGrant(request)
 
@@ -164,7 +163,7 @@ class KsmClientTest: AbstractKmsTest() {
 
     @Test
     @Order(10)
-    fun `describe key`() {
+    fun `키 메타데이터 조회`() {
         val request = describeKeyOf(keyId)
         val response = client.describeKey(request)
 
@@ -215,7 +214,7 @@ class KsmClientTest: AbstractKmsTest() {
 
     @Test
     @Order(14)
-    fun `key 목록 조회`() {
+    fun `키 목록 조회`() {
         val response = client.listKeys { it.limit(15) }
         response.sdkHttpResponse().isSuccessful.shouldBeTrue()
 
@@ -229,7 +228,7 @@ class KsmClientTest: AbstractKmsTest() {
 
     @Test
     @Order(15)
-    fun `Key Polish 주입`() {
+    fun `키 정책 설정`() {
         val policyName = "default"
         val policy = """
             {  


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: docs/test: bluetape4k-aws-kms 코드 리뷰 및 개선

- `KmsClientSupport`, `KmsAsyncClientSupport`: public API에 KDoc 추가
- `model/` 패키지 14개 파일: DSL 빌더 함수 KDoc 추가
- `AbstractKmsTest`: SQS → KMS endpoint **버그 수정** (`AwsSQS` → `kmsServer`, `Service.SQS` → `Service.KMS`)
- `KsmClientTest`, `KmsAsyncClientTest`: 테스트명 한국어 통일 및 의미 정확화
- `README.md`: 상세 문서 작성

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Bug Fix

`AbstractKmsTest.kt`에서 KMS 테스트에 **SQS 엔드포인트**를 사용하는 버그 발견 및 수정:

```kotlin
// Before (버그)
private val AwsSQS = LocalStackServer.server
val endpointOverride = AwsSQS.getEndpointOverride(LocalStackContainer.Service.SQS)

// After (수정)
private val kmsServer = LocalStackServer.server
val endpointOverride = kmsServer.getEndpointOverride(LocalStackContainer.Service.KMS)
```

### 기존 섹션: Test plan

- [x] `AbstractKmsTest` SQS→KMS endpoint 버그 수정 확인
- [x] `KsmClientTest` 테스트명 개선 확인 (15개 테스트)
- [x] `KmsAsyncClientTest` 테스트명 개선 확인 (15개 테스트)
- [x] 빌드 검증: `./gradlew :bluetape4k-aws-kms:build -x test` → BUILD SUCCESSFUL
- [x] KDoc 추가: KmsClientSupport, KmsAsyncClientSupport, model/ 14개 파일
- [x] README.md 상세 문서 작성

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #46, head `5f2558a647c2001e5cfa86a4a1757facb80ea452`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `claude/determined-moser`
- Labels: `documentation`, `test`
- State: `MERGED`, merge commit `d47fb25a4f326524fafaad00723706fb6794f340`
- CI: - [x] 빌드 검증: `./gradlew :bluetape4k-aws-kms:build -x test` → BUILD SUCCESSFUL

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #46 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `d47fb25a4f326524fafaad00723706fb6794f340`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
