### PR TITLE
docs: Enhance javers module KDoc standardization

### DIFF
--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/CdoExtensions.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/CdoExtensions.kt
@@ -3,4 +3,12 @@ package io.bluetape4k.javers
 import org.javers.core.graph.Cdo
 import kotlin.jvm.optionals.getOrNull
 
+/**
+ * [Cdo]가 감싸고 있는 원본 객체를 반환하거나, 없으면 null을 반환한다.
+ *
+ * ```kotlin
+ * val wrapped = cdo.getWrappedOrNull()
+ * // wrapped == null 또는 원본 도메인 객체
+ * ```
+ */
 fun Cdo.getWrappedOrNull(): Any? = this.wrappedCdo.getOrNull()

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/JaversExtensions.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/JaversExtensions.kt
@@ -13,42 +13,118 @@ import kotlin.jvm.optionals.getOrNull
 import kotlin.reflect.KClass
 import kotlin.streams.asSequence
 
+/**
+ * reified 타입 파라미터로 [EntityType] 매핑 정보를 조회한다.
+ *
+ * ```kotlin
+ * val entityType = javers.getEntityTypeMapping<Person>()
+ * // entityType.baseJavaType == Person::class.java
+ * ```
+ */
 inline fun <reified T: Any> Javers.getEntityTypeMapping(): EntityType =
     this.getTypeMapping(T::class.java)
 
+/**
+ * reified 타입 파라미터로 [ValueObjectType] 매핑 정보를 조회한다.
+ *
+ * ```kotlin
+ * val voType = javers.getValueObjectTypeMapping<Address>()
+ * // voType.baseJavaType == Address::class.java
+ * ```
+ */
 inline fun <reified T: Any> Javers.getValueObjectTypeMapping(): ValueObjectType =
     this.getTypeMapping(T::class.java)
 
+/**
+ * 엔티티 인스턴스로부터 [InstanceId]를 생성한다.
+ *
+ * ```kotlin
+ * val bob = Person("Bob", "Dev")
+ * val id = javers.createEntityInstanceId(bob)
+ * // id.value() == "Person/Bob"
+ * ```
+ */
 inline fun <reified T: Any> Javers.createEntityInstanceId(entity: T): InstanceId =
     this.getEntityTypeMapping<T>().createIdFromInstance(entity)
 
-
+/**
+ * 엔티티의 로컬 ID 값으로부터 [InstanceId]를 생성한다.
+ *
+ * ```kotlin
+ * val id = javers.createEntityInstanceIdByEntityId<Person>("Bob")
+ * // id.value() == "Person/Bob"
+ * ```
+ */
 inline fun <reified T: Any> Javers.createEntityInstanceIdByEntityId(localId: Any): InstanceId =
     this.getEntityTypeMapping<T>().createIdFromInstanceId(localId)
 
+/**
+ * 두 컬렉션의 차이를 비교하여 [Diff]를 반환한다.
+ *
+ * ```kotlin
+ * val oldList = listOf(Person("Tommy", "Tommy Smart"))
+ * val newList = listOf(Person("Tommy", "Tommy C. Smart"))
+ * val diff = javers.compareCollections(oldList, newList)
+ * // diff.changes.size == 1
+ * ```
+ */
 inline fun <reified T: Any> Javers.compareCollections(oldVersion: Collection<T>, newVersion: Collection<T>): Diff =
     this.compareCollections(oldVersion, newVersion, T::class.java)
 
+/**
+ * 지정한 엔티티의 최신 [CdoSnapshot]을 반환하거나, 없으면 null을 반환한다.
+ *
+ * ```kotlin
+ * val snapshot = javers.latestSnapshotOrNull(1, SnapshotEntity::class)
+ * // snapshot?.globalId?.value() == "...SnapshotEntity/1"
+ * ```
+ */
 fun Javers.latestSnapshotOrNull(localId: Any, entityClass: KClass<*>): CdoSnapshot? =
     getLatestSnapshot(localId, entityClass.java).getOrNull()
 
+/**
+ * reified 타입 파라미터로 지정한 엔티티의 최신 [CdoSnapshot]을 반환하거나, 없으면 null을 반환한다.
+ *
+ * ```kotlin
+ * val snapshot = javers.latestSnapshotOrNull<SnapshotEntity>(1)
+ * // snapshot?.globalId?.value() == "...SnapshotEntity/1"
+ * ```
+ */
 inline fun <reified T: Any> Javers.latestSnapshotOrNull(localId: Any): CdoSnapshot? =
     getLatestSnapshot(localId, T::class.java).getOrNull()
 
 /**
- * Snapshot을 시스템에서 사용하는 실제 Entity를 가진 Shadow로 변환합니다.
+ * [CdoSnapshot]을 원본 엔티티를 감싼 [Shadow]로 변환한다.
  *
- * @param T business entity type
- * @param snapshot snapshot 정보
- * @return `Shadow<T>` 인스턴스
+ * ## 동작/계약
+ * - [ShadowFactory]를 통해 snapshot의 상태를 원본 엔티티 객체로 복원한다
+ * - 반환된 Shadow의 `get()`으로 복원된 엔티티를 얻을 수 있다
+ *
+ * ```kotlin
+ * val snapshot = javers.commit("a", entity).snapshots.first()
+ * val shadow: Shadow<SnapshotEntity> = javers.getShadow(snapshot)
+ * // shadow.get() == entity
+ * ```
  */
 @Suppress("UNCHECKED_CAST")
 fun <T> Javers.getShadow(snapshot: CdoSnapshot): Shadow<T> {
     return shadowFactory.createShadow(snapshot, snapshot.commitMetadata, null) as Shadow<T>
 }
 
+/**
+ * [Javers] 인스턴스에 연결된 [ShadowFactory]를 반환한다.
+ */
 val Javers.shadowFactory: ShadowFactory
     get() = ShadowProvider.getShadowFactory(this)
 
+/**
+ * JQL 쿼리로 Shadow를 조회하여 [Sequence]로 반환한다.
+ *
+ * ```kotlin
+ * val query = queryByInstanceId<SnapshotEntity>(1)
+ * val shadows = javers.findShadowsAndSequence<SnapshotEntity>(query)
+ * // shadows.toList().size >= 1
+ * ```
+ */
 fun <T: Any> Javers.findShadowsAndSequence(jql: JqlQuery): Sequence<Shadow<T>> =
     findShadowsAndStream<T>(jql).asSequence()

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/QueryParamsExtensions.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/QueryParamsExtensions.kt
@@ -4,6 +4,19 @@ import org.javers.repository.api.QueryParams
 import java.time.LocalDateTime
 import kotlin.jvm.optionals.getOrNull
 
+/**
+ * 주어진 [date]가 [QueryParams]의 from~to 범위 안에 포함되는지 확인한다.
+ *
+ * ## 동작/계약
+ * - from이 설정되어 있고 date보다 뒤이면 false
+ * - to가 설정되어 있고 date보다 앞이면 false
+ * - from/to가 미설정이면 해당 경계는 무시한다
+ *
+ * ```kotlin
+ * val inRange = queryParams.isDateInRange(LocalDateTime.now())
+ * // inRange == true (범위 내인 경우)
+ * ```
+ */
 fun QueryParams.isDateInRange(date: LocalDateTime): Boolean {
     if (from().getOrNull()?.isAfter(date) == true) {
         return false

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/ShadowProvider.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/ShadowProvider.kt
@@ -8,7 +8,16 @@ import java.lang.reflect.Field
 import java.util.concurrent.ConcurrentHashMap
 
 /**
- * [ShadowFactory]를 제공하는 Provider 입니다.
+ * [Javers] 인스턴스로부터 [ShadowFactory]를 생성·캐싱하여 제공하는 싱글턴 Provider.
+ *
+ * ## 동작/계약
+ * - [Javers] 인스턴스별로 [ShadowFactory]를 [ConcurrentHashMap]에 캐싱한다
+ * - 내부 [TypeMapper]는 Reflection으로 추출한다
+ *
+ * ```kotlin
+ * val factory = ShadowProvider.getShadowFactory(javers)
+ * val shadow = factory.createShadow(snapshot, metadata, null)
+ * ```
  */
 object ShadowProvider: KLogging() {
 
@@ -16,7 +25,11 @@ object ShadowProvider: KLogging() {
     private val shadowFactories = ConcurrentHashMap<Javers, ShadowFactory>()
 
     /**
-     * 지정한 `javers`의 내부 내용을 기반으로 [ShadowFactory]를 제공합니다.
+     * 지정한 [javers]에 대응하는 [ShadowFactory]를 반환한다.
+     *
+     * ## 동작/계약
+     * - 동일한 [Javers] 인스턴스에 대해 항상 같은 [ShadowFactory]를 반환한다
+     * - 최초 호출 시 [Javers] 내부 [TypeMapper]를 Reflection으로 추출하여 생성한다
      */
     fun getShadowFactory(javers: Javers): ShadowFactory {
         return shadowFactories.computeIfAbsent(javers) {
@@ -25,10 +38,7 @@ object ShadowProvider: KLogging() {
     }
 
     /**
-     * [Javers] 내부의 [TypeMapper]를 Reflection을 통해 제공합니다.
-     *
-     * @param javers [Javers] 인스턴스
-     * @return
+     * [Javers] 내부의 [TypeMapper]를 Reflection을 통해 추출한다.
      */
     private fun getTypeMapper(javers: Javers): TypeMapper {
         return typeMappers.computeIfAbsent(javers) {

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/base/EntityEnvelop.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/base/EntityEnvelop.kt
@@ -3,9 +3,25 @@ package io.bluetape4k.javers.base
 import java.io.Serializable
 
 /**
- * 엔티티 상태 정보 변경에 따른 Dispatch 시에 봉투 역할을 수행합니다.
+ * 엔티티 상태 변경 이벤트를 전달할 때 사용하는 봉투(envelope) 객체.
  *
- * @property entity 상태가 변경된 Entity (Save 시에만 가능
+ * ## 동작/계약
+ * - [entity] 기반 생성자는 SAVED 이벤트로 기본 설정된다
+ * - [entityId] + [entityType] 기반 생성자는 DELETED 이벤트로 설정된다
+ * - 커스텀 메타데이터는 [addHeader]/[getHeader]로 관리한다
+ *
+ * ```kotlin
+ * val saved = EntityEnvelop(myEntity)
+ * // saved.isSavedEntity == true
+ *
+ * val deleted = EntityEnvelop(entityId = 1L, entityType = User::class.java)
+ * // deleted.isDeletedEntity == true
+ * ```
+ *
+ * @property entity 상태가 변경된 엔티티 (SAVED 이벤트 시에만 설정)
+ * @property entityId 삭제된 엔티티의 ID (DELETED 이벤트 시에만 설정)
+ * @property entityType 엔티티의 Java 클래스 타입
+ * @property eventType 이벤트 유형 (기본값: [EntityEventType.SAVED])
  */
 data class EntityEnvelop(
     val entity: Any? = null,
@@ -19,12 +35,21 @@ data class EntityEnvelop(
 
     private val headers = hashMapOf<String, String>()
 
+    /**
+     * 커스텀 헤더를 추가한다.
+     */
     fun addHeader(key: String, value: String) {
         headers[key] = value
     }
 
+    /**
+     * 지정한 키의 헤더 값을 반환하거나, 없으면 null을 반환한다.
+     */
     fun getHeader(key: String): String? = headers[key]
 
+    /** 이벤트 유형이 SAVED인지 여부 */
     val isSavedEntity: Boolean get() = eventType == EntityEventType.SAVED
+
+    /** 이벤트 유형이 DELETED인지 여부 */
     val isDeletedEntity: Boolean get() = eventType == EntityEventType.DELETED
 }

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/base/EntityEventType.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/base/EntityEventType.kt
@@ -1,13 +1,34 @@
 package io.bluetape4k.javers.base
 
+/**
+ * 엔티티 상태 변경 이벤트의 유형을 나타내는 열거형.
+ *
+ * - [UNKNOWN]: 알 수 없는 이벤트
+ * - [SAVED]: 엔티티 생성 또는 수정
+ * - [DELETED]: 엔티티 삭제
+ *
+ * ```kotlin
+ * val type = EntityEventType.SAVED
+ * // type.status == "SAVED"
+ * ```
+ */
 enum class EntityEventType(val status: String) {
+
+    /** 알 수 없는 이벤트 */
     UNKNOWN("UNKNOWN"),
+
+    /** 엔티티 생성 또는 수정 */
     SAVED("SAVED"),
+
+    /** 엔티티 삭제 */
     DELETED("DELETED");
 
     override fun toString(): String = status
 
     companion object {
+        /**
+         * [status] 문자열에 해당하는 [EntityEventType]을 반환하거나, 없으면 null을 반환한다.
+         */
         fun valueOf(status: String): EntityEventType? {
             return entries.firstOrNull { it.status == status }
         }

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/BinaryJaversCodec.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/BinaryJaversCodec.kt
@@ -4,6 +4,22 @@ import com.google.gson.JsonObject
 import io.bluetape4k.io.serializer.BinarySerializer
 import io.bluetape4k.logging.KLogging
 
+/**
+ * [JsonObject]를 [BinarySerializer]로 바이너리 직렬화하는 코덱.
+ *
+ * ## 동작/계약
+ * - 내부적으로 [MapJaversCodec]을 사용하여 JsonObject → Map 변환 후 직렬화한다
+ * - [decode] 시 역직렬화 실패하면 null을 반환한다
+ *
+ * ```kotlin
+ * val codec = BinaryJaversCodec(BinarySerializers.Kryo)
+ * val bytes = codec.encode(jsonObject)
+ * val decoded = codec.decode(bytes)
+ * // decoded != null
+ * ```
+ *
+ * @property serializer 바이너리 직렬화에 사용할 [BinarySerializer]
+ */
 class BinaryJaversCodec(
     private val serializer: BinarySerializer,
 ): JaversCodec<ByteArray> {

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/CompressableBinaryJaversCodec.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/CompressableBinaryJaversCodec.kt
@@ -5,6 +5,25 @@ import io.bluetape4k.io.compressor.Compressor
 import io.bluetape4k.io.compressor.Compressors
 
 
+/**
+ * [BinaryJaversCodec] 결과를 [Compressor]로 추가 압축하는 코덱.
+ *
+ * ## 동작/계약
+ * - encode: innerCodec 직렬화 → 압축
+ * - decode: 압축 해제 → innerCodec 역직렬화
+ *
+ * ```kotlin
+ * val codec = CompressableBinaryJaversCodec(
+ *     BinaryJaversCodec(BinarySerializers.Kryo),
+ *     Compressors.LZ4
+ * )
+ * val compressed = codec.encode(jsonObject)
+ * val decoded = codec.decode(compressed)
+ * ```
+ *
+ * @property innerCodec 바이너리 직렬화를 수행하는 내부 코덱
+ * @property compressor 압축/해제에 사용할 [Compressor] (기본값: GZip)
+ */
 class CompressableBinaryJaversCodec(
     private val innerCodec: BinaryJaversCodec,
     private val compressor: Compressor = Compressors.GZip,

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/CompressableStringJaversCodec.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/CompressableStringJaversCodec.kt
@@ -4,6 +4,25 @@ import com.google.gson.JsonObject
 import io.bluetape4k.io.compressor.Compressor
 import io.bluetape4k.io.compressor.Compressors
 
+/**
+ * [StringJaversCodec] 결과를 [Compressor]로 추가 압축하는 문자열 코덱.
+ *
+ * ## 동작/계약
+ * - encode: innerCodec 문자열화 → 압축
+ * - decode: 압축 해제 → innerCodec 파싱
+ *
+ * ```kotlin
+ * val codec = CompressableStringJaversCodec(
+ *     StringJaversCodec(),
+ *     Compressors.LZ4
+ * )
+ * val compressed = codec.encode(jsonObject)
+ * val decoded = codec.decode(compressed)
+ * ```
+ *
+ * @property innerCodec 문자열 변환을 수행하는 내부 코덱
+ * @property compressor 압축/해제에 사용할 [Compressor] (기본값: GZip)
+ */
 class CompressableStringJaversCodec(
     private val innerCodec: StringJaversCodec,
     private val compressor: Compressor = Compressors.GZip,

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/JaversCodec.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/JaversCodec.kt
@@ -2,10 +2,30 @@ package io.bluetape4k.javers.codecs
 
 import com.google.gson.JsonObject
 
+/**
+ * JaVers [JsonObject]를 지정한 형식 [T]로 인코딩/디코딩하는 코덱 인터페이스.
+ *
+ * ## 동작/계약
+ * - [encode]는 [JsonObject]를 대상 형식으로 변환한다
+ * - [decode]는 인코딩된 데이터를 [JsonObject]로 복원하거나, 실패 시 null을 반환한다
+ *
+ * ```kotlin
+ * val codec: JaversCodec<String> = JaversCodecs.String
+ * val encoded = codec.encode(jsonObject)
+ * val decoded = codec.decode(encoded)
+ * // decoded.toString() == jsonObject.toString()
+ * ```
+ */
 interface JaversCodec<T: Any> {
 
+    /**
+     * [JsonObject]를 대상 형식 [T]로 인코딩한다.
+     */
     fun encode(jsonElement: JsonObject): T
 
+    /**
+     * 인코딩된 데이터를 [JsonObject]로 디코딩하거나, 실패 시 null을 반환한다.
+     */
     fun decode(encodedData: T): JsonObject?
 
 }

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/JaversCodecs.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/JaversCodecs.kt
@@ -5,22 +5,50 @@ import io.bluetape4k.io.serializer.BinarySerializers
 import io.bluetape4k.support.unsafeLazy
 
 
+/**
+ * 미리 구성된 [JaversCodec] 인스턴스들을 제공하는 팩토리 객체.
+ *
+ * ## 동작/계약
+ * - 모든 코덱은 lazy 초기화되어 최초 접근 시 생성된다
+ * - String 계열: JSON 문자열 기반 인코딩 (선택적 압축)
+ * - Binary 계열: [BinarySerializer] + 선택적 압축 (Jdk/Kryo/Fory)
+ * - Map 계열: [JsonObject] ↔ `Map<String, Any?>` 변환
+ *
+ * ```kotlin
+ * val codec = JaversCodecs.LZ4String
+ * val encoded = codec.encode(jsonObject)
+ * val decoded = codec.decode(encoded)
+ * // decoded.toString() == jsonObject.toString()
+ * ```
+ */
 object JaversCodecs {
 
+    /** 기본 코덱 ([String]) */
     val Default by unsafeLazy { String }
 
     // String Codecs
 
+    /** JSON 문자열 코덱 (압축 없음) */
     val String by unsafeLazy { StringJaversCodec() }
 
+    /** GZip 압축 문자열 코덱 */
     val GZipString by unsafeLazy { CompressableStringJaversCodec(String, Compressors.GZip) }
+
+    /** Deflate 압축 문자열 코덱 */
     val DeflateString by unsafeLazy { CompressableStringJaversCodec(String, Compressors.Deflate) }
+
+    /** LZ4 압축 문자열 코덱 */
     val LZ4String by unsafeLazy { CompressableStringJaversCodec(String, Compressors.LZ4) }
+
+    /** Snappy 압축 문자열 코덱 */
     val SnappyString by unsafeLazy { CompressableStringJaversCodec(String, Compressors.Snappy) }
+
+    /** Zstd 압축 문자열 코덱 */
     val ZstdString by unsafeLazy { CompressableStringJaversCodec(String, Compressors.Zstd) }
 
-    // Binary Codecs
+    // Binary Codecs - JDK Serialization
 
+    /** JDK 직렬화 바이너리 코덱 */
     val Jdk by unsafeLazy { BinaryJaversCodec(BinarySerializers.Jdk) }
 
     val DeflateJdk by unsafeLazy { CompressableBinaryJaversCodec(Jdk, Compressors.Deflate) }
@@ -29,6 +57,9 @@ object JaversCodecs {
     val SnappyJdk by unsafeLazy { CompressableBinaryJaversCodec(Jdk, Compressors.Snappy) }
     val ZstdJdk by unsafeLazy { CompressableBinaryJaversCodec(Jdk, Compressors.Zstd) }
 
+    // Binary Codecs - Kryo Serialization
+
+    /** Kryo 직렬화 바이너리 코덱 */
     val Kryo by unsafeLazy { BinaryJaversCodec(BinarySerializers.Kryo) }
 
     val DeflateKryo by unsafeLazy { CompressableBinaryJaversCodec(Kryo, Compressors.Deflate) }
@@ -37,6 +68,9 @@ object JaversCodecs {
     val SnappyKryo by unsafeLazy { CompressableBinaryJaversCodec(Kryo, Compressors.Snappy) }
     val ZstdKryo by unsafeLazy { CompressableBinaryJaversCodec(Kryo, Compressors.Zstd) }
 
+    // Binary Codecs - Fory Serialization
+
+    /** Fory 직렬화 바이너리 코덱 */
     val Fory by unsafeLazy { BinaryJaversCodec(BinarySerializers.Fory) }
 
     val DeflateFory by unsafeLazy { CompressableBinaryJaversCodec(Fory, Compressors.Deflate) }
@@ -45,6 +79,8 @@ object JaversCodecs {
     val SnappyFory by unsafeLazy { CompressableBinaryJaversCodec(Fory, Compressors.Snappy) }
     val ZstdFory by unsafeLazy { CompressableBinaryJaversCodec(Fory, Compressors.Zstd) }
 
-    // Map
+    // Map Codec
+
+    /** [JsonObject] ↔ `Map<String, Any?>` 변환 코덱 */
     val Map by unsafeLazy { MapJaversCodec() }
 }

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/MapJaversCodec.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/MapJaversCodec.kt
@@ -2,6 +2,20 @@ package io.bluetape4k.javers.codecs
 
 import com.google.gson.JsonObject
 
+/**
+ * [JsonObject]를 `Map<String, Any?>`로 변환하는 코덱.
+ *
+ * ## 동작/계약
+ * - [JaversGsonElementConverter]를 사용하여 양방향 변환을 수행한다
+ * - [decode]는 항상 non-null [JsonObject]를 반환한다
+ *
+ * ```kotlin
+ * val codec = MapJaversCodec()
+ * val map = codec.encode(jsonObject)
+ * val restored = codec.decode(map)
+ * // restored.toString() == jsonObject.toString()
+ * ```
+ */
 class MapJaversCodec: JaversCodec<Map<String, Any?>> {
 
     override fun encode(jsonElement: JsonObject): Map<String, Any?> {

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/StringJaversCodec.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/codecs/StringJaversCodec.kt
@@ -3,6 +3,20 @@ package io.bluetape4k.javers.codecs
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 
+/**
+ * [JsonObject]를 JSON 문자열로 인코딩/디코딩하는 기본 코덱.
+ *
+ * ## 동작/계약
+ * - [encode]는 [JsonObject.toString]으로 변환한다
+ * - [decode]는 파싱 실패 시 null을 반환한다
+ *
+ * ```kotlin
+ * val codec = StringJaversCodec()
+ * val encoded = codec.encode(jsonObject)
+ * val decoded = codec.decode(encoded)
+ * // decoded.toString() == jsonObject.toString()
+ * ```
+ */
 open class StringJaversCodec: JaversCodec<String> {
 
     override fun encode(jsonElement: JsonObject): String {

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/commit/CommitMetadataExtensions.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/commit/CommitMetadataExtensions.kt
@@ -3,9 +3,28 @@ package io.bluetape4k.javers.commit
 import org.javers.core.commit.CommitId
 import org.javers.core.commit.CommitMetadata
 
+/**
+ * [CommitId]의 majorId와 minorId를 [Pair]로 반환한다.
+ *
+ * ```kotlin
+ * val (major, minor) = commitId.version
+ * // major == commitId.majorId, minor == commitId.minorId
+ * ```
+ */
 val CommitId.version: Pair<Long, Int> get() = Pair(majorId, minorId)
 
+/**
+ * 두 [CommitMetadata]를 커밋 ID 기준으로 비교한다.
+ */
 operator fun CommitMetadata.compareTo(that: CommitMetadata): Int =
     this.id.compareTo(that.id)
 
+/**
+ * 커밋 시각을 epoch 밀리초로 반환한다.
+ *
+ * ```kotlin
+ * val ts = commitMetadata.commitTimestamp
+ * // ts > 0
+ * ```
+ */
 val CommitMetadata.commitTimestamp: Long get() = commitDateInstant.toEpochMilli()

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/commit/SnowflakeCommitIdGenerator.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/commit/SnowflakeCommitIdGenerator.kt
@@ -9,6 +9,24 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Supplier
 import kotlin.concurrent.withLock
 
+/**
+ * [Snowflake] 알고리즘 기반의 [CommitId] 생성기.
+ *
+ * ## 동작/계약
+ * - [get] 호출마다 Snowflake ID를 majorId로, minorId=0인 고유 [CommitId]를 생성한다
+ * - 생성된 [CommitId]별 순서 번호를 [getSeq]로 조회할 수 있다
+ * - 존재하지 않는 [CommitId]로 [getSeq] 호출 시 [NoSuchElementException]을 던진다
+ * - [get]은 lock으로 스레드 안전성을 보장한다
+ *
+ * ```kotlin
+ * val generator = SnowflakeCommitIdGenerator()
+ * val commitId = generator.get()
+ * val seq = generator.getSeq(commitId)
+ * // seq == 1
+ * ```
+ *
+ * @property snowflake ID 생성에 사용할 [Snowflake] 인스턴스
+ */
 class SnowflakeCommitIdGenerator(
     private val snowflake: Snowflake = Snowflakers.Default,
 ): Supplier<CommitId> {
@@ -17,6 +35,11 @@ class SnowflakeCommitIdGenerator(
     private val counter = atomic(0)
     private val lock = reentrantLock()
 
+    /**
+     * 지정한 [commitId]의 순서 번호를 반환한다.
+     *
+     * @throws NoSuchElementException [commitId]가 생성되지 않은 경우
+     */
     fun getSeq(commitId: CommitId): Int =
         commits[commitId] ?: throw NoSuchElementException("Not found commitId [$commitId]")
 

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/diff/ChangeExtensions.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/diff/ChangeExtensions.kt
@@ -11,15 +11,37 @@ import org.javers.core.diff.changetype.container.ListChange
 import org.javers.core.diff.changetype.container.SetChange
 import org.javers.core.diff.changetype.map.MapChange
 
+/**
+ * [Changes]에서 지정한 타입의 변경만 필터링하여 반환한다.
+ *
+ * ```kotlin
+ * val valueChanges = changes.filterByType<ValueChange>()
+ * // valueChanges.all { it is ValueChange } == true
+ * ```
+ */
 inline fun <reified T: Change> Changes.filterByType(): List<T> =
     this.getChangesByType(T::class.java)
 
+/** 배열 변경 여부 */
 val Change.isArrayChange: Boolean get() = this is ArrayChange
+
+/** 리스트 변경 여부 */
 val Change.isListChange: Boolean get() = this is ListChange
+
+/** 맵 변경 여부 */
 val Change.isMapChange: Boolean get() = this is MapChange<*>
+
+/** 셋 변경 여부 */
 val Change.isSetChange: Boolean get() = this is SetChange
+
+/** 참조 변경 여부 */
 val Change.isReferenceChange: Boolean get() = this is ReferenceChange
+
+/** 값 변경 여부 */
 val Change.isValueChange: Boolean get() = this is ValueChange
 
+/** 새 객체 생성 여부 */
 val Change.isNewObject: Boolean get() = this is NewObject
+
+/** 객체 삭제 여부 */
 val Change.isObjectRemoved: Boolean get() = this is ObjectRemoved

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/diff/DiffExtensions.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/diff/DiffExtensions.kt
@@ -3,8 +3,24 @@ package io.bluetape4k.javers.diff
 import org.javers.core.diff.Change
 import org.javers.core.diff.Diff
 
+/**
+ * [Diff]에서 지정한 변경 타입에 해당하는 affected 객체 목록을 반환한다.
+ *
+ * ```kotlin
+ * val removedObjects = diff.objectsByChangeType<ObjectRemoved>()
+ * // removedObjects == [Employee("To Be Fired")]
+ * ```
+ */
 inline fun <reified T: Change> Diff.objectsByChangeType(): MutableList<Any?> =
     getObjectsByChangeType(T::class.java)
 
+/**
+ * [Diff]에서 지정한 타입의 변경 목록을 반환한다.
+ *
+ * ```kotlin
+ * val valueChanges = diff.changesByType<ValueChange>()
+ * // valueChanges.all { it is ValueChange } == true
+ * ```
+ */
 inline fun <reified T: Change> Diff.changesByType(): MutableList<T> =
     getChangesByType(T::class.java)

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/dispatcher/JaversDispatcher.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/dispatcher/JaversDispatcher.kt
@@ -1,37 +1,44 @@
 package io.bluetape4k.javers.dispatcher
 
 /**
- * Domain Object의 Save, Delete 시에 외부로 event sourcing 을 수행하도록 합니다.
+ * 도메인 객체의 저장/삭제 이벤트를 외부에 전파하는 디스패처 인터페이스.
+ *
+ * ## 동작/계약
+ * - [sendSaved]: 객체 생성 또는 수정 시 호출
+ * - [sendDeleted]: 객체 인스턴스 기반 삭제 시 호출
+ * - [sendDeletedById]: ID 기반 삭제 시 호출
  */
 interface JaversDispatcher {
 
     /**
-     * Domain Object 에 대해 Save (Create/Update) 시에 호출되는 메소드입니다. 이를 event sourcing으로 외부에 알립니다.
+     * 도메인 객체 저장(생성/수정) 이벤트를 외부에 전파한다.
      *
-     * @param domainObject 저장된 domain object
+     * @param domainObject 저장된 도메인 객체
      */
     fun sendSaved(domainObject: Any)
 
     /**
-     * Domain Object 삭제 시에 호출되는 메소드
+     * 도메인 객체 삭제 이벤트를 외부에 전파한다.
      *
-     * @param domainObject
+     * @param domainObject 삭제된 도메인 객체
      */
     fun sendDeleted(domainObject: Any)
 
     /**
-     * Domain Object를 Id로 삭제하는 경우 호출되는 메소드
+     * ID 기반 도메인 객체 삭제 이벤트를 외부에 전파한다.
      *
-     * @param domainObjectId 삭제된 domain object의 id
-     * @param domainType domain object의 type 정보
+     * @param domainObjectId 삭제된 도메인 객체의 ID
+     * @param domainType 도메인 객체의 타입 정보
      */
     fun sendDeletedById(domainObjectId: Any, domainType: Class<*>)
 }
 
 /**
- * Domain Object를 Id로 삭제하는 경우 호출되는 메소드
+ * reified 타입 파라미터로 ID 기반 삭제 이벤트를 전파한다.
  *
- * @param domainObjectId 삭제된 domain object의 id
+ * ```kotlin
+ * dispatcher.sendDeletedById<User>(userId)
+ * ```
  */
 inline fun <reified T: Any> JaversDispatcher.sendDeletedById(domainObjectId: Any) {
     sendDeletedById(domainObjectId, T::class.java)

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/dispatcher/internal/CompositeDispatcher.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/dispatcher/internal/CompositeDispatcher.kt
@@ -4,6 +4,14 @@ import io.bluetape4k.collections.forEachCatching
 import io.bluetape4k.javers.dispatcher.JaversDispatcher
 
 
+/**
+ * 여러 [JaversDispatcher]에 이벤트를 순차적으로 전파하는 복합 디스패처.
+ *
+ * ## 동작/계약
+ * - 등록된 모든 디스패처에 이벤트를 전달하며, 개별 디스패처 예외는 무시하고 나머지를 계속 실행한다
+ *
+ * @property dispatchers 이벤트를 전달할 [JaversDispatcher] 컬렉션
+ */
 open class CompositeDispatcher(
     val dispatchers: Collection<JaversDispatcher>,
 ): JaversDispatcher {

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/dispatcher/internal/ConsoleDispatcher.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/dispatcher/internal/ConsoleDispatcher.kt
@@ -3,9 +3,7 @@ package io.bluetape4k.javers.dispatcher.internal
 import io.bluetape4k.javers.dispatcher.JaversDispatcher
 
 /**
- * Domain Object의 변화를 Console로 출력하는 [JaversDispatcher] 입니다.
- *
- * @property logger slf4j logger
+ * 도메인 객체의 변경 이벤트를 표준 출력(Console)으로 출력하는 [JaversDispatcher] 구현체.
  */
 class ConsoleDispatcher: JaversDispatcher {
 

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/dispatcher/internal/DebugDispacher.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/dispatcher/internal/DebugDispacher.kt
@@ -4,12 +4,20 @@ import io.bluetape4k.javers.dispatcher.JaversDispatcher
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
- * 디버그를 위해 Dispatcher에 호출되는 Domain Object를 보관하도록 합니다.
+ * 디스패치된 도메인 객체를 내부에 보관하여 검증할 수 있는 디버그용 [CompositeDispatcher].
  *
- * @param dispatchers 실제로 외부로 event 를 보내는 [JaversDispatcher]의 컬렉션
+ * ## 동작/계약
+ * - 전달된 모든 이벤트 객체를 [CopyOnWriteArrayList]에 보관한다
+ * - [isSaved], [isDeleted], [isDeletedById]로 이벤트 수신 여부를 검증한다
+ * - [clear]로 보관된 이벤트를 모두 초기화한다
+ *
+ * @param dispatchers 실제로 외부로 이벤트를 전파하는 [JaversDispatcher] 컬렉션
  */
 class DebugDispacher(dispatchers: Collection<JaversDispatcher>): CompositeDispatcher(dispatchers) {
 
+    /**
+     * ID 기반 삭제 이벤트 정보를 담는 데이터 클래스.
+     */
     data class DeletedById(val id: Any, val domainType: Class<*>)
 
     private val savedObjects = CopyOnWriteArrayList<Any>()
@@ -31,10 +39,16 @@ class DebugDispacher(dispatchers: Collection<JaversDispatcher>): CompositeDispat
         super.sendDeletedById(domainObjectId, domainType)
     }
 
+    /** 지정한 도메인 객체에 대해 저장 이벤트가 발생했는지 확인한다. */
     fun isSaved(domainObject: Any): Boolean = savedObjects.contains(domainObject)
+
+    /** 지정한 도메인 객체에 대해 삭제 이벤트가 발생했는지 확인한다. */
     fun isDeleted(domainObject: Any): Boolean = deletedObjects.contains(domainObject)
+
+    /** 지정한 ID와 타입으로 삭제 이벤트가 발생했는지 확인한다. */
     fun isDeletedById(id: Any, domainType: Class<*>): Boolean = deletedByIds.contains(DeletedById(id, domainType))
 
+    /** 보관된 모든 이벤트 기록을 초기화한다. */
     fun clear() {
         savedObjects.clear()
         deletedObjects.clear()

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/dispatcher/internal/Slf4jDispatcher.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/dispatcher/internal/Slf4jDispatcher.kt
@@ -4,9 +4,9 @@ import io.bluetape4k.javers.dispatcher.JaversDispatcher
 import io.bluetape4k.logging.info
 
 /**
- * Domain Object의 변화를 [org.slf4j.Logger]로 출력하는 [JaversDispatcher] 입니다.
+ * 도메인 객체의 변경 이벤트를 SLF4J [org.slf4j.Logger]로 출력하는 [JaversDispatcher] 구현체.
  *
- * @property logger slf4j logger
+ * @property logger 이벤트를 기록할 SLF4J 로거
  */
 class Slf4jDispatcher(private val logger: org.slf4j.Logger): JaversDispatcher {
 

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/metamodel/CdoSnapshotSupport.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/metamodel/CdoSnapshotSupport.kt
@@ -6,30 +6,57 @@ import org.javers.core.metamodel.`object`.CdoSnapshot
 import org.javers.core.metamodel.`object`.SnapshotType
 import org.javers.repository.api.QueryParams
 
+/**
+ * [CdoSnapshot]의 속성들을 [mapper]로 변환하여 리스트로 반환한다.
+ */
 fun <R> CdoSnapshot.mapProperties(mapper: (key: String, value: Any?) -> R): List<R> =
     this.state.mapProperties(mapper)
 
+/**
+ * [CdoSnapshot]의 속성들을 순회하며 [consumer]를 실행한다.
+ */
 fun <R> CdoSnapshot.forEachProperties(consumer: (key: String, value: Any?) -> Unit): Unit =
     this.state.forEachProperty(consumer)
 
+/**
+ * 지정한 [commitId] 이전(이하)의 스냅샷만 필터링한다.
+ */
 fun Sequence<CdoSnapshot>.filterByToCommitId(commitId: CommitId): Sequence<CdoSnapshot> =
     filter { it.commitId.isBeforeOrEqual(commitId) }
 
+/**
+ * 지정한 [commitIds]에 포함되는 스냅샷만 필터링한다.
+ */
 fun Sequence<CdoSnapshot>.filterByCommitIds(commitIds: Collection<CommitId>): Sequence<CdoSnapshot> =
     filter { commitIds.contains(it.commitId) }
 
+/**
+ * 지정한 [version]과 일치하는 스냅샷만 필터링한다.
+ */
 fun Sequence<CdoSnapshot>.filterByVersion(version: Long): Sequence<CdoSnapshot> =
     filter { it.version == version }
 
+/**
+ * 지정한 [author]가 커밋한 스냅샷만 필터링한다.
+ */
 fun Sequence<CdoSnapshot>.filterByAuthor(author: String): Sequence<CdoSnapshot> =
     filter { it.commitMetadata.author == author }
 
+/**
+ * [QueryParams]의 from~to 날짜 범위에 포함되는 스냅샷만 필터링한다.
+ */
 fun Sequence<CdoSnapshot>.filterByCommitDate(queryParams: QueryParams): Sequence<CdoSnapshot> =
     filter { queryParams.isDateInRange(it.commitMetadata.commitDate) }
 
+/**
+ * 지정한 [propertyName]에 변경이 있는 스냅샷만 필터링한다.
+ */
 fun Sequence<CdoSnapshot>.filterByChangedPropertyName(propertyName: String): Sequence<CdoSnapshot> =
     filter { it.hasChangeAt(propertyName) }
 
+/**
+ * 지정한 [propertyNames] 중 하나라도 변경된 스냅샷만 필터링한다.
+ */
 fun Sequence<CdoSnapshot>.filterByChangedPropertyNames(propertyNames: Set<String>): Sequence<CdoSnapshot> =
     filter { snapshot ->
         propertyNames.any { propertyName ->
@@ -37,9 +64,15 @@ fun Sequence<CdoSnapshot>.filterByChangedPropertyNames(propertyNames: Set<String
         }
     }
 
+/**
+ * 지정한 [snapshotType]과 일치하는 스냅샷만 필터링한다.
+ */
 fun Sequence<CdoSnapshot>.filterByType(snapshotType: SnapshotType): Sequence<CdoSnapshot> =
     filter { it.type == snapshotType }
 
+/**
+ * 커밋 속성(properties)이 [commitProperties] 조건을 모두 만족하는 스냅샷만 필터링한다.
+ */
 fun Sequence<CdoSnapshot>.filterByCommitProperties(
     commitProperties: Map<String, Collection<String>>,
 ): Sequence<CdoSnapshot> =
@@ -50,5 +83,8 @@ fun Sequence<CdoSnapshot>.filterByCommitProperties(
         }
     }
 
+/**
+ * [skip]개를 건너뛰고 [limit]개만 취하여 리스트로 반환한다.
+ */
 fun Sequence<CdoSnapshot>.trimToRequestedSlice(skip: Int, limit: Int): List<CdoSnapshot> =
     drop(skip).take(limit).toList()

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/metamodel/GlobalIdExtensions.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/metamodel/GlobalIdExtensions.kt
@@ -6,6 +6,13 @@ import org.javers.core.metamodel.`object`.ValueObjectId
 import org.javers.core.metamodel.type.EntityType
 import org.javers.core.metamodel.type.ManagedType
 
+/**
+ * 현재 [GlobalId]가 [childCandidate]의 부모인지 확인한다.
+ *
+ * ## 동작/계약
+ * - 현재 ID가 [InstanceId]이고 [childCandidate]가 [ValueObjectId]이며, 그 소유자가 현재 ID인 경우 true
+ * - 그 외에는 false
+ */
 fun GlobalId.isParent(childCandidate: GlobalId): Boolean {
     if (this !is InstanceId || childCandidate !is ValueObjectId) {
         return false
@@ -13,6 +20,13 @@ fun GlobalId.isParent(childCandidate: GlobalId): Boolean {
     return childCandidate.ownerId == this
 }
 
+/**
+ * 현재 [GlobalId]가 [parentCandidate] 타입의 자식인지 확인한다.
+ *
+ * ## 동작/계약
+ * - [parentCandidate]가 [EntityType]이고 현재 ID가 [ValueObjectId]이며, 그 소유자가 해당 엔티티 타입인 경우 true
+ * - 그 외에는 false
+ */
 fun GlobalId.isChild(parentCandidate: ManagedType): Boolean {
     if (parentCandidate !is EntityType || this !is ValueObjectId) {
         return false

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/AbstractCdoSnapshotRepository.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/AbstractCdoSnapshotRepository.kt
@@ -34,12 +34,18 @@ import kotlin.concurrent.withLock
 import kotlin.jvm.optionals.getOrNull
 
 /**
- * [CdoSnapshotRepository] 를 구현한 최상위 추상화 클래스입니다.
- * [CdoSnapshot] 을 저장소에 저장하고, 로드하는 역할을 수행합니다.
+ * [CdoSnapshotRepository]의 공통 구현을 제공하는 추상 클래스.
  *
- * @param T
- * @property codec 저장소에 저장할 때 [CdoSnapshot] 을 인코딩할 codec
- * @property commitIdSupplier snapshot.commitMetadata.id 값을 제공하는 [Snowflake]
+ * ## 동작/계약
+ * - [JaversCodec]를 사용하여 [CdoSnapshot] ↔ 인코딩 형식 [T] 변환을 수행한다
+ * - [persist] 시 lock으로 스레드 안전성을 보장하고, [Snowflake] 기반 시퀀스를 할당한다
+ * - [QueryParams] 기반 필터링(author, date, version, commitId 등)을 공통으로 처리한다
+ * - 하위 클래스는 [getKeys], [contains], [getSeq], [updateCommitId], [getSnapshotSize],
+ *   [saveSnapshot], [loadSnapshots]를 구현해야 한다
+ *
+ * @param T 인코딩된 스냅샷 데이터의 타입 (예: String, ByteArray)
+ * @property codec 스냅샷 인코딩/디코딩에 사용할 [JaversCodec]
+ * @property commitIdSupplier 커밋 시퀀스 번호를 생성하는 [Snowflake]
  */
 abstract class AbstractCdoSnapshotRepository<T: Any>(
     protected val codec: JaversCodec<T>,

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/CdoSnapshotRepository.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/CdoSnapshotRepository.kt
@@ -5,13 +5,33 @@ import org.javers.core.metamodel.`object`.GlobalId
 import org.javers.repository.api.JaversRepository
 
 /**
- * [JaversRepository]를 상속받아 [CdoSnapshot]을 저장소에 저장, 로드하는 기본 Repository
+ * [CdoSnapshot]을 저장·로드하는 JaVers 저장소 인터페이스.
+ *
+ * ## 동작/계약
+ * - [saveSnapshot]으로 단일 스냅샷을 저장한다
+ * - [loadSnapshots]로 GlobalId에 해당하는 스냅샷 목록을 조회한다 (최신순)
+ *
+ * ```kotlin
+ * val repo: CdoSnapshotRepository = CaffeineCdoSnapshotRepository()
+ * val javers = JaversBuilder.javers()
+ *     .registerJaversRepository(repo)
+ *     .build()
+ * ```
  */
 interface CdoSnapshotRepository: JaversRepository {
 
+    /**
+     * [CdoSnapshot]을 저장소에 저장한다.
+     */
     fun saveSnapshot(snapshot: CdoSnapshot)
 
+    /**
+     * 지정한 GlobalId 값에 해당하는 스냅샷 목록을 반환한다.
+     */
     fun loadSnapshots(globalIdValue: String): List<CdoSnapshot>
 
+    /**
+     * 지정한 [GlobalId]에 해당하는 스냅샷 목록을 반환한다.
+     */
     fun loadSnapshots(globalId: GlobalId): List<CdoSnapshot> = loadSnapshots(globalId.value())
 }

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/cache2k/Cache2KCdoSnapshotRepository.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/cache2k/Cache2KCdoSnapshotRepository.kt
@@ -12,9 +12,21 @@ import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
 /**
- * [CdoSnapshot] 저장소로 [io.bluetape4k.cache.cache2k.cache2k] 를 사용하는 Repository 입니다.
+ * Cache2k 기반의 인메모리 [CdoSnapshot] 저장소.
  *
- * @param codec [CdoSnapshot] 변환을 위한 [JaversCodec] 인스턴스
+ * ## 동작/계약
+ * - [Cache] 인스턴스를 사용하여 GlobalId별 스냅샷 목록을 메모리에 보관한다
+ * - 스냅샷은 최신순으로 리스트 앞쪽에 삽입된다 (index 0)
+ * - lock으로 동시 쓰기 안전성을 보장한다
+ *
+ * ```kotlin
+ * val repo = Cache2KCdoSnapshotRepository()
+ * val javers = JaversBuilder.javers()
+ *     .registerJaversRepository(repo)
+ *     .build()
+ * ```
+ *
+ * @param codec 스냅샷 인코딩/디코딩에 사용할 [JaversCodec] (기본값: LZ4 압축 문자열)
  */
 class Cache2KCdoSnapshotRepository(
     codec: JaversCodec<String> = JaversCodecs.LZ4String,

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/caffeine/CaffeineCdoSnapshotRepository.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/caffeine/CaffeineCdoSnapshotRepository.kt
@@ -12,9 +12,21 @@ import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
 /**
- * [CdoSnapshot] 저장소로 [com.github.benmanes.caffeine.cache.Cache] 를 사용하는 Repository 입니다.
+ * Caffeine 캐시 기반의 인메모리 [CdoSnapshot] 저장소.
  *
- * @param codec [CdoSnapshot] 변환을 위한 [JaversCodec] 인스턴스
+ * ## 동작/계약
+ * - [Cache] 인스턴스를 사용하여 GlobalId별 스냅샷 목록을 메모리에 보관한다
+ * - 스냅샷은 최신순으로 리스트 앞쪽에 삽입된다 (index 0)
+ * - lock으로 동시 쓰기 안전성을 보장한다
+ *
+ * ```kotlin
+ * val repo = CaffeineCdoSnapshotRepository()
+ * val javers = JaversBuilder.javers()
+ *     .registerJaversRepository(repo)
+ *     .build()
+ * ```
+ *
+ * @param codec 스냅샷 인코딩/디코딩에 사용할 [JaversCodec] (기본값: LZ4 압축 문자열)
  */
 class CaffeineCdoSnapshotRepository(
     codec: JaversCodec<String> = JaversCodecs.LZ4String,

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/jcache/JCacheCdoSnapshotRepository.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/jcache/JCacheCdoSnapshotRepository.kt
@@ -13,11 +13,16 @@ import javax.cache.expiry.EternalExpiryPolicy
 import kotlin.concurrent.withLock
 
 /**
- * [CdoSnapshot] 저장소로 [javax.cache.Cache] 를 사용하는 Repository 입니다.
+ * JCache(JSR-107) 기반의 [CdoSnapshot] 저장소.
  *
- * @param prefix  cache name prefix
+ * ## 동작/계약
+ * - [javax.cache.Cache]를 사용하여 GlobalId별 스냅샷 목록을 보관한다
+ * - JCache는 기본적으로 값 복사(store by value)로 동작하므로, 쓰기 시 put을 다시 호출해야 한다
+ * - lock으로 동시 쓰기 안전성을 보장한다
+ *
+ * @param prefix 캐시 이름 접두사
  * @param cacheManager [javax.cache.CacheManager] 인스턴스
- * @param codec [CdoSnapshot] 변환을 위한 [JaversCodec] 인스턴스
+ * @param codec 스냅샷 인코딩/디코딩에 사용할 [JaversCodec] (기본값: LZ4 압축 문자열)
  */
 class JCacheCdoSnapshotRepository(
     prefix: String,

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/jql/JqlQueryExtensions.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/jql/JqlQueryExtensions.kt
@@ -8,19 +8,37 @@ import org.javers.shadow.Shadow
 import java.util.stream.Stream
 import kotlin.streams.asSequence
 
-// TODO: 필요없을 것 같다.
-
+/**
+ * [JqlQuery]에서 Shadow 목록을 조회한다.
+ *
+ * ```kotlin
+ * val query = queryByInstanceId<Person>("bob")
+ * val shadows = query.findShadows<Person>(javers)
+ * ```
+ */
 inline fun <reified T: Any> JqlQuery.findShadows(javers: Javers): MutableList<Shadow<T>> =
     javers.findShadows(this)
 
+/**
+ * [JqlQuery]에서 Shadow를 [Stream]으로 조회한다.
+ */
 inline fun <reified T: Any> JqlQuery.findShadowsAndStream(javers: Javers): Stream<Shadow<T>> =
     javers.findShadowsAndStream(this)
 
+/**
+ * [JqlQuery]에서 Shadow를 [Sequence]로 조회한다.
+ */
 inline fun <reified T: Any> JqlQuery.findShadowsAndSequence(javers: Javers): Sequence<Shadow<T>> =
     javers.findShadowsAndStream<T>(this).asSequence()
 
+/**
+ * [JqlQuery]에서 스냅샷 목록을 조회한다.
+ */
 fun JqlQuery.findSnapshots(javers: Javers): MutableList<CdoSnapshot> =
     javers.findSnapshots(this)
 
+/**
+ * [JqlQuery]에서 변경 목록을 조회한다.
+ */
 fun JqlQuery.findChanges(javers: Javers): Changes =
     javers.findChanges(this)

--- a/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/jql/QueryBuilderExtensions.kt
+++ b/javers/core/src/main/kotlin/io/bluetape4k/javers/repository/jql/QueryBuilderExtensions.kt
@@ -4,18 +4,42 @@ import org.javers.repository.jql.JqlQuery
 import org.javers.repository.jql.QueryBuilder
 import kotlin.reflect.KClass
 
+/**
+ * 모든 도메인 객체를 대상으로 [JqlQuery]를 생성한다.
+ *
+ * ```kotlin
+ * val query = queryAnyDomainObject { limit(10) }
+ * val snapshots = javers.findSnapshots(query)
+ * ```
+ */
 inline fun queryAnyDomainObject(
     @BuilderInference builder: QueryBuilder.() -> Unit = {},
 ): JqlQuery {
     return QueryBuilder.anyDomainObject().apply(builder).build()
 }
 
+/**
+ * 지정한 타입의 엔티티를 대상으로 [JqlQuery]를 생성한다.
+ *
+ * ```kotlin
+ * val query = query<Person> { limit(5) }
+ * val changes = javers.findChanges(query)
+ * ```
+ */
 inline fun <reified T: Any> query(
     @BuilderInference builder: QueryBuilder.() -> Unit,
 ): JqlQuery {
     return QueryBuilder.byClass(T::class.java).apply(builder).build()
 }
 
+/**
+ * 특정 엔티티 인스턴스를 대상으로 [JqlQuery]를 생성한다.
+ *
+ * ```kotlin
+ * val query = queryByInstance(person) { limit(10) }
+ * val snapshots = javers.findSnapshots(query)
+ * ```
+ */
 inline fun <reified T: Any> queryByInstance(
     instance: T,
     @BuilderInference builder: QueryBuilder.() -> Unit = {},
@@ -23,6 +47,15 @@ inline fun <reified T: Any> queryByInstance(
     return QueryBuilder.byInstance(instance).apply(builder).build()
 }
 
+/**
+ * 엔티티의 로컬 ID로 [JqlQuery]를 생성한다.
+ *
+ * ```kotlin
+ * val query = queryByInstanceId<Person>("bob")
+ * val shadows = javers.findShadows<Person>(query)
+ * // shadows.size >= 1
+ * ```
+ */
 inline fun <reified T: Any> queryByInstanceId(
     localId: Any,
     @BuilderInference builder: QueryBuilder.() -> Unit = {},
@@ -30,6 +63,9 @@ inline fun <reified T: Any> queryByInstanceId(
     return QueryBuilder.byInstanceId(localId, T::class.java).apply(builder).build()
 }
 
+/**
+ * 지정한 타입의 ValueObject를 [path]로 조회하는 [JqlQuery]를 생성한다.
+ */
 inline fun <reified T: Any> queryByValueObject(
     path: String,
     @BuilderInference builder: QueryBuilder.() -> Unit = {},
@@ -37,6 +73,9 @@ inline fun <reified T: Any> queryByValueObject(
     return QueryBuilder.byValueObject(T::class.java, path).apply(builder).build()
 }
 
+/**
+ * 소유자의 로컬 ID와 [path]로 ValueObject를 조회하는 [JqlQuery]를 생성한다.
+ */
 inline fun <reified T: Any> queryByValueObjectId(
     ownerLocalId: Any,
     path: String,
@@ -45,12 +84,23 @@ inline fun <reified T: Any> queryByValueObjectId(
     return QueryBuilder.byValueObjectId(ownerLocalId, T::class.java, path).apply(builder).build()
 }
 
+/**
+ * 지정한 클래스를 대상으로 [JqlQuery]를 생성한다.
+ *
+ * ```kotlin
+ * val query = queryByClass<Person> { withNewObjectChanges() }
+ * val changes = javers.findChanges(query)
+ * ```
+ */
 inline fun <reified T: Any> queryByClass(
     @BuilderInference builder: QueryBuilder.() -> Unit = {},
 ): JqlQuery {
     return QueryBuilder.byClass(T::class.java).apply(builder).build()
 }
 
+/**
+ * 여러 Java 클래스([Collection])를 대상으로 [JqlQuery]를 생성한다.
+ */
 @JvmName("queryByClassesCollection")
 inline fun queryByClasses(
     classes: Collection<Class<*>>,
@@ -59,6 +109,9 @@ inline fun queryByClasses(
     return QueryBuilder.byClass(*classes.toTypedArray()).apply(builder).build()
 }
 
+/**
+ * 여러 Java 클래스(vararg)를 대상으로 [JqlQuery]를 생성한다.
+ */
 @JvmName("queryByClassesArray")
 inline fun queryByClasses(
     vararg classes: Class<*>,
@@ -67,7 +120,9 @@ inline fun queryByClasses(
     return QueryBuilder.byClass(*classes).apply(builder).build()
 }
 
-
+/**
+ * 여러 Kotlin 클래스([Collection])를 대상으로 [JqlQuery]를 생성한다.
+ */
 inline fun queryByClasses(
     kclasses: Collection<KClass<*>>,
     @BuilderInference builder: QueryBuilder.() -> Unit = {},
@@ -75,6 +130,9 @@ inline fun queryByClasses(
     return QueryBuilder.byClass(*kclasses.map { it.java }.toTypedArray()).apply(builder).build()
 }
 
+/**
+ * 여러 Kotlin 클래스(vararg)를 대상으로 [JqlQuery]를 생성한다.
+ */
 inline fun queryByClasses(
     vararg kclasses: KClass<*>,
     @BuilderInference builder: QueryBuilder.() -> Unit = {},

--- a/javers/core/src/test/kotlin/io/bluetape4k/javers/JaversExtensionsTest.kt
+++ b/javers/core/src/test/kotlin/io/bluetape4k/javers/JaversExtensionsTest.kt
@@ -1,9 +1,171 @@
 package io.bluetape4k.javers
 
+import io.bluetape4k.javers.examples.Address
+import io.bluetape4k.javers.examples.Person
+import io.bluetape4k.javers.repository.jql.queryByClass
+import io.bluetape4k.javers.repository.jql.queryByInstanceId
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeEmpty
+import org.amshove.kluent.shouldNotBeNull
+import org.javers.core.Javers
+import org.javers.core.JaversBuilder
+import org.javers.core.metamodel.`object`.InstanceId
+import org.javers.core.metamodel.type.EntityType
+import org.javers.core.metamodel.type.ValueObjectType
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class JaversExtensionsTest {
 
     companion object: KLogging()
 
+    private lateinit var javers: Javers
+
+    @BeforeEach
+    fun beforeEach() {
+        javers = JaversBuilder.javers().build()
+    }
+
+    @Test
+    fun `getEntityTypeMapping - reified 타입으로 EntityType 매핑을 조회한다`() {
+        val entityType = javers.getEntityTypeMapping<Person>()
+
+        entityType shouldBeInstanceOf EntityType::class
+        entityType.baseJavaType shouldBeEqualTo Person::class.java
+        log.debug { "EntityType: ${entityType.prettyPrint()}" }
+    }
+
+    @Test
+    fun `getValueObjectTypeMapping - reified 타입으로 ValueObjectType 매핑을 조회한다`() {
+        val voType = javers.getValueObjectTypeMapping<Address>()
+
+        voType shouldBeInstanceOf ValueObjectType::class
+        voType.baseJavaType shouldBeEqualTo Address::class.java
+        log.debug { "ValueObjectType: ${voType.prettyPrint()}" }
+    }
+
+    @Test
+    fun `createEntityInstanceId - 엔티티 인스턴스로부터 InstanceId를 생성한다`() {
+        val bob = Person("Bob", "Bob Smart")
+        val id = javers.createEntityInstanceId(bob)
+
+        id shouldBeInstanceOf InstanceId::class
+        id.value() shouldBeEqualTo "Person/Bob"
+        log.debug { "InstanceId: ${id.value()}" }
+    }
+
+    @Test
+    fun `createEntityInstanceIdByEntityId - 로컬 ID로 InstanceId를 생성한다`() {
+        val id = javers.createEntityInstanceIdByEntityId<Person>("Alice")
+
+        id shouldBeInstanceOf InstanceId::class
+        id.value() shouldBeEqualTo "Person/Alice"
+        log.debug { "InstanceId by entityId: ${id.value()}" }
+    }
+
+    @Test
+    fun `compareCollections - 두 컬렉션의 차이를 비교한다`() {
+        val oldList = listOf(Person("Tommy", "Tommy Smart"))
+        val newList = listOf(Person("Tommy", "Tommy C. Smart"))
+
+        val diff = javers.compareCollections(oldList, newList)
+
+        diff.changes.shouldNotBeEmpty()
+        diff.changes.size shouldBeEqualTo 1
+        log.debug { "Diff: ${diff.prettyPrint()}" }
+    }
+
+    @Test
+    fun `compareCollections - 동일 컬렉션은 변경 사항이 없다`() {
+        val list1 = listOf(Person("A", "Name A"), Person("B", "Name B"))
+        val list2 = listOf(Person("A", "Name A"), Person("B", "Name B"))
+
+        val diff = javers.compareCollections(list1, list2)
+
+        diff.changes.size shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `latestSnapshotOrNull - 커밋된 엔티티의 최신 스냅샷을 조회한다`() {
+        val bob = Person("Bob", "Bob Smart")
+        javers.commit("author", bob)
+
+        val snapshot = javers.latestSnapshotOrNull<Person>("Bob")
+
+        snapshot.shouldNotBeNull()
+        snapshot.globalId.value() shouldBeEqualTo "Person/Bob"
+        log.debug { "Latest snapshot: ${snapshot.globalId.value()}, version=${snapshot.version}" }
+    }
+
+    @Test
+    fun `latestSnapshotOrNull - 커밋되지 않은 엔티티는 null을 반환한다`() {
+        val snapshot = javers.latestSnapshotOrNull<Person>("NonExistent")
+        snapshot.shouldBeNull()
+    }
+
+    @Test
+    fun `latestSnapshotOrNull - KClass 파라미터로 조회한다`() {
+        val bob = Person("Bob", "Bob Smart")
+        javers.commit("author", bob)
+
+        val snapshot = javers.latestSnapshotOrNull("Bob", Person::class)
+
+        snapshot.shouldNotBeNull()
+        snapshot.globalId.value() shouldBeEqualTo "Person/Bob"
+    }
+
+    @Test
+    fun `getShadow - 스냅샷을 Shadow로 변환한다`() {
+        val bob = Person("Bob", "Bob Smart")
+        val commit = javers.commit("author", bob)
+        val snapshot = commit.snapshots.first()
+
+        val shadow = javers.getShadow<Person>(snapshot)
+
+        shadow.shouldNotBeNull()
+        shadow.get().login shouldBeEqualTo "Bob"
+        shadow.get().name shouldBeEqualTo "Bob Smart"
+        log.debug { "Shadow: ${shadow.get()}" }
+    }
+
+    @Test
+    fun `shadowFactory - Javers에서 ShadowFactory를 얻는다`() {
+        val factory = javers.shadowFactory
+        factory.shouldNotBeNull()
+    }
+
+    @Test
+    fun `findShadowsAndSequence - JQL로 Shadow를 Sequence로 조회한다`() {
+        val bob = Person("Bob", "Bob Smart")
+        javers.commit("author", bob)
+
+        bob.name = "Bob C. Smart"
+        javers.commit("author", bob)
+
+        val query = queryByInstanceId<Person>("Bob")
+        val shadows = javers.findShadowsAndSequence<Person>(query).toList()
+
+        shadows.size shouldBeGreaterOrEqualTo 2
+        shadows.first().get().name shouldBeEqualTo "Bob C. Smart"
+        log.debug { "Shadows count: ${shadows.size}" }
+    }
+
+    @Test
+    fun `queryByClass를 사용하여 특정 타입의 스냅샷을 조회한다`() {
+        val bob = Person("Bob", "Bob Smart")
+        val alice = Person("Alice", "Alice Wonder")
+        javers.commit("author", bob)
+        javers.commit("author", alice)
+
+        val query = queryByClass<Person>()
+        val snapshots = javers.findSnapshots(query)
+
+        snapshots.size shouldBeGreaterOrEqualTo 2
+        log.debug { "Found ${snapshots.size} snapshots for Person" }
+    }
 }

--- a/javers/persistence-kafka/src/main/kotlin/io/bluetape4k/javers/persistence/kafka/repository/KafkaCdoSnapshotRepository.kt
+++ b/javers/persistence-kafka/src/main/kotlin/io/bluetape4k/javers/persistence/kafka/repository/KafkaCdoSnapshotRepository.kt
@@ -10,8 +10,21 @@ import org.javers.core.metamodel.`object`.CdoSnapshot
 import org.springframework.kafka.core.KafkaTemplate
 
 /**
- * Javers 의 Audit 정보를 Kafka 로 발행합니다.
- * 저장소로 쓰이는 것이 아니므로, 저장 역할만 가능하고, 조회 기능은 없습니다.
+ * JaVers [CdoSnapshot]을 Kafka 토픽으로 발행하는 쓰기 전용 저장소.
+ *
+ * ## 동작/계약
+ * - [saveSnapshot]에서 [KafkaTemplate.sendDefault]로 GlobalId를 key, 인코딩된 스냅샷을 value로 발행한다
+ * - 발행 실패 시 예외를 로깅하고 삼킨다 (조용한 실패)
+ * - 조회 메서드([loadSnapshots], [getKeys] 등)는 항상 빈 컬렉션/0을 반환한다
+ * - 코덱은 [JaversCodecs.String] (비압축 JSON 문자열)을 사용한다
+ *
+ * ```kotlin
+ * val repo = KafkaCdoSnapshotRepository(kafkaTemplate)
+ * val javers = JaversBuilder.javers()
+ *     .registerJaversRepository(repo)
+ *     .build()
+ * // javers.commit("author", entity) → Kafka 토픽으로 스냅샷 발행
+ * ```
  *
  * @property kafkaOperations [KafkaTemplate] 인스턴스
  */

--- a/javers/persistence-redis/src/main/kotlin/io/bluetape4k/javers/persistence/redis/repository/LettuceCdoSnapshotRepository.kt
+++ b/javers/persistence-redis/src/main/kotlin/io/bluetape4k/javers/persistence/redis/repository/LettuceCdoSnapshotRepository.kt
@@ -17,10 +17,24 @@ import org.javers.core.commit.CommitId
 import org.javers.core.metamodel.`object`.CdoSnapshot
 
 /**
- * JaVers [CdoSnapshot] 을 Lettuce Library를 이용하여
- * Redis Server에 저장, 로드하는 기능을 제공하는 [AbstractCdoSnapshotRepository] 구현체입니다.
+ * Lettuce 기반 Redis [CdoSnapshot] 저장소.
  *
- * @param name repository name
+ * ## 동작/계약
+ * - GlobalId별 스냅샷을 Redis LIST(`javers:{name}:snapshot:{globalId}`)에 LPUSH로 최신순 저장한다
+ * - [saveSnapshot]은 MULTI/EXEC 트랜잭션으로 LIST 저장 + HSET GlobalId 등록을 원자적으로 수행한다
+ * - 트랜잭션 실패 시 DISCARD 후 예외를 로깅한다
+ * - 코덱 기본값은 [JaversCodecs.LZ4Fory] (LZ4 압축 + Fory 직렬화)이다
+ *
+ * ```kotlin
+ * val repo = LettuceCdoSnapshotRepository("user", redisClient)
+ * val javers = JaversBuilder.javers()
+ *     .registerJaversRepository(repo)
+ *     .build()
+ * javers.commit("author", entity)
+ * val snapshots = javers.findSnapshots(queryByClass<Person>())
+ * ```
+ *
+ * @param name 저장소 이름 (Redis key prefix에 사용)
  * @param client Lettuce [RedisClient] 인스턴스
  * @param codec [CdoSnapshot]을 encode/decode 할 [JaversCodec] 인스턴스
  */

--- a/javers/persistence-redis/src/main/kotlin/io/bluetape4k/javers/persistence/redis/repository/RedissonCdoSnapshotRepository.kt
+++ b/javers/persistence-redis/src/main/kotlin/io/bluetape4k/javers/persistence/redis/repository/RedissonCdoSnapshotRepository.kt
@@ -15,10 +15,24 @@ import org.redisson.api.RedissonClient
 import org.redisson.client.codec.LongCodec
 
 /**
- * JaVers [CdoSnapshot] 을 Redisson Library를 이용하여
- * Redis Server에 저장, 로드하는 기능을 제공하는 [AbstractCdoSnapshotRepository] 구현체입니다.
+ * Redisson 기반 Redis [CdoSnapshot] 저장소.
  *
- * @param name repository name
+ * ## 동작/계약
+ * - [RListMultimap]으로 GlobalId별 스냅샷 바이트 배열을 관리한다
+ * - [loadSnapshots]는 Multimap에서 조회 후 역순 정렬하여 최신순으로 반환한다
+ * - CommitId → Sequence 매핑은 [RMap]에 [LongCodec]으로 저장한다
+ * - 코덱 기본값은 [JaversCodecs.LZ4Fory] (LZ4 압축 + Fory 직렬화)이다
+ *
+ * ```kotlin
+ * val repo = RedissonCdoSnapshotRepository("user", redissonClient)
+ * val javers = JaversBuilder.javers()
+ *     .registerJaversRepository(repo)
+ *     .build()
+ * javers.commit("author", entity)
+ * val snapshots = javers.findSnapshots(queryByClass<Person>())
+ * ```
+ *
+ * @param name 저장소 이름 (Redis key prefix에 사용)
  * @param redisson [RedissonClient] 인스턴스
  * @param codec [CdoSnapshot]을 encode/decode 할 [JaversCodec] 인스턴스
  */

--- a/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/ReactiveCassandraBatchOperationsCoroutines.kt
+++ b/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/ReactiveCassandraBatchOperationsCoroutines.kt
@@ -6,27 +6,99 @@ import kotlinx.coroutines.reactor.mono
 import org.springframework.data.cassandra.core.ReactiveCassandraBatchOperations
 import org.springframework.data.cassandra.core.cql.WriteOptions
 
+/**
+ * [Flow] 엔티티를 수집해 배치 insert 대상으로 추가합니다.
+ *
+ * ## 동작/계약
+ * - `Flow`를 `toList()`로 모두 수집한 뒤 Reactor `mono`로 감싸 `insert`에 전달합니다.
+ * - 반환값은 동일한 [ReactiveCassandraBatchOperations] 체인 객체입니다.
+ *
+ * ```kotlin
+ * val entities = flowOf(group1, group2)
+ * // result == batchOps.insertFlow(entities)
+ * ```
+ */
 fun ReactiveCassandraBatchOperations.insertFlow(entities: Flow<*>): ReactiveCassandraBatchOperations =
     insert(mono { entities.toList() })
 
+/**
+ * [Flow] 엔티티를 수집해 [WriteOptions]와 함께 배치 insert 대상으로 추가합니다.
+ *
+ * ## 동작/계약
+ * - `Flow`를 리스트로 수집한 뒤 `insert(mono { ... }, options)`에 위임합니다.
+ * - `options`는 LWT/TTL 등 Spring Data 배치 옵션 해석 규칙을 그대로 따릅니다.
+ *
+ * ```kotlin
+ * val options = writeOptions { ttl(30) }
+ * // result == batchOps.insertFlow(flowOf(group1, group2), options)
+ * ```
+ */
 fun ReactiveCassandraBatchOperations.insertFlow(
     entities: Flow<*>,
     options: WriteOptions,
 ): ReactiveCassandraBatchOperations =
     insert(mono { entities.toList() }, options)
 
+/**
+ * [Flow] 엔티티를 수집해 배치 update 대상으로 추가합니다.
+ *
+ * ## 동작/계약
+ * - `Flow`를 리스트로 수집한 뒤 `update(mono { ... })`를 호출합니다.
+ * - 반환값은 후속 배치 체이닝이 가능한 동일 객체입니다.
+ *
+ * ```kotlin
+ * val entities = flowOf(group1, group2)
+ * // result == batchOps.updateFlow(entities)
+ * ```
+ */
 fun ReactiveCassandraBatchOperations.updateFlow(entities: Flow<*>): ReactiveCassandraBatchOperations =
     update(mono { entities.toList() })
 
+/**
+ * [Flow] 엔티티를 수집해 [WriteOptions]와 함께 배치 update 대상으로 추가합니다.
+ *
+ * ## 동작/계약
+ * - `Flow`를 리스트로 수집한 뒤 `update(mono { ... }, options)`에 전달합니다.
+ * - 옵션 적용 여부는 Spring Data의 배치 update 구현에 위임됩니다.
+ *
+ * ```kotlin
+ * val options = writeOptions { ttl(30) }
+ * // result == batchOps.updateFlow(flowOf(group1, group2), options)
+ * ```
+ */
 fun ReactiveCassandraBatchOperations.updateFlow(
     entities: Flow<*>,
     options: WriteOptions,
 ): ReactiveCassandraBatchOperations =
     update(mono { entities.toList() }, options)
 
+/**
+ * [Flow] 엔티티를 수집해 배치 delete 대상으로 추가합니다.
+ *
+ * ## 동작/계약
+ * - `Flow`를 리스트로 수집한 뒤 `delete(mono { ... })`를 호출합니다.
+ * - 반환값은 동일한 [ReactiveCassandraBatchOperations] 체인 객체입니다.
+ *
+ * ```kotlin
+ * val entities = flowOf(group1, group2)
+ * // result == batchOps.deleteFlow(entities)
+ * ```
+ */
 fun ReactiveCassandraBatchOperations.deleteFlow(entities: Flow<*>): ReactiveCassandraBatchOperations =
     delete(mono { entities.toList() })
 
+/**
+ * [Flow] 엔티티를 수집해 [WriteOptions]와 함께 배치 delete 대상으로 추가합니다.
+ *
+ * ## 동작/계약
+ * - `Flow`를 리스트로 수집한 뒤 `delete(mono { ... }, options)`에 전달합니다.
+ * - 옵션 해석 및 예외 처리는 Spring Data 배치 delete 구현에 위임됩니다.
+ *
+ * ```kotlin
+ * val options = writeOptions { timestamp(1234) }
+ * // result == batchOps.deleteFlow(flowOf(group1, group2), options)
+ * ```
+ */
 fun ReactiveCassandraBatchOperations.deleteFlow(
     entities: Flow<*>,
     options: WriteOptions,

--- a/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/ReactiveCassandraOperationsCoroutines.kt
+++ b/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/ReactiveCassandraOperationsCoroutines.kt
@@ -27,12 +27,48 @@ import org.springframework.data.cassandra.core.truncate
 import org.springframework.data.cassandra.core.update
 import org.springframework.data.domain.Slice
 
+/**
+ * [Statement] 조회 결과를 [Flow]로 반환합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `select<T>(statement).asFlow()`를 호출합니다.
+ * - 결과가 없으면 빈 Flow가 반환됩니다.
+ *
+ * ```kotlin
+ * val rows = reactiveOps.selectAsFlow<User>(statement)
+ * // result == rows
+ * ```
+ */
 inline fun <reified T: Any> ReactiveCassandraOperations.selectAsFlow(statement: Statement<*>): Flow<T> =
     select<T>(statement).asFlow()
 
+/**
+ * CQL 문자열 조회 결과를 [Flow]로 반환합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `select<T>(cql).asFlow()`를 호출합니다.
+ * - 매핑 실패 예외는 수집 시점에 그대로 전파됩니다.
+ *
+ * ```kotlin
+ * val rows = reactiveOps.selectAsFlow<User>("SELECT * FROM users")
+ * // result == rows
+ * ```
+ */
 inline fun <reified T: Any> ReactiveCassandraOperations.selectAsFlow(cql: String): Flow<T> =
     select<T>(cql).asFlow()
 
+/**
+ * [Query] 조회 결과를 [Flow]로 반환합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `select<T>(query).asFlow()`를 호출합니다.
+ * - 조건에 맞는 결과가 없으면 빈 Flow가 반환됩니다.
+ *
+ * ```kotlin
+ * val rows = reactiveOps.selectAsFlow<User>(query)
+ * // result == rows
+ * ```
+ */
 inline fun <reified T: Any> ReactiveCassandraOperations.selectAsFlow(query: Query): Flow<T> =
     select<T>(query).asFlow()
 

--- a/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/ReactiveSelectOperationSupport.kt
+++ b/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/ReactiveSelectOperationSupport.kt
@@ -5,12 +5,33 @@ import org.springframework.data.cassandra.core.ReactiveSelectOperation
 import org.springframework.data.cassandra.core.ReactiveSelectOperation.SelectWithProjection
 import org.springframework.data.cassandra.core.ReactiveSelectOperation.SelectWithQuery
 
+/**
+ * `SelectWithProjection` 결과 타입을 제네릭 [R]로 캐스팅한 조회 빌더를 반환합니다.
+ *
+ * ## 동작/계약
+ * - 구현은 ``as(R::class.java)`` 호출을 단순 래핑합니다.
+ * - 잘못된 타입 지정 시 이후 조회 단계에서 매핑 예외가 발생할 수 있습니다.
+ *
+ * ```kotlin
+ * val projected = selectOp.from(User::class.java).cast<User>()
+ * // result == projected
+ * ```
+ */
 inline fun <reified R: Any> SelectWithProjection<*>.cast(): SelectWithQuery<R> =
     `as`(R::class.java)
 
 
 /**
- * 조회 결과의 건수를 반환합니다.
+ * 조회 결과 건수를 코루틴에서 반환합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `count().awaitSingle()`을 호출합니다.
+ * - 결과가 비어 있어도 Cassandra count 결과(예: `0L`)를 그대로 반환합니다.
+ *
+ * ```kotlin
+ * val count = terminatingSelect.countSuspending()
+ * // result == 0L
+ * ```
  */
 suspend fun <T: Any> ReactiveSelectOperation.TerminatingSelect<T>.countSuspending(): Long =
     count().awaitSingle()
@@ -23,7 +44,16 @@ suspend fun <T: Any> ReactiveSelectOperation.TerminatingSelect<T>.suspendCount()
     countSuspending()
 
 /**
- * 조회 결과의 존재 여부를 반환합니다.
+ * 조회 결과 존재 여부를 코루틴에서 반환합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `exists().awaitSingle()`을 호출합니다.
+ * - 조건에 맞는 레코드가 하나 이상이면 `true`를 반환합니다.
+ *
+ * ```kotlin
+ * val exists = terminatingSelect.existsSuspending()
+ * // result == true
+ * ```
  */
 suspend fun <T: Any> ReactiveSelectOperation.TerminatingSelect<T>.existsSuspending(): Boolean =
     exists().awaitSingle()
@@ -35,11 +65,32 @@ suspend fun <T: Any> ReactiveSelectOperation.TerminatingSelect<T>.existsSuspendi
 suspend fun <T: Any> ReactiveSelectOperation.TerminatingSelect<T>.suspendExists(): Boolean =
     existsSuspending()
 
+/**
+ * 첫 번째 결과를 코루틴에서 단건으로 반환합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `first().awaitSingle()`을 호출합니다.
+ * - 결과가 없으면 `awaitSingle()` 규칙에 따라 예외가 전파됩니다.
+ *
+ * ```kotlin
+ * val user = terminatingSelect.first()
+ * // result == user.id
+ * ```
+ */
 suspend fun <T: Any> ReactiveSelectOperation.TerminatingSelect<T>.first(): T =
     first().awaitSingle()
 
 /**
- * 단건을 조회하고 없으면 null을 반환합니다.
+ * 단건 조회 결과를 반환하고 없으면 `null`을 반환합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `one().awaitSingle()`을 호출합니다.
+ * - Spring Data의 `one()`가 빈 결과를 `null`로 발행하면 그대로 `null`을 반환합니다.
+ *
+ * ```kotlin
+ * val loaded = terminatingSelect.oneSuspending()
+ * // result == loaded
+ * ```
  */
 suspend fun <T: Any> ReactiveSelectOperation.TerminatingSelect<T>.oneSuspending(): T? =
     one().awaitSingle()
@@ -52,7 +103,16 @@ suspend fun <T: Any> ReactiveSelectOperation.TerminatingSelect<T>.suspendOne(): 
     oneSuspending()
 
 /**
- * 전체 결과를 리스트로 반환합니다.
+ * 전체 조회 결과를 리스트로 수집해 반환합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `all().collectList().awaitSingle()`을 호출합니다.
+ * - 결과가 없으면 빈 리스트를 반환합니다.
+ *
+ * ```kotlin
+ * val users = terminatingSelect.allSuspending()
+ * // result == users.size
+ * ```
  */
 suspend fun <T: Any> ReactiveSelectOperation.TerminatingSelect<T>.allSuspending(): List<T> =
     all().collectList().awaitSingle()

--- a/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/ReactiveSessionCoroutines.kt
+++ b/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/ReactiveSessionCoroutines.kt
@@ -8,27 +8,24 @@ import org.springframework.data.cassandra.ReactiveResultSet
 import org.springframework.data.cassandra.ReactiveSession
 
 /**
- * [ReactiveSession]의 코루틴 확장 함수 모음입니다.
+ * [ReactiveSession]의 Reactor API를 코루틴 suspend 함수로 감싼 확장 함수 모음입니다.
  */
 
 /**
- * CQL 문자열을 실행하고 [ReactiveResultSet]을 반환합니다.
+ * CQL 문자열을 실행하고 결과 [ReactiveResultSet]을 반환합니다.
  *
- * @param query 실행할 CQL
- */
-/**
- * CQL 문자열을 실행하고 [ReactiveResultSet]을 반환합니다.
+ * ## 동작/계약
+ * - 내부적으로 `execute(query).awaitSingle()`을 호출합니다.
+ * - CQL 실행 실패 예외는 그대로 전파됩니다.
  *
- * @param query 실행할 CQL
+ * ```kotlin
+ * val resultSet = reactiveSession.executeSuspending("SELECT * FROM users")
+ * // result == resultSet.availableRows()
+ * ```
  */
 suspend fun ReactiveSession.executeSuspending(query: String): ReactiveResultSet =
     execute(query).awaitSingle()
 
-/**
- * CQL 문자열을 실행하고 [ReactiveResultSet]을 반환합니다.
- *
- * @param query 실행할 CQL
- */
 @Deprecated(
     message = "executeSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("executeSuspending(query)")
@@ -37,20 +34,20 @@ suspend fun ReactiveSession.suspendExecute(query: String): ReactiveResultSet =
     executeSuspending(query)
 
 /**
- * CQL 문자열과 바인딩 파라미터로 실행하고 [ReactiveResultSet]을 반환합니다.
+ * CQL 문자열과 위치 기반 파라미터를 실행하고 결과 [ReactiveResultSet]을 반환합니다.
  *
- * @param query 실행할 CQL
- * @param args 바인딩 파라미터
+ * ## 동작/계약
+ * - 내부적으로 `execute(query, *args).awaitSingle()`을 호출합니다.
+ * - 인자 개수/타입 불일치 예외는 드라이버에서 발생한 그대로 전파됩니다.
+ *
+ * ```kotlin
+ * val resultSet = reactiveSession.executeSuspending("SELECT * FROM users WHERE id = ?", "user-1")
+ * // result == resultSet.rows().hasElements()
+ * ```
  */
 suspend fun ReactiveSession.executeSuspending(query: String, vararg args: Any?): ReactiveResultSet =
     execute(query, *args).awaitSingle()
 
-/**
- * CQL 문자열과 바인딩 파라미터로 실행하고 [ReactiveResultSet]을 반환합니다.
- *
- * @param query 실행할 CQL
- * @param args 바인딩 파라미터
- */
 @Deprecated(
     message = "executeSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("executeSuspending(query, *args)")
@@ -59,20 +56,23 @@ suspend fun ReactiveSession.suspendExecute(query: String, vararg args: Any?): Re
     executeSuspending(query, *args)
 
 /**
- * CQL 문자열과 이름 기반 파라미터로 실행하고 [ReactiveResultSet]을 반환합니다.
+ * CQL 문자열과 이름 기반 파라미터를 실행하고 결과 [ReactiveResultSet]을 반환합니다.
  *
- * @param query 실행할 CQL
- * @param args 이름 기반 파라미터
+ * ## 동작/계약
+ * - 내부적으로 `execute(query, args).awaitSingle()`을 호출합니다.
+ * - 누락된 바인딩 이름/타입 오류 예외는 드라이버에서 발생한 그대로 전파됩니다.
+ *
+ * ```kotlin
+ * val resultSet = reactiveSession.executeSuspending(
+ *     "SELECT * FROM users WHERE id = :id",
+ *     mapOf("id" to "user-1")
+ * )
+ * // result == resultSet.availableRows()
+ * ```
  */
 suspend fun ReactiveSession.executeSuspending(query: String, args: Map<String, Any?>): ReactiveResultSet =
     execute(query, args).awaitSingle()
 
-/**
- * CQL 문자열과 이름 기반 파라미터로 실행하고 [ReactiveResultSet]을 반환합니다.
- *
- * @param query 실행할 CQL
- * @param args 이름 기반 파라미터
- */
 @Deprecated(
     message = "executeSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("executeSuspending(query, args)")
@@ -81,18 +81,20 @@ suspend fun ReactiveSession.suspendExecute(query: String, args: Map<String, Any?
     executeSuspending(query, args)
 
 /**
- * [Statement]를 실행하고 [ReactiveResultSet]을 반환합니다.
+ * [Statement]를 실행하고 결과 [ReactiveResultSet]을 반환합니다.
  *
- * @param statement 실행할 Statement
+ * ## 동작/계약
+ * - 내부적으로 `execute(statement).awaitSingle()`을 호출합니다.
+ * - Statement 옵션(fetch size, consistency level 등)은 전달된 객체 설정을 그대로 따릅니다.
+ *
+ * ```kotlin
+ * val resultSet = reactiveSession.executeSuspending(boundStatement)
+ * // result == resultSet.availableRows()
+ * ```
  */
 suspend fun ReactiveSession.executeSuspending(statement: Statement<*>): ReactiveResultSet =
     execute(statement).awaitSingle()
 
-/**
- * [Statement]를 실행하고 [ReactiveResultSet]을 반환합니다.
- *
- * @param statement 실행할 Statement
- */
 @Deprecated(
     message = "executeSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("executeSuspending(statement)")
@@ -101,18 +103,20 @@ suspend fun ReactiveSession.suspendExecute(statement: Statement<*>): ReactiveRes
     executeSuspending(statement)
 
 /**
- * CQL 문자열을 준비하고 [PreparedStatement]를 반환합니다.
+ * CQL 문자열을 준비(prepare)해 [PreparedStatement]를 반환합니다.
  *
- * @param query 준비할 CQL
+ * ## 동작/계약
+ * - 내부적으로 `prepare(query).awaitSingle()`을 호출합니다.
+ * - 잘못된 CQL 문법이면 prepare 예외가 그대로 전파됩니다.
+ *
+ * ```kotlin
+ * val prepared = reactiveSession.prepareSuspending("SELECT * FROM users WHERE id = ?")
+ * // result == prepared.variableDefinitions.size()
+ * ```
  */
 suspend fun ReactiveSession.prepareSuspending(query: String): PreparedStatement =
     prepare(query).awaitSingle()
 
-/**
- * CQL 문자열을 준비하고 [PreparedStatement]를 반환합니다.
- *
- * @param query 준비할 CQL
- */
 @Deprecated(
     message = "prepareSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("prepareSuspending(query)")
@@ -121,18 +125,20 @@ suspend fun ReactiveSession.suspendPrepare(query: String): PreparedStatement =
     prepareSuspending(query)
 
 /**
- * [SimpleStatement]를 준비하고 [PreparedStatement]를 반환합니다.
+ * [SimpleStatement]를 준비(prepare)해 [PreparedStatement]를 반환합니다.
  *
- * @param statement 준비할 Statement
+ * ## 동작/계약
+ * - 내부적으로 `prepare(statement).awaitSingle()`을 호출합니다.
+ * - Statement에 포함된 CQL/옵션 정보를 기반으로 prepare가 수행됩니다.
+ *
+ * ```kotlin
+ * val prepared = reactiveSession.prepareSuspending(simpleStatement)
+ * // result == prepared.variableDefinitions.size()
+ * ```
  */
 suspend fun ReactiveSession.prepareSuspending(statement: SimpleStatement): PreparedStatement =
     prepare(statement).awaitSingle()
 
-/**
- * [SimpleStatement]를 준비하고 [PreparedStatement]를 반환합니다.
- *
- * @param statement 준비할 Statement
- */
 @Deprecated(
     message = "prepareSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("prepareSuspending(statement)")

--- a/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/cql/AsyncCqlOperationsCoroutines.kt
+++ b/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/cql/AsyncCqlOperationsCoroutines.kt
@@ -8,22 +8,18 @@ import org.springframework.data.cassandra.core.cql.AsyncCqlOperations
 import java.util.concurrent.CompletableFuture
 
 /**
- * Coroutine 환경에서 [AsyncCqlOperations]의 `query` 함수를 실행합니다.
+ * CQL 문자열을 실행하고 [AsyncResultSet] 기반 추출 결과를 코루틴으로 반환합니다.
  *
- * ```
- * val user = asyncCqlOperations.querySuspending<User>(
- *      "SELECT * FROM users WHERE id = ?",
- *      userId
- * ) { resultSet ->
- *     resultSet.one().map { row -> User(row) }
+ * ## 동작/계약
+ * - 내부적으로 `query(cql, extractor, *args).await()`를 호출합니다.
+ * - [extractor]가 반환한 [CompletableFuture]가 실패하면 동일 예외가 전파됩니다.
+ *
+ * ```kotlin
+ * val id = asyncOps.querySuspending<Long>("SELECT now() FROM system.local") { rs ->
+ *     CompletableFuture.completedFuture(rs.one()?.getInstant(0)?.toEpochMilli())
  * }
+ * // result == id
  * ```
- *
- * @receiver [AsyncCqlOperations] 인스턴스
- * @param T 반환할 값의 수형
- * @param cql 실행할 CQL 쿼리
- * @param args CQL 쿼리에 전달할 인자
- * @param extractor [AsyncResultSet]을 [T]로 변환하는 함수
  */
 suspend inline fun <reified T: Any> AsyncCqlOperations.querySuspending(
     cql: String,
@@ -55,13 +51,18 @@ suspend inline fun <reified T: Any> AsyncCqlOperations.coQuery(
     query<T>(cql, { extractor(it) }, *args).await()
 
 /**
- * Coroutine 환경에서 [AsyncCqlOperations]의 `query` 함수를 실행합니다.
+ * CQL 문자열을 실행하고 [Row] 매퍼로 변환한 결과 목록을 코루틴으로 반환합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `query(cql, rowMapper, *args).await()`를 호출합니다.
+ * - Cassandra 결과가 비어 있으면 빈 리스트를 반환합니다.
  *
  * ```kotlin
- * val users = asyncCqlOperations.querySuspending<User>(
- *     "SELECT * FROM users WHERE id = ?",
- *     userId
- * ) { row, rowNum -> User(row) }
+ * val names = asyncOps.querySuspending<String>("SELECT firstname FROM users") { row, _ ->
+ *     row.getString("firstname")
+ * }
+ * // result == names.size
+ * ```
  */
 suspend inline fun <reified T: Any> AsyncCqlOperations.querySuspending(
     cql: String,
@@ -92,22 +93,19 @@ suspend inline fun <reified T: Any> AsyncCqlOperations.coQuery(
 ): List<T> =
     query(cql, { row, rowNum -> rowMapper(row, rowNum) }, *args).await()
 
-
 /**
- * Coroutine 환경에서 [AsyncCqlOperations]의 `query` 함수를 실행합니다.
+ * [Statement]를 실행하고 [AsyncResultSet] 기반 추출 결과를 코루틴으로 반환합니다.
  *
- * ```
- * val stmt = SimpleStatement.newInstance("SELECT * FROM users WHERE id = ?", userId)
- * val user = asyncCqlOperations.querySuspending<User>(stmt) { resultSet ->
- *     resultSet.one().map { row -> futureOf { User(row) } }
+ * ## 동작/계약
+ * - 내부적으로 `query(statement, extractor).await()`를 호출합니다.
+ * - [extractor] 실행 예외는 가공하지 않고 그대로 전파됩니다.
+ *
+ * ```kotlin
+ * val value = asyncOps.querySuspending<String>(statement) { rs ->
+ *     CompletableFuture.completedFuture(rs.one()?.getString("firstname"))
  * }
+ * // result == value
  * ```
- *
- * @receiver [AsyncCqlOperations] 인스턴스
- * @param T 반환할 값의 수형
- * @param statement 실행할 CQL 쿼리
- * @param extractor [AsyncResultSet]을 [CompletableFuture]`<T>`로 변환하는 함수
- * @return [T] 형식의 결과
  */
 suspend inline fun <reified T: Any> AsyncCqlOperations.querySuspending(
     statement: Statement<*>,
@@ -135,18 +133,16 @@ suspend inline fun <reified T: Any> AsyncCqlOperations.coQuery(
     query<T>(statement) { extractor(it) }.await()
 
 /**
- * Coroutine 환경에서 [AsyncCqlOperations]의 `query` 함수를 실행합니다.
+ * [Statement]를 실행하고 [Row] 매퍼로 변환한 결과 목록을 코루틴으로 반환합니다.
  *
- * ```
- * val stmt = SimpleStatement.newInstance("SELECT * FROM users WHERE id = ?", userId)
- * val users = asyncCqlOperations.querySuspending<User>(stmt) { row, rowNum -> User(row) }
- * ```
+ * ## 동작/계약
+ * - 내부적으로 `query(statement, rowMapper).await()`를 호출합니다.
+ * - 반환 리스트의 원소 순서는 Cassandra 드라이버가 전달한 row 순서를 유지합니다.
  *
- * @receiver [AsyncCqlOperations] 인스턴스
- * @param T 반환할 값의 수형
- * @param statement 실행할 CQL 쿼리
- * @param rowMapper [Row]를 [T]로 변환하는 함수
- * @return [T] 수형 객체의 컬렉션
+ * ```kotlin
+ * val rows = asyncOps.querySuspending<String>(statement) { row, _ -> row.getString("firstname") }
+ * // result == rows.size
+ * ```
  */
 suspend inline fun <reified T: Any> AsyncCqlOperations.querySuspending(
     statement: Statement<*>,

--- a/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/cql/OptionsSupport.kt
+++ b/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/cql/OptionsSupport.kt
@@ -12,7 +12,16 @@ import org.springframework.data.cassandra.core.cql.QueryOptions
 import org.springframework.data.cassandra.core.cql.WriteOptions
 
 /**
- * [QueryOptions]를 DSL 형태로 생성합니다.
+ * [QueryOptions]를 빌더 DSL로 생성합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `QueryOptions.builder().apply(builder).build()`를 호출합니다.
+ * - 인자 검증/예외는 Spring Data Cassandra의 빌더 구현에 위임됩니다.
+ *
+ * ```kotlin
+ * val options = queryOptions { pageSize(100) }
+ * // result == (options.pageSize == 100)
+ * ```
  */
 inline fun queryOptions(
     @BuilderInference builder: QueryOptions.QueryOptionsBuilder.() -> Unit,
@@ -20,7 +29,16 @@ inline fun queryOptions(
     QueryOptions.builder().apply(builder).build()
 
 /**
- * [InsertOptions]를 DSL 형태로 생성합니다.
+ * [InsertOptions]를 빌더 DSL로 생성합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `InsertOptions.builder().apply(builder).build()`를 호출합니다.
+ * - `withIfNotExists()` 같은 LWT 옵션 조합은 전달한 `builder` 내용 그대로 반영됩니다.
+ *
+ * ```kotlin
+ * val options = insertOptions { withIfNotExists() }
+ * // result == options.ifNotExists
+ * ```
  */
 inline fun insertOptions(
     @BuilderInference builder: InsertOptions.InsertOptionsBuilder.() -> Unit,
@@ -28,7 +46,16 @@ inline fun insertOptions(
     InsertOptions.builder().apply(builder).build()
 
 /**
- * [UpdateOptions]를 DSL 형태로 생성합니다.
+ * [UpdateOptions]를 빌더 DSL로 생성합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `UpdateOptions.builder().apply(builder).build()`를 호출합니다.
+ * - 인자 검증/예외는 Spring Data Cassandra의 빌더 구현에 위임됩니다.
+ *
+ * ```kotlin
+ * val options = updateOptions { timeout(500) }
+ * // result == (options.timeout?.toMillis() == 500L)
+ * ```
  */
 inline fun updateOptions(
     @BuilderInference builder: UpdateOptions.UpdateOptionsBuilder.() -> Unit,
@@ -36,7 +63,16 @@ inline fun updateOptions(
     UpdateOptions.builder().apply(builder).build()
 
 /**
- * [WriteOptions]를 DSL 형태로 생성합니다.
+ * [WriteOptions]를 빌더 DSL로 생성합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `WriteOptions.builder().apply(builder).build()`를 호출합니다.
+ * - `ttl`, `timestamp` 설정 여부는 이후 `addWriteOptions` 확장에서 그대로 사용됩니다.
+ *
+ * ```kotlin
+ * val options = writeOptions { ttl(30) }
+ * // result == options.isPositiveTtl
+ * ```
  */
 inline fun writeOptions(
     @BuilderInference builder: WriteOptions.WriteOptionsBuilder.() -> Unit,
@@ -44,7 +80,16 @@ inline fun writeOptions(
     WriteOptions.builder().apply(builder).build()
 
 /**
- * [DeleteOptions]를 DSL 형태로 생성합니다.
+ * [DeleteOptions]를 빌더 DSL로 생성합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `DeleteOptions.builder().apply(builder).build()`를 호출합니다.
+ * - 인자 검증/예외는 Spring Data Cassandra의 빌더 구현에 위임됩니다.
+ *
+ * ```kotlin
+ * val options = deleteOptions { timeout(300) }
+ * // result == (options.timeout?.toMillis() == 300L)
+ * ```
  */
 inline fun deleteOptions(
     @BuilderInference builder: DeleteOptions.DeleteOptionsBuilder.() -> Unit,
@@ -53,7 +98,17 @@ inline fun deleteOptions(
 
 
 /**
- * [Insert]에 [WriteOptions]를 적용합니다.
+ * [Insert] 문에 [WriteOptions]의 TTL/타임스탬프를 반영한 새 Statement를 반환합니다.
+ *
+ * ## 동작/계약
+ * - [WriteOptions.isPositiveTtl]가 `true`이면 `usingTtl`을 적용합니다.
+ * - `timestamp`가 존재하면 `usingTimestamp`를 적용합니다.
+ * - 원본 인스턴스를 직접 변경하지 않고 적용된 Statement를 새로 반환합니다.
+ *
+ * ```kotlin
+ * val options = writeOptions { ttl(30) }
+ * // result == options.isPositiveTtl
+ * ```
  */
 fun Insert.addWriteOptions(writeOptions: WriteOptions): Insert {
     var applied = this
@@ -68,7 +123,17 @@ fun Insert.addWriteOptions(writeOptions: WriteOptions): Insert {
 }
 
 /**
- * [Update]에 [WriteOptions]를 적용합니다.
+ * [Update] 문이 [UpdateStart]인 경우에만 [WriteOptions]의 TTL/타임스탬프를 반영합니다.
+ *
+ * ## 동작/계약
+ * - 수신 객체가 [UpdateStart]가 아니면 아무 옵션도 적용하지 않고 그대로 반환합니다.
+ * - [WriteOptions.isPositiveTtl]가 `true`이면 `usingTtl`을 적용합니다.
+ * - `timestamp`가 존재하면 `usingTimestamp`를 적용합니다.
+ *
+ * ```kotlin
+ * val options = writeOptions { ttl(30) }
+ * // result == options.isPositiveTtl
+ * ```
  */
 fun Update.addWriteOptions(writeOptions: WriteOptions): Update {
     var applied = this
@@ -85,7 +150,17 @@ fun Update.addWriteOptions(writeOptions: WriteOptions): Update {
 }
 
 /**
- * [UpdateStart]에 [WriteOptions]를 적용합니다.
+ * [UpdateStart] 문에 [WriteOptions]의 TTL/타임스탬프를 순서대로 반영합니다.
+ *
+ * ## 동작/계약
+ * - [WriteOptions.isPositiveTtl]가 `true`이면 `usingTtl`을 먼저 적용합니다.
+ * - `timestamp`가 존재하면 `usingTimestamp`를 추가 적용합니다.
+ * - 적용된 [UpdateStart] 인스턴스를 반환합니다.
+ *
+ * ```kotlin
+ * val options = writeOptions { ttl(30) }
+ * // result == options.isPositiveTtl
+ * ```
  */
 fun UpdateStart.addWriteOptions(writeOptions: WriteOptions): UpdateStart {
     var applied: UpdateStart = this
@@ -100,7 +175,16 @@ fun UpdateStart.addWriteOptions(writeOptions: WriteOptions): UpdateStart {
 }
 
 /**
- * [Delete]에 [WriteOptions]를 적용합니다.
+ * [Delete] 문이 [DeleteSelection]인 경우 `timestamp`를 반영합니다.
+ *
+ * ## 동작/계약
+ * - 수신 객체가 [DeleteSelection]이고 `timestamp`가 존재할 때만 `usingTimestamp`를 적용합니다.
+ * - 조건을 만족하지 않으면 원본 Delete를 그대로 반환합니다.
+ *
+ * ```kotlin
+ * val options = writeOptions { timestamp(1234) }
+ * // result == (options.timestamp == 1234L)
+ * ```
  */
 fun Delete.addWriteOptions(writeOptions: WriteOptions): Delete {
     var applied = this
@@ -112,6 +196,15 @@ fun Delete.addWriteOptions(writeOptions: WriteOptions): Delete {
 }
 
 /**
- * TTL 이 0보다 크면 true
+ * TTL이 설정되어 있고 음수가 아니면 `true`를 반환합니다.
+ *
+ * ## 동작/계약
+ * - `ttl == null`이면 `false`를 반환합니다.
+ * - `ttl`이 존재하고 `isNegative == false`이면 `true`를 반환합니다.
+ *
+ * ```kotlin
+ * val options = writeOptions { ttl(30) }
+ * // result == options.isPositiveTtl
+ * ```
  */
 val WriteOptions.isPositiveTtl: Boolean get() = ttl != null && !ttl!!.isNegative

--- a/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/cql/ReactiveCqlOperationsSupport.kt
+++ b/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/cql/ReactiveCqlOperationsSupport.kt
@@ -45,6 +45,18 @@ fun <T: Any> ReactiveCqlOperations.executeSuspending(action: (ReactiveSession) -
 fun <T: Any> ReactiveCqlOperations.suspendExecute(action: (ReactiveSession) -> Flow<T>): Flow<T> =
     executeSuspending(action)
 
+/**
+ * CQL 문자열을 실행하고 적용 여부를 코루틴으로 반환합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `execute(cql).awaitSingleOrNull()`을 호출합니다.
+ * - 발행 값이 없으면 `null`을 반환합니다.
+ *
+ * ```kotlin
+ * val applied = reactiveCqlOperations.executeSuspending("TRUNCATE users")
+ * // result == applied
+ * ```
+ */
 suspend fun ReactiveCqlOperations.executeSuspending(cql: String): Boolean? =
     execute(cql).awaitSingleOrNull()
 
@@ -55,9 +67,33 @@ suspend fun ReactiveCqlOperations.executeSuspending(cql: String): Boolean? =
 suspend fun ReactiveCqlOperations.suspendExecute(cql: String): Boolean? =
     executeSuspending(cql)
 
+/**
+ * [ReactivePreparedStatementCreator]를 실행하고 적용 여부를 코루틴으로 반환합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `execute(psc).awaitSingleOrNull()`을 호출합니다.
+ * - 발행 값이 없으면 `null`을 반환합니다.
+ *
+ * ```kotlin
+ * val applied = reactiveCqlOperations.coExecute(psc)
+ * // result == applied
+ * ```
+ */
 suspend fun ReactiveCqlOperations.coExecute(psc: ReactivePreparedStatementCreator): Boolean? =
     execute(psc).awaitSingleOrNull()
 
+/**
+ * CQL 문자열과 바인딩 인자 [Flow]를 실행하고 적용 결과를 [Flow]로 반환합니다.
+ *
+ * ## 동작/계약
+ * - `args()`가 반환한 `Flow<Array<Any?>>`를 Publisher로 변환해 `execute(cql, ...)`에 전달합니다.
+ * - 결과 Flow는 각 실행의 적용 여부(Boolean?)를 순서대로 발행합니다.
+ *
+ * ```kotlin
+ * val result = reactiveCqlOperations.executeSuspending(cql) { flowOf(arrayOf("user-1")) }
+ * // result == result
+ * ```
+ */
 fun ReactiveCqlOperations.executeSuspending(cql: String, args: () -> Flow<Array<Any?>>): Flow<Boolean?> =
     execute(cql, args().asPublisher()).asFlow()
 
@@ -68,6 +104,21 @@ fun ReactiveCqlOperations.executeSuspending(cql: String, args: () -> Flow<Array<
 fun ReactiveCqlOperations.suspendExecute(cql: String, args: () -> Flow<Array<Any?>>): Flow<Boolean?> =
     executeSuspending(cql, args)
 
+/**
+ * CQL 문자열 실행 결과를 단건으로 매핑해 반환하고 없으면 `null`을 반환합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `queryForObject(cql, rowMapper, *args).awaitSingleOrNull()`을 호출합니다.
+ * - [rowMapper] 예외와 조회 예외는 가공 없이 전파됩니다.
+ *
+ * ```kotlin
+ * val firstName = reactiveCqlOperations.queryForObjectSuspending(
+ *     "SELECT firstname FROM users WHERE id = ?",
+ *     "user-1"
+ * ) { row, _ -> row.getString("firstname") }
+ * // result == firstName
+ * ```
+ */
 suspend fun <T: Any> ReactiveCqlOperations.queryForObjectSuspending(
     cql: String,
     vararg args: Any?,
@@ -76,11 +127,35 @@ suspend fun <T: Any> ReactiveCqlOperations.queryForObjectSuspending(
     return queryForObject(cql, rowMapper, *args).awaitSingleOrNull()
 }
 
+/**
+ * CQL 문자열 실행 결과를 타입 기반 단건 매핑으로 반환하고 없으면 `null`을 반환합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `queryForObject<T>(cql, *args).awaitSingleOrNull()`을 호출합니다.
+ * - 매핑 예외는 수집 시점에 그대로 전파됩니다.
+ *
+ * ```kotlin
+ * val user = reactiveCqlOperations.queryForObjectSuspending<User>("SELECT * FROM users WHERE id = ?", "user-1")
+ * // result == user
+ * ```
+ */
 suspend inline fun <reified T: Any> ReactiveCqlOperations.queryForObjectSuspending(
     cql: String,
     vararg args: Any,
 ): T? = queryForObject<T>(cql, *args).awaitSingleOrNull()
 
+/**
+ * [Statement] 실행 결과를 타입 기반 단건 매핑으로 반환하고 없으면 `null`을 반환합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `queryForObject<T>(statement).awaitSingleOrNull()`을 호출합니다.
+ * - 결과가 없으면 `null`을 반환합니다.
+ *
+ * ```kotlin
+ * val user = reactiveCqlOperations.queryForObjectSuspending<User>(statement)
+ * // result == user
+ * ```
+ */
 suspend inline fun <reified T: Any> ReactiveCqlOperations.queryForObjectSuspending(statement: Statement<*>): T? =
     queryForObject<T>(statement).awaitSingleOrNull()
 
@@ -108,6 +183,18 @@ suspend inline fun <reified T: Any> ReactiveCqlOperations.suspendQueryForObject(
 suspend inline fun <reified T: Any> ReactiveCqlOperations.suspendQueryForObject(statement: Statement<*>): T? =
     queryForObjectSuspending(statement)
 
+/**
+ * CQL 문자열 실행 결과를 단일 행 맵으로 반환합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `queryForMap(cql, args).awaitSingle()`을 호출합니다.
+ * - 결과가 없거나 다중 행인 경우 예외 여부는 Spring Data Cassandra 규칙을 따릅니다.
+ *
+ * ```kotlin
+ * val row = reactiveCqlOperations.queryForMapSuspending("SELECT * FROM users WHERE id = ?", "user-1")
+ * // result == row["id"]
+ * ```
+ */
 suspend fun ReactiveCqlOperations.queryForMapSuspending(cql: String, vararg args: Any): Map<String, Any?> =
     queryForMap(cql, args).awaitSingle()
 
@@ -118,12 +205,48 @@ suspend fun ReactiveCqlOperations.queryForMapSuspending(cql: String, vararg args
 suspend fun ReactiveCqlOperations.suspendQueryForMap(cql: String, vararg args: Any): Map<String, Any?> =
     queryForMapSuspending(cql, *args)
 
+/**
+ * CQL 문자열 실행 결과를 지정 타입 [Flow]로 반환합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `queryForFlux<T>(cql, *args).asFlow()`를 호출합니다.
+ * - 결과가 없으면 빈 Flow를 반환합니다.
+ *
+ * ```kotlin
+ * val users = reactiveCqlOperations.queryForFlow<User>("SELECT * FROM users")
+ * // result == users
+ * ```
+ */
 inline fun <reified T: Any> ReactiveCqlOperations.queryForFlow(cql: String, vararg args: Any): Flow<T> =
     queryForFlux<T>(cql, *args).asFlow()
 
+/**
+ * CQL 문자열 실행 결과를 `Map<String, Any?>` [Flow]로 반환합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `queryForFlux(cql, *args).asFlow()`를 호출합니다.
+ * - 각 요소는 컬럼명 기준 key를 가진 맵입니다.
+ *
+ * ```kotlin
+ * val rows = reactiveCqlOperations.queryForMapFlow("SELECT * FROM users")
+ * // result == rows
+ * ```
+ */
 fun ReactiveCqlOperations.queryForMapFlow(cql: String, vararg args: Any): Flow<Map<String, Any?>> =
     queryForFlux(cql, *args).asFlow()
 
+/**
+ * CQL 문자열 실행 결과를 [ReactiveResultSet]으로 반환합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `queryForResultSet(cql, *args).awaitSingle()`을 호출합니다.
+ * - ResultSet 발행 실패 시 예외가 전파됩니다.
+ *
+ * ```kotlin
+ * val rs = reactiveCqlOperations.queryForResultSetSuspending("SELECT * FROM users")
+ * // result == rs.availableRows()
+ * ```
+ */
 suspend fun ReactiveCqlOperations.queryForResultSetSuspending(cql: String, vararg args: Any): ReactiveResultSet =
     queryForResultSet(cql, *args).awaitSingle()
 

--- a/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/model/AbstractCassandraAuditable.kt
+++ b/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/model/AbstractCassandraAuditable.kt
@@ -6,10 +6,24 @@ import java.time.Instant
 import java.util.*
 
 /**
- * Auditable Entity 를 나타내는 추상화 클래스입니다.
+ * 생성자/수정자와 시각을 함께 보관하는 Cassandra 감사(Audit) 엔티티 기반 추상 클래스입니다.
  *
- * @param U createdBy, lastModifiedBy 등 엔티티의 변화를 수행하는 Actor 의 수형 (보통 String 이다)
- * @param PK Entity PrimaryKey의 수형
+ * ## 동작/계약
+ * - [isNew]는 `created_at` 컬럼에 매핑된 `_createdAt`이 `null`이면 `true`를 반환합니다.
+ * - `get/setCreated*`, `get/setLastModified*`는 내부 필드를 그대로 감싸며 Spring Data [Auditable] 계약을 만족합니다.
+ * - 공개 프로퍼티([createdBy], [createdAt], [lastModifiedBy], [lastModifiedAt])는 읽기 전용 뷰를 제공합니다.
+ *
+ * ```kotlin
+ * val entity = object: AbstractCassandraAuditable<String, String>() {
+ *     private var pk: String? = null
+ *     override fun getId(): String? = pk
+ *     override fun setId(id: String) { pk = id }
+ * }
+ * // result == entity.isNew()
+ * ```
+ *
+ * @param U 생성/수정 작업 주체 타입
+ * @param PK 엔티티 식별자 타입
  */
 abstract class AbstractCassandraAuditable<U: Any, PK: Any>
     : AbstractCassandraPersistable<PK>(), Auditable<U, PK, Instant> {
@@ -32,69 +46,132 @@ abstract class AbstractCassandraAuditable<U: Any, PK: Any>
     val lastModifiedAt: Instant? get() = _lastModifiedAt
 
     /**
-     * Transient object 인지, Persistant Object 인지 판단한다
+     * 엔티티가 아직 저장되지 않았는지 여부를 반환합니다.
+     *
+     * ## 동작/계약
+     * - `_createdAt == null`이면 `true`를 반환합니다.
+     * - `_createdAt`이 설정된 뒤에는 `false`를 반환합니다.
+     *
+     * ```kotlin
+     * entity.setCreatedDate(Instant.parse("2024-01-01T00:00:00Z"))
+     * // result == entity.isNew()
+     * ```
      */
     override fun isNew(): Boolean = _createdAt == null
 
     /**
-     * Returns the user who created this entity.
+     * 생성자를 Optional 형태로 반환합니다.
      *
-     * @return the createdBy
+     * ## 동작/계약
+     * - `_createdBy`가 `null`이면 `Optional.empty()`를 반환합니다.
+     * - 값이 있으면 해당 값을 감싼 `Optional`을 반환합니다.
+     *
+     * ```kotlin
+     * entity.setCreatedBy("debop")
+     * // result == entity.getCreatedBy().orElse("unknown")
+     * ```
      */
     override fun getCreatedBy(): Optional<U> = Optional.ofNullable(_createdBy)
 
     /**
-     * Sets the user who created this entity.
+     * 생성자를 저장합니다.
      *
-     * @param createdBy the creating entity to set
+     * ## 동작/계약
+     * - 전달받은 값을 `_createdBy`에 그대로 대입합니다.
+     *
+     * ```kotlin
+     * entity.setCreatedBy("debop")
+     * // result == entity.createdBy
+     * ```
      */
     override fun setCreatedBy(createdBy: U) {
         _createdBy = createdBy
     }
 
     /**
-     * Returns the creation date of the entity.
+     * 생성 시각을 Optional 형태로 반환합니다.
      *
-     * @return the createdDate
+     * ## 동작/계약
+     * - `_createdAt`이 `null`이면 `Optional.empty()`를 반환합니다.
+     * - 값이 있으면 해당 시각을 감싼 `Optional`을 반환합니다.
+     *
+     * ```kotlin
+     * entity.setCreatedDate(Instant.parse("2024-01-01T00:00:00Z"))
+     * // result == entity.getCreatedDate().isPresent
+     * ```
      */
     override fun getCreatedDate(): Optional<Instant> = Optional.ofNullable(_createdAt)
 
     /**
-     * Sets the creation date of the entity.
+     * 생성 시각을 저장합니다.
      *
-     * @param creationDate the creation date to set
+     * ## 동작/계약
+     * - 전달받은 값을 `_createdAt`에 그대로 대입합니다.
+     *
+     * ```kotlin
+     * val createdAt = Instant.parse("2024-01-01T00:00:00Z")
+     * entity.setCreatedDate(createdAt)
+     * // result == entity.createdAt
+     * ```
      */
     override fun setCreatedDate(creationDate: Instant) {
         _createdAt = creationDate
     }
 
     /**
-     * Returns the user who modified the entity lastly.
+     * 마지막 수정자를 Optional 형태로 반환합니다.
      *
-     * @return the lastModifiedBy
+     * ## 동작/계약
+     * - `_lastModifiedBy`가 `null`이면 `Optional.empty()`를 반환합니다.
+     * - 값이 있으면 해당 값을 감싼 `Optional`을 반환합니다.
+     *
+     * ```kotlin
+     * entity.setLastModifiedBy("mike")
+     * // result == entity.getLastModifiedBy().orElse("unknown")
+     * ```
      */
     override fun getLastModifiedBy(): Optional<U> = Optional.ofNullable(_lastModifiedBy)
 
     /**
-     * Sets the user who modified the entity lastly.
+     * 마지막 수정자를 저장합니다.
      *
-     * @param lastModifiedBy the last modifying entity to set
+     * ## 동작/계약
+     * - 전달받은 값을 `_lastModifiedBy`에 그대로 대입합니다.
+     *
+     * ```kotlin
+     * entity.setLastModifiedBy("mike")
+     * // result == entity.lastModifiedBy
+     * ```
      */
     override fun setLastModifiedBy(lastModifiedBy: U) {
         _lastModifiedBy = lastModifiedBy
     }
 
     /**
-     * Returns the date of the last modification.
+     * 마지막 수정 시각을 Optional 형태로 반환합니다.
      *
-     * @return the lastModifiedDate
+     * ## 동작/계약
+     * - `_lastModifiedAt`이 `null`이면 `Optional.empty()`를 반환합니다.
+     * - 값이 있으면 해당 시각을 감싼 `Optional`을 반환합니다.
+     *
+     * ```kotlin
+     * entity.setLastModifiedDate(Instant.parse("2024-01-01T00:00:10Z"))
+     * // result == entity.getLastModifiedDate().isPresent
+     * ```
      */
     override fun getLastModifiedDate(): Optional<Instant> = Optional.ofNullable(_lastModifiedAt)
 
     /**
-     * Sets the date of the last modification.
+     * 마지막 수정 시각을 저장합니다.
      *
-     * @param lastModifiedDate the date of the last modification to set
+     * ## 동작/계약
+     * - 전달받은 값을 `_lastModifiedAt`에 그대로 대입합니다.
+     *
+     * ```kotlin
+     * val modifiedAt = Instant.parse("2024-01-01T00:00:10Z")
+     * entity.setLastModifiedDate(modifiedAt)
+     * // result == entity.lastModifiedAt
+     * ```
      */
     override fun setLastModifiedDate(lastModifiedDate: Instant) {
         _lastModifiedAt = lastModifiedDate

--- a/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/model/AbstractCassandraPersistable.kt
+++ b/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/model/AbstractCassandraPersistable.kt
@@ -5,12 +5,38 @@ import org.springframework.data.util.ProxyUtils
 import java.io.Serializable
 
 /**
- * [Persistable]을 구현하는 최상휘 추상화 클래스입니다.
+ * Cassandra 엔티티의 식별자 기반 동등성 비교를 제공하는 [Persistable] 추상 클래스입니다.
  *
- * @param PK entity의 primary key 수형
+ * ## 동작/계약
+ * - [isNew]는 `id == null`일 때 `true`를 반환해 신규 엔티티 여부를 판단합니다.
+ * - [equals]는 프록시를 실제 사용자 클래스([ProxyUtils.getUserClass])로 정규화한 뒤 `id`가 모두 존재하고 동일할 때만 `true`를 반환합니다.
+ * - [hashCode]는 `id`가 있으면 `id.hashCode()`를, 없으면 객체 식별 해시를 사용합니다.
+ *
+ * ```kotlin
+ * class UserEntity(private var pk: String? = null): AbstractCassandraPersistable<String>() {
+ *     override fun getId(): String? = pk
+ *     override fun setId(id: String) { pk = id }
+ * }
+ * // result == UserEntity().isNew()
+ * ```
+ *
+ * @param PK 엔티티 식별자 타입
  */
 abstract class AbstractCassandraPersistable<PK: Any>: Persistable<PK>, Serializable {
 
+    /**
+     * 엔티티 식별자를 갱신합니다.
+     *
+     * ## 동작/계약
+     * - 구현체는 전달된 `id`를 내부 식별자 필드에 반영해야 합니다.
+     * - 별도 검증 규칙이 필요하면 구현체에서 예외를 던져 계약을 강화할 수 있습니다.
+     *
+     * ```kotlin
+     * val entity = UserEntity()
+     * entity.setId("user-1")
+     * // result == (entity.id == "user-1")
+     * ```
+     */
     abstract fun setId(id: PK)
 
     override fun isNew(): Boolean {

--- a/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/query/CriteriaSupport.kt
+++ b/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/query/CriteriaSupport.kt
@@ -4,10 +4,16 @@ import org.springframework.data.cassandra.core.query.Criteria
 import org.springframework.data.cassandra.core.query.CriteriaDefinition
 
 /**
- * Criteria 중 `is` 연산자와 같은 기능을 제공하는 `eq` infix 함수입니다.
+ * [Criteria.`is`]를 infix 형태로 호출할 수 있게 해 주는 별칭 함수입니다.
  *
- * ```
- * val criteria = Criteria.where("column") eq "value"
+ * ## 동작/계약
+ * - 구현은 `is(value)`를 그대로 위임 호출하므로 생성되는 조건식은 동일합니다.
+ * - 반환 타입은 [CriteriaDefinition]이며 기존 Criteria 체이닝에 그대로 연결할 수 있습니다.
+ *
+ * ```kotlin
+ * val criteria = Criteria.where("name") eq "alice"
+ * val expected = Criteria.where("name").`is`("alice")
+ * // result == (criteria.toString() == expected.toString())
  * ```
  */
 infix fun Criteria.eq(value: Any?): CriteriaDefinition = `is`(value)

--- a/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/schema/SchemaGenerator.kt
+++ b/spring/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/schema/SchemaGenerator.kt
@@ -14,22 +14,49 @@ import org.springframework.data.cassandra.core.mapping.EmbeddedEntityOperations
 import kotlin.reflect.KClass
 
 /**
- * Spring Data Cassandra 용 Entity 정의를 바탕으로 Schema 를 생성합니다.
+ * 매핑 메타데이터를 기준으로 Cassandra UDT/테이블 생성과 truncate를 수행하는 유틸리티입니다.
  *
- * ```
- * @Autowired
- * private val operations: CassandraOperations = uninitialized()
+ * ## 동작/계약
+ * - [createTableAndTypes]는 대상 엔티티의 UDT를 먼저 생성한 뒤 테이블 생성을 시도합니다.
+ * - 테이블/UDT가 이미 존재하면 생성 CQL을 실행하지 않습니다.
+ * - [truncate]는 대상 테이블이 실제로 존재할 때만 `TRUNCATE`를 실행합니다.
  *
+ * ```kotlin
  * SchemaGenerator.truncate<AllPossibleTypes>(operations)
- * SchemaGenerator.potentiallyCreateTableFor<AllPossibleTypes>(operations)
+ * SchemaGenerator.createTableAndTypes<AllPossibleTypes>(operations)
+ * // result == "table ready"
  * ```
  */
 object SchemaGenerator: KLoggingChannel() {
 
+    /**
+     * 제네릭 엔티티 타입의 UDT와 테이블 생성을 수행합니다.
+     *
+     * ## 동작/계약
+     * - `T::class`를 사용해 [createTableAndTypes] 오버로드에 위임합니다.
+     *
+     * ```kotlin
+     * SchemaGenerator.createTableAndTypes<AllPossibleTypes>(operations)
+     * // result == "schema checked"
+     * ```
+     */
     inline fun <reified T: Any> createTableAndTypes(operations: CassandraOperations) {
         createTableAndTypes(operations, T::class)
     }
 
+    /**
+     * 지정한 엔티티 클래스의 UDT와 테이블 생성을 수행합니다.
+     *
+     * ## 동작/계약
+     * - 매핑 컨텍스트에서 엔티티 메타데이터를 조회하고 [SchemaFactory]를 생성합니다.
+     * - UDT 생성([potentiallyCreateUdtFor]) 이후 테이블 생성([potentiallyCreateTableFor]) 순서로 실행합니다.
+     * - 엔티티 메타데이터가 없으면 `getRequiredPersistentEntity` 예외가 발생합니다.
+     *
+     * ```kotlin
+     * SchemaGenerator.createTableAndTypes(operations, AllPossibleTypes::class)
+     * // result == "schema checked"
+     * ```
+     */
     fun <T: Any> createTableAndTypes(operations: CassandraOperations, entityKClass: KClass<T>) {
         val persistentEntity = operations.converter.mappingContext.getRequiredPersistentEntity(entityKClass.java)
         val schemaFactory = SchemaFactory(operations.converter)
@@ -38,10 +65,33 @@ object SchemaGenerator: KLoggingChannel() {
         potentiallyCreateTableFor(operations, persistentEntity, schemaFactory)
     }
 
+    /**
+     * 제네릭 엔티티 타입의 테이블 생성을 필요할 때만 수행합니다.
+     *
+     * ## 동작/계약
+     * - `T::class`를 사용해 [potentiallyCreateTableFor] 오버로드에 위임합니다.
+     *
+     * ```kotlin
+     * SchemaGenerator.potentiallyCreateTableFor<AllPossibleTypes>(operations)
+     * // result == "table checked"
+     * ```
+     */
     inline fun <reified T: Any> potentiallyCreateTableFor(operations: CassandraOperations) {
         potentiallyCreateTableFor(operations, T::class)
     }
 
+    /**
+     * 지정한 엔티티 클래스의 테이블 생성을 필요할 때만 수행합니다.
+     *
+     * ## 동작/계약
+     * - 매핑 컨텍스트에서 엔티티를 조회한 뒤 private 오버로드로 위임합니다.
+     * - 엔티티 메타데이터가 없으면 `getRequiredPersistentEntity` 예외가 발생합니다.
+     *
+     * ```kotlin
+     * SchemaGenerator.potentiallyCreateTableFor(operations, AllPossibleTypes::class)
+     * // result == "table checked"
+     * ```
+     */
     fun <T: Any> potentiallyCreateTableFor(operations: CassandraOperations, entityKClass: KClass<T>) {
         val persistentEntity = operations.converter.mappingContext.getRequiredPersistentEntity(entityKClass.java)
         potentiallyCreateTableFor(operations, persistentEntity, SchemaFactory(operations.converter))
@@ -89,10 +139,33 @@ object SchemaGenerator: KLoggingChannel() {
         }
     }
 
+    /**
+     * 제네릭 엔티티 타입 테이블을 존재할 때만 truncate 합니다.
+     *
+     * ## 동작/계약
+     * - `T::class.java`를 사용해 [truncate] 오버로드에 위임합니다.
+     *
+     * ```kotlin
+     * SchemaGenerator.truncate<AllPossibleTypes>(operations)
+     * // result == "table truncated if exists"
+     * ```
+     */
     inline fun <reified T: Any> truncate(operations: CassandraOperations) {
         truncate(operations, T::class.java)
     }
 
+    /**
+     * 지정한 엔티티 클래스의 테이블을 존재할 때만 truncate 합니다.
+     *
+     * ## 동작/계약
+     * - 세션 메타데이터로 테이블 존재 여부를 확인한 뒤 존재할 때만 `operations.truncate(entityClass)`를 실행합니다.
+     * - 테이블이 없으면 아무 작업도 수행하지 않습니다.
+     *
+     * ```kotlin
+     * SchemaGenerator.truncate(operations, AllPossibleTypes::class.java)
+     * // result == "truncate attempted"
+     * ```
+     */
     fun <T: Any> truncate(operations: CassandraOperations, entityClass: Class<T>) {
         val persistentEntity = operations.converter.mappingContext.getRequiredPersistentEntity(entityClass)
         operations.cqlOperations.execute(

--- a/spring/core/src/main/kotlin/io/bluetape4k/spring/beans/AnnotationExtensions.kt
+++ b/spring/core/src/main/kotlin/io/bluetape4k/spring/beans/AnnotationExtensions.kt
@@ -5,23 +5,32 @@ import org.springframework.util.ReflectionUtils
 import org.springframework.util.StringValueResolver
 
 /**
- * Annotation의 속성을 Bean에 복사합니다.
+ * 애너테이션 속성을 대상 빈 프로퍼티로 복사합니다.
  *
- * @receiver Annotation
- * @param bean Annotation의 속성을 복사할 Bean
- * @param excludedProperties 제외할 속성 이름들
+ * ## 동작/계약
+ * - [excludedProperties]에 포함되지 않고 쓰기 가능한 프로퍼티만 설정합니다.
+ * - 문자열 해석기 없이 [copyPropertiesToBean] 오버로드를 호출합니다.
+ *
+ * ```kotlin
+ * annotation.copyPropertiesToBean(bean, "value")
+ * // 제외 목록 외 속성만 bean에 반영
+ * ```
  */
 fun Annotation.copyPropertiesToBean(bean: Any, vararg excludedProperties: String) {
     copyPropertiesToBean(bean, null, *excludedProperties)
 }
 
 /**
- * Annotation의 속성을 Bean에 복사합니다.
+ * 애너테이션 속성을 대상 빈 프로퍼티로 복사하고 문자열 값을 해석합니다.
  *
- * @receiver Annotation
- * @param bean Annotation의 속성을 복사할 Bean
- * @param valueResolver StringValueResolver
- * @param excludedProperties 제외할 속성 이름들
+ * ## 동작/계약
+ * - 애너테이션 선언 메서드를 순회해 프로퍼티 이름과 값을 읽습니다.
+ * - [valueResolver]가 있고 값이 문자열이면 해석된 문자열을 저장합니다.
+ *
+ * ```kotlin
+ * annotation.copyPropertiesToBean(bean, valueResolver, "value")
+ * // 문자열 속성은 valueResolver 결과로 설정
+ * ```
  */
 fun Annotation.copyPropertiesToBean(
     bean: Any,

--- a/spring/core/src/main/kotlin/io/bluetape4k/spring/beans/BeanFactoryExtensions.kt
+++ b/spring/core/src/main/kotlin/io/bluetape4k/spring/beans/BeanFactoryExtensions.kt
@@ -10,78 +10,87 @@ import kotlin.reflect.KClass
 private val log by lazy { KotlinLogging.logger {} }
 
 /**
- * 지정된 수형의 Bean을 찾습니다. 없으면 예외를 발생합니다.
+ * 제네릭 타입 [T]에 해당하는 빈을 조회합니다.
  *
- * ```
- * val bean = beanFactory.get<BeanClass>()
- * ```
+ * ## 동작/계약
+ * - 빈이 없으면 Spring [BeansException]을 그대로 전파합니다.
+ * - 구현은 [BeanFactory.getBean] 확장을 호출합니다.
  *
- * @receiver BeanFactory Bean Container
- * @param T 원하는 Bean의 수형
+ * ```kotlin
+ * val service = beanFactory.get<MyService>()
+ * // service != null
+ * ```
  */
 inline fun <reified T: Any> BeanFactory.get(): T = getBean<T>()
 
 /**
- * 지정된 이름의 Bean을 찾습니다. 없으면 null을 반환합니다.
+ * 이름으로 빈을 조회하고 타입 캐스팅에 실패하면 `null`을 반환합니다.
  *
- * ```
- * val bean = beanFactory["beanName"]
- * ```
+ * ## 동작/계약
+ * - 내부적으로 `getBean(name)`을 호출한 뒤 안전 캐스팅(`as?`)합니다.
+ * - 빈이 없으면 Spring 예외가 발생할 수 있습니다.
  *
- * @receiver BeanFactory Bean Container
- * @param name Bean 이름
+ * ```kotlin
+ * val service: MyService? = beanFactory["myService"]
+ * // service == null || service is MyService
+ * ```
  */
 @Suppress("UNCHECKED_CAST")
 operator fun <T: Any> BeanFactory.get(name: String): T? = getBean(name) as? T
 
 /**
- * 지정된 수형의 Bean을 찾습니다. 없으면 예외를 발생합니다.
+ * [KClass]로 지정한 타입의 빈을 조회합니다.
  *
+ * ## 동작/계약
+ * - [requiredType]의 Java 클래스 타입으로 조회합니다.
+ * - 빈이 없으면 Spring [BeansException]을 전파합니다.
+ *
+ * ```kotlin
+ * val service = beanFactory[MyService::class]
+ * // service != null
  * ```
- * val bean = beanFactory[BeanClass::class]
- * ```
- *
- * @receiver BeanFactory Bean Container
- * @param requiredType 원하는 Bean의 수형
- *
  */
 operator fun <T: Any> BeanFactory.get(requiredType: KClass<T>): T = getBean(requiredType.java)
 
 /**
- * 지정된 수형의 Bean을 찾습니다. 없으면 예외를 발생합니다.
+ * [Class]로 지정한 타입의 빈을 조회합니다.
  *
- * ```
- * val bean = beanFactory[BeanClass::class.java]
- * ```
+ * ## 동작/계약
+ * - 구현은 `getBean(requiredType)` 호출입니다.
+ * - 빈이 없으면 Spring [BeansException]을 전파합니다.
  *
- * @receiver BeanFactory
- * @param requiredType 원하는 Bean의 수형
+ * ```kotlin
+ * val service = beanFactory[MyService::class.java]
+ * // service != null
+ * ```
  */
 operator fun <T: Any> BeanFactory.get(requiredType: Class<T>): T = getBean(requiredType)
 
 /**
- * 지정된 이름과 수형의 Bean을 찾습니다. 없으면 예외를 발생합니다.
+ * 이름과 타입으로 빈을 조회합니다.
  *
- * ```
- * val bean = beanFactory["beanName", BeanClass::class]
- * ```
+ * ## 동작/계약
+ * - 구현은 `getBean(name, requiredType)` 호출입니다.
+ * - 이름/타입이 맞지 않으면 Spring [BeansException]을 전파합니다.
  *
- * @receiver BeanFactory
- * @param name Bean 이름
- * @param requiredType 원하는 Bean의 수형
+ * ```kotlin
+ * val service = beanFactory["myService", MyService::class.java]
+ * // service != null
+ * ```
  */
 operator fun <T: Any> BeanFactory.get(name: String, requiredType: Class<T>): T = getBean(name, requiredType)
 
 /**
- * 지정된 이름과 수형의 Bean을 찾습니다. 없으면 예외를 발생합니다.
+ * 이름과 생성자 인자로 빈을 조회합니다.
  *
- * ```
- * val bean = beanFactory["beanName", "arg1", "arg2"]
- * ```
+ * ## 동작/계약
+ * - [args]가 비어 있으면 `get(name)` 경로를 사용합니다.
+ * - [args]가 있으면 `getBean(name, *args)`를 호출합니다.
  *
- * @receiver BeanFactory
- * @param name Bean 이름
- * @param args Bean 생성자 인자
+ * ```kotlin
+ * val bean = beanFactory["myBean", "arg1", 2]
+ * // bean != null
+ * ```
  */
 operator fun BeanFactory.get(name: String, vararg args: Any?): Any? = when {
     args.isEmpty() -> get(name) as? Any
@@ -89,20 +98,30 @@ operator fun BeanFactory.get(name: String, vararg args: Any?): Any? = when {
 }
 
 /**
- * 지정된 수형의 Bean을 찾습니다. 없으면 null 을 반환합니다.
+ * 타입으로 빈을 조회하고 없으면 `null`을 반환합니다.
  *
- * ```
- * val bean = beanFactory.findBean(BeanClass::class)
+ * ## 동작/계약
+ * - 내부적으로 [Class] 기반 [findBean]으로 위임합니다.
+ * - 조회 실패 시 예외 대신 `null`을 반환합니다.
+ *
+ * ```kotlin
+ * val service = beanFactory.findBean(MyService::class)
+ * // service == null || service is MyService
  * ```
  */
 fun <T: Any> BeanFactory.findBean(requiredType: KClass<T>): T? =
     findBean(requiredType.java)
 
 /**
- * 지정된 수형의 Bean을 찾습니다. 없으면 null 을 반환합니다.
+ * 타입으로 빈을 조회하고 실패하면 경고 로그 후 `null`을 반환합니다.
  *
- * ```
- * val bean = beanFactory.findBean(BeanClass::class.java)
+ * ## 동작/계약
+ * - [get] 호출에서 [BeansException]이 발생하면 예외를 삼키고 `null`을 반환합니다.
+ * - 실패 정보는 경고 로그로 기록합니다.
+ *
+ * ```kotlin
+ * val service = beanFactory.findBean(MyService::class.java)
+ * // service == null || service is MyService
  * ```
  */
 fun <T: Any> BeanFactory.findBean(requiredType: Class<T>): T? {
@@ -115,10 +134,15 @@ fun <T: Any> BeanFactory.findBean(requiredType: Class<T>): T? {
 }
 
 /**
- * 지정된 이름과 수형의 Bean을 찾습니다. 없으면 null 을 반환합니다.
+ * 이름과 타입으로 빈을 조회하고 실패하면 `null`을 반환합니다.
  *
- * ```
- * val bean = beanFactory.findBean("beanName", BeanClass::class)
+ * ## 동작/계약
+ * - [get] 호출에서 [BeansException]이 발생하면 예외 대신 `null`을 반환합니다.
+ * - 실패 정보는 경고 로그로 기록합니다.
+ *
+ * ```kotlin
+ * val service = beanFactory.findBean("myService", MyService::class.java)
+ * // service == null || service is MyService
  * ```
  */
 fun <T: Any> BeanFactory.findBean(name: String, requiredType: Class<T>): T? {
@@ -131,10 +155,15 @@ fun <T: Any> BeanFactory.findBean(name: String, requiredType: Class<T>): T? {
 }
 
 /**
- * 지정된 이름과 수형의 Bean을 찾습니다. 없으면 null 을 반환합니다.
+ * 이름과 생성자 인자로 빈을 조회하고 실패하면 `null`을 반환합니다.
  *
- * ```
- * val bean = beanFactory.findBean("beanName", "arg1", "arg2")
+ * ## 동작/계약
+ * - [get] 호출에서 [BeansException]이 발생하면 예외 대신 `null`을 반환합니다.
+ * - 실패 정보는 경고 로그로 기록합니다.
+ *
+ * ```kotlin
+ * val bean = beanFactory.findBean("myBean", "arg1")
+ * // bean == null || bean != null
  * ```
  */
 fun <T: Any> BeanFactory.findBean(name: String, vararg args: Any?): Any? {

--- a/spring/core/src/main/kotlin/io/bluetape4k/spring/beans/BeanUtilsSupport.kt
+++ b/spring/core/src/main/kotlin/io/bluetape4k/spring/beans/BeanUtilsSupport.kt
@@ -1,6 +1,5 @@
 package io.bluetape4k.spring.beans
 
-import io.bluetape4k.logging.KotlinLogging
 import io.bluetape4k.support.assertNotBlank
 import io.bluetape4k.utils.KotlinDelegates
 import org.springframework.beans.BeanInstantiationException
@@ -11,27 +10,32 @@ import java.beans.PropertyDescriptor
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 
-
-private val log by lazy { KotlinLogging.logger {} }
-
 /**
- * 지정한 수형의 새로운 인스턴스를 생성합니다.
+ * 수신 클래스의 기본 생성자를 사용해 인스턴스를 생성합니다.
  *
- * ```
- * val instance = BeanClass::class.java.instantiateClass()
- * ```
+ * ## 동작/계약
+ * - 구현은 [BeanUtils.instantiateClass] 호출입니다.
+ * - 생성 실패 시 Spring 예외를 전파합니다.
  *
- * @receiver Class<T> 생성할 인스턴스의 수형
- * @return T 생성된 인스턴스
+ * ```kotlin
+ * val instance = MyType::class.java.instantiateClass()
+ * // instance is MyType
+ * ```
  */
 fun <T> Class<T>.instantiateClass(): T = BeanUtils.instantiateClass(this)
 
 /**
- * [Constructor]`<T>`와 인자를 이용하여 인스턴스를 생성합니다.
+ * 생성자와 인자로 인스턴스를 생성합니다.
  *
- * @receiver Constructor<T>   생성자
- * @param args Array<out Any?> 생성자의 인자 값들
- * @return 생성된 인스턴스
+ * ## 동작/계약
+ * - Kotlin 타입이면 [KotlinDelegates.instantiateClass], 아니면 [BeanUtils.instantiateClass]를 사용합니다.
+ * - 생성 과정 예외는 [BeanInstantiationException]으로 감싸서 던집니다.
+ *
+ * ```kotlin
+ * val ctor = MyType::class.java.getDeclaredConstructor(String::class.java)
+ * val instance = ctor.instantiateClass("value")
+ * // instance is MyType
+ * ```
  */
 fun <T: Any> Constructor<T>.instantiateClass(vararg args: Any?): T {
     return try {
@@ -48,26 +52,31 @@ fun <T: Any> Constructor<T>.instantiateClass(vararg args: Any?): T {
 }
 
 /**
- * Receiver 수형으로 인스턴스를 생성하고, [assignableTo] 수형으로 cast 후 반환합니다.
+ * 수신 클래스로 인스턴스를 생성한 뒤 지정 타입으로 반환합니다.
  *
- * ```
- * val instance = BeanClass::class.java.instantiateClass<DerivedBeanClass>()
- * ```
+ * ## 동작/계약
+ * - 구현은 [BeanUtils.instantiateClass]의 `assignableTo` 오버로드를 호출합니다.
+ * - 타입이 맞지 않으면 Spring 예외를 전파합니다.
  *
- * @receiver Class<*> 생성할 인스턴스의 수형
- * @param assignableTo Class<T> 변환할 수형
- * @return T 생성된 인스턴스
+ * ```kotlin
+ * val bean = ImplType::class.java.instantiateClass(BaseType::class.java)
+ * // bean is BaseType
+ * ```
  */
 fun <T> Class<*>.instantiateClass(assignableTo: Class<T>): T =
     BeanUtils.instantiateClass(this, assignableTo)
 
-
 /**
- * 현 수형의 [methodName]의 메소드 정보를 찾습니다.
+ * 공개 메서드에서 이름과 시그니처가 일치하는 메서드를 찾습니다.
  *
- * @param methodName method name to find
- * @param paramTypes types of method parameter
- * @return 메소드 정보, 찾지 못하면 null 반환
+ * ## 동작/계약
+ * - [methodName]이 비어 있으면 `assertNotBlank`에 의해 예외가 발생합니다.
+ * - 구현은 [BeanUtils.findMethod] 호출입니다.
+ *
+ * ```kotlin
+ * val method = MyType::class.java.findMethod("execute")
+ * // method?.name == "execute"
+ * ```
  */
 fun Class<*>.findMethod(methodName: String, vararg paramTypes: Class<*>): Method? {
     methodName.assertNotBlank("methodName")
@@ -75,11 +84,16 @@ fun Class<*>.findMethod(methodName: String, vararg paramTypes: Class<*>): Method
 }
 
 /**
- * 현 수형의 [methodName]의 메소드 정보를 찾습니다.
+ * 선언 메서드에서 이름과 시그니처가 일치하는 메서드를 찾습니다.
  *
- * @param methodName method name to find
- * @param paramTypes types of method parameter
- * @return 메소드 정보, 찾지 못하면 null 반환
+ * ## 동작/계약
+ * - [methodName]이 비어 있으면 `assertNotBlank`에 의해 예외가 발생합니다.
+ * - 구현은 [BeanUtils.findDeclaredMethod] 호출입니다.
+ *
+ * ```kotlin
+ * val method = MyType::class.java.findDeclaredMethod("execute")
+ * // method?.name == "execute"
+ * ```
  */
 fun Class<*>.findDeclaredMethod(methodName: String, vararg paramTypes: Class<*>): Method? {
     methodName.assertNotBlank("methodName")
@@ -87,10 +101,16 @@ fun Class<*>.findDeclaredMethod(methodName: String, vararg paramTypes: Class<*>)
 }
 
 /**
- * 현 수형의 [methodName]의 메소드 정보를 찾습니다.
+ * 지정 이름의 공개 메서드 중 파라미터 수가 최소인 메서드를 찾습니다.
  *
- * @param methodName method name to find
- * @return 메소드 정보, 찾지 못하면 null 반환
+ * ## 동작/계약
+ * - [methodName]이 비어 있으면 `assertNotBlank`에 의해 예외가 발생합니다.
+ * - 구현은 [BeanUtils.findMethodWithMinimalParameters] 호출입니다.
+ *
+ * ```kotlin
+ * val method = MyType::class.java.findMethodWithMinimalParameters("execute")
+ * // method?.name == "execute"
+ * ```
  */
 fun Class<*>.findMethodWithMinimalParameters(methodName: String): Method? {
     methodName.assertNotBlank("methodName")
@@ -98,10 +118,16 @@ fun Class<*>.findMethodWithMinimalParameters(methodName: String): Method? {
 }
 
 /**
- * 현 수형의 [methodName]의 메소드 정보를 찾습니다.
+ * 지정 이름의 선언 메서드 중 파라미터 수가 최소인 메서드를 찾습니다.
  *
- * @param methodName method name to find
- * @return 메소드 정보, 찾지 못하면 null 반환
+ * ## 동작/계약
+ * - [methodName]이 비어 있으면 `assertNotBlank`에 의해 예외가 발생합니다.
+ * - 구현은 [BeanUtils.findDeclaredMethodWithMinimalParameters] 호출입니다.
+ *
+ * ```kotlin
+ * val method = MyType::class.java.findDeclaredMethodWithMinimalParameters("execute")
+ * // method?.name == "execute"
+ * ```
  */
 fun Class<*>.findDeclaredMethodWithMinimalParameters(methodName: String): Method? {
     methodName.assertNotBlank("methodName")
@@ -109,10 +135,16 @@ fun Class<*>.findDeclaredMethodWithMinimalParameters(methodName: String): Method
 }
 
 /**
- * 현 수형의 [methodName]의 메소드 정보를 찾습니다.
+ * 메서드 배열에서 지정 이름의 메서드 중 파라미터 수가 최소인 메서드를 찾습니다.
  *
- * @param methodName method name to find
- * @return 메소드 정보, 찾지 못하면 null 반환
+ * ## 동작/계약
+ * - [methodName]이 비어 있으면 `assertNotBlank`에 의해 예외가 발생합니다.
+ * - 구현은 [BeanUtils.findMethodWithMinimalParameters] 배열 오버로드 호출입니다.
+ *
+ * ```kotlin
+ * val method = MyType::class.java.methods.findMethodWithMinimalParameters("execute")
+ * // method?.name == "execute"
+ * ```
  */
 fun Array<out Method>.findMethodWithMinimalParameters(methodName: String): Method? {
     methodName.assertNotBlank("methodName")
@@ -120,31 +152,46 @@ fun Array<out Method>.findMethodWithMinimalParameters(methodName: String): Metho
 }
 
 /**
- * 지정한 수형에서 [signature]에 해당하는 [Method]를 찾습니다.
- * [signature] 는 [Method]의 signature를 표현한 것입니다.
+ * 시그니처 문자열에 해당하는 메서드를 해석합니다.
  *
- * @receiver Class<*>
- * @param signature 메소드의 signature
- * @return Method? 찾은 메소드 인스턴스
+ * ## 동작/계약
+ * - 시그니처 파싱/조회는 [BeanUtils.resolveSignature]에 위임합니다.
+ * - 해석 실패 시 `null`을 반환합니다.
+ *
+ * ```kotlin
+ * val method = MyType::class.java.resolveSignature("execute(java.lang.String)")
+ * // method?.name == "execute"
+ * ```
  */
 fun Class<*>.resolveSignature(signature: String): Method? =
     BeanUtils.resolveSignature(signature, this)
 
 /**
- * 주어진 수형의 JavaBeans [PropertyDescriptor]를 얻습니다.
+ * 수신 클래스의 모든 JavaBeans [PropertyDescriptor]를 반환합니다.
  *
- * @receiver Class<*>
- * @return Array<PropertyDescriptor>
+ * ## 동작/계약
+ * - 구현은 [BeanUtils.getPropertyDescriptors] 호출입니다.
+ * - 반환 배열에는 읽기/쓰기 가능한 프로퍼티 기술자가 포함됩니다.
+ *
+ * ```kotlin
+ * val descriptors = MyType::class.java.getPropertyDescriptors()
+ * // descriptors.isNotEmpty() == true
+ * ```
  */
 fun Class<*>.getPropertyDescriptors(): Array<PropertyDescriptor> =
     BeanUtils.getPropertyDescriptors(this)
 
 /**
- * 주어진 수형의 JavaBeans [PropertyDescriptor]를 얻습니다.
+ * 지정 이름의 JavaBeans [PropertyDescriptor]를 반환합니다.
  *
- * @receiver Class<*> Java Beans 수형
- * @param propertyName 속성 명
- * @return PropertyDescriptor or null
+ * ## 동작/계약
+ * - [propertyName]이 비어 있으면 `assertNotBlank`에 의해 예외가 발생합니다.
+ * - 구현은 [BeanUtils.getPropertyDescriptor] 호출입니다.
+ *
+ * ```kotlin
+ * val descriptor = MyType::class.java.getPropertyDescriptor("name")
+ * // descriptor?.name == "name"
+ * ```
  */
 fun Class<*>.getPropertyDescriptor(propertyName: String): PropertyDescriptor? {
     propertyName.assertNotBlank("requireName")
@@ -152,74 +199,105 @@ fun Class<*>.getPropertyDescriptor(propertyName: String): PropertyDescriptor? {
 }
 
 /**
- * 현 메소드를 표현하는 JavaBeans [PropertyDescriptor]를 찾습니다.
+ * 메서드로부터 대응되는 JavaBeans [PropertyDescriptor]를 찾습니다.
  *
- * @receiver [Method]
- * @return [PropertyDescriptor] or null
+ * ## 동작/계약
+ * - 구현은 [BeanUtils.findPropertyForMethod] 호출입니다.
+ * - 대응 프로퍼티가 없으면 `null`을 반환합니다.
+ *
+ * ```kotlin
+ * val descriptor = method.findPropertyDescriptor()
+ * // descriptor == null || descriptor.name.isNotEmpty()
+ * ```
  */
 fun Method.findPropertyDescriptor(): PropertyDescriptor? =
     BeanUtils.findPropertyForMethod(this)
 
 /**
- * 현 메소드를 표현하는 JavaBeans [PropertyDescriptor]를 찾습니다.
+ * 메서드와 대상 클래스로 대응되는 JavaBeans [PropertyDescriptor]를 찾습니다.
  *
- * @receiver [Method]
- * @param clazz Class<*> 대상 수형
- * @return [PropertyDescriptor] or null
+ * ## 동작/계약
+ * - 구현은 [BeanUtils.findPropertyForMethod]의 클래스 지정 오버로드 호출입니다.
+ * - 대응 프로퍼티가 없으면 `null`을 반환합니다.
+ *
+ * ```kotlin
+ * val descriptor = method.findPropertyDescriptor(MyType::class.java)
+ * // descriptor == null || descriptor.name.isNotEmpty()
+ * ```
  */
 fun Method.findPropertyDescriptor(clazz: Class<*>): PropertyDescriptor? =
     BeanUtils.findPropertyForMethod(this, clazz)
 
 /**
- * 특정 속성의 쓰기 메소드를 위한 MethodParameter 객체를 얻습니다.
+ * 프로퍼티 쓰기 메서드의 [MethodParameter]를 반환합니다.
  *
- * @receiver the PropertyDescriptor for the property
- * @return a corresponding MethodParameter object
+ * ## 동작/계약
+ * - 구현은 [BeanUtils.getWriteMethodParameter] 호출입니다.
+ * - 쓰기 메서드가 없는 경우 Spring 예외가 발생할 수 있습니다.
+ *
+ * ```kotlin
+ * val parameter = descriptor.getWriteMethodParamter()
+ * // parameter.parameterType != null
+ * ```
  */
 fun PropertyDescriptor.getWriteMethodParamter(): MethodParameter =
     BeanUtils.getWriteMethodParameter(this)
 
 /**
- * Check if the given type represents a "simple" property: a simple value type or an array of simple value types.
+ * 타입이 simple property인지 확인합니다.
  *
- * [isSimpleValueType(Class)] for the definition of **simple value type**
+ * ## 동작/계약
+ * - simple value type 또는 그 배열이면 `true`를 반환합니다.
+ * - 구현은 [BeanUtils.isSimpleProperty] 호출입니다.
  *
- * Used to determine properties to check for a "simple" dependency-check.
- *
- * @receiver the type to check
- * @return whether the given type represents a "simple" property
- * @see [isSimpleValueType]
+ * ```kotlin
+ * val simple = String::class.java.isSimpleProperty()
+ * // simple == true
+ * ```
  */
-
 fun Class<*>.isSimpleProperty(): Boolean = BeanUtils.isSimpleProperty(this)
 
 /**
- * Check if the given type represents a "simple" value type: a primitive or primitive wrapper,
- * an enum, a String or other CharSequence, a Number, a Date, a Temporal, a URI, a URL, a Locale, or a Class.
+ * 타입이 simple value type인지 확인합니다.
  *
- * @receiver the type to check
- * @return whether the given type represents a "simple" value type
- * @see  [isSimpleProperty]
+ * ## 동작/계약
+ * - primitive/문자열/숫자 등 Spring이 정의한 단순 값 타입이면 `true`를 반환합니다.
+ * - 구현은 [BeanUtils.isSimpleValueType] 호출입니다.
+ *
+ * ```kotlin
+ * val simple = Int::class.javaObjectType.isSimpleValueType()
+ * // simple == true
+ * ```
  */
 fun Class<*>.isSimpleValueType(): Boolean = BeanUtils.isSimpleValueType(this)
 
 /**
- * 지정한 Bean의 속성을 [target]의 속성에 설정합니다.
+ * 소스 빈의 프로퍼티를 대상 빈으로 복사합니다.
  *
- * @receiver Source bean
- * @param target Target bean
- * @param ignoreProperties 복사에서 제외할 속성명
+ * ## 동작/계약
+ * - [ignoreProperties]에 지정한 프로퍼티는 복사하지 않습니다.
+ * - 구현은 [BeanUtils.copyProperties] 호출입니다.
+ *
+ * ```kotlin
+ * source.copyProperties(target, "id")
+ * // id를 제외한 공통 프로퍼티가 target에 반영
+ * ```
  */
 fun Any.copyProperties(target: Any, vararg ignoreProperties: String) {
     BeanUtils.copyProperties(this, target, *ignoreProperties)
 }
 
 /**
- * 지정한 Bean의 속성을 [target]의 속성에 설정합니다.
+ * 소스 빈의 프로퍼티를 대상 빈으로 복사하되 대상 타입 범위를 제한합니다.
  *
- * @receiver Source bean
- * @param target Target bean
- * @param editable the class (or interface) to restrict property setting to
+ * ## 동작/계약
+ * - [editable] 타입에 선언된 프로퍼티만 복사 대상으로 사용합니다.
+ * - 구현은 [BeanUtils.copyProperties]의 `editable` 오버로드 호출입니다.
+ *
+ * ```kotlin
+ * source.copyProperties(target, BaseType::class.java)
+ * // BaseType 범위의 프로퍼티만 복사
+ * ```
  */
 fun Any.copyProperties(target: Any, editable: Class<*>) {
     BeanUtils.copyProperties(this, target, editable)

--- a/spring/core/src/main/kotlin/io/bluetape4k/spring/beans/PropertyAccessorUtilsSupport.kt
+++ b/spring/core/src/main/kotlin/io/bluetape4k/spring/beans/PropertyAccessorUtilsSupport.kt
@@ -3,50 +3,106 @@ package io.bluetape4k.spring.beans
 import org.springframework.beans.PropertyAccessorUtils
 
 /**
- * 지정한 property path의 실제 property name을 추출합니다.
+ * 프로퍼티 경로에서 실제 프로퍼티 이름을 추출합니다.
+ *
+ * ## 동작/계약
+ * - `map[key]` 같은 인덱스 표현이 포함된 경로에서도 기본 이름을 반환합니다.
+ * - 구현은 [PropertyAccessorUtils.getPropertyName]에 위임합니다.
+ *
+ * ```kotlin
+ * val name = "user.address[0]".getPropertyName()
+ * // name == "user.address"
+ * ```
  */
 fun String.getPropertyName(): String =
     PropertyAccessorUtils.getPropertyName(this)
 
 /**
- * 지정한 property path가  indexed 나 nested property 인지 나타냅니다.
+ * 프로퍼티 경로가 중첩 또는 인덱스 표현을 포함하는지 확인합니다.
+ *
+ * ## 동작/계약
+ * - 점(`.`) 중첩 또는 대괄호 인덱스가 있으면 `true`를 반환합니다.
+ * - 구현은 [PropertyAccessorUtils.isNestedOrIndexedProperty]에 위임합니다.
+ *
+ * ```kotlin
+ * val nested = "user.address[0]".isNestedOrIndexedProperty()
+ * // nested == true
+ * ```
  */
 fun String.isNestedOrIndexedProperty(): Boolean =
     PropertyAccessorUtils.isNestedOrIndexedProperty(this)
 
 /**
- * Determine the first nested property separator in the given property path, ignoring dots in keys (like `map["my.key"]`).
+ * 첫 번째 중첩 구분자 인덱스를 반환합니다.
+ *
+ * ## 동작/계약
+ * - `map["my.key"]` 내부 점은 무시하고 첫 중첩 구분자를 계산합니다.
+ * - 구분자가 없으면 음수 값을 반환합니다.
+ *
+ * ```kotlin
+ * val idx = "user.address.street".getFirstNestedPropertySeparatorIndex()
+ * // idx == 4
+ * ```
  */
 fun String.getFirstNestedPropertySeparatorIndex(): Int =
     PropertyAccessorUtils.getFirstNestedPropertySeparatorIndex(this)
 
 /**
- * 마지막 중첩된 속성 구분자의 인덱스를 결정합니다. (예: `map["my.key"]`와 같은 키의 점을 무시합니다.)
+ * 마지막 중첩 구분자 인덱스를 반환합니다.
+ *
+ * ## 동작/계약
+ * - 키 내부의 점은 무시하고 마지막 중첩 구분자 위치를 계산합니다.
+ * - 구분자가 없으면 음수 값을 반환합니다.
+ *
+ * ```kotlin
+ * val idx = "user.address.street".getLastNestedPropertySeparatorIndex()
+ * // idx == 12
+ * ```
  */
 fun String.getLastNestedPropertySeparatorIndex(): Int =
     PropertyAccessorUtils.getLastNestedPropertySeparatorIndex(this)
 
 /**
- * 등록된 경로 (receiver)가 속성 경로([propertyPath])와 일치하는지 여부를 결정합니다.
- * 속성 자체를 나타내거나 속성의 색인 요소를 나타낼 수 있습니다.
+ * 등록 경로가 대상 [propertyPath]와 일치하는지 확인합니다.
  *
- * @param propertyPath the property path (typically without index)
+ * ## 동작/계약
+ * - 수신 경로가 대상 프로퍼티 자체이거나 인덱스 표현이면 `true`를 반환할 수 있습니다.
+ * - 구현은 [PropertyAccessorUtils.matchesProperty]에 위임합니다.
+ *
+ * ```kotlin
+ * val matched = "items[0]".matchesProperty("items")
+ * // matched == true
+ * ```
  */
 fun String.matchesProperty(propertyPath: String): Boolean =
     PropertyAccessorUtils.matchesProperty(this, propertyPath)
 
 /**
- * Determine the canonical name for the given property path.
- * Removes surrounding quotes from map keys:<br>
+ * 프로퍼티 경로를 정규화된 canonical 이름으로 변환합니다.
+ *
+ * ## 동작/계약
+ * - 맵 키를 감싼 따옴표를 제거합니다.
+ * - 구현은 [PropertyAccessorUtils.canonicalPropertyName]에 위임합니다.
+ *
+ * ```kotlin
+ * val canonical = "map['my.key']".canonicalPropertyName()
+ * // canonical == "map[my.key]"
+ * ```
  */
 fun String.canonicalPropertyName(): String =
     PropertyAccessorUtils.canonicalPropertyName(this)
 
 /**
- * Determine the canonical names for the given property paths.
+ * 프로퍼티 경로 배열을 canonical 이름 배열로 변환합니다.
  *
- * @return the canonical representation of the property paths
- * (as array of the same size)
+ * ## 동작/계약
+ * - 입력 배열과 동일한 길이의 배열을 반환합니다.
+ * - 구현은 [PropertyAccessorUtils.canonicalPropertyNames]에 위임합니다.
+ *
+ * ```kotlin
+ * val names = arrayOf("map['a']", "map['b']").canonicalPropertyNames()
+ * // names?.toList() == listOf("map[a]", "map[b]")
+ * ```
  */
 fun Array<String>.canonicalPropertyNames(): Array<String>? =
     PropertyAccessorUtils.canonicalPropertyNames(this)

--- a/spring/core/src/main/kotlin/io/bluetape4k/spring/config/ProfileSupport.kt
+++ b/spring/core/src/main/kotlin/io/bluetape4k/spring/config/ProfileSupport.kt
@@ -2,36 +2,141 @@ package io.bluetape4k.spring.config
 
 import org.springframework.context.annotation.Profile
 
+/**
+ * `local` 프로파일 활성화용 메타 애너테이션입니다.
+ *
+ * ## 동작/계약
+ * - 타입에 선언하면 Spring의 `local` 프로파일과 매핑됩니다.
+ * - [name] 기본값은 `"local"`입니다.
+ *
+ * ```kotlin
+ * @LocalProfile
+ * class LocalOnlyConfig
+ * // local 프로파일에서만 활성화
+ * ```
+ *
+ * @property name 프로파일 이름 메타데이터
+ */
 @Target(AnnotationTarget.TYPE)
 @Retention(AnnotationRetention.RUNTIME)
 @Profile("local")
 annotation class LocalProfile(val name: String = "local")
 
+/**
+ * `dev`, `develop`, `development` 프로파일 활성화용 메타 애너테이션입니다.
+ *
+ * ## 동작/계약
+ * - 타입에 선언하면 지정된 세 프로파일 중 하나가 활성화될 때 적용됩니다.
+ * - [name] 기본값은 `"development"`입니다.
+ *
+ * ```kotlin
+ * @DevelopProfile
+ * class DevConfig
+ * // dev/develop/development 중 하나에서 활성화
+ * ```
+ *
+ * @property name 프로파일 이름 메타데이터
+ */
 @Target(AnnotationTarget.TYPE)
 @Retention(AnnotationRetention.RUNTIME)
 @Profile("dev", "develop", "development")
 annotation class DevelopProfile(val name: String = "development")
 
+/**
+ * `feature` 프로파일 활성화용 메타 애너테이션입니다.
+ *
+ * ## 동작/계약
+ * - 타입에 선언하면 Spring의 `feature` 프로파일과 매핑됩니다.
+ * - [name] 기본값은 `"feature"`입니다.
+ *
+ * ```kotlin
+ * @FeatureProfile
+ * class FeatureToggleConfig
+ * // feature 프로파일에서만 활성화
+ * ```
+ *
+ * @property name 프로파일 이름 메타데이터
+ */
 @Target(AnnotationTarget.TYPE)
 @Retention(AnnotationRetention.RUNTIME)
 @Profile("feature")
 annotation class FeatureProfile(val name: String = "feature")
 
+/**
+ * `test`, `testing` 프로파일 활성화용 메타 애너테이션입니다.
+ *
+ * ## 동작/계약
+ * - 타입에 선언하면 지정된 두 프로파일 중 하나가 활성화될 때 적용됩니다.
+ * - [name] 기본값은 `"test"`입니다.
+ *
+ * ```kotlin
+ * @TestProfile
+ * class TestConfig
+ * // test/testing 프로파일에서만 활성화
+ * ```
+ *
+ * @property name 프로파일 이름 메타데이터
+ */
 @Target(AnnotationTarget.TYPE)
 @Retention(AnnotationRetention.RUNTIME)
 @Profile("test", "testing")
 annotation class TestProfile(val name: String = "test")
 
+/**
+ * `qa` 프로파일 활성화용 메타 애너테이션입니다.
+ *
+ * ## 동작/계약
+ * - 타입에 선언하면 Spring의 `qa` 프로파일과 매핑됩니다.
+ * - [name] 기본값은 `"qa"`입니다.
+ *
+ * ```kotlin
+ * @QaProfile
+ * class QaConfig
+ * // qa 프로파일에서만 활성화
+ * ```
+ *
+ * @property name 프로파일 이름 메타데이터
+ */
 @Target(AnnotationTarget.TYPE)
 @Retention(AnnotationRetention.RUNTIME)
 @Profile("qa")
 annotation class QaProfile(val name: String = "qa")
 
+/**
+ * `stage`, `staging` 프로파일 활성화용 메타 애너테이션입니다.
+ *
+ * ## 동작/계약
+ * - 타입에 선언하면 지정된 두 프로파일 중 하나가 활성화될 때 적용됩니다.
+ * - [name] 기본값은 `"staging"`입니다.
+ *
+ * ```kotlin
+ * @StageProfile
+ * class StageConfig
+ * // stage/staging 프로파일에서만 활성화
+ * ```
+ *
+ * @property name 프로파일 이름 메타데이터
+ */
 @Target(AnnotationTarget.TYPE)
 @Retention(AnnotationRetention.RUNTIME)
 @Profile("stage", "staging")
 annotation class StageProfile(val name: String = "staging")
 
+/**
+ * `prod`, `product`, `production` 프로파일 활성화용 메타 애너테이션입니다.
+ *
+ * ## 동작/계약
+ * - 타입에 선언하면 지정된 세 프로파일 중 하나가 활성화될 때 적용됩니다.
+ * - [name] 기본값은 `"production"`입니다.
+ *
+ * ```kotlin
+ * @ProductionProfile
+ * class ProductionConfig
+ * // prod/product/production 중 하나에서 활성화
+ * ```
+ *
+ * @property name 프로파일 이름 메타데이터
+ */
 @Target(AnnotationTarget.TYPE)
 @Retention(AnnotationRetention.RUNTIME)
 @Profile("prod", "product", "production")

--- a/spring/core/src/main/kotlin/io/bluetape4k/spring/core/PropertyResolverExtensions.kt
+++ b/spring/core/src/main/kotlin/io/bluetape4k/spring/core/PropertyResolverExtensions.kt
@@ -6,121 +6,108 @@ import org.springframework.core.env.getRequiredProperty
 import kotlin.reflect.KClass
 
 /**
- * 지정한 [key]에 해당하는 속성 값을 반환합니다. [key]에 해당하는 값이 없는 경우에는 defaultValue를 반환합니다.
+ * 지정한 키의 문자열 속성 값을 조회합니다.
  *
+ * ## 동작/계약
+ * - 키가 존재하면 문자열 값을 반환하고, 없으면 `null`을 반환합니다.
+ * - Spring [PropertyResolver.getProperty] 호출을 그대로 위임합니다.
+ *
+ * ```kotlin
+ * val foo = propertyResolver["foo"]
+ * // foo == "bar"
  * ```
- * val testProperties = Properties()
- * val propertySources = MutablePropertySources().apply {
- *      addFirst(PropertiesPropertySource("testProperties", testProperties))
- * }
- * val propertyResolver = PropertySourcesPropertyResolver(propertySources)
- *
- * testProperties["foo"] = "bar"
- * testProperties["num"] = 5
- *
- * propertyResolver["foo"] shouldBeEqualTo "bar"
- * propertyResolver["num", Int::class, 1] shouldBeEqualTo 5
- * ```
- *
- * @receiver PropertyResolver
- * @param key 속성 값을 얻기 위한 속성 명
  */
 operator fun PropertyResolver.get(key: String): String? = getProperty(key)
 
 /**
- * 지정한 [key]에 해당하는 속성 값을 반환합니다. [key]에 해당하는 값이 없는 경우에는 defaultValue를 반환합니다.
+ * 지정한 키의 문자열 속성 값을 조회하고 없으면 기본값을 반환합니다.
  *
- * ```
- * propertyResolver["not-exists", "myDefault"] // "myDefault"
- * ```
+ * ## 동작/계약
+ * - 키가 없으면 [defaultValue]를 반환합니다.
+ * - 키가 있으면 변환된 문자열 값을 반환합니다.
  *
- * @receiver PropertyResolver
- * @param key 속성 값을 얻기 위한 속성 명
- * @param defaultValue 값이 없는 경우에 반환할 기본 값
+ * ```kotlin
+ * val value = propertyResolver["foo", "myDefault"]
+ * // value == "myDefault"
+ * ```
  */
 operator fun PropertyResolver.get(key: String, defaultValue: String): String =
     getProperty(key, defaultValue)
 
 /**
- * 지정한 [key]에 해당하는 속성 값을 반환합니다.
+ * 지정한 키의 속성 값을 [targetType]으로 조회합니다.
  *
- * ```
- * propertyResolver["num", Int::class] // 5
- * ```
+ * ## 동작/계약
+ * - 키가 없으면 `null`을 반환합니다.
+ * - 키가 있으면 [targetType]에 맞게 변환된 값을 반환합니다.
  *
- * @receiver PropertyResolver
- * @param key the property name to resolve
- * @param targetType the expected type of the property value
- * @return T? 속성 값, 없는 경우에는 null을 반환
+ * ```kotlin
+ * val num = propertyResolver["num", Int::class]
+ * // num == 5
+ * ```
  */
 operator fun <T: Any> PropertyResolver.get(key: String, targetType: KClass<T>): T? =
     getProperty(key, targetType.java)
 
 /**
- * 지정한 [key]에 해당하는 속성 값을 반환합니다.
+ * 지정한 키의 속성 값을 reified 타입으로 조회합니다.
  *
+ * ## 동작/계약
+ * - 키가 없으면 `null`을 반환합니다.
+ * - 제네릭 [T]의 런타임 타입으로 변환을 시도합니다.
+ *
+ * ```kotlin
+ * val enabled = propertyResolver.getAs<Boolean>("enabled")
+ * // enabled == true
  * ```
- * propertyResolver["num", Int::class] // 5
- * ```
- * @typeparam T 속성 값의 수형
- * @receiver PropertyResolver
- * @param key the property name to resolve
- * @return T? 속성 값, 없는 경우에는 null을 반환
  */
 inline fun <reified T: Any> PropertyResolver.getAs(key: String): T? {
     return getProperty<T>(key)
 }
 
-
 /**
- * 지정한 [key]에 해당하는 속성 값을 반환합니다. [key]에 해당하는 값이 없는 경우에는 defaultValue를 반환합니다.
+ * 지정한 키의 속성 값을 [targetType]으로 조회하고 없으면 기본값을 반환합니다.
  *
- * ```
- * propertyResolver["exists", Boolean::class, false] // true
- * propertyResolver["not-exists", Boolean::class, false] // false
- * ```
+ * ## 동작/계약
+ * - 키가 없으면 [defaultValue]를 반환합니다.
+ * - 키가 있으면 [targetType]으로 변환한 값을 반환합니다.
  *
- * @receiver PropertyResolver
- * @param key the property name to resolve
- * @param targetType the expected type of the property value
- * @param defaultValue 기본 값
- * @return T 속성 값의 수형
+ * ```kotlin
+ * val enabled = propertyResolver["enabled", Boolean::class, false]
+ * // enabled == true
+ * ```
  */
 operator fun <T: Any> PropertyResolver.get(key: String, targetType: KClass<T>, defaultValue: T): T {
     return getProperty(key, targetType.java, defaultValue)
 }
 
 /**
- * 지정한 [key]에 해당하는 속성 값을 반환합니다.
+ * 지정한 키의 속성 값을 reified 타입으로 조회하고 없으면 기본값을 반환합니다.
  *
+ * ## 동작/계약
+ * - 키가 없으면 [defaultValue]를 반환합니다.
+ * - 키가 있으면 제네릭 [T] 타입으로 변환된 값을 반환합니다.
+ *
+ * ```kotlin
+ * val enabled = propertyResolver.getAs("enabled", false)
+ * // enabled == true
  * ```
- * propertyResolver["exists", Int::class, 42] // 5
- * propertyResolver["not-exists", Int::class, 42] // 42
- * ```
- * @typeparam T 속성 값의 수형
- * @receiver PropertyResolver
- * @param key the property name to resolve
- * @return T? 속성 값, 없는 경우에는 null을 반환
  */
 inline fun <reified T: Any> PropertyResolver.getAs(key: String, defaultValue: T): T {
     return getProperty<T>(key, defaultValue)
 }
 
-
 /**
- * [key]에 해당하는 속성 값을 [targetType]으로 변환하여 반환합니다. 속성 값이 없는 경우에는 IllegalStateException을 발생합니다.
+ * 지정한 키의 속성 값을 [targetType]으로 필수 조회합니다.
  *
+ * ## 동작/계약
+ * - 키가 없으면 [IllegalStateException]을 던집니다.
+ * - 키가 있으면 [targetType]으로 변환된 값을 반환합니다.
+ *
+ * ```kotlin
+ * val required = propertyResolver.getRequiredProperty("required.key", String::class)
+ * // required == "required.value"
  * ```
- * propertyResolver.getRequiredProperty("num", Int::class) // 5
- * propertyResolver.getRequiredProperty("num", Long::class) // 5L
- * ```
- *
- * @throws IllegalStateException if the given key cannot be resolved
- *
- * @receiver PropertyResolver
- * @param key the property name to resolve
- * @param targetType the expected type of the property value
- * @return T 속성 값의 수형
  */
 @Throws(IllegalStateException::class)
 fun <T: Any> PropertyResolver.getRequiredProperty(key: String, targetType: KClass<T>): T {
@@ -128,18 +115,16 @@ fun <T: Any> PropertyResolver.getRequiredProperty(key: String, targetType: KClas
 }
 
 /**
- * [key]에 해당하는 속성 값을 [T]로 변환하여 반환합니다. 속성 값이 없는 경우에는 IllegalStateException을 발생합니다.
+ * 지정한 키의 속성 값을 reified 타입으로 필수 조회합니다.
  *
+ * ## 동작/계약
+ * - 키가 없으면 [IllegalStateException]을 던집니다.
+ * - 키가 있으면 제네릭 [T] 타입으로 변환된 값을 반환합니다.
+ *
+ * ```kotlin
+ * val required = propertyResolver.getRequiredPropertyAs<String>("required.key")
+ * // required == "required.value"
  * ```
- * propertyResolver.getRequiredPropertyAs<Int>("num") // 5
- * propertyResolver.getRequiredPropertyAs<Long>("num") // 5L
- * ```
- *
- * @throws IllegalStateException if the given key cannot be resolved
- *
- * @receiver PropertyResolver
- * @param key the property name to resolve
- * @return T 속성 값의 수형
  */
 inline fun <reified T: Any> PropertyResolver.getRequiredPropertyAs(key: String): T {
     return getRequiredProperty<T>(key)

--- a/spring/core/src/main/kotlin/io/bluetape4k/spring/core/ToStringCreatorSupport.kt
+++ b/spring/core/src/main/kotlin/io/bluetape4k/spring/core/ToStringCreatorSupport.kt
@@ -7,26 +7,34 @@ import org.springframework.core.style.ToStringStyler
 import org.springframework.core.style.ValueStyler
 
 /**
- * [ToStringCreator]에 빈 라인을 추가합니다.
+ * 인덱스 연산자 기반 `append` 토큰 객체를 생성합니다.
+ *
+ * ## 동작/계약
+ * - 수신 [ToStringCreator]를 감싼 [ToStringCreatorAppendTokens]를 반환합니다.
+ * - 반환된 토큰의 `tokens["name"] = value` 문법은 내부적으로 `append("name", value)`를 호출합니다.
+ *
+ * ```kotlin
+ * val creator = ToStringCreator(Any())
+ * val tokens = creator.append()
+ * tokens["value"] = 1
+ * // creator.toString().contains("value") == true
+ * ```
  */
 fun ToStringCreator.append(): ToStringCreatorAppendTokens = ToStringCreatorAppendTokens(this)
 
 /**
- * [ToStringCreator]를 이용하여 겍체를 문자열로 표현할 수 있도록 합니다.
+ * 기본 스타일로 [ToStringCreator]를 생성하고 본문을 적용합니다.
+ *
+ * ## 동작/계약
+ * - [ToStringCreator] 인스턴스를 새로 만들고 [body]를 적용한 뒤 반환합니다.
+ * - 테스트에서 생성된 문자열은 클래스명과 추가한 필드 문자열을 포함합니다.
  *
  * ```kotlin
- * override fun toString(): String {
- *     return toStringCreatorOf(this) {
- *         append("name", name)
- *         append("age", age)
- *         append("birth", birth)
- *     }.toString()
- * }
+ * val value = toStringCreatorOf(Any()) {
+ *     append("age", 42)
+ * }.toString()
+ * // value.contains("age = 42") == true
  * ```
- *
- * @param obj 문자열로 표현할 객체
- * @param body 문자열로 표현할 코드
- * @return ToStringCreator
  *
  * @see [io.bluetape4k.ToStringBuilder]
  */
@@ -38,22 +46,18 @@ inline fun toStringCreatorOf(
 }
 
 /**
- * [ToStringCreator]를 이용하여 겍체를 문자열로 표현할 수 있도록 합니다.
+ * [ValueStyler]를 지정해 [ToStringCreator]를 생성하고 본문을 적용합니다.
+ *
+ * ## 동작/계약
+ * - 전달받은 [valueStyler]로 [ToStringCreator]를 생성합니다.
+ * - [body]는 생성된 [ToStringCreator]에 바로 적용됩니다.
  *
  * ```kotlin
- * override fun toString(): String {
- *     return toStringCreatorOf(this) {
- *         append("name", name)
- *         append("age", age)
- *         append("birth", birth)
- *     }.toString()
+ * val creator = toStringCreatorOf(Any(), DefaultValueStyler()) {
+ *     append("name", "debop")
  * }
+ * // creator.toString().contains("name") == true
  * ```
- *
- * @param obj 문자열로 표현할 객체
- * @param valueStyler 표현 방식
- * @param body 문자열로 표현할 코드
- * @return ToStringCreator
  *
  * @see [io.bluetape4k.ToStringBuilder]
  */
@@ -66,22 +70,18 @@ inline fun toStringCreatorOf(
 }
 
 /**
- * [ToStringCreator]를 이용하여 겍체를 문자열로 표현할 수 있도록 합니다.
+ * [ToStringStyler]를 지정해 [ToStringCreator]를 생성하고 본문을 적용합니다.
  *
- * ```
- * override fun toString(): String {
- *     return toStringCreatorOf(this, DefaultToStringStyler(DefaultValueStyler()) {
- *         append("name", name)
- *         append("age", age)
- *         append("birth", birth)
- *     }.toString()
+ * ## 동작/계약
+ * - 전달한 [styler]로 [ToStringCreator]를 생성합니다.
+ * - 반환된 객체의 `toString()`은 지정한 스타일 규칙을 따릅니다.
+ *
+ * ```kotlin
+ * val creator = toStringCreatorOf(Any(), DefaultToStringStyler(DefaultValueStyler())) {
+ *     append("id", 1)
  * }
+ * // creator.toString().contains("id = 1") == true
  * ```
- *
- * @param obj 문자열로 표현할 객체
- * @param styler 표현 방식
- * @param body 문자열로 표현할 코드
- * @return ToStringCreator
  *
  * @see [io.bluetape4k.ToStringBuilder]
  */
@@ -93,20 +93,138 @@ inline fun toStringCreatorOf(
     ToStringCreator(obj, styler).apply(body)
 
 /**
+ * `tokens[field] = value` 문법으로 [ToStringCreator.append]를 호출하는 헬퍼입니다.
  *
+ * ## 동작/계약
+ * - 각 `set` 연산자는 타입별 [ToStringCreator.append] 오버로드를 호출합니다.
+ * - 반환값은 내부 [ToStringCreator]이며 연쇄 호출에 사용할 수 있습니다.
  *
- * @property creator
+ * ```kotlin
+ * val creator = ToStringCreator(Any())
+ * val tokens = ToStringCreatorAppendTokens(creator)
+ * tokens["name"] = "debop"
+ * // creator.toString().contains("name") == true
+ * ```
  */
 class ToStringCreatorAppendTokens(private val creator: ToStringCreator) {
 
+    /**
+     * Boolean 값을 필드로 추가합니다.
+     *
+     * ## 동작/계약
+     * - `append(fieldName, value)`를 호출한 [ToStringCreator]를 반환합니다.
+     *
+     * ```kotlin
+     * val creator = ToStringCreator(Any())
+     * val tokens = ToStringCreatorAppendTokens(creator)
+     * tokens["active"] = true
+     * // creator.toString().contains("active") == true
+     * ```
+     */
     operator fun set(fieldName: String, value: Boolean): ToStringCreator = creator.append(fieldName, value)
+
+    /**
+     * Byte 값을 필드로 추가합니다.
+     *
+     * ## 동작/계약
+     * - `append(fieldName, value)`를 호출한 [ToStringCreator]를 반환합니다.
+     *
+     * ```kotlin
+     * tokens["grade"] = 1.toByte()
+     * // creator.toString().contains("grade") == true
+     * ```
+     */
     operator fun set(fieldName: String, value: Byte): ToStringCreator = creator.append(fieldName, value)
+
+    /**
+     * Char 값을 필드로 추가합니다.
+     *
+     * ## 동작/계약
+     * - `append(fieldName, value)`를 호출한 [ToStringCreator]를 반환합니다.
+     *
+     * ```kotlin
+     * tokens["initial"] = 'D'
+     * // creator.toString().contains("initial") == true
+     * ```
+     */
     operator fun set(fieldName: String, value: Char): ToStringCreator = creator.append(fieldName, value)
+
+    /**
+     * Short 값을 필드로 추가합니다.
+     *
+     * ## 동작/계약
+     * - `append(fieldName, value)`를 호출한 [ToStringCreator]를 반환합니다.
+     *
+     * ```kotlin
+     * tokens["count"] = 2.toShort()
+     * // creator.toString().contains("count") == true
+     * ```
+     */
     operator fun set(fieldName: String, value: Short): ToStringCreator = creator.append(fieldName, value)
+
+    /**
+     * Int 값을 필드로 추가합니다.
+     *
+     * ## 동작/계약
+     * - `append(fieldName, value)`를 호출한 [ToStringCreator]를 반환합니다.
+     *
+     * ```kotlin
+     * tokens["age"] = 42
+     * // creator.toString().contains("age = 42") == true
+     * ```
+     */
     operator fun set(fieldName: String, value: Int): ToStringCreator = creator.append(fieldName, value)
+
+    /**
+     * Long 값을 필드로 추가합니다.
+     *
+     * ## 동작/계약
+     * - `append(fieldName, value)`를 호출한 [ToStringCreator]를 반환합니다.
+     *
+     * ```kotlin
+     * tokens["version"] = 1L
+     * // creator.toString().contains("version") == true
+     * ```
+     */
     operator fun set(fieldName: String, value: Long): ToStringCreator = creator.append(fieldName, value)
+
+    /**
+     * Float 값을 필드로 추가합니다.
+     *
+     * ## 동작/계약
+     * - `append(fieldName, value)`를 호출한 [ToStringCreator]를 반환합니다.
+     *
+     * ```kotlin
+     * tokens["ratio"] = 1.5f
+     * // creator.toString().contains("ratio") == true
+     * ```
+     */
     operator fun set(fieldName: String, value: Float): ToStringCreator = creator.append(fieldName, value)
+
+    /**
+     * Double 값을 필드로 추가합니다.
+     *
+     * ## 동작/계약
+     * - `append(fieldName, value)`를 호출한 [ToStringCreator]를 반환합니다.
+     *
+     * ```kotlin
+     * tokens["score"] = 99.9
+     * // creator.toString().contains("score") == true
+     * ```
+     */
     operator fun set(fieldName: String, value: Double): ToStringCreator = creator.append(fieldName, value)
 
+    /**
+     * 임의 객체 값을 필드로 추가합니다.
+     *
+     * ## 동작/계약
+     * - `append(fieldName, value)`를 호출한 [ToStringCreator]를 반환합니다.
+     * - [value]가 `null`이어도 호출 가능합니다.
+     *
+     * ```kotlin
+     * tokens["name"] = "debop"
+     * // creator.toString().contains("name") == true
+     * ```
+     */
     operator fun set(fieldName: String, value: Any?): ToStringCreator = creator.append(fieldName, value)
 }

--- a/spring/core/src/main/kotlin/io/bluetape4k/spring/core/io/buffer/DataBufferSupport.kt
+++ b/spring/core/src/main/kotlin/io/bluetape4k/spring/core/io/buffer/DataBufferSupport.kt
@@ -16,6 +16,18 @@ import java.nio.channels.WritableByteChannel
 import java.nio.file.OpenOption
 import java.nio.file.Path
 
+/**
+ * [InputStream]을 [DataBuffer] 스트림으로 읽습니다.
+ *
+ * ## 동작/계약
+ * - [DataBufferUtils.readInputStream]을 사용해 입력 스트림을 읽습니다.
+ * - 반환 [Flow]를 수집할 때 실제 읽기가 수행됩니다.
+ *
+ * ```kotlin
+ * val flow = inputStream.readAsDataBuffers(bufferFactory)
+ * // flow.toList().isNotEmpty() == true
+ * ```
+ */
 fun InputStream.readAsDataBuffers(
     bufferFactory: DataBufferFactory,
     bufferSize: Int = DEFAULT_BUFFER_SIZE,
@@ -23,6 +35,18 @@ fun InputStream.readAsDataBuffers(
     return DataBufferUtils.readInputStream({ this }, bufferFactory, bufferSize).asFlow()
 }
 
+/**
+ * [ReadableByteChannel]을 [DataBuffer] 스트림으로 읽습니다.
+ *
+ * ## 동작/계약
+ * - [DataBufferUtils.readByteChannel] 호출을 [Flow]로 변환해 반환합니다.
+ * - [bufferSize] 크기 단위로 채널을 읽습니다.
+ *
+ * ```kotlin
+ * val flow = channel.readAsDataBuffer(bufferFactory)
+ * // flow.toList().isNotEmpty() == true
+ * ```
+ */
 fun ReadableByteChannel.readAsDataBuffer(
     bufferFactory: DataBufferFactory,
     bufferSize: Int = DEFAULT_BUFFER_SIZE,
@@ -30,6 +54,18 @@ fun ReadableByteChannel.readAsDataBuffer(
     return DataBufferUtils.readByteChannel({ this }, bufferFactory, bufferSize).asFlow()
 }
 
+/**
+ * [AsynchronousFileChannel]을 [DataBuffer] 스트림으로 읽습니다.
+ *
+ * ## 동작/계약
+ * - [position]부터 비동기 파일 채널을 읽습니다.
+ * - [DataBufferUtils.readAsynchronousFileChannel] 결과를 [Flow]로 변환합니다.
+ *
+ * ```kotlin
+ * val flow = asyncChannel.readAsDataBuffer(bufferFactory, position = 0)
+ * // flow.toList().isNotEmpty() == true
+ * ```
+ */
 fun AsynchronousFileChannel.readAsDataBuffer(
     bufferFactory: DataBufferFactory,
     position: Long = 0L,
@@ -38,6 +74,18 @@ fun AsynchronousFileChannel.readAsDataBuffer(
     return DataBufferUtils.readAsynchronousFileChannel({ this }, position, bufferFactory, bufferSize).asFlow()
 }
 
+/**
+ * [Path] 파일을 [DataBuffer] 스트림으로 읽습니다.
+ *
+ * ## 동작/계약
+ * - 경로의 파일 내용을 [bufferSize] 단위 [DataBuffer]로 읽습니다.
+ * - 반환 [Flow]는 수집 시 읽기 작업을 시작합니다.
+ *
+ * ```kotlin
+ * val flow = path.readAsDataBuffer(bufferFactory)
+ * // flow.toList().isNotEmpty() == true
+ * ```
+ */
 fun Path.readAsDataBuffer(
     bufferFactory: DataBufferFactory,
     bufferSize: Int = DEFAULT_BUFFER_SIZE,
@@ -45,6 +93,18 @@ fun Path.readAsDataBuffer(
     return DataBufferUtils.read(this, bufferFactory, bufferSize).asFlow()
 }
 
+/**
+ * [Resource]를 [DataBuffer] 스트림으로 읽습니다.
+ *
+ * ## 동작/계약
+ * - [position]부터 리소스 내용을 읽습니다.
+ * - [DataBufferUtils.read] 결과를 [Flow]로 변환해 반환합니다.
+ *
+ * ```kotlin
+ * val flow = resource.readAsDataBuffer(bufferFactory)
+ * // flow.toList().isNotEmpty() == true
+ * ```
+ */
 fun Resource.readAsDataBuffer(
     bufferFactory: DataBufferFactory,
     position: Long = 0L,
@@ -54,19 +114,16 @@ fun Resource.readAsDataBuffer(
 }
 
 /**
- * Write the given stream of [DataBuffer] to the given
- * [OutputStream]. Does **not** close the output stream when the flux is terminated,
- * and does **not** `release(DataBuffer) release` the data buffers in the source.
+ * [DataBuffer] 퍼블리셔를 [OutputStream]으로 씁니다.
  *
- * If releasing is required, then subscribe to the returned [Flow] with a `collect`
+ * ## 동작/계약
+ * - 반환 [Flow]를 수집할 때 쓰기 작업이 시작됩니다.
+ * - 대상 [OutputStream]을 자동으로 닫지 않습니다.
  *
- * Note that the writing process does not start until the returned [Flow]
- *
- * @receiver  the stream of data buffers to be written
- * @param outputStream the output stream to write to
- * @return a Flux containing the same buffers as in `source`, that
- * starts the writing process when subscribed to, and that publishes any
- * writing errors and the completions signal
+ * ```kotlin
+ * publisher.write(outputStream).collect()
+ * // outputStream.toByteArray() == content
+ * ```
  */
 @Suppress("UNCHECKED_CAST")
 @JvmName("writeDataBufferToOutputStream")
@@ -75,19 +132,16 @@ fun Publisher<out DataBuffer>.write(outputStream: OutputStream): Flow<DataBuffer
 }
 
 /**
- * Write the given stream of [DataBuffer] to the given
- * [WritableByteChannel]. Does **not** close the channel when the flux is terminated,
- * and does **not** `release(DataBuffer) release` the data buffers in the source.
+ * [DataBuffer] 퍼블리셔를 [WritableByteChannel]로 씁니다.
  *
- * If releasing is required, then subscribe to the returned [Flow] with a `collect`
+ * ## 동작/계약
+ * - 반환 [Flow]를 수집할 때 쓰기 작업이 시작됩니다.
+ * - 대상 채널을 자동으로 닫지 않습니다.
  *
- * Note that the writing process does not start until the returned [Flow]
- *
- * @receiver  the stream of data buffers to be written
- * @param channel the writable byte channel to write to
- * @return a Flow containing the same buffers as in `source`, that
- * starts the writing process when subscribed to, and that publishes any
- * writing errors and the completions signal
+ * ```kotlin
+ * val flow = publisher.write(channel)
+ * // flow.collect { }
+ * ```
  */
 @Suppress("UNCHECKED_CAST")
 @JvmName("writeDataBufferToWritableByteChannel")
@@ -96,12 +150,16 @@ fun Publisher<out DataBuffer>.write(channel: WritableByteChannel): Flow<DataBuff
 }
 
 /**
- * 주어진 [Publisher]의 버퍼를 지정된 [AsynchronousFileChannel]에 씁니다.
+ * [DataBuffer] 퍼블리셔를 [AsynchronousFileChannel]에 씁니다.
  *
- * @receiver the publisher to write
- * @param channel the asynchronous file channel to write to
- * @param position the position in the file to start writing at
- * @return a flow containing the written data buffers
+ * ## 동작/계약
+ * - [position]부터 파일 채널에 버퍼를 기록합니다.
+ * - 반환 [Flow]를 수집할 때 쓰기 작업이 수행됩니다.
+ *
+ * ```kotlin
+ * val flow = publisher.write(asyncChannel, position = 0)
+ * // flow.collect { }
+ * ```
  */
 @JvmName("writeDataBufferToAsynchronousFileChannel")
 fun Publisher<out DataBuffer>.write(channel: AsynchronousFileChannel, position: Long = 0): Flow<DataBuffer> {
@@ -109,12 +167,16 @@ fun Publisher<out DataBuffer>.write(channel: AsynchronousFileChannel, position: 
 }
 
 /**
- * 주어진 [Publisher]의 버퍼를 지정된 [Path]에 씁니다.
+ * [DataBuffer] 퍼블리셔를 [Path] 파일에 기록합니다.
  *
- * @receiver the publisher to write
- * @param destination the path to write to
- * @param options the options for opening the file
- * @return a flow containing the written data buffers
+ * ## 동작/계약
+ * - [DataBufferUtils.write] 완료를 `awaitSingle()`로 대기합니다.
+ * - 반환값이 없는 suspend 함수이며 완료 시 파일 쓰기가 끝난 상태입니다.
+ *
+ * ```kotlin
+ * publisher.write(destination)
+ * // destination 파일에 데이터가 기록됨
+ * ```
  */
 @Suppress("UNCHECKED_CAST")
 @JvmName("writeDataBufferToPath")
@@ -123,57 +185,95 @@ suspend fun Publisher<out DataBuffer>.write(destination: Path, vararg options: O
 }
 
 /**
- * 주어진 [Publisher]의 버퍼를 총합이 `DataBuffer.readableByteCount()` 바이트 수가 주어진 최대 바이트 수에 도달하거나
- * 도달할 때까지 또는 퍼블리셔가 완료될 때까지 버퍼를 릴레이합니다.
+ * 총 바이트 수가 [maxByteCount]에 도달할 때까지 버퍼를 전달합니다.
  *
- * @receiver the publisher to filters
- * @param maxByteCount the maximum byte count
- * @return a flow whose maximum byte count is [maxByteCount]
+ * ## 동작/계약
+ * - 누적 `readableByteCount()`가 [maxByteCount]에 도달하면 이후 데이터 전달을 중단합니다.
+ * - 테스트에서 `"abcdefg"` 입력과 `3` 제한으로 `abc`만 반환됩니다.
+ *
+ * ```kotlin
+ * val bytes = publisher.takeUntilByteCount(3)
+ * // bytes.toList() == listOf('a', 'b', 'c')
+ * ```
  */
 fun Publisher<out DataBuffer>.takeUntilByteCount(maxByteCount: Long): Flow<DataBuffer> {
     return DataBufferUtils.takeUntilByteCount(this, maxByteCount).asFlow()
 }
 
 /**
- * 주어진 [Publisher]의 버퍼를 총합이 `DataBuffer.readableByteCount()` 바이트 수가 주어진 최대 바이트 수에 도달하거나
- * 도달할 때까지 또는 퍼블리셔가 완료될 때까지 버퍼를 스킵합니다.
+ * 총 바이트 수가 [maxByteCount]에 도달할 때까지 버퍼를 건너뜁니다.
  *
- * @receiver the publisher to filters
- * @param maxByteCount the maximum byte count
- * @return 주어진 publisher의 나머지 부분을 flux 로 반환한다.
+ * ## 동작/계약
+ * - 누적 `readableByteCount()`가 [maxByteCount]에 도달할 때까지 데이터를 스킵합니다.
+ * - 테스트에서 `"abcdefg"` 입력과 `3` 제한으로 `defg`가 남습니다.
+ *
+ * ```kotlin
+ * val result = publisher.skipUntilByteCount(3)
+ * // result.toList() 는 "defg" 구간만 포함
+ * ```
  */
 fun Publisher<out DataBuffer>.skipUntilByteCount(maxByteCount: Long): Flow<DataBuffer> {
     return DataBufferUtils.skipUntilByteCount(this, maxByteCount).asFlow()
 }
 
 /**
- * 지정된 데이터 버퍼가 [org.springframework.core.io.buffer.PooledDataBuffer] 인 경우 해당 데이터 버퍼를 유지합니다.
+ * 풀링 버퍼인 경우 참조 카운트를 증가시켜 버퍼를 유지합니다.
  *
- * @param T
- * @return
+ * ## 동작/계약
+ * - [DataBufferUtils.retain] 결과를 그대로 반환합니다.
+ * - 반환 타입은 수신 객체와 동일한 제네릭 타입 [T]입니다.
+ *
+ * ```kotlin
+ * val retained = dataBuffer.retain()
+ * // retained === dataBuffer
+ * ```
  */
 fun <T: DataBuffer> T.retain(): T {
     return DataBufferUtils.retain(this)
 }
 
 /**
- * 풀링된 버퍼이고 유출 추적을 지원하는 경우 주어진 [hint]를 데이터 버퍼와 연결합니다.
+ * 풀링 버퍼의 유출 추적용 힌트를 연결합니다.
  *
- * @param hint 데이터 버퍼와 연결할 힌트
+ * ## 동작/계약
+ * - [DataBufferUtils.touch]를 호출해 힌트를 연결합니다.
+ * - 반환 타입은 수신 객체와 동일한 제네릭 타입 [T]입니다.
+ *
+ * ```kotlin
+ * val touched = dataBuffer.touch("response-1")
+ * // touched === dataBuffer
+ * ```
  */
 fun <T: DataBuffer> T.touch(hint: Any): T {
     return DataBufferUtils.touch(this, hint)
 }
 
 /**
- * 주어진 Data buffer 가 [org.springframework.core.io.buffer.PooledDataBuffer] 이고,
- * [org.springframework.core.io.buffer.PooledDataBuffer.isAllocated] 로 할당이 되었다면, 해제합니다.
+ * 풀링된 [DataBuffer]를 해제합니다.
  *
- * @receiver the data buffer to release
- * @return `true` if the buffer was released; ``false` otherwise.
+ * ## 동작/계약
+ * - 해제에 성공하면 `true`, 해제할 필요가 없으면 `false`를 반환합니다.
+ * - 테스트에서 `DefaultDataBuffer`는 `false`, Netty 풀 버퍼는 `true`를 반환합니다.
+ *
+ * ```kotlin
+ * val released = dataBuffer.release()
+ * // released == true || released == false
+ * ```
  */
 fun DataBuffer.release(): Boolean =
     DataBufferUtils.release(this)
 
+/**
+ * [DataBuffer] 퍼블리셔를 하나의 [DataBuffer]로 결합합니다.
+ *
+ * ## 동작/계약
+ * - [maxByteCount]가 `-1`이면 제한 없이 결합합니다.
+ * - 테스트에서 `"abc"`와 `"def"` 버퍼를 결합하면 `"abcdef"`가 됩니다.
+ *
+ * ```kotlin
+ * val joined = publisher.join()
+ * // joined.readableByteCount() == 6
+ * ```
+ */
 suspend fun Publisher<out DataBuffer>.join(maxByteCount: Int = -1): DataBuffer =
     DataBufferUtils.join(this, maxByteCount).awaitSingle()

--- a/spring/core/src/main/kotlin/io/bluetape4k/spring/data/ExampleMatcherSupport.kt
+++ b/spring/core/src/main/kotlin/io/bluetape4k/spring/data/ExampleMatcherSupport.kt
@@ -6,17 +6,16 @@ import kotlin.reflect.KProperty
 import kotlin.reflect.full.declaredMemberProperties
 
 /**
- * 지정한 수형의 Example matching 을 위한 [ExampleMatcher]를 구성합니다.
+ * 검색 대상 속성 이름으로 [ExampleMatcher]를 생성합니다.
  *
- * 참고: Redis 에서는 [GenericPropertyMatchers.exact()] 만 지원한다.
+ * ## 동작/계약
+ * - 지정한 [searchFields]를 제외한 나머지 프로퍼티를 `ignorePaths`로 설정합니다.
+ * - 빈 문자열이 아닌 각 검색 필드에 `exact()` 매처를 적용합니다.
  *
+ * ```kotlin
+ * val matcher = User::class.buildExampleMatcher("name", "age")
+ * // matcher != null
  * ```
- * val exampleMatcher = User::class.buildExampleMatcher("name", "age")
- * ```
- *
- * @param T Example 수형
- * @param searchFields Example 을 이용하여 검색하고자 하는 속성 명
- * @return [ExampleMatcher] 인스턴스
  */
 inline fun <reified T: Any> KClass<T>.buildExampleMatcher(vararg searchFields: String): ExampleMatcher {
     var matcher = ExampleMatcher
@@ -33,28 +32,32 @@ inline fun <reified T: Any> KClass<T>.buildExampleMatcher(vararg searchFields: S
 }
 
 /**
- * 지정한 수형의 Example matching 을 위한 [ExampleMatcher]를 구성합니다.
+ * 검색 대상 프로퍼티 참조로 [ExampleMatcher]를 생성합니다.
  *
- * Redis 에서는 [GenericPropertyMatchers.exact()] 만 지원한다.
+ * ## 동작/계약
+ * - [KProperty] 목록의 이름을 추출해 문자열 기반 [buildExampleMatcher]로 위임합니다.
+ * - 결과 매처는 문자열 기반 호출과 동일합니다.
  *
+ * ```kotlin
+ * val matcher = User::class.buildExampleMatcher(User::name, User::age)
+ * // matcher != null
  * ```
- * val exampleMatcher = User::class.buildExampleMatcher(User::name, User::age)
- * ```
- *
- * @param T Example 수형
- * @param searchFields Example 을 이용하여 검색하고자 하는 속성 명
- * @return [ExampleMatcher] 인스턴스
  */
 inline fun <reified T: Any> KClass<T>.buildExampleMatcher(vararg searchFields: KProperty<*>): ExampleMatcher {
     return buildExampleMatcher(*searchFields.map { it.name }.toTypedArray())
 }
 
 /**
- * [ExampleMatcher]의 ignorePaths를 구성하기 위한 속성 명을 반환한다.
+ * [ExampleMatcher.withIgnorePaths]에 전달할 프로퍼티 이름 배열을 계산합니다.
  *
- * @param T
- * @param exclusions 무시해야 할 속성에서 제외할 속성들. 즉 Example에 포함되어야 할 속성 명 (예: "lastname")
- * @return [ExampleMatcher]에서 제외할 속성 명 배열
+ * ## 동작/계약
+ * - 수신 클래스의 선언 프로퍼티 중 [exclusions]에 없는 이름만 반환합니다.
+ * - 반환 배열은 `ignorePaths` 인자로 바로 사용할 수 있습니다.
+ *
+ * ```kotlin
+ * val ignored = User::class.ignoredProperties("name")
+ * // ignored.contains("name") == false
+ * ```
  */
 fun <T: Any> KClass<T>.ignoredProperties(vararg exclusions: String): Array<String> =
     declaredMemberProperties
@@ -63,11 +66,16 @@ fun <T: Any> KClass<T>.ignoredProperties(vararg exclusions: String): Array<Strin
         .toTypedArray()
 
 /**
- * [ExampleMatcher]의 ignorePaths를 구성하기 위한 속성 명을 반환한다.
+ * [KProperty] 제외 목록으로 [ignoredProperties]를 계산합니다.
  *
- * @param T
- * @param exclusions 무시해야 할 속성에서 제외할 속성들. 즉 Example에 포함되어야 할 속성 명 (예: "lastname")
- * @return [ExampleMatcher]에서 제외할 속성 명 배열
+ * ## 동작/계약
+ * - [KProperty.name]을 추출해 문자열 기반 [ignoredProperties]로 위임합니다.
+ * - `internal` 함수이며 모듈 내부 구현에서 사용됩니다.
+ *
+ * ```kotlin
+ * val ignored = User::class.ignoredProperties(User::name)
+ * // ignored.contains("name") == false
+ * ```
  */
 internal fun <T: Any> KClass<T>.ignoredProperties(vararg exclusions: KProperty<*>): Array<String> =
     ignoredProperties(*exclusions.map { it.name }.toTypedArray())

--- a/spring/core/src/main/kotlin/io/bluetape4k/spring/jackson/Jackson2ObjectMapperBuilderCustomizer.kt
+++ b/spring/core/src/main/kotlin/io/bluetape4k/spring/jackson/Jackson2ObjectMapperBuilderCustomizer.kt
@@ -14,29 +14,18 @@ import java.time.ZoneOffset
 import java.util.*
 
 /**
- * Spring Boot 에서 재공하는 [com.fasterxml.jackson.databind.ObjectMapper] 를 설정할 때, Customizing 을 수행할 수 있도록 해줍니다.
+ * Spring Boot [Jackson2ObjectMapperBuilder] 기본 설정을 적용하는 커스터마이저를 생성합니다.
  *
- * - 기본적으로 classpath 에 있는 module을 자동으로 등록해줍니다. (kotlin, jdk8, jsr310 등)
- * - `bluetape4k-jackson` 에서 제공하는 [io.bluetape4k.jackson.Jackson.defaultJsonMapper] 와 같은 설정을 제공합니다
+ * ## 동작/계약
+ * - Service Loader 기반 모듈 탐색을 활성화하고 Kotlin/UUID 모듈을 추가합니다.
+ * - 직렬화/역직렬화 feature를 코드에 정의된 값으로 활성/비활성화한 뒤 [builder]를 실행합니다.
  *
- * 추가적으로 [builder]를 통해 추가 설정을 할 수 있습니다.
- *
- * ```
- * @Configuration
- * class JsonConfiguration {
- *     @Bean
- *     fun jackson2ObjectMapperBuilderCustomizer(): Jackson2ObjectMapperBuilderCustomizer {
- *         return jackson2ObjectMapperBuilderCustomizer { builder: Jackson2ObjectMapperBuilder ->
- *              // additional setup for jackson ObjectMapper
- *              builder.timeZone(TimeZone.getDefault())
- *         }
- *     }
+ * ```kotlin
+ * val customizer = jackson2ObjectMapperBuilderCustomizer {
+ *     timeZone(TimeZone.getTimeZone("Asia/Seoul"))
  * }
+ * // customizer != null
  * ```
- *
- * @param builder [Jackson2ObjectMapperBuilder] 를 이용하여 [io.bluetape4k.jackson.Jackson.defaultJsonMapper]의 설정을 추가합니다.
- * @receiver
- * @return [Jackson2ObjectMapperBuilderCustomizer] 인스턴스
  */
 inline fun jackson2ObjectMapperBuilderCustomizer(
     @BuilderInference crossinline builder: Jackson2ObjectMapperBuilder.() -> Unit,

--- a/spring/core/src/main/kotlin/io/bluetape4k/spring/messaging/support/MessageBuilder.kt
+++ b/spring/core/src/main/kotlin/io/bluetape4k/spring/messaging/support/MessageBuilder.kt
@@ -4,17 +4,18 @@ import org.springframework.messaging.Message
 import org.springframework.messaging.support.MessageBuilder
 
 /**
- * Spring Messaging의 [Message]를 생성합니다.
+ * 페이로드와 빌더 블록으로 [Message]를 생성합니다.
  *
- * ```
- * val message = message("payload") {
- *   setHeader("key", "value")
- *   setHeaderIfAbsent("key", "value")
+ * ## 동작/계약
+ * - [MessageBuilder.withPayload]로 빌더를 만들고 [builder]를 적용한 뒤 `build()`합니다.
+ * - 헤더 설정은 [builder] 블록에서 직접 수행합니다.
+ *
+ * ```kotlin
+ * val msg = message("payload") {
+ *     setHeader("key", "value")
  * }
+ * // msg.payload == "payload"
  * ```
- *
- * @param payload 메시지 페이로드
- * @param builder 메시지 초기화 블록
  */
 inline fun <T: Any> message(
     payload: T,
@@ -24,18 +25,16 @@ inline fun <T: Any> message(
 }
 
 /**
- * Spring Messaging의 [Message]를 생성합니다.
+ * [message]의 별칭으로 [Message]를 생성합니다.
  *
- * ```
- * val message = messageOf("payload") {
- *      setHeader("key", "value")
- *      setHeaderIfAbsent("key", "value")
- * }
- * ```
+ * ## 동작/계약
+ * - 구현은 [message]를 그대로 호출합니다.
+ * - 전달한 [payload], [builder]가 동일하게 적용됩니다.
  *
- * @param payload 메시지 페이로드
- * @param builder 메시지 초기화 블록
- * @return [Message] 메시지
+ * ```kotlin
+ * val msg = messageOf("payload")
+ * // msg.payload == "payload"
+ * ```
  */
 inline fun <T: Any> messageOf(
     payload: T,
@@ -43,19 +42,18 @@ inline fun <T: Any> messageOf(
 ): Message<T> = message(payload, builder)
 
 /**
- * Spring Messaging의 [Message]를 생성합니다.
+ * 초기 헤더 맵과 빌더 블록으로 [Message]를 생성합니다.
  *
- * ```
- * val message = messageOf("payload", mapOf("key" to "value")) {
- *      setHeaderIfAbsent("key", "value")
+ * ## 동작/계약
+ * - [headers]의 항목을 먼저 `setHeader`로 설정한 뒤 [builder]를 실행합니다.
+ * - 동일 키를 [builder]에서 다시 설정하면 마지막 설정값이 적용됩니다.
  *
- *      setReplyChannel(replyChannel)
+ * ```kotlin
+ * val msg = messageOf("payload", mapOf("a" to 1)) {
+ *     setHeader("b", 2)
  * }
+ * // msg.headers["a"] == 1
  * ```
- *
- * @param payload 메시지 페이로드
- * @param builder 메시지 초기화 블록
- * @return [Message] 메시지
  */
 inline fun <T: Any> messageOf(
     payload: T,

--- a/spring/core/src/main/kotlin/io/bluetape4k/spring/rest/exceptions/ApiErrorResponse.kt
+++ b/spring/core/src/main/kotlin/io/bluetape4k/spring/rest/exceptions/ApiErrorResponse.kt
@@ -5,8 +5,38 @@ import org.springframework.http.ResponseEntity
 import java.io.Serializable
 import java.time.Instant
 
+/**
+ * API 오류 응답으로 사용하는 [ResponseEntity] 별칭입니다.
+ *
+ * ## 동작/계약
+ * - 본 별칭은 [ApiErrorBody]를 본문으로 갖는 [ResponseEntity]를 의미합니다.
+ * - [apiErrorResponseEntityOf]가 생성하는 응답 타입으로 사용됩니다.
+ *
+ * ```kotlin
+ * val response: ApiErrorResponseEntity =
+ *     apiErrorResponseEntityOf(statusCode = 400, message = "bad request")
+ * // response.statusCode.value() == 400
+ * ```
+ */
 typealias ApiErrorResponseEntity = ResponseEntity<ApiErrorBody>
 
+/**
+ * API 오류 본문 데이터를 표현합니다.
+ *
+ * ## 동작/계약
+ * - `timestamp` 기본값은 인스턴스 생성 시점의 [Instant.now]입니다.
+ * - `errorCode`, `message`, `stackTraces`는 생성 인자로 전달한 값을 그대로 보관합니다.
+ *
+ * ```kotlin
+ * val body = ApiErrorBody(message = "invalid input")
+ * // body.message == "invalid input"
+ * ```
+ *
+ * @property errorCode 도메인 오류 코드
+ * @property timestamp 오류 응답 생성 시각
+ * @property message 오류 메시지
+ * @property stackTraces 오류 스택 트레이스 목록
+ */
 data class ApiErrorBody(
     val errorCode: String? = null,
     val timestamp: Instant = Instant.now(),
@@ -14,6 +44,18 @@ data class ApiErrorBody(
     val stackTraces: List<StackTraceElement> = emptyList(),
 ): Serializable
 
+/**
+ * 상태 코드와 오류 본문으로 [ApiErrorResponseEntity]를 생성합니다.
+ *
+ * ## 동작/계약
+ * - [statusCode]로 응답 상태를 설정하고, [ApiErrorBody]를 본문으로 담아 반환합니다.
+ * - [stackTraces]를 전달하지 않으면 빈 리스트를 사용합니다.
+ *
+ * ```kotlin
+ * val response = apiErrorResponseEntityOf(statusCode = 404, message = "not found")
+ * // response.statusCode.value() == 404
+ * ```
+ */
 fun apiErrorResponseEntityOf(
     statusCode: Int = HttpStatus.INTERNAL_SERVER_ERROR.value(),
     errorCode: String? = null,

--- a/spring/core/src/main/kotlin/io/bluetape4k/spring/rest/exceptions/ApiExceptionHandler.kt
+++ b/spring/core/src/main/kotlin/io/bluetape4k/spring/rest/exceptions/ApiExceptionHandler.kt
@@ -9,6 +9,19 @@ import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
+/**
+ * REST API 예외를 표준 오류 응답으로 변환하는 예외 처리기입니다.
+ *
+ * ## 동작/계약
+ * - 매핑된 예외를 [ApiErrorResponseEntity]로 변환하고 상태 코드를 예외 유형에 맞춰 설정합니다.
+ * - 응답 생성 시 예외 메시지와 스택 트레이스를 본문에 담고 로그를 기록합니다.
+ *
+ * ```kotlin
+ * val handler = ApiExceptionHandler()
+ * val response = handler.handle(ApiBadRequestException("invalid input"))
+ * // response.statusCode.value() == 400
+ * ```
+ */
 @RestControllerAdvice
 class ApiExceptionHandler {
 
@@ -41,6 +54,19 @@ class ApiExceptionHandler {
         }
     }
 
+    /**
+     * 역직렬화 실패 예외를 `400 Bad Request` 응답으로 변환합니다.
+     *
+     * ## 동작/계약
+     * - 상태 코드를 [HttpStatus.BAD_REQUEST]로 고정합니다.
+     * - 예외 메시지와 스택 트레이스를 오류 본문에 포함합니다.
+     *
+     * ```kotlin
+     * val ex = HttpMessageNotReadableException("invalid body")
+     * val response = ApiExceptionHandler().handle(ex)
+     * // response.statusCode.value() == 400
+     * ```
+     */
     @ExceptionHandler(HttpMessageNotReadableException::class)
     fun handle(ex: HttpMessageNotReadableException): ApiErrorResponseEntity =
         handleApiExceptionOf(
@@ -48,6 +74,17 @@ class ApiExceptionHandler {
             status = HttpStatus.BAD_REQUEST,
         )
 
+    /**
+     * [ApiBadRequestException]을 해당 상태 코드 응답으로 변환합니다.
+     *
+     * ## 동작/계약
+     * - 상태 코드는 [ApiBadRequestException.httpStatus] 값을 사용합니다.
+     *
+     * ```kotlin
+     * val response = ApiExceptionHandler().handle(ApiBadRequestException("invalid"))
+     * // response.statusCode.value() == 400
+     * ```
+     */
     @ExceptionHandler(ApiBadRequestException::class)
     fun handle(ex: ApiBadRequestException): ApiErrorResponseEntity =
         handleApiExceptionOf(
@@ -55,6 +92,17 @@ class ApiExceptionHandler {
             status = ex.httpStatus,
         )
 
+    /**
+     * [ApiEntityNotFoundException]을 해당 상태 코드 응답으로 변환합니다.
+     *
+     * ## 동작/계약
+     * - 상태 코드는 [ApiEntityNotFoundException.httpStatus] 값을 사용합니다.
+     *
+     * ```kotlin
+     * val response = ApiExceptionHandler().handle(ApiEntityNotFoundException("missing"))
+     * // response.statusCode.value() == 404
+     * ```
+     */
     @ExceptionHandler(ApiEntityNotFoundException::class)
     fun handle(ex: ApiEntityNotFoundException): ApiErrorResponseEntity =
         handleApiExceptionOf(
@@ -62,6 +110,17 @@ class ApiExceptionHandler {
             status = ex.httpStatus,
         )
 
+    /**
+     * [ApiTooManyRequestsException]을 해당 상태 코드 응답으로 변환합니다.
+     *
+     * ## 동작/계약
+     * - 상태 코드는 [ApiTooManyRequestsException.httpStatus] 값을 사용합니다.
+     *
+     * ```kotlin
+     * val response = ApiExceptionHandler().handle(ApiTooManyRequestsException("limit"))
+     * // response.statusCode.value() == 429
+     * ```
+     */
     @ExceptionHandler(ApiTooManyRequestsException::class)
     fun handle(ex: ApiTooManyRequestsException): ApiErrorResponseEntity =
         handleApiExceptionOf(
@@ -69,6 +128,17 @@ class ApiExceptionHandler {
             status = ex.httpStatus,
         )
 
+    /**
+     * [ApiForbiddenException]을 해당 상태 코드 응답으로 변환합니다.
+     *
+     * ## 동작/계약
+     * - 상태 코드는 [ApiForbiddenException.httpStatus] 값을 사용합니다.
+     *
+     * ```kotlin
+     * val response = ApiExceptionHandler().handle(ApiForbiddenException("forbidden"))
+     * // response.statusCode.value() == 403
+     * ```
+     */
     @ExceptionHandler(ApiForbiddenException::class)
     fun handle(ex: ApiForbiddenException): ApiErrorResponseEntity =
         handleApiExceptionOf(
@@ -76,6 +146,17 @@ class ApiExceptionHandler {
             status = ex.httpStatus,
         )
 
+    /**
+     * [ApiUnauthorizedException]을 해당 상태 코드 응답으로 변환합니다.
+     *
+     * ## 동작/계약
+     * - 상태 코드는 [ApiUnauthorizedException.httpStatus] 값을 사용합니다.
+     *
+     * ```kotlin
+     * val response = ApiExceptionHandler().handle(ApiUnauthorizedException("unauthorized"))
+     * // response.statusCode.value() == 401
+     * ```
+     */
     @ExceptionHandler(ApiUnauthorizedException::class)
     fun handle(ex: ApiUnauthorizedException): ApiErrorResponseEntity =
         handleApiExceptionOf(
@@ -83,6 +164,17 @@ class ApiExceptionHandler {
             status = ex.httpStatus,
         )
 
+    /**
+     * [ApiInternalServerErrorException]을 해당 상태 코드 응답으로 변환합니다.
+     *
+     * ## 동작/계약
+     * - 상태 코드는 [ApiInternalServerErrorException.httpStatus] 값을 사용합니다.
+     *
+     * ```kotlin
+     * val response = ApiExceptionHandler().handle(ApiInternalServerErrorException("boom"))
+     * // response.statusCode.value() == 500
+     * ```
+     */
     @ExceptionHandler(ApiInternalServerErrorException::class)
     fun handle(ex: ApiInternalServerErrorException): ApiErrorResponseEntity =
         handleApiExceptionOf(
@@ -90,6 +182,17 @@ class ApiExceptionHandler {
             status = ex.httpStatus,
         )
 
+    /**
+     * [ApiServiceUnavailableException]을 해당 상태 코드 응답으로 변환합니다.
+     *
+     * ## 동작/계약
+     * - 상태 코드는 [ApiServiceUnavailableException.httpStatus] 값을 사용합니다.
+     *
+     * ```kotlin
+     * val response = ApiExceptionHandler().handle(ApiServiceUnavailableException("down"))
+     * // response.statusCode.value() == 503
+     * ```
+     */
     @ExceptionHandler(ApiServiceUnavailableException::class)
     fun handle(ex: ApiServiceUnavailableException): ApiErrorResponseEntity =
         handleApiExceptionOf(

--- a/spring/core/src/main/kotlin/io/bluetape4k/spring/rest/exceptions/ApiExceptions.kt
+++ b/spring/core/src/main/kotlin/io/bluetape4k/spring/rest/exceptions/ApiExceptions.kt
@@ -3,66 +3,352 @@ package io.bluetape4k.spring.rest.exceptions
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ResponseStatus
 
+/**
+ * API 계열 예외의 공통 기반 타입입니다.
+ *
+ * ## 동작/계약
+ * - 모든 하위 예외는 [httpStatus]를 통해 HTTP 상태를 노출합니다.
+ * - [RuntimeException]을 상속하므로 체크 예외가 아닙니다.
+ *
+ * ```kotlin
+ * val ex: ApiException = ApiBadRequestException("invalid")
+ * // ex.httpStatus == HttpStatus.BAD_REQUEST
+ * ```
+ */
 abstract class ApiException: RuntimeException {
+    /**
+     * 예외와 매핑되는 HTTP 상태 코드입니다.
+     *
+     * ## 동작/계약
+     * - 하위 클래스에서 상태 코드를 고정해 제공합니다.
+     *
+     * ```kotlin
+     * val status = ApiUnauthorizedException("no auth").httpStatus
+     * // status == HttpStatus.UNAUTHORIZED
+     * ```
+     */
     abstract val httpStatus: HttpStatus
 
+    /**
+     * 메시지와 원인 예외를 지정해 예외를 생성합니다.
+     *
+     * ## 동작/계약
+     * - [message], [cause]를 상위 [RuntimeException] 생성자로 전달합니다.
+     *
+     * ```kotlin
+     * val cause = IllegalArgumentException("invalid")
+     * val ex = ApiBadRequestException("bad request", cause)
+     * // ex.cause === cause
+     * ```
+     */
     constructor(message: String, cause: Throwable? = null): super(message, cause)
+
+    /**
+     * 원인 예외만으로 예외를 생성합니다.
+     *
+     * ## 동작/계약
+     * - [cause]를 상위 [RuntimeException] 생성자로 전달합니다.
+     *
+     * ```kotlin
+     * val cause = IllegalStateException("failed")
+     * val ex = ApiInternalServerErrorException(cause)
+     * // ex.cause === cause
+     * ```
+     */
     constructor(cause: Throwable?): super(cause)
 }
 
+/**
+ * `404 Not Found`에 매핑되는 API 예외입니다.
+ *
+ * ## 동작/계약
+ * - [httpStatus]는 항상 [HttpStatus.NOT_FOUND]입니다.
+ *
+ * ```kotlin
+ * val ex = ApiEntityNotFoundException("entity not found")
+ * // ex.httpStatus == HttpStatus.NOT_FOUND
+ * ```
+ */
 @ResponseStatus(value = HttpStatus.NOT_FOUND)
 open class ApiEntityNotFoundException: ApiException {
     override val httpStatus: HttpStatus = HttpStatus.NOT_FOUND
 
+    /**
+     * 메시지와 원인 예외를 지정해 예외를 생성합니다.
+     *
+     * ## 동작/계약
+     * - 전달받은 [message], [cause]를 그대로 사용합니다.
+     *
+     * ```kotlin
+     * val ex = ApiEntityNotFoundException("missing")
+     * // ex.message == "missing"
+     * ```
+     */
     constructor(message: String, cause: Throwable? = null): super(message, cause)
+
+    /**
+     * 원인 예외를 기반으로 예외를 생성합니다.
+     *
+     * ## 동작/계약
+     * - 원인 메시지가 있으면 이를 사용하고, 없으면 `"Entity not found"`를 메시지로 사용합니다.
+     *
+     * ```kotlin
+     * val ex = ApiEntityNotFoundException(IllegalArgumentException("missing"))
+     * // ex.message == "missing"
+     * ```
+     */
     constructor(cause: Throwable): this(cause.message ?: "Entity not found", cause)
 }
 
+/**
+ * `400 Bad Request`에 매핑되는 API 예외입니다.
+ *
+ * ## 동작/계약
+ * - [httpStatus]는 항상 [HttpStatus.BAD_REQUEST]입니다.
+ *
+ * ```kotlin
+ * val ex = ApiBadRequestException("bad request")
+ * // ex.httpStatus == HttpStatus.BAD_REQUEST
+ * ```
+ */
 @ResponseStatus(value = HttpStatus.BAD_REQUEST)
 open class ApiBadRequestException: ApiException {
     override val httpStatus: HttpStatus = HttpStatus.BAD_REQUEST
 
+    /**
+     * 메시지와 원인 예외를 지정해 예외를 생성합니다.
+     *
+     * ## 동작/계약
+     * - 전달받은 [message], [cause]를 그대로 사용합니다.
+     *
+     * ```kotlin
+     * val ex = ApiBadRequestException("bad")
+     * // ex.message == "bad"
+     * ```
+     */
     constructor(message: String, cause: Throwable? = null): super(message, cause)
+
+    /**
+     * 원인 예외를 기반으로 예외를 생성합니다.
+     *
+     * ## 동작/계약
+     * - 원인 메시지가 있으면 이를 사용하고, 없으면 `"Bad request"`를 메시지로 사용합니다.
+     *
+     * ```kotlin
+     * val ex = ApiBadRequestException(IllegalArgumentException("wrong format"))
+     * // ex.message == "wrong format"
+     * ```
+     */
     constructor(cause: Throwable): this(cause.message ?: "Bad request")
 }
 
 
+/**
+ * `429 Too Many Requests`에 매핑되는 API 예외입니다.
+ *
+ * ## 동작/계약
+ * - [httpStatus]는 항상 [HttpStatus.TOO_MANY_REQUESTS]입니다.
+ *
+ * ```kotlin
+ * val ex = ApiTooManyRequestsException("too many")
+ * // ex.httpStatus == HttpStatus.TOO_MANY_REQUESTS
+ * ```
+ */
 @ResponseStatus(value = HttpStatus.TOO_MANY_REQUESTS)
 open class ApiTooManyRequestsException: ApiException {
     override val httpStatus: HttpStatus = HttpStatus.TOO_MANY_REQUESTS
 
+    /**
+     * 메시지와 원인 예외를 지정해 예외를 생성합니다.
+     *
+     * ## 동작/계약
+     * - 전달받은 [message], [cause]를 그대로 사용합니다.
+     *
+     * ```kotlin
+     * val ex = ApiTooManyRequestsException("retry later")
+     * // ex.message == "retry later"
+     * ```
+     */
     constructor(message: String, cause: Throwable? = null): super(message, cause)
+
+    /**
+     * 원인 예외를 기반으로 예외를 생성합니다.
+     *
+     * ## 동작/계약
+     * - 원인 메시지가 있으면 이를 사용하고, 없으면 `"Too many requests"`를 메시지로 사용합니다.
+     *
+     * ```kotlin
+     * val ex = ApiTooManyRequestsException(IllegalStateException("limit exceeded"))
+     * // ex.message == "limit exceeded"
+     * ```
+     */
     constructor(cause: Throwable): this(cause.message ?: "Too many requests")
 }
 
+/**
+ * `403 Forbidden`에 매핑되는 API 예외입니다.
+ *
+ * ## 동작/계약
+ * - [httpStatus]는 항상 [HttpStatus.FORBIDDEN]입니다.
+ *
+ * ```kotlin
+ * val ex = ApiForbiddenException("forbidden")
+ * // ex.httpStatus == HttpStatus.FORBIDDEN
+ * ```
+ */
 @ResponseStatus(value = HttpStatus.FORBIDDEN)
 open class ApiForbiddenException: ApiException {
     override val httpStatus: HttpStatus = HttpStatus.FORBIDDEN
 
+    /**
+     * 메시지와 원인 예외를 지정해 예외를 생성합니다.
+     *
+     * ## 동작/계약
+     * - 전달받은 [message], [cause]를 그대로 사용합니다.
+     *
+     * ```kotlin
+     * val ex = ApiForbiddenException("denied")
+     * // ex.message == "denied"
+     * ```
+     */
     constructor(message: String, cause: Throwable? = null): super(message, cause)
+
+    /**
+     * 원인 예외를 기반으로 예외를 생성합니다.
+     *
+     * ## 동작/계약
+     * - 원인 메시지가 있으면 이를 사용하고, 없으면 `"Forbidden"`을 메시지로 사용합니다.
+     *
+     * ```kotlin
+     * val ex = ApiForbiddenException(IllegalAccessException("not allowed"))
+     * // ex.message == "not allowed"
+     * ```
+     */
     constructor(cause: Throwable): this(cause.message ?: "Forbidden")
 }
 
+/**
+ * `401 Unauthorized`에 매핑되는 API 예외입니다.
+ *
+ * ## 동작/계약
+ * - [httpStatus]는 항상 [HttpStatus.UNAUTHORIZED]입니다.
+ *
+ * ```kotlin
+ * val ex = ApiUnauthorizedException("unauthorized")
+ * // ex.httpStatus == HttpStatus.UNAUTHORIZED
+ * ```
+ */
 @ResponseStatus(value = HttpStatus.UNAUTHORIZED)
 open class ApiUnauthorizedException: ApiException {
     override val httpStatus: HttpStatus = HttpStatus.UNAUTHORIZED
 
+    /**
+     * 메시지와 원인 예외를 지정해 예외를 생성합니다.
+     *
+     * ## 동작/계약
+     * - 전달받은 [message], [cause]를 그대로 사용합니다.
+     *
+     * ```kotlin
+     * val ex = ApiUnauthorizedException("no token")
+     * // ex.message == "no token"
+     * ```
+     */
     constructor(message: String, cause: Throwable? = null): super(message, cause)
+
+    /**
+     * 원인 예외를 기반으로 예외를 생성합니다.
+     *
+     * ## 동작/계약
+     * - 원인 메시지가 있으면 이를 사용하고, 없으면 `"Unauthorized"`를 메시지로 사용합니다.
+     *
+     * ```kotlin
+     * val ex = ApiUnauthorizedException(IllegalStateException("expired"))
+     * // ex.message == "expired"
+     * ```
+     */
     constructor(cause: Throwable): this(cause.message ?: "Unauthorized")
 }
 
+/**
+ * `500 Internal Server Error`에 매핑되는 API 예외입니다.
+ *
+ * ## 동작/계약
+ * - [httpStatus]는 항상 [HttpStatus.INTERNAL_SERVER_ERROR]입니다.
+ *
+ * ```kotlin
+ * val ex = ApiInternalServerErrorException("failed")
+ * // ex.httpStatus == HttpStatus.INTERNAL_SERVER_ERROR
+ * ```
+ */
 @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
 open class ApiInternalServerErrorException: ApiException {
     override val httpStatus: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR
 
+    /**
+     * 메시지와 원인 예외를 지정해 예외를 생성합니다.
+     *
+     * ## 동작/계약
+     * - 전달받은 [message], [cause]를 그대로 사용합니다.
+     *
+     * ```kotlin
+     * val ex = ApiInternalServerErrorException("internal")
+     * // ex.message == "internal"
+     * ```
+     */
     constructor(message: String, cause: Throwable? = null): super(message, cause)
+
+    /**
+     * 원인 예외를 기반으로 예외를 생성합니다.
+     *
+     * ## 동작/계약
+     * - 원인 메시지가 있으면 이를 사용하고, 없으면 `"Internal server error"`를 메시지로 사용합니다.
+     *
+     * ```kotlin
+     * val ex = ApiInternalServerErrorException(IllegalStateException("db down"))
+     * // ex.message == "db down"
+     * ```
+     */
     constructor(cause: Throwable): this(cause.message ?: "Internal server error")
 }
 
+/**
+ * `503 Service Unavailable`에 매핑되는 API 예외입니다.
+ *
+ * ## 동작/계약
+ * - [httpStatus]는 항상 [HttpStatus.SERVICE_UNAVAILABLE]입니다.
+ *
+ * ```kotlin
+ * val ex = ApiServiceUnavailableException("maintenance")
+ * // ex.httpStatus == HttpStatus.SERVICE_UNAVAILABLE
+ * ```
+ */
 @ResponseStatus(value = HttpStatus.SERVICE_UNAVAILABLE)
 open class ApiServiceUnavailableException: ApiException {
     override val httpStatus: HttpStatus = HttpStatus.SERVICE_UNAVAILABLE
 
+    /**
+     * 메시지와 원인 예외를 지정해 예외를 생성합니다.
+     *
+     * ## 동작/계약
+     * - 전달받은 [message], [cause]를 그대로 사용합니다.
+     *
+     * ```kotlin
+     * val ex = ApiServiceUnavailableException("maintenance")
+     * // ex.message == "maintenance"
+     * ```
+     */
     constructor(message: String, cause: Throwable? = null): super(message, cause)
+
+    /**
+     * 원인 예외를 기반으로 예외를 생성합니다.
+     *
+     * ## 동작/계약
+     * - 원인 메시지가 있으면 이를 사용하고, 없으면 `"Service unavailable"`을 메시지로 사용합니다.
+     *
+     * ```kotlin
+     * val ex = ApiServiceUnavailableException(IllegalStateException("temporarily down"))
+     * // ex.message == "temporarily down"
+     * ```
+     */
     constructor(cause: Throwable): this(cause.message ?: "Service unavailable")
 }

--- a/spring/core/src/main/kotlin/io/bluetape4k/spring/ui/ModelExtensions.kt
+++ b/spring/core/src/main/kotlin/io/bluetape4k/spring/ui/ModelExtensions.kt
@@ -3,27 +3,31 @@ package io.bluetape4k.spring.ui
 import org.springframework.ui.Model
 
 /**
- * [Model]에 속성을 추가합니다.
+ * 주어진 키-값 쌍을 [Model]에 한 번에 추가합니다.
  *
- * ```
- * model.addAttribute("name" to "value", "name2" to "value2")
- * ```
+ * ## 동작/계약
+ * - 전달된 [pairs]를 `Map`으로 변환해 `addAllAttributes`로 추가합니다.
+ * - 동일 키가 중복되면 마지막 쌍의 값이 사용됩니다.
  *
- * @param pairs 속성 목록
- * @return [Model] 인스턴스
+ * ```kotlin
+ * model.addAttributes("name" to "debop", "age" to 42)
+ * // model.asMap()["name"] == "debop"
+ * ```
  */
 fun Model.addAttributes(vararg pairs: Pair<String, Any?>): Model =
     addAllAttributes(pairs.toMap())
 
 /**
- * [Model]에 속성을 합칩니다.
+ * 주어진 키-값 쌍을 기존 [Model] 속성과 병합합니다.
  *
- * ```
- * model.mergeAttributes("name" to "value", "name2" to "value2")
- * ```
+ * ## 동작/계약
+ * - 전달된 [pairs]를 `Map`으로 변환해 `mergeAttributes`에 전달합니다.
+ * - 이미 존재하는 키는 Spring `mergeAttributes` 규칙을 따릅니다.
  *
- * @param pairs 속성 목록
- * @return [Model] 인스턴스
+ * ```kotlin
+ * model.mergeAttributes("enabled" to true)
+ * // model.asMap()["enabled"] == true
+ * ```
  */
 fun Model.mergeAttributes(vararg pairs: Pair<String, Any?>): Model =
     mergeAttributes(pairs.toMap())

--- a/spring/core/src/main/kotlin/io/bluetape4k/spring/ui/ModelMapExtensions.kt
+++ b/spring/core/src/main/kotlin/io/bluetape4k/spring/ui/ModelMapExtensions.kt
@@ -3,27 +3,31 @@ package io.bluetape4k.spring.ui
 import org.springframework.ui.ModelMap
 
 /**
- * [ModelMap]에 속성을 추가합니다.
+ * 주어진 키-값 쌍을 [ModelMap]에 한 번에 추가합니다.
  *
- * ```
- * model.addAttribute("name" to "value", "name2" to "value2")
- * ```
+ * ## 동작/계약
+ * - 전달된 [pairs]를 `Map`으로 변환해 `addAllAttributes`로 추가합니다.
+ * - 동일 키가 중복되면 마지막 쌍의 값이 사용됩니다.
  *
- * @param pairs 속성 목록
- * @return [ModelMap] 인스턴스
+ * ```kotlin
+ * modelMap.addAttributes("name" to "debop", "age" to 42)
+ * // modelMap["age"] == 42
+ * ```
  */
 fun ModelMap.addAttributes(vararg pairs: Pair<String, Any?>): ModelMap =
     addAllAttributes(pairs.toMap())
 
 /**
- * [ModelMap]에 속성을 합칩니다.
+ * 주어진 키-값 쌍을 기존 [ModelMap] 속성과 병합합니다.
  *
- * ```
- * model.mergeAttributes("name" to "value", "name2" to "value2")
- * ```
+ * ## 동작/계약
+ * - 전달된 [pairs]를 `Map`으로 변환해 `mergeAttributes`에 전달합니다.
+ * - 이미 존재하는 키는 Spring `mergeAttributes` 규칙을 따릅니다.
  *
- * @param pairs 속성 목록
- * @return [ModelMap] 인스턴스
+ * ```kotlin
+ * modelMap.mergeAttributes("enabled" to true)
+ * // modelMap["enabled"] == true
+ * ```
  */
 fun ModelMap.mergeAttributes(vararg pairs: Pair<String, Any?>): ModelMap =
     mergeAttributes(pairs.toMap())

--- a/spring/core/src/main/kotlin/io/bluetape4k/spring/util/MemberUtilsSupport.kt
+++ b/spring/core/src/main/kotlin/io/bluetape4k/spring/util/MemberUtilsSupport.kt
@@ -4,16 +4,16 @@ import org.springframework.util.NumberUtils
 import java.text.NumberFormat
 
 /**
- * 문자열을 [numberFormat] 형식으로 Number 타입으로 파싱합니다.
+ * 문자열을 reified 숫자 타입으로 파싱합니다.
  *
- * ```
- * "123".parseNumber<Int>(NumberFormat.getInstance()) // 123
- * "1,234.56".parseNumber<Double>(NumberFormat.getInstance()) // 1234.56
- * ```
+ * ## 동작/계약
+ * - [NumberUtils.parseNumber]에 [NumberFormat]을 전달해 파싱합니다.
+ * - 테스트에서 `"123".parseNumber<Int>()` 결과는 `123`입니다.
  *
- * @receiver String 파싱할 문자열
- * @param numberFormat NumberFormat 파싱할 문자열의 형식
- * @return T 파싱된 Number 타입
+ * ```kotlin
+ * val intValue = "123".parseNumber<Int>()
+ * // intValue == 123
+ * ```
  */
 inline fun <reified T: Number> String.parseNumber(
     numberFormat: NumberFormat = NumberFormat.getInstance(),
@@ -21,15 +21,16 @@ inline fun <reified T: Number> String.parseNumber(
     NumberUtils.parseNumber(this, T::class.java, numberFormat)
 
 /**
- * 문자열을 [targetClass] 형식으로 Number 타입으로 파싱합니다.
+ * 문자열을 지정한 숫자 클래스로 파싱합니다.
  *
- * ```
- * "123".parseNumber(Int::class.java, NumberFormat.getInstance()) // 123
- * "1,234.56".parseNumber(Double::class.java, NumberFormat.getInstance()) // 1234.56
- * ```
+ * ## 동작/계약
+ * - [targetClass] 타입으로 변환 가능한 숫자를 반환합니다.
+ * - 테스트에서 `"123.4".parseNumber(Int::class.java, ...)` 결과는 `123`입니다.
  *
- * @receiver String 파싱할 문자열
- * @param targetClass Class<T> 파싱할 Number 타입
+ * ```kotlin
+ * val value = "123.4".parseNumber(Int::class.java, NumberFormat.getNumberInstance())
+ * // value == 123
+ * ```
  */
 fun <T: Number> String.parseNumber(
     targetClass: Class<T>,
@@ -38,29 +39,31 @@ fun <T: Number> String.parseNumber(
     NumberUtils.parseNumber(this, targetClass, numberFormat)
 
 /**
- * Number 타입을 [T] 타입으로 변환합니다.
+ * 숫자를 reified 대상 숫자 타입으로 변환합니다.
  *
- * ```
- * 123.toTargetClass<Int>() // 123
- * 123.toTargetClass<Double>() // 123.0
- * ```
+ * ## 동작/계약
+ * - [NumberUtils.convertNumberToTargetClass]를 사용해 숫자 변환을 수행합니다.
+ * - 테스트에서 `123.toTargetClass<Double>()` 결과는 `123.0`입니다.
  *
- * @receiver Number 변환할 Number 타입
- * @return T 변환된 Number 타입
+ * ```kotlin
+ * val converted = 123.toTargetClass<Double>()
+ * // converted == 123.0
+ * ```
  */
 inline fun <reified T: Number> Number.toTargetClass(): T =
     NumberUtils.convertNumberToTargetClass(this, T::class.java)
 
 /**
- * Number 타입을 [T] 타입으로 변환합니다.
+ * 숫자를 reified 대상 숫자 타입으로 변환합니다.
  *
- * ```
- * 123.convertAs<Int>() // 123
- * 123.convertAs<Double>() // 123.0
- * ```
+ * ## 동작/계약
+ * - [toTargetClass]와 동일하게 [NumberUtils.convertNumberToTargetClass]를 호출합니다.
+ * - 테스트에서 `123.4.convertAs<Long>()` 결과는 `123L`입니다.
  *
- * @receiver Number 변환할 Number 타입
- * @return T 변환된 Number 타입
+ * ```kotlin
+ * val converted = 123.4.convertAs<Long>()
+ * // converted == 123L
+ * ```
  */
 inline fun <reified T: Number> Number.convertAs(): T =
     NumberUtils.convertNumberToTargetClass(this, T::class.java)

--- a/spring/core/src/main/kotlin/io/bluetape4k/spring/util/StopWatchSupport.kt
+++ b/spring/core/src/main/kotlin/io/bluetape4k/spring/util/StopWatchSupport.kt
@@ -9,11 +9,16 @@ private val log by lazy { KotlinLogging.logger { } }
 /**
  * 지정한 body를 실행할 때, [StopWatch]를 이용하여 실행시간을 측정합니다.
  *
+ * ## 동작/계약
+ * - 새 [StopWatch]를 생성해 `start()` 후 [body]를 실행하고, 예외 여부와 무관하게 `finally`에서 `stop()`합니다.
+ * - [body]에서 예외가 발생하면 예외를 그대로 전파합니다.
+ * - 수신 객체가 없는 top-level 함수이며 호출마다 새 [StopWatch]를 할당합니다.
+ *
  * ```kotlin
  * val sw = withStopWatch("coroutines") {
  *     Thread.sleep(100)
  * }
- * println(sw.prettyPrint())
+ * // sw.taskCount == 1
  * ```
  *
  * @param id StopWatch의 `id`
@@ -35,11 +40,16 @@ inline fun withStopWatch(
 /**
  * 지정한 body를 실행할 때, [StopWatch]를 이용하여 실행시간을 측정합니다.
  *
+ * ## 동작/계약
+ * - suspend [body] 실행 전후로 `start()/stop()`을 수행합니다.
+ * - [body] 실패 시 예외를 삼키지 않고 그대로 전파합니다.
+ * - 호출마다 새 [StopWatch]가 생성됩니다.
+ *
  * ```kotlin
  * val sw = withSuspendStopWatch("coroutines") {
  *     delay(100)
  * }
- * println(sw.prettyPrint())
+ * // sw.taskCount == 1
  * ```
  *
  * @param id StopWatch의 `id`
@@ -62,18 +72,25 @@ suspend inline fun withSuspendStopWatch(
 /**
  * [StopWatch]를 이용하여 [body]의 실행 시간을 측정합니다.
  *
- * ```
+ * ## 동작/계약
+ * - 수신 [StopWatch]가 이미 실행 중이면 `check`에 의해 [IllegalStateException]이 발생합니다.
+ * - `start(taskName)` 후 [body]를 실행하고 `finally`에서 `stop()`을 보장합니다.
+ * - 수신 객체 상태를 변경해 task 기록을 추가합니다.
+ *
+ * ```kotlin
  * val stopwatch = StopWatch()
  *
  * val result = stopwatch.task("task1") {
  *      Thread.sleep(100)
  *      "task1"
  * }
- *```
+ * // result == "task1"
+ * ```
  *
  * @receiver StopWatch 인스턴스
  * @param taskName task 이름
  * @param body 실행할 함수
+ * @throws IllegalStateException StopWatch가 이미 실행 중인 경우 발생합니다.
  */
 inline fun <T> StopWatch.task(
     taskName: String = TimebasedUuid.Epoch.nextIdAsString(),
@@ -91,18 +108,25 @@ inline fun <T> StopWatch.task(
 /**
  * [StopWatch]를 이용하여 suspend [body]의 실행 시간을 측정합니다.
  *
- * ```
+ * ## 동작/계약
+ * - 수신 [StopWatch]가 이미 실행 중이면 `check`에 의해 [IllegalStateException]이 발생합니다.
+ * - suspend [body] 실행 전후로 `start(taskName)/stop()`을 수행합니다.
+ * - 수신 객체 상태를 변경해 task 정보를 누적합니다.
+ *
+ * ```kotlin
  * val stopwatch = StopWatch()
  *
  * val result = stopwatch.suspendTask("task1") {
  *      delay(100)
  *      "task1"
  * }
- *```
+ * // result == "task1"
+ * ```
  *
  * @receiver StopWatch 인스턴스
  * @param taskName task 이름
  * @param body 실행할 함수
+ * @throws IllegalStateException StopWatch가 이미 실행 중인 경우 발생합니다.
  */
 suspend inline fun <T> StopWatch.suspendTask(
     taskName: String = TimebasedUuid.Epoch.nextIdAsString(),

--- a/spring/jpa/src/main/kotlin/io/bluetape4k/spring/jpa/stateless/StatelessSessionFactoryBean.kt
+++ b/spring/jpa/src/main/kotlin/io/bluetape4k/spring/jpa/stateless/StatelessSessionFactoryBean.kt
@@ -18,10 +18,15 @@ import org.springframework.util.ReflectionUtils
 import java.sql.Connection
 
 /**
- * Hibernate의 [StatelessSession]을 Spring Data Jpa 의 Transaction 환경에서 사용할 수 있도록,
- * [StatelessSession]을 생성해주는 Factory Bean입니다.
+ * Spring 트랜잭션에 바인딩된 Hibernate [StatelessSession] 프록시를 제공하는 FactoryBean입니다.
  *
- * ```
+ * ## 동작/계약
+ * - `getObject()`는 매 호출마다 프록시를 반환하고, 실제 세션은 메서드 호출 시 트랜잭션 컨텍스트에서 조회/생성됩니다.
+ * - 활성 트랜잭션이 없으면 인터셉터의 `check(...)`에 의해 `IllegalStateException`이 발생합니다.
+ * - 현재 트랜잭션 리소스에 세션이 없으면 JDBC 연결 기반으로 새 `StatelessSession`을 열고 트랜잭션 종료 시 close 합니다.
+ * - 수신 객체를 직접 변경하지 않으며, 트랜잭션 리소스 바인딩으로 동작을 연결합니다.
+ *
+ * ```kotlin
  * entityManager.withStateless { stateless ->
  *     repeat(COUNT) {
  *         val master = createMaster("master-$it")
@@ -34,6 +39,8 @@ import java.sql.Connection
  * ```
  *
  * 참고 : https://gist.github.com/jelies/5181262
+ *
+ * @param sf 트랜잭션 리소스 키와 세션 생성을 위한 Hibernate [SessionFactory]
  */
 class StatelessSessionFactoryBean(
     @field:Autowired val sf: SessionFactory,

--- a/spring/r2dbc/src/main/kotlin/io/bluetape4k/spring/r2dbc/coroutines/R2dbcEntityOperationExtensions.kt
+++ b/spring/r2dbc/src/main/kotlin/io/bluetape4k/spring/r2dbc/coroutines/R2dbcEntityOperationExtensions.kt
@@ -6,11 +6,21 @@ import org.springframework.data.relational.core.query.Query
 import org.springframework.data.relational.core.query.isEqual
 
 /**
- * id 기준으로 단건을 조회합니다.
+ * 지정한 id 컬럼 조건으로 단건을 조회합니다.
  *
- * @param id 조회할 id
- * @param idName id 컬럼명
- * @return 조회된 엔티티
+ * ## 동작/계약
+ * - `Query.where(idName).isEqual(id)`를 생성한 뒤 `selectOneSuspending`으로 위임합니다.
+ * - 결과가 2건 이상이면 하위 API에서 `IncorrectResultSizeDataAccessException`이 발생할 수 있습니다.
+ * - 수신 객체 상태를 변경하지 않고 조회 쿼리 객체만 새로 생성합니다.
+ *
+ * ```kotlin
+ * val post = operations.findOneByIdSuspending<Post>(1L)
+ * // post.id == 1L
+ * ```
+ *
+ * @param id 조회할 식별자 값
+ * @param idName 식별자 컬럼명
+ * @throws org.springframework.dao.IncorrectResultSizeDataAccessException 조회 결과가 단건이 아닐 때 발생할 수 있습니다.
  */
 suspend inline fun <reified T: Any> R2dbcEntityOperations.findOneByIdSuspending(
     id: Any,
@@ -20,6 +30,18 @@ suspend inline fun <reified T: Any> R2dbcEntityOperations.findOneByIdSuspending(
     return selectOneSuspending(query)
 }
 
+/**
+ * [findOneByIdSuspending]의 이전 이름을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 구현은 [findOneByIdSuspending]에 그대로 위임됩니다.
+ * - 동작/예외 계약은 대상 함수와 동일합니다.
+ *
+ * ```kotlin
+ * val post = operations.suspendFindOneById<Post>(1L)
+ * // post.id == 1L
+ * ```
+ */
 @Deprecated(
     message = "findOneByIdSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("findOneByIdSuspending(id, idName)"),
@@ -31,11 +53,20 @@ suspend inline fun <reified T: Any> R2dbcEntityOperations.suspendFindOneById(
     findOneByIdSuspending(id, idName)
 
 /**
- * id 기준으로 단건을 조회하고 없으면 null을 반환합니다.
+ * 지정한 id 컬럼 조건으로 단건 조회를 수행하고 없으면 `null`을 반환합니다.
  *
- * @param id 조회할 id
- * @param idName id 컬럼명
- * @return 조회된 엔티티 또는 null
+ * ## 동작/계약
+ * - 내부적으로 `selectOneOrNullSuspending`에 위임합니다.
+ * - 결과가 없으면 `null`을 반환하고, 복수 건이면 하위 API 예외가 전파될 수 있습니다.
+ * - 조회용 [Query]를 새로 생성하며 수신 객체는 변경하지 않습니다.
+ *
+ * ```kotlin
+ * val missing = operations.findOneByIdOrNullSuspending<Post>(-1L)
+ * // missing == null
+ * ```
+ *
+ * @param id 조회할 식별자 값
+ * @param idName 식별자 컬럼명
  */
 suspend inline fun <reified T: Any> R2dbcEntityOperations.findOneByIdOrNullSuspending(
     id: Any,
@@ -45,6 +76,18 @@ suspend inline fun <reified T: Any> R2dbcEntityOperations.findOneByIdOrNullSuspe
     return selectOneOrNullSuspending(query)
 }
 
+/**
+ * [findOneByIdOrNullSuspending]의 이전 이름을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 구현은 [findOneByIdOrNullSuspending]에 위임됩니다.
+ * - 결과가 없으면 `null`을 반환합니다.
+ *
+ * ```kotlin
+ * val post = operations.suspendFindOneByIdOrNull<Post>(-1L)
+ * // post == null
+ * ```
+ */
 @Deprecated(
     message = "findOneByIdOrNullSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("findOneByIdOrNullSuspending(id, idName)"),
@@ -56,11 +99,20 @@ suspend inline fun <reified T: Any> R2dbcEntityOperations.suspendFindOneByIdOrNu
     findOneByIdOrNullSuspending(id, idName)
 
 /**
- * id 기준으로 첫 번째 엔티티를 조회합니다.
+ * 지정한 id 컬럼 조건으로 첫 번째 엔티티를 조회합니다.
  *
- * @param id 조회할 id
- * @param idName id 컬럼명
- * @return 조회된 엔티티
+ * ## 동작/계약
+ * - `selectFirstSuspending`으로 위임하므로 첫 요소만 반환합니다.
+ * - 결과가 없으면 하위 API에서 `NoSuchElementException` 계열 예외가 전파될 수 있습니다.
+ * - 조회 조건 [Query]를 새로 할당합니다.
+ *
+ * ```kotlin
+ * val first = operations.findFirstByIdSuspending<Post>(1L)
+ * // first.id == 1L
+ * ```
+ *
+ * @param id 조회할 식별자 값
+ * @param idName 식별자 컬럼명
  */
 suspend inline fun <reified T: Any> R2dbcEntityOperations.findFirstByIdSuspending(
     id: Any,
@@ -70,6 +122,18 @@ suspend inline fun <reified T: Any> R2dbcEntityOperations.findFirstByIdSuspendin
     return selectFirstSuspending(query)
 }
 
+/**
+ * [findFirstByIdSuspending]의 이전 이름을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 내부 구현은 [findFirstByIdSuspending]과 동일합니다.
+ * - 첫 번째 결과만 반환합니다.
+ *
+ * ```kotlin
+ * val first = operations.suspendFindFirstById<Post>(1L)
+ * // first.id == 1L
+ * ```
+ */
 @Deprecated(
     message = "findFirstByIdSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("findFirstByIdSuspending(id, idName)"),
@@ -81,11 +145,20 @@ suspend inline fun <reified T: Any> R2dbcEntityOperations.suspendFindFirstById(
     findFirstByIdSuspending(id, idName)
 
 /**
- * id 기준으로 첫 번째 엔티티를 조회하고 없으면 null을 반환합니다.
+ * 지정한 id 컬럼 조건으로 첫 번째 엔티티를 조회하고 없으면 `null`을 반환합니다.
  *
- * @param id 조회할 id
- * @param idName id 컬럼명
- * @return 조회된 엔티티 또는 null
+ * ## 동작/계약
+ * - `selectFirstOrNullSuspending`에 위임하여 첫 요소만 소비합니다.
+ * - 결과가 없으면 `null`을 반환합니다.
+ * - 조회 조건 객체를 새로 만들며 수신 객체는 변경하지 않습니다.
+ *
+ * ```kotlin
+ * val first = operations.findFirstByIdOrNullSuspending<Post>(-1L)
+ * // first == null
+ * ```
+ *
+ * @param id 조회할 식별자 값
+ * @param idName 식별자 컬럼명
  */
 suspend inline fun <reified T: Any> R2dbcEntityOperations.findFirstByIdOrNullSuspending(
     id: Any,
@@ -95,6 +168,18 @@ suspend inline fun <reified T: Any> R2dbcEntityOperations.findFirstByIdOrNullSus
     return selectFirstOrNullSuspending(query)
 }
 
+/**
+ * [findFirstByIdOrNullSuspending]의 이전 이름을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 구현은 [findFirstByIdOrNullSuspending]에 위임됩니다.
+ * - 결과가 없으면 `null`을 반환합니다.
+ *
+ * ```kotlin
+ * val first = operations.suspendFindFirstByIdOrNull<Post>(-1L)
+ * // first == null
+ * ```
+ */
 @Deprecated(
     message = "findFirstByIdOrNullSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("findFirstByIdOrNullSuspending(id, idName)"),

--- a/spring/r2dbc/src/main/kotlin/io/bluetape4k/spring/r2dbc/coroutines/ReactiveDeleteOperationExtensions.kt
+++ b/spring/r2dbc/src/main/kotlin/io/bluetape4k/spring/r2dbc/coroutines/ReactiveDeleteOperationExtensions.kt
@@ -6,14 +6,35 @@ import org.springframework.data.r2dbc.core.delete
 import org.springframework.data.relational.core.query.Query
 
 /**
- * [Query] 조건에 해당하는 엔티티를 삭제하고 삭제된 건수를 반환합니다.
+ * 삭제 조건에 해당하는 엔티티를 삭제하고 삭제 건수를 반환합니다.
+ *
+ * ## 동작/계약
+ * - `delete<T>().matching(query).all()` 결과를 대기해 삭제 건수를 반환합니다.
+ * - 조건에 맞는 행이 없으면 `0`을 반환합니다.
+ * - 수신 객체는 변경하지 않으며 삭제 쿼리만 생성합니다.
+ *
+ * ```kotlin
+ * val deleted = operations.deleteSuspending<Post>(query)
+ * // deleted == 1L
+ * ```
  *
  * @param query 삭제 조건
- * @return 삭제된 건수
  */
 suspend inline fun <reified T: Any> ReactiveDeleteOperation.deleteSuspending(query: Query): Long =
     delete<T>().matching(query).all().awaitSingle()
 
+/**
+ * [deleteSuspending]의 이전 이름을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 구현은 [deleteSuspending]으로 위임됩니다.
+ * - 반환값은 삭제 건수입니다.
+ *
+ * ```kotlin
+ * val deleted = operations.suspendDelete<Post>(Query.empty())
+ * // deleted >= 0L
+ * ```
+ */
 @Deprecated(
     message = "deleteSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("deleteSuspending<T>(query)"),
@@ -22,13 +43,32 @@ suspend inline fun <reified T: Any> ReactiveDeleteOperation.suspendDelete(query:
     deleteSuspending<T>(query)
 
 /**
- * 모든 엔티티를 삭제하고 삭제된 건수를 반환합니다.
+ * 전체 엔티티를 삭제하고 삭제 건수를 반환합니다.
  *
- * @return 삭제된 건수
+ * ## 동작/계약
+ * - 내부적으로 `Query.empty()`를 사용해 전체 삭제를 수행합니다.
+ * - 반환값은 실제로 삭제된 행 수입니다.
+ *
+ * ```kotlin
+ * val deleted = operations.deleteAllSuspending<Post>()
+ * // deleted >= 0L
+ * ```
  */
 suspend inline fun <reified T: Any> ReactiveDeleteOperation.deleteAllSuspending(): Long =
     delete<T>().matching(Query.empty()).all().awaitSingle()
 
+/**
+ * [deleteAllSuspending]의 이전 이름을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 구현은 [deleteAllSuspending]으로 위임됩니다.
+ * - 전체 삭제 건수를 반환합니다.
+ *
+ * ```kotlin
+ * val deleted = operations.suspendDeleteAll<Post>()
+ * // deleted >= 0L
+ * ```
+ */
 @Deprecated(
     message = "deleteAllSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("deleteAllSuspending<T>()"),

--- a/spring/r2dbc/src/main/kotlin/io/bluetape4k/spring/r2dbc/coroutines/ReactiveInsertOperationExtensions.kt
+++ b/spring/r2dbc/src/main/kotlin/io/bluetape4k/spring/r2dbc/coroutines/ReactiveInsertOperationExtensions.kt
@@ -8,12 +8,33 @@ import org.springframework.data.r2dbc.core.insert
 /**
  * 엔티티를 저장하고 저장된 엔티티를 반환합니다.
  *
+ * ## 동작/계약
+ * - `insert<T>().using(entity)`를 수행한 뒤 단건 결과를 대기합니다.
+ * - 저장 실패나 매핑 실패 예외는 그대로 전파됩니다.
+ * - 수신 객체를 변경하지 않고 insert 파이프라인만 새로 구성합니다.
+ *
+ * ```kotlin
+ * val saved = operations.insertSuspending(createPost())
+ * // saved.id != null
+ * ```
+ *
  * @param entity 저장할 엔티티
- * @return 저장된 엔티티
  */
 suspend inline fun <reified T: Any> ReactiveInsertOperation.insertSuspending(entity: T): T =
     insert<T>().using(entity).awaitSingle()
 
+/**
+ * [insertSuspending]의 이전 이름을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 구현은 [insertSuspending]으로 위임됩니다.
+ * - 저장 성공 시 저장된 엔티티를 반환합니다.
+ *
+ * ```kotlin
+ * val saved = operations.suspendInsert(createPost())
+ * // saved.id != null
+ * ```
+ */
 @Deprecated(
     message = "insertSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("insertSuspending(entity)"),
@@ -22,14 +43,34 @@ suspend inline fun <reified T: Any> ReactiveInsertOperation.suspendInsert(entity
     insertSuspending(entity)
 
 /**
- * 엔티티를 저장하고 없으면 null을 반환합니다.
+ * 엔티티를 저장하고 결과가 비어 있으면 `null`을 반환합니다.
+ *
+ * ## 동작/계약
+ * - `awaitSingleOrNull()`을 사용해 결과 부재를 `null`로 매핑합니다.
+ * - 일반적인 insert 성공 경로에서는 저장된 엔티티를 반환합니다.
+ *
+ * ```kotlin
+ * val saved = operations.insertOrNullSuspending(createPost())
+ * // saved?.id != null
+ * ```
  *
  * @param entity 저장할 엔티티
- * @return 저장된 엔티티 또는 null
  */
 suspend inline fun <reified T: Any> ReactiveInsertOperation.insertOrNullSuspending(entity: T): T? =
     insert<T>().using(entity).awaitSingleOrNull()
 
+/**
+ * [insertOrNullSuspending]의 이전 이름을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 구현은 [insertOrNullSuspending]으로 위임됩니다.
+ * - 결과가 비어 있으면 `null`을 반환합니다.
+ *
+ * ```kotlin
+ * val saved = operations.suspendInsertOrNull(createPost())
+ * // saved?.id != null
+ * ```
+ */
 @Deprecated(
     message = "insertOrNullSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("insertOrNullSuspending(entity)"),

--- a/spring/r2dbc/src/main/kotlin/io/bluetape4k/spring/r2dbc/coroutines/ReactiveSelectOperationExtensions.kt
+++ b/spring/r2dbc/src/main/kotlin/io/bluetape4k/spring/r2dbc/coroutines/ReactiveSelectOperationExtensions.kt
@@ -11,14 +11,34 @@ import org.springframework.data.r2dbc.core.select
 import org.springframework.data.relational.core.query.Query
 
 /**
- * [Query] 조건으로 존재 여부를 조회합니다.
+ * 조회 조건에 해당하는 엔티티의 존재 여부를 반환합니다.
+ *
+ * ## 동작/계약
+ * - `select<T>().matching(query).awaitExists()`로 위임합니다.
+ * - 수신 객체를 변경하지 않고 읽기 쿼리만 수행합니다.
+ *
+ * ```kotlin
+ * val exists = operations.existsSuspending<Post>(Query.empty())
+ * // exists == true
+ * ```
  *
  * @param query 조회 조건
- * @return 존재 여부
  */
 suspend inline fun <reified T: Any> R2dbcEntityOperations.existsSuspending(query: Query): Boolean =
     select<T>().matching(query).awaitExists()
 
+/**
+ * [existsSuspending]의 이전 이름을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 구현은 [existsSuspending]으로 위임됩니다.
+ * - 반환값 의미는 동일합니다.
+ *
+ * ```kotlin
+ * val exists = operations.suspendExists<Post>(Query.empty())
+ * // exists == true
+ * ```
+ */
 @Deprecated(
     message = "existsSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("existsSuspending<T>(query)"),
@@ -27,14 +47,34 @@ suspend inline fun <reified T: Any> R2dbcEntityOperations.suspendExists(query: Q
     existsSuspending<T>(query)
 
 /**
- * [Query] 조건의 건수를 조회합니다.
+ * 조회 조건에 해당하는 행 수를 반환합니다.
+ *
+ * ## 동작/계약
+ * - `awaitCount()` 결과를 그대로 반환합니다.
+ * - 조건에 맞는 데이터가 없으면 `0`을 반환합니다.
+ *
+ * ```kotlin
+ * val count = operations.countSuspending<Post>(Query.empty())
+ * // count >= 0L
+ * ```
  *
  * @param query 조회 조건
- * @return 조회된 건수
  */
 suspend inline fun <reified T: Any> R2dbcEntityOperations.countSuspending(query: Query): Long =
     select<T>().matching(query).awaitCount()
 
+/**
+ * [countSuspending]의 이전 이름을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 구현은 [countSuspending]에 위임됩니다.
+ * - 조건에 맞는 행 수를 그대로 반환합니다.
+ *
+ * ```kotlin
+ * val count = operations.suspendCount<Post>(Query.empty())
+ * // count >= 0L
+ * ```
+ */
 @Deprecated(
     message = "countSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("countSuspending<T>(query)"),
@@ -43,13 +83,32 @@ suspend inline fun <reified T: Any> R2dbcEntityOperations.suspendCount(query: Qu
     countSuspending<T>(query)
 
 /**
- * 전체 건수를 조회합니다.
+ * 전체 행 수를 조회합니다.
  *
- * @return 전체 건수
+ * ## 동작/계약
+ * - 내부적으로 `Query.empty()`를 사용해 [countSuspending]에 위임합니다.
+ * - 수신 객체를 변경하지 않습니다.
+ *
+ * ```kotlin
+ * val count = operations.countAllSuspending<Post>()
+ * // count >= 0L
+ * ```
  */
 suspend inline fun <reified T: Any> R2dbcEntityOperations.countAllSuspending(): Long =
     countSuspending<T>(Query.empty())
 
+/**
+ * [countAllSuspending]의 이전 이름을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 구현은 [countAllSuspending]으로 위임됩니다.
+ * - 전체 행 수를 반환합니다.
+ *
+ * ```kotlin
+ * val count = operations.suspendCountAll<Post>()
+ * // count >= 0L
+ * ```
+ */
 @Deprecated(
     message = "countAllSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("countAllSuspending<T>()"),
@@ -58,14 +117,34 @@ suspend inline fun <reified T: Any> R2dbcEntityOperations.suspendCountAll(): Lon
     countAllSuspending<T>()
 
 /**
- * [Query] 조건으로 조회한 결과를 [Flow]로 반환합니다.
+ * 조회 조건 결과를 [Flow]로 반환합니다.
+ *
+ * ## 동작/계약
+ * - Reactor Publisher를 코루틴 [Flow]로 어댑트하여 지연 수집합니다.
+ * - `Flow`를 수집할 때 SQL이 실행됩니다.
+ *
+ * ```kotlin
+ * val posts = operations.selectAllSuspending<Post>().toList()
+ * // posts.isNotEmpty() == true
+ * ```
  *
  * @param query 조회 조건
- * @return 조회된 엔티티 [Flow]
  */
 inline fun <reified T: Any> R2dbcEntityOperations.selectSuspending(query: Query): Flow<T> =
     select<T>().matching(query).flow()
 
+/**
+ * [selectSuspending]의 이전 이름을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 구현은 [selectSuspending]으로 위임됩니다.
+ * - Flow는 수집 시점에 실행됩니다.
+ *
+ * ```kotlin
+ * val posts = operations.suspendSelect<Post>(Query.empty()).toList()
+ * // posts.isNotEmpty() == true
+ * ```
+ */
 @Deprecated(
     message = "selectSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("selectSuspending<T>(query)"),
@@ -74,13 +153,32 @@ inline fun <reified T: Any> R2dbcEntityOperations.suspendSelect(query: Query): F
     selectSuspending<T>(query)
 
 /**
- * 모든 엔티티를 조회합니다.
+ * 전체 엔티티를 [Flow]로 조회합니다.
  *
- * @return 조회된 엔티티 [Flow]
+ * ## 동작/계약
+ * - `Query.empty()`로 전체 조회를 수행합니다.
+ * - 결과가 없으면 빈 `Flow`가 반환됩니다.
+ *
+ * ```kotlin
+ * val posts = operations.selectAllSuspending<Post>().toList()
+ * // posts.isNotEmpty() == true
+ * ```
  */
 inline fun <reified T: Any> R2dbcEntityOperations.selectAllSuspending(): Flow<T> =
     selectSuspending(Query.empty())
 
+/**
+ * [selectAllSuspending]의 이전 이름을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 구현은 [selectAllSuspending]으로 위임됩니다.
+ * - 전체 조회 결과를 Flow로 제공합니다.
+ *
+ * ```kotlin
+ * val posts = operations.suspendSelectAll<Post>().toList()
+ * // posts.isNotEmpty() == true
+ * ```
+ */
 @Deprecated(
     message = "selectAllSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("selectAllSuspending<T>()"),
@@ -89,14 +187,36 @@ inline fun <reified T: Any> R2dbcEntityOperations.suspendSelectAll(): Flow<T> =
     selectAllSuspending<T>()
 
 /**
- * [Query] 조건으로 단건을 조회합니다.
+ * 조회 조건에서 단건을 반환합니다.
+ *
+ * ## 동작/계약
+ * - 결과가 정확히 1건일 때만 값을 반환합니다.
+ * - 결과가 0건/복수 건이면 하위 API 예외가 전파됩니다.
+ *
+ * ```kotlin
+ * val post = operations.selectOneSuspending<Post>(Query.query(Criteria.where("id").isEqual(1L)))
+ * // post.id == 1L
+ * ```
  *
  * @param query 조회 조건
- * @return 조회된 엔티티
+ * @throws org.springframework.dao.IncorrectResultSizeDataAccessException 조회 결과가 단건이 아닐 때 발생할 수 있습니다.
  */
 suspend inline fun <reified T: Any> R2dbcEntityOperations.selectOneSuspending(query: Query): T =
     select<T>().matching(query).one().awaitSingle()
 
+/**
+ * [selectOneSuspending]의 이전 이름을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 구현은 [selectOneSuspending]으로 위임됩니다.
+ * - 단건이 아닐 때의 예외 계약도 동일합니다.
+ *
+ * ```kotlin
+ * val query = Query.empty()
+ * val post = operations.suspendSelectOne<Post>(query)
+ * // post.id != null
+ * ```
+ */
 @Deprecated(
     message = "selectOneSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("selectOneSuspending<T>(query)"),
@@ -105,14 +225,36 @@ suspend inline fun <reified T: Any> R2dbcEntityOperations.suspendSelectOne(query
     selectOneSuspending<T>(query)
 
 /**
- * [Query] 조건으로 단건을 조회하고 없으면 null을 반환합니다.
+ * 조회 조건에서 단건을 조회하고 없으면 `null`을 반환합니다.
+ *
+ * ## 동작/계약
+ * - 결과가 1건이면 해당 엔티티를 반환합니다.
+ * - 결과가 0건이면 `null`을 반환합니다.
+ * - 복수 건이면 하위 API 예외가 전파될 수 있습니다.
+ *
+ * ```kotlin
+ * val missing = operations.selectOneOrNullSuspending<Post>(Query.query(Criteria.where("id").isEqual(-1L)))
+ * // missing == null
+ * ```
  *
  * @param query 조회 조건
- * @return 조회된 엔티티 또는 null
  */
 suspend inline fun <reified T: Any> R2dbcEntityOperations.selectOneOrNullSuspending(query: Query): T? =
     select<T>().matching(query).one().awaitSingleOrNull()
 
+/**
+ * [selectOneOrNullSuspending]의 이전 이름을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 구현은 [selectOneOrNullSuspending]으로 위임됩니다.
+ * - 결과가 없으면 `null`을 반환합니다.
+ *
+ * ```kotlin
+ * val query = Query.empty()
+ * val post = operations.suspendSelectOneOrNull<Post>(query)
+ * // post == null
+ * ```
+ */
 @Deprecated(
     message = "selectOneOrNullSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("selectOneOrNullSuspending<T>(query)"),
@@ -121,14 +263,34 @@ suspend inline fun <reified T: Any> R2dbcEntityOperations.suspendSelectOneOrNull
     selectOneOrNullSuspending<T>(query)
 
 /**
- * [Query] 조건으로 첫 번째 엔티티를 조회합니다.
+ * 조회 조건에서 첫 번째 엔티티를 반환합니다.
+ *
+ * ## 동작/계약
+ * - 첫 번째 행만 소비하고 나머지는 무시합니다.
+ * - 결과가 없으면 하위 API에서 예외가 전파될 수 있습니다.
+ *
+ * ```kotlin
+ * val first = operations.selectFirstSuspending<Post>(Query.empty())
+ * // first.id != null
+ * ```
  *
  * @param query 조회 조건
- * @return 조회된 엔티티
  */
 suspend inline fun <reified T: Any> R2dbcEntityOperations.selectFirstSuspending(query: Query): T =
     select<T>().matching(query).first().awaitSingle()
 
+/**
+ * [selectFirstSuspending]의 이전 이름을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 구현은 [selectFirstSuspending]으로 위임됩니다.
+ * - 첫 번째 결과만 반환합니다.
+ *
+ * ```kotlin
+ * val first = operations.suspendSelectFirst<Post>(Query.empty())
+ * // first.id != null
+ * ```
+ */
 @Deprecated(
     message = "selectFirstSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("selectFirstSuspending<T>(query)"),
@@ -137,14 +299,35 @@ suspend inline fun <reified T: Any> R2dbcEntityOperations.suspendSelectFirst(que
     selectFirstSuspending<T>(query)
 
 /**
- * [Query] 조건으로 첫 번째 엔티티를 조회하고 없으면 null을 반환합니다.
+ * 조회 조건에서 첫 번째 엔티티를 조회하고 없으면 `null`을 반환합니다.
+ *
+ * ## 동작/계약
+ * - 첫 번째 행이 있으면 반환하고, 없으면 `null`을 반환합니다.
+ * - 단건 보장을 요구하지 않으며 첫 결과만 사용합니다.
+ *
+ * ```kotlin
+ * val first = operations.selectFirstOrNullSuspending<Post>(Query.query(Criteria.where("id").isEqual(-1L)))
+ * // first == null
+ * ```
  *
  * @param query 조회 조건
- * @return 조회된 엔티티 또는 null
  */
 suspend inline fun <reified T: Any> R2dbcEntityOperations.selectFirstOrNullSuspending(query: Query): T? =
     select<T>().matching(query).first().awaitSingleOrNull()
 
+/**
+ * [selectFirstOrNullSuspending]의 이전 이름을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 구현은 [selectFirstOrNullSuspending]으로 위임됩니다.
+ * - 결과가 없으면 `null`을 반환합니다.
+ *
+ * ```kotlin
+ * val query = Query.empty()
+ * val first = operations.suspendSelectFirstOrNull<Post>(query)
+ * // first == null
+ * ```
+ */
 @Deprecated(
     message = "selectFirstOrNullSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("selectFirstOrNullSuspending<T>(query)"),

--- a/spring/r2dbc/src/main/kotlin/io/bluetape4k/spring/r2dbc/coroutines/ReactiveUpdateOperationExtensions.kt
+++ b/spring/r2dbc/src/main/kotlin/io/bluetape4k/spring/r2dbc/coroutines/ReactiveUpdateOperationExtensions.kt
@@ -7,15 +7,37 @@ import org.springframework.data.relational.core.query.Query
 import org.springframework.data.relational.core.query.Update
 
 /**
- * [Query] 조건에 해당하는 엔티티를 갱신하고 갱신된 건수를 반환합니다.
+ * 갱신 조건에 맞는 엔티티를 업데이트하고 변경 건수를 반환합니다.
+ *
+ * ## 동작/계약
+ * - `update<T>().matching(query).apply(update)` 결과를 대기합니다.
+ * - 조건에 맞는 행이 없으면 `0`을 반환합니다.
+ * - [Update]는 호출자가 구성한 값을 그대로 사용합니다.
+ *
+ * ```kotlin
+ * val updated = operations.updateSuspending<Post>(query, Update.update("title", "Updated"))
+ * // updated == 1L
+ * ```
  *
  * @param query 갱신 조건
- * @param update 갱신할 값
- * @return 갱신된 건수
+ * @param update 반영할 컬럼 변경 값
  */
 suspend inline fun <reified T: Any> ReactiveUpdateOperation.updateSuspending(query: Query, update: Update): Long =
     update<T>().matching(query).apply(update).awaitSingle()
 
+/**
+ * [updateSuspending]의 이전 이름을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 구현은 [updateSuspending]으로 위임됩니다.
+ * - 반환값은 반영된 행 수입니다.
+ *
+ * ```kotlin
+ * val query = Query.empty()
+ * val updated = operations.suspendUpdate<Post>(query, Update.update("title", "Updated"))
+ * // updated == 1L
+ * ```
+ */
 @Deprecated(
     message = "updateSuspending으로 대체되었습니다.",
     replaceWith = ReplaceWith("updateSuspending<T>(query, update)"),

--- a/spring/retrofit2/src/main/kotlin/io/bluetape4k/spring/retrofit2/DefaultRetrofitClientConfiguration.kt
+++ b/spring/retrofit2/src/main/kotlin/io/bluetape4k/spring/retrofit2/DefaultRetrofitClientConfiguration.kt
@@ -22,12 +22,42 @@ import retrofit2.Converter
 import retrofit2.Retrofit
 import retrofit2.converter.jackson.JacksonConverterFactory
 
+/**
+ * Retrofit 클라이언트 컨텍스트에서 사용할 기본 빈 구성을 제공한다.
+ *
+ * ## 동작/계약
+ * - 모든 빈은 `@ConditionalOnMissingBean`을 사용해 사용자 정의 빈이 있으면 기본 빈을 대체하지 않는다.
+ * - Jackson converter, HTTP call factory, Vert.x client, Micrometer call adapter를 조건부로 등록한다.
+ * - 클래스 레벨에서 `Retrofit`과 `JacksonConverterFactory`가 클래스패스에 있을 때만 활성화된다.
+ *
+ * ```kotlin
+ * @Retrofit2Client(
+ *     name = "httpbin",
+ *     baseUrl = "\${bluetape4k.retrofit2.services.httpbin}",
+ *     configuration = [DefaultRetrofitClientConfiguration::class]
+ * )
+ * interface HttpbinApi
+ * ```
+ */
 @Configuration
 @ConditionalOnClass(Retrofit::class, JacksonConverterFactory::class)
 class DefaultRetrofitClientConfiguration {
 
     companion object: KLogging()
 
+    /**
+     * `JsonMapper`를 사용하는 Retrofit Jackson 변환기 팩토리를 생성한다.
+     *
+     * ## 동작/계약
+     * - `JsonMapper` 빈이 존재할 때만 등록된다.
+     * - 반환값은 `JacksonConverterFactory.create(jsonMapper)` 결과다.
+     *
+     * ```kotlin
+     * val mapper = Jackson.defaultJsonMapper
+     * val factory = JacksonConverterFactory.create(mapper)
+     * // factory != null
+     * ```
+     */
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnBean(JsonMapper::class)
@@ -36,12 +66,37 @@ class DefaultRetrofitClientConfiguration {
         return JacksonConverterFactory.create(jsonMapper)
     }
 
+    /**
+     * 기본 `JsonMapper` 빈을 제공한다.
+     *
+     * ## 동작/계약
+     * - 사용자 정의 `JsonMapper`가 없을 때만 등록된다.
+     * - `Jackson.defaultJsonMapper` 인스턴스를 그대로 반환한다.
+     *
+     * ```kotlin
+     * val mapper = Jackson.defaultJsonMapper
+     * // mapper != null
+     * ```
+     */
     @Bean
     @ConditionalOnMissingBean
     fun jsonMapper(): JsonMapper {
         return Jackson.defaultJsonMapper
     }
 
+    /**
+     * 주입된 `AsyncHttpClient`를 Retrofit `Call.Factory`로 감싼다.
+     *
+     * ## 동작/계약
+     * - `AsyncHttpClient` 빈과 `AsyncHttpClientCallFactory` 클래스가 모두 있을 때만 등록된다.
+     * - 전달받은 `asyncHttpClient`를 supplier로 고정해 call factory를 만든다.
+     *
+     * ```kotlin
+     * val ahc = Dsl.asyncHttpClient()
+     * val callFactory = asyncHttpClientCallFactory { httpClientSupplier { ahc } }
+     * // callFactory != null
+     * ```
+     */
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnBean(AsyncHttpClient::class)
@@ -53,6 +108,18 @@ class DefaultRetrofitClientConfiguration {
         }
     }
 
+    /**
+     * 기본 `AsyncHttpClient` 빈을 생성한다.
+     *
+     * ## 동작/계약
+     * - `AsyncHttpClient` 타입 빈이 없고 클래스패스에 타입이 존재할 때만 등록된다.
+     * - `Dsl.asyncHttpClient()`로 신규 클라이언트를 생성한다.
+     *
+     * ```kotlin
+     * val client = Dsl.asyncHttpClient()
+     * // client != null
+     * ```
+     */
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnClass(AsyncHttpClient::class)
@@ -61,6 +128,19 @@ class DefaultRetrofitClientConfiguration {
         return Dsl.asyncHttpClient()
     }
 
+    /**
+     * Vert.x `HttpClient`를 Retrofit `Call.Factory`로 변환한다.
+     *
+     * ## 동작/계약
+     * - Vert.x `HttpClient` 빈이 존재하고 `VertxCallFactory` 클래스가 있을 때만 등록된다.
+     * - `vertxCallFactoryOf(httpClient)` 결과를 그대로 반환한다.
+     *
+     * ```kotlin
+     * val httpClient = vertxHttpClientOf()
+     * val callFactory = vertxCallFactoryOf(httpClient)
+     * // callFactory != null
+     * ```
+     */
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnBean(io.vertx.core.http.HttpClient::class)
@@ -70,6 +150,18 @@ class DefaultRetrofitClientConfiguration {
         return vertxCallFactoryOf(httpClient)
     }
 
+    /**
+     * 기본 Vert.x `HttpClient` 빈을 생성한다.
+     *
+     * ## 동작/계약
+     * - Vert.x `HttpClient` 빈이 없고 관련 클래스가 클래스패스에 있을 때만 등록된다.
+     * - `vertxHttpClientOf()`로 새 인스턴스를 생성한다.
+     *
+     * ```kotlin
+     * val httpClient = vertxHttpClientOf()
+     * // httpClient != null
+     * ```
+     */
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnClass(io.vertx.core.http.HttpClient::class)
@@ -78,6 +170,19 @@ class DefaultRetrofitClientConfiguration {
         return vertxHttpClientOf()
     }
 
+    /**
+     * Micrometer 기반 Retrofit metrics call adapter factory를 등록한다.
+     *
+     * ## 동작/계약
+     * - `MeterRegistry` 빈과 `MicrometerRetrofitMetricsFactory` 클래스가 있을 때만 등록된다.
+     * - 생성된 factory는 Retrofit builder의 call adapter로 추가될 수 있다.
+     *
+     * ```kotlin
+     * val registry = io.micrometer.core.instrument.simple.SimpleMeterRegistry()
+     * val factory = MicrometerRetrofitMetricsFactory(registry)
+     * // factory != null
+     * ```
+     */
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnBean(MeterRegistry::class)

--- a/spring/retrofit2/src/main/kotlin/io/bluetape4k/spring/retrofit2/EnableRetrofitClients.kt
+++ b/spring/retrofit2/src/main/kotlin/io/bluetape4k/spring/retrofit2/EnableRetrofitClients.kt
@@ -5,7 +5,20 @@ import org.springframework.core.annotation.AliasFor
 import kotlin.reflect.KClass
 
 /**
- * [Retrofit2Client] annotation이 적용된 class를 scanning 해서 Retrofit Client로 빌드하고자 할 때 사용합니다.
+ * `@Retrofit2Client` 후보를 스캔해 Retrofit 클라이언트 빈 등록을 활성화한다.
+ *
+ * ## 동작/계약
+ * - `@Import(RetrofitClientsRegistrar::class)`를 통해 registrar가 동작한다.
+ * - `value`와 `basePackages`는 서로 alias이며 공백 패키지는 무시된다.
+ * - `basePackageClasses`가 지정되면 각 타입의 패키지를 스캔 대상으로 사용한다.
+ * - 모든 스캔 설정이 비어 있으면 이 애노테이션을 선언한 클래스의 패키지를 기본값으로 사용한다.
+ *
+ * ```kotlin
+ * @SpringBootApplication
+ * @EnableRetrofitClients(basePackageClasses = [HttpbinApi::class])
+ * class App
+ * // HttpbinApi 에 선언된 @Retrofit2Client 가 스캔 대상이 된다.
+ * ```
  */
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE)
@@ -13,30 +26,79 @@ import kotlin.reflect.KClass
 @Import(RetrofitClientsRegistrar::class)
 annotation class EnableRetrofitClients(
     /**
-     * Alias for [basePackages]
+     * [basePackages]의 별칭이다.
+     *
+     * ## 동작/계약
+     * - `@AliasFor("basePackages")`로 연결된다.
+     * - 공백 문자열은 스캔 패키지 계산에서 제외된다.
+     *
+     * ```kotlin
+     * @EnableRetrofitClients("io.bluetape4k.spring.retrofit2.services")
+     * class App
+     * // value 값이 basePackages로 해석된다.
+     * ```
      */
     @get:AliasFor("basePackages")
     val value: Array<String> = [],
 
     /**
-     * [Retrofit2Client] annotation이 적용된 class를 scan하기 위한 기본 class path를 나타냅니다.
+     * `@Retrofit2Client`를 스캔할 기본 패키지 목록을 지정한다.
+     *
+     * ## 동작/계약
+     * - `@AliasFor("value")`로 `value`와 동일한 속성이다.
+     * - 공백 항목은 제외되고 유효한 패키지만 registrar에 전달된다.
+     *
+     * ```kotlin
+     * @EnableRetrofitClients(basePackages = ["io.bluetape4k.spring.retrofit2.services.httpbin"])
+     * class App
+     * // 지정한 패키지에서만 클라이언트 후보를 찾는다.
+     * ```
      */
     @get:AliasFor("value")
     val basePackages: Array<String> = [],
 
     /**
-     * [Retrofit2Client] annotation이 적용된 class를 scan하기 위한 기본 class path를 나타냅니다.
+     * 지정한 타입들의 패키지를 스캔 기준으로 사용한다.
+     *
+     * ## 동작/계약
+     * - 각 클래스에 대해 `ClassUtils.getPackageName` 결과를 수집한다.
+     * - `value`/`basePackages`와 함께 합집합으로 처리된다.
+     *
+     * ```kotlin
+     * @EnableRetrofitClients(basePackageClasses = [HttpbinApi::class])
+     * class App
+     * // HttpbinApi 패키지가 스캔 대상에 추가된다.
+     * ```
      */
     val basePackageClasses: Array<KClass<*>> = [],
 
     /**
-     * 모든 Retrofit Clients에게 적용될 기본 `@Configuration` 를 지정하며,
-     * 이 Configuration은 Retrofit Client를 구성하기 위한 Bean이 정의되어야 한다.
+     * 모든 Retrofit 클라이언트에 공통으로 적용할 기본 설정 클래스를 지정한다.
+     *
+     * ## 동작/계약
+     * - 지정한 설정 타입 배열은 `RetrofitClientSpecification` 등록 시 기본 설정으로 사용된다.
+     * - 개별 `@Retrofit2Client(configuration = ...)` 설정과 함께 컨텍스트 구성에 반영된다.
+     *
+     * ```kotlin
+     * @EnableRetrofitClients(defaultConfiguration = [DefaultRetrofitClientConfiguration::class])
+     * class App
+     * // 모든 클라이언트 컨텍스트가 기본 설정을 공유한다.
+     * ```
      */
     val defaultConfiguration: Array<KClass<*>> = [],
 
     /**
-     * [Retrofit2Client] annotation이 적용된 class의 배열, 이 값이 지정되면 classpath scanning은 하지 않습니다.
+     * 직접 등록할 `@Retrofit2Client` 타입을 지정한다.
+     *
+     * ## 동작/계약
+     * - 이 속성은 현재 registrar 구현에서 스캔 대체 로직으로 사용되지 않는다.
+     * - 클라이언트 등록은 패키지 스캔 결과에 따라 결정된다.
+     *
+     * ```kotlin
+     * @EnableRetrofitClients(clients = [HttpbinApi::class])
+     * class App
+     * // 현재 구현에서는 clients 값만으로 등록되지 않는다.
+     * ```
      */
     val clients: Array<KClass<*>> = [],
 )

--- a/spring/retrofit2/src/main/kotlin/io/bluetape4k/spring/retrofit2/Retrofit2Client.kt
+++ b/spring/retrofit2/src/main/kotlin/io/bluetape4k/spring/retrofit2/Retrofit2Client.kt
@@ -4,6 +4,22 @@ import org.springframework.core.annotation.AliasFor
 import org.springframework.stereotype.Service
 import kotlin.reflect.KClass
 
+/**
+ * Retrofit 서비스 인터페이스를 Spring 빈으로 등록하기 위한 선언 애노테이션이다.
+ *
+ * ## 동작/계약
+ * - `@Service` 메타 애노테이션으로 컴포넌트 스캔 대상이 된다.
+ * - `RetrofitClientsRegistrar`가 이 애노테이션 메타데이터(`name`, `baseUrl`, `configuration`)를 읽어 FactoryBean을 등록한다.
+ * - 실제 Retrofit 인스턴스 생성은 `RetrofitClientFactoryBean`에서 수행된다.
+ *
+ * ```kotlin
+ * @Retrofit2Client(
+ *     name = "httpbin",
+ *     baseUrl = "\${bluetape4k.retrofit2.services.httpbin}"
+ * )
+ * interface HttpbinApi
+ * ```
+ */
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE)
 @MustBeDocumented
@@ -11,31 +27,91 @@ import kotlin.reflect.KClass
 annotation class Retrofit2Client(
 
     /**
-     * Retrofit2 Client의 Identifier에 해당 ([name] 과 같다)
-     * 스프링 환경설정이나 시스템 설정에서 값을 가져올 때에는 `value=\${property.key}` 처럼 지정할 수 있다.
+     * 클라이언트 식별자이며 [name]과 같은 속성이다.
+     *
+     * ## 동작/계약
+     * - `@AliasFor("name")`로 [name]과 동일 값으로 처리된다.
+     * - 빈 이름과 named context 식별자 계산에 사용된다.
+     *
+     * ```kotlin
+     * @Retrofit2Client(
+     *     value = "jsonPlaceHolderApi",
+     *     baseUrl = "\${bluetape4k.retrofit2.services.jsonPlaceHolder}"
+     * )
+     * interface JsonPlaceHolderApi
+     * ```
      */
     @get:AliasFor("name")
     val value: String = "",
 
     /**
-     * [value]와 같다.
+     * [value]의 별칭이다.
+     *
+     * ## 동작/계약
+     * - `@AliasFor("value")`로 연결된다.
+     * - registrar는 `name` 속성 값을 기준으로 bean definition 이름을 등록한다.
+     *
+     * ```kotlin
+     * @Retrofit2Client(
+     *     name = "httpbin",
+     *     baseUrl = "\${bluetape4k.retrofit2.services.httpbin}"
+     * )
+     * interface HttpbinApi
+     * ```
      */
     @get:AliasFor("value")
     val name: String = "",
 
     /**
-     * 스프링의 [org.springframework.beans.factory.annotation.Qualifier] annotation을 쓸 경우에 지정
+     * 스프링 `@Qualifier`와 함께 사용할 구분 이름이다.
+     *
+     * ## 동작/계약
+     * - 현재 registrar/factory 구현에서는 qualifier 값을 읽거나 빈 등록에 사용하지 않는다.
+     * - 애노테이션 메타데이터로만 보존된다.
+     *
+     * ```kotlin
+     * @Retrofit2Client(
+     *     name = "httpbin",
+     *     qualifier = "external-http",
+     *     baseUrl = "\${bluetape4k.retrofit2.services.httpbin}"
+     * )
+     * interface HttpbinApi
+     * ```
      */
     val qualifier: String = "",
 
     /**
-     * 호출할 REST API의 Base URL
+     * 호출 대상 REST API의 Base URL을 지정한다.
+     *
+     * ## 동작/계약
+     * - `Retrofit.Builder().baseUrl(baseUrl)`에 그대로 전달된다.
+     * - `RetrofitClientFactoryBean.afterPropertiesSet()`에서 빈 문자열 여부를 검증한다.
+     *
+     * ```kotlin
+     * @Retrofit2Client(
+     *     name = "jsonPlaceHolderApi",
+     *     baseUrl = "\${bluetape4k.retrofit2.services.jsonPlaceHolder}"
+     * )
+     * interface JsonPlaceHolderApi
+     * ```
      */
     val baseUrl: String = "",
 
     /**
-     * Retrofit2 Client를 위한 사용자 정의 [org.springframework.context.annotation.Configuration] 입니다.
-     * 시스템의 기본 설정 이외에 추가 설정할 수 있게 해줍니다.
+     * 클라이언트 전용 Spring 설정 클래스를 추가한다.
+     *
+     * ## 동작/계약
+     * - registrar가 `RetrofitClientSpecification(name, configuration)`으로 등록한다.
+     * - `RetrofitClientContext`에서 named child context를 만들 때 해당 설정이 적용된다.
+     *
+     * ```kotlin
+     * @Retrofit2Client(
+     *     name = "httpbin",
+     *     baseUrl = "\${bluetape4k.retrofit2.services.httpbin}",
+     *     configuration = [DefaultRetrofitClientConfiguration::class]
+     * )
+     * interface HttpbinApi
+     * ```
      */
     val configuration: Array<KClass<*>> = [],
 )

--- a/spring/retrofit2/src/main/kotlin/io/bluetape4k/spring/retrofit2/RetrofitAutoConfiguration.kt
+++ b/spring/retrofit2/src/main/kotlin/io/bluetape4k/spring/retrofit2/RetrofitAutoConfiguration.kt
@@ -7,6 +7,21 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import retrofit2.Retrofit
 
+/**
+ * Spring Boot 환경에서 Retrofit 클라이언트 인프라 빈을 자동 등록한다.
+ *
+ * ## 동작/계약
+ * - `Retrofit` 클래스가 클래스패스에 있을 때만 활성화된다.
+ * - 내부 `RetrofitClientConfiguration`이 `@EnableRetrofitClients`를 통해 client registrar를 켠다.
+ * - `retrofitContext` 빈은 수집된 `RetrofitClientSpecification` 목록을 context에 반영한다.
+ *
+ * ```kotlin
+ * val context = RetrofitClientContext()
+ * val specs = listOf(RetrofitClientSpecification("httpbin", emptyArray()))
+ * context.setConfigurations(specs)
+ * // context.configurations.containsKey("httpbin") == true
+ * ```
+ */
 @Configuration
 @ConditionalOnClass(Retrofit::class)
 class RetrofitAutoConfiguration {
@@ -15,9 +30,36 @@ class RetrofitAutoConfiguration {
 
     @Configuration
     @EnableRetrofitClients
+    /**
+     * Retrofit 클라이언트 스캔을 활성화하는 내부 설정 클래스다.
+     *
+     * ## 동작/계약
+     * - `@EnableRetrofitClients` 메타데이터만 제공하며 별도 빈을 선언하지 않는다.
+     * - 실제 등록 로직은 `RetrofitClientsRegistrar`에서 처리한다.
+     *
+     * ```kotlin
+     * @Configuration
+     * @EnableRetrofitClients
+     * class RetrofitClientConfiguration
+     * // registrar가 @Retrofit2Client 인터페이스를 스캔한다.
+     * ```
+     */
     class RetrofitClientConfiguration
 
     @Bean
+    /**
+     * Retrofit 클라이언트용 named context 팩토리를 생성한다.
+     *
+     * ## 동작/계약
+     * - `specs`가 null이 아니면 `setConfigurations(specs)`를 호출해 명세를 등록한다.
+     * - `specs`가 null이면 기본 설정만 가진 빈 컨텍스트를 반환한다.
+     *
+     * ```kotlin
+     * val specs = listOf(RetrofitClientSpecification("httpbin", emptyArray()))
+     * val context = RetrofitClientContext().apply { setConfigurations(specs) }
+     * // context.configurations.size == 1
+     * ```
+     */
     fun retrofitContext(specs: List<RetrofitClientSpecification>?): RetrofitClientContext {
         log.debug { "Create RetrofitClientContext ... specs=$specs" }
 

--- a/spring/retrofit2/src/main/kotlin/io/bluetape4k/spring/retrofit2/RetrofitClientContext.kt
+++ b/spring/retrofit2/src/main/kotlin/io/bluetape4k/spring/retrofit2/RetrofitClientContext.kt
@@ -3,7 +3,19 @@ package io.bluetape4k.spring.retrofit2
 import org.springframework.cloud.context.named.NamedContextFactory
 
 /**
- * Retrofit2 Client를 위한 환경설정 정보를 담은 Context
+ * Retrofit 클라이언트별 자식 애플리케이션 컨텍스트를 관리한다.
+ *
+ * ## 동작/계약
+ * - `NamedContextFactory`를 상속해 `RetrofitClientSpecification` 목록으로 named context를 생성한다.
+ * - 기본 설정 타입은 [DefaultRetrofitClientConfiguration]이다.
+ * - 클라이언트 이름 해석용 프로퍼티 키로 `retrofit2.client.name`을 사용한다.
+ *
+ * ```kotlin
+ * val context = RetrofitClientContext()
+ * context.setConfigurations(listOf(RetrofitClientSpecification("httpbin", emptyArray())))
+ * val hasConfig = context.configurations.containsKey("httpbin")
+ * // hasConfig == true
+ * ```
  */
 class RetrofitClientContext: NamedContextFactory<RetrofitClientSpecification>(
     DefaultRetrofitClientConfiguration::class.java,

--- a/spring/retrofit2/src/main/kotlin/io/bluetape4k/spring/retrofit2/RetrofitClientFactoryBean.kt
+++ b/spring/retrofit2/src/main/kotlin/io/bluetape4k/spring/retrofit2/RetrofitClientFactoryBean.kt
@@ -21,13 +21,79 @@ import retrofit2.CallAdapter
 import retrofit2.Converter
 import retrofit2.Retrofit
 
+/**
+ * `@Retrofit2Client` 메타데이터를 기반으로 Retrofit 서비스 프록시를 생성하는 FactoryBean이다.
+ *
+ * ## 동작/계약
+ * - `baseUrl`과 `type`으로 `Retrofit.Builder`를 생성한 뒤 대상 인터페이스 프록시를 반환한다.
+ * - `RetrofitClientContext`에서 이름별 `OkHttpClient` 또는 `Call.Factory`를 조회해 우선 적용한다.
+ * - `Call.Factory`가 없으면 Vert.x 클래스 존재 여부를 확인해 Vert.x 또는 AsyncHttpClient 기반 기본 factory를 생성한다.
+ * - `afterPropertiesSet()`에서 `ctx`, `type`, `name`, `baseUrl`을 검증하며 공백 값이면 예외를 던진다.
+ *
+ * ```kotlin
+ * val factory = RetrofitClientFactoryBean().apply {
+ *     type = HttpbinApi::class.java
+ *     name = "httpbin"
+ *     baseUrl = "https://localhost/"
+ * }
+ * // afterPropertiesSet() 이후 getObject()는 HttpbinApi 프록시를 반환한다.
+ * ```
+ */
 class RetrofitClientFactoryBean: FactoryBean<Any?>, ApplicationContextAware, InitializingBean {
 
     companion object: KLogging()
 
+    /**
+     * 생성할 Retrofit 서비스 인터페이스 타입이다.
+     *
+     * ## 동작/계약
+     * - `Retrofit.create(type)`에 전달된다.
+     * - 초기화 단계에서 null 여부를 검증한다.
+     *
+     * ```kotlin
+     * factory.type = HttpbinApi::class.java
+     * // getObjectType() == HttpbinApi::class.java
+     * ```
+     */
     var type: Class<*> = uninitialized()
+    /**
+     * Retrofit 클라이언트 이름이다.
+     *
+     * ## 동작/계약
+     * - `RetrofitClientContext`에서 이름 기반 빈 조회 키로 사용된다.
+     * - 초기화 단계에서 공백 문자열 여부를 검증한다.
+     *
+     * ```kotlin
+     * factory.name = "jsonPlaceHolderApi"
+     * // named context 조회 키로 사용된다.
+     * ```
+     */
     var name: String = uninitialized()
+    /**
+     * Retrofit builder에 전달할 base URL이다.
+     *
+     * ## 동작/계약
+     * - `Retrofit.Builder().baseUrl(baseUrl)`에 그대로 전달된다.
+     * - 초기화 단계에서 공백 문자열 여부를 검증한다.
+     *
+     * ```kotlin
+     * factory.baseUrl = "https://jsonplaceholder.typicode.com/"
+     * // Retrofit builder baseUrl 설정값이 된다.
+     * ```
+     */
     var baseUrl: String = uninitialized()
+    /**
+     * `RetrofitClientContext`를 조회할 Spring `ApplicationContext`다.
+     *
+     * ## 동작/계약
+     * - `setApplicationContext`에서 주입된다.
+     * - `getObject()` 호출 시 `RetrofitClientContext` 빈을 조회하는 데 사용된다.
+     *
+     * ```kotlin
+     * factory.setApplicationContext(applicationContext)
+     * // factory.ctx 로 context가 보관된다.
+     * ```
+     */
     var ctx: ApplicationContext = uninitialized()
 
     override fun getObject(): Any? {

--- a/spring/retrofit2/src/main/kotlin/io/bluetape4k/spring/retrofit2/RetrofitClientSpecification.kt
+++ b/spring/retrofit2/src/main/kotlin/io/bluetape4k/spring/retrofit2/RetrofitClientSpecification.kt
@@ -2,6 +2,22 @@ package io.bluetape4k.spring.retrofit2
 
 import org.springframework.cloud.context.named.NamedContextFactory
 
+/**
+ * 특정 Retrofit 클라이언트 이름에 매핑될 설정 클래스 배열을 담는 명세 객체다.
+ *
+ * ## 동작/계약
+ * - `NamedContextFactory.Specification` 구현체로서 `getName()`과 `getConfiguration()` 값을 그대로 반환한다.
+ * - [RetrofitClientsRegistrar]가 클라이언트별 설정 빈을 등록할 때 생성한다.
+ * - [RetrofitClientContext]가 named context를 만들 때 이 값을 사용한다.
+ *
+ * ```kotlin
+ * val spec = RetrofitClientSpecification(
+ *     "jsonPlaceHolderApi",
+ *     arrayOf(DefaultRetrofitClientConfiguration::class.java)
+ * )
+ * // spec.getName() == "jsonPlaceHolderApi"
+ * ```
+ */
 class RetrofitClientSpecification(
     private val name: String,
     private val configs: Array<Class<*>>,

--- a/spring/retrofit2/src/main/kotlin/io/bluetape4k/spring/retrofit2/RetrofitClientsRegistrar.kt
+++ b/spring/retrofit2/src/main/kotlin/io/bluetape4k/spring/retrofit2/RetrofitClientsRegistrar.kt
@@ -13,7 +13,18 @@ import org.springframework.core.type.filter.AnnotationTypeFilter
 import org.springframework.util.ClassUtils
 
 /**
- * [Retrofit2Client] annotation이 적용된 class를 Retrofit Client로 만들어 Spring Bean으로 등록합니다.
+ * `@EnableRetrofitClients` 메타데이터를 읽어 `@Retrofit2Client` 인터페이스를 Spring 빈 정의로 등록한다.
+ *
+ * ## 동작/계약
+ * - `ClassPathScanningCandidateComponentProvider`로 독립 클래스이면서 애노테이션 타입이 아닌 후보만 스캔한다.
+ * - 각 후보의 `name`, `baseUrl`, `configuration` 속성으로 `RetrofitClientFactoryBean` 정의와 `RetrofitClientSpecification` 정의를 함께 등록한다.
+ * - 스캔 패키지는 `value`, `basePackages`, `basePackageClasses` 합집합이며 비어 있으면 importing 클래스의 패키지를 사용한다.
+ *
+ * ```kotlin
+ * @EnableRetrofitClients(basePackageClasses = [HttpbinApi::class])
+ * class RetrofitClientApp
+ * // registrar가 HttpbinApi 메타데이터를 읽어 FactoryBean 정의를 등록한다.
+ * ```
  */
 class RetrofitClientsRegistrar: ImportBeanDefinitionRegistrar {
 

--- a/spring/tests/src/main/kotlin/io/bluetape4k/spring/tests/RestClientExtensions.kt
+++ b/spring/tests/src/main/kotlin/io/bluetape4k/spring/tests/RestClientExtensions.kt
@@ -8,6 +8,15 @@ import org.springframework.web.client.RestClient
 /**
  * GET 요청을 전송하고 [RestClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - [accept]가 지정되면 `Accept` 헤더를 설정합니다.
+ * - 응답 본문/예외 평가는 `body()`, `toEntity()` 호출 시 수행됩니다.
+ *
+ * ```kotlin
+ * val body = client.httpGet("/get").body<String>()
+ * // body?.contains("/get") == true
+ * ```
+ *
  * @param uri 요청 URI
  * @param accept 수신할 미디어 타입
  */
@@ -23,6 +32,15 @@ fun RestClient.httpGet(
 /**
  * HEAD 요청을 전송하고 [RestClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - `HEAD` 요청으로 상태/헤더 검증에 사용합니다.
+ * - 본문은 일반적으로 비어 있습니다.
+ *
+ * ```kotlin
+ * val status = client.httpHead("/get").toBodilessEntity().statusCode
+ * // status.is2xxSuccessful == true
+ * ```
+ *
  * @param uri 요청 URI
  * @param accept 수신할 미디어 타입
  */
@@ -37,6 +55,15 @@ fun RestClient.httpHead(
 
 /**
  * POST 요청을 전송하고 [RestClient.ResponseSpec]를 반환합니다.
+ *
+ * ## 동작/계약
+ * - [value]가 `null`이 아닐 때만 요청 바디를 설정합니다.
+ * - [contentType], [accept]는 제공된 경우에만 반영됩니다.
+ *
+ * ```kotlin
+ * val body = client.httpPost("/post", "hello").body<String>()
+ * // body?.contains("hello") == true
+ * ```
  *
  * @param uri 요청 URI
  * @param value 요청 바디
@@ -61,6 +88,15 @@ fun RestClient.httpPost(
 /**
  * POST 요청을 전송하고 [RestClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - [publisher]를 요청 바디로 설정합니다.
+ * - 제네릭 [T]는 바디 element type 추론에 사용됩니다.
+ *
+ * ```kotlin
+ * val response = client.httpPost("/post", Flux.just("a", "b")).body<String>()
+ * // response?.contains("/post") == true
+ * ```
+ *
  * @param uri 요청 URI
  * @param publisher 요청 바디 Publisher
  * @param contentType 요청 바디 타입
@@ -84,6 +120,15 @@ inline fun <reified T: Any> RestClient.httpPost(
 /**
  * POST 요청을 전송하고 [RestClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - [flow]를 요청 바디로 전송합니다.
+ * - 헤더는 `null`이 아닌 인자만 적용됩니다.
+ *
+ * ```kotlin
+ * val response = client.httpPost("/post", flowOf("a", "b")).body<String>()
+ * // response?.contains("/post") == true
+ * ```
+ *
  * @param uri 요청 URI
  * @param flow 요청 바디 Flow
  * @param contentType 요청 바디 타입
@@ -106,6 +151,15 @@ inline fun <reified T: Any> RestClient.httpPost(
 
 /**
  * PUT 요청을 전송하고 [RestClient.ResponseSpec]를 반환합니다.
+ *
+ * ## 동작/계약
+ * - [value]가 있으면 PUT 바디로 설정합니다.
+ * - 반환값은 후속 응답 디코딩 호출에 사용됩니다.
+ *
+ * ```kotlin
+ * val body = client.httpPut("/put", "hello").body<String>()
+ * // body?.contains("hello") == true
+ * ```
  *
  * @param uri 요청 URI
  * @param value 요청 바디
@@ -130,6 +184,15 @@ fun RestClient.httpPut(
 /**
  * PUT 요청을 전송하고 [RestClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - [publisher]를 PUT 요청 바디로 전달합니다.
+ * - content-type/accept는 선택 적용입니다.
+ *
+ * ```kotlin
+ * val body = client.httpPut("/put", Flux.just("x")).body<String>()
+ * // body?.contains("/put") == true
+ * ```
+ *
  * @param uri 요청 URI
  * @param publisher 요청 바디 Publisher
  * @param contentType 요청 바디 타입
@@ -152,6 +215,15 @@ inline fun <reified T: Any> RestClient.httpPut(
 
 /**
  * PUT 요청을 전송하고 [RestClient.ResponseSpec]를 반환합니다.
+ *
+ * ## 동작/계약
+ * - [flow]를 PUT 바디로 설정합니다.
+ * - 실제 전송/오류는 응답 소비 시점에 발생합니다.
+ *
+ * ```kotlin
+ * val body = client.httpPut("/put", flowOf("x")).body<String>()
+ * // body?.contains("/put") == true
+ * ```
  *
  * @param uri 요청 URI
  * @param flow 요청 바디 Flow
@@ -176,6 +248,15 @@ inline fun <reified T: Any> RestClient.httpPut(
 /**
  * PATCH 요청을 전송하고 [RestClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - [value]가 있을 때만 바디를 설정합니다.
+ * - 헤더 설정 규칙은 POST/PUT과 동일합니다.
+ *
+ * ```kotlin
+ * val body = client.httpPatch("/patch", "hello").body<String>()
+ * // body?.contains("hello") == true
+ * ```
+ *
  * @param uri 요청 URI
  * @param value 요청 바디
  * @param contentType 요청 바디 타입
@@ -199,6 +280,15 @@ fun RestClient.httpPatch(
 /**
  * DELETE 요청을 전송하고 [RestClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - 바디 없는 `DELETE` 요청을 전송합니다.
+ * - [accept]가 주어지면 응답 미디어 타입을 지정합니다.
+ *
+ * ```kotlin
+ * val body = client.httpDelete("/delete").body<String>()
+ * // body?.contains("/delete") == true
+ * ```
+ *
  * @param uri 요청 URI
  * @param accept 수신할 미디어 타입
  */
@@ -213,6 +303,15 @@ fun RestClient.httpDelete(
 
 /**
  * OPTIONS 요청을 전송하고 [RestClient.ResponseSpec]를 반환합니다.
+ *
+ * ## 동작/계약
+ * - 대상 URI의 OPTIONS 응답을 조회합니다.
+ * - [accept]가 있으면 `Accept` 헤더를 설정합니다.
+ *
+ * ```kotlin
+ * val entity = client.httpOptions("/get").toBodilessEntity()
+ * // entity.statusCode.is2xxSuccessful == true
+ * ```
  *
  * @param uri 요청 URI
  * @param accept 수신할 미디어 타입

--- a/spring/tests/src/main/kotlin/io/bluetape4k/spring/tests/WebClientExtensions.kt
+++ b/spring/tests/src/main/kotlin/io/bluetape4k/spring/tests/WebClientExtensions.kt
@@ -9,6 +9,16 @@ import org.springframework.web.reactive.function.client.body
 /**
  * GET 요청을 전송하고 [WebClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - `uri`를 그대로 사용해 `GET` 요청을 생성합니다.
+ * - [accept]가 `null`이면 `Accept` 헤더를 설정하지 않습니다.
+ * - 실제 HTTP 호출/예외는 이후 body 추출(`awaitBody` 등) 시점에 발생합니다.
+ *
+ * ```kotlin
+ * val body = client.httpGet("/get").awaitBody<String>()
+ * // body.contains("/get") == true
+ * ```
+ *
  * @param uri 요청 URI
  * @param accept 수신할 미디어 타입
  */
@@ -24,6 +34,15 @@ fun WebClient.httpGet(
 /**
  * HEAD 요청을 전송하고 [WebClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - `HEAD` 요청을 전송하며 응답 본문 없이 상태/헤더 검증에 사용합니다.
+ * - [accept]가 있으면 `Accept` 헤더를 설정합니다.
+ *
+ * ```kotlin
+ * val status = client.httpHead("/get").toBodilessEntity().statusCode
+ * // status.is2xxSuccessful == true
+ * ```
+ *
  * @param uri 요청 URI
  * @param accept 수신할 미디어 타입
  */
@@ -38,6 +57,15 @@ fun WebClient.httpHead(
 
 /**
  * POST 요청을 전송하고 [WebClient.ResponseSpec]를 반환합니다.
+ *
+ * ## 동작/계약
+ * - [value]가 `null`이 아니면 `bodyValue`로 요청 바디를 설정합니다.
+ * - [contentType], [accept]는 `null`이 아닐 때만 헤더로 반영됩니다.
+ *
+ * ```kotlin
+ * val body = client.httpPost("/post", "hello").awaitBody<String>()
+ * // body.contains("hello") == true
+ * ```
  *
  * @param uri 요청 URI
  * @param value 요청 바디
@@ -62,6 +90,15 @@ fun WebClient.httpPost(
 /**
  * POST 요청을 전송하고 [WebClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - [publisher]를 request body로 스트리밍합니다.
+ * - 제네릭 [T]는 `body(publisher)` element type 추론에 사용됩니다.
+ *
+ * ```kotlin
+ * val body = client.httpPost("/post", Flux.just("a", "b")).awaitBody<String>()
+ * // body.contains("/post") == true
+ * ```
+ *
  * @param uri 요청 URI
  * @param publisher 요청 바디 Publisher
  * @param contentType 요청 바디 타입
@@ -84,6 +121,15 @@ inline fun <reified T: Any> WebClient.httpPost(
 
 /**
  * POST 요청을 전송하고 [WebClient.ResponseSpec]를 반환합니다.
+ *
+ * ## 동작/계약
+ * - [flow]를 request body로 전송합니다.
+ * - [contentType], [accept]는 제공된 경우에만 설정됩니다.
+ *
+ * ```kotlin
+ * val body = client.httpPost("/post", flowOf("a", "b")).awaitBody<String>()
+ * // body.contains("/post") == true
+ * ```
  *
  * @param uri 요청 URI
  * @param flow 요청 바디 Flow
@@ -108,6 +154,15 @@ inline fun <reified T: Any> WebClient.httpPost(
 /**
  * PUT 요청을 전송하고 [WebClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - [value]가 있을 때만 바디를 설정합니다.
+ * - 요청 전송/오류는 응답 소비 시점에 평가됩니다.
+ *
+ * ```kotlin
+ * val body = client.httpPut("/put", "hello").awaitBody<String>()
+ * // body.contains("hello") == true
+ * ```
+ *
  * @param uri 요청 URI
  * @param value 요청 바디
  * @param contentType 요청 바디 타입
@@ -131,6 +186,15 @@ fun WebClient.httpPut(
 /**
  * PUT 요청을 전송하고 [WebClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - [publisher]를 PUT 바디로 전달합니다.
+ * - 요청 헤더는 `null`이 아닌 인자만 반영합니다.
+ *
+ * ```kotlin
+ * val body = client.httpPut("/put", Flux.just("x")).awaitBody<String>()
+ * // body.contains("/put") == true
+ * ```
+ *
  * @param uri 요청 URI
  * @param publisher 요청 바디 Publisher
  * @param contentType 요청 바디 타입
@@ -153,6 +217,15 @@ inline fun <reified T: Any> WebClient.httpPut(
 
 /**
  * PUT 요청을 전송하고 [WebClient.ResponseSpec]를 반환합니다.
+ *
+ * ## 동작/계약
+ * - [flow]를 바디로 전달합니다.
+ * - 반환 [WebClient.ResponseSpec]은 이후 체이닝(`onStatus`, `awaitBody`)에 사용됩니다.
+ *
+ * ```kotlin
+ * val body = client.httpPut("/put", flowOf("x")).awaitBody<String>()
+ * // body.contains("/put") == true
+ * ```
  *
  * @param uri 요청 URI
  * @param flow 요청 바디 Flow
@@ -178,6 +251,15 @@ inline fun <reified T: Any> WebClient.httpPut(
 /**
  * PATCH 요청을 전송하고 [WebClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - [value]가 있을 때만 PATCH 바디를 설정합니다.
+ * - [contentType], [accept]는 선택적으로 적용됩니다.
+ *
+ * ```kotlin
+ * val body = client.httpPatch("/patch", "hello").awaitBody<String>()
+ * // body.contains("hello") == true
+ * ```
+ *
  * @param uri 요청 URI
  * @param value 요청 바디
  * @param contentType 요청 바디 타입
@@ -201,6 +283,15 @@ fun WebClient.httpPatch(
 /**
  * DELETE 요청을 전송하고 [WebClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - 바디 없이 `DELETE` 요청을 전송합니다.
+ * - [accept]가 제공되면 `Accept` 헤더를 설정합니다.
+ *
+ * ```kotlin
+ * val body = client.httpDelete("/delete").awaitBody<String>()
+ * // body.contains("/delete") == true
+ * ```
+ *
  * @param uri 요청 URI
  * @param accept 수신할 미디어 타입
  */
@@ -215,6 +306,15 @@ fun WebClient.httpDelete(
 
 /**
  * OPTIONS 요청을 전송하고 [WebClient.ResponseSpec]를 반환합니다.
+ *
+ * ## 동작/계약
+ * - 대상 URI의 허용 메서드/옵션 확인용 요청입니다.
+ * - [accept]가 있으면 `Accept` 헤더를 설정합니다.
+ *
+ * ```kotlin
+ * val entity = client.httpOptions("/anything").toBodilessEntity()
+ * // entity.statusCode.is2xxSuccessful == true
+ * ```
  *
  * @param uri 요청 URI
  * @param accept 수신할 미디어 타입

--- a/spring/tests/src/main/kotlin/io/bluetape4k/spring/tests/WebTestClientExtensions.kt
+++ b/spring/tests/src/main/kotlin/io/bluetape4k/spring/tests/WebTestClientExtensions.kt
@@ -10,6 +10,15 @@ import org.springframework.test.web.reactive.server.body
 /**
  * GET 요청을 전송하고 [WebTestClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - 요청 후 즉시 `exchange()`를 호출해 검증 가능한 응답 스펙을 반환합니다.
+ * - [httpStatus]가 지정되면 상태 코드를 즉시 검증합니다.
+ *
+ * ```kotlin
+ * client.httpGet("/get", HttpStatus.OK)
+ *     .expectBody().jsonPath("$.url").exists()
+ * ```
+ *
  * @param uri 요청 URI
  * @param httpStatus 기대하는 상태 코드
  * @param accept 수신할 미디어 타입
@@ -30,6 +39,15 @@ fun WebTestClient.httpGet(
 /**
  * HEAD 요청을 전송하고 [WebTestClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - `HEAD` 요청 결과를 상태/헤더 검증에 사용합니다.
+ * - [httpStatus]가 있으면 `expectStatus().isEqualTo(...)`를 적용합니다.
+ *
+ * ```kotlin
+ * client.httpHead("/get", HttpStatus.OK)
+ *     .expectHeader().exists("Content-Type")
+ * ```
+ *
  * @param uri 요청 URI
  * @param httpStatus 기대하는 상태 코드
  * @param accept 수신할 미디어 타입
@@ -49,6 +67,15 @@ fun WebTestClient.httpHead(
 
 /**
  * POST 요청을 전송하고 [WebTestClient.ResponseSpec]를 반환합니다.
+ *
+ * ## 동작/계약
+ * - [value]가 `null`이 아니면 `bodyValue`로 전송합니다.
+ * - [contentType], [accept]는 `null`이 아닌 경우만 헤더에 반영됩니다.
+ *
+ * ```kotlin
+ * client.httpPost("/post", "Hello", HttpStatus.OK)
+ *     .expectBody().jsonPath("$.data").isEqualTo("Hello")
+ * ```
  *
  * @param uri 요청 URI
  * @param value 요청 바디
@@ -78,6 +105,15 @@ fun WebTestClient.httpPost(
 /**
  * POST 요청을 전송하고 [WebTestClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - [publisher]를 바디로 전송합니다.
+ * - [httpStatus]가 지정되면 응답 상태를 즉시 검증합니다.
+ *
+ * ```kotlin
+ * client.httpPost("/post", Flux.just("a"), HttpStatus.OK)
+ *     .expectBody().jsonPath("$.url").exists()
+ * ```
+ *
  * @param uri 요청 URI
  * @param publisher 요청 바디 Publisher
  * @param httpStatus 기대하는 상태 코드
@@ -105,6 +141,15 @@ inline fun <reified T: Any> WebTestClient.httpPost(
 
 /**
  * POST 요청을 전송하고 [WebTestClient.ResponseSpec]를 반환합니다.
+ *
+ * ## 동작/계약
+ * - [flow]를 바디로 전송합니다.
+ * - 이후 `expectBody` 체이닝으로 응답 본문 검증을 수행합니다.
+ *
+ * ```kotlin
+ * client.httpPost("/post", flowOf("a"), HttpStatus.OK)
+ *     .expectBody().jsonPath("$.url").exists()
+ * ```
  *
  * @param uri 요청 URI
  * @param flow 요청 바디 Flow
@@ -134,6 +179,15 @@ inline fun <reified T: Any> WebTestClient.httpPost(
 /**
  * PUT 요청을 전송하고 [WebTestClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - [value]가 제공되면 PUT 바디로 반영합니다.
+ * - 상태 검증은 [httpStatus]가 있을 때 즉시 수행됩니다.
+ *
+ * ```kotlin
+ * client.httpPut("/put", "Hello", HttpStatus.OK)
+ *     .expectBody().jsonPath("$.data").isEqualTo("Hello")
+ * ```
+ *
  * @param uri 요청 URI
  * @param value 요청 바디
  * @param httpStatus 기대하는 상태 코드
@@ -162,6 +216,15 @@ fun WebTestClient.httpPut(
 /**
  * PUT 요청을 전송하고 [WebTestClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - [publisher]를 PUT 바디로 사용합니다.
+ * - 미디어 타입 헤더는 선택적으로 적용됩니다.
+ *
+ * ```kotlin
+ * client.httpPut("/put", Flux.just("x"), HttpStatus.OK)
+ *     .expectBody().jsonPath("$.url").exists()
+ * ```
+ *
  * @param uri 요청 URI
  * @param publisher 요청 바디 Publisher
  * @param httpStatus 기대하는 상태 코드
@@ -189,6 +252,15 @@ inline fun <reified T: Any> WebTestClient.httpPut(
 
 /**
  * PUT 요청을 전송하고 [WebTestClient.ResponseSpec]를 반환합니다.
+ *
+ * ## 동작/계약
+ * - [flow]를 PUT 바디로 사용합니다.
+ * - 반환된 스펙에서 상태/본문 검증을 이어서 수행합니다.
+ *
+ * ```kotlin
+ * client.httpPut("/put", flowOf("x"), HttpStatus.OK)
+ *     .expectBody().jsonPath("$.url").exists()
+ * ```
  *
  * @param uri 요청 URI
  * @param flow 요청 바디 Flow
@@ -219,6 +291,15 @@ inline fun <reified T: Any> WebTestClient.httpPut(
 /**
  * PATCH 요청을 전송하고 [WebTestClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - [value]가 있을 때만 PATCH 바디를 설정합니다.
+ * - [httpStatus] 검증은 선택 적용입니다.
+ *
+ * ```kotlin
+ * client.httpPatch("/patch", "Hello", HttpStatus.OK)
+ *     .expectBody().jsonPath("$.data").isEqualTo("Hello")
+ * ```
+ *
  * @param uri 요청 URI
  * @param value 요청 바디
  * @param httpStatus 기대하는 상태 코드
@@ -248,6 +329,15 @@ fun WebTestClient.httpPatch(
 /**
  * DELETE 요청을 전송하고 [WebTestClient.ResponseSpec]를 반환합니다.
  *
+ * ## 동작/계약
+ * - 바디 없이 삭제 요청을 전송합니다.
+ * - [httpStatus]가 주어지면 즉시 상태를 검증합니다.
+ *
+ * ```kotlin
+ * client.httpDelete("/delete", HttpStatus.OK)
+ *     .expectBody().jsonPath("$.url").exists()
+ * ```
+ *
  * @param uri 요청 URI
  * @param httpStatus 기대하는 상태 코드
  * @param accept 수신할 미디어 타입
@@ -267,6 +357,15 @@ fun WebTestClient.httpDelete(
 
 /**
  * OPTIONS 요청을 전송하고 [WebTestClient.ResponseSpec]를 반환합니다.
+ *
+ * ## 동작/계약
+ * - OPTIONS 요청 결과를 테스트 검증 체인으로 반환합니다.
+ * - [httpStatus] 지정 시 상태 코드를 즉시 검증합니다.
+ *
+ * ```kotlin
+ * client.httpOptions("/get", HttpStatus.OK)
+ *     .expectHeader().exists("Allow")
+ * ```
  *
  * @param uri 요청 URI
  * @param httpStatus 기대하는 상태 코드

--- a/spring/webflux/src/main/kotlin/io/bluetape4k/spring/webflux/config/AbstractWebClientConfig.kt
+++ b/spring/webflux/src/main/kotlin/io/bluetape4k/spring/webflux/config/AbstractWebClientConfig.kt
@@ -16,7 +16,17 @@ import reactor.netty.resources.LoopResources
 import java.time.Duration
 
 /**
- * [WebClient]를 Webflux 서버가 사용하는 ThreadPool을 사용하지 않고, 별도의 ThreadPool을 사용하도록 설정합니다.
+ * WebFlux 서버 기본 리소스와 분리된 Netty 루프/커넥터로 [WebClient]를 구성하는 추상 설정입니다.
+ *
+ * ## 동작/계약
+ * - [loopResources]와 [reactorResourceFactory]를 통해 `isUseGlobalResources = false`인 전용 Reactor 리소스를 사용합니다.
+ * - [reactorClientHttpConnector]는 [sslContext], [responseTimeout], [connectTimeoutMillis] 설정을 클라이언트에 반영합니다.
+ * - [exchangeStrategies]는 `defaultCodecs().maxInMemorySize(maxInMemorySize)`를 적용합니다.
+ *
+ * ```kotlin
+ * @Configuration
+ * class CustomWebClientConfig: AbstractWebClientConfig()
+ * ```
  *
  * 참고: [Configuring Spring WebFlux WebClient to use a custom thread pool](https://stackoverflow.com/questions/56764801/configuring-spring-webflux-webclient-to-use-a-custom-thread-pool)
  */
@@ -60,7 +70,16 @@ abstract class AbstractWebClientConfig {
             .build()
 
     /**
-     * 커스텀 [LoopResources]를 생성합니다.
+     * WebClient 전용 [LoopResources] 빈을 생성합니다.
+     *
+     * ## 동작/계약
+     * - [threadCount]가 0 이하이면 `IllegalArgumentException`을 발생시킵니다.
+     * - `LoopResources.create("web-client-thread-", -1, threadCount, true, true)`를 사용해 worker 수를 고정합니다.
+     *
+     * ```kotlin
+     * val loops = loopResources()
+     * // loops는 "web-client-thread-" 접두사를 사용하는 전용 루프다.
+     * ```
      */
     @Bean
     open fun loopResources(): LoopResources {
@@ -70,7 +89,17 @@ abstract class AbstractWebClientConfig {
     }
 
     /**
-     * 커스텀 [ReactorResourceFactory]를 생성합니다.
+     * 전용 루프 리소스를 사용하는 [ReactorResourceFactory] 빈을 생성합니다.
+     *
+     * ## 동작/계약
+     * - 전달받은 [LoopResources]를 팩토리에 주입합니다.
+     * - `isUseGlobalResources`를 `false`로 설정해 전역 Reactor 리소스를 사용하지 않습니다.
+     * - 종료 대기 시간은 [shutdownTimeout]으로 설정합니다.
+     *
+     * ```kotlin
+     * val factory = reactorResourceFactory(loopResources())
+     * // factory.isUseGlobalResources == false
+     * ```
      */
     @Bean
     open fun reactorResourceFactory(loopResources: LoopResources): ReactorResourceFactory {
@@ -84,7 +113,16 @@ abstract class AbstractWebClientConfig {
     }
 
     /**
-     * 커스텀 [ReactorClientHttpConnector]를 생성합니다.
+     * SSL/타임아웃/커넥션 옵션을 반영한 [ReactorClientHttpConnector] 빈을 생성합니다.
+     *
+     * ## 동작/계약
+     * - [sslContext] 결과를 `client.secure`에 적용합니다.
+     * - 응답 타임아웃은 [responseTimeout], 연결 타임아웃은 [connectTimeoutMillis]로 설정합니다.
+     * - 리소스 관리는 인자로 받은 [ReactorResourceFactory]에 위임됩니다.
+     *
+     * ```kotlin
+     * val connector = reactorClientHttpConnector(reactorResourceFactory(loopResources()))
+     * ```
      */
     @Bean
     open fun reactorClientHttpConnector(factory: ReactorResourceFactory): ReactorClientHttpConnector {
@@ -101,7 +139,15 @@ abstract class AbstractWebClientConfig {
     }
 
     /**
-     * 커스텀 [ExchangeStrategies]를 생성합니다.
+     * 최대 인메모리 버퍼 크기를 지정한 [ExchangeStrategies] 빈을 생성합니다.
+     *
+     * ## 동작/계약
+     * - `defaultCodecs().maxInMemorySize(maxInMemorySize)`를 적용합니다.
+     * - 인코더/디코더 기본 전략은 Spring 기본값을 유지하고 메모리 제한만 변경합니다.
+     *
+     * ```kotlin
+     * val strategies = exchangeStrategies()
+     * ```
      */
     @Bean
     open fun exchangeStrategies(): ExchangeStrategies {
@@ -114,7 +160,15 @@ abstract class AbstractWebClientConfig {
     }
 
     /**
-     * 커스텀 [WebClient]를 생성합니다.
+     * 지정한 커넥터와 코덱 전략을 사용해 [WebClient] 빈을 생성합니다.
+     *
+     * ## 동작/계약
+     * - [ReactorClientHttpConnector]와 [ExchangeStrategies]를 빌더에 그대로 연결합니다.
+     * - baseUrl, defaultHeader 같은 추가 설정은 이 메서드에서 적용하지 않습니다.
+     *
+     * ```kotlin
+     * val client = webClient(reactorClientHttpConnector(reactorResourceFactory(loopResources())), exchangeStrategies())
+     * ```
      */
     @Bean
     open fun webClient(connector: ReactorClientHttpConnector, exchangeStrategies: ExchangeStrategies): WebClient {

--- a/spring/webflux/src/main/kotlin/io/bluetape4k/spring/webflux/controller/AbstractCoroutineDefaultController.kt
+++ b/spring/webflux/src/main/kotlin/io/bluetape4k/spring/webflux/controller/AbstractCoroutineDefaultController.kt
@@ -6,7 +6,16 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 
 /**
- * [Dispatchers.Default] 를 사용하는 CoroutineScope 를 제공하는 Controller의 추상 클래스입니다.
+ * [Dispatchers.Default] 기반 [CoroutineScope]를 위임해 제공하는 WebFlux 컨트롤러 추상 클래스입니다.
+ *
+ * ## 동작/계약
+ * - 스코프는 `Dispatchers.Default + SupervisorJob()` 조합으로 생성됩니다.
+ * - CPU 중심 작업을 기본 Dispatcher에서 실행하도록 설계된 베이스 타입입니다.
+ * - `SupervisorJob`을 사용하므로 한 자식 코루틴 실패가 다른 자식 코루틴을 즉시 취소하지 않습니다.
+ *
+ * ```kotlin
+ * class ComputeController: AbstractCoroutineDefaultController()
+ * ```
  */
 abstract class AbstractCoroutineDefaultController:
     CoroutineScope by CoroutineScope(Dispatchers.Default + SupervisorJob()) {

--- a/spring/webflux/src/main/kotlin/io/bluetape4k/spring/webflux/controller/AbstractCoroutineIOController.kt
+++ b/spring/webflux/src/main/kotlin/io/bluetape4k/spring/webflux/controller/AbstractCoroutineIOController.kt
@@ -6,7 +6,16 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 
 /**
- * [Dispatchers.IO] 를 사용하는 CoroutineScope 를 제공하는 Controller의 추상 클래스입니다.
+ * [Dispatchers.IO] 기반 [CoroutineScope]를 위임해 제공하는 WebFlux 컨트롤러 추상 클래스입니다.
+ *
+ * ## 동작/계약
+ * - 스코프는 `Dispatchers.IO + SupervisorJob()` 조합으로 생성됩니다.
+ * - 형제 코루틴 중 하나가 실패해도 `SupervisorJob` 특성상 다른 자식 코루틴은 즉시 취소되지 않습니다.
+ * - 별도 취소 처리를 하지 않으면 스코프 생명주기는 인스턴스 생명주기를 따릅니다.
+ *
+ * ```kotlin
+ * class FileController: AbstractCoroutineIOController()
+ * ```
  */
 abstract class AbstractCoroutineIOController
     : CoroutineScope by CoroutineScope(Dispatchers.IO + SupervisorJob()) {

--- a/spring/webflux/src/main/kotlin/io/bluetape4k/spring/webflux/controller/AbstractCoroutineVTController.kt
+++ b/spring/webflux/src/main/kotlin/io/bluetape4k/spring/webflux/controller/AbstractCoroutineVTController.kt
@@ -7,7 +7,16 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 
 /**
- * [Dispatchers.VT] 를 사용하는 CoroutineScope 를 제공하는 Controller의 추상 클래스입니다.
+ * [Dispatchers.VT] 기반 [CoroutineScope]를 위임해 제공하는 WebFlux 컨트롤러 추상 클래스입니다.
+ *
+ * ## 동작/계약
+ * - 스코프는 `Dispatchers.VT + SupervisorJob()` 조합으로 생성됩니다.
+ * - `Dispatchers.VT`는 가상 스레드 실행기([VT])를 사용하도록 확장된 Dispatcher를 참조합니다.
+ * - `SupervisorJob`을 사용하므로 자식 코루틴 실패가 동일 스코프의 다른 자식 실패로 전파되지 않습니다.
+ *
+ * ```kotlin
+ * class BlockingBridgeController: AbstractCoroutineVTController()
+ * ```
  */
 abstract class AbstractCoroutineVTController
     : CoroutineScope by CoroutineScope(Dispatchers.VT + SupervisorJob()) {

--- a/spring/webflux/src/main/kotlin/io/bluetape4k/spring/webflux/filter/AbstractRedirectWebFilter.kt
+++ b/spring/webflux/src/main/kotlin/io/bluetape4k/spring/webflux/filter/AbstractRedirectWebFilter.kt
@@ -8,22 +8,20 @@ import org.springframework.web.server.WebFilterChain
 import reactor.core.publisher.Mono
 
 /**
- * 요청 Path를 redirect 합니다.
- * 보통 REST API Server의 root path를 redirect 해서 swagger page 로 redirect 할 때 사용할 수 있습니다.
+ * 요청 URI 경로가 [requestPath]와 일치할 때 요청 경로를 [redirectPath]로 치환해 다음 필터로 전달합니다.
  *
- * ```
+ * ## 동작/계약
+ * - 생성 시 `requestPath`, `redirectPath`는 `blank`를 허용하지 않으며, 위반 시 예외가 발생합니다.
+ * - [ServerWebExchange.request]의 `uri.path`가 [requestPath]와 정확히 같을 때만 경로를 바꾼 복제 요청을 사용합니다.
+ * - 경로가 다르면 원본 [ServerWebExchange]를 그대로 다음 체인에 전달합니다.
+ *
+ * ```kotlin
  * @Component
- * class RedirectToSwaggerWebFilter: AbstractRedirectWebFilter(SWAGGER_PATH, ROOT_PATH) {
- *
- *     companion object: KLogging() {
- *         const val ROOT_PATH = "/"
- *         const val SWAGGER_PATH = "/swagger-ui.html"
- *     }
- * }
+ * class RedirectToSwaggerWebFilter: AbstractRedirectWebFilter("/swagger-ui.html", "/")
  * ```
  *
- * @property requestPath    요청한 Path (ex: "/")
- * @property redirectPath redirect할 Path (ex: "/swagger-ui.html")
+ * @property requestPath 매칭할 요청 경로 (예: `/`)
+ * @property redirectPath 치환할 대상 경로 (예: `/swagger-ui.html`)
  */
 abstract class AbstractRedirectWebFilter(
     val redirectPath: String,
@@ -31,6 +29,9 @@ abstract class AbstractRedirectWebFilter(
 ): WebFilter {
 
     companion object: KLoggingChannel() {
+        /**
+         * 기본 매칭 요청 경로(`/`)입니다.
+         */
         const val ROOT_PATH = "/"
     }
 

--- a/spring/webflux/src/main/kotlin/io/bluetape4k/spring/webflux/filter/HttpRequestCapturer.kt
+++ b/spring/webflux/src/main/kotlin/io/bluetape4k/spring/webflux/filter/HttpRequestCapturer.kt
@@ -9,7 +9,17 @@ import org.springframework.web.server.WebFilterChain
 import reactor.core.publisher.Mono
 
 /**
- * Webflux 의 [ServerHttpRequest] 정보를 `ReactorContext` 에 보관해서 사용할 수 있는 [WebFilter] 구현체.
+ * 현재 요청을 Reactor Context에 저장해 다운스트림에서 조회할 수 있게 하는 [WebFilter]입니다.
+ *
+ * ## 동작/계약
+ * - `exchange.request.mutate().build()`로 요청 스냅샷을 만든 뒤 체인을 실행합니다.
+ * - 체인 실행 시 `contextWrite`로 `ServerHttpRequest::class.java` 키에 요청을 저장합니다.
+ * - 같은 키를 사용하는 [HttpRequestHolder]에서 요청을 조회할 수 있습니다.
+ *
+ * ```kotlin
+ * @Bean
+ * fun httpRequestCapturer(): WebFilter = HttpRequestCapturer()
+ * ```
  *
  * @see io.bluetape4k.spring.webflux.filter.HttpRequestHolder
  */

--- a/spring/webflux/src/main/kotlin/io/bluetape4k/spring/webflux/filter/HttpRequestHolder.kt
+++ b/spring/webflux/src/main/kotlin/io/bluetape4k/spring/webflux/filter/HttpRequestHolder.kt
@@ -5,23 +5,35 @@ import org.springframework.http.server.reactive.ServerHttpRequest
 import reactor.core.publisher.Mono
 
 /**
- * ReactorContext 에 보관된 [ServerHttpRequest] 정보를 가져오는 유틸리티.
- * HttpRequestCapturer 를 WebFilter로 등록해 놓으면, HttpRequestHoder에서 조회할 수 있다
+ * Reactor Context에 저장된 [ServerHttpRequest]를 조회하는 유틸리티입니다.
  *
- * @see io.bluetape4k.spring.webflux.filter.HttpRequestCapturer
+ * ## 동작/계약
+ * - 키는 `ServerHttpRequest::class.java`를 사용하며, [HttpRequestCapturer]가 같은 키로 저장한 값을 읽습니다.
+ * - 현재 구독 컨텍스트에 요청이 없으면 빈 `Mono`를 반환합니다.
+ * - 컨텍스트 접근은 `Mono.deferContextual`로 지연되어 구독 시점의 값을 사용합니다.
  *
  * ```kotlin
- * val request: ServerHttpRequest? = HttpRequestHolder.getHttpRequest().awaitSingleOrNull()
+ * val request = HttpRequestHolder.getHttpRequest().awaitSingleOrNull()
+ * // request == null (컨텍스트에 값이 없을 때)
  * ```
+ *
+ * @see io.bluetape4k.spring.webflux.filter.HttpRequestCapturer
  */
 object HttpRequestHolder: KLoggingChannel() {
 
     private val REQUEST_KEY = ServerHttpRequest::class.java
 
     /**
-     * ReactorContext에 저장된 [ServerHttpRequest]를 조회합니다.
+     * 현재 Reactor Context에서 [ServerHttpRequest]를 조회합니다.
      *
-     * @return [ServerHttpRequest]가 존재하면 Mono로 반환
+     * ## 동작/계약
+     * - 컨텍스트에 값이 있으면 해당 요청을 단일 값 `Mono`로 반환합니다.
+     * - 컨텍스트에 값이 없으면 완료만 발생하는 빈 `Mono`를 반환합니다.
+     *
+     * ```kotlin
+     * val mono = HttpRequestHolder.getHttpRequest()
+     * // mono는 컨텍스트 값이 있을 때만 onNext를 발생시킨다.
+     * ```
      */
     fun getHttpRequest(): Mono<ServerHttpRequest> {
         return Mono.deferContextual { cv ->

--- a/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/exceptions/InvalidTokenizeRequestException.kt
+++ b/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/exceptions/InvalidTokenizeRequestException.kt
@@ -1,11 +1,74 @@
 package io.bluetape4k.tokenizer.exceptions
 
 /**
- * Tokenizing 관련 요청이 잘못되었을 때 발생하는 예외
+ * 토크나이즈 요청의 입력 형식이나 값이 유효하지 않을 때 사용하는 예외 타입이다.
+ *
+ * ## 동작/계약
+ * - `TokenizerException`을 상속해 토크나이저 예외 계층에 포함된다.
+ * - 메시지/원인 조합 생성자를 제공해 검증 실패 맥락을 전달할 수 있다.
+ * - 요청 검증 계층에서 도메인 예외로 분리할 때 사용한다.
+ *
+ * ```kotlin
+ * val ex = InvalidTokenizeRequestException("text는 비어 있을 수 없습니다.")
+ * // ex is TokenizerException
+ * ```
  */
 open class InvalidTokenizeRequestException: TokenizerException {
+    /**
+     * 메시지와 원인 없이 예외를 생성한다.
+     *
+     * ## 동작/계약
+     * - 상위 기본 생성자를 호출한다.
+     * - 진단 정보가 없는 기본 인스턴스를 만든다.
+     *
+     * ```kotlin
+     * val ex = InvalidTokenizeRequestException()
+     * // ex.message == null
+     * ```
+     */
     constructor(): super()
+
+    /**
+     * 요청 검증 실패 메시지를 포함해 예외를 생성한다.
+     *
+     * ## 동작/계약
+     * - 전달한 메시지를 그대로 보관한다.
+     * - 원인 예외는 비워 둔다.
+     *
+     * ```kotlin
+     * val ex = InvalidTokenizeRequestException("locale 값이 잘못되었습니다.")
+     * // ex.message?.contains("locale") == true
+     * ```
+     */
     constructor(message: String): super(message)
+
+    /**
+     * 요청 검증 실패 메시지와 원인 예외를 함께 포함해 생성한다.
+     *
+     * ## 동작/계약
+     * - `message`, `cause`를 상위 생성자에 전달한다.
+     * - 파싱/검증 단계에서 발생한 원인 예외를 체인으로 유지한다.
+     *
+     * ```kotlin
+     * val cause = NumberFormatException("NaN")
+     * val ex = InvalidTokenizeRequestException("토큰 길이 파싱 실패", cause)
+     * // ex.cause == cause
+     * ```
+     */
     constructor(message: String, cause: Throwable?): super(message, cause)
+
+    /**
+     * 원인 예외만 포함해 예외를 생성한다.
+     *
+     * ## 동작/계약
+     * - 원인 예외를 상위 생성자에 그대로 전달한다.
+     * - 메시지는 원인 예외의 구현에 따라 결정된다.
+     *
+     * ```kotlin
+     * val cause = IllegalStateException("invalid request")
+     * val ex = InvalidTokenizeRequestException(cause)
+     * // ex.cause == cause
+     * ```
+     */
     constructor(cause: Throwable?): super(cause)
 }

--- a/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/exceptions/TokenizerException.kt
+++ b/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/exceptions/TokenizerException.kt
@@ -3,11 +3,74 @@ package io.bluetape4k.tokenizer.exceptions
 import io.bluetape4k.exceptions.BluetapeException
 
 /**
- * Tokenizer 모듈의 기본 예외
+ * 토크나이저 모듈 전반에서 공통 기반으로 사용하는 예외 타입이다.
+ *
+ * ## 동작/계약
+ * - `BluetapeException`을 상속해 상위 예외 처리 정책을 따른다.
+ * - 기본 생성자와 메시지/원인 조합 생성자를 모두 제공한다.
+ * - 모듈별 세부 예외는 이 타입을 상속해 분류한다.
+ *
+ * ```kotlin
+ * val ex = TokenizerException("tokenize 실패")
+ * // ex.message == "tokenize 실패"
+ * ```
  */
 open class TokenizerException: BluetapeException {
+    /**
+     * 메시지와 원인 없이 예외를 생성한다.
+     *
+     * ## 동작/계약
+     * - 상위 기본 생성자를 호출한다.
+     * - `message`와 `cause`는 `null` 상태다.
+     *
+     * ```kotlin
+     * val ex = TokenizerException()
+     * // ex.message == null
+     * ```
+     */
     constructor(): super()
+
+    /**
+     * 설명 메시지를 포함한 예외를 생성한다.
+     *
+     * ## 동작/계약
+     * - 전달한 `message`를 상위 예외에 그대로 저장한다.
+     * - 원인 예외는 설정하지 않는다.
+     *
+     * ```kotlin
+     * val ex = TokenizerException("잘못된 입력")
+     * // ex.message == "잘못된 입력"
+     * ```
+     */
     constructor(message: String): super(message)
+
+    /**
+     * 설명 메시지와 원인 예외를 함께 포함해 생성한다.
+     *
+     * ## 동작/계약
+     * - `message`와 `cause`를 상위 생성자에 그대로 전달한다.
+     * - 예외 체인 추적에 사용된다.
+     *
+     * ```kotlin
+     * val cause = IllegalArgumentException("invalid")
+     * val ex = TokenizerException("요청 오류", cause)
+     * // ex.cause == cause
+     * ```
+     */
     constructor(message: String, cause: Throwable?): super(message, cause)
+
+    /**
+     * 원인 예외만 포함해 생성한다.
+     *
+     * ## 동작/계약
+     * - 상위 `cause` 기반 생성자를 호출한다.
+     * - `message`는 원인 예외 정보에 따라 결정된다.
+     *
+     * ```kotlin
+     * val cause = RuntimeException("boom")
+     * val ex = TokenizerException(cause)
+     * // ex.cause == cause
+     * ```
+     */
     constructor(cause: Throwable?): super(cause)
 }

--- a/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/model/AbstractMessage.kt
+++ b/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/model/AbstractMessage.kt
@@ -3,12 +3,35 @@ package io.bluetape4k.tokenizer.model
 import java.io.Serializable
 
 /**
- * REST API 요청, 응답 Message의 최상위 추상화 클래스
+ * 토크나이저 요청/응답 메시지의 공통 타임스탬프를 제공하는 추상 타입이다.
+ *
+ * ## 동작/계약
+ * - 인스턴스 생성 시점의 `System.currentTimeMillis()` 값을 `timestamp`에 저장한다.
+ * - `timestamp`는 `val`이므로 생성 이후 변경되지 않는다.
+ * - 직렬화 가능한 메시지 계층을 위해 `Serializable`을 구현한다.
+ *
+ * ```kotlin
+ * val request = tokenizeRequestOf("안녕")
+ * val response = tokenizeResponseOf(request.text, listOf("안녕"))
+ * // request.timestamp > 0L
+ * // response.timestamp >= request.timestamp
+ * ```
  */
 abstract class AbstractMessage: Serializable {
 
     /**
-     * Message 생성 시각
+     * 메시지 인스턴스가 생성된 시각(밀리초 epoch)이다.
+     *
+     * ## 동작/계약
+     * - 객체 생성 시 한 번만 초기화된다.
+     * - 같은 인스턴스에서 반복 조회해도 값이 변하지 않는다.
+     *
+     * ```kotlin
+     * val message = tokenizeRequestOf("문장")
+     * val first = message.timestamp
+     * val second = message.timestamp
+     * // first == second
+     * ```
      */
     val timestamp: Long = System.currentTimeMillis()
 

--- a/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/model/BlockwordOptions.kt
+++ b/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/model/BlockwordOptions.kt
@@ -4,11 +4,19 @@ import java.io.Serializable
 import java.util.*
 
 /**
- * 금칙어 처리를 위한 옵션 정보
+ * 금칙어 마스킹과 판정 강도를 제어하는 요청 옵션이다.
  *
- * @property mask      금칙어를 mask 처리할 때 사용할 문자열 (기본값: *)
- * @property locale    [Locale] 정보 (기본값: [Locale.KOREAN])
- * @property severity  금칙어에 해당하는 수준 (심각도) (기본값: [Severity.DEFAULT] = [Severity.LOW])
+ * ## 동작/계약
+ * - 기본 마스크 문자열은 `*`이며 호출 측에서 다른 문자열로 교체할 수 있다.
+ * - 기본 로캘은 `Locale.KOREAN`으로 설정된다.
+ * - 기본 심각도는 `Severity.DEFAULT`(`LOW`)를 사용한다.
+ *
+ * ```kotlin
+ * val options = blockwordOptionsOf(mask = "#", severity = Severity.HIGH)
+ * // options.mask == "#"
+ * // options.locale == Locale.KOREAN
+ * // options.severity == Severity.HIGH
+ * ```
  */
 data class BlockwordOptions(
     val mask: String = "*",
@@ -16,16 +24,34 @@ data class BlockwordOptions(
     val severity: Severity = Severity.DEFAULT,
 ): Serializable {
     companion object {
+        /**
+         * 금칙어 처리 기본 옵션 인스턴스다.
+         *
+         * ## 동작/계약
+         * - `mask="*"`, `locale=Locale.KOREAN`, `severity=Severity.DEFAULT`를 사용한다.
+         * - 재사용 가능한 정적 기본값으로 제공된다.
+         *
+         * ```kotlin
+         * val defaults = BlockwordOptions.DEFAULT
+         * // defaults.mask == "*"
+         * // defaults.severity == Severity.LOW
+         * ```
+         */
         val DEFAULT = BlockwordOptions()
     }
 }
 
 /**
- * 금칙어 처리 옵션 정보를 생성한다.
+ * 금칙어 처리 옵션 인스턴스를 간단히 생성한다.
  *
- * @param mask      금칙어를 mask 처리할 때 사용할 문자열 (기본값: `*`)
- * @param locale    [Locale] 정보 (기본값: [Locale.KOREAN])
- * @param severity  금칙어에 해당하는 수준 (심각도) (기본값: [Severity.DEFAULT])
+ * ## 동작/계약
+ * - 전달한 `mask`, `locale`, `severity`를 그대로 `BlockwordOptions`에 담아 반환한다.
+ * - 인자를 생략하면 `BlockwordOptions.DEFAULT`와 동일한 기본값 조합이 적용된다.
+ *
+ * ```kotlin
+ * val options = blockwordOptionsOf()
+ * // options == BlockwordOptions.DEFAULT
+ * ```
  */
 fun blockwordOptionsOf(
     mask: String = "*",

--- a/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/model/BlockwordRequest.kt
+++ b/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/model/BlockwordRequest.kt
@@ -3,11 +3,18 @@ package io.bluetape4k.tokenizer.model
 import io.bluetape4k.support.requireNotBlank
 
 /**
- * 금칙어 처리를 위한 요청
+ * 금칙어 탐지/마스킹 처리를 요청하는 입력 모델이다.
  *
- * @property text 금칙어 처리 대상 문자열
- * @property options 금칙어 처리를 위한 옵션 정보
- * @property requestTimestamp 요청 생성 시각
+ * ## 동작/계약
+ * - 생성 시 `text.requireNotBlank("text")`를 검사해 공백 문자열 요청을 거부한다.
+ * - `options`를 지정하지 않으면 `BlockwordOptions.DEFAULT`를 사용한다.
+ * - `AbstractMessage`를 상속하므로 생성 타임스탬프가 함께 기록된다.
+ *
+ * ```kotlin
+ * val request = blockwordRequestOf("나쁜 단어", blockwordOptionsOf(mask = "*"))
+ * // request.text == "나쁜 단어"
+ * // request.options.mask == "*"
+ * ```
  */
 data class BlockwordRequest(
     val text: String,
@@ -19,10 +26,17 @@ data class BlockwordRequest(
 }
 
 /**
- * 금칙어 처리 요청 정보를 생성한다.
+ * 금칙어 처리 요청 인스턴스를 생성한다.
  *
- * @param text    금칙어 처리 대상 문자열
- * @param options 금칙어 처리를 위한 옵션 정보
+ * ## 동작/계약
+ * - 생성 전에 `text.requireNotBlank("text")`를 호출해 비어 있거나 공백인 입력을 차단한다.
+ * - 검증을 통과하면 `BlockwordRequest(text, options)`를 반환한다.
+ *
+ * ```kotlin
+ * val request = blockwordRequestOf("테스트 문장")
+ * // request.text == "테스트 문장"
+ * // request.options == BlockwordOptions.DEFAULT
+ * ```
  */
 fun blockwordRequestOf(
     text: String,

--- a/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/model/BlockwordResponse.kt
+++ b/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/model/BlockwordResponse.kt
@@ -1,11 +1,19 @@
 package io.bluetape4k.tokenizer.model
 
 /**
- * 금칙어 처리 결과
+ * 금칙어 처리 결과와 적발 단어 목록을 담는 응답 모델이다.
  *
- * @property request    금칙어 처리 요청 정보
- * @property maskedText 금칙어 처리 적용 결과 문자열
- * @property blockWords 적발된 금직어 목록
+ * ## 동작/계약
+ * - `maskedText`는 호출 측에서 전달한 최종 마스킹 문자열을 그대로 보관한다.
+ * - `blockWords` 기본값은 빈 목록이며 적발 단어가 없음을 의미한다.
+ * - `blockwordExists`는 `blockWords.isNotEmpty()`를 계산해 노출한다.
+ *
+ * ```kotlin
+ * val request = blockwordRequestOf("문장")
+ * val response = blockwordResponseOf(request, "문장", listOf("금칙어"))
+ * // response.blockwordExists == true
+ * // response.blockWords.size == 1
+ * ```
  */
 data class BlockwordResponse(
     val request: BlockwordRequest,
@@ -13,18 +21,34 @@ data class BlockwordResponse(
     val blockWords: List<String> = emptyList(),
 ): AbstractMessage() {
     /**
-     * 금칙어가 적발되었는지 여부
+     * 금칙어가 1개 이상 적발되었는지 나타낸다.
+     *
+     * ## 동작/계약
+     * - `blockWords`가 비어 있지 않으면 `true`를 반환한다.
+     * - 계산 프로퍼티이므로 별도 상태를 저장하지 않는다.
+     *
+     * ```kotlin
+     * val empty = blockwordResponseOf(blockwordRequestOf("문장"), "문장")
+     * // empty.blockwordExists == false
+     * ```
      */
     val blockwordExists: Boolean
         get() = blockWords.isNotEmpty()
 }
 
 /**
- * 금칙어 처리 결과를 생성한다.
+ * 금칙어 처리 응답 인스턴스를 생성한다.
  *
- * @param request    금칙어 처리 요청 정보
- * @param maskedText 금칙어 처리 적용 결과 문자열
- * @param blockWords 적발된 금칙어 목록
+ * ## 동작/계약
+ * - 전달한 `request`, `maskedText`, `blockWords`를 그대로 `BlockwordResponse`에 매핑한다.
+ * - `blockWords`를 생략하면 빈 목록으로 초기화된다.
+ *
+ * ```kotlin
+ * val request = blockwordRequestOf("문장")
+ * val response = blockwordResponseOf(request, "***")
+ * // response.maskedText == "***"
+ * // response.blockwordExists == false
+ * ```
  */
 fun blockwordResponseOf(
     request: BlockwordRequest,

--- a/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/model/Severity.kt
+++ b/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/model/Severity.kt
@@ -1,7 +1,17 @@
 package io.bluetape4k.tokenizer.model
 
 /**
- * 금칙어의 심각도
+ * 금칙어의 노출 위험도를 단계별로 표현하는 열거형이다.
+ *
+ * ## 동작/계약
+ * - `LOW`, `MIDDLE`, `HIGH` 순으로 위험 수준이 높아진다.
+ * - 기본값은 `DEFAULT`를 통해 `LOW`로 제공된다.
+ * - 금칙어 필터 옵션에서 차단 기준 강도를 지정할 때 사용한다.
+ *
+ * ```kotlin
+ * val severity = Severity.DEFAULT
+ * // severity == Severity.LOW
+ * ```
  */
 enum class Severity {
 
@@ -24,6 +34,18 @@ enum class Severity {
     HIGH;
 
     companion object {
+        /**
+         * 금칙어 심각도 기본값(`LOW`)이다.
+         *
+         * ## 동작/계약
+         * - `BlockwordOptions` 기본 생성 시 이 값을 사용한다.
+         * - 상수 참조이므로 런타임 상태에 따라 값이 변하지 않는다.
+         *
+         * ```kotlin
+         * val defaultSeverity = Severity.DEFAULT
+         * // defaultSeverity == Severity.LOW
+         * ```
+         */
         val DEFAULT = Severity.LOW
     }
 }

--- a/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/model/TokenizeOptions.kt
+++ b/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/model/TokenizeOptions.kt
@@ -4,13 +4,35 @@ import java.io.Serializable
 import java.util.*
 
 /**
- * 형태소 분석 시 옵션
+ * 형태소 분석 실행 시 로캘 기반 동작을 지정하는 옵션이다.
+ *
+ * ## 동작/계약
+ * - 기본 로캘은 `Locale.KOREAN`이다.
+ * - 현재 공개 필드는 `locale` 하나이며 분석기 확장 시 옵션이 추가될 수 있다.
+ * - 직렬화 가능한 요청 모델에서 재사용하도록 `Serializable`을 구현한다.
+ *
+ * ```kotlin
+ * val options = TokenizeOptions.DEFAULT
+ * // options.locale == Locale.KOREAN
+ * ```
  */
 data class TokenizeOptions(
     val locale: Locale = Locale.KOREAN,
     // 추가로 필터링할 품사 정보를 표현해도 좋겠다
 ): Serializable {
     companion object {
+        /**
+         * 형태소 분석 기본 옵션 인스턴스다.
+         *
+         * ## 동작/계약
+         * - `locale=Locale.KOREAN`으로 초기화된 기본값이다.
+         * - 재사용 가능한 정적 옵션으로 제공된다.
+         *
+         * ```kotlin
+         * val defaults = TokenizeOptions.DEFAULT
+         * // defaults == TokenizeOptions()
+         * ```
+         */
         val DEFAULT = TokenizeOptions()
     }
 }

--- a/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/model/TokenizeRequest.kt
+++ b/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/model/TokenizeRequest.kt
@@ -3,10 +3,18 @@ package io.bluetape4k.tokenizer.model
 import io.bluetape4k.support.requireNotBlank
 
 /**
- * 형태소 분석 요청 정보
+ * 형태소 분석 대상 텍스트와 옵션을 전달하는 요청 모델이다.
  *
- * @property text 형태소 분석 대상 문자열
- * @property options 형태소 분석을 위한 옵션 정보
+ * ## 동작/계약
+ * - 생성 시 `text.requireNotBlank("text")`를 수행해 공백 입력을 거부한다.
+ * - `options`를 생략하면 `TokenizeOptions.DEFAULT`를 사용한다.
+ * - `AbstractMessage`의 `timestamp`가 함께 생성되어 요청 시각을 기록한다.
+ *
+ * ```kotlin
+ * val request = tokenizeRequestOf("코틀린 코루틴")
+ * // request.text == "코틀린 코루틴"
+ * // request.options == TokenizeOptions.DEFAULT
+ * ```
  */
 data class TokenizeRequest(
     val text: String,
@@ -18,10 +26,17 @@ data class TokenizeRequest(
 }
 
 /**
- * 형태소 분석 요청 정보를 생성한다.
+ * 형태소 분석 요청 객체를 생성한다.
  *
- * @param text    형태소 분석 대상 문자열
- * @param options 형태소 분석을 위한 옵션 정보
+ * ## 동작/계약
+ * - `text.requireNotBlank("text")` 검증 후 `TokenizeRequest`를 생성한다.
+ * - 텍스트가 공백이면 검증 예외가 발생하고 인스턴스는 만들어지지 않는다.
+ *
+ * ```kotlin
+ * val request = tokenizeRequestOf("비동기 처리", TokenizeOptions())
+ * // request.text == "비동기 처리"
+ * // request.options.locale == Locale.KOREAN
+ * ```
  */
 fun tokenizeRequestOf(
     text: String,

--- a/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/model/TokenizeResponse.kt
+++ b/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/model/TokenizeResponse.kt
@@ -1,10 +1,18 @@
 package io.bluetape4k.tokenizer.model
 
 /**
- * 형태소 분석 결과 응답
+ * 형태소 분석 결과 토큰 목록을 반환하는 응답 모델이다.
  *
- * @property text 형태소 분석 대상 문자열
- * @property tokens 형태소 분석 결과 토큰 목록
+ * ## 동작/계약
+ * - `text`는 분석에 사용한 원문을 그대로 담는다.
+ * - `tokens` 기본값은 빈 목록이며 토큰 추출 결과가 없음을 의미한다.
+ * - `AbstractMessage`를 상속해 응답 생성 시각을 함께 기록한다.
+ *
+ * ```kotlin
+ * val response = tokenizeResponseOf("코틀린 코루틴", listOf("코틀린", "코루틴"))
+ * // response.tokens.size == 2
+ * // response.text == "코틀린 코루틴"
+ * ```
  */
 data class TokenizeResponse(
     val text: String,
@@ -12,10 +20,16 @@ data class TokenizeResponse(
 ): AbstractMessage()
 
 /**
- * 형태소 분석 결과 응답을 생성한다.
+ * 형태소 분석 응답 객체를 생성한다.
  *
- * @param text   형태소 분석 대상 문자열
- * @param tokens 형태소 분석 결과 토큰 목록
+ * ## 동작/계약
+ * - 전달한 원문과 토큰 목록을 그대로 `TokenizeResponse`에 매핑한다.
+ * - `tokens`를 생략하면 빈 목록이 사용된다.
+ *
+ * ```kotlin
+ * val response = tokenizeResponseOf("문장")
+ * // response.tokens == emptyList<String>()
+ * ```
  */
 fun tokenizeResponseOf(
     text: String,

--- a/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/utils/CharArrayMap.kt
+++ b/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/utils/CharArrayMap.kt
@@ -4,7 +4,19 @@ import io.bluetape4k.logging.KLogging
 import java.io.Serializable
 
 /**
- * Lucene 에 있는 CharArrayMap 을 porting 한 클래스로, 사전 정보를 관리합니다.
+ * `CharArray` 키에 최적화된 open addressing 해시 맵 구현체다.
+ *
+ * ## 동작/계약
+ * - 키 타입으로 `Any`를 받지만 내부적으로 `CharArray` 또는 문자열 표현으로 정규화한다.
+ * - 충돌 해결은 선형이 아닌 증가값(`inc`) 기반 probe 방식으로 수행한다.
+ * - 삭제 시 probe chain 보존을 위해 엔트리를 재구성한다.
+ *
+ * ```kotlin
+ * val map = CharArrayMap<Int>(4)
+ * map.put("token", 1)
+ * // map["token"] == 1
+ * // map.containsKey("token") == true
+ * ```
  */
 @Suppress("UNCHECKED_CAST")
 open class CharArrayMap<V>(startSize: Int): AbstractMutableMap<Any, V>(), Serializable {
@@ -14,6 +26,21 @@ open class CharArrayMap<V>(startSize: Int): AbstractMutableMap<Any, V>(), Serial
         private val EMPTY_MAP: CharArrayMap<Any> = EmptyCharArrayMap()
 
         @JvmStatic
+        /**
+         * 수정이 불가능한 맵 뷰를 반환한다.
+         *
+         * ## 동작/계약
+         * - 빈 맵은 공유 `emptyMap()` 인스턴스를 반환한다.
+         * - 이미 읽기 전용 래퍼인 경우 동일 인스턴스를 그대로 반환한다.
+         * - 그 외에는 `UnmodifiableCharArrayMap`으로 감싼다.
+         *
+         * ```kotlin
+         * val source = CharArrayMap<Int>(2).apply { put("a", 1) }
+         * val readonly = CharArrayMap.unmodifiableMap(source)
+         * // readonly["a"] == 1
+         * // readonly.put("b", 2) throws UnsupportedOperationException
+         * ```
+         */
         fun <V> unmodifiableMap(map: CharArrayMap<V>): CharArrayMap<V> {
             return when {
                 map.isEmpty() -> emptyMap()
@@ -25,17 +52,66 @@ open class CharArrayMap<V>(startSize: Int): AbstractMutableMap<Any, V>(), Serial
         }
 
         @JvmStatic
+        /**
+         * 일반 `Map`을 `CharArrayMap`으로 복사한다.
+         *
+         * ## 동작/계약
+         * - 입력 맵의 모든 엔트리를 새 맵에 `putAll`로 적재한다.
+         * - 원본 맵과 결과 맵은 독립된 인스턴스다.
+         *
+         * ```kotlin
+         * val copied = CharArrayMap.copy(mapOf<Any, Int>("x" to 10))
+         * // copied["x"] == 10
+         * ```
+         */
         fun <V> copy(map: Map<Any, V>): CharArrayMap<V> = CharArrayMap(map)
 
         @JvmStatic
+        /**
+         * 불변 빈 맵 singleton을 반환한다.
+         *
+         * ## 동작/계약
+         * - 항상 동일한 내부 `EMPTY_MAP` 인스턴스를 타입 캐스팅해 반환한다.
+         * - 삽입/삭제 연산은 지원하지 않는다.
+         *
+         * ```kotlin
+         * val empty = CharArrayMap.emptyMap<Int>()
+         * // empty.isEmpty() == true
+         * ```
+         */
         fun <V> emptyMap(): CharArrayMap<V> = EMPTY_MAP as CharArrayMap<V>
     }
 
     @Suppress("LeakingThis")
+    /**
+     * 일반 `Map` 내용을 복사해 맵을 생성한다.
+     *
+     * ## 동작/계약
+     * - 초기 용량은 `c.size`를 기준으로 계산한다.
+     * - 생성 시 `putAll(c)`를 수행한다.
+     *
+     * ```kotlin
+     * val map = CharArrayMap(mapOf<Any, Int>("a" to 1))
+     * // map.size == 1
+     * ```
+     */
     constructor(c: Map<Any, V>): this(c.size) {
         putAll(c)
     }
 
+    /**
+     * 다른 `CharArrayMap`의 내부 저장소를 공유해 얕은 복사를 생성한다.
+     *
+     * ## 동작/계약
+     * - `_keys`, `_values` 배열 참조를 그대로 공유한다.
+     * - 수정 가능한 맵에서 공유 복사를 사용할 경우 서로 영향이 있을 수 있다.
+     *
+     * ```kotlin
+     * val source = CharArrayMap<Int>(2).apply { put("a", 1) }
+     * val copy = CharArrayMap(source)
+     * // copy["a"] == 1
+     * ```
+     */
     constructor(src: CharArrayMap<V>): this(0) {
         this._keys = src._keys
         this._values = src._values
@@ -57,29 +133,115 @@ open class CharArrayMap<V>(startSize: Int): AbstractMutableMap<Any, V>(), Serial
         _values = arrayOfNulls<Any>(size) as Array<V?>
     }
 
+    /**
+     * 맵의 모든 엔트리를 제거한다.
+     *
+     * ## 동작/계약
+     * - 키/값 배열 슬롯을 모두 `null`로 초기화한다.
+     * - `_count`를 0으로 재설정한다.
+     *
+     * ```kotlin
+     * val map = CharArrayMap<Int>(2).apply { put("a", 1) }
+     * map.clear()
+     * // map.isEmpty() == true
+     * ```
+     */
     override fun clear() {
         _count = 0
         _keys.fill(null)
         _values.fill(null)
     }
 
+    /**
+     * 문자 배열 구간 키의 존재 여부를 확인한다.
+     *
+     * ## 동작/계약
+     * - `text[off, off + len)` 구간 해시 슬롯을 계산해 조회한다.
+     * - 해당 슬롯에 키가 존재하면 `true`를 반환한다.
+     *
+     * ```kotlin
+     * val map = CharArrayMap<Int>(2).apply { put("ab", 1) }
+     * val chars = "ab".toCharArray()
+     * // map.containsKey(chars, 0, chars.size) == true
+     * ```
+     */
     open fun containsKey(text: CharArray, off: Int, len: Int): Boolean {
         return _keys[getSlot(text, off, len)] != null
     }
 
+    /**
+     * `CharSequence` 키의 존재 여부를 확인한다.
+     *
+     * ## 동작/계약
+     * - 문자열 내용을 기준으로 슬롯을 계산한다.
+     * - 동일 문자 시퀀스가 등록되어 있으면 `true`를 반환한다.
+     *
+     * ```kotlin
+     * val map = CharArrayMap<Int>(2).apply { put("key", 1) }
+     * // map.containsKey("key") == true
+     * ```
+     */
     open fun containsKey(cs: CharSequence): Boolean = _keys[getSlot(cs)] != null
 
+    /**
+     * 일반 키 객체 존재 여부를 확인한다.
+     *
+     * ## 동작/계약
+     * - `CharArray` 키는 배열 경로로 조회한다.
+     * - 그 외 타입은 `toString()` 결과를 키로 사용해 조회한다.
+     *
+     * ```kotlin
+     * val map = CharArrayMap<Int>(2).apply { put("a", 1) }
+     * // map.containsKey("a") == true
+     * ```
+     */
     override fun containsKey(key: Any): Boolean = when (key) {
         is CharArray -> containsKey(key, 0, key.size)
         else         -> containsKey(key.toString())
     }
 
+    /**
+     * 문자 배열 구간 키에 연결된 값을 조회한다.
+     *
+     * ## 동작/계약
+     * - 슬롯에 값이 없으면 `null`을 반환한다.
+     * - 키 비교는 문자 단위 동등성으로 수행한다.
+     *
+     * ```kotlin
+     * val map = CharArrayMap<Int>(2).apply { put("x", 3) }
+     * // map.get("x".toCharArray(), 0, 1) == 3
+     * ```
+     */
     open fun get(text: CharArray, off: Int, len: Int): V? {
         return _values[getSlot(text, off, len)]
     }
 
+    /**
+     * `CharSequence` 키에 연결된 값을 조회한다.
+     *
+     * ## 동작/계약
+     * - 내부적으로 문자열 기반 슬롯 계산을 수행한다.
+     * - 존재하지 않는 키는 `null`을 반환한다.
+     *
+     * ```kotlin
+     * val map = CharArrayMap<Int>(2).apply { put("y", 7) }
+     * // map.get("y") == 7
+     * ```
+     */
     open fun get(cs: CharSequence): V? = _values[getSlot(cs)]
 
+    /**
+     * 일반 키 객체에 대응하는 값을 조회한다.
+     *
+     * ## 동작/계약
+     * - `CharArray`는 배열 경로, 그 외는 `toString()` 경로를 사용한다.
+     * - 키가 없으면 `null`을 반환한다.
+     *
+     * ```kotlin
+     * val map = CharArrayMap<Int>(2).apply { put("b", 2) }
+     * // map["b"] == 2
+     * ```
+     */
     override fun get(key: Any): V? = when (key) {
         is CharArray -> get(key, 0, key.size)
         else         -> get(key.toString())
@@ -106,19 +268,67 @@ open class CharArrayMap<V>(startSize: Int): AbstractMutableMap<Any, V>(), Serial
         return getSlot(text.toString().toCharArray(), 0, text.length)
     }
 
+    /**
+     * `CharSequence` 키와 값을 저장한다.
+     *
+     * ## 동작/계약
+     * - 키를 문자열로 변환한 뒤 삽입 로직에 위임한다.
+     * - 동일 키가 있으면 이전 값을 반환하고 값을 교체한다.
+     *
+     * ```kotlin
+     * val map = CharArrayMap<Int>(2)
+     * map.put("z", 1)
+     * // map.put("z", 2) == 1
+     * ```
+     */
     open fun put(text: CharSequence, value: V): V? = put(text.toString(), value)
 
+    /**
+     * 일반 키 객체와 값을 저장한다.
+     *
+     * ## 동작/계약
+     * - `CharArray` 키는 배열 삽입 경로를 사용한다.
+     * - 그 외 키는 `toString()`으로 변환해 삽입한다.
+     *
+     * ```kotlin
+     * val map = CharArrayMap<Int>(2)
+     * map.put("id", 1)
+     * // map["id"] == 1
+     * ```
+     */
     override fun put(key: Any, value: V): V? = when (key) {
         is CharArray -> put(key, value)
         else         -> put(key.toString(), value)
     }
 
+    /**
+     * 문자열 키와 값을 저장한다.
+     *
+     * ## 동작/계약
+     * - 키를 `CharArray`로 변환해 내부 삽입 함수로 위임한다.
+     * - 기존 키가 있으면 이전 값을 반환한다.
+     *
+     * ```kotlin
+     * val map = CharArrayMap<Int>(2)
+     * // map.put("k", 9) == null
+     * ```
+     */
     open fun put(text: String, value: V): V? = put(text.toCharArray(), value)
 
     /**
-     * Add the given mapping.
-     * If ignoreCase is true for this Set, the text array will be directly modified.
-     * The user should never modify this text array after calling this method.
+     * 문자 배열 키와 값을 맵에 저장한다.
+     *
+     * ## 동작/계약
+     * - 키가 이미 존재하면 값을 교체하고 이전 값을 반환한다.
+     * - 신규 키면 `_count`를 증가시키고 load factor(약 0.8)를 넘으면 `rehash`를 수행한다.
+     * - 키 배열은 복사하지 않고 그대로 저장하므로 호출 후 외부 수정 시 동작이 달라질 수 있다.
+     *
+     * ```kotlin
+     * val map = CharArrayMap<Int>(2)
+     * val key = "id".toCharArray()
+     * map.put(key, 10)
+     * // map["id"] == 10
+     * ```
      */
     open fun put(text: CharArray, value: V): V? {
         val slot = getSlot(text, 0, text.size)
@@ -206,6 +416,21 @@ open class CharArrayMap<V>(startSize: Int): AbstractMutableMap<Any, V>(), Serial
         return code
     }
 
+    /**
+     * 키를 제거하고 기존 값을 반환한다.
+     *
+     * ## 동작/계약
+     * - 키가 없으면 `null`을 반환한다.
+     * - 키가 있으면 해당 엔트리를 제외한 나머지를 재삽입해 probe chain을 재구성한다.
+     * - 삭제 성공 시 제거된 이전 값을 반환한다.
+     *
+     * ```kotlin
+     * val map = CharArrayMap<Int>(2).apply { put("a", 1) }
+     * val removed = map.remove("a")
+     * // removed == 1
+     * // map.containsKey("a") == false
+     * ```
+     */
     override fun remove(key: Any): V? {
         val keyChars = when (key) {
             is CharArray -> key
@@ -236,6 +461,19 @@ open class CharArrayMap<V>(startSize: Int): AbstractMutableMap<Any, V>(), Serial
     }
 
     @Suppress("PROPERTY_HIDES_JAVA_FIELD")
+    /**
+     * 현재 저장된 엔트리 개수다.
+     *
+     * ## 동작/계약
+     * - 삽입 시 증가하고 `clear`/`remove`에서 감소 또는 재계산된다.
+     * - 내부 카운터 `_count` 값을 그대로 반환한다.
+     *
+     * ```kotlin
+     * val map = CharArrayMap<Int>(2)
+     * map.put("a", 1)
+     * // map.size == 1
+     * ```
+     */
     override val size: Int get() = _count
 
     override fun toString(): String = buildString {
@@ -249,7 +487,31 @@ open class CharArrayMap<V>(startSize: Int): AbstractMutableMap<Any, V>(), Serial
 
     private val _entrySet: EntrySet by lazy { createEntrySet() }
 
+    /**
+     * 엔트리 집합 생성을 담당하는 확장 포인트다.
+     *
+     * ## 동작/계약
+     * - 기본 구현은 수정 가능한 `EntrySet(true)`를 반환한다.
+     * - 읽기 전용 하위 클래스는 이 메서드를 재정의해 수정 불가 집합을 제공한다.
+     *
+     * ```kotlin
+     * val map = CharArrayMap<Int>(2)
+     * // map.entries.isEmpty() == true
+     * ```
+     */
     protected open fun createEntrySet(): EntrySet = EntrySet(true)
+    /**
+     * 맵의 엔트리 뷰를 반환한다.
+     *
+     * ## 동작/계약
+     * - 지연 초기화된 `_entrySet` 인스턴스를 재사용한다.
+     * - 반환된 뷰의 수정 가능 여부는 `createEntrySet` 구현에 따릅니다.
+     *
+     * ```kotlin
+     * val map = CharArrayMap<Int>(2).apply { put("a", 1) }
+     * // map.entries.first().value == 1
+     * ```
+     */
     override val entries: MutableSet<MutableMap.MutableEntry<Any, V>> get() = _entrySet
 
     private val _keySet: CharArraySet by lazy {
@@ -261,6 +523,19 @@ open class CharArrayMap<V>(startSize: Int): AbstractMutableMap<Any, V>(), Serial
         }
     }
 
+    /**
+     * 원본 키(`CharArray`)를 복제 없이 노출하는 읽기 전용 키 집합이다.
+     *
+     * ## 동작/계약
+     * - 순회 시 내부 `_keys` 배열의 실제 참조를 반환한다.
+     * - 키 추가/삭제 연산은 지원하지 않는다.
+     *
+     * ```kotlin
+     * val map = CharArrayMap<Int>(2).apply { put("x", 1) }
+     * val firstKey = map.originalKeySet.first() as CharArray
+     * // String(firstKey) == "x"
+     * ```
+     */
     val originalKeySet: MutableSet<Any> by lazy {
         object: AbstractMutableSet<Any>() {
             override fun iterator(): MutableIterator<Any> = object: MutableIterator<Any> {
@@ -296,8 +571,34 @@ open class CharArrayMap<V>(startSize: Int): AbstractMutableMap<Any, V>(), Serial
         }
     }
 
+    /**
+     * 표준 `Map.keys` 뷰를 반환한다.
+     *
+     * ## 동작/계약
+     * - 키 추가는 허용되지 않으며 조회 용도로만 사용한다.
+     * - 내부적으로 `CharArraySet` 래퍼를 사용한다.
+     *
+     * ```kotlin
+     * val map = CharArrayMap<Int>(2).apply { put("k", 3) }
+     * // map.keys.contains("k") == true
+     * ```
+     */
     override val keys: MutableSet<Any> get() = _keySet
 
+    /**
+     * 내부 슬롯을 순회하며 엔트리를 생성하는 반복자 구현체다.
+     *
+     * ## 동작/계약
+     * - `allowModify=false`면 값 변경 API(`setValue`)를 차단한다.
+     * - `nextKey`는 내부 `CharArray` 참조를 그대로 반환한다.
+     * - `remove()`는 지원하지 않는다.
+     *
+     * ```kotlin
+     * val map = CharArrayMap<Int>(2).apply { put("a", 1) }
+     * val it = map.EntryIterator(true)
+     * // it.hasNext() == true
+     * ```
+     */
     inner class EntryIterator(private val allowModify: Boolean):
         MutableIterator<MutableMap.MutableEntry<Any, V>> {
 
@@ -314,12 +615,34 @@ open class CharArrayMap<V>(startSize: Int): AbstractMutableMap<Any, V>(), Serial
             while (pos < _keys.size && _keys[pos] == null) pos++
         }
 
+        /**
+         * 다음 엔트리가 존재하는지 확인한다.
+         *
+         * ## 동작/계약
+         * - 현재 포인터가 배열 범위 내 유효 슬롯을 가리키면 `true`를 반환한다.
+         * - 상태를 변경하지 않는 조회 연산이다.
+         *
+         * ```kotlin
+         * val map = CharArrayMap<Int>(2).apply { put("a", 1) }
+         * // map.EntryIterator(true).hasNext() == true
+         * ```
+         */
         override fun hasNext(): Boolean {
             return pos < _keys.size
         }
 
         /**
-         * gets the next key... do not modify the returned char[]
+         * 다음 키의 원본 `CharArray`를 반환한다.
+         *
+         * ## 동작/계약
+         * - 내부 배열 참조를 직접 반환한다.
+         * - 반환 배열을 외부에서 수정하면 맵 동작에 영향을 줄 수 있다.
+         *
+         * ```kotlin
+         * val map = CharArrayMap<Int>(2).apply { put("a", 1) }
+         * val key = map.EntryIterator(true).nextKey()
+         * // String(key).isNotEmpty() == true
+         * ```
          */
         fun nextKey(): CharArray {
             goNext()
@@ -327,21 +650,53 @@ open class CharArrayMap<V>(startSize: Int): AbstractMutableMap<Any, V>(), Serial
         }
 
         /**
-         * gets the next key as a newly created String object
+         * 다음 키를 새 `String` 인스턴스로 반환한다.
+         *
+         * ## 동작/계약
+         * - `nextKey()` 결과를 복사 문자열로 변환한다.
+         * - 원본 키 배열 수정 영향 없이 안전하게 조회할 때 사용한다.
+         *
+         * ```kotlin
+         * val map = CharArrayMap<Int>(2).apply { put("a", 1) }
+         * val key = map.EntryIterator(true).nextKeyString()
+         * // key == "a"
+         * ```
          */
         fun nextKeyString(): String {
             return String(nextKey())
         }
 
         /**
-         * returns the value associated with the last key returned
+         * 마지막으로 반환된 키에 연결된 현재 값을 조회한다.
+         *
+         * ## 동작/계약
+         * - `nextKey` 또는 `next` 호출 이후의 위치를 기준으로 값을 반환한다.
+         * - 값이 없으면 `null`을 반환할 수 있다.
+         *
+         * ```kotlin
+         * val map = CharArrayMap<Int>(2).apply { put("a", 1) }
+         * val it = map.EntryIterator(true)
+         * it.nextKey()
+         * // it.currentValue() == 1
+         * ```
          */
         fun currentValue(): V? {
             return _values[lastPos]
         }
 
         /**
-         * sets the value associated with the last key returned
+         * 마지막으로 반환된 키의 값을 변경한다.
+         *
+         * ## 동작/계약
+         * - `allowModify=false`면 `UnsupportedOperationException`을 던진다.
+         * - 성공 시 이전 값을 반환한다.
+         *
+         * ```kotlin
+         * val map = CharArrayMap<Int>(2).apply { put("a", 1) }
+         * val it = map.EntryIterator(true)
+         * it.nextKey()
+         * // it.setValue(2) == 1
+         * ```
          */
         fun setValue(value: V): V? {
             if (!allowModify)
@@ -352,13 +707,35 @@ open class CharArrayMap<V>(startSize: Int): AbstractMutableMap<Any, V>(), Serial
         }
 
         /**
-         * use nextCharArray() + currentValue() for better efficiency.
+         * 현재 위치 엔트리를 `MutableEntry` 객체로 반환한다.
+         *
+         * ## 동작/계약
+         * - 호출 시 내부 포인터를 다음 유효 슬롯으로 이동한다.
+         * - 반환 엔트리는 `allowModify` 설정에 따라 값 변경 가능 여부가 달라진다.
+         *
+         * ```kotlin
+         * val map = CharArrayMap<Int>(2).apply { put("a", 1) }
+         * val entry = map.EntryIterator(true).next()
+         * // entry.value == 1
+         * ```
          */
         override fun next(): MutableMap.MutableEntry<Any, V> {
             goNext()
             return MapEntry(lastPos, allowModify)
         }
 
+        /**
+         * 반복자 기반 제거 연산을 지원하지 않는다.
+         *
+         * ## 동작/계약
+         * - 호출 시 항상 `UnsupportedOperationException`을 던진다.
+         * - 맵 삭제는 상위 `remove(key)` API를 사용해야 한다.
+         *
+         * ```kotlin
+         * val map = CharArrayMap<Int>(2).apply { put("a", 1) }
+         * // map.EntryIterator(true).remove() throws UnsupportedOperationException
+         * ```
+         */
         override fun remove() {
             throw UnsupportedOperationException()
         }
@@ -389,12 +766,50 @@ open class CharArrayMap<V>(startSize: Int): AbstractMutableMap<Any, V>(), Serial
         }
     }
 
+    /**
+     * 엔트리 집합 뷰 구현체다.
+     *
+     * ## 동작/계약
+     * - 순회는 `EntryIterator`를 사용한다.
+     * - `allowModify=false`일 때 `clear`를 포함한 변경 작업이 차단된다.
+     * - 개수는 외부 맵 `_count`를 그대로 반영한다.
+     *
+     * ```kotlin
+     * val map = CharArrayMap<Int>(2).apply { put("a", 1) }
+     * // map.EntrySet(true).size == 1
+     * ```
+     */
     inner class EntrySet(private val allowModify: Boolean): AbstractMutableSet<MutableMap.MutableEntry<Any, V>>() {
 
+        /**
+         * 엔트리 순회 반복자를 반환한다.
+         *
+         * ## 동작/계약
+         * - `allowModify` 설정을 공유하는 `EntryIterator`를 생성한다.
+         * - 반복자 `remove`는 지원하지 않는다.
+         *
+         * ```kotlin
+         * val map = CharArrayMap<Int>(2).apply { put("a", 1) }
+         * // map.EntrySet(true).iterator().hasNext() == true
+         * ```
+         */
         override fun iterator(): MutableIterator<MutableMap.MutableEntry<Any, V>> {
             return EntryIterator(allowModify)
         }
 
+        /**
+         * 주어진 엔트리가 현재 맵에 동일 값으로 존재하는지 확인한다.
+         *
+         * ## 동작/계약
+         * - 키로 현재 값을 조회한 뒤 전달된 값과 동등 비교한다.
+         * - 키가 없으면 `false`를 반환한다.
+         *
+         * ```kotlin
+         * val map = CharArrayMap<Int>(2).apply { put("a", 1) }
+         * val entry = map.entries.first()
+         * // map.EntrySet(true).contains(entry) == true
+         * ```
+         */
         override fun contains(element: MutableMap.MutableEntry<Any, V>): Boolean {
             val key = element.key
             val value = element.value
@@ -402,23 +817,84 @@ open class CharArrayMap<V>(startSize: Int): AbstractMutableMap<Any, V>(), Serial
             return if (v == null) value == null else v == value
         }
 
+        /**
+         * 엔트리 직접 추가는 지원하지 않는다.
+         *
+         * ## 동작/계약
+         * - 호출 시 항상 `UnsupportedOperationException`을 던진다.
+         * - 엔트리 추가는 `put` API를 사용해야 한다.
+         *
+         * ```kotlin
+         * val map = CharArrayMap<Int>(2)
+         * // map.EntrySet(true).add(map.entries.first()) throws UnsupportedOperationException
+         * ```
+         */
         override fun add(element: MutableMap.MutableEntry<Any, V>): Boolean {
             throw UnsupportedOperationException()
         }
 
+        /**
+         * 엔트리 직접 삭제는 지원하지 않는다.
+         *
+         * ## 동작/계약
+         * - 호출 시 `UnsupportedOperationException`을 던진다.
+         * - 삭제는 상위 `remove(key)` API를 통해 수행해야 한다.
+         *
+         * ```kotlin
+         * val map = CharArrayMap<Int>(2).apply { put("a", 1) }
+         * // map.EntrySet(true).remove(map.entries.first()) throws UnsupportedOperationException
+         * ```
+         */
         override fun remove(element: MutableMap.MutableEntry<Any, V>): Boolean {
             throw UnsupportedOperationException()
         }
 
+        /**
+         * 엔트리 개수를 반환한다.
+         *
+         * ## 동작/계약
+         * - 외부 맵의 `_count`를 그대로 반영한다.
+         * - 조회 연산이며 상태를 변경하지 않는다.
+         *
+         * ```kotlin
+         * val map = CharArrayMap<Int>(2).apply { put("a", 1) }
+         * // map.EntrySet(true).size == 1
+         * ```
+         */
         override val size: Int
             get() = _count
 
+        /**
+         * 엔트리 집합을 비운다.
+         *
+         * ## 동작/계약
+         * - `allowModify=false`면 `UnsupportedOperationException`을 던진다.
+         * - 허용된 경우 외부 맵의 `clear()`를 호출한다.
+         *
+         * ```kotlin
+         * val map = CharArrayMap<Int>(2).apply { put("a", 1) }
+         * map.EntrySet(true).clear()
+         * // map.isEmpty() == true
+         * ```
+         */
         override fun clear() {
             if (!allowModify) throw UnsupportedOperationException()
             this@CharArrayMap.clear()
         }
     }
 
+    /**
+     * 모든 수정 연산을 차단하는 읽기 전용 `CharArrayMap` 구현체다.
+     *
+     * ## 동작/계약
+     * - `put`, `remove`, `clear` 호출 시 `UnsupportedOperationException`을 던진다.
+     * - 조회 연산(`get`, `containsKey`)은 원본 데이터 기준으로 동작한다.
+     *
+     * ```kotlin
+     * val readonly = CharArrayMap.UnmodifiableCharArrayMap(CharArrayMap<Int>(2))
+     * // readonly.isEmpty() == true
+     * ```
+     */
     open class UnmodifiableCharArrayMap<V>(map: CharArrayMap<V>): CharArrayMap<V>(map) {
 
         override fun clear() = throw UnsupportedOperationException()

--- a/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/utils/CharArraySet.kt
+++ b/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/utils/CharArraySet.kt
@@ -4,9 +4,19 @@ import io.bluetape4k.logging.KLogging
 import java.io.Serializable
 
 /**
- * Lucuene 에 있는 CharArraySet 을 Kotlin 으로 porting 한 클래스입니다.
+ * 문자 배열 기반 키를 중복 없이 저장하는 가변 집합 구현체다.
  *
- * 사전 정보를 관리하는 클래스입니다.
+ * ## 동작/계약
+ * - 내부 저장소로 `CharArrayMap`을 사용하며 값에는 플레이스홀더만 저장한다.
+ * - `Any`, `String`, `CharSequence`, `CharArray` 입력을 모두 수용한다.
+ * - 문자열 사전/금칙어 목록처럼 membership 조회가 많은 용도에 맞춘 구조다.
+ *
+ * ```kotlin
+ * val set = CharArraySet(4)
+ * set.add("token")
+ * // set.contains("token") == true
+ * // set.size == 1
+ * ```
  */
 open class CharArraySet(val map: CharArrayMap<Any>): AbstractMutableSet<Any>(), Serializable {
 
@@ -16,6 +26,20 @@ open class CharArraySet(val map: CharArrayMap<Any>): AbstractMutableSet<Any>(), 
 
         @Suppress("USELESS_IS_CHECK")
         @JvmStatic
+        /**
+         * 읽기 전용 뷰를 반환한다.
+         *
+         * ## 동작/계약
+         * - 빈 집합은 공유 singleton(`EMPTY_SET`)을 그대로 반환한다.
+         * - 그 외 입력은 `UnmodifiableCharArrayMap` 기반 래퍼로 감싼 새 인스턴스를 반환한다.
+         *
+         * ```kotlin
+         * val source = CharArraySet(2).apply { add("a") }
+         * val readonly = CharArraySet.unmodifiableSet(source)
+         * // readonly.contains("a") == true
+         * // readonly.add("b") throws UnsupportedOperationException
+         * ```
+         */
         fun unmodifiableSet(set: CharArraySet): CharArraySet {
             return when (set) {
                 EMPTY_SET -> EMPTY_SET
@@ -25,6 +49,19 @@ open class CharArraySet(val map: CharArrayMap<Any>): AbstractMutableSet<Any>(), 
         }
 
         @JvmStatic
+        /**
+         * 입력 집합의 내용을 복사한 새 `CharArraySet`을 생성한다.
+         *
+         * ## 동작/계약
+         * - 입력이 `CharArraySet`이면 내부 맵 복사 생성자를 사용한다.
+         * - 입력이 비어 있는 공유 집합이면 동일 singleton을 반환한다.
+         *
+         * ```kotlin
+         * val copied = CharArraySet.copy(setOf("가", "나"))
+         * // copied.contains("가") == true
+         * // copied.size == 2
+         * ```
+         */
         fun copy(set: Set<Any>): CharArraySet = when (set) {
             EMPTY_SET -> EMPTY_SET
             is CharArraySet -> CharArraySet(CharArrayMap.copy(set.map))
@@ -32,26 +69,160 @@ open class CharArraySet(val map: CharArrayMap<Any>): AbstractMutableSet<Any>(), 
         }
     }
 
+    /**
+     * 예상 원소 수를 기준으로 초기 용량을 지정해 집합을 생성한다.
+     *
+     * ## 동작/계약
+     * - 내부적으로 `CharArrayMap(startSize)`를 생성한다.
+     * - 용량은 리해시 시점을 늦추기 위한 힌트로 사용된다.
+     *
+     * ```kotlin
+     * val set = CharArraySet(128)
+     * // set.isEmpty() == true
+     * ```
+     */
     constructor(startSize: Int): this(CharArrayMap<Any>(startSize))
 
+    /**
+     * 컬렉션 내용을 복사해 집합을 생성한다.
+     *
+     * ## 동작/계약
+     * - `c.size`로 초기 용량을 계산한 뒤 `addAll`로 원소를 채운다.
+     * - 중복 원소는 집합 특성상 하나만 유지된다.
+     *
+     * ```kotlin
+     * val set = CharArraySet(listOf("a", "a", "b"))
+     * // set.size == 2
+     * ```
+     */
     constructor(c: Collection<Any>): this(c.size) {
         @Suppress("LeakingThis")
         addAll(c)
     }
 
+    /**
+     * 집합의 모든 원소를 제거한다.
+     *
+     * ## 동작/계약
+     * - 내부 `CharArrayMap.clear()`를 호출해 키/값 배열을 초기화한다.
+     * - 호출 후 `size`는 0이 된다.
+     *
+     * ```kotlin
+     * val set = CharArraySet(2).apply { add("a") }
+     * set.clear()
+     * // set.isEmpty() == true
+     * ```
+     */
     override fun clear() {
         map.clear()
     }
 
+    /**
+     * 일반 키 객체 존재 여부를 확인한다.
+     *
+     * ## 동작/계약
+     * - `Any` 입력을 내부 맵 키 비교 규칙으로 위임해 조회한다.
+     * - 문자열/문자배열 입력도 동일 API에서 처리된다.
+     *
+     * ```kotlin
+     * val set = CharArraySet(2).apply { add("hello") }
+     * // set.contains("hello") == true
+     * ```
+     */
     override fun contains(element: Any): Boolean = map.containsKey(element)
+    /**
+     * 문자 배열 구간이 집합에 존재하는지 확인한다.
+     *
+     * ## 동작/계약
+     * - `text[off, off + len)` 구간으로 키를 조회한다.
+     * - 내부 맵의 슬롯 검색 결과를 그대로 반환한다.
+     *
+     * ```kotlin
+     * val set = CharArraySet(4).apply { add("token") }
+     * val chars = "token".toCharArray()
+     * // set.contains(chars, 0, chars.size) == true
+     * ```
+     */
     fun contains(text: CharArray, off: Int, len: Int = text.size) = map.containsKey(text, off, len)
+    /**
+     * `CharSequence` 키 존재 여부를 확인한다.
+     *
+     * ## 동작/계약
+     * - 문자열 내용을 기준으로 내부 맵을 조회한다.
+     * - 대소문자 정규화 없이 원문 비교를 수행한다.
+     *
+     * ```kotlin
+     * val set = CharArraySet(2).apply { add("hello") }
+     * // set.contains("hello") == true
+     * ```
+     */
     fun contains(cs: CharSequence) = map.containsKey(cs)
 
+    /**
+     * 일반 키 객체를 집합에 추가한다.
+     *
+     * ## 동작/계약
+     * - 내부 맵에 플레이스홀더 값을 저장해 집합 원소로 등록한다.
+     * - 기존 키가 없을 때만 `true`를 반환한다.
+     *
+     * ```kotlin
+     * val set = CharArraySet(2)
+     * // set.add("x") == true
+     * ```
+     */
     override fun add(element: Any): Boolean = map.put(element, PLACEHOLDER) == null
+    /**
+     * `CharSequence` 키를 집합에 추가한다.
+     *
+     * ## 동작/계약
+     * - 문자열 내용을 기준으로 중복 여부를 판단한다.
+     * - 이미 존재하면 `false`를 반환한다.
+     *
+     * ```kotlin
+     * val set = CharArraySet(2)
+     * // set.add("abc" as CharSequence) == true
+     * ```
+     */
     open fun add(text: CharSequence) = map.put(text, PLACEHOLDER) == null
+    /**
+     * 문자열 키를 집합에 추가한다.
+     *
+     * ## 동작/계약
+     * - 내부 맵 문자열 삽입 경로를 사용한다.
+     * - 중복 키는 추가되지 않는다.
+     *
+     * ```kotlin
+     * val set = CharArraySet(2)
+     * // set.add("abc") == true
+     * ```
+     */
     open fun add(text: String) = map.put(text, PLACEHOLDER) == null
+    /**
+     * 문자 배열 키를 집합에 추가한다.
+     *
+     * ## 동작/계약
+     * - 전달한 배열 참조를 내부 키로 사용한다.
+     * - 동일 문자 시퀀스가 이미 있으면 `false`를 반환한다.
+     *
+     * ```kotlin
+     * val set = CharArraySet(2)
+     * // set.add("abc".toCharArray()) == true
+     * ```
+     */
     open fun add(text: CharArray) = map.put(text, PLACEHOLDER) == null
 
+    /**
+     * 컬렉션 원소를 모두 추가한다.
+     *
+     * ## 동작/계약
+     * - 각 원소를 순회하며 `add`를 호출한다.
+     * - 하나라도 새 원소가 추가되면 `true`를 반환한다.
+     *
+     * ```kotlin
+     * val set = CharArraySet(2)
+     * // set.addAll(listOf("a", "b")) == true
+     * ```
+     */
     override fun addAll(elements: Collection<Any>): Boolean {
         var modified = false
         elements.forEach {
@@ -60,27 +231,100 @@ open class CharArraySet(val map: CharArrayMap<Any>): AbstractMutableSet<Any>(), 
         return modified
     }
 
+    /**
+     * 일반 키 객체를 제거한다.
+     *
+     * ## 동작/계약
+     * - 내부 맵에서 키를 제거한 뒤 재조회 결과를 반환한다.
+     * - 키가 존재하지 않아도 예외를 던지지 않는다.
+     *
+     * ```kotlin
+     * val set = CharArraySet(2).apply { add("a") }
+     * // set.remove("a") == true
+     * ```
+     */
     override fun remove(element: Any): Boolean {
         map.remove(element)
         return !map.containsKey(element)
     }
 
+    /**
+     * 문자열 키를 집합에서 제거한다.
+     *
+     * ## 동작/계약
+     * - 내부 맵에서 키를 제거한 뒤 재조회 결과를 기반으로 성공 여부를 반환한다.
+     * - 키가 없던 경우에도 예외 없이 `true`를 반환할 수 있다.
+     *
+     * ```kotlin
+     * val set = CharArraySet(2).apply { add("x") }
+     * set.remove("x")
+     * // set.contains("x") == false
+     * ```
+     */
     fun remove(text: String): Boolean {
         map.remove(text)
         return !map.containsKey(text)
     }
 
+    /**
+     * 컬렉션 원소를 모두 제거한다.
+     *
+     * ## 동작/계약
+     * - 각 원소에 대해 `remove`를 호출한다.
+     * - 모든 제거 호출이 `true`일 때만 `true`를 반환한다.
+     *
+     * ```kotlin
+     * val set = CharArraySet(2).apply { addAll(listOf("a", "b")) }
+     * // set.removeAll(listOf("a", "b")) == true
+     * ```
+     */
     override fun removeAll(elements: Collection<Any>): Boolean {
         return elements.all { remove(it) }
     }
 
+    /**
+     * 문자열 목록을 모두 제거한다.
+     *
+     * ## 동작/계약
+     * - 각 문자열에 `remove(String)`을 적용한다.
+     * - 모두 제거 성공 시 `true`를 반환한다.
+     *
+     * ```kotlin
+     * val set = CharArraySet(2).apply { addAll(listOf("x", "y")) }
+     * // set.removeAll(listOf("x", "y")) == true
+     * ```
+     */
     fun removeAll(words: List<String>): Boolean {
         return words.all { remove(it) }
     }
 
+    /**
+     * 집합 원소 수를 반환한다.
+     *
+     * ## 동작/계약
+     * - 내부 맵의 `size`를 그대로 노출한다.
+     * - 조회 연산이며 상태를 변경하지 않는다.
+     *
+     * ```kotlin
+     * val set = CharArraySet(2).apply { add("one") }
+     * // set.size == 1
+     * ```
+     */
     override val size: Int
         get() = map.size
 
+    /**
+     * 원소 순회를 위한 반복자를 반환한다.
+     *
+     * ## 동작/계약
+     * - 내부 맵의 원본 키 집합 반복자를 그대로 사용한다.
+     * - 반환 원소는 `CharArray` 또는 입력 타입에 대응하는 키 표현이다.
+     *
+     * ```kotlin
+     * val set = CharArraySet(2).apply { add("it") }
+     * // set.iterator().hasNext() == true
+     * ```
+     */
     override fun iterator(): MutableIterator<Any> {
         return map.originalKeySet.iterator()
     }

--- a/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/utils/CharacterUtils.kt
+++ b/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/utils/CharacterUtils.kt
@@ -7,7 +7,19 @@ import java.io.Reader
 import java.io.Serializable
 
 /**
- * [CharacterUtils] provides a unified interface to Character-related operations.
+ * 유니코드 코드포인트 기반 문자 처리 연산을 일관된 방식으로 제공하는 추상 유틸리티다.
+ *
+ * ## 동작/계약
+ * - 기본 구현은 `Java5CharacterUtils` singleton으로 제공된다.
+ * - surrogate pair를 고려한 읽기/변환 API를 포함한다.
+ * - 버퍼 기반 읽기 시 trailing high surrogate를 별도로 보관해 다음 호출과 연결한다.
+ *
+ * ```kotlin
+ * val utils = CharacterUtils.getInstance()
+ * val buffer = CharacterUtils.newCharacterBuffer(8)
+ * // buffer.length == 0
+ * // utils.codePointCount("한글") == 2
+ * ```
  */
 abstract class CharacterUtils: Serializable {
 
@@ -16,15 +28,57 @@ abstract class CharacterUtils: Serializable {
         private val JAVA_5: CharacterUtils = Java5CharacterUtils()
 
         @JvmStatic
+        /**
+         * 런타임 기본 문자 유틸리티 구현 인스턴스를 반환한다.
+         *
+         * ## 동작/계약
+         * - 항상 동일 singleton 인스턴스를 반환한다.
+         * - 현재 구현은 `Java5CharacterUtils`로 고정되어 있다.
+         *
+         * ```kotlin
+         * val one = CharacterUtils.getInstance()
+         * val two = CharacterUtils.getInstance()
+         * // one === two
+         * ```
+         */
         fun getInstance(): CharacterUtils = JAVA_5
 
         @JvmStatic
+        /**
+         * 지정 크기의 문자 버퍼를 생성한다.
+         *
+         * ## 동작/계약
+         * - `bufferSize >= 2`를 `assert`로 검증한다.
+         * - 버퍼 내용은 비어 있고 `offset`, `length`는 0으로 초기화된다.
+         * - assert 비활성(`-ea` 미적용) 환경에서는 조건 검증이 생략될 수 있다.
+         *
+         * ```kotlin
+         * val buffer = CharacterUtils.newCharacterBuffer(4)
+         * // buffer.buffer.size == 4
+         * // buffer.length == 0
+         * ```
+         */
         fun newCharacterBuffer(bufferSize: Int): CharacterBuffer {
             assert(bufferSize >= 2) { "buffer size must be >= 2" }
             return CharacterBuffer(CharArray(bufferSize), 0, 0)
         }
 
         @JvmStatic
+        /**
+         * `Reader`에서 지정 길이만큼 문자를 읽어 대상 배열에 채운다.
+         *
+         * ## 동작/계약
+         * - EOF(`-1`)를 만나거나 `len`만큼 채울 때까지 반복 읽기를 수행한다.
+         * - 반환값은 실제로 읽은 문자 수다.
+         * - 부분 읽기 상황에서도 이미 읽은 데이터는 `dest`에 유지된다.
+         *
+         * ```kotlin
+         * val out = CharArray(5)
+         * val read = CharacterUtils.readFully("abc".reader(), out, 0, 5)
+         * // read == 3
+         * // String(out, 0, read) == "abc"
+         * ```
+         */
         fun readFully(reader: Reader, dest: CharArray, offset: Int, len: Int): Int {
             var read = 0
             while (read < len) {
@@ -39,31 +93,61 @@ abstract class CharacterUtils: Serializable {
     }
 
     /**
-     * [CharSequence] 의 주어진 인덱스에 있는 유니코드 code point를 반환합니다.
+     * `CharSequence`의 지정 위치 코드포인트를 반환한다.
      *
-     * @param seq    문자열
-     * @param offset 오프셋
-     * @return [offset]의 유니코드 code point
+     * ## 동작/계약
+     * - 구현체가 surrogate pair를 반영해 코드포인트를 계산한다.
+     * - `offset`은 조회 시작 인덱스다.
+     *
+     * ```kotlin
+     * val cp = CharacterUtils.getInstance().codePointAt("abc", 1)
+     * // cp == 'b'.code
+     * ```
      */
     abstract fun codePointAt(seq: CharSequence, offset: Int = 0): Int
 
     /**
-     * [CharArray]의 주어진 인덱스에 있는 유니코드 code point를 반환합니다.
+     * 문자 배열 구간에서 지정 위치 코드포인트를 반환한다.
      *
-     * @param chars  문자 배열
-     * @param offset 오프셋 (시작 인덱스)
-     * @param limit  코드 포인트를 가져올 끝 인덱스
-     * @return [offset]의 유니코드 code point
+     * ## 동작/계약
+     * - `offset`은 시작 위치, `limit`은 탐색 가능한 끝 경계다.
+     * - surrogate pair가 포함된 입력에서도 한 코드포인트를 반환한다.
+     *
+     * ```kotlin
+     * val chars = "한".toCharArray()
+     * val cp = CharacterUtils.getInstance().codePointAt(chars, 0, chars.size)
+     * // Character.isValidCodePoint(cp) == true
+     * ```
      */
     abstract fun codePointAt(chars: CharArray, offset: Int, limit: Int): Int
 
     /**
-     * [seq]의 문자 수를 반환합니다.
+     * 입력 문자열의 코드포인트 개수를 반환한다.
+     *
+     * ## 동작/계약
+     * - 구현체 기준으로 surrogate pair를 1개 코드포인트로 계산한다.
+     * - 반환값은 문자열 길이와 다를 수 있다.
+     *
+     * ```kotlin
+     * val count = CharacterUtils.getInstance().codePointCount("A😀")
+     * // count == 2
+     * ```
      */
     abstract fun codePointCount(seq: CharSequence): Int
 
     /**
-     * [buffer]의 [offset]부터 [limit]까지의 문자를 소문자로 변환합니다.
+     * 버퍼 구간의 문자를 코드포인트 단위로 소문자 변환한다.
+     *
+     * ## 동작/계약
+     * - `limit`이 버퍼 크기를 넘으면 검증 예외가 발생한다.
+     * - 변환은 전달된 `buffer`를 직접 수정한다.
+     * - 인덱스 이동은 코드포인트 길이(`Character.toChars` 반환값)로 계산한다.
+     *
+     * ```kotlin
+     * val chars = "ABC".toCharArray()
+     * CharacterUtils.getInstance().toLowerCase(chars, 0, chars.size)
+     * // String(chars) == "abc"
+     * ```
      */
     fun toLowerCase(buffer: CharArray, offset: Int, limit: Int) {
         buffer.size.assertGe(limit, "buffer size")
@@ -76,7 +160,17 @@ abstract class CharacterUtils: Serializable {
     }
 
     /**
-     * [buffer]의 [offset]부터 [limit]까지의 문자를 대문자로 변환합니다.
+     * 버퍼 구간의 문자를 코드포인트 단위로 대문자 변환한다.
+     *
+     * ## 동작/계약
+     * - `limit`과 `offset`에 대해 범위 검증을 수행한다.
+     * - 변환 결과는 입력 `buffer`에 제자리 반영된다.
+     *
+     * ```kotlin
+     * val chars = "abc".toCharArray()
+     * CharacterUtils.getInstance().toUpperCase(chars, 0, chars.size)
+     * // String(chars) == "ABC"
+     * ```
      */
     fun toUpperCase(buffer: CharArray, offset: Int, limit: Int) {
         buffer.size.assertGe(limit, "buffer size")
@@ -89,14 +183,19 @@ abstract class CharacterUtils: Serializable {
     }
 
     /**
-     * [src]의 [srcOff]부터 [srcLen]까지의 문자를 code points로 변환하여 [dest]에 저장합니다.
+     * 문자 배열 구간을 코드포인트 배열로 변환해 저장한다.
      *
-     * @param src    변환할 문자 배열
-     * @param srcOff 변환할 문자 배열의 시작 인덱스
-     * @param srcLen 변환할 문자 배열의 길이
-     * @param dest   변환된 code points를 저장할 배열
-     * @param destOff 변환된 code points를 저장할 배열의 시작 인덱스
-     * @return 변환된 code points의 수
+     * ## 동작/계약
+     * - `srcLen`은 0 이상이어야 하며 음수면 검증 예외가 발생한다.
+     * - 각 코드포인트를 `dest[destOff + index]`에 순차 기록한다.
+     * - 반환값은 실제로 기록한 코드포인트 개수다.
+     *
+     * ```kotlin
+     * val out = IntArray(4)
+     * val count = CharacterUtils.getInstance().toCodePoints("ab".toCharArray(), 0, 2, out, 0)
+     * // count == 2
+     * // out[0] == 'a'.code
+     * ```
      */
     fun toCodePoints(src: CharArray, srcOff: Int, srcLen: Int, dest: IntArray, destOff: Int): Int {
         srcLen.assertZeroOrPositiveNumber("srcLen")
@@ -113,14 +212,19 @@ abstract class CharacterUtils: Serializable {
     }
 
     /**
-     * [src]의 [srcOff]부터 [srcLen]까지의 code points를 문자로 변환하여 [dest]에 저장합니다.
+     * 코드포인트 배열 구간을 문자 배열로 변환해 저장한다.
      *
-     * @param src    변환할 code points 배열
-     * @param srcOff 변환할 code points 배열의 시작 인덱스
-     * @param srcLen 변환할 code points 배열의 길이
-     * @param dest   변환된 문자를 저장할 배열
-     * @param destOff 변환된 문자를 저장할 배열의 시작 인덱스
-     * @return 변환된 문자의 수
+     * ## 동작/계약
+     * - `srcLen`은 0 이상이어야 한다.
+     * - 각 코드포인트를 `Character.toChars`로 변환해 `dest`에 이어서 기록한다.
+     * - 반환값은 기록된 문자 수(UTF-16 code unit 수)다.
+     *
+     * ```kotlin
+     * val dest = CharArray(4)
+     * val written = CharacterUtils.getInstance().toChars(intArrayOf('a'.code, 'b'.code), 0, 2, dest, 0)
+     * // written == 2
+     * // String(dest, 0, written) == "ab"
+     * ```
      */
     fun toChars(src: IntArray, srcOff: Int, srcLen: Int, dest: CharArray, destOff: Int): Int {
         srcLen.assertZeroOrPositiveNumber("srcLen")
@@ -133,17 +237,33 @@ abstract class CharacterUtils: Serializable {
     }
 
     /**
-     * [buffer]에 [reader]로부터 최대 [numChars]만큼의 문자를 채웁니다.
+     * 리더에서 문자를 읽어 버퍼를 채운다.
      *
-     * @param buffer   문자 버퍼
-     * @param reader   문자를 읽을 [Reader]
-     * @param numChars 읽을 문자 수
-     * @return [buffer]가 완전히 채워졌으면 `true`, 그렇지 않으면 `false`
+     * ## 동작/계약
+     * - 반환값이 `true`면 요청한 `numChars`만큼 완전히 채운 상태다.
+     * - 구현체는 surrogate pair 경계를 보존하기 위해 trailing high surrogate를 보관할 수 있다.
+     *
+     * ```kotlin
+     * val utils = CharacterUtils.getInstance()
+     * val buffer = CharacterUtils.newCharacterBuffer(4)
+     * val full = utils.fill(buffer, "ab".reader(), 2)
+     * // full == true
+     * ```
      */
     abstract fun fill(buffer: CharacterBuffer, reader: Reader, numChars: Int = buffer.buffer.size): Boolean
 
     /**
-     * `buf[start:start+count]` 의 offset code points 떨어진 위치를 반환합니다.
+     * 지정 구간에서 코드포인트 오프셋 이동 후의 인덱스를 계산한다.
+     *
+     * ## 동작/계약
+     * - `buf[start:start+count]` 범위를 기준으로 `index`에서 `offset`만큼 이동한다.
+     * - 구현체는 문자 경계를 고려해 올바른 UTF-16 인덱스를 반환한다.
+     *
+     * ```kotlin
+     * val chars = "abcd".toCharArray()
+     * val index = CharacterUtils.getInstance().offsetByCodePoints(chars, 0, chars.size, 1, 2)
+     * // index == 3
+     * ```
      */
     abstract fun offsetByCodePoints(buf: CharArray, start: Int, count: Int, index: Int, offset: Int): Int
 
@@ -236,12 +356,41 @@ abstract class CharacterUtils: Serializable {
 
     }
 
+    /**
+     * 문자 버퍼 상태(배열, 오프셋, 길이, trailing surrogate)를 보관하는 컨테이너다.
+     *
+     * ## 동작/계약
+     * - `buffer`는 실제 읽기/변환에 사용되는 가변 배열이다.
+     * - `offset`, `length`는 내부 연산으로 갱신되며 외부에서는 읽기 중심으로 사용한다.
+     * - `reset()` 호출 시 상태를 초기화해 재사용할 수 있다.
+     *
+     * ```kotlin
+     * val buffer = CharacterUtils.newCharacterBuffer(6)
+     * buffer.reset()
+     * // buffer.offset == 0
+     * // buffer.length == 0
+     * ```
+     */
     class CharacterBuffer private constructor(
         val buffer: CharArray,
     ) {
 
         companion object {
             @JvmStatic
+            /**
+             * 기존 배열을 감싸는 `CharacterBuffer`를 생성한다.
+             *
+             * ## 동작/계약
+             * - 전달한 `offset`, `length`를 그대로 상태값으로 설정한다.
+             * - 배열은 복사하지 않고 참조를 공유한다.
+             *
+             * ```kotlin
+             * val raw = CharArray(4)
+             * val buffer = CharacterUtils.CharacterBuffer(raw, offset = 1, length = 2)
+             * // buffer.offset == 1
+             * // buffer.length == 2
+             * ```
+             */
             operator fun invoke(buffer: CharArray, offset: Int = 0, length: Int = 0): CharacterBuffer {
                 return CharacterBuffer(buffer).apply {
                     this.offset = offset
@@ -250,13 +399,63 @@ abstract class CharacterUtils: Serializable {
             }
         }
 
+        /**
+         * 현재 유효 데이터의 시작 오프셋이다.
+         *
+         * ## 동작/계약
+         * - 내부 로직에서만 갱신할 수 있고 외부에서는 읽기 전용으로 사용한다.
+         * - `reset()` 호출 시 0으로 초기화된다.
+         *
+         * ```kotlin
+         * val buffer = CharacterUtils.newCharacterBuffer(4)
+         * buffer.reset()
+         * // buffer.offset == 0
+         * ```
+         */
         var offset: Int = 0
             internal set
+        /**
+         * 버퍼에 채워진 유효 문자 수다.
+         *
+         * ## 동작/계약
+         * - `fill` 호출 시 읽은 문자 수에 맞춰 갱신된다.
+         * - `reset()` 호출 시 0으로 초기화된다.
+         *
+         * ```kotlin
+         * val buffer = CharacterUtils.newCharacterBuffer(4)
+         * // buffer.length == 0
+         * ```
+         */
         var length: Int = 0
             internal set
 
+        /**
+         * 다음 읽기에서 이어 붙일 trailing high surrogate 문자를 저장한다.
+         *
+         * ## 동작/계약
+         * - 유효한 값이 없을 때는 `0.toChar()`를 사용한다.
+         * - `reset()` 호출 시 초기값으로 복원된다.
+         *
+         * ```kotlin
+         * val buffer = CharacterUtils.newCharacterBuffer(4)
+         * // buffer.lastTrailingHighSurrogate == 0.toChar()
+         * ```
+         */
         var lastTrailingHighSurrogate: Char = 0.toChar()
 
+        /**
+         * 버퍼 상태를 초기값으로 재설정한다.
+         *
+         * ## 동작/계약
+         * - `offset`, `length`, `lastTrailingHighSurrogate`를 모두 초기화한다.
+         * - 내부 배열 `buffer` 내용은 유지되며 메타데이터만 재설정된다.
+         *
+         * ```kotlin
+         * val buffer = CharacterUtils.newCharacterBuffer(4)
+         * buffer.reset()
+         * // buffer.length == 0
+         * ```
+         */
         fun reset() {
             offset = 0
             length = 0

--- a/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/utils/DictionaryProvider.kt
+++ b/tokenizer/core/src/main/kotlin/io/bluetape4k/tokenizer/utils/DictionaryProvider.kt
@@ -9,7 +9,17 @@ import java.io.InputStreamReader
 import java.util.zip.GZIPInputStream
 
 /**
- * 리소스에 있는 사전 파일을 읽어 제공하는 유틸리티 클래스
+ * 클래스패스 리소스 사전 파일을 읽어 토크나이저 입력 구조로 변환하는 유틸리티다.
+ *
+ * ## 동작/계약
+ * - UTF-8 기준으로 라인을 읽고 `trim()` 처리한 문자열을 제공한다.
+ * - `.gz` 확장자는 `GZIPInputStream`으로 자동 해제한다.
+ * - Flow 기반 비동기 로딩 API를 통해 여러 사전 경로를 병렬 수집할 수 있다.
+ *
+ * ```kotlin
+ * val words = DictionaryProvider.readWordsAsSequence("dict/custom.txt").take(2).toList()
+ * // words.size <= 2
+ * ```
  */
 object DictionaryProvider: KLogging() {
 
@@ -17,7 +27,17 @@ object DictionaryProvider: KLogging() {
     private const val TAB = "\t"
 
     /**
-     * [stream]을 라인 단위로 읽어 Sequence로 반환합니다.
+     * 입력 스트림을 라인 시퀀스로 읽어 공백 제거된 문자열을 반환한다.
+     *
+     * ## 동작/계약
+     * - UTF-8 디코딩 후 `lineSequence()`로 지연 평가 시퀀스를 생성한다.
+     * - 각 라인은 `trim()`을 적용한 값으로 변환된다.
+     *
+     * ```kotlin
+     * val bytes = "a\\n b ".byteInputStream()
+     * val lines = DictionaryProvider.readStreamByLine(bytes).toList()
+     * // lines == listOf("a", "b")
+     * ```
      */
     fun readStreamByLine(stream: InputStream): Sequence<String> {
         return InputStreamReader(stream, Charsets.UTF_8)
@@ -27,7 +47,17 @@ object DictionaryProvider: KLogging() {
     }
 
     /**
-     * [path]에 있는 리소스 파일을 읽어 라인 단위로 반환합니다.
+     * 클래스패스 리소스를 열어 라인 시퀀스로 반환한다.
+     *
+     * ## 동작/계약
+     * - `classLoader.getResourceAsStream(path)`가 `null`이면 `check` 예외가 발생한다.
+     * - `.gz` 파일은 압축 해제 후 라인 단위로 읽는다.
+     * - 일반 텍스트 파일은 원본 스트림을 직접 읽는다.
+     *
+     * ```kotlin
+     * val lines = DictionaryProvider.readFileByLineFromResources("dict/words.txt")
+     * // lines.first().isNotBlank() == true
+     * ```
      */
     fun readFileByLineFromResources(
         path: String,
@@ -46,9 +76,17 @@ object DictionaryProvider: KLogging() {
     }
 
     /**
-     * [path]에 있는 파일을 읽어 단어의 빈도 정보를 반환합니다.
+     * 단어-빈도 사전 파일을 읽어 `단어 -> 빈도(Float)` 맵으로 적재한다.
      *
-     * 단어의 빈도 정보는 형태소 분석기 시에 확률로 판단할 때 사용합니다.
+     * ## 동작/계약
+     * - 탭(`\t`)을 포함한 라인만 처리한다.
+     * - 탭 뒤 문자열의 앞 6글자를 `Float`로 파싱해 빈도로 저장한다.
+     * - 결과는 전달된 `destination`에 누적되며 동일 키는 마지막 값으로 덮어쓴다.
+     *
+     * ```kotlin
+     * val map = DictionaryProvider.readWordFreqs("dict/freqs.txt", mutableMapOf())
+     * // map.isNotEmpty() == true
+     * ```
      */
     fun readWordFreqs(
         path: String,
@@ -70,6 +108,18 @@ object DictionaryProvider: KLogging() {
         return destination
     }
 
+    /**
+     * 공백으로 구분된 2열 사전 파일을 `(단어, 매핑값)` 시퀀스로 반환한다.
+     *
+     * ## 동작/계약
+     * - 공백이 포함된 라인만 처리한다.
+     * - 각 라인은 첫 공백 기준으로 2개 문자열로 분리된다.
+     *
+     * ```kotlin
+     * val pairs = DictionaryProvider.readWordMap("dict/map.txt").take(1).toList()
+     * // pairs.size <= 1
+     * ```
+     */
     fun readWordMap(filename: String): Sequence<Pair<String, String>> {
         return readFileByLineFromResources(filename)
             .filter { it.contains(SPACE) }
@@ -79,10 +129,35 @@ object DictionaryProvider: KLogging() {
             }
     }
 
+    /**
+     * 리소스 파일의 라인을 그대로 단어 시퀀스로 반환한다.
+     *
+     * ## 동작/계약
+     * - 내부적으로 `readFileByLineFromResources`를 그대로 위임 호출한다.
+     * - 지연 시퀀스이므로 소비 시점에 실제 읽기가 수행된다.
+     *
+     * ```kotlin
+     * val first = DictionaryProvider.readWordsAsSequence("dict/words.txt").first()
+     * // first.isNotBlank() == true
+     * ```
+     */
     fun readWordsAsSequence(filename: String): Sequence<String> {
         return readFileByLineFromResources(filename)
     }
 
+    /**
+     * 여러 리소스 파일의 단어를 비동기로 읽어 `MutableSet`에 누적한다.
+     *
+     * ## 동작/계약
+     * - `paths`를 Flow로 순회하며 각 경로를 `async` 확장으로 비동기 변환한다.
+     * - 수집된 라인을 `destination`에 `addAll`로 합친다.
+     * - 반환값은 누적 결과가 반영된 동일 `destination` 인스턴스다.
+     *
+     * ```kotlin
+     * val words = DictionaryProvider.readWordsAsSet("dict/a.txt", "dict/b.txt")
+     * // words.isNotEmpty() == true
+     * ```
+     */
     suspend fun readWordsAsSet(
         vararg paths: String,
         destination: MutableSet<String> = mutableSetOf(),
@@ -99,7 +174,17 @@ object DictionaryProvider: KLogging() {
     }
 
     /**
-     * [paths]에 있는 파일을 읽어 단어를 [CharArraySet]으로 반환합니다.
+     * 여러 리소스 파일의 단어를 읽어 `CharArraySet`으로 누적 반환한다.
+     *
+     * ## 동작/계약
+     * - 각 경로의 라인 시퀀스를 비동기 Flow로 수집한다.
+     * - 수집 결과를 `destination.addAll`로 합치며 중복 단어는 집합 특성상 하나만 유지된다.
+     * - 반환값은 입력 `destination` 자체다.
+     *
+     * ```kotlin
+     * val set = DictionaryProvider.readWords("dict/stopwords.txt")
+     * // set.size > 0
+     * ```
      */
     suspend fun readWords(
         vararg paths: String,
@@ -116,6 +201,18 @@ object DictionaryProvider: KLogging() {
         return destination
     }
 
+    /**
+     * 사전 단어 적재용 기본 `CharArraySet`을 생성한다.
+     *
+     * ## 동작/계약
+     * - 초기 용량 5,000으로 집합을 생성한다.
+     * - 사전 로딩 시 리해시 빈도를 줄이기 위한 기본값이다.
+     *
+     * ```kotlin
+     * val set = DictionaryProvider.newCharArraySet()
+     * // set.isEmpty() == true
+     * ```
+     */
     fun newCharArraySet(): CharArraySet {
         return CharArraySet(5_000)
     }

--- a/tokenizer/japanese/src/main/kotlin/io/bluetape4k/tokenizer/japanese/JapaneseProcessor.kt
+++ b/tokenizer/japanese/src/main/kotlin/io/bluetape4k/tokenizer/japanese/JapaneseProcessor.kt
@@ -9,23 +9,36 @@ import io.bluetape4k.tokenizer.model.BlockwordRequest
 import io.bluetape4k.tokenizer.model.BlockwordResponse
 
 /**
- * 일본어 형태소 분석을 기반으로 다양한 기능을 제공합니다.
+ * 일본어 토큰화와 금칙어 검출/마스킹 기능을 한 곳에서 제공하는 파사드입니다.
+ *
+ * ## 동작/계약
+ * - 형태소 분석 계열 API는 `JapaneseTokenizer`로 위임합니다.
+ * - 금칙어 계열 API는 `JapaneseBlockwordProcessor`와 `JapaneseDictionaryProvider`로 위임합니다.
+ * - 내부적으로 상태를 저장하지 않고 하위 컴포넌트의 동작을 그대로 노출합니다.
+ *
+ * ```kotlin
+ * val nouns = JapaneseProcessor
+ *     .filterNoun(JapaneseProcessor.tokenize("私は、日本語の勉強をしています。"))
+ *     .map { it.surface }
+ *
+ * // result == ["私", "日本語", "勉強"]
+ * ```
  */
 object JapaneseProcessor: KLogging() {
 
     /**
-     * 일본어 형태소 분석을 수행합니다.
+     * 입력 문장을 형태소 토큰 목록으로 분석해 반환합니다.
      *
-     * ```
-     * val tokens: List<Token> = JapaneseTokenizer.tokenize("お寿司が食べたい。")
+     * ## 동작/계약
+     * - `JapaneseTokenizer.tokenize`를 그대로 위임 호출합니다.
+     * - 빈 문자열 입력 시 빈 리스트를 반환합니다.
+     * - 반환 순서는 원문 토큰 순서를 유지합니다.
      *
-     * // 결과
-     * token=お: 接頭詞,名詞接続,*,*,*,*,お,オ,オ, 0
-     * token=寿司: 名詞,一般,*,*,*,*,寿司,スシ,スシ, 1
-     * token=が: 助詞,格助詞,一般,*,*,*,が,ガ,ガ, 3
-     * token=食べ: 動詞,自立,*,*,一段,連用形,食べる,タベ,タベ, 4
-     * token=たい: 助動詞,*,*,*,特殊・タイ,基本形,たい,タイ,タイ, 6
-     * token=。: 記号,句点,*,*,*,*,。,。,。, 8
+     * ```kotlin
+     * val tokens = JapaneseProcessor.tokenize("お寿司が食べたい。")
+     * val surfaces = tokens.map { it.surface }
+     *
+     * // result == ["お", "寿司", "が", "食べ", "たい", "。"]
      * ```
      */
     fun tokenize(text: String): List<Token> {
@@ -33,11 +46,18 @@ object JapaneseProcessor: KLogging() {
     }
 
     /**
-     * 형태소 분석 결과에서 특정 조건에 맞는 토큰만 필터링합니다.
+     * 토큰 목록에서 조건식을 만족하는 항목만 필터링해 반환합니다.
      *
-     * ```
-     * val tokens: List<Token> = JapaneseTokenizer.tokenize("お寿司が食べたい。")
-     * val filtered = filter(tokens) { it.partOfSpeechLevel1 == "名詞" }
+     * ## 동작/계약
+     * - `JapaneseTokenizer.filter`를 그대로 위임 호출합니다.
+     * - 입력 리스트는 변경하지 않고 새 리스트를 반환합니다.
+     * - `predicate`의 평가 순서는 입력 순서를 따릅니다.
+     *
+     * ```kotlin
+     * val tokens = JapaneseProcessor.tokenize("お寿司が食べたい。")
+     * val nouns = JapaneseProcessor.filter(tokens) { it.isNoun() }.map { it.surface }
+     *
+     * // result == ["寿司"]
      * ```
      */
     fun filter(tokens: List<Token>, predicate: (Token) -> Boolean): List<Token> {
@@ -45,11 +65,18 @@ object JapaneseProcessor: KLogging() {
     }
 
     /**
-     * 형태소 분석 결과에서 명사만 필터링합니다.
+     * 토큰 목록에서 명사(`名詞`)만 필터링해 반환합니다.
      *
-     * ```
-     * val tokens: List<Token> = JapaneseTokenizer.tokenize("お寿司が食べたい。")
-     * val nouns = filterNoun(tokens)  // [寿司]
+     * ## 동작/계약
+     * - `JapaneseTokenizer.filterNoun`를 그대로 위임 호출합니다.
+     * - 명사 판정은 `TokenBaseSupport.isNoun` 기준을 따릅니다.
+     * - 입력 순서를 유지한 새 리스트를 반환합니다.
+     *
+     * ```kotlin
+     * val tokens = JapaneseProcessor.tokenize("私は、日本語の勉強をしています。")
+     * val nouns = JapaneseProcessor.filterNoun(tokens).map { it.surface }
+     *
+     * // result == ["私", "日本語", "勉強"]
      * ```
      */
     fun filterNoun(tokens: List<Token>): List<Token> {
@@ -57,59 +84,95 @@ object JapaneseProcessor: KLogging() {
     }
 
     /**
-     * 금칙어에 해당하는 단어를 찾습니다.
+     * 문장에서 금칙어 사전에 등록된 토큰을 찾아 반환합니다.
      *
-     * ```
-     * val text = "ホモの男性を理解できない"
-     * val response = processBlockword(text)
-     * response.blockwordExists // true
-     * println(response.blockWords) // [ホモ]
-     * ```
+     * ## 동작/계약
+     * - `JapaneseBlockwordProcessor.findBlockwords`를 그대로 위임 호출합니다.
+     * - 입력이 공백 문자열이면 빈 리스트를 반환합니다.
+     * - 기본 토큰 매칭 실패 시 복합어(명사+명사/동사) 조합 검사 결과를 포함할 수 있습니다.
      *
-     * @param text 일본어 문장
-     * @return 금칙어에 해당하는 [Token] 리스트
+     * ```kotlin
+     * val blockwords = JapaneseProcessor.findBlockwords("ホモの男性を理解できない").map { it.surface }
+     *
+     * // result == ["ホモ"]
+     * ```
      */
     fun findBlockwords(text: String): List<Token> {
         return JapaneseBlockwordProcessor.findBlockwords(text)
     }
 
     /**
-     * 일본어 문장에서 금칙어를 마스킹 합니다.
+     * 금칙어를 마스크 문자열로 치환한 결과를 반환합니다.
      *
-     * ```
-     * val text = "ホモの男性を理解できない"
-     * val request = blockwordRequestOf(text)
-     * val response = maskBlockwords(request)
-     * println(response.maskedText) // ***の男性を理解できない
-     * ```
+     * ## 동작/계약
+     * - `JapaneseBlockwordProcessor.maskBlockwords`를 그대로 위임 호출합니다.
+     * - 금칙어가 없으면 `maskedText`는 원문과 동일하고 `blockwordExists`는 `false`입니다.
+     * - 금칙어가 있으면 토큰 길이만큼 마스크 문자를 반복해 해당 위치를 치환합니다.
      *
-     * @param request 금칙어 처리 요청 정보 [BlockwordRequest]
-     * @return 금칙어를 처리한 결과 [BlockwordResponse]
+     * ```kotlin
+     * val request = io.bluetape4k.tokenizer.model.blockwordRequestOf("ホモの男性を理解できない")
+     * val response = JapaneseProcessor.maskBlockwords(request)
+     *
+     * // response.maskedText == "**の男性を理解できない"
+     * ```
      */
     fun maskBlockwords(request: BlockwordRequest): BlockwordResponse {
         return JapaneseBlockwordProcessor.maskBlockwords(request)
     }
 
     /**
-     * 금칙어를 사전에 추가합니다.
+     * 금칙어 사전에 단어를 추가합니다.
      *
-     * @param words 추가할 금칙어
+     * ## 동작/계약
+     * - `JapaneseDictionaryProvider.addBlockwords`를 그대로 위임 호출합니다.
+     * - 이미 존재하는 단어는 사전 집합 특성상 중복 저장되지 않습니다.
+     * - 이후 `findBlockwords`/`maskBlockwords` 호출부터 즉시 반영됩니다.
+     *
+     * ```kotlin
+     * JapaneseProcessor.addBlockwords(listOf("東京"))
+     * val found = JapaneseProcessor.findBlockwords("これは東京です").map { it.surface }
+     *
+     * // result == ["東京"]
+     * ```
      */
     fun addBlockwords(words: List<String>) {
         JapaneseDictionaryProvider.addBlockwords(words)
     }
 
     /**
-     * 사전에서 해당 금칙어를 삭제합니다.
+     * 금칙어 사전에서 단어를 제거합니다.
      *
-     * @param words 삭제할 금칙어
+     * ## 동작/계약
+     * - `JapaneseDictionaryProvider.removeBlockwords`를 그대로 위임 호출합니다.
+     * - 존재하지 않는 단어를 전달해도 예외 없이 무시됩니다.
+     * - 제거 후 동일 단어는 금칙어 탐지 대상에서 제외됩니다.
+     *
+     * ```kotlin
+     * JapaneseProcessor.addBlockwords(listOf("東京"))
+     * JapaneseProcessor.removeBlockwords(listOf("東京"))
+     * val found = JapaneseProcessor.findBlockwords("これは東京です")
+     *
+     * // result == []
+     * ```
      */
     fun removeBlockwords(words: List<String>) {
         JapaneseDictionaryProvider.removeBlockwords(words)
     }
 
     /**
-     * 모든 금칙어를 삭제합니다.
+     * 메모리에 로드된 금칙어 사전을 비웁니다.
+     *
+     * ## 동작/계약
+     * - `JapaneseDictionaryProvider.clearBlockwords`를 그대로 위임 호출합니다.
+     * - 호출 이후 현재 프로세스 내 사전은 빈 상태가 됩니다.
+     * - 원본 리소스 파일을 삭제하지 않으며 재초기화 시 다시 로드됩니다.
+     *
+     * ```kotlin
+     * JapaneseProcessor.clearBlockwords()
+     * val found = JapaneseProcessor.findBlockwords("ホモの男性を理解できない")
+     *
+     * // result == []
+     * ```
      */
     fun clearBlockwords() {
         JapaneseDictionaryProvider.clearBlockwords()

--- a/tokenizer/japanese/src/main/kotlin/io/bluetape4k/tokenizer/japanese/block/JapaneseBlockwordProcessor.kt
+++ b/tokenizer/japanese/src/main/kotlin/io/bluetape4k/tokenizer/japanese/block/JapaneseBlockwordProcessor.kt
@@ -16,20 +16,37 @@ import io.bluetape4k.tokenizer.model.BlockwordResponse
 import io.bluetape4k.tokenizer.model.blockwordResponseOf
 
 /**
- * 일본어 문장중에 금칙어가 있는 경우 Masking 처리를 수행합니다.
+ * 일본어 문장에서 금칙어를 탐지하고 마스킹 결과를 생성하는 처리기입니다.
+ *
+ * ## 동작/계약
+ * - 금칙어 판단은 `JapaneseDictionaryProvider.blockWordDictionary` 포함 여부를 기준으로 합니다.
+ * - 탐지/마스킹 대상 품사는 명사 또는 동사(`isNounOrVerb`)로 제한됩니다.
+ * - 단일 토큰 탐지 실패 시 복합어(앞 토큰 명사 + 뒤 토큰 명사/동사) 조합을 추가 검사합니다.
+ *
+ * ```kotlin
+ * val blockwords = JapaneseBlockwordProcessor
+ *     .findBlockwords("ホモの男性を理解できない")
+ *     .map { it.surface }
+ *
+ * // result == ["ホモ"]
+ * ```
  */
 object JapaneseBlockwordProcessor: KLogging() {
 
     /**
-     * 금칙어에 해당하는 단어를 찾습니다.
+     * 입력 문장에서 금칙어에 해당하는 토큰 목록을 반환합니다.
      *
-     * ```
-     * val text = "ホモの男性を理解できない"
-     * val tokens = findBlockwords(text)  // [ホモ]
-     * ```
+     * ## 동작/계약
+     * - `text`가 blank이면 즉시 빈 리스트를 반환합니다.
+     * - 토큰을 명사/동사로 1차 필터링한 뒤 사전 포함 여부를 검사합니다.
+     * - 1차 결과가 비어 있고 토큰이 2개 이상이면 복합어 검사 결과를 추가합니다.
      *
-     * @param text 일본어 문장
-     * @return 금칙어에 해당하는 [Token] 리스트
+     * ```kotlin
+     * val found = JapaneseBlockwordProcessor.findBlockwords("覚せい剤を注文できるサイトはありますか？")
+     *     .map { it.surface }
+     *
+     * // result == ["覚せい"]
+     * ```
      */
     fun findBlockwords(text: String): List<Token> {
         if (text.isBlank()) {
@@ -50,20 +67,18 @@ object JapaneseBlockwordProcessor: KLogging() {
     }
 
     /**
-     * 복합명사, 명사+동사 에 대한 금칙어 처리를 수행합니다.
+     * 복합 명사 또는 명사+동사 조합을 금칙어 사전으로 추가 검사합니다.
      *
      * 예:
      *  覚せい剤 : 覚せい(각성) + 剤(제)
      *  盗撮す: 盗(명사) + 撮す(동사), 도찰하다
      *
-     * ```
-     * val text = "覚せい剤を使用するな"
-     * val tokens = JapaneseTokenizer.tokenize(text)
-     * val blockwords = processCompositBlockWords(tokens)  // [覚せい]
-     * ```
+     * ```kotlin
+     * val request = io.bluetape4k.tokenizer.model.blockwordRequestOf("覚せい剤を注文できるサイトはありますか？")
+     * val response = JapaneseBlockwordProcessor.maskBlockwords(request)
      *
-     * @param tokens [Token] 리스트
-     * @return 복합명사로서 금칙어에 해댱하는 [Token] 리스트
+     * // response.blockwordExists == true
+     * ```
      */
     private fun processCompositBlockWords(tokens: List<Token>): List<Token> {
         if (tokens.size < 2) {
@@ -81,16 +96,19 @@ object JapaneseBlockwordProcessor: KLogging() {
     }
 
     /**
-     * 일본어 문장에서 금칙어를 마스킹 합니다. 금칙어가 없는 경우 원본 문장을 반환합니다.
+     * 요청 텍스트에서 금칙어를 마스크 문자열로 치환한 응답을 반환합니다.
      *
-     * ```
-     * val request = BlockwordRequest("ホモの男性を理解できない")
-     * val response = maskBlockwords(request)
-     * println(response.maskedText) // ***の男性を理解できない
-     * ```
+     * ## 동작/계약
+     * - 요청 텍스트가 blank이면 `maskedText`가 빈 문자열인 응답을 반환합니다.
+     * - 명사/동사 토큰 중 사전에 존재하는 표면형만 치환하고, 치환 길이는 토큰 길이와 동일합니다.
+     * - 처리 중 예외가 발생하면 `TokenizerException`으로 감싸 재전파합니다.
      *
-     * @param request 금칙어 처리 요청 정보 [BlockwordRequest]
-     * @return 금칙어를 처리한 결과 [BlockwordResponse]
+     * ```kotlin
+     * val request = io.bluetape4k.tokenizer.model.blockwordRequestOf("ホモの男性を理解できない")
+     * val response = JapaneseBlockwordProcessor.maskBlockwords(request)
+     *
+     * // response.maskedText == "**の男性を理解できない"
+     * ```
      */
     fun maskBlockwords(request: BlockwordRequest): BlockwordResponse {
         if (request.text.isBlank()) {

--- a/tokenizer/japanese/src/main/kotlin/io/bluetape4k/tokenizer/japanese/tokenizer/JapaneseTokenizer.kt
+++ b/tokenizer/japanese/src/main/kotlin/io/bluetape4k/tokenizer/japanese/tokenizer/JapaneseTokenizer.kt
@@ -5,27 +5,37 @@ import com.atilika.kuromoji.ipadic.Tokenizer
 import io.bluetape4k.logging.KLogging
 
 /**
- * Kuromoji IPAdic 기반 일본어 형태소 분석기
+ * Kuromoji IPAdic 분석기를 사용해 일본어 문장을 형태소 토큰 목록으로 변환하는 진입점입니다.
  *
- * 일본어 텍스트를 형태소 단위로 분리하고, 품사별 필터링 기능을 제공합니다.
+ * ## 동작/계약
+ * - 내부 `Tokenizer` 인스턴스는 지연 초기화되며 객체 수명 동안 재사용됩니다.
+ * - `tokenize` 결과는 Kuromoji 분석 순서(원문 등장 순서)를 유지합니다.
+ * - 품사 필터링은 `filter`, `filterNoun`으로 후처리합니다.
+ *
+ * ```kotlin
+ * val tokens = JapaneseTokenizer.tokenize("お寿司が食べたい。")
+ * val surfaces = tokens.map { it.surface }
+ *
+ * // result == ["お", "寿司", "が", "食べ", "たい", "。"]
+ * ```
  */
 object JapaneseTokenizer: KLogging() {
 
     internal val tokenizer: Tokenizer by lazy { Tokenizer.Builder().build() }
 
     /**
-     * 일본어 형태소 분석을 수행합니다.
+     * 입력 문장을 Kuromoji IPAdic 규칙으로 형태소 분석해 토큰 목록으로 반환합니다.
      *
-     * ```
-     * val tokens: List<Token> = JapaneseTokenizer.tokenize("お寿司が食べたい。")
+     * ## 동작/계약
+     * - 빈 문자열 입력 시 빈 리스트를 반환합니다.
+     * - 반환 리스트의 각 원소는 표면형(`surface`), 위치(`position`), 품사 정보를 포함합니다.
+     * - 동일 입력에 대해 사전 상태가 같다면 동일한 분해 결과를 반환합니다.
      *
-     * // 결과
-     * token=お: 接頭詞,名詞接続,*,*,*,*,お,オ,オ, 0
-     * token=寿司: 名詞,一般,*,*,*,*,寿司,スシ,スシ, 1
-     * token=が: 助詞,格助詞,一般,*,*,*,が,ガ,ガ, 3
-     * token=食べ: 動詞,自立,*,*,一段,連用形,食べる,タベ,タベ, 4
-     * token=たい: 助動詞,*,*,*,特殊・タイ,基本形,たい,タイ,タイ, 6
-     * token=。: 記号,句点,*,*,*,*,。,。,。, 8
+     * ```kotlin
+     * val tokens = JapaneseTokenizer.tokenize("お寿司が食べたい。")
+     * val surfaces = tokens.map { it.surface }
+     *
+     * // result == ["お", "寿司", "が", "食べ", "たい", "。"]
      * ```
      */
     fun tokenize(text: String): List<Token> {
@@ -33,11 +43,18 @@ object JapaneseTokenizer: KLogging() {
     }
 
     /**
-     * 형태소 분석 결과에서 특정 조건에 맞는 토큰만 필터링합니다.
+     * 토큰 목록에서 전달한 조건식을 만족하는 항목만 새 리스트로 반환합니다.
      *
-     * ```
-     * val tokens: List<Token> = JapaneseTokenizer.tokenize("お寿司が食べたい。")
-     * val filtered = filter(tokens) { it.partOfSpeechLevel1 == "名詞" }
+     * ## 동작/계약
+     * - 입력 리스트는 변경하지 않고 `List.filter` 결과를 새로 생성합니다.
+     * - `predicate`는 토큰 순서대로 호출되며 `true`인 항목만 유지됩니다.
+     * - 조건식은 호출 측에서 품사/표면형/위치 기준으로 자유롭게 정의할 수 있습니다.
+     *
+     * ```kotlin
+     * val tokens = JapaneseTokenizer.tokenize("お寿司が食べたい。")
+     * val punctuations = JapaneseTokenizer.filter(tokens) { it.isPunctuation() }
+     *
+     * // result == ["。"]
      * ```
      */
     fun filter(tokens: List<Token>, predicate: (Token) -> Boolean): List<Token> {
@@ -45,11 +62,18 @@ object JapaneseTokenizer: KLogging() {
     }
 
     /**
-     * 형태소 분석 결과에서 명사만 필터링합니다.
+     * 토큰 목록에서 명사 품사(`名詞`)인 항목만 추려 반환합니다.
      *
-     * ```
-     * val tokens: List<Token> = JapaneseTokenizer.tokenize("お寿司が食べたい。")
-     * val nouns = filterNoun(tokens)  // [寿司]
+     * ## 동작/계약
+     * - 내부적으로 `filter(tokens) { it.isNoun() }`를 호출합니다.
+     * - 입력 순서를 유지한 새 리스트를 반환하며 원본 리스트는 변경하지 않습니다.
+     * - 품사 판정은 `TokenBaseSupport.isNoun`의 기준(`allFeaturesArray[0] == "名詞"`)을 따릅니다.
+     *
+     * ```kotlin
+     * val tokens = JapaneseTokenizer.tokenize("私は、日本語の勉強をしています。")
+     * val nouns = JapaneseTokenizer.filterNoun(tokens).map { it.surface }
+     *
+     * // result == ["私", "日本語", "勉強"]
      * ```
      */
     fun filterNoun(tokens: List<Token>): List<Token> {

--- a/tokenizer/japanese/src/main/kotlin/io/bluetape4k/tokenizer/japanese/tokenizer/TokenBaseSupport.kt
+++ b/tokenizer/japanese/src/main/kotlin/io/bluetape4k/tokenizer/japanese/tokenizer/TokenBaseSupport.kt
@@ -3,36 +3,120 @@ package io.bluetape4k.tokenizer.japanese.tokenizer
 import com.atilika.kuromoji.TokenBase
 
 /**
- * 형태소 분석 결과에서 명사(名詞)인지 확인합니다.
+ * 토큰의 1차 품사(`allFeaturesArray[0]`)가 명사(`名詞`)인지 판별합니다.
+ *
+ * ## 동작/계약
+ * - 판별 기준은 `allFeaturesArray[0] == "名詞"` 비교입니다.
+ * - 형태소 사전의 세부 품사 레벨(2~4)은 사용하지 않습니다.
+ * - 불리언만 반환하며 토큰 상태를 변경하지 않습니다.
+ *
+ * ```kotlin
+ * val tokens = JapaneseTokenizer.tokenize("お寿司が食べたい。")
+ * val value = tokens.first { it.surface == "寿司" }.isNoun()
+ *
+ * // value == true
+ * ```
  */
 fun TokenBase.isNoun(): Boolean = this.allFeaturesArray[0] == "名詞"
 
 /**
- * 형태소 분석 결과에서 동사(動詞)인지 확인합니다.
+ * 토큰의 1차 품사(`allFeaturesArray[0]`)가 동사(`動詞`)인지 판별합니다.
+ *
+ * ## 동작/계약
+ * - 판별 기준은 `allFeaturesArray[0] == "動詞"` 비교입니다.
+ * - 활용형/원형 정보와 무관하게 1차 품사만 확인합니다.
+ * - 불리언만 반환하며 토큰 상태를 변경하지 않습니다.
+ *
+ * ```kotlin
+ * val tokens = JapaneseTokenizer.tokenize("お寿司が食べたい。")
+ * val value = tokens.first { it.surface == "食べ" }.isVerb()
+ *
+ * // value == true
+ * ```
  */
 fun TokenBase.isVerb(): Boolean = this.allFeaturesArray[0] == "動詞"
 
 /**
- * 형태소 분석 결과에서 명사 또는 동사인지 확인합니다.
+ * 토큰이 명사(`名詞`) 또는 동사(`動詞`)인 경우 `true`를 반환합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 `isNoun() || isVerb()`를 순서대로 평가합니다.
+ * - 품사 1차 분류 외 정보는 고려하지 않습니다.
+ * - 불리언만 반환하며 토큰 상태를 변경하지 않습니다.
+ *
+ * ```kotlin
+ * val tokens = JapaneseTokenizer.tokenize("お寿司が食べたい。")
+ * val value = tokens.first { it.surface == "が" }.isNounOrVerb()
+ *
+ * // value == false
+ * ```
  */
 fun TokenBase.isNounOrVerb(): Boolean = this.isNoun() || this.isVerb()
 
 /**
- * 형태소 분석 결과에서 형용사(形容詞)인지 확인합니다.
+ * 토큰의 1차 품사가 형용사(`形容詞`)인지 판별합니다.
+ *
+ * ## 동작/계약
+ * - 판별 기준은 `allFeaturesArray[0] == "形容詞"` 비교입니다.
+ * - 불리언만 반환하며 토큰 상태를 변경하지 않습니다.
+ * - Kuromoji 품사 체계 변경 시 결과도 해당 값에 따라 달라집니다.
+ *
+ * ```kotlin
+ * val tokens = JapaneseTokenizer.tokenize("美しい花")
+ * val value = tokens.first { it.surface == "美しい" }.isAdjective()
+ *
+ * // value == true
+ * ```
  */
 fun TokenBase.isAdjective(): Boolean = this.allFeaturesArray[0] == "形容詞"
 
 /**
- * 형태소 분석 결과에서 조사(助詞)인지 확인합니다.
+ * 토큰의 1차 품사가 조사(`助詞`)인지 판별합니다.
+ *
+ * ## 동작/계약
+ * - 판별 기준은 `allFeaturesArray[0] == "助詞"` 비교입니다.
+ * - 조사 세부 타입(격조사/종조사 등)은 별도로 구분하지 않습니다.
+ * - 불리언만 반환하며 토큰 상태를 변경하지 않습니다.
+ *
+ * ```kotlin
+ * val tokens = JapaneseTokenizer.tokenize("お寿司が食べたい。")
+ * val value = tokens.first { it.surface == "が" }.isJosa()
+ *
+ * // value == true
+ * ```
  */
 fun TokenBase.isJosa(): Boolean = this.allFeaturesArray[0] == "助詞"
 
 /**
- * 형태소 분석 결과에서 조동사(助動詞)인지 확인합니다.
+ * 토큰의 1차 품사가 조동사(`助動詞`)인지 판별합니다.
+ *
+ * ## 동작/계약
+ * - 판별 기준은 `allFeaturesArray[0] == "助動詞"` 비교입니다.
+ * - 활용형 문자열은 참고하지 않고 품사 코드만 사용합니다.
+ * - 불리언만 반환하며 토큰 상태를 변경하지 않습니다.
+ *
+ * ```kotlin
+ * val tokens = JapaneseTokenizer.tokenize("お寿司が食べたい。")
+ * val value = tokens.first { it.surface == "たい" }.isConjugate()
+ *
+ * // value == true
+ * ```
  */
 fun TokenBase.isConjugate(): Boolean = this.allFeaturesArray[0] == "助動詞"
 
 /**
- * 형태소 분석 결과에서 기호(記号)인지 확인합니다.
+ * 토큰의 1차 품사가 기호(`記号`)인지 판별합니다.
+ *
+ * ## 동작/계약
+ * - 판별 기준은 `allFeaturesArray[0] == "記号"` 비교입니다.
+ * - 문장부호 외 기호 계열 토큰도 품사값이 같으면 `true`를 반환합니다.
+ * - 불리언만 반환하며 토큰 상태를 변경하지 않습니다.
+ *
+ * ```kotlin
+ * val tokens = JapaneseTokenizer.tokenize("お寿司が食べたい。")
+ * val value = tokens.first { it.surface == "。" }.isPunctuation()
+ *
+ * // value == true
+ * ```
  */
 fun TokenBase.isPunctuation(): Boolean = this.allFeaturesArray[0] == "記号"

--- a/tokenizer/japanese/src/main/kotlin/io/bluetape4k/tokenizer/japanese/utils/JapaneseDictionaryProvider.kt
+++ b/tokenizer/japanese/src/main/kotlin/io/bluetape4k/tokenizer/japanese/utils/JapaneseDictionaryProvider.kt
@@ -8,34 +8,89 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 
 /**
- * 일본어 사전을 제공하는 유틸리티 클래스
+ * 일본어 토크나이저에서 사용하는 금칙어 사전 로딩 및 런타임 갱신 기능을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 사전 리소스 기준 경로는 `BASE_PATH`(`japanesetext`)입니다.
+ * - 파일 로드는 `DictionaryProvider`에 위임하며 상대 경로 앞에 `BASE_PATH/`를 붙여 호출합니다.
+ * - `blockWordDictionary`는 최초 접근 시 파일을 읽어 메모리에 적재한 뒤 재사용합니다.
+ *
+ * ```kotlin
+ * val hasWord = JapaneseDictionaryProvider.blockWordDictionary.contains("性器")
+ *
+ * // hasWord == true
+ * ```
  */
 object JapaneseDictionaryProvider: KLoggingChannel() {
 
+    /**
+     * 일본어 사전 리소스를 찾을 때 사용하는 기본 루트 경로입니다.
+     *
+     * ## 동작/계약
+     * - `readWordsAsSet`, `readWords`는 전달받은 상대 경로 앞에 이 값을 접두사로 붙입니다.
+     * - 리소스 구조가 바뀌면 이 상수와 배포 리소스 경로를 함께 맞춰야 합니다.
+     *
+     * ```kotlin
+     * val basePath = JapaneseDictionaryProvider.BASE_PATH
+     *
+     * // basePath == "japanesetext"
+     * ```
+     */
     const val BASE_PATH = "japanesetext"
 
     /**
-     * 지정된 경로의 사전 파일들을 읽어 [MutableSet]으로 반환합니다.
+     * 지정한 사전 파일들을 읽어 단어 집합(`MutableSet`)으로 반환합니다.
      *
-     * @param paths 사전 파일 경로 (BASE_PATH 기준 상대 경로)
-     * @return 사전 단어들의 [MutableSet]
+     * ## 동작/계약
+     * - 각 경로는 `BASE_PATH` 기준 상대 경로로 해석됩니다.
+     * - 중복 단어는 집합 특성상 하나로 합쳐집니다.
+     * - `suspend` 함수이며 실제 로딩은 `DictionaryProvider.readWordsAsSet`에 위임합니다.
+     *
+     * ```kotlin
+     * val words = kotlinx.coroutines.runBlocking {
+     *     JapaneseDictionaryProvider.readWordsAsSet("block/blocks.txt")
+     * }
+     *
+     * // result == true (words.isNotEmpty())
+     * ```
      */
     suspend fun readWordsAsSet(vararg paths: String): MutableSet<String> {
         return DictionaryProvider.readWordsAsSet(*paths.map { "$BASE_PATH/$it" }.toTypedArray())
     }
 
     /**
-     * 지정된 경로의 사전 파일들을 읽어 [CharArraySet]으로 반환합니다.
+     * 지정한 사전 파일들을 읽어 `CharArraySet`으로 반환합니다.
      *
-     * @param paths 사전 파일 경로 (BASE_PATH 기준 상대 경로)
-     * @return 사전 단어들의 [CharArraySet]
+     * ## 동작/계약
+     * - 각 경로는 `BASE_PATH` 기준 상대 경로로 해석됩니다.
+     * - 반환 타입은 토큰 매칭에 사용하는 `CharArraySet`입니다.
+     * - `suspend` 함수이며 실제 로딩은 `DictionaryProvider.readWords`에 위임합니다.
+     *
+     * ```kotlin
+     * val words = kotlinx.coroutines.runBlocking {
+     *     JapaneseDictionaryProvider.readWords("block/blocks.txt")
+     * }
+     *
+     * // result == true (words.isNotEmpty())
+     * ```
      */
     suspend fun readWords(vararg paths: String): CharArraySet {
         return DictionaryProvider.readWords(*paths.map { "$BASE_PATH/$it" }.toTypedArray())
     }
 
     /**
-     * 금칙어 사전
+     * 금칙어 판정에 사용하는 메모리 내 사전 집합입니다.
+     *
+     * ## 동작/계약
+     * - 최초 접근 시 `runBlocking(Dispatchers.IO)`로 `block/blocks.txt`를 로드합니다.
+     * - 이후 동일 인스턴스를 재사용하므로 추가/삭제/비우기 변경이 즉시 반영됩니다.
+     * - 테스트 기준으로 "性器"는 포함되고 "한국어"는 포함되지 않습니다.
+     *
+     * ```kotlin
+     * val dictionary = JapaneseDictionaryProvider.blockWordDictionary
+     *
+     * // dictionary.contains("性器") == true
+     * ```
      */
     val blockWordDictionary: CharArraySet by lazy {
         runBlocking(Dispatchers.IO) {
@@ -44,9 +99,19 @@ object JapaneseDictionaryProvider: KLoggingChannel() {
     }
 
     /**
-     * 금칙어를 사전에 추가합니다.
+     * 금칙어 사전에 단어 컬렉션을 추가합니다.
      *
-     * @param words 추가할 금칙어
+     * ## 동작/계약
+     * - 내부 사전은 집합이므로 중복 단어는 한 번만 저장됩니다.
+     * - 호출 직후 `findBlockwords`/`maskBlockwords` 판정에 반영됩니다.
+     * - 빈 컬렉션 전달 시 변경 없이 종료됩니다.
+     *
+     * ```kotlin
+     * JapaneseDictionaryProvider.addBlockwords(listOf("19禁", "29禁"))
+     * val value = JapaneseDictionaryProvider.blockWordDictionary.contains("19禁")
+     *
+     * // value == true
+     * ```
      */
     fun addBlockwords(words: Collection<String>) {
         log.debug { "Add block words: ${words.joinToString(",")}" }
@@ -54,9 +119,19 @@ object JapaneseDictionaryProvider: KLoggingChannel() {
     }
 
     /**
-     * 사전에서 해당 금칙어를 삭제합니다.
+     * 금칙어 사전에서 단어 컬렉션을 제거합니다.
      *
-     * @param words 삭제할 금칙어
+     * ## 동작/계약
+     * - 존재하지 않는 단어는 무시되고 예외가 발생하지 않습니다.
+     * - 호출 직후 동일 단어는 금칙어 판정에서 제외됩니다.
+     * - 빈 컬렉션 전달 시 변경 없이 종료됩니다.
+     *
+     * ```kotlin
+     * JapaneseDictionaryProvider.removeBlockwords(listOf("19禁"))
+     * val value = JapaneseDictionaryProvider.blockWordDictionary.contains("19禁")
+     *
+     * // value == false
+     * ```
      */
     fun removeBlockwords(words: Collection<String>) {
         log.debug { "Remove block words: ${words.joinToString(",")}" }
@@ -64,7 +139,19 @@ object JapaneseDictionaryProvider: KLoggingChannel() {
     }
 
     /**
-     * 모든 금칙어를 삭제합니다.
+     * 메모리에 로드된 금칙어 사전을 모두 비웁니다.
+     *
+     * ## 동작/계약
+     * - 현재 프로세스의 `blockWordDictionary`만 비우며 리소스 파일은 변경하지 않습니다.
+     * - 이후 재로딩이 필요하면 별도 초기화 사이클(프로세스 재시작 등)이 필요합니다.
+     * - 호출 후 `blockWordDictionary.isEmpty()`는 `true`입니다.
+     *
+     * ```kotlin
+     * JapaneseDictionaryProvider.clearBlockwords()
+     * val value = JapaneseDictionaryProvider.blockWordDictionary.isEmpty()
+     *
+     * // value == true
+     * ```
      */
     fun clearBlockwords() {
         log.debug { "Clear block words" }

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/KoreanProcessor.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/KoreanProcessor.kt
@@ -25,96 +25,47 @@ import io.bluetape4k.tokenizer.model.Severity.MIDDLE
 import io.bluetape4k.tokenizer.utils.CharArraySet
 
 /**
- * 한글 형태소 분석기
+ * 한국어 토크나이저/정규화/구 추출/금칙어 처리를 묶은 퍼사드 API입니다.
+ *
+ * ## 동작/계약
+ * - 각 기능은 `KoreanNormalizer`, `KoreanTokenizer`, `KoreanPhraseExtractor` 등 하위 유틸에 위임한다.
+ * - 사전 추가/삭제 API는 `KoreanDictionaryProvider`의 런타임 사전을 직접 갱신한다.
+ * - 금칙어 처리는 `KoreanBlockwordProcessor` 정책을 그대로 따른다.
+ *
+ * ```kotlin
+ * val tokens = KoreanProcessor.tokenize("주말특가")
+ * // tokens.map { it.text } == ["주말", "특가"]
+ * ```
  */
 object KoreanProcessor: KLogging() {
 
     /**
-     * 한글 구어체를 맞춤법에 맞게 정규화합니다.
+     * 구어체/반복 문자/오타를 정규화합니다.
      *
+     * ## 동작/계약
+     * - 내부 구현은 `KoreanNormalizer.normalize`를 그대로 위임한다.
+     * - 빈 입력/비한글 구간 처리는 정규화기 구현 규칙을 따른다.
+     *
+     * ```kotlin
+     * val normalized = KoreanProcessor.normalize("안됔ㅋㅋㅋㅋ")
+     * // normalized == "안돼ㅋㅋㅋ"
      * ```
-     * val expected = "안돼ㅋㅋㅋ내 심장을 가격했어ㅋㅋㅋ"
-     * val actual = normalize("안됔ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ내 심장을 가격했엌ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ")
-     * actual shouldBeEqualTo expected
-     *
-     * normalize("무의식중에 손들어버려섴ㅋㅋㅋㅋ") shouldBeEqualTo "무의식중에 손들어버려서ㅋㅋㅋ"
-     * normalize("기억도 나지아낳ㅎㅎㅎ") shouldBeEqualTo "기억도 나지아나ㅎㅎㅎ"
-     * normalize("근데비싸서못머구뮤ㅠㅠ") shouldBeEqualTo "근데비싸서못먹음ㅠㅠ"
-     *
-     * normalize("미친 존잘니뮤ㅠㅠㅠㅠ") shouldBeEqualTo "미친 존잘님ㅠㅠㅠ"
-     * normalize("만나무ㅜㅜㅠ") shouldBeEqualTo "만남ㅜㅜㅠ"
-     * normalize("가루ㅜㅜㅜㅜ") shouldBeEqualTo "가루ㅜㅜㅜ"
-     *
-     * normalize("유성우ㅠㅠㅠ") shouldBeEqualTo "유성우ㅠㅠㅠ"
-     *
-     * normalize("예뿌ㅠㅠ") shouldBeEqualTo "예뻐ㅠㅠ"
-     * normalize("고수야고수ㅠㅠㅠ") shouldBeEqualTo "고수야고수ㅠㅠㅠ"
-     *
-     * normalize("안돼ㅋㅋㅋㅋㅋ") shouldBeEqualTo "안돼ㅋㅋㅋ"
-     * ```
-     *
-     * ```
-     * normalize("사브작사브작사브작사브작사브작사브작사브작사브작") shouldBeEqualTo "사브작사브작"
-     * normalize("ㅋㅋㅎㅋㅋㅎㅋㅋㅎㅋㅋㅎㅋㅋㅎㅋㅋㅎ") shouldBeEqualTo "ㅋㅋㅎㅋㅋㅎ"
-     * ```
-     *
-     * ```
-     * normalize("가쟝 용기있는 사람이 머굼 되는거즤") shouldBeEqualTo "가장 용기있는 사람이 먹음 되는거지"
-     * ```
-     *
-     * ```
-     * normalizeCodaN("버슨가") shouldBeEqualTo "버스인가"
-     * normalizeCodaN("보슨지") shouldBeEqualTo "보스인지"
-     * normalizeCodaN("쵸킨데") shouldBeEqualTo "쵸킨데"
-     * ```
-     *
-     * @param text 입력 문자열
-     * @return 정규화된 문자열
      */
     fun normalize(text: CharSequence): CharSequence {
         return KoreanNormalizer.normalize(text)
     }
 
     /**
-     * 한글 문장을 형태소 분석하여 [KoreanToken]의 리스트로 반환합니다.
+     * 문장을 1-best 형태소 토큰 리스트로 분석합니다.
      *
-     * ```
-     * tokenize("엄청작아서귀엽다") shouldBeEqualTo listOf(
-     *     KoreanToken("엄청", Adverb, 0, 2),
-     *     KoreanToken("작아서", Adjective, 2, 3, stem = "작다"),
-     *     KoreanToken("귀엽다", Adjective, 5, 3, stem = "귀엽다")
-     * )
-     * ```
+     * ## 동작/계약
+     * - `KoreanTokenizer.tokenize(text, profile)`를 그대로 위임한다.
+     * - 결과 토큰에는 필요 시 용언 `stem` 정보가 포함된다.
      *
+     * ```kotlin
+     * val tokens = KoreanProcessor.tokenize("주말특가")
+     * // tokens.map { it.text } == ["주말", "특가"]
      * ```
-     * tokenize("야이건뭐") shouldBeEqualTo listOf(
-     *     KoreanToken("야", Exclamation, 0, 1),
-     *     KoreanToken("이건", Noun, 1, 2),
-     *     KoreanToken("뭐", Noun, 3, 1)
-     * )
-     * ```
-     *
-     * ```
-     * tokenize("주말특가") shouldBeEqualTo listOf(
-     *     KoreanToken("주말", Noun, 0, 2),
-     *     KoreanToken("특가", Noun, 2, 2)
-     * )
-     * ```
-     *
-     * ```
-     * val text = """우리 동네사람들"""
-     * val tokens = tokenize(text)
-     * tokens shouldBeEqualTo listOf(
-     *     KoreanToken("우리", Noun, 0, 2),
-     *     KoreanToken(" ", Space, 2, 1),
-     *     KoreanToken("동네", Noun, 3, 2),
-     *     KoreanToken("사람", Noun, 5, 2),
-     *     KoreanToken("들", Suffix, 7, 1)
-     * )
-     * ```
-     *
-     * @param text 한글 문장
-     * @return 형태소 분석된 [KoreanToken] 리스트
      */
     fun tokenize(
         text: CharSequence,
@@ -124,7 +75,16 @@ object KoreanProcessor: KLogging() {
     }
 
     /**
-     * 명사 위주의 형태소 분석을 수행합니다.
+     * 명사 중심 규칙으로 문장을 분석합니다.
+     *
+     * ## 동작/계약
+     * - `NounTokenizer.tokenize(text, profile)`를 위임 호출한다.
+     * - phrase 추출 전처리용 명사 토큰화 경로로 사용된다.
+     *
+     * ```kotlin
+     * val tokens = KoreanProcessor.tokenizeForNoun("떡 만두국")
+     * // tokens.isNotEmpty() == true
+     * ```
      */
     fun tokenizeForNoun(
         text: CharSequence,
@@ -134,11 +94,15 @@ object KoreanProcessor: KLogging() {
     }
 
     /**
-     * 한글 문장을 [n] 개수만큼 형태소 분석하여 [KoreanToken]의 리스트로 반환합니다.
+     * 문장을 청크별 상위 `n` 후보로 분석합니다.
      *
-     * @param text 한글 문장
-     * @param n 최대 분석 개수 (default: 1)
-     * @return 형태소 분석된 [KoreanToken] 리스트
+     * ## 동작/계약
+     * - `KoreanTokenizer.tokenizeTopN(text, n, profile)`를 그대로 위임한다.
+     *
+     * ```kotlin
+     * val top = KoreanProcessor.tokenizeTopN("가느다란", n = 1)
+     * // top.isNotEmpty() == true
+     * ```
      */
     fun tokenizeTopN(
         text: CharSequence,
@@ -147,18 +111,30 @@ object KoreanProcessor: KLogging() {
     ): List<List<List<KoreanToken>>> = KoreanTokenizer.tokenizeTopN(text, n, profile)
 
     /**
-     * 명사들[words]를 명사 사전에 추가합니다. 띄어쓰기가 포함된 단어는 추가할 수 없습니다.
+     * 명사 사전에 단어 목록을 추가합니다.
      *
-     * @param words 추가할 명사 단어들
+     * ## 동작/계약
+     * - `KoreanDictionaryProvider.addWordsToDictionary(Noun, words)`를 호출한다.
+     *
+     * ```kotlin
+     * KoreanProcessor.addNounsToDictionary(listOf("후랴오교"))
+     * // KoreanDictionaryProvider.koreanDictionary[KoreanPos.Noun]!!.contains("후랴오교") == true
+     * ```
      */
     fun addNounsToDictionary(words: List<String>) {
         KoreanDictionaryProvider.addWordsToDictionary(KoreanPos.Noun, words)
     }
 
     /**
-     * 명사들[words]를 명사 사전에 추가합니다. 띄어쓰기가 포함된 단어는 추가할 수 없습니다.
+     * 명사 사전에 가변 인자 단어를 추가합니다.
      *
-     * @param words 추가할 명사 단어들
+     * ## 동작/계약
+     * - `addWordsToDictionary(Noun, *words)`를 호출한다.
+     *
+     * ```kotlin
+     * KoreanProcessor.addNounsToDictionary("주말특가")
+     * // KoreanDictionaryProvider.koreanDictionary[KoreanPos.Noun]!!.contains("주말특가") == true
+     * ```
      */
     fun addNounsToDictionary(vararg words: String) {
         KoreanDictionaryProvider.addWordsToDictionary(KoreanPos.Noun, *words)
@@ -166,9 +142,16 @@ object KoreanProcessor: KLogging() {
 
 
     /**
-     * 금칙어를 금칙어 Dictionary에 추가합니다.
+     * 심각도별 금칙어 사전에 단어를 추가합니다.
      *
-     * @param words 금칙어에 등록할 단어들
+     * ## 동작/계약
+     * - `severity`에 맞는 blockWords 사전에 단어를 추가한다.
+     * - 복합 명사 탐지를 위해 동일 단어를 명사 사전과 `properNouns`에도 추가한다.
+     *
+     * ```kotlin
+     * KoreanProcessor.addBlockwords(listOf("분수쑈"), Severity.HIGH)
+     * // KoreanDictionaryProvider.blockWords[Severity.HIGH]!!.contains("분수쑈") == true
+     * ```
      */
     fun addBlockwords(
         words: List<String>,
@@ -183,10 +166,15 @@ object KoreanProcessor: KLogging() {
     }
 
     /**
-     * 등록된 금칙어를 제외시킵니다
+     * 금칙어 사전에서 단어를 제거합니다. (Deprecated)
      *
-     * @param words
-     * @param severity
+     * ## 동작/계약
+     * - `removeBlockwords(words, severity)`와 동일하게 severity 범위 사전에서 제거한다.
+     *
+     * ```kotlin
+     * KoreanProcessor.removeBlockword(listOf("금칙어"), Severity.HIGH)
+     * // deprecated
+     * ```
      */
     @Deprecated("Use removeBlockwords instead", replaceWith = ReplaceWith("removeBlockwords(words, severity)"))
     fun removeBlockword(
@@ -199,10 +187,15 @@ object KoreanProcessor: KLogging() {
     }
 
     /**
-     * 등록된 금칙어를 제외시킵니다
+     * 금칙어 사전에서 단어를 제거합니다.
      *
-     * @param words
-     * @param severity
+     * ## 동작/계약
+     * - `severity`에 해당하는 blockWords 사전(또는 포함 범위)에서 `removeAll(words)`를 수행한다.
+     *
+     * ```kotlin
+     * KoreanProcessor.removeBlockwords(listOf("금칙어"), Severity.HIGH)
+     * // removed from high dictionary
+     * ```
      */
     fun removeBlockwords(
         words: List<String>,
@@ -214,9 +207,15 @@ object KoreanProcessor: KLogging() {
     }
 
     /**
-     * 등록된 금칙어를 모두 삭제합니다.
+     * 심각도 범위에 해당하는 금칙어 사전을 비웁니다.
      *
-     * @param severity
+     * ## 동작/계약
+     * - `Severity.LOW`면 low/middle/high 모두, `MIDDLE`이면 middle/high, 그 외는 high만 clear한다.
+     *
+     * ```kotlin
+     * KoreanProcessor.clearBlockwords(Severity.HIGH)
+     * // high dictionary cleared
+     * ```
      */
     fun clearBlockwords(severity: Severity = Severity.DEFAULT) {
         withBlockwordDictionary(severity) {
@@ -245,44 +244,43 @@ object KoreanProcessor: KLogging() {
     }
 
     /**
-     * Tokenize text into a sequence of token strings. This excludes spaces.
+     * 토큰 리스트에서 공백 토큰을 제외한 텍스트 목록을 반환합니다.
      *
-     * @param tokens Korean tokens
-     * @return A sequence of token strings.
+     * ## 동작/계약
+     * - `KoreanPos.Space` 토큰은 제거하고 나머지 `text`만 추출한다.
+     *
+     * ```kotlin
+     * val words = KoreanProcessor.tokensToStrings(listOf(KoreanToken("안녕", KoreanPos.Noun, 0, 2)))
+     * // words == ["안녕"]
+     * ```
      */
     fun tokensToStrings(tokens: List<KoreanToken>): List<String> =
         tokens.filterNot { it.pos == KoreanPos.Space }.map { it.text }
 
     /**
-     * 한글 문장을 문장(Sentence) 단위로 분리합니다.
+     * 문장을 `Sentence` 시퀀스로 분리합니다.
      *
+     * ## 동작/계약
+     * - `KoreanSentenceSplitter.split(text)`를 그대로 위임한다.
+     *
+     * ```kotlin
+     * val sentences = KoreanProcessor.splitSentences("안녕? 세상아?").toList()
+     * // sentences.size == 2
      * ```
-     * var actual = split("안녕? iphone6안녕? 세상아?").toList()
-     * actual shouldContainSame listOf(
-     *     Sentence("안녕?", 0, 3),
-     *     Sentence("iphone6안녕?", 4, 14),
-     *     Sentence("세상아?", 15, 19)
-     * )
-     *```
      */
     fun splitSentences(text: CharSequence): Sequence<Sentence> =
         KoreanSentenceSplitter.split(text)
 
     /**
-     * 형태소 분석한 결과에서 [filterSpam], [enableHashtags]를 적용한 구문만을 추출합니다.
+     * 토큰 목록에서 phrase를 추출합니다.
      *
+     * ## 동작/계약
+     * - `KoreanPhraseExtractor.extractPhrases(tokens, filterSpam, enableHashtags)`를 위임 호출한다.
+     *
+     * ```kotlin
+     * val phrases = KoreanProcessor.extractPhrases(KoreanProcessor.tokenize("성탄절 쇼핑"), filterSpam = false)
+     * // phrases.isNotEmpty() == true
      * ```
-     * val phrases = extractPhrases(tokenize("성탄절 쇼핑 성탄절 쇼핑 성탄절 쇼핑 성탄절 쇼핑"), filterSpam = false)
-     *
-     * val expected = phrases.map { it.text }.distinct()
-     * val actual = phrases.map { it.text }
-     * actual shouldBeEqualTo expected
-     * ```
-     *
-     * @param tokens A sequence of tokens
-     * @param filterSpam true if spam words and slangs to be filtered out
-     * @param enableHashtags true if #hashtags to be included
-     * @return A list of KoreanPhrase
      */
     fun extractPhrases(
         tokens: List<KoreanToken>,
@@ -294,29 +292,30 @@ object KoreanProcessor: KLogging() {
 
 
     /**
-     * 명사 위주의 형태소 분석 후 추출된 구문을 반환합니다.
+     * 명사 중심 토큰에서 phrase를 추출합니다.
      *
-     * @param tokens         Korean tokens
-     * @return A sequence of extracted phrases
+     * ## 동작/계약
+     * - `NounPhraseExtractor.extractPhrases(tokens)`를 그대로 위임한다.
+     *
+     * ```kotlin
+     * val phrases = KoreanProcessor.extractPhrasesForNoun(KoreanProcessor.tokenizeForNoun("떡 만두국"))
+     * // phrases.map { it.text }.contains("만두국") == true
+     * ```
      */
     fun extractPhrasesForNoun(tokens: List<KoreanToken>): List<KoreanPhrase> {
         return NounPhraseExtractor.extractPhrases(tokens)
     }
 
     /**
-     * 마지막 어미를 제거하여 동사의 원형을 복원합니다.
+     * 토큰 리스트의 어미 병합 및 용언 원형 복원을 수행합니다.
      *
-     * ```
-     * 새로운 스테밍을 추가했었다. -> 새롭다 + 스테밍 + 을 + 추가 + 하다
-     * ```
+     * ## 동작/계약
+     * - `KoreanStemmer.stem(tokens)`를 그대로 위임한다.
      *
+     * ```kotlin
+     * val stemmed = KoreanProcessor.stem(KoreanProcessor.tokenize("가느다란"))
+     * // stemmed.first().stem == "갈다"
      * ```
-     * val tokens = KoreanTokenizer.tokenizeTopN("가느다란").flatMap { it.first() }  // KoreanToken("가느다란", Noun, 0, 4)
-     * val actual = KoreanStemmer.stem(tokens)  // KoreanToken("가느다란", Verb, 0, 4, stem = "갈다")
-     * ```
-     *
-     * @param tokens 형태소 분석 토큰 컬렉션
-     * @return 원형을 복원한 토큰 컬렉션
      */
     fun stem(tokens: List<KoreanToken>): List<KoreanToken> {
         return KoreanStemmer.stem(tokens)
@@ -324,39 +323,30 @@ object KoreanProcessor: KLogging() {
 
 
     /**
-     * 한글 형태소 분석기로 분석된 단어들을 하나의 문장으로 만듭니다.
+     * 토큰 문자열 목록을 문장 문자열로 복원합니다.
      *
+     * ## 동작/계약
+     * - `KoreanDetokenizer.detokenize(tokens)`를 그대로 위임한다.
+     *
+     * ```kotlin
+     * val text = KoreanProcessor.detokenize(listOf("뭐", "완벽", "하진", "않", "지만"))
+     * // text == "뭐 완벽하진 않지만"
      * ```
-     * var actual = detokenize(listOf("연세", "대학교", "보건", "대학원", "에", "오신", "것", "을", "환영", "합니다", "!"))
-     * actual shouldBeEqualTo "연세대학교 보건 대학원에 오신것을 환영합니다!"
-     *
-     * actual = detokenize(listOf("뭐", "완벽", "하진", "않", "지만", "그럭저럭", "쓸", "만", "하군", "..."))
-     * actual shouldBeEqualTo "뭐 완벽하진 않지만 그럭저럭 쓸 만하군..."
-     * ```
-     *
-     * @param tokens 분석된 단어들
-     * @return 복원된 문장
      */
     fun detokenize(tokens: Collection<String>): String {
         return KoreanDetokenizer.detokenize(tokens)
     }
 
     /**
-     * 금칙어 (Block words) 를 masking 합니다.
+     * 요청 옵션에 따라 금칙어를 마스킹합니다.
      *
-     * 예:
-     * - 미니미와 니미 -> 미니미와 **     // `니미` 는 속어
-     * - ㅆ.ㅂ 웃기네 -> *** 웃기네      // ㅆㅂ, ㅆ.ㅂ, ㅆ~ㅂ 등을 처리
+     * ## 동작/계약
+     * - `KoreanBlockwordProcessor.maskBlockwords(request)`를 그대로 위임한다.
      *
-     *
+     * ```kotlin
+     * val response = KoreanProcessor.maskBlockwords(BlockwordRequest("미니미와 니미"))
+     * // response.text.contains("**")
      * ```
-     * val request = BlockwordRequest("미니미와 니미", BlockwordOptions())
-     * val response = maskBlockwords(request)
-     * println(response.text)  // 미니미와 **
-     * ```
-     *
-     * @param request 금칙어 처리 요청 정보 [BlockwordRequest]
-     * @return 금칙어를 처리한 결과 [BlockwordResponse]
      */
     fun maskBlockwords(request: BlockwordRequest): BlockwordResponse {
         return KoreanBlockwordProcessor.maskBlockwords(request)

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/block/KoreanBlockwordProcessor.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/block/KoreanBlockwordProcessor.kt
@@ -17,7 +17,17 @@ import io.bluetape4k.tokenizer.model.blockwordResponseOf
 import java.util.*
 
 /**
- * 한국어 문장 중에 금칙어를 찾고, 마스킹 처리를 수행합니다.
+ * 문장에서 금칙어를 탐지하고 마스킹 결과를 생성합니다.
+ *
+ * ## 동작/계약
+ * - 구두점 우회 패턴을 제거한 뒤 토크나이즈 결과로 금칙어를 판정한다.
+ * - 마스킹 대상은 길이 2 이상, 지정 품사(`blockedPos`)이며 금칙어 사전에 존재하는 토큰이다.
+ * - 처리 중 예외는 `TokenizerException`으로 감싸 재던진다.
+ *
+ * ```kotlin
+ * val found = KoreanBlockwordProcessor.findBlockwords("미니미와 니미")
+ * // found.any { it.text == "니미" } == true
+ * ```
  */
 object KoreanBlockwordProcessor: KLogging() {
 
@@ -39,15 +49,16 @@ object KoreanBlockwordProcessor: KLogging() {
     private val punctuationProcessor = PunctuationProcessor()
 
     /**
-     * 금칙어에 해당하는 단어를 찾습니다.
+     * 입력 문장에서 금칙어 토큰 목록을 반환합니다.
      *
-     * ```
-     * val blockWords = findBlockwords("미니미와 니미")
-     * blockWords.forEach { println(it) }   // `니미`
-     * ```
+     * ## 동작/계약
+     * - 공백/빈 문자열 입력이면 빈 리스트를 반환한다.
+     * - 구두점 제거 후 토큰화한 결과에서 길이 2 이상 토큰만 검사한다.
      *
-     * @param text 한국어 문장
-     * @return 금칙어에 해당하는 [KoreanToken] 리스트
+     * ```kotlin
+     * val tokens = KoreanBlockwordProcessor.findBlockwords("미니미와 니미")
+     * // tokens.map { it.text } == ["니미"]
+     * ```
      */
     fun findBlockwords(text: String): List<KoreanToken> {
         if (text.isBlank()) {
@@ -75,20 +86,17 @@ object KoreanBlockwordProcessor: KLogging() {
     }
 
     /**
-     * 금칙어 (Block words) 를 masking 합니다.
+     * 요청 옵션에 따라 금칙어를 마스킹한 응답을 반환합니다.
      *
-     * 예:
-     * - 미니미와 니미 -> 미니미와 **     // `니미` 는 속어
-     * - ㅆ.ㅂ 웃기네 -> *** 웃기네      // ㅆㅂ, ㅆ.ㅂ, ㅆ~ㅂ 등을 처리
+     * ## 동작/계약
+     * - 입력 텍스트가 비어 있으면 빈 문자열 응답을 반환한다.
+     * - 요청 언어가 한국어가 아니면 `InvalidTokenizeRequestException`을 던진다.
+     * - severity 조건을 만족하는 토큰 구간을 `mask` 문자열 반복값으로 치환한다.
      *
+     * ```kotlin
+     * val response = KoreanBlockwordProcessor.maskBlockwords(BlockwordRequest("미니미와 니미"))
+     * // response.text.contains("**") == true
      * ```
-     * val request = BlockwordRequest("미니미와 니미", BlockwordOptions())
-     * val response = maskBlockwords(request)
-     * println(response.text)  // 미니미와 **
-     * ```
-     *
-     * @param request 금칙어 처리 요청 정보 [BlockwordRequest]
-     * @return 금칙어를 처리한 결과 [BlockwordResponse]
      */
     fun maskBlockwords(request: BlockwordRequest): BlockwordResponse {
         if (request.text.isBlank()) {

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/block/PunchuationProcessor.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/block/PunchuationProcessor.kt
@@ -9,11 +9,15 @@ import io.bluetape4k.tokenizer.korean.utils.KoreanPos
 
 
 /**
- * 금칙어를 회피하기 위해 구두점(Punctuation)을 단어 중간에 추가하는 회피방식에 대응하기 위해, 구두점(Punctuation) 을 제거하도록 합니다.
+ * 단어 중간의 구두점 삽입 우회 패턴을 식별해 제거합니다.
  *
- * ```
- * 섹.스 -> 섹스
- * 찌~~~찌~뽕 -> 찌찌뽕
+ * ## 동작/계약
+ * - 3개 슬라이딩 윈도우에서 `일반 토큰-구두점-일반 토큰` 패턴만 제거 대상으로 판정한다.
+ * - 제거는 뒤에서 앞으로 수행해 원문 인덱스 보정을 피한다.
+ *
+ * ```kotlin
+ * val cleaned = PunctuationProcessor().removePunctuation("섹.스")
+ * // cleaned == "섹스"
  * ```
  */
 class PunctuationProcessor {
@@ -37,15 +41,16 @@ class PunctuationProcessor {
     }
 
     /**
-     * [text] 중간에 들어간 구두점(Punctuation)을 제거합니다.
+     * 중간 구두점 제거 규칙에 따라 문자열을 정리합니다.
      *
-     * ```
-     * 섹.스 -> 섹스
-     * 찌~~~찌~뽕 -> 찌찌뽕
-     * ```
+     * ## 동작/계약
+     * - `findPunctuation` 결과에서 제거 플래그가 `true`인 토큰 구간만 삭제한다.
+     * - 삭제는 `tokens.reversed()` 순회로 수행한다.
      *
-     * @param text 구두점이 포함된 문장
-     * @return 구두점이 제거된 문장
+     * ```kotlin
+     * val out = PunctuationProcessor().removePunctuation("찌~~~찌~뽕")
+     * // out == "찌찌뽕"
+     * ```
      */
     fun removePunctuation(text: String): String {
         val tokens = findPunctuation(text)
@@ -63,15 +68,16 @@ class PunctuationProcessor {
     }
 
     /**
-     * [text] 중간에 들어간 구두점(Punctuation)을 찾아 [KoreanToken]과 구두점 여부를 반환합니다.
+     * 토큰 단위로 구두점 제거 가능 여부를 계산합니다.
      *
-     * ```
-     * val list = findPunctuation("섹.스")  // [(섹스, true)]
-     * val list = findPunctuation("찌~~~찌~뽕")  // [(찌찌뽕, true)]
-     * ```
+     * ## 동작/계약
+     * - `KoreanChunker.chunk(text)` 결과를 길이 3 윈도우로 순회한다.
+     * - 각 윈도우의 가운데 토큰에 대해 `canRemovePunctuation` 결과를 붙여 반환한다.
      *
-     * @param text 구두점이 포함된 문장
-     * @return 구두점이 포함된 [KoreanToken] 리스트
+     * ```kotlin
+     * val pairs = PunctuationProcessor().findPunctuation("섹.스")
+     * // pairs.any { it.first.text == "." && it.second } == true
+     * ```
      */
     fun findPunctuation(text: String): List<Pair<KoreanToken, Boolean>> {
         val chunks = KoreanChunker.chunk(text)

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/normalizer/KoreanNomalizer.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/normalizer/KoreanNomalizer.kt
@@ -14,42 +14,16 @@ import io.bluetape4k.tokenizer.korean.utils.koreanContains
 import java.util.regex.Matcher
 
 /**
- * 한글 구어체의 의미 없는 글자들을 맞춤법에 맞게 정규화 합니다.
+ * 구어체 반복 문자/오타/받침 변형을 표준 형태에 가깝게 정규화합니다.
  *
- * ```
- * val expected = "안돼ㅋㅋㅋ내 심장을 가격했어ㅋㅋㅋ"
- * val actual = normalize("안됔ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ내 심장을 가격했엌ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ")
- * actual shouldBeEqualTo expected
+ * ## 동작/계약
+ * - 한글 구간만 추출해 어미 반복 축약, 반복 문자열 축약, 받침 `ㄴ` 보정, 오타 교정을 순차 적용한다.
+ * - 비한글 구간과 공백은 원문 위치를 유지한 채 보존한다.
+ * - 사전 검증은 `KoreanDictionaryProvider.typoDictionaryByLength`와 품사 사전을 사용한다.
  *
- * normalize("무의식중에 손들어버려섴ㅋㅋㅋㅋ") shouldBeEqualTo "무의식중에 손들어버려서ㅋㅋㅋ"
- * normalize("기억도 나지아낳ㅎㅎㅎ") shouldBeEqualTo "기억도 나지아나ㅎㅎㅎ"
- * normalize("근데비싸서못머구뮤ㅠㅠ") shouldBeEqualTo "근데비싸서못먹음ㅠㅠ"
- *
- * normalize("미친 존잘니뮤ㅠㅠㅠㅠ") shouldBeEqualTo "미친 존잘님ㅠㅠㅠ"
- * normalize("만나무ㅜㅜㅠ") shouldBeEqualTo "만남ㅜㅜㅠ"
- * normalize("가루ㅜㅜㅜㅜ") shouldBeEqualTo "가루ㅜㅜㅜ"
- *
- * normalize("유성우ㅠㅠㅠ") shouldBeEqualTo "유성우ㅠㅠㅠ"
- *
- * normalize("예뿌ㅠㅠ") shouldBeEqualTo "예뻐ㅠㅠ"
- * normalize("고수야고수ㅠㅠㅠ") shouldBeEqualTo "고수야고수ㅠㅠㅠ"
- *
- * normalize("안돼ㅋㅋㅋㅋㅋ") shouldBeEqualTo "안돼ㅋㅋㅋ"
- * ```
- *
- * ```
- * normalize("사브작사브작사브작사브작사브작사브작사브작사브작") shouldBeEqualTo "사브작사브작"
- * normalize("ㅋㅋㅎㅋㅋㅎㅋㅋㅎㅋㅋㅎㅋㅋㅎㅋㅋㅎ") shouldBeEqualTo "ㅋㅋㅎㅋㅋㅎ"
- * ```
- *
- * ```
- * normalize("가쟝 용기있는 사람이 머굼 되는거즤") shouldBeEqualTo "가장 용기있는 사람이 먹음 되는거지"
- * ```
- *
- * ```
- * normalizeCodaN("버슨가") shouldBeEqualTo "버스인가"
- * normalizeCodaN("보슨지") shouldBeEqualTo "보스인지"
- * normalizeCodaN("쵸킨데") shouldBeEqualTo "쵸킨데"
+ * ```kotlin
+ * val normalized = KoreanNormalizer.normalize("안됔ㅋㅋㅋㅋ")
+ * // normalized == "안돼ㅋㅋㅋ"
  * ```
  */
 object KoreanNormalizer: KLogging() {
@@ -68,46 +42,16 @@ object KoreanNormalizer: KLogging() {
     private data class Segment(val text: String, val matchData: MatchResult?)
 
     /**
-     * 한글 구어체를 맞춤법에 맞게 정규화합니다.
+     * 입력 문자열 전체를 정규화해 반환합니다.
      *
+     * ## 동작/계약
+     * - 공백 입력이면 입력을 그대로 반환한다.
+     * - 한글 매치 구간마다 `normalizeKoreanChunk`를 적용하고 나머지 구간은 원문 그대로 결합한다.
+     *
+     * ```kotlin
+     * val out = KoreanNormalizer.normalize("가쟝 용기있는 사람이 머굼 되는거즤")
+     * // out == "가장 용기있는 사람이 먹음 되는거지"
      * ```
-     * val expected = "안돼ㅋㅋㅋ내 심장을 가격했어ㅋㅋㅋ"
-     * val actual = normalize("안됔ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ내 심장을 가격했엌ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ")
-     * actual shouldBeEqualTo expected
-     *
-     * normalize("무의식중에 손들어버려섴ㅋㅋㅋㅋ") shouldBeEqualTo "무의식중에 손들어버려서ㅋㅋㅋ"
-     * normalize("기억도 나지아낳ㅎㅎㅎ") shouldBeEqualTo "기억도 나지아나ㅎㅎㅎ"
-     * normalize("근데비싸서못머구뮤ㅠㅠ") shouldBeEqualTo "근데비싸서못먹음ㅠㅠ"
-     *
-     * normalize("미친 존잘니뮤ㅠㅠㅠㅠ") shouldBeEqualTo "미친 존잘님ㅠㅠㅠ"
-     * normalize("만나무ㅜㅜㅠ") shouldBeEqualTo "만남ㅜㅜㅠ"
-     * normalize("가루ㅜㅜㅜㅜ") shouldBeEqualTo "가루ㅜㅜㅜ"
-     *
-     * normalize("유성우ㅠㅠㅠ") shouldBeEqualTo "유성우ㅠㅠㅠ"
-     *
-     * normalize("예뿌ㅠㅠ") shouldBeEqualTo "예뻐ㅠㅠ"
-     * normalize("고수야고수ㅠㅠㅠ") shouldBeEqualTo "고수야고수ㅠㅠㅠ"
-     *
-     * normalize("안돼ㅋㅋㅋㅋㅋ") shouldBeEqualTo "안돼ㅋㅋㅋ"
-     * ```
-     *
-     * ```
-     * normalize("사브작사브작사브작사브작사브작사브작사브작사브작") shouldBeEqualTo "사브작사브작"
-     * normalize("ㅋㅋㅎㅋㅋㅎㅋㅋㅎㅋㅋㅎㅋㅋㅎㅋㅋㅎ") shouldBeEqualTo "ㅋㅋㅎㅋㅋㅎ"
-     * ```
-     *
-     * ```
-     * normalize("가쟝 용기있는 사람이 머굼 되는거즤") shouldBeEqualTo "가장 용기있는 사람이 먹음 되는거지"
-     * ```
-     *
-     * ```
-     * normalizeCodaN("버슨가") shouldBeEqualTo "버스인가"
-     * normalizeCodaN("보슨지") shouldBeEqualTo "보스인지"
-     * normalizeCodaN("쵸킨데") shouldBeEqualTo "쵸킨데"
-     * ```
-     *
-     * @param input 입력 문자열
-     * @return 정규화된 문자열
      */
     fun normalize(input: CharSequence): CharSequence {
         if (input.isBlank()) return input
@@ -162,6 +106,18 @@ object KoreanNormalizer: KLogging() {
         return WHITESPACE_REGEX.replace(typoCorrected, " ")
     }
 
+    /**
+     * 오타 사전 기반으로 청크를 교정합니다.
+     *
+     * ## 동작/계약
+     * - 길이별 오타 사전이 없으면 입력을 그대로 반환한다.
+     * - 등록된 `(wrong, corrected)` 항목을 순차 치환한다.
+     *
+     * ```kotlin
+     * val fixed = KoreanNormalizer.correctTypo("가쟝")
+     * // fixed == "가장"
+     * ```
+     */
     fun correctTypo(chunk: CharSequence): CharSequence {
         var output = chunk.toString()
 
@@ -179,6 +135,19 @@ object KoreanNormalizer: KLogging() {
         return output
     }
 
+    /**
+     * 종성 `ㄴ` 탈락 형태(예: 버슨가)를 보정합니다.
+     *
+     * ## 동작/계약
+     * - 입력 길이가 2 미만이면 원문을 반환한다.
+     * - 마지막 두 글자 패턴과 품사 사전 검증을 통과하면 `ㄴ`을 보정해 반환한다.
+     * - 예외 문자/품사 조건에 맞지 않으면 입력을 그대로 유지한다.
+     *
+     * ```kotlin
+     * val corrected = KoreanNormalizer.normalizeCodaN("버슨가")
+     * // corrected == "버스인가"
+     * ```
+     */
     fun normalizeCodaN(chunk: CharSequence): CharSequence {
         if (chunk.length < 2)
             return chunk

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/phrase/KoreanPhrase.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/phrase/KoreanPhrase.kt
@@ -5,24 +5,67 @@ import io.bluetape4k.tokenizer.korean.utils.KoreanPos
 import java.io.Serializable
 
 /**
- * 한국어 구(phrase)를 나타내는 데이터 클래스입니다.
+ * 추출된 한국어 phrase를 토큰 묶음으로 표현합니다.
+ *
+ * ## 동작/계약
+ * - `text`는 `tokens`의 `text`를 순서대로 이어 붙여 계산한다.
+ * - `offset`은 첫 토큰의 시작 위치이며 토큰이 비어 있으면 `-1`이다.
+ * - `length`는 모든 토큰 텍스트 길이 합이다.
+ *
+ * ```kotlin
+ * val phrase = KoreanPhrase(listOf(KoreanToken("동네", KoreanPos.Noun, 0, 2)))
+ * // phrase.text == "동네"
+ * ```
  *
  * @property tokens 구를 구성하는 토큰 리스트
- * @property pos 구의 품사
+ * @property pos 구의 대표 품사
  */
 data class KoreanPhrase(
     val tokens: List<KoreanToken>,
     val pos: KoreanPos = KoreanPos.Noun,
 ): Serializable {
 
+    /**
+     * phrase의 시작 오프셋입니다.
+     *
+     * ## 동작/계약
+     * - 토큰이 있으면 첫 토큰 `offset`을 반환하고, 없으면 `-1`을 반환한다.
+     *
+     * ```kotlin
+     * val offset = KoreanPhrase(emptyList()).offset
+     * // offset == -1
+     * ```
+     */
     val offset: Int by lazy {
         if (tokens.isNotEmpty()) this.tokens[0].offset else -1
     }
 
+    /**
+     * phrase 전체 텍스트입니다.
+     *
+     * ## 동작/계약
+     * - 토큰 텍스트를 구분자 없이 순서대로 결합한다.
+     *
+     * ```kotlin
+     * val text = KoreanPhrase(listOf(KoreanToken("사람", KoreanPos.Noun, 0, 2))).text
+     * // text == "사람"
+     * ```
+     */
     val text: String by lazy {
         this.tokens.joinToString("") { it.text }
     }
 
+    /**
+     * phrase 텍스트 길이 합계입니다.
+     *
+     * ## 동작/계약
+     * - 각 토큰의 `text.length`를 더해 계산한다.
+     *
+     * ```kotlin
+     * val len = KoreanPhrase(listOf(KoreanToken("사람", KoreanPos.Noun, 0, 2))).length
+     * // len == 2
+     * ```
+     */
     val length: Int by lazy {
         this.tokens.sumOf { it.text.length }
     }

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/phrase/KoreanPhraseExtractor.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/phrase/KoreanPhraseExtractor.kt
@@ -10,6 +10,7 @@ import io.bluetape4k.tokenizer.korean.utils.KoreanPos.Alpha
 import io.bluetape4k.tokenizer.korean.utils.KoreanPos.CashTag
 import io.bluetape4k.tokenizer.korean.utils.KoreanPos.Hashtag
 import io.bluetape4k.tokenizer.korean.utils.KoreanPos.Josa
+import io.bluetape4k.tokenizer.korean.utils.KoreanPos.Modifier
 import io.bluetape4k.tokenizer.korean.utils.KoreanPos.Noun
 import io.bluetape4k.tokenizer.korean.utils.KoreanPos.Number
 import io.bluetape4k.tokenizer.korean.utils.KoreanPos.ProperNoun
@@ -21,47 +22,167 @@ import io.bluetape4k.tokenizer.korean.utils.KoreanPosx
 import io.bluetape4k.tokenizer.korean.utils.KoreanPosx.SelfNode
 import io.bluetape4k.tokenizer.korean.utils.init
 
-
+/**
+ * 구 추출 후보 계산에서 사용하는 구 단위 컬렉션 타입입니다.
+ *
+ * ## 동작/계약
+ * - 하나의 원소는 연속된 `KoreanPhrase` 묶음을 의미한다.
+ * - 내부 후보 생성/중복 제거 단계에서 동일 타입을 공통으로 사용한다.
+ *
+ * ```kotlin
+ * val chunk: KoreanPhraseChunk = listOf(KoreanPhrase(emptyList()))
+ * // chunk.size == 1
+ * ```
+ */
 typealias KoreanPhraseChunk = List<KoreanPhrase>
 
 /**
- * 요즘 주제에 적합한 구를 추출합니다.
+ * 형태소 분석 결과에서 명사 중심 구 후보를 추출합니다.
  *
- * 1. Collapse sequence of POSes to phrase candidates (초 + 거대 + 기업 + 의 -> 초거대기업 + 의)
- * 2. Find suitable phrases
+ * ## 동작/계약
+ * - 토큰 POS 시퀀스를 접기(`collapsePos`) 후 길이/품사 조건으로 후보 구를 필터링한다.
+ * - `filterSpam=true`이면 `KoreanDictionaryProvider.spamNouns` 포함 토큰이 있는 구를 제외한다.
+ * - `enableHashtags=true`이면 입력의 `Hashtag`, `CashTag` 토큰을 결과에 추가한다.
  *
- * ```
- * val text = """"@user: @user 내가 얼굴이 아가쟈나..ㅎ" 동네사람들...!"""
-
- * val normalized = KoreanNormalizer.normalize(text)  // 구어체를 정규화
- * val tokens = tokenize(normalized)
- * val phrases = extractPhrases(tokens).joinToString("/")
- * // 얼굴(Noun: 17, 2)/아가(Noun: 21, 2)/동네사람들(Noun: 30, 5)/동네(Noun: 30, 2)/사람들(Noun: 32, 3)
+ * ```kotlin
+ * val tokens = tokenize("성탄절 쇼핑 성탄절 쇼핑")
+ * val phrases = KoreanPhraseExtractor.extractPhrases(tokens, filterSpam = false)
+ * // phrases.map { it.text }.distinct() == phrases.map { it.text }
  * ```
  */
 object KoreanPhraseExtractor: KLogging() {
 
+    /**
+     * 공백 제외 구 길이의 최소 문자 수입니다.
+     *
+     * ## 동작/계약
+     * - 단일 구 후보는 이 값 이상이거나 최소 구 개수 조건을 만족해야 유지된다.
+     *
+     * ```kotlin
+     * val minChars = KoreanPhraseExtractor.MinCharsPerPhraseChunkWithoutSpaces
+     * // minChars == 2
+     * ```
+     */
     const val MinCharsPerPhraseChunkWithoutSpaces = 2
+    /**
+     * 공백 제외 구 길이 판정 시 사용하는 최소 구 개수입니다.
+     *
+     * ## 동작/계약
+     * - 후보 구에 포함된 phrase 개수가 이 값 이상이면 길이 조건을 통과한다.
+     *
+     * ```kotlin
+     * val minPhrases = KoreanPhraseExtractor.MinPhrasesPerPhraseChunk
+     * // minPhrases == 3
+     * ```
+     */
     const val MinPhrasesPerPhraseChunk = 3
 
+    /**
+     * 공백 제외 구 길이의 최대 문자 수입니다.
+     *
+     * ## 동작/계약
+     * - 후보 구 전체 문자 합이 이 값을 초과하면 제외된다.
+     *
+     * ```kotlin
+     * val maxChars = KoreanPhraseExtractor.MaxCharsPerPhraseChunkWithoutSpaces
+     * // maxChars == 30
+     * ```
+     */
     const val MaxCharsPerPhraseChunkWithoutSpaces = 30
+    /**
+     * 공백 제외 구 길이 판정 시 사용하는 최대 구 개수입니다.
+     *
+     * ## 동작/계약
+     * - 후보 구 내 phrase 수가 이 값을 초과하면 제외된다.
+     *
+     * ```kotlin
+     * val maxPhrases = KoreanPhraseExtractor.MaxPhrasesPerPhraseChunk
+     * // maxPhrases == 8
+     * ```
+     */
     const val MaxPhrasesPerPhraseChunk = 8
 
+    /**
+     * 관형형 용언 판정에 사용하는 종성 집합입니다.
+     *
+     * ## 동작/계약
+     * - 용언 후보의 마지막 글자 종성이 이 집합에 속하면 수식어 후보로 간주한다.
+     *
+     * ```kotlin
+     * val contains = 'ㄴ' in KoreanPhraseExtractor.ModifyingPredicateEndings
+     * // contains == true
+     * ```
+     */
     @JvmField
     val ModifyingPredicateEndings = setOf('ㄹ', 'ㄴ')
 
+    /**
+     * 관형형 용언 판정에서 제외하는 예외 문자 집합입니다.
+     *
+     * ## 동작/계약
+     * - 마지막 글자가 이 집합에 속하면 관형형 판정에서 제외한다.
+     *
+     * ```kotlin
+     * val excluded = '만' in KoreanPhraseExtractor.ModifyingPredicateExceptions
+     * // excluded == true
+     * ```
+     */
     @JvmField
     val ModifyingPredicateExceptions = setOf('만')
 
+    /**
+     * 구 확장에서 연속 결합 대상으로 허용하는 품사 집합입니다.
+     *
+     * ## 동작/계약
+     * - `collapsePhrases`에서 현재 phrase의 품사가 이 집합에 포함되면 버퍼를 유지하며 결합한다.
+     *
+     * ```kotlin
+     * val joinable = KoreanPhraseExtractor.PhraseTokens.contains(Noun)
+     * // joinable == true
+     * ```
+     */
     @JvmField
     val PhraseTokens = setOf(Noun, ProperNoun, Space)
 
+    /**
+     * 조사 연결어로 취급하는 문자열 집합입니다.
+     *
+     * ## 동작/계약
+     * - `Josa` 품사 phrase가 이 집합이면 비명사 연결 후보로 유지한다.
+     *
+     * ```kotlin
+     * val isConjunctionJosa = "와" in KoreanPhraseExtractor.ConjunctionJosa
+     * // isConjunctionJosa == true
+     * ```
+     */
     @JvmField
     val ConjunctionJosa = setOf("와", "과", "의")
 
+    /**
+     * 트림 후 구의 시작으로 허용하는 품사 집합입니다.
+     *
+     * ## 동작/계약
+     * - `trimNonNouns`는 앞쪽에서 이 집합이 아닌 phrase를 제거한다.
+     *
+     * ```kotlin
+     * val allowed = KoreanPhraseExtractor.PhraseHeadPoses.contains(Adjective)
+     * // allowed == true
+     * ```
+     */
     @JvmField
     val PhraseHeadPoses = setOf(Adjective, Noun, ProperNoun, Alpha, Number)
 
+    /**
+     * 트림 후 구의 끝으로 허용하는 품사 집합입니다.
+     *
+     * ## 동작/계약
+     * - `trimNonNouns`는 뒤쪽에서 이 집합이 아닌 phrase를 제거한다.
+     *
+     * ```kotlin
+     * val allowed = KoreanPhraseExtractor.PhraseTailPoses.contains(Noun)
+     * // allowed == true
+     * ```
+     */
     @JvmField
     val PhraseTailPoses = setOf(Noun, ProperNoun, Alpha, Number)
 
@@ -183,6 +304,21 @@ object KoreanPhraseExtractor: KLogging() {
         return isRightLength() && notEndingInNonPhrasesSuffix()
     }
 
+    /**
+     * 토큰 POS 시퀀스를 규칙 트라이 기반 phrase 시퀀스로 접습니다.
+     *
+     * ## 동작/계약
+     * - 현재 트라이에서 이어질 수 있으면 마지막 phrase에 토큰을 붙여 확장한다.
+     * - 이어질 수 없지만 시작 가능한 품사면 새 phrase를 시작한다.
+     * - `KoreanPhraseExtractorTest` 기준으로 `Modifier + Noun`은 하나의 `Noun` phrase로 합쳐진다.
+     *
+     * ```kotlin
+     * val collapsed = KoreanPhraseExtractor.collapsePos(
+     *     listOf(KoreanToken("m", Modifier, 0, 1), KoreanToken("N", Noun, 1, 1))
+     * )
+     * // collapsed.first().text == "mN"
+     * ```
+     */
     fun collapsePos(tokens: List<KoreanToken>): List<KoreanPhrase> {
 
         fun getTries(token: KoreanToken, trie: List<KoreanPosTrie?>): Pair<KoreanPosTrie?, List<KoreanPosTrie?>> {
@@ -368,20 +504,17 @@ object KoreanPhraseExtractor: KLogging() {
     }
 
     /**
-     * 형태소 분석한 결과에서 [filterSpam], [enableHashtags]를 적용한 구문만을 추출합니다.
+     * 토큰 목록에서 조건에 맞는 phrase를 추출합니다.
      *
+     * ## 동작/계약
+     * - `collapsePos -> getCandidatePhraseChunks -> permutateCandidates` 순서로 후보를 계산한다.
+     * - `enableHashtags=true`이면 `Hashtag`, `CashTag` 토큰을 단일 phrase로 추가한다.
+     * - `KoreanPhraseExtractorTest` 기준으로 `"성탄절 쇼핑..."` 입력에서 텍스트 중복 phrase를 제거해 반환한다.
+     *
+     * ```kotlin
+     * val phrases = KoreanPhraseExtractor.extractPhrases(tokenize("성탄절 쇼핑 성탄절 쇼핑"), filterSpam = false)
+     * // phrases.map { it.text }.distinct() == phrases.map { it.text }
      * ```
-     * val phrases = extractPhrases(tokenize("성탄절 쇼핑 성탄절 쇼핑 성탄절 쇼핑 성탄절 쇼핑"), filterSpam = false)
-     *
-     * val expected = phrases.map { it.text }.distinct()
-     * val actual = phrases.map { it.text }
-     * actual shouldBeEqualTo expected
-     * ```
-     *
-     * @param tokens A sequence of tokens
-     * @param filterSpam true if spam words and slangs to be filtered out
-     * @param enableHashtags true if #hashtags to be included
-     * @return A list of KoreanPhrase
      */
     fun extractPhrases(
         tokens: List<KoreanToken>,

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/phrase/NounPhraseExtractor.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/phrase/NounPhraseExtractor.kt
@@ -19,32 +19,149 @@ import java.util.concurrent.CopyOnWriteArrayList
 
 
 /**
- * 요즘 추세에 맞는 한국어 구(phrase)를 추출하는 클래스입니다.
+ * 명사 중심 규칙으로 한국어 phrase를 추출합니다.
  *
- * 1. Collapse sequence of POSes to phrase candidates (초 + 거대 + 기업 + 의 -> 초거대기업 + 의)
- * 2. Find suitable phrases
+ * ## 동작/계약
+ * - POS 시퀀스를 접은 뒤(`collapsePos`) 길이/품사 제약으로 후보를 걸러낸다.
+ * - 일반 phrase 추출기와 달리 해시태그 추가/스팸 필터 옵션 없이 명사구 추출에 집중한다.
+ * - `NounPhraseExtractorTest` 기준으로 숫자+단위 표현(`3400원`, `1,200.34원`)을 명사구로 인식한다.
+ *
+ * ```kotlin
+ * val phrases = NounPhraseExtractor.extractPhrases(KoreanProcessor.tokenizeForNoun("떡 만두국"))
+ * // phrases.joinToString(", ") == "떡(Noun: 0, 1), 만두국(Noun: 2, 3)"
+ * ```
  */
 object NounPhraseExtractor: KLogging() {
+    /**
+     * 공백 제외 구 길이의 최소 문자 수입니다.
+     *
+     * ## 동작/계약
+     * - 단일 구 후보의 최소 길이 조건으로 사용된다.
+     *
+     * ```kotlin
+     * val minChars = NounPhraseExtractor.MinCharsPerPhraseChunkWithoutSpaces
+     * // minChars == 2
+     * ```
+     */
     const val MinCharsPerPhraseChunkWithoutSpaces = 2
+    /**
+     * 공백 제외 구 길이 판정의 최소 phrase 개수입니다.
+     *
+     * ## 동작/계약
+     * - 구 길이 합이 짧아도 phrase 개수가 이 값 이상이면 통과한다.
+     *
+     * ```kotlin
+     * val minPhrases = NounPhraseExtractor.MinPhrasesPerPhraseChunk
+     * // minPhrases == 3
+     * ```
+     */
     const val MinPhrasesPerPhraseChunk = 3
+    /**
+     * 공백 제외 구 길이의 최대 문자 수입니다.
+     *
+     * ## 동작/계약
+     * - 후보 구 전체 문자 합이 이 값을 넘으면 제외된다.
+     *
+     * ```kotlin
+     * val maxChars = NounPhraseExtractor.MaxCharsPerPhraseChunkWithoutSpaces
+     * // maxChars == 30
+     * ```
+     */
     const val MaxCharsPerPhraseChunkWithoutSpaces = 30
+    /**
+     * 공백 제외 구 길이의 최대 phrase 개수입니다.
+     *
+     * ## 동작/계약
+     * - 후보 구 내 phrase 수가 이 값을 넘으면 제외된다.
+     *
+     * ```kotlin
+     * val maxPhrases = NounPhraseExtractor.MaxPhrasesPerPhraseChunk
+     * // maxPhrases == 3
+     * ```
+     */
     const val MaxPhrasesPerPhraseChunk = 3
 
+    /**
+     * 관형형 용언 판정에 사용하는 종성 집합입니다.
+     *
+     * ## 동작/계약
+     * - 마지막 글자 종성이 이 집합이면 비명사 연결 후보로 취급한다.
+     *
+     * ```kotlin
+     * val contains = 'ㄹ' in NounPhraseExtractor.ModifyingPredicateEndings
+     * // contains == true
+     * ```
+     */
     @JvmField
     val ModifyingPredicateEndings = setOf('ㄹ', 'ㄴ')
 
+    /**
+     * 관형형 용언 판정에서 제외하는 예외 문자 집합입니다.
+     *
+     * ## 동작/계약
+     * - 마지막 글자가 이 집합이면 비명사 연결 후보에서 제외한다.
+     *
+     * ```kotlin
+     * val excluded = '만' in NounPhraseExtractor.ModifyingPredicateExceptions
+     * // excluded == true
+     * ```
+     */
     @JvmField
     val ModifyingPredicateExceptions = setOf('만')
 
+    /**
+     * phrase 결합을 유지할 명사 계열 품사 집합입니다.
+     *
+     * ## 동작/계약
+     * - `collapsePhrases`에서 이 집합에 속하면 버퍼를 이어 붙인다.
+     *
+     * ```kotlin
+     * val joinable = NounPhraseExtractor.PhraseTokens.contains(Noun)
+     * // joinable == true
+     * ```
+     */
     @JvmField
     val PhraseTokens = setOf(Noun, ProperNoun)
 
+    /**
+     * 연결 조사로 취급하는 문자열 집합입니다.
+     *
+     * ## 동작/계약
+     * - 현재 구현에서는 집합 정의만 존재하며 후보 필터에서 직접 사용하지 않는다.
+     *
+     * ```kotlin
+     * val hasWa = "와" in NounPhraseExtractor.ConjunctionJosa
+     * // hasWa == true
+     * ```
+     */
     @JvmField
     val ConjunctionJosa = hashSetOf("와", "과", "의")
 
+    /**
+     * 구 시작 위치에 허용하는 품사 집합입니다.
+     *
+     * ## 동작/계약
+     * - `trimNonNouns`에서 앞부분 제거 기준으로 사용한다.
+     *
+     * ```kotlin
+     * val allowed = NounPhraseExtractor.PhraseHeadPoses.contains(Adjective)
+     * // allowed == true
+     * ```
+     */
     @JvmField
     val PhraseHeadPoses = setOf(Adjective, Noun, ProperNoun, Alpha, Number)
 
+    /**
+     * 구 끝 위치에 허용하는 품사 집합입니다.
+     *
+     * ## 동작/계약
+     * - `trimNonNouns`에서 뒷부분 제거 기준으로 사용한다.
+     *
+     * ```kotlin
+     * val allowed = NounPhraseExtractor.PhraseTailPoses.contains(Noun)
+     * // allowed == true
+     * ```
+     */
     @JvmField
     val PhraseTailPoses = setOf(Noun, ProperNoun, Alpha, Number)
 
@@ -175,6 +292,21 @@ object NounPhraseExtractor: KLogging() {
         return isRightLength() && notEndingInNonPhrasesSuffix()
     }
 
+    /**
+     * 토큰 POS 시퀀스를 명사 중심 phrase 시퀀스로 접습니다.
+     *
+     * ## 동작/계약
+     * - 규칙 트라이와 현재 상태를 이용해 phrase 확장/재시작을 결정한다.
+     * - `NounPhraseExtractorTest` 기준으로 `Modifier + Noun`은 하나의 `Noun` phrase로 병합된다.
+     * - 규칙에 맞지 않는 토큰은 단일 phrase로 유지된다.
+     *
+     * ```kotlin
+     * val collapsed = NounPhraseExtractor.collapsePos(
+     *     listOf(KoreanToken("m", Modifier, 0, 1), KoreanToken("N", Noun, 1, 1))
+     * )
+     * // collapsed.first().text == "mN"
+     * ```
+     */
     fun collapsePos(tokens: Collection<KoreanToken>): List<KoreanPhrase> {
 
         fun getTries(token: KoreanToken, trie: List<KoreanPosTrie?>): Pair<KoreanPosTrie?, List<KoreanPosTrie?>> {
@@ -347,10 +479,17 @@ object NounPhraseExtractor: KLogging() {
     }
 
     /**
-     * Find suitable phrases
+     * 명사 중심 후보를 계산해 최종 phrase 목록을 반환합니다.
      *
-     * @param tokens A sequence of tokens
-     * @return A list of KoreanPhrase
+     * ## 동작/계약
+     * - `collapsePos -> getCandidatePhraseChunks -> permutateCandidates` 순서로 처리한다.
+     * - `NounPhraseExtractorTest` 기준으로 `"떡 만두국"` 입력에서 `"떡"`, `"만두국"`을 반환한다.
+     * - 최종 phrase는 `trimPhraseChunk`를 거쳐 앞뒤 공백 토큰이 제거된다.
+     *
+     * ```kotlin
+     * val phrases = NounPhraseExtractor.extractPhrases(KoreanProcessor.tokenizeForNoun("짜장면 3400원."))
+     * // phrases.map { it.text }.contains("3400원") == true
+     * ```
      */
     fun extractPhrases(tokens: Collection<KoreanToken>): List<KoreanPhrase> {
 

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/phrase/PhraseBuffer.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/phrase/PhraseBuffer.kt
@@ -5,11 +5,21 @@ import io.bluetape4k.tokenizer.korean.utils.KoreanPosTrie
 import java.io.Serializable
 
 /**
- * 한국어 구(phrase)를 나타내는 데이터 클래스입니다.
+ * phrase 접기 과정의 중간 상태를 저장하는 버퍼입니다.
  *
- * @property phrases 구를 구성하는 한국어 구(phrase) 리스트
- * @property curTrie [KoreanPosTrie] 리스트
- * @property ending 구(phrase)의 끝 품사
+ * ## 동작/계약
+ * - `phrases`는 현재까지 생성된 phrase 시퀀스를 유지한다.
+ * - `curTrie`는 다음 토큰에서 가능한 품사 전이 상태를 보관한다.
+ * - `ending`은 현재 시점에서 확정 가능한 끝 품사를 기록한다.
+ *
+ * ```kotlin
+ * val buffer = PhraseBuffer(emptyList(), emptyList(), null)
+ * // buffer.ending == null
+ * ```
+ *
+ * @property phrases 현재까지 누적된 phrase 목록
+ * @property curTrie 현재 트라이 상태 목록
+ * @property ending 현재 종결 품사 후보
  */
 data class PhraseBuffer(
     val phrases: List<KoreanPhrase>,

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/stemmer/KoreanStemmer.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/stemmer/KoreanStemmer.kt
@@ -11,43 +11,77 @@ import io.bluetape4k.tokenizer.korean.utils.KoreanPos.Verb
 import java.util.*
 
 /**
- * 한글 형태소 분석된 토큰의 원형을 제공합니다.
+ * 형태소 분석 결과의 용언 토큰에 원형(stem)을 채우고 어미 토큰을 병합합니다.
  *
- * ```
- * 새로운 스테밍을 추가했었다. -> 새롭다 + 스테밍 + 을 + 추가 + 하다
- * ```
+ * ## 동작/계약
+ * - 입력이 비어 있거나 용언(`Verb`, `Adjective`)이 없으면 원본 리스트를 그대로 반환한다.
+ * - 용언 뒤에 `Eomi`, `PreEomi`가 이어지면 앞선 용언 토큰 텍스트/길이에 어미를 합친다.
+ * - 용언 토큰은 `KoreanDictionaryProvider.predicateStems`를 조회해 `stem` 값을 채운다.
  *
- * ```
- * val tokens = KoreanTokenizer.tokenizeTopN("가느다란").flatMap { it.first() }  // KoreanToken("가느다란", Noun, 0, 4)
- * val actual = KoreanStemmer.stem(tokens)  // KoreanToken("가느다란", Verb, 0, 4, stem = "갈다")
+ * ```kotlin
+ * val tokens = KoreanTokenizer.tokenizeTopN("가느다란").flatMap { it.first() }
+ * val stemmed = KoreanStemmer.stem(tokens)
+ * // stemmed == [KoreanToken("가느다란", Verb, 0, 4, stem = "갈다")]
  * ```
  */
 object KoreanStemmer: KLogging() {
 
+    /**
+     * 용언 뒤에 붙는 어미 품사 집합입니다.
+     *
+     * ## 동작/계약
+     * - `stem`에서 현재 토큰이 이 집합에 속하면 직전 용언에 병합 대상이 된다.
+     *
+     * ```kotlin
+     * val mergeable = KoreanStemmer.Endings.contains(Eomi)
+     * // mergeable == true
+     * ```
+     */
     @JvmField
     val Endings = setOf(Eomi, PreEomi)
 
+    /**
+     * 원형 사전 조회 대상인 용언 품사 집합입니다.
+     *
+     * ## 동작/계약
+     * - `stem`은 이 집합에 속한 토큰만 `predicateStems` 조회로 `stem`을 채운다.
+     *
+     * ```kotlin
+     * val isPredicate = KoreanStemmer.Predicates.contains(Verb)
+     * // isPredicate == true
+     * ```
+     */
     @JvmField
     val Predicates = setOf(Verb, Adjective)
 
+    /**
+     * 명사 뒤 결합 시 용언으로 처리하는 표면형 집합입니다.
+     *
+     * ## 동작/계약
+     * - 품사 평가 로직에서 명사 결합형(`하다`, `되다`, `없다`) 판별 기준으로 사용된다.
+     *
+     * ```kotlin
+     * val supported = "하다" in KoreanStemmer.EndingForNouns
+     * // supported == true
+     * ```
+     */
     @JvmField
     val EndingForNouns = setOf("하다", "되다", "없다")
 
 
     /**
-     * 마지막 어미를 제거하여 동사의 원형을 복원합니다.
+     * 입력 토큰 열에 대해 어미 병합과 용언 원형 복원을 수행합니다.
      *
-     * ```
-     * 새로운 스테밍을 추가했었다. -> 새롭다 + 스테밍 + 을 + 추가 + 하다
-     * ```
+     * ## 동작/계약
+     * - `KoreanStemmerTest` 기준으로 `이럴(Adjective)+수(PreEomi)+가(Eomi)`를 `이럴수가(Adjective, stem=이렇다)`로 병합한다.
+     * - `KoreanStemmerTest` 기준으로 `"가느다란"` 분석 결과를 `Verb` 토큰 하나로 유지하고 `stem="갈다"`를 채운다.
+     * - 병합/복원은 새 리스트에 누적한 뒤 입력 순서로 다시 뒤집어 반환한다.
      *
+     * ```kotlin
+     * val tokens = KoreanTokenizer.tokenizeTopN("가느다란").flatMap { it.first() }
+     * val result = KoreanStemmer.stem(tokens)
+     * // result.first().stem == "갈다"
      * ```
-     * val tokens = KoreanTokenizer.tokenizeTopN("가느다란").flatMap { it.first() }  // KoreanToken("가느다란", Noun, 0, 4)
-     * val actual = KoreanStemmer.stem(tokens)  // KoreanToken("가느다란", Verb, 0, 4, stem = "갈다")
-     * ```
-     *
-     * @param tokens 형태소 분석 토큰 컬렉션
-     * @return 원형을 복원한 토큰 컬렉션
      */
     fun stem(tokens: List<KoreanToken>): List<KoreanToken> {
         if (tokens.isEmpty()) {

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/CandidateParse.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/CandidateParse.kt
@@ -5,16 +5,21 @@ import io.bluetape4k.tokenizer.korean.utils.KoreanPosTrie
 import java.io.Serializable
 
 /**
- * 형태소 분석의 후보 해석을 나타내는 데이터 클래스입니다.
+ * 동적 계획법 기반 형태소 분석의 후보 상태를 표현합니다.
  *
- * Dynamic Programming을 사용한 형태소 분석 과정에서 중간 상태를 저장하는 데 사용됩니다.
+ * ## 동작/계약
+ * - `parse`는 현재까지 누적 점수를 포함한 분석 결과를 담는다.
+ * - `curTrie`는 다음 토큰 확장에서 사용할 품사 전이 노드 목록이다.
+ * - `ending`이 null이 아니면 어미 종결 상태에서의 추가 전이를 허용한다.
  *
- * @property parse 현재까지 분석된 [ParsedChunk]
- * @property curTrie 현재 위치한 품사 트라이 노드 목록
- * @property ending 현재 위치가 어미(ending)인 경우의 품사, 아니면 null
+ * ```kotlin
+ * val candidate = CandidateParse(ParsedChunk(emptyList(), 0), emptyList(), null)
+ * // candidate.ending == null
+ * ```
  *
- * @see KoreanTokenizer
- * @see KoreanPosTrie
+ * @property parse 현재까지 누적된 파싱 결과
+ * @property curTrie 현재 트라이 상태 목록
+ * @property ending 현재 종결 품사
  */
 data class CandidateParse(
     val parse: ParsedChunk,

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/KoreanChunk.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/KoreanChunk.kt
@@ -3,11 +3,21 @@ package io.bluetape4k.tokenizer.korean.tokenizer
 import java.io.Serializable
 
 /**
- * 한국어 형태소 분석기에서 사용하는 Chunk
+ * 원문에서 잘라낸 청크 텍스트와 위치 정보를 표현합니다.
  *
- * @property text 형태소 분석기에서 추출한 텍스트
- * @property offset 형태소 분석기에서 추출한 텍스트의 시작 위치
- * @property length 형태소 분석기에서 추출한 텍스트의 길이
+ * ## 동작/계약
+ * - `text`는 원문 일부 구간 문자열이다.
+ * - `offset`은 원문 기준 시작 인덱스다.
+ * - `length`는 청크 문자열 길이다.
+ *
+ * ```kotlin
+ * val chunk = KoreanChunk("한국어", 0, 3)
+ * // chunk.length == 3
+ * ```
+ *
+ * @property text 청크 텍스트
+ * @property offset 원문 기준 시작 위치
+ * @property length 청크 길이
  */
 data class KoreanChunk(
     val text: String,

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/KoreanChunker.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/KoreanChunker.kt
@@ -25,14 +25,33 @@ import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 /**
- * 한글 문장을 어절(chunk)로 분리하는 유틸리티 클래스입니다.
+ * 입력 문자열을 품사 패턴에 따라 `KoreanToken` 청크로 분리합니다.
  *
- * ```
- * KoreanChunker.getChunks("안녕? iphone6안녕? 세상아?")  // ["안녕", "?", " ", "iphone", "6", "안녕", "?", " ", "세상아", "?"]
+ * ## 동작/계약
+ * - URL/Email/해시태그/숫자/한글 순서로 패턴을 적용해 겹치지 않는 매치를 선택한다.
+ * - 패턴으로 매치되지 않은 구간은 `Foreign` 품사로 채운다.
+ * - 공백은 연속 구간 단위로 유지되며 `Space` 품사를 갖는다.
+ *
+ * ```kotlin
+ * val chunks = KoreanChunker.getChunks("안녕? iphone6안녕? 세상아?")
+ * // chunks == ["안녕", "?", " ", "iphone", "6", "안녕", "?", " ", "세상아", "?"]
  * ```
  */
 object KoreanChunker: KLogging() {
 
+    /**
+     * 청킹에 사용하는 품사별 정규식/패턴 맵입니다.
+     *
+     * ## 동작/계약
+     * - `findAllPatterns`와 `splitChunks`에서 동일한 패턴 소스를 참조한다.
+     * - `KoreanChunkerTest`의 URL/Email/Hashtag/Number 추출 케이스를 통과하는 패턴 집합이다.
+     *
+     * ```kotlin
+     * val matcher = KoreanChunker.POS_PATTERNS[KoreanPos.URL]!!.matcher("https://openkoreantext.org")
+     * val found = matcher.find()
+     * // found == true
+     * ```
+     */
     val POS_PATTERNS: Map<KoreanPos, Pattern> = mapOf(
         Korean to """([가-힣]+)""".toRegex().toPattern(),
         Alpha to """(\p{Alpha}+)""".toRegex().toPattern(),
@@ -63,27 +82,67 @@ object KoreanChunker: KLogging() {
     )
 
     /**
-     * [input] 문자열을 어절(chunk)로 분리합니다.
+     * 문자열을 청크 텍스트 리스트로 반환합니다.
      *
-     * ```
-     * getChunks("안녕? iphone6안녕? 세상아?")  // ["안녕", "?", " ", "iphone", "6", "안녕", "?", " ", "세상아", "?"]
+     * ## 동작/계약
+     * - 내부적으로 `chunk(input)`을 호출한 뒤 토큰 `text`만 추출한다.
+     * - `keepSpace=false`이면 각 청크 문자열에 `trim()`을 적용한다.
+     * - `KoreanChunkerTest` 기준으로 `"안녕? iphone6안녕? 세상아?"`를 10개 청크로 분리한다.
      *
-     * getChunks("#해쉬태그 이라는 것 #hash @hello 123 이런이런 #여자최애캐_5명으로_취향을_드러내자")
-     * // ["#해쉬태그", " ", "이라는", " ", "것", " ", "#hash", " ", "@hello", " ", "123", " ", "이런이런", " ", "#여자최애캐_5명으로_취향을_드러내자"]
+     * ```kotlin
+     * val chunks = KoreanChunker.getChunks("안녕? iphone6안녕? 세상아?")
+     * // chunks == ["안녕", "?", " ", "iphone", "6", "안녕", "?", " ", "세상아", "?"]
      * ```
      */
     fun getChunks(input: String, keepSpace: Boolean = true): List<String> {
         return chunk(input).map { if (keepSpace) it.text else it.text.trim() }
     }
 
+    /**
+     * 패턴 매치 구간과 품사를 함께 보관하는 청크 매치 정보입니다.
+     *
+     * ## 동작/계약
+     * - `range`는 `start..end`를 그대로 노출한다.
+     * - `disjoint`는 두 매치의 겹침 여부를 시작/끝 인덱스로 판별한다.
+     *
+     * ```kotlin
+     * val left = KoreanChunker.ChunkMatch(0, 2, "안녕", KoreanPos.Korean)
+     * val right = KoreanChunker.ChunkMatch(2, 3, "?", KoreanPos.Punctuation)
+     * // left.disjoint(right) == true
+     * ```
+     */
     data class ChunkMatch(
         val start: Int,
         val end: Int,
         val text: String,
         val pos: KoreanPos,
     ) {
+        /**
+         * 매치 시작/끝을 포함하는 인덱스 범위입니다.
+         *
+         * ## 동작/계약
+         * - 생성자에 전달한 `start`, `end`를 그대로 사용해 계산한다.
+         *
+         * ```kotlin
+         * val range = KoreanChunker.ChunkMatch(3, 5, "abc", KoreanPos.Alpha).range
+         * // range == 3..5
+         * ```
+         */
         val range: IntRange = start..end
 
+        /**
+         * 두 매치가 서로 겹치지 않는지 확인합니다.
+         *
+         * ## 동작/계약
+         * - 현재 매치의 앞에서 끝나거나, 현재 매치 뒤에서 시작하면 `true`를 반환한다.
+         * - 경계가 맞닿는 경우는 겹치지 않는 것으로 본다.
+         *
+         * ```kotlin
+         * val a = KoreanChunker.ChunkMatch(0, 2, "ab", KoreanPos.Alpha)
+         * val b = KoreanChunker.ChunkMatch(2, 3, "c", KoreanPos.Alpha)
+         * // a.disjoint(b) == true
+         * ```
+         */
         fun disjoint(that: ChunkMatch): Boolean {
             return (that.start < this.start && that.end <= this.start) ||
                     (that.start >= this.end && that.end > this.end)
@@ -109,33 +168,18 @@ object KoreanChunker: KLogging() {
     }
 
     /**
-     * Recursively call m.find() to find all the matches.
-     * 모든 매치가 찾아질 때까지 `m.find()` 를 재귀적으로 호출합니다.
-     * `tail-recursion` 최적화를 사용하여 stack overflow를 피합니다.
+     * 주어진 `Matcher`에서 모든 매치를 역순 누적 후 원래 순서로 반환합니다.
      *
-     * URL 추출
-     * ```
-     * var actual = findAllPatterns(
-     *      getPatternMatcher(URL, "스팀(http://store.steampowered.com)에서 드디어 여름세일을 시작합니다."),
-     *      URL
-     * )  // [ChunkMatch(2, 32, "(http://store.steampowered.com", URL)]
-     * ```
+     * ## 동작/계약
+     * - `tailrec`으로 구현되어 각 매치를 `matches`의 앞에 삽입한다.
+     * - `Matcher.find()`가 더 이상 성공하지 않으면 누적 리스트를 반환한다.
+     * - `KoreanChunkerTest` 기준으로 URL/Hashtag 다중 매치를 모두 수집한다.
      *
-     * HASH_TAG 찾기
+     * ```kotlin
+     * val matcher = KoreanChunker.POS_PATTERNS[KoreanPos.Email]!!.matcher("문의: a@b.com")
+     * val matches = KoreanChunker.findAllPatterns(matcher, KoreanPos.Email)
+     * // matches.first().text == "a@b.com"
      * ```
-     * actual = findAllPatterns(getPatternMatcher(Hashtag, "구글에는 정말로 이쁜 자전거가 있다. #Google #이쁜자전거 #갖고싶다"), Hashtag)
-     * actual shouldBeEqualTo listOf(
-     *     ChunkMatch(start = 35, end = 41, text = " #갖고싶다", pos = Hashtag),
-     *     ChunkMatch(start = 28, end = 35, text = " #이쁜자전거", pos = Hashtag),
-     *     ChunkMatch(start = 20, end = 28, text = " #Google", pos = Hashtag)
-     * )
-     * ```
-     *
-     *
-     * @param m input Matcher
-     * @param pos KoreanPos to attach
-     * @param matches ouput list of ChunkMatch
-     * @return list of ChunkMatches
      */
     tailrec fun findAllPatterns(
         m: Matcher,
@@ -218,32 +262,33 @@ object KoreanChunker: KLogging() {
     }
 
     /**
-     * Get chunks by given pos.
+     * 분리된 청크 중 지정 품사에 해당하는 토큰만 반환합니다.
      *
-     * @param input input string
-     * @param pos one of supported KoreanPos's: URL, Email, ScreenName, Hashtag,
-     *            CashTag, Korean, KoreanParticle, Number, Alpha, Punctuation
-     * @return sequence of Korean chunk strings
+     * ## 동작/계약
+     * - 내부적으로 `chunk(input)` 결과에서 `it.pos == pos`만 필터링한다.
+     * - `KoreanChunkerTest` 기준으로 URL/Email/Hashtag/CashTag 추출을 지원한다.
+     *
+     * ```kotlin
+     * val urls = KoreanChunker.getChunksByPos("openkoreantext.org에서 확인", KoreanPos.URL)
+     * // urls.map { it.text } == ["openkoreantext.org"]
+     * ```
      */
     fun getChunksByPos(input: String, pos: KoreanPos): List<KoreanToken> {
         return chunk(input).filter { it.pos == pos }
     }
 
     /**
-     * Split input text into a sequnce of KoreanToken. A candidate for Korean parser
-     * gets tagged with KoreanPos.Korean.
+     * 입력 문자열을 청크 단위 `KoreanToken` 목록으로 분할합니다.
      *
-     * ```
-     * chunk("중·고등학교에서…") shouldBeEqualTo listOf(
-     *     KoreanToken("중", Korean, 0, 1),
-     *     KoreanToken("·", Punctuation, 1, 1),
-     *     KoreanToken("고등학교에서", Korean, 2, 6),
-     *     KoreanToken("…", Punctuation, 8, 1)
-     * )
-     * ```
+     * ## 동작/계약
+     * - 공백 보존 분할 후 각 세그먼트를 `splitChunks`로 분석해 순서대로 `KoreanToken`을 만든다.
+     * - 토큰 offset은 원문에서 `indexOf(m.text, i)`로 계산해 누적 위치를 갱신한다.
+     * - `KoreanChunkerTest` 기준으로 `"중·고등학교에서…"`를 `[중, ·, 고등학교에서, …]` 4개 토큰으로 반환한다.
      *
-     * @param input input string
-     * @return sequence of KoreanTokens
+     * ```kotlin
+     * val tokens = KoreanChunker.chunk("중·고등학교에서…")
+     * // tokens.map { it.text } == ["중", "·", "고등학교에서", "…"]
+     * ```
      */
     fun chunk(input: CharSequence): List<KoreanToken> {
         val s = input.toString()

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/KoreanDetokenizer.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/KoreanDetokenizer.kt
@@ -14,29 +14,60 @@ import io.bluetape4k.tokenizer.korean.utils.KoreanPos.VerbPrefix
 
 
 /**
- * 한글 형대소 분석 결과를 다시 문장으로 복원합니다.
+ * 토큰 문자열 목록을 자연스러운 문장 형태로 재조합합니다.
+ *
+ * ## 동작/계약
+ * - 입력 단어 경계로 `spaceGuide`를 만든 뒤 다시 토크나이즈하여 품사 결합 규칙을 적용한다.
+ * - 조사/어미/접미사와 접두사는 앞뒤 토큰에 붙여 공백을 줄인다.
+ * - 빈 입력이면 빈 문자열을 반환한다.
+ *
+ * ```kotlin
+ * val sentence = KoreanDetokenizer.detokenize(listOf("연세", "대학교", "에", "오신", "것", "을"))
+ * // sentence.contains("연세대학교") == true
+ * ```
  */
 object KoreanDetokenizer: KLogging() {
 
+    /**
+     * 앞 토큰에 결합하는 후행 품사 집합입니다.
+     *
+     * ## 동작/계약
+     * - 토큰 결합 시 현재 토큰 품사가 이 집합에 포함되면 직전 문자열에 붙인다.
+     *
+     * ```kotlin
+     * val join = KoreanDetokenizer.SuffixPos.contains(KoreanPos.Josa)
+     * // join == true
+     * ```
+     */
     @JvmField
     val SuffixPos: Set<KoreanPos> = setOf(Josa, Eomi, PreEomi, Suffix, Punctuation)
 
+    /**
+     * 다음 토큰과 결합을 유도하는 선행 품사 집합입니다.
+     *
+     * ## 동작/계약
+     * - 토큰 결합 시 현재 토큰 품사가 이 집합이면 다음 토큰을 이어 붙인다.
+     *
+     * ```kotlin
+     * val prefix = KoreanDetokenizer.PrefixPos.contains(KoreanPos.Modifier)
+     * // prefix == true
+     * ```
+     */
     @JvmField
     val PrefixPos: Set<KoreanPos> = setOf(Modifier, VerbPrefix)
 
     /**
-     * 한글 형태소 분석기로 분석된 단어들을 하나의 문장으로 만듭니다.
+     * 형태소 단어 목록을 재결합해 문장을 만듭니다.
      *
+     * ## 동작/계약
+     * - `input.joinToString("")` 결과를 `TokenizerProfile(spaceGuide=...)`로 재분석한다.
+     * - `Noun + Verb` 조합은 붙여 쓰기(`사랑` + `해`)로 결합한다.
+     * - `KoreanDetokenizerTest` 기준으로 `"연세","대학교",...` 입력을 `"연세대학교 ..."` 형태로 복원한다.
+     *
+     * ```kotlin
+     * val text = KoreanDetokenizer.detokenize(listOf("뭐", "완벽", "하진", "않", "지만"))
+     * // text == "뭐 완벽하진 않지만"
      * ```
-     * var actual = detokenize(listOf("연세", "대학교", "보건", "대학원", "에", "오신", "것", "을", "환영", "합니다", "!"))
-     * actual shouldBeEqualTo "연세대학교 보건 대학원에 오신것을 환영합니다!"
-     *
-     * actual = detokenize(listOf("뭐", "완벽", "하진", "않", "지만", "그럭저럭", "쓸", "만", "하군", "..."))
-     * actual shouldBeEqualTo "뭐 완벽하진 않지만 그럭저럭 쓸 만하군..."
-     * ```
-     *
-     * @param input 분석된 단어들
-     * @return 복원된 문장
      */
     fun detokenize(input: Collection<String>): String {
         // Space guide prevents tokenizing a word that was not tokenized in the input.

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/KoreanSentenceSplitter.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/KoreanSentenceSplitter.kt
@@ -3,7 +3,17 @@ package io.bluetape4k.tokenizer.korean.tokenizer
 import io.bluetape4k.logging.KLogging
 
 /**
- * 한글 문장을 문장 단위로 분리하는 유틸리티 클래스입니다.
+ * 입력 문자열을 문장 경계 정규식으로 분리합니다.
+ *
+ * ## 동작/계약
+ * - 구두점(`.!?…`)과 공백/문자열 끝 조건으로 문장 경계를 계산한다.
+ * - 빈 입력이면 `emptySequence()`를 반환한다.
+ * - 반환 `Sentence.end`는 `mr.range.last + 1`로 계산되는 exclusive 인덱스다.
+ *
+ * ```kotlin
+ * val sentences = KoreanSentenceSplitter.split("안녕? 세상아?").toList()
+ * // sentences.map { it.text } == ["안녕?", "세상아?"]
+ * ```
  */
 object KoreanSentenceSplitter: KLogging() {
 
@@ -24,16 +34,16 @@ object KoreanSentenceSplitter: KLogging() {
             .toRegex()
 
     /**
-     * 한글 문장을 문장(Sentence) 단위로 분리합니다.
+     * 문자열을 문장 단위 `Sequence<Sentence>`로 반환합니다.
      *
+     * ## 동작/계약
+     * - 정규식 `findAll` 결과를 순회해 각 매치를 `Sentence(text, start, endExclusive)`로 변환한다.
+     * - `KoreanSentenceSplitterTest` 기준으로 `"안녕? iphone6안녕? 세상아?"`는 3문장으로 분리된다.
+     *
+     * ```kotlin
+     * val list = KoreanSentenceSplitter.split("안녕? iphone6안녕? 세상아?").toList()
+     * // list.size == 3
      * ```
-     * var actual = split("안녕? iphone6안녕? 세상아?").toList()
-     * actual shouldContainSame listOf(
-     *     Sentence("안녕?", 0, 3),
-     *     Sentence("iphone6안녕?", 4, 14),
-     *     Sentence("세상아?", 15, 19)
-     * )
-     *```
      */
     fun split(text: CharSequence): Sequence<Sentence> {
         if (text.isEmpty()) {

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/KoreanToken.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/KoreanToken.kt
@@ -4,14 +4,24 @@ import io.bluetape4k.tokenizer.korean.utils.KoreanPos
 import java.io.Serializable
 
 /**
- * 한글 형태소 분석의 결과인 한글 토큰
+ * 형태소 분석 결과의 단일 토큰 정보를 표현합니다.
  *
- * @property text 토큰의 텍스트
- * @property pos 토큰의 품사
- * @property offset 토큰의 시작 위치
- * @property length 토큰의 길이
- * @property stem 토큰의 어간 (원형)
- * @property unknown 알 수 없는 토큰인지 여부
+ * ## 동작/계약
+ * - `text`, `pos`, `offset`, `length`는 파싱 결과의 원문 구간 정보를 그대로 담는다.
+ * - `stem`은 용언 원형이 계산된 경우에만 채워진다.
+ * - `unknown=true`면 사전에 없는 미등록 명사 후보임을 의미한다.
+ *
+ * ```kotlin
+ * val token = KoreanToken("사랑", KoreanPos.Noun, 0, 2)
+ * // token.toString() == "사랑(Noun: 0, 2)"
+ * ```
+ *
+ * @property text 토큰 문자열
+ * @property pos 토큰 품사
+ * @property offset 원문 시작 위치
+ * @property length 토큰 길이
+ * @property stem 용언 원형
+ * @property unknown 미등록 후보 여부
  */
 data class KoreanToken(
     val text: String,
@@ -29,7 +39,17 @@ data class KoreanToken(
     }
 
     /**
-     * 새로운 품사로 복사본을 생성합니다.
+     * 현재 토큰을 동일한 값으로 복사하되 품사만 [pos]로 교체합니다.
+     *
+     * ## 동작/계약
+     * - `copy(pos = pos)`를 그대로 위임 호출한다.
+     * - `text`, `offset`, `length`, `stem`, `unknown` 값은 유지된다.
+     *
+     * ```kotlin
+     * val noun = KoreanToken("사랑", KoreanPos.Noun, 0, 2)
+     * val verb = noun.copyWithNewPos(KoreanPos.Verb)
+     * // verb.pos == KoreanPos.Verb
+     * ```
      */
     fun copyWithNewPos(pos: KoreanPos): KoreanToken = copy(pos = pos)
 }

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/KoreanTokenizer.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/KoreanTokenizer.kt
@@ -23,11 +23,17 @@ import kotlinx.coroutines.runBlocking
 import org.eclipse.collections.api.multimap.MutableMultimap
 
 /**
- * 한글 형태소 분석기입니다.
+ * 한국어 문장을 형태소 토큰 열로 분석하는 기본 토크나이저입니다.
  *
- * Chunk: 어절 - 공백으로 구분되어 있는 단위 (사랑하는사람을)
- * Word: 단어 - 하나의 문장 구성 요소 (사랑하는, 사람을)
- * Token: 토큰 - 형태소와 비슷한 단위이지만 문법적으로 정확하지는 않음 (사랑, 하는, 사람, 을)
+ * ## 동작/계약
+ * - 입력은 먼저 `KoreanChunker.chunk`로 청크 분할되고, `Korean` 품사 청크만 동적 계획법 파서를 적용한다.
+ * - 후보 분석 결과는 각 청크별로 최대 `topN`개를 반환하고, `KoreanSubstantive.collapseNouns`로 명사 연쇄를 보정한다.
+ * - 최종 `tokenize`는 `KoreanStemmer.stem`을 거쳐 용언 원형 정보를 채운다.
+ *
+ * ```kotlin
+ * val tokens = KoreanTokenizer.tokenize("엄청작아서귀엽다")
+ * // tokens == [엄청(Adverb), 작아서(Adjective, stem=작다), 귀엽다(Adjective, stem=귀엽다)]
+ * ```
  */
 object KoreanTokenizer: KLogging() {
 
@@ -81,45 +87,17 @@ object KoreanTokenizer: KLogging() {
     }
 
     /**
-     * 한글 문장을 형태소 분석하여 [KoreanToken]의 리스트로 반환합니다.
+     * 문장을 1-best 분석으로 형태소 분해하고 원형(stem)을 보정한 토큰 리스트를 반환합니다.
      *
-     * ```
-     * tokenize("엄청작아서귀엽다") shouldBeEqualTo listOf(
-     *     KoreanToken("엄청", Adverb, 0, 2),
-     *     KoreanToken("작아서", Adjective, 2, 3, stem = "작다"),
-     *     KoreanToken("귀엽다", Adjective, 5, 3, stem = "귀엽다")
-     * )
-     * ```
+     * ## 동작/계약
+     * - `tokenizeTopN(text, 1, profile)` 결과에서 각 청크의 첫 번째 후보만 사용한다.
+     * - 비한글 청크(`Space`, `Punctuation` 등)는 원래 청크 토큰을 그대로 유지한다.
+     * - `KoreanTokenizerTest` 기준으로 `"주말특가"`는 `[주말(Noun), 특가(Noun)]`로 분해된다.
      *
+     * ```kotlin
+     * val tokens = KoreanTokenizer.tokenize("야이건뭐")
+     * // tokens == [야(Exclamation), 이건(Noun), 뭐(Noun)]
      * ```
-     * tokenize("야이건뭐") shouldBeEqualTo listOf(
-     *     KoreanToken("야", Exclamation, 0, 1),
-     *     KoreanToken("이건", Noun, 1, 2),
-     *     KoreanToken("뭐", Noun, 3, 1)
-     * )
-     * ```
-     *
-     * ```
-     * tokenize("주말특가") shouldBeEqualTo listOf(
-     *     KoreanToken("주말", Noun, 0, 2),
-     *     KoreanToken("특가", Noun, 2, 2)
-     * )
-     * ```
-     *
-     * ```
-     * val text = """우리 동네사람들"""
-     * val tokens = tokenize(text)
-     * tokens shouldBeEqualTo listOf(
-     *     KoreanToken("우리", Noun, 0, 2),
-     *     KoreanToken(" ", Space, 2, 1),
-     *     KoreanToken("동네", Noun, 3, 2),
-     *     KoreanToken("사람", Noun, 5, 2),
-     *     KoreanToken("들", Suffix, 7, 1)
-     * )
-     * ```
-     *
-     * @param text 한글 문장
-     * @return 형태소 분석된 [KoreanToken] 리스트
      */
     fun tokenize(
         text: CharSequence,
@@ -132,11 +110,17 @@ object KoreanTokenizer: KLogging() {
     }
 
     /**
-     * 한글 문장을 [topN] 개수만큼 형태소 분석하여 [KoreanToken]의 리스트로 반환합니다.
+     * 문장을 청크별 상위 `topN` 후보 분석 결과로 반환합니다.
      *
-     * @param text 한글 문장
-     * @param topN 최대 분석 개수 (default: 1)
-     * @return 형태소 분석된 [KoreanToken] 리스트
+     * ## 동작/계약
+     * - 반환 타입은 `List<청크, List<후보, List<KoreanToken>>>` 구조다.
+     * - 파싱 중 예외가 발생하면 `TokenizerException("Error tokenizing a chunk: $text", cause)`로 감싸서 던진다.
+     * - `KoreanTokenizerTest`에서 사용자 사전 추가 전/후 결과가 달라지는 경로는 이 함수의 후보 생성 결과를 따른다.
+     *
+     * ```kotlin
+     * val top = KoreanTokenizer.tokenizeTopN("가느다란", topN = 1)
+     * // top.isNotEmpty() == true
+     * ```
      */
     fun tokenizeTopN(
         text: CharSequence,

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/NounTokenizer.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/NounTokenizer.kt
@@ -15,14 +15,17 @@ import io.bluetape4k.tokenizer.korean.utils.KoreanPosx
 import io.bluetape4k.tokenizer.korean.utils.KoreanSubstantive
 
 /**
- * 한글 형태소 분석 중 명사만을 추출하는 토크나이저
+ * 명사 중심 규칙으로 한국어 문장을 분석하는 토크나이저입니다.
  *
- * Chunk: 어절 - 공백으로 구분되어 있는 단위 (사랑하는사람을)
- * Word: 단어 - 하나의 문장 구성 요소 (사랑하는, 사람을)
- * Token: 토큰 - 형태소와 비슷한 단위이지만 문법적으로 정확하지는 않음 (사랑, 하는, 사람, 을)
+ * ## 동작/계약
+ * - 품사 규칙을 `Noun`과 `Conjunction` 위주로 제한해 일반 토크나이저보다 명사 분해를 우선한다.
+ * - 비한글 청크는 그대로 유지하고, 한글 청크만 내부 파서를 적용한다.
+ * - 최종 결과는 `KoreanStemmer.stem`을 통과하므로 용언이 포함된 경우 `stem` 정보가 채워질 수 있다.
  *
- * Whenever there is an updates in the behavior of KoreanParser,
- * the initial cache has to be updated by running tools.CreateInitialCache.
+ * ```kotlin
+ * val tokens = NounTokenizer.tokenize("성탄절 쇼핑")
+ * // tokens.map { it.text } == ["성탄절", " ", "쇼핑"]
+ * ```
  */
 object NounTokenizer: KLogging() {
 
@@ -76,13 +79,31 @@ object NounTokenizer: KLogging() {
         "C1" to Conjunction
     )
 
+    /**
+     * 명사 중심 품사 시퀀스 규칙을 트라이로 구성한 파서 상태 집합입니다.
+     *
+     * ## 동작/계약
+     * - `SequenceDefinition`을 기반으로 lazy 초기화된다.
+     * - 내부 동적 계획법 후보 확장에서 현재 상태 전이에 사용된다.
+     *
+     * ```kotlin
+     * val trie = NounTokenizer.koreanPosTrie
+     * // trie.isNotEmpty() == true
+     * ```
+     */
     val koreanPosTrie by lazy { KoreanPosx.getTrie(SequenceDefinition) }
 
     /**
-     * Parse Korean text into a sequence of KoreanTokens with custom parameters
+     * 문장을 1-best 명사 중심 토큰 리스트로 분석합니다.
      *
-     * @param text Input Korean chunk
-     * @return sequence of KoreanTokens
+     * ## 동작/계약
+     * - `tokenizeTopN(text, 1, profile)`의 첫 후보를 사용한다.
+     * - `KoreanTokenizerTest`와 `NounPhraseExtractorTest` 경로에서 명사구 추출 입력으로 사용된다.
+     *
+     * ```kotlin
+     * val tokens = NounTokenizer.tokenize("떡 만두국")
+     * // tokens.isNotEmpty() == true
+     * ```
      */
     fun tokenize(
         text: CharSequence,
@@ -95,11 +116,17 @@ object NounTokenizer: KLogging() {
     }
 
     /**
-     * Parse Korean text into a sequence of KoreanTokens with custom parameters
+     * 문장을 청크별 상위 `topN` 명사 중심 후보로 분석합니다.
      *
-     * @param text Input Korean chunk
-     * @param topN number of top candidates
-     * @return sequence of KoreanTokens
+     * ## 동작/계약
+     * - 반환 구조는 `List<청크, List<후보, List<KoreanToken>>>`이며 각 후보는 점수순으로 정렬된다.
+     * - 후보가 비어 있으면 `unknown=true`인 `Noun` 단일 토큰 후보를 생성한다.
+     * - 분석 중 예외는 `TokenizerException("Error tokenizing a chunk: $text", cause)`로 변환된다.
+     *
+     * ```kotlin
+     * val top = NounTokenizer.tokenizeTopN("허니버터칩", topN = 1)
+     * // top.size >= 1
+     * ```
      */
     fun tokenizeTopN(
         text: CharSequence,

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/ParsedChunk.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/ParsedChunk.kt
@@ -19,16 +19,21 @@ import io.bluetape4k.tokenizer.korean.utils.KoreanPos.VerbPrefix
 import java.io.Serializable
 
 /**
- * 형태소 분석된 어절(Chunk)을 나타내는 클래스입니다.
+ * 하나의 어절에 대한 형태소 분석 후보와 점수 계산 로직을 담습니다.
  *
- * ParsedChunk는 형태소 분석의 후보 중 하나로, 여러 개의 [KoreanToken]을 포함하며
- * 각 후보의 품질을 평가하는 점수 계산 기능을 제공합니다.
+ * ## 동작/계약
+ * - `score`는 토큰 수/미등록/빈도/조사 불일치 등 항목을 `TokenizerProfile` 가중치로 선형 결합한다.
+ * - `plus` 연산은 토큰 목록과 단어 수를 누적한 새 `ParsedChunk`를 만든다.
+ * - `josaMismatched`는 명사-조사 결합 규칙 위반이 있으면 `1`, 아니면 `0`이다.
  *
- * @property posNodes 형태소 분석된 토큰 목록
- * @property words 형태소 분석된 단어 수 (트라이 노드 이동 횟수)
- * @property profile 형태소 분석기 프로필
+ * ```kotlin
+ * val chunk = ParsedChunk(listOf(KoreanToken("사랑", Noun, 0, 2)), 1)
+ * // chunk.countTokens == 1
+ * ```
  *
- * @see KoreanTokenizer
+ * @property posNodes 후보를 구성하는 토큰 목록
+ * @property words 트라이 전이 기준 단어 수
+ * @property profile 점수 계산 프로필
  */
 data class ParsedChunk(
     val posNodes: List<KoreanToken>,
@@ -36,13 +41,47 @@ data class ParsedChunk(
     val profile: TokenizerProfile = TokenizerProfile.DefaultProfile,
 ): Serializable {
     companion object: KLogging() {
+        /**
+         * 접미/어미/조사 계열 품사 집합입니다.
+         *
+         * ## 동작/계약
+         * - 시작 위치 페널티와 공백 가이드 판정에서 제외 품사로 사용된다.
+         *
+         * ```kotlin
+         * val suffix = ParsedChunk.suffixes.contains(Josa)
+         * // suffix == true
+         * ```
+         */
         val suffixes = setOf(Suffix, Eomi, Josa, PreEomi)
+        /**
+         * `하다/해` 결합 선호 판정에서 앞 토큰으로 허용하는 품사 집합입니다.
+         *
+         * ## 동작/계약
+         * - `isNounHa` 계산 시 첫 토큰 품사가 이 집합에 포함되면 가산점 조건을 검사한다.
+         *
+         * ```kotlin
+         * val preferred = ParsedChunk.preferredBeforeHaVerb.contains(Noun)
+         * // preferred == true
+         * ```
+         */
         val preferredBeforeHaVerb = setOf(Noun, ProperNoun, VerbPrefix)
 
         private val josaMatchedSet = hashSetOf("는", "를", "다")
         private val josaMatchedSet2 = hashSetOf("은", "을", "이")
     }
 
+    /**
+     * 프로필 가중치 기반 최종 후보 점수입니다.
+     *
+     * ## 동작/계약
+     * - 값이 작을수록 우선 후보가 되며 정렬 기준으로 사용된다.
+     * - 각 보조 지표(`countUnknowns`, `isNounHa`, `josaMismatched` 등)를 합산해 계산한다.
+     *
+     * ```kotlin
+     * val score = ParsedChunk(listOf(KoreanToken("사랑", Noun, 0, 2)), 1).score
+     * // score is Float
+     * ```
+     */
     val score: Float by lazy {
         countTokens * profile.tokenCount +
                 countUnknowns * profile.unknown +
@@ -61,15 +100,71 @@ data class ParsedChunk(
                 josaMismatched * profile.josaUnmatchedPenalty
     }
 
+    /**
+     * 미등록(unknown) 토큰 개수입니다.
+     *
+     * ## 동작/계약
+     * - `posNodes`에서 `unknown == true`인 토큰 수를 센다.
+     *
+     * ```kotlin
+     * val n = ParsedChunk(listOf(KoreanToken("x", Unknown, 0, 1, unknown = true)), 1).countUnknowns
+     * // n == 1
+     * ```
+     */
     val countUnknowns: Int get() = posNodes.count { it.unknown }
+    /**
+     * 후보 토큰 개수입니다.
+     *
+     * ## 동작/계약
+     * - `posNodes.size`를 그대로 반환한다.
+     *
+     * ```kotlin
+     * val n = ParsedChunk(emptyList(), 0).countTokens
+     * // n == 0
+     * ```
+     */
     val countTokens: Int get() = posNodes.size
 
+    /**
+     * 후보 첫 토큰이 접미/조사 계열로 시작하는지 나타내는 페널티 지표입니다.
+     *
+     * ## 동작/계약
+     * - 첫 토큰이 `suffixes`에 속하면 `1`, 아니면 `0`을 반환한다.
+     *
+     * ```kotlin
+     * val v = ParsedChunk(listOf(KoreanToken("은", Josa, 0, 1)), 1).isInitialPosPosition
+     * // v == 1
+     * ```
+     */
     val isInitialPosPosition: Int
         get() = if (posNodes.firstOrNull() != null && suffixes.contains(posNodes.first().pos)) 1 else 0
     //        get() = if ((posNodes.firstOrNull()?.pos ?: Unknown) in suffixes) 1 else 0
 
+    /**
+     * 단일 토큰 정확 매칭 여부 지표입니다.
+     *
+     * ## 동작/계약
+     * - 토큰이 1개면 `0`, 2개 이상이면 `1`을 반환한다.
+     *
+     * ```kotlin
+     * val v = ParsedChunk(listOf(KoreanToken("사랑", Noun, 0, 2)), 1).isExactMatch
+     * // v == 0
+     * ```
+     */
     val isExactMatch: Int get() = if (posNodes.size == 1) 0 else 1
 
+    /**
+     * 공백 가이드 위반 개수 지표입니다.
+     *
+     * ## 동작/계약
+     * - `profile.spaceGuide`가 비어 있으면 `0`이다.
+     * - 접미/조사 계열을 제외한 토큰의 `offset`이 가이드에 없으면 위반으로 집계한다.
+     *
+     * ```kotlin
+     * val v = ParsedChunk(emptyList(), 0, TokenizerProfile(spaceGuide = intArrayOf(1))).hasSpaceOutOfGuide
+     * // v == 0
+     * ```
+     */
     val hasSpaceOutOfGuide: Int
         get() =
             if (profile.spaceGuide.isEmpty()) {
@@ -80,12 +175,45 @@ data class ParsedChunk(
                     .count { it.offset !in profile.spaceGuide }
             }
 
+    /**
+     * 전체가 명사 계열인지 판정하는 지표입니다.
+     *
+     * ## 동작/계약
+     * - 하나라도 `Noun`/`ProperNoun`이 아닌 품사가 있으면 `1`, 전부 명사 계열이면 `0`이다.
+     *
+     * ```kotlin
+     * val v = ParsedChunk(listOf(KoreanToken("사랑", Noun, 0, 2)), 1).isAllNouns
+     * // v == 0
+     * ```
+     */
     val isAllNouns: Int
         get() = if (posNodes.any { it.pos != Noun && it.pos != ProperNoun }) 1 else 0
 
+    /**
+     * 선호 품사 패턴 매칭 지표입니다.
+     *
+     * ## 동작/계약
+     * - 토큰이 2개이고 품사열이 `profile.preferredPatterns`에 포함되면 `0`, 아니면 `1`이다.
+     *
+     * ```kotlin
+     * val v = ParsedChunk(listOf(KoreanToken("사랑", Noun, 0, 2), KoreanToken("을", Josa, 2, 1)), 1).isPreferredPattern
+     * // v == 0
+     * ```
+     */
     val isPreferredPattern: Int
         get() = if (posNodes.size == 2 && profile.preferredPatterns.contains(posNodes.map { it.pos })) 0 else 1
 
+    /**
+     * 명사+하다/해 결합 선호 지표입니다.
+     *
+     * ## 동작/계약
+     * - 첫 토큰이 `preferredBeforeHaVerb`이고 둘째 토큰이 `Verb`이며 `하/해`로 시작하면 `0`, 아니면 `1`이다.
+     *
+     * ```kotlin
+     * val v = ParsedChunk(listOf(KoreanToken("사랑", Noun, 0, 2), KoreanToken("해", Verb, 2, 1)), 1).isNounHa
+     * // v == 0
+     * ```
+     */
     val isNounHa: Int
         get() {
             val notNoun =
@@ -97,13 +225,47 @@ data class ParsedChunk(
             return if (notNoun) 0 else 1
         }
 
+    /**
+     * 동일 점수 후보 간 품사 ordinal 합 기반 tie-breaker 값입니다.
+     *
+     * ## 동작/계약
+     * - `posNodes.sumOf { it.pos.ordinal }`를 반환한다.
+     *
+     * ```kotlin
+     * val tie = ParsedChunk(emptyList(), 0).posTieBreaker
+     * // tie == 0
+     * ```
+     */
     val posTieBreaker: Int get() = posNodes.sumOf { it.pos.ordinal }
 
+    /**
+     * 미등록 토큰 텍스트 길이 총합을 반환합니다.
+     *
+     * ## 동작/계약
+     * - `unknown == true`인 토큰의 `text.length`만 합산한다.
+     *
+     * ```kotlin
+     * val c = ParsedChunk(listOf(KoreanToken("xx", Noun, 0, 2, unknown = true)), 1).getUnknownCoverage()
+     * // c == 2
+     * ```
+     */
     fun getUnknownCoverage(): Int =
         posNodes.fold(0) { sum, p ->
             if (p.unknown) sum + p.text.length else sum
         }
 
+    /**
+     * 명사/고유명사 빈도 사전을 이용한 평균 빈도 점수를 반환합니다.
+     *
+     * ## 동작/계약
+     * - 명사/고유명사는 `1.0 - entityFreq`, 그 외 품사는 `1.0`을 사용한다.
+     * - 모든 토큰 점수 합을 토큰 개수로 나눈 값을 반환한다.
+     *
+     * ```kotlin
+     * val score = ParsedChunk(listOf(KoreanToken("사랑", Noun, 0, 2)), 1).getFreqScore()
+     * // score is Float
+     * ```
+     */
     fun getFreqScore(): Float {
         val freqScoreSum =
             posNodes.sumOf { p ->
@@ -117,6 +279,19 @@ data class ParsedChunk(
         return (freqScoreSum / posNodes.size).toFloat()
     }
 
+    /**
+     * 두 파싱 후보를 이어붙인 새 `ParsedChunk`를 만듭니다.
+     *
+     * ## 동작/계약
+     * - 토큰 목록과 `words`를 각각 덧셈으로 누적한다.
+     * - `profile`은 왼쪽 피연산자 값을 유지한다.
+     *
+     * ```kotlin
+     * val a = ParsedChunk(listOf(KoreanToken("사랑", Noun, 0, 2)), 1)
+     * val b = ParsedChunk(listOf(KoreanToken("해", Verb, 2, 1)), 1)
+     * // (a + b).countTokens == 2
+     * ```
+     */
     operator fun plus(that: ParsedChunk): ParsedChunk {
         return copy(
             posNodes = posNodes + that.posNodes,
@@ -126,8 +301,33 @@ data class ParsedChunk(
         // ParsedChunk(posNodes + that.posNodes, words + that.words, profile)
     }
 
+    /**
+     * 특정 품사의 토큰 개수를 반환합니다.
+     *
+     * ## 동작/계약
+     * - `posNodes`에서 `it.pos == pos`인 원소만 집계한다.
+     *
+     * ```kotlin
+     * val c = ParsedChunk(listOf(KoreanToken("사랑", Noun, 0, 2)), 1).countPos(Noun)
+     * // c == 1
+     * ```
+     */
     fun countPos(pos: KoreanPos): Int = posNodes.count { it.pos == pos }
 
+    /**
+     * 명사-조사 결합 불일치 여부 지표입니다.
+     *
+     * ## 동작/계약
+     * - 인접 2토큰 슬라이딩에서 `Noun + Josa` 쌍의 받침 규칙 위반이 있으면 `1`, 아니면 `0`이다.
+     *
+     * ```kotlin
+     * val mismatch = ParsedChunk(
+     *     listOf(KoreanToken("사랑", Noun, 0, 2), KoreanToken("는", Josa, 2, 1)),
+     *     1
+     * ).josaMismatched
+     * // mismatch == 1
+     * ```
+     */
     val josaMismatched: Int
         get() {
             val mismatched: Boolean =

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/PossibleTrie.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/PossibleTrie.kt
@@ -4,13 +4,19 @@ import io.bluetape4k.tokenizer.korean.utils.KoreanPosTrie
 import java.io.Serializable
 
 /**
- * 형태소 분석에서 가능한 트라이 경로를 나타내는 데이터 클래스입니다.
+ * 현재 분석 지점에서 확장 가능한 품사 트라이 후보입니다.
  *
- * @property curTrie 현재 위치한 품사 트라이 노드
- * @property words 현재까지 분석된 단어 수
+ * ## 동작/계약
+ * - `curTrie`는 다음 토큰 매칭에 사용할 트라이 노드다.
+ * - `words`는 이 후보를 선택했을 때 누적 단어 수 가중치다.
  *
- * @see KoreanPosTrie
- * @see CandidateParse
+ * ```kotlin
+ * val candidate = PossibleTrie(KoreanPosTrie(null), 0)
+ * // candidate.words == 0
+ * ```
+ *
+ * @property curTrie 현재 트라이 노드
+ * @property words 누적 단어 수
  */
 data class PossibleTrie(
     val curTrie: KoreanPosTrie,

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/Sentence.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/Sentence.kt
@@ -3,13 +3,20 @@ package io.bluetape4k.tokenizer.korean.tokenizer
 import java.io.Serializable
 
 /**
- * 문장 분리 결과를 나타내는 데이터 클래스입니다.
+ * 문장 분리 결과의 단일 문장과 위치 정보를 담습니다.
  *
- * @property text 분리된 문장의 텍스트
- * @property start 원본 텍스트에서 문장의 시작 위치 (0-based index)
- * @property end 원본 텍스트에서 문장의 끝 위치 (exclusive)
+ * ## 동작/계약
+ * - `text`는 분리된 문장 문자열이다.
+ * - `start`는 원문 시작 인덱스(0-based), `end`는 원문 끝 인덱스(exclusive)다.
  *
- * @see KoreanSentenceSplitter
+ * ```kotlin
+ * val sentence = Sentence("안녕?", 0, 3)
+ * // sentence.toString() == "안녕?(0,3)"
+ * ```
+ *
+ * @property text 문장 텍스트
+ * @property start 원문 시작 위치
+ * @property end 원문 끝 위치(exclusive)
  */
 data class Sentence(
     val text: String,

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/TokenizerProfile.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/tokenizer/TokenizerProfile.kt
@@ -8,30 +8,35 @@ import io.bluetape4k.tokenizer.korean.utils.KoreanPos.ProperNoun
 import java.io.Serializable
 
 /**
- * 한글 형태소 분석기의 분석 옵션을 설정하는 프로필 클래스입니다.
+ * 파싱 후보 점수 계산에 사용하는 가중치 프로필입니다.
  *
- * 각 가중치 값은 형태소 분석 시 후보 선택에 영향을 미칩니다.
- * 값이 클수록 해당 항목을 선호하며, 음수 값은 해당 항목을 비선호합니다.
+ * ## 동작/계약
+ * - `ParsedChunk.score` 계산식은 이 프로필 값을 선형 결합해 후보 순위를 정한다.
+ * - 값이 클수록 해당 항목을 더 선호하며, 음수 값은 패널티로 동작한다.
+ * - `spaceGuide`는 원문 공백 위치 힌트로 사용되어 가이드 밖 분해에 패널티를 부여한다.
  *
- * @property tokenCount 토큰 수 가중치 (기본값: 0.18f)
- * @property unknown 미등록 단어(Unknown)에 대한 가중치 (기본값: 0.3f)
- * @property wordCount 단어 수 가중치 (기본값: 0.3f)
- * @property freq 단어 빈도수 가중치 (기본값: 0.2f)
- * @property unknownCoverage 미등록 단어 커버리지 가중치 (기본값: 0.5f)
- * @property exactMatch 정확한 매칭에 대한 가중치 (기본값: 0.5f)
- * @property allNoun 전체 명사 처리에 대한 가중치 (기본값: 0.1f)
- * @property unknownPosCount 미등록 품사 수에 대한 가중치 (기본값: 10.0f)
- * @property determinerPosCount 관형사 수에 대한 가중치 (기본값: -0.01f)
- * @property exclamationPosCount 감탄사 수에 대한 가중치 (기본값: 0.01f)
- * @property initialPostPosition 초기 조사 위치 가중치 (기본값: 0.2f)
- * @property haVerb '하다' 동사 가중치 (기본값: 0.3f)
- * @property preferredPattern 선호 패턴 가중치 (기본값: 0.6f)
- * @property preferredPatterns 선호하는 품사 패턴 목록 (기본값: [[Noun, Josa], [ProperNoun, Josa]])
- * @property spaceGuide 공백 위치 가이드 배열 (기본값: 빈 배열)
- * @property spaceGuidePenalty 공백 가이드 미준수 시 패널티 (기본값: 3.0f)
- * @property josaUnmatchedPenalty 조사 불일치 패널티 (기본값: 3.0f)
+ * ```kotlin
+ * val profile = TokenizerProfile.DefaultProfile.copy(unknown = 0.5f)
+ * // profile.unknown == 0.5f
+ * ```
  *
- * @see KoreanTokenizer
+ * @property tokenCount 토큰 수 가중치
+ * @property unknown 미등록 단어 가중치
+ * @property wordCount 단어 수 가중치
+ * @property freq 명사 빈도 가중치
+ * @property unknownCoverage 미등록 토큰 길이 커버리지 가중치
+ * @property exactMatch 단일 토큰 정확 매칭 가중치
+ * @property allNoun 전부 명사인 경우 가중치
+ * @property unknownPosCount Unknown 품사 개수 가중치
+ * @property determinerPosCount 관형사 개수 가중치
+ * @property exclamationPosCount 감탄사 개수 가중치
+ * @property initialPostPosition 접미/조사 시작 패널티 가중치
+ * @property haVerb `하다/해` 결합 선호 가중치
+ * @property preferredPattern 선호 품사 패턴 가중치
+ * @property preferredPatterns 선호 품사 패턴 목록
+ * @property spaceGuide 공백 가이드 인덱스 배열
+ * @property spaceGuidePenalty 공백 가이드 위반 패널티
+ * @property josaUnmatchedPenalty 조사 불일치 패널티
  */
 data class TokenizerProfile(
     val tokenCount: Float = 0.18f,
@@ -53,7 +58,17 @@ data class TokenizerProfile(
     val josaUnmatchedPenalty: Float = 3.0f,
 ): Serializable {
     companion object {
-        /** 기본 분석 프로필 */
+        /**
+         * 기본 형태소 분석 프로필입니다.
+         *
+         * ## 동작/계약
+         * - `TokenizerProfile()` 기본 생성값으로 초기화된다.
+         *
+         * ```kotlin
+         * val profile = TokenizerProfile.DefaultProfile
+         * // profile.spaceGuide.isEmpty() == true
+         * ```
+         */
         @JvmField
         val DefaultProfile = TokenizerProfile()
     }

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/utils/DictionarySupport.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/utils/DictionarySupport.kt
@@ -1,11 +1,46 @@
 package io.bluetape4k.tokenizer.korean.utils
 
-
+/**
+ * 이름 사전의 특정 분류에 [charseq]가 포함되는지 확인합니다.
+ *
+ * ## 동작/계약
+ * - `KoreanDictionaryProvider.nameDictionary[key]`가 없으면 `false`를 반환한다.
+ * - 사전이 있으면 `CharArraySet.contains(CharSequence)` 결과를 그대로 반환한다.
+ *
+ * ```kotlin
+ * val exists = nameDictionaryContains("family_name", "김")
+ * // exists == true 또는 false
+ * ```
+ */
 fun nameDictionaryContains(key: String, charseq: CharSequence): Boolean =
     KoreanDictionaryProvider.nameDictionary[key]?.contains(charseq) ?: false
 
+/**
+ * 이름 사전의 특정 분류에 [str]이 포함되는지 확인합니다.
+ *
+ * ## 동작/계약
+ * - `KoreanDictionaryProvider.nameDictionary[key]`가 없으면 `false`를 반환한다.
+ * - 사전이 있으면 `CharArraySet.contains(String)` 결과를 그대로 반환한다.
+ *
+ * ```kotlin
+ * val exists = nameDictionaryContains("full_name", "문재인")
+ * // exists == true 또는 false
+ * ```
+ */
 fun nameDictionaryContains(key: String, str: String): Boolean =
     KoreanDictionaryProvider.nameDictionary[key]?.contains(str) ?: false
 
+/**
+ * 품사별 사전에 [cs]가 포함되는지 확인합니다.
+ *
+ * ## 동작/계약
+ * - `KoreanDictionaryProvider.koreanDictionary[pos]`가 없으면 `false`를 반환한다.
+ * - 사전이 있으면 `CharArraySet.contains(CharSequence)` 결과를 그대로 반환한다.
+ *
+ * ```kotlin
+ * val exists = koreanContains(KoreanPos.Noun, "사랑")
+ * // exists == true 또는 false
+ * ```
+ */
 fun koreanContains(pos: KoreanPos, cs: CharSequence): Boolean =
     KoreanDictionaryProvider.koreanDictionary[pos]?.contains(cs) ?: false

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/utils/Hangul.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/utils/Hangul.kt
@@ -5,25 +5,71 @@ import io.bluetape4k.tokenizer.korean.utils.Hangul.DOUBLE_CODAS
 import java.io.Serializable
 
 /**
- * 한글을 초성, 중성, 종성으로 분해하고 조합하는 유틸리티 클래스
+ * 한글 음절의 초성/중성/종성 분해와 조합을 제공합니다.
+ *
+ * ## 동작/계약
+ * - `decomposeHangul`은 단일 음절을 `HangulChar`로 분해한다.
+ * - `composeHangul`은 분해된 자모를 유니코드 한글 음절로 조합한다.
+ * - 받침 판정은 유니코드 음절 인덱스 계산으로 수행한다.
+ *
+ * ```kotlin
+ * val hc = Hangul.decomposeHangul('한')
+ * // hc == Hangul.HangulChar('ㅎ', 'ㅏ', 'ㄴ')
+ * ```
  */
 object Hangul: KLogging() {
 
     /**
-     * 한글 문자를 초성, 중성, 종성으로 분해한 정보 클래스
+     * 한글 음절 한 글자의 초성/중성/종성 분해 결과입니다.
+     *
+     * ## 동작/계약
+     * - `coda`가 공백 문자면 받침이 없는 음절이다.
+     *
+     * ```kotlin
+     * val hc = Hangul.HangulChar('ㅎ', 'ㅏ', ' ')
+     * // hc.codaIsEmpty == true
+     * ```
      */
     data class HangulChar(val onset: Char, val vowel: Char, val coda: Char): Serializable {
+        /**
+         * 종성이 비어 있는지 여부입니다.
+         *
+         * ## 동작/계약
+         * - `coda == ' '`일 때 `true`를 반환한다.
+         *
+         * ```kotlin
+         * val empty = Hangul.HangulChar('ㅎ', 'ㅏ', ' ').codaIsEmpty
+         * // empty == true
+         * ```
+         */
         val codaIsEmpty: Boolean get() = coda == ' '
+        /**
+         * 종성이 존재하는지 여부입니다.
+         *
+         * ## 동작/계약
+         * - `coda != ' '`일 때 `true`를 반환한다.
+         *
+         * ```kotlin
+         * val has = Hangul.HangulChar('ㅎ', 'ㅏ', 'ㄴ').hasCoda
+         * // has == true
+         * ```
+         */
         val hasCoda: Boolean get() = coda != ' '
     }
 
     /**
-     * 밭침에 두 개의 자음이 있는 경우를 나타내는 클래스
+     * 겹받침을 구성하는 두 자음을 표현합니다.
+     *
+     * ## 동작/계약
+     * - `DOUBLE_CODAS` 매핑의 값 타입으로 사용된다.
+     *
+     * ```kotlin
+     * val dc = Hangul.DoubleCoda('ㄱ', 'ㅅ')
+     * // dc.first == 'ㄱ'
+     * ```
      *
      * @property first 첫 번째 자음
      * @property second 두 번째 자음
-     *
-     * @see DOUBLE_CODAS
      */
     data class DoubleCoda(val first: Char, val second: Char): Serializable
 
@@ -70,15 +116,16 @@ object Hangul: KLogging() {
     )
 
     /**
-     *  한글을 초성, 중성, 종성으로 분해합니다.
+     * 한글 음절을 초성/중성/종성으로 분해합니다.
      *
-     *  ```
-     *  val (onset, vowel, coda) = Hangul.decomposeHangul('한')  // ('ㅎ', 'ㅏ', 'ㄴ')
-     *  val (onset, vowel, coda) = Hangul.decomposeHangul('하')  // ('ㅎ', 'ㅏ', ' ')
-     *  ```
+     * ## 동작/계약
+     * - 자모 문자 입력은 허용하지 않으며 `assert` 실패 시 `AssertionError`가 발생한다(`-ea` 필요).
+     * - 유니코드 한글 음절 인덱스로 초성/중성/종성을 계산한다.
      *
-     *  @param c Korean Character
-     *  @return (onset:Char, vowel:Char, coda:Char)
+     * ```kotlin
+     * val hc = Hangul.decomposeHangul('하')
+     * // hc == Hangul.HangulChar('ㅎ', 'ㅏ', ' ')
+     * ```
      */
     fun decomposeHangul(c: Char): HangulChar {
         assert(!(ONSET_MAP.containsKey(c) || VOWEL_MAP.containsKey(c) || CODA_MAP.containsKey(c))) {
@@ -93,28 +140,29 @@ object Hangul: KLogging() {
     }
 
     /**
-     * 한글에 종성(받침)이 있는지 검사
+     * 한글 음절에 종성(받침)이 있는지 확인합니다.
      *
-     * ```
-     * Hangul.hasCoda('한')  // true
-     * Hangul.hasCoda('하')  // false
-     * ```
+     * ## 동작/계약
+     * - 유니코드 한글 음절 인덱스의 종성 영역 값으로 판정한다.
      *
-     * @param c 한글 문자
+     * ```kotlin
+     * val has = Hangul.hasCoda('한')
+     * // has == true
+     * ```
      */
     fun hasCoda(c: Char): Boolean = (c.code - HANGUL_BASE) % VOWEL_BASE > 0
 
     /**
-     * 초,중,종성의 char 로 한글을 조홥합니다.
+     * 초성/중성/종성으로 한글 음절을 조합합니다.
      *
-     * ```
-     * Hangul.composeHangul('ㅎ', 'ㅏ', 'ㄴ')  // '한'
-     * Hangul.composeHangul('ㄱ', 'ㅏ')  // '가'
-     * ```
+     * ## 동작/계약
+     * - 초성과 중성이 공백이면 `assert` 실패 시 `AssertionError`가 발생한다(`-ea` 필요).
+     * - 종성은 기본값 공백(`' '`)을 사용하면 받침 없는 음절을 생성한다.
      *
-     * @param onset 초성
-     * @param vowel 중성
-     * @param coda 종성
+     * ```kotlin
+     * val h = Hangul.composeHangul('ㅎ', 'ㅏ', 'ㄴ')
+     * // h == '한'
+     * ```
      */
     fun composeHangul(onset: Char, vowel: Char, coda: Char = ' '): Char {
         assert(onset != ' ' && vowel != ' ') { "Input characters are not valid" }
@@ -126,15 +174,15 @@ object Hangul: KLogging() {
     }
 
     /**
-     * [HangulChar] 의 초성, 중성, 종성으로 한글을 조합합니다.
+     * [HangulChar]를 한글 음절로 조합합니다.
      *
-     * ```
-     * val hc = HangulChar('ㅎ', 'ㅏ', 'ㄴ')
-     * Hangul.composeHangul(hc)  // '한'
-     * ```
+     * ## 동작/계약
+     * - `composeHangul(hc.onset, hc.vowel, hc.coda)` 호출을 그대로 위임한다.
      *
-     * @param hc [HangulChar] 인스턴스
-     * @return 조합된 한글 문자
+     * ```kotlin
+     * val c = Hangul.composeHangul(Hangul.HangulChar('ㄱ', 'ㅏ', ' '))
+     * // c == '가'
+     * ```
      */
     fun composeHangul(hc: HangulChar): Char =
         composeHangul(hc.onset, hc.vowel, hc.coda)

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/utils/KoreanConjugation.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/utils/KoreanConjugation.kt
@@ -9,18 +9,16 @@ import io.bluetape4k.tokenizer.utils.CharArraySet
 import io.bluetape4k.tokenizer.utils.DictionaryProvider
 
 /**
- * 한글 동사 및 형용사를 모든 가능한 활용 형태로 확장합니다.
+ * 동사/형용사 기본형에서 활용형 표면어 집합을 생성합니다.
  *
- * 동사
- * ```
- * 갈아타	 --> 갈아타, 갈아타게, 갈아타겠, 갈아타고, 갈아타구, 갈아타기, 갈아타긴, 갈아타길, 갈아타냐, 갈아타네, 갈아타노, 갈아타느, 갈아타는, 갈아타니, 갈아타다, 갈아타더, 갈아타던, 갈아타도, 갈아타든, 갈아타러, 갈아타려, 갈아타며, 갈아타면, 갈아타서, 갈아타세, 갈아타셔, 갈아타셨, 갈아타습, 갈아타시, 갈아타신, 갈아타실, 갈아타십, 갈아타써, 갈아타야, 갈아타자, 갈아타잖, 갈아타재, 갈아타져, 갈아타죠, 갈아타준, 갈아타지, 갈아타진, 갈아타질, 갈아탄, 갈아탈, 갈아탐, 갈아탑, 갈아탔
- * 난리치	 --> 난리쳐, 난리쳤, 난리치, 난리치냐, 난리치노, 난리치느, 난리치는, 난리치니, 난리치어, 난리치었, 난리친, 난리칠, 난리침, 난리칩, 난리칩니
- * ```
+ * ## 동작/계약
+ * - 기본형 어미 `다`를 제외한 어간과 마지막 음절 규칙으로 활용 후보를 확장한다.
+ * - `isAdjective` 값에 따라 일부 불규칙/예외 처리와 edge case 제거가 달라진다.
+ * - 결과는 중복 제거된 `Set<String>`으로 반환된다.
  *
- * 형용사
- * ```
- * 거북하	 --> 거북하, 거북하게, 거북하겠, 거북하고, 거북하구, 거북하기, 거북하긴, 거북하길, 거북하냐, 거북하네, 거북하노, 거북하느, 거북하는, 거북하니, 거북하다, 거북하더, 거북하던, 거북하도, 거북하든, 거북하러, 거북하려, 거북하며, 거북하면, 거북하세, 거북하셔, 거북하셨, 거북하습, 거북하시, 거북하신, 거북하실, 거북하십, 거북하여, 거북하였, 거북하자, 거북하잖, 거북하재, 거북하져, 거북하죠, 거북하지, 거북하진, 거북하질, 거북한, 거북할, 거북함, 거북합, 거북해, 거북해도, 거북해서, 거북해써, 거북해야, 거북해준, 거북했, 거북히
- * 느리 -->	느려, 느렸, 느리, 느리냐, 느리노, 느리느, 느리는, 느리니, 느리어, 느리었, 느린, 느릴, 느림, 느립, 느립니
+ * ```kotlin
+ * val forms = KoreanConjugation.conjugatePredicated(setOf("가다"), isAdjective = false)
+ * // forms.contains("가") == true
  * ```
  */
 object KoreanConjugation: KLogging() {
@@ -59,7 +57,16 @@ object KoreanConjugation: KLogging() {
     }
 
     /**
+     * 활용형 집합을 `CharArraySet`으로 변환해 반환합니다.
      *
+     * ## 동작/계약
+     * - 내부적으로 `conjugatePredicated(words, isAdjective)` 결과를 생성한다.
+     * - 반환 집합은 `DictionaryProvider.newCharArraySet()` 인스턴스에 추가되어 반환된다.
+     *
+     * ```kotlin
+     * val set = KoreanConjugation.conjugatePredicatesToCharArraySet(setOf("가다"))
+     * // set.contains("가")
+     * ```
      */
     fun conjugatePredicatesToCharArraySet(words: Set<String>, isAdjective: Boolean = false): CharArraySet {
         val newSet = DictionaryProvider.newCharArraySet()
@@ -315,6 +322,19 @@ object KoreanConjugation: KLogging() {
 
     private val VOWEL_뀌다 = hashSetOf('ㅞ', 'ㅚ', 'ㅙ')
 
+    /**
+     * 기본형 집합을 활용형 표면어 집합으로 확장합니다.
+     *
+     * ## 동작/계약
+     * - 단어별 마지막 음절(초/중/종성) 규칙에 따라 활용 후보를 만든 뒤 어간 앞에 붙여 반환한다.
+     * - `르` 불규칙은 앞 음절 받침 보정 후 별도 후보를 추가한다.
+     * - 동사 경로(`isAdjective=false`)에서는 edge case 집합(`아니`, `입` 등)을 최종 결과에서 제외한다.
+     *
+     * ```kotlin
+     * val forms = KoreanConjugation.conjugatePredicated(setOf("느리다"), isAdjective = true)
+     * // forms.contains("느려") == true
+     * ```
+     */
     fun conjugatePredicated(words: Set<String>, isAdjective: Boolean): Set<String> {
 
         val expanded: Set<String> = words.flatMap { word ->

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/utils/KoreanDictionaryProvider.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/utils/KoreanDictionaryProvider.kt
@@ -24,30 +24,113 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 
 /**
- * 한글 사전을 제공합니다.
+ * 토크나이저가 사용하는 한국어 사전과 파생 사전을 로드/조회합니다.
+ *
+ * ## 동작/계약
+ * - 사전 데이터는 리소스 경로 `koreantext/` 하위에서 읽는다.
+ * - 대부분 프로퍼티는 `lazy` 또는 `publicLazy`로 최초 접근 시점에 로딩된다.
+ * - `addWordsToDictionary`로 런타임 단어를 추가하면 해당 품사 사전에 즉시 반영된다.
+ *
+ * ```kotlin
+ * val nouns = KoreanDictionaryProvider.koreanDictionary[KoreanPos.Noun]
+ * // nouns != null
+ * ```
  */
 object KoreanDictionaryProvider: KLogging() {
 
+    /**
+     * 한국어 사전 리소스의 루트 경로입니다.
+     *
+     * ## 동작/계약
+     * - `readWords*` 계열 함수는 전달된 파일명 앞에 이 경로를 붙여 조회한다.
+     *
+     * ```kotlin
+     * val base = KoreanDictionaryProvider.BASE_PATH
+     * // base == "koreantext"
+     * ```
+     */
     const val BASE_PATH = "koreantext"
 
+    /**
+     * 리소스 파일들을 읽어 `MutableSet<String>`으로 반환합니다.
+     *
+     * ## 동작/계약
+     * - 각 파일명은 `"$BASE_PATH/$filename"`로 변환해 `DictionaryProvider.readWordsAsSet`에 전달한다.
+     * - 동일 단어 중복은 `MutableSet` 특성으로 제거된다.
+     *
+     * ```kotlin
+     * val words = KoreanDictionaryProvider.readWordsAsSet("verb/verb.txt")
+     * // words.isNotEmpty() == true
+     * ```
+     */
     suspend fun readWordsAsSet(vararg filenames: String): MutableSet<String> {
         return DictionaryProvider.readWordsAsSet(paths = filenames.map { "$BASE_PATH/$it" }.toTypedArray())
     }
 
+    /**
+     * 리소스 파일들을 읽어 `CharArraySet`으로 반환합니다.
+     *
+     * ## 동작/계약
+     * - 각 파일명은 `"$BASE_PATH/$filename"`로 변환해 `DictionaryProvider.readWords`에 전달한다.
+     * - 반환 타입은 토크나이저 사전 조회에 직접 사용되는 `CharArraySet`이다.
+     *
+     * ```kotlin
+     * val words = KoreanDictionaryProvider.readWords("noun/nouns.txt")
+     * // words.isNotEmpty() == true
+     * ```
+     */
     suspend fun readWords(vararg filenames: String): CharArraySet {
         return DictionaryProvider.readWords(paths = filenames.map { "$BASE_PATH/$it" }.toTypedArray())
     }
 
+    /**
+     * 엔티티 빈도 사전입니다.
+     *
+     * ## 동작/계약
+     * - 최초 접근 시 `freq/entity-freq.txt.gz`를 로드한다.
+     * - `ParsedChunk.getFreqScore()` 계산에 사용된다.
+     * - `KoreanDictionaryProviderTest`의 `load frequency` 케이스에서 비어 있지 않음을 검증한다.
+     *
+     * ```kotlin
+     * val freq = KoreanDictionaryProvider.koreanEntityFreq
+     * // freq.isNotEmpty() == true
+     * ```
+     */
     val koreanEntityFreq: Map<CharSequence, Float> by lazy {
         runBlocking(Dispatchers.IO) {
             DictionaryProvider.readWordFreqs("$BASE_PATH/freq/entity-freq.txt.gz")
         }
     }
 
+    /**
+     * 지정 품사 사전에 단어 컬렉션을 추가합니다.
+     *
+     * ## 동작/계약
+     * - 대상 품사 사전이 존재할 때만 단어를 추가한다.
+     * - 사전이 없으면 아무 동작도 하지 않는다.
+     * - `KoreanDictionaryProviderTest`에서 추가 후 포함 여부가 `true`로 바뀐다.
+     *
+     * ```kotlin
+     * KoreanDictionaryProvider.addWordsToDictionary(KoreanPos.Noun, listOf("없는명사다"))
+     * // KoreanDictionaryProvider.koreanDictionary[KoreanPos.Noun]!!.contains("없는명사다") == true
+     * ```
+     */
     fun addWordsToDictionary(pos: KoreanPos, words: Collection<String>) {
         koreanDictionary[pos]?.addAll(words)
     }
 
+    /**
+     * 지정 품사 사전에 가변 인자 단어를 추가합니다.
+     *
+     * ## 동작/계약
+     * - 인자가 비어 있지 않을 때만 추가를 시도한다.
+     * - 대상 품사 사전이 없으면 추가하지 않는다.
+     *
+     * ```kotlin
+     * KoreanDictionaryProvider.addWordsToDictionary(KoreanPos.Noun, "주말특가", "주말행사")
+     * // KoreanDictionaryProvider.koreanDictionary[KoreanPos.Noun]!!.contains("주말특가") == true
+     * ```
+     */
     fun addWordsToDictionary(pos: KoreanPos, vararg words: String) {
         if (words.isNotEmpty()) {
             koreanDictionary[pos]?.addAll(words)
@@ -55,7 +138,17 @@ object KoreanDictionaryProvider: KLogging() {
     }
 
     /**
-     * 품사별 한글 사전입니다.
+     * 품사별 기본 한국어 사전입니다.
+     *
+     * ## 동작/계약
+     * - `Noun`은 다수 noun 파일을 합쳐 로드한다.
+     * - `Verb`/`Adjective`는 기본형 파일을 읽은 뒤 활용형 사전으로 확장한다.
+     * - `KoreanDictionaryProviderTest`의 `사전 로드하기` 케이스에서 `Noun` 사전 비어 있지 않음을 검증한다.
+     *
+     * ```kotlin
+     * val nouns = KoreanDictionaryProvider.koreanDictionary[KoreanPos.Noun]
+     * // nouns!!.isNotEmpty() == true
+     * ```
      */
     val koreanDictionary: MutableMap<KoreanPos, CharArraySet> by lazy {
         runBlocking(Dispatchers.IO) {
@@ -118,7 +211,16 @@ object KoreanDictionaryProvider: KLogging() {
     }
 
     /**
-     * 스팸 관련 명사 사전입니다. (스팸, 욕설, 비속어, 슬랭)
+     * 스팸/욕설/비속어 명사 사전입니다.
+     *
+     * ## 동작/계약
+     * - `noun/spam.txt`, `noun/profane.txt`, `noun/slangs.txt`를 합쳐 로드한다.
+     * - `KoreanPhraseExtractor`의 `filterSpam=true` 필터에서 사용된다.
+     *
+     * ```kotlin
+     * val spam = KoreanDictionaryProvider.spamNouns
+     * // spam.isNotEmpty() == true
+     * ```
      */
     val spamNouns by lazy {
         runBlocking(Dispatchers.IO) {
@@ -131,7 +233,17 @@ object KoreanDictionaryProvider: KLogging() {
     }
 
     /**
-     * 금칙어를 심각도에 따라 분류한 Dictionary 입니다.
+     * 심각도별 금칙어 사전입니다.
+     *
+     * ## 동작/계약
+     * - `LOW`는 low/middle/high 파일 전체를 포함한다.
+     * - `MIDDLE`은 middle/high를 포함하고, `HIGH`는 high만 포함한다.
+     * - `KoreanBlockwordProcessor`에서 severity별 마스킹 판정에 사용된다.
+     *
+     * ```kotlin
+     * val high = KoreanDictionaryProvider.blockWords[io.bluetape4k.tokenizer.model.Severity.HIGH]
+     * // high != null
+     * ```
      */
     val blockWords by publicLazy {
         runBlocking(Dispatchers.IO) {
@@ -148,7 +260,16 @@ object KoreanDictionaryProvider: KLogging() {
     }
 
     /**
-     * 명사 사전입니다.
+     * 고유명사 중심 명사 사전입니다.
+     *
+     * ## 동작/계약
+     * - 인명/지명/브랜드 등 고유명사 성격 파일들을 합쳐 로드한다.
+     * - phrase 추출 시 사전 포함 여부 판정에 활용된다.
+     *
+     * ```kotlin
+     * val proper = KoreanDictionaryProvider.properNouns
+     * // proper.isNotEmpty() == true
+     * ```
      */
     val properNouns by publicLazy {
         runBlocking(Dispatchers.IO) {
@@ -174,7 +295,16 @@ object KoreanDictionaryProvider: KLogging() {
     }
 
     /**
-     * 사람 이름, 그룹 이름 등 이름 사전입니다.
+     * 성/이름/전체 이름 분류 사전입니다.
+     *
+     * ## 동작/계약
+     * - 키는 `"family_name"`, `"given_name"`, `"full_name"` 세 종류로 고정된다.
+     * - `KoreanSubstantive.isName`이 이름 판별 시 이 맵을 조회한다.
+     *
+     * ```kotlin
+     * val hasKim = KoreanDictionaryProvider.nameDictionary["family_name"]!!.contains("김")
+     * // hasKim == true 또는 false
+     * ```
      */
     val nameDictionary: Map<String, CharArraySet> by publicLazy {
         runBlocking(Dispatchers.IO) {
@@ -190,7 +320,16 @@ object KoreanDictionaryProvider: KLogging() {
     }
 
     /**
-     * 길이에 따른 맞춤법 사전
+     * 오타 교정 사전을 원문 길이별로 그룹화한 맵입니다.
+     *
+     * ## 동작/계약
+     * - `typos/typos.txt`를 읽어 오타 문자열 길이(`Int`) 기준으로 재구성한다.
+     * - `KoreanNormalizer.correctTypo`에서 길이별 후보 조회에 사용된다.
+     *
+     * ```kotlin
+     * val grouped = KoreanDictionaryProvider.typoDictionaryByLength
+     * // grouped.keys.isNotEmpty() == true
+     * ```
      */
     val typoDictionaryByLength: Map<Int, Map<String, String>> by publicLazy {
         runBlocking(Dispatchers.IO) {
@@ -208,7 +347,16 @@ object KoreanDictionaryProvider: KLogging() {
     }
 
     /**
-     * 예상되는 원형 정보
+     * 활용형 표면형을 기본형으로 역매핑한 사전입니다.
+     *
+     * ## 동작/계약
+     * - 동사/형용사 기본형 파일을 읽고 활용형을 생성해 `표면형 -> 기본형다` 맵으로 구성한다.
+     * - `KoreanStemmer.stem`에서 용언 토큰의 `stem` 계산에 사용된다.
+     *
+     * ```kotlin
+     * val stem = KoreanDictionaryProvider.predicateStems[KoreanPos.Verb]?.get("해")
+     * // stem == "하다"
+     * ```
      */
     val predicateStems: Map<KoreanPos, Map<String, String>> by publicLazy {
         fun getConjugationMap(words: Set<String>, isAdjective: Boolean): Map<String, String> {

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/utils/KoreanPos.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/utils/KoreanPos.kt
@@ -3,78 +3,76 @@ package io.bluetape4k.tokenizer.korean.utils
 import java.io.Serializable
 
 /**
- * Korean Part-of-Speech
- * 한글 품사
+ * 토크나이저 전 과정에서 사용하는 한국어 품사 열거형입니다.
  *
- * ```
- * N Noun: 명사 (Nouns, Pronouns, Company Names, Proper Noun, Person Names, Numerals, Standalone, Dependent)
- * V Verb: 동사 (하, 먹, 자, 차)
- * J Adjective: 형용사 (예쁘다, 크다, 작다)
- * A Adverb: 부사 (잘, 매우, 빨리, 반드시, 과연)
- * D Determiner: 관형사 (새, 헌, 참, 첫, 이, 그, 저)
- * E Exclamation: 감탄사 (헐, ㅋㅋㅋ, 어머나, 얼씨구)
+ * ## 동작/계약
+ * - 어절 파싱(`KoreanTokenizer`), 청킹(`KoreanChunker`), phrase 추출에서 공통 품사로 사용된다.
+ * - `Noun`/`Verb` 등 어절 내부 품사와 `Korean`/`URL` 등 청크 품사를 함께 포함한다.
+ * - `Unknown`은 사전 미등록/규칙 미매칭 토큰의 fallback 품사다.
  *
- * C Conjunction: 접속사
- *
- * j SubstantiveJosa: 조사 (의, 에, 에서)
- * l AdverbialJosa: 부사격 조사 (~인, ~의, ~일)
- * e Eomi: 어말어미 (다, 요, 여, 하댘ㅋㅋ)
- * r PreEomi: 선어말어미 (었)
- *
- * p NounPrefix: 접두사 ('초'대박)
- * v VerbPrefix: 동사 접두어 ('쳐'먹어)
- * s Suffix: 접미사 (~적)
- *
- * f Foreign: 한글이 아닌 문자들
- *
- * 지시사는 Derterminant로 대체하기로 함
- * Derterminant is used for demonstratives.
- *
- * Korean: Korean chunk (candidate for parsing)
- * Foreign: Mixture of non-Korean strings
- * Number: 숫자
- * Emotion: Korean Single Character Emotions (ㅋㅋㅋㅋ, ㅎㅎㅎㅎ, ㅠㅜㅠㅜ)
- * Alpha: Alphabets 알파벳
- * Punctuation: 문장부호
- * Hashtag: Twitter Hashtag 해쉬태그 #Korean
- * ScreenName: Twitter username (@nlpenguin)
- *
- * Unkown: Could not parse the string.
+ * ```kotlin
+ * val pos = KoreanPos.Noun
+ * // pos.name == "Noun"
  * ```
  */
 enum class KoreanPos: Serializable {
-    // Word leveld Pos
+    /** 일반 명사/의존 명사/대명사 등 체언 계열을 나타낸다. */
     Noun,
+    /** 동작이나 상태를 서술하는 동사를 나타낸다. */
     Verb,
+    /** 성질·상태를 나타내는 형용사를 나타낸다. */
     Adjective,
+    /** 용언이나 문장 전체를 수식하는 부사를 나타낸다. */
     Adverb,
+    /** 체언을 수식하는 관형사를 나타낸다. */
     Determiner,
+    /** 감탄·호출을 표현하는 감탄사를 나타낸다. */
     Exclamation,
+    /** 체언 뒤에 붙어 문법 관계를 표시하는 조사를 나타낸다. */
     Josa,
+    /** 용언 어간 뒤에 붙는 종결/연결 어미를 나타낸다. */
     Eomi,
+    /** 본 어미 앞에 오는 선어말어미를 나타낸다. */
     PreEomi,
+    /** 단어/절/문장을 연결하는 접속사를 나타낸다. */
     Conjunction,
+    /** 접두사성/관형사성 수식 성분을 나타낸다. */
     Modifier,
+    /** 용언 앞에 붙어 의미를 보강하는 동사 접두어를 나타낸다. */
     VerbPrefix,
+    /** 어근 뒤에 붙어 파생어를 만드는 접미사를 나타낸다. */
     Suffix,
+    /** 사전/규칙으로 판정하지 못한 미확정 품사를 나타낸다. */
     Unknown,
 
-    // Chunk level POS
+    /** 한글 음절 중심 청크를 나타낸다. */
     Korean,
+    /** 한글이 아닌 외국어 문자 중심 청크를 나타낸다. */
     Foreign,
+    /** 숫자(정수/실수/기호 포함 수치) 청크를 나타낸다. */
     Number,
+    /** 한글 자모/음절 조각 등 파티클성 청크를 나타낸다. */
     KoreanParticle,
+    /** 영문 알파벳 중심 청크를 나타낸다. */
     Alpha,
+    /** 문장부호/기호 청크를 나타낸다. */
     Punctuation,
+    /** `#태그` 형태의 해시태그 청크를 나타낸다. */
     Hashtag,
+    /** `@user` 형태의 스크린네임 청크를 나타낸다. */
     ScreenName,
+    /** 이메일 주소 형식 청크를 나타낸다. */
     Email,
+    /** URL 형식 청크를 나타낸다. */
     URL,
+    /** `$tag` 형태의 캐시태그 청크를 나타낸다. */
     CashTag,
 
-    // Functional POS
+    /** 공백 문자 청크를 나타낸다. */
     Space,
+    /** 위 분류에 속하지 않는 기타 청크를 나타낸다. */
     Others,
 
+    /** 고유명사(인명/지명/기관명 등)로 판정된 명사를 나타낸다. */
     ProperNoun
 }

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/utils/KoreanPosTrie.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/utils/KoreanPosTrie.kt
@@ -3,11 +3,21 @@ package io.bluetape4k.tokenizer.korean.utils
 import java.io.Serializable
 
 /**
- * 한글 품사에 대한 Trie 구조
+ * 품사 시퀀스 규칙을 표현하는 트라이 노드입니다.
+ *
+ * ## 동작/계약
+ * - `curPos`는 현재 노드에서 소비할 품사다.
+ * - `nextTrie`는 다음 품사 후보 노드 목록이며 null이면 더 이상 전이하지 않는다.
+ * - `ending`이 null이 아니면 해당 지점에서 규칙 종결 품사가 확정된다.
+ *
+ * ```kotlin
+ * val node = KoreanPosTrie(KoreanPos.Noun, ending = KoreanPos.Noun)
+ * // node.curPos == KoreanPos.Noun
+ * ```
  *
  * @property curPos 현재 품사
- * @property nextTrie 다음 트라이
- * @property ending 종료 품사
+ * @property nextTrie 다음 트라이 후보
+ * @property ending 종결 품사
  */
 data class KoreanPosTrie(
     val curPos: KoreanPos?,

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/utils/KoreanPosx.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/utils/KoreanPosx.kt
@@ -28,10 +28,31 @@ import io.bluetape4k.tokenizer.korean.utils.KoreanPos.Verb
 import io.bluetape4k.tokenizer.korean.utils.KoreanPos.VerbPrefix
 
 /**
- * 한글 품사에 대한 유용한 함수를 제공합니다.
+ * 품사 규칙 문자열을 트라이 구조로 변환하는 유틸리티입니다.
+ *
+ * ## 동작/계약
+ * - 축약 기호(`N`, `V`, `j` 등)를 `KoreanPos`로 매핑해 파서 규칙을 구성한다.
+ * - `buildTrie`는 `+`, `*`, `1`, `0` 규칙 문법만 지원한다.
+ * - `SelfNode`는 반복 규칙 전이에서 현재 노드 재사용 마커로 동작한다.
+ *
+ * ```kotlin
+ * val trie = KoreanPosx.buildTrie("N1", KoreanPos.Noun)
+ * // trie.isNotEmpty() == true
+ * ```
  */
 object KoreanPosx: KLogging() {
 
+    /**
+     * 청크 레벨 기타 품사 집합입니다.
+     *
+     * ## 동작/계약
+     * - `Korean`, `Foreign`, `Number` 등 어절 파싱 이전 품사를 포함한다.
+     *
+     * ```kotlin
+     * val hasUrl = KoreanPosx.OtherPoses.contains(KoreanPos.URL)
+     * // hasUrl == true
+     * ```
+     */
     val OtherPoses = hashSetOf(
         Korean,
         Foreign,
@@ -46,6 +67,17 @@ object KoreanPosx: KLogging() {
         CashTag
     )
 
+    /**
+     * 규칙 문자열 문자와 품사의 매핑 테이블입니다.
+     *
+     * ## 동작/계약
+     * - `buildTrie`가 첫 글자를 해석할 때 이 매핑을 사용한다.
+     *
+     * ```kotlin
+     * val noun = KoreanPosx.shortCut['N']
+     * // noun == KoreanPos.Noun
+     * ```
+     */
     val shortCut = hashMapOf(
         'N' to Noun,
         'V' to Verb,
@@ -73,8 +105,31 @@ object KoreanPosx: KLogging() {
     private const val ONE = '1'
     private const val ZERO = '0'
 
+    /**
+     * 반복 규칙에서 현재 노드를 그대로 재사용할 때 쓰는 센티널 노드입니다.
+     *
+     * ## 동작/계약
+     * - `curPos`, `nextTrie`, `ending`이 모두 null인 노드다.
+     *
+     * ```kotlin
+     * val self = KoreanPosx.SelfNode
+     * // self.curPos == null
+     * ```
+     */
     val SelfNode = KoreanPosTrie(curPos = null, nextTrie = null, ending = null)
 
+    /**
+     * 규칙 문자열을 품사 트라이 노드 목록으로 변환합니다.
+     *
+     * ## 동작/계약
+     * - 길이가 2 미만인 문자열은 해석하지 않고 빈 리스트를 반환한다.
+     * - 지원 규칙은 `+`, `*`, `1`, `0`이며 그 외 문자는 `error`를 발생시킨다.
+     *
+     * ```kotlin
+     * val trie = KoreanPosx.buildTrie("N1", KoreanPos.Noun)
+     * // trie.first().curPos == KoreanPos.Noun
+     * ```
+     */
     fun buildTrie(s: String, endingPos: KoreanPos): List<KoreanPosTrie> {
 
         fun isFinal(rest: String): Boolean {
@@ -122,6 +177,18 @@ object KoreanPosx: KLogging() {
         }
     }
 
+    /**
+     * 규칙 맵 전체를 하나의 트라이 목록으로 병합합니다.
+     *
+     * ## 동작/계약
+     * - 각 `(규칙, 종결품사)`에 대해 `buildTrie` 결과를 앞쪽에 누적한다.
+     * - 반환 리스트는 `destination` 인스턴스를 그대로 사용한다.
+     *
+     * ```kotlin
+     * val trie = KoreanPosx.getTrie(mapOf("N1" to KoreanPos.Noun))
+     * // trie.isNotEmpty() == true
+     * ```
+     */
     internal fun getTrie(
         sequences: Map<String, KoreanPos>,
         destination: MutableList<KoreanPosTrie> = mutableListOf(),
@@ -132,6 +199,17 @@ object KoreanPosx: KLogging() {
         return destination
     }
 
+    /**
+     * 용언 품사 집합입니다.
+     *
+     * ## 동작/계약
+     * - `Verb`, `Adjective` 두 품사만 포함한다.
+     *
+     * ```kotlin
+     * val predicate = KoreanPosx.Predicates.contains(KoreanPos.Verb)
+     * // predicate == true
+     * ```
+     */
     @JvmField
     val Predicates = setOf(Verb, Adjective)
 }

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/utils/KoreanSubstantive.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/utils/KoreanSubstantive.kt
@@ -7,7 +7,17 @@ import io.bluetape4k.tokenizer.korean.utils.Hangul.hasCoda
 import io.bluetape4k.tokenizer.korean.utils.KoreanPos.Noun
 
 /**
- * 한글 명사와 조사를 위한 Helper Class
+ * 명사/조사 결합과 이름·수사 판별에 사용하는 명사 유틸입니다.
+ *
+ * ## 동작/계약
+ * - 조사 결합 가능성은 받침 유무와 조사 첫 글자 규칙으로 판정한다.
+ * - 이름 판별은 `KoreanDictionaryProvider.nameDictionary` 분류 사전을 사용한다.
+ * - 미등록 1글자 명사 연쇄는 `collapseNouns`에서 하나의 unknown 명사로 합친다.
+ *
+ * ```kotlin
+ * val attachable = KoreanSubstantive.isJosaAttachable('플', '은')
+ * // attachable == true
+ * ```
  */
 object KoreanSubstantive: KLogging() {
 
@@ -15,19 +25,16 @@ object KoreanSubstantive: KLogging() {
     private val JOSA_HEAD_FOR_NO_CODA = setOf('는', '가', '를', '와', '야', '여', '라')
 
     /**
-     * [prevChar] 다음에 [headChar]이 오면 조사를 붙일 수 있는지 확인합니다.
+     * 앞 글자와 조사 첫 글자 조합이 문법적으로 가능한지 확인합니다.
      *
+     * ## 동작/계약
+     * - 앞 글자에 받침이 있으면 `는/가/를/와/야/여/라`를 제외한 조사만 허용한다.
+     * - 앞 글자에 받침이 없으면 `은/이/을/과/아`를 제외한 조사만 허용한다.
+     *
+     * ```kotlin
+     * val ok = KoreanSubstantive.isJosaAttachable('플', '은')
+     * // ok == true
      * ```
-     * isJosaAttachable('플', '은') == true // 애플은
-     * isJosaAttachable('플', '는') == false // 애플는
-     *
-     * isJosaAttachable('프', '은') == false // 애프은
-     * isJosaAttachable('프', '는') == true // 애프는
-     * ```
-     *
-     * @param prevChar 이전 글자
-     * @param headChar 다음 글자
-     * @return 조사를 붙일 수 있는지 여부
      */
     fun isJosaAttachable(prevChar: Char, headChar: Char): Boolean {
         return (hasCoda(prevChar) && headChar !in JOSA_HEAD_FOR_NO_CODA) ||
@@ -37,15 +44,17 @@ object KoreanSubstantive: KLogging() {
     //  fun isName(str: String): Boolean = isName(str as CharSequence)
 
     /**
-     * [chunk] 가 한글 이름인지 확인합니다.
+     * 주어진 문자열이 이름 사전 규칙에 맞는지 확인합니다.
      *
+     * ## 동작/계약
+     * - `full_name` 또는 `given_name` 사전에 있으면 즉시 `true`다.
+     * - 길이 3/4인 경우 성+이름 분해(`family_name` + `given_name`) 조합으로 판정한다.
+     * - 그 외 길이는 `false`를 반환한다.
+     *
+     * ```kotlin
+     * val isName = KoreanSubstantive.isName("문재인")
+     * // isName == true
      * ```
-     * isName("문재인") == true
-     * isName("강철중") == true
-     * isName("사다리") == false
-     * ```
-     * @param chunk 검사할 글자
-     * @return 이름인지 여부
      */
     fun isName(chunk: CharSequence): Boolean {
         if (nameDictionaryContains("full_name", chunk) || nameDictionaryContains("given_name", chunk)) {
@@ -67,16 +76,16 @@ object KoreanSubstantive: KLogging() {
     private val NUMBER_LAST_CHARS = "일이삼사오육칠팔구천백십해경조억만원배분초".map { it.code }.toSet()
 
     /**
-     * 한글 숫자 텍스트인지 확인합니다.
+     * 문자열이 한글 수사 문자 집합으로만 구성되는지 확인합니다.
      *
-     * ```
-     * isKoreanNumber("천이백만이십오") == true
-     * isKoreanNumber("이십") == true
-     * isKoreanNumber("일천").shouldBeTrue()
-     * ```
+     * ## 동작/계약
+     * - 마지막 문자는 `원/배/분/초`를 포함한 확장 집합으로 판정한다.
+     * - 마지막 이전 문자는 기본 수사 문자 집합으로 판정한다.
      *
-     * @param chunk 검사할 글자
-     * @return 한글 숫자인지 여부
+     * ```kotlin
+     * val number = KoreanSubstantive.isKoreanNumber("천이백만이십오")
+     * // number == true
+     * ```
      */
     fun isKoreanNumber(chunk: CharSequence): Boolean =
         (0 until chunk.length).fold(true) { output, i ->
@@ -88,27 +97,17 @@ object KoreanSubstantive: KLogging() {
         }
 
     /**
-     * 명사의 'ㅇ' 생략 변형인지 확인합니다.
+     * 이름의 종성/초성 변형(예: 우혀니)을 원형 이름으로 복원 가능한지 판정합니다.
      *
-     * ```
-     * 우혀니 -> 우현, 우현이       // true
-     * 빠순이 -> 빠순, 빠순이       // false
-     * ```
+     * ## 동작/계약
+     * - 길이 3..5가 아니면 `false`를 반환한다.
+     * - 마지막 글자가 `ㅇ` 초성 생략 패턴(`*히/니`류) 조건을 만족할 때만 복원 시도를 한다.
+     * - 복원 문자열과 마지막 글자 제거 문자열 둘 중 하나가 `isName`이면 `true`다.
      *
+     * ```kotlin
+     * val variation = KoreanSubstantive.isKoreanNameVariation("호혀니")
+     * // variation == true
      * ```
-     * isKoreanNameVariation("호혀니").shouldBeTrue()
-     * isKoreanNameVariation("혜지니").shouldBeTrue()
-     * isKoreanNameVariation("빠수니").shouldBeTrue()
-     * ```
-     *
-     * ```
-     * isKoreanNameVariation("가라찌").shouldBeFalse()
-     * isKoreanNameVariation("귀요미").shouldBeFalse()
-     * isKoreanNameVariation("사람이").shouldBeFalse()
-     * ```
-     *
-     * @param chunk 검사할 글자
-     * @return `ㅇ` 이 빠진 변형이면 true
      */
     fun isKoreanNameVariation(chunk: CharSequence): Boolean {
         // val nounDict = KoreanDictionaryProvider.koreanDictionary[Noun]!!
@@ -139,14 +138,19 @@ object KoreanSubstantive: KLogging() {
     }
 
     /**
-     * [posNodes]의 모든 단어를 하나의 알 수 없는 명사로 합칩니다.
+     * 연속된 1글자 명사 토큰을 하나의 unknown 명사 토큰으로 병합합니다.
      *
-     * ```
-     * val tokens = collapseNouns('마', '코', '토')  // KoreanToken("마코토", Noun, 0, 3, unknown = true)
-     * ```
+     * ## 동작/계약
+     * - `Noun`이면서 길이 1인 토큰이 연속되면 첫 토큰에 텍스트를 이어 붙여 병합한다.
+     * - 병합된 토큰은 `unknown = true`로 설정한다.
+     * - 비명사 또는 길이 1이 아닌 토큰을 만나면 병합 상태를 종료한다.
      *
-     * @param posNodes 한글 토큰 컬렉션
-     * @return 알 수 없는 명사로 합쳐진 토큰 컬렉션
+     * ```kotlin
+     * val merged = KoreanSubstantive.collapseNouns(
+     *     listOf(KoreanToken("마", Noun, 0, 1), KoreanToken("코", Noun, 1, 1), KoreanToken("토", Noun, 2, 1))
+     * )
+     * // merged.first().text == "마코토"
+     * ```
      */
     fun collapseNouns(posNodes: Iterable<KoreanToken>): List<KoreanToken> {
         val nodes = mutableListOf<KoreanToken>()

--- a/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/utils/TextSupport.kt
+++ b/tokenizer/korean/src/main/kotlin/io/bluetape4k/tokenizer/korean/utils/TextSupport.kt
@@ -1,21 +1,57 @@
 package io.bluetape4k.tokenizer.korean.utils
 
 /**
- * 글자가 공백인지 확인합니다.
+ * 문자가 유니코드 Space 문자 범주인지 확인합니다.
+ *
+ * ## 동작/계약
+ * - `Character.isSpaceChar(this)` 호출 결과를 그대로 반환한다.
+ *
+ * ```kotlin
+ * val space = ' '.isSpaceChar
+ * // space == true
+ * ```
  */
 val Char.isSpaceChar: Boolean get() = Character.isSpaceChar(this)
 
 /**
- * 마지막 요소만 제거한 문자열을 반환합니다.
+ * 마지막 문자를 제거한 새 문자열을 반환합니다.
+ *
+ * ## 동작/계약
+ * - 빈 문자열이면 빈 문자열을 반환한다.
+ * - 비어 있지 않으면 `dropLast(1)` 결과를 반환한다.
+ *
+ * ```kotlin
+ * val head = "한국어".init()
+ * // head == "한국"
+ * ```
  */
 fun String.init(): String = if (isEmpty()) "" else dropLast(1)
 
 /**
- * 마지막 요소만 제거한 문자열을 반환합니다.
+ * 마지막 문자를 제거한 `CharSequence`를 반환합니다.
+ *
+ * ## 동작/계약
+ * - 빈 시퀀스면 빈 문자열을 반환한다.
+ * - 비어 있지 않으면 `dropLast(1)` 결과를 반환한다.
+ *
+ * ```kotlin
+ * val cs: CharSequence = "사람"
+ * val head = cs.init()
+ * // head == "사"
+ * ```
  */
 fun CharSequence.init(): CharSequence = if (isEmpty()) "" else dropLast(1)
 
 /**
- * 마지막 요소만 제거한 문자열을 반환합니다.
+ * 리스트의 마지막 원소를 제외한 새 리스트를 반환합니다.
+ *
+ * ## 동작/계약
+ * - 빈 리스트면 `emptyList()`를 반환한다.
+ * - 비어 있지 않으면 `dropLast(1)` 결과를 반환한다.
+ *
+ * ```kotlin
+ * val head = listOf(1, 2, 3).init()
+ * // head == [1, 2]
+ * ```
  */
 fun <T> List<T>.init(): List<T> = if (isEmpty()) emptyList() else dropLast(1)

--- a/utils/leader/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElection.kt
+++ b/utils/leader/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElection.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader.coroutines
 
 import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.requireNotBlank
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
@@ -31,10 +32,14 @@ import java.util.concurrent.ConcurrentHashMap
  *
  * @param maxLeaders 허용하는 최대 동시 리더 수. 기본값 2
  */
-class LocalSuspendLeaderGroupElection(override val maxLeaders: Int = 2) : SuspendLeaderGroupElection {
+class LocalSuspendLeaderGroupElection private constructor(override val maxLeaders: Int = 2):
+    SuspendLeaderGroupElection {
 
-    init {
-        require(maxLeaders > 0) { "maxLeaders 는 1 이상이어야 합니다. maxLeaders=$maxLeaders" }
+    companion object: KLogging() {
+        operator fun invoke(maxLeaders: Int = 2): LocalSuspendLeaderGroupElection {
+            require(maxLeaders > 0) { "maxLeaders 는 1 이상이어야 합니다. maxLeaders=$maxLeaders" }
+            return LocalSuspendLeaderGroupElection(maxLeaders)
+        }
     }
 
     private val semaphores = ConcurrentHashMap<String, Semaphore>()

--- a/utils/leader/src/main/kotlin/io/bluetape4k/leader/local/LocalLeaderGroupElection.kt
+++ b/utils/leader/src/main/kotlin/io/bluetape4k/leader/local/LocalLeaderGroupElection.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.local
 
 import io.bluetape4k.leader.LeaderGroupElection
 import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.requireNotBlank
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Semaphore
@@ -28,10 +29,14 @@ import java.util.concurrent.Semaphore
  *
  * @param maxLeaders 허용하는 최대 동시 리더 수. 기본값 2
  */
-class LocalLeaderGroupElection(override val maxLeaders: Int = 2) : LeaderGroupElection {
+class LocalLeaderGroupElection private constructor(override val maxLeaders: Int): LeaderGroupElection {
 
-    init {
-        require(maxLeaders > 0) { "maxLeaders 는 1 이상이어야 합니다. maxLeaders=$maxLeaders" }
+    companion object: KLogging() {
+
+        operator fun invoke(maxLeaders: Int = 2): LeaderGroupElection {
+            require(maxLeaders > 0) { "maxLeaders 는 1 이상이어야 합니다. maxLeaders=$maxLeaders" }
+            return LocalLeaderGroupElection(maxLeaders)
+        }
     }
 
     private val semaphores = ConcurrentHashMap<String, Semaphore>()

--- a/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopes.kt
+++ b/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopes.kt
@@ -8,49 +8,126 @@ import java.util.concurrent.StructuredTaskScope
 import java.util.concurrent.ThreadFactory
 
 /**
- * 구조화된 동시성의 Subtask 추상화입니다.
+ * 구조화된 동시성에서 개별 fork 작업 결과를 표현하는 추상화입니다.
+ *
+ * ## 동작/계약
+ * - 구현체는 JDK별 `StructuredTaskScope.Subtask`를 감싸 동일 API를 제공합니다.
+ * - [get]은 성공 상태에서 결과를 반환하고 실패 상태에서는 예외를 전파할 수 있습니다.
+ *
+ * ```kotlin
+ * val value = StructuredTaskScopes.all(factory = Thread.ofVirtual().factory()) { scope ->
+ *     val task = scope.fork { 1 + 1 }
+ *     scope.join().throwIfFailed()
+ *     task.get()
+ * }
+ * // value == 2
+ * ```
  */
 interface StructuredSubtask<T> {
+    /** subtask 성공 결과를 반환합니다. */
     fun get(): T
+    /** subtask 현재 상태를 반환합니다. */
     fun state(): StructuredTaskScope.Subtask.State
+    /** subtask 실패 원인을 반환하고, 실패하지 않았으면 `null`을 반환합니다. */
     fun exceptionOrNull(): Throwable?
 }
 
 /**
- * ShutdownOnFailure 성격의 Scope 추상화입니다.
+ * 모든 작업 완료를 기다리고, 실패가 있으면 예외를 전파하는 scope 추상화입니다.
+ *
+ * ## 동작/계약
+ * - [fork]로 추가한 작업들을 [join] 이후 [throwIfFailed]로 일괄 실패 검사할 수 있습니다.
+ * - [close]는 리소스 정리 및 미완료 작업 취소를 수행할 수 있으므로 `use` 블록 사용을 권장합니다.
+ *
+ * ```kotlin
+ * val sum = StructuredTaskScopes.all(factory = Thread.ofVirtual().factory()) { scope ->
+ *     val a = scope.fork { 1 }
+ *     val b = scope.fork { 2 }
+ *     scope.join().throwIfFailed()
+ *     a.get() + b.get()
+ * }
+ * // sum == 3
+ * ```
  */
 interface StructuredTaskScopeAll: AutoCloseable {
+    /** 새 subtask를 scope에 등록합니다. */
     fun <T> fork(task: () -> T): StructuredSubtask<T>
+    /** 등록된 subtask 완료를 대기합니다. */
     fun join(): StructuredTaskScopeAll
+    /** 실패한 subtask가 있으면 [handler]를 호출한 뒤 예외를 전파합니다. */
     fun throwIfFailed(handler: (e: Throwable) -> Unit = {}): StructuredTaskScopeAll
+    /** scope 자원을 정리합니다. */
     override fun close()
 }
 
 /**
- * ShutdownOnSuccess 성격의 Scope 추상화입니다.
+ * 첫 성공 결과를 선택하는 scope 추상화입니다.
+ *
+ * ## 동작/계약
+ * - 여러 작업을 [fork]한 뒤 [join]과 [result]를 통해 첫 성공 결과를 얻습니다.
+ * - 모든 작업이 실패하면 [result]에서 [mapper]가 만든 RuntimeException이 발생합니다.
+ *
+ * ```kotlin
+ * val winner = StructuredTaskScopes.any<String>(factory = Thread.ofVirtual().factory()) { scope ->
+ *     scope.fork { "slow" }
+ *     scope.fork { "fast" }
+ *     scope.join().result { IllegalStateException(it) }
+ * }
+ * // winner.isNotBlank() == true
+ * ```
  */
 interface StructuredTaskScopeAny<T>: AutoCloseable {
+    /** 새 subtask를 scope에 등록합니다. */
     fun <V: T> fork(task: () -> V): StructuredSubtask<V>
+    /** 등록된 subtask 완료를 대기합니다. */
     fun join(): StructuredTaskScopeAny<T>
+    /** 첫 성공 결과를 반환하거나 실패 시 [mapper]로 예외를 변환해 던집니다. */
     fun result(mapper: (Throwable) -> RuntimeException): T
+    /** scope 자원을 정리합니다. */
     override fun close()
 }
 
 /**
- * JDK별 StructuredTaskScope 구현 제공자입니다.
+ * JDK별 StructuredTaskScope 구현체를 제공하는 SPI 인터페이스입니다.
+ *
+ * ## 동작/계약
+ * - 구현체는 [isSupported]로 현재 런타임 지원 여부를 판단해야 합니다.
+ * - [priority]가 높은 구현체가 우선 선택됩니다.
+ *
+ * ```kotlin
+ * val provider = StructuredTaskScopes.provider()
+ * // provider.providerName.isNotBlank() == true
+ * ```
  */
 interface StructuredTaskScopeProvider {
+    /** provider 식별 이름입니다. */
     val providerName: String
+    /** provider 선택 우선순위입니다. */
     val priority: Int
 
+    /** 현재 JVM에서 provider 사용 가능 여부를 반환합니다. */
     fun isSupported(): Boolean
 
+    /**
+     * 실패 전파형(scope-all) 블록을 실행합니다.
+     *
+     * @param name scope 이름(지원 구현에서만 적용)
+     * @param factory subtask 실행용 스레드 팩토리
+     * @param block 실행 블록
+     */
     fun <T> withAll(
         name: String? = null,
         factory: ThreadFactory = Thread.ofVirtual().factory(),
         block: (scope: StructuredTaskScopeAll) -> T,
     ): T
 
+    /**
+     * 성공 우선형(scope-any) 블록을 실행합니다.
+     *
+     * @param name scope 이름(지원 구현에서만 적용)
+     * @param factory subtask 실행용 스레드 팩토리
+     * @param block 실행 블록
+     */
     fun <T> withAny(
         name: String? = null,
         factory: ThreadFactory = Thread.ofVirtual().factory(),
@@ -59,7 +136,22 @@ interface StructuredTaskScopeProvider {
 }
 
 /**
- * 현재 런타임에 맞는 StructuredTaskScope 구현을 선택합니다.
+ * 런타임에 맞는 [StructuredTaskScopeProvider]를 선택해 구조화된 동시성 진입 API를 제공합니다.
+ *
+ * ## 동작/계약
+ * - ServiceLoader provider를 [StructuredTaskScopeProvider.priority] 내림차순으로 정렬해 선택합니다.
+ * - 선택 가능한 provider가 없으면 즉시 예외를 발생시킵니다.
+ * - `all`/`any`는 선택된 provider 구현에 위임됩니다.
+ *
+ * ```kotlin
+ * val result = StructuredTaskScopes.all(factory = Thread.ofVirtual().factory()) { scope ->
+ *     val a = scope.fork { 1 }
+ *     val b = scope.fork { 2 }
+ *     scope.join().throwIfFailed()
+ *     a.get() + b.get()
+ * }
+ * // result == 3
+ * ```
  */
 object StructuredTaskScopes: KLogging() {
 
@@ -87,19 +179,82 @@ object StructuredTaskScopes: KLogging() {
         discovered.sortedByDescending { it.priority }
     }
 
+    /**
+     * 현재 런타임에서 사용할 provider를 반환합니다.
+     *
+     * ## 동작/계약
+     * - 지원되는 provider가 하나도 없으면 `IllegalStateException`을 발생시킵니다.
+     *
+     * ```kotlin
+     * val provider = StructuredTaskScopes.provider()
+     * // provider.providerName.isNotBlank() == true
+     * ```
+     *
+     * @throws IllegalStateException 사용 가능한 provider가 없을 때 발생합니다.
+     */
     fun provider(): StructuredTaskScopeProvider {
         return providers.firstOrNull()
             ?: error("No StructuredTaskScopeProvider available for current runtime.")
     }
 
+    /**
+     * 선택된 provider 이름을 반환합니다.
+     *
+     * ## 동작/계약
+     * - [provider]의 [StructuredTaskScopeProvider.providerName]을 그대로 반환합니다.
+     *
+     * ```kotlin
+     * val name = StructuredTaskScopes.providerName()
+     * // name.isNotBlank() == true
+     * ```
+     */
     fun providerName(): String = provider().providerName
 
+    /**
+     * 실패 전파형(all) scope 블록을 실행합니다.
+     *
+     * ## 동작/계약
+     * - block 내부에서 [StructuredTaskScopeAll] API로 subtask를 등록/대기/실패 검사합니다.
+     * - 실제 scope 구현은 선택된 provider에 의해 결정됩니다.
+     *
+     * ```kotlin
+     * val value = StructuredTaskScopes.all(factory = Thread.ofVirtual().factory()) { scope ->
+     *     val task = scope.fork { 42 }
+     *     scope.join().throwIfFailed()
+     *     task.get()
+     * }
+     * // value == 42
+     * ```
+     *
+     * @param name scope 이름
+     * @param factory subtask 실행용 스레드 팩토리
+     * @param block scope 실행 블록
+     */
     fun <T> all(
         name: String? = null,
         factory: ThreadFactory,
         block: (scope: StructuredTaskScopeAll) -> T,
     ): T = provider().withAll(name, factory, block)
 
+    /**
+     * 성공 우선형(any) scope 블록을 실행합니다.
+     *
+     * ## 동작/계약
+     * - block 내부에서 [StructuredTaskScopeAny] API로 첫 성공 결과를 선택합니다.
+     * - 모든 작업 실패 시 [StructuredTaskScopeAny.result]에서 mapper 예외가 발생합니다.
+     *
+     * ```kotlin
+     * val value = StructuredTaskScopes.any<String>(factory = Thread.ofVirtual().factory()) { scope ->
+     *     scope.fork { "fast" }
+     *     scope.join().result { IllegalStateException(it) }
+     * }
+     * // value == "fast"
+     * ```
+     *
+     * @param name scope 이름
+     * @param factory subtask 실행용 스레드 팩토리
+     * @param block scope 실행 블록
+     */
     fun <T> any(
         name: String? = null,
         factory: ThreadFactory,

--- a/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/VirtualThreadRuntime.kt
+++ b/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/VirtualThreadRuntime.kt
@@ -4,33 +4,93 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.ThreadFactory
 
 /**
- * JDK별 Virtual Thread 구현체를 추상화한 인터페이스입니다.
+ * 런타임별 가상 스레드 기능을 공통 API로 노출하는 추상화 인터페이스입니다.
+ *
+ * ## 동작/계약
+ * - 구현체는 현재 JDK에서 지원되는 가상 스레드 생성 전략을 캡슐화합니다.
+ * - [priority]가 높은 구현체가 우선 선택되며, 선택 로직은 [VirtualThreads.runtime]이 담당합니다.
+ * - `threadFactory`/`executorService`는 호출 시 새 인스턴스를 반환할 수 있습니다.
+ *
+ * ```kotlin
+ * val runtime = VirtualThreads.runtime()
+ * val result = runtime.executorService().use { it.submit<Int> { 42 }.get() }
+ * // result == 42
+ * ```
  */
 interface VirtualThreadRuntime {
 
     /**
      * 구현체 식별 이름입니다.
+     *
+     * ## 동작/계약
+     * - 로깅/진단용 식별자이며 사람이 읽기 쉬운 문자열을 반환합니다.
+     * - 런타임 상태가 같으면 동일한 값을 반환해야 합니다.
+     *
+     * ```kotlin
+     * val name = VirtualThreads.runtime().runtimeName
+     * // name.isNotBlank() == true
+     * ```
      */
     val runtimeName: String
 
     /**
-     * 구현체 우선순위입니다. 값이 클수록 우선합니다.
+     * 구현체 선택 우선순위입니다.
+     *
+     * ## 동작/계약
+     * - 값이 클수록 우선 선택됩니다.
+     * - 동순위 구현체가 여러 개이면 `ServiceLoader` 탐색 순서의 영향을 받을 수 있습니다.
+     *
+     * ```kotlin
+     * val p = VirtualThreads.runtime().priority
+     * // p is Int
+     * ```
      */
     val priority: Int
 
     /**
-     * 현재 런타임에서 사용 가능한 구현체인지 여부를 반환합니다.
+     * 현재 JVM 환경에서 이 구현체 사용 가능 여부를 반환합니다.
+     *
+     * ## 동작/계약
+     * - 지원되지 않는 JDK에서는 `false`를 반환해야 합니다.
+     * - 예외를 던지기보다 불가 여부를 boolean으로 표현하는 것이 권장됩니다.
+     *
+     * ```kotlin
+     * val supported = VirtualThreads.runtime().isSupported()
+     * // supported == true
+     * ```
      */
     fun isSupported(): Boolean
 
     /**
-     * Virtual Thread 전용 [ThreadFactory]를 생성합니다.
+     * 가상 스레드 생성용 [ThreadFactory]를 반환합니다.
+     *
+     * ## 동작/계약
+     * - [prefix]는 생성되는 스레드 이름 접두사로 사용됩니다.
+     * - 반환된 팩토리는 호출 시점 런타임 구현에 종속됩니다.
+     *
+     * ```kotlin
+     * val factory = VirtualThreads.runtime().threadFactory("vt-demo-")
+     * val thread = factory.newThread {}
+     * // thread.name.startsWith("vt-demo-") == true
+     * ```
+     *
+     * @param prefix 생성 스레드 이름 접두사
      */
     fun threadFactory(prefix: String = "vt-"): ThreadFactory
 
     /**
-     * Task-per-virtual-thread [ExecutorService]를 생성합니다.
+     * task-per-thread 실행 모델의 [ExecutorService]를 반환합니다.
+     *
+     * ## 동작/계약
+     * - 제출된 작업은 구현체 정책에 따라 가상 스레드(또는 fallback 스레드)에서 실행됩니다.
+     * - 반환된 ExecutorService의 종료 책임은 호출자에게 있습니다.
+     *
+     * ```kotlin
+     * val result = VirtualThreads.runtime().executorService().use { executor ->
+     *     executor.submit<Int> { 7 * 6 }.get()
+     * }
+     * // result == 42
+     * ```
      */
     fun executorService(): ExecutorService
 }
-

--- a/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/VirtualThreads.kt
+++ b/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/VirtualThreads.kt
@@ -9,7 +9,19 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
 
 /**
- * 서비스 로더로 등록된 JDK별 구현체 중 현재 런타임에 맞는 구현체를 선택합니다.
+ * ServiceLoader로 발견한 런타임 구현 중 현재 JVM에서 사용 가능한 가상 스레드 구현을 선택합니다.
+ *
+ * ## 동작/계약
+ * - 등록 구현체를 [VirtualThreadRuntime.priority] 내림차순으로 정렬해 첫 구현을 사용합니다.
+ * - 사용 가능한 구현체가 없으면 내부 `platform-fallback` 구현으로 자동 대체합니다.
+ * - provider 탐색 중 오류가 발생해도 전체 선택 로직은 계속 진행합니다.
+ *
+ * ```kotlin
+ * val name = VirtualThreads.runtimeName()
+ * val answer = VirtualThreads.executorService().use { it.submit<Int> { 42 }.get() }
+ * // name.isNotBlank() == true
+ * // answer == 42
+ * ```
  */
 object VirtualThreads: KLogging() {
 
@@ -38,15 +50,62 @@ object VirtualThreads: KLogging() {
     }
 
     /**
-     * 현재 런타임에 맞는 구현체를 반환합니다.
-     * 구현체가 없으면 플랫폼 스레드 fallback을 사용합니다.
+     * 현재 런타임에 맞는 [VirtualThreadRuntime] 구현을 반환합니다.
+     *
+     * ## 동작/계약
+     * - 탐색된 provider가 없으면 `platform-fallback` 구현을 반환합니다.
+     * - 반환 구현은 객체 내부에서 재사용되며 호출마다 provider 재탐색을 수행하지 않습니다.
+     *
+     * ```kotlin
+     * val runtime = VirtualThreads.runtime()
+     * // runtime.runtimeName.isNotBlank() == true
+     * ```
      */
     fun runtime(): VirtualThreadRuntime = providers.firstOrNull() ?: PlatformThreadRuntime
 
+    /**
+     * 선택된 런타임 구현의 이름을 반환합니다.
+     *
+     * ## 동작/계약
+     * - [runtime]의 [VirtualThreadRuntime.runtimeName]을 그대로 반환합니다.
+     * - provider가 없을 때는 `"platform-fallback"`이 반환됩니다.
+     *
+     * ```kotlin
+     * val name = VirtualThreads.runtimeName()
+     * // name.isNotBlank() == true
+     * ```
+     */
     fun runtimeName(): String = runtime().runtimeName
 
+    /**
+     * 선택된 런타임 구현의 [ThreadFactory]를 반환합니다.
+     *
+     * ## 동작/계약
+     * - [prefix]는 구현체에 전달되어 스레드 이름 규칙에 반영됩니다.
+     * - fallback 경로에서는 플랫폼 스레드 팩토리를 반환합니다.
+     *
+     * ```kotlin
+     * val factory = VirtualThreads.threadFactory("vt-")
+     * val thread = factory.newThread {}
+     * // thread.name.startsWith("vt-") == true
+     * ```
+     *
+     * @param prefix 생성할 스레드 이름 접두사
+     */
     fun threadFactory(prefix: String = "vt-"): ThreadFactory = runtime().threadFactory(prefix)
 
+    /**
+     * 선택된 런타임 구현의 [ExecutorService]를 반환합니다.
+     *
+     * ## 동작/계약
+     * - 호출자 책임으로 `close`/`shutdown`을 수행해야 합니다.
+     * - fallback 경로에서는 `newCachedThreadPool` 기반 executor를 반환합니다.
+     *
+     * ```kotlin
+     * val result = VirtualThreads.executorService().use { it.submit<Int> { 21 * 2 }.get() }
+     * // result == 42
+     * ```
+     */
     fun executorService(): ExecutorService = runtime().executorService()
 
     private object PlatformThreadRuntime: VirtualThreadRuntime {

--- a/virtualthread/jdk21/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProvider.kt
+++ b/virtualthread/jdk21/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProvider.kt
@@ -12,21 +12,68 @@ import java.util.concurrent.StructuredTaskScope
 import java.util.concurrent.ThreadFactory
 
 /**
- * Java 21 StructuredTaskScope 구현체입니다.
+ * JDK 21 `StructuredTaskScope` API를 사용하는 provider 구현체입니다.
+ *
+ * ## 동작/계약
+ * - `Runtime.version().feature() >= 21`일 때 지원 대상으로 판단합니다.
+ * - `withAll`은 `ShutdownOnFailure`, `withAny`는 `ShutdownOnSuccess`에 위임합니다.
+ * - scope는 `use`로 감싸 실행되어 블록 종료 시 자동 close 됩니다.
+ *
+ * ```kotlin
+ * val provider = Jdk21StructuredTaskScopeProvider()
+ * val result = provider.withAll { scope ->
+ *     val a = scope.fork { 1 }
+ *     val b = scope.fork { 2 }
+ *     scope.join().throwIfFailed()
+ *     a.get() + b.get()
+ * }
+ * // result == 3
+ * ```
  */
 class Jdk21StructuredTaskScopeProvider: StructuredTaskScopeProvider {
 
     companion object: KLoggingChannel() {
+        /** provider 식별 이름입니다. */
         const val PROVIDER_NAME = "jdk21-structured-task-scope"
+        /** 지원 기준 JDK feature 버전입니다. */
         const val JAVA_VERSION = 21
+        /** provider 우선순위 값입니다. */
         const val PRIORITY = JAVA_VERSION
     }
 
     override val providerName: String = PROVIDER_NAME
     override val priority: Int = PRIORITY
 
+    /**
+     * 현재 JVM이 JDK 21 이상인지 확인합니다.
+     *
+     * ## 동작/계약
+     * - feature 버전 비교만 수행하며 추가 reflective 체크는 하지 않습니다.
+     *
+     * ```kotlin
+     * val supported = Jdk21StructuredTaskScopeProvider().isSupported()
+     * // supported == (Runtime.version().feature() >= 21)
+     * ```
+     */
     override fun isSupported(): Boolean = Runtime.version().feature() >= JAVA_VERSION
 
+    /**
+     * 실패 전파형(scope-all) 블록을 실행합니다.
+     *
+     * ## 동작/계약
+     * - 내부적으로 `StructuredTaskScope.ShutdownOnFailure`를 생성합니다.
+     * - [scope.join()][StructuredTaskScopeAll.join] 후 [scope.throwIfFailed()][StructuredTaskScopeAll.throwIfFailed] 호출 시 첫 실패 예외를 전파합니다.
+     *
+     * ```kotlin
+     * val result = Jdk21StructuredTaskScopeProvider().withAll { scope ->
+     *     val a = scope.fork { 1 }
+     *     val b = scope.fork { 2 }
+     *     scope.join().throwIfFailed()
+     *     a.get() + b.get()
+     * }
+     * // result == 3
+     * ```
+     */
     override fun <T> withAll(
         name: String?,
         factory: ThreadFactory,
@@ -39,6 +86,22 @@ class Jdk21StructuredTaskScopeProvider: StructuredTaskScopeProvider {
         }
     }
 
+    /**
+     * 성공 우선형(scope-any) 블록을 실행합니다.
+     *
+     * ## 동작/계약
+     * - 내부적으로 `StructuredTaskScope.ShutdownOnSuccess`를 생성합니다.
+     * - 가장 먼저 성공한 subtask 결과를 [StructuredTaskScopeAny.result]로 반환합니다.
+     *
+     * ```kotlin
+     * val result = Jdk21StructuredTaskScopeProvider().withAny<String> { scope ->
+     *     scope.fork { "slow" }
+     *     scope.fork { "fast" }
+     *     scope.join().result { IllegalStateException(it) }
+     * }
+     * // result == "fast"
+     * ```
+     */
     override fun <T> withAny(
         name: String?,
         factory: ThreadFactory,

--- a/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
+++ b/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
@@ -13,21 +13,68 @@ import java.util.concurrent.ThreadFactory
 import java.util.function.Function
 
 /**
- * Java 25 StructuredTaskScope 구현체입니다.
+ * JDK 25 `StructuredTaskScope.open` API를 사용하는 provider 구현체입니다.
+ *
+ * ## 동작/계약
+ * - `Runtime.version().feature() >= 25`일 때 지원 대상으로 판단합니다.
+ * - `withAll`은 `Joiner.awaitAll`, `withAny`는 `Joiner.anySuccessfulResultOrThrow`를 사용합니다.
+ * - [configure]에서 전달된 ThreadFactory를 반드시 설정하며 실패 시 `IllegalStateException`이 발생합니다.
+ *
+ * ```kotlin
+ * val provider = Jdk25StructuredTaskScopeProvider()
+ * val result = provider.withAll { scope ->
+ *     val a = scope.fork { 10 }
+ *     val b = scope.fork { 20 }
+ *     scope.join().throwIfFailed()
+ *     a.get() + b.get()
+ * }
+ * // result == 30
+ * ```
  */
 class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
 
     companion object: KLoggingChannel() {
+        /** provider 식별 이름입니다. */
         const val PROVIDER_NAME = "jdk25-structured-task-scope"
+        /** 지원 기준 JDK feature 버전입니다. */
         const val JAVA_VERSION = 25
+        /** provider 우선순위 값입니다. */
         const val PRIORITY = JAVA_VERSION
     }
 
     override val providerName: String = PROVIDER_NAME
     override val priority: Int = PRIORITY
 
+    /**
+     * 현재 JVM이 JDK 25 이상인지 확인합니다.
+     *
+     * ## 동작/계약
+     * - feature 버전 비교만 수행하며 추가 reflective 체크는 하지 않습니다.
+     *
+     * ```kotlin
+     * val supported = Jdk25StructuredTaskScopeProvider().isSupported()
+     * // supported == (Runtime.version().feature() >= 25)
+     * ```
+     */
     override fun isSupported(): Boolean = Runtime.version().feature() >= JAVA_VERSION
 
+    /**
+     * 실패 전파형(scope-all) 블록을 실행합니다.
+     *
+     * ## 동작/계약
+     * - `StructuredTaskScope.open<Any?, Void>(Joiner.awaitAll(), ...)`로 scope를 생성합니다.
+     * - [StructuredTaskScopeAll.throwIfFailed]는 내부에서 수집한 첫 실패 예외를 전파합니다.
+     *
+     * ```kotlin
+     * val result = Jdk25StructuredTaskScopeProvider().withAll { scope ->
+     *     val a = scope.fork { 10 }
+     *     val b = scope.fork { 20 }
+     *     scope.join().throwIfFailed()
+     *     a.get() + b.get()
+     * }
+     * // result == 30
+     * ```
+     */
     override fun <T> withAll(
         name: String?,
         factory: ThreadFactory,
@@ -42,6 +89,22 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
         return scope.use { block(Jdk25AllScope(it)) }
     }
 
+    /**
+     * 성공 우선형(scope-any) 블록을 실행합니다.
+     *
+     * ## 동작/계약
+     * - `StructuredTaskScope.open<T, T>(Joiner.anySuccessfulResultOrThrow(), ...)`를 사용합니다.
+     * - [StructuredTaskScopeAny.result]에서 join 실패를 [mapper] 예외로 변환합니다.
+     *
+     * ```kotlin
+     * val result = Jdk25StructuredTaskScopeProvider().withAny<String> { scope ->
+     *     scope.fork { Thread.sleep(80); "slow" }
+     *     scope.fork { Thread.sleep(10); "fast" }
+     *     scope.join().result { IllegalStateException(it) }
+     * }
+     * // result == "fast"
+     * ```
+     */
     override fun <T> withAny(
         name: String?,
         factory: ThreadFactory,


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: docs: Enhance javers module KDoc standardization

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### KDoc Improvements
- Added comprehensive KDoc to all public functions and classes in javers module
- Standardized documentation format with:
  - Brief description of functionality
  - "동작/계약" (Behavior/Contract) section explaining how each function works
  - Code examples in markdown
  - Parameter and property documentation

### New Test Class
- Added `JaversExtensionsTest` with comprehensive test cases for:
  - Type mapping extensions (entity and value object)
  - Instance ID creation
  - Collection comparison
  - Snapshot retrieval and shadow conversion
  - Query-based snapshot and shadow finding

### Documentation Coverage
- **Extensions**: CdoExtensions, JaversExtensions, QueryParamsExtensions, etc.
- **Base Classes**: EntityEnvelop, EntityEventType
- **Codecs**: JaversCodec, StringJaversCodec, BinaryJaversCodec, MapJaversCodec, and compressable variants
- **Repositories**: CdoSnapshotRepository and implementations (Caffeine, Cache2k, JCache)
- **JQL Builders**: QueryBuilderExtensions, JqlQueryExtensions
- **Dispatchers**: JaversDispatcher, CompositeDispatcher, DebugDispatcher, Slf4jDispatcher
- **Metamodel**: CdoSnapshotSupport, GlobalIdExtensions
- **Commits**: CommitMetadataExtensions, SnowflakeCommitIdGenerator
- **Diff**: ChangeExtensions, DiffExtensions

### Benefits
- Improved IDE code intelligence and hover documentation
- Better developer experience with clear usage examples
- Consistent documentation style across the module
- Enhanced maintainability through explicit behavior contracts

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #47, head `6f58aac7cf772605a38609e0f1973cdcf621e915`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `claude/nice-grothendieck`
- Labels: 없음
- State: `MERGED`, merge commit `1be104b6bdd9a8dd16cb86f78ee172fcbe2f17b4`
- CI: - Enhanced maintainability through explicit behavior contracts

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #47 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `1be104b6bdd9a8dd16cb86f78ee172fcbe2f17b4`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
