### PR TITLE
refactor: Enhance money module with improved KDoc and tests

### DIFF
--- a/utils/money/README.md
+++ b/utils/money/README.md
@@ -15,10 +15,14 @@ dependencies {
 
 ## 주요 기능
 
-- **통화 단위 (CurrencyUnit)**: KRW, USD, EUR, CNY, JPY 등 주요 통화 지원
-- **금액 (Money)**: 통화 금액 생성 및 연산
+- **통화 단위 (CurrencyUnit)**: KRW, USD, EUR, CNY, JPY 등 주요 통화 지원 및 캐시
+- **금액 (Money)**: BigDecimal 기반 통화 금액 생성 및 연산
 - **고성능 금액 (FastMoney)**: Long 기반의 고성능 금액 연산
+- **산술 연산자**: `+`, `-`, `*`, `/`, 단항 `-` 연산자 오버로딩
+- **금액 값 추출**: `intValue`, `longValue`, `doubleValue`, `bigDecimalValue` 등 프로퍼티 확장
+- **반올림**: `round()`, `defaultRound()` 지원
 - **환율 변환**: ECB, IMF 환율 데이터를 이용한 통화 변환
+- **합산**: `Collection<MonetaryAmount>.sum()` 확장 함수
 
 ## 사용 예시
 
@@ -27,7 +31,7 @@ dependencies {
 ```kotlin
 import io.bluetape4k.money.*
 
-// 통화 코드로 생성
+// 통화 코드로 생성 (내부 캐시 사용)
 val krw = currencyUnitOf("KRW")
 val usd = currencyUnitOf("USD")
 val eur = currencyUnitOf("EUR")
@@ -36,16 +40,16 @@ val eur = currencyUnitOf("EUR")
 val usCurrency = currencyUnitOf(Locale.US)        // USD
 val koreaCurrency = currencyUnitOf(Locale.KOREA)  // KRW
 
-// 사전 정의된 통화 단위
+// 사전 정의된 통화 단위 상수
 val koreanWon = KRW      // 한국 원화
 val usDollar = USD       // 미국 달러
 val euro = EUR           // 유로
 val chineseYuan = CNY    // 중국 위안
 val japaneseYen = JPY    // 일본 엔
 
-// 시스템 기본 통화
-val defaultCurrency = DefaultCurrencyUnit
-val defaultCode = DefaultCurrencyCode
+// 통화 코드 유효성 검증
+"USD".isAvailableCurrency()  // true
+"AAA".isAvailableCurrency()  // false
 ```
 
 ### 금액 생성 (Money)
@@ -65,9 +69,9 @@ val won2 = 1024L.toMoney(KRW)       // 1,024 KRW
 val dollar2 = 1.05.toMoney("USD")   // 1.05 USD
 
 // 편의 함수
-val krw = 10000.inKRW()             // 10,000 KRW
-val usd = 100.50.inUSD()            // 100.50 USD
-val eur = 50.inEUR()                // 50 EUR
+val krwMoney = 10000.inKRW()        // 10,000 KRW
+val usdMoney = 100.50.inUSD()       // 100.50 USD
+val eurMoney = 50.inEUR()           // 50 EUR
 ```
 
 ### 고성능 금액 (FastMoney)
@@ -96,28 +100,22 @@ val fastUsd2 = 100.50.inFastUSD()
 val fastEur2 = 50.inFastEUR()
 ```
 
-### 환율 변환
+### MonetaryAmount 생성
+
+`MonetaryAmount`는 `Money`, `FastMoney`의 상위 인터페이스입니다.
 
 ```kotlin
 import io.bluetape4k.money.*
 
-// USD를 EUR로 변환
-val usd = 100.0.toMoney(USD)
-val eur = usd.convertTo(EUR)
-
-// USD를 KRW로 변환
-val krw = usd.convertTo(KRW)
-
-// 역변환 검증
-eur.convertTo(USD).doubleValue shouldBeNear usd.doubleValue
-krw.convertTo(USD).doubleValue shouldBeNear usd.doubleValue
-
-// CurrencyConversion 직접 사용
-val conversion = CurrencyConvertor.getConversion(USD)
-val converted = conversion.conversion(KRW).apply(usd)
+val amount = monetaryAmountOf(100, "KRW")
+val amount2 = monetaryAmountOf(1.05, USD)
+val amount3 = 500.toMonetaryAmount(KRW)
+val amount4 = 99.99.toMonetaryAmount("USD")
 ```
 
 ### 금액 연산
+
+Kotlin 연산자 오버로딩으로 자연스러운 산술 연산을 지원합니다.
 
 ```kotlin
 import io.bluetape4k.money.*
@@ -127,31 +125,102 @@ val price2 = 500.toMoney(KRW)
 
 // 덧셈
 val total = price1 + price2  // 1,500 KRW
+val added = price1 + 200     // 1,200 KRW
 
 // 뺄셈
 val diff = price1 - price2   // 500 KRW
+val subtracted = price1 - 100 // 900 KRW
 
-// 곱셈
+// 곱셈 (교환법칙 지원)
 val doubled = price1 * 2     // 2,000 KRW
+val doubled2 = 2 * price1    // 2,000 KRW
 
 // 나눗셈
 val half = price1 / 2        // 500 KRW
 
-// 비교
-price1 > price2  // true
-price1 == 1000.toMoney(KRW)  // true
+// 부호 반전
+val negated = -price1        // -1,000 KRW
 ```
 
-## 주요 기능 상세
+### 금액 값 추출
 
-| 파일                             | 설명                                 |
-|--------------------------------|------------------------------------|
-| `CurrencySupport.kt`           | 통화 단위 생성 (KRW, USD, EUR, CNY, JPY) |
-| `MoneySupport.kt`              | Money 인스턴스 생성 확장 함수                |
-| `FastMoneySupport.kt`          | FastMoney 인스턴스 생성 확장 함수            |
-| `MoneyAmountSupport.kt`        | 금액 연산 확장 함수                        |
-| `CurrencyConverter.kt`         | 환율 변환기 (ECB, IMF 데이터 사용)           |
-| `CurrencyConversionSupport.kt` | 통화 변환 확장 함수                        |
+```kotlin
+import io.bluetape4k.money.*
+
+val m = moneyOf(12.5, USD)
+
+// 프로퍼티 확장
+m.intValue          // 12
+m.longValue         // 12L
+m.floatValue        // 12.5f
+m.doubleValue       // 12.5
+m.bigDecimalValue   // BigDecimal(12.5)
+m.bigIntValue       // BigInteger(12)
+
+// 제네릭 방식
+val bd: BigDecimal = m.numberValue()
+val d: Double = m.numberValue()
+```
+
+### 반올림
+
+```kotlin
+import io.bluetape4k.money.*
+
+val usd = 1.31473908.toMoney(USD)
+usd.round()         // USD 1.31 (통화별 기본 반올림)
+usd.defaultRound()  // USD 1.31 (시스템 기본 반올림)
+
+val krw = 131.473908.toMoney(KRW)
+krw.round()          // KRW 131 (원화는 소수점 0자리)
+```
+
+### 합산
+
+```kotlin
+import io.bluetape4k.money.*
+
+val amounts = listOf(100.toMonetaryAmount(KRW), 200.toMonetaryAmount(KRW), 300.toMonetaryAmount(KRW))
+val total = amounts.sum(KRW)  // KRW 600
+
+// 빈 컬렉션
+emptyList<MonetaryAmount>().sum(USD)  // USD 0
+```
+
+### 환율 변환
+
+```kotlin
+import io.bluetape4k.money.*
+
+// USD를 EUR로 변환
+val usd = 100.0.toMoney(USD)
+val eur = usd.convertTo(EUR)
+val krw = usd.convertTo(KRW)
+
+// 역변환 검증
+eur.convertTo(USD).doubleValue  // ≈ 100.0
+krw.convertTo(USD).doubleValue  // ≈ 100.0
+
+// CurrencyConvertor 사용
+val conversion = CurrencyConvertor.getConversion(USD)
+val usdConversion = CurrencyConvertor.USDConversion
+
+// 환전 가능 여부 확인
+"USD".isCurrencyConversionAvailable  // true
+USD.isCurrencyConversionAvailable    // true
+"AAA".isCurrencyConversionAvailable  // false
+```
+
+## 주요 파일
+
+| 파일                             | 설명                                  |
+|--------------------------------|-------------------------------------|
+| `CurrencySupport.kt`           | 통화 단위 생성 및 캐시 (KRW, USD, EUR, CNY, JPY) |
+| `MoneySupport.kt`              | Money 인스턴스 생성 확장 함수                 |
+| `FastMoneySupport.kt`          | FastMoney 인스턴스 생성 확장 함수             |
+| `MoneyAmountSupport.kt`        | 산술 연산자, 값 추출, 반올림, 환전, 합산 확장 함수   |
+| `CurrencyConverter.kt`         | 환율 변환기 (ECB, IMF 데이터 사용)            |
+| `CurrencyConversionSupport.kt` | 환전 가능 여부 확인 확장 함수                  |
 
 ## Money vs FastMoney
 
@@ -160,4 +229,8 @@ price1 == 1000.toMoney(KRW)  // true
 | 내부 타입 | BigDecimal       | Long         |
 | 정밀도   | 무제한              | 소수점 5자리까지    |
 | 성능    | 보통               | 매우 빠름        |
+| 환전    | 정확               | 정밀도 손실 가능    |
 | 사용 예시 | 금융 계산, 높은 정밀도 필요 | 대량 연산, 성능 중요 |
+
+> **참고**: 환전 작업은 정확성을 위해 `Money`를 사용하는 것을 권장합니다.
+> `FastMoney`는 기본 스케일이 5이므로, 소수점 5자리 이하의 값은 손실될 수 있습니다.

--- a/utils/money/src/main/kotlin/io/bluetape4k/money/FastMoneySupport.kt
+++ b/utils/money/src/main/kotlin/io/bluetape4k/money/FastMoneySupport.kt
@@ -34,7 +34,7 @@ fun <T: Number> fastMoneyOf(amount: T, currency: CurrencyUnit = DefaultCurrencyU
  * @return [FastMoney] 인스턴스
  */
 fun <T: Number> fastMoneyOf(amount: T, currencyCode: String): FastMoney =
-    FastMoney.of(amount, currencyCode)
+    FastMoney.of(amount, currencyUnitOf(currencyCode))
 
 /**
  * 통화단위에 맞는 [FastMoney] 인스턴스를 생성합니다.
@@ -51,34 +51,34 @@ fun fastMoneyOf(numberBinding: NumberValue, currency: CurrencyUnit): FastMoney =
     FastMoney.of(numberBinding, currency)
 
 /**
- * FastMoney는 통화량을 Long 수형만 지원하므로 [amountMinor]에 소수점 이하의 정보인 [factionDigits]를 같이 제공하여 [FastMoney]를 생성한다
+ * FastMoney는 통화량을 Long 수형만 지원하므로 [amountMinor]에 소수점 이하의 정보인 [fractionDigits]를 같이 제공하여 [FastMoney]를 생성한다
  *
  * ```
  * fastMoneyMinorOf("USD", 1245L, 2) // $12.45
  * ```
  *
- * @param currencyCode 통화 코드 ("KRW", "USD", "EUR", "CNY")
- * @param amountMinor  소숫점이 포함된 실제 통화량에서 소수점을 뺀 Long 수형의 숫자 (123.59 일 경우 12359)
- * @param factionDigits 실제 통화량에 해당하는 소수점 위치를 표현 (123.59 인 경우 2)
+ * @param currencyCode  통화 코드 ("KRW", "USD", "EUR", "CNY")
+ * @param amountMinor   소숫점이 포함된 실제 통화량에서 소수점을 뺀 Long 수형의 숫자 (123.59 일 경우 12359)
+ * @param fractionDigits 실제 통화량에 해당하는 소수점 위치를 표현 (123.59 인 경우 2)
  * @return [FastMoney] instance
  */
-fun fastMoneyMinorOf(currencyCode: String, amountMinor: Long, factionDigits: Int = 2): FastMoney =
-    FastMoney.ofMinor(currencyUnitOf(currencyCode), amountMinor, factionDigits)
+fun fastMoneyMinorOf(currencyCode: String, amountMinor: Long, fractionDigits: Int = 2): FastMoney =
+    FastMoney.ofMinor(currencyUnitOf(currencyCode), amountMinor, fractionDigits)
 
 /**
- * FastMoney는 통화량을 Long 수형만 지원하므로 [amountMinor]에 소수점 이하의 정보인 [factionDigits]를 같이 제공하여 [FastMoney]를 생성한다
+ * FastMoney는 통화량을 Long 수형만 지원하므로 [amountMinor]에 소수점 이하의 정보인 [fractionDigits]를 같이 제공하여 [FastMoney]를 생성한다
  *
  * ```
  * fastMoneyMinorOf("USD", 1245, 2) // $12.45
  * ```
  *
- * @param currency 통화 단위
- * @param amountMinor  소숫점이 포함된 실제 통화량에서 소수점을 뺀 Long 수형의 숫자 (123.59 일 경우 12359)
- * @param factionDigits 실제 통화량에 해당하는 소수점 위치를 표현 (123.59 인 경우 2)
+ * @param currency       통화 단위
+ * @param amountMinor    소숫점이 포함된 실제 통화량에서 소수점을 뺀 Long 수형의 숫자 (123.59 일 경우 12359)
+ * @param fractionDigits 실제 통화량에 해당하는 소수점 위치를 표현 (123.59 인 경우 2)
  * @return [FastMoney] instance
  */
-fun fastMoneyMinorOf(currency: CurrencyUnit, amountMinor: Long, factionDigits: Int = 2): FastMoney =
-    FastMoney.ofMinor(currency, amountMinor, factionDigits)
+fun fastMoneyMinorOf(currency: CurrencyUnit, amountMinor: Long, fractionDigits: Int = 2): FastMoney =
+    FastMoney.ofMinor(currency, amountMinor, fractionDigits)
 
 /**
  * 숫자를 [currency] 통화 단위를 사용하는 [FastMoney] 인스턴스로 빌드합니다.
@@ -106,32 +106,32 @@ fun Number.toFastMoney(currency: CurrencyUnit = DefaultCurrencyUnit): FastMoney 
 fun Number.toFastMoney(currencyCode: String): FastMoney = fastMoneyOf(this, currencyCode)
 
 /**
- * FastMoney는 통화량을 Long 수형만 지원하므로 [factionDigits]를 같이 제공하여 [FastMoney]를 생성한다
+ * FastMoney는 통화량을 Long 수형만 지원하므로 [fractionDigits]를 같이 제공하여 [FastMoney]를 생성한다
  *
  * ```
  * 1245L.toFastMoneyMinor(currencyOf("USD"), 2)  // USD 12.45
  * ```
  * @receiver 소숫점이 포함된 실제 통화량에서 소수점을 뺀 Long 수형의 숫자 (123.59 일 경우 12359)
- * @param currency      통화 단위 ([CurrencyUnit])
- * @param factionDigits 실제 통화량에 해당하는 소수점 위치를 표현 (123.59 인 경우 2)
+ * @param currency       통화 단위 ([CurrencyUnit])
+ * @param fractionDigits 실제 통화량에 해당하는 소수점 위치를 표현 (123.59 인 경우 2)
  * @return [FastMoney] instance
  */
-fun Long.toFastMoneyMinor(currency: CurrencyUnit = DefaultCurrencyUnit, factionDigits: Int = 5): FastMoney =
-    fastMoneyMinorOf(currency, this, factionDigits)
+fun Long.toFastMoneyMinor(currency: CurrencyUnit = DefaultCurrencyUnit, fractionDigits: Int = 2): FastMoney =
+    fastMoneyMinorOf(currency, this, fractionDigits)
 
 /**
- * FastMoney는 통화량을 Long 수형만 지원하므로 @receiver에 소수점 이하의 정보인 [factionDigits]를 같이 제공하여 [FastMoney]를 생성한다
+ * FastMoney는 통화량을 Long 수형만 지원하므로 @receiver에 소수점 이하의 정보인 [fractionDigits]를 같이 제공하여 [FastMoney]를 생성한다
  *
  * ```
- * 1245L.toFastMoneyMinor(currencyOf("USD"), 2)  // USD 12.45
+ * 1245L.toFastMoneyMinor("USD", 2)  // USD 12.45
  * ```
- * @receiver      소숫점이 포함된 실제 통화량에서 소수점을 뺀 Long 수형의 숫자 (123.59 일 경우 12359)
- * @param currencyCode  통화 코드 ("KRW", "USD", "EUR", "CNY")
- * @param factionDigits 실제 통화량에 해당하는 소수점 위치를 표현 (123.59 인 경우 2)
+ * @receiver       소숫점이 포함된 실제 통화량에서 소수점을 뺀 Long 수형의 숫자 (123.59 일 경우 12359)
+ * @param currencyCode   통화 코드 ("KRW", "USD", "EUR", "CNY")
+ * @param fractionDigits 실제 통화량에 해당하는 소수점 위치를 표현 (123.59 인 경우 2)
  * @return [FastMoney] instance
  */
-fun Long.toFastMoneyMinor(currencyCode: String, factionDigits: Int = 2): FastMoney =
-    fastMoneyMinorOf(currencyCode, this, factionDigits)
+fun Long.toFastMoneyMinor(currencyCode: String, fractionDigits: Int = 2): FastMoney =
+    fastMoneyMinorOf(currencyCode, this, fractionDigits)
 
 
 /**
@@ -141,7 +141,7 @@ fun Long.toFastMoneyMinor(currencyCode: String, factionDigits: Int = 2): FastMon
  * 1_200.inFastKRW()  // 1,200원
  * ```
  */
-fun Number.inFastKRW(): FastMoney = toFastMoney("KRW")
+fun Number.inFastKRW(): FastMoney = toFastMoney(KRW)
 
 /**
  * 숫자를 US Dollar 로 표현하는 [FastMoney]로 빌드합니다.
@@ -150,7 +150,7 @@ fun Number.inFastKRW(): FastMoney = toFastMoney("KRW")
  * 1.05.inFastUSD()  // USD 1.05
  * ```
  */
-fun Number.inFastUSD(): FastMoney = toFastMoney("USD")
+fun Number.inFastUSD(): FastMoney = toFastMoney(USD)
 
 /**
  * 숫자를 EURO 화로 표현하는 [FastMoney]로 빌드합니다.
@@ -159,4 +159,4 @@ fun Number.inFastUSD(): FastMoney = toFastMoney("USD")
  * 1.05.inFastEUR()  // EUR 1.05
  * ```
  */
-fun Number.inFastEUR(): FastMoney = toFastMoney("EUR")
+fun Number.inFastEUR(): FastMoney = toFastMoney(EUR)

--- a/utils/money/src/main/kotlin/io/bluetape4k/money/MoneyAmountSupport.kt
+++ b/utils/money/src/main/kotlin/io/bluetape4k/money/MoneyAmountSupport.kt
@@ -68,28 +68,131 @@ fun Number.toMonetaryAmount(currencyCode: String): MonetaryAmount =
 //
 // MonetaryAmount Arithmetic Operators
 //
+
+/**
+ * 통화 금액의 부호를 반전합니다.
+ *
+ * ```kotlin
+ * val usd = 10.toMoney(USD)
+ * val negated = -usd  // USD -10
+ * ```
+ */
 operator fun <T: MonetaryAmount> T.unaryMinus(): T = this.negate() as T
 
+/**
+ * 두 통화 금액을 더합니다. 같은 통화 단위여야 합니다.
+ *
+ * ```kotlin
+ * val a = 10.toMoney(USD)
+ * val b = 20.toMoney(USD)
+ * val sum = a + b  // USD 30
+ * ```
+ */
 operator fun <T: MonetaryAmount> T.plus(other: MonetaryAmount): T = this.add(other) as T
+
+/**
+ * 통화 금액에 숫자를 더합니다.
+ *
+ * ```kotlin
+ * val a = 10.toMoney(USD)
+ * val result = a + 5  // USD 15
+ * ```
+ */
 operator fun <T: MonetaryAmount> T.plus(scalar: Number): T = this.add(scalar.toMonetaryAmount(currency)) as T
+
+/**
+ * 두 통화 금액을 뺍니다. 같은 통화 단위여야 합니다.
+ *
+ * ```kotlin
+ * val a = 20.toMoney(USD)
+ * val b = 10.toMoney(USD)
+ * val diff = a - b  // USD 10
+ * ```
+ */
 operator fun <T: MonetaryAmount> T.minus(other: MonetaryAmount): T = this.subtract(other) as T
+
+/**
+ * 통화 금액에서 숫자를 뺍니다.
+ *
+ * ```kotlin
+ * val a = 20.toMoney(USD)
+ * val result = a - 5  // USD 15
+ * ```
+ */
 operator fun <T: MonetaryAmount> T.minus(scalar: Number): T = this.subtract(scalar.toMonetaryAmount(currency)) as T
 
+/**
+ * 통화 금액에 스칼라 값을 곱합니다.
+ *
+ * ```kotlin
+ * val a = 10.toMoney(USD)
+ * val result = a * 3  // USD 30
+ * ```
+ */
 operator fun <T: MonetaryAmount> T.times(scalar: Number): T = this.multiply(scalar) as T
+
+/**
+ * 숫자에 통화 금액을 곱합니다. (교환법칙 지원)
+ *
+ * ```kotlin
+ * val a = 10.toMoney(USD)
+ * val result = 3 * a  // USD 30
+ * ```
+ */
 operator fun <T: MonetaryAmount> Number.times(amount: T): T = amount.multiply(this) as T
 
+/**
+ * 통화 금액을 스칼라 값으로 나눕니다.
+ *
+ * ```kotlin
+ * val a = 30.toMoney(USD)
+ * val result = a / 3  // USD 10
+ * ```
+ */
 operator fun <T: MonetaryAmount> T.div(scalar: Number): T = this.divide(scalar) as T
 
 /**
- * [MonetaryAmount]에서 금액을 원하는 수형으로 가져온다
+ * [MonetaryAmount]에서 금액을 원하는 수형으로 가져옵니다.
+ *
+ * ```kotlin
+ * val m = moneyOf(12.5, USD)
+ * val bd: BigDecimal = m.numberValue()
+ * val d: Double = m.numberValue()
+ * ```
+ *
+ * @param T 변환할 수형 ([Int], [Long], [Double], [BigDecimal] 등)
+ * @return 해당 수형의 금액 값
  */
 inline fun <reified T: Number> MonetaryAmount.numberValue(): T = number.numberValue(T::class.java)
 
+/**
+ * 금액을 [Int] 값으로 가져옵니다.
+ */
 val MonetaryAmount.intValue: Int get() = numberValue()
+
+/**
+ * 금액을 [Long] 값으로 가져옵니다.
+ */
 val MonetaryAmount.longValue: Long get() = numberValue()
+
+/**
+ * 금액을 [Float] 값으로 가져옵니다.
+ */
 val MonetaryAmount.floatValue: Float get() = numberValue()
+
+/**
+ * 금액을 [Double] 값으로 가져옵니다.
+ */
 val MonetaryAmount.doubleValue: Double get() = numberValue()
+
+/**
+ * 금액을 [BigDecimal] 값으로 가져옵니다.
+ */
 val MonetaryAmount.bigDecimalValue: BigDecimal get() = numberValue()
+
+/**
+ * 금액을 [BigInteger] 값으로 가져옵니다.
+ */
 val MonetaryAmount.bigIntValue: BigInteger get() = numberValue()
 
 /**
@@ -111,7 +214,7 @@ fun <T: MonetaryAmount> T.defaultRound(): T = this.with(Monetary.getDefaultRound
  * EU의 오늘자 환율 정보를 이용하여 @receiver 의 금액을 대상 금액으로 환전합니다
  *
  * ```
- * 1.05L.inUSD().convertTo("KRW")        // USD 1.05 를 원화로 환젼
+ * 1.05L.inUSD().convertTo("KRW")        // USD 1.05 를 원화로 환전
  * ```
  *
  * @param T
@@ -125,7 +228,7 @@ fun <T: MonetaryAmount> T.convertTo(currencyCode: String): T =
  * 오늘자 환율 정보를 이용하여 [T]의 금액을 대상 금액으로 환전합니다
  *
  * ```
- * 1.05L.inUSD().convertTo(currencyOf("KRW"))        // USD 1.05 를 원화로 환젼
+ * 1.05L.inUSD().convertTo(currencyOf("KRW"))        // USD 1.05 를 원화로 환전
  * ```
  *
  * @param T 통화량 수형
@@ -144,9 +247,9 @@ fun <T: MonetaryAmount> T.convertTo(
 /**
  * 금액을 합산합니다
  *
- * ```
- * listOf(1.05L.inUSD(), 2.05L.inUSD()).sum(CurrencyUnit.USD)        // USD 3.10
- * listOf(100L.inKRW(), 200L.inKRW()).sum(CurrencyUnit.USD)          // USD 0.30
+ * ```kotlin
+ * listOf(1.05.inUSD(), 2.05.inUSD()).sum(USD)        // USD 3.10
+ * listOf(100L.inKRW(), 200L.inKRW()).sum(KRW)        // KRW 300
  * ```
  *
  * @param currencyUnit 환전할 통화 단위 (Default: [DefaultCurrencyUnit])

--- a/utils/money/src/test/kotlin/io/bluetape4k/money/CurrencyConversionSupportTest.kt
+++ b/utils/money/src/test/kotlin/io/bluetape4k/money/CurrencyConversionSupportTest.kt
@@ -1,0 +1,41 @@
+package io.bluetape4k.money
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.Test
+
+class CurrencyConversionSupportTest {
+
+    companion object: KLogging()
+
+    @Test
+    fun `유효한 통화 코드는 환전 가능 여부를 확인할 수 있다`() {
+        "USD".isCurrencyConversionAvailable.shouldBeTrue()
+        "EUR".isCurrencyConversionAvailable.shouldBeTrue()
+        "KRW".isCurrencyConversionAvailable.shouldBeTrue()
+        "JPY".isCurrencyConversionAvailable.shouldBeTrue()
+        "CNY".isCurrencyConversionAvailable.shouldBeTrue()
+
+        log.debug { "USD conversion available: ${"USD".isCurrencyConversionAvailable}" }
+    }
+
+    @Test
+    fun `유효하지 않은 통화 코드는 환전 불가`() {
+        "".isCurrencyConversionAvailable.shouldBeFalse()
+        "AAA".isCurrencyConversionAvailable.shouldBeFalse()
+        "ZZZ".isCurrencyConversionAvailable.shouldBeFalse()
+    }
+
+    @Test
+    fun `CurrencyUnit으로 환전 가능 여부 확인`() {
+        USD.isCurrencyConversionAvailable.shouldBeTrue()
+        EUR.isCurrencyConversionAvailable.shouldBeTrue()
+        KRW.isCurrencyConversionAvailable.shouldBeTrue()
+        JPY.isCurrencyConversionAvailable.shouldBeTrue()
+        CNY.isCurrencyConversionAvailable.shouldBeTrue()
+
+        log.debug { "USD CurrencyUnit conversion available: ${USD.isCurrencyConversionAvailable}" }
+    }
+}

--- a/utils/money/src/test/kotlin/io/bluetape4k/money/MoneyAmountSupportTest.kt
+++ b/utils/money/src/test/kotlin/io/bluetape4k/money/MoneyAmountSupportTest.kt
@@ -1,0 +1,212 @@
+package io.bluetape4k.money
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeLessThan
+import org.amshove.kluent.shouldBeNear
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.math.BigInteger
+
+class MoneyAmountSupportTest {
+
+    companion object: KLogging()
+
+    @Test
+    fun `MonetaryAmount 생성 - 통화코드 문자열`() {
+        val krw = monetaryAmountOf(1000, "KRW")
+        krw.currency.currencyCode shouldBeEqualTo "KRW"
+        krw.numberValue<Long>() shouldBeEqualTo 1000L
+
+        val usd = monetaryAmountOf(1.05, "USD")
+        usd.currency.currencyCode shouldBeEqualTo "USD"
+        usd.numberValue<Double>().shouldBeNear(1.05, 1e-10)
+    }
+
+    @Test
+    fun `MonetaryAmount 생성 - CurrencyUnit`() {
+        val krw = monetaryAmountOf(500, KRW)
+        krw.currency shouldBeEqualTo KRW
+        krw.numberValue<Int>() shouldBeEqualTo 500
+
+        val usd = monetaryAmountOf(99.99, USD)
+        usd.currency shouldBeEqualTo USD
+    }
+
+    @Test
+    fun `Number toMonetaryAmount 확장 함수`() {
+        val krw = 1000.toMonetaryAmount(KRW)
+        krw.currency shouldBeEqualTo KRW
+        krw.numberValue<Int>() shouldBeEqualTo 1000
+
+        val usd = 50.5.toMonetaryAmount("USD")
+        usd.currency shouldBeEqualTo USD
+    }
+
+    @Test
+    fun `unaryMinus 연산자`() {
+        val usd = 10.toMoney(USD)
+        val negated = -usd
+        negated.numberValue<Int>() shouldBeEqualTo -10
+        negated.currency shouldBeEqualTo USD
+    }
+
+    @Test
+    fun `plus 연산자 - MonetaryAmount`() {
+        val a = 10.toMoney(USD)
+        val b = 20.toMoney(USD)
+        val sum = a + b
+        sum.numberValue<Int>() shouldBeEqualTo 30
+    }
+
+    @Test
+    fun `plus 연산자 - 스칼라`() {
+        val a = 10.toMoney(USD)
+        val result = a + 5
+        result.numberValue<Int>() shouldBeEqualTo 15
+    }
+
+    @Test
+    fun `minus 연산자 - MonetaryAmount`() {
+        val a = 20.toMoney(USD)
+        val b = 10.toMoney(USD)
+        val diff = a - b
+        diff.numberValue<Int>() shouldBeEqualTo 10
+    }
+
+    @Test
+    fun `minus 연산자 - 스칼라`() {
+        val a = 20.toMoney(USD)
+        val result = a - 5
+        result.numberValue<Int>() shouldBeEqualTo 15
+    }
+
+    @Test
+    fun `times 연산자`() {
+        val a = 10.toMoney(USD)
+        val result = a * 3
+        result.numberValue<Int>() shouldBeEqualTo 30
+    }
+
+    @Test
+    fun `times 교환법칙`() {
+        val a = 10.toMoney(USD)
+        val result = 3 * a
+        result.numberValue<Int>() shouldBeEqualTo 30
+    }
+
+    @Test
+    fun `div 연산자`() {
+        val a = 30.toMoney(USD)
+        val result = a / 3
+        result.numberValue<Int>() shouldBeEqualTo 10
+    }
+
+    @Test
+    fun `numberValue로 다양한 수형 변환`() {
+        val m = moneyOf(12.5, USD)
+
+        val intVal: Int = m.numberValue()
+        intVal shouldBeEqualTo 12
+
+        val longVal: Long = m.numberValue()
+        longVal shouldBeEqualTo 12L
+
+        val doubleVal: Double = m.numberValue()
+        doubleVal.shouldBeNear(12.5, 1e-10)
+
+        val bdVal: BigDecimal = m.numberValue()
+        bdVal shouldBeEqualTo 12.5.toBigDecimal()
+    }
+
+    @Test
+    fun `프로퍼티 확장으로 금액 값 추출`() {
+        val m = moneyOf(12.5, USD)
+
+        m.intValue shouldBeEqualTo 12
+        m.longValue shouldBeEqualTo 12L
+        m.doubleValue.shouldBeNear(12.5, 1e-10)
+        m.floatValue.shouldBeNear(12.5f, 1e-5f)
+        m.bigDecimalValue shouldBeEqualTo 12.5.toBigDecimal()
+        m.bigIntValue shouldBeEqualTo BigInteger.valueOf(12)
+    }
+
+    @Test
+    fun `round 함수`() {
+        val usd = 1.31473908.toMoney(USD)
+        usd.round().toString() shouldBeEqualTo "USD 1.31"
+
+        val krw = 131.473908.toMoney(KRW)
+        krw.round().toString() shouldBeEqualTo "KRW 131"
+    }
+
+    @Test
+    fun `defaultRound 함수`() {
+        val usd = 1.31473908.toMoney(USD)
+        usd.defaultRound().toString() shouldBeEqualTo "USD 1.31"
+    }
+
+    @Test
+    fun `convertTo - 통화 코드 문자열`() {
+        val usd = 1.0.toMoney(USD)
+        val eur = usd.convertTo("EUR")
+        eur.currency.currencyCode shouldBeEqualTo "EUR"
+
+        // 역변환 시 원래 값 근사
+        eur.convertTo("USD").doubleValue.shouldBeNear(usd.doubleValue, 1e-2)
+    }
+
+    @Test
+    fun `convertTo - CurrencyUnit`() {
+        val usd = 1.0.toMoney(USD)
+        val krw = usd.convertTo(KRW)
+        krw.currency shouldBeEqualTo KRW
+
+        krw.convertTo(USD).doubleValue.shouldBeNear(usd.doubleValue, 1e-2)
+    }
+
+    @Test
+    fun `Collection sum - 같은 통화`() {
+        val amounts = listOf(
+            100.toMonetaryAmount(KRW),
+            200.toMonetaryAmount(KRW),
+            300.toMonetaryAmount(KRW)
+        )
+        val total = amounts.sum(KRW)
+        total.numberValue<Int>() shouldBeEqualTo 600
+        total.currency shouldBeEqualTo KRW
+    }
+
+    @Test
+    fun `Collection sum - 빈 컬렉션`() {
+        val amounts = emptyList<javax.money.MonetaryAmount>()
+        val total = amounts.sum(USD)
+        total.numberValue<Long>() shouldBeEqualTo 0L
+        total.currency shouldBeEqualTo USD
+    }
+
+    @Test
+    fun `복합 산술 연산`() {
+        val a = 100.toMoney(USD)
+        val b = 50.toMoney(USD)
+
+        val result = (a + b) * 2 - 100
+        log.debug { "result=$result" }
+        result.numberValue<Int>() shouldBeEqualTo 200
+
+        // (100 + 50) * 2 - 100 = 200
+        result shouldBeEqualTo 200.toMoney(USD)
+    }
+
+    @Test
+    fun `MonetaryAmount 비교 연산`() {
+        val a = 100.toMonetaryAmount(USD)
+        val b = 200.toMonetaryAmount(USD)
+
+        a.compareTo(b) shouldBeLessThan 0
+        b.compareTo(a) shouldBeGreaterThan 0
+        a.compareTo(100.toMonetaryAmount(USD)) shouldBeEqualTo 0
+    }
+}


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: refactor: Enhance money module with improved KDoc and tests

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- **README.md**: Comprehensively updated with detailed usage examples for all features
  - Added sections for MonetaryAmount creation, arithmetic operators, value extraction, rounding, and currency conversion
  - Included practical code examples for each feature
  - Added comparison table between Money vs FastMoney with new columns
  - Clarified caching behavior and conversion availability

- **FastMoneySupport.kt**: Code review improvements
  - Fixed typo: `factionDigits` → `fractionDigits` in all KDoc and parameter names
  - Corrected default value: `fractionDigits` default changed from 5 to 2 in `toFastMoneyMinor` extension
  - Updated currency code references to use `CurrencyUnit` constants (e.g., `KRW` instead of `"KRW"`)

- **MoneyAmountSupport.kt**: Enhanced with comprehensive KDoc
  - Added detailed KDoc for all arithmetic operators (`unaryMinus`, `plus`, `minus`, `times`, `div`)
  - Added documentation for value extraction functions (`numberValue`, property extensions)
  - Improved documentation for `convertTo`, `defaultRound`, and `sum` functions
  - Fixed typos in existing documentation

- **New test files**:
  - **CurrencyConversionSupportTest.kt**: Tests for currency conversion availability checking
  - **MoneyAmountSupportTest.kt**: Comprehensive tests (212 lines) covering:
    - MonetaryAmount creation from strings and CurrencyUnit
    - All arithmetic operators and combinations
    - Value extraction in multiple numeric types
    - Rounding operations
    - Currency conversion
    - Collection sum operations
    - Comparison operations

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #49, head `34165802fdcd7908a75dc22ee89b85a73aef0ffa`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `claude/gracious-ramanujan`
- Labels: 없음
- State: `MERGED`, merge commit `b565d8d022f02d6e256b9f5423082d8e13302902`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #49 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `b565d8d022f02d6e256b9f5423082d8e13302902`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
