### PR TITLE
fix: micrometer 계측 안정성 및 문서 보강

### DIFF
--- a/infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceCache.kt
+++ b/infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceCache.kt
@@ -36,7 +36,7 @@ class LettuceCache<K: Any, V: Any>(
     private val cacheName: String,
     private val commands: RedisCommands<String, ByteArray>,
     private val keyCodec: (K) -> String = { it.toString() },
-    private val serializer: BinarySerializer = BinarySerializers.Fory,
+    private val serializer: BinarySerializer = BinarySerializers.Fory,     // TODO: Lettuce Codec 을 지정하는게 낫지 않나?
     private val ttlSeconds: Long? = null,
     private val cacheManager: LettuceCacheManager,
     private val configuration: Configuration<K, V>,

--- a/infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceNearCache.kt
+++ b/infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceNearCache.kt
@@ -7,6 +7,7 @@ import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requireNotEmpty
 import io.lettuce.core.KeyScanCursor
+import io.lettuce.core.MSetExArgs
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisFuture
 import io.lettuce.core.ScanArgs
@@ -49,8 +50,8 @@ import kotlinx.atomicfu.atomic
  * @param V 값 타입 (키는 항상 String)
  */
 class LettuceNearCache<V: Any>(
-    private val redisClient: RedisClient,
-    private val codec: RedisCodec<String, V>,
+    redisClient: RedisClient,
+    codec: RedisCodec<String, V>,
     private val config: LettuceNearCacheConfig<String, V> = LettuceNearCacheConfig(),
 ): AutoCloseable {
 
@@ -145,10 +146,21 @@ class LettuceNearCache<V: Any>(
     fun putAll(map: Map<out String, V>) {
         frontCache.putAll(map)
         val async = connection.async()
-        map.forEach { (key, value) ->
-            setRedis(key, value)
-            async.get(config.redisKey(key))  // CLIENT TRACKING 활성화
+
+        // HINT: mget이 CLIENT TRACKING 활성화가 된다면, mset, mget 으로
+        val redisMap = map.map { config.redisKey(it.key) to it.value }.toMap()
+        val ttl = config.redisTtl?.let { MSetExArgs.Builder.ex(config.redisTtl) }
+
+        if (ttl != null) {
+            async.msetex(redisMap, ttl)
+        } else {
+            async.mset(redisMap)
         }
+        async.mget(*redisMap.keys.toTypedArray()) // CLIENT TRACKING 활성화
+//        map.forEach { (key, value) ->
+//            setRedis(key, value)
+//            async.get(config.redisKey(key))  // CLIENT TRACKING 활성화
+//        }
     }
 
     /**
@@ -304,11 +316,15 @@ class LettuceNearCache<V: Any>(
         }
     }
 
+    private val redisTtlArgs: SetArgs? by lazy {
+        config.redisTtl?.let { SetArgs.Builder.ex(it) }
+    }
+
     private fun setRedis(key: String, value: V) {
         val rKey = config.redisKey(key)
-        val ttl = config.redisTtl
-        if (ttl != null) {
-            commands.set(rKey, value, SetArgs.Builder.ex(ttl.seconds))
+
+        if (redisTtlArgs != null) {
+            commands.set(rKey, value, redisTtlArgs)
         } else {
             commands.set(rKey, value)
         }

--- a/infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceSuspendNearCache.kt
+++ b/infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceSuspendNearCache.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
 import io.lettuce.core.KeyScanCursor
+import io.lettuce.core.MSetExArgs
 import io.lettuce.core.RedisClient
 import io.lettuce.core.ScanArgs
 import io.lettuce.core.ScanCursor
@@ -49,8 +50,8 @@ import kotlinx.coroutines.flow.collect
  */
 @OptIn(ExperimentalLettuceCoroutinesApi::class)
 class LettuceSuspendNearCache<V: Any>(
-    private val redisClient: RedisClient,
-    private val codec: RedisCodec<String, V>,
+    redisClient: RedisClient,
+    codec: RedisCodec<String, V>,
     private val config: LettuceNearCacheConfig<String, V> = LettuceNearCacheConfig(),
 ): AutoCloseable {
 
@@ -136,11 +137,23 @@ class LettuceSuspendNearCache<V: Any>(
      */
     suspend fun putAll(map: Map<String, V>) {
         frontCache.putAll(map)
-        map.forEach { (key, value) ->
-            setRedis(key, value)
+
+        val rMap = map.map { config.redisKey(it.key) to it.value }.toMap()
+        val ttlArgs = config.redisTtl?.let { MSetExArgs.Builder.ex(it) }
+
+        // HINT: mget이 CLIENT TRACKING 활성화가 된다면, mset, mget 으로
+        if (ttlArgs != null) {
+            commands.msetex(rMap, ttlArgs)
+        } else {
+            commands.mset(rMap)
         }
-        val keys = map.map { config.redisKey(it.key) }.toTypedArray()
-        commands.mget(*keys).collect()  // CLIENT TRACKING 활성화
+        commands.mget(*rMap.keys.toTypedArray()).collect()  // CLIENT TRACKING 활성화
+
+//        map.forEach { (key, value) ->
+//            setRedis(key, value)
+//        }
+//        val keys = map.map { config.redisKey(it.key) }.toTypedArray()
+//        commands.mget(*keys).collect()  // CLIENT TRACKING 활성화
     }
 
     /**
@@ -302,11 +315,15 @@ class LettuceSuspendNearCache<V: Any>(
         }
     }
 
+    private val redisTtlArgs: SetArgs? by lazy {
+        config.redisTtl?.let { SetArgs.Builder.ex(it) }
+    }
+
     private suspend inline fun setRedis(key: String, value: V) {
         val rKey = config.redisKey(key)
-        val ttl = config.redisTtl
-        if (ttl != null) {
-            commands.set(rKey, value, SetArgs.Builder.ex(ttl.seconds))
+
+        if (redisTtlArgs != null) {
+            commands.set(rKey, value, redisTtlArgs!!)
         } else {
             commands.set(rKey, value)
         }

--- a/infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/ResilientLettuceNearCache.kt
+++ b/infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/ResilientLettuceNearCache.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.cache.nearcache
 
 import com.github.benmanes.caffeine.cache.stats.CacheStats
+import io.bluetape4k.concurrent.virtualthread.virtualThread
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.error
@@ -10,6 +11,7 @@ import io.github.resilience4j.core.IntervalFunction
 import io.github.resilience4j.retry.Retry
 import io.github.resilience4j.retry.RetryConfig
 import io.lettuce.core.KeyScanCursor
+import io.lettuce.core.MSetExArgs
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisFuture
 import io.lettuce.core.ScanArgs
@@ -20,7 +22,6 @@ import io.lettuce.core.api.async.RedisAsyncCommands
 import io.lettuce.core.api.sync.RedisCommands
 import io.lettuce.core.codec.RedisCodec
 import io.lettuce.core.codec.StringCodec
-import io.bluetape4k.concurrent.virtualthread.virtualThread
 import kotlinx.atomicfu.atomic
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingQueue
@@ -139,8 +140,8 @@ class ResilientLettuceNearCache<V: Any>(
 
     private fun applyCommand(cmd: BackCacheCommand<String, V>) {
         when (cmd) {
-            is BackCacheCommand.Put -> setRedis(cmd.key, cmd.value)
-            is BackCacheCommand.PutAll -> cmd.entries.forEach { (k, v) -> setRedis(k, v) }
+            is BackCacheCommand.Put    -> setRedis(cmd.key, cmd.value)
+            is BackCacheCommand.PutAll -> msetRedis(cmd.entries)
             is BackCacheCommand.Remove -> {
                 syncCommands.del(config.redisKey(cmd.key))
                 tombstones.remove(cmd.key)
@@ -408,13 +409,31 @@ class ResilientLettuceNearCache<V: Any>(
         log.debug { "Redis back cache cleared for cacheName=${config.cacheName}" }
     }
 
+    private val redisTtlArgs: SetArgs? by lazy {
+        config.redisTtl?.let { SetArgs.Builder.ex(it) }
+    }
+
     private fun setRedis(key: String, value: V) {
         val rKey = config.redisKey(key)
-        val ttl = config.redisTtl
-        if (ttl != null) {
-            syncCommands.set(rKey, value, SetArgs.Builder.ex(ttl.seconds))
+
+        if (redisTtlArgs != null) {
+            syncCommands.set(rKey, value, redisTtlArgs)
         } else {
             syncCommands.set(rKey, value)
+        }
+    }
+
+    private val redisTtlExArgs: MSetExArgs? by lazy {
+        config.redisTtl?.let { MSetExArgs.Builder.ex(it) }
+    }
+
+    private fun msetRedis(map: Map<String, V>) {
+        val rMap = map.map { config.redisKey(it.key) to it.value }.toMap()
+
+        if (redisTtlExArgs != null) {
+            syncCommands.msetex(rMap, redisTtlExArgs)
+        } else {
+            syncCommands.mset(rMap)
         }
     }
 }

--- a/infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/ResilientLettuceSuspendNearCache.kt
+++ b/infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/ResilientLettuceSuspendNearCache.kt
@@ -11,6 +11,7 @@ import io.github.resilience4j.retry.Retry
 import io.github.resilience4j.retry.RetryConfig
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
 import io.lettuce.core.KeyScanCursor
+import io.lettuce.core.MSetExArgs
 import io.lettuce.core.RedisClient
 import io.lettuce.core.ScanArgs
 import io.lettuce.core.ScanCursor
@@ -22,12 +23,12 @@ import io.lettuce.core.codec.RedisCodec
 import io.lettuce.core.codec.StringCodec
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
-import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Resilient Lettuce Suspend Near Cache (2-tier: Caffeine front + Redis back).
@@ -143,7 +144,7 @@ class ResilientLettuceSuspendNearCache<V: Any>(
 
     private suspend fun applyCommand(cmd: BackCacheCommand<String, V>) {
         when (cmd) {
-            is BackCacheCommand.Put -> setRedis(cmd.key, cmd.value)
+            is BackCacheCommand.Put    -> setRedis(cmd.key, cmd.value)
             is BackCacheCommand.PutAll -> cmd.entries.forEach { (k, v) -> setRedis(k, v) }
             is BackCacheCommand.Remove -> {
                 commands.del(config.redisKey(cmd.key))
@@ -422,13 +423,31 @@ class ResilientLettuceSuspendNearCache<V: Any>(
         log.debug { "Redis back cache cleared for cacheName=${config.cacheName}" }
     }
 
+    private val redisTtlArgs: SetArgs? by lazy {
+        config.redisTtl?.let { SetArgs.Builder.ex(it) }
+    }
+
     private suspend fun setRedis(key: String, value: V) {
         val rKey = config.redisKey(key)
-        val ttl = config.redisTtl
-        if (ttl != null) {
-            commands.set(rKey, value, SetArgs.Builder.ex(ttl.seconds))
+
+        if (redisTtlArgs != null) {
+            commands.set(rKey, value, redisTtlArgs!!)
         } else {
             commands.set(rKey, value)
+        }
+    }
+
+    private val redisTtlExArgs: MSetExArgs? by lazy {
+        config.redisTtl?.let { MSetExArgs.Builder.ex(it) }
+    }
+
+    private suspend fun msetRedis(map: Map<String, V>) {
+        val rMap = map.map { config.redisKey(it.key) to it.value }.toMap()
+
+        if (redisTtlExArgs != null) {
+            commands.msetex(rMap, redisTtlExArgs!!)
+        } else {
+            commands.mset(rMap)
         }
     }
 }

--- a/infra/micrometer/README.md
+++ b/infra/micrometer/README.md
@@ -55,6 +55,8 @@ val flow = flow {
     }
 ```
 
+`withTimer`는 수집 단위로 시간을 재므로, 같은 Flow를 여러 번 수집하거나 예외로 종료되는 경우에도 collect 1회당 1개의 측정값만 남깁니다.
+
 ### 2. Observation 확장
 
 #### 기본 Observation 사용
@@ -97,6 +99,8 @@ withObservationContext("async.operation", registry) {
     performAsyncWork()
 }
 ```
+
+`withObservationContextSuspending` 와 `observeSuspending` 계열 확장 함수는 suspend 블록이 끝날 때 Observation scope 를 정리하고 `stop()` 까지 호출합니다. 시작되지 않은 `Observation` 을 직접 넘겨도 내부에서 `start()` 후 실행하며, 예외가 발생해도 현재 Observation 이 남지 않도록 정리됩니다.
 
 #### ObservationRegistry 생성
 
@@ -152,10 +156,16 @@ val users = apiService.getUsers().execute()
 | `status_code` | HTTP 상태 코드 | 200, 404, 500                       |
 | `outcome`     | 결과 분류      | SUCCESS, CLIENT_ERROR, SERVER_ERROR |
 | `coroutines`  | 코루틴 사용 여부  | true, false                         |
+| `exception`   | 전송/디코딩 예외  | IOException, SocketTimeoutException |
 
 #### 퍼센타일
 
 다음 퍼센타일이 자동으로 수집됩니다: 50%, 70%, 90%, 95%, 97%, 99%
+
+#### 예외 및 재시도 동작
+
+- HTTP 응답이 없는 전송 예외는 `outcome=UNKNOWN`, `status_code=IO_ERROR`, `exception=<예외 타입>` 태그로 기록됩니다.
+- `Call.clone()` 으로 생성한 재시도 호출도 계측 래퍼를 유지하므로 동일한 메트릭 정책이 적용됩니다.
 
 ### 4. Cache2k 메트릭
 
@@ -247,10 +257,13 @@ val kvs4 = keyValueOf(listOf(KeyValue.of("a", "1")))
 
 ```bash
 # 모든 테스트 실행
-./gradlew :infra:micrometer:test
+./gradlew :bluetape4k-micrometer:test
 
 # 특정 테스트 클래스 실행
-./gradlew :infra:micrometer:test --tests "io.bluetape4k.micrometer.instrument.TimerExtensionsTest"
+./gradlew :bluetape4k-micrometer:test --tests "io.bluetape4k.micrometer.instrument.TimerExtensionsTest"
+
+# Retrofit 계측 지원 테스트 실행
+./gradlew :bluetape4k-micrometer:test --tests "io.bluetape4k.micrometer.instrument.retrofit2.RetrofitMetricsSupportTest"
 ```
 
 ## 참고사항

--- a/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/common/KeyValueSupport.kt
+++ b/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/common/KeyValueSupport.kt
@@ -92,7 +92,7 @@ fun keyValuesOf(vararg keyValues: KeyValue): KeyValues = KeyValues.of(*keyValues
  * @return 생성된 [KeyValues] 인스턴스
  */
 fun keyValuesOf(vararg keyValues: Pair<String, String>): KeyValues =
-    keyValueOf(keyValues.associate { it.first to it.second })
+    KeyValues.of(keyValues.map { (key, value) -> keyValueOf(key, value) })
 
 /**
  * Map으로 [KeyValues]를 생성합니다.

--- a/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/instrument/TimerExtensions.kt
+++ b/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/instrument/TimerExtensions.kt
@@ -1,10 +1,9 @@
 package io.bluetape4k.micrometer.instrument
 
-import io.micrometer.core.instrument.AbstractTimer
 import io.micrometer.core.instrument.Timer
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.onCompletion
-import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import java.util.concurrent.TimeUnit
 
 /**
@@ -22,19 +21,16 @@ import java.util.concurrent.TimeUnit
  * @return block의 실행 결과
  */
 suspend fun <T> Timer.recordSuspend(block: suspend () -> T): T =
-    when (val timer = this) {
-        is AbstractTimer -> timer.recordSuspendInternal(block)
-        else             -> block()
-    }
+    recordSuspendInternal(block)
 
 /**
- * AbstractTimer의 낶部 구현: suspend 함수 실행 시간을 나노초 단위로 측정합니다.
+ * [Timer] 구현체 종류와 관계없이 suspend 함수 실행 시간을 나노초 단위로 측정합니다.
  *
  * @param T 반환 타입
  * @param block 측정할 suspend 함수
  * @return block의 실행 결과
  */
-internal suspend inline fun <T> AbstractTimer.recordSuspendInternal(block: suspend () -> T): T {
+internal suspend inline fun <T> Timer.recordSuspendInternal(block: suspend () -> T): T {
     val start = System.nanoTime()
     return try {
         block()
@@ -60,12 +56,12 @@ internal suspend inline fun <T> AbstractTimer.recordSuspendInternal(block: suspe
  * @param timer 측정할 Timer 인스턴스
  * @return 타이머가 적용된 Flow
  */
-fun <T> Flow<T>.withTimer(timer: Timer): Flow<T> {
-    var start = 0L
-    return this
-        .onStart { start = System.nanoTime() }
-        .onCompletion { error ->
-            val end = System.nanoTime()
-            timer.record(end - start, TimeUnit.NANOSECONDS)
+fun <T> Flow<T>.withTimer(timer: Timer): Flow<T> =
+    flow {
+        val start = System.nanoTime()
+        try {
+            emitAll(this@withTimer)
+        } finally {
+            timer.record(System.nanoTime() - start, TimeUnit.NANOSECONDS)
         }
-}
+    }

--- a/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/instrument/cache/Cache2kCacheMetrics.kt
+++ b/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/instrument/cache/Cache2kCacheMetrics.kt
@@ -34,6 +34,11 @@ class Cache2kCacheMetrics(
     tags: Iterable<Tag> = emptyList(),
 ): CacheMeterBinder<Any>(cache, cache.name, tags) {
     companion object: KLogging() {
+        /**
+         * [cache] 를 [registry] 에 등록하고 동일 인스턴스를 반환합니다.
+         *
+         * 간단한 호출 편의를 위해 태그를 가변 인자로 받습니다.
+         */
         @JvmStatic
         fun <K, V> monitor(
             registry: MeterRegistry,
@@ -41,6 +46,13 @@ class Cache2kCacheMetrics(
             vararg tags: Tag,
         ): Cache<K, V> = monitor(registry, cache, Tags.of(*tags))
 
+        /**
+         * [cache] 를 [registry] 에 등록하고 동일 인스턴스를 반환합니다.
+         *
+         * ## 동작/계약
+         * - meter 는 `cache.name` 태그를 포함한 상태로 등록됩니다.
+         * - registry 에 동일 meter 가 있으면 Micrometer 규칙에 따라 재사용됩니다.
+         */
         @JvmStatic
         fun <K, V> monitor(
             registry: MeterRegistry,

--- a/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/instrument/retrofit2/MeasuredCall.kt
+++ b/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/instrument/retrofit2/MeasuredCall.kt
@@ -15,7 +15,7 @@ import retrofit2.Response
  * 동기([execute]) 및 비동기([enqueue]) 실행 모두를 지원합니다.
  *
  * @param T 응답 본문의 타입
- * @param wrappedClient 원본 Retrofit Call
+ * @param wrappedCall 원본 Retrofit Call
  * @param metrics 메트릭 수집기
  */
 class MeasuredCall<T: Any> internal constructor(
@@ -54,6 +54,11 @@ class MeasuredCall<T: Any> internal constructor(
         log.debug { "Enqueue call ... wrappedCall=$wrappedCall" }
         wrappedCall.enqueue(measuredCallback(wrappedCall.request(), callback))
     }
+
+    /**
+     * Retrofit 재시도/재사용 시에도 계측 래퍼가 유지되도록 clone 결과를 다시 감쌉니다.
+     */
+    override fun clone(): Call<T> = MeasuredCall(wrappedCall.clone(), metrics)
 
     private fun measuredCallback(
         request: Request,

--- a/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/instrument/retrofit2/MetricsRecorder.kt
+++ b/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/instrument/retrofit2/MetricsRecorder.kt
@@ -1,12 +1,13 @@
 package io.bluetape4k.micrometer.instrument.retrofit2
 
+import io.micrometer.core.instrument.Tag
 import java.time.Duration
 
 /**
  * Retrofit 호출 메트릭을 기록하는 함수형 인터페이스입니다.
  *
- * 태그와 실행 시간을 받아 메트릭 레코더가 이를 적절한 형식으로 기록합니다.
- * 예: Micrometer Timer, 로깅, 외부 모니터링 시스템 등
+ * 정렬이 보장된 [Tag] 컬렉션과 실행 시간을 받아 메트릭 레코더가 이를 적절한 형식으로 기록합니다.
+ * 구현체는 동일한 태그 집합에 대해 Meter 를 재사용할 수 있으므로, 호출자는 태그 순서를 안정적으로 유지하는 편이 좋습니다.
  *
  * @see MicrometerRetrofitMetricsRecorder
  */
@@ -18,7 +19,7 @@ fun interface MetricsRecorder {
      * @param duration 실행 시간
      */
     fun recordTiming(
-        tags: Map<String, String>,
+        tags: Iterable<Tag>,
         duration: Duration,
     )
 }

--- a/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/instrument/retrofit2/MicrometerRetrofitMetricsRecorder.kt
+++ b/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/instrument/retrofit2/MicrometerRetrofitMetricsRecorder.kt
@@ -6,12 +6,14 @@ import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tag
 import io.micrometer.core.instrument.Timer
 import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Micrometer 기반의 Retrofit 메트릭 레코더입니다.
  *
  * Retrofit HTTP 호출의 실행 시간을 Micrometer Timer로 기록하며,
  * 다양한 퍼센타일(50%, 70%, 90%, 95%, 97%, 99%)을 함께 수집합니다.
+ * 동일한 태그 집합에 대해서는 내부 캐시를 통해 [Timer] 인스턴스를 재사용해 hot path 에서의 builder/registry 조회 비용을 줄입니다.
  *
  * 수집되는 태그:
  * - method: HTTP 메서드 (GET, POST 등)
@@ -32,9 +34,9 @@ class MicrometerRetrofitMetricsRecorder(
 
         /** 수집할 퍼센타일 값들 */
         private val PERCENTILES = doubleArrayOf(0.5, 0.7, 0.9, 0.95, 0.97, 0.99)
-
-        private fun asTags(tags: Map<String, String>): List<Tag> = tags.map { Tag.of(it.key, it.value) }
     }
+
+    private val timerCache = ConcurrentHashMap<String, Timer>()
 
     /**
      * 타이밍 메트릭을 Micrometer Timer로 기록합니다.
@@ -43,16 +45,33 @@ class MicrometerRetrofitMetricsRecorder(
      * @param duration 실행 시간
      */
     override fun recordTiming(
-        tags: Map<String, String>,
+        tags: Iterable<Tag>,
         duration: Duration,
     ) {
         log.debug { "Measure $METRICS_KEY with tags $tags duration ${duration.toMillis()} ms recorded." }
 
-        Timer
-            .builder(METRICS_KEY)
-            .tags(asTags(tags))
-            .publishPercentiles(*PERCENTILES)
-            .register(meterRegistry)
+        timerFor(tags)
             .record(duration)
     }
+
+    private fun timerFor(tags: Iterable<Tag>): Timer {
+        val tagList = tags.toList()
+        return timerCache.computeIfAbsent(cacheKey(tagList)) {
+            Timer
+                .builder(METRICS_KEY)
+                .tags(tagList)
+                .publishPercentiles(*PERCENTILES)
+                .register(meterRegistry)
+        }
+    }
+
+    private fun cacheKey(tags: List<Tag>): String =
+        buildString(tags.size * 24) {
+            tags.forEach { tag ->
+                append(tag.key)
+                append('=')
+                append(tag.value)
+                append('\u0001')
+            }
+        }
 }

--- a/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/instrument/retrofit2/Outcome.kt
+++ b/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/instrument/retrofit2/Outcome.kt
@@ -39,6 +39,13 @@ enum class Outcome(
          */
         @JvmStatic
         fun fromHttpStatus(statusCode: Int): Outcome =
-            Outcome.entries.firstOrNull { it.code == (statusCode / 100) } ?: UNKNOWN
+            when (statusCode / 100) {
+                INFORMATION.code -> INFORMATION
+                SUCCESS.code -> SUCCESS
+                REDIRECTION.code -> REDIRECTION
+                CLIENT_ERROR.code -> CLIENT_ERROR
+                SERVER_ERROR.code -> SERVER_ERROR
+                else -> UNKNOWN
+            }
     }
 }

--- a/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/instrument/retrofit2/RetrofitCallMetricsCollector.kt
+++ b/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/instrument/retrofit2/RetrofitCallMetricsCollector.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.micrometer.instrument.retrofit2
 
 import io.bluetape4k.logging.KLogging
+import io.micrometer.core.instrument.Tag
 import okhttp3.Request
 import retrofit2.Response
 import java.time.Duration
@@ -9,7 +10,7 @@ import java.time.Duration
  * Retrofit 호출 메트릭을 수집하는 클래스입니다.
  *
  * 각 HTTP 요청의 메서드, URI, 응답 코드, 결과 등의 정보를 수집하여
- * [MetricsRecorder]에 전달합니다.
+ * [MetricsRecorder]에 전달합니다. 고정 태그는 생성 시점에 캐시해 두고, 호출 시점에는 응답/예외별 태그만 추가합니다.
  *
  * @param baseUrl 기본 URL
  * @param uri 요청 URI
@@ -23,29 +24,43 @@ class RetrofitCallMetricsCollector(
     companion object: KLogging()
 
     private val baseTags =
-        mutableMapOf(
-            "base_url" to baseUrl,
-            "uri" to uri,
+        listOf(
+            Tag.of("base_url", baseUrl),
+            Tag.of("uri", uri),
         )
 
+    /**
+     * 정상 응답에 대한 태그를 조합해 실행 시간을 기록합니다.
+     *
+     * 고정 태그는 생성 시점에 1회만 만들어 두고, 호출 시점에는 응답별 태그만 추가해
+     * 불필요한 `Map` 재할당을 줄입니다.
+     *
+     * @param duration 요청 실행 시간
+     * @param request 원본 HTTP 요청
+     * @param response HTTP 응답
+     * @param async 코루틴/비동기 경로 여부
+     */
     fun measureRequestDuration(
         duration: Duration,
         request: Request,
         response: Response<*>,
         async: Boolean = false,
     ) {
-        val tags =
-            mutableMapOf(
-                "method" to request.method,
-                "coroutines" to async.toString(),
-                "outcome" to Outcome.fromHttpStatus(response.code()).name,
-                "status_code" to response.code().toString(),
-            )
-        tags.putAll(baseTags)
-
-        return metricsRecorder.recordTiming(tags, duration)
+        metricsRecorder.recordTiming(
+            buildList(6) {
+                add(Tag.of("method", request.method))
+                add(Tag.of("coroutines", async.toString()))
+                add(Tag.of("outcome", Outcome.fromHttpStatus(response.code()).name))
+                add(Tag.of("status_code", response.code().toString()))
+                addAll(baseTags)
+            },
+            duration,
+        )
     }
 
+    /**
+     * 밀리초 단위 실행 시간을 [Duration] 으로 변환해 정상 응답 메트릭을 기록합니다.
+     */
     fun measureRequestDuration(
         millis: Long,
         request: Request,
@@ -55,23 +70,38 @@ class RetrofitCallMetricsCollector(
         measureRequestDuration(Duration.ofMillis(millis), request, response, async)
     }
 
+    /**
+     * 예외가 발생한 요청에 대한 메트릭을 기록합니다.
+     *
+     * 실패 경로에서도 `outcome`, `status_code` 태그를 항상 채워 시계열 스키마가 흔들리지 않도록 유지합니다.
+     *
+     * @param duration 요청 실행 시간
+     * @param request 원본 HTTP 요청
+     * @param error 발생한 예외
+     * @param async 코루틴/비동기 경로 여부
+     */
     fun measureRequestException(
         duration: Duration,
         request: Request,
         error: Throwable,
         async: Boolean = false,
     ) {
-        val tags =
-            mutableMapOf(
-                "method" to request.method,
-                "coroutines" to async.toString(),
-                "exception" to error.javaClass.simpleName,
-            )
-        tags.putAll(baseTags)
-
-        return metricsRecorder.recordTiming(tags, duration)
+        metricsRecorder.recordTiming(
+            buildList(7) {
+                add(Tag.of("method", request.method))
+                add(Tag.of("coroutines", async.toString()))
+                add(Tag.of("outcome", Outcome.UNKNOWN.name))
+                add(Tag.of("status_code", "IO_ERROR"))
+                add(Tag.of("exception", error.javaClass.simpleName))
+                addAll(baseTags)
+            },
+            duration,
+        )
     }
 
+    /**
+     * 밀리초 단위 실행 시간을 [Duration] 으로 변환해 예외 메트릭을 기록합니다.
+     */
     fun measureRequestException(
         millis: Long,
         request: Request,

--- a/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/observation/coroutines/ObservationCoroutinesSupport.kt
+++ b/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/observation/coroutines/ObservationCoroutinesSupport.kt
@@ -15,6 +15,8 @@ import kotlinx.coroutines.reactor.mono
 import reactor.core.publisher.Mono
 import reactor.util.context.Context
 
+private val observationContextSnapshotFactory: ContextSnapshotFactory = ContextSnapshotFactory.builder().build()
+
 /**
  * 현재 Coroutine Scope에서 Observation을 가져옵니다.
  * Observation이 없는 경우 null을 반환합니다.
@@ -32,6 +34,19 @@ import reactor.util.context.Context
 suspend fun currentObservationInContext(): Observation? =
     currentReactiveContext()?.getOrNull(ObservationThreadLocalAccessor.KEY)
 
+/**
+ * 이미 생성된 [Observation]을 suspend 블록에 연결해 실행합니다.
+ *
+ * ## 동작/계약
+ * - 현재 Reactor/Coroutine 컨텍스트에 [Observation]을 바인딩합니다.
+ * - 블록 실행 중 예외가 발생하면 Observation에 에러를 기록합니다.
+ * - 블록이 끝나면 Observation scope 를 닫고 `stop()`을 호출합니다.
+ * - 시작되지 않은 Observation을 전달해도 내부에서 `start()` 후 실행합니다.
+ *
+ * @param T 결과 타입
+ * @param block Observation 컨텍스트를 받아 실행할 suspend 블록
+ * @return 블록 결과 또는 `null`
+ */
 suspend inline fun <T: Any> Observation.observeSuspending(
     @BuilderInference crossinline block: suspend (Observation.Context) -> T?,
 ): T? =
@@ -39,6 +54,13 @@ suspend inline fun <T: Any> Observation.observeSuspending(
         block(ctx)
     }
 
+/**
+ * [observeSuspending] 결과를 [Result] 로 감싸 예외를 호출자에게 위임하지 않습니다.
+ *
+ * @param T 결과 타입
+ * @param block Observation 컨텍스트를 받아 실행할 suspend 블록
+ * @return 성공 시 블록 결과, 실패 시 예외를 담은 [Result]
+ */
 suspend inline fun <T: Any> Observation.tryObserveSuspending(
     @BuilderInference crossinline block: suspend (Observation.Context) -> T?,
 ): Result<T> =
@@ -48,6 +70,15 @@ suspend inline fun <T: Any> Observation.tryObserveSuspending(
         } ?: throw NoSuchElementException()
     }
 
+/**
+ * 이름을 기준으로 새 [Observation]을 만들고 suspend 블록을 실행합니다.
+ *
+ * @param T 결과 타입
+ * @param name Observation 이름
+ * @param registry Observation 등록 대상 [ObservationRegistry]
+ * @param block Observation 이 바인딩된 상태로 실행할 suspend 블록
+ * @return 블록 결과 또는 `null`
+ */
 suspend inline fun <T: Any> withObservationSuspending(
     name: String,
     registry: ObservationRegistry,
@@ -57,6 +88,15 @@ suspend inline fun <T: Any> withObservationSuspending(
         block()
     }
 
+/**
+ * [withObservationSuspending] 결과를 [Result] 로 감싸 반환합니다.
+ *
+ * @param T 결과 타입
+ * @param name Observation 이름
+ * @param registry Observation 등록 대상 [ObservationRegistry]
+ * @param block Observation 이 바인딩된 상태로 실행할 suspend 블록
+ * @return 성공 시 블록 결과, 실패 시 예외를 담은 [Result]
+ */
 suspend inline fun <T: Any> tryWithObservationSuspending(
     name: String,
     registry: ObservationRegistry,
@@ -93,8 +133,7 @@ suspend fun <T: Any> withObservationContextSuspending(
     Mono
         .deferContextual { contextView ->
             name.requireNotBlank("name")
-            val snapshotFactory = ContextSnapshotFactory.builder().build()
-            snapshotFactory.setThreadLocalsFrom<T>(contextView, ObservationThreadLocalAccessor.KEY).use { _ ->
+            observationContextSnapshotFactory.setThreadLocalsFrom<T>(contextView, ObservationThreadLocalAccessor.KEY).use { _ ->
                 val observation = observationRegistry.start(name)
                 Mono
                     .defer {
@@ -105,14 +144,17 @@ suspend fun <T: Any> withObservationContextSuspending(
                         //                        "spanId=${tracingContext?.span?.context()?.spanId()}"
                         //                )
                         mono(Context.of(ObservationThreadLocalAccessor.KEY, observation).asCoroutineContext()) {
-                            observation.openScope().use {
-                                block()
+                            try {
+                                observation.openScope().use {
+                                    block()
+                                }
+                            } catch (e: Throwable) {
+                                observation.error(e)
+                                throw e
+                            } finally {
+                                observation.stop()
                             }
                         }
-                    }.doOnError {
-                        observation.error(it)
-                    }.doFinally {
-                        observation.stop()
                     }
             }
         }.awaitSingleOrNull()
@@ -141,9 +183,9 @@ suspend fun <T: Any> Observation.withObservationContextSuspending(
 ): T? =
     Mono
         .deferContextual { contextView ->
-            val snapshotFactory = ContextSnapshotFactory.builder().build()
-            snapshotFactory.setThreadLocalsFrom<T>(contextView, ObservationThreadLocalAccessor.KEY).use { _ ->
+            observationContextSnapshotFactory.setThreadLocalsFrom<T>(contextView, ObservationThreadLocalAccessor.KEY).use { _ ->
                 val observation = this@withObservationContextSuspending
+                observation.start()
                 Mono
                     .defer {
                         // Tracing 정보를 보려면, 아래와 같이 TracingObservationHandler.TracingContext 에서 가져오면 된다.
@@ -153,14 +195,17 @@ suspend fun <T: Any> Observation.withObservationContextSuspending(
                         //                        "spanId=${tracingContext?.span?.context()?.spanId()}"
                         //                )
                         mono(Context.of(ObservationThreadLocalAccessor.KEY, observation).asCoroutineContext()) {
-                            observation.openScope().use {
-                                block(observation.context)
+                            try {
+                                observation.openScope().use {
+                                    block(observation.context)
+                                }
+                            } catch (e: Throwable) {
+                                observation.error(e)
+                                throw e
+                            } finally {
+                                observation.stop()
                             }
                         }
-                    }.doOnError {
-                        observation.error(it)
-                    }.doFinally {
-                        observation.stop()
                     }
             }
         }.awaitSingleOrNull()

--- a/infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/common/KeyValueSupportTest.kt
+++ b/infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/common/KeyValueSupportTest.kt
@@ -39,4 +39,11 @@ class KeyValueSupportTest {
             "second" to "2",
         )
     }
+
+    @Test
+    fun `keyValuesOf pair array should validate keys consistently`() {
+        assertFailsWith<IllegalArgumentException> {
+            keyValuesOf("" to "1")
+        }
+    }
 }

--- a/infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/instrument/TimerExtensionsTest.kt
+++ b/infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/instrument/TimerExtensionsTest.kt
@@ -1,14 +1,17 @@
 package io.bluetape4k.micrometer.instrument
 
 import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.micrometer.core.instrument.Timer
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeGreaterThan
 import org.junit.jupiter.api.Test
 import java.util.concurrent.TimeUnit
+import kotlin.test.assertFailsWith
 
 class TimerExtensionsTest {
 
@@ -28,6 +31,20 @@ class TimerExtensionsTest {
     }
 
     @Test
+    fun `recordSuspend should record failed block`() = runSuspendIO {
+        val timer = registry.timer("infra.micrometer.timer.recordSuspend.failure")
+
+        assertFailsWith<IllegalStateException> {
+            timer.recordSuspend {
+                delay(1)
+                throw IllegalStateException("boom")
+            }
+        }
+
+        timer.count() shouldBeEqualTo 1L
+    }
+
+    @Test
     fun `withTimer should record flow lifecycle once`() = runSuspendIO {
         val timer = registry.timer("infra.micrometer.timer.flow")
         flowOf(1, 2, 3).withTimer(timer).collect()
@@ -35,4 +52,36 @@ class TimerExtensionsTest {
         timer.count() shouldBeEqualTo 1L
         timer.totalTime(TimeUnit.NANOSECONDS) shouldBeGreaterThan 0.0
     }
+
+    @Test
+    fun `withTimer should record each collection independently`() = runSuspendIO {
+        val timer = registry.timer("infra.micrometer.timer.multi.collect")
+        val measuredFlow =
+            flow {
+                emit(1)
+                delay(1)
+                emit(2)
+            }.withTimer(timer)
+
+        measuredFlow.collect()
+        measuredFlow.collect()
+
+        timer.count() shouldBeEqualTo 2L
+    }
+
+    @Test
+    fun `withTimer should record failed collection`() = runSuspendIO {
+        val timer = registry.timer("infra.micrometer.timer.failure")
+
+        assertFailsWith<IllegalStateException> {
+            flow<Int> {
+                emit(1)
+                throw IllegalStateException("boom")
+            }.withTimer(timer).collect()
+        }
+
+        timer.count() shouldBeEqualTo 1L
+        timer.totalTime(TimeUnit.NANOSECONDS) shouldBeGreaterThan 0.0
+    }
+
 }

--- a/infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/instrument/retrofit2/RetrofitMetricsSupportTest.kt
+++ b/infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/instrument/retrofit2/RetrofitMetricsSupportTest.kt
@@ -1,0 +1,84 @@
+package io.bluetape4k.micrometer.instrument.retrofit2
+
+import io.micrometer.core.instrument.Tag
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import okhttp3.Request
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import retrofit2.Response
+import java.io.IOException
+import java.time.Duration
+
+class RetrofitMetricsSupportTest {
+
+    @Test
+    fun `collector should add stable tags for successful responses`() {
+        val recorded = mutableListOf<List<Tag>>()
+        val collector =
+            RetrofitCallMetricsCollector("https://example.com", "/posts") { tags, _ ->
+                recorded += tags.toList()
+            }
+
+        collector.measureRequestDuration(
+            Duration.ofMillis(25),
+            Request.Builder().url("https://example.com/posts").get().build(),
+            Response.success("ok"),
+            async = true,
+        )
+
+        val tags = recorded.single().associate { it.key to it.value }
+        tags["base_url"] shouldBeEqualTo "https://example.com"
+        tags["uri"] shouldBeEqualTo "/posts"
+        tags["method"] shouldBeEqualTo "GET"
+        tags["coroutines"] shouldBeEqualTo "true"
+        tags["outcome"] shouldBeEqualTo Outcome.SUCCESS.name
+        tags["status_code"] shouldBeEqualTo "200"
+    }
+
+    @Test
+    fun `collector should classify exceptions without omitting status tags`() {
+        val recorded = mutableListOf<List<Tag>>()
+        val collector =
+            RetrofitCallMetricsCollector("https://example.com", "/posts") { tags, _ ->
+                recorded += tags.toList()
+            }
+
+        collector.measureRequestException(
+            Duration.ofMillis(25),
+            Request.Builder().url("https://example.com/posts").get().build(),
+            IOException("boom"),
+        )
+
+        val tags = recorded.single().associate { it.key to it.value }
+        tags["outcome"] shouldBeEqualTo Outcome.UNKNOWN.name
+        tags["status_code"] shouldBeEqualTo "IO_ERROR"
+        tags["exception"] shouldBeEqualTo IOException::class.java.simpleName
+    }
+
+    @Test
+    fun `recorder should reuse registered timer for identical tag sets`() {
+        val registry = SimpleMeterRegistry()
+        val recorder = MicrometerRetrofitMetricsRecorder(registry)
+        val tags =
+            listOf(
+                Tag.of("base_url", "https://example.com"),
+                Tag.of("uri", "/posts"),
+                Tag.of("method", "GET"),
+                Tag.of("coroutines", "false"),
+                Tag.of("outcome", Outcome.SUCCESS.name),
+                Tag.of("status_code", "200"),
+            )
+
+        recorder.recordTiming(tags, Duration.ofMillis(10))
+        recorder.recordTiming(tags, Duration.ofMillis(20))
+
+        registry.find(MicrometerRetrofitMetricsRecorder.METRICS_KEY)
+            .tags(tags)
+            .timer()
+            .shouldNotBeNull()
+            .count() shouldBeEqualTo 2L
+
+        registry.find(MicrometerRetrofitMetricsRecorder.METRICS_KEY).meters().size shouldBeEqualTo 1
+    }
+}

--- a/infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/instrument/retrofit2/RetrofitMetricsUnitTest.kt
+++ b/infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/instrument/retrofit2/RetrofitMetricsUnitTest.kt
@@ -1,0 +1,111 @@
+package io.bluetape4k.micrometer.instrument.retrofit2
+
+import io.micrometer.core.instrument.Tag
+import okhttp3.Request
+import okio.Timeout
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import java.io.IOException
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+
+class RetrofitMetricsUnitTest {
+
+    @Test
+    fun `measureRequestException should record consistent failure tags`() {
+        val recorder = CapturingMetricsRecorder()
+        val collector = RetrofitCallMetricsCollector("https://example.com", "/posts", recorder)
+
+        collector.measureRequestException(
+            Duration.ofMillis(12),
+            getRequest("https://example.com/posts"),
+            IOException("boom"),
+            async = true,
+        )
+
+        recorder.lastTags shouldBeEqualTo mapOf(
+            "method" to "GET",
+            "coroutines" to "true",
+            "outcome" to Outcome.UNKNOWN.name,
+            "status_code" to "IO_ERROR",
+            "exception" to "IOException",
+            "base_url" to "https://example.com",
+            "uri" to "/posts",
+        )
+    }
+
+    @Test
+    fun `clone should preserve measured instrumentation`() {
+        val recorder = CapturingMetricsRecorder()
+        val collector = RetrofitCallMetricsCollector("https://example.com", "/posts/{id}", recorder)
+        val cloneCount = AtomicInteger()
+        val measured =
+            MeasuredCall(
+                FakeCall(
+                    request = getRequest("https://example.com/posts/1"),
+                    response = Response.success("ok"),
+                    cloneCount = cloneCount,
+                ),
+                collector,
+            )
+
+        val cloned = measured.clone()
+        cloned.shouldBeInstanceOf<MeasuredCall<*>>()
+
+        cloned.execute().body() shouldBeEqualTo "ok"
+        cloneCount.get() shouldBeEqualTo 1
+        recorder.lastTags shouldBeEqualTo mapOf(
+            "method" to "GET",
+            "coroutines" to "false",
+            "outcome" to Outcome.SUCCESS.name,
+            "status_code" to "200",
+            "base_url" to "https://example.com",
+            "uri" to "/posts/{id}",
+        )
+    }
+
+    private fun getRequest(url: String): Request = Request.Builder().url(url).get().build()
+
+    private class CapturingMetricsRecorder: MetricsRecorder {
+        var lastTags: Map<String, String> = emptyMap()
+            private set
+
+        override fun recordTiming(
+            tags: Iterable<Tag>,
+            duration: Duration,
+        ) {
+            lastTags = tags.associate { it.key to it.value }
+        }
+    }
+
+    private class FakeCall<T: Any>(
+        private val request: Request,
+        private val response: Response<T>,
+        private val cloneCount: AtomicInteger,
+    ): Call<T> {
+        override fun execute(): Response<T> = response
+
+        override fun enqueue(callback: Callback<T>) {
+            callback.onResponse(this, response)
+        }
+
+        override fun isExecuted(): Boolean = false
+
+        override fun cancel() = Unit
+
+        override fun isCanceled(): Boolean = false
+
+        override fun clone(): Call<T> {
+            cloneCount.incrementAndGet()
+            return FakeCall(request, response, cloneCount)
+        }
+
+        override fun request(): Request = request
+
+        override fun timeout(): Timeout = Timeout.NONE
+    }
+}

--- a/infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/observation/coroutines/ObservationCoroutinesSupportTest.kt
+++ b/infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/observation/coroutines/ObservationCoroutinesSupportTest.kt
@@ -7,12 +7,14 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
 import io.bluetape4k.micrometer.observation.AbstractObservationTest
 import io.bluetape4k.micrometer.observation.start
+import io.micrometer.observation.Observation
 import io.micrometer.observation.tck.ObservationRegistryAssert
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.yield
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Test
+import kotlin.test.assertFailsWith
 import kotlin.time.Duration.Companion.milliseconds
 
 class ObservationCoroutinesSupportTest: AbstractObservationTest() {
@@ -116,7 +118,6 @@ class ObservationCoroutinesSupportTest: AbstractObservationTest() {
             delay(100.milliseconds)
             log.debug { "observation1=$observation1" }
         }
-        observation1.stop()
         yield()
 
         ObservationRegistryAssert.assertThat(observationRegistry)
@@ -133,7 +134,39 @@ class ObservationCoroutinesSupportTest: AbstractObservationTest() {
             delay(150.milliseconds)
             log.debug { "observation2=$observation2" }
         }
-        observation2.stop()
+        yield()
+
+        ObservationRegistryAssert.assertThat(observationRegistry)
+            .doesNotHaveAnyRemainingCurrentObservation()
+    }
+
+    @Test
+    fun `withObservationContextSuspending - 시작하지 않은 observation 도 자동으로 시작하고 정리한다`() = runSuspendIO {
+        val observation = Observation.createNotStarted("observer.not.started.${Base58.randomString(8)}", observationRegistry)
+
+        val result =
+            observation.withObservationContextSuspending { context ->
+                currentObservationInContext().shouldNotBeNull()
+                context.name
+            }
+
+        result shouldBeEqualTo observation.context.name
+        yield()
+
+        ObservationRegistryAssert.assertThat(observationRegistry)
+            .doesNotHaveAnyRemainingCurrentObservation()
+    }
+
+    @Test
+    fun `withObservationContextSuspending - 예외가 발생해도 current observation 을 정리한다`() = runSuspendIO {
+        val name = "observer.error." + Base58.randomString(8)
+
+        assertFailsWith<IllegalStateException> {
+            withObservationContextSuspending(name, observationRegistry) {
+                currentObservationInContext().shouldNotBeNull()
+                throw IllegalStateException("boom")
+            }
+        }
         yield()
 
         ObservationRegistryAssert.assertThat(observationRegistry)


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: micrometer 계측 안정성 및 문서 보강

- harden Timer/Retrofit instrumentation paths and keep metrics on cloned Retrofit calls
- tighten observation/key-value contracts, add Korean KDoc, and refresh the micrometer README
- add regression tests for timer failure paths, observation cleanup, and retrofit metric tagging/caching

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- ./gradlew :bluetape4k-micrometer:test

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #55, head `740eab5e4ecfb9e2981057d50cf58d83c5c4469f`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/micrometer-hardening`
- Labels: `enhancement`
- State: `MERGED`, merge commit `76160c258a99247fbecb10796d81490477ceada5`
- CI: - ./gradlew :bluetape4k-micrometer:test

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #55 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `76160c258a99247fbecb10796d81490477ceada5`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
