### PR TITLE
fix: bucket4j rate limiter hardening

### DIFF
--- a/infra/bucket4j/README.md
+++ b/infra/bucket4j/README.md
@@ -8,6 +8,7 @@ Bucket4j 기반으로 애플리케이션 레벨 Rate Limiter를 구성하기 위
 - **로컬/분산 환경 지원**: in-memory(`Local*`)와 Redis 기반 분산(`Distributed*`) 구현 제공
 - **동기/코루틴 API 동시 제공**: `RateLimiter`, `SuspendRateLimiter`
 - **즉시 소비 시도 계약**: `SuspendRateLimiter.consume`은 대기하지 않고 즉시 소비 시도 후 `CONSUMED/REJECTED`를 반환
+- **Probe 기반 결과 계산**: 소비 성공 여부와 남은 토큰 수를 `ConsumptionProbe` 한 번의 조회 결과로 계산해 추가 토큰 조회를 줄임
 - **Bucket 구성 DSL**: `bucketConfiguration { ... }`, `addBandwidth { ... }` 헬퍼 제공
 - **Redis ProxyManager 헬퍼**: Lettuce/Redisson용 `*ProxyManagerOf` 유틸 제공
 - **결과 상태 표준화**: `RateLimitResult(status, consumedTokens, availableTokens)`로 소비/거절/오류를 일관되게 반환
@@ -21,6 +22,7 @@ Bucket4j 기반으로 애플리케이션 레벨 Rate Limiter를 구성하기 위
 - **RateLimiter 추상화 제공**: `consume(key, token)` 호출로 로컬/분산 구현체 교체가 쉬움
 - **코루틴 친화 구현**: `SuspendLocalBucket`, `LocalSuspendRateLimiter`, `DistributedSuspendRateLimiter`
 - **Redis 연동 초기화 단순화**: `lettuceBasedProxyManagerOf`, `redissonBasedProxyManagerOf`
+- **추가 원격 조회 최소화**: distributed/local rate limiter는 잔여 토큰 계산을 위해 별도 `availableTokens` 조회를 하지 않음
 
 ## 의존성 추가
 
@@ -96,6 +98,18 @@ when (result.status) {
 
 > 참고: `SuspendRateLimiter.consume`은 내부적으로 대기하지 않는 즉시 소비 시도 API입니다. 토큰 부족 시 `REJECTED`가 즉시 반환되며, 재시도/백오프는 호출자 정책으로 처리합니다.
 
+## Public API 계약 메모
+
+- `RateLimiter.consume`, `SuspendRateLimiter.consume`은 모두 `key`와 `numToken`을 먼저 검증합니다.
+  `key`는 blank일 수 없고, `numToken`은 `1..MAX_TOKENS_PER_REQUEST` 범위여야 합니다.
+- `DistributedRateLimiter`, `DistributedSuspendRateLimiter`는 `ConsumptionProbe` 한 번으로 소비 여부와 잔여 토큰을 계산합니다.
+  따라서 결과를 만들기 위해 추가 Redis round-trip을 발생시키지 않습니다.
+- `BucketProxyProvider`, `AsyncBucketProxyProvider`는 기본 prefix를 사용해 bucket key를 namespacing 합니다.
+  운영 환경에서 여러 rate limit 정책이 같은 Redis를 공유한다면 prefix를 명시적으로 분리하는 것이 안전합니다.
+- `LocalBucketProvider`, `LocalSuspendBucketProvider`는 같은 key에 대해 동일한 버킷 상태를 재사용합니다.
+- `SuspendLocalBucket.tryConsume(maxWaitTime)`는 대기가 필요하면 코루틴을 `delay`로 일시 중단하고, 취소 시 `CancellationException`을 그대로 전파합니다.
+- `RateLimitResult.error(cause)`는 예외 메시지를 `errorMessage`에 보존해 상위 계층이 로깅/메트릭 태깅에 재사용할 수 있게 합니다.
+
 ## Spring Boot 환경 구성
 
 이 모듈은 Spring Boot Auto Configuration을 제공하기보다, 애플리케이션 빈으로 조립해 사용하는 방식에 적합합니다.
@@ -124,3 +138,4 @@ WebFlux/WebMVC 필터(또는 인터셉터)에서 `RateLimiter`를 주입받아 `
 - `LocalSuspendRateLimiter`, `DistributedSuspendRateLimiter`는 `CancellationException`을 `ERROR`로 변환하지 않고 그대로 전파합니다.
 - `maxWaitTime`이 비정상적으로 큰 경우 nanos 변환 overflow를 `IllegalArgumentException`으로 처리합니다.
 - `AbstractLocalBucketProvider`는 blank key를 허용하지 않습니다.
+- `BucketProxyProvider`, `AsyncBucketProxyProvider`는 bucket resolve 시점에 잔여 토큰을 읽지 않아 불필요한 원격 조회를 방지합니다.

--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/distributed/AsyncBucketProxyProvider.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/distributed/AsyncBucketProxyProvider.kt
@@ -11,15 +11,19 @@ import io.github.bucket4j.distributed.AsyncBucketProxy
 import io.github.bucket4j.distributed.proxy.AsyncProxyManager
 
 /**
- * Bucket4j Bucket을 Redis 서버에 저장하고, 특정 Key 기반의 Rate-limit을 수행하는 Bucket 을 제공합니다.
- * 보통은 IP Address 기반이지만, User 기반으로 Rate-limit을 적용할 수 있습니다.
+ * 비동기 원격 저장소 기반 [AsyncBucketProxy]를 key별로 조회하는 provider 입니다.
+ *
+ * ## 동작/계약
+ * - [resolveBucket]은 blank key를 허용하지 않습니다.
+ * - 실제 원격 bucket key는 [keyPrefix] + `key`를 UTF-8 바이트 배열로 직렬화해 구성합니다.
+ * - resolve 시점에는 proxy 생성/조회만 수행하고, 잔여 토큰 조회 같은 추가 비동기 호출은 하지 않습니다.
  *
  * ```
  * class UserBasedAsyncBucketProvider(
  *    asyncProxyManager: AsyncProxyManager<ByteArray>,
  *    bucketConfiguration: BucketConfiguration,
  *    tokenPrefix: String
- * ): BucketProxyProvider(proxyManager, bucketConfiguration, tokenPrefix) {
+ * ): AsyncBucketProxyProvider(asyncProxyManager, bucketConfiguration, tokenPrefix) {
  *
  *     companion object: KLogging()
  *
@@ -29,9 +33,9 @@ import io.github.bucket4j.distributed.proxy.AsyncProxyManager
  * }
  * ```
  *
- * @property asyncProxyManager Bucket4j [AsyncProxyManager] 인스턴스 (@see Bucket4jConfig)
+ * @property asyncProxyManager Bucket4j [AsyncProxyManager] 인스턴스
  * @property bucketConfiguration Bucket Configuration
- * @property keyPrefix Bucket Key Prefix
+ * @property keyPrefix Bucket Key Prefix. Redis namespace 충돌 방지를 위해 기본 prefix가 적용됩니다.
  */
 open class AsyncBucketProxyProvider(
     protected val asyncProxyManager: AsyncProxyManager<ByteArray>,
@@ -44,7 +48,12 @@ open class AsyncBucketProxyProvider(
     }
 
     /**
-     * Key 기반의 [AsyncBucketProxy]를 [AsyncProxyManager]로 부터 가져온다
+     * [key]에 해당하는 [AsyncBucketProxy]를 반환합니다.
+     *
+     * ## 동작/계약
+     * - [key]는 blank일 수 없습니다.
+     * - 반환값은 같은 key에 대해 동일한 원격 상태를 바라봅니다.
+     * - future completion과 토큰 잔량 조회는 호출자가 명시적으로 수행해야 합니다.
      *
      * @param key Bucket 소유자 (Rate Limit 적용 대상) Key
      * @return [Bucket] 인스턴스
@@ -58,10 +67,15 @@ open class AsyncBucketProxyProvider(
         return asyncProxyManager.builder()
             .build(bucketKey) { completableFutureOf(bucketConfiguration) }
             .apply {
-                log.debug { "Resolved bucket for key[$key]: avaiableTokens=${this.availableTokens.get()}" }
+                log.debug { "Resolved async bucket for key[$key] with prefix[$keyPrefix]" }
             }
     }
 
+    /**
+     * 실제 원격 저장소에 사용할 async bucket key를 생성합니다.
+     *
+     * 기본 구현은 [keyPrefix]를 붙인 뒤 UTF-8 바이트 배열로 변환합니다.
+     */
     protected open fun getBucketKey(key: String): ByteArray {
         return "$keyPrefix$key".toUtf8Bytes()
     }

--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/distributed/BucketProxyProvider.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/distributed/BucketProxyProvider.kt
@@ -10,8 +10,12 @@ import io.github.bucket4j.distributed.BucketProxy
 import io.github.bucket4j.distributed.proxy.ProxyManager
 
 /**
- * Bucket4j Bucket을 Redis 서버에 저장하고, 특정 Key 기반의 Rate-limit을 수행하는 Bucket 을 제공합니다.
- * 보통은 IP Address 기반이지만, User 기반으로 Rate-limit을 적용할 수 있습니다.
+ * 원격 저장소 기반 [BucketProxy]를 key별로 조회하는 provider 입니다.
+ *
+ * ## 동작/계약
+ * - [resolveBucket]은 blank key를 허용하지 않습니다.
+ * - 실제 원격 bucket key는 [keyPrefix] + `key`를 UTF-8 바이트 배열로 직렬화해 구성합니다.
+ * - resolve 시점에는 bucket 생성/조회만 수행하고, 잔여 토큰 조회 같은 추가 원격 호출은 하지 않습니다.
  *
  * ```
  * class UserBasedBucketProvider(
@@ -28,9 +32,9 @@ import io.github.bucket4j.distributed.proxy.ProxyManager
  * }
  * ```
  *
- * @property proxyManager Bucket4j [ProxyManager] 인스턴스 (@see Bucket4jConfig)
+ * @property proxyManager Bucket4j [ProxyManager] 인스턴스
  * @property bucketConfiguration Bucket Configuration
- * @property keyPrefix Bucket Key Prefix
+ * @property keyPrefix Bucket Key Prefix. Redis namespace 충돌 방지를 위해 기본 prefix가 적용됩니다.
  */
 open class BucketProxyProvider(
     protected val proxyManager: ProxyManager<ByteArray>,
@@ -43,7 +47,12 @@ open class BucketProxyProvider(
     }
 
     /**
-     * Key 기반의 Bucket을 [ProxyManager]로 부터 가져온다
+     * [key]에 해당하는 [BucketProxy]를 반환합니다.
+     *
+     * ## 동작/계약
+     * - [key]는 blank일 수 없습니다.
+     * - 반환값은 같은 key에 대해 동일한 원격 상태를 바라봅니다.
+     * - 토큰 잔량 조회는 호출자가 명시적으로 수행해야 하며, 이 메서드는 resolve만 담당합니다.
      *
      * @param key Bucket 소유자 (Rate Limit 적용 대상) Key
      * @return [Bucket] 인스턴스
@@ -57,10 +66,15 @@ open class BucketProxyProvider(
         return proxyManager.builder()
             .build(bucketKey) { bucketConfiguration }
             .apply {
-                log.debug { "Resolved bucket for key[$key]: avaiableTokens=${this.availableTokens}" }
+                log.debug { "Resolved bucket for key[$key] with prefix[$keyPrefix]" }
             }
     }
 
+    /**
+     * 실제 원격 저장소에 사용할 bucket key를 생성합니다.
+     *
+     * 기본 구현은 [keyPrefix]를 붙인 뒤 UTF-8 바이트 배열로 변환합니다.
+     */
     protected open fun getBucketKey(key: String): ByteArray {
         return "$keyPrefix$key".toUtf8Bytes()
     }

--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/distributed/redis/LettuceBasedProxyManagerSupport.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/distributed/redis/LettuceBasedProxyManagerSupport.kt
@@ -6,7 +6,12 @@ import io.lettuce.core.RedisClient
 import io.lettuce.core.cluster.RedisClusterClient
 
 /**
- * Lettuce 기반의 ProxyManager 를 생성합니다.
+ * Lettuce 단일 노드 클라이언트로 Bucket4j CAS 기반 proxy manager를 생성합니다.
+ *
+ * ## 동작/계약
+ * - 호출마다 새 [LettuceBasedProxyManager]를 생성합니다.
+ * - [builder]에서 client-side config, expiration strategy, execution strategy를 설정할 수 있습니다.
+ * - key 직렬화 타입은 `ByteArray`로 고정됩니다.
  *
  * ```
  * val redisClient = RedisClient.create("redis://localhost:6379")
@@ -25,8 +30,7 @@ import io.lettuce.core.cluster.RedisClusterClient
  *
  * @param redisClient Lettuce의 [io.lettuce.core.RedisClient] 인스턴스
  * @param builder ProxyManager 를 초기화하는 람다 함수
- * @receiver
- * @return
+ * @return [LettuceBasedProxyManager] 인스턴스
  */
 inline fun lettuceBasedProxyManagerOf(
     redisClient: RedisClient,
@@ -39,7 +43,12 @@ inline fun lettuceBasedProxyManagerOf(
 }
 
 /**
- * Lettuce 기반의 ProxyManager 를 생성합니다.
+ * Lettuce cluster client로 Bucket4j CAS 기반 proxy manager를 생성합니다.
+ *
+ * ## 동작/계약
+ * - 호출마다 새 [LettuceBasedProxyManager]를 생성합니다.
+ * - [builder]에서 client-side config, expiration strategy, execution strategy를 설정할 수 있습니다.
+ * - key 직렬화 타입은 `ByteArray`로 고정됩니다.
  *
  * ```
  * val redisClusterClient = RedisClusterClient.create("redis://localhost:6379")
@@ -58,8 +67,7 @@ inline fun lettuceBasedProxyManagerOf(
  *
  * @param redisClusterClient Lettuce의 [io.lettuce.core.cluster.RedisClusterClient] 인스턴스
  * @param builder ProxyManager 를 초기화하는 람다 함수
- * @receiver
- * @return
+ * @return [LettuceBasedProxyManager] 인스턴스
  */
 inline fun lettuceBasedProxyManagerOf(
     redisClusterClient: RedisClusterClient,

--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/distributed/redis/RedissonBasedProxyManagerSupport.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/distributed/redis/RedissonBasedProxyManagerSupport.kt
@@ -8,11 +8,16 @@ import org.redisson.api.RedissonClient
 import org.redisson.command.CommandAsyncExecutor
 
 /**
- * Redisson 기반의 [io.github.bucket4j.distributed.proxy.ProxyManager] 를 생성합니다.
+ * [RedissonClient]로 Bucket4j CAS 기반 proxy manager를 생성합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 [Redisson] 구현체의 [CommandAsyncExecutor]를 추출해 사용합니다.
+ * - 호출마다 새 [RedissonBasedProxyManager]를 생성합니다.
+ * - key 직렬화 타입은 `ByteArray`로 고정됩니다.
  *
  * ```
  * val redisson = Redisson.create()
- * val proxyManager = lettuceBasedProxyManagerOf(redisson) {
+ * val proxyManager = redissonBasedProxyManagerOf(redisson) {
  *    withClientSideConfig(
  *        ClientSideConfig.getDefault()
  *           .withExpirationAfterWriteStrategy(
@@ -25,28 +30,37 @@ import org.redisson.command.CommandAsyncExecutor
  * }
  * ```
  *
- * @param redisson [Redisson] instance
+ * @param redisson [RedissonClient] 인스턴스. 내부 구현이 [Redisson]이어야 합니다.
  * @param builder ProxyManager 를 초기화하는 람다 함수
- * @receiver
  * @return [RedissonBasedProxyManager] 인스턴스
  */
 inline fun redissonBasedProxyManagerOf(
     redisson: RedissonClient,
     @BuilderInference builder: Bucket4jRedisson.RedissonBasedProxyManagerBuilder<ByteArray>.() -> Unit,
 ): RedissonBasedProxyManager<ByteArray> {
+    val executor = (redisson as? Redisson)?.commandExecutor
+        ?: throw IllegalArgumentException(
+            "redisson must be an instance of org.redisson.Redisson to extract CommandAsyncExecutor. actual=${redisson::class.qualifiedName}"
+        )
+
     return redissonBasedProxyManagerOf(
-        (redisson as Redisson).commandExecutor,
+        executor,
         builder
     )
 }
 
 
 /**
- * Redisson 기반의 [io.github.bucket4j.distributed.proxy.ProxyManager] 를 생성합니다.
+ * [CommandAsyncExecutor]로 Bucket4j CAS 기반 proxy manager를 생성합니다.
+ *
+ * ## 동작/계약
+ * - 이미 준비된 executor를 직접 주입해 Redisson lifecycle과 분리할 수 있습니다.
+ * - 호출마다 새 [RedissonBasedProxyManager]를 생성합니다.
+ * - key 직렬화 타입은 `ByteArray`로 고정됩니다.
  *
  * ```
  * val redisson = Redisson.create()
- * val proxyManager = lettuceBasedProxyManagerOf(redisson) {
+ * val proxyManager = redissonBasedProxyManagerOf(redisson) {
  *    withClientSideConfig(
  *        ClientSideConfig.getDefault()
  *           .withExpirationAfterWriteStrategy(
@@ -61,7 +75,6 @@ inline fun redissonBasedProxyManagerOf(
  *
  * @param commandAsyncExecutor Redisson의 [CommandAsyncExecutor] 인스턴스
  * @param builder ProxyManager 를 초기화하는 람다 함수
- * @receiver
  * @return [RedissonBasedProxyManager] 인스턴스
  */
 inline fun redissonBasedProxyManagerOf(

--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/local/LocalBucketProvider.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/local/LocalBucketProvider.kt
@@ -7,7 +7,12 @@ import io.github.bucket4j.local.LocalBucket
 import io.github.bucket4j.local.SynchronizationStrategy
 
 /**
- * Custom Key 기반 (예: userId) 으로 [LocalBucket]을 제공합니다.
+ * Custom key 기반(예: `userId`, `tenantId`)으로 [LocalBucket]을 제공하는 provider 입니다.
+ *
+ * ## 동작/계약
+ * - in-memory bucket을 key별 캐시에 보관합니다.
+ * - 기본 구현은 lock-free synchronization 전략과 millisecond precision을 사용합니다.
+ * - 같은 key를 재조회하면 동일한 로컬 버킷 상태를 공유합니다.
  *
  * ```
  * val bucketProvider = LocalBucketProvider(bucketConfiguration)
@@ -32,9 +37,9 @@ open class LocalBucketProvider(
     companion object: KLogging()
 
     /**
-     * Local에서 사용하는 [LocalBucket] 을 생성합니다.
+     * Local에서 사용하는 [LocalBucket]을 생성합니다.
      *
-     * @return [LocalBucket]을 반환합니다.
+     * lock-free synchronization 전략을 사용해 단일 JVM 내 높은 처리량을 우선합니다.
      */
     override fun createBucket(): LocalBucket {
         val builder = Bucket.builder()

--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/local/LocalSuspendBucketProvider.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/local/LocalSuspendBucketProvider.kt
@@ -8,7 +8,12 @@ import io.github.bucket4j.MathType
 import io.github.bucket4j.TimeMeter
 
 /**
- * Custom key 기준(예: userId) 으로 Coroutines 환경에서 사용할 [SuspendLocalBucket]을 제공하는 Provider 입니다.
+ * Coroutines 환경에서 사용할 [SuspendLocalBucket]을 key별로 제공하는 provider 입니다.
+ *
+ * ## 동작/계약
+ * - 같은 key를 재조회하면 동일한 로컬 버킷 상태를 공유합니다.
+ * - 기본 구현은 millisecond time meter와 64-bit math를 사용합니다.
+ * - 소비 대기 자체는 [SuspendLocalBucket]이 `delay`로 처리하므로 호출 스레드를 블로킹하지 않습니다.
  *
  * ```
  * val bucketProvider = LocalSuspendBucketProvider(bucketConfiguration)
@@ -38,7 +43,7 @@ open class LocalSuspendBucketProvider(
     /**
      * Coroutines용 [SuspendLocalBucket]을 생성합니다.
      *
-     * @return [SuspendLocalBucket] 인스턴스
+     * 기본 수학/시간 설정은 `INTEGER_64_BITS`, `SYSTEM_MILLISECONDS` 입니다.
      */
     override fun createBucket(): SuspendLocalBucket {
         log.debug { "Create SuspendLocalBucket ..." }

--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/RateLimitValidation.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/RateLimitValidation.kt
@@ -2,6 +2,7 @@
 
 package io.bluetape4k.bucket4j.ratelimit
 
+import io.github.bucket4j.ConsumptionProbe
 import io.bluetape4k.support.requireInRange
 import io.bluetape4k.support.requireNotBlank
 
@@ -26,5 +27,16 @@ internal inline fun toRateLimitResult(
         RateLimitResult.consumed(requestedTokens, availableTokens)
     } else {
         RateLimitResult.rejected(availableTokens)
+    }
+}
+
+internal inline fun toRateLimitResult(
+    probe: ConsumptionProbe,
+    requestedTokens: Long,
+): RateLimitResult {
+    return if (probe.isConsumed) {
+        RateLimitResult.consumed(requestedTokens, probe.remainingTokens)
+    } else {
+        RateLimitResult.rejected(probe.remainingTokens)
     }
 }

--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/distributed/DistributedRateLimiter.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/distributed/DistributedRateLimiter.kt
@@ -10,7 +10,12 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 
 /**
- * 분산 환경에서 Rate Limiter 를 적용하는 Rate Limiter 구현체
+ * 분산 버킷에 대해 즉시 소비 시도를 수행하는 동기 rate limiter 구현체입니다.
+ *
+ * ## 동작/계약
+ * - Redis 등 분산 저장소를 사용하는 [BucketProxyProvider] 기반 버킷에서 토큰을 소비합니다.
+ * - 내부적으로 `tryConsumeAndReturnRemaining`을 사용해 소비 결과와 잔여 토큰을 한 번에 계산합니다.
+ * - 입력 검증 실패는 예외로 처리하고, 분산 저장소 장애는 [RateLimitResult.error]로 변환합니다.
  *
  * ```
  * val rateLimiter = DistributedRateLimiter(bucketProxyProvider)
@@ -51,7 +56,7 @@ class DistributedRateLimiter(
 
         return try {
             val bucketProxy = bucketProxyProvider.resolveBucket(key)
-            toRateLimitResult(bucketProxy.tryConsume(numToken), numToken, bucketProxy.availableTokens)
+            toRateLimitResult(bucketProxy.tryConsumeAndReturnRemaining(numToken), numToken)
         } catch (e: Exception) {
             log.warn(e) { "Rate Limiter 적용에 실패했습니다. key=$key" }
             RateLimitResult.error(e)

--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/distributed/DistributedSuspendRateLimiter.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/distributed/DistributedSuspendRateLimiter.kt
@@ -10,10 +10,14 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.future.await
 
 /**
- * 분산 환경에서 Rate Limiter 를 적용하는 Coroutine Rate Limiter 구현체
+ * 분산 환경에서 즉시 소비 시도 계약을 제공하는 코루틴용 rate limiter 구현체입니다.
+ *
+ * ## 동작/계약
+ * - [consume]은 원격 버킷에 대해 대기 없는 즉시 소비를 시도합니다.
+ * - 소비 결과와 잔여 토큰은 `ConsumptionProbe` 한 번의 조회 결과로 해석합니다.
+ * - 코루틴 취소는 `ERROR`로 감싸지 않고 그대로 전파합니다.
  *
  * ```
  * val rateLimiter = DistributedSuspendRateLimiter(asyncBucketProxyProvider)
@@ -32,7 +36,8 @@ import kotlinx.coroutines.future.await
  * }
  * ```
  *
- * @property asyncBucketProxyProvider [AsyncBucketProxyProvider] 인스턴스
+ * @property asyncBucketProxyProvider [AsyncBucketProxyProvider] 인스턴스.
+ * 원격 저장소(Redis 등)에 연결된 async bucket proxy를 제공합니다.
  */
 class DistributedSuspendRateLimiter(
     private val asyncBucketProxyProvider: AsyncBucketProxyProvider,
@@ -55,11 +60,7 @@ class DistributedSuspendRateLimiter(
 
         return try {
             val bucketProxy = asyncBucketProxyProvider.resolveBucket(key)
-            toRateLimitResult(
-                consumed = bucketProxy.tryConsume(numToken).awaitSuspending(),
-                requestedTokens = numToken,
-                availableTokens = bucketProxy.availableTokens.await()
-            )
+            toRateLimitResult(bucketProxy.tryConsumeAndReturnRemaining(numToken).awaitSuspending(), numToken)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/local/LocalRateLimiter.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/local/LocalRateLimiter.kt
@@ -10,7 +10,12 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 
 /**
- * 로컬 환경에서 Rate Limiter 를 적용하는 Rate Limiter 구현체
+ * 로컬 메모리 버킷에 대해 즉시 소비 시도를 수행하는 동기 rate limiter 구현체입니다.
+ *
+ * ## 동작/계약
+ * - [consume]은 대기 없이 즉시 소비 가능 여부를 판정합니다.
+ * - 내부적으로 `tryConsumeAndReturnRemaining`을 사용해 소비 여부와 잔여 토큰 수를 한 번에 계산합니다.
+ * - 입력 검증 실패는 예외로 처리하고, 버킷 조회/소비 중 런타임 오류는 [RateLimitResult.error]로 변환합니다.
  *
  * ```
  * val bucketProvider by lazy {
@@ -64,7 +69,7 @@ open class LocalRateLimiter(
 
         return try {
             val bucketProxy = bucketProvider.resolveBucket(key)
-            toRateLimitResult(bucketProxy.tryConsume(numToken), numToken, bucketProxy.availableTokens)
+            toRateLimitResult(bucketProxy.tryConsumeAndReturnRemaining(numToken), numToken)
         } catch (e: Exception) {
             log.warn(e) { "Rate Limiter 적용에 실패했습니다. key=$key" }
             RateLimitResult.error(e)

--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/local/LocalSuspendRateLimiter.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/local/LocalSuspendRateLimiter.kt
@@ -12,7 +12,12 @@ import io.bluetape4k.logging.warn
 import kotlinx.coroutines.CancellationException
 
 /**
- * 로컬 환경에서 Rate Limiter 를 적용하는 Coroutine Rate Limiter 구현체
+ * 로컬 메모리 버킷에 대해 즉시 소비 시도를 수행하는 coroutine rate limiter 구현체입니다.
+ *
+ * ## 동작/계약
+ * - [consume]은 대기 없이 즉시 소비 가능 여부를 판정합니다.
+ * - 내부적으로 `tryConsumeAndReturnRemaining`을 사용해 소비 결과와 잔여 토큰을 한 번에 계산합니다.
+ * - `CancellationException`은 그대로 전파하고, 그 외 런타임 오류는 [RateLimitResult.error]로 변환합니다.
  *
  * ```
  * val rateLimiter = LocalSuspendRateLimiter(bucketProvider)
@@ -55,11 +60,7 @@ class LocalSuspendRateLimiter(
 
         return try {
             val bucketProxy: SuspendLocalBucket = bucketProvider.resolveBucket(key)
-            toRateLimitResult(
-                bucketProxy.tryConsume(numToken),
-                numToken,
-                bucketProxy.availableTokens
-            )
+            toRateLimitResult(bucketProxy.tryConsumeAndReturnRemaining(numToken), numToken)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/distributed/redis/RedissonBasedProxyManagerSupportTest.kt
+++ b/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/distributed/redis/RedissonBasedProxyManagerSupportTest.kt
@@ -1,0 +1,18 @@
+package io.bluetape4k.bucket4j.distributed.redis
+
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.redisson.api.RedissonClient
+
+class RedissonBasedProxyManagerSupportTest {
+
+    @Test
+    fun `Redisson 구현체가 아니면 명확한 예외를 던진다`() {
+        val client = mockk<RedissonClient>()
+
+        assertThrows<IllegalArgumentException> {
+            redissonBasedProxyManagerOf(client) {}
+        }
+    }
+}

--- a/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/ratelimit/RateLimitResultTest.kt
+++ b/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/ratelimit/RateLimitResultTest.kt
@@ -1,0 +1,55 @@
+package io.bluetape4k.bucket4j.ratelimit
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.Test
+
+class RateLimitResultTest {
+
+    @Test
+    fun `consumed factory 는 consumed 상태와 잔여 토큰을 유지한다`() {
+        val result = RateLimitResult.consumed(consumedTokens = 2, availableTokens = 8)
+
+        result.status shouldBeEqualTo RateLimitStatus.CONSUMED
+        result.consumedTokens shouldBeEqualTo 2
+        result.availableTokens shouldBeEqualTo 8
+        result.isConsumed.shouldBeTrue()
+        result.isRejected.shouldBeFalse()
+        result.isError.shouldBeFalse()
+    }
+
+    @Test
+    fun `rejected factory 는 consumedTokens 를 0으로 고정한다`() {
+        val result = RateLimitResult.rejected(availableTokens = 3)
+
+        result.status shouldBeEqualTo RateLimitStatus.REJECTED
+        result.consumedTokens shouldBeEqualTo 0
+        result.availableTokens shouldBeEqualTo 3
+        result.isConsumed.shouldBeFalse()
+        result.isRejected.shouldBeTrue()
+        result.isError.shouldBeFalse()
+    }
+
+    @Test
+    fun `error factory 는 errorMessage 를 보존한다`() {
+        val result = RateLimitResult.error(IllegalStateException("redis unavailable"))
+
+        result.status shouldBeEqualTo RateLimitStatus.ERROR
+        result.consumedTokens shouldBeEqualTo 0
+        result.availableTokens shouldBeEqualTo 0
+        result.errorMessage shouldBeEqualTo "redis unavailable"
+        result.isConsumed.shouldBeFalse()
+        result.isRejected.shouldBeFalse()
+        result.isError.shouldBeTrue()
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `deprecated 생성자는 consumedTokens 가 0이면 rejected 로 해석한다`() {
+        val result = RateLimitResult(consumedTokens = 0, availableTokens = 4)
+
+        result.status shouldBeEqualTo RateLimitStatus.REJECTED
+        result.isRejected.shouldBeTrue()
+    }
+}

--- a/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/ratelimit/RateLimiterProbeUsageTest.kt
+++ b/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/ratelimit/RateLimiterProbeUsageTest.kt
@@ -1,0 +1,95 @@
+package io.bluetape4k.bucket4j.ratelimit
+
+import io.bluetape4k.bucket4j.coroutines.SuspendLocalBucket
+import io.bluetape4k.bucket4j.distributed.AsyncBucketProxyProvider
+import io.bluetape4k.bucket4j.distributed.BucketProxyProvider
+import io.bluetape4k.bucket4j.local.LocalBucketProvider
+import io.bluetape4k.bucket4j.local.LocalSuspendBucketProvider
+import io.bluetape4k.bucket4j.ratelimit.distributed.DistributedRateLimiter
+import io.bluetape4k.bucket4j.ratelimit.distributed.DistributedSuspendRateLimiter
+import io.bluetape4k.bucket4j.ratelimit.local.LocalRateLimiter
+import io.bluetape4k.bucket4j.ratelimit.local.LocalSuspendRateLimiter
+import io.github.bucket4j.ConsumptionProbe
+import io.github.bucket4j.distributed.AsyncBucketProxy
+import io.github.bucket4j.distributed.BucketProxy
+import io.github.bucket4j.local.LocalBucket
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+
+class RateLimiterProbeUsageTest {
+
+    @Test
+    fun `local rate limiter 는 probe 기반으로 남은 토큰을 계산한다`() {
+        val bucketProvider = mockk<LocalBucketProvider>()
+        val bucket = mockk<LocalBucket>()
+        every { bucketProvider.resolveBucket("user:1") } returns bucket
+        every { bucket.tryConsumeAndReturnRemaining(3) } returns ConsumptionProbe.consumed(7, 0)
+
+        val result = LocalRateLimiter(bucketProvider).consume("user:1", 3)
+
+        result.status shouldBeEqualTo RateLimitStatus.CONSUMED
+        result.consumedTokens shouldBeEqualTo 3
+        result.availableTokens shouldBeEqualTo 7
+
+        verify(exactly = 1) { bucket.tryConsumeAndReturnRemaining(3) }
+        verify(exactly = 0) { bucket.availableTokens }
+    }
+
+    @Test
+    fun `distributed rate limiter 는 probe 기반으로 남은 토큰을 계산한다`() {
+        val bucketProvider = mockk<BucketProxyProvider>()
+        val bucket = mockk<BucketProxy>()
+        every { bucketProvider.resolveBucket("user:1") } returns bucket
+        every { bucket.tryConsumeAndReturnRemaining(2) } returns ConsumptionProbe.rejected(8, 11, 11)
+
+        val result = DistributedRateLimiter(bucketProvider).consume("user:1", 2)
+
+        result.status shouldBeEqualTo RateLimitStatus.REJECTED
+        result.consumedTokens shouldBeEqualTo 0
+        result.availableTokens shouldBeEqualTo 8
+
+        verify(exactly = 1) { bucket.tryConsumeAndReturnRemaining(2) }
+        verify(exactly = 0) { bucket.availableTokens }
+    }
+
+    @Test
+    fun `local suspend rate limiter 는 probe 기반으로 남은 토큰을 계산한다`() = runTest {
+        val bucketProvider = mockk<LocalSuspendBucketProvider>()
+        val bucket = mockk<SuspendLocalBucket>()
+        every { bucketProvider.resolveBucket("user:1") } returns bucket
+        every { bucket.tryConsumeAndReturnRemaining(4) } returns ConsumptionProbe.consumed(6, 0)
+
+        val result = LocalSuspendRateLimiter(bucketProvider).consume("user:1", 4)
+
+        result.status shouldBeEqualTo RateLimitStatus.CONSUMED
+        result.consumedTokens shouldBeEqualTo 4
+        result.availableTokens shouldBeEqualTo 6
+
+        verify(exactly = 1) { bucket.tryConsumeAndReturnRemaining(4) }
+        verify(exactly = 0) { bucket.availableTokens }
+    }
+
+    @Test
+    fun `distributed suspend rate limiter 는 probe future 하나만 await 한다`() = runTest {
+        val bucketProvider = mockk<AsyncBucketProxyProvider>()
+        val bucket = mockk<AsyncBucketProxy>()
+        every { bucketProvider.resolveBucket("user:1") } returns bucket
+        every {
+            bucket.tryConsumeAndReturnRemaining(5)
+        } returns CompletableFuture.completedFuture(ConsumptionProbe.consumed(5, 0))
+
+        val result = DistributedSuspendRateLimiter(bucketProvider).consume("user:1", 5)
+
+        result.status shouldBeEqualTo RateLimitStatus.CONSUMED
+        result.consumedTokens shouldBeEqualTo 5
+        result.availableTokens shouldBeEqualTo 5
+
+        verify(exactly = 1) { bucket.tryConsumeAndReturnRemaining(5) }
+        verify(exactly = 0) { bucket.availableTokens }
+    }
+}

--- a/infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceCache.kt
+++ b/infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceCache.kt
@@ -36,7 +36,7 @@ class LettuceCache<K: Any, V: Any>(
     private val cacheName: String,
     private val commands: RedisCommands<String, ByteArray>,
     private val keyCodec: (K) -> String = { it.toString() },
-    private val serializer: BinarySerializer = BinarySerializers.Fory,
+    private val serializer: BinarySerializer = BinarySerializers.Fory,     // TODO: Lettuce Codec 을 지정하는게 낫지 않나?
     private val ttlSeconds: Long? = null,
     private val cacheManager: LettuceCacheManager,
     private val configuration: Configuration<K, V>,

--- a/infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceNearCache.kt
+++ b/infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceNearCache.kt
@@ -7,6 +7,7 @@ import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requireNotEmpty
 import io.lettuce.core.KeyScanCursor
+import io.lettuce.core.MSetExArgs
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisFuture
 import io.lettuce.core.ScanArgs
@@ -49,8 +50,8 @@ import kotlinx.atomicfu.atomic
  * @param V 값 타입 (키는 항상 String)
  */
 class LettuceNearCache<V: Any>(
-    private val redisClient: RedisClient,
-    private val codec: RedisCodec<String, V>,
+    redisClient: RedisClient,
+    codec: RedisCodec<String, V>,
     private val config: LettuceNearCacheConfig<String, V> = LettuceNearCacheConfig(),
 ): AutoCloseable {
 
@@ -145,10 +146,21 @@ class LettuceNearCache<V: Any>(
     fun putAll(map: Map<out String, V>) {
         frontCache.putAll(map)
         val async = connection.async()
-        map.forEach { (key, value) ->
-            setRedis(key, value)
-            async.get(config.redisKey(key))  // CLIENT TRACKING 활성화
+
+        // HINT: mget이 CLIENT TRACKING 활성화가 된다면, mset, mget 으로
+        val redisMap = map.map { config.redisKey(it.key) to it.value }.toMap()
+        val ttl = config.redisTtl?.let { MSetExArgs.Builder.ex(config.redisTtl) }
+
+        if (ttl != null) {
+            async.msetex(redisMap, ttl)
+        } else {
+            async.mset(redisMap)
         }
+        async.mget(*redisMap.keys.toTypedArray()) // CLIENT TRACKING 활성화
+//        map.forEach { (key, value) ->
+//            setRedis(key, value)
+//            async.get(config.redisKey(key))  // CLIENT TRACKING 활성화
+//        }
     }
 
     /**
@@ -304,11 +316,15 @@ class LettuceNearCache<V: Any>(
         }
     }
 
+    private val redisTtlArgs: SetArgs? by lazy {
+        config.redisTtl?.let { SetArgs.Builder.ex(it) }
+    }
+
     private fun setRedis(key: String, value: V) {
         val rKey = config.redisKey(key)
-        val ttl = config.redisTtl
-        if (ttl != null) {
-            commands.set(rKey, value, SetArgs.Builder.ex(ttl.seconds))
+
+        if (redisTtlArgs != null) {
+            commands.set(rKey, value, redisTtlArgs)
         } else {
             commands.set(rKey, value)
         }

--- a/infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceSuspendNearCache.kt
+++ b/infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceSuspendNearCache.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
 import io.lettuce.core.KeyScanCursor
+import io.lettuce.core.MSetExArgs
 import io.lettuce.core.RedisClient
 import io.lettuce.core.ScanArgs
 import io.lettuce.core.ScanCursor
@@ -49,8 +50,8 @@ import kotlinx.coroutines.flow.collect
  */
 @OptIn(ExperimentalLettuceCoroutinesApi::class)
 class LettuceSuspendNearCache<V: Any>(
-    private val redisClient: RedisClient,
-    private val codec: RedisCodec<String, V>,
+    redisClient: RedisClient,
+    codec: RedisCodec<String, V>,
     private val config: LettuceNearCacheConfig<String, V> = LettuceNearCacheConfig(),
 ): AutoCloseable {
 
@@ -136,11 +137,23 @@ class LettuceSuspendNearCache<V: Any>(
      */
     suspend fun putAll(map: Map<String, V>) {
         frontCache.putAll(map)
-        map.forEach { (key, value) ->
-            setRedis(key, value)
+
+        val rMap = map.map { config.redisKey(it.key) to it.value }.toMap()
+        val ttlArgs = config.redisTtl?.let { MSetExArgs.Builder.ex(it) }
+
+        // HINT: mget이 CLIENT TRACKING 활성화가 된다면, mset, mget 으로
+        if (ttlArgs != null) {
+            commands.msetex(rMap, ttlArgs)
+        } else {
+            commands.mset(rMap)
         }
-        val keys = map.map { config.redisKey(it.key) }.toTypedArray()
-        commands.mget(*keys).collect()  // CLIENT TRACKING 활성화
+        commands.mget(*rMap.keys.toTypedArray()).collect()  // CLIENT TRACKING 활성화
+
+//        map.forEach { (key, value) ->
+//            setRedis(key, value)
+//        }
+//        val keys = map.map { config.redisKey(it.key) }.toTypedArray()
+//        commands.mget(*keys).collect()  // CLIENT TRACKING 활성화
     }
 
     /**
@@ -302,11 +315,15 @@ class LettuceSuspendNearCache<V: Any>(
         }
     }
 
+    private val redisTtlArgs: SetArgs? by lazy {
+        config.redisTtl?.let { SetArgs.Builder.ex(it) }
+    }
+
     private suspend inline fun setRedis(key: String, value: V) {
         val rKey = config.redisKey(key)
-        val ttl = config.redisTtl
-        if (ttl != null) {
-            commands.set(rKey, value, SetArgs.Builder.ex(ttl.seconds))
+
+        if (redisTtlArgs != null) {
+            commands.set(rKey, value, redisTtlArgs!!)
         } else {
             commands.set(rKey, value)
         }

--- a/infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/ResilientLettuceNearCache.kt
+++ b/infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/ResilientLettuceNearCache.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.cache.nearcache
 
 import com.github.benmanes.caffeine.cache.stats.CacheStats
+import io.bluetape4k.concurrent.virtualthread.virtualThread
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.error
@@ -10,6 +11,7 @@ import io.github.resilience4j.core.IntervalFunction
 import io.github.resilience4j.retry.Retry
 import io.github.resilience4j.retry.RetryConfig
 import io.lettuce.core.KeyScanCursor
+import io.lettuce.core.MSetExArgs
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisFuture
 import io.lettuce.core.ScanArgs
@@ -20,7 +22,6 @@ import io.lettuce.core.api.async.RedisAsyncCommands
 import io.lettuce.core.api.sync.RedisCommands
 import io.lettuce.core.codec.RedisCodec
 import io.lettuce.core.codec.StringCodec
-import io.bluetape4k.concurrent.virtualthread.virtualThread
 import kotlinx.atomicfu.atomic
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingQueue
@@ -139,8 +140,8 @@ class ResilientLettuceNearCache<V: Any>(
 
     private fun applyCommand(cmd: BackCacheCommand<String, V>) {
         when (cmd) {
-            is BackCacheCommand.Put -> setRedis(cmd.key, cmd.value)
-            is BackCacheCommand.PutAll -> cmd.entries.forEach { (k, v) -> setRedis(k, v) }
+            is BackCacheCommand.Put    -> setRedis(cmd.key, cmd.value)
+            is BackCacheCommand.PutAll -> msetRedis(cmd.entries)
             is BackCacheCommand.Remove -> {
                 syncCommands.del(config.redisKey(cmd.key))
                 tombstones.remove(cmd.key)
@@ -408,13 +409,31 @@ class ResilientLettuceNearCache<V: Any>(
         log.debug { "Redis back cache cleared for cacheName=${config.cacheName}" }
     }
 
+    private val redisTtlArgs: SetArgs? by lazy {
+        config.redisTtl?.let { SetArgs.Builder.ex(it) }
+    }
+
     private fun setRedis(key: String, value: V) {
         val rKey = config.redisKey(key)
-        val ttl = config.redisTtl
-        if (ttl != null) {
-            syncCommands.set(rKey, value, SetArgs.Builder.ex(ttl.seconds))
+
+        if (redisTtlArgs != null) {
+            syncCommands.set(rKey, value, redisTtlArgs)
         } else {
             syncCommands.set(rKey, value)
+        }
+    }
+
+    private val redisTtlExArgs: MSetExArgs? by lazy {
+        config.redisTtl?.let { MSetExArgs.Builder.ex(it) }
+    }
+
+    private fun msetRedis(map: Map<String, V>) {
+        val rMap = map.map { config.redisKey(it.key) to it.value }.toMap()
+
+        if (redisTtlExArgs != null) {
+            syncCommands.msetex(rMap, redisTtlExArgs)
+        } else {
+            syncCommands.mset(rMap)
         }
     }
 }

--- a/infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/ResilientLettuceSuspendNearCache.kt
+++ b/infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/ResilientLettuceSuspendNearCache.kt
@@ -11,6 +11,7 @@ import io.github.resilience4j.retry.Retry
 import io.github.resilience4j.retry.RetryConfig
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
 import io.lettuce.core.KeyScanCursor
+import io.lettuce.core.MSetExArgs
 import io.lettuce.core.RedisClient
 import io.lettuce.core.ScanArgs
 import io.lettuce.core.ScanCursor
@@ -22,12 +23,12 @@ import io.lettuce.core.codec.RedisCodec
 import io.lettuce.core.codec.StringCodec
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
-import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Resilient Lettuce Suspend Near Cache (2-tier: Caffeine front + Redis back).
@@ -143,7 +144,7 @@ class ResilientLettuceSuspendNearCache<V: Any>(
 
     private suspend fun applyCommand(cmd: BackCacheCommand<String, V>) {
         when (cmd) {
-            is BackCacheCommand.Put -> setRedis(cmd.key, cmd.value)
+            is BackCacheCommand.Put    -> setRedis(cmd.key, cmd.value)
             is BackCacheCommand.PutAll -> cmd.entries.forEach { (k, v) -> setRedis(k, v) }
             is BackCacheCommand.Remove -> {
                 commands.del(config.redisKey(cmd.key))
@@ -422,13 +423,31 @@ class ResilientLettuceSuspendNearCache<V: Any>(
         log.debug { "Redis back cache cleared for cacheName=${config.cacheName}" }
     }
 
+    private val redisTtlArgs: SetArgs? by lazy {
+        config.redisTtl?.let { SetArgs.Builder.ex(it) }
+    }
+
     private suspend fun setRedis(key: String, value: V) {
         val rKey = config.redisKey(key)
-        val ttl = config.redisTtl
-        if (ttl != null) {
-            commands.set(rKey, value, SetArgs.Builder.ex(ttl.seconds))
+
+        if (redisTtlArgs != null) {
+            commands.set(rKey, value, redisTtlArgs!!)
         } else {
             commands.set(rKey, value)
+        }
+    }
+
+    private val redisTtlExArgs: MSetExArgs? by lazy {
+        config.redisTtl?.let { MSetExArgs.Builder.ex(it) }
+    }
+
+    private suspend fun msetRedis(map: Map<String, V>) {
+        val rMap = map.map { config.redisKey(it.key) to it.value }.toMap()
+
+        if (redisTtlExArgs != null) {
+            commands.msetex(rMap, redisTtlExArgs!!)
+        } else {
+            commands.mset(rMap)
         }
     }
 }


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: bucket4j rate limiter hardening

- switch local/distributed rate limiters to ConsumptionProbe-based remaining-token calculation to avoid extra token lookups
- harden Redis proxy manager/provider contracts and expand Korean KDoc plus README guidance for public APIs
- add regression tests for probe usage, RateLimitResult factories, and Redisson client type validation

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary
- switch local/distributed rate limiters to ConsumptionProbe-based remaining-token calculation to avoid extra token lookups
- harden Redis proxy manager/provider contracts and expand Korean KDoc plus README guidance for public APIs
- add regression tests for probe usage, RateLimitResult factories, and Redisson client type validation

### Testing
- ./gradlew :bluetape4k-bucket4j:compileTestKotlin
- ./gradlew :bluetape4k-bucket4j:test

## Validation

- ./gradlew :bluetape4k-bucket4j:compileTestKotlin
- ./gradlew :bluetape4k-bucket4j:test

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #56, head `4af6ebac0d19687c2daadc875e19a00cb1c5613f`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/bucket4j-review`
- Labels: `enhancement`
- State: `MERGED`, merge commit `509110f657e18ddc87634fce92287006e75cd970`
- CI: - ./gradlew :bluetape4k-bucket4j:compileTestKotlin / - ./gradlew :bluetape4k-bucket4j:test

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #56 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `509110f657e18ddc87634fce92287006e75cd970`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
