### PR TITLE
fix: testcontainers 2.0.3 업그레이드 및 안정성 보강

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -192,7 +192,7 @@ object Versions {
     const val springmockk = "5.0.1"         // https://mvnrepository.com/artifact/com.ninja-squad/springmockk
     const val awaitility = "4.3.0"          // https://mvnrepository.com/artifact/org.awaitility/awaitility
     const val jmh = "1.37"                  // https://mvnrepository.com/artifact/org.openjdk.jmh/jmh-core
-    const val testcontainers = "1.21.4"     // https://mvnrepository.com/artifact/org.testcontainers/testcontainers
+    const val testcontainers = "2.0.3"      // https://mvnrepository.com/artifact/org.testcontainers/testcontainers
     const val jna = "5.18.1"                // https://mvnrepository.com/artifact/net.java.dev.jna/jna
     const val archunit = "1.4.1"            // https://mvnrepository.com/artifact/com.tngtech.archunit/archunit-junit5
     const val rest_assured = "5.5.7"        // https://mvnrepository.com/artifact/io.rest-assured/rest-assured
@@ -1382,53 +1382,59 @@ object Libs {
     // -------------------------------------------------------------------------------------------
     // Testcontainers
     //
-    fun testcontainers(module: String) = "org.testcontainers:$module:${Versions.testcontainers}"
+    private fun testcontainersCore(module: String) = "org.testcontainers:$module:${Versions.testcontainers}"
+    private fun testcontainersModule(module: String) = "org.testcontainers:testcontainers-$module:${Versions.testcontainers}"
 
-    val testcontainers_bom = testcontainers("testcontainers-bom")
-    val testcontainers = testcontainers("testcontainers")
-    val testcontainers_junit_jupiter = testcontainers("junit-jupiter")
-    val testcontainers_cassandra = testcontainers("cassandra")
-    val testcontainers_chromadb = testcontainers("chromadb")
-    val testcontainers_clickhouse = testcontainers("clickhouse")
-    val testcontainers_cockroachdb = testcontainers("cockroachdb")
-    val testcontainers_couchbase = testcontainers("couchbase")
-    val testcontainers_elasticsearch = testcontainers("elasticsearch")
-    val testcontainers_influxdb = testcontainers("influxdb")
-    val testcontainers_dynalite = testcontainers("dynalite")
-    val testcontainers_mariadb = testcontainers("mariadb")
-    val testcontainers_mongodb = testcontainers("mongodb")
-    val testcontainers_mysql = testcontainers("mysql")
-    val testcontaiiners_nginx = testcontainers("nginx")
-    val testcontainers_ollama = testcontainers("ollama")
-    val testcontainers_oracle_xe = testcontainers("oracle-xe")
-    val testcontainers_postgresql = testcontainers("postgresql")
-    val testcontainers_kafka = testcontainers("kafka")
-    val testcontainers_pulsar = testcontainers("pulsar")
-    val testcontainers_redpanda = testcontainers("redpanda")
-    val testcontainers_rabbitmq = testcontainers("rabbitmq")
-    val testcontainers_selenuim = testcontainers("selenuim")
-    val testcontainers_solace = testcontainers("solace")
-    val testcontainers_tidb = testcontainers("tidb")
-    val testcontainers_vault = testcontainers("vault")
+    val testcontainers_bom = testcontainersCore("testcontainers-bom")
+    val testcontainers = testcontainersCore("testcontainers")
+    val testcontainers_junit_jupiter = testcontainersModule("junit-jupiter")
+    val testcontainers_cassandra = testcontainersModule("cassandra")
+    val testcontainers_chromadb = testcontainersModule("chromadb")
+    val testcontainers_clickhouse = testcontainersModule("clickhouse")
+    val testcontainers_cockroachdb = testcontainersModule("cockroachdb")
+    val testcontainers_couchbase = testcontainersModule("couchbase")
+    val testcontainers_elasticsearch = testcontainersModule("elasticsearch")
+    val testcontainers_influxdb = testcontainersModule("influxdb")
+    val testcontainers_dynalite = testcontainersModule("dynalite")
+    val testcontainers_mariadb = testcontainersModule("mariadb")
+    val testcontainers_mongodb = testcontainersModule("mongodb")
+    val testcontainers_mysql = testcontainersModule("mysql")
+    val testcontaiiners_nginx = testcontainersModule("nginx")
+    val testcontainers_ollama = testcontainersModule("ollama")
+    val testcontainers_oracle_xe = testcontainersModule("oracle-xe")
+    val testcontainers_postgresql = testcontainersModule("postgresql")
+    val testcontainers_kafka = testcontainersModule("kafka")
+    val testcontainers_pulsar = testcontainersModule("pulsar")
+    val testcontainers_redpanda = testcontainersModule("redpanda")
+    val testcontainers_rabbitmq = testcontainersModule("rabbitmq")
+    val testcontainers_selenuim = testcontainersModule("selenuim")
+    val testcontainers_solace = testcontainersModule("solace")
+    @Deprecated(
+        message = "Testcontainers 2.x에서 TiDB 모듈이 제공되지 않아 deprecated 되었습니다.",
+        level = DeprecationLevel.WARNING
+    )
+    // NOTE: TiDB module은 2.0.3 좌표가 제공되지 않아 마지막 1.x 릴리스를 유지합니다.
+    val testcontainers_tidb = "org.testcontainers:tidb:1.21.4"
+    val testcontainers_vault = testcontainersModule("vault")
 
     // the Atlassian's LocalStack, 'a fully functional local AWS cloud stack'.
-    val testcontainers_localstack = testcontainers("localstack")
-    val testcontainers_mockserver = testcontainers("mockserver")
+    val testcontainers_localstack = testcontainersModule("localstack")
+    val testcontainers_mockserver = testcontainersModule("mockserver")
 
-    val testcontainers_nginx = testcontainers("nginx")
-    val testcontainers_r2dbc = testcontainers("r2dbc")
+    val testcontainers_nginx = testcontainersModule("nginx")
+    val testcontainers_r2dbc = testcontainersModule("r2dbc")
 
-    val testcontainers_gcloud = testcontainers("gcloud")
+    val testcontainers_gcloud = testcontainersModule("gcloud")
 
     // kubernetes
-    val testcontainers_k3s = testcontainers("k3s")
+    val testcontainers_k3s = testcontainersModule("k3s")
     const val fabric8_kubernetes_client_bom = "io.fabric8:kubernetes-client-bom:7.3.1" // https://mvnrepository.com/artifact/io.fabric8/kubernetes-client-bom
     const val fabric8_kubernetes_client = "io.fabric8:kubernetes-client:7.3.1"  // https://mvnrepository.com/artifact/io.fabric8/kubernetes-client
     const val kubernetes_client_java = "io.kubernetes:client-java:24.0.0"   // https://mvnrepository.com/artifact/io.kubernetes/client-java
 
     // Minio
     const val minio = "io.minio:minio:8.6.0" // https://mvnrepository.com/artifact/io.minio/minio
-    val testcontainers_minio = testcontainers("minio")
+    val testcontainers_minio = testcontainersModule("minio")
 
     // Milvus
     const val milvus_sdk_java = "io.milvus:milvus-sdk-java:2.6.13" // https://mvnrepository.com/artifact/io.milvus/milvus-sdk-java
@@ -1441,7 +1447,7 @@ object Libs {
     const val curator_framework = "org.apache.curator:curator-framework:5.9.0" // https://mvnrepository.com/artifact/org.apache.curator/curator-framework
 
     // Weaviate
-    val testcontainers_weaviate = testcontainers("weaviate")
+    val testcontainers_weaviate = testcontainersModule("weaviate")
     const val weaviate_client = "io.weaviate:client6:6.0.1"   // https://mvnrepository.com/artifact/io.weaviate/client6
 
     // Apple Silicon에서 testcontainers 를 사용하기 위해 참조해야 합니다.

--- a/testing/testcontainers/README.md
+++ b/testing/testcontainers/README.md
@@ -1,15 +1,22 @@
 # Module bluetape4k-testcontainers
 
-Testcontainers 기반 통합 테스트를 빠르게 구성하기 위한 서버 래퍼/유틸 라이브러리입니다.
+Testcontainers `2.0.3` 기반 통합 테스트를 빠르게 구성하기 위한 서버 래퍼/유틸 라이브러리입니다.
 
 ## 주요 기능
 
-- **DB 서버 지원**: MySQL, MariaDB, PostgreSQL, Cockroach, ClickHouse, TiDB
+- **DB 서버 지원**: MySQL, MariaDB, PostgreSQL, Cockroach, ClickHouse, TiDB(Deprecated)
 - **Storage 서버 지원**: Redis/Redis Cluster, MongoDB, Cassandra, Elastic/OpenSearch, MinIO
 - **MQ 서버 지원**: Kafka, RabbitMQ, Pulsar, Nats, Redpanda
 - **Infra 서버 지원**: Consul, Vault, Prometheus, Jaeger, Zipkin, ZooKeeper
 - **AWS LocalStack 지원**: S3, DynamoDB 등 로컬 테스트 환경 구성
 - **Container 유틸**: 공통 GenericServer/GenericContainer 확장
+
+## 최근 안정성 개선
+
+- `GenericContainer.exposeCustomPorts(...)`가 `hostConfig`가 비어 있는 경우에도 포트 바인딩을 생성하도록 보강되었습니다.
+- `GenericServer.writeToSystemProperties(...)`는 기본/추가 속성을 일관된 순서로 구성하여 일괄 등록합니다.
+- `KafkaServer.Launcher`의 문자열 producer/consumer 생성 시 serializer/deserializer 인스턴스를 호출마다 새로 생성해 `close()` 이후 재사용 이슈를 방지합니다.
+- `TiDBServer`는 Testcontainers 2.x 미지원으로 deprecated 처리되었으며, 신규 테스트에서는 `GenericContainer` 또는 `MySQL8Server` 사용을 권장합니다.
 
 ## 직접 Testcontainers 사용 대비 추가 기능
 

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/GenericContainerExtensions.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/GenericContainerExtensions.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.testcontainers
 
 import com.github.dockerjava.api.model.ExposedPort
+import com.github.dockerjava.api.model.HostConfig
 import com.github.dockerjava.api.model.PortBinding
 import com.github.dockerjava.api.model.Ports
 import org.testcontainers.containers.GenericContainer
@@ -18,7 +19,8 @@ internal fun resolvePortBindings(ports: Iterable<Int>): List<PortBinding> {
  * ## 동작/계약
  * - 전달한 포트와 컨테이너 기존 exposed port를 합쳐 중복 제거 후 바인딩합니다.
  * - 포트 값이 0 이하이면 [IllegalArgumentException]이 발생합니다.
- * - 컨테이너 설정(hostConfig)에 포트 바인딩을 추가하며, 컨테이너 시작 전 호출을 권장합니다.
+ * - 컨테이너 설정(hostConfig)에 포트 바인딩을 추가하며, hostConfig가 비어 있으면 새로 생성해 적용합니다.
+ * - 컨테이너 시작 전 호출을 권장합니다.
  *
  * ```kotlin
  * val container = GenericContainer("redis:7").withExposedPorts(6379)
@@ -33,7 +35,9 @@ fun <T: GenericContainer<T>> GenericContainer<T>.exposeCustomPorts(vararg expose
     val bindings = resolvePortBindings(exposedPorts.asIterable() + this.exposedPorts)
     if (bindings.isNotEmpty()) {
         withCreateContainerCmdModifier { cmd ->
-            cmd.hostConfig?.withPortBindings(bindings)
+            val hostConfig = cmd.hostConfig ?: HostConfig.newHostConfig()
+            hostConfig.withPortBindings(bindings)
+            cmd.withHostConfig(hostConfig)
         }
     }
 }
@@ -46,6 +50,7 @@ fun <T: GenericContainer<T>> GenericContainer<T>.exposeCustomPorts(vararg expose
  * - [Array] 오버로드로 전달된 포트를 기존 exposed port와 합쳐 바인딩합니다.
  * - 포트 값 검증/중복 제거 규칙은 vararg 버전과 동일합니다.
  * - 수신 컨테이너 설정을 변경하며 새 컨테이너를 생성하지 않습니다.
+ * - hostConfig가 비어 있으면 내부에서 생성하여 포트 바인딩을 보장합니다.
  *
  * ```kotlin
  * val ports = arrayOf(5432, 8080)
@@ -61,7 +66,9 @@ fun <T: GenericContainer<T>> GenericContainer<T>.exposeCustomPorts(exposedPorts:
     val bindings = resolvePortBindings(exposedPorts.asIterable() + this.exposedPorts)
     if (bindings.isNotEmpty()) {
         withCreateContainerCmdModifier { cmd ->
-            cmd.hostConfig?.withPortBindings(bindings)
+            val hostConfig = cmd.hostConfig ?: HostConfig.newHostConfig()
+            hostConfig.withPortBindings(bindings)
+            cmd.withHostConfig(hostConfig)
         }
     }
 }

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/GenericServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/GenericServer.kt
@@ -36,6 +36,7 @@ internal const val SERVER_PREFIX = "testcontainers"
  * - `name`이 blank이면 [IllegalArgumentException]이 발생합니다.
  * - `${testcontainers.$name.host|port|url}` 기본 속성을 항상 기록합니다.
  * - `extraProps`의 null 값은 무시하고 non-null 값만 문자열로 기록합니다.
+ * - 속성은 계산된 스냅샷을 기준으로 순서 있게 일괄 적용됩니다.
  * - JVM 전역 System Property를 변경하므로 테스트 종료 후 정리가 필요할 수 있습니다.
  *
  * ```kotlin
@@ -47,28 +48,23 @@ fun <T: GenericServer> T.writeToSystemProperties(name: String, extraProps: Map<S
     require(name.isNotBlank()) { "Server name must not be blank." }
     log.info { "Setup Server properties ..." }
 
-    System.setProperty("$SERVER_PREFIX.$name.host", this.host)
-    System.setProperty("$SERVER_PREFIX.$name.port", this.port.toString())
-    System.setProperty("$SERVER_PREFIX.$name.url", this.url)
-
+    val baseKey = "$SERVER_PREFIX.$name"
+    val properties = linkedMapOf(
+        "$baseKey.host" to host,
+        "$baseKey.port" to port.toString(),
+        "$baseKey.url" to url,
+    )
     extraProps.forEach { (key, value) ->
-        value?.run {
-            System.setProperty("$SERVER_PREFIX.$name.$key", this.toString())
-        }
+        value?.let { properties["$baseKey.$key"] = it.toString() }
     }
+    properties.forEach { (key, value) -> System.setProperty(key, value) }
 
     log.info {
         buildString {
             appendLine()
             appendLine("Start $name Server:")
-            appendLine("\t$SERVER_PREFIX.$name.host=$host")
-            appendLine("\t$SERVER_PREFIX.$name.port=$port")
-            appendLine("\t$SERVER_PREFIX.$name.url=$url")
-
-            extraProps.forEach { (key, value) ->
-                value?.let {
-                    appendLine("\t$SERVER_PREFIX.$name.$key=$it")
-                }
+            properties.forEach { (key, value) ->
+                appendLine("\t$key=$value")
             }
         }
     }

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/TiDBServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/TiDBServer.kt
@@ -12,9 +12,17 @@ import org.testcontainers.utility.DockerImageName
  * 분산형 RDBMS인 PingCAP 의 [TiDB](https://www.pingcap.com/tidb/) 테스트용으로 사용할 수 있는 컨테이너를 제공한다.
  * MySQL과 호환됩니다.
  *
+ * @deprecated Testcontainers 2.x에서 TiDB 모듈이 제공되지 않아 유지보수 대상에서 제외되었습니다.
+ * 대체가 필요하면 `GenericContainer`로 직접 구성하거나, MySQL 호환 테스트는 [MySQL8Server] 사용을 권장합니다.
+ *
  * - 참고: [TiDB](https://www.pingcap.com/tidb/)
  * - 참고: [TiDB Docker](https://hub.docker.com/r/pingcap/tidb)
  */
+@Deprecated(
+    message = "Testcontainers 2.x에서 TiDB 모듈이 제공되지 않아 deprecated 되었습니다. GenericContainer 또는 MySQL8Server 사용을 권장합니다.",
+    replaceWith = ReplaceWith("MySQL8Server(useDefaultPort, reuse)"),
+    level = DeprecationLevel.WARNING
+)
 class TiDBServer private constructor(
     imageName: DockerImageName,
     useDefaultPort: Boolean,

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/HttpbinHttp2Server.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/HttpbinHttp2Server.kt
@@ -15,7 +15,8 @@ import java.time.Duration
  * HTTP/2(h2c) 지원 `httpbin` API를 로컬 Docker 컨테이너로 실행하는 테스트 서버입니다.
  *
  * ## 동작/계약
- * - `Wait.forHttp("/get")` 대기 전략으로 상태 코드 `200`이 반환될 때까지(최대 2분) 시작을 기다립니다.
+ * - HTTP 체크 대신 리스닝 포트 준비 상태를 기준으로(최대 2분) 시작을 기다립니다.
+ *   h2c 환경에서 HTTP/1.x 헬스체크가 502를 반환하는 경우를 피하기 위한 선택입니다.
  * - `useDefaultPort=true`이면 `8000` 포트를 호스트에 고정 바인딩하려고 시도하고, 아니면 동적 포트를 사용합니다.
  * - 인스턴스 생성만으로는 컨테이너가 시작되지 않으며, `start()` 호출이 필요합니다.
  *
@@ -104,9 +105,7 @@ class HttpbinHttp2Server private constructor(
         withExposedPorts(PORT)
         withReuse(reuse)
         waitingFor(
-            Wait.forHttp("/get")
-                .forPort(PORT)
-                .forStatusCode(200)
+            Wait.forListeningPort()
                 .withStartupTimeout(Duration.ofMinutes(2))
         )
 

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/KafkaServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/KafkaServer.kt
@@ -155,24 +155,29 @@ class KafkaServer private constructor(
             }
         }
 
-        private val stringSerializer by lazy { StringSerializer() }
-        private val stringDeserializer by lazy { StringDeserializer() }
-
         /**
          * [KafkaProducer] 를 생성하기 위한 properties 를 반환합니다.
+         *
+         * ## 동작/계약
+         * - 매 호출마다 새로운 [MutableMap] 인스턴스를 생성합니다.
+         * - `CLIENT_ID_CONFIG`는 호출 단위로 고유한 값이 생성됩니다.
          */
         fun getProducerProperties(kafkaServer: KafkaServer = kafka): MutableMap<String, Any?> {
             return mutableMapOf(
                 ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to kafkaServer.bootstrapServers,
                 ProducerConfig.CLIENT_ID_CONFIG to UUID.randomUUID().encodeBase62(),
                 ProducerConfig.COMPRESSION_TYPE_CONFIG to "lz4",
-                ProducerConfig.LINGER_MS_CONFIG to "0",
-                ProducerConfig.BATCH_SIZE_CONFIG to "1"
+                ProducerConfig.LINGER_MS_CONFIG to 0,
+                ProducerConfig.BATCH_SIZE_CONFIG to 1
             )
         }
 
         /**
          * [KafkaConsumer] 를 생성하기 위한 properties 를 반환합니다.
+         *
+         * ## 동작/계약
+         * - 매 호출마다 새로운 [MutableMap] 인스턴스를 생성합니다.
+         * - `GROUP_ID_CONFIG`, `CLIENT_ID_CONFIG`는 호출 단위로 고유한 값이 생성됩니다.
          */
         fun getConsumerProperties(kafkaServer: KafkaServer = kafka): MutableMap<String, Any?> {
             return mutableMapOf(
@@ -185,22 +190,41 @@ class KafkaServer private constructor(
             )
         }
 
+        /**
+         * 문자열 key/value 전용 [KafkaProducer] 인스턴스를 생성합니다.
+         *
+         * ## 동작/계약
+         * - 호출마다 새로운 producer/serializer 인스턴스를 생성합니다.
+         * - 직렬화기 인스턴스를 공유하지 않아 `close()` 이후 재사용 문제를 방지합니다.
+         */
         fun createStringProducer(kafkaServer: KafkaServer = kafka): KafkaProducer<String, String> {
             val props = getProducerProperties(kafkaServer)
-            return KafkaProducer(props, stringSerializer, stringSerializer)
+            return KafkaProducer(props, StringSerializer(), StringSerializer())
         }
 
+        /**
+         * 문자열 key/value 전용 [KafkaConsumer] 인스턴스를 생성합니다.
+         *
+         * ## 동작/계약
+         * - 호출마다 새로운 consumer/deserializer 인스턴스를 생성합니다.
+         * - 역직렬화기 인스턴스를 공유하지 않아 `close()` 이후 재사용 문제를 방지합니다.
+         */
         fun createStringConsumer(kafkaServer: KafkaServer = kafka): KafkaConsumer<String, String> {
             val props = getConsumerProperties(kafkaServer)
-            return KafkaConsumer(props, stringDeserializer, stringDeserializer)
+            return KafkaConsumer(props, StringDeserializer(), StringDeserializer())
         }
 
-
+        /**
+         * 바이너리 key/value 전용 [KafkaProducer] 인스턴스를 생성합니다.
+         */
         fun createBinaryProducer(kafkaServer: KafkaServer = kafka): KafkaProducer<ByteArray?, ByteArray?> {
             val props = getProducerProperties(kafkaServer)
             return KafkaProducer(props, ByteArraySerializer(), ByteArraySerializer())
         }
 
+        /**
+         * 바이너리 key/value 전용 [KafkaConsumer] 인스턴스를 생성합니다.
+         */
         fun createBinaryConsumer(kafkaServer: KafkaServer = kafka): KafkaConsumer<ByteArray?, ByteArray?> {
             val props = getConsumerProperties(kafkaServer)
             return KafkaConsumer(props, ByteArrayDeserializer(), ByteArrayDeserializer())

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/GenericContainerExtensionsSupportTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/GenericContainerExtensionsSupportTest.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.testcontainers
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class GenericContainerExtensionsSupportTest {
 
@@ -20,5 +21,21 @@ class GenericContainerExtensionsSupportTest {
         assertFailsWith<IllegalArgumentException> {
             resolvePortBindings(listOf(0, 8080))
         }
+    }
+
+    @Test
+    fun `resolvePortBindings 는 빈 입력이면 빈 바인딩을 반환한다`() {
+        val bindings = resolvePortBindings(emptyList())
+        assertTrue(bindings.isEmpty())
+    }
+
+    @Test
+    fun `resolvePortBindings 는 첫 등장 순서를 유지하며 중복을 제거한다`() {
+        val bindings = resolvePortBindings(listOf(9092, 8080, 9092, 8080, 19092))
+
+        assertEquals(3, bindings.size)
+        assertEquals("9092", bindings[0].binding.hostPortSpec)
+        assertEquals("8080", bindings[1].binding.hostPortSpec)
+        assertEquals("19092", bindings[2].binding.hostPortSpec)
     }
 }

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/GenericServerSupportTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/GenericServerSupportTest.kt
@@ -16,6 +16,7 @@ class GenericServerSupportTest {
         System.clearProperty("testcontainers.redis.port")
         System.clearProperty("testcontainers.redis.url")
         System.clearProperty("testcontainers.redis.ssl")
+        System.clearProperty("testcontainers.redis.timeoutMs")
         System.clearProperty("testcontainers.redis.nullable")
     }
 
@@ -34,6 +35,25 @@ class GenericServerSupportTest {
         assertEquals("127.0.0.1:6379", System.getProperty("testcontainers.redis.url"))
         assertEquals("true", System.getProperty("testcontainers.redis.ssl"))
         assertNull(System.getProperty("testcontainers.redis.nullable"))
+    }
+
+    @Test
+    fun `writeToSystemProperties 는 기존 값을 덮어쓰고 숫자 extra 속성을 문자열로 기록한다`() {
+        System.setProperty("testcontainers.redis.host", "old-host")
+        System.setProperty("testcontainers.redis.port", "1")
+
+        val server = mockk<GenericServer>(relaxed = true) {
+            every { host } returns "10.0.0.15"
+            every { port } returns 16379
+            every { url } returns "10.0.0.15:16379"
+        }
+
+        server.writeToSystemProperties("redis", mapOf("timeoutMs" to 1500))
+
+        assertEquals("10.0.0.15", System.getProperty("testcontainers.redis.host"))
+        assertEquals("16379", System.getProperty("testcontainers.redis.port"))
+        assertEquals("10.0.0.15:16379", System.getProperty("testcontainers.redis.url"))
+        assertEquals("1500", System.getProperty("testcontainers.redis.timeoutMs"))
     }
 
     @Test

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/http/HttpbinHttp2ServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/http/HttpbinHttp2ServerTest.kt
@@ -6,10 +6,12 @@ import io.bluetape4k.testcontainers.AbstractContainerTest
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.Request
+import org.awaitility.kotlin.await
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldContain
 import org.junit.jupiter.api.Test
+import java.time.Duration
 import kotlin.test.assertFailsWith
 
 class HttpbinHttp2ServerTest: AbstractContainerTest() {
@@ -49,18 +51,26 @@ class HttpbinHttp2ServerTest: AbstractContainerTest() {
             .protocols(listOf(Protocol.H2_PRIOR_KNOWLEDGE))
             .build()
 
-        val request = Request.Builder()
-            .get()
-            .url("${httpbin.url}/get")
-            .build()
+        await.atMost(Duration.ofSeconds(20))
+            .pollInterval(Duration.ofMillis(300))
+            .ignoreExceptions()
+            .untilAsserted {
+                val request = Request.Builder()
+                    .get()
+                    .url("${httpbin.url}/get")
+                    .build()
 
-        client.newCall(request).execute().use { response ->
-            val body = response.body.string()
-            log.debug { "protocol=${response.protocol}, code=${response.code}, response=$body" }
+                client.newCall(request).execute().use { response ->
+                    val body = response.body.string()
+                    log.debug { "protocol=${response.protocol}, code=${response.code}, response=$body" }
 
-            response.isSuccessful.shouldBeTrue()
-            (response.protocol == Protocol.H2_PRIOR_KNOWLEDGE || response.protocol == Protocol.HTTP_2).shouldBeTrue()
-            body shouldContain "url"
-        }
+                    response.isSuccessful.shouldBeTrue()
+                    (response.protocol == Protocol.H2_PRIOR_KNOWLEDGE || response.protocol == Protocol.HTTP_2).shouldBeTrue()
+                    body shouldContain "url"
+                }
+            }
+        client.dispatcher.executorService.shutdown()
+        client.connectionPool.evictAll()
+        client.cache?.close()
     }
 }

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/ElasticsearchOssServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/ElasticsearchOssServerTest.kt
@@ -7,6 +7,7 @@ import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.ResourceLock
 import org.springframework.data.elasticsearch.client.ClientConfiguration
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchClients
 import kotlin.test.assertFailsWith
@@ -30,6 +31,7 @@ class ElasticsearchOssServerTest: AbstractContainerTest() {
     }
 
     @Nested
+    @ResourceLock("elasticsearch-default-port")
     inner class UseDefaultPort {
         @Test
         fun `Elasticsearch OSS 서버를 기본 포트를 사용하여 실행하기`() {

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/ElasticsearchServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/ElasticsearchServerTest.kt
@@ -6,6 +6,7 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.ResourceLock
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchClients
 import kotlin.test.assertFailsWith
 
@@ -40,6 +41,7 @@ class ElasticsearchServerTest: AbstractContainerTest() {
     }
 
     @Nested
+    @ResourceLock("elasticsearch-default-port")
     inner class UseDefaultPort {
         @Test
         fun `launch elasticsearch with default port`() {


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: testcontainers 2.0.3 업그레이드 및 안정성 보강

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- `Libs.testcontainers`를 `1.21.4`에서 `2.0.3`으로 상향
- Testcontainers 2.x 모듈 좌표(`org.testcontainers:testcontainers-*`) 체계로 정리
- `TiDBServer` 및 `Libs.testcontainers_tidb`를 deprecated 처리하고 TiDB 의존성은 `1.21.4` 고정
- `GenericServer.writeToSystemProperties`를 일괄 스냅샷 기록 방식으로 안정화
- `GenericContainer.exposeCustomPorts`에서 hostConfig null 케이스를 안전 처리
- `KafkaServer.Launcher`의 문자열 serializer/deserializer 재사용 제거로 close 이후 재사용 이슈 방지
- `HttpbinHttp2Server` 대기 전략을 포트 리스닝 기반으로 변경
- `HttpbinHttp2ServerTest`에 재시도 기반 검증을 추가해 arm64 에뮬레이션 502 초기 응답에 대한 회귀 안정성 보강
- Elasticsearch 기본 포트 테스트 2건에 `ResourceLock`을 적용해 9200 포트 충돌 제거
- public API KDoc(한글) 및 `testing/testcontainers/README.md` 최신화

## Validation

- `./bin/repo-test-summary -- ./gradlew :bluetape4k-testcontainers:test --tests "*HttpbinHttp2ServerTest"`
- `./bin/repo-test-summary -- ./gradlew :bluetape4k-testcontainers:test --tests "*ElasticsearchServerTest" --tests "*ElasticsearchOssServerTest" --tests "*HttpbinHttp2ServerTest"`
- `./bin/repo-test-summary -- ./gradlew :bluetape4k-testcontainers:test`

전체 결과: 182 passing, 1 pending, 0 failing

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #62, head `1aaf71309100ec85797a8b8f6bc3b74044c6db92`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/testcontainers-2.0.3-upgrade`
- Labels: `enhancement`
- State: `MERGED`, merge commit `a8c955bbd8d6f04d060dba60d79a6f302ee236c3`
- CI: - `./bin/repo-test-summary -- ./gradlew :bluetape4k-testcontainers:test --tests "*HttpbinHttp2ServerTest"` / - `./bin/repo-test-summary -- ./gradlew :bluetape4k-testcontainers:test --tests "*ElasticsearchServerTest" --tests "*ElasticsearchOssServerTest" --tests "*HttpbinHttp2ServerTest"` / - `./bin/repo-test-summary -- ./gradlew :bluetape4k-testcontainers:test`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #62 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `a8c955bbd8d6f04d060dba60d79a6f302ee236c3`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
