### PR TITLE
fix: redis memorizer 동시성 안정성 보강

### DIFF
--- a/infra/redis/README.md
+++ b/infra/redis/README.md
@@ -12,6 +12,7 @@ Kotlin Coroutines 환경에서의 사용을 위한 확장 함수와 유틸리티
 - **Coroutines 통합**: `suspend` 함수 및 Flow 지원
 - **코덱 지원**: LZ4, GZip, Zstd, Fory, Protobuf 등 다양한 압축/직렬화 코덱
 - **Spring 통합**: Spring Data Redis Serializer 지원
+- **메모라이저 안정성 강화**: 동일 키 동시 요청 시 in-flight 연산 공유로 중복 계산 완화
 
 ## 의존성
 
@@ -163,6 +164,23 @@ val nearCache = RedissonNearCache(redisson, "near-cache") {
 }
 ```
 
+### 5-1. Redisson Memorizer 동시성 보장
+
+`RedissonMemorizer` / `RedissonSuspendMemorizer` / `AsyncRedissonMemorizer`는
+같은 JVM에서 동일 키가 동시에 요청될 때 in-flight 연산을 공유합니다.
+이를 통해 고비용 evaluator의 중복 실행을 줄여 성능과 안정성을 높입니다.
+
+```kotlin
+val map = redisson.getMap<Int, Int>("memo")
+val memo = map.memorizer { key ->
+    Thread.sleep(100) // 비용이 큰 연산
+    key * key
+}
+
+// 동시에 같은 key=7 요청이 들어와도 evaluator는 1회만 실행
+val result = memo(7) // 49
+```
+
 ### 6. Redisson 리더 선출 (Leader Election)
 
 #### 단일 리더 선출 — 동시에 1개만 실행
@@ -218,6 +236,14 @@ val result = groupElection.runIfLeader("batch-job") {
 }
 
 // 상태 조회
+
+## 테스트
+
+모듈 단위 회귀 테스트는 아래처럼 실행할 수 있습니다.
+
+```bash
+./gradlew :infra:redis:test
+```
 val state = groupElection.state("batch-job")
 println("활성 리더: ${state.activeCount} / ${state.maxLeaders}")
 println("남은 슬롯: ${state.availableSlots}, 가득 참: ${state.isFull}")

--- a/infra/redis/src/main/kotlin/io/bluetape4k/redis/redisson/coroutines/RedissonClientCoroutine.kt
+++ b/infra/redis/src/main/kotlin/io/bluetape4k/redis/redisson/coroutines/RedissonClientCoroutine.kt
@@ -1,8 +1,8 @@
 package io.bluetape4k.redis.redisson.coroutines
 
 import io.bluetape4k.LibraryName
-import io.bluetape4k.coroutines.support.awaitSuspending
 import io.bluetape4k.support.requireNotBlank
+import kotlinx.coroutines.future.await
 import org.redisson.api.BatchOptions
 import org.redisson.api.BatchResult
 import org.redisson.api.RBatch
@@ -17,7 +17,7 @@ suspend inline fun RedissonClient.withSuspendedBatch(
     options: BatchOptions = BatchOptions.defaults(),
     action: RBatch.() -> Unit,
 ): BatchResult<*> =
-    createBatch(options).apply(action).executeAsync().awaitSuspending()
+    createBatch(options).apply(action).executeAsync().await()
 
 /**
  * Redisson 작업을 Coroutines 환경에서 Transaction model 에서 실행하도록 합니다.
@@ -29,9 +29,9 @@ suspend inline fun RedissonClient.withSuspendedTransaction(
     val tx: RTransaction = createTransaction(options)
     try {
         action(tx)
-        tx.commitAsync().awaitSuspending()
+        tx.commitAsync().await()
     } catch (e: Throwable) {
-        runCatching { tx.rollbackAsync().awaitSuspending() }
+        runCatching { tx.rollbackAsync().await() }
         throw e
     }
 }

--- a/infra/redis/src/main/kotlin/io/bluetape4k/redis/redisson/leader/RedissonLeaderGroupElection.kt
+++ b/infra/redis/src/main/kotlin/io/bluetape4k/redis/redisson/leader/RedissonLeaderGroupElection.kt
@@ -20,11 +20,11 @@ import java.util.concurrent.Executor
  * - `lockName`별로 Redis 분산 `RSemaphore(maxLeaders)`를 생성하여 동시 실행 수를 제한합니다.
  * - 슬롯이 가득 찬 경우 [RedissonLeaderElectionOptions.waitTime] 내에 슬롯을 획득하지 못하면
  *   [RedisException]을 던집니다.
- * - 슬롯 획득 성공 시 [action]을 실행하고, 완료(또는 예외) 후 반드시 슬롯을 반납합니다.
+ * - 슬롯 획득 성공 시 `action`을 실행하고, 완료(또는 예외) 후 반드시 슬롯을 반납합니다.
  * - 여러 JVM 프로세스에 걸친 분산 동시 실행 제한에 적합합니다.
  *
- * ## [LocalLeaderGroupElection] 과의 차이
- * - [LocalLeaderGroupElection]은 단일 JVM 내 `java.util.concurrent.Semaphore`를 사용합니다.
+ * ## [io.bluetape4k.leader.local.LocalLeaderGroupElection] 과의 차이
+ * - [io.bluetape4k.leader.local.LocalLeaderGroupElection]은 단일 JVM 내 `java.util.concurrent.Semaphore`를 사용합니다.
  * - 이 구현체는 Redis 기반 `RSemaphore`를 사용하므로 여러 프로세스에서 동작합니다.
  *
  * ```kotlin
@@ -48,9 +48,9 @@ class RedissonLeaderGroupElection private constructor(
     private val redissonClient: RedissonClient,
     override val maxLeaders: Int,
     options: RedissonLeaderElectionOptions,
-) : LeaderGroupElection {
+): LeaderGroupElection {
 
-    companion object : KLogging() {
+    companion object: KLogging() {
         /**
          * [RedissonLeaderGroupElection] 인스턴스를 생성합니다.
          *
@@ -138,6 +138,9 @@ class RedissonLeaderGroupElection private constructor(
 
     /**
      * [lockName]의 분산 [RSemaphore] 슬롯을 [executor]에서 획득하고 비동기 [action]을 실행합니다.
+     *
+     * - 슬롯이 가득 찬 경우 [waitTime] 내 슬롯을 획득하지 못하면 [RedisException]을 던집니다.
+     * - [action] 예외 발생 시에도 슬롯은 반드시 반환됩니다.
      *
      * @param lockName 리더 그룹 선출에 사용할 락 이름
      * @param executor 비동기 실행에 사용할 [Executor]

--- a/infra/redis/src/main/kotlin/io/bluetape4k/redis/redisson/leader/coroutines/RedissonSuspendLeaderElection.kt
+++ b/infra/redis/src/main/kotlin/io/bluetape4k/redis/redisson/leader/coroutines/RedissonSuspendLeaderElection.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.logging.warn
 import io.bluetape4k.redis.redisson.coroutines.getLockId
 import io.bluetape4k.redis.redisson.leader.RedissonLeaderElectionOptions
 import io.bluetape4k.support.requireNotBlank
+import kotlinx.coroutines.future.await
 import org.redisson.api.RLock
 import org.redisson.api.RedissonClient
 import org.redisson.client.RedisException
@@ -80,7 +81,7 @@ class RedissonSuspendLeaderElection private constructor(
                     return action()
                 } finally {
                     if (lock.isHeldByThread(lockId)) {
-                        lock.unlockAsync(lockId).awaitSuspending()
+                        lock.unlockAsync(lockId).await()
                         log.debug { "작업이 완료되어 Leader 권한을 반납했습니다. lock=$lockName, lockId=$lockId" }
                     }
                 }

--- a/infra/redis/src/main/kotlin/io/bluetape4k/redis/redisson/leader/coroutines/RedissonSuspendLeaderGroupElection.kt
+++ b/infra/redis/src/main/kotlin/io/bluetape4k/redis/redisson/leader/coroutines/RedissonSuspendLeaderGroupElection.kt
@@ -1,6 +1,5 @@
 package io.bluetape4k.redis.redisson.leader.coroutines
 
-import io.bluetape4k.coroutines.support.awaitSuspending
 import io.bluetape4k.leader.LeaderGroupState
 import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElection
 import io.bluetape4k.logging.coroutines.KLoggingChannel
@@ -8,6 +7,7 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import io.bluetape4k.redis.redisson.leader.RedissonLeaderElectionOptions
 import io.bluetape4k.support.requireNotBlank
+import kotlinx.coroutines.future.await
 import org.redisson.api.RSemaphore
 import org.redisson.api.RedissonClient
 import org.redisson.client.RedisException
@@ -21,12 +21,12 @@ import java.time.Duration
  * - 슬롯이 가득 찬 경우 [RedissonLeaderElectionOptions.waitTime] 내에 슬롯을 획득하지 못하면
  *   [RedisException]을 던집니다.
  * - `tryAcquireAsync`/`releaseAsync`를 사용하여 호출 코루틴을 블로킹하지 않습니다.
- * - [action] 예외 발생 시에도 슬롯은 반드시 반환됩니다.
+ * - `action` 예외 발생 시에도 슬롯은 반드시 반환됩니다.
  * - 여러 JVM 프로세스에 걸친 분산 동시 실행 제한에 적합합니다.
  *
- * ## [RedissonLeaderGroupElection] 과의 차이
- * - [RedissonLeaderGroupElection]은 스레드를 블로킹합니다.
- * - 이 구현체는 `awaitSuspending()`으로 코루틴을 suspend합니다.
+ * ## [io.bluetape4k.redis.redisson.leader.RedissonLeaderGroupElection] 과의 차이
+ * - [io.bluetape4k.redis.redisson.leader.RedissonLeaderGroupElection]은 스레드를 블로킹합니다.
+ * - 이 구현체는 `awit()`으로 코루틴을 suspend합니다.
  *
  * ```kotlin
  * val election = RedissonSuspendLeaderGroupElection(redissonClient, maxLeaders = 3)
@@ -46,9 +46,9 @@ class RedissonSuspendLeaderGroupElection private constructor(
     private val redissonClient: RedissonClient,
     override val maxLeaders: Int,
     options: RedissonLeaderElectionOptions,
-) : SuspendLeaderGroupElection {
+): SuspendLeaderGroupElection {
 
-    companion object : KLoggingChannel() {
+    companion object: KLoggingChannel() {
         /**
          * [RedissonSuspendLeaderGroupElection] 인스턴스를 생성합니다.
          *
@@ -81,7 +81,7 @@ class RedissonSuspendLeaderGroupElection private constructor(
     private suspend fun getInitializedSemaphoreAsync(lockName: String): RSemaphore {
         lockName.requireNotBlank("lockName")
         val semaphore = redissonClient.getSemaphore(lockName)
-        semaphore.trySetPermitsAsync(maxLeaders).awaitSuspending()
+        semaphore.trySetPermitsAsync(maxLeaders).await()
         return semaphore
     }
 
@@ -108,7 +108,7 @@ class RedissonSuspendLeaderGroupElection private constructor(
     /**
      * [lockName]의 분산 [RSemaphore] 슬롯을 비동기로 획득하고 suspend [action]을 실행합니다.
      *
-     * - 슬롯이 가득 찬 경우 [waitTimeMillis] 내 슬롯을 획득하지 못하면 [RedisException]을 던집니다.
+     * - 슬롯이 가득 찬 경우 [waitTime] 내 슬롯을 획득하지 못하면 [RedisException]을 던집니다.
      * - [action] 예외 발생 시에도 슬롯은 반드시 반환됩니다.
      *
      * @param lockName 리더 그룹 선출에 사용할 락 이름
@@ -123,7 +123,7 @@ class RedissonSuspendLeaderGroupElection private constructor(
         log.debug { "리더 그룹 슬롯 획득을 요청합니다. lockName=$lockName, maxLeaders=$maxLeaders" }
 
         val acquired = try {
-            semaphore.tryAcquireAsync(waitTime).awaitSuspending()
+            semaphore.tryAcquireAsync(waitTime).await()
         } catch (e: InterruptedException) {
             Thread.currentThread().interrupt()
             log.warn(e) { "슬롯 획득 대기 중 인터럽트가 발생했습니다. lockName=$lockName" }
@@ -138,7 +138,7 @@ class RedissonSuspendLeaderGroupElection private constructor(
         try {
             return action()
         } finally {
-            semaphore.releaseAsync().awaitSuspending()
+            semaphore.releaseAsync().await()
             log.debug { "작업이 완료되어 슬롯을 반납했습니다. lockName=$lockName" }
         }
     }

--- a/infra/redis/src/main/kotlin/io/bluetape4k/redis/redisson/memorizer/RedissonMemorizer.kt
+++ b/infra/redis/src/main/kotlin/io/bluetape4k/redis/redisson/memorizer/RedissonMemorizer.kt
@@ -4,6 +4,8 @@ import io.bluetape4k.cache.memorizer.Memorizer
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import org.redisson.api.RMap
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * [evaluator]가 실행한 결과를 Redis 에 저장하고, 재 실행 시에 빠르게 응답할 수 있도록 합니다.
@@ -45,6 +47,7 @@ fun <T: Any, R: Any> ((T) -> R).memorizer(map: RMap<T, R>): RedissonMemorizer<T,
 
 /**
  * [evaluator]가 실행한 결과를 [map]에 저장하고, 재 실행 시에 빠르게 응답할 수 있도록 합니다.
+ * 같은 JVM에서 동일 키가 동시에 요청되면 in-flight 연산을 공유하여 [evaluator]의 중복 실행을 줄입니다.
  *
  * ```
  * val map: RMap<Int, Int> = redisson.getMap("map")
@@ -63,8 +66,34 @@ class RedissonMemorizer<T: Any, R: Any>(
 
     companion object: KLogging()
 
+    private val inFlight = ConcurrentHashMap<T, CompletableFuture<R>>()
+
     override fun invoke(key: T): R {
-        return map.getOrPut(key) { evaluator(key) }
+        inFlight[key]?.let { return it.join() }
+
+        val promise = CompletableFuture<R>()
+        val existing = inFlight.putIfAbsent(key, promise)
+        if (existing != null) {
+            return existing.join()
+        }
+
+        try {
+            val cached = map.get(key)
+            if (cached != null) {
+                promise.complete(cached)
+                return cached
+            }
+
+            val evaluated = evaluator(key)
+            val winner = map.putIfAbsent(key, evaluated) ?: evaluated
+            promise.complete(winner)
+            return winner
+        } catch (e: Throwable) {
+            promise.completeExceptionally(e)
+            throw e
+        } finally {
+            inFlight.remove(key, promise)
+        }
     }
 
     override fun clear() {

--- a/infra/redis/src/main/kotlin/io/bluetape4k/redis/redisson/memorizer/RedissonSuspendMemorizer.kt
+++ b/infra/redis/src/main/kotlin/io/bluetape4k/redis/redisson/memorizer/RedissonSuspendMemorizer.kt
@@ -4,7 +4,10 @@ import io.bluetape4k.cache.memorizer.SuspendMemorizer
 import io.bluetape4k.coroutines.support.awaitSuspending
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
 import org.redisson.api.RMap
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * [evaluator]가 실행한 결과를 Redis 에 저장하고, 재 실행 시에 빠르게 응답할 수 있도록 합니다.
@@ -46,6 +49,7 @@ fun <T: Any, R: Any> (suspend (T) -> R).memorizer(map: RMap<T, R>): RedissonSusp
 
 /**
  * [evaluator]가 실행한 결과를 [map]에 저장하고, 재 실행 시에 빠르게 응답할 수 있도록 합니다.
+ * 같은 JVM에서 동일 키가 동시에 요청되면 in-flight 연산을 공유하여 [evaluator]의 중복 실행을 줄입니다.
  *
  * ```
  * val map: RMap<Int, Int> = redisson.getMap("map")
@@ -64,8 +68,34 @@ class RedissonSuspendMemorizer<T: Any, R: Any>(
 
     companion object: KLogging()
 
+    private val inFlight = ConcurrentHashMap<T, Deferred<R>>()
+
     override suspend fun invoke(key: T): R {
-        return map.getOrPut(key) { evaluator(key) }
+        inFlight[key]?.let { return it.await() }
+
+        val deferred = CompletableDeferred<R>()
+        val existing = inFlight.putIfAbsent(key, deferred)
+        if (existing != null) {
+            return existing.await()
+        }
+
+        try {
+            val cached = map.get(key)
+            if (cached != null) {
+                deferred.complete(cached)
+                return cached
+            }
+
+            val evaluated = evaluator(key)
+            val winner = map.putIfAbsentAsync(key, evaluated).awaitSuspending() ?: evaluated
+            deferred.complete(winner)
+            return winner
+        } catch (e: Throwable) {
+            deferred.completeExceptionally(e)
+            throw e
+        } finally {
+            inFlight.remove(key, deferred)
+        }
     }
 
     override suspend fun clear() {

--- a/infra/redis/src/main/kotlin/io/bluetape4k/redis/redisson/memorizer/RedissonSuspendMemorizer.kt
+++ b/infra/redis/src/main/kotlin/io/bluetape4k/redis/redisson/memorizer/RedissonSuspendMemorizer.kt
@@ -1,11 +1,11 @@
 package io.bluetape4k.redis.redisson.memorizer
 
 import io.bluetape4k.cache.memorizer.SuspendMemorizer
-import io.bluetape4k.coroutines.support.awaitSuspending
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.future.await
 import org.redisson.api.RMap
 import java.util.concurrent.ConcurrentHashMap
 
@@ -87,7 +87,7 @@ class RedissonSuspendMemorizer<T: Any, R: Any>(
             }
 
             val evaluated = evaluator(key)
-            val winner = map.putIfAbsentAsync(key, evaluated).awaitSuspending() ?: evaluated
+            val winner = map.putIfAbsentAsync(key, evaluated).await() ?: evaluated
             deferred.complete(winner)
             return winner
         } catch (e: Throwable) {
@@ -100,6 +100,6 @@ class RedissonSuspendMemorizer<T: Any, R: Any>(
 
     override suspend fun clear() {
         log.debug { "Clear all memorized values. map=${map.name}" }
-        map.clearAsync().awaitSuspending()
+        map.clearAsync().await()
     }
 }

--- a/infra/redis/src/test/kotlin/io/bluetape4k/redis/redisson/memorizer/RedissonMemoerizerTest.kt
+++ b/infra/redis/src/test/kotlin/io/bluetape4k/redis/redisson/memorizer/RedissonMemoerizerTest.kt
@@ -9,6 +9,10 @@ import org.junit.jupiter.api.assertTimeout
 import org.redisson.client.codec.IntegerCodec
 import org.redisson.client.codec.LongCodec
 import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.system.measureTimeMillis
 
 class RedissonMemoerizerTest: AbstractRedissonTest() {
@@ -61,6 +65,35 @@ class RedissonMemoerizerTest: AbstractRedissonTest() {
         assertTimeout(Duration.ofMillis(1000)) {
             fibonacci.calc(100)
         } shouldBeEqualTo x1
+    }
+
+    @Test
+    fun `memorizer should evaluate once for same key in concurrent calls`() {
+        val map = redisson.getMap<Int, Int>(randomName(), IntegerCodec()).apply { clear() }
+        val evaluateCount = AtomicInteger(0)
+        val memorizer = map.memorizer { key ->
+            evaluateCount.incrementAndGet()
+            Thread.sleep(100)
+            key * key
+        }
+        val pool = Executors.newFixedThreadPool(16)
+        val startLatch = CountDownLatch(1)
+
+        try {
+            val tasks = List(16) {
+                pool.submit<Int> {
+                    startLatch.await(1, TimeUnit.SECONDS)
+                    memorizer(7)
+                }
+            }
+
+            startLatch.countDown()
+            tasks.forEach { it.get(2, TimeUnit.SECONDS) shouldBeEqualTo 49 }
+            evaluateCount.get() shouldBeEqualTo 1
+        } finally {
+            pool.shutdownNow()
+            map.delete()
+        }
     }
 
     interface FactorialProvider {

--- a/infra/redis/src/test/kotlin/io/bluetape4k/redis/redisson/memorizer/RedissonSuspendMemoerizerTest.kt
+++ b/infra/redis/src/test/kotlin/io/bluetape4k/redis/redisson/memorizer/RedissonSuspendMemoerizerTest.kt
@@ -4,6 +4,9 @@ import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.trace
 import io.bluetape4k.redis.redisson.AbstractRedissonTest
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
@@ -11,6 +14,7 @@ import org.redisson.client.codec.IntegerCodec
 import org.redisson.client.codec.LongCodec
 import kotlin.system.measureTimeMillis
 import kotlin.time.Duration.Companion.seconds
+import java.util.concurrent.atomic.AtomicInteger
 
 class RedissonSuspendMemoerizerTest: AbstractRedissonTest() {
 
@@ -64,6 +68,25 @@ class RedissonSuspendMemoerizerTest: AbstractRedissonTest() {
             fibonacci.calc(100)
         }
         result shouldBeEqualTo x1
+    }
+
+    @Test
+    fun `suspend memorizer should evaluate once for same key in concurrent calls`() = runSuspendIO {
+        val map = redisson.getMap<Int, Int>(randomName(), IntegerCodec()).apply { clear() }
+        val evaluateCount = AtomicInteger(0)
+        val memorizer = map.suspendMemorizer { key ->
+            evaluateCount.incrementAndGet()
+            delay(100)
+            key * key
+        }
+
+        try {
+            val results = List(16) { async { memorizer(7) } }.awaitAll()
+            results.forEach { it shouldBeEqualTo 49 }
+            evaluateCount.get() shouldBeEqualTo 1
+        } finally {
+            map.delete()
+        }
     }
 
     interface SuspendFactorialProvider {


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: redis memorizer 동시성 안정성 보강

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- `RedissonMemorizer`/`RedissonSuspendMemorizer`에 동일 키 in-flight dedup 로직을 추가해 JVM 내 동시 요청 시 evaluator 중복 실행을 방지했습니다.
- 동기/코루틴 memorizer 경로에 동시 호출 회귀 테스트를 추가했습니다.
- `infra/redis/README.md`에 memorizer 동시성 보장과 모듈 테스트 실행 방법을 최신화했습니다.
- public API KDoc에 in-flight 동작 계약을 보강했습니다.

### 기존 섹션: 성능/안정성 관점

- 동일 키 동시 호출 상황에서 중복 계산을 줄여 피크 부하를 완화합니다.
- 에러 발생 시 in-flight 엔트리를 정리하여 후속 호출이 교착되지 않도록 했습니다.

## Validation

- `./gradlew :bluetape4k-redis:test`
- `./gradlew :bluetape4k-redis:test --tests "*RedissonMemoerizerTest" --tests "*RedissonSuspendMemoerizerTest"`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #64, head `221c6d51bbc60516c3be77e85495101e465f382d`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/redis-review-hardening`
- Labels: `enhancement`
- State: `MERGED`, merge commit `2365d3d3a5162a09b8a3ca25403821cfa4598863`
- CI: - `./gradlew :bluetape4k-redis:test` / - `./gradlew :bluetape4k-redis:test --tests "*RedissonMemoerizerTest" --tests "*RedissonSuspendMemoerizerTest"`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #64 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `2365d3d3a5162a09b8a3ca25403821cfa4598863`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
