### PR TITLE
fix: aws-kotlin core/s3 안정성·문서 보강

### DIFF
--- a/aws-kotlin/core/README.md
+++ b/aws-kotlin/core/README.md
@@ -40,8 +40,11 @@ val localProvider = LocalCredentialsProvider
 import io.bluetape4k.aws.kotlin.http.crtHttpEngineOf
 import aws.smithy.kotlin.runtime.http.engine.crt.CrtHttpEngine
 
-// CRT 기반 HTTP 엔진 생성 (권장)
+// CRT 기반 기본 HTTP 엔진 singleton (권장)
 val httpEngine = HttpClientEngineProvider.defaultHttpEngine
+
+// 필요 시 OkHttp 엔진 singleton 사용
+val okHttpEngine = HttpClientEngineProvider.OkHttp.httpEngine
 
 // 클라이언트 생성 시 사용
 val s3Client = S3Client {

--- a/aws-kotlin/core/src/main/kotlin/io/bluetape4k/aws/kotlin/http/HttpClientEngineProvider.kt
+++ b/aws-kotlin/core/src/main/kotlin/io/bluetape4k/aws/kotlin/http/HttpClientEngineProvider.kt
@@ -2,27 +2,41 @@ package io.bluetape4k.aws.kotlin.http
 
 import aws.smithy.kotlin.runtime.http.engine.crt.CrtHttpEngine
 import aws.smithy.kotlin.runtime.http.engine.okhttp.OkHttpEngine
-import io.bluetape4k.utils.ShutdownQueue
 
+/**
+ * AWS SDK for Kotlin 클라이언트에서 재사용할 HTTP 엔진 singleton 제공자입니다.
+ *
+ * 기본 엔진은 [Crt]를 사용하며, 필요 시 [OkHttp] 엔진을 선택적으로 사용할 수 있습니다.
+ */
 object HttpClientEngineProvider {
 
+    /**
+     * AWS CRT 기반 HTTP 엔진 singleton 공급자입니다.
+     *
+     * `crtHttpEngineOf()`에서 이미 `ShutdownQueue` 등록을 수행하므로,
+     * 여기서는 추가 등록을 하지 않습니다.
+     */
     object Crt {
         @JvmStatic
-        val httpEngine: CrtHttpEngine by lazy {
-            crtHttpEngineOf().apply {
-                ShutdownQueue.register(this)
-            }
-        }
+        val httpEngine: CrtHttpEngine by lazy { crtHttpEngineOf() }
     }
 
+    /**
+     * OkHttp 기반 HTTP 엔진 singleton 공급자입니다.
+     *
+     * `okHttpEngineOf()`에서 이미 `ShutdownQueue` 등록을 수행하므로,
+     * 여기서는 추가 등록을 하지 않습니다.
+     */
     object OkHttp {
         @JvmStatic
-        val httpEngine: OkHttpEngine by lazy {
-            okHttpEngineOf().apply {
-                ShutdownQueue.register(this)
-            }
-        }
+        val httpEngine: OkHttpEngine by lazy { okHttpEngineOf() }
     }
 
+    /**
+     * 기본 HTTP 엔진입니다.
+     *
+     * 현재 기본값은 CRT singleton 엔진([Crt.httpEngine])이며,
+     * 모듈 전반에서 동일 인스턴스를 재사용합니다.
+     */
     val defaultHttpEngine get() = Crt.httpEngine
 }

--- a/aws-kotlin/core/src/test/kotlin/io/bluetape4k/aws/kotlin/http/CrtHttpEngineSupportTest.kt
+++ b/aws-kotlin/core/src/test/kotlin/io/bluetape4k/aws/kotlin/http/CrtHttpEngineSupportTest.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.aws.kotlin.http
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Test
 
 class CrtHttpEngineSupportTest {
@@ -15,5 +16,12 @@ class CrtHttpEngineSupportTest {
             log.debug { "CrtHttpEngine: $engine" }
             engine.shouldNotBeNull()
         }
+    }
+
+    @Test
+    fun `HttpClientEngineProvider default는 Crt singleton을 재사용한다`() {
+        val crtEngine = HttpClientEngineProvider.Crt.httpEngine
+        val defaultEngine = HttpClientEngineProvider.defaultHttpEngine
+        assertSame(crtEngine, defaultEngine)
     }
 }

--- a/aws-kotlin/dynamodb/README.md
+++ b/aws-kotlin/dynamodb/README.md
@@ -65,6 +65,13 @@ client.waitForTableReady("Users", timeout = 60.seconds)
 client.deleteTableIfExists("Users")
 ```
 
+## 동작 계약(안정성)
+
+- `existsTable`은 `listTablesPaginated`를 사용해 모든 페이지를 순회하므로,
+  테이블 수가 많은 환경에서도 첫 페이지 누락으로 인한 오탐을 줄입니다.
+- `waitForTableReady`는 지정한 `timeout` 내에서 `CREATING` 상태 해제를 폴링하며,
+  타임아웃 초과 시 예외를 전파합니다.
+
 ### 아이템 조작
 
 ```kotlin

--- a/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/DynamoDbClientExtensions.kt
+++ b/aws-kotlin/dynamodb/src/main/kotlin/io/bluetape4k/aws/kotlin/dynamodb/DynamoDbClientExtensions.kt
@@ -15,7 +15,9 @@ import aws.sdk.kotlin.services.dynamodb.model.PutItemResponse
 import aws.sdk.kotlin.services.dynamodb.model.ScanRequest
 import aws.sdk.kotlin.services.dynamodb.model.ScanResponse
 import aws.sdk.kotlin.services.dynamodb.model.TableStatus
+import aws.sdk.kotlin.services.dynamodb.paginators.listTablesPaginated
 import aws.sdk.kotlin.services.dynamodb.paginators.scanPaginated
+import aws.sdk.kotlin.services.dynamodb.paginators.tableNames
 import aws.sdk.kotlin.services.dynamodb.putItem
 import aws.smithy.kotlin.runtime.ServiceException
 import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
@@ -30,6 +32,7 @@ import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.utils.ShutdownQueue
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.any
 import kotlinx.coroutines.withTimeout
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -117,7 +120,7 @@ suspend fun DynamoDbClient.createTable(
  * [name] 이름의 DynamoDB 테이블이 존재하는지 확인합니다.
  *
  * ## 동작/계약
- * - `listTables`를 호출해 테이블 이름 목록에서 [name] 포함 여부를 반환한다.
+ * - `listTablesPaginated`를 통해 모든 페이지를 순회하며 [name] 포함 여부를 반환한다.
  * - [name]이 blank이면 `IllegalArgumentException`을 던진다.
  *
  * ```kotlin
@@ -129,7 +132,9 @@ suspend fun DynamoDbClient.createTable(
  */
 suspend fun DynamoDbClient.existsTable(name: String): Boolean {
     name.requireNotBlank("name")
-    return this.listTables { }.tableNames?.contains(name) ?: false
+    return listTablesPaginated()
+        .tableNames()
+        .any { it == name }
 }
 
 /**

--- a/aws-kotlin/s3/README.md
+++ b/aws-kotlin/s3/README.md
@@ -47,6 +47,7 @@ s3Client.getAsOutputStream("my-bucket", "path/to/file.txt", outputStream)
 
 // 병렬 다운로드
 val responses = s3Client.getAll(
+    concurrency = 8,
     getObjectRequestOf("bucket", "key1"),
     getObjectRequestOf("bucket", "key2"),
     getObjectRequestOf("bucket", "key3")
@@ -123,7 +124,7 @@ val presignedRequest = s3Client.presignGetObject(
     key = "path/to/file.txt",
     duration = 5.minutes
 )
-println("Presigned URL: ${presignedRequest.url}")
+println("Presigned URL generated (expires in 5 minutes)")
 ```
 
 ### 버킷 관리
@@ -143,6 +144,13 @@ s3Client.deleteBucket("my-bucket")
 // 버킷 정책 조회
 val policy = s3Client.tryGetBucketPolicy("my-bucket")
 ```
+
+## 동작 계약
+
+- `existsBucket`, `existsObject`는 `NoSuchBucket`/`NoSuchKey`/`NotFound` 및 HTTP `404` 응답을
+  "리소스 미존재"로 해석해 `false`를 반환합니다.
+- 인증 실패, 권한 오류, 네트워크 장애 등 미존재 외 예외는 그대로 전파합니다.
+- `putAll`, `getAll`은 `concurrency`를 적용해 요청을 병렬 처리하며, Flow 수집 시 실제 전송/조회가 수행됩니다.
 
 ## 주요 기능 상세
 

--- a/aws-kotlin/s3/src/main/kotlin/io/bluetape4k/aws/kotlin/s3/S3ClientBucket.kt
+++ b/aws-kotlin/s3/src/main/kotlin/io/bluetape4k/aws/kotlin/s3/S3ClientBucket.kt
@@ -8,6 +8,8 @@ import aws.sdk.kotlin.services.s3.model.CreateBucketResponse
 import aws.sdk.kotlin.services.s3.model.DeleteBucketRequest
 import aws.sdk.kotlin.services.s3.model.DeleteBucketResponse
 import aws.sdk.kotlin.services.s3.model.HeadBucketRequest
+import aws.smithy.kotlin.runtime.ServiceException
+import aws.smithy.kotlin.runtime.http.response.statusCode
 import io.bluetape4k.aws.kotlin.s3.model.deleteBucketRequestOf
 import io.bluetape4k.aws.kotlin.s3.model.headBucketRequestOf
 import io.bluetape4k.logging.debug
@@ -15,6 +17,9 @@ import io.bluetape4k.support.requireNotBlank
 
 /**
  * [bucket]의 버킷이 존재하는지 확인합니다.
+ *
+ * 존재하지 않는 버킷(`NoSuchBucket`/`NotFound`/HTTP `404`)만 `false`로 정규화하고,
+ * 인증 실패/네트워크 오류 등 다른 예외는 그대로 전파합니다.
  *
  * ```
  * val exists = s3Client.existsBucket("bucket-name")
@@ -28,7 +33,12 @@ suspend inline fun S3Client.existsBucket(
     @BuilderInference crossinline builder: HeadBucketRequest.Builder.() -> Unit = {},
 ): Boolean {
     val headBucketRequest = headBucketRequestOf(bucket, builder = builder)
-    return runCatching { headBucket(headBucketRequest) }.isSuccess
+    return runCatching {
+        headBucket(headBucketRequest)
+        true
+    }.recover { error ->
+        if (error.isMissingBucketError()) false else throw error
+    }.getOrThrow()
 }
 
 /**
@@ -91,7 +101,7 @@ suspend inline fun S3Client.forceDeleteBucket(
     bucket: String,
     @BuilderInference crossinline builder: DeleteBucketRequest.Builder.() -> Unit = {},
 ): DeleteBucketResponse {
-    bucket.requireNotBlank("bucketName")
+    bucket.requireNotBlank("bucket")
 
     // 버킷 내 모든 Object 삭제 (listObjectsV2는 최대 1000개만 반환하므로, 모든 Object를 삭제하기 위해 반복)
     log.debug { "버킷의 모든 Object를 삭제합니다. bucket=$bucket" }
@@ -106,4 +116,12 @@ suspend inline fun S3Client.forceDeleteBucket(
     // 버킷 삭제
     log.debug { "버킷을 삭제합니다. bucket=$bucket" }
     return deleteBucket(deleteBucketRequestOf(bucket, builder = builder))
+}
+
+@PublishedApi
+internal fun Throwable.isMissingBucketError(): Boolean {
+    val serviceError = this as? ServiceException ?: return false
+    val errorCode = serviceError.sdkErrorMetadata.errorCode
+    val statusCode = serviceError.sdkErrorMetadata.protocolResponse.statusCode()?.value
+    return errorCode in setOf("NoSuchBucket", "NotFound") || statusCode == 404
 }

--- a/aws-kotlin/s3/src/main/kotlin/io/bluetape4k/aws/kotlin/s3/S3ClientGet.kt
+++ b/aws-kotlin/s3/src/main/kotlin/io/bluetape4k/aws/kotlin/s3/S3ClientGet.kt
@@ -11,6 +11,8 @@ import aws.sdk.kotlin.services.s3.model.GetObjectRetentionRequest
 import aws.sdk.kotlin.services.s3.model.GetObjectRetentionResponse
 import aws.sdk.kotlin.services.s3.model.HeadObjectRequest
 import aws.sdk.kotlin.services.s3.presigners.presignGetObject
+import aws.smithy.kotlin.runtime.ServiceException
+import aws.smithy.kotlin.runtime.http.response.statusCode
 import aws.smithy.kotlin.runtime.content.decodeToString
 import aws.smithy.kotlin.runtime.content.toByteArray
 import aws.smithy.kotlin.runtime.content.writeToFile
@@ -21,12 +23,13 @@ import io.bluetape4k.aws.kotlin.s3.model.getObjectRequestOf
 import io.bluetape4k.aws.kotlin.s3.model.getObjectRetentionRequestOf
 import io.bluetape4k.aws.kotlin.s3.model.headObjectRequestOf
 import io.bluetape4k.coroutines.flow.async
+import io.bluetape4k.coroutines.flow.collect as collectAsync
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requireNotEmpty
 import kotlinx.coroutines.flow.DEFAULT_CONCURRENCY
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flow
 import java.io.OutputStream
 import java.nio.file.Path
 import kotlin.time.Duration
@@ -34,6 +37,9 @@ import kotlin.time.Duration.Companion.seconds
 
 /**
  * [bucket]의 [key]에 해당하는 객체가 존재하는지 확인합니다.
+ *
+ * 존재하지 않는 객체(`NoSuchKey`/`NotFound`/HTTP `404`)만 `false`로 정규화하고,
+ * 인증 실패/네트워크 오류 등 다른 예외는 그대로 전파합니다.
  *
  * ```
  * val exists = s3Client.existsObject("bucket-name", "key")
@@ -45,7 +51,12 @@ suspend inline fun S3Client.existsObject(
     @BuilderInference crossinline builder: HeadObjectRequest.Builder.() -> Unit = {},
 ): Boolean {
     val request = headObjectRequestOf(bucket, key, builder = builder)
-    return runCatching { headObject(request); true }.isSuccess
+    return runCatching {
+        headObject(request)
+        true
+    }.recover { error ->
+        if (error.isMissingObjectError()) false else throw error
+    }.getOrThrow()
 }
 
 /**
@@ -226,13 +237,14 @@ suspend inline fun S3Client.getAsOutputStream(
 fun S3Client.getAll(
     concurrency: Int = DEFAULT_CONCURRENCY,
     vararg getObjectRequests: GetObjectRequest,
-): Flow<GetObjectResponse> = callbackFlow {
-    getObjectRequests
+): Flow<GetObjectResponse> = flow {
+    val asyncFlow = getObjectRequests
         .asFlow()
         .async { request ->
-            val response = getObject(request) { it }
-            send(response)
+            getObject(request) { it }
         }
+
+    asyncFlow.collectAsync(concurrency) { response -> emit(response) }
 }
 
 /**
@@ -343,4 +355,12 @@ suspend inline fun S3Client.tryGetBucketPolicy(
             builder()
         }.policy
     }.getOrNull()
+}
+
+@PublishedApi
+internal fun Throwable.isMissingObjectError(): Boolean {
+    val serviceError = this as? ServiceException ?: return false
+    val errorCode = serviceError.sdkErrorMetadata.errorCode
+    val statusCode = serviceError.sdkErrorMetadata.protocolResponse.statusCode()?.value
+    return errorCode in setOf("NoSuchKey", "NotFound") || statusCode == 404
 }

--- a/aws-kotlin/s3/src/main/kotlin/io/bluetape4k/aws/kotlin/s3/S3ClientPut.kt
+++ b/aws-kotlin/s3/src/main/kotlin/io/bluetape4k/aws/kotlin/s3/S3ClientPut.kt
@@ -8,11 +8,12 @@ import aws.smithy.kotlin.runtime.content.ByteStream
 import aws.smithy.kotlin.runtime.content.fromFile
 import io.bluetape4k.aws.kotlin.s3.model.putObjectRequestOf
 import io.bluetape4k.coroutines.flow.async
+import io.bluetape4k.coroutines.flow.collect as collectAsync
 import io.bluetape4k.io.exists
 import kotlinx.coroutines.flow.DEFAULT_CONCURRENCY
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flow
 import java.io.File
 import java.nio.file.Path
 
@@ -169,11 +170,12 @@ suspend inline fun S3Client.putFromPath(
 fun S3Client.putAll(
     concurrency: Int = DEFAULT_CONCURRENCY,
     vararg putRequests: PutObjectRequest,
-): Flow<PutObjectResponse> = callbackFlow {
-    putRequests
+): Flow<PutObjectResponse> = flow {
+    val asyncFlow = putRequests
         .asFlow()
-        .async {
-            val putResponse = putObject(it)
-            send(putResponse)
+        .async { request ->
+            putObject(request)
         }
+
+    asyncFlow.collectAsync(concurrency) { putResponse -> emit(putResponse) }
 }

--- a/aws-kotlin/s3/src/test/kotlin/io/bluetape4k/aws/kotlin/s3/S3ClientErrorClassifierTest.kt
+++ b/aws-kotlin/s3/src/test/kotlin/io/bluetape4k/aws/kotlin/s3/S3ClientErrorClassifierTest.kt
@@ -1,0 +1,49 @@
+package io.bluetape4k.aws.kotlin.s3
+
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.ServiceErrorMetadata
+import aws.smithy.kotlin.runtime.ServiceException
+import aws.smithy.kotlin.runtime.http.HttpStatusCode
+import aws.smithy.kotlin.runtime.http.response.HttpResponse
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(InternalApi::class)
+class S3ClientErrorClassifierTest {
+
+    @Test
+    fun `isMissingBucketError는 NoSuchBucket과 404를 미존재로 판별한다`() {
+        serviceException(errorCode = "NoSuchBucket").isMissingBucketError().shouldBeTrue()
+        serviceException(statusCode = 404).isMissingBucketError().shouldBeTrue()
+    }
+
+    @Test
+    fun `isMissingBucketError는 기타 서비스 오류를 미존재로 판별하지 않는다`() {
+        serviceException(errorCode = "AccessDenied", statusCode = 403).isMissingBucketError().shouldBeFalse()
+    }
+
+    @Test
+    fun `isMissingObjectError는 NoSuchKey와 404를 미존재로 판별한다`() {
+        serviceException(errorCode = "NoSuchKey").isMissingObjectError().shouldBeTrue()
+        serviceException(statusCode = 404).isMissingObjectError().shouldBeTrue()
+    }
+
+    @Test
+    fun `isMissingObjectError는 기타 서비스 오류를 미존재로 판별하지 않는다`() {
+        serviceException(errorCode = "AccessDenied", statusCode = 403).isMissingObjectError().shouldBeFalse()
+    }
+
+    private fun serviceException(
+        errorCode: String? = null,
+        statusCode: Int? = null,
+    ): ServiceException {
+        val exception = ServiceException("test error")
+        errorCode?.let { exception.sdkErrorMetadata.attributes[ServiceErrorMetadata.ErrorCode] = it }
+        statusCode?.let {
+            exception.sdkErrorMetadata.attributes[ServiceErrorMetadata.ProtocolResponse] =
+                HttpResponse(status = HttpStatusCode.fromValue(it))
+        }
+        return exception
+    }
+}

--- a/aws-kotlin/s3/src/test/kotlin/io/bluetape4k/aws/kotlin/s3/S3ClientExtensionsTest.kt
+++ b/aws-kotlin/s3/src/test/kotlin/io/bluetape4k/aws/kotlin/s3/S3ClientExtensionsTest.kt
@@ -1,5 +1,9 @@
 package io.bluetape4k.aws.kotlin.s3
 
+import aws.smithy.kotlin.runtime.content.ByteStream
+import aws.smithy.kotlin.runtime.content.decodeToString
+import io.bluetape4k.aws.kotlin.s3.model.getObjectRequestOf
+import io.bluetape4k.aws.kotlin.s3.model.putObjectRequestOf
 import io.bluetape4k.io.deleteIfExists
 import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.junit5.coroutines.runSuspendIO
@@ -13,9 +17,12 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.io.File
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
 
 @TempFolderTest
 class S3ClientExtensionsTest: AbstractKotlinS3Test() {
@@ -36,6 +43,54 @@ class S3ClientExtensionsTest: AbstractKotlinS3Test() {
 
         val downloadedContent = s3Client.getAsString(BUCKET_NAME, key)
         downloadedContent.shouldNotBeNull() shouldBeEqualTo content
+    }
+
+    @Test
+    fun `existsBucket는 없는 버킷에 대해 false를 반환한다`() = runSuspendIO {
+        val missingBucket = "missing-${randomKey()}"
+        s3Client.existsBucket(missingBucket) shouldBeEqualTo false
+    }
+
+    @Test
+    fun `existsObject는 없는 객체에 대해 false를 반환한다`() = runSuspendIO {
+        val missingKey = "missing-${randomKey()}"
+        s3Client.existsObject(BUCKET_NAME, missingKey) shouldBeEqualTo false
+    }
+
+    @Test
+    fun `putAll은 모든 요청을 실행하고 업로드 결과를 반환한다`() = runSuspendIO {
+        val prefix = "bulk-put-${randomKey()}"
+        val requests = arrayOf(
+            putObjectRequestOf(BUCKET_NAME, "$prefix-1", body = ByteStream.fromString("alpha")),
+            putObjectRequestOf(BUCKET_NAME, "$prefix-2", body = ByteStream.fromString("beta")),
+            putObjectRequestOf(BUCKET_NAME, "$prefix-3", body = ByteStream.fromString("gamma")),
+        )
+
+        val responses = s3Client.putAll(concurrency = 2, *requests).toList()
+        responses.size shouldBeEqualTo requests.size
+        s3Client.existsObject(BUCKET_NAME, "$prefix-1").shouldBeTrue()
+        s3Client.existsObject(BUCKET_NAME, "$prefix-2").shouldBeTrue()
+        s3Client.existsObject(BUCKET_NAME, "$prefix-3").shouldBeTrue()
+    }
+
+    @Test
+    fun `getAll은 모든 요청을 실행하고 객체 본문을 반환한다`() = runSuspendIO {
+        val prefix = "bulk-get-${randomKey()}"
+        val samples = listOf("one", "two", "three")
+        samples.forEachIndexed { index, value ->
+            s3Client.putFromString(BUCKET_NAME, "$prefix-$index", value)
+        }
+
+        val requests = samples.indices.map { index ->
+            getObjectRequestOf(BUCKET_NAME, "$prefix-$index")
+        }.toTypedArray()
+
+        val contents = s3Client.getAll(concurrency = 2, *requests)
+            .map { it.body?.decodeToString() }
+            .toList()
+
+        contents.size shouldBeEqualTo samples.size
+        contents shouldBeEqualTo samples
     }
 
     @RepeatedTest(REPEAT_SIZE)

--- a/aws-kotlin/sqs/README.md
+++ b/aws-kotlin/sqs/README.md
@@ -92,6 +92,13 @@ receiveResponse.messages?.forEach { message ->
 }
 ```
 
+## 입력 검증(안정성)
+
+- `receiveMessageRequestOf`의 `waitTimeSeconds` 기본값은 `20`초이며 허용 범위는 `0..20`입니다.
+- `receiveMessage`의 `maxNumberOfMessages`는 지정 시 `1..10` 범위를 강제합니다.
+- `sendMessage`는 blank `messageBody`를 허용하지 않습니다.
+- 배치 API(`sendMessageBatch`, `changeMessageVisibilityBatch`, `deleteMessageBatch`)는 빈 엔트리를 허용하지 않습니다.
+
 ### 배치 작업
 
 ```kotlin

--- a/aws-kotlin/sqs/README.md
+++ b/aws-kotlin/sqs/README.md
@@ -94,6 +94,8 @@ receiveResponse.messages?.forEach { message ->
 
 ## 입력 검증(안정성)
 
+- `existsQueue`는 `QueueDoesNotExist`/`ResourceNotFoundException`/HTTP `404`를 큐 미존재로 해석해 `false`를 반환하고,
+  그 외 예외(권한/네트워크 등)는 그대로 전파합니다.
 - `receiveMessageRequestOf`의 `waitTimeSeconds` 기본값은 `20`초이며 허용 범위는 `0..20`입니다.
 - `receiveMessage`의 `maxNumberOfMessages`는 지정 시 `1..10` 범위를 강제합니다.
 - `sendMessage`는 blank `messageBody`를 허용하지 않습니다.

--- a/aws-kotlin/sqs/src/main/kotlin/io/bluetape4k/aws/kotlin/sqs/SqsClientExtensions.kt
+++ b/aws-kotlin/sqs/src/main/kotlin/io/bluetape4k/aws/kotlin/sqs/SqsClientExtensions.kt
@@ -41,6 +41,11 @@ import io.bluetape4k.support.requireNotEmpty
 import io.bluetape4k.utils.ShutdownQueue
 
 val log by lazy { KotlinLogging.logger { } }
+@PublishedApi
+internal const val MIN_RECEIVE_MESSAGES = 1
+
+@PublishedApi
+internal const val MAX_RECEIVE_MESSAGES = 10
 
 /**
  * [SqsClient] 인스턴스를 생성합니다.
@@ -238,7 +243,7 @@ suspend inline fun SqsClient.deleteQueue(
  * }
  *
  * @param queueUrl 메시지를 보낼 Amazon SQS 큐의 URL입니다.
- * @param messageBody 전송할 메시지의 본문입니다.
+ * @param messageBody 전송할 메시지의 본문입니다. blank이면 [IllegalArgumentException]을 던집니다.
  * @param delaySeconds 메시지를 보내기 전 대기할 시간(초)입니다. 기본값은 null입니다.
  * @param builder SendMessageRequest.Builder를 초기화하는 람다입니다. 기본값은 빈 람다입니다.
  * @return SendMessageResponse 인스턴스를 반환합니다.
@@ -250,6 +255,7 @@ suspend inline fun SqsClient.sendMessage(
     @BuilderInference crossinline builder: SendMessageRequest.Builder.() -> Unit = {},
 ): SendMessageResponse {
     queueUrl.requireNotBlank("queueUrl")
+    messageBody.requireNotBlank("messageBody")
 
     return sendMessage {
         this.queueUrl = queueUrl
@@ -328,13 +334,18 @@ suspend inline fun SqsClient.sendMessageBatch(
  * ```
  *
  * @param queueUrl 메시지를 수신할 Amazon SQS 큐의 URL입니다.
- * @param maxNumberOfMessages 한 번에 수신할 최대 메시지 수입니다. 기본값은 null입니다.
+ * @param maxNumberOfMessages 한 번에 수신할 최대 메시지 수입니다. 기본값은 null이며, 지정 시 1..10 범위여야 합니다.
  */
 suspend inline fun SqsClient.receiveMessage(
     queueUrl: String,
     maxNumberOfMessages: Int? = null,
 ): ReceiveMessageResponse {
     queueUrl.requireNotBlank("queueUrl")
+    maxNumberOfMessages?.let {
+        require(it in MIN_RECEIVE_MESSAGES..MAX_RECEIVE_MESSAGES) {
+            "maxNumberOfMessages must be in the range $MIN_RECEIVE_MESSAGES..$MAX_RECEIVE_MESSAGES."
+        }
+    }
 
     return receiveMessage {
         this.queueUrl = queueUrl

--- a/aws-kotlin/sqs/src/main/kotlin/io/bluetape4k/aws/kotlin/sqs/SqsClientExtensions.kt
+++ b/aws-kotlin/sqs/src/main/kotlin/io/bluetape4k/aws/kotlin/sqs/SqsClientExtensions.kt
@@ -22,7 +22,9 @@ import aws.sdk.kotlin.services.sqs.model.DeleteQueueResponse
 import aws.sdk.kotlin.services.sqs.model.GetQueueUrlRequest
 import aws.sdk.kotlin.services.sqs.model.ListQueuesRequest
 import aws.sdk.kotlin.services.sqs.model.ListQueuesResponse
+import aws.sdk.kotlin.services.sqs.model.QueueDoesNotExist
 import aws.sdk.kotlin.services.sqs.model.ReceiveMessageResponse
+import aws.sdk.kotlin.services.sqs.model.ResourceNotFoundException
 import aws.sdk.kotlin.services.sqs.model.SendMessageBatchRequestEntry
 import aws.sdk.kotlin.services.sqs.model.SendMessageBatchResponse
 import aws.sdk.kotlin.services.sqs.model.SendMessageRequest
@@ -30,8 +32,10 @@ import aws.sdk.kotlin.services.sqs.model.SendMessageResponse
 import aws.sdk.kotlin.services.sqs.receiveMessage
 import aws.sdk.kotlin.services.sqs.sendMessage
 import aws.sdk.kotlin.services.sqs.sendMessageBatch
+import aws.smithy.kotlin.runtime.ServiceException
 import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngine
+import aws.smithy.kotlin.runtime.http.response.statusCode
 import aws.smithy.kotlin.runtime.net.url.Url
 import io.bluetape4k.aws.kotlin.http.HttpClientEngineProvider
 import io.bluetape4k.logging.KotlinLogging
@@ -143,6 +147,9 @@ suspend inline fun SqsClient.ensureQueue(
 /**
  * [queueName]에 해당하는 큐가 존재하는지 확인합니다.
  *
+ * 존재하지 않는 큐(`QueueDoesNotExist`/`ResourceNotFoundException`/HTTP `404`)만 `false`로 정규화하고,
+ * 인증 실패/네트워크 오류 등 다른 예외는 그대로 전파합니다.
+ *
  * ```
  * val exists = sqsClient.existsQueue("my-queue")
  * ```
@@ -152,7 +159,9 @@ suspend inline fun SqsClient.ensureQueue(
  */
 suspend inline fun SqsClient.existsQueue(queueName: String): Boolean = runCatching {
     getQueueUrl(queueName)?.isNotBlank() ?: false
-}.getOrDefault(false)
+}.recover { error ->
+    if (error.isMissingQueueError()) false else throw error
+}.getOrThrow()
 
 /**
  * [queueNamePrefix]를 접두사로 가지는 큐 목록을 반환합니다.
@@ -542,4 +551,20 @@ suspend inline fun SqsClient.deleteMessageBatch(
         this.queueUrl = queueUrl
         this.entries = entries.toList()
     }
+}
+
+@PublishedApi
+internal fun Throwable.isMissingQueueError(): Boolean = when (this) {
+    is QueueDoesNotExist, is ResourceNotFoundException -> true
+    is ServiceException                                -> {
+        val errorCode = sdkErrorMetadata.errorCode
+        val statusCode = sdkErrorMetadata.protocolResponse.statusCode()?.value
+        errorCode in setOf(
+            "QueueDoesNotExist",
+            "AWS.SimpleQueueService.NonExistentQueue",
+            "ResourceNotFoundException",
+            "NotFound",
+        ) || statusCode == 404
+    }
+    else                                               -> false
 }

--- a/aws-kotlin/sqs/src/main/kotlin/io/bluetape4k/aws/kotlin/sqs/model/ReceiveMessage.kt
+++ b/aws-kotlin/sqs/src/main/kotlin/io/bluetape4k/aws/kotlin/sqs/model/ReceiveMessage.kt
@@ -3,12 +3,24 @@ package io.bluetape4k.aws.kotlin.sqs.model
 import aws.sdk.kotlin.services.sqs.model.ReceiveMessageRequest
 import io.bluetape4k.support.requireNotBlank
 
+@PublishedApi
+internal const val MIN_RECEIVE_MESSAGES = 1
+
+@PublishedApi
+internal const val MAX_RECEIVE_MESSAGES = 10
+
+@PublishedApi
+internal const val MIN_WAIT_TIME_SECONDS = 0
+
+@PublishedApi
+internal const val MAX_WAIT_TIME_SECONDS = 20
+
 /**
  * queueUrl, maxNumber, waitTimeSeconds, attributeNames를 사용하여 ReceiveMessageRequest를 생성합니다.
  *
  * @param queueUrl 메시지를 수신할 Amazon SQS 큐의 URL입니다.
- * @param maxNumberOfMessages 한 번에 수신할 최대 메시지 수입니다. 기본값은 3입니다.
- * @param waitTimeSeconds 메시지가 없을 경우 대기할 시간(초)입니다. 기본값은 30초입니다.
+ * @param maxNumberOfMessages 한 번에 수신할 최대 메시지 수입니다. 기본값은 3입니다. 허용 범위는 1..10 입니다.
+ * @param waitTimeSeconds 메시지가 없을 경우 대기할 시간(초)입니다. 기본값은 20초입니다. 허용 범위는 0..20 입니다.
  * @param visibilityTimeout 메시지를 처리하는 동안 숨겨진 시간(초)입니다. 기본값은 null입니다.
  * @param attributeNames 수신할 메시지의 속성 이름 컬렉션입니다. 기본값은 null입니다.
  * @param builder ReceiveMessageRequest.Builder를 초기화하는 람다입니다. 기본값은 빈 람다입니다.
@@ -17,14 +29,18 @@ import io.bluetape4k.support.requireNotBlank
 inline fun receiveMessageRequestOf(
     queueUrl: String,
     maxNumberOfMessages: Int = 3,
-    waitTimeSeconds: Int = 30,
+    waitTimeSeconds: Int = 20,
     visibilityTimeout: Int? = null,
     attributeNames: Collection<String>? = null,
     @BuilderInference crossinline builder: ReceiveMessageRequest.Builder.() -> Unit = {},
 ): ReceiveMessageRequest {
     queueUrl.requireNotBlank("queueUrl")
-    require(maxNumberOfMessages in 1..10) { "maxNumberOfMessages must be in the range 1..10." }
-    require(waitTimeSeconds in 0..20) { "waitTimeSeconds must be in the range 0..20." }
+    require(maxNumberOfMessages in MIN_RECEIVE_MESSAGES..MAX_RECEIVE_MESSAGES) {
+        "maxNumberOfMessages must be in the range $MIN_RECEIVE_MESSAGES..$MAX_RECEIVE_MESSAGES."
+    }
+    require(waitTimeSeconds in MIN_WAIT_TIME_SECONDS..MAX_WAIT_TIME_SECONDS) {
+        "waitTimeSeconds must be in the range $MIN_WAIT_TIME_SECONDS..$MAX_WAIT_TIME_SECONDS."
+    }
 
     return ReceiveMessageRequest {
         this.queueUrl = queueUrl

--- a/aws-kotlin/sqs/src/test/kotlin/io/bluetape4k/aws/kotlin/sqs/SqsClientErrorClassifierTest.kt
+++ b/aws-kotlin/sqs/src/test/kotlin/io/bluetape4k/aws/kotlin/sqs/SqsClientErrorClassifierTest.kt
@@ -1,0 +1,49 @@
+package io.bluetape4k.aws.kotlin.sqs
+
+import aws.sdk.kotlin.services.sqs.model.QueueDoesNotExist
+import aws.sdk.kotlin.services.sqs.model.ResourceNotFoundException
+import aws.sdk.kotlin.services.sqs.model.SqsException
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.ServiceErrorMetadata
+import aws.smithy.kotlin.runtime.http.HttpStatusCode
+import aws.smithy.kotlin.runtime.http.response.HttpResponse
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(InternalApi::class)
+class SqsClientErrorClassifierTest {
+
+    @Test
+    fun `isMissingQueueError는 QueueDoesNotExist를 미존재로 판별한다`() {
+        QueueDoesNotExist { message = "missing queue" }.isMissingQueueError().shouldBeTrue()
+    }
+
+    @Test
+    fun `isMissingQueueError는 ResourceNotFoundException을 미존재로 판별한다`() {
+        ResourceNotFoundException { message = "missing resource" }.isMissingQueueError().shouldBeTrue()
+    }
+
+    @Test
+    fun `isMissingQueueError는 HTTP 404를 미존재로 판별한다`() {
+        serviceException(statusCode = 404).isMissingQueueError().shouldBeTrue()
+    }
+
+    @Test
+    fun `isMissingQueueError는 기타 서비스 오류를 미존재로 판별하지 않는다`() {
+        serviceException(errorCode = "AccessDenied", statusCode = 403).isMissingQueueError().shouldBeFalse()
+    }
+
+    private fun serviceException(
+        errorCode: String? = null,
+        statusCode: Int? = null,
+    ): SqsException {
+        val exception = SqsException("test error")
+        errorCode?.let { exception.sdkErrorMetadata.attributes[ServiceErrorMetadata.ErrorCode] = it }
+        statusCode?.let {
+            exception.sdkErrorMetadata.attributes[ServiceErrorMetadata.ProtocolResponse] =
+                HttpResponse(status = HttpStatusCode.fromValue(it))
+        }
+        return exception
+    }
+}

--- a/aws-kotlin/sqs/src/test/kotlin/io/bluetape4k/aws/kotlin/sqs/SqsClientExtensionsTest.kt
+++ b/aws-kotlin/sqs/src/test/kotlin/io/bluetape4k/aws/kotlin/sqs/SqsClientExtensionsTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
+import kotlin.test.assertFailsWith
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class SqsClientExtensionsTest: AbstractKotlinSqsTest() {
@@ -137,5 +138,28 @@ class SqsClientExtensionsTest: AbstractKotlinSqsTest() {
         log.debug { "Delete queue response=$response" }
 
         sqsClient.existsQueue(QUEUE_NAME).shouldBeFalse()
+    }
+
+    @Test
+    @Order(9)
+    fun `receiveMessage는 maxNumberOfMessages 범위를 검증한다`() = runSuspendIO {
+        val queueUrl = "https://example.com/queue/demo"
+
+        assertFailsWith<IllegalArgumentException> {
+            sqsClient.receiveMessage(queueUrl, maxNumberOfMessages = 0)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            sqsClient.receiveMessage(queueUrl, maxNumberOfMessages = 11)
+        }
+    }
+
+    @Test
+    @Order(10)
+    fun `sendMessage는 blank messageBody를 허용하지 않는다`() = runSuspendIO {
+        val queueUrl = "https://example.com/queue/demo"
+
+        assertFailsWith<IllegalArgumentException> {
+            sqsClient.sendMessage(queueUrl, "   ")
+        }
     }
 }

--- a/aws-kotlin/sqs/src/test/kotlin/io/bluetape4k/aws/kotlin/sqs/model/SqsModelSupportTest.kt
+++ b/aws-kotlin/sqs/src/test/kotlin/io/bluetape4k/aws/kotlin/sqs/model/SqsModelSupportTest.kt
@@ -45,6 +45,16 @@ class SqsModelSupportTest {
     }
 
     @Test
+    fun `receiveMessageRequestOf 기본값은 유효한 waitTimeSeconds 20을 사용한다`() {
+        val request = receiveMessageRequestOf(
+            queueUrl = "https://localhost:4566/000000000000/test-queue",
+        )
+
+        request.maxNumberOfMessages shouldBeEqualTo 3
+        request.waitTimeSeconds shouldBeEqualTo 20
+    }
+
+    @Test
     fun `changeMessageVisibilityBatchRequestOf는 엔트리를 설정한다`() {
         val entry = changeMessageVisibilityBatchRequestEntryOf(
             id = "id-1",
@@ -118,6 +128,16 @@ class SqsModelSupportTest {
             sendMessageBatchRequestOf(
                 queueUrl = "https://localhost:4566/000000000000/test-queue",
                 entries = emptyList(),
+            )
+        }
+    }
+
+    @Test
+    fun `sendMessageRequestOf는 blank messageBody를 허용하지 않는다`() {
+        assertFailsWith<IllegalArgumentException> {
+            sendMessageRequestOf(
+                queueUrl = "https://localhost:4566/000000000000/test-queue",
+                messageBody = "   ",
             )
         }
     }

--- a/aws-kotlin/sts/README.md
+++ b/aws-kotlin/sts/README.md
@@ -20,6 +20,12 @@ Kotlin 스타일의 DSL 팩토리 함수와 유틸리티를 제공합니다.
 - **세션 토큰 발급**: `getSessionToken()` - MFA 기반 임시 자격 증명 발급
 - **요청 모델 빌더**: `assumeRoleRequestOf()` DSL - 역할 임시 맡기 요청 구성
 
+## durationSeconds 계약
+
+- `assumeRole`: `900..43200`
+- `getSessionToken`: `900..129600`
+- 범위를 벗어나면 원격 호출 전에 `IllegalArgumentException`으로 실패합니다.
+
 ## 의존성 추가
 
 ```kotlin
@@ -86,7 +92,7 @@ val response = client.assumeRole(
 val response = client.assumeRole(
     roleArn = "arn:aws:iam::123456789012:role/MyRole",
     sessionName = "my-session",
-    durationSeconds = 900
+    durationSeconds = 900 // 900..43200
 )
 
 // 임시 자격 증명 사용
@@ -136,6 +142,10 @@ println("accessKeyId=${credentials?.accessKeyId}")
 println("secretAccessKey=${credentials?.secretAccessKey}")
 println("sessionToken=${credentials?.sessionToken}")
 println("expiration=${credentials?.expiration}")
+
+// fail-fast 검증 예시
+runCatching { client.getSessionToken(durationSeconds = 899) }
+    .onFailure { println(it.message) }
 ```
 
 ## 주요 파일

--- a/aws-kotlin/sts/src/main/kotlin/io/bluetape4k/aws/kotlin/sts/StsClientSupport.kt
+++ b/aws-kotlin/sts/src/main/kotlin/io/bluetape4k/aws/kotlin/sts/StsClientSupport.kt
@@ -72,7 +72,8 @@ suspend fun StsClient.getCallerIdentity(): GetCallerIdentityResponse =
  * ## 동작/계약
  * - [roleArn]은 맡을 IAM 역할의 ARN이다.
  * - [sessionName]은 세션 이름으로, 감사 로그에 기록된다.
- * - [durationSeconds]는 임시 자격 증명의 유효 시간(초)이다. 기본값은 3600초(1시간)이다.
+ * - [durationSeconds]는 임시 자격 증명의 유효 시간(초)이다.
+ * - [durationSeconds]는 900~43200 범위를 만족해야 하며, 범위를 벗어나면 [IllegalArgumentException]을 던진다.
  *
  * ```kotlin
  * val response = client.assumeRole(
@@ -87,6 +88,8 @@ suspend fun StsClient.assumeRole(
     sessionName: String,
     durationSeconds: Int = 3600,
 ): AssumeRoleResponse {
+    requireValidAssumeRoleDuration(durationSeconds)
+
     val request = assumeRoleRequestOf(roleArn, sessionName) {
         this.durationSeconds = durationSeconds
     }
@@ -97,7 +100,8 @@ suspend fun StsClient.assumeRole(
  * MFA 인증 기반의 임시 세션 자격 증명을 반환합니다.
  *
  * ## 동작/계약
- * - [durationSeconds]는 임시 자격 증명의 유효 시간(초)이다. 기본값은 3600초(1시간)이다.
+ * - [durationSeconds]는 임시 자격 증명의 유효 시간(초)이다.
+ * - [durationSeconds]는 900~129600 범위를 만족해야 하며, 범위를 벗어나면 [IllegalArgumentException]을 던진다.
  *
  * ```kotlin
  * val response = client.getSessionToken()
@@ -106,7 +110,9 @@ suspend fun StsClient.assumeRole(
  */
 suspend fun StsClient.getSessionToken(
     durationSeconds: Int = 3600,
-): GetSessionTokenResponse =
-    getSessionToken {
+): GetSessionTokenResponse {
+    requireValidSessionTokenDuration(durationSeconds)
+    return getSessionToken {
         this.durationSeconds = durationSeconds
     }
+}

--- a/aws-kotlin/sts/src/main/kotlin/io/bluetape4k/aws/kotlin/sts/StsDurationValidation.kt
+++ b/aws-kotlin/sts/src/main/kotlin/io/bluetape4k/aws/kotlin/sts/StsDurationValidation.kt
@@ -1,0 +1,30 @@
+package io.bluetape4k.aws.kotlin.sts
+
+private const val ASSUME_ROLE_MIN_DURATION_SECONDS = 900
+private const val ASSUME_ROLE_MAX_DURATION_SECONDS = 43_200
+private const val SESSION_TOKEN_MIN_DURATION_SECONDS = 900
+private const val SESSION_TOKEN_MAX_DURATION_SECONDS = 129_600
+
+/**
+ * AssumeRole API의 `durationSeconds` 계약을 검증합니다.
+ *
+ * AWS STS AssumeRole은 기본적으로 900~43200초 범위를 허용합니다.
+ */
+internal fun requireValidAssumeRoleDuration(durationSeconds: Int) {
+    require(durationSeconds in ASSUME_ROLE_MIN_DURATION_SECONDS..ASSUME_ROLE_MAX_DURATION_SECONDS) {
+        "durationSeconds must be between $ASSUME_ROLE_MIN_DURATION_SECONDS and " +
+                "$ASSUME_ROLE_MAX_DURATION_SECONDS for AssumeRole, but was $durationSeconds."
+    }
+}
+
+/**
+ * GetSessionToken API의 `durationSeconds` 계약을 검증합니다.
+ *
+ * AWS STS GetSessionToken은 기본적으로 900~129600초 범위를 허용합니다.
+ */
+internal fun requireValidSessionTokenDuration(durationSeconds: Int) {
+    require(durationSeconds in SESSION_TOKEN_MIN_DURATION_SECONDS..SESSION_TOKEN_MAX_DURATION_SECONDS) {
+        "durationSeconds must be between $SESSION_TOKEN_MIN_DURATION_SECONDS and " +
+                "$SESSION_TOKEN_MAX_DURATION_SECONDS for GetSessionToken, but was $durationSeconds."
+    }
+}

--- a/aws-kotlin/sts/src/test/kotlin/io/bluetape4k/aws/kotlin/sts/StsClientTest.kt
+++ b/aws-kotlin/sts/src/test/kotlin/io/bluetape4k/aws/kotlin/sts/StsClientTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
+import kotlin.test.assertFailsWith
 
 /**
  * AWS Kotlin SDK [aws.sdk.kotlin.services.sts.StsClient] 확장 함수 테스트.
@@ -67,5 +68,25 @@ class StsClientTest: AbstractKotlinStsTest() {
         response.credentials!!.accessKeyId.shouldNotBeNull().shouldNotBeBlank()
         response.credentials!!.secretAccessKey.shouldNotBeNull().shouldNotBeBlank()
         response.credentials!!.sessionToken.shouldNotBeNull().shouldNotBeBlank()
+    }
+
+    @Test
+    @Order(5)
+    fun `AssumeRole durationSeconds 범위 검증`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            client.assumeRole(
+                roleArn = "arn:aws:iam::000000000000:role/TestRole",
+                sessionName = "invalid-session",
+                durationSeconds = 899,
+            )
+        }
+    }
+
+    @Test
+    @Order(6)
+    fun `GetSessionToken durationSeconds 범위 검증`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            client.getSessionToken(durationSeconds = 899)
+        }
     }
 }


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: aws-kotlin core/s3 안정성·문서 보강

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- aws-kotlin/s3 존재성 판별 로직을 보강해 `NoSuch*`/`NotFound`/HTTP 404만 `false`로 정규화하고 나머지 예외는 전파하도록 수정했습니다.
- aws-kotlin/s3 `putAll`/`getAll`이 실제 병렬 실행되도록 수정하고, 입력 순서 기반 결과 방출 계약을 유지했습니다.
- aws-kotlin/sqs `existsQueue` 예외 분류를 보강해 미존재 큐(`QueueDoesNotExist`/`ResourceNotFoundException`/404)만 `false`로 정규화했습니다.
- aws-kotlin/dynamodb `existsTable`이 `listTablesPaginated`로 전체 페이지를 순회하도록 개선했습니다.
- core/s3/sqs/dynamodb 공개 API KDoc 및 README를 최신 동작 계약 기준으로 보강했습니다.
- 회귀 테스트를 보강했습니다 (`S3ClientErrorClassifierTest`, `SqsClientErrorClassifierTest` 포함).

### 기존 섹션: 리뷰 포인트

- s3/sqs 존재성 판별의 예외 분류 계약(미존재만 false)
- s3 `putAll/getAll` 동시성 처리 및 순서 계약
- dynamodb `existsTable` 페이지네이션 기반 정확성

## Validation

- `./bin/repo-test-summary -- ./gradlew :bluetape4k-aws-kotlin-core:test :bluetape4k-aws-kotlin-cloudwatch:test :bluetape4k-aws-kotlin-dynamodb:test :bluetape4k-aws-kotlin-kinesis:test :bluetape4k-aws-kotlin-kms:test :bluetape4k-aws-kotlin-s3:test :bluetape4k-aws-kotlin-ses:test :bluetape4k-aws-kotlin-sesv2:test :bluetape4k-aws-kotlin-sns:test :bluetape4k-aws-kotlin-sqs:test :bluetape4k-aws-kotlin-sts:test`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #68, head `fe1ebb7423e7b27bd5729655d20a5c6e1ab1c60a`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/aws-kotlin-hardening`
- Labels: `enhancement`
- State: `MERGED`, merge commit `6735dda1140b46f18d7541a482cb7cb24eaeefa8`
- CI: - `./bin/repo-test-summary -- ./gradlew :bluetape4k-aws-kotlin-core:test :bluetape4k-aws-kotlin-cloudwatch:test :bluetape4k-aws-kotlin-dynamodb:test :bluetape4k-aws-kotlin-kinesis:test :bluetape4k-aws-kotlin-kms:test :bluetape4k-aws-kotlin-s3:test :bluetape4k-aws-kotlin-ses:test :bluetape4k-aws-kotlin-sesv2:test :bluetape4k-aws-kotlin-sns:test :bluetape4k-aws-kotlin-sqs:test :bluetape4k-aws-kotlin-sts:test`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #68 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `6735dda1140b46f18d7541a482cb7cb24eaeefa8`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
