### PR TITLE
refactor: io/io 모듈 okio 의존성 제거 및 README 정비

### DIFF
--- a/io/io/README.md
+++ b/io/io/README.md
@@ -115,101 +115,16 @@ val foryBytes = forySerializer.serialize(user)
 - **성능 우선**: Kryo, Fory (3-10배 빠름)
 - **저장 공간 절약**: LZ4Kryo, ZstdFory (압축 포함)
 
-### 3. Okio 통합 (비동기 I/O)
+### 3. Okio 통합
 
-Square의 Okio 라이브러리를 Kotlin Coroutines와 통합하여 비동기 I/O를 제공합니다.
-
-**주요 기능:**
-
-- Suspended Source/Sink (Coroutine 기반)
-- File/Socket Channel 지원
-- 암호화/복호화 스트림
-- Base64 인코딩/디코딩
-- 압축 스트림
+Okio 기반 I/O 기능(Source/Sink, 압축 스트림, 암호화 스트림, Coroutines 비동기 I/O 등)은
+별도의 [`bluetape4k-okio`](../okio/README.md) 모듈로 분리되어 있습니다.
 
 ```kotlin
-import io.bluetape4k.io.okio.coroutines.*
-import okio.Buffer
-import java.nio.file.Paths
-
-// Suspended 파일 읽기
-suspend fun readFileAsync(path: String): ByteArray {
-    val source = SuspendedFileChannelSource(Paths.get(path))
-    val buffer = Buffer()
-    source.use {
-        it.readAll(buffer)
-    }
-    return buffer.readByteArray()
+dependencies {
+    implementation("io.github.bluetape4k:bluetape4k-okio:${version}")
 }
-
-// Suspended 파일 쓰기
-suspend fun writeFileAsync(path: String, data: ByteArray) {
-    val sink = SuspendedFileChannelSink(Paths.get(path))
-    val buffer = Buffer().write(data)
-    sink.use {
-        it.write(buffer)
-        it.flush()
-    }
-}
-
-// 압축 스트림
-import io.bluetape4k.io.okio.compress.*
-import io.bluetape4k.io.compressor.Compressors
-
-val sink = /* ... */
-CompressableSink(sink, Compressors.Zstd).use { compressedSink ->
-    compressedSink.write(buffer, buffer.size)
-}
-
-// Tink 기반 암호화 스트림 (권장)
-import io.bluetape4k.io.okio.tink.*
-import io.bluetape4k.tink.encrypt.TinkEncryptors
-
-val encryptSink = sink.asTinkEncryptSink(TinkEncryptors.AES256_GCM)
-encryptSink.write(buffer, buffer.size)
-
-// 복호화
-val decryptSource = encryptedBuffer.asTinkDecryptSource(TinkEncryptors.AES256_GCM)
-val result = Buffer()
-decryptSource.readAllTo(result)
 ```
-
-**압축 + 암호화 조합:**
-
-```kotlin
-import io.bluetape4k.io.okio.tink.*
-import io.bluetape4k.io.okio.compress.*
-import io.bluetape4k.tink.encrypt.TinkEncryptors
-import io.bluetape4k.io.compressor.Compressors
-
-// 압축 → 암호화
-val sink = Buffer()
-sink.asTinkEncryptSink(TinkEncryptors.AES256_GCM)
-    .asCompressSink(Compressors.Zstd)
-    .use { it.write(buffer, buffer.size) }
-
-// 복호화 → 압축 해제
-val source = sink.asTinkDecryptSource(TinkEncryptors.AES256_GCM)
-    .asDecompressSource(Compressors.Zstd)
-```
-
-압축 Sink 사용 정책:
-
-- `CompressableSink`는 `close()` 시점에 압축 결과를 확정하므로 반드시 `close()` 또는 `use {}`를 사용해야 합니다.
-- `asCompressSink(StreamingCompressor)`도 footer/finalize 기록을 위해 `close()` 또는 `use {}`가 필요합니다.
-
-암호화 Sink/Source 현황:
-
-| 클래스 | 상태 | 대체 |
-|--------|------|------|
-| `TinkEncryptSink` | **권장** | — |
-| `TinkDecryptSource` | **권장** | — |
-| `EncryptSink` (jasypt) | Deprecated | `TinkEncryptSink` |
-| `DecryptSource` (jasypt) | Deprecated | `TinkDecryptSource` |
-| `FinalizingCipherSink` | Deprecated | `TinkEncryptSink` |
-| `StreamingCipherSource` | Deprecated | `TinkDecryptSource` |
-| `CipherSink` | Deprecated | `TinkEncryptSink` |
-| `CipherSource` | Deprecated | `TinkDecryptSource` |
 
 ### 4. 파일 유틸리티 (FileSupport)
 
@@ -369,54 +284,58 @@ dependencies {
 </dependency>
 ```
 
-## 성능 특성
+## 벤치마크 결과
 
-### 압축 알고리즘 비교 (1MB 텍스트 기준)
+### 직렬화 성능 비교
 
-| 알고리즘   | 압축 속도    | 해제 속도    | 압축률    | 용도      |
-|--------|----------|----------|--------|---------|
-| LZ4    | ~500MB/s | ~2GB/s   | 50-60% | 실시간 처리  |
-| Snappy | ~400MB/s | ~1.5GB/s | 50-60% | 범용      |
-| Zstd   | ~200MB/s | ~800MB/s | 65-75% | 균형 (추천) |
-| GZip   | ~50MB/s  | ~200MB/s | 65-75% | 호환성     |
-| BZip2  | ~10MB/s  | ~30MB/s  | 75-85% | 최대 압축   |
+`SimpleData` 객체 20개 컬렉션의 직렬화/역직렬화 처리량입니다.
 
-### 직렬화 방식 비교
+**Byte Array 속성이 없는 경우:**
 
-| 방식   | 속도    | 크기   | 호환성   | 특징      |
-|------|-------|------|-------|---------|
-| Jdk  | 1x    | 100% | ⭐⭐⭐⭐⭐ | Java 표준 |
-| Kryo | 3-5x  | 50%  | ⭐⭐⭐   | 빠르고 작음  |
-| Fory | 5-10x | 40%  | ⭐⭐    | 최고 성능   |
+| 라이브러리 | ops/s   | 비고 |
+|---------|---------|------|
+| Fory    | 305,821 | 최고 성능 |
+| Kryo    | 81,823  | 범용 추천 |
+| Jackson | 39,510  | JSON 기반 |
+| Jdk     | 22,249  | Java 표준 |
 
-## Coroutines 지원
+**Byte Array (4096 bytes) 포함 시:**
 
-모든 비동기 I/O 작업은 Kotlin Coroutines를 완벽하게 지원합니다.
+| 라이브러리 | ops/s  | 비고 |
+|---------|--------|------|
+| Fory    | 59,192 | 최고 성능 |
+| Kryo    | 29,329 | 범용 추천 |
+| Jdk     | 8,431  | Java 표준 |
+| Jackson | 4,323  | 바이너리 데이터에 불리 |
 
-```kotlin
-import kotlinx.coroutines.*
-import io.bluetape4k.io.okio.coroutines.*
+> Fory는 Kryo 대비 약 3배 이상 빠릅니다.
+> ByteArray가 포함된 경우, Jackson이 가장 느립니다.
 
-suspend fun processLargeFile(path: String) = coroutineScope {
-    val source = SuspendedFileChannelSource(Paths.get(path))
-    val buffer = Buffer()
+### 압축 성능 비교
 
-    source.use {
-        // Non-blocking 읽기
-        val bytesRead = it.read(buffer, 8192)
-        processData(buffer.readByteArray())
-    }
-}
+40KB UTF-8 텍스트 파일(`Utf8Samples.txt`) 기준 압축/복원 처리량입니다.
 
-// 병렬 파일 처리
-suspend fun processMultipleFiles(files: List<String>) = coroutineScope {
-    files.map { path ->
-        async(Dispatchers.IO) {
-            processLargeFile(path)
-        }
-    }.awaitAll()
-}
-```
+| 알고리즘 | ops/s | 특성 |
+|---------|-------|------|
+| Snappy  | 8,073 | 최고 속도 |
+| LZ4     | 6,769 | 실시간 처리 적합 |
+| Zstd    | 5,103 | 속도 + 압축률 균형 (추천) |
+| GZip    | 1,195 | 호환성 우수 |
+| Deflate | 1,084 | GZip 기반 |
+
+**직렬화 선택 가이드:**
+
+| 방식 | 속도 | 크기 | 호환성 | 추천 용도 |
+|------|------|------|-------|----------|
+| Fory | 5-10x | 40% | 보통 | 최고 성능이 필요한 내부 시스템 |
+| Kryo | 3-5x | 50% | 좋음 | 범용 (가장 추천) |
+| Jdk | 1x | 100% | 최고 | 외부 호환이 필요한 경우 |
+
+**압축 선택 가이드:**
+
+- **실시간 처리**: LZ4, Snappy (압축률 < 속도)
+- **네트워크 전송**: Zstd, GZip (속도 + 압축률 균형)
+- **저장 공간 최적화**: BZip2, Zstd (압축률 > 속도)
 
 ## Virtual Threads 지원 (Java 21+)
 
@@ -464,17 +383,6 @@ io.bluetape4k.io
 │   ├── BinarySerializer.kt
 │   ├── BinarySerializers.kt
 │   └── [각종 구현체]
-├── okio/               # Okio 통합
-│   ├── coroutines/     # Suspended I/O
-│   ├── channels/       # Channel 지원
-│   ├── tink/           # Tink 기반 암호화 (권장)
-│   │   ├── TinkEncryptSink.kt
-│   │   └── TinkDecryptSource.kt
-│   ├── cipher/         # javax.crypto.Cipher 기반 (Deprecated)
-│   │   ├── FinalizingCipherSink.kt
-│   │   └── StreamingCipherSource.kt
-│   ├── compress/       # 압축 스트림
-│   └── jasypt/         # Jasypt 암호화 (Deprecated)
 ├── FileSupport.kt          # 파일 유틸리티 (비동기 복사/이동/읽기/쓰기)
 ├── FileSupportResult.kt    # Result 패턴 파일 유틸리티 (tryXXXX API)
 ├── FileCoroutineSupport.kt # Coroutine 기반 파일 I/O (readAllBytesSuspending 등)
@@ -488,7 +396,7 @@ Apache License 2.0
 
 ## 참고
 
-- [Okio Documentation](https://square.github.io/okio/)
+- [bluetape4k-okio](../okio/README.md) (Okio 기반 I/O 모듈)
 - [Kryo Documentation](https://github.com/EsotericSoftware/kryo)
 - [Apache Fory](https://fory.apache.org/)
 - [LZ4 for Java](https://github.com/lz4/lz4-java)

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ApacheDeflateCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ApacheDeflateCompressor.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.io.compressor
 
 import io.bluetape4k.logging.KLogging
-import okio.Buffer
 import org.apache.commons.compress.compressors.deflate.DeflateCompressorInputStream
 import org.apache.commons.compress.compressors.deflate.DeflateCompressorOutputStream
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 
 /**
  * Apache Commons Compress 라이브러리의 [DeflateCompressorOutputStream]을 이용한 Deflate 압축기
@@ -26,12 +26,12 @@ class ApacheDeflateCompressor: AbstractCompressor() {
      * I/O 압축에서 `doCompress` 함수를 제공합니다.
      */
     override fun doCompress(plain: ByteArray): ByteArray {
-        val output = Buffer()
-        DeflateCompressorOutputStream(output.outputStream()).use { deflate ->
+        val output = ByteArrayOutputStream(plain.size)
+        DeflateCompressorOutputStream(output).use { deflate ->
             deflate.write(plain)
             deflate.flush()
         }
-        return output.readByteArray()
+        return output.toByteArray()
     }
 
     /**
@@ -40,7 +40,7 @@ class ApacheDeflateCompressor: AbstractCompressor() {
     override fun doDecompress(compressed: ByteArray): ByteArray {
         return ByteArrayInputStream(compressed).use { input ->
             DeflateCompressorInputStream(input).use { deflate ->
-                Buffer().readFrom(deflate).readByteArray()
+                deflate.readBytes()
             }
         }
     }

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ApacheGZipCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ApacheGZipCompressor.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.io.compressor
 
 import io.bluetape4k.logging.KLogging
-import okio.Buffer
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 
 /**
  * Apache Commons Compress 라이브러리의 [GzipCompressorOutputStream]을 이용한 GZip 압축기
@@ -26,12 +26,12 @@ class ApacheGZipCompressor: AbstractCompressor() {
      * I/O 압축에서 `doCompress` 함수를 제공합니다.
      */
     override fun doCompress(plain: ByteArray): ByteArray {
-        val output = Buffer()
-        GzipCompressorOutputStream(output.outputStream()).use { gzip ->
+        val output = ByteArrayOutputStream(plain.size)
+        GzipCompressorOutputStream(output).use { gzip ->
             gzip.write(plain)
             gzip.flush()
         }
-        return output.readByteArray()
+        return output.toByteArray()
     }
 
     /**
@@ -40,7 +40,7 @@ class ApacheGZipCompressor: AbstractCompressor() {
     override fun doDecompress(compressed: ByteArray): ByteArray {
         return ByteArrayInputStream(compressed).use { input ->
             GzipCompressorInputStream(input).use { gzip ->
-                Buffer().readFrom(gzip).readByteArray()
+                gzip.readBytes()
             }
         }
     }

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ApacheZstdCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ApacheZstdCompressor.kt
@@ -3,11 +3,11 @@ package io.bluetape4k.io.compressor
 import com.github.luben.zstd.Zstd
 import io.bluetape4k.io.compressor.ApacheZstdCompressor.Companion.DEFAULT_LEVEL
 import io.bluetape4k.logging.KLogging
-import okio.Buffer
 import org.apache.commons.compress.compressors.zstandard.ZstdCompressorInputStream
 import org.apache.commons.compress.compressors.zstandard.ZstdCompressorOutputStream
 import org.apache.commons.compress.compressors.zstandard.ZstdUtils
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 
 /**
  * Apache Compress 라이브러리의 Zstd 알고리즘을 사용한 Compressor (내부적으로 zstd-jni 라이브러리 사용)
@@ -45,17 +45,17 @@ class ApacheZstdCompressor private constructor(val level: Int): AbstractCompress
      * I/O 압축에서 `doCompress` 함수를 제공합니다.
      */
     override fun doCompress(plain: ByteArray): ByteArray {
-        val output = Buffer()
+        val output = ByteArrayOutputStream(plain.size)
         ZstdCompressorOutputStream(
             ZstdCompressorOutputStream.builder()
-                .setOutputStream(output.outputStream())
+                .setOutputStream(output)
                 .setLevel(level)
                 .outputStream
         ).use { zstd ->
             zstd.write(plain)
             zstd.flush()
         }
-        return output.readByteArray()
+        return output.toByteArray()
     }
 
     /**
@@ -64,7 +64,7 @@ class ApacheZstdCompressor private constructor(val level: Int): AbstractCompress
     override fun doDecompress(compressed: ByteArray): ByteArray {
         return ByteArrayInputStream(compressed).use { input ->
             ZstdCompressorInputStream(input).use { zstd ->
-                Buffer().readFrom(zstd).readByteArray()
+                zstd.readBytes()
             }
         }
     }

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/BZip2Compressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/BZip2Compressor.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.io.compressor
 
 import io.bluetape4k.logging.KLogging
-import okio.Buffer
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 
 /**
  * BZip2 알고리즘을 사용한 Compressor
@@ -28,12 +28,12 @@ class BZip2Compressor(
      * I/O 압축에서 `doCompress` 함수를 제공합니다.
      */
     override fun doCompress(plain: ByteArray): ByteArray {
-        val output = Buffer()
-        BZip2CompressorOutputStream(output.outputStream()).use { bzip2 ->
+        val output = ByteArrayOutputStream(plain.size)
+        BZip2CompressorOutputStream(output).use { bzip2 ->
             bzip2.write(plain)
             bzip2.flush()
         }
-        return output.readByteArray()
+        return output.toByteArray()
     }
 
     /**
@@ -42,7 +42,7 @@ class BZip2Compressor(
     override fun doDecompress(compressed: ByteArray): ByteArray {
         return ByteArrayInputStream(compressed).use { input ->
             BZip2CompressorInputStream(input).use { bzip2 ->
-                Buffer().readFrom(bzip2).readByteArray()
+                bzip2.readBytes()
             }
         }
     }

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/BlockLZ4Compressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/BlockLZ4Compressor.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.io.compressor
 
 import io.bluetape4k.logging.KLogging
-import okio.Buffer
 import org.apache.commons.compress.compressors.lz4.BlockLZ4CompressorInputStream
 import org.apache.commons.compress.compressors.lz4.BlockLZ4CompressorOutputStream
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 
 /**
  * Apache Compress 라이브러리의 Block LZ4 알고리즘을 사용한 Compressor
@@ -26,12 +26,12 @@ class BlockLZ4Compressor: AbstractCompressor() {
      * I/O 압축에서 `doCompress` 함수를 제공합니다.
      */
     override fun doCompress(plain: ByteArray): ByteArray {
-        val output = Buffer()
-        BlockLZ4CompressorOutputStream(output.outputStream()).use { lz4 ->
+        val output = ByteArrayOutputStream(plain.size)
+        BlockLZ4CompressorOutputStream(output).use { lz4 ->
             lz4.write(plain)
             lz4.flush()
         }
-        return output.readByteArray()
+        return output.toByteArray()
     }
 
     /**
@@ -40,7 +40,7 @@ class BlockLZ4Compressor: AbstractCompressor() {
     override fun doDecompress(compressed: ByteArray): ByteArray {
         return ByteArrayInputStream(compressed).use { input ->
             BlockLZ4CompressorInputStream(input).use { lz4 ->
-                Buffer().readFrom(lz4).readByteArray()
+                lz4.readBytes()
             }
         }
     }

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/DeflateCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/DeflateCompressor.kt
@@ -1,7 +1,7 @@
 package io.bluetape4k.io.compressor
 
-import okio.Buffer
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.util.zip.DeflaterOutputStream
 import java.util.zip.InflaterInputStream
 
@@ -23,12 +23,12 @@ class DeflateCompressor: AbstractCompressor() {
      * I/O 압축에서 `doCompress` 함수를 제공합니다.
      */
     override fun doCompress(plain: ByteArray): ByteArray {
-        val output = Buffer()
-        DeflaterOutputStream(output.outputStream()).use { deflate ->
+        val output = ByteArrayOutputStream(plain.size)
+        DeflaterOutputStream(output).use { deflate ->
             deflate.write(plain)
             deflate.finish()
         }
-        return output.readByteArray()
+        return output.toByteArray()
     }
 
     /**
@@ -37,7 +37,7 @@ class DeflateCompressor: AbstractCompressor() {
     override fun doDecompress(compressed: ByteArray): ByteArray {
         return ByteArrayInputStream(compressed).use { input ->
             InflaterInputStream(input).use { inflate ->
-                Buffer().readFrom(inflate).readByteArray()
+                inflate.readBytes()
             }
         }
     }

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/FramedLZ4Compressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/FramedLZ4Compressor.kt
@@ -1,9 +1,9 @@
 package io.bluetape4k.io.compressor
 
-import okio.Buffer
 import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorInputStream
 import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorOutputStream
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 
 /**
  * Apache Commons Compress FramedLZ4 알고리즘을 이용한 압축기
@@ -23,12 +23,12 @@ class FramedLZ4Compressor: AbstractCompressor() {
      * I/O 압축에서 `doCompress` 함수를 제공합니다.
      */
     override fun doCompress(plain: ByteArray): ByteArray {
-        val output = Buffer()
-        FramedLZ4CompressorOutputStream(output.outputStream()).use { lz4 ->
+        val output = ByteArrayOutputStream(plain.size)
+        FramedLZ4CompressorOutputStream(output).use { lz4 ->
             lz4.write(plain)
             lz4.flush()
         }
-        return output.readByteArray()
+        return output.toByteArray()
     }
 
     /**
@@ -37,7 +37,7 @@ class FramedLZ4Compressor: AbstractCompressor() {
     override fun doDecompress(compressed: ByteArray): ByteArray {
         return ByteArrayInputStream(compressed).use { input ->
             FramedLZ4CompressorInputStream(input).use { lz4 ->
-                Buffer().readFrom(lz4).readByteArray()
+                lz4.readBytes()
             }
         }
     }

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/FramedSnappyCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/FramedSnappyCompressor.kt
@@ -1,9 +1,9 @@
 package io.bluetape4k.io.compressor
 
-import okio.Buffer
 import org.apache.commons.compress.compressors.snappy.FramedSnappyCompressorInputStream
 import org.apache.commons.compress.compressors.snappy.FramedSnappyCompressorOutputStream
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 
 /**
  * Apache Commons Compress의 Framed Snappy 알고리즘을 사용한 Compressor
@@ -23,12 +23,12 @@ class FramedSnappyCompressor: AbstractCompressor() {
      * I/O 압축에서 `doCompress` 함수를 제공합니다.
      */
     override fun doCompress(plain: ByteArray): ByteArray {
-        val output = Buffer()
-        FramedSnappyCompressorOutputStream(output.outputStream()).use { snappy ->
+        val output = ByteArrayOutputStream(plain.size)
+        FramedSnappyCompressorOutputStream(output).use { snappy ->
             snappy.write(plain)
             snappy.flush()
         }
-        return output.readByteArray()
+        return output.toByteArray()
     }
 
     /**
@@ -37,7 +37,7 @@ class FramedSnappyCompressor: AbstractCompressor() {
     override fun doDecompress(compressed: ByteArray): ByteArray {
         return ByteArrayInputStream(compressed).use { input ->
             FramedSnappyCompressorInputStream(input).use { snappy ->
-                Buffer().readFrom(snappy).readByteArray()
+                snappy.readBytes()
             }
         }
     }

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/GZipCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/GZipCompressor.kt
@@ -1,7 +1,7 @@
 package io.bluetape4k.io.compressor
 
-import okio.Buffer
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
 
@@ -29,12 +29,12 @@ class GZipCompressor(
      * I/O 압축에서 `doCompress` 함수를 제공합니다.
      */
     override fun doCompress(plain: ByteArray): ByteArray {
-        val output = Buffer()
-        GZIPOutputStream(output.outputStream(), bufferSize).use { gzip ->
+        val output = ByteArrayOutputStream(plain.size)
+        GZIPOutputStream(output, bufferSize).use { gzip ->
             gzip.write(plain)
             gzip.finish()
         }
-        return output.readByteArray()
+        return output.toByteArray()
     }
 
     /**
@@ -43,7 +43,7 @@ class GZipCompressor(
     override fun doDecompress(compressed: ByteArray): ByteArray {
         return ByteArrayInputStream(compressed).use { input ->
             GZIPInputStream(input, bufferSize).use { gzip ->
-                Buffer().readFrom(gzip).readByteArray()
+                gzip.readBytes()
             }
         }
     }

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/JdkBinarySerializer.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/JdkBinarySerializer.kt
@@ -1,8 +1,8 @@
 package io.bluetape4k.io.serializer
 
 import io.bluetape4k.logging.KLogging
-import okio.Buffer
 import java.io.BufferedInputStream
+import java.io.ByteArrayOutputStream
 import java.io.BufferedOutputStream
 import java.io.ByteArrayInputStream
 import java.io.ObjectInputFilter
@@ -44,14 +44,14 @@ class JdkBinarySerializer(
      * I/O 직렬화에서 `doSerialize` 함수를 제공합니다.
      */
     override fun doSerialize(graph: Any): ByteArray {
-        val output = Buffer()
-        BufferedOutputStream(output.outputStream(), bufferSize).use { bos ->
+        val output = ByteArrayOutputStream(bufferSize)
+        BufferedOutputStream(output, bufferSize).use { bos ->
             ObjectOutputStream(bos).use { oos ->
                 oos.writeObject(graph)
                 oos.flush()
             }
         }
-        return output.readByteArray()
+        return output.toByteArray()
     }
 
     /**

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/KryoBinarySerializer.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/KryoBinarySerializer.kt
@@ -5,8 +5,8 @@ import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import com.esotericsoftware.kryo.util.Pool
 import io.bluetape4k.logging.KLogging
-import okio.Buffer
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 
 /**
  *  [Kryo](https://github.com/EsotericSoftware/kryo) 라이브러리를 이용하는 [BinarySerializer]
@@ -102,16 +102,16 @@ class KryoBinarySerializer(
      * I/O 직렬화에서 `doSerialize` 함수를 제공합니다.
      */
     override fun doSerialize(graph: Any): ByteArray {
-        val buffer = Buffer()
+        val buffer = ByteArrayOutputStream(bufferSize)
 
         Output(bufferSize, -1).use { output ->
-            output.outputStream = buffer.outputStream()
+            output.outputStream = buffer
             useKryo {
                 writeClassAndObject(output, graph)
             }
             output.flush()
         }
-        return buffer.readByteArray()
+        return buffer.toByteArray()
     }
 
     /**

--- a/io/okio/README.md
+++ b/io/okio/README.md
@@ -1,0 +1,277 @@
+# Module bluetape4k-okio
+
+## 개요
+
+`bluetape4k-okio`는 Square의 [Okio](https://square.github.io/okio/) 라이브러리를 기반으로 한 고성능 I/O 확장 모듈입니다.
+Okio의 `Source`/`Sink` 추상화 위에 압축, 암호화, Base64 인코딩, NIO 채널 통합, Kotlin Coroutines 비동기 I/O 등을 제공합니다.
+
+## 주요 기능
+
+### 1. Buffer / ByteString 유틸리티
+
+Okio `Buffer`와 `ByteString` 생성을 위한 팩토리 함수와 확장 함수를 제공합니다.
+
+```kotlin
+import io.bluetape4k.okio.*
+
+// Buffer 생성
+val buffer = bufferOf("Hello, Okio!")
+val buffer2 = bufferOf(byteArrayOf(1, 2, 3))
+val buffer3 = bufferOf(inputStream)
+
+// ByteString 생성
+val byteString = byteStringOf("Hello")
+val byteString2 = byteStringOf(byteArrayOf(1, 2, 3))
+```
+
+### 2. Source / Sink 확장
+
+`InputStream`/`OutputStream`을 Okio `Source`/`Sink`로 변환하는 어댑터를 제공합니다.
+
+```kotlin
+import io.bluetape4k.okio.*
+
+// InputStream → Source
+val source = inputStream.asSource()
+
+// OutputStream → Sink
+val sink = outputStream.asSink()
+```
+
+### 3. NIO 채널 지원
+
+Java NIO `ReadableByteChannel`/`WritableByteChannel`/`FileChannel`을 Okio와 통합합니다.
+
+```kotlin
+import io.bluetape4k.okio.channels.*
+
+// ByteChannel → Source/Sink
+val source = readableByteChannel.asSource()
+val sink = writableByteChannel.asSink()
+
+// FileChannel → Source/Sink
+val fileSource = FileChannelSource(fileChannel)
+val fileSink = FileChannelSink(fileChannel)
+```
+
+### 4. 압축 스트림
+
+`bluetape4k-io`의 `Compressor`/`StreamingCompressor`를 Okio Sink/Source로 래핑하여 스트리밍 압축/해제를 지원합니다.
+
+```kotlin
+import io.bluetape4k.okio.compress.*
+import io.bluetape4k.io.compressor.Compressors
+
+// 압축 Sink (close 시점에 압축 확정)
+val compressSink = sink.asCompressSink(Compressors.LZ4)
+compressSink.use { cs ->
+    cs.write(buffer, buffer.size)
+}
+
+// 복원 Source
+val decompressSource = source.asDecompressSource(Compressors.LZ4)
+decompressSource.use { ds ->
+    ds.read(outputBuffer, Long.MAX_VALUE)
+}
+
+// StreamingCompressor 사용 (대용량 스트리밍)
+val streamingSink = sink.asCompressSink(Compressors.Streaming.Zstd)
+val streamingSource = source.asDecompressSource(Compressors.Streaming.Zstd)
+```
+
+**주의사항:**
+- `CompressableSink`는 `close()` 시점에 압축 결과가 확정됩니다. 반드시 `close()` 또는 `use {}`를 사용하세요.
+- `StreamingCompressSink`도 footer/finalize 기록을 위해 `close()`가 필요합니다.
+
+### 5. Tink 암호화 (권장)
+
+Google Tink AEAD 기반 암호화 Sink/Source를 제공합니다.
+
+```kotlin
+import io.bluetape4k.okio.tink.*
+import io.bluetape4k.tink.encrypt.TinkEncryptors
+
+// 암호화 Sink
+val encryptSink = sink.asTinkEncryptSink(TinkEncryptors.AES256_GCM)
+encryptSink.write(buffer, buffer.size)
+
+// 복호화 Source
+val decryptSource = source.asTinkDecryptSource(TinkEncryptors.AES256_GCM)
+val result = Buffer()
+decryptSource.read(result, Long.MAX_VALUE)
+```
+
+**암호화 + 압축 조합:**
+
+```kotlin
+// 압축 → 암호화
+val combinedSink = sink
+    .asTinkEncryptSink(TinkEncryptors.AES256_GCM)
+    .asCompressSink(Compressors.Zstd)
+
+combinedSink.use { it.write(buffer, buffer.size) }
+```
+
+### 6. Base64 인코딩/디코딩
+
+Okio Sink/Source 기반 Base64 인코딩/디코딩을 제공합니다.
+
+```kotlin
+import io.bluetape4k.okio.base64.*
+
+// Base64 인코딩 Sink
+val encodeSink = ApacheBase64Sink(delegate)
+encodeSink.write(buffer, buffer.size)
+
+// Base64 디코딩 Source
+val decodeSource = ApacheBase64Source(delegate)
+decodeSource.read(outputBuffer, Long.MAX_VALUE)
+```
+
+### 7. Cipher 암호화 (Deprecated)
+
+javax.crypto 기반 암호화. Tink 기반으로 마이그레이션을 권장합니다.
+
+| 클래스 | 상태 | 대체 |
+|--------|------|------|
+| `TinkEncryptSink` | **권장** | — |
+| `TinkDecryptSource` | **권장** | — |
+| `FinalizingCipherSink` | Deprecated | `TinkEncryptSink` |
+| `StreamingCipherSource` | Deprecated | `TinkDecryptSource` |
+| `CipherSink` | Deprecated | `TinkEncryptSink` |
+| `CipherSource` | Deprecated | `TinkDecryptSource` |
+| `JasyptSink` | Deprecated | `TinkEncryptSink` |
+| `JasyptSource` | Deprecated | `TinkDecryptSource` |
+
+### 8. Kotlin Coroutines 비동기 I/O
+
+Okio Source/Sink를 Kotlin Coroutines `suspend` 함수로 래핑하여 비동기 I/O를 제공합니다.
+
+```kotlin
+import io.bluetape4k.okio.coroutines.*
+import java.nio.file.Paths
+
+// Suspended 파일 읽기
+suspend fun readFileAsync(path: String): ByteArray {
+    val source = SuspendedFileChannelSource(Paths.get(path))
+    val buffer = Buffer()
+    source.use { it.readAll(buffer) }
+    return buffer.readByteArray()
+}
+
+// Suspended 파일 쓰기
+suspend fun writeFileAsync(path: String, data: ByteArray) {
+    val sink = SuspendedFileChannelSink(Paths.get(path))
+    val buffer = Buffer().write(data)
+    sink.use {
+        it.write(buffer)
+        it.flush()
+    }
+}
+
+// Suspended Socket 통신
+val socketSource = SuspendedSocketChannelSource(socketChannel)
+val socketSink = SuspendedSocketChannelSink(socketChannel)
+```
+
+**Suspended Pipe (생산자-소비자 패턴):**
+
+```kotlin
+import io.bluetape4k.okio.coroutines.*
+
+val pipe = SuspendedPipe()
+
+// 생산자
+launch {
+    pipe.sink.use { sink ->
+        sink.write(Buffer().writeUtf8("Hello"))
+        sink.flush()
+    }
+}
+
+// 소비자
+launch {
+    pipe.source.use { source ->
+        val buffer = Buffer()
+        source.read(buffer, Long.MAX_VALUE)
+    }
+}
+```
+
+## 의존성 추가
+
+### Gradle (Kotlin DSL)
+
+```kotlin
+dependencies {
+    implementation("io.github.bluetape4k:bluetape4k-okio:${version}")
+
+    // 필수 (자동 포함)
+    // io.github.bluetape4k:bluetape4k-io
+    // com.squareup.okio:okio
+
+    // 선택적 의존성 (필요한 기능에 따라 추가)
+    implementation("io.github.bluetape4k:bluetape4k-tink:${version}")        // Tink 암호화
+    implementation("io.github.bluetape4k:bluetape4k-coroutines:${version}")  // Coroutines 비동기 I/O
+    implementation("commons-codec:commons-codec:1.17.0")                     // Base64
+}
+```
+
+## 모듈 구조
+
+```
+io.bluetape4k.okio
+├── BufferSupport.kt            # Buffer 팩토리 (bufferOf)
+├── ByteStringSupport.kt        # ByteString 팩토리 (byteStringOf)
+├── SinkSupport.kt              # Sink 확장 함수
+├── SourceSupport.kt            # Source 확장 함수
+├── InputStreamSource.kt        # InputStream → Source 어댑터
+├── OutputStreamSink.kt         # OutputStream → Sink 어댑터
+├── channels/                   # NIO 채널 통합
+│   ├── FileChannelSink.kt
+│   ├── FileChannelSource.kt
+│   ├── ByteChannelSink.kt
+│   └── ByteChannelSource.kt
+├── compress/                   # 압축 스트림
+│   ├── CompressableSink.kt     # Compressor 기반 압축 Sink
+│   ├── DecompressableSource.kt # Compressor 기반 복원 Source
+│   ├── SinkWithCompressor.kt   # 레거시 호환 압축 Sink
+│   ├── SourceWithCompressor.kt # 레거시 호환 복원 Source
+│   └── Compressable.kt         # 압축 인터페이스
+├── tink/                       # Tink AEAD 암호화 (권장)
+│   ├── TinkEncryptSink.kt
+│   └── TinkDecryptSource.kt
+├── cipher/                     # javax.crypto 암호화 (Deprecated)
+│   ├── FinalizingCipherSink.kt
+│   ├── StreamingCipherSource.kt
+│   ├── CipherSink.kt
+│   └── CipherSource.kt
+├── jasypt/                     # Jasypt 암호화 (Deprecated)
+│   ├── JasyptSink.kt
+│   └── JasyptSource.kt
+├── base64/                     # Base64 인코딩/디코딩
+│   ├── ApacheBase64Sink.kt
+│   ├── ApacheBase64Source.kt
+│   ├── OkioBase64Sink.kt
+│   └── OkioBase64Source.kt
+└── coroutines/                 # Kotlin Coroutines 비동기 I/O
+    ├── SuspendedSource.kt
+    ├── SuspendedSink.kt
+    ├── SuspendedFileChannelSource.kt
+    ├── SuspendedFileChannelSink.kt
+    ├── SuspendedSocketChannelSource.kt
+    ├── SuspendedSocketChannelSink.kt
+    ├── SuspendedPipe.kt
+    └── [Buffered 구현체 등]
+```
+
+## 라이선스
+
+Apache License 2.0
+
+## 참고
+
+- [Okio Documentation](https://square.github.io/okio/)
+- [Google Tink](https://developers.google.com/tink)
+- [bluetape4k-io](../io/README.md)
+- [bluetape4k-tink](../tink/README.md)


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: refactor: io/io 모듈 okio 의존성 제거 및 README 정비

- io/io 모듈의 compressor 9개, serializer 2개에서 `okio.Buffer` → `ByteArrayOutputStream` 교체하여 okio 의존성 완전 제거
- io/io README.md에 실제 벤치마크 결과(Benchmark.md 기반) 추가 및 okio 관련 섹션을 io/okio 모듈 안내로 교체
- io/okio README.md 신규 작성 (모듈 구조, 사용법, 의존성 가이드)

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Test plan

- [x] `bluetape4k-io` 컴파일 성공
- [x] `bluetape4k-okio` 컴파일 성공
- [x] `bluetape4k-io` + `bluetape4k-okio` 테스트 1309개 전부 통과
- [x] io/io 모듈에 okio import 잔존 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #70, head `9f635504abff85b7a03cf33f73b527b2c55f6f47`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `claude/dazzling-brown`
- Labels: `enhancement`
- State: `MERGED`, merge commit `547b26940f5be1ed0ac6ba9370e361d8d76403fc`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #70 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `547b26940f5be1ed0ac6ba9370e361d8d76403fc`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
