### PR TITLE
fix: cache-ignite2 ARM64 hang 방지 및 untilSuspending 안정성 복원

### DIFF
--- a/infra/cache-ignite2/src/main/kotlin/io/bluetape4k/cache/jcache/IgniteClientSuspendCache.kt
+++ b/infra/cache-ignite2/src/main/kotlin/io/bluetape4k/cache/jcache/IgniteClientSuspendCache.kt
@@ -1,16 +1,16 @@
 package io.bluetape4k.cache.jcache
 
 import io.bluetape4k.coroutines.support.awaitSuspending
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.future.asDeferred
-import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 import org.apache.ignite.cache.query.ContinuousQuery
 import org.apache.ignite.cache.query.ScanQuery
 import org.apache.ignite.client.ClientCache
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Future
 import javax.cache.configuration.CacheEntryListenerConfiguration
 import javax.cache.event.CacheEntryCreatedListener
 import javax.cache.event.CacheEntryExpiredListener
@@ -37,6 +37,17 @@ class IgniteClientSuspendCache<K: Any, V: Any>(
     private val cache: ClientCache<K, V>,
 ): SuspendCache<K, V> {
 
+    companion object {
+        /**
+         * Ignite 연산 최대 대기 시간 (ms).
+         *
+         * ARM64 환경에서 IgniteClientFuture가 완료되지 않아 무한 대기하는 현상 방지.
+         * [awaitSuspending]이 내부적으로 폴링 기반 [FutureToCompletableFutureWrapper]를 사용하므로
+         * Future가 완료되지 않으면 영구 hang 가능 → 30초 상한으로 보호합니다.
+         */
+        const val OPERATION_TIMEOUT_MS = 30_000L
+    }
+
     /** ContinuousQuery 기반 리스너 등록 시 반환된 커서 맵. deregister 시 닫기 위해 보관. */
     private val queryCursors = ConcurrentHashMap<CacheEntryListenerConfiguration<K, V>, AutoCloseable>()
 
@@ -46,7 +57,7 @@ class IgniteClientSuspendCache<K: Any, V: Any>(
     }
 
     override suspend fun clear() {
-        cache.clearAsync().awaitSuspending()
+        cache.clearAsync().awaitOrTimeout()
     }
 
     override suspend fun close() {
@@ -56,65 +67,66 @@ class IgniteClientSuspendCache<K: Any, V: Any>(
     override fun isClosed(): Boolean = false
 
     override suspend fun containsKey(key: K): Boolean =
-        cache.containsKeyAsync(key).awaitSuspending()
+        cache.containsKeyAsync(key).awaitOrTimeout()
 
     override suspend fun get(key: K): V? =
-        cache.getAsync(key).awaitSuspending()
+        cache.getAsync(key).awaitOrTimeout()
 
     override fun getAll(): Flow<SuspendCacheEntry<K, V>> = entries()
 
     override fun getAll(keys: Set<K>): Flow<SuspendCacheEntry<K, V>> = flow {
-        cache.getAllAsync(keys).awaitSuspending().forEach { (key, value) ->
+        cache.getAllAsync(keys).awaitOrTimeout().forEach { (key, value) ->
             emit(SuspendCacheEntry(key, value))
         }
     }
 
     override suspend fun getAndPut(key: K, value: V): V? =
-        cache.getAndPutAsync(key, value).awaitSuspending()
+        cache.getAndPutAsync(key, value).awaitOrTimeout()
 
     override suspend fun getAndRemove(key: K): V? =
-        cache.getAndRemoveAsync(key).awaitSuspending()
+        cache.getAndRemoveAsync(key).awaitOrTimeout()
 
     override suspend fun getAndReplace(key: K, value: V): V? =
-        cache.getAndReplaceAsync(key, value).awaitSuspending()
+        cache.getAndReplaceAsync(key, value).awaitOrTimeout()
 
     override suspend fun put(key: K, value: V) {
-        cache.putAsync(key, value).awaitSuspending()
+        cache.putAsync(key, value).awaitOrTimeout()
     }
 
     override suspend fun putAll(map: Map<K, V>) {
-        cache.putAllAsync(map).awaitSuspending()
+        cache.putAllAsync(map).awaitOrTimeout()
     }
 
     override suspend fun putAllFlow(entries: Flow<Pair<K, V>>) {
-        entries
-            .map { cache.putAsync(it.first, it.second).asDeferred() }
-            .toList()
-            .joinAll()
+        coroutineScope {
+            entries.collect { (key, value) ->
+                launch { cache.putAsync(key, value).awaitOrTimeout() }
+            }
+        }
     }
 
     override suspend fun putIfAbsent(key: K, value: V): Boolean =
-        cache.putIfAbsentAsync(key, value).awaitSuspending()
+        cache.putIfAbsentAsync(key, value).awaitOrTimeout()
 
     override suspend fun remove(key: K): Boolean =
-        cache.removeAsync(key).awaitSuspending()
+        cache.removeAsync(key).awaitOrTimeout()
 
     override suspend fun remove(key: K, oldValue: V): Boolean =
-        cache.removeAsync(key, oldValue).awaitSuspending()
+        cache.removeAsync(key, oldValue).awaitOrTimeout()
 
     override suspend fun removeAll() {
-        cache.removeAllAsync().awaitSuspending()
+        cache.removeAllAsync().awaitOrTimeout()
     }
 
     override suspend fun removeAll(keys: Set<K>) {
-        cache.removeAllAsync(keys).awaitSuspending()
+        cache.removeAllAsync(keys).awaitOrTimeout()
     }
 
     override suspend fun replace(key: K, oldValue: V, newValue: V): Boolean =
-        cache.replaceAsync(key, oldValue, newValue).awaitSuspending()
+        cache.replaceAsync(key, oldValue, newValue).awaitOrTimeout()
 
     override suspend fun replace(key: K, value: V): Boolean =
-        cache.replaceAsync(key, value).awaitSuspending()
+        cache.replaceAsync(key, value).awaitOrTimeout()
 
     /**
      * ContinuousQuery의 localListener를 사용해 캐시 이벤트 리스너를 등록합니다.
@@ -154,4 +166,11 @@ class IgniteClientSuspendCache<K: Any, V: Any>(
     override fun deregisterCacheEntryListener(configuration: CacheEntryListenerConfiguration<K, V>) {
         queryCursors.remove(configuration)?.close()
     }
+
+    /**
+     * ARM64에서 [IgniteClientFuture]가 완료되지 않아 무한 대기하는 현상 방지를 위해
+     * [awaitSuspending] 호출에 [OPERATION_TIMEOUT_MS] 상한을 적용합니다.
+     */
+    private suspend fun <T> Future<T>.awaitOrTimeout(): T =
+        withTimeout(OPERATION_TIMEOUT_MS) { awaitSuspending() }
 }

--- a/infra/cache-ignite2/src/main/kotlin/io/bluetape4k/cache/jcache/IgniteSuspendCache.kt
+++ b/infra/cache-ignite2/src/main/kotlin/io/bluetape4k/cache/jcache/IgniteSuspendCache.kt
@@ -3,14 +3,13 @@ package io.bluetape4k.cache.jcache
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.support.requireNotBlank
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.future.asDeferred
 import kotlinx.coroutines.future.await
-import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import org.apache.ignite.IgniteCache
 import org.apache.ignite.lang.IgniteFuture
 import java.util.concurrent.CompletableFuture
@@ -37,6 +36,13 @@ import org.apache.ignite.cache.CachingProvider as IgniteCachingProvider
 class IgniteSuspendCache<K: Any, V: Any>(private val cache: JCache<K, V>): SuspendCache<K, V> {
 
     companion object: KLoggingChannel() {
+        /**
+         * Ignite 연산 최대 대기 시간 (ms).
+         *
+         * ARM64 환경에서 [IgniteFuture.listen] 콜백이 발화하지 않아 무한 대기하는 현상 방지.
+         */
+        const val OPERATION_TIMEOUT_MS = 30_000L
+
         /**
          * 캐시 이름과 구성으로 [IgniteSuspendCache]를 생성합니다.
          *
@@ -149,11 +155,11 @@ class IgniteSuspendCache<K: Any, V: Any>(private val cache: JCache<K, V>): Suspe
 
     override suspend fun putAllFlow(entries: Flow<Pair<K, V>>) {
         if (igniteCache != null) {
-            entries
-                .map { igniteCache.putAsync(it.first, it.second).toCompletableFuture() }
-                .toList()
-                .map { it.asDeferred() }
-                .joinAll()
+            coroutineScope {
+                entries.collect { (key, value) ->
+                    launch { igniteCache.putAsync(key, value).awaitIgnite() }
+                }
+            }
             return
         }
         entries.collect { put(it.first, it.second) }
@@ -210,4 +216,9 @@ private fun <T> IgniteFuture<T>.toCompletableFuture(): CompletableFuture<T> {
     return cf
 }
 
-private suspend fun <T> IgniteFuture<T>.awaitIgnite(): T = toCompletableFuture().await()
+/**
+ * ARM64에서 [IgniteFuture.listen] 콜백이 발화하지 않아 무한 대기하는 현상 방지를 위해
+ * [IgniteSuspendCache.OPERATION_TIMEOUT_MS] 상한을 적용합니다.
+ */
+private suspend fun <T> IgniteFuture<T>.awaitIgnite(): T =
+    withTimeout(IgniteSuspendCache.OPERATION_TIMEOUT_MS) { toCompletableFuture().await() }

--- a/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/awaitility/AwaitilityCoroutines.kt
+++ b/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/awaitility/AwaitilityCoroutines.kt
@@ -1,8 +1,6 @@
 package io.bluetape4k.junit5.awaitility
 
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.withTimeout
 import org.awaitility.Durations
 import org.awaitility.constraint.WaitConstraint
 import org.awaitility.core.ConditionFactory
@@ -84,18 +82,11 @@ suspend infix fun ConditionFactory.untilSuspending(
     var lastInterval: Duration = initialPollDelay
     var lastThrowable: Throwable? = null
 
-    // 개별 poll 호출의 최대 대기 시간 (block()이 suspend 상태로 hang되는 것을 방지)
-    val perPollTimeoutMs = maxOf(timeout.toMillis() / 2, 5_000L)
-
     while (true) {
         val satisfied = try {
-            val result = withTimeout(perPollTimeoutMs) { block() }
+            val result = block()
             lastThrowable = null
             result
-        } catch (e: TimeoutCancellationException) {
-            // block() 자체가 hang된 경우 — false로 처리하고 다음 폴링에서 재시도
-            lastThrowable = e
-            false
         } catch (e: Throwable) {
             if (exceptionIgnorer?.shouldIgnoreException(e) == true) {
                 lastThrowable = e


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: cache-ignite2 ARM64 hang 방지 및 untilSuspending 안정성 복원

- cache-ignite2 모듈의 `IgniteClientSuspendCache`, `IgniteSuspendCache` 모든 async 연산에 `withTimeout(30초)` 보호 추가
- `untilSuspending`의 per-poll `withTimeout` 제거하여 Redisson 등 다른 모듈 테스트 실패 해결
- `putAllFlow`의 `asDeferred()` 경로도 timeout 보호 적용 (`coroutineScope + launch`)

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 근본 원인

- ARM64에서 Ignite 2.x thin client `IgniteClientFuture`가 완료되지 않으면 `FutureToCompletableFutureWrapper` 폴링 루프 영구 실행 → hang
- `untilSuspending`에 추가된 per-poll timeout이 Redisson 정상 연산을 조기 취소시켜 테스트 실패 유발

### 기존 섹션: Test plan

- [x] `./gradlew :bluetape4k-cache-ignite2:compileKotlin` 성공
- [x] `./gradlew :bluetape4k-cache-ignite2:compileTestKotlin` 성공
- [x] `./gradlew :bluetape4k-junit5:compileKotlin` 성공
- [ ] `bluetape4k-redisson` 테스트 통과 확인
- [ ] `cache-ignite2` 테스트 hang 없이 완료 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #74, head `c1712e85b903bab59fe156bf60fe72bcf7979378`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/ignite2-test-stability`
- Labels: `bug`
- State: `CLOSED`, merge commit `N/A`
- CI: - [x] `./gradlew :bluetape4k-cache-ignite2:compileKotlin` 성공 / - [x] `./gradlew :bluetape4k-cache-ignite2:compileTestKotlin` 성공 / - [x] `./gradlew :bluetape4k-junit5:compileKotlin` 성공

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #74 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: CLOSED (not merged; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
