### PR TITLE
fix: cache-ignite2 및 redisson 테스트 안정화

### DIFF
--- a/infra/cache-ignite2/src/test/kotlin/io/bluetape4k/cache/IgniteCachesTest.kt
+++ b/infra/cache-ignite2/src/test/kotlin/io/bluetape4k/cache/IgniteCachesTest.kt
@@ -7,9 +7,13 @@ import io.bluetape4k.cache.nearcache.NearCache
 import io.bluetape4k.cache.nearcache.SuspendNearCache
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.KLogging
+import kotlinx.coroutines.withTimeoutOrNull
+import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
+import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.testcontainers.utility.Base58
+import kotlin.time.Duration.Companion.seconds
 
 class IgniteCachesTest {
 
@@ -33,6 +37,27 @@ class IgniteCachesTest {
         try {
             cache.shouldBeInstanceOf<IgniteClientSuspendCache<*, *>>()
         } finally {
+            runCatching { cache.close() }
+        }
+    }
+
+    @RepeatedTest(3)
+    fun `clientSuspendCache - 동적 cache 생성 직후에도 hang 없이 접근할 수 있다`() = runSuspendIO {
+        val cacheName = "ignite-caches-test-dynamic-" + Base58.randomString(6)
+        val key = "key-" + Base58.randomString(6)
+        val value = "value-" + Base58.randomString(12)
+        val clientCache = IgniteServers.getOrCreateCache<String, String>(cacheName)
+        val cache = IgniteCaches.clientSuspendCache<String, String>(clientCache)
+
+        try {
+            val result = withTimeoutOrNull(10.seconds) {
+                cache.put(key, value)
+                cache.get(key)
+            }
+
+            result shouldBeEqualTo value
+        } finally {
+            runCatching { clientCache.clear() }
             runCatching { cache.close() }
         }
     }

--- a/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/nearcache/RedissonNearCacheTest.kt
+++ b/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/nearcache/RedissonNearCacheTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.redis.redisson.nearcache
 
 import io.bluetape4k.codec.Base58
 import io.bluetape4k.coroutines.support.awaitSuspending
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.junit5.awaitility.untilSuspending
 import io.bluetape4k.junit5.faker.Fakers
 import io.bluetape4k.logging.KLogging
@@ -10,7 +11,6 @@ import io.bluetape4k.redis.redisson.codec.RedissonCodecs
 import io.bluetape4k.testcontainers.storage.RedisServer
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeNull
@@ -204,7 +204,7 @@ class RedissonNearCacheTest {
     inner class Async {
 
         @RepeatedTest(REPEAT_SIZE)
-        fun `nearCache1 에 cache item을 추가하면 nearCache2에 추가됩니다`() = runTest {
+        fun `nearCache1 에 cache item을 추가하면 nearCache2에 추가됩니다`() = runSuspendIO {
             val keyToAdd = randomName()
             val valueToAdd = randomName()
 
@@ -219,7 +219,7 @@ class RedissonNearCacheTest {
         }
 
         @RepeatedTest(REPEAT_SIZE)
-        fun `nearCache1 에 cache item을 삭제하면 nearCache2에 삭제됩니다`() = runTest {
+        fun `nearCache1 에 cache item을 삭제하면 nearCache2에 삭제됩니다`() = runSuspendIO {
             val keyToRemove = randomName()
             val valueToRemove = randomName()
 
@@ -240,7 +240,7 @@ class RedissonNearCacheTest {
         }
 
         @RepeatedTest(REPEAT_SIZE)
-        fun `backCache 에 캐시를 추가하면, near cache 들에게 반영된다`() = runTest {
+        fun `backCache 에 캐시를 추가하면, near cache 들에게 반영된다`() = runSuspendIO {
             val key = randomName()
             val value = randomValue()
 
@@ -273,7 +273,7 @@ class RedissonNearCacheTest {
         }
 
         @RepeatedTest(REPEAT_SIZE)
-        fun `frontCache에 expiration을 설정하면, 해당 시간이 지나면 자동으로 삭제된다`() = runTest {
+        fun `frontCache에 expiration을 설정하면, 해당 시간이 지나면 자동으로 삭제된다`() = runSuspendIO {
             val key1 = randomName()
             val value1 = randomValue()
 

--- a/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/awaitility/AwaitilityCoroutines.kt
+++ b/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/awaitility/AwaitilityCoroutines.kt
@@ -1,8 +1,10 @@
 package io.bluetape4k.junit5.awaitility
 
-import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.selects.onTimeout
+import kotlinx.coroutines.selects.select
 import org.awaitility.Durations
 import org.awaitility.constraint.WaitConstraint
 import org.awaitility.core.ConditionFactory
@@ -53,6 +55,7 @@ suspend infix fun ConditionFactory.awaitSuspending(
  *
  * ## 동작/계약
  * - 초기 지연과 poll interval을 반영해 반복 호출하며, 호출 스레드를 block 하지 않습니다.
+ * - 개별 poll을 별도 timeout으로 취소하지 않고, 전체 await timeout 안에서 suspend block을 실행합니다.
  * - 예외 무시 설정이 있으면 해당 예외는 마지막 원인으로 저장하고 계속 재시도합니다.
  * - 타임아웃 초과 시 [ConditionTimeoutException]을 던집니다.
  * - 수신 [ConditionFactory]는 변경하지 않고, 내부 루프 상태만 지역 변수로 관리합니다.
@@ -67,36 +70,55 @@ suspend infix fun ConditionFactory.awaitSuspending(
  */
 suspend infix fun ConditionFactory.untilSuspending(
     block: suspend () -> Boolean,
-) {
+) = coroutineScope {
     val timeout = timeoutConstraintOrDefault().maxWaitTime
     val pollInterval = pollIntervalOrDefault()
     val initialPollDelay = pollDelayOrDefault(pollInterval)
     val exceptionIgnorer = exceptionIgnorerOrNull()
 
-    val startNanos = System.nanoTime()
-    val timeoutNanos = timeout.toNanosSafely()
-
-    if (!initialPollDelay.isZero && !initialPollDelay.isNegative) {
-        delay(initialPollDelay.toMillisCeil())
-    }
-
     var pollCount = 1
     var lastInterval: Duration = initialPollDelay
     var lastThrowable: Throwable? = null
 
-    // 개별 poll 호출의 최대 대기 시간 (block()이 suspend 상태로 hang되는 것을 방지)
-    val perPollTimeoutMs = maxOf(timeout.toMillis() / 2, 5_000L)
+    val startNanos = System.nanoTime()
+    val timeoutNanos = timeout.toNanosSafely()
+
+    if (!initialPollDelay.isZero && !initialPollDelay.isNegative) {
+        val initialDelayNanos = minOf(initialPollDelay.toNanosSafely(), timeoutNanos)
+        if (initialDelayNanos > 0) {
+            delay(nanosToMillisCeil(initialDelayNanos))
+        }
+    }
 
     while (true) {
+        val remainingNanos = timeoutNanos - (System.nanoTime() - startNanos)
+        if (remainingNanos <= 0L) {
+            throw conditionTimeoutException(timeout, lastThrowable)
+        }
+
         val satisfied = try {
-            val result = withTimeout(perPollTimeoutMs) { block() }
-            lastThrowable = null
-            result
-        } catch (e: TimeoutCancellationException) {
-            // block() 자체가 hang된 경우 — false로 처리하고 다음 폴링에서 재시도
-            lastThrowable = e
-            false
+            val pollDeferred = async { runCatching { block() } }
+            val pollResult = select<Any?> {
+                pollDeferred.onAwait { result ->
+                    result
+                }
+                onTimeout(nanosToMillisCeil(remainingNanos)) {
+                    pollDeferred.cancel()
+                    PollTimedOut
+                }
+            }
+
+            if (pollResult === PollTimedOut) {
+                throw conditionTimeoutException(timeout, lastThrowable)
+            }
+
+            (pollResult as Result<Boolean>).getOrThrow().also {
+                lastThrowable = null
+            }
         } catch (e: Throwable) {
+            if (e is ConditionTimeoutException) {
+                throw e
+            }
             if (exceptionIgnorer?.shouldIgnoreException(e) == true) {
                 lastThrowable = e
                 false
@@ -105,26 +127,14 @@ suspend infix fun ConditionFactory.untilSuspending(
             }
         }
 
-        if (satisfied) return
-
-        val elapsedNanos = System.nanoTime() - startNanos
-        if (elapsedNanos >= timeoutNanos) {
-            val message = "Condition was not fulfilled within $timeout."
-            throw if (lastThrowable != null) {
-                ConditionTimeoutException(message, lastThrowable)
-            } else {
-                ConditionTimeoutException(message)
-            }
-        }
+        if (satisfied) return@coroutineScope
 
         val nextInterval = pollInterval.next(pollCount++, lastInterval)
         lastInterval = nextInterval
 
-        val remainingNanos = timeoutNanos - (System.nanoTime() - startNanos)
-        val sleepNanos = minOf(nextInterval.toNanosSafely(), remainingNanos)
-
+        val sleepNanos = minOf(nextInterval.toNanosSafely(), timeoutNanos - (System.nanoTime() - startNanos))
         if (sleepNanos > 0) {
-            delay(sleepNanos / 1_000_000L)
+            delay(nanosToMillisCeil(sleepNanos))
         }
     }
 }
@@ -157,7 +167,23 @@ private fun Duration.toNanosSafely(): Long = runCatching { toNanos() }.getOrElse
 
 private fun Duration.toMillisCeil(): Long {
     val nanos = toNanosSafely()
-    return if (nanos <= 0L) 0L else (nanos + 999_999L) / 1_000_000L
+    return nanosToMillisCeil(nanos)
+}
+
+private fun nanosToMillisCeil(nanos: Long): Long =
+    if (nanos <= 0L) 0L else (nanos + 999_999L) / 1_000_000L
+
+private fun conditionTimeoutException(timeout: Duration, cause: Throwable?): ConditionTimeoutException {
+    val message = "Condition was not fulfilled within $timeout."
+    val rootCause = cause.unwrapConditionTimeout()
+    return if (rootCause != null) ConditionTimeoutException(message, rootCause) else ConditionTimeoutException(message)
+}
+
+private object PollTimedOut
+
+private tailrec fun Throwable?.unwrapConditionTimeout(): Throwable? = when (this) {
+    is ConditionTimeoutException -> cause.unwrapConditionTimeout()
+    else                        -> this
 }
 
 @Suppress("UNCHECKED_CAST")

--- a/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/awaitility/AwaitilityCoroutinesTest.kt
+++ b/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/awaitility/AwaitilityCoroutinesTest.kt
@@ -4,12 +4,17 @@ import io.bluetape4k.junit5.coroutines.runSuspendTest
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.yield
 import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeLessOrEqualTo
 import org.awaitility.kotlin.await
+import org.awaitility.core.ConditionTimeoutException
 import org.junit.jupiter.api.Test
 import java.time.Duration
+import kotlin.test.assertIs
 import kotlin.test.assertFailsWith
+import kotlinx.coroutines.TimeoutCancellationException
 
 class AwaitilityCoroutinesTest {
 
@@ -90,4 +95,66 @@ class AwaitilityCoroutinesTest {
                 }
         }
     }
+
+    @Test
+    fun `untilSuspending - 조건이 계속 false 이면 timeout 예외가 발생한다`() = runSuspendTest {
+        assertFailsWith<ConditionTimeoutException> {
+            await
+                .atMost(Duration.ofMillis(150))
+                .pollDelay(Duration.ZERO)
+                .pollInterval(Duration.ofMillis(10))
+                .untilSuspending { false }
+        }
+    }
+
+    @Test
+    fun `untilSuspending - 무시된 예외로 timeout 되면 마지막 원인을 유지한다`() = runSuspendTest {
+        val exception = assertFailsWith<ConditionTimeoutException> {
+            await
+                .atMost(Duration.ofMillis(150))
+                .pollDelay(Duration.ZERO)
+                .pollInterval(Duration.ofMillis(10))
+                .ignoreExceptions()
+                .untilSuspending {
+                    throw IllegalStateException("poll timed out")
+                }
+        }
+
+        assertIs<IllegalStateException>(exception.findRootCause())
+    }
+
+    @Test
+    fun `untilSuspending - atMost 보다 긴 poll block 도 전체 timeout 내에서 중단한다`() = runSuspendTest {
+        val start = System.currentTimeMillis()
+
+        assertFailsWith<ConditionTimeoutException> {
+            await
+                .atMost(Duration.ofMillis(150))
+                .pollDelay(Duration.ZERO)
+                .untilSuspending {
+                    delay(500)
+                    false
+                }
+        }
+
+        val elapsed = System.currentTimeMillis() - start
+        elapsed shouldBeLessOrEqualTo 400
+    }
+
+    @Test
+    fun `untilSuspending - block 내부 timeout 은 그대로 전파한다`() = runSuspendTest {
+        assertFailsWith<TimeoutCancellationException> {
+            await
+                .atMost(Duration.ofSeconds(1))
+                .pollDelay(Duration.ZERO)
+                .untilSuspending {
+                    withTimeout(50) {
+                        delay(500)
+                        true
+                    }
+                }
+        }
+    }
+
+    private tailrec fun Throwable.findRootCause(): Throwable = cause?.findRootCause() ?: this
 }


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: cache-ignite2 및 redisson 테스트 안정화

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- `untilSuspending` 이 poll 단위 timeout 으로 block 내부 `TimeoutCancellationException` 을 가리던 문제를 수정했습니다.
- `RedissonNearCacheTest` async 케이스를 `runSuspendIO` 로 전환해 wall-clock Awaitility 와 실제 Redis I/O 환경에 맞췄습니다.
- `IgniteCachesTest` 에 동적 cache 생성 직후 hang 회귀 테스트를 추가했습니다.

## Validation

- `env -u TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE ./gradlew --no-daemon :bluetape4k-junit5:test --tests 'io.bluetape4k.junit5.awaitility.AwaitilityCoroutinesTest'`\n- `env -u TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE ./gradlew --no-daemon :bluetape4k-redisson:test --tests 'io.bluetape4k.redis.redisson.nearcache.RedissonNearCacheTest'`\n- `env -u TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE ./gradlew --no-daemon :bluetape4k-cache-ignite2:test --tests 'io.bluetape4k.cache.IgniteCachesTest' --tests 'io.bluetape4k.cache.memoizer.IgniteSuspendMemoizerTest' --tests 'io.bluetape4k.cache.nearcache.IgniteSuspendNearCacheTest'`\n- `env -u TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE ./gradlew --no-daemon :bluetape4k-cache-ignite2:test`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #75, head `12766771f36098d15a3783ca91a46c0a8ca421e4`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/cache-fixes-redisson-ignite`
- Labels: `bug`
- State: `MERGED`, merge commit `dd3f883e4ba3b717175105b6ff4d4b2e7a184e7b`
- CI: - `env -u TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE ./gradlew --no-daemon :bluetape4k-junit5:test --tests 'io.bluetape4k.junit5.awaitility.AwaitilityCoroutinesTest'`\n- `env -u TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE ./gradlew --no-daemon :bluetape4k-redisson:test --tests 'io.bluetape4k.redis.redisson.nearcache.RedissonNearCacheTest'`\n- `env -u TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE ./gradlew --no-daemon :bluetape4k-cache-ignite2:test --tests 'io.bluetape4k.cache.IgniteCachesTest' --tests 'io.bluetape4k.cache.memoizer.IgniteSuspendMemoizerTest' --tests 'io.bluetape4k.cache.nearcache.IgniteSuspendNearCacheTest'`\n- `env -u TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE ./gradlew --no-daemon :bluetape4k-cache-ignite2:test`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #75 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `dd3f883e4ba3b717175105b6ff4d4b2e7a184e7b`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
