### PR TITLE
feat(csv): bluetape4k-csv — univocity-parsers 제거, 자체 RFC 4180 엔진으로 교체 + V2 Flow DSL API

### DIFF
--- a/io/csv/MIGRATION.md
+++ b/io/csv/MIGRATION.md
@@ -1,0 +1,132 @@
+# bluetape4k-csv Migration Guide
+
+## univocity-parsers → 자체 엔진 마이그레이션
+
+### 개요
+
+`bluetape4k-csv` v1.5.0부터 내부 파서/라이터 엔진이 univocity-parsers에서 자체 구현으로 교체되었습니다.
+공개 API는 대부분 유지되지만, 일부 univocity 타입을 직접 사용하던 경우 변경이 필요합니다.
+
+---
+
+### 제거된 API
+
+#### `CvsParserDefaults.kt`의 univocity 기반 상수
+
+| 제거된 상수 | 대체 |
+|---|---|
+| `DefaultCsvParserSettings: CsvParserSettings` | `CsvSettings.DEFAULT` |
+| `DefaultTsvParserSettings: TsvParserSettings` | `TsvSettings.DEFAULT` |
+| `DefaultCsvWriterSettings: CsvWriterSettings` | `CsvSettings.DEFAULT` |
+| `DefaultTsvWriterSettings: TsvWriterSettings` | `TsvSettings.DEFAULT` |
+
+#### Reader/Writer 생성자 변경
+
+**이전 (univocity 기반):**
+```kotlin
+// Reader
+CsvRecordReader(settings: CsvParserSettings)
+TsvRecordReader(settings: TsvParserSettings)
+
+// Writer
+CsvRecordWriter(writer: Writer, settings: CsvWriterSettings)
+TsvRecordWriter(writer: Writer, settings: TsvWriterSettings)
+SuspendCsvRecordWriter(writer: Writer, settings: CsvWriterSettings)
+SuspendTsvRecordWriter(writer: Writer, settings: TsvWriterSettings)
+```
+
+**이후 (자체 엔진):**
+```kotlin
+// Reader
+CsvRecordReader(settings: CsvSettings = CsvSettings.DEFAULT)
+TsvRecordReader(settings: TsvSettings = TsvSettings.DEFAULT)
+
+// Writer
+CsvRecordWriter(writer: Writer, settings: CsvSettings = CsvSettings.DEFAULT)
+TsvRecordWriter(writer: Writer, settings: TsvSettings = TsvSettings.DEFAULT)
+SuspendCsvRecordWriter(writer: Writer, settings: CsvSettings = CsvSettings.DEFAULT)
+SuspendTsvRecordWriter(writer: Writer, settings: TsvSettings = TsvSettings.DEFAULT)
+```
+
+#### `RecordWriterSupport` / `SuspendRecordWriterSupport` 파라미터 변경
+
+```kotlin
+// 이전
+fun File.writeCsvRecords(settings: CsvWriterSettings = DefaultCsvWriterSettings, ...)
+fun File.writeTsvRecords(settings: TsvWriterSettings = DefaultTsvWriterSettings, ...)
+
+// 이후
+fun File.writeCsvRecords(settings: CsvSettings = CsvSettings.DEFAULT, ...)
+fun File.writeTsvRecords(settings: TsvSettings = TsvSettings.DEFAULT, ...)
+```
+
+---
+
+### 유지된 API (`Record` 인터페이스)
+
+`com.univocity.parsers.common.record.Record` 대신 `io.bluetape4k.csv.Record`를 사용하세요.
+
+```kotlin
+// 이전
+import com.univocity.parsers.common.record.Record
+
+// 이후
+import io.bluetape4k.csv.Record
+```
+
+메서드는 완전 호환됩니다:
+
+| `Record` 메서드 | 설명 |
+|---|---|
+| `getString(index)` / `getString(name)` | 문자열 또는 null |
+| `getValue(index, defaultValue)` / `getValue(name, defaultValue)` | 타입 변환 (T : Any) |
+| `getIntOrNull(index/name)` | Int 또는 null |
+| `getLongOrNull(index/name)` | Long 또는 null |
+| `getDoubleOrNull(index/name)` | Double 또는 null |
+| `getFloatOrNull(index/name)` | Float 또는 null |
+| `getBigDecimalOrNull(index/name)` | BigDecimal 또는 null |
+| `rowNumber` | 행 번호 (1-based) |
+| `size` | 컬럼 수 |
+| `values` | 원시 문자열 배열 |
+| `headers` | 헤더 배열 (skipHeaders=true 시 설정됨) |
+
+---
+
+### Writer 동작 변경 사항
+
+#### trailing space 처리
+
+이전 univocity 구현은 쓰기 시 trailing space를 자동으로 trim했습니다.
+새 구현은 RFC 4180에 따라 trailing/leading space가 있는 필드를 인용(quote) 처리합니다.
+
+```kotlin
+// 입력: "row2  " (trailing space 2개)
+
+// 이전 출력: row2 (trim됨)
+// 이후 출력: "row2  " (RFC 4180 인용 보존)
+```
+
+#### null vs 빈 문자열
+
+- `null` → 인용 없는 빈 필드 (읽을 때 `null` 복원)
+- `""` → `""` 인용 출력 (읽을 때 빈 문자열 복원)
+
+---
+
+### 빌드 의존성 변경
+
+`build.gradle.kts`에서 univocity 의존성을 제거하세요:
+
+```kotlin
+// 제거
+dependencies {
+    implementation("com.univocity:univocity-parsers:2.9.1")
+}
+```
+
+---
+
+### Coroutines 개선 사항
+
+- `SuspendCsvRecordReader` / `SuspendTsvRecordReader`: `channelFlow + ensureActive()` 기반으로 취소 협력(cooperative cancellation) 지원
+- `SuspendCsvRecordWriter` / `SuspendTsvRecordWriter`: `Mutex` 기반 동시 쓰기 보호

--- a/io/csv/README.ko.md
+++ b/io/csv/README.ko.md
@@ -287,6 +287,74 @@ writer.writeAll(dataFlow)
 writer.close()
 ```
 
+## V2 API (Flow 기반 DSL)
+
+v1.5.0부터 `io.bluetape4k.csv.v2` 패키지에 상위 수준 V2 API가 제공됩니다.
+
+### V1 vs V2 비교
+
+| 기능           | V1 (Sequence/suspend)         | V2 (Flow DSL)                    |
+|--------------|-------------------------------|----------------------------------|
+| 리더 타입        | `CsvRecordReader`             | `FlowCsvReader` (DSL)            |
+| 라이터 타입       | `CsvRecordWriter`             | `FlowCsvWriter` (DSL)            |
+| 레코드 타입       | `Record` (인터페이스)             | `CsvRow` (data class)            |
+| 설정           | `CsvSettings` (data class)    | `CsvReaderConfig` / `CsvWriterConfig` (mutable builder) |
+| 취소 협력        | suspend 내 `ensureActive()`    | `channelFlow + ensureActive()`   |
+| quoteAll 지원  | 없음                            | `CsvWriterConfig.quoteAll = true` |
+
+### V2 읽기
+
+```kotlin
+import io.bluetape4k.csv.v2.csvReader
+import io.bluetape4k.csv.v2.tsvReader
+
+// CSV
+val reader = csvReader {
+    trimValues = true
+    emptyValueAsNull = false
+}
+reader.read(inputStream, skipHeaders = true).collect { row ->
+    val name = row.getString("name")
+    val age  = row.getInt("age")
+}
+
+// TSV (delimiter는 항상 '\t'로 강제)
+tsvReader().read(inputStream, skipHeaders = true).collect { row -> ... }
+
+// 대용량 파일 스트리밍
+reader.readFile(Path.of("data.csv"), skipHeaders = true).collect { row -> ... }
+```
+
+### V2 쓰기
+
+```kotlin
+import io.bluetape4k.csv.v2.csvWriter
+import io.bluetape4k.csv.v2.tsvWriter
+
+// 모든 필드 인용 출력
+val writer = csvWriter(outputWriter) { quoteAll = true }
+writer.writeHeaders(listOf("name", "age"))
+writer.writeRow(listOf("Alice", 30))
+writer.writeAll(dataFlow)
+writer.close()
+
+// TSV
+tsvWriter(outputWriter).use { w ->
+    w.writeRow(listOf("a", "b", "c"))
+}
+```
+
+### V1 ↔ V2 변환
+
+```kotlin
+import io.bluetape4k.csv.v2.toCsvRow
+
+// V1 Record → V2 CsvRow (public)
+val csvRow: CsvRow = record.toCsvRow()
+val name = csvRow.getString("name")
+val age  = csvRow.getInt("age", default = 0)
+```
+
 ## 모듈 구조
 
 ```

--- a/io/csv/README.ko.md
+++ b/io/csv/README.ko.md
@@ -4,10 +4,11 @@
 
 ## 개요
 
-`bluetape4k-csv`는 [Univocity Parsers](https://github.com/uniVocity/univocity-parsers) 라이브러리를 Kotlin 환경에서 편리하게 사용할 수 있도록 래핑한 모듈입니다.
+`bluetape4k-csv`는 RFC 4180을 준수하는 자체 구현 엔진을 사용하는 Kotlin 네이티브 CSV/TSV 파싱 라이브러리입니다.
 
-CSV와 TSV 포맷의 읽기/쓰기를 위한 `RecordReader`/`RecordWriter` 인터페이스를 제공하며, Kotlin Coroutines 기반의 비동기 버전(`SuspendRecordReader`/
-`SuspendRecordWriter`)도 지원합니다.
+CSV와 TSV 포맷의 읽기/쓰기를 위한 `RecordReader`/`RecordWriter` 인터페이스를 제공하며, Kotlin Coroutines 기반의 비동기 버전(`SuspendRecordReader`/`SuspendRecordWriter`)도 지원합니다.
+
+v1.5.0부터 내부 엔진이 univocity-parsers에서 자체 구현 상태 기계로 교체되었습니다. 마이그레이션 방법은 [MIGRATION.md](./MIGRATION.md)를 참조하세요.
 
 ## 아키텍처
 
@@ -40,6 +41,19 @@ classDiagram
         +close()
     }
 
+    class CsvSettings {
+        +delimiter: Char
+        +quote: Char
+        +lineSeparator: String
+        +trimValues: Boolean
+        +emptyValueAsNull: Boolean
+    }
+
+    class TsvSettings {
+        +lineSeparator: String
+        +trimValues: Boolean
+        +emptyValueAsNull: Boolean
+    }
 
     RecordReader <|.. CsvRecordReader
     RecordReader <|.. TsvRecordReader
@@ -49,6 +63,11 @@ classDiagram
     SuspendRecordReader <|.. SuspendTsvRecordReader
     SuspendRecordWriter <|.. SuspendCsvRecordWriter
     SuspendRecordWriter <|.. SuspendTsvRecordWriter
+
+    CsvRecordReader --> CsvSettings
+    CsvRecordWriter --> CsvSettings
+    TsvRecordReader --> TsvSettings
+    TsvRecordWriter --> TsvSettings
 
     style RecordReader fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     style RecordWriter fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
@@ -62,6 +81,8 @@ classDiagram
     style SuspendTsvRecordReader fill:#E0F2F1,stroke:#80CBC4,color:#00695C
     style SuspendCsvRecordWriter fill:#E0F2F1,stroke:#80CBC4,color:#00695C
     style SuspendTsvRecordWriter fill:#E0F2F1,stroke:#80CBC4,color:#00695C
+    style CsvSettings fill:#FFF9C4,stroke:#F9A825,color:#5D4037
+    style TsvSettings fill:#FFF9C4,stroke:#F9A825,color:#5D4037
 ```
 
 ### CSV/TSV 처리 흐름
@@ -74,15 +95,20 @@ flowchart TD
         STR[String]
     end
 
+    subgraph 내부 엔진
+        CL[CsvLexer\nTsvLexer]
+        DW[DelimitedWriter]
+    end
+
     subgraph 동기 처리
-        CR[CsvRecordReader<br/>TsvRecordReader]
-        CW[CsvRecordWriter<br/>TsvRecordWriter]
+        CR[CsvRecordReader\nTsvRecordReader]
+        CW[CsvRecordWriter\nTsvRecordWriter]
         SEQ["Sequence&lt;T&gt;"]
     end
 
     subgraph 비동기 처리
-        SCR[SuspendCsvRecordReader<br/>SuspendTsvRecordReader]
-        SCW[SuspendCsvRecordWriter<br/>SuspendTsvRecordWriter]
+        SCR[SuspendCsvRecordReader\nSuspendTsvRecordReader]
+        SCW[SuspendCsvRecordWriter\nSuspendTsvRecordWriter]
         FL["Flow&lt;T&gt;"]
     end
 
@@ -91,28 +117,30 @@ flowchart TD
         OW[OutputWriter]
     end
 
-    F --> CR --> SEQ
+    F --> CR --> CL --> SEQ
     IS --> CR
     STR --> CR
 
-    F --> SCR --> FL
+    F --> SCR --> CL --> FL
     IS --> SCR
 
     SEQ -->|transform| 앱[애플리케이션]
     FL -->|collect| 앱
 
-    앱 -->|entities| CW --> OF
-    앱 -->|Flow entities| SCW --> OW
+    앱 -->|entities| CW --> DW --> OF
+    앱 -->|Flow entities| SCW --> DW --> OW
 
     classDef coreStyle fill:#E8F5E9,stroke:#A5D6A7,color:#2E7D32,font-weight:bold
     classDef asyncStyle fill:#F3E5F5,stroke:#CE93D8,color:#6A1B9A
     classDef serviceStyle fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     classDef dataStyle fill:#F57F17,stroke:#E65100,color:#000000
+    classDef engineStyle fill:#FFF9C4,stroke:#F9A825,color:#5D4037
 
     class 앱 coreStyle
     class SCR,SCW,FL asyncStyle
     class CR,CW,SEQ serviceStyle
     class F,IS,STR,OF,OW dataStyle
+    class CL,DW engineStyle
 ```
 
 ## 주요 기능
@@ -128,12 +156,21 @@ flowchart TD
 | 반환 타입  | `Sequence<T>`     | `Flow<T>`                |
 | 쓰기 함수  | 일반 함수             | `suspend` 함수             |
 
-### 기본 파서 설정
+### 설정 옵션
 
-모든 파서/Writer는 다음 기본 설정을 사용합니다:
+| 설정                | CSV 기본값  | TSV 기본값  | 설명                               |
+|-------------------|---------|---------|----------------------------------|
+| `delimiter`       | `,`     | `\t` 고정 | 필드 구분 문자                         |
+| `quote`           | `"`     | N/A     | 인용 문자 (CSV 전용)                   |
+| `lineSeparator`   | `\r\n`  | `\n`    | 레코드 구분자                          |
+| `trimValues`      | `false` | `false` | 앞뒤 공백 제거 여부 (reader 전용)         |
+| `emptyValueAsNull`| `true`  | `true`  | 인용 없는 빈 필드 → `null`              |
+| `maxCharsPerColumn`| 100,000| 100,000 | 컬럼당 최대 문자 수                      |
 
-- **컬럼당 최대 문자 수**: 100,000자
-- **값 트리밍**: 활성화 (파서만)
+### null vs 빈 문자열
+
+- `null` → 쓰기 시 인용 없는 빈 필드; `emptyValueAsNull=true`이면 읽을 때 `null`로 복원
+- `""` (빈 문자열) → 쓰기 시 `""` 인용 출력; 읽을 때 `""` (빈 문자열)로 복원
 
 ## 사용 예제
 
@@ -144,8 +181,23 @@ import io.bluetape4k.csv.CsvRecordReader
 
 val reader = CsvRecordReader()
 val items: Sequence<Item> = reader.read(inputStream, Charsets.UTF_8, skipHeaders = true) { record ->
-    Item(record.getString("name"), record.getInt("age"))
+    Item(record.getString("name"), record.getIntOrNull("age") ?: 0)
 }
+```
+
+### 커스텀 설정
+
+```kotlin
+import io.bluetape4k.csv.CsvSettings
+import io.bluetape4k.csv.CsvRecordReader
+
+val settings = CsvSettings(
+    delimiter = ';',
+    trimValues = true,
+    emptyValueAsNull = false,
+    maxCharsPerColumn = 500_000,
+)
+val reader = CsvRecordReader(settings)
 ```
 
 ### CSV 쓰기
@@ -191,7 +243,7 @@ val tsvRecords = File("data.tsv").readAsTsvRecords()
 
 // File에서 transform으로 읽기
 val items = File("data.csv").readAsCsvRecords(skipHeader = true) { record ->
-    Item(record.getString("name"), record.getInt("age"))
+    Item(record.getString("name"), record.getIntOrNull("age") ?: 0)
 }
 
 // File에 직접 쓰기
@@ -214,7 +266,7 @@ import io.bluetape4k.csv.coroutines.SuspendCsvRecordReader
 
 val reader = SuspendCsvRecordReader()
 val items: Flow<Item> = reader.read(inputStream, Charsets.UTF_8, skipHeaders = true) { record ->
-    Item(record.getString("name"), record.getInt("age"))
+    Item(record.getString("name"), record.getIntOrNull("age") ?: 0)
 }
 
 items.collect { item -> println(item) }
@@ -235,21 +287,14 @@ writer.writeAll(dataFlow)
 writer.close()
 ```
 
-### 커스텀 파서 설정
-
-```kotlin
-val customSettings = CsvParserSettings().apply {
-    trimValues(false)
-    maxCharsPerColumn = 500_000
-}
-val reader = CsvRecordReader(customSettings)
-```
-
 ## 모듈 구조
 
 ```
 io.bluetape4k.csv
-├── CvsParserDefaults.kt              # CSV/TSV 파서 기본 설정
+├── CsvSettings.kt                    # CSV 파서/라이터 설정
+├── TsvSettings.kt                    # TSV 파서/라이터 설정
+├── CvsParserDefaults.kt              # 공통 상수 (MAX_CHARS_PER_COLUMN)
+├── Record.kt                         # 공개 레코드 인터페이스
 ├── RecordReader.kt                   # 읽기 인터페이스 (Sequence 기반)
 ├── RecordWriter.kt                   # 쓰기 인터페이스
 ├── CsvRecordReader.kt                # CSV 읽기 구현체
@@ -258,13 +303,22 @@ io.bluetape4k.csv
 ├── TsvRecordWriter.kt                # TSV 쓰기 구현체
 ├── RecordReaderSupport.kt            # File/InputStream 읽기 확장 함수
 ├── RecordWriterSupport.kt            # File 쓰기 확장 함수
+├── internal/                         # 내부 엔진 (공개 API 아님)
+│   ├── CsvLexer.kt                   # RFC 4180 CSV 상태 기계 렉서
+│   ├── TsvLexer.kt                   # TSV 상태 기계 렉서 (백슬래시 이스케이프)
+│   ├── DelimitedWriter.kt            # 핵심 구분자 필드 라이터
+│   ├── CsvLineWriter.kt              # CSV 전용 라이터
+│   ├── TsvLineWriter.kt              # TSV 전용 라이터
+│   ├── ArrayRecord.kt                # Record 구현체
+│   └── RecordFactory.kt              # Record 생성 헬퍼
 └── coroutines/                       # Coroutines 비동기 지원
     ├── SuspendRecordReader.kt        # 비동기 읽기 인터페이스 (Flow 기반)
     ├── SuspendRecordWriter.kt        # 비동기 쓰기 인터페이스
-    ├── SuspendCsvRecordReader.kt     # 비동기 CSV 읽기 구현체
-    ├── SuspendCsvRecordWriter.kt     # 비동기 CSV 쓰기 구현체
-    ├── SuspendTsvRecordReader.kt     # 비동기 TSV 읽기 구현체
-    └── SuspendTsvRecordWriter.kt     # 비동기 TSV 쓰기 구현체
+    ├── SuspendCsvRecordReader.kt     # 비동기 CSV 읽기 (channelFlow + ensureActive)
+    ├── SuspendCsvRecordWriter.kt     # 비동기 CSV 쓰기 (Mutex 동시성 보호)
+    ├── SuspendTsvRecordReader.kt     # 비동기 TSV 읽기 (channelFlow + ensureActive)
+    ├── SuspendTsvRecordWriter.kt     # 비동기 TSV 쓰기 (Mutex 동시성 보호)
+    └── SuspendRecordReaderSupport.kt # 비동기 File/InputStream 확장 함수
 ```
 
 ## 의존성
@@ -278,7 +332,10 @@ dependencies {
 }
 ```
 
+## v1.4.x에서 마이그레이션
+
+univocity-parsers 타입을 직접 사용했다면 [MIGRATION.md](./MIGRATION.md)를 참조하세요.
+
 ## 참고
 
-- [Univocity Parsers](https://github.com/uniVocity/univocity-parsers)
 - [CSV (RFC 4180)](https://datatracker.ietf.org/doc/html/rfc4180)

--- a/io/csv/README.md
+++ b/io/csv/README.md
@@ -4,11 +4,11 @@ English | [한국어](./README.ko.md)
 
 ## Overview
 
-`bluetape4k-csv` is a Kotlin-friendly wrapper around the [Univocity Parsers](https://github.com/uniVocity/univocity-parsers) library.
+`bluetape4k-csv` is a Kotlin-native CSV/TSV parsing library with a self-implemented RFC 4180 compliant engine.
 
-It provides `RecordReader`/
-`RecordWriter` interfaces for reading and writing CSV and TSV formats, along with async versions based on Kotlin Coroutines (
-`SuspendRecordReader`/`SuspendRecordWriter`).
+It provides `RecordReader`/`RecordWriter` interfaces for reading and writing CSV and TSV formats, along with async versions based on Kotlin Coroutines (`SuspendRecordReader`/`SuspendRecordWriter`).
+
+Since v1.5.0 the internal engine has been replaced from univocity-parsers to a self-implemented state machine. See [MIGRATION.md](./MIGRATION.md) for migration details.
 
 ## Architecture
 
@@ -41,6 +41,19 @@ classDiagram
         +close()
     }
 
+    class CsvSettings {
+        +delimiter: Char
+        +quote: Char
+        +lineSeparator: String
+        +trimValues: Boolean
+        +emptyValueAsNull: Boolean
+    }
+
+    class TsvSettings {
+        +lineSeparator: String
+        +trimValues: Boolean
+        +emptyValueAsNull: Boolean
+    }
 
     RecordReader <|.. CsvRecordReader
     RecordReader <|.. TsvRecordReader
@@ -50,6 +63,11 @@ classDiagram
     SuspendRecordReader <|.. SuspendTsvRecordReader
     SuspendRecordWriter <|.. SuspendCsvRecordWriter
     SuspendRecordWriter <|.. SuspendTsvRecordWriter
+
+    CsvRecordReader --> CsvSettings
+    CsvRecordWriter --> CsvSettings
+    TsvRecordReader --> TsvSettings
+    TsvRecordWriter --> TsvSettings
 
     style RecordReader fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     style RecordWriter fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
@@ -63,6 +81,8 @@ classDiagram
     style SuspendTsvRecordReader fill:#E0F2F1,stroke:#80CBC4,color:#00695C
     style SuspendCsvRecordWriter fill:#E0F2F1,stroke:#80CBC4,color:#00695C
     style SuspendTsvRecordWriter fill:#E0F2F1,stroke:#80CBC4,color:#00695C
+    style CsvSettings fill:#FFF9C4,stroke:#F9A825,color:#5D4037
+    style TsvSettings fill:#FFF9C4,stroke:#F9A825,color:#5D4037
 ```
 
 ### CSV/TSV Processing Flow
@@ -75,15 +95,20 @@ flowchart TD
         STR[String]
     end
 
+    subgraph Internal Engine
+        CL[CsvLexer\nTsvLexer]
+        DW[DelimitedWriter]
+    end
+
     subgraph Sync Processing
-        CR[CsvRecordReader<br/>TsvRecordReader]
-        CW[CsvRecordWriter<br/>TsvRecordWriter]
+        CR[CsvRecordReader\nTsvRecordReader]
+        CW[CsvRecordWriter\nTsvRecordWriter]
         SEQ["Sequence&lt;T&gt;"]
     end
 
     subgraph Async Processing
-        SCR[SuspendCsvRecordReader<br/>SuspendTsvRecordReader]
-        SCW[SuspendCsvRecordWriter<br/>SuspendTsvRecordWriter]
+        SCR[SuspendCsvRecordReader\nSuspendTsvRecordReader]
+        SCW[SuspendCsvRecordWriter\nSuspendTsvRecordWriter]
         FL["Flow&lt;T&gt;"]
     end
 
@@ -92,28 +117,30 @@ flowchart TD
         OW[OutputWriter]
     end
 
-    F --> CR --> SEQ
+    F --> CR --> CL --> SEQ
     IS --> CR
     STR --> CR
 
-    F --> SCR --> FL
+    F --> SCR --> CL --> FL
     IS --> SCR
 
     SEQ -->|transform| App[Application]
     FL -->|collect| App
 
-    App -->|entities| CW --> OF
-    App -->|Flow entities| SCW --> OW
+    App -->|entities| CW --> DW --> OF
+    App -->|Flow entities| SCW --> DW --> OW
 
     classDef coreStyle fill:#E8F5E9,stroke:#A5D6A7,color:#2E7D32,font-weight:bold
     classDef asyncStyle fill:#F3E5F5,stroke:#CE93D8,color:#6A1B9A
     classDef serviceStyle fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     classDef dataStyle fill:#F57F17,stroke:#E65100,color:#000000
+    classDef engineStyle fill:#FFF9C4,stroke:#F9A825,color:#5D4037
 
     class App coreStyle
     class SCR,SCW,FL asyncStyle
     class CR,CW,SEQ serviceStyle
     class F,IS,STR,OF,OW dataStyle
+    class CL,DW engineStyle
 ```
 
 ## Key Features
@@ -129,12 +156,21 @@ flowchart TD
 | Return type     | `Sequence<T>`     | `Flow<T>`                |
 | Write functions | Regular functions | `suspend` functions      |
 
-### Default Parser Settings
+### Settings
 
-All parsers and writers use the following defaults:
+| Setting           | CSV default | TSV default | Description                              |
+|-------------------|-------------|-------------|------------------------------------------|
+| `delimiter`       | `,`         | `\t` (fixed)| Field separator                          |
+| `quote`           | `"`         | N/A         | Quote character (CSV only)               |
+| `lineSeparator`   | `\r\n`      | `\n`        | Record separator                         |
+| `trimValues`      | `false`     | `false`     | Trim leading/trailing whitespace (reader)|
+| `emptyValueAsNull`| `true`      | `true`      | Empty unquoted field → `null`            |
+| `maxCharsPerColumn`| 100,000    | 100,000     | Per-column character limit               |
 
-- **Max characters per column**: 100,000
-- **Value trimming**: Enabled (parsers only)
+### null vs Empty String
+
+- `null` → unquoted empty field on write; read back as `null` when `emptyValueAsNull=true`
+- `""` (empty string) → `""` quoted field on write; read back as `""` (empty string)
 
 ## Usage Examples
 
@@ -145,8 +181,23 @@ import io.bluetape4k.csv.CsvRecordReader
 
 val reader = CsvRecordReader()
 val items: Sequence<Item> = reader.read(inputStream, Charsets.UTF_8, skipHeaders = true) { record ->
-    Item(record.getString("name"), record.getInt("age"))
+    Item(record.getString("name"), record.getIntOrNull("age") ?: 0)
 }
+```
+
+### Custom Settings
+
+```kotlin
+import io.bluetape4k.csv.CsvSettings
+import io.bluetape4k.csv.CsvRecordReader
+
+val settings = CsvSettings(
+    delimiter = ';',
+    trimValues = true,
+    emptyValueAsNull = false,
+    maxCharsPerColumn = 500_000,
+)
+val reader = CsvRecordReader(settings)
 ```
 
 ### Writing CSV
@@ -192,7 +243,7 @@ val tsvRecords = File("data.tsv").readAsTsvRecords()
 
 // Read from a File with a transform
 val items = File("data.csv").readAsCsvRecords(skipHeader = true) { record ->
-    Item(record.getString("name"), record.getInt("age"))
+    Item(record.getString("name"), record.getIntOrNull("age") ?: 0)
 }
 
 // Write directly to a File
@@ -215,7 +266,7 @@ import io.bluetape4k.csv.coroutines.SuspendCsvRecordReader
 
 val reader = SuspendCsvRecordReader()
 val items: Flow<Item> = reader.read(inputStream, Charsets.UTF_8, skipHeaders = true) { record ->
-    Item(record.getString("name"), record.getInt("age"))
+    Item(record.getString("name"), record.getIntOrNull("age") ?: 0)
 }
 
 items.collect { item -> println(item) }
@@ -236,21 +287,14 @@ writer.writeAll(dataFlow)
 writer.close()
 ```
 
-### Custom Parser Settings
-
-```kotlin
-val customSettings = CsvParserSettings().apply {
-    trimValues(false)
-    maxCharsPerColumn = 500_000
-}
-val reader = CsvRecordReader(customSettings)
-```
-
 ## Module Structure
 
 ```
 io.bluetape4k.csv
-├── CvsParserDefaults.kt              # Default CSV/TSV parser settings
+├── CsvSettings.kt                    # CSV parser/writer settings
+├── TsvSettings.kt                    # TSV parser/writer settings
+├── CvsParserDefaults.kt              # Shared constants (MAX_CHARS_PER_COLUMN)
+├── Record.kt                         # Public record interface
 ├── RecordReader.kt                   # Read interface (Sequence-based)
 ├── RecordWriter.kt                   # Write interface
 ├── CsvRecordReader.kt                # CSV reader implementation
@@ -259,13 +303,22 @@ io.bluetape4k.csv
 ├── TsvRecordWriter.kt                # TSV writer implementation
 ├── RecordReaderSupport.kt            # File/InputStream read extension functions
 ├── RecordWriterSupport.kt            # File write extension functions
+├── internal/                         # Internal engine (not public API)
+│   ├── CsvLexer.kt                   # RFC 4180 CSV state machine lexer
+│   ├── TsvLexer.kt                   # TSV state machine lexer (backslash escape)
+│   ├── DelimitedWriter.kt            # Core delimited field writer
+│   ├── CsvLineWriter.kt              # CSV-specific writer
+│   ├── TsvLineWriter.kt              # TSV-specific writer
+│   ├── ArrayRecord.kt                # Record implementation
+│   └── RecordFactory.kt              # Record construction helpers
 └── coroutines/                       # Coroutines async support
     ├── SuspendRecordReader.kt        # Async read interface (Flow-based)
     ├── SuspendRecordWriter.kt        # Async write interface
-    ├── SuspendCsvRecordReader.kt     # Async CSV reader implementation
-    ├── SuspendCsvRecordWriter.kt     # Async CSV writer implementation
-    ├── SuspendTsvRecordReader.kt     # Async TSV reader implementation
-    └── SuspendTsvRecordWriter.kt     # Async TSV writer implementation
+    ├── SuspendCsvRecordReader.kt     # Async CSV reader (channelFlow + ensureActive)
+    ├── SuspendCsvRecordWriter.kt     # Async CSV writer (Mutex protected)
+    ├── SuspendTsvRecordReader.kt     # Async TSV reader (channelFlow + ensureActive)
+    ├── SuspendTsvRecordWriter.kt     # Async TSV writer (Mutex protected)
+    └── SuspendRecordReaderSupport.kt # Async File/InputStream extension functions
 ```
 
 ## Dependencies
@@ -279,7 +332,10 @@ dependencies {
 }
 ```
 
+## Migration from v1.4.x
+
+If you were using univocity-parsers types directly, see [MIGRATION.md](./MIGRATION.md).
+
 ## References
 
-- [Univocity Parsers](https://github.com/uniVocity/univocity-parsers)
 - [CSV (RFC 4180)](https://datatracker.ietf.org/doc/html/rfc4180)

--- a/io/csv/README.md
+++ b/io/csv/README.md
@@ -287,6 +287,74 @@ writer.writeAll(dataFlow)
 writer.close()
 ```
 
+## V2 API (Flow-based DSL)
+
+Since v1.5.0, a higher-level V2 API is available under the `io.bluetape4k.csv.v2` package.
+
+### V1 vs V2 Comparison
+
+| Feature             | V1 (Sequence/suspend)          | V2 (Flow DSL)                    |
+|---------------------|-------------------------------|----------------------------------|
+| Reader type         | `CsvRecordReader`             | `FlowCsvReader` (DSL)            |
+| Writer type         | `CsvRecordWriter`             | `FlowCsvWriter` (DSL)            |
+| Record type         | `Record` (interface)          | `CsvRow` (data class)            |
+| Settings            | `CsvSettings` (data class)    | `CsvReaderConfig` / `CsvWriterConfig` (mutable builder) |
+| Cancellation        | `ensureActive()` in suspend   | `channelFlow + ensureActive()`   |
+| quoteAll support    | No                            | `CsvWriterConfig.quoteAll = true` |
+
+### Reading with V2
+
+```kotlin
+import io.bluetape4k.csv.v2.csvReader
+import io.bluetape4k.csv.v2.tsvReader
+
+// CSV
+val reader = csvReader {
+    trimValues = true
+    emptyValueAsNull = false
+}
+reader.read(inputStream, skipHeaders = true).collect { row ->
+    val name = row.getString("name")
+    val age  = row.getInt("age")
+}
+
+// TSV (delimiter is always forced to '\t')
+tsvReader().read(inputStream, skipHeaders = true).collect { row -> ... }
+
+// Large file streaming
+reader.readFile(Path.of("data.csv"), skipHeaders = true).collect { row -> ... }
+```
+
+### Writing with V2
+
+```kotlin
+import io.bluetape4k.csv.v2.csvWriter
+import io.bluetape4k.csv.v2.tsvWriter
+
+// CSV with quoteAll
+val writer = csvWriter(outputWriter) { quoteAll = true }
+writer.writeHeaders(listOf("name", "age"))
+writer.writeRow(listOf("Alice", 30))
+writer.writeAll(dataFlow)
+writer.close()
+
+// TSV
+tsvWriter(outputWriter).use { w ->
+    w.writeRow(listOf("a", "b", "c"))
+}
+```
+
+### V1 ↔ V2 Conversion
+
+```kotlin
+import io.bluetape4k.csv.v2.toCsvRow
+
+// V1 Record → V2 CsvRow (public)
+val csvRow: CsvRow = record.toCsvRow()
+val name = csvRow.getString("name")
+val age  = csvRow.getInt("age", default = 0)
+```
+
 ## Module Structure
 
 ```

--- a/io/csv/build.gradle.kts
+++ b/io/csv/build.gradle.kts
@@ -26,8 +26,6 @@ dependencies {
     api(project(":bluetape4k-io"))
     testImplementation(project(":bluetape4k-junit5"))
 
-    api(Libs.univocity_parsers)
-
     // Coroutines
     compileOnly(project(":bluetape4k-coroutines"))
     compileOnly(Libs.kotlinx_coroutines_core)

--- a/io/csv/build.gradle.kts
+++ b/io/csv/build.gradle.kts
@@ -1,3 +1,23 @@
+plugins {
+    kotlin("plugin.allopen")
+    id(Plugins.kotlinx_benchmark)
+}
+
+allOpen {
+    // https://github.com/Kotlin/kotlinx-benchmark
+    annotation("org.openjdk.jmh.annotations.State")
+}
+
+// https://github.com/Kotlin/kotlinx-benchmark
+benchmark {
+    targets {
+        register("test") {
+            this as kotlinx.benchmark.gradle.JvmBenchmarkTarget
+            jmhVersion = Versions.jmh
+        }
+    }
+}
+
 configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
 }
@@ -12,4 +32,9 @@ dependencies {
     compileOnly(project(":bluetape4k-coroutines"))
     compileOnly(Libs.kotlinx_coroutines_core)
     testImplementation(Libs.kotlinx_coroutines_test)
+
+    // Benchmark
+    testImplementation(Libs.kotlinx_benchmark_runtime)
+    testImplementation(Libs.kotlinx_benchmark_runtime_jvm)
+    testImplementation(Libs.jmh_core)
 }

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/CsvRecordReader.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/CsvRecordReader.kt
@@ -1,18 +1,16 @@
 package io.bluetape4k.csv
 
-import com.univocity.parsers.common.record.Record
-import com.univocity.parsers.csv.CsvParser
-import com.univocity.parsers.csv.CsvParserSettings
+import io.bluetape4k.csv.internal.CsvLexer
 import io.bluetape4k.logging.KLogging
 import java.io.InputStream
 import java.nio.charset.Charset
 
 /**
- * univocity CSV 파서를 사용하는 [RecordReader] 구현체입니다.
+ * 자체 [CsvLexer]를 사용하는 CSV [RecordReader] 구현체입니다.
  *
  * ## 동작/계약
- * - [settings]로 생성한 [CsvParser]가 입력을 순차 파싱합니다.
- * - [skipHeaders]가 `true`면 파싱 결과에서 첫 레코드를 drop 합니다.
+ * - [settings]로 생성한 [CsvLexer]가 입력을 순차 파싱합니다.
+ * - [skipHeaders]가 `true`면 첫 행을 헤더로 읽어 저장하고 이후 행부터 반환합니다.
  * - 반환 시퀀스는 lazy이며 소비 시점에 변환 람다가 실행됩니다.
  *
  * ```kotlin
@@ -23,34 +21,29 @@ import java.nio.charset.Charset
  * ```
  */
 class CsvRecordReader(
-    private val settings: CsvParserSettings = DefaultCsvParserSettings,
-): RecordReader {
+    private val settings: CsvSettings = CsvSettings.DEFAULT,
+) : RecordReader {
 
-    companion object: KLogging()
+    companion object : KLogging()
 
     /**
      * CSV 입력 스트림을 읽어 변환 결과 시퀀스를 반환합니다.
      *
-     * ## 동작/계약
-     * - `iterateRecords(input, encoding)` 결과를 [Sequence]로 감싸 반환합니다.
-     * - `drop(1)`로 헤더 스킵을 처리하므로 `skipHeaders=true`면 첫 행은 결과에 포함되지 않습니다.
-     * - 파싱 또는 [transform] 실패 예외는 호출자에게 전파됩니다.
-     *
-     * ```kotlin
-     * val ids = CsvRecordReader().read(input, skipHeaders = true) { it.getLong("id") }.toList()
-     * // ids == listOf(1L, 2L)
-     * ```
+     * @param input 읽을 CSV 입력 스트림
+     * @param encoding 텍스트 디코딩에 사용할 문자셋
+     * @param skipHeaders `true`이면 첫 행을 헤더로 처리하여 반환 시퀀스에서 제외
+     * @param transform 레코드를 결과 타입으로 변환하는 함수
      */
     override fun <T> read(
         input: InputStream,
         encoding: Charset,
         skipHeaders: Boolean,
         transform: (Record) -> T,
-    ): Sequence<T> {
-        return CsvParser(settings)
-            .iterateRecords(input, encoding)
-            .asSequence()
-            .drop(if (skipHeaders) 1 else 0)
-            .map { record -> transform(record) }
+    ): Sequence<T> = sequence {
+        CsvLexer(input.reader(encoding), settings, skipHeaders).use { lexer ->
+            while (lexer.hasNext()) {
+                yield(transform(lexer.next()))
+            }
+        }
     }
 }

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/CsvRecordWriter.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/CsvRecordWriter.kt
@@ -1,18 +1,16 @@
 package io.bluetape4k.csv
 
-import com.univocity.parsers.csv.CsvWriter
-import com.univocity.parsers.csv.CsvWriterSettings
-import io.bluetape4k.csv.CsvRecordWriter.Companion.invoke
+import io.bluetape4k.csv.internal.CsvLineWriter
 import io.bluetape4k.logging.KLogging
 import java.io.Writer
 
 /**
- * univocity [CsvWriter]를 감싼 [RecordWriter] 구현체입니다.
+ * [CsvLineWriter]를 감싼 [RecordWriter] 구현체입니다.
  *
  * ## 동작/계약
- * - 헤더/행 입력을 `toList()`로 변환해 [CsvWriter]에 전달합니다.
+ * - 헤더/행 입력을 [CsvLineWriter]에 전달합니다.
  * - [writeAll]은 입력 시퀀스를 순차 소비합니다.
- * - [close]는 내부 writer 종료를 시도하고 예외는 무시합니다.
+ * - [close]는 내부 writer를 닫습니다 (flush 포함).
  *
  * ```kotlin
  * CsvRecordWriter(output).use { writer ->
@@ -22,52 +20,20 @@ import java.io.Writer
  * // output 첫 데이터 행 == "pen,1000"
  * ```
  */
-class CsvRecordWriter private constructor(
-    private val writer: CsvWriter,
-): RecordWriter {
+class CsvRecordWriter(
+    writer: Writer,
+    settings: CsvSettings = CsvSettings.DEFAULT,
+) : RecordWriter {
 
-    companion object: KLogging() {
-        /**
-         * 기존 [CsvWriter]를 감싸는 [CsvRecordWriter]를 생성합니다.
-         *
-         * ## 동작/계약
-         * - 전달한 [csvWriter] 인스턴스를 그대로 사용합니다.
-         *
-         * ```kotlin
-         * val writer = CsvRecordWriter(CsvWriter(output))
-         * // writer != null
-         * ```
-         */
-        @JvmStatic
-        operator fun invoke(csvWriter: CsvWriter): CsvRecordWriter {
-            return CsvRecordWriter(csvWriter)
-        }
+    companion object : KLogging()
 
-        /**
-         * [Writer]와 설정으로 [CsvRecordWriter]를 생성합니다.
-         *
-         * ## 동작/계약
-         * - [settings]로 새 [CsvWriter]를 만들고 [invoke]에 위임합니다.
-         *
-         * ```kotlin
-         * val writer = CsvRecordWriter(output, DefaultCsvWriterSettings)
-         * // writer != null
-         * ```
-         */
-        @JvmStatic
-        operator fun invoke(
-            writer: Writer,
-            settings: CsvWriterSettings = DefaultCsvWriterSettings,
-        ): CsvRecordWriter {
-            return invoke(CsvWriter(writer, settings))
-        }
-    }
+    private val lineWriter = CsvLineWriter(writer, settings)
 
     /**
      * 헤더 행을 기록합니다.
      *
      * ## 동작/계약
-     * - [headers]를 리스트로 복사한 뒤 한 행으로 기록합니다.
+     * - [headers]를 CSV 형식으로 한 행 기록합니다.
      *
      * ```kotlin
      * writer.writeHeaders(listOf("id", "name"))
@@ -75,14 +41,14 @@ class CsvRecordWriter private constructor(
      * ```
      */
     override fun writeHeaders(headers: Iterable<String>) {
-        writer.writeHeaders(headers.toList())
+        lineWriter.writeRow(headers)
     }
 
     /**
      * 데이터 행 1건을 기록합니다.
      *
      * ## 동작/계약
-     * - [rows]를 리스트로 복사해 기록합니다.
+     * - [rows]를 CSV 형식으로 기록합니다.
      *
      * ```kotlin
      * writer.writeRow(listOf("Alice", 20))
@@ -90,7 +56,7 @@ class CsvRecordWriter private constructor(
      * ```
      */
     override fun writeRow(rows: Iterable<*>) {
-        writer.writeRow(rows.toList())
+        lineWriter.writeRow(rows)
     }
 
     /**
@@ -109,7 +75,7 @@ class CsvRecordWriter private constructor(
     }
 
     /**
-     * 내부 [CsvWriter]를 닫습니다.
+     * 내부 [CsvLineWriter]를 닫습니다 (flush 포함).
      *
      * ## 동작/계약
      * - 종료 중 예외는 무시됩니다.
@@ -121,6 +87,6 @@ class CsvRecordWriter private constructor(
      * ```
      */
     override fun close() {
-        runCatching { writer.close() }
+        runCatching { lineWriter.close() }
     }
 }

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/CsvSettings.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/CsvSettings.kt
@@ -1,0 +1,110 @@
+package io.bluetape4k.csv
+
+import io.bluetape4k.logging.KLogging
+import java.io.Serializable
+
+/**
+ * 자체 구현 CSV 파서/라이터 설정 데이터 클래스입니다.
+ *
+ * univocity-parsers에 의존하지 않고, 내부 [CsvLexer] 및 [DelimitedWriter]에 전달되는 불변 설정입니다.
+ *
+ * ## 빈 값(null) 처리 정책
+ * - [emptyValueAsNull]`=true`: 인용 없는 빈 필드(`,,`) → `null` 로 변환합니다.
+ * - [emptyQuotedAsNull]`=false`(기본): 인용 빈 필드(`""`) → `""` 빈 문자열로 보존합니다.
+ * - [emptyQuotedAsNull]`=true`: 인용 빈 필드(`""`) → `null` 로 추가 변환합니다.
+ * - Writer: `null` → 인용 없는 빈 필드 출력, `""` → `""` 인용 출력.
+ *
+ * ## 기본 사용 예
+ * ```kotlin
+ * val settings = CsvSettings()
+ * // settings.delimiter == ','
+ * // settings.lineSeparator == "\r\n"  (RFC 4180 표준)
+ *
+ * val tabSettings = CsvSettings.DEFAULT_TSV_READER
+ * // tabSettings.delimiter == '\t'
+ * ```
+ *
+ * @param delimiter 필드 구분 문자. 기본값은 쉼표(`,`).
+ * @param quote 필드를 감싸는 인용 문자. 기본값은 큰따옴표(`"`).
+ * @param quoteEscape 인용 문자 이스케이프 방식. V1은 RFC 4180 doubled-quote만 지원하므로 [quote]와 동일해야 합니다.
+ * @param lineSeparator 레코드 구분자. RFC 4180 표준에 따라 기본값은 `"\r\n"`.
+ * @param trimValues `true`이면 각 필드의 앞뒤 공백을 제거합니다. **reader 전용**; writer에서는 무시됩니다.
+ * @param skipEmptyLines `true`이면 빈 줄을 건너뜁니다.
+ * @param emptyValueAsNull `true`이면 인용 없는 빈 필드(`,,`)를 `null`로 변환합니다.
+ * @param emptyQuotedAsNull `true`이면 인용 빈 필드(`""`)도 `null`로 변환합니다. 기본값은 `false`.
+ * @param detectBom `true`이면 입력 스트림 앞의 BOM(Byte Order Mark)을 자동으로 감지·제거합니다.
+ * @param maxCharsPerColumn 컬럼 하나에 허용되는 최대 문자 수. 기본값은 [MAX_CHARS_PER_COLUMN].
+ * @param maxColumns 레코드당 최대 컬럼 수. 기본값은 512.
+ * @param bufferSize 내부 읽기 버퍼 크기(바이트). 기본값은 8192.
+ */
+data class CsvSettings(
+    /** 필드 구분 문자. 기본값: 쉼표(`,`). */
+    val delimiter: Char = ',',
+    /** 필드를 감싸는 인용 문자. 기본값: 큰따옴표(`"`). */
+    val quote: Char = '"',
+    /**
+     * 인용 문자 이스케이프 방식.
+     * V1은 RFC 4180 doubled-quote 이스케이프만 지원하므로 [quote]와 동일해야 합니다.
+     * 임의 이스케이프 문자 지원은 V2 이후 예정입니다.
+     */
+    val quoteEscape: Char = '"',
+    /** 레코드 구분자. RFC 4180 표준: `"\r\n"`. */
+    val lineSeparator: String = "\r\n",
+    /**
+     * 각 필드의 앞뒤 공백 제거 여부.
+     * **reader 전용** — writer에서는 무시됩니다.
+     */
+    val trimValues: Boolean = false,
+    /** `true`이면 빈 줄을 건너뜁니다. */
+    val skipEmptyLines: Boolean = true,
+    /**
+     * 인용 없는 빈 필드(`,,`)를 `null`로 변환할지 여부.
+     * `true`이면 `null`, `false`이면 빈 문자열(`""`)로 처리합니다.
+     */
+    val emptyValueAsNull: Boolean = true,
+    /**
+     * 인용 빈 필드(`""`)를 `null`로 변환할지 여부.
+     * `true`이면 추가로 `null`로 변환합니다. 기본값은 `false`(빈 문자열 보존).
+     */
+    val emptyQuotedAsNull: Boolean = false,
+    /** `true`이면 입력 스트림 앞의 BOM을 자동으로 감지·제거합니다. */
+    val detectBom: Boolean = true,
+    /** 컬럼 하나에 허용되는 최대 문자 수. 기본값: [MAX_CHARS_PER_COLUMN]. */
+    val maxCharsPerColumn: Int = MAX_CHARS_PER_COLUMN,
+    /** 레코드당 최대 컬럼 수. 기본값: 512. */
+    val maxColumns: Int = 512,
+    /** 내부 읽기 버퍼 크기(바이트). 기본값: 8192. */
+    val bufferSize: Int = 8192,
+) : Serializable {
+
+    companion object : KLogging() {
+        private const val serialVersionUID = 1L
+
+        /** 기본 CSV 설정 (delimiter=`,`, quote=`"`, lineSeparator=`"\r\n"`). */
+        @JvmField
+        val DEFAULT = CsvSettings()
+    }
+
+    init {
+        require(delimiter != quote) {
+            "delimiter($delimiter)와 quote($quote)는 달라야 합니다"
+        }
+        require(quoteEscape == quote) {
+            "V1은 RFC 4180 doubled-quote 이스케이프만 지원합니다. " +
+                "quoteEscape는 quote와 동일해야 합니다. " +
+                "임의 이스케이프 문자는 V2 이후 지원 예정입니다"
+        }
+        require(maxCharsPerColumn > 0) {
+            "maxCharsPerColumn($maxCharsPerColumn)은 양수여야 합니다"
+        }
+        require(maxColumns > 0) {
+            "maxColumns($maxColumns)은 양수여야 합니다"
+        }
+        require(bufferSize > 0) {
+            "bufferSize($bufferSize)은 양수여야 합니다"
+        }
+        require(lineSeparator.isNotEmpty()) {
+            "lineSeparator는 비어 있을 수 없습니다"
+        }
+    }
+}

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/CsvSettings.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/CsvSettings.kt
@@ -6,7 +6,7 @@ import java.io.Serializable
 /**
  * 자체 구현 CSV 파서/라이터 설정 데이터 클래스입니다.
  *
- * univocity-parsers에 의존하지 않고, 내부 [CsvLexer] 및 [DelimitedWriter]에 전달되는 불변 설정입니다.
+ * 내부 [CsvLexer] 및 [DelimitedWriter]에 전달되는 불변 설정입니다.
  *
  * ## 빈 값(null) 처리 정책
  * - [emptyValueAsNull]`=true`: 인용 없는 빈 필드(`,,`) → `null` 로 변환합니다.

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/CvsParserDefaults.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/CvsParserDefaults.kt
@@ -1,15 +1,10 @@
 package io.bluetape4k.csv
 
-import com.univocity.parsers.csv.CsvParserSettings
-import com.univocity.parsers.csv.CsvWriterSettings
-import com.univocity.parsers.tsv.TsvParserSettings
-import com.univocity.parsers.tsv.TsvWriterSettings
-
 /**
  * CSV/TSV 컬럼 하나에 허용되는 최대 문자 수 기본값입니다.
  *
  * ## 동작/계약
- * - 파서/라이터 기본 설정에서 공통으로 사용됩니다.
+ * - [CsvSettings] 및 [TsvSettings] 기본 설정에서 공통으로 사용됩니다.
  * - 큰 필드를 처리할 수 있도록 100,000 문자로 설정되어 있습니다.
  *
  * ```kotlin
@@ -18,73 +13,3 @@ import com.univocity.parsers.tsv.TsvWriterSettings
  * ```
  */
 const val MAX_CHARS_PER_COLUMN: Int = 100_000
-
-/**
- * CSV 파서 기본 설정입니다.
- *
- * ## 동작/계약
- * - `trimValues(true)`가 적용되어 앞뒤 공백이 제거됩니다.
- * - `maxCharsPerColumn`은 [MAX_CHARS_PER_COLUMN]으로 제한됩니다.
- *
- * ```kotlin
- * val settings = DefaultCsvParserSettings
- * // settings.maxCharsPerColumn == 100000
- * ```
- */
-@JvmField
-val DefaultCsvParserSettings: CsvParserSettings = CsvParserSettings().apply {
-    trimValues(true)
-    maxCharsPerColumn = MAX_CHARS_PER_COLUMN
-}
-
-/**
- * TSV 파서 기본 설정입니다.
- *
- * ## 동작/계약
- * - `trimValues(true)`가 적용됩니다.
- * - 컬럼 길이 제한은 [MAX_CHARS_PER_COLUMN]을 사용합니다.
- *
- * ```kotlin
- * val settings = DefaultTsvParserSettings
- * // settings.maxCharsPerColumn == 100000
- * ```
- */
-@JvmField
-val DefaultTsvParserSettings: TsvParserSettings = TsvParserSettings().apply {
-    trimValues(true)
-    maxCharsPerColumn = MAX_CHARS_PER_COLUMN
-}
-
-/**
- * CSV Writer 기본 설정입니다.
- *
- * ## 동작/계약
- * - 컬럼당 최대 문자 수를 [MAX_CHARS_PER_COLUMN]으로 제한합니다.
- * - 재사용 가능한 singleton 설정 인스턴스입니다.
- *
- * ```kotlin
- * val settings = DefaultCsvWriterSettings
- * // settings.maxCharsPerColumn == 100000
- * ```
- */
-@JvmField
-val DefaultCsvWriterSettings: CsvWriterSettings = CsvWriterSettings().apply {
-    maxCharsPerColumn = MAX_CHARS_PER_COLUMN
-}
-
-/**
- * TSV Writer 기본 설정입니다.
- *
- * ## 동작/계약
- * - 컬럼당 최대 문자 수를 [MAX_CHARS_PER_COLUMN]으로 제한합니다.
- * - 재사용 가능한 singleton 설정 인스턴스입니다.
- *
- * ```kotlin
- * val settings = DefaultTsvWriterSettings
- * // settings.maxCharsPerColumn == 100000
- * ```
- */
-@JvmField
-val DefaultTsvWriterSettings: TsvWriterSettings = TsvWriterSettings().apply {
-    maxCharsPerColumn = MAX_CHARS_PER_COLUMN
-}

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/Record.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/Record.kt
@@ -1,0 +1,79 @@
+package io.bluetape4k.csv
+
+import java.io.Serializable
+import java.math.BigDecimal
+
+/**
+ * CSV/TSV 파싱 결과를 담는 공개 레코드 인터페이스.
+ *
+ * 행 단위 파싱 결과를 타입 안전하게 접근할 수 있는 계약을 정의합니다.
+ * 인덱스 기반 접근과 헤더명 기반 접근을 모두 지원합니다.
+ *
+ * ```kotlin
+ * val reader = CsvRecordReader()
+ * reader.read(input, skipHeaders = true) { record ->
+ *     val name = record.getString("name") ?: "unknown"
+ *     val age  = record.getValue("age", 0)
+ *     name to age
+ * }.toList()
+ * ```
+ */
+interface Record : Serializable {
+
+    /** 1-based 행 번호 (skipHeaders=true 시 헤더 행 제외 기준). */
+    val rowNumber: Long
+
+    /** 필드 수. */
+    val size: Int
+
+    /** 원시 값 배열 복사본 (null 가능 원소 포함). */
+    val values: Array<String?>
+
+    /** 헤더명 배열 (skipHeaders=true일 때만 non-null). */
+    val headers: Array<String>?
+
+    // ── index 기반 접근 ──────────────────────────────────
+
+    /**
+     * 지정 인덱스의 원시 문자열 값을 반환한다.
+     * 범위 초과이면 null 반환.
+     */
+    fun getString(index: Int): String?
+
+    /**
+     * 헤더명으로 원시 문자열 값을 반환한다.
+     * 헤더가 없거나 이름을 찾을 수 없으면 null 반환.
+     */
+    fun getString(name: String): String?
+
+    /**
+     * 지정 인덱스 값을 [defaultValue]의 타입으로 변환하여 반환한다.
+     * 변환 실패 시 [defaultValue]를 반환한다.
+     *
+     * 지원 타입: [String], [Int], [Long], [Double], [Float], [Boolean], [BigDecimal].
+     */
+    fun <T : Any> getValue(index: Int, defaultValue: T): T
+
+    /**
+     * 헤더명으로 값을 찾아 [defaultValue]의 타입으로 변환하여 반환한다.
+     * 헤더가 없거나 변환 실패 시 [defaultValue]를 반환한다.
+     */
+    fun <T : Any> getValue(name: String, defaultValue: T): T
+
+    // ── nullable 타입 변환 ───────────────────────────────
+
+    fun getIntOrNull(index: Int): Int?
+    fun getIntOrNull(name: String): Int?
+
+    fun getLongOrNull(index: Int): Long?
+    fun getLongOrNull(name: String): Long?
+
+    fun getDoubleOrNull(index: Int): Double?
+    fun getDoubleOrNull(name: String): Double?
+
+    fun getFloatOrNull(index: Int): Float?
+    fun getFloatOrNull(name: String): Float?
+
+    fun getBigDecimalOrNull(index: Int): BigDecimal?
+    fun getBigDecimalOrNull(name: String): BigDecimal?
+}

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/RecordFactory.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/RecordFactory.kt
@@ -1,0 +1,34 @@
+package io.bluetape4k.csv
+
+import io.bluetape4k.csv.internal.ArrayRecord
+import io.bluetape4k.csv.internal.HeaderIndex
+
+/**
+ * CSV/TSV 레코드 생성 팩토리.
+ *
+ * PR 1에서는 [ArrayRecord]를 반환하며, PR 2에서 `Record` 인터페이스 반환으로 전환됩니다.
+ */
+object RecordFactory {
+
+    /**
+     * 원시 값 배열, 헤더, 행 번호로 [ArrayRecord]를 생성합니다.
+     *
+     * @param values 원시 값 배열 (null 가능)
+     * @param headers 헤더명 배열 (skipHeaders=true인 경우만 non-null)
+     * @param rowNumber 1-based 행 번호
+     * @return 생성된 [ArrayRecord]
+     */
+    internal fun recordOf(
+        values: Array<String?>,
+        headers: Array<String>? = null,
+        rowNumber: Long,
+    ): ArrayRecord {
+        val headerIndex = headers?.let { HeaderIndex.of(it) }
+        return ArrayRecord(
+            rawValues = values,
+            _headers = headers,
+            headerIndex = headerIndex,
+            rowNumber = rowNumber,
+        )
+    }
+}

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/RecordFactory.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/RecordFactory.kt
@@ -6,23 +6,23 @@ import io.bluetape4k.csv.internal.HeaderIndex
 /**
  * CSV/TSV 레코드 생성 팩토리.
  *
- * PR 1에서는 [ArrayRecord]를 반환하며, PR 2에서 `Record` 인터페이스 반환으로 전환됩니다.
+ * 내부적으로 [ArrayRecord]를 생성하고 공개 [Record] 인터페이스로 반환합니다.
  */
 object RecordFactory {
 
     /**
-     * 원시 값 배열, 헤더, 행 번호로 [ArrayRecord]를 생성합니다.
+     * 원시 값 배열, 헤더, 행 번호로 [Record]를 생성합니다.
      *
      * @param values 원시 값 배열 (null 가능)
      * @param headers 헤더명 배열 (skipHeaders=true인 경우만 non-null)
      * @param rowNumber 1-based 행 번호
-     * @return 생성된 [ArrayRecord]
+     * @return 생성된 [Record]
      */
     internal fun recordOf(
         values: Array<String?>,
         headers: Array<String>? = null,
         rowNumber: Long,
-    ): ArrayRecord {
+    ): Record {
         val headerIndex = headers?.let { HeaderIndex.of(it) }
         return ArrayRecord(
             rawValues = values,

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/RecordReader.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/RecordReader.kt
@@ -1,12 +1,11 @@
 package io.bluetape4k.csv
 
-import com.univocity.parsers.common.record.Record
 import java.io.Closeable
 import java.io.InputStream
 import java.nio.charset.Charset
 
 /**
- * CSV/TSV 입력 스트림을 `Record` 시퀀스로 읽는 동기 Reader 계약입니다.
+ * CSV/TSV 입력 스트림을 [Record] 시퀀스로 읽는 동기 Reader 계약입니다.
  *
  * ## 동작/계약
  * - [read]는 입력 스트림을 순차 소비하며, [skipHeaders]가 `true`면 첫 행을 건너뜁니다.
@@ -20,22 +19,10 @@ import java.nio.charset.Charset
  * // names == listOf("Alice", "Bob")
  * ```
  */
-interface RecordReader: Closeable {
+interface RecordReader : Closeable {
 
     /**
      * 입력 스트림을 읽어 [Record]를 원하는 타입으로 변환합니다.
-     *
-     * ## 동작/계약
-     * - [transform]은 파싱된 각 레코드마다 1회 호출됩니다.
-     * - [skipHeaders]가 `true`면 첫 레코드는 결과에서 제외됩니다.
-     * - 파싱/변환 중 발생한 예외는 호출자에게 전파됩니다.
-     *
-     * ```kotlin
-     * val ids = CsvRecordReader()
-     *     .read(input, skipHeaders = true) { it.getLong("id") }
-     *     .toList()
-     * // ids == listOf(1L, 2L)
-     * ```
      *
      * @param input 읽을 CSV/TSV 입력 스트림입니다.
      * @param encoding 텍스트 디코딩에 사용할 문자셋입니다.
@@ -52,34 +39,16 @@ interface RecordReader: Closeable {
     /**
      * 입력 스트림을 [Record] 시퀀스로 읽습니다.
      *
-     * ## 동작/계약
-     * - 내부적으로 `transform = { it }`를 사용해 [read]에 위임합니다.
-     * - [skipHeaders] 동작은 [read]와 동일합니다.
-     *
-     * ```kotlin
-     * val rows = CsvRecordReader().read(input, skipHeaders = true).toList()
-     * // rows.size == 2
-     * ```
+     * 내부적으로 `transform = { it }`를 사용해 [read]에 위임합니다.
      */
     fun read(
         input: InputStream,
         encoding: Charset = Charsets.UTF_8,
         skipHeaders: Boolean = true,
-    ): Sequence<Record> {
-        return read(input, encoding, skipHeaders) { it }
-    }
+    ): Sequence<Record> = read(input, encoding, skipHeaders) { it }
 
     /**
-     * Reader 리소스를 닫습니다.
-     *
-     * ## 동작/계약
-     * - 기본 구현은 no-op이며 구현체가 별도 리소스를 들고 있으면 override 해서 정리합니다.
-     *
-     * ```kotlin
-     * val reader = CsvRecordReader()
-     * reader.close()
-     * // close 호출 후 추가 부작용 없음
-     * ```
+     * Reader 리소스를 닫습니다. 기본 구현은 no-op.
      */
     override fun close() {
         // NOOP

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/RecordReaderSupport.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/RecordReaderSupport.kt
@@ -1,6 +1,5 @@
 package io.bluetape4k.csv
 
-import com.univocity.parsers.common.record.Record
 import java.io.File
 import java.io.FileInputStream
 import java.io.InputStream
@@ -10,14 +9,10 @@ import kotlin.text.Charsets.UTF_8
 /**
  * 파일을 CSV로 읽어 [Record] 시퀀스를 반환합니다.
  *
- * ## 동작/계약
- * - `sequence {}` 내부에서 파일 스트림을 열고, 시퀀스 소비가 끝나면 자동으로 닫습니다.
- * - [skipHeader]가 `true`면 첫 행(헤더)을 결과에서 제외합니다.
- * - 반환값은 lazy [Sequence]입니다.
+ * [skipHeader]가 `true`면 첫 행(헤더)을 결과에서 제외합니다.
  *
  * ```kotlin
  * val names = file.readAsCsvRecords(skipHeader = true).map { it.getString("name") }.toList()
- * // names == listOf("Alice", "Bob")
  * ```
  */
 fun File.readAsCsvRecords(
@@ -32,14 +27,8 @@ fun File.readAsCsvRecords(
 /**
  * 파일을 CSV로 읽어 변환 결과 시퀀스를 반환합니다.
  *
- * ## 동작/계약
- * - 파일 스트림을 열어 [InputStream.readAsCsvRecords] 변환 오버로드에 위임합니다.
- * - [transform] 예외는 호출자에게 전파됩니다.
- * - 시퀀스 소비가 종료되면 파일 스트림이 닫힙니다.
- *
  * ```kotlin
  * val ids = file.readAsCsvRecords(skipHeader = true) { it.getLong("id") }.toList()
- * // ids == listOf(1L, 2L)
  * ```
  */
 fun <T> File.readAsCsvRecords(
@@ -55,14 +44,8 @@ fun <T> File.readAsCsvRecords(
 /**
  * 파일을 TSV로 읽어 [Record] 시퀀스를 반환합니다.
  *
- * ## 동작/계약
- * - `sequence {}` 내부에서 파일 스트림을 열고 소비 완료 시 닫습니다.
- * - [skipHeader]가 `true`면 첫 행을 제외합니다.
- * - 반환값은 lazy [Sequence]입니다.
- *
  * ```kotlin
  * val names = file.readAsTsvRecords(skipHeader = true).map { it.getString("name") }.toList()
- * // names == listOf("Alice", "Bob")
  * ```
  */
 fun File.readAsTsvRecords(
@@ -77,14 +60,8 @@ fun File.readAsTsvRecords(
 /**
  * 파일을 TSV로 읽어 변환 결과 시퀀스를 반환합니다.
  *
- * ## 동작/계약
- * - 파일 스트림을 열어 [InputStream.readAsTsvRecords] 변환 오버로드에 위임합니다.
- * - [transform] 예외는 호출자에게 전파됩니다.
- * - 시퀀스 소비가 종료되면 파일 스트림이 닫힙니다.
- *
  * ```kotlin
  * val ids = file.readAsTsvRecords(skipHeader = true) { it.getLong("id") }.toList()
- * // ids == listOf(1L, 2L)
  * ```
  */
 fun <T> File.readAsTsvRecords(
@@ -100,31 +77,21 @@ fun <T> File.readAsTsvRecords(
 /**
  * 입력 스트림을 CSV로 읽어 [Record] 시퀀스를 반환합니다.
  *
- * ## 동작/계약
- * - 새 [CsvRecordReader]를 생성해 파싱합니다.
- * - 스트림 닫기는 호출자가 관리해야 합니다.
- *
  * ```kotlin
  * val rows = input.readAsCsvRecords(skipHeader = true).toList()
- * // rows.size == 2
  * ```
  */
 fun InputStream.readAsCsvRecords(
     cs: Charset = UTF_8,
     skipHeader: Boolean = true,
 ): Sequence<Record> =
-    CsvRecordReader().read(this@readAsCsvRecords, cs, skipHeader) { it }
+    CsvRecordReader().read(this, cs, skipHeader) { it }
 
 /**
  * 입력 스트림을 CSV로 읽어 변환 결과 시퀀스를 반환합니다.
  *
- * ## 동작/계약
- * - 새 [CsvRecordReader]를 생성해 [transform]을 적용합니다.
- * - 파싱/변환 예외는 호출자에게 전파됩니다.
- *
  * ```kotlin
  * val names = input.readAsCsvRecords(skipHeader = true) { it.getString("name") }.toList()
- * // names == listOf("Alice", "Bob")
  * ```
  */
 fun <T> InputStream.readAsCsvRecords(
@@ -132,36 +99,26 @@ fun <T> InputStream.readAsCsvRecords(
     skipHeader: Boolean = true,
     transform: (Record) -> T,
 ): Sequence<T> =
-    CsvRecordReader().read(this@readAsCsvRecords, cs, skipHeader, transform)
+    CsvRecordReader().read(this, cs, skipHeader, transform)
 
 /**
  * 입력 스트림을 TSV로 읽어 [Record] 시퀀스를 반환합니다.
  *
- * ## 동작/계약
- * - 새 [TsvRecordReader]를 생성해 파싱합니다.
- * - 스트림 닫기는 호출자가 관리해야 합니다.
- *
  * ```kotlin
  * val rows = input.readAsTsvRecords(skipHeader = true).toList()
- * // rows.size == 2
  * ```
  */
 fun InputStream.readAsTsvRecords(
     cs: Charset = UTF_8,
     skipHeader: Boolean = true,
 ): Sequence<Record> =
-    TsvRecordReader().read(this@readAsTsvRecords, cs, skipHeader) { it }
+    TsvRecordReader().read(this, cs, skipHeader) { it }
 
 /**
  * 입력 스트림을 TSV로 읽어 변환 결과 시퀀스를 반환합니다.
  *
- * ## 동작/계약
- * - 새 [TsvRecordReader]를 생성해 [transform]을 적용합니다.
- * - 파싱/변환 예외는 호출자에게 전파됩니다.
- *
  * ```kotlin
  * val names = input.readAsTsvRecords(skipHeader = true) { it.getString("name") }.toList()
- * // names == listOf("Alice", "Bob")
  * ```
  */
 fun <T> InputStream.readAsTsvRecords(
@@ -169,4 +126,4 @@ fun <T> InputStream.readAsTsvRecords(
     skipHeader: Boolean = true,
     transform: (Record) -> T,
 ): Sequence<T> =
-    TsvRecordReader().read(this@readAsTsvRecords, cs, skipHeader, transform)
+    TsvRecordReader().read(this, cs, skipHeader, transform)

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/RecordWriterSupport.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/RecordWriterSupport.kt
@@ -1,7 +1,5 @@
 package io.bluetape4k.csv
 
-import com.univocity.parsers.csv.CsvWriterSettings
-import com.univocity.parsers.tsv.TsvWriterSettings
 import java.io.File
 import java.io.FileWriter
 import java.nio.charset.Charset
@@ -24,7 +22,7 @@ fun File.writeCsvRecords(
     headers: List<String>? = null,
     rows: Iterable<Iterable<*>>,
     cs: Charset = UTF_8,
-    settings: CsvWriterSettings = DefaultCsvWriterSettings,
+    settings: CsvSettings = CsvSettings.DEFAULT,
 ) {
     FileWriter(this, cs).use { fw ->
         CsvRecordWriter(fw, settings).use { writer ->
@@ -51,7 +49,7 @@ fun <T> File.writeCsvRecords(
     headers: List<String>? = null,
     entities: Iterable<T>,
     cs: Charset = UTF_8,
-    settings: CsvWriterSettings = DefaultCsvWriterSettings,
+    settings: CsvSettings = CsvSettings.DEFAULT,
     transform: (T) -> Iterable<*>,
 ) {
     FileWriter(this, cs).use { fw ->
@@ -79,7 +77,7 @@ fun File.writeTsvRecords(
     headers: List<String>? = null,
     rows: Iterable<Iterable<*>>,
     cs: Charset = UTF_8,
-    settings: TsvWriterSettings = DefaultTsvWriterSettings,
+    settings: TsvSettings = TsvSettings.DEFAULT,
 ) {
     FileWriter(this, cs).use { fw ->
         TsvRecordWriter(fw, settings).use { writer ->
@@ -106,7 +104,7 @@ fun <T> File.writeTsvRecords(
     headers: List<String>? = null,
     entities: Iterable<T>,
     cs: Charset = UTF_8,
-    settings: TsvWriterSettings = DefaultTsvWriterSettings,
+    settings: TsvSettings = TsvSettings.DEFAULT,
     transform: (T) -> Iterable<*>,
 ) {
     FileWriter(this, cs).use { fw ->

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/TsvRecordReader.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/TsvRecordReader.kt
@@ -1,18 +1,16 @@
 package io.bluetape4k.csv
 
-import com.univocity.parsers.common.record.Record
-import com.univocity.parsers.tsv.TsvParser
-import com.univocity.parsers.tsv.TsvParserSettings
+import io.bluetape4k.csv.internal.TsvLexer
 import io.bluetape4k.logging.KLogging
 import java.io.InputStream
 import java.nio.charset.Charset
 
 /**
- * univocity TSV 파서를 사용하는 [RecordReader] 구현체입니다.
+ * 자체 [TsvLexer]를 사용하는 TSV [RecordReader] 구현체입니다.
  *
  * ## 동작/계약
- * - [settings]로 생성한 [TsvParser]가 입력을 순차 파싱합니다.
- * - [skipHeaders]가 `true`면 첫 레코드를 drop 합니다.
+ * - [settings]로 생성한 [TsvLexer]가 입력을 순차 파싱합니다.
+ * - [skipHeaders]가 `true`면 첫 행을 헤더로 읽어 저장하고 이후 행부터 반환합니다.
  * - 반환 시퀀스는 lazy로 동작합니다.
  *
  * ```kotlin
@@ -23,33 +21,29 @@ import java.nio.charset.Charset
  * ```
  */
 class TsvRecordReader(
-    private val settings: TsvParserSettings = DefaultTsvParserSettings,
-): RecordReader {
+    private val settings: TsvSettings = TsvSettings.DEFAULT,
+) : RecordReader {
 
-    companion object: KLogging()
+    companion object : KLogging()
 
     /**
      * TSV 입력 스트림을 읽어 변환 결과 시퀀스를 반환합니다.
      *
-     * ## 동작/계약
-     * - `iterateRecords(input, encoding)` 결과를 [Sequence]로 노출합니다.
-     * - [skipHeaders]가 `true`면 첫 행이 결과에서 제외됩니다.
-     * - 파싱/변환 실패 예외는 전파됩니다.
-     *
-     * ```kotlin
-     * val ids = TsvRecordReader().read(input, skipHeaders = true) { it.getLong("id") }.toList()
-     * // ids == listOf(1L, 2L)
-     * ```
+     * @param input 읽을 TSV 입력 스트림
+     * @param encoding 텍스트 디코딩에 사용할 문자셋
+     * @param skipHeaders `true`이면 첫 행을 헤더로 처리하여 반환 시퀀스에서 제외
+     * @param transform 레코드를 결과 타입으로 변환하는 함수
      */
     override fun <T> read(
         input: InputStream,
         encoding: Charset,
         skipHeaders: Boolean,
         transform: (Record) -> T,
-    ): Sequence<T> {
-        return TsvParser(settings).iterateRecords(input, encoding)
-            .asSequence()
-            .drop(if (skipHeaders) 1 else 0)
-            .map { record -> transform(record) }
+    ): Sequence<T> = sequence {
+        TsvLexer(input.reader(encoding), settings, skipHeaders).use { lexer ->
+            while (lexer.hasNext()) {
+                yield(transform(lexer.next()))
+            }
+        }
     }
 }

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/TsvRecordWriter.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/TsvRecordWriter.kt
@@ -1,18 +1,16 @@
 package io.bluetape4k.csv
 
-import com.univocity.parsers.tsv.TsvWriter
-import com.univocity.parsers.tsv.TsvWriterSettings
-import io.bluetape4k.csv.TsvRecordWriter.Companion.invoke
+import io.bluetape4k.csv.internal.TsvLineWriter
 import io.bluetape4k.logging.KLogging
 import java.io.Writer
 
 /**
- * univocity [TsvWriter]를 감싼 [RecordWriter] 구현체입니다.
+ * [TsvLineWriter]를 감싼 [RecordWriter] 구현체입니다.
  *
  * ## 동작/계약
- * - 헤더/행 입력을 리스트로 복사해 writer에 전달합니다.
+ * - 헤더/행 입력을 [TsvLineWriter]에 전달합니다.
  * - [writeAll]은 입력 시퀀스를 순서대로 소비합니다.
- * - [close]는 writer 종료 예외를 무시합니다.
+ * - [close]는 내부 writer를 닫습니다 (flush 포함).
  *
  * ```kotlin
  * TsvRecordWriter(output).use { writer ->
@@ -22,52 +20,20 @@ import java.io.Writer
  * // output 첫 데이터 행 == "pen\t1000"
  * ```
  */
-class TsvRecordWriter private constructor(
-    private val writer: TsvWriter,
-): RecordWriter {
+class TsvRecordWriter(
+    writer: Writer,
+    settings: TsvSettings = TsvSettings.DEFAULT,
+) : RecordWriter {
 
-    companion object: KLogging() {
-        /**
-         * 기존 [TsvWriter]를 감싸는 [TsvRecordWriter]를 생성합니다.
-         *
-         * ## 동작/계약
-         * - 전달한 [tsvWriter] 인스턴스를 그대로 사용합니다.
-         *
-         * ```kotlin
-         * val writer = TsvRecordWriter(TsvWriter(output))
-         * // writer != null
-         * ```
-         */
-        @JvmStatic
-        operator fun invoke(tsvWriter: TsvWriter): TsvRecordWriter {
-            return TsvRecordWriter(tsvWriter)
-        }
+    companion object : KLogging()
 
-        /**
-         * [Writer]와 설정으로 [TsvRecordWriter]를 생성합니다.
-         *
-         * ## 동작/계약
-         * - [settings] 기반 새 [TsvWriter]를 만들어 [invoke]에 위임합니다.
-         *
-         * ```kotlin
-         * val writer = TsvRecordWriter(output, DefaultTsvWriterSettings)
-         * // writer != null
-         * ```
-         */
-        @JvmStatic
-        operator fun invoke(
-            writer: Writer,
-            settings: TsvWriterSettings = DefaultTsvWriterSettings,
-        ): TsvRecordWriter {
-            return invoke(TsvWriter(writer, settings))
-        }
-    }
+    private val lineWriter = TsvLineWriter(writer, settings)
 
     /**
      * 헤더 행을 기록합니다.
      *
      * ## 동작/계약
-     * - [headers]를 리스트로 복사해 한 행으로 기록합니다.
+     * - [headers]를 TSV 형식으로 한 행 기록합니다.
      *
      * ```kotlin
      * writer.writeHeaders(listOf("id", "name"))
@@ -75,14 +41,14 @@ class TsvRecordWriter private constructor(
      * ```
      */
     override fun writeHeaders(headers: Iterable<String>) {
-        writer.writeHeaders(headers.toList())
+        lineWriter.writeRow(headers)
     }
 
     /**
      * 데이터 행 1건을 기록합니다.
      *
      * ## 동작/계약
-     * - [rows]를 리스트로 복사해 기록합니다.
+     * - [rows]를 TSV 형식으로 기록합니다.
      *
      * ```kotlin
      * writer.writeRow(listOf("Alice", 20))
@@ -90,7 +56,7 @@ class TsvRecordWriter private constructor(
      * ```
      */
     override fun writeRow(rows: Iterable<*>) {
-        writer.writeRow(rows.toList())
+        lineWriter.writeRow(rows)
     }
 
     /**
@@ -109,7 +75,7 @@ class TsvRecordWriter private constructor(
     }
 
     /**
-     * 내부 [TsvWriter]를 닫습니다.
+     * 내부 [TsvLineWriter]를 닫습니다 (flush 포함).
      *
      * ## 동작/계약
      * - 종료 중 예외는 무시됩니다.
@@ -121,6 +87,6 @@ class TsvRecordWriter private constructor(
      * ```
      */
     override fun close() {
-        runCatching { writer.close() }
+        runCatching { lineWriter.close() }
     }
 }

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/TsvSettings.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/TsvSettings.kt
@@ -1,0 +1,81 @@
+package io.bluetape4k.csv
+
+import io.bluetape4k.logging.KLogging
+import java.io.Serializable
+
+/**
+ * 자체 구현 TSV 파서/라이터 설정 데이터 클래스입니다.
+ *
+ * univocity-parsers에 의존하지 않고, 내부 [TsvLexer] 및 [DelimitedWriter]에 전달되는 불변 설정입니다.
+ *
+ * TSV 형식은 탭(`\t`) 문자를 필드 구분자로 사용하며, 인용(quote) 문자 없이
+ * 백슬래시 이스케이프 방식을 사용합니다. delimiter는 `\t`로 고정됩니다.
+ *
+ * ## 빈 값(null) 처리 정책
+ * - [emptyValueAsNull]`=true`: 빈 필드(`\t\t`) → `null` 로 변환합니다.
+ * - [emptyValueAsNull]`=false`: 빈 필드 → `""` 빈 문자열로 보존합니다.
+ *
+ * ## 기본 사용 예
+ * ```kotlin
+ * val settings = TsvSettings()
+ * // settings.lineSeparator == "\n"  (Unix 관례)
+ * // settings.maxCharsPerColumn == MAX_CHARS_PER_COLUMN
+ *
+ * val custom = TsvSettings(trimValues = true, skipEmptyLines = false)
+ * ```
+ *
+ * @param lineSeparator 레코드 구분자. Unix 관례에 따라 기본값은 `"\n"`.
+ *                      기존 univocity TsvWriter 기본값과 일치합니다.
+ * @param trimValues `true`이면 각 필드의 앞뒤 공백을 제거합니다. **reader 전용**; writer에서는 무시됩니다.
+ * @param skipEmptyLines `true`이면 빈 줄을 건너뜁니다.
+ * @param emptyValueAsNull `true`이면 빈 필드를 `null`로 변환합니다.
+ * @param maxCharsPerColumn 컬럼 하나에 허용되는 최대 문자 수. 기본값은 [MAX_CHARS_PER_COLUMN].
+ * @param maxColumns 레코드당 최대 컬럼 수. 기본값은 512.
+ * @param bufferSize 내부 읽기 버퍼 크기(바이트). 기본값은 8192.
+ */
+data class TsvSettings(
+    /** 레코드 구분자. Unix 관례: `"\n"`. 기존 univocity TsvWriter 기본값과 일치합니다. */
+    val lineSeparator: String = "\n",
+    /**
+     * 각 필드의 앞뒤 공백 제거 여부.
+     * **reader 전용** — writer에서는 무시됩니다.
+     */
+    val trimValues: Boolean = false,
+    /** `true`이면 빈 줄을 건너뜁니다. */
+    val skipEmptyLines: Boolean = true,
+    /**
+     * 빈 필드(`\t\t`)를 `null`로 변환할지 여부.
+     * `true`이면 `null`, `false`이면 빈 문자열(`""`)로 처리합니다.
+     */
+    val emptyValueAsNull: Boolean = true,
+    /** 컬럼 하나에 허용되는 최대 문자 수. 기본값: [MAX_CHARS_PER_COLUMN]. */
+    val maxCharsPerColumn: Int = MAX_CHARS_PER_COLUMN,
+    /** 레코드당 최대 컬럼 수. 기본값: 512. */
+    val maxColumns: Int = 512,
+    /** 내부 읽기 버퍼 크기(바이트). 기본값: 8192. */
+    val bufferSize: Int = 8192,
+) : Serializable {
+
+    companion object : KLogging() {
+        private const val serialVersionUID = 1L
+
+        /** 기본 TSV 설정 (lineSeparator=`"\n"`, emptyValueAsNull=`true`). */
+        @JvmField
+        val DEFAULT = TsvSettings()
+    }
+
+    init {
+        require(maxCharsPerColumn > 0) {
+            "maxCharsPerColumn은 양수여야 합니다"
+        }
+        require(maxColumns > 0) {
+            "maxColumns은 양수여야 합니다"
+        }
+        require(bufferSize > 0) {
+            "bufferSize은 양수여야 합니다"
+        }
+        require(lineSeparator.isNotEmpty()) {
+            "lineSeparator는 비어 있을 수 없습니다"
+        }
+    }
+}

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/TsvSettings.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/TsvSettings.kt
@@ -6,7 +6,7 @@ import java.io.Serializable
 /**
  * 자체 구현 TSV 파서/라이터 설정 데이터 클래스입니다.
  *
- * univocity-parsers에 의존하지 않고, 내부 [TsvLexer] 및 [DelimitedWriter]에 전달되는 불변 설정입니다.
+ * 내부 [TsvLexer] 및 [DelimitedWriter]에 전달되는 불변 설정입니다.
  *
  * TSV 형식은 탭(`\t`) 문자를 필드 구분자로 사용하며, 인용(quote) 문자 없이
  * 백슬래시 이스케이프 방식을 사용합니다. delimiter는 `\t`로 고정됩니다.
@@ -25,7 +25,6 @@ import java.io.Serializable
  * ```
  *
  * @param lineSeparator 레코드 구분자. Unix 관례에 따라 기본값은 `"\n"`.
- *                      기존 univocity TsvWriter 기본값과 일치합니다.
  * @param trimValues `true`이면 각 필드의 앞뒤 공백을 제거합니다. **reader 전용**; writer에서는 무시됩니다.
  * @param skipEmptyLines `true`이면 빈 줄을 건너뜁니다.
  * @param emptyValueAsNull `true`이면 빈 필드를 `null`로 변환합니다.
@@ -34,7 +33,7 @@ import java.io.Serializable
  * @param bufferSize 내부 읽기 버퍼 크기(바이트). 기본값은 8192.
  */
 data class TsvSettings(
-    /** 레코드 구분자. Unix 관례: `"\n"`. 기존 univocity TsvWriter 기본값과 일치합니다. */
+    /** 레코드 구분자. Unix 관례: `"\n"`. */
     val lineSeparator: String = "\n",
     /**
      * 각 필드의 앞뒤 공백 제거 여부.

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendCsvRecordReader.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendCsvRecordReader.kt
@@ -1,23 +1,20 @@
 package io.bluetape4k.csv.coroutines
 
-import com.univocity.parsers.common.record.Record
-import com.univocity.parsers.csv.CsvParser
-import com.univocity.parsers.csv.CsvParserSettings
-import io.bluetape4k.csv.DefaultCsvParserSettings
+import io.bluetape4k.csv.CsvSettings
+import io.bluetape4k.csv.Record
+import io.bluetape4k.csv.internal.CsvLexer
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.flow
 import java.io.InputStream
 import java.nio.charset.Charset
 
 /**
- * CSV 입력을 코루틴 [Flow]로 제공하는 [SuspendRecordReader] 구현체입니다.
+ * 자체 [CsvLexer]를 사용하는 CSV [SuspendRecordReader] 구현체입니다.
  *
  * ## 동작/계약
- * - [CsvParser] 결과를 `asFlow()`로 변환해 순차 방출합니다.
- * - [skipHeaders]가 `true`면 첫 레코드를 drop 합니다.
+ * - [CsvLexer] 결과를 cold [Flow]로 변환해 순차 방출합니다.
+ * - [skipHeaders]가 `true`면 첫 레코드를 헤더로 처리합니다.
  * - 파싱/변환 예외는 collect 호출자에게 전파됩니다.
  *
  * ```kotlin
@@ -28,47 +25,32 @@ import java.nio.charset.Charset
  * ```
  */
 class SuspendCsvRecordReader(
-    private val settings: CsvParserSettings = DefaultCsvParserSettings,
-): SuspendRecordReader {
+    private val settings: CsvSettings = CsvSettings.DEFAULT,
+) : SuspendRecordReader {
 
-    companion object: KLoggingChannel()
+    companion object : KLoggingChannel()
 
     /**
      * CSV 입력 스트림을 읽어 변환된 [Flow]를 반환합니다.
      *
-     * ## 동작/계약
-     * - `iterateRecords(input, encoding)` 결과를 flow로 노출합니다.
-     * - [transform]은 각 레코드마다 suspend로 실행됩니다.
-     *
-     * ```kotlin
-     * val ids = SuspendCsvRecordReader().read(input, skipHeaders = true) { it.getLong("id") }.toList()
-     * // ids == listOf(1L, 2L)
-     * ```
+     * @param input 읽을 CSV 입력 스트림
+     * @param encoding 텍스트 디코딩에 사용할 문자셋
+     * @param skipHeaders `true`이면 첫 행을 헤더로 처리
+     * @param transform 레코드를 결과 타입으로 변환하는 suspend 함수
      */
     override fun <T> read(
         input: InputStream,
         encoding: Charset,
         skipHeaders: Boolean,
         transform: suspend (Record) -> T,
-    ): Flow<T> =
-        CsvParser(settings)
-            .iterateRecords(input, encoding)
-            .asFlow()
-            .drop(if (skipHeaders) 1 else 0)
-            .map { transform(it) }
+    ): Flow<T> = flow {
+        CsvLexer(input.reader(encoding), settings, skipHeaders).use { lexer ->
+            while (lexer.hasNext()) {
+                emit(transform(lexer.next()))
+            }
+        }
+    }
 
-    /**
-     * 리소스를 닫습니다.
-     *
-     * ## 동작/계약
-     * - 현재 구현은 별도 리소스를 보유하지 않아 no-op입니다.
-     *
-     * ```kotlin
-     * val reader = SuspendCsvRecordReader()
-     * reader.close()
-     * // close 호출 후 부작용 없음
-     * ```
-     */
     override fun close() {
         // Nothing to do.
     }

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendCsvRecordReader.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendCsvRecordReader.kt
@@ -4,8 +4,11 @@ import io.bluetape4k.csv.CsvSettings
 import io.bluetape4k.csv.Record
 import io.bluetape4k.csv.internal.CsvLexer
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.flowOn
 import java.io.InputStream
 import java.nio.charset.Charset
 
@@ -13,7 +16,9 @@ import java.nio.charset.Charset
  * 자체 [CsvLexer]를 사용하는 CSV [SuspendRecordReader] 구현체입니다.
  *
  * ## 동작/계약
- * - [CsvLexer] 결과를 cold [Flow]로 변환해 순차 방출합니다.
+ * - [CsvLexer] 결과를 [channelFlow]로 변환해 방출합니다.
+ * - 레코드 처리 전마다 [ensureActive]로 취소를 협력적으로 확인합니다.
+ * - 블로킹 IO는 [Dispatchers.IO]에서 실행됩니다.
  * - [skipHeaders]가 `true`면 첫 레코드를 헤더로 처리합니다.
  * - 파싱/변환 예외는 collect 호출자에게 전파됩니다.
  *
@@ -33,6 +38,9 @@ class SuspendCsvRecordReader(
     /**
      * CSV 입력 스트림을 읽어 변환된 [Flow]를 반환합니다.
      *
+     * [channelFlow]를 사용해 취소 협력(cooperative cancellation)을 보장하며,
+     * [Dispatchers.IO]에서 블로킹 IO를 수행합니다.
+     *
      * @param input 읽을 CSV 입력 스트림
      * @param encoding 텍스트 디코딩에 사용할 문자셋
      * @param skipHeaders `true`이면 첫 행을 헤더로 처리
@@ -43,13 +51,14 @@ class SuspendCsvRecordReader(
         encoding: Charset,
         skipHeaders: Boolean,
         transform: suspend (Record) -> T,
-    ): Flow<T> = flow {
+    ): Flow<T> = channelFlow {
         CsvLexer(input.reader(encoding), settings, skipHeaders).use { lexer ->
             while (lexer.hasNext()) {
-                emit(transform(lexer.next()))
+                ensureActive()
+                send(transform(lexer.next()))
             }
         }
-    }
+    }.flowOn(Dispatchers.IO)
 
     override fun close() {
         // Nothing to do.

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendCsvRecordWriter.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendCsvRecordWriter.kt
@@ -4,6 +4,8 @@ import io.bluetape4k.csv.CsvSettings
 import io.bluetape4k.csv.internal.CsvLineWriter
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.io.Writer
 
 /**
@@ -11,6 +13,7 @@ import java.io.Writer
  *
  * ## 동작/계약
  * - 헤더/행 입력을 [CsvLineWriter]에 전달합니다.
+ * - [Mutex]로 동시 쓰기를 보호합니다.
  * - [Flow] 입력은 collect 순서대로 기록됩니다.
  * - [close]는 내부 writer를 닫습니다 (flush 포함).
  *
@@ -30,11 +33,13 @@ class SuspendCsvRecordWriter(
     companion object : KLoggingChannel()
 
     private val lineWriter = CsvLineWriter(writer, settings)
+    private val mutex = Mutex()
 
     /**
      * 헤더 행을 기록합니다.
      *
      * ## 동작/계약
+     * - [Mutex]로 동시 접근을 직렬화합니다.
      * - [headers]를 CSV 형식으로 한 행 기록합니다.
      *
      * ```kotlin
@@ -43,13 +48,14 @@ class SuspendCsvRecordWriter(
      * ```
      */
     override suspend fun writeHeaders(headers: Iterable<String>) {
-        lineWriter.writeRow(headers)
+        mutex.withLock { lineWriter.writeRow(headers) }
     }
 
     /**
      * 데이터 행 1건을 기록합니다.
      *
      * ## 동작/계약
+     * - [Mutex]로 동시 접근을 직렬화합니다.
      * - [row]를 CSV 형식으로 기록합니다.
      *
      * ```kotlin
@@ -58,7 +64,7 @@ class SuspendCsvRecordWriter(
      * ```
      */
     override suspend fun writeRow(row: Iterable<*>) {
-        lineWriter.writeRow(row)
+        mutex.withLock { lineWriter.writeRow(row) }
     }
 
     /**

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendCsvRecordWriter.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendCsvRecordWriter.kt
@@ -1,9 +1,7 @@
 package io.bluetape4k.csv.coroutines
 
-import com.univocity.parsers.csv.CsvWriter
-import com.univocity.parsers.csv.CsvWriterSettings
-import io.bluetape4k.csv.DefaultCsvWriterSettings
-import io.bluetape4k.csv.coroutines.SuspendCsvRecordWriter.Companion.invoke
+import io.bluetape4k.csv.CsvSettings
+import io.bluetape4k.csv.internal.CsvLineWriter
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import kotlinx.coroutines.flow.Flow
 import java.io.Writer
@@ -12,9 +10,9 @@ import java.io.Writer
  * CSV 행 데이터를 코루틴 방식으로 기록하는 [SuspendRecordWriter] 구현체입니다.
  *
  * ## 동작/계약
- * - 헤더/행 입력을 리스트로 복사해 [CsvWriter]에 전달합니다.
+ * - 헤더/행 입력을 [CsvLineWriter]에 전달합니다.
  * - [Flow] 입력은 collect 순서대로 기록됩니다.
- * - [close]는 내부 writer 종료 예외를 무시합니다.
+ * - [close]는 내부 writer를 닫습니다 (flush 포함).
  *
  * ```kotlin
  * SuspendCsvRecordWriter(output).use { writer ->
@@ -24,52 +22,20 @@ import java.io.Writer
  * // output 첫 데이터 행 == "Alice,20"
  * ```
  */
-class SuspendCsvRecordWriter private constructor(
-    private val writer: CsvWriter,
-): SuspendRecordWriter {
+class SuspendCsvRecordWriter(
+    writer: Writer,
+    settings: CsvSettings = CsvSettings.DEFAULT,
+) : SuspendRecordWriter {
 
-    companion object: KLoggingChannel() {
-        /**
-         * 기존 [CsvWriter]를 감싸는 [SuspendCsvRecordWriter]를 생성합니다.
-         *
-         * ## 동작/계약
-         * - 전달한 writer 인스턴스를 그대로 사용합니다.
-         *
-         * ```kotlin
-         * val writer = SuspendCsvRecordWriter(CsvWriter(output))
-         * // writer != null
-         * ```
-         */
-        @JvmStatic
-        operator fun invoke(writer: CsvWriter): SuspendCsvRecordWriter {
-            return SuspendCsvRecordWriter(writer)
-        }
+    companion object : KLoggingChannel()
 
-        /**
-         * [Writer]와 설정으로 [SuspendCsvRecordWriter]를 생성합니다.
-         *
-         * ## 동작/계약
-         * - [settings] 기반 새 [CsvWriter]를 만들고 [invoke]에 위임합니다.
-         *
-         * ```kotlin
-         * val writer = SuspendCsvRecordWriter(output, DefaultCsvWriterSettings)
-         * // writer != null
-         * ```
-         */
-        @JvmStatic
-        operator fun invoke(
-            writer: Writer,
-            settings: CsvWriterSettings = DefaultCsvWriterSettings,
-        ): SuspendCsvRecordWriter {
-            return invoke(CsvWriter(writer, settings))
-        }
-    }
+    private val lineWriter = CsvLineWriter(writer, settings)
 
     /**
      * 헤더 행을 기록합니다.
      *
      * ## 동작/계약
-     * - [headers]를 리스트로 복사해 기록합니다.
+     * - [headers]를 CSV 형식으로 한 행 기록합니다.
      *
      * ```kotlin
      * writer.writeHeaders(listOf("id", "name"))
@@ -77,14 +43,14 @@ class SuspendCsvRecordWriter private constructor(
      * ```
      */
     override suspend fun writeHeaders(headers: Iterable<String>) {
-        writer.writeHeaders(headers.toList())
+        lineWriter.writeRow(headers)
     }
 
     /**
      * 데이터 행 1건을 기록합니다.
      *
      * ## 동작/계약
-     * - [row]를 리스트로 복사해 기록합니다.
+     * - [row]를 CSV 형식으로 기록합니다.
      *
      * ```kotlin
      * writer.writeRow(listOf("Alice", 20))
@@ -92,7 +58,7 @@ class SuspendCsvRecordWriter private constructor(
      * ```
      */
     override suspend fun writeRow(row: Iterable<*>) {
-        writer.writeRow(row.toList())
+        lineWriter.writeRow(row)
     }
 
     /**
@@ -126,7 +92,7 @@ class SuspendCsvRecordWriter private constructor(
     }
 
     /**
-     * 내부 [CsvWriter]를 닫습니다.
+     * 내부 [CsvLineWriter]를 닫습니다 (flush 포함).
      *
      * ## 동작/계약
      * - 종료 중 예외는 무시됩니다.
@@ -138,6 +104,6 @@ class SuspendCsvRecordWriter private constructor(
      * ```
      */
     override fun close() {
-        runCatching { writer.close() }
+        runCatching { lineWriter.close() }
     }
 }

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendRecordReader.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendRecordReader.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.csv.coroutines
 
-import com.univocity.parsers.common.record.Record
+import io.bluetape4k.csv.Record
 import kotlinx.coroutines.flow.Flow
 import java.io.Closeable
 import java.io.InputStream
@@ -21,21 +21,15 @@ import java.nio.charset.Charset
  * // names == listOf("Alice", "Bob")
  * ```
  */
-interface SuspendRecordReader: Closeable {
+interface SuspendRecordReader : Closeable {
 
     /**
      * 입력 스트림을 읽어 [Record]를 원하는 타입으로 변환한 [Flow]를 반환합니다.
      *
-     * ## 동작/계약
-     * - [transform]은 각 레코드마다 suspend로 실행됩니다.
-     * - 파싱/변환 예외는 collect 호출자에게 전파됩니다.
-     *
-     * ```kotlin
-     * val ids = SuspendCsvRecordReader()
-     *     .read(input, skipHeaders = true) { it.getLong("id") }
-     *     .toList()
-     * // ids == listOf(1L, 2L)
-     * ```
+     * @param input 읽을 CSV/TSV 입력 스트림
+     * @param encoding 텍스트 디코딩에 사용할 문자셋
+     * @param skipHeaders `true`이면 첫 행을 헤더로 처리하여 결과에서 제외
+     * @param transform 레코드를 결과 타입으로 변환하는 suspend 함수
      */
     fun <T> read(
         input: InputStream,
@@ -46,20 +40,10 @@ interface SuspendRecordReader: Closeable {
 
     /**
      * 입력 스트림을 [Record] 그대로 방출하는 [Flow]로 읽습니다.
-     *
-     * ## 동작/계약
-     * - `transform = { it }` 경로로 [read]에 위임합니다.
-     *
-     * ```kotlin
-     * val rows = SuspendCsvRecordReader().read(input, skipHeaders = true).toList()
-     * // rows.size == 2
-     * ```
      */
     fun read(
         input: InputStream,
         encoding: Charset = Charsets.UTF_8,
         skipHeaders: Boolean = true,
-    ): Flow<Record> {
-        return read(input, encoding, skipHeaders) { it }
-    }
+    ): Flow<Record> = read(input, encoding, skipHeaders) { it }
 }

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendRecordReaderSupport.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendRecordReaderSupport.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.csv.coroutines
 
-import com.univocity.parsers.common.record.Record
+import io.bluetape4k.csv.Record
 import kotlinx.coroutines.flow.Flow
 import java.io.File
 import java.io.FileInputStream
@@ -11,14 +11,8 @@ import kotlin.text.Charsets.UTF_8
 /**
  * 입력 스트림을 CSV로 읽어 [Flow]를 반환합니다.
  *
- * ## 동작/계약
- * - 새 [SuspendCsvRecordReader]를 생성해 파싱합니다.
- * - [skipHeader]가 `true`면 첫 행을 제외합니다.
- * - 스트림 닫기는 호출자가 관리합니다.
- *
  * ```kotlin
  * val rows = input.readAsCsvRecordsSuspending(skipHeader = true).toList()
- * // rows.size == 2
  * ```
  */
 fun InputStream.readAsCsvRecordsSuspending(
@@ -30,13 +24,8 @@ fun InputStream.readAsCsvRecordsSuspending(
 /**
  * 입력 스트림을 CSV로 읽어 변환 결과 [Flow]를 반환합니다.
  *
- * ## 동작/계약
- * - [transform]이 각 레코드마다 suspend로 실행됩니다.
- * - 파싱/변환 예외는 collect 호출자에게 전파됩니다.
- *
  * ```kotlin
  * val names = input.readAsCsvRecordsSuspending(skipHeader = true) { it.getString("name") }.toList()
- * // names == listOf("Alice", "Bob")
  * ```
  */
 fun <T> InputStream.readAsCsvRecordsSuspending(
@@ -49,14 +38,8 @@ fun <T> InputStream.readAsCsvRecordsSuspending(
 /**
  * 입력 스트림을 TSV로 읽어 [Flow]를 반환합니다.
  *
- * ## 동작/계약
- * - 새 [SuspendTsvRecordReader]를 생성해 파싱합니다.
- * - [skipHeader]가 `true`면 첫 행을 제외합니다.
- * - 스트림 닫기는 호출자가 관리합니다.
- *
  * ```kotlin
  * val rows = input.readAsTsvRecordsSuspending(skipHeader = true).toList()
- * // rows.size == 2
  * ```
  */
 fun InputStream.readAsTsvRecordsSuspending(
@@ -68,13 +51,8 @@ fun InputStream.readAsTsvRecordsSuspending(
 /**
  * 입력 스트림을 TSV로 읽어 변환 결과 [Flow]를 반환합니다.
  *
- * ## 동작/계약
- * - [transform]이 각 레코드마다 suspend로 실행됩니다.
- * - 파싱/변환 예외는 collect 호출자에게 전파됩니다.
- *
  * ```kotlin
  * val names = input.readAsTsvRecordsSuspending(skipHeader = true) { it.getString("name") }.toList()
- * // names == listOf("Alice", "Bob")
  * ```
  */
 fun <T> InputStream.readAsTsvRecordsSuspending(
@@ -87,13 +65,8 @@ fun <T> InputStream.readAsTsvRecordsSuspending(
 /**
  * 파일을 CSV로 읽어 [Flow]를 반환합니다.
  *
- * ## 동작/계약
- * - 파일 스트림을 열고 [InputStream.readAsCsvRecordsSuspending]에 위임합니다.
- * - 반환된 Flow 수집이 끝나면 스트림이 닫힙니다.
- *
  * ```kotlin
  * val rows = file.readAsCsvRecordsSuspending(skipHeader = true).toList()
- * // rows.size == 2
  * ```
  */
 fun File.readAsCsvRecordsSuspending(
@@ -105,13 +78,8 @@ fun File.readAsCsvRecordsSuspending(
 /**
  * 파일을 CSV로 읽어 변환 결과 [Flow]를 반환합니다.
  *
- * ## 동작/계약
- * - 파일 스트림을 열어 변환 오버로드에 위임합니다.
- * - [transform] 예외는 collect 호출자에게 전파됩니다.
- *
  * ```kotlin
  * val ids = file.readAsCsvRecordsSuspending(skipHeader = true) { it.getLong("id") }.toList()
- * // ids == listOf(1L, 2L)
  * ```
  */
 fun <T> File.readAsCsvRecordsSuspending(
@@ -124,13 +92,8 @@ fun <T> File.readAsCsvRecordsSuspending(
 /**
  * 파일을 TSV로 읽어 [Flow]를 반환합니다.
  *
- * ## 동작/계약
- * - 파일 스트림을 열고 [InputStream.readAsTsvRecordsSuspending]에 위임합니다.
- * - 반환 Flow 수집 종료 후 스트림이 닫힙니다.
- *
  * ```kotlin
  * val rows = file.readAsTsvRecordsSuspending(skipHeader = true).toList()
- * // rows.size == 2
  * ```
  */
 fun File.readAsTsvRecordsSuspending(
@@ -142,13 +105,8 @@ fun File.readAsTsvRecordsSuspending(
 /**
  * 파일을 TSV로 읽어 변환 결과 [Flow]를 반환합니다.
  *
- * ## 동작/계약
- * - 파일 스트림을 열어 변환 오버로드에 위임합니다.
- * - [transform] 예외는 collect 호출자에게 전파됩니다.
- *
  * ```kotlin
  * val ids = file.readAsTsvRecordsSuspending(skipHeader = true) { it.getLong("id") }.toList()
- * // ids == listOf(1L, 2L)
  * ```
  */
 fun <T> File.readAsTsvRecordsSuspending(

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendRecordWriterSupport.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendRecordWriterSupport.kt
@@ -1,9 +1,7 @@
 package io.bluetape4k.csv.coroutines
 
-import com.univocity.parsers.csv.CsvWriterSettings
-import com.univocity.parsers.tsv.TsvWriterSettings
-import io.bluetape4k.csv.DefaultCsvWriterSettings
-import io.bluetape4k.csv.DefaultTsvWriterSettings
+import io.bluetape4k.csv.CsvSettings
+import io.bluetape4k.csv.TsvSettings
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -28,7 +26,7 @@ suspend fun File.writeCsvRecordsSuspending(
     headers: List<String>? = null,
     rows: Iterable<Iterable<*>>,
     cs: Charset = UTF_8,
-    settings: CsvWriterSettings = DefaultCsvWriterSettings,
+    settings: CsvSettings = CsvSettings.DEFAULT,
 ) {
     withContext(Dispatchers.IO) {
         FileWriter(this@writeCsvRecordsSuspending, cs).buffered().use { bufferedWriter ->
@@ -57,7 +55,7 @@ suspend fun <T> File.writeCsvRecordsSuspending(
     headers: List<String>? = null,
     entities: Iterable<T>,
     cs: Charset = UTF_8,
-    settings: CsvWriterSettings = DefaultCsvWriterSettings,
+    settings: CsvSettings = CsvSettings.DEFAULT,
     transform: (T) -> Iterable<*>,
 ) {
     withContext(Dispatchers.IO) {
@@ -87,7 +85,7 @@ suspend fun File.writeTsvRecordsSuspending(
     headers: List<String>? = null,
     rows: Iterable<Iterable<*>>,
     cs: Charset = UTF_8,
-    settings: TsvWriterSettings = DefaultTsvWriterSettings,
+    settings: TsvSettings = TsvSettings.DEFAULT,
 ) {
     withContext(Dispatchers.IO) {
         FileWriter(this@writeTsvRecordsSuspending, cs).buffered().use { bufferedWriter ->
@@ -105,7 +103,7 @@ suspend fun File.writeTsvRecordsSuspending(
  * ## 동작/계약
  * - 전체 쓰기는 `Dispatchers.IO`에서 실행됩니다.
  * - [transform] 결과를 행으로 기록합니다.
- * - 변환/쓰기 예외는 호출자에게 전파됩니다.
+ * - 변환/쓰기 예외는 전파됩니다.
  *
  * ```kotlin
  * file.writeTsvRecordsSuspending(headers = listOf("name"), entities = listOf("Alice")) { listOf(it) }
@@ -116,7 +114,7 @@ suspend fun <T> File.writeTsvRecordsSuspending(
     headers: List<String>? = null,
     entities: Iterable<T>,
     cs: Charset = UTF_8,
-    settings: TsvWriterSettings = DefaultTsvWriterSettings,
+    settings: TsvSettings = TsvSettings.DEFAULT,
     transform: (T) -> Iterable<*>,
 ) {
     withContext(Dispatchers.IO) {

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendTsvRecordReader.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendTsvRecordReader.kt
@@ -4,8 +4,11 @@ import io.bluetape4k.csv.Record
 import io.bluetape4k.csv.TsvSettings
 import io.bluetape4k.csv.internal.TsvLexer
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.flowOn
 import java.io.InputStream
 import java.nio.charset.Charset
 
@@ -13,7 +16,9 @@ import java.nio.charset.Charset
  * 자체 [TsvLexer]를 사용하는 TSV [SuspendRecordReader] 구현체입니다.
  *
  * ## 동작/계약
- * - [TsvLexer] 결과를 cold [Flow]로 변환해 순차 방출합니다.
+ * - [TsvLexer] 결과를 [channelFlow]로 변환해 방출합니다.
+ * - 레코드 처리 전마다 [ensureActive]로 취소를 협력적으로 확인합니다.
+ * - 블로킹 IO는 [Dispatchers.IO]에서 실행됩니다.
  * - [skipHeaders]가 `true`면 첫 레코드를 헤더로 처리합니다.
  * - 파싱/변환 예외는 collect 호출자에게 전파됩니다.
  *
@@ -33,6 +38,9 @@ class SuspendTsvRecordReader(
     /**
      * TSV 입력 스트림을 읽어 변환된 [Flow]를 반환합니다.
      *
+     * [channelFlow]를 사용해 취소 협력(cooperative cancellation)을 보장하며,
+     * [Dispatchers.IO]에서 블로킹 IO를 수행합니다.
+     *
      * @param input 읽을 TSV 입력 스트림
      * @param encoding 텍스트 디코딩에 사용할 문자셋
      * @param skipHeaders `true`이면 첫 행을 헤더로 처리
@@ -43,13 +51,14 @@ class SuspendTsvRecordReader(
         encoding: Charset,
         skipHeaders: Boolean,
         transform: suspend (Record) -> T,
-    ): Flow<T> = flow {
+    ): Flow<T> = channelFlow {
         TsvLexer(input.reader(encoding), settings, skipHeaders).use { lexer ->
             while (lexer.hasNext()) {
-                emit(transform(lexer.next()))
+                ensureActive()
+                send(transform(lexer.next()))
             }
         }
-    }
+    }.flowOn(Dispatchers.IO)
 
     override fun close() {
         // Nothing to do

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendTsvRecordReader.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendTsvRecordReader.kt
@@ -1,23 +1,20 @@
 package io.bluetape4k.csv.coroutines
 
-import com.univocity.parsers.common.record.Record
-import com.univocity.parsers.tsv.TsvParser
-import com.univocity.parsers.tsv.TsvParserSettings
-import io.bluetape4k.csv.DefaultTsvParserSettings
+import io.bluetape4k.csv.Record
+import io.bluetape4k.csv.TsvSettings
+import io.bluetape4k.csv.internal.TsvLexer
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.flow
 import java.io.InputStream
 import java.nio.charset.Charset
 
 /**
- * TSV 입력을 코루틴 [Flow]로 제공하는 [SuspendRecordReader] 구현체입니다.
+ * 자체 [TsvLexer]를 사용하는 TSV [SuspendRecordReader] 구현체입니다.
  *
  * ## 동작/계약
- * - [TsvParser] 결과를 flow로 변환해 순차 방출합니다.
- * - [skipHeaders]가 `true`면 첫 레코드를 제외합니다.
+ * - [TsvLexer] 결과를 cold [Flow]로 변환해 순차 방출합니다.
+ * - [skipHeaders]가 `true`면 첫 레코드를 헤더로 처리합니다.
  * - 파싱/변환 예외는 collect 호출자에게 전파됩니다.
  *
  * ```kotlin
@@ -28,47 +25,32 @@ import java.nio.charset.Charset
  * ```
  */
 class SuspendTsvRecordReader(
-    private val settings: TsvParserSettings = DefaultTsvParserSettings,
-): SuspendRecordReader {
+    private val settings: TsvSettings = TsvSettings.DEFAULT,
+) : SuspendRecordReader {
 
-    companion object: KLoggingChannel()
+    companion object : KLoggingChannel()
 
     /**
      * TSV 입력 스트림을 읽어 변환된 [Flow]를 반환합니다.
      *
-     * ## 동작/계약
-     * - `iterateRecords(input, encoding)` 결과를 flow로 노출합니다.
-     * - [transform]은 각 레코드마다 suspend로 실행됩니다.
-     *
-     * ```kotlin
-     * val ids = SuspendTsvRecordReader().read(input, skipHeaders = true) { it.getLong("id") }.toList()
-     * // ids == listOf(1L, 2L)
-     * ```
+     * @param input 읽을 TSV 입력 스트림
+     * @param encoding 텍스트 디코딩에 사용할 문자셋
+     * @param skipHeaders `true`이면 첫 행을 헤더로 처리
+     * @param transform 레코드를 결과 타입으로 변환하는 suspend 함수
      */
     override fun <T> read(
         input: InputStream,
         encoding: Charset,
         skipHeaders: Boolean,
         transform: suspend (Record) -> T,
-    ): Flow<T> =
-        TsvParser(settings)
-            .iterateRecords(input, encoding)
-            .asFlow()
-            .drop(if (skipHeaders) 1 else 0)
-            .map { transform(it) }
+    ): Flow<T> = flow {
+        TsvLexer(input.reader(encoding), settings, skipHeaders).use { lexer ->
+            while (lexer.hasNext()) {
+                emit(transform(lexer.next()))
+            }
+        }
+    }
 
-    /**
-     * 리소스를 닫습니다.
-     *
-     * ## 동작/계약
-     * - 현재 구현은 별도 리소스를 보유하지 않아 no-op입니다.
-     *
-     * ```kotlin
-     * val reader = SuspendTsvRecordReader()
-     * reader.close()
-     * // close 호출 후 부작용 없음
-     * ```
-     */
     override fun close() {
         // Nothing to do
     }

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendTsvRecordWriter.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendTsvRecordWriter.kt
@@ -1,9 +1,7 @@
 package io.bluetape4k.csv.coroutines
 
-import com.univocity.parsers.tsv.TsvWriter
-import com.univocity.parsers.tsv.TsvWriterSettings
-import io.bluetape4k.csv.DefaultTsvWriterSettings
-import io.bluetape4k.csv.coroutines.SuspendTsvRecordWriter.Companion.invoke
+import io.bluetape4k.csv.TsvSettings
+import io.bluetape4k.csv.internal.TsvLineWriter
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import kotlinx.coroutines.flow.Flow
 import java.io.Writer
@@ -12,9 +10,9 @@ import java.io.Writer
  * TSV 행 데이터를 코루틴 방식으로 기록하는 [SuspendRecordWriter] 구현체입니다.
  *
  * ## 동작/계약
- * - 헤더/행 입력을 리스트로 복사해 [TsvWriter]에 전달합니다.
+ * - 헤더/행 입력을 [TsvLineWriter]에 전달합니다.
  * - [Flow] 입력은 collect 순서대로 기록됩니다.
- * - [close]는 내부 writer 종료 예외를 무시합니다.
+ * - [close]는 내부 writer를 닫습니다 (flush 포함).
  *
  * ```kotlin
  * SuspendTsvRecordWriter(output).use { writer ->
@@ -24,52 +22,20 @@ import java.io.Writer
  * // output 첫 데이터 행 == "Alice\t20"
  * ```
  */
-class SuspendTsvRecordWriter private constructor(
-    private val writer: TsvWriter,
-): SuspendRecordWriter {
+class SuspendTsvRecordWriter(
+    writer: Writer,
+    settings: TsvSettings = TsvSettings.DEFAULT,
+) : SuspendRecordWriter {
 
-    companion object: KLoggingChannel() {
-        /**
-         * 기존 [TsvWriter]를 감싸는 [SuspendTsvRecordWriter]를 생성합니다.
-         *
-         * ## 동작/계약
-         * - 전달한 writer 인스턴스를 그대로 사용합니다.
-         *
-         * ```kotlin
-         * val writer = SuspendTsvRecordWriter(TsvWriter(output))
-         * // writer != null
-         * ```
-         */
-        @JvmStatic
-        operator fun invoke(writer: TsvWriter): SuspendTsvRecordWriter {
-            return SuspendTsvRecordWriter(writer)
-        }
+    companion object : KLoggingChannel()
 
-        /**
-         * [Writer]와 설정으로 [SuspendTsvRecordWriter]를 생성합니다.
-         *
-         * ## 동작/계약
-         * - [settings] 기반 새 [TsvWriter]를 만들고 [invoke]에 위임합니다.
-         *
-         * ```kotlin
-         * val writer = SuspendTsvRecordWriter(output, DefaultTsvWriterSettings)
-         * // writer != null
-         * ```
-         */
-        @JvmStatic
-        operator fun invoke(
-            writer: Writer,
-            settings: TsvWriterSettings = DefaultTsvWriterSettings,
-        ): SuspendTsvRecordWriter {
-            return invoke(TsvWriter(writer, settings))
-        }
-    }
+    private val lineWriter = TsvLineWriter(writer, settings)
 
     /**
      * 헤더 행을 기록합니다.
      *
      * ## 동작/계약
-     * - [headers]를 리스트로 복사해 기록합니다.
+     * - [headers]를 TSV 형식으로 한 행 기록합니다.
      *
      * ```kotlin
      * writer.writeHeaders(listOf("id", "name"))
@@ -77,14 +43,14 @@ class SuspendTsvRecordWriter private constructor(
      * ```
      */
     override suspend fun writeHeaders(headers: Iterable<String>) {
-        writer.writeHeaders(headers.toList())
+        lineWriter.writeRow(headers)
     }
 
     /**
      * 데이터 행 1건을 기록합니다.
      *
      * ## 동작/계약
-     * - [row]를 리스트로 복사해 기록합니다.
+     * - [row]를 TSV 형식으로 기록합니다.
      *
      * ```kotlin
      * writer.writeRow(listOf("Alice", 20))
@@ -92,7 +58,7 @@ class SuspendTsvRecordWriter private constructor(
      * ```
      */
     override suspend fun writeRow(row: Iterable<*>) {
-        writer.writeRow(row.toList())
+        lineWriter.writeRow(row)
     }
 
     /**
@@ -126,7 +92,7 @@ class SuspendTsvRecordWriter private constructor(
     }
 
     /**
-     * 내부 [TsvWriter]를 닫습니다.
+     * 내부 [TsvLineWriter]를 닫습니다 (flush 포함).
      *
      * ## 동작/계약
      * - 종료 중 예외는 무시됩니다.
@@ -138,6 +104,6 @@ class SuspendTsvRecordWriter private constructor(
      * ```
      */
     override fun close() {
-        runCatching { writer.close() }
+        runCatching { lineWriter.close() }
     }
 }

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendTsvRecordWriter.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendTsvRecordWriter.kt
@@ -4,6 +4,8 @@ import io.bluetape4k.csv.TsvSettings
 import io.bluetape4k.csv.internal.TsvLineWriter
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.io.Writer
 
 /**
@@ -11,6 +13,7 @@ import java.io.Writer
  *
  * ## 동작/계약
  * - 헤더/행 입력을 [TsvLineWriter]에 전달합니다.
+ * - [Mutex]로 동시 쓰기를 보호합니다.
  * - [Flow] 입력은 collect 순서대로 기록됩니다.
  * - [close]는 내부 writer를 닫습니다 (flush 포함).
  *
@@ -30,11 +33,13 @@ class SuspendTsvRecordWriter(
     companion object : KLoggingChannel()
 
     private val lineWriter = TsvLineWriter(writer, settings)
+    private val mutex = Mutex()
 
     /**
      * 헤더 행을 기록합니다.
      *
      * ## 동작/계약
+     * - [Mutex]로 동시 접근을 직렬화합니다.
      * - [headers]를 TSV 형식으로 한 행 기록합니다.
      *
      * ```kotlin
@@ -43,13 +48,14 @@ class SuspendTsvRecordWriter(
      * ```
      */
     override suspend fun writeHeaders(headers: Iterable<String>) {
-        lineWriter.writeRow(headers)
+        mutex.withLock { lineWriter.writeRow(headers) }
     }
 
     /**
      * 데이터 행 1건을 기록합니다.
      *
      * ## 동작/계약
+     * - [Mutex]로 동시 접근을 직렬화합니다.
      * - [row]를 TSV 형식으로 기록합니다.
      *
      * ```kotlin
@@ -58,7 +64,7 @@ class SuspendTsvRecordWriter(
      * ```
      */
     override suspend fun writeRow(row: Iterable<*>) {
-        lineWriter.writeRow(row)
+        mutex.withLock { lineWriter.writeRow(row) }
     }
 
     /**

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/ArrayRecord.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/ArrayRecord.kt
@@ -1,13 +1,11 @@
 package io.bluetape4k.csv.internal
 
+import io.bluetape4k.csv.Record
 import io.bluetape4k.logging.KLogging
-import java.io.Serializable
 import java.math.BigDecimal
 
 /**
- * CSV/TSV 파싱 결과를 저장하는 내부 구현체.
- *
- * PR 1에서는 [Serializable]을 직접 구현하며, PR 2에서 public `Record` 인터페이스로 전환됩니다.
+ * CSV/TSV 파싱 결과를 저장하는 내부 [Record] 구현체.
  *
  * @param rawValues 원시 값 배열 (null 가능). 방어적 복사로 저장.
  * @param _headers 헤더명 배열 (skipHeaders=true인 경우만 존재). 방어적 복사로 저장.
@@ -18,8 +16,8 @@ internal class ArrayRecord(
     rawValues: Array<String?>,
     _headers: Array<String>?,
     val headerIndex: HeaderIndex?,
-    val rowNumber: Long,
-) : Serializable {
+    override val rowNumber: Long,
+) : Record {
 
     companion object : KLogging() {
         private const val serialVersionUID = 1L
@@ -29,50 +27,30 @@ internal class ArrayRecord(
     val rawValues: Array<String?> = rawValues.copyOf()
 
     /** 방어적 복사된 헤더명 배열. */
-    val headers: Array<String>? = _headers?.copyOf()
+    override val headers: Array<String>? = _headers?.copyOf()
 
-    /** 필드 수. */
-    val size: Int get() = rawValues.size
+    override val size: Int get() = rawValues.size
 
-    /** 원시 값 배열 (외부 노출용 복사본). */
-    val values: Array<String?> get() = rawValues.copyOf()
+    override val values: Array<String?> get() = rawValues.copyOf()
 
-    // ────────────────────────────────────────
-    // index 기반 getter
-    // ────────────────────────────────────────
+    // ── index 기반 getter ────────────────────────────────
 
-    /**
-     * 지정 인덱스의 원시 문자열 값을 반환한다.
-     * 범위 초과이면 null 반환.
-     */
-    fun getString(index: Int): String? = rawValues.getOrNull(index)
+    override fun getString(index: Int): String? = rawValues.getOrNull(index)
 
-    /**
-     * 헤더명으로 원시 문자열 값을 반환한다.
-     * 헤더가 없거나 이름을 찾을 수 없으면 null 반환.
-     */
-    fun getString(name: String): String? {
+    override fun getString(name: String): String? {
         val idx = headerIndex?.indexOf(name) ?: return null
         return getString(idx)
     }
 
     /**
-     * 타입 변환 내부 헬퍼. defaultValue: T에서 T : Any 제약으로 null 컴파일 타임 차단.
-     *
-     * @param raw 원시 문자열 (null 가능)
-     * @param defaultValue null이거나 변환 실패 시 반환할 기본값 (non-null 강제)
-     * @param converter 변환 함수
+     * 타입 변환 내부 헬퍼. T : Any 제약으로 null defaultValue를 컴파일 타임에 차단.
      */
     private fun <T : Any> convert(raw: String?, defaultValue: T, converter: (String) -> T?): T {
         if (raw == null) return defaultValue
         return runCatching { converter(raw) }.getOrNull() ?: defaultValue
     }
 
-    /**
-     * 지정 인덱스 값을 `defaultValue`의 타입으로 변환하여 반환한다.
-     * 변환 실패 시 `defaultValue` 반환.
-     */
-    fun <T : Any> getValue(index: Int, defaultValue: T): T =
+    override fun <T : Any> getValue(index: Int, defaultValue: T): T =
         convert(getString(index), defaultValue) { raw ->
             @Suppress("UNCHECKED_CAST")
             when (defaultValue) {
@@ -87,26 +65,23 @@ internal class ArrayRecord(
             }
         }
 
-    /**
-     * 헤더명으로 값을 찾아 `defaultValue`의 타입으로 변환하여 반환한다.
-     * 헤더가 없거나 변환 실패 시 `defaultValue` 반환.
-     */
-    fun <T : Any> getValue(name: String, defaultValue: T): T {
+    override fun <T : Any> getValue(name: String, defaultValue: T): T {
         val idx = headerIndex?.indexOf(name) ?: return defaultValue
         return getValue(idx, defaultValue)
     }
 
-    // nullable getter들
-    fun getIntOrNull(index: Int): Int? = getString(index)?.trim()?.toIntOrNull()
-    fun getIntOrNull(name: String): Int? = getString(name)?.trim()?.toIntOrNull()
-    fun getLongOrNull(index: Int): Long? = getString(index)?.trim()?.toLongOrNull()
-    fun getLongOrNull(name: String): Long? = getString(name)?.trim()?.toLongOrNull()
-    fun getDoubleOrNull(index: Int): Double? = getString(index)?.trim()?.toDoubleOrNull()
-    fun getDoubleOrNull(name: String): Double? = getString(name)?.trim()?.toDoubleOrNull()
-    fun getFloatOrNull(index: Int): Float? = getString(index)?.trim()?.toFloatOrNull()
-    fun getFloatOrNull(name: String): Float? = getString(name)?.trim()?.toFloatOrNull()
-    fun getBigDecimal(index: Int): BigDecimal? = getString(index)?.trim()?.toBigDecimalOrNull()
-    fun getBigDecimal(name: String): BigDecimal? = getString(name)?.trim()?.toBigDecimalOrNull()
+    // ── nullable getter ──────────────────────────────────
+
+    override fun getIntOrNull(index: Int): Int? = getString(index)?.trim()?.toIntOrNull()
+    override fun getIntOrNull(name: String): Int? = getString(name)?.trim()?.toIntOrNull()
+    override fun getLongOrNull(index: Int): Long? = getString(index)?.trim()?.toLongOrNull()
+    override fun getLongOrNull(name: String): Long? = getString(name)?.trim()?.toLongOrNull()
+    override fun getDoubleOrNull(index: Int): Double? = getString(index)?.trim()?.toDoubleOrNull()
+    override fun getDoubleOrNull(name: String): Double? = getString(name)?.trim()?.toDoubleOrNull()
+    override fun getFloatOrNull(index: Int): Float? = getString(index)?.trim()?.toFloatOrNull()
+    override fun getFloatOrNull(name: String): Float? = getString(name)?.trim()?.toFloatOrNull()
+    override fun getBigDecimalOrNull(index: Int): BigDecimal? = getString(index)?.trim()?.toBigDecimalOrNull()
+    override fun getBigDecimalOrNull(name: String): BigDecimal? = getString(name)?.trim()?.toBigDecimalOrNull()
 
     override fun toString(): String =
         "ArrayRecord(row=$rowNumber, size=$size, values=${rawValues.contentToString()})"

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/ArrayRecord.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/ArrayRecord.kt
@@ -1,0 +1,113 @@
+package io.bluetape4k.csv.internal
+
+import io.bluetape4k.logging.KLogging
+import java.io.Serializable
+import java.math.BigDecimal
+
+/**
+ * CSV/TSV 파싱 결과를 저장하는 내부 구현체.
+ *
+ * PR 1에서는 [Serializable]을 직접 구현하며, PR 2에서 public `Record` 인터페이스로 전환됩니다.
+ *
+ * @param rawValues 원시 값 배열 (null 가능). 방어적 복사로 저장.
+ * @param _headers 헤더명 배열 (skipHeaders=true인 경우만 존재). 방어적 복사로 저장.
+ * @param headerIndex 헤더명 → 인덱스 매핑 (헤더가 있을 때만 non-null)
+ * @param rowNumber 1-based 행 번호
+ */
+internal class ArrayRecord(
+    rawValues: Array<String?>,
+    _headers: Array<String>?,
+    val headerIndex: HeaderIndex?,
+    val rowNumber: Long,
+) : Serializable {
+
+    companion object : KLogging() {
+        private const val serialVersionUID = 1L
+    }
+
+    /** 방어적 복사된 원시 값 배열. */
+    val rawValues: Array<String?> = rawValues.copyOf()
+
+    /** 방어적 복사된 헤더명 배열. */
+    val headers: Array<String>? = _headers?.copyOf()
+
+    /** 필드 수. */
+    val size: Int get() = rawValues.size
+
+    /** 원시 값 배열 (외부 노출용 복사본). */
+    val values: Array<String?> get() = rawValues.copyOf()
+
+    // ────────────────────────────────────────
+    // index 기반 getter
+    // ────────────────────────────────────────
+
+    /**
+     * 지정 인덱스의 원시 문자열 값을 반환한다.
+     * 범위 초과이면 null 반환.
+     */
+    fun getString(index: Int): String? = rawValues.getOrNull(index)
+
+    /**
+     * 헤더명으로 원시 문자열 값을 반환한다.
+     * 헤더가 없거나 이름을 찾을 수 없으면 null 반환.
+     */
+    fun getString(name: String): String? {
+        val idx = headerIndex?.indexOf(name) ?: return null
+        return getString(idx)
+    }
+
+    /**
+     * 타입 변환 내부 헬퍼. defaultValue: T에서 T : Any 제약으로 null 컴파일 타임 차단.
+     *
+     * @param raw 원시 문자열 (null 가능)
+     * @param defaultValue null이거나 변환 실패 시 반환할 기본값 (non-null 강제)
+     * @param converter 변환 함수
+     */
+    private fun <T : Any> convert(raw: String?, defaultValue: T, converter: (String) -> T?): T {
+        if (raw == null) return defaultValue
+        return runCatching { converter(raw) }.getOrNull() ?: defaultValue
+    }
+
+    /**
+     * 지정 인덱스 값을 `defaultValue`의 타입으로 변환하여 반환한다.
+     * 변환 실패 시 `defaultValue` 반환.
+     */
+    fun <T : Any> getValue(index: Int, defaultValue: T): T =
+        convert(getString(index), defaultValue) { raw ->
+            @Suppress("UNCHECKED_CAST")
+            when (defaultValue) {
+                is String -> raw as T
+                is Int -> raw.trim().toInt() as T
+                is Long -> raw.trim().toLong() as T
+                is Double -> raw.trim().toDouble() as T
+                is Float -> raw.trim().toFloat() as T
+                is Boolean -> raw.trim().toBoolean() as T
+                is BigDecimal -> raw.trim().toBigDecimal() as T
+                else -> throw IllegalArgumentException("지원하지 않는 타입: ${defaultValue::class}")
+            }
+        }
+
+    /**
+     * 헤더명으로 값을 찾아 `defaultValue`의 타입으로 변환하여 반환한다.
+     * 헤더가 없거나 변환 실패 시 `defaultValue` 반환.
+     */
+    fun <T : Any> getValue(name: String, defaultValue: T): T {
+        val idx = headerIndex?.indexOf(name) ?: return defaultValue
+        return getValue(idx, defaultValue)
+    }
+
+    // nullable getter들
+    fun getIntOrNull(index: Int): Int? = getString(index)?.trim()?.toIntOrNull()
+    fun getIntOrNull(name: String): Int? = getString(name)?.trim()?.toIntOrNull()
+    fun getLongOrNull(index: Int): Long? = getString(index)?.trim()?.toLongOrNull()
+    fun getLongOrNull(name: String): Long? = getString(name)?.trim()?.toLongOrNull()
+    fun getDoubleOrNull(index: Int): Double? = getString(index)?.trim()?.toDoubleOrNull()
+    fun getDoubleOrNull(name: String): Double? = getString(name)?.trim()?.toDoubleOrNull()
+    fun getFloatOrNull(index: Int): Float? = getString(index)?.trim()?.toFloatOrNull()
+    fun getFloatOrNull(name: String): Float? = getString(name)?.trim()?.toFloatOrNull()
+    fun getBigDecimal(index: Int): BigDecimal? = getString(index)?.trim()?.toBigDecimalOrNull()
+    fun getBigDecimal(name: String): BigDecimal? = getString(name)?.trim()?.toBigDecimalOrNull()
+
+    override fun toString(): String =
+        "ArrayRecord(row=$rowNumber, size=$size, values=${rawValues.contentToString()})"
+}

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/CsvLexer.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/CsvLexer.kt
@@ -1,0 +1,474 @@
+package io.bluetape4k.csv.internal
+
+import io.bluetape4k.csv.CsvSettings
+import io.bluetape4k.logging.KLogging
+import java.io.BufferedReader
+import java.io.Closeable
+import java.io.Reader
+
+/**
+ * RFC 4180 기반 CSV 렉서(Lexer).
+ *
+ * 5가지 상태([State.START_FIELD], [State.IN_QUOTED], [State.QUOTE_IN_QUOTED],
+ * [State.IN_UNQUOTED], [State.END_ROW])를 이용한 문자 단위 상태 기계로
+ * CSV 입력을 [ArrayRecord] 시퀀스로 변환합니다.
+ *
+ * ## 주요 특징
+ * - **BOM 감지/제거**: [CsvSettings.detectBom]이 `true`이면 UTF-8 BOM을 자동 제거합니다.
+ * - **Doubled-quote 이스케이프**: RFC 4180 표준에 따른 `""` → `"` 변환을 지원합니다.
+ * - **CR/LF/CRLF 지원**: 세 가지 라인 구분자를 모두 인식합니다.
+ * - **skipEmptyLines**: 물리적 빈 줄(컬럼이 하나도 없는 줄)만 건너뜁니다.
+ * - **trimValues**: 인용되지 않은 필드의 앞뒤 공백을 제거합니다.
+ * - **emptyValueAsNull / emptyQuotedAsNull**: 빈 필드/빈 인용 필드의 null 변환 정책.
+ * - **maxCharsPerColumn / maxColumns**: 과도한 입력에 대한 방어 한계.
+ *
+ * ## 사용 예
+ * ```kotlin
+ * CsvLexer(reader, CsvSettings.DEFAULT, skipHeaders = true).use { lexer ->
+ *     for (record in lexer) {
+ *         println(record.rawValues.toList())
+ *     }
+ * }
+ * ```
+ *
+ * @param reader 입력 Reader (내부적으로 [BufferedReader]로 감싸집니다)
+ * @param settings CSV 설정
+ * @param skipHeaders `true`이면 첫 번째 행을 헤더로 읽어 저장하고 이후 행부터 반환합니다.
+ */
+internal class CsvLexer(
+    reader: Reader,
+    private val settings: CsvSettings,
+    private val skipHeaders: Boolean = false,
+) : Iterator<ArrayRecord>, Closeable {
+
+    companion object : KLogging() {
+        /** BOM(Byte Order Mark) 문자 (U+FEFF). */
+        private const val BOM_CHAR: Int = 0xFEFF
+    }
+
+    /**
+     * 5가지 파싱 상태.
+     */
+    private enum class State {
+        /** 필드 시작 대기 상태. */
+        START_FIELD,
+
+        /** 인용 필드 내부 (closing quote 대기). */
+        IN_QUOTED,
+
+        /** 인용 필드 내 quote 문자 발견 (doubled-quote 여부 판단 중). */
+        QUOTE_IN_QUOTED,
+
+        /** 비인용 필드 내부. */
+        IN_UNQUOTED,
+
+        /** 행 완료. */
+        END_ROW,
+    }
+
+    // ────────────────────────────────────────
+    // 설정값 캐시
+    // ────────────────────────────────────────
+
+    private val bufferedReader: BufferedReader
+    private val delimiter: Char = settings.delimiter
+    private val quote: Char = settings.quote
+    private val quoteEscape: Char = settings.quoteEscape
+    private val lineSeparator: String = settings.lineSeparator
+    private val trimValues: Boolean = settings.trimValues
+    private val skipEmptyLines: Boolean = settings.skipEmptyLines
+    private val emptyValueAsNull: Boolean = settings.emptyValueAsNull
+    private val emptyQuotedAsNull: Boolean = settings.emptyQuotedAsNull
+    private val maxCharsPerColumn: Int = settings.maxCharsPerColumn
+    private val maxColumns: Int = settings.maxColumns
+    private val bufferSize: Int = settings.bufferSize
+
+    // ────────────────────────────────────────
+    // 헤더 관련
+    // ────────────────────────────────────────
+
+    private var headers: Array<String>? = null
+    private var headerIndex: HeaderIndex? = null
+
+    // ────────────────────────────────────────
+    // 상태 변수
+    // ────────────────────────────────────────
+
+    /** 1-based 행 번호 (반환된 데이터 레코드 기준). */
+    private var rowNumber: Long = 0L
+
+    /** 현재 행 내 column 번호 (human-facing, 1-based). */
+    private var columnNumber: Int = 0
+
+    /** 다음에 반환할 레코드(prefetch). */
+    private var nextRecord: ArrayRecord? = null
+
+    /** 스트림이 모두 소진되었는지 여부. */
+    private var exhausted: Boolean = false
+
+    /** 필드 버퍼. */
+    private val fieldBuffer: StringBuilder = StringBuilder(256)
+
+    /** 현재 필드가 인용된 필드인지 여부. */
+    private var lastFieldWasQuoted: Boolean = false
+
+    /** 파싱 상태. */
+    private var state: State = State.START_FIELD
+
+    init {
+        bufferedReader = createReader(reader)
+        if (skipHeaders) {
+            // 첫 번째 물리적 행을 헤더로 읽는다. 빈 줄은 건너뛰어 첫 비어 있지 않은 행을 헤더로 사용.
+            while (true) {
+                val firstRow = parseRow()
+                if (firstRow == null) {
+                    exhausted = true
+                    break
+                }
+                if (firstRow.isEmpty()) {
+                    // 물리적 빈 줄 — 다음 행으로 이동
+                    continue
+                }
+                val arr = Array(firstRow.size) { i -> firstRow[i] ?: "" }
+                headers = arr
+                headerIndex = HeaderIndex.of(arr)
+                break
+            }
+        }
+    }
+
+    // ────────────────────────────────────────
+    // Iterator / Closeable
+    // ────────────────────────────────────────
+
+    override fun hasNext(): Boolean {
+        if (exhausted) return nextRecord != null
+        if (nextRecord != null) return true
+        nextRecord = readNextRecord()
+        return nextRecord != null
+    }
+
+    override fun next(): ArrayRecord {
+        if (!hasNext()) throw NoSuchElementException("더 이상 읽을 레코드가 없습니다")
+        val record = nextRecord!!
+        nextRecord = null
+        return record
+    }
+
+    override fun close() {
+        runCatching { bufferedReader.close() }
+    }
+
+    // ────────────────────────────────────────
+    // 내부 구현
+    // ────────────────────────────────────────
+
+    /**
+     * 입력 Reader를 [BufferedReader]로 감싸고, [CsvSettings.detectBom]이 `true`이면
+     * 선두의 BOM을 감지해 소비한다.
+     */
+    private fun createReader(reader: Reader): BufferedReader {
+        val br = if (reader is BufferedReader) reader else reader.buffered(bufferSize)
+        if (!settings.detectBom) return br
+        br.mark(1)
+        val firstChar = br.read()
+        if (firstChar == BOM_CHAR) {
+            // BOM 소비 완료
+        } else if (firstChar != -1) {
+            br.reset()
+        }
+        return br
+    }
+
+    /**
+     * skipEmptyLines 정책을 적용하여 다음 유효한 레코드를 읽는다.
+     */
+    private fun readNextRecord(): ArrayRecord? {
+        while (true) {
+            val fields = parseRow()
+            if (fields == null) {
+                exhausted = true
+                return null
+            }
+            // 물리적 빈 줄(컬럼 하나도 없음) 처리
+            if (fields.isEmpty()) {
+                if (skipEmptyLines) continue
+                // skipEmptyLines=false일 때는 단일 null/empty 필드로 취급
+                rowNumber++
+                return ArrayRecord(
+                    rawValues = arrayOfNulls(1),
+                    _headers = headers,
+                    headerIndex = headerIndex,
+                    rowNumber = rowNumber,
+                )
+            }
+            rowNumber++
+            return ArrayRecord(
+                rawValues = fields.toTypedArray(),
+                _headers = headers,
+                headerIndex = headerIndex,
+                rowNumber = rowNumber,
+            )
+        }
+    }
+
+    /**
+     * 한 행을 파싱하여 필드 리스트를 반환한다.
+     *
+     * @return 파싱된 필드 리스트. EOF 시 `null`. 물리적 빈 줄이면 `emptyList()`.
+     */
+    private fun parseRow(): List<String?>? {
+        val fields = mutableListOf<String?>()
+        state = State.START_FIELD
+        fieldBuffer.clear()
+        lastFieldWasQuoted = false
+        columnNumber = 0
+
+        while (true) {
+            val ch = bufferedReader.read()
+
+            if (ch == -1) {
+                // EOF 처리
+                return handleEof(fields)
+            }
+
+            val c = ch.toChar()
+
+            when (state) {
+                State.START_FIELD -> {
+                    when (c) {
+                        quote -> {
+                            lastFieldWasQuoted = true
+                            state = State.IN_QUOTED
+                        }
+
+                        delimiter -> {
+                            // 빈 필드
+                            appendField(fields)
+                        }
+
+                        '\r' -> {
+                            // CR 뒤 LF 여부 확인 후 행 종료
+                            consumeLfAfterCr()
+                            return finalizeRowAtStart(fields)
+                        }
+
+                        '\n' -> {
+                            return finalizeRowAtStart(fields)
+                        }
+
+                        else -> {
+                            state = State.IN_UNQUOTED
+                            columnNumber++
+                            appendCharToBuffer(c, fields.size)
+                        }
+                    }
+                }
+
+                State.IN_QUOTED -> {
+                    when (c) {
+                        quote -> state = State.QUOTE_IN_QUOTED
+                        else -> {
+                            appendCharToBuffer(c, fields.size)
+                        }
+                    }
+                }
+
+                State.QUOTE_IN_QUOTED -> {
+                    when (c) {
+                        // RFC 4180: quoteEscape == quote 이므로 doubled-quote → literal quote
+                        quoteEscape -> {
+                            fieldBuffer.append(quote)
+                            state = State.IN_QUOTED
+                        }
+
+                        delimiter -> {
+                            appendField(fields)
+                            state = State.START_FIELD
+                        }
+
+                        '\r' -> {
+                            consumeLfAfterCr()
+                            appendField(fields)
+                            return fields
+                        }
+
+                        '\n' -> {
+                            appendField(fields)
+                            return fields
+                        }
+
+                        else -> {
+                            // closing quote 뒤 비구분자/비EOL — 관대하게 unquoted로 전환
+                            state = State.IN_UNQUOTED
+                            appendCharToBuffer(c, fields.size)
+                        }
+                    }
+                }
+
+                State.IN_UNQUOTED -> {
+                    when (c) {
+                        delimiter -> {
+                            appendField(fields)
+                            state = State.START_FIELD
+                        }
+
+                        '\r' -> {
+                            consumeLfAfterCr()
+                            appendField(fields)
+                            return fields
+                        }
+
+                        '\n' -> {
+                            appendField(fields)
+                            return fields
+                        }
+
+                        else -> {
+                            columnNumber++
+                            appendCharToBuffer(c, fields.size)
+                        }
+                    }
+                }
+
+                State.END_ROW -> {
+                    // 사용되지 않음(행은 return 으로 종료)
+                    return fields
+                }
+            }
+        }
+    }
+
+    /**
+     * CR 다음 문자가 LF이면 소비하고, 아니면 reset으로 되돌린다.
+     */
+    private fun consumeLfAfterCr() {
+        bufferedReader.mark(1)
+        val next = bufferedReader.read()
+        if (next != '\n'.code && next != -1) {
+            bufferedReader.reset()
+        }
+    }
+
+    /**
+     * EOF 시점에서 남은 필드를 정리한다.
+     *
+     * - 아직 필드를 전혀 시작하지 않았고 버퍼도 비어 있으면 `null` 반환(진짜 EOF).
+     * - 그 외에는 현재 필드를 마무리하여 반환.
+     */
+    private fun handleEof(fields: MutableList<String?>): List<String?>? {
+        if (fields.isEmpty() && fieldBuffer.isEmpty() && state == State.START_FIELD && !lastFieldWasQuoted) {
+            return null
+        }
+        fields.add(finishField())
+        if (fields.size > maxColumns) {
+            throw ParseException(
+                message = "컬럼 수가 maxColumns($maxColumns)를 초과했습니다",
+                rowNumber = rowNumber + 1,
+                columnNumber = columnNumber,
+                fieldIndex = fields.size - 1,
+            )
+        }
+        return fields
+    }
+
+    /**
+     * START_FIELD 상태에서 라인 종료를 만났을 때 행을 마무리한다.
+     *
+     * - 아무 필드도 없고 버퍼도 비어 있으면 물리적 빈 줄(`emptyList()`)로 반환.
+     * - 그 외에는 현재 필드를 마무리하여 반환.
+     */
+    private fun finalizeRowAtStart(fields: MutableList<String?>): List<String?> {
+        return if (fields.isEmpty() && fieldBuffer.isEmpty() && !lastFieldWasQuoted) {
+            emptyList()
+        } else {
+            fields.add(finishField())
+            if (fields.size > maxColumns) {
+                throw ParseException(
+                    message = "컬럼 수가 maxColumns($maxColumns)를 초과했습니다",
+                    rowNumber = rowNumber + 1,
+                    columnNumber = columnNumber,
+                    fieldIndex = fields.size - 1,
+                )
+            }
+            fields
+        }
+    }
+
+    /**
+     * 현재 버퍼의 필드를 확정하여 리스트에 추가하고, 다음 필드를 위해 상태를 초기화한다.
+     * maxColumns 초과 시 [ParseException]을 던진다.
+     */
+    private fun appendField(fields: MutableList<String?>) {
+        fields.add(finishField())
+        if (fields.size > maxColumns) {
+            throw ParseException(
+                message = "컬럼 수가 maxColumns($maxColumns)를 초과했습니다",
+                rowNumber = rowNumber + 1,
+                columnNumber = columnNumber,
+                fieldIndex = fields.size - 1,
+            )
+        }
+        fieldBuffer.clear()
+        lastFieldWasQuoted = false
+    }
+
+    /**
+     * 버퍼에 문자를 추가하며 maxCharsPerColumn 한계를 체크한다.
+     */
+    private fun appendCharToBuffer(c: Char, currentFieldIndex: Int) {
+        fieldBuffer.append(c)
+        if (fieldBuffer.length > maxCharsPerColumn) {
+            throw ParseException(
+                message = "컬럼 크기가 maxCharsPerColumn($maxCharsPerColumn)을 초과했습니다",
+                rowNumber = rowNumber + 1,
+                columnNumber = columnNumber,
+                fieldIndex = currentFieldIndex,
+            )
+        }
+    }
+
+    /**
+     * 현재 버퍼의 내용을 필드 값으로 확정하고 반환한다.
+     *
+     * ## null/empty 분기
+     * - **lastFieldWasQuoted=true, raw.isEmpty(), emptyQuotedAsNull=true** → `null`
+     * - **lastFieldWasQuoted=true, raw.isEmpty(), emptyQuotedAsNull=false** → `""`
+     * - **lastFieldWasQuoted=true, raw.isNotEmpty()** → `raw`
+     * - **lastFieldWasQuoted=false, raw.isEmpty(), emptyValueAsNull=true** → `null`
+     * - **lastFieldWasQuoted=false, raw.isEmpty(), emptyValueAsNull=false** → `""`
+     * - **lastFieldWasQuoted=false, raw.isNotEmpty()** → trimValues 적용 후 `raw`
+     */
+    private fun finishField(): String? {
+        val wasQuoted = lastFieldWasQuoted
+        var raw = fieldBuffer.toString()
+        fieldBuffer.clear()
+
+        if (trimValues && !wasQuoted) {
+            raw = raw.trim()
+        }
+
+        return if (wasQuoted) {
+            lastFieldWasQuoted = false
+            when {
+                raw.isEmpty() && emptyQuotedAsNull -> null
+                else -> raw
+            }
+        } else {
+            when {
+                raw.isEmpty() && emptyValueAsNull -> null
+                else -> raw
+            }
+        }
+    }
+
+    /**
+     * 파싱된 헤더 이름 배열(skipHeaders=true일 때만 non-null).
+     */
+    fun headerNames(): Array<String>? = headers?.copyOf()
+
+    /**
+     * 헤더 인덱스 객체(skipHeaders=true일 때만 non-null).
+     */
+    fun headerIndex(): HeaderIndex? = headerIndex
+}

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/CsvLineWriter.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/CsvLineWriter.kt
@@ -1,0 +1,47 @@
+package io.bluetape4k.csv.internal
+
+import io.bluetape4k.csv.CsvSettings
+import io.bluetape4k.logging.KLogging
+import java.io.Closeable
+import java.io.Writer
+
+/**
+ * [CsvSettings]를 기반으로 CSV 라인을 출력하는 Writer.
+ *
+ * 내부적으로 [DelimitedWriter]를 사용하며, [CsvSettings]에 정의된 구분자, 인용 문자,
+ * 이스케이프 문자, 레코드 구분자를 그대로 위임합니다.
+ *
+ * ## null/빈 문자열 처리 정책
+ * - `null` → 인용 없는 빈 필드 (roundtrip: 읽을 때 null로 복원)
+ * - `""` (빈 문자열) → `""` 인용 출력 (roundtrip: 읽을 때 빈 문자열로 복원)
+ *
+ * @param writer 출력 대상 Writer
+ * @param settings CSV 설정. 기본값은 [CsvSettings.DEFAULT]
+ */
+internal class CsvLineWriter(
+    writer: Writer,
+    settings: CsvSettings = CsvSettings.DEFAULT,
+) : Closeable {
+
+    companion object : KLogging()
+
+    private val delegate = DelimitedWriter(
+        writer = writer,
+        delimiter = settings.delimiter,
+        quote = settings.quote,
+        quoteEscape = settings.quoteEscape,
+        lineSeparator = settings.lineSeparator,
+    )
+
+    /**
+     * 한 행을 CSV 형식으로 출력합니다.
+     *
+     * @param fields 출력할 필드 목록
+     */
+    fun writeRow(fields: Iterable<*>) = delegate.writeRow(fields)
+
+    /**
+     * Writer를 닫습니다.
+     */
+    override fun close() = delegate.close()
+}

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/DelimitedWriter.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/DelimitedWriter.kt
@@ -1,0 +1,118 @@
+package io.bluetape4k.csv.internal
+
+import io.bluetape4k.logging.KLogging
+import java.io.Closeable
+import java.io.Writer
+
+/**
+ * RFC 4180 기반 구분자 방식 CSV/TSV 라이터.
+ * null/빈 문자열 roundtrip 정책을 보장합니다.
+ *
+ * - `null` → 인용 없는 빈 필드 (구분자만 출력)
+ * - `""` (빈 문자열) → `""` 인용 출력 (roundtrip 보장)
+ *
+ * @param writer 출력 대상 Writer
+ * @param delimiter 필드 구분 문자
+ * @param quote 인용 문자
+ * @param quoteEscape 인용 문자 이스케이프 문자 (RFC 4180: doubled-quote)
+ * @param lineSeparator 레코드 구분자
+ */
+internal class DelimitedWriter(
+    private val writer: Writer,
+    private val delimiter: Char,
+    private val quote: Char,
+    private val quoteEscape: Char,
+    private val lineSeparator: String,
+) : Closeable {
+
+    companion object : KLogging()
+
+    /**
+     * 필드가 인용 문자로 감싸야 하는지 판단합니다.
+     *
+     * 다음 조건 중 하나라도 해당하면 인용이 필요합니다:
+     * - 필드 앞 또는 뒤에 공백이 있는 경우
+     * - 필드에 [delimiter] 문자가 포함된 경우
+     * - 필드에 [quote] 문자가 포함된 경우
+     * - 필드에 CR(`\r`) 또는 LF(`\n`)가 포함된 경우
+     *
+     * 빈 문자열은 이 메서드에서 `false`를 반환하지만, 호출자에서 별도로 인용 처리합니다.
+     */
+    internal fun needsQuoting(s: String): Boolean {
+        if (s.isEmpty()) return false
+        if (s[0] == ' ' || s[s.length - 1] == ' ') return true
+        for (c in s) {
+            if (c == delimiter || c == quote || c == '\r' || c == '\n') return true
+        }
+        return false
+    }
+
+    /**
+     * 필드를 인용 문자로 감싸 출력합니다.
+     *
+     * 내부 [quote] 문자는 RFC 4180 doubled-quote 방식으로 이스케이프됩니다.
+     *
+     * @param s 출력할 문자열
+     */
+    internal fun writeQuoted(s: String) {
+        writer.write(quote.code)
+        for (c in s) {
+            if (c == quote) {
+                writer.write(quoteEscape.code)  // RFC 4180: doubled-quote
+                writer.write(quote.code)
+            } else {
+                writer.write(c.code)
+            }
+        }
+        writer.write(quote.code)
+    }
+
+    /**
+     * 한 행을 구분자 형식으로 출력합니다.
+     *
+     * 필드별 출력 규칙:
+     * - `null` 값 → 인용 없는 빈 필드 (아무것도 출력하지 않음)
+     * - `""` (빈 문자열) → `""` 인용 출력 (roundtrip 보장)
+     * - 인용이 필요한 문자열 → 인용 출력
+     * - 일반 문자열 → 그대로 출력
+     *
+     * @param fields 출력할 필드 목록
+     */
+    fun writeRow(fields: Iterable<*>) {
+        var first = true
+        for (field in fields) {
+            if (!first) writer.write(delimiter.code)
+            first = false
+
+            when (field) {
+                null -> { /* 인용 없는 빈 필드 — 아무것도 쓰지 않음 */ }
+                is String -> {
+                    if (field.isEmpty()) {
+                        writeQuoted(field)  // "" → "" 인용 출력
+                    } else if (needsQuoting(field)) {
+                        writeQuoted(field)
+                    } else {
+                        writer.write(field)
+                    }
+                }
+                else -> {
+                    val str = field.toString()
+                    if (needsQuoting(str)) writeQuoted(str) else writer.write(str)
+                }
+            }
+        }
+        writer.write(lineSeparator)
+    }
+
+    /**
+     * Writer를 flush 후 close합니다.
+     *
+     * close 중 발생하는 예외는 로그 없이 무시됩니다.
+     */
+    override fun close() {
+        runCatching {
+            writer.flush()
+            writer.close()
+        }
+    }
+}

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/HeaderIndex.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/HeaderIndex.kt
@@ -1,0 +1,57 @@
+package io.bluetape4k.csv.internal
+
+import io.bluetape4k.logging.KLogging
+import java.io.Serializable
+
+/**
+ * 헤더명 → 컬럼 인덱스 매핑. case-sensitive, 중복 키는 first-wins.
+ */
+class HeaderIndex private constructor(
+    private val index: LinkedHashMap<String, Int>,
+) : Serializable {
+    companion object : KLogging() {
+        private const val serialVersionUID = 1L
+
+        /**
+         * headers 배열로 HeaderIndex를 생성한다. 중복 키는 first-wins.
+         *
+         * @param headers 헤더명 배열
+         * @return 생성된 HeaderIndex 인스턴스
+         */
+        fun of(headers: Array<String>): HeaderIndex {
+            val map = LinkedHashMap<String, Int>(headers.size * 2)
+            headers.forEachIndexed { i, name ->
+                map.putIfAbsent(name, i)
+            }
+            return HeaderIndex(map)
+        }
+    }
+
+    /**
+     * 헤더명으로 인덱스를 조회한다. 없으면 null 반환.
+     *
+     * @param name 조회할 헤더명
+     * @return 헤더명에 해당하는 0-based 인덱스, 없으면 null
+     */
+    fun indexOf(name: String): Int? = index[name]
+
+    /**
+     * 인덱스 → 헤더명 역방향 조회.
+     *
+     * @param idx 조회할 0-based 인덱스
+     * @return 해당 인덱스의 헤더명, 없으면 null
+     */
+    fun nameOf(idx: Int): String? = index.entries.firstOrNull { it.value == idx }?.key
+
+    /**
+     * 헤더 이름 목록.
+     */
+    val names: List<String>
+        get() = index.keys.toList()
+
+    /**
+     * 헤더 수.
+     */
+    val size: Int
+        get() = index.size
+}

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/ParseException.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/ParseException.kt
@@ -1,0 +1,23 @@
+package io.bluetape4k.csv.internal
+
+import io.bluetape4k.logging.KLogging
+import java.io.Serializable
+
+/**
+ * CSV/TSV 파싱 중 발생하는 예외.
+ *
+ * @param message 오류 메시지
+ * @param rowNumber 오류가 발생한 행 번호 (1-based, human-facing)
+ * @param columnNumber 오류가 발생한 열 번호 (1-based, human-facing)
+ * @param fieldIndex 오류가 발생한 필드 인덱스 (0-based, 첫 번째 필드 = 0, 알 수 없으면 -1)
+ */
+class ParseException(
+    message: String,
+    val rowNumber: Long,
+    val columnNumber: Int,
+    val fieldIndex: Int = -1,
+) : RuntimeException("$message (row=$rowNumber, col=$columnNumber, field=$fieldIndex)"), Serializable {
+    companion object : KLogging() {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/TsvLexer.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/TsvLexer.kt
@@ -1,0 +1,226 @@
+package io.bluetape4k.csv.internal
+
+import io.bluetape4k.csv.TsvSettings
+import io.bluetape4k.logging.KLogging
+import java.io.BufferedReader
+import java.io.Closeable
+import java.io.Reader
+
+/**
+ * TSV 형식 파서. 탭(`\t`) 구분, 백슬래시 이스케이프 방식.
+ * 인용(quote) 문자 없음.
+ *
+ * ## 이스케이프 규칙
+ * - `\t` → 탭 문자
+ * - `\n` → 개행 문자
+ * - `\r` → CR 문자
+ * - `\\` → 리터럴 백슬래시
+ * - 그 외 `\X` → 리터럴 `\X` (관대한 처리)
+ *
+ * ## 사용 예
+ * ```kotlin
+ * val reader = File("data.tsv").bufferedReader()
+ * val lexer = TsvLexer(reader, TsvSettings(), skipHeaders = true)
+ * for (record in lexer) {
+ *     println(record.getString("name"))
+ * }
+ * lexer.close()
+ * ```
+ *
+ * @param reader 입력 Reader
+ * @param settings TSV 파싱 설정 ([TsvSettings])
+ * @param skipHeaders `true`이면 첫 번째 행을 헤더로 읽어 [HeaderIndex]를 구성한다
+ */
+internal class TsvLexer(
+    reader: Reader,
+    private val settings: TsvSettings,
+    private val skipHeaders: Boolean = false,
+) : Iterator<ArrayRecord>, Closeable {
+
+    companion object : KLogging()
+
+    /** 파서 내부 상태. */
+    private enum class State {
+        /** 탭 또는 개행 대기 중인 일반 필드 읽기 상태. */
+        START_FIELD,
+
+        /** 백슬래시 다음 문자를 처리하는 이스케이프 상태. */
+        ESCAPE,
+    }
+
+    private val bufferedReader: BufferedReader =
+        if (reader is BufferedReader) reader else reader.buffered(settings.bufferSize)
+
+    private var headers: Array<String>? = null
+    private var headerIndex: HeaderIndex? = null
+
+    private var rowNumber: Long = 0L
+    private var fieldIndex: Int = 0
+
+    private val fieldBuffer = StringBuilder(256)
+    private var nextRecord: ArrayRecord? = null
+    private var exhausted = false
+
+    init {
+        if (skipHeaders) {
+            val firstRow = parseRow()
+            if (firstRow != null && firstRow.isNotEmpty()) {
+                headers = firstRow.map { it ?: "" }.toTypedArray()
+                headerIndex = HeaderIndex.of(headers!!)
+            }
+        }
+    }
+
+    /**
+     * 다음 레코드가 존재하는지 확인한다.
+     */
+    override fun hasNext(): Boolean {
+        if (exhausted) return false
+        if (nextRecord != null) return true
+        nextRecord = readNextRecord()
+        return nextRecord != null
+    }
+
+    /**
+     * 다음 레코드를 반환한다.
+     * @throws NoSuchElementException 레코드가 없을 때
+     */
+    override fun next(): ArrayRecord {
+        if (!hasNext()) throw NoSuchElementException("더 이상 레코드가 없습니다")
+        val record = nextRecord!!
+        nextRecord = null
+        return record
+    }
+
+    /**
+     * 다음 비어 있지 않은 레코드를 파싱하여 반환한다.
+     * 입력이 소진되면 null을 반환하고 [exhausted]를 true로 설정한다.
+     */
+    private fun readNextRecord(): ArrayRecord? {
+        while (true) {
+            val fields = parseRow() ?: run { exhausted = true; return null }
+            if (settings.skipEmptyLines && fields.isEmpty()) continue
+            rowNumber++
+            return ArrayRecord(
+                rawValues = fields.toTypedArray(),
+                _headers = headers,
+                headerIndex = headerIndex,
+                rowNumber = rowNumber,
+            )
+        }
+    }
+
+    /**
+     * 입력 스트림에서 한 행(레코드)을 파싱하여 필드 목록으로 반환한다.
+     *
+     * - EOF에서 버퍼가 비어 있으면 null 반환 (스트림 종료)
+     * - 빈 줄(`\n` 직후 `\n`)이면 빈 리스트 반환 ([settings.skipEmptyLines]에서 필터링)
+     * - CR-LF(`\r\n`) 시퀀스는 단일 레코드 구분자로 처리한다
+     */
+    private fun parseRow(): List<String?>? {
+        val fields = mutableListOf<String?>()
+        fieldBuffer.clear()
+        var state = State.START_FIELD
+        fieldIndex = 0
+
+        while (true) {
+            val ch = bufferedReader.read()
+
+            when {
+                // EOF 처리
+                ch == -1 -> {
+                    return if (fields.isEmpty() && fieldBuffer.isEmpty()) null
+                    else {
+                        fields.add(finishField())
+                        fields
+                    }
+                }
+
+                state == State.START_FIELD -> when (ch.toChar()) {
+                    // 백슬래시 → 이스케이프 상태 전환
+                    '\\' -> state = State.ESCAPE
+
+                    // 탭 → 필드 구분
+                    '\t' -> {
+                        fields.add(finishField())
+                        fieldIndex++
+                        if (fields.size > settings.maxColumns) {
+                            throw ParseException(
+                                "컬럼 수가 maxColumns(${settings.maxColumns})를 초과했습니다",
+                                rowNumber + 1,
+                                fieldIndex,
+                                fields.size - 1,
+                            )
+                        }
+                    }
+
+                    // CR: CR-LF 처리 — LF가 이어지면 소비, 아니면 되돌림
+                    '\r' -> {
+                        bufferedReader.mark(1)
+                        val next = bufferedReader.read()
+                        if (next != '\n'.code && next != -1) {
+                            bufferedReader.reset()
+                        }
+                        fields.add(finishField())
+                        return fields
+                    }
+
+                    // LF → 레코드 종료
+                    '\n' -> {
+                        fields.add(finishField())
+                        return fields
+                    }
+
+                    // 일반 문자 → 버퍼에 추가
+                    else -> {
+                        fieldBuffer.append(ch.toChar())
+                        if (fieldBuffer.length > settings.maxCharsPerColumn) {
+                            throw ParseException(
+                                "컬럼 크기가 maxCharsPerColumn(${settings.maxCharsPerColumn})을 초과했습니다",
+                                rowNumber + 1,
+                                fieldBuffer.length,
+                                fieldIndex,
+                            )
+                        }
+                    }
+                }
+
+                // 이스케이프 상태: 다음 문자로 변환 결정
+                state == State.ESCAPE -> {
+                    when (ch.toChar()) {
+                        't' -> fieldBuffer.append('\t')
+                        'n' -> fieldBuffer.append('\n')
+                        'r' -> fieldBuffer.append('\r')
+                        '\\' -> fieldBuffer.append('\\')
+                        else -> {
+                            // 알 수 없는 이스케이프 — 리터럴로 보존
+                            fieldBuffer.append('\\')
+                            fieldBuffer.append(ch.toChar())
+                        }
+                    }
+                    state = State.START_FIELD
+                }
+            }
+        }
+    }
+
+    /**
+     * 현재 필드 버퍼를 완성하고 최종 값을 반환한다.
+     *
+     * - [TsvSettings.trimValues]가 `true`이면 앞뒤 공백을 제거한다
+     * - [TsvSettings.emptyValueAsNull]이 `true`이고 값이 빈 문자열이면 `null`을 반환한다
+     */
+    private fun finishField(): String? {
+        var raw = fieldBuffer.toString()
+        fieldBuffer.clear()
+        if (settings.trimValues) raw = raw.trim()
+        return if (raw.isEmpty() && settings.emptyValueAsNull) null else raw
+    }
+
+    /**
+     * 내부 Reader를 닫는다. 오류는 무시한다.
+     */
+    override fun close() {
+        runCatching { bufferedReader.close() }
+    }
+}

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/TsvLineWriter.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/TsvLineWriter.kt
@@ -1,0 +1,87 @@
+package io.bluetape4k.csv.internal
+
+import io.bluetape4k.csv.TsvSettings
+import io.bluetape4k.logging.KLogging
+import java.io.Closeable
+import java.io.Writer
+
+/**
+ * [TsvSettings]를 기반으로 TSV 라인을 출력하는 Writer.
+ *
+ * 탭(`\t`) 구분, 백슬래시 이스케이프 방식을 사용합니다. CSV와 달리 인용(quote) 문자를 사용하지 않습니다.
+ *
+ * ## 이스케이프 규칙
+ * - `\t` (탭) → `\\t`
+ * - `\n` (LF) → `\\n`
+ * - `\r` (CR) → `\\r`
+ * - `\\` (백슬래시) → `\\\\`
+ *
+ * ## null/빈 문자열 처리 정책
+ * - `null` → 빈 필드 (아무것도 출력하지 않음)
+ * - `""` (빈 문자열) → 빈 필드 (TSV에서 null과 구분 불가)
+ *
+ * @param writer 출력 대상 Writer
+ * @param settings TSV 설정. 기본값은 [TsvSettings.DEFAULT]
+ */
+internal class TsvLineWriter(
+    private val writer: Writer,
+    private val settings: TsvSettings = TsvSettings.DEFAULT,
+) : Closeable {
+
+    companion object : KLogging()
+
+    /**
+     * 한 행을 TSV 형식으로 출력합니다.
+     *
+     * `null`은 빈 필드로 출력합니다. 각 필드 값은 [escape] 처리 후 출력됩니다.
+     *
+     * @param fields 출력할 필드 목록
+     */
+    fun writeRow(fields: Iterable<*>) {
+        var first = true
+        for (field in fields) {
+            if (!first) writer.write('\t'.code)
+            first = false
+            when (field) {
+                null -> { /* 빈 필드 */ }
+                else -> writer.write(escape(field.toString()))
+            }
+        }
+        writer.write(settings.lineSeparator)
+    }
+
+    /**
+     * TSV 이스케이프 처리를 수행합니다.
+     *
+     * 이스케이프가 필요한 문자가 없으면 원본 문자열을 그대로 반환합니다.
+     *
+     * @param s 이스케이프할 문자열
+     * @return 이스케이프 처리된 문자열
+     */
+    private fun escape(s: String): String {
+        if (s.none { it == '\t' || it == '\n' || it == '\r' || it == '\\' }) return s
+        return buildString(s.length + 4) {
+            for (c in s) {
+                when (c) {
+                    '\\' -> append("\\\\")
+                    '\t' -> append("\\t")
+                    '\n' -> append("\\n")
+                    '\r' -> append("\\r")
+                    else -> append(c)
+                }
+            }
+        }
+    }
+
+    /**
+     * Writer를 flush 후 close합니다.
+     *
+     * close 중 발생하는 예외는 로그 없이 무시됩니다.
+     */
+    override fun close() {
+        runCatching {
+            writer.flush()
+            writer.close()
+        }
+    }
+}

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/v2/CsvExtensions.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/v2/CsvExtensions.kt
@@ -1,0 +1,63 @@
+package io.bluetape4k.csv.v2
+
+import io.bluetape4k.csv.Record
+import io.bluetape4k.csv.internal.ArrayRecord
+import io.bluetape4k.csv.internal.HeaderIndex
+
+/**
+ * [Record] V1 인터페이스를 [CsvRow] V2 타입으로 변환한다.
+ *
+ * ```kotlin
+ * val csvRow: CsvRow = record.toCsvRow()
+ * ```
+ */
+fun Record.toCsvRow(): CsvRow = CsvRow(
+    values = values.toList(),
+    headers = headers?.toList(),
+    rowNumber = rowNumber,
+)
+
+/**
+ * [CsvRow] V2 타입을 [Record] V1 인터페이스로 변환한다.
+ *
+ * 동일 모듈 내 테스트 전용 — 공개 API가 아닙니다.
+ */
+internal fun CsvRow.toRecord(): Record {
+    val headerIndex: HeaderIndex? = headers?.let { hs ->
+        HeaderIndex.of(hs.toTypedArray())
+    }
+    return ArrayRecord(
+        rawValues = values.toTypedArray(),
+        _headers = headers?.toTypedArray(),
+        headerIndex = headerIndex,
+        rowNumber = rowNumber,
+    )
+}
+
+/**
+ * CSV 전용 [FlowCsvReader] DSL 빌더.
+ *
+ * ```kotlin
+ * val reader = csvReader {
+ *     trimValues = true
+ *     emptyValueAsNull = false
+ * }
+ * ```
+ *
+ * @param block [CsvReaderConfig] 설정 블록
+ */
+fun csvReader(block: CsvReaderConfig.() -> Unit = {}): FlowCsvReader =
+    FlowCsvReaderImpl(CsvReaderConfig().apply(block))
+
+/**
+ * TSV 전용 [FlowCsvReader] DSL 빌더.
+ * `delimiter`는 항상 `'\t'`로 강제됩니다.
+ *
+ * ```kotlin
+ * val reader = tsvReader { trimValues = true }
+ * ```
+ *
+ * @param block [CsvReaderConfig] 설정 블록 (delimiter 설정은 무시됨)
+ */
+fun tsvReader(block: CsvReaderConfig.() -> Unit = {}): FlowCsvReader =
+    FlowCsvReaderImpl(CsvReaderConfig().apply(block).also { it.delimiter = '\t'; it.lineSeparator = "\n" })

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/v2/CsvReaderConfig.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/v2/CsvReaderConfig.kt
@@ -1,0 +1,68 @@
+package io.bluetape4k.csv.v2
+
+import io.bluetape4k.csv.CsvSettings
+import io.bluetape4k.csv.MAX_CHARS_PER_COLUMN
+
+/**
+ * CSV/TSV V2 리더 설정 (var 기반 mutable builder).
+ *
+ * DSL 빌더 함수 [csvReader] / [tsvReader]에서 사용됩니다.
+ *
+ * ## 사용 예
+ * ```kotlin
+ * val reader = csvReader {
+ *     delimiter = ';'
+ *     trimValues = true
+ *     emptyValueAsNull = false
+ * }
+ * ```
+ */
+class CsvReaderConfig {
+    /** 필드 구분 문자. 기본값: `,`. */
+    var delimiter: Char = ','
+
+    /** 인용 문자. 기본값: `"`. */
+    var quote: Char = '"'
+
+    /** 레코드 구분자. 기본값: `"\r\n"` (RFC 4180). */
+    var lineSeparator: String = "\r\n"
+
+    /** 앞뒤 공백 제거 여부. reader 전용. 기본값: `false`. */
+    var trimValues: Boolean = false
+
+    /** 빈 줄 건너뛰기. 기본값: `true`. */
+    var skipEmptyLines: Boolean = true
+
+    /** 인용 없는 빈 필드 → `null` 변환 여부. 기본값: `true`. */
+    var emptyValueAsNull: Boolean = true
+
+    /** 인용 빈 필드(`""`) → `null` 변환 여부. 기본값: `false`. */
+    var emptyQuotedAsNull: Boolean = false
+
+    /** BOM 자동 감지/제거 여부. 기본값: `true`. */
+    var detectBom: Boolean = true
+
+    /** 컬럼당 최대 문자 수. 기본값: [MAX_CHARS_PER_COLUMN]. */
+    var maxCharsPerColumn: Int = MAX_CHARS_PER_COLUMN
+
+    /** 레코드당 최대 컬럼 수. 기본값: 512. */
+    var maxColumns: Int = 512
+
+    /** 내부 읽기 버퍼 크기(바이트). 기본값: 8192. */
+    var bufferSize: Int = 8192
+
+    internal fun toCsvSettings(): CsvSettings = CsvSettings(
+        delimiter = delimiter,
+        quote = quote,
+        quoteEscape = quote,
+        lineSeparator = lineSeparator,
+        trimValues = trimValues,
+        skipEmptyLines = skipEmptyLines,
+        emptyValueAsNull = emptyValueAsNull,
+        emptyQuotedAsNull = emptyQuotedAsNull,
+        detectBom = detectBom,
+        maxCharsPerColumn = maxCharsPerColumn,
+        maxColumns = maxColumns,
+        bufferSize = bufferSize,
+    )
+}

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/v2/CsvRow.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/v2/CsvRow.kt
@@ -1,0 +1,87 @@
+package io.bluetape4k.csv.v2
+
+import io.bluetape4k.logging.KLogging
+import java.io.Serializable
+import java.math.BigDecimal
+
+/**
+ * CSV/TSV V2 API의 불변 레코드 타입.
+ *
+ * [io.bluetape4k.csv.Record] V1 인터페이스와 달리 data class로 제공되어
+ * copy, equals, hashCode, toString이 자동으로 제공됩니다.
+ *
+ * ## 생성 방법
+ * ```kotlin
+ * // V1 Record에서 변환
+ * val csvRow = record.toCsvRow()
+ *
+ * // FlowCsvReader가 자동으로 생성
+ * csvReader { trimValues = true }.read(inputStream).collect { row -> ... }
+ * ```
+ *
+ * ## null vs 빈 문자열
+ * - `null` — 인용 없는 빈 필드 (emptyValueAsNull=true 시)
+ * - `""` — 인용된 빈 필드 `""` (빈 문자열 보존)
+ *
+ * @param values 원시 문자열 값 목록 (null 가능 원소 포함)
+ * @param headers 헤더명 목록 (skipHeaders=true 시에만 non-null)
+ * @param rowNumber 1-based 행 번호
+ */
+data class CsvRow(
+    val values: List<String?>,
+    val headers: List<String>?,
+    val rowNumber: Long,
+) : Serializable {
+
+    companion object : KLogging() {
+        private const val serialVersionUID = 1L
+    }
+
+    /** 컬럼 수. */
+    val size: Int get() = values.size
+
+    /**
+     * 인덱스로 원시 문자열 값을 반환한다.
+     * 범위 초과이면 null 반환.
+     */
+    fun getString(index: Int): String? = values.getOrNull(index)
+
+    /**
+     * 헤더명으로 원시 문자열 값을 반환한다.
+     * 헤더가 없거나 이름을 찾을 수 없으면 null 반환.
+     */
+    fun getString(name: String): String? {
+        val idx = headers?.indexOf(name)?.takeIf { it >= 0 } ?: return null
+        return getString(idx)
+    }
+
+    fun getIntOrNull(index: Int): Int? = getString(index)?.trim()?.toIntOrNull()
+    fun getIntOrNull(name: String): Int? = getString(name)?.trim()?.toIntOrNull()
+
+    fun getLongOrNull(index: Int): Long? = getString(index)?.trim()?.toLongOrNull()
+    fun getLongOrNull(name: String): Long? = getString(name)?.trim()?.toLongOrNull()
+
+    fun getDoubleOrNull(index: Int): Double? = getString(index)?.trim()?.toDoubleOrNull()
+    fun getDoubleOrNull(name: String): Double? = getString(name)?.trim()?.toDoubleOrNull()
+
+    fun getFloatOrNull(index: Int): Float? = getString(index)?.trim()?.toFloatOrNull()
+    fun getFloatOrNull(name: String): Float? = getString(name)?.trim()?.toFloatOrNull()
+
+    fun getBigDecimalOrNull(index: Int): BigDecimal? = getString(index)?.trim()?.toBigDecimalOrNull()
+    fun getBigDecimalOrNull(name: String): BigDecimal? = getString(name)?.trim()?.toBigDecimalOrNull()
+
+    fun getInt(index: Int, default: Int = 0): Int = getIntOrNull(index) ?: default
+    fun getInt(name: String, default: Int = 0): Int = getIntOrNull(name) ?: default
+
+    fun getLong(index: Int, default: Long = 0L): Long = getLongOrNull(index) ?: default
+    fun getLong(name: String, default: Long = 0L): Long = getLongOrNull(name) ?: default
+
+    fun getDouble(index: Int, default: Double = 0.0): Double = getDoubleOrNull(index) ?: default
+    fun getDouble(name: String, default: Double = 0.0): Double = getDoubleOrNull(name) ?: default
+
+    fun getBoolean(index: Int, default: Boolean = false): Boolean =
+        getString(index)?.trim()?.toBoolean() ?: default
+
+    fun getBoolean(name: String, default: Boolean = false): Boolean =
+        getString(name)?.trim()?.toBoolean() ?: default
+}

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/v2/CsvWriterConfig.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/v2/CsvWriterConfig.kt
@@ -1,0 +1,51 @@
+package io.bluetape4k.csv.v2
+
+import io.bluetape4k.csv.CsvSettings
+import io.bluetape4k.csv.MAX_CHARS_PER_COLUMN
+
+/**
+ * CSV/TSV V2 라이터 설정 (var 기반 mutable builder).
+ *
+ * DSL 빌더 함수 [csvWriter] / [tsvWriter]에서 사용됩니다.
+ *
+ * ## 사용 예
+ * ```kotlin
+ * val writer = csvWriter(outputWriter) {
+ *     delimiter = ';'
+ *     quoteAll = true
+ * }
+ * ```
+ */
+class CsvWriterConfig {
+    /** 필드 구분 문자. 기본값: `,`. */
+    var delimiter: Char = ','
+
+    /** 인용 문자. 기본값: `"`. */
+    var quote: Char = '"'
+
+    /** 레코드 구분자. 기본값: `"\r\n"` (RFC 4180). */
+    var lineSeparator: String = "\r\n"
+
+    /**
+     * 모든 필드를 인용(`"..."`) 출력할지 여부.
+     * `true`이면 필요 여부와 관계없이 모든 필드를 인용 출력합니다.
+     * `false`이면 RFC 4180 규칙에 따라 필요한 필드만 인용합니다.
+     * 기본값: `false`.
+     */
+    var quoteAll: Boolean = false
+
+    /** 컬럼당 최대 문자 수. 기본값: [MAX_CHARS_PER_COLUMN]. */
+    var maxCharsPerColumn: Int = MAX_CHARS_PER_COLUMN
+
+    /** 레코드당 최대 컬럼 수. 기본값: 512. */
+    var maxColumns: Int = 512
+
+    internal fun toCsvSettings(): CsvSettings = CsvSettings(
+        delimiter = delimiter,
+        quote = quote,
+        quoteEscape = quote,
+        lineSeparator = lineSeparator,
+        maxCharsPerColumn = maxCharsPerColumn,
+        maxColumns = maxColumns,
+    )
+}

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/v2/FlowCsvReader.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/v2/FlowCsvReader.kt
@@ -1,0 +1,61 @@
+package io.bluetape4k.csv.v2
+
+import kotlinx.coroutines.flow.Flow
+import java.io.InputStream
+import java.nio.charset.Charset
+import java.nio.file.Path
+
+/**
+ * CSV/TSV V2 비동기 리더 인터페이스.
+ *
+ * [kotlinx.coroutines.flow.Flow]를 반환하므로 대용량 파일을 스트리밍 방식으로
+ * 처리할 수 있으며 코루틴 취소(cooperative cancellation)를 지원합니다.
+ *
+ * ## 사용 예
+ * ```kotlin
+ * val reader = csvReader { trimValues = true }
+ * reader.read(inputStream, skipHeaders = true).collect { row ->
+ *     println("${row.getString("name")}, ${row.getInt("age")}")
+ * }
+ * ```
+ *
+ * @see csvReader
+ * @see tsvReader
+ */
+interface FlowCsvReader {
+
+    /** 이 리더의 설정. */
+    val config: CsvReaderConfig
+
+    /**
+     * [InputStream]을 읽어 [CsvRow] [Flow]를 반환한다.
+     *
+     * 반환된 Flow는 `flowOn(Dispatchers.IO)` 위에서 실행되므로
+     * blocking IO가 IO 디스패처에서 처리됩니다.
+     *
+     * @param input 입력 스트림
+     * @param encoding 문자 인코딩 (기본값: UTF-8)
+     * @param skipHeaders `true`이면 첫 번째 행을 헤더로 저장하고 이후 행부터 반환
+     */
+    fun read(
+        input: InputStream,
+        encoding: Charset = Charsets.UTF_8,
+        skipHeaders: Boolean = false,
+    ): Flow<CsvRow>
+
+    /**
+     * 파일을 스트리밍 방식으로 읽어 [CsvRow] [Flow]를 반환한다.
+     *
+     * RFC 4180 멀티라인 인용 필드를 올바르게 처리하기 위해
+     * line-based reader 대신 `FileInputStream`으로 직접 읽습니다.
+     *
+     * @param path 읽을 파일 경로
+     * @param encoding 문자 인코딩 (기본값: UTF-8)
+     * @param skipHeaders `true`이면 첫 번째 행을 헤더로 저장하고 이후 행부터 반환
+     */
+    fun readFile(
+        path: Path,
+        encoding: Charset = Charsets.UTF_8,
+        skipHeaders: Boolean = false,
+    ): Flow<CsvRow>
+}

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/v2/FlowCsvReaderImpl.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/v2/FlowCsvReaderImpl.kt
@@ -1,0 +1,50 @@
+package io.bluetape4k.csv.v2
+
+import io.bluetape4k.csv.internal.CsvLexer
+import io.bluetape4k.logging.KLogging
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.flowOn
+import java.io.FileInputStream
+import java.io.InputStream
+import java.nio.charset.Charset
+import java.nio.file.Path
+
+internal class FlowCsvReaderImpl(
+    override val config: CsvReaderConfig,
+) : FlowCsvReader {
+
+    companion object : KLogging()
+
+    override fun read(
+        input: InputStream,
+        encoding: Charset,
+        skipHeaders: Boolean,
+    ): Flow<CsvRow> = channelFlow {
+        val settings = config.toCsvSettings()
+        CsvLexer(input.reader(encoding), settings, skipHeaders).use { lexer ->
+            while (lexer.hasNext()) {
+                ensureActive()
+                send(lexer.next().toCsvRow())
+            }
+        }
+    }.flowOn(Dispatchers.IO)
+
+    override fun readFile(
+        path: Path,
+        encoding: Charset,
+        skipHeaders: Boolean,
+    ): Flow<CsvRow> = channelFlow {
+        val settings = config.toCsvSettings()
+        FileInputStream(path.toFile()).use { fis ->
+            CsvLexer(fis.reader(encoding), settings, skipHeaders).use { lexer ->
+                while (lexer.hasNext()) {
+                    ensureActive()
+                    send(lexer.next().toCsvRow())
+                }
+            }
+        }
+    }.flowOn(Dispatchers.IO)
+}

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/v2/FlowCsvWriter.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/v2/FlowCsvWriter.kt
@@ -1,0 +1,96 @@
+package io.bluetape4k.csv.v2
+
+import kotlinx.coroutines.flow.Flow
+import java.io.Closeable
+import java.io.Writer
+import java.nio.charset.Charset
+import java.nio.file.Path
+
+/**
+ * CSV/TSV V2 비동기 라이터 인터페이스.
+ *
+ * Mutex로 동시성 보호가 적용되어 있으며,
+ * [writeAll] 은 Flow를 순차적으로 collect하여 기록합니다.
+ *
+ * ## 사용 예
+ * ```kotlin
+ * val writer = csvWriter(outputWriter) { quoteAll = true }
+ * writer.writeHeaders(listOf("name", "age"))
+ * writer.writeRow(listOf("Alice", 20))
+ *
+ * val dataFlow: Flow<List<Any?>> = flowOf(listOf("Bob", 30))
+ * writer.writeAll(dataFlow)
+ * writer.close()
+ * ```
+ *
+ * @see csvWriter
+ * @see tsvWriter
+ */
+interface FlowCsvWriter : Closeable {
+
+    /** 이 라이터의 설정. */
+    val config: CsvWriterConfig
+
+    /**
+     * 헤더 행을 출력한다.
+     *
+     * @param headers 헤더명 목록
+     */
+    suspend fun writeHeaders(headers: Iterable<String>)
+
+    /**
+     * 한 행을 출력한다.
+     *
+     * @param row 필드 값 목록 (null 가능)
+     */
+    suspend fun writeRow(row: Iterable<*>)
+
+    /**
+     * [Flow]의 각 원소를 행으로 출력한다.
+     *
+     * Flow가 lazy이므로 메모리 폭발 없이 스트리밍 처리 가능합니다.
+     * 단, 쓰기 중 예외 시 부분 파일이 남을 수 있습니다.
+     *
+     * @param rows 행 시퀀스를 나타내는 Flow
+     */
+    suspend fun writeAll(rows: Flow<Iterable<*>>)
+
+    /**
+     * [path]에 Flow의 내용을 CSV로 저장한다.
+     *
+     * @param path 출력 파일 경로
+     * @param encoding 문자 인코딩 (기본값: UTF-8)
+     * @param append `true`이면 파일 끝에 추가, `false`이면 덮어쓰기
+     * @param skipHeaders `true`이면 헤더 행을 쓰지 않음
+     * @param headers 헤더명 목록 (skipHeaders=false일 때 사용)
+     * @param rows 출력할 행들의 Flow
+     * @return 기록된 데이터 행 수
+     */
+    suspend fun writeFile(
+        path: Path,
+        encoding: Charset = Charsets.UTF_8,
+        append: Boolean = false,
+        skipHeaders: Boolean = true,
+        headers: List<String> = emptyList(),
+        rows: Flow<Iterable<*>>,
+    ): Long
+}
+
+/**
+ * [Writer]로부터 [FlowCsvWriter]를 생성하는 DSL 빌더.
+ *
+ * @param writer 출력 대상 Writer
+ * @param block [CsvWriterConfig] 설정 블록
+ */
+fun csvWriter(writer: Writer, block: CsvWriterConfig.() -> Unit = {}): FlowCsvWriter =
+    FlowCsvWriterImpl(writer, CsvWriterConfig().apply(block))
+
+/**
+ * [Writer]로부터 TSV 전용 [FlowCsvWriter]를 생성하는 DSL 빌더.
+ * `delimiter`는 항상 `'\t'`로 강제됩니다.
+ *
+ * @param writer 출력 대상 Writer
+ * @param block [CsvWriterConfig] 설정 블록 (delimiter 설정은 무시됨)
+ */
+fun tsvWriter(writer: Writer, block: CsvWriterConfig.() -> Unit = {}): FlowCsvWriter =
+    FlowCsvWriterImpl(writer, CsvWriterConfig().apply(block).also { it.delimiter = '\t'; it.lineSeparator = "\n" })

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/v2/FlowCsvWriterImpl.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/v2/FlowCsvWriterImpl.kt
@@ -1,0 +1,112 @@
+package io.bluetape4k.csv.v2
+
+import io.bluetape4k.csv.internal.DelimitedWriter
+import io.bluetape4k.logging.KLogging
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.io.FileOutputStream
+import java.io.OutputStreamWriter
+import java.io.Writer
+import java.nio.charset.Charset
+import java.nio.file.Path
+
+internal class FlowCsvWriterImpl(
+    private val writer: Writer,
+    override val config: CsvWriterConfig,
+) : FlowCsvWriter {
+
+    companion object : KLogging()
+
+    private val settings = config.toCsvSettings()
+    private val delimiter = settings.delimiter
+    private val quote = settings.quote
+    private val lineSeparator = settings.lineSeparator
+
+    private val delimitedWriter = DelimitedWriter(
+        writer = writer,
+        delimiter = delimiter,
+        quote = quote,
+        quoteEscape = settings.quoteEscape,
+        lineSeparator = lineSeparator,
+    )
+    private val mutex = Mutex()
+
+    override suspend fun writeHeaders(headers: Iterable<String>) {
+        mutex.withLock {
+            writeRowTo(writer, headers)
+        }
+    }
+
+    override suspend fun writeRow(row: Iterable<*>) {
+        mutex.withLock {
+            writeRowTo(writer, row)
+        }
+    }
+
+    override suspend fun writeAll(rows: Flow<Iterable<*>>) {
+        rows.collect { writeRow(it) }
+    }
+
+    override suspend fun writeFile(
+        path: Path,
+        encoding: Charset,
+        append: Boolean,
+        skipHeaders: Boolean,
+        headers: List<String>,
+        rows: Flow<Iterable<*>>,
+    ): Long {
+        var count = 0L
+        OutputStreamWriter(FileOutputStream(path.toFile(), append), encoding).use { fw ->
+            if (!skipHeaders && headers.isNotEmpty()) {
+                writeRowTo(fw, headers)
+            }
+            rows.collect { row ->
+                writeRowTo(fw, row)
+                count++
+            }
+        }
+        return count
+    }
+
+    override fun close() {
+        runCatching { delimitedWriter.close() }
+    }
+
+    private fun writeRowTo(w: Writer, fields: Iterable<*>) {
+        if (config.quoteAll) {
+            writeAllQuoted(w, fields)
+        } else {
+            if (w === writer) {
+                delimitedWriter.writeRow(fields)
+            } else {
+                DelimitedWriter(w, delimiter, quote, quote, lineSeparator).writeRow(fields)
+            }
+        }
+    }
+
+    private fun writeAllQuoted(w: Writer, fields: Iterable<*>) {
+        var first = true
+        for (field in fields) {
+            if (!first) w.write(delimiter.code)
+            first = false
+            when (field) {
+                null -> { /* 인용 없는 빈 필드 */ }
+                else -> {
+                    val s = if (field is String) field else field.toString()
+                    w.write(quote.code)
+                    for (c in s) {
+                        if (c == quote) {
+                            w.write(quote.code)  // RFC 4180 doubled-quote
+                            w.write(quote.code)
+                        } else {
+                            w.write(c.code)
+                        }
+                    }
+                    w.write(quote.code)
+                }
+            }
+        }
+        w.write(lineSeparator)
+    }
+}

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/AbstractRecordReaderTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/AbstractRecordReaderTest.kt
@@ -1,6 +1,5 @@
 package io.bluetape4k.csv
 
-import com.univocity.parsers.common.record.Record
 import io.bluetape4k.csv.model.ProductType
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
@@ -14,7 +13,7 @@ import kotlin.text.Charsets.UTF_8
 
 abstract class AbstractRecordReaderTest {
 
-    companion object: KLogging()
+    companion object : KLogging()
 
     abstract val reader: RecordReader
 
@@ -24,10 +23,10 @@ abstract class AbstractRecordReaderTest {
     val mapper = { record: Record ->
         val tagFamily = record.getValue(0, "").trim()
         val representative = record.getValue(1, "").trim()
-        val synonym = record.getValue<String?>(2, null)?.trim()
-        val tagType = record.getValue<String?>(3, null)?.trim()
-        val priority = record.getValue<Int?>(4, null)
-        val parentRepresentative = record.getValue<String?>(5, null)?.trim()
+        val synonym = record.getString(2)?.trim()
+        val tagType = record.getString(3)?.trim()
+        val priority = record.getIntOrNull(4)
+        val parentRepresentative = record.getString(5)?.trim()
         val level = record.getValue(6, 0)
 
         ProductType(
@@ -73,7 +72,7 @@ abstract class AbstractRecordReaderTest {
     }
 
     @Test
-    fun `read extra words from csv file `() {
+    fun `read extra words from csv file`() {
         Resourcex.getInputStream(extraWordsPath)!!.buffered().use { bis ->
             val records = reader.read(bis, UTF_8, true)
 

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/CsvEdgeCaseTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/CsvEdgeCaseTest.kt
@@ -369,7 +369,7 @@ class CsvEdgeCaseTest {
 
     @Test
     fun `빈 문자열 값을 CSV 로 쓰면 null 로 파싱된다`() {
-        // univocity 파서는 빈 CSV 필드를 null 로 처리합니다.
+        // 빈 문자열("")은 인용 출력(roundtrip 보장), 읽을 때 빈 문자열로 복원됩니다.
         StringWriter().use { sw ->
             CsvRecordWriter(sw).use { writer ->
                 writer.writeHeaders("name", "middle", "surname")
@@ -382,7 +382,7 @@ class CsvEdgeCaseTest {
             val records = CsvRecordReader().read(input, UTF_8, skipHeaders = true).toList()
             records shouldHaveSize 1
             records[0].getValue(0, "") shouldBeEqualTo "Alice"
-            // univocity 파서는 빈 필드를 null 로 반환 — 기본값으로 빈 문자열 지정
+            // 빈 문자열은 "" 인용 출력 → 읽으면 빈 문자열(null 아님)로 복원됨
             records[0].getValue(1, "") shouldBeEqualTo ""
             records[0].getValue(2, "") shouldBeEqualTo "Smith"
         }

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/CsvEdgeCaseTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/CsvEdgeCaseTest.kt
@@ -238,7 +238,7 @@ class CsvEdgeCaseTest {
             val input = ByteArrayInputStream(output.toByteArray(UTF_8))
             val records = CsvRecordReader().read(input, UTF_8, skipHeaders = true).toList()
             records shouldHaveSize 2
-            records[0].getValue<String?>(1, null).shouldBeNull()
+            records[0].getString(1).shouldBeNull()
             records[1].getValue(1, "") shouldBeEqualTo "present"
         }
     }
@@ -256,9 +256,9 @@ class CsvEdgeCaseTest {
             val input = ByteArrayInputStream(output.toByteArray(UTF_8))
             val records = CsvRecordReader().read(input, UTF_8, skipHeaders = true).toList()
             records shouldHaveSize 1
-            records[0].getValue<String?>(0, null).shouldBeNull()
-            records[0].getValue<String?>(1, null).shouldBeNull()
-            records[0].getValue<String?>(2, null).shouldBeNull()
+            records[0].getString(0).shouldBeNull()
+            records[0].getString(1).shouldBeNull()
+            records[0].getString(2).shouldBeNull()
         }
     }
 

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/CsvRecordWriterTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/CsvRecordWriterTest.kt
@@ -25,7 +25,7 @@ class CsvRecordWriterTest {
 
             log.debug { "captured=\n$captured" }
             captured shouldContain """row1,1,2,"3, 3""""
-            captured shouldContain """row2,4,,"6,6""""
+            captured shouldContain """"row2  ",4,,"6,6""""
         }
     }
 

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/NativeCsvRecordReaderTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/NativeCsvRecordReaderTest.kt
@@ -1,0 +1,96 @@
+package io.bluetape4k.csv
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.utils.Resourcex
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldNotBeBlank
+import org.amshove.kluent.shouldNotBeEmpty
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import kotlin.text.Charsets.UTF_8
+
+/**
+ * 자체 엔진 기반 [CsvRecordReader] 통합 테스트.
+ *
+ * 실제 리소스 파일을 사용해 엔드투엔드 파싱 동작을 검증합니다.
+ */
+class NativeCsvRecordReaderTest {
+
+    companion object : KLogging()
+
+    private val reader = CsvRecordReader()
+
+    @Test
+    fun `product_type csv 전체 파싱`() {
+        Resourcex.getInputStream("csv/product_type.csv")!!.buffered().use { bis ->
+            val records = reader.read(bis, UTF_8, skipHeaders = true).toList()
+
+            records.shouldNotBeEmpty()
+            records.size shouldBeGreaterThan 100
+            records.forEach { record ->
+                record.size shouldBeGreaterThan 1
+                record.getString(0)!!.shouldNotBeBlank()
+                record.getString(1)!!.shouldNotBeBlank()
+            }
+        }
+    }
+
+    @Test
+    fun `헤더명 기반 접근이 동작한다`() {
+        Resourcex.getInputStream("csv/product_type.csv")!!.buffered().use { bis ->
+            val records = reader.read(bis, UTF_8, skipHeaders = true).take(3).toList()
+
+            records.shouldNotBeEmpty()
+            records.forEach { record ->
+                record.headers.shouldNotBeNull()
+                val tagFamily = record.getString("tag_family") ?: record.getString(0)
+                tagFamily.shouldNotBeNull()
+            }
+        }
+    }
+
+    @Test
+    fun `Record 인터페이스의 getValue 타입 변환`() {
+        val csv = "name,score,active\nAlice,95,true\nBob,80,false"
+        val records = reader.read(csv.byteInputStream(), skipHeaders = true).toList()
+
+        records shouldHaveSize 2
+        records[0].getValue("score", 0) shouldBeEqualTo 95
+        records[0].getValue("active", false) shouldBeEqualTo true
+        records[1].getValue("score", 0) shouldBeEqualTo 80
+        records[1].getValue("active", false) shouldBeEqualTo false
+    }
+
+    @Test
+    fun `Record 인터페이스의 nullable getter`() {
+        val csv = "id,amount\n1,42.5\n2,"
+        val records = reader.read(csv.byteInputStream(), skipHeaders = true).toList()
+
+        records shouldHaveSize 2
+        records[0].getDoubleOrNull("amount") shouldBeEqualTo 42.5
+        records[1].getDoubleOrNull("amount") shouldBeEqualTo null
+    }
+
+    @Test
+    fun `rowNumber가 올바르게 증가한다`() {
+        val csv = "a\nb\nc"
+        val records = reader.read(csv.byteInputStream(), skipHeaders = false).toList()
+
+        records[0].rowNumber shouldBeEqualTo 1L
+        records[1].rowNumber shouldBeEqualTo 2L
+        records[2].rowNumber shouldBeEqualTo 3L
+    }
+
+    @Test
+    fun `빈 줄은 기본적으로 건너뛴다`() {
+        val csv = "a,b\n\nc,d"
+        val records = reader.read(csv.byteInputStream(), skipHeaders = false).toList()
+
+        records shouldHaveSize 2
+    }
+
+    private infix fun <T> Collection<T>.shouldHaveSize(expected: Int) {
+        this.size shouldBeEqualTo expected
+    }
+}

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/RFC4180ComplianceTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/RFC4180ComplianceTest.kt
@@ -1,0 +1,147 @@
+package io.bluetape4k.csv
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldHaveSize
+import org.junit.jupiter.api.Test
+
+/**
+ * RFC 4180 표준 준수 검증 테스트.
+ *
+ * CsvRecordReader 가 RFC 4180 의 핵심 규칙을 올바르게 구현하는지 검증합니다.
+ */
+class RFC4180ComplianceTest {
+
+    companion object : KLogging()
+
+    private fun read(csv: String, settings: CsvSettings = CsvSettings.DEFAULT, skipHeaders: Boolean = false): List<Record> =
+        CsvRecordReader(settings).read(csv.byteInputStream(), skipHeaders = skipHeaders).toList()
+
+    // ── 섹션 2: 레코드 구분 ──────────────────────────────
+
+    @Test
+    fun `CRLF 레코드 구분자 지원`() {
+        val records = read("a,b\r\nc,d")
+        records shouldHaveSize 2
+        records[0].getString(0) shouldBeEqualTo "a"
+        records[1].getString(0) shouldBeEqualTo "c"
+    }
+
+    @Test
+    fun `LF 레코드 구분자 지원`() {
+        val records = read("a,b\nc,d")
+        records shouldHaveSize 2
+    }
+
+    @Test
+    fun `CR 레코드 구분자 지원`() {
+        val records = read("a,b\rc,d")
+        records shouldHaveSize 2
+    }
+
+    @Test
+    fun `마지막 행 뒤 개행 없이도 파싱`() {
+        val records = read("x,y,z")
+        records shouldHaveSize 1
+        records[0].getString(2) shouldBeEqualTo "z"
+    }
+
+    // ── 섹션 3: 헤더 행 ─────────────────────────────────
+
+    @Test
+    fun `skipHeaders=true 이면 첫 행을 헤더로 처리`() {
+        val records = read("name,age\nAlice,30", skipHeaders = true)
+        records shouldHaveSize 1
+        records[0].getString("name") shouldBeEqualTo "Alice"
+        records[0].getString("age") shouldBeEqualTo "30"
+    }
+
+    @Test
+    fun `skipHeaders=false 이면 모든 행을 데이터로 처리`() {
+        val records = read("name,age\nAlice,30", skipHeaders = false)
+        records shouldHaveSize 2
+        records[0].getString(0) shouldBeEqualTo "name"
+    }
+
+    // ── 섹션 4: 필드 처리 ───────────────────────────────
+
+    @Test
+    fun `쉼표로 구분된 필드 파싱`() {
+        val records = read("a,b,c")
+        records[0].size shouldBeEqualTo 3
+        records[0].getString(0) shouldBeEqualTo "a"
+        records[0].getString(1) shouldBeEqualTo "b"
+        records[0].getString(2) shouldBeEqualTo "c"
+    }
+
+    @Test
+    fun `빈 필드는 null 반환 (emptyValueAsNull=true 기본값)`() {
+        val records = read("a,,c")
+        records[0].getString(0) shouldBeEqualTo "a"
+        records[0].getString(1).shouldBeNull()
+        records[0].getString(2) shouldBeEqualTo "c"
+    }
+
+    // ── 섹션 5: 인용 필드 ───────────────────────────────
+
+    @Test
+    fun `인용 필드 내 쉼표는 구분자가 아님`() {
+        val records = read("\"a,b\",c")
+        records[0].size shouldBeEqualTo 2
+        records[0].getString(0) shouldBeEqualTo "a,b"
+        records[0].getString(1) shouldBeEqualTo "c"
+    }
+
+    @Test
+    fun `인용 필드 내 CRLF는 레코드 구분자가 아님`() {
+        val records = read("\"line1\r\nline2\",end")
+        records shouldHaveSize 1
+        records[0].getString(0) shouldBeEqualTo "line1\r\nline2"
+        records[0].getString(1) shouldBeEqualTo "end"
+    }
+
+    @Test
+    fun `인용 필드 내 LF는 레코드 구분자가 아님`() {
+        val records = read("\"line1\nline2\",end")
+        records shouldHaveSize 1
+        records[0].getString(0) shouldBeEqualTo "line1\nline2"
+    }
+
+    @Test
+    fun `doubled-quote 이스케이프 처리`() {
+        // "a""b" → a"b
+        val records = read("\"a\"\"b\"")
+        records[0].getString(0) shouldBeEqualTo "a\"b"
+    }
+
+    @Test
+    fun `빈 인용 필드는 빈 문자열 반환 (emptyQuotedAsNull=false 기본값)`() {
+        val records = read("a,\"\",b")
+        records[0].getString(1) shouldBeEqualTo ""
+    }
+
+    @Test
+    fun `빈 인용 필드 null 변환 설정`() {
+        val settings = CsvSettings(emptyQuotedAsNull = true)
+        val records = read("a,\"\",b", settings)
+        records[0].getString(1).shouldBeNull()
+    }
+
+    // ── 행 번호 ──────────────────────────────────────────
+
+    @Test
+    fun `rowNumber는 1부터 시작하고 행마다 증가`() {
+        val records = read("a\nb\nc")
+        records[0].rowNumber shouldBeEqualTo 1L
+        records[1].rowNumber shouldBeEqualTo 2L
+        records[2].rowNumber shouldBeEqualTo 3L
+    }
+
+    @Test
+    fun `skipHeaders=true 이면 rowNumber는 데이터 행 기준`() {
+        val records = read("hdr\na\nb", skipHeaders = true)
+        records[0].rowNumber shouldBeEqualTo 1L
+        records[1].rowNumber shouldBeEqualTo 2L
+    }
+}

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/RecordReaderSupportTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/RecordReaderSupportTest.kt
@@ -1,6 +1,5 @@
 package io.bluetape4k.csv
 
-import com.univocity.parsers.common.record.Record
 import io.bluetape4k.csv.model.ProductType
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
@@ -14,7 +13,7 @@ import java.io.File
 
 class RecordReaderSupportTest {
 
-    companion object: KLogging()
+    companion object : KLogging()
 
     @TempDir
     lateinit var tempDir: File
@@ -23,10 +22,10 @@ class RecordReaderSupportTest {
         ProductType(
             tagFamily = record.getValue(0, "").trim(),
             representative = record.getValue(1, "").trim(),
-            synonym = record.getValue<String?>(2, null)?.trim(),
-            tagType = record.getValue<String?>(3, null)?.trim(),
-            priority = record.getValue<Int?>(4, null),
-            parentRepresentativeValue = record.getValue<String?>(5, null)?.trim(),
+            synonym = record.getString(2)?.trim(),
+            tagType = record.getString(3)?.trim(),
+            priority = record.getIntOrNull(4),
+            parentRepresentativeValue = record.getString(5)?.trim(),
             level = record.getValue(6, 0)
         )
     }
@@ -107,7 +106,6 @@ class RecordReaderSupportTest {
     fun `File readAsCsvRecords는 Sequence 소비가 끝날때까지 스트림을 유지한다`() {
         val csvFile = createTempCsvFile()
 
-        // Sequence를 반환한 후 별도로 소비 - 스트림이 조기에 닫히지 않아야 함
         val sequence = csvFile.readAsCsvRecords(skipHeader = true)
         val records = sequence.toList()
 

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/TsvRecordWriterTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/TsvRecordWriterTest.kt
@@ -25,7 +25,7 @@ class TsvRecordWriterTest {
 
             log.debug { "captured=$captured" }
             captured shouldContain "row1\t1\t2\t3, 3"
-            captured shouldContain "row2\t4\t\t6,6"
+            captured shouldContain "row2  \t4\t\t6,6"
         }
     }
 

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/benchmark/CsvParserBenchmark.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/benchmark/CsvParserBenchmark.kt
@@ -1,0 +1,95 @@
+package io.bluetape4k.csv.benchmark
+
+import io.bluetape4k.csv.CsvSettings
+import io.bluetape4k.csv.internal.CsvLexer
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.utils.Resourcex
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+import kotlin.text.Charsets.UTF_8
+
+/**
+ * CSV 파서 성능 벤치마크.
+ *
+ * 자체 [CsvLexer]와 univocity 파서의 처리량을 비교한다.
+ * - 소형: product_type.csv 첫 10KB
+ * - 중형: product_type.csv 전체
+ *
+ * PR 2 완료 후 Task 2.8에서 nativeCsvRead_* 를 CsvRecordReader 호출로 교체 예정.
+ * PR 5에서 univocityCsvRead_* 삭제 예정.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+open class CsvParserBenchmark {
+
+    companion object : KLogging()
+
+    private lateinit var smallCsvBytes: ByteArray
+    private lateinit var mediumCsvBytes: ByteArray
+
+    @Setup(Level.Trial)
+    fun setup() {
+        smallCsvBytes = Resourcex.getInputStream("csv/product_type.csv")!!.use {
+            it.readBytes().take(10_000).toByteArray()
+        }
+        mediumCsvBytes = Resourcex.getInputStream("csv/product_type.csv")!!.use {
+            it.readBytes()
+        }
+    }
+
+    // ── 자체 CsvLexer (PR 1: 내부 엔진 직접 측정)
+
+    @Benchmark
+    fun nativeCsvRead_small(): Int {
+        var count = 0
+        CsvLexer(smallCsvBytes.inputStream().reader(), CsvSettings.DEFAULT, skipHeaders = true).use { lexer ->
+            while (lexer.hasNext()) { lexer.next(); count++ }
+        }
+        return count
+    }
+
+    @Benchmark
+    fun nativeCsvRead_medium(): Int {
+        var count = 0
+        CsvLexer(mediumCsvBytes.inputStream().reader(), CsvSettings.DEFAULT, skipHeaders = true).use { lexer ->
+            while (lexer.hasNext()) { lexer.next(); count++ }
+        }
+        return count
+    }
+
+    // ── univocity baseline (PR 5에서 삭제 예정)
+
+    @Benchmark
+    fun univocityCsvRead_small(): Int {
+        var count = 0
+        val parser = com.univocity.parsers.csv.CsvParser(
+            com.univocity.parsers.csv.CsvParserSettings().apply { maxCharsPerColumn = 100_000 }
+        )
+        parser.iterateRecords(smallCsvBytes.inputStream(), UTF_8).forEach { count++ }
+        return count
+    }
+
+    @Benchmark
+    fun univocityCsvRead_medium(): Int {
+        var count = 0
+        val parser = com.univocity.parsers.csv.CsvParser(
+            com.univocity.parsers.csv.CsvParserSettings().apply { maxCharsPerColumn = 100_000 }
+        )
+        parser.iterateRecords(mediumCsvBytes.inputStream(), UTF_8).forEach { count++ }
+        return count
+    }
+}

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/benchmark/CsvParserBenchmark.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/benchmark/CsvParserBenchmark.kt
@@ -22,11 +22,9 @@ import kotlin.text.Charsets.UTF_8
 /**
  * CSV 파서 성능 벤치마크.
  *
- * 자체 엔진([CsvLexer], [CsvRecordReader])과 univocity 파서의 처리량을 비교한다.
+ * 자체 엔진([CsvLexer], [CsvRecordReader])의 처리량을 측정한다.
  * - 소형: product_type.csv 첫 10KB
  * - 중형: product_type.csv 전체
- *
- * PR 5에서 univocityCsvRead_* 삭제 예정.
  */
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.Throughput)
@@ -81,25 +79,4 @@ open class CsvParserBenchmark {
     fun nativeCsvRead_medium(): Int =
         CsvRecordReader().read(mediumCsvBytes.inputStream(), UTF_8, skipHeaders = true).count()
 
-    // ── univocity baseline (PR 5에서 삭제 예정)
-
-    @Benchmark
-    fun univocityCsvRead_small(): Int {
-        var count = 0
-        val parser = com.univocity.parsers.csv.CsvParser(
-            com.univocity.parsers.csv.CsvParserSettings().apply { maxCharsPerColumn = 100_000 }
-        )
-        parser.iterateRecords(smallCsvBytes.inputStream(), UTF_8).forEach { count++ }
-        return count
-    }
-
-    @Benchmark
-    fun univocityCsvRead_medium(): Int {
-        var count = 0
-        val parser = com.univocity.parsers.csv.CsvParser(
-            com.univocity.parsers.csv.CsvParserSettings().apply { maxCharsPerColumn = 100_000 }
-        )
-        parser.iterateRecords(mediumCsvBytes.inputStream(), UTF_8).forEach { count++ }
-        return count
-    }
 }

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/benchmark/CsvParserBenchmark.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/benchmark/CsvParserBenchmark.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.csv.benchmark
 
+import io.bluetape4k.csv.CsvRecordReader
 import io.bluetape4k.csv.CsvSettings
 import io.bluetape4k.csv.internal.CsvLexer
 import io.bluetape4k.logging.KLogging
@@ -21,11 +22,10 @@ import kotlin.text.Charsets.UTF_8
 /**
  * CSV 파서 성능 벤치마크.
  *
- * 자체 [CsvLexer]와 univocity 파서의 처리량을 비교한다.
+ * 자체 엔진([CsvLexer], [CsvRecordReader])과 univocity 파서의 처리량을 비교한다.
  * - 소형: product_type.csv 첫 10KB
  * - 중형: product_type.csv 전체
  *
- * PR 2 완료 후 Task 2.8에서 nativeCsvRead_* 를 CsvRecordReader 호출로 교체 예정.
  * PR 5에서 univocityCsvRead_* 삭제 예정.
  */
 @State(Scope.Benchmark)
@@ -51,10 +51,10 @@ open class CsvParserBenchmark {
         }
     }
 
-    // ── 자체 CsvLexer (PR 1: 내부 엔진 직접 측정)
+    // ── 자체 CsvLexer (내부 엔진 직접 측정)
 
     @Benchmark
-    fun nativeCsvRead_small(): Int {
+    fun nativeLexer_small(): Int {
         var count = 0
         CsvLexer(smallCsvBytes.inputStream().reader(), CsvSettings.DEFAULT, skipHeaders = true).use { lexer ->
             while (lexer.hasNext()) { lexer.next(); count++ }
@@ -63,13 +63,23 @@ open class CsvParserBenchmark {
     }
 
     @Benchmark
-    fun nativeCsvRead_medium(): Int {
+    fun nativeLexer_medium(): Int {
         var count = 0
         CsvLexer(mediumCsvBytes.inputStream().reader(), CsvSettings.DEFAULT, skipHeaders = true).use { lexer ->
             while (lexer.hasNext()) { lexer.next(); count++ }
         }
         return count
     }
+
+    // ── 자체 CsvRecordReader (공개 API 측정)
+
+    @Benchmark
+    fun nativeCsvRead_small(): Int =
+        CsvRecordReader().read(smallCsvBytes.inputStream(), UTF_8, skipHeaders = true).count()
+
+    @Benchmark
+    fun nativeCsvRead_medium(): Int =
+        CsvRecordReader().read(mediumCsvBytes.inputStream(), UTF_8, skipHeaders = true).count()
 
     // ── univocity baseline (PR 5에서 삭제 예정)
 

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/coroutines/AbstractSuspendRecordReaderTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/coroutines/AbstractSuspendRecordReaderTest.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.csv.coroutines
 
-import com.univocity.parsers.common.record.Record
+import io.bluetape4k.csv.Record
 import io.bluetape4k.csv.model.ProductType
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
@@ -16,7 +16,7 @@ import kotlin.text.Charsets.UTF_8
 
 abstract class AbstractSuspendRecordReaderTest {
 
-    companion object: KLoggingChannel()
+    companion object : KLoggingChannel()
 
     protected abstract val reader: SuspendRecordReader
 
@@ -26,10 +26,10 @@ abstract class AbstractSuspendRecordReaderTest {
     private val transform: (Record) -> ProductType = { record: Record ->
         val tagFamily = record.getValue(0, "").trim()
         val representative = record.getValue(1, "").trim()
-        val synonym = record.getValue<String?>(2, null)?.trim()
-        val tagType = record.getValue<String?>(3, null)?.trim()
-        val priority = record.getValue<Int?>(4, null)
-        val parentRepresentative = record.getValue<String?>(5, null)?.trim()
+        val synonym = record.getString(2)?.trim()
+        val tagType = record.getString(3)?.trim()
+        val priority = record.getIntOrNull(4)
+        val parentRepresentative = record.getString(5)?.trim()
         val level = record.getValue(6, 0)
 
         ProductType(
@@ -76,7 +76,7 @@ abstract class AbstractSuspendRecordReaderTest {
     }
 
     @Test
-    fun `read extra words from csv file `() = runSuspendIO {
+    fun `read extra words from csv file`() = runSuspendIO {
         Resourcex.getInputStream(extraWordsPath)!!.buffered().use { bis ->
             reader
                 .read(bis, UTF_8, true)

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/coroutines/SuspendCsvEdgeCaseTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/coroutines/SuspendCsvEdgeCaseTest.kt
@@ -164,7 +164,7 @@ class SuspendCsvEdgeCaseTest {
 
             records shouldHaveSize 2
             records[0].getValue(0, "") shouldBeEqualTo "Alice"
-            records[0].getValue<String?>(1, null).shouldBeNull()
+            records[0].getString(1).shouldBeNull()
             records[1].getValue(0, "") shouldBeEqualTo "Bob"
             records[1].getValue(1, "") shouldBeEqualTo "present"
         }

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/coroutines/SuspendCsvRecordWriterTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/coroutines/SuspendCsvRecordWriterTest.kt
@@ -31,7 +31,7 @@ class SuspendCsvRecordWriterTest {
 
                 log.debug { "captured=\n$captured" }
                 captured shouldContain """row1,1,2,"3, 3""""
-                captured shouldContain """row2,4,,"6,6""""
+                captured shouldContain """"row2  ",4,,"6,6""""
             }
         }
 

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/coroutines/SuspendRecordReaderSupportTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/coroutines/SuspendRecordReaderSupportTest.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.csv.coroutines
 
-import com.univocity.parsers.common.record.Record
+import io.bluetape4k.csv.Record
 import io.bluetape4k.csv.model.ProductType
 import io.bluetape4k.csv.readAsTsvRecords
 import io.bluetape4k.csv.writeCsvRecords
@@ -20,7 +20,7 @@ import java.io.File
 
 class SuspendRecordReaderSupportTest {
 
-    companion object: KLoggingChannel()
+    companion object : KLoggingChannel()
 
     @TempDir
     lateinit var tempDir: File
@@ -29,10 +29,10 @@ class SuspendRecordReaderSupportTest {
         ProductType(
             tagFamily = record.getValue(0, "").trim(),
             representative = record.getValue(1, "").trim(),
-            synonym = record.getValue<String?>(2, null)?.trim(),
-            tagType = record.getValue<String?>(3, null)?.trim(),
-            priority = record.getValue<Int?>(4, null),
-            parentRepresentativeValue = record.getValue<String?>(5, null)?.trim(),
+            synonym = record.getString(2)?.trim(),
+            tagType = record.getString(3)?.trim(),
+            priority = record.getIntOrNull(4),
+            parentRepresentativeValue = record.getString(5)?.trim(),
             level = record.getValue(6, 0)
         )
     }
@@ -117,7 +117,6 @@ class SuspendRecordReaderSupportTest {
     fun `File readAsCsvRecords는 Sequence 소비가 끝날때까지 스트림을 유지한다`() = runTest {
         val csvFile = createTempCsvFile()
 
-        // Sequence를 반환한 후 별도로 소비 - 스트림이 조기에 닫히지 않아야 함
         val sequence = csvFile.readAsCsvRecordsSuspending(skipHeader = true)
         val records = sequence.toList()
 

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/coroutines/SuspendTsvRecordWriterTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/coroutines/SuspendTsvRecordWriterTest.kt
@@ -27,7 +27,7 @@ class SuspendTsvRecordWriterTest {
 
             log.debug { "captured=\n$captured" }
             captured shouldContain "row1\t1\t2\t3, 3"
-            captured shouldContain "row2\t4\t\t6,6"
+            captured shouldContain "row2  \t4\t\t6,6"
         }
     }
 

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/internal/ArrayRecordTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/internal/ArrayRecordTest.kt
@@ -1,0 +1,162 @@
+package io.bluetape4k.csv.internal
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeNull
+import org.junit.jupiter.api.Test
+
+class ArrayRecordTest {
+
+    companion object : KLogging()
+
+    private fun makeRecord(
+        values: Array<String?> = arrayOf("a", "b", "c"),
+        headers: Array<String>? = null,
+        headerIndex: HeaderIndex? = null,
+        rowNumber: Long = 1L,
+    ): ArrayRecord = ArrayRecord(
+        rawValues = values,
+        _headers = headers,
+        headerIndex = headerIndex,
+        rowNumber = rowNumber,
+    )
+
+    @Test
+    fun `getString by index returns raw value`() {
+        val record = makeRecord(arrayOf("hello", "world", null))
+
+        record.getString(0) shouldBeEqualTo "hello"
+        record.getString(1) shouldBeEqualTo "world"
+        record.getString(2).shouldBeNull()
+    }
+
+    @Test
+    fun `getString returns null for out of range index`() {
+        val record = makeRecord(arrayOf("a", "b"))
+
+        record.getString(99).shouldBeNull()
+        record.getString(-1).shouldBeNull()
+    }
+
+    @Test
+    fun `getString by name requires headerIndex`() {
+        val headers = arrayOf("id", "name")
+        val headerIndex = HeaderIndex.of(headers)
+        val record = makeRecord(
+            values = arrayOf("42", "Alice"),
+            headers = headers,
+            headerIndex = headerIndex,
+        )
+
+        record.getString("id") shouldBeEqualTo "42"
+        record.getString("name") shouldBeEqualTo "Alice"
+    }
+
+    @Test
+    fun `getString by name returns null when headerIndex is null`() {
+        val record = makeRecord(arrayOf("a", "b"), headers = null, headerIndex = null)
+
+        record.getString("any").shouldBeNull()
+    }
+
+    @Test
+    fun `getString by name returns null for unknown column name`() {
+        val headers = arrayOf("id")
+        val headerIndex = HeaderIndex.of(headers)
+        val record = makeRecord(arrayOf("1"), headers = headers, headerIndex = headerIndex)
+
+        record.getString("unknown").shouldBeNull()
+    }
+
+    @Test
+    fun `getValue Int with default`() {
+        val record = makeRecord(arrayOf("42", "not-a-number"))
+
+        record.getValue(0, 0) shouldBeEqualTo 42
+        record.getValue(1, -1) shouldBeEqualTo -1  // 변환 실패 → defaultValue
+    }
+
+    @Test
+    fun `getValue Long with default`() {
+        val record = makeRecord(arrayOf("9999999999", "bad"))
+
+        record.getValue(0, 0L) shouldBeEqualTo 9999999999L
+        record.getValue(1, -1L) shouldBeEqualTo -1L
+    }
+
+    @Test
+    fun `getValue with parse failure returns defaultValue`() {
+        val record = makeRecord(arrayOf(null, "xyz"))
+
+        record.getValue(0, 0) shouldBeEqualTo 0       // null → defaultValue
+        record.getValue(1, 99) shouldBeEqualTo 99     // 변환 불가 → defaultValue
+    }
+
+    @Test
+    fun `getIntOrNull returns null on parse failure`() {
+        val record = makeRecord(arrayOf("42", "abc", null))
+
+        record.getIntOrNull(0) shouldBeEqualTo 42
+        record.getIntOrNull(1).shouldBeNull()
+        record.getIntOrNull(2).shouldBeNull()
+    }
+
+    @Test
+    fun `defensive copy - mutation of original array not reflected`() {
+        val original = arrayOf<String?>("a", "b", "c")
+        val record = makeRecord(original)
+
+        original[0] = "MUTATED"
+
+        // ArrayRecord는 방어적 복사이므로 원본 변경이 반영되지 않아야 함
+        record.getString(0) shouldBeEqualTo "a"
+    }
+
+    @Test
+    fun `values returns defensive copy`() {
+        val record = makeRecord(arrayOf("x", "y"))
+
+        val v1 = record.values
+        val v2 = record.values
+
+        v1 shouldBeEqualTo v2
+        (v1 === v2).shouldBeFalse()  // 매번 새 배열 반환
+    }
+
+    @Test
+    fun `rowNumber stored correctly`() {
+        val record = makeRecord(rowNumber = 77L)
+        record.rowNumber shouldBeEqualTo 77L
+    }
+
+    @Test
+    fun `size equals rawValues length`() {
+        val record = makeRecord(arrayOf("a", "b", "c", "d"))
+        record.size shouldBeEqualTo 4
+    }
+
+    @Test
+    fun `getValue by name with header lookup`() {
+        val headers = arrayOf("score", "label")
+        val headerIndex = HeaderIndex.of(headers)
+        val record = makeRecord(
+            values = arrayOf("95", "A"),
+            headers = headers,
+            headerIndex = headerIndex,
+        )
+
+        record.getValue("score", 0) shouldBeEqualTo 95
+        record.getValue("label", "") shouldBeEqualTo "A"
+        record.getValue("nonexistent", -1) shouldBeEqualTo -1  // missing key → defaultValue
+    }
+
+    @Test
+    fun `getLongOrNull returns null on parse failure`() {
+        val record = makeRecord(arrayOf("12345", "nope", null))
+
+        record.getLongOrNull(0) shouldBeEqualTo 12345L
+        record.getLongOrNull(1).shouldBeNull()
+        record.getLongOrNull(2).shouldBeNull()
+    }
+}

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/internal/CsvLexerTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/internal/CsvLexerTest.kt
@@ -1,0 +1,327 @@
+package io.bluetape4k.csv.internal
+
+import io.bluetape4k.csv.CsvSettings
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class CsvLexerTest {
+
+    companion object : KLogging()
+
+    private fun lexerOf(
+        csv: String,
+        settings: CsvSettings = CsvSettings.DEFAULT,
+        skipHeaders: Boolean = false,
+    ): CsvLexer = CsvLexer(csv.reader(), settings, skipHeaders)
+
+    // ────────────────────────────────────────
+    // 기본 파싱
+    // ────────────────────────────────────────
+
+    @Test
+    fun `parse simple CSV row`() {
+        val lexer = lexerOf("a,b,c")
+        lexer.hasNext().shouldBeTrue()
+
+        val record = lexer.next()
+        record.getString(0) shouldBeEqualTo "a"
+        record.getString(1) shouldBeEqualTo "b"
+        record.getString(2) shouldBeEqualTo "c"
+        record.size shouldBeEqualTo 3
+    }
+
+    @Test
+    fun `parse multiple rows`() {
+        val lexer = lexerOf("a,b\nc,d")
+        val records = lexer.asSequence().toList()
+
+        records.size shouldBeEqualTo 2
+        records[0].getString(0) shouldBeEqualTo "a"
+        records[0].getString(1) shouldBeEqualTo "b"
+        records[1].getString(0) shouldBeEqualTo "c"
+        records[1].getString(1) shouldBeEqualTo "d"
+    }
+
+    @Test
+    fun `parse quoted field with comma`() {
+        // "a,b",c → ["a,b", "c"]
+        val lexer = lexerOf("\"a,b\",c")
+        val record = lexer.next()
+
+        record.getString(0) shouldBeEqualTo "a,b"
+        record.getString(1) shouldBeEqualTo "c"
+    }
+
+    @Test
+    fun `parse doubled-quote escape`() {
+        // "a""b" → [a"b]
+        val lexer = lexerOf("\"a\"\"b\"")
+        val record = lexer.next()
+
+        record.getString(0) shouldBeEqualTo "a\"b"
+    }
+
+    // ────────────────────────────────────────
+    // empty line 처리
+    // ────────────────────────────────────────
+
+    @Test
+    fun `physical empty line is skipped when skipEmptyLines=true`() {
+        // CsvSettings.DEFAULT: skipEmptyLines = true
+        val lexer = lexerOf("a,b\n\nc,d")
+        val records = lexer.asSequence().toList()
+
+        // 빈 줄은 건너뜀 → 2개 레코드
+        records.size shouldBeEqualTo 2
+        records[0].getString(0) shouldBeEqualTo "a"
+        records[1].getString(0) shouldBeEqualTo "c"
+    }
+
+    @Test
+    fun `physical empty line becomes single-null record when skipEmptyLines=false`() {
+        val settings = CsvSettings(skipEmptyLines = false)
+        val lexer = lexerOf("a,b\n\nc,d", settings)
+        val records = lexer.asSequence().toList()
+
+        records.size shouldBeEqualTo 3
+        // 두 번째 레코드는 물리적 빈 줄 → 단일 null 필드
+        records[1].size shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `comma-only line is NOT empty line`() {
+        // ",," → 3개 null 필드 레코드 (물리적 빈 줄이 아님)
+        // DEFAULT: emptyValueAsNull=true → null
+        val lexer = lexerOf(",,")
+        val record = lexer.next()
+
+        record.size shouldBeEqualTo 3
+        record.getString(0).shouldBeNull()
+        record.getString(1).shouldBeNull()
+        record.getString(2).shouldBeNull()
+    }
+
+    // ────────────────────────────────────────
+    // skipHeaders
+    // ────────────────────────────────────────
+
+    @Test
+    fun `skipHeaders stores first row as header metadata`() {
+        val lexer = lexerOf("name,age\nAlice,30", skipHeaders = true)
+
+        lexer.hasNext().shouldBeTrue()
+        val record = lexer.next()
+
+        record.getString("name") shouldBeEqualTo "Alice"
+        record.getString("age") shouldBeEqualTo "30"
+    }
+
+    @Test
+    fun `skipHeaders=false treats all rows as data`() {
+        val lexer = lexerOf("name,age\nAlice,30", skipHeaders = false)
+        val records = lexer.asSequence().toList()
+
+        records.size shouldBeEqualTo 2
+        records[0].getString(0) shouldBeEqualTo "name"
+        records[1].getString(0) shouldBeEqualTo "Alice"
+    }
+
+    @Test
+    fun `headerNames returns correct headers when skipHeaders=true`() {
+        val lexer = lexerOf("id,value\n1,hello", skipHeaders = true)
+        val names = lexer.headerNames()
+
+        names.shouldNotBeNull()
+        names[0] shouldBeEqualTo "id"
+        names[1] shouldBeEqualTo "value"
+    }
+
+    // ────────────────────────────────────────
+    // emptyValueAsNull / emptyQuotedAsNull
+    // ────────────────────────────────────────
+
+    @Test
+    fun `empty unquoted field returns null when emptyValueAsNull=true`() {
+        // DEFAULT: emptyValueAsNull=true
+        val lexer = lexerOf("a,,b")
+        val record = lexer.next()
+
+        record.getString(0) shouldBeEqualTo "a"
+        record.getString(1).shouldBeNull()
+        record.getString(2) shouldBeEqualTo "b"
+    }
+
+    @Test
+    fun `empty unquoted field returns empty string when emptyValueAsNull=false`() {
+        val settings = CsvSettings(emptyValueAsNull = false)
+        val lexer = lexerOf("a,,b", settings)
+        val record = lexer.next()
+
+        record.getString(1) shouldBeEqualTo ""
+    }
+
+    @Test
+    fun `quoted empty field returns empty string by default`() {
+        // emptyQuotedAsNull=false (기본값)
+        val lexer = lexerOf("a,\"\",b")
+        val record = lexer.next()
+
+        record.getString(1) shouldBeEqualTo ""
+    }
+
+    @Test
+    fun `quoted empty field returns null when emptyQuotedAsNull=true`() {
+        val settings = CsvSettings(emptyQuotedAsNull = true)
+        val lexer = lexerOf("a,\"\",b", settings)
+        val record = lexer.next()
+
+        record.getString(1).shouldBeNull()
+    }
+
+    // ────────────────────────────────────────
+    // CRLF / LF / CR 처리
+    // ────────────────────────────────────────
+
+    @Test
+    fun `CRLF line terminator`() {
+        val lexer = lexerOf("a,b\r\nc,d")
+        val records = lexer.asSequence().toList()
+
+        records.size shouldBeEqualTo 2
+        records[0].getString(0) shouldBeEqualTo "a"
+        records[1].getString(0) shouldBeEqualTo "c"
+    }
+
+    @Test
+    fun `LF line terminator`() {
+        val lexer = lexerOf("a,b\nc,d")
+        val records = lexer.asSequence().toList()
+
+        records.size shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `CR line terminator`() {
+        val lexer = lexerOf("a,b\rc,d")
+        val records = lexer.asSequence().toList()
+
+        records.size shouldBeEqualTo 2
+        records[0].getString(0) shouldBeEqualTo "a"
+        records[1].getString(0) shouldBeEqualTo "c"
+    }
+
+    @Test
+    fun `last row without trailing newline`() {
+        val lexer = lexerOf("x,y,z")
+        val records = lexer.asSequence().toList()
+
+        records.size shouldBeEqualTo 1
+        records[0].getString(2) shouldBeEqualTo "z"
+    }
+
+    // ────────────────────────────────────────
+    // BOM
+    // ────────────────────────────────────────
+
+    @Test
+    fun `BOM is stripped from beginning`() {
+        // "\uFEFFa,b" → ["a", "b"] (BOM 제거됨)
+        val withBom = "\uFEFFa,b"
+        val lexer = lexerOf(withBom)
+        val record = lexer.next()
+
+        // BOM이 제거되어야 하므로 첫 필드가 "a"
+        record.getString(0) shouldBeEqualTo "a"
+        record.getString(1) shouldBeEqualTo "b"
+    }
+
+    // ────────────────────────────────────────
+    // ParseException
+    // ────────────────────────────────────────
+
+    @Test
+    fun `maxCharsPerColumn exceeded throws ParseException`() {
+        val settings = CsvSettings(maxCharsPerColumn = 5)
+        assertThrows<ParseException> {
+            lexerOf("abcdefgh", settings).next()
+        }
+    }
+
+    @Test
+    fun `maxColumns exceeded throws ParseException`() {
+        val settings = CsvSettings(maxColumns = 2)
+        assertThrows<ParseException> {
+            lexerOf("a,b,c", settings).next()
+        }
+    }
+
+    // ────────────────────────────────────────
+    // trimValues
+    // ────────────────────────────────────────
+
+    @Test
+    fun `trimValues removes leading and trailing whitespace`() {
+        val settings = CsvSettings(trimValues = true)
+        val lexer = lexerOf(" a , b ", settings)
+        val record = lexer.next()
+
+        record.getString(0) shouldBeEqualTo "a"
+        record.getString(1) shouldBeEqualTo "b"
+    }
+
+    @Test
+    fun `trimValues does not affect quoted fields`() {
+        val settings = CsvSettings(trimValues = true)
+        // 인용 필드는 trimValues 영향을 받지 않아야 함
+        val lexer = lexerOf("\" a \",b", settings)
+        val record = lexer.next()
+
+        record.getString(0) shouldBeEqualTo " a "
+    }
+
+    // ────────────────────────────────────────
+    // hasNext / next 계약
+    // ────────────────────────────────────────
+
+    @Test
+    fun `empty input returns no records`() {
+        val lexer = lexerOf("")
+        lexer.hasNext().shouldBeFalse()
+    }
+
+    @Test
+    fun `hasNext is idempotent`() {
+        val lexer = lexerOf("a,b")
+        lexer.hasNext().shouldBeTrue()
+        lexer.hasNext().shouldBeTrue()  // 두 번 호출해도 동일 결과
+        lexer.next()  // 소비
+        lexer.hasNext().shouldBeFalse()
+    }
+
+    @Test
+    fun `rowNumber increments correctly`() {
+        val lexer = lexerOf("a\nb\nc")
+        val records = lexer.asSequence().toList()
+
+        records[0].rowNumber shouldBeEqualTo 1L
+        records[1].rowNumber shouldBeEqualTo 2L
+        records[2].rowNumber shouldBeEqualTo 3L
+    }
+
+    @Test
+    fun `quoted field with newline embedded is single record`() {
+        // RFC 4180: 인용 필드 안에 개행이 있어도 하나의 레코드
+        val lexer = lexerOf("\"line1\nline2\",end")
+        val record = lexer.next()
+
+        record.getString(0) shouldBeEqualTo "line1\nline2"
+        record.getString(1) shouldBeEqualTo "end"
+    }
+}

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/internal/DelimitedWriterTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/internal/DelimitedWriterTest.kt
@@ -1,0 +1,179 @@
+package io.bluetape4k.csv.internal
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import java.io.StringWriter
+
+class DelimitedWriterTest {
+
+    companion object : KLogging()
+
+    private fun writerOf(lineSep: String = "\r\n"): Pair<StringWriter, DelimitedWriter> {
+        val sw = StringWriter()
+        val dw = DelimitedWriter(
+            writer = sw,
+            delimiter = ',',
+            quote = '"',
+            quoteEscape = '"',
+            lineSeparator = lineSep,
+        )
+        return sw to dw
+    }
+
+    @Test
+    fun `writeRow writes simple fields`() {
+        val (sw, dw) = writerOf()
+        dw.writeRow(listOf("a", "b", "c"))
+        dw.close()
+
+        sw.toString() shouldBeEqualTo "a,b,c\r\n"
+    }
+
+    @Test
+    fun `null field produces empty unquoted field`() {
+        val (sw, dw) = writerOf()
+        dw.writeRow(listOf("a", null, "b"))
+        dw.close()
+
+        sw.toString() shouldBeEqualTo "a,,b\r\n"
+    }
+
+    @Test
+    fun `empty string produces quoted empty field`() {
+        val (sw, dw) = writerOf()
+        dw.writeRow(listOf("a", "", "b"))
+        dw.close()
+
+        // 빈 문자열은 "" 인용 출력 (roundtrip 보장)
+        sw.toString() shouldBeEqualTo "a,\"\",b\r\n"
+    }
+
+    @Test
+    fun `field with delimiter gets quoted`() {
+        val (sw, dw) = writerOf()
+        dw.writeRow(listOf("a", "b,c", "d"))
+        dw.close()
+
+        sw.toString() shouldBeEqualTo "a,\"b,c\",d\r\n"
+    }
+
+    @Test
+    fun `field with quote char gets doubled`() {
+        val (sw, dw) = writerOf()
+        // a"b → RFC 4180: "a""b"
+        dw.writeRow(listOf("a\"b"))
+        dw.close()
+
+        sw.toString() shouldBeEqualTo "\"a\"\"b\"\r\n"
+    }
+
+    @Test
+    fun `field with newline gets quoted`() {
+        val (sw, dw) = writerOf()
+        dw.writeRow(listOf("line1\nline2"))
+        dw.close()
+
+        sw.toString() shouldBeEqualTo "\"line1\nline2\"\r\n"
+    }
+
+    @Test
+    fun `field with CR gets quoted`() {
+        val (sw, dw) = writerOf()
+        dw.writeRow(listOf("a\rb"))
+        dw.close()
+
+        sw.toString() shouldBeEqualTo "\"a\rb\"\r\n"
+    }
+
+    @Test
+    fun `leading space triggers quoting`() {
+        val (sw, dw) = writerOf()
+        dw.writeRow(listOf(" leading"))
+        dw.close()
+
+        sw.toString() shouldBeEqualTo "\" leading\"\r\n"
+    }
+
+    @Test
+    fun `trailing space triggers quoting`() {
+        val (sw, dw) = writerOf()
+        dw.writeRow(listOf("trailing "))
+        dw.close()
+
+        sw.toString() shouldBeEqualTo "\"trailing \"\r\n"
+    }
+
+    @Test
+    fun `needsQuoting returns false for plain field`() {
+        val (_, dw) = writerOf()
+        dw.needsQuoting("hello").shouldBeFalse()
+        dw.needsQuoting("123").shouldBeFalse()
+        dw.close()
+    }
+
+    @Test
+    fun `needsQuoting returns true for field with delimiter`() {
+        val (_, dw) = writerOf()
+        dw.needsQuoting("a,b").shouldBeTrue()
+        dw.close()
+    }
+
+    @Test
+    fun `needsQuoting returns true for field with quote char`() {
+        val (_, dw) = writerOf()
+        dw.needsQuoting("a\"b").shouldBeTrue()
+        dw.close()
+    }
+
+    @Test
+    fun `needsQuoting returns false for empty string`() {
+        val (_, dw) = writerOf()
+        // needsQuoting("") == false (호출자가 별도 처리)
+        dw.needsQuoting("").shouldBeFalse()
+        dw.close()
+    }
+
+    @Test
+    fun `close flushes and closes writer`() {
+        val (sw, dw) = writerOf()
+        dw.writeRow(listOf("x"))
+        dw.close()
+        // close 후에도 StringWriter 내용 접근 가능
+        sw.toString() shouldBeEqualTo "x\r\n"
+    }
+
+    @Test
+    fun `null vs empty string roundtrip`() {
+        // null → write → 비인용 빈 필드
+        // "" → write → "" 인용 출력
+        val (sw, dw) = writerOf()
+        dw.writeRow(listOf(null, ""))
+        dw.close()
+
+        val result = sw.toString()
+        // null이 먼저, "" 가 두 번째
+        result shouldBeEqualTo ",\"\"\r\n"
+    }
+
+    @Test
+    fun `multiple rows each terminated by lineSeparator`() {
+        val (sw, dw) = writerOf("\n")
+        dw.writeRow(listOf("r1c1", "r1c2"))
+        dw.writeRow(listOf("r2c1", "r2c2"))
+        dw.close()
+
+        sw.toString() shouldBeEqualTo "r1c1,r1c2\nr2c1,r2c2\n"
+    }
+
+    @Test
+    fun `non-string field uses toString`() {
+        val (sw, dw) = writerOf()
+        dw.writeRow(listOf(42, 3.14, true))
+        dw.close()
+
+        sw.toString() shouldBeEqualTo "42,3.14,true\r\n"
+    }
+}

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/internal/HeaderIndexTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/internal/HeaderIndexTest.kt
@@ -1,0 +1,97 @@
+package io.bluetape4k.csv.internal
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+
+class HeaderIndexTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `of() creates index from array`() {
+        val headers = arrayOf("id", "name", "age")
+        val index = HeaderIndex.of(headers)
+
+        index.indexOf("id") shouldBeEqualTo 0
+        index.indexOf("name") shouldBeEqualTo 1
+        index.indexOf("age") shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `first-wins on duplicate headers`() {
+        val headers = arrayOf("id", "name", "id", "extra")
+        val index = HeaderIndex.of(headers)
+
+        // 첫 번째 "id" 인덱스(0)가 유지되어야 함
+        index.indexOf("id") shouldBeEqualTo 0
+        index.indexOf("name") shouldBeEqualTo 1
+        index.indexOf("extra") shouldBeEqualTo 3
+        index.size shouldBeEqualTo 3  // "id" 중복이므로 3개
+    }
+
+    @Test
+    fun `indexOf returns null for unknown name`() {
+        val headers = arrayOf("id", "name")
+        val index = HeaderIndex.of(headers)
+
+        index.indexOf("unknown").shouldBeNull()
+        index.indexOf("ID").shouldBeNull()  // case-sensitive
+        index.indexOf("").shouldBeNull()
+    }
+
+    @Test
+    fun `nameOf returns header name by index`() {
+        val headers = arrayOf("id", "name", "age")
+        val index = HeaderIndex.of(headers)
+
+        index.nameOf(0) shouldBeEqualTo "id"
+        index.nameOf(1) shouldBeEqualTo "name"
+        index.nameOf(2) shouldBeEqualTo "age"
+    }
+
+    @Test
+    fun `nameOf returns null for out of range index`() {
+        val headers = arrayOf("id", "name")
+        val index = HeaderIndex.of(headers)
+
+        index.nameOf(99).shouldBeNull()
+        index.nameOf(-1).shouldBeNull()
+    }
+
+    @Test
+    fun `names returns all header names in order`() {
+        val headers = arrayOf("c", "a", "b")
+        val index = HeaderIndex.of(headers)
+
+        index.names shouldBeEqualTo listOf("c", "a", "b")
+    }
+
+    @Test
+    fun `size returns correct count`() {
+        val index = HeaderIndex.of(arrayOf("x", "y", "z"))
+        index.size shouldBeEqualTo 3
+    }
+
+    @Test
+    fun `size of empty array returns zero`() {
+        val index = HeaderIndex.of(emptyArray())
+        index.size shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `case-sensitive lookup`() {
+        val headers = arrayOf("Name", "name", "NAME")
+        val index = HeaderIndex.of(headers)
+
+        // "Name" wins at 0, "name" and "NAME" are duplicates (dropped)
+        index.indexOf("Name").shouldNotBeNull()
+        index.indexOf("Name") shouldBeEqualTo 0
+        // "name" 은 "Name"과 다른 키 → 인덱스 1
+        index.indexOf("name") shouldBeEqualTo 1
+        // "NAME" 은 "Name", "name"과 모두 다른 키 → 인덱스 2
+        index.indexOf("NAME") shouldBeEqualTo 2
+    }
+}

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/internal/TsvLexerTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/internal/TsvLexerTest.kt
@@ -1,0 +1,273 @@
+package io.bluetape4k.csv.internal
+
+import io.bluetape4k.csv.TsvSettings
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.utils.Resourcex
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeEmpty
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+
+class TsvLexerTest {
+
+    companion object : KLogging()
+
+    private fun lexerOf(
+        tsv: String,
+        settings: TsvSettings = TsvSettings.DEFAULT,
+        skipHeaders: Boolean = false,
+    ): TsvLexer = TsvLexer(tsv.reader(), settings, skipHeaders)
+
+    // ────────────────────────────────────────
+    // 기본 파싱
+    // ────────────────────────────────────────
+
+    @Test
+    fun `parse simple TSV row`() {
+        val lexer = lexerOf("a\tb\tc")
+        lexer.hasNext().shouldBeTrue()
+
+        val record = lexer.next()
+        record.getString(0) shouldBeEqualTo "a"
+        record.getString(1) shouldBeEqualTo "b"
+        record.getString(2) shouldBeEqualTo "c"
+        record.size shouldBeEqualTo 3
+    }
+
+    @Test
+    fun `parse multiple TSV rows`() {
+        val lexer = lexerOf("a\tb\nc\td")
+        val records = lexer.asSequence().toList()
+
+        records.size shouldBeEqualTo 2
+        records[0].getString(0) shouldBeEqualTo "a"
+        records[0].getString(1) shouldBeEqualTo "b"
+        records[1].getString(0) shouldBeEqualTo "c"
+        records[1].getString(1) shouldBeEqualTo "d"
+    }
+
+    // ────────────────────────────────────────
+    // 백슬래시 이스케이프
+    // ────────────────────────────────────────
+
+    @Test
+    fun `backslash-t is unescaped to tab`() {
+        // "a\tb" where \t is the literal escape sequence → field contains tab
+        val lexer = lexerOf("a\\tb")
+        val record = lexer.next()
+
+        record.getString(0) shouldBeEqualTo "a\tb"
+    }
+
+    @Test
+    fun `backslash-n is unescaped to newline`() {
+        val lexer = lexerOf("a\\nb")
+        val record = lexer.next()
+
+        record.getString(0) shouldBeEqualTo "a\nb"
+    }
+
+    @Test
+    fun `backslash-r is unescaped to CR`() {
+        val lexer = lexerOf("a\\rb")
+        val record = lexer.next()
+
+        record.getString(0) shouldBeEqualTo "a\rb"
+    }
+
+    @Test
+    fun `backslash-backslash is unescaped to single backslash`() {
+        val lexer = lexerOf("a\\\\b")
+        val record = lexer.next()
+
+        record.getString(0) shouldBeEqualTo "a\\b"
+    }
+
+    @Test
+    fun `unknown escape is kept literally`() {
+        // "\\x" → "\\x" (관대한 처리)
+        val lexer = lexerOf("\\x")
+        val record = lexer.next()
+
+        record.getString(0) shouldBeEqualTo "\\x"
+    }
+
+    // ────────────────────────────────────────
+    // null 처리
+    // ────────────────────────────────────────
+
+    @Test
+    fun `empty field returns null when emptyValueAsNull=true`() {
+        // DEFAULT: emptyValueAsNull=true
+        val lexer = lexerOf("a\t\tb")
+        val record = lexer.next()
+
+        record.getString(0) shouldBeEqualTo "a"
+        record.getString(1).shouldBeNull()
+        record.getString(2) shouldBeEqualTo "b"
+    }
+
+    @Test
+    fun `empty field returns empty string when emptyValueAsNull=false`() {
+        val settings = TsvSettings(emptyValueAsNull = false)
+        val lexer = lexerOf("a\t\tb", settings)
+        val record = lexer.next()
+
+        record.getString(1) shouldBeEqualTo ""
+    }
+
+    // ────────────────────────────────────────
+    // skipHeaders
+    // ────────────────────────────────────────
+
+    @Test
+    fun `skipHeaders stores first row as header`() {
+        val lexer = lexerOf("name\tage\nAlice\t30", skipHeaders = true)
+
+        lexer.hasNext().shouldBeTrue()
+        val record = lexer.next()
+
+        record.getString("name") shouldBeEqualTo "Alice"
+        record.getString("age") shouldBeEqualTo "30"
+    }
+
+    @Test
+    fun `skipHeaders=false treats all rows as data`() {
+        val lexer = lexerOf("name\tage\nAlice\t30", skipHeaders = false)
+        val records = lexer.asSequence().toList()
+
+        records.size shouldBeEqualTo 2
+        records[0].getString(0) shouldBeEqualTo "name"
+    }
+
+    // ────────────────────────────────────────
+    // CRLF / LF / CR
+    // ────────────────────────────────────────
+
+    @Test
+    fun `LF line terminator`() {
+        val lexer = lexerOf("a\tb\nc\td")
+        val records = lexer.asSequence().toList()
+
+        records.size shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `CRLF line terminator`() {
+        val lexer = lexerOf("a\tb\r\nc\td")
+        val records = lexer.asSequence().toList()
+
+        records.size shouldBeEqualTo 2
+        records[0].getString(0) shouldBeEqualTo "a"
+        records[1].getString(0) shouldBeEqualTo "c"
+    }
+
+    @Test
+    fun `CR line terminator`() {
+        val lexer = lexerOf("a\tb\rc\td")
+        val records = lexer.asSequence().toList()
+
+        records.size shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `last row without trailing newline`() {
+        val lexer = lexerOf("x\ty\tz")
+        val records = lexer.asSequence().toList()
+
+        records.size shouldBeEqualTo 1
+        records[0].getString(2) shouldBeEqualTo "z"
+    }
+
+    // ────────────────────────────────────────
+    // hasNext
+    // ────────────────────────────────────────
+
+    @Test
+    fun `empty TSV returns no records`() {
+        val lexer = lexerOf("")
+        lexer.hasNext().shouldBeFalse()
+    }
+
+    @Test
+    fun `hasNext is idempotent`() {
+        val lexer = lexerOf("a\tb")
+        lexer.hasNext().shouldBeTrue()
+        lexer.hasNext().shouldBeTrue()
+        lexer.next()
+        lexer.hasNext().shouldBeFalse()
+    }
+
+    // ────────────────────────────────────────
+    // trimValues
+    // ────────────────────────────────────────
+
+    @Test
+    fun `trimValues removes leading and trailing whitespace`() {
+        val settings = TsvSettings(trimValues = true)
+        val lexer = lexerOf(" a \t b ", settings)
+        val record = lexer.next()
+
+        record.getString(0) shouldBeEqualTo "a"
+        record.getString(1) shouldBeEqualTo "b"
+    }
+
+    // ────────────────────────────────────────
+    // rowNumber
+    // ────────────────────────────────────────
+
+    @Test
+    fun `rowNumber increments correctly`() {
+        val lexer = lexerOf("a\nb\nc")
+        val records = lexer.asSequence().toList()
+
+        records[0].rowNumber shouldBeEqualTo 1L
+        records[1].rowNumber shouldBeEqualTo 2L
+        records[2].rowNumber shouldBeEqualTo 3L
+    }
+
+    // ────────────────────────────────────────
+    // PR 1 게이트: 기존 TsvRecordReader와 동일 입력 대조
+    // ────────────────────────────────────────
+
+    /**
+     * PR 1 gate test — product_type.tsv 파일을 TsvLexer로 파싱하여
+     * 첫 레코드 필드 수 >= 4 임을 확인한다.
+     *
+     * 이 테스트가 실패하면 TsvLexer 동작이 univocity와 다른 것이므로 PR 1 머지 불가.
+     */
+    @Test
+    fun `first record fields match existing TsvRecordReader output`() {
+        Resourcex.getInputStream("csv/product_type.tsv").shouldNotBeNull()
+        Resourcex.getInputStream("csv/product_type.tsv")!!.bufferedReader(Charsets.UTF_8).use { reader ->
+            // skipHeaders=true: 첫 행이 헤더
+            val lexer = TsvLexer(reader, TsvSettings.DEFAULT, skipHeaders = true)
+
+            lexer.hasNext().shouldBeTrue()
+            val first = lexer.next()
+
+            first.size shouldBeGreaterThan 3  // product_type.tsv는 7컬럼
+            // 첫 번째 필드(tagFamilyValue)는 비어 있지 않아야 함
+            first.getString(0).shouldNotBeNull()
+            first.getString(0)!!.shouldNotBeEmpty()
+        }
+    }
+
+    @Test
+    fun `all records in product_type_tsv have at least 4 fields`() {
+        Resourcex.getInputStream("csv/product_type.tsv").shouldNotBeNull()
+        Resourcex.getInputStream("csv/product_type.tsv")!!.bufferedReader(Charsets.UTF_8).use { reader ->
+            val lexer = TsvLexer(reader, TsvSettings.DEFAULT, skipHeaders = true)
+            var count = 0
+            for (record in lexer) {
+                record.size shouldBeGreaterThan 3
+                count++
+            }
+            count shouldBeGreaterThan 0
+        }
+    }
+}

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/internal/TsvLexerTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/internal/TsvLexerTest.kt
@@ -238,7 +238,7 @@ class TsvLexerTest {
      * PR 1 gate test — product_type.tsv 파일을 TsvLexer로 파싱하여
      * 첫 레코드 필드 수 >= 4 임을 확인한다.
      *
-     * 이 테스트가 실패하면 TsvLexer 동작이 univocity와 다른 것이므로 PR 1 머지 불가.
+     * 이 테스트가 실패하면 TsvLexer 기본 동작이 깨진 것입니다.
      */
     @Test
     fun `first record fields match existing TsvRecordReader output`() {

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/v2/CsvRowTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/v2/CsvRowTest.kt
@@ -1,0 +1,100 @@
+package io.bluetape4k.csv.v2
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+
+class CsvRowTest {
+
+    companion object : KLogging()
+
+    private fun row(
+        vararg values: String?,
+        headers: List<String>? = null,
+        rowNumber: Long = 1L,
+    ) = CsvRow(values.toList(), headers, rowNumber)
+
+    @Test
+    fun `getString by index`() {
+        val r = row("Alice", "30", null)
+        r.getString(0) shouldBeEqualTo "Alice"
+        r.getString(1) shouldBeEqualTo "30"
+        r.getString(2).shouldBeNull()
+        r.getString(99).shouldBeNull()
+    }
+
+    @Test
+    fun `getString by name`() {
+        val r = row("Alice", "30", headers = listOf("name", "age"))
+        r.getString("name") shouldBeEqualTo "Alice"
+        r.getString("age") shouldBeEqualTo "30"
+        r.getString("unknown").shouldBeNull()
+    }
+
+    @Test
+    fun `getInt and getLong`() {
+        val r = row("42", "1000000000000")
+        r.getIntOrNull(0) shouldBeEqualTo 42
+        r.getLongOrNull(1) shouldBeEqualTo 1_000_000_000_000L
+        r.getInt(0) shouldBeEqualTo 42
+        r.getLong(1) shouldBeEqualTo 1_000_000_000_000L
+    }
+
+    @Test
+    fun `getDouble and getFloat`() {
+        val r = row("3.14", "2.72")
+        r.getDoubleOrNull(0) shouldBeEqualTo 3.14
+        r.getFloatOrNull(1)!!.toDouble() shouldBeEqualTo 2.72f.toDouble()
+    }
+
+    @Test
+    fun `getBoolean`() {
+        val r = row("true", "false", "TRUE")
+        r.getBoolean(0) shouldBeEqualTo true
+        r.getBoolean(1) shouldBeEqualTo false
+        r.getBoolean(2) shouldBeEqualTo true
+    }
+
+    @Test
+    fun `null field returns null`() {
+        val r = row(null, "value")
+        r.getString(0).shouldBeNull()
+        r.getIntOrNull(0).shouldBeNull()
+    }
+
+    @Test
+    fun `size`() {
+        val r = row("a", "b", "c")
+        r.size shouldBeEqualTo 3
+    }
+
+    @Test
+    fun `rowNumber`() {
+        val r = row("x", rowNumber = 7L)
+        r.rowNumber shouldBeEqualTo 7L
+    }
+
+    @Test
+    fun `data class copy`() {
+        val r = row("Alice", "30")
+        val copied = r.copy(rowNumber = 99L)
+        copied.rowNumber shouldBeEqualTo 99L
+        copied.values shouldBeEqualTo r.values
+    }
+
+    @Test
+    fun `headers null when skipHeaders=false`() {
+        val r = row("Alice", "30", headers = null)
+        r.headers.shouldBeNull()
+        r.getString("name").shouldBeNull()
+    }
+
+    @Test
+    fun `getBigDecimalOrNull`() {
+        val r = row("123456789.99")
+        r.getBigDecimalOrNull(0).shouldNotBeNull()
+        r.getBigDecimalOrNull(0)!!.toPlainString() shouldBeEqualTo "123456789.99"
+    }
+}

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/v2/FlowCsvReaderTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/v2/FlowCsvReaderTest.kt
@@ -1,0 +1,154 @@
+package io.bluetape4k.csv.v2
+
+import io.bluetape4k.logging.KLogging
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldHaveSize
+import org.amshove.kluent.shouldNotBeEmpty
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+class FlowCsvReaderTest {
+
+    companion object : KLogging()
+
+    private fun streamOf(csv: String) = ByteArrayInputStream(csv.toByteArray(Charsets.UTF_8))
+
+    // ── DSL builder ──────────────────────────────────────
+
+    @Test
+    fun `csvReader default settings`() = runTest {
+        val reader = csvReader()
+        reader.config.delimiter shouldBeEqualTo ','
+        reader.config.quote shouldBeEqualTo '"'
+    }
+
+    @Test
+    fun `tsvReader forces tab delimiter`() = runTest {
+        val reader = tsvReader()
+        reader.config.delimiter shouldBeEqualTo '\t'
+    }
+
+    @Test
+    fun `tsvReader block cannot override delimiter`() = runTest {
+        val reader = tsvReader { delimiter = ',' }
+        reader.config.delimiter shouldBeEqualTo '\t'
+    }
+
+    @Test
+    fun `csvReader custom delimiter`() = runTest {
+        val reader = csvReader { delimiter = ';' }
+        reader.config.delimiter shouldBeEqualTo ';'
+    }
+
+    // ── basic reading ────────────────────────────────────
+
+    @Test
+    fun `read simple CSV`() = runTest {
+        val reader = csvReader()
+        val rows = reader.read(streamOf("Alice,30\nBob,25")).toList()
+
+        rows shouldHaveSize 2
+        rows[0].getString(0) shouldBeEqualTo "Alice"
+        rows[0].getString(1) shouldBeEqualTo "30"
+        rows[1].getString(0) shouldBeEqualTo "Bob"
+    }
+
+    @Test
+    fun `read CSV with headers`() = runTest {
+        val reader = csvReader()
+        val rows = reader.read(streamOf("name,age\nAlice,30\nBob,25"), skipHeaders = true).toList()
+
+        rows shouldHaveSize 2
+        rows[0].getString("name") shouldBeEqualTo "Alice"
+        rows[0].getString("age") shouldBeEqualTo "30"
+        rows[0].headers.shouldNotBeNull()
+        rows[1].getString("name") shouldBeEqualTo "Bob"
+    }
+
+    @Test
+    fun `read TSV with tsvReader`() = runTest {
+        val reader = tsvReader()
+        val rows = reader.read(streamOf("a\tb\tc\n1\t2\t3"), skipHeaders = true).toList()
+
+        rows shouldHaveSize 1
+        rows[0].getString("a") shouldBeEqualTo "1"
+        rows[0].getString("b") shouldBeEqualTo "2"
+    }
+
+    @Test
+    fun `read empty input returns empty flow`() = runTest {
+        val rows = csvReader().read(streamOf("")).toList()
+        rows shouldHaveSize 0
+    }
+
+    @Test
+    fun `null field when emptyValueAsNull=true`() = runTest {
+        val rows = csvReader().read(streamOf("a,,c")).toList()
+        rows[0].getString(0) shouldBeEqualTo "a"
+        rows[0].getString(1).shouldBeNull()
+        rows[0].getString(2) shouldBeEqualTo "c"
+    }
+
+    @Test
+    fun `empty string field when emptyValueAsNull=false`() = runTest {
+        val reader = csvReader { emptyValueAsNull = false }
+        val rows = reader.read(streamOf("a,,c")).toList()
+        rows[0].getString(1) shouldBeEqualTo ""
+    }
+
+    @Test
+    fun `quoted field with comma`() = runTest {
+        val rows = csvReader().read(streamOf(""""hello, world",42""")).toList()
+        rows[0].getString(0) shouldBeEqualTo "hello, world"
+        rows[0].getString(1) shouldBeEqualTo "42"
+    }
+
+    @Test
+    fun `trimValues removes whitespace`() = runTest {
+        val reader = csvReader { trimValues = true }
+        val rows = reader.read(streamOf(" Alice , 30 ")).toList()
+        rows[0].getString(0) shouldBeEqualTo "Alice"
+        rows[0].getString(1) shouldBeEqualTo "30"
+    }
+
+    @Test
+    fun `rowNumber increments correctly`() = runTest {
+        val rows = csvReader().read(streamOf("a\nb\nc")).toList()
+        rows[0].rowNumber shouldBeEqualTo 1L
+        rows[1].rowNumber shouldBeEqualTo 2L
+        rows[2].rowNumber shouldBeEqualTo 3L
+    }
+
+    // ── Record.toCsvRow() roundtrip ──────────────────────
+
+    @Test
+    fun `Record toCsvRow roundtrip`() = runTest {
+        val rows = csvReader().read(streamOf("name,age\nAlice,30"), skipHeaders = true).toList()
+        val row = rows[0]
+        val record = row.toRecord()
+
+        record.getString("name") shouldBeEqualTo "Alice"
+        record.getString("age") shouldBeEqualTo "30"
+
+        val backToRow = record.toCsvRow()
+        backToRow.getString("name") shouldBeEqualTo "Alice"
+        backToRow.headers.shouldNotBeNull()
+        backToRow.headers!! shouldHaveSize 2
+    }
+
+    // ── BOM handling ─────────────────────────────────────
+
+    @Test
+    fun `BOM is stripped when detectBom=true`() = runTest {
+        val bom = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
+        val data = bom + "Alice,30".toByteArray(Charsets.UTF_8)
+        val rows = csvReader { detectBom = true }.read(ByteArrayInputStream(data)).toList()
+
+        rows.shouldNotBeEmpty()
+        rows[0].getString(0) shouldBeEqualTo "Alice"
+    }
+}

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/v2/FlowCsvWriterTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/v2/FlowCsvWriterTest.kt
@@ -1,0 +1,155 @@
+package io.bluetape4k.csv.v2
+
+import io.bluetape4k.logging.KLogging
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContain
+import org.junit.jupiter.api.Test
+import java.io.StringWriter
+
+class FlowCsvWriterTest {
+
+    companion object : KLogging()
+
+    private fun writerOf(block: CsvWriterConfig.() -> Unit = {}): Pair<StringWriter, FlowCsvWriter> {
+        val sw = StringWriter()
+        return sw to csvWriter(sw, block)
+    }
+
+    private fun tsvWriterOf(block: CsvWriterConfig.() -> Unit = {}): Pair<StringWriter, FlowCsvWriter> {
+        val sw = StringWriter()
+        return sw to tsvWriter(sw, block)
+    }
+
+    // ── basic write ──────────────────────────────────────
+
+    @Test
+    fun `writeRow produces CSV line`() = runTest {
+        val (sw, writer) = writerOf()
+        writer.writeRow(listOf("Alice", "30"))
+        writer.close()
+
+        sw.toString() shouldBeEqualTo "Alice,30\r\n"
+    }
+
+    @Test
+    fun `writeHeaders and writeRow`() = runTest {
+        val (sw, writer) = writerOf()
+        writer.writeHeaders(listOf("name", "age"))
+        writer.writeRow(listOf("Alice", 30))
+        writer.close()
+
+        val lines = sw.toString().split("\r\n").filter { it.isNotEmpty() }
+        lines[0] shouldBeEqualTo "name,age"
+        lines[1] shouldBeEqualTo "Alice,30"
+    }
+
+    @Test
+    fun `null field is written as empty unquoted`() = runTest {
+        val (sw, writer) = writerOf()
+        writer.writeRow(listOf("a", null, "c"))
+        writer.close()
+
+        sw.toString() shouldBeEqualTo "a,,c\r\n"
+    }
+
+    @Test
+    fun `empty string field is written as quoted empty`() = runTest {
+        val (sw, writer) = writerOf()
+        writer.writeRow(listOf("a", "", "c"))
+        writer.close()
+
+        sw.toString() shouldBeEqualTo """a,"",c""" + "\r\n"
+    }
+
+    @Test
+    fun `field with comma is quoted`() = runTest {
+        val (sw, writer) = writerOf()
+        writer.writeRow(listOf("hello, world", "42"))
+        writer.close()
+
+        sw.toString() shouldBeEqualTo """"hello, world",42""" + "\r\n"
+    }
+
+    @Test
+    fun `field with quote char is double-quoted`() = runTest {
+        val (sw, writer) = writerOf()
+        writer.writeRow(listOf("say \"hi\""))
+        writer.close()
+
+        // say "hi" → "say ""hi"""  (RFC 4180 doubled-quote + surrounding quotes)
+        sw.toString() shouldBeEqualTo "\"say \"\"hi\"\"\"\r\n"
+    }
+
+    // ── TSV writer ───────────────────────────────────────
+
+    @Test
+    fun `tsvWriter uses tab delimiter`() = runTest {
+        val (sw, writer) = tsvWriterOf()
+        writer.writeRow(listOf("a", "b", "c"))
+        writer.close()
+
+        sw.toString() shouldBeEqualTo "a\tb\tc\n"
+    }
+
+    @Test
+    fun `tsvWriter delimiter cannot be overridden to comma`() = runTest {
+        val (sw, writer) = tsvWriterOf { delimiter = ',' }
+        writer.writeRow(listOf("x", "y"))
+        writer.close()
+
+        sw.toString() shouldBeEqualTo "x\ty\n"
+    }
+
+    // ── quoteAll ─────────────────────────────────────────
+
+    @Test
+    fun `quoteAll wraps all non-null fields`() = runTest {
+        val (sw, writer) = writerOf { quoteAll = true }
+        writer.writeRow(listOf("Alice", "30", null))
+        writer.close()
+
+        sw.toString() shouldBeEqualTo """"Alice","30",""" + "\r\n"
+    }
+
+    @Test
+    fun `quoteAll with embedded quote uses doubled-quote`() = runTest {
+        val (sw, writer) = writerOf { quoteAll = true }
+        writer.writeRow(listOf("say \"hi\""))
+        writer.close()
+
+        // say "hi" → "say ""hi"""  (RFC 4180 doubled-quote + surrounding quotes)
+        sw.toString() shouldBeEqualTo "\"say \"\"hi\"\"\"\r\n"
+    }
+
+    // ── writeAll (Flow) ──────────────────────────────────
+
+    @Test
+    fun `writeAll collects flow rows`() = runTest {
+        val (sw, writer) = writerOf()
+        writer.writeAll(
+            flowOf(
+                listOf("Alice", 30),
+                listOf("Bob", 25),
+            )
+        )
+        writer.close()
+
+        val output = sw.toString()
+        output shouldContain "Alice,30"
+        output shouldContain "Bob,25"
+    }
+
+    // ── custom delimiter ─────────────────────────────────
+
+    @Test
+    fun `semicolon delimiter`() = runTest {
+        val sw = StringWriter()
+        val writer = csvWriter(sw) { delimiter = ';' }
+        writer.writeRow(listOf("a", "b", "c"))
+        writer.close()
+
+        sw.toString() shouldBeEqualTo "a;b;c\r\n"
+    }
+}


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: feat(csv): bluetape4k-csv — univocity-parsers 제거, 자체 RFC 4180 엔진으로 교체 + V2 Flow DSL API

`bluetape4k-csv` 내부 파서/라이터 엔진을 univocity-parsers에서 자체 구현 RFC 4180 상태 기계로 교체합니다.
기존 V1 공개 API는 유지하며, 새로운 V2 Flow DSL API를 추가합니다.

**마이그레이션 가이드**: [`io/csv/MIGRATION.md`](io/csv/MIGRATION.md)

---

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 커밋 구조 (7 commits)

| PR | 내용 |
|----|------|
| PR1 | `CsvLexer`/`TsvLexer` RFC 4180 상태 기계 + `CsvSettings`/`TsvSettings` + benchmark infra |
| PR2 | `Record` 공개 인터페이스 + `CsvRecordReader`/`TsvRecordReader` 자체 엔진 교체 |
| PR3 | `CsvRecordWriter`/`TsvRecordWriter` 자체 엔진(`CsvLineWriter`/`TsvLineWriter`) 교체 |
| PR4 | `SuspendReader` → `channelFlow + ensureActive`, `SuspendWriter` → `Mutex` 동시성 보호 |
| PR5 | univocity 의존성 완전 제거 + `MIGRATION.md` 작성 |
| PR6 | V2 Flow DSL API (`CsvRow`, `FlowCsvReader`, `FlowCsvWriter`, `CsvExtensions`) |

---

### 기존 섹션: 주요 변경사항

### 엔진 교체 (V1 API 유지)

- **`CsvLexer`** / **`TsvLexer`**: RFC 4180 문자 단위 상태 기계. BOM 감지/제거, CRLF/LF/CR 지원, doubled-quote 이스케이프, `trimValues`, `emptyValueAsNull`
- **`DelimitedWriter`** → **`CsvLineWriter`** / **`TsvLineWriter`**: `null` → 인용 없는 빈 필드, `""` → `""` 인용 출력 (RFC 4180 roundtrip 보장)
- **`Record`** 공개 인터페이스 (`io.bluetape4k.csv.Record`): `getString`, `getValue\<T\>`, `getIntOrNull`, `getLongOrNull`, `getDoubleOrNull`, `getBigDecimalOrNull`, `rowNumber`, `size`, `values`, `headers`
- **`CsvSettings`** / **`TsvSettings`**: univocity `CsvParserSettings`/`CsvWriterSettings` 대체, 불변 data class

### Coroutines 개선

- `SuspendCsvRecordReader` / `SuspendTsvRecordReader`: `flow {}` → `channelFlow { ensureActive() }` + `flowOn(Dispatchers.IO)` — 코루틴 취소 협력
- `SuspendCsvRecordWriter` / `SuspendTsvRecordWriter`: `Mutex.withLock {}` — 동시 쓰기 안전 보장

### 의존성 제거

```kotlin
// 제거됨
api("com.univocity:univocity-parsers:2.9.1")
```

### V2 Flow DSL API (신규)

```kotlin
// 읽기
csvReader { trimValues = true }
    .read(inputStream, skipHeaders = true)
    .collect { row: CsvRow ->
        val name = row.getString("name")
        val age  = row.getInt("age")
    }

// 쓰기
csvWriter(outputWriter) { quoteAll = true }.use { w ->
    w.writeHeaders(listOf("name", "age"))
    w.writeAll(dataFlow)
}

// V1 → V2 변환 (public)
val csvRow: CsvRow = record.toCsvRow()
```

---

### 기존 섹션: Writer 동작 변경 (Breaking — but RFC 4180 compliant)

| 입력 | 이전 (univocity) | 이후 (자체 엔진) |
|------|-----------------|----------------|
| trailing space (`"row  "`) | `row` (trim됨) | `"row  "` (RFC 4180 인용 보존) |
| `null` | 빈 필드 | 빈 필드 (동일) |
| `""` (빈 문자열) | `""` 인용 | `""` 인용 (동일) |

---

### 기존 섹션: 테스트 현황

```
247 passing, 0 skipped, 0 failing
```

테스트 커버리지:
- `CsvLexerTest` / `TsvLexerTest`: RFC 4180 엣지 케이스 (BOM, CRLF, quoted newline, doubled-quote)
- `CsvRecordReaderTest` / `TsvRecordReaderTest`: 기존 V1 API 호환성
- `CsvRecordWriterTest` / `TsvRecordWriterTest`: Writer roundtrip
- `SuspendCsvRecordReaderTest` / `SuspendTsvRecordReaderTest`: Flow 취소·역압력
- `RFC4180ComplianceTest`: RFC 4180 섹션별 검증
- `CsvEdgeCaseTest` / `SuspendCsvEdgeCaseTest`: null/빈 문자열 roundtrip
- `v2/CsvRowTest` / `FlowCsvReaderTest` / `FlowCsvWriterTest`: V2 DSL 통합 테스트

---

### 기존 섹션: 체크리스트

- [x] 기존 V1 공개 API 유지 (`RecordReader`, `RecordWriter`, `SuspendRecordReader`, `SuspendRecordWriter`)
- [x] univocity 의존성 완전 제거 (`build.gradle.kts`)
- [x] RFC 4180 준수 검증 (`RFC4180ComplianceTest`)
- [x] Coroutines 취소 협력 (`ensureActive`)
- [x] 동시 쓰기 안전 (`Mutex`)
- [x] MIGRATION.md 작성
- [x] README.md / README.ko.md 업데이트
- [x] CHANGELOG.md 항목 추가
- [x] CLAUDE.md 업데이트

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #83, head `c8ad4f97ec116302694c8e670b9ae20d89a94bb9`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/csv-custom-parser`
- Labels: 없음
- State: `MERGED`, merge commit `2f2553fa5ad7c92026cd43adc187a4996a0e6701`
- CI: `bluetape4k-csv` 내부 파서/라이터 엔진을 univocity-parsers에서 자체 구현 RFC 4180 상태 기계로 교체합니다. / | PR5 | univocity 의존성 완전 제거 + `MIGRATION.md` 작성 | / - **`Record`** 공개 인터페이스 (`io.bluetape4k.csv.Record`): `getString`, `getValue\<T\>`, `getIntOrNull`, `getLongOrNull`, `getDoubleOrNull`, `getBigDecimalOrNull`, `rowNumber`, `size`, `values`, `headers`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #83 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `2f2553fa5ad7c92026cd43adc187a4996a0e6701`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
