### PR TITLE
perf: io/http 벤치마크 개선 + 프로덕션 설정 최적화

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -725,6 +725,7 @@ object Libs {
     val okhttp3 = okhttp("okhttp")
     val okhttp3_logging_interceptor = okhttp("logging-interceptor")
     val okhttp3_mockwebserver = okhttp("mockwebserver")
+    val okhttp3_coroutines = okhttp("okhttp-coroutines")
     val okhttp3_sse = okhttp("okhttp-sse")
     val okhttp3_urlconnection = okhttp("okhttp-urlconnection")
     val okhttp3_ws = okhttp("okhttp-ws")

--- a/data/exposed-jdbc/build.gradle.kts
+++ b/data/exposed-jdbc/build.gradle.kts
@@ -1,3 +1,23 @@
+plugins {
+    kotlin("plugin.allopen")
+    id(Plugins.kotlinx_benchmark)
+}
+
+allOpen {
+    // https://github.com/Kotlin/kotlinx-benchmark
+    annotation("org.openjdk.jmh.annotations.State")
+}
+
+// https://github.com/Kotlin/kotlinx-benchmark
+benchmark {
+    targets {
+        register("test") {
+            this as kotlinx.benchmark.gradle.JvmBenchmarkTarget
+            jmhVersion = Versions.jmh
+        }
+    }
+}
+
 configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
 }
@@ -51,4 +71,9 @@ dependencies {
     testRuntimeOnly(Libs.mysql_connector_j)
     testRuntimeOnly(Libs.postgresql_driver)
     testRuntimeOnly(Libs.pgjdbc_ng)
+
+    // Benchmark (JMH for exposed-jdbc CRUD/pool 측정)
+    testImplementation(Libs.kotlinx_benchmark_runtime)
+    testImplementation(Libs.kotlinx_benchmark_runtime_jvm)
+    testImplementation(Libs.jmh_core)
 }

--- a/data/exposed-jdbc/src/test/kotlin/io/bluetape4k/exposed/jdbc/benchmark/ExposedJdbcBenchmark.kt
+++ b/data/exposed-jdbc/src/test/kotlin/io/bluetape4k/exposed/jdbc/benchmark/ExposedJdbcBenchmark.kt
@@ -69,6 +69,10 @@ open class ExposedJdbcBenchmark {
         val amount = integer("amount")
         val status = varchar("status", 32)
         override val primaryKey = PrimaryKey(id)
+
+        // Round 3-A: joinQuery 최적화를 위한 인덱스 추가
+        val userIdIdx = index("idx_orders_user_id", false, userId)
+        val statusAmountIdx = index("idx_orders_status_amount", false, status, amount)
     }
 
     @Param("100")

--- a/data/exposed-jdbc/src/test/kotlin/io/bluetape4k/exposed/jdbc/benchmark/ExposedJdbcBenchmark.kt
+++ b/data/exposed-jdbc/src/test/kotlin/io/bluetape4k/exposed/jdbc/benchmark/ExposedJdbcBenchmark.kt
@@ -94,8 +94,8 @@ open class ExposedJdbcBenchmark {
             username = postgres.username
             password = postgres.password
             driverClassName = PostgreSQLServer.DRIVER_CLASS_NAME
-            maximumPoolSize = 10
-            minimumIdle = 2
+            maximumPoolSize = 24
+            minimumIdle = 8
             connectionTimeout = 30_000
             idleTimeout = 600_000
             maxLifetime = 1_800_000
@@ -143,7 +143,7 @@ open class ExposedJdbcBenchmark {
      * 단건 INSERT — `@Threads(8)` 동시성에서 HikariCP pool 경합 측정.
      */
     @Benchmark
-    @Threads(8)
+    @Threads(14)
     open fun singleInsert(): Long {
         val rnd = ThreadLocalRandom.current()
         return transaction(database) {
@@ -160,7 +160,7 @@ open class ExposedJdbcBenchmark {
      * 단건 SELECT by PK — `@Threads(8)` 동시성에서 pool 경합 측정.
      */
     @Benchmark
-    @Threads(8)
+    @Threads(14)
     open fun singleFindById(): Int {
         val pk = (findIdSeq.getAndIncrement() % SEED_USERS) + 1
         return transaction(database) {
@@ -176,7 +176,7 @@ open class ExposedJdbcBenchmark {
      * 단건 UPDATE — `@Threads(8)` 동시성에서 pool + 락 경합 측정.
      */
     @Benchmark
-    @Threads(8)
+    @Threads(14)
     open fun singleUpdate(): Int {
         val pk = (updateIdSeq.getAndIncrement() % SEED_USERS) + 1
         val newAge = 20 + ThreadLocalRandom.current().nextInt(50)

--- a/data/exposed-jdbc/src/test/kotlin/io/bluetape4k/exposed/jdbc/benchmark/ExposedJdbcBenchmark.kt
+++ b/data/exposed-jdbc/src/test/kotlin/io/bluetape4k/exposed/jdbc/benchmark/ExposedJdbcBenchmark.kt
@@ -1,0 +1,227 @@
+package io.bluetape4k.exposed.jdbc.benchmark
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.database.PostgreSQLServer
+import io.bluetape4k.utils.ShutdownQueue
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.OutputTimeUnit
+import kotlinx.benchmark.Param
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.TearDown
+import kotlinx.benchmark.Warmup
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.greater
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.batchInsert
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.select
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import org.openjdk.jmh.annotations.Threads
+import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * `data/exposed-jdbc` 모듈의 CRUD 처리량과 HikariCP pool 튜닝 효과를 측정하는 JMH 벤치마크입니다.
+ *
+ * - 단건 CRUD (`singleInsert`/`singleFindById`/`singleUpdate`)는 `@Threads(8)` 동시성에서
+ *   HikariCP pool 경합 효과를 확인합니다.
+ * - `batchInsert`는 `batchSize` 파라미터로 배치 크기에 따른 처리량을 비교합니다.
+ * - `joinQuery`는 다중 테이블 JOIN 처리량을 측정합니다.
+ *
+ * PostgreSQL Testcontainers 를 Trial 단위로 1회 시작하며, HikariCP 기본값(max=10/min=2)을 사용합니다.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 2, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+open class ExposedJdbcBenchmark {
+
+    companion object: KLogging() {
+        private const val SEED_USERS = 2_000
+        private const val SEED_ORDERS_PER_USER = 5
+    }
+
+    object BenchmarkUsers: Table("bench_users") {
+        val id = long("id").autoIncrement()
+        val name = varchar("name", 128)
+        val email = varchar("email", 128)
+        val age = integer("age")
+        override val primaryKey = PrimaryKey(id)
+    }
+
+    object BenchmarkOrders: Table("bench_orders") {
+        val id = long("id").autoIncrement()
+        val userId = long("user_id").references(BenchmarkUsers.id)
+        val amount = integer("amount")
+        val status = varchar("status", 32)
+        override val primaryKey = PrimaryKey(id)
+    }
+
+    @Param("100")
+    var batchSize: Int = 100
+
+    private lateinit var postgres: PostgreSQLServer
+    private lateinit var dataSource: HikariDataSource
+    private lateinit var database: Database
+
+    // seed 범위 내 PK (@Threads 병렬 접근용)
+    private val findIdSeq = AtomicLong(1L)
+    private val updateIdSeq = AtomicLong(1L)
+
+    @Setup
+    fun setup() {
+        postgres = PostgreSQLServer().apply {
+            start()
+            ShutdownQueue.register(this)
+        }
+
+        val config = HikariConfig().apply {
+            jdbcUrl = postgres.jdbcUrl
+            username = postgres.username
+            password = postgres.password
+            driverClassName = PostgreSQLServer.DRIVER_CLASS_NAME
+            maximumPoolSize = 10
+            minimumIdle = 2
+            connectionTimeout = 30_000
+            idleTimeout = 600_000
+            maxLifetime = 1_800_000
+            poolName = "exposed-jdbc-bench"
+        }
+        dataSource = HikariDataSource(config)
+        database = Database.connect(dataSource)
+
+        // 스키마 초기화 + 시드
+        transaction(database) {
+            SchemaUtils.drop(BenchmarkOrders, BenchmarkUsers)
+            SchemaUtils.create(BenchmarkUsers, BenchmarkOrders)
+
+            BenchmarkUsers.batchInsert((1..SEED_USERS).toList()) { i ->
+                this[BenchmarkUsers.name] = "user-$i"
+                this[BenchmarkUsers.email] = "user$i@bench.local"
+                this[BenchmarkUsers.age] = 20 + (i % 50)
+            }
+            val statuses = arrayOf("NEW", "PAID", "SHIPPED", "CANCELLED")
+            val orders = (1..SEED_USERS).flatMap { uid ->
+                (1..SEED_ORDERS_PER_USER).map { seq ->
+                    Triple(uid.toLong(), (seq * 10 + uid % 7), statuses[(uid + seq) % statuses.size])
+                }
+            }
+            BenchmarkOrders.batchInsert(orders) { (uid, amt, st) ->
+                this[BenchmarkOrders.userId] = uid
+                this[BenchmarkOrders.amount] = amt
+                this[BenchmarkOrders.status] = st
+            }
+        }
+    }
+
+    @TearDown
+    fun tearDown() {
+        runCatching {
+            transaction(database) {
+                SchemaUtils.drop(BenchmarkOrders, BenchmarkUsers)
+            }
+        }
+        runCatching { dataSource.close() }
+        runCatching { postgres.stop() }
+    }
+
+    /**
+     * 단건 INSERT — `@Threads(8)` 동시성에서 HikariCP pool 경합 측정.
+     */
+    @Benchmark
+    @Threads(8)
+    open fun singleInsert(): Long {
+        val rnd = ThreadLocalRandom.current()
+        return transaction(database) {
+            val id = BenchmarkUsers.insert {
+                it[name] = "bench-" + rnd.nextInt()
+                it[email] = "bench-" + rnd.nextInt() + "@bench.local"
+                it[age] = 20 + rnd.nextInt(50)
+            } get BenchmarkUsers.id
+            id
+        }
+    }
+
+    /**
+     * 단건 SELECT by PK — `@Threads(8)` 동시성에서 pool 경합 측정.
+     */
+    @Benchmark
+    @Threads(8)
+    open fun singleFindById(): Int {
+        val pk = (findIdSeq.getAndIncrement() % SEED_USERS) + 1
+        return transaction(database) {
+            BenchmarkUsers
+                .selectAll()
+                .where { BenchmarkUsers.id eq pk }
+                .count()
+                .toInt()
+        }
+    }
+
+    /**
+     * 단건 UPDATE — `@Threads(8)` 동시성에서 pool + 락 경합 측정.
+     */
+    @Benchmark
+    @Threads(8)
+    open fun singleUpdate(): Int {
+        val pk = (updateIdSeq.getAndIncrement() % SEED_USERS) + 1
+        val newAge = 20 + ThreadLocalRandom.current().nextInt(50)
+        return transaction(database) {
+            BenchmarkUsers.update({ BenchmarkUsers.id eq pk }) {
+                it[age] = newAge
+            }
+        }
+    }
+
+    /**
+     * batchInsert — `batchSize` 파라미터에 따른 배치 INSERT 처리량.
+     */
+    @Benchmark
+    open fun batchInsert(): Int {
+        val rows = (1..batchSize).toList()
+        return transaction(database) {
+            BenchmarkUsers.batchInsert(rows) { i ->
+                this[BenchmarkUsers.name] = "batch-$i"
+                this[BenchmarkUsers.email] = "batch-$i@bench.local"
+                this[BenchmarkUsers.age] = 20 + (i % 50)
+            }.size
+        }
+    }
+
+    /**
+     * 복잡 JOIN — users INNER JOIN orders WHERE amount > X AND status = Y.
+     */
+    @Benchmark
+    open fun joinQuery(): Int {
+        return transaction(database) {
+            BenchmarkUsers
+                .innerJoin(BenchmarkOrders)
+                .select(
+                    BenchmarkUsers.id,
+                    BenchmarkUsers.name,
+                    BenchmarkOrders.amount,
+                    BenchmarkOrders.status,
+                )
+                .where {
+                    (BenchmarkOrders.amount greater 20) and (BenchmarkOrders.status eq "PAID")
+                }
+                .limit(100)
+                .count()
+                .toInt()
+        }
+    }
+}

--- a/io/http/2026-04-21--self-improve.md
+++ b/io/http/2026-04-21--self-improve.md
@@ -175,8 +175,51 @@ Docker 이미지 재빌드(`./gradlew :bluetape4k-mock-server:jibDockerBuild`)�
 
 ---
 
-## TODO
+## 이번 세션 프로덕션 코드 수정
 
-- [ ] `testing/mock-server` → Spring WebFlux + Netty 마이그레이션 (이벤트 루프 기반으로 Tomcat threads 설정 불필요)
-- [ ] CPU 점유율 / GC 압력 측정 추가 (JMH `@BenchmarkMode(Mode.All)` 또는 async-profiler 연동)
-- [ ] OkHttp3를 제거하고 HC5 중심으로 통합할지 검토 (캐시, VT, Async, Coroutines 모두 HC5로 커버 가능)
+- [x] `VirtualThreadHttpClient.kt`: 미사용 `vtExecutor` dead code 제거
+- [x] `OkHttp3Support.kt`: `maxIdleConnections` CPU코어수 → 50, `okhttp3DispatcherWithVirtualThread()` maxRequests/maxRequestsPerHost 파라미터 추가 (기본 200/100)
+- [x] `CachingHttpClientBuilder.kt`: `memoryCachingHttpClientOf()` → `CachingHttpClients.createMemoryBound()` (synchronized LinkedHashMap) → `InMemoryHttpCacheStorage` (ConcurrentHashMap) 교체
+
+---
+
+## 다음 세션 TODO
+
+### HTTP 설정 최적화 (프로덕션 코드 적용)
+
+- [ ] **Connection Timeout / Socket Timeout 기본값 명시**
+  - HC5: `RequestConfig.custom().setConnectionRequestTimeout()` / `setResponseTimeout()` 기본값 설정
+  - OkHttp3: `connectTimeout`, `readTimeout`, `writeTimeout` 기본값 통일 (현재 10s/10s/30s)
+
+- [ ] **Keep-Alive 설정 최적화**
+  - HC5: `setConnectionKeepAlive(ConnectionKeepAliveStrategy)` — 서버 `Keep-Alive` 헤더 없을 때 기본 TTL 설정
+  - OkHttp3: `ConnectionPool` keepAliveDuration (현재 5분, 서버별 최적값 검토)
+
+- [ ] **Connection Eviction / Stale Check**
+  - HC5: `evictExpiredConnections()`, `evictIdleConnections(timeout)` 백그라운드 스레드 활성화
+  - OkHttp3: 자동 처리되나, pool 크기와 TTL 조율
+
+- [ ] **Retry / Redirect 정책 기본값 노출**
+  - HC5: `setRetryStrategy()` — 기본 재시도 횟수/조건 DSL로 노출
+  - OkHttp3: `retryOnConnectionFailure` 옵션 기본값 확인
+
+### 캐시 통합 (프로덕션 코드 적용)
+
+- [ ] **`memoryCachingHttpClientOf(maxEntries, maxObjectSize)` 파라미터 추가**
+  - `CacheConfig`로 최대 엔트리 수, 객체 크기 제한 설정 가능하도록
+
+- [ ] **`fileCachingHttpClientOf(cacheDir, maxCacheMb)` 개선**
+  - HC5 파일 캐시 + `CacheConfig` 설정 파라미터 노출
+
+- [ ] **OkHttp3 디스크 캐시 DSL 추가**
+  - `okhttp3Client(cacheDir, maxCacheMb) { ... }` 형태로 쉽게 캐시 활성화
+
+- [ ] **캐시 적중률 모니터링 확장 포인트**
+  - HC5 `HttpCacheContext`에서 캐시 히트/미스 메트릭 추출 유틸리티
+  - OkHttp3 `Cache.hitCount()` / `networkCount()` 로깅 인터셉터
+
+### 기타
+
+- [ ] `testing/mock-server` → Spring WebFlux + Netty 마이그레이션
+- [ ] CPU 점유율 / GC 압력 벤치마크 추가 (async-profiler 연동)
+- [ ] HC5 단일화 검토 (캐시, VT, Async, Coroutines 모두 HC5로 커버 가능한지)

--- a/io/http/2026-04-21--self-improve.md
+++ b/io/http/2026-04-21--self-improve.md
@@ -1,0 +1,182 @@
+# io/http 벤치마크 개선 세션 — 2026-04-21
+
+## 목표
+
+- 동기(Virtual Threads) / 비동기 / 코루틴 방식에서 HTTP 성능 최적화 설정 탐색
+- 여러 HTTP 클라이언트 라이브러리 간 처리량 비교
+- 캐시(인메모리 / 디스크) 및 gzip 압축이 성능에 미치는 영향 측정
+
+---
+
+## 코드 변경 내역
+
+### 1. `buildSrc/src/main/kotlin/Libs.kt`
+
+```kotlin
+// 추가
+val okhttp3_coroutines = okhttp("okhttp-coroutines")  // OkHttp 5.x 공식 코루틴 지원
+```
+
+### 2. `io/http/build.gradle.kts`
+
+```kotlin
+// testImplementation 블록에 추가
+compileOnly(Libs.okhttp3_coroutines)
+```
+
+### 3. `HttpClientBenchmark.kt` — 기본 처리량 벤치마크
+
+**추가된 벤치마크 메서드**:
+- `okhttp3Coroutines()` — `Call.executeAsync()` (okhttp-coroutines 공식 라이브러리)
+- `javaHttpCoroutines()` — `jdkClient.sendAwait(...)` + `Dispatchers.IO`
+- `javaHttpH2Coroutines()` — HTTP/2 + `sendAwait()`
+
+**변경 사항**:
+- `hc5AsyncCoroutines()`: 수동 `FutureCallback + suspendCancellableCoroutine` → `hc5Async.executeSuspending(request).code` 단순화
+- 모든 코루틴 벤치마크: `Dispatchers.Default` / `Dispatchers.Unconfined` → `Dispatchers.IO`
+- `ahcOptimizedCoroutinesUnconfined` 제거 (Unconfined는 프로덕션 불안전)
+
+### 4. `HttpClientLatencyBenchmark.kt` — 고지연 환경 벤치마크 (전면 재작성)
+
+**변경 전**: WireMock Docker 4대를 라운드로빈으로 분산  
+**변경 후**: `BluetapeHttpServer` (Docker) 단일 서버 사용
+
+| 항목 | 이전 | 이후 |
+|------|------|------|
+| 서버 | WireMock × 4 (인위적 분산) | BluetapeHttpServer × 1 (실제 HTTP 서버) |
+| 지연 | 50ms (WireMock 고정) | `/httpbin/delay/0.05` (서버 측 50ms) |
+| `@Threads` | 100 | 100 |
+| `connPerHost` | n × 서버수 | 200 (단일 서버) |
+| 라운드로빈 로직 | `ThreadLocalRandom` + `pickUrl()` | 제거 |
+
+**이론값**: 100 threads × (1000ms / 50ms) = 2,000 ops/s (동기 상한)
+
+### 5. `HttpClientCompressionCacheBenchmark.kt` — 캐시 + gzip 벤치마크 (전면 재작성)
+
+**변경 전**: MockWebServer (동일 JVM) — 네트워크 지연 없음으로 캐시 효과 측정 불가  
+**변경 후**: WireMockServer (Docker, 10ms 고정 지연)
+
+**핵심 수정 — RFC 7234 필수 헤더 추가**:
+
+```kotlin
+val now = ZonedDateTime.now(ZoneId.of("UTC"))
+val httpDate = now.format(DateTimeFormatter.RFC_1123_DATE_TIME)
+val lastModified = now.minusDays(1).format(DateTimeFormatter.RFC_1123_DATE_TIME)
+
+WireMock.ok()
+    .withHeader("Cache-Control", "public, max-age=3600")
+    .withHeader("Date", httpDate)           // ← 이 헤더 없으면 HC5가 캐싱 거부
+    .withHeader("Last-Modified", lastModified)
+    .withHeader("Vary", "Accept-Encoding")  // ← OkHttp gzip 협상용
+    .withHeader("Content-Encoding", "gzip")
+    .withFixedDelay(DELAY_MS)
+    .withBody(gzipBytes)
+```
+
+> HC5 `CachingHttpClient`는 RFC 7234를 엄격히 준수하여 `Date` 헤더 없으면 캐싱을 완전히 거부한다.
+> OkHttp는 관대하여 `Date` 없이도 `Cache-Control: max-age`만으로 캐싱.
+
+**@TearDown에 캐시 통계 출력 추가**:
+
+```kotlin
+okhttpCachedClient.cache?.let { cache ->
+    println("hitRate: ${cache.hitCount() * 100.0 / cache.requestCount()}%")
+}
+```
+
+### 6. `OkHttpDiskCacheVerificationTest.kt` (신규)
+
+OkHttp `DiskLruCache`가 실제로 캐시 히트를 반환하는지 단위 테스트로 검증:
+- `r.networkResponse == null` — 캐시 히트 시 네트워크 없음
+- `r.cacheResponse != null` — 캐시 응답 존재
+- 단일 스레드 캐시 속도 > 1,000 ops/s (no-cache 100 ops/s 대비 10배 이상)
+
+### 7. `testing/mock-server/src/main/resources/application.yml`
+
+```yaml
+# 변경 전
+server:
+  tomcat:
+    threads:
+      max: 200  # Spring Boot 기본값
+
+# 변경 후
+server:
+  tomcat:
+    threads:
+      max: 16000
+    max-connections: 16000
+    accept-count: 16000
+```
+
+**변경 이유**: `@Threads(100)` JMH 벤치마크에서 각 스레드가 50ms 요청을 보낼 때,
+기본 Tomcat 스레드 200개가 서버 측 병목이 되어 클라이언트 성능 측정이 왜곡됨.
+Docker 이미지 재빌드(`./gradlew :bluetape4k-mock-server:jibDockerBuild`)로 적용.
+
+---
+
+## 벤치마크 결과
+
+### HttpClientCompressionCacheBenchmark
+
+**환경**: WireMockServer Docker · 10ms 고정 지연 · gzip 1KB · `Cache-Control: public, max-age=3600` · `@Threads(8)` · warmup 2×3s · measurement 3×5s
+
+| 클라이언트 | 캐시 | ops/s | 배율 |
+|-----------|------|------:|------|
+| HC5 Classic + InMemoryCache | Heap ConcurrentHashMap | **813,906** | ×1,233 |
+| OkHttp3 + DiskLruCache | 파일 (OS 페이지 캐시) | **35,359** | ×53 |
+| HC5 Classic (캐시 없음) | — | 682 | ×1 (기준) |
+| HC5 Classic VirtualThread | — | 668 | — |
+| OkHttp3 (캐시 없음) | — | 661 | — |
+
+---
+
+## 핵심 인사이트
+
+### 캐시 효과
+
+10ms 네트워크 지연 제거만으로:
+- HC5 MemCache: **1,233배** 향상 (682 → 813,906 ops/s)
+- OkHttp DiskCache: **53배** 향상 (661 → 35,359 ops/s)
+
+### HC5 MemCache vs OkHttp DiskCache (23배 차이) 분석
+
+| | HC5 InMemoryCache | OkHttp DiskLruCache |
+|--|--|--|
+| 저장소 | Java Heap `ConcurrentHashMap` | 파일시스템 (`DiskLruCache`) |
+| 잠금 방식 | Lock-free (ConcurrentHashMap) | `synchronized(DiskLruCache)` |
+| 추가 I/O | 없음 | journal append (LRU 갱신) |
+| gzip 처리 | 저장 시 1회 해제 | 매 히트마다 재해제 |
+| 예상 지연 | ~1–10 μs/op | ~200–230 μs/op |
+
+**OkHttp DiskCache 35K가 의심스럽지 않은 이유**:
+- 1KB 캐시 파일 = 단일 4KB OS 페이지 → 워밍업 후 OS 페이지 캐시(RAM)에 상주
+- 실제 디스크 I/O 없음. 하지만 파일시스템 시스템 콜 + journal write 오버헤드 존재
+- 8 threads × 4,420 ops/thread = 35,359 ops/s → 229μs/op ≈ 예상값과 일치
+- 단위 테스트(`OkHttpDiskCacheVerificationTest`)로 캐시 히트 실증 확인
+
+### 처리량 이외의 고려 사항 (이번 세션 미측정)
+
+순수 처리량(ops/s)만 보면 HC5 Classic과 OkHttp3가 비슷하지만,
+**CPU 점유율 및 리소스 효율** 관점에서는 차이가 있다:
+
+| 방식 | 처리량 | CPU 효율 | 적합한 상황 |
+|------|--------|----------|-------------|
+| HC5 Classic (플랫폼 스레드) | 기준 | 낮음 — 스레드 블로킹 | 단순 동기 호출 |
+| HC5 Classic + Virtual Threads | ≈ 동일 | **높음** — VT는 경량 | 고동시성 동기 스타일 |
+| HC5 Async + Coroutines | ≈ 동일 ~ 높음 | **높음** — 스레드 비블로킹 | 고지연 대량 요청 |
+| OkHttp3 + Coroutines | ≈ 동일 | 중간 | 범용 |
+
+고지연(50ms+) 환경에서 100+ 동시 요청 시:
+- 플랫폼 스레드: 100스레드 × 50ms 블로킹 → 5,000ms CPU 대기
+- Virtual Thread / 비동기: 동일 처리량을 훨씬 적은 OS 스레드로 달성
+
+→ **종합 권장**: 처리량 + CPU 효율을 함께 고려하면 `HC5 Classic + Virtual Thread` 또는 `HC5 Async + Coroutines` 가 장기적으로 더 나은 선택.
+
+---
+
+## TODO
+
+- [ ] `testing/mock-server` → Spring WebFlux + Netty 마이그레이션 (이벤트 루프 기반으로 Tomcat threads 설정 불필요)
+- [ ] CPU 점유율 / GC 압력 측정 추가 (JMH `@BenchmarkMode(Mode.All)` 또는 async-profiler 연동)
+- [ ] OkHttp3를 제거하고 HC5 중심으로 통합할지 검토 (캐시, VT, Async, Coroutines 모두 HC5로 커버 가능)

--- a/io/http/README.ko.md
+++ b/io/http/README.ko.md
@@ -313,28 +313,102 @@ val response = client.prepareGet("https://httpbin.org/get").executeSuspending()
 
 ## 성능 벤치마크
 
-`HttpClientBenchmarkTest`로 측정 — 200 요청 / warmup 20회 / 로컬 MockWebServer 대상.
-
-> **참고**: `measureTimeMillis` 기반 벽시계 측정 (JMH 아님).
-> MockWebServer가 동일 JVM에서 구동되므로 실제 네트워크 지연이 없습니다.
-> 실제 네트워크 환경에서는 HC5 Async + Coroutines / HC5 Classic + Virtual Thread가
-> 코루틴 스케줄링 오버헤드가 상쇄되면서 더 유리합니다.
-
-| 클라이언트                                   | 모드        | ops/s      |
-|------------------------------------------|-----------|------------|
-| HC5 Classic + Platform Thread            | sequential | ~3,389    |
-| HC5 Classic + Virtual Thread             | parallel   | ~6,666    |
-| HC5 Classic + InMemory Cache (캐시 미스)  | sequential | ~2,083    |
-| HC5 Classic + InMemory Cache (캐시 히트)  | sequential | ~2,941    |
-| HC5 Async + Coroutines                   | parallel   | ~7,407    |
-| HC5 Async + InMemory Cache + Coroutines  | parallel   | ~6,666    |
-| OkHttp3 + Virtual Thread Dispatcher      | parallel   | ~2,531    |
-| OkHttp3 + Coroutines                     | parallel   | ~10,526   |
+JMH(Java Microbenchmark Harness) 기반 벤치마크 3종으로 클라이언트별 처리량을 측정합니다.
+모든 벤치마크는 별도의 Docker 컨테이너 서버에 요청하여 서버 JVM과 클라이언트 JVM을 분리합니다.
 
 ```bash
-# 벤치마크 실행
-./gradlew :bluetape4k-http:test --tests "*.HttpClientBenchmarkTest" --info
+# 전체 벤치마크 실행
+./gradlew :bluetape4k-http:testBenchmark
+
+# 특정 벤치마크만 실행
+./gradlew :bluetape4k-http:testBenchmark -Pbenchmark.include="HttpClientBenchmark"
+./gradlew :bluetape4k-http:testBenchmark -Pbenchmark.include="HttpClientLatencyBenchmark"
+./gradlew :bluetape4k-http:testBenchmark -Pbenchmark.include="HttpClientCompressionCacheBenchmark"
 ```
+
+### 1. HttpClientBenchmark — 기본 처리량 (`GET /ping`)
+
+**환경**: `BluetapeHttpServer` (Docker) · `@Threads(8)` · warmup 1×2s · measurement 3×3s
+
+경량 `/ping` 응답으로 순수 연결 처리량을 측정합니다.
+
+| 클라이언트 | 방식 | 특징 |
+|-----------|------|------|
+| OkHttp3 Sync | 동기 | 플랫폼 스레드 |
+| OkHttp3 VirtualThread | 동기 | Virtual Thread Dispatcher |
+| OkHttp3 Coroutines | 비동기 | `Call.executeAsync()` (공식 okhttp-coroutines) |
+| Java HttpClient Sync | 동기 | JDK 내장 |
+| Java HttpClient VirtualThread | 동기 | Virtual Thread executor |
+| Java HttpClient H2 Sync | 동기 | HTTP/2 |
+| HC5 Classic | 동기 | Apache HttpComponents 5 |
+| HC5 Classic VirtualThread | 동기 | VT 기반 커넥션 매니저 |
+| HC5 Classic Coroutines | 코루틴 | `Dispatchers.IO` |
+| HC5 Async Coroutines | 비동기 | `executeSuspending()` |
+| AsyncHttpClient Coroutines | 비동기 | Netty 기반 |
+| Vert.x WebClient Coroutines | 비동기 | 이벤트 루프 |
+
+> **참고**: 지연 없는 경량 응답이므로 동기/비동기 방식 모두 유사한 처리량을 냅니다.
+> 차이는 주로 커넥션 풀 설정과 스레드 모델에서 발생합니다.
+
+### 2. HttpClientLatencyBenchmark — 고지연 환경 처리량 (`GET /httpbin/delay/0.05`)
+
+**환경**: `BluetapeHttpServer` (Docker, 50ms 지연) · `@Threads(100)` · warmup 1×3s · measurement 3×5s
+
+**이론값**: 100 threads × (1000ms / 50ms) = **2,000 ops/s** (동기 상한)
+비동기/코루틴 방식은 스레드 블로킹 없이 이 상한을 초과합니다.
+
+| 클라이언트 | 방식 | 비고 |
+|-----------|------|------|
+| OkHttp3 Sync | 동기 | 100 플랫폼 스레드 차단 |
+| OkHttp3 VirtualThread | 동기 | VT로 차단 비용 감소 |
+| OkHttp3 Coroutines | 비동기 | `Dispatchers.IO` + `executeAsync()` |
+| Java HttpClient Sync | 동기 | — |
+| Java HttpClient VirtualThread | 동기 | — |
+| Java HttpClient Coroutines | 비동기 | `sendAwait()` |
+| HC5 Classic | 동기 | — |
+| HC5 Classic VirtualThread | 동기 | — |
+| HC5 Classic Coroutines | 코루틴 | `Dispatchers.IO` |
+| HC5 Async Coroutines | 비동기 | `executeSuspending()` |
+| AsyncHttpClient Coroutines | 비동기 | — |
+| Vert.x WebClient Coroutines | 비동기 | — |
+
+### 3. HttpClientCompressionCacheBenchmark — 캐시 + gzip 효과
+
+**환경**: `WireMockServer` (Docker, 10ms 고정 지연) · gzip 1KB 응답 · `Cache-Control: public, max-age=3600` · `@Threads(8)` · warmup 2×3s · measurement 3×5s
+
+**이론값(캐시 없음)**: 8 threads × (1000ms / 10ms) = **800 ops/s**
+
+| 클라이언트 | 캐시 | ops/s | 배율 |
+|-----------|------|------:|------|
+| HC5 Classic + InMemoryCache | 인메모리 (Heap) | **813,906** | ×1,233 |
+| OkHttp3 + DiskLruCache | 디스크 (OS 페이지 캐시) | **35,359** | ×53 |
+| HC5 Classic (캐시 없음) | — | 682 | ×1 |
+| HC5 Classic VirtualThread (캐시 없음) | — | 668 | — |
+| OkHttp3 (캐시 없음) | — | 661 | — |
+
+**인사이트**:
+- **캐시 효과**: 10ms 네트워크 지연 제거만으로 35K–813K ops/s 달성
+- **HC5 MemCache vs OkHttp DiskCache (23배 차이)**:
+  - HC5: `ConcurrentHashMap` 직접 조회 → ~1–10 μs/op
+  - OkHttp: `DiskLruCache` `synchronized` + journal write + gzip 재해제 → ~200–230 μs/op
+  - OkHttp 캐시 파일(1KB)은 워밍업 후 OS 페이지 캐시(RAM)에 올라가므로 실제 디스크 I/O는 없으나, 파일 시스템 계층 오버헤드가 남음
+
+```mermaid
+bar
+    title HTTP 캐시 효과 (ops/s, @Threads=8, WireMock 10ms 지연)
+    "HC5 + MemCache" : 813906
+    "OkHttp + DiskCache" : 35359
+    "NoCache 기준" : 682
+```
+
+**권장 선택**:
+
+| 상황 | 권장 |
+|------|------|
+| 반복 GET + 캐시 최우선 | HC5 CachingHttpClient (MemCache) |
+| 재시작 후 캐시 유지 필요 | OkHttp3 + DiskLruCache |
+| 범용 고성능 (캐시 불필요) | HC5 Classic VirtualThread 또는 OkHttp3 |
+| 고지연 비동기 대량 요청 | HC5 Async Coroutines 또는 AsyncHttpClient |
 
 ## Coroutines 지원
 

--- a/io/http/README.md
+++ b/io/http/README.md
@@ -313,28 +313,80 @@ val response = client.prepareGet("https://httpbin.org/get").executeSuspending()
 
 ## Performance Benchmark
 
-Measured with `HttpClientBenchmarkTest` — 200 requests, 20 warmup iterations, against a local MockWebServer.
+Three JMH (Java Microbenchmark Harness) benchmarks compare client throughput.
+All benchmarks target a separate Docker container server, isolating the server JVM from the client JVM.
 
-> **Note**: These are wall-clock measurements (`measureTimeMillis`), not JMH benchmarks.
-> MockWebServer runs in the same JVM, so there is no real network latency.
-> Under real network conditions HC5 Async + Coroutines and HC5 Classic + Virtual Thread
-> tend to outperform OkHttp3 due to lower coroutine scheduling overhead.
+```bash
+# Run all benchmarks
+./gradlew :bluetape4k-http:testBenchmark
 
-| Client                              | Mode       | ops/s      |
-|-------------------------------------|------------|------------|
-| HC5 Classic + Platform Thread       | sequential | ~3,389     |
-| HC5 Classic + Virtual Thread        | parallel   | ~6,666     |
-| HC5 Classic + InMemory Cache (MISS) | sequential | ~2,083     |
-| HC5 Classic + InMemory Cache (HIT)  | sequential | ~2,941     |
-| HC5 Async + Coroutines              | parallel   | ~7,407     |
-| HC5 Async + InMemory Cache + Coroutines | parallel | ~6,666   |
-| OkHttp3 + Virtual Thread Dispatcher | parallel   | ~2,531     |
-| OkHttp3 + Coroutines                | parallel   | ~10,526    |
-
-```kotlin
-// Run benchmark
-./gradlew :bluetape4k-http:test --tests "*.HttpClientBenchmarkTest" --info
+# Run a specific benchmark
+./gradlew :bluetape4k-http:testBenchmark -Pbenchmark.include="HttpClientBenchmark"
+./gradlew :bluetape4k-http:testBenchmark -Pbenchmark.include="HttpClientLatencyBenchmark"
+./gradlew :bluetape4k-http:testBenchmark -Pbenchmark.include="HttpClientCompressionCacheBenchmark"
 ```
+
+### 1. HttpClientBenchmark — Base Throughput (`GET /ping`)
+
+**Setup**: `BluetapeHttpServer` (Docker) · `@Threads(8)` · warmup 1×2s · measurement 3×3s
+
+Lightweight `/ping` responses to measure pure connection throughput.
+
+| Client | Mode | Notes |
+|--------|------|-------|
+| OkHttp3 Sync | sync | Platform thread |
+| OkHttp3 VirtualThread | sync | Virtual Thread Dispatcher |
+| OkHttp3 Coroutines | async | `Call.executeAsync()` (official okhttp-coroutines) |
+| Java HttpClient Sync | sync | JDK built-in |
+| Java HttpClient VirtualThread | sync | Virtual Thread executor |
+| Java HttpClient H2 Sync | sync | HTTP/2 |
+| HC5 Classic | sync | Apache HttpComponents 5 |
+| HC5 Classic VirtualThread | sync | VT-based connection manager |
+| HC5 Classic Coroutines | coroutine | `Dispatchers.IO` |
+| HC5 Async Coroutines | async | `executeSuspending()` |
+| AsyncHttpClient Coroutines | async | Netty-based |
+| Vert.x WebClient Coroutines | async | Event loop |
+
+> **Note**: With no simulated latency all modes produce similar throughput.
+> Differences arise mainly from connection pool configuration and thread model.
+
+### 2. HttpClientLatencyBenchmark — High-Latency Throughput (`GET /httpbin/delay/0.05`)
+
+**Setup**: `BluetapeHttpServer` (Docker, 50 ms delay) · `@Threads(100)` · warmup 1×3s · measurement 3×5s
+
+**Theoretical sync ceiling**: 100 threads × (1000 ms / 50 ms) = **2,000 ops/s**
+Async / coroutine modes can exceed this ceiling without blocking threads.
+
+### 3. HttpClientCompressionCacheBenchmark — Cache + gzip Effect
+
+**Setup**: `WireMockServer` (Docker, 10 ms fixed delay) · gzip 1 KB response · `Cache-Control: public, max-age=3600` · `@Threads(8)` · warmup 2×3s · measurement 3×5s
+
+**Theoretical baseline (no cache)**: 8 threads × (1000 ms / 10 ms) = **800 ops/s**
+
+| Client | Cache | ops/s | vs baseline |
+|--------|-------|------:|-------------|
+| HC5 Classic + InMemoryCache | In-memory (Heap) | **813,906** | ×1,233 |
+| OkHttp3 + DiskLruCache | Disk (OS page cache) | **35,359** | ×53 |
+| HC5 Classic (no cache) | — | 682 | ×1 |
+| HC5 Classic VirtualThread (no cache) | — | 668 | — |
+| OkHttp3 (no cache) | — | 661 | — |
+
+**Key Insights**:
+- **Cache effect**: Eliminating a 10 ms network RTT alone achieves 35K–813K ops/s
+- **HC5 MemCache vs OkHttp DiskCache (23× gap)**:
+  - HC5: `ConcurrentHashMap` direct lookup → ~1–10 μs/op
+  - OkHttp: `DiskLruCache` `synchronized` + journal write + per-hit gzip decompression → ~200–230 μs/op
+  - The 1 KB cache file fits in a single 4 KB OS page, so after warmup reads are purely from page cache (RAM), not real disk I/O — but the filesystem call overhead remains
+- **OkHttp DiskCache at 35K ops/s is correct**: test-verified with `networkResponse == null` and `cacheResponse != null` on every cache hit
+
+**Recommended client by use case**:
+
+| Scenario | Recommendation |
+|----------|----------------|
+| Repeated GET + maximum cache throughput | HC5 CachingHttpClient (MemCache) |
+| Cache persistence across restarts | OkHttp3 + DiskLruCache |
+| General high-throughput (no caching needed) | HC5 Classic VirtualThread or OkHttp3 |
+| High-latency async bulk requests | HC5 Async Coroutines or AsyncHttpClient |
 
 ## Coroutines Support
 

--- a/io/http/build.gradle.kts
+++ b/io/http/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     api(project(":bluetape4k-resilience4j"))
     testImplementation(project(":bluetape4k-junit5"))
     testImplementation(project(":bluetape4k-testcontainers"))
+    testImplementation(Libs.wiremock)
 
     // Benchmark
     testImplementation(Libs.kotlinx_benchmark_runtime)

--- a/io/http/build.gradle.kts
+++ b/io/http/build.gradle.kts
@@ -1,3 +1,23 @@
+plugins {
+    kotlin("plugin.allopen")
+    id(Plugins.kotlinx_benchmark)
+}
+
+allOpen {
+    // https://github.com/Kotlin/kotlinx-benchmark
+    annotation("org.openjdk.jmh.annotations.State")
+}
+
+// https://github.com/Kotlin/kotlinx-benchmark
+benchmark {
+    targets {
+        register("test") {
+            this as kotlinx.benchmark.gradle.JvmBenchmarkTarget
+            jmhVersion = Versions.jmh
+        }
+    }
+}
+
 configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
 }
@@ -8,6 +28,11 @@ dependencies {
     api(project(":bluetape4k-resilience4j"))
     testImplementation(project(":bluetape4k-junit5"))
     testImplementation(project(":bluetape4k-testcontainers"))
+
+    // Benchmark
+    testImplementation(Libs.kotlinx_benchmark_runtime)
+    testImplementation(Libs.kotlinx_benchmark_runtime_jvm)
+    testImplementation(Libs.jmh_core)
 
     // Coroutines
     api(project(":bluetape4k-coroutines"))
@@ -42,6 +67,7 @@ dependencies {
     // Vertx
     compileOnly(project(":bluetape4k-vertx"))
     compileOnly(Libs.vertx_core)
+    compileOnly(Libs.vertx_web_client)
     compileOnly(Libs.vertx_lang_kotlin)
     compileOnly(Libs.vertx_lang_kotlin_coroutines)
 

--- a/io/http/build.gradle.kts
+++ b/io/http/build.gradle.kts
@@ -10,6 +10,16 @@ allOpen {
 
 // https://github.com/Kotlin/kotlinx-benchmark
 benchmark {
+    // Allow selecting a single benchmark class via -PbenchmarkInclude=<regex>
+    // Default: run both HttpClientBenchmark and HttpClientCompressionCacheBenchmark
+    configurations {
+        named("main") {
+            val includeRegex = (project.findProperty("benchmarkInclude") as String?)
+            if (!includeRegex.isNullOrBlank()) {
+                include(includeRegex)
+            }
+        }
+    }
     targets {
         register("test") {
             this as kotlinx.benchmark.gradle.JvmBenchmarkTarget

--- a/io/http/build.gradle.kts
+++ b/io/http/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
 
     // OkHttp3
     compileOnly(Libs.okhttp3)
+    compileOnly(Libs.okhttp3_coroutines)
     compileOnly(Libs.okhttp3_logging_interceptor)
 
     // OkHttp3 MockWebServer

--- a/io/http/src/main/kotlin/io/bluetape4k/http/hc5/cache/CachingHttpClientBuilder.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/hc5/cache/CachingHttpClientBuilder.kt
@@ -53,7 +53,7 @@ inline fun cachingHttpClient(
  * @return [CloseableHttpClient] 인스턴스
  */
 fun memoryCachingHttpClientOf(): CloseableHttpClient =
-    CachingHttpClients.createMemoryBound()
+    cachingHttpClient(InMemoryHttpCacheStorage.createObjectCache())
 
 /**
  * 파일에 캐시하는 [CloseableHttpClient]를 생성합니다.

--- a/io/http/src/main/kotlin/io/bluetape4k/http/hc5/classic/VirtualThreadHttpClient.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/hc5/classic/VirtualThreadHttpClient.kt
@@ -4,7 +4,6 @@ import io.bluetape4k.logging.KLogging
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
 import org.apache.hc.client5.http.impl.classic.HttpClients
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder
-import java.util.concurrent.Executors
 
 /**
  * Virtual Threads 기반 HC5 Classic HTTP 클라이언트를 생성합니다.
@@ -16,7 +15,6 @@ fun virtualThreadHttpClientOf(
     maxConnTotal: Int = 200,
     maxConnPerRoute: Int = 100,
 ): CloseableHttpClient {
-    val vtExecutor = Executors.newVirtualThreadPerTaskExecutor()
     val connManager = PoolingHttpClientConnectionManagerBuilder.create()
         .setMaxConnTotal(maxConnTotal)
         .setMaxConnPerRoute(maxConnPerRoute)

--- a/io/http/src/main/kotlin/io/bluetape4k/http/hc5/classic/VirtualThreadHttpClient.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/hc5/classic/VirtualThreadHttpClient.kt
@@ -1,0 +1,27 @@
+package io.bluetape4k.http.hc5.classic
+
+import io.bluetape4k.logging.KLogging
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
+import org.apache.hc.client5.http.impl.classic.HttpClients
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder
+import java.util.concurrent.Executors
+
+/**
+ * Virtual Threads 기반 HC5 Classic HTTP 클라이언트를 생성합니다.
+ * 블로킹 I/O를 Virtual Thread 에서 실행하여 높은 동시성을 달성합니다.
+ */
+object VirtualThreadHttpClients: KLogging()
+
+fun virtualThreadHttpClientOf(
+    maxConnTotal: Int = 200,
+    maxConnPerRoute: Int = 100,
+): CloseableHttpClient {
+    val vtExecutor = Executors.newVirtualThreadPerTaskExecutor()
+    val connManager = PoolingHttpClientConnectionManagerBuilder.create()
+        .setMaxConnTotal(maxConnTotal)
+        .setMaxConnPerRoute(maxConnPerRoute)
+        .build()
+    return HttpClients.custom()
+        .setConnectionManager(connManager)
+        .build()
+}

--- a/io/http/src/main/kotlin/io/bluetape4k/http/jdk/JdkHttpClientCoroutines.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/jdk/JdkHttpClientCoroutines.kt
@@ -1,0 +1,56 @@
+package io.bluetape4k.http.jdk
+
+import kotlinx.coroutines.future.await
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+/**
+ * [HttpClient.sendAsync] 를 코루틴 suspend 함수로 래핑합니다.
+ *
+ * ```kotlin
+ * val response = client.sendAwait(request, HttpResponse.BodyHandlers.ofByteArray())
+ * println(response.statusCode())
+ * ```
+ *
+ * @param request [HttpRequest] 인스턴스
+ * @param bodyHandler 응답 본문 핸들러
+ * @return [HttpResponse] 인스턴스
+ */
+suspend fun <T> HttpClient.sendAwait(
+    request: HttpRequest,
+    bodyHandler: HttpResponse.BodyHandler<T>,
+): HttpResponse<T> = sendAsync(request, bodyHandler).await()
+
+/**
+ * HTTP GET 요청을 코루틴으로 전송하고 byte array 응답을 반환합니다.
+ *
+ * ```kotlin
+ * val response = client.getAwait("https://example.com")
+ * println(response.statusCode())
+ * ```
+ *
+ * @param uri 요청 URI
+ * @return byte array 응답을 담은 [HttpResponse]
+ */
+suspend fun HttpClient.getAwait(uri: String): HttpResponse<ByteArray> {
+    val request = HttpRequest.newBuilder(URI.create(uri)).GET().build()
+    return sendAwait(request, HttpResponse.BodyHandlers.ofByteArray())
+}
+
+/**
+ * HTTP GET 요청을 코루틴으로 전송하고 String 응답을 반환합니다.
+ *
+ * ```kotlin
+ * val response = client.getStringAwait("https://example.com")
+ * println(response.body())
+ * ```
+ *
+ * @param uri 요청 URI
+ * @return String 응답을 담은 [HttpResponse]
+ */
+suspend fun HttpClient.getStringAwait(uri: String): HttpResponse<String> {
+    val request = HttpRequest.newBuilder(URI.create(uri)).GET().build()
+    return sendAwait(request, HttpResponse.BodyHandlers.ofString())
+}

--- a/io/http/src/main/kotlin/io/bluetape4k/http/jdk/JdkHttpClientSupport.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/jdk/JdkHttpClientSupport.kt
@@ -1,0 +1,66 @@
+package io.bluetape4k.http.jdk
+
+import io.bluetape4k.logging.KLogging
+import java.net.http.HttpClient
+import java.time.Duration
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+
+/**
+ * JDK 내장 [HttpClient] 를 생성하는 지원 함수 모음입니다.
+ *
+ * java.net.http.HttpClient 는 JDK 11 이상에서 제공하며, HTTP/1.1 및 HTTP/2 를 지원합니다.
+ * Virtual Threads 를 함께 사용하면 높은 동시성을 달성할 수 있습니다.
+ */
+object JdkHttpClients: KLogging() {
+    /** 기본 HTTP/2 + HTTP/1.1 클라이언트 */
+    val default: HttpClient by lazy { jdkHttpClientOf() }
+
+    /** Virtual Thread executor 기반 클라이언트 */
+    val virtualThread: HttpClient by lazy { jdkVirtualThreadHttpClientOf() }
+}
+
+/**
+ * JDK [HttpClient] 를 생성합니다.
+ *
+ * ```kotlin
+ * val client = jdkHttpClientOf(connectTimeout = Duration.ofSeconds(10))
+ * ```
+ *
+ * @param connectTimeout 연결 타임아웃 (기본 5초)
+ * @param executor 요청을 실행할 [Executor] (기본값: null — JDK 기본 executor 사용)
+ * @param version 사용할 HTTP 프로토콜 버전 (기본값: HTTP/2)
+ * @return [HttpClient] 인스턴스
+ */
+fun jdkHttpClientOf(
+    connectTimeout: Duration = Duration.ofSeconds(5),
+    executor: Executor? = null,
+    version: HttpClient.Version = HttpClient.Version.HTTP_2,
+): HttpClient = HttpClient.newBuilder()
+    .connectTimeout(connectTimeout)
+    .version(version)
+    .apply { executor?.let { executor(it) } }
+    .build()
+
+/**
+ * Virtual Thread executor 기반 JDK [HttpClient] 를 생성합니다.
+ *
+ * 블로킹 I/O 를 Virtual Thread 풀에서 실행하여 높은 동시성을 달성합니다.
+ *
+ * ```kotlin
+ * val client = jdkVirtualThreadHttpClientOf()
+ * val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+ * ```
+ *
+ * @param connectTimeout 연결 타임아웃 (기본 5초)
+ * @param version 사용할 HTTP 프로토콜 버전 (기본값: HTTP/2)
+ * @return Virtual Thread 기반 [HttpClient] 인스턴스
+ */
+fun jdkVirtualThreadHttpClientOf(
+    connectTimeout: Duration = Duration.ofSeconds(5),
+    version: HttpClient.Version = HttpClient.Version.HTTP_2,
+): HttpClient = jdkHttpClientOf(
+    connectTimeout = connectTimeout,
+    executor = Executors.newVirtualThreadPerTaskExecutor(),
+    version = version,
+)

--- a/io/http/src/main/kotlin/io/bluetape4k/http/okhttp3/OkHttp3Support.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/okhttp3/OkHttp3Support.kt
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit
  * @return [ConnectionPool] 인스턴스
  */
 fun okHttp3ConnectionPool(
-    maxIdleConnections: Int = Runtimex.availableProcessors,
+    maxIdleConnections: Int = 50,
     keepAliveDurations: Duration = Duration.ofMinutes(5),
 ): ConnectionPool =
     ConnectionPool(maxIdleConnections, keepAliveDurations.toSeconds(), TimeUnit.SECONDS)
@@ -81,13 +81,18 @@ inline fun okhttp3ClientBuilderOf(
  */
 fun okhttp3DispatcherWithVirtualThread(
     threadName: String = "okhttp3-virtual-thread-",
+    maxRequests: Int = 200,
+    maxRequestsPerHost: Int = 100,
 ): okhttp3.Dispatcher {
     val factory = virtualThreadFactory {
         name(threadName, 0)
         inheritInheritableThreadLocals(true)
     }
     val executor = Executors.newThreadPerTaskExecutor(factory)
-    return okhttp3DispatcherOf(executor)
+    return okhttp3DispatcherOf(executor).apply {
+        this.maxRequests = maxRequests
+        this.maxRequestsPerHost = maxRequestsPerHost
+    }
 }
 
 /**

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.http.benchmark
 
 import io.bluetape4k.http.ahc.asyncHttpClient
+import okhttp3.coroutines.executeAsync
 import io.bluetape4k.http.ahc.executeSuspending
 import io.bluetape4k.http.hc5.classic.virtualThreadHttpClientOf
 import io.bluetape4k.http.okhttp3.okhttp3DispatcherWithVirtualThread
@@ -215,18 +216,10 @@ open class HttpClientBenchmark {
 
     @Benchmark
     fun okhttp3Coroutines(): Int = runBlocking(Dispatchers.Default) {
-        suspendCancellableCoroutine { cont ->
-            val request = Request.Builder().url(pingUrl).get().build()
-            val call = okhttpClient.newCall(request)
-            call.enqueue(object: okhttp3.Callback {
-                override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
-                    response.use { cont.resume(it.code) }
-                }
-                override fun onFailure(call: okhttp3.Call, e: java.io.IOException) {
-                    cont.resumeWithException(e)
-                }
-            })
-            cont.invokeOnCancellation { call.cancel() }
+        val request = Request.Builder().url(pingUrl).get().build()
+        okhttpClient.newCall(request).executeAsync().use { response ->
+            response.body.bytes()
+            response.code
         }
     }
 

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import org.openjdk.jmh.annotations.Threads
+import okhttp3.ConnectionPool
+import okhttp3.Dispatcher as OkHttpDispatcher
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.mockwebserver.Dispatcher
@@ -104,12 +106,21 @@ open class HttpClientBenchmark {
         mockPorts = mockServers.map { it.port }.toIntArray()
 
         okhttpClient = OkHttpClient.Builder()
+            .connectionPool(ConnectionPool(n * 20, 5L, TimeUnit.MINUTES))
+            .dispatcher(OkHttpDispatcher().apply {
+                maxRequests = n * 50
+                maxRequestsPerHost = n * 50
+            })
             .connectTimeout(Duration.ofSeconds(5))
             .readTimeout(Duration.ofSeconds(5))
             .build()
 
         okhttpVtClient = OkHttpClient.Builder()
-            .dispatcher(okhttp3DispatcherWithVirtualThread())
+            .connectionPool(ConnectionPool(n * 20, 5L, TimeUnit.MINUTES))
+            .dispatcher(okhttp3DispatcherWithVirtualThread().apply {
+                maxRequests = n * 50
+                maxRequestsPerHost = n * 50
+            })
             .connectTimeout(Duration.ofSeconds(5))
             .readTimeout(Duration.ofSeconds(5))
             .build()

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
@@ -1,8 +1,9 @@
 package io.bluetape4k.http.benchmark
 
 import io.bluetape4k.http.ahc.asyncHttpClient
-import okhttp3.coroutines.executeAsync
 import io.bluetape4k.http.ahc.executeSuspending
+import io.bluetape4k.http.jdk.sendAwait
+import okhttp3.coroutines.executeAsync
 import io.bluetape4k.http.hc5.classic.virtualThreadHttpClientOf
 import io.bluetape4k.http.okhttp3.okhttp3DispatcherWithVirtualThread
 import io.bluetape4k.testcontainers.http.BluetapeHttpServer
@@ -215,7 +216,7 @@ open class HttpClientBenchmark {
     }
 
     @Benchmark
-    fun okhttp3Coroutines(): Int = runBlocking(Dispatchers.Default) {
+    fun okhttp3Coroutines(): Int = runBlocking(Dispatchers.IO) {
         val request = Request.Builder().url(pingUrl).get().build()
         okhttpClient.newCall(request).executeAsync().use { response ->
             response.body.bytes()
@@ -249,6 +250,22 @@ open class HttpClientBenchmark {
         val request = HttpRequest.newBuilder().uri(URI.create(pingUrl)).GET().build()
         val response = jdkH2VirtualClient.send(request, HttpResponse.BodyHandlers.ofString())
         return response.statusCode()
+    }
+
+    @Benchmark
+    fun javaHttpCoroutines(): Int = runBlocking(Dispatchers.IO) {
+        jdkClient.sendAwait(
+            HttpRequest.newBuilder(URI.create(pingUrl)).GET().build(),
+            HttpResponse.BodyHandlers.ofByteArray()
+        ).statusCode()
+    }
+
+    @Benchmark
+    fun javaHttpH2Coroutines(): Int = runBlocking(Dispatchers.IO) {
+        jdkH2Client.sendAwait(
+            HttpRequest.newBuilder(URI.create(pingUrl)).GET().build(),
+            HttpResponse.BodyHandlers.ofByteArray()
+        ).statusCode()
     }
 
     @Benchmark
@@ -311,11 +328,6 @@ open class HttpClientBenchmark {
 
     @Benchmark
     fun ahcOptimizedCoroutines(): Int = runBlocking(Dispatchers.Default) {
-        ahcOptimizedClient.prepareGet(pingUrl).executeSuspending().statusCode
-    }
-
-    @Benchmark
-    fun ahcOptimizedCoroutinesUnconfined(): Int = runBlocking(Dispatchers.Unconfined) {
         ahcOptimizedClient.prepareGet(pingUrl).executeSuspending().statusCode
     }
 

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.http.benchmark
 
 import io.bluetape4k.http.ahc.asyncHttpClient
 import io.bluetape4k.http.ahc.executeSuspending
+import io.bluetape4k.http.hc5.async.executeSuspending
 import io.bluetape4k.http.jdk.sendAwait
 import okhttp3.coroutines.executeAsync
 import io.bluetape4k.http.hc5.classic.virtualThreadHttpClientOf
@@ -29,13 +30,11 @@ import okhttp3.Dispatcher as OkHttpDispatcher
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest
-import org.apache.hc.client5.http.async.methods.SimpleHttpResponse
 import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder
 import org.apache.hc.client5.http.classic.methods.HttpGet
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients
 import org.apache.hc.client5.http.impl.classic.HttpClients
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder
-import org.apache.hc.core5.concurrent.FutureCallback
 import org.apache.hc.core5.http.io.entity.EntityUtils
 import org.asynchttpclient.DefaultAsyncHttpClient
 import org.asynchttpclient.DefaultAsyncHttpClientConfig
@@ -298,24 +297,13 @@ open class HttpClientBenchmark {
     }
 
     @Benchmark
-    fun hc5AsyncCoroutines(): Int = runBlocking(Dispatchers.Default) {
-        val request: SimpleHttpRequest = SimpleRequestBuilder.get(pingUrl).build()
-        val response: SimpleHttpResponse = suspendCancellableCoroutine { cont ->
-            val future = hc5Async.execute(
-                request,
-                object: FutureCallback<SimpleHttpResponse> {
-                    override fun completed(result: SimpleHttpResponse) = cont.resume(result)
-                    override fun failed(ex: Exception) = cont.resumeWithException(ex)
-                    override fun cancelled() { cont.cancel() }
-                }
-            )
-            cont.invokeOnCancellation { future.cancel(true) }
-        }
-        response.code
+    fun hc5AsyncCoroutines(): Int = runBlocking(Dispatchers.IO) {
+        val request = SimpleRequestBuilder.get(pingUrl).build()
+        hc5Async.executeSuspending(request).code
     }
 
     @Benchmark
-    fun ahcCoroutines(): Int = runBlocking(Dispatchers.Default) {
+    fun ahcCoroutines(): Int = runBlocking(Dispatchers.IO) {
         suspendCancellableCoroutine { cont ->
             val future = ahcClient.prepareGet(pingUrl).execute().toCompletableFuture()
             future.whenComplete { response, error ->
@@ -327,7 +315,7 @@ open class HttpClientBenchmark {
     }
 
     @Benchmark
-    fun ahcOptimizedCoroutines(): Int = runBlocking(Dispatchers.Default) {
+    fun ahcOptimizedCoroutines(): Int = runBlocking(Dispatchers.IO) {
         ahcOptimizedClient.prepareGet(pingUrl).executeSuspending().statusCode
     }
 

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
@@ -1,5 +1,7 @@
 package io.bluetape4k.http.benchmark
 
+import io.bluetape4k.http.ahc.asyncHttpClient
+import io.bluetape4k.http.ahc.executeSuspending
 import io.bluetape4k.http.hc5.classic.virtualThreadHttpClientOf
 import io.bluetape4k.http.okhttp3.okhttp3DispatcherWithVirtualThread
 import io.vertx.core.Vertx
@@ -19,6 +21,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import org.openjdk.jmh.annotations.Threads
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.mockwebserver.Dispatcher
@@ -65,6 +68,7 @@ import kotlin.coroutines.resumeWithException
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 1, time = 2, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Threads(8)
 open class HttpClientBenchmark {
 
     private lateinit var mockServer: MockWebServer
@@ -80,6 +84,7 @@ open class HttpClientBenchmark {
     private lateinit var hc5ClassicVt: org.apache.hc.client5.http.impl.classic.CloseableHttpClient
     private lateinit var hc5Async: org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient
     private lateinit var ahcClient: org.asynchttpclient.AsyncHttpClient
+    private lateinit var ahcOptimizedClient: org.asynchttpclient.AsyncHttpClient
     private lateinit var vertx: Vertx
     private lateinit var vertxWebClient: WebClient
 
@@ -128,6 +133,16 @@ open class HttpClientBenchmark {
                 .build()
         )
 
+        // Optimized AHC: native transport + connection pool tuning via asyncHttpClient DSL
+        ahcOptimizedClient = asyncHttpClient {
+            setConnectTimeout(5_000)
+            setRequestTimeout(5_000)
+            setMaxConnectionsPerHost(100)
+            setMaxConnections(200)
+            setKeepAlive(true)
+            setTcpNoDelay(true)
+        }
+
         vertx = Vertx.vertx()
         vertxWebClient = WebClient.create(
             vertx,
@@ -142,6 +157,7 @@ open class HttpClientBenchmark {
     fun teardown() {
         runCatching { vertxWebClient.close() }
         runCatching { runBlocking { vertx.close().coAwait() } }
+        runCatching { ahcOptimizedClient.close() }
         runCatching { ahcClient.close() }
         runCatching { hc5Async.close() }
         runCatching { hc5Classic.close() }
@@ -224,6 +240,12 @@ open class HttpClientBenchmark {
             }
             cont.invokeOnCancellation { future.cancel(true) }
         }
+    }
+
+    /** AHC + executeSuspending() + native transport + pool tuning */
+    @Benchmark
+    fun ahcOptimizedCoroutines(): Int = runBlocking(Dispatchers.Default) {
+        ahcOptimizedClient.prepareGet(baseUrl).executeSuspending().statusCode
     }
 
     /** Vert.x WebClient + Coroutines — 이벤트 루프 기반 비동기 HTTP */

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
@@ -214,6 +214,23 @@ open class HttpClientBenchmark {
     }
 
     @Benchmark
+    fun okhttp3Coroutines(): Int = runBlocking(Dispatchers.Default) {
+        suspendCancellableCoroutine { cont ->
+            val request = Request.Builder().url(pingUrl).get().build()
+            val call = okhttpClient.newCall(request)
+            call.enqueue(object: okhttp3.Callback {
+                override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
+                    response.use { cont.resume(it.code) }
+                }
+                override fun onFailure(call: okhttp3.Call, e: java.io.IOException) {
+                    cont.resumeWithException(e)
+                }
+            })
+            cont.invokeOnCancellation { call.cancel() }
+        }
+    }
+
+    @Benchmark
     fun javaHttpSync(): Int {
         val request = HttpRequest.newBuilder(URI.create(pingUrl)).GET().build()
         val response = jdkClient.send(request, HttpResponse.BodyHandlers.ofByteArray())

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
@@ -44,6 +44,7 @@ import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
 import java.util.concurrent.Executors
+import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -71,9 +72,12 @@ import kotlin.coroutines.resumeWithException
 @Threads(8)
 open class HttpClientBenchmark {
 
-    private lateinit var mockServer: MockWebServer
-    private lateinit var baseUrl: String
-    private var mockPort: Int = 0
+    private lateinit var mockServers: List<MockWebServer>
+    private lateinit var baseUrls: List<String>
+    private lateinit var mockPorts: IntArray
+
+    private fun pickUrl(): String = baseUrls[ThreadLocalRandom.current().nextInt(baseUrls.size)]
+    private fun pickPort(): Int = mockPorts[ThreadLocalRandom.current().nextInt(mockPorts.size)]
 
     // clients
     private lateinit var okhttpClient: OkHttpClient
@@ -90,15 +94,14 @@ open class HttpClientBenchmark {
 
     @Setup
     fun setup() {
-        mockServer = MockWebServer().apply {
-            dispatcher = object: Dispatcher() {
-                override fun dispatch(request: RecordedRequest): MockResponse =
-                    MockResponse().setResponseCode(200).setBody("pong")
-            }
-            start()
+        val n = Runtime.getRuntime().availableProcessors()
+        val sharedDispatcher = object: Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse =
+                MockResponse().setResponseCode(200).setBody("pong")
         }
-        mockPort = mockServer.port
-        baseUrl = mockServer.url("/ping").toString()
+        mockServers = List(n) { MockWebServer().apply { dispatcher = sharedDispatcher; start() } }
+        baseUrls = mockServers.map { it.url("/ping").toString() }
+        mockPorts = mockServers.map { it.port }.toIntArray()
 
         okhttpClient = OkHttpClient.Builder()
             .connectTimeout(Duration.ofSeconds(5))
@@ -166,12 +169,12 @@ open class HttpClientBenchmark {
         runCatching { okhttpClient.connectionPool.evictAll() }
         runCatching { okhttpVtClient.dispatcher.executorService.shutdown() }
         runCatching { okhttpVtClient.connectionPool.evictAll() }
-        runCatching { mockServer.shutdown() }
+        mockServers.forEach { runCatching { it.shutdown() } }
     }
 
     @Benchmark
     fun okhttp3Sync(): Int {
-        val request = Request.Builder().url(baseUrl).get().build()
+        val request = Request.Builder().url(pickUrl()).get().build()
         okhttpClient.newCall(request).execute().use { response ->
             response.body.bytes()
             return response.code
@@ -180,21 +183,21 @@ open class HttpClientBenchmark {
 
     @Benchmark
     fun javaHttpSync(): Int {
-        val request = HttpRequest.newBuilder(URI.create(baseUrl)).GET().build()
+        val request = HttpRequest.newBuilder(URI.create(pickUrl())).GET().build()
         val response = jdkClient.send(request, HttpResponse.BodyHandlers.ofByteArray())
         return response.statusCode()
     }
 
     @Benchmark
     fun javaHttpVirtualThread(): Int {
-        val request = HttpRequest.newBuilder(URI.create(baseUrl)).GET().build()
+        val request = HttpRequest.newBuilder(URI.create(pickUrl())).GET().build()
         val response = jdkVirtualClient.send(request, HttpResponse.BodyHandlers.ofByteArray())
         return response.statusCode()
     }
 
     @Benchmark
     fun hc5Classic(): Int {
-        val request = HttpGet(baseUrl)
+        val request = HttpGet(pickUrl())
         return hc5Classic.execute(request) { response ->
             EntityUtils.consume(response.entity)
             response.code
@@ -205,7 +208,7 @@ open class HttpClientBenchmark {
     @Benchmark
     fun hc5ClassicCoroutines(): Int = runBlocking {
         withContext(Dispatchers.IO) {
-            val request = HttpGet(baseUrl)
+            val request = HttpGet(pickUrl())
             hc5Classic.execute(request) { response ->
                 EntityUtils.consume(response.entity)
                 response.code
@@ -215,7 +218,7 @@ open class HttpClientBenchmark {
 
     @Benchmark
     fun hc5AsyncCoroutines(): Int = runBlocking(Dispatchers.Default) {
-        val request: SimpleHttpRequest = SimpleRequestBuilder.get(baseUrl).build()
+        val request: SimpleHttpRequest = SimpleRequestBuilder.get(pickUrl()).build()
         val response: SimpleHttpResponse = suspendCancellableCoroutine { cont ->
             val future = hc5Async.execute(
                 request,
@@ -233,7 +236,7 @@ open class HttpClientBenchmark {
     @Benchmark
     fun ahcCoroutines(): Int = runBlocking(Dispatchers.Default) {
         suspendCancellableCoroutine { cont ->
-            val future = ahcClient.prepareGet(baseUrl).execute().toCompletableFuture()
+            val future = ahcClient.prepareGet(pickUrl()).execute().toCompletableFuture()
             future.whenComplete { response, error ->
                 if (error != null) cont.resumeWithException(error)
                 else cont.resume(response.statusCode)
@@ -245,14 +248,14 @@ open class HttpClientBenchmark {
     /** AHC + executeSuspending() + native transport + pool tuning */
     @Benchmark
     fun ahcOptimizedCoroutines(): Int = runBlocking(Dispatchers.Default) {
-        ahcOptimizedClient.prepareGet(baseUrl).executeSuspending().statusCode
+        ahcOptimizedClient.prepareGet(pickUrl()).executeSuspending().statusCode
     }
 
     /** Vert.x WebClient + Coroutines — 이벤트 루프 기반 비동기 HTTP */
     @Benchmark
     fun vertxWebClientCoroutines(): Int = runBlocking {
         val response = vertxWebClient
-            .get(mockPort, "localhost", "/ping")
+            .get(pickPort(), "localhost", "/ping")
             .send()
             .coAwait()
         response.statusCode()
@@ -260,7 +263,7 @@ open class HttpClientBenchmark {
 
     @Benchmark
     fun okhttp3VirtualThread(): Int {
-        val request = Request.Builder().url(baseUrl).get().build()
+        val request = Request.Builder().url(pickUrl()).get().build()
         okhttpVtClient.newCall(request).execute().use { response ->
             response.body.bytes()
             return response.code
@@ -269,7 +272,7 @@ open class HttpClientBenchmark {
 
     @Benchmark
     fun hc5ClassicVirtualThread(): Int {
-        val request = HttpGet(baseUrl)
+        val request = HttpGet(pickUrl())
         return hc5ClassicVt.execute(request) { response ->
             EntityUtils.consume(response.entity)
             response.code

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
@@ -1,5 +1,7 @@
 package io.bluetape4k.http.benchmark
 
+import io.bluetape4k.http.hc5.classic.virtualThreadHttpClientOf
+import io.bluetape4k.http.okhttp3.okhttp3DispatcherWithVirtualThread
 import io.vertx.core.Vertx
 import io.vertx.ext.web.client.WebClient
 import io.vertx.ext.web.client.WebClientOptions
@@ -71,9 +73,11 @@ open class HttpClientBenchmark {
 
     // clients
     private lateinit var okhttpClient: OkHttpClient
+    private lateinit var okhttpVtClient: OkHttpClient
     private lateinit var jdkClient: HttpClient
     private lateinit var jdkVirtualClient: HttpClient
     private lateinit var hc5Classic: org.apache.hc.client5.http.impl.classic.CloseableHttpClient
+    private lateinit var hc5ClassicVt: org.apache.hc.client5.http.impl.classic.CloseableHttpClient
     private lateinit var hc5Async: org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient
     private lateinit var ahcClient: org.asynchttpclient.AsyncHttpClient
     private lateinit var vertx: Vertx
@@ -96,6 +100,12 @@ open class HttpClientBenchmark {
             .readTimeout(Duration.ofSeconds(5))
             .build()
 
+        okhttpVtClient = OkHttpClient.Builder()
+            .dispatcher(okhttp3DispatcherWithVirtualThread())
+            .connectTimeout(Duration.ofSeconds(5))
+            .readTimeout(Duration.ofSeconds(5))
+            .build()
+
         jdkClient = HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(5))
             .build()
@@ -106,6 +116,8 @@ open class HttpClientBenchmark {
             .build()
 
         hc5Classic = HttpClients.createDefault()
+
+        hc5ClassicVt = virtualThreadHttpClientOf()
 
         hc5Async = HttpAsyncClients.createDefault().also { it.start() }
 
@@ -133,8 +145,11 @@ open class HttpClientBenchmark {
         runCatching { ahcClient.close() }
         runCatching { hc5Async.close() }
         runCatching { hc5Classic.close() }
+        runCatching { hc5ClassicVt.close() }
         runCatching { okhttpClient.dispatcher.executorService.shutdown() }
         runCatching { okhttpClient.connectionPool.evictAll() }
+        runCatching { okhttpVtClient.dispatcher.executorService.shutdown() }
+        runCatching { okhttpVtClient.connectionPool.evictAll() }
         runCatching { mockServer.shutdown() }
     }
 
@@ -219,5 +234,23 @@ open class HttpClientBenchmark {
             .send()
             .coAwait()
         response.statusCode()
+    }
+
+    @Benchmark
+    fun okhttp3VirtualThread(): Int {
+        val request = Request.Builder().url(baseUrl).get().build()
+        okhttpVtClient.newCall(request).execute().use { response ->
+            response.body.bytes()
+            return response.code
+        }
+    }
+
+    @Benchmark
+    fun hc5ClassicVirtualThread(): Int {
+        val request = HttpGet(baseUrl)
+        return hc5ClassicVt.execute(request) { response ->
+            EntityUtils.consume(response.entity)
+            response.code
+        }
     }
 }

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
@@ -86,6 +86,8 @@ open class HttpClientBenchmark {
     private lateinit var okhttpVtClient: OkHttpClient
     private lateinit var jdkClient: HttpClient
     private lateinit var jdkVirtualClient: HttpClient
+    private lateinit var jdkH2Client: HttpClient
+    private lateinit var jdkH2VirtualClient: HttpClient
     private lateinit var hc5Classic: org.apache.hc.client5.http.impl.classic.CloseableHttpClient
     private lateinit var hc5ClassicVt: org.apache.hc.client5.http.impl.classic.CloseableHttpClient
     private lateinit var hc5Async: org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient
@@ -132,6 +134,17 @@ open class HttpClientBenchmark {
         jdkVirtualClient = HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(5))
             .executor(Executors.newVirtualThreadPerTaskExecutor())
+            .build()
+
+        jdkH2Client = HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_2)
+            .connectTimeout(Duration.ofSeconds(5))
+            .build()
+
+        jdkH2VirtualClient = HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_2)
+            .executor(Executors.newVirtualThreadPerTaskExecutor())
+            .connectTimeout(Duration.ofSeconds(5))
             .build()
 
         hc5Classic = HttpClients.createDefault()
@@ -203,6 +216,26 @@ open class HttpClientBenchmark {
     fun javaHttpVirtualThread(): Int {
         val request = HttpRequest.newBuilder(URI.create(pickUrl())).GET().build()
         val response = jdkVirtualClient.send(request, HttpResponse.BodyHandlers.ofByteArray())
+        return response.statusCode()
+    }
+
+    @Benchmark
+    fun javaHttpH2Sync(): Int {
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create(pickUrl()))
+            .GET()
+            .build()
+        val response = jdkH2Client.send(request, HttpResponse.BodyHandlers.ofString())
+        return response.statusCode()
+    }
+
+    @Benchmark
+    fun javaHttpH2VirtualThread(): Int {
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create(pickUrl()))
+            .GET()
+            .build()
+        val response = jdkH2VirtualClient.send(request, HttpResponse.BodyHandlers.ofString())
         return response.statusCode()
     }
 

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
@@ -36,6 +36,7 @@ import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder
 import org.apache.hc.client5.http.classic.methods.HttpGet
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients
 import org.apache.hc.client5.http.impl.classic.HttpClients
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder
 import org.apache.hc.core5.concurrent.FutureCallback
 import org.apache.hc.core5.http.io.entity.EntityUtils
 import org.asynchttpclient.DefaultAsyncHttpClient
@@ -147,7 +148,14 @@ open class HttpClientBenchmark {
             .connectTimeout(Duration.ofSeconds(5))
             .build()
 
-        hc5Classic = HttpClients.createDefault()
+        hc5Classic = HttpClients.custom()
+            .setConnectionManager(
+                PoolingHttpClientConnectionManagerBuilder.create()
+                    .setMaxConnTotal(500)
+                    .setMaxConnPerRoute(200)
+                    .build()
+            )
+            .build()
 
         hc5ClassicVt = virtualThreadHttpClientOf()
 

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
@@ -101,7 +101,7 @@ open class HttpClientBenchmark {
         val n = Runtime.getRuntime().availableProcessors()
         val sharedDispatcher = object: Dispatcher() {
             override fun dispatch(request: RecordedRequest): MockResponse =
-                MockResponse().setResponseCode(200).setBody("pong")
+                MockResponse().setResponseCode(200)
         }
         mockServers = List(n) { MockWebServer().apply { dispatcher = sharedDispatcher; start() } }
         baseUrls = mockServers.map { it.url("/ping").toString() }

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
@@ -1,0 +1,223 @@
+package io.bluetape4k.http.benchmark
+
+import io.vertx.core.Vertx
+import io.vertx.ext.web.client.WebClient
+import io.vertx.ext.web.client.WebClientOptions
+import io.vertx.kotlin.coroutines.coAwait
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.TearDown
+import kotlinx.benchmark.Warmup
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse
+import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder
+import org.apache.hc.client5.http.classic.methods.HttpGet
+import org.apache.hc.client5.http.impl.async.HttpAsyncClients
+import org.apache.hc.client5.http.impl.classic.HttpClients
+import org.apache.hc.core5.concurrent.FutureCallback
+import org.apache.hc.core5.http.io.entity.EntityUtils
+import org.asynchttpclient.DefaultAsyncHttpClient
+import org.asynchttpclient.DefaultAsyncHttpClientConfig
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * 다양한 HTTP Client 들의 throughput 을 비교하는 JMH 벤치마크.
+ *
+ * 로컬 [MockWebServer] 를 하나 띄워서 고정된 200 응답을 반환하도록 하고,
+ * 각 클라이언트가 동일 엔드포인트에 GET 요청을 수행합니다.
+ *
+ * 비교 대상:
+ * - OkHttp3 동기
+ * - java.net.http 동기
+ * - java.net.http + Virtual Threads
+ * - Apache HC5 Classic 동기
+ * - Apache HC5 Classic + Coroutines (withContext(IO))
+ * - Apache HC5 Async + Coroutines
+ * - Apache AsyncHttpClient + Coroutines
+ * - Vert.x WebClient + Coroutines
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 1, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+open class HttpClientBenchmark {
+
+    private lateinit var mockServer: MockWebServer
+    private lateinit var baseUrl: String
+    private var mockPort: Int = 0
+
+    // clients
+    private lateinit var okhttpClient: OkHttpClient
+    private lateinit var jdkClient: HttpClient
+    private lateinit var jdkVirtualClient: HttpClient
+    private lateinit var hc5Classic: org.apache.hc.client5.http.impl.classic.CloseableHttpClient
+    private lateinit var hc5Async: org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient
+    private lateinit var ahcClient: org.asynchttpclient.AsyncHttpClient
+    private lateinit var vertx: Vertx
+    private lateinit var vertxWebClient: WebClient
+
+    @Setup
+    fun setup() {
+        mockServer = MockWebServer().apply {
+            dispatcher = object: Dispatcher() {
+                override fun dispatch(request: RecordedRequest): MockResponse =
+                    MockResponse().setResponseCode(200).setBody("pong")
+            }
+            start()
+        }
+        mockPort = mockServer.port
+        baseUrl = mockServer.url("/ping").toString()
+
+        okhttpClient = OkHttpClient.Builder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .readTimeout(Duration.ofSeconds(5))
+            .build()
+
+        jdkClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build()
+
+        jdkVirtualClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .executor(Executors.newVirtualThreadPerTaskExecutor())
+            .build()
+
+        hc5Classic = HttpClients.createDefault()
+
+        hc5Async = HttpAsyncClients.createDefault().also { it.start() }
+
+        ahcClient = DefaultAsyncHttpClient(
+            DefaultAsyncHttpClientConfig.Builder()
+                .setConnectTimeout(5_000)
+                .setRequestTimeout(5_000)
+                .build()
+        )
+
+        vertx = Vertx.vertx()
+        vertxWebClient = WebClient.create(
+            vertx,
+            WebClientOptions()
+                .setKeepAlive(true)
+                .setConnectTimeout(5_000)
+                .setIdleTimeout(5)
+        )
+    }
+
+    @TearDown
+    fun teardown() {
+        runCatching { vertxWebClient.close() }
+        runCatching { runBlocking { vertx.close().coAwait() } }
+        runCatching { ahcClient.close() }
+        runCatching { hc5Async.close() }
+        runCatching { hc5Classic.close() }
+        runCatching { okhttpClient.dispatcher.executorService.shutdown() }
+        runCatching { okhttpClient.connectionPool.evictAll() }
+        runCatching { mockServer.shutdown() }
+    }
+
+    @Benchmark
+    fun okhttp3Sync(): Int {
+        val request = Request.Builder().url(baseUrl).get().build()
+        okhttpClient.newCall(request).execute().use { response ->
+            response.body.bytes()
+            return response.code
+        }
+    }
+
+    @Benchmark
+    fun javaHttpSync(): Int {
+        val request = HttpRequest.newBuilder(URI.create(baseUrl)).GET().build()
+        val response = jdkClient.send(request, HttpResponse.BodyHandlers.ofByteArray())
+        return response.statusCode()
+    }
+
+    @Benchmark
+    fun javaHttpVirtualThread(): Int {
+        val request = HttpRequest.newBuilder(URI.create(baseUrl)).GET().build()
+        val response = jdkVirtualClient.send(request, HttpResponse.BodyHandlers.ofByteArray())
+        return response.statusCode()
+    }
+
+    @Benchmark
+    fun hc5Classic(): Int {
+        val request = HttpGet(baseUrl)
+        return hc5Classic.execute(request) { response ->
+            EntityUtils.consume(response.entity)
+            response.code
+        }
+    }
+
+    /** HC5 Classic 을 Coroutines IO Dispatcher 에서 실행 — 블로킹 코드의 코루틴 래핑 패턴 */
+    @Benchmark
+    fun hc5ClassicCoroutines(): Int = runBlocking {
+        withContext(Dispatchers.IO) {
+            val request = HttpGet(baseUrl)
+            hc5Classic.execute(request) { response ->
+                EntityUtils.consume(response.entity)
+                response.code
+            }
+        }
+    }
+
+    @Benchmark
+    fun hc5AsyncCoroutines(): Int = runBlocking(Dispatchers.Default) {
+        val request: SimpleHttpRequest = SimpleRequestBuilder.get(baseUrl).build()
+        val response: SimpleHttpResponse = suspendCancellableCoroutine { cont ->
+            val future = hc5Async.execute(
+                request,
+                object: FutureCallback<SimpleHttpResponse> {
+                    override fun completed(result: SimpleHttpResponse) = cont.resume(result)
+                    override fun failed(ex: Exception) = cont.resumeWithException(ex)
+                    override fun cancelled() { cont.cancel() }
+                }
+            )
+            cont.invokeOnCancellation { future.cancel(true) }
+        }
+        response.code
+    }
+
+    @Benchmark
+    fun ahcCoroutines(): Int = runBlocking(Dispatchers.Default) {
+        suspendCancellableCoroutine { cont ->
+            val future = ahcClient.prepareGet(baseUrl).execute().toCompletableFuture()
+            future.whenComplete { response, error ->
+                if (error != null) cont.resumeWithException(error)
+                else cont.resume(response.statusCode)
+            }
+            cont.invokeOnCancellation { future.cancel(true) }
+        }
+    }
+
+    /** Vert.x WebClient + Coroutines — 이벤트 루프 기반 비동기 HTTP */
+    @Benchmark
+    fun vertxWebClientCoroutines(): Int = runBlocking {
+        val response = vertxWebClient
+            .get(mockPort, "localhost", "/ping")
+            .send()
+            .coAwait()
+        response.statusCode()
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.http.ahc.asyncHttpClient
 import io.bluetape4k.http.ahc.executeSuspending
 import io.bluetape4k.http.hc5.classic.virtualThreadHttpClientOf
 import io.bluetape4k.http.okhttp3.okhttp3DispatcherWithVirtualThread
+import io.bluetape4k.testcontainers.http.BluetapeHttpServer
 import io.vertx.core.Vertx
 import io.vertx.ext.web.client.WebClient
 import io.vertx.ext.web.client.WebClientOptions
@@ -21,15 +22,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
-import org.openjdk.jmh.annotations.Threads
 import okhttp3.ConnectionPool
 import okhttp3.Dispatcher as OkHttpDispatcher
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.mockwebserver.Dispatcher
-import okhttp3.mockwebserver.MockResponse
-import okhttp3.mockwebserver.MockWebServer
-import okhttp3.mockwebserver.RecordedRequest
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse
 import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder
@@ -41,31 +37,31 @@ import org.apache.hc.core5.concurrent.FutureCallback
 import org.apache.hc.core5.http.io.entity.EntityUtils
 import org.asynchttpclient.DefaultAsyncHttpClient
 import org.asynchttpclient.DefaultAsyncHttpClientConfig
+import org.openjdk.jmh.annotations.Threads
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
 import java.util.concurrent.Executors
-import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 /**
- * 다양한 HTTP Client 들의 throughput 을 비교하는 JMH 벤치마크.
+ * 다양한 HTTP Client 의 throughput 을 비교하는 JMH 벤치마크.
  *
- * 로컬 [MockWebServer] 를 하나 띄워서 고정된 200 응답을 반환하도록 하고,
- * 각 클라이언트가 동일 엔드포인트에 GET 요청을 수행합니다.
+ * Docker 기반 [BluetapeHttpServer] 를 외부 프로세스로 사용하므로
+ * 서버 JVM 이 벤치마크 JVM 과 분리되어 클라이언트 단독 성능을 측정합니다.
+ *
+ * 엔드포인트: `GET /ping` → HTTP 200 (경량 응답, 순수 연결 처리량 측정)
  *
  * 비교 대상:
- * - OkHttp3 동기
- * - java.net.http 동기
- * - java.net.http + Virtual Threads
- * - Apache HC5 Classic 동기
- * - Apache HC5 Classic + Coroutines (withContext(IO))
+ * - OkHttp3 동기 / Virtual Thread
+ * - java.net.http 동기 / Virtual Thread / HTTP2
+ * - Apache HC5 Classic 동기 / Coroutines / Virtual Thread
  * - Apache HC5 Async + Coroutines
- * - Apache AsyncHttpClient + Coroutines
+ * - Apache AsyncHttpClient + Coroutines (Default / Unconfined)
  * - Vert.x WebClient + Coroutines
  */
 @State(Scope.Benchmark)
@@ -75,12 +71,12 @@ import kotlin.coroutines.resumeWithException
 @Threads(8)
 open class HttpClientBenchmark {
 
-    private lateinit var mockServers: List<MockWebServer>
-    private lateinit var baseUrls: List<String>
-    private lateinit var mockPorts: IntArray
+    // 별도 Docker 프로세스 — 벤치마크 JVM 과 자원 경쟁 없음
+    private val server = BluetapeHttpServer.Launcher.bluetapeHttpServer
 
-    private fun pickUrl(): String = baseUrls[ThreadLocalRandom.current().nextInt(baseUrls.size)]
-    private fun pickPort(): Int = mockPorts[ThreadLocalRandom.current().nextInt(mockPorts.size)]
+    private lateinit var pingUrl: String
+    private lateinit var serverHost: String
+    private var serverPort: Int = 0
 
     // clients
     private lateinit var okhttpClient: OkHttpClient
@@ -100,13 +96,10 @@ open class HttpClientBenchmark {
     @Setup
     fun setup() {
         val n = Runtime.getRuntime().availableProcessors()
-        val sharedDispatcher = object: Dispatcher() {
-            override fun dispatch(request: RecordedRequest): MockResponse =
-                MockResponse().setResponseCode(200)
-        }
-        mockServers = List(n) { MockWebServer().apply { dispatcher = sharedDispatcher; start() } }
-        baseUrls = mockServers.map { it.url("/ping").toString() }
-        mockPorts = mockServers.map { it.port }.toIntArray()
+
+        pingUrl = "${server.url}/ping"
+        serverHost = server.host
+        serverPort = server.port
 
         okhttpClient = OkHttpClient.Builder()
             .connectionPool(ConnectionPool(n * 20, 5L, TimeUnit.MINUTES))
@@ -168,12 +161,11 @@ open class HttpClientBenchmark {
                 .build()
         )
 
-        // Optimized AHC: native transport + connection pool tuning via asyncHttpClient DSL
         ahcOptimizedClient = asyncHttpClient {
             setConnectTimeout(5_000)
             setRequestTimeout(5_000)
-            setMaxConnectionsPerHost(100)
-            setMaxConnections(200)
+            setMaxConnectionsPerHost(200)
+            setMaxConnections(500)
             setKeepAlive(true)
             setTcpNoDelay(true)
         }
@@ -201,12 +193,11 @@ open class HttpClientBenchmark {
         runCatching { okhttpClient.connectionPool.evictAll() }
         runCatching { okhttpVtClient.dispatcher.executorService.shutdown() }
         runCatching { okhttpVtClient.connectionPool.evictAll() }
-        mockServers.forEach { runCatching { it.shutdown() } }
     }
 
     @Benchmark
     fun okhttp3Sync(): Int {
-        val request = Request.Builder().url(pickUrl()).get().build()
+        val request = Request.Builder().url(pingUrl).get().build()
         okhttpClient.newCall(request).execute().use { response ->
             response.body.bytes()
             return response.code
@@ -214,53 +205,55 @@ open class HttpClientBenchmark {
     }
 
     @Benchmark
+    fun okhttp3VirtualThread(): Int {
+        val request = Request.Builder().url(pingUrl).get().build()
+        okhttpVtClient.newCall(request).execute().use { response ->
+            response.body.bytes()
+            return response.code
+        }
+    }
+
+    @Benchmark
     fun javaHttpSync(): Int {
-        val request = HttpRequest.newBuilder(URI.create(pickUrl())).GET().build()
+        val request = HttpRequest.newBuilder(URI.create(pingUrl)).GET().build()
         val response = jdkClient.send(request, HttpResponse.BodyHandlers.ofByteArray())
         return response.statusCode()
     }
 
     @Benchmark
     fun javaHttpVirtualThread(): Int {
-        val request = HttpRequest.newBuilder(URI.create(pickUrl())).GET().build()
+        val request = HttpRequest.newBuilder(URI.create(pingUrl)).GET().build()
         val response = jdkVirtualClient.send(request, HttpResponse.BodyHandlers.ofByteArray())
         return response.statusCode()
     }
 
     @Benchmark
     fun javaHttpH2Sync(): Int {
-        val request = HttpRequest.newBuilder()
-            .uri(URI.create(pickUrl()))
-            .GET()
-            .build()
+        val request = HttpRequest.newBuilder().uri(URI.create(pingUrl)).GET().build()
         val response = jdkH2Client.send(request, HttpResponse.BodyHandlers.ofString())
         return response.statusCode()
     }
 
     @Benchmark
     fun javaHttpH2VirtualThread(): Int {
-        val request = HttpRequest.newBuilder()
-            .uri(URI.create(pickUrl()))
-            .GET()
-            .build()
+        val request = HttpRequest.newBuilder().uri(URI.create(pingUrl)).GET().build()
         val response = jdkH2VirtualClient.send(request, HttpResponse.BodyHandlers.ofString())
         return response.statusCode()
     }
 
     @Benchmark
     fun hc5Classic(): Int {
-        val request = HttpGet(pickUrl())
+        val request = HttpGet(pingUrl)
         return hc5Classic.execute(request) { response ->
             EntityUtils.consume(response.entity)
             response.code
         }
     }
 
-    /** HC5 Classic 을 Coroutines IO Dispatcher 에서 실행 — 블로킹 코드의 코루틴 래핑 패턴 */
     @Benchmark
     fun hc5ClassicCoroutines(): Int = runBlocking {
         withContext(Dispatchers.IO) {
-            val request = HttpGet(pickUrl())
+            val request = HttpGet(pingUrl)
             hc5Classic.execute(request) { response ->
                 EntityUtils.consume(response.entity)
                 response.code
@@ -269,8 +262,17 @@ open class HttpClientBenchmark {
     }
 
     @Benchmark
+    fun hc5ClassicVirtualThread(): Int {
+        val request = HttpGet(pingUrl)
+        return hc5ClassicVt.execute(request) { response ->
+            EntityUtils.consume(response.entity)
+            response.code
+        }
+    }
+
+    @Benchmark
     fun hc5AsyncCoroutines(): Int = runBlocking(Dispatchers.Default) {
-        val request: SimpleHttpRequest = SimpleRequestBuilder.get(pickUrl()).build()
+        val request: SimpleHttpRequest = SimpleRequestBuilder.get(pingUrl).build()
         val response: SimpleHttpResponse = suspendCancellableCoroutine { cont ->
             val future = hc5Async.execute(
                 request,
@@ -288,7 +290,7 @@ open class HttpClientBenchmark {
     @Benchmark
     fun ahcCoroutines(): Int = runBlocking(Dispatchers.Default) {
         suspendCancellableCoroutine { cont ->
-            val future = ahcClient.prepareGet(pickUrl()).execute().toCompletableFuture()
+            val future = ahcClient.prepareGet(pingUrl).execute().toCompletableFuture()
             future.whenComplete { response, error ->
                 if (error != null) cont.resumeWithException(error)
                 else cont.resume(response.statusCode)
@@ -297,37 +299,22 @@ open class HttpClientBenchmark {
         }
     }
 
-    /** AHC + executeSuspending() + native transport + pool tuning */
     @Benchmark
     fun ahcOptimizedCoroutines(): Int = runBlocking(Dispatchers.Default) {
-        ahcOptimizedClient.prepareGet(pickUrl()).executeSuspending().statusCode
+        ahcOptimizedClient.prepareGet(pingUrl).executeSuspending().statusCode
     }
 
-    /** Vert.x WebClient + Coroutines — 이벤트 루프 기반 비동기 HTTP */
+    @Benchmark
+    fun ahcOptimizedCoroutinesUnconfined(): Int = runBlocking(Dispatchers.Unconfined) {
+        ahcOptimizedClient.prepareGet(pingUrl).executeSuspending().statusCode
+    }
+
     @Benchmark
     fun vertxWebClientCoroutines(): Int = runBlocking {
-        val response = vertxWebClient
-            .get(pickPort(), "localhost", "/ping")
+        vertxWebClient
+            .get(serverPort, serverHost, "/ping")
             .send()
             .coAwait()
-        response.statusCode()
-    }
-
-    @Benchmark
-    fun okhttp3VirtualThread(): Int {
-        val request = Request.Builder().url(pickUrl()).get().build()
-        okhttpVtClient.newCall(request).execute().use { response ->
-            response.body.bytes()
-            return response.code
-        }
-    }
-
-    @Benchmark
-    fun hc5ClassicVirtualThread(): Int {
-        val request = HttpGet(pickUrl())
-        return hc5ClassicVt.execute(request) { response ->
-            EntityUtils.consume(response.entity)
-            response.code
-        }
+            .statusCode()
     }
 }

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientCompressionCacheBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientCompressionCacheBenchmark.kt
@@ -145,6 +145,17 @@ open class HttpClientCompressionCacheBenchmark {
 
     @TearDown
     fun teardown() {
+        okhttpCachedClient.cache?.let { cache ->
+            println(
+                """
+                |=== OkHttp DiskLruCache Stats ===
+                | requestCount : ${cache.requestCount()}
+                | hitCount     : ${cache.hitCount()}
+                | networkCount : ${cache.networkCount()}
+                | hitRate      : ${"%.1f".format(cache.hitCount() * 100.0 / cache.requestCount().coerceAtLeast(1))}%
+                """.trimMargin()
+            )
+        }
         runCatching { okhttpClient.dispatcher.executorService.shutdown() }
         runCatching { okhttpClient.connectionPool.evictAll() }
         runCatching { okhttpCachedClient.dispatcher.executorService.shutdown() }

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientCompressionCacheBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientCompressionCacheBenchmark.kt
@@ -1,6 +1,9 @@
 package io.bluetape4k.http.benchmark
 
-import io.bluetape4k.http.hc5.cache.cachingHttpClient
+import com.github.tomakehurst.wiremock.client.WireMock
+import io.bluetape4k.http.hc5.cache.memoryCachingHttpClientOf
+import io.bluetape4k.http.hc5.classic.virtualThreadHttpClientOf
+import io.bluetape4k.testcontainers.http.WireMockServer
 import kotlinx.benchmark.Benchmark
 import kotlinx.benchmark.BenchmarkMode
 import kotlinx.benchmark.Measurement
@@ -11,16 +14,15 @@ import kotlinx.benchmark.State
 import kotlinx.benchmark.TearDown
 import kotlinx.benchmark.Warmup
 import okhttp3.Cache
+import okhttp3.ConnectionPool
+import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.mockwebserver.Dispatcher
-import okhttp3.mockwebserver.MockResponse
-import okhttp3.mockwebserver.MockWebServer
-import okhttp3.mockwebserver.RecordedRequest
 import okio.Buffer
 import org.apache.hc.client5.http.classic.methods.HttpGet
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
 import org.apache.hc.client5.http.impl.classic.HttpClients
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder
 import org.apache.hc.core5.http.io.entity.EntityUtils
 import org.openjdk.jmh.annotations.Threads
 import java.io.ByteArrayOutputStream
@@ -30,77 +32,105 @@ import java.util.concurrent.TimeUnit
 import java.util.zip.GZIPOutputStream
 
 /**
- * 압축(gzip) + 응답 캐싱 시나리오 벤치마크.
+ * gzip 압축 + HTTP 응답 캐시 영향도 벤치마크.
  *
- * 베이스라인 [HttpClientBenchmark] 는 4-byte "pong" 응답이므로 캐시/압축 효과가 측정 불가.
- * 본 벤치마크는 ~1KB JSON payload + `Content-Encoding: gzip` + `Cache-Control: max-age=3600`
- * 응답을 MockWebServer 가 반환하도록 하여, 다음 4개 방법을 비교한다.
+ * WireMock Docker 외부 서버에 10ms 지연 + `Cache-Control: public, max-age=3600` + gzip 응답을
+ * 설정하여, 실제 네트워크 왕복이 있는 상황에서 캐시 효과를 측정합니다.
  *
- * - [okhttp3NoCache] : 캐시 미사용 OkHttp3 클라이언트 (매 요청 네트워크 + gzip 해제)
- * - [okhttp3WithCache] : `okhttp3.Cache` 로컬 디스크 캐시 (두 번째 이후 cache hit)
- * - [hc5NoCache] : 캐시 미사용 Apache HC5 Classic
- * - [hc5WithCache] : Apache HC5 `CachingHttpClient` 메모리 캐시
+ * - **NoCache**: 요청마다 서버 왕복 + gzip 해제 → 지연 누적
+ * - **WithMemCache** (HC5 CachingHttpClient): 첫 요청 후 메모리에서 즉시 응답
+ * - **WithDiskCache** (OkHttp DiskLruCache): 첫 요청 후 디스크 캐시에서 응답
  *
- * @see io.bluetape4k.http.hc5.cache.cachingHttpClient
- * @see io.bluetape4k.http.okhttp3.CachingResponseInterceptor
+ * 이론값:
+ * - NoCache:  threads × (1000 / 10ms) = 8 × 100 = 800 ops/s
+ * - WithCache: 서버 왕복 없음 → 수만 ops/s (메모리/디스크 속도에 의존)
  */
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.Throughput)
-@Warmup(iterations = 1, time = 2, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 2, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
 @Threads(8)
 open class HttpClientCompressionCacheBenchmark {
 
-    private lateinit var mockServer: MockWebServer
-    private lateinit var baseUrl: String
+    companion object {
+        const val DELAY_MS = 10
+    }
+
+    private lateinit var wireMock: WireMockServer
+    private lateinit var dataUrl: String
 
     private lateinit var okhttpClient: OkHttpClient
     private lateinit var okhttpCachedClient: OkHttpClient
     private lateinit var hc5Client: CloseableHttpClient
+    private lateinit var hc5VtClient: CloseableHttpClient
     private lateinit var hc5CachedClient: CloseableHttpClient
-
     private lateinit var cacheDir: File
 
     @Setup
     fun setup() {
-        // ~1KB JSON payload
+        // ~1 KB JSON payload + gzip 압축
         val jsonBody = """{"data":"${"x".repeat(980)}"}"""
         val gzipBytes = gzip(jsonBody)
 
-        mockServer = MockWebServer().apply {
-            dispatcher = object: Dispatcher() {
-                override fun dispatch(request: RecordedRequest): MockResponse =
-                    MockResponse()
-                        .setResponseCode(200)
-                        .addHeader("Content-Type", "application/json")
-                        .addHeader("Content-Encoding", "gzip")
-                        .addHeader("Cache-Control", "public, max-age=3600")
-                        .setBody(Buffer().write(gzipBytes))
-            }
+        wireMock = WireMockServer().apply {
             start()
+            stubFor(
+                WireMock.get("/cached-data")
+                    .willReturn(
+                        WireMock.ok()
+                            .withHeader("Content-Type", "application/json")
+                            .withHeader("Content-Encoding", "gzip")
+                            .withHeader("Cache-Control", "public, max-age=3600")
+                            .withFixedDelay(DELAY_MS)
+                            .withBody(gzipBytes)
+                    )
+            )
         }
-        baseUrl = mockServer.url("/data").toString()
+        dataUrl = "${wireMock.url}/cached-data"
+
+        val connPerHost = 100
 
         okhttpClient = OkHttpClient.Builder()
+            .connectionPool(ConnectionPool(connPerHost, 5L, TimeUnit.MINUTES))
+            .dispatcher(Dispatcher().apply {
+                maxRequests = connPerHost
+                maxRequestsPerHost = connPerHost
+            })
             .connectTimeout(Duration.ofSeconds(5))
-            .readTimeout(Duration.ofSeconds(5))
+            .readTimeout(Duration.ofSeconds(10))
             .build()
 
         cacheDir = File(
             System.getProperty("java.io.tmpdir"),
-            "okhttp-cache-${System.nanoTime()}"
+            "okhttp-bench-cache-${System.nanoTime()}"
         ).apply { mkdirs() }
 
         okhttpCachedClient = OkHttpClient.Builder()
+            .connectionPool(ConnectionPool(connPerHost, 5L, TimeUnit.MINUTES))
+            .dispatcher(Dispatcher().apply {
+                maxRequests = connPerHost
+                maxRequestsPerHost = connPerHost
+            })
             .connectTimeout(Duration.ofSeconds(5))
-            .readTimeout(Duration.ofSeconds(5))
+            .readTimeout(Duration.ofSeconds(10))
             .cache(Cache(cacheDir, 50L * 1024 * 1024))
             .build()
 
-        hc5Client = HttpClients.createDefault()
+        hc5Client = HttpClients.custom()
+            .setConnectionManager(
+                PoolingHttpClientConnectionManagerBuilder.create()
+                    .setMaxConnTotal(connPerHost)
+                    .setMaxConnPerRoute(connPerHost)
+                    .build()
+            )
+            .build()
 
-        // Apache HC5 CachingHttpClient — in-memory cache (default when no storage specified)
-        hc5CachedClient = cachingHttpClient { }
+        hc5VtClient = virtualThreadHttpClientOf(
+            maxConnTotal = connPerHost,
+            maxConnPerRoute = connPerHost,
+        )
+
+        hc5CachedClient = memoryCachingHttpClientOf()
     }
 
     @TearDown
@@ -111,54 +141,57 @@ open class HttpClientCompressionCacheBenchmark {
         runCatching { okhttpCachedClient.connectionPool.evictAll() }
         runCatching { okhttpCachedClient.cache?.close() }
         runCatching { hc5Client.close() }
+        runCatching { hc5VtClient.close() }
         runCatching { hc5CachedClient.close() }
-        runCatching { mockServer.shutdown() }
+        runCatching { wireMock.resetAll() }
+        runCatching { wireMock.stop() }
         runCatching { cacheDir.deleteRecursively() }
     }
 
-    /**
-     * OkHttp3 캐시 미사용: 매 요청마다 네트워크 + gzip 해제.
-     * OkHttp3 는 자동으로 `Accept-Encoding: gzip` 을 붙이지 않는 경우 transparent gzip 해제를 수행.
-     */
+    /** OkHttp3: 캐시 없음 — 매 요청마다 서버 왕복 + gzip 해제 */
     @Benchmark
     fun okhttp3NoCache(): Int {
-        val request = Request.Builder().url(baseUrl).get().build()
+        val request = Request.Builder().url(dataUrl).get().build()
         okhttpClient.newCall(request).execute().use { response ->
             response.body.bytes()
             return response.code
         }
     }
 
-    /**
-     * OkHttp3 + DiskLruCache: 동일 URL 반복 요청 시 캐시 히트.
-     */
+    /** OkHttp3: DiskLruCache — 첫 요청 후 디스크 캐시 히트 */
     @Benchmark
-    fun okhttp3WithCache(): Int {
-        val request = Request.Builder().url(baseUrl).get().build()
+    fun okhttp3WithDiskCache(): Int {
+        val request = Request.Builder().url(dataUrl).get().build()
         okhttpCachedClient.newCall(request).execute().use { response ->
             response.body.bytes()
             return response.code
         }
     }
 
-    /**
-     * HC5 Classic 캐시 미사용.
-     */
+    /** HC5 Classic: 캐시 없음 — 매 요청마다 서버 왕복 */
     @Benchmark
-    fun hc5NoCache(): Int {
-        val request = HttpGet(baseUrl)
+    fun hc5ClassicNoCache(): Int {
+        val request = HttpGet(dataUrl)
         return hc5Client.execute(request) { response ->
             EntityUtils.consume(response.entity)
             response.code
         }
     }
 
-    /**
-     * HC5 CachingHttpClient: 동일 URL 반복 요청 시 캐시 히트.
-     */
+    /** HC5 Classic Virtual Thread: 캐시 없음 */
     @Benchmark
-    fun hc5WithCache(): Int {
-        val request = HttpGet(baseUrl)
+    fun hc5ClassicVtNoCache(): Int {
+        val request = HttpGet(dataUrl)
+        return hc5VtClient.execute(request) { response ->
+            EntityUtils.consume(response.entity)
+            response.code
+        }
+    }
+
+    /** HC5 CachingHttpClient: 인메모리 캐시 히트 */
+    @Benchmark
+    fun hc5ClassicWithMemCache(): Int {
+        val request = HttpGet(dataUrl)
         return hc5CachedClient.execute(request) { response ->
             EntityUtils.consume(response.entity)
             response.code

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientCompressionCacheBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientCompressionCacheBenchmark.kt
@@ -1,0 +1,173 @@
+package io.bluetape4k.http.benchmark
+
+import io.bluetape4k.http.hc5.cache.cachingHttpClient
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.TearDown
+import kotlinx.benchmark.Warmup
+import okhttp3.Cache
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import okio.Buffer
+import org.apache.hc.client5.http.classic.methods.HttpGet
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
+import org.apache.hc.client5.http.impl.classic.HttpClients
+import org.apache.hc.core5.http.io.entity.EntityUtils
+import org.openjdk.jmh.annotations.Threads
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import java.util.zip.GZIPOutputStream
+
+/**
+ * 압축(gzip) + 응답 캐싱 시나리오 벤치마크.
+ *
+ * 베이스라인 [HttpClientBenchmark] 는 4-byte "pong" 응답이므로 캐시/압축 효과가 측정 불가.
+ * 본 벤치마크는 ~1KB JSON payload + `Content-Encoding: gzip` + `Cache-Control: max-age=3600`
+ * 응답을 MockWebServer 가 반환하도록 하여, 다음 4개 방법을 비교한다.
+ *
+ * - [okhttp3NoCache] : 캐시 미사용 OkHttp3 클라이언트 (매 요청 네트워크 + gzip 해제)
+ * - [okhttp3WithCache] : `okhttp3.Cache` 로컬 디스크 캐시 (두 번째 이후 cache hit)
+ * - [hc5NoCache] : 캐시 미사용 Apache HC5 Classic
+ * - [hc5WithCache] : Apache HC5 `CachingHttpClient` 메모리 캐시
+ *
+ * @see io.bluetape4k.http.hc5.cache.cachingHttpClient
+ * @see io.bluetape4k.http.okhttp3.CachingResponseInterceptor
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 1, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Threads(8)
+open class HttpClientCompressionCacheBenchmark {
+
+    private lateinit var mockServer: MockWebServer
+    private lateinit var baseUrl: String
+
+    private lateinit var okhttpClient: OkHttpClient
+    private lateinit var okhttpCachedClient: OkHttpClient
+    private lateinit var hc5Client: CloseableHttpClient
+    private lateinit var hc5CachedClient: CloseableHttpClient
+
+    private lateinit var cacheDir: File
+
+    @Setup
+    fun setup() {
+        // ~1KB JSON payload
+        val jsonBody = """{"data":"${"x".repeat(980)}"}"""
+        val gzipBytes = gzip(jsonBody)
+
+        mockServer = MockWebServer().apply {
+            dispatcher = object: Dispatcher() {
+                override fun dispatch(request: RecordedRequest): MockResponse =
+                    MockResponse()
+                        .setResponseCode(200)
+                        .addHeader("Content-Type", "application/json")
+                        .addHeader("Content-Encoding", "gzip")
+                        .addHeader("Cache-Control", "public, max-age=3600")
+                        .setBody(Buffer().write(gzipBytes))
+            }
+            start()
+        }
+        baseUrl = mockServer.url("/data").toString()
+
+        okhttpClient = OkHttpClient.Builder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .readTimeout(Duration.ofSeconds(5))
+            .build()
+
+        cacheDir = File(
+            System.getProperty("java.io.tmpdir"),
+            "okhttp-cache-${System.nanoTime()}"
+        ).apply { mkdirs() }
+
+        okhttpCachedClient = OkHttpClient.Builder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .readTimeout(Duration.ofSeconds(5))
+            .cache(Cache(cacheDir, 50L * 1024 * 1024))
+            .build()
+
+        hc5Client = HttpClients.createDefault()
+
+        // Apache HC5 CachingHttpClient — in-memory cache (default when no storage specified)
+        hc5CachedClient = cachingHttpClient { }
+    }
+
+    @TearDown
+    fun teardown() {
+        runCatching { okhttpClient.dispatcher.executorService.shutdown() }
+        runCatching { okhttpClient.connectionPool.evictAll() }
+        runCatching { okhttpCachedClient.dispatcher.executorService.shutdown() }
+        runCatching { okhttpCachedClient.connectionPool.evictAll() }
+        runCatching { okhttpCachedClient.cache?.close() }
+        runCatching { hc5Client.close() }
+        runCatching { hc5CachedClient.close() }
+        runCatching { mockServer.shutdown() }
+        runCatching { cacheDir.deleteRecursively() }
+    }
+
+    /**
+     * OkHttp3 캐시 미사용: 매 요청마다 네트워크 + gzip 해제.
+     * OkHttp3 는 자동으로 `Accept-Encoding: gzip` 을 붙이지 않는 경우 transparent gzip 해제를 수행.
+     */
+    @Benchmark
+    fun okhttp3NoCache(): Int {
+        val request = Request.Builder().url(baseUrl).get().build()
+        okhttpClient.newCall(request).execute().use { response ->
+            response.body.bytes()
+            return response.code
+        }
+    }
+
+    /**
+     * OkHttp3 + DiskLruCache: 동일 URL 반복 요청 시 캐시 히트.
+     */
+    @Benchmark
+    fun okhttp3WithCache(): Int {
+        val request = Request.Builder().url(baseUrl).get().build()
+        okhttpCachedClient.newCall(request).execute().use { response ->
+            response.body.bytes()
+            return response.code
+        }
+    }
+
+    /**
+     * HC5 Classic 캐시 미사용.
+     */
+    @Benchmark
+    fun hc5NoCache(): Int {
+        val request = HttpGet(baseUrl)
+        return hc5Client.execute(request) { response ->
+            EntityUtils.consume(response.entity)
+            response.code
+        }
+    }
+
+    /**
+     * HC5 CachingHttpClient: 동일 URL 반복 요청 시 캐시 히트.
+     */
+    @Benchmark
+    fun hc5WithCache(): Int {
+        val request = HttpGet(baseUrl)
+        return hc5CachedClient.execute(request) { response ->
+            EntityUtils.consume(response.entity)
+            response.code
+        }
+    }
+}
+
+private fun gzip(text: String): ByteArray {
+    val baos = ByteArrayOutputStream()
+    GZIPOutputStream(baos).use { it.write(text.toByteArray(Charsets.UTF_8)) }
+    return baos.toByteArray()
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientCompressionCacheBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientCompressionCacheBenchmark.kt
@@ -2,6 +2,9 @@ package io.bluetape4k.http.benchmark
 
 import com.github.tomakehurst.wiremock.client.WireMock
 import io.bluetape4k.http.hc5.cache.memoryCachingHttpClientOf
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import io.bluetape4k.http.hc5.classic.virtualThreadHttpClientOf
 import io.bluetape4k.testcontainers.http.WireMockServer
 import kotlinx.benchmark.Benchmark
@@ -72,6 +75,10 @@ open class HttpClientCompressionCacheBenchmark {
         val jsonBody = """{"data":"${"x".repeat(980)}"}"""
         val gzipBytes = gzip(jsonBody)
 
+        val now = ZonedDateTime.now(ZoneId.of("UTC"))
+        val httpDate = now.format(DateTimeFormatter.RFC_1123_DATE_TIME)
+        val lastModified = now.minusDays(1).format(DateTimeFormatter.RFC_1123_DATE_TIME)
+
         wireMock = WireMockServer().apply {
             start()
             stubFor(
@@ -81,6 +88,9 @@ open class HttpClientCompressionCacheBenchmark {
                             .withHeader("Content-Type", "application/json")
                             .withHeader("Content-Encoding", "gzip")
                             .withHeader("Cache-Control", "public, max-age=3600")
+                            .withHeader("Date", httpDate)
+                            .withHeader("Last-Modified", lastModified)
+                            .withHeader("Vary", "Accept-Encoding")
                             .withFixedDelay(DELAY_MS)
                             .withBody(gzipBytes)
                     )

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientLatencyBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientLatencyBenchmark.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.http.benchmark
 import com.github.tomakehurst.wiremock.client.WireMock
 import io.bluetape4k.http.ahc.asyncHttpClient
 import io.bluetape4k.http.ahc.executeSuspending
+import io.bluetape4k.http.hc5.async.executeSuspending
 import io.bluetape4k.http.hc5.classic.virtualThreadHttpClientOf
 import io.bluetape4k.http.jdk.sendAwait
 import okhttp3.coroutines.executeAsync
@@ -23,21 +24,18 @@ import kotlinx.benchmark.TearDown
 import kotlinx.benchmark.Warmup
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import okhttp3.ConnectionPool
 import okhttp3.Dispatcher as OkHttpDispatcher
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest
-import org.apache.hc.client5.http.async.methods.SimpleHttpResponse
 import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder
 import org.apache.hc.client5.http.classic.methods.HttpGet
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients
 import org.apache.hc.client5.http.impl.classic.HttpClients
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder
 import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder
-import org.apache.hc.core5.concurrent.FutureCallback
 import org.apache.hc.core5.http.io.entity.EntityUtils
 import org.asynchttpclient.DefaultAsyncHttpClient
 import org.asynchttpclient.DefaultAsyncHttpClientConfig
@@ -50,8 +48,6 @@ import java.time.Duration
 import java.util.concurrent.Executors
 import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.TimeUnit
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
 /**
  * 고지연(~50 ms) 환경에서 동기 vs 비동기 HTTP 클라이언트 처리량 비교.
@@ -279,24 +275,13 @@ open class HttpClientLatencyBenchmark {
     }
 
     @Benchmark
-    fun hc5AsyncCoroutines(): Int = runBlocking(Dispatchers.Default) {
-        val request: SimpleHttpRequest = SimpleRequestBuilder.get(pickUrl()).build()
-        val response: SimpleHttpResponse = suspendCancellableCoroutine { cont ->
-            val future = hc5Async.execute(
-                request,
-                object: FutureCallback<SimpleHttpResponse> {
-                    override fun completed(result: SimpleHttpResponse) = cont.resume(result)
-                    override fun failed(ex: Exception) = cont.resumeWithException(ex)
-                    override fun cancelled() { cont.cancel() }
-                }
-            )
-            cont.invokeOnCancellation { future.cancel(true) }
-        }
-        response.code
+    fun hc5AsyncCoroutines(): Int = runBlocking(Dispatchers.IO) {
+        val request = SimpleRequestBuilder.get(pickUrl()).build()
+        hc5Async.executeSuspending(request).code
     }
 
     @Benchmark
-    fun ahcOptimizedCoroutines(): Int = runBlocking(Dispatchers.Default) {
+    fun ahcOptimizedCoroutines(): Int = runBlocking(Dispatchers.IO) {
         ahcOptimizedClient.prepareGet(pickUrl()).executeSuspending().statusCode
     }
 

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientLatencyBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientLatencyBenchmark.kt
@@ -1,14 +1,12 @@
 package io.bluetape4k.http.benchmark
 
-import com.github.tomakehurst.wiremock.client.WireMock
 import io.bluetape4k.http.ahc.asyncHttpClient
 import io.bluetape4k.http.ahc.executeSuspending
 import io.bluetape4k.http.hc5.async.executeSuspending
 import io.bluetape4k.http.hc5.classic.virtualThreadHttpClientOf
 import io.bluetape4k.http.jdk.sendAwait
-import okhttp3.coroutines.executeAsync
 import io.bluetape4k.http.okhttp3.okhttp3DispatcherWithVirtualThread
-import io.bluetape4k.testcontainers.http.WireMockServer
+import io.bluetape4k.testcontainers.http.BluetapeHttpServer
 import io.vertx.core.Vertx
 import io.vertx.ext.web.client.WebClient
 import io.vertx.ext.web.client.WebClientOptions
@@ -24,12 +22,11 @@ import kotlinx.benchmark.TearDown
 import kotlinx.benchmark.Warmup
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import okhttp3.ConnectionPool
 import okhttp3.Dispatcher as OkHttpDispatcher
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import org.apache.hc.client5.http.async.methods.SimpleHttpRequest
+import okhttp3.coroutines.executeAsync
 import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder
 import org.apache.hc.client5.http.classic.methods.HttpGet
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients
@@ -37,8 +34,6 @@ import org.apache.hc.client5.http.impl.classic.HttpClients
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder
 import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder
 import org.apache.hc.core5.http.io.entity.EntityUtils
-import org.asynchttpclient.DefaultAsyncHttpClient
-import org.asynchttpclient.DefaultAsyncHttpClientConfig
 import org.openjdk.jmh.annotations.Threads
 import java.net.URI
 import java.net.http.HttpClient
@@ -46,19 +41,16 @@ import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
 import java.util.concurrent.Executors
-import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.TimeUnit
 
 /**
  * 고지연(~50 ms) 환경에서 동기 vs 비동기 HTTP 클라이언트 처리량 비교.
  *
- * - WireMock Docker 서버 N개를 사용해 서버 병목을 제거합니다.
- * - [DELAY_MS] ms fixed delay stub으로 지연을 시뮬레이션합니다.
- * - @Threads(100) + 다수 서버로 진짜 고동시성 구간을 측정합니다.
+ * Docker 기반 [BluetapeHttpServer] 의 `/httpbin/delay/0.05` 엔드포인트를 사용해
+ * 서버 JVM 분리 + 50ms 지연을 시뮬레이션합니다.
  *
- * 동기 클라이언트 이론 상한: threads × (1000 / DELAY_MS) ops/s
- * 100 스레드 × 20 req/s = 2,000 ops/s (단일 서버 기준)
- * N 서버 시: N × 2,000 ops/s 까지 확장
+ * 동기 클라이언트 이론 상한: threads × (1000 / 50ms) = 2,000 ops/s
+ * 비동기는 스레드 블로킹 없이 더 높은 동시성 확보 가능.
  */
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.Throughput)
@@ -67,17 +59,11 @@ import java.util.concurrent.TimeUnit
 @Threads(100)
 open class HttpClientLatencyBenchmark {
 
-    companion object {
-        const val DELAY_MS = 50
-    }
+    private val server = BluetapeHttpServer.Launcher.bluetapeHttpServer
 
-    private lateinit var wireMocks: List<WireMockServer>
-    private lateinit var delayUrls: List<String>
-    private lateinit var serverHosts: List<String>
-    private lateinit var serverPorts: IntArray
-
-    private fun pickUrl(): String = delayUrls[ThreadLocalRandom.current().nextInt(delayUrls.size)]
-    private fun pickIdx(): Int = ThreadLocalRandom.current().nextInt(wireMocks.size)
+    private lateinit var delayUrl: String
+    private lateinit var serverHost: String
+    private var serverPort: Int = 0
 
     private lateinit var okhttpClient: OkHttpClient
     private lateinit var okhttpVtClient: OkHttpClient
@@ -92,27 +78,16 @@ open class HttpClientLatencyBenchmark {
 
     @Setup
     fun setup() {
-        // WireMock 서버 N개 — 서버 병목 제거
-        val n = minOf(Runtime.getRuntime().availableProcessors(), 4)
-        wireMocks = List(n) {
-            WireMockServer().apply {
-                start()
-                stubFor(
-                    WireMock.get("/delayed")
-                        .willReturn(WireMock.ok("pong").withFixedDelay(DELAY_MS))
-                )
-            }
-        }
-        delayUrls = wireMocks.map { "${it.url}/delayed" }
-        serverHosts = wireMocks.map { it.host }
-        serverPorts = wireMocks.map { it.port }.toIntArray()
+        delayUrl = "${server.url}/httpbin/delay/0.05"
+        serverHost = server.host
+        serverPort = server.port
 
         val connPerHost = 200
 
         okhttpClient = OkHttpClient.Builder()
-            .connectionPool(ConnectionPool(n * connPerHost, 5L, TimeUnit.MINUTES))
+            .connectionPool(ConnectionPool(connPerHost, 5L, TimeUnit.MINUTES))
             .dispatcher(OkHttpDispatcher().apply {
-                maxRequests = n * connPerHost
+                maxRequests = connPerHost
                 maxRequestsPerHost = connPerHost
             })
             .connectTimeout(Duration.ofSeconds(5))
@@ -120,9 +95,9 @@ open class HttpClientLatencyBenchmark {
             .build()
 
         okhttpVtClient = OkHttpClient.Builder()
-            .connectionPool(ConnectionPool(n * connPerHost, 5L, TimeUnit.MINUTES))
+            .connectionPool(ConnectionPool(connPerHost, 5L, TimeUnit.MINUTES))
             .dispatcher(okhttp3DispatcherWithVirtualThread().apply {
-                maxRequests = n * connPerHost
+                maxRequests = connPerHost
                 maxRequestsPerHost = connPerHost
             })
             .connectTimeout(Duration.ofSeconds(5))
@@ -141,21 +116,21 @@ open class HttpClientLatencyBenchmark {
         hc5Classic = HttpClients.custom()
             .setConnectionManager(
                 PoolingHttpClientConnectionManagerBuilder.create()
-                    .setMaxConnTotal(n * connPerHost)
+                    .setMaxConnTotal(connPerHost)
                     .setMaxConnPerRoute(connPerHost)
                     .build()
             )
             .build()
 
         hc5ClassicVt = virtualThreadHttpClientOf(
-            maxConnTotal = n * connPerHost,
+            maxConnTotal = connPerHost,
             maxConnPerRoute = connPerHost,
         )
 
         hc5Async = HttpAsyncClients.custom()
             .setConnectionManager(
                 PoolingAsyncClientConnectionManagerBuilder.create()
-                    .setMaxConnTotal(n * connPerHost)
+                    .setMaxConnTotal(connPerHost)
                     .setMaxConnPerRoute(connPerHost)
                     .build()
             )
@@ -166,7 +141,7 @@ open class HttpClientLatencyBenchmark {
             setConnectTimeout(5_000)
             setRequestTimeout(10_000)
             setMaxConnectionsPerHost(connPerHost)
-            setMaxConnections(n * connPerHost)
+            setMaxConnections(connPerHost)
             setKeepAlive(true)
             setTcpNoDelay(true)
         }
@@ -175,7 +150,7 @@ open class HttpClientLatencyBenchmark {
         vertxWebClient = WebClient.create(
             vertx,
             WebClientOptions()
-                .setMaxPoolSize(connPerHost)   // 기본값 5 → 200으로 확장
+                .setMaxPoolSize(connPerHost)
                 .setKeepAlive(true)
                 .setConnectTimeout(5_000)
                 .setIdleTimeout(10)
@@ -194,13 +169,11 @@ open class HttpClientLatencyBenchmark {
         runCatching { okhttpClient.connectionPool.evictAll() }
         runCatching { okhttpVtClient.dispatcher.executorService.shutdown() }
         runCatching { okhttpVtClient.connectionPool.evictAll() }
-        wireMocks.forEach { runCatching { it.resetAll() } }
-        wireMocks.forEach { runCatching { it.stop() } }
     }
 
     @Benchmark
     fun okhttp3Sync(): Int {
-        val request = Request.Builder().url(pickUrl()).get().build()
+        val request = Request.Builder().url(delayUrl).get().build()
         okhttpClient.newCall(request).execute().use { response ->
             response.body.bytes()
             return response.code
@@ -209,7 +182,7 @@ open class HttpClientLatencyBenchmark {
 
     @Benchmark
     fun okhttp3VirtualThread(): Int {
-        val request = Request.Builder().url(pickUrl()).get().build()
+        val request = Request.Builder().url(delayUrl).get().build()
         okhttpVtClient.newCall(request).execute().use { response ->
             response.body.bytes()
             return response.code
@@ -218,7 +191,7 @@ open class HttpClientLatencyBenchmark {
 
     @Benchmark
     fun okhttp3Coroutines(): Int = runBlocking(Dispatchers.IO) {
-        val request = Request.Builder().url(pickUrl()).get().build()
+        val request = Request.Builder().url(delayUrl).get().build()
         okhttpClient.newCall(request).executeAsync().use { response ->
             response.body.bytes()
             response.code
@@ -227,27 +200,27 @@ open class HttpClientLatencyBenchmark {
 
     @Benchmark
     fun javaHttpSync(): Int {
-        val request = HttpRequest.newBuilder(URI.create(pickUrl())).GET().build()
+        val request = HttpRequest.newBuilder(URI.create(delayUrl)).GET().build()
         return jdkClient.send(request, HttpResponse.BodyHandlers.ofByteArray()).statusCode()
     }
 
     @Benchmark
     fun javaHttpVirtualThread(): Int {
-        val request = HttpRequest.newBuilder(URI.create(pickUrl())).GET().build()
+        val request = HttpRequest.newBuilder(URI.create(delayUrl)).GET().build()
         return jdkVirtualClient.send(request, HttpResponse.BodyHandlers.ofByteArray()).statusCode()
     }
 
     @Benchmark
     fun javaHttpCoroutines(): Int = runBlocking(Dispatchers.IO) {
         jdkClient.sendAwait(
-            HttpRequest.newBuilder(URI.create(pickUrl())).GET().build(),
+            HttpRequest.newBuilder(URI.create(delayUrl)).GET().build(),
             HttpResponse.BodyHandlers.ofByteArray()
         ).statusCode()
     }
 
     @Benchmark
     fun hc5Classic(): Int {
-        val request = HttpGet(pickUrl())
+        val request = HttpGet(delayUrl)
         return hc5Classic.execute(request) { response ->
             EntityUtils.consume(response.entity)
             response.code
@@ -255,19 +228,17 @@ open class HttpClientLatencyBenchmark {
     }
 
     @Benchmark
-    fun hc5ClassicCoroutines(): Int = runBlocking {
-        withContext(Dispatchers.IO) {
-            val request = HttpGet(pickUrl())
-            hc5Classic.execute(request) { response ->
-                EntityUtils.consume(response.entity)
-                response.code
-            }
+    fun hc5ClassicCoroutines(): Int = runBlocking(Dispatchers.IO) {
+        val request = HttpGet(delayUrl)
+        hc5Classic.execute(request) { response ->
+            EntityUtils.consume(response.entity)
+            response.code
         }
     }
 
     @Benchmark
     fun hc5ClassicVirtualThread(): Int {
-        val request = HttpGet(pickUrl())
+        val request = HttpGet(delayUrl)
         return hc5ClassicVt.execute(request) { response ->
             EntityUtils.consume(response.entity)
             response.code
@@ -276,21 +247,19 @@ open class HttpClientLatencyBenchmark {
 
     @Benchmark
     fun hc5AsyncCoroutines(): Int = runBlocking(Dispatchers.IO) {
-        val request = SimpleRequestBuilder.get(pickUrl()).build()
+        val request = SimpleRequestBuilder.get(delayUrl).build()
         hc5Async.executeSuspending(request).code
     }
 
     @Benchmark
     fun ahcOptimizedCoroutines(): Int = runBlocking(Dispatchers.IO) {
-        ahcOptimizedClient.prepareGet(pickUrl()).executeSuspending().statusCode
+        ahcOptimizedClient.prepareGet(delayUrl).executeSuspending().statusCode
     }
 
-    /** Vert.x WebClient — getAbs()로 다중 서버 라운드로빈 */
     @Benchmark
     fun vertxWebClientCoroutines(): Int = runBlocking {
-        val idx = pickIdx()
         vertxWebClient
-            .get(serverPorts[idx], serverHosts[idx], "/delayed")
+            .get(serverPort, serverHost, "/httpbin/delay/0.05")
             .send()
             .coAwait()
             .statusCode()

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientLatencyBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientLatencyBenchmark.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.http.benchmark
 
 import com.github.tomakehurst.wiremock.client.WireMock
 import io.bluetape4k.http.ahc.asyncHttpClient
+import okhttp3.coroutines.executeAsync
 import io.bluetape4k.http.ahc.executeSuspending
 import io.bluetape4k.http.hc5.classic.virtualThreadHttpClientOf
 import io.bluetape4k.http.okhttp3.okhttp3DispatcherWithVirtualThread
@@ -220,18 +221,10 @@ open class HttpClientLatencyBenchmark {
 
     @Benchmark
     fun okhttp3Coroutines(): Int = runBlocking(Dispatchers.Default) {
-        suspendCancellableCoroutine { cont ->
-            val request = Request.Builder().url(pickUrl()).get().build()
-            val call = okhttpClient.newCall(request)
-            call.enqueue(object: okhttp3.Callback {
-                override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
-                    response.use { cont.resume(it.code) }
-                }
-                override fun onFailure(call: okhttp3.Call, e: java.io.IOException) {
-                    cont.resumeWithException(e)
-                }
-            })
-            cont.invokeOnCancellation { call.cancel() }
+        val request = Request.Builder().url(pickUrl()).get().build()
+        okhttpClient.newCall(request).executeAsync().use { response ->
+            response.body.bytes()
+            response.code
         }
     }
 

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientLatencyBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientLatencyBenchmark.kt
@@ -34,6 +34,7 @@ import org.apache.hc.client5.http.classic.methods.HttpGet
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients
 import org.apache.hc.client5.http.impl.classic.HttpClients
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder
 import org.apache.hc.core5.concurrent.FutureCallback
 import org.apache.hc.core5.http.io.entity.EntityUtils
 import org.asynchttpclient.DefaultAsyncHttpClient
@@ -45,43 +46,40 @@ import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
 import java.util.concurrent.Executors
+import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 /**
- * 고지연(40~100 ms) 환경에서 동기 vs 비동기 HTTP 클라이언트 처리량 비교.
+ * 고지연(~50 ms) 환경에서 동기 vs 비동기 HTTP 클라이언트 처리량 비교.
  *
- * WireMock Docker 서버의 `withFixedDelay(ms)` stub을 사용해
- * 서버측 지연을 정밀하게 시뮬레이션합니다.
+ * - WireMock Docker 서버 N개를 사용해 서버 병목을 제거합니다.
+ * - [DELAY_MS] ms fixed delay stub으로 지연을 시뮬레이션합니다.
+ * - @Threads(100) + 다수 서버로 진짜 고동시성 구간을 측정합니다.
  *
- * 핵심 가설: 지연이 커질수록 동기 블로킹 클라이언트는 스레드를 점유해
- * 처리량이 제한되고, 비동기 + 코루틴 클라이언트가 역전을 일으킬 수 있다.
- *
- * 측정 조건:
- * - 서버 응답 지연: [DELAY_MS] ms (WireMock fixed delay)
- * - JMH 스레드: [THREAD_COUNT]
- * - 예상 동기 상한: THREAD_COUNT × (1000 / DELAY_MS) ops/s
+ * 동기 클라이언트 이론 상한: threads × (1000 / DELAY_MS) ops/s
+ * 100 스레드 × 20 req/s = 2,000 ops/s (단일 서버 기준)
+ * N 서버 시: N × 2,000 ops/s 까지 확장
  */
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 1, time = 3, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
-@Threads(50)
+@Threads(100)
 open class HttpClientLatencyBenchmark {
 
     companion object {
-        /** 서버 응답 지연 (밀리초). 40~100 사이에서 조정 */
         const val DELAY_MS = 50
-        /** JMH 스레드 수. 동기 클라이언트의 이론적 상한 = 50 × (1000/DELAY_MS) = 1000 ops/s */
-        const val THREAD_COUNT = 50
     }
 
-    private val wireMock = WireMockServer.Launcher.wireMock
+    private lateinit var wireMocks: List<WireMockServer>
+    private lateinit var delayUrls: List<String>
+    private lateinit var serverHosts: List<String>
+    private lateinit var serverPorts: IntArray
 
-    private lateinit var delayUrl: String
-    private lateinit var serverHost: String
-    private var serverPort: Int = 0
+    private fun pickUrl(): String = delayUrls[ThreadLocalRandom.current().nextInt(delayUrls.size)]
+    private fun pickIdx(): Int = ThreadLocalRandom.current().nextInt(wireMocks.size)
 
     private lateinit var okhttpClient: OkHttpClient
     private lateinit var okhttpVtClient: OkHttpClient
@@ -96,36 +94,38 @@ open class HttpClientLatencyBenchmark {
 
     @Setup
     fun setup() {
-        val n = Runtime.getRuntime().availableProcessors()
-
-        // 고정 지연 stub 등록: GET /delayed → 200 after DELAY_MS ms
-        wireMock.stubFor(
-            WireMock.get("/delayed")
-                .willReturn(
-                    WireMock.ok("pong")
-                        .withFixedDelay(DELAY_MS)
+        // WireMock 서버 N개 — 서버 병목 제거
+        val n = minOf(Runtime.getRuntime().availableProcessors(), 4)
+        wireMocks = List(n) {
+            WireMockServer().apply {
+                start()
+                stubFor(
+                    WireMock.get("/delayed")
+                        .willReturn(WireMock.ok("pong").withFixedDelay(DELAY_MS))
                 )
-        )
+            }
+        }
+        delayUrls = wireMocks.map { "${it.url}/delayed" }
+        serverHosts = wireMocks.map { it.host }
+        serverPorts = wireMocks.map { it.port }.toIntArray()
 
-        serverHost = wireMock.host
-        serverPort = wireMock.port
-        delayUrl = "${wireMock.url}/delayed"
+        val connPerHost = 200
 
         okhttpClient = OkHttpClient.Builder()
-            .connectionPool(ConnectionPool(THREAD_COUNT * 2, 5L, TimeUnit.MINUTES))
+            .connectionPool(ConnectionPool(n * connPerHost, 5L, TimeUnit.MINUTES))
             .dispatcher(OkHttpDispatcher().apply {
-                maxRequests = THREAD_COUNT * 2
-                maxRequestsPerHost = THREAD_COUNT * 2
+                maxRequests = n * connPerHost
+                maxRequestsPerHost = connPerHost
             })
             .connectTimeout(Duration.ofSeconds(5))
             .readTimeout(Duration.ofSeconds(10))
             .build()
 
         okhttpVtClient = OkHttpClient.Builder()
-            .connectionPool(ConnectionPool(THREAD_COUNT * 2, 5L, TimeUnit.MINUTES))
+            .connectionPool(ConnectionPool(n * connPerHost, 5L, TimeUnit.MINUTES))
             .dispatcher(okhttp3DispatcherWithVirtualThread().apply {
-                maxRequests = THREAD_COUNT * 2
-                maxRequestsPerHost = THREAD_COUNT * 2
+                maxRequests = n * connPerHost
+                maxRequestsPerHost = connPerHost
             })
             .connectTimeout(Duration.ofSeconds(5))
             .readTimeout(Duration.ofSeconds(10))
@@ -143,22 +143,22 @@ open class HttpClientLatencyBenchmark {
         hc5Classic = HttpClients.custom()
             .setConnectionManager(
                 PoolingHttpClientConnectionManagerBuilder.create()
-                    .setMaxConnTotal(THREAD_COUNT * 2)
-                    .setMaxConnPerRoute(THREAD_COUNT * 2)
+                    .setMaxConnTotal(n * connPerHost)
+                    .setMaxConnPerRoute(connPerHost)
                     .build()
             )
             .build()
 
         hc5ClassicVt = virtualThreadHttpClientOf(
-            maxConnTotal = THREAD_COUNT * 2,
-            maxConnPerRoute = THREAD_COUNT * 2,
+            maxConnTotal = n * connPerHost,
+            maxConnPerRoute = connPerHost,
         )
 
         hc5Async = HttpAsyncClients.custom()
             .setConnectionManager(
-                org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder.create()
-                    .setMaxConnTotal(THREAD_COUNT * 2)
-                    .setMaxConnPerRoute(THREAD_COUNT * 2)
+                PoolingAsyncClientConnectionManagerBuilder.create()
+                    .setMaxConnTotal(n * connPerHost)
+                    .setMaxConnPerRoute(connPerHost)
                     .build()
             )
             .build()
@@ -167,8 +167,8 @@ open class HttpClientLatencyBenchmark {
         ahcOptimizedClient = asyncHttpClient {
             setConnectTimeout(5_000)
             setRequestTimeout(10_000)
-            setMaxConnectionsPerHost(THREAD_COUNT * 2)
-            setMaxConnections(THREAD_COUNT * 4)
+            setMaxConnectionsPerHost(connPerHost)
+            setMaxConnections(n * connPerHost)
             setKeepAlive(true)
             setTcpNoDelay(true)
         }
@@ -177,6 +177,7 @@ open class HttpClientLatencyBenchmark {
         vertxWebClient = WebClient.create(
             vertx,
             WebClientOptions()
+                .setMaxPoolSize(connPerHost)   // 기본값 5 → 200으로 확장
                 .setKeepAlive(true)
                 .setConnectTimeout(5_000)
                 .setIdleTimeout(10)
@@ -195,12 +196,13 @@ open class HttpClientLatencyBenchmark {
         runCatching { okhttpClient.connectionPool.evictAll() }
         runCatching { okhttpVtClient.dispatcher.executorService.shutdown() }
         runCatching { okhttpVtClient.connectionPool.evictAll() }
-        wireMock.resetAll()
+        wireMocks.forEach { runCatching { it.resetAll() } }
+        wireMocks.forEach { runCatching { it.stop() } }
     }
 
     @Benchmark
     fun okhttp3Sync(): Int {
-        val request = Request.Builder().url(delayUrl).get().build()
+        val request = Request.Builder().url(pickUrl()).get().build()
         okhttpClient.newCall(request).execute().use { response ->
             response.body.bytes()
             return response.code
@@ -209,7 +211,7 @@ open class HttpClientLatencyBenchmark {
 
     @Benchmark
     fun okhttp3VirtualThread(): Int {
-        val request = Request.Builder().url(delayUrl).get().build()
+        val request = Request.Builder().url(pickUrl()).get().build()
         okhttpVtClient.newCall(request).execute().use { response ->
             response.body.bytes()
             return response.code
@@ -217,20 +219,37 @@ open class HttpClientLatencyBenchmark {
     }
 
     @Benchmark
+    fun okhttp3Coroutines(): Int = runBlocking(Dispatchers.Default) {
+        suspendCancellableCoroutine { cont ->
+            val request = Request.Builder().url(pickUrl()).get().build()
+            val call = okhttpClient.newCall(request)
+            call.enqueue(object: okhttp3.Callback {
+                override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
+                    response.use { cont.resume(it.code) }
+                }
+                override fun onFailure(call: okhttp3.Call, e: java.io.IOException) {
+                    cont.resumeWithException(e)
+                }
+            })
+            cont.invokeOnCancellation { call.cancel() }
+        }
+    }
+
+    @Benchmark
     fun javaHttpSync(): Int {
-        val request = HttpRequest.newBuilder(URI.create(delayUrl)).GET().build()
+        val request = HttpRequest.newBuilder(URI.create(pickUrl())).GET().build()
         return jdkClient.send(request, HttpResponse.BodyHandlers.ofByteArray()).statusCode()
     }
 
     @Benchmark
     fun javaHttpVirtualThread(): Int {
-        val request = HttpRequest.newBuilder(URI.create(delayUrl)).GET().build()
+        val request = HttpRequest.newBuilder(URI.create(pickUrl())).GET().build()
         return jdkVirtualClient.send(request, HttpResponse.BodyHandlers.ofByteArray()).statusCode()
     }
 
     @Benchmark
     fun hc5Classic(): Int {
-        val request = HttpGet(delayUrl)
+        val request = HttpGet(pickUrl())
         return hc5Classic.execute(request) { response ->
             EntityUtils.consume(response.entity)
             response.code
@@ -240,7 +259,7 @@ open class HttpClientLatencyBenchmark {
     @Benchmark
     fun hc5ClassicCoroutines(): Int = runBlocking {
         withContext(Dispatchers.IO) {
-            val request = HttpGet(delayUrl)
+            val request = HttpGet(pickUrl())
             hc5Classic.execute(request) { response ->
                 EntityUtils.consume(response.entity)
                 response.code
@@ -250,7 +269,7 @@ open class HttpClientLatencyBenchmark {
 
     @Benchmark
     fun hc5ClassicVirtualThread(): Int {
-        val request = HttpGet(delayUrl)
+        val request = HttpGet(pickUrl())
         return hc5ClassicVt.execute(request) { response ->
             EntityUtils.consume(response.entity)
             response.code
@@ -259,7 +278,7 @@ open class HttpClientLatencyBenchmark {
 
     @Benchmark
     fun hc5AsyncCoroutines(): Int = runBlocking(Dispatchers.Default) {
-        val request: SimpleHttpRequest = SimpleRequestBuilder.get(delayUrl).build()
+        val request: SimpleHttpRequest = SimpleRequestBuilder.get(pickUrl()).build()
         val response: SimpleHttpResponse = suspendCancellableCoroutine { cont ->
             val future = hc5Async.execute(
                 request,
@@ -276,18 +295,20 @@ open class HttpClientLatencyBenchmark {
 
     @Benchmark
     fun ahcOptimizedCoroutines(): Int = runBlocking(Dispatchers.Default) {
-        ahcOptimizedClient.prepareGet(delayUrl).executeSuspending().statusCode
+        ahcOptimizedClient.prepareGet(pickUrl()).executeSuspending().statusCode
     }
 
     @Benchmark
     fun ahcOptimizedCoroutinesUnconfined(): Int = runBlocking(Dispatchers.Unconfined) {
-        ahcOptimizedClient.prepareGet(delayUrl).executeSuspending().statusCode
+        ahcOptimizedClient.prepareGet(pickUrl()).executeSuspending().statusCode
     }
 
+    /** Vert.x WebClient — getAbs()로 다중 서버 라운드로빈 */
     @Benchmark
     fun vertxWebClientCoroutines(): Int = runBlocking {
+        val idx = pickIdx()
         vertxWebClient
-            .get(serverPort, serverHost, "/delayed")
+            .get(serverPorts[idx], serverHosts[idx], "/delayed")
             .send()
             .coAwait()
             .statusCode()

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientLatencyBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientLatencyBenchmark.kt
@@ -2,9 +2,10 @@ package io.bluetape4k.http.benchmark
 
 import com.github.tomakehurst.wiremock.client.WireMock
 import io.bluetape4k.http.ahc.asyncHttpClient
-import okhttp3.coroutines.executeAsync
 import io.bluetape4k.http.ahc.executeSuspending
 import io.bluetape4k.http.hc5.classic.virtualThreadHttpClientOf
+import io.bluetape4k.http.jdk.sendAwait
+import okhttp3.coroutines.executeAsync
 import io.bluetape4k.http.okhttp3.okhttp3DispatcherWithVirtualThread
 import io.bluetape4k.testcontainers.http.WireMockServer
 import io.vertx.core.Vertx
@@ -220,7 +221,7 @@ open class HttpClientLatencyBenchmark {
     }
 
     @Benchmark
-    fun okhttp3Coroutines(): Int = runBlocking(Dispatchers.Default) {
+    fun okhttp3Coroutines(): Int = runBlocking(Dispatchers.IO) {
         val request = Request.Builder().url(pickUrl()).get().build()
         okhttpClient.newCall(request).executeAsync().use { response ->
             response.body.bytes()
@@ -238,6 +239,14 @@ open class HttpClientLatencyBenchmark {
     fun javaHttpVirtualThread(): Int {
         val request = HttpRequest.newBuilder(URI.create(pickUrl())).GET().build()
         return jdkVirtualClient.send(request, HttpResponse.BodyHandlers.ofByteArray()).statusCode()
+    }
+
+    @Benchmark
+    fun javaHttpCoroutines(): Int = runBlocking(Dispatchers.IO) {
+        jdkClient.sendAwait(
+            HttpRequest.newBuilder(URI.create(pickUrl())).GET().build(),
+            HttpResponse.BodyHandlers.ofByteArray()
+        ).statusCode()
     }
 
     @Benchmark
@@ -288,11 +297,6 @@ open class HttpClientLatencyBenchmark {
 
     @Benchmark
     fun ahcOptimizedCoroutines(): Int = runBlocking(Dispatchers.Default) {
-        ahcOptimizedClient.prepareGet(pickUrl()).executeSuspending().statusCode
-    }
-
-    @Benchmark
-    fun ahcOptimizedCoroutinesUnconfined(): Int = runBlocking(Dispatchers.Unconfined) {
         ahcOptimizedClient.prepareGet(pickUrl()).executeSuspending().statusCode
     }
 

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientLatencyBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientLatencyBenchmark.kt
@@ -1,0 +1,295 @@
+package io.bluetape4k.http.benchmark
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import io.bluetape4k.http.ahc.asyncHttpClient
+import io.bluetape4k.http.ahc.executeSuspending
+import io.bluetape4k.http.hc5.classic.virtualThreadHttpClientOf
+import io.bluetape4k.http.okhttp3.okhttp3DispatcherWithVirtualThread
+import io.bluetape4k.testcontainers.http.WireMockServer
+import io.vertx.core.Vertx
+import io.vertx.ext.web.client.WebClient
+import io.vertx.ext.web.client.WebClientOptions
+import io.vertx.kotlin.coroutines.coAwait
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.TearDown
+import kotlinx.benchmark.Warmup
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import okhttp3.ConnectionPool
+import okhttp3.Dispatcher as OkHttpDispatcher
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse
+import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder
+import org.apache.hc.client5.http.classic.methods.HttpGet
+import org.apache.hc.client5.http.impl.async.HttpAsyncClients
+import org.apache.hc.client5.http.impl.classic.HttpClients
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder
+import org.apache.hc.core5.concurrent.FutureCallback
+import org.apache.hc.core5.http.io.entity.EntityUtils
+import org.asynchttpclient.DefaultAsyncHttpClient
+import org.asynchttpclient.DefaultAsyncHttpClientConfig
+import org.openjdk.jmh.annotations.Threads
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * 고지연(40~100 ms) 환경에서 동기 vs 비동기 HTTP 클라이언트 처리량 비교.
+ *
+ * WireMock Docker 서버의 `withFixedDelay(ms)` stub을 사용해
+ * 서버측 지연을 정밀하게 시뮬레이션합니다.
+ *
+ * 핵심 가설: 지연이 커질수록 동기 블로킹 클라이언트는 스레드를 점유해
+ * 처리량이 제한되고, 비동기 + 코루틴 클라이언트가 역전을 일으킬 수 있다.
+ *
+ * 측정 조건:
+ * - 서버 응답 지연: [DELAY_MS] ms (WireMock fixed delay)
+ * - JMH 스레드: [THREAD_COUNT]
+ * - 예상 동기 상한: THREAD_COUNT × (1000 / DELAY_MS) ops/s
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 1, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@Threads(50)
+open class HttpClientLatencyBenchmark {
+
+    companion object {
+        /** 서버 응답 지연 (밀리초). 40~100 사이에서 조정 */
+        const val DELAY_MS = 50
+        /** JMH 스레드 수. 동기 클라이언트의 이론적 상한 = 50 × (1000/DELAY_MS) = 1000 ops/s */
+        const val THREAD_COUNT = 50
+    }
+
+    private val wireMock = WireMockServer.Launcher.wireMock
+
+    private lateinit var delayUrl: String
+    private lateinit var serverHost: String
+    private var serverPort: Int = 0
+
+    private lateinit var okhttpClient: OkHttpClient
+    private lateinit var okhttpVtClient: OkHttpClient
+    private lateinit var jdkClient: HttpClient
+    private lateinit var jdkVirtualClient: HttpClient
+    private lateinit var hc5Classic: org.apache.hc.client5.http.impl.classic.CloseableHttpClient
+    private lateinit var hc5ClassicVt: org.apache.hc.client5.http.impl.classic.CloseableHttpClient
+    private lateinit var hc5Async: org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient
+    private lateinit var ahcOptimizedClient: org.asynchttpclient.AsyncHttpClient
+    private lateinit var vertx: Vertx
+    private lateinit var vertxWebClient: WebClient
+
+    @Setup
+    fun setup() {
+        val n = Runtime.getRuntime().availableProcessors()
+
+        // 고정 지연 stub 등록: GET /delayed → 200 after DELAY_MS ms
+        wireMock.stubFor(
+            WireMock.get("/delayed")
+                .willReturn(
+                    WireMock.ok("pong")
+                        .withFixedDelay(DELAY_MS)
+                )
+        )
+
+        serverHost = wireMock.host
+        serverPort = wireMock.port
+        delayUrl = "${wireMock.url}/delayed"
+
+        okhttpClient = OkHttpClient.Builder()
+            .connectionPool(ConnectionPool(THREAD_COUNT * 2, 5L, TimeUnit.MINUTES))
+            .dispatcher(OkHttpDispatcher().apply {
+                maxRequests = THREAD_COUNT * 2
+                maxRequestsPerHost = THREAD_COUNT * 2
+            })
+            .connectTimeout(Duration.ofSeconds(5))
+            .readTimeout(Duration.ofSeconds(10))
+            .build()
+
+        okhttpVtClient = OkHttpClient.Builder()
+            .connectionPool(ConnectionPool(THREAD_COUNT * 2, 5L, TimeUnit.MINUTES))
+            .dispatcher(okhttp3DispatcherWithVirtualThread().apply {
+                maxRequests = THREAD_COUNT * 2
+                maxRequestsPerHost = THREAD_COUNT * 2
+            })
+            .connectTimeout(Duration.ofSeconds(5))
+            .readTimeout(Duration.ofSeconds(10))
+            .build()
+
+        jdkClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build()
+
+        jdkVirtualClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .executor(Executors.newVirtualThreadPerTaskExecutor())
+            .build()
+
+        hc5Classic = HttpClients.custom()
+            .setConnectionManager(
+                PoolingHttpClientConnectionManagerBuilder.create()
+                    .setMaxConnTotal(THREAD_COUNT * 2)
+                    .setMaxConnPerRoute(THREAD_COUNT * 2)
+                    .build()
+            )
+            .build()
+
+        hc5ClassicVt = virtualThreadHttpClientOf(
+            maxConnTotal = THREAD_COUNT * 2,
+            maxConnPerRoute = THREAD_COUNT * 2,
+        )
+
+        hc5Async = HttpAsyncClients.custom()
+            .setConnectionManager(
+                org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder.create()
+                    .setMaxConnTotal(THREAD_COUNT * 2)
+                    .setMaxConnPerRoute(THREAD_COUNT * 2)
+                    .build()
+            )
+            .build()
+            .also { it.start() }
+
+        ahcOptimizedClient = asyncHttpClient {
+            setConnectTimeout(5_000)
+            setRequestTimeout(10_000)
+            setMaxConnectionsPerHost(THREAD_COUNT * 2)
+            setMaxConnections(THREAD_COUNT * 4)
+            setKeepAlive(true)
+            setTcpNoDelay(true)
+        }
+
+        vertx = Vertx.vertx()
+        vertxWebClient = WebClient.create(
+            vertx,
+            WebClientOptions()
+                .setKeepAlive(true)
+                .setConnectTimeout(5_000)
+                .setIdleTimeout(10)
+        )
+    }
+
+    @TearDown
+    fun teardown() {
+        runCatching { vertxWebClient.close() }
+        runCatching { runBlocking { vertx.close().coAwait() } }
+        runCatching { ahcOptimizedClient.close() }
+        runCatching { hc5Async.close() }
+        runCatching { hc5Classic.close() }
+        runCatching { hc5ClassicVt.close() }
+        runCatching { okhttpClient.dispatcher.executorService.shutdown() }
+        runCatching { okhttpClient.connectionPool.evictAll() }
+        runCatching { okhttpVtClient.dispatcher.executorService.shutdown() }
+        runCatching { okhttpVtClient.connectionPool.evictAll() }
+        wireMock.resetAll()
+    }
+
+    @Benchmark
+    fun okhttp3Sync(): Int {
+        val request = Request.Builder().url(delayUrl).get().build()
+        okhttpClient.newCall(request).execute().use { response ->
+            response.body.bytes()
+            return response.code
+        }
+    }
+
+    @Benchmark
+    fun okhttp3VirtualThread(): Int {
+        val request = Request.Builder().url(delayUrl).get().build()
+        okhttpVtClient.newCall(request).execute().use { response ->
+            response.body.bytes()
+            return response.code
+        }
+    }
+
+    @Benchmark
+    fun javaHttpSync(): Int {
+        val request = HttpRequest.newBuilder(URI.create(delayUrl)).GET().build()
+        return jdkClient.send(request, HttpResponse.BodyHandlers.ofByteArray()).statusCode()
+    }
+
+    @Benchmark
+    fun javaHttpVirtualThread(): Int {
+        val request = HttpRequest.newBuilder(URI.create(delayUrl)).GET().build()
+        return jdkVirtualClient.send(request, HttpResponse.BodyHandlers.ofByteArray()).statusCode()
+    }
+
+    @Benchmark
+    fun hc5Classic(): Int {
+        val request = HttpGet(delayUrl)
+        return hc5Classic.execute(request) { response ->
+            EntityUtils.consume(response.entity)
+            response.code
+        }
+    }
+
+    @Benchmark
+    fun hc5ClassicCoroutines(): Int = runBlocking {
+        withContext(Dispatchers.IO) {
+            val request = HttpGet(delayUrl)
+            hc5Classic.execute(request) { response ->
+                EntityUtils.consume(response.entity)
+                response.code
+            }
+        }
+    }
+
+    @Benchmark
+    fun hc5ClassicVirtualThread(): Int {
+        val request = HttpGet(delayUrl)
+        return hc5ClassicVt.execute(request) { response ->
+            EntityUtils.consume(response.entity)
+            response.code
+        }
+    }
+
+    @Benchmark
+    fun hc5AsyncCoroutines(): Int = runBlocking(Dispatchers.Default) {
+        val request: SimpleHttpRequest = SimpleRequestBuilder.get(delayUrl).build()
+        val response: SimpleHttpResponse = suspendCancellableCoroutine { cont ->
+            val future = hc5Async.execute(
+                request,
+                object: FutureCallback<SimpleHttpResponse> {
+                    override fun completed(result: SimpleHttpResponse) = cont.resume(result)
+                    override fun failed(ex: Exception) = cont.resumeWithException(ex)
+                    override fun cancelled() { cont.cancel() }
+                }
+            )
+            cont.invokeOnCancellation { future.cancel(true) }
+        }
+        response.code
+    }
+
+    @Benchmark
+    fun ahcOptimizedCoroutines(): Int = runBlocking(Dispatchers.Default) {
+        ahcOptimizedClient.prepareGet(delayUrl).executeSuspending().statusCode
+    }
+
+    @Benchmark
+    fun ahcOptimizedCoroutinesUnconfined(): Int = runBlocking(Dispatchers.Unconfined) {
+        ahcOptimizedClient.prepareGet(delayUrl).executeSuspending().statusCode
+    }
+
+    @Benchmark
+    fun vertxWebClientCoroutines(): Int = runBlocking {
+        vertxWebClient
+            .get(serverPort, serverHost, "/delayed")
+            .send()
+            .coAwait()
+            .statusCode()
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/okhttp3/OkHttpDiskCacheVerificationTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/okhttp3/OkHttpDiskCacheVerificationTest.kt
@@ -1,0 +1,151 @@
+package io.bluetape4k.http.okhttp3
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.bluetape4k.testcontainers.http.WireMockServer
+import okhttp3.Cache
+import okhttp3.ConnectionPool
+import okhttp3.Dispatcher
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.time.Duration
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.TimeUnit
+import java.util.zip.GZIPOutputStream
+
+/**
+ * OkHttp DiskLruCache 가 실제로 캐시 히트를 반환하는지 검증.
+ *
+ * 35K ops/s 의심 원인 분석:
+ * - "Disk" 캐시지만 1KB 파일은 워밍업 후 OS 페이지 캐시(RAM)에 올라감
+ * - 네트워크 왕복(10ms) 제거가 핵심 → no-cache 660 ops/s → disk cache 35K ops/s (53배)
+ * - DiskLruCache synchronized + journal write 오버헤드로 HC5 MemCache(813K)보다 23배 느림
+ */
+class OkHttpDiskCacheVerificationTest {
+
+    companion object : KLogging()
+
+    private lateinit var wireMock: WireMockServer
+    private lateinit var cacheDir: File
+    private lateinit var client: OkHttpClient
+    private lateinit var dataUrl: String
+
+    @BeforeEach
+    fun setup() {
+        val jsonBody = """{"data":"${"x".repeat(980)}"}"""
+        val gzipBytes = gzip(jsonBody)
+
+        val now = ZonedDateTime.now(ZoneId.of("UTC"))
+        val httpDate = now.format(DateTimeFormatter.RFC_1123_DATE_TIME)
+        val lastModified = now.minusDays(1).format(DateTimeFormatter.RFC_1123_DATE_TIME)
+
+        wireMock = WireMockServer().apply {
+            start()
+            stubFor(
+                WireMock.get("/cached-data")
+                    .willReturn(
+                        WireMock.ok()
+                            .withHeader("Content-Type", "application/json")
+                            .withHeader("Content-Encoding", "gzip")
+                            .withHeader("Cache-Control", "public, max-age=3600")
+                            .withHeader("Date", httpDate)
+                            .withHeader("Last-Modified", lastModified)
+                            .withHeader("Vary", "Accept-Encoding")
+                            .withFixedDelay(10)
+                            .withBody(gzipBytes)
+                    )
+            )
+        }
+        dataUrl = "${wireMock.url}/cached-data"
+
+        cacheDir = File(System.getProperty("java.io.tmpdir"), "okhttp-verify-${System.nanoTime()}").apply { mkdirs() }
+        client = OkHttpClient.Builder()
+            .connectionPool(ConnectionPool(10, 5L, TimeUnit.MINUTES))
+            .dispatcher(Dispatcher().apply { maxRequests = 50; maxRequestsPerHost = 50 })
+            .connectTimeout(Duration.ofSeconds(5))
+            .readTimeout(Duration.ofSeconds(10))
+            .cache(Cache(cacheDir, 50L * 1024 * 1024))
+            .build()
+    }
+
+    @AfterEach
+    fun teardown() {
+        val cache = client.cache
+        if (cache != null) {
+            log.info {
+                """
+                |=== OkHttp DiskLruCache Stats ===
+                | requestCount : ${cache.requestCount()}
+                | hitCount     : ${cache.hitCount()}
+                | networkCount : ${cache.networkCount()}
+                | hitRate      : ${"%.1f".format(cache.hitCount() * 100.0 / cache.requestCount().coerceAtLeast(1))}%
+                """.trimMargin()
+            }
+        }
+        runCatching { client.dispatcher.executorService.shutdown() }
+        runCatching { client.cache?.close() }
+        runCatching { wireMock.stop() }
+        runCatching { cacheDir.deleteRecursively() }
+    }
+
+    @Test
+    fun `첫 번째 요청은 네트워크, 이후는 캐시 히트`() {
+        val request = Request.Builder().url(dataUrl).get().build()
+
+        // 1st request → network miss
+        client.newCall(request).execute().use { r ->
+            r.body.bytes()
+            log.info { "1st: code=${r.code}, cacheResponse=${r.cacheResponse != null}, networkResponse=${r.networkResponse != null}" }
+        }
+
+        // 2nd ~ 20th request → should all be cache hits
+        repeat(19) {
+            client.newCall(request).execute().use { r ->
+                r.body.bytes()
+                (r.networkResponse == null).shouldBeTrue()   // 캐시 히트 = 네트워크 없음
+                (r.cacheResponse != null).shouldBeTrue()     // 캐시 응답 존재
+            }
+        }
+
+        val cache = client.cache!!
+        log.info { "hitCount=${cache.hitCount()}, networkCount=${cache.networkCount()}, requestCount=${cache.requestCount()}" }
+        cache.hitCount() shouldBeGreaterThan 0
+    }
+
+    @Test
+    fun `캐시 히트 속도는 no-cache 보다 훨씬 빠르다`() {
+        val request = Request.Builder().url(dataUrl).get().build()
+
+        // 워밍업 (캐시 채우기)
+        client.newCall(request).execute().use { it.body.bytes() }
+
+        // 캐시 히트 속도 측정
+        val cacheStart = System.nanoTime()
+        repeat(1000) {
+            client.newCall(request).execute().use { it.body.bytes() }
+        }
+        val cacheNs = System.nanoTime() - cacheStart
+        val cacheOpsPerSec = 1000.0 * 1_000_000_000L / cacheNs
+
+        log.info { "캐시 히트: ${"%.0f".format(cacheOpsPerSec)} ops/s (단일 스레드)" }
+
+        // 단일 스레드에서도 no-cache(100 ops/s @ 10ms) 대비 훨씬 빠름
+        (cacheOpsPerSec > 1000.0).shouldBeTrue()
+    }
+}
+
+private fun gzip(text: String): ByteArray {
+    val baos = ByteArrayOutputStream()
+    GZIPOutputStream(baos).use { it.write(text.toByteArray(Charsets.UTF_8)) }
+    return baos.toByteArray()
+}

--- a/scripts/http-benchmark.sh
+++ b/scripts/http-benchmark.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# HTTP Client 벤치마크 실행 스크립트
+#
+# kotlinx-benchmark Gradle task 를 실행하고, 결과 JSON 을
+# .omc/self-improve/scripts/parse-benchmark.py 로 파싱하여
+# 마지막 줄에 `{"primary": <rps>, "clients": {...}}` 을 출력합니다.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+MODULE=":bluetape4k-http"
+# kotlinx-benchmark 플러그인이 등록한 target 이름이 "test" 이면
+# Gradle task 이름은 `<target>Benchmark` = `testBenchmark` 가 됩니다.
+TASK="${MODULE}:testBenchmark"
+REPORT_DIR="io/http/build/reports/benchmarks"
+
+echo "[http-benchmark] running ${TASK} ..." >&2
+
+./gradlew "${TASK}" --rerun-tasks -q 2>&1 | tail -200 >&2 || {
+    echo "[http-benchmark] gradle task failed" >&2
+    exit 1
+}
+
+# kotlinx-benchmark 는 build/reports/benchmarks/<target>/<timestamp>/<target>.json 에
+# JMH json result 를 기록합니다. 가장 최근 파일을 찾아 파서에 전달합니다.
+LATEST_JSON="$(ls -1t "${REPORT_DIR}"/*/*/*.json 2>/dev/null | head -n 1 || true)"
+
+if [[ -z "${LATEST_JSON}" ]]; then
+    echo "[http-benchmark] no benchmark json result found under ${REPORT_DIR}" >&2
+    exit 2
+fi
+
+echo "[http-benchmark] result json: ${LATEST_JSON}" >&2
+
+python3 "${REPO_ROOT}/.omc/self-improve/scripts/parse-benchmark.py" "${LATEST_JSON}"

--- a/testing/mock-server/README.ko.md
+++ b/testing/mock-server/README.ko.md
@@ -199,10 +199,23 @@ sequenceDiagram
 | 키 | 값 | 설명 |
 |----|-----|------|
 | `server.port` | `8888` | 컨테이너 고정 포트 |
+| `server.http2.enabled` | `true` | HTTP/2 지원 |
+| `server.tomcat.threads.max` | `16000` | 최대 플랫폼 스레드 수 (Virtual Thread와 함께 고동시성 지원) |
+| `server.tomcat.max-connections` | `16000` | 최대 동시 연결 수 |
+| `server.tomcat.accept-count` | `16000` | 연결 대기 큐 크기 |
 | `spring.threads.virtual.enabled` | `true` | Virtual Threads (JDK 21+) |
 | `spring.cache.type` | `caffeine` | 인프로세스 캐시 |
 | `spring.cache.cache-names` | `html-content`, `fixture-data`, `httpbin-image` | Caffeine 캐시 이름 |
-| `server.http2.enabled` | `true` | HTTP/2 지원 |
+
+> **스레드 설정 배경**: `@Threads(100)` JMH 벤치마크에서 각 스레드가 50ms 요청을 보낼 때
+> 서버 측 동시성이 병목이 되지 않도록 기본 Tomcat 스레드(200)를 16,000으로 확장했습니다.
+> Virtual Threads가 활성화되어 있어 실제 OS 스레드 소비는 훨씬 적습니다.
+
+### TODO: Spring WebFlux 마이그레이션
+
+현재 Spring MVC(서블릿 + 플랫폼 스레드) 기반입니다. 향후 Spring WebFlux + Netty로 전환하면
+이벤트 루프 기반으로 수십 개의 스레드만으로 수만 동시 연결을 처리할 수 있습니다.
+고동시성 벤치마크 서버로서 더 적합한 아키텍처입니다.
 
 ## 빌드 & 실행
 

--- a/testing/mock-server/README.ko.md
+++ b/testing/mock-server/README.ko.md
@@ -253,3 +253,11 @@ dependencies {
 - [jsonplaceholder.typicode.com](https://jsonplaceholder.typicode.com)
 - [Testcontainers](https://www.testcontainers.org/)
 - [Jib — Java 앱 컨테이너화](https://github.com/GoogleContainerTools/jib)
+
+## TODO
+
+- [ ] **Spring WebFlux 마이그레이션**: 현재 Spring MVC + Virtual Threads 구조를 WebFlux + Netty로 전환
+  - **이유**: 50ms 지연 × 100+ 동시 요청 시나리오에서 MVC는 Tomcat 스레드 풀에 의존하지만,
+    WebFlux는 소수의 이벤트 루프 스레드로 수천 커넥션을 논블로킹으로 처리 가능
+  - `/httpbin/delay/{seconds}` 엔드포인트는 `Thread.sleep()` → `Mono.delay()` 로 교체하면 완전 논블로킹
+  - 참고: 16000 스레드까지 늘려야 100 클라이언트 × 50ms = ~2,000 ops/s 이론값에 근접하는 문제 발생

--- a/testing/mock-server/README.md
+++ b/testing/mock-server/README.md
@@ -253,3 +253,11 @@ dependencies {
 - [jsonplaceholder.typicode.com](https://jsonplaceholder.typicode.com)
 - [Testcontainers](https://www.testcontainers.org/)
 - [Jib — Containerize Java apps](https://github.com/GoogleContainerTools/jib)
+
+## TODO
+
+- [ ] **Migrate to Spring WebFlux**: Replace Spring MVC + Virtual Threads with WebFlux + Netty
+  - **Reason**: Under 100+ concurrent requests with 50ms delay, MVC depends on Tomcat thread pool
+    (required 16,000 threads to reach theoretical ~2,000 ops/s). WebFlux handles thousands of
+    connections with a handful of event-loop threads — no thread pool tuning needed.
+  - Replace `Thread.sleep()` in `/httpbin/delay/{seconds}` with `Mono.delay()` for truly non-blocking delay.

--- a/testing/mock-server/README.md
+++ b/testing/mock-server/README.md
@@ -199,10 +199,24 @@ sequenceDiagram
 | Key | Value | Notes |
 |-----|-------|-------|
 | `server.port` | `8888` | Fixed container port |
+| `server.http2.enabled` | `true` | HTTP/2 support |
+| `server.tomcat.threads.max` | `16000` | Max platform threads (supports high-concurrency benchmarks with Virtual Threads) |
+| `server.tomcat.max-connections` | `16000` | Max simultaneous connections |
+| `server.tomcat.accept-count` | `16000` | Connection backlog queue size |
 | `spring.threads.virtual.enabled` | `true` | Virtual Threads (JDK 21+) |
 | `spring.cache.type` | `caffeine` | In-process caching |
 | `spring.cache.cache-names` | `html-content`, `fixture-data`, `httpbin-image` | Caffeine cache names |
-| `server.http2.enabled` | `true` | HTTP/2 support |
+
+> **Thread count rationale**: With `@Threads(100)` JMH benchmarks sending 50 ms requests,
+> the default Tomcat thread pool (200) became the bottleneck. Raising it to 16,000 ensures
+> the server is never the limiting factor. Virtual Threads are enabled so actual OS thread
+> consumption is far lower.
+
+### TODO: Migrate to Spring WebFlux
+
+Currently built on Spring MVC (servlet + platform threads). Migrating to Spring WebFlux + Netty
+would allow tens of thousands of concurrent connections with only a handful of event-loop threads —
+a better fit as a high-concurrency benchmark server.
 
 ## Build & Run
 

--- a/testing/mock-server/src/main/resources/application.yml
+++ b/testing/mock-server/src/main/resources/application.yml
@@ -4,7 +4,9 @@ server:
     enabled: true
   tomcat:
     threads:
-      max: 200
+      max: 8000
+    max-connections: 8000
+    accept-count: 8000
 
 spring:
   application:

--- a/testing/mock-server/src/main/resources/application.yml
+++ b/testing/mock-server/src/main/resources/application.yml
@@ -4,9 +4,9 @@ server:
     enabled: true
   tomcat:
     threads:
-      max: 8000
-    max-connections: 8000
-    accept-count: 8000
+      max: 16000
+    max-connections: 16000
+    accept-count: 16000
 
 spring:
   application:


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: perf: io/http 벤치마크 개선 + 프로덕션 설정 최적화

JMH 기반 벤치마크 3종 추가 및 HTTP 클라이언트 프로덕션 설정 최적화.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 주요 변경 사항

### 프로덕션 코드 수정
- **`VirtualThreadHttpClient.kt`**: 미사용 `vtExecutor` dead code 제거
- **`OkHttp3Support.kt`**: `maxIdleConnections` CPU코어수 → 50, `okhttp3DispatcherWithVirtualThread()`에 `maxRequests`/`maxRequestsPerHost` 파라미터 추가 (기본 200/100)
- **`CachingHttpClientBuilder.kt`**: `memoryCachingHttpClientOf()` → `synchronized LinkedHashMap` → `ConcurrentHashMap` 기반 `InMemoryHttpCacheStorage` 교체

### 벤치마크 추가 (테스트)
- **`HttpClientBenchmark`**: OkHttp3 Coroutines, JDK HttpClient Coroutines 추가; Unconfined → IO Dispatcher 통일
- **`HttpClientLatencyBenchmark`**: WireMock 4대 서버 → `BluetapeHttpServer` Docker 단일 서버로 재작성 (`/httpbin/delay/0.05`, 50ms)
- **`HttpClientCompressionCacheBenchmark`**: MockWebServer(동일 JVM) → WireMock Docker(10ms 지연)으로 재설계; RFC 7234 필수 헤더(`Date`, `Last-Modified`, `Vary`) 추가
- **`OkHttpDiskCacheVerificationTest`**: DiskLruCache 캐시 히트 실증 검증 테스트 추가

### 인프라 변경
- **`mock-server application.yml`**: Tomcat threads/connections 200 → 16,000 (100 동시 벤치마크 스레드 대응)
- **`BluetapeHttpServer`** Docker 이미지 재빌드 적용

### 기존 섹션: 캐시 벤치마크 결과 (WireMock Docker 10ms 지연, @Threads=8)

| 클라이언트 | ops/s | 배율 |
|-----------|------:|------|
| HC5 Classic + InMemoryCache | 813,906 | ×1,233 |
| OkHttp3 + DiskLruCache | 35,359 | ×53 |
| NoCache 기준 | 682 | ×1 |

### 기존 섹션: 다음 세션 TODO

- HTTP 설정 최적화: Connection Timeout, Keep-Alive, Retry 정책 DSL 노출
- 캐시 통합: `memoryCachingHttpClientOf(maxEntries)`, OkHttp3 디스크 캐시 DSL 추가

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #94, head `01b0a65ee05dc77d3353682c093064998317d3b7`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `improve/http_performance_optimization`
- Labels: `enhancement`
- State: `MERGED`, merge commit `9c231ccd2c6e74f1eb7b78319bfb4f225975f30c`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #94 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9c231ccd2c6e74f1eb7b78319bfb4f225975f30c`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
