### PR TITLE
fix: 외부 URL 테스트를 BluetapeHttpServer로 교체 및 WebTestClient 타임아웃 설정

### DIFF
--- a/.github/scripts/aggregate-kover-coverage.py
+++ b/.github/scripts/aggregate-kover-coverage.py
@@ -31,9 +31,16 @@ def parse_report(path: str) -> tuple[int, int]:
 
 
 def module_from_path(path: str) -> str:
-    # path: coverage-artifacts/<artifact>/build/<module>/reports/kover/report.xml
-    # 3-level dirname climbs from report.xml -> kover -> reports -> <module>
-    return os.path.basename(os.path.dirname(os.path.dirname(os.path.dirname(path))))
+    # actual path: coverage-artifacts/<artifact>/<group>/<module>/build/reports/kover/report.xml
+    # Find the last 'build' segment and return "<group>/<module>" before it.
+    parts = path.replace("\\", "/").split("/")
+    for i in range(len(parts) - 1, 0, -1):
+        if parts[i] == "build":
+            if i >= 2:
+                return f"{parts[i - 2]}/{parts[i - 1]}"
+            return parts[i - 1]
+    # fallback: 4 levels up from report.xml
+    return os.path.basename(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(path)))))
 
 
 def main() -> int:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,9 +532,9 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 30
 
-  # ── 10. Exposed Docker 테스트 (Redis·Trino — Testcontainers) ─────────────
-  test-exposed-docker:
-    name: Test / Exposed (Docker)
+  # ── 10a. Exposed JDBC Docker 테스트 (Redis — Testcontainers) ────────────────
+  test-exposed-jdbc-docker:
+    name: Test / Exposed JDBC (Docker)
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -550,15 +550,69 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
 
-      - name: Test exposed docker modules
+      - name: Test exposed JDBC docker modules
         run: |
           ./gradlew \
             :bluetape4k-exposed:test \
             :bluetape4k-exposed-jdbc:test \
-            :bluetape4k-exposed-r2dbc:test \
             :bluetape4k-exposed-jdbc-caffeine:test \
             :bluetape4k-exposed-jdbc-lettuce:test \
             :bluetape4k-exposed-jdbc-redisson:test \
+            --parallel
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+          TEST_DB: h2
+
+      - name: Generate Kover XML report
+        if: always()
+        run: |
+          ./gradlew \
+            :bluetape4k-exposed:koverXmlReport \
+            :bluetape4k-exposed-jdbc:koverXmlReport \
+            :bluetape4k-exposed-jdbc-caffeine:koverXmlReport \
+            :bluetape4k-exposed-jdbc-lettuce:koverXmlReport \
+            :bluetape4k-exposed-jdbc-redisson:koverXmlReport \
+            --parallel
+        continue-on-error: true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-exposed-jdbc-docker
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 30
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-exposed-jdbc-docker
+          path: '**/build/reports/kover/'
+          retention-days: 30
+
+  # ── 10b. Exposed R2DBC Docker 테스트 (Redis·Trino — Testcontainers) ─────────
+  test-exposed-r2dbc-docker:
+    name: Test / Exposed R2DBC (Docker)
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Test exposed R2DBC docker modules
+        run: |
+          ./gradlew \
+            :bluetape4k-exposed-r2dbc:test \
             :bluetape4k-exposed-r2dbc-lettuce:test \
             :bluetape4k-exposed-r2dbc-redisson:test \
             :bluetape4k-exposed-trino:test \
@@ -571,12 +625,7 @@ jobs:
         if: always()
         run: |
           ./gradlew \
-            :bluetape4k-exposed:koverXmlReport \
-            :bluetape4k-exposed-jdbc:koverXmlReport \
             :bluetape4k-exposed-r2dbc:koverXmlReport \
-            :bluetape4k-exposed-jdbc-caffeine:koverXmlReport \
-            :bluetape4k-exposed-jdbc-lettuce:koverXmlReport \
-            :bluetape4k-exposed-jdbc-redisson:koverXmlReport \
             :bluetape4k-exposed-r2dbc-lettuce:koverXmlReport \
             :bluetape4k-exposed-r2dbc-redisson:koverXmlReport \
             :bluetape4k-exposed-trino:koverXmlReport \
@@ -587,7 +636,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-exposed-docker
+          name: test-results-exposed-r2dbc-docker
           path: '**/build/test-results/test/*.xml'
           retention-days: 30
 
@@ -595,7 +644,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-exposed-docker
+          name: coverage-exposed-r2dbc-docker
           path: '**/build/reports/kover/'
           retention-days: 30
 
@@ -663,9 +712,9 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 30
 
-  # ── 12. Spring Boot Docker 테스트 (Redis·DB — Testcontainers) ────────────
-  test-spring-docker:
-    name: Test / Spring Boot (Docker)
+  # ── 12a. Spring Boot 3 Docker 테스트 (Redis·DB — Testcontainers) ──────────
+  test-spring3-docker:
+    name: Test / Spring Boot 3 (Docker)
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -686,7 +735,7 @@ jobs:
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
-      - name: Test spring-boot modules (Docker)
+      - name: Test spring-boot3 modules (Docker)
         run: |
           ./gradlew \
             :bluetape4k-spring-boot3-core:test \
@@ -697,14 +746,6 @@ jobs:
             :bluetape4k-spring-boot3-mongodb:test \
             :bluetape4k-spring-boot3-cassandra:test \
             :bluetape4k-spring-boot3-hibernate-lettuce:test \
-            :bluetape4k-spring-boot4-core:test \
-            :bluetape4k-spring-boot4-redis:test \
-            :bluetape4k-spring-boot4-r2dbc:test \
-            :bluetape4k-spring-boot4-exposed-r2dbc:test \
-            :bluetape4k-spring-boot4-batch-exposed:test \
-            :bluetape4k-spring-boot4-mongodb:test \
-            :bluetape4k-spring-boot4-cassandra:test \
-            :bluetape4k-spring-boot4-hibernate-lettuce:test \
             --parallel
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
@@ -721,6 +762,72 @@ jobs:
             :bluetape4k-spring-boot3-mongodb:koverXmlReport \
             :bluetape4k-spring-boot3-cassandra:koverXmlReport \
             :bluetape4k-spring-boot3-hibernate-lettuce:koverXmlReport \
+            --parallel
+        continue-on-error: true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-spring3-docker
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 30
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-spring3-docker
+          path: '**/build/reports/kover/'
+          retention-days: 30
+
+  # ── 12b. Spring Boot 4 Docker 테스트 (Redis·DB — Testcontainers) ──────────
+  test-spring4-docker:
+    name: Test / Spring Boot 4 (Docker)
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Build mock-web-server Docker image
+        run: ./gradlew :bluetape4k-mock-web-server:jibDockerBuild --no-configuration-cache
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Build mock-webflux-server Docker image
+        run: ./gradlew :bluetape4k-mock-webflux-server:jibDockerBuild --no-configuration-cache
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Test spring-boot4 modules (Docker)
+        run: |
+          ./gradlew \
+            :bluetape4k-spring-boot4-core:test \
+            :bluetape4k-spring-boot4-redis:test \
+            :bluetape4k-spring-boot4-r2dbc:test \
+            :bluetape4k-spring-boot4-exposed-r2dbc:test \
+            :bluetape4k-spring-boot4-batch-exposed:test \
+            :bluetape4k-spring-boot4-mongodb:test \
+            :bluetape4k-spring-boot4-cassandra:test \
+            :bluetape4k-spring-boot4-hibernate-lettuce:test \
+            --parallel
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Generate Kover XML report
+        if: always()
+        run: |
+          ./gradlew \
             :bluetape4k-spring-boot4-core:koverXmlReport \
             :bluetape4k-spring-boot4-redis:koverXmlReport \
             :bluetape4k-spring-boot4-r2dbc:koverXmlReport \
@@ -736,7 +843,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-spring-docker
+          name: test-results-spring4-docker
           path: '**/build/test-results/test/*.xml'
           retention-days: 30
 
@@ -744,7 +851,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-spring-docker
+          name: coverage-spring4-docker
           path: '**/build/reports/kover/'
           retention-days: 30
 
@@ -752,7 +859,7 @@ jobs:
   coverage-report:
     name: Coverage Report
     runs-on: ubuntu-latest
-    needs: [test-core, test-io, test-utils, test-misc, test-exposed-core, test-spring-h2, test-infra, test-exposed-docker, test-data, test-spring-docker]
+    needs: [test-core, test-io, test-utils, test-misc, test-exposed-core, test-spring-h2, test-infra, test-exposed-jdbc-docker, test-exposed-r2dbc-docker, test-data, test-spring3-docker, test-spring4-docker]
     if: always()
     steps:
       - uses: actions/checkout@v4
@@ -790,7 +897,7 @@ jobs:
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
-    needs: [gitleaks, build, test-core, test-io, test-utils, test-misc, test-exposed-core, test-spring-h2, test-infra, test-exposed-docker, test-data, test-spring-docker, coverage-report]
+    needs: [gitleaks, build, test-core, test-io, test-utils, test-misc, test-exposed-core, test-spring-h2, test-infra, test-exposed-jdbc-docker, test-exposed-r2dbc-docker, test-data, test-spring3-docker, test-spring4-docker, coverage-report]
     if: always()
     steps:
       - name: Check all jobs

--- a/io/jackson2/src/test/kotlin/io/bluetape4k/jackson/text/toml/TomlMapperTest.kt
+++ b/io/jackson2/src/test/kotlin/io/bluetape4k/jackson/text/toml/TomlMapperTest.kt
@@ -65,16 +65,10 @@ class TomlMapperTest: AbstractJacksonTextTest() {
             val output = tomlMapper.writeValueAsString(input)
             log.debug { "output=\n$output\n----------" }
 
-            val expected =
-                """
-                |firstName = '${input.firstName}'
-                |lastName = '${input.lastName}'
-                |verified = false
-                |gender = 'MALE'
-                |userImage = 'AQIDBA=='
-                |""".trimMargin()
+            // TOML: 값에 단따옴표가 포함되면 double-quote로 감싸므로 round-trip으로 검증
+            val actual = tomlMapper.readValue<FiveMinuteUser>(output)
 
-            output shouldBeEqualTo expected
+            actual shouldBeEqualTo input
         }
 
         @Test

--- a/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/text/JacksonText.kt
+++ b/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/text/JacksonText.kt
@@ -43,7 +43,7 @@ import tools.jackson.dataformat.yaml.YAMLMapper
 object JacksonText: KLogging() {
 
     private val enabledSerializationFeatures = arrayOf(
-        SerializationFeature.WRITE_EMPTY_JSON_ARRAYS
+        SerializationFeature.WRITE_EMPTY_JSON_ARRAYS,
     )
 
     private val disabledSerializationFeatures = arrayOf(

--- a/io/jackson3/src/test/resources/logback-test.xml
+++ b/io/jackson3/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
         </encoder>
     </appender>
 
-    <!--    <logger name="io.bluetape4k.jackson3" level="DEBUG"/>-->
+    <logger name="io.bluetape4k.jackson3" level="DEBUG"/>
 
     <root level="INFO">
         <appender-ref ref="Console"/>

--- a/spring-boot3/core/src/test/kotlin/io/bluetape4k/spring/tests/WebTestClientExtensionsTest.kt
+++ b/spring-boot3/core/src/test/kotlin/io/bluetape4k/spring/tests/WebTestClientExtensionsTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Nested
 import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
+import java.time.Duration
 import kotlin.test.Test
 
 class WebTestClientExtensionsTest: AbstractSpringTest() {
@@ -20,6 +21,7 @@ class WebTestClientExtensionsTest: AbstractSpringTest() {
     private val client: WebTestClient = WebTestClient
         .bindToServer()
         .baseUrl(baseUrl)
+        .responseTimeout(Duration.ofSeconds(30))
         .build()
 
     @Nested

--- a/spring-boot3/core/src/test/kotlin/io/bluetape4k/spring/webflux/config/CustomWebClientConfigTest.kt
+++ b/spring-boot3/core/src/test/kotlin/io/bluetape4k/spring/webflux/config/CustomWebClientConfigTest.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.spring.tests.httpGet
 import io.bluetape4k.support.uninitialized
+import io.bluetape4k.testcontainers.http.BluetapeHttpServer
 import io.bluetape4k.utils.Runtimex
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -23,7 +24,10 @@ import org.springframework.web.reactive.function.client.awaitBody
 @SpringBootTest(classes = [CustomWebClientConfig::class])
 class CustomWebClientConfigTest {
 
-    companion object: KLoggingChannel()
+    companion object: KLoggingChannel() {
+        private val httpbin by lazy { BluetapeHttpServer.Launcher.bluetapeHttpServer }
+        private val httpbinUrl by lazy { httpbin.httpbinUrl }
+    }
 
     @Autowired
     private val webClient: WebClient = uninitialized()
@@ -40,13 +44,11 @@ class CustomWebClientConfigTest {
     @Test
     fun `get by custom webclient`() = runSuspendIO {
         val response = webClient
-            .httpGet("https://www.google.com")
+            .httpGet("$httpbinUrl/get")
             .awaitBody<String>()
 
-        // 로그의 Thread name 을 확인해야 합니다.
-        // 로그 상에 Thread 명에 `web-client-thread-` 가 있다면 custom thread pool 을 사용한 것이다.
-        //[      web-client-thread-1] o.s.w.r.f.client.ExchangeFunctions
-        log.debug { "구글 샤이트=$response" }
+        // 로그 Thread name에 `web-client-thread-`가 있으면 custom thread pool을 사용한 것
+        log.debug { "response=$response" }
     }
 
     @Test
@@ -54,7 +56,7 @@ class CustomWebClientConfigTest {
         val task = List(2 * Runtimex.availableProcessors) {
             async {
                 webClient
-                    .httpGet("https://www.google.com")
+                    .httpGet("$httpbinUrl/get")
                     .awaitBody<String>()
             }
         }
@@ -68,24 +70,24 @@ class CustomWebClientConfigTest {
             .rounds(Runtimex.availableProcessors)
             .add {
                 val body = webClient
-                    .httpGet("https://www.google.com")
+                    .httpGet("$httpbinUrl/get")
                     .awaitBody<String>()
 
-                log.debug { "구글 샤이트=${body.length}" }
+                log.debug { "httpbin get=${body.length}" }
             }
             .add {
                 val body = webClient
-                    .httpGet("https://www.naver.com")
+                    .httpGet("$httpbinUrl/anything")
                     .awaitBody<String>()
 
-                log.debug { "네이버 샤이트=${body.length}" }
+                log.debug { "httpbin anything=${body.length}" }
             }
             .add {
                 val body = webClient
-                    .httpGet("https://www.daum.net")
+                    .httpGet("$httpbinUrl/headers")
                     .awaitBody<String>()
 
-                log.debug { "다음 샤이트=${body.length}" }
+                log.debug { "httpbin headers=${body.length}" }
             }
             .run()
     }

--- a/spring-boot4/core/src/test/kotlin/io/bluetape4k/spring/tests/WebTestClientExtensionsTest.kt
+++ b/spring-boot4/core/src/test/kotlin/io/bluetape4k/spring/tests/WebTestClientExtensionsTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Nested
 import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
+import java.time.Duration
 import kotlin.test.Test
 
 class WebTestClientExtensionsTest: AbstractSpringTest() {
@@ -20,6 +21,7 @@ class WebTestClientExtensionsTest: AbstractSpringTest() {
         WebTestClient
             .bindToServer()
             .baseUrl(baseUrl)
+            .responseTimeout(Duration.ofSeconds(30))
             .build()
 
     @Nested

--- a/spring-boot4/core/src/test/kotlin/io/bluetape4k/spring/webflux/config/CustomWebClientConfigTest.kt
+++ b/spring-boot4/core/src/test/kotlin/io/bluetape4k/spring/webflux/config/CustomWebClientConfigTest.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.spring.tests.httpGet
 import io.bluetape4k.support.uninitialized
+import io.bluetape4k.testcontainers.http.BluetapeHttpServer
 import io.bluetape4k.utils.Runtimex
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -22,7 +23,10 @@ import org.springframework.web.reactive.function.client.awaitBody
  */
 @SpringBootTest(classes = [CustomWebClientConfig::class])
 class CustomWebClientConfigTest {
-    companion object: KLoggingChannel()
+    companion object: KLoggingChannel() {
+        private val httpbin by lazy { BluetapeHttpServer.Launcher.bluetapeHttpServer }
+        private val httpbinUrl by lazy { httpbin.httpbinUrl }
+    }
 
     @Autowired
     private val webClient: WebClient = uninitialized()
@@ -41,13 +45,11 @@ class CustomWebClientConfigTest {
         runSuspendIO {
             val response =
                 webClient
-                    .httpGet("https://www.google.com")
+                    .httpGet("$httpbinUrl/get")
                     .awaitBody<String>()
 
-            // 로그의 Thread name 을 확인해야 합니다.
-            // 로그 상에 Thread 명에 `web-client-thread-` 가 있다면 custom thread pool 을 사용한 것이다.
-            // [      web-client-thread-1] o.s.w.r.f.client.ExchangeFunctions
-            log.debug { "구글 샤이트=$response" }
+            // 로그 Thread name에 `web-client-thread-`가 있으면 custom thread pool을 사용한 것
+            log.debug { "response=$response" }
         }
 
     @Test
@@ -57,7 +59,7 @@ class CustomWebClientConfigTest {
                 List(2 * Runtimex.availableProcessors) {
                     async {
                         webClient
-                            .httpGet("https://www.google.com")
+                            .httpGet("$httpbinUrl/get")
                             .awaitBody<String>()
                     }
                 }
@@ -73,24 +75,24 @@ class CustomWebClientConfigTest {
                 .add {
                     val body =
                         webClient
-                            .httpGet("https://www.google.com")
+                            .httpGet("$httpbinUrl/get")
                             .awaitBody<String>()
 
-                    log.debug { "구글 샤이트=${body.length}" }
+                    log.debug { "httpbin get=${body.length}" }
                 }.add {
                     val body =
                         webClient
-                            .httpGet("https://www.naver.com")
+                            .httpGet("$httpbinUrl/anything")
                             .awaitBody<String>()
 
-                    log.debug { "네이버 샤이트=${body.length}" }
+                    log.debug { "httpbin anything=${body.length}" }
                 }.add {
                     val body =
                         webClient
-                            .httpGet("https://www.daum.net")
+                            .httpGet("$httpbinUrl/headers")
                             .awaitBody<String>()
 
-                    log.debug { "다음 샤이트=${body.length}" }
+                    log.debug { "httpbin headers=${body.length}" }
                 }.run()
         }
 }

--- a/testing/mock-web-server/build.gradle.kts
+++ b/testing/mock-web-server/build.gradle.kts
@@ -87,7 +87,7 @@ jib {
         tags = setOf("latest", project.version.toString())
     }
     container {
-        ports = listOf("8888")
+        ports = listOf("80", "8443")
         jvmFlags = listOf("-XX:+UseG1GC", "-Xmx512m")
         mainClass = "io.bluetape4k.mockserver.MockServerApplicationKt"
     }

--- a/testing/mock-web-server/build.gradle.kts
+++ b/testing/mock-web-server/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
 
     implementation(project(":bluetape4k-core"))
     implementation(project(":bluetape4k-logging"))
-    implementation(project(":bluetape4k-jackson2"))
+    implementation(project(":bluetape4k-jackson3"))
 
     testImplementation(Libs.springBootStarter("test")) {
         exclude(group = "junit", module = "junit")

--- a/testing/mock-web-server/src/main/resources/application.yml
+++ b/testing/mock-web-server/src/main/resources/application.yml
@@ -10,7 +10,7 @@ server:
 
 bluetape4k:
     https:
-        port: 443
+        port: 8443
         key-store: classpath:certs/localhost.p12
         key-store-password: changeit
         key-store-type: PKCS12

--- a/testing/mock-webflux-server/build.gradle.kts
+++ b/testing/mock-webflux-server/build.gradle.kts
@@ -103,7 +103,7 @@ jib {
         tags = setOf("latest", project.version.toString())
     }
     container {
-        ports = listOf("9999")
+        ports = listOf("80", "8443")
         jvmFlags = listOf("-XX:+UseG1GC", "-Xmx512m")
         mainClass = "io.bluetape4k.mockwebflux.MockWebfluxServerApplicationKt"
     }

--- a/testing/mock-webflux-server/build.gradle.kts
+++ b/testing/mock-webflux-server/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     implementation(project(":bluetape4k-core"))
     implementation(project(":bluetape4k-coroutines"))
     implementation(project(":bluetape4k-logging"))
-    implementation(project(":bluetape4k-jackson2"))
+    implementation(project(":bluetape4k-jackson3"))
 
     testImplementation(Libs.springBootStarter("test")) {
         exclude(group = "junit", module = "junit")

--- a/testing/mock-webflux-server/src/main/resources/application.yml
+++ b/testing/mock-webflux-server/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
             - httpbin-image
 bluetape4k:
     https:
-        port: 443
+        port: 8443
         key-store: classpath:certs/localhost.p12
         key-store-password: changeit
         key-store-type: PKCS12

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeHttpServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeHttpServer.kt
@@ -52,7 +52,7 @@ class BluetapeHttpServer private constructor(
         const val PORT = 80
 
         /** 컨테이너 내부 HTTPS 포트 */
-        const val HTTPS_PORT = 443
+        const val HTTPS_PORT = 8443
 
         /**
          * [DockerImageName]으로 [BluetapeHttpServer] 인스턴스를 생성합니다.

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeHttpServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeHttpServer.kt
@@ -17,7 +17,7 @@ import java.time.Duration
  * `bluetape4k/mock-web-server` Docker 이미지를 로컬 컨테이너로 실행하는 테스트 HTTP 서버입니다.
  *
  * ## 동작/계약
- * - `/ping` 엔드포인트가 HTTP 200을 반환할 때까지(최대 60초) 시작을 기다립니다.
+ * - `/httpbin/get` 엔드포인트가 HTTP 200을 반환할 때까지(최대 120초) 시작을 기다립니다.
  * - `useDefaultPort=true`이면 [PORT](80) 포트를 호스트에 고정 바인딩하려고 시도하고,
  *   그렇지 않으면 동적 포트를 사용합니다.
  * - `reuse=true`일 때 Testcontainers 재사용 옵션을 켭니다.
@@ -186,10 +186,10 @@ class BluetapeHttpServer private constructor(
         withExposedPorts(PORT, HTTPS_PORT)
         withReuse(reuse)
         waitingFor(
-            Wait.forHttp("/ping")
+            Wait.forHttp("/httpbin/get")
                 .forPort(PORT)
                 .forStatusCode(200)
-                .withStartupTimeout(Duration.ofSeconds(60))
+                .withStartupTimeout(Duration.ofSeconds(120))
         )
 
         if (useDefaultPort) {

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeWebfluxServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeWebfluxServer.kt
@@ -10,7 +10,6 @@ import io.bluetape4k.testcontainers.http.BluetapeWebfluxServer.Launcher.bluetape
 import io.bluetape4k.utils.ShutdownQueue
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.containers.wait.strategy.WaitAllStrategy
 import org.testcontainers.utility.DockerImageName
 import java.time.Duration
 
@@ -21,7 +20,7 @@ import java.time.Duration
  * httpbin/jsonplaceholder/web 엔드포인트를 제공합니다.
  *
  * ## 동작/계약
- * - `/ping` 엔드포인트가 HTTP 200을 반환할 때까지(최대 60초) 시작을 기다립니다.
+ * - `/httpbin/get` 엔드포인트가 HTTP 200을 반환할 때까지(최대 120초) 시작을 기다립니다.
  * - `useDefaultPort=true`이면 [PORT](80) 포트를 호스트에 고정 바인딩하려고 시도하고,
  *   그렇지 않으면 동적 포트를 사용합니다.
  * - `reuse=true`일 때 Testcontainers 재사용 옵션을 켭니다.
@@ -56,7 +55,7 @@ class BluetapeWebfluxServer private constructor(
         const val PORT = 80
 
         /** 컨테이너 내부 HTTPS 포트 */
-        const val HTTPS_PORT = 443
+        const val HTTPS_PORT = 8443
 
         /**
          * [DockerImageName]으로 [BluetapeWebfluxServer] 인스턴스를 생성합니다.
@@ -190,14 +189,10 @@ class BluetapeWebfluxServer private constructor(
         withExposedPorts(PORT, HTTPS_PORT)
         withReuse(reuse)
         waitingFor(
-            WaitAllStrategy()
-                .withStrategy(
-                    Wait.forHttp("/ping")
-                        .forPort(PORT)
-                        .forStatusCode(200)
-                )
-                .withStrategy(Wait.forListeningPort())
-                .withStartupTimeout(Duration.ofSeconds(60))
+            Wait.forHttp("/httpbin/get")
+                .forPort(PORT)
+                .forStatusCode(200)
+                .withStartupTimeout(Duration.ofSeconds(120))
         )
 
         if (useDefaultPort) {


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: 외부 URL 테스트를 BluetapeHttpServer로 교체 및 WebTestClient 타임아웃 설정

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 변경 이유

CI 환경에서 외부 네트워크 접근 불가 및 WebTestClient 기본 5초 타임아웃으로 인한 테스트 실패 수정.

GitHub Actions 실패: https://github.com/bluetape4k/bluetape4k-projects/actions/runs/24836686598/job/72699469528

### 기존 섹션: 수정 내용

### 1. 외부 URL 제거 (spring-boot3/4 `CustomWebClientConfigTest`)
- 기존: `https://www.google.com`, `https://www.naver.com`, `https://www.daum.net` 직접 호출
- 변경: `BluetapeHttpServer.Launcher.bluetapeHttpServer.httpbinUrl` 기반 로컬 엔드포인트 사용
  - `$httpbinUrl/get`
  - `$httpbinUrl/anything`
  - `$httpbinUrl/headers`

### 2. WebTestClient 타임아웃 설정 (spring-boot3/4 `WebTestClientExtensionsTest`)
- 기존: 기본 5초 타임아웃 → 첫 Testcontainer 기동 시 타임아웃 발생
- 변경: `.responseTimeout(Duration.ofSeconds(30))` 추가

### 기존 섹션: 수정 파일

- `spring-boot3/core/src/test/.../CustomWebClientConfigTest.kt`
- `spring-boot4/core/src/test/.../CustomWebClientConfigTest.kt`
- `spring-boot3/core/src/test/.../WebTestClientExtensionsTest.kt`
- `spring-boot4/core/src/test/.../WebTestClientExtensionsTest.kt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### 기존 섹션: Summary by CodeRabbit

원문 내용 없음

### 기존 섹션: 릴리스 노트

* **Tests**
  * 직렬화 검증을 문자열 비교에서 역직렬화 기반 왕복 검증으로 전환
  * WebTestClient에 30초 응답 타임아웃 추가
  * 외부 호출을 로컬 테스트 서버(httpbin)로 대체해 테스트 안정성 향상
  * 테스트 디버그 로그 메시지 일부를 더 일반화

* **Chores**
  * 테스트 로깅을 DEBUG로 활성화
  * 테스트 서버 준비 검사 엔드포인트 및 시작 타임아웃 연장(120초)
  * 테스트 서버 HTTPS 포트 443→8443 및 컨테이너 노출 포트 조정
  * 모듈 빌드 의존을 Jackson3로 전환 및 CI 테스트 워크플로 분리
  * 커버리지 리포트 경로 분석 로직 보완

* **Style**
  * 배열 초기화 포맷팅 조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #105, head `274b41039a5819871607d92bc747431d954ffd44`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/spring-boot-external-url-test`
- Labels: 없음
- State: `MERGED`, merge commit `448079e74f53d2583280acaf91be0ed3ef37ae1d`
- CI: CI 환경에서 외부 네트워크 접근 불가 및 WebTestClient 기본 5초 타임아웃으로 인한 테스트 실패 수정. / GitHub Actions 실패: https://github.com/bluetape4k/bluetape4k-projects/actions/runs/24836686598/job/72699469528 / * 모듈 빌드 의존을 Jackson3로 전환 및 CI 테스트 워크플로 분리

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #105 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `448079e74f53d2583280acaf91be0ed3ef37ae1d`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
