### PR TITLE
feat: 태그 push 시 Maven Central Portal 자동 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,14 +161,33 @@ jobs:
           ref: ${{ needs.resolve-version.outputs.ref }}
           fetch-depth: 0
 
-      - name: Extract CHANGELOG section
-        id: notes
+      - name: Resolve previous tag
+        id: prev_tag
         shell: bash
         env:
           VERSION: ${{ needs.resolve-version.outputs.version }}
         run: |
           set -euo pipefail
+          # 현재 태그를 제외하고 버전 규약에 맞는 최근 태그를 찾는다.
+          PREV=$(git tag --list --sort=-v:refname \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$' \
+            | grep -vx "$VERSION" \
+            | head -1 || true)
+          echo "previous=$PREV" >> "$GITHUB_OUTPUT"
+          echo "이전 태그: ${PREV:-(없음)}"
+
+      - name: Compose release notes
+        id: notes
+        shell: bash
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+          PREV_TAG: ${{ steps.prev_tag.outputs.previous }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
           NOTES_FILE="$(mktemp)"
+
+          # 1) CHANGELOG 본문 추출
           awk -v ver="$VERSION" '
             BEGIN { inblock=0 }
             /^## \[/ {
@@ -180,12 +199,37 @@ jobs:
 
           if [[ ! -s "$NOTES_FILE" ]]; then
             echo "::warning::No CHANGELOG section found for $VERSION. Using fallback notes."
-            printf "Release %s\n\nSee [CHANGELOG.md](./CHANGELOG.md) for details.\n" "$VERSION" > "$NOTES_FILE"
+            printf "Release %s\n\nSee [CHANGELOG.md](./CHANGELOG.md) for details.\n\n" "$VERSION" > "$NOTES_FILE"
+          fi
+
+          # 2) Contributors (이전 태그 → 현재 태그 범위)
+          if [[ -n "$PREV_TAG" ]]; then
+            CONTRIBUTORS=$(git shortlog -sne "${PREV_TAG}..${VERSION}" \
+              | sed -E 's/^[[:space:]]*[0-9]+[[:space:]]+//' \
+              | sort -u || true)
+            if [[ -n "$CONTRIBUTORS" ]]; then
+              {
+                printf '\n## Contributors\n\n'
+                printf '본 릴리즈에 기여해주신 분들께 감사드립니다.\n\n'
+                while IFS= read -r line; do
+                  printf -- '- %s\n' "$line"
+                done <<< "$CONTRIBUTORS"
+              } >> "$NOTES_FILE"
+            fi
+
+            # 3) Full Changelog 링크
+            printf '\n**Full Changelog**: https://github.com/%s/compare/%s...%s\n' \
+              "$REPO" "$PREV_TAG" "$VERSION" >> "$NOTES_FILE"
+          else
+            printf '\n**Full Changelog**: https://github.com/%s/commits/%s\n' \
+              "$REPO" "$VERSION" >> "$NOTES_FILE"
           fi
 
           echo "notes_file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
-          echo "--- Release notes preview ---"
-          head -40 "$NOTES_FILE"
+          echo "--- Release notes preview (상위 60줄) ---"
+          head -60 "$NOTES_FILE"
+          echo "--- 하단 20줄 ---"
+          tail -20 "$NOTES_FILE"
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,205 @@
+name: Publish Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version to publish (e.g. 1.7.0). Must match an existing tag.'
+        required: true
+        type: string
+      diagnoseSigning:
+        description: 'Run signing diagnostics before publishing'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: publish-release
+  cancel-in-progress: false
+
+env:
+  JAVA_VERSION: '21'
+  JAVA_DISTRIBUTION: 'temurin'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  resolve-version:
+    name: Resolve release version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      ref: ${{ steps.resolve.outputs.ref }}
+    steps:
+      - id: resolve
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TAG_NAME: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            VERSION="$TAG_NAME"
+          else
+            VERSION="$INPUT_VERSION"
+          fi
+
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+            echo "::error::Invalid version format: $VERSION"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "ref=refs/tags/$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version=$VERSION"
+
+  publish:
+    name: Publish RELEASE to Maven Central Portal
+    needs: resolve-version
+    runs-on: ubuntu-latest
+    environment: maven-central-release
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-version.outputs.ref }}
+          fetch-depth: 0
+
+      - name: Verify gradle.properties matches tag
+        shell: bash
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          BASE=$(grep -E '^baseVersion=' gradle.properties | cut -d= -f2)
+          SNAP=$(grep -E '^snapshotVersion=' gradle.properties | cut -d= -f2 || echo "")
+          echo "tag=$VERSION baseVersion=$BASE snapshotVersion='$SNAP'"
+          if [[ "$BASE" != "$VERSION" ]]; then
+            echo "::error::gradle.properties baseVersion ($BASE) does not match tag ($VERSION)"
+            exit 1
+          fi
+          if [[ -n "$SNAP" ]]; then
+            echo "::error::snapshotVersion must be empty for release. Got: '$SNAP'"
+            exit 1
+          fi
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Diagnose signing inputs
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.diagnoseSigning }}
+        shell: bash
+        env:
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+        run: |
+          python <<'PY'
+          import base64, os
+
+          raw_key = os.environ.get("SIGNING_KEY", "")
+          key_id = os.environ.get("SIGNING_KEY_ID", "")
+          password = os.environ.get("SIGNING_PASSWORD", "")
+
+          print(f"SIGNING_KEY_ID set={bool(key_id)} length={len(key_id)}")
+          print(f"SIGNING_PASSWORD set={bool(password)} length={len(password)}")
+          print(f"SIGNING_KEY set={bool(raw_key)} length={len(raw_key)}")
+
+          if raw_key.lstrip().startswith("-----BEGIN"):
+              normalized_key = raw_key.replace("\\n", "\n")
+              source = "armored"
+          elif "\\n" in raw_key:
+              normalized_key = raw_key.replace("\\n", "\n")
+              source = "escaped_newlines"
+          else:
+              try:
+                  normalized_key = base64.b64decode(raw_key.strip()).decode("utf-8")
+                  source = "base64"
+              except Exception:
+                  normalized_key = raw_key
+                  source = "raw"
+
+          print(f"SIGNING_KEY source={source} normalized_length={len(normalized_key)}")
+          print(f"SIGNING_KEY armored={'BEGIN PGP PRIVATE KEY BLOCK' in normalized_key}")
+          PY
+
+      - name: Publish to Central Portal
+        run: >
+          ./gradlew publishAggregationToCentralPortal
+          --no-daemon
+          --no-configuration-cache
+          --no-build-cache
+          --stacktrace
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+
+  github-release:
+    name: Create GitHub Release
+    needs: [resolve-version, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-version.outputs.ref }}
+          fetch-depth: 0
+
+      - name: Extract CHANGELOG section
+        id: notes
+        shell: bash
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          NOTES_FILE="$(mktemp)"
+          awk -v ver="$VERSION" '
+            BEGIN { inblock=0 }
+            /^## \[/ {
+              if (inblock) exit
+              if (index($0, "[" ver "]") > 0) { inblock=1; next }
+            }
+            inblock { print }
+          ' CHANGELOG.md > "$NOTES_FILE"
+
+          if [[ ! -s "$NOTES_FILE" ]]; then
+            echo "::warning::No CHANGELOG section found for $VERSION. Using fallback notes."
+            printf "Release %s\n\nSee [CHANGELOG.md](./CHANGELOG.md) for details.\n" "$VERSION" > "$NOTES_FILE"
+          fi
+
+          echo "notes_file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+          echo "--- Release notes preview ---"
+          head -40 "$NOTES_FILE"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+          NOTES_FILE: ${{ steps.notes.outputs.notes_file }}
+        run: |
+          set -euo pipefail
+          PRERELEASE_FLAG=""
+          if [[ "$VERSION" =~ -(RC|Beta|Alpha|M) ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --notes-file "$NOTES_FILE" \
+            $PRERELEASE_FLAG


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: feat: 태그 push 시 Maven Central Portal 자동 배포 워크플로우 추가

## Background

지금까지 수동으로 실행하던 Maven Central Portal RELEASE 배포를 `git push origin <version>` 한 번으로 완결되도록 자동화합니다. 기존 snapshot 배포 파이프라인(`publish-snapshot.yml`)과 대칭을 이룹니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 주요 변경

### `.github/workflows/release.yml` (신규)

| Job | 동작 |
|-----|------|
| `resolve-version` | 태그/workflow_dispatch input에서 버전 추출 + semver 정규식 검증 |
| `publish` | `gradle.properties`의 `baseVersion`이 태그와 일치 · `snapshotVersion` 비어있음 검증 → `./gradlew publishAggregationToCentralPortal` (nmcp AUTOMATIC 모드) |
| `github-release` | CHANGELOG [버전] 섹션 추출 → Contributors 목록(`git shortlog -sne PREV..CUR`) + Full Changelog compare 링크 합성 → `gh release create` |

### 트리거

- `push: tags: ['[0-9]+.[0-9]+.[0-9]+', '[0-9]+.[0-9]+.[0-9]+-*']` — `1.7.0`, `1.7.0-RC1` 등
- `workflow_dispatch` — 수동 실행 (version input 필수, diagnoseSigning 옵션)

### 보안

- 모든 `${{ github.* }}` / `${{ inputs.* }}` 값은 env 변수로 전달 후 shell 변수로 참조 (command injection 차단)
- 버전 문자열은 정규식으로 검증
- `environment: maven-central-release` — 저장소 Settings에서 보호 규칙(수동 승인 등) 적용 가능

### 기존 섹션: 릴리즈 노트 자동 생성

예상 1.7.0 release notes 구조 (dry-run 검증 완료):

```markdown
### Added
#### io/csv — univocity-parsers 제거 ...
...
### Removed
...

## Contributors
본 릴리즈에 기여해주신 분들께 감사드립니다.
- Sunghyouk Bae <sunghyouk.bae@gmail.com>
- debop <sunghyouk.bae@gmail.com>

**Full Changelog**: https://github.com/bluetape4k/bluetape4k-projects/compare/1.6.2...1.7.0
```

### 기존 섹션: 사용 시나리오

1. `git flow release start 1.7.0` (또는 worktree)
2. 릴리즈 브랜치에서 버전/CHANGELOG/README 업데이트 커밋
3. `git flow release finish 1.7.0`
4. `git push origin main develop 1.7.0` → **🎉 워크플로우가 Central Portal 배포 + GitHub Release 생성 자동 수행**
5. develop에서 `baseVersion=1.8.0-SNAPSHOT`으로 bump

### 기존 섹션: 후속 작업

이 PR 머지 후 `release/1.7.0` 브랜치를 만들어 실제 1.7.0 릴리즈 진행.

## Validation

- `yq`로 YAML 유효성 OK
- 로컬 dry-run: CHANGELOG 추출(201줄), 이전 태그 탐지(`1.6.2`), contributors · compare 링크 합성 모두 정상 확인
- Gradle 태스크 존재 확인: `publishAggregationToCentralPortal` ✅

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #121, head `b34a3385d95e5b69af106f26638313df262da229`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `chore/release-workflow`
- Labels: 없음
- State: `MERGED`, merge commit `d2b950fb82694e9ea2a76b2fc2eabe53f538bb34`
- CI: | `publish` | `gradle.properties`의 `baseVersion`이 태그와 일치 · `snapshotVersion` 비어있음 검증 → `./gradlew publishAggregationToCentralPortal` (nmcp AUTOMATIC 모드) | / #### io/csv — univocity-parsers 제거 ... / - Gradle 태스크 존재 확인: `publishAggregationToCentralPortal` ✅

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #121 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `d2b950fb82694e9ea2a76b2fc2eabe53f538bb34`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
