### PR TITLE
docs(kdoc): FastFory 공개 API KDoc 예제 강화 및 forHighThroughput() 팩토리 추가

### DIFF
--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodecs.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodecs.kt
@@ -142,6 +142,13 @@ object LettuceBinaryCodecs {
      *
      * FastFory는 `CompatibleMode.SCHEMA_CONSISTENT`를 사용하는 고성능 직렬화기입니다.
      *
+     * ```kotlin
+     * val codec = LettuceBinaryCodecs.fastFory<MyData>()
+     * val connection = redisClient.connect(codec)
+     * connection.sync().set("key", myData)
+     * val result = connection.sync().get("key")
+     * ```
+     *
      * ⚠️ **와이어 포맷 경고**
      * - `CompatibleMode.SCHEMA_CONSISTENT`를 사용하며, 기본 Fory codec과 **와이어 포맷이 상호 비호환**합니다.
      * - fallback이 없으므로 기존 Fory 데이터를 FastFory로 읽으면 역직렬화 오류가 발생합니다.
@@ -153,6 +160,14 @@ object LettuceBinaryCodecs {
 
     /**
      * FastFory Serializer와 LZ4 Compressor를 사용하는 [LettuceBinaryCodec]를 생성합니다.
+     *
+     * LZ4 압축으로 네트워크 전송 크기를 줄이면서 고성능 직렬화를 제공합니다.
+     *
+     * ```kotlin
+     * val codec = LettuceBinaryCodecs.lz4FastFory<MyData>()
+     * val connection = redisClient.connect(codec)
+     * connection.sync().set("key", myData)
+     * ```
      *
      * ⚠️ **와이어 포맷 경고**
      * - `CompatibleMode.SCHEMA_CONSISTENT`를 사용하며, 기본 Fory codec과 **와이어 포맷이 상호 비호환**합니다.
@@ -166,6 +181,14 @@ object LettuceBinaryCodecs {
     /**
      * FastFory Serializer와 Zstd Compressor를 사용하는 [LettuceBinaryCodec]를 생성합니다.
      *
+     * Zstd 압축은 LZ4보다 높은 압축률을 제공하며, 큰 객체 캐시에 적합합니다.
+     *
+     * ```kotlin
+     * val codec = LettuceBinaryCodecs.zstdFastFory<MyData>()
+     * val connection = redisClient.connect(codec)
+     * connection.sync().set("key", largeData)
+     * ```
+     *
      * ⚠️ **와이어 포맷 경고**
      * - `CompatibleMode.SCHEMA_CONSISTENT`를 사용하며, 기본 Fory codec과 **와이어 포맷이 상호 비호환**합니다.
      * - fallback이 없으므로 기존 Fory 데이터를 FastFory로 읽으면 역직렬화 오류가 발생합니다.
@@ -178,6 +201,12 @@ object LettuceBinaryCodecs {
     /**
      * FastFory Serializer와 Snappy Compressor를 사용하는 [LettuceBinaryCodec]를 생성합니다.
      *
+     * ```kotlin
+     * val codec = LettuceBinaryCodecs.snappyFastFory<MyData>()
+     * val connection = redisClient.connect(codec)
+     * connection.sync().set("key", myData)
+     * ```
+     *
      * ⚠️ **와이어 포맷 경고**
      * - `CompatibleMode.SCHEMA_CONSISTENT`를 사용하며, 기본 Fory codec과 **와이어 포맷이 상호 비호환**합니다.
      * - fallback이 없으므로 기존 Fory 데이터를 FastFory로 읽으면 역직렬화 오류가 발생합니다.
@@ -189,6 +218,12 @@ object LettuceBinaryCodecs {
 
     /**
      * FastFory Serializer와 GZip Compressor를 사용하는 [LettuceBinaryCodec]를 생성합니다.
+     *
+     * ```kotlin
+     * val codec = LettuceBinaryCodecs.gzipFastFory<MyData>()
+     * val connection = redisClient.connect(codec)
+     * connection.sync().set("key", myData)
+     * ```
      *
      * ⚠️ **와이어 포맷 경고**
      * - `CompatibleMode.SCHEMA_CONSISTENT`를 사용하며, 기본 Fory codec과 **와이어 포맷이 상호 비호환**합니다.

--- a/infra/redisson/README.ko.md
+++ b/infra/redisson/README.ko.md
@@ -151,6 +151,27 @@ Codec 클래스:
 - `ZstdCodec` — Zstd 압축 래퍼
 - `GzipCodec` — GZip 압축 래퍼
 
+#### 사용 목적별 팩토리 함수
+
+`RedissonCodecs`는 내부 구현을 몰라도 적절한 Codec을 쉽게 선택할 수 있는 사용 목적 기반 팩토리 함수를 제공합니다:
+
+| 팩토리 함수                                  | 반환값              | 설명                                                  |
+|----------------------------------------------|---------------------|-------------------------------------------------------|
+| `RedissonCodecs.forCache()`                  | `LZ4Fory`           | 처리량 중심 값 캐시 (1KB 이상 객체)                   |
+| `RedissonCodecs.forHighThroughput()`         | `LZ4FastFory`       | `forCache()` 대비 ~27% 높은 처리량. 휘발성 캐시 전용 ⚠️ |
+| `RedissonCodecs.forCacheMap()`               | `LZ4ForyComposite`  | Map 형 캐시 (RMap, RLocalCachedMap)                   |
+| `RedissonCodecs.forGeneral()`                | `Fory`              | 범용 혼합 읽기/쓰기 워크로드                          |
+| `RedissonCodecs.forSmallValue()`             | `Kryo5`             | 작은 값 (<1KB) — 압축 오버헤드 생략                   |
+| `RedissonCodecs.forArchival()`               | `ZstdFory`          | 아카이브/콜드 스토리지 — 최고 압축률                  |
+| `RedissonCodecs.forCompatibility()`          | `Jdk`               | 외부 시스템 상호 운용 (non-bluetape4k)                 |
+
+```kotlin
+val config = Config()
+// 고처리량 휘발성 캐시에 FastFory + LZ4 조합 사용
+config.codec = RedissonCodecs.forHighThroughput()
+val redisson = Redisson.create(config)
+```
+
 ---
 
 ### 3. Batch / Transaction

--- a/infra/redisson/README.md
+++ b/infra/redisson/README.md
@@ -152,6 +152,27 @@ Codec classes:
 - `ZstdCodec` — Zstd compression wrapper.
 - `GzipCodec` — GZip compression wrapper.
 
+#### Use-Case Factory Functions
+
+`RedissonCodecs` provides use-case-oriented factory functions so you can select the right codec without knowing the internals:
+
+| Factory                                | Returns             | Description                                          |
+|----------------------------------------|---------------------|------------------------------------------------------|
+| `RedissonCodecs.forCache()`            | `LZ4Fory`           | High-throughput value cache (>1KB objects)           |
+| `RedissonCodecs.forHighThroughput()`   | `LZ4FastFory`       | ~27% faster than `forCache()`. Volatile cache only ⚠️ |
+| `RedissonCodecs.forCacheMap()`         | `LZ4ForyComposite`  | Map-type cache (RMap, RLocalCachedMap)               |
+| `RedissonCodecs.forGeneral()`          | `Fory`              | General mixed read/write workload                    |
+| `RedissonCodecs.forSmallValue()`       | `Kryo5`             | Small values (<1KB) — skips compression overhead     |
+| `RedissonCodecs.forArchival()`         | `ZstdFory`          | Cold/archival storage — maximum compression          |
+| `RedissonCodecs.forCompatibility()`    | `Jdk`               | Interop with non-bluetape4k systems                  |
+
+```kotlin
+val config = Config()
+// Use the highest-throughput codec for a hot volatile cache
+config.codec = RedissonCodecs.forHighThroughput()
+val redisson = Redisson.create(config)
+```
+
 ---
 
 ### 3. Batch / Transaction

--- a/infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/codec/RedissonCodecs.kt
+++ b/infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/codec/RedissonCodecs.kt
@@ -158,6 +158,15 @@ object RedissonCodecs: KLogging() {
      * Apache Fory SCHEMA_CONSISTENT 모드(FastFory) 직렬화 Codec.
      * 기본 [Fory](COMPATIBLE 모드) 대비 더 빠른 직렬화 속도를 제공하며, 직렬화 실패 시 [Fory]로 자동 전환합니다.
      *
+     * ```kotlin
+     * val config = Config()
+     * config.codec = RedissonCodecs.FastFory
+     * val redisson = Redisson.create(config)
+     * val bucket = redisson.getBucket<MyData>("key")
+     * bucket.set(myData)
+     * val result = bucket.get()
+     * ```
+     *
      * ⚠️ [Fory] codec과 와이어 포맷이 상호 비호환입니다. **휘발성 캐시 전용**으로 사용하십시오.
      */
     val FastFory: Codec by lazy { FastForyCodec() }
@@ -295,6 +304,24 @@ object RedissonCodecs: KLogging() {
      */
     @JvmStatic
     fun forCache(): Codec = LZ4Fory
+
+    /**
+     * 최고 처리량(high-throughput) 캐시용 Codec.
+     *
+     * [forCache]보다 ~27% 높은 직렬화 처리량이 필요할 때 사용합니다.
+     * FastFory(`SCHEMA_CONSISTENT` + `refTracking=false`) + LZ4 압축 조합입니다.
+     * 직렬화 실패 시 [Fory]로 자동 fallback하여 마이그레이션 기간에도 안전합니다.
+     *
+     * ```kotlin
+     * val config = Config()
+     * config.codec = RedissonCodecs.forHighThroughput()
+     * val redisson = Redisson.create(config)
+     * ```
+     *
+     * ⚠️ [forCache] 및 [LZ4Fory] codec과 와이어 포맷이 상호 비호환입니다. **휘발성 캐시 전용**으로 사용하십시오.
+     */
+    @JvmStatic
+    fun forHighThroughput(): Codec = LZ4FastFory
 
     /**
      * Map 형태의 캐시용 Codec.

--- a/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/codec/RedissonCodecsTest.kt
+++ b/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/codec/RedissonCodecsTest.kt
@@ -73,6 +73,14 @@ class RedissonCodecsTest: AbstractRedissonTest() {
         RedissonCodecs.ZstdFastForyComposite,
         RedissonCodecs.SnappyFastForyComposite,
         RedissonCodecs.GzipFastForyComposite,
+
+        // use-case factory functions
+        RedissonCodecs.forHighThroughput(),
+        RedissonCodecs.forCache(),
+        RedissonCodecs.forGeneral(),
+        RedissonCodecs.forSmallValue(),
+        RedissonCodecs.forArchival(),
+        RedissonCodecs.forCompatibility(),
     )
 
     @ParameterizedTest(name = "codec={0}")

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/BinarySerializers.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/BinarySerializers.kt
@@ -357,6 +357,12 @@ object BinarySerializers {
      *
      * **Thread-safety**: 내부적으로 `ThreadSafeFory` (풀 기반)를 사용하므로 멀티스레드 환경에서 안전합니다.
      *
+     * ```kotlin
+     * val bytes = BinarySerializers.FastFory.serialize(myObject)
+     * val restored = BinarySerializers.FastFory.deserialize<MyClass>(bytes)
+     * // restored == myObject
+     * ```
+     *
      * ⚠️ **와이어 포맷 경고**
      * - `CompatibleMode.SCHEMA_CONSISTENT`를 사용하며, 기본 Fory codec(`CompatibleMode.COMPATIBLE`)과 **와이어 포맷이 상호 비호환**합니다.
      * - **비대칭 호환성**: Redisson `FastForyCodec`은 구 Fory 데이터를 fallback으로 읽을 수 있습니다. 반대(기존 Fory codec으로 FastFory 데이터 읽기)는 불가합니다.
@@ -369,6 +375,11 @@ object BinarySerializers {
 
     /**
      * LZ4 압축 FastFory 직렬화기. 와이어 포맷 비호환 경고는 [FastFory] 참고.
+     *
+     * ```kotlin
+     * val bytes = BinarySerializers.LZ4FastFory.serialize(myObject)
+     * val restored = BinarySerializers.LZ4FastFory.deserialize<MyClass>(bytes)
+     * ```
      */
     val LZ4FastFory: CompressableBinarySerializer by lazy {
         CompressableBinarySerializer(FastFory, Compressors.LZ4)
@@ -376,6 +387,11 @@ object BinarySerializers {
 
     /**
      * Zstd 압축 FastFory 직렬화기. 와이어 포맷 비호환 경고는 [FastFory] 참고.
+     *
+     * ```kotlin
+     * val bytes = BinarySerializers.ZstdFastFory.serialize(largeObject)
+     * val restored = BinarySerializers.ZstdFastFory.deserialize<MyClass>(bytes)
+     * ```
      */
     val ZstdFastFory: CompressableBinarySerializer by lazy {
         CompressableBinarySerializer(FastFory, Compressors.Zstd)
@@ -383,6 +399,11 @@ object BinarySerializers {
 
     /**
      * Snappy 압축 FastFory 직렬화기. 와이어 포맷 비호환 경고는 [FastFory] 참고.
+     *
+     * ```kotlin
+     * val bytes = BinarySerializers.SnappyFastFory.serialize(myObject)
+     * val restored = BinarySerializers.SnappyFastFory.deserialize<MyClass>(bytes)
+     * ```
      */
     val SnappyFastFory: CompressableBinarySerializer by lazy {
         CompressableBinarySerializer(FastFory, Compressors.Snappy)
@@ -390,6 +411,11 @@ object BinarySerializers {
 
     /**
      * GZip 압축 FastFory 직렬화기. 와이어 포맷 비호환 경고는 [FastFory] 참고.
+     *
+     * ```kotlin
+     * val bytes = BinarySerializers.GZipFastFory.serialize(myObject)
+     * val restored = BinarySerializers.GZipFastFory.deserialize<MyClass>(bytes)
+     * ```
      */
     val GZipFastFory: CompressableBinarySerializer by lazy {
         CompressableBinarySerializer(FastFory, Compressors.GZip)


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: docs(kdoc): FastFory 공개 API KDoc 예제 강화 및 forHighThroughput() 팩토리 추가

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### KDoc 예제 강화
- `BinarySerializers.FastFory` 및 압축 변형 (LZ4/Zstd/Snappy/GZip): 직렬화/역직렬화 코드 예제 추가
- `LettuceBinaryCodecs.fastFory()` / `lz4FastFory()` / `zstdFastFory()` / `snappyFastFory()` / `gzipFastFory()`: Lettuce Redis 연결 예제 추가
- `RedissonCodecs.FastFory` val: Redisson Config 설정 예제 추가

### 신규 API
- `RedissonCodecs.forHighThroughput()`: `LZ4FastFory` 반환, Fory 대비 ~27% 처리량 향상 팩토리 추가
  - `forCache()` / `forGeneral()` / `forSmallValue()` / `forArchival()` / `forCompatibility()` 기존 팩토리와 동격

### 테스트 추가
- `RedissonCodecsTest`: use-case 팩토리 함수 6개 파라미터 테스트에 추가
  - `forHighThroughput()`, `forCache()`, `forGeneral()`, `forSmallValue()`, `forArchival()`, `forCompatibility()`

### README 최신화
- `infra/redisson/README.md` / `README.ko.md`: Use-Case Factory Functions 테이블 섹션 추가

### 기존 섹션: 변경 요약

지난 24시간 변경 사항 검토 후, FastFory 신규 API KDoc 품질 및 테스트 커버리지 개선.

## Validation

```bash
# 빌드 확인
./gradlew :bluetape4k-io:compileKotlin
./gradlew :bluetape4k-lettuce:compileKotlin
./gradlew :bluetape4k-redisson:compileKotlin

# 테스트 (Redis 필요)
./gradlew :bluetape4k-redisson:test --tests '*.RedissonCodecsTest'
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #126, head `2a0dc5615f972b07e60c67a5666ab03df6be594a`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `chore/daily-review-2026-04-25`
- Labels: `documentation`
- State: `MERGED`, merge commit `30aaf462e3e40eb2b5e0cd9621e5205082f69e7e`
- CI: ./gradlew :bluetape4k-io:compileKotlin / ./gradlew :bluetape4k-lettuce:compileKotlin / ./gradlew :bluetape4k-redisson:compileKotlin

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #126 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `30aaf462e3e40eb2b5e0cd9621e5205082f69e7e`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
