### PR TITLE
docs(utils/science): README 전면 재작성 — NetCDF/Shapefile/GIS/JTS/PostGIS 통합 가이드

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@
 
 <!-- 1.7.0 이후 변경 사항을 이곳에 기록합니다. -->
 
+### Documentation
+
+#### utils/science — README 전면 재작성 (GIS/Shapefile/JTS/PostGIS/NetCDF 통합 가이드) ([#128](https://github.com/bluetape4k/bluetape4k-projects/issues/128))
+
+`bluetape4k-science` 모듈의 README.md(영문) + README.ko.md(한국어)를 전면 재작성했습니다.
+PR #127(NetCDF 지원 완성)로 추가된 NetCDF 도메인을 포함해 모듈이 다루는 5개 영역을 동등하게 다룹니다.
+
+**변경 내용**
+
+- 5개 도메인 상태 테이블 추가 (GIS / Shapefile / JTS / PostGIS / NetCDF)
+- Mermaid 통합 아키텍처 다이어그램 신규 작성 (5개 영역 관계도 + 좌표 변환 흐름 + DB 스키마)
+- 패키지 구조(`Module Layout`) 섹션 신설 — 전체 파일 트리 기재
+- 핵심 기능 대조표 — 도메인별 API 한눈에 보기
+- Quick Start 5개 섹션 (5.1 좌표 변환 ~ 5.5 NetCDF 카탈로그) 독립 작성
+- API 가이드 섹션 — coords / projection / shapefile / geometry / exposed(PostGIS + NetCDF) 분리
+- NetCDF 현황 정확히 반영: `NetCdfFileTable/GridValueTable/Repository` ✅, `NetCdfCatalogService` ⚠️ Phase 5
+- 성능 / 운영 가이드 섹션 — 도메인별 인덱스 전략 및 튜닝 포인트
+- "Phase 4: Planned" 표현 제거 → 구현 완료/부분 구현 정확히 명시
+
 ---
 
 ## [1.7.0] — 2026-04-24

--- a/utils/science/README.ko.md
+++ b/utils/science/README.ko.md
@@ -2,104 +2,126 @@
 
 [English](./README.md) | 한국어
 
-GIS(지리정보 시스템) 좌표 변환, Shapefile 처리, JTS 도형 연산, PostGIS 데이터베이스 적재 파이프라인을 제공하는 통합 모듈입니다.
+GIS 좌표 변환, Shapefile 처리, JTS 도형 연산, PostGIS 데이터베이스 파이프라인, NetCDF 메타데이터 카탈로그를 통합 제공하는 Kotlin 모듈입니다.
 
-Proj4J 기반 좌표계 변환, GeoTools Shapefile 파싱, JTS 공간 기하학 연산, 그리고 Exposed + PostGIS를 활용한 데이터베이스 파이프라인을 포함합니다.
+## 개요
 
-## 핵심 기능
+`bluetape4k-science`는 다섯 가지 도메인을 다룹니다:
 
-### 좌표 기본 타입 (coords 패키지)
+| # | 도메인 | 핵심 라이브러리 | 상태 |
+|---|--------|---------------|------|
+| 1 | **GIS 좌표 변환** | Proj4J, proj4j-epsg | ✅ 구현 완료 |
+| 2 | **Shapefile 처리** | GeoTools (LGPL) | ✅ 구현 완료 |
+| 3 | **JTS 도형 연산** | JTS Core | ✅ 구현 완료 |
+| 4 | **PostGIS 데이터 파이프라인** | Exposed + PostGIS | ✅ 구현 완료 |
+| 5 | **NetCDF 메타데이터 카탈로그** | UCAR netCDF-Java (스키마 + 저장소만) | ⚠️ 부분 구현 |
 
-**GeoLocation** — WGS84 위경도 좌표
+> **NetCDF 현황**: `NetCdfFileTable`, `NetCdfGridValueTable`, `NetCdfFileRepository`, 모든 모델 클래스는
+> 완전히 구현되어 테스트까지 통과했습니다. `NetCdfCatalogService`(실제 `.nc` 파일 읽기)는
+> `edu.ucar:netcdfAll` 의존성 문제로 Phase 5에 구현 예정입니다.
 
-- 위도: -90~90, 경도: -180~180
-- Haversine 공식 거리 계산
-- 사전 정의된 지점: `SEOUL`, `NEW_YORK`, `TOKYO` 등
+---
 
-**BoundingBox** — 사각형 경계 영역
+## 아키텍처
 
-- 좌표 포함 여부 판정
-- 교집합/합집합 계산
-- 중심점, 너비, 높이 계산
+### 통합 모듈 구조
 
-**DM / DMS** — 도분 / 도분초 표기법
+```mermaid
+flowchart TD
+    Science["bluetape4k-science"]
 
-- `37°33'59.4"N` 형식 파싱
-- GeoLocation 상호 변환
+    subgraph Coords["coords — 좌표 기본 타입"]
+        GeoLocation["GeoLocation\nWGS84 위경도"]
+        BoundingBox["BoundingBox\n사각형 경계"]
+        DMS["DM / DMS\n도분 / 도분초"]
+        UtmZone["UtmZone\nUTM 좌표계"]
+        Vector["Vector\n2D / 3D"]
+    end
 
-**UtmZone** — UTM 좌표계
+    subgraph Projection["projection — 좌표계 변환"]
+        Projections["Projections\nwgs84ToUtm / utmToWgs84\ntransform(EPSG)"]
+        CrsRegistry["CrsRegistry\nEPSG 캐시"]
+    end
 
-- 위경도 → 해당 Zone 자동 판정 (`utmZoneOf()`)
-- Easting/Northing 변환
+    subgraph Shapefile["shapefile — Shapefile I/O"]
+        LoadShape["loadShape() 동기"]
+        LoadShapeAsync["loadShapeAsync() 비동기"]
+        ShapeModels["ShapeModels\nShape / ShapeRecord"]
+    end
 
-**Vector** — 2D/3D 벡터 연산
+    subgraph Geometry["geometry — JTS 도형 연산"]
+        GeomOps["GeometryOperations\nintersection / union / buffer\nsimplify / distance"]
+        PolyExt["PolygonExtensions\n면적 / 둘레"]
+    end
 
-**CoordConverters** — 좌표 변환 유틸리티
+    subgraph ExposedDB["exposed — DB 파이프라인"]
+        SpatialSchema["SpatialLayerTable\nSpatialFeatureTable"]
+        NetCdfSchema["NetCdfFileTable\nNetCdfGridValueTable"]
+        SpatialRepos["SpatialLayerRepository\nSpatialFeatureRepository"]
+        NetCdfRepo["NetCdfFileRepository"]
+        SpatialSvc["ShapefileImportService\nVirtual Thread 배치"]
+        NetCdfSvc["NetCdfCatalogService\n⚠️ Phase 5"]
+    end
 
-- 십진도 ↔ DM/DMS 변환
-- 좌표 정규화
+    Science --> Coords
+    Science --> Projection
+    Science --> Shapefile
+    Science --> Geometry
+    Science --> ExposedDB
 
-### 좌표 변환 및 투영 (projection 패키지)
+    Coords --> Projection
+    Projection --> Shapefile
+    Shapefile --> ExposedDB
+    Geometry --> ExposedDB
 
-**Projections** — Proj4J 기반 변환
+    SpatialSchema --> SpatialRepos --> SpatialSvc
+    NetCdfSchema --> NetCdfRepo --> NetCdfSvc
 
-- `wgs84ToUtm()` — WGS84 → UTM
-- `utmToWgs84()` — UTM → WGS84
-- `transform()` — EPSG 코드 간 임의의 좌표 변환
+    classDef coreStyle fill:#E8F5E9,stroke:#A5D6A7,color:#2E7D32,font-weight:bold
+    classDef serviceStyle fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
+    classDef utilStyle fill:#FFF3E0,stroke:#FFCC80,color:#E65100
+    classDef dataStyle fill:#FFF9C4,stroke:#FFF176,color:#F57F17
+    classDef warnStyle fill:#FFF3E0,stroke:#FF8F00,color:#E65100,stroke-dasharray:4
 
-**CrsRegistry** — CRS 레지스트리
+    class Science coreStyle
+    class GeoLocation,BoundingBox,DMS,UtmZone,Vector dataStyle
+    class Projections,CrsRegistry,GeomOps,PolyExt serviceStyle
+    class LoadShape,LoadShapeAsync,ShapeModels utilStyle
+    class SpatialSchema,SpatialRepos,SpatialSvc,NetCdfSchema,NetCdfRepo serviceStyle
+    class NetCdfSvc warnStyle
+```
 
-- EPSG 코드 및 Proj4 문자열 지원
-- 인스턴스 캐싱으로 성능 최적화
+### 좌표 변환 흐름
 
-### Shapefile 읽기 (shapefile 패키지)
+```mermaid
+flowchart TD
+    A[WGS84 GeoLocation\n위도, 경도] -->|wgs84ToUtm| B[UTM Zone 결정\nutmZoneOf]
+    B --> C{남반구?}
+    C -->|latBand < N| D[proj4: +south]
+    C -->|latBand >= N| E[proj4: 북반구]
+    D --> F[BasicCoordinateTransform]
+    E --> F
+    F --> G[UTM 좌표\neasting, northing]
+    G -->|utmToWgs84| H[UtmZone 입력]
+    H --> I[BasicCoordinateTransform 역변환]
+    I --> J[WGS84 GeoLocation]
 
-**ShapefileReader / loadShape()** — 동기 Shapefile 읽기
+    classDef coreStyle fill:#E8F5E9,stroke:#A5D6A7,color:#2E7D32,font-weight:bold
+    classDef serviceStyle fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
+    classDef dataStyle fill:#FFF9C4,stroke:#FFF176,color:#F57F17
 
-- `.shp`, `.shx`, `.dbf` 파일 자동 처리
-- 도형(Geometry) + 속성(Attributes) 통합 반환
-- UTF-8 및 커스텀 charset 지원
+    class A,J coreStyle
+    class F,I serviceStyle
+    class G,H dataStyle
+```
 
-**loadShapeAsync()** — 비동기 읽기
-
-- Coroutines 기반, `Dispatchers.IO` 사용
-- 대용량 파일 처리에 최적화
-
-**ShapeModels** — 타입 안전 모델
-
-- `Shape`: 파일 메타데이터
-- `ShapeRecord`: 도형 + 속성
-- `ShapeHeader`: 파일 헤더 정보
-- 공개 API에 GeoTools 타입 노출 안 함
-
-**지원 기하학 타입**
-
-- Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon
-
-### 공간 기하학 연산 (geometry 패키지)
-
-**GeometryOperations** — JTS 기반 연산
-
-- 교집합, 합집합, 차집합
-- 버퍼(Buffer) 영역 생성 (지정 거리)
-- 거리 계산
-- 단순화 (Douglas-Peucker 알고리즘)
-- Envelope (최소 경계 사각형)
-- 포함 여부 판정
-
-**PolygonExtensions** — 다각형 확장
-
-- 면적 계산
-- 둘레 계산
-
-### PostGIS 데이터베이스 파이프라인 (exposed 패키지)
+### PostGIS + NetCDF 데이터베이스 스키마
 
 ```mermaid
 classDiagram
     direction TB
 
     class SpatialLayerRecord {
-        <<dataClass>>
         +id: Long
         +name: String
         +srid: Int
@@ -107,184 +129,366 @@ classDiagram
         +recordCount: Int
     }
     class SpatialFeatureRecord {
-        <<dataClass>>
         +id: Long
         +layerId: Long
         +featureType: String
         +geom: Geometry
-        +properties: Map
+        +properties: Map~String,Any?~
     }
     class NetCdfFileRecord {
-        <<dataClass>>
         +id: Long
         +filename: String
+        +filePath: String
+        +fileSize: Long
         +variables: List~NetCdfVariableInfo~
+        +dimensions: Map~String,Int~
+        +globalAttrs: Map~String,String~
+    }
+    class NetCdfVariableInfo {
+        +name: String
+        +dataType: String
+        +shape: List~Int~
+        +attributes: Map~String,String~
     }
 
     class SpatialLayerTable {
         <<AuditableLongIdTable>>
-        +name: Column~String~
-        +srid: Column~Int~
-        +geometryType: Column~String?~
+        name, srid, geometryType
     }
     class SpatialFeatureTable {
         <<AuditableLongIdTable>>
-        +layerId: Column~EntityID~
-        +geom: Column~PGGeometry~
-        +properties: Column~Map~
+        layerId, geom(PGGeometry), properties(JSONB)
     }
     class NetCdfFileTable {
         <<AuditableLongIdTable>>
-        +filename: Column~String~
-        +variables: Column~List~
+        filename, filePath, fileSize
+        variables(JSONB), dimensions(JSONB)
+        globalAttrs(JSONB), bbox(PostGIS?)
+        timeStart, timeEnd
+    }
+    class NetCdfGridValueTable {
+        <<LongIdTable>>
+        fileId, variableName
+        location(PostGIS POINT)
+        timeIdx, levelIdx, value
+        attrs(JSONB?)
     }
 
-    class SpatialLayerRepository {
-        <<LongJdbcRepository>>
-        +save(SpatialLayerRecord): SpatialLayerRecord
-        +findByName(String): SpatialLayerRecord?
-    }
-    class SpatialFeatureRepository {
-        <<LongJdbcRepository>>
-        +save(SpatialFeatureRecord): SpatialFeatureRecord
-    }
-    class NetCdfFileRepository {
-        <<LongJdbcRepository>>
-        +save(NetCdfFileRecord): NetCdfFileRecord
-    }
+    SpatialLayerRepository --> SpatialLayerTable
+    SpatialLayerRepository --> SpatialLayerRecord
+    SpatialFeatureRepository --> SpatialFeatureTable
+    SpatialFeatureRepository --> SpatialFeatureRecord
+    NetCdfFileRepository --> NetCdfFileTable
+    NetCdfFileRepository --> NetCdfFileRecord
+    NetCdfFileRecord --> NetCdfVariableInfo
+    SpatialFeatureTable --> SpatialLayerTable : 참조
+    NetCdfGridValueTable --> NetCdfFileTable : 참조
 
-    class ShapefileImportService {
-        -layerRepo: SpatialLayerRepository
-        -featureRepo: SpatialFeatureRepository
-        +importShapefile(File, String, Int): Int
-    }
-
-    SpatialLayerRepository --> SpatialLayerTable : uses
-    SpatialLayerRepository --> SpatialLayerRecord : maps
-    SpatialFeatureRepository --> SpatialFeatureTable : uses
-    SpatialFeatureRepository --> SpatialFeatureRecord : maps
-    NetCdfFileRepository --> NetCdfFileTable : uses
-    NetCdfFileRepository --> NetCdfFileRecord : maps
-    ShapefileImportService --> SpatialLayerRepository : delegates
-    ShapefileImportService --> SpatialFeatureRepository : delegates
-    SpatialFeatureTable --> SpatialLayerTable : references
-
+    style NetCdfFileRecord fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     style SpatialLayerRecord fill:#FFFDE7,stroke:#FFF176,color:#F57F17
     style SpatialFeatureRecord fill:#FFFDE7,stroke:#FFF176,color:#F57F17
-    style NetCdfFileRecord fill:#FFFDE7,stroke:#FFF176,color:#F57F17
-    style SpatialLayerTable fill:#E0F7FA,stroke:#80DEEA,color:#00695C
-    style SpatialFeatureTable fill:#E0F7FA,stroke:#80DEEA,color:#00695C
-    style NetCdfFileTable fill:#E0F7FA,stroke:#80DEEA,color:#00695C
-    style SpatialLayerRepository fill:#E0F2F1,stroke:#80CBC4,color:#00695C
-    style SpatialFeatureRepository fill:#E0F2F1,stroke:#80CBC4,color:#00695C
-    style NetCdfFileRepository fill:#E0F2F1,stroke:#80CBC4,color:#00695C
-    style ShapefileImportService fill:#E8F5E9,stroke:#A5D6A7,color:#2E7D32
-
+    style NetCdfVariableInfo fill:#E8F5E9,stroke:#A5D6A7,color:#2E7D32
 ```
 
-**Schema** — Exposed 테이블 정의
+---
 
-- `SpatialLayerTable` / `SpatialFeatureTable` — 공간 데이터 저장
-- `PoiTable` — 관심 지점(Point of Interest)
-- `NetCdfFileTable` / `NetCdfGridValueTable` — NetCDF 메타데이터 (Phase 4)
+## 모듈 레이아웃
 
-**Models** — Serializable 데이터 클래스
-
-- `SpatialLayerRecord` / `SpatialFeatureRecord` — 공간 데이터
-- `NetCdfVariableInfo`, `NetCdfDimensionInfo`, `NetCdfFileRecord` — NetCDF (Phase 4)
-
-**Repository** — JDBC 저장소
-
-- `SpatialLayerRepository` — 레이어 관리
-- `SpatialFeatureRepository` — 피처 CRUD 및 공간 검색
-- `NetCdfRepository` — NetCDF 카탈로그 (Phase 4)
-
-**Service** — 비즈니스 로직
-
-- `ShapefileImportService.importShapefile()` — Virtual Thread 기반 배치 임포트
-- `NetCdfCatalogService` — NetCDF 파일 등록 (Phase 4)
-
-```mermaid
-sequenceDiagram
-    box "소비자" #E8F5E9
-    participant Caller
-    end
-    box "서비스" #E3F2FD
-    participant SIS as ShapefileImportService
-    participant VT as VirtualThread
-    end
-    box "저장소" #FFF3E0
-    participant LR as SpatialLayerRepository
-    participant FR as SpatialFeatureRepository
-    end
-    box "데이터베이스" #F3E5F5
-    participant DB as PostgreSQL/PostGIS
-    end
-
-    Caller->>SIS: importShapefile(file, layerName, batchSize)
-    SIS->>SIS: loadShape(file)
-
-    SIS->>VT: newVirtualThreadJdbcTransaction
-    VT->>LR: findByName(layerName)
-    LR->>DB: SELECT
-    DB-->>LR: null (중복 없음)
-    VT->>LR: save(SpatialLayerRecord)
-    LR->>DB: INSERT spatial_layers
-    DB-->>LR: layerRecord (id)
-    VT-->>SIS: layerRecord
-
-    loop 배치마다 (batchSize=1000)
-        SIS->>VT: newVirtualThreadJdbcTransaction
-        VT->>DB: batchInsert spatial_features
-        DB-->>VT: inserted rows
-        VT-->>SIS: batch complete
-    end
-
-    SIS-->>Caller: totalInserted count
-```
-
-## 아키텍처
+### 패키지 구조
 
 ```
-coords (좌표 기본 타입)
-  ├─ GeoLocation (위경도)
-  ├─ BoundingBox (경계 사각형)
-  ├─ DM / DMS (도분/도분초)
-  ├─ UtmZone (UTM 좌표계)
-  └─ Vector (벡터)
-    │
-    └─→ projection (좌표 변환)
-          ├─ Projections (Proj4J 기반)
-          │  ├─ wgs84ToUtm()
-          │  ├─ utmToWgs84()
-          │  └─ transform() [EPSG]
-          └─ CrsRegistry (캐싱)
-              │
-              ├─→ shapefile (Shapefile 읽기)
-              │     ├─ loadShape() [동기]
-              │     ├─ loadShapeAsync() [비동기]
-              │     └─ ShapeModels
-              │          │
-              │          └─→ exposed (PostGIS 파이프라인)
-              │                ├─ schema/ (테이블)
-              │                ├─ model/ (직렬화 데이터)
-              │                ├─ repository/ (JDBC)
-              │                └─ service/ (비즈니스 로직)
-              │
-              └─→ geometry (JTS 도형 연산)
-                    ├─ GeometryOperations
-                    │  ├─ intersection()
-                    │  ├─ buffer()
-                    │  ├─ simplify()
-                    │  └─ distance()
-                    └─ PolygonExtensions
-                         │
-                         └─→ exposed (DB 적재)
+io.bluetape4k.science/
+├── coords/                          — 좌표 기본 타입
+│   ├── GeoLocation.kt              — WGS84 위경도, Haversine 거리
+│   ├── BoundingBox.kt              — 사각형 경계 영역, contains/intersects
+│   ├── BoundingBoxRelation.kt      — 경계 관계 계산
+│   ├── DM.kt / DMS.kt              — 도분 / 도분초 표기법
+│   ├── Vector.kt                   — 2D/3D 벡터
+│   ├── UtmZone.kt                  — UTM Zone 데이터 클래스
+│   ├── UtmZoneSupport.kt           — utmZoneOf(), boundingBox()
+│   └── CoordConverters.kt          — 십진도 ↔ DM/DMS 변환 유틸리티
+│
+├── projection/                      — 좌표계 변환 (Proj4J)
+│   ├── CrsRegistry.kt              — EPSG/Proj4 CRS 레지스트리 (인스턴스 캐싱)
+│   └── Projections.kt              — wgs84ToUtm(), utmToWgs84(), transform()
+│
+├── shapefile/                       — Shapefile I/O (GeoTools)
+│   ├── ShapeModels.kt              — Shape, ShapeRecord, ShapeHeader (GeoTools 미노출 공개 API)
+│   ├── ShapefileReader.kt          — 동기 읽기
+│   └── ShapefileExtensions.kt      — loadShape(), loadShapeAsync()
+│
+├── geometry/                        — 공간 기하학 (JTS)
+│   ├── GeometryOperations.kt       — intersection, union, buffer, simplify, distance
+│   └── PolygonExtensions.kt        — 면적, 둘레
+│
+└── exposed/                         — 데이터베이스 파이프라인
+    ├── model/
+    │   ├── SpatialModels.kt        — SpatialLayerRecord, SpatialFeatureRecord
+    │   └── NetCdfModels.kt         — NetCdfFileRecord, NetCdfVariableInfo, NetCdfDimensionInfo
+    ├── schema/
+    │   ├── SpatialTables.kt        — SpatialLayerTable, SpatialFeatureTable
+    │   ├── PoiTable.kt             — 관심 지점(POI) 테이블
+    │   └── NetCdfTables.kt         — NetCdfFileTable, NetCdfGridValueTable
+    ├── repository/
+    │   ├── SpatialFeatureRepository.kt — 공간 피처 CRUD + bbox 검색
+    │   └── NetCdfFileRepository.kt — NetCDF 파일 메타데이터 CRUD
+    └── service/
+        ├── ShapefileImportService.kt — Virtual Thread 배치 임포트
+        └── NetCdfCatalogService.kt  — ⚠️ Phase 5 — 플레이스홀더만 존재
 ```
+
+---
+
+## 핵심 기능
+
+| 도메인 | 기능 | API |
+|--------|------|-----|
+| **좌표 기본 타입** | WGS84 위경도 + Haversine 거리 | `GeoLocation.distanceTo()` |
+| | 사각형 경계 영역 | `BoundingBox.contains()`, `.intersects()` |
+| | 도분초 표기법 | `DMS.parse()`, `.toDecimal()` |
+| | UTM Zone 자동 판정 | `utmZoneOf(lat, lon)` |
+| | 2D/3D 벡터 연산 | `Vector(x, y, z?)` |
+| **좌표계 변환** | WGS84 ↔ UTM 변환 | `wgs84ToUtm()`, `utmToWgs84()` |
+| | 임의 EPSG 간 변환 | `transform(x, y, srcEpsg, tgtEpsg)` |
+| | CRS 인스턴스 캐싱 | `CrsRegistry` |
+| **Shapefile** | 동기 Shapefile 읽기 | `loadShape(file)` |
+| | 코루틴 기반 비동기 읽기 | `loadShapeAsync(file)` |
+| | 타입 안전 모델 (GeoTools 미노출) | `Shape`, `ShapeRecord` |
+| **도형 연산** | JTS 교집합 / 합집합 / 차집합 | `GeometryOperations.intersection()` |
+| | 버퍼 영역 생성 | `GeometryOperations.buffer()` |
+| | Douglas-Peucker 단순화 | `GeometryOperations.simplify()` |
+| | 거리 계산 | `GeometryOperations.distance()` |
+| **데이터베이스** | 공간 레이어 + 피처 CRUD | `SpatialLayerRepository`, `SpatialFeatureRepository` |
+| | Virtual Thread 배치 Shapefile 임포트 | `ShapefileImportService` |
+| | NetCDF 파일 메타데이터 카탈로그 | `NetCdfFileRepository` ✅ |
+| | NetCDF 격자 값 저장 스키마 | `NetCdfGridValueTable` ✅ |
+| | `.nc` 파일 임포트 서비스 | `NetCdfCatalogService` ⚠️ Phase 5 |
+
+---
+
+## 빠른 시작 (Quick Start)
+
+### 5.1 GIS 좌표 변환
+
+```kotlin
+import io.bluetape4k.science.coords.GeoLocation
+import io.bluetape4k.science.coords.BoundingBox
+import io.bluetape4k.science.coords.DMS
+import io.bluetape4k.science.coords.utmZoneOf
+import io.bluetape4k.science.projection.wgs84ToUtm
+import io.bluetape4k.science.projection.utmToWgs84
+import io.bluetape4k.science.projection.transform
+
+val seoul = GeoLocation(latitude = 37.5665, longitude = 126.9780)
+val tokyo = GeoLocation(latitude = 35.6762, longitude = 139.6503)
+
+// Haversine 거리 계산
+val distanceKm = seoul.distanceTo(tokyo) / 1000.0
+println("서울 ↔ 도쿄: $distanceKm km")
+
+// 경계 영역 확인
+val seoulArea = BoundingBox(minLat = 37.4, maxLat = 37.6, minLon = 126.8, maxLon = 127.0)
+println("서울 시청 포함 여부: ${seoulArea.contains(seoul)}")
+println("중심: ${seoulArea.center}, 너비: ${seoulArea.widthKm} km")
+
+// 도분초 파싱
+val dms = DMS.parse("37°33'59.4\"N")
+println("도분초 → 십진도: ${dms.toDecimal()}")  // 37.5665
+
+// UTM Zone 자동 판정
+val zone = utmZoneOf(37.5665, 126.9780)
+println("서울 UTM Zone: ${zone.longitudeZone}${zone.hemisphere}")  // 52S
+
+// WGS84 ↔ UTM 왕복 변환
+val (easting, northing) = wgs84ToUtm(seoul)
+val restored = utmToWgs84(easting, northing, zone)
+println("UTM 복원 좌표: $restored")
+
+// 임의 EPSG 변환 (WGS84 → 한국 2000 중부원점)
+val (kx, ky) = transform(x = 126.9780, y = 37.5665, sourceEpsg = 4326, targetEpsg = 5179)
+println("EPSG:4326 → EPSG:5179: ($kx, $ky)")
+```
+
+### 5.2 Shapefile 처리
+
+```kotlin
+import io.bluetape4k.science.shapefile.loadShape
+import io.bluetape4k.science.shapefile.loadShapeAsync
+import java.io.File
+
+// 동기 읽기
+val shapeFile = File("/data/provinces.shp")
+val shape = loadShape(shapeFile, charset = Charsets.UTF_8)
+println("파일 타입: ${shape.shapeType}, 레코드 수: ${shape.recordCount}")
+
+shape.records.forEach { record ->
+    println("도형 타입: ${record.geometry.geometryType}")
+    println("속성: ${record.attributes}")
+}
+
+// 비동기 읽기 (Dispatchers.IO 사용)
+suspend fun processAsync() {
+    val large = loadShapeAsync(File("/data/large_dataset.shp"))
+    println("로드 완료: ${large.recordCount} 레코드")
+}
+```
+
+### 5.3 JTS 도형 연산
+
+```kotlin
+import io.bluetape4k.science.geometry.GeometryOperations
+import org.locationtech.jts.io.WKTReader
+
+val wkt = WKTReader()
+val poly1 = wkt.read("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))")
+val poly2 = wkt.read("POLYGON((5 5, 15 5, 15 15, 5 15, 5 5))")
+
+val intersection = GeometryOperations.intersection(poly1, poly2)   // 교집합
+val union        = GeometryOperations.union(poly1, poly2)          // 합집합
+val buffered     = GeometryOperations.buffer(poly1, 100.0)         // 100m 버퍼
+val simplified   = GeometryOperations.simplify(poly1, 1.0)         // Douglas-Peucker
+val distance     = GeometryOperations.distance(poly1, poly2)
+println("거리: $distance m")
+```
+
+### 5.4 PostGIS 데이터 파이프라인
+
+```kotlin
+import io.bluetape4k.science.exposed.service.ShapefileImportService
+import io.bluetape4k.science.exposed.repository.SpatialLayerRepository
+import io.bluetape4k.science.exposed.repository.SpatialFeatureRepository
+import org.jetbrains.exposed.sql.Database
+import java.io.File
+
+val database = Database.connect(
+    url = "jdbc:postgresql://localhost:5432/gis_db",
+    driver = "org.postgresql.Driver",
+    user = "postgres",
+    password = "password"
+)
+
+val service = ShapefileImportService(SpatialLayerRepository(), SpatialFeatureRepository())
+val importedCount = service.importShapefile(
+    file = File("/data/harbors.shp"),
+    layerName = "harbors-2024"
+)
+println("임포트 완료: $importedCount 레코드")
+```
+
+### 5.5 NetCDF 메타데이터 카탈로그
+
+DB 스키마와 저장소가 완성되어 있습니다. `NetCdfFileRepository`로 파일 메타데이터를 직접 등록하세요.
+
+```kotlin
+import io.bluetape4k.science.exposed.model.NetCdfFileRecord
+import io.bluetape4k.science.exposed.model.NetCdfVariableInfo
+import io.bluetape4k.science.exposed.repository.NetCdfFileRepository
+import org.jetbrains.exposed.sql.transactions.transaction
+
+val repo = NetCdfFileRepository()
+
+transaction {
+    val record = NetCdfFileRecord(
+        filename = "ERA5_2024_01.nc",
+        filePath = "/data/era5/ERA5_2024_01.nc",
+        fileSize = 104_857_600L,
+        variables = listOf(
+            NetCdfVariableInfo(
+                name = "temperature",
+                dataType = "float",
+                shape = listOf(24, 181, 360),
+                attributes = mapOf("units" to "K", "long_name" to "Air Temperature")
+            ),
+            NetCdfVariableInfo(
+                name = "precipitation",
+                dataType = "float",
+                shape = listOf(24, 181, 360),
+                attributes = mapOf("units" to "mm", "long_name" to "Total Precipitation")
+            )
+        ),
+        dimensions = mapOf("time" to 24, "lat" to 181, "lon" to 360),
+        globalAttrs = mapOf("Conventions" to "CF-1.8", "institution" to "ECMWF")
+    )
+
+    val saved = repo.save(record)
+    println("저장 완료: id=${saved.id}, filename=${saved.filename}")
+
+    val found = repo.findByIdOrNull(saved.id)
+    println("변수 목록: ${found?.variables?.map { it.name }}")  // [temperature, precipitation]
+    println("시간 스텝: ${found?.dimensions?.get("time")}")      // 24
+}
+```
+
+---
+
+## API 가이드
+
+### coords
+
+| 클래스 / 함수 | 설명 |
+|--------------|------|
+| `GeoLocation(lat, lon)` | WGS84 좌표; `.distanceTo()` — Haversine 거리 (미터) |
+| `BoundingBox(minLat, maxLat, minLon, maxLon)` | 사각형 경계; `.contains()`, `.intersects()` |
+| `DMS.parse(str)` / `DM.parse(str)` | 도분초 / 도분 문자열 파싱 |
+| `UtmZone(zone, hemisphere)` | UTM Zone 데이터 클래스 |
+| `utmZoneOf(lat, lon)` | WGS84 좌표로 UTM Zone 자동 판정 |
+| `Vector(x, y, z?)` | 2D/3D 벡터 + 산술 연산 |
+
+### projection
+
+| 함수 | 설명 |
+|------|------|
+| `wgs84ToUtm(geoLocation)` | WGS84 → UTM (easting, northing) |
+| `utmToWgs84(e, n, zone)` | UTM → WGS84 |
+| `transform(x, y, srcEpsg, tgtEpsg)` | 임의 EPSG 간 좌표 변환 |
+| `CrsRegistry` | EPSG 코드별 CRS 인스턴스 캐시 (스레드 안전) |
+
+### shapefile
+
+| 함수 | 설명 |
+|------|------|
+| `loadShape(file, charset?)` | 동기 Shapefile 읽기 |
+| `loadShapeAsync(file, charset?)` | 코루틴 비동기 읽기 (`Dispatchers.IO`) |
+| `Shape` | 파일 메타데이터 + 레코드 목록 |
+| `ShapeRecord` | 도형 + 속성 맵 (GeoTools 타입 미노출) |
+
+### geometry
+
+| 함수 | 설명 |
+|------|------|
+| `GeometryOperations.intersection(a, b)` | 교집합 |
+| `GeometryOperations.union(a, b)` | 합집합 |
+| `GeometryOperations.buffer(g, dist)` | 지정 거리 버퍼 영역 생성 |
+| `GeometryOperations.simplify(g, tol)` | Douglas-Peucker 단순화 |
+| `GeometryOperations.distance(a, b)` | 도형 간 최소 거리 |
+| `Polygon.area()` / `.perimeter()` | 면적 / 둘레 확장 함수 |
+
+### exposed (PostGIS)
+
+| 클래스 | 설명 |
+|--------|------|
+| `SpatialLayerRepository` | 레이어 CRUD (`save`, `findByName`) |
+| `SpatialFeatureRepository` | 피처 CRUD + PostGIS bbox 검색 |
+| `ShapefileImportService` | Virtual Thread 배치 Shapefile 임포트 |
+
+### exposed (NetCDF)
+
+| 클래스 | 상태 | 설명 |
+|--------|------|------|
+| `NetCdfFileRecord` | ✅ | 파일 메타데이터 모델 (filename, path, size, variables, dimensions) |
+| `NetCdfVariableInfo` | ✅ | 변수 기술자 (name, dataType, shape, attributes) |
+| `NetCdfDimensionInfo` | ✅ | 차원 기술자 (name, length, isUnlimited) |
+| `NetCdfFileRepository` | ✅ | 파일 메타데이터 CRUD (`save`, `findByIdOrNull`, `findAll`, `deleteById`) |
+| `NetCdfFileTable` | ✅ | JSONB 컬럼 + PostGIS bbox + 시간 범위 |
+| `NetCdfGridValueTable` | ✅ | 격자 값 테이블 (location: PostGIS POINT, value, timeIdx, levelIdx) |
+| `NetCdfCatalogService` | ⚠️ Phase 5 | 플레이스홀더 — `NotImplementedError` 발생 (`netcdfAll` 해결 후 구현) |
+
+---
 
 ## 설치 및 의존성
 
-bluetape4k-science는 선택적 기능별로 `compileOnly` 의존성을 선언합니다. **필요한 라이브러리만 런타임 의존성으로 추가하세요.**
+`bluetape4k-science`는 기능별 선택 의존성을 `compileOnly`로 선언합니다.
+**필요한 라이브러리만 런타임 의존성으로 추가하세요.**
 
 ### 기본 설치
 
@@ -294,51 +498,60 @@ dependencies {
 }
 ```
 
-### 기능별 의존성 추가
-
-**좌표 변환 (Proj4J 기반)**
+### GIS 좌표 변환 (Proj4J)
 
 ```kotlin
-implementation(Libs.proj4j)            // Proj4J 핵심
-implementation(Libs.proj4j_epsg)       // EPSG 데이터베이스
+implementation(Libs.proj4j)
+implementation(Libs.proj4j_epsg)
 ```
 
-**Shapefile 읽기 (GeoTools)**
-
-GeoTools는 LGPL 라이선스입니다. OSGeo Maven 저장소를 추가해야 합니다.
+### Shapefile 읽기 (GeoTools — LGPL)
 
 ```kotlin
-// build.gradle.kts — repositories 섹션
 repositories {
-    maven(url = "https://repo.osgeo.org/repository/release/") {
-        name = "OSGeo Release"
-    }
+    maven(url = "https://repo.osgeo.org/repository/release/") { name = "OSGeo Release" }
 }
-
-// 의존성
-implementation(Libs.geotools_shapefile)  // Shapefile I/O
-implementation(Libs.geotools_referencing) // 좌표계 참조
-implementation(Libs.geotools_epsg_hsql)   // EPSG 메타데이터
+dependencies {
+    implementation(Libs.geotools_shapefile)
+    implementation(Libs.geotools_referencing)
+    implementation(Libs.geotools_epsg_hsql)
+}
 ```
 
-**공간 기하학 연산 (JTS)**
+> **라이선스**: GeoTools는 LGPL입니다. `bluetape4k-science`는 `compileOnly`로 선언하므로
+> 배포 시 포함되지 않습니다. GeoTools 클래스를 재배포하려면 LGPL을 준수해야 합니다.
+
+### 공간 기하학 (JTS)
 
 ```kotlin
-implementation(Libs.jts_core)  // Java Topology Suite
+implementation(Libs.jts_core)
 ```
 
-**PostGIS 데이터베이스**
+### PostGIS 데이터베이스
 
 ```kotlin
 implementation("io.github.bluetape4k:bluetape4k-exposed-postgresql:${bluetape4kVersion}")
-implementation(Libs.postgis_jdbc)  // PostGIS JDBC
+implementation(Libs.postgis_jdbc)
 ```
 
-**비동기 처리 (Coroutines)**
+### 비동기 처리 (Coroutines)
 
 ```kotlin
 implementation("io.github.bluetape4k:bluetape4k-coroutines:${bluetape4kVersion}")
 implementation(Libs.kotlinx_coroutines_core)
+```
+
+### NetCDF (Phase 5 — 현재 불필요)
+
+`NetCdfCatalogService` 구현 완료 시 필요:
+
+```kotlin
+repositories {
+    maven(url = "https://artifacts.unidata.ucar.edu/repository/unidata-all/") { name = "Unidata" }
+}
+dependencies {
+    implementation("edu.ucar:netcdfAll:5.6.0")
+}
 ```
 
 ### 전체 의존성 예시
@@ -346,639 +559,122 @@ implementation(Libs.kotlinx_coroutines_core)
 ```kotlin
 dependencies {
     implementation("io.github.bluetape4k:bluetape4k-science:${bluetape4kVersion}")
-
-    // GIS 좌표 변환
     implementation(Libs.proj4j)
     implementation(Libs.proj4j_epsg)
-    
-    // Shapefile
     implementation(Libs.geotools_shapefile)
     implementation(Libs.geotools_referencing)
     implementation(Libs.geotools_epsg_hsql)
-    
-    // 공간 기하학
     implementation(Libs.jts_core)
-    
-    // PostGIS
     implementation("io.github.bluetape4k:bluetape4k-exposed-postgresql:${bluetape4kVersion}")
     implementation(Libs.postgis_jdbc)
-    
-    // Coroutines (선택)
     implementation("io.github.bluetape4k:bluetape4k-coroutines:${bluetape4kVersion}")
     implementation(Libs.kotlinx_coroutines_core)
 }
 ```
 
-### GeoTools LGPL 라이선스
-
-**bluetape4k-science는 GeoTools를 `compileOnly`로 선언합니다.**
-
-- **컴파일만**: Shapefile 타입 체크 시 필요
-- **런타임 불필요**: 배포 시 GeoTools 포함되지 않음
-- **재배포 시**: GeoTools를 포함하려면 LGPL 준수 필요
-    - 소스 공개 또는
-    - 동적 링킹(Dynamic Linking) 사용
-
-**권장**:
-
-1. 내부 시스템: 제약 없음
-2. 외부 배포: 클라이언트에서 GeoTools 관리
-3. 포함 배포: LGPL 준수 문서 포함
-
-## 패키지 구조
-
-```mermaid
-classDiagram
-    direction LR
-
-    class GeoLocation {
-        +latitude: Double
-        +longitude: Double
-    }
-    class BoundingBox {
-        +minLat: Double
-        +maxLat: Double
-        +minLon: Double
-        +maxLon: Double
-        +contains(GeoLocation): Boolean
-        +intersects(BoundingBox): Boolean
-    }
-    class UtmZone {
-        +longitudeZone: Int
-        +latitudeZone: Char
-        +boundingBox(): BoundingBox
-        +cellBoundingBox(size, row, col): BoundingBox
-    }
-    class DM {
-        +degree: Int
-        +minute: Double
-    }
-    class DMS {
-        +degree: Int
-        +minute: Int
-        +second: Double
-    }
-
-    class CrsRegistry {
-        <<object>>
-        +getCrs(epsg: String): CoordinateReferenceSystem
-        +clearCache()
-    }
-    class Projections {
-        <<functions>>
-        +wgs84ToUtm(GeoLocation): Pair~Double,Double~
-        +utmToWgs84(easting, northing, UtmZone): GeoLocation
-    }
-
-    class Shape {
-        +header: ShapeHeader
-        +records: List~ShapeRecord~
-        +size: Int
-    }
-    class ShapeRecord {
-        +geometry: Geometry
-        +attributes: Map~String,Any?~
-    }
-    class ShapeHeader {
-        +bbox: BoundingBox
-        +shapeType: Int
-    }
-
-    BoundingBox --> GeoLocation : contains
-    UtmZone --> BoundingBox : produces
-    Shape --> ShapeHeader
-    Shape --> ShapeRecord
-
-
-```
-
-```
-io.bluetape4k.science/
-├── coords/                          — 좌표 기본 타입
-│   ├── GeoLocation.kt              — WGS84 위경도 (Haversine 거리)
-│   ├── BoundingBox.kt              — 사각형 경계 영역
-│   ├── BoundingBoxRelation.kt      — 경계 관계 계산
-│   ├── DM.kt / DMS.kt              — 도분 / 도분초 표기
-│   ├── Vector.kt                   — 2D/3D 벡터
-│   ├── UtmZone.kt                  — UTM Zone 데이터 클래스
-│   ├── UtmZoneSupport.kt           — utmZoneOf(), boundingBox()
-│   └── CoordConverters.kt          — 좌표 변환 유틸리티
-│
-├── projection/                      — 좌표계 변환 (Proj4J)
-│   ├── CrsRegistry.kt              — EPSG/Proj4 CRS 레지스트리
-│   └── Projections.kt              — wgs84ToUtm(), transform()
-│
-├── shapefile/                       — Shapefile 파싱 (GeoTools)
-│   ├── ShapeModels.kt              — Shape, ShapeRecord, ShapeHeader
-│   ├── ShapefileReader.kt          — 동기 읽기
-│   ├── ShapefileExtensions.kt      — 확장 함수 (loadShape 등)
-│
-├── geometry/                        — 공간 기하학 (JTS)
-│   ├── GeometryOperations.kt       — intersection, buffer, simplify
-│   └── PolygonExtensions.kt        — 다각형 확장
-│
-└── exposed/                         — PostGIS DB 파이프라인
-    ├── model/                       — Serializable 데이터 클래스
-    │   ├── SpatialModels.kt        — SpatialLayerRecord, SpatialFeatureRecord
-    │   └── NetCdfModels.kt         — NetCdfVariableInfo 등 (Phase 4)
-    │
-    ├── schema/                      — Exposed 테이블 정의
-    │   ├── SpatialTables.kt        — SpatialLayerTable, SpatialFeatureTable
-    │   ├── PoiTable.kt             — Point of Interest 테이블
-    │   └── NetCdfTables.kt         — NetCDF 메타데이터 (Phase 4)
-    │
-    ├── repository/                  — JDBC 저장소
-    │   ├── SpatialFeatureRepository.kt — 피처 CRUD/검색
-    │   └── NetCdfRepository.kt      — NetCDF 카탈로그 (Phase 4)
-    │
-    └── service/                     — 비즈니스 서비스
-        ├── ShapefileImportService.kt — Virtual Thread 배치 임포트
-        └── NetCdfCatalogService.kt  — NetCDF 등록 (Phase 4)
-```
-
-## 주요 API 사용 예시
-
-### 기본 좌표 타입 사용
-
-**GeoLocation — WGS84 위경도**
-
-```kotlin
-import io.bluetape4k.science.coords.GeoLocation
-
-// 좌표 생성
-val seoul = GeoLocation(latitude = 37.5665, longitude = 126.9780)
-val tokyo = GeoLocation(latitude = 35.6762, longitude = 139.6503)
-
-// Haversine 공식 거리 계산 (미터 단위)
-val distanceMeters = seoul.distanceTo(tokyo)
-val distanceKm = distanceMeters / 1000.0
-println("서울↔도쿄: $distanceKm km")
-
-// 사전 정의 지점
-val newYork = GeoLocation.NEW_YORK
-val london = GeoLocation.LONDON
-```
-
-**BoundingBox — 사각형 경계 영역**
-
-```kotlin
-import io.bluetape4k.science.coords.BoundingBox
-
-// 경계 생성 (남서쪽, 북동쪽)
-val seoulArea = BoundingBox(
-    minLat = 37.4, maxLat = 37.6,  // 위도 범위
-    minLon = 126.8, maxLon = 127.0  // 경도 범위
-)
-
-// 포함 여부 판정
-if (seoulArea.contains(seoul)) {
-    println("서울 시청은 범위 내")
-}
-
-// 경계 정보 계산
-println("중심: ${seoulArea.center}")           // GeoLocation
-println("너비: ${seoulArea.widthKm} km")
-println("높이: ${seoulArea.heightKm} km")
-```
-
-**DMS / DM — 도분초 / 도분 표기**
-
-```kotlin
-import io.bluetape4k.science.coords.DMS
-
-// 도분초 문자열 파싱
-val dms = DMS.parse("37°33'59.4\"N")
-val decimal = dms.toDecimal()  // 37.5665
-println("도분초 → 십진도: $decimal")
-
-// 십진도 → 도분초
-val dmsStr = DMS(degree = 37, minute = 33, second = 59.4, direction = 'N').toString()
-println("십진도 → 도분초: $dmsStr")
-```
-
-**UtmZone — UTM 좌표계**
-
-```kotlin
-import io.bluetape4k.science.coords.utmZoneOf
-import io.bluetape4k.science.coords.UtmZone
-
-// WGS84 좌표 → UTM Zone 자동 판정
-val zone = utmZoneOf(37.5665, 126.9780)
-println("서울: UTM Zone ${zone.longitudeZone}${zone.hemisphere}")  // 52S
-
-// UTM Zone 경계 (BoundingBox)
-val bbox = zone.boundingBox()
-println("Zone 경계: $bbox")
-```
-
-### 좌표계 변환
-
-```mermaid
-flowchart TD
-    A[WGS84 위경도\nGeoLocation] -->|wgs84ToUtm| B[UTM Zone 결정\nutmZoneOf]
-    B --> C{남반구?}
-    C -->|latBand < N| D[proj4: +south]
-    C -->|latBand >= N| E[proj4: 북반구]
-    D --> F[BasicCoordinateTransform]
-    E --> F
-    F --> G[UTM 좌표\neasting, northing]
-
-    G -->|utmToWgs84| H[UtmZone 입력]
-    H --> I{latitudeZone < N?}
-    I -->|Yes| J[proj4: +south]
-    I -->|No| K[proj4: 북반구]
-    J --> L[BasicCoordinateTransform]
-    K --> L
-    L --> M[WGS84 위경도\nGeoLocation]
-
-    style A fill:#4CAF50
-    style G fill:#2196F3
-    style M fill:#4CAF50
-```
-
-**WGS84 ↔ UTM 변환**
-
-```kotlin
-import io.bluetape4k.science.projection.wgs84ToUtm
-import io.bluetape4k.science.projection.utmToWgs84
-import io.bluetape4k.science.coords.UtmZone
-
-// WGS84 → UTM 변환
-val seoul = GeoLocation(37.5665, 126.9780)
-val (easting, northing) = wgs84ToUtm(seoul)
-println("WGS84(37.5665, 126.9780) → UTM($easting, $northing)")
-
-// UTM → WGS84 역변환
-val zone = UtmZone(longitudeZone = 52, hemisphere = 'S')
-val restored = utmToWgs84(easting, northing, zone)
-println("UTM → WGS84: $restored")
-```
-
-**EPSG 코드 간 변환**
-
-```kotlin
-import io.bluetape4k.science.projection.transform
-
-// EPSG:4326 (WGS84) → EPSG:5179 (Korea 2000 Central Belt)
-val (transformedX, transformedY) = transform(
-    x = 126.9780,
-    y = 37.5665,
-    sourceEpsg = 4326,
-    targetEpsg = 5179
-)
-println("EPSG:4326 → EPSG:5179: ($transformedX, $transformedY)")
-```
-
-### Shapefile 읽기
-
-**동기 읽기**
-
-```kotlin
-import io.bluetape4k.science.shapefile.loadShape
-import java.io.File
-
-val shapeFile = File("/data/provinces.shp")
-val shape = loadShape(shapeFile, charset = Charsets.UTF_8)
-
-println("파일: ${shape.shapeType}, 레코드: ${shape.recordCount}")
-
-// 각 도형 처리
-shape.records.forEach { record ->
-    println("도형 타입: ${record.geometry.geometryType}")
-    println("속성: ${record.attributes}")
-}
-```
-
-**비동기 읽기 (Coroutines)**
-
-```kotlin
-import io.bluetape4k.science.shapefile.loadShapeAsync
-import kotlinx.coroutines.runBlocking
-import java.io.File
-
-suspend fun processLargeShapefile() {
-    val shapeFile = File("/data/large_dataset.shp")
-    
-    // Dispatchers.IO에서 비동기 처리
-    val shape = loadShapeAsync(shapeFile)
-    
-    shape.records.forEach { record ->
-        // 도형 처리
-    }
-}
-
-// 실행
-runBlocking {
-    processLargeShapefile()
-}
-```
-
-### 공간 기하학 연산
-
-**JTS 도형 연산**
-
-```kotlin
-import io.bluetape4k.science.geometry.GeometryOperations
-import org.locationtech.jts.io.WKTReader
-
-val wkt = WKTReader()
-
-// 두 다각형
-val poly1 = wkt.read("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))")
-val poly2 = wkt.read("POLYGON((5 5, 15 5, 15 15, 5 15, 5 5))")
-
-// 교집합
-val intersection = GeometryOperations.intersection(poly1, poly2)
-println("교집합: $intersection")
-
-// 합집합
-val union = GeometryOperations.union(poly1, poly2)
-
-// 버퍼 (100m 반경 확대)
-val buffered = GeometryOperations.buffer(poly1, 100.0)
-
-// 단순화 (Douglas-Peucker, tolerance=1.0)
-val simplified = GeometryOperations.simplify(poly1, 1.0)
-
-// 거리 계산
-val distance = GeometryOperations.distance(poly1, poly2)
-println("거리: $distance m")
-```
-
-### PostGIS 데이터베이스 파이프라인
-
-**Virtual Thread 기반 배치 임포트**
-
-```kotlin
-import io.bluetape4k.science.exposed.service.ShapefileImportService
-import io.bluetape4k.science.exposed.repository.SpatialFeatureRepository
-import io.bluetape4k.science.exposed.repository.SpatialLayerRepository
-import org.jetbrains.exposed.sql.Database
-import java.io.File
-
-// Database 초기화 (PostgreSQL + PostGIS)
-val database = Database.connect(
-    url = "jdbc:postgresql://localhost:5432/gis_db",
-    driver = "org.postgresql.Driver",
-    user = "postgres",
-    password = "password"
-)
-
-// 저장소 생성
-val layerRepo = SpatialLayerRepository()
-val featureRepo = SpatialFeatureRepository()
-
-// 배치 임포트 (Virtual Thread)
-val service = ShapefileImportService(layerRepo, featureRepo)
-val shapeFile = File("/data/harbors.shp")
-
-val importedCount = service.importShapefile(
-    file = shapeFile,
-    layerName = "harbors-2024"
-)
-println("임포트 완료: $importedCount 레코드")
-```
-
-**공간 검색**
-
-```kotlin
-import io.bluetape4k.science.coords.BoundingBox
-import io.bluetape4k.science.exposed.repository.SpatialFeatureRepository
-import org.jetbrains.exposed.sql.transactions.transaction
-
-transaction {
-    val repo = SpatialFeatureRepository()
-    
-    // BoundingBox 범위 검색
-    val bbox = BoundingBox(
-        minLat = 37.4, maxLat = 37.6,
-        minLon = 126.8, maxLon = 127.0
-    )
-    val features = repo.searchWithinBbox(bbox)
-    println("검색 결과: ${features.size}개 피처")
-}
-```
+---
 
 ## 테스트 (Testcontainers + PostGIS)
 
-Shapefile 임포트 및 공간 검색 테스트는 Testcontainers 기반 PostgreSQL + PostGIS 컨테이너를 사용합니다.
+통합 테스트는 Testcontainers 기반 PostgreSQL + PostGIS 컨테이너(`postgis/postgis:16-3.4`)로 실행됩니다.
+
+### NetCDF 카탈로그 테스트
 
 ```kotlin
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.transactions.transaction
-import org.junit.jupiter.api.Test
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
-
 @Testcontainers
-class SpatialImportTest {
-    
-    companion object {
-        @Container
-        val postgres = PostgreSQLContainer("postgis/postgis:16-3.4")
-            .withDatabaseName("test_gis")
-            .withUsername("test_user")
-            .withPassword("test_pass")
+class NetCdfTableTest : AbstractPostgisTest() {
+
+    private val repo = NetCdfFileRepository()
+
+    @Test
+    fun `NetCDF 파일 레코드 저장 및 조회`() {
+        transaction(db) {
+            val record = NetCdfFileRecord(
+                filename = "ERA5_2024_01.nc",
+                filePath = "/data/ERA5_2024_01.nc",
+                fileSize = 1_024_000L,
+                variables = listOf(
+                    NetCdfVariableInfo("temperature", "float", listOf(24, 181, 360),
+                        mapOf("units" to "K"))
+                ),
+                dimensions = mapOf("time" to 24, "lat" to 181, "lon" to 360),
+                globalAttrs = mapOf("Conventions" to "CF-1.8", "institution" to "ECMWF")
+            )
+            val saved = repo.save(record)
+
+            val found = repo.findByIdOrNull(saved.id)
+            found shouldNotBeNull()
+            found.filename shouldBeEqualTo "ERA5_2024_01.nc"
+            found.variables.size shouldBeEqualTo 1
+            found.dimensions["time"] shouldBeEqualTo 24
+        }
     }
 
     @Test
-    fun testShapefileImport() {
-        // Database 초기화 (Testcontainers 제공 URL)
-        val database = Database.connect(
-            url = postgres.jdbcUrl,
-            driver = "org.postgresql.Driver",
-            user = postgres.username,
-            password = postgres.password
-        )
-        
-        transaction {
-            // 테이블 생성
-            SchemaUtils.create(SpatialLayerTable, SpatialFeatureTable)
-            
-            // Shapefile 임포트
-            val service = ShapefileImportService(
-                SpatialLayerRepository(),
-                SpatialFeatureRepository()
-            )
-            val count = service.importShapefile(
-                File("/test-data/provinces.shp"),
-                "provinces"
-            )
-            assert(count > 0)
+    fun `NetCdfCatalogService - registerFile 호출 시 NotImplementedError 발생`() {
+        assertThrows<NotImplementedError> {
+            catalogService.registerFile("/data/test.nc")
         }
     }
 }
 ```
 
-## 성능 최적화
+### Shapefile 임포트 테스트
+
+```kotlin
+@Test
+fun `Shapefile PostGIS 임포트`() {
+    transaction(db) {
+        SchemaUtils.create(SpatialLayerTable, SpatialFeatureTable)
+        val service = ShapefileImportService(SpatialLayerRepository(), SpatialFeatureRepository())
+        val count = service.importShapefile(
+            file = File("src/test/resources/test-data/provinces.shp"),
+            layerName = "provinces-test"
+        )
+        count shouldBeGreaterThan 0
+    }
+}
+```
+
+---
+
+## 성능 / 운영 가이드
 
 ### 좌표 변환
 
-- **CRS 캐싱**: `CrsRegistry`는 EPSG 코드별 CRS 인스턴스를 캐시하여 반복 변환 시 성능 향상
+- **CRS 캐싱**: `CrsRegistry`는 EPSG 코드별 CRS 인스턴스를 캐시 — 반복 변환 비용 거의 없음.
+- **스레드 안전**: `CrsRegistry`는 ConcurrentMap 기반; 멀티스레드 환경에서 안전.
 
 ### Shapefile 처리
 
-- **비동기 I/O**: `loadShapeAsync()` 사용 시 대용량 파일을 Dispatchers.IO에서 논블로킹 처리
-- **스트림 처리**: 메모리 효율적인 레코드 순회 가능
+- 대용량 파일은 `loadShapeAsync()` 사용 — `Dispatchers.IO` 디스패치, 논블로킹 처리.
+- 지연(lazy) 레코드 순회로 수 GB 파일도 메모리 효율적 처리 가능.
 
-### 데이터베이스
+### PostGIS 데이터베이스
 
-- **공간 인덱스**: PostGIS GIST/BRIN 인덱스 자동 생성으로 범위 검색 가속화
-- **배치 적재**: Virtual Thread 기반 배치 처리로 네트워크 지연 최소화
-- **연결 풀링**: Exposed JDBC 기본 풀 사용
+- **공간 인덱스**: `CREATE INDEX ON spatial_features USING GIST (geom)` — bbox 범위 검색 가속.
+- **배치 처리**: `ShapefileImportService`는 설정 가능한 배치 크기(기본 1000행)로 Virtual Thread 처리.
+- **연결 풀링**: HikariCP 또는 Exposed 내장 풀 사용 권장.
 
 ### JTS 도형
 
-- **단순화**: Douglas-Peucker 알고리즘으로 복잡한 도형 경량화
-- **버퍼 정밀도**: 용도별 tolerance 조정으로 계산 비용 제어
+- 저장 전 `GeometryOperations.simplify()` 적용 → 좌표 수 감소, DB 저장 비용 절감.
+- `GeometryFactory`에 일관된 `PrecisionModel` 설정 → 재현 가능한 계산 결과.
 
-## NetCDF 지원
+### NetCDF 카탈로그
 
-`bluetape4k-science` 는 UCAR netCDF-Java 5.9.1 기반 NetCDF 파일 임포트를 제공합니다.
-메타데이터는 `netcdf_files` 에 등록되고, 격자 값은 슬라이스 단위로 `netcdf_grid_values` 에 임포트되며,
-변수 단위 진행 상태는 `netcdf_import_progress` 에서 관리되어 안전한 재개가 가능합니다.
+- `NetCdfFileTable`은 `bbox`(PostGIS POLYGON) + `timeStart/timeEnd` 컬럼 제공 → 시공간 필터링 지원.
+- `netcdf_files(time_start, time_end)` 인덱스 → 시간 범위 쿼리 가속.
+- `netcdf_grid_values(file_id, variable_name)` 복합 인덱스 → 변수별 격자 조회 가속.
 
-### 아키텍처 (NetCDF 파이프라인)
-
-```mermaid
-flowchart LR
-    NC[".nc 파일<br/>(NetCDF-3 / 4)"] -->|NetcdfFiles.open| READ[NetCdfCatalogService]
-    READ --> META[(netcdf_files)]
-    READ -->|Variable.read 슬라이스| AXIS[VariableAxisMap]
-    AXIS --> CRS{CRS}
-    CRS -->|EPSG:4326| GEO[Geographic 1D 축]
-    CRS -->|EPSG:3857/UTM/Polar| PROJ[Projected 2D pair<br/>proj4j]
-    GEO --> SLICE[importSlice2D]
-    PROJ --> SLICE
-    SLICE -->|ON CONFLICT DO NOTHING| GRID[(netcdf_grid_values)]
-    SLICE --> PROG[(netcdf_import_progress)]
-    PROG -->|heartbeat lease 5분| PROG
-    SLICE -.옵션.-> METR[Micrometer]
-```
-
-### 주요 기능
-
-- **rank 1 ~ 4 변수**: 1D 시계열 (location null), 2D, 3D (time × lat × lon), 4D (time × level × lat × lon)
-- **heartbeat lease + sliceIdx 재개**: `(fileId, variableName)` 단위 lease (5분 TTL).
-  4D 슬라이스 인덱스는 `timeIdx × levelN + levelIdx` 로 선형화되어 안전하게 재개 가능.
-- **CRS 재투영** (proj4j 화이트리스트):
-  EPSG:4326 / 4269 (Geographic 1D), EPSG:3857, EPSG:32601~32660 / 32701~32760 (UTM 북·남반구),
-  EPSG:3413 / 3031 (극 stereographic) — projected CRS 는 격자 cell 단위 2D `(lat, lon)` pair 캐싱.
-- **Axis-to-dimension 매핑**: 비표준 dim order (예: `[lat, lon, time]`) 도
-  `AxisType` 1차 + 이름 fallback (`lat`/`latitude`, `lon`/`longitude`, `time`/`t`,
-  `level`/`lev`/`pressure`/`depth`) 으로 처리.
-- **NaN / `_FillValue` 자동 skip** + Micrometer counter (`netcdf.import.nan.skipped`).
-- **동시성 안전성**: raw `INSERT ... ON CONFLICT DO NOTHING` + partial expression unique index
-  (`MD5(ST_AsBinary(location))` non-null + 일반 index null) 로 재개 시 중복 row 방지.
-- **선택적 Micrometer 계측**: `netcdf.register.duration`, `netcdf.import.variable.records`,
-  `netcdf.import.slice.duration`, `netcdf.import.nan.skipped`, `netcdf.import.status`.
-
-### 제약 / 비목표
-
-- `CoordinateAxis2D` (curvilinear / rotated pole / tripolar grid) **비지원** — 후속 이슈로 분리.
-  2D lat/lon 축이 발견되면 `NetCdfException.MissingCoordinate` 가 발생합니다.
-- GRIB / BUFR / OPeNDAP 포맷은 본 모듈 범위 외 (필요 시 `netcdfAll` jar 직접 추가).
-- 메서드는 **blocking** 시그니처 — Spring Boot Virtual Thread executor 에서 호출 권장 (Java 21+).
-
-### 사용 예시
-
-```kotlin
-val fileRepo = NetCdfFileRepository()
-val progressRepo = NetCdfImportProgressRepository()
-val service = NetCdfCatalogService(fileRepo, progressRepo, meterRegistry)
-
-// NetCDF 파일 등록 (메타데이터를 netcdf_files 에 저장)
-val fileId: Long = service.registerFile("/data/era5_2024_01.nc")
-
-// 변수의 모든 격자 값 임포트 (netcdf_grid_values 에 row 생성)
-service.importGridValues(fileId, "temperature")
-
-// 크래시 후 재호출 → 마지막 commit 슬라이스 다음부터 재개
-service.importGridValues(fileId, "temperature")  // COMPLETED 면 no-op, 아니면 resume
-
-// 다른 호출자가 active lease 보유 중인 경우
-try {
-    service.importGridValues(fileId, "temperature")
-} catch (e: NetCdfException.ImportAlreadyRunning) {
-    // 5분 후 재시도 (lease TTL 만료 후 정상 재개 가능)
-}
-```
-
-### 런타임 의존성
-
-```kotlin
-dependencies {
-    implementation("io.github.bluetape4k:bluetape4k-science:${bluetape4kVersion}")
-    // CDM API + NetCDF-3 IOSP
-    implementation("edu.ucar:cdm-core:5.9.1")
-    // 선택 — HDF5 / NetCDF-4 IOSP
-    implementation("edu.ucar:netcdf4:5.9.1")
-    // CRS 재투영
-    implementation("org.locationtech.proj4j:proj4j:${proj4jVersion}")
-    implementation("org.locationtech.proj4j:proj4j-epsg:${proj4jVersion}")  // EPSG:32633 등
-    implementation("io.micrometer:micrometer-core:${micrometerVersion}")    // 선택
-}
-repositories {
-    mavenCentral()
-    // Unidata Nexus — UCAR 아티팩트는 Maven Central 에 미게시
-    maven("https://artifacts.unidata.ucar.edu/repository/unidata-all/")
-}
-```
+---
 
 ## 관련 모듈
 
-| 모듈                                           | 용도                           |
-|----------------------------------------------|------------------------------|
-| `bluetape4k-core`                            | 기본 유틸리티 (압축, 암호화, 어설션)       |
-| `bluetape4k-coroutines`                      | 코루틴 확장 (DeferredValue, Flow) |
-| `bluetape4k-exposed-postgresql`              | PostGIS 컬럼 타입                |
-| `bluetape4k-exposed-jdbc`                    | Exposed JDBC 저장소             |
-| `bluetape4k-spring-boot3-exposed-jdbc-demo`  | Spring MVC + Exposed 데모      |
-| `bluetape4k-spring-boot3-exposed-r2dbc-demo` | Spring WebFlux + R2DBC 데모    |
-
-## API 요약
-
-### coords
-
-| 클래스/함수                                        | 설명           |
-|-----------------------------------------------|--------------|
-| `GeoLocation(lat, lon)`                       | WGS84 좌표     |
-| `BoundingBox(minLat, maxLat, minLon, maxLon)` | 사각형 경계       |
-| `DMS.parse(str)` / `DM.parse(str)`            | 도분초/도분 파싱    |
-| `UtmZone(zone, hemisphere)`                   | UTM Zone     |
-| `utmZoneOf(lat, lon)`                         | 좌표 → Zone 판정 |
-| `Vector(x, y, z?)`                            | 2D/3D 벡터     |
-
-### projection
-
-| 함수                                  | 설명          |
-|-------------------------------------|-------------|
-| `wgs84ToUtm(geoLocation)`           | WGS84 → UTM |
-| `utmToWgs84(e, n, zone)`            | UTM → WGS84 |
-| `transform(x, y, srcEpsg, tgtEpsg)` | EPSG 간 변환   |
-
-### shapefile
-
-| 함수                               | 설명               |
-|----------------------------------|------------------|
-| `loadShape(file, charset?)`      | Shapefile 동기 읽기  |
-| `loadShapeAsync(file, charset?)` | Shapefile 비동기 읽기 |
-
-### geometry
-
-| 함수                                  | 설명                  |
-|-------------------------------------|---------------------|
-| `GeometryOperations.intersection()` | 교집합                 |
-| `GeometryOperations.union()`        | 합집합                 |
-| `GeometryOperations.buffer()`       | 버퍼 생성               |
-| `GeometryOperations.simplify()`     | Douglas-Peucker 단순화 |
-| `GeometryOperations.distance()`     | 거리 계산               |
-
-### exposed
-
-| 클래스                        | 설명                    |
-|----------------------------|-----------------------|
-| `SpatialFeatureRepository` | 피처 CRUD/검색            |
-| `SpatialLayerRepository`   | 레이어 관리                |
-| `ShapefileImportService`   | Virtual Thread 배치 임포트 |
+| 모듈 | 용도 |
+|------|------|
+| `bluetape4k-core` | 기본 유틸리티 (압축, 어설션) |
+| `bluetape4k-coroutines` | 코루틴 확장 (Flow, DeferredValue) |
+| `bluetape4k-exposed-postgresql` | PostGIS 컬럼 타입 |
+| `bluetape4k-exposed-jdbc` | Exposed JDBC 저장소 기반 클래스 |
+| `bluetape4k-testing-testcontainers` | Testcontainers 헬퍼 |

--- a/utils/science/README.md
+++ b/utils/science/README.md
@@ -2,13 +2,30 @@
 
 English | [한국어](./README.ko.md)
 
-An integrated module for GIS coordinate conversion, Shapefile processing, JTS geometry operations, and PostGIS data-loading pipelines.
+An integrated Kotlin module for scientific and geospatial data processing: GIS coordinate conversion,
+Shapefile I/O, JTS geometry operations, PostGIS database pipelines, and NetCDF metadata cataloging.
 
-It includes coordinate transforms based on Proj4J, GeoTools-backed Shapefile parsing, JTS spatial geometry operations, and database pipelines built on Exposed + PostGIS.
+## Overview
+
+`bluetape4k-science` covers five domains:
+
+| # | Domain | Key Libraries | Status |
+|---|--------|---------------|--------|
+| 1 | **GIS Coordinate Conversion** | Proj4J, proj4j-epsg | ✅ Implemented |
+| 2 | **Shapefile Processing** | GeoTools (LGPL) | ✅ Implemented |
+| 3 | **JTS Geometry Operations** | JTS Core | ✅ Implemented |
+| 4 | **PostGIS Data Pipeline** | Exposed + PostGIS | ✅ Implemented |
+| 5 | **NetCDF Metadata Catalog** | UCAR netCDF-Java (schema + repo only) | ⚠️ Partial |
+
+> **NetCDF status**: `NetCdfFileTable`, `NetCdfGridValueTable`, `NetCdfFileRepository`, and all model
+> classes are fully implemented and tested. `NetCdfCatalogService` (actual `.nc` file reading) requires
+> `edu.ucar:netcdfAll` and is planned for Phase 5.
+
+---
 
 ## Architecture
 
-### Module Overview
+### Integrated Module Overview
 
 ```mermaid
 flowchart TD
@@ -17,9 +34,9 @@ flowchart TD
     subgraph Coords["coords — Coordinate Primitives"]
         GeoLocation["GeoLocation\nWGS84 lat/lon"]
         BoundingBox["BoundingBox\nbounding rectangle"]
-        DMS["DM / DMS\ndegree-minute-second"]
-        UtmZone["UtmZone\nUTM coordinate system"]
-        Vector["Vector\n2D/3D"]
+        DMS["DM / DMS\ndeg-min-sec"]
+        UtmZone["UtmZone\nUTM system"]
+        Vector["Vector\n2D / 3D"]
     end
 
     subgraph Projection["projection — CRS Transforms"]
@@ -38,39 +55,42 @@ flowchart TD
         PolyExt["PolygonExtensions\narea / perimeter"]
     end
 
-    subgraph Exposed["exposed — PostGIS Pipeline"]
-        Schema["schema/\nSpatialLayerTable\nSpatialFeatureTable"]
-        Models["model/\nSpatialLayerRecord\nSpatialFeatureRecord"]
-        Repos["repository/\nSpatialLayerRepository\nSpatialFeatureRepository"]
-        Service["service/\nShapefileImportService"]
+    subgraph ExposedDB["exposed — DB Pipelines"]
+        SpatialSchema["SpatialLayerTable\nSpatialFeatureTable"]
+        NetCdfSchema["NetCdfFileTable\nNetCdfGridValueTable"]
+        SpatialRepos["SpatialLayerRepository\nSpatialFeatureRepository"]
+        NetCdfRepo["NetCdfFileRepository"]
+        SpatialSvc["ShapefileImportService\nVirtual Thread batch"]
+        NetCdfSvc["NetCdfCatalogService\n⚠️ Phase 5"]
     end
 
     Science --> Coords
     Science --> Projection
     Science --> Shapefile
     Science --> Geometry
-    Science --> Exposed
+    Science --> ExposedDB
 
     Coords --> Projection
     Projection --> Shapefile
-    Shapefile --> Exposed
-    Geometry --> Exposed
+    Shapefile --> ExposedDB
+    Geometry --> ExposedDB
+
+    SpatialSchema --> SpatialRepos --> SpatialSvc
+    NetCdfSchema --> NetCdfRepo --> NetCdfSvc
 
     classDef coreStyle fill:#E8F5E9,stroke:#A5D6A7,color:#2E7D32,font-weight:bold
     classDef serviceStyle fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     classDef utilStyle fill:#FFF3E0,stroke:#FFCC80,color:#E65100
-    classDef dataStyle fill:#F57F17,stroke:#F57F17,color:#000000
-    classDef dslStyle fill:#E0F7FA,stroke:#80DEEA,color:#00695C
+    classDef dataStyle fill:#FFF9C4,stroke:#FFF176,color:#F57F17
+    classDef warnStyle fill:#FFF3E0,stroke:#FF8F00,color:#E65100,stroke-dasharray:4
 
     class Science coreStyle
     class GeoLocation,BoundingBox,DMS,UtmZone,Vector dataStyle
-    class Projections,CrsRegistry serviceStyle
+    class Projections,CrsRegistry,GeomOps,PolyExt serviceStyle
     class LoadShape,LoadShapeAsync,ShapeModels utilStyle
-    class GeomOps,PolyExt serviceStyle
-    class Schema,Models,Repos,Service dslStyle
+    class SpatialSchema,SpatialRepos,SpatialSvc,NetCdfSchema,NetCdfRepo serviceStyle
+    class NetCdfSvc warnStyle
 ```
-
----
 
 ### Coordinate Transformation Flow
 
@@ -83,34 +103,26 @@ flowchart TD
     D --> F[BasicCoordinateTransform]
     E --> F
     F --> G[UTM coordinates\neasting, northing]
-
     G -->|utmToWgs84| H[UtmZone input]
-    H --> I{latitudeZone < N?}
-    I -->|Yes| J[proj4: +south]
-    I -->|No| K[proj4: northern]
-    J --> L[BasicCoordinateTransform]
-    K --> L
-    L --> M[WGS84 GeoLocation]
+    H --> I[BasicCoordinateTransform reverse]
+    I --> J[WGS84 GeoLocation]
 
     classDef coreStyle fill:#E8F5E9,stroke:#A5D6A7,color:#2E7D32,font-weight:bold
     classDef serviceStyle fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
-    classDef dataStyle fill:#F57F17,stroke:#F57F17,color:#000000
+    classDef dataStyle fill:#FFF9C4,stroke:#FFF176,color:#F57F17
 
-    class A,M coreStyle
-    class F,L serviceStyle
+    class A,J coreStyle
+    class F,I serviceStyle
     class G,H dataStyle
 ```
 
----
-
-### PostGIS Database Pipeline Class Diagram
+### PostGIS + NetCDF Database Schema
 
 ```mermaid
 classDiagram
     direction TB
 
     class SpatialLayerRecord {
-        <<dataClass>>
         +id: Long
         +name: String
         +srid: Int
@@ -118,304 +130,232 @@ classDiagram
         +recordCount: Int
     }
     class SpatialFeatureRecord {
-        <<dataClass>>
         +id: Long
         +layerId: Long
         +featureType: String
         +geom: Geometry
-        +properties: Map
+        +properties: Map~String,Any?~
     }
     class NetCdfFileRecord {
-        <<dataClass>>
         +id: Long
         +filename: String
+        +filePath: String
+        +fileSize: Long
         +variables: List~NetCdfVariableInfo~
+        +dimensions: Map~String,Int~
+        +globalAttrs: Map~String,String~
+    }
+    class NetCdfVariableInfo {
+        +name: String
+        +dataType: String
+        +shape: List~Int~
+        +attributes: Map~String,String~
     }
 
     class SpatialLayerTable {
         <<AuditableLongIdTable>>
-        +name: Column~String~
-        +srid: Column~Int~
-        +geometryType: Column~String?~
+        name, srid, geometryType
     }
     class SpatialFeatureTable {
         <<AuditableLongIdTable>>
-        +layerId: Column~EntityID~
-        +geom: Column~PGGeometry~
-        +properties: Column~Map~
+        layerId, geom(PGGeometry), properties(JSONB)
     }
     class NetCdfFileTable {
         <<AuditableLongIdTable>>
-        +filename: Column~String~
-        +variables: Column~List~
+        filename, filePath, fileSize
+        variables(JSONB), dimensions(JSONB)
+        globalAttrs(JSONB), bbox(PostGIS?)
+        timeStart, timeEnd
+    }
+    class NetCdfGridValueTable {
+        <<LongIdTable>>
+        fileId, variableName
+        location(PostGIS POINT)
+        timeIdx, levelIdx, value
+        attrs(JSONB?)
     }
 
-    class SpatialLayerRepository {
-        <<LongJdbcRepository>>
-        +save(SpatialLayerRecord): SpatialLayerRecord
-        +findByName(String): SpatialLayerRecord?
-    }
-    class SpatialFeatureRepository {
-        <<LongJdbcRepository>>
-        +save(SpatialFeatureRecord): SpatialFeatureRecord
-    }
-    class NetCdfFileRepository {
-        <<LongJdbcRepository>>
-        +save(NetCdfFileRecord): NetCdfFileRecord
-    }
-
-    class ShapefileImportService {
-        -layerRepo: SpatialLayerRepository
-        -featureRepo: SpatialFeatureRepository
-        +importShapefile(File, String, Int): Int
-    }
-
-    SpatialLayerRepository --> SpatialLayerTable : uses
-    SpatialLayerRepository --> SpatialLayerRecord : maps
-    SpatialFeatureRepository --> SpatialFeatureTable : uses
-    SpatialFeatureRepository --> SpatialFeatureRecord : maps
-    NetCdfFileRepository --> NetCdfFileTable : uses
-    NetCdfFileRepository --> NetCdfFileRecord : maps
-    ShapefileImportService --> SpatialLayerRepository : delegates
-    ShapefileImportService --> SpatialFeatureRepository : delegates
+    SpatialLayerRepository --> SpatialLayerTable
+    SpatialLayerRepository --> SpatialLayerRecord
+    SpatialFeatureRepository --> SpatialFeatureTable
+    SpatialFeatureRepository --> SpatialFeatureRecord
+    NetCdfFileRepository --> NetCdfFileTable
+    NetCdfFileRepository --> NetCdfFileRecord
+    NetCdfFileRecord --> NetCdfVariableInfo
     SpatialFeatureTable --> SpatialLayerTable : references
+    NetCdfGridValueTable --> NetCdfFileTable : references
 
+    style NetCdfFileRecord fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     style SpatialLayerRecord fill:#FFFDE7,stroke:#FFF176,color:#F57F17
     style SpatialFeatureRecord fill:#FFFDE7,stroke:#FFF176,color:#F57F17
-    style NetCdfFileRecord fill:#FFFDE7,stroke:#FFF176,color:#F57F17
-    style SpatialLayerTable fill:#E0F7FA,stroke:#80DEEA,color:#00695C
-    style SpatialFeatureTable fill:#E0F7FA,stroke:#80DEEA,color:#00695C
-    style NetCdfFileTable fill:#E0F7FA,stroke:#80DEEA,color:#00695C
-    style SpatialLayerRepository fill:#E0F2F1,stroke:#80CBC4,color:#00695C
-    style SpatialFeatureRepository fill:#E0F2F1,stroke:#80CBC4,color:#00695C
-    style NetCdfFileRepository fill:#E0F2F1,stroke:#80CBC4,color:#00695C
-    style ShapefileImportService fill:#E8F5E9,stroke:#A5D6A7,color:#2E7D32
+    style NetCdfVariableInfo fill:#E8F5E9,stroke:#A5D6A7,color:#2E7D32
 ```
 
 ---
 
-### Shapefile Import Sequence
+## Module Layout
 
-```mermaid
-sequenceDiagram
-    box "Consumer" #E8F5E9
-    participant Caller
-    end
-    box "Service" #E3F2FD
-    participant SIS as ShapefileImportService
-    participant VT as VirtualThread
-    end
-    box "Repositories" #FFF3E0
-    participant LR as SpatialLayerRepository
-    participant FR as SpatialFeatureRepository
-    end
-    box "Database" #F3E5F5
-    participant DB as PostgreSQL/PostGIS
-    end
-
-    Caller->>SIS: importShapefile(file, layerName, batchSize)
-    SIS->>SIS: loadShape(file)
-
-    SIS->>VT: newVirtualThreadJdbcTransaction
-    VT->>LR: findByName(layerName)
-    LR->>DB: SELECT
-    DB-->>LR: null (no duplicate)
-    VT->>LR: save(SpatialLayerRecord)
-    LR->>DB: INSERT spatial_layers
-    DB-->>LR: layerRecord (id)
-    VT-->>SIS: layerRecord
-
-    loop Per batch (batchSize=1000)
-        SIS->>VT: newVirtualThreadJdbcTransaction
-        VT->>DB: batchInsert spatial_features
-        DB-->>VT: inserted rows
-        VT-->>SIS: batch complete
-    end
-
-    SIS-->>Caller: totalInserted count
+```
+io.bluetape4k.science/
+├── coords/                          — Coordinate primitives
+│   ├── GeoLocation.kt              — WGS84 lat/lon, Haversine distance
+│   ├── BoundingBox.kt              — Rectangular boundary, contains/intersects
+│   ├── BoundingBoxRelation.kt      — Relationship computation
+│   ├── DM.kt / DMS.kt              — Degree-minute / degree-minute-second notation
+│   ├── Vector.kt                   — 2D/3D vector
+│   ├── UtmZone.kt                  — UTM zone data class
+│   ├── UtmZoneSupport.kt           — utmZoneOf(), boundingBox()
+│   └── CoordConverters.kt          — Decimal ↔ DM/DMS utilities
+│
+├── projection/                      — CRS transforms (Proj4J)
+│   ├── CrsRegistry.kt              — EPSG/Proj4 registry with instance caching
+│   └── Projections.kt              — wgs84ToUtm(), utmToWgs84(), transform()
+│
+├── shapefile/                       — Shapefile I/O (GeoTools)
+│   ├── ShapeModels.kt              — Shape, ShapeRecord, ShapeHeader (GeoTools-free public API)
+│   ├── ShapefileReader.kt          — Synchronous reader
+│   └── ShapefileExtensions.kt      — loadShape(), loadShapeAsync()
+│
+├── geometry/                        — Spatial geometry (JTS)
+│   ├── GeometryOperations.kt       — intersection, union, buffer, simplify, distance
+│   └── PolygonExtensions.kt        — area, perimeter
+│
+└── exposed/                         — Database pipelines
+    ├── model/
+    │   ├── SpatialModels.kt        — SpatialLayerRecord, SpatialFeatureRecord
+    │   └── NetCdfModels.kt         — NetCdfFileRecord, NetCdfVariableInfo, NetCdfDimensionInfo
+    ├── schema/
+    │   ├── SpatialTables.kt        — SpatialLayerTable, SpatialFeatureTable
+    │   ├── PoiTable.kt             — Point of Interest table
+    │   └── NetCdfTables.kt         — NetCdfFileTable, NetCdfGridValueTable
+    ├── repository/
+    │   ├── SpatialFeatureRepository.kt — Spatial feature CRUD + bbox search
+    │   └── NetCdfFileRepository.kt — NetCDF file metadata CRUD
+    └── service/
+        ├── ShapefileImportService.kt — Virtual Thread batch importer
+        └── NetCdfCatalogService.kt  — ⚠️ Phase 5 — placeholder only
 ```
 
 ---
 
-## Key Features
+## Features
 
-- **Coordinate Primitives**: `GeoLocation` (WGS84), `BoundingBox`, `DM/DMS`, `UtmZone`, `Vector`
-- **Coordinate Transforms**: Proj4J-based WGS84 ↔ UTM and arbitrary EPSG code transformations via `CrsRegistry`
-- **Shapefile I/O**: Synchronous and async Shapefile reading; type-safe `ShapeModels` without exposing GeoTools types
-- **JTS Geometry**: `GeometryOperations` — intersection, union, difference, buffer, simplify, distance
-- **PostGIS Pipeline**: `SpatialLayerTable/Repository` + `SpatialFeatureTable/Repository` +
-  `ShapefileImportService` backed by Virtual Threads
+| Domain | Feature | API |
+|--------|---------|-----|
+| **Coordinates** | WGS84 lat/lon with Haversine distance | `GeoLocation.distanceTo()` |
+| | Rectangular bounding box | `BoundingBox.contains()`, `.intersects()` |
+| | Degree-minute-second notation | `DMS.parse()`, `.toDecimal()` |
+| | UTM zone detection | `utmZoneOf(lat, lon)` |
+| | 2D/3D vector math | `Vector(x, y, z?)` |
+| **Projection** | WGS84 ↔ UTM conversion | `wgs84ToUtm()`, `utmToWgs84()` |
+| | Arbitrary EPSG conversion | `transform(x, y, srcEpsg, tgtEpsg)` |
+| | CRS instance caching | `CrsRegistry` |
+| **Shapefile** | Synchronous Shapefile reading | `loadShape(file)` |
+| | Coroutine-based async reading | `loadShapeAsync(file)` |
+| | Type-safe models (no GeoTools leakage) | `Shape`, `ShapeRecord` |
+| **Geometry** | JTS intersection / union / difference | `GeometryOperations.intersection()` |
+| | Buffer zone creation | `GeometryOperations.buffer()` |
+| | Douglas-Peucker simplification | `GeometryOperations.simplify()` |
+| | Distance calculation | `GeometryOperations.distance()` |
+| **Database** | Spatial layer + feature CRUD | `SpatialLayerRepository`, `SpatialFeatureRepository` |
+| | Virtual Thread batch Shapefile import | `ShapefileImportService` |
+| | NetCDF file metadata catalog | `NetCdfFileRepository` ✅ |
+| | NetCDF grid value storage schema | `NetCdfGridValueTable` ✅ |
+| | `.nc` file import service | `NetCdfCatalogService` ⚠️ Phase 5 |
 
-## Usage Examples
+---
 
-### Coordinate Primitives
+## Quick Start
 
-**GeoLocation — WGS84 latitude/longitude**
+### 5.1 GIS Coordinate Conversion
 
 ```kotlin
 import io.bluetape4k.science.coords.GeoLocation
+import io.bluetape4k.science.coords.BoundingBox
+import io.bluetape4k.science.coords.DMS
+import io.bluetape4k.science.coords.utmZoneOf
+import io.bluetape4k.science.projection.wgs84ToUtm
+import io.bluetape4k.science.projection.utmToWgs84
+import io.bluetape4k.science.projection.transform
 
 val seoul = GeoLocation(latitude = 37.5665, longitude = 126.9780)
 val tokyo = GeoLocation(latitude = 35.6762, longitude = 139.6503)
 
-// Haversine distance (meters)
-val distanceMeters = seoul.distanceTo(tokyo)
-val distanceKm = distanceMeters / 1000.0
-println("Seoul↔Tokyo: $distanceKm km")
+// Haversine distance
+val distanceKm = seoul.distanceTo(tokyo) / 1000.0
+println("Seoul ↔ Tokyo: $distanceKm km")
 
-// Predefined locations
-val newYork = GeoLocation.NEW_YORK
-val london = GeoLocation.LONDON
-```
+// Bounding box
+val seoulArea = BoundingBox(minLat = 37.4, maxLat = 37.6, minLon = 126.8, maxLon = 127.0)
+println("Contains Seoul City Hall: ${seoulArea.contains(seoul)}")
+println("Center: ${seoulArea.center}, Width: ${seoulArea.widthKm} km")
 
-**BoundingBox — rectangular boundary**
-
-```kotlin
-import io.bluetape4k.science.coords.BoundingBox
-
-val seoulArea = BoundingBox(
-    minLat = 37.4, maxLat = 37.6,
-    minLon = 126.8, maxLon = 127.0
-)
-
-if (seoulArea.contains(seoul)) {
-    println("Seoul City Hall is within the area")
-}
-
-println("Center: ${seoulArea.center}")
-println("Width: ${seoulArea.widthKm} km")
-println("Height: ${seoulArea.heightKm} km")
-```
-
-**DMS — degree-minute-second notation**
-
-```kotlin
-import io.bluetape4k.science.coords.DMS
-
+// Degree-minute-second
 val dms = DMS.parse("37°33'59.4\"N")
-val decimal = dms.toDecimal()  // 37.5665
-println("DMS → decimal: $decimal")
+println("DMS → decimal: ${dms.toDecimal()}")  // 37.5665
 
-val dmsStr = DMS(degree = 37, minute = 33, second = 59.4, direction = 'N').toString()
-println("Decimal → DMS: $dmsStr")
-```
-
-**UtmZone — UTM coordinate system**
-
-```kotlin
-import io.bluetape4k.science.coords.utmZoneOf
-
+// UTM zone
 val zone = utmZoneOf(37.5665, 126.9780)
-println("Seoul: UTM Zone ${zone.longitudeZone}${zone.hemisphere}")  // 52S
+println("Seoul UTM Zone: ${zone.longitudeZone}${zone.hemisphere}")  // 52S
 
-val bbox = zone.boundingBox()
-println("Zone boundary: $bbox")
-```
-
-### Coordinate Transformation
-
-**WGS84 ↔ UTM**
-
-```kotlin
-import io.bluetape4k.science.projection.wgs84ToUtm
-import io.bluetape4k.science.projection.utmToWgs84
-import io.bluetape4k.science.coords.UtmZone
-
-val seoul = GeoLocation(37.5665, 126.9780)
+// WGS84 ↔ UTM roundtrip
 val (easting, northing) = wgs84ToUtm(seoul)
-println("WGS84(37.5665, 126.9780) → UTM($easting, $northing)")
-
-val zone = UtmZone(longitudeZone = 52, hemisphere = 'S')
 val restored = utmToWgs84(easting, northing, zone)
-println("UTM → WGS84: $restored")
+println("Roundtrip: $restored")
+
+// Arbitrary EPSG transform (WGS84 → Korea 2000 Central Belt)
+val (kx, ky) = transform(x = 126.9780, y = 37.5665, sourceEpsg = 4326, targetEpsg = 5179)
+println("EPSG:4326 → EPSG:5179: ($kx, $ky)")
 ```
 
-**EPSG code transformation**
-
-```kotlin
-import io.bluetape4k.science.projection.transform
-
-// EPSG:4326 (WGS84) → EPSG:5179 (Korea 2000 Central Belt)
-val (transformedX, transformedY) = transform(
-    x = 126.9780,
-    y = 37.5665,
-    sourceEpsg = 4326,
-    targetEpsg = 5179
-)
-println("EPSG:4326 → EPSG:5179: ($transformedX, $transformedY)")
-```
-
-### Shapefile Reading
-
-**Synchronous**
+### 5.2 Shapefile Processing
 
 ```kotlin
 import io.bluetape4k.science.shapefile.loadShape
+import io.bluetape4k.science.shapefile.loadShapeAsync
 import java.io.File
 
+// Synchronous
 val shapeFile = File("/data/provinces.shp")
 val shape = loadShape(shapeFile, charset = Charsets.UTF_8)
-
 println("Type: ${shape.shapeType}, Records: ${shape.recordCount}")
 
 shape.records.forEach { record ->
     println("Geometry: ${record.geometry.geometryType}")
     println("Attributes: ${record.attributes}")
 }
-```
 
-**Asynchronous (Coroutines)**
-
-```kotlin
-import io.bluetape4k.science.shapefile.loadShapeAsync
-import java.io.File
-
-suspend fun processLargeShapefile() {
-    val shapeFile = File("/data/large_dataset.shp")
-
-    // Processes on Dispatchers.IO
-    val shape = loadShapeAsync(shapeFile)
-
-    shape.records.forEach { record ->
-        // process geometry
-    }
+// Asynchronous (Coroutines — dispatches to Dispatchers.IO)
+suspend fun processAsync() {
+    val large = loadShapeAsync(File("/data/large_dataset.shp"))
+    println("Loaded ${large.recordCount} records")
 }
 ```
 
-### JTS Geometry Operations
+### 5.3 JTS Geometry Operations
 
 ```kotlin
 import io.bluetape4k.science.geometry.GeometryOperations
 import org.locationtech.jts.io.WKTReader
 
 val wkt = WKTReader()
-
 val poly1 = wkt.read("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))")
 val poly2 = wkt.read("POLYGON((5 5, 15 5, 15 15, 5 15, 5 5))")
 
-// Intersection
 val intersection = GeometryOperations.intersection(poly1, poly2)
-
-// Union
-val union = GeometryOperations.union(poly1, poly2)
-
-// Buffer (100m radius)
-val buffered = GeometryOperations.buffer(poly1, 100.0)
-
-// Simplify (Douglas-Peucker, tolerance=1.0)
-val simplified = GeometryOperations.simplify(poly1, 1.0)
-
-// Distance
-val distance = GeometryOperations.distance(poly1, poly2)
+val union        = GeometryOperations.union(poly1, poly2)
+val buffered     = GeometryOperations.buffer(poly1, 100.0)
+val simplified   = GeometryOperations.simplify(poly1, 1.0)
+val distance     = GeometryOperations.distance(poly1, poly2)
 println("Distance: $distance m")
 ```
 
-### PostGIS Database Pipeline
+### 5.4 PostGIS Data Pipeline
 
 ```kotlin
 import io.bluetape4k.science.exposed.service.ShapefileImportService
-import io.bluetape4k.science.exposed.repository.SpatialFeatureRepository
 import io.bluetape4k.science.exposed.repository.SpatialLayerRepository
+import io.bluetape4k.science.exposed.repository.SpatialFeatureRepository
 import org.jetbrains.exposed.sql.Database
 import java.io.File
 
@@ -426,171 +366,307 @@ val database = Database.connect(
     password = "password"
 )
 
-val layerRepo = SpatialLayerRepository()
-val featureRepo = SpatialFeatureRepository()
-val service = ShapefileImportService(layerRepo, featureRepo)
-
-val shapeFile = File("/data/harbors.shp")
+val service = ShapefileImportService(SpatialLayerRepository(), SpatialFeatureRepository())
 val importedCount = service.importShapefile(
-    file = shapeFile,
+    file = File("/data/harbors.shp"),
     layerName = "harbors-2024"
 )
 println("Imported: $importedCount records")
 ```
 
-## Tests (Testcontainers + PostGIS)
+### 5.5 NetCDF Metadata Catalog
 
-Integration tests can be run with Testcontainers-backed PostgreSQL / PostGIS environments. The Korean README includes the full setup and sample test scenarios.
-
-## Performance Optimization
-
-- Cache CRS instances through `CrsRegistry`
-- Use `loadShapeAsync()` for large files
-- Process imports in batches through the PostGIS pipeline
-- Use PostGIS GIST/BRIN spatial indexes for range queries
-
-## NetCDF Support
-
-`bluetape4k-science` provides NetCDF file ingestion via UCAR netCDF-Java 5.9.1.
-Metadata is registered into `netcdf_files`, grid values are imported slice-by-slice into `netcdf_grid_values`,
-and import progress is tracked per (file, variable) in `netcdf_import_progress` for safe resume.
-
-### Architecture (NetCDF pipeline)
-
-```mermaid
-flowchart LR
-    NC[".nc file<br/>(NetCDF-3 / 4)"] -->|NetcdfFiles.open| READ[NetCdfCatalogService]
-    READ --> META[(netcdf_files)]
-    READ -->|Variable.read sliced| AXIS[VariableAxisMap]
-    AXIS --> CRS{CRS}
-    CRS -->|EPSG:4326| GEO[Geographic 1D axis]
-    CRS -->|EPSG:3857/UTM/Polar| PROJ[Projected 2D pair<br/>proj4j]
-    GEO --> SLICE[importSlice2D]
-    PROJ --> SLICE
-    SLICE -->|ON CONFLICT DO NOTHING| GRID[(netcdf_grid_values)]
-    SLICE --> PROG[(netcdf_import_progress)]
-    PROG -->|heartbeat lease 5min| PROG
-    SLICE -.optional.-> METR[Micrometer]
-```
-
-### Features
-
-- **Rank 1 ~ 4 variables** : 1D time series (location null), 2D, 3D (time × lat × lon), 4D (time × level × lat × lon).
-- **Heartbeat lease + sliceIdx resume** : per (`fileId`, `variableName`) lease (5 min TTL).
-  Slice index is linearised as `timeIdx × levelN + levelIdx` for safe 4D resume.
-- **CRS reprojection** via proj4j whitelist:
-  EPSG:4326 / 4269 (Geographic 1D), EPSG:3857, EPSG:32601~32660 / 32701~32760 (UTM north / south),
-  EPSG:3413 / 3031 (Polar) — projected CRS use 2D `(lat, lon)` pair caching.
-- **Axis-to-dimension mapping** : non-standard dim order (e.g. `[lat, lon, time]`) handled via
-  `AxisType` first, then name fallback (`lat`/`latitude`, `lon`/`longitude`, `time`/`t`,
-  `level`/`lev`/`pressure`/`depth`).
-- **NaN / `_FillValue` skip** + Micrometer counter (`netcdf.import.nan.skipped`).
-- **Concurrency safety** : raw `INSERT ... ON CONFLICT DO NOTHING` + partial expression unique indexes
-  (`MD5(ST_AsBinary(location))` for non-null location, plain index for null) prevent duplicate rows on resume.
-- **Optional Micrometer instrumentation** : `netcdf.register.duration`, `netcdf.import.variable.records`,
-  `netcdf.import.slice.duration`, `netcdf.import.nan.skipped`, `netcdf.import.status`.
-
-### Limitations / non-goals
-
-- `CoordinateAxis2D` (curvilinear / rotated pole / tripolar grid) is **not supported** — see follow-up
-  issue if needed. A 2D lat/lon axis raises `NetCdfException.MissingCoordinate`.
-- GRIB / BUFR / OPeNDAP formats: not in scope (use `netcdfAll` jar manually if needed).
-- Method signatures are **blocking** — call from a Spring Boot Virtual Thread executor (Java 21+).
-
-### Examples
+The DB schema and repository are ready. Register NetCDF file metadata directly using `NetCdfFileRepository`.
 
 ```kotlin
-val fileRepo = NetCdfFileRepository()
-val progressRepo = NetCdfImportProgressRepository()
-val service = NetCdfCatalogService(fileRepo, progressRepo, meterRegistry)
+import io.bluetape4k.science.exposed.model.NetCdfFileRecord
+import io.bluetape4k.science.exposed.model.NetCdfVariableInfo
+import io.bluetape4k.science.exposed.repository.NetCdfFileRepository
+import org.jetbrains.exposed.sql.transactions.transaction
 
-// Register a NetCDF file (extracts metadata into netcdf_files)
-val fileId: Long = service.registerFile("/data/era5_2024_01.nc")
+val repo = NetCdfFileRepository()
 
-// Import all values of a variable (creates rows in netcdf_grid_values)
-service.importGridValues(fileId, "temperature")
+transaction {
+    val record = NetCdfFileRecord(
+        filename = "ERA5_2024_01.nc",
+        filePath = "/data/era5/ERA5_2024_01.nc",
+        fileSize = 104_857_600L,
+        variables = listOf(
+            NetCdfVariableInfo(
+                name = "temperature",
+                dataType = "float",
+                shape = listOf(24, 181, 360),
+                attributes = mapOf("units" to "K", "long_name" to "Air Temperature")
+            ),
+            NetCdfVariableInfo(
+                name = "precipitation",
+                dataType = "float",
+                shape = listOf(24, 181, 360),
+                attributes = mapOf("units" to "mm", "long_name" to "Total Precipitation")
+            )
+        ),
+        dimensions = mapOf("time" to 24, "lat" to 181, "lon" to 360),
+        globalAttrs = mapOf("Conventions" to "CF-1.8", "institution" to "ECMWF")
+    )
 
-// Re-call after a crash → resumes from last committed slice
-service.importGridValues(fileId, "temperature")  // no-op if COMPLETED, otherwise resume
+    val saved = repo.save(record)
+    println("Saved: id=${saved.id}, filename=${saved.filename}")
 
-// Concurrency : another caller while lease is active
-try {
-    service.importGridValues(fileId, "temperature")
-} catch (e: NetCdfException.ImportAlreadyRunning) {
-    // retry later — lease will expire after 5 minutes if the holder dies
+    val found = repo.findByIdOrNull(saved.id)
+    println("Variables: ${found?.variables?.map { it.name }}")  // [temperature, precipitation]
+    println("Time steps: ${found?.dimensions?.get("time")}")     // 24
 }
 ```
 
-### Required runtime dependencies
+---
+
+## API Guide
+
+### coords
+
+| Class / Function | Description |
+|------------------|-------------|
+| `GeoLocation(lat, lon)` | WGS84 coordinate; `.distanceTo()` for Haversine distance |
+| `BoundingBox(minLat, maxLat, minLon, maxLon)` | Rectangular boundary; `.contains()`, `.intersects()` |
+| `DMS.parse(str)` / `DM.parse(str)` | Parse degree-minute-second / degree-minute strings |
+| `UtmZone(zone, hemisphere)` | UTM zone data class |
+| `utmZoneOf(lat, lon)` | Auto-detect UTM zone from WGS84 coordinates |
+| `Vector(x, y, z?)` | 2D/3D vector with arithmetic operations |
+
+### projection
+
+| Function | Description |
+|----------|-------------|
+| `wgs84ToUtm(geoLocation)` | WGS84 → UTM (easting, northing) |
+| `utmToWgs84(e, n, zone)` | UTM → WGS84 |
+| `transform(x, y, srcEpsg, tgtEpsg)` | Arbitrary EPSG-to-EPSG conversion |
+| `CrsRegistry` | Thread-safe CRS instance cache by EPSG code |
+
+### shapefile
+
+| Function | Description |
+|----------|-------------|
+| `loadShape(file, charset?)` | Synchronous Shapefile reading |
+| `loadShapeAsync(file, charset?)` | Coroutine-based async reading (`Dispatchers.IO`) |
+| `Shape` | File metadata + record list |
+| `ShapeRecord` | Geometry + attribute map (GeoTools-free public API) |
+
+### geometry
+
+| Function | Description |
+|----------|-------------|
+| `GeometryOperations.intersection(a, b)` | Geometric intersection |
+| `GeometryOperations.union(a, b)` | Geometric union |
+| `GeometryOperations.buffer(g, dist)` | Buffer zone at given distance |
+| `GeometryOperations.simplify(g, tol)` | Douglas-Peucker simplification |
+| `GeometryOperations.distance(a, b)` | Minimum distance between geometries |
+| `Polygon.area()` / `.perimeter()` | Area and perimeter extensions |
+
+### exposed (PostGIS)
+
+| Class | Description |
+|-------|-------------|
+| `SpatialLayerRepository` | Layer CRUD (`save`, `findByName`) |
+| `SpatialFeatureRepository` | Feature CRUD + PostGIS bbox search |
+| `ShapefileImportService` | Virtual Thread batch import from Shapefile |
+
+### exposed (NetCDF)
+
+| Class | Status | Description |
+|-------|--------|-------------|
+| `NetCdfFileRecord` | ✅ | File metadata model (filename, path, size, variables, dimensions) |
+| `NetCdfVariableInfo` | ✅ | Variable descriptor (name, dataType, shape, attributes) |
+| `NetCdfDimensionInfo` | ✅ | Dimension descriptor (name, length, isUnlimited) |
+| `NetCdfFileRepository` | ✅ | File metadata CRUD (`save`, `findByIdOrNull`, `findAll`, `deleteById`) |
+| `NetCdfFileTable` | ✅ | Exposed table — JSONB columns + PostGIS bbox + time range |
+| `NetCdfGridValueTable` | ✅ | Grid value table (location: PostGIS POINT, value, timeIdx, levelIdx) |
+| `NetCdfCatalogService` | ⚠️ Phase 5 | Placeholder — throws `NotImplementedError` until `netcdfAll` is resolved |
+
+---
+
+## Dependencies
+
+`bluetape4k-science` declares optional feature-specific libraries as `compileOnly`.
+Add only what your application uses at runtime.
+
+### Base
 
 ```kotlin
 dependencies {
     implementation("io.github.bluetape4k:bluetape4k-science:${bluetape4kVersion}")
-    // CDM API + NetCDF-3 IOSP
-    implementation("edu.ucar:cdm-core:5.9.1")
-    // Optional — HDF5 / NetCDF-4 IOSP
-    implementation("edu.ucar:netcdf4:5.9.1")
-    // CRS reprojection
-    implementation("org.locationtech.proj4j:proj4j:${proj4jVersion}")
-    implementation("org.locationtech.proj4j:proj4j-epsg:${proj4jVersion}")  // EPSG:32633 etc.
-    implementation("io.micrometer:micrometer-core:${micrometerVersion}")    // optional
-}
-repositories {
-    mavenCentral()
-    // Unidata Nexus — UCAR artefacts are not on Maven Central
-    maven("https://artifacts.unidata.ucar.edu/repository/unidata-all/")
 }
 ```
 
-## Related Modules
-
-- `data/exposed-postgresql`
-- `data/exposed-jdbc`
-- `testing/testcontainers`
-
-## Installation and Dependencies
-
-`bluetape4k-science` declares optional, feature-specific dependencies through
-`compileOnly`. Add only the libraries you actually need at runtime.
-
-### Basic Installation
-
-```kotlin
-dependencies {
-    implementation("io.github.bluetape4k:bluetape4k-science:${bluetape4kVersion}")
-}
-```
-
-### Feature-specific Dependencies
-
-**Coordinate transformation (Proj4J)**
+### GIS Coordinate Conversion (Proj4J)
 
 ```kotlin
 implementation(Libs.proj4j)
 implementation(Libs.proj4j_epsg)
 ```
 
-**Shapefile reading (GeoTools — LGPL)**
+### Shapefile (GeoTools — LGPL)
 
 ```kotlin
-// repositories block
-maven(url = "https://repo.osgeo.org/repository/release/") { name = "OSGeo Release" }
-
-// dependencies
-implementation(Libs.geotools_shapefile)
-implementation(Libs.geotools_referencing)
-implementation(Libs.geotools_epsg_hsql)
+repositories {
+    maven(url = "https://repo.osgeo.org/repository/release/") { name = "OSGeo Release" }
+}
+dependencies {
+    implementation(Libs.geotools_shapefile)
+    implementation(Libs.geotools_referencing)
+    implementation(Libs.geotools_epsg_hsql)
+}
 ```
 
-**Spatial geometry (JTS)**
+> **License note**: GeoTools uses LGPL. `bluetape4k-science` declares it `compileOnly`.
+> Add it explicitly only if your application redistributes GeoTools classes.
+
+### JTS Geometry
 
 ```kotlin
 implementation(Libs.jts_core)
 ```
 
-**PostGIS database**
+### PostGIS Database
 
 ```kotlin
 implementation("io.github.bluetape4k:bluetape4k-exposed-postgresql:${bluetape4kVersion}")
 implementation(Libs.postgis_jdbc)
 ```
+
+### Coroutines (async Shapefile reading)
+
+```kotlin
+implementation("io.github.bluetape4k:bluetape4k-coroutines:${bluetape4kVersion}")
+implementation(Libs.kotlinx_coroutines_core)
+```
+
+### NetCDF (Phase 5 — not yet required)
+
+When `NetCdfCatalogService` is complete, you will need:
+
+```kotlin
+repositories {
+    maven(url = "https://artifacts.unidata.ucar.edu/repository/unidata-all/") { name = "Unidata" }
+}
+dependencies {
+    implementation("edu.ucar:netcdfAll:5.6.0")
+}
+```
+
+### Full Example
+
+```kotlin
+dependencies {
+    implementation("io.github.bluetape4k:bluetape4k-science:${bluetape4kVersion}")
+    implementation(Libs.proj4j)
+    implementation(Libs.proj4j_epsg)
+    implementation(Libs.geotools_shapefile)
+    implementation(Libs.geotools_referencing)
+    implementation(Libs.geotools_epsg_hsql)
+    implementation(Libs.jts_core)
+    implementation("io.github.bluetape4k:bluetape4k-exposed-postgresql:${bluetape4kVersion}")
+    implementation(Libs.postgis_jdbc)
+    implementation("io.github.bluetape4k:bluetape4k-coroutines:${bluetape4kVersion}")
+    implementation(Libs.kotlinx_coroutines_core)
+}
+```
+
+---
+
+## Tests
+
+Integration tests run against a Testcontainers-managed PostgreSQL + PostGIS container (`postgis/postgis:16-3.4`).
+
+### NetCDF Catalog Test
+
+```kotlin
+@Testcontainers
+class NetCdfTableTest : AbstractPostgisTest() {
+
+    private val repo = NetCdfFileRepository()
+
+    @Test
+    fun `save and retrieve NetCDF file record`() {
+        transaction(db) {
+            val record = NetCdfFileRecord(
+                filename = "ERA5_2024_01.nc",
+                filePath = "/data/ERA5_2024_01.nc",
+                fileSize = 1_024_000L,
+                variables = listOf(
+                    NetCdfVariableInfo("temperature", "float", listOf(24, 181, 360),
+                        mapOf("units" to "K"))
+                ),
+                dimensions = mapOf("time" to 24, "lat" to 181, "lon" to 360),
+                globalAttrs = mapOf("Conventions" to "CF-1.8", "institution" to "ECMWF")
+            )
+            val saved = repo.save(record)
+
+            val found = repo.findByIdOrNull(saved.id)
+            found shouldNotBeNull()
+            found.filename shouldBeEqualTo "ERA5_2024_01.nc"
+            found.variables.size shouldBeEqualTo 1
+            found.dimensions["time"] shouldBeEqualTo 24
+        }
+    }
+}
+```
+
+### Shapefile Import Test
+
+```kotlin
+@Test
+fun `import shapefile into PostGIS`() {
+    transaction(db) {
+        SchemaUtils.create(SpatialLayerTable, SpatialFeatureTable)
+        val service = ShapefileImportService(SpatialLayerRepository(), SpatialFeatureRepository())
+        val count = service.importShapefile(
+            file = File("src/test/resources/test-data/provinces.shp"),
+            layerName = "provinces-test"
+        )
+        count shouldBeGreaterThan 0
+    }
+}
+```
+
+---
+
+## Performance / Operations
+
+### Coordinate Transforms
+
+- **CRS caching**: `CrsRegistry` caches instances by EPSG code — repeated transforms have near-zero overhead.
+- **Thread safety**: `CrsRegistry` uses a concurrent map; safe for multi-threaded use.
+
+### Shapefile Processing
+
+- Use `loadShapeAsync()` for large files — dispatches to `Dispatchers.IO`, non-blocking.
+- Stream records lazily for memory-efficient processing of multi-GB Shapefiles.
+
+### PostGIS Database
+
+- **Spatial indexes**: `CREATE INDEX ON spatial_features USING GIST (geom)` for fast bbox queries.
+- **Batch loading**: `ShapefileImportService` processes rows in configurable batches (default: 1000) via Virtual Threads.
+- **Connection pooling**: Use HikariCP or Exposed's built-in pool.
+
+### JTS Geometry
+
+- Apply `GeometryOperations.simplify()` before persistence to reduce coordinate count.
+- Set a consistent `PrecisionModel` in your `GeometryFactory` for reproducible results.
+
+### NetCDF Catalog
+
+- `NetCdfFileTable` stores `bbox` (PostGIS POLYGON) and `timeStart/timeEnd` for spatio-temporal filtering.
+- Add index on `netcdf_files(time_start, time_end)` for time-range queries.
+- Add composite index on `netcdf_grid_values(file_id, variable_name)` for per-variable lookups.
+
+---
+
+## Related Modules
+
+| Module | Purpose |
+|--------|---------|
+| `bluetape4k-core` | Core utilities (compression, assertions) |
+| `bluetape4k-coroutines` | Coroutine extensions (Flow, DeferredValue) |
+| `bluetape4k-exposed-postgresql` | PostGIS column types |
+| `bluetape4k-exposed-jdbc` | Exposed JDBC repository base |
+| `bluetape4k-testing-testcontainers` | Testcontainers helpers |


### PR DESCRIPTION
## Summary

Closes #128

- PR 제목: docs(utils/science): README 전면 재작성 — NetCDF/Shapefile/GIS/JTS/PostGIS 통합 가이드

PR #127 (NetCDF 지원 완성) 이후 `utils/science` README를 5개 도메인을 동등하게 다루는 통합 가이드로 전면 재작성합니다.

Closes #128

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### `utils/science/README.md` + `README.ko.md` (영/한 동기)

| 섹션 | 변경 내용 |
|------|----------|
| 개요 | 5개 도메인 상태 테이블 신설 (✅/⚠️ 구분) |
| Architecture | Mermaid 통합 다이어그램 신규 작성 (5영역 관계도 + 좌표 변환 흐름 + DB 스키마) |
| Module Layout | 전체 패키지 트리 신설 |
| Features | 도메인별 API 대조표 |
| Quick Start | 5개 독립 섹션 (5.1 GIS ~ 5.5 NetCDF) |
| API Guide | coords/projection/shapefile/geometry/exposed(PostGIS+NetCDF) 분리 |
| Dependencies | compileOnly 정책 + 기능별 추가 의존성 (NetCDF Phase 5 포함) |
| Tests | NetCDF 카탈로그 + Shapefile 임포트 테스트 예시 |
| Performance | 도메인별 인덱스 전략 및 튜닝 포인트 |

### NetCDF 현황 정확히 반영

- `NetCdfFileTable`, `NetCdfGridValueTable`, `NetCdfFileRepository`, 모델 클래스: ✅ 구현 완료
- `NetCdfCatalogService`: ⚠️ Phase 5 (NotImplementedError) — edu.ucar:netcdfAll 해결 후 구현 예정
- 기존 README의 "Phase 4: Planned" 표현 제거 → 정확한 상태 명시

### `CHANGELOG.md`

`[Unreleased]` 섹션에 Documentation 항목 추가

### 기존 섹션: 비목표

- 코드 변경 없음 (docs only)
- 새로운 기능 추가 없음

## Validation

- [x] README.md (영문) + README.ko.md (한국어) 동기 재작성
- [x] 언어 전환 링크 유지 (`English | 한국어`)
- [x] Mermaid 다이어그램 5개 (통합 개요 + 좌표 변환 흐름 + DB 스키마 classDiagram + 한국어 버전 2개)
- [x] Quick Start 5개 영역 모두 작성
- [x] CHANGELOG 갱신

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #128, milestone 없음, assignee 없음
- PR: #129, head `61a8443a079878b42a048735019648a51704d039`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `docs/science-readme-rewrite`
- Labels: `documentation`
- State: `MERGED`, merge commit `a0099af278c5317eaf26cba0f1ab0fc9c8781cd3`
- CI: PR #127 (NetCDF 지원 완성) 이후 `utils/science` README를 5개 도메인을 동등하게 다루는 통합 가이드로 전면 재작성합니다. / ### `utils/science/README.md` + `README.ko.md` (영/한 동기) / | Dependencies | compileOnly 정책 + 기능별 추가 의존성 (NetCDF Phase 5 포함) |

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #129 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `a0099af278c5317eaf26cba0f1ab0fc9c8781cd3`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
