### PR TITLE
feat: nightly CI — Testcontainers jobs GitHub Actions Matrix 병렬화

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -460,11 +460,47 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── Infra 모듈 테스트 (Testcontainers) ───────────────────────────────────
+  # ── Infra 모듈 테스트 (Testcontainers) — Matrix 병렬 ─────────────────────
+  # 3 groups run in parallel on separate runners
   test-infra:
-    name: Test / Infra
+    name: Test / Infra (${{ matrix.group }})
     runs-on: ubuntu-latest
     needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - group: redis
+            test_tasks: >-
+              :bluetape4k-redis:test
+              :bluetape4k-redisson:test
+              :bluetape4k-lettuce:test
+              :bluetape4k-cache-lettuce:test
+              :bluetape4k-cache-redisson:test
+            kover_tasks: >-
+              :bluetape4k-redis:koverXmlReport
+              :bluetape4k-redisson:koverXmlReport
+              :bluetape4k-lettuce:koverXmlReport
+              :bluetape4k-cache-lettuce:koverXmlReport
+              :bluetape4k-cache-redisson:koverXmlReport
+          - group: kafka-resilience
+            test_tasks: >-
+              :bluetape4k-kafka:test
+              :bluetape4k-resilience4j:test
+              :bluetape4k-bucket4j:test
+            kover_tasks: >-
+              :bluetape4k-kafka:koverXmlReport
+              :bluetape4k-resilience4j:koverXmlReport
+              :bluetape4k-bucket4j:koverXmlReport
+          - group: cache-misc
+            test_tasks: >-
+              :bluetape4k-micrometer:test
+              :bluetape4k-cache:test
+              :bluetape4k-cache-hazelcast:test
+            kover_tasks: >-
+              :bluetape4k-micrometer:koverXmlReport
+              :bluetape4k-cache:koverXmlReport
+              :bluetape4k-cache-hazelcast:koverXmlReport
     steps:
       - uses: actions/checkout@v4
 
@@ -478,51 +514,28 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
 
-      - name: Build mock-web-server Docker image
-        run: ./gradlew :bluetape4k-mock-web-server:jibDockerBuild --no-configuration-cache
+      - name: Test infra modules (${{ matrix.group }})
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
-
-      - name: Test infra modules (Testcontainers)
+          TEST_TASKS: ${{ matrix.test_tasks }}
         run: |
-          ./gradlew \
-            :bluetape4k-redis:test \
-            :bluetape4k-redisson:test \
-            :bluetape4k-lettuce:test \
-            :bluetape4k-resilience4j:test \
-            :bluetape4k-bucket4j:test \
-            :bluetape4k-micrometer:test \
-            :bluetape4k-kafka:test \
-            :bluetape4k-cache:test \
-            :bluetape4k-cache-lettuce:test \
-            :bluetape4k-cache-redisson:test \
-            :bluetape4k-cache-hazelcast:test
-        env:
-          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+          read -ra tasks <<< "$TEST_TASKS"
+          ./gradlew "${tasks[@]}"
 
       - name: Generate Kover XML report
         if: always()
+        env:
+          KOVER_TASKS: ${{ matrix.kover_tasks }}
         run: |
-          ./gradlew \
-            :bluetape4k-redis:koverXmlReport \
-            :bluetape4k-redisson:koverXmlReport \
-            :bluetape4k-lettuce:koverXmlReport \
-            :bluetape4k-resilience4j:koverXmlReport \
-            :bluetape4k-bucket4j:koverXmlReport \
-            :bluetape4k-micrometer:koverXmlReport \
-            :bluetape4k-kafka:koverXmlReport \
-            :bluetape4k-cache:koverXmlReport \
-            :bluetape4k-cache-lettuce:koverXmlReport \
-            :bluetape4k-cache-redisson:koverXmlReport \
-            :bluetape4k-cache-hazelcast:koverXmlReport \
-            --parallel
+          read -ra tasks <<< "$KOVER_TASKS"
+          ./gradlew "${tasks[@]}" --parallel
         continue-on-error: true
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: nightly-test-results-infra
+          name: nightly-test-results-infra-${{ matrix.group }}
           path: '**/build/test-results/test/*.xml'
           retention-days: 14
 
@@ -530,7 +543,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: nightly-coverage-infra
+          name: nightly-coverage-infra-${{ matrix.group }}
           path: '**/build/reports/kover/'
           retention-days: 14
 
@@ -559,7 +572,8 @@ jobs:
             :bluetape4k-exposed-jdbc:test \
             :bluetape4k-exposed-jdbc-caffeine:test \
             :bluetape4k-exposed-jdbc-lettuce:test \
-            :bluetape4k-exposed-jdbc-redisson:test
+            :bluetape4k-exposed-jdbc-redisson:test \
+            --parallel
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           TEST_DB: h2
@@ -648,11 +662,38 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── Data 모듈 테스트 ──────────────────────────────────────────────────────
+  # ── Data 모듈 테스트 (Testcontainers) — Matrix 병렬 ──────────────────────
+  # 2 groups run in parallel on separate runners
   test-data:
-    name: Test / Data (RDB · NoSQL)
+    name: Test / Data (${{ matrix.group }})
     runs-on: ubuntu-latest
     needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - group: rdb
+            test_tasks: >-
+              :bluetape4k-exposed-postgresql:test
+              :bluetape4k-exposed-mysql8:test
+              :bluetape4k-jdbc:test
+              :bluetape4k-hibernate:test
+              :bluetape4k-hibernate-cache-lettuce:test
+              :bluetape4k-hibernate-reactive:test
+            kover_tasks: >-
+              :bluetape4k-exposed-postgresql:koverXmlReport
+              :bluetape4k-exposed-mysql8:koverXmlReport
+              :bluetape4k-jdbc:koverXmlReport
+              :bluetape4k-hibernate:koverXmlReport
+              :bluetape4k-hibernate-cache-lettuce:koverXmlReport
+              :bluetape4k-hibernate-reactive:koverXmlReport
+          - group: nosql
+            test_tasks: >-
+              :bluetape4k-mongodb:test
+              :bluetape4k-cassandra:test
+            kover_tasks: >-
+              :bluetape4k-mongodb:koverXmlReport
+              :bluetape4k-cassandra:koverXmlReport
     steps:
       - uses: actions/checkout@v4
 
@@ -666,40 +707,28 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
 
-      - name: Test data modules (Testcontainers DB)
-        run: |
-          ./gradlew \
-            :bluetape4k-exposed-postgresql:test \
-            :bluetape4k-exposed-mysql8:test \
-            :bluetape4k-jdbc:test \
-            :bluetape4k-mongodb:test \
-            :bluetape4k-cassandra:test \
-            :bluetape4k-hibernate:test \
-            :bluetape4k-hibernate-cache-lettuce:test \
-            :bluetape4k-hibernate-reactive:test
+      - name: Test data modules (${{ matrix.group }})
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+          TEST_TASKS: ${{ matrix.test_tasks }}
+        run: |
+          read -ra tasks <<< "$TEST_TASKS"
+          ./gradlew "${tasks[@]}"
 
       - name: Generate Kover XML report
         if: always()
+        env:
+          KOVER_TASKS: ${{ matrix.kover_tasks }}
         run: |
-          ./gradlew \
-            :bluetape4k-exposed-postgresql:koverXmlReport \
-            :bluetape4k-exposed-mysql8:koverXmlReport \
-            :bluetape4k-jdbc:koverXmlReport \
-            :bluetape4k-mongodb:koverXmlReport \
-            :bluetape4k-cassandra:koverXmlReport \
-            :bluetape4k-hibernate:koverXmlReport \
-            :bluetape4k-hibernate-cache-lettuce:koverXmlReport \
-            :bluetape4k-hibernate-reactive:koverXmlReport \
-            --parallel
+          read -ra tasks <<< "$KOVER_TASKS"
+          ./gradlew "${tasks[@]}" --parallel
         continue-on-error: true
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: nightly-test-results-data
+          name: nightly-test-results-data-${{ matrix.group }}
           path: '**/build/test-results/test/*.xml'
           retention-days: 14
 
@@ -707,15 +736,42 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: nightly-coverage-data
+          name: nightly-coverage-data-${{ matrix.group }}
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── Spring Boot 3 Docker 테스트 ──────────────────────────────────────────
+  # ── Spring Boot 3 Docker 테스트 — Matrix 병렬 ───────────────────────────
+  # 2 groups run in parallel on separate runners
   test-spring3-docker:
-    name: Test / Spring Boot 3 (Docker)
+    name: Test / Spring Boot 3 (${{ matrix.group }})
     runs-on: ubuntu-latest
     needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - group: core-redis-r2dbc
+            test_tasks: >-
+              :bluetape4k-spring-boot3-core:test
+              :bluetape4k-spring-boot3-redis:test
+              :bluetape4k-spring-boot3-r2dbc:test
+              :bluetape4k-spring-boot3-exposed-r2dbc:test
+            kover_tasks: >-
+              :bluetape4k-spring-boot3-core:koverXmlReport
+              :bluetape4k-spring-boot3-redis:koverXmlReport
+              :bluetape4k-spring-boot3-r2dbc:koverXmlReport
+              :bluetape4k-spring-boot3-exposed-r2dbc:koverXmlReport
+          - group: batch-nosql
+            test_tasks: >-
+              :bluetape4k-spring-boot3-batch-exposed:test
+              :bluetape4k-spring-boot3-mongodb:test
+              :bluetape4k-spring-boot3-cassandra:test
+              :bluetape4k-spring-boot3-hibernate-lettuce:test
+            kover_tasks: >-
+              :bluetape4k-spring-boot3-batch-exposed:koverXmlReport
+              :bluetape4k-spring-boot3-mongodb:koverXmlReport
+              :bluetape4k-spring-boot3-cassandra:koverXmlReport
+              :bluetape4k-spring-boot3-hibernate-lettuce:koverXmlReport
     steps:
       - uses: actions/checkout@v4
 
@@ -734,40 +790,28 @@ jobs:
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
-      - name: Test spring-boot3 modules (Docker)
-        run: |
-          ./gradlew \
-            :bluetape4k-spring-boot3-core:test \
-            :bluetape4k-spring-boot3-redis:test \
-            :bluetape4k-spring-boot3-r2dbc:test \
-            :bluetape4k-spring-boot3-exposed-r2dbc:test \
-            :bluetape4k-spring-boot3-batch-exposed:test \
-            :bluetape4k-spring-boot3-mongodb:test \
-            :bluetape4k-spring-boot3-cassandra:test \
-            :bluetape4k-spring-boot3-hibernate-lettuce:test
+      - name: Test spring-boot3 modules (${{ matrix.group }})
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+          TEST_TASKS: ${{ matrix.test_tasks }}
+        run: |
+          read -ra tasks <<< "$TEST_TASKS"
+          ./gradlew "${tasks[@]}"
 
       - name: Generate Kover XML report
         if: always()
+        env:
+          KOVER_TASKS: ${{ matrix.kover_tasks }}
         run: |
-          ./gradlew \
-            :bluetape4k-spring-boot3-core:koverXmlReport \
-            :bluetape4k-spring-boot3-redis:koverXmlReport \
-            :bluetape4k-spring-boot3-r2dbc:koverXmlReport \
-            :bluetape4k-spring-boot3-exposed-r2dbc:koverXmlReport \
-            :bluetape4k-spring-boot3-batch-exposed:koverXmlReport \
-            :bluetape4k-spring-boot3-mongodb:koverXmlReport \
-            :bluetape4k-spring-boot3-cassandra:koverXmlReport \
-            :bluetape4k-spring-boot3-hibernate-lettuce:koverXmlReport \
-            --parallel
+          read -ra tasks <<< "$KOVER_TASKS"
+          ./gradlew "${tasks[@]}" --parallel
         continue-on-error: true
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: nightly-test-results-spring3-docker
+          name: nightly-test-results-spring3-${{ matrix.group }}
           path: '**/build/test-results/test/*.xml'
           retention-days: 14
 
@@ -775,15 +819,42 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: nightly-coverage-spring3-docker
+          name: nightly-coverage-spring3-${{ matrix.group }}
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── Spring Boot 4 Docker 테스트 ──────────────────────────────────────────
+  # ── Spring Boot 4 Docker 테스트 — Matrix 병렬 ───────────────────────────
+  # 2 groups run in parallel on separate runners
   test-spring4-docker:
-    name: Test / Spring Boot 4 (Docker)
+    name: Test / Spring Boot 4 (${{ matrix.group }})
     runs-on: ubuntu-latest
     needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - group: core-redis-r2dbc
+            test_tasks: >-
+              :bluetape4k-spring-boot4-core:test
+              :bluetape4k-spring-boot4-redis:test
+              :bluetape4k-spring-boot4-r2dbc:test
+              :bluetape4k-spring-boot4-exposed-r2dbc:test
+            kover_tasks: >-
+              :bluetape4k-spring-boot4-core:koverXmlReport
+              :bluetape4k-spring-boot4-redis:koverXmlReport
+              :bluetape4k-spring-boot4-r2dbc:koverXmlReport
+              :bluetape4k-spring-boot4-exposed-r2dbc:koverXmlReport
+          - group: batch-nosql
+            test_tasks: >-
+              :bluetape4k-spring-boot4-batch-exposed:test
+              :bluetape4k-spring-boot4-mongodb:test
+              :bluetape4k-spring-boot4-cassandra:test
+              :bluetape4k-spring-boot4-hibernate-lettuce:test
+            kover_tasks: >-
+              :bluetape4k-spring-boot4-batch-exposed:koverXmlReport
+              :bluetape4k-spring-boot4-mongodb:koverXmlReport
+              :bluetape4k-spring-boot4-cassandra:koverXmlReport
+              :bluetape4k-spring-boot4-hibernate-lettuce:koverXmlReport
     steps:
       - uses: actions/checkout@v4
 
@@ -807,40 +878,28 @@ jobs:
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
-      - name: Test spring-boot4 modules (Docker)
-        run: |
-          ./gradlew \
-            :bluetape4k-spring-boot4-core:test \
-            :bluetape4k-spring-boot4-redis:test \
-            :bluetape4k-spring-boot4-r2dbc:test \
-            :bluetape4k-spring-boot4-exposed-r2dbc:test \
-            :bluetape4k-spring-boot4-batch-exposed:test \
-            :bluetape4k-spring-boot4-mongodb:test \
-            :bluetape4k-spring-boot4-cassandra:test \
-            :bluetape4k-spring-boot4-hibernate-lettuce:test
+      - name: Test spring-boot4 modules (${{ matrix.group }})
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+          TEST_TASKS: ${{ matrix.test_tasks }}
+        run: |
+          read -ra tasks <<< "$TEST_TASKS"
+          ./gradlew "${tasks[@]}"
 
       - name: Generate Kover XML report
         if: always()
+        env:
+          KOVER_TASKS: ${{ matrix.kover_tasks }}
         run: |
-          ./gradlew \
-            :bluetape4k-spring-boot4-core:koverXmlReport \
-            :bluetape4k-spring-boot4-redis:koverXmlReport \
-            :bluetape4k-spring-boot4-r2dbc:koverXmlReport \
-            :bluetape4k-spring-boot4-exposed-r2dbc:koverXmlReport \
-            :bluetape4k-spring-boot4-batch-exposed:koverXmlReport \
-            :bluetape4k-spring-boot4-mongodb:koverXmlReport \
-            :bluetape4k-spring-boot4-cassandra:koverXmlReport \
-            :bluetape4k-spring-boot4-hibernate-lettuce:koverXmlReport \
-            --parallel
+          read -ra tasks <<< "$KOVER_TASKS"
+          ./gradlew "${tasks[@]}" --parallel
         continue-on-error: true
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: nightly-test-results-spring4-docker
+          name: nightly-test-results-spring4-${{ matrix.group }}
           path: '**/build/test-results/test/*.xml'
           retention-days: 14
 
@@ -848,7 +907,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: nightly-coverage-spring4-docker
+          name: nightly-coverage-spring4-${{ matrix.group }}
           path: '**/build/reports/kover/'
           retention-days: 14
 
@@ -968,7 +1027,23 @@ jobs:
   coverage-report:
     name: Coverage Report
     runs-on: ubuntu-latest
-    needs: [build, detekt, test-core, test-io, test-utils, test-misc, test-exposed-core, test-spring-h2, test-infra, test-exposed-jdbc-docker, test-exposed-r2dbc-docker, test-data, test-spring3-docker, test-spring4-docker, test-testcontainers, test-aws]
+    needs:
+      - build
+      - detekt
+      - test-core
+      - test-io
+      - test-utils
+      - test-misc
+      - test-exposed-core
+      - test-spring-h2
+      - test-infra
+      - test-exposed-jdbc-docker
+      - test-exposed-r2dbc-docker
+      - test-data
+      - test-spring3-docker
+      - test-spring4-docker
+      - test-testcontainers
+      - test-aws
     if: always()
     steps:
       - uses: actions/checkout@v4
@@ -997,7 +1072,24 @@ jobs:
   nightly-status:
     name: Nightly Status
     runs-on: ubuntu-latest
-    needs: [build, detekt, test-core, test-io, test-utils, test-misc, test-exposed-core, test-spring-h2, test-infra, test-exposed-jdbc-docker, test-exposed-r2dbc-docker, test-data, test-spring3-docker, test-spring4-docker, test-testcontainers, test-aws, coverage-report]
+    needs:
+      - build
+      - detekt
+      - test-core
+      - test-io
+      - test-utils
+      - test-misc
+      - test-exposed-core
+      - test-spring-h2
+      - test-infra
+      - test-exposed-jdbc-docker
+      - test-exposed-r2dbc-docker
+      - test-data
+      - test-spring3-docker
+      - test-spring4-docker
+      - test-testcontainers
+      - test-aws
+      - coverage-report
     if: always()
     steps:
       - name: Check all jobs


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: feat: nightly CI — Testcontainers jobs GitHub Actions Matrix 병렬화

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 목적
Nightly 빌드에서 Testcontainers 테스트 소요 시간을 단축하기 위해 순차 실행 job들을 GitHub Actions Matrix로 병렬 실행으로 전환.

### Matrix 분할

| Job | 이전 | 이후 | Parallel runners |
|-----|------|------|-----------------|
| `test-infra` | 11개 모듈 순차 | 3 groups (redis / kafka-resilience / cache-misc) | +2 runners |
| `test-data` | 8개 모듈 순차 | 2 groups (rdb / nosql) | +1 runner |
| `test-spring3-docker` | 8개 모듈 순차 | 2 groups (core-redis-r2dbc / batch-nosql) | +1 runner |
| `test-spring4-docker` | 8개 모듈 순차 | 2 groups (core-redis-r2dbc / batch-nosql) | +1 runner |

### 추가 개선
- **test-infra**: `jibDockerBuild` 제거 — infra 모듈이 mock-server를 사용하지 않음을 확인
- **test-exposed-jdbc-docker**: `--parallel` 추가
- **fail-fast: false**: 한 group 실패해도 나머지 계속 실행
- SC2086 (word splitting) 수정: `read -ra` 배열 패턴 사용

### 검증
- `actionlint` 검증 통과 (에러 0개)
- coverage-report / nightly-status의 `needs` 리스트는 base job 이름만 유지 (matrix 전체 대기 자동 적용)

### 아티팩트 이름
Matrix group별 고유 이름 사용 — `nightly-coverage-infra-redis`, `nightly-coverage-data-rdb` 등.
기존 `pattern: nightly-coverage-*` 다운로드는 그대로 동작.

### 기존 섹션: 관련 이슈

- NetCdfCatalogServiceTest #29 fix (이전 커밋)
- jibDockerBuild 403 fix (이전 커밋)

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #159, head `ec500dee0e6ee4c292ae65261e090a7b898fe36f`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/ci-nightly-matrix`
- Labels: 없음
- State: `MERGED`, merge commit `8198f429e4da5942459e6c10458a393a2e10c089`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #159 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `8198f429e4da5942459e6c10458a393a2e10c089`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
