### PR TITLE
feat: bluetape4k-pulsar 모듈 신규 구현 (Issue #147)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ All tools installed at `/opt/homebrew/bin/`.
 | `aws/`           | Java SDK v2, 3-tier API (sync→async→coroutines)                                                                             |
 | `aws-kotlin/`    | Kotlin SDK, native suspend                                                                                                  |
 | `data/`          | `exposed-*` (core/dao/jdbc/r2dbc/cache/db-specific), `hibernate`, `mongodb`, `jdbc`, `r2dbc`, `cassandra`                   |
-| `infra/`         | `lettuce`, `redisson`, `kafka`, `resilience4j`, `bucket4j`, `micrometer`, `opentelemetry`, `cache-*`, `elasticsearch`       |
+| `infra/`         | `lettuce`, `redisson`, `kafka`, `pulsar`, `resilience4j`, `bucket4j`, `micrometer`, `opentelemetry`, `cache-*`, `elasticsearch` |
 | `spring-boot3/`  | WebFlux+Coroutines, Exposed JDBC/R2DBC repos, Hibernate Lettuce cache, Spring Batch                                         |
 | `spring-boot4/`  | Same as boot3 — use `implementation(platform(Libs.spring_boot4_dependencies))` (not `dependencyManagement`)                 |
 | `utils/`         | `geo`, `idgenerators`, `javatimes`, `jwt`, `batch`, `lingua`, `states`, `workflow`, `measured`, `money`, `text-search`      |

--- a/docs/superpowers/plans/2026-04-27-infra-pulsar-plan.md
+++ b/docs/superpowers/plans/2026-04-27-infra-pulsar-plan.md
@@ -1,0 +1,886 @@
+# bluetape4k-pulsar 구현 플랜
+
+- Spec: docs/superpowers/specs/2026-04-27-infra-pulsar-design.md
+- Issue: #147
+- 브랜치: feat/infra-pulsar
+- 작성일: 2026-04-27
+
+---
+
+## 개요
+
+`infra/pulsar` 모듈을 신규 추가한다. Apache Pulsar Java Client(3.3.9)를 Kotlin Coroutines / Flow 로 감싸는
+extension function 우선의 래퍼 라이브러리이다. 산출물은 12개 Task 로 분할되며 각 Task는 독립적으로 검증 가능하다.
+
+### 모듈 패키지 루트
+
+`io.bluetape4k.pulsar` (자동 등록명: `bluetape4k-pulsar`)
+
+### 설계 원칙 (스펙 §2-2 발췌)
+
+- **Extension functions 우선** (object 메서드 금지)
+- **CompletableFuture → Coroutine**: `awaitSuspending()` 사용 (`bluetape4k-coroutines`)
+- **Flow 변환 폴링 패턴**: `flow { while (currentCoroutineContext().isActive) { ... } }`
+  + 취소 시 대기 중 `CompletableFuture.cancel(true)` 명시적 호출
+- **DSL**: `pulsarClient {}`, `producer {}`, `consumer {}`, `reader {}`
+- **withXxx {}**: `suspend inline fun` + `try/finally { closeAsync().awaitSuspending() }`
+- top-level 파일 로깅: `private val log = KotlinLogging.logger {}`
+- 클래스 파일: `companion object : KLogging()`
+
+---
+
+## Tasks
+
+### T1 — 모듈 Gradle 설정 + 테스트 리소스
+**complexity: medium**
+
+생성 파일:
+- `infra/pulsar/build.gradle.kts`
+- `infra/pulsar/src/test/resources/junit-platform.properties`
+- `infra/pulsar/src/test/resources/logback-test.xml`
+
+구현 힌트:
+
+`build.gradle.kts` — `infra/nats/build.gradle.kts` 패턴 참고. 스펙 §5 의존성 정확히 반영.
+
+```kotlin
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    api(project(":bluetape4k-core"))
+    api(project(":bluetape4k-coroutines"))
+
+    // Pulsar — pulsar_client(구현체 포함) vs pulsar_client_api(인터페이스만) 구분
+    // 래퍼 라이브러리이므로 PulsarClient.builder().build() 사용 → 구현체 필요 → pulsar_client 사용
+    api(Libs.pulsar_client)                    // 3.3.9 — buildSrc/Libs.kt 에 존재 확인 필요
+
+    // Jackson (compileOnly — 사용 모듈이 런타임에 implementation 으로 선언)
+    compileOnly(project(":bluetape4k-jackson2"))
+    compileOnly(Libs.jackson_databind)
+    compileOnly(project(":bluetape4k-jackson3"))
+    compileOnly(Libs.jackson3_databind)
+
+    // Coroutines
+    implementation(Libs.kotlinx_coroutines_core)
+    testImplementation(Libs.kotlinx_coroutines_test)
+
+    // Testcontainers
+    testImplementation(project(":bluetape4k-junit5"))
+    testImplementation(project(":bluetape4k-testcontainers"))
+    testImplementation(Libs.testcontainers_pulsar)
+
+    // 테스트용 Jackson (Schema 라운드트립용)
+    testImplementation(project(":bluetape4k-jackson2"))
+    testImplementation(project(":bluetape4k-jackson3"))
+    testImplementation(Libs.jackson_module_kotlin)
+}
+```
+
+`junit-platform.properties` — `bluetape4k-projects/.claude/templates` 또는 다른 모듈 (예: `infra/nats/src/test/resources/junit-platform.properties`) 그대로 복사:
+
+```
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+```
+
+`logback-test.xml` — 기존 모듈(예: `infra/nats/src/test/resources/logback-test.xml`)을 그대로 복사하고
+패키지명만 `io.bluetape4k.pulsar` 로 교체.
+
+**검증**:
+- `./gradlew :bluetape4k-pulsar:dependencies` 실행 시 `pulsar_client`, `kotlinx_coroutines_core` 해석 성공
+- `./gradlew :bluetape4k-pulsar:compileKotlin` 통과 (소스가 비어 있어도 OK)
+
+---
+
+### T2 — PulsarClientSupport (DSL + withPulsarClient)
+**complexity: medium**
+
+생성 파일:
+- `infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/PulsarClientSupport.kt`
+
+구현 힌트:
+
+```kotlin
+package io.bluetape4k.pulsar
+
+import io.bluetape4k.coroutines.support.awaitSuspending
+import io.bluetape4k.logging.KotlinLogging
+import org.apache.pulsar.client.api.ClientBuilder
+import org.apache.pulsar.client.api.PulsarClient
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * [PulsarClient] DSL 빌더.
+ *
+ * @param serviceUrl 비어있지 않으면 `serviceUrl(serviceUrl)` 호출 후 setup 블록 적용
+ * @param setup [ClientBuilder] 추가 설정
+ */
+fun pulsarClient(
+    serviceUrl: String = "",
+    setup: ClientBuilder.() -> Unit = {},
+): PulsarClient {
+    val builder = PulsarClient.builder()
+    if (serviceUrl.isNotBlank()) builder.serviceUrl(serviceUrl)
+    return builder.apply(setup).build()
+}
+
+/**
+ * Pulsar 클라이언트 생명주기를 블록 스코프로 자동 관리한다.
+ *
+ * 블록 종료 시(정상/예외/취소 무관) `client.closeAsync().awaitSuspending()` 으로 비동기 close 보장.
+ */
+suspend inline fun <T> withPulsarClient(
+    serviceUrl: String,
+    noinline setup: ClientBuilder.() -> Unit = {},
+    crossinline block: suspend PulsarClient.() -> T,
+): T {
+    val client = pulsarClient(serviceUrl, setup)
+    try {
+        return block(client)
+    } finally {
+        runCatching { client.closeAsync().awaitSuspending() }
+    }
+}
+```
+
+**주의**:
+- `inline fun` + `crossinline` 사용. `noinline` 은 inline 컨텍스트로 람다를 전달할 수 없는 setup 람다에 적용
+- finally 의 close 실패가 본 예외를 가리지 않도록 `runCatching` 사용
+
+**검증**: 컴파일 통과. T7 의 `AbstractPulsarTest` 에서 사용됨.
+
+---
+
+### T3 — ProducerSupport + ProducerExtensions
+**complexity: medium**
+
+생성 파일:
+- `infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/producer/ProducerSupport.kt`
+- `infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/producer/ProducerExtensions.kt`
+
+#### `ProducerSupport.kt`
+
+```kotlin
+package io.bluetape4k.pulsar.producer
+
+import io.bluetape4k.coroutines.support.awaitSuspending
+import io.bluetape4k.logging.KotlinLogging
+import org.apache.pulsar.client.api.Producer
+import org.apache.pulsar.client.api.ProducerBuilder
+import org.apache.pulsar.client.api.PulsarClient
+import org.apache.pulsar.client.api.Schema
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * [Producer] DSL 빌더 (PulsarClient 확장).
+ */
+fun <T> PulsarClient.producer(
+    schema: Schema<T>,
+    setup: ProducerBuilder<T>.() -> Unit,
+): Producer<T> = newProducer(schema).apply(setup).create()
+
+/**
+ * Producer 생명주기를 블록 스코프로 관리. 종료 시 `closeAsync().awaitSuspending()`.
+ */
+suspend inline fun <T, R> PulsarClient.withProducer(
+    schema: Schema<T>,
+    noinline setup: ProducerBuilder<T>.() -> Unit = {},
+    crossinline block: suspend Producer<T>.() -> R,
+): R {
+    val producer = producer(schema, setup)
+    try {
+        return block(producer)
+    } finally {
+        runCatching { producer.closeAsync().awaitSuspending() }
+    }
+}
+```
+
+#### `ProducerExtensions.kt`
+
+```kotlin
+package io.bluetape4k.pulsar.producer
+
+import io.bluetape4k.coroutines.support.awaitSuspending
+import io.bluetape4k.logging.KotlinLogging
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.apache.pulsar.client.api.MessageId
+import org.apache.pulsar.client.api.Producer
+import org.apache.pulsar.client.api.TypedMessageBuilder
+
+private val log = KotlinLogging.logger {}
+
+/** suspend send — `sendAsync(message).awaitSuspending()`. */
+suspend fun <T> Producer<T>.sendSuspend(message: T): MessageId =
+    sendAsync(message).awaitSuspending()
+
+/**
+ * TypedMessageBuilder DSL 기반 send.
+ *
+ * ```
+ * producer.sendSuspend<Order> {
+ *     value(order); key("order-${order.id}"); property("v", "1")
+ * }
+ * ```
+ */
+suspend fun <T> Producer<T>.sendSuspend(
+    setup: TypedMessageBuilder<T>.() -> Unit,
+): MessageId = newMessage().apply(setup).sendAsync().awaitSuspending()
+
+/**
+ * Flow 기반 배치 발행.
+ *
+ * 첫 실패 시 Flow 가 즉시 종료되고 예외가 전파된다 (재시도는 호출자 책임).
+ * map 의 suspend 람다 안에서 sendSuspend 호출 — 실패 시 자연스럽게 throw.
+ */
+fun <T> Producer<T>.sendAsFlow(messages: Flow<T>): Flow<MessageId> =
+    messages.map { sendSuspend(it) }
+```
+
+**주의**:
+- `sendAsFlow` 는 Kafka 의 `sendAsFlow` 와 달리 `flush()` 없음 (Pulsar 는 자동 batch flush)
+- 첫 실패 시 종료 → `Flow.map` 자체가 예외를 전파하므로 별도 처리 불필요
+- `Flow.map { }` 람다는 내부적으로 suspend 컨텍스트 — `sendSuspend` (suspend fun) 호출 가능. 컴파일 오류 없음
+
+**검증**: T7 `ProducerExtensionsTest` 에서 검증.
+
+---
+
+### T4 — ConsumerSupport + ConsumerExtensions
+**complexity: high**
+
+생성 파일:
+- `infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/consumer/ConsumerSupport.kt`
+- `infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/consumer/ConsumerExtensions.kt`
+
+#### `ConsumerSupport.kt`
+
+`ProducerSupport.kt` 와 동일 패턴. `PulsarClient.consumer(schema, setup)` + `withConsumer`.
+
+```kotlin
+fun <T> PulsarClient.consumer(
+    schema: Schema<T>,
+    setup: ConsumerBuilder<T>.() -> Unit,
+): Consumer<T> = newConsumer(schema).apply(setup).subscribe()
+
+suspend inline fun <T, R> PulsarClient.withConsumer(
+    schema: Schema<T>,
+    noinline setup: ConsumerBuilder<T>.() -> Unit = {},
+    crossinline block: suspend Consumer<T>.() -> R,
+): R {
+    val consumer = consumer(schema, setup)
+    try { return block(consumer) }
+    finally { runCatching { consumer.closeAsync().awaitSuspending() } }
+}
+```
+
+#### `ConsumerExtensions.kt` (스펙 §3-3 생명주기 계약 엄수)
+
+```kotlin
+package io.bluetape4k.pulsar.consumer
+
+import io.bluetape4k.coroutines.support.awaitSuspending
+import io.bluetape4k.logging.KotlinLogging
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.isActive
+import org.apache.pulsar.client.api.Consumer
+import org.apache.pulsar.client.api.Message
+
+private val log = KotlinLogging.logger {}
+
+/** suspend receive — `receiveAsync().awaitSuspending()`. */
+suspend fun <T> Consumer<T>.receiveSuspend(): Message<T> =
+    receiveAsync().awaitSuspending()
+
+/**
+ * Flow 기반 무한 소비.
+ *
+ * ## 생명주기 계약 (스펙 §3-3)
+ * - Flow 취소 시 대기 중인 [java.util.concurrent.CompletableFuture]를 `cancel(true)` 호출 후 종료
+ * - Flow 는 Consumer 를 소유하지 않음 — 호출자/`withConsumer {}` 가 close 책임
+ * - 브로커 연결 끊김은 Pulsar Client 자동 재연결 — receiveAsync() 가 그동안 블로킹
+ */
+fun <T> Consumer<T>.receiveAsFlow(): Flow<Message<T>> = flow {
+    while (currentCoroutineContext().isActive) {
+        val future = receiveAsync()
+        try {
+            emit(future.awaitSuspending())
+        } catch (ce: CancellationException) {
+            future.cancel(true)
+            throw ce
+        }
+    }
+}
+
+/** suspend ack — `acknowledgeAsync(message).awaitSuspending()`. */
+suspend fun <T> Consumer<T>.acknowledgeSuspend(message: Message<T>) {
+    acknowledgeAsync(message).awaitSuspending()
+}
+
+/**
+ * Cumulative ack (suspend).
+ *
+ * **주의**: Shared subscription 에서 호출하면 `PulsarClientException` 발생.
+ * Exclusive / Failover 구독에서만 사용해야 한다.
+ */
+suspend fun <T> Consumer<T>.acknowledgeCumulativeSuspend(message: Message<T>) {
+    acknowledgeCumulativeAsync(message).awaitSuspending()
+}
+
+// negativeAcknowledge 확장 정의 없음:
+// Consumer 인터페이스에 이미 negativeAcknowledge(Message<T>) 가 void 로 정의됨.
+// 동일 시그니처 확장은 인스턴스 메서드에 가려지므로 아무 효과 없음.
+// 호출자는 consumer.negativeAcknowledge(msg) 를 직접 사용한다.
+```
+
+**주의**:
+- `negativeAcknowledge` 확장 **생략 확정**: Pulsar `Consumer` 인터페이스에 동일 시그니처 메서드가 이미 존재.
+  확장이 인스턴스 메서드보다 우선되지 않으므로 무의미. DoD에서도 제외됨.
+- `currentCoroutineContext().isActive` 사용 (`coroutineContext` 임포트 필요 없음)
+
+**검증**: T8 `ConsumerExtensionsTest` 에서 검증.
+
+---
+
+### T5 — ReaderSupport + ReaderExtensions
+**complexity: medium**
+
+생성 파일:
+- `infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/reader/ReaderSupport.kt`
+- `infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/reader/ReaderExtensions.kt`
+
+#### `ReaderSupport.kt`
+
+`ConsumerSupport.kt` 동일 패턴.
+
+```kotlin
+fun <T> PulsarClient.reader(
+    schema: Schema<T>,
+    setup: ReaderBuilder<T>.() -> Unit,
+): Reader<T> = newReader(schema).apply(setup).create()
+
+suspend inline fun <T, R> PulsarClient.withReader(
+    schema: Schema<T>,
+    noinline setup: ReaderBuilder<T>.() -> Unit = {},
+    crossinline block: suspend Reader<T>.() -> R,
+): R {
+    val reader = reader(schema, setup)
+    try { return block(reader) }
+    finally { runCatching { reader.closeAsync().awaitSuspending() } }
+}
+```
+
+#### `ReaderExtensions.kt`
+
+```kotlin
+suspend fun <T> Reader<T>.readNextSuspend(): Message<T> =
+    readNextAsync().awaitSuspending()
+
+/**
+ * `hasMessageAvailable()` 기반 Flow.
+ *
+ * ## 생명주기 계약
+ * - `hasMessageAvailable() == false` 이면 Flow 정상 종료
+ * - 취소 시 대기 중 `CompletableFuture.cancel(true)` 후 종료
+ * - Reader 는 Flow 가 소유하지 않음
+ */
+fun <T> Reader<T>.readAsFlow(): Flow<Message<T>> = flow {
+    while (currentCoroutineContext().isActive && hasMessageAvailable()) {
+        val future = readNextAsync()
+        try {
+            emit(future.awaitSuspending())
+        } catch (ce: CancellationException) {
+            future.cancel(true)
+            throw ce
+        }
+    }
+}
+```
+
+**주의**:
+- `hasMessageAvailable()` 은 동기 호출. Pulsar Java Client 내부에서 캐시된 큐를 확인하는 방식이므로
+  대부분 비블로킹이나, 확인 필요 시 `withContext(Dispatchers.IO)` 로 감싸서 테스트해볼 것.
+- T9 테스트에서 동작 확인.
+
+**검증**: T9 `ReaderExtensionsTest` 에서 검증.
+
+---
+
+### T6 — Jackson Schema (compileOnly)
+**complexity: medium**
+
+생성 파일:
+- `infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/codec/JacksonSchema.kt` (Jackson2)
+- `infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/codec/Jackson3Schema.kt` (Jackson3)
+
+#### `JacksonSchema.kt` (Jackson2 — `com.fasterxml.jackson.databind.ObjectMapper`)
+
+```kotlin
+package io.bluetape4k.pulsar.codec
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.bluetape4k.jackson.Jackson
+import io.bluetape4k.logging.KotlinLogging
+import org.apache.pulsar.client.api.Schema
+import org.apache.pulsar.common.schema.SchemaInfo
+import org.apache.pulsar.common.schema.SchemaType
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Jackson2 기반 Pulsar [Schema] 구현.
+ *
+ * ⚠️ **compileOnly 의존**: 사용 모듈은 `bluetape4k-jackson2` 를 implementation 으로 선언해야 한다.
+ * 누락 시 런타임에 `NoClassDefFoundError` 발생.
+ */
+fun <T> jacksonSchema(
+    type: Class<T>,
+    mapper: ObjectMapper = Jackson.defaultJsonMapper,
+): Schema<T> = JacksonSchemaImpl(type, mapper)
+
+inline fun <reified T> jacksonSchema(
+    mapper: ObjectMapper = Jackson.defaultJsonMapper,
+): Schema<T> = jacksonSchema(T::class.java, mapper)
+
+private class JacksonSchemaImpl<T>(
+    private val type: Class<T>,
+    private val mapper: ObjectMapper,
+) : Schema<T> {
+    private val info: SchemaInfo = SchemaInfo.builder()
+        .name(type.simpleName)
+        .type(SchemaType.JSON)
+        .schema(ByteArray(0))            // 브로커 스키마 검증 없음
+        .build()
+
+    override fun encode(message: T): ByteArray = mapper.writeValueAsBytes(message)
+    override fun decode(bytes: ByteArray): T = mapper.readValue(bytes, type)
+    override fun getSchemaInfo(): SchemaInfo = info
+    override fun clone(): Schema<T> = JacksonSchemaImpl(type, mapper)
+}
+```
+
+#### `Jackson3Schema.kt` (Jackson3 — `tools.jackson.databind.ObjectMapper`)
+
+위와 동일한 구조. import 만 다름:
+
+```kotlin
+import tools.jackson.databind.ObjectMapper as Jackson3ObjectMapper
+
+fun <T> jackson3Schema(
+    type: Class<T>,
+    mapper: Jackson3ObjectMapper,
+): Schema<T> = Jackson3SchemaImpl(type, mapper)
+
+inline fun <reified T> jackson3Schema(
+    mapper: Jackson3ObjectMapper,
+): Schema<T> = jackson3Schema(T::class.java, mapper)
+```
+
+Jackson3 의 default mapper 헬퍼는 `bluetape4k-jackson3` 모듈의 정확한 API 명을 확인해서 사용 (`io.bluetape4k.jackson3.Jackson3.defaultJsonMapper` 등이 있는지 검토; 없으면 default 인자 제거하고 호출자가 mapper 전달).
+
+**주의**:
+- `Schema<T>.clone()` 은 Pulsar 인터페이스 요구. 새 인스턴스 반환
+- `getSchemaInfo()` 의 schema bytes 는 `ByteArray(0)` — 브로커 호환성 우선
+
+**검증**: T10 에서 라운드트립 테스트.
+
+---
+
+### T7 — AbstractPulsarTest + ProducerExtensionsTest
+**complexity: medium**
+
+생성 파일:
+- `infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/AbstractPulsarTest.kt`
+- `infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/producer/ProducerExtensionsTest.kt`
+
+#### `AbstractPulsarTest.kt`
+
+```kotlin
+package io.bluetape4k.pulsar
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.mq.PulsarServer
+import org.apache.pulsar.client.api.PulsarClient
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+
+abstract class AbstractPulsarTest {
+
+    companion object : KLogging() {
+        @JvmStatic
+        protected val pulsar = PulsarServer.Launcher.pulsar  // lazy 시작
+    }
+
+    protected lateinit var client: PulsarClient
+
+    @BeforeEach
+    fun setupClient() {
+        client = pulsarClient(pulsar.url) {
+            // 기본 설정만
+        }
+    }
+
+    @AfterEach
+    fun closeClient() {
+        runCatching { client.close() }
+    }
+
+    /** 테스트별 고유 토픽 — 토픽 충돌 방지. */
+    protected fun newTopic(prefix: String = "test"): String =
+        "persistent://public/default/$prefix-${java.util.UUID.randomUUID()}"
+
+    /** 테스트별 고유 subscriptionName — 스펙 §3-3 패턴. */
+    protected fun newSubscription(prefix: String = "test-sub"): String =
+        "$prefix-${java.util.UUID.randomUUID()}"
+}
+```
+
+#### `ProducerExtensionsTest.kt`
+
+```kotlin
+class ProducerExtensionsTest : AbstractPulsarTest() {
+
+    @Test
+    fun `sendSuspend - 단건 발행`() = runTest {
+        val topic = newTopic()
+        client.withProducer(Schema.STRING, { topic(topic) }) {
+            val msgId = sendSuspend("hello")
+            msgId.shouldNotBeNull()
+        }
+    }
+
+    @Test
+    fun `sendAsFlow - 100건 발행 후 결과 수신`() = runTest {
+        val topic = newTopic()
+        client.withProducer(Schema.STRING, { topic(topic) }) {
+            val results = sendAsFlow(flow {
+                repeat(100) { emit("msg-$it") }
+            }).toList()
+            results.size shouldBeEqualTo 100
+        }
+    }
+}
+```
+
+**주의**:
+- `runTest(timeout = 30.seconds)` 로 타임아웃 반드시 명시 (Pulsar 컨테이너 첫 시작 시 시간 소요)
+  → T7 코드 블록의 두 테스트도 `runTest(timeout = 30.seconds)` / `runTest(timeout = 60.seconds)` 적용
+- Kluent matcher: `shouldBeEqualTo`, `shouldNotBeNull` (절대 `(x == y).shouldBeTrue()` 금지)
+- `pulsarClient {}` DSL 사용 이유: `PulsarServer.Launcher.PulsarClient()` 팩토리 대신 본 모듈의 DSL을 직접 검증하기 위함
+
+**검증**: `./gradlew :bluetape4k-pulsar:test --tests "*ProducerExtensionsTest"` 통과.
+
+---
+
+### T8 — ConsumerExtensionsTest
+**complexity: medium**
+
+생성 파일:
+- `infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/consumer/ConsumerExtensionsTest.kt`
+
+테스트 케이스:
+1. `receiveSuspend + acknowledgeSuspend 라운드트립` — Producer 1건 발행 후 Consumer 1건 수신 + ack
+2. `receiveAsFlow - Exclusive 구독에서 10건 소비` — `take(10).toList()` 로 Flow 종료, 그 후 ack 일괄
+3. `acknowledgeCumulativeSuspend - Shared 구독에서 예외 발생 확인` — Shared subscription 에서 cumulative ack 호출 시 `PulsarClientException` 발생 검증
+
+힌트:
+
+```kotlin
+@Test
+fun `receiveSuspend - 라운드트립`() = runTest(timeout = 30.seconds) {
+    val topic = newTopic()
+    val sub = newSubscription()
+
+    client.withConsumer(Schema.STRING, {
+        topic(topic); subscriptionName(sub)
+        subscriptionType(SubscriptionType.Exclusive)
+    }) {
+        client.withProducer(Schema.STRING, { topic(topic) }) {
+            sendSuspend("hello")
+        }
+        val msg = receiveSuspend()
+        msg.value shouldBeEqualTo "hello"
+        acknowledgeSuspend(msg)
+    }
+}
+
+@Test
+fun `receiveAsFlow - Exclusive 10건 소비`() = runTest(timeout = 60.seconds) {
+    val topic = newTopic()
+    val sub = newSubscription()
+    val total = 10
+
+    client.withConsumer(Schema.STRING, {
+        topic(topic); subscriptionName(sub)
+        subscriptionType(SubscriptionType.Exclusive)
+    }) {
+        client.withProducer(Schema.STRING, { topic(topic) }) {
+            repeat(total) { sendSuspend("msg-$it") }
+        }
+        val received = receiveAsFlow().take(total).toList()
+        received.size shouldBeEqualTo total
+        received.forEach { acknowledgeSuspend(it) }
+    }
+}
+```
+
+테스트 케이스 3 힌트:
+```kotlin
+@Test
+fun `acknowledgeCumulativeSuspend - Shared 구독에서 예외 발생`() = runTest(timeout = 30.seconds) {
+    val topic = newTopic()
+    val sub = newSubscription()
+    client.withProducer(Schema.STRING, { topic(topic) }) { sendSuspend("hello") }
+    client.withConsumer(Schema.STRING, {
+        topic(topic); subscriptionName(sub)
+        subscriptionType(SubscriptionType.Shared)
+    }) {
+        val msg = receiveSuspend()
+        // Shared subscription 에서 cumulative ack 는 예외 발생
+        assertThrows<PulsarClientException> { acknowledgeCumulativeSuspend(msg) }
+    }
+}
+```
+
+**주의**:
+- subscription 은 producer 발행 **이전에** 생성되어야 메시지 손실 없음. `withConsumer {}` 가 outer
+- `take(total)` 로 Flow 종료 — `receiveAsFlow` 의 cancel 경로 검증 효과
+
+**검증**: `./gradlew :bluetape4k-pulsar:test --tests "*ConsumerExtensionsTest"` 통과.
+
+---
+
+### T9 — ReaderExtensionsTest
+**complexity: medium**
+
+생성 파일:
+- `infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/reader/ReaderExtensionsTest.kt`
+
+테스트 케이스:
+1. `readNextSuspend - earliest 부터 첫 메시지 읽기` — 발행 후 `MessageId.earliest` Reader 로 1건 읽기
+2. `readAsFlow - hasMessageAvailable 기반 종료` — 5건 발행 후 Flow 가 5건만 emit 후 정상 종료
+
+힌트:
+
+```kotlin
+@Test
+fun `readAsFlow - 발행한 모든 메시지 읽고 종료`() = runTest(timeout = 60.seconds) {
+    val topic = newTopic()
+    client.withProducer(Schema.STRING, { topic(topic) }) {
+        repeat(5) { sendSuspend("msg-$it") }
+    }
+    client.withReader(Schema.STRING, {
+        topic(topic); startMessageId(MessageId.earliest)
+    }) {
+        val msgs = readAsFlow().toList()
+        msgs.size shouldBeEqualTo 5
+    }
+}
+```
+
+**검증**: `./gradlew :bluetape4k-pulsar:test --tests "*ReaderExtensionsTest"` 통과.
+
+---
+
+### T10 — JacksonSchemaTest + Jackson3SchemaTest
+**complexity: medium**
+
+생성 파일:
+- `infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/codec/JacksonSchemaTest.kt`
+- `infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/codec/Jackson3SchemaTest.kt`
+
+테스트 페이로드:
+
+```kotlin
+data class Order(val id: Long, val name: String, val amount: Double)
+```
+
+테스트 케이스:
+1. `encode → decode 라운드트립` — `schema.decode(schema.encode(order)) shouldBeEqualTo order`
+2. `getSchemaInfo - SchemaType.JSON 검증` — `info.type shouldBeEqualTo SchemaType.JSON`,
+   `info.name shouldBeEqualTo "Order"`, `info.schema.shouldBeEmpty()`
+
+힌트 (Jackson2):
+
+```kotlin
+class JacksonSchemaTest {
+    @Test
+    fun `encode decode 라운드트립`() {
+        val schema = jacksonSchema<Order>()
+        val original = Order(1, "test", 99.9)
+        val bytes = schema.encode(original)
+        val decoded = schema.decode(bytes)
+        decoded shouldBeEqualTo original
+    }
+
+    @Test
+    fun `SchemaInfo 타입 검증`() {
+        val schema = jacksonSchema<Order>()
+        val info = schema.schemaInfo
+        info.type shouldBeEqualTo SchemaType.JSON
+        info.name shouldBeEqualTo "Order"
+        info.schema.size shouldBeEqualTo 0
+    }
+}
+```
+
+Jackson3 테스트는 `jackson3Schema(mapper)` 시그니처에 맞춰 mapper 전달.
+
+Jackson3 mapper 생성 힌트:
+```kotlin
+// bluetape4k-jackson3 의 Jackson3.defaultJsonMapper 또는
+// tools.jackson.module.kotlin.jsonMapper { addModule(kotlinModule()) }
+// 실제 API 명칭은 T6 구현 시 io.bluetape4k.jackson3.Jackson 소스 확인 후 결정
+```
+
+**주의**:
+- 두 테스트 모두 testcontainers 불필요 (순수 단위 테스트) → 빠름
+- Pulsar 브로커 통합 라운드트립은 별도로 안 함 (Producer/Consumer 테스트가 STRING schema 만 사용)
+
+**검증**: `./gradlew :bluetape4k-pulsar:test --tests "*Schema*Test"` 통과.
+
+---
+
+### T11 — README.md + README.ko.md
+**complexity: low**
+
+생성 파일:
+- `infra/pulsar/README.md` (English)
+- `infra/pulsar/README.ko.md` (Korean)
+
+요구사항:
+- 제목 바로 아래 언어 전환 링크
+  - `README.md` → `[한국어](./README.ko.md) | English`
+  - `README.ko.md` → `한국어 | [English](./README.md)`
+- Mermaid Class diagram 포함 (PulsarClient ↔ Producer/Consumer/Reader 관계)
+- 구조: **Architecture → UML → Features → Examples**
+- 예시 코드: `pulsarClient {}`, `withProducer/withConsumer/withReader`, `sendSuspend`, `receiveAsFlow`, `jacksonSchema`
+
+Mermaid 예:
+
+```mermaid
+classDiagram
+    class PulsarClient
+    class Producer~T~
+    class Consumer~T~
+    class Reader~T~
+    class Schema~T~
+    PulsarClient --> Producer
+    PulsarClient --> Consumer
+    PulsarClient --> Reader
+    Producer ..> Schema : uses
+    Consumer ..> Schema : uses
+    Reader ..> Schema : uses
+```
+
+**검증**: 마크다운 렌더 확인 (Obsidian / GitHub preview).
+
+---
+
+### T13 — bluetape4k-patterns 체크리스트 검증
+**complexity: low**
+
+`bluetape4k-patterns` 스킬 기준 전수 점검:
+- [ ] 모든 public API KDoc 한국어 기재 여부
+- [ ] 클래스 `companion object : KLogging()` 누락 없음
+- [ ] top-level 파일 `private val log = KotlinLogging.logger {}` 누락 없음
+- [ ] `requireNotBlank`, `requireNotNull` 등 validataion 패턴 적절히 사용
+- [ ] Kluent `shouldBeTrue()` 직접 사용 없음 — 비교 matcher 사용
+
+---
+
+### T12 — CLAUDE.md 업데이트
+**complexity: low**
+
+대상 파일:
+- `CLAUDE.md` (루트 — 워크트리 cwd 기준 `/Users/debop/work/bluetape4k/bluetape4k-projects/.worktrees/feat/infra-pulsar/CLAUDE.md`
+  와 `/Users/debop/work/bluetape4k/bluetape4k-projects/CLAUDE.md` 양쪽 동기화 필요 시 검토)
+
+수정 위치: `## Module Groups` 테이블, `infra/` 행.
+
+기존:
+```
+| `infra/`         | `lettuce`, `redisson`, `kafka`, `resilience4j`, `bucket4j`, `micrometer`, `opentelemetry`, `cache-*`, `elasticsearch`       |
+```
+
+수정 후:
+```
+| `infra/`         | `lettuce`, `redisson`, `kafka`, `pulsar`, `resilience4j`, `bucket4j`, `micrometer`, `opentelemetry`, `cache-*`, `elasticsearch` |
+```
+
+**검증**: `rg "pulsar" CLAUDE.md` 결과에 module groups 행이 포함됨.
+
+---
+
+## 작업 순서
+
+T1 → T2 → T3 → T4 → T5 → T6 (구현 6 Task 완료) → T7 → T8 → T9 → T10 (테스트 4 Task) → T13 (patterns 체크) → T11 → T12 (문서)
+
+각 Task 완료 후 즉시 컴파일 확인:
+- T1: `./gradlew :bluetape4k-pulsar:compileKotlin`
+- T2~T6: `./gradlew :bluetape4k-pulsar:compileKotlin`
+- T7~T10: `./gradlew :bluetape4k-pulsar:test`
+- T11~T12: 문서 체크
+
+전체 완료 후:
+- `./gradlew :bluetape4k-pulsar:build`
+- `./gradlew :bluetape4k-pulsar:detekt`
+- code-reviewer 에이전트 실행 → HIGH/CRITICAL 해소
+- 한국어 commit + PR
+
+---
+
+## DoD 체크리스트 (스펙 §7)
+
+### 구현
+- [ ] T1: 모듈 등록 + 의존성 + test resources
+- [ ] T2: `pulsarClient {}` / `withPulsarClient {}`
+- [ ] T3: `producer {}` / `withProducer {}` / `sendSuspend` / `sendAsFlow`
+- [ ] T4: `consumer {}` / `withConsumer {}` / `receiveSuspend` / `receiveAsFlow` / `acknowledgeSuspend` / `acknowledgeCumulativeSuspend`
+- [ ] T5: `reader {}` / `withReader {}` / `readNextSuspend` / `readAsFlow`
+- [ ] T6: Jackson2 `jacksonSchema<T>()` + Jackson3 `jackson3Schema<T>()` (SchemaInfo 포함)
+
+### 코드 품질
+- [ ] 모든 public API 한국어 KDoc
+- [ ] top-level 파일 `private val log = KotlinLogging.logger {}`
+- [ ] 클래스 파일 `companion object : KLogging()`
+- [ ] Kluent matcher 일관 사용 (shouldBeEqualTo / shouldNotBeNull)
+
+### 테스트
+- [ ] T7: ProducerExtensionsTest 통과
+- [ ] T8: ConsumerExtensionsTest 통과 (UUID subscriptionName)
+- [ ] T9: ReaderExtensionsTest 통과
+- [ ] T10: JacksonSchemaTest + Jackson3SchemaTest 통과
+- [ ] `junit-platform.properties` + `logback-test.xml` 포함
+
+### 코드 품질 추가
+- [ ] T13: bluetape4k-patterns 체크리스트 전수 통과
+
+### 문서
+- [ ] T11: README.md + README.ko.md (Mermaid + 언어 전환 링크)
+- [ ] T12: CLAUDE.md `infra/` 그룹에 `pulsar` 추가
+
+### PR 전 필수
+- [ ] `./gradlew :bluetape4k-pulsar:test` 결과 (passing count + duration) PR description 포함
+
+---
+
+## 리스크 및 주의사항
+
+1. **`Libs.pulsar_client` 존재 확인**: `buildSrc/Libs.kt` 에 Pulsar 클라이언트 dependency 가 없으면 T1 에서 추가 필요. 버전 `3.3.9` (스펙 §5).
+2. **`Libs.testcontainers_pulsar` 존재 확인**: 동일.
+3. **`Libs.jackson3_databind` 존재 확인**: jackson3 모듈은 비교적 신규이므로 buildSrc 에 dependency 등록 필요할 수 있음.
+4. **`io.bluetape4k.coroutines.support.awaitSuspending`**: 시그니처가 `CompletableFuture<T>.awaitSuspending(): T` 인지 확인. 다를 경우 `kotlinx.coroutines.future.await()` 로 대체.
+5. **Pulsar 컨테이너 첫 부팅**: Docker pull + 시작에 30초+ 소요 가능 → 모든 테스트 `runTest(timeout = 60.seconds)` 권장.
+6. **테스트 격리**: 동일 broker 를 공유하므로 토픽/구독 이름은 반드시 UUID 로 고유화 (`AbstractPulsarTest.newTopic()` / `newSubscription()`).
+7. **Jackson3 default mapper**: `bluetape4k-jackson3` 의 default mapper helper 명이 확정되지 않았으면 default 파라미터 생략하고 호출자가 항상 mapper 를 전달하도록 한다.

--- a/docs/superpowers/specs/2026-04-27-infra-pulsar-design.md
+++ b/docs/superpowers/specs/2026-04-27-infra-pulsar-design.md
@@ -1,0 +1,383 @@
+# bluetape4k-pulsar 설계 스펙
+
+- **Issue**: #147
+- **브랜치**: feat/infra-pulsar
+- **작성일**: 2026-04-27
+- **상태**: v1.1 (2026-04-27 리뷰 반영)
+
+---
+
+## 1. 배경 및 목표
+
+Apache Pulsar는 멀티테넌시, 토픽별 독립 스토리지, 지리적 복제를 내장한 분산 메시징 플랫폼. Kafka 대비 파티션 수 변경 없이 무한 스케일아웃 가능.
+
+현재 bluetape4k에는 Pulsar Java Client를 Kotlin Coroutines / Flow로 감싸는 래퍼가 없음.
+
+**목표**:
+- `infra/pulsar` 단일 모듈로 Kotlin 코루틴 퍼스트 Pulsar 클라이언트 래퍼 제공
+- Extension functions 우선 (object 메서드 금지)
+- Jackson2 + Jackson3 양쪽 지원 (compileOnly)
+- 네이티브 CompressionType DSL 노출
+- Spring 통합은 별도 이슈로 분리
+
+---
+
+## 2. 아키텍처 결정
+
+### 2-1. 모듈 구조 (A안 확정)
+
+```
+infra/pulsar/
+├── build.gradle.kts
+└── src/
+    ├── main/kotlin/io/bluetape4k/pulsar/
+    │   ├── PulsarClientSupport.kt          -- pulsarClient {} DSL, withPulsarClient {}
+    │   ├── codec/
+    │   │   ├── JacksonSchema.kt            -- Jackson2용 Schema<T> (compileOnly)
+    │   │   └── Jackson3Schema.kt           -- Jackson3용 Schema<T> (compileOnly)
+    │   ├── producer/
+    │   │   ├── ProducerSupport.kt          -- producer {} DSL, withProducer {}
+    │   │   └── ProducerExtensions.kt       -- suspend send, sendAsFlow
+    │   ├── consumer/
+    │   │   ├── ConsumerSupport.kt          -- consumer {} DSL, withConsumer {}
+    │   │   └── ConsumerExtensions.kt       -- suspend receive, receiveAsFlow, suspend ack/nack
+    │   └── reader/
+    │       ├── ReaderSupport.kt            -- reader {} DSL, withReader {}
+    │       └── ReaderExtensions.kt         -- suspend readNext, readAsFlow
+    └── test/kotlin/io/bluetape4k/pulsar/
+        ├── AbstractPulsarTest.kt
+        ├── codec/
+        │   ├── JacksonSchemaTest.kt
+        │   └── Jackson3SchemaTest.kt
+        ├── producer/
+        │   └── ProducerExtensionsTest.kt
+        ├── consumer/
+        │   └── ConsumerExtensionsTest.kt
+        └── reader/
+            └── ReaderExtensionsTest.kt
+```
+
+### 2-2. 설계 원칙
+
+1. **Extension functions 우선**: `suspend fun Producer<T>.sendSuspend(...)` 형태
+2. **CompletableFuture → Coroutine**: `awaitSuspending()` (`bluetape4k-coroutines`)
+3. **Flow 변환**: `flow { while (isActive) { emit(receiveAsync().awaitSuspending()) } }` 폴링 패턴. 취소 시 대기 중인 `CompletableFuture.cancel(true)` 명시적 호출
+4. **DSL**: `pulsarClient {}`, `producer {}`, `consumer {}`, `reader {}` 빌더 DSL
+5. **withXxx {}**: `suspend inline fun` + `try/finally { closeAsync().awaitSuspending() }` — 예외/취소 시 비동기 close 보장
+6. **top-level 파일 로깅**: `companion object : KLogging()` 없는 파일은 `private val log = KotlinLogging.logger {}` 사용
+
+---
+
+## 3. API 설계
+
+### 3-1. 클라이언트 DSL
+
+```kotlin
+// 생성 DSL
+val client = pulsarClient {
+    serviceUrl("pulsar://localhost:6650")
+    connectionTimeout(5, TimeUnit.SECONDS)
+    operationTimeout(30, TimeUnit.SECONDS)
+}
+
+// withPulsarClient {} — 블록 후 자동 close
+withPulsarClient("pulsar://localhost:6650") {
+    // PulsarClient scope
+}
+```
+
+**구현 시그니처**:
+```kotlin
+fun pulsarClient(serviceUrl: String = "", setup: ClientBuilder.() -> Unit = {}): PulsarClient
+
+// block은 suspend 람다 — 내부에서 sendSuspend/receiveSuspend 호출 가능
+// finally에서 closeAsync().awaitSuspending() 보장
+suspend inline fun <T> withPulsarClient(
+    serviceUrl: String,
+    setup: ClientBuilder.() -> Unit = {},
+    crossinline block: suspend PulsarClient.() -> T
+): T
+```
+
+### 3-2. Producer DSL + Extension
+
+```kotlin
+// Producer 생성 DSL (PulsarClient 확장)
+val producer = client.producer(Schema.JSON(Order::class.java)) {
+    topic("persistent://public/default/orders")
+    producerName("order-producer")
+    compressionType(CompressionType.LZ4)   // 네이티브 CompressionType 노출
+    batchingEnabled(true)
+}
+
+// suspend send
+val msgId: MessageId = producer.sendSuspend(order)
+
+// TypedMessageBuilder DSL
+val msgId = producer.sendSuspend<Order> {
+    value(order)
+    key("order-${order.id}")
+    property("version", "1")
+}
+
+// Flow 기반 배치 발행
+val results: Flow<MessageId> = producer.sendAsFlow(ordersFlow)
+```
+
+**구현 시그니처**:
+```kotlin
+// ProducerSupport.kt
+fun <T> PulsarClient.producer(schema: Schema<T>, setup: ProducerBuilder<T>.() -> Unit): Producer<T>
+
+// block은 suspend 람다, finally에서 closeAsync().awaitSuspending() 보장
+suspend inline fun <T, R> PulsarClient.withProducer(
+    schema: Schema<T>,
+    setup: ProducerBuilder<T>.() -> Unit = {},
+    crossinline block: suspend Producer<T>.() -> R
+): R
+
+// ProducerExtensions.kt
+suspend fun <T> Producer<T>.sendSuspend(message: T): MessageId
+// sendSuspend { value(order); key("...") } — <T> 명시 불필요, Producer<T>에서 추론
+suspend fun <T> Producer<T>.sendSuspend(setup: TypedMessageBuilder<T>.() -> Unit): MessageId
+// 에러 전파: 첫 메시지 실패 시 Flow 즉시 종료 (기본). retry는 호출자 책임
+fun <T> Producer<T>.sendAsFlow(messages: Flow<T>): Flow<MessageId>
+```
+
+### 3-3. Consumer DSL + Extension
+
+```kotlin
+// Consumer 생성 DSL
+val consumer = client.consumer(Schema.JSON(Order::class.java)) {
+    topic("persistent://public/default/orders")
+    subscriptionName("order-processor")
+    subscriptionType(SubscriptionType.Failover)
+    ackTimeout(30, TimeUnit.SECONDS)
+}
+
+// suspend receive
+val msg: Message<Order> = consumer.receiveSuspend()
+
+// Flow 기반 무한 소비
+consumer.receiveAsFlow()
+    .map { msg ->
+        processOrder(msg.value)
+        consumer.acknowledgeSuspend(msg)
+    }
+    .catch { e -> log.error("처리 실패", e) }
+    .collect()
+
+// suspend ack
+consumer.acknowledgeSuspend(msg)
+// negativeAcknowledge — Pulsar API가 void (non-blocking 큐 enqueue). suspend 불필요
+// PulsarClientException 발생 시 전파하지 않음 (내부 큐잉)
+consumer.negativeAcknowledge(msg)
+```
+
+**구현 시그니처**:
+```kotlin
+// ConsumerSupport.kt
+fun <T> PulsarClient.consumer(schema: Schema<T>, setup: ConsumerBuilder<T>.() -> Unit): Consumer<T>
+
+suspend inline fun <T, R> PulsarClient.withConsumer(
+    schema: Schema<T>,
+    setup: ConsumerBuilder<T>.() -> Unit = {},
+    crossinline block: suspend Consumer<T>.() -> R
+): R
+
+// ConsumerExtensions.kt
+suspend fun <T> Consumer<T>.receiveSuspend(): Message<T>
+
+// receiveAsFlow() 생명주기 계약:
+// - Flow 취소(coroutineContext.isActive == false) 시 루프 종료
+// - CancellationException 발생 시 대기 중인 CompletableFuture.cancel(true) 후 예외 재전파
+// - Flow는 Consumer를 소유하지 않음 — withConsumer {} 블록이나 호출자가 close 책임
+// - Pulsar Java Client 내부 재연결(자동)은 receiveAsync() 수준에서 처리됨
+// - 브로커 연결 끊김: Pulsar Client가 자동 재연결 시도, 연결 복구 전까지 receiveAsync() 블로킹
+fun <T> Consumer<T>.receiveAsFlow(): Flow<Message<T>>
+
+suspend fun <T> Consumer<T>.acknowledgeSuspend(message: Message<T>)
+// cumulative ack: Exclusive/Failover subscription에서만 유효.
+// Shared subscription에서 호출하면 PulsarClientException 발생 (KDoc에 명시)
+suspend fun <T> Consumer<T>.acknowledgeCumulativeSuspend(message: Message<T>)
+```
+
+**테스트 subscriptionName**: 각 테스트마다 `subscriptionName("test-sub-${UUID.randomUUID()}")` 패턴 사용 → 테스트 간 충돌 방지.
+
+### 3-4. Reader DSL + Extension
+
+```kotlin
+// Reader 생성 DSL
+val reader = client.reader(Schema.JSON(Order::class.java)) {
+    topic("persistent://public/default/orders")
+    startMessageId(MessageId.earliest)
+}
+
+// suspend readNext
+val msg: Message<Order> = reader.readNextSuspend()
+
+// Flow 기반 읽기 (hasMessageAvailable 기반)
+reader.readAsFlow()
+    .map { it.value }
+    .collect { order -> println(order) }
+```
+
+**구현 시그니처**:
+```kotlin
+// ReaderSupport.kt
+fun <T> PulsarClient.reader(schema: Schema<T>, setup: ReaderBuilder<T>.() -> Unit): Reader<T>
+
+suspend inline fun <T, R> PulsarClient.withReader(
+    schema: Schema<T>,
+    setup: ReaderBuilder<T>.() -> Unit = {},
+    crossinline block: suspend Reader<T>.() -> R
+): R
+
+// ReaderExtensions.kt
+suspend fun <T> Reader<T>.readNextSuspend(): Message<T>
+
+// readAsFlow() 생명주기 계약:
+// - hasMessageAvailable() == false 이면 Flow 정상 종료
+// - 취소 시 대기 중 CompletableFuture.cancel(true) 후 종료
+// - Reader는 소유하지 않음 — withReader {} 또는 호출자가 close 책임
+fun <T> Reader<T>.readAsFlow(): Flow<Message<T>>
+```
+
+### 3-5. Jackson Schema (compileOnly)
+
+**Jackson2 vs Jackson3 선택 기준**:
+- 프로젝트에 `bluetape4k-jackson2` 의존 → `jacksonSchema<T>()` 사용
+- 프로젝트에 `bluetape4k-jackson3` 의존 → `jackson3Schema<T>()` 사용
+- Jackson2: `com.fasterxml.jackson.databind.ObjectMapper` / Jackson3: `tools.jackson.databind.ObjectMapper` (패키지 다름, 바이너리 비호환) → 런타임에 하나만 사용
+
+> **⚠️ 주의**: `JacksonSchema.kt` / `Jackson3Schema.kt`는 `compileOnly` 의존. 사용 모듈의
+> `build.gradle.kts`에서 `implementation(project(":bluetape4k-jackson2"))` (또는 jackson3)를
+> 반드시 선언해야 함. 없으면 런타임에 `NoClassDefFoundError` 발생.
+
+```kotlin
+// JacksonSchema.kt (Jackson2용 — com.fasterxml.jackson.databind.ObjectMapper)
+fun <T> jacksonSchema(type: Class<T>, mapper: ObjectMapper = Jackson.defaultJsonMapper): Schema<T>
+inline fun <reified T> jacksonSchema(mapper: ObjectMapper = Jackson.defaultJsonMapper): Schema<T>
+
+// Jackson3Schema.kt (Jackson3용 — tools.jackson.databind.ObjectMapper)
+fun <T> jackson3Schema(type: Class<T>, mapper: tools.jackson.databind.ObjectMapper): Schema<T>
+inline fun <reified T> jackson3Schema(mapper: tools.jackson.databind.ObjectMapper): Schema<T>
+```
+
+내부적으로 Pulsar `Schema<T>` 인터페이스 구현:
+- `encode(T): ByteArray` — `mapper.writeValueAsBytes(value)`
+- `decode(ByteArray): T` — `mapper.readValue(bytes, type)`
+- `getSchemaInfo(): SchemaInfo` — 다음을 포함해야 함:
+  ```kotlin
+  SchemaInfo.builder()
+      .name(type.simpleName)
+      .type(SchemaType.JSON)
+      .schema(ByteArray(0))   // 브로커 스키마 검증 없음 (호환성 우선)
+      .build()
+  ```
+
+---
+
+## 4. 압축 지원
+
+Pulsar 네이티브 CompressionType을 DSL로 노출하는 방식 사용:
+
+```kotlin
+client.producer(Schema.STRING) {
+    topic("...")
+    compressionType(CompressionType.LZ4)    // LZ4 / ZSTD / SNAPPY / ZLIB / NONE
+}
+```
+
+`io/io` Compressor 기반 별도 Schema 래퍼는 이번 스코프에서 제외 (네이티브 지원으로 충분).
+
+---
+
+## 5. 의존성
+
+```kotlin
+// build.gradle.kts
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    api(project(":bluetape4k-core"))
+    api(project(":bluetape4k-coroutines"))
+    // bluetape4k-io 제외 — io/io Compressor 미사용 (네이티브 CompressionType 사용)
+
+    // Pulsar
+    api(Libs.pulsar_client)                   // 3.3.9
+
+    // Jackson (compileOnly — 사용 모듈이 런타임에 하나를 implementation으로 선언해야 함)
+    compileOnly(project(":bluetape4k-jackson2"))
+    compileOnly(Libs.jackson_databind)         // Jackson2: com.fasterxml.jackson.databind
+    compileOnly(project(":bluetape4k-jackson3"))
+    compileOnly(Libs.jackson3_databind)        // Jackson3: tools.jackson.databind
+
+    // Coroutines
+    implementation(Libs.kotlinx_coroutines_core)
+    testImplementation(Libs.kotlinx_coroutines_test)
+
+    // Testcontainers
+    testImplementation(project(":bluetape4k-junit5"))
+    testImplementation(project(":bluetape4k-testcontainers"))
+    testImplementation(Libs.testcontainers_pulsar)
+}
+```
+
+---
+
+## 6. 테스트 전략
+
+### 테스트 환경
+- `PulsarServer.Launcher.pulsar` (기존 testcontainers) 재사용
+- `AbstractPulsarTest` 기반 클래스로 client 생명주기 관리
+
+### 테스트 케이스
+
+| 테스트 | 검증 내용 |
+|--------|-----------|
+| `ProducerExtensionsTest` | sendSuspend, sendAsFlow (100건) |
+| `ConsumerExtensionsTest` | receiveSuspend, receiveAsFlow (Exclusive/Shared/Failover) |
+| `ReaderExtensionsTest` | readNextSuspend, readAsFlow (earliest~latest) |
+| `JacksonSchemaTest` | Jackson2 encode/decode 라운드트립 |
+| `Jackson3SchemaTest` | Jackson3 encode/decode 라운드트립 |
+
+---
+
+## 7. DoD (Definition of Done)
+
+### 구현
+- [ ] `infra/pulsar` 모듈 Gradle 등록 (`settings.gradle.kts` 자동)
+- [ ] `pulsarClient {}` / `withPulsarClient {}` DSL 구현
+- [ ] `producer {}` / `consumer {}` / `reader {}` DSL on PulsarClient 구현
+- [ ] `withProducer {}` / `withConsumer {}` / `withReader {}` — `suspend inline fun` + `try/finally { closeAsync().awaitSuspending() }` 구현
+- [ ] `Producer<T>` — `sendSuspend(T)`, `sendSuspend(TypedMessageBuilder DSL)`, `sendAsFlow` extension 구현
+- [ ] `Consumer<T>` — `receiveSuspend`, `receiveAsFlow`, `acknowledgeSuspend`, `acknowledgeCumulativeSuspend` extension 구현
+- [ ] `Reader<T>` — `readNextSuspend`, `readAsFlow` extension 구현
+- [ ] Jackson2 `jacksonSchema<T>()` 구현 (SchemaInfo 포함)
+- [ ] Jackson3 `jackson3Schema<T>()` 구현 (SchemaInfo 포함)
+
+### 코드 품질
+- [ ] 모든 public API 한국어 KDoc (예외 타입, compileOnly 사용 경고 포함)
+- [ ] 클래스 파일: `companion object : KLogging()` 포함
+- [ ] top-level 파일(`*Extensions.kt`, `*Support.kt`): `private val log = KotlinLogging.logger {}` 사용
+
+### 테스트
+- [ ] 테스트별 UUID subscriptionName 사용 (`subscriptionName("test-sub-${UUID.randomUUID()}")`)
+- [ ] 테스트 전수 통과 (ProducerExtensionsTest / ConsumerExtensionsTest / ReaderExtensionsTest / JacksonSchemaTest / Jackson3SchemaTest)
+- [ ] `src/test/resources/junit-platform.properties` + `logback-test.xml` 포함
+
+### 문서
+- [ ] `README.md` + `README.ko.md` 작성
+- [ ] `CLAUDE.md` `infra/` 모듈 그룹 테이블에 `pulsar` 추가
+
+---
+
+## 8. 제외 범위
+
+- Spring Integration (별도 이슈)
+- Pulsar Functions / Pulsar IO Connectors
+- Admin API suspend 래핑
+- io/io Compressor 기반 CompressedSchema (네이티브 CompressionType으로 충분)

--- a/infra/pulsar/README.ko.md
+++ b/infra/pulsar/README.ko.md
@@ -1,0 +1,192 @@
+한국어 | [English](./README.md)
+
+# bluetape4k-pulsar
+
+Kotlin을 위한 Apache Pulsar 클라이언트 확장 — 코루틴 우선, DSL 친화적, Jackson2/Jackson3 스키마 지원.
+
+## 아키텍처
+
+```mermaid
+classDiagram
+    class PulsarClient {
+        +pulsarClient(serviceUrl, setup)
+        +withPulsarClient(serviceUrl, setup, block)
+    }
+
+    class ProducerSupport {
+        +PulsarClient.producer(schema, setup)
+        +PulsarClient.withProducer(schema, setup, block)
+    }
+
+    class ProducerExtensions {
+        +Producer.sendSuspend(message)
+        +Producer.sendSuspend(setup)
+        +Producer.sendAsFlow(messages)
+    }
+
+    class ConsumerSupport {
+        +PulsarClient.consumer(schema, setup)
+        +PulsarClient.withConsumer(schema, setup, block)
+    }
+
+    class ConsumerExtensions {
+        +Consumer.receiveSuspend()
+        +Consumer.receiveAsFlow()
+        +Consumer.acknowledgeSuspend(message)
+        +Consumer.acknowledgeCumulativeSuspend(message)
+    }
+
+    class ReaderSupport {
+        +PulsarClient.reader(schema, setup)
+        +PulsarClient.withReader(schema, setup, block)
+    }
+
+    class ReaderExtensions {
+        +Reader.readNextSuspend()
+        +Reader.readAsFlow()
+    }
+
+    class JacksonSchema {
+        +jacksonSchema~T~(type, mapper)
+        +jacksonSchema~T~(mapper)
+    }
+
+    class Jackson3Schema {
+        +jackson3Schema~T~(type, mapper)
+        +jackson3Schema~T~(mapper)
+    }
+
+    PulsarClient --> ProducerSupport
+    PulsarClient --> ConsumerSupport
+    PulsarClient --> ReaderSupport
+    ProducerSupport --> ProducerExtensions
+    ConsumerSupport --> ConsumerExtensions
+    ReaderSupport --> ReaderExtensions
+```
+
+## 주요 기능
+
+- **코루틴 우선**: 모든 비동기 작업을 `awaitSuspending()`으로 `suspend` 함수로 래핑
+- **DSL 빌더**: `withProducer {}`, `withConsumer {}`, `withReader {}`로 생명주기 자동 관리
+- **Flow 지원**: `receiveAsFlow()`, `readAsFlow()`, `sendAsFlow()`로 리액티브 파이프라인 구성
+- **Jackson2 스키마**: `jacksonSchema<T>()`로 `com.fasterxml.jackson.databind.ObjectMapper` 사용
+- **Jackson3 스키마**: `jackson3Schema<T>()`로 `tools.jackson.databind.ObjectMapper` 사용
+- **취소 안전**: 코루틴 취소 시 대기 중인 `CompletableFuture`를 `cancel(true)`로 중단
+
+## 의존성
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation(project(":bluetape4k-pulsar"))
+
+    // 선택: jacksonSchema<T>() 사용 시
+    implementation(project(":bluetape4k-jackson2"))
+
+    // 선택: jackson3Schema<T>() 사용 시
+    implementation(project(":bluetape4k-jackson3"))
+}
+```
+
+## 사용 예제
+
+### 클라이언트 생명주기
+
+```kotlin
+withPulsarClient("pulsar://localhost:6650") {
+    // PulsarClient가 this로 제공됨
+    withProducer(Schema.STRING) { topic("orders") } {
+        sendSuspend("order-1")
+    }
+}
+```
+
+### Producer
+
+```kotlin
+val client = pulsarClient("pulsar://localhost:6650")
+
+// 단순 발행
+client.withProducer(Schema.STRING, { topic("events") }) {
+    val msgId = sendSuspend("hello")
+}
+
+// DSL 메시지 빌더
+client.withProducer(Schema.STRING, { topic("events") }) {
+    sendSuspend {
+        value("주문 완료")
+        key("order-42")
+        property("version", "1")
+    }
+}
+
+// Flow 기반 배치 발행
+val producer = client.producer(Schema.STRING) { topic("events") }
+producer.sendAsFlow(items.asFlow()).collect { msgId -> log.debug { "발행: $msgId" } }
+```
+
+### Consumer
+
+```kotlin
+client.withConsumer(Schema.STRING, {
+    topic("events")
+    subscriptionName("my-service")
+    subscriptionType(SubscriptionType.Exclusive)
+}) {
+    // 메시지 1건 수신
+    val msg = receiveSuspend()
+    acknowledgeSuspend(msg)
+
+    // 무한 스트림 (취소로 종료)
+    receiveAsFlow()
+        .map { msg -> process(msg.value).also { acknowledgeSuspend(msg) } }
+        .collect()
+}
+```
+
+### Reader (구독·ack 불필요)
+
+```kotlin
+client.withReader(Schema.STRING, {
+    topic("events")
+    startMessageId(MessageId.earliest)
+}) {
+    // 사용 가능한 메시지 전부 읽기
+    readAsFlow().collect { msg -> println(msg.value) }
+}
+```
+
+### 커스텀 JSON 스키마
+
+```kotlin
+data class Order(val id: String, val amount: Int)
+
+// Jackson2
+val schema = jacksonSchema<Order>()
+
+// Jackson3
+val schema3 = jackson3Schema<Order>()
+
+val producer = client.newProducer(schema).topic("orders").create()
+producer.sendSuspend(Order("order-1", 9900))
+```
+
+## 압축
+
+Producer 빌더에서 Pulsar 내장 `CompressionType` 사용:
+
+```kotlin
+client.withProducer(Schema.STRING, {
+    topic("events")
+    compressionType(CompressionType.LZ4)
+}) {
+    sendSuspend("압축 메시지")
+}
+```
+
+## 주의사항
+
+- `acknowledgeCumulativeSuspend`는 `Exclusive`/`Failover` 구독에서만 유효합니다. `Shared`에서 호출하면 `PulsarClientException`이 발생합니다.
+- `receiveAsFlow()`는 무한 스트림 — `take(n)`, `takeWhile {}`, 또는 코루틴 취소로 종료합니다.
+- `readAsFlow()`는 `hasMessageAvailable()`이 `false`가 되면 자동 종료됩니다.
+- Jackson2/Jackson3는 `compileOnly` 의존성 — 사용 모듈에서 `implementation`으로 선언해야 합니다.

--- a/infra/pulsar/README.md
+++ b/infra/pulsar/README.md
@@ -1,0 +1,192 @@
+[한국어](./README.ko.md) | English
+
+# bluetape4k-pulsar
+
+Apache Pulsar client extensions for Kotlin — coroutine-first, DSL-friendly, Jackson2/Jackson3 schema support.
+
+## Architecture
+
+```mermaid
+classDiagram
+    class PulsarClient {
+        +pulsarClient(serviceUrl, setup)
+        +withPulsarClient(serviceUrl, setup, block)
+    }
+
+    class ProducerSupport {
+        +PulsarClient.producer(schema, setup)
+        +PulsarClient.withProducer(schema, setup, block)
+    }
+
+    class ProducerExtensions {
+        +Producer.sendSuspend(message)
+        +Producer.sendSuspend(setup)
+        +Producer.sendAsFlow(messages)
+    }
+
+    class ConsumerSupport {
+        +PulsarClient.consumer(schema, setup)
+        +PulsarClient.withConsumer(schema, setup, block)
+    }
+
+    class ConsumerExtensions {
+        +Consumer.receiveSuspend()
+        +Consumer.receiveAsFlow()
+        +Consumer.acknowledgeSuspend(message)
+        +Consumer.acknowledgeCumulativeSuspend(message)
+    }
+
+    class ReaderSupport {
+        +PulsarClient.reader(schema, setup)
+        +PulsarClient.withReader(schema, setup, block)
+    }
+
+    class ReaderExtensions {
+        +Reader.readNextSuspend()
+        +Reader.readAsFlow()
+    }
+
+    class JacksonSchema {
+        +jacksonSchema~T~(type, mapper)
+        +jacksonSchema~T~(mapper)
+    }
+
+    class Jackson3Schema {
+        +jackson3Schema~T~(type, mapper)
+        +jackson3Schema~T~(mapper)
+    }
+
+    PulsarClient --> ProducerSupport
+    PulsarClient --> ConsumerSupport
+    PulsarClient --> ReaderSupport
+    ProducerSupport --> ProducerExtensions
+    ConsumerSupport --> ConsumerExtensions
+    ReaderSupport --> ReaderExtensions
+```
+
+## Features
+
+- **Coroutine-first**: All async operations wrapped as `suspend` functions via `awaitSuspending()`
+- **DSL builders**: `withProducer {}`, `withConsumer {}`, `withReader {}` for scoped lifecycle management
+- **Flow support**: `receiveAsFlow()`, `readAsFlow()`, `sendAsFlow()` for reactive pipelines
+- **Jackson2 schema**: `jacksonSchema<T>()` using `com.fasterxml.jackson.databind.ObjectMapper`
+- **Jackson3 schema**: `jackson3Schema<T>()` using `tools.jackson.databind.ObjectMapper`
+- **Cancellation-safe**: Pending `CompletableFuture` is cancelled on coroutine cancellation
+
+## Dependency
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation(project(":bluetape4k-pulsar"))
+
+    // Optional: for jacksonSchema<T>()
+    implementation(project(":bluetape4k-jackson2"))
+
+    // Optional: for jackson3Schema<T>()
+    implementation(project(":bluetape4k-jackson3"))
+}
+```
+
+## Examples
+
+### Client lifecycle
+
+```kotlin
+withPulsarClient("pulsar://localhost:6650") {
+    // PulsarClient available as `this`
+    withProducer(Schema.STRING) { topic("orders") } {
+        sendSuspend("order-1")
+    }
+}
+```
+
+### Producer
+
+```kotlin
+val client = pulsarClient("pulsar://localhost:6650")
+
+// Simple send
+client.withProducer(Schema.STRING, { topic("events") }) {
+    val msgId = sendSuspend("hello")
+}
+
+// DSL message builder
+client.withProducer(Schema.STRING, { topic("events") }) {
+    sendSuspend {
+        value("order placed")
+        key("order-42")
+        property("version", "1")
+    }
+}
+
+// Flow-based batch send
+val producer = client.producer(Schema.STRING) { topic("events") }
+producer.sendAsFlow(items.asFlow()).collect { msgId -> log.debug { "sent: $msgId" } }
+```
+
+### Consumer
+
+```kotlin
+client.withConsumer(Schema.STRING, {
+    topic("events")
+    subscriptionName("my-service")
+    subscriptionType(SubscriptionType.Exclusive)
+}) {
+    // Receive one message
+    val msg = receiveSuspend()
+    acknowledgeSuspend(msg)
+
+    // Infinite stream (cancel to stop)
+    receiveAsFlow()
+        .map { msg -> process(msg.value).also { acknowledgeSuspend(msg) } }
+        .collect()
+}
+```
+
+### Reader (no subscription, no ack)
+
+```kotlin
+client.withReader(Schema.STRING, {
+    topic("events")
+    startMessageId(MessageId.earliest)
+}) {
+    // Read all available messages
+    readAsFlow().collect { msg -> println(msg.value) }
+}
+```
+
+### Custom JSON Schema
+
+```kotlin
+data class Order(val id: String, val amount: Int)
+
+// Jackson2
+val schema = jacksonSchema<Order>()
+
+// Jackson3
+val schema3 = jackson3Schema<Order>()
+
+val producer = client.newProducer(schema).topic("orders").create()
+producer.sendSuspend(Order("order-1", 9900))
+```
+
+## Compression
+
+Use Pulsar's native `CompressionType` in the producer builder:
+
+```kotlin
+client.withProducer(Schema.STRING, {
+    topic("events")
+    compressionType(CompressionType.LZ4)
+}) {
+    sendSuspend("compressed message")
+}
+```
+
+## Notes
+
+- `acknowledgeCumulativeSuspend` is only valid for `Exclusive`/`Failover` subscriptions. Calling it on `Shared` throws `PulsarClientException`.
+- `receiveAsFlow()` is infinite — use `take(n)`, `takeWhile {}`, or coroutine cancellation to stop it.
+- `readAsFlow()` terminates when `hasMessageAvailable()` returns `false`.
+- Jackson2 and Jackson3 are `compileOnly` dependencies — declare `implementation` in consuming modules.

--- a/infra/pulsar/build.gradle.kts
+++ b/infra/pulsar/build.gradle.kts
@@ -1,0 +1,33 @@
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    api(project(":bluetape4k-core"))
+    api(project(":bluetape4k-coroutines"))
+
+    // Pulsar — pulsar_client(구현체)를 사용해야 PulsarClient.builder().build() 가능
+    api(Libs.pulsar_client)
+
+    // Jackson2 (compileOnly — 사용 모듈이 runtime에 implementation으로 선언 필요)
+    compileOnly(project(":bluetape4k-jackson2"))
+    compileOnly(Libs.jackson_databind)
+
+    // Jackson3 (compileOnly — 사용 모듈이 runtime에 implementation으로 선언 필요)
+    compileOnly(project(":bluetape4k-jackson3"))
+    compileOnly(Libs.jackson3_databind)
+
+    // Coroutines
+    implementation(Libs.kotlinx_coroutines_core)
+    testImplementation(Libs.kotlinx_coroutines_test)
+
+    // Testcontainers
+    testImplementation(project(":bluetape4k-junit5"))
+    testImplementation(project(":bluetape4k-testcontainers"))
+    testImplementation(Libs.testcontainers_pulsar)
+
+    // 테스트용 Jackson — Schema 라운드트립
+    testImplementation(project(":bluetape4k-jackson2"))
+    testImplementation(project(":bluetape4k-jackson3"))
+    testImplementation(Libs.jackson_module_kotlin)
+}

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/PulsarClientSupport.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/PulsarClientSupport.kt
@@ -12,10 +12,18 @@ internal val log = KotlinLogging.logger {}
 /**
  * Apache Pulsar 클라이언트를 DSL 방식으로 생성합니다.
  *
+ * `serviceUrl`이 비어 있으면 [setup] 블록에서 `serviceUrl()`을 반드시 설정해야 합니다.
+ * 둘 다 지정하지 않으면 `build()` 시 Pulsar 예외가 발생합니다.
+ *
  * ```kotlin
  * val client = pulsarClient("pulsar://localhost:6650") {
  *     connectionTimeout(5, TimeUnit.SECONDS)
- *     operationTimeout(30, TimeUnit.SECONDS)
+ * }
+ *
+ * // setup-only 모드 (TLS/인증 등 빌더로 완전 설정)
+ * val client = pulsarClient {
+ *     serviceUrl("pulsar+ssl://broker:6651")
+ *     tlsTrustCertsFilePath("/path/to/ca.cert.pem")
  * }
  * ```
  *
@@ -63,3 +71,26 @@ suspend inline fun <T> withPulsarClient(
             .onFailure { log.warn(it) { "PulsarClient close 실패" } }
     }
 }
+
+/**
+ * setup 블록만으로 Pulsar 클라이언트를 생성하고 생명주기를 자동 관리합니다.
+ *
+ * TLS, 인증 등 [ClientBuilder]에서 직접 URL을 설정하는 경우 사용합니다.
+ *
+ * ```kotlin
+ * withPulsarClient({
+ *     serviceUrl("pulsar+ssl://broker:6651")
+ *     tlsTrustCertsFilePath("/path/to/ca.cert.pem")
+ * }) {
+ *     // PulsarClient 사용
+ * }
+ * ```
+ *
+ * @param setup [ClientBuilder] 설정 블록 (serviceUrl 포함)
+ * @param block [PulsarClient]를 receiver로 받는 suspend 블록
+ * @return 블록의 반환값
+ */
+suspend inline fun <T> withPulsarClient(
+    noinline setup: ClientBuilder.() -> Unit,
+    crossinline block: suspend PulsarClient.() -> T,
+): T = withPulsarClient(serviceUrl = "", setup = setup, block = block)

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/PulsarClientSupport.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/PulsarClientSupport.kt
@@ -1,0 +1,65 @@
+package io.bluetape4k.pulsar
+
+import io.bluetape4k.coroutines.support.awaitSuspending
+import io.bluetape4k.logging.KotlinLogging
+import io.bluetape4k.logging.warn
+import org.apache.pulsar.client.api.ClientBuilder
+import org.apache.pulsar.client.api.PulsarClient
+
+@PublishedApi
+internal val log = KotlinLogging.logger {}
+
+/**
+ * Apache Pulsar 클라이언트를 DSL 방식으로 생성합니다.
+ *
+ * ```kotlin
+ * val client = pulsarClient("pulsar://localhost:6650") {
+ *     connectionTimeout(5, TimeUnit.SECONDS)
+ *     operationTimeout(30, TimeUnit.SECONDS)
+ * }
+ * ```
+ *
+ * @param serviceUrl 브로커 URL (비어 있으면 [setup] 블록에서 직접 지정)
+ * @param setup [ClientBuilder] 추가 설정 블록
+ * @return 생성된 [PulsarClient] 인스턴스
+ */
+fun pulsarClient(
+    serviceUrl: String = "",
+    setup: ClientBuilder.() -> Unit = {},
+): PulsarClient {
+    val builder = PulsarClient.builder()
+    if (serviceUrl.isNotBlank()) {
+        builder.serviceUrl(serviceUrl)
+    }
+    return builder.apply(setup).build()
+}
+
+/**
+ * Pulsar 클라이언트 생명주기를 블록 스코프로 자동 관리합니다.
+ *
+ * 블록 종료(정상/예외/취소) 시 [PulsarClient.closeAsync]를 호출해 비동기 close를 보장합니다.
+ *
+ * ```kotlin
+ * withPulsarClient("pulsar://localhost:6650") {
+ *     // PulsarClient 사용
+ * }
+ * ```
+ *
+ * @param serviceUrl 브로커 URL
+ * @param setup [ClientBuilder] 추가 설정 블록
+ * @param block [PulsarClient]를 receiver로 받는 suspend 블록
+ * @return 블록의 반환값
+ */
+suspend inline fun <T> withPulsarClient(
+    serviceUrl: String,
+    noinline setup: ClientBuilder.() -> Unit = {},
+    crossinline block: suspend PulsarClient.() -> T,
+): T {
+    val client = pulsarClient(serviceUrl, setup)
+    try {
+        return block(client)
+    } finally {
+        runCatching { client.closeAsync().awaitSuspending() }
+            .onFailure { log.warn(it) { "PulsarClient close 실패" } }
+    }
+}

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/codec/Jackson3Schema.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/codec/Jackson3Schema.kt
@@ -45,10 +45,12 @@ inline fun <reified T> jackson3Schema(
 private class Jackson3SchemaImpl<T>(
     private val type: Class<T>,
     private val mapper: Jackson3ObjectMapper,
+    cachedInfo: SchemaInfo? = null,
 ) : Schema<T> {
 
-    // Schema.JSON(type)에서 브로커 호환성 검증용 schema bytes를 가져오고, name은 type에서 직접 설정
-    private val info: SchemaInfo = Schema.JSON(type).schemaInfo.let { base ->
+    // Schema.JSON(type)에서 브로커 호환성 검증용 schema bytes를 가져오고, name은 type에서 직접 설정.
+    // clone() 시 재계산을 피하기 위해 생성된 SchemaInfo를 재사용한다.
+    private val info: SchemaInfo = cachedInfo ?: Schema.JSON(type).schemaInfo.let { base ->
         val name = type.simpleName?.takeIf { it.isNotBlank() } ?: type.name
         SchemaInfo.builder()
             .name(name)
@@ -64,5 +66,5 @@ private class Jackson3SchemaImpl<T>(
 
     override fun getSchemaInfo(): SchemaInfo = info
 
-    override fun clone(): Schema<T> = Jackson3SchemaImpl(type, mapper)
+    override fun clone(): Schema<T> = Jackson3SchemaImpl(type, mapper, info)
 }

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/codec/Jackson3Schema.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/codec/Jackson3Schema.kt
@@ -1,0 +1,68 @@
+package io.bluetape4k.pulsar.codec
+
+import io.bluetape4k.jackson3.Jackson as Jackson3
+import org.apache.pulsar.client.api.Schema
+import org.apache.pulsar.common.schema.SchemaInfo
+import org.apache.pulsar.common.schema.SchemaType
+import tools.jackson.databind.ObjectMapper as Jackson3ObjectMapper
+
+/**
+ * Jackson3 기반 Pulsar [Schema] 구현체를 생성합니다.
+ *
+ * ⚠️ **compileOnly 의존성 주의**: 사용 모듈의 `build.gradle.kts`에서
+ * `implementation(project(":bluetape4k-jackson3"))`를 반드시 선언해야 합니다.
+ * 누락 시 런타임에 `NoClassDefFoundError`가 발생합니다.
+ *
+ * Jackson3는 `tools.jackson.databind.ObjectMapper`를 사용합니다.
+ * Jackson2(`com.fasterxml.jackson.databind.ObjectMapper`)와 바이너리 호환되지 않으므로
+ * 런타임에 둘 중 하나만 사용해야 합니다.
+ *
+ * ```kotlin
+ * val schema = jackson3Schema<Order>(Jackson3.defaultJsonMapper)
+ * val producer = client.producer(schema) { topic("orders") }
+ * ```
+ *
+ * @param type 직렬화/역직렬화 대상 클래스
+ * @param mapper Jackson3 [Jackson3ObjectMapper]
+ * @return Pulsar [Schema] 구현체
+ */
+fun <T> jackson3Schema(
+    type: Class<T>,
+    mapper: Jackson3ObjectMapper = Jackson3.defaultJsonMapper,
+): Schema<T> = Jackson3SchemaImpl(type, mapper)
+
+/**
+ * reified 타입 파라미터를 활용한 [jackson3Schema] 편의 함수.
+ *
+ * ```kotlin
+ * val schema = jackson3Schema<Order>(Jackson3.defaultJsonMapper)
+ * ```
+ */
+inline fun <reified T> jackson3Schema(
+    mapper: Jackson3ObjectMapper = Jackson3.defaultJsonMapper,
+): Schema<T> = jackson3Schema(T::class.java, mapper)
+
+private class Jackson3SchemaImpl<T>(
+    private val type: Class<T>,
+    private val mapper: Jackson3ObjectMapper,
+) : Schema<T> {
+
+    // Schema.JSON(type)에서 브로커 호환성 검증용 schema bytes를 가져오고, name은 type에서 직접 설정
+    private val info: SchemaInfo = Schema.JSON(type).schemaInfo.let { base ->
+        val name = type.simpleName?.takeIf { it.isNotBlank() } ?: type.name
+        SchemaInfo.builder()
+            .name(name)
+            .type(SchemaType.JSON)
+            .schema(base.schema)
+            .properties(base.properties)
+            .build()
+    }
+
+    override fun encode(message: T): ByteArray = mapper.writeValueAsBytes(message)
+
+    override fun decode(bytes: ByteArray): T = mapper.readValue(bytes, type)
+
+    override fun getSchemaInfo(): SchemaInfo = info
+
+    override fun clone(): Schema<T> = Jackson3SchemaImpl(type, mapper)
+}

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/codec/JacksonSchema.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/codec/JacksonSchema.kt
@@ -41,10 +41,12 @@ inline fun <reified T> jacksonSchema(
 private class JacksonSchemaImpl<T>(
     private val type: Class<T>,
     private val mapper: ObjectMapper,
+    cachedInfo: SchemaInfo? = null,
 ) : Schema<T> {
 
-    // Schema.JSON(type)에서 브로커 호환성 검증용 schema bytes를 가져오고, name은 type에서 직접 설정
-    private val info: SchemaInfo = Schema.JSON(type).schemaInfo.let { base ->
+    // Schema.JSON(type)에서 브로커 호환성 검증용 schema bytes를 가져오고, name은 type에서 직접 설정.
+    // clone() 시 재계산을 피하기 위해 생성된 SchemaInfo를 재사용한다.
+    private val info: SchemaInfo = cachedInfo ?: Schema.JSON(type).schemaInfo.let { base ->
         val name = type.simpleName?.takeIf { it.isNotBlank() } ?: type.name
         SchemaInfo.builder()
             .name(name)
@@ -60,5 +62,5 @@ private class JacksonSchemaImpl<T>(
 
     override fun getSchemaInfo(): SchemaInfo = info
 
-    override fun clone(): Schema<T> = JacksonSchemaImpl(type, mapper)
+    override fun clone(): Schema<T> = JacksonSchemaImpl(type, mapper, info)
 }

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/codec/JacksonSchema.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/codec/JacksonSchema.kt
@@ -1,0 +1,64 @@
+package io.bluetape4k.pulsar.codec
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.bluetape4k.jackson.Jackson
+import org.apache.pulsar.client.api.Schema
+import org.apache.pulsar.common.schema.SchemaInfo
+import org.apache.pulsar.common.schema.SchemaType
+
+/**
+ * Jackson2 기반 Pulsar [Schema] 구현체를 생성합니다.
+ *
+ * ⚠️ **compileOnly 의존성 주의**: 사용 모듈의 `build.gradle.kts`에서
+ * `implementation(project(":bluetape4k-jackson2"))`를 반드시 선언해야 합니다.
+ * 누락 시 런타임에 `NoClassDefFoundError`가 발생합니다.
+ *
+ * ```kotlin
+ * val schema = jacksonSchema<Order>()
+ * val producer = client.producer(schema) { topic("orders") }
+ * ```
+ *
+ * @param type 직렬화/역직렬화 대상 클래스
+ * @param mapper Jackson2 [ObjectMapper] (기본값: [Jackson.defaultJsonMapper])
+ * @return Pulsar [Schema] 구현체
+ */
+fun <T> jacksonSchema(
+    type: Class<T>,
+    mapper: ObjectMapper = Jackson.defaultJsonMapper,
+): Schema<T> = JacksonSchemaImpl(type, mapper)
+
+/**
+ * reified 타입 파라미터를 활용한 [jacksonSchema] 편의 함수.
+ *
+ * ```kotlin
+ * val schema = jacksonSchema<Order>()
+ * ```
+ */
+inline fun <reified T> jacksonSchema(
+    mapper: ObjectMapper = Jackson.defaultJsonMapper,
+): Schema<T> = jacksonSchema(T::class.java, mapper)
+
+private class JacksonSchemaImpl<T>(
+    private val type: Class<T>,
+    private val mapper: ObjectMapper,
+) : Schema<T> {
+
+    // Schema.JSON(type)에서 브로커 호환성 검증용 schema bytes를 가져오고, name은 type에서 직접 설정
+    private val info: SchemaInfo = Schema.JSON(type).schemaInfo.let { base ->
+        val name = type.simpleName?.takeIf { it.isNotBlank() } ?: type.name
+        SchemaInfo.builder()
+            .name(name)
+            .type(SchemaType.JSON)
+            .schema(base.schema)
+            .properties(base.properties)
+            .build()
+    }
+
+    override fun encode(message: T): ByteArray = mapper.writeValueAsBytes(message)
+
+    override fun decode(bytes: ByteArray): T = mapper.readValue(bytes, type)
+
+    override fun getSchemaInfo(): SchemaInfo = info
+
+    override fun clone(): Schema<T> = JacksonSchemaImpl(type, mapper)
+}

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/consumer/ConsumerExtensions.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/consumer/ConsumerExtensions.kt
@@ -1,0 +1,79 @@
+package io.bluetape4k.pulsar.consumer
+
+import io.bluetape4k.coroutines.support.awaitSuspending
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.isActive
+import org.apache.pulsar.client.api.Consumer
+import org.apache.pulsar.client.api.Message
+
+/**
+ * 메시지를 비동기로 수신합니다.
+ *
+ * ```kotlin
+ * val msg = consumer.receiveSuspend()
+ * println(msg.value)
+ * ```
+ *
+ * @return 수신된 [Message]
+ * @throws org.apache.pulsar.client.api.PulsarClientException 브로커 오류 시
+ */
+suspend fun <T> Consumer<T>.receiveSuspend(): Message<T> =
+    receiveAsync().awaitSuspending()
+
+/**
+ * 메시지를 무한 소비하는 [Flow]를 반환합니다.
+ *
+ * ## 생명주기 계약
+ * - 코루틴 취소 시 대기 중인 [java.util.concurrent.CompletableFuture]를 `cancel(true)`로 중단 후 종료
+ * - Flow는 Consumer를 소유하지 않음 — `withConsumer {}` 또는 호출자가 close 책임
+ * - 브로커 연결 끊김 시 Pulsar Client가 자동 재연결을 시도하며, 복구 전까지 `receiveAsync()`가 블로킹됨
+ *
+ * ```kotlin
+ * consumer.receiveAsFlow()
+ *     .map { msg -> process(msg.value).also { consumer.acknowledgeSuspend(msg) } }
+ *     .collect()
+ * ```
+ *
+ * @return 수신 메시지 [Flow]
+ */
+fun <T> Consumer<T>.receiveAsFlow(): Flow<Message<T>> = flow {
+    while (currentCoroutineContext().isActive) {
+        val future = receiveAsync()
+        try {
+            emit(future.awaitSuspending())
+        } catch (ce: CancellationException) {
+            future.cancel(true)
+            throw ce
+        }
+    }
+}
+
+/**
+ * 메시지를 비동기로 ack 처리합니다.
+ *
+ * ```kotlin
+ * consumer.acknowledgeSuspend(msg)
+ * ```
+ *
+ * @param message ack 처리할 메시지
+ * @throws org.apache.pulsar.client.api.PulsarClientException ack 전송 실패 시
+ */
+suspend fun <T> Consumer<T>.acknowledgeSuspend(message: Message<T>) {
+    acknowledgeAsync(message).awaitSuspending()
+}
+
+/**
+ * 메시지 ID까지 누적 ack 처리합니다.
+ *
+ * **주의**: Exclusive/Failover subscription에서만 유효합니다.
+ * Shared subscription에서 호출하면 [org.apache.pulsar.client.api.PulsarClientException]이 발생합니다.
+ *
+ * @param message 누적 ack 기준 메시지
+ * @throws org.apache.pulsar.client.api.PulsarClientException Shared 구독에서 호출 시, 또는 ack 전송 실패 시
+ */
+suspend fun <T> Consumer<T>.acknowledgeCumulativeSuspend(message: Message<T>) {
+    acknowledgeCumulativeAsync(message).awaitSuspending()
+}

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/consumer/ConsumerSupport.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/consumer/ConsumerSupport.kt
@@ -28,7 +28,7 @@ internal val log = KotlinLogging.logger {}
  */
 fun <T> PulsarClient.consumer(
     schema: Schema<T>,
-    setup: ConsumerBuilder<T>.() -> Unit,
+    setup: ConsumerBuilder<T>.() -> Unit = {},
 ): Consumer<T> = newConsumer(schema).apply(setup).subscribe()
 
 /**

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/consumer/ConsumerSupport.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/consumer/ConsumerSupport.kt
@@ -1,0 +1,65 @@
+package io.bluetape4k.pulsar.consumer
+
+import io.bluetape4k.coroutines.support.awaitSuspending
+import io.bluetape4k.logging.KotlinLogging
+import io.bluetape4k.logging.warn
+import org.apache.pulsar.client.api.Consumer
+import org.apache.pulsar.client.api.ConsumerBuilder
+import org.apache.pulsar.client.api.PulsarClient
+import org.apache.pulsar.client.api.Schema
+
+@PublishedApi
+internal val log = KotlinLogging.logger {}
+
+/**
+ * [Consumer] DSL 빌더 ([PulsarClient] 확장).
+ *
+ * ```kotlin
+ * val consumer = client.consumer(Schema.STRING) {
+ *     topic("persistent://public/default/orders")
+ *     subscriptionName("order-processor")
+ *     subscriptionType(SubscriptionType.Exclusive)
+ * }
+ * ```
+ *
+ * @param schema 메시지 스키마
+ * @param setup [ConsumerBuilder] 설정 블록
+ * @return 생성된 [Consumer] 인스턴스
+ */
+fun <T> PulsarClient.consumer(
+    schema: Schema<T>,
+    setup: ConsumerBuilder<T>.() -> Unit,
+): Consumer<T> = newConsumer(schema).apply(setup).subscribe()
+
+/**
+ * Consumer 생명주기를 블록 스코프로 자동 관리합니다.
+ *
+ * 블록 종료(정상/예외/취소) 시 [Consumer.closeAsync]를 호출해 비동기 close를 보장합니다.
+ *
+ * ```kotlin
+ * client.withConsumer(Schema.STRING, {
+ *     topic("orders"); subscriptionName("sub-1")
+ * }) {
+ *     val msg = receiveSuspend()
+ *     acknowledgeSuspend(msg)
+ * }
+ * ```
+ *
+ * @param schema 메시지 스키마
+ * @param setup [ConsumerBuilder] 설정 블록
+ * @param block [Consumer]를 receiver로 받는 suspend 블록
+ * @return 블록의 반환값
+ */
+suspend inline fun <T, R> PulsarClient.withConsumer(
+    schema: Schema<T>,
+    noinline setup: ConsumerBuilder<T>.() -> Unit = {},
+    crossinline block: suspend Consumer<T>.() -> R,
+): R {
+    val consumer = consumer(schema, setup)
+    try {
+        return block(consumer)
+    } finally {
+        runCatching { consumer.closeAsync().awaitSuspending() }
+            .onFailure { log.warn(it) { "Consumer close 실패" } }
+    }
+}

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/producer/ProducerExtensions.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/producer/ProducerExtensions.kt
@@ -1,8 +1,9 @@
 package io.bluetape4k.pulsar.producer
 
 import io.bluetape4k.coroutines.support.awaitSuspending
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.flow
 import org.apache.pulsar.client.api.MessageId
 import org.apache.pulsar.client.api.Producer
 import org.apache.pulsar.client.api.TypedMessageBuilder
@@ -41,12 +42,12 @@ suspend fun <T> Producer<T>.sendSuspend(
 ): MessageId = newMessage().apply(setup).sendAsync().awaitSuspending()
 
 /**
- * [Flow] 기반으로 메시지를 배치 발행하고 [MessageId] Flow를 반환합니다.
+ * [Flow] 기반으로 메시지를 순차 발행하고 [MessageId] Flow를 반환합니다.
  *
- * 첫 번째 메시지 발행 실패 시 Flow가 즉시 종료되고 예외가 전파됩니다.
- * 재시도는 호출자가 `Flow.retry {}` 등으로 처리해야 합니다.
- *
- * `Flow.map { }` 람다는 suspend 컨텍스트이므로 `sendSuspend` 호출이 가능합니다.
+ * ## 생명주기 계약
+ * - 메시지는 순차적으로 발행됩니다 (`buffer()` / `flatMapMerge`로 병렬화 가능).
+ * - 코루틴 취소 시 대기 중인 [java.util.concurrent.CompletableFuture]를 `cancel(true)`로 중단 후 종료합니다.
+ * - 발행 실패 시 Flow가 즉시 종료되고 예외가 전파됩니다. 재시도는 `Flow.retry {}` 등으로 처리하세요.
  *
  * ```kotlin
  * val ids = producer.sendAsFlow(flow {
@@ -57,5 +58,14 @@ suspend fun <T> Producer<T>.sendSuspend(
  * @param messages 발행할 메시지 [Flow]
  * @return 발행 결과 [MessageId] [Flow]
  */
-fun <T> Producer<T>.sendAsFlow(messages: Flow<T>): Flow<MessageId> =
-    messages.map { sendSuspend(it) }
+fun <T> Producer<T>.sendAsFlow(messages: Flow<T>): Flow<MessageId> = flow {
+    messages.collect { message ->
+        val future = sendAsync(message)
+        try {
+            emit(future.awaitSuspending())
+        } catch (ce: CancellationException) {
+            future.cancel(true)
+            throw ce
+        }
+    }
+}

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/producer/ProducerExtensions.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/producer/ProducerExtensions.kt
@@ -1,0 +1,61 @@
+package io.bluetape4k.pulsar.producer
+
+import io.bluetape4k.coroutines.support.awaitSuspending
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.apache.pulsar.client.api.MessageId
+import org.apache.pulsar.client.api.Producer
+import org.apache.pulsar.client.api.TypedMessageBuilder
+
+/**
+ * 메시지를 비동기로 발행하고 [MessageId]를 반환합니다.
+ *
+ * ```kotlin
+ * val msgId = producer.sendSuspend("hello")
+ * ```
+ *
+ * @param message 발행할 메시지
+ * @return 발행된 메시지의 [MessageId]
+ * @throws org.apache.pulsar.client.api.PulsarClientException 브로커 오류 시
+ */
+suspend fun <T> Producer<T>.sendSuspend(message: T): MessageId =
+    sendAsync(message).awaitSuspending()
+
+/**
+ * [TypedMessageBuilder] DSL 기반으로 메시지를 발행합니다.
+ *
+ * ```kotlin
+ * val msgId = producer.sendSuspend {
+ *     value(order)
+ *     key("order-${order.id}")
+ *     property("version", "1")
+ * }
+ * ```
+ *
+ * @param setup [TypedMessageBuilder] 설정 블록
+ * @return 발행된 메시지의 [MessageId]
+ * @throws org.apache.pulsar.client.api.PulsarClientException 브로커 오류 시
+ */
+suspend fun <T> Producer<T>.sendSuspend(
+    setup: TypedMessageBuilder<T>.() -> Unit,
+): MessageId = newMessage().apply(setup).sendAsync().awaitSuspending()
+
+/**
+ * [Flow] 기반으로 메시지를 배치 발행하고 [MessageId] Flow를 반환합니다.
+ *
+ * 첫 번째 메시지 발행 실패 시 Flow가 즉시 종료되고 예외가 전파됩니다.
+ * 재시도는 호출자가 `Flow.retry {}` 등으로 처리해야 합니다.
+ *
+ * `Flow.map { }` 람다는 suspend 컨텍스트이므로 `sendSuspend` 호출이 가능합니다.
+ *
+ * ```kotlin
+ * val ids = producer.sendAsFlow(flow {
+ *     repeat(100) { emit("msg-$it") }
+ * }).toList()
+ * ```
+ *
+ * @param messages 발행할 메시지 [Flow]
+ * @return 발행 결과 [MessageId] [Flow]
+ */
+fun <T> Producer<T>.sendAsFlow(messages: Flow<T>): Flow<MessageId> =
+    messages.map { sendSuspend(it) }

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/producer/ProducerSupport.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/producer/ProducerSupport.kt
@@ -28,7 +28,7 @@ internal val log = KotlinLogging.logger {}
  */
 fun <T> PulsarClient.producer(
     schema: Schema<T>,
-    setup: ProducerBuilder<T>.() -> Unit,
+    setup: ProducerBuilder<T>.() -> Unit = {},
 ): Producer<T> = newProducer(schema).apply(setup).create()
 
 /**

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/producer/ProducerSupport.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/producer/ProducerSupport.kt
@@ -1,0 +1,62 @@
+package io.bluetape4k.pulsar.producer
+
+import io.bluetape4k.coroutines.support.awaitSuspending
+import io.bluetape4k.logging.KotlinLogging
+import io.bluetape4k.logging.warn
+import org.apache.pulsar.client.api.Producer
+import org.apache.pulsar.client.api.ProducerBuilder
+import org.apache.pulsar.client.api.PulsarClient
+import org.apache.pulsar.client.api.Schema
+
+@PublishedApi
+internal val log = KotlinLogging.logger {}
+
+/**
+ * [Producer] DSL 빌더 ([PulsarClient] 확장).
+ *
+ * ```kotlin
+ * val producer = client.producer(Schema.STRING) {
+ *     topic("persistent://public/default/orders")
+ *     producerName("order-producer")
+ *     compressionType(CompressionType.LZ4)
+ * }
+ * ```
+ *
+ * @param schema 메시지 스키마
+ * @param setup [ProducerBuilder] 설정 블록
+ * @return 생성된 [Producer] 인스턴스
+ */
+fun <T> PulsarClient.producer(
+    schema: Schema<T>,
+    setup: ProducerBuilder<T>.() -> Unit,
+): Producer<T> = newProducer(schema).apply(setup).create()
+
+/**
+ * Producer 생명주기를 블록 스코프로 자동 관리합니다.
+ *
+ * 블록 종료(정상/예외/취소) 시 [Producer.closeAsync]를 호출해 비동기 close를 보장합니다.
+ *
+ * ```kotlin
+ * client.withProducer(Schema.STRING, { topic("orders") }) {
+ *     sendSuspend("hello")
+ * }
+ * ```
+ *
+ * @param schema 메시지 스키마
+ * @param setup [ProducerBuilder] 설정 블록
+ * @param block [Producer]를 receiver로 받는 suspend 블록
+ * @return 블록의 반환값
+ */
+suspend inline fun <T, R> PulsarClient.withProducer(
+    schema: Schema<T>,
+    noinline setup: ProducerBuilder<T>.() -> Unit = {},
+    crossinline block: suspend Producer<T>.() -> R,
+): R {
+    val producer = producer(schema, setup)
+    try {
+        return block(producer)
+    } finally {
+        runCatching { producer.closeAsync().awaitSuspending() }
+            .onFailure { log.warn(it) { "Producer close 실패" } }
+    }
+}

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/reader/ReaderExtensions.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/reader/ReaderExtensions.kt
@@ -1,0 +1,52 @@
+package io.bluetape4k.pulsar.reader
+
+import io.bluetape4k.coroutines.support.awaitSuspending
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.isActive
+import org.apache.pulsar.client.api.Message
+import org.apache.pulsar.client.api.Reader
+
+/**
+ * 다음 메시지를 비동기로 읽습니다.
+ *
+ * ```kotlin
+ * val msg = reader.readNextSuspend()
+ * println(msg.value)
+ * ```
+ *
+ * @return 읽은 [Message]
+ * @throws org.apache.pulsar.client.api.PulsarClientException 브로커 오류 시
+ */
+suspend fun <T> Reader<T>.readNextSuspend(): Message<T> =
+    readNextAsync().awaitSuspending()
+
+/**
+ * `hasMessageAvailable()`이 true인 동안 메시지를 읽는 [Flow]를 반환합니다.
+ *
+ * ## 생명주기 계약
+ * - `hasMessageAvailable() == false`이면 Flow 정상 종료
+ * - 코루틴 취소 시 대기 중인 [java.util.concurrent.CompletableFuture]를 `cancel(true)`로 중단 후 종료
+ * - Flow는 Reader를 소유하지 않음 — `withReader {}` 또는 호출자가 close 책임
+ *
+ * ```kotlin
+ * client.withReader(Schema.STRING, { topic(topic); startMessageId(MessageId.earliest) }) {
+ *     readAsFlow().map { it.value }.collect { println(it) }
+ * }
+ * ```
+ *
+ * @return 메시지 [Flow] (발행된 메시지를 모두 읽으면 자동 종료)
+ */
+fun <T> Reader<T>.readAsFlow(): Flow<Message<T>> = flow {
+    while (currentCoroutineContext().isActive && hasMessageAvailable()) {
+        val future = readNextAsync()
+        try {
+            emit(future.awaitSuspending())
+        } catch (ce: CancellationException) {
+            future.cancel(true)
+            throw ce
+        }
+    }
+}

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/reader/ReaderSupport.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/reader/ReaderSupport.kt
@@ -1,0 +1,66 @@
+package io.bluetape4k.pulsar.reader
+
+import io.bluetape4k.coroutines.support.awaitSuspending
+import io.bluetape4k.logging.KotlinLogging
+import io.bluetape4k.logging.warn
+import org.apache.pulsar.client.api.PulsarClient
+import org.apache.pulsar.client.api.Reader
+import org.apache.pulsar.client.api.ReaderBuilder
+import org.apache.pulsar.client.api.Schema
+
+@PublishedApi
+internal val log = KotlinLogging.logger {}
+
+/**
+ * [Reader] DSL 빌더 ([PulsarClient] 확장).
+ *
+ * Consumer와 달리 subscription 없이 토픽을 직접 읽습니다. ack 불필요.
+ *
+ * ```kotlin
+ * val reader = client.reader(Schema.STRING) {
+ *     topic("persistent://public/default/orders")
+ *     startMessageId(MessageId.earliest)
+ * }
+ * ```
+ *
+ * @param schema 메시지 스키마
+ * @param setup [ReaderBuilder] 설정 블록
+ * @return 생성된 [Reader] 인스턴스
+ */
+fun <T> PulsarClient.reader(
+    schema: Schema<T>,
+    setup: ReaderBuilder<T>.() -> Unit,
+): Reader<T> = newReader(schema).apply(setup).create()
+
+/**
+ * Reader 생명주기를 블록 스코프로 자동 관리합니다.
+ *
+ * 블록 종료(정상/예외/취소) 시 [Reader.closeAsync]를 호출해 비동기 close를 보장합니다.
+ *
+ * ```kotlin
+ * client.withReader(Schema.STRING, {
+ *     topic("orders"); startMessageId(MessageId.earliest)
+ * }) {
+ *     val msg = readNextSuspend()
+ *     println(msg.value)
+ * }
+ * ```
+ *
+ * @param schema 메시지 스키마
+ * @param setup [ReaderBuilder] 설정 블록
+ * @param block [Reader]를 receiver로 받는 suspend 블록
+ * @return 블록의 반환값
+ */
+suspend inline fun <T, R> PulsarClient.withReader(
+    schema: Schema<T>,
+    noinline setup: ReaderBuilder<T>.() -> Unit = {},
+    crossinline block: suspend Reader<T>.() -> R,
+): R {
+    val reader = reader(schema, setup)
+    try {
+        return block(reader)
+    } finally {
+        runCatching { reader.closeAsync().awaitSuspending() }
+            .onFailure { log.warn(it) { "Reader close 실패" } }
+    }
+}

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/reader/ReaderSupport.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/reader/ReaderSupport.kt
@@ -29,7 +29,7 @@ internal val log = KotlinLogging.logger {}
  */
 fun <T> PulsarClient.reader(
     schema: Schema<T>,
-    setup: ReaderBuilder<T>.() -> Unit,
+    setup: ReaderBuilder<T>.() -> Unit = {},
 ): Reader<T> = newReader(schema).apply(setup).create()
 
 /**

--- a/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/AbstractPulsarTest.kt
+++ b/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/AbstractPulsarTest.kt
@@ -1,0 +1,23 @@
+package io.bluetape4k.pulsar
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.mq.PulsarServer
+import org.apache.pulsar.client.api.PulsarClient
+import java.util.UUID
+
+abstract class AbstractPulsarTest {
+
+    companion object: KLogging() {
+        @JvmStatic
+        val pulsar: PulsarServer by lazy { PulsarServer.Launcher.pulsar }
+
+        @JvmStatic
+        fun newClient(): PulsarClient = PulsarServer.Launcher.PulsarClient(pulsar.url)
+
+        @JvmStatic
+        fun newTopic(): String = "test-topic-${UUID.randomUUID()}"
+
+        @JvmStatic
+        fun newSubscription(): String = "test-sub-${UUID.randomUUID()}"
+    }
+}

--- a/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/codec/Jackson3SchemaTest.kt
+++ b/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/codec/Jackson3SchemaTest.kt
@@ -1,0 +1,78 @@
+package io.bluetape4k.pulsar.codec
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.pulsar.AbstractPulsarTest
+import io.bluetape4k.pulsar.consumer.receiveSuspend
+import io.bluetape4k.pulsar.producer.sendSuspend
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeEmpty
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.pulsar.common.schema.SchemaType
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.io.Serializable
+import kotlin.time.Duration.Companion.seconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class Jackson3SchemaTest: AbstractPulsarTest() {
+
+    companion object: KLogging() {
+        private val TEST_PRODUCT = Product(sku = "PROD-42", price = 29900, name = "Kotlin Coroutines Book")
+    }
+
+    data class Product(
+        val sku: String,
+        val price: Int,
+        val name: String,
+    ): Serializable
+
+    @Test
+    fun `jackson3Schema - SchemaInfo 타입 확인`() {
+        val schema = jackson3Schema<Product>()
+        schema.schemaInfo.shouldNotBeNull()
+        schema.schemaInfo.type shouldBeEqualTo SchemaType.JSON
+        schema.schemaInfo.name shouldBeEqualTo "Product"
+    }
+
+    @Test
+    fun `jackson3Schema - encode와 decode 왕복`() {
+        val schema = jackson3Schema<Product>()
+        val encoded = schema.encode(TEST_PRODUCT)
+        val decoded = schema.decode(encoded)
+        decoded shouldBeEqualTo TEST_PRODUCT
+    }
+
+    @Test
+    fun `jackson3Schema - Pulsar 메시지 발행 및 수신`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+        val schema = jackson3Schema<Product>()
+
+        val consumer = client.newConsumer(schema)
+            .topic(topic)
+            .subscriptionName(newSubscription())
+            .subscribe()
+        val producer = client.newProducer(schema)
+            .topic(topic)
+            .create()
+        try {
+            producer.sendSuspend(TEST_PRODUCT)
+            val msg = consumer.receiveSuspend()
+            msg.value shouldBeEqualTo TEST_PRODUCT
+        } finally {
+            producer.close()
+            consumer.close()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `jackson3Schema - clone 후 독립 동작`() {
+        val schema = jackson3Schema<Product>()
+        val cloned = schema.clone()
+        val encoded = cloned.encode(TEST_PRODUCT)
+        val decoded = cloned.decode(encoded)
+        decoded shouldBeEqualTo TEST_PRODUCT
+    }
+}

--- a/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/codec/JacksonSchemaTest.kt
+++ b/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/codec/JacksonSchemaTest.kt
@@ -1,0 +1,78 @@
+package io.bluetape4k.pulsar.codec
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.pulsar.AbstractPulsarTest
+import io.bluetape4k.pulsar.consumer.receiveSuspend
+import io.bluetape4k.pulsar.producer.sendSuspend
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeEmpty
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.pulsar.common.schema.SchemaType
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.io.Serializable
+import kotlin.time.Duration.Companion.seconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JacksonSchemaTest: AbstractPulsarTest() {
+
+    companion object: KLogging() {
+        private val TEST_ORDER = Order(id = "order-1", amount = 9900, item = "Bluetooth Speaker")
+    }
+
+    data class Order(
+        val id: String,
+        val amount: Int,
+        val item: String,
+    ): Serializable
+
+    @Test
+    fun `jacksonSchema - SchemaInfo 타입 확인`() {
+        val schema = jacksonSchema<Order>()
+        schema.schemaInfo.shouldNotBeNull()
+        schema.schemaInfo.type shouldBeEqualTo SchemaType.JSON
+        schema.schemaInfo.name shouldBeEqualTo "Order"
+    }
+
+    @Test
+    fun `jacksonSchema - encode와 decode 왕복`() {
+        val schema = jacksonSchema<Order>()
+        val encoded = schema.encode(TEST_ORDER)
+        val decoded = schema.decode(encoded)
+        decoded shouldBeEqualTo TEST_ORDER
+    }
+
+    @Test
+    fun `jacksonSchema - Pulsar 메시지 발행 및 수신`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+        val schema = jacksonSchema<Order>()
+
+        val consumer = client.newConsumer(schema)
+            .topic(topic)
+            .subscriptionName(newSubscription())
+            .subscribe()
+        val producer = client.newProducer(schema)
+            .topic(topic)
+            .create()
+        try {
+            producer.sendSuspend(TEST_ORDER)
+            val msg = consumer.receiveSuspend()
+            msg.value shouldBeEqualTo TEST_ORDER
+        } finally {
+            producer.close()
+            consumer.close()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `jacksonSchema - clone 후 독립 동작`() {
+        val schema = jacksonSchema<Order>()
+        val cloned = schema.clone()
+        val encoded = cloned.encode(TEST_ORDER)
+        val decoded = cloned.decode(encoded)
+        decoded shouldBeEqualTo TEST_ORDER
+    }
+}

--- a/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/consumer/ConsumerExtensionsTest.kt
+++ b/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/consumer/ConsumerExtensionsTest.kt
@@ -1,0 +1,190 @@
+package io.bluetape4k.pulsar.consumer
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.pulsar.AbstractPulsarTest
+import io.bluetape4k.pulsar.producer.sendSuspend
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldHaveSize
+import org.apache.pulsar.client.api.PulsarClientException
+import org.apache.pulsar.client.api.Schema
+import org.apache.pulsar.client.api.SubscriptionType
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration.Companion.seconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ConsumerExtensionsTest: AbstractPulsarTest() {
+
+    companion object: KLogging()
+
+    @Test
+    fun `receiveSuspend - 메시지 수신`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+
+        val consumer = client.newConsumer(Schema.STRING)
+            .topic(topic)
+            .subscriptionName(newSubscription())
+            .subscribe()
+        val producer = client.newProducer(Schema.STRING)
+            .topic(topic)
+            .create()
+        try {
+            producer.sendSuspend("hello consumer")
+            val msg = consumer.receiveSuspend()
+            msg.value shouldBeEqualTo "hello consumer"
+        } finally {
+            producer.close()
+            consumer.close()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `acknowledgeSuspend - 메시지 ack 처리`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+        val sub = newSubscription()
+
+        val consumer = client.newConsumer(Schema.STRING)
+            .topic(topic)
+            .subscriptionName(sub)
+            .subscriptionType(SubscriptionType.Exclusive)
+            .subscribe()
+        val producer = client.newProducer(Schema.STRING)
+            .topic(topic)
+            .create()
+        try {
+            producer.sendSuspend("ack test")
+            val msg = consumer.receiveSuspend()
+            consumer.acknowledgeSuspend(msg)
+            msg.value shouldBeEqualTo "ack test"
+        } finally {
+            producer.close()
+            consumer.close()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `acknowledgeCumulativeSuspend - Exclusive subscription cumulative ack`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+
+        val consumer = client.newConsumer(Schema.STRING)
+            .topic(topic)
+            .subscriptionName(newSubscription())
+            .subscriptionType(SubscriptionType.Exclusive)
+            .subscribe()
+        val producer = client.newProducer(Schema.STRING)
+            .topic(topic)
+            .create()
+        try {
+            repeat(3) { i -> producer.sendSuspend("msg-$i") }
+
+            val msgs = (1..3).map { consumer.receiveSuspend() }
+            msgs shouldHaveSize 3
+            consumer.acknowledgeCumulativeSuspend(msgs.last())
+        } finally {
+            producer.close()
+            consumer.close()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `acknowledgeCumulativeSuspend - Shared subscription에서 예외 발생`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+
+        val consumer = client.newConsumer(Schema.STRING)
+            .topic(topic)
+            .subscriptionName(newSubscription())
+            .subscriptionType(SubscriptionType.Shared)
+            .subscribe()
+        val producer = client.newProducer(Schema.STRING)
+            .topic(topic)
+            .create()
+        try {
+            producer.sendSuspend("msg")
+            val msg = consumer.receiveSuspend()
+
+            assertFailsWith<PulsarClientException> {
+                consumer.acknowledgeCumulativeSuspend(msg)
+            }
+        } finally {
+            producer.close()
+            consumer.close()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `receiveAsFlow - 취소 시 정상 종료`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+        val messageCount = 5
+
+        val consumer = client.newConsumer(Schema.STRING)
+            .topic(topic)
+            .subscriptionName(newSubscription())
+            .subscribe()
+        val producer = client.newProducer(Schema.STRING)
+            .topic(topic)
+            .create()
+        try {
+            // 메시지를 미리 발행
+            repeat(messageCount) { i -> producer.sendSuspend("flow-msg-$i") }
+
+            // Flow에서 지정 개수만 수신 후 취소
+            val received = consumer.receiveAsFlow()
+                .take(messageCount)
+                .toList()
+
+            received shouldHaveSize messageCount
+            received.mapIndexed { i, msg -> msg.value shouldBeEqualTo "flow-msg-$i" }
+        } finally {
+            producer.close()
+            consumer.close()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `receiveAsFlow - 수신 후 ack 처리`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+
+        val consumer = client.newConsumer(Schema.STRING)
+            .topic(topic)
+            .subscriptionName(newSubscription())
+            .subscriptionType(SubscriptionType.Exclusive)
+            .subscribe()
+        val producer = client.newProducer(Schema.STRING)
+            .topic(topic)
+            .create()
+        try {
+            launch {
+                repeat(3) { i -> producer.sendSuspend("ack-msg-$i") }
+            }
+
+            val received = mutableListOf<String>()
+            consumer.receiveAsFlow().take(3).collect { msg ->
+                received.add(msg.value)
+                consumer.acknowledgeSuspend(msg)
+            }
+
+            received shouldHaveSize 3
+            received.forEachIndexed { i, v -> v shouldBeEqualTo "ack-msg-$i" }
+        } finally {
+            producer.close()
+            consumer.close()
+            client.close()
+        }
+    }
+}

--- a/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/producer/ProducerExtensionsTest.kt
+++ b/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/producer/ProducerExtensionsTest.kt
@@ -1,0 +1,98 @@
+package io.bluetape4k.pulsar.producer
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.pulsar.AbstractPulsarTest
+import io.bluetape4k.pulsar.consumer.receiveSuspend
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldHaveSize
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.pulsar.client.api.Schema
+import org.apache.pulsar.client.api.SubscriptionType
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.time.Duration.Companion.seconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ProducerExtensionsTest: AbstractPulsarTest() {
+
+    companion object: KLogging()
+
+    @Test
+    fun `sendSuspend - 단일 메시지 발행`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+
+        val consumer = client.newConsumer(Schema.STRING)
+            .topic(topic)
+            .subscriptionName(newSubscription())
+            .subscriptionType(SubscriptionType.Exclusive)
+            .subscribe()
+        val producer = client.newProducer(Schema.STRING)
+            .topic(topic)
+            .create()
+        try {
+            val msgId = producer.sendSuspend("hello pulsar")
+            msgId.shouldNotBeNull()
+
+            val msg = consumer.receiveSuspend()
+            msg.value shouldBeEqualTo "hello pulsar"
+        } finally {
+            producer.close()
+            consumer.close()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `sendSuspend - TypedMessageBuilder DSL 발행`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+
+        val consumer = client.newConsumer(Schema.STRING)
+            .topic(topic)
+            .subscriptionName(newSubscription())
+            .subscribe()
+        val producer = client.newProducer(Schema.STRING)
+            .topic(topic)
+            .create()
+        try {
+            val msgId = producer.sendSuspend {
+                value("DSL message")
+                key("key-1")
+                property("version", "1")
+            }
+            msgId.shouldNotBeNull()
+
+            val msg = consumer.receiveSuspend()
+            msg.value shouldBeEqualTo "DSL message"
+            msg.key shouldBeEqualTo "key-1"
+            msg.properties["version"] shouldBeEqualTo "1"
+        } finally {
+            producer.close()
+            consumer.close()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `sendAsFlow - Flow 기반 배치 발행`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+        val messages = (1..5).map { "msg-$it" }
+
+        val producer = client.newProducer(Schema.STRING)
+            .topic(topic)
+            .create()
+        try {
+            val ids = producer.sendAsFlow(messages.asFlow()).toList()
+            ids shouldHaveSize 5
+            ids.forEach { it.shouldNotBeNull() }
+        } finally {
+            producer.close()
+            client.close()
+        }
+    }
+}

--- a/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/reader/ReaderExtensionsTest.kt
+++ b/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/reader/ReaderExtensionsTest.kt
@@ -1,0 +1,94 @@
+package io.bluetape4k.pulsar.reader
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.pulsar.AbstractPulsarTest
+import io.bluetape4k.pulsar.producer.sendSuspend
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldHaveSize
+import org.apache.pulsar.client.api.MessageId
+import org.apache.pulsar.client.api.Schema
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.time.Duration.Companion.seconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ReaderExtensionsTest: AbstractPulsarTest() {
+
+    companion object: KLogging()
+
+    @Test
+    fun `readNextSuspend - 단일 메시지 읽기`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+
+        val producer = client.newProducer(Schema.STRING)
+            .topic(topic)
+            .create()
+        val reader = client.newReader(Schema.STRING)
+            .topic(topic)
+            .startMessageId(MessageId.earliest)
+            .create()
+        try {
+            producer.sendSuspend("reader test")
+            val msg = reader.readNextSuspend()
+            msg.value shouldBeEqualTo "reader test"
+        } finally {
+            reader.close()
+            producer.close()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `readAsFlow - hasMessageAvailable 기반 Flow 읽기`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+        val messageCount = 5
+
+        val producer = client.newProducer(Schema.STRING)
+            .topic(topic)
+            .create()
+        try {
+            // 메시지를 미리 모두 발행한 후 Reader로 읽기
+            repeat(messageCount) { i -> producer.sendSuspend("read-msg-$i") }
+        } finally {
+            producer.close()
+        }
+
+        // Reader는 earliest 시점부터 읽으므로 미리 발행된 메시지 전부 수신
+        val reader = client.newReader(Schema.STRING)
+            .topic(topic)
+            .startMessageId(MessageId.earliest)
+            .create()
+        try {
+            val messages = reader.readAsFlow().toList()
+            messages shouldHaveSize messageCount
+            messages.forEachIndexed { i, msg ->
+                msg.value shouldBeEqualTo "read-msg-$i"
+            }
+        } finally {
+            reader.close()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `readAsFlow - 메시지 없으면 빈 Flow`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+
+        val reader = client.newReader(Schema.STRING)
+            .topic(topic)
+            .startMessageId(MessageId.latest)
+            .create()
+        try {
+            val messages = reader.readAsFlow().toList()
+            messages shouldHaveSize 0
+        } finally {
+            reader.close()
+            client.close()
+        }
+    }
+}

--- a/infra/pulsar/src/test/resources/junit-platform.properties
+++ b/infra/pulsar/src/test/resources/junit-platform.properties
@@ -1,0 +1,5 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/infra/pulsar/src/test/resources/logback-test.xml
+++ b/infra/pulsar/src/test/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <!-- @formatter:off -->
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%.24t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <!-- @formatter:on -->
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.pulsar" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
## Summary

Closes #147

- PR 제목: feat: bluetape4k-pulsar 모듈 신규 구현 (Issue #147)

Apache Pulsar 3.3.9 코루틴 기반 Kotlin 확장 모듈 `infra/pulsar` 신규 구현.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 구현 내용

### 소스 파일 (9개)
| 파일 | 설명 |
|------|------|
| `PulsarClientSupport.kt` | `pulsarClient()`, `withPulsarClient {}` DSL |
| `producer/ProducerSupport.kt` | `PulsarClient.producer()`, `withProducer {}` |
| `producer/ProducerExtensions.kt` | `sendSuspend()`, `sendAsFlow()` |
| `consumer/ConsumerSupport.kt` | `PulsarClient.consumer()`, `withConsumer {}` |
| `consumer/ConsumerExtensions.kt` | `receiveSuspend()`, `receiveAsFlow()`, `acknowledgeSuspend()`, `acknowledgeCumulativeSuspend()` |
| `reader/ReaderSupport.kt` | `PulsarClient.reader()`, `withReader {}` |
| `reader/ReaderExtensions.kt` | `readNextSuspend()`, `readAsFlow()` |
| `codec/JacksonSchema.kt` | `jacksonSchema<T>()` — Jackson2 기반 |
| `codec/Jackson3Schema.kt` | `jackson3Schema<T>()` — Jackson3 기반 |

### 주요 설계 결정
- **코루틴 우선**: 모든 비동기 작업을 `awaitSuspending()`으로 래핑
- **취소 안전 Flow**: `CancellationException` 시 in-flight `CompletableFuture.cancel(true)` 보장
- **DSL 생명주기**: `withXxx {}` 블록에서 `try/finally { closeAsync() }` 자동 관리
- **Jackson compileOnly**: 사용 모듈에서 jackson2/jackson3 중 필요한 것만 선언
- **SchemaInfo**: `Schema.JSON(type).schemaInfo` 로 브로커 JSON 스키마 검증 통과, name은 type에서 직접 설정

### 기존 섹션: 코드 리뷰 반영

- [HIGH] `sendAsFlow` 취소 안전성: `CancellationException` 시 `Future.cancel(true)` 추가
- [MEDIUM] `withPulsarClient` setup-only 오버로드 추가 (TLS/인증 전용)
- [LOW] `producer`/`consumer`/`reader` 빌더 `setup = {}` 기본값 추가
- [LOW] `clone()` 시 SchemaInfo 재계산 방지 (`cachedInfo` 파라미터)

### 기존 섹션: DoD 체크리스트

### 구현
- [x] T1: 모듈 등록 + 의존성 + test resources
- [x] T2: `pulsarClient {}` / `withPulsarClient {}`
- [x] T3: `producer {}` / `withProducer {}` / `sendSuspend` / `sendAsFlow`
- [x] T4: `consumer {}` / `withConsumer {}` / `receiveSuspend` / `receiveAsFlow` / `acknowledgeSuspend` / `acknowledgeCumulativeSuspend`
- [x] T5: `reader {}` / `withReader {}` / `readNextSuspend` / `readAsFlow`
- [x] T6: Jackson2 `jacksonSchema<T>()` + Jackson3 `jackson3Schema<T>()`

### 코드 품질
- [x] 모든 public API 한국어 KDoc
- [x] top-level 파일 `@PublishedApi internal val log = KotlinLogging.logger {}`
- [x] 클래스 파일 `companion object : KLogging()`
- [x] Kluent matcher 일관 사용 (`shouldBeEqualTo` / `shouldNotBeNull` / `shouldHaveSize`)

### 테스트
- [x] T7: ProducerExtensionsTest 통과
- [x] T8: ConsumerExtensionsTest 통과 (UUID subscriptionName 격리)
- [x] T9: ReaderExtensionsTest 통과
- [x] T10: JacksonSchemaTest + Jackson3SchemaTest 통과
- [x] `junit-platform.properties` + `logback-test.xml` 포함

### 패턴 검증 (T13)
- [x] bluetape4k-patterns 체크리스트 전수 통과

### 문서
- [x] T11: README.md + README.ko.md (Mermaid 다이어그램 + 언어 전환 링크)
- [x] T12: CLAUDE.md `infra/` 그룹에 `pulsar` 추가

Closes #147

## Validation

```
20 tests completed, 0 failed (39.4s)
```

```bash
./gradlew :bluetape4k-pulsar:test
```

| 테스트 클래스 | 케이스 수 | 결과 |
|-------------|---------|------|
| `ProducerExtensionsTest` | 3 | ✅ |
| `ConsumerExtensionsTest` | 6 | ✅ |
| `ReaderExtensionsTest` | 3 | ✅ |
| `JacksonSchemaTest` | 4 | ✅ |
| `Jackson3SchemaTest` | 4 | ✅ |
| **합계** | **20** | **전수 통과** |

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #147, milestone 없음, assignee `debop`
- PR: #168, head `fc54f03d876b36e74df9966441c8d551f7a288cd`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/infra-pulsar`
- Labels: `enhancement`
- State: `MERGED`, merge commit `6e786f32a92143b3f05e898e64492bc226686dab`
- CI: ./gradlew :bluetape4k-pulsar:test

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #168 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `6e786f32a92143b3f05e898e64492bc226686dab`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
