### PR TITLE
fix: test-io-http CI job에 mock-web-server Docker 이미지 빌드 step 추가

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -229,6 +229,11 @@ jobs:
                   gradle-version: wrapper
                   cache-read-only: true
 
+          -   name: Build mock-web-server Docker image
+              run: ./gradlew :bluetape4k-mock-web-server:jibDockerBuild --no-configuration-cache
+              env:
+                  GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
           -   name: Test io http client modules
               uses: nick-fields/retry@v3
               with:


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: test-io-http CI job에 mock-web-server Docker 이미지 빌드 step 추가

## Background

**GitHub Actions run #24961208194** 의 `Test / IO HTTP` job 실패:

```
Caused by: com.github.dockerjava.api.exception.NotFoundException:
  Status 404: {"message":"pull access denied for bluetape4k/mock-web-server,
  repository does not exist or may require 'docker login': denied: requested access to the resource is denied"}
```

`test-io-http` job이 `bluetape4k-feign` 모듈을 테스트할 때 `BluetapeHttpServer`를 사용하는데, 이 컨테이너는 `bluetape4k/mock-web-server:latest` Docker 이미지에 의존합니다.

그런데 `test-io-http` job에는 이미지를 먼저 빌드하는 `jibDockerBuild` step이 없어서 Docker Hub에서 pull을 시도하다가 이미지가 private/존재하지 않아 실패합니다.

## What This Solves

`test-io-http` job에 테스트 실행 전 mock-web-server Docker 이미지를 로컬 빌드하는 step 추가:

```yaml
- name: Build mock-web-server Docker image
  run: ./gradlew :bluetape4k-mock-web-server:jibDockerBuild --no-configuration-cache
  env:
    GRADLE_OPTS: "-Dorg.gradle.daemon=false"
```

동일한 패턴을 이미 사용 중인 job:
- `test-infra` (cache-misc 그룹)
- `test-spring3-docker`
- `test-spring4-docker`
- `test-testcontainers` (infra-http 그룹)

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### 문제

**GitHub Actions run #24961208194** 의 `Test / IO HTTP` job 실패:

```
Caused by: com.github.dockerjava.api.exception.NotFoundException:
  Status 404: {"message":"pull access denied for bluetape4k/mock-web-server,
  repository does not exist or may require 'docker login': denied: requested access to the resource is denied"}
```

### 원인

`test-io-http` job이 `bluetape4k-feign` 모듈을 테스트할 때 `BluetapeHttpServer`를 사용하는데, 이 컨테이너는 `bluetape4k/mock-web-server:latest` Docker 이미지에 의존합니다.

그런데 `test-io-http` job에는 이미지를 먼저 빌드하는 `jibDockerBuild` step이 없어서 Docker Hub에서 pull을 시도하다가 이미지가 private/존재하지 않아 실패합니다.

### 해결

`test-io-http` job에 테스트 실행 전 mock-web-server Docker 이미지를 로컬 빌드하는 step 추가:

```yaml
- name: Build mock-web-server Docker image
  run: ./gradlew :bluetape4k-mock-web-server:jibDockerBuild --no-configuration-cache
  env:
    GRADLE_OPTS: "-Dorg.gradle.daemon=false"
```

동일한 패턴을 이미 사용 중인 job:
- `test-infra` (cache-misc 그룹)
- `test-spring3-docker`
- `test-spring4-docker`
- `test-testcontainers` (infra-http 그룹)

### 검증

- CI 파일 변경만이므로 별도 테스트 없음
- nightly-tests 워크플로우를 수동 실행(`workflow_dispatch`)하여 검증 가능

## Validation

- CI 파일 변경만이므로 별도 테스트 없음
- nightly-tests 워크플로우를 수동 실행(`workflow_dispatch`)하여 검증 가능

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #171, head `9c091f8a3d4dd6afc8eb6c419db740b3f4fc0ca9`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/ci-mock-web-server`
- Labels: `management`
- State: `MERGED`, merge commit `93c4a7ac460f11f7aeaedc5369b0a623ef5a3664`
- CI: run: ./gradlew :bluetape4k-mock-web-server:jibDockerBuild --no-configuration-cache / GRADLE_OPTS: "-Dorg.gradle.daemon=false" / - CI 파일 변경만이므로 별도 테스트 없음

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #171 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `93c4a7ac460f11f7aeaedc5369b0a623ef5a3664`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
