### PR TITLE
feat: Issue #132 — utils/images 변환 API (AutoCrop/SmartCrop/Rotation/Perspective/CLAHE)

### DIFF
--- a/docs/superpowers/plans/2026-04-27-images-transform-plan.md
+++ b/docs/superpowers/plans/2026-04-27-images-transform-plan.md
@@ -1,0 +1,496 @@
+# utils/images Transform API Implementation Plan — Issue #132
+
+- **Issue**: #132
+- **Spec**: `docs/superpowers/specs/2026-04-27-images-transform-design.md`
+- **모듈**: `utils/images` (`bluetape4k-images`)
+- **브랜치**: `feat/issue-132-images-transform`
+- **Worktree**: `.worktrees/feat/issue-132-images-transform/`
+- **작성일**: 2026-04-27
+
+---
+
+## 0. 작업 원칙
+
+- 모든 task는 worktree(`.worktrees/feat/issue-132-images-transform/`) 안에서 수행한다.
+- 모든 `.kt` 편집 후: `ide_diagnostics` → import error/`@Deprecated` 경고 즉시 해소.
+- 구현 task와 테스트 task는 1:1로 페어링한다 (T2/T3, T4/T5, ...).
+- 각 구현 task 종료 시 해당 단위 테스트 통과 확인 후 다음 task 진행.
+- KDoc은 Korean. KLogging: `companion object : KLoggingChannel()`.
+- Coroutines: `withContext(Dispatchers.Default)` (CPU bound).
+- 픽셀 단위 luma 비교: `assertSimilarToImage(actual, expected, tolerance)` (기존 `AbstractFilterTest` 사용).
+- Kluent 비교: `shouldBeGreaterThan` / `shouldBeInRange` 등 — `(x >= y).shouldBeTrue()` 금지.
+- 모든 `Graphics2D` 사용은 `try { ... } finally { g.dispose() }` 패턴.
+
+---
+
+## 1. Task Dependency Graph
+
+```mermaid
+flowchart TD
+    T1[T1: RasterUtils internal helpers]
+    T2[T2: AutoCrop impl]
+    T3[T3: AutoCropTest]
+    T4[T4: Rotation impl]
+    T5[T5: RotationTest]
+    T6[T6: SmartCrop impl + AspectRatio + SaliencyStrategy]
+    T7[T7: SmartCropTest]
+    T8[T8: PerspectiveTransform impl + ImagePoint + Gauss-Jordan]
+    T9[T9: PerspectiveTransformTest]
+    T10[T10: HistogramEqualization impl + CLAHE + globalEqualize]
+    T11[T11: HistogramEqualizationTest]
+    T12[T12: DSL ops file]
+    T13[T13: DSL ops test]
+    T14[T14: KDoc audit + final]
+    T15[T15: README.md + README.ko.md]
+    T16[T16: CLAUDE.md + docs index]
+    T17[T17: Testlog entry + final verification]
+
+    T1 --> T2
+    T1 --> T4
+    T1 --> T6
+    T1 --> T8
+    T1 --> T10
+    T2 --> T3
+    T4 --> T5
+    T6 --> T7
+    T8 --> T9
+    T10 --> T11
+    T2 --> T12
+    T4 --> T12
+    T6 --> T12
+    T8 --> T12
+    T10 --> T12
+    T12 --> T13
+    T3 --> T14
+    T5 --> T14
+    T7 --> T14
+    T9 --> T14
+    T11 --> T14
+    T13 --> T14
+    T14 --> T15
+    T15 --> T16
+    T16 --> T17
+```
+
+---
+
+## 2. Tasks
+
+### T1 — `internal/RasterUtils.kt` 헬퍼 작성
+
+- **complexity**: high
+- **dependencies**: none
+- **files (create)**:
+  - `utils/images/src/main/kotlin/io/bluetape4k/images/transforms/internal/RasterUtils.kt`
+- **what to implement**:
+  - `internal fun ImmutableImage.toIntArgb(): BufferedImage`
+    - scrimage `awt()` 결과가 `TYPE_INT_ARGB` 면 그대로, 아니면 새 ARGB BufferedImage 에 `Graphics2D.drawImage` 로 복사 후 반환.
+    - `try { ... } finally { g.dispose() }` 패턴 적용.
+  - `internal fun BufferedImage.copyArgb(): BufferedImage` — 같은 width/height 의 새 `TYPE_INT_ARGB` 복사본 반환.
+  - `internal fun BufferedImage.fill(color: Color): BufferedImage` — `Graphics2D.setBackground(color)` + `clearRect(0, 0, w, h)` 후 자기 자신 반환 (mutating helper, internal usage 한정).
+  - `internal fun BufferedImage.getArgb(): IntArray` — `getRGB(0, 0, w, h, IntArray(w*h), 0, w)` wrapper.
+  - `internal fun BufferedImage.setArgb(pixels: IntArray): BufferedImage` — `setRGB(0, 0, w, h, pixels, 0, w)` wrapper, this 반환.
+  - `internal const val MAX_OUTPUT_PIXELS = 67_108_864L`
+  - `internal inline fun argb(a: Int, r: Int, g: Int, b: Int): Int` — bit packing helper (a<<24 | r<<16 | g<<8 | b)
+  - `internal inline fun Int.alpha(): Int / red() / green() / blue()` — int extraction extensions
+  - 로깅: top-level extension 파일이므로 `private val log = KotlinLogging.logger {}` 사용.
+- **검증**: `./gradlew :bluetape4k-images:compileKotlin` 통과 + 컴파일러 경고 0건.
+
+### T2 — `AutoCrop.kt` 구현
+
+- **complexity**: medium
+- **dependencies**: T1
+- **files (create)**:
+  - `utils/images/src/main/kotlin/io/bluetape4k/images/transforms/AutoCrop.kt`
+- **what to implement**:
+  - `fun ImmutableImage.autoCrop(tolerance: Int = 10, padding: Int = 0, backgroundColor: Color? = null): ImmutableImage`
+  - `suspend fun ImmutableImage.suspendAutoCrop(...) = withContext(Dispatchers.Default) { autoCrop(...) }`
+  - 알고리즘 (spec §6.1):
+    1. `toIntArgb()` → IntArray pixel buffer
+    2. `backgroundColor` 가 null 이면 corner 4픽셀 ARGB 평균을 계산해 채널별로 사용.
+    3. 위/아래/왼쪽/오른쪽 경계 스캔: 각 행/열의 모든 픽셀이 `|channel - bg| <= tolerance` 인지 검사.
+    4. 결정된 `(top, bottom, left, right)` 에서 `padding` 만큼 양보, `coerceIn` 으로 원본 클램프.
+    5. `width < 1 || height < 1` 시 `log.debug { "autoCrop silent fallback (w=$w, h=$h, bg=$bg)" }` 후 `this` 반환.
+    6. 그 외에는 `subimage(left, top, w, h)` 반환.
+  - 로깅: `private val log = KotlinLogging.logger {}` (top-level extension 파일).
+  - **검증 예외**: `require(tolerance in 0..255)`, `require(padding >= 0)`.
+
+### T3 — `AutoCropTest.kt`
+
+- **complexity**: medium
+- **dependencies**: T2
+- **files (create)**:
+  - `utils/images/src/test/kotlin/io/bluetape4k/images/transforms/AutoCropTest.kt`
+- **what to implement** (extends `AbstractFilterTest`):
+  - `흰색 여백 + 빨간 사각형 합성 이미지 → 크롭 결과의 width/height 가 사각형 영역과 정확히 일치`
+  - `명시적 backgroundColor = WHITE 와 코너 자동 검출 결과가 동일`
+  - `padding = 5 → 결과가 사각형 영역 + 사방 5px`
+  - `완전 단색 이미지 → 원본과 동일 ImmutableImage 반환 (silent fallback)`
+  - `tolerance = 0 → 정확히 같은 색만 자름` / `tolerance = 50 → 더 넓게 자름`
+  - `landscape.jpg → tolerance = 0 일 때 변경 없음`
+  - `suspendAutoCrop = autoCrop` (`runTest { ... }`, `assertSimilarToImage` tolerance 0)
+  - `tolerance = -1 → IllegalArgumentException`
+  - `padding = -1 → IllegalArgumentException`
+
+### T4 — `Rotation.kt` 구현
+
+- **complexity**: medium
+- **dependencies**: T1
+- **files (create)**:
+  - `utils/images/src/main/kotlin/io/bluetape4k/images/transforms/Rotation.kt`
+- **what to implement**:
+  - `fun ImmutableImage.rotateDegrees(angle: Double, background: Color = Color(0, 0, 0, 0)): ImmutableImage`
+  - `fun ImmutableImage.flipHorizontal(): ImmutableImage = flipX()`
+  - `fun ImmutableImage.flipVertical(): ImmutableImage = flipY()`
+  - `suspend fun ImmutableImage.suspendRotateDegrees(...): ImmutableImage`
+  - 알고리즘 (spec §6.3):
+    1. `angle.normalize()` → -360..360 범위로 정규화 (`angle % 360`).
+    2. 90/180/270 배수 → `rotateLeft()` / `rotate(PI)` / `rotateRight()` 위임 (무손실).
+    3. 그 외: 회전 라디안 → 새 bounds(`newW`, `newH`) 계산 → `BufferedImage(newW, newH, TYPE_INT_ARGB)` 생성 → `Graphics2D` 로 background fill → `AffineTransform.translate(newW/2, newH/2).rotate(rad).translate(-w/2, -h/2)` → `setRenderingHint(KEY_INTERPOLATION, VALUE_INTERPOLATION_BICUBIC)` → `drawImage` → `dispose()`.
+    4. `ImmutableImage.wrapAwt(...)` 반환.
+  - 90도 배수 판별 시 부동소수점 오차 허용 (`Math.abs(angle % 90) < 1e-9`).
+  - 로깅: `private val log = KotlinLogging.logger {}` (top-level extension 파일).
+
+### T5 — `RotationTest.kt`
+
+- **complexity**: medium
+- **dependencies**: T4
+- **files (create)**:
+  - `utils/images/src/test/kotlin/io/bluetape4k/images/transforms/RotationTest.kt`
+- **what to implement**:
+  - `0도 회전 → 원본과 동일 (tolerance 0)`
+  - `90도 회전 = rotateRight() (tolerance 0)`
+  - `-90도 회전 = rotateLeft() (tolerance 0)`
+  - `180도 두 번 → 원본 (tolerance 3, 보간 영향)`
+  - `15도 회전 → 새 width/height 가 ceil(|w cos| + |h sin|), ceil(|w sin| + |h cos|) 와 일치`
+  - `45도 회전 + background = WHITE → corner pixel 이 흰색`
+  - `flipHorizontal().flipHorizontal() → 원본 (tolerance 0)`
+  - `flipVertical().flipVertical() → 원본 (tolerance 0)`
+  - `suspendRotateDegrees(15.0) ≈ rotateDegrees(15.0)` — `runTest`
+  - **[추가]** `이미지를 180도 회전 후 다시 180도 회전 → 원본 중앙 픽셀과 동일` — `translate(newW/2, newH/2)` 회전 중심이 올바름을 검증.
+
+### T6 — `SmartCrop.kt` 구현 (+ AspectRatio + SaliencyStrategy)
+
+- **complexity**: high
+- **dependencies**: T1
+- **files (create)**:
+  - `utils/images/src/main/kotlin/io/bluetape4k/images/transforms/SmartCrop.kt`
+- **what to implement**:
+  - `data class AspectRatio(val width: Int, val height: Int)` — `init { require(width > 0 && height > 0) }`
+    - companion presets: `SQUARE = AspectRatio(1, 1)`, `WIDESCREEN = (16, 9)`, `PORTRAIT = (9, 16)`, `STANDARD = (4, 3)`
+  - `sealed interface SaliencyStrategy { object SobelEnergy : SaliencyStrategy }`
+  - `fun ImmutableImage.smartCrop(aspectRatio: AspectRatio, strategy: SaliencyStrategy = SaliencyStrategy.SobelEnergy): ImmutableImage`
+  - `fun ImmutableImage.smartCropTo(width: Int, height: Int, strategy: SaliencyStrategy = SaliencyStrategy.SobelEnergy): ImmutableImage`
+  - `suspend fun ImmutableImage.suspendSmartCrop(...): ImmutableImage`
+  - 알고리즘 (spec §6.2):
+    1. 다운샘플: `longSide = max(width, height)`, `if (longSide > 256) scaleTo(...)`. 다운샘플 비율 `ds = 256 / longSide` 보존.
+    2. 그레이스케일 → IntArray (luma = 0.299R + 0.587G + 0.114B).
+    3. **Sobel 3×3** (Gx, Gy) → magnitude `IntArray((w-2)*(h-2))` (테두리 1픽셀 제외) 또는 (w*h) padding 처리.
+    4. **integral image** `IntArray((w+1) * (h+1))` (1행/1열 0 padding).
+    5. 후보 윈도우: `aspectRatio` 비율 유지하며 다운샘플 영역 안에 들어가는 최대 크기 → `(winW, winH)`.
+    6. stride 1로 모든 (x, y) 슬라이드 → integral image 기반 O(1) sum 계산 → 최대 위치.
+    7. 다운샘플 좌표 → 원본 좌표 복원 (`(x / ds, y / ds, winW / ds, winH / ds)`, `coerceIn`/`coerceAtMost`).
+    8. `subimage(x, y, w, h)` 반환.
+  - `smartCropTo(width, height, ...)` 는 내부적으로 `AspectRatio(width, height)` + 정확한 픽셀 크기 후처리 (`scaleTo(width, height)` 추가 호출).
+  - 로깅: `private val log = KotlinLogging.logger {}` (top-level extension 파일).
+
+### T7 — `SmartCropTest.kt`
+
+- **complexity**: medium
+- **dependencies**: T6
+- **files (create)**:
+  - `utils/images/src/test/kotlin/io/bluetape4k/images/transforms/SmartCropTest.kt`
+- **what to implement**:
+  - `좌측 절반 체커보드 + 우측 단색 → smartCrop(SQUARE) 결과의 중심 x < 원본 width/2`
+  - `AspectRatio.WIDESCREEN → 결과 width/height 비율이 16/9 ± 1px`
+  - `AspectRatio.PORTRAIT → height/width 비율이 16/9 ± 1px`
+  - `smartCropTo(320, 240) → 결과가 정확히 320×240`
+  - `흰색 단색 이미지 → 결과 크기는 비율에 맞고, 예외 미발생`
+  - `AspectRatio(0, 1) → IllegalArgumentException`
+  - `suspendSmartCrop ≈ smartCrop` — `runTest`
+
+### T8 — `PerspectiveTransform.kt` 구현 (+ ImagePoint + Gauss-Jordan)
+
+- **complexity**: high
+- **dependencies**: T1
+- **files (create)**:
+  - `utils/images/src/main/kotlin/io/bluetape4k/images/transforms/PerspectiveTransform.kt`
+- **what to implement**:
+  - `data class ImagePoint(val x: Double, val y: Double)`
+  - `fun ImmutableImage.perspectiveTransform(sourceCorners: List<ImagePoint>, destinationCorners: List<ImagePoint>, outputWidth: Int, outputHeight: Int, outsideColor: Color = Color(0, 0, 0, 0)): ImmutableImage`
+  - `suspend fun ImmutableImage.suspendPerspectiveTransform(...): ImmutableImage`
+  - 입력 검증 (spec §6.4 step 1):
+    - `require(sourceCorners.size == 4)`, `destinationCorners.size == 4`
+    - `require(outputWidth > 0 && outputHeight > 0)`
+    - `require(outputWidth.toLong() * outputHeight.toLong() <= MAX_OUTPUT_PIXELS)` ("output exceeds 64M pixels")
+    - `require(sourceCorners.all { it.x.isFinite() && it.y.isFinite() }) { "sourceCorners must have finite coordinates" }`
+    - `require(destinationCorners.all { it.x.isFinite() && it.y.isFinite() }) { "destinationCorners must have finite coordinates" }`
+  - **Gauss-Jordan with partial pivoting** private 헬퍼:
+    - `private fun solve8x8(a: DoubleArray, b: DoubleArray): DoubleArray`
+    - `a` (size 64, row-major) + `b` (size 8) → 풀이된 `x` (size 8)
+    - 피벗 절대값 `< 1e-12` → `IllegalArgumentException("source/destination points are nearly collinear")`
+  - 호모그래피 행렬 H (3×3) 계산 (h33 = 1):
+    - 4쌍 점 → 8 식 → `solve8x8` → DoubleArray(9) (h33 = 1.0 추가)
+  - 역행렬 Hinv 계산:
+    - `private fun invert3x3(h: DoubleArray): DoubleArray` — adjugate / determinant 직접 계산 (3×3 은 closed-form 빠름).
+    - `det < 1e-12` → IllegalArgumentException.
+  - 출력 BufferedImage 생성 → `outsideColor` fill.
+  - 출력 픽셀 (x, y) 마다 inverse mapping + bilinear 4-tap:
+    - `(x', y', w') = Hinv * (x + 0.5, y + 0.5, 1)` (pixel center)
+    - `srcX = x'/w', srcY = y'/w'`
+    - 영역 안 → bilinear 샘플링, 영역 밖 → outsideColor 유지
+  - `private fun bilinearSample(pixels: IntArray, w: Int, h: Int, x: Double, y: Double): Int` — 4-tap weighted average for ARGB channels.
+  - `ImmutableImage.wrapAwt(...)` 반환.
+  - 로깅: `private val log = KotlinLogging.logger {}` (top-level extension 파일).
+
+### T9 — `PerspectiveTransformTest.kt`
+
+- **complexity**: medium
+- **dependencies**: T8
+- **files (create)**:
+  - `utils/images/src/test/kotlin/io/bluetape4k/images/transforms/PerspectiveTransformTest.kt`
+- **what to implement**:
+  - `항등 매핑 (source = destination = (0,0)/(w,0)/(w,h)/(0,h)) → 결과가 원본과 동일 (tolerance 1)`
+  - `90도 회전 호모그래피 ≈ rotateRight() (tolerance 3)`
+  - `outsideColor = RED, 결과 코너 픽셀이 RED 인 시나리오 (작은 source 사각형 → 큰 output)`
+  - `sourceCorners.size = 3 → IllegalArgumentException`
+  - `destinationCorners.size = 5 → IllegalArgumentException`
+  - `outputWidth = 0 → IllegalArgumentException`
+  - `outputWidth = 10000, outputHeight = 10000 (1억 pixels > 64M) → IllegalArgumentException`
+  - `4점 거의 일직선 (3개가 같은 좌표) → IllegalArgumentException("nearly collinear")`
+  - `suspendPerspectiveTransform ≈ perspectiveTransform` — `runTest`
+
+### T10 — `HistogramEqualization.kt` 구현 (CLAHE + globalEqualize)
+
+- **complexity**: high
+- **dependencies**: T1
+- **files (create)**:
+  - `utils/images/src/main/kotlin/io/bluetape4k/images/transforms/HistogramEqualization.kt`
+- **what to implement**:
+  - `fun ImmutableImage.clahe(tileSize: Int = 8, clipLimit: Double = 2.0): ImmutableImage`
+  - `fun ImmutableImage.globalEqualize(): ImmutableImage`
+  - `suspend fun ImmutableImage.suspendClahe(...): ImmutableImage`
+  - 입력 검증: `require(tileSize >= 1)`, `require(clipLimit > 0)`
+  - 알고리즘 (spec §6.5):
+    1. `toIntArgb()` → IntArray
+    2. **RGB → YCbCr** (BT.601):
+       - `Y = 0.299R + 0.587G + 0.114B`
+       - `Cb = -0.169R - 0.331G + 0.5B + 128`
+       - `Cr = 0.5R - 0.419G - 0.081B + 128`
+       - 결과 IntArray Y, ByteArray Cb, ByteArray Cr.
+    3. `tileSize > min(w, h)` → 단일 타일 (= globalEqualize), `log.debug { "clahe tile fallback (w=$w, h=$h, tile=$tileSize)" }`
+    4. 그 외: `nTilesX = ceil(w / tileSize)`, `nTilesY = ceil(h / tileSize)`
+       - 타일별 `IntArray(256)` 히스토그램
+       - **클리핑**: `cap = (clipLimit * tilePixelCount / 256).toInt()`. 빈도 > cap 인 빈은 잘라내고, 잘라낸 총량 `excess` 를 모든 빈에 균등 분배 (`excess / 256` per bin, 나머지는 라운드로빈).
+       - CDF 누적합 → `lut[256]` (정규화: `lut[i] = round(cdf[i] / tilePixelCount * 255)`).
+    5. 각 픽셀 `(x, y)` → 인접 4개 타일 LUT 의 bilinear interpolation 으로 `Y'` 매핑.
+    6. **YCbCr → RGB**:
+       - `R = Y + 1.402 * (Cr - 128)`
+       - `G = Y - 0.344 * (Cb - 128) - 0.714 * (Cr - 128)`
+       - `B = Y + 1.772 * (Cb - 128)`
+       - `coerceIn(0, 255)`
+    7. `setArgb` → `wrapAwt`.
+  - `globalEqualize()` 는 `clahe(tileSize = max(width, height), clipLimit = 2.0)` — 기본 `clipLimit` 사용.
+  - 로깅: `private val log = KotlinLogging.logger {}` (top-level extension 파일).
+
+### T11 — `HistogramEqualizationTest.kt`
+
+- **complexity**: medium
+- **dependencies**: T10
+- **files (create)**:
+  - `utils/images/src/test/kotlin/io/bluetape4k/images/transforms/HistogramEqualizationTest.kt`
+- **what to implement**:
+  - `어두운 합성 이미지 (모든 픽셀 RGB 50,50,50) → CLAHE 후 평균 luma 변화 (luma 분산이 0 이므로 결과 동일 검증)`
+  - `회색 그라데이션 → CLAHE 후 luma 표준편차 증가 (대비 향상)`
+  - `tileSize = 1024 (이미지보다 큼) → globalEqualize() 와 결과 동일 (silent fallback)`
+  - `채도 보존: 빨강 단색(255,0,0) 이미지 → CLAHE 후 평균 R 채널이 G/B 채널 대비 압도적으로 큰지 (Cb/Cr 보존 검증)`
+  - `globalEqualize() → 평균 luma 결과는 입력 luma 분포 따라 다름, 결과 width/height 동일`
+  - `tileSize = 0 → IllegalArgumentException`
+  - `clipLimit = 0 → IllegalArgumentException`
+  - `suspendClahe ≈ clahe` — `runTest`
+  - **[주의]** `globalEqualize()` 는 `clahe(tileSize = max(w, h), clipLimit = 2.0)` 이므로, `tileSize = 1024` 테스트는 이미지 크기가 1024 미만임을 전제로 fallback 경로를 검증한다.
+
+### T12 — `dsl/ImageFilterChainTransformOps.kt`
+
+- **complexity**: medium
+- **dependencies**: T2, T4, T6, T8, T10
+- **files (create)**:
+  - `utils/images/src/main/kotlin/io/bluetape4k/images/transforms/dsl/ImageFilterChainTransformOps.kt`
+- **what to implement** (spec §5.6):
+  - `fun ImageFilterChain.autoCrop(tolerance: Int = 10, padding: Int = 0, backgroundColor: Color? = null)`
+  - `fun ImageFilterChain.smartCrop(aspectRatio: AspectRatio, strategy: SaliencyStrategy = SaliencyStrategy.SobelEnergy)`
+  - `fun ImageFilterChain.rotateDegrees(angle: Double, background: Color = Color(0, 0, 0, 0))`
+  - `fun ImageFilterChain.rotateLeft()`
+  - `fun ImageFilterChain.rotateRight()`
+  - `fun ImageFilterChain.flipHorizontal()`
+  - `fun ImageFilterChain.flipVertical()`
+  - `fun ImageFilterChain.perspectiveTransform(sourceCorners: List<ImagePoint>, destinationCorners: List<ImagePoint>, outputWidth: Int, outputHeight: Int, outsideColor: Color = Color(0, 0, 0, 0))`
+  - `fun ImageFilterChain.clahe(tileSize: Int = 8, clipLimit: Double = 2.0)`
+  - 로깅: `private val log = KotlinLogging.logger {}` (top-level 파일).
+  - **공통 헬퍼 (필수)**:
+    ```kotlin
+    private inline fun ImageFilterChain.transformOp(
+        name: String,
+        crossinline block: (ImmutableImage) -> ImmutableImage
+    ) {
+        addPixel { image ->
+            try {
+                block(image)
+            } catch (e: Exception) {
+                log.warn(e) { "[$name] failed: ${image.width}×${image.height}" }
+                throw e
+            }
+        }
+    }
+    ```
+  - 위 9개 DSL op 는 모두 `transformOp` 헬퍼를 통해 위임 — `addPixel { ... }` 직접 호출 금지.
+
+### T13 — `dsl/ImageFilterChainTransformOpsTest.kt`
+
+- **complexity**: medium
+- **dependencies**: T12
+- **files (create)**:
+  - `utils/images/src/test/kotlin/io/bluetape4k/images/transforms/dsl/ImageFilterChainTransformOpsTest.kt`
+- **what to implement** (spec §7.2):
+  - `applyFilters { autoCrop() } ≈ autoCrop()` (tolerance 0)
+  - `applyFilters { rotateDegrees(15.0) } ≈ rotateDegrees(15.0)` (tolerance 0)
+  - `applyFilters { smartCrop(SQUARE) } ≈ smartCrop(SQUARE)` (tolerance 0)
+  - `applyFilters { perspectiveTransform(...) } ≈ perspectiveTransform(...)` (tolerance 0)
+  - `applyFilters { clahe() } ≈ clahe()` (tolerance 0)
+  - `applyFilters { rotateLeft() } ≈ rotateLeft()` (tolerance 0)
+  - `applyFilters { rotateRight() } ≈ rotateRight()` (tolerance 0)
+  - `applyFilters { flipHorizontal() } ≈ flipHorizontal()` (tolerance 0)
+  - `applyFilters { flipVertical() } ≈ flipVertical()` (tolerance 0)
+  - `applyFilters { autoCrop(); vignette() } → 변환 + 네이티브 필터 혼합 정상 동작` (예외 없이 실행, 결과 width <= 원본)
+  - `applyFilters { } → 원본과 동일`
+  - `suspendApplyFilters { clahe(); smartCrop(SQUARE) } ≈ image.clahe().smartCrop(SQUARE)` — `runTest`
+  - **예외 로깅 검증**: `perspectiveTransform` DSL op 에 의도적으로 예외를 발생시키는 잘못된 파라미터를 전달 → `log.warn` 이 호출됨을 logback `ListAppender` 를 사용하여 검증 — WARN 레벨 로그 메시지에 op 이름(`perspectiveTransform`)이 포함되는지 확인.
+
+### T14 — KDoc 검증 및 보강
+
+- **complexity**: low
+- **dependencies**: T3, T5, T7, T9, T11, T13
+- **files (modify)**:
+  - 모든 transform `.kt` 파일 (5 main + 1 DSL)
+- **what to implement**:
+  - 모든 public 함수: `@param`, `@return`, `@throws` 누락 검사.
+  - Risk 섹션 주의사항 반영:
+    - SmartCrop: "휴리스틱 saliency, 얼굴/객체 검출 아님"
+    - rotateDegrees: "scrimage rotate(radians) 와 의미 동등, 차이는 도 단위 + 투명 기본 배경"
+    - DSL ops: "체인 순서가 결과에 영향, 후속 필터는 변환 후 bounds 에서 동작"
+    - perspectiveTransform: "출력 크기 64M pixels 상한"
+    - autoCrop / clahe: "silent fallback debug 로그"
+  - 사용 예제 1건씩 (`@sample` 또는 KDoc 코드블록).
+  - `./gradlew :bluetape4k-images:dokkaHtml` (선택) — KDoc 렌더 확인.
+  - `./gradlew :bluetape4k-images:detekt` 통과.
+
+### T15 — `utils/images/README.md` + `utils/images/README.ko.md`
+
+- **complexity**: low
+- **dependencies**: T14
+- **files (modify)**:
+  - `utils/images/README.md`
+  - `utils/images/README.ko.md`
+- **what to implement** (spec §9.4):
+  - "Transforms" / "변환" 섹션 추가:
+    - 5개 변환 카테고리 (AutoCrop, SmartCrop, Rotation, PerspectiveTransform, CLAHE) 각각 1줄 설명 + 1개 코드 예제.
+    - DSL 통합 예제 (spec §5.7 의 혼합 체인).
+  - Mermaid 다이어그램 갱신: `ImageFilterChain` 안에 변환 ops 가 새 카테고리로 추가됨을 시각화 (기존 다이어그램에 박스 1개 추가).
+  - 한국어/영어 동기 작성 — 예제 코드는 동일, 본문만 언어 차이.
+  - README 상단 언어 전환 링크 유지 (`[한국어](./README.ko.md) | English` / `한국어 | [English](./README.md)`).
+
+### T16 — `CLAUDE.md` + `docs/superpowers/index` 업데이트
+
+- **complexity**: low
+- **dependencies**: T15
+- **files (modify)**:
+  - `CLAUDE.md` (project root) — `transforms` 패키지 1줄 언급 (모듈 그룹 표는 변경 불필요, 새 모듈 아님)
+  - `docs/superpowers/index.md` 또는 해당 인덱스 파일 — spec/plan 등록 (있는 경우)
+- **what to implement**:
+  - `CLAUDE.md` "Key Design Patterns" 섹션 또는 module-specific note 에 `bluetape4k-images transforms`: `autoCrop / smartCrop / rotateDegrees / perspectiveTransform / clahe` 1줄 추가.
+  - `docs/superpowers/index.md` (또는 index 파일이 있다면) 에 spec/plan 링크 등록.
+  - index 파일이 없으면 새로 만들지 않는다 (spec 위치만 알려주면 충분).
+
+### T16-post — Code Review + Wiki Sync (PR 전 필수)
+
+- **complexity**: low
+- **dependencies**: T16
+- **what to implement**:
+  - `/wiki-update` 실행 — spec/plan → Obsidian wiki 동기화.
+  - `oh-my-claudecode:code-reviewer` 에이전트 실행 → CRITICAL/HIGH 이슈 0건 확인.
+  - 이 두 sub-task 는 CLAUDE.md "Before Creating a PR" 항목에 따라 필수이며, T17 testlog 작성 전에 완료해야 한다.
+
+### T17 — Testlog entry + 최종 검증
+
+- **complexity**: low
+- **dependencies**: T16-post
+- **files (create/modify)**:
+  - `docs/superpowers/testlogs/2026-04-27-images-transform.md` (신규) — 또는 기존 testlog 컨벤션을 따른다.
+- **what to implement**:
+  - `./gradlew :bluetape4k-images:test --tests "io.bluetape4k.images.transforms.*"` 실행 결과 (passing count + duration).
+  - `./gradlew :bluetape4k-images:build` 통과 확인.
+  - `./gradlew :bluetape4k-images:detekt` 통과 확인.
+  - 테스트 파일별 통과/skip/fail 표.
+  - 알려진 한계 (성능 테스트 미수행, 예: 1920×1080 측정값 등) 기록.
+  - DoD 체크리스트 (spec §10) 항목별 ✓ 표.
+  - **커버리지 검증**:
+    - `./gradlew :bluetape4k-images:test` 실행 후 테스트 count 확인.
+    - `git diff utils/images/build.gradle.kts` — 변경 없음 확인 (의존성 변경 금지).
+    - line coverage ≥ 80% 확인 (Gradle Jacoco 리포트 또는 테스트 수 기반 수동 추산).
+
+---
+
+## 3. 검증 명령
+
+```bash
+# 컴파일
+./gradlew :bluetape4k-images:compileKotlin
+./gradlew :bluetape4k-images:compileTestKotlin
+
+# 테스트 (전체 transform 패키지)
+./gradlew :bluetape4k-images:test --tests "io.bluetape4k.images.transforms.*"
+
+# 모듈 빌드
+./gradlew :bluetape4k-images:build
+
+# 정적 분석
+./gradlew :bluetape4k-images:detekt
+
+# 의존성 변경 검증 (Hash 비교)
+git diff utils/images/build.gradle.kts  # 변경 없어야 함
+```
+
+---
+
+## 4. 변경 영향 / 호환성
+
+- 신규 API only (5개 main + 9개 DSL op + 2개 data class + 1개 sealed interface).
+- 기존 `ImmutableImageSupport` / 기존 DSL ops / 기존 필터 시그니처 변경 없음.
+- `build.gradle.kts` 의존성 변경 없음 — pure JDK + scrimage-core.
+- 파일 신규 6 main + 6 test + 2 README + index/CLAUDE.md/testlog.
+
+---
+
+## 5. 후속 작업 (out of scope, future PR)
+
+- Lanczos/Mitchell 보간 옵션
+- Saliency 색분산/코너/face-detection 전략 추가
+- 4점 자동 검출
+- LAB CLAHE 정밀 캘리브레이션
+
+---
+
+## 6. 작업 순서 요약
+
+1. **T1** (RasterUtils) → 모든 transform 의 토대.
+2. **T2 / T3** AutoCrop + Test (가장 단순한 변환으로 패턴 확립).
+3. **T4 / T5** Rotation + Test (Java2D 패턴 확립).
+4. **T6 / T7** SmartCrop + Test (Sobel + integral image).
+5. **T8 / T9** PerspectiveTransform + Test (Gauss-Jordan + bilinear).
+6. **T10 / T11** CLAHE + Test (YCbCr + 타일 LUT bilinear).
+7. **T12 / T13** DSL ops + Test.
+8. **T14** KDoc + detekt.
+9. **T15** README.md + README.ko.md.
+10. **T16** CLAUDE.md + index.
+11. **T16-post** `/wiki-update` + `code-reviewer` (CRITICAL/HIGH 0건).
+12. **T17** testlog + 최종 DoD 체크 + 커버리지 검증.

--- a/docs/superpowers/specs/2026-04-27-images-transform-design.md
+++ b/docs/superpowers/specs/2026-04-27-images-transform-design.md
@@ -1,0 +1,936 @@
+# utils/images 변환/조작 API 설계 — Issue #132
+
+- **Issue**: #132
+- **모듈**: `utils/images` (`bluetape4k-images`)
+- **scrimage 버전**: 4.3.10
+- **작성일**: 2026-04-27
+- **브랜치**: `feat/issue-132-images-transform`
+- **상태**: Approved (Step 2-R 통과, Step 3 대기)
+
+---
+
+## 1. 배경 및 목적
+
+### 1.1 현재 상황
+
+`utils/images` 모듈은 Issue #131 까지 다음 기능을 갖춘다.
+
+- 로딩/저장/스케일/스플릿(`ImmutableImageSupport`, `scaler/`, `splitter/`)
+- 70+ 필터 + 색보정 DSL(`filters/`, `filters/dsl/ImageFilterChain`)
+- 이미지 유사도(`similarity/`)
+- 코루틴 비동기 I/O(`coroutines/`)
+
+scrimage 자체에는 `rotate(radians: Double)`, `rotateLeft()`, `rotateRight()`, `flipX()`, `flipY()`, `subimage(x, y, w, h)` 등이 이미 존재한다. 그러나 다음 5종의 **고수준 변환/조작**은 모듈 외부 사용자가 직접 구현해야 했다.
+
+1. **AutoCrop**: 사진 가장자리에 균일한 배경(흰색/투명/단색) 여백을 자동으로 잘라내기
+2. **Smart Crop**: 이미지의 시각적으로 중요한 영역을 보존하면서 지정 종횡비로 크롭
+3. **임의 각도 회전 + 좌우/상하 반전**: 사용자 친화적인 도(degree) 단위 회전 + 경계 자동 확장
+4. **Perspective Transform**: 4점 변환(예: 책 표지를 정면으로 펴기) — 3×3 호모그래피 + 역매핑
+5. **Histogram Equalization (CLAHE)**: 휘도 채널 대비 보정으로 어두운 사진 가시성 향상
+
+### 1.2 도입 효과
+
+1. **선언적 변환 파이프라인**: 필터 DSL과 동일한 컨벤션으로 `applyFilters { autoCrop(); rotate(15.0); clahe() }` 형태 호출
+2. **확장 함수 + DSL 양 계층 노출**: 단발 사용은 `image.autoCrop()`, 체인 사용은 DSL — 기존 `ImmutableImageSupport`/`WatermarkFilterSupport`/`filters/dsl` 와 동일한 이중 표면(dual surface) 패턴 유지
+3. **Pure JVM**: BoofCV / Jama / OpenCV 등 외부 의존성 없이 Java2D `AffineTransform` + `BufferedImage.raster` + `DoubleArray` 기반 구현 → `build.gradle.kts` 의존성 변동 없음
+4. **suspend 친화**: 무거운 픽셀 연산은 `Dispatchers.Default`에서 실행 (`suspend*` 변형 + `suspendApplyFilters` 호환)
+5. **종횡비/색상/품질 보존 권장 기본값**: AutoCrop tolerance, SmartCrop 후보 윈도우, 회전 보간(BICUBIC), CLAHE clipLimit 등 OpenCV/scrimage 관례 기반의 안전한 기본값
+
+### 1.3 비목표(Non-goals)
+
+- ML/딥러닝 기반 saliency / 얼굴 검출 — Smart Crop은 **휴리스틱 saliency**(Sobel 에너지) 사용
+- ImageMagick / OpenCV 수준의 모든 변환 옵션
+- 렌즈 왜곡(distortion) 보정 — 4점 호모그래피만 지원
+- LAB / sRGB linear 변환의 정밀 캘리브레이션 — CLAHE는 ITU-R BT.601 휘도(Y' = 0.299R + 0.587G + 0.114B) 사용
+- GPU 가속
+
+---
+
+## 2. 설계 위험 및 실패 모드
+
+### Risk-1: 필터 체인 안의 dimension 변경
+
+`ImageFilterChain.Op.Pixel` 은 `(ImmutableImage) -> ImmutableImage` 임의 변환을 허용하므로 **도중에 width/height 가 바뀌어도** 체인은 정상 진행된다. 그러나 후속 `Op.Native` 필터가 변경된 bounds 에서 동작한다는 점을 사용자가 인지하지 못할 수 있다.
+
+- **실패 모드**: `applyFilters { rotate(45.0); vignette() }` — 비네트가 회전 후의 확장된 바운딩 박스에 적용되어 의도한 원본 프레임이 아니다.
+- **완화**:
+  - DSL 함수 KDoc에 **"체인 순서가 결과에 영향을 준다"**, **"다음 필터는 변환 후 bounds 에서 동작"** 명시
+  - README 예제에서 변환을 마지막에 두는 권장 패턴 제시
+  - Op 자체는 그대로 유지 (방어 차단은 과도한 abstraction)
+
+### Risk-2: 임의 각도 회전 시 bounds 처리
+
+scrimage 의 `ImmutableImage.rotate(radians)` 는 **이미 bounds 를 자동으로 확장**한다 (scrimage 4.3.10 검증 — `Image.scala`).
+
+새 API `rotateDegrees` 가 추가하는 가치:
+1. **도(degree) 단위 각도** — scrimage `rotate(radians)` 와 달리 사용자 친화적
+2. **투명 기본 배경** — scrimage 는 검정 배경, 새 API 는 `Color(0, 0, 0, 0)` (알파 0) 기본값
+3. **편의 alias** — `flipHorizontal()` / `flipVertical()`
+
+- **완화**:
+  - `rotateLeft()`/`rotateRight()`/`flipHorizontal()`/`flipVertical()` 은 차원 변경이 자명하므로 단순 위임
+
+### Risk-3: AutoCrop 의 "배경 없음" 케이스
+
+이미지 전체가 배경이거나(완전 단색), 가장자리가 균일하지 않은 복잡한 사진(자연 풍경)에서는 잘라낼 영역이 없거나 과도하게 잘릴 수 있다.
+
+- **실패 모드 A (전체 배경)**: 너비 0 또는 높이 0 의 잘못된 이미지 반환
+- **실패 모드 B (배경 없음)**: 기대했던 여백 제거가 일어나지 않거나, 작은 노이즈 픽셀로 인해 거의 자르지 않음
+- **완화**:
+  - 코너 4픽셀의 평균색을 배경 후보로 사용 (KDoc에 명시) — `backgroundColor` 파라미터로 명시적 지정도 허용
+  - `tolerance: Int = 10` (RGB 채널 절대 차이) 파라미터 — OpenCV `cv2.threshold` 관행과 유사
+  - 결과 영역이 너무 작으면(width < 1 || height < 1) 원본을 그대로 반환 — `Result<T>`/예외 대신 silent fallback (기존 모듈 컨벤션 일치)
+  - silent fallback 경로에서는 `logger.debug` 로 fallback 이유 + 이미지 크기를 출력한다
+  - 패딩 보존 옵션: `padding: Int = 0` — 잘라낸 영역의 사방에 픽셀 추가
+
+### Risk-4: Smart Crop 의 "saliency 정확도" 오해
+
+휴리스틱(Sobel 엣지 에너지) 기반 SmartCrop 은 **얼굴/사물 인식이 아닌 고주파 영역 우선**이다. 텍스처가 강한 배경, 균일한 색의 주제(예: 단색 옷의 인물)에서는 의도와 다른 영역이 선택될 수 있다.
+
+- **실패 모드**: 인물 사진에서 얼굴 대신 텍스처가 강한 옷이나 배경이 선택됨
+- **완화**:
+  - KDoc에 **"휴리스틱 saliency"** 임을 명시. "deep learning 기반 객체 감지가 아님" 경고
+  - 함수 이름: `smartCrop` — 단어 자체가 휴리스틱적임을 시사. 추후 다른 알고리즘 추가 여지를 위해 `strategy: SaliencyStrategy = SaliencyStrategy.SobelEnergy` sealed interface 노출
+  - 디폴트 다운샘플(긴 변 256px) 후 saliency 계산 → 원본 좌표로 복원. 큰 이미지에서도 100ms 이내 보장
+
+### Risk-5: Perspective Transform 의 8×8 선형 시스템 풀이 정확도
+
+8×8 시스템(픽셀 좌표 4쌍 → 호모그래피 8개 미지수)은 floats 으로 풀면 누적 오차로 결과 좌표가 ±1픽셀 흔들릴 수 있다. 또한 forward mapping 으로 구현하면 출력에 hole 이 생긴다.
+
+- **실패 모드 A (precision)**: float 으로 풀어 입력 4점이 거의 일직선일 때 (degenerate) 발산
+- **실패 모드 B (forward mapping)**: 출력 픽셀 사이에 빈 공간 발생
+- **완화**:
+  - **`DoubleArray(64)` Gauss-Jordan 부분 피벗팅** 으로 직접 구현 (~30라인) — 정밀도 + 0 의존성
+  - degenerate 시 `IllegalArgumentException("source points are nearly collinear")` 명시적 throw
+  - **inverse mapping + bilinear 샘플링**: 출력 픽셀 → 호모그래피 역행렬 → 입력 좌표 → 4-tap bilinear → 색상
+  - 입력 영역 밖이면 `outsideColor: Color = TRANSPARENT` 채움
+
+### Risk-6: CLAHE 의 색공간 처리
+
+각 RGB 채널을 독립 평활화하면 채도/색상이 뒤틀린다. 휘도(Y) 채널만 평활화 후 RGB 복원이 표준.
+
+- **실패 모드**: RGB 독립 처리 → 보색 변경, 회색 빨갛게 변함
+- **완화**:
+  - **YCbCr 공간 변환** → Y 채널에만 CLAHE → YCbCr→RGB 복원
+  - 타일 크기 8×8, clipLimit 2.0 (OpenCV 기본값) 디폴트
+  - tileSize 가 이미지보다 크면 단일 타일 (= global histogram equalization) 로 폴백
+  - silent fallback 경로에서는 `logger.debug` 로 fallback 이유 + 이미지 크기를 출력한다
+
+### Risk-7: 원본 이미지 mutation
+
+기존 DSL 의 `compactAndApply` 는 진입 시 `source.copy()` 1회 방어 복사한다. 새 변환 ops 는 `Op.Pixel` 람다로 등록되며, 람다 내부에서 새 `BufferedImage` 를 생성해 `ImmutableImage.wrapAwt(...)` 로 감싸 반환하므로 mutation 위험 없음.
+
+- 단, 신규 코드에서도 **항상 새 `BufferedImage` 인스턴스에 그리고 `ImmutableImage.wrapAwt(...)` 로 반환** 하는 컨벤션 KDoc/README 에 명시
+
+### Risk-8: 대용량 출력 메모리 할당
+
+`perspectiveTransform` 에 매우 큰 `outputWidth` × `outputHeight` 를 지정하면 수 GB 의 BufferedImage 가 할당될 수 있다.
+
+- **실패 모드**: `OutOfMemoryError` 또는 GC pause 로 인한 응답 지연
+- **완화**:
+  - `require(outputWidth.toLong() * outputHeight.toLong() <= MAX_OUTPUT_PIXELS)` 사전 검증
+  - `MAX_OUTPUT_PIXELS = 67_108_864L` (64M pixels = ~256MB ARGB)
+  - 초과 시 `IllegalArgumentException` throw — KDoc 에 명시
+
+---
+
+## 3. 접근 방법 비교
+
+세 가지 가능한 통합 방식을 검토한다. **요점은 알고리즘 선택이 아니라 API 표면 구조**다.
+
+### Approach A: 확장 함수만 (Extension-only)
+
+```kotlin
+fun ImmutableImage.autoCrop(...): ImmutableImage
+fun ImmutableImage.smartCrop(...): ImmutableImage
+fun ImmutableImage.rotateDegrees(...): ImmutableImage
+fun ImmutableImage.perspective(...): ImmutableImage
+fun ImmutableImage.clahe(...): ImmutableImage
+```
+
+- **장점**: 단순. DSL 결합도 0.
+- **단점**: 기존 필터 DSL 과 체인 불가. 사용자는 `image.applyFilters { ... }.rotateDegrees(...).applyFilters { ... }` 같은 수동 체인 필요.
+
+### Approach B: DSL 전용 (DSL-only)
+
+```kotlin
+// 오직 ImageFilterChain 안에서만 호출
+image.applyFilters {
+    autoCrop()
+    smartCrop(AspectRatio.WIDESCREEN)
+    rotateDegrees(15.0)
+    clahe()
+}
+```
+
+- **장점**: 구현 1회. 모든 변환이 체인의 일급 시민.
+- **단점**: 단발 사용이 어색 (`image.applyFilters { autoCrop() }` 의 noise). 기존 모듈 컨벤션과 불일치 — `ImmutableImageSupport`/`WatermarkFilterSupport` 는 모두 top-level extension 도 노출.
+
+### Approach C: 양 계층 (Both layers) — **선택**
+
+```kotlin
+// 1) Top-level extension function (단발 사용)
+fun ImmutableImage.autoCrop(...): ImmutableImage = ...
+
+// 2) DSL op (체인 사용) — extension 으로 위임
+fun ImageFilterChain.autoCrop(...) {
+    addPixel { it.autoCrop(...) }
+}
+
+// 3) suspend variant (코루틴)
+suspend fun ImmutableImage.suspendAutoCrop(...): ImmutableImage =
+    withContext(Dispatchers.Default) { autoCrop(...) }
+```
+
+- **장점**:
+  - 기존 모듈 패턴(`oil()`, `pixelate()`, `vignette()` 모두 DSL + 직접 `applyFilters { raw(OilFilter()) }` 양 방향) 일관성
+  - 단발/체인/코루틴 모두 자연스러움
+  - DSL op 가 extension 으로 위임 → 알고리즘 코드 1회만 작성
+- **단점**: 파일 수가 약간 더 많음 (feature 당 1 main + 1 DSL ops 합본). 큰 비용 아님
+
+**선택: Approach C**. 기존 패턴(`ImageFilterChainEffectOps.kt` ↔ `RoundedCornerFilter.kt`/`MedianBlurFilter.kt`) 과 동일.
+
+---
+
+## 4. 패키지 레이아웃
+
+```
+src/main/kotlin/io/bluetape4k/images/transforms/
+├── AutoCrop.kt                  # autoCrop / suspendAutoCrop + 내부 헬퍼
+├── SmartCrop.kt                 # smartCrop / suspendSmartCrop + SaliencyStrategy + AspectRatio
+├── Rotation.kt                  # rotateDegrees / flipHorizontal / flipVertical / rotateLeft / rotateRight 위임
+├── PerspectiveTransform.kt      # perspectiveTransform + 호모그래피 풀이 헬퍼
+├── HistogramEqualization.kt     # clahe / globalEqualize + YCbCr 변환 헬퍼
+└── dsl/
+    └── ImageFilterChainTransformOps.kt  # ImageFilterChain.{autoCrop,smartCrop,rotateDegrees,...}
+```
+
+테스트:
+
+```
+src/test/kotlin/io/bluetape4k/images/transforms/
+├── AutoCropTest.kt
+├── SmartCropTest.kt
+├── RotationTest.kt
+├── PerspectiveTransformTest.kt
+├── HistogramEqualizationTest.kt
+└── dsl/
+    └── ImageFilterChainTransformOpsTest.kt
+```
+
+기존 `AbstractImageTest` / `AbstractFilterTest` 활용.
+
+---
+
+## 5. API 설계
+
+> 모든 public API는 KDoc + `@param` + 예제 포함. 한국어 KDoc.
+
+### 5.1 AutoCrop
+
+```kotlin
+package io.bluetape4k.images.transforms
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.awt.Color
+
+/**
+ * 이미지 가장자리의 단색 배경 여백을 자동으로 잘라냅니다.
+ *
+ * ## 동작/계약
+ * - [backgroundColor] 가 null 이면 좌상/우상/좌하/우하 4픽셀 평균색을 배경으로 사용합니다.
+ * - 배경과 모든 RGB 채널의 절대 차이가 [tolerance] 이하인 픽셀을 배경으로 간주합니다.
+ * - 잘라낸 영역의 4면에 [padding] 픽셀의 여백을 추가합니다.
+ * - 결과 width 또는 height 가 1 미만이면 원본을 반환합니다 (silent fallback).
+ * - silent fallback 시 `logger.debug` 로 fallback 이유와 이미지 크기를 출력합니다.
+ *
+ * ```kotlin
+ * val cropped = image.autoCrop(tolerance = 10, padding = 4)
+ * // cropped.width <= image.width
+ * ```
+ *
+ * @param tolerance 배경으로 간주할 RGB 채널 최대 차이 (0..255, 기본값 10)
+ * @param padding 잘라낸 영역에 추가할 사방 여백 픽셀 (기본값 0)
+ * @param backgroundColor 명시적 배경색. null 이면 코너 평균색 자동 검출
+ * @return 여백이 제거된 새 [ImmutableImage]
+ */
+fun ImmutableImage.autoCrop(
+    tolerance: Int = 10,
+    padding: Int = 0,
+    backgroundColor: Color? = null,
+): ImmutableImage
+
+suspend fun ImmutableImage.suspendAutoCrop(
+    tolerance: Int = 10,
+    padding: Int = 0,
+    backgroundColor: Color? = null,
+): ImmutableImage = withContext(Dispatchers.Default) {
+    autoCrop(tolerance, padding, backgroundColor)
+}
+```
+
+### 5.2 SmartCrop
+
+```kotlin
+/** SmartCrop 의 saliency 계산 전략. 추후 확장을 위해 sealed interface 로 정의합니다. */
+sealed interface SaliencyStrategy {
+    /** Sobel 엣지 magnitude 합. 휴리스틱이며 빠름. */
+    object SobelEnergy : SaliencyStrategy
+}
+
+/**
+ * 종횡비를 나타내는 값 클래스.
+ *
+ * x는 열(column), y는 행(row) 방향입니다.
+ *
+ * ```kotlin
+ * val ratio = AspectRatio(16, 9)
+ * val square = AspectRatio.SQUARE
+ * ```
+ *
+ * @param width 종횡비 너비 (양수)
+ * @param height 종횡비 높이 (양수)
+ */
+data class AspectRatio(val width: Int, val height: Int) {
+    companion object {
+        val SQUARE = AspectRatio(1, 1)
+        val WIDESCREEN = AspectRatio(16, 9)
+        val PORTRAIT = AspectRatio(9, 16)
+        val STANDARD = AspectRatio(4, 3)
+    }
+}
+
+/**
+ * 시각적으로 중요한 영역을 보존하면서 지정 종횡비로 크롭합니다.
+ *
+ * ## 동작/계약
+ * - [strategy] 알고리즘으로 saliency map 을 계산하고, [aspectRatio] 비율의 후보 윈도우 중
+ *   에너지 합이 최대인 영역을 반환합니다.
+ * - 큰 이미지는 긴 변 256px 로 다운샘플링 후 계산하여 100ms 이내를 목표로 합니다.
+ * - 결과 영역의 좌표는 원본 해상도로 복원됩니다.
+ * - **휴리스틱**입니다: 얼굴/객체 검출이 아닌 고주파 영역 기준입니다.
+ *
+ * ```kotlin
+ * // 16:9 종횡비로 크롭
+ * val banner = image.smartCrop(AspectRatio.WIDESCREEN)
+ * // 1:1 정사각형 썸네일
+ * val square = image.smartCrop(AspectRatio.SQUARE)
+ * ```
+ *
+ * @param aspectRatio 결과 종횡비 ([AspectRatio])
+ * @param strategy saliency 계산 전략 (기본값 [SaliencyStrategy.SobelEnergy])
+ * @return 휴리스틱 saliency 기준 최적 영역의 [ImmutableImage]
+ */
+fun ImmutableImage.smartCrop(
+    aspectRatio: AspectRatio,
+    strategy: SaliencyStrategy = SaliencyStrategy.SobelEnergy,
+): ImmutableImage
+
+/**
+ * 시각적으로 중요한 영역을 보존하면서 정확한 픽셀 크기로 크롭합니다.
+ *
+ * ```kotlin
+ * val thumb = image.smartCropTo(320, 240)
+ * ```
+ *
+ * @param width 결과 너비 (양수)
+ * @param height 결과 높이 (양수)
+ * @param strategy saliency 계산 전략 (기본값 [SaliencyStrategy.SobelEnergy])
+ * @return 휴리스틱 saliency 기준 최적 영역의 [ImmutableImage]
+ */
+fun ImmutableImage.smartCropTo(
+    width: Int,
+    height: Int,
+    strategy: SaliencyStrategy = SaliencyStrategy.SobelEnergy,
+): ImmutableImage
+
+suspend fun ImmutableImage.suspendSmartCrop(
+    aspectRatio: AspectRatio,
+    strategy: SaliencyStrategy = SaliencyStrategy.SobelEnergy,
+): ImmutableImage = withContext(Dispatchers.Default) {
+    smartCrop(aspectRatio, strategy)
+}
+```
+
+### 5.3 Rotation / Flip
+
+```kotlin
+/**
+ * 도(degree) 단위로 이미지를 회전합니다.
+ *
+ * ## 동작/계약
+ * - 양의 [angle] 은 시계 방향 회전입니다.
+ * - scrimage 의 `rotate(radians)` 는 이미 bounds 를 자동 확장합니다. 이 함수는 추가로:
+ *   (1) 도(degree) 단위 각도를 지원합니다.
+ *   (2) 투명(`Color(0, 0, 0, 0)`) 배경을 기본값으로 사용합니다.
+ *   (3) `flipHorizontal()`/`flipVertical()` 편의 alias 를 제공합니다.
+ * - 90도 배수는 [ImmutableImage.rotateLeft]/[ImmutableImage.rotateRight] 로 위임하여 무손실 처리합니다.
+ *
+ * ```kotlin
+ * val tilted = image.rotateDegrees(15.0)
+ * val withBg = image.rotateDegrees(45.0, background = Color.WHITE)
+ * ```
+ *
+ * @param angle 회전 각도(도)
+ * @param background 빈 영역 채우기 색 (기본값 알파 0 = 투명)
+ * @return 회전된 새 [ImmutableImage]
+ */
+fun ImmutableImage.rotateDegrees(
+    angle: Double,
+    background: Color = Color(0, 0, 0, 0),
+): ImmutableImage
+
+/** 좌우 반전 (alias for [ImmutableImage.flipX]). */
+fun ImmutableImage.flipHorizontal(): ImmutableImage = flipX()
+
+/** 상하 반전 (alias for [ImmutableImage.flipY]). */
+fun ImmutableImage.flipVertical(): ImmutableImage = flipY()
+
+suspend fun ImmutableImage.suspendRotateDegrees(
+    angle: Double,
+    background: Color = Color(0, 0, 0, 0),
+): ImmutableImage = withContext(Dispatchers.Default) {
+    rotateDegrees(angle, background)
+}
+```
+
+### 5.4 Perspective Transform
+
+```kotlin
+/**
+ * 이미지의 한 점. 좌상이 (0, 0).
+ *
+ * x는 열(column), y는 행(row) 방향입니다.
+ */
+data class ImagePoint(val x: Double, val y: Double)
+
+/**
+ * 4점 원근 변환(homography)을 적용합니다.
+ *
+ * ## 동작/계약
+ * - [sourceCorners] 의 4점이 [destinationCorners] 의 4점으로 매핑되도록 3×3 호모그래피를 계산합니다.
+ * - 점 순서는 시계방향: 좌상 → 우상 → 우하 → 좌하.
+ * - 출력 캔버스 크기는 [outputWidth] × [outputHeight] 입니다.
+ * - 출력 최대 크기: `outputWidth * outputHeight <= 67_108_864` (64M pixels, ~256MB ARGB).
+ * - inverse mapping + bilinear 샘플링으로 hole 없는 결과를 보장합니다.
+ * - 입력 영역 밖은 [outsideColor] 로 채워집니다.
+ * - 4점이 거의 일직선이면 [IllegalArgumentException] 을 던집니다.
+ *
+ * ```kotlin
+ * // 기울어진 책 표지를 정면 사각형으로 변환
+ * val flat = image.perspectiveTransform(
+ *     sourceCorners = listOf(
+ *         ImagePoint(120.0, 80.0),  ImagePoint(540.0, 100.0),
+ *         ImagePoint(560.0, 420.0), ImagePoint(100.0, 400.0),
+ *     ),
+ *     destinationCorners = listOf(
+ *         ImagePoint(0.0,   0.0),   ImagePoint(400.0, 0.0),
+ *         ImagePoint(400.0, 600.0), ImagePoint(0.0,   600.0),
+ *     ),
+ *     outputWidth = 400,
+ *     outputHeight = 600,
+ * )
+ * ```
+ *
+ * @param sourceCorners 원본 이미지의 4점 (시계방향)
+ * @param destinationCorners 출력 이미지의 4점 (시계방향)
+ * @param outputWidth 출력 너비
+ * @param outputHeight 출력 높이
+ * @param outsideColor 입력 밖 영역 채우기 색 (기본값 알파 0)
+ * @return 변환된 새 [ImmutableImage]
+ * @throws IllegalArgumentException 점 개수가 4 가 아니거나, 출력 크기가 0 이하이거나,
+ *   출력 크기가 64M pixels 초과이거나, sourceCorners 또는 destinationCorners 중 하나가 거의 일직선인 경우
+ */
+fun ImmutableImage.perspectiveTransform(
+    sourceCorners: List<ImagePoint>,
+    destinationCorners: List<ImagePoint>,
+    outputWidth: Int,
+    outputHeight: Int,
+    outsideColor: Color = Color(0, 0, 0, 0),
+): ImmutableImage
+
+suspend fun ImmutableImage.suspendPerspectiveTransform(
+    sourceCorners: List<ImagePoint>,
+    destinationCorners: List<ImagePoint>,
+    outputWidth: Int,
+    outputHeight: Int,
+    outsideColor: Color = Color(0, 0, 0, 0),
+): ImmutableImage = withContext(Dispatchers.Default) {
+    perspectiveTransform(sourceCorners, destinationCorners, outputWidth, outputHeight, outsideColor)
+}
+```
+
+### 5.5 Histogram Equalization (CLAHE)
+
+```kotlin
+/**
+ * CLAHE (Contrast Limited Adaptive Histogram Equalization) 로 휘도 채널을 평활화합니다.
+ *
+ * ## 동작/계약
+ * - RGB → YCbCr 변환 후 Y(휘도) 채널에만 CLAHE 를 적용하고 RGB 로 복원합니다 (채도 보존).
+ * - 이미지를 [tileSize] × [tileSize] 타일로 나누어 각 타일의 히스토그램을 [clipLimit] 로 제한 후 평활화합니다.
+ * - 타일 경계는 bilinear interpolation 으로 부드럽게 처리합니다.
+ * - 이미지가 [tileSize] 보다 작으면 단일 타일(전역 평활화)로 폴백합니다.
+ *
+ * ```kotlin
+ * // 어두운 사진의 가시성 향상
+ * val clearer = image.clahe()
+ * // 강한 대비 (clipLimit 가 높을수록 강한 평활화)
+ * val strong = image.clahe(tileSize = 4, clipLimit = 4.0)
+ * ```
+ *
+ * @param tileSize 타일 한 변의 픽셀 수 (1 이상, 기본값 8)
+ * @param clipLimit 히스토그램 클리핑 한계 (양수, 기본값 2.0)
+ * @return 평활화된 새 [ImmutableImage]
+ */
+fun ImmutableImage.clahe(
+    tileSize: Int = 8,
+    clipLimit: Double = 2.0,
+): ImmutableImage
+
+/**
+ * 전역 히스토그램 평활화. CLAHE 의 단순 변형으로 [clahe] 를 [tileSize] = max(width,height) 로 호출한 것과 동일.
+ */
+fun ImmutableImage.globalEqualize(): ImmutableImage
+
+suspend fun ImmutableImage.suspendClahe(
+    tileSize: Int = 8,
+    clipLimit: Double = 2.0,
+): ImmutableImage = withContext(Dispatchers.Default) { clahe(tileSize, clipLimit) }
+```
+
+### 5.6 DSL 통합
+
+```kotlin
+package io.bluetape4k.images.transforms.dsl
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.images.filters.dsl.ImageFilterChain
+import io.bluetape4k.images.transforms.*
+import java.awt.Color
+
+/** 가장자리 단색 여백 자동 제거. 자세한 동작은 [ImmutableImage.autoCrop] 참조. */
+fun ImageFilterChain.autoCrop(
+    tolerance: Int = 10,
+    padding: Int = 0,
+    backgroundColor: Color? = null,
+) {
+    addPixel { it.autoCrop(tolerance, padding, backgroundColor) }
+}
+
+/**
+ * 휴리스틱 saliency 기반 종횡비 크롭. 자세한 동작은 [ImmutableImage.smartCrop] 참조.
+ *
+ * 변환 ops 는 예외 발생 시 op 이름과 입력 요약을 warn 로그로 출력합니다.
+ */
+fun ImageFilterChain.smartCrop(
+    aspectRatio: AspectRatio,
+    strategy: SaliencyStrategy = SaliencyStrategy.SobelEnergy,
+) {
+    addPixel { it.smartCrop(aspectRatio, strategy) }
+}
+
+/**
+ * 도 단위 회전. 자세한 동작은 [ImmutableImage.rotateDegrees] 참조.
+ *
+ * 변환 ops 는 예외 발생 시 op 이름과 입력 요약을 warn 로그로 출력합니다.
+ */
+fun ImageFilterChain.rotateDegrees(
+    angle: Double,
+    background: Color = Color(0, 0, 0, 0),
+) {
+    addPixel { it.rotateDegrees(angle, background) }
+}
+
+/** 좌로 90도 회전. */
+fun ImageFilterChain.rotateLeft() {
+    addPixel { it.rotateLeft() }
+}
+
+/** 우로 90도 회전. */
+fun ImageFilterChain.rotateRight() {
+    addPixel { it.rotateRight() }
+}
+
+/** 좌우 반전. */
+fun ImageFilterChain.flipHorizontal() {
+    addPixel { it.flipHorizontal() }
+}
+
+/** 상하 반전. */
+fun ImageFilterChain.flipVertical() {
+    addPixel { it.flipVertical() }
+}
+
+/** 4점 원근 변환. 자세한 동작은 [ImmutableImage.perspectiveTransform] 참조. */
+fun ImageFilterChain.perspectiveTransform(
+    sourceCorners: List<ImagePoint>,
+    destinationCorners: List<ImagePoint>,
+    outputWidth: Int,
+    outputHeight: Int,
+    outsideColor: Color = Color(0, 0, 0, 0),
+) {
+    addPixel {
+        it.perspectiveTransform(sourceCorners, destinationCorners, outputWidth, outputHeight, outsideColor)
+    }
+}
+
+/** CLAHE. 자세한 동작은 [ImmutableImage.clahe] 참조. */
+fun ImageFilterChain.clahe(tileSize: Int = 8, clipLimit: Double = 2.0) {
+    addPixel { it.clahe(tileSize, clipLimit) }
+}
+```
+
+> **주의**: 변환 ops 는 모두 `Op.Pixel` 로 등록된다. 인접한 scrimage Native 필터와 자연스럽게 섞이며,
+> 변환 op 는 `PipelineFilter` 그룹화의 경계가 된다 (`compactAndApply` 의 기존 동작과 일치).
+>
+> **예외 로깅**: 각 변환 op 는 예외 발생 시 op 이름과 입력 이미지 크기(width×height)를 warn 로그로 출력한다.
+
+### 5.7 사용 예시
+
+```kotlin
+// 단발 사용
+val cropped = image.autoCrop(tolerance = 8)
+val rotated = image.rotateDegrees(15.0, background = Color.WHITE)
+
+// 체인 사용 — 필터 + 변환 혼합
+val processed = image.applyFilters {
+    clahe()                             // 어두움 보정
+    autoCrop()                          // 여백 제거
+    smartCrop(AspectRatio.WIDESCREEN)   // 16:9 크롭
+    rotateDegrees(2.0)                  // 살짝 기울이기
+    vignette()                          // 비네트 (변환 후 bounds 기준)
+    border(thickness = 4, color = Color.BLACK)
+}
+
+// 1:1 정사각형 썸네일
+val thumb = image.applyFilters {
+    smartCrop(AspectRatio.SQUARE)
+}
+
+// 코루틴
+val async = image.suspendApplyFilters {
+    clahe()
+    smartCrop(AspectRatio.SQUARE)
+}
+```
+
+---
+
+## 6. 구현 접근
+
+### 6.1 AutoCrop
+
+1. `image.awt()` → `BufferedImage` 직접 raster 접근 (`getRGB(int[], ...)`)
+2. 코너 4픽셀 평균색을 RGB 정수로 계산 (또는 `backgroundColor` 사용)
+3. 위쪽 행부터 스캔 — 모든 픽셀이 배경 ± tolerance 인 행은 잘라낼 후보
+4. 같은 방식으로 아래/왼쪽/오른쪽 경계 결정 → `(top, bottom, left, right)`
+5. `padding` 만큼 양보 (단, 원본 경계 안으로 클램프)
+6. `image.subimage(left, top, w, h)` 반환. silent fallback: `w < 1 || h < 1` 시 `logger.debug("autoCrop silent fallback: ...")` 후 원본 반환
+7. 채널 비교는 절대값 차이로 단순 비교 (lightweight)
+
+성능 목표: 1920×1080 RGB 이미지 < 50ms (단일 스레드, 4행 동시 비교 가능 시 < 30ms)
+
+### 6.2 SmartCrop
+
+1. 다운샘플: 긴 변 256px 로 `image.scaleTo(...)` (scrimage 내장)
+2. Sobel 3×3 (Gx, Gy) → 그레이스케일에 적용 → magnitude = |Gx| + |Gy| (L1, fast)
+3. **integral image** (적분 이미지) 계산 — `IntArray((w+1) * (h+1))`
+4. 후보 윈도우 크기: aspect 비율 유지하며 다운샘플 영역에 들어가는 최대 크기
+5. 적분 이미지로 모든 윈도우 위치(슬라이드 stride 1)의 에너지 합을 O(1) 계산 → 최댓값 위치
+6. 다운샘플 좌표 → 원본 좌표 스케일 복원
+7. `image.subimage(...)` 반환
+
+성능 목표: 4000×3000 사진 < 100ms (다운샘플 + Sobel + 슬라이드)
+
+### 6.3 Rotation / Flip
+
+`rotateDegrees`:
+
+1. 90도 배수면 `rotateLeft()` / `rotateRight()` / `rotate(PI)` 위임 (무손실)
+2. 임의 각도 (scrimage 가 bounds 자동 확장하므로 `radians` 변환 후 위임하되, 배경색을 지원하기 위해 직접 구현):
+   - `radians = Math.toRadians(angle)`
+   - 새 bounds 계산:
+     - `newW = |w*cos(θ)| + |h*sin(θ)|`
+     - `newH = |w*sin(θ)| + |h*cos(θ)|`
+   - `BufferedImage(newW, newH, TYPE_INT_ARGB)` 생성
+   - `Graphics2D.setBackground(background)` + `clearRect(0, 0, newW, newH)` 로 배경 채우기
+   - `AffineTransform`: `translate(newW/2, newH/2) → rotate(radians) → translate(-w/2, -h/2)`
+   - `setRenderingHint(KEY_INTERPOLATION, VALUE_INTERPOLATION_BICUBIC)`
+   - `g.drawImage(src, transform, null)`
+   - `g.dispose()` (try/finally)
+
+`flipHorizontal` / `flipVertical`: scrimage `flipX` / `flipY` 직접 위임.
+
+### 6.4 Perspective Transform
+
+1. 입력 검증:
+   - `require(sourceCorners.size == 4)`, destinationCorners size 4, output > 0
+   - `require(outputWidth.toLong() * outputHeight.toLong() <= MAX_OUTPUT_PIXELS)` — `MAX_OUTPUT_PIXELS = 67_108_864L`
+2. **호모그래피 행렬 H (3×3) 풀이**:
+   - 8개 미지수: `h11, h12, h13, h21, h22, h23, h31, h32` (h33 = 1 정규화)
+   - 각 점 쌍 (sx, sy) → (dx, dy) 마다 2개 식:
+     - `h11*sx + h12*sy + h13 - h31*sx*dx - h32*sy*dx = dx`
+     - `h21*sx + h22*sy + h23 - h31*sx*dy - h32*sy*dy = dy`
+   - 4점 → 8×8 시스템. `DoubleArray(64)` + `DoubleArray(8)` 우변
+   - **Gauss-Jordan with partial pivoting**: 각 열에서 최대 절대값 행을 피벗 → row swap → 정규화 → 다른 행 제거. 작은 피벗(< 1e-12) 만나면 `IllegalArgumentException("nearly collinear source points")` 던짐
+   - 결과 8개 → 3×3 H 구성
+3. **역행렬 Hinv** 계산 (다시 동일 Gauss-Jordan, augmented [H | I]) — inverse mapping 용
+4. 출력 `BufferedImage(outputWidth, outputHeight, TYPE_INT_ARGB)` 생성, `outsideColor` 채움
+5. 출력 픽셀 (x, y) 마다:
+   - `[x', y', w'] = Hinv * [x, y, 1]`
+   - `srcX = x'/w', srcY = y'/w'`
+   - `(srcX, srcY)` 가 [0, w-1] × [0, h-1] 안이면 **bilinear 4-tap 샘플링** (네 코너 가중평균)
+   - 밖이면 `outsideColor` 유지
+6. `ImmutableImage.wrapAwt(...)` 반환
+
+> **이유**: pure JVM, double 정밀도, ~30~50라인의 헬퍼 함수. 외부 의존성 0.
+
+### 6.5 CLAHE
+
+1. RGB → YCbCr 변환 (각 픽셀 — `Y = 0.299R + 0.587G + 0.114B`, `Cb = -0.169R - 0.331G + 0.5B + 128`, `Cr = 0.5R - 0.419G - 0.081B + 128`)
+2. Y 평면을 `IntArray(w*h)` 로 추출
+3. 타일별 히스토그램 (각 256 bin) 계산
+4. **클리핑**: 빈도가 `clipLimit * (tilePixelCount / 256)` 초과인 빈은 잘라내고, 잘린 양을 모든 빈에 균등 재분배
+5. 누적분포(CDF) → 매핑 함수 `lut[256]` 생성
+6. 각 픽셀에 대해 4개 인접 타일의 LUT 를 **bilinear interpolation** 으로 매핑 (타일 경계 부드럽게)
+7. Y' → YCbCr → RGB 복원
+8. `ImmutableImage.wrapAwt(...)` 반환
+9. 타일 크기 > 이미지 시 단일 타일로 폴백 (`globalEqualize()` 와 동일 경로) — `logger.debug` 로 fallback 이유 + 이미지 크기 출력
+
+타일 크기 > 이미지 → 단일 타일 (`globalEqualize()` 와 동일 경로).
+
+성능 목표: 1920×1080 RGB < 200ms (타일 8×8, JIT 후).
+
+### 6.6 공통 헬퍼
+
+`transforms/internal/RasterUtils.kt` (internal):
+
+```kotlin
+internal fun ImmutableImage.toIntArgb(): BufferedImage     // BufferedImage.TYPE_INT_ARGB 보장
+internal fun BufferedImage.copyArgb(): BufferedImage       // 새 ARGB 복사본
+internal fun BufferedImage.fill(color: Color): BufferedImage
+```
+
+각 transform 파일 내부에서만 사용. `companion object : KLoggingChannel()` 로깅.
+
+---
+
+## 7. 테스트 전략
+
+### 7.1 테스트 케이스 (각 feature)
+
+#### AutoCrop
+- 흰색 여백 + 단색 사각형 합성 이미지 → 크롭 결과 정확히 사각형 영역
+- 코너 자동 검출 vs 명시적 `backgroundColor = Color.WHITE` 결과 동일
+- `padding = 5` 시 결과가 정확히 사방 +5 픽셀 큰지
+- 완전 단색 이미지 → 원본 반환 (silent fallback)
+- 자연 사진(`landscape.jpg`) → tolerance 가 충분히 작으면 변경 없음, 충분히 크면 일부 잘림
+
+#### SmartCrop
+- 좌측 절반에 큰 텍스처(체커보드), 우측 단색인 합성 이미지 → 좌측 영역 선택
+- `AspectRatio.SQUARE` / `AspectRatio.WIDESCREEN` / `AspectRatio.PORTRAIT` 종횡비 모두 정상 동작
+- 가로 긴 사진 → 결과 width/height 비율이 요청과 정확히 일치 (±1 픽셀)
+- 빈 이미지(흰색만) → 임의 위치 (정확성 검증 X, 크기만 검증)
+
+#### Rotation
+- 0도 회전 → 원본과 동일 (assertSimilarToImage)
+- 90도 회전 = `rotateLeft()` 결과와 동일 (assertSimilarToImage)
+- 180도 회전 두 번 → 원본과 동일 (tolerance ≤ 3, 보간 영향)
+- 임의 각도 15도 → bounds 계산 결과가 수학식과 일치
+- `flipX().flipX()` → 원본 동일
+
+#### Perspective Transform
+- 항등 매핑(source = destination 사각형) → 원본 픽셀 동일
+- 단순 회전 90도 효과를 호모그래피로 → `rotateRight()` 결과와 유사
+- 잘못된 입력 (3점, 거의 일직선) → `IllegalArgumentException`
+- 출력 크기 초과 (> 64M pixels) → `IllegalArgumentException`
+- 출력 영역 밖 영역 → `outsideColor` 정확히 채워짐 (corner 픽셀 검증)
+
+#### CLAHE
+- 어두운 합성 이미지 (균일하게 RGB 50) → CLAHE 후 평균 휘도 증가
+- 회색 그라데이션 이미지 → CLAHE 후 그라데이션이 더 가팔라짐 (히스토그램이 더 평탄)
+- `tileSize` > 이미지 → `globalEqualize()` 와 결과 동일
+- 채도 보존: 강한 색조의 이미지(빨강 단색)에서 CLAHE 전후 평균 채도 변화 < 5% (Cb/Cr 채널 보존 검증)
+
+### 7.2 DSL 테스트
+
+`ImageFilterChainTransformOpsTest.kt`:
+
+- 각 DSL op 가 단발 extension 호출과 동일 결과 (`assertSimilarToImage`)
+- 변환 op + 네이티브 필터 혼합 체인 동작 (예: `applyFilters { autoCrop(); vignette() }`)
+- 빈 체인 (`applyFilters { }`) — 원본 그대로 반환
+- `rotateLeft()` / `rotateRight()` DSL op 정상 동작
+
+### 7.3 코루틴 테스트
+
+각 `suspend*` 변형:
+- `runTest { ... }` 사용
+- 동기 버전 결과와 동일한지 (`assertSimilarToImage`)
+- `suspendApplyFilters { autoCrop(); rotateDegrees(...) }` 통합 시나리오 1건
+
+### 7.4 성능 테스트 (선택)
+
+JMH 없이 간이 측정 — 1920×1080 이미지 100회 반복 → 평균 < 목표 ms. 디버그 로그로 측정값 출력만 하고 `assertTrue(time < threshold)` 강제 검증은 하지 않음(CI 환경 변동성).
+
+### 7.5 픽셀 비교 컨벤션
+
+기존 `AbstractFilterTest.assertSimilarToImage(actual, expected, tolerance)` 사용.
+- 보간 결과 비교 시 `tolerance = 3`
+- 무손실 변환(flip, 90도 rotate) 비교 시 `tolerance = 0`
+
+### 7.6 Kluent matcher 사용 (사용자 메모리 규칙)
+
+```kotlin
+result.width shouldBeGreaterThan 0
+result.height shouldBeInRange (0..image.height)
+// (x >= y).shouldBeTrue() 금지
+```
+
+### 7.7 테스트 리소스
+
+기존 `src/test/resources/images/` 활용 (`homer.jpg`, `cafe.jpg`, `landscape.jpg`, `aqua.jpg`).
+새 합성 이미지가 필요한 케이스는 테스트 안에서 `BufferedImage` 직접 생성 (외부 리소스 추가 없음).
+
+---
+
+## 8. 성능 / 스레드 안전성
+
+### 8.1 성능 가이드
+
+| Feature | 입력 | 목표 |
+|---------|------|------|
+| AutoCrop | 1920×1080 | < 50ms |
+| SmartCrop | 4000×3000 | < 100ms (256px 다운샘플 후 계산) |
+| rotateDegrees | 1920×1080 | < 80ms (Java2D BICUBIC) |
+| perspectiveTransform | 1920×1080 → 800×600 | < 200ms (역매핑 + bilinear) |
+| CLAHE | 1920×1080, 8×8 타일 | < 200ms |
+
+핫패스 가이드라인:
+- `getRGB(int[])` / `setRGB(int[])` 로 raster 직접 접근 (픽셀 단위 `getPixel` 호출 회피)
+- 내부 루프에서 `Color` 객체 생성 금지 — int 비트 연산
+- integral image / LUT 등 사전 계산 활용
+
+### 8.2 스레드 안전성
+
+- 모든 변환은 새 `BufferedImage`/`ImmutableImage` 를 반환 — **immutable, 동시 호출 안전**
+- `Graphics2D` 는 `try { ... } finally { g.dispose() }` 패턴 적용
+- 정적 상태 없음 (모든 함수가 pure)
+
+### 8.3 메모리
+
+- 일시적으로 입력 + 출력 + (CLAHE 의 경우) Y 평면 + 타일 히스토그램 = 약 입력 크기 × 3
+- 4000×3000 ARGB 입력 → 약 144MB 추가. CLAHE 는 약 +60MB
+- 메모리 예산 초과 가능성 있는 호출자는 입력 다운스케일 후 변환 권장 — KDoc 에 명시
+
+### 8.4 코루틴 컨벤션
+
+- 모든 `suspend*` 는 `withContext(Dispatchers.Default)` 래핑 (CPU bound)
+- I/O 는 호출자가 관리 (`suspendImmutableImageOf` 와 결합)
+- `CancellationException` 은 자동 전파 — 직접 catch 하지 않음
+
+---
+
+## 9. 영향 분석
+
+### 9.1 기존 코드 변경
+- `ImageFilterChain` 코드 수정 없음 — 기존 `addPixel` 진입점만 사용
+- 기존 DSL ops 파일 수정 없음
+- `build.gradle.kts` 변경 없음
+
+**결정 사항 (Step 2-R 통과)**:
+- `rotateDegrees` 에서 `expand` 파라미터 제거 — scrimage 가 이미 bounds 를 자동 확장함
+- `AspectRatio` data class 도입 — `smartCrop(aspectWidth, aspectHeight)` 대신 타입 안전 API
+- `Point2D` → `ImagePoint` 리네이밍 — 이미지 도메인 명확화
+- `SaliencyStrategy` sealed interface 전환 — 미래 확장성
+
+### 9.2 새 의존성
+**없음**. 모든 알고리즘은 JDK + scrimage-core 만 사용.
+
+### 9.3 호환성
+- 신규 API 만 추가. 기존 `ImmutableImage.rotate` / `flipX` / `flipY` / `subimage` 동작은 그대로
+- `rotateDegrees(angle)` 는 scrimage `rotate(radians)` 와 의미 동등 (도 단위 + 투명 배경 기본값 추가)
+
+### 9.4 README 갱신 (`utils/images/README.md` + `README.ko.md`)
+- "Transforms / 변환 / 조작" 섹션 추가
+- Mermaid 다이어그램: ImageFilterChain 안에 변환 ops 가 새 카테고리로 추가됨을 시각화
+- 주요 함수별 예제 1건씩
+
+---
+
+## 10. Definition of Done
+
+### 10.1 구현
+- [ ] `io.bluetape4k.images.transforms` 패키지 신규 생성
+- [ ] `AutoCrop.kt` 구현 + KDoc + 한국어 주석
+- [ ] `SmartCrop.kt` 구현 (Sobel + integral image) — `AspectRatio` data class 포함
+- [ ] `Rotation.kt` 구현 (`rotateDegrees`, `flipHorizontal`, `flipVertical`)
+- [ ] `PerspectiveTransform.kt` 구현 (Gauss-Jordan + inverse mapping + bilinear)
+- [ ] `HistogramEqualization.kt` 구현 (CLAHE + globalEqualize)
+- [ ] 모든 함수의 `suspend*` 변형
+- [ ] `transforms/dsl/ImageFilterChainTransformOps.kt` — 9개 DSL op (autoCrop, smartCrop, rotateDegrees, rotateLeft, rotateRight, flipHorizontal, flipVertical, perspectiveTransform, clahe)
+- [ ] `transforms/internal/RasterUtils.kt` (internal 헬퍼)
+- [ ] perspectiveTransform 출력 크기 상한 검증 (64M pixels)
+- [ ] 변환 ops 예외 시 op 이름 + 입력 요약 warn 로그
+- [ ] silent fallback 경로 debug 로그 emission
+- [ ] 모든 `Graphics2D` 사용은 `try { ... } finally { g.dispose() }` 패턴 적용
+
+### 10.2 KDoc
+- [ ] 모든 public 함수: KDoc + `@param` + `@return` + 사용 예제
+- [ ] Risk 섹션의 주의사항(휴리스틱, 차원 변경, expand 동작 등) KDoc 에 명시
+
+### 10.3 테스트
+- [ ] `AutoCropTest`, `SmartCropTest`, `RotationTest`, `PerspectiveTransformTest`, `HistogramEqualizationTest`
+- [ ] `dsl/ImageFilterChainTransformOpsTest`
+- [ ] 각 feature 동기 + suspend 양쪽 검증
+- [ ] 80% 라인 커버리지
+- [ ] `./gradlew :bluetape4k-images:test --tests "io.bluetape4k.images.transforms.*"` 전수 통과
+
+### 10.4 빌드/검증
+- [ ] `./gradlew :bluetape4k-images:build` 통과
+- [ ] `./gradlew :bluetape4k-images:detekt` 통과
+- [ ] `build.gradle.kts` 의존성 변경 없음 (검증)
+
+### 10.5 문서
+- [ ] `utils/images/README.md` "Transforms" 섹션 추가
+- [ ] `utils/images/README.ko.md` 동기 갱신
+- [ ] Mermaid 다이어그램 (변환 카테고리 포함) 1건 갱신/추가
+
+### 10.6 워크플로우
+- [ ] worktree `.worktrees/feat/issue-132-images-transform/` 안에서 작업
+- [ ] Korean + prefix commit (`feat: utils/images 변환 API 추가 (#132)` 등)
+- [ ] PR 본문에 테스트 결과(passed count + 시간), 검증 명령, 변경 영향 명시
+- [ ] OMC code-reviewer 통과 (CRITICAL/HIGH 0건)
+- [ ] `/wiki-update` 실행
+
+---
+
+## 11. 향후 확장 (out of scope)
+
+- Lanczos / Mitchell 보간 옵션 (현재 Java2D BICUBIC 고정)
+- Saliency 전략 추가: 색상 분산, 코너 검출(Harris), face-detection (외부 의존성 추가 시)
+- `transforms` op 와 `Op.Native` 사이 자동 캐싱 (현재 `Op.Pixel` 사이마다 새 ImmutableImage)
+- 4점 자동 검출 (책 표지 자동 변환의 사전 단계)
+- LAB 색공간 기반 CLAHE (sRGB linear 캘리브레이션 포함)
+
+---
+
+## 12. 가정 (Assumptions)
+
+본 spec 작성 시 결정된 사항 (Step 2-R 에서 사용자 승인 완료).
+
+1. **AutoCrop 배경 검출**: 코너 4픽셀 평균 사용 (4-corner sampling). 가장자리 1행/열 평균(edge sampling) 대안은 채택하지 않음 — 단순성 우선.
+2. **SmartCrop saliency**: Sobel 엣지 magnitude 만 1차 구현. 색 분산/코너/얼굴 검출은 추후 sealed interface 확장.
+3. **rotateDegrees**: `expand` 파라미터 없음 — scrimage 가 이미 bounds 를 자동 확장함. 도(degree) 단위 + 투명 기본 배경 추가가 핵심 가치.
+4. **회전 보간**: `BICUBIC` 고정. 미래에 enum 으로 노출 가능.
+5. **CLAHE 색공간**: YCbCr (BT.601). HSL/LAB 대안은 1차 비대상.
+6. **CLAHE 기본값**: tileSize 8, clipLimit 2.0 (OpenCV `cv2.createCLAHE` 기본값).
+7. **Perspective 점 개수**: 정확히 4. N-point homography (least squares) 는 제외.
+8. **Smart Crop 다운샘플 임계값**: 긴 변 256px. 80~512px 범위에서 결과 차이는 미미 (실험 검증으로 조정 가능).
+9. **Op.Native vs Op.Pixel 선택**: 5개 변환 모두 `Op.Pixel` (scrimage Filter 인터페이스로 표현하기 어려움 — bounds 변경, 4점 입력 등). PipelineFilter 그룹화의 자연 경계가 됨.
+10. **에러 정책**: silent fallback (AutoCrop) vs IllegalArgumentException (Perspective degenerate). 기존 모듈 컨벤션과 일치.
+11. **AspectRatio**: `data class AspectRatio(val width: Int, val height: Int)` — `smartCrop(aspectWidth, aspectHeight)` 대신 사용. 공통 프리셋 `SQUARE`, `WIDESCREEN`, `PORTRAIT`, `STANDARD` 제공.
+12. **ImagePoint**: `Point2D` 대신 `ImagePoint` 사용 — 이미지 도메인 명확화. x는 열(column), y는 행(row) 방향.

--- a/utils/images/README.ko.md
+++ b/utils/images/README.ko.md
@@ -28,6 +28,7 @@ flowchart LR
         WM["워터마크<br/>(WatermarkFilter)"]
         CP["캡션<br/>(CaptionFilter)"]
         PD["패딩<br/>(PaddingSupport)"]
+        TR["변환<br/>(AutoCrop/SmartCrop/회전/원근/CLAHE)"]
     end
 
     subgraph 출력["비동기 저장 (Coroutines)"]
@@ -687,6 +688,142 @@ val (r, g, b) = ColorSpaceConverter.kelvinToRgb(6500)
 // 픽셀 배열 일괄 변환
 val hsvArray = image.toHsvArray()     // FloatArray [h0,s0,v0, h1,s1,v1, ...]
 val ycbcrArray = image.toYCbCrArray() // FloatArray [y0,cb0,cr0, ...]
+```
+
+## 이미지 변환 (Issue #132)
+
+순수 JVM(Java2D) 기반 고급 이미지 변환 연산. 모든 연산은 suspend 변형을 제공합니다.
+
+### 변환 아키텍처
+
+```mermaid
+flowchart TD
+    subgraph Transforms["transforms 패키지"]
+        AC["AutoCrop\nautoCrop()"]
+        SC["SmartCrop\nsmartCrop(AspectRatio)"]
+        RT["Rotation\nrotateDegrees / flipH / flipV"]
+        PT["PerspectiveTransform\nperspectiveTransform(4pts)"]
+        HE["HistogramEqualization\nclahe / globalEqualize"]
+    end
+
+    subgraph DSL["applyFilters { } DSL"]
+        DO["ImageFilterChainTransformOps\nautoCrop / smartCrop / rotateDegrees\nrotateLeft / rotateRight\nflipH / flipV / perspective / clahe"]
+    end
+
+    ImmutableImage --> Transforms
+    Transforms --> ImmutableImage
+    DSL --> Transforms
+
+    classDef opStyle fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
+    classDef dslStyle fill:#F3E5F5,stroke:#CE93D8,color:#6A1B9A
+    class AC,SC,RT,PT,HE opStyle
+    class DO dslStyle
+```
+
+### AutoCrop — 자동 여백 제거
+
+배경색을 자동으로 감지하여 불필요한 여백을 제거합니다.
+
+```kotlin
+// 4개 모서리 평균으로 배경색 자동 감지
+val cropped = image.autoCrop(tolerance = 10, padding = 2)
+
+// 배경색 명시
+val cropped2 = image.autoCrop(tolerance = 5, backgroundColor = Color.WHITE)
+
+// Suspend 변형
+val cropped3 = image.suspendAutoCrop()
+```
+
+### SmartCrop — 중요 영역 자동 크롭
+
+Sobel 엣지 에너지 기반 휴리스틱 saliency (ML 없음).
+
+```kotlin
+// 16:9 와이드스크린 비율로 가장 흥미로운 영역 크롭
+val wide = image.smartCrop(AspectRatio.WIDESCREEN)
+
+// 크롭 후 정확한 출력 크기로 리사이즈
+val thumb = image.smartCropTo(400, 300)
+
+// Suspend 변형
+val wide2 = image.suspendSmartCrop(AspectRatio.SQUARE)
+```
+
+`AspectRatio` 프리셋: `SQUARE (1:1)`, `WIDESCREEN (16:9)`, `PORTRAIT (9:16)`, `STANDARD (4:3)`.
+
+### Rotation & Flip — 회전 및 반전
+
+```kotlin
+// 임의 각도 회전 (투명 배경, 캔버스 자동 확장)
+val rotated = image.rotateDegrees(45.0)
+val rotatedRed = image.rotateDegrees(30.0, background = Color.RED)
+
+// 90도 단위 (scrimage 네이티브, 무손실)
+val cw90  = image.rotateRight()
+val ccw90 = image.rotateLeft()
+
+// 반전
+val hFlip = image.flipHorizontal()
+val vFlip = image.flipVertical()
+
+// Suspend
+val async = image.suspendRotateDegrees(45.0)
+```
+
+### Perspective Transform — 원근 변환
+
+4점 호모그래피를 이용한 문서 왜곡 보정 및 원근 교정.
+
+```kotlin
+val src = listOf(
+    ImagePoint(10.0, 10.0), ImagePoint(490.0, 0.0),
+    ImagePoint(500.0, 490.0), ImagePoint(0.0, 500.0),
+)
+val dst = listOf(
+    ImagePoint(0.0, 0.0), ImagePoint(499.0, 0.0),
+    ImagePoint(499.0, 499.0), ImagePoint(0.0, 499.0),
+)
+val corrected = image.perspectiveTransform(src, dst, outputWidth = 500, outputHeight = 500)
+
+// Suspend 변형
+val async = image.suspendPerspectiveTransform(src, dst, 500, 500)
+```
+
+### CLAHE — 히스토그램 균일화
+
+YCbCr 색공간(BT.601) 기반 CLAHE(Contrast Limited Adaptive Histogram Equalization).
+
+```kotlin
+// 기본 설정 (tileSize=8, clipLimit=2.0)
+val enhanced = image.clahe()
+
+// 타일/클립 직접 지정
+val enhanced2 = image.clahe(tileSize = 16, clipLimit = 3.0)
+
+// 전역(단일 타일) 균일화
+val global = image.globalEqualize()
+
+// Suspend 변형
+val async = image.suspendClahe(tileSize = 8, clipLimit = 2.0)
+```
+
+### DSL 통합
+
+모든 변환은 `applyFilters { }` / `suspendApplyFilters { }` DSL에서 사용 가능합니다.
+
+```kotlin
+val result = image.applyFilters {
+    autoCrop(tolerance = 10, backgroundColor = Color.WHITE)
+    rotateDegrees(15.0)
+    clahe()
+}
+
+// Suspend DSL
+val asyncResult = image.suspendApplyFilters {
+    smartCrop(AspectRatio.WIDESCREEN)
+    flipHorizontal()
+}
 ```
 
 ## 의존성 추가

--- a/utils/images/README.md
+++ b/utils/images/README.md
@@ -27,6 +27,7 @@ flowchart LR
         WM["Watermark<br/>(WatermarkFilter)"]
         CP["Caption<br/>(CaptionFilter)"]
         PD["Padding<br/>(PaddingSupport)"]
+        TR["Transform<br/>(AutoCrop/SmartCrop/Rotate/Perspective/CLAHE)"]
     end
 
     subgraph Output["Async Output (Coroutines)"]
@@ -661,6 +662,142 @@ val (r, g, b) = ColorSpaceConverter.kelvinToRgb(6500)
 // Pixel array conversions (per-pixel bulk)
 val hsvArray = image.toHsvArray()     // FloatArray [h0,s0,v0, h1,s1,v1, ...]
 val ycbcrArray = image.toYCbCrArray() // FloatArray [y0,cb0,cr0, ...]
+```
+
+## Image Transforms
+
+Advanced image transformation operations backed by pure JVM (Java2D) with suspend variants.
+
+### Transform Architecture
+
+```mermaid
+flowchart TD
+    subgraph Transforms["transforms package"]
+        AC["AutoCrop\nautoCrop()"]
+        SC["SmartCrop\nsmartCrop(AspectRatio)"]
+        RT["Rotation\nrotateDegrees / flipH / flipV"]
+        PT["PerspectiveTransform\nperspectiveTransform(4pts)"]
+        HE["HistogramEqualization\nclahe / globalEqualize"]
+    end
+
+    subgraph DSL["applyFilters { } DSL"]
+        DO["ImageFilterChainTransformOps\nautoCrop / smartCrop / rotateDegrees\nrotateLeft / rotateRight\nflipH / flipV / perspective / clahe"]
+    end
+
+    ImmutableImage --> Transforms
+    Transforms --> ImmutableImage
+    DSL --> Transforms
+
+    classDef opStyle fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
+    classDef dslStyle fill:#F3E5F5,stroke:#CE93D8,color:#6A1B9A
+    class AC,SC,RT,PT,HE opStyle
+    class DO dslStyle
+```
+
+### AutoCrop
+
+Remove background margins automatically.
+
+```kotlin
+// Auto-detect background from 4 corners
+val cropped = image.autoCrop(tolerance = 10, padding = 2)
+
+// Explicit background color
+val cropped2 = image.autoCrop(tolerance = 5, backgroundColor = Color.WHITE)
+
+// Suspend variant
+val cropped3 = image.suspendAutoCrop()
+```
+
+### SmartCrop
+
+Saliency-based crop (Sobel edge energy — not ML).
+
+```kotlin
+// Crop to 16:9 widescreen, keeping the most "interesting" region
+val wide = image.smartCrop(AspectRatio.WIDESCREEN)
+
+// Crop and resize to exact output dimensions
+val thumb = image.smartCropTo(400, 300)
+
+// Suspend variant
+val wide2 = image.suspendSmartCrop(AspectRatio.SQUARE)
+```
+
+`AspectRatio` presets: `SQUARE (1:1)`, `WIDESCREEN (16:9)`, `PORTRAIT (9:16)`, `STANDARD (4:3)`.
+
+### Rotation & Flip
+
+```kotlin
+// Arbitrary angle (transparent background, canvas auto-expanded)
+val rotated = image.rotateDegrees(45.0)
+val rotatedRed = image.rotateDegrees(30.0, background = Color.RED)
+
+// 90-degree multiples (native scrimage, lossless)
+val cw90  = image.rotateRight()
+val ccw90 = image.rotateLeft()
+
+// Flip
+val hFlip = image.flipHorizontal()
+val vFlip = image.flipVertical()
+
+// Suspend
+val async = image.suspendRotateDegrees(45.0)
+```
+
+### Perspective Transform
+
+4-point homography for document de-skewing and perspective correction.
+
+```kotlin
+val src = listOf(
+    ImagePoint(10.0, 10.0), ImagePoint(490.0, 0.0),
+    ImagePoint(500.0, 490.0), ImagePoint(0.0, 500.0),
+)
+val dst = listOf(
+    ImagePoint(0.0, 0.0), ImagePoint(499.0, 0.0),
+    ImagePoint(499.0, 499.0), ImagePoint(0.0, 499.0),
+)
+val corrected = image.perspectiveTransform(src, dst, outputWidth = 500, outputHeight = 500)
+
+// Suspend variant
+val async = image.suspendPerspectiveTransform(src, dst, 500, 500)
+```
+
+### CLAHE (Histogram Equalization)
+
+Contrast Limited Adaptive Histogram Equalization via YCbCr colour space.
+
+```kotlin
+// CLAHE with default tile/clip settings
+val enhanced = image.clahe()
+
+// Custom tile size and clip limit
+val enhanced2 = image.clahe(tileSize = 16, clipLimit = 3.0)
+
+// Global (single-tile) equalization
+val global = image.globalEqualize()
+
+// Suspend variant
+val async = image.suspendClahe(tileSize = 8, clipLimit = 2.0)
+```
+
+### DSL Integration
+
+All transforms are available inside `applyFilters { }` / `suspendApplyFilters { }` DSL.
+
+```kotlin
+val result = image.applyFilters {
+    autoCrop(tolerance = 10, backgroundColor = Color.WHITE)
+    rotateDegrees(15.0)
+    clahe()
+}
+
+// Suspend DSL
+val asyncResult = image.suspendApplyFilters {
+    smartCrop(AspectRatio.WIDESCREEN)
+    flipHorizontal()
+}
 ```
 
 ## Dependency

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/transforms/AutoCrop.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/transforms/AutoCrop.kt
@@ -1,0 +1,159 @@
+package io.bluetape4k.images.transforms
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.images.transforms.internal.getArgbPixels
+import io.bluetape4k.images.transforms.internal.toIntArgb
+import io.bluetape4k.logging.KotlinLogging
+import io.bluetape4k.logging.debug
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.awt.Color
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 이미지의 배경색을 감지하여 불필요한 여백을 자동으로 제거합니다.
+ *
+ * ## 동작/계약
+ * - `tolerance` 범위 내의 픽셀을 배경으로 간주하고, 실제 콘텐츠 경계를 찾아 잘라냅니다.
+ * - `backgroundColor` 가 `null` 이면 이미지의 4개 모서리 픽셀을 평균하여 배경색을 추정합니다.
+ * - 콘텐츠가 전혀 없는 경우 (모든 픽셀이 배경) 원본 이미지를 그대로 반환하며, debug 로그를 남깁니다.
+ * - `padding` 을 지정하면 잘라낸 영역의 외곽에 여백을 추가합니다.
+ *
+ * ```kotlin
+ * val cropped = image.autoCrop()
+ * // 배경색 명시
+ * val cropped2 = image.autoCrop(tolerance = 20, padding = 5, backgroundColor = Color.WHITE)
+ * ```
+ *
+ * @param tolerance 배경으로 판단하는 RGB 채널별 최대 편차 (0..255, 기본값 10).
+ * @param padding 자른 후 각 방향에 추가할 여백 픽셀 수 (0 이상, 기본값 0).
+ * @param backgroundColor 기준 배경색. `null` 이면 4개 모서리 평균으로 자동 감지.
+ * @return 여백이 제거된 [ImmutableImage]. 콘텐츠가 없으면 원본 반환.
+ */
+fun ImmutableImage.autoCrop(
+    tolerance: Int = 10,
+    padding: Int = 0,
+    backgroundColor: Color? = null,
+): ImmutableImage {
+    require(tolerance in 0..255) { "tolerance must be in 0..255, but was $tolerance" }
+    require(padding >= 0) { "padding must be >= 0, but was $padding" }
+
+    val w = width
+    val h = height
+    val argbImage = toIntArgb()
+    val pixels = argbImage.getArgbPixels()
+
+    // 배경색 결정: 명시 지정 또는 4 모서리 평균
+    val (bgR, bgG, bgB) = if (backgroundColor != null) {
+        Triple(backgroundColor.red, backgroundColor.green, backgroundColor.blue)
+    } else {
+        val topLeft = pixels[0]
+        val topRight = pixels[w - 1]
+        val bottomLeft = pixels[(h - 1) * w]
+        val bottomRight = pixels[h * w - 1]
+
+        val avgR = ((topLeft ushr 16 and 0xFF) + (topRight ushr 16 and 0xFF) +
+            (bottomLeft ushr 16 and 0xFF) + (bottomRight ushr 16 and 0xFF)) / 4
+        val avgG = ((topLeft ushr 8 and 0xFF) + (topRight ushr 8 and 0xFF) +
+            (bottomLeft ushr 8 and 0xFF) + (bottomRight ushr 8 and 0xFF)) / 4
+        val avgB = ((topLeft and 0xFF) + (topRight and 0xFF) +
+            (bottomLeft and 0xFF) + (bottomRight and 0xFF)) / 4
+
+        Triple(avgR, avgG, avgB)
+    }
+
+    // 픽셀이 배경인지 검사: 모든 RGB 채널 편차가 tolerance 이하이면 배경
+    fun isBackground(pixel: Int): Boolean {
+        val r = pixel ushr 16 and 0xFF
+        val g = pixel ushr 8 and 0xFF
+        val b = pixel and 0xFF
+        return kotlin.math.abs(r - bgR) <= tolerance &&
+            kotlin.math.abs(g - bgG) <= tolerance &&
+            kotlin.math.abs(b - bgB) <= tolerance
+    }
+
+    // 위쪽 경계: 배경이 아닌 픽셀이 하나라도 있는 첫 번째 행
+    var top = h
+    outer@ for (y in 0 until h) {
+        for (x in 0 until w) {
+            if (!isBackground(pixels[y * w + x])) {
+                top = y
+                break@outer
+            }
+        }
+    }
+
+    // 아래쪽 경계: 배경이 아닌 픽셀이 하나라도 있는 마지막 행 (exclusive)
+    var bottom = 0
+    outer@ for (y in h - 1 downTo 0) {
+        for (x in 0 until w) {
+            if (!isBackground(pixels[y * w + x])) {
+                bottom = y + 1
+                break@outer
+            }
+        }
+    }
+
+    // 왼쪽 경계: 배경이 아닌 픽셀이 하나라도 있는 첫 번째 열
+    var left = w
+    outer@ for (x in 0 until w) {
+        for (y in 0 until h) {
+            if (!isBackground(pixels[y * w + x])) {
+                left = x
+                break@outer
+            }
+        }
+    }
+
+    // 오른쪽 경계: 배경이 아닌 픽셀이 하나라도 있는 마지막 열 (exclusive)
+    var right = 0
+    outer@ for (x in w - 1 downTo 0) {
+        for (y in 0 until h) {
+            if (!isBackground(pixels[y * w + x])) {
+                right = x + 1
+                break@outer
+            }
+        }
+    }
+
+    // 패딩 적용
+    left = (left - padding).coerceAtLeast(0)
+    top = (top - padding).coerceAtLeast(0)
+    right = (right + padding).coerceAtMost(w)
+    bottom = (bottom + padding).coerceAtMost(h)
+
+    // 콘텐츠 없음 → 원본 반환 (silent fallback)
+    if (right - left < 1 || bottom - top < 1) {
+        log.debug {
+            "autoCrop silent fallback: no content found (w=$w, h=$h, bg=($bgR,$bgG,$bgB))"
+        }
+        return this
+    }
+
+    return subimage(left, top, right - left, bottom - top)
+}
+
+/**
+ * 코루틴 환경에서 이미지의 배경색을 감지하여 불필요한 여백을 자동으로 제거합니다.
+ *
+ * ## 동작/계약
+ * - [autoCrop] 을 `Dispatchers.Default` 에서 실행합니다.
+ * - 콘텐츠가 전혀 없는 경우 원본 이미지를 그대로 반환합니다.
+ *
+ * ```kotlin
+ * val cropped = image.suspendAutoCrop()
+ * // 배경색 명시
+ * val cropped2 = image.suspendAutoCrop(tolerance = 20, padding = 5, backgroundColor = Color.WHITE)
+ * ```
+ *
+ * @param tolerance 배경으로 판단하는 RGB 채널별 최대 편차 (0..255, 기본값 10).
+ * @param padding 자른 후 각 방향에 추가할 여백 픽셀 수 (0 이상, 기본값 0).
+ * @param backgroundColor 기준 배경색. `null` 이면 4개 모서리 평균으로 자동 감지.
+ * @return 여백이 제거된 [ImmutableImage]. 콘텐츠가 없으면 원본 반환.
+ */
+suspend fun ImmutableImage.suspendAutoCrop(
+    tolerance: Int = 10,
+    padding: Int = 0,
+    backgroundColor: Color? = null,
+): ImmutableImage = withContext(Dispatchers.Default) { autoCrop(tolerance, padding, backgroundColor) }

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/transforms/HistogramEqualization.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/transforms/HistogramEqualization.kt
@@ -62,10 +62,10 @@ fun ImmutableImage.clahe(tileSize: Int = 8, clipLimit: Double = 2.0): ImmutableI
         crPlane[i] = (0.5 * r - 0.419 * g - 0.081 * b + 128).toInt().coerceIn(0, 255)
     }
 
-    // Step 3: Tile fallback
-    val effectiveTileSize = if (tileSize > minOf(w, h)) {
-        log.debug { "clahe tile fallback: tile=$tileSize > min(w=$w, h=$h), using single tile" }
-        minOf(w, h)
+    // Step 3: Tile fallback — clamp to maxOf(w,h) so globalEqualize (tileSize=max) yields a 1×1 grid
+    val effectiveTileSize = if (tileSize >= maxOf(w, h)) {
+        log.debug { "clahe tile fallback: tile=$tileSize >= max(w=$w, h=$h), collapsing to single tile" }
+        maxOf(w, h)
     } else {
         tileSize
     }

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/transforms/HistogramEqualization.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/transforms/HistogramEqualization.kt
@@ -1,0 +1,192 @@
+package io.bluetape4k.images.transforms
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.images.transforms.internal.alphaComponent
+import io.bluetape4k.images.transforms.internal.argb
+import io.bluetape4k.images.transforms.internal.blueComponent
+import io.bluetape4k.images.transforms.internal.copyArgb
+import io.bluetape4k.images.transforms.internal.getArgbPixels
+import io.bluetape4k.images.transforms.internal.greenComponent
+import io.bluetape4k.images.transforms.internal.redComponent
+import io.bluetape4k.images.transforms.internal.setArgbPixels
+import io.bluetape4k.images.transforms.internal.toIntArgb
+import io.bluetape4k.logging.KotlinLogging
+import io.bluetape4k.logging.debug
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * CLAHE (Contrast Limited Adaptive Histogram Equalization) 를 적용한 새 [ImmutableImage] 를 반환합니다.
+ *
+ * 이 구현은 다음 단계로 진행됩니다.
+ *
+ * 1. RGB 채널을 YCbCr (BT.601) 색공간으로 변환하여 휘도(Y) 평면에만 평활화를 적용합니다.
+ *    크로마(Cb, Cr) 채널은 보존되어 색상 왜곡을 최소화합니다.
+ * 2. 영상을 [tileSize] x [tileSize] 크기의 타일로 분할하고, 각 타일별 히스토그램을 계산합니다.
+ *    - 영상 크기가 [tileSize] 보다 작으면 단일 타일로 fallback 합니다.
+ * 3. 히스토그램의 한 빈이 `clipLimit * tilePixelCount / 256` 을 초과하면 잘라내고(clip),
+ *    잘려나간 양을 모든 빈에 균등 재분배하여 노이즈 증폭을 제어합니다.
+ * 4. 각 타일의 누적 분포 함수(CDF) 로 256-entry LUT 를 구성합니다.
+ * 5. 각 픽셀에 대해 인접 4개 타일의 LUT 결과를 거리 기반 **bilinear 보간** 하여
+ *    타일 경계에서 발생하는 블록 아티팩트를 제거합니다.
+ * 6. 변환된 Y 와 원본 Cb, Cr 을 RGB 로 역변환하여 결과 이미지를 생성합니다.
+ *
+ * @param tileSize 타일 한 변의 픽셀 크기. 작을수록 적응성이 높아지고 클수록 전역에 가까워집니다. 기본값 8.
+ * @param clipLimit 히스토그램 빈 별 상한 배수 (1.0 이면 균등 분포 수준). 클수록 대비 향상이 강해지고 노이즈가 증가합니다. 기본값 2.0.
+ * @return CLAHE 가 적용된 새 [ImmutableImage].
+ * @throws IllegalArgumentException [tileSize] 가 1 미만이거나 [clipLimit] 가 0 이하일 때.
+ */
+fun ImmutableImage.clahe(tileSize: Int = 8, clipLimit: Double = 2.0): ImmutableImage {
+    require(tileSize >= 1) { "tileSize must be >= 1" }
+    require(clipLimit > 0.0) { "clipLimit must be > 0" }
+
+    val srcBuf = this.toIntArgb()
+    val pixels = srcBuf.getArgbPixels()
+    val w = srcBuf.width
+    val h = srcBuf.height
+    val total = w * h
+
+    // Step 2: RGB -> YCbCr (BT.601)
+    val yPlane = IntArray(total)
+    val cbPlane = IntArray(total)
+    val crPlane = IntArray(total)
+    for (i in 0 until total) {
+        val argb = pixels[i]
+        val r = argb.redComponent()
+        val g = argb.greenComponent()
+        val b = argb.blueComponent()
+        yPlane[i] = (0.299 * r + 0.587 * g + 0.114 * b).toInt().coerceIn(0, 255)
+        cbPlane[i] = (-0.169 * r - 0.331 * g + 0.5 * b + 128).toInt().coerceIn(0, 255)
+        crPlane[i] = (0.5 * r - 0.419 * g - 0.081 * b + 128).toInt().coerceIn(0, 255)
+    }
+
+    // Step 3: Tile fallback
+    val effectiveTileSize = if (tileSize > minOf(w, h)) {
+        log.debug { "clahe tile fallback: tile=$tileSize > min(w=$w, h=$h), using single tile" }
+        minOf(w, h)
+    } else {
+        tileSize
+    }
+
+    // Step 4: Compute tile grid
+    val nTilesX = (w + effectiveTileSize - 1) / effectiveTileSize
+    val nTilesY = (h + effectiveTileSize - 1) / effectiveTileSize
+
+    // Step 5: For each tile, compute histogram -> clip -> CDF -> LUT
+    val tileLuts = Array(nTilesY) { ty ->
+        Array(nTilesX) { tx ->
+            val x0 = tx * effectiveTileSize
+            val y0 = ty * effectiveTileSize
+            val x1 = minOf(x0 + effectiveTileSize, w)
+            val y1 = minOf(y0 + effectiveTileSize, h)
+            val tilePixelCount = (x1 - x0) * (y1 - y0)
+
+            // Build histogram
+            val hist = IntArray(256)
+            for (py in y0 until y1) {
+                for (px in x0 until x1) {
+                    hist[yPlane[py * w + px]]++
+                }
+            }
+
+            // Clip histogram
+            val cap = (clipLimit * tilePixelCount / 256).toInt().coerceAtLeast(1)
+            var excess = 0
+            for (i in 0 until 256) {
+                if (hist[i] > cap) {
+                    excess += hist[i] - cap
+                    hist[i] = cap
+                }
+            }
+            // Redistribute excess evenly
+            val addPerBin = excess / 256
+            val remainder = excess % 256
+            for (i in 0 until 256) {
+                hist[i] += addPerBin
+            }
+            for (i in 0 until remainder) {
+                hist[i]++
+            }
+
+            // Build CDF LUT
+            val lut = IntArray(256)
+            var cdf = 0
+            for (i in 0 until 256) {
+                cdf += hist[i]
+                lut[i] = (cdf.toLong() * 255 / tilePixelCount).toInt().coerceIn(0, 255)
+            }
+            lut
+        }
+    }
+
+    // Step 6: Apply bilinear tile interpolation
+    for (py in 0 until h) {
+        for (px in 0 until w) {
+            val txF = (px - effectiveTileSize / 2.0) / effectiveTileSize
+            val tyF = (py - effectiveTileSize / 2.0) / effectiveTileSize
+            val tx0 = txF.toInt().coerceIn(0, nTilesX - 1)
+            val tx1 = (tx0 + 1).coerceIn(0, nTilesX - 1)
+            val ty0 = tyF.toInt().coerceIn(0, nTilesY - 1)
+            val ty1 = (ty0 + 1).coerceIn(0, nTilesY - 1)
+            val wx = (txF - tx0).coerceIn(0.0, 1.0)
+            val wy = (tyF - ty0).coerceIn(0.0, 1.0)
+            val yVal = yPlane[py * w + px]
+            val v00 = tileLuts[ty0][tx0][yVal]
+            val v10 = tileLuts[ty0][tx1][yVal]
+            val v01 = tileLuts[ty1][tx0][yVal]
+            val v11 = tileLuts[ty1][tx1][yVal]
+            val yNew = ((1 - wx) * (1 - wy) * v00
+                + wx * (1 - wy) * v10
+                + (1 - wx) * wy * v01
+                + wx * wy * v11).toInt().coerceIn(0, 255)
+            yPlane[py * w + px] = yNew
+        }
+    }
+
+    // Step 7: YCbCr -> RGB
+    for (i in 0 until total) {
+        val y = yPlane[i]
+        val cb = cbPlane[i] - 128
+        val cr = crPlane[i] - 128
+        val r = (y + 1.402 * cr).toInt().coerceIn(0, 255)
+        val g = (y - 0.344 * cb - 0.714 * cr).toInt().coerceIn(0, 255)
+        val b = (y + 1.772 * cb).toInt().coerceIn(0, 255)
+        val alpha = pixels[i].alphaComponent()
+        pixels[i] = argb(alpha, r, g, b)
+    }
+
+    // Step 8: Return result
+    val outBuf = srcBuf.copyArgb()
+    outBuf.setArgbPixels(pixels)
+    return ImmutableImage.wrapAwt(outBuf)
+}
+
+/**
+ * 영상 전체를 단일 타일로 처리하는 전역 히스토그램 평활화를 적용합니다.
+ *
+ * 내부적으로 [clahe] 를 `tileSize = max(width, height)` 로 호출하여
+ * 단일 타일 LUT 를 생성한 뒤 모든 픽셀에 동일하게 적용합니다.
+ * `clipLimit = 2.0` 으로 약한 클리핑이 들어가므로 순수 글로벌 평활화 보다 약간의 노이즈 억제 효과가 있습니다.
+ *
+ * @return 전역 평활화가 적용된 새 [ImmutableImage].
+ */
+fun ImmutableImage.globalEqualize(): ImmutableImage =
+    clahe(tileSize = maxOf(width, height), clipLimit = 2.0)
+
+/**
+ * [clahe] 의 코루틴 비동기 버전.
+ *
+ * 픽셀 연산이 CPU 바운드이므로 [Dispatchers.Default] 컨텍스트에서 수행합니다.
+ *
+ * @param tileSize 타일 한 변의 픽셀 크기. 기본값 8.
+ * @param clipLimit 히스토그램 빈 별 상한 배수. 기본값 2.0.
+ * @return CLAHE 가 적용된 새 [ImmutableImage].
+ */
+suspend fun ImmutableImage.suspendClahe(
+    tileSize: Int = 8,
+    clipLimit: Double = 2.0,
+): ImmutableImage = withContext(Dispatchers.Default) {
+    clahe(tileSize, clipLimit)
+}

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/transforms/PerspectiveTransform.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/transforms/PerspectiveTransform.kt
@@ -1,0 +1,338 @@
+package io.bluetape4k.images.transforms
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.images.transforms.internal.MAX_OUTPUT_PIXELS
+import io.bluetape4k.images.transforms.internal.alphaComponent
+import io.bluetape4k.images.transforms.internal.argb
+import io.bluetape4k.images.transforms.internal.blueComponent
+import io.bluetape4k.images.transforms.internal.fillColor
+import io.bluetape4k.images.transforms.internal.getArgbPixels
+import io.bluetape4k.images.transforms.internal.greenComponent
+import io.bluetape4k.images.transforms.internal.redComponent
+import io.bluetape4k.images.transforms.internal.setArgbPixels
+import io.bluetape4k.images.transforms.internal.toIntArgb
+import io.bluetape4k.logging.KotlinLogging
+import io.bluetape4k.logging.debug
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.awt.Color
+import java.awt.image.BufferedImage
+import kotlin.math.abs
+import kotlin.math.floor
+import kotlin.math.roundToInt
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 이미지 평면상의 한 점을 표현합니다.
+ *
+ * x는 열(column) 방향, y는 행(row) 방향입니다.
+ *
+ * @property x 열(column) 좌표.
+ * @property y 행(row) 좌표.
+ */
+data class ImagePoint(val x: Double, val y: Double)
+
+/**
+ * 4개의 모서리를 매핑하여 원근(perspective) 변환을 적용한 새 [ImmutableImage] 를 반환합니다.
+ *
+ * `sourceCorners` 는 입력 이미지에서의 4개 점, `destinationCorners` 는 출력 이미지에서의 4개 점이며,
+ * 보통 시계방향 좌상→우상→우하→좌하 순서로 지정합니다. 두 점 집합은 4×4 호모그래피(H, 3×3, h33=1)를
+ * 정의하고, 출력 픽셀에서 역 호모그래피(H⁻¹) 로 원본 좌표를 역추적하여 4-tap bilinear sampling 으로
+ * 색상을 결정합니다.
+ *
+ * 역추적된 좌표가 입력 이미지 범위를 벗어나면 [outsideColor] 로 채웁니다.
+ *
+ * ## 출력 한도
+ * `outputWidth × outputHeight` 는 [MAX_OUTPUT_PIXELS] (64M pixels) 이하여야 합니다.
+ *
+ * ```kotlin
+ * val src = listOf(
+ *     ImagePoint(10.0, 10.0),
+ *     ImagePoint(190.0, 12.0),
+ *     ImagePoint(195.0, 195.0),
+ *     ImagePoint(8.0, 200.0),
+ * )
+ * val dst = listOf(
+ *     ImagePoint(0.0, 0.0),
+ *     ImagePoint(255.0, 0.0),
+ *     ImagePoint(255.0, 255.0),
+ *     ImagePoint(0.0, 255.0),
+ * )
+ * val warped = image.perspectiveTransform(src, dst, 256, 256)
+ * ```
+ *
+ * @param sourceCorners        입력 이미지의 4개 점 (시계방향 좌상→우상→우하→좌하 권장).
+ * @param destinationCorners   출력 이미지의 4개 점 (대응 순서).
+ * @param outputWidth          출력 이미지 너비 (양수).
+ * @param outputHeight         출력 이미지 높이 (양수).
+ * @param outsideColor         원본 범위를 벗어난 픽셀을 채울 색 (기본값: 투명).
+ * @return 변환된 새 [ImmutableImage].
+ * @throws IllegalArgumentException 점이 4개가 아니거나, 출력 크기가 한도를 초과하거나, 점이 거의 일직선이거나
+ * 호모그래피가 퇴화한 경우.
+ */
+fun ImmutableImage.perspectiveTransform(
+    sourceCorners: List<ImagePoint>,
+    destinationCorners: List<ImagePoint>,
+    outputWidth: Int,
+    outputHeight: Int,
+    outsideColor: Color = Color(0, 0, 0, 0),
+): ImmutableImage {
+    require(sourceCorners.size == 4) { "sourceCorners must have exactly 4 points" }
+    require(destinationCorners.size == 4) { "destinationCorners must have exactly 4 points" }
+    require(outputWidth > 0 && outputHeight > 0) { "output dimensions must be positive" }
+    require(outputWidth.toLong() * outputHeight.toLong() <= MAX_OUTPUT_PIXELS) {
+        "output size ${outputWidth}x${outputHeight} exceeds 64M pixels limit"
+    }
+    require(sourceCorners.all { it.x.isFinite() && it.y.isFinite() }) {
+        "sourceCorners must have finite coordinates"
+    }
+    require(destinationCorners.all { it.x.isFinite() && it.y.isFinite() }) {
+        "destinationCorners must have finite coordinates"
+    }
+
+    log.debug {
+        "perspectiveTransform: src=${width}x${height}, out=${outputWidth}x${outputHeight}"
+    }
+
+    val homography = computeHomography(sourceCorners, destinationCorners)
+    val inverse = invert3x3(homography)
+
+    val srcBuf = this.toIntArgb()
+    val srcW = srcBuf.width
+    val srcH = srcBuf.height
+    val srcPixels = srcBuf.getArgbPixels()
+
+    val outBuf = BufferedImage(outputWidth, outputHeight, BufferedImage.TYPE_INT_ARGB)
+        .fillColor(outsideColor)
+    val outPixels = outBuf.getArgbPixels()
+
+    val maxX = (srcW - 1).toDouble()
+    val maxY = (srcH - 1).toDouble()
+
+    for (y in 0 until outputHeight) {
+        val rowOffset = y * outputWidth
+        val cy = y + 0.5
+        for (x in 0 until outputWidth) {
+            val cx = x + 0.5
+            val wx = inverse[0] * cx + inverse[1] * cy + inverse[2]
+            val wy = inverse[3] * cx + inverse[4] * cy + inverse[5]
+            val ww = inverse[6] * cx + inverse[7] * cy + inverse[8]
+
+            if (ww == 0.0 || !ww.isFinite()) continue
+
+            val srcX = wx / ww
+            val srcY = wy / ww
+
+            if (!srcX.isFinite() || !srcY.isFinite()) continue
+            if (srcX < 0.0 || srcY < 0.0 || srcX > maxX || srcY > maxY) continue
+
+            outPixels[rowOffset + x] = bilinearSample(srcPixels, srcW, srcH, srcX, srcY)
+        }
+    }
+
+    outBuf.setArgbPixels(outPixels)
+    return ImmutableImage.wrapAwt(outBuf)
+}
+
+/**
+ * Coroutines 환경에서 [perspectiveTransform] 을 실행합니다.
+ *
+ * CPU 바운드 작업이므로 [Dispatchers.Default] 에서 수행합니다.
+ *
+ * @see perspectiveTransform
+ */
+suspend fun ImmutableImage.suspendPerspectiveTransform(
+    sourceCorners: List<ImagePoint>,
+    destinationCorners: List<ImagePoint>,
+    outputWidth: Int,
+    outputHeight: Int,
+    outsideColor: Color = Color(0, 0, 0, 0),
+): ImmutableImage = withContext(Dispatchers.Default) {
+    perspectiveTransform(sourceCorners, destinationCorners, outputWidth, outputHeight, outsideColor)
+}
+
+/**
+ * 4쌍 점에 대한 호모그래피 행렬 H (3×3, h33=1) 를 계산합니다.
+ *
+ * 각 점쌍 (sx, sy) → (dx, dy) 에 대해 다음 두 행을 8×8 선형계에 추가합니다.
+ * - `[sx, sy, 1, 0, 0, 0, -dx*sx, -dx*sy] · h = dx`
+ * - `[0, 0, 0, sx, sy, 1, -dy*sx, -dy*sy] · h = dy`
+ *
+ * @return `[h11, h12, h13, h21, h22, h23, h31, h32, h33=1.0]` (row-major, size 9).
+ */
+private fun computeHomography(src: List<ImagePoint>, dst: List<ImagePoint>): DoubleArray {
+    val a = DoubleArray(8 * 8)
+    val b = DoubleArray(8)
+
+    for (i in 0 until 4) {
+        val sx = src[i].x
+        val sy = src[i].y
+        val dx = dst[i].x
+        val dy = dst[i].y
+
+        val r1 = (i * 2) * 8
+        a[r1 + 0] = sx
+        a[r1 + 1] = sy
+        a[r1 + 2] = 1.0
+        a[r1 + 3] = 0.0
+        a[r1 + 4] = 0.0
+        a[r1 + 5] = 0.0
+        a[r1 + 6] = -dx * sx
+        a[r1 + 7] = -dx * sy
+        b[i * 2] = dx
+
+        val r2 = (i * 2 + 1) * 8
+        a[r2 + 0] = 0.0
+        a[r2 + 1] = 0.0
+        a[r2 + 2] = 0.0
+        a[r2 + 3] = sx
+        a[r2 + 4] = sy
+        a[r2 + 5] = 1.0
+        a[r2 + 6] = -dy * sx
+        a[r2 + 7] = -dy * sy
+        b[i * 2 + 1] = dy
+    }
+
+    val solution = solve8x8(a, b)
+    return doubleArrayOf(
+        solution[0], solution[1], solution[2],
+        solution[3], solution[4], solution[5],
+        solution[6], solution[7], 1.0,
+    )
+}
+
+/**
+ * 부분 피벗팅(partial pivoting) 을 사용하는 Gauss-Jordan 소거법으로 8×8 선형계를 풉니다.
+ *
+ * @param a 8×8 row-major 계수 행렬 (size 64). 호출 후 변경됩니다.
+ * @param b 우변 벡터 (size 8). 호출 후 해(x) 로 덮어쓰입니다.
+ * @return 해 벡터 (size 8). 입력 [b] 와 동일한 인스턴스입니다.
+ * @throws IllegalArgumentException 피벗 절댓값이 1e-12 미만이면 (점이 거의 일직선) 발생합니다.
+ */
+private fun solve8x8(a: DoubleArray, b: DoubleArray): DoubleArray {
+    val n = 8
+    val pivotEpsilon = 1e-12
+
+    for (col in 0 until n) {
+        // Find pivot row
+        var pivotRow = col
+        var pivotAbs = abs(a[col * n + col])
+        for (r in (col + 1) until n) {
+            val v = abs(a[r * n + col])
+            if (v > pivotAbs) {
+                pivotAbs = v
+                pivotRow = r
+            }
+        }
+        if (pivotAbs < pivotEpsilon) {
+            throw IllegalArgumentException("source or destination points are nearly collinear")
+        }
+
+        // Swap pivot row with current row
+        if (pivotRow != col) {
+            for (c in 0 until n) {
+                val tmp = a[col * n + c]
+                a[col * n + c] = a[pivotRow * n + c]
+                a[pivotRow * n + c] = tmp
+            }
+            val tmpB = b[col]
+            b[col] = b[pivotRow]
+            b[pivotRow] = tmpB
+        }
+
+        // Normalize pivot row
+        val pivot = a[col * n + col]
+        for (c in 0 until n) {
+            a[col * n + c] /= pivot
+        }
+        b[col] /= pivot
+
+        // Eliminate other rows
+        for (r in 0 until n) {
+            if (r == col) continue
+            val factor = a[r * n + col]
+            if (factor == 0.0) continue
+            for (c in 0 until n) {
+                a[r * n + c] -= factor * a[col * n + c]
+            }
+            b[r] -= factor * b[col]
+        }
+    }
+    return b
+}
+
+/**
+ * 3×3 행렬의 역행렬을 cofactor/adjugate 방식의 닫힌 형태(closed form)로 계산합니다.
+ *
+ * @param h row-major 3×3 행렬 (size 9).
+ * @return 역행렬 (size 9, row-major).
+ * @throws IllegalArgumentException 행렬식의 절댓값이 1e-12 미만이면 (퇴화된 호모그래피) 발생합니다.
+ */
+private fun invert3x3(h: DoubleArray): DoubleArray {
+    val det = h[0] * (h[4] * h[8] - h[5] * h[7]) -
+        h[1] * (h[3] * h[8] - h[5] * h[6]) +
+        h[2] * (h[3] * h[7] - h[4] * h[6])
+
+    if (abs(det) < 1e-12) {
+        throw IllegalArgumentException("homography matrix is degenerate")
+    }
+
+    val invDet = 1.0 / det
+    val r = DoubleArray(9)
+    r[0] = (h[4] * h[8] - h[5] * h[7]) * invDet
+    r[1] = (h[2] * h[7] - h[1] * h[8]) * invDet
+    r[2] = (h[1] * h[5] - h[2] * h[4]) * invDet
+    r[3] = (h[5] * h[6] - h[3] * h[8]) * invDet
+    r[4] = (h[0] * h[8] - h[2] * h[6]) * invDet
+    r[5] = (h[2] * h[3] - h[0] * h[5]) * invDet
+    r[6] = (h[3] * h[7] - h[4] * h[6]) * invDet
+    r[7] = (h[1] * h[6] - h[0] * h[7]) * invDet
+    r[8] = (h[0] * h[4] - h[1] * h[3]) * invDet
+    return r
+}
+
+/**
+ * 4-tap bilinear sampling 으로 ARGB 픽셀을 보간합니다.
+ *
+ * 좌표가 정수 경계 바깥(예: -0.5 ~ 0.0) 에 있을 수 있으므로 코너 인덱스는 [0, w-1], [0, h-1] 범위로 클램프됩니다.
+ *
+ * @param pixels row-major ARGB 픽셀 배열.
+ * @param w      이미지 너비.
+ * @param h      이미지 높이.
+ * @param x      샘플링할 x 좌표 (실수).
+ * @param y      샘플링할 y 좌표 (실수).
+ * @return 보간된 ARGB packed `Int`.
+ */
+private fun bilinearSample(pixels: IntArray, w: Int, h: Int, x: Double, y: Double): Int {
+    val x0i = floor(x).toInt()
+    val y0i = floor(y).toInt()
+    val fx = x - x0i
+    val fy = y - y0i
+
+    val x0 = x0i.coerceIn(0, w - 1)
+    val y0 = y0i.coerceIn(0, h - 1)
+    val x1 = (x0i + 1).coerceIn(0, w - 1)
+    val y1 = (y0i + 1).coerceIn(0, h - 1)
+
+    val c00 = pixels[y0 * w + x0]
+    val c10 = pixels[y0 * w + x1]
+    val c01 = pixels[y1 * w + x0]
+    val c11 = pixels[y1 * w + x1]
+
+    val w00 = (1.0 - fx) * (1.0 - fy)
+    val w10 = fx * (1.0 - fy)
+    val w01 = (1.0 - fx) * fy
+    val w11 = fx * fy
+
+    val a = (w00 * c00.alphaComponent() + w10 * c10.alphaComponent() +
+        w01 * c01.alphaComponent() + w11 * c11.alphaComponent()).roundToInt().coerceIn(0, 255)
+    val r = (w00 * c00.redComponent() + w10 * c10.redComponent() +
+        w01 * c01.redComponent() + w11 * c11.redComponent()).roundToInt().coerceIn(0, 255)
+    val g = (w00 * c00.greenComponent() + w10 * c10.greenComponent() +
+        w01 * c01.greenComponent() + w11 * c11.greenComponent()).roundToInt().coerceIn(0, 255)
+    val b = (w00 * c00.blueComponent() + w10 * c10.blueComponent() +
+        w01 * c01.blueComponent() + w11 * c11.blueComponent()).roundToInt().coerceIn(0, 255)
+
+    return argb(a, r, g, b)
+}

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/transforms/Rotation.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/transforms/Rotation.kt
@@ -1,0 +1,125 @@
+package io.bluetape4k.images.transforms
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.angles.Radians
+import io.bluetape4k.logging.KotlinLogging
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.awt.Color
+import java.awt.RenderingHints
+import java.awt.geom.AffineTransform
+import java.awt.image.BufferedImage
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 이미지를 지정한 각도(도 단위)만큼 회전합니다.
+ *
+ * 90, 180, 270도의 경우 scrimage 네이티브 메서드([rotateRight], [rotate], [rotateLeft])를 사용합니다.
+ * 임의의 각도인 경우 [AffineTransform]으로 회전하며, 회전 후 이미지가 잘리지 않도록 캔버스를 자동 확장합니다.
+ *
+ * scrimage는 이미 bounds를 자동 확장합니다. 이 함수는 도(degree) 단위 편의 API와 투명 기본 배경을 제공합니다.
+ *
+ * ```kotlin
+ * val rotated = image.rotateDegrees(45.0)
+ * // 45도 회전된 새 이미지 반환 (배경은 투명)
+ *
+ * val rotatedRed = image.rotateDegrees(30.0, background = Color.RED)
+ * // 30도 회전, 빈 영역은 빨간색으로 채움
+ * ```
+ *
+ * @param angle      회전 각도 (도 단위, 시계 방향)
+ * @param background 회전 후 빈 영역을 채울 배경색 (기본값: 투명)
+ * @return 회전된 새 [ImmutableImage]
+ */
+fun ImmutableImage.rotateDegrees(angle: Double, background: Color = Color(0, 0, 0, 0)): ImmutableImage {
+    val normalized = ((angle % 360) + 360) % 360
+
+    if (Math.abs(normalized % 90) < 1e-9) {
+        return when (Math.round(normalized).toInt()) {
+            0 -> this
+            90 -> rotateRight()
+            180 -> rotate(Radians(Math.PI))
+            270 -> rotateLeft()
+            else -> this
+        }
+    }
+
+    val radians = Math.toRadians(angle)
+    val cos = Math.abs(Math.cos(radians))
+    val sin = Math.abs(Math.sin(radians))
+    val newW = Math.ceil(width * cos + height * sin).toInt()
+    val newH = Math.ceil(width * sin + height * cos).toInt()
+
+    val buf = BufferedImage(newW, newH, BufferedImage.TYPE_INT_ARGB)
+    val g = buf.createGraphics()
+    try {
+        g.color = background
+        g.fillRect(0, 0, newW, newH)
+        g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC)
+        g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY)
+        val transform = AffineTransform()
+        transform.translate(newW / 2.0, newH / 2.0)
+        transform.rotate(radians)
+        transform.translate(-width / 2.0, -height / 2.0)
+        g.drawImage(this.awt(), transform, null)
+    } finally {
+        g.dispose()
+    }
+
+    return ImmutableImage.wrapAwt(buf)
+}
+
+/**
+ * 이미지를 좌우 반전합니다.
+ *
+ * scrimage의 [flipX]를 래핑하는 편의 함수입니다.
+ *
+ * ```kotlin
+ * val flipped = image.flipHorizontal()
+ * // 좌우 반전된 새 이미지 반환
+ * ```
+ *
+ * @return 좌우 반전된 새 [ImmutableImage]
+ */
+fun ImmutableImage.flipHorizontal(): ImmutableImage = flipX()
+
+/**
+ * 이미지를 상하 반전합니다.
+ *
+ * scrimage의 [flipY]를 래핑하는 편의 함수입니다.
+ *
+ * ```kotlin
+ * val flipped = image.flipVertical()
+ * // 상하 반전된 새 이미지 반환
+ * ```
+ *
+ * @return 상하 반전된 새 [ImmutableImage]
+ */
+fun ImmutableImage.flipVertical(): ImmutableImage = flipY()
+
+/**
+ * Coroutines 환경에서 이미지를 지정한 각도(도 단위)만큼 회전합니다.
+ *
+ * [rotateDegrees]를 [Dispatchers.Default]에서 비동기로 실행합니다.
+ *
+ * scrimage는 이미 bounds를 자동 확장합니다. 이 함수는 도(degree) 단위 편의 API와 투명 기본 배경을 제공합니다.
+ *
+ * ```kotlin
+ * val rotated = image.suspendRotateDegrees(45.0)
+ * // Coroutines 환경에서 45도 회전된 새 이미지 반환
+ *
+ * val rotatedWithBg = image.suspendRotateDegrees(30.0, background = Color(255, 255, 255, 128))
+ * // 30도 회전, 빈 영역은 반투명 흰색으로 채움
+ * ```
+ *
+ * @param angle      회전 각도 (도 단위, 시계 방향)
+ * @param background 회전 후 빈 영역을 채울 배경색 (기본값: 투명)
+ * @return 회전된 새 [ImmutableImage]
+ */
+suspend fun ImmutableImage.suspendRotateDegrees(
+    angle: Double,
+    background: Color = Color(0, 0, 0, 0),
+): ImmutableImage = withContext(Dispatchers.Default) {
+    rotateDegrees(angle, background)
+}

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/transforms/SmartCrop.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/transforms/SmartCrop.kt
@@ -1,0 +1,295 @@
+package io.bluetape4k.images.transforms
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.images.transforms.internal.blueComponent
+import io.bluetape4k.images.transforms.internal.getArgbPixels
+import io.bluetape4k.images.transforms.internal.greenComponent
+import io.bluetape4k.images.transforms.internal.redComponent
+import io.bluetape4k.images.transforms.internal.toIntArgb
+import io.bluetape4k.logging.KotlinLogging
+import io.bluetape4k.logging.debug
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 다운샘플링 시 가장 긴 변의 목표 픽셀 수.
+ *
+ * 256px 보다 큰 이미지를 처리할 때 이 값으로 축소하여 saliency 계산을 수행합니다.
+ * 256px 이하 이미지는 원본 해상도에서 직접 계산합니다.
+ */
+private const val DOWNSAMPLE_TARGET_LONGEST_SIDE = 256
+
+/**
+ * 자르기에 사용되는 종횡비를 표현하는 값 객체.
+ *
+ * `width:height` 비율을 정수 쌍으로 보관하며, 두 값은 모두 양의 정수여야 합니다.
+ *
+ * ```kotlin
+ * val ratio = AspectRatio(16, 9)
+ * val square = AspectRatio.SQUARE
+ * ```
+ *
+ * @property width 가로 비율 (양의 정수).
+ * @property height 세로 비율 (양의 정수).
+ */
+data class AspectRatio(val width: Int, val height: Int) {
+    init {
+        require(width > 0 && height > 0) { "AspectRatio dimensions must be positive: width=$width, height=$height" }
+    }
+
+    companion object {
+        /** 1:1 정사각형 비율. */
+        val SQUARE = AspectRatio(1, 1)
+
+        /** 16:9 와이드스크린 비율. */
+        val WIDESCREEN = AspectRatio(16, 9)
+
+        /** 9:16 세로형 (포트레이트) 비율. */
+        val PORTRAIT = AspectRatio(9, 16)
+
+        /** 4:3 표준 비율. */
+        val STANDARD = AspectRatio(4, 3)
+    }
+}
+
+/**
+ * Smart crop 에서 사용할 saliency (관심 영역) 추정 전략.
+ *
+ * 이 전략은 **휴리스틱** 이며 머신러닝 기반 얼굴/객체 검출이 아닙니다.
+ * 단순한 엣지 에너지(edge energy) 기반으로 "정보가 많아 보이는" 영역을 추정할 뿐입니다.
+ */
+sealed interface SaliencyStrategy {
+
+    /**
+     * Sobel 연산자를 사용해 엣지 강도(L1 norm) 를 합산하는 휴리스틱.
+     *
+     * - 빠르고 의존성 없음 (순수 JVM 연산).
+     * - 얼굴/객체 인식이 아니라 텍스처/엣지가 풍부한 영역을 선호.
+     * - 단색 배경 위에 텍스트가 있는 이미지처럼 엣지가 또렷한 콘텐츠에 효과적.
+     */
+    data object SobelEnergy : SaliencyStrategy
+}
+
+/**
+ * 이미지에서 [aspectRatio] 비율을 유지하는 가장 "흥미로워 보이는" 영역을 잘라냅니다.
+ *
+ * > **주의**: 이 함수는 **휴리스틱 saliency** 입니다 — 얼굴/객체 검출이 아닌
+ * > **Sobel 엣지 에너지** 기준입니다. 인물 사진 등에서 얼굴이 항상 중앙에 오도록
+ * > 보장하지 않으며, 어디까지나 엣지가 풍부한 영역을 우선시할 뿐입니다.
+ *
+ * ## 동작/계약
+ * - 가장 긴 변이 256px 이상인 이미지는 saliency 계산 전 256px 로 다운샘플링하여 성능을 확보합니다.
+ * - 다운샘플 좌표계에서 [aspectRatio] 를 유지하는 최대 윈도우를 슬라이딩하며,
+ *   integral image 를 사용해 O(1) 윈도우 합 평가로 최적 위치를 찾습니다.
+ * - 최적 윈도우를 원본 좌표로 복원하여 [ImmutableImage.subimage] 호출로 잘라냅니다.
+ *
+ * ```kotlin
+ * val cropped = image.smartCrop(AspectRatio.SQUARE)
+ * val widescreen = image.smartCrop(AspectRatio.WIDESCREEN)
+ * ```
+ *
+ * @param aspectRatio 결과 영역의 종횡비 (`width:height`).
+ * @param strategy saliency 추정 전략. 기본은 [SaliencyStrategy.SobelEnergy].
+ * @return saliency 가 가장 높은 영역을 [aspectRatio] 비율로 잘라낸 새 [ImmutableImage].
+ */
+fun ImmutableImage.smartCrop(
+    aspectRatio: AspectRatio,
+    strategy: SaliencyStrategy = SaliencyStrategy.SobelEnergy,
+): ImmutableImage {
+    require(aspectRatio.width > 0 && aspectRatio.height > 0) {
+        "aspectRatio dimensions must be positive: width=${aspectRatio.width}, height=${aspectRatio.height}"
+    }
+
+    val origW = width
+    val origH = height
+    val longest = if (origW >= origH) origW else origH
+
+    // 1) 다운샘플링: 가장 긴 변이 256 초과인 경우만
+    val dsScale: Double
+    val dsImage: ImmutableImage
+    if (longest > DOWNSAMPLE_TARGET_LONGEST_SIDE) {
+        dsScale = DOWNSAMPLE_TARGET_LONGEST_SIDE.toDouble() / longest
+        val newW = (origW * dsScale).roundToInt().coerceAtLeast(1)
+        val newH = (origH * dsScale).roundToInt().coerceAtLeast(1)
+        dsImage = scaleTo(newW, newH)
+    } else {
+        dsScale = 1.0
+        dsImage = this
+    }
+
+    val dsW = dsImage.width
+    val dsH = dsImage.height
+
+    // 2) ARGB 픽셀 추출 후 luma(grayscale) 변환
+    val argb = dsImage.toIntArgb().getArgbPixels()
+    val luma = IntArray(dsW * dsH)
+    for (i in argb.indices) {
+        val p = argb[i]
+        val r = p.redComponent()
+        val g = p.greenComponent()
+        val b = p.blueComponent()
+        luma[i] = (0.299 * r + 0.587 * g + 0.114 * b).toInt()
+    }
+
+    // 3) Sobel 엣지 magnitude (L1 norm). border 픽셀은 0.
+    val mag = when (strategy) {
+        SaliencyStrategy.SobelEnergy -> computeSobelMagnitude(luma, dsW, dsH)
+    }
+
+    // 4) Integral image (1-indexed, (dsW+1) x (dsH+1))
+    val iw = dsW + 1
+    val ih = dsH + 1
+    val integ = LongArray(iw * ih)
+    for (y in 0 until dsH) {
+        var rowSum = 0L
+        for (x in 0 until dsW) {
+            rowSum += mag[y * dsW + x]
+            integ[(y + 1) * iw + (x + 1)] = integ[y * iw + (x + 1)] + rowSum
+        }
+    }
+
+    // 5) 종횡비 유지 최대 윈도우 크기 결정 (다운샘플 좌표계)
+    val ratio = aspectRatio.width.toDouble() / aspectRatio.height
+    val winW: Int
+    val winH: Int
+    if (dsW / ratio <= dsH) {
+        winW = dsW
+        winH = (dsW / ratio).toInt().coerceAtLeast(1)
+    } else {
+        winH = dsH
+        winW = (dsH * ratio).toInt().coerceAtLeast(1)
+    }
+
+    // 6) 슬라이딩 윈도우로 최대 saliency 위치 탐색
+    var bestSum = Long.MIN_VALUE
+    var bestX = 0
+    var bestY = 0
+    val maxX = dsW - winW
+    val maxY = dsH - winH
+    for (y in 0..maxY) {
+        for (x in 0..maxX) {
+            val sum = integ[(y + winH) * iw + (x + winW)] -
+                integ[y * iw + (x + winW)] -
+                integ[(y + winH) * iw + x] +
+                integ[y * iw + x]
+            if (sum > bestSum) {
+                bestSum = sum
+                bestX = x
+                bestY = y
+            }
+        }
+    }
+
+    // 7) 원본 좌표로 복원
+    val restoredX: Int
+    val restoredY: Int
+    val restoredW: Int
+    val restoredH: Int
+    if (dsScale == 1.0) {
+        restoredX = bestX.coerceIn(0, origW - 1)
+        restoredY = bestY.coerceIn(0, origH - 1)
+        restoredW = winW.coerceIn(1, origW - restoredX)
+        restoredH = winH.coerceIn(1, origH - restoredY)
+    } else {
+        restoredX = (bestX / dsScale).toInt().coerceIn(0, origW - 1)
+        restoredY = (bestY / dsScale).toInt().coerceIn(0, origH - 1)
+        restoredW = (winW / dsScale).toInt().coerceIn(1, origW - restoredX)
+        restoredH = (winH / dsScale).toInt().coerceIn(1, origH - restoredY)
+    }
+
+    log.debug {
+        "smartCrop: orig=${origW}x${origH}, ds=${dsW}x${dsH} (scale=$dsScale), " +
+            "win=${winW}x${winH} at ds($bestX,$bestY) -> orig(${restoredX},${restoredY}) ${restoredW}x${restoredH}"
+    }
+
+    return subimage(restoredX, restoredY, restoredW, restoredH)
+}
+
+/**
+ * 이미지를 [width] x [height] 크기로 smart crop + resize 합니다.
+ *
+ * > **주의**: 내부적으로 [smartCrop] 의 휴리스틱 saliency 를 사용합니다 —
+ * > 얼굴/객체 검출이 아닌 Sobel 엣지 에너지 기준입니다.
+ *
+ * ## 동작/계약
+ * - 1) [width] / [height] 비율로 [smartCrop] 호출하여 핵심 영역을 자르고,
+ * - 2) `scaleTo(width, height)` 로 정확한 출력 크기로 리사이즈합니다.
+ *
+ * ```kotlin
+ * val thumb = image.smartCropTo(400, 300)
+ * ```
+ *
+ * @param width 출력 이미지 너비 (양의 정수).
+ * @param height 출력 이미지 높이 (양의 정수).
+ * @param strategy saliency 추정 전략. 기본은 [SaliencyStrategy.SobelEnergy].
+ * @return smart-crop 후 정확히 [width] x [height] 로 리사이즈된 [ImmutableImage].
+ */
+fun ImmutableImage.smartCropTo(
+    width: Int,
+    height: Int,
+    strategy: SaliencyStrategy = SaliencyStrategy.SobelEnergy,
+): ImmutableImage {
+    require(width > 0 && height > 0) { "output dimensions must be positive: width=$width, height=$height" }
+    return smartCrop(AspectRatio(width, height), strategy).scaleTo(width, height)
+}
+
+/**
+ * 코루틴 환경에서 [smartCrop] 을 실행합니다.
+ *
+ * > **주의**: [smartCrop] 과 동일하게 휴리스틱 saliency 입니다 — 얼굴/객체 검출이 아닌
+ * > Sobel 엣지 에너지 기준입니다.
+ *
+ * ## 동작/계약
+ * - `Dispatchers.Default` 컨텍스트에서 [smartCrop] 을 호출합니다.
+ *
+ * ```kotlin
+ * val cropped = image.suspendSmartCrop(AspectRatio.SQUARE)
+ * ```
+ *
+ * @param aspectRatio 결과 영역의 종횡비.
+ * @param strategy saliency 추정 전략. 기본은 [SaliencyStrategy.SobelEnergy].
+ * @return saliency 가 가장 높은 영역을 [aspectRatio] 비율로 잘라낸 새 [ImmutableImage].
+ */
+suspend fun ImmutableImage.suspendSmartCrop(
+    aspectRatio: AspectRatio,
+    strategy: SaliencyStrategy = SaliencyStrategy.SobelEnergy,
+): ImmutableImage = withContext(Dispatchers.Default) { smartCrop(aspectRatio, strategy) }
+
+/**
+ * Sobel 엣지 magnitude (L1 norm) 맵을 계산합니다.
+ *
+ * - Gx kernel: `[[-1,0,1],[-2,0,2],[-1,0,1]]`
+ * - Gy kernel: `[[-1,-2,-1],[0,0,0],[1,2,1]]`
+ * - 결과: `|Gx| + |Gy|` (border 픽셀은 0)
+ */
+private fun computeSobelMagnitude(luma: IntArray, w: Int, h: Int): IntArray {
+    val mag = IntArray(w * h)
+    if (w < 3 || h < 3) {
+        return mag
+    }
+    for (y in 1 until h - 1) {
+        val ym1 = (y - 1) * w
+        val y0 = y * w
+        val yp1 = (y + 1) * w
+        for (x in 1 until w - 1) {
+            val tl = luma[ym1 + (x - 1)]
+            val t = luma[ym1 + x]
+            val tr = luma[ym1 + (x + 1)]
+            val l = luma[y0 + (x - 1)]
+            val r = luma[y0 + (x + 1)]
+            val bl = luma[yp1 + (x - 1)]
+            val bot = luma[yp1 + x]
+            val br = luma[yp1 + (x + 1)]
+
+            val gx = -tl + tr - 2 * l + 2 * r - bl + br
+            val gy = -tl - 2 * t - tr + bl + 2 * bot + br
+            mag[y0 + x] = abs(gx) + abs(gy)
+        }
+    }
+    return mag
+}
+

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/transforms/dsl/ImageFilterChainTransformOps.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/transforms/dsl/ImageFilterChainTransformOps.kt
@@ -1,0 +1,152 @@
+package io.bluetape4k.images.transforms.dsl
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.images.filters.dsl.ImageFilterChain
+import io.bluetape4k.images.transforms.AspectRatio
+import io.bluetape4k.images.transforms.ImagePoint
+import io.bluetape4k.images.transforms.SaliencyStrategy
+import io.bluetape4k.images.transforms.autoCrop
+import io.bluetape4k.images.transforms.clahe
+import io.bluetape4k.images.transforms.flipHorizontal
+import io.bluetape4k.images.transforms.flipVertical
+import io.bluetape4k.images.transforms.perspectiveTransform
+import io.bluetape4k.images.transforms.rotateDegrees
+import io.bluetape4k.images.transforms.smartCrop
+import io.bluetape4k.logging.KotlinLogging
+import io.bluetape4k.logging.warn
+import java.awt.Color
+
+private val log = KotlinLogging.logger {}
+
+private inline fun ImageFilterChain.transformOp(
+    name: String,
+    crossinline block: (ImmutableImage) -> ImmutableImage,
+) {
+    addPixel { image ->
+        try {
+            block(image)
+        } catch (e: Exception) {
+            log.warn(e) { "[$name] failed: ${image.width}×${image.height}" }
+            throw e
+        }
+    }
+}
+
+/**
+ * 이미지의 배경색을 감지하여 불필요한 여백을 자동으로 제거합니다.
+ *
+ * @param tolerance 배경으로 판단하는 RGB 채널별 최대 편차 (0..255, 기본값 10).
+ * @param padding 자른 후 각 방향에 추가할 여백 픽셀 수 (0 이상, 기본값 0).
+ * @param backgroundColor 기준 배경색. `null` 이면 4개 모서리 평균으로 자동 감지.
+ */
+fun ImageFilterChain.autoCrop(
+    tolerance: Int = 10,
+    padding: Int = 0,
+    backgroundColor: Color? = null,
+) {
+    transformOp("autoCrop") { image ->
+        image.autoCrop(tolerance, padding, backgroundColor)
+    }
+}
+
+/**
+ * Saliency 기반으로 중요 영역을 중심으로 지정 종횡비로 잘라냅니다.
+ *
+ * @param aspectRatio 대상 종횡비 (예: [AspectRatio.WIDESCREEN]).
+ * @param strategy saliency 계산 전략 (기본값: [SaliencyStrategy.SobelEnergy]).
+ */
+fun ImageFilterChain.smartCrop(
+    aspectRatio: AspectRatio,
+    strategy: SaliencyStrategy = SaliencyStrategy.SobelEnergy,
+) {
+    transformOp("smartCrop") { image ->
+        image.smartCrop(aspectRatio, strategy)
+    }
+}
+
+/**
+ * 임의 각도로 이미지를 회전합니다. 투명 배경으로 확장된 캔버스를 반환합니다.
+ *
+ * @param angle 회전 각도 (도 단위, 양수 = 시계 방향).
+ * @param background 확장 영역의 배경색 (기본값: 완전 투명).
+ */
+fun ImageFilterChain.rotateDegrees(
+    angle: Double,
+    background: Color = Color(0, 0, 0, 0),
+) {
+    transformOp("rotateDegrees") { image ->
+        image.rotateDegrees(angle, background)
+    }
+}
+
+/**
+ * 이미지를 시계 반대 방향으로 90도 회전합니다 (scrimage `rotateLeft`).
+ */
+fun ImageFilterChain.rotateLeft() {
+    transformOp("rotateLeft") { image ->
+        image.rotateLeft()
+    }
+}
+
+/**
+ * 이미지를 시계 방향으로 90도 회전합니다 (scrimage `rotateRight`).
+ */
+fun ImageFilterChain.rotateRight() {
+    transformOp("rotateRight") { image ->
+        image.rotateRight()
+    }
+}
+
+/**
+ * 이미지를 수평으로 뒤집습니다 (좌우 반전).
+ */
+fun ImageFilterChain.flipHorizontal() {
+    transformOp("flipHorizontal") { image ->
+        image.flipHorizontal()
+    }
+}
+
+/**
+ * 이미지를 수직으로 뒤집습니다 (상하 반전).
+ */
+fun ImageFilterChain.flipVertical() {
+    transformOp("flipVertical") { image ->
+        image.flipVertical()
+    }
+}
+
+/**
+ * 4점 호모그래피를 이용하여 원근 변환을 수행합니다.
+ *
+ * @param sourceCorners 소스 이미지의 4개 꼭짓점 (topLeft, topRight, bottomRight, bottomLeft 순).
+ * @param destinationCorners 출력 이미지의 4개 꼭짓점.
+ * @param outputWidth 출력 이미지 너비 (픽셀).
+ * @param outputHeight 출력 이미지 높이 (픽셀).
+ * @param outsideColor 소스 이미지 외부에 매핑되는 영역의 색상 (기본값: 완전 투명).
+ */
+fun ImageFilterChain.perspectiveTransform(
+    sourceCorners: List<ImagePoint>,
+    destinationCorners: List<ImagePoint>,
+    outputWidth: Int,
+    outputHeight: Int,
+    outsideColor: Color = Color(0, 0, 0, 0),
+) {
+    transformOp("perspectiveTransform") { image ->
+        image.perspectiveTransform(sourceCorners, destinationCorners, outputWidth, outputHeight, outsideColor)
+    }
+}
+
+/**
+ * CLAHE (Contrast Limited Adaptive Histogram Equalization)로 이미지 대비를 향상시킵니다.
+ *
+ * @param tileSize 타일 크기 (픽셀 수, 기본값 8).
+ * @param clipLimit 히스토그램 클리핑 임계값 (기본값 2.0).
+ */
+fun ImageFilterChain.clahe(
+    tileSize: Int = 8,
+    clipLimit: Double = 2.0,
+) {
+    transformOp("clahe") { image ->
+        image.clahe(tileSize, clipLimit)
+    }
+}

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/transforms/internal/RasterUtils.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/transforms/internal/RasterUtils.kt
@@ -1,0 +1,126 @@
+package io.bluetape4k.images.transforms.internal
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.logging.KotlinLogging
+import java.awt.Color
+import java.awt.image.BufferedImage
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 변환 결과 이미지의 최대 픽셀 수.
+ *
+ * 64M pixels (약 256MB ARGB 메모리 사용량) 까지를 안전 한계로 제한합니다.
+ * 변환 입력이 이 값을 초과하면 OOM 위험이 있으므로 호출 측에서 사전 검증해야 합니다.
+ */
+internal const val MAX_OUTPUT_PIXELS: Long = 67_108_864L
+
+/**
+ * [ImmutableImage] 의 내부 [BufferedImage] 를 [BufferedImage.TYPE_INT_ARGB] 형식으로 반환합니다.
+ *
+ * 이미 `TYPE_INT_ARGB` 인 경우 원본을 그대로 반환하고, 그렇지 않으면 새 ARGB 버퍼를 만들어
+ * `Graphics2D` 로 그려서 반환합니다.
+ *
+ * @return ARGB 포맷의 [BufferedImage].
+ */
+internal fun ImmutableImage.toIntArgb(): BufferedImage {
+    val src = awt()
+    if (src.type == BufferedImage.TYPE_INT_ARGB) {
+        return src
+    }
+    val dst = BufferedImage(src.width, src.height, BufferedImage.TYPE_INT_ARGB)
+    val g = dst.createGraphics()
+    try {
+        g.drawImage(src, 0, 0, null)
+    } finally {
+        g.dispose()
+    }
+    return dst
+}
+
+/**
+ * 동일한 너비와 높이를 가진 [BufferedImage.TYPE_INT_ARGB] 사본을 생성합니다.
+ *
+ * 원본 이미지를 보존한 채 픽셀 단위 작업을 수행해야 할 때 사용합니다.
+ *
+ * @return 새로 생성된 ARGB 사본.
+ */
+internal fun BufferedImage.copyArgb(): BufferedImage {
+    val dst = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+    val g = dst.createGraphics()
+    try {
+        g.drawImage(this, 0, 0, null)
+    } finally {
+        g.dispose()
+    }
+    return dst
+}
+
+/**
+ * 이미지 전체를 지정한 [color] 로 채웁니다.
+ *
+ * `Graphics2D.setBackground` + `clearRect` 를 사용하므로 알파 채널을 보존하여
+ * 투명한 색으로 채울 수도 있습니다. 원본을 변경(mutating)하므로 internal 사용에 한정합니다.
+ *
+ * @param color 채울 색상.
+ * @return 같은 [BufferedImage] 인스턴스 (체이닝 용도).
+ */
+internal fun BufferedImage.fillColor(color: Color): BufferedImage {
+    val g = createGraphics()
+    try {
+        g.background = color
+        g.clearRect(0, 0, width, height)
+    } finally {
+        g.dispose()
+    }
+    return this
+}
+
+/**
+ * 이미지 전체 픽셀을 ARGB packed `Int` 배열로 읽어옵니다.
+ *
+ * 길이는 `width * height` 이며, row-major 순서로 저장됩니다.
+ *
+ * @return ARGB 픽셀 배열.
+ */
+internal fun BufferedImage.getArgbPixels(): IntArray =
+    getRGB(0, 0, width, height, IntArray(width * height), 0, width)
+
+/**
+ * ARGB packed `Int` 배열을 이미지 전체 픽셀로 기록합니다.
+ *
+ * 배열 길이는 `width * height` 와 일치해야 하며, row-major 순서를 가정합니다.
+ *
+ * @param pixels 기록할 ARGB 픽셀 배열.
+ * @return 같은 [BufferedImage] 인스턴스 (체이닝 용도).
+ */
+internal fun BufferedImage.setArgbPixels(pixels: IntArray): BufferedImage {
+    setRGB(0, 0, width, height, pixels, 0, width)
+    return this
+}
+
+/**
+ * Alpha/Red/Green/Blue 4채널을 packed ARGB `Int` 로 결합합니다.
+ *
+ * 각 채널은 하위 8비트만 사용하며, 8비트를 초과하는 비트는 잘립니다.
+ *
+ * @param a Alpha 채널 (0..255).
+ * @param r Red 채널 (0..255).
+ * @param g Green 채널 (0..255).
+ * @param b Blue 채널 (0..255).
+ * @return packed ARGB `Int`.
+ */
+internal inline fun argb(a: Int, r: Int, g: Int, b: Int): Int =
+    (a and 0xFF shl 24) or (r and 0xFF shl 16) or (g and 0xFF shl 8) or (b and 0xFF)
+
+/** packed ARGB `Int` 의 alpha 채널(0..255) 을 추출합니다. */
+internal inline fun Int.alphaComponent(): Int = (this ushr 24) and 0xFF
+
+/** packed ARGB `Int` 의 red 채널(0..255) 을 추출합니다. */
+internal inline fun Int.redComponent(): Int = (this ushr 16) and 0xFF
+
+/** packed ARGB `Int` 의 green 채널(0..255) 을 추출합니다. */
+internal inline fun Int.greenComponent(): Int = (this ushr 8) and 0xFF
+
+/** packed ARGB `Int` 의 blue 채널(0..255) 을 추출합니다. */
+internal inline fun Int.blueComponent(): Int = this and 0xFF

--- a/utils/images/src/test/kotlin/io/bluetape4k/images/transforms/AutoCropTest.kt
+++ b/utils/images/src/test/kotlin/io/bluetape4k/images/transforms/AutoCropTest.kt
@@ -1,0 +1,148 @@
+package io.bluetape4k.images.transforms
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.images.AbstractImageTest
+import io.bluetape4k.images.immutableImageOf
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeLessThan
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.awt.Color
+import java.awt.image.BufferedImage
+
+class AutoCropTest : AbstractImageTest() {
+
+    companion object : KLoggingChannel()
+
+    /**
+     * 흰 배경 위에 지정한 색상의 사각형이 그려진 테스트용 이미지를 생성합니다.
+     */
+    private fun createWhitePaddedImage(
+        totalW: Int = 100, totalH: Int = 100,
+        rectX: Int = 10, rectY: Int = 10, rectW: Int = 80, rectH: Int = 80,
+        bgColor: Color = Color.WHITE,
+        fgColor: Color = Color.RED,
+    ): ImmutableImage {
+        val buf = BufferedImage(totalW, totalH, BufferedImage.TYPE_INT_ARGB)
+        val g = buf.createGraphics()
+        try {
+            g.color = bgColor
+            g.fillRect(0, 0, totalW, totalH)
+            g.color = fgColor
+            g.fillRect(rectX, rectY, rectW, rectH)
+        } finally {
+            g.dispose()
+        }
+        return ImmutableImage.wrapAwt(buf)
+    }
+
+    @Test
+    fun `autoCrop removes white padding around red rectangle`() {
+        val image = createWhitePaddedImage(100, 100, 10, 10, 80, 80)
+        val result = image.autoCrop(tolerance = 0, backgroundColor = Color.WHITE)
+
+        result.width shouldBeGreaterOrEqualTo 78
+        result.width shouldBeLessThan 100
+        result.height shouldBeGreaterOrEqualTo 78
+        result.height shouldBeLessThan 100
+    }
+
+    @Test
+    fun `explicit backgroundColor matches corner auto-detection`() {
+        val image = createWhitePaddedImage()
+        val result1 = image.autoCrop(tolerance = 0, backgroundColor = Color.WHITE)
+        val result2 = image.autoCrop(tolerance = 0, backgroundColor = null)
+
+        result1.width shouldBeEqualTo result2.width
+        result1.height shouldBeEqualTo result2.height
+    }
+
+    @Test
+    fun `padding adds border to cropped result`() {
+        val image = createWhitePaddedImage(100, 100, 10, 10, 80, 80)
+        val noPad = image.autoCrop(tolerance = 0, backgroundColor = Color.WHITE)
+        val withPad = image.autoCrop(tolerance = 0, padding = 5, backgroundColor = Color.WHITE)
+
+        // padding=5 adds up to 10 pixels per axis (clamped to original bounds)
+        withPad.width shouldBeGreaterOrEqualTo (noPad.width + 8)
+    }
+
+    @Test
+    fun `solid color image returns original dimensions (silent fallback)`() {
+        val buf = BufferedImage(50, 50, BufferedImage.TYPE_INT_ARGB)
+        val g = buf.createGraphics()
+        try {
+            g.color = Color.WHITE
+            g.fillRect(0, 0, 50, 50)
+        } finally {
+            g.dispose()
+        }
+        val solid = ImmutableImage.wrapAwt(buf)
+        val result = solid.autoCrop(tolerance = 0, backgroundColor = Color.WHITE)
+
+        result.width shouldBeEqualTo solid.width
+        result.height shouldBeEqualTo solid.height
+    }
+
+    @Test
+    fun `tolerance zero vs high tolerance`() {
+        // 이미지: 거의-흰색(245,245,245) 배경 위에 빨간 사각형
+        val buf = BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB)
+        val g = buf.createGraphics()
+        try {
+            g.color = Color(245, 245, 245)  // near-white, not pure white
+            g.fillRect(0, 0, 100, 100)
+            g.color = Color.RED
+            g.fillRect(20, 20, 60, 60)
+        } finally {
+            g.dispose()
+        }
+        val image = ImmutableImage.wrapAwt(buf)
+
+        // tolerance=0 with pure white background — near-white is not removed
+        val nocrop = image.autoCrop(tolerance = 0, backgroundColor = Color.WHITE)
+        nocrop.width shouldBeEqualTo 100
+
+        // tolerance=20 matches near-white → crop occurs
+        val cropped = image.autoCrop(tolerance = 20, backgroundColor = Color.WHITE)
+        cropped.width shouldBeLessThan 100
+    }
+
+    @Test
+    fun `landscape jpg with tolerance=0 returns unchanged dimensions`() {
+        val image = immutableImageOf(getImage(LANDSCAPE_JPG))
+        val result = image.autoCrop(tolerance = 0)
+
+        result.width shouldBeEqualTo image.width
+        result.height shouldBeEqualTo image.height
+    }
+
+    @Test
+    fun `suspendAutoCrop produces same result as autoCrop`() = runTest {
+        val image = createWhitePaddedImage(100, 100, 10, 10, 80, 80)
+        val sync = image.autoCrop(tolerance = 0, backgroundColor = Color.WHITE)
+        val suspended = image.suspendAutoCrop(tolerance = 0, backgroundColor = Color.WHITE)
+
+        suspended.width shouldBeEqualTo sync.width
+        suspended.height shouldBeEqualTo sync.height
+    }
+
+    @Test
+    fun `negative tolerance throws`() {
+        val image = createWhitePaddedImage()
+        assertThrows<IllegalArgumentException> {
+            image.autoCrop(tolerance = -1)
+        }
+    }
+
+    @Test
+    fun `negative padding throws`() {
+        val image = createWhitePaddedImage()
+        assertThrows<IllegalArgumentException> {
+            image.autoCrop(padding = -1)
+        }
+    }
+}

--- a/utils/images/src/test/kotlin/io/bluetape4k/images/transforms/HistogramEqualizationTest.kt
+++ b/utils/images/src/test/kotlin/io/bluetape4k/images/transforms/HistogramEqualizationTest.kt
@@ -128,4 +128,15 @@ class HistogramEqualizationTest {
         resultSuspend.width shouldBeEqualTo resultSync.width
         resultSuspend.height shouldBeEqualTo resultSync.height
     }
+
+    @Test
+    fun `globalEqualize produces 1x1 tile for non-square image`() {
+        // 200×100 비정방형 — tileSize = maxOf(200,100) = 200 → nTilesX=1, nTilesY=1
+        val image = createGradientImage(200, 100)
+        val result = image.globalEqualize()
+
+        result.width shouldBeEqualTo 200
+        result.height shouldBeEqualTo 100
+        // 단일 타일이므로 중앙과 가장자리에서 동일한 LUT가 적용됨 — 결과 이미지 크기만 검증
+    }
 }

--- a/utils/images/src/test/kotlin/io/bluetape4k/images/transforms/HistogramEqualizationTest.kt
+++ b/utils/images/src/test/kotlin/io/bluetape4k/images/transforms/HistogramEqualizationTest.kt
@@ -1,0 +1,131 @@
+package io.bluetape4k.images.transforms
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import java.awt.Color
+import java.awt.image.BufferedImage
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldThrow
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class HistogramEqualizationTest {
+
+    companion object : KLoggingChannel()
+
+    private fun createUniformImage(w: Int, h: Int, r: Int, g: Int, b: Int): ImmutableImage {
+        val buf = BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB)
+        val g2 = buf.createGraphics()
+        try {
+            g2.color = Color(r, g, b)
+            g2.fillRect(0, 0, w, h)
+        } finally {
+            g2.dispose()
+        }
+        return ImmutableImage.wrapAwt(buf)
+    }
+
+    private fun createGradientImage(w: Int = 256, h: Int = 64): ImmutableImage {
+        val buf = BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB)
+        for (x in 0 until w) {
+            val v = x  // 0 to 255
+            for (y in 0 until h) {
+                buf.setRGB(x, y, (0xFF shl 24) or (v shl 16) or (v shl 8) or v)
+            }
+        }
+        return ImmutableImage.wrapAwt(buf)
+    }
+
+    private fun averageLuma(image: ImmutableImage): Double {
+        val pixels = image.awt().let { buf ->
+            val arr = IntArray(buf.width * buf.height)
+            buf.getRGB(0, 0, buf.width, buf.height, arr, 0, buf.width)
+            arr
+        }
+        return pixels.map { argb ->
+            val r = (argb ushr 16) and 0xFF
+            val g = (argb ushr 8) and 0xFF
+            val b = argb and 0xFF
+            0.299 * r + 0.587 * g + 0.114 * b
+        }.average()
+    }
+
+    @Test
+    fun `clahe on uniform dark image keeps same dimensions`() {
+        val dark = createUniformImage(64, 64, 50, 50, 50)
+        val result = dark.clahe()
+
+        result.width shouldBeEqualTo dark.width
+        result.height shouldBeEqualTo dark.height
+        // Uniform image has 0 variance — CLAHE output should differ or stay; just check it doesn't throw
+    }
+
+    @Test
+    fun `clahe increases contrast on gradient image`() {
+        val gradient = createGradientImage(256, 64)
+        val result = gradient.clahe(tileSize = 8, clipLimit = 2.0)
+
+        result.width shouldBeEqualTo 256
+        result.height shouldBeEqualTo 64
+        // No exception should be thrown
+    }
+
+    @Test
+    fun `globalEqualize on gradient has same dimensions`() {
+        val gradient = createGradientImage(256, 64)
+        val result = gradient.globalEqualize()
+
+        result.width shouldBeEqualTo gradient.width
+        result.height shouldBeEqualTo gradient.height
+    }
+
+    @Test
+    fun `tileSize larger than image falls back gracefully (same as globalEqualize)`() {
+        val small = createGradientImage(50, 50)
+        val resultBig = small.clahe(tileSize = 1024)
+        val resultGlobal = small.globalEqualize()
+
+        resultBig.width shouldBeEqualTo resultGlobal.width
+        resultBig.height shouldBeEqualTo resultGlobal.height
+        // Pixel-level comparison optional — both use same fallback path
+    }
+
+    @Test
+    fun `clahe preserves chrominance on red image`() {
+        val red = createUniformImage(64, 64, 200, 30, 30)
+        val result = red.clahe()
+
+        val rgb = result.awt().getRGB(32, 32)
+        val r = (rgb ushr 16) and 0xFF
+        val g = (rgb ushr 8) and 0xFF
+
+        // red channel should dominate — r should be greater than g
+        r shouldBeGreaterThan g
+    }
+
+    @Test
+    fun `tileSize 0 throws`() {
+        assertThrows<IllegalArgumentException> {
+            createUniformImage(64, 64, 128, 128, 128).clahe(tileSize = 0)
+        }
+    }
+
+    @Test
+    fun `clipLimit 0 throws`() {
+        assertThrows<IllegalArgumentException> {
+            createUniformImage(64, 64, 128, 128, 128).clahe(clipLimit = 0.0)
+        }
+    }
+
+    @Test
+    fun `suspendClahe matches clahe dimensions`() = runTest {
+        val gradient = createGradientImage(256, 64)
+        val resultSync = gradient.clahe(tileSize = 8, clipLimit = 2.0)
+        val resultSuspend = gradient.suspendClahe(tileSize = 8, clipLimit = 2.0)
+
+        resultSuspend.width shouldBeEqualTo resultSync.width
+        resultSuspend.height shouldBeEqualTo resultSync.height
+    }
+}

--- a/utils/images/src/test/kotlin/io/bluetape4k/images/transforms/PerspectiveTransformTest.kt
+++ b/utils/images/src/test/kotlin/io/bluetape4k/images/transforms/PerspectiveTransformTest.kt
@@ -1,0 +1,200 @@
+package io.bluetape4k.images.transforms
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.images.AbstractImageTest
+import io.bluetape4k.images.immutableImageOf
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.utils.Resourcex
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeLessThan
+import org.amshove.kluent.shouldThrow
+import org.junit.jupiter.api.Test
+import java.awt.Color
+import java.awt.image.BufferedImage
+
+class PerspectiveTransformTest : AbstractImageTest() {
+
+    companion object : KLoggingChannel()
+
+    /**
+     * 단색으로 채워진 테스트용 [ImmutableImage]를 생성합니다.
+     */
+    private fun createSolidImage(w: Int, h: Int, color: Color): ImmutableImage {
+        val buf = BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB)
+        val g = buf.createGraphics()
+        try {
+            g.color = color
+            g.fillRect(0, 0, w, h)
+        } finally {
+            g.dispose()
+        }
+        return ImmutableImage.wrapAwt(buf)
+    }
+
+    /** packed ARGB int 에서 빨간 채널(0..255)을 추출합니다. */
+    private fun Int.redBits(): Int = (this ushr 16) and 0xFF
+
+    /** packed ARGB int 에서 초록 채널(0..255)을 추출합니다. */
+    private fun Int.greenBits(): Int = (this ushr 8) and 0xFF
+
+    @Test
+    fun `identity mapping returns same dimensions`() {
+        val image = immutableImageOf(Resourcex.getInputStream(CAFE_JPG)!!)
+        val w = image.width
+        val h = image.height
+
+        val srcCorners = listOf(
+            ImagePoint(0.0, 0.0),
+            ImagePoint(w.toDouble(), 0.0),
+            ImagePoint(w.toDouble(), h.toDouble()),
+            ImagePoint(0.0, h.toDouble()),
+        )
+        val dstCorners = listOf(
+            ImagePoint(0.0, 0.0),
+            ImagePoint(w.toDouble(), 0.0),
+            ImagePoint(w.toDouble(), h.toDouble()),
+            ImagePoint(0.0, h.toDouble()),
+        )
+
+        val result = image.perspectiveTransform(srcCorners, dstCorners, w, h)
+
+        result.width shouldBeEqualTo w
+        result.height shouldBeEqualTo h
+    }
+
+    @Test
+    fun `outsideColor fills areas outside source region`() {
+        // 50×50 소스 이미지, 파란색으로 채움
+        val image = createSolidImage(50, 50, Color.BLUE)
+
+        // sourceCorners 가 소스 이미지 경계 바깥(-10,-10)까지 확장 → 출력(0,0) 역매핑이 소스 밖
+        val srcCorners = listOf(
+            ImagePoint(-10.0, -10.0),
+            ImagePoint(60.0, -10.0),
+            ImagePoint(60.0, 60.0),
+            ImagePoint(-10.0, 60.0),
+        )
+        val dstCorners = listOf(
+            ImagePoint(0.0, 0.0),
+            ImagePoint(100.0, 0.0),
+            ImagePoint(100.0, 100.0),
+            ImagePoint(0.0, 100.0),
+        )
+
+        val result = image.perspectiveTransform(srcCorners, dstCorners, 100, 100, outsideColor = Color.RED)
+
+        // 출력(0,0)의 역매핑은 소스(-10,-10) → 소스 범위 밖 → outsideColor(빨간색)
+        val packed = result.awt().getRGB(0, 0)
+        val red = packed.redBits()
+        val green = packed.greenBits()
+
+        red shouldBeGreaterThan 200
+        green shouldBeLessThan 50
+    }
+
+    @Test
+    fun `sourceCorners wrong size throws`() {
+        val image = createSolidImage(100, 100, Color.GRAY)
+        val dst4 = listOf(
+            ImagePoint(0.0, 0.0),
+            ImagePoint(100.0, 0.0),
+            ImagePoint(100.0, 100.0),
+            ImagePoint(0.0, 100.0),
+        )
+        val tooFew = listOf(ImagePoint(0.0, 0.0))
+
+        val block = { image.perspectiveTransform(tooFew, dst4, 100, 100) }
+        block shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `outputWidth zero throws`() {
+        val image = createSolidImage(100, 100, Color.GRAY)
+        val src4 = listOf(
+            ImagePoint(0.0, 0.0),
+            ImagePoint(100.0, 0.0),
+            ImagePoint(100.0, 100.0),
+            ImagePoint(0.0, 100.0),
+        )
+        val dst4 = listOf(
+            ImagePoint(0.0, 0.0),
+            ImagePoint(100.0, 0.0),
+            ImagePoint(100.0, 100.0),
+            ImagePoint(0.0, 100.0),
+        )
+
+        val block = { image.perspectiveTransform(src4, dst4, 0, 100) }
+        block shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `output too large throws`() {
+        val image = createSolidImage(100, 100, Color.GRAY)
+        val src4 = listOf(
+            ImagePoint(0.0, 0.0),
+            ImagePoint(100.0, 0.0),
+            ImagePoint(100.0, 100.0),
+            ImagePoint(0.0, 100.0),
+        )
+        val dst4 = listOf(
+            ImagePoint(0.0, 0.0),
+            ImagePoint(10000.0, 0.0),
+            ImagePoint(10000.0, 10000.0),
+            ImagePoint(0.0, 10000.0),
+        )
+
+        // 10000×10000 = 100M > 64M 한계
+        val block = { image.perspectiveTransform(src4, dst4, 10000, 10000) }
+        block shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `collinear source points throws`() {
+        val image = createSolidImage(100, 100, Color.GRAY)
+
+        // 소스 4개 점이 모두 동일 직선 (y=0) 위에 있음 → 호모그래피 연산 실패
+        val collinearSrc = listOf(
+            ImagePoint(0.0, 0.0),
+            ImagePoint(10.0, 0.0),
+            ImagePoint(20.0, 0.0),
+            ImagePoint(30.0, 0.0),
+        )
+        val dst4 = listOf(
+            ImagePoint(0.0, 0.0),
+            ImagePoint(100.0, 0.0),
+            ImagePoint(100.0, 100.0),
+            ImagePoint(0.0, 100.0),
+        )
+
+        val block = { image.perspectiveTransform(collinearSrc, dst4, 100, 100) }
+        block shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `suspendPerspectiveTransform matches perspectiveTransform dimensions`() = runTest {
+        val image = immutableImageOf(Resourcex.getInputStream(CAFE_JPG)!!)
+        val w = image.width
+        val h = image.height
+
+        val srcCorners = listOf(
+            ImagePoint(0.0, 0.0),
+            ImagePoint(w.toDouble(), 0.0),
+            ImagePoint(w.toDouble(), h.toDouble()),
+            ImagePoint(0.0, h.toDouble()),
+        )
+        val dstCorners = listOf(
+            ImagePoint(0.0, 0.0),
+            ImagePoint(w.toDouble(), 0.0),
+            ImagePoint(w.toDouble(), h.toDouble()),
+            ImagePoint(0.0, h.toDouble()),
+        )
+
+        val syncResult = image.perspectiveTransform(srcCorners, dstCorners, w, h)
+        val suspendResult = image.suspendPerspectiveTransform(srcCorners, dstCorners, w, h)
+
+        suspendResult.width shouldBeEqualTo syncResult.width
+        suspendResult.height shouldBeEqualTo syncResult.height
+    }
+}

--- a/utils/images/src/test/kotlin/io/bluetape4k/images/transforms/RotationTest.kt
+++ b/utils/images/src/test/kotlin/io/bluetape4k/images/transforms/RotationTest.kt
@@ -1,0 +1,122 @@
+package io.bluetape4k.images.transforms
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.images.AbstractImageTest
+import io.bluetape4k.images.immutableImageOf
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeInRange
+import org.junit.jupiter.api.Test
+import java.awt.Color
+
+class RotationTest : AbstractImageTest() {
+
+    companion object : KLoggingChannel()
+
+    private fun loadCafeImage(): ImmutableImage = immutableImageOf(getImage(CAFE_JPG))
+
+    @Test
+    fun `0 degree rotation returns same dimensions`() {
+        val image = loadCafeImage()
+        val result = image.rotateDegrees(0.0)
+
+        result.width shouldBeEqualTo image.width
+        result.height shouldBeEqualTo image.height
+    }
+
+    @Test
+    fun `90 degree rotation equals rotateRight`() {
+        val image = loadCafeImage()
+        val rotated = image.rotateDegrees(90.0)
+        val expected = image.rotateRight()
+
+        rotated.width shouldBeEqualTo expected.width
+        rotated.height shouldBeEqualTo expected.height
+    }
+
+    @Test
+    fun `-90 degree equals rotateLeft`() {
+        val image = loadCafeImage()
+        val rotated = image.rotateDegrees(-90.0)
+        val expected = image.rotateLeft()
+
+        rotated.width shouldBeEqualTo expected.width
+        rotated.height shouldBeEqualTo expected.height
+    }
+
+    @Test
+    fun `15 degree rotation expands bounds`() {
+        val image = loadCafeImage()
+        val r = Math.toRadians(15.0)
+        val expectedW = Math.ceil(image.width * Math.cos(r) + image.height * Math.sin(r)).toInt()
+        val expectedH = Math.ceil(image.width * Math.sin(r) + image.height * Math.cos(r)).toInt()
+        val result = image.rotateDegrees(15.0)
+
+        result.width shouldBeInRange (expectedW - 2)..(expectedW + 2)
+        result.height shouldBeInRange (expectedH - 2)..(expectedH + 2)
+    }
+
+    @Test
+    fun `45 degree with white background has white corner`() {
+        val image = loadCafeImage()
+        val result = image.rotateDegrees(45.0, background = Color.WHITE)
+
+        // corner pixel (0,0) should be white (red channel > 200)
+        val cornerRgb = result.awt().getRGB(0, 0)
+        val red = (cornerRgb ushr 16) and 0xFF
+        red shouldBeGreaterThan 200
+    }
+
+    @Test
+    fun `double flipHorizontal returns original dimensions`() {
+        val image = loadCafeImage()
+        val result = image.flipHorizontal().flipHorizontal()
+
+        result.width shouldBeEqualTo image.width
+        result.height shouldBeEqualTo image.height
+    }
+
+    @Test
+    fun `double flipVertical returns original dimensions`() {
+        val image = loadCafeImage()
+        val result = image.flipVertical().flipVertical()
+
+        result.width shouldBeEqualTo image.width
+        result.height shouldBeEqualTo image.height
+    }
+
+    @Test
+    fun `180 degree twice returns original dimensions`() {
+        val image = loadCafeImage()
+        val twice = image.rotateDegrees(180.0).rotateDegrees(180.0)
+
+        twice.width shouldBeInRange (image.width - 2)..(image.width + 2)
+        twice.height shouldBeInRange (image.height - 2)..(image.height + 2)
+
+        // center pixel check: should be close to original center pixel (tolerance 5 per channel)
+        val cx = image.width / 2
+        val cy = image.height / 2
+        val origRgb = image.awt().getRGB(cx, cy)
+        val twiceRgb = twice.awt().getRGB(cx, cy)
+
+        val dr = kotlin.math.abs(((origRgb ushr 16) and 0xFF) - ((twiceRgb ushr 16) and 0xFF))
+        val dg = kotlin.math.abs(((origRgb ushr 8) and 0xFF) - ((twiceRgb ushr 8) and 0xFF))
+        val db = kotlin.math.abs((origRgb and 0xFF) - (twiceRgb and 0xFF))
+
+        dr shouldBeInRange 0..5
+        dg shouldBeInRange 0..5
+        db shouldBeInRange 0..5
+    }
+
+    @Test
+    fun `suspendRotateDegrees produces same dimensions as rotateDegrees`() = runTest {
+        val image = loadCafeImage()
+        val sync = image.rotateDegrees(30.0)
+        val suspended = image.suspendRotateDegrees(30.0)
+
+        suspended.width shouldBeEqualTo sync.width
+        suspended.height shouldBeEqualTo sync.height
+    }
+}

--- a/utils/images/src/test/kotlin/io/bluetape4k/images/transforms/SmartCropTest.kt
+++ b/utils/images/src/test/kotlin/io/bluetape4k/images/transforms/SmartCropTest.kt
@@ -1,0 +1,128 @@
+package io.bluetape4k.images.transforms
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.images.AbstractImageTest
+import io.bluetape4k.images.immutableImageOf
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.utils.Resourcex
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeInRange
+import org.amshove.kluent.shouldThrow
+import org.junit.jupiter.api.Test
+import java.awt.Color
+import java.awt.image.BufferedImage
+
+class SmartCropTest : AbstractImageTest() {
+
+    companion object : KLoggingChannel()
+
+    /**
+     * 왼쪽 절반은 체커보드(흑백 10px 격자), 오른쪽 절반은 단색 라이트그레이인 이미지를 생성합니다.
+     *
+     * SmartCrop 이 체커보드(엣지 에너지 높음) 쪽을 선택하는지 검증하는 데 사용합니다.
+     */
+    private fun createCheckerboardLeftSolidRight(w: Int = 200, h: Int = 100): ImmutableImage {
+        val buf = BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB)
+        val g = buf.createGraphics()
+        try {
+            // 왼쪽 절반: 10px 체커보드 (흑백 교차)
+            for (y in 0 until h) {
+                for (x in 0 until w / 2) {
+                    g.color = if ((x / 10 + y / 10) % 2 == 0) Color.BLACK else Color.WHITE
+                    g.fillRect(x, y, 1, 1)
+                }
+            }
+            // 오른쪽 절반: 단색 라이트그레이
+            g.color = Color.LIGHT_GRAY
+            g.fillRect(w / 2, 0, w / 2, h)
+        } finally {
+            g.dispose()
+        }
+        return ImmutableImage.wrapAwt(buf)
+    }
+
+    @Test
+    fun `smartCrop SQUARE selects content-rich region`() {
+        val image = createCheckerboardLeftSolidRight(200, 100)
+
+        val result = image.smartCrop(AspectRatio.SQUARE)
+
+        // 결과가 대략 정사각형인지 확인 (±25% 허용)
+        val ratio = result.width.toDouble() / result.height
+        ratio shouldBeInRange (0.8..1.25)
+        result.width shouldBeGreaterThan 0
+        result.height shouldBeGreaterThan 0
+    }
+
+    @Test
+    fun `smartCrop WIDESCREEN aspect ratio is correct`() {
+        val image = immutableImageOf(Resourcex.getInputStream(LANDSCAPE_JPG)!!)
+
+        val result = image.smartCrop(AspectRatio.WIDESCREEN)
+
+        // 16:9 ≈ 1.778, 허용 범위 1.6..1.9
+        val ratio = result.width.toDouble() / result.height
+        ratio shouldBeInRange (1.6..1.9)
+    }
+
+    @Test
+    fun `smartCrop PORTRAIT aspect ratio`() {
+        val image = immutableImageOf(Resourcex.getInputStream(LANDSCAPE_JPG)!!)
+
+        val result = image.smartCrop(AspectRatio.PORTRAIT)
+
+        // 9:16 세로형이므로 높이/너비 ≈ 1.778, 허용 범위 1.6..1.9
+        val ratio = result.height.toDouble() / result.width
+        ratio shouldBeInRange (1.6..1.9)
+    }
+
+    @Test
+    fun `smartCropTo returns exact dimensions`() {
+        val image = immutableImageOf(Resourcex.getInputStream(LANDSCAPE_JPG)!!)
+
+        val result = image.smartCropTo(320, 240)
+
+        result.width shouldBeEqualTo 320
+        result.height shouldBeEqualTo 240
+    }
+
+    @Test
+    fun `smartCrop on solid white image does not throw`() {
+        val buf = BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB)
+        val g = buf.createGraphics()
+        try {
+            g.color = Color.WHITE
+            g.fillRect(0, 0, 100, 100)
+        } finally {
+            g.dispose()
+        }
+        val white = ImmutableImage.wrapAwt(buf)
+
+        val result = white.smartCrop(AspectRatio.SQUARE)
+
+        result.width shouldBeGreaterThan 0
+        result.height shouldBeGreaterThan 0
+    }
+
+    @Test
+    fun `invalid AspectRatio throws`() {
+        val throwOnZeroWidth = { AspectRatio(0, 1) }
+        val throwOnNegativeHeight = { AspectRatio(1, -1) }
+
+        throwOnZeroWidth shouldThrow IllegalArgumentException::class
+        throwOnNegativeHeight shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `suspendSmartCrop matches smartCrop dimensions`() = runTest {
+        val image = immutableImageOf(Resourcex.getInputStream(LANDSCAPE_JPG)!!)
+
+        val syncResult = image.smartCrop(AspectRatio.WIDESCREEN)
+        val suspendResult = image.suspendSmartCrop(AspectRatio.WIDESCREEN)
+
+        suspendResult.width shouldBeEqualTo syncResult.width
+        suspendResult.height shouldBeEqualTo syncResult.height
+    }
+}

--- a/utils/images/src/test/kotlin/io/bluetape4k/images/transforms/dsl/ImageFilterChainTransformOpsTest.kt
+++ b/utils/images/src/test/kotlin/io/bluetape4k/images/transforms/dsl/ImageFilterChainTransformOpsTest.kt
@@ -188,9 +188,11 @@ class ImageFilterChainTransformOpsTest : AbstractImageTest() {
     @Test
     fun `transformOp logs warning when op throws exception`() {
         // logback ListAppender로 warn 로그 캡처
+        // KLoggerNameResolver: "Kt$..." → substringBefore("Kt$") → no "Kt" suffix
         val logger = LoggerFactory.getLogger(
-            "io.bluetape4k.images.transforms.dsl.ImageFilterChainTransformOpsKt"
+            "io.bluetape4k.images.transforms.dsl.ImageFilterChainTransformOps"
         ) as Logger
+        logger.level = Level.WARN
         val listAppender = ListAppender<ILoggingEvent>()
         listAppender.start()
         logger.addAppender(listAppender)
@@ -201,17 +203,17 @@ class ImageFilterChainTransformOpsTest : AbstractImageTest() {
                 // tolerance 범위 초과 → autoCrop require() → IllegalArgumentException
                 autoCrop(tolerance = -1)
             }
-        } catch (_: IllegalArgumentException) {
-            // 예외가 전파되어야 함
+            throw AssertionError("Expected IllegalArgumentException to be rethrown by transformOp")
+        } catch (e: IllegalArgumentException) {
+            // 예외가 전파되어야 함 — 정상
+        } finally {
+            logger.detachAppender(listAppender)
         }
 
-        logger.detachAppender(listAppender)
-
         val warnLogs = listAppender.list.filter { it.level == Level.WARN }
-        warnLogs.any { it.message.contains("[autoCrop]") || it.formattedMessage.contains("[autoCrop]") }
-            .let { found ->
-                // transformOp이 warn 로그를 남겼거나, 예외가 전파됐으면 OK
-                // (warn 로그가 없어도 예외 전파가 올바른 동작)
-            }
+        warnLogs.shouldNotBeNull()
+        warnLogs.size shouldBeGreaterThan 0
+        val hasAutoCropWarn = warnLogs.any { it.formattedMessage.contains("[autoCrop]") }
+        hasAutoCropWarn shouldBeEqualTo true
     }
 }

--- a/utils/images/src/test/kotlin/io/bluetape4k/images/transforms/dsl/ImageFilterChainTransformOpsTest.kt
+++ b/utils/images/src/test/kotlin/io/bluetape4k/images/transforms/dsl/ImageFilterChainTransformOpsTest.kt
@@ -1,0 +1,217 @@
+package io.bluetape4k.images.transforms.dsl
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.images.AbstractImageTest
+import io.bluetape4k.images.filters.dsl.applyFilters
+import io.bluetape4k.images.filters.dsl.suspendApplyFilters
+import io.bluetape4k.images.transforms.AspectRatio
+import io.bluetape4k.images.transforms.ImagePoint
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeLessThan
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import java.awt.Color
+import java.awt.image.BufferedImage
+
+class ImageFilterChainTransformOpsTest : AbstractImageTest() {
+
+    companion object : KLoggingChannel()
+
+    private fun createSolidImage(w: Int = 100, h: Int = 100, color: Color = Color.BLUE): ImmutableImage {
+        val buf = BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB)
+        val g = buf.createGraphics()
+        try {
+            g.color = color
+            g.fillRect(0, 0, w, h)
+        } finally {
+            g.dispose()
+        }
+        return ImmutableImage.wrapAwt(buf)
+    }
+
+    private fun createWhitePaddedImage(
+        totalW: Int = 100, totalH: Int = 100,
+        rectX: Int = 10, rectY: Int = 10, rectW: Int = 80, rectH: Int = 80,
+    ): ImmutableImage {
+        val buf = BufferedImage(totalW, totalH, BufferedImage.TYPE_INT_ARGB)
+        val g = buf.createGraphics()
+        try {
+            g.color = Color.WHITE
+            g.fillRect(0, 0, totalW, totalH)
+            g.color = Color.RED
+            g.fillRect(rectX, rectY, rectW, rectH)
+        } finally {
+            g.dispose()
+        }
+        return ImmutableImage.wrapAwt(buf)
+    }
+
+    @Test
+    fun `autoCrop DSL op removes white margin`() {
+        val image = createWhitePaddedImage(100, 100, 10, 10, 80, 80)
+        val result = image.applyFilters {
+            autoCrop(tolerance = 0, backgroundColor = Color.WHITE)
+        }
+        result.shouldNotBeNull()
+        result.width shouldBeLessThan 100
+        result.height shouldBeLessThan 100
+    }
+
+    @Test
+    fun `smartCrop DSL op produces target aspect ratio`() {
+        val image = createSolidImage(200, 200)
+        val ratio = AspectRatio.WIDESCREEN
+        val result = image.applyFilters {
+            smartCrop(ratio)
+        }
+        result.shouldNotBeNull()
+        result.width shouldBeGreaterThan 0
+        result.height shouldBeGreaterThan 0
+    }
+
+    @Test
+    fun `rotateDegrees DSL op returns non-null image`() {
+        val image = createSolidImage(60, 60)
+        val result = image.applyFilters {
+            rotateDegrees(45.0)
+        }
+        result.shouldNotBeNull()
+        result.width shouldBeGreaterThan 0
+    }
+
+    @Test
+    fun `rotateLeft DSL op swaps width and height`() {
+        val image = createSolidImage(80, 60)
+        val result = image.applyFilters {
+            rotateLeft()
+        }
+        result.shouldNotBeNull()
+        result.width shouldBeEqualTo 60
+        result.height shouldBeEqualTo 80
+    }
+
+    @Test
+    fun `rotateRight DSL op swaps width and height`() {
+        val image = createSolidImage(80, 60)
+        val result = image.applyFilters {
+            rotateRight()
+        }
+        result.shouldNotBeNull()
+        result.width shouldBeEqualTo 60
+        result.height shouldBeEqualTo 80
+    }
+
+    @Test
+    fun `flipHorizontal DSL op preserves dimensions`() {
+        val image = createSolidImage(80, 60)
+        val result = image.applyFilters {
+            flipHorizontal()
+        }
+        result.shouldNotBeNull()
+        result.width shouldBeEqualTo 80
+        result.height shouldBeEqualTo 60
+    }
+
+    @Test
+    fun `flipVertical DSL op preserves dimensions`() {
+        val image = createSolidImage(80, 60)
+        val result = image.applyFilters {
+            flipVertical()
+        }
+        result.shouldNotBeNull()
+        result.width shouldBeEqualTo 80
+        result.height shouldBeEqualTo 60
+    }
+
+    @Test
+    fun `perspectiveTransform DSL op produces requested output size`() {
+        val image = createSolidImage(100, 100)
+        val src = listOf(
+            ImagePoint(0.0, 0.0), ImagePoint(99.0, 0.0),
+            ImagePoint(99.0, 99.0), ImagePoint(0.0, 99.0),
+        )
+        val dst = listOf(
+            ImagePoint(5.0, 5.0), ImagePoint(94.0, 5.0),
+            ImagePoint(94.0, 94.0), ImagePoint(5.0, 94.0),
+        )
+        val result = image.applyFilters {
+            perspectiveTransform(src, dst, 80, 80)
+        }
+        result.shouldNotBeNull()
+        result.width shouldBeEqualTo 80
+        result.height shouldBeEqualTo 80
+    }
+
+    @Test
+    fun `clahe DSL op preserves dimensions`() {
+        val image = createSolidImage(100, 100, Color.RED)
+        val result = image.applyFilters {
+            clahe(tileSize = 8, clipLimit = 2.0)
+        }
+        result.shouldNotBeNull()
+        result.width shouldBeEqualTo 100
+        result.height shouldBeEqualTo 100
+    }
+
+    @Test
+    fun `chained DSL ops all apply sequentially`() {
+        val image = createSolidImage(100, 100)
+        val result = image.applyFilters {
+            autoCrop(backgroundColor = Color(0, 0, 255))
+            rotateLeft()
+            flipHorizontal()
+            clahe()
+        }
+        result.shouldNotBeNull()
+        result.width shouldBeGreaterThan 0
+        result.height shouldBeGreaterThan 0
+    }
+
+    @Test
+    fun `suspendApplyFilters DSL executes on coroutine dispatcher`() = runTest {
+        val image = createSolidImage(80, 60)
+        val result = image.suspendApplyFilters {
+            rotateDegrees(90.0)
+        }
+        result.shouldNotBeNull()
+        result.width shouldBeGreaterThan 0
+    }
+
+    @Test
+    fun `transformOp logs warning when op throws exception`() {
+        // logback ListAppender로 warn 로그 캡처
+        val logger = LoggerFactory.getLogger(
+            "io.bluetape4k.images.transforms.dsl.ImageFilterChainTransformOpsKt"
+        ) as Logger
+        val listAppender = ListAppender<ILoggingEvent>()
+        listAppender.start()
+        logger.addAppender(listAppender)
+
+        val image = createSolidImage(50, 50)
+        try {
+            image.applyFilters {
+                // tolerance 범위 초과 → autoCrop require() → IllegalArgumentException
+                autoCrop(tolerance = -1)
+            }
+        } catch (_: IllegalArgumentException) {
+            // 예외가 전파되어야 함
+        }
+
+        logger.detachAppender(listAppender)
+
+        val warnLogs = listAppender.list.filter { it.level == Level.WARN }
+        warnLogs.any { it.message.contains("[autoCrop]") || it.formattedMessage.contains("[autoCrop]") }
+            .let { found ->
+                // transformOp이 warn 로그를 남겼거나, 예외가 전파됐으면 OK
+                // (warn 로그가 없어도 예외 전파가 올바른 동작)
+            }
+    }
+}


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: feat: Issue #132 — utils/images 변환 API (AutoCrop/SmartCrop/Rotation/Perspective/CLAHE)

Issue #132 에서 요청한 이미지 변환 API를 `utils/images` 모듈에 구현합니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 신규 소스 파일

| 파일 | 내용 |
|------|------|
| `transforms/internal/RasterUtils.kt` | ARGB 픽셀 유틸리티 (변환/복사/컴포넌트 추출) |
| `transforms/AutoCrop.kt` | 배경 자동 감지 여백 제거 |
| `transforms/Rotation.kt` | 임의 각도 회전 + flipHorizontal/flipVertical |
| `transforms/SmartCrop.kt` | Sobel 에너지 saliency 기반 크롭 (AspectRatio, SaliencyStrategy) |
| `transforms/PerspectiveTransform.kt` | 4점 호모그래피 원근 변환 (Gauss-Jordan 8×8 solver) |
| `transforms/HistogramEqualization.kt` | CLAHE (YCbCr BT.601 + 타일 이중선형 보간) |
| `transforms/dsl/ImageFilterChainTransformOps.kt` | `applyFilters {}` DSL 통합 (9개 ops) |

### 신규 테스트 파일

| 파일 | 테스트 수 |
|------|-----------|
| `AutoCropTest.kt` | 9 |
| `RotationTest.kt` | 9 |
| `SmartCropTest.kt` | 7 |
| `PerspectiveTransformTest.kt` | 7 |
| `HistogramEqualizationTest.kt` | 9 |
| `dsl/ImageFilterChainTransformOpsTest.kt` | 12 |
| **합계** | **53** |

### README 업데이트

- `README.md` / `README.ko.md`: Image Transforms 섹션 + Mermaid 다이어그램 추가

### 기존 섹션: 구현 세부 사항

- **AutoCrop**: 4 모서리 평균으로 배경색 자동 감지, tolerance/padding/backgroundColor 지원
- **SmartCrop**: 256px 다운샘플 → luma → Sobel L1 → 적분 이미지 O(1) 슬라이딩 윈도우
- **Rotation**: 90도 단위는 scrimage 네이티브 위임, 임의 각도는 AffineTransform + BICUBIC
- **PerspectiveTransform**: Gauss-Jordan partial pivoting 8×8 solver, 4-tap 이중선형 보간, 64M 픽셀 guard
- **CLAHE**: BT.601 YCbCr 변환, 타일 히스토그램 클리핑, 이중선형 타일 보간
- **DSL**: 모든 ops가 `transformOp` 헬퍼를 통해 예외 로깅 + 재전파

### 기존 섹션: 코드 리뷰 결과

oh-my-claudecode:code-reviewer 실행 결과:
- **CRITICAL**: 0
- **HIGH**: 2 → 모두 수정 완료
  - `globalEqualize()` 비정방형 이미지 단일 타일 보장 (effectiveTileSize fallback 수정)
  - DSL warn 로그 테스트 assertion 강화 (실제 검증 추가)
- **MEDIUM**: 3 (선택적 — 이번 PR 범위 외)
- **LOW**: 4 (선택적)

### 기존 섹션: 검증 명령

```bash
./gradlew :bluetape4k-images:test
# 242 passing (8 pending) — 45s
```

## Validation

```
./gradlew :bluetape4k-images:test

242 passing (8 pending) — 45s
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #132, milestone `없음`, assignee debop
- PR: #172, head `c35cb34e53cd835c3f5bab2f542a2f2398635122`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/issue-132-images-transform`
- Labels: `enhancement`
- State: `MERGED`, merge commit `660d16da7399ffb0c31232cfb212d0e803b2ad5c`
- CI: ./gradlew :bluetape4k-images:test
## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #172 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `660d16da7399ffb0c31232cfb212d0e803b2ad5c`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
