### PR TITLE
test: bluetape4k-pulsar DSL lifecycle 테스트 추가 및 문서 개선

### DIFF
--- a/infra/pulsar/README.ko.md
+++ b/infra/pulsar/README.ko.md
@@ -95,7 +95,7 @@ dependencies {
 ```kotlin
 withPulsarClient("pulsar://localhost:6650") {
     // PulsarClient가 this로 제공됨
-    withProducer(Schema.STRING) { topic("orders") } {
+    withProducer(Schema.STRING, { topic("orders") }) {
         sendSuspend("order-1")
     }
 }

--- a/infra/pulsar/README.md
+++ b/infra/pulsar/README.md
@@ -95,7 +95,7 @@ dependencies {
 ```kotlin
 withPulsarClient("pulsar://localhost:6650") {
     // PulsarClient available as `this`
-    withProducer(Schema.STRING) { topic("orders") } {
+    withProducer(Schema.STRING, { topic("orders") }) {
         sendSuspend("order-1")
     }
 }

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/consumer/ConsumerExtensions.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/consumer/ConsumerExtensions.kt
@@ -71,6 +71,12 @@ suspend fun <T> Consumer<T>.acknowledgeSuspend(message: Message<T>) {
  * **주의**: Exclusive/Failover subscription에서만 유효합니다.
  * Shared subscription에서 호출하면 [org.apache.pulsar.client.api.PulsarClientException]이 발생합니다.
  *
+ * ```kotlin
+ * val msgs = (1..10).map { consumer.receiveSuspend() }
+ * // 마지막 메시지 ID까지 일괄 ack — 이전 메시지 모두 포함
+ * consumer.acknowledgeCumulativeSuspend(msgs.last())
+ * ```
+ *
  * @param message 누적 ack 기준 메시지
  * @throws org.apache.pulsar.client.api.PulsarClientException Shared 구독에서 호출 시, 또는 ack 전송 실패 시
  */

--- a/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/PulsarClientSupportTest.kt
+++ b/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/PulsarClientSupportTest.kt
@@ -1,0 +1,54 @@
+package io.bluetape4k.pulsar
+
+import io.bluetape4k.logging.KLogging
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.pulsar.client.api.Schema
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.time.Duration.Companion.seconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PulsarClientSupportTest : AbstractPulsarTest() {
+
+    companion object : KLogging()
+
+    @Test
+    fun `pulsarClient - serviceUrl로 클라이언트 생성`() {
+        val client = pulsarClient(pulsar.url)
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `pulsarClient - setup 블록으로 클라이언트 생성`() {
+        val url = pulsar.url
+        val client = pulsarClient { serviceUrl(url) }
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `withPulsarClient - 블록 실행 후 자동 close`() = runTest(timeout = 30.seconds) {
+        var clientRef: org.apache.pulsar.client.api.PulsarClient? = null
+        withPulsarClient(pulsar.url) {
+            clientRef = this
+            shouldNotBeNull()
+        }
+        // close 후 재사용 시 예외 발생 — 단순히 close 됐는지 확인 가능하지 않으므로
+        // 블록 내에서 정상 실행됐음을 확인
+        clientRef.shouldNotBeNull()
+    }
+
+    @Test
+    fun `withPulsarClient - setup-only 오버로드`() = runTest(timeout = 30.seconds) {
+        val url = pulsar.url
+        withPulsarClient({ serviceUrl(url) }) {
+            shouldNotBeNull()
+            // 생성된 클라이언트로 간단한 동작 검증
+            val producer = newProducer(Schema.STRING).topic(newTopic()).create()
+            producer.shouldNotBeNull()
+            producer.close()
+        }
+    }
+}

--- a/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/consumer/ConsumerSupportTest.kt
+++ b/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/consumer/ConsumerSupportTest.kt
@@ -1,0 +1,91 @@
+package io.bluetape4k.pulsar.consumer
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.pulsar.AbstractPulsarTest
+import io.bluetape4k.pulsar.producer.sendSuspend
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.pulsar.client.api.Schema
+import org.apache.pulsar.client.api.SubscriptionType
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.time.Duration.Companion.seconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ConsumerSupportTest : AbstractPulsarTest() {
+
+    companion object : KLogging()
+
+    @Test
+    fun `consumer DSL - Schema와 setup으로 Consumer 생성`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+        try {
+            val consumer = client.consumer(Schema.STRING) {
+                topic(topic)
+                subscriptionName(newSubscription())
+                subscriptionType(SubscriptionType.Exclusive)
+            }
+            consumer.shouldNotBeNull()
+            consumer.close()
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `withConsumer - 블록 실행 후 자동 close`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+        val sub = newSubscription()
+
+        // Consumer 먼저 구독 → 이후 메시지 발행
+        client.withConsumer(Schema.STRING, {
+            topic(topic)
+            subscriptionName(sub)
+            subscriptionType(SubscriptionType.Exclusive)
+        }) {
+            shouldNotBeNull()
+            // Consumer 생성 후 메시지 발행
+            launch {
+                val producer = client.newProducer(Schema.STRING).topic(topic).create()
+                producer.sendSuspend("withConsumer test")
+                producer.close()
+            }
+            val msg = receiveSuspend()
+            msg.value shouldBeEqualTo "withConsumer test"
+            acknowledgeSuspend(msg)
+        }
+        client.close()
+    }
+
+    @Test
+    fun `withConsumer - 복수 메시지 처리`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+        val sub = newSubscription()
+
+        val received = mutableListOf<String>()
+        client.withConsumer(Schema.STRING, {
+            topic(topic)
+            subscriptionName(sub)
+        }) {
+            // Consumer 생성 후 메시지 발행
+            launch {
+                val producer = client.newProducer(Schema.STRING).topic(topic).create()
+                repeat(3) { i -> producer.sendSuspend("msg-$i") }
+                producer.close()
+            }
+            repeat(3) {
+                val msg = receiveSuspend()
+                received.add(msg.value)
+                acknowledgeSuspend(msg)
+            }
+        }
+        client.close()
+
+        received.forEachIndexed { i, v -> v shouldBeEqualTo "msg-$i" }
+    }
+}

--- a/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/producer/ProducerSupportTest.kt
+++ b/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/producer/ProducerSupportTest.kt
@@ -1,0 +1,85 @@
+package io.bluetape4k.pulsar.producer
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.pulsar.AbstractPulsarTest
+import io.bluetape4k.pulsar.consumer.receiveSuspend
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.pulsar.client.api.CompressionType
+import org.apache.pulsar.client.api.Schema
+import org.apache.pulsar.client.api.SubscriptionType
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.time.Duration.Companion.seconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ProducerSupportTest : AbstractPulsarTest() {
+
+    companion object : KLogging()
+
+    @Test
+    fun `producer DSL - Schema와 setup으로 Producer 생성`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+        try {
+            val producer = client.producer(Schema.STRING) {
+                topic(topic)
+                producerName("test-producer")
+            }
+            producer.shouldNotBeNull()
+            producer.close()
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `withProducer - 블록 실행 후 자동 close`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+
+        // Consumer 먼저 구독 → withProducer로 발행
+        val consumer = client.newConsumer(Schema.STRING)
+            .topic(topic)
+            .subscriptionName(newSubscription())
+            .subscriptionType(SubscriptionType.Exclusive)
+            .subscribe()
+        try {
+            client.withProducer(Schema.STRING, { topic(topic) }) {
+                shouldNotBeNull()
+                val msgId = sendSuspend("withProducer test")
+                msgId.shouldNotBeNull()
+            }
+            val msg = consumer.receiveSuspend()
+            msg.value shouldBeEqualTo "withProducer test"
+        } finally {
+            consumer.close()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `withProducer - compressionType 설정 동작`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+
+        val consumer = client.newConsumer(Schema.STRING)
+            .topic(topic)
+            .subscriptionName(newSubscription())
+            .subscribe()
+        try {
+            client.withProducer(Schema.STRING, {
+                topic(topic)
+                compressionType(CompressionType.LZ4)
+            }) {
+                sendSuspend("compressed")
+            }
+            val msg = consumer.receiveSuspend()
+            msg.value shouldBeEqualTo "compressed"
+        } finally {
+            consumer.close()
+            client.close()
+        }
+    }
+}

--- a/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/reader/ReaderSupportTest.kt
+++ b/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/reader/ReaderSupportTest.kt
@@ -1,0 +1,84 @@
+package io.bluetape4k.pulsar.reader
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.pulsar.AbstractPulsarTest
+import io.bluetape4k.pulsar.producer.sendSuspend
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.pulsar.client.api.MessageId
+import org.apache.pulsar.client.api.Schema
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.time.Duration.Companion.seconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ReaderSupportTest : AbstractPulsarTest() {
+
+    companion object : KLogging()
+
+    @Test
+    fun `reader DSL - Schema와 setup으로 Reader 생성`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+        try {
+            val reader = client.reader(Schema.STRING) {
+                topic(topic)
+                startMessageId(MessageId.earliest)
+            }
+            reader.shouldNotBeNull()
+            reader.close()
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `withReader - 블록 실행 후 자동 close`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+
+        // 메시지 발행 후 Reader로 earliest부터 읽기
+        val producer = client.newProducer(Schema.STRING).topic(topic).create()
+        try {
+            producer.sendSuspend("withReader test")
+        } finally {
+            producer.close()
+        }
+
+        client.withReader(Schema.STRING, {
+            topic(topic)
+            startMessageId(MessageId.earliest)
+        }) {
+            shouldNotBeNull()
+            val msg = readNextSuspend()
+            msg.value shouldBeEqualTo "withReader test"
+        }
+        client.close()
+    }
+
+    @Test
+    fun `withReader - earliest부터 모든 메시지 읽기`() = runTest(timeout = 30.seconds) {
+        val client = newClient()
+        val topic = newTopic()
+        val messageCount = 3
+
+        val producer = client.newProducer(Schema.STRING).topic(topic).create()
+        try {
+            repeat(messageCount) { i -> producer.sendSuspend("r-msg-$i") }
+        } finally {
+            producer.close()
+        }
+
+        client.withReader(Schema.STRING, {
+            topic(topic)
+            startMessageId(MessageId.earliest)
+        }) {
+            repeat(messageCount) { i ->
+                val msg = readNextSuspend()
+                msg.value shouldBeEqualTo "r-msg-$i"
+            }
+        }
+        client.close()
+    }
+}


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: test: bluetape4k-pulsar DSL lifecycle 테스트 추가 및 문서 개선

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 변경 요약

### 버그 수정
- `README.md` / `README.ko.md`: `withProducer` 예제의 잘못된 구문 수정
  - `withProducer(Schema.STRING) { topic("orders") } {}` → `withProducer(Schema.STRING, { topic("orders") }) {}`

### KDoc 개선
- `ConsumerExtensions.kt`: `acknowledgeCumulativeSuspend` KDoc에 코드 예제 추가

### 누락 테스트 추가 (13건 신규)

| 파일 | 테스트 수 | 검증 대상 |
|------|----------|----------|
| `PulsarClientSupportTest` | 4 | `pulsarClient()`, `withPulsarClient()` (serviceUrl·setup-only 오버로드) |
| `ConsumerSupportTest` | 3 | `consumer()` DSL, `withConsumer()` 생명주기 자동 close |
| `ProducerSupportTest` | 3 | `producer()` DSL, `withProducer()` 생명주기·compressionType |
| `ReaderSupportTest` | 3 | `reader()` DSL, `withReader()` 생명주기·earliest 읽기 |

### 기존 섹션: 검증 명령

```bash
./gradlew :bluetape4k-pulsar:test
```

## Validation

```
./gradlew :bluetape4k-pulsar:test
33 passing (1m 4s) — BUILD SUCCESSFUL
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #173, head `9453e4d59c01a642cc2ac535a9eee110fd1d839f`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `claude/eloquent-goldberg-40c7d8`
- Labels: `test`
- State: `MERGED`, merge commit `e34a62f74826ccee66f218b99ad6371160c84542`
- CI: ./gradlew :bluetape4k-pulsar:test

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #173 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e34a62f74826ccee66f218b99ad6371160c84542`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
