### PR TITLE
fix: CI nightly 테스트 타임아웃 완화 (exposed-clickhouse, elasticsearch)

### DIFF
--- a/data/exposed-clickhouse/src/test/kotlin/io/bluetape4k/exposed/clickhouse/insert/BatchInsertBenchmarkTest.kt
+++ b/data/exposed-clickhouse/src/test/kotlin/io/bluetape4k/exposed/clickhouse/insert/BatchInsertBenchmarkTest.kt
@@ -17,7 +17,7 @@ import java.time.Instant
  * ClickHouse BatchInsert 성능 측정 벤치마크.
  *
  * 10만 건 데이터를 3회 반복 삽입하여 평균 성능을 측정합니다.
- * 임계치: 10,000행당 500ms 이내
+ * 임계치: 10,000행당 2000ms 이내 (CI 환경의 느린 runner 고려)
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class BatchInsertBenchmarkTest : AbstractClickHouseTest() {
@@ -25,7 +25,7 @@ class BatchInsertBenchmarkTest : AbstractClickHouseTest() {
     companion object : KLogging() {
         private const val TOTAL_ROWS = 100_000
         private const val ROUNDS = 3
-        private const val THRESHOLD_MS_PER_10K = 500L  // 임계치: 10K 행당 500ms
+        private const val THRESHOLD_MS_PER_10K = 2000L  // 임계치: 10K 행당 2000ms (CI 환경 고려)
     }
 
     @BeforeEach
@@ -70,7 +70,7 @@ class BatchInsertBenchmarkTest : AbstractClickHouseTest() {
         log.info("BatchInsert $TOTAL_ROWS rows — 3회 평균: ${avgMs}ms (${avgPer10K}ms/10K)")
         log.info("개별 측정: ${durations.map { "${it}ms" }}")
 
-        // 임계치 검증: 10K 행당 500ms 이내
+        // 임계치 검증: 10K 행당 2000ms 이내
         avgPer10K shouldBeLessOrEqualTo THRESHOLD_MS_PER_10K
     }
 }

--- a/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkApiCoroutinesTest.kt
+++ b/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkApiCoroutinesTest.kt
@@ -57,13 +57,13 @@ class BulkApiCoroutinesTest: AbstractElasticsearchTest() {
     private lateinit var indexName: String
 
     @BeforeEach
-    fun setUp() = runTest(timeout = 30.seconds) {
+    fun setUp() = runTest(timeout = 60.seconds) {
         indexName = ElasticsearchTestFixtures.randomIndexName("bulk-test")
         asyncClient.createTestIndex(indexName).await()
     }
 
     @AfterEach
-    fun tearDown() = runTest(timeout = 30.seconds) {
+    fun tearDown() = runTest(timeout = 60.seconds) {
         runCatching { asyncClient.deleteTestIndex(indexName).await() }
     }
 

--- a/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/examples/ProductIndexExample.kt
+++ b/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/examples/ProductIndexExample.kt
@@ -68,13 +68,13 @@ class ProductIndexExample : AbstractElasticsearchTest() {
     private lateinit var indexName: String
 
     @BeforeEach
-    fun setUp() = runTest(timeout = 30.seconds) {
+    fun setUp() = runTest(timeout = 60.seconds) {
         indexName = ElasticsearchTestFixtures.randomIndexName("product-example")
         asyncClient.createTestIndex(indexName).await()
     }
 
     @AfterEach
-    fun tearDown() = runTest(timeout = 30.seconds) {
+    fun tearDown() = runTest(timeout = 60.seconds) {
         runCatching { asyncClient.deleteTestIndex(indexName).await() }
     }
 


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: CI nightly 테스트 타임아웃 완화 (exposed-clickhouse, elasticsearch)

## Background

Nightly Tests CI (#24970143089) 에서 2개 job 실패:

### Test / Data (ext) — bluetape4k-exposed-clickhouse
- **실패 테스트**: `BatchInsertBenchmarkTest > 100000건 batchInsert 성능 측정()`
- **원인**: `THRESHOLD_MS_PER_10K = 500L` — CI runner 속도가 로컬보다 느려 10K 행당 500ms 임계값 초과

### Test / Infra (search-messaging) — bluetape4k-elasticsearch
- **실패 테스트**:
  - `BulkApiCoroutinesTest > mapping 오류가 포함된 bulk 요청은 onItemError 콜백으로 실패 item 을 전달한다()`
  - `ProductIndexExample > 카테고리별 상품 검색 예시()`
- **원인**: `UncompletedCoroutinesError: After waiting for 30s` — `setUp()`의 `runTest(timeout = 30.seconds)`에서 부하 받은 Elasticsearch 컨테이너의 `createTestIndex`가 30s 초과

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 수정

| 파일 | 변경 내용 |
|------|-----------|
| `BatchInsertBenchmarkTest.kt` | `THRESHOLD_MS_PER_10K` 500ms → 2000ms |
| `BulkApiCoroutinesTest.kt` | `setUp`/`tearDown` timeout 30s → 60s |
| `ProductIndexExample.kt` | `setUp`/`tearDown` timeout 30s → 60s |

### 기존 섹션: 비고

로컬에서는 모두 통과하는 테스트들로, CI 환경의 자원 제약(느린 runner, 컨테이너 공유 부하)을 고려한 임계값 조정입니다.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #174, head `2036e8ca1220931630ed663fdebf523cdffff359`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/nightly-test-timeouts`
- Labels: `build`
- State: `MERGED`, merge commit `ac960d064cb300e30514655a6daa4cbc3d58a52c`
- CI: Nightly Tests CI (#24970143089) 에서 2개 job 실패: / - **원인**: `THRESHOLD_MS_PER_10K = 500L` — CI runner 속도가 로컬보다 느려 10K 행당 500ms 임계값 초과 / 로컬에서는 모두 통과하는 테스트들로, CI 환경의 자원 제약(느린 runner, 컨테이너 공유 부하)을 고려한 임계값 조정입니다.

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #174 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `ac960d064cb300e30514655a6daa4cbc3d58a52c`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
