### PR TITLE
test: bluetape4k-nats 테스트 커버리지 개선 (49% → 79.45%)

### DIFF
--- a/docs/superpowers/plans/2026-04-27-nats-test-coverage-plan.md
+++ b/docs/superpowers/plans/2026-04-27-nats-test-coverage-plan.md
@@ -1,0 +1,202 @@
+# bluetape4k-nats 테스트 커버리지 개선 구현 계획
+
+**작성일**: 2026-04-27  
+**이슈**: #177  
+**목표**: 라인 커버리지 49.08% → 70% (+68라인)
+
+---
+
+## Task 목록
+
+### T1 — OptionsTest.kt 작성 (complexity: low)
+
+**파일**: `infra/nats/src/test/kotlin/io/bluetape4k/nats/client/OptionsTest.kt`
+
+- `natsOptions { server(url) }` → Options 반환, server 설정 확인
+- `natsOptions(Properties())` → Properties 기반 Options 생성
+- `natsOptionsOf()` → 기본 URL 적용
+- `natsOptionsOf(url, maxReconnects, bufferSize)` → 파라미터 반영
+
+**기대 커버**: Options.kt +12라인
+
+---
+
+### T2 — JetStreamOptionsTest.kt 작성 (complexity: low)
+
+**파일**: `infra/nats/src/test/kotlin/io/bluetape4k/nats/client/JetStreamOptionsTest.kt`
+
+- `defaultJetStreamOptions` → JetStreamOptions.DEFAULT_JS_OPTIONS와 동일
+- `jetStreamOptions { }` → 기본 인스턴스 생성
+- `jetStreamOptionsOf()` → 기본값
+- `jetStreamOptionsOf(prefix = "myprefix")` → prefix 설정 확인
+- `jetStreamOptionsOf(requestTimeout = 5.seconds)` → requestTimeout 설정
+- `jetStreamOptionsOf(publishNoAck = true)` → publishNoAck 설정
+
+**기대 커버**: JetStreamOptions.kt +15라인
+
+---
+
+### T3 — PublishOptionsTest.kt 작성 (complexity: low)
+
+**파일**: `infra/nats/src/test/kotlin/io/bluetape4k/nats/client/PublishOptionsTest.kt`
+
+- `publishOptions { stream("orders") }` → stream 설정 확인
+- `publishOptionsOf(Properties())` → Properties 기반 생성
+
+**기대 커버**: PublishOptions.kt +5라인
+
+---
+
+### T4 — KeyValueOptionsTest.kt 작성 (complexity: low)
+
+**파일**: `infra/nats/src/test/kotlin/io/bluetape4k/nats/client/KeyValueOptionsTest.kt`
+
+- `keyValueOptions { }` → 기본 인스턴스
+- `keyValueOptions(existingKvo) { }` → 기존 옵션 기반 빌더
+- `keyValueOptions(jso) { }` → JetStreamOptions 포함 빌더
+
+**기대 커버**: KeyValueOptions.kt +6라인
+
+---
+
+### T5 — PullSubscriptionOptionsTest.kt 작성 (complexity: low)
+
+**파일**: `infra/nats/src/test/kotlin/io/bluetape4k/nats/client/PullSubscriptionOptionsTest.kt`
+
+- `pullSubscriptionOptions { stream("orders") }` → 빌더 경로
+- `pullSubscriptionOptionsOf("orders", "consumer-a")` → bind() 경로
+- `pullSubscriptionOptionsOf("", "consumer-a")` → IllegalArgumentException
+- `pullSubscriptionOptionsOf("orders", "")` → IllegalArgumentException
+
+**기대 커버**: PullSubscriptionOptions.kt +3라인 (현재 3/6 → 6/6)
+
+---
+
+### T6 — PushSubscriptionOptionsTest.kt 작성 (complexity: low)
+
+**파일**: `infra/nats/src/test/kotlin/io/bluetape4k/nats/client/PushSubscriptionOptionsTest.kt`
+
+- `pushSubscriptionOptions { stream("orders") }` → 빌더 경로
+- `pushSubscriptionOf("orders")` → stream() 경로
+- `pushSubscriptionOf("")` → IllegalArgumentException
+- `pushSubscriptionOf("orders", "consumer-a")` → bind() 경로
+- `pushSubscriptionOf("orders", "")` → IllegalArgumentException
+
+**기대 커버**: PushSubscriptionOptions.kt +6라인
+
+---
+
+### T7 — NatsMessageTest.kt 확장 (complexity: low)
+
+**파일**: `infra/nats/src/test/kotlin/io/bluetape4k/nats/client/NatsMessageTest.kt`
+
+현재 10/20 커버. 추가 케이스:
+- `natsMessage { subject("foo"); data("hello") }` → 빌더 경로
+- `natsMessageOf(message: Message)` → MockK Message 래핑
+- `natsMessageOf("foo", "hello".toByteArray())` → ByteArray 경로
+- `natsMessageOf("foo", "hello")` → String 경로
+- `natsMessageOf("foo", "hello", replyTo = "reply.topic")` → replyTo 설정
+- `natsMessageOf("", "data")` → IllegalArgumentException
+
+**기대 커버**: NatsMessage.kt +10라인 (10/20 → 20/20)
+
+---
+
+### T8 — ConnectionExtensionsTest.kt 작성 (complexity: medium)
+
+**파일**: `infra/nats/src/test/kotlin/io/bluetape4k/nats/client/ConnectionExtensionsTest.kt`
+
+MockK `Connection` 사용. 현재 23/50, 미커버 경로 집중:
+
+**동기 메서드**:
+- `publish(subject, body)` → Connection.publish(subject, null, bytes) 호출 verify
+- `publish(subject, replyTo, body)` → 3-arg publish 호출 verify
+- `request(subject, body)` → 응답 Message 반환
+- `requestAsync(subject, body, timeout = null)` → request() 경로
+- `requestAsync(subject, body, timeout = 1.seconds)` → requestWithTimeout() 경로
+- `flush(1.seconds)` → flush(java.time.Duration) 호출 verify
+
+**suspend 메서드** (`runTest`):
+- `requestSuspending(message, null)` → request(message).await()
+- `requestSuspending(message, 1.seconds)` → requestWithTimeout(message, ...).await()
+- `requestSuspending(subject, bytes)` → request(subject, null, bytes).await()
+- `requestWithTimeoutSuspending(subject, bytes, timeout = null)` → null timeout 경로
+- `requestWithTimeoutSuspending(subject, bytes, timeout = 1.seconds)` → timeout 경로
+- `drainSuspending(1.seconds)` → drain(Duration) future await
+
+**기대 커버**: ConnectionExtensions.kt +12라인 (23/50 → 35/50+)
+
+---
+
+### T9 — ServiceExtensionsTest.kt 작성 (complexity: medium)
+
+**파일**: `infra/nats/src/test/kotlin/io/bluetape4k/nats/service/ServiceExtensionsTest.kt`
+
+MockK `Connection` 사용. `ServiceBuilder`는 실제 객체 사용:
+
+- `natsService { connection(nc); name("svc"); version("1.0") }` → Service 비null 반환
+- `natsServiceOf(nc, "svc", "1.0")` → 최소 구성 Service 생성
+- `natsServiceOf(nc, "svc", "1.0", endpoint1, endpoint2)` → 엔드포인트 2개 등록
+- `natsServiceOf(nc, "svc", "1.0") { description("desc") }` → builder 블록 적용
+
+**기대 커버**: Service.kt +10라인 (1/13 → 11/13)
+
+---
+
+### T10 — ConsumerExtensionsTest.kt 작성 (complexity: medium)
+
+**파일**: `infra/nats/src/test/kotlin/io/bluetape4k/nats/client/ConsumerExtensionsTest.kt`
+
+MockK `Consumer` 사용:
+
+- `consumer.drain(100L)` → drain(Duration.ofMillis(100)) 호출 verify
+- `consumer.drain(0L)` → 경계값 0 허용
+- `consumer.drain(-1L)` → IllegalArgumentException (requireZeroOrPositiveNumber)
+- `consumer.drain(kotlin.time.Duration.ZERO)` → 경계값 0 허용
+- `consumer.drainSuspending(100L)` → runTest, await() 결과 true
+- `consumer.drainSuspending(kotlin.time.Duration.ZERO)` → runTest, 경계값 허용
+
+**기대 커버**: Consumer.kt +7라인 (0/8 → 7/8+)
+
+---
+
+### T11 — 테스트 실행 및 커버리지 검증 (complexity: low)
+
+```bash
+cd .worktrees/test-nats-coverage
+./gradlew :bluetape4k-nats:test
+./gradlew :bluetape4k-nats:koverXmlReport
+```
+
+- 목표: ≥ 70% 확인
+- 실패 시 미커버 경로 추가 테스트 작성
+
+---
+
+### T12 — README.md + README.ko.md 업데이트 (complexity: low)
+
+**파일**:
+- `infra/nats/README.md`
+- `infra/nats/README.ko.md`
+
+테스트 섹션에 신규 테스트 파일 목록 + 커버리지 수치 업데이트
+
+---
+
+## 예상 커버리지 개선 요약
+
+| Task | 파일 | 기대 추가 라인 |
+|------|------|-------------|
+| T1 | Options.kt | +12 |
+| T2 | JetStreamOptions.kt | +15 |
+| T3 | PublishOptions.kt | +5 |
+| T4 | KeyValueOptions.kt | +6 |
+| T5 | PullSubscriptionOptions.kt | +3 |
+| T6 | PushSubscriptionOptions.kt | +6 |
+| T7 | NatsMessage.kt | +10 |
+| T8 | ConnectionExtensions.kt | +12 |
+| T9 | Service.kt | +10 |
+| T10 | Consumer.kt | +7 |
+| **합계** | | **+86라인** (목표 +68라인 초과) |
+
+현재 160 + 86 = 246/326 = **75.5%** (예상)

--- a/docs/superpowers/specs/2026-04-27-nats-test-coverage-design.md
+++ b/docs/superpowers/specs/2026-04-27-nats-test-coverage-design.md
@@ -1,0 +1,196 @@
+# bluetape4k-nats 테스트 커버리지 개선 설계
+
+**작성일**: 2026-04-27  
+**이슈**: #177  
+**목표**: `infra/nats` 모듈 라인 커버리지 49.08% → 70% (최소 +68 라인 커버)
+
+---
+
+## 1. 현황 분석
+
+### 베이스라인 (koverXmlReport 실측)
+
+| 파일 | 커버 | 전체 | 비율 | 우선순위 |
+|------|------|------|------|--------|
+| `Options.kt` | 1 | 13 | 7.7% | HIGH |
+| `Service.kt` | 1 | 13 | 7.7% | HIGH |
+| `JetStream.kt` | 4 | 15 | 26.7% | HIGH |
+| `KeyValueConfiguration.kt` | 5 | 18 | 27.8% | HIGH |
+| `ConnectionExtensions.kt` | 23 | 50 | 46.0% | HIGH |
+| `NatsMessage.kt` | 10 | 20 | 50.0% | MEDIUM |
+| `PullSubscriptionOptions.kt` | 3 | 6 | 50.0% | MEDIUM |
+| `JetStreamOptions.kt` | 0 | 16 | 0% | HIGH |
+| `KeyValueOptions.kt` | 0 | 6 | 0% | HIGH |
+| `PublishOptions.kt` | 0 | 5 | 0% | MEDIUM |
+| `PushSubscriptionOptions.kt` | 0 | 6 | 0% | MEDIUM |
+| `Consumer.kt` | 0 | 8 | 0% | MEDIUM |
+| `StreamInfoOptions.kt` | 0 | 4 | 0% | LOW |
+| `ObjectLink.kt` | 0 | 5 | 0% | LOW |
+
+**전체**: 160/326 = 49.08%  
+**목표**: 228/326 = 70.0%  
+**필요 추가 커버**: +68 라인
+
+---
+
+## 2. 설계 원칙
+
+### 2-1. 테스트 분류
+
+**순수 단위 테스트 (서버 불필요)**  
+DSL 빌더 함수, 파라미터 검증, 반환 타입 검증 → MockK 또는 단순 인스턴스 생성으로 검증
+
+**MockK 기반 단위 테스트**  
+`Connection`, `JetStream`, `Consumer` 인터페이스의 extension function → MockK 모킹 + 동작 검증
+
+**`runTest` 기반 코루틴 단위 테스트**  
+suspend extension function (`requestSuspending`, `drainSuspending`) → MockK + `runTest`  
+`CompletableFuture.completedFuture(value)` 사용하여 실제 서버 없이 await 검증
+
+### 2-2. 파라미터 검증 패턴
+
+`requireNotBlank` 검증이 있는 함수는 blank 입력 케이스를 반드시 포함한다.
+
+```kotlin
+assertThrows(IllegalArgumentException::class.java) {
+    someFunction("")
+}
+```
+
+---
+
+## 3. 신규 테스트 파일 목록
+
+### 3-1. `OptionsTest.kt` (기대 커버: +12라인)
+
+```
+io.bluetape4k.nats.client.OptionsTest
+```
+
+- `natsOptions { }` → `Options` 인스턴스 반환
+- `natsOptions(properties) { }` → Properties 기반 초기화
+- `natsOptionsOf()` → 기본 URL/maxReconnects/bufferSize 반영
+- `natsOptionsOf(url, maxReconnects, bufferSize)` → 파라미터 반영
+
+### 3-2. `JetStreamOptionsTest.kt` (기대 커버: +15라인)
+
+```
+io.bluetape4k.nats.client.JetStreamOptionsTest
+```
+
+- `defaultJetStreamOptions` → `JetStreamOptions.DEFAULT_JS_OPTIONS`와 동일
+- `jetStreamOptions { }` → 빈 빌더로 기본 인스턴스 생성
+- `jetStreamOptionsOf()` → 기본값으로 생성
+- `jetStreamOptionsOf(prefix, requestTimeout, publishNoAck)` → 파라미터 반영
+
+### 3-3. `PublishOptionsTest.kt` (기대 커버: +5라인)
+
+```
+io.bluetape4k.nats.client.PublishOptionsTest
+```
+
+- `publishOptions { }` → 기본 빌더 호출
+- `publishOptionsOf(properties)` → Properties 기반 초기화
+
+### 3-4. `KeyValueOptionsTest.kt` (기대 커버: +6라인)
+
+```
+io.bluetape4k.nats.client.KeyValueOptionsTest
+```
+
+- `keyValueOptions { }` → 기본 빌더
+- `keyValueOptions(kvo) { }` → 기존 옵션 복사
+- `keyValueOptions(jso) { }` → JetStreamOptions 포함
+
+### 3-5. `PullSubscriptionOptionsTest.kt` (기대 커버: +3라인)
+
+```
+io.bluetape4k.nats.client.PullSubscriptionOptionsTest
+```
+
+- `pullSubscriptionOptionsOf(stream, bind)` → PullSubscribeOptions.bind() 호출 확인
+- `pullSubscriptionOptionsOf("", bind)` → IllegalArgumentException
+- `pullSubscriptionOptionsOf(stream, "")` → IllegalArgumentException
+
+### 3-6. `PushSubscriptionOptionsTest.kt` (기대 커버: +6라인)
+
+```
+io.bluetape4k.nats.client.PushSubscriptionOptionsTest
+```
+
+- `pushSubscriptionOf(stream)` → PushSubscribeOptions.stream() 결과
+- `pushSubscriptionOf("") ` → IllegalArgumentException
+- `pushSubscriptionOf(stream, durable)` → bind() 호출
+- `pushSubscriptionOf(stream, "")` → IllegalArgumentException
+
+### 3-7. `NatsMessageTest.kt` (기대 커버: +10라인)
+
+```
+io.bluetape4k.nats.client.NatsMessageTest
+```
+
+- `natsMessage { subject("foo") }` → NatsMessage 반환
+- `natsMessageOf(ByteArray)` → subject/data 설정 확인
+- `natsMessageOf(String)` → subject/data 설정 확인
+- `natsMessageOf("", data)` → IllegalArgumentException (requireNotBlank)
+- replyTo, headers 파라미터 전달 확인
+
+### 3-8. `ConnectionExtensionsTest.kt` (기대 커버: +10라인)
+
+```
+io.bluetape4k.nats.client.ConnectionExtensionsTest
+```
+
+MockK `Connection` 사용. 아직 커버 안 된 경로 중심:
+
+- `publish(subject, body)` → `Connection.publish(subject, null, body.toUtf8Bytes())` 호출
+- `publish(subject, replyTo, body)` → 3-arg publish 호출
+- `request(subject, body)` → 동기 호출 결과 반환
+- `requestAsync(subject, body, timeout = null)` → `request(...)` 경로
+- `requestAsync(subject, body, timeout = someTimeout)` → `requestWithTimeout(...)` 경로
+- `flush(timeout)` → `Connection.flush(java.time.Duration)` 호출
+- suspend: `requestSuspending(message)` → `CompletableFuture.completedFuture` 로 await 확인
+- suspend: `drainSuspending(timeout)` → drain future await
+
+### 3-9. `ServiceExtensionsTest.kt` (기대 커버: +10라인)
+
+```
+io.bluetape4k.nats.service.ServiceExtensionsTest
+```
+
+MockK `Connection` 사용:
+
+- `natsService { connection(nc); name("svc"); version("1.0") }` → Service 반환
+- `natsServiceOf(nc, name, version, endpoint)` → Service에 endpoint 등록 확인
+
+### 3-10. `ConsumerExtensionsTest.kt` (기대 커버: +7라인)
+
+```
+io.bluetape4k.nats.client.ConsumerExtensionsTest
+```
+
+MockK `Consumer` 사용:
+
+- `consumer.drain(100L)` → CompletableFuture<Boolean> 반환
+- `consumer.drain(Duration.ofSeconds(1))` → 유효 Duration
+- `consumer.drainSuspending(100L)` → runTest 내 await 결과
+- `consumer.drainSuspending(Duration.ZERO)` → 0 이상 경계값
+
+---
+
+## 4. 리스크
+
+1. **`ConnectionExtensions` suspend 테스트**: `requestSuspending`은 `request(message).await()`를 호출하므로 MockK에서 `every { request(message) } returns CompletableFuture.completedFuture(response)` 형태로 모킹해야 한다. `Connection.request()` 반환 타입이 `CompletableFuture<Message>`인지 확인 필요.
+
+2. **`Service` 빌더 검증**: `natsService { }` 빌더에 필수 필드(`connection`, `name`, `version`) 없이 build 시 예외 발생 여부 — 빈 빌더 케이스는 건너뛰고 최소 유효 파라미터만 사용한다.
+
+3. **`Consumer` 인터페이스**: `Consumer.drain(java.time.Duration)` 반환 타입이 `CompletableFuture<Boolean>`인지 확인 후 MockK 설정.
+
+---
+
+## 5. 수락 기준 (DoD)
+
+- [ ] `./gradlew :bluetape4k-nats:koverXmlReport` 결과 라인 커버리지 ≥ 70%
+- [ ] 신규 테스트 파일 10개 모두 컴파일 + 통과
+- [ ] 모든 신규 테스트는 Testcontainers(NATS 서버) 없이 실행 가능
+- [ ] `README.md` + `README.ko.md` 테스트 섹션 업데이트

--- a/infra/nats/README.ko.md
+++ b/infra/nats/README.ko.md
@@ -310,6 +310,25 @@ val allOpts = streamInfoOptionsOfAllSubjects()
 val info = management.getStreamInfo("my-stream", filteredOpts)
 ```
 
+## 테스트 커버리지
+
+라인 커버리지: **79.45%** (259/326 라인) — Kover 측정.
+
+서버 없이 실행 가능한 단위 테스트:
+
+| 테스트 파일 | 대상 |
+|-----------|------|
+| `OptionsTest` | `natsOptions`, `natsOptionsOf` 빌더 |
+| `JetStreamOptionsTest` | `jetStreamOptionsOf`, `defaultJetStreamOptions` |
+| `PublishOptionsTest` | `publishOptions`, `publishOptionsOf` 빌더 |
+| `KeyValueOptionsTest` | `keyValueOptions` (3가지 오버로드) |
+| `PullSubscriptionOptionsTest` | `pullSubscriptionOptions`, `pullSubscriptionOptionsOf` |
+| `PushSubscriptionOptionsTest` | `pushSubscriptionOptions`, `pushSubscriptionOf` (2가지 오버로드) |
+| `NatsMessageTest` | `natsMessage`, `natsMessageOf` (3가지 오버로드) |
+| `ConnectionExtensionsTest` | `publish`, `request`, `requestAsync`, `requestSuspending`, `drainSuspending` (MockK) |
+| `ConsumerExtensionsTest` | `Consumer.drain`, `Consumer.drainSuspending` (MockK) |
+| `ServiceExtensionsTest` | `natsService`, `natsServiceOf` (MockK Connection) |
+
 ## 테스트 지원
 
 `AbstractNatsTest`를 상속하면 Testcontainers 기반 NATS 서버에 자동으로 연결됩니다:

--- a/infra/nats/README.md
+++ b/infra/nats/README.md
@@ -310,6 +310,25 @@ val allOpts = streamInfoOptionsOfAllSubjects()
 val info = management.getStreamInfo("my-stream", filteredOpts)
 ```
 
+## Test Coverage
+
+Line coverage: **79.45%** (259/326 lines) — measured with Kover.
+
+Unit tests (no server required):
+
+| Test File | Scope |
+|-----------|-------|
+| `OptionsTest` | `natsOptions`, `natsOptionsOf` builders |
+| `JetStreamOptionsTest` | `jetStreamOptionsOf`, `defaultJetStreamOptions` |
+| `PublishOptionsTest` | `publishOptions`, `publishOptionsOf` builders |
+| `KeyValueOptionsTest` | `keyValueOptions` (3 overloads) |
+| `PullSubscriptionOptionsTest` | `pullSubscriptionOptions`, `pullSubscriptionOptionsOf` |
+| `PushSubscriptionOptionsTest` | `pushSubscriptionOptions`, `pushSubscriptionOf` (2 overloads) |
+| `NatsMessageTest` | `natsMessage`, `natsMessageOf` (3 overloads) |
+| `ConnectionExtensionsTest` | `publish`, `request`, `requestAsync`, `requestSuspending`, `drainSuspending` (MockK) |
+| `ConsumerExtensionsTest` | `Consumer.drain`, `Consumer.drainSuspending` (MockK) |
+| `ServiceExtensionsTest` | `natsService`, `natsServiceOf` (MockK Connection) |
+
 ## Test Support
 
 Extend `AbstractNatsTest` to get a pre-connected NATS server via Testcontainers:

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/ConnectionExtensionsTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/ConnectionExtensionsTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CompletableFuture
 import kotlin.time.Duration.Companion.seconds
@@ -20,7 +21,12 @@ import kotlin.time.toJavaDuration
 
 class ConnectionExtensionsTest {
 
-    private val nc = mockk<Connection>(relaxed = true)
+    private lateinit var nc: Connection
+
+    @BeforeEach
+    fun setUp() {
+        nc = mockk<Connection>(relaxed = true)
+    }
 
     @Test
     fun `publish with subject and body calls underlying publish`() {

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/ConnectionExtensionsTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/ConnectionExtensionsTest.kt
@@ -1,0 +1,191 @@
+package io.bluetape4k.nats.client
+
+import io.bluetape4k.support.toUtf8Bytes
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import io.nats.client.Connection
+import io.nats.client.Message
+import io.nats.client.impl.Headers
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+class ConnectionExtensionsTest {
+
+    private val nc = mockk<Connection>(relaxed = true)
+
+    @Test
+    fun `publish with subject and body calls underlying publish`() {
+        nc.publish("test.subject", "hello")
+
+        verify { nc.publish("test.subject", null as Headers?, "hello".toUtf8Bytes()) }
+    }
+
+    @Test
+    fun `publish with subject and body and headers passes headers`() {
+        val headers = Headers()
+        nc.publish("test.subject", "hello", headers)
+
+        verify { nc.publish("test.subject", headers, "hello".toUtf8Bytes()) }
+    }
+
+    @Test
+    fun `publish with blank subject throws IllegalArgumentException`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            nc.publish("", "hello")
+        }
+    }
+
+    @Test
+    fun `publish with subject replyTo and body calls 4-arg publish`() {
+        nc.publish("test.subject", "reply.inbox", "hello")
+
+        verify { nc.publish("test.subject", "reply.inbox", null as Headers?, "hello".toUtf8Bytes()) }
+    }
+
+    @Test
+    fun `publish with blank replyTo throws IllegalArgumentException`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            nc.publish("test.subject", "", "hello")
+        }
+    }
+
+    @Test
+    fun `request with subject and body returns response message`() {
+        val response = mockk<Message>()
+        every { nc.request(any<String>(), any(), any(), any()) } returns response
+
+        val result = nc.request("test.subject", "body", timeout = 1.seconds)
+
+        result shouldBeEqualTo response
+    }
+
+    @Test
+    fun `request with blank subject throws IllegalArgumentException`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            nc.request("", "body", timeout = 1.seconds)
+        }
+    }
+
+    @Test
+    fun `requestAsync without timeout calls request returning CompletableFuture`() {
+        val response = mockk<Message>()
+        val future = CompletableFuture.completedFuture(response)
+        every { nc.request(any<String>(), any(), any<ByteArray>()) } returns future
+
+        val result = nc.requestAsync("test.subject", "body")
+
+        result shouldBeEqualTo future
+    }
+
+    @Test
+    fun `requestAsync with timeout calls requestWithTimeout`() {
+        val response = mockk<Message>()
+        val future = CompletableFuture.completedFuture(response)
+        every { nc.requestWithTimeout(any<String>(), any(), any<ByteArray>(), any()) } returns future
+
+        val result = nc.requestAsync("test.subject", "body", timeout = 1.seconds)
+
+        result shouldBeEqualTo future
+    }
+
+    @Test
+    fun `requestAsync with message and no timeout calls request`() {
+        val message = mockk<Message>()
+        val response = mockk<Message>()
+        val future = CompletableFuture.completedFuture(response)
+        every { nc.request(message) } returns future
+
+        val result = nc.requestAsync(message)
+
+        result shouldBeEqualTo future
+    }
+
+    @Test
+    fun `requestAsync with message and timeout calls requestWithTimeout`() {
+        val message = mockk<Message>()
+        val response = mockk<Message>()
+        val future = CompletableFuture.completedFuture(response)
+        every { nc.requestWithTimeout(message, any()) } returns future
+
+        val result = nc.requestAsync(message, timeout = 1.seconds)
+
+        result shouldBeEqualTo future
+    }
+
+    @Test
+    fun `flush with kotlin Duration calls flush with java Duration`() {
+        nc.flush(1.seconds)
+
+        verify { nc.flush(1.seconds.toJavaDuration()) }
+    }
+
+    @Test
+    fun `requestSuspending with message and no timeout awaits future`() = runTest {
+        val message = mockk<Message>()
+        val response = mockk<Message>()
+        every { nc.request(message) } returns CompletableFuture.completedFuture(response)
+
+        val result = nc.requestSuspending(message)
+
+        result shouldBeEqualTo response
+    }
+
+    @Test
+    fun `requestSuspending with message and timeout awaits requestWithTimeout future`() = runTest {
+        val message = mockk<Message>()
+        val response = mockk<Message>()
+        every { nc.requestWithTimeout(message, any()) } returns CompletableFuture.completedFuture(response)
+
+        val result = nc.requestSuspending(message, 1.seconds)
+
+        result shouldBeEqualTo response
+    }
+
+    @Test
+    fun `requestSuspending with subject and bytes awaits future`() = runTest {
+        val response = mockk<Message>()
+        every { nc.request(any<String>(), any(), any<ByteArray>()) } returns CompletableFuture.completedFuture(response)
+
+        val result = nc.requestSuspending("test.subject", "hello".toUtf8Bytes())
+
+        result shouldBeEqualTo response
+    }
+
+    @Test
+    fun `requestWithTimeoutSuspending without timeout uses request path`() = runTest {
+        val response = mockk<Message>()
+        every { nc.request(any<String>(), any(), any<ByteArray>()) } returns CompletableFuture.completedFuture(response)
+
+        val result = nc.requestWithTimeoutSuspending("test.subject", "hello".toUtf8Bytes())
+
+        result shouldBeEqualTo response
+    }
+
+    @Test
+    fun `requestWithTimeoutSuspending with timeout uses requestWithTimeout path`() = runTest {
+        val response = mockk<Message>()
+        every { nc.requestWithTimeout(any<String>(), any(), any<ByteArray>(), any()) } returns CompletableFuture.completedFuture(response)
+
+        val result = nc.requestWithTimeoutSuspending("test.subject", "hello".toUtf8Bytes(), timeout = 1.seconds)
+
+        result shouldBeEqualTo response
+    }
+
+    @Test
+    fun `drainSuspending with kotlin Duration awaits drain future`() = runTest {
+        every { nc.drain(any()) } returns CompletableFuture.completedFuture(true)
+
+        val result = nc.drainSuspending(1.seconds)
+
+        result.shouldBeTrue()
+    }
+}

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/ConsumerExtensionsTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/ConsumerExtensionsTest.kt
@@ -1,0 +1,92 @@
+package io.bluetape4k.nats.client
+
+import io.mockk.every
+import io.mockk.mockk
+import io.nats.client.Consumer
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Duration.Companion.seconds
+
+class ConsumerExtensionsTest {
+
+    private val consumer = mockk<Consumer>()
+
+    @Test
+    fun `drain with positive millis calls underlying drain with java Duration`() {
+        every { consumer.drain(any<java.time.Duration>()) } returns CompletableFuture.completedFuture(true)
+
+        val future = consumer.drain(500L)
+
+        future.shouldNotBeNull()
+        future.get().shouldBeTrue()
+    }
+
+    @Test
+    fun `drain with zero millis is allowed`() {
+        every { consumer.drain(any<java.time.Duration>()) } returns CompletableFuture.completedFuture(true)
+
+        val future = consumer.drain(0L)
+
+        future.shouldNotBeNull()
+    }
+
+    @Test
+    fun `drain with negative millis throws IllegalArgumentException`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            consumer.drain(-1L)
+        }
+    }
+
+    @Test
+    fun `drain with kotlin Duration ZERO is allowed`() {
+        every { consumer.drain(any<java.time.Duration>()) } returns CompletableFuture.completedFuture(false)
+
+        val future = consumer.drain(ZERO)
+
+        future.shouldNotBeNull()
+        future.get().shouldBeFalse()
+    }
+
+    @Test
+    fun `drain with positive kotlin Duration calls underlying drain`() {
+        every { consumer.drain(any<java.time.Duration>()) } returns CompletableFuture.completedFuture(true)
+
+        val future = consumer.drain(1.seconds)
+
+        future.shouldNotBeNull()
+        future.get().shouldBeTrue()
+    }
+
+    @Test
+    fun `drainSuspending with millis awaits future result`() = runTest {
+        every { consumer.drain(any<java.time.Duration>()) } returns CompletableFuture.completedFuture(true)
+
+        val result = consumer.drainSuspending(100L)
+
+        result.shouldBeTrue()
+    }
+
+    @Test
+    fun `drainSuspending with kotlin Duration awaits future result`() = runTest {
+        every { consumer.drain(any<java.time.Duration>()) } returns CompletableFuture.completedFuture(false)
+
+        val result = consumer.drainSuspending(1.seconds)
+
+        result.shouldBeFalse()
+    }
+
+    @Test
+    fun `drainSuspending with java Duration awaits future result`() = runTest {
+        every { consumer.drain(any<java.time.Duration>()) } returns CompletableFuture.completedFuture(true)
+
+        val result = consumer.drainSuspending(java.time.Duration.ofSeconds(1))
+
+        result.shouldBeTrue()
+    }
+}

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/ConsumerExtensionsTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/ConsumerExtensionsTest.kt
@@ -8,6 +8,7 @@ import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CompletableFuture
 import kotlin.time.Duration.Companion.ZERO
@@ -15,7 +16,12 @@ import kotlin.time.Duration.Companion.seconds
 
 class ConsumerExtensionsTest {
 
-    private val consumer = mockk<Consumer>()
+    private lateinit var consumer: Consumer
+
+    @BeforeEach
+    fun setUp() {
+        consumer = mockk<Consumer>()
+    }
 
     @Test
     fun `drain with positive millis calls underlying drain with java Duration`() {

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/JetStreamOptionsTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/JetStreamOptionsTest.kt
@@ -1,0 +1,73 @@
+package io.bluetape4k.nats.client
+
+import io.nats.client.JetStreamOptions
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class JetStreamOptionsTest {
+
+    @Test
+    fun `defaultJetStreamOptions is DEFAULT_JS_OPTIONS`() {
+        defaultJetStreamOptions shouldBeEqualTo JetStreamOptions.DEFAULT_JS_OPTIONS
+    }
+
+    @Test
+    fun `jetStreamOptions with empty builder creates default instance`() {
+        val jso = jetStreamOptions {}
+
+        jso.shouldNotBeNull()
+    }
+
+    @Test
+    fun `jetStreamOptionsOf with no parameters creates default instance`() {
+        val jso = jetStreamOptionsOf()
+
+        jso.shouldNotBeNull()
+        jso.isPublishNoAck.shouldBeFalse()
+    }
+
+    @Test
+    fun `jetStreamOptionsOf with prefix applies prefix`() {
+        val jso = jetStreamOptionsOf(prefix = "myprefix")
+
+        jso.shouldNotBeNull()
+        // jnats appends "." to prefix by convention
+        jso.prefix shouldBeEqualTo "myprefix."
+    }
+
+    @Test
+    fun `jetStreamOptionsOf with requestTimeout applies timeout`() {
+        val timeout = Duration.ofSeconds(5)
+        val jso = jetStreamOptionsOf(requestTimeout = timeout)
+
+        jso.shouldNotBeNull()
+        jso.requestTimeout shouldBeEqualTo timeout
+    }
+
+    @Test
+    fun `jetStreamOptionsOf with publishNoAck true applies flag`() {
+        val jso = jetStreamOptionsOf(publishNoAck = true)
+
+        jso.shouldNotBeNull()
+        jso.isPublishNoAck.shouldBeTrue()
+    }
+
+    @Test
+    fun `jetStreamOptionsOf with all params applies all`() {
+        val jso = jetStreamOptionsOf(
+            prefix = "test",
+            requestTimeout = Duration.ofSeconds(3),
+            publishNoAck = false,
+        )
+
+        jso.shouldNotBeNull()
+        jso.prefix shouldBeEqualTo "test."
+        jso.requestTimeout shouldBeEqualTo Duration.ofSeconds(3)
+        jso.isPublishNoAck.shouldBeFalse()
+    }
+}

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/KeyValueOptionsTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/KeyValueOptionsTest.kt
@@ -1,0 +1,41 @@
+package io.bluetape4k.nats.client
+
+import io.nats.client.KeyValueOptions
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+
+class KeyValueOptionsTest {
+
+    @Test
+    fun `keyValueOptions with empty builder creates instance`() {
+        val kvo = keyValueOptions {}
+
+        kvo.shouldNotBeNull()
+    }
+
+    @Test
+    fun `keyValueOptions based on existing KeyValueOptions`() {
+        val base = keyValueOptions {}
+        val kvo = keyValueOptions(base) {}
+
+        kvo.shouldNotBeNull()
+    }
+
+    @Test
+    fun `keyValueOptions with JetStreamOptions`() {
+        val jso = jetStreamOptionsOf()
+        val kvo = keyValueOptions(jso) {}
+
+        kvo.shouldNotBeNull()
+    }
+
+    @Test
+    fun `keyValueOptions with JetStreamOptions and additional builder`() {
+        val jso = jetStreamOptionsOf(publishNoAck = false)
+        val kvo = keyValueOptions(jso) {
+            // additional configuration
+        }
+
+        kvo.shouldNotBeNull()
+    }
+}

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/KeyValueOptionsTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/KeyValueOptionsTest.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.nats.client
 
 import io.nats.client.KeyValueOptions
+import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Test
 
@@ -14,28 +15,30 @@ class KeyValueOptionsTest {
     }
 
     @Test
-    fun `keyValueOptions based on existing KeyValueOptions`() {
-        val base = keyValueOptions {}
+    fun `keyValueOptions based on existing KeyValueOptions preserves JetStreamOptions`() {
+        val jso = jetStreamOptionsOf(prefix = "base-prefix")
+        val base = keyValueOptions(jso) {}
         val kvo = keyValueOptions(base) {}
 
         kvo.shouldNotBeNull()
+        kvo.jetStreamOptions.prefix shouldBeEqualTo "base-prefix."
     }
 
     @Test
-    fun `keyValueOptions with JetStreamOptions`() {
-        val jso = jetStreamOptionsOf()
+    fun `keyValueOptions with JetStreamOptions propagates JetStreamOptions`() {
+        val jso = jetStreamOptionsOf(prefix = "kv-prefix")
         val kvo = keyValueOptions(jso) {}
 
         kvo.shouldNotBeNull()
+        kvo.jetStreamOptions.prefix shouldBeEqualTo "kv-prefix."
     }
 
     @Test
-    fun `keyValueOptions with JetStreamOptions and additional builder`() {
+    fun `keyValueOptions with JetStreamOptions and builder propagates options`() {
         val jso = jetStreamOptionsOf(publishNoAck = false)
-        val kvo = keyValueOptions(jso) {
-            // additional configuration
-        }
+        val kvo = keyValueOptions(jso) {}
 
         kvo.shouldNotBeNull()
+        kvo.jetStreamOptions.isPublishNoAck shouldBeEqualTo false
     }
 }

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/NatsMessageTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/NatsMessageTest.kt
@@ -1,0 +1,112 @@
+package io.bluetape4k.nats.client
+
+import io.bluetape4k.support.toUtf8Bytes
+import io.mockk.every
+import io.mockk.mockk
+import io.nats.client.Message
+import io.nats.client.impl.Headers
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class NatsMessageTest {
+
+    @Test
+    fun `natsMessage with builder creates NatsMessage`() {
+        val msg = natsMessage {
+            subject("foo")
+            data("hello")
+        }
+
+        msg.shouldNotBeNull()
+        msg.subject shouldBeEqualTo "foo"
+        String(msg.data) shouldBeEqualTo "hello"
+    }
+
+    @Test
+    fun `natsMessageOf wraps existing Message`() {
+        val original = mockk<Message>(relaxed = true)
+        every { original.subject } returns "wrapped.subject"
+
+        val wrapped = natsMessageOf(original)
+
+        wrapped.shouldNotBeNull()
+    }
+
+    @Test
+    fun `natsMessageOf with ByteArray creates message with subject and data`() {
+        val data = "hello".toUtf8Bytes()
+        val msg = natsMessageOf("test.subject", data)
+
+        msg.shouldNotBeNull()
+        msg.subject shouldBeEqualTo "test.subject"
+        msg.data shouldBeEqualTo data
+    }
+
+    @Test
+    fun `natsMessageOf with ByteArray and replyTo sets replyTo`() {
+        val data = "hello".toUtf8Bytes()
+        val msg = natsMessageOf("test.subject", data, replyTo = "reply.inbox")
+
+        msg.shouldNotBeNull()
+        msg.replyTo shouldBeEqualTo "reply.inbox"
+    }
+
+    @Test
+    fun `natsMessageOf with ByteArray and headers sets headers`() {
+        val headers = Headers()
+        headers.add("X-Test", "value")
+        val msg = natsMessageOf("test.subject", "data".toUtf8Bytes(), headers = headers)
+
+        msg.shouldNotBeNull()
+        msg.headers shouldBeEqualTo headers
+    }
+
+    @Test
+    fun `natsMessageOf with blank subject throws IllegalArgumentException for ByteArray`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            natsMessageOf("", "data".toUtf8Bytes())
+        }
+    }
+
+    @Test
+    fun `natsMessageOf with String creates message`() {
+        val msg = natsMessageOf("test.subject", "hello world")
+
+        msg.shouldNotBeNull()
+        msg.subject shouldBeEqualTo "test.subject"
+        String(msg.data) shouldBeEqualTo "hello world"
+    }
+
+    @Test
+    fun `natsMessageOf with String and replyTo sets replyTo`() {
+        val msg = natsMessageOf("test.subject", "data", replyTo = "reply.inbox")
+
+        msg.shouldNotBeNull()
+        msg.replyTo shouldBeEqualTo "reply.inbox"
+    }
+
+    @Test
+    fun `natsMessageOf with blank subject throws IllegalArgumentException for String`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            natsMessageOf("", "data")
+        }
+    }
+
+    @Test
+    fun `natsMessageOf with null ByteArray creates message without data`() {
+        val msg = natsMessageOf("test.subject", null as ByteArray?)
+
+        msg.shouldNotBeNull()
+        msg.subject shouldBeEqualTo "test.subject"
+    }
+
+    @Test
+    fun `natsMessageOf with null String creates message without data`() {
+        val msg = natsMessageOf("test.subject", null as String?)
+
+        msg.shouldNotBeNull()
+        msg.subject shouldBeEqualTo "test.subject"
+    }
+}

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/OptionsTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/OptionsTest.kt
@@ -52,11 +52,10 @@ class OptionsTest {
 
     @Test
     fun `natsOptionsOf with custom parameters applies them`() {
-        val url = Options.DEFAULT_URL
-        val options = natsOptionsOf(url = url, maxReconnects = 5, bufferSize = 65536)
+        val options = natsOptionsOf(maxReconnects = 3, bufferSize = 32_768)
 
         options.shouldNotBeNull()
-        options.maxReconnect shouldBeEqualTo 5
-        options.bufferSize shouldBeEqualTo 65536
+        options.maxReconnect shouldBeEqualTo 3
+        options.bufferSize shouldBeEqualTo 32_768
     }
 }

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/OptionsTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/OptionsTest.kt
@@ -1,0 +1,62 @@
+package io.bluetape4k.nats.client
+
+import io.nats.client.Options
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import java.util.Properties
+import kotlin.time.Duration.Companion.seconds
+
+class OptionsTest {
+
+    @Test
+    fun `natsOptions with builder creates Options instance`() {
+        val options = natsOptions {
+            server(Options.DEFAULT_URL)
+        }
+
+        options.shouldNotBeNull()
+        options.servers.first().toString() shouldBeEqualTo Options.DEFAULT_URL
+    }
+
+    @Test
+    fun `natsOptions with properties creates Options from properties`() {
+        val props = Properties().apply {
+            setProperty(Options.PROP_URL, Options.DEFAULT_URL)
+        }
+        val options = natsOptions(props)
+
+        options.shouldNotBeNull()
+    }
+
+    @Test
+    fun `natsOptions with properties and builder allows override`() {
+        val props = Properties()
+        val options = natsOptions(props) {
+            maxReconnects(10)
+        }
+
+        options.shouldNotBeNull()
+        options.maxReconnect shouldBeEqualTo 10
+    }
+
+    @Test
+    fun `natsOptionsOf uses default values`() {
+        val options = natsOptionsOf()
+
+        options.shouldNotBeNull()
+        options.servers.first().toString() shouldBeEqualTo Options.DEFAULT_URL
+        options.maxReconnect shouldBeEqualTo Options.DEFAULT_MAX_RECONNECT
+        options.bufferSize shouldBeEqualTo Options.DEFAULT_BUFFER_SIZE
+    }
+
+    @Test
+    fun `natsOptionsOf with custom parameters applies them`() {
+        val url = Options.DEFAULT_URL
+        val options = natsOptionsOf(url = url, maxReconnects = 5, bufferSize = 65536)
+
+        options.shouldNotBeNull()
+        options.maxReconnect shouldBeEqualTo 5
+        options.bufferSize shouldBeEqualTo 65536
+    }
+}

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/PublishOptionsTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/PublishOptionsTest.kt
@@ -1,0 +1,36 @@
+package io.bluetape4k.nats.client
+
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import java.util.Properties
+
+class PublishOptionsTest {
+
+    @Test
+    fun `publishOptions with builder creates instance`() {
+        val opts = publishOptions {
+            stream("orders")
+        }
+
+        opts.shouldNotBeNull()
+        opts.stream.shouldNotBeNull()
+    }
+
+    @Test
+    fun `publishOptionsOf with properties creates instance`() {
+        val props = Properties()
+        val opts = publishOptionsOf(props)
+
+        opts.shouldNotBeNull()
+    }
+
+    @Test
+    fun `publishOptionsOf with properties and builder applies builder`() {
+        val props = Properties()
+        val opts = publishOptionsOf(props) {
+            stream("events")
+        }
+
+        opts.shouldNotBeNull()
+    }
+}

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/PublishOptionsTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/PublishOptionsTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.nats.client
 
+import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Test
 import java.util.Properties
@@ -7,13 +8,13 @@ import java.util.Properties
 class PublishOptionsTest {
 
     @Test
-    fun `publishOptions with builder creates instance`() {
+    fun `publishOptions with builder creates instance with stream`() {
         val opts = publishOptions {
             stream("orders")
         }
 
         opts.shouldNotBeNull()
-        opts.stream.shouldNotBeNull()
+        opts.stream shouldBeEqualTo "orders"
     }
 
     @Test
@@ -25,12 +26,13 @@ class PublishOptionsTest {
     }
 
     @Test
-    fun `publishOptionsOf with properties and builder applies builder`() {
+    fun `publishOptionsOf with properties and builder applies stream`() {
         val props = Properties()
         val opts = publishOptionsOf(props) {
             stream("events")
         }
 
         opts.shouldNotBeNull()
+        opts.stream shouldBeEqualTo "events"
     }
 }

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/PullSubscriptionOptionsTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/PullSubscriptionOptionsTest.kt
@@ -1,0 +1,38 @@
+package io.bluetape4k.nats.client
+
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class PullSubscriptionOptionsTest {
+
+    @Test
+    fun `pullSubscriptionOptions with builder creates instance`() {
+        val opts = pullSubscriptionOptions {
+            stream("orders")
+        }
+
+        opts.shouldNotBeNull()
+    }
+
+    @Test
+    fun `pullSubscriptionOptionsOf with valid stream and bind creates instance`() {
+        val opts = pullSubscriptionOptionsOf("orders", "consumer-a")
+
+        opts.shouldNotBeNull()
+    }
+
+    @Test
+    fun `pullSubscriptionOptionsOf with blank stream throws IllegalArgumentException`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            pullSubscriptionOptionsOf("", "consumer-a")
+        }
+    }
+
+    @Test
+    fun `pullSubscriptionOptionsOf with blank bind throws IllegalArgumentException`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            pullSubscriptionOptionsOf("orders", "")
+        }
+    }
+}

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/PushSubscriptionOptionsTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/PushSubscriptionOptionsTest.kt
@@ -1,0 +1,52 @@
+package io.bluetape4k.nats.client
+
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class PushSubscriptionOptionsTest {
+
+    @Test
+    fun `pushSubscriptionOptions with builder creates instance`() {
+        val opts = pushSubscriptionOptions {
+            stream("orders")
+        }
+
+        opts.shouldNotBeNull()
+    }
+
+    @Test
+    fun `pushSubscriptionOf with valid stream creates instance`() {
+        val opts = pushSubscriptionOf("orders")
+
+        opts.shouldNotBeNull()
+    }
+
+    @Test
+    fun `pushSubscriptionOf with blank stream throws IllegalArgumentException`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            pushSubscriptionOf("")
+        }
+    }
+
+    @Test
+    fun `pushSubscriptionOf with stream and durable creates bound instance`() {
+        val opts = pushSubscriptionOf("orders", "consumer-a")
+
+        opts.shouldNotBeNull()
+    }
+
+    @Test
+    fun `pushSubscriptionOf with blank durable throws IllegalArgumentException`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            pushSubscriptionOf("orders", "")
+        }
+    }
+
+    @Test
+    fun `pushSubscriptionOf with blank stream and durable throws IllegalArgumentException`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            pushSubscriptionOf("", "consumer-a")
+        }
+    }
+}

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/service/ServiceExtensionsTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/service/ServiceExtensionsTest.kt
@@ -1,0 +1,60 @@
+package io.bluetape4k.nats.service
+
+import io.mockk.mockk
+import io.nats.client.Connection
+import io.nats.service.ServiceMessageHandler
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+
+class ServiceExtensionsTest {
+
+    private val nc = mockk<Connection>(relaxed = true)
+
+    @Test
+    fun `natsService with minimal config creates Service`() {
+        val service = natsService {
+            connection(nc)
+            name("test-service")
+            version("1.0.0")
+        }
+
+        service.shouldNotBeNull()
+        service.name shouldBeEqualTo "test-service"
+        service.version shouldBeEqualTo "1.0.0"
+    }
+
+    @Test
+    fun `natsServiceOf with connection name and version creates Service`() {
+        val service = natsServiceOf(nc, "my-service", "2.0.0")
+
+        service.shouldNotBeNull()
+        service.name shouldBeEqualTo "my-service"
+        service.version shouldBeEqualTo "2.0.0"
+    }
+
+    @Test
+    fun `natsServiceOf with endpoints registers endpoints`() {
+        val handler = mockk<ServiceMessageHandler>(relaxed = true)
+        val endpoint = serviceEndpointOf {
+            endpointName("echo")
+            endpointSubject("service.echo")
+            handler(handler)
+        }
+
+        val service = natsServiceOf(nc, "echo-service", "1.0.0", endpoint)
+
+        service.shouldNotBeNull()
+        service.name shouldBeEqualTo "echo-service"
+    }
+
+    @Test
+    fun `natsServiceOf with builder block applies additional config`() {
+        val service = natsServiceOf(nc, "svc", "1.0.0") {
+            description("A test service")
+        }
+
+        service.shouldNotBeNull()
+        service.name shouldBeEqualTo "svc"
+    }
+}

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/service/ServiceExtensionsTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/service/ServiceExtensionsTest.kt
@@ -5,11 +5,17 @@ import io.nats.client.Connection
 import io.nats.service.ServiceMessageHandler
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class ServiceExtensionsTest {
 
-    private val nc = mockk<Connection>(relaxed = true)
+    private lateinit var nc: Connection
+
+    @BeforeEach
+    fun setUp() {
+        nc = mockk<Connection>(relaxed = true)
+    }
 
     @Test
     fun `natsService with minimal config creates Service`() {


### PR DESCRIPTION
## Summary

Closes #177

- PR 제목: test: bluetape4k-nats 테스트 커버리지 개선 (49% → 79.45%)

Closes #177

`infra/nats` 모듈의 라인 커버리지를 **49.08% → 79.45%**로 개선합니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 신규 테스트 파일 10개 (서버 없이 실행 가능)

| 파일 | 대상 |
|------|------|
| `OptionsTest` | `natsOptions`, `natsOptionsOf` DSL 빌더 |
| `JetStreamOptionsTest` | `jetStreamOptionsOf`, `defaultJetStreamOptions` |
| `PublishOptionsTest` | `publishOptions`, `publishOptionsOf` 빌더 |
| `KeyValueOptionsTest` | `keyValueOptions` 3가지 오버로드 + JetStreamOptions 전파 검증 |
| `PullSubscriptionOptionsTest` | `pullSubscriptionOptionsOf` + blank 입력 검증 |
| `PushSubscriptionOptionsTest` | `pushSubscriptionOf` 2가지 오버로드 + 경계값 |
| `NatsMessageTest` | `natsMessageOf` 3가지 오버로드 + null/blank 검증 |
| `ConnectionExtensionsTest` | publish/request/requestAsync/requestSuspending/drainSuspending (MockK) |
| `ConsumerExtensionsTest` | Consumer.drain/drainSuspending kotlin+java Duration (MockK) |
| `ServiceExtensionsTest` | natsService/natsServiceOf DSL 빌더 (MockK Connection) |

### 커버리지 상세

```
BEFORE: 160/326 = 49.08%
AFTER:  259/326 = 79.45%  (+68라인 이상 커버)
```

### 기존 섹션: 검증 명령

```bash
./gradlew :bluetape4k-nats:test
./gradlew :bluetape4k-nats:koverXmlReport
```

### 기존 섹션: 참고

- 모든 신규 테스트는 Testcontainers(NATS 서버) 없이 실행 가능 (MockK 단위 테스트)
- 코루틴 테스트: `runTest` + `CompletableFuture.completedFuture`로 서버 없이 await 검증
- per_class 라이프사이클 대응: MockK mock은 `@BeforeEach`에서 재초기화

## Validation

```
165 tests passing (1m 20s)
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #177, milestone 없음, assignee `debop`
- PR: #182, head `b4ebddc028756d49de6a53bb3fe7c3d2f7c34468`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/test-nats-coverage`
- Labels: `test`
- State: `MERGED`, merge commit `85103aef06b4432994cd19cd94c3b1b56822fe33`
- CI: ./gradlew :bluetape4k-nats:test / ./gradlew :bluetape4k-nats:koverXmlReport

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #182 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `85103aef06b4432994cd19cd94c3b1b56822fe33`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
