### PR TITLE
test: utils/math 테스트 커버리지 65.4% → 70.7% 향상

### DIFF
--- a/utils/math/src/test/kotlin/io/bluetape4k/math/geometry/euclidean/Vector1DSupportTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/geometry/euclidean/Vector1DSupportTest.kt
@@ -1,0 +1,70 @@
+package io.bluetape4k.math.geometry.euclidean
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeNear
+import org.apache.commons.math3.geometry.euclidean.oned.Vector1D
+import org.junit.jupiter.api.Test
+
+class Vector1DSupportTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `두 1차원 벡터를 더할 수 있다`() {
+        val v1 = Vector1D(1.0)
+        val v2 = Vector1D(2.0)
+        val result = v1 + v2
+        result.x.shouldBeNear(3.0, 1e-10)
+    }
+
+    @Test
+    fun `두 1차원 벡터를 뺄 수 있다`() {
+        val v1 = Vector1D(5.0)
+        val v2 = Vector1D(3.0)
+        val result = v1 - v2
+        result.x.shouldBeNear(2.0, 1e-10)
+    }
+
+    @Test
+    fun `숫자를 1차원 벡터로 변환할 수 있다`() {
+        val v = 3.14.toVector1D()
+        v.x.shouldBeNear(3.14, 1e-10)
+    }
+
+    @Test
+    fun `Int를 1차원 벡터로 변환할 수 있다`() {
+        val v = 5.toVector1D()
+        v.x.shouldBeNear(5.0, 1e-10)
+    }
+
+    @Test
+    fun `스칼라와 벡터의 선형 결합으로 1차원 벡터를 생성한다`() {
+        val u = Vector1D(2.0)
+        val v = vector1DOf(3.0, u)
+        v.x.shouldBeNear(6.0, 1e-10)
+    }
+
+    @Test
+    fun `두 스칼라-벡터 쌍의 선형 결합으로 1차원 벡터를 생성한다`() {
+        val u1 = Vector1D(1.0)
+        val u2 = Vector1D(2.0)
+        val v = vector1DOf(2.0, u1, 3.0, u2)
+        v.x.shouldBeNear(8.0, 1e-10)
+    }
+
+    @Test
+    fun `세 스칼라-벡터 쌍의 선형 결합으로 1차원 벡터를 생성한다`() {
+        val u1 = Vector1D(1.0)
+        val u2 = Vector1D(2.0)
+        val u3 = Vector1D(3.0)
+        val v = vector1DOf(1.0, u1, 2.0, u2, 3.0, u3)
+        v.x.shouldBeNear(14.0, 1e-10)
+    }
+
+    @Test
+    fun `네 스칼라-벡터 쌍의 선형 결합으로 1차원 벡터를 생성한다`() {
+        val u = Vector1D(1.0)
+        val v = vector1DOf(1.0, u, 2.0, u, 3.0, u, 4.0, u)
+        v.x.shouldBeNear(10.0, 1e-10)
+    }
+}

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/geometry/euclidean/Vector2DSupportTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/geometry/euclidean/Vector2DSupportTest.kt
@@ -1,0 +1,74 @@
+package io.bluetape4k.math.geometry.euclidean
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeNear
+import org.apache.commons.math3.geometry.euclidean.twod.Vector2D
+import org.junit.jupiter.api.Test
+import kotlin.math.PI
+
+class Vector2DSupportTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `DoubleArray를 2차원 벡터로 변환할 수 있다`() {
+        val v = doubleArrayOf(3.0, 4.0).toVector2D()
+        v.x.shouldBeNear(3.0, 1e-10)
+        v.y.shouldBeNear(4.0, 1e-10)
+    }
+
+    @Test
+    fun `x, y 좌표로 2차원 벡터를 생성할 수 있다`() {
+        val v = vector2DOf(3.0, 4.0)
+        v.x.shouldBeNear(3.0, 1e-10)
+        v.y.shouldBeNear(4.0, 1e-10)
+    }
+
+    @Test
+    fun `두 2차원 벡터를 더할 수 있다`() {
+        val v1 = vector2DOf(1.0, 2.0)
+        val v2 = vector2DOf(3.0, 4.0)
+        val result = v1 + v2
+        result.x.shouldBeNear(4.0, 1e-10)
+        result.y.shouldBeNear(6.0, 1e-10)
+    }
+
+    @Test
+    fun `두 2차원 벡터를 뺄 수 있다`() {
+        val v1 = vector2DOf(5.0, 7.0)
+        val v2 = vector2DOf(2.0, 3.0)
+        val result = v1 - v2
+        result.x.shouldBeNear(3.0, 1e-10)
+        result.y.shouldBeNear(4.0, 1e-10)
+    }
+
+    @Test
+    fun `스칼라와 2차원 벡터를 곱할 수 있다`() {
+        val v = vector2DOf(1.0, 2.0)
+        val result = 3.0 * v
+        result.x.shouldBeNear(3.0, 1e-10)
+        result.y.shouldBeNear(6.0, 1e-10)
+    }
+
+    @Test
+    fun `두 2차원 벡터 사이의 각도를 계산할 수 있다`() {
+        val v1 = vector2DOf(1.0, 0.0)
+        val v2 = vector2DOf(0.0, 1.0)
+        val angle = v1.angle(v2)
+        angle.shouldBeNear(PI / 2, 1e-10)
+    }
+
+    @Test
+    fun `동일한 방향의 두 벡터의 각도는 0이다`() {
+        val v1 = vector2DOf(1.0, 0.0)
+        val v2 = vector2DOf(2.0, 0.0)
+        val angle = v1.angle(v2)
+        angle.shouldBeNear(0.0, 1e-10)
+    }
+
+    @Test
+    fun `영벡터가 아닌 벡터의 노름이 올바르다`() {
+        val v = vector2DOf(3.0, 4.0)
+        v.norm.shouldBeNear(5.0, 1e-10)
+    }
+}

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/geometry/euclidean/Vector3DSupportTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/geometry/euclidean/Vector3DSupportTest.kt
@@ -3,7 +3,6 @@ package io.bluetape4k.math.geometry.euclidean
 import io.bluetape4k.logging.KLogging
 import org.amshove.kluent.shouldBeNear
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D
-import kotlin.math.PI
 import org.junit.jupiter.api.Test
 import kotlin.math.PI
 

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/geometry/euclidean/Vector3DSupportTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/geometry/euclidean/Vector3DSupportTest.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.math.geometry.euclidean
 import io.bluetape4k.logging.KLogging
 import org.amshove.kluent.shouldBeNear
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D
+import kotlin.math.PI
 import org.junit.jupiter.api.Test
 import kotlin.math.PI
 
@@ -28,10 +29,23 @@ class Vector3DSupportTest {
 
     @Test
     fun `구면 좌표로 3차원 벡터를 생성할 수 있다`() {
-        val v = vector3DOf(alpha = 0.0, delta = 0.0)
-        v.x.shouldBeNear(1.0, 1e-10)
-        v.y.shouldBeNear(0.0, 1e-10)
-        v.z.shouldBeNear(0.0, 1e-10)
+        // alpha=0, delta=0 → (cos(0)*cos(0), cos(0)*sin(0), sin(0)) = (1, 0, 0)
+        val v0 = vector3DOf(alpha = 0.0, delta = 0.0)
+        v0.x.shouldBeNear(1.0, 1e-10)
+        v0.y.shouldBeNear(0.0, 1e-10)
+        v0.z.shouldBeNear(0.0, 1e-10)
+
+        // alpha=π/2, delta=0 → (0, 1, 0)
+        val v1 = vector3DOf(alpha = PI / 2, delta = 0.0)
+        v1.x.shouldBeNear(0.0, 1e-10)
+        v1.y.shouldBeNear(1.0, 1e-10)
+        v1.z.shouldBeNear(0.0, 1e-10)
+
+        // alpha=0, delta=π/2 → (0, 0, 1)
+        val v2 = vector3DOf(alpha = 0.0, delta = PI / 2)
+        v2.x.shouldBeNear(0.0, 1e-10)
+        v2.y.shouldBeNear(0.0, 1e-10)
+        v2.z.shouldBeNear(1.0, 1e-10)
     }
 
     @Test

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/geometry/euclidean/Vector3DSupportTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/geometry/euclidean/Vector3DSupportTest.kt
@@ -1,0 +1,100 @@
+package io.bluetape4k.math.geometry.euclidean
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeNear
+import org.apache.commons.math3.geometry.euclidean.threed.Vector3D
+import org.junit.jupiter.api.Test
+import kotlin.math.PI
+
+class Vector3DSupportTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `DoubleArray를 3차원 벡터로 변환할 수 있다`() {
+        val v = doubleArrayOf(1.0, 2.0, 3.0).toVector3D()
+        v.x.shouldBeNear(1.0, 1e-10)
+        v.y.shouldBeNear(2.0, 1e-10)
+        v.z.shouldBeNear(3.0, 1e-10)
+    }
+
+    @Test
+    fun `x, y, z 좌표로 3차원 벡터를 생성할 수 있다`() {
+        val v = vector3DOf(1.0, 2.0, 3.0)
+        v.x.shouldBeNear(1.0, 1e-10)
+        v.y.shouldBeNear(2.0, 1e-10)
+        v.z.shouldBeNear(3.0, 1e-10)
+    }
+
+    @Test
+    fun `구면 좌표로 3차원 벡터를 생성할 수 있다`() {
+        val v = vector3DOf(alpha = 0.0, delta = 0.0)
+        v.x.shouldBeNear(1.0, 1e-10)
+        v.y.shouldBeNear(0.0, 1e-10)
+        v.z.shouldBeNear(0.0, 1e-10)
+    }
+
+    @Test
+    fun `스칼라와 벡터의 선형 결합으로 3차원 벡터를 생성한다`() {
+        val u = Vector3D.PLUS_I
+        val v = vector3DOf(2.0, u)
+        v.x.shouldBeNear(2.0, 1e-10)
+        v.y.shouldBeNear(0.0, 1e-10)
+        v.z.shouldBeNear(0.0, 1e-10)
+    }
+
+    @Test
+    fun `두 스칼라-벡터 쌍의 선형 결합으로 3차원 벡터를 생성한다`() {
+        val u1 = Vector3D.PLUS_I
+        val u2 = Vector3D.PLUS_J
+        val v = vector3DOf(2.0, u1, 3.0, u2)
+        v.x.shouldBeNear(2.0, 1e-10)
+        v.y.shouldBeNear(3.0, 1e-10)
+        v.z.shouldBeNear(0.0, 1e-10)
+    }
+
+    @Test
+    fun `세 스칼라-벡터 쌍의 선형 결합으로 3차원 벡터를 생성한다`() {
+        val v = vector3DOf(1.0, Vector3D.PLUS_I, 2.0, Vector3D.PLUS_J, 3.0, Vector3D.PLUS_K)
+        v.x.shouldBeNear(1.0, 1e-10)
+        v.y.shouldBeNear(2.0, 1e-10)
+        v.z.shouldBeNear(3.0, 1e-10)
+    }
+
+    @Test
+    fun `네 스칼라-벡터 쌍의 선형 결합으로 3차원 벡터를 생성한다`() {
+        val u = Vector3D.PLUS_I
+        val v = vector3DOf(1.0, u, 2.0, u, 3.0, u, 4.0, u)
+        v.x.shouldBeNear(10.0, 1e-10)
+        v.y.shouldBeNear(0.0, 1e-10)
+        v.z.shouldBeNear(0.0, 1e-10)
+    }
+
+    @Test
+    fun `두 3차원 벡터를 더할 수 있다`() {
+        val v1 = vector3DOf(1.0, 2.0, 3.0)
+        val v2 = vector3DOf(4.0, 5.0, 6.0)
+        val result = v1 + v2
+        result.x.shouldBeNear(5.0, 1e-10)
+        result.y.shouldBeNear(7.0, 1e-10)
+        result.z.shouldBeNear(9.0, 1e-10)
+    }
+
+    @Test
+    fun `두 3차원 벡터를 뺄 수 있다`() {
+        val v1 = vector3DOf(5.0, 7.0, 9.0)
+        val v2 = vector3DOf(1.0, 2.0, 3.0)
+        val result = v1 - v2
+        result.x.shouldBeNear(4.0, 1e-10)
+        result.y.shouldBeNear(5.0, 1e-10)
+        result.z.shouldBeNear(6.0, 1e-10)
+    }
+
+    @Test
+    fun `두 3차원 벡터 사이의 각도를 계산할 수 있다`() {
+        val v1 = vector3DOf(1.0, 0.0, 0.0)
+        val v2 = vector3DOf(0.0, 1.0, 0.0)
+        val angle = v1.angle(v2)
+        angle.shouldBeNear(PI / 2, 1e-10)
+    }
+}

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/geometry/spherial/SpherialGeometryTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/geometry/spherial/SpherialGeometryTest.kt
@@ -1,0 +1,102 @@
+package io.bluetape4k.math.geometry.spherial
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.math.geometry.euclidean.vector3DOf
+import io.bluetape4k.math.geometry.spherial.oned.arcOf
+import io.bluetape4k.math.geometry.spherial.oned.arcsSetOf
+import io.bluetape4k.math.geometry.spherial.oned.toS1Point
+import io.bluetape4k.math.geometry.spherial.twod.circleOf
+import io.bluetape4k.math.geometry.spherial.twod.circlrOf
+import io.bluetape4k.math.geometry.spherial.twod.copy
+import io.bluetape4k.math.geometry.spherial.twod.s2PointOf
+import io.bluetape4k.math.geometry.spherial.twod.toS2Point
+import org.amshove.kluent.shouldBeNear
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.commons.math3.geometry.euclidean.threed.Vector3D
+import org.junit.jupiter.api.Test
+import kotlin.math.PI
+
+class SpherialGeometryTest {
+
+    companion object : KLogging()
+
+    // --- Arc (S1D) ---
+
+    @Test
+    fun `arcOf로 구면 1D 호를 생성할 수 있다`() {
+        val arc = arcOf(lower = 0.0, upper = PI, tolerance = 1e-10)
+        arc.inf.shouldBeNear(0.0, 1e-10)
+        arc.sup.shouldBeNear(PI, 1e-10)
+    }
+
+    // --- ArcsSet (S1D) ---
+
+    @Test
+    fun `arcsSetOf로 빈 ArcsSet을 생성할 수 있다`() {
+        val arcsSet = arcsSetOf(tolerance = 1e-10)
+        arcsSet.shouldNotBeNull()
+    }
+
+    @Test
+    fun `arcsSetOf로 단일 호를 담은 ArcsSet을 생성할 수 있다`() {
+        val arcsSet = arcsSetOf(lower = 0.0, upper = PI, tolerance = 1e-10)
+        arcsSet.shouldNotBeNull()
+        arcsSet.size.shouldBeNear(PI, 1e-10)
+    }
+
+    // --- S1Point ---
+
+    @Test
+    fun `Double을 구면 1D 점으로 변환할 수 있다`() {
+        val point = PI.toS1Point()
+        point.alpha.shouldBeNear(PI, 1e-10)
+    }
+
+    @Test
+    fun `Int를 구면 1D 점으로 변환할 수 있다`() {
+        val point = 1.toS1Point()
+        point.alpha.shouldBeNear(1.0, 1e-10)
+    }
+
+    // --- S2Point ---
+
+    @Test
+    fun `theta, phi로 구면 2D 점을 생성할 수 있다`() {
+        val point = s2PointOf(theta = 0.0, phi = PI / 2)
+        point.shouldNotBeNull()
+    }
+
+    @Test
+    fun `3D 벡터를 구면 2D 점으로 변환할 수 있다`() {
+        val v = Vector3D(0.0, 0.0, 1.0)
+        val point = v.toS2Point()
+        point.shouldNotBeNull()
+    }
+
+    // --- Circle (S2D) ---
+
+    @Test
+    fun `극 벡터로 구면 2D 원을 생성할 수 있다`() {
+        val pole = Vector3D(0.0, 0.0, 1.0)
+        val circle = circleOf(pole = pole, tolerance = 1e-10)
+        circle.shouldNotBeNull()
+        circle.pole.z.shouldBeNear(1.0, 1e-10)
+    }
+
+    @Test
+    fun `두 구면 점으로 대원을 생성할 수 있다`() {
+        // phi != 0 인 두 다른 점 사용 (phi=0이면 north pole이라 두 점이 동일해짐)
+        val p1 = s2PointOf(0.0, PI / 4)
+        val p2 = s2PointOf(PI / 2, PI / 4)
+        val circle = circlrOf(first = p1, second = p2, tolerance = 1e-10)
+        circle.shouldNotBeNull()
+    }
+
+    @Test
+    fun `Circle을 복사할 수 있다`() {
+        val original = circleOf(pole = Vector3D(0.0, 0.0, 1.0), tolerance = 1e-10)
+        val copy = original.copy()
+        copy.shouldNotBeNull()
+        copy.getPole().z.shouldBeNear(original.getPole().z, 1e-10)
+    }
+}

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/geometry/spherial/SpherialGeometryTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/geometry/spherial/SpherialGeometryTest.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.math.geometry.euclidean.vector3DOf
 import io.bluetape4k.math.geometry.spherial.oned.arcOf
 import io.bluetape4k.math.geometry.spherial.oned.arcsSetOf
+import io.bluetape4k.math.geometry.spherial.oned.buildArcsSet
 import io.bluetape4k.math.geometry.spherial.oned.toS1Point
 import io.bluetape4k.math.geometry.spherial.twod.circleOf
 import io.bluetape4k.math.geometry.spherial.twod.circlrOf
@@ -44,6 +45,15 @@ class SpherialGeometryTest {
         arcsSet.size.shouldBeNear(PI, 1e-10)
     }
 
+    @Test
+    fun `BSPTree로부터 ArcsSet을 생성할 수 있다`() {
+        val source = arcsSetOf(lower = 0.0, upper = PI, tolerance = 1e-10)
+        val tree = source.getTree(false)
+        val arcsSet = tree.buildArcsSet(tolerance = 1e-10)
+        arcsSet.shouldNotBeNull()
+        arcsSet.size.shouldBeNear(PI, 1e-10)
+    }
+
     // --- S1Point ---
 
     @Test
@@ -64,13 +74,17 @@ class SpherialGeometryTest {
     fun `theta, phi로 구면 2D 점을 생성할 수 있다`() {
         val point = s2PointOf(theta = 0.0, phi = PI / 2)
         point.shouldNotBeNull()
+        point.theta.shouldBeNear(0.0, 1e-10)
+        point.phi.shouldBeNear(PI / 2, 1e-10)
     }
 
     @Test
     fun `3D 벡터를 구면 2D 점으로 변환할 수 있다`() {
+        // (0, 0, 1) → north pole: phi = 0
         val v = Vector3D(0.0, 0.0, 1.0)
         val point = v.toS2Point()
         point.shouldNotBeNull()
+        point.phi.shouldBeNear(0.0, 1e-10)
     }
 
     // --- Circle (S2D) ---

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/linear/FieldMatrixSupportTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/linear/FieldMatrixSupportTest.kt
@@ -1,0 +1,135 @@
+package io.bluetape4k.math.linear
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.apache.commons.math3.fraction.Fraction
+import org.apache.commons.math3.fraction.FractionField
+import org.apache.commons.math3.linear.Array2DRowFieldMatrix
+import org.junit.jupiter.api.Test
+
+class FieldMatrixSupportTest {
+
+    companion object : KLogging()
+
+    private fun fractionMatrix(vararg rows: Array<Fraction>) =
+        Array2DRowFieldMatrix(rows)
+
+    private fun f(n: Int, d: Int = 1) = Fraction(n, d)
+
+    @Test
+    fun `인덱스로 필드 행렬의 원소를 가져올 수 있다`() {
+        val m = fractionMatrix(
+            arrayOf(f(1), f(2)),
+            arrayOf(f(3), f(4))
+        )
+        m[0, 0].shouldBeEqualTo(f(1))
+        m[1, 1].shouldBeEqualTo(f(4))
+    }
+
+    @Test
+    fun `인덱스로 필드 행렬의 원소를 설정할 수 있다`() {
+        val m = fractionMatrix(
+            arrayOf(f(1), f(2)),
+            arrayOf(f(3), f(4))
+        )
+        m[0, 0] = f(10)
+        m[0, 0].shouldBeEqualTo(f(10))
+    }
+
+    @Test
+    fun `두 필드 행렬을 더할 수 있다`() {
+        val m1 = fractionMatrix(
+            arrayOf(f(1), f(2)),
+            arrayOf(f(3), f(4))
+        )
+        val m2 = fractionMatrix(
+            arrayOf(f(5), f(6)),
+            arrayOf(f(7), f(8))
+        )
+        val result = m1 + m2
+        result[0, 0].shouldBeEqualTo(f(6))
+        result[1, 1].shouldBeEqualTo(f(12))
+    }
+
+    @Test
+    fun `필드 행렬에 스칼라를 더할 수 있다`() {
+        val m = fractionMatrix(
+            arrayOf(f(1), f(2)),
+            arrayOf(f(3), f(4))
+        )
+        val result = m + f(10)
+        result[0, 0].shouldBeEqualTo(f(11))
+        result[1, 1].shouldBeEqualTo(f(14))
+    }
+
+    @Test
+    fun `두 필드 행렬을 뺄 수 있다`() {
+        val m1 = fractionMatrix(
+            arrayOf(f(5), f(6)),
+            arrayOf(f(7), f(8))
+        )
+        val m2 = fractionMatrix(
+            arrayOf(f(1), f(2)),
+            arrayOf(f(3), f(4))
+        )
+        val result = m1 - m2
+        result[0, 0].shouldBeEqualTo(f(4))
+        result[1, 1].shouldBeEqualTo(f(4))
+    }
+
+    @Test
+    fun `필드 행렬에서 스칼라를 뺄 수 있다`() {
+        val m = fractionMatrix(
+            arrayOf(f(5), f(6)),
+            arrayOf(f(7), f(8))
+        )
+        val result = m - f(1)
+        result[0, 0].shouldBeEqualTo(f(4))
+        result[1, 1].shouldBeEqualTo(f(7))
+    }
+
+    @Test
+    fun `두 필드 행렬을 곱할 수 있다`() {
+        val m1 = fractionMatrix(
+            arrayOf(f(1), f(0)),
+            arrayOf(f(0), f(2))
+        )
+        val m2 = fractionMatrix(
+            arrayOf(f(3), f(0)),
+            arrayOf(f(0), f(4))
+        )
+        val result = m1 * m2
+        result[0, 0].shouldBeEqualTo(f(3))
+        result[1, 1].shouldBeEqualTo(f(8))
+    }
+
+    @Test
+    fun `필드 행렬에 스칼라를 곱할 수 있다`() {
+        val m = fractionMatrix(
+            arrayOf(f(1), f(2)),
+            arrayOf(f(3), f(4))
+        )
+        val result = m * f(2)
+        result[0, 0].shouldBeEqualTo(f(2))
+        result[1, 1].shouldBeEqualTo(f(8))
+    }
+
+    @Test
+    fun `필드 행렬을 스칼라로 나눌 수 있다`() {
+        val m = fractionMatrix(
+            arrayOf(f(2), f(4)),
+            arrayOf(f(6), f(8))
+        )
+        val result = m / f(2)
+        result[0, 0].shouldBeEqualTo(f(1))
+        result[1, 1].shouldBeEqualTo(f(4))
+    }
+
+    @Test
+    fun `createFieldMatrix로 FieldMatrix를 생성할 수 있다`() {
+        val field = FractionField.getInstance()
+        val m = field.createFieldMatrix(2, 3)
+        m.rowDimension.shouldBeEqualTo(2)
+        m.columnDimension.shouldBeEqualTo(3)
+    }
+}

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/linear/FieldVectorSupportTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/linear/FieldVectorSupportTest.kt
@@ -1,0 +1,105 @@
+package io.bluetape4k.math.linear
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.apache.commons.math3.fraction.Fraction
+import org.apache.commons.math3.linear.ArrayFieldVector
+import org.junit.jupiter.api.Test
+
+class FieldVectorSupportTest {
+
+    companion object : KLogging()
+
+    private fun fractionVector(vararg values: Fraction) = ArrayFieldVector(values)
+    private fun f(n: Int, d: Int = 1) = Fraction(n, d)
+
+    @Test
+    fun `인덱스로 필드 벡터의 원소를 가져올 수 있다`() {
+        val v = fractionVector(f(1), f(2), f(3))
+        v[0].shouldBeEqualTo(f(1))
+        v[2].shouldBeEqualTo(f(3))
+    }
+
+    @Test
+    fun `인덱스로 필드 벡터의 원소를 설정할 수 있다`() {
+        val v = fractionVector(f(1), f(2), f(3))
+        v[1] = f(10)
+        v[1].shouldBeEqualTo(f(10))
+    }
+
+    @Test
+    fun `두 필드 벡터를 더할 수 있다`() {
+        val v1 = fractionVector(f(1), f(2), f(3))
+        val v2 = fractionVector(f(4), f(5), f(6))
+        val result = v1 + v2
+        result[0].shouldBeEqualTo(f(5))
+        result[1].shouldBeEqualTo(f(7))
+        result[2].shouldBeEqualTo(f(9))
+    }
+
+    @Test
+    fun `필드 벡터에 스칼라를 더할 수 있다`() {
+        val v = fractionVector(f(1), f(2), f(3))
+        val result = v + f(10)
+        result[0].shouldBeEqualTo(f(11))
+        result[1].shouldBeEqualTo(f(12))
+        result[2].shouldBeEqualTo(f(13))
+    }
+
+    @Test
+    fun `두 필드 벡터를 뺄 수 있다`() {
+        val v1 = fractionVector(f(4), f(5), f(6))
+        val v2 = fractionVector(f(1), f(2), f(3))
+        val result = v1 - v2
+        result[0].shouldBeEqualTo(f(3))
+        result[1].shouldBeEqualTo(f(3))
+        result[2].shouldBeEqualTo(f(3))
+    }
+
+    @Test
+    fun `필드 벡터에서 스칼라를 뺄 수 있다`() {
+        val v = fractionVector(f(4), f(5), f(6))
+        val result = v - f(1)
+        result[0].shouldBeEqualTo(f(3))
+        result[1].shouldBeEqualTo(f(4))
+        result[2].shouldBeEqualTo(f(5))
+    }
+
+    @Test
+    fun `두 필드 벡터를 원소별로 곱할 수 있다`() {
+        val v1 = fractionVector(f(1), f(2), f(3))
+        val v2 = fractionVector(f(2), f(3), f(4))
+        val result = v1 * v2
+        result[0].shouldBeEqualTo(f(2))
+        result[1].shouldBeEqualTo(f(6))
+        result[2].shouldBeEqualTo(f(12))
+    }
+
+    @Test
+    fun `필드 벡터에 스칼라를 곱할 수 있다`() {
+        val v = fractionVector(f(1), f(2), f(3))
+        val result = v * f(3)
+        result[0].shouldBeEqualTo(f(3))
+        result[1].shouldBeEqualTo(f(6))
+        result[2].shouldBeEqualTo(f(9))
+    }
+
+    @Test
+    fun `두 필드 벡터를 원소별로 나눌 수 있다`() {
+        val v1 = fractionVector(f(6), f(8), f(10))
+        val v2 = fractionVector(f(2), f(4), f(5))
+        val result = v1 / v2
+        result[0].shouldBeEqualTo(f(3))
+        result[1].shouldBeEqualTo(f(2))
+        result[2].shouldBeEqualTo(f(2))
+    }
+
+    @Test
+    fun `필드 벡터를 스칼라로 나눌 수 있다`() {
+        val v = fractionVector(f(4), f(6), f(8))
+        val result = v / f(2)
+        result[0].shouldBeEqualTo(f(2))
+        result[1].shouldBeEqualTo(f(3))
+        result[2].shouldBeEqualTo(f(4))
+    }
+}

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/linear/MatrixSupportTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/linear/MatrixSupportTest.kt
@@ -1,0 +1,129 @@
+package io.bluetape4k.math.linear
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNear
+import org.amshove.kluent.shouldBeTrue
+import org.apache.commons.math3.linear.Array2DRowRealMatrix
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class MatrixSupportTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `diagonalMatrixOf로 대각행렬을 생성할 수 있다`() {
+        val m = diagonalMatrixOf(3)
+        m.rowDimension.shouldBeEqualTo(3)
+        m.columnDimension.shouldBeEqualTo(3)
+    }
+
+    @Test
+    fun `원소 배열로 대각행렬을 생성할 수 있다`() {
+        val m = diagonalMatrixOf(doubleArrayOf(1.0, 2.0, 3.0))
+        m.getEntry(0, 0).shouldBeNear(1.0, 1e-10)
+        m.getEntry(1, 1).shouldBeNear(2.0, 1e-10)
+        m.getEntry(2, 2).shouldBeNear(3.0, 1e-10)
+    }
+
+    @Test
+    fun `2차원 배열로 RealMatrix를 생성할 수 있다`() {
+        val m = arrayOf(
+            doubleArrayOf(1.0, 2.0),
+            doubleArrayOf(3.0, 4.0)
+        ).createRealMatrix()
+        m.getEntry(0, 0).shouldBeNear(1.0, 1e-10)
+        m.getEntry(1, 1).shouldBeNear(4.0, 1e-10)
+    }
+
+    @Test
+    fun `realMatrixOf로 RealMatrix를 생성할 수 있다`() {
+        val m = realMatrixOf(2, 3)
+        m.rowDimension.shouldBeEqualTo(2)
+        m.columnDimension.shouldBeEqualTo(3)
+    }
+
+    @Test
+    fun `realIdentityMatrixOf로 단위행렬을 생성할 수 있다`() {
+        val I = realIdentityMatrixOf(3)
+        I.getEntry(0, 0).shouldBeNear(1.0, 1e-10)
+        I.getEntry(1, 1).shouldBeNear(1.0, 1e-10)
+        I.getEntry(2, 2).shouldBeNear(1.0, 1e-10)
+        I.getEntry(0, 1).shouldBeNear(0.0, 1e-10)
+    }
+
+    @Test
+    fun `realDiagonalMatrixOf로 실수 대각행렬을 생성할 수 있다`() {
+        val m = realDiagonalMatrixOf(doubleArrayOf(5.0, 6.0, 7.0))
+        m.getEntry(0, 0).shouldBeNear(5.0, 1e-10)
+        m.getEntry(1, 1).shouldBeNear(6.0, 1e-10)
+        m.getEntry(2, 2).shouldBeNear(7.0, 1e-10)
+    }
+
+    @Test
+    fun `realVectorOf로 실수 벡터를 생성할 수 있다`() {
+        val v = realVectorOf(doubleArrayOf(1.0, 2.0, 3.0))
+        v.getDimension().shouldBeEqualTo(3)
+        v.getEntry(0).shouldBeNear(1.0, 1e-10)
+    }
+
+    @Test
+    fun `rowRealMatrixOf로 행 행렬을 생성할 수 있다`() {
+        val m = rowRealMatrixOf(doubleArrayOf(1.0, 2.0, 3.0))
+        m.rowDimension.shouldBeEqualTo(1)
+        m.columnDimension.shouldBeEqualTo(3)
+    }
+
+    @Test
+    fun `columnRealMatrixOf로 열 행렬을 생성할 수 있다`() {
+        val m = columnRealMatrixOf(doubleArrayOf(1.0, 2.0, 3.0))
+        m.rowDimension.shouldBeEqualTo(3)
+        m.columnDimension.shouldBeEqualTo(1)
+    }
+
+    @Test
+    fun `단위행렬은 대칭이다`() {
+        val I = realIdentityMatrixOf(3)
+        I.isSymmetric().shouldBeTrue()
+    }
+
+    @Test
+    fun `단위행렬의 역행렬은 자기 자신이다`() {
+        val I = realIdentityMatrixOf(3)
+        val inv = I.inverse()
+        inv.getEntry(0, 0).shouldBeNear(1.0, 1e-10)
+        inv.getEntry(1, 1).shouldBeNear(1.0, 1e-10)
+    }
+
+    @Test
+    fun `2x2 행렬의 역행렬을 계산할 수 있다`() {
+        val m = Array2DRowRealMatrix(
+            arrayOf(doubleArrayOf(2.0, 0.0), doubleArrayOf(0.0, 2.0))
+        )
+        val inv = m.inverse()
+        inv.getEntry(0, 0).shouldBeNear(0.5, 1e-10)
+        inv.getEntry(1, 1).shouldBeNear(0.5, 1e-10)
+    }
+
+    @Test
+    fun `checkMatrixIndex는 유효한 인덱스에서 예외를 던지지 않는다`() {
+        val m = realMatrixOf(3, 3)
+        m.checkMatrixIndex(0, 0)
+        m.checkMatrixIndex(2, 2)
+    }
+
+    @Test
+    fun `checkRowIndex는 유효한 행 인덱스에서 예외를 던지지 않는다`() {
+        val m = realMatrixOf(3, 3)
+        m.checkRowIndex(0)
+        m.checkRowIndex(2)
+    }
+
+    @Test
+    fun `checkColumnIndex는 유효한 열 인덱스에서 예외를 던지지 않는다`() {
+        val m = realMatrixOf(3, 3)
+        m.checkColumnIndex(0)
+        m.checkColumnIndex(2)
+    }
+}

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/linear/MatrixSupportTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/linear/MatrixSupportTest.kt
@@ -4,6 +4,10 @@ import io.bluetape4k.logging.KLogging
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNear
 import org.amshove.kluent.shouldBeTrue
+import org.apache.commons.math3.fraction.BigFraction
+import org.apache.commons.math3.fraction.BigFractionField
+import org.apache.commons.math3.fraction.Fraction
+import org.apache.commons.math3.fraction.FractionField
 import org.apache.commons.math3.linear.Array2DRowRealMatrix
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -125,5 +129,120 @@ class MatrixSupportTest {
         val m = realMatrixOf(3, 3)
         m.checkColumnIndex(0)
         m.checkColumnIndex(2)
+    }
+
+    @Test
+    fun `checkRowIndex는 유효 범위를 벗어난 인덱스에서 예외를 던진다`() {
+        val m = realMatrixOf(3, 3)
+        assertThrows<Exception> { m.checkRowIndex(99) }
+        assertThrows<Exception> { m.checkRowIndex(-1) }
+    }
+
+    @Test
+    fun `checkColumnIndex는 유효 범위를 벗어난 인덱스에서 예외를 던진다`() {
+        val m = realMatrixOf(3, 3)
+        assertThrows<Exception> { m.checkColumnIndex(99) }
+    }
+
+    @Test
+    fun `checkMatrixIndex는 유효 범위를 벗어난 인덱스에서 예외를 던진다`() {
+        val m = realMatrixOf(3, 3)
+        assertThrows<Exception> { m.checkMatrixIndex(99, 0) }
+        assertThrows<Exception> { m.checkMatrixIndex(0, 99) }
+    }
+
+    @Test
+    fun `checkAdditionCompatible은 크기가 다른 행렬에서 예외를 던진다`() {
+        val m1 = realMatrixOf(2, 3)
+        val m2 = realMatrixOf(3, 2)
+        assertThrows<Exception> { m1.checkAdditionCompatible(m2) }
+    }
+
+    @Test
+    fun `checkMultiplicationCompatible은 열-행 크기가 맞지 않으면 예외를 던진다`() {
+        val m1 = realMatrixOf(2, 3)
+        val m2 = realMatrixOf(2, 2)
+        assertThrows<Exception> { m1.checkMultiplicationCompatible(m2) }
+    }
+
+    @Test
+    fun `solveLowerTriangularSystem은 하삼각 시스템을 푼다`() {
+        val L = Array2DRowRealMatrix(
+            arrayOf(doubleArrayOf(1.0, 0.0), doubleArrayOf(2.0, 1.0))
+        )
+        val b = realVectorOf(doubleArrayOf(1.0, 4.0))
+        L.solveLowerTriangularSystem(b)
+        // L·[1,2]=[1,4] : x0=1, x1=4-2*1=2
+        b.getEntry(0).shouldBeNear(1.0, 1e-10)
+        b.getEntry(1).shouldBeNear(2.0, 1e-10)
+    }
+
+    @Test
+    fun `solveUpperTriangularSystem은 상삼각 시스템을 푼다`() {
+        val U = Array2DRowRealMatrix(
+            arrayOf(doubleArrayOf(2.0, 1.0), doubleArrayOf(0.0, 1.0))
+        )
+        val b = realVectorOf(doubleArrayOf(5.0, 3.0))
+        U.solveUpperTriangularSystem(b)
+        // x1=3, x0=(5-1*3)/2=1
+        b.getEntry(0).shouldBeNear(1.0, 1e-10)
+        b.getEntry(1).shouldBeNear(3.0, 1e-10)
+    }
+
+    @Test
+    fun `blockInverse는 단위행렬의 역행렬로 단위행렬을 반환한다`() {
+        val I4 = realIdentityMatrixOf(4)
+        val inv = I4.blockInverse(2)
+        inv.getEntry(0, 0).shouldBeNear(1.0, 1e-10)
+        inv.getEntry(1, 1).shouldBeNear(1.0, 1e-10)
+        inv.getEntry(2, 2).shouldBeNear(1.0, 1e-10)
+        inv.getEntry(3, 3).shouldBeNear(1.0, 1e-10)
+        inv.getEntry(0, 1).shouldBeNear(0.0, 1e-10)
+    }
+
+    @Test
+    fun `fieldVectorOf로 Fraction 벡터를 생성할 수 있다`() {
+        val fv = fieldVectorOf(arrayOf(Fraction(1), Fraction(2), Fraction(3)))
+        fv.dimension.shouldBeEqualTo(3)
+        fv.getEntry(0).shouldBeEqualTo(Fraction(1))
+        fv.getEntry(2).shouldBeEqualTo(Fraction(3))
+    }
+
+    @Test
+    fun `rowFieldMatrixOf로 Fraction 행 행렬을 생성할 수 있다`() {
+        val m = rowFieldMatrixOf(arrayOf(Fraction(1), Fraction(2), Fraction(3)))
+        m.rowDimension.shouldBeEqualTo(1)
+        m.columnDimension.shouldBeEqualTo(3)
+    }
+
+    @Test
+    fun `columnFieldMatrixOf로 Fraction 열 행렬을 생성할 수 있다`() {
+        val m = columnFieldMatrixOf(arrayOf(Fraction(4), Fraction(5)))
+        m.rowDimension.shouldBeEqualTo(2)
+        m.columnDimension.shouldBeEqualTo(1)
+    }
+
+    @Test
+    fun `FieldMatrix Fraction을 RealMatrix로 변환할 수 있다`() {
+        val field = FractionField.getInstance()
+        val fm = field.createFieldMatrix(2, 2)
+        fm.setEntry(0, 0, Fraction(1))
+        fm.setEntry(0, 1, Fraction(2))
+        fm.setEntry(1, 0, Fraction(3))
+        fm.setEntry(1, 1, Fraction(4))
+        val rm = fm.toRealMatrix()
+        rm.getEntry(0, 0).shouldBeNear(1.0, 1e-10)
+        rm.getEntry(1, 1).shouldBeNear(4.0, 1e-10)
+    }
+
+    @Test
+    fun `FieldMatrix BigFraction을 RealMatrix로 변환할 수 있다`() {
+        val field = BigFractionField.getInstance()
+        val fm = field.createFieldMatrix(2, 2)
+        fm.setEntry(0, 0, BigFraction(5))
+        fm.setEntry(1, 1, BigFraction(6))
+        val rm = fm.toRealMatrix()
+        rm.getEntry(0, 0).shouldBeNear(5.0, 1e-10)
+        rm.getEntry(1, 1).shouldBeNear(6.0, 1e-10)
     }
 }

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/ml/DistanceMeasureMethodTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/ml/DistanceMeasureMethodTest.kt
@@ -4,7 +4,9 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.math.ml.clustering.doublePointOf
 import io.bluetape4k.math.ml.distance.DistanceMeasureMethod
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
 import org.amshove.kluent.shouldBeNear
+import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Test
 
@@ -40,8 +42,9 @@ class DistanceMeasureMethodTest {
     fun `Canberra 거리를 계산할 수 있다`() {
         val a = doubleArrayOf(1.0, 2.0)
         val b = doubleArrayOf(3.0, 4.0)
+        // |1-3|/(1+3) + |2-4|/(2+4) = 0.5 + 1/3 = 5/6
         val dist = DistanceMeasureMethod.Canberra.compute(a, b)
-        dist > 0.0
+        dist.shouldBeNear(5.0 / 6.0, 1e-10)
     }
 
     @Test
@@ -49,7 +52,7 @@ class DistanceMeasureMethodTest {
         val a = doubleArrayOf(1.0, 2.0, 3.0)
         val b = doubleArrayOf(4.0, 5.0, 6.0)
         val dist = DistanceMeasureMethod.EarthMovers.compute(a, b)
-        dist > 0.0
+        dist shouldBeGreaterThan 0.0
     }
 
     @Test
@@ -77,7 +80,7 @@ class DistanceMeasureMethodTest {
     @Test
     fun `존재하지 않는 이름은 null을 반환한다`() {
         val method = DistanceMeasureMethod.parse("unknown")
-        method shouldBeEqualTo null
+        method.shouldBeNull()
     }
 
     @Test

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/ml/DistanceMeasureMethodTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/ml/DistanceMeasureMethodTest.kt
@@ -84,6 +84,16 @@ class DistanceMeasureMethodTest {
     }
 
     @Test
+    fun `빈 문자열은 null을 반환한다`() {
+        DistanceMeasureMethod.parse("").shouldBeNull()
+    }
+
+    @Test
+    fun `공백 문자열은 null을 반환한다`() {
+        DistanceMeasureMethod.parse("   ").shouldBeNull()
+    }
+
+    @Test
     fun `동일한 점 사이의 거리는 0이다`() {
         val a = doubleArrayOf(1.0, 2.0, 3.0)
         DistanceMeasureMethod.Euclidean.compute(a, a).shouldBeNear(0.0, 1e-10)

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/ml/DistanceMeasureMethodTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/ml/DistanceMeasureMethodTest.kt
@@ -1,0 +1,90 @@
+package io.bluetape4k.math.ml
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.math.ml.clustering.doublePointOf
+import io.bluetape4k.math.ml.distance.DistanceMeasureMethod
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNear
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+
+class DistanceMeasureMethodTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `Euclidean 거리를 계산할 수 있다`() {
+        val a = doubleArrayOf(0.0, 0.0)
+        val b = doubleArrayOf(3.0, 4.0)
+        val dist = DistanceMeasureMethod.Euclidean.compute(a, b)
+        dist.shouldBeNear(5.0, 1e-10)
+    }
+
+    @Test
+    fun `Manhattan 거리를 계산할 수 있다`() {
+        val a = doubleArrayOf(0.0, 0.0)
+        val b = doubleArrayOf(3.0, 4.0)
+        val dist = DistanceMeasureMethod.Manhattan.compute(a, b)
+        dist.shouldBeNear(7.0, 1e-10)
+    }
+
+    @Test
+    fun `Chebyshev 거리를 계산할 수 있다`() {
+        val a = doubleArrayOf(0.0, 0.0)
+        val b = doubleArrayOf(3.0, 4.0)
+        val dist = DistanceMeasureMethod.Chebyshev.compute(a, b)
+        dist.shouldBeNear(4.0, 1e-10)
+    }
+
+    @Test
+    fun `Canberra 거리를 계산할 수 있다`() {
+        val a = doubleArrayOf(1.0, 2.0)
+        val b = doubleArrayOf(3.0, 4.0)
+        val dist = DistanceMeasureMethod.Canberra.compute(a, b)
+        dist > 0.0
+    }
+
+    @Test
+    fun `EarthMovers 거리를 계산할 수 있다`() {
+        val a = doubleArrayOf(1.0, 2.0, 3.0)
+        val b = doubleArrayOf(4.0, 5.0, 6.0)
+        val dist = DistanceMeasureMethod.EarthMovers.compute(a, b)
+        dist > 0.0
+    }
+
+    @Test
+    fun `DoublePoint를 사용하여 거리를 계산할 수 있다`() {
+        val a = doublePointOf(0.0, 0.0)
+        val b = doublePointOf(3.0, 4.0)
+        val dist = DistanceMeasureMethod.Euclidean.compute(a, b)
+        dist.shouldBeNear(5.0, 1e-10)
+    }
+
+    @Test
+    fun `이름으로 DistanceMeasureMethod를 파싱할 수 있다`() {
+        val method = DistanceMeasureMethod.parse("euclidean")
+        method.shouldNotBeNull()
+        method.shouldBeEqualTo(DistanceMeasureMethod.Euclidean)
+    }
+
+    @Test
+    fun `대소문자 무시하여 파싱할 수 있다`() {
+        val method = DistanceMeasureMethod.parse("MANHATTAN")
+        method.shouldNotBeNull()
+        method.shouldBeEqualTo(DistanceMeasureMethod.Manhattan)
+    }
+
+    @Test
+    fun `존재하지 않는 이름은 null을 반환한다`() {
+        val method = DistanceMeasureMethod.parse("unknown")
+        method shouldBeEqualTo null
+    }
+
+    @Test
+    fun `동일한 점 사이의 거리는 0이다`() {
+        val a = doubleArrayOf(1.0, 2.0, 3.0)
+        DistanceMeasureMethod.Euclidean.compute(a, a).shouldBeNear(0.0, 1e-10)
+        DistanceMeasureMethod.Manhattan.compute(a, a).shouldBeNear(0.0, 1e-10)
+        DistanceMeasureMethod.Chebyshev.compute(a, a).shouldBeNear(0.0, 1e-10)
+    }
+}

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/ml/MapSupportTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/ml/MapSupportTest.kt
@@ -4,12 +4,14 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.math.ml.distance.DistanceMeasureMethod
 import io.bluetape4k.math.ml.neuralnet.computeHitHistogram
 import io.bluetape4k.math.ml.neuralnet.computeQuantizationError
+import io.bluetape4k.math.ml.neuralnet.computeTopographicError
 import io.bluetape4k.math.ml.neuralnet.computeU
 import io.bluetape4k.math.ml.neuralnet.findBest
 import io.bluetape4k.math.ml.neuralnet.findBestAndSecondBest
 import io.bluetape4k.math.ml.neuralnet.sort
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeInRange
 import org.amshove.kluent.shouldNotBeNull
 import org.apache.commons.math3.ml.neuralnet.FeatureInitializerFactory
 import org.apache.commons.math3.ml.neuralnet.SquareNeighbourhood
@@ -100,5 +102,17 @@ class MapSupportTest {
         // 각 데이터 포인트는 정확히 하나의 뉴런에 매핑되므로 합계 == data.size
         val totalHits = histogram.sumOf { row -> row.sum() }
         totalHits shouldBeEqualTo data.size
+    }
+
+    @Test
+    fun `computeTopographicError는 위상 오차를 0과 1 사이 값으로 반환한다`() {
+        val data = listOf(
+            doubleArrayOf(0.1, 0.1),
+            doubleArrayOf(0.9, 0.9),
+            doubleArrayOf(0.5, 0.5),
+            doubleArrayOf(0.2, 0.8)
+        )
+        val error = mesh.network.computeTopographicError(data, distance)
+        error shouldBeInRange 0.0..1.0
     }
 }

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/ml/MapSupportTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/ml/MapSupportTest.kt
@@ -1,0 +1,91 @@
+package io.bluetape4k.math.ml
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.math.ml.distance.DistanceMeasureMethod
+import io.bluetape4k.math.ml.neuralnet.computeHitHistogram
+import io.bluetape4k.math.ml.neuralnet.computeQuantizationError
+import io.bluetape4k.math.ml.neuralnet.computeU
+import io.bluetape4k.math.ml.neuralnet.findBest
+import io.bluetape4k.math.ml.neuralnet.findBestAndSecondBest
+import io.bluetape4k.math.ml.neuralnet.sort
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.commons.math3.ml.neuralnet.FeatureInitializerFactory
+import org.apache.commons.math3.ml.neuralnet.SquareNeighbourhood
+import org.apache.commons.math3.ml.neuralnet.twod.NeuronSquareMesh2D
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class MapSupportTest {
+
+    companion object : KLogging()
+
+    private lateinit var mesh: NeuronSquareMesh2D
+    private val distance: (DoubleArray, DoubleArray) -> Double =
+        { a, b -> DistanceMeasureMethod.Euclidean.compute(a, b) }
+
+    @BeforeEach
+    fun setup() {
+        val initializers = arrayOf(
+            FeatureInitializerFactory.uniform(0.0, 1.0),
+            FeatureInitializerFactory.uniform(0.0, 1.0)
+        )
+        mesh = NeuronSquareMesh2D(3, false, 3, false, SquareNeighbourhood.VON_NEUMANN, initializers)
+    }
+
+    @Test
+    fun `findBest는 가장 가까운 뉴런을 반환한다`() {
+        val features = doubleArrayOf(0.5, 0.5)
+        val neurons = mesh.network.toList()
+        val best = neurons.findBest(features, distance)
+        best.shouldNotBeNull()
+    }
+
+    @Test
+    fun `findBestAndSecondBest는 가장 가까운 두 뉴런을 반환한다`() {
+        val features = doubleArrayOf(0.5, 0.5)
+        val neurons = mesh.network.toList()
+        val (best, second) = neurons.findBestAndSecondBest(features, distance)
+        best.shouldNotBeNull()
+        second.shouldNotBeNull()
+    }
+
+    @Test
+    fun `sort는 거리 순으로 뉴런을 정렬한다`() {
+        val features = doubleArrayOf(0.5, 0.5)
+        val neurons = mesh.network.toList()
+        val sorted = neurons.sort(features, distance)
+        sorted.shouldNotBeNull()
+        sorted.size shouldBeGreaterOrEqualTo 1
+    }
+
+    @Test
+    fun `computeQuantizationError는 양자화 오차를 반환한다`() {
+        val data = listOf(
+            doubleArrayOf(0.1, 0.1),
+            doubleArrayOf(0.9, 0.9),
+            doubleArrayOf(0.5, 0.5)
+        )
+        val neurons = mesh.network.toList()
+        val error = neurons.computeQuantizationError(data, distance)
+        error shouldBeGreaterOrEqualTo 0.0
+    }
+
+    @Test
+    fun `computeU는 U-Matrix를 반환한다`() {
+        val uMatrix = mesh.computeU(distance)
+        uMatrix.shouldNotBeNull()
+        uMatrix.size shouldBeGreaterOrEqualTo 1
+    }
+
+    @Test
+    fun `computeHitHistogram은 히트 히스토그램을 반환한다`() {
+        val data = listOf(
+            doubleArrayOf(0.1, 0.1),
+            doubleArrayOf(0.9, 0.9)
+        )
+        val histogram = mesh.computeHitHistogram(data, distance)
+        histogram.shouldNotBeNull()
+        histogram.size shouldBeGreaterOrEqualTo 1
+    }
+}

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/ml/MapSupportTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/ml/MapSupportTest.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.math.ml.neuralnet.computeU
 import io.bluetape4k.math.ml.neuralnet.findBest
 import io.bluetape4k.math.ml.neuralnet.findBestAndSecondBest
 import io.bluetape4k.math.ml.neuralnet.sort
+import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeGreaterOrEqualTo
 import org.amshove.kluent.shouldNotBeNull
 import org.apache.commons.math3.ml.neuralnet.FeatureInitializerFactory
@@ -56,7 +57,13 @@ class MapSupportTest {
         val neurons = mesh.network.toList()
         val sorted = neurons.sort(features, distance)
         sorted.shouldNotBeNull()
-        sorted.size shouldBeGreaterOrEqualTo 1
+        // 모든 뉴런이 포함되어야 한다
+        sorted.size shouldBeEqualTo neurons.size
+        // 거리 비단조 증가 순서 검증
+        val distances = sorted.map { distance(it.features, features) }
+        for (i in 1 until distances.size) {
+            distances[i] shouldBeGreaterOrEqualTo distances[i - 1]
+        }
     }
 
     @Test
@@ -68,24 +75,30 @@ class MapSupportTest {
         )
         val neurons = mesh.network.toList()
         val error = neurons.computeQuantizationError(data, distance)
+        // 오차는 비음수: 뉴런이 데이터 범위 [0,1]^2 내에 있으므로 최대 대각 길이(√2) 미만
         error shouldBeGreaterOrEqualTo 0.0
     }
 
     @Test
-    fun `computeU는 U-Matrix를 반환한다`() {
+    fun `computeU는 3x3 mesh에서 3x3 U-Matrix를 반환한다`() {
         val uMatrix = mesh.computeU(distance)
         uMatrix.shouldNotBeNull()
-        uMatrix.size shouldBeGreaterOrEqualTo 1
+        // 3x3 NeuronSquareMesh2D → U-Matrix 차원도 3x3
+        uMatrix.size shouldBeEqualTo 3
+        uMatrix[0].size shouldBeEqualTo 3
     }
 
     @Test
-    fun `computeHitHistogram은 히트 히스토그램을 반환한다`() {
+    fun `computeHitHistogram은 히트 총합이 데이터 크기와 같다`() {
         val data = listOf(
             doubleArrayOf(0.1, 0.1),
             doubleArrayOf(0.9, 0.9)
         )
         val histogram = mesh.computeHitHistogram(data, distance)
         histogram.shouldNotBeNull()
-        histogram.size shouldBeGreaterOrEqualTo 1
+        histogram.size shouldBeEqualTo 3
+        // 각 데이터 포인트는 정확히 하나의 뉴런에 매핑되므로 합계 == data.size
+        val totalHits = histogram.sumOf { row -> row.sum() }
+        totalHits shouldBeEqualTo data.size
     }
 }

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/transform/TransformSupportTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/transform/TransformSupportTest.kt
@@ -1,0 +1,78 @@
+package io.bluetape4k.math.transform
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNear
+import org.apache.commons.math3.complex.Complex
+import org.junit.jupiter.api.Test
+
+class TransformSupportTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `DoubleArray를 스케일링할 수 있다`() {
+        val data = doubleArrayOf(1.0, 2.0, 3.0)
+        val result = data.scale(2.0)
+        result[0].shouldBeNear(2.0, 1e-10)
+        result[1].shouldBeNear(4.0, 1e-10)
+        result[2].shouldBeNear(6.0, 1e-10)
+    }
+
+    @Test
+    fun `DoubleArray를 0으로 스케일링하면 모두 0이 된다`() {
+        val data = doubleArrayOf(1.0, 2.0, 3.0)
+        val result = data.scale(0.0)
+        result[0].shouldBeNear(0.0, 1e-10)
+        result[1].shouldBeNear(0.0, 1e-10)
+        result[2].shouldBeNear(0.0, 1e-10)
+    }
+
+    @Test
+    fun `복소수 배열을 스케일링할 수 있다`() {
+        val data = arrayOf(Complex(1.0, 0.0), Complex(0.0, 1.0))
+        val result = data.scale(2.0)
+        result[0].real.shouldBeNear(2.0, 1e-10)
+        result[0].imaginary.shouldBeNear(0.0, 1e-10)
+        result[1].real.shouldBeNear(0.0, 1e-10)
+        result[1].imaginary.shouldBeNear(2.0, 1e-10)
+    }
+
+    @Test
+    fun `복소수 배열을 실수부와 허수부 2차원 배열로 변환할 수 있다`() {
+        val data = arrayOf(Complex(1.0, 2.0), Complex(3.0, 4.0))
+        val result = data.toRealImaginaryArray()
+        result[0][0].shouldBeNear(1.0, 1e-10)
+        result[0][1].shouldBeNear(3.0, 1e-10)
+        result[1][0].shouldBeNear(2.0, 1e-10)
+        result[1][1].shouldBeNear(4.0, 1e-10)
+    }
+
+    @Test
+    fun `2차원 실수 배열을 복소수 배열로 변환할 수 있다`() {
+        val data = arrayOf(doubleArrayOf(1.0, 3.0), doubleArrayOf(2.0, 4.0))
+        val result = data.toComplexArray()
+        result[0].real.shouldBeNear(1.0, 1e-10)
+        result[0].imaginary.shouldBeNear(2.0, 1e-10)
+        result[1].real.shouldBeNear(3.0, 1e-10)
+        result[1].imaginary.shouldBeNear(4.0, 1e-10)
+    }
+
+    @Test
+    fun `2의 거듭제곱에 대한 log2를 계산할 수 있다`() {
+        8.exactLog2().shouldBeEqualTo(3)
+        16.exactLog2().shouldBeEqualTo(4)
+        1.exactLog2().shouldBeEqualTo(0)
+        2.exactLog2().shouldBeEqualTo(1)
+    }
+
+    @Test
+    fun `toRealImaginaryArray 후 toComplexArray로 왕복 변환된다`() {
+        val original = arrayOf(Complex(1.0, 2.0), Complex(3.0, 4.0))
+        val roundTrip = original.toRealImaginaryArray().toComplexArray()
+        roundTrip[0].real.shouldBeNear(original[0].real, 1e-10)
+        roundTrip[0].imaginary.shouldBeNear(original[0].imaginary, 1e-10)
+        roundTrip[1].real.shouldBeNear(original[1].real, 1e-10)
+        roundTrip[1].imaginary.shouldBeNear(original[1].imaginary, 1e-10)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #181

- PR 제목: test: utils/math 테스트 커버리지 65.4% → 70.7% 향상

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 관련 이슈

Closes #181 — utils/math 테스트 커버리지 70% 이상 달성

utils/math 모듈의 테스트 커버리지가 65.36%로 목표치(70%)에 미달. 미테스트 패키지에 대한 테스트 클래스를 추가하여 70.72%를 달성.

### 기존 섹션: 작업 내역

- `geometry/euclidean`: Vector1D/2D/3DSupport 테스트 추가 (+/- 연산자, 생성자, angle 계산 등)
- `geometry/spherial`: Arc, ArcsSet, S1Point, S2Point, Circle 테스트 통합 추가
- `linear`: FieldMatrixSupport, FieldVectorSupport, MatrixSupport 테스트 추가
  - Fraction 타입 기반 사칙연산, 대각행렬, 단위행렬, 역행렬 등
- `ml/distance`: DistanceMeasureMethod 전 타입(Euclidean/Manhattan/Chebyshev/Canberra/EarthMovers) 테스트
- `ml/neuralnet`: MapSupport(findBest/findBestAndSecondBest/sort/computeQuantizationError/computeU/computeHitHistogram) 테스트
- `transform`: TransformSupport(scale/toRealImaginaryArray/toComplexArray/exactLog2) 테스트

### 기존 섹션: Spec DoD

| 항목 | 상태 |
|------|------|
| 기존 65.36% 커버리지에서 70% 이상 달성 | ✅ (70.72%) |
| 미테스트 패키지 모두 커버 | ✅ (10개 신규 테스트 클래스) |
| 기존 테스트 회귀 없음 | ✅ |

### 기존 섹션: PR 전 필수 체크 (CLAUDE.md)

| 항목 | 상태 |
|------|------|
| 로컬 테스트 전수 통과 | ✅ 549 passing, 0 failed |
| README.md / README.ko.md | ✅ N/A (테스트 전용 변경) |
| KDoc | ✅ N/A (테스트 파일) |
| worktree 작업 완료 | ✅ feat/math-test-coverage |

### 기존 섹션: Commits

5a110b1c2 test: utils/math 테스트 커버리지 65.4% → 70.7% 향상 (#181)

## Validation

Module : :bluetape4k-math
Tests  : 549 passing, 0 failed, 1 pending
Coverage: 70.72% (목표 70% 초과)
Date   : 2026-04-27

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #181, milestone 없음, assignee `debop`
- PR: #183, head `4cc4fd33e0a85377c1af67710a1bbd3b11ff47d8`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/math-test-coverage`
- Labels: `test`
- State: `MERGED`, merge commit `6a34687e90330e1c8665d2a873245702190b3b66`
- CI: - `geometry/spherial`: Arc, ArcsSet, S1Point, S2Point, Circle 테스트 통합 추가

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #183 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `6a34687e90330e1c8665d2a873245702190b3b66`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
