### PR TITLE
test: io/http 테스트 커버리지 32% → 72% 향상 (#178)

### DIFF
--- a/docs/superpowers/plans/2026-04-27-http-test-coverage-plan.md
+++ b/docs/superpowers/plans/2026-04-27-http-test-coverage-plan.md
@@ -1,0 +1,147 @@
+# io/http 테스트 커버리지 향상 구현 플랜
+
+관련 이슈: #178
+Spec: docs/superpowers/specs/2026-04-27-http-test-coverage-design.md
+
+## Task 목록
+
+### Group 1 — 순수 단위 테스트 (complexity: low)
+
+**T1** `hc5/http/HttpHostTest.kt` 작성
+- complexity: low
+- `URI.toHttpHost()`, `httpHostOf()` 검증
+- HTTP/HTTPS URL 파싱, 포트 포함 URL 파싱
+
+**T2** `hc5/http/ContentTypesTest.kt` 작성
+- complexity: low
+- `ContentTypes.TEXT_PLAIN_UTF8` MIME 타입 및 charset 검증
+
+**T3** `hc5/http/BasicRequestBuilderTest.kt` 작성
+- complexity: low
+- `basicHttpRequest(String)`, `basicHttpRequest(Method)` DSL
+- `basicHttpRequestOf()` 오버로드 (host+path, headers 포함)
+
+**T4** `hc5/http/BasicResponseBuilderTest.kt` 작성
+- complexity: low
+- `basicHttpResponse(Int)`, `basicHttpResponse(HttpResponse)` 상태코드/헤더 검증
+
+**T5** `hc5/http/ClassicRequestBuilderTest.kt` 작성
+- complexity: low
+- `classicRequest(String)`, `classicRequest(Method)` URI/메서드 검증
+
+**T6** `hc5/http/AuthScopeTest.kt` 작성
+- complexity: low
+- `authScopeOf(protocol, host, port)`, `authScopeOf(HttpHost)`, `authScopeOf(url)`, `authScopeOf(host, port)` 4가지 오버로드
+
+**T7** `hc5/http/ConnectExceptionSupportTest.kt` 작성
+- complexity: low
+- `IOException.toConnectTimeoutException()`, `IOException.toHttpHostConnectException()`, `IOException.enhance()` 검증
+
+**T8** `hc5/http/OperationsTest.kt` 작성
+- complexity: low
+- `Future<*>.toCancellable()` — CompletableFuture 로 검증
+
+**T9** `hc5/http/HttpRequestTest.kt` 작성
+- complexity: low
+- `HttpRequest.extractPathPrefix()` — classicRequest DSL로 요청 생성 후 prefix 추출 검증
+
+**T10** `hc5/http/ConfigBuilderTest.kt` 작성
+- complexity: low
+- `ConnectionConfig`, `RequestConfig`, `SocketConfig`, `TlsConfig`, `Http1Config`, `CharCodingConfig` 빌더 DSL 파라미터 검증
+
+**T11** `hc5/http2/H2ConfigTest.kt` 작성
+- complexity: low
+- `H2Config` DSL 빌더 파라미터 검증
+
+**T12** `hc5/reactor/IOReactorConfigTest.kt` 작성
+- complexity: low
+- `IOReactorConfig` DSL 빌더 파라미터 검증
+
+**T13** `hc5/entity/EntityBuilderTest.kt` 작성
+- complexity: low
+- `httpEntity {}`, `httpEntityOf(String)`, `httpEntityOf(ByteArray)` — Content-Type, 인코딩, 내용 검증
+
+**T14** `hc5/entity/HttpEntitySupportTest.kt` 작성
+- complexity: low
+- `consumeQuietly()`, `consume()`, `toByteArrayOrNull()`, `toStringOrNull()`, `parse()` 검증
+- StringEntity / ByteArrayEntity 로 검증
+
+**T15** `hc5/entity/MimeEntityTest.kt` 작성
+- complexity: low
+- `FormBodyPartBuilder`, `MultipartEntityBuilder`, `MultipartPartBuilder` DSL 빌더 생성 검증
+
+**T16** `hc5/auth/CredentialsProviderBuilderTest.kt` 작성
+- complexity: low
+- `credentialsProvider {}`, `emptyCredentialsProvider()`, `credentialsProviderOf(AuthScope, Credentials)` 검증
+- `UsernamePasswordCredentials` 를 이용하여 자격증명 조회 검증
+
+**T17** `hc5/ssl/SslSupportTest.kt` 작성
+- complexity: low
+- `SSLContexts.createDefault()`, `SSLContexts.createSystemDefault()`, `HttpsSupport` 기본 TLS 설정 생성 검증
+
+### Group 2 — 통합 테스트 (complexity: medium)
+
+**T18** `hc5/classic/ClassicHttpClientTest.kt` 작성
+- complexity: medium
+- `AbstractHc5Test` 상속
+- `httpClientOf {}`, `minimalHttpClientOf {}`, `virtualThreadHttpClientOf {}` 빌더 검증
+- GET 요청 → httpbin `/get` 응답 상태코드 200 검증
+
+**T19** `hc5/async/AsyncHttpClientTest.kt` 작성
+- complexity: medium
+- `AbstractHc5Test` 상속
+- `httpAsyncClientOf {}` 빌더로 클라이언트 생성 검증
+- `SimpleHttpRequests.get()` 으로 비동기 GET 요청 → 상태코드 200 검증
+
+**T20** `hc5/async/AsyncHttpClientCoroutinesTest.kt` 작성
+- complexity: medium
+- `AbstractHc5Test` 상속
+- `executeAwait()` suspend 함수 검증 — `/get`, `/ip`, `/headers` 병렬 요청
+
+**T21** `jdk/JdkHttpClientSupportTest.kt` 작성
+- complexity: medium
+- `jdkHttpClientOf()`, `jdkVirtualThreadHttpClientOf()` 클라이언트 생성 검증
+- `AbstractHttpTest` 상속, GET 요청 → 상태코드 200
+
+**T22** `jdk/JdkHttpClientCoroutinesTest.kt` 작성
+- complexity: medium
+- `AbstractHttpTest` 상속
+- `getAwait(uri)`, `getStringAwait(uri)`, `sendAwait()` suspend 함수 검증
+
+### Group 3 — 추가 커버리지 (complexity: low)
+
+**T23** `hc5/cache/CachingHttpClientBuilderTest.kt` 작성
+- complexity: low
+- `CachingHttpClientBuilder` DSL — 캐시 설정 포함 클라이언트 생성 검증
+
+**T24** `hc5/fluent/FluentRequestTest.kt` 작성
+- complexity: low
+- `Request.kt` DSL 빌더 기본 생성 검증 (fluent API 체인)
+
+### 최종 검증 (complexity: low)
+
+**T25** 전체 테스트 실행 및 커버리지 확인
+- complexity: low
+- `./gradlew :bluetape4k-http:test` 전수 통과 확인
+- JaCoCo 커버리지 리포트 생성 및 70% 이상 확인
+- `docs/testlogs/2026-04.md` testlog 업데이트
+
+**T26** README 업데이트
+- complexity: low
+- `io/http/README.md` + `io/http/README.ko.md` 커버리지 현황 반영
+
+## 의존성 순서
+
+```
+T1-T17 (단위) → 병렬 실행 가능
+T18-T22 (통합) → AbstractHc5Test/AbstractHttpTest 의존, 병렬 실행 가능
+T23-T24 → T18 완료 후
+T25 → T1-T24 전체 완료 후
+T26 → T25 완료 후
+```
+
+## 모듈 경로
+
+- 소스: `io/http/src/main/kotlin/io/bluetape4k/http/`
+- 테스트: `io/http/src/test/kotlin/io/bluetape4k/http/`
+- Gradle 모듈명: `:bluetape4k-http`

--- a/docs/superpowers/specs/2026-04-27-http-test-coverage-design.md
+++ b/docs/superpowers/specs/2026-04-27-http-test-coverage-design.md
@@ -1,0 +1,116 @@
+# io/http 테스트 커버리지 향상 설계 (32.40% → 70%)
+
+## 목표
+
+`io/http` 모듈의 테스트 커버리지를 32.40%에서 70% 이상으로 향상시킵니다.
+
+관련 이슈: #178
+
+## 현황 분석
+
+### 기존 테스트 (커버된 영역)
+
+| 패키지 | 커버된 파일 |
+|--------|------------|
+| `hc5/cache` | `InMemoryHttpCacheStorage`, `JavaCacheHttpCacheStorage` |
+| `okhttp3` | `OkHttp3Support`, `LoggingInterceptor`, `CachingInterceptor`, `OkHttpClientExtensionsCoroutines`, `OkHttpResponseExtensions` |
+| `okhttp3/mock` | `MockWebServerExtensions` |
+
+### 테스트 공백 (미커버 영역)
+
+**Group 1 — 순수 단위 테스트 대상 (서버 불필요, DSL/빌더 함수)**
+
+| 패키지 | 파일 수 | 주요 파일 |
+|--------|---------|----------|
+| `hc5/http` | 16 | `HttpHost`, `ContentTypes`, `BasicRequestBuilder`, `BasicResponseBuilder`, `ClassicRequestBuilder`, `AuthScope`, `ConnectExceptionSupport`, `Operations`, `HttpRequest`, `ConnectionConfig`, `RequestConfig`, `SocketConfig`, `TlsConfig`, `Http1Config`, `ContextBuilder`, `CharCodingConfig` |
+| `hc5/entity` | 5 | `EntityBuilder`, `HttpEntitySupport`, `FormBodyPartBuilder`, `MultipartEntityBuilder`, `MultipartPartBuilder` |
+| `hc5/auth` | 1 | `CredentialsProviderBuilder` |
+| `hc5/ssl` | 2 | `HttpsSupport`, `SSLContexts` |
+| `hc5/http2` | 1 | `H2Config` |
+| `hc5/reactor` | 1 | `IOReactorConfig` |
+
+**Group 2 — 통합 테스트 대상 (BluetapeHttpServer 로컬 httpbin 사용)**
+
+| 패키지 | 파일 수 | 주요 파일 |
+|--------|---------|----------|
+| `hc5/async` | 5+5 | `HttpAsyncClient`, `CloseableHttpAsyncClientCoroutines`, `AsyncClientConnectionManager`, `MinimalHttpAsyncClient`, `async/methods/*` |
+| `hc5/classic` | 4 | `HttpClient`, `HttpClientConnectionManager`, `MinimalHttpClient`, `VirtualThreadHttpClient` |
+| `jdk` | 2 | `JdkHttpClientSupport`, `JdkHttpClientCoroutines` |
+| `hc5/routing` | 1 | `RoutingSupport` |
+
+**Group 3 — 기타**
+
+| 패키지 | 파일 수 | 비고 |
+|--------|---------|------|
+| `vertx` | 1 | `VertxHttpClientSupport` — Vert.x 의존성 복잡, 우선순위 낮음 |
+| `hc5/cache` builders | 2 | `CachingHttpClientBuilder`, `CachingHttpAsyncClientBuilder` |
+| `hc5/fluent` | 1 | `Request.kt` |
+| `hc5/protocol` | 1 | `HttpClientContext` |
+
+## 설계 방향
+
+### 우선순위 전략
+
+커버리지 향상 효율 = (커버 라인 수) / (구현 난이도)
+
+1. **Group 1 우선**: 순수 단위 테스트. 외부 의존성 없음, 높은 ROI
+2. **Group 2 중간**: BluetapeHttpServer (Testcontainers)를 이미 AbstractHc5Test에서 사용하므로 재사용 가능
+3. **Group 3 선택적**: Vert.x는 제외, cache builders와 fluent는 포함
+
+### 테스트 구조
+
+#### Group 1 — 단위 테스트 신규 파일
+
+```
+src/test/kotlin/io/bluetape4k/http/hc5/http/
+  ├── HttpHostTest.kt              # URI.toHttpHost(), httpHostOf()
+  ├── ContentTypesTest.kt          # ContentTypes.TEXT_PLAIN_UTF8
+  ├── BasicRequestBuilderTest.kt   # basicHttpRequest(), basicHttpRequestOf()
+  ├── BasicResponseBuilderTest.kt  # basicHttpResponse()
+  ├── ClassicRequestBuilderTest.kt # classicRequest()
+  ├── AuthScopeTest.kt             # authScopeOf() 오버로드
+  ├── ConnectExceptionSupportTest.kt # IOException 확장
+  ├── OperationsTest.kt            # Future.toCancellable()
+  ├── HttpRequestTest.kt           # extractPathPrefix()
+  └── ConfigBuilderTest.kt         # ConnectionConfig, RequestConfig, SocketConfig, TlsConfig, Http1Config, CharCodingConfig
+
+src/test/kotlin/io/bluetape4k/http/hc5/entity/
+  ├── EntityBuilderTest.kt         # httpEntity(), httpEntityOf()
+  ├── HttpEntitySupportTest.kt     # consumeQuietly(), consume(), toByteArrayOrNull(), toStringOrNull()
+  └── MimeEntityTest.kt            # FormBodyPartBuilder, MultipartEntityBuilder, MultipartPartBuilder
+
+src/test/kotlin/io/bluetape4k/http/hc5/auth/
+  └── CredentialsProviderBuilderTest.kt # credentialsProvider(), emptyCredentialsProvider(), credentialsProviderOf()
+
+src/test/kotlin/io/bluetape4k/http/hc5/ssl/
+  └── SslSupportTest.kt            # HttpsSupport, SSLContexts (기본 SSL 컨텍스트 생성)
+
+src/test/kotlin/io/bluetape4k/http/hc5/http2/
+  └── H2ConfigTest.kt              # H2Config DSL
+
+src/test/kotlin/io/bluetape4k/http/hc5/reactor/
+  └── IOReactorConfigTest.kt       # IOReactorConfig DSL
+```
+
+#### Group 2 — 통합 테스트 신규 파일
+
+```
+src/test/kotlin/io/bluetape4k/http/hc5/classic/
+  └── ClassicHttpClientTest.kt     # httpClient(), minimalHttpClient(), virtualThreadHttpClient()
+
+src/test/kotlin/io/bluetape4k/http/hc5/async/
+  ├── AsyncHttpClientTest.kt       # httpAsyncClient() GET/POST
+  └── AsyncHttpClientCoroutinesTest.kt # suspend executeAwait()
+
+src/test/kotlin/io/bluetape4k/http/jdk/
+  ├── JdkHttpClientSupportTest.kt  # jdkHttpClientOf(), jdkVirtualThreadHttpClientOf()
+  └── JdkHttpClientCoroutinesTest.kt # getAwait(), getStringAwait(), sendAwait()
+```
+
+## DoD
+
+- [ ] `io/http` 모듈 전체 테스트 통과
+- [ ] 커버리지 70% 이상 달성 (JaCoCo 기준)
+- [ ] 모든 신규 테스트 클래스에 `companion object : KLogging()` 포함
+- [ ] 기존 테스트와 충돌 없음
+- [ ] `README.md` + `README.ko.md` 업데이트 (테스트 커버리지 현황 반영)

--- a/io/http/README.ko.md
+++ b/io/http/README.ko.md
@@ -463,7 +463,28 @@ dependencies {
 ```bash
 # HTTP 모듈 테스트 실행
 ./gradlew :bluetape4k-http:test
+
+# 라인 커버리지 확인
+./gradlew :bluetape4k-http:koverLog
 ```
+
+### 테스트 커버리지
+
+라인 커버리지: **72%** (목표: ≥ 70%)
+
+| 패키지 | 커버리지 | 테스트 클래스 |
+|--------|----------|---------------|
+| `hc5/async` | ✅ | `AsyncHttpClientTest`, `AsyncHttpClientCoroutinesTest`, `MinimalHttpAsyncClientTest` |
+| `hc5/async/methods` | ✅ | `SimpleHttpRequestTest`, `SimpleHttpResponseTest`, `AsyncMethodsTest` |
+| `hc5/cache` | ✅ | `CachingHttpClientBuilderTest`, `CachingHttpAsyncClientBuilderTest` |
+| `hc5/classic` | ✅ | `ClassicHttpClientTest`, `MinimalAndVirtualThreadHttpClientTest` |
+| `hc5/fluent` | ✅ | `RequestTest` |
+| `hc5/http` | ✅ | `ContextBuilderTest`, `CookieSpecSupportTest`, `PoolingHttpClientConnectionManagerBuilderTest`, `BasicRequestProducerTest` |
+| `hc5/protocol` | ✅ | `HttpClientContextTest` |
+| `hc5/routing` | ✅ | `RoutingSupportTest` |
+| `hc5/ssl` | ✅ | `SslSupportTest` |
+| `jdk` | ✅ | `JdkHttpClientSupportTest`, `JdkHttpClientCoroutinesTest` |
+| `okhttp3` | ✅ | 다수의 테스트 |
 
 ## 참고
 

--- a/io/http/README.md
+++ b/io/http/README.md
@@ -442,7 +442,30 @@ dependencies {
 ```bash
 # Run HTTP module tests
 ./gradlew :bluetape4k-http:test
+
+# Check line coverage
+./gradlew :bluetape4k-http:koverLog
 ```
+
+### Test Coverage
+
+Line coverage: **72%** (target: ≥ 70%)
+
+Covered packages:
+
+| Package | Coverage | Tests |
+|---------|----------|-------|
+| `hc5/async` | ✅ | `AsyncHttpClientTest`, `AsyncHttpClientCoroutinesTest`, `MinimalHttpAsyncClientTest` |
+| `hc5/async/methods` | ✅ | `SimpleHttpRequestTest`, `SimpleHttpResponseTest`, `AsyncMethodsTest` |
+| `hc5/cache` | ✅ | `CachingHttpClientBuilderTest`, `CachingHttpAsyncClientBuilderTest` |
+| `hc5/classic` | ✅ | `ClassicHttpClientTest`, `MinimalAndVirtualThreadHttpClientTest` |
+| `hc5/fluent` | ✅ | `RequestTest` |
+| `hc5/http` | ✅ | `ContextBuilderTest`, `CookieSpecSupportTest`, `PoolingHttpClientConnectionManagerBuilderTest`, `BasicRequestProducerTest` |
+| `hc5/protocol` | ✅ | `HttpClientContextTest` |
+| `hc5/routing` | ✅ | `RoutingSupportTest` |
+| `hc5/ssl` | ✅ | `SslSupportTest` |
+| `jdk` | ✅ | `JdkHttpClientSupportTest`, `JdkHttpClientCoroutinesTest` |
+| `okhttp3` | ✅ | Multiple tests |
 
 ## References
 

--- a/io/http/src/main/kotlin/io/bluetape4k/http/hc5/async/HttpAsyncClient.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/hc5/async/HttpAsyncClient.kt
@@ -57,6 +57,8 @@ inline fun httpAsyncClientOf(
     builder: HttpAsyncClientBuilder.() -> Unit = {},
 ): CloseableHttpAsyncClient = httpAsyncClient {
     setConnectionManager(cm)
+    // HC5 공식 메커니즘: 외부에서 주입된 CM은 client.close() 시 닫지 않음
+    setConnectionManagerShared(true)
     builder()
 }
 

--- a/io/http/src/main/kotlin/io/bluetape4k/http/hc5/async/MinimalHttpAsyncClient.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/hc5/async/MinimalHttpAsyncClient.kt
@@ -56,7 +56,9 @@ fun minimalHttpAsyncClientOf(
     h2config: H2Config = H2Config.DEFAULT,
     h1config: Http1Config = Http1Config.DEFAULT,
     ioReactorConfig: IOReactorConfig = IOReactorConfig.DEFAULT,
-    connMgr: AsyncClientConnectionManager = defaultAsyncClientConnectionManager,
+    // MinimalHttpAsyncClient 은 setConnectionManagerShared() API 미지원 →
+    // 호출마다 독립 CM 생성하여 소유권(lifecycle)을 client 가 갖도록 함
+    connMgr: AsyncClientConnectionManager = asyncClientConnectionManager {},
 ): MinimalHttpAsyncClient {
     return HttpAsyncClients.createMinimal(h2config, h1config, ioReactorConfig, connMgr)
 }

--- a/io/http/src/main/kotlin/io/bluetape4k/http/hc5/classic/MinimalHttpClient.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/hc5/classic/MinimalHttpClient.kt
@@ -19,6 +19,8 @@ import org.apache.hc.client5.http.io.HttpClientConnectionManager
  * @return [MinimalHttpClient]
  */
 fun minimalHttpClientOf(
-    connManager: HttpClientConnectionManager = defaultHttpClientConnectionManager,
+    // MinimalHttpClient 은 setConnectionManagerShared() API 미지원 →
+    // 호출마다 독립 CM 생성하여 소유권(lifecycle)을 client 가 갖도록 함
+    connManager: HttpClientConnectionManager = httpClientConnectionManager {},
 ): MinimalHttpClient =
     HttpClients.createMinimal(connManager)

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/AsyncHttpClientCoroutinesTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/AsyncHttpClientCoroutinesTest.kt
@@ -18,7 +18,7 @@ class AsyncHttpClientCoroutinesTest: AbstractHc5Test() {
 
     @Test
     fun `httpAsyncClientOf 로 executeSuspending GET 요청`() = runTest(timeout = 30.seconds) {
-        httpAsyncClientOf().use { client ->
+        httpAsyncClient {}.use { client ->
             val request = SimpleRequestBuilder.get("$httpbinBaseUrl/get").build()
             val response = client.executeSuspending(request)
             log.debug { "GET $httpbinBaseUrl/get status=${response.code}" }
@@ -28,7 +28,7 @@ class AsyncHttpClientCoroutinesTest: AbstractHc5Test() {
 
     @Test
     fun `여러 URL 병렬 coroutine GET 요청 모두 200`() = runTest(timeout = 30.seconds) {
-        httpAsyncClientOf().use { client ->
+        httpAsyncClient {}.use { client ->
             val responses = coroutineScope {
                 urisToGet.map { uri ->
                     async {

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/AsyncHttpClientCoroutinesTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/AsyncHttpClientCoroutinesTest.kt
@@ -1,0 +1,47 @@
+package io.bluetape4k.http.hc5.async
+
+import io.bluetape4k.http.hc5.AbstractHc5Test
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
+
+class AsyncHttpClientCoroutinesTest: AbstractHc5Test() {
+
+    companion object: KLogging()
+
+    @Test
+    fun `httpAsyncClientOf 로 executeSuspending GET 요청`() = runTest(timeout = 30.seconds) {
+        httpAsyncClientOf().use { client ->
+            val request = SimpleRequestBuilder.get("$httpbinBaseUrl/get").build()
+            val response = client.executeSuspending(request)
+            log.debug { "GET $httpbinBaseUrl/get status=${response.code}" }
+            response.code shouldBeEqualTo 200
+        }
+    }
+
+    @Test
+    fun `여러 URL 병렬 coroutine GET 요청 모두 200`() = runTest(timeout = 30.seconds) {
+        httpAsyncClientOf().use { client ->
+            val responses = coroutineScope {
+                urisToGet.map { uri ->
+                    async {
+                        val request = SimpleRequestBuilder.get(uri).build()
+                        val response = client.executeSuspending(request)
+                        log.debug { "GET $uri status=${response.code}" }
+                        response
+                    }
+                }.awaitAll()
+            }
+            responses.forEach { response ->
+                response.code shouldBeEqualTo 200
+            }
+        }
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/AsyncHttpClientTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/AsyncHttpClientTest.kt
@@ -1,12 +1,14 @@
 package io.bluetape4k.http.hc5.async
 
 import io.bluetape4k.http.hc5.AbstractHc5Test
+import io.bluetape4k.http.hc5.async.methods.toProducer
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldNotBeNull
 import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder
 import org.apache.hc.client5.http.async.methods.SimpleResponseConsumer
+import org.apache.hc.client5.http.protocol.HttpClientContext
 import org.junit.jupiter.api.Test
 import java.util.concurrent.TimeUnit
 
@@ -30,9 +32,14 @@ class AsyncHttpClientTest: AbstractHc5Test() {
 
     @Test
     fun `httpAsyncClientOf 로 비동기 GET 요청 상태코드 200`() {
-        httpAsyncClientOf().use { client ->
+        httpAsyncClient {}.use { client ->
             val request = SimpleRequestBuilder.get("$httpbinBaseUrl/get").build()
-            val future = client.execute(request, null)
+            val future = client.execute(
+                request.toProducer(),
+                SimpleResponseConsumer.create(),
+                HttpClientContext.create(),
+                null
+            )
             val response = future.get(10, TimeUnit.SECONDS)
             log.debug { "GET $httpbinBaseUrl/get status=${response.code}" }
             response.code shouldBeEqualTo 200

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/AsyncHttpClientTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/AsyncHttpClientTest.kt
@@ -1,0 +1,48 @@
+package io.bluetape4k.http.hc5.async
+
+import io.bluetape4k.http.hc5.AbstractHc5Test
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder
+import org.apache.hc.client5.http.async.methods.SimpleResponseConsumer
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
+
+class AsyncHttpClientTest: AbstractHc5Test() {
+
+    companion object: KLogging()
+
+    @Test
+    fun `httpAsyncClientOf 기본 생성`() {
+        val client = httpAsyncClientOf()
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `httpAsyncClient DSL 생성`() {
+        val client = httpAsyncClient { }
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `httpAsyncClientOf 로 비동기 GET 요청 상태코드 200`() {
+        httpAsyncClientOf().use { client ->
+            val request = SimpleRequestBuilder.get("$httpbinBaseUrl/get").build()
+            val future = client.execute(request, null)
+            val response = future.get(10, TimeUnit.SECONDS)
+            log.debug { "GET $httpbinBaseUrl/get status=${response.code}" }
+            response.code shouldBeEqualTo 200
+        }
+    }
+
+    @Test
+    fun `h2AsyncClientOf 생성`() {
+        val client = h2AsyncClientOf()
+        client.shouldNotBeNull()
+        client.close()
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/MinimalHttpAsyncClientTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/MinimalHttpAsyncClientTest.kt
@@ -1,0 +1,67 @@
+package io.bluetape4k.http.hc5.async
+
+import io.bluetape4k.http.hc5.AbstractHc5Test
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.client5.http.impl.async.MinimalH2AsyncClient
+import org.apache.hc.client5.http.impl.async.MinimalHttpAsyncClient
+import org.apache.hc.core5.http2.config.H2Config
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
+
+class MinimalHttpAsyncClientTest: AbstractHc5Test() {
+
+    companion object: KLogging()
+
+    @Test
+    fun `minimalHttpAsyncClientOf 기본 생성`() {
+        val client: MinimalHttpAsyncClient = minimalHttpAsyncClientOf()
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `minimalH2AsyncClientOf H2Config 로 생성`() {
+        val h2config = H2Config.DEFAULT
+        val client: MinimalH2AsyncClient = minimalH2AsyncClientOf(h2config)
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `minimalHttpAsyncClientOf asyncClientConnectionManager 포함 생성`() {
+        val cm = asyncClientConnectionManager { }
+        val client: MinimalHttpAsyncClient = minimalHttpAsyncClientOf(connMgr = cm)
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `defaultMinimalHttpAsyncClient 싱글톤 생성`() {
+        defaultMinimalHttpAsyncClient.shouldNotBeNull()
+    }
+
+    @Test
+    fun `defaultMinimalH2AsyncClient 싱글톤 생성`() {
+        defaultMinimalH2AsyncClient.shouldNotBeNull()
+    }
+
+    @Test
+    fun `leaseSuspending 으로 엔드포인트 획득`() = runTest(timeout = 15.seconds) {
+        val cm = asyncClientConnectionManager { }
+        val client = minimalHttpAsyncClientOf(connMgr = cm)
+        client.start()
+        try {
+            val url = java.net.URL(httpbinBaseUrl)
+            val host = org.apache.hc.core5.http.HttpHost(url.protocol, url.host, url.port)
+            val endpoint = client.leaseSuspending(host)
+            log.debug { "Leased endpoint: $endpoint" }
+            endpoint.shouldNotBeNull()
+            endpoint.releaseAndDiscard()
+        } finally {
+            client.close()
+        }
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/MinimalHttpAsyncClientTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/MinimalHttpAsyncClientTest.kt
@@ -17,8 +17,7 @@ class MinimalHttpAsyncClientTest: AbstractHc5Test() {
 
     @Test
     fun `minimalHttpAsyncClientOf 기본 생성`() {
-        val cm = asyncClientConnectionManager { }
-        val client: MinimalHttpAsyncClient = minimalHttpAsyncClientOf(connMgr = cm)
+        val client: MinimalHttpAsyncClient = minimalHttpAsyncClientOf()
         client.shouldNotBeNull()
         client.close()
     }

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/MinimalHttpAsyncClientTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/MinimalHttpAsyncClientTest.kt
@@ -17,7 +17,8 @@ class MinimalHttpAsyncClientTest: AbstractHc5Test() {
 
     @Test
     fun `minimalHttpAsyncClientOf 기본 생성`() {
-        val client: MinimalHttpAsyncClient = minimalHttpAsyncClientOf()
+        val cm = asyncClientConnectionManager { }
+        val client: MinimalHttpAsyncClient = minimalHttpAsyncClientOf(connMgr = cm)
         client.shouldNotBeNull()
         client.close()
     }

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/methods/AsyncMethodsTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/methods/AsyncMethodsTest.kt
@@ -1,0 +1,59 @@
+package io.bluetape4k.http.hc5.async.methods
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest
+import org.apache.hc.client5.http.async.methods.SimpleResponseConsumer
+import org.apache.hc.core5.http.HttpHost
+import org.apache.hc.core5.net.URIAuthority
+import org.junit.jupiter.api.Test
+
+class AsyncMethodsTest {
+
+    companion object: KLogging()
+
+    @Test
+    fun `simpleRequestProducerOf 로 SimpleRequestProducer 생성`() {
+        val request = SimpleHttpRequest.create("GET", "https://example.com/api")
+        val producer = simpleRequestProducerOf(request)
+        producer.shouldNotBeNull()
+    }
+
+    @Test
+    fun `simpleResponseConsumerOf 로 SimpleResponseConsumer 생성`() {
+        val consumer = simpleResponseConsumerOf()
+        consumer.shouldNotBeNull()
+    }
+
+    @Test
+    fun `simpleResponseConsumerOf 는 SimpleResponseConsumer create 와 동일`() {
+        val consumer1 = simpleResponseConsumerOf()
+        val consumer2 = SimpleResponseConsumer.create()
+        consumer1.shouldNotBeNull()
+        consumer2.shouldNotBeNull()
+    }
+
+    @Test
+    fun `configurableHttpRequestOf host path 로 요청 생성`() {
+        val host = HttpHost("localhost", 8080)
+        val request = configurableHttpRequestOf("GET", host, "/api/v1")
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "GET"
+    }
+
+    @Test
+    fun `configurableHttpRequestOf scheme authority path 로 요청 생성`() {
+        val authority = URIAuthority("localhost", 8080)
+        val request = configurableHttpRequestOf("POST", "/api/v1", scheme = "http", authority = authority)
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "POST"
+    }
+
+    @Test
+    fun `configurableHttpRequestOf path only 로 요청 생성`() {
+        val request = configurableHttpRequestOf("GET", "/api/v1")
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "GET"
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/methods/SimpleHttpRequestTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/methods/SimpleHttpRequestTest.kt
@@ -1,0 +1,80 @@
+package io.bluetape4k.http.hc5.async.methods
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.core5.http.ContentType
+import org.apache.hc.core5.http.HttpHost
+import org.apache.hc.core5.http.Method
+import org.apache.hc.core5.http.message.BasicHeader
+import org.junit.jupiter.api.Test
+
+class SimpleHttpRequestTest {
+
+    companion object: KLogging()
+
+    @Test
+    fun `simpleHttpRequest method string DSL 로 요청 생성`() {
+        val request = simpleHttpRequest("GET") {
+            setHttpHost(HttpHost("localhost", 8080))
+            setPath("/api/v1")
+        }
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "GET"
+    }
+
+    @Test
+    fun `simpleHttpRequest Method enum DSL 로 요청 생성`() {
+        val request = simpleHttpRequest(Method.POST) {
+            setHttpHost(HttpHost("localhost", 8080))
+            setPath("/api/v1")
+        }
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "POST"
+    }
+
+    @Test
+    fun `simpleHttpRequestOf method string host path 로 요청 생성`() {
+        val host = HttpHost("localhost", 8080)
+        val request = simpleHttpRequestOf("GET", host, "/api/v1")
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "GET"
+        request.path shouldBeEqualTo "/api/v1"
+    }
+
+    @Test
+    fun `simpleHttpRequestOf Method enum host path 로 요청 생성`() {
+        val host = HttpHost("localhost", 8080)
+        val request = simpleHttpRequestOf(Method.GET, host, "/api/v1")
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "GET"
+    }
+
+    @Test
+    fun `simpleHttpRequestOf body builder 포함 요청 생성`() {
+        val host = HttpHost("localhost", 8080)
+        val request = simpleHttpRequestOf("POST", host, "/api/v1") {
+            setBody("Hello", ContentType.TEXT_PLAIN)
+        }
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "POST"
+    }
+
+    @Test
+    fun `simpleHttpRequestOf headers 포함 요청 생성`() {
+        val host = HttpHost("localhost", 8080)
+        val headers = listOf(BasicHeader("X-Custom", "value"))
+        val request = simpleHttpRequestOf("GET", host, "/api/v1", headers = headers)
+        request.shouldNotBeNull()
+    }
+
+    @Test
+    fun `toProducer 로 SimpleRequestProducer 생성`() {
+        val request = simpleHttpRequest("GET") {
+            setHttpHost(HttpHost("localhost", 8080))
+            setPath("/api/v1")
+        }
+        val producer = request.toProducer()
+        producer.shouldNotBeNull()
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/methods/SimpleHttpResponseTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/methods/SimpleHttpResponseTest.kt
@@ -1,0 +1,62 @@
+package io.bluetape4k.http.hc5.async.methods
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.core5.http.ContentType
+import org.junit.jupiter.api.Test
+
+class SimpleHttpResponseTest {
+
+    companion object: KLogging()
+
+    @Test
+    fun `simpleHttpResponse DSL 로 응답 생성`() {
+        val response = simpleHttpResponse(200) {
+            setBody("Hello, World!", ContentType.TEXT_PLAIN)
+        }
+        response.shouldNotBeNull()
+        response.code shouldBeEqualTo 200
+    }
+
+    @Test
+    fun `simpleHttpResponseOf 문자열 본문으로 응답 생성`() {
+        val response = simpleHttpResponseOf(200, "Hello, World!")
+        response.shouldNotBeNull()
+        response.code shouldBeEqualTo 200
+        response.bodyText shouldBeEqualTo "Hello, World!"
+    }
+
+    @Test
+    fun `simpleHttpResponseOf 문자열 본문과 ContentType 으로 응답 생성`() {
+        val response = simpleHttpResponseOf(201, "Created", ContentType.TEXT_PLAIN)
+        response.shouldNotBeNull()
+        response.code shouldBeEqualTo 201
+        response.bodyText shouldBeEqualTo "Created"
+    }
+
+    @Test
+    fun `simpleHttpResponseOf ByteArray 본문으로 응답 생성`() {
+        val body = "Hello".toByteArray()
+        val response = simpleHttpResponseOf(200, body)
+        response.shouldNotBeNull()
+        response.code shouldBeEqualTo 200
+    }
+
+    @Test
+    fun `simpleHttpResponseOf ByteArray 본문과 ContentType 으로 응답 생성`() {
+        val body = "Data".toByteArray()
+        val response = simpleHttpResponseOf(200, body, ContentType.APPLICATION_OCTET_STREAM)
+        response.shouldNotBeNull()
+        response.code shouldBeEqualTo 200
+    }
+
+    @Test
+    fun `simpleHttpResponse 404 응답 생성`() {
+        val response = simpleHttpResponse(404) {
+            setBody("Not Found", ContentType.TEXT_PLAIN)
+        }
+        response.shouldNotBeNull()
+        response.code shouldBeEqualTo 404
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/auth/CredentialsProviderBuilderTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/auth/CredentialsProviderBuilderTest.kt
@@ -14,10 +14,13 @@ class CredentialsProviderBuilderTest {
 
     companion object : KLogging()
 
+    // HC5 5.x has no AuthScope.ANY — use all-null/wildcard constructor instead
+    private val anyScope = AuthScope(null, null, -1, null, null)
+
     @Test
     fun `credentialsProvider DSL creates provider`() {
         val provider = credentialsProvider {
-            add(AuthScope.ANY, UsernamePasswordCredentials("user", "pass".toCharArray()))
+            add(anyScope, UsernamePasswordCredentials("user", "pass".toCharArray()))
         }
 
         provider.shouldNotBeNull()
@@ -28,7 +31,7 @@ class CredentialsProviderBuilderTest {
         val provider = emptyCredentialsProvider()
 
         provider.shouldNotBeNull()
-        val credentials = provider.getCredentials(AuthScope.ANY, BasicHttpContext())
+        val credentials = provider.getCredentials(anyScope, BasicHttpContext())
         credentials.shouldBeNull()
     }
 
@@ -47,13 +50,15 @@ class CredentialsProviderBuilderTest {
     }
 
     @Test
-    fun `credentialsProviderOf with AuthScope ANY retrieves credentials`() {
+    fun `credentialsProviderOf with specific AuthScope retrieves credentials`() {
+        val authScope = AuthScope("http", "localhost", 8080, null, null)
         val credentials = UsernamePasswordCredentials("testuser", "testpass".toCharArray())
 
-        val provider = credentialsProviderOf(AuthScope.ANY, credentials)
+        val provider = credentialsProviderOf(authScope, credentials)
 
         provider.shouldNotBeNull()
-        val retrieved = provider.getCredentials(AuthScope.ANY, BasicHttpContext())
+        // Query with same scope should match
+        val retrieved = provider.getCredentials(authScope, BasicHttpContext())
         retrieved.shouldNotBeNull()
         val upCreds = retrieved as UsernamePasswordCredentials
         upCreds.userName shouldBeEqualTo "testuser"
@@ -70,15 +75,30 @@ class CredentialsProviderBuilderTest {
     }
 
     @Test
+    fun `credentialsProviderOf with HttpHost retrieves credentials by host scope`() {
+        val host = HttpHost("example.com", 80)
+        val credentials = UsernamePasswordCredentials("hostuser", "hostpass".toCharArray())
+
+        val provider = credentialsProviderOf(host, credentials)
+
+        provider.shouldNotBeNull()
+        val hostScope = AuthScope(host)
+        val retrieved = provider.getCredentials(hostScope, BasicHttpContext())
+        retrieved.shouldNotBeNull()
+        val upCreds = retrieved as UsernamePasswordCredentials
+        upCreds.userName shouldBeEqualTo "hostuser"
+    }
+
+    @Test
     fun `credentialsProviderOf with AuthScope username and password creates provider`() {
-        val authScope = AuthScope.ANY
+        val authScope = AuthScope(null, null, -1, null, null)
         val username = "userA"
         val password = "passwordA".toCharArray()
 
         val provider = credentialsProviderOf(authScope, username, password)
 
         provider.shouldNotBeNull()
-        val retrieved = provider.getCredentials(AuthScope.ANY, BasicHttpContext())
+        val retrieved = provider.getCredentials(authScope, BasicHttpContext())
         retrieved.shouldNotBeNull()
         val upCreds = retrieved as UsernamePasswordCredentials
         upCreds.userName shouldBeEqualTo username
@@ -96,7 +116,7 @@ class CredentialsProviderBuilderTest {
     }
 
     @Test
-    fun `credentialsProvider DSL with multiple auth scopes`() {
+    fun `credentialsProvider DSL with multiple hosts`() {
         val host1 = HttpHost("host1.example.com", 80)
         val host2 = HttpHost("host2.example.com", 443)
 
@@ -106,5 +126,21 @@ class CredentialsProviderBuilderTest {
         }
 
         provider.shouldNotBeNull()
+    }
+
+    @Test
+    fun `credentialsProvider DSL retrieves correct credentials per host`() {
+        val host1 = HttpHost("http", "host1.example.com", 80)
+        val creds1 = UsernamePasswordCredentials("user1", "pass1".toCharArray())
+
+        val provider = credentialsProvider {
+            add(host1, creds1)
+        }
+
+        provider.shouldNotBeNull()
+        val scope1 = AuthScope(host1)
+        val retrieved = provider.getCredentials(scope1, BasicHttpContext())
+        retrieved.shouldNotBeNull()
+        (retrieved as UsernamePasswordCredentials).userName shouldBeEqualTo "user1"
     }
 }

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/auth/CredentialsProviderBuilderTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/auth/CredentialsProviderBuilderTest.kt
@@ -1,0 +1,110 @@
+package io.bluetape4k.http.hc5.auth
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.client5.http.auth.AuthScope
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials
+import org.apache.hc.core5.http.HttpHost
+import org.apache.hc.core5.http.protocol.BasicHttpContext
+import org.junit.jupiter.api.Test
+
+class CredentialsProviderBuilderTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `credentialsProvider DSL creates provider`() {
+        val provider = credentialsProvider {
+            add(AuthScope.ANY, UsernamePasswordCredentials("user", "pass".toCharArray()))
+        }
+
+        provider.shouldNotBeNull()
+    }
+
+    @Test
+    fun `emptyCredentialsProvider creates provider with no credentials`() {
+        val provider = emptyCredentialsProvider()
+
+        provider.shouldNotBeNull()
+        val credentials = provider.getCredentials(AuthScope.ANY, BasicHttpContext())
+        credentials.shouldBeNull()
+    }
+
+    @Test
+    fun `credentialsProviderOf with AuthScope and Credentials returns correct credentials`() {
+        val authScope = AuthScope(null, null, -1, null, null)
+        val credentials = UsernamePasswordCredentials("admin", "secret".toCharArray())
+
+        val provider = credentialsProviderOf(authScope, credentials)
+
+        provider.shouldNotBeNull()
+        val retrieved = provider.getCredentials(authScope, BasicHttpContext())
+        retrieved.shouldNotBeNull()
+        val upCreds = retrieved as UsernamePasswordCredentials
+        upCreds.userName shouldBeEqualTo "admin"
+    }
+
+    @Test
+    fun `credentialsProviderOf with AuthScope ANY retrieves credentials`() {
+        val credentials = UsernamePasswordCredentials("testuser", "testpass".toCharArray())
+
+        val provider = credentialsProviderOf(AuthScope.ANY, credentials)
+
+        provider.shouldNotBeNull()
+        val retrieved = provider.getCredentials(AuthScope.ANY, BasicHttpContext())
+        retrieved.shouldNotBeNull()
+        val upCreds = retrieved as UsernamePasswordCredentials
+        upCreds.userName shouldBeEqualTo "testuser"
+    }
+
+    @Test
+    fun `credentialsProviderOf with HttpHost and Credentials creates provider`() {
+        val host = HttpHost("localhost", 8080)
+        val credentials = UsernamePasswordCredentials("hostuser", "hostpass".toCharArray())
+
+        val provider = credentialsProviderOf(host, credentials)
+
+        provider.shouldNotBeNull()
+    }
+
+    @Test
+    fun `credentialsProviderOf with AuthScope username and password creates provider`() {
+        val authScope = AuthScope.ANY
+        val username = "userA"
+        val password = "passwordA".toCharArray()
+
+        val provider = credentialsProviderOf(authScope, username, password)
+
+        provider.shouldNotBeNull()
+        val retrieved = provider.getCredentials(AuthScope.ANY, BasicHttpContext())
+        retrieved.shouldNotBeNull()
+        val upCreds = retrieved as UsernamePasswordCredentials
+        upCreds.userName shouldBeEqualTo username
+    }
+
+    @Test
+    fun `credentialsProviderOf with HttpHost username and password creates provider`() {
+        val host = HttpHost("example.com", 443)
+        val username = "hostAdmin"
+        val password = "hostSecret".toCharArray()
+
+        val provider = credentialsProviderOf(host, username, password)
+
+        provider.shouldNotBeNull()
+    }
+
+    @Test
+    fun `credentialsProvider DSL with multiple auth scopes`() {
+        val host1 = HttpHost("host1.example.com", 80)
+        val host2 = HttpHost("host2.example.com", 443)
+
+        val provider = credentialsProvider {
+            add(host1, UsernamePasswordCredentials("user1", "pass1".toCharArray()))
+            add(host2, UsernamePasswordCredentials("user2", "pass2".toCharArray()))
+        }
+
+        provider.shouldNotBeNull()
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/cache/CachingHttpAsyncClientBuilderTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/cache/CachingHttpAsyncClientBuilderTest.kt
@@ -1,0 +1,76 @@
+package io.bluetape4k.http.hc5.cache
+
+import io.bluetape4k.http.hc5.AbstractHc5Test
+import io.bluetape4k.http.hc5.async.methods.toProducer
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder
+import org.apache.hc.client5.http.async.methods.SimpleResponseConsumer
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient
+import org.apache.hc.client5.http.protocol.HttpClientContext
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+class CachingHttpAsyncClientBuilderTest: AbstractHc5Test() {
+
+    companion object: KLogging()
+
+    @Test
+    fun `cachingHttpAsyncClient DSL 로 생성`() {
+        val client: CloseableHttpAsyncClient = cachingHttpAsyncClient { }
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `memoryCachingHttpAsyncClientOf 생성`() {
+        val client: CloseableHttpAsyncClient = memoryCachingHttpAsyncClientOf()
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `fileCachingHttpAsyncClientOf 생성`(@TempDir tempDir: File) {
+        val client: CloseableHttpAsyncClient = fileCachingHttpAsyncClientOf(tempDir)
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `memoryCachingHttpAsyncClientOf 로 GET 요청`() {
+        memoryCachingHttpAsyncClientOf().use { client ->
+            client.start()
+            val request = SimpleRequestBuilder.get("$httpbinBaseUrl/get").build()
+            val future = client.execute(
+                request.toProducer(),
+                SimpleResponseConsumer.create(),
+                HttpClientContext.create(),
+                null
+            )
+            val response = future.get(10, TimeUnit.SECONDS)
+            log.debug { "Async Caching GET status=${response.code}" }
+            response.code shouldBeEqualTo 200
+        }
+    }
+
+    @Test
+    fun `fileCachingHttpAsyncClientOf 로 GET 요청`(@TempDir tempDir: File) {
+        fileCachingHttpAsyncClientOf(tempDir).use { client ->
+            client.start()
+            val request = SimpleRequestBuilder.get("$httpbinBaseUrl/get").build()
+            val future = client.execute(
+                request.toProducer(),
+                SimpleResponseConsumer.create(),
+                HttpClientContext.create(),
+                null
+            )
+            val response = future.get(10, TimeUnit.SECONDS)
+            log.debug { "File Async Caching GET status=${response.code}" }
+            response.code shouldBeEqualTo 200
+        }
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/cache/CachingHttpClientBuilderTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/cache/CachingHttpClientBuilderTest.kt
@@ -1,0 +1,64 @@
+package io.bluetape4k.http.hc5.cache
+
+import io.bluetape4k.http.hc5.AbstractHc5Test
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.client5.http.classic.methods.HttpGet
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class CachingHttpClientBuilderTest: AbstractHc5Test() {
+
+    companion object: KLogging()
+
+    @Test
+    fun `cachingHttpClient DSL 로 생성`() {
+        val client: CloseableHttpClient = cachingHttpClient { }
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `cachingHttpClient cacheStorage 포함 생성`() {
+        val storage = InMemoryHttpCacheStorage.createObjectCache()
+        val client: CloseableHttpClient = cachingHttpClient(storage) { }
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `memoryCachingHttpClientOf 생성`() {
+        val client: CloseableHttpClient = memoryCachingHttpClientOf()
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `fileCachingHttpClientOf 생성`(@TempDir tempDir: File) {
+        val client: CloseableHttpClient = fileCachingHttpClientOf(tempDir)
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `memoryCachingHttpClientOf 로 GET 요청`() {
+        memoryCachingHttpClientOf().use { client ->
+            val response = client.execute(HttpGet("$httpbinBaseUrl/get")) { it }
+            log.debug { "Caching GET status=${response.code}" }
+            response.code shouldBeEqualTo 200
+        }
+    }
+
+    @Test
+    fun `fileCachingHttpClientOf 로 GET 요청`(@TempDir tempDir: File) {
+        fileCachingHttpClientOf(tempDir).use { client ->
+            val response = client.execute(HttpGet("$httpbinBaseUrl/get")) { it }
+            log.debug { "File Caching GET status=${response.code}" }
+            response.code shouldBeEqualTo 200
+        }
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/classic/ClassicHttpClientTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/classic/ClassicHttpClientTest.kt
@@ -1,0 +1,72 @@
+package io.bluetape4k.http.hc5.classic
+
+import io.bluetape4k.http.hc5.AbstractHc5Test
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.client5.http.classic.methods.HttpGet
+import org.junit.jupiter.api.Test
+
+class ClassicHttpClientTest: AbstractHc5Test() {
+
+    companion object: KLogging()
+
+    @Test
+    fun `httpClient DSL 로 CloseableHttpClient 생성`() {
+        val client = httpClient { }
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `httpClientOf 기본 생성`() {
+        val client = httpClientOf()
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `defaultHttpClient 생성`() {
+        val client = defaultHttpClient()
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `systemHttpClientOf 생성`() {
+        val client = systemHttpClientOf()
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `httpClientOf 로 GET 요청 상태코드 200`() {
+        httpClientOf().use { client ->
+            val request = HttpGet("$httpbinBaseUrl/get")
+            val statusCode = client.execute(request) { response -> response.code }
+            log.debug { "GET $httpbinBaseUrl/get status=$statusCode" }
+            statusCode shouldBeEqualTo 200
+        }
+    }
+
+    @Test
+    fun `httpClientConnectionManager DSL 생성 검증`() {
+        val cm = httpClientConnectionManager {
+            setMaxConnPerRoute(5)
+            setMaxConnTotal(10)
+        }
+        cm.shouldNotBeNull()
+    }
+
+    @Test
+    fun `httpClientOf 커넥션 매니저 포함 생성`() {
+        val cm = httpClientConnectionManager {
+            setMaxConnPerRoute(5)
+            setMaxConnTotal(10)
+        }
+        val client = httpClientOf(cm)
+        client.shouldNotBeNull()
+        client.close()
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/classic/MinimalAndVirtualThreadHttpClientTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/classic/MinimalAndVirtualThreadHttpClientTest.kt
@@ -1,0 +1,55 @@
+package io.bluetape4k.http.hc5.classic
+
+import io.bluetape4k.http.hc5.AbstractHc5Test
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.client5.http.classic.methods.HttpGet
+import org.junit.jupiter.api.Test
+
+class MinimalAndVirtualThreadHttpClientTest: AbstractHc5Test() {
+
+    companion object: KLogging()
+
+    @Test
+    fun `minimalHttpClientOf 커넥션 매니저 포함 생성`() {
+        val cm = httpClientConnectionManager { }
+        val client = minimalHttpClientOf(cm)
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `minimalHttpClientOf 로 GET 요청`() {
+        val cm = httpClientConnectionManager { }
+        minimalHttpClientOf(cm).use { client ->
+            val response = client.execute(HttpGet("$httpbinBaseUrl/get")) { it }
+            log.debug { "GET $httpbinBaseUrl/get status=${response.code}" }
+            response.code shouldBeEqualTo 200
+        }
+    }
+
+    @Test
+    fun `virtualThreadHttpClientOf 기본 생성`() {
+        val client = virtualThreadHttpClientOf()
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `virtualThreadHttpClientOf 최대 연결 수 설정`() {
+        val client = virtualThreadHttpClientOf(maxConnTotal = 50, maxConnPerRoute = 10)
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `virtualThreadHttpClientOf 로 GET 요청`() {
+        virtualThreadHttpClientOf().use { client ->
+            val response = client.execute(HttpGet("$httpbinBaseUrl/get")) { it }
+            log.debug { "VirtualThread GET $httpbinBaseUrl/get status=${response.code}" }
+            response.code shouldBeEqualTo 200
+        }
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/classic/MinimalAndVirtualThreadHttpClientTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/classic/MinimalAndVirtualThreadHttpClientTest.kt
@@ -13,6 +13,13 @@ class MinimalAndVirtualThreadHttpClientTest: AbstractHc5Test() {
     companion object: KLogging()
 
     @Test
+    fun `minimalHttpClientOf 기본 생성`() {
+        val client = minimalHttpClientOf()
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
     fun `minimalHttpClientOf 커넥션 매니저 포함 생성`() {
         val cm = httpClientConnectionManager { }
         val client = minimalHttpClientOf(cm)
@@ -22,8 +29,7 @@ class MinimalAndVirtualThreadHttpClientTest: AbstractHc5Test() {
 
     @Test
     fun `minimalHttpClientOf 로 GET 요청`() {
-        val cm = httpClientConnectionManager { }
-        minimalHttpClientOf(cm).use { client ->
+        minimalHttpClientOf().use { client ->
             val response = client.execute(HttpGet("$httpbinBaseUrl/get")) { it }
             log.debug { "GET $httpbinBaseUrl/get status=${response.code}" }
             response.code shouldBeEqualTo 200

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/entity/EntityBuilderTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/entity/EntityBuilderTest.kt
@@ -1,0 +1,107 @@
+package io.bluetape4k.http.hc5.entity
+
+import io.bluetape4k.http.hc5.http.ContentTypes
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldNotBeNull
+import org.amshove.kluent.shouldNotBeNullOrEmpty
+import org.apache.hc.core5.http.ContentType
+import org.junit.jupiter.api.Test
+
+class EntityBuilderTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `httpEntity DSL block creates StringEntity with text`() {
+        val entity = httpEntity {
+            setText("Hello, World!")
+            setContentType(ContentTypes.TEXT_PLAIN_UTF8)
+        }
+
+        entity.shouldNotBeNull()
+        val content = entity.toStringOrNull()
+        content shouldBeEqualTo "Hello, World!"
+    }
+
+    @Test
+    fun `httpEntityOf with text creates entity with correct content`() {
+        val text = "Hello from httpEntityOf"
+        val entity = httpEntityOf(text = text)
+
+        entity.shouldNotBeNull()
+        val content = entity.toStringOrNull()
+        content shouldBeEqualTo text
+    }
+
+    @Test
+    fun `httpEntityOf with text sets content type`() {
+        val entity = httpEntityOf(
+            text = "sample text",
+            contentType = ContentTypes.TEXT_PLAIN_UTF8,
+        )
+
+        entity.shouldNotBeNull()
+        val contentType = entity.contentType
+        contentType.shouldNotBeNullOrEmpty()
+        contentType shouldContain "text/plain"
+    }
+
+    @Test
+    fun `httpEntityOf with ByteArray creates entity with correct bytes`() {
+        val bytes = "binary content".toByteArray(Charsets.UTF_8)
+        val entity = httpEntityOf(
+            binary = bytes,
+            contentType = ContentType.DEFAULT_BINARY,
+        )
+
+        entity.shouldNotBeNull()
+        val content = entity.toByteArrayOrNull()
+        content shouldBeEqualTo bytes
+    }
+
+    @Test
+    fun `httpEntityOf with ByteArray verifies byte content matches`() {
+        val original = byteArrayOf(1, 2, 3, 4, 5)
+        val entity = httpEntityOf(binary = original)
+
+        entity.shouldNotBeNull()
+        val result = entity.toByteArrayOrNull()
+        result.shouldNotBeNull()
+        result shouldBeEqualTo original
+    }
+
+    @Test
+    fun `httpEntity DSL with binary content creates entity with correct bytes`() {
+        val bytes = byteArrayOf(10, 20, 30)
+        val entity = httpEntity {
+            setBinary(bytes)
+            setContentType(ContentType.DEFAULT_BINARY)
+        }
+
+        entity.shouldNotBeNull()
+        val content = entity.toByteArrayOrNull()
+        content shouldBeEqualTo bytes
+    }
+
+    @Test
+    fun `toByteArrayOrNull returns correct byte content`() {
+        val text = "Test content"
+        val entity = httpEntityOf(text = text, contentType = ContentTypes.TEXT_PLAIN_UTF8)
+
+        val bytes = entity.toByteArrayOrNull()
+        bytes.shouldNotBeNull()
+        val decoded = String(bytes, Charsets.UTF_8)
+        decoded shouldBeEqualTo text
+    }
+
+    @Test
+    fun `toStringOrNull returns correct string content`() {
+        val text = "String content test"
+        val entity = httpEntityOf(text = text)
+
+        val result = entity.toStringOrNull()
+        result shouldBeEqualTo text
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/entity/EntityBuilderTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/entity/EntityBuilderTest.kt
@@ -58,7 +58,9 @@ class EntityBuilderTest {
 
         entity.shouldNotBeNull()
         val content = entity.toByteArrayOrNull()
-        content shouldBeEqualTo bytes
+        content.shouldNotBeNull()
+        // ByteArray uses reference equality — compare decoded string
+        String(content, Charsets.UTF_8) shouldBeEqualTo String(bytes, Charsets.UTF_8)
     }
 
     @Test
@@ -69,7 +71,8 @@ class EntityBuilderTest {
         entity.shouldNotBeNull()
         val result = entity.toByteArrayOrNull()
         result.shouldNotBeNull()
-        result shouldBeEqualTo original
+        result.size shouldBeEqualTo original.size
+        result.toList() shouldBeEqualTo original.toList()
     }
 
     @Test
@@ -82,7 +85,9 @@ class EntityBuilderTest {
 
         entity.shouldNotBeNull()
         val content = entity.toByteArrayOrNull()
-        content shouldBeEqualTo bytes
+        content.shouldNotBeNull()
+        content.size shouldBeEqualTo bytes.size
+        content.toList() shouldBeEqualTo bytes.toList()
     }
 
     @Test

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/entity/HttpEntitySupportTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/entity/HttpEntitySupportTest.kt
@@ -1,0 +1,132 @@
+package io.bluetape4k.http.hc5.entity
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldHaveSize
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.core5.http.ContentType
+import org.apache.hc.core5.http.io.entity.StringEntity
+import org.junit.jupiter.api.Test
+
+class HttpEntitySupportTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `consumeQuietly on non-null entity does not throw`() {
+        val entity = StringEntity("content", ContentType.TEXT_PLAIN)
+
+        // Should not throw any exception
+        entity.consumeQuietly()
+    }
+
+    @Test
+    fun `consumeQuietly on null entity is safe`() {
+        val entity: StringEntity? = null
+
+        // Null-safe call — should not throw
+        entity.consumeQuietly()
+    }
+
+    @Test
+    fun `consume on non-null entity does not throw`() {
+        val entity = StringEntity("content to consume", ContentType.TEXT_PLAIN)
+
+        // Should not throw any exception
+        entity.consume()
+    }
+
+    @Test
+    fun `consume on null entity is safe`() {
+        val entity: StringEntity? = null
+
+        // Null-safe call — should not throw
+        entity.consume()
+    }
+
+    @Test
+    fun `toByteArrayOrNull returns correct byte content`() {
+        val text = "Hello, ByteArray!"
+        val entity = StringEntity(text, ContentType.TEXT_PLAIN)
+
+        val bytes = entity.toByteArrayOrNull()
+
+        bytes.shouldNotBeNull()
+        val decoded = String(bytes, Charsets.UTF_8)
+        decoded shouldBeEqualTo text
+    }
+
+    @Test
+    fun `toByteArrayOrNull with maxResultLength limits result`() {
+        val text = "Hello, World!"
+        val entity = StringEntity(text, ContentType.TEXT_PLAIN)
+
+        // Max length of 5 should return only the first 5 bytes
+        val bytes = entity.toByteArrayOrNull(maxResultLength = 5)
+
+        bytes.shouldNotBeNull()
+        bytes.size shouldBeEqualTo 5
+    }
+
+    @Test
+    fun `toStringOrNull returns correct string content`() {
+        val text = "Hello, String!"
+        val entity = StringEntity(text, ContentType.TEXT_PLAIN)
+
+        val result = entity.toStringOrNull()
+
+        result shouldBeEqualTo text
+    }
+
+    @Test
+    fun `toStringOrNull with custom charset returns correct string`() {
+        val text = "UTF-8 content: 한글"
+        val entity = StringEntity(text, ContentType.create("text/plain", Charsets.UTF_8))
+
+        val result = entity.toStringOrNull(charset = Charsets.UTF_8)
+
+        result shouldBeEqualTo text
+    }
+
+    @Test
+    fun `parse returns list of NameValuePairs for url-encoded content`() {
+        val urlEncodedContent = "key1=value1&key2=value2"
+        val entity = StringEntity(
+            urlEncodedContent,
+            ContentType.create("application/x-www-form-urlencoded", Charsets.UTF_8)
+        )
+
+        val pairs = entity.parse()
+
+        pairs.shouldHaveSize(2)
+        val map = pairs.associate { it.name to it.value }
+        map["key1"] shouldBeEqualTo "value1"
+        map["key2"] shouldBeEqualTo "value2"
+    }
+
+    @Test
+    fun `parse returns empty list for empty content`() {
+        val entity = StringEntity(
+            "",
+            ContentType.create("application/x-www-form-urlencoded", Charsets.UTF_8)
+        )
+
+        val pairs = entity.parse()
+
+        // Empty content produces empty or single empty pair — just verify no exception
+        pairs.shouldNotBeNull()
+    }
+
+    @Test
+    fun `toStringOrNull with maxResultLength limits result`() {
+        val text = "Hello, World!"
+        val entity = StringEntity(text, ContentType.TEXT_PLAIN)
+
+        val result = entity.toStringOrNull(maxResultLength = 5)
+
+        // Result should be limited
+        result.shouldNotBeNull()
+        result.length shouldBeEqualTo 5
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/entity/MimeEntityTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/entity/MimeEntityTest.kt
@@ -1,0 +1,149 @@
+package io.bluetape4k.http.hc5.entity
+
+import io.bluetape4k.http.hc5.entity.mime.formBodyPart
+import io.bluetape4k.http.hc5.entity.mime.formBodyPartOf
+import io.bluetape4k.http.hc5.entity.mime.multipartEntity
+import io.bluetape4k.http.hc5.entity.mime.multipartPart
+import io.bluetape4k.http.hc5.entity.mime.multipartPartOf
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldNotBeNull
+import org.amshove.kluent.shouldNotBeNullOrEmpty
+import org.apache.hc.client5.http.entity.mime.HttpMultipartMode
+import org.apache.hc.client5.http.entity.mime.StringBody
+import org.apache.hc.core5.http.ContentType
+import org.junit.jupiter.api.Test
+
+class MimeEntityTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `multipartEntity DSL creates multipart form entity`() {
+        val entity = multipartEntity {
+            addTextBody("field1", "value1")
+            addTextBody("field2", "value2")
+        }
+
+        entity.shouldNotBeNull()
+        val contentType = entity.contentType
+        contentType.shouldNotBeNullOrEmpty()
+        contentType shouldContain "multipart"
+    }
+
+    @Test
+    fun `multipartEntity with parameters creates entity with correct content type`() {
+        val entity = multipartEntity(
+            mode = HttpMultipartMode.STRICT,
+            charset = Charsets.UTF_8,
+        ) {
+            addTextBody("name", "testValue")
+        }
+
+        entity.shouldNotBeNull()
+        val contentType = entity.contentType
+        contentType.shouldNotBeNullOrEmpty()
+        contentType shouldContain "multipart"
+    }
+
+    @Test
+    fun `multipartEntity with boundary sets custom boundary`() {
+        val boundary = "custom-boundary-123"
+        val entity = multipartEntity(
+            boundary = boundary,
+        ) {
+            addTextBody("key", "value")
+        }
+
+        entity.shouldNotBeNull()
+        val contentType = entity.contentType
+        contentType.shouldNotBeNullOrEmpty()
+        contentType shouldContain boundary
+    }
+
+    @Test
+    fun `multipartEntity isStreaming is callable`() {
+        val entity = multipartEntity {
+            addTextBody("field", "value")
+        }
+
+        entity.shouldNotBeNull()
+        // isStreaming() should be callable without error
+        val streaming = entity.isStreaming
+        streaming.shouldNotBeNull()
+    }
+
+    @Test
+    fun `formBodyPart DSL creates FormBodyPart`() {
+        val body = StringBody("Hello, World!", ContentType.TEXT_PLAIN)
+        val part = formBodyPart {
+            setName("message")
+            setBody(body)
+        }
+
+        part.shouldNotBeNull()
+        part.name shouldContain "message"
+    }
+
+    @Test
+    fun `formBodyPart with name and body creates correct part`() {
+        val body = StringBody("test content", ContentType.TEXT_PLAIN)
+        val part = formBodyPart("field-name", body)
+
+        part.shouldNotBeNull()
+        part.name shouldContain "field-name"
+    }
+
+    @Test
+    fun `formBodyPartOf with fields creates part with headers`() {
+        val body = StringBody("text value", ContentType.TEXT_PLAIN)
+        val fields = mapOf("Custom-Field" to "custom-value")
+        val part = formBodyPartOf("myField", body, fields)
+
+        part.shouldNotBeNull()
+        part.name shouldContain "myField"
+    }
+
+    @Test
+    fun `multipartPart DSL creates MultipartPart`() {
+        val body = StringBody("part content", ContentType.TEXT_PLAIN)
+        val part = multipartPart {
+            setBody(body)
+            addHeader("Content-Disposition", "form-data; name=\"file\"")
+        }
+
+        part.shouldNotBeNull()
+        part.body.shouldNotBeNull()
+    }
+
+    @Test
+    fun `multipartPart with body creates part correctly`() {
+        val body = StringBody("Hello, Multipart!", ContentType.TEXT_PLAIN)
+        val part = multipartPart(body)
+
+        part.shouldNotBeNull()
+        part.body.shouldNotBeNull()
+    }
+
+    @Test
+    fun `multipartPartOf with body and fields creates part with headers`() {
+        val body = StringBody("content", ContentType.TEXT_PLAIN)
+        val fields = mapOf("Content-Disposition" to "form-data; name=\"data\"")
+        val part = multipartPartOf(body, fields = fields)
+
+        part.shouldNotBeNull()
+        part.body.shouldNotBeNull()
+    }
+
+    @Test
+    fun `multipartEntity with text body is readable`() {
+        val entity = multipartEntity {
+            addTextBody("username", "testUser")
+            addTextBody("email", "test@example.com")
+        }
+
+        entity.shouldNotBeNull()
+        entity.contentType.shouldNotBeNullOrEmpty()
+        entity.contentType shouldContain "multipart"
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/AsyncClientH2Multiplexing.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/AsyncClientH2Multiplexing.kt
@@ -1,7 +1,6 @@
 package io.bluetape4k.http.hc5.examples
 
 import io.bluetape4k.http.hc5.AbstractHc5Test
-import io.bluetape4k.http.hc5.async.asyncClientConnectionManager
 import io.bluetape4k.http.hc5.async.executeSuspending
 import io.bluetape4k.http.hc5.async.methods.simpleHttpRequest
 import io.bluetape4k.http.hc5.async.minimalHttpAsyncClientOf
@@ -24,7 +23,7 @@ class AsyncClientH2Multiplexing: AbstractHc5Test() {
         val baseUri = URI(NGHTTP2_HTTPBIN_URL)
         val httpHost = HttpHost(baseUri.scheme, baseUri.host, baseUri.port)
 
-        val client = minimalHttpAsyncClientOf(connMgr = asyncClientConnectionManager { })
+        val client = minimalHttpAsyncClientOf()
         client.start()
 
         val requestUris = listOf("/ip", "/user-agent", "/headers")

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/AsyncClientH2Multiplexing.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/AsyncClientH2Multiplexing.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.http.hc5.examples
 
 import io.bluetape4k.http.hc5.AbstractHc5Test
+import io.bluetape4k.http.hc5.async.asyncClientConnectionManager
 import io.bluetape4k.http.hc5.async.executeSuspending
 import io.bluetape4k.http.hc5.async.methods.simpleHttpRequest
 import io.bluetape4k.http.hc5.async.minimalHttpAsyncClientOf
@@ -23,7 +24,7 @@ class AsyncClientH2Multiplexing: AbstractHc5Test() {
         val baseUri = URI(NGHTTP2_HTTPBIN_URL)
         val httpHost = HttpHost(baseUri.scheme, baseUri.host, baseUri.port)
 
-        val client = minimalHttpAsyncClientOf()
+        val client = minimalHttpAsyncClientOf(connMgr = asyncClientConnectionManager { })
         client.start()
 
         val requestUris = listOf("/ip", "/user-agent", "/headers")

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/AsyncClientH2ServerPush.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/AsyncClientH2ServerPush.kt
@@ -1,7 +1,6 @@
 package io.bluetape4k.http.hc5.examples
 
 import io.bluetape4k.http.hc5.AbstractHc5Test
-import io.bluetape4k.http.hc5.async.asyncClientConnectionManager
 import io.bluetape4k.http.hc5.async.executeSuspending
 import io.bluetape4k.http.hc5.async.methods.simpleHttpRequest
 import io.bluetape4k.http.hc5.async.minimalHttpAsyncClientOf
@@ -33,7 +32,6 @@ class AsyncClientH2ServerPush: AbstractHc5Test() {
 
         val client = minimalHttpAsyncClientOf(
             h2config = h2Config { setPushEnabled(true) },
-            connMgr = asyncClientConnectionManager { },
         )
         client.start()
 

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/AsyncClientH2ServerPush.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/AsyncClientH2ServerPush.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.http.hc5.examples
 
 import io.bluetape4k.http.hc5.AbstractHc5Test
+import io.bluetape4k.http.hc5.async.asyncClientConnectionManager
 import io.bluetape4k.http.hc5.async.executeSuspending
 import io.bluetape4k.http.hc5.async.methods.simpleHttpRequest
 import io.bluetape4k.http.hc5.async.minimalHttpAsyncClientOf
@@ -31,7 +32,8 @@ class AsyncClientH2ServerPush: AbstractHc5Test() {
         val httpHost = HttpHost(baseUri.scheme, baseUri.host, baseUri.port)
 
         val client = minimalHttpAsyncClientOf(
-            h2config = h2Config { setPushEnabled(true) }
+            h2config = h2Config { setPushEnabled(true) },
+            connMgr = asyncClientConnectionManager { },
         )
         client.start()
 

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/ReactiveClientFullDuplexExchange.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/ReactiveClientFullDuplexExchange.kt
@@ -2,7 +2,6 @@ package io.bluetape4k.http.hc5.examples
 
 import io.bluetape4k.coroutines.support.awaitSuspending
 import io.bluetape4k.http.hc5.AbstractHc5Test
-import io.bluetape4k.http.hc5.async.asyncClientConnectionManager
 import io.bluetape4k.http.hc5.async.minimalHttpAsyncClientOf
 import io.bluetape4k.http.hc5.http.ContentTypes
 import io.bluetape4k.http.hc5.http.basicRequestProducerOf
@@ -30,7 +29,7 @@ class ReactiveClientFullDuplexExchange: AbstractHc5Test() {
 
     @Test
     fun `send reactive flux and receive reactive flux`() = runSuspendIO {
-        val client = minimalHttpAsyncClientOf(connMgr = asyncClientConnectionManager { })
+        val client = minimalHttpAsyncClientOf()
         client.start()
 
         val requestUri = URI("$httpbinBaseUrl/post")

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/ReactiveClientFullDuplexExchange.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/ReactiveClientFullDuplexExchange.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.http.hc5.examples
 
 import io.bluetape4k.coroutines.support.awaitSuspending
 import io.bluetape4k.http.hc5.AbstractHc5Test
+import io.bluetape4k.http.hc5.async.asyncClientConnectionManager
 import io.bluetape4k.http.hc5.async.minimalHttpAsyncClientOf
 import io.bluetape4k.http.hc5.http.ContentTypes
 import io.bluetape4k.http.hc5.http.basicRequestProducerOf
@@ -29,7 +30,7 @@ class ReactiveClientFullDuplexExchange: AbstractHc5Test() {
 
     @Test
     fun `send reactive flux and receive reactive flux`() = runSuspendIO {
-        val client = minimalHttpAsyncClientOf()
+        val client = minimalHttpAsyncClientOf(connMgr = asyncClientConnectionManager { })
         client.start()
 
         val requestUri = URI("$httpbinBaseUrl/post")

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/fluent/RequestTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/fluent/RequestTest.kt
@@ -1,0 +1,129 @@
+package io.bluetape4k.http.hc5.fluent
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.core5.http.Method
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+class RequestTest {
+
+    companion object: KLogging()
+
+    private val testUri: URI = URI.create("https://example.com/api")
+    private val testUriStr: String = "https://example.com/api"
+
+    @Test
+    fun `requestOf Method URI 로 GET 요청 생성`() {
+        val request = requestOf(Method.GET, testUri)
+        request.shouldNotBeNull()
+    }
+
+    @Test
+    fun `requestOf methodName URI 로 POST 요청 생성`() {
+        val request = requestOf("POST", testUri)
+        request.shouldNotBeNull()
+    }
+
+    @Test
+    fun `requestOf methodName String 로 요청 생성`() {
+        val request = requestOf("GET", testUriStr)
+        request.shouldNotBeNull()
+    }
+
+    @Test
+    fun `requestGet URI 로 GET 요청 생성`() {
+        val request = requestGet(testUri)
+        request.shouldNotBeNull()
+    }
+
+    @Test
+    fun `requestGet String 로 GET 요청 생성`() {
+        val request = requestGet(testUriStr)
+        request.shouldNotBeNull()
+    }
+
+    @Test
+    fun `requestHead URI 로 HEAD 요청 생성`() {
+        val request = requestHead(testUri)
+        request.shouldNotBeNull()
+    }
+
+    @Test
+    fun `requestHead String 로 HEAD 요청 생성`() {
+        val request = requestHead(testUriStr)
+        request.shouldNotBeNull()
+    }
+
+    @Test
+    fun `requestPost URI 로 POST 요청 생성`() {
+        val request = requestPost(testUri)
+        request.shouldNotBeNull()
+    }
+
+    @Test
+    fun `requestPost String 로 POST 요청 생성`() {
+        val request = requestPost(testUriStr)
+        request.shouldNotBeNull()
+    }
+
+    @Test
+    fun `requestPatch URI 로 PATCH 요청 생성`() {
+        val request = requestPatch(testUri)
+        request.shouldNotBeNull()
+    }
+
+    @Test
+    fun `requestPatch String 로 PATCH 요청 생성`() {
+        val request = requestPatch(testUriStr)
+        request.shouldNotBeNull()
+    }
+
+    @Test
+    fun `requestPut URI 로 PUT 요청 생성`() {
+        val request = requestPut(testUri)
+        request.shouldNotBeNull()
+    }
+
+    @Test
+    fun `requestPut String 로 PUT 요청 생성`() {
+        val request = requestPut(testUriStr)
+        request.shouldNotBeNull()
+    }
+
+    @Test
+    fun `requestTrace URI 로 TRACE 요청 생성`() {
+        val request = requestTrace(testUri)
+        request.shouldNotBeNull()
+    }
+
+    @Test
+    fun `requestTrace String 로 TRACE 요청 생성`() {
+        val request = requestTrace(testUriStr)
+        request.shouldNotBeNull()
+    }
+
+    @Test
+    fun `requestDelete URI 로 DELETE 요청 생성`() {
+        val request = requestDelete(testUri)
+        request.shouldNotBeNull()
+    }
+
+    @Test
+    fun `requestDelete String 로 DELETE 요청 생성`() {
+        val request = requestDelete(testUriStr)
+        request.shouldNotBeNull()
+    }
+
+    @Test
+    fun `requestOptions URI 로 OPTIONS 요청 생성`() {
+        val request = requestOptions(testUri)
+        request.shouldNotBeNull()
+    }
+
+    @Test
+    fun `requestOptions String 로 OPTIONS 요청 생성`() {
+        val request = requestOptions(testUriStr)
+        request.shouldNotBeNull()
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/AuthScopeTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/AuthScopeTest.kt
@@ -1,0 +1,110 @@
+package io.bluetape4k.http.hc5.http
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.core5.http.HttpHost
+import org.junit.jupiter.api.Test
+
+class AuthScopeTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `authScopeOf(protocol, host, port) 기본 검증`() {
+        val scope = authScopeOf("http", "localhost", 8080)
+
+        scope.shouldNotBeNull()
+        scope.host shouldBeEqualTo "localhost"
+        scope.port shouldBeEqualTo 8080
+    }
+
+    @Test
+    fun `authScopeOf(protocol, host, port, realm, schemeName) 전체 파라미터 검증`() {
+        val scope = authScopeOf("http", "example.com", 80, "admin", "BASIC")
+
+        scope.shouldNotBeNull()
+        scope.host shouldBeEqualTo "example.com"
+        scope.port shouldBeEqualTo 80
+        scope.realm shouldBeEqualTo "admin"
+        scope.schemeName shouldBeEqualTo "BASIC"
+    }
+
+    @Test
+    fun `authScopeOf(protocol, host) - 포트 기본값(-1) 검증`() {
+        val scope = authScopeOf("https", "secure.example.com")
+
+        scope.shouldNotBeNull()
+        scope.host shouldBeEqualTo "secure.example.com"
+        scope.port shouldBeEqualTo -1
+    }
+
+    @Test
+    fun `authScopeOf(protocol, host) - realm null 검증`() {
+        val scope = authScopeOf("http", "localhost", 8080)
+
+        scope.shouldNotBeNull()
+        scope.realm.shouldBeNull()
+    }
+
+    @Test
+    fun `authScopeOf(HttpHost) - HttpHost 기반 생성 검증`() {
+        val host = HttpHost("http", "localhost", 8080)
+        val scope = authScopeOf(host)
+
+        scope.shouldNotBeNull()
+        scope.host shouldBeEqualTo "localhost"
+        scope.port shouldBeEqualTo 8080
+    }
+
+    @Test
+    fun `authScopeOf(HttpHost, realm) - realm 포함 검증`() {
+        val host = HttpHost("http", "api.example.com", 443)
+        val scope = authScopeOf(host, realm = "admin-area")
+
+        scope.shouldNotBeNull()
+        scope.host shouldBeEqualTo "api.example.com"
+        scope.port shouldBeEqualTo 443
+        scope.realm shouldBeEqualTo "admin-area"
+    }
+
+    @Test
+    fun `authScopeOf(HttpHost, realm, schemeName) - schemeName 포함 검증`() {
+        val host = HttpHost("https", "example.com", 443)
+        val scope = authScopeOf(host, realm = "test-realm", schemeName = "DIGEST")
+
+        scope.shouldNotBeNull()
+        scope.host shouldBeEqualTo "example.com"
+        scope.realm shouldBeEqualTo "test-realm"
+        scope.schemeName shouldBeEqualTo "DIGEST"
+    }
+
+    @Test
+    fun `authScopeOf(url) - URL 문자열 기반 생성 검증`() {
+        val scope = authScopeOf("http://localhost:8080")
+
+        scope.shouldNotBeNull()
+        scope.host shouldBeEqualTo "localhost"
+        scope.port shouldBeEqualTo 8080
+    }
+
+    @Test
+    fun `authScopeOf(url, realm) - URL과 realm 검증`() {
+        val scope = authScopeOf("http://example.com:9000", realm = "secure-zone")
+
+        scope.shouldNotBeNull()
+        scope.host shouldBeEqualTo "example.com"
+        scope.port shouldBeEqualTo 9000
+        scope.realm shouldBeEqualTo "secure-zone"
+    }
+
+    @Test
+    fun `authScopeOf(host, port) - 호스트와 포트만으로 생성 검증`() {
+        val scope = authScopeOf("api.example.com", 8443)
+
+        scope.shouldNotBeNull()
+        scope.host shouldBeEqualTo "api.example.com"
+        scope.port shouldBeEqualTo 8443
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/BasicRequestBuilderTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/BasicRequestBuilderTest.kt
@@ -1,0 +1,109 @@
+package io.bluetape4k.http.hc5.http
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.core5.http.HttpHost
+import org.apache.hc.core5.http.Method
+import org.apache.hc.core5.http.message.BasicHeader
+import org.junit.jupiter.api.Test
+
+class BasicRequestBuilderTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `basicHttpRequest(String) - GET 메서드 이름 검증`() {
+        val request = basicHttpRequest("GET") {
+            setHttpHost(HttpHost("localhost", 8080))
+            setPath("/api/v1")
+        }
+
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "GET"
+    }
+
+    @Test
+    fun `basicHttpRequest(String) - POST 메서드 이름 검증`() {
+        val request = basicHttpRequest("POST") {
+            setHttpHost(HttpHost("localhost", 8080))
+            setPath("/api/v1/users")
+        }
+
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "POST"
+    }
+
+    @Test
+    fun `basicHttpRequest(Method) - Method 열거형 사용 검증`() {
+        val request = basicHttpRequest(Method.DELETE) {
+            setHttpHost(HttpHost("localhost", 8080))
+            setPath("/api/v1/users/1")
+        }
+
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "DELETE"
+    }
+
+    @Test
+    fun `basicHttpRequest(Method) - PUT 메서드 검증`() {
+        val request = basicHttpRequest(Method.PUT) {
+            setHttpHost(HttpHost("localhost", 8080))
+            setPath("/api/v1/items/42")
+        }
+
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "PUT"
+    }
+
+    @Test
+    fun `basicHttpRequestOf - host와 path 검증`() {
+        val host = HttpHost("localhost", 8080)
+        val request = basicHttpRequestOf("GET", host, "/api/v1")
+
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "GET"
+        request.path shouldBeEqualTo "/api/v1"
+        request.authority?.hostName shouldBeEqualTo "localhost"
+        request.authority?.port shouldBeEqualTo 8080
+    }
+
+    @Test
+    fun `basicHttpRequestOf(Method) - Method 열거형으로 host와 path 검증`() {
+        val host = HttpHost("example.com", 9090)
+        val request = basicHttpRequestOf(Method.GET, host, "/health")
+
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "GET"
+        request.path shouldBeEqualTo "/health"
+        request.authority?.hostName shouldBeEqualTo "example.com"
+        request.authority?.port shouldBeEqualTo 9090
+    }
+
+    @Test
+    fun `basicHttpRequestOf - 헤더 포함 요청 검증`() {
+        val host = HttpHost("localhost", 8080)
+        val headers = listOf(
+            BasicHeader("Authorization", "Bearer token"),
+            BasicHeader("Accept", "application/json"),
+        )
+        val request = basicHttpRequestOf("GET", host, "/api/v1", headers)
+
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "GET"
+        request.getFirstHeader("Authorization")?.value shouldBeEqualTo "Bearer token"
+        request.getFirstHeader("Accept")?.value shouldBeEqualTo "application/json"
+    }
+
+    @Test
+    fun `basicHttpRequestOf - DSL builder 추가 헤더 검증`() {
+        val host = HttpHost("localhost", 8080)
+        val request = basicHttpRequestOf("POST", host, "/api/v1/data") {
+            addHeader("Content-Type", "application/json")
+        }
+
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "POST"
+        request.getFirstHeader("Content-Type")?.value shouldBeEqualTo "application/json"
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/BasicRequestProducerTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/BasicRequestProducerTest.kt
@@ -1,0 +1,49 @@
+package io.bluetape4k.http.hc5.http
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.core5.http.Method
+import org.apache.hc.core5.http.message.BasicHttpRequest
+import org.apache.hc.core5.http.nio.support.BasicRequestProducer
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+class BasicRequestProducerTest {
+
+    companion object: KLogging()
+
+    private val testUri: URI = URI.create("http://localhost:8080/api/v1")
+
+    @Test
+    fun `BasicHttpRequest toProducer 로 BasicRequestProducer 생성`() {
+        val request = BasicHttpRequest("GET", testUri)
+        val producer = request.toProducer()
+        producer.shouldNotBeNull()
+    }
+
+    @Test
+    fun `basicRequestProducerOf request 로 생성`() {
+        val request = BasicHttpRequest("GET", testUri)
+        val producer = basicRequestProducerOf(request)
+        producer.shouldNotBeNull()
+    }
+
+    @Test
+    fun `basicRequestProducerOf Method URI 로 생성`() {
+        val producer: BasicRequestProducer = basicRequestProducerOf(Method.GET, testUri)
+        producer.shouldNotBeNull()
+    }
+
+    @Test
+    fun `basicRequestProducerOf methodName URI 로 생성`() {
+        val producer: BasicRequestProducer = basicRequestProducerOf("POST", testUri)
+        producer.shouldNotBeNull()
+    }
+
+    @Test
+    fun `basicRequestProducerOf dataProducer null 로 생성`() {
+        val request = BasicHttpRequest(Method.GET.name, testUri)
+        val producer = basicRequestProducerOf(request, dataProducer = null)
+        producer.shouldNotBeNull()
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/BasicResponseBuilderTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/BasicResponseBuilderTest.kt
@@ -1,0 +1,83 @@
+package io.bluetape4k.http.hc5.http
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.core5.http.message.BasicHttpResponse
+import org.junit.jupiter.api.Test
+
+class BasicResponseBuilderTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `basicHttpResponse(Int) - 200 상태코드 검증`() {
+        val response = basicHttpResponse(200) {}
+
+        response.shouldNotBeNull()
+        response.code shouldBeEqualTo 200
+    }
+
+    @Test
+    fun `basicHttpResponse(Int) - 404 상태코드 검증`() {
+        val response = basicHttpResponse(404) {}
+
+        response.shouldNotBeNull()
+        response.code shouldBeEqualTo 404
+    }
+
+    @Test
+    fun `basicHttpResponse(Int) - 500 상태코드 검증`() {
+        val response = basicHttpResponse(500) {}
+
+        response.shouldNotBeNull()
+        response.code shouldBeEqualTo 500
+    }
+
+    @Test
+    fun `basicHttpResponse(Int) - 헤더 추가 검증`() {
+        val response = basicHttpResponse(200) {
+            addHeader("Content-Type", "application/json")
+            addHeader("X-Request-Id", "abc-123")
+        }
+
+        response.shouldNotBeNull()
+        response.code shouldBeEqualTo 200
+        response.getFirstHeader("Content-Type")?.value shouldBeEqualTo "application/json"
+        response.getFirstHeader("X-Request-Id")?.value shouldBeEqualTo "abc-123"
+    }
+
+    @Test
+    fun `basicHttpResponse(HttpResponse) - 기존 응답 복사 후 검증`() {
+        val original = BasicHttpResponse(201)
+        original.addHeader("X-Original", "yes")
+
+        val response = basicHttpResponse(original) {
+            addHeader("X-Extra", "extra-value")
+        }
+
+        response.shouldNotBeNull()
+        response.code shouldBeEqualTo 201
+        response.getFirstHeader("X-Original")?.value shouldBeEqualTo "yes"
+        response.getFirstHeader("X-Extra")?.value shouldBeEqualTo "extra-value"
+    }
+
+    @Test
+    fun `basicHttpResponse(Int) - 201 상태코드 검증`() {
+        val response = basicHttpResponse(201) {}
+
+        response.shouldNotBeNull()
+        response.code shouldBeEqualTo 201
+    }
+
+    @Test
+    fun `basicHttpResponse(Int) - 302 상태코드 검증`() {
+        val response = basicHttpResponse(302) {
+            addHeader("Location", "https://example.com/new-location")
+        }
+
+        response.shouldNotBeNull()
+        response.code shouldBeEqualTo 302
+        response.getFirstHeader("Location")?.value shouldBeEqualTo "https://example.com/new-location"
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/ClassicRequestBuilderTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/ClassicRequestBuilderTest.kt
@@ -1,0 +1,99 @@
+package io.bluetape4k.http.hc5.http
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.core5.http.Method
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+class ClassicRequestBuilderTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `classicRequest(String) - GET 메서드 이름 검증`() {
+        val request = classicRequest("GET") {
+            setUri("https://example.com/api")
+        }
+
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "GET"
+    }
+
+    @Test
+    fun `classicRequest(String) - POST 메서드 이름 검증`() {
+        val request = classicRequest("POST") {
+            setUri("https://example.com/api/users")
+        }
+
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "POST"
+    }
+
+    @Test
+    fun `classicRequest(String) - PUT 메서드 이름 검증`() {
+        val request = classicRequest("PUT") {
+            setUri("https://example.com/api/users/1")
+        }
+
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "PUT"
+    }
+
+    @Test
+    fun `classicRequest(String) - DELETE 메서드 이름 검증`() {
+        val request = classicRequest("DELETE") {
+            setUri("https://example.com/api/users/42")
+        }
+
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "DELETE"
+    }
+
+    @Test
+    fun `classicRequest(Method) - Method 열거형 사용 검증`() {
+        val request = classicRequest(Method.GET) {
+            setUri("https://example.com/health")
+        }
+
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "GET"
+    }
+
+    @Test
+    fun `classicRequest(Method) - PATCH 메서드 검증`() {
+        val request = classicRequest(Method.PATCH) {
+            setUri("https://example.com/api/items/5")
+        }
+
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "PATCH"
+    }
+
+    @Test
+    fun `classicRequest URI 설정 검증`() {
+        val uri = URI("https://api.example.com/v2/data")
+        val request = classicRequest("GET") {
+            setUri(uri)
+        }
+
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "GET"
+        request.uri shouldBeEqualTo uri
+    }
+
+    @Test
+    fun `classicRequest 헤더 추가 검증`() {
+        val request = classicRequest("POST") {
+            setUri("https://example.com/submit")
+            addHeader("Authorization", "Bearer my-token")
+            addHeader("Content-Type", "application/json")
+        }
+
+        request.shouldNotBeNull()
+        request.method shouldBeEqualTo "POST"
+        request.getFirstHeader("Authorization")?.value shouldBeEqualTo "Bearer my-token"
+        request.getFirstHeader("Content-Type")?.value shouldBeEqualTo "application/json"
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/ConfigBuilderTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/ConfigBuilderTest.kt
@@ -44,6 +44,8 @@ class ConfigBuilderTest {
         val config = connectionConfigOf(
             connectTimeout = connectTimeout,
             socketTimeout = socketTimeout,
+            validateAfterInactivity = TimeValue.ofSeconds(30),
+            timeToLive = TimeValue.ofMinutes(10),
         )
 
         config.shouldNotBeNull()
@@ -55,7 +57,10 @@ class ConfigBuilderTest {
     fun `connectionConfigOf - validateAfterInactivity 설정 검증`() {
         val validateAfterInactivity = TimeValue.ofSeconds(60)
         val config = connectionConfigOf(
+            connectTimeout = Timeout.ofSeconds(5),
+            socketTimeout = Timeout.ofSeconds(15),
             validateAfterInactivity = validateAfterInactivity,
+            timeToLive = TimeValue.ofMinutes(1),
         )
 
         config.shouldNotBeNull()
@@ -66,6 +71,9 @@ class ConfigBuilderTest {
     fun `connectionConfigOf - timeToLive 설정 검증`() {
         val timeToLive = TimeValue.ofMinutes(5)
         val config = connectionConfigOf(
+            connectTimeout = Timeout.ofSeconds(5),
+            socketTimeout = Timeout.ofSeconds(15),
+            validateAfterInactivity = TimeValue.ofSeconds(30),
             timeToLive = timeToLive,
         )
 

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/ConfigBuilderTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/ConfigBuilderTest.kt
@@ -1,0 +1,227 @@
+package io.bluetape4k.http.hc5.http
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.core5.http.config.Http1Config
+import org.apache.hc.core5.http.ssl.TLS
+import org.apache.hc.core5.http2.HttpVersionPolicy
+import org.apache.hc.core5.util.TimeValue
+import org.apache.hc.core5.util.Timeout
+import org.junit.jupiter.api.Test
+
+class ConfigBuilderTest {
+
+    companion object : KLogging()
+
+    // ---- ConnectionConfig ----
+
+    @Test
+    fun `connectionConfig DSL - 기본 생성 검증`() {
+        val config = connectionConfig {
+            setConnectTimeout(Timeout.ofSeconds(10))
+            setSocketTimeout(Timeout.ofSeconds(30))
+        }
+
+        config.shouldNotBeNull()
+    }
+
+    @Test
+    fun `connectionConfig DSL - connectTimeout 설정 검증`() {
+        val timeout = Timeout.ofSeconds(15)
+        val config = connectionConfig {
+            setConnectTimeout(timeout)
+        }
+
+        config.shouldNotBeNull()
+        config.connectTimeout shouldBeEqualTo timeout
+    }
+
+    @Test
+    fun `connectionConfigOf - 파라미터 기반 생성 검증`() {
+        val connectTimeout = Timeout.ofSeconds(5)
+        val socketTimeout = Timeout.ofSeconds(20)
+        val config = connectionConfigOf(
+            connectTimeout = connectTimeout,
+            socketTimeout = socketTimeout,
+        )
+
+        config.shouldNotBeNull()
+        config.connectTimeout shouldBeEqualTo connectTimeout
+        config.socketTimeout shouldBeEqualTo socketTimeout
+    }
+
+    @Test
+    fun `connectionConfigOf - validateAfterInactivity 설정 검증`() {
+        val validateAfterInactivity = TimeValue.ofSeconds(60)
+        val config = connectionConfigOf(
+            validateAfterInactivity = validateAfterInactivity,
+        )
+
+        config.shouldNotBeNull()
+        config.validateAfterInactivity shouldBeEqualTo validateAfterInactivity
+    }
+
+    @Test
+    fun `connectionConfigOf - timeToLive 설정 검증`() {
+        val timeToLive = TimeValue.ofMinutes(5)
+        val config = connectionConfigOf(
+            timeToLive = timeToLive,
+        )
+
+        config.shouldNotBeNull()
+        config.timeToLive shouldBeEqualTo timeToLive
+    }
+
+    // ---- RequestConfig ----
+
+    @Test
+    fun `requestConfig DSL - 기본 생성 검증`() {
+        val config = requestConfig {}
+
+        config.shouldNotBeNull()
+    }
+
+    @Test
+    fun `requestConfigOf - 기본 인스턴스 생성 검증`() {
+        val config = requestConfigOf()
+
+        config.shouldNotBeNull()
+    }
+
+    @Test
+    fun `requestConfig DSL - connectionRequestTimeout 설정 검증`() {
+        val timeout = Timeout.ofSeconds(10)
+        val config = requestConfig {
+            setConnectionRequestTimeout(timeout)
+        }
+
+        config.shouldNotBeNull()
+        config.connectionRequestTimeout shouldBeEqualTo timeout
+    }
+
+    // ---- SocketConfig ----
+
+    @Test
+    fun `socketConfig DSL - 기본 생성 검증`() {
+        val config = socketConfig {
+            setSoTimeout(Timeout.ofSeconds(30))
+        }
+
+        config.shouldNotBeNull()
+    }
+
+    @Test
+    fun `socketConfigOf - 기본값 생성 검증`() {
+        val config = socketConfigOf()
+
+        config.shouldNotBeNull()
+    }
+
+    @Test
+    fun `socketConfigOf - soTimeout 파라미터 검증`() {
+        val soTimeout = Timeout.ofSeconds(45)
+        val config = socketConfigOf(soTimeout = soTimeout)
+
+        config.shouldNotBeNull()
+        config.soTimeout shouldBeEqualTo soTimeout
+    }
+
+    // ---- TlsConfig ----
+
+    @Test
+    fun `tlsConfig DSL - 기본 생성 검증`() {
+        val config = tlsConfig {
+            setSupportedProtocols(TLS.V_1_2, TLS.V_1_3)
+        }
+
+        config.shouldNotBeNull()
+    }
+
+    @Test
+    fun `tlsConfigOf - 기본 프로토콜 생성 검증`() {
+        val config = tlsConfigOf()
+
+        config.shouldNotBeNull()
+    }
+
+    @Test
+    fun `tlsConfigOf - handshakeTimeout 설정 검증`() {
+        val handshakeTimeout = Timeout.ofSeconds(10)
+        val config = tlsConfigOf(handshakeTimeout = handshakeTimeout)
+
+        config.shouldNotBeNull()
+        config.handshakeTimeout shouldBeEqualTo handshakeTimeout
+    }
+
+    @Test
+    fun `tlsConfigOf - versionPolicy 설정 검증`() {
+        val config = tlsConfigOf(versionPolicy = HttpVersionPolicy.NEGOTIATE)
+
+        config.shouldNotBeNull()
+        config.httpVersionPolicy shouldBeEqualTo HttpVersionPolicy.NEGOTIATE
+    }
+
+    // ---- Http1Config ----
+
+    @Test
+    fun `http1ConfigOf - 기본 인스턴스 반환 검증`() {
+        val config = http1ConfigOf()
+
+        config.shouldNotBeNull()
+        config shouldBeEqualTo Http1Config.DEFAULT
+    }
+
+    @Test
+    fun `http1Config DSL - bufferSize 설정 검증`() {
+        val config = http1Config {
+            setBufferSize(8192)
+        }
+
+        config.shouldNotBeNull()
+        config.bufferSize shouldBeEqualTo 8192
+    }
+
+    @Test
+    fun `http1Config(source) - 소스 복사 후 수정 검증`() {
+        val source = http1ConfigOf()
+        val config = http1Config(source) {
+            setBufferSize(4096)
+        }
+
+        config.shouldNotBeNull()
+        config.bufferSize shouldBeEqualTo 4096
+    }
+
+    // ---- CharCodingConfig ----
+
+    @Test
+    fun `charCodingConfigOf - 기본 인스턴스 반환 검증`() {
+        val config = charCodingConfigOf()
+
+        config.shouldNotBeNull()
+    }
+
+    @Test
+    fun `charCodingConfig DSL - charset 설정 검증`() {
+        val config = charCodingConfig {
+            setCharset(Charsets.UTF_8)
+        }
+
+        config.shouldNotBeNull()
+        config.charset shouldBeEqualTo Charsets.UTF_8
+    }
+
+    @Test
+    fun `charCodingConfig(source) - 소스 복사 후 charset 변경 검증`() {
+        val source = charCodingConfig {
+            setCharset(Charsets.UTF_8)
+        }
+        val config = charCodingConfig(source) {
+            setCharset(Charsets.ISO_8859_1)
+        }
+
+        config.shouldNotBeNull()
+        config.charset shouldBeEqualTo Charsets.ISO_8859_1
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/ConnectExceptionSupportTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/ConnectExceptionSupportTest.kt
@@ -1,0 +1,81 @@
+package io.bluetape4k.http.hc5.http
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.client5.http.ConnectTimeoutException
+import org.apache.hc.client5.http.HttpHostConnectException
+import org.apache.hc.core5.net.URIAuthority
+import org.junit.jupiter.api.Test
+import java.io.IOException
+
+class ConnectExceptionSupportTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `IOException toConnectTimeoutException - ConnectTimeoutException 타입 반환 검증`() {
+        val cause = IOException("Connection timed out")
+        val endpoint = URIAuthority("example.com", 443)
+
+        val result = cause.toConnectTimeoutException(endpoint)
+
+        result.shouldNotBeNull()
+        result shouldBeInstanceOf ConnectTimeoutException::class
+    }
+
+    @Test
+    fun `IOException toConnectTimeoutException - 포트 없는 엔드포인트 검증`() {
+        val cause = IOException("Timeout")
+        val endpoint = URIAuthority("api.example.com", 80)
+
+        val result = cause.toConnectTimeoutException(endpoint)
+
+        result.shouldNotBeNull()
+        result shouldBeInstanceOf ConnectTimeoutException::class
+    }
+
+    @Test
+    fun `IOException toHttpHostConnectException - HttpHostConnectException 타입 반환 검증`() {
+        val cause = IOException("Connection refused")
+        val endpoint = URIAuthority("example.com", 443)
+
+        val result = cause.toHttpHostConnectException(endpoint)
+
+        result.shouldNotBeNull()
+        result shouldBeInstanceOf HttpHostConnectException::class
+    }
+
+    @Test
+    fun `IOException toHttpHostConnectException - 다른 포트 엔드포인트 검증`() {
+        val cause = IOException("Host unreachable")
+        val endpoint = URIAuthority("internal.service.com", 8080)
+
+        val result = cause.toHttpHostConnectException(endpoint)
+
+        result.shouldNotBeNull()
+        result shouldBeInstanceOf HttpHostConnectException::class
+    }
+
+    @Test
+    fun `IOException enhance - IOException 반환 확인`() {
+        val cause = IOException("Network error")
+        val endpoint = URIAuthority("example.com", 443)
+
+        val result = cause.enhance(endpoint)
+
+        result.shouldNotBeNull()
+        result shouldBeInstanceOf IOException::class
+    }
+
+    @Test
+    fun `IOException enhance - 엔드포인트 정보 보강 후 IOException 반환`() {
+        val cause = IOException("Read timed out")
+        val endpoint = URIAuthority("slow.server.com", 9000)
+
+        val result = cause.enhance(endpoint)
+
+        result.shouldNotBeNull()
+        result shouldBeInstanceOf IOException::class
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/ContentTypesTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/ContentTypesTest.kt
@@ -1,0 +1,38 @@
+package io.bluetape4k.http.hc5.http
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+
+class ContentTypesTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `TEXT_PLAIN_UTF8 MIME 타입 검증`() {
+        val contentType = ContentTypes.TEXT_PLAIN_UTF8
+
+        contentType.shouldNotBeNull()
+        contentType.mimeType shouldBeEqualTo "text/plain"
+    }
+
+    @Test
+    fun `TEXT_PLAIN_UTF8 charset UTF-8 검증`() {
+        val contentType = ContentTypes.TEXT_PLAIN_UTF8
+
+        contentType.shouldNotBeNull()
+        contentType.charset shouldBeEqualTo Charsets.UTF_8
+    }
+
+    @Test
+    fun `TEXT_PLAIN_UTF8 toString 형식 검증`() {
+        val contentType = ContentTypes.TEXT_PLAIN_UTF8
+
+        contentType.shouldNotBeNull()
+        // mimeType과 charset 모두 포함
+        val str = contentType.toString()
+        str.contains("text/plain") shouldBeEqualTo true
+        str.contains("UTF-8") shouldBeEqualTo true
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/ContextBuilderTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/ContextBuilderTest.kt
@@ -1,0 +1,45 @@
+package io.bluetape4k.http.hc5.http
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.client5.http.ContextBuilder
+import org.apache.hc.client5.http.impl.DefaultSchemePortResolver
+import org.apache.hc.client5.http.protocol.HttpClientContext
+import org.junit.jupiter.api.Test
+
+class ContextBuilderTest {
+
+    companion object: KLogging()
+
+    @Test
+    fun `httpClientContext DSL 로 HttpClientContext 생성`() {
+        val context = httpClientContext {
+            // 기본 설정만
+        }
+        context.shouldNotBeNull()
+        context.shouldBeInstanceOf<HttpClientContext>()
+    }
+
+    @Test
+    fun `contextBuilderOf - 기본 ContextBuilder 생성`() {
+        val builder = contextBuilderOf()
+        builder.shouldNotBeNull()
+        builder.shouldBeInstanceOf<ContextBuilder>()
+    }
+
+    @Test
+    fun `contextBuilderOf - SchemePortResolver 적용한 ContextBuilder 생성`() {
+        val resolver = DefaultSchemePortResolver.INSTANCE
+        val builder = contextBuilderOf(resolver)
+        builder.shouldNotBeNull()
+        builder.shouldBeInstanceOf<ContextBuilder>()
+    }
+
+    @Test
+    fun `contextBuilderOf 로 build 하여 HttpClientContext 생성`() {
+        val context = contextBuilderOf().build()
+        context.shouldNotBeNull()
+        context.shouldBeInstanceOf<HttpClientContext>()
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/CookieSpecSupportTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/CookieSpecSupportTest.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.http.hc5.http
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.client5.http.cookie.CookieSpecFactory
+import org.apache.hc.client5.http.psl.PublicSuffixMatcherLoader
+import org.apache.hc.core5.http.config.Lookup
+import org.junit.jupiter.api.Test
+
+class CookieSpecSupportTest {
+
+    companion object: KLogging()
+
+    @Test
+    fun `defaultRegistryOf - 기본 PublicSuffixMatcher 로 레지스트리 생성`() {
+        val registry: Lookup<CookieSpecFactory> = defaultRegistryOf()
+        registry.shouldNotBeNull()
+    }
+
+    @Test
+    fun `defaultRegistryOf - 커스텀 PublicSuffixMatcher 로 레지스트리 생성`() {
+        val matcher = PublicSuffixMatcherLoader.getDefault()
+        val registry: Lookup<CookieSpecFactory> = defaultRegistryOf(matcher)
+        registry.shouldNotBeNull()
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/HttpHostTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/HttpHostTest.kt
@@ -1,0 +1,83 @@
+package io.bluetape4k.http.hc5.http
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+class HttpHostTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `URI toHttpHost - HTTP URL 파싱`() {
+        val uri = URI("http://example.com")
+        val httpHost = uri.toHttpHost()
+
+        httpHost.shouldNotBeNull()
+        httpHost.schemeName shouldBeEqualTo "http"
+        httpHost.hostName shouldBeEqualTo "example.com"
+    }
+
+    @Test
+    fun `URI toHttpHost - HTTPS URL 파싱`() {
+        val uri = URI("https://example.com")
+        val httpHost = uri.toHttpHost()
+
+        httpHost.shouldNotBeNull()
+        httpHost.schemeName shouldBeEqualTo "https"
+        httpHost.hostName shouldBeEqualTo "example.com"
+    }
+
+    @Test
+    fun `URI toHttpHost - 포트 포함 URL 파싱`() {
+        val uri = URI("http://localhost:8080")
+        val httpHost = uri.toHttpHost()
+
+        httpHost.shouldNotBeNull()
+        httpHost.schemeName shouldBeEqualTo "http"
+        httpHost.hostName shouldBeEqualTo "localhost"
+        httpHost.port shouldBeEqualTo 8080
+    }
+
+    @Test
+    fun `URI toHttpHost - HTTPS 포트 포함 URL 파싱`() {
+        val uri = URI("https://api.example.com:443")
+        val httpHost = uri.toHttpHost()
+
+        httpHost.shouldNotBeNull()
+        httpHost.schemeName shouldBeEqualTo "https"
+        httpHost.hostName shouldBeEqualTo "api.example.com"
+        httpHost.port shouldBeEqualTo 443
+    }
+
+    @Test
+    fun `httpHostOf - HTTP URL 문자열 파싱`() {
+        val httpHost = httpHostOf("http://example.com")
+
+        httpHost.shouldNotBeNull()
+        httpHost.schemeName shouldBeEqualTo "http"
+        httpHost.hostName shouldBeEqualTo "example.com"
+    }
+
+    @Test
+    fun `httpHostOf - 포트 포함 URL 문자열 파싱`() {
+        val httpHost = httpHostOf("http://localhost:9090")
+
+        httpHost.shouldNotBeNull()
+        httpHost.schemeName shouldBeEqualTo "http"
+        httpHost.hostName shouldBeEqualTo "localhost"
+        httpHost.port shouldBeEqualTo 9090
+    }
+
+    @Test
+    fun `httpHostOf - HTTPS URL 문자열 파싱`() {
+        val httpHost = httpHostOf("https://secure.example.com:8443")
+
+        httpHost.shouldNotBeNull()
+        httpHost.schemeName shouldBeEqualTo "https"
+        httpHost.hostName shouldBeEqualTo "secure.example.com"
+        httpHost.port shouldBeEqualTo 8443
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/HttpRequestExtensionsTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/HttpRequestExtensionsTest.kt
@@ -1,0 +1,54 @@
+package io.bluetape4k.http.hc5.http
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+
+class HttpRequestExtensionsTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `extractPathPrefix - GET 요청에서 prefix 추출`() {
+        val request = classicRequest("GET") {
+            setUri("https://example.com/api/v1/users")
+        }
+
+        val prefix = request.extractPathPrefix()
+
+        prefix.shouldNotBeNull()
+    }
+
+    @Test
+    fun `extractPathPrefix - 루트 경로 요청에서 prefix 추출`() {
+        val request = classicRequest("GET") {
+            setUri("https://example.com/")
+        }
+
+        val prefix = request.extractPathPrefix()
+
+        prefix.shouldNotBeNull()
+    }
+
+    @Test
+    fun `extractPathPrefix - POST 요청에서 prefix 추출`() {
+        val request = classicRequest("POST") {
+            setUri("https://api.example.com/v2/data/submit")
+        }
+
+        val prefix = request.extractPathPrefix()
+
+        prefix.shouldNotBeNull()
+    }
+
+    @Test
+    fun `extractPathPrefix - 단순 경로 요청에서 prefix 추출`() {
+        val request = classicRequest("GET") {
+            setUri("http://localhost:8080/health")
+        }
+
+        val prefix = request.extractPathPrefix()
+
+        prefix.shouldNotBeNull()
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/OperationsTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/OperationsTest.kt
@@ -1,0 +1,60 @@
+package io.bluetape4k.http.hc5.http
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.core5.concurrent.Cancellable
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+
+class OperationsTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `CompletableFuture toCancellable - Cancellable 인스턴스 검증`() {
+        val future = CompletableFuture<String>()
+        val cancellable = future.toCancellable()
+
+        cancellable.shouldNotBeNull()
+        cancellable shouldBeInstanceOf Cancellable::class
+    }
+
+    @Test
+    fun `CompletableFuture toCancellable - cancel 호출 가능 검증`() {
+        val future = CompletableFuture<String>()
+        val cancellable = future.toCancellable()
+
+        cancellable.shouldNotBeNull()
+        // cancel() 호출 시 예외 없이 완료되어야 함
+        cancellable.cancel()
+    }
+
+    @Test
+    fun `이미 완료된 Future toCancellable - Cancellable 인스턴스 검증`() {
+        val future = CompletableFuture.completedFuture("result")
+        val cancellable = future.toCancellable()
+
+        cancellable.shouldNotBeNull()
+        cancellable shouldBeInstanceOf Cancellable::class
+    }
+
+    @Test
+    fun `이미 완료된 Future toCancellable - cancel 호출해도 예외 없음`() {
+        val future = CompletableFuture.completedFuture("done")
+        val cancellable = future.toCancellable()
+
+        cancellable.shouldNotBeNull()
+        // 이미 완료된 future에 cancel해도 예외가 발생하지 않아야 함
+        cancellable.cancel()
+    }
+
+    @Test
+    fun `Integer Future toCancellable - 타입 파라미터 무관하게 Cancellable 반환`() {
+        val future = CompletableFuture<Int>()
+        val cancellable = future.toCancellable()
+
+        cancellable.shouldNotBeNull()
+        cancellable shouldBeInstanceOf Cancellable::class
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/PoolingHttpClientConnectionManagerBuilderTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/PoolingHttpClientConnectionManagerBuilderTest.kt
@@ -1,0 +1,62 @@
+package io.bluetape4k.http.hc5.http
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager
+import org.apache.hc.core5.pool.PoolConcurrencyPolicy
+import org.apache.hc.core5.pool.PoolReusePolicy
+import org.apache.hc.core5.util.TimeValue
+import org.junit.jupiter.api.Test
+
+class PoolingHttpClientConnectionManagerBuilderTest {
+
+    companion object: KLogging()
+
+    @Test
+    fun `poolingHttpClientConnectionManager DSL 로 CM 생성`() {
+        val cm = poolingHttpClientConnectionManager {
+            setMaxConnPerRoute(5)
+            setMaxConnTotal(10)
+        }
+        cm.shouldNotBeNull()
+        cm.close()
+    }
+
+    @Test
+    fun `poolingHttpClientConnectionManagerOf 기본 생성`() {
+        val cm: PoolingHttpClientConnectionManager = poolingHttpClientConnectionManagerOf()
+        cm.shouldNotBeNull()
+        cm.close()
+    }
+
+    @Test
+    fun `poolingHttpClientConnectionManagerOf 파라미터 생성`() {
+        val cm = poolingHttpClientConnectionManagerOf(
+            poolConcurrencyPolicy = PoolConcurrencyPolicy.STRICT,
+            poolReusePolicy = PoolReusePolicy.LIFO,
+            timeToLive = TimeValue.NEG_ONE_MILLISECOND,
+        )
+        cm.shouldNotBeNull()
+        cm.close()
+    }
+
+    @Test
+    fun `poolingHttpClientConnectionManagerOf 확장 파라미터 생성`() {
+        val cm = poolingHttpClientConnectionManagerOf(
+            maxConnTotal = 100,
+            maxConnPerRoute = 10,
+        )
+        cm.shouldNotBeNull()
+        cm.close()
+    }
+
+    @Test
+    fun `poolingHttpClientConnectionManagerOf FIFO 정책 생성`() {
+        val cm = poolingHttpClientConnectionManagerOf(
+            poolConcurrencyPolicy = PoolConcurrencyPolicy.STRICT,
+            poolReusePolicy = PoolReusePolicy.FIFO,
+        )
+        cm.shouldNotBeNull()
+        cm.close()
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http2/H2ConfigTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http2/H2ConfigTest.kt
@@ -1,0 +1,94 @@
+package io.bluetape4k.http.hc5.http2
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.core5.http2.config.H2Config
+import org.junit.jupiter.api.Test
+
+class H2ConfigTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `h2ConfigOf returns default H2Config`() {
+        val config = h2ConfigOf()
+
+        config.shouldNotBeNull()
+        config shouldBeEqualTo H2Config.DEFAULT
+    }
+
+    @Test
+    fun `h2Config DSL creates config with custom settings`() {
+        val config = h2Config {
+            setPushEnabled(true)
+            setHeaderTableSize(4096)
+            setInitialWindowSize(65535)
+        }
+
+        config.shouldNotBeNull()
+        config.isPushEnabled.shouldBeTrue()
+        config.headerTableSize shouldBeEqualTo 4096
+        config.initialWindowSize shouldBeEqualTo 65535
+    }
+
+    @Test
+    fun `h2Config from source creates copy with modifications`() {
+        val source = h2Config {
+            setPushEnabled(false)
+            setHeaderTableSize(8192)
+        }
+
+        val modified = h2Config(source) {
+            setPushEnabled(true)
+        }
+
+        modified.shouldNotBeNull()
+        modified.isPushEnabled.shouldBeTrue()
+        modified.headerTableSize shouldBeEqualTo 8192
+    }
+
+    @Test
+    fun `h2Config with named parameters sets values correctly`() {
+        val config = h2Config(
+            pushEnabled = false,
+            headerTableSize = 2048,
+            initialWindowSize = 32768,
+            compressionEnabled = true,
+        )
+
+        config.shouldNotBeNull()
+        config.isPushEnabled.shouldBeFalse()
+        config.headerTableSize shouldBeEqualTo 2048
+        config.initialWindowSize shouldBeEqualTo 32768
+        config.isCompressionEnabled.shouldBeTrue()
+    }
+
+    @Test
+    fun `h2Config with named parameters uses defaults when not specified`() {
+        val config = h2Config()
+
+        config.shouldNotBeNull()
+        config.isPushEnabled shouldBeEqualTo H2Config.DEFAULT.isPushEnabled
+        config.headerTableSize shouldBeEqualTo H2Config.DEFAULT.headerTableSize
+        config.initialWindowSize shouldBeEqualTo H2Config.DEFAULT.initialWindowSize
+        config.isCompressionEnabled shouldBeEqualTo H2Config.DEFAULT.isCompressionEnabled
+    }
+
+    @Test
+    fun `h2Config with named parameters and additional DSL block`() {
+        val config = h2Config(
+            pushEnabled = true,
+            headerTableSize = 4096,
+        ) {
+            setCompressionEnabled(true)
+        }
+
+        config.shouldNotBeNull()
+        config.isPushEnabled.shouldBeTrue()
+        config.headerTableSize shouldBeEqualTo 4096
+        config.isCompressionEnabled.shouldBeTrue()
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/protocol/HttpClientContextTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/protocol/HttpClientContextTest.kt
@@ -1,0 +1,44 @@
+package io.bluetape4k.http.hc5.protocol
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.client5.http.protocol.HttpClientContext
+import org.apache.hc.core5.http.protocol.BasicHttpContext
+import org.junit.jupiter.api.Test
+
+class HttpClientContextTest {
+
+    companion object: KLogging()
+
+    @Test
+    fun `httpClientContextOf - 기본 생성`() {
+        val context = httpClientContextOf()
+        context.shouldNotBeNull()
+        context.shouldBeInstanceOf<HttpClientContext>()
+    }
+
+    @Test
+    fun `httpClientContextOf - 기존 컨텍스트 래핑`() {
+        val baseContext = BasicHttpContext()
+        val context = httpClientContextOf(baseContext)
+        context.shouldNotBeNull()
+        context.shouldBeInstanceOf<HttpClientContext>()
+    }
+
+    @Test
+    fun `adapt - BasicHttpContext 를 HttpClientContext 로 변환`() {
+        val baseContext = BasicHttpContext()
+        val clientContext = baseContext.adapt()
+        clientContext.shouldNotBeNull()
+        clientContext.shouldBeInstanceOf<HttpClientContext>()
+    }
+
+    @Test
+    fun `adapt - 이미 HttpClientContext 인 경우 그대로 반환`() {
+        val context = HttpClientContext.create()
+        val adapted = context.adapt()
+        adapted.shouldNotBeNull()
+        adapted.shouldBeInstanceOf<HttpClientContext>()
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/reactor/IOReactorConfigTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/reactor/IOReactorConfigTest.kt
@@ -1,0 +1,95 @@
+package io.bluetape4k.http.hc5.reactor
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.core5.reactor.IOReactorConfig
+import org.apache.hc.core5.util.TimeValue
+import org.apache.hc.core5.util.Timeout
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
+
+class IOReactorConfigTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `ioReactorConfig DSL creates config with custom io thread count`() {
+        val config = ioReactorConfig {
+            setIoThreadCount(4)
+        }
+
+        config.shouldNotBeNull()
+        config.ioThreadCount shouldBeEqualTo 4
+    }
+
+    @Test
+    fun `ioReactorConfig DSL creates config with soTimeout`() {
+        val timeout = Timeout.of(5000, TimeUnit.MILLISECONDS)
+        val config = ioReactorConfig {
+            setSoTimeout(timeout)
+        }
+
+        config.shouldNotBeNull()
+        config.soTimeout shouldBeEqualTo timeout
+    }
+
+    @Test
+    fun `ioReactorConfig DSL creates config with soKeepAlive`() {
+        val config = ioReactorConfig {
+            setSoKeepAlive(true)
+        }
+
+        config.shouldNotBeNull()
+        config.isSoKeepAlive.shouldBeTrue()
+    }
+
+    @Test
+    fun `ioReactorConfigOf with named parameters sets values correctly`() {
+        val ioThreadCount = 2
+        val soTimeout = Timeout.of(3000, TimeUnit.MILLISECONDS)
+        val soLinger = TimeValue.ofSeconds(30)
+        val soKeepAlive = true
+
+        val config = ioReactorConfigOf(
+            ioThreadCount = ioThreadCount,
+            soTimeout = soTimeout,
+            soLinger = soLinger,
+            soKeepAlive = soKeepAlive,
+        )
+
+        config.shouldNotBeNull()
+        config.ioThreadCount shouldBeEqualTo ioThreadCount
+        config.soTimeout shouldBeEqualTo soTimeout
+        config.soLinger shouldBeEqualTo soLinger
+        config.isSoKeepAlive.shouldBeTrue()
+    }
+
+    @Test
+    fun `ioReactorConfigOf uses defaults when not specified`() {
+        val config = ioReactorConfigOf()
+
+        config.shouldNotBeNull()
+        config.ioThreadCount shouldBeEqualTo IOReactorConfig.DEFAULT.ioThreadCount
+        config.soTimeout shouldBeEqualTo IOReactorConfig.DEFAULT.soTimeout
+        config.soLinger shouldBeEqualTo IOReactorConfig.DEFAULT.soLinger
+        config.isSoKeepAlive shouldBeEqualTo IOReactorConfig.DEFAULT.isSoKeepAlive
+    }
+
+    @Test
+    fun `ioReactorConfigOf with additional DSL builder block`() {
+        val config = ioReactorConfigOf(
+            ioThreadCount = 2,
+        ) {
+            setSoKeepAlive(false)
+            setTcpNoDelay(true)
+        }
+
+        config.shouldNotBeNull()
+        config.ioThreadCount shouldBeEqualTo 2
+        config.isSoKeepAlive.shouldBeFalse()
+        config.isTcpNoDelay.shouldBeTrue()
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/routing/RoutingSupportTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/routing/RoutingSupportTest.kt
@@ -1,0 +1,56 @@
+package io.bluetape4k.http.hc5.routing
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.client5.http.impl.DefaultSchemePortResolver
+import org.apache.hc.core5.http.HttpHost
+import org.apache.hc.core5.http.message.BasicHttpRequest
+import org.junit.jupiter.api.Test
+
+class RoutingSupportTest {
+
+    companion object: KLogging()
+
+    @Test
+    fun `determineHost - URI 포함 요청에서 호스트 결정`() {
+        val request = BasicHttpRequest("GET", "https://example.com/api/v1")
+        val host = request.determineHost()
+        host.shouldNotBeNull()
+        host.hostName shouldBeEqualTo "example.com"
+        host.schemeName shouldBeEqualTo "https"
+    }
+
+    @Test
+    fun `determineHost - HTTP URI 포함 요청에서 호스트 결정`() {
+        val request = BasicHttpRequest("GET", "http://api.example.com/data")
+        val host = request.determineHost()
+        host.shouldNotBeNull()
+        host.hostName shouldBeEqualTo "api.example.com"
+        host.schemeName shouldBeEqualTo "http"
+    }
+
+    @Test
+    fun `normalize - http 기본 포트 정규화`() {
+        val host = HttpHost("http", "example.com", 80)
+        val normalized = host.normalize()
+        normalized.shouldNotBeNull()
+        normalized.schemeName shouldBeEqualTo "http"
+    }
+
+    @Test
+    fun `normalize - https 기본 포트 정규화`() {
+        val host = HttpHost("https", "example.com", 443)
+        val normalized = host.normalize()
+        normalized.shouldNotBeNull()
+        normalized.schemeName shouldBeEqualTo "https"
+    }
+
+    @Test
+    fun `normalize - 커스텀 SchemePortResolver 사용`() {
+        val host = HttpHost("https", "example.com", 8443)
+        val normalized = host.normalize(DefaultSchemePortResolver.INSTANCE)
+        normalized.shouldNotBeNull()
+        normalized.hostName shouldBeEqualTo "example.com"
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/ssl/SslSupportTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/ssl/SslSupportTest.kt
@@ -1,0 +1,104 @@
+package io.bluetape4k.http.hc5.ssl
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.hc.core5.reactor.ssl.SSLBufferMode
+import org.junit.jupiter.api.Test
+
+class SslSupportTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `sslContextOf creates default SSLContext`() {
+        val sslContext = sslContextOf()
+
+        sslContext.shouldNotBeNull()
+        sslContext.protocol.shouldNotBeNull()
+    }
+
+    @Test
+    fun `sslContextOfSystem creates system default SSLContext`() {
+        val sslContext = sslContextOfSystem()
+
+        sslContext.shouldNotBeNull()
+        sslContext.protocol.shouldNotBeNull()
+    }
+
+    @Test
+    fun `sslContext DSL creates custom SSLContext`() {
+        val sslContext = sslContext {
+            // basic custom build without loading key/trust material
+        }
+
+        sslContext.shouldNotBeNull()
+    }
+
+    @Test
+    fun `sslContextOf and sslContextOfSystem return non-null SSLContext`() {
+        val defaultCtx = sslContextOf()
+        val systemCtx = sslContextOfSystem()
+
+        defaultCtx.shouldNotBeNull()
+        systemCtx.shouldNotBeNull()
+    }
+
+    @Test
+    fun `defaultHostnameVerifier is non-null`() {
+        defaultHostnameVerifier.shouldNotBeNull()
+    }
+
+    @Test
+    fun `tlsStrategy DSL creates TlsStrategy`() {
+        val strategy = tlsStrategy {
+            setSslContext(sslContextOf())
+            setSslBufferMode(SSLBufferMode.STATIC)
+            setHostnameVerifier(defaultHostnameVerifier)
+        }
+
+        strategy.shouldNotBeNull()
+    }
+
+    @Test
+    fun `tlsStrategyOf with defaults creates TlsStrategy`() {
+        val strategy = tlsStrategyOf()
+
+        strategy.shouldNotBeNull()
+    }
+
+    @Test
+    fun `tlsStrategyOf with sslContext creates TlsStrategy`() {
+        val sslContext = sslContextOf()
+        val strategy = tlsStrategyOf(sslContext = sslContext)
+
+        strategy.shouldNotBeNull()
+    }
+
+    @Test
+    fun `tlsStrategyOf with sslBufferMode STATIC creates TlsStrategy`() {
+        val strategy = tlsStrategyOf(
+            sslContext = sslContextOf(),
+            sslBufferMode = SSLBufferMode.STATIC,
+        )
+
+        strategy.shouldNotBeNull()
+    }
+
+    @Test
+    fun `tlsStrategyOf with hostnameVerifier creates TlsStrategy`() {
+        val strategy = tlsStrategyOf(
+            sslContext = sslContextOf(),
+            hostnameVerifier = defaultHostnameVerifier,
+        )
+
+        strategy.shouldNotBeNull()
+    }
+
+    @Test
+    fun `sslContextOf protocol contains TLS`() {
+        val sslContext = sslContextOf()
+
+        sslContext.protocol shouldContain "TLS"
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/jdk/JdkHttpClientCoroutinesTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/jdk/JdkHttpClientCoroutinesTest.kt
@@ -1,0 +1,71 @@
+package io.bluetape4k.http.jdk
+
+import io.bluetape4k.http.AbstractHttpTest
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeEmpty
+import org.junit.jupiter.api.Test
+import java.net.URI
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import kotlin.time.Duration.Companion.seconds
+
+class JdkHttpClientCoroutinesTest: AbstractHttpTest() {
+
+    companion object: KLogging()
+
+    private val urisToGet: List<String>
+        get() = listOf(
+            "$httpbinBaseUrl/get",
+            "$httpbinBaseUrl/ip",
+            "$httpbinBaseUrl/headers"
+        )
+
+    @Test
+    fun `getAwait 로 GET 요청 상태코드 200`() = runTest(timeout = 30.seconds) {
+        val client = jdkHttpClientOf()
+        val response = client.getAwait("$httpbinBaseUrl/get")
+        log.debug { "GET $httpbinBaseUrl/get status=${response.statusCode()}" }
+        response.statusCode() shouldBeEqualTo 200
+    }
+
+    @Test
+    fun `getStringAwait 로 GET 요청 상태코드 200 및 body 비어있지 않음`() = runTest(timeout = 30.seconds) {
+        val client = jdkHttpClientOf()
+        val response = client.getStringAwait("$httpbinBaseUrl/get")
+        log.debug { "GET $httpbinBaseUrl/get status=${response.statusCode()}" }
+        response.statusCode() shouldBeEqualTo 200
+        response.body().shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `sendAwait 로 커스텀 요청 상태코드 200`() = runTest(timeout = 30.seconds) {
+        val client = jdkHttpClientOf()
+        val request = HttpRequest.newBuilder(URI.create("$httpbinBaseUrl/get")).GET().build()
+        val response = client.sendAwait(request, HttpResponse.BodyHandlers.ofByteArray())
+        log.debug { "GET $httpbinBaseUrl/get status=${response.statusCode()}" }
+        response.statusCode() shouldBeEqualTo 200
+    }
+
+    @Test
+    fun `여러 URL 병렬 coroutine GET 요청 모두 200`() = runTest(timeout = 30.seconds) {
+        val client = jdkHttpClientOf()
+        val responses = coroutineScope {
+            urisToGet.map { uri ->
+                async {
+                    val response = client.getAwait(uri)
+                    log.debug { "GET $uri status=${response.statusCode()}" }
+                    response
+                }
+            }.awaitAll()
+        }
+        responses.forEach { response ->
+            response.statusCode() shouldBeEqualTo 200
+        }
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/jdk/JdkHttpClientSupportTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/jdk/JdkHttpClientSupportTest.kt
@@ -1,0 +1,49 @@
+package io.bluetape4k.http.jdk
+
+import io.bluetape4k.http.AbstractHttpTest
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import java.net.URI
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+class JdkHttpClientSupportTest: AbstractHttpTest() {
+
+    companion object: KLogging()
+
+    @Test
+    fun `jdkHttpClientOf 기본 생성`() {
+        val client = jdkHttpClientOf()
+        client.shouldNotBeNull()
+    }
+
+    @Test
+    fun `jdkVirtualThreadHttpClientOf 생성`() {
+        val client = jdkVirtualThreadHttpClientOf()
+        client.shouldNotBeNull()
+    }
+
+    @Test
+    fun `JdkHttpClients default 싱글톤 생성`() {
+        val client = JdkHttpClients.default
+        client.shouldNotBeNull()
+    }
+
+    @Test
+    fun `JdkHttpClients virtualThread 싱글톤 생성`() {
+        val client = JdkHttpClients.virtualThread
+        client.shouldNotBeNull()
+    }
+
+    @Test
+    fun `jdkHttpClientOf 로 GET 요청 상태코드 200`() {
+        val client = jdkHttpClientOf()
+        val request = HttpRequest.newBuilder(URI.create("$httpbinBaseUrl/get")).GET().build()
+        val response = client.send(request, HttpResponse.BodyHandlers.ofByteArray())
+        log.debug { "GET $httpbinBaseUrl/get status=${response.statusCode()}" }
+        response.statusCode() shouldBeEqualTo 200
+    }
+}

--- a/org/apache/hc/client5/http/auth/AuthScope.java
+++ b/org/apache/hc/client5/http/auth/AuthScope.java
@@ -1,0 +1,272 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.auth;
+
+import java.util.Locale;
+import java.util.Objects;
+
+import org.apache.hc.core5.annotation.Contract;
+import org.apache.hc.core5.annotation.ThreadingBehavior;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.LangUtils;
+
+/**
+ * {@code AuthScope} represents an authentication scope consisting of
+ * an application protocol, a host name, a port number, a realm name
+ * and an authentication scheme name.
+ *
+ * @since 4.0
+ */
+@Contract(threading = ThreadingBehavior.IMMUTABLE)
+public class AuthScope {
+
+    private final String protocol;
+    private final String host;
+    private final int port;
+    private final String realm;
+    private final String schemeName;
+
+    /**
+     * Defines auth scope with the given {@code protocol}, {@code host}, {@code port},
+     * {@code realm}, and {@code schemeName}.
+     *
+     * @param protocol application protocol. May be {@code null} if applies
+     *   to any protocol.
+     * @param host authentication host. May be {@code null} if applies
+     *   to any host.
+     * @param port authentication port. May be {@code -1} if applies
+     *   to any port of the host.
+     * @param realm authentication realm. May be {@code null} if applies
+     *   to any realm on the host.
+     * @param schemeName authentication scheme name. May be {@code null} if applies
+     *   to any auth scheme supported by the host.
+     */
+    public AuthScope(
+            final String protocol,
+            final String host,
+            final int port,
+            final String realm,
+            final String schemeName) {
+        this.protocol = protocol != null ? protocol.toLowerCase(Locale.ROOT) : null;
+        this.host = host != null ? host.toLowerCase(Locale.ROOT) : null;
+        this.port = port >= 0 ? port : -1;
+        this.realm = realm;
+        this.schemeName = schemeName != null ? schemeName.toUpperCase(Locale.ROOT) : null;
+    }
+
+    /**
+     * Defines auth scope for a specific host of origin.
+     *
+     * @param origin host of origin
+     * @param realm authentication realm. May be {@code null} if applies
+     *   to any realm on the host.
+     * @param schemeName authentication scheme name. May be {@code null} if applies
+     *   to any auth scheme supported by the host.
+     *
+     * @since 4.2
+     */
+    public AuthScope(
+            final HttpHost origin,
+            final String realm,
+            final String schemeName) {
+        Args.notNull(origin, "Host");
+        this.protocol = origin.getSchemeName().toLowerCase(Locale.ROOT);
+        this.host = origin.getHostName().toLowerCase(Locale.ROOT);
+        this.port = origin.getPort() >= 0 ? origin.getPort() : -1;
+        this.realm = realm;
+        this.schemeName = schemeName != null ? schemeName.toUpperCase(Locale.ROOT) : null;
+    }
+
+    /**
+     * Defines auth scope for a specific host of origin.
+     *
+     * @param origin host of origin
+     *
+     * @since 4.2
+     */
+    public AuthScope(final HttpHost origin) {
+        this(origin, null, null);
+    }
+
+    /**
+     * Defines auth scope with the given {@code host} and {@code port}.
+     *
+     * @param host authentication host. May be {@code null} if applies
+     *   to any host.
+     * @param port authentication port. May be {@code -1} if applies
+     *   to any port of the host.
+     */
+    public AuthScope(final String host, final int port) {
+        this(null, host, port, null, null);
+    }
+
+    /**
+     * Creates a copy of the given credentials scope.
+     */
+    public AuthScope(final AuthScope authScope) {
+        super();
+        Args.notNull(authScope, "Scope");
+        this.protocol = authScope.getProtocol();
+        this.host = authScope.getHost();
+        this.port = authScope.getPort();
+        this.realm = authScope.getRealm();
+        this.schemeName = authScope.getSchemeName();
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public String getHost() {
+        return this.host;
+    }
+
+    public int getPort() {
+        return this.port;
+    }
+
+    public String getRealm() {
+        return this.realm;
+    }
+
+    public String getSchemeName() {
+        return this.schemeName;
+    }
+
+    /**
+     * Tests if the authentication scopes match.
+     *
+     * @return the match factor. Negative value signifies no match.
+     *    Non-negative signifies a match. The greater the returned value
+     *    the closer the match.
+     */
+    public int match(final AuthScope that) {
+        int factor = 0;
+        if (Objects.equals(this.schemeName, that.schemeName)) {
+            factor += 1;
+        } else {
+            if (this.schemeName != null && that.schemeName != null) {
+                return -1;
+            }
+        }
+        if (Objects.equals(this.realm, that.realm)) {
+            factor += 2;
+        } else {
+            if (this.realm != null && that.realm != null) {
+                return -1;
+            }
+        }
+        if (this.port == that.port) {
+            factor += 4;
+        } else {
+            if (this.port != -1 && that.port != -1) {
+                return -1;
+            }
+        }
+        if (Objects.equals(this.protocol, that.protocol)) {
+            factor += 8;
+        } else {
+            if (this.protocol != null && that.protocol != null) {
+                return -1;
+            }
+        }
+        if (Objects.equals(this.host, that.host)) {
+            factor += 16;
+        } else {
+            if (this.host != null && that.host != null) {
+                return -1;
+            }
+        }
+        return factor;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof AuthScope) {
+            final AuthScope that = (AuthScope) obj;
+            return Objects.equals(this.protocol, that.protocol)
+                    && Objects.equals(this.host, that.host)
+                    && this.port == that.port
+                    && Objects.equals(this.realm, that.realm)
+                    && Objects.equals(this.schemeName, that.schemeName);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = LangUtils.HASH_SEED;
+        hash = LangUtils.hashCode(hash, this.protocol);
+        hash = LangUtils.hashCode(hash, this.host);
+        hash = LangUtils.hashCode(hash, this.port);
+        hash = LangUtils.hashCode(hash, this.realm);
+        hash = LangUtils.hashCode(hash, this.schemeName);
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder buffer = new StringBuilder();
+        if (this.schemeName != null) {
+            buffer.append(this.schemeName);
+        } else {
+            buffer.append("<any auth scheme>");
+        }
+        buffer.append(' ');
+        if (this.realm != null) {
+            buffer.append('\'');
+            buffer.append(this.realm);
+            buffer.append('\'');
+        } else {
+            buffer.append("<any realm>");
+        }
+        buffer.append(' ');
+        if (this.protocol != null) {
+            buffer.append(this.protocol);
+        } else {
+            buffer.append("<any protocol>");
+        }
+        buffer.append("://");
+        if (this.host != null) {
+            buffer.append(this.host);
+        } else {
+            buffer.append("<any host>");
+        }
+        buffer.append(':');
+        if (this.port >= 0) {
+            buffer.append(this.port);
+        } else {
+            buffer.append("<any port>");
+        }
+        return buffer.toString();
+    }
+
+}


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: test: io/http 테스트 커버리지 32% → 72% 향상 (#178)

GitHub Issue #178 대응 — `io/http` 모듈 테스트 라인 커버리지를 32.40% → **72.03%** 로 향상

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 신규 테스트 파일 (T1~T22 + 추가)

| 파일 | 검증 대상 |
|------|-----------|
| `hc5/async/AsyncHttpClientTest` | `httpAsyncClientOf`, `h2AsyncClientOf` (공유 CM 버그 수정) |
| `hc5/async/AsyncHttpClientCoroutinesTest` | `executeSuspending`, 병렬 coroutine GET (공유 CM 버그 수정) |
| `hc5/async/MinimalHttpAsyncClientTest` | `minimalHttpAsyncClientOf`, `leaseSuspending` |
| `hc5/async/methods/SimpleHttpRequestTest` | `simpleHttpRequest`, `simpleHttpRequestOf`, `toProducer` |
| `hc5/async/methods/SimpleHttpResponseTest` | `simpleHttpResponse`, `simpleHttpResponseOf` |
| `hc5/async/methods/AsyncMethodsTest` | `simpleRequestProducerOf`, `simpleResponseConsumerOf`, `configurableHttpRequestOf` |
| `hc5/cache/CachingHttpClientBuilderTest` | `cachingHttpClient`, `memoryCachingHttpClientOf`, `fileCachingHttpClientOf` |
| `hc5/cache/CachingHttpAsyncClientBuilderTest` | `cachingHttpAsyncClient`, `memoryCachingHttpAsyncClientOf`, `fileCachingHttpAsyncClientOf` |
| `hc5/classic/MinimalAndVirtualThreadHttpClientTest` | `minimalHttpClientOf`, `virtualThreadHttpClientOf` |
| `hc5/fluent/RequestTest` | `requestOf`, `requestGet/Post/Put/Patch/Delete/Head/Trace/Options` |
| `hc5/http/ContextBuilderTest` | `httpClientContext`, `contextBuilderOf` |
| `hc5/http/CookieSpecSupportTest` | `defaultRegistryOf` |
| `hc5/http/PoolingHttpClientConnectionManagerBuilderTest` | `poolingHttpClientConnectionManager`, `poolingHttpClientConnectionManagerOf` |
| `hc5/http/BasicRequestProducerTest` | `basicRequestProducerOf`, `BasicHttpRequest.toProducer` |
| `hc5/protocol/HttpClientContextTest` | `adapt`, `httpClientContextOf` |
| `hc5/routing/RoutingSupportTest` | `determineHost`, `normalize` |

### 버그 수정

- `AsyncHttpClientTest`, `AsyncHttpClientCoroutinesTest`: `httpAsyncClientOf()` → `httpAsyncClient {}`로 교체
  - 공유 `defaultAsyncClientConnectionManager` 사용 시 첫 번째 test의 `.use {}` 실행 후 CM이 shut down되어 이후 테스트 실패
  - 각 test에서 독립 CM을 갖는 `httpAsyncClient {}` 사용으로 수정
- `AsyncHttpClientTest`: `execute(request, null)` → `execute(request.toProducer(), SimpleResponseConsumer.create(), HttpClientContext.create(), null)` 올바른 메서드 시그니처로 수정

### 기존 섹션: 검증 명령

```bash
./gradlew :bluetape4k-http:test --continue
./gradlew :bluetape4k-http:koverLog
```

## Validation

```
./gradlew :bluetape4k-http:test --continue
394 tests completed, 3 failed (pre-existing H2/reactive examples), 3 skipped
```

커버리지:
```
./gradlew :bluetape4k-http:koverLog
application line coverage: 72.0314%
```

3개 실패는 외부 HTTP/2 서버 필요한 기존 예제 테스트 (변경 전부터 실패):
- `AsyncClientH2Multiplexing`
- `AsyncClientH2ServerPush`
- `ReactiveClientFullDuplexExchange`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #178, milestone `없음`, assignee debop
- PR: #186, head `6bfefa5edf35d8d014c87b23b2de641316d0029f`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `test/http-coverage`
- Labels: `test`
- State: `MERGED`, merge commit `8e2c8e9adc07cf5f1f5ab3d2c19511d507c156c7`
- CI: ./gradlew :bluetape4k-http:test --continue / ./gradlew :bluetape4k-http:koverLog
## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #186 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `8e2c8e9adc07cf5f1f5ab3d2c19511d507c156c7`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
