### PR TITLE
fix: MatrixSupport 직렬화 버그 수정 - defaultWriteObject/defaultReadObject 컨텍스트 오용 (#187)

### DIFF
--- a/utils/math/src/main/kotlin/io/bluetape4k/math/linear/MatrixSupport.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/linear/MatrixSupport.kt
@@ -184,44 +184,77 @@ fun FieldMatrix<BigFraction>.toRealMatrix(): Array2DRowRealMatrix =
     MatrixUtils.bigFractionMatrixToRealMatrix(this)
 
 
+/**
+ * [RealVector]를 바이트 배열로 직렬화합니다.
+ *
+ * ```kotlin
+ * val v = realVectorOf(doubleArrayOf(1.0, 2.0, 3.0))
+ * val bytes = v.toByteArray()
+ * val restored = bytes.toRealVector()
+ * ```
+ */
 fun RealVector.toByteArray(): ByteArray {
     return ByteArrayOutputStream().use { bos ->
         ObjectOutputStream(bos).use { oos ->
-            oos.defaultWriteObject()
             MatrixUtils.serializeRealVector(this, oos)
             oos.flush()
-            bos.toByteArray()
         }
+        bos.toByteArray()
     }
 }
 
-fun ByteArray.toRealVector(fieldName: String): RealVector {
+/**
+ * 바이트 배열을 [RealVector]로 역직렬화합니다.
+ *
+ * ```kotlin
+ * val v = realVectorOf(doubleArrayOf(1.0, 2.0, 3.0))
+ * val restored = v.toByteArray().toRealVector()
+ * ```
+ */
+fun ByteArray.toRealVector(): RealVector {
     return ByteArrayInputStream(this).use { bis ->
         ObjectInputStream(bis).use { ois ->
-            ois.defaultReadObject()
-            MatrixUtils.deserializeRealVector(this, fieldName, ois)
-            ois.readObject() as RealVector
+            val n = ois.readInt()
+            val data = DoubleArray(n) { ois.readDouble() }
+            MatrixUtils.createRealVector(data)
         }
     }
 }
 
+/**
+ * [RealMatrix]를 바이트 배열로 직렬화합니다.
+ *
+ * ```kotlin
+ * val m = realMatrixOf(2, 2)
+ * val bytes = m.toByteArray()
+ * val restored = bytes.toRealMatrix()
+ * ```
+ */
 fun RealMatrix.toByteArray(): ByteArray {
     return ByteArrayOutputStream().use { bos ->
         ObjectOutputStream(bos).use { oos ->
-            oos.defaultWriteObject()
             MatrixUtils.serializeRealMatrix(this, oos)
             oos.flush()
-            bos.toByteArray()
         }
+        bos.toByteArray()
     }
 }
 
-fun ByteArray.toRealMatrix(fieldName: String): RealMatrix {
+/**
+ * 바이트 배열을 [RealMatrix]로 역직렬화합니다.
+ *
+ * ```kotlin
+ * val m = realMatrixOf(2, 2)
+ * val restored = m.toByteArray().toRealMatrix()
+ * ```
+ */
+fun ByteArray.toRealMatrix(): RealMatrix {
     return ByteArrayInputStream(this).use { bis ->
         ObjectInputStream(bis).use { ois ->
-            ois.defaultReadObject()
-            MatrixUtils.deserializeRealMatrix(this, fieldName, ois)
-            ois.readObject() as RealMatrix
+            val n = ois.readInt()
+            val m = ois.readInt()
+            val data = Array(n) { DoubleArray(m) { ois.readDouble() } }
+            MatrixUtils.createRealMatrix(data)
         }
     }
 }

--- a/utils/math/src/main/kotlin/io/bluetape4k/math/linear/MatrixSupport.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/linear/MatrixSupport.kt
@@ -187,6 +187,10 @@ fun FieldMatrix<BigFraction>.toRealMatrix(): Array2DRowRealMatrix =
 /**
  * [RealVector]를 바이트 배열로 직렬화합니다.
  *
+ * 포맷: ObjectStream 헤더(4 bytes) + writeInt(n) + n × writeDouble
+ * [MatrixUtils.serializeRealVector]가 [ObjectOutputStream]을 필수로 요구하므로 ObjectStream 래퍼를 유지합니다.
+ * [toRealVector]와 쌍으로만 사용하세요.
+ *
  * ```kotlin
  * val v = realVectorOf(doubleArrayOf(1.0, 2.0, 3.0))
  * val bytes = v.toByteArray()
@@ -205,6 +209,7 @@ fun RealVector.toByteArray(): ByteArray {
 
 /**
  * 바이트 배열을 [RealVector]로 역직렬화합니다.
+ * [toByteArray]로 직렬화된 바이트 배열만 지원합니다.
  *
  * ```kotlin
  * val v = realVectorOf(doubleArrayOf(1.0, 2.0, 3.0))
@@ -215,6 +220,7 @@ fun ByteArray.toRealVector(): RealVector {
     return ByteArrayInputStream(this).use { bis ->
         ObjectInputStream(bis).use { ois ->
             val n = ois.readInt()
+            require(n >= 0) { "올바르지 않은 벡터 차원: $n" }
             val data = DoubleArray(n) { ois.readDouble() }
             MatrixUtils.createRealVector(data)
         }
@@ -223,6 +229,10 @@ fun ByteArray.toRealVector(): RealVector {
 
 /**
  * [RealMatrix]를 바이트 배열로 직렬화합니다.
+ *
+ * 포맷: ObjectStream 헤더(4 bytes) + writeInt(rows) + writeInt(cols) + rows×cols × writeDouble
+ * [MatrixUtils.serializeRealMatrix]가 [ObjectOutputStream]을 필수로 요구하므로 ObjectStream 래퍼를 유지합니다.
+ * [toRealMatrix]와 쌍으로만 사용하세요.
  *
  * ```kotlin
  * val m = realMatrixOf(2, 2)
@@ -242,6 +252,7 @@ fun RealMatrix.toByteArray(): ByteArray {
 
 /**
  * 바이트 배열을 [RealMatrix]로 역직렬화합니다.
+ * [toByteArray]로 직렬화된 바이트 배열만 지원합니다.
  *
  * ```kotlin
  * val m = realMatrixOf(2, 2)
@@ -253,6 +264,7 @@ fun ByteArray.toRealMatrix(): RealMatrix {
         ObjectInputStream(bis).use { ois ->
             val n = ois.readInt()
             val m = ois.readInt()
+            require(n >= 0 && m >= 0) { "올바르지 않은 행렬 차원: ${n}x${m}" }
             val data = Array(n) { DoubleArray(m) { ois.readDouble() } }
             MatrixUtils.createRealMatrix(data)
         }

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/linear/MatrixSupportTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/linear/MatrixSupportTest.kt
@@ -286,4 +286,14 @@ class MatrixSupportTest {
         val restored = bytes.toRealVector()
         restored.dimension.shouldBeEqualTo(0)
     }
+
+    @Test
+    fun `1x1 RealMatrix를 직렬화 후 복원할 수 있다`() {
+        val original = Array2DRowRealMatrix(arrayOf(doubleArrayOf(42.0)))
+        val bytes = original.toByteArray()
+        val restored = bytes.toRealMatrix()
+        restored.rowDimension.shouldBeEqualTo(1)
+        restored.columnDimension.shouldBeEqualTo(1)
+        restored.getEntry(0, 0).shouldBeNear(42.0, 1e-10)
+    }
 }

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/linear/MatrixSupportTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/linear/MatrixSupportTest.kt
@@ -245,4 +245,45 @@ class MatrixSupportTest {
         rm.getEntry(0, 0).shouldBeNear(5.0, 1e-10)
         rm.getEntry(1, 1).shouldBeNear(6.0, 1e-10)
     }
+
+    @Test
+    fun `RealVector를 바이트 배열로 직렬화 후 복원할 수 있다`() {
+        val original = realVectorOf(doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0))
+        val bytes = original.toByteArray()
+        val restored = bytes.toRealVector()
+
+        restored.dimension.shouldBeEqualTo(original.dimension)
+        for (i in 0 until original.dimension) {
+            restored.getEntry(i).shouldBeNear(original.getEntry(i), 1e-10)
+        }
+    }
+
+    @Test
+    fun `RealMatrix를 바이트 배열로 직렬화 후 복원할 수 있다`() {
+        val original = Array2DRowRealMatrix(
+            arrayOf(
+                doubleArrayOf(1.0, 2.0, 3.0),
+                doubleArrayOf(4.0, 5.0, 6.0),
+                doubleArrayOf(7.0, 8.0, 9.0)
+            )
+        )
+        val bytes = original.toByteArray()
+        val restored = bytes.toRealMatrix()
+
+        restored.rowDimension.shouldBeEqualTo(original.rowDimension)
+        restored.columnDimension.shouldBeEqualTo(original.columnDimension)
+        for (i in 0 until original.rowDimension) {
+            for (j in 0 until original.columnDimension) {
+                restored.getEntry(i, j).shouldBeNear(original.getEntry(i, j), 1e-10)
+            }
+        }
+    }
+
+    @Test
+    fun `빈 RealVector도 직렬화 후 복원할 수 있다`() {
+        val original = realVectorOf(DoubleArray(0))
+        val bytes = original.toByteArray()
+        val restored = bytes.toRealVector()
+        restored.dimension.shouldBeEqualTo(0)
+    }
 }


### PR DESCRIPTION
## Summary

Closes #187

- PR 제목: fix: MatrixSupport 직렬화 버그 수정 - defaultWriteObject/defaultReadObject 컨텍스트 오용 (#187)

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: DoD 완료 보고 — MatrixSupport 직렬화 버그 수정

### 관련 이슈

Closes #187 — MatrixSupport.kt 직렬화 함수 구현 버그 - defaultWriteObject/defaultReadObject 컨텍스트 오용

> `utils/math` 모듈의 4개 직렬화 함수가 `ObjectOutputStream.defaultWriteObject()`를 잘못된 컨텍스트에서 호출하여
> 런타임에 `java.io.NotActiveException`을 던지는 버그를 수정합니다.

### 작업 내역

- **`RealVector.toByteArray()`**: `oos.defaultWriteObject()` 제거, `MatrixUtils.serializeRealVector(this, oos)` 직접 사용
- **`ByteArray.toRealVector()`**: `ois.defaultReadObject()` 제거, `ObjectInputStream`으로 직접 `readInt()/readDouble()` 읽기. `fieldName` 파라미터 제거 (callers 없음 확인)
- **`RealMatrix.toByteArray()`**: `oos.defaultWriteObject()` 제거, `MatrixUtils.serializeRealMatrix(this, oos)` 직접 사용
- **`ByteArray.toRealMatrix()`**: `ois.defaultReadObject()` 제거, `ObjectInputStream`으로 직접 `readInt()/readDouble()` 읽기. `fieldName` 파라미터 제거
- **차원 검증**: `readInt()` 후 `require(n >= 0)` 추가 (음수 차원 방어)
- **KDoc**: 포맷 명세(ObjectStream 헤더 포함 이유), 사용 예제 추가
- **round-trip 테스트 4건 추가**: RealVector, RealMatrix (3×3), 빈 벡터(0차원), 1×1 행렬

### DoD 체크리스트 (CLAUDE.md Before Creating a PR)

| 항목 | 상태 |
|------|------|
| 로컬 테스트 전수 통과 | ✅ 570 passing, 1 pending, 0 failed (3.3s) |
| oh-my-claudecode:code-reviewer 실행 | ✅ HIGH 0건, MEDIUM 조치 완료 |
| README.md / README.ko.md 업데이트 | ⏭️ N/A — 버그 픽스 (공개 API 시그니처 변경은 기존 callers 없음) |
| KDoc 추가/수정 | ✅ 4개 함수 모두 KDoc 추가 |
| worktree 작업 | ✅ `.worktrees/fix-matrix-serialization` |

### 테스트 결과

Module : :bluetape4k-math
Tests  : 570 passing, 0 failed, 1 pending
Time   : 3.3s
Date   : 2026-04-27

### Commits (2개)

```
f69e33bfd fix: 코드 리뷰 반영 - KDoc 포맷 명시, 차원 검증, 빈 행렬 테스트 추가
4dece1fcd fix: MatrixSupport 직렬화 버그 수정 - defaultWriteObject/defaultReadObject 제거 (#187)
```

**최종 상태: DONE** — PR 머지 대기 중.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #187, milestone 없음, assignee `debop`
- PR: #192, head `f69e33bfd421038304cf9682613969426fc24960`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/matrix-serialization-bug`
- Labels: `bug`
- State: `MERGED`, merge commit `ec45cc60488e50fbf9d194127022d313ba95d9a5`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #192 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `ec45cc60488e50fbf9d194127022d313ba95d9a5`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
