### PR TITLE
feat: utils/images — 이미지 분석 기능 추가 (Issue #133)

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -207,6 +207,7 @@ object Versions {
     const val sentry_logback = "8.33.0"  // https://mvnrepository.com/artifact/io.sentry/sentry-logback
 
     const val scrimage = "4.3.10"  // https://mvnrepository.com/artifact/com.sksamuel.scrimage/scrimage-core
+    const val metadata_extractor = "2.19.0"  // https://mvnrepository.com/artifact/com.drewnoakes/metadata-extractor
 
     // Gatling
     const val gatling = "3.15.0" // https://mvnrepository.com/artifact/io.gatling/gatling-core
@@ -1509,6 +1510,9 @@ object Libs {
     val scrimage_core = scrimage("core")
     val scrimage_filters = scrimage("filters")
     val scrimage_webp = scrimage("webp")
+
+    // https://mvnrepository.com/artifact/com.drewnoakes/metadata-extractor
+    val metadata_extractor = "com.drewnoakes:metadata-extractor:${Versions.metadata_extractor}"
 
     // NLP / Language Detection
     const val lingua = "com.github.pemistahl:lingua:${Versions.lingua}"  // https://mvnrepository.com/artifact/com.github.pemistahl/lingua

--- a/docs/superpowers/plans/2026-04-27-images-analysis-plan.md
+++ b/docs/superpowers/plans/2026-04-27-images-analysis-plan.md
@@ -1,0 +1,510 @@
+# Implementation Plan: utils/images Image Analysis (#133)
+
+**Date**: 2026-04-27
+**Spec**: docs/superpowers/specs/2026-04-27-images-analysis-design.md
+**Issue**: #133
+**Branch**: `feat/issue-133-images-analysis`
+**Worktree**: `.worktrees/feat/issue-133-images-analysis`
+**Module**: `utils/images` (`bluetape4k-images`)
+
+## Overview
+
+`utils/images` 모듈에 3종의 순수 JVM 기반 이미지 분석 기능을 추가한다.
+
+1. **Dominant Color Extraction** — Median Cut quantization 자체 구현 (5-bit color cube).
+2. **Blur Detection** — Laplacian variance grayscale convolution.
+3. **EXIF Metadata Extraction** — drewnoakes `metadata-extractor 2.19.0` 활용.
+
+설계 원칙: pure JVM (native dep 금지), 기존 `HistogramSimilarity` sealed interface 패턴 재사용, extension function API, suspend 변형은 CPU-bound → `Dispatchers.Default` / 파일 I/O는 `Dispatchers.IO`.
+
+OCR / Face Detection / 분류는 본 PR scope 외 — follow-up issue 등록.
+
+## Source Tree (생성/변경 파일)
+
+```
+buildSrc/src/main/kotlin/Libs.kt                                              # 변경 (T01)
+utils/images/build.gradle.kts                                                 # 변경 (T02)
+
+utils/images/src/main/kotlin/io/bluetape4k/images/analysis/
+├── DominantColor.kt                                                          # 신규 (T03 + T06)
+├── DominantColorExtractor.kt                                                 # 신규 (T05)
+├── MedianCutQuantizer.kt                                                     # 신규 (T04)
+├── BlurDetector.kt                                                           # 신규 (T07 + T08 + T09)
+└── ExifData.kt                                                               # 신규 (T10 + T11)
+
+utils/images/src/test/kotlin/io/bluetape4k/images/analysis/
+├── DominantColorExtractorTest.kt                                             # 신규 (T12)
+├── BlurDetectorTest.kt                                                       # 신규 (T13)
+├── ExifDataTest.kt                                                           # 신규 (T15)
+└── SuspendAnalysisTest.kt                                                    # 신규 (T16)
+
+utils/images/src/test/resources/images/exif/
+├── with-gps.jpg                                                              # 신규 fixture (T14)
+├── no-exif.jpg                                                               # 신규 fixture (T14)
+├── full-exif.jpg                                                             # 신규 fixture (T14)
+└── README.md                                                                 # 신규 license/origin 문서 (T14)
+
+utils/images/README.md                                                        # 변경 (T17)
+utils/images/README.ko.md                                                     # 변경 (T17)
+```
+
+## Task List
+
+---
+
+### T01 — Libs.kt 의존성 좌표/버전 추가
+
+- **complexity**: low
+- **파일**: `/Users/debop/work/bluetape4k/bluetape4k-projects/.worktrees/feat/issue-133-images-analysis/buildSrc/src/main/kotlin/Libs.kt`
+- **내용**:
+  - `Versions` object에 `const val metadata_extractor = "2.19.0"` 추가
+  - `Libs` object에 `val metadata_extractor = "com.drewnoakes:metadata-extractor:${Versions.metadata_extractor}"` 추가 (scrimage 인접 위치 ~line 1511)
+- **완료 기준**: `Libs.metadata_extractor` 참조가 컴파일됨. (DoD §Dependencies 1)
+
+---
+
+### T02 — utils/images/build.gradle.kts 의존성 추가
+
+- **complexity**: low
+- **파일**: `/Users/debop/work/bluetape4k/bluetape4k-projects/.worktrees/feat/issue-133-images-analysis/utils/images/build.gradle.kts`
+- **내용**:
+  - `dependencies { ... implementation(Libs.metadata_extractor) }` 추가
+  - 공개 API에 metadata-extractor 타입을 노출하지 않으므로 `implementation` 스코프 (api 아님)
+- **완료 기준**: `./gradlew :bluetape4k-images:dependencies | grep metadata-extractor` 출력 확인. (DoD §Dependencies 2)
+
+---
+
+### T03 — DominantColor data class
+
+- **complexity**: low
+- **파일**: `utils/images/src/main/kotlin/io/bluetape4k/images/analysis/DominantColor.kt`
+- **내용**:
+  - `data class DominantColor(r: Int, g: Int, b: Int, population: Int)` 정의
+  - `init` 블록: `r/g/b in 0..255`, `population >= 0` require 검증
+  - `val hex: String = "#%02x%02x%02x".format(r, g, b)` 계산 프로퍼티
+  - `fun toAwtColor(): java.awt.Color`
+  - `companion object { fun fromRgb(rgb: Int, population: Int = 1): DominantColor }`
+  - `companion object: KLogging()` 패턴 적용
+- **완료 기준**: 단위 테스트(T12)에서 `DominantColor(200, 100, 50, 1234).hex shouldBeEqualTo "#c86432"` 통과. (DoD §Code 1)
+
+---
+
+### T04 — MedianCutQuantizer internal 알고리즘
+
+- **complexity**: high
+- **파일**: `utils/images/src/main/kotlin/io/bluetape4k/images/analysis/MedianCutQuantizer.kt`
+- **내용**:
+  - `internal object MedianCutQuantizer` 또는 `internal class`
+  - 5-bit color cube (32 levels/channel) — RGB → bin index `((r shr 3) shl 10) or ((g shr 3) shl 5) or (b shr 3)`
+  - 픽셀 샘플링: `quality` 간격으로 `image.pixels()` 순회, alpha=0 제외, ignoreWhite 옵션
+  - `VBox` 내부 데이터 구조: rmin/rmax/gmin/gmax/bmin/bmax + histogram bin 카운트
+  - `vbox.volume()`, `vbox.count()`, `vbox.average()` 헬퍼
+  - 가장 긴 축 기반 median split — pixel histogram median으로 분할점 결정
+  - PriorityQueue (population 큰 박스 우선) 또는 list + sort 방식으로 박스 분할 반복
+  - 종료 조건: `count == k` 또는 `box.count <= 1 || box.volume == 0` (단색 edge case)
+  - 결과: `List<DominantColor>` — 각 박스의 평균 RGB + population, population 내림차순
+  - 빈 픽셀 시 `emptyList()`
+- **완료 기준**:
+  - 단색 이미지 → size=1 List 반환
+  - 투명 이미지 → emptyList()
+  - 5색 그라데이션 이미지 → count=5 호출 시 5개 색상 반환, population 내림차순
+  - (DoD §Code 3)
+
+---
+
+### T05 — DominantColorExtractor sealed interface
+
+- **complexity**: medium
+- **파일**: `utils/images/src/main/kotlin/io/bluetape4k/images/analysis/DominantColorExtractor.kt`
+- **내용**:
+  - `sealed interface DominantColorExtractor { fun extract(image: ImmutableImage, count: Int): List<DominantColor> }`
+  - `data class MedianCut(val quality: Int = 10, val ignoreWhite: Boolean = false): DominantColorExtractor`
+    - `init { require(quality in 1..30) { "quality 1..30, 입력: $quality" } }`
+    - `extract` → `MedianCutQuantizer` 위임
+  - `companion object { fun medianCut(quality: Int = 10, ignoreWhite: Boolean = false): DominantColorExtractor = MedianCut(quality, ignoreWhite) }`
+- **완료 기준**:
+  - `DominantColorExtractor.medianCut().extract(image, 5)` 호출 가능
+  - `quality=0` 시 `IllegalArgumentException`
+  - (DoD §Code 2)
+
+---
+
+### T06 — ImmutableImage extensions (DominantColor)
+
+- **complexity**: low
+- **파일**: `utils/images/src/main/kotlin/io/bluetape4k/images/analysis/DominantColor.kt` (T03 동일 파일에 extension 추가)
+- **내용**:
+  - `fun ImmutableImage.dominantColors(count: Int = 5, extractor: DominantColorExtractor = DominantColorExtractor.medianCut()): List<DominantColor>`
+    - `require(count >= 1)` 검증
+  - `fun ImmutableImage.dominantColor(extractor: DominantColorExtractor = DominantColorExtractor.medianCut()): DominantColor?`
+    - `dominantColors(1, extractor).firstOrNull()`
+  - `suspend fun ImmutableImage.suspendDominantColors(...)` → `withContext(Dispatchers.Default) { dominantColors(...) }`
+  - KDoc 한국어 작성
+- **완료 기준**: 4-5 종 fixture 이미지에서 `dominantColors(5).size == 5` 또는 단색 이미지 size==1 검증 (T12). (DoD §Code 4-6)
+
+---
+
+### T07 — BlurScore data class
+
+- **complexity**: low
+- **파일**: `utils/images/src/main/kotlin/io/bluetape4k/images/analysis/BlurDetector.kt`
+- **내용**:
+  - `data class BlurScore(val score: Double, val threshold: Double)`
+  - `val isBlurry: Boolean get() = score < threshold`
+  - `companion object { const val DEFAULT_THRESHOLD: Double = 100.0 }` (Pech-Pacheco/PyImageSearch 권장)
+- **완료 기준**: `BlurScore(50.0, 100.0).isBlurry shouldBeEqualTo true` (T13). (DoD §Code 7)
+
+---
+
+### T08 — BlurDetector internal Laplacian variance
+
+- **complexity**: medium
+- **파일**: `utils/images/src/main/kotlin/io/bluetape4k/images/analysis/BlurDetector.kt` (T07 동일 파일)
+- **내용**:
+  - `internal object BlurDetector { fun computeVariance(image: ImmutableImage): Double }`
+  - require: `image.width >= 3 && image.height >= 3`
+  - 1픽셀 boundary 제외하고 모든 내부 픽셀에 3x3 Laplacian 커널 `[[0,1,0],[1,-4,1],[0,1,0]]` 적용
+  - grayscale 변환: `0.299*R + 0.587*G + 0.114*B` (Rec. 601)
+  - convolution 결과 픽셀 값들의 분산(variance) 계산: `mean = sum / n`, `variance = sumSq/n - mean*mean`
+  - 효율성: 단일 패스, double 누적
+- **완료 기준**:
+  - 강하게 블러 처리한 이미지(`image.blur(20)`) variance ≪ 100
+  - sharp 원본 이미지 variance ≫ 100
+  - `width=2` 이미지에서 `IllegalArgumentException`
+  - (DoD §Code 8)
+
+---
+
+### T09 — ImmutableImage extensions (Blur)
+
+- **complexity**: low
+- **파일**: `utils/images/src/main/kotlin/io/bluetape4k/images/analysis/BlurDetector.kt` (T07 동일 파일에 extension)
+- **내용**:
+  - `fun ImmutableImage.blurScore(threshold: Double = BlurScore.DEFAULT_THRESHOLD): BlurScore`
+    - `BlurScore(BlurDetector.computeVariance(this), threshold)`
+  - `fun ImmutableImage.isBlurry(threshold: Double = BlurScore.DEFAULT_THRESHOLD): Boolean = blurScore(threshold).isBlurry`
+  - `suspend fun ImmutableImage.suspendBlurScore(threshold: Double = BlurScore.DEFAULT_THRESHOLD): BlurScore = withContext(Dispatchers.Default) { blurScore(threshold) }`
+  - KDoc 한국어 작성
+- **완료 기준**: T13 테스트 통과. (DoD §Code 9-11)
+
+---
+
+### T10 — ExifData data class
+
+- **complexity**: low
+- **파일**: `utils/images/src/main/kotlin/io/bluetape4k/images/analysis/ExifData.kt`
+- **내용**:
+  - 17개 nullable 필드: `gpsLatitude`, `gpsLongitude`, `gpsAltitude`, `dateTimeOriginal: LocalDateTime?`, `cameraMake`, `cameraModel`, `lensModel`, `iso: Int?`, `shutterSpeed: String?` (e.g. "1/250"), `aperture: Double?`, `focalLength: Double?`, `focalLength35mm: Int?`, `orientation: Int?`, `width: Int?`, `height: Int?`, `flashFired: Boolean?`, `whiteBalance: String?`
+  - `val hasGps: Boolean get() = gpsLatitude != null && gpsLongitude != null`
+  - `companion object { val EMPTY: ExifData = ExifData() }`
+  - 모든 필드 default = null
+- **완료 기준**: `ExifData.EMPTY.hasGps shouldBeEqualTo false` (T15). (DoD §Code 12)
+
+---
+
+### T11 — ExifData metadata-extractor 변환 + 진입점 4종
+
+- **complexity**: medium
+- **파일**: `utils/images/src/main/kotlin/io/bluetape4k/images/analysis/ExifData.kt` (T10 동일 파일)
+- **내용**:
+  - `private fun Metadata.toExifData(width: Int? = null, height: Int? = null): ExifData`
+    - `ExifIFD0Directory` → make/model/orientation
+    - `ExifSubIFDDirectory` → dateTimeOriginal/iso/shutterSpeed/aperture/focalLength/focalLength35mm/lensModel/flashFired/whiteBalance
+    - `GpsDirectory.geoLocation` → latitude/longitude (decimal), altitude
+    - `JpegDirectory` → width/height (없으면 width/height 파라미터 사용)
+    - 모든 필드 read는 `try { dir.getXxx(tag) } catch { null }` 가드
+    - `LocalDateTime` 변환: EXIF 문자열 직접 파싱 (tz-independent)
+      ```kotlin
+      private val EXIF_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy:MM:dd HH:mm:ss")
+      subIfd.getString(TAG_DATETIME_ORIGINAL)?.let {
+          runCatching { LocalDateTime.parse(it, EXIF_DATE_FORMATTER) }.getOrNull()
+      }
+      ```
+      (이유: `TimeZone.getDefault()` 의존 방식은 CI 환경 tz에 따라 비결정적)
+    - `shutterSpeed`: `Rational` → `"${numer}/${denom}"` 문자열 변환 (e.g. "1/250")
+      ```kotlin
+      subIfd.getRational(TAG_SHUTTER_SPEED_VALUE)?.let { "${it.numerator}/${it.denominator}" }
+          ?: subIfd.getString(TAG_EXPOSURE_TIME)
+      ```
+  - 진입점 4종:
+    - `fun readExif(bytes: ByteArray): ExifData`
+      - `require(bytes.size <= 50 * 1024 * 1024) { "이미지 byte 50MB 초과: ${bytes.size}" }`
+      - `try { ImageMetadataReader.readMetadata(ByteArrayInputStream(bytes)) } catch (e: Exception) { return ExifData.EMPTY }`
+    - `fun File.readExif(): ExifData` — `try { ImageMetadataReader.readMetadata(this) } catch { ExifData.EMPTY }`
+    - `fun Path.readExif(): ExifData` — `Files.newInputStream(this).use { it.readExif() }`
+      (이유: `toFile()` 방식은 jar/zip 내 Path 접근 시 실패)
+    - `fun InputStream.readExif(): ExifData` — `try { ImageMetadataReader.readMetadata(this) } catch { ExifData.EMPTY }`
+  - suspend:
+    - `suspend fun File.suspendReadExif(): ExifData = withContext(Dispatchers.IO) { readExif() }`
+    - `suspend fun Path.suspendReadExif(): ExifData = withContext(Dispatchers.IO) { readExif() }`
+  - 모든 catch 블록은 `companion object: KLogging()` 통한 debug 로그 + EMPTY 반환
+- **완료 기준**:
+  - GPS 포함 이미지에서 `readExif().hasGps == true` (T15)
+  - 손상/EXIF 미포함 이미지에서 `ExifData.EMPTY` 반환 (T15)
+  - 50MB 초과 ByteArray → `IllegalArgumentException`
+  - (DoD §Code 13-15)
+
+---
+
+### T12 — DominantColorExtractorTest
+
+- **complexity**: medium
+- **파일**: `utils/images/src/test/kotlin/io/bluetape4k/images/analysis/DominantColorExtractorTest.kt`
+- **내용**:
+  - `class DominantColorExtractorTest: AbstractImageTest()`
+  - `companion object: KLoggingChannel()` 패턴
+  - 테스트 케이스:
+    - `homer.jpg`/`landscape.jpg`/`cafe.jpg`(기존 fixture 가용시) 또는 동적 생성 이미지에서 `dominantColors(5)` 추출 → size <= 5, 모든 hex 형식 검증
+    - count=1 → size=1
+    - 단색 이미지(전체 white) → size=1, hex == "#ffffff"
+    - 투명 이미지(alpha=0 전부) → emptyList()
+    - `quality=0` IllegalArgumentException
+    - `count=0` IllegalArgumentException
+    - `ignoreWhite=true` 동작 검증 (대부분 흰색 + 빨간 점 → 빨간색이 1순위)
+  - `population 내림차순` 검증
+- **완료 기준**: 8개 이상 테스트 케이스 모두 PASS. (DoD §Tests 1)
+
+---
+
+### T13 — BlurDetectorTest
+
+- **complexity**: medium
+- **파일**: `utils/images/src/test/kotlin/io/bluetape4k/images/analysis/BlurDetectorTest.kt`
+- **내용**:
+  - `class BlurDetectorTest: AbstractImageTest()`
+  - `companion object: KLoggingChannel()` 패턴 적용
+  - sharp fixture: 기존 `src/test/resources/images/` 의 `homer.jpg` 사용 (사진 이미지, 선명)
+  - blur fixture: `homer.jpg`에 Scrimage `image.blur(20)` 적용 (동적 생성)
+  - 테스트 케이스:
+    - `sharp.blurScore().score shouldBeGreaterThan blurred.blurScore().score`
+    - `blurred.isBlurry(100.0) shouldBeEqualTo true` (강한 블러)
+    - `sharp.isBlurry(100.0) shouldBeEqualTo false`
+    - `BlurScore(50.0, 100.0).isBlurry shouldBeEqualTo true`
+    - 너무 작은 이미지(`width=2`) → IllegalArgumentException
+    - threshold 변경 시 isBlurry 결과 변화
+  - **Kluent matcher 규칙**: `(x > y).shouldBeTrue()` 금지 → `shouldBeGreaterThan` 사용
+- **완료 기준**: 6개 이상 테스트 케이스 모두 PASS. (DoD §Tests 2)
+
+---
+
+### T14 — EXIF test fixtures
+
+- **complexity**: medium
+- **파일**:
+  - `utils/images/src/test/resources/images/exif/with-gps.jpg`
+  - `utils/images/src/test/resources/images/exif/no-exif.jpg`
+  - `utils/images/src/test/resources/images/exif/full-exif.jpg`
+  - `utils/images/src/test/resources/images/exif/README.md`
+- **내용**:
+  - `with-gps.jpg`: GPS EXIF 포함 샘플 (Wikimedia Commons / CC0 출처). 작은 사이즈 (~100KB 이하) 권장
+  - `no-exif.jpg`: EXIF 없는 이미지 (Scrimage 등으로 새로 인코딩하면 EXIF 제거됨)
+  - `full-exif.jpg`: 카메라 make/model/lens/iso/aperture 풍부한 EXIF (DPReview/Wikimedia 샘플)
+  - `README.md`: 각 fixture의 origin URL + license + 추출된 EXIF 요약 (테스트 기대값 documentation)
+- **완료 기준**: 3개 jpg + README 모두 존재, fixture를 T15에서 로드 가능. license 명시 완료. (DoD §Test Resources)
+
+---
+
+### T15 — ExifDataTest
+
+- **complexity**: medium
+- **파일**: `utils/images/src/test/kotlin/io/bluetape4k/images/analysis/ExifDataTest.kt`
+- **내용**:
+  - `class ExifDataTest: AbstractImageTest()`
+  - `companion object: KLoggingChannel()` 패턴 적용
+  - 테스트 케이스:
+    - `with-gps.jpg`.readExif() → `hasGps == true`, latitude/longitude 범위 검증 (`shouldBeInRange`)
+    - `no-exif.jpg`.readExif() → `ExifData.EMPTY` 또는 모든 필드 null
+    - `full-exif.jpg`.readExif() → cameraMake, cameraModel, iso, aperture 등 not null
+    - `dateTimeOriginal` LocalDateTime 검증
+    - `readExif(ByteArray)` 진입점 검증
+    - `Path.readExif()` 진입점 검증
+    - `InputStream.readExif()` 진입점 검증
+    - `ByteArray(50 * 1024 * 1024 + 1)` → IllegalArgumentException
+    - 손상 byte (`byteArrayOf(0x00, 0x01, 0x02)`) → ExifData.EMPTY (예외 X)
+  - `ExifData.EMPTY.hasGps == false` 검증
+- **완료 기준**: 9개 이상 테스트 케이스 모두 PASS. (DoD §Tests 3)
+
+---
+
+### T16 — SuspendAnalysisTest
+
+- **complexity**: low
+- **파일**: `utils/images/src/test/kotlin/io/bluetape4k/images/analysis/SuspendAnalysisTest.kt`
+- **내용**:
+  - `class SuspendAnalysisTest: AbstractImageTest()`
+  - `companion object: KLoggingChannel()` 패턴 적용
+  - `kotlinx.coroutines.test.runTest(timeout = 30.seconds)` 사용
+  - 테스트:
+    - `suspendDominantColors(5)` — 결과가 blocking `dominantColors(5)`와 동일
+    - `suspendBlurScore()` — 결과가 blocking `blurScore()`와 동일 (score 동일)
+    - `File.suspendReadExif()` — 결과가 blocking `readExif()`와 동일
+- **완료 기준**: 3개 테스트 PASS. (DoD §Tests 4)
+
+---
+
+### T17 — README + README.ko 업데이트
+
+- **complexity**: medium
+- **파일**:
+  - `utils/images/README.md`
+  - `utils/images/README.ko.md`
+- **내용**:
+  - 새 섹션 "Image Analysis" 추가 (영어/한국어 둘 다)
+  - 하위: Dominant Color / Blur Detection / EXIF Metadata 각 코드 예제 포함
+  - Mermaid 다이어그램: `Image → Extractor → Result` 파이프라인
+    ```mermaid
+    graph LR
+      Image[ImmutableImage / File / ByteArray] --> Analyzer
+      Analyzer{Analyzer}
+      Analyzer -->|MedianCut| DC[List<DominantColor>]
+      Analyzer -->|Laplacian| BS[BlurScore]
+      Analyzer -->|metadata-extractor| EX[ExifData]
+    ```
+  - Architecture / Features / Examples 표준 구조 따르기
+  - 양쪽 README 동기화 (구조 동일, 언어만 다름)
+- **완료 기준**: 두 README 모두 새 섹션 포함, Mermaid 다이어그램 렌더 가능. (DoD §Documentation 1-3)
+
+---
+
+### T18 — KDoc 한국어 작성
+
+- **complexity**: low
+- **파일**: T03~T11에서 작성한 모든 .kt 파일
+- **내용**:
+  - 모든 public class/data class/sealed interface/extension function에 KDoc
+  - `@property` / `@param` / `@return` / `@throws` 명시
+  - 한국어 OK (CLAUDE.md 가이드)
+  - 핵심 KDoc 주의사항:
+    - `BlurScore` — "동일 도메인 이미지에서 상대 비교용. 절대 threshold는 캘리브레이션 필요"
+    - `ExifData.dateTimeOriginal` — "EXIF DateTimeOriginal은 timezone 정보 없음. 카메라 wall-clock 그대로"
+    - `readExif(ByteArray)` — "50MB 상한, 파싱 실패 시 EMPTY 반환"
+    - `dominantColor()` — "빈 이미지(alpha=0 전부) → null"
+- **완료 기준**: 모든 public symbol이 KDoc 보유. (DoD §Documentation 4)
+
+---
+
+### T19 — Follow-up issues 등록
+
+- **complexity**: low
+- **파일**: 없음 (GitHub Issue)
+- **내용**: `gh issue create` 비대화형 모드로 3건 등록
+  1. **OCR support (Tesseract)** — Tess4J/Tesseract via JNI 평가
+  2. **Face Detection** — OpenCV / openimaj / native binding 평가
+  3. **Image Classification** — ONNX Runtime / TFLite Java 평가
+  - 각 이슈에 본 PR(#133) 링크
+  - 라벨: `enhancement`, `images`
+- **완료 기준**: 3개 이슈 URL을 PR 본문에 첨부. (DoD §Follow-up)
+
+---
+
+### T20 — :bluetape4k-images:test 전수 통과 확인
+
+- **complexity**: low
+- **파일**: 없음 (CI/local verification)
+- **내용**:
+  - `./gradlew :bluetape4k-images:test` 실행
+  - 결과 (통과 수 + duration) 보고
+  - `./gradlew :bluetape4k-images:detekt` 실행 — 0 issue 확인
+  - `oh-my-claudecode:code-reviewer` 실행 — HIGH/CRITICAL 0건 확인
+- **완료 기준**: 모든 신규 테스트 PASS, detekt clean, code-reviewer clean. (DoD §Verification)
+
+---
+
+## 의존성 순서 / 병렬화 가능성
+
+```
+Wave 1: T01 → T02 (의존성 추가 sequential)
+Wave 2: T03 / T07 / T10 (data class 3종 병렬 — 알고리즘 미의존)
+Wave 3: T04 / T08 / T11 (internal 알고리즘 3종 병렬)
+Wave 4: T05 → T06 / T09 (T04 완료 후 sealed interface, T08 완료 후 blur extensions)
+         ※ T05는 T04 의존, T06은 T05 의존, T09는 T08 의존
+Wave 5: T14 (EXIF fixtures — 독립, T11 병렬 가능하나 T15보다 먼저)
+Wave 6: T12 / T13 / T15 / T16 (테스트 4종 병렬 — 각 기능 구현 완료 후)
+Wave 7: T17 / T18 (docs 병렬)
+Wave 8: T19 → T20 (follow-up + verification sequential)
+```
+
+병렬 처리 권장 그룹:
+- **Wave 1**: T01 → T02 (sequential)
+- **Wave 2 (parallel)**: T03 / T07 / T10 — 단순 data class, 알고리즘 의존 없음
+- **Wave 3 (parallel)**: T04 / T08 / T11 — 각각 독립적 internal 구현
+- **Wave 4**: T05 (T04 완료 후) → T06 / T09 (T05, T08 각 완료 후)
+- **Wave 5**: T14 (EXIF fixtures, 독립)
+- **Wave 6 (parallel)**: T12 / T13 / T15 / T16 — 각 기능 완료 후 테스트
+- **Wave 7 (parallel)**: T17 / T18 — docs
+- **Wave 8**: T19 → T20
+
+## 주의사항 / 구현 가이드
+
+### Median Cut 알고리즘 핵심 포인트
+
+1. **5-bit 색공간 필수** — 8-bit는 메모리 16MB 폭발 (32^3=32K bin이 256^3=16M로 폭증)
+2. **bin index 공식**: `((r shr 3) shl 10) or ((g shr 3) shl 5) or (b shr 3)` — 각 채널 5bit
+3. **Median split**: 가장 긴 축(`max(rrange, grange, brange)`)을 선택 → 해당 축 histogram cumulative sum의 median에서 분할
+4. **종료 조건**: `box.count <= 1 || box.volume == 0` 시 더 이상 분할 안 함 → 사용자 요청 count보다 적은 결과 가능
+5. **빈 이미지** (alpha=0 모두 또는 ignoreWhite로 모두 제외) → emptyList() 반환 — `dominantColor()` 가 null 반환
+
+### Laplacian Variance 핵심
+
+- 3x3 커널 sum=0 → DC 컴포넌트 제거됨, edge 강도만 측정
+- variance가 dispersion 측도로 동작 — sharp 이미지는 강한 edge 다수 → high variance
+- 1픽셀 boundary 제외 (커널이 image bound 밖으로 나감 방지)
+- 단일 패스: `sum`, `sumSq`, `n` 누적 → `variance = sumSq/n - (sum/n)^2`
+
+### EXIF 변환 edge case
+
+- `ExifSubIFDDirectory.getDate(TAG_DATETIME_ORIGINAL)` deprecated일 수 있음 — `getDate(tag, timeZone)` 사용
+- `Rational` 타입 (shutterSpeed) → `numerator/denominator` 형식 직접 포매팅 ("1/250")
+- `getDouble(tag)` 호출 시 tag 없으면 `MetadataException` → try/catch 필수
+- GPS는 `GpsDirectory.geoLocation: GeoLocation?` (decimal degree) 권장 — DMS 변환 자동
+- `flashFired` — `getInt(TAG_FLASH) and 0x01 != 0`
+
+### Coroutines Dispatcher 결정 (spec §5 Risk 6)
+
+- CPU-bound: `suspendDominantColors`, `suspendBlurScore` → `Dispatchers.Default`
+- I/O 포함: `suspendReadExif (File/Path)` → `Dispatchers.IO`
+- 직관에 어긋나지만 **CPU-bound 작업에 IO Dispatcher는 부적절** (스레드 풀 크기/특성 다름)
+
+### 입력 검증 (Risk 7)
+
+- `readExif(ByteArray)`: 50MB 상한 (`require`)
+- 모든 metadata-extractor 예외 → catch → EMPTY (사용자에게 throw 안 함)
+- `dominantColors`: `count >= 1`
+- `blurScore`: `width >= 3 && height >= 3`
+
+### bluetape4k 패턴 준수
+
+- `companion object: KLogging()` (또는 KLoggingChannel for tests)
+- `Serializable` — data class 직렬화 가능 (`serialVersionUID = 1L`)는 model이 아니므로 선택. `ExifData`는 직렬화 가능하면 좋음
+- Kluent matcher: `shouldBeEqualTo`, `shouldBeGreaterThan`, `shouldBeInRange` — `.shouldBeTrue()` 비교 보다 우선
+- Test base: `AbstractImageTest`(이미 모듈에 존재 추정)
+
+### Library Source 추출 위치
+
+- 필요시 `.claude/lib-sources/metadata-extractor/` 사용 — `/tmp` 또는 프로젝트 src 금지
+
+### 알려진 라이브러리 사양
+
+- `metadata-extractor 2.19.0` — Apache 2.0, ~800KB
+- `ImageMetadataReader.readMetadata(File|InputStream)` 진입점
+- 주요 directory class: `ExifIFD0Directory`, `ExifSubIFDDirectory`, `GpsDirectory`, `JpegDirectory`
+- Tag 상수: `ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL`, `TAG_ISO_EQUIVALENT`, `TAG_APERTURE`, `TAG_FOCAL_LENGTH`, etc.
+
+## 검증 체크리스트 (PR 직전)
+
+- [ ] T01~T20 전체 완료
+- [ ] `./gradlew :bluetape4k-images:test` PASS (테스트 수/duration 보고)
+- [ ] `./gradlew :bluetape4k-images:detekt` 0 issue
+- [ ] `oh-my-claudecode:code-reviewer` HIGH/CRITICAL 0건
+- [ ] README.md / README.ko.md 동기화
+- [ ] KDoc 100% public API 커버리지
+- [ ] Follow-up issue 3건 URL 확보
+- [ ] worktree (`.worktrees/feat/issue-133-images-analysis/`) 내부 작업 확인
+
+## 참고
+
+- **Spec**: `docs/superpowers/specs/2026-04-27-images-analysis-design.md`
+- **color-thief-java**: https://github.com/SvenWoltmann/color-thief-java (MIT)
+- **metadata-extractor**: https://github.com/drewnoakes/metadata-extractor (Apache 2.0)
+- **Pech-Pacheco Laplacian**: "Diatom autofocusing in brightfield microscopy" (2000)
+- **기존 패턴**: `utils/images/src/main/kotlin/io/bluetape4k/images/similarity/HistogramSimilarity.kt`

--- a/docs/superpowers/specs/2026-04-27-images-analysis-design.md
+++ b/docs/superpowers/specs/2026-04-27-images-analysis-design.md
@@ -1,0 +1,447 @@
+# utils/images — Image Analysis Design Spec
+
+**Date**: 2026-04-27
+**Issue**: #133
+**Branch**: `feat/issue-133-images-analysis`
+**Worktree**: `.worktrees/feat/issue-133-images-analysis`
+**Module**: `utils/images` (`bluetape4k-images`)
+
+## 1. 배경 / 목표
+
+`utils/images` 모듈에 이미지 분석 기능 3종을 추가한다.
+
+- **Dominant Color Extraction**: 대표 색상 N개 추출 (palette 생성, 썸네일 컬러, UI theming).
+- **Blur Detection**: 흐림 정도 점수화 (사진 품질 검증, autofocus 검수).
+- **EXIF Metadata**: GPS/카메라/촬영일시 등 EXIF 메타 추출 (사진 자산 색인, 지오태깅).
+
+OCR / Face Detection은 **본 PR 범위에서 제외**하며 별도 이슈로 등록한다 (외부 native 의존성/모델 파일 부담 회피).
+
+### 비목표 (Non-Goals)
+
+- OCR (Tesseract, Google ML Kit 등 native 모델 의존).
+- Face Detection (OpenCV / dlib native binding 필요).
+- 이미지 분류/라벨링 (TensorFlow/ONNX 모델 필요).
+- EXIF **쓰기** — 본 PR은 **읽기만** 지원.
+
+### 설계 원칙
+
+- **Pure JVM only** — 외부 native dependency 금지 (Scrimage가 이미 ImageIO + WebP만 사용).
+- 기존 모듈의 sealed interface + data class 패턴 (`HistogramSimilarity`) 재사용.
+- Extension function 형태의 공개 API (`ImmutableImage.xxx`, `File.xxx`, `Path.xxx`).
+- Coroutines suspend 변형은 `withContext(Dispatchers.IO)` 래핑 — 큰 이미지 처리는 IO 풀로.
+- 기능별 서브패키지: `io.bluetape4k.images.analysis`.
+
+## 2. Brainstorming — 구현 방식 비교
+
+### 2.1 Dominant Color Extraction
+
+| 방식 | 장점 | 단점 | 평가 |
+|------|------|------|------|
+| **(a) Median Cut quantization** | 표준 알고리즘, color-thief-java 검증, O(n·log k), 메모리 효율, k=5 등 정확한 N개 보장 | 직접 구현 필요 (~150 LoC), edge case (단색 이미지) 처리 필요 | **선택** |
+| (b) K-means clustering | 통계적으로 더 균일한 클러스터, 라이브러리 (commons-math) 활용 가능 | k-means 초기 시드 random → 비결정적, 수렴 안 할 수 있음, 느림 (반복) | 보류 |
+| (c) Histogram bucket | 가장 단순, 빠름 (O(n)) | 낮은 정확도 — bin 경계 근처 색상이 분산됨, "비슷한 색"이 한 그룹으로 안 묶임 | 보류 |
+
+**선택: (a) Median Cut**.
+
+- color-thief-java (SvenWoltmann/color-thief-java MIT 라이선스) 알고리즘을 Kotlin으로 자체 구현.
+- 핵심 단계: ① 픽셀 샘플링 → ② RGB 큐브 분할 (가장 긴 축 기준 median으로 분할) → ③ k 개 박스가 될 때까지 반복 → ④ 각 박스의 평균 색상 반환.
+- 외부 라이브러리 import 불가 (color-thief-java는 jcenter 종료, 일부 fork만 maven central).
+
+**성능 고려**:
+- 큰 이미지는 픽셀 샘플링 (every Nth pixel) — 기본 quality=10 (color-thief-java 디폴트).
+- Alpha=0 픽셀 제외, 거의 흰색/검정 (선택적) 제외 옵션.
+
+### 2.2 Blur Detection
+
+| 방식 | 장점 | 단점 | 평가 |
+|------|------|------|------|
+| **(a) Laplacian variance** | 표준 (Pech-Pacheco 2000), 직관적 — variance 낮을수록 blur, OpenCV 표준 방법, 단일 패스 | threshold가 이미지 도메인에 따라 다름 (절대값 아님) — 사용자에게 threshold 명시 필요 | **선택** |
+| (b) FFT 주파수 분석 | 더 정확, 노이즈에 강건 | FFT 라이브러리 의존 (commons-math3.transform), 구현 복잡 | 보류 |
+| (c) Tenengrad gradient (Sobel) | Laplacian 변형, 조명 변화에 강건 | Laplacian 대비 이점 미미, 두 패스 필요 | 보류 |
+
+**선택: (a) Laplacian variance**.
+
+- Laplacian 커널 `[[0,1,0],[1,-4,1],[0,1,0]]` 적용 → grayscale 픽셀에 convolution → variance 계산.
+- `threshold` 디폴트 `100.0` (OpenCV/PyImageSearch 권장값) — 이미지 사이즈에 따라 사용자가 조정.
+- grayscale 변환은 luminance 공식 `0.299*R + 0.587*G + 0.114*B` (Rec. 601).
+
+**성능 고려**:
+- 이미지 크기 dependent. 큰 이미지는 사전 다운샘플링 옵션 (예: max 1024px) — 첫 PR에서는 다운샘플링 옵션 보류, 사용자가 직접 `scale()` 호출.
+
+### 2.3 EXIF Metadata
+
+| 방식 | 장점 | 단점 | 평가 |
+|------|------|------|------|
+| **(a) metadata-extractor 2.x (drewnoakes)** | EXIF/IPTC/XMP/GPS 광범위, 80개+ 카메라 maker note, 활발한 유지보수, pure Java, 800KB | 외부 의존 (Apache 2.0) | **선택** |
+| (b) scrimage 내장 EXIF | 추가 의존 없음 | scrimage는 EXIF metadata write/preserve만 지원, **파싱 API 없음** (확인됨: `ImageMetadata` 는 directory 단위 raw tag 노출 정도) | 보류 |
+| (c) javax.imageio EXIF | JDK 내장 | 매우 제한적 — JPEG/TIFF만, 일부 tag 누락, GPS 파싱 직접 해야 함 | 보류 |
+
+**선택: (a) metadata-extractor 2.x**.
+
+- `com.drewnoakes:metadata-extractor:2.19.0` (current latest).
+- JPEG/TIFF/PNG/HEIF/WebP/RAW 등 광범위 포맷 지원.
+- GPS 좌표는 자동 decimal degree 변환 제공 (`GpsDirectory.geoLocation`).
+- `LocalDateTime` 변환은 `ExifSubIFDDirectory.getDateOriginal(timezone)` 사용.
+
+## 3. API 설계
+
+### 3.1 패키지 / 파일 구조
+
+```
+utils/images/src/main/kotlin/io/bluetape4k/images/analysis/
+├── DominantColor.kt                  // data class + ImmutableImage extensions
+├── DominantColorExtractor.kt         // sealed interface (Strategy)
+├── MedianCutQuantizer.kt             // internal Median Cut implementation
+├── BlurDetector.kt                   // BlurScore + extensions + internal Laplacian
+└── ExifData.kt                       // ExifData + ImmutableImage/File/Path extensions
+```
+
+### 3.2 Dominant Color API
+
+```kotlin
+package io.bluetape4k.images.analysis
+
+/**
+ * 추출된 대표 색상 단위.
+ *
+ * @property r 0..255 red
+ * @property g 0..255 green
+ * @property b 0..255 blue
+ * @property hex `"#rrggbb"` 형식
+ * @property population 이 색상이 속한 박스의 픽셀 수 (가중치)
+ */
+data class DominantColor(
+    val r: Int,
+    val g: Int,
+    val b: Int,
+    val population: Int,
+) {
+    val hex: String = "#%02x%02x%02x".format(r, g, b)
+    fun toAwtColor(): java.awt.Color = java.awt.Color(r, g, b)
+
+    companion object {
+        fun fromRgb(rgb: Int, population: Int = 1): DominantColor =
+            DominantColor((rgb shr 16) and 0xFF, (rgb shr 8) and 0xFF, rgb and 0xFF, population)
+    }
+}
+
+/**
+ * Dominant color 추출 전략 (sealed interface — `HistogramSimilarity` 패턴 재사용).
+ */
+sealed interface DominantColorExtractor {
+
+    fun extract(image: ImmutableImage, count: Int): List<DominantColor>
+
+    /**
+     * Median Cut quantization (color-thief-java 알고리즘).
+     *
+     * @property quality 픽셀 샘플링 간격 (1=모든 픽셀, 10=10픽셀당 1개). 1..30
+     * @property ignoreWhite `true`면 거의 흰색 픽셀 제외
+     */
+    data class MedianCut(
+        val quality: Int = 10,
+        val ignoreWhite: Boolean = false,
+    ): DominantColorExtractor {
+        init { require(quality in 1..30) { "quality 1..30, 입력: $quality" } }
+        override fun extract(image: ImmutableImage, count: Int): List<DominantColor> { /* ... */ }
+    }
+
+    companion object {
+        fun medianCut(quality: Int = 10, ignoreWhite: Boolean = false): DominantColorExtractor =
+            MedianCut(quality, ignoreWhite)
+    }
+}
+
+// Extension functions (블로킹)
+fun ImmutableImage.dominantColors(
+    count: Int = 5,
+    extractor: DominantColorExtractor = DominantColorExtractor.medianCut(),
+): List<DominantColor> = extractor.extract(this, count)
+
+// 빈 이미지(alpha=0 전체)에서 null 반환 — emptyList() 계약과 일관
+fun ImmutableImage.dominantColor(
+    extractor: DominantColorExtractor = DominantColorExtractor.medianCut(),
+): DominantColor? = dominantColors(1, extractor).firstOrNull()
+
+// Coroutines suspend — CPU-bound이므로 Dispatchers.Default 사용
+suspend fun ImmutableImage.suspendDominantColors(
+    count: Int = 5,
+    extractor: DominantColorExtractor = DominantColorExtractor.medianCut(),
+): List<DominantColor> = withContext(Dispatchers.Default) { dominantColors(count, extractor) }
+```
+
+**검증 규칙**:
+- `count >= 1` (require).
+- `count` 가 추출 가능한 색상 수보다 크면 가능한 만큼만 반환 (단색 이미지 → size=1).
+- 픽셀 0개 (alpha=0 전부) → `emptyList()`.
+- 결과는 `population` 내림차순 정렬.
+
+### 3.3 Blur Detection API
+
+```kotlin
+/**
+ * 블러 검사 결과.
+ *
+ * @property score Laplacian variance — 클수록 sharp, 작을수록 blur
+ * @property threshold 비교 기준값
+ * @property isBlurry `score < threshold`이면 true
+ */
+data class BlurScore(
+    val score: Double,
+    val threshold: Double,
+) {
+    val isBlurry: Boolean get() = score < threshold
+}
+
+/**
+ * Laplacian variance 기반 블러 점수.
+ *
+ * @param threshold 디폴트 100.0 (OpenCV/PyImageSearch 권장값)
+ * @return BlurScore
+ */
+fun ImmutableImage.blurScore(threshold: Double = 100.0): BlurScore
+
+fun ImmutableImage.isBlurry(threshold: Double = 100.0): Boolean = blurScore(threshold).isBlurry
+
+// CPU-bound이므로 Dispatchers.Default 사용
+suspend fun ImmutableImage.suspendBlurScore(threshold: Double = 100.0): BlurScore =
+    withContext(Dispatchers.Default) { blurScore(threshold) }
+```
+
+**구현 노트**:
+- Laplacian kernel `[[0,1,0],[1,-4,1],[0,1,0]]` 3x3 single-pass convolution.
+- 이미지 boundary 픽셀은 분석에서 제외 (1px border).
+- ImmutableImage → grayscale variance — luminance Rec. 601.
+- 너무 작은 이미지 (`width < 3 || height < 3`) → `IllegalArgumentException`.
+
+### 3.4 EXIF Metadata API
+
+```kotlin
+/**
+ * 추출된 EXIF 메타데이터 (모든 필드 nullable — 카메라/포맷별 누락 정상).
+ */
+data class ExifData(
+    val gpsLatitude: Double? = null,
+    val gpsLongitude: Double? = null,
+    val gpsAltitude: Double? = null,
+    val dateTimeOriginal: LocalDateTime? = null,
+    val cameraMake: String? = null,
+    val cameraModel: String? = null,
+    val lensModel: String? = null,
+    val iso: Int? = null,
+    val shutterSpeed: String? = null,        // e.g. "1/250"
+    val aperture: Double? = null,            // f-number
+    val focalLength: Double? = null,         // mm
+    val focalLength35mm: Int? = null,        // 35mm equiv.
+    val orientation: Int? = null,            // EXIF 1..8
+    val width: Int? = null,
+    val height: Int? = null,
+    val flashFired: Boolean? = null,
+    val whiteBalance: String? = null,
+) {
+    val hasGps: Boolean get() = gpsLatitude != null && gpsLongitude != null
+    companion object {
+        val EMPTY = ExifData()
+    }
+}
+
+// Extensions
+fun readExif(bytes: ByteArray): ExifData
+fun File.readExif(): ExifData
+fun Path.readExif(): ExifData
+fun InputStream.readExif(): ExifData
+
+// suspend
+suspend fun File.suspendReadExif(): ExifData = withContext(Dispatchers.IO) { readExif() }
+suspend fun Path.suspendReadExif(): ExifData = withContext(Dispatchers.IO) { readExif() }
+```
+
+**중요한 결정 — `ImmutableImage.readExif()`는 제공하지 않는다**:
+- Scrimage `ImmutableImage` 는 디코딩된 픽셀만 보존하며 EXIF는 `ImageMetadata` 객체로 분리되어 있음.
+- EXIF 추출에는 **원본 byte stream** 이 필요 → `ImmutableImage` 단계에서는 ByteArray 손실.
+- 따라서 EXIF API는 `File`/`Path`/`ByteArray`/`InputStream` 진입점만 제공.
+
+**구현 노트**:
+- `metadata-extractor` `Metadata` 객체에서 `ExifIFD0Directory`, `ExifSubIFDDirectory`, `GpsDirectory`, `JpegDirectory` 추출.
+- 누락된 tag는 모두 `null` 처리 (예외 X) — `try` 가드 후 `null`.
+- 손상된 / EXIF 없는 이미지 → `ExifData.EMPTY` 반환 (예외 X).
+
+## 4. 의존성 추가
+
+### 4.1 `buildSrc/src/main/kotlin/Libs.kt`
+
+```kotlin
+object Versions {
+    // ...existing...
+    const val metadata_extractor = "2.19.0"  // https://mvnrepository.com/artifact/com.drewnoakes/metadata-extractor
+}
+
+object Libs {
+    // ...existing... (after scrimage entries ~line 1511)
+    val metadata_extractor = "com.drewnoakes:metadata-extractor:${Versions.metadata_extractor}"
+}
+```
+
+### 4.2 `utils/images/build.gradle.kts`
+
+```kotlin
+dependencies {
+    // ...existing...
+
+    // EXIF metadata — 공개 API에서 metadata-extractor 타입 미노출, implementation 스코프
+    implementation(Libs.metadata_extractor)
+}
+```
+
+> **결정: `implementation`** — 본 모듈의 공개 API(`ExifData`)는 metadata-extractor 타입을 노출하지 않는다.
+> metadata-extractor는 **필수 런타임 의존성**이다 (optional/compileOnly 아님).
+> 다운스트림이 추가 EXIF 처리를 원하면 별도로 의존성을 선언해야 한다.
+
+## 5. 설계 리스크 & 실패 모드
+
+### Risk 1 — Median Cut: 단색/저색상 이미지 edge case
+
+- **시나리오**: 단색 이미지 (모두 흰색) 에서 `dominantColors(5)` 호출 → 원본 알고리즘은 box 1개에서 멈춤.
+- **완화**: 박스 분할 시 `box.count <= 1 || box.volume == 0` 이면 분할 중단. 사용자에게는 size < count 인 List 반환 (계약 명시).
+- **테스트**: 단색/2색/투명 이미지 fixture 추가.
+
+### Risk 2 — Median Cut: 픽셀 5x5x5 색공간 vs 8x8x8 색공간 결정
+
+- color-thief-java는 5-bit/channel (32 levels) — RGB cube 32x32x32 = 32K bin → 메모리/속도 균형.
+- **결정**: 5-bit (32 levels)/channel 채택. 박스 분할 시 longest-axis variance 기반.
+- 8-bit (256 levels) 사용 시 메모리 16MB+ 폭발. 5-bit가 표준.
+
+### Risk 3 — Blur Detection: 이미지 사이즈 의존성
+
+- threshold=100 은 ~640x480 기준. 4K 이미지에서는 variance 자체가 더 큼 → blur 판정 어려움.
+- **완화 (이번 PR)**: KDoc에 명시 — "동일 도메인 이미지에서 상대 비교용으로 사용. 절대 threshold는 캘리브레이션 필요". 사용자가 직접 다운샘플링.
+- **완화 (후속 옵션)**: `BlurDetector.LaplacianVariance(maxSize = 1024)` — 자동 다운스케일 옵션. 본 PR에서는 보류 (YAGNI).
+
+### Risk 4 — EXIF: `LocalDateTime` 타임존 없음
+
+- EXIF `DateTimeOriginal` 태그는 **timezone 정보를 포함하지 않는다** (ISO 8601과 달리).
+- **결정**: `ExifData.dateTimeOriginal: LocalDateTime?` — EXIF wall-clock 값을 그대로 보존. "UTC 가정"이 아니라 단순히 timezone-naive.
+- KDoc에 명시: "EXIF DateTimeOriginal은 timezone 정보 없음. 이 필드는 카메라 현지 시각 그대로이며 UTC 변환은 호출자 책임 (GPS 좌표 또는 카메라 설정 기반 보정 권장)."
+- 구현에서 `getDateOriginal(TimeZone.UTC)` 호출 시 metadata-extractor는 UTC 해석이 아닌 날짜/시간 문자열만 파싱하므로 결과 값 동일. KDoc 경고로 충분.
+
+### Risk 5 — metadata-extractor: 의존성 크기 증가
+
+- 약 800KB jar. webp + scrimage-core 합산이 이미 크므로 영향 미미. 그러나 모든 utils/images 사용자에게 부과.
+- **완화**: `implementation` 스코프 — transitive 노출 차단. **필수 런타임 의존** (optional 처리 안 함).
+- 추가 완화 검토: `DominantColor`/`Blur` 만 쓰는 사용자를 위한 별도 모듈 분리는 **불필요** (단일 모듈 유지).
+
+### Risk 6 — Coroutines: CPU-bound 작업 Dispatcher
+
+- Median Cut / Laplacian convolution은 **CPU-bound** 연산.
+- **결정: `Dispatchers.Default`** — CPU-bound 작업 본질에 맞는 선택. 기존 `suspendBytes`/`suspendWrite`는 실제 I/O이므로 IO Dispatcher가 맞음 — 본 분석 함수는 다름.
+- `suspend` 변형 전체 (`suspendDominantColors`, `suspendBlurScore`, `suspendReadExif`) 에 `Dispatchers.Default` 적용.
+- (단, `suspendReadExif`는 파일 읽기 포함이므로 `Dispatchers.IO` 유지)
+
+### Risk 7 — 입력 이미지 크기 / malformed EXIF
+
+- 제한 없는 이미지 입력 → OOM 위험. 100MP RAW 이미지(12000×8000px)에서 Laplacian 전체 픽셀 순회 → 수십 MB 힙 점유.
+- malformed/조작된 JPEG EXIF → metadata-extractor 내부 무한루프 또는 메모리 폭발 가능성 (버전별 패치 이력 있음).
+- **완화 (이번 PR)**:
+  - `readExif(bytes: ByteArray)`: `require(bytes.size <= 50 * 1024 * 1024)` 가드 (50MB 상한).
+  - metadata-extractor가 던지는 모든 예외 (`ImageProcessingException`, `IOException`, `Exception`) → catch → `ExifData.EMPTY` 반환.
+  - Blur/DominantColor: 사용자 책임 명시 (KDoc에 "큰 이미지는 호출 전 다운샘플링 권장"). 자동 상한은 YAGNI.
+- **완화 (후속)**: `maxPixels` 파라미터 추가 옵션.
+
+## 6. DoD (Definition of Done)
+
+```markdown
+## DoD
+
+### Code
+- [ ] `io.bluetape4k.images.analysis.DominantColor` data class 정의 (r/g/b/hex/population)
+- [ ] `DominantColorExtractor` sealed interface + `MedianCut` data class 구현
+- [ ] `MedianCutQuantizer` internal 객체 — 픽셀 샘플링 + 5-bit color cube + 박스 분할
+- [ ] `ImmutableImage.dominantColors(count, extractor)` extension
+- [ ] `ImmutableImage.dominantColor(extractor): DominantColor?` extension (빈 이미지 → null)
+- [ ] `ImmutableImage.suspendDominantColors(count, extractor)` extension (Dispatchers.Default)
+
+- [ ] `BlurScore` data class (score / threshold / isBlurry)
+- [ ] `ImmutableImage.blurScore(threshold)` — Laplacian variance
+- [ ] `ImmutableImage.isBlurry(threshold)` 단축
+- [ ] `ImmutableImage.suspendBlurScore(threshold)` (Dispatchers.Default)
+
+- [ ] `ExifData` data class (모든 필드 nullable + `hasGps` + `EMPTY`)
+- [ ] `readExif(ByteArray)` — 50MB 상한 가드, 모든 예외 → EMPTY 반환
+- [ ] `File.readExif()` / `Path.readExif()` / `InputStream.readExif()` extensions
+- [ ] `File.suspendReadExif()` / `Path.suspendReadExif()` extensions (Dispatchers.IO — 파일 I/O 포함)
+
+### Dependencies
+- [ ] `buildSrc/Libs.kt`에 `metadata_extractor` 버전/좌표 추가
+- [ ] `utils/images/build.gradle.kts`에 `implementation(Libs.metadata_extractor)` 추가
+
+### Tests (`utils/images/src/test/kotlin/io/bluetape4k/images/analysis/`)
+- [ ] `DominantColorExtractorTest` — homer.jpg/landscape.jpg/cafe.jpg 에서 색상 추출, count=1/3/5, edge case (단색)
+- [ ] `BlurDetectorTest` — sharp 이미지 vs blur 이미지 (Scrimage `ImmutableImage.blur()` 사용해 흐림 fixture 생성), threshold 검증
+- [ ] `ExifDataTest` — `src/test/resources/images/exif/` 에 GPS 포함 / 미포함 / 손상 이미지 3종 fixture, GPS decimal 변환, dateTimeOriginal 검증
+- [ ] `SuspendAnalysisTest` — `runTest`로 suspend 변형 호출 검증
+- [ ] 모든 테스트는 `AbstractImageTest` 상속, Kluent `shouldBe*` 사용
+- [ ] `companion object: KLoggingChannel()` 패턴 준수
+
+### Test Resources
+- [ ] `src/test/resources/images/exif/with-gps.jpg` — GPS EXIF 포함 샘플 (Wikimedia/CC0 출처 명시)
+- [ ] `src/test/resources/images/exif/no-exif.jpg` — EXIF 없는 이미지
+- [ ] `src/test/resources/images/exif/full-exif.jpg` — 카메라/렌즈 등 풍부한 EXIF
+- [ ] 각 fixture의 origin/license는 `src/test/resources/images/exif/README.md`에 명시
+
+### Documentation
+- [ ] `utils/images/README.md` — Image Analysis 섹션 추가 (영어)
+- [ ] `utils/images/README.ko.md` — 동일 섹션 (한국어)
+- [ ] Mermaid 다이어그램: 분석 파이프라인 (Image → Extractor → Result)
+- [ ] 모든 public API에 KDoc (Korean OK)
+
+### Follow-up Issues
+- [ ] OCR (Tesseract) — 별도 이슈 등록
+- [ ] Face Detection — 별도 이슈 등록
+- [ ] Image Classification (ONNX/TFLite) — 별도 이슈 등록 (장기)
+
+### Verification
+- [ ] `./gradlew :bluetape4k-images:test` 통과 (테스트 수 + duration 보고)
+- [ ] `./gradlew :bluetape4k-images:detekt` 통과
+- [ ] `oh-my-claudecode:code-reviewer` 실행 — HIGH/CRITICAL 0건
+```
+
+## 7. 초안 Task 목록 (복잡도 라벨)
+
+| # | Task | 복잡도 | 비고 |
+|---|------|--------|------|
+| T01 | `Libs.kt` + `build.gradle.kts` — metadata-extractor 추가 | **low** | 좌표/버전 추가 |
+| T02 | `DominantColor` data class + companion (`fromRgb`) | **low** | 단순 value class |
+| T03 | `MedianCutQuantizer` internal — 5-bit color cube + 박스 분할 알고리즘 | **high** | core algorithm — color-thief-java 참조 자체 구현 (~150 LoC). edge case (단색/투명) 핵심 |
+| T04 | `DominantColorExtractor` sealed interface + `MedianCut` data class | **medium** | T03 호출 wrapping |
+| T05 | `ImmutableImage.dominantColors/dominantColor/suspendDominantColors` extensions | **low** | T04 사용 |
+| T06 | `DominantColorExtractorTest` — fixtures, count 변화, edge case | **medium** | 테스트 데이터 검증 까다로움 |
+| T07 | `BlurScore` data class | **low** | |
+| T08 | `BlurDetector` internal — Laplacian variance grayscale 계산 | **medium** | 3x3 convolution + variance, boundary 처리 |
+| T09 | `ImmutableImage.blurScore/isBlurry/suspendBlurScore` extensions | **low** | |
+| T10 | `BlurDetectorTest` — sharp vs `image.blur()` 흐림 비교 | **medium** | fixture 동적 생성 가능 |
+| T11 | `ExifData` data class (17 필드 + `hasGps` + `EMPTY`) | **low** | |
+| T12 | `ExifData.kt` — metadata-extractor → `ExifData` 변환 (`readExif` 4 진입점) | **medium** | tag null 가드, GPS decimal 변환, LocalDateTime 변환 |
+| T13 | EXIF test fixtures 추가 (`with-gps.jpg`, `no-exif.jpg`, `full-exif.jpg`) + license README | **medium** | 외부 샘플 출처/라이선스 검증 필요 |
+| T14 | `ExifDataTest` — 3 fixture × 다양한 진입점 + `EMPTY` 케이스 | **medium** | |
+| T15 | `SuspendAnalysisTest` — runTest로 suspend 호출 검증 | **low** | |
+| T16 | `README.md` + `README.ko.md` — Image Analysis 섹션 + Mermaid | **medium** | 이중 언어 동기 |
+| T17 | KDoc 보완 (Korean) — 모든 public API | **low** | |
+| T18 | Follow-up issue 3건 등록 (OCR / Face / Classification) | **low** | `gh issue create` |
+| T19 | `code-reviewer` 실행 → HIGH/CRITICAL 해소 | **medium** | |
+| T20 | `:bluetape4k-images:test` 전수 통과 + 결과 보고 | **low** | CI 검증 |
+
+**총 20 tasks** — high 1, medium 9, low 10.
+
+## 8. 의문점 / 후속 결정
+
+1. **CPU-bound dispatcher**: **결정 완료** — `Dispatchers.Default` 사용 (분석 연산). `suspendReadExif`만 `Dispatchers.IO` (파일 I/O).
+2. **Blur 다운스케일 옵션**: 본 PR에서는 보류. 사용자 피드백 후 옵션 추가 검토.
+3. **DominantColor palette extraction with weighting**: 현재 `population` 단순 픽셀 수. HSV-aware weighting (saturation 보정) 은 v2.
+4. **EXIF 쓰기 (write/preserve)**: 본 PR scope 외. Scrimage가 자체 metadata preserve 지원하므로 별도 이슈로 분리.
+
+## 9. 참조
+
+- color-thief-java: https://github.com/SvenWoltmann/color-thief-java (MIT)
+- metadata-extractor: https://github.com/drewnoakes/metadata-extractor (Apache 2.0)
+- Pech-Pacheco "Diatom autofocusing in brightfield microscopy" (Laplacian variance)
+- 기존 패턴 참조: `utils/images/src/main/kotlin/io/bluetape4k/images/similarity/HistogramSimilarity.kt`

--- a/utils/images/README.ko.md
+++ b/utils/images/README.ko.md
@@ -191,6 +191,9 @@ classDiagram
 | `filters/CaptionFilterSupport.kt`                    | 캡션 필터                         |
 | `filters/PaddingSupport.kt`                          | 패딩 필터                         |
 | `filters/WatermarkFilterType.kt`                     | 워터마크 타입 (COVER/STAMP)         |
+| `analysis/DominantColor.kt`                          | 대표 색상 추출 — `dominantColor()`, `dominantColors()` |
+| `analysis/BlurDetector.kt`                           | 블러 감지 — `blurScore()`, `isBlurry()` |
+| `analysis/ExifData.kt`                               | EXIF 파싱 — `readExif()`, GPS PII 제거 |
 | `similarity/ImageSimilarity.kt`                      | 핵심 유사도: 픽셀 Δ, MSE, PSNR, 전역 SSIM, pHash |
 | `similarity/MssimSimilarity.kt`                      | MSSIM — 슬라이딩 윈도우 Gaussian SSIM            |
 | `similarity/HashSimilarity.kt`                       | aHash/dHash/wHash/phashOf (64/256/1024bit), HashDistance |
@@ -825,6 +828,90 @@ val asyncResult = image.suspendApplyFilters {
     flipHorizontal()
 }
 ```
+
+### 이미지 분석
+
+대표 색상 추출, 블러 감지, EXIF 메타데이터 파싱 — 순수 JVM, 네이티브 의존성 없음.
+
+#### 대표 색상 추출 (Median Cut)
+
+```kotlin
+import io.bluetape4k.images.analysis.*
+
+val image = ImmutableImage.loader().fromFile(File("photo.jpg"))
+
+// 상위 5개 대표 색상 추출
+val colors: List<DominantColor> = image.dominantColors(5)
+colors.forEach { c ->
+    println("${c.hex} (population=${c.population})")
+}
+
+// 단일 대표 색상 (완전 투명 이미지이면 null)
+val primary: DominantColor? = image.dominantColor()
+
+// 커스텀 추출기 — 흰색 픽셀 제외
+val extractor = DominantColorExtractor.medianCut(quality = 5, ignoreWhite = true)
+val filtered = image.dominantColors(3, extractor)
+
+// Suspend (CPU-bound → Dispatchers.Default)
+val asyncColors = image.suspendDominantColors(5)
+```
+
+#### 블러 감지 (Laplacian Variance)
+
+```kotlin
+import io.bluetape4k.images.analysis.*
+
+val image = ImmutableImage.loader().fromFile(File("photo.jpg"))
+
+// 블러 점수 — 높을수록 선명
+val result: BlurScore = image.blurScore(threshold = 100.0)
+println("score=${result.score}, isBlurry=${result.isBlurry}")
+
+// Boolean 단축형
+if (image.isBlurry()) {
+    println("이미지가 흐림 — 처리 건너뜀")
+}
+
+// Suspend
+val asyncScore: BlurScore = image.suspendBlurScore(threshold = 150.0)
+```
+
+#### EXIF 메타데이터
+
+```kotlin
+import io.bluetape4k.images.analysis.*
+
+// File에서 읽기
+val exif: ExifData = File("photo.jpg").readExif()
+println("제조사=${exif.cameraMake}, 모델=${exif.cameraModel}")
+println("ISO=${exif.iso}, 조리개=f/${exif.aperture}")
+println("촬영시각=${exif.dateTimeOriginal}")
+
+// GPS — PII 제거 헬퍼
+if (exif.hasGps) {
+    val safe = exif.withoutGps()  // lat/lon/altitude 제거
+    println("${safe.cameraMake}")
+}
+
+// ByteArray에서 읽기 (최대 50MB)
+val exifFromBytes: ExifData = readExif(bytes)
+
+// Path에서 읽기 (jar/zip 내부 경로 지원)
+val exifFromPath: ExifData = Paths.get("photo.jpg").readExif()
+
+// Suspend
+val asyncExif: ExifData = File("photo.jpg").suspendReadExif()
+```
+
+#### 주요 파일
+
+| 파일                                     | 설명                                              |
+|------------------------------------------|--------------------------------------------------|
+| `analysis/DominantColor.kt`             | `DominantColor` data class + `DominantColorExtractor` sealed interface |
+| `analysis/MedianCutQuantizer.kt`        | Median Cut quantization 엔진 (5-bit/channel)     |
+| `analysis/BlurDetector.kt`              | `BlurScore` + Laplacian variance 계산             |
+| `analysis/ExifData.kt`                  | `ExifData` 모델 + `readExif()` 진입점            |
 
 ## 의존성 추가
 

--- a/utils/images/README.md
+++ b/utils/images/README.md
@@ -190,6 +190,9 @@ classDiagram
 | `filters/CaptionFilterSupport.kt`              | Caption filter                           |
 | `filters/PaddingSupport.kt`                    | Padding filter                           |
 | `filters/WatermarkFilterType.kt`               | Watermark type (COVER/STAMP)             |
+| `analysis/DominantColor.kt`                    | Dominant color extraction (MedianCut) — `dominantColor()`, `dominantColors()` |
+| `analysis/BlurDetector.kt`                     | Blur detection via Laplacian variance — `blurScore()`, `isBlurry()` |
+| `analysis/ExifData.kt`                         | EXIF metadata parsing — `readExif()`, GPS PII removal |
 | `similarity/ImageSimilarity.kt`                | Core similarity: pixel Δ, MSE, PSNR, global SSIM, pHash |
 | `similarity/MssimSimilarity.kt`                | MSSIM — sliding-window Gaussian SSIM                    |
 | `similarity/HashSimilarity.kt`                 | aHash/dHash/wHash/phashOf (64/256/1024bit), HashDistance |
@@ -799,6 +802,134 @@ val asyncResult = image.suspendApplyFilters {
     flipHorizontal()
 }
 ```
+
+### Image Analysis
+
+Dominant color extraction, blur detection, and EXIF metadata parsing — all pure JVM, no native dependencies.
+
+```mermaid
+classDiagram
+    class DominantColor {
+        +r: Int
+        +g: Int
+        +b: Int
+        +population: Int
+        +hex: String
+        +toAwtColor() Color
+        +fromRgb(rgb, population) DominantColor
+    }
+    class DominantColorExtractor {
+        <<sealed interface>>
+        +extract(image, count) List~DominantColor~
+    }
+    class MedianCut {
+        +quality: Int
+        +ignoreWhite: Boolean
+        +extract(image, count) List~DominantColor~
+    }
+    class BlurScore {
+        +score: Double
+        +threshold: Double
+        +isBlurry: Boolean
+    }
+    class ExifData {
+        +gpsLatitude: Double?
+        +gpsLongitude: Double?
+        +dateTimeOriginal: LocalDateTime?
+        +cameraMake: String?
+        +iso: Int?
+        +hasGps: Boolean
+        +withoutGps() ExifData
+    }
+
+    DominantColorExtractor <|.. MedianCut
+    DominantColor <-- MedianCut : produces
+    ImmutableImage --> DominantColor : dominantColors()
+    ImmutableImage --> BlurScore : blurScore()
+    ExifData <-- File : readExif()
+    ExifData <-- Path : readExif()
+    ExifData <-- InputStream : readExif()
+```
+
+#### Dominant Color Extraction (Median Cut)
+
+```kotlin
+import io.bluetape4k.images.analysis.*
+
+val image = ImmutableImage.loader().fromFile(File("photo.jpg"))
+
+// Extract top 5 dominant colors
+val colors: List<DominantColor> = image.dominantColors(5)
+colors.forEach { c ->
+    println("${c.hex} (population=${c.population})")
+}
+
+// Extract single dominant color (null if image is fully transparent)
+val primary: DominantColor? = image.dominantColor()
+
+// Custom extractor — exclude near-white pixels
+val extractor = DominantColorExtractor.medianCut(quality = 5, ignoreWhite = true)
+val filtered = image.dominantColors(3, extractor)
+
+// Suspend (CPU-bound → Dispatchers.Default)
+val asyncColors = image.suspendDominantColors(5)
+```
+
+#### Blur Detection (Laplacian Variance)
+
+```kotlin
+import io.bluetape4k.images.analysis.*
+
+val image = ImmutableImage.loader().fromFile(File("photo.jpg"))
+
+// Blur score — higher = sharper
+val result: BlurScore = image.blurScore(threshold = 100.0)
+println("score=${result.score}, isBlurry=${result.isBlurry}")
+
+// Boolean shorthand
+if (image.isBlurry()) {
+    println("Image is blurry — skip processing")
+}
+
+// Suspend
+val asyncScore: BlurScore = image.suspendBlurScore(threshold = 150.0)
+```
+
+#### EXIF Metadata
+
+```kotlin
+import io.bluetape4k.images.analysis.*
+
+// From File
+val exif: ExifData = File("photo.jpg").readExif()
+println("make=${exif.cameraMake}, model=${exif.cameraModel}")
+println("iso=${exif.iso}, aperture=f/${exif.aperture}")
+println("taken=${exif.dateTimeOriginal}")
+
+// GPS — with PII-removal helper
+if (exif.hasGps) {
+    val safe = exif.withoutGps()  // removes lat/lon/altitude
+    println("${safe.cameraMake}")
+}
+
+// From ByteArray (max 50 MB)
+val exifFromBytes: ExifData = readExif(bytes)
+
+// From Path (jar/zip-safe)
+val exifFromPath: ExifData = Paths.get("photo.jpg").readExif()
+
+// Suspend
+val asyncExif: ExifData = File("photo.jpg").suspendReadExif()
+```
+
+#### Key Files
+
+| File                                     | Description                                      |
+|------------------------------------------|--------------------------------------------------|
+| `analysis/DominantColor.kt`             | `DominantColor` data class + `DominantColorExtractor` sealed interface |
+| `analysis/MedianCutQuantizer.kt`        | Median Cut quantization engine (5-bit/channel)  |
+| `analysis/BlurDetector.kt`              | `BlurScore` + Laplacian variance computation     |
+| `analysis/ExifData.kt`                  | `ExifData` model + `readExif()` entry points     |
 
 ## Dependency
 

--- a/utils/images/build.gradle.kts
+++ b/utils/images/build.gradle.kts
@@ -13,6 +13,9 @@ dependencies {
     api(Libs.scrimage_filters)
     implementation(Libs.scrimage_webp)
 
+    // EXIF metadata (required runtime dependency)
+    implementation(Libs.metadata_extractor)
+
     // Coroutines
     implementation(project(":bluetape4k-coroutines"))
     implementation(Libs.kotlinx_coroutines_core)

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/analysis/BlurDetector.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/analysis/BlurDetector.kt
@@ -1,0 +1,98 @@
+package io.bluetape4k.images.analysis
+
+import com.sksamuel.scrimage.ImmutableImage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * 이미지 블러 감지 결과.
+ *
+ * @property score Laplacian variance 점수. 클수록 선명하고 작을수록 흐림.
+ * @property threshold 블러 판정 기준값.
+ * @property isBlurry [score]가 [threshold]보다 작으면 true (흐린 이미지).
+ */
+data class BlurScore(
+    val score: Double,
+    val threshold: Double,
+) {
+    val isBlurry: Boolean get() = score < threshold
+
+    companion object {
+        /** blurScore() 기본 threshold 값 (~640x480 이미지 기준). 해상도에 따라 캘리브레이션 필요. */
+        const val DEFAULT_THRESHOLD = 100.0
+    }
+}
+
+/**
+ * Laplacian variance 기반 블러 점수를 계산한다.
+ *
+ * Laplacian 커널 `[[0,1,0],[1,-4,1],[0,1,0]]`을 적용하고 variance를 계산한다.
+ * score가 높을수록 선명하고, 낮을수록 흐린 이미지이다.
+ *
+ * **주의**: threshold=100.0은 ~640x480 기준. 고해상도 이미지는 더 큰 threshold 필요.
+ * 같은 도메인 이미지 간 상대 비교용으로 사용 권장.
+ * 큰 이미지 다수 처리 시 호출 전 다운샘플링 권장.
+ *
+ * @param threshold 블러 판정 기준값. 기본 [BlurScore.DEFAULT_THRESHOLD].
+ * @throws IllegalArgumentException 이미지가 3x3보다 작을 경우.
+ */
+fun ImmutableImage.blurScore(threshold: Double = BlurScore.DEFAULT_THRESHOLD): BlurScore {
+    require(width >= 3 && height >= 3) {
+        "블러 감지를 위한 최소 이미지 크기는 3×3입니다. 현재: ${width}×${height}"
+    }
+    val score = computeLaplacianVariance(this)
+    return BlurScore(score, threshold)
+}
+
+/**
+ * 이미지가 흐린지 여부를 반환한다.
+ *
+ * @param threshold 블러 판정 기준값. 기본 [BlurScore.DEFAULT_THRESHOLD].
+ */
+fun ImmutableImage.isBlurry(threshold: Double = BlurScore.DEFAULT_THRESHOLD): Boolean =
+    blurScore(threshold).isBlurry
+
+/**
+ * 블러 점수를 비동기로 계산한다.
+ *
+ * CPU-bound 연산이므로 [Dispatchers.Default]를 사용한다.
+ */
+suspend fun ImmutableImage.suspendBlurScore(threshold: Double = BlurScore.DEFAULT_THRESHOLD): BlurScore =
+    withContext(Dispatchers.Default) { blurScore(threshold) }
+
+/**
+ * Laplacian variance를 계산하는 내부 함수.
+ *
+ * 1. grayscale 변환 (Rec. 601 luminance)
+ * 2. Laplacian 3×3 convolution
+ * 3. variance 계산 (boundary 1px 제외)
+ */
+internal fun computeLaplacianVariance(image: ImmutableImage): Double {
+    val w = image.width
+    val h = image.height
+    val pixels = image.pixels()
+
+    // grayscale 값 2D 배열 생성 (row-major)
+    val gray = DoubleArray(w * h) { idx ->
+        val p = pixels[idx]
+        0.299 * p.red() + 0.587 * p.green() + 0.114 * p.blue()
+    }
+
+    // Laplacian convolution — boundary 1px 제외
+    val laplacian = mutableListOf<Double>()
+    for (y in 1 until h - 1) {
+        for (x in 1 until w - 1) {
+            val center = gray[y * w + x]
+            val top    = gray[(y - 1) * w + x]
+            val bottom = gray[(y + 1) * w + x]
+            val left   = gray[y * w + (x - 1)]
+            val right  = gray[y * w + (x + 1)]
+            laplacian.add(top + bottom + left + right - 4.0 * center)
+        }
+    }
+
+    if (laplacian.isEmpty()) return 0.0
+
+    val mean = laplacian.average()
+    return laplacian.sumOf { (it - mean) * (it - mean) } / laplacian.size
+}

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/analysis/BlurDetector.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/analysis/BlurDetector.kt
@@ -78,21 +78,21 @@ internal fun computeLaplacianVariance(image: ImmutableImage): Double {
         0.299 * p.red() + 0.587 * p.green() + 0.114 * p.blue()
     }
 
-    // Laplacian convolution — boundary 1px 제외
-    val laplacian = mutableListOf<Double>()
+    // Laplacian convolution + Welford's online variance — boundary 1px 제외
+    // mutableList<Double> 대신 single-pass로 heap 할당 없이 분산 계산
+    var count = 0L
+    var mean = 0.0
+    var m2 = 0.0
     for (y in 1 until h - 1) {
         for (x in 1 until w - 1) {
             val center = gray[y * w + x]
-            val top    = gray[(y - 1) * w + x]
-            val bottom = gray[(y + 1) * w + x]
-            val left   = gray[y * w + (x - 1)]
-            val right  = gray[y * w + (x + 1)]
-            laplacian.add(top + bottom + left + right - 4.0 * center)
+            val v = gray[(y - 1) * w + x] + gray[(y + 1) * w + x] +
+                    gray[y * w + (x - 1)] + gray[y * w + (x + 1)] - 4.0 * center
+            count++
+            val delta = v - mean
+            mean += delta / count
+            m2 += delta * (v - mean)
         }
     }
-
-    if (laplacian.isEmpty()) return 0.0
-
-    val mean = laplacian.average()
-    return laplacian.sumOf { (it - mean) * (it - mean) } / laplacian.size
+    return if (count > 0) m2 / count else 0.0
 }

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/analysis/DominantColor.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/analysis/DominantColor.kt
@@ -1,0 +1,130 @@
+package io.bluetape4k.images.analysis
+
+import com.sksamuel.scrimage.ImmutableImage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * 이미지에서 추출된 대표 색상.
+ *
+ * @property r 빨간색 채널 (0..255)
+ * @property g 녹색 채널 (0..255)
+ * @property b 파란색 채널 (0..255)
+ * @property population 이 색상이 속한 Median Cut 박스의 샘플 픽셀 수.
+ *   [quality] 파라미터로 샘플링된 값이므로 원본 픽셀 수와 다를 수 있음.
+ *   값이 클수록 해당 색상의 상대적 비중이 높음.
+ */
+data class DominantColor(
+    val r: Int,
+    val g: Int,
+    val b: Int,
+    val population: Int,
+) {
+    init {
+        require(r in 0..255) { "r은 0..255 범위여야 합니다. 입력: $r" }
+        require(g in 0..255) { "g은 0..255 범위여야 합니다. 입력: $g" }
+        require(b in 0..255) { "b은 0..255 범위여야 합니다. 입력: $b" }
+        require(population >= 0) { "population은 0 이상이어야 합니다. 입력: $population" }
+    }
+
+    /** `#rrggbb` 형식의 16진수 색상 코드 */
+    val hex: String = "#%02x%02x%02x".format(r, g, b)
+
+    /** java.awt.Color 변환 */
+    fun toAwtColor(): java.awt.Color = java.awt.Color(r, g, b)
+
+    companion object {
+        /**
+         * RGB 정수값(0xRRGGBB)으로부터 [DominantColor]를 생성한다.
+         */
+        fun fromRgb(rgb: Int, population: Int = 1): DominantColor =
+            DominantColor(
+                r = (rgb shr 16) and 0xFF,
+                g = (rgb shr 8) and 0xFF,
+                b = rgb and 0xFF,
+                population = population,
+            )
+    }
+}
+
+/**
+ * 이미지에서 대표 색상을 추출하는 전략 인터페이스.
+ */
+sealed interface DominantColorExtractor {
+
+    /**
+     * [image]에서 [count]개의 대표 색상을 추출한다.
+     *
+     * @param image 분석할 이미지
+     * @param count 추출할 색상 수 (결과는 이 값보다 적을 수 있음 — 단색 이미지 등)
+     * @return population 내림차순 정렬된 색상 목록
+     */
+    fun extract(image: ImmutableImage, count: Int): List<DominantColor>
+
+    /**
+     * Median Cut quantization 기반 추출 전략.
+     *
+     * color-thief-java (MIT) 알고리즘을 Kotlin으로 자체 구현.
+     * 5-bit/channel (32 levels) RGB 색공간 사용.
+     *
+     * @property quality 픽셀 샘플링 간격 (1=모든 픽셀, 10=10픽셀당 1개). 범위: 1..30.
+     * @property ignoreWhite true이면 R>250 && G>250 && B>250인 픽셀 제외.
+     */
+    data class MedianCut(
+        val quality: Int = 10,
+        val ignoreWhite: Boolean = false,
+    ) : DominantColorExtractor {
+        init {
+            require(quality in 1..30) { "quality는 1..30 범위여야 합니다. 입력: $quality" }
+        }
+
+        override fun extract(image: ImmutableImage, count: Int): List<DominantColor> =
+            MedianCutQuantizer.quantize(image, count, quality, ignoreWhite)
+    }
+
+    companion object {
+        /** 기본 MedianCut 추출기를 생성한다. */
+        fun medianCut(quality: Int = 10, ignoreWhite: Boolean = false): DominantColorExtractor =
+            MedianCut(quality, ignoreWhite)
+    }
+}
+
+/**
+ * 이미지에서 [count]개의 대표 색상을 추출한다.
+ *
+ * @param count 추출할 색상 수. 결과 리스트 크기는 이 값 이하일 수 있음 (단색 이미지 등).
+ * @param extractor 추출 전략. 기본값은 Median Cut.
+ * @return population 내림차순 정렬된 색상 목록. 완전 투명 이미지의 경우 빈 리스트.
+ */
+fun ImmutableImage.dominantColors(
+    count: Int = 5,
+    extractor: DominantColorExtractor = DominantColorExtractor.medianCut(),
+): List<DominantColor> {
+    require(count >= 1) { "count는 1 이상이어야 합니다. 입력: $count" }
+    return extractor.extract(this, count)
+}
+
+/**
+ * 이미지에서 가장 지배적인 색상 1개를 추출한다.
+ *
+ * 완전 투명 이미지 등 색상 추출이 불가능한 경우 null을 반환한다.
+ *
+ * @param extractor 추출 전략. 기본값은 Median Cut.
+ * @return 가장 대표적인 색상, 또는 추출 불가 시 null.
+ */
+fun ImmutableImage.dominantColor(
+    extractor: DominantColorExtractor = DominantColorExtractor.medianCut(),
+): DominantColor? = dominantColors(1, extractor).firstOrNull()
+
+/**
+ * 이미지에서 [count]개의 대표 색상을 비동기로 추출한다.
+ *
+ * CPU-bound 연산이므로 [Dispatchers.Default]를 사용한다.
+ *
+ * @param count 추출할 색상 수.
+ * @param extractor 추출 전략.
+ */
+suspend fun ImmutableImage.suspendDominantColors(
+    count: Int = 5,
+    extractor: DominantColorExtractor = DominantColorExtractor.medianCut(),
+): List<DominantColor> = withContext(Dispatchers.Default) { dominantColors(count, extractor) }

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/analysis/DominantColor.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/analysis/DominantColor.kt
@@ -22,8 +22,8 @@ data class DominantColor(
 ) {
     init {
         require(r in 0..255) { "r은 0..255 범위여야 합니다. 입력: $r" }
-        require(g in 0..255) { "g은 0..255 범위여야 합니다. 입력: $g" }
-        require(b in 0..255) { "b은 0..255 범위여야 합니다. 입력: $b" }
+        require(g in 0..255) { "g는 0..255 범위여야 합니다. 입력: $g" }
+        require(b in 0..255) { "b는 0..255 범위여야 합니다. 입력: $b" }
         require(population >= 0) { "population은 0 이상이어야 합니다. 입력: $population" }
     }
 

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/analysis/ExifData.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/analysis/ExifData.kt
@@ -1,0 +1,229 @@
+package io.bluetape4k.images.analysis
+
+import com.drew.imaging.ImageMetadataReader
+import com.drew.metadata.Metadata
+import com.drew.metadata.exif.ExifIFD0Directory
+import com.drew.metadata.exif.ExifSubIFDDirectory
+import com.drew.metadata.exif.GpsDirectory
+import com.drew.metadata.jpeg.JpegDirectory
+import io.bluetape4k.logging.KotlinLogging
+import io.bluetape4k.logging.debug
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * 이미지 파일에서 추출된 EXIF 메타데이터.
+ *
+ * 모든 필드는 nullable이다. EXIF 정보가 없거나 지원되지 않는 포맷의 경우 null이 된다.
+ *
+ * **주의**: [dateTimeOriginal]은 timezone 정보가 없다.
+ * EXIF DateTimeOriginal 태그는 카메라 현지 시각(wall-clock)을 기록하며 timezone을 포함하지 않는다.
+ * UTC 변환이 필요하면 GPS 좌표 또는 카메라 설정을 기반으로 호출자가 직접 수행해야 한다.
+ *
+ * **GPS 주의**: [gpsLatitude]와 [gpsLongitude]는 개인 위치 정보(PII)에 해당한다.
+ * 외부 API에 노출하기 전 명시적 동의 또는 제거가 필요하다. [withoutGps]를 사용하라.
+ */
+data class ExifData(
+    /** GPS 위도 (decimal degrees, 북위 양수/남위 음수) */
+    val gpsLatitude: Double? = null,
+    /** GPS 경도 (decimal degrees, 동경 양수/서경 음수) */
+    val gpsLongitude: Double? = null,
+    /** GPS 고도 (미터) */
+    val gpsAltitude: Double? = null,
+    /** 촬영 일시 (EXIF DateTimeOriginal — timezone 정보 없는 wall-clock) */
+    val dateTimeOriginal: LocalDateTime? = null,
+    /** 카메라 제조사 (e.g. "Canon") */
+    val cameraMake: String? = null,
+    /** 카메라 모델 (e.g. "EOS R5") */
+    val cameraModel: String? = null,
+    /** 렌즈 모델 */
+    val lensModel: String? = null,
+    /** ISO 감도 */
+    val iso: Int? = null,
+    /** 셔터 스피드 (e.g. "1/250") */
+    val shutterSpeed: String? = null,
+    /** 조리개 f-number (e.g. 2.8) */
+    val aperture: Double? = null,
+    /** 초점 거리 (mm) */
+    val focalLength: Double? = null,
+    /** 35mm 환산 초점 거리 */
+    val focalLength35mm: Int? = null,
+    /** EXIF 방향 (1..8) */
+    val orientation: Int? = null,
+    /** 이미지 너비 (px) */
+    val width: Int? = null,
+    /** 이미지 높이 (px) */
+    val height: Int? = null,
+    /** 플래시 발광 여부 */
+    val flashFired: Boolean? = null,
+    /** 화이트 밸런스 설명 */
+    val whiteBalance: String? = null,
+) {
+    /** GPS 좌표가 존재하면 true */
+    val hasGps: Boolean get() = gpsLatitude != null && gpsLongitude != null
+
+    /**
+     * GPS 좌표를 제거한 복사본을 반환한다 (PII 제거).
+     */
+    fun withoutGps(): ExifData = copy(
+        gpsLatitude = null,
+        gpsLongitude = null,
+        gpsAltitude = null,
+    )
+
+    companion object {
+        /** EXIF 정보가 없거나 파싱 실패 시 반환되는 빈 인스턴스 */
+        val EMPTY = ExifData()
+    }
+}
+
+private val log = KotlinLogging.logger(ExifData::class)
+
+private val EXIF_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy:MM:dd HH:mm:ss")
+
+/**
+ * ByteArray에서 EXIF 메타데이터를 읽는다.
+ *
+ * @param bytes 이미지 바이트 배열. 50MB 초과 시 [IllegalArgumentException].
+ * @return EXIF 데이터. EXIF 없거나 파싱 실패 시 [ExifData.EMPTY].
+ */
+fun readExif(bytes: ByteArray): ExifData {
+    require(bytes.size <= 50 * 1024 * 1024) {
+        "이미지 바이트 배열이 50MB를 초과합니다: ${bytes.size} bytes"
+    }
+    return runCatching {
+        ImageMetadataReader.readMetadata(ByteArrayInputStream(bytes)).toExifData()
+    }.getOrElse { e ->
+        log.debug(e) { "EXIF 파싱 실패 (ByteArray ${bytes.size} bytes)" }
+        ExifData.EMPTY
+    }
+}
+
+/**
+ * [File]에서 EXIF 메타데이터를 읽는다.
+ *
+ * **주의**: 신뢰할 수 없는 경로를 직접 전달하지 말 것. 사용자 입력 경로는 정규화 필요.
+ *
+ * @return EXIF 데이터. EXIF 없거나 파싱 실패 시 [ExifData.EMPTY].
+ */
+fun File.readExif(): ExifData =
+    runCatching {
+        ImageMetadataReader.readMetadata(this).toExifData()
+    }.getOrElse { e ->
+        log.debug(e) { "EXIF 파싱 실패: $absolutePath" }
+        ExifData.EMPTY
+    }
+
+/**
+ * [Path]에서 EXIF 메타데이터를 읽는다.
+ *
+ * jar/zip 내부 경로도 지원하기 위해 [Files.newInputStream]을 사용한다.
+ *
+ * @return EXIF 데이터. EXIF 없거나 파싱 실패 시 [ExifData.EMPTY].
+ */
+fun Path.readExif(): ExifData =
+    runCatching {
+        Files.newInputStream(this).use { it.readExif() }
+    }.getOrElse { e ->
+        log.debug(e) { "EXIF 파싱 실패: $this" }
+        ExifData.EMPTY
+    }
+
+/**
+ * [InputStream]에서 EXIF 메타데이터를 읽는다.
+ *
+ * 스트림 close는 호출자가 관리한다.
+ *
+ * @return EXIF 데이터. EXIF 없거나 파싱 실패 시 [ExifData.EMPTY].
+ */
+fun InputStream.readExif(): ExifData =
+    runCatching {
+        ImageMetadataReader.readMetadata(this).toExifData()
+    }.getOrElse { e ->
+        log.debug(e) { "EXIF 파싱 실패 (InputStream)" }
+        ExifData.EMPTY
+    }
+
+/**
+ * [File]에서 EXIF 메타데이터를 비동기로 읽는다.
+ *
+ * 파일 I/O를 포함하므로 [Dispatchers.IO]를 사용한다.
+ */
+suspend fun File.suspendReadExif(): ExifData =
+    withContext(Dispatchers.IO) { readExif() }
+
+/**
+ * [Path]에서 EXIF 메타데이터를 비동기로 읽는다.
+ *
+ * 파일 I/O를 포함하므로 [Dispatchers.IO]를 사용한다.
+ */
+suspend fun Path.suspendReadExif(): ExifData =
+    withContext(Dispatchers.IO) { readExif() }
+
+// ─── 내부 변환 ───────────────────────────────────────────────────────────────
+
+private fun Metadata.toExifData(): ExifData {
+    val ifd0 = getFirstDirectoryOfType(ExifIFD0Directory::class.java)
+    val subIfd = getFirstDirectoryOfType(ExifSubIFDDirectory::class.java)
+    val gps = getFirstDirectoryOfType(GpsDirectory::class.java)
+    val jpeg = getFirstDirectoryOfType(JpegDirectory::class.java)
+
+    val geoLocation = runCatching { gps?.geoLocation }.getOrNull()
+
+    return ExifData(
+        gpsLatitude = geoLocation?.latitude,
+        gpsLongitude = geoLocation?.longitude,
+        gpsAltitude = runCatching {
+            gps?.getRational(GpsDirectory.TAG_ALTITUDE)?.toDouble()
+        }.getOrNull(),
+        dateTimeOriginal = runCatching {
+            subIfd?.getString(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL)
+                ?.let { LocalDateTime.parse(it.trim(), EXIF_DATE_FORMATTER) }
+        }.getOrNull(),
+        cameraMake = runCatching { ifd0?.getString(ExifIFD0Directory.TAG_MAKE)?.trim() }.getOrNull(),
+        cameraModel = runCatching { ifd0?.getString(ExifIFD0Directory.TAG_MODEL)?.trim() }.getOrNull(),
+        lensModel = runCatching {
+            subIfd?.getString(ExifSubIFDDirectory.TAG_LENS_MODEL)?.trim()
+        }.getOrNull(),
+        iso = runCatching {
+            subIfd?.getInteger(ExifSubIFDDirectory.TAG_ISO_EQUIVALENT)
+        }.getOrNull(),
+        shutterSpeed = runCatching {
+            subIfd?.getRational(ExifSubIFDDirectory.TAG_EXPOSURE_TIME)
+                ?.let { "${it.numerator}/${it.denominator}" }
+        }.getOrNull(),
+        aperture = runCatching {
+            subIfd?.getRational(ExifSubIFDDirectory.TAG_FNUMBER)?.toDouble()
+        }.getOrNull(),
+        focalLength = runCatching {
+            subIfd?.getRational(ExifSubIFDDirectory.TAG_FOCAL_LENGTH)?.toDouble()
+        }.getOrNull(),
+        focalLength35mm = runCatching {
+            subIfd?.getInteger(ExifSubIFDDirectory.TAG_35MM_FILM_EQUIV_FOCAL_LENGTH)
+        }.getOrNull(),
+        orientation = runCatching {
+            ifd0?.getInteger(ExifIFD0Directory.TAG_ORIENTATION)
+        }.getOrNull(),
+        width = runCatching {
+            jpeg?.getInteger(JpegDirectory.TAG_IMAGE_WIDTH)
+                ?: subIfd?.getInteger(ExifSubIFDDirectory.TAG_EXIF_IMAGE_WIDTH)
+        }.getOrNull(),
+        height = runCatching {
+            jpeg?.getInteger(JpegDirectory.TAG_IMAGE_HEIGHT)
+                ?: subIfd?.getInteger(ExifSubIFDDirectory.TAG_EXIF_IMAGE_HEIGHT)
+        }.getOrNull(),
+        flashFired = runCatching {
+            subIfd?.getInteger(ExifSubIFDDirectory.TAG_FLASH)?.let { it and 0x1 == 1 }
+        }.getOrNull(),
+        whiteBalance = runCatching {
+            subIfd?.getDescription(ExifSubIFDDirectory.TAG_WHITE_BALANCE)?.trim()
+        }.getOrNull(),
+    )
+}

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/analysis/MedianCutQuantizer.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/analysis/MedianCutQuantizer.kt
@@ -1,0 +1,247 @@
+package io.bluetape4k.images.analysis
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.logging.KotlinLogging
+
+/**
+ * Median Cut quantization 알고리즘으로 이미지의 대표 색상을 추출한다.
+ *
+ * color-thief-java (MIT) 알고리즘을 Kotlin으로 자체 구현.
+ * 5-bit/channel (32 levels) RGB 색공간을 사용하여 메모리를 절약한다.
+ */
+internal object MedianCutQuantizer {
+
+    private val log = KotlinLogging.logger {}
+
+    private const val SIGNAL_BITS = 5
+    private const val RIGHT_SHIFT = 8 - SIGNAL_BITS  // = 3
+    private const val MULT = 1 shl RIGHT_SHIFT        // = 8
+    private const val HIST_SIZE = 1 shl (3 * SIGNAL_BITS) // 32^3 = 32768
+
+    /**
+     * 이미지에서 [count]개의 대표 색상을 추출한다.
+     *
+     * @param image 분석할 이미지
+     * @param count 추출할 색상 수 (결과는 이 수보다 적을 수 있음 — 단색 이미지 등)
+     * @param quality 픽셀 샘플링 간격 (1=모든 픽셀)
+     * @param ignoreWhite true이면 흰색에 가까운 픽셀 제외
+     * @return population 내림차순 정렬된 DominantColor 목록 (빈 이미지면 emptyList)
+     */
+    fun quantize(
+        image: ImmutableImage,
+        count: Int,
+        quality: Int = 10,
+        ignoreWhite: Boolean = false,
+    ): List<DominantColor> {
+        val pixels = collectPixels(image, quality, ignoreWhite)
+        if (pixels.isEmpty()) return emptyList()
+
+        val histogram = buildHistogram(pixels)
+        val boxes = mutableListOf(buildInitialBox(histogram))
+
+        // count개 박스가 될 때까지 분할
+        repeat(count - 1) {
+            val boxToSplit = boxes.maxByOrNull { it.count }
+                ?.takeIf { it.count > 1 && it.volume > 0 }
+                ?: return@repeat
+            boxes.remove(boxToSplit)
+            val (box1, box2) = splitBox(boxToSplit, histogram)
+            boxes.add(box1)
+            boxes.add(box2)
+        }
+
+        return boxes
+            .map { averageColor(it, histogram) }
+            .sortedByDescending { it.population }
+    }
+
+    /** 이미지에서 유효한 픽셀의 (r,g,b) 목록을 수집한다 (5-bit 양자화). */
+    private fun collectPixels(
+        image: ImmutableImage,
+        quality: Int,
+        ignoreWhite: Boolean,
+    ): List<IntArray> {
+        val pixelArray = image.pixels()
+        val result = mutableListOf<IntArray>()
+        var i = 0
+        while (i < pixelArray.size) {
+            val pixel = pixelArray[i]
+            val alpha = pixel.alpha()
+            val r = pixel.red()
+            val g = pixel.green()
+            val b = pixel.blue()
+
+            if (alpha > 125) {
+                if (!ignoreWhite || !(r > 250 && g > 250 && b > 250)) {
+                    result.add(intArrayOf(r, g, b))
+                }
+            }
+            i += quality
+        }
+        return result
+    }
+
+    /** 5-bit 색공간 히스토그램을 빌드한다. index → pixel count */
+    private fun buildHistogram(pixels: List<IntArray>): IntArray {
+        val hist = IntArray(HIST_SIZE)
+        for ((r, g, b) in pixels) {
+            val index = colorIndex(r, g, b)
+            hist[index]++
+        }
+        return hist
+    }
+
+    private fun colorIndex(r: Int, g: Int, b: Int): Int =
+        ((r shr RIGHT_SHIFT) shl (2 * SIGNAL_BITS)) or
+            ((g shr RIGHT_SHIFT) shl SIGNAL_BITS) or
+            (b shr RIGHT_SHIFT)
+
+    /** 히스토그램 전체를 포괄하는 초기 박스를 생성한다. */
+    private fun buildInitialBox(histogram: IntArray): ColorBox {
+        var rMin = 32; var rMax = 0
+        var gMin = 32; var gMax = 0
+        var bMin = 32; var bMax = 0
+        var count = 0
+
+        for (i in 0 until HIST_SIZE) {
+            if (histogram[i] == 0) continue
+            val r = (i shr (2 * SIGNAL_BITS)) and 0x1F
+            val g = (i shr SIGNAL_BITS) and 0x1F
+            val b = i and 0x1F
+            count += histogram[i]
+            if (r < rMin) rMin = r; if (r > rMax) rMax = r
+            if (g < gMin) gMin = g; if (g > gMax) gMax = g
+            if (b < bMin) bMin = b; if (b > bMax) bMax = b
+        }
+
+        return ColorBox(rMin, rMax, gMin, gMax, bMin, bMax, count)
+    }
+
+    /** 박스를 가장 긴 축의 중앙에서 분할한다. */
+    private fun splitBox(box: ColorBox, histogram: IntArray): Pair<ColorBox, ColorBox> {
+        val rRange = box.rMax - box.rMin
+        val gRange = box.gMax - box.gMin
+        val bRange = box.bMax - box.bMin
+
+        return when {
+            rRange >= gRange && rRange >= bRange -> splitAlongAxis(box, histogram, Axis.R)
+            gRange >= bRange -> splitAlongAxis(box, histogram, Axis.G)
+            else -> splitAlongAxis(box, histogram, Axis.B)
+        }
+    }
+
+    private enum class Axis { R, G, B }
+
+    private fun splitAlongAxis(box: ColorBox, histogram: IntArray, axis: Axis): Pair<ColorBox, ColorBox> {
+        val lookAheadSum = IntArray(32)
+        var sum = 0
+
+        val (start, end) = when (axis) {
+            Axis.R -> box.rMin to box.rMax
+            Axis.G -> box.gMin to box.gMax
+            Axis.B -> box.bMin to box.bMax
+        }
+
+        for (val_ in start..end) {
+            val dimSum = countInSlice(box, histogram, axis, val_)
+            sum += dimSum
+            lookAheadSum[val_] = sum
+        }
+
+        val total = sum
+        val half = total / 2
+
+        var splitAt = start
+        var cumSum = 0
+        for (val_ in start..end) {
+            cumSum = lookAheadSum[val_]
+            if (cumSum >= half) {
+                splitAt = val_
+                break
+            }
+        }
+
+        // 분할점이 start와 같으면 최소 1 이동
+        if (splitAt == start) splitAt = minOf(start + 1, end)
+
+        val box1 = when (axis) {
+            Axis.R -> box.copy(rMax = splitAt)
+            Axis.G -> box.copy(gMax = splitAt)
+            Axis.B -> box.copy(bMax = splitAt)
+        }
+        val box2 = when (axis) {
+            Axis.R -> box.copy(rMin = splitAt + 1)
+            Axis.G -> box.copy(gMin = splitAt + 1)
+            Axis.B -> box.copy(bMin = splitAt + 1)
+        }
+
+        return Pair(
+            box1.copy(count = countInBox(box1, histogram)),
+            box2.copy(count = countInBox(box2, histogram)),
+        )
+    }
+
+    private fun countInSlice(box: ColorBox, histogram: IntArray, axis: Axis, val_: Int): Int {
+        var count = 0
+        when (axis) {
+            Axis.R -> for (g in box.gMin..box.gMax) for (b in box.bMin..box.bMax)
+                count += histogram[colorIndex(val_ shl RIGHT_SHIFT, g shl RIGHT_SHIFT, b shl RIGHT_SHIFT)]
+            Axis.G -> for (r in box.rMin..box.rMax) for (b in box.bMin..box.bMax)
+                count += histogram[colorIndex(r shl RIGHT_SHIFT, val_ shl RIGHT_SHIFT, b shl RIGHT_SHIFT)]
+            Axis.B -> for (r in box.rMin..box.rMax) for (g in box.gMin..box.gMax)
+                count += histogram[colorIndex(r shl RIGHT_SHIFT, g shl RIGHT_SHIFT, val_ shl RIGHT_SHIFT)]
+        }
+        return count
+    }
+
+    private fun countInBox(box: ColorBox, histogram: IntArray): Int {
+        var count = 0
+        for (r in box.rMin..box.rMax)
+            for (g in box.gMin..box.gMax)
+                for (b in box.bMin..box.bMax)
+                    count += histogram[colorIndex(r shl RIGHT_SHIFT, g shl RIGHT_SHIFT, b shl RIGHT_SHIFT)]
+        return count
+    }
+
+    /** 박스 내 평균 색상을 계산한다. */
+    private fun averageColor(box: ColorBox, histogram: IntArray): DominantColor {
+        var rSum = 0L; var gSum = 0L; var bSum = 0L; var total = 0
+        for (r in box.rMin..box.rMax) {
+            for (g in box.gMin..box.gMax) {
+                for (b in box.bMin..box.bMax) {
+                    val hval = histogram[colorIndex(r shl RIGHT_SHIFT, g shl RIGHT_SHIFT, b shl RIGHT_SHIFT)]
+                    if (hval > 0) {
+                        rSum += hval.toLong() * (r * MULT + MULT / 2)
+                        gSum += hval.toLong() * (g * MULT + MULT / 2)
+                        bSum += hval.toLong() * (b * MULT + MULT / 2)
+                        total += hval
+                    }
+        }}}
+        return if (total == 0) {
+            // 박스에 픽셀이 없는 경우 (단색 이미지 분할 시 rMin > rMax 가능) — coerceIn 으로 방어
+            DominantColor(
+                r = (box.rMin * MULT).coerceIn(0, 255),
+                g = (box.gMin * MULT).coerceIn(0, 255),
+                b = (box.bMin * MULT).coerceIn(0, 255),
+                population = 0,
+            )
+        } else {
+            DominantColor(
+                r = (rSum / total).toInt().coerceIn(0, 255),
+                g = (gSum / total).toInt().coerceIn(0, 255),
+                b = (bSum / total).toInt().coerceIn(0, 255),
+                population = total,
+            )
+        }
+    }
+
+    /** Median Cut 과정에서 사용하는 RGB 색 공간 내 박스 (5-bit 색 공간 기준). */
+    private data class ColorBox(
+        val rMin: Int, val rMax: Int,
+        val gMin: Int, val gMax: Int,
+        val bMin: Int, val bMax: Int,
+        val count: Int,
+    ) {
+        val volume: Int get() = (rMax - rMin + 1) * (gMax - gMin + 1) * (bMax - bMin + 1)
+    }
+}

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/analysis/MedianCutQuantizer.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/analysis/MedianCutQuantizer.kt
@@ -1,8 +1,6 @@
 package io.bluetape4k.images.analysis
 
 import com.sksamuel.scrimage.ImmutableImage
-import io.bluetape4k.logging.KotlinLogging
-
 /**
  * Median Cut quantization 알고리즘으로 이미지의 대표 색상을 추출한다.
  *
@@ -10,8 +8,6 @@ import io.bluetape4k.logging.KotlinLogging
  * 5-bit/channel (32 levels) RGB 색공간을 사용하여 메모리를 절약한다.
  */
 internal object MedianCutQuantizer {
-
-    private val log = KotlinLogging.logger {}
 
     private const val SIGNAL_BITS = 5
     private const val RIGHT_SHIFT = 8 - SIGNAL_BITS  // = 3
@@ -52,6 +48,7 @@ internal object MedianCutQuantizer {
 
         return boxes
             .map { averageColor(it, histogram) }
+            .filter { it.population > 0 }
             .sortedByDescending { it.population }
     }
 

--- a/utils/images/src/test/kotlin/io/bluetape4k/images/analysis/BlurDetectorTest.kt
+++ b/utils/images/src/test/kotlin/io/bluetape4k/images/analysis/BlurDetectorTest.kt
@@ -1,0 +1,154 @@
+package io.bluetape4k.images.analysis
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import io.bluetape4k.utils.Resourcex
+import org.amshove.kluent.invoking
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeLessOrEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldThrow
+import org.junit.jupiter.api.Test
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+
+class BlurDetectorTest {
+
+    companion object: KLoggingChannel() {
+        private const val HOMER_JPG = "images/homer.jpg"
+        private const val LANDSCAPE_JPG = "images/landscape.jpg"
+
+        private fun loadImage(path: String): ImmutableImage =
+            ImmutableImage.loader().fromStream(Resourcex.getInputStream(path)!!)
+
+        /** 단색 (완전 흐린) 이미지를 생성한다. Laplacian variance ≈ 0. */
+        fun uniformImage(w: Int = 50, h: Int = 50): ImmutableImage {
+            val buf = BufferedImage(w, h, BufferedImage.TYPE_3BYTE_BGR)
+            val gfx = buf.createGraphics()
+            gfx.color = java.awt.Color(128, 128, 128)
+            gfx.fillRect(0, 0, w, h)
+            gfx.dispose()
+            val baos = ByteArrayOutputStream()
+            ImageIO.write(buf, "jpg", baos)
+            return ImmutableImage.loader().fromBytes(baos.toByteArray())
+        }
+
+        /** 수직 줄무늬 (엣지 풍부) 이미지를 생성한다. Laplacian variance 높음. */
+        fun stripedImage(w: Int = 50, h: Int = 50): ImmutableImage {
+            val buf = BufferedImage(w, h, BufferedImage.TYPE_3BYTE_BGR)
+            for (x in 0 until w) {
+                val c = if (x % 2 == 0) java.awt.Color.BLACK else java.awt.Color.WHITE
+                for (y in 0 until h) {
+                    buf.setRGB(x, y, c.rgb)
+                }
+            }
+            val baos = ByteArrayOutputStream()
+            ImageIO.write(buf, "jpg", baos)
+            return ImmutableImage.loader().fromBytes(baos.toByteArray())
+        }
+    }
+
+    @Test
+    fun `homer image returns positive blur score`() {
+        val image = loadImage(HOMER_JPG)
+        val result = image.blurScore()
+        log.debug { "homer blurScore: score=${result.score}, isBlurry=${result.isBlurry}" }
+        result.score shouldBeGreaterThan 0.0
+    }
+
+    @Test
+    fun `landscape image returns positive blur score`() {
+        val image = loadImage(LANDSCAPE_JPG)
+        val result = image.blurScore()
+        log.debug { "landscape blurScore: score=${result.score}, isBlurry=${result.isBlurry}" }
+        result.score shouldBeGreaterThan 0.0
+    }
+
+    @Test
+    fun `uniform solid image has very low blur score`() {
+        val image = uniformImage()
+        val result = image.blurScore(threshold = 100.0)
+        log.debug { "uniform blurScore: ${result.score}" }
+        // 단색 이미지는 Laplacian variance가 매우 낮다 (JPEG 인코딩으로 인한 약간의 noise 허용)
+        result.score shouldBeLessOrEqualTo 200.0  // JPEG noise 허용
+        result.isBlurry.shouldBeTrue()
+    }
+
+    @Test
+    fun `striped image has higher score than uniform image`() {
+        val uniform = uniformImage()
+        val striped = stripedImage()
+        val uniformScore = computeLaplacianVariance(uniform)
+        val stripedScore = computeLaplacianVariance(striped)
+        log.debug { "uniform=$uniformScore, striped=$stripedScore" }
+        stripedScore shouldBeGreaterThan uniformScore
+    }
+
+    @Test
+    fun `isBlurry returns correct value based on threshold`() {
+        val image = loadImage(HOMER_JPG)
+        val score = image.blurScore()
+        // 매우 낮은 threshold → isBlurry=false (선명)
+        val veryLow = image.blurScore(threshold = 0.0)
+        veryLow.isBlurry.shouldBeFalse()
+        // 매우 높은 threshold → isBlurry=true
+        val veryHigh = image.blurScore(threshold = Double.MAX_VALUE)
+        veryHigh.isBlurry.shouldBeTrue()
+        log.debug { "homer score=${score.score}, veryLow.isBlurry=${veryLow.isBlurry}, veryHigh.isBlurry=${veryHigh.isBlurry}" }
+    }
+
+    @Test
+    fun `isBlurry extension matches blurScore`() {
+        val image = loadImage(HOMER_JPG)
+        val threshold = 50.0
+        val fromScore = image.blurScore(threshold).isBlurry
+        val fromExt = image.isBlurry(threshold)
+        log.debug { "isBlurry match: $fromScore == $fromExt" }
+        (fromScore == fromExt).shouldBeTrue()
+    }
+
+    @Test
+    fun `image smaller than 3x3 throws`() {
+        val tiny = ImmutableImage.create(2, 2)
+        invoking {
+            tiny.blurScore()
+        } shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `exactly 3x3 image does not throw`() {
+        val small = ImmutableImage.create(3, 3)
+        val result = small.blurScore()
+        log.debug { "3x3 blurScore: ${result.score}" }
+        result.score shouldBeGreaterOrEqualTo 0.0
+    }
+
+    @Test
+    fun `BlurScore data class properties are correct`() {
+        val score = BlurScore(score = 75.5, threshold = 100.0)
+        score.isBlurry.shouldBeTrue()
+
+        val sharp = BlurScore(score = 200.0, threshold = 100.0)
+        sharp.isBlurry.shouldBeFalse()
+    }
+
+    @Test
+    fun `threshold boundary score equals threshold is not blurry`() {
+        val score = BlurScore(score = 100.0, threshold = 100.0)
+        // score < threshold → isBlurry; score == threshold → NOT blurry
+        score.isBlurry.shouldBeFalse()
+    }
+
+    @Test
+    fun `internal computeLaplacianVariance returns non-negative value`() {
+        val image = loadImage(HOMER_JPG)
+        val variance = computeLaplacianVariance(image)
+        log.debug { "homer laplacian variance: $variance" }
+        variance shouldBeGreaterOrEqualTo 0.0
+    }
+}
+

--- a/utils/images/src/test/kotlin/io/bluetape4k/images/analysis/DominantColorExtractorTest.kt
+++ b/utils/images/src/test/kotlin/io/bluetape4k/images/analysis/DominantColorExtractorTest.kt
@@ -8,6 +8,7 @@ import org.amshove.kluent.invoking
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
 import org.amshove.kluent.shouldBeLessOrEqualTo
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldHaveSize
@@ -136,21 +137,21 @@ class DominantColorExtractorTest {
 
     @Test
     fun `fromRgb parses RGB integer correctly`() {
-        val rgb = 0xFF8000 // orange
+        val rgb = 0xFF8000 // orange: R=255 G=128 B=0
         val color = DominantColor.fromRgb(rgb, population = 42)
-        color.r shouldBeLessOrEqualTo 255
-        color.g shouldBeLessOrEqualTo 255
-        color.b shouldBeLessOrEqualTo 255
-        color.population shouldBeGreaterOrEqualTo 0
+        color.r shouldBeEqualTo 0xFF
+        color.g shouldBeEqualTo 0x80
+        color.b shouldBeEqualTo 0x00
+        color.population shouldBeEqualTo 42
     }
 
     @Test
     fun `toAwtColor returns correct color`() {
         val dominant = DominantColor(100, 150, 200, 50)
         val awt = dominant.toAwtColor()
-        awt.red shouldBeLessOrEqualTo 255
-        awt.green shouldBeLessOrEqualTo 255
-        awt.blue shouldBeLessOrEqualTo 255
+        awt.red shouldBeEqualTo 100
+        awt.green shouldBeEqualTo 150
+        awt.blue shouldBeEqualTo 200
     }
 
     @Test
@@ -193,14 +194,15 @@ class DominantColorExtractorTest {
     }
 
     @Test
-    fun `medianCut with quality=1 uses all pixels`() {
+    fun `medianCut quality=1 samples more pixels than quality=10`() {
         val image = loadImage(HOMER_JPG)
         val fast = image.dominantColors(3, DominantColorExtractor.medianCut(quality = 10))
         val precise = image.dominantColors(3, DominantColorExtractor.medianCut(quality = 1))
         log.debug { "fast: $fast, precise: $precise" }
-        // 두 결과 모두 non-empty이고 색상 값이 유효해야 한다
         fast.shouldNotBeEmpty()
         precise.shouldNotBeEmpty()
+        // quality=1은 모든 픽셀 샘플링 → 첫 번째 색상의 population이 더 큼
+        precise.first().population shouldBeGreaterThan fast.first().population
     }
 
     @Test

--- a/utils/images/src/test/kotlin/io/bluetape4k/images/analysis/DominantColorExtractorTest.kt
+++ b/utils/images/src/test/kotlin/io/bluetape4k/images/analysis/DominantColorExtractorTest.kt
@@ -1,0 +1,221 @@
+package io.bluetape4k.images.analysis
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import io.bluetape4k.utils.Resourcex
+import org.amshove.kluent.invoking
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeLessOrEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldHaveSize
+import org.amshove.kluent.shouldMatch
+import org.amshove.kluent.shouldNotBeEmpty
+import org.amshove.kluent.shouldNotBeNull
+import org.amshove.kluent.shouldThrow
+import org.junit.jupiter.api.Test
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+
+class DominantColorExtractorTest {
+
+    companion object: KLoggingChannel() {
+        private const val HOMER_JPG = "images/homer.jpg"
+        private const val CAFE_JPG = "images/cafe.jpg"
+        private const val LANDSCAPE_JPG = "images/landscape.jpg"
+
+        private fun loadImage(path: String): ImmutableImage =
+            ImmutableImage.loader().fromStream(Resourcex.getInputStream(path)!!)
+
+        /** 단색 JPEG 이미지를 프로그래밍으로 생성한다. */
+        fun solidColorImage(r: Int, g: Int, b: Int, width: Int = 100, height: Int = 100): ImmutableImage {
+            val buffered = BufferedImage(width, height, BufferedImage.TYPE_3BYTE_BGR)
+            val color = java.awt.Color(r, g, b)
+            val gfx = buffered.createGraphics()
+            gfx.color = color
+            gfx.fillRect(0, 0, width, height)
+            gfx.dispose()
+            val baos = ByteArrayOutputStream()
+            ImageIO.write(buffered, "jpg", baos)
+            return ImmutableImage.loader().fromBytes(baos.toByteArray())
+        }
+
+        /** 단색 PNG 이미지를 프로그래밍으로 생성한다 (손실 없음 — ignoreWhite 테스트용). */
+        fun solidColorPngImage(r: Int, g: Int, b: Int, width: Int = 50, height: Int = 50): ImmutableImage {
+            val buffered = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
+            val color = java.awt.Color(r, g, b)
+            val gfx = buffered.createGraphics()
+            gfx.color = color
+            gfx.fillRect(0, 0, width, height)
+            gfx.dispose()
+            val baos = ByteArrayOutputStream()
+            ImageIO.write(buffered, "png", baos)
+            return ImmutableImage.loader().fromBytes(baos.toByteArray())
+        }
+    }
+
+    @Test
+    fun `dominantColors returns correct number of colors`() {
+        val image = loadImage(HOMER_JPG)
+        val colors = image.dominantColors(5)
+        log.debug { "homer dominantColors(5): $colors" }
+        colors.shouldNotBeEmpty()
+        colors.size shouldBeLessOrEqualTo 5
+    }
+
+    @Test
+    fun `dominantColor returns single nullable color`() {
+        val image = loadImage(HOMER_JPG)
+        val color = image.dominantColor()
+        log.debug { "homer dominantColor: $color" }
+        color.shouldNotBeNull()
+    }
+
+    @Test
+    fun `red solid image returns reddish dominant color`() {
+        val image = solidColorImage(220, 30, 30)
+        val color = image.dominantColor()
+        log.debug { "red solid dominantColor: $color" }
+        color.shouldNotBeNull()
+        color.r shouldBeGreaterOrEqualTo color.g
+        color.r shouldBeGreaterOrEqualTo color.b
+    }
+
+    @Test
+    fun `blue solid image returns bluish dominant color`() {
+        val image = solidColorImage(30, 30, 200)
+        val color = image.dominantColor()
+        log.debug { "blue solid dominantColor: $color" }
+        color.shouldNotBeNull()
+        color.b shouldBeGreaterOrEqualTo color.r
+        color.b shouldBeGreaterOrEqualTo color.g
+    }
+
+    @Test
+    fun `count=1 returns at most 1 color`() {
+        val image = loadImage(HOMER_JPG)
+        val colors = image.dominantColors(1)
+        colors.size shouldBeLessOrEqualTo 1
+    }
+
+    @Test
+    fun `colors are sorted by population descending`() {
+        val image = loadImage(CAFE_JPG)
+        val colors = image.dominantColors(5)
+        log.debug { "cafe dominantColors(5): $colors" }
+        colors.shouldNotBeEmpty()
+        for (i in 0 until colors.size - 1) {
+            colors[i].population shouldBeGreaterOrEqualTo colors[i + 1].population
+        }
+    }
+
+    @Test
+    fun `all color values are in 0-255 range`() {
+        val image = loadImage(LANDSCAPE_JPG)
+        val colors = image.dominantColors(8)
+        colors.forEach { color ->
+            color.r shouldBeGreaterOrEqualTo 0
+            color.r shouldBeLessOrEqualTo 255
+            color.g shouldBeGreaterOrEqualTo 0
+            color.g shouldBeLessOrEqualTo 255
+            color.b shouldBeGreaterOrEqualTo 0
+            color.b shouldBeLessOrEqualTo 255
+            color.population shouldBeGreaterOrEqualTo 0
+        }
+    }
+
+    @Test
+    fun `hex format is correct`() {
+        val color = DominantColor(255, 128, 0, 100)
+        color.hex shouldMatch "#[0-9a-f]{6}"
+        color.hex shouldBeEqualTo "#ff8000"
+    }
+
+    @Test
+    fun `fromRgb parses RGB integer correctly`() {
+        val rgb = 0xFF8000 // orange
+        val color = DominantColor.fromRgb(rgb, population = 42)
+        color.r shouldBeLessOrEqualTo 255
+        color.g shouldBeLessOrEqualTo 255
+        color.b shouldBeLessOrEqualTo 255
+        color.population shouldBeGreaterOrEqualTo 0
+    }
+
+    @Test
+    fun `toAwtColor returns correct color`() {
+        val dominant = DominantColor(100, 150, 200, 50)
+        val awt = dominant.toAwtColor()
+        awt.red shouldBeLessOrEqualTo 255
+        awt.green shouldBeLessOrEqualTo 255
+        awt.blue shouldBeLessOrEqualTo 255
+    }
+
+    @Test
+    fun `invalid quality throws`() {
+        invoking {
+            DominantColorExtractor.MedianCut(quality = 0)
+        } shouldThrow IllegalArgumentException::class
+
+        invoking {
+            DominantColorExtractor.MedianCut(quality = 31)
+        } shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `invalid count throws`() {
+        val image = loadImage(HOMER_JPG)
+        invoking {
+            image.dominantColors(count = 0)
+        } shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `ignoreWhite excludes near-white pixels`() {
+        // PNG(손실 없음) 흰색 이미지 → ignoreWhite=true 이면 픽셀 없어 emptyList 반환
+        val whiteImage = solidColorPngImage(255, 255, 255)
+        val withIgnore = whiteImage.dominantColors(5, DominantColorExtractor.medianCut(ignoreWhite = true))
+        val withoutIgnore = whiteImage.dominantColors(5, DominantColorExtractor.medianCut(ignoreWhite = false))
+        log.debug { "white ignoreWhite=true: $withIgnore, ignoreWhite=false: $withoutIgnore" }
+        withIgnore.shouldBeEmpty()
+        withoutIgnore.shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `dominantColor on empty image returns null`() {
+        // 완전 투명 이미지 (alpha=0) → 픽셀 없음 → null
+        val transparent = ImmutableImage.create(10, 10)
+        val color = transparent.dominantColor()
+        log.debug { "transparent dominantColor: $color" }
+        color.shouldBeNull()
+    }
+
+    @Test
+    fun `medianCut with quality=1 uses all pixels`() {
+        val image = loadImage(HOMER_JPG)
+        val fast = image.dominantColors(3, DominantColorExtractor.medianCut(quality = 10))
+        val precise = image.dominantColors(3, DominantColorExtractor.medianCut(quality = 1))
+        log.debug { "fast: $fast, precise: $precise" }
+        // 두 결과 모두 non-empty이고 색상 값이 유효해야 한다
+        fast.shouldNotBeEmpty()
+        precise.shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `DominantColor init rejects out-of-range values`() {
+        invoking { DominantColor(-1, 0, 0, 1) } shouldThrow IllegalArgumentException::class
+        invoking { DominantColor(0, 256, 0, 1) } shouldThrow IllegalArgumentException::class
+        invoking { DominantColor(0, 0, 300, 1) } shouldThrow IllegalArgumentException::class
+        invoking { DominantColor(0, 0, 0, -1) } shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `cafe image extracts multiple distinct colors`() {
+        val image = loadImage(CAFE_JPG)
+        val colors = image.dominantColors(5)
+        log.debug { "cafe colors: ${colors.map { it.hex }}" }
+        colors shouldHaveSize colors.distinctBy { it.hex }.size // 중복 hex 없어야 함
+    }
+}

--- a/utils/images/src/test/kotlin/io/bluetape4k/images/analysis/ExifDataTest.kt
+++ b/utils/images/src/test/kotlin/io/bluetape4k/images/analysis/ExifDataTest.kt
@@ -1,0 +1,217 @@
+package io.bluetape4k.images.analysis
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import io.bluetape4k.utils.Resourcex
+import org.amshove.kluent.invoking
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldThrow
+import org.junit.jupiter.api.Test
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.file.Path
+import javax.imageio.ImageIO
+
+class ExifDataTest {
+
+    companion object: KLoggingChannel() {
+        private const val HOMER_JPG = "images/homer.jpg"
+        private const val CAFE_JPG = "images/cafe.jpg"
+
+        /** 프로그래밍으로 생성한 JPEG — EXIF 없음. */
+        fun noExifJpegBytes(width: Int = 10, height: Int = 10): ByteArray {
+            val buf = BufferedImage(width, height, BufferedImage.TYPE_3BYTE_BGR)
+            val gfx = buf.createGraphics()
+            gfx.color = java.awt.Color(100, 150, 200)
+            gfx.fillRect(0, 0, width, height)
+            gfx.dispose()
+            val baos = ByteArrayOutputStream()
+            ImageIO.write(buf, "jpg", baos)
+            return baos.toByteArray()
+        }
+
+        private fun resourceFile(path: String): File? =
+            Thread.currentThread().contextClassLoader.getResource(path)
+                ?.let { url ->
+                    runCatching { File(url.toURI()) }.getOrNull()?.takeIf { it.exists() }
+                }
+
+        private fun resourcePath(path: String): Path? = resourceFile(path)?.toPath()
+    }
+
+    // ─── readExif(ByteArray) ─────────────────────────────────────────────────
+
+    @Test
+    fun `readExif on empty byte array returns EMPTY`() {
+        val result = readExif(ByteArray(0))
+        result shouldBeEqualTo ExifData.EMPTY
+    }
+
+    @Test
+    fun `readExif on invalid bytes returns EMPTY`() {
+        val result = readExif(ByteArray(100) { 0xFF.toByte() })
+        result shouldBeEqualTo ExifData.EMPTY
+    }
+
+    @Test
+    fun `readExif on programmatic no-exif jpeg has no GPS`() {
+        val bytes = noExifJpegBytes()
+        val result = readExif(bytes)
+        log.debug { "no-exif readExif: $result" }
+        result.hasGps.shouldBeFalse()
+        result.gpsLatitude.shouldBeNull()
+        result.gpsLongitude.shouldBeNull()
+    }
+
+    @Test
+    fun `readExif 50MB guard throws`() {
+        val oversized = ByteArray(50 * 1024 * 1024 + 1)
+        invoking {
+            readExif(oversized)
+        } shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `readExif exactly 50MB does not throw`() {
+        // 유효한 JPEG가 아니므로 파싱 실패 → EMPTY 반환 (예외 아님)
+        val maxSized = ByteArray(50 * 1024 * 1024)
+        val result = readExif(maxSized)
+        result shouldBeEqualTo ExifData.EMPTY
+    }
+
+    @Test
+    fun `readExif on real photo bytes succeeds`() {
+        val bytes = Resourcex.getInputStream(HOMER_JPG)!!.use { it.readBytes() }
+        val result = readExif(bytes)
+        log.debug { "homer readExif via bytes: $result" }
+        // 예외 없이 ExifData를 반환해야 한다
+        result.hasGps.shouldBeFalse()  // homer는 만화 이미지 → GPS 없음
+    }
+
+    // ─── File.readExif() ─────────────────────────────────────────────────────
+
+    @Test
+    fun `File readExif on nonexistent file returns EMPTY`() {
+        val file = File("/tmp/does-not-exist-99999.jpg")
+        val result = file.readExif()
+        result shouldBeEqualTo ExifData.EMPTY
+    }
+
+    @Test
+    fun `File readExif on real photo file succeeds`() {
+        val file = resourceFile(HOMER_JPG) ?: return  // classpath 파일 없으면 skip
+        val result = file.readExif()
+        log.debug { "homer File.readExif: $result" }
+        result.hasGps.shouldBeFalse()
+    }
+
+    @Test
+    fun `File readExif on cafe succeeds`() {
+        val file = resourceFile(CAFE_JPG) ?: return
+        val result = file.readExif()
+        log.debug { "cafe File.readExif: make=${result.cameraMake}, model=${result.cameraModel}, iso=${result.iso}" }
+        // 카페 이미지는 EXIF가 있을 수도 없을 수도 있으므로 예외만 없으면 통과
+    }
+
+    // ─── Path.readExif() ─────────────────────────────────────────────────────
+
+    @Test
+    fun `Path readExif on real photo file`() {
+        val path = resourcePath(HOMER_JPG) ?: return
+        val result = path.readExif()
+        log.debug { "homer Path.readExif: $result" }
+        result.hasGps.shouldBeFalse()
+    }
+
+    // ─── InputStream.readExif() ─────────────────────────────────────────────
+
+    @Test
+    fun `InputStream readExif on programmatic jpeg`() {
+        val bytes = noExifJpegBytes()
+        val result = ByteArrayInputStream(bytes).readExif()
+        log.debug { "no-exif InputStream.readExif: $result" }
+        result.hasGps.shouldBeFalse()
+    }
+
+    @Test
+    fun `InputStream readExif on real photo`() {
+        val result = Resourcex.getInputStream(HOMER_JPG)!!.readExif()
+        log.debug { "homer InputStream.readExif: $result" }
+        result.hasGps.shouldBeFalse()
+    }
+
+    // ─── ExifData model ─────────────────────────────────────────────────────
+
+    @Test
+    fun `hasGps is false when both lat and lon are null`() {
+        val data = ExifData(gpsLatitude = null, gpsLongitude = null)
+        data.hasGps.shouldBeFalse()
+    }
+
+    @Test
+    fun `hasGps is false when only latitude is set`() {
+        val data = ExifData(gpsLatitude = 37.5, gpsLongitude = null)
+        data.hasGps.shouldBeFalse()
+    }
+
+    @Test
+    fun `hasGps is true when both lat and lon are set`() {
+        val data = ExifData(gpsLatitude = 37.5, gpsLongitude = 127.0)
+        data.hasGps.shouldBeTrue()
+    }
+
+    @Test
+    fun `withoutGps removes all GPS fields`() {
+        val data = ExifData(
+            gpsLatitude = 37.5665,
+            gpsLongitude = 126.9780,
+            gpsAltitude = 38.0,
+            cameraMake = "Canon",
+        )
+        data.hasGps.shouldBeTrue()
+
+        val stripped = data.withoutGps()
+        stripped.gpsLatitude.shouldBeNull()
+        stripped.gpsLongitude.shouldBeNull()
+        stripped.gpsAltitude.shouldBeNull()
+        stripped.cameraMake shouldBeEqualTo "Canon"  // 다른 필드는 유지
+    }
+
+    @Test
+    fun `EMPTY instance has all null fields`() {
+        val empty = ExifData.EMPTY
+        empty.gpsLatitude.shouldBeNull()
+        empty.gpsLongitude.shouldBeNull()
+        empty.dateTimeOriginal.shouldBeNull()
+        empty.cameraMake.shouldBeNull()
+        empty.iso.shouldBeNull()
+        empty.hasGps.shouldBeFalse()
+    }
+
+    @Test
+    fun `ExifData data class equality works`() {
+        val a = ExifData(cameraMake = "Canon", iso = 100)
+        val b = ExifData(cameraMake = "Canon", iso = 100)
+        val c = ExifData(cameraMake = "Nikon", iso = 200)
+        (a == b).shouldBeTrue()
+        (a == c).shouldBeFalse()
+    }
+
+    @Test
+    fun `ExifData copy preserves non-overridden fields`() {
+        val original = ExifData(
+            cameraMake = "Sony",
+            iso = 400,
+            aperture = 2.8,
+        )
+        val modified = original.copy(iso = 800)
+        modified.cameraMake shouldBeEqualTo "Sony"
+        modified.iso shouldBeEqualTo 800
+        modified.aperture shouldBeEqualTo 2.8
+    }
+}

--- a/utils/images/src/test/kotlin/io/bluetape4k/images/analysis/SuspendAnalysisTest.kt
+++ b/utils/images/src/test/kotlin/io/bluetape4k/images/analysis/SuspendAnalysisTest.kt
@@ -1,0 +1,135 @@
+package io.bluetape4k.images.analysis
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import io.bluetape4k.utils.Resourcex
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldNotBeEmpty
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.nio.file.Path
+import kotlin.time.Duration.Companion.seconds
+
+class SuspendAnalysisTest {
+
+    companion object: KLoggingChannel() {
+        private const val HOMER_JPG = "images/homer.jpg"
+        private const val CAFE_JPG = "images/cafe.jpg"
+        private const val LANDSCAPE_JPG = "images/landscape.jpg"
+
+        private fun loadImage(path: String): ImmutableImage =
+            ImmutableImage.loader().fromStream(Resourcex.getInputStream(path)!!)
+
+        private fun resourceFile(path: String): File? =
+            Thread.currentThread().contextClassLoader.getResource(path)
+                ?.let { url -> runCatching { File(url.toURI()) }.getOrNull()?.takeIf { it.exists() } }
+
+        private fun resourcePath(path: String): Path? = resourceFile(path)?.toPath()
+    }
+
+    // ─── suspendDominantColors ───────────────────────────────────────────────
+
+    @Test
+    fun `suspendDominantColors returns colors in coroutine`() = runTest(timeout = 30.seconds) {
+        val image = loadImage(HOMER_JPG)
+        val colors = image.suspendDominantColors(5)
+        log.debug { "suspendDominantColors(5): $colors" }
+        colors.shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `suspendDominantColors with count=1 returns single color`() = runTest(timeout = 30.seconds) {
+        val image = loadImage(HOMER_JPG)
+        val colors = image.suspendDominantColors(1)
+        log.debug { "suspendDominantColors(1): $colors" }
+        colors.shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `parallel suspendDominantColors on multiple images completes correctly`() = runTest(timeout = 60.seconds) {
+        val paths = listOf(HOMER_JPG, CAFE_JPG, LANDSCAPE_JPG)
+        val results = paths.map { path ->
+            async {
+                val image = loadImage(path)
+                path to image.suspendDominantColors(3)
+            }
+        }.awaitAll()
+
+        results.forEach { (path, colors) ->
+            log.debug { "$path → ${colors.map { it.hex }}" }
+            colors.shouldNotBeEmpty()
+        }
+    }
+
+    // ─── suspendBlurScore ────────────────────────────────────────────────────
+
+    @Test
+    fun `suspendBlurScore returns score in coroutine`() = runTest(timeout = 30.seconds) {
+        val image = loadImage(HOMER_JPG)
+        val result = image.suspendBlurScore()
+        log.debug { "suspendBlurScore: score=${result.score}, isBlurry=${result.isBlurry}" }
+        result.score shouldBeGreaterThan 0.0
+    }
+
+    @Test
+    fun `suspendBlurScore with zero threshold is never blurry`() = runTest(timeout = 30.seconds) {
+        val image = loadImage(LANDSCAPE_JPG)
+        val result = image.suspendBlurScore(threshold = 0.0)
+        log.debug { "landscape suspendBlurScore(threshold=0): ${result.score}" }
+        result.isBlurry.shouldBeFalse()
+    }
+
+    @Test
+    fun `parallel suspendBlurScore on multiple images`() = runTest(timeout = 60.seconds) {
+        val paths = listOf(HOMER_JPG, CAFE_JPG, LANDSCAPE_JPG)
+        val results = paths.map { path ->
+            async {
+                val image = loadImage(path)
+                path to image.suspendBlurScore()
+            }
+        }.awaitAll()
+
+        results.forEach { (path, score) ->
+            log.debug { "$path blurScore=${score.score}, isBlurry=${score.isBlurry}" }
+            score.score shouldBeGreaterOrEqualTo 0.0
+        }
+    }
+
+    // ─── suspendReadExif ─────────────────────────────────────────────────────
+
+    @Test
+    fun `suspendReadExif via File in coroutine`() = runTest(timeout = 30.seconds) {
+        val file = resourceFile(HOMER_JPG) ?: return@runTest
+        val result = file.suspendReadExif()
+        log.debug { "suspendReadExif homer File: $result" }
+        result.hasGps.shouldBeFalse()
+    }
+
+    @Test
+    fun `suspendReadExif via Path in coroutine`() = runTest(timeout = 30.seconds) {
+        val path = resourcePath(CAFE_JPG) ?: return@runTest
+        val result = path.suspendReadExif()
+        log.debug { "suspendReadExif cafe Path: make=${result.cameraMake}, iso=${result.iso}" }
+    }
+
+    @Test
+    fun `parallel suspend analysis combines dominantColors and blurScore`() = runTest(timeout = 60.seconds) {
+        val image = loadImage(HOMER_JPG)
+
+        val colorsDeferred = async { image.suspendDominantColors(5) }
+        val blurDeferred = async { image.suspendBlurScore() }
+
+        val colors = colorsDeferred.await()
+        val blur = blurDeferred.await()
+
+        log.debug { "homer colors=${colors.map { it.hex }}, blurScore=${blur.score}" }
+        colors.shouldNotBeEmpty()
+        blur.score shouldBeGreaterOrEqualTo 0.0
+    }
+}


### PR DESCRIPTION
## Summary

Closes #133

- PR 제목: feat: utils/images — 이미지 분석 기능 추가 (Issue #133)

Issue #133 요청사항 중 순수 JVM 분석 기능을 구현합니다.
OCR / 얼굴 탐지 / 분류는 네이티브 의존성으로 인해 별도 이슈(#189, #190, #191)로 분리했습니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 구현 내용

### 1. Dominant Color Extraction (Median Cut)
- `DominantColor(r, g, b, population)` — hex, toAwtColor, fromRgb 포함
- `DominantColorExtractor` sealed interface + `MedianCut` data class
- 5-bit/channel RGB quantization, alpha≤125 픽셀 제외
- `ImmutableImage.dominantColors(count, extractor)` — population 내림차순 정렬
- `ImmutableImage.dominantColor()` — nullable (완전 투명 이미지 → null)
- `suspendDominantColors()` — Dispatchers.Default (CPU-bound)
- 단색 이미지 분할 시 population=0 유령 박스 필터링 (coerceIn 버그 수정)

### 2. Blur Detection (Laplacian Variance)
- `BlurScore(score, threshold, isBlurry)` — score가 높을수록 선명
- 3×3 Laplacian 커널, Rec.601 grayscale 변환
- Welford's online variance로 단일 패스 계산 (heap 할당 없음)
- `ImmutableImage.blurScore(threshold)` / `isBlurry()`
- `suspendBlurScore()` — Dispatchers.Default
- 최소 3×3 크기 검증

### 3. EXIF Metadata (metadata-extractor)
- `ExifData` — 17개 필드 (GPS, 날짜, 카메라, ISO, 조리개, 초점거리 등) 모두 nullable
- `readExif(ByteArray)` — 50MB guard, EXIF 없으면 ExifData.EMPTY
- `File/Path/InputStream.readExif()` — Path는 Files.newInputStream() 사용 (jar/zip 안전)
- `withoutGps()` — GPS PII 제거 헬퍼
- `suspendReadExif()` — Dispatchers.IO (파일 I/O)
- EXIF 날짜: timezone-independent 직접 파싱 (yyyy:MM:dd HH:mm:ss)

### 기존 섹션: 파일 목록

| 파일 | 설명 |
|------|------|
| `buildSrc/Libs.kt` | metadata-extractor 2.19.0 의존성 추가 |
| `utils/images/build.gradle.kts` | runtime dependency 추가 |
| `analysis/DominantColor.kt` | DominantColor + sealed interface |
| `analysis/MedianCutQuantizer.kt` | Median Cut 내부 구현 |
| `analysis/BlurDetector.kt` | Laplacian variance 블러 감지 |
| `analysis/ExifData.kt` | EXIF 파싱 + 진입점 함수들 |
| `analysis/DominantColorExtractorTest.kt` | 15개 테스트 |
| `analysis/BlurDetectorTest.kt` | 11개 테스트 |
| `analysis/ExifDataTest.kt` | 19개 테스트 |
| `analysis/SuspendAnalysisTest.kt` | 11개 테스트 |
| `README.md` / `README.ko.md` | Image Analysis 섹션 추가 |

### 기존 섹션: 후속 이슈

- #189 — OCR (Tesseract)
- #190 — 얼굴/객체 탐지 (OpenCV)
- #191 — 이미지 분류 (ONNX Runtime)

### 기존 섹션: Closes

Closes #133

## Validation

```
./gradlew :bluetape4k-images:test
298 passing (49s)   ← 기존 242 + 신규 56
BUILD SUCCESSFUL
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #133, milestone 없음, assignee 없음
- PR: #193, head `b74195b4be5dcd2cbb6c4d75dc88d8b384bd6d77`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/issue-133-images-analysis`
- Labels: `enhancement`
- State: `MERGED`, merge commit `32a768ee596018559821dd20af58f0b42c7cc452`
- CI: ### 2. Blur Detection (Laplacian Variance) / - 3×3 Laplacian 커널, Rec.601 grayscale 변환 / ./gradlew :bluetape4k-images:test

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #193 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `32a768ee596018559821dd20af58f0b42c7cc452`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
