### PR TITLE
docs: README Mermaid UML 다이어그램 / KDoc 커버리지 확대 완료 (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,32 @@ Fury `SCHEMA_CONSISTENT` + `refTracking=false` 모드 기반 고처리량 직렬
 
 - `ForyBinarySerializer.forHighThroughput()` 팩토리 메서드 추가 및 KDoc 예제 강화
 
+#### docs — README Mermaid UML 다이어그램 / KDoc 커버리지 확대 ([#152](https://github.com/bluetape4k/bluetape4k-projects/issues/152))
+
+10개 모듈 README에 Mermaid UML 다이어그램 추가 및 공개 API KDoc 전수 작성 완료.
+
+**README Mermaid 다이어그램 추가 모듈 (10개)**
+
+| 모듈 | 다이어그램 |
+|------|-----------|
+| `data/exposed-cache` | `classDiagram`: JdbcCacheRepository / SuspendedJdbc* / R2dbc* 계층, `sequenceDiagram`: Read-Through / Write-Through / Write-Behind |
+| `data/exposed-jdbc-lettuce` | `classDiagram`: JdbcLettuceRepository 상속 구조 + NearCache 흐름도 |
+| `data/exposed-jdbc-redisson` | `classDiagram`: JdbcRedissonRepository 계층 + 9종 Mermaid 다이어그램 |
+| `data/exposed-jdbc-caffeine` | `classDiagram`: AbstractJdbcCaffeineRepository / AbstractSuspendedJdbcCaffeineRepository |
+| `data/exposed-r2dbc` | `classDiagram`: R2DBC 파이프라인 + 4종 다이어그램 |
+| `infra/cache-core` | `classDiagram`: NearCacheOperations / SuspendNearCacheOperations + `sequenceDiagram` NearCache get/put |
+| `infra/cache-lettuce` | `classDiagram`: LettuceNearCache 계층 + `sequenceDiagram`: RESP3 Pub/Sub 무효화 흐름 |
+| `infra/cache-redisson` | `classDiagram`: RedissonNearCache / Resp3 변형 + `sequenceDiagram`: RLocalCachedMap 흐름 |
+| `infra/cache-hazelcast` | `classDiagram`: HazelcastNearCache + EntryListener 계층 + `sequenceDiagram`: 2-tier 흐름 |
+| `utils/batch` | `classDiagram`: BatchJob/BatchStep/Chunk 파이프라인 + `sequenceDiagram`: 실행 흐름 |
+
+**KDoc 전수 작성 완료 (공개 API)**
+
+- `JdbcCacheRepository` / `SuspendedJdbcCacheRepository` / `R2dbcCacheRepository` — `@param`, `@return`, 사용 예제 포함
+- `CacheMode` / `CacheWriteMode` / `LocalCacheConfig` — enum 항목별 KDoc + 제약 조건 설명
+- `NearCacheOperations` / `SuspendNearCacheOperations` — checkpoint 시맨틱, 사용 순서 명시
+- `BatchReader` / `BatchProcessor` / `BatchWriter` / `BatchJob` — 사용 패턴 + 예외 조건 문서화
+
 ---
 
 ## [1.7.0] — 2026-04-24


### PR DESCRIPTION
## Summary

Closes #152

- PR 제목: docs: README Mermaid UML 다이어그램 / KDoc 커버리지 확대 완료 (#152)

Issue #152 '[docs] README Mermaid UML 다이어그램 / KDoc 커버리지 확대'의 모든 작업이 이전 세션들에서 완료되었음을 확인하고 CHANGELOG.md에 기록합니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### CHANGELOG.md 업데이트

1.8.0 Unreleased  섹션에 Issue #152 완료 항목 추가:

**10개 모듈 README Mermaid 다이어그램 완비**
- `data/exposed-cache` — classDiagram 2종 + sequenceDiagram
- `data/exposed-jdbc-lettuce` — classDiagram + NearCache 흐름도
- `data/exposed-jdbc-redisson` — 9종 Mermaid 다이어그램
- `data/exposed-jdbc-caffeine` — classDiagram 2종
- `data/exposed-r2dbc` — 4종 다이어그램
- `infra/cache-core` — classDiagram + sequenceDiagram NearCache get/put
- `infra/cache-lettuce` — classDiagram + RESP3 Pub/Sub 무효화 흐름
- `infra/cache-redisson` — 2종 다이어그램
- `infra/cache-hazelcast` — classDiagram + 2-tier 흐름도
- `utils/batch` — classDiagram + 실행 흐름도

**공개 API KDoc 전수 작성 완료**
- `JdbcCacheRepository` / `SuspendedJdbcCacheRepository` / `R2dbcCacheRepository`
- `CacheMode` / `CacheWriteMode` / `LocalCacheConfig`
- `NearCacheOperations` / `SuspendNearCacheOperations`
- `BatchReader` / `BatchProcessor` / `BatchWriter` / `BatchJob`

### 기존 섹션: 관련 이슈

Closes #152

## Validation

- 10개 target 모듈 README 전수 확인 — Mermaid 블록 존재 확인 완료
- KDoc sub-agent 검사 — 77개 소스파일 0개 미작성 확인
- CHANGELOG.md 1.6.0/1.6.1 기존 항목(exposed-cache 모듈 추가, Mermaid 스타일 가이드)과 중복 없음

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #152, milestone 없음, assignee `debop`
- PR: #198, head `bf06d0430fdf16f8453afd6f2c56270f4d9294d0`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `docs/issue-152-readme-kdoc`
- Labels: `documentation`
- State: `MERGED`, merge commit `075a7684fc0549ed4d6d0667af41c402091ed9a9`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #198 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `075a7684fc0549ed4d6d0667af41c402091ed9a9`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
