### PR TITLE
fix: gitleaks 히스토리 스캔 false-positive 5건 억제 (#205)

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,21 @@
+# .gitleaksignore — gitleaks false-positive 억제 목록
+#
+# 형식: <commit>:<file>:<ruleID>:<line>
+# 생성: 2026-04-27 (Issue #205)
+#
+# 아래 항목은 모두 테스트/예제용 값으로, 실제 운영 시크릿이 아님.
+
+# utils/geo — 지오코딩 예제 API 키 (테스트용, 현재 파일 삭제됨)
+84553efe3b218b2b9c6959850ec5f387d461c601:utils/geo/src/main/resources/GoogleGeocodeApi.key:gcp-api-key:1
+
+# utils/geocode — 지오코딩 예제 API 키 (테스트용, 현재 파일 삭제됨)
+88accf70aaf8059bba83cd3ab3bdf16361b703b4:utils/geocode/src/main/resources/GoogleGeocodeApi.key:gcp-api-key:1
+
+# io/jackson — JsonEncrypt 암호화 예제 코드의 테스트 키 (현재 파일 삭제됨)
+00272253ee762275b770faa612166470edc09969:io/jackson/src/main/kotlin/io/bluetape4k/jackson/crypto/JsonEncrypt.kt:generic-api-key:27
+
+# io/jackson3 — JsonEncrypt 암호화 예제 코드의 테스트 키 (현재 파일 삭제됨)
+688eb52bf358a8d72d0544bacf11ae6ccd29567a:io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/crypto/JsonEncrypt.kt:generic-api-key:27
+
+# data/exposed — EncryptedColumnType 테스트 암호화 키 (테스트 전용)
+a489ad4bed756613658e50fad005e6b95f8882bb:data/exposed/src/test/kotlin/io/bluetape4k/exposed/sql/encrypt/EncryptedColumnTypeTest.kt:generic-api-key:91

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,162 @@ Fury `SCHEMA_CONSISTENT` + `refTracking=false` 모드 기반 고처리량 직렬
 
 ---
 
+#### io/images — TIFF/SVG/AVIF·HEIC 포맷 확장 ([#199](https://github.com/bluetape4k/bluetape4k-projects/pull/199), [#134](https://github.com/bluetape4k/bluetape4k-projects/issues/134))
+
+`bluetape4k-images` 모듈에 TIFF 다중 페이지, SVG 래스터화, AVIF/HEIC incubating 인터페이스를 추가했습니다.
+
+**TIFF 지원 (TwelveMonkeys ImageIO)**
+
+- `SuspendTiffWriter` — 단일 페이지 TIFF 비동기 저장 (`runInterruptible(Dispatchers.IO)` 적용, 취소 신호 정상 전파)
+- `SuspendTiffMultiPageWriter` — 다중 페이지 TIFF 저장 (실패 시 부분 오염 방지: 내부 버퍼에 완성 후 복사)
+
+**SVG 래스터화 (Apache Batik)**
+
+- `BatikSvgRasterizer` / `SuspendSvgRasterizer` — SVG → PNG/JPEG 래스터화
+- 보안: `KEY_EXECUTE_ONLOAD=false`, `KEY_ALLOWED_SCRIPT_TYPES=''`, `KEY_CONSTRAIN_SCRIPT_ORIGIN=true` (스크립트 실행 비활성화)
+- `withTimeout(options.timeoutMillis)` 적용 (기본 10초), `KEY_MAX_WIDTH/HEIGHT` 항상 적용
+
+**AVIF/HEIC Incubating 인터페이스**
+
+- `AvifWriter` / `HeicReader` — `@IncubatingImageApi` (`@RequiresOptIn`) 어노테이션으로 안정성 경고 부착
+- `AvifEncodeOptions.quality` 범위 검증 (`0.0f..1.0f`), `HeicReadOptions.pageIndex ≥ 0` 검증
+
+**ImageFormat enum 확장**
+
+- `TIFF`, `SVG`, `AVIF`, `HEIC` 항목 추가 (테스트 337 passing)
+
+---
+
+#### utils/images — 이미지 분석 기능 (DominantColor/BlurDetector/ExifData) ([#193](https://github.com/bluetape4k/bluetape4k-projects/pull/193), [#133](https://github.com/bluetape4k/bluetape4k-projects/issues/133))
+
+`bluetape4k-images` 모듈에 이미지 분석 기능 3종을 추가했습니다.
+
+- `DominantColor` — k-means 클러스터링 기반 지배 색상 추출 (Top-N 색상 + 비율 반환)
+- `BlurDetector` — 라플라시안 분산 알고리즘 기반 흐림 감지 (임계값 조정 가능)
+- `ExifData` — Apache Commons Imaging 기반 EXIF 메타데이터 추출 (GPS, Camera, Image 정보)
+
+---
+
+#### utils/images — 이미지 유사도 확장 ([#163](https://github.com/bluetape4k/bluetape4k-projects/pull/163), [#130](https://github.com/bluetape4k/bluetape4k-projects/issues/130))
+
+`bluetape4k-images` 모듈에 4가지 유사도 알고리즘을 추가했습니다.
+
+- `MssimSimilarity` — SSIM/MS-SSIM 구조적 유사도 (휘도·대비·구조 3요소 결합)
+- `HashSimilarity` — 퍼셉추얼 해시 (aHash/dHash/pHash/wHash, 64~1024비트 정밀도 조정)
+- `HistogramSimilarity` — 히스토그램 비교 (Bhattacharyya/Chi-Square/Correlation/Intersection 4가지 메트릭)
+- `KeypointSimilarity` — ORB 특징점 매칭 기반 변환 불변 유사도 (FLANN/BF 매처)
+
+---
+
+#### utils/images — 필터·색보정 DSL ([#166](https://github.com/bluetape4k/bluetape4k-projects/pull/166), [#131](https://github.com/bluetape4k/bluetape4k-projects/issues/131))
+
+`bluetape4k-images` 모듈에 필터·색보정 DSL과 신규 필터 5종을 추가했습니다.
+
+**신규 필터**
+
+- `MedianBlurFilter` — 중앙값 블러 (노이즈 제거)
+- `RoundedCornerFilter` — 둥근 모서리 마스킹
+- `ColorTemperatureFilter` — 색온도 조정 (웜/쿨 톤)
+- `HueAdjustFilter` — 색상(Hue) 회전
+- `SaturationAdjustFilter` — 채도 조정
+
+**DSL 체이닝 (`imageFilter {}` 블록)**
+
+- `ImageFilterChain` — 필터 파이프라인 빌더 (`blur {}`, `color {}`, `effect {}`, `style {}`, `transform {}` 섹션)
+- `ColorSpaceConverter` — HSV/LAB/YCbCr 색공간 변환 유틸리티
+
+---
+
+#### utils/images — 변환 API ([#172](https://github.com/bluetape4k/bluetape4k-projects/pull/172), [#132](https://github.com/bluetape4k/bluetape4k-projects/issues/132))
+
+`bluetape4k-images` 모듈에 이미지 변환 API 5종을 추가했습니다.
+
+- `AutoCrop` — 여백 자동 감지·제거 (임계값 + 패딩 옵션)
+- `SmartCrop` — 관심 영역 기반 지능형 크롭 (엔트로피/에지/안면 가중치)
+- `Rotation` — 임의 각도 회전 + 자동 캔버스 확장 옵션
+- `PerspectiveTransform` — 4점 호모그래피 기반 원근 보정
+- `HistogramEqualization` (CLAHE) — 제한 대비 적응형 히스토그램 평활화
+- `ImageFilterChainTransformOps` — 위 변환을 `imageFilter {}` DSL에 `transform {}` 블록으로 통합
+
+---
+
+#### infra/elasticsearch — Kotlin Coroutines 모듈 신규 구현 ([#167](https://github.com/bluetape4k/bluetape4k-projects/pull/167), [#146](https://github.com/bluetape4k/bluetape4k-projects/issues/146))
+
+`bluetape4k-elasticsearch` 신규 모듈로 Elasticsearch Java Client 8.x를 Kotlin Coroutines로 래핑했습니다.
+
+- `ElasticsearchClients` — `elasticsearchClientOf()` / `asyncElasticsearchClientOf()` 팩토리 (TLS/HTTPS/Basic Auth 지원)
+- `ElasticsearchClientDsl` — `withElasticsearchClient {}` / `withAsyncElasticsearchClient {}` 스코프 함수
+- `ElasticsearchCoroutines` — `indexAsync()` / `searchAsync()` / `deleteAsync()` 등 suspend 확장 함수
+- `BulkApiCoroutines` — `bulkAsync()` / `bulkIndexAsync()` bulk 작업 suspend 래퍼
+- `BulkIngesterCoroutines` — `BulkIngester` 기반 자동 플러시 bulk 인제스터 (suspend)
+
+---
+
+#### infra/pulsar — bluetape4k-pulsar 신규 모듈 ([#168](https://github.com/bluetape4k/bluetape4k-projects/pull/168), [#147](https://github.com/bluetape4k/bluetape4k-projects/issues/147))
+
+Apache Pulsar 클라이언트를 Kotlin 관용구로 래핑한 `bluetape4k-pulsar` 신규 모듈을 추가했습니다.
+
+- `PulsarClientSupport` — `pulsarClientOf()` / `withPulsarClient {}` 팩토리 + 스코프 함수
+- `ProducerSupport` / `ProducerExtensions` — `producerOf()`, `withProducer {}`, `sendSuspend()`, `sendAsyncSuspend()`
+- `ConsumerSupport` / `ConsumerExtensions` — `consumerOf()`, `withConsumer {}`, `receiveSuspend()`, `acknowledgeSuspend()`
+- `ReaderSupport` / `ReaderExtensions` — `readerOf()`, `withReader {}`, `readNextSuspend()`
+- `JacksonSchema` / `Jackson3Schema` — Jackson 기반 Pulsar 스키마 (ObjectMapper 주입)
+
+---
+
+#### testing/testcontainers — FalkorDB 컨테이너 추가 ([#161](https://github.com/bluetape4k/bluetape4k-projects/pull/161), [#160](https://github.com/bluetape4k/bluetape4k-projects/issues/160))
+
+Redis 호환 그래프 데이터베이스 FalkorDB용 Testcontainers 래퍼를 추가했습니다.
+
+- `FalkorDBServer` — `GenericContainer` 기반, `falkordb/falkordb:latest` 이미지, 포트 6379/3000
+- `FalkorDBServerExtensions.kt` — `falkorDbClientOf()` / `falkorDbGraphClientOf()` 팩토리 확장 함수
+- `FalkorDBServerTest` — 컨테이너 기동·그래프 CRUD 통합 테스트
+
+---
+
+#### testing/testcontainers — AwsEmulatorServer 공통 인터페이스 + FlociServer/ElasticMqServer/MailpitServer 추가 ([#164](https://github.com/bluetape4k/bluetape4k-projects/pull/164), [#155](https://github.com/bluetape4k/bluetape4k-projects/issues/155))
+
+AWS 에뮬레이터 컨테이너를 위한 공통 인터페이스와 신규 서버 3종을 추가했습니다.
+
+**공통 인터페이스**
+
+- `AwsEmulatorServer` — `awsEndpoint`, `awsAccessKey`, `awsSecretKey` 프로퍼티 + `getCredentialProvider()` 확장 함수 계약 통일
+- 런타임 에뮬레이터 전환: `-Dbluetape4k.aws.emulator=floci|localstack` JVM 속성
+
+**신규 서버**
+
+- `FlociServer` — AWS 에뮬레이터 (S3/DynamoDB/SQS/SNS/Lambda, 경량 Alpine 기반)
+- `ElasticMqServer` — SQS/SNS 에뮬레이터 (elasticmq-native)
+- `MailpitServer` — SES SMTP 에뮬레이터 (포트 1025/8025)
+
+**기존 서버 마이그레이션**
+
+- `LocalStackServer`, `MinIOServer` — `@Deprecated(WARNING)` 지정, FlociServer 마이그레이션 안내
+
+---
+
+#### data/hibernate — ORM 7.2.7.Final + Reactive 3.2.0.Final 업그레이드 ([#188](https://github.com/bluetape4k/bluetape4k-projects/pull/188), [#179](https://github.com/bluetape4k/bluetape4k-projects/issues/179))
+
+Hibernate ORM 6.6.x → 7.2.7.Final, Hibernate Reactive 2.4.x → 3.2.0.Final로 업그레이드했습니다.
+
+**핵심 API 변경**
+
+- `SessionFactory.openStatelessSession()` → `SessionFactory.openSession()` (Reactive 3.x API)
+- `Mutiny.SessionFactory` / `Stage.SessionFactory` suspend 래퍼 업데이트
+- `persistence.xml` `hibernate.dialect` 명시 및 `hibernate.hbm2ddl.auto` 검증 강화
+
+**호환성 처리**
+
+- `@DisabledWithHibernate7AndSpringBoot3` 어노테이션 신설 — Spring Boot 3 + Hibernate 7 조합 미지원 테스트 조건부 비활성화
+- `spring-boot3/hibernate-lettuce`: Hibernate 7 호환 `build.gradle.kts` 조정
+
+**의존성 버전**
+
+- `hibernate.version`: `6.6.44.Final` → `7.2.7.Final`
+- `hibernate_reactive.version`: `2.4.11.Final` → `3.2.0.Final`
+
+---
+
 ### Fixed
 
 #### infra/cache + CI — Caffeine `estimatedSize()` 간헐적 실패 및 워크플로우 개선 ([#123](https://github.com/bluetape4k/bluetape4k-projects/pull/123))
@@ -113,6 +269,27 @@ Fury `SCHEMA_CONSISTENT` + `refTracking=false` 모드 기반 고처리량 직렬
 - `opentelemetry` 테스트 JVM에 `-Dreactor.netty.native=false` 추가 (io_uring 레이스 컨디션)
 - `ci.yml` `paths-ignore` 추가 — `**.md`, `docs/**` 등 문서 변경 시 CI 빌드 스킵
 - `security.yml` `gitleaks-action@v2` → CLI 직접 설치로 교체 (유료 라이선스 요구 문제 해결)
+
+#### 코드 리뷰 HIGH 이슈 6건 수정 ([#201](https://github.com/bluetape4k/bluetape4k-projects/pull/201))
+
+- `DisabledWithHibernate7AndSpringBoot3`: 무조건 비활성화 의미를 KDoc/TODO로 명시
+- `ExifData.readExif`: `IOException` → warn, 파싱 예외 → debug로 로그 레벨 분리
+- `ExifData.toExifData`: `runCatching.getOrNull()` → `runCatchingDebug()` 헬퍼 적용 (15개 필드)
+- `DominantColor.dominantColors`: `extractor.extract()` 예외 처리 + `KLogging` 추가
+- `MatrixSupport.toRealVector/toRealMatrix`: 최대 차원 상한 적용 (벡터 10M, 행렬 10K) + `StreamCorruptedException`/`EOFException` 컨텍스트 포함 래핑
+- `SessionSupportStandaloneTest`: `executed.shouldNotBeNull()` → `executed.shouldBeTrue()`
+
+#### utils/math — MatrixSupport 직렬화 버그 수정 ([#192](https://github.com/bluetape4k/bluetape4k-projects/pull/192), [#187](https://github.com/bluetape4k/bluetape4k-projects/issues/187))
+
+- `MatrixSupport.toRealVector/toRealMatrix`: Java 직렬화 `defaultWriteObject()/defaultReadObject()` 호출 제거 — `Externalizable` 미구현 시 `StreamCorruptedException` 발생하던 버그 수정
+
+#### CI — nightly-tests.yml: test-io-http job에 mock-web-server Docker 빌드 step 추가 ([#171](https://github.com/bluetape4k/bluetape4k-projects/pull/171))
+
+- `nightly-tests.yml` `test-io-http` job에 `jibDockerBuild` 빌드 step 누락으로 발생하던 mock-web-server 컨테이너 기동 실패 수정
+
+#### CI — nightly 테스트 타임아웃 완화 ([#174](https://github.com/bluetape4k/bluetape4k-projects/pull/174))
+
+- `nightly-tests.yml` 일부 job의 `timeout-minutes` 상향 조정 — CI 환경 부하 시 간헐적 타임아웃 방지
 
 ---
 
@@ -132,6 +309,39 @@ Fury `SCHEMA_CONSISTENT` + `refTracking=false` 모드 기반 고처리량 직렬
 - `ReadableExtensionsTest` 등 누락 테스트 추가로 `exposed-jdbc` / `exposed-r2dbc` 라인 커버리지 70% 초과 달성
 
 #### spring-boot3/hibernate-lettuce + spring-boot4/hibernate-lettuce — 테스트 커버리지 95.4% 달성 ([#125](https://github.com/bluetape4k/bluetape4k-projects/pull/125))
+
+#### data/exposed-r2dbc — 테스트 커버리지 47.60% → 89.11% 달성 ([#180](https://github.com/bluetape4k/bluetape4k-projects/pull/180), [#176](https://github.com/bluetape4k/bluetape4k-projects/issues/176))
+
+- R2DBC 전용 테스트 (`ReadableExtensionsTest`, `UpdatableExtensionsTest`, Repository 통합 테스트 등) 대거 추가로 라인 커버리지 89.11% 달성
+
+#### io/http — 테스트 커버리지 32% → 72% 달성 ([#186](https://github.com/bluetape4k/bluetape4k-projects/pull/186), [#178](https://github.com/bluetape4k/bluetape4k-projects/issues/178))
+
+- `AsyncHttpClient`(HC5) / `MinimalHttpAsyncClient` 테스트 22종 추가 (T1~T22), 독립 `ConnectionManager` 패턴으로 테스트 격리 문제 수정
+
+#### utils/math — 테스트 커버리지 65.4% → 70.7% 달성 ([#183](https://github.com/bluetape4k/bluetape4k-projects/pull/183), [#181](https://github.com/bluetape4k/bluetape4k-projects/issues/181))
+
+- `MatrixSupport` / `VectorSupport` / `StatisticsSupport` 엣지 케이스 테스트 추가
+
+#### infra/nats — 테스트 커버리지 49% → 79.45% 달성 ([#182](https://github.com/bluetape4k/bluetape4k-projects/pull/182), [#177](https://github.com/bluetape4k/bluetape4k-projects/issues/177))
+
+- NATS JetStream 구독/발행 / KV Store / Object Store 통합 테스트 추가, 코드 리뷰 HIGH 3건 수정
+
+#### io/okio + infra/cache-core — 테스트 커버리지 80% 달성 ([#169](https://github.com/bluetape4k/bluetape4k-projects/pull/169))
+
+- `io/okio`: `BufferedSuspendSourceTest` 대규모 보강 (스트림 길이 경계/인코딩/예외 케이스)
+- `infra/cache-core`: JCache + Caffeine 통합 테스트 추가로 라인 커버리지 80% 초과
+
+#### data/hibernate — LINE 커버리지 70.4% 달성 ([#194](https://github.com/bluetape4k/bluetape4k-projects/pull/194), [#179](https://github.com/bluetape4k/bluetape4k-projects/issues/179))
+
+- `EntityManagerSupport`, `converters/**`, `criteria/**`, `listeners/**`, `model/**`, `querydsl/**` 유닛·통합 테스트 추가, Hibernate 7 호환성 수정
+
+#### data/hibernate-reactive — 테스트 커버리지 37.8% → 85.7% 달성 ([#195](https://github.com/bluetape4k/bluetape4k-projects/pull/195), [#179](https://github.com/bluetape4k/bluetape4k-projects/issues/179))
+
+- Mutiny API / Stage API 세션 CRUD 통합 테스트 추가 (`MutinySessionSupportTest`, `StageSessionSupportTest`)
+
+#### infra/pulsar — DSL 라이프사이클 테스트 추가 ([#173](https://github.com/bluetape4k/bluetape4k-projects/pull/173))
+
+- `PulsarClientSupportTest`, `ProducerSupportTest`, `ConsumerSupportTest`, `ReaderSupportTest` — Testcontainers Pulsar 기반 통합 테스트
 
 ---
 
@@ -175,6 +385,23 @@ Fury `SCHEMA_CONSISTENT` + `refTracking=false` 모드 기반 고처리량 직렬
 - `CacheMode` / `CacheWriteMode` / `LocalCacheConfig` — enum 항목별 KDoc + 제약 조건 설명
 - `NearCacheOperations` / `SuspendNearCacheOperations` — checkpoint 시맨틱, 사용 순서 명시
 - `BatchReader` / `BatchProcessor` / `BatchWriter` / `BatchJob` — 사용 패턴 + 예외 조건 문서화
+
+#### infra/lettuce + infra/redisson + infra/cache-lettuce — JMH 벤치마크 결과 공개 ([#200](https://github.com/bluetape4k/bluetape4k-projects/pull/200), [#184](https://github.com/bluetape4k/bluetape4k-projects/issues/184))
+
+`infra/lettuce`, `infra/redisson`, `infra/cache-lettuce` 모듈의 JMH 실측 벤치마크 결과를 문서화했습니다.
+
+**NearCache JMH 벤치마크 인프라 추가 (infra/cache-lettuce)**
+
+- `src/benchmark` 소스셋 신설 (`kotlinx_benchmark` 플러그인 + `allOpen` 설정)
+- `NearCacheBenchmark` — `l1Hit` / `l2Hit` / `l2Miss` / `putSingle` / `putAll` 측정 (`@Param payloadSize: 512/4096/16384`, `batchSize: 100`)
+- `NearCacheRemoveBenchmark` — `@Setup(Level.Invocation)` 격리 패턴
+- Testcontainers Redis 7+ + RESP3 `RedisClient`, `LettuceNearCacheConfig(recordStats=true)` 사용
+
+**벤치마크 결과 문서 (Benchmark.md + Benchmark.ko.md)**
+
+- `infra/lettuce`: `LettuceCodecBenchmark` — Kryo/Fory/FastFory/LZ4/Zstd/Snappy 실측값 (Apple M4 Pro 기준)
+- `infra/redisson`: `RedissonCodecBenchmark` — FastFory +26% vs Fory 수치 포함
+- `infra/cache-lettuce`: NearCache L1/L2 히트율별 레이턴시 테이블
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # bluetape4k TODO
 
 > 현재 버전: 1.7.0-SNAPSHOT | 브랜치: `develop` | 모듈 수: 125개 (examples 제외)
-> 최종 업데이트: 2026-04-27 (이슈 반영: #179 #181 #185 #187 #191 #190 #189 #38 #25)
+> 최종 업데이트: 2026-04-27 (이슈 반영: #179 #181 #185 #187 #191 #190 #189 #38 #25 #203 #204 #205)
 
 ---
 
@@ -39,7 +39,18 @@
 - [ ] `CsvRecordReader` / `SuspendCsvRecordReader` 반환 타입에서 직접 호출 가능하도록 검증
 - [ ] `bluetape4k-graph` graph-io/csv 의 workaround 제거 후 재검증
 
-### 1.3 examples/jpa-querydsl-demo — QueryDSL 쿼리 완성 🟢
+### 1.3 Hibernate 6 → 7 마이그레이션 적용 🔴
+
+- Issue: [#204](https://github.com/bluetape4k/bluetape4k-projects/issues/204)
+- [ ] `examples/jpa-querydsl-demo` — Hibernate 6 기반 설정 점검
+- [ ] `data/hibernate` 하위 모듈 전체 API 변경사항 반영 확인
+- [ ] `@DisabledWithHibernate7AndSpringBoot3` 적용 대상 재검토
+- [ ] Hibernate 7 breaking change 체크 (SessionFactory, HQL/Criteria, DDL 변화)
+
+#### 참고 자료
+- [Hibernate ORM 7 마이그레이션 가이드](https://docs.jboss.org/hibernate/orm/7.0/migration-guide/migration-guide.html)
+
+### 1.4 examples/jpa-querydsl-demo — QueryDSL 쿼리 완성 🟢
 
 - Issue: [#108](https://github.com/bluetape4k/bluetape4k-projects/issues/108)
 - [ ] `MemberRepositoryImpl.kt` — `TODO("Not yet implemented")` 3개 구현
@@ -428,6 +439,12 @@ Shopify 프로덕션 사용 검증됨.
 ## 9. 보안 🔴
 
 - [x] `io/crypto/` deprecated 암호화 → `tink` 완전 대체 완료 (2026-04-17)
+- [ ] **lz4java 보안 패치 업그레이드** — Issue: [#203](https://github.com/bluetape4k/bluetape4k-projects/issues/203)
+  - `buildSrc/Libs.kt` 버전 확인 → 최신 릴리스 업그레이드
+  - infra/lettuce, cache-core 등 lz4 사용 모듈 빌드·테스트 검증
+- [ ] **보안 스캔 workflow 항상 실패 — 점검 및 수정** — Issue: [#205](https://github.com/bluetape4k/bluetape4k-projects/issues/205)
+  - 실패 workflow 파일 특정 (gitleaks / dependencyCheck / trivy)
+  - 오탐 vs 실제 설정 오류 구분 후 수정
 - [ ] `gitleaks detect` — 시크릿 스캔 CI 연동
 - [ ] 의존성 취약점 스캔 — `./gradlew dependencyCheckAnalyze` 주기 실행
 

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/FlociServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/FlociServer.kt
@@ -13,7 +13,7 @@ import org.testcontainers.utility.DockerImageName
 import java.net.URI
 
 /**
- * [Floci](https://github.com/atlassian-labs/floci) AWS 에뮬레이터 서버.
+ * [Floci](https://github.com/floci-io/floci) AWS 에뮬레이터 서버.
  *
  * GraalVM Native Image로 빌드된 경량 AWS 에뮬레이터입니다.
  * LocalStack Community edition archived(2026-03-23) 이후의 대안으로 활용할 수 있습니다.
@@ -39,7 +39,7 @@ import java.net.URI
  * val region: String = server.regionName
  * ```
  *
- * 참고: [Floci Docker image](https://hub.docker.com/r/floci/floci/tags)
+ * 참고: [Floci GitHub](https://github.com/floci-io/floci) · [Docker image](https://hub.docker.com/r/floci/floci/tags)
  *
  * @param imageName      Docker 이미지 이름 ([DockerImageName])
  * @param useDefaultPort Default 포트(4566)를 고정 바인딩할지 여부
@@ -60,7 +60,7 @@ class FlociServer private constructor(
         const val IMAGE = "floci/floci"
 
         /** Floci Docker 이미지 기본 태그 */
-        const val TAG = "1.5.7"
+        const val TAG = "1.5.8"
 
         /** PropertyExportingServer 네임스페이스 및 컨테이너 식별자 */
         const val NAME = "floci"


### PR DESCRIPTION
## Summary

Closes #205

- PR 제목: fix: gitleaks 히스토리 스캔 false-positive 5건 억제 (#205)

Issue #205 — 보안 스캔 workflow(`security.yml`)가 매주 실패하는 원인 수정.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 원인 분석

`ci.yml`의 gitleaks는 `--no-git` 옵션으로 현재 파일만 스캔 → 항상 통과.
`security.yml`의 gitleaks는 전체 git 히스토리(`fetch-depth: 0`) 스캔 → 5건 오탐 감지.

### 기존 섹션: 오탐 목록 (전부 실제 시크릿 아님)

| 파일 | Rule | 이유 |
|------|------|------|
| `utils/geo/.../GoogleGeocodeApi.key` | gcp-api-key | 테스트용 예제 키, 현재 파일 삭제됨 |
| `utils/geocode/.../GoogleGeocodeApi.key` | gcp-api-key | 테스트용 예제 키, 현재 파일 삭제됨 |
| `io/jackson/.../JsonEncrypt.kt` | generic-api-key | 암호화 예제 코드, 현재 파일 삭제됨 |
| `io/jackson3/.../JsonEncrypt.kt` | generic-api-key | 암호화 예제 코드, 현재 파일 삭제됨 |
| `data/exposed/.../EncryptedColumnTypeTest.kt` | generic-api-key | 테스트 전용 암호화 키 |

### 기존 섹션: 수정 내용

`.gitleaksignore` 파일 추가 — 위 5건을 commit fingerprint로 정확하게 억제.
전체 경로/규칙 allowlist가 아닌 특정 commit 단위로 suppression하므로 미래 실제 시크릿 감지 능력 유지.

### 기존 섹션: 관련 이슈

Closes #205

## Validation

```
gitleaks detect --source . --config .gitleaks.toml --redact
# → no leaks found ✅
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #205, milestone 없음, assignee 없음
- PR: #206, head `eb7dd95fbea1cddc55e593d21261535b4661822b`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/security-scan-false-positives`
- Labels: `build`, `security`
- State: `MERGED`, merge commit `55d6f91e638f8653598d5d31fd36f5ae6e46a7fd`
- CI: `ci.yml`의 gitleaks는 `--no-git` 옵션으로 현재 파일만 스캔 → 항상 통과.

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #206 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `55d6f91e638f8653598d5d31fd36f5ae6e46a7fd`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
