### PR TITLE
test(testcontainers): FlociServer 기반 AWS 서비스 통합 테스트 추가 (#202)

### DIFF
--- a/docs/superpowers/plans/2026-04-27-floci-service-tests-plan.md
+++ b/docs/superpowers/plans/2026-04-27-floci-service-tests-plan.md
@@ -1,0 +1,61 @@
+# FlociServer AWS 서비스 통합 테스트 추가 — Implementation Plan
+
+**Date**: 2026-04-27  
+**Spec**: docs/superpowers/specs/2026-04-27-floci-service-tests-design.md  
+**Issue**: #202
+
+---
+
+## Task List
+
+### T1 — FlociS3Test 작성 (complexity: medium)
+- 파일: `src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociS3Test.kt`
+- S3Test.kt 패턴 그대로, LocalStackServer → FlociServer 교체
+- `server.endpoint` → `floci.awsEndpoint`, `server.region` → `floci.regionName`
+- 테스트: 서버 시작 확인, 버킷 생성, 오브젝트 put/get
+
+### T2 — FlociSQSTest 작성 (complexity: medium)
+- 파일: `src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSQSTest.kt`
+- SQSTest.kt 패턴: 큐 생성/조회, 메시지 send/receive/delete, batch
+
+### T3 — FlociSNSTest 작성 (complexity: medium)
+- 파일: `src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSNSTest.kt`
+- SNSTest.kt 패턴: 토픽 생성/조회/삭제, 발행, 구독
+
+### T4 — FlociDynamoDBTest 작성 (complexity: medium)
+- 파일: `src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociDynamoDBTest.kt`
+- DynamoDBTest.kt 패턴: 테이블 생성, CRUD
+- GSI 관련 테스트는 `@Disabled("Floci #587: GSI Query pagination loops forever")` 처리
+
+### T5 — FlociKinesisTest 작성 (complexity: medium)
+- 파일: `src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociKinesisTest.kt`
+- KinesisTest.kt 패턴: 스트림 생성, put/get records
+
+### T6 — FlociKMSTest 작성 (complexity: medium)
+- 파일: `src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociKMSTest.kt`
+- KMSTest.kt 패턴: symmetric key 생성, encrypt/decrypt, alias
+- asymmetric key `GetKeyRotationStatus` 관련 테스트는 `@Disabled("Floci #586: GetKeyRotationStatus is not working with asymmetric key")` 처리
+
+### T7 — FlociSTSTest 작성 (complexity: medium)
+- 파일: `src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSTSTest.kt`
+- STSTest.kt 패턴: getCallerIdentity, assumeRole, getSessionToken
+
+### T8 — FlociCloudWatchTest 작성 (complexity: medium)
+- 파일: `src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociCloudWatchTest.kt`
+- CloudWatchTest.kt 패턴: metrics, logs
+
+### T9 — 테스트 실행 및 검증 (complexity: low)
+- `./gradlew :bluetape4k-testcontainers:test --tests "io.bluetape4k.testcontainers.aws.floci.*"`
+- 실패 시 원인 파악 및 수정 또는 `@Disabled` 추가
+
+### T10 — Commit + Push (complexity: low)
+- 커밋 메시지: `feat(testcontainers): FlociServer 기반 AWS 서비스 통합 테스트 추가 (#202)`
+- push → PR 생성
+
+---
+
+## 의존 관계
+
+T1-T8은 독립적 → 병렬 실행 가능  
+T9는 T1-T8 완료 후  
+T10은 T9 통과 후

--- a/docs/superpowers/specs/2026-04-27-floci-service-tests-design.md
+++ b/docs/superpowers/specs/2026-04-27-floci-service-tests-design.md
@@ -1,0 +1,121 @@
+# FlociServer AWS 서비스 통합 테스트 추가 — Design Spec
+
+**Date**: 2026-04-27  
+**Issue**: #202  
+**Branch**: feat/floci-service-tests
+
+---
+
+## 1. 배경 및 목표
+
+`LocalStack Community Edition`이 2026-03-23 아카이브 이후 [Floci](https://github.com/floci-io/floci)가 무료 오픈소스 AWS 에뮬레이터 대안으로 부상하고 있다.
+
+현재 `io.bluetape4k.testcontainers.aws.services` 패키지에 LocalStack 기반 서비스 통합 테스트 8개가 존재하지만, Floci 기반 대응 테스트는 없다. 이를 추가하여:
+1. Floci의 실제 서비스 지원 범위를 검증한다
+2. LocalStack 대체 가능성을 테스트 수준에서 확인한다
+3. Floci 알려진 버그/미지원 항목을 문서화한다
+
+---
+
+## 2. 설계 결정
+
+### 2-A. 패키지 분리
+
+LocalStack 테스트와 별도 패키지로 분리한다:
+- **신규**: `io.bluetape4k.testcontainers.aws.floci.services`
+- **기존**: `io.bluetape4k.testcontainers.aws.services` (변경 없음)
+
+**이유**: 두 에뮬레이터를 동시에 사용하는 경우 클래스명 충돌 방지. 향후 Floci 전용 헬퍼/확장이 추가될 수 있어 네임스페이스 분리가 유리.
+
+### 2-B. FlociServer 참조 방식
+
+```kotlin
+// LocalStack 방식 (서비스 선택 가능)
+private val server = LocalStackServer.Launcher.localStack.withServices("s3")
+
+// Floci 방식 (모든 서비스 항상 활성화)
+private val floci = FlociServer.Launcher.floci
+```
+
+`FlociServer.Launcher.floci`는 싱글턴으로 이미 `start()` 호출 포함. `@BeforeAll`에서 참조만 하면 lazy 초기화 트리거됨.
+
+### 2-C. API 매핑
+
+| LocalStack | Floci |
+|-----------|-------|
+| `server.endpoint` (URI) | `floci.awsEndpoint` (URI) |
+| `server.region` (String) | `floci.regionName` (String) |
+| `server.getCredentialProvider()` | `floci.getCredentialProvider()` (동일 확장함수) |
+| `withServices("s3")` | no-op (전체 활성) |
+
+### 2-D. @Disabled 처리 정책
+
+Floci 알려진 버그/제한이 있는 테스트는 `@Disabled` + 이유 주석으로 표시:
+
+| 서비스 | 알려진 이슈 | 처리 |
+|-------|-----------|------|
+| KMS | `GetKeyRotationStatus` asymmetric key 버그 (#586) | 해당 테스트 케이스만 `@Disabled` |
+| DynamoDB | GSI pagination 무한루프 (#587) | GSI 관련 테스트만 `@Disabled`. 기본 CRUD는 정상 동작 |
+
+> Lambda credentials 버그 (#611)는 본 테스트 범위 외 (Lambda 테스트 없음).
+
+---
+
+## 3. 테스트 파일 목록
+
+| 파일명 | 대응 LocalStack 테스트 | 비고 |
+|--------|----------------------|------|
+| `FlociS3Test.kt` | `S3Test.kt` | 정상 |
+| `FlociSQSTest.kt` | `SQSTest.kt` | 정상 |
+| `FlociSNSTest.kt` | `SNSTest.kt` | 정상 |
+| `FlociDynamoDBTest.kt` | `DynamoDBTest.kt` | GSI 테스트 제외 |
+| `FlociKinesisTest.kt` | `KinesisTest.kt` | 정상 |
+| `FlociKMSTest.kt` | `KMSTest.kt` | asymmetric key 테스트 제외 |
+| `FlociSTSTest.kt` | `STSTest.kt` | 정상 |
+| `FlociCloudWatchTest.kt` | `CloudWatchTest.kt` | 정상 |
+
+---
+
+## 4. 코드 패턴 (공통)
+
+```kotlin
+@Suppress("DEPRECATION")
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class FlociXxxTest : AbstractContainerTest() {
+
+    companion object : KLogging()
+
+    private val floci: FlociServer
+        get() = FlociServer.Launcher.floci
+
+    private val xxxClient: XxxClient by lazy {
+        XxxClient.builder()
+            .endpointOverride(floci.awsEndpoint)
+            .region(Region.of(floci.regionName))
+            .credentialsProvider(floci.getCredentialProvider())
+            .build()
+            .apply { ShutdownQueue.register(this) }
+    }
+
+    @BeforeAll
+    fun setup() {
+        // Lazy 초기화 트리거 (내부에서 start() 호출됨)
+        floci.isRunning.shouldBeTrue()
+    }
+    
+    // ...
+}
+```
+
+---
+
+## 5. DoD (Definition of Done)
+
+- [ ] 8개 테스트 파일 신규 생성 (`floci.services` 패키지)
+- [ ] 모든 테스트 클래스에 `@Suppress("DEPRECATION")` 적용
+- [ ] 모든 테스트 클래스에 `companion object : KLogging()` 적용
+- [ ] 모든 public 클래스에 한국어 KDoc 작성
+- [ ] Floci 알려진 버그 항목은 `@Disabled` + 이유 주석 처리
+- [ ] `FlociServer.Launcher.floci` 싱글턴으로 컨테이너 재사용
+- [ ] Kluent assertion 사용 (shouldBe*, shouldNotBe*, shouldContain 등)
+- [ ] 로컬 테스트 통과 (`./gradlew :bluetape4k-testcontainers:test`)

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/FlociServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/FlociServer.kt
@@ -13,7 +13,7 @@ import org.testcontainers.utility.DockerImageName
 import java.net.URI
 
 /**
- * [Floci](https://github.com/atlassian-labs/floci) AWS 에뮬레이터 서버.
+ * [Floci](https://github.com/floci-io/floci) AWS 에뮬레이터 서버.
  *
  * GraalVM Native Image로 빌드된 경량 AWS 에뮬레이터입니다.
  * LocalStack Community edition archived(2026-03-23) 이후의 대안으로 활용할 수 있습니다.
@@ -39,7 +39,7 @@ import java.net.URI
  * val region: String = server.regionName
  * ```
  *
- * 참고: [Floci Docker image](https://hub.docker.com/r/floci/floci/tags)
+ * 참고: [Floci GitHub](https://github.com/floci-io/floci) · [Docker image](https://hub.docker.com/r/floci/floci/tags)
  *
  * @param imageName      Docker 이미지 이름 ([DockerImageName])
  * @param useDefaultPort Default 포트(4566)를 고정 바인딩할지 여부
@@ -60,7 +60,7 @@ class FlociServer private constructor(
         const val IMAGE = "floci/floci"
 
         /** Floci Docker 이미지 기본 태그 */
-        const val TAG = "1.5.7"
+        const val TAG = "1.5.8"
 
         /** PropertyExportingServer 네임스페이스 및 컨테이너 식별자 */
         const val NAME = "floci"

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociCloudWatchTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociCloudWatchTest.kt
@@ -1,0 +1,161 @@
+package io.bluetape4k.testcontainers.aws.floci.services
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.testcontainers.aws.FlociServer
+import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.utils.ShutdownQueue
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeEmpty
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import software.amazon.awssdk.http.apache.ApacheHttpClient
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient
+import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent
+import java.time.Instant
+
+/**
+ * [FlociServer]를 사용한 CloudWatch 서비스 통합 테스트.
+ *
+ * LocalStack 기반 [io.bluetape4k.testcontainers.aws.services.CloudWatchTest]에 대응합니다.
+ */
+@Suppress("DEPRECATION")
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class FlociCloudWatchTest: AbstractContainerTest() {
+
+    companion object: KLogging() {
+        private val NAMESPACE = "Bluetape4k/Test-${System.currentTimeMillis()}"
+        private val LOG_GROUP_NAME = "/bluetape4k/test-${System.currentTimeMillis()}"
+        private const val LOG_STREAM_NAME = "app-stream"
+    }
+
+    private val floci: FlociServer
+        get() = FlociServer.Launcher.floci
+
+    private val cloudWatchClient: CloudWatchClient by lazy {
+        CloudWatchClient.builder()
+            .endpointOverride(floci.awsEndpoint)
+            .region(Region.of(floci.regionName))
+            .credentialsProvider(floci.getCredentialProvider())
+            .httpClient(ApacheHttpClient.create())
+            .build()
+            .apply { ShutdownQueue.register(this) }
+    }
+
+    private val cloudWatchLogsClient: CloudWatchLogsClient by lazy {
+        CloudWatchLogsClient.builder()
+            .endpointOverride(floci.awsEndpoint)
+            .region(Region.of(floci.regionName))
+            .credentialsProvider(floci.getCredentialProvider())
+            .httpClient(ApacheHttpClient.create())
+            .build()
+            .apply { ShutdownQueue.register(this) }
+    }
+
+    @BeforeAll
+    fun setup() {
+        floci.isRunning.shouldBeTrue()
+    }
+
+    @Test
+    @Order(1)
+    fun `create client`() {
+        cloudWatchClient.shouldNotBeNull()
+        cloudWatchLogsClient.shouldNotBeNull()
+    }
+
+    @Test
+    @Order(2)
+    fun `put metric data`() {
+        val response = cloudWatchClient.putMetricData {
+            it.namespace(NAMESPACE)
+                .metricData(
+                    MetricDatum.builder()
+                        .metricName("RequestCount")
+                        .value(42.0)
+                        .unit(StandardUnit.COUNT)
+                        .build(),
+                    MetricDatum.builder()
+                        .metricName("ResponseTimeMs")
+                        .value(125.5)
+                        .unit(StandardUnit.MILLISECONDS)
+                        .build(),
+                )
+        }
+        log.debug { "PutMetricData response: ${response.sdkHttpResponse().statusCode()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(3)
+    fun `list metrics`() {
+        val metrics = cloudWatchClient.listMetrics { it.namespace(NAMESPACE) }.metrics()
+        log.debug { "Metrics: ${metrics.map { it.metricName() }}" }
+        metrics.size shouldBeGreaterOrEqualTo 1
+    }
+
+    @Test
+    @Order(4)
+    fun `create log group`() {
+        val response = cloudWatchLogsClient.createLogGroup { it.logGroupName(LOG_GROUP_NAME) }
+        log.debug { "CreateLogGroup: ${response.sdkHttpResponse().statusCode()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(5)
+    fun `create log stream`() {
+        val response = cloudWatchLogsClient.createLogStream {
+            it.logGroupName(LOG_GROUP_NAME).logStreamName(LOG_STREAM_NAME)
+        }
+        log.debug { "CreateLogStream: ${response.sdkHttpResponse().statusCode()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(6)
+    fun `put log events`() {
+        val now = Instant.now().toEpochMilli()
+        val events = (1..3).map { i ->
+            InputLogEvent.builder()
+                .timestamp(now + i * 100L)
+                .message("로그 이벤트 #$i - Floci CloudWatchLogs 테스트")
+                .build()
+        }
+        val response = cloudWatchLogsClient.putLogEvents {
+            it.logGroupName(LOG_GROUP_NAME)
+                .logStreamName(LOG_STREAM_NAME)
+                .logEvents(events)
+        }
+        log.debug { "PutLogEvents nextSequenceToken=${response.nextSequenceToken()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(7)
+    fun `describe log groups`() {
+        val groups = cloudWatchLogsClient.describeLogGroups { }.logGroups()
+        log.debug { "Log groups: ${groups.map { it.logGroupName() }}" }
+        groups.shouldNotBeEmpty()
+    }
+
+    @Test
+    @Order(8)
+    fun `describe log streams`() {
+        val streams = cloudWatchLogsClient.describeLogStreams {
+            it.logGroupName(LOG_GROUP_NAME)
+        }.logStreams()
+        log.debug { "Log streams: ${streams.map { it.logStreamName() }}" }
+        streams.shouldNotBeEmpty()
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociDynamoDBTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociDynamoDBTest.kt
@@ -1,0 +1,145 @@
+package io.bluetape4k.testcontainers.aws.floci.services
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.testcontainers.aws.FlociServer
+import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.utils.ShutdownQueue
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.AttributeAction
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.AttributeValueUpdate
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement
+import software.amazon.awssdk.services.dynamodb.model.KeyType
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest
+
+/**
+ * [FlociServer]를 사용한 DynamoDB 서비스 통합 테스트.
+ *
+ * LocalStack 기반 [io.bluetape4k.testcontainers.aws.services.DynamoDBTest]에 대응합니다.
+ *
+ * > **알려진 제한사항**: Floci #587 — GSI Query 페이지네이션 무한루프 버그로 인해
+ * > GSI 관련 테스트는 포함하지 않습니다.
+ */
+@Suppress("DEPRECATION")
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class FlociDynamoDBTest: AbstractContainerTest() {
+
+    companion object: KLogging() {
+        private const val TABLE_NAME = "test-table"
+    }
+
+    private val floci: FlociServer
+        get() = FlociServer.Launcher.floci
+
+    private val client: DynamoDbClient by lazy {
+        DynamoDbClient.builder()
+            .endpointOverride(floci.awsEndpoint)
+            .region(Region.of(floci.regionName))
+            .credentialsProvider(floci.getCredentialProvider())
+            .build()
+            .apply { ShutdownQueue.register(this) }
+    }
+
+    @BeforeAll
+    fun setup() {
+        floci.isRunning.shouldBeTrue()
+
+        val createTableRequest = CreateTableRequest.builder()
+            .tableName(TABLE_NAME)
+            .attributeDefinitions(
+                AttributeDefinition.builder().attributeName("id").attributeType(ScalarAttributeType.S).build()
+            )
+            .keySchema(KeySchemaElement.builder().attributeName("id").keyType(KeyType.HASH).build())
+            .provisionedThroughput(ProvisionedThroughput.builder().readCapacityUnits(5L).writeCapacityUnits(5L).build())
+            .build()
+        val createTableResponse = client.createTable(createTableRequest)
+        createTableResponse.shouldNotBeNull()
+        log.debug { "Table: ${createTableResponse.tableDescription()}" }
+    }
+
+    @Test
+    @Order(1)
+    fun `insert data`() {
+        val item = mutableMapOf(
+            "id" to AttributeValue.builder().s("1").build(),
+            "name" to AttributeValue.builder().s("debop").build(),
+            "age" to AttributeValue.builder().n("51").build()
+        )
+
+        val response = client.putItem(PutItemRequest.builder().tableName(TABLE_NAME).item(item).build())
+        response.shouldNotBeNull()
+
+        val scanResponse = client.scan(ScanRequest.builder().tableName(TABLE_NAME).build())
+        scanResponse.shouldNotBeNull()
+        scanResponse.count() shouldBeGreaterOrEqualTo 1
+    }
+
+    @Test
+    @Order(2)
+    fun `get item`() {
+        val key = mutableMapOf(
+            "id" to AttributeValue.builder().s("1").build()
+        )
+        val response = client.getItem { it.tableName(TABLE_NAME).key(key) }
+        response.shouldNotBeNull()
+        response.hasItem().shouldBeTrue()
+        log.debug { "Item: ${response.item()}" }
+        response.item()["name"]?.s() shouldBeEqualTo "debop"
+    }
+
+    @Test
+    @Order(3)
+    fun `update item`() {
+        val key = mutableMapOf(
+            "id" to AttributeValue.builder().s("1").build()
+        )
+        val updates = mutableMapOf(
+            "age" to AttributeValueUpdate.builder()
+                .value(AttributeValue.builder().n("52").build())
+                .action(AttributeAction.PUT)
+                .build()
+        )
+        val response = client.updateItem {
+            it.tableName(TABLE_NAME).key(key).attributeUpdates(updates)
+        }
+        log.debug { "UpdateItem HTTP status: ${response.sdkHttpResponse().statusCode()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(4)
+    fun `delete item`() {
+        val key = mutableMapOf(
+            "id" to AttributeValue.builder().s("1").build()
+        )
+        val response = client.deleteItem { it.tableName(TABLE_NAME).key(key) }
+        log.debug { "DeleteItem HTTP status: ${response.sdkHttpResponse().statusCode()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(5)
+    fun `list tables`() {
+        val response = client.listTables()
+        log.debug { "Tables: ${response.tableNames()}" }
+        response.tableNames() shouldContain TABLE_NAME
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociKMSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociKMSTest.kt
@@ -1,0 +1,250 @@
+package io.bluetape4k.testcontainers.aws.floci.services
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.testcontainers.aws.FlociServer
+import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.utils.ShutdownQueue
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldNotBeEmpty
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.kms.KmsClient
+import software.amazon.awssdk.services.kms.model.CreateKeyRequest
+import software.amazon.awssdk.services.kms.model.DecryptRequest
+import software.amazon.awssdk.services.kms.model.DecryptResponse
+import software.amazon.awssdk.services.kms.model.DisableKeyRequest
+import software.amazon.awssdk.services.kms.model.EncryptRequest
+import software.amazon.awssdk.services.kms.model.GrantOperation
+import software.amazon.awssdk.services.kms.model.KeySpec
+import software.amazon.awssdk.services.kms.model.KeyUsageType
+
+/**
+ * [FlociServer]를 사용한 KMS 서비스 통합 테스트.
+ *
+ * LocalStack 기반 [io.bluetape4k.testcontainers.aws.services.KMSTest]에 대응합니다.
+ *
+ * > **알려진 제한사항**: Floci #586 — 비대칭 키(asymmetric key)의 `GetKeyRotationStatus` 동작 불가.
+ * > 비대칭 키 관련 테스트는 포함하지 않습니다.
+ */
+@Suppress("DEPRECATION")
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class FlociKMSTest: AbstractContainerTest() {
+
+    companion object: KLogging()
+
+    private val floci: FlociServer
+        get() = FlociServer.Launcher.floci
+
+    private val kmsClient: KmsClient by lazy {
+        KmsClient.builder()
+            .endpointOverride(floci.awsEndpoint)
+            .region(Region.of(floci.regionName))
+            .credentialsProvider(floci.getCredentialProvider())
+            .build()
+            .apply { ShutdownQueue.register(this) }
+    }
+
+    private val keyDesc = "Create by the AWS KMS API"
+    private lateinit var keyId: String
+
+    private val data = "동해물과 백두산이"
+    private lateinit var encryptedData: SdkBytes
+
+    private val granteePrincipal = ""
+    private lateinit var grantId: String
+
+    private val aliasName = "alias/ExampleName"
+
+    @BeforeAll
+    fun setup() {
+        floci.isRunning.shouldBeTrue()
+    }
+
+    @Test
+    @Order(1)
+    fun `container loading`() {
+        kmsClient.shouldNotBeNull()
+    }
+
+    @Test
+    @Order(2)
+    fun `create custom key`() {
+        val keyRequest = CreateKeyRequest.builder()
+            .description(keyDesc)
+            .keySpec(KeySpec.SYMMETRIC_DEFAULT)
+            .keyUsage(KeyUsageType.ENCRYPT_DECRYPT)
+            .build()
+
+        val response = kmsClient.createKey(keyRequest)
+        log.debug { "Created a custom key with id=${response.keyMetadata().arn()}" }
+
+        keyId = response.keyMetadata().keyId()
+        log.info { "custom keyId=$keyId" }
+        keyId.shouldNotBeEmpty()
+    }
+
+    @Test
+    @Order(3)
+    fun `encrypt data`() {
+        val encryptRequest = EncryptRequest.builder()
+            .keyId(keyId)
+            .plaintext(SdkBytes.fromUtf8String(data))
+            .build()
+
+        val response = kmsClient.encrypt(encryptRequest)
+        val algorithm = response.encryptionAlgorithmAsString()
+        log.debug { "Encryption algorithm is $algorithm" }
+
+        encryptedData = response.ciphertextBlob()
+    }
+
+    @Test
+    @Order(4)
+    fun `decrypt data`() {
+        val decryptRequest = DecryptRequest.builder()
+            .keyId(keyId)
+            .ciphertextBlob(encryptedData)
+            .build()
+
+        val response: DecryptResponse = kmsClient.decrypt(decryptRequest)
+        val plainBytes = response.plaintext()
+
+        plainBytes.asUtf8String() shouldBeEqualTo data
+    }
+
+    @Test
+    @Order(5)
+    fun `disable customer key`() {
+        val disableKeyRequest = DisableKeyRequest.builder().keyId(keyId).build()
+
+        val response = kmsClient.disableKey(disableKeyRequest)
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(6)
+    fun `enable customer key`() {
+        val response = kmsClient.enableKey { it.keyId(keyId) }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(7)
+    fun `create grant`() {
+        val response = kmsClient.createGrant {
+            it.keyId(keyId)
+            it.granteePrincipal(granteePrincipal)
+            it.operations(GrantOperation.CREATE_GRANT, GrantOperation.ENCRYPT, GrantOperation.DECRYPT)
+        }
+        log.debug { "Grant id=${response.grantId()}, token=${response.grantToken()}" }
+        grantId = response.grantId()
+    }
+
+    @Test
+    @Order(8)
+    fun `list grants`() {
+        val response = kmsClient.listGrants {
+            it.keyId(keyId)
+            it.limit(15)
+        }
+        val grants = response.grants()
+        grants.forEach { grant ->
+            log.debug { "Grant id=${grant.grantId()}" }
+        }
+        grants.map { it.grantId() } shouldContain this.grantId
+    }
+
+    @Test
+    @Order(9)
+    fun `revoke grant`() {
+        val response = kmsClient.revokeGrant { it.keyId(keyId).grantId(grantId) }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(10)
+    fun `describe key`() {
+        val response = kmsClient.describeKey { it.keyId(keyId) }
+
+        val keyMetadata = response.keyMetadata()
+        log.debug { "key description=${keyMetadata.description()}" }
+        log.debug { "key arn=${keyMetadata.arn()}" }
+    }
+
+    @Test
+    @Order(11)
+    fun `create custom alias`() {
+        val response = kmsClient.createAlias {
+            it.aliasName(aliasName).targetKeyId(keyId)
+        }
+
+        val metadata = response.responseMetadata()
+        log.debug { "metadata=$metadata" }
+    }
+
+    @Test
+    @Order(12)
+    fun `list aliases`() {
+        val response = kmsClient.listAliases { it.limit(10) }
+        response.aliases().forEach { alias ->
+            log.debug { "Alias name=$alias" }
+        }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(13)
+    fun `delete alias`() {
+        val response = kmsClient.deleteAlias { it.aliasName(aliasName) }
+        val metadata = response.responseMetadata()
+        log.debug { "metadata=$metadata" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(14)
+    fun `list keys`() {
+        val response = kmsClient.listKeys { it.limit(15) }
+
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+
+        val keys = response.keys()
+        keys.forEach { entry ->
+            log.debug { "Key arn=${entry.keyArn()}, id=${entry.keyId()}" }
+        }
+    }
+
+    @Test
+    @Order(15)
+    fun `put key policy`() {
+        val policyName = "default"
+        val policy = """
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {"AWS": "arn:aws:iam::814548047983:root"},
+                        "Action": "kms:*",
+                        "Resource": "*"
+                    }
+                ]
+            }""".trimIndent()
+
+        val response = kmsClient.putKeyPolicy {
+            it.keyId(keyId).policyName(policyName).policy(policy)
+        }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociKMSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociKMSTest.kt
@@ -13,6 +13,7 @@ import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldNotBeEmpty
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -34,8 +35,10 @@ import software.amazon.awssdk.services.kms.model.KeyUsageType
  *
  * LocalStack 기반 [io.bluetape4k.testcontainers.aws.services.KMSTest]에 대응합니다.
  *
- * > **알려진 제한사항**: Floci #586 — 비대칭 키(asymmetric key)의 `GetKeyRotationStatus` 동작 불가.
+ * > **알려진 제한사항 1**: Floci #586 — 비대칭 키(asymmetric key)의 `GetKeyRotationStatus` 동작 불가.
  * > 비대칭 키 관련 테스트는 포함하지 않습니다.
+ * > **알려진 제한사항 2**: `DisableKey`, `EnableKey`, `CreateGrant`, `ListGrants`, `RevokeGrant` 미지원 (Status 400).
+ * > 해당 테스트는 `@Disabled`로 표시합니다.
  */
 @Suppress("DEPRECATION")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
@@ -125,6 +128,7 @@ class FlociKMSTest: AbstractContainerTest() {
 
     @Test
     @Order(5)
+    @Disabled("Floci KMS: DisableKey 미지원 (Operation not supported, Status 400)")
     fun `disable customer key`() {
         val disableKeyRequest = DisableKeyRequest.builder().keyId(keyId).build()
 
@@ -134,6 +138,7 @@ class FlociKMSTest: AbstractContainerTest() {
 
     @Test
     @Order(6)
+    @Disabled("Floci KMS: EnableKey 미지원 (Operation not supported, Status 400)")
     fun `enable customer key`() {
         val response = kmsClient.enableKey { it.keyId(keyId) }
         response.sdkHttpResponse().isSuccessful.shouldBeTrue()
@@ -141,6 +146,7 @@ class FlociKMSTest: AbstractContainerTest() {
 
     @Test
     @Order(7)
+    @Disabled("Floci KMS: CreateGrant 미지원 (Operation not supported, Status 400)")
     fun `create grant`() {
         val response = kmsClient.createGrant {
             it.keyId(keyId)
@@ -153,6 +159,7 @@ class FlociKMSTest: AbstractContainerTest() {
 
     @Test
     @Order(8)
+    @Disabled("Floci KMS: ListGrants 미지원 (Operation not supported, Status 400)")
     fun `list grants`() {
         val response = kmsClient.listGrants {
             it.keyId(keyId)
@@ -167,6 +174,7 @@ class FlociKMSTest: AbstractContainerTest() {
 
     @Test
     @Order(9)
+    @Disabled("Floci KMS: RevokeGrant 미지원 (CreateGrant 선행 필요, 동일 제약)")
     fun `revoke grant`() {
         val response = kmsClient.revokeGrant { it.keyId(keyId).grantId(grantId) }
         response.sdkHttpResponse().isSuccessful.shouldBeTrue()

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociKinesisTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociKinesisTest.kt
@@ -1,0 +1,148 @@
+package io.bluetape4k.testcontainers.aws.floci.services
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.testcontainers.aws.FlociServer
+import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.utils.ShutdownQueue
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeNull
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.until
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.kinesis.KinesisClient
+import software.amazon.awssdk.services.kinesis.model.PutRecordsRequestEntry
+import software.amazon.awssdk.services.kinesis.model.ShardIteratorType
+import software.amazon.awssdk.services.kinesis.model.StreamStatus
+import java.time.Duration
+
+/**
+ * [FlociServer]를 사용한 Kinesis 서비스 통합 테스트.
+ *
+ * LocalStack 기반 [io.bluetape4k.testcontainers.aws.services.KinesisTest]에 대응합니다.
+ */
+@Suppress("DEPRECATION")
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class FlociKinesisTest: AbstractContainerTest() {
+
+    companion object: KLogging() {
+        private val STREAM_NAME = "test-stream-${System.currentTimeMillis()}"
+    }
+
+    private val floci: FlociServer
+        get() = FlociServer.Launcher.floci
+
+    private val kinesisClient: KinesisClient by lazy {
+        KinesisClient.builder()
+            .endpointOverride(floci.awsEndpoint)
+            .region(Region.of(floci.regionName))
+            .credentialsProvider(floci.getCredentialProvider())
+            .build()
+            .apply { ShutdownQueue.register(this) }
+    }
+
+    @BeforeAll
+    fun setup() {
+        floci.isRunning.shouldBeTrue()
+    }
+
+    @Test
+    @Order(1)
+    fun `create stream`() {
+        kinesisClient.createStream { it.streamName(STREAM_NAME).shardCount(1) }
+
+        await atMost Duration.ofSeconds(30) until {
+            kinesisClient.describeStream { it.streamName(STREAM_NAME) }
+                .streamDescription().streamStatus() == StreamStatus.ACTIVE
+        }
+        log.debug { "Stream $STREAM_NAME is now ACTIVE" }
+    }
+
+    @Test
+    @Order(2)
+    fun `list streams`() {
+        val streams = kinesisClient.listStreams().streamNames()
+        log.debug { "Streams: $streams" }
+        streams.shouldNotBeNull()
+    }
+
+    @Test
+    @Order(3)
+    fun `put record`() {
+        val response = kinesisClient.putRecord {
+            it.streamName(STREAM_NAME)
+                .partitionKey("pk-1")
+                .data(SdkBytes.fromUtf8String("Hello Kinesis!"))
+        }
+        log.debug { "SequenceNumber: ${response.sequenceNumber()}, ShardId: ${response.shardId()}" }
+        response.sequenceNumber().shouldNotBeNull()
+    }
+
+    @Test
+    @Order(4)
+    fun `put records batch`() {
+        val entries = (1..5).map { i ->
+            PutRecordsRequestEntry.builder()
+                .partitionKey("pk-$i")
+                .data(SdkBytes.fromUtf8String("배치 메시지 #$i"))
+                .build()
+        }
+        val response = kinesisClient.putRecords {
+            it.streamName(STREAM_NAME).records(entries)
+        }
+        log.debug { "FailedRecordCount: ${response.failedRecordCount()}" }
+        response.failedRecordCount() shouldBeEqualTo 0
+    }
+
+    @Test
+    @Order(5)
+    fun `get records`() {
+        val shardId = kinesisClient.describeStream { it.streamName(STREAM_NAME) }
+            .streamDescription().shards().first().shardId()
+
+        val shardIterator = kinesisClient.getShardIterator {
+            it.streamName(STREAM_NAME)
+                .shardId(shardId)
+                .shardIteratorType(ShardIteratorType.TRIM_HORIZON)
+        }.shardIterator()
+
+        var receivedCount = 0
+        var currentIterator = shardIterator
+        await atMost Duration.ofSeconds(15) until {
+            val response = kinesisClient.getRecords {
+                it.shardIterator(currentIterator).limit(10)
+            }
+            currentIterator = response.nextShardIterator() ?: currentIterator
+            receivedCount += response.records().size
+            response.records().isNotEmpty()
+        }
+        log.debug { "Received $receivedCount records" }
+        receivedCount shouldBeGreaterOrEqualTo 1
+    }
+
+    @Test
+    @Order(6)
+    fun `describe stream`() {
+        val description = kinesisClient.describeStream { it.streamName(STREAM_NAME) }.streamDescription()
+        log.debug { "Stream status: ${description.streamStatus()}, shards: ${description.shards().size}" }
+        description.streamStatus() shouldBeEqualTo StreamStatus.ACTIVE
+    }
+
+    @Test
+    @Order(7)
+    fun `delete stream`() {
+        val response = kinesisClient.deleteStream { it.streamName(STREAM_NAME) }
+        log.debug { "DeleteStream HTTP status: ${response.sdkHttpResponse().statusCode()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociS3Test.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociS3Test.kt
@@ -1,0 +1,109 @@
+package io.bluetape4k.testcontainers.aws.floci.services
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.support.toUtf8Bytes
+import io.bluetape4k.support.toUtf8String
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.testcontainers.aws.FlociServer
+import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.utils.ShutdownQueue
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeEmpty
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+
+/**
+ * [FlociServer]를 사용한 S3 서비스 통합 테스트.
+ *
+ * LocalStack 기반 [io.bluetape4k.testcontainers.aws.services.S3Test]에 대응합니다.
+ */
+@Suppress("DEPRECATION")
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class FlociS3Test: AbstractContainerTest() {
+
+    companion object: KLogging()
+
+    private val floci: FlociServer
+        get() = FlociServer.Launcher.floci
+
+    private val s3Client: S3Client by lazy {
+        S3Client.builder()
+            .endpointOverride(floci.awsEndpoint)
+            .region(Region.of(floci.regionName))
+            .credentialsProvider(floci.getCredentialProvider())
+            .build()
+            .apply { ShutdownQueue.register(this) }
+    }
+
+    private val bucketName = "foo"
+    private val keyName = "bar"
+    private val content = "baz"
+
+    @BeforeAll
+    fun setup() {
+        floci.isRunning.shouldBeTrue()
+    }
+
+    @Test
+    @Order(1)
+    fun `run s3 server by FlociServer`() {
+        floci.isRunning.shouldBeTrue()
+    }
+
+    @Test
+    @Order(2)
+    fun `create bucket`() {
+        val waiter = s3Client.waiter()
+
+        val createBucketRequest = CreateBucketRequest.builder().bucket(bucketName).build()
+        s3Client.createBucket(createBucketRequest)
+
+        val bucketRequestWait = HeadBucketRequest.builder().bucket(bucketName).build()
+        val waiterResponse = waiter.waitUntilBucketExists(bucketRequestWait)
+        waiterResponse.matched().response().ifPresent {
+            log.debug { "S3 HTTP response: ${it.sdkHttpResponse()}" }
+            it.sdkHttpResponse().isSuccessful.shouldBeTrue()
+        }
+    }
+
+    @Test
+    @Order(3)
+    fun `put object`() {
+        val metadata = mapOf("x-amz-meta-myVal" to "test")
+        val request = PutObjectRequest.builder()
+            .bucket(bucketName)
+            .key(keyName)
+            .metadata(metadata)
+            .build()
+
+        val response = s3Client.putObject(request, RequestBody.fromBytes(content.toUtf8Bytes()))
+
+        log.debug { "eTag=${response.eTag()}" }
+        response.eTag().shouldNotBeEmpty()
+    }
+
+    @Test
+    @Order(4)
+    fun `get object`() {
+        val request = GetObjectRequest.builder()
+            .bucket(bucketName)
+            .key(keyName)
+            .build()
+
+        val response = s3Client.getObjectAsBytes(request)!!
+        val bytes = response.asByteArray()!!
+        bytes.toUtf8String() shouldBeEqualTo content
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociS3Test.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociS3Test.kt
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.TestMethodOrder
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.S3Configuration
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.HeadBucketRequest
@@ -43,6 +44,8 @@ class FlociS3Test: AbstractContainerTest() {
             .endpointOverride(floci.awsEndpoint)
             .region(Region.of(floci.regionName))
             .credentialsProvider(floci.getCredentialProvider())
+            // Floci는 virtual-hosted-style URL을 지원하지 않으므로 path-style 필수
+            .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
             .build()
             .apply { ShutdownQueue.register(this) }
     }

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSNSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSNSTest.kt
@@ -1,0 +1,130 @@
+package io.bluetape4k.testcontainers.aws.floci.services
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.testcontainers.aws.FlociServer
+import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.utils.ShutdownQueue
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeEmpty
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.sns.SnsClient
+
+/**
+ * [FlociServer]를 사용한 SNS 서비스 통합 테스트.
+ *
+ * LocalStack 기반 [io.bluetape4k.testcontainers.aws.services.SNSTest]에 대응합니다.
+ */
+@Suppress("DEPRECATION")
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class FlociSNSTest: AbstractContainerTest() {
+
+    companion object: KLogging() {
+        private val TOPIC_NAME = "test-topic-${System.currentTimeMillis()}"
+    }
+
+    private val floci: FlociServer
+        get() = FlociServer.Launcher.floci
+
+    private val snsClient: SnsClient by lazy {
+        SnsClient.builder()
+            .endpointOverride(floci.awsEndpoint)
+            .region(Region.of(floci.regionName))
+            .credentialsProvider(floci.getCredentialProvider())
+            .build()
+            .apply { ShutdownQueue.register(this) }
+    }
+
+    private lateinit var topicArn: String
+    private lateinit var subscriptionArn: String
+
+    @BeforeAll
+    fun setup() {
+        floci.isRunning.shouldBeTrue()
+    }
+
+    @Test
+    @Order(1)
+    fun `create topic`() {
+        val response = snsClient.createTopic { it.name(TOPIC_NAME) }
+        topicArn = response.topicArn()
+        log.debug { "Created topic ARN: $topicArn" }
+        topicArn.shouldNotBeNull()
+    }
+
+    @Test
+    @Order(2)
+    fun `list topics`() {
+        val topics = snsClient.listTopics().topics()
+        log.debug { "Topics: ${topics.map { it.topicArn() }}" }
+        topics.shouldNotBeEmpty()
+    }
+
+    @Test
+    @Order(3)
+    fun `get topic attributes`() {
+        val attrs = snsClient.getTopicAttributes { it.topicArn(topicArn) }.attributes()
+        log.debug { "Topic attributes: $attrs" }
+        attrs.shouldNotBeNull()
+    }
+
+    @Test
+    @Order(4)
+    fun `publish message`() {
+        val response = snsClient.publish {
+            it.topicArn(topicArn)
+                .subject("Test Subject")
+                .message("Hello from SNS Floci!")
+        }
+        log.debug { "Published MessageId: ${response.messageId()}" }
+        response.messageId().shouldNotBeNull()
+    }
+
+    @Test
+    @Order(5)
+    fun `subscribe with email protocol`() {
+        val response = snsClient.subscribe {
+            it.topicArn(topicArn)
+                .protocol("email")
+                .endpoint("test@example.com")
+        }
+        log.debug { "Subscription ARN: ${response.subscriptionArn()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+        subscriptionArn = response.subscriptionArn()
+    }
+
+    @Test
+    @Order(6)
+    fun `list subscriptions`() {
+        val subscriptions = snsClient.listSubscriptions().subscriptions()
+        log.debug { "Subscriptions: ${subscriptions.map { it.subscriptionArn() }}" }
+        subscriptions.shouldNotBeEmpty()
+    }
+
+    @Test
+    @Order(7)
+    fun `set topic attributes`() {
+        val response = snsClient.setTopicAttributes {
+            it.topicArn(topicArn)
+                .attributeName("DisplayName")
+                .attributeValue("Bluetape4k Test Topic")
+        }
+        log.debug { "SetTopicAttributes HTTP status: ${response.sdkHttpResponse().statusCode()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(8)
+    fun `delete topic`() {
+        val response = snsClient.deleteTopic { it.topicArn(topicArn) }
+        log.debug { "DeleteTopic HTTP status: ${response.sdkHttpResponse().statusCode()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSQSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSQSTest.kt
@@ -1,0 +1,141 @@
+package io.bluetape4k.testcontainers.aws.floci.services
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.testcontainers.aws.FlociServer
+import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.utils.ShutdownQueue
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldHaveSize
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.sqs.SqsClient
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry
+
+/**
+ * [FlociServer]를 사용한 SQS 서비스 통합 테스트.
+ *
+ * LocalStack 기반 [io.bluetape4k.testcontainers.aws.services.SQSTest]에 대응합니다.
+ */
+@Suppress("DEPRECATION")
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class FlociSQSTest: AbstractContainerTest() {
+
+    companion object: KLogging() {
+        private val QUEUE_NAME = "test-queue-${System.currentTimeMillis()}"
+    }
+
+    private val floci: FlociServer
+        get() = FlociServer.Launcher.floci
+
+    private val sqsClient: SqsClient by lazy {
+        SqsClient.builder()
+            .endpointOverride(floci.awsEndpoint)
+            .region(Region.of(floci.regionName))
+            .credentialsProvider(floci.getCredentialProvider())
+            .build()
+            .apply { ShutdownQueue.register(this) }
+    }
+
+    private lateinit var queueUrl: String
+
+    @BeforeAll
+    fun setup() {
+        floci.isRunning.shouldBeTrue()
+    }
+
+    @Test
+    @Order(1)
+    fun `create queue`() {
+        sqsClient.createQueue { it.queueName(QUEUE_NAME) }
+        queueUrl = sqsClient.getQueueUrl { it.queueName(QUEUE_NAME) }.queueUrl()
+        log.debug { "Queue url=$queueUrl" }
+    }
+
+    @Test
+    @Order(2)
+    fun `list queue`() {
+        val listResponse = sqsClient.listQueues { it.queueNamePrefix("test") }
+
+        listResponse.queueUrls().forEach {
+            log.debug { "queue url=$it" }
+        }
+    }
+
+    @Test
+    @Order(3)
+    fun `send message`() {
+        val sendResponse = sqsClient.sendMessage {
+            it.queueUrl(queueUrl)
+                .messageBody("Hello world")
+                .delaySeconds(10)
+        }
+        log.debug { "sendResponse=$sendResponse" }
+    }
+
+    @Test
+    @Order(4)
+    fun `send batch messages`() {
+        val entries = List(10) {
+            SendMessageBatchRequestEntry.builder()
+                .id("id$it")
+                .messageBody("Hello, world $it")
+                .build()
+        }
+        val sendBatchResponse = sqsClient.sendMessageBatch {
+            it.queueUrl(queueUrl)
+                .entries(entries)
+        }
+        sendBatchResponse.successful() shouldHaveSize entries.size
+        sendBatchResponse.successful().forEach {
+            log.debug { "result entry=$it" }
+        }
+    }
+
+    @Test
+    @Order(5)
+    fun `receive messages`() {
+        val messages = sqsClient.receiveMessage {
+            it.queueUrl(queueUrl).maxNumberOfMessages(3)
+        }.messages()
+
+        messages shouldHaveSize 3
+    }
+
+    @Test
+    @Order(6)
+    fun `change messages`() {
+        val messages = sqsClient.receiveMessage {
+            it.queueUrl(queueUrl).maxNumberOfMessages(3)
+        }.messages()
+
+        val responses = messages.map { message ->
+            sqsClient.changeMessageVisibility {
+                it.queueUrl(queueUrl)
+                    .receiptHandle(message.receiptHandle())
+                    .visibilityTimeout(100)
+            }
+        }
+        responses shouldHaveSize messages.size
+    }
+
+    @Test
+    @Order(7)
+    fun `delete messages`() {
+        val messages = sqsClient.receiveMessage {
+            it.queueUrl(queueUrl).maxNumberOfMessages(3)
+        }.messages()
+
+        val responses = messages.map { message ->
+            sqsClient.deleteMessage {
+                it.queueUrl(queueUrl).receiptHandle(message.receiptHandle())
+            }
+        }
+        responses shouldHaveSize messages.size
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSTSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSTSTest.kt
@@ -1,0 +1,92 @@
+package io.bluetape4k.testcontainers.aws.floci.services
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.testcontainers.aws.FlociServer
+import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.utils.ShutdownQueue
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeBlank
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.sts.StsClient
+
+/**
+ * [FlociServer]를 사용한 STS 서비스 통합 테스트.
+ *
+ * LocalStack 기반 [io.bluetape4k.testcontainers.aws.services.STSTest]에 대응합니다.
+ */
+@Suppress("DEPRECATION")
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class FlociSTSTest: AbstractContainerTest() {
+
+    companion object: KLogging()
+
+    private val floci: FlociServer
+        get() = FlociServer.Launcher.floci
+
+    private val stsClient: StsClient by lazy {
+        StsClient.builder()
+            .endpointOverride(floci.awsEndpoint)
+            .region(Region.of(floci.regionName))
+            .credentialsProvider(floci.getCredentialProvider())
+            .build()
+            .apply { ShutdownQueue.register(this) }
+    }
+
+    private lateinit var accountId: String
+
+    @BeforeAll
+    fun setup() {
+        floci.isRunning.shouldBeTrue()
+    }
+
+    @Test
+    @Order(1)
+    fun `get caller identity`() {
+        val identity = stsClient.getCallerIdentity { }
+        log.debug { "Account: ${identity.account()}, UserId: ${identity.userId()}, ARN: ${identity.arn()}" }
+
+        accountId = identity.account()
+        identity.account().shouldNotBeBlank()
+        identity.userId().shouldNotBeBlank()
+        identity.arn().shouldNotBeBlank()
+    }
+
+    @Test
+    @Order(2)
+    fun `assume role`() {
+        val credentials = stsClient.assumeRole {
+            it.roleArn("arn:aws:iam::$accountId:role/test-execution-role")
+                .roleSessionName("bluetape4k-test-session")
+                .durationSeconds(3600)
+        }.credentials()
+
+        log.debug { "AssumeRole AccessKeyId: ${credentials.accessKeyId()}" }
+        credentials.shouldNotBeNull()
+        credentials.accessKeyId().shouldNotBeBlank()
+        credentials.secretAccessKey().shouldNotBeBlank()
+        credentials.sessionToken().shouldNotBeBlank()
+        credentials.expiration().shouldNotBeNull()
+    }
+
+    @Test
+    @Order(3)
+    fun `get session token`() {
+        val credentials = stsClient.getSessionToken {
+            it.durationSeconds(3600)
+        }.credentials()
+
+        log.debug { "SessionToken AccessKeyId: ${credentials?.accessKeyId()}" }
+        credentials.shouldNotBeNull()
+        credentials.accessKeyId().shouldNotBeBlank()
+        credentials.secretAccessKey().shouldNotBeBlank()
+        credentials.sessionToken().shouldNotBeBlank()
+    }
+}


### PR DESCRIPTION
## Summary

Closes #202

- PR 제목: test(testcontainers): FlociServer 기반 AWS 서비스 통합 테스트 추가 (#202)

GitHub Issue #202에 따라 FlociServer를 사용한 AWS 서비스 통합 테스트 8종을 추가합니다.
기존 LocalStack 기반 `io.bluetape4k.testcontainers.aws.services` 테스트를 Floci 에뮬레이터용으로 미러링합니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 신규 테스트 파일 (8종)
`testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/`

| 파일 | 테스트 수 | Skipped | 대응 LocalStack 테스트 |
|------|-----------|---------|----------------------|
| FlociS3Test.kt | 4 | 0 | S3Test.kt |
| FlociSQSTest.kt | 7 | 0 | SQSTest.kt |
| FlociSNSTest.kt | 8 | 0 | SNSTest.kt |
| FlociDynamoDBTest.kt | 5 | 0 | DynamoDBTest.kt |
| FlociKinesisTest.kt | 7 | 0 | KinesisTest.kt |
| FlociKMSTest.kt | 15 | 5 | KMSTest.kt |
| FlociSTSTest.kt | 3 | 0 | STSTest.kt |
| FlociCloudWatchTest.kt | 8 | 0 | CloudWatchTest.kt |

**총계: 57 실행, 5 skipped(@Disabled), 0 실패**

### FlociServer TAG 업데이트
- `FlociServer.kt`: TAG `1.5.7` → `1.5.8`
- KDoc GitHub URL 수정: `atlassian-labs/floci` → `floci-io/floci`

### 설계/구현 문서
- `docs/superpowers/specs/2026-04-27-floci-service-tests-design.md`
- `docs/superpowers/plans/2026-04-27-floci-service-tests-plan.md`

### 기존 섹션: 주요 적용 패턴

- `@Suppress("DEPRECATION")` — FlociServer는 @Deprecated(WARNING)
- `companion object: KLogging()` — 프로젝트 표준 로깅
- `FlociServer.Launcher.floci` 싱글톤 사용
- `floci.awsEndpoint` / `floci.regionName` API
- **S3**: `S3Configuration.builder().pathStyleAccessEnabled(true)` — Floci는 virtual-hosted-style URL 미지원
- **CloudWatch**: `ApacheHttpClient.create()` 명시 (LocalStack과 동일)

### 기존 섹션: 알려진 Floci 제한사항 (@Disabled 처리)

| 서비스 | 미지원 작업 | Disabled 수 |
|--------|-------------|-------------|
| KMS | DisableKey, EnableKey, CreateGrant, ListGrants, RevokeGrant | 5 |
| DynamoDB | GSI Query pagination (Floci #587, 무한루프 버그) | 미포함 |

### 기존 섹션: 검증 명령

```bash
./gradlew :bluetape4k-testcontainers:test --tests "io.bluetape4k.testcontainers.aws.floci.*"
```

## Validation

```
./gradlew :bluetape4k-testcontainers:test --tests "io.bluetape4k.testcontainers.aws.floci.*"

FlociCloudWatchTest : tests=8, skipped=0, failures=0
FlociDynamoDBTest   : tests=5, skipped=0, failures=0
FlociKMSTest        : tests=15, skipped=5, failures=0
FlociKinesisTest    : tests=7, skipped=0, failures=0
FlociS3Test         : tests=4, skipped=0, failures=0
FlociSNSTest        : tests=8, skipped=0, failures=0
FlociSQSTest        : tests=7, skipped=0, failures=0
FlociSTSTest        : tests=3, skipped=0, failures=0

총 57 tests completed, 5 skipped, 0 failed — BUILD SUCCESSFUL
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #202, milestone 없음, assignee 없음
- PR: #207, head `f34d0878a7d650d27dcc172042d8478dedc4e1de`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/floci-service-tests`
- Labels: `test`
- State: `MERGED`, merge commit `9a3ef8d0e5f770afa3cfc16ab571497386785adf`
- CI: GitHub Issue #202에 따라 FlociServer를 사용한 AWS 서비스 통합 테스트 8종을 추가합니다. / 기존 LocalStack 기반 `io.bluetape4k.testcontainers.aws.services` 테스트를 Floci 에뮬레이터용으로 미러링합니다. / `testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #207 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9a3ef8d0e5f770afa3cfc16ab571497386785adf`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
