### PR TITLE
feat: MiniStack AWS 에뮬레이터 서버 도입 (ministackorg/ministack:1.3.14)

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -1427,6 +1427,11 @@ object Libs {
 
     // the Atlassian's LocalStack, 'a fully functional local AWS cloud stack'.
     val testcontainers_localstack = testcontainersModule("localstack")
+
+    // MiniStack — free MIT-licensed AWS emulator (ministack.org), 31+ services, ~270MB image
+    // https://mvnrepository.com/artifact/org.ministack/testcontainers-ministack
+    const val testcontainers_ministack = "org.ministack:testcontainers-ministack:0.1.4"
+
     val testcontainers_mockserver = testcontainersModule("mockserver")
 
     val testcontainers_nginx = testcontainersModule("nginx")

--- a/docs/superpowers/plans/2026-04-28-ministack-server-plan.md
+++ b/docs/superpowers/plans/2026-04-28-ministack-server-plan.md
@@ -1,0 +1,160 @@
+# MiniStackServer 구현 계획
+
+**날짜**: 2026-04-28  
+**브랜치**: `feat/ministack-server`  
+**Spec**: `docs/superpowers/specs/2026-04-27-ministack-server-design.md`  
+**범위**: `testing/testcontainers` 모듈
+
+---
+
+## Task 목록
+
+### T1. 의존성 추가 (complexity: low)
+
+**파일**: `buildSrc/src/main/kotlin/Libs.kt`
+
+- `testcontainers_ministack` 상수를 LocalStack 상수 근처에 추가
+  ```kotlin
+  // MiniStack — free MIT-licensed AWS emulator (ministack.org)
+  const val testcontainers_ministack =
+      "org.ministack:testcontainers-ministack:0.1.4"
+  ```
+
+**파일**: `testing/testcontainers/build.gradle.kts`
+
+- `compileOnly(Libs.testcontainers_localstack)` 아래에 추가
+  ```kotlin
+  compileOnly(Libs.testcontainers_ministack)
+  ```
+
+---
+
+### T2. MiniStackServer.kt 구현 (complexity: medium)
+
+**파일**: `testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServer.kt`
+
+FlociServer.kt 패턴 그대로 따르되 MiniStack 특화 부분 적용:
+
+- `GenericContainer<MiniStackServer>` 상속 + `AwsEmulatorServer` 구현
+- companion object: IMAGE/TAG/NAME/PORT/DEFAULT_ACCESS_KEY/DEFAULT_SECRET_KEY/DEFAULT_REGION 상수
+- `invoke(image, tag, useDefaultPort, reuse)` + `invoke(imageName, useDefaultPort, reuse)` factory
+- `init` 블록:
+  - `addExposedPorts(PORT)`
+  - `withReuse(reuse)`
+  - `Wait.forHttp("/_ministack/health").forStatusCode(200).withStartupTimeout(Duration.ofSeconds(60))`
+  - `if (useDefaultPort) exposeCustomPorts(PORT)`
+- `override val port`, `url`, `awsEndpoint`, `awsAccessKey`, `awsSecretKey`, `regionName`, `propertyNamespace`
+- `propertyKeys()`, `properties()` 구현
+- `withServices()`: no-op (FlociServer 패턴 동일)
+- `start()`: `super.start()` + `writeToSystemProperties()`
+- `Launcher.miniStack`: lazy singleton + `ShutdownQueue.register`
+- 모든 public API에 Korean KDoc 필수
+
+---
+
+### T3. AwsEmulatorServer.kt KDoc 업데이트 (complexity: low)
+
+**파일**: `testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/AwsEmulatorServer.kt`
+
+- class-level KDoc의 에뮬레이터 목록에 MiniStack 추가
+- `withServices` KDoc에 MiniStack no-op 동작 추가
+
+---
+
+### T4. MiniStackServerTest.kt 구현 (complexity: medium)
+
+**파일**: `testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServerTest.kt`
+
+FlociServerTest.kt 패턴 따르되 MiniStack 적용:
+
+- blank image/tag 검증 (`assertFailsWith<IllegalArgumentException>`)
+- 서버 시작 후 `isRunning.shouldBeTrue()`
+- S3 client 연결 테스트 (path-style access enabled)
+  - bucket 생성 → object put → object get 검증
+- `withServices()` no-op 검증
+
+---
+
+### T5. MiniStack CloudWatch/DynamoDB/KMS 서비스 테스트 (complexity: medium)
+
+**경로**: `testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/`
+
+공통 패턴:
+- `MiniStackServer.Launcher.miniStack` (no `.withServices()`)
+- `server.awsEndpoint` (LocalStack의 `.endpoint`가 아닌 `AwsEmulatorServer` 인터페이스 속성)
+- `Region.of(server.regionName)` (LocalStack의 `.region`이 아님)
+- `server.getCredentialProvider()`
+
+**MiniStackCloudWatchTest.kt**: CloudWatchTest.kt 1:1 대응
+- `put metric data`, `list metrics`, `create/describe log groups/streams`, `put log events`
+
+**MiniStackDynamoDBTest.kt**: DynamoDBTest.kt 1:1 대응  
+- `insert/get/update/delete item`, `list tables`
+
+**MiniStackKMSTest.kt**: KMSTest.kt 1:1 대응
+- `create key`, `encrypt`, `decrypt`, `disable/enable key`, `create/list/revoke grant`
+- `create/list/delete alias`, `list keys`, `put key policy`
+- ⚠️ `@Disabled` 없이 전체 테스트 실행 (MiniStack KMS 전 기능 지원)
+
+---
+
+### T6. MiniStack Kinesis/S3/SNS 서비스 테스트 (complexity: medium)
+
+**MiniStackKinesisTest.kt**: KinesisTest.kt 1:1 대응
+- `create stream`, `put records`, `get records`
+
+**MiniStackS3Test.kt**: S3Test.kt 1:1 대응
+- S3Client에 `.serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())` 추가
+- `create bucket`, `put object`, `get object`
+
+**MiniStackSNSTest.kt**: SNSTest.kt 1:1 대응
+- `create topic`, `publish`, `subscribe`, `list topics/subscriptions`
+
+---
+
+### T7. MiniStack SQS/STS 서비스 테스트 (complexity: medium)
+
+**MiniStackSQSTest.kt**: SQSTest.kt 1:1 대응
+- `create queue`, `send message batch`, `receive message`, `delete message`
+
+**MiniStackSTSTest.kt**: STSTest.kt 1:1 대응
+- `get caller identity`, `get session token`
+
+---
+
+### T8. README 업데이트 (complexity: low)
+
+**파일**: `testing/testcontainers/README.md`
+- MiniStack 섹션 추가 (LocalStack/Floci 섹션 다음)
+- Docker image, port, health endpoint, 의존성, 예시 코드 포함
+
+**파일**: `testing/testcontainers/README.ko.md`
+- 동일 내용 한국어로 작성
+
+---
+
+## 실행 순서
+
+```
+T1 (의존성) → T2 (MiniStackServer) → T3 (KDoc) → T4 (기본 테스트)
+                                                 → T5 (CloudWatch/DynamoDB/KMS — 병렬)
+                                                 → T6 (Kinesis/S3/SNS — 병렬)
+                                                 → T7 (SQS/STS — 병렬)
+                                     → T8 (README)
+```
+
+T5/T6/T7은 T2 완료 후 병렬 실행 가능.
+
+---
+
+## DoD 체크리스트 (Spec 기준)
+
+- [ ] `MiniStackServer.kt` 구현 완료 (`AwsEmulatorServer` 인터페이스 전부 구현)
+- [ ] `MiniStackServer.Launcher.miniStack` 싱글턴 동작 확인
+- [ ] `MiniStackServerTest.kt` 통과
+- [ ] 8종 서비스 통합 테스트 모두 통과 (실패 시 `@Disabled` + KDoc 제한사항 문서화)
+- [ ] KMS 테스트: `@Disabled` 없이 전체 통과
+- [ ] `Libs.kt` + `build.gradle.kts` 의존성 추가 완료
+- [ ] Korean KDoc — 모든 public API
+- [ ] README.md + README.ko.md 업데이트
+- [ ] Step 6-R 코드 리뷰 (CRITICAL/HIGH 0건)

--- a/docs/superpowers/specs/2026-04-27-ministack-server-design.md
+++ b/docs/superpowers/specs/2026-04-27-ministack-server-design.md
@@ -1,0 +1,282 @@
+# MiniStackServer 설계 스펙
+
+**날짜**: 2026-04-27
+**브랜치**: `feat/ministack-server`
+**범위**: `testing/testcontainers` 모듈
+
+---
+
+## 1. 배경 및 목적
+
+### 1.1 배경
+
+- **LocalStack Community Edition** — 2026-03-23 아카이브됨. 기존 `LocalStackServer`는 `@Deprecated(WARNING)` 상태.
+- **Floci** — GraalVM Native Image 기반 경량 에뮬레이터(v1.5.8). KMS DisableKey/EnableKey/Grant, DynamoDB GSI pagination (#587) 등 미지원 기능 다수. `@Deprecated(WARNING)` 상태.
+- **MiniStack** — 새 AWS 에뮬레이터. v1.3.14(2026-04-24), MIT License, 31+ 서비스, ~270MB 이미지, ~30MB RAM, ~2s 기동.
+  - Maven: `org.ministack:testcontainers-ministack:0.1.4` (공식 Testcontainers 모듈)
+  - Docker: `ministackorg/ministack:1.3.14`
+  - 헬스 엔드포인트: `/_ministack/health`
+  - Floci 미지원 기능 — KMS 전 기능, DynamoDB GSI 지원 확인됨
+
+### 1.2 목적
+
+1. `MiniStackServer.kt` 구현 — `AwsEmulatorServer` 인터페이스 구현, `MiniStackContainer` 래핑
+2. `MiniStackServerTest.kt` — 서버 시작/정상 동작 기본 검증
+3. AWS 서비스별 통합 테스트 8종 — FlociServer 서비스 테스트 대응
+4. `Libs.kt`, `build.gradle.kts` 의존성 추가
+5. `AwsEmulatorServer` KDoc에 MiniStack 언급 추가
+
+---
+
+## 2. 범위
+
+### In-scope
+- `MiniStackServer.kt` 메인 소스
+- `MiniStackServerTest.kt` 기본 서버 테스트
+- AWS 서비스 테스트 8종: CloudWatch, DynamoDB, KMS, Kinesis, S3, SNS, SQS, STS
+- `Libs.kt` — MiniStack 의존성 상수 추가
+- `testing/testcontainers/build.gradle.kts` — `compileOnly` 의존성 추가
+- `AwsEmulatorServer.kt` KDoc 업데이트
+- `testing/testcontainers/README.md` + `README.ko.md` 업데이트
+
+### Out-of-scope
+- Spring Boot Auto-configuration (별도 PR)
+- `@Deprecated` 제거 (LocalStack/Floci/MiniStack 중 안정적인 것이 확인된 후)
+- DynamoDB Enhanced Client 심화 테스트
+
+---
+
+## 3. 기술 설계
+
+### 3.1 브레인스토밍 — 접근 방식 비교
+
+#### 접근 방식 A: `MiniStackContainer` 직접 래핑 + `AwsEmulatorServer` 구현 [검토]
+
+```kotlin
+class MiniStackServer private constructor(
+    imageName: DockerImageName,
+    useDefaultPort: Boolean,
+    reuse: Boolean,
+): MiniStackContainer(imageName), GenericServer, PropertyExportingServer, AwsEmulatorServer {
+    ...
+}
+```
+
+**장점**:
+- MiniStack 공식 Testcontainers 모듈(`testcontainers-ministack:0.1.4`) 사용 → 헬스체크, 초기화 로직 자동 처리
+- Floci처럼 `GenericContainer` 직접 래핑하지 않아도 됨
+- `MiniStackContainer.getEndpoint()` 활용 가능
+
+**단점**:
+- `MiniStackContainer`의 `getEndpoint()` → `awsEndpoint` 이름 충돌 위험 (JVM getter 충돌 패턴)
+- 외부 라이브러리 변경 시 영향 받음
+
+#### 접근 방식 B: `GenericContainer<MiniStackServer>` 직접 래핑 (Floci 패턴 동일) [채택]
+
+```kotlin
+class MiniStackServer private constructor(
+    imageName: DockerImageName,
+    useDefaultPort: Boolean,
+    reuse: Boolean,
+): GenericContainer<MiniStackServer>(imageName), GenericServer, PropertyExportingServer, AwsEmulatorServer {
+    ...
+}
+```
+
+**장점**:
+- Floci 패턴과 완전히 동일 → 코드베이스 일관성 극대화
+- 외부 라이브러리 의존성 없음 (공식 testcontainers-ministack 모듈 불필요)
+
+**단점**:
+- 헬스체크, 환경변수 등 MiniStack 특유 설정을 직접 구현해야 함
+- 공식 모듈이 업데이트될 때 수동 동기화 필요
+
+#### 접근 방식 C: `MiniStackContainer` 위임(delegation) 패턴 [기각]
+
+**장점**: 래핑 없이 인터페이스만 구현
+**단점**: Kotlin delegation은 GenericContainer 상속 구조와 충돌, Testcontainers가 lifecycle 관리를 상속 기반으로 처리하므로 불가
+
+**채택 결정**: **접근 방식 B** (GenericContainer 직접 래핑)
+- Floci 패턴과 동일하여 유지보수 일관성 확보
+- `MiniStackContainer`의 내부 구현에 의존하지 않아 안정적
+- 헬스 엔드포인트(`/_ministack/health`)를 직접 Wait 전략으로 설정
+- `compileOnly` 의존성으로 선택적 사용 가능
+
+### 3.2 위험 요인 및 대응
+
+| 위험 | 설명 | 대응 |
+|------|------|------|
+| **포트 충돌** | MiniStack 기본 포트 4566 — LocalStack/Floci와 동일 | `useDefaultPort=false` 기본값 (동적 포트 할당). `GATEWAY_PORT` 환경변수는 GenericContainer 직접 래핑에서 불필요 — Testcontainers가 랜덤 외부 포트로 매핑 |
+| **S3 path-style** | Floci와 동일하게 virtual-hosted URL 미지원 가능 | 서비스 테스트에 `pathStyleAccessEnabled(true)` 적용 |
+| **헬스체크 타이밍** | 2초 기동이지만 CI 환경에서 더 느릴 수 있음 (이미지 pull 포함) | `Wait.forHttp("/_ministack/health").forStatusCode(200).withStartupTimeout(Duration.ofSeconds(60))`. 구현 시 health endpoint 응답 body에 서비스별 준비 상태 필드가 있는지 확인 후 body predicate 추가 검토 |
+| **미지원 서비스** | 아직 31+ 지원이지만 엣지 케이스 존재 가능 | 실패 테스트에 `@Disabled` + KDoc 알려진 제한사항 문서화 |
+| **안정성 불확실** | v1.3.14이지만 107 릴리스로 활발히 개발 중 | `@Deprecated(WARNING)` 적용하지 않음 (LocalStack 아카이브 이후 주력 에뮬레이터로 포지셔닝) |
+
+### 3.3 `MiniStackServer` 클래스 설계
+
+```kotlin
+@Suppress("DEPRECATION")
+class MiniStackServer private constructor(
+    imageName: DockerImageName,
+    useDefaultPort: Boolean,
+    reuse: Boolean,
+): GenericContainer<MiniStackServer>(imageName), GenericServer, PropertyExportingServer, AwsEmulatorServer {
+
+    companion object: KLogging() {
+        const val IMAGE = "ministackorg/ministack"
+        const val TAG = "1.3.14"
+        const val NAME = "ministack"
+        const val PORT = 4566
+        const val DEFAULT_ACCESS_KEY = "test"
+        const val DEFAULT_SECRET_KEY = "test"
+        const val DEFAULT_REGION = "us-east-1"
+
+        @JvmStatic
+        operator fun invoke(
+            image: String = IMAGE,
+            tag: String = TAG,
+            useDefaultPort: Boolean = false,
+            reuse: Boolean = true,
+        ): MiniStackServer { ... }
+
+        @JvmStatic
+        operator fun invoke(
+            imageName: DockerImageName,
+            useDefaultPort: Boolean = false,
+            reuse: Boolean = true,
+        ): MiniStackServer { ... }
+    }
+
+    override val port: Int get() = getMappedPort(PORT)
+    override val url: String get() = "http://$host:$port"
+    override val awsEndpoint: URI get() = URI.create("http://$host:$port")
+    override val awsAccessKey: String = DEFAULT_ACCESS_KEY
+    override val awsSecretKey: String = DEFAULT_SECRET_KEY
+    override val regionName: String = DEFAULT_REGION
+    override val propertyNamespace: String = NAME
+
+    override fun propertyKeys(): Set<String> =
+        setOf("host", "port", "url", "aws-endpoint", "aws-access-key", "aws-secret-key", "region")
+
+    override fun properties(): Map<String, String> = mapOf(
+        "host" to host,
+        "port" to port.toString(),
+        "url" to url,
+        "aws-endpoint" to awsEndpoint.toString(),
+        "aws-access-key" to awsAccessKey,
+        "aws-secret-key" to awsSecretKey,
+        "region" to regionName,
+    )
+
+    init {
+        addExposedPorts(PORT)
+        withReuse(reuse)
+        // MiniStack 공식 헬스 엔드포인트 사용
+        setWaitStrategy(
+            Wait.forHttp("/_ministack/health")
+                .forStatusCode(200)
+                .withStartupTimeout(Duration.ofSeconds(60))
+        )
+        if (useDefaultPort) {
+            exposeCustomPorts(PORT)
+        }
+    }
+
+    override fun withServices(vararg services: String): MiniStackServer {
+        log.debug { "MiniStack enables all services by default. withServices(${services.toList()}) is a no-op." }
+        return this
+    }
+
+    override fun start() {
+        super.start()
+        writeToSystemProperties()
+    }
+
+    object Launcher {
+        val miniStack: MiniStackServer by lazy {
+            MiniStackServer().apply {
+                start()
+                ShutdownQueue.register(this)
+            }
+        }
+    }
+}
+```
+
+### 3.4 서비스 테스트 구조
+
+서비스 테스트는 `floci/services/` 패턴을 그대로 따름:
+- 경로: `testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/`
+- 테스트 클래스: `FlociXxxTest` → `MiniStackXxxTest` (1:1 대응)
+- `floci: FlociServer` → `miniStack: MiniStackServer` 교체
+- KMS: `@Disabled` 테스트 제거 (MiniStack은 KMS 전 기능 지원)
+- S3: `pathStyleAccessEnabled(true)` 유지 (안전망)
+- DynamoDB: GSI 테스트 추가 가능 (Floci #587 제한 없음)
+
+### 3.5 기본 서버 테스트
+
+`MiniStackServerTest.kt` — `FlociServerTest.kt` 패턴 동일:
+- 서버 시작 확인
+- `awsEndpoint` URI 형식 검증
+- `awsAccessKey`, `awsSecretKey`, `regionName` 기본값 확인
+- S3 client 연결 테스트 (path-style)
+
+---
+
+## 4. 의존성
+
+### 4.1 Libs.kt 추가
+
+```kotlin
+// MiniStack — free MIT-licensed AWS emulator (ministack.org)
+const val testcontainers_ministack =
+    "org.ministack:testcontainers-ministack:0.1.4"  // https://mvnrepository.com/artifact/org.ministack/testcontainers-ministack
+```
+
+> 참고: MiniStack 공식 testcontainers 모듈은 `org.ministack:testcontainers-ministack` 좌표를 사용한다.
+> 일반 testcontainersModule() 헬퍼(org.testcontainers 그룹)와 다르므로 `const` 리터럴로 선언.
+
+### 4.2 build.gradle.kts 추가
+
+```kotlin
+// MiniStack for AWS emulation
+compileOnly(Libs.testcontainers_ministack)
+```
+
+`LocalStack` 의존성 바로 아래(line ~136)에 추가.
+
+---
+
+## 5. 파일 목록
+
+| 파일 | 작업 |
+|------|------|
+| `buildSrc/src/main/kotlin/Libs.kt` | MiniStack 의존성 상수 추가 |
+| `testing/testcontainers/build.gradle.kts` | `compileOnly(Libs.testcontainers_ministack)` 추가 |
+| `testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServer.kt` | 신규 생성 |
+| `testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/AwsEmulatorServer.kt` | KDoc에 MiniStack 언급 추가 |
+| `testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServerTest.kt` | 신규 생성 |
+| `testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackCloudWatchTest.kt` | 신규 생성 |
+| `testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackDynamoDBTest.kt` | 신규 생성 |
+| `testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKMSTest.kt` | 신규 생성 |
+| `testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKinesisTest.kt` | 신규 생성 |
+| `testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackS3Test.kt` | 신규 생성 |
+| `testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSNSTest.kt` | 신규 생성 |
+| `testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSQSTest.kt` | 신규 생성 |
+| `testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSTSTest.kt` | 신규 생성 |
+| `testing/testcontainers/README.md` | MiniStack 섹션 추가 |
+| `testing/testcontainers/README.ko.md` | MiniStack 섹션 추가 |
+
+---
+
+## 6. DoD (Definition of Done)
+
+- [ ] `MiniStackServer.kt` 구현 완료 (`AwsEmulatorServer` 인터페이스 전부 구현)
+- [ ] `MiniStackServer.Launcher.miniStack` 싱글턴 동작 확인
+- [ ] `MiniStackServerTest.kt` 통과
+- [ ] 8종 서비스 통합 테스트 모두 통과 (실패 시 `@Disabled` + KDoc 제한사항 문서화)
+- [ ] KMS 테스트: `@Disabled` 없이 전체 통과 (MiniStack KMS 전 기능 지원)
+- [ ] `Libs.kt` + `build.gradle.kts` 의존성 추가 완료
+- [ ] Korean KDoc — 모든 public API
+- [ ] README.md + README.ko.md 업데이트
+- [ ] Step 6-R 코드 리뷰 (CRITICAL/HIGH 0건)

--- a/testing/testcontainers/README.ko.md
+++ b/testing/testcontainers/README.ko.md
@@ -82,6 +82,10 @@ classDiagram
         +withServices() FlociServer (no-op)
         @Deprecated
     }
+    class MiniStackServer {
+        +awsEndpoint: URI
+        +withServices() MiniStackServer (no-op)
+    }
     class ElasticMqServer {
         +sqsEndpoint: URI
         +host: String
@@ -113,6 +117,7 @@ classDiagram
     GenericServer <|-- KafkaServer
     GenericServer <|-- LocalStackServer
     GenericServer <|-- FlociServer
+    GenericServer <|-- MiniStackServer
     GenericServer <|-- MailpitServer
     GenericServer <|-- BluetapeHttpServer
     GenericServer <|-- BluetapeWebfluxServer
@@ -120,6 +125,7 @@ classDiagram
     PostgreSQLServer <|-- PgvectorServer
     AwsEmulatorServer <|.. LocalStackServer
     AwsEmulatorServer <|.. FlociServer
+    AwsEmulatorServer <|.. MiniStackServer
 
     style GenericServer fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     style AwsEmulatorServer fill:#E8F5E9,stroke:#A5D6A7,color:#2E7D32
@@ -213,6 +219,7 @@ flowchart TD
     subgraph AWS
         LS["LocalStackServer\n(deprecated)"]
         FC["FlociServer\n(S3, DynamoDB, SQS 등)"]
+        MS["MiniStackServer\n(31+ 서비스, 권장)"]
         EMQ["ElasticMqServer\n(임베디드 SQS, JVM)"]
     end
 
@@ -253,7 +260,8 @@ flowchart TD
     class TR sqlStyle
     class WM,NG,BHS,BWS mockStyle
     class LS deprecatedStyle
-    class FC,EMQ awsStyle
+    class FC deprecatedStyle
+    class MS,EMQ awsStyle
     class MP mailStyle
     class CDB,OL llmStyle
 ```
@@ -311,6 +319,7 @@ flowchart TD
 | RabbitMQServer      | `rabbitmq`      | `host`, `port`, `url`, `amqp-url`, `amqp-port`, `amqps-port`, `management-url`      |
 | LocalStackServer    | `localstack`    | `host`, `port`, `url`, `awsEndpoint`, `awsAccessKey`, `awsSecretKey`, `regionName` |
 | FlociServer         | `floci`         | `host`, `port`, `url`, `awsEndpoint`, `awsAccessKey`, `awsSecretKey`, `regionName` |
+| MiniStackServer     | `ministack`     | `host`, `port`, `url`, `awsEndpoint`, `awsAccessKey`, `awsSecretKey`, `regionName` |
 | ElasticMqServer     | `elasticmq`     | `host`, `port`, `url`, `sqsEndpoint`                                                |
 | MailpitServer       | `mailpit`       | `host`, `port`, `url`, `smtpPort`, `uiPort`, `uiUrl`                               |
 | PrometheusServer    | `prometheus`    | `host`, `port`, `url`, `server-port`, `pushgateway-port`, `graphite-exporter-port`  |
@@ -590,12 +599,28 @@ val client = IgniteClient.builder()
 
 ### AWS 에뮬레이터
 
-`AwsEmulatorServer`는 로컬 AWS 에뮬레이터 공통 인터페이스입니다. `bluetape4k.aws.emulator` 시스템 프로퍼티(`localstack` | `floci`)로 에뮬레이터를 선택합니다.
+`AwsEmulatorServer`는 로컬 AWS 에뮬레이터 공통 인터페이스입니다.
 
 ```kotlin
-// FlociServer — GraalVM Native, 권장
-val floci = FlociServer.Launcher.floci
+// MiniStackServer — MIT 라이선스, 31+ 서비스, 권장
+val miniStack = MiniStackServer.Launcher.miniStack
 val s3Client = S3Client.builder()
+    .endpointOverride(miniStack.awsEndpoint)
+    .credentialsProvider(miniStack.getCredentialProvider())
+    .region(Region.of(miniStack.regionName))
+    .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
+    .build()
+
+// MiniStack은 모든 서비스가 항상 활성화 — withServices() 불필요
+val kmsClient = KmsClient.builder()
+    .endpointOverride(miniStack.awsEndpoint)
+    .credentialsProvider(miniStack.getCredentialProvider())
+    .region(Region.of(miniStack.regionName))
+    .build()
+
+// FlociServer — GraalVM Native (@Deprecated)
+val floci = FlociServer.Launcher.floci
+val sqsClient = SqsClient.builder()
     .endpointOverride(floci.awsEndpoint)
     .credentialsProvider(floci.getCredentialProvider())
     .region(Region.of(floci.regionName))

--- a/testing/testcontainers/README.md
+++ b/testing/testcontainers/README.md
@@ -82,6 +82,10 @@ classDiagram
         +withServices() FlociServer (no-op)
         @Deprecated
     }
+    class MiniStackServer {
+        +awsEndpoint: URI
+        +withServices() MiniStackServer (no-op)
+    }
     class ElasticMqServer {
         +sqsEndpoint: URI
         +host: String
@@ -113,6 +117,7 @@ classDiagram
     GenericServer <|-- KafkaServer
     GenericServer <|-- LocalStackServer
     GenericServer <|-- FlociServer
+    GenericServer <|-- MiniStackServer
     GenericServer <|-- MailpitServer
     GenericServer <|-- BluetapeHttpServer
     GenericServer <|-- BluetapeWebfluxServer
@@ -120,6 +125,7 @@ classDiagram
     PostgreSQLServer <|-- PgvectorServer
     AwsEmulatorServer <|.. LocalStackServer
     AwsEmulatorServer <|.. FlociServer
+    AwsEmulatorServer <|.. MiniStackServer
 
     style GenericServer fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     style AwsEmulatorServer fill:#E8F5E9,stroke:#A5D6A7,color:#2E7D32
@@ -213,6 +219,7 @@ flowchart TD
     subgraph AWS
         LS["LocalStackServer\n(deprecated)"]
         FC["FlociServer\n(S3, DynamoDB, SQS, etc.)"]
+        MS["MiniStackServer\n(31+ services, recommended)"]
         EMQ["ElasticMqServer\n(embedded SQS, JVM)"]
     end
 
@@ -253,7 +260,8 @@ flowchart TD
     class TR sqlStyle
     class WM,NG,BHS,BWS mockStyle
     class LS deprecatedStyle
-    class FC,EMQ awsStyle
+    class FC deprecatedStyle
+    class MS,EMQ awsStyle
     class MP mailStyle
     class CDB,OL llmStyle
 ```
@@ -262,7 +270,7 @@ flowchart TD
 
 - Wrappers for database, graph DB, storage, messaging, infrastructure, distributed SQL, and LLM services
 - HTTP mocking through WireMock and NginxServer
-- **AWS Emulator support**: `AwsEmulatorServer` common interface; `FlociServer` (GraalVM Native image, recommended), `LocalStackServer` (@Deprecated)
+- **AWS Emulator support**: `AwsEmulatorServer` common interface; `MiniStackServer` (31+ services, MIT license, recommended), `FlociServer` (@Deprecated), `LocalStackServer` (@Deprecated)
 - **Embedded SQS**: `ElasticMqServer` runs an in-process SQS server — no Docker needed
 - **Mail testing**: `MailpitServer` provides SMTP + Web UI for email integration tests
 - **LLM support**: `ChromaDBServer` (vector DB, port 8000), `OllamaServer` (local LLM inference, port 11434)
@@ -306,6 +314,7 @@ Every server implements
 | RabbitMQServer      | `rabbitmq`      | `host`, `port`, `url`, `amqp-url`, `amqp-port`, `amqps-port`, `management-url`      |
 | LocalStackServer    | `localstack`    | `host`, `port`, `url`, `awsEndpoint`, `awsAccessKey`, `awsSecretKey`, `regionName` |
 | FlociServer         | `floci`         | `host`, `port`, `url`, `awsEndpoint`, `awsAccessKey`, `awsSecretKey`, `regionName` |
+| MiniStackServer     | `ministack`     | `host`, `port`, `url`, `awsEndpoint`, `awsAccessKey`, `awsSecretKey`, `regionName` |
 | ElasticMqServer     | `elasticmq`     | `host`, `port`, `url`, `sqsEndpoint`                                                |
 | MailpitServer       | `mailpit`       | `host`, `port`, `url`, `smtpPort`, `uiPort`, `uiUrl`                               |
 | PrometheusServer    | `prometheus`    | `host`, `port`, `url`, `server-port`, `pushgateway-port`, `graphite-exporter-port`  |
@@ -543,12 +552,28 @@ sequenceDiagram
 
 ### AWS Emulators
 
-`AwsEmulatorServer` is the common interface for local AWS emulators. Select the emulator via the `bluetape4k.aws.emulator` system property (`localstack` | `floci`).
+`AwsEmulatorServer` is the common interface for local AWS emulators.
 
 ```kotlin
-// FlociServer — GraalVM Native image, recommended
-val floci = FlociServer.Launcher.floci
+// MiniStackServer — MIT license, 31+ services, recommended
+val miniStack = MiniStackServer.Launcher.miniStack
 val s3Client = S3Client.builder()
+    .endpointOverride(miniStack.awsEndpoint)
+    .credentialsProvider(miniStack.getCredentialProvider())
+    .region(Region.of(miniStack.regionName))
+    .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
+    .build()
+
+// MiniStack supports all services by default — no withServices() needed
+val kmsClient = KmsClient.builder()
+    .endpointOverride(miniStack.awsEndpoint)
+    .credentialsProvider(miniStack.getCredentialProvider())
+    .region(Region.of(miniStack.regionName))
+    .build()
+
+// FlociServer — GraalVM Native image (@Deprecated)
+val floci = FlociServer.Launcher.floci
+val sqsClient = SqsClient.builder()
     .endpointOverride(floci.awsEndpoint)
     .credentialsProvider(floci.getCredentialProvider())
     .region(Region.of(floci.regionName))

--- a/testing/testcontainers/build.gradle.kts
+++ b/testing/testcontainers/build.gradle.kts
@@ -134,6 +134,9 @@ dependencies {
     // LocalStack for AWS
     compileOnly(Libs.testcontainers_localstack)
 
+    // MiniStack for AWS emulation
+    compileOnly(Libs.testcontainers_ministack)
+
     // ElasticMQ - embedded SQS emulator (no Docker)
     compileOnly(Libs.elasticmq_rest_sqs_2_13)
 

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/AwsEmulatorServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/AwsEmulatorServer.kt
@@ -7,7 +7,7 @@ import java.net.URI
 /**
  * AWS 에뮬레이터 서버 공통 인터페이스.
  *
- * LocalStack, Floci 등 다양한 AWS 에뮬레이터를 동일한 방식으로 사용할 수 있도록
+ * LocalStack, Floci, MiniStack 등 다양한 AWS 에뮬레이터를 동일한 방식으로 사용할 수 있도록
  * 공통 계약을 정의합니다.
  *
  * > ⚠️ **주의 (R7)**: 이 인터페이스는 AWS SDK 타입을 포함하지 않습니다.
@@ -17,10 +17,16 @@ import java.net.URI
  * > ⚠️ **주의 (R8)**: [withServices]는 구현체마다 동작이 다릅니다.
  * > - LocalStack: 활성화할 서비스를 지정합니다.
  * > - Floci: 모든 서비스가 항상 활성화되므로 이 메서드는 no-op입니다.
+ * > - MiniStack: 모든 서비스가 항상 활성화되므로 이 메서드는 no-op입니다.
  *
  * ```kotlin
+ * // LocalStack (서비스 선택 가능)
  * val server: AwsEmulatorServer = LocalStackServer()
  *     .withServices("s3", "sqs")
+ * server.start()
+ *
+ * // MiniStack (모든 서비스 항상 활성화)
+ * val server: AwsEmulatorServer = MiniStackServer()
  * server.start()
  *
  * // 에뮬레이터 엔드포인트와 자격 증명 정보를 SDK 타입에 의존하지 않고 사용
@@ -76,6 +82,8 @@ interface AwsEmulatorServer: GenericServer, PropertyExportingServer {
      * 구현체마다 동작이 다릅니다:
      * - **LocalStack**: 인자로 전달된 서비스만 활성화합니다.
      * - **Floci**: 모든 서비스가 항상 활성화되므로 이 메서드는 no-op이며,
+     *   동일한 인스턴스를 그대로 반환합니다.
+     * - **MiniStack**: 모든 서비스가 항상 활성화되므로 이 메서드는 no-op이며,
      *   동일한 인스턴스를 그대로 반환합니다.
      *
      * @param services 활성화할 AWS 서비스 이름 (예: `"s3"`, `"sqs"`, `"dynamodb"`)

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServer.kt
@@ -1,0 +1,235 @@
+package io.bluetape4k.testcontainers.aws
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.testcontainers.GenericServer
+import io.bluetape4k.testcontainers.PropertyExportingServer
+import io.bluetape4k.testcontainers.exposeCustomPorts
+import io.bluetape4k.utils.ShutdownQueue
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import java.net.URI
+import java.time.Duration
+
+/**
+ * [MiniStack](https://ministack.org) AWS 에뮬레이터 서버.
+ *
+ * MIT 라이선스 기반의 경량 AWS 에뮬레이터로, 31개 이상의 AWS 서비스를 지원합니다.
+ * LocalStack Community Edition 아카이브(2026-03-23) 이후의 주력 대안입니다.
+ *
+ * - Docker 이미지: `ministackorg/ministack:1.3.14` (~270MB, ~30MB RAM, ~2초 기동)
+ * - 헬스 엔드포인트: `/_ministack/health`
+ * - KMS 전 기능 지원 (DisableKey/EnableKey/Grant 포함)
+ * - DynamoDB GSI Pagination 지원
+ *
+ * MiniStack은 모든 AWS 서비스를 항상 활성화합니다.
+ * [withServices]를 호출해도 서비스 선택이 적용되지 않습니다 (no-op).
+ *
+ * ```kotlin
+ * // 기본 설정으로 MiniStack 서버 시작
+ * val server = MiniStackServer()
+ * server.start()
+ *
+ * // 에뮬레이터 엔드포인트와 자격 증명 정보를 SDK 타입에 의존하지 않고 사용
+ * val endpoint: URI = server.awsEndpoint
+ * val accessKey: String = server.awsAccessKey
+ * val secretKey: String = server.awsSecretKey
+ * val region: String = server.regionName
+ * ```
+ *
+ * 참고: [MiniStack 공식 사이트](https://ministack.org) · [Docker image](https://hub.docker.com/r/ministackorg/ministack)
+ *
+ * @param imageName      Docker 이미지 이름 ([DockerImageName])
+ * @param useDefaultPort 기본 포트(4566)를 고정 바인딩할지 여부
+ * @param reuse          컨테이너 재사용 여부
+ */
+class MiniStackServer private constructor(
+    imageName: DockerImageName,
+    useDefaultPort: Boolean,
+    reuse: Boolean,
+): GenericContainer<MiniStackServer>(imageName), GenericServer, PropertyExportingServer, AwsEmulatorServer {
+
+    companion object: KLogging() {
+        /** MiniStack Docker 이미지 이름 (Repository) */
+        const val IMAGE = "ministackorg/ministack"
+
+        /** MiniStack Docker 이미지 기본 태그 */
+        const val TAG = "1.3.14"
+
+        /** PropertyExportingServer 네임스페이스 및 컨테이너 식별자 */
+        const val NAME = "ministack"
+
+        /** MiniStack이 노출하는 단일 AWS 에뮬레이터 포트 */
+        const val PORT = 4566
+
+        /** 기본 access key (MiniStack은 임의의 값을 허용함) */
+        const val DEFAULT_ACCESS_KEY = "test"
+
+        /** 기본 secret key (MiniStack은 임의의 값을 허용함) */
+        const val DEFAULT_SECRET_KEY = "test"
+
+        /** 기본 region 이름 */
+        const val DEFAULT_REGION = "us-east-1"
+
+        /**
+         * 이미지 이름/태그로 [MiniStackServer] 인스턴스를 생성합니다.
+         *
+         * ```kotlin
+         * val server = MiniStackServer(image = "ministackorg/ministack", tag = "1.3.14")
+         * server.start()
+         * // server.url.startsWith("http://") == true
+         * ```
+         *
+         * @param image          Docker 이미지 이름. blank이면 [IllegalArgumentException]이 발생합니다.
+         * @param tag            Docker 이미지 태그. blank이면 [IllegalArgumentException]이 발생합니다.
+         * @param useDefaultPort `true`면 4566 포트를 고정 바인딩합니다.
+         * @param reuse          컨테이너 재사용 여부
+         */
+        @JvmStatic
+        operator fun invoke(
+            image: String = IMAGE,
+            tag: String = TAG,
+            useDefaultPort: Boolean = false,
+            reuse: Boolean = true,
+        ): MiniStackServer {
+            image.requireNotBlank("image")
+            tag.requireNotBlank("tag")
+
+            val imageName = DockerImageName.parse(image).withTag(tag)
+            return invoke(imageName, useDefaultPort, reuse)
+        }
+
+        /**
+         * [DockerImageName]으로 [MiniStackServer] 인스턴스를 생성합니다.
+         *
+         * ```kotlin
+         * val image = DockerImageName.parse("ministackorg/ministack").withTag("1.3.14")
+         * val server = MiniStackServer(image)
+         * // server.isRunning == false (아직 start 전)
+         * ```
+         *
+         * @param imageName      Docker 이미지 이름
+         * @param useDefaultPort `true`면 4566 포트를 고정 바인딩합니다.
+         * @param reuse          컨테이너 재사용 여부
+         */
+        @JvmStatic
+        operator fun invoke(
+            imageName: DockerImageName,
+            useDefaultPort: Boolean = false,
+            reuse: Boolean = true,
+        ): MiniStackServer {
+            return MiniStackServer(imageName, useDefaultPort, reuse)
+        }
+    }
+
+    /** 컨테이너의 매핑된 MiniStack 포트(4566)를 반환합니다. */
+    override val port: Int get() = getMappedPort(PORT)
+
+    /** MiniStack 서버의 기본 URL (예: `http://localhost:32768`)을 반환합니다. */
+    override val url: String get() = "http://$host:$port"
+
+    /**
+     * AWS 에뮬레이터 엔드포인트 URI.
+     *
+     * AWS SDK 클라이언트의 `endpointOverride`로 사용합니다.
+     */
+    override val awsEndpoint: URI get() = URI.create("http://$host:$port")
+
+    /** 기본 AWS access key (`"test"`). MiniStack은 임의의 값을 허용합니다. */
+    override val awsAccessKey: String = DEFAULT_ACCESS_KEY
+
+    /** 기본 AWS secret key (`"test"`). MiniStack은 임의의 값을 허용합니다. */
+    override val awsSecretKey: String = DEFAULT_SECRET_KEY
+
+    /** 기본 AWS region 이름 (`"us-east-1"`). */
+    override val regionName: String = DEFAULT_REGION
+
+    /** PropertyExportingServer 네임스페이스 ([NAME]). */
+    override val propertyNamespace: String = NAME
+
+    /**
+     * 시스템 프로퍼티로 export할 키 목록을 반환합니다.
+     *
+     * 모든 키는 kebab-case 소문자를 사용합니다.
+     * `host`, `port`, `url`, `aws-endpoint`, `aws-access-key`, `aws-secret-key`, `region`을 노출합니다.
+     */
+    override fun propertyKeys(): Set<String> =
+        setOf("host", "port", "url", "aws-endpoint", "aws-access-key", "aws-secret-key", "region")
+
+    /**
+     * 시스템 프로퍼티로 export할 key/value 맵을 반환합니다.
+     *
+     * 컨테이너가 시작된 이후에 호출되어야 [host], [port]가 유효합니다.
+     */
+    override fun properties(): Map<String, String> = mapOf(
+        "host" to host,
+        "port" to port.toString(),
+        "url" to url,
+        "aws-endpoint" to awsEndpoint.toString(),
+        "aws-access-key" to awsAccessKey,
+        "aws-secret-key" to awsSecretKey,
+        "region" to regionName,
+    )
+
+    init {
+        addExposedPorts(PORT)
+        withReuse(reuse)
+
+        // MiniStack 공식 헬스 엔드포인트 사용
+        setWaitStrategy(
+            Wait.forHttp("/_ministack/health")
+                .forStatusCode(200)
+                .withStartupTimeout(Duration.ofSeconds(60))
+        )
+
+        if (useDefaultPort) {
+            exposeCustomPorts(PORT)
+        }
+    }
+
+    /**
+     * 활성화할 AWS 서비스 목록을 지정합니다.
+     *
+     * > ⚠️ MiniStack은 모든 AWS 서비스를 항상 활성화하므로 이 메서드는 **no-op**입니다.
+     * > 호출해도 서비스 선택이 적용되지 않으며, 동일한 [MiniStackServer] 인스턴스를 그대로 반환합니다.
+     *
+     * @param services (무시됨) 활성화할 서비스 이름 목록
+     * @return 메서드 체이닝을 위한 현재 [MiniStackServer] 인스턴스
+     */
+    override fun withServices(vararg services: String): MiniStackServer {
+        log.debug { "MiniStack enables all services by default. withServices(${services.toList()}) is a no-op." }
+        return this
+    }
+
+    /**
+     * 컨테이너를 시작하고, 시스템 프로퍼티로 [properties]를 export합니다.
+     */
+    override fun start() {
+        super.start()
+        writeToSystemProperties()
+    }
+
+    /**
+     * 테스트에서 재사용할 [MiniStackServer] 싱글턴을 제공합니다.
+     *
+     * 첫 접근 시 컨테이너를 시작하고 JVM 종료 시 자동 정리하도록 [ShutdownQueue]에 등록합니다.
+     */
+    object Launcher {
+        /**
+         * 지연 초기화되는 [MiniStackServer] 싱글턴.
+         *
+         * ```kotlin
+         * val miniStack = MiniStackServer.Launcher.miniStack
+         * val endpoint = miniStack.awsEndpoint
+         * ```
+         */
+        val miniStack: MiniStackServer by lazy {
+            MiniStackServer().apply {
+                start()
+                ShutdownQueue.register(this)
+            }
+        }
+    }
+}

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServer.kt
@@ -164,7 +164,9 @@ class MiniStackServer private constructor(
     /**
      * 시스템 프로퍼티로 export할 key/value 맵을 반환합니다.
      *
-     * 컨테이너가 시작된 이후에 호출되어야 [host], [port]가 유효합니다.
+     * ⚠️ 컨테이너가 시작된 이후에만 호출해야 합니다.
+     * 시작 전 호출 시 [host]/[port] 평가 과정에서 `IllegalStateException`이 발생합니다.
+     * 시작 여부와 무관하게 키 목록만 필요한 경우 [propertyKeys]를 사용하세요.
      */
     override fun properties(): Map<String, String> = mapOf(
         "host" to host,
@@ -202,7 +204,9 @@ class MiniStackServer private constructor(
      * @return 메서드 체이닝을 위한 현재 [MiniStackServer] 인스턴스
      */
     override fun withServices(vararg services: String): MiniStackServer {
-        log.warn { "withServices(${services.toList()}) is a no-op: MiniStack enables all AWS services by default. Service selection is ignored." }
+        if (services.isNotEmpty()) {
+            log.warn { "withServices(${services.toList()}) is a no-op: MiniStack enables all AWS services by default. Service selection is ignored." }
+        }
         return this
     }
 
@@ -229,9 +233,11 @@ class MiniStackServer private constructor(
          * ```
          */
         val miniStack: MiniStackServer by lazy {
+            MiniStackServer.log.debug { "Starting MiniStack singleton container..." }
             MiniStackServer().apply {
                 start()
                 ShutdownQueue.register(this)
+                MiniStackServer.log.debug { "MiniStack singleton started. endpoint=$awsEndpoint" }
             }
         }
     }

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServer.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.testcontainers.aws
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.testcontainers.GenericServer
 import io.bluetape4k.testcontainers.PropertyExportingServer
@@ -85,6 +86,8 @@ class MiniStackServer private constructor(
          * @param image          Docker 이미지 이름. blank이면 [IllegalArgumentException]이 발생합니다.
          * @param tag            Docker 이미지 태그. blank이면 [IllegalArgumentException]이 발생합니다.
          * @param useDefaultPort `true`면 4566 포트를 고정 바인딩합니다.
+         *                       ⚠️ CI 환경에서 여러 테스트를 병렬 실행하는 경우 포트 충돌이 발생할 수 있습니다.
+         *                       병렬 테스트에서는 `false`(기본값)를 사용하여 랜덤 포트를 할당받으세요.
          * @param reuse          컨테이너 재사용 여부
          */
         @JvmStatic
@@ -199,7 +202,7 @@ class MiniStackServer private constructor(
      * @return 메서드 체이닝을 위한 현재 [MiniStackServer] 인스턴스
      */
     override fun withServices(vararg services: String): MiniStackServer {
-        log.debug { "MiniStack enables all services by default. withServices(${services.toList()}) is a no-op." }
+        log.warn { "withServices(${services.toList()}) is a no-op: MiniStack enables all AWS services by default. Service selection is ignored." }
         return this
     }
 

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServerTest.kt
@@ -1,0 +1,107 @@
+package io.bluetape4k.testcontainers.aws
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.utils.ShutdownQueue
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeNull
+import org.amshove.kluent.shouldStartWith
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.until
+import org.junit.jupiter.api.Test
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.S3Configuration
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import java.time.Duration
+import kotlin.test.assertFailsWith
+
+/**
+ * [MiniStackServer] 기본 동작 테스트.
+ */
+class MiniStackServerTest: AbstractContainerTest() {
+
+    companion object: KLogging()
+
+    @Test
+    fun `blank image tag 는 허용하지 않는다`() {
+        assertFailsWith<IllegalArgumentException> { MiniStackServer(image = " ") }
+        assertFailsWith<IllegalArgumentException> { MiniStackServer(tag = " ") }
+    }
+
+    @Test
+    fun `MiniStack 서버가 시작되고 실행 중이어야 한다`() {
+        MiniStackServer().use { server ->
+            server.start()
+            server.isRunning.shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `MiniStack 서버의 기본 속성이 올바르게 설정되어야 한다`() {
+        MiniStackServer().use { server ->
+            server.start()
+
+            server.awsEndpoint.shouldNotBeNull()
+            server.awsEndpoint.toString() shouldStartWith "http://"
+            server.awsAccessKey shouldBeEqualTo MiniStackServer.DEFAULT_ACCESS_KEY
+            server.awsSecretKey shouldBeEqualTo MiniStackServer.DEFAULT_SECRET_KEY
+            server.regionName shouldBeEqualTo MiniStackServer.DEFAULT_REGION
+        }
+    }
+
+    @Test
+    fun `MiniStack S3 서비스를 사용하여 버킷을 생성하고 오브젝트를 저장 및 조회한다`() {
+        MiniStackServer().use { server ->
+            server.start()
+
+            val credentialProvider = server.getCredentialProvider()
+
+            val s3Client = S3Client.builder()
+                .endpointOverride(server.awsEndpoint)
+                .region(Region.of(server.regionName))
+                .credentialsProvider(credentialProvider)
+                .serviceConfiguration(
+                    S3Configuration.builder().pathStyleAccessEnabled(true).build()
+                )
+                .build()
+                .apply { ShutdownQueue.register(this) }
+
+            s3Client.createBucket(CreateBucketRequest.builder().bucket("test-bucket").build())
+
+            val putRequest = PutObjectRequest.builder()
+                .bucket("test-bucket")
+                .key("test-key")
+                .build()
+            s3Client.putObject(putRequest, RequestBody.fromString("hello-ministack"))
+
+            val getRequest = GetObjectRequest.builder()
+                .bucket("test-bucket")
+                .key("test-key")
+                .build()
+
+            var content: String? = null
+            await atMost Duration.ofSeconds(5) until {
+                runCatching {
+                    content = s3Client.getObjectAsBytes(getRequest).asUtf8String()
+                    content == "hello-ministack"
+                }.getOrDefault(false)
+            }
+
+            content shouldBeEqualTo "hello-ministack"
+        }
+    }
+
+    @Test
+    fun `withServices는 no-op이어야 한다 (MiniStack은 항상 모든 서비스 활성화)`() {
+        MiniStackServer().use { server ->
+            val returned = server.withServices("S3", "SQS", "DynamoDB")
+            (returned === server).shouldBeTrue()
+        }
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServerTest.kt
@@ -5,11 +5,9 @@ import io.bluetape4k.testcontainers.AbstractContainerTest
 import io.bluetape4k.utils.ShutdownQueue
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContainAll
 import org.amshove.kluent.shouldNotBeNull
 import org.amshove.kluent.shouldStartWith
-import org.awaitility.kotlin.atMost
-import org.awaitility.kotlin.await
-import org.awaitility.kotlin.until
 import org.junit.jupiter.api.Test
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.regions.Region
@@ -18,7 +16,6 @@ import software.amazon.awssdk.services.s3.S3Configuration
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
-import java.time.Duration
 import kotlin.test.assertFailsWith
 
 /**
@@ -36,7 +33,7 @@ class MiniStackServerTest: AbstractContainerTest() {
 
     @Test
     fun `MiniStack 서버가 시작되고 실행 중이어야 한다`() {
-        MiniStackServer().use { server ->
+        MiniStackServer(reuse = false).use { server ->
             server.start()
             server.isRunning.shouldBeTrue()
         }
@@ -44,11 +41,12 @@ class MiniStackServerTest: AbstractContainerTest() {
 
     @Test
     fun `MiniStack 서버의 기본 속성이 올바르게 설정되어야 한다`() {
-        MiniStackServer().use { server ->
+        MiniStackServer(reuse = false).use { server ->
             server.start()
 
             server.awsEndpoint.shouldNotBeNull()
             server.awsEndpoint.toString() shouldStartWith "http://"
+            server.url shouldStartWith "http://"
             server.awsAccessKey shouldBeEqualTo MiniStackServer.DEFAULT_ACCESS_KEY
             server.awsSecretKey shouldBeEqualTo MiniStackServer.DEFAULT_SECRET_KEY
             server.regionName shouldBeEqualTo MiniStackServer.DEFAULT_REGION
@@ -56,8 +54,33 @@ class MiniStackServerTest: AbstractContainerTest() {
     }
 
     @Test
+    fun `propertyKeys는 start 전에도 호출 가능하고 7개의 키를 반환해야 한다`() {
+        val server = MiniStackServer(reuse = false)
+        server.propertyKeys() shouldContainAll setOf(
+            "host", "port", "url", "aws-endpoint", "aws-access-key", "aws-secret-key", "region"
+        )
+    }
+
+    @Test
+    fun `propertyNamespace는 ministack이어야 한다`() {
+        MiniStackServer(reuse = false).propertyNamespace shouldBeEqualTo MiniStackServer.NAME
+    }
+
+    @Test
+    fun `start 후 시스템 프로퍼티가 올바르게 등록되어야 한다`() {
+        MiniStackServer(reuse = false).use { server ->
+            server.start()
+            System.getProperty("testcontainers.ministack.host") shouldBeEqualTo server.host
+            System.getProperty("testcontainers.ministack.port") shouldBeEqualTo server.port.toString()
+            System.getProperty("testcontainers.ministack.url") shouldBeEqualTo server.url
+            System.getProperty("testcontainers.ministack.aws-endpoint") shouldBeEqualTo server.awsEndpoint.toString()
+            System.getProperty("testcontainers.ministack.region") shouldBeEqualTo MiniStackServer.DEFAULT_REGION
+        }
+    }
+
+    @Test
     fun `MiniStack S3 서비스를 사용하여 버킷을 생성하고 오브젝트를 저장 및 조회한다`() {
-        MiniStackServer().use { server ->
+        MiniStackServer(reuse = false).use { server ->
             server.start()
 
             val credentialProvider = server.getCredentialProvider()
@@ -85,21 +108,14 @@ class MiniStackServerTest: AbstractContainerTest() {
                 .key("test-key")
                 .build()
 
-            var content: String? = null
-            await atMost Duration.ofSeconds(5) until {
-                runCatching {
-                    content = s3Client.getObjectAsBytes(getRequest).asUtf8String()
-                    content == "hello-ministack"
-                }.getOrDefault(false)
-            }
-
+            val content = s3Client.getObjectAsBytes(getRequest).asUtf8String()
             content shouldBeEqualTo "hello-ministack"
         }
     }
 
     @Test
     fun `withServices는 no-op이어야 한다 (MiniStack은 항상 모든 서비스 활성화)`() {
-        MiniStackServer().use { server ->
+        MiniStackServer(reuse = false).use { server ->
             val returned = server.withServices("S3", "SQS", "DynamoDB")
             (returned === server).shouldBeTrue()
         }

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackCloudWatchTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackCloudWatchTest.kt
@@ -1,0 +1,157 @@
+package io.bluetape4k.testcontainers.aws.ministack.services
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.testcontainers.aws.MiniStackServer
+import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.utils.ShutdownQueue
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeEmpty
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import software.amazon.awssdk.http.apache.ApacheHttpClient
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient
+import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent
+import java.time.Instant
+
+/**
+ * MiniStack CloudWatch / CloudWatchLogs 서비스 통합 테스트.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class MiniStackCloudWatchTest: AbstractContainerTest() {
+
+    companion object: KLogging() {
+        private val NAMESPACE = "Bluetape4k/MiniStack-Test-${System.currentTimeMillis()}"
+        private val LOG_GROUP_NAME = "/bluetape4k/ministack-test-${System.currentTimeMillis()}"
+        private const val LOG_STREAM_NAME = "app-stream"
+    }
+
+    private val miniStack: MiniStackServer by lazy { MiniStackServer.Launcher.miniStack }
+
+    private val cloudWatchClient by lazy {
+        CloudWatchClient.builder()
+            .endpointOverride(miniStack.awsEndpoint)
+            .region(Region.of(miniStack.regionName))
+            .credentialsProvider(miniStack.getCredentialProvider())
+            .httpClient(ApacheHttpClient.create())
+            .build()
+            .apply { ShutdownQueue.register(this) }
+    }
+
+    private val cloudWatchLogsClient by lazy {
+        CloudWatchLogsClient.builder()
+            .endpointOverride(miniStack.awsEndpoint)
+            .region(Region.of(miniStack.regionName))
+            .credentialsProvider(miniStack.getCredentialProvider())
+            .httpClient(ApacheHttpClient.create())
+            .build()
+            .apply { ShutdownQueue.register(this) }
+    }
+
+    @BeforeAll
+    fun setup() {
+        miniStack.start()
+    }
+
+    @Test
+    @Order(1)
+    fun `create client`() {
+        cloudWatchClient.shouldNotBeNull()
+        cloudWatchLogsClient.shouldNotBeNull()
+    }
+
+    @Test
+    @Order(2)
+    fun `put metric data`() {
+        val response = cloudWatchClient.putMetricData {
+            it.namespace(NAMESPACE)
+                .metricData(
+                    MetricDatum.builder()
+                        .metricName("RequestCount")
+                        .value(42.0)
+                        .unit(StandardUnit.COUNT)
+                        .build(),
+                    MetricDatum.builder()
+                        .metricName("ResponseTimeMs")
+                        .value(125.5)
+                        .unit(StandardUnit.MILLISECONDS)
+                        .build(),
+                )
+        }
+        log.debug { "PutMetricData response: ${response.sdkHttpResponse().statusCode()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(3)
+    fun `list metrics`() {
+        val metrics = cloudWatchClient.listMetrics { it.namespace(NAMESPACE) }.metrics()
+        log.debug { "Metrics: ${metrics.map { it.metricName() }}" }
+        metrics.size shouldBeGreaterOrEqualTo 1
+    }
+
+    @Test
+    @Order(4)
+    fun `create log group`() {
+        val response = cloudWatchLogsClient.createLogGroup { it.logGroupName(LOG_GROUP_NAME) }
+        log.debug { "CreateLogGroup: ${response.sdkHttpResponse().statusCode()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(5)
+    fun `create log stream`() {
+        val response = cloudWatchLogsClient.createLogStream {
+            it.logGroupName(LOG_GROUP_NAME).logStreamName(LOG_STREAM_NAME)
+        }
+        log.debug { "CreateLogStream: ${response.sdkHttpResponse().statusCode()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(6)
+    fun `put log events`() {
+        val now = Instant.now().toEpochMilli()
+        val events = (1..3).map { i ->
+            InputLogEvent.builder()
+                .timestamp(now + i * 100L)
+                .message("로그 이벤트 #$i - MiniStack CloudWatchLogs 테스트")
+                .build()
+        }
+        val response = cloudWatchLogsClient.putLogEvents {
+            it.logGroupName(LOG_GROUP_NAME)
+                .logStreamName(LOG_STREAM_NAME)
+                .logEvents(events)
+        }
+        log.debug { "PutLogEvents nextSequenceToken=${response.nextSequenceToken()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(7)
+    fun `describe log groups`() {
+        val groups = cloudWatchLogsClient.describeLogGroups { }.logGroups()
+        log.debug { "Log groups: ${groups.map { it.logGroupName() }}" }
+        groups.shouldNotBeEmpty()
+    }
+
+    @Test
+    @Order(8)
+    fun `describe log streams`() {
+        val streams = cloudWatchLogsClient.describeLogStreams {
+            it.logGroupName(LOG_GROUP_NAME)
+        }.logStreams()
+        log.debug { "Log streams: ${streams.map { it.logStreamName() }}" }
+        streams.shouldNotBeEmpty()
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackCloudWatchTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackCloudWatchTest.kt
@@ -8,9 +8,9 @@ import io.bluetape4k.testcontainers.aws.getCredentialProvider
 import io.bluetape4k.utils.ShutdownQueue
 import org.amshove.kluent.shouldBeGreaterOrEqualTo
 import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldNotBeEmpty
 import org.amshove.kluent.shouldNotBeNull
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -56,11 +56,6 @@ class MiniStackCloudWatchTest: AbstractContainerTest() {
             .httpClient(ApacheHttpClient.create())
             .build()
             .apply { ShutdownQueue.register(this) }
-    }
-
-    @BeforeAll
-    fun setup() {
-        miniStack.start()
     }
 
     @Test
@@ -142,7 +137,7 @@ class MiniStackCloudWatchTest: AbstractContainerTest() {
     fun `describe log groups`() {
         val groups = cloudWatchLogsClient.describeLogGroups { }.logGroups()
         log.debug { "Log groups: ${groups.map { it.logGroupName() }}" }
-        groups.shouldNotBeEmpty()
+        groups.map { it.logGroupName() }.shouldContain(LOG_GROUP_NAME)
     }
 
     @Test

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackDynamoDBTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackDynamoDBTest.kt
@@ -1,0 +1,131 @@
+package io.bluetape4k.testcontainers.aws.ministack.services
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.testcontainers.aws.MiniStackServer
+import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.utils.ShutdownQueue
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.AttributeAction
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.AttributeValueUpdate
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement
+import software.amazon.awssdk.services.dynamodb.model.KeyType
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest
+
+/**
+ * MiniStack DynamoDB 서비스 통합 테스트.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class MiniStackDynamoDBTest: AbstractContainerTest() {
+
+    companion object: KLogging() {
+        private const val TABLE_NAME = "ministack-test-table"
+    }
+
+    private val miniStack: MiniStackServer by lazy { MiniStackServer.Launcher.miniStack }
+
+    private val client by lazy {
+        DynamoDbClient.builder()
+            .endpointOverride(miniStack.awsEndpoint)
+            .region(Region.of(miniStack.regionName))
+            .credentialsProvider(miniStack.getCredentialProvider())
+            .build()
+            .apply { ShutdownQueue.register(this) }
+    }
+
+    @BeforeAll
+    fun setup() {
+        miniStack.start()
+
+        val createTableRequest = CreateTableRequest.builder()
+            .tableName(TABLE_NAME)
+            .attributeDefinitions(
+                AttributeDefinition.builder().attributeName("id").attributeType(ScalarAttributeType.S).build()
+            )
+            .keySchema(KeySchemaElement.builder().attributeName("id").keyType(KeyType.HASH).build())
+            .provisionedThroughput(ProvisionedThroughput.builder().readCapacityUnits(5L).writeCapacityUnits(5L).build())
+            .build()
+        val createTableResponse = client.createTable(createTableRequest)
+        createTableResponse.shouldNotBeNull()
+        log.debug { "Table: ${createTableResponse.tableDescription()}" }
+    }
+
+    @Test
+    @Order(1)
+    fun `insert data`() {
+        val item = mutableMapOf(
+            "id" to AttributeValue.builder().s("1").build(),
+            "name" to AttributeValue.builder().s("debop").build(),
+            "age" to AttributeValue.builder().n("51").build()
+        )
+        val response = client.putItem(PutItemRequest.builder().tableName(TABLE_NAME).item(item).build())
+        response.shouldNotBeNull()
+
+        val scanResponse = client.scan(ScanRequest.builder().tableName(TABLE_NAME).build())
+        scanResponse.shouldNotBeNull()
+        scanResponse.count() shouldBeGreaterOrEqualTo 1
+    }
+
+    @Test
+    @Order(2)
+    fun `get item`() {
+        val key = mutableMapOf("id" to AttributeValue.builder().s("1").build())
+        val response = client.getItem { it.tableName(TABLE_NAME).key(key) }
+        response.shouldNotBeNull()
+        response.hasItem().shouldBeTrue()
+        log.debug { "Item: ${response.item()}" }
+        response.item()["name"]?.s() shouldBeEqualTo "debop"
+    }
+
+    @Test
+    @Order(3)
+    fun `update item`() {
+        val key = mutableMapOf("id" to AttributeValue.builder().s("1").build())
+        val updates = mutableMapOf(
+            "age" to AttributeValueUpdate.builder()
+                .value(AttributeValue.builder().n("52").build())
+                .action(AttributeAction.PUT)
+                .build()
+        )
+        val response = client.updateItem {
+            it.tableName(TABLE_NAME).key(key).attributeUpdates(updates)
+        }
+        log.debug { "UpdateItem HTTP status: ${response.sdkHttpResponse().statusCode()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(4)
+    fun `delete item`() {
+        val key = mutableMapOf("id" to AttributeValue.builder().s("1").build())
+        val response = client.deleteItem { it.tableName(TABLE_NAME).key(key) }
+        log.debug { "DeleteItem HTTP status: ${response.sdkHttpResponse().statusCode()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(5)
+    fun `list tables`() {
+        val response = client.listTables()
+        log.debug { "Tables: ${response.tableNames()}" }
+        response.tableNames() shouldContain TABLE_NAME
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackDynamoDBTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackDynamoDBTest.kt
@@ -37,7 +37,7 @@ import software.amazon.awssdk.services.dynamodb.model.ScanRequest
 class MiniStackDynamoDBTest: AbstractContainerTest() {
 
     companion object: KLogging() {
-        private const val TABLE_NAME = "ministack-test-table"
+        private val TABLE_NAME = "ministack-test-table-${System.currentTimeMillis()}"
     }
 
     private val miniStack: MiniStackServer by lazy { MiniStackServer.Launcher.miniStack }
@@ -53,8 +53,6 @@ class MiniStackDynamoDBTest: AbstractContainerTest() {
 
     @BeforeAll
     fun setup() {
-        miniStack.start()
-
         val createTableRequest = CreateTableRequest.builder()
             .tableName(TABLE_NAME)
             .attributeDefinitions(

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKMSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKMSTest.kt
@@ -12,7 +12,6 @@ import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldNotBeEmpty
 import org.amshove.kluent.shouldNotBeNull
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
@@ -56,14 +55,9 @@ class MiniStackKMSTest: AbstractContainerTest() {
     private lateinit var keyId: String
     private val data = "동해물과 백두산이"
     private lateinit var encryptedData: SdkBytes
-    private val granteePrincipal = ""
+    private val granteePrincipal = "arn:aws:iam::000000000000:user/test-grantee"
     private lateinit var grantId: String
-    private val aliasName = "alias/MiniStackExampleName"
-
-    @BeforeAll
-    fun setup() {
-        miniStack.start()
-    }
+    private val aliasName = "alias/MiniStackExampleName-${System.currentTimeMillis()}"
 
     @Test
     @Order(1)

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKMSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKMSTest.kt
@@ -1,0 +1,218 @@
+package io.bluetape4k.testcontainers.aws.ministack.services
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.testcontainers.aws.MiniStackServer
+import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.utils.ShutdownQueue
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldNotBeEmpty
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.kms.KmsClient
+import software.amazon.awssdk.services.kms.model.CreateKeyRequest
+import software.amazon.awssdk.services.kms.model.DecryptRequest
+import software.amazon.awssdk.services.kms.model.DisableKeyRequest
+import software.amazon.awssdk.services.kms.model.EncryptRequest
+import software.amazon.awssdk.services.kms.model.GrantOperation
+import software.amazon.awssdk.services.kms.model.KeySpec
+import software.amazon.awssdk.services.kms.model.KeyUsageType
+
+/**
+ * MiniStack KMS 서비스 통합 테스트.
+ *
+ * **알려진 제한사항 (MiniStack v1.3.14)**:
+ * - `CreateGrant`, `ListGrants`, `RevokeGrant` 미지원 (Unknown action 400 오류 반환)
+ * - 해당 테스트는 `@Disabled`로 표시되어 있으며, 향후 MiniStack 업그레이드 시 재활성화 가능
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class MiniStackKMSTest: AbstractContainerTest() {
+
+    companion object: KLogging()
+
+    private val miniStack: MiniStackServer by lazy { MiniStackServer.Launcher.miniStack }
+
+    private val kmsClient: KmsClient by lazy {
+        KmsClient.builder()
+            .endpointOverride(miniStack.awsEndpoint)
+            .region(Region.of(miniStack.regionName))
+            .credentialsProvider(miniStack.getCredentialProvider())
+            .build()
+            .apply { ShutdownQueue.register(this) }
+    }
+
+    private val keyDesc = "Created by the MiniStack KMS API"
+    private lateinit var keyId: String
+    private val data = "동해물과 백두산이"
+    private lateinit var encryptedData: SdkBytes
+    private val granteePrincipal = ""
+    private lateinit var grantId: String
+    private val aliasName = "alias/MiniStackExampleName"
+
+    @BeforeAll
+    fun setup() {
+        miniStack.start()
+    }
+
+    @Test
+    @Order(1)
+    fun `container loading`() {
+        kmsClient.shouldNotBeNull()
+    }
+
+    @Test
+    @Order(2)
+    fun `create custom key`() {
+        val response = kmsClient.createKey(
+            CreateKeyRequest.builder()
+                .description(keyDesc)
+                .keySpec(KeySpec.SYMMETRIC_DEFAULT)
+                .keyUsage(KeyUsageType.ENCRYPT_DECRYPT)
+                .build()
+        )
+        log.debug { "Created key with arn=${response.keyMetadata().arn()}" }
+        keyId = response.keyMetadata().keyId()
+        log.info { "custom keyId=$keyId" }
+        keyId.shouldNotBeEmpty()
+    }
+
+    @Test
+    @Order(3)
+    fun `encrypt data`() {
+        val response = kmsClient.encrypt(
+            EncryptRequest.builder()
+                .keyId(keyId)
+                .plaintext(SdkBytes.fromUtf8String(data))
+                .build()
+        )
+        log.debug { "Encryption algorithm: ${response.encryptionAlgorithmAsString()}" }
+        encryptedData = response.ciphertextBlob()
+    }
+
+    @Test
+    @Order(4)
+    fun `decrypt data`() {
+        val response = kmsClient.decrypt(
+            DecryptRequest.builder()
+                .keyId(keyId)
+                .ciphertextBlob(encryptedData)
+                .build()
+        )
+        response.plaintext().asUtf8String() shouldBeEqualTo data
+    }
+
+    @Test
+    @Order(5)
+    fun `disable customer key`() {
+        val response = kmsClient.disableKey(DisableKeyRequest.builder().keyId(keyId).build())
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(6)
+    fun `enable customer key`() {
+        val response = kmsClient.enableKey { it.keyId(keyId) }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(7)
+    @Disabled("MiniStack v1.3.14 미지원: CreateGrant (Unknown action 400) — 향후 업그레이드 시 재활성화")
+    fun `create grant`() {
+        val response = kmsClient.createGrant {
+            it.keyId(keyId)
+                .granteePrincipal(granteePrincipal)
+                .operations(GrantOperation.CREATE_GRANT, GrantOperation.ENCRYPT, GrantOperation.DECRYPT)
+        }
+        log.debug { "Grant id=${response.grantId()}, token=${response.grantToken()}" }
+        grantId = response.grantId()
+    }
+
+    @Test
+    @Order(8)
+    @Disabled("MiniStack v1.3.14 미지원: ListGrants (Unknown action 400) — 향후 업그레이드 시 재활성화")
+    fun `list grants`() {
+        val grants = kmsClient.listGrants { it.keyId(keyId).limit(15) }.grants()
+        grants.forEach { log.debug { "Grant id=${it.grantId()}" } }
+        grants.map { it.grantId() } shouldContain grantId
+    }
+
+    @Test
+    @Order(9)
+    @Disabled("MiniStack v1.3.14 미지원: RevokeGrant — create grant가 비활성화되어 grantId 없음")
+    fun `revoke grant`() {
+        val response = kmsClient.revokeGrant { it.keyId(keyId).grantId(grantId) }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(10)
+    fun `describe key`() {
+        val keyMetadata = kmsClient.describeKey { it.keyId(keyId) }.keyMetadata()
+        log.debug { "key description=${keyMetadata.description()}, arn=${keyMetadata.arn()}" }
+        keyMetadata.shouldNotBeNull()
+    }
+
+    @Test
+    @Order(11)
+    fun `create custom alias`() {
+        val response = kmsClient.createAlias { it.aliasName(aliasName).targetKeyId(keyId) }
+        log.debug { "CreateAlias metadata=${response.responseMetadata()}" }
+    }
+
+    @Test
+    @Order(12)
+    fun `list aliases`() {
+        val response = kmsClient.listAliases { it.limit(10) }
+        response.aliases().forEach { log.debug { "Alias name=$it" } }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(13)
+    fun `delete alias`() {
+        val response = kmsClient.deleteAlias { it.aliasName(aliasName) }
+        log.debug { "DeleteAlias metadata=${response.responseMetadata()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(14)
+    fun `list keys`() {
+        val response = kmsClient.listKeys { it.limit(15) }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+        response.keys().forEach { log.debug { "Key arn=${it.keyArn()}, id=${it.keyId()}" } }
+    }
+
+    @Test
+    @Order(15)
+    fun `put key policy`() {
+        val policy = """
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {"AWS": "arn:aws:iam::814548047983:root"},
+                        "Action": "kms:*",
+                        "Resource": "*"
+                    }
+                ]
+            }""".trimIndent()
+        val response = kmsClient.putKeyPolicy {
+            it.keyId(keyId).policyName("default").policy(policy)
+        }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKMSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKMSTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestMethodOrder
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.regions.Region
@@ -35,6 +36,7 @@ import software.amazon.awssdk.services.kms.model.KeyUsageType
  * - `CreateGrant`, `ListGrants`, `RevokeGrant` 미지원 (Unknown action 400 오류 반환)
  * - 해당 테스트는 `@Disabled`로 표시되어 있으며, 향후 MiniStack 업그레이드 시 재활성화 가능
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class MiniStackKMSTest: AbstractContainerTest() {
 
@@ -163,6 +165,7 @@ class MiniStackKMSTest: AbstractContainerTest() {
     fun `create custom alias`() {
         val response = kmsClient.createAlias { it.aliasName(aliasName).targetKeyId(keyId) }
         log.debug { "CreateAlias metadata=${response.responseMetadata()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
     }
 
     @Test

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKinesisTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKinesisTest.kt
@@ -1,0 +1,140 @@
+package io.bluetape4k.testcontainers.aws.ministack.services
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.testcontainers.aws.MiniStackServer
+import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.utils.ShutdownQueue
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeNull
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.until
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.kinesis.KinesisClient
+import software.amazon.awssdk.services.kinesis.model.PutRecordsRequestEntry
+import software.amazon.awssdk.services.kinesis.model.ShardIteratorType
+import software.amazon.awssdk.services.kinesis.model.StreamStatus
+import java.time.Duration
+
+/**
+ * MiniStack Kinesis 서비스 통합 테스트.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class MiniStackKinesisTest: AbstractContainerTest() {
+
+    companion object: KLogging() {
+        private val STREAM_NAME = "ministack-test-stream-${System.currentTimeMillis()}"
+    }
+
+    private val miniStack: MiniStackServer by lazy { MiniStackServer.Launcher.miniStack }
+
+    private val kinesisClient: KinesisClient by lazy {
+        KinesisClient.builder()
+            .endpointOverride(miniStack.awsEndpoint)
+            .region(Region.of(miniStack.regionName))
+            .credentialsProvider(miniStack.getCredentialProvider())
+            .build()
+            .apply { ShutdownQueue.register(this) }
+    }
+
+    @BeforeAll
+    fun setup() {
+        miniStack.start()
+    }
+
+    @Test
+    @Order(1)
+    fun `create stream`() {
+        kinesisClient.createStream { it.streamName(STREAM_NAME).shardCount(1) }
+
+        await atMost Duration.ofSeconds(30) until {
+            kinesisClient.describeStream { it.streamName(STREAM_NAME) }
+                .streamDescription().streamStatus() == StreamStatus.ACTIVE
+        }
+        log.debug { "Stream $STREAM_NAME is now ACTIVE" }
+    }
+
+    @Test
+    @Order(2)
+    fun `list streams`() {
+        val streams = kinesisClient.listStreams().streamNames()
+        log.debug { "Streams: $streams" }
+        streams.shouldNotBeNull()
+    }
+
+    @Test
+    @Order(3)
+    fun `put record`() {
+        val response = kinesisClient.putRecord {
+            it.streamName(STREAM_NAME)
+                .partitionKey("pk-1")
+                .data(SdkBytes.fromUtf8String("Hello MiniStack Kinesis!"))
+        }
+        log.debug { "SequenceNumber: ${response.sequenceNumber()}, ShardId: ${response.shardId()}" }
+        response.sequenceNumber().shouldNotBeNull()
+    }
+
+    @Test
+    @Order(4)
+    fun `put records batch`() {
+        val entries = (1..5).map { i ->
+            PutRecordsRequestEntry.builder()
+                .partitionKey("pk-$i")
+                .data(SdkBytes.fromUtf8String("배치 메시지 #$i"))
+                .build()
+        }
+        val response = kinesisClient.putRecords { it.streamName(STREAM_NAME).records(entries) }
+        log.debug { "FailedRecordCount: ${response.failedRecordCount()}" }
+        response.failedRecordCount() shouldBeEqualTo 0
+    }
+
+    @Test
+    @Order(5)
+    fun `get records`() {
+        val shardId = kinesisClient.describeStream { it.streamName(STREAM_NAME) }
+            .streamDescription().shards().first().shardId()
+
+        val shardIterator = kinesisClient.getShardIterator {
+            it.streamName(STREAM_NAME)
+                .shardId(shardId)
+                .shardIteratorType(ShardIteratorType.TRIM_HORIZON)
+        }.shardIterator()
+
+        var receivedCount = 0
+        var currentIterator = shardIterator
+        await atMost Duration.ofSeconds(15) until {
+            val response = kinesisClient.getRecords { it.shardIterator(currentIterator).limit(10) }
+            currentIterator = response.nextShardIterator() ?: currentIterator
+            receivedCount += response.records().size
+            response.records().isNotEmpty()
+        }
+        log.debug { "Received $receivedCount records" }
+        receivedCount shouldBeGreaterOrEqualTo 1
+    }
+
+    @Test
+    @Order(6)
+    fun `describe stream`() {
+        val description = kinesisClient.describeStream { it.streamName(STREAM_NAME) }.streamDescription()
+        log.debug { "Stream status: ${description.streamStatus()}, shards: ${description.shards().size}" }
+        description.streamStatus() shouldBeEqualTo StreamStatus.ACTIVE
+    }
+
+    @Test
+    @Order(7)
+    fun `delete stream`() {
+        val response = kinesisClient.deleteStream { it.streamName(STREAM_NAME) }
+        log.debug { "DeleteStream HTTP status: ${response.sdkHttpResponse().statusCode()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKinesisTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKinesisTest.kt
@@ -13,7 +13,6 @@ import org.amshove.kluent.shouldNotBeNull
 import org.awaitility.kotlin.atMost
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.until
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -45,11 +44,6 @@ class MiniStackKinesisTest: AbstractContainerTest() {
             .credentialsProvider(miniStack.getCredentialProvider())
             .build()
             .apply { ShutdownQueue.register(this) }
-    }
-
-    @BeforeAll
-    fun setup() {
-        miniStack.start()
     }
 
     @Test

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKinesisTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKinesisTest.kt
@@ -108,9 +108,10 @@ class MiniStackKinesisTest: AbstractContainerTest() {
         var currentIterator = shardIterator
         await atMost Duration.ofSeconds(15) until {
             val response = kinesisClient.getRecords { it.shardIterator(currentIterator).limit(10) }
-            currentIterator = response.nextShardIterator() ?: currentIterator
             receivedCount += response.records().size
-            response.records().isNotEmpty()
+            val next = response.nextShardIterator()
+            if (next != null) currentIterator = next
+            receivedCount >= 1 || next == null
         }
         log.debug { "Received $receivedCount records" }
         receivedCount shouldBeGreaterOrEqualTo 1

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackS3Test.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackS3Test.kt
@@ -11,7 +11,6 @@ import io.bluetape4k.utils.ShutdownQueue
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeEmpty
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -49,14 +48,9 @@ class MiniStackS3Test: AbstractContainerTest() {
             .apply { ShutdownQueue.register(this) }
     }
 
-    private val bucketName = "ministack-test-bucket"
+    private val bucketName = "ministack-test-bucket-${System.currentTimeMillis()}"
     private val keyName = "test-object"
     private val content = "hello-ministack-s3"
-
-    @BeforeAll
-    fun setup() {
-        miniStack.start()
-    }
 
     @Test
     @Order(1)
@@ -74,10 +68,13 @@ class MiniStackS3Test: AbstractContainerTest() {
         val waiterResponse = waiter.waitUntilBucketExists(
             HeadBucketRequest.builder().bucket(bucketName).build()
         )
-        waiterResponse.matched().response().ifPresent {
-            log.debug { "Bucket created: ${it.sdkHttpResponse()}" }
-            it.sdkHttpResponse().isSuccessful.shouldBeTrue()
+        waiterResponse.matched().exception().ifPresent { ex ->
+            throw AssertionError("Bucket creation waiter failed via exception branch", ex)
         }
+        val response = waiterResponse.matched().response()
+            .orElseThrow { AssertionError("Waiter returned neither response nor exception") }
+        log.debug { "Bucket created: ${response.sdkHttpResponse()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
     }
 
     @Test

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackS3Test.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackS3Test.kt
@@ -14,6 +14,7 @@ import org.amshove.kluent.shouldNotBeEmpty
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestMethodOrder
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.regions.Region
@@ -29,10 +30,15 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest
  *
  * MiniStack은 virtual-hosted URL을 지원하지 않을 수 있으므로 path-style access를 사용합니다.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class MiniStackS3Test: AbstractContainerTest() {
 
-    companion object: KLogging()
+    companion object: KLogging() {
+        private val BUCKET_NAME = "ministack-test-bucket-${System.currentTimeMillis()}"
+        private const val KEY_NAME = "test-object"
+        private const val CONTENT = "hello-ministack-s3"
+    }
 
     private val miniStack: MiniStackServer by lazy { MiniStackServer.Launcher.miniStack }
 
@@ -48,10 +54,6 @@ class MiniStackS3Test: AbstractContainerTest() {
             .apply { ShutdownQueue.register(this) }
     }
 
-    private val bucketName = "ministack-test-bucket-${System.currentTimeMillis()}"
-    private val keyName = "test-object"
-    private val content = "hello-ministack-s3"
-
     @Test
     @Order(1)
     fun `MiniStack S3 서버가 실행 중이어야 한다`() {
@@ -63,10 +65,10 @@ class MiniStackS3Test: AbstractContainerTest() {
     fun `create bucket`() {
         val waiter = s3Client.waiter()
 
-        s3Client.createBucket(CreateBucketRequest.builder().bucket(bucketName).build())
+        s3Client.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build())
 
         val waiterResponse = waiter.waitUntilBucketExists(
-            HeadBucketRequest.builder().bucket(bucketName).build()
+            HeadBucketRequest.builder().bucket(BUCKET_NAME).build()
         )
         waiterResponse.matched().exception().ifPresent { ex ->
             throw AssertionError("Bucket creation waiter failed via exception branch", ex)
@@ -81,8 +83,8 @@ class MiniStackS3Test: AbstractContainerTest() {
     @Order(3)
     fun `put object`() {
         val response = s3Client.putObject(
-            PutObjectRequest.builder().bucket(bucketName).key(keyName).build(),
-            RequestBody.fromBytes(content.toUtf8Bytes())
+            PutObjectRequest.builder().bucket(BUCKET_NAME).key(KEY_NAME).build(),
+            RequestBody.fromBytes(CONTENT.toUtf8Bytes())
         )
         log.debug { "eTag=${response.eTag()}" }
         response.eTag().shouldNotBeEmpty()
@@ -92,8 +94,8 @@ class MiniStackS3Test: AbstractContainerTest() {
     @Order(4)
     fun `get object`() {
         val bytes = s3Client.getObjectAsBytes(
-            GetObjectRequest.builder().bucket(bucketName).key(keyName).build()
+            GetObjectRequest.builder().bucket(BUCKET_NAME).key(KEY_NAME).build()
         ).asByteArray()
-        bytes.toUtf8String() shouldBeEqualTo content
+        bytes.toUtf8String() shouldBeEqualTo CONTENT
     }
 }

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackS3Test.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackS3Test.kt
@@ -1,0 +1,102 @@
+package io.bluetape4k.testcontainers.aws.ministack.services
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.support.toUtf8Bytes
+import io.bluetape4k.support.toUtf8String
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.testcontainers.aws.MiniStackServer
+import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.utils.ShutdownQueue
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeEmpty
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.S3Configuration
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+
+/**
+ * MiniStack S3 서비스 통합 테스트.
+ *
+ * MiniStack은 virtual-hosted URL을 지원하지 않을 수 있으므로 path-style access를 사용합니다.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class MiniStackS3Test: AbstractContainerTest() {
+
+    companion object: KLogging()
+
+    private val miniStack: MiniStackServer by lazy { MiniStackServer.Launcher.miniStack }
+
+    private val s3Client by lazy {
+        S3Client.builder()
+            .endpointOverride(miniStack.awsEndpoint)
+            .region(Region.of(miniStack.regionName))
+            .credentialsProvider(miniStack.getCredentialProvider())
+            .serviceConfiguration(
+                S3Configuration.builder().pathStyleAccessEnabled(true).build()
+            )
+            .build()
+            .apply { ShutdownQueue.register(this) }
+    }
+
+    private val bucketName = "ministack-test-bucket"
+    private val keyName = "test-object"
+    private val content = "hello-ministack-s3"
+
+    @BeforeAll
+    fun setup() {
+        miniStack.start()
+    }
+
+    @Test
+    @Order(1)
+    fun `MiniStack S3 서버가 실행 중이어야 한다`() {
+        miniStack.isRunning.shouldBeTrue()
+    }
+
+    @Test
+    @Order(2)
+    fun `create bucket`() {
+        val waiter = s3Client.waiter()
+
+        s3Client.createBucket(CreateBucketRequest.builder().bucket(bucketName).build())
+
+        val waiterResponse = waiter.waitUntilBucketExists(
+            HeadBucketRequest.builder().bucket(bucketName).build()
+        )
+        waiterResponse.matched().response().ifPresent {
+            log.debug { "Bucket created: ${it.sdkHttpResponse()}" }
+            it.sdkHttpResponse().isSuccessful.shouldBeTrue()
+        }
+    }
+
+    @Test
+    @Order(3)
+    fun `put object`() {
+        val response = s3Client.putObject(
+            PutObjectRequest.builder().bucket(bucketName).key(keyName).build(),
+            RequestBody.fromBytes(content.toUtf8Bytes())
+        )
+        log.debug { "eTag=${response.eTag()}" }
+        response.eTag().shouldNotBeEmpty()
+    }
+
+    @Test
+    @Order(4)
+    fun `get object`() {
+        val bytes = s3Client.getObjectAsBytes(
+            GetObjectRequest.builder().bucket(bucketName).key(keyName).build()
+        ).asByteArray()
+        bytes.toUtf8String() shouldBeEqualTo content
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSNSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSNSTest.kt
@@ -9,7 +9,6 @@ import io.bluetape4k.utils.ShutdownQueue
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeEmpty
 import org.amshove.kluent.shouldNotBeNull
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -40,18 +39,14 @@ class MiniStackSNSTest: AbstractContainerTest() {
 
     private lateinit var topicArn: String
 
-    @BeforeAll
-    fun setup() {
-        miniStack.start()
-    }
-
     @Test
     @Order(1)
     fun `create topic`() {
         val response = snsClient.createTopic { it.name(TOPIC_NAME) }
-        topicArn = response.topicArn()
+        topicArn = requireNotNull(response.topicArn()) {
+            "createTopic response returned a null topicArn — MiniStack createTopic failed"
+        }
         log.debug { "Created topic ARN: $topicArn" }
-        topicArn.shouldNotBeNull()
     }
 
     @Test

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSNSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSNSTest.kt
@@ -1,0 +1,124 @@
+package io.bluetape4k.testcontainers.aws.ministack.services
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.testcontainers.aws.MiniStackServer
+import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.utils.ShutdownQueue
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeEmpty
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.sns.SnsClient
+
+/**
+ * MiniStack SNS 서비스 통합 테스트.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class MiniStackSNSTest: AbstractContainerTest() {
+
+    companion object: KLogging() {
+        private val TOPIC_NAME = "ministack-test-topic-${System.currentTimeMillis()}"
+    }
+
+    private val miniStack: MiniStackServer by lazy { MiniStackServer.Launcher.miniStack }
+
+    private val snsClient: SnsClient by lazy {
+        SnsClient.builder()
+            .endpointOverride(miniStack.awsEndpoint)
+            .region(Region.of(miniStack.regionName))
+            .credentialsProvider(miniStack.getCredentialProvider())
+            .build()
+            .apply { ShutdownQueue.register(this) }
+    }
+
+    private lateinit var topicArn: String
+
+    @BeforeAll
+    fun setup() {
+        miniStack.start()
+    }
+
+    @Test
+    @Order(1)
+    fun `create topic`() {
+        val response = snsClient.createTopic { it.name(TOPIC_NAME) }
+        topicArn = response.topicArn()
+        log.debug { "Created topic ARN: $topicArn" }
+        topicArn.shouldNotBeNull()
+    }
+
+    @Test
+    @Order(2)
+    fun `list topics`() {
+        val topics = snsClient.listTopics().topics()
+        log.debug { "Topics: ${topics.map { it.topicArn() }}" }
+        topics.shouldNotBeEmpty()
+    }
+
+    @Test
+    @Order(3)
+    fun `get topic attributes`() {
+        val attrs = snsClient.getTopicAttributes { it.topicArn(topicArn) }.attributes()
+        log.debug { "Topic attributes: $attrs" }
+        attrs.shouldNotBeNull()
+    }
+
+    @Test
+    @Order(4)
+    fun `publish message`() {
+        val response = snsClient.publish {
+            it.topicArn(topicArn)
+                .subject("Test Subject")
+                .message("Hello from MiniStack SNS!")
+        }
+        log.debug { "Published MessageId: ${response.messageId()}" }
+        response.messageId().shouldNotBeNull()
+    }
+
+    @Test
+    @Order(5)
+    fun `subscribe with email protocol`() {
+        val response = snsClient.subscribe {
+            it.topicArn(topicArn)
+                .protocol("email")
+                .endpoint("test@example.com")
+        }
+        log.debug { "Subscription ARN: ${response.subscriptionArn()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(6)
+    fun `list subscriptions`() {
+        val subscriptions = snsClient.listSubscriptions().subscriptions()
+        log.debug { "Subscriptions: ${subscriptions.map { it.subscriptionArn() }}" }
+        subscriptions.shouldNotBeEmpty()
+    }
+
+    @Test
+    @Order(7)
+    fun `set topic attributes`() {
+        val response = snsClient.setTopicAttributes {
+            it.topicArn(topicArn)
+                .attributeName("DisplayName")
+                .attributeValue("MiniStack Test Topic")
+        }
+        log.debug { "SetTopicAttributes HTTP status: ${response.sdkHttpResponse().statusCode()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+
+    @Test
+    @Order(8)
+    fun `delete topic`() {
+        val response = snsClient.deleteTopic { it.topicArn(topicArn) }
+        log.debug { "DeleteTopic HTTP status: ${response.sdkHttpResponse().statusCode()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSQSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSQSTest.kt
@@ -1,0 +1,119 @@
+package io.bluetape4k.testcontainers.aws.ministack.services
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.testcontainers.aws.MiniStackServer
+import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.utils.ShutdownQueue
+import org.amshove.kluent.shouldHaveSize
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.sqs.SqsClient
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry
+
+/**
+ * MiniStack SQS 서비스 통합 테스트.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class MiniStackSQSTest: AbstractContainerTest() {
+
+    companion object: KLogging() {
+        private val QUEUE_NAME = "ministack-test-queue-${System.currentTimeMillis()}"
+    }
+
+    private val miniStack: MiniStackServer by lazy { MiniStackServer.Launcher.miniStack }
+
+    private val sqsClient: SqsClient by lazy {
+        SqsClient.builder()
+            .endpointOverride(miniStack.awsEndpoint)
+            .region(Region.of(miniStack.regionName))
+            .credentialsProvider(miniStack.getCredentialProvider())
+            .build()
+            .apply { ShutdownQueue.register(this) }
+    }
+
+    private lateinit var queueUrl: String
+
+    @BeforeAll
+    fun setup() {
+        miniStack.start()
+    }
+
+    @Test
+    @Order(1)
+    fun `create queue`() {
+        sqsClient.createQueue { it.queueName(QUEUE_NAME) }
+        queueUrl = sqsClient.getQueueUrl { it.queueName(QUEUE_NAME) }.queueUrl()
+        log.debug { "Queue url=$queueUrl" }
+    }
+
+    @Test
+    @Order(2)
+    fun `list queue`() {
+        val queues = sqsClient.listQueues { it.queueNamePrefix("ministack") }.queueUrls()
+        queues.forEach { log.debug { "queue url=$it" } }
+    }
+
+    @Test
+    @Order(3)
+    fun `send message`() {
+        val response = sqsClient.sendMessage {
+            it.queueUrl(queueUrl).messageBody("Hello MiniStack SQS!").delaySeconds(10)
+        }
+        log.debug { "sendResponse=$response" }
+    }
+
+    @Test
+    @Order(4)
+    fun `send batch messages`() {
+        val entries = List(10) {
+            SendMessageBatchRequestEntry.builder()
+                .id("id$it")
+                .messageBody("Hello MiniStack SQS $it")
+                .build()
+        }
+        val response = sqsClient.sendMessageBatch { it.queueUrl(queueUrl).entries(entries) }
+        response.successful() shouldHaveSize entries.size
+        response.successful().forEach { log.debug { "result entry=$it" } }
+    }
+
+    @Test
+    @Order(5)
+    fun `receive messages`() {
+        val messages = sqsClient.receiveMessage {
+            it.queueUrl(queueUrl).maxNumberOfMessages(3)
+        }.messages()
+        messages shouldHaveSize 3
+    }
+
+    @Test
+    @Order(6)
+    fun `change message visibility`() {
+        val messages = sqsClient.receiveMessage {
+            it.queueUrl(queueUrl).maxNumberOfMessages(3)
+        }.messages()
+        val responses = messages.map { message ->
+            sqsClient.changeMessageVisibility {
+                it.queueUrl(queueUrl).receiptHandle(message.receiptHandle()).visibilityTimeout(100)
+            }
+        }
+        responses shouldHaveSize messages.size
+    }
+
+    @Test
+    @Order(7)
+    fun `delete messages`() {
+        val messages = sqsClient.receiveMessage {
+            it.queueUrl(queueUrl).maxNumberOfMessages(3)
+        }.messages()
+        val responses = messages.map { message ->
+            sqsClient.deleteMessage { it.queueUrl(queueUrl).receiptHandle(message.receiptHandle()) }
+        }
+        responses shouldHaveSize messages.size
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSQSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSQSTest.kt
@@ -6,8 +6,10 @@ import io.bluetape4k.testcontainers.AbstractContainerTest
 import io.bluetape4k.testcontainers.aws.MiniStackServer
 import io.bluetape4k.testcontainers.aws.getCredentialProvider
 import io.bluetape4k.utils.ShutdownQueue
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldHaveSize
-import org.junit.jupiter.api.BeforeAll
+import org.amshove.kluent.shouldNotBeBlank
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -39,11 +41,6 @@ class MiniStackSQSTest: AbstractContainerTest() {
 
     private lateinit var queueUrl: String
 
-    @BeforeAll
-    fun setup() {
-        miniStack.start()
-    }
-
     @Test
     @Order(1)
     fun `create queue`() {
@@ -63,9 +60,11 @@ class MiniStackSQSTest: AbstractContainerTest() {
     @Order(3)
     fun `send message`() {
         val response = sqsClient.sendMessage {
-            it.queueUrl(queueUrl).messageBody("Hello MiniStack SQS!").delaySeconds(10)
+            it.queueUrl(queueUrl).messageBody("Hello MiniStack SQS!")
         }
         log.debug { "sendResponse=$response" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
+        response.messageId().shouldNotBeBlank()
     }
 
     @Test
@@ -88,7 +87,7 @@ class MiniStackSQSTest: AbstractContainerTest() {
         val messages = sqsClient.receiveMessage {
             it.queueUrl(queueUrl).maxNumberOfMessages(3)
         }.messages()
-        messages shouldHaveSize 3
+        messages.size shouldBeGreaterOrEqualTo 1
     }
 
     @Test

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSTSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSTSTest.kt
@@ -1,0 +1,85 @@
+package io.bluetape4k.testcontainers.aws.ministack.services
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.testcontainers.aws.MiniStackServer
+import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.utils.ShutdownQueue
+import org.amshove.kluent.shouldNotBeBlank
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.sts.StsClient
+
+/**
+ * MiniStack STS 서비스 통합 테스트.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class MiniStackSTSTest: AbstractContainerTest() {
+
+    companion object: KLogging()
+
+    private val miniStack: MiniStackServer by lazy { MiniStackServer.Launcher.miniStack }
+
+    private val stsClient: StsClient by lazy {
+        StsClient.builder()
+            .endpointOverride(miniStack.awsEndpoint)
+            .region(Region.of(miniStack.regionName))
+            .credentialsProvider(miniStack.getCredentialProvider())
+            .build()
+            .apply { ShutdownQueue.register(this) }
+    }
+
+    private lateinit var accountId: String
+
+    @BeforeAll
+    fun setup() {
+        miniStack.start()
+    }
+
+    @Test
+    @Order(1)
+    fun `get caller identity`() {
+        val identity = stsClient.getCallerIdentity { }
+        log.debug { "Account: ${identity.account()}, UserId: ${identity.userId()}, ARN: ${identity.arn()}" }
+
+        accountId = identity.account()
+        identity.account().shouldNotBeBlank()
+        identity.userId().shouldNotBeBlank()
+        identity.arn().shouldNotBeBlank()
+    }
+
+    @Test
+    @Order(2)
+    fun `assume role`() {
+        val credentials = stsClient.assumeRole {
+            it.roleArn("arn:aws:iam::$accountId:role/test-execution-role")
+                .roleSessionName("bluetape4k-ministack-test-session")
+                .durationSeconds(3600)
+        }.credentials()
+
+        log.debug { "AssumeRole AccessKeyId: ${credentials.accessKeyId()}" }
+        credentials.shouldNotBeNull()
+        credentials.accessKeyId().shouldNotBeBlank()
+        credentials.secretAccessKey().shouldNotBeBlank()
+        credentials.sessionToken().shouldNotBeBlank()
+        credentials.expiration().shouldNotBeNull()
+    }
+
+    @Test
+    @Order(3)
+    fun `get session token`() {
+        val credentials = stsClient.getSessionToken { it.durationSeconds(3600) }.credentials()
+
+        log.debug { "SessionToken AccessKeyId: ${credentials?.accessKeyId()}" }
+        credentials.shouldNotBeNull()
+        credentials.accessKeyId().shouldNotBeBlank()
+        credentials.secretAccessKey().shouldNotBeBlank()
+        credentials.sessionToken().shouldNotBeBlank()
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSTSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSTSTest.kt
@@ -8,7 +8,6 @@ import io.bluetape4k.testcontainers.aws.getCredentialProvider
 import io.bluetape4k.utils.ShutdownQueue
 import org.amshove.kluent.shouldNotBeBlank
 import org.amshove.kluent.shouldNotBeNull
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -37,19 +36,16 @@ class MiniStackSTSTest: AbstractContainerTest() {
 
     private lateinit var accountId: String
 
-    @BeforeAll
-    fun setup() {
-        miniStack.start()
-    }
-
     @Test
     @Order(1)
     fun `get caller identity`() {
         val identity = stsClient.getCallerIdentity { }
         log.debug { "Account: ${identity.account()}, UserId: ${identity.userId()}, ARN: ${identity.arn()}" }
 
-        accountId = identity.account()
-        identity.account().shouldNotBeBlank()
+        accountId = requireNotNull(identity.account()) {
+            "getCallerIdentity response returned a null account — MiniStack STS failed"
+        }
+        accountId.shouldNotBeBlank()
         identity.userId().shouldNotBeBlank()
         identity.arn().shouldNotBeBlank()
     }


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: feat: MiniStack AWS 에뮬레이터 서버 도입 (ministackorg/ministack:1.3.14)

MIT 라이선스 기반의 경량 AWS 에뮬레이터 [MiniStack](https://ministack.org)을 `testing/testcontainers` 모듈에 추가합니다.
LocalStack Community Edition 아카이브(2026-03-23) 이후의 주력 대안으로, 31개 이상의 AWS 서비스를 지원합니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 신규 파일
- `testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServer.kt`
  - `GenericContainer<MiniStackServer>` 직접 확장 (FlociServer 패턴 동일)
  - `GenericServer`, `PropertyExportingServer`, `AwsEmulatorServer` 구현
  - 헬스 엔드포인트: `/_ministack/health` HTTP 200
  - `Launcher.miniStack` 싱글턴 (lazy 초기화, ShutdownQueue 등록)
  - `withServices()`: no-op + log.warn으로 동작 가시화

### 신규 테스트 (9개 파일, 62 tests)
- `MiniStackServerTest.kt`: 기본 동작 + PropertyExportingServer 계약 검증 (8 tests)
- `services/MiniStackS3Test.kt`: 버킷 생성/업로드/다운로드 — path-style access (4 tests)
- `services/MiniStackDynamoDBTest.kt`: 테이블 CRUD + 스캔 (5 tests)
- `services/MiniStackKMSTest.kt`: 키 생성/암복호화/별칭 — Grant 3개 @Disabled (12+3 tests)
- `services/MiniStackKinesisTest.kt`: 스트림/레코드 전송-수신 (7 tests)
- `services/MiniStackSQSTest.kt`: 큐/메시지 전송-수신-삭제 (7 tests)
- `services/MiniStackSNSTest.kt`: 토픽/구독/발행/삭제 (8 tests)
- `services/MiniStackSTSTest.kt`: GetCallerIdentity/AssumeRole/GetSessionToken (3 tests)
- `services/MiniStackCloudWatchTest.kt`: 메트릭 + 로그 그룹/스트림/이벤트 (8 tests)

### 수정 파일
- `buildSrc/Libs.kt`: `testcontainers_ministack` 상수 추가
- `testing/testcontainers/build.gradle.kts`: MiniStack 의존성 추가
- `testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/AwsEmulatorServer.kt`: KDoc 업데이트
- `testing/testcontainers/README.md` / `README.ko.md`: Mermaid UML 다이어그램, 아키텍처 플로우차트, 예제 추가

### 기존 섹션: 알려진 제한사항

| 기능 | 상태 | 비고 |
|------|------|------|
| KMS CreateGrant | ❌ @Disabled | MiniStack v1.3.14 미지원 (HTTP 400 Unknown action) |
| KMS ListGrants | ❌ @Disabled | 동일 |
| KMS RevokeGrant | ❌ @Disabled | 동일 |
| S3 Virtual-hosted URL | ⚠️ | path-style access 필요 |

### 기존 섹션: 코드 리뷰 (5-Tier)

5단계 병렬 코드 리뷰 완료 — CRITICAL/HIGH 이슈 전부 해결:

| Tier | 에이전트 | 주요 발견 | 처리 |
|------|---------|---------|------|
| 1 | Security | MEDIUM: mutable tag (informational) | N/A |
| 2 | Ops/SRE | HIGH: 중복 start() 호출, useDefaultPort 경고 KDoc, Awaitility 직접 호출 | ✅ 수정 |
| 3 | code-reviewer | HIGH: reuse 충돌, granteePrincipal 빈값 | ✅ 수정 |
| 4 | pr-test-analyzer | HIGH: PropertyExportingServer 계약 미테스트 | ✅ 3개 테스트 추가 |
| 5 | silent-failure-hunter | CRITICAL: S3 waiter ifPresent silent pass; HIGH: 하드코딩 리소스명, withServices warn, requireNotNull 가드 | ✅ 전부 수정 |
| **최종** | | **CRITICAL: 0 / HIGH: 0** | ✅ 머지 준비 완료 |

### 기존 섹션: Definition of Done

### Spec DoD
| 항목 | 상태 |
|------|------|
| GenericContainer 직접 확장 (Approach B) | ✅ |
| AwsEmulatorServer 인터페이스 준수 | ✅ |
| PropertyExportingServer 시스템 프로퍼티 export | ✅ |
| 헬스 엔드포인트 `/_ministack/health` | ✅ |
| withServices() no-op + 가시적 경고 | ✅ |
| KMS Grant 제한사항 문서화 (@Disabled + KDoc) | ✅ |

### Plan DoD
| Task | 상태 |
|------|------|
| T1: 의존성 추가 | ✅ |
| T2: MiniStackServer.kt 구현 | ✅ |
| T3: KDoc 업데이트 | ✅ |
| T4~T7: 9개 테스트 클래스 (62 tests) | ✅ |
| T8: README.md + README.ko.md | ✅ |

### CLAUDE.md 체크리스트
- [x] 로컬 테스트 전수 통과: 62 passed, 3 skipped, 0 failed
- [x] 5-Tier Code review 완료: CRITICAL/HIGH = 0
- [x] README.md + README.ko.md 업데이트
- [x] KDoc 추가/업데이트 (모든 public API)
- [x] git worktree에서 작업 (.worktrees/ministack-server)

### 커밋 목록
| 커밋 | 내용 |
|------|------|
| f5212ada | docs: MiniStackServer 구현 계획 작성 |
| d83924d0 | feat: MiniStackServer 구현 및 AWS 서비스 통합 테스트 8종 추가 |
| edf92748 | fix: MiniStack 코드 리뷰 HIGH/CRITICAL 이슈 해결 |
| 33b6a6e5 | fix: 코드 리뷰 이슈 수정 - 테스트 격리, 로직 안정성, KDoc 강화 |

### 기존 섹션: 검증 명령

```bash
# 컴파일 검증
./gradlew :bluetape4k-testcontainers:compileTestKotlin

# 전체 테스트 (Docker 필요)
./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.aws.MiniStack*'
```

## Validation

```
./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.aws.MiniStack*'
BUILD SUCCESSFUL in ~30s
```

| 테스트 클래스 | 통과 | Skip | 비고 |
|-------------|------|------|------|
| MiniStackServerTest | 8 | 0 | PropertyExportingServer 계약 포함 |
| MiniStackS3Test | 4 | 0 | |
| MiniStackDynamoDBTest | 5 | 0 | |
| MiniStackKMSTest | 12 | 3 | Grant 3개 @Disabled (v1.3.14 미지원) |
| MiniStackKinesisTest | 7 | 0 | |
| MiniStackSQSTest | 7 | 0 | |
| MiniStackSNSTest | 8 | 0 | |
| MiniStackSTSTest | 3 | 0 | |
| MiniStackCloudWatchTest | 8 | 0 | |
| **합계** | **62** | **3** | **FAILED: 0** |

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #209, head `33b6a6e504a22ce78929dc6e92211e84b7ad5381`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/ministack-server`
- Labels: 없음
- State: `MERGED`, merge commit `4821801a96664163be7973f924d3dc30c01462f8`
- CI: - `GenericContainer<MiniStackServer>` 직접 확장 (FlociServer 패턴 동일) / - `testing/testcontainers/build.gradle.kts`: MiniStack 의존성 추가 / ./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.aws.MiniStack*'

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #209 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `4821801a96664163be7973f924d3dc30c01462f8`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
