### PR TITLE
refactor: Floci/MiniStack 테스트 기반 클래스 도입 (AbstractFlociServiceTest / AbstractMiniStackServiceTest)

### DIFF
--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/AbstractFlociServiceTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/AbstractFlociServiceTest.kt
@@ -1,0 +1,10 @@
+package io.bluetape4k.testcontainers.aws.floci
+
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.testcontainers.aws.FlociServer
+
+@Suppress("DEPRECATION")
+abstract class AbstractFlociServiceTest : AbstractContainerTest() {
+    protected val floci: FlociServer
+        get() = FlociServer.Launcher.floci
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociCloudWatchTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociCloudWatchTest.kt
@@ -2,15 +2,13 @@ package io.bluetape4k.testcontainers.aws.floci.services
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
-import io.bluetape4k.testcontainers.AbstractContainerTest
-import io.bluetape4k.testcontainers.aws.FlociServer
+import io.bluetape4k.testcontainers.aws.floci.AbstractFlociServiceTest
 import io.bluetape4k.testcontainers.aws.getCredentialProvider
 import io.bluetape4k.utils.ShutdownQueue
 import org.amshove.kluent.shouldBeGreaterOrEqualTo
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeEmpty
 import org.amshove.kluent.shouldNotBeNull
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -25,22 +23,19 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent
 import java.time.Instant
 
 /**
- * [FlociServer]를 사용한 CloudWatch 서비스 통합 테스트.
+ * [io.bluetape4k.testcontainers.aws.FlociServer]를 사용한 CloudWatch 서비스 통합 테스트.
  *
  * LocalStack 기반 [io.bluetape4k.testcontainers.aws.services.CloudWatchTest]에 대응합니다.
  */
 @Suppress("DEPRECATION")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-class FlociCloudWatchTest: AbstractContainerTest() {
+class FlociCloudWatchTest : AbstractFlociServiceTest() {
 
-    companion object: KLogging() {
+    companion object : KLogging() {
         private val NAMESPACE = "Bluetape4k/Test-${System.currentTimeMillis()}"
         private val LOG_GROUP_NAME = "/bluetape4k/test-${System.currentTimeMillis()}"
         private const val LOG_STREAM_NAME = "app-stream"
     }
-
-    private val floci: FlociServer
-        get() = FlociServer.Launcher.floci
 
     private val cloudWatchClient: CloudWatchClient by lazy {
         CloudWatchClient.builder()
@@ -60,11 +55,6 @@ class FlociCloudWatchTest: AbstractContainerTest() {
             .httpClient(ApacheHttpClient.create())
             .build()
             .apply { ShutdownQueue.register(this) }
-    }
-
-    @BeforeAll
-    fun setup() {
-        floci.isRunning.shouldBeTrue()
     }
 
     @Test

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociDynamoDBTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociDynamoDBTest.kt
@@ -2,8 +2,7 @@ package io.bluetape4k.testcontainers.aws.floci.services
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
-import io.bluetape4k.testcontainers.AbstractContainerTest
-import io.bluetape4k.testcontainers.aws.FlociServer
+import io.bluetape4k.testcontainers.aws.floci.AbstractFlociServiceTest
 import io.bluetape4k.testcontainers.aws.getCredentialProvider
 import io.bluetape4k.utils.ShutdownQueue
 import org.amshove.kluent.shouldBeEqualTo
@@ -31,7 +30,7 @@ import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType
 import software.amazon.awssdk.services.dynamodb.model.ScanRequest
 
 /**
- * [FlociServer]를 사용한 DynamoDB 서비스 통합 테스트.
+ * [io.bluetape4k.testcontainers.aws.FlociServer]를 사용한 DynamoDB 서비스 통합 테스트.
  *
  * LocalStack 기반 [io.bluetape4k.testcontainers.aws.services.DynamoDBTest]에 대응합니다.
  *
@@ -40,14 +39,11 @@ import software.amazon.awssdk.services.dynamodb.model.ScanRequest
  */
 @Suppress("DEPRECATION")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-class FlociDynamoDBTest: AbstractContainerTest() {
+class FlociDynamoDBTest : AbstractFlociServiceTest() {
 
-    companion object: KLogging() {
-        private const val TABLE_NAME = "test-table"
+    companion object : KLogging() {
+        private val TABLE_NAME = "test-table-${System.currentTimeMillis()}"
     }
-
-    private val floci: FlociServer
-        get() = FlociServer.Launcher.floci
 
     private val client: DynamoDbClient by lazy {
         DynamoDbClient.builder()
@@ -60,8 +56,6 @@ class FlociDynamoDBTest: AbstractContainerTest() {
 
     @BeforeAll
     fun setup() {
-        floci.isRunning.shouldBeTrue()
-
         val createTableRequest = CreateTableRequest.builder()
             .tableName(TABLE_NAME)
             .attributeDefinitions(

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociKMSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociKMSTest.kt
@@ -3,8 +3,7 @@ package io.bluetape4k.testcontainers.aws.floci.services
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
-import io.bluetape4k.testcontainers.AbstractContainerTest
-import io.bluetape4k.testcontainers.aws.FlociServer
+import io.bluetape4k.testcontainers.aws.floci.AbstractFlociServiceTest
 import io.bluetape4k.testcontainers.aws.getCredentialProvider
 import io.bluetape4k.utils.ShutdownQueue
 import org.amshove.kluent.shouldBeEqualTo
@@ -12,7 +11,6 @@ import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldNotBeEmpty
 import org.amshove.kluent.shouldNotBeNull
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
@@ -31,7 +29,7 @@ import software.amazon.awssdk.services.kms.model.KeySpec
 import software.amazon.awssdk.services.kms.model.KeyUsageType
 
 /**
- * [FlociServer]를 사용한 KMS 서비스 통합 테스트.
+ * [io.bluetape4k.testcontainers.aws.FlociServer]를 사용한 KMS 서비스 통합 테스트.
  *
  * LocalStack 기반 [io.bluetape4k.testcontainers.aws.services.KMSTest]에 대응합니다.
  *
@@ -42,12 +40,9 @@ import software.amazon.awssdk.services.kms.model.KeyUsageType
  */
 @Suppress("DEPRECATION")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-class FlociKMSTest: AbstractContainerTest() {
+class FlociKMSTest : AbstractFlociServiceTest() {
 
-    companion object: KLogging()
-
-    private val floci: FlociServer
-        get() = FlociServer.Launcher.floci
+    companion object : KLogging()
 
     private val kmsClient: KmsClient by lazy {
         KmsClient.builder()
@@ -64,15 +59,10 @@ class FlociKMSTest: AbstractContainerTest() {
     private val data = "동해물과 백두산이"
     private lateinit var encryptedData: SdkBytes
 
-    private val granteePrincipal = ""
+    private val granteePrincipal = "arn:aws:iam::000000000000:user/test-grantee"
     private lateinit var grantId: String
 
-    private val aliasName = "alias/ExampleName"
-
-    @BeforeAll
-    fun setup() {
-        floci.isRunning.shouldBeTrue()
-    }
+    private val aliasName = "alias/ExampleName-${System.currentTimeMillis()}"
 
     @Test
     @Order(1)
@@ -188,6 +178,7 @@ class FlociKMSTest: AbstractContainerTest() {
         val keyMetadata = response.keyMetadata()
         log.debug { "key description=${keyMetadata.description()}" }
         log.debug { "key arn=${keyMetadata.arn()}" }
+        keyMetadata.shouldNotBeNull()
     }
 
     @Test
@@ -199,6 +190,7 @@ class FlociKMSTest: AbstractContainerTest() {
 
         val metadata = response.responseMetadata()
         log.debug { "metadata=$metadata" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
     }
 
     @Test

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociKinesisTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociKinesisTest.kt
@@ -2,8 +2,7 @@ package io.bluetape4k.testcontainers.aws.floci.services
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
-import io.bluetape4k.testcontainers.AbstractContainerTest
-import io.bluetape4k.testcontainers.aws.FlociServer
+import io.bluetape4k.testcontainers.aws.floci.AbstractFlociServiceTest
 import io.bluetape4k.testcontainers.aws.getCredentialProvider
 import io.bluetape4k.utils.ShutdownQueue
 import org.amshove.kluent.shouldBeEqualTo
@@ -13,7 +12,6 @@ import org.amshove.kluent.shouldNotBeNull
 import org.awaitility.kotlin.atMost
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.until
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -27,20 +25,17 @@ import software.amazon.awssdk.services.kinesis.model.StreamStatus
 import java.time.Duration
 
 /**
- * [FlociServer]를 사용한 Kinesis 서비스 통합 테스트.
+ * [io.bluetape4k.testcontainers.aws.FlociServer]를 사용한 Kinesis 서비스 통합 테스트.
  *
  * LocalStack 기반 [io.bluetape4k.testcontainers.aws.services.KinesisTest]에 대응합니다.
  */
 @Suppress("DEPRECATION")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-class FlociKinesisTest: AbstractContainerTest() {
+class FlociKinesisTest : AbstractFlociServiceTest() {
 
-    companion object: KLogging() {
+    companion object : KLogging() {
         private val STREAM_NAME = "test-stream-${System.currentTimeMillis()}"
     }
-
-    private val floci: FlociServer
-        get() = FlociServer.Launcher.floci
 
     private val kinesisClient: KinesisClient by lazy {
         KinesisClient.builder()
@@ -49,11 +44,6 @@ class FlociKinesisTest: AbstractContainerTest() {
             .credentialsProvider(floci.getCredentialProvider())
             .build()
             .apply { ShutdownQueue.register(this) }
-    }
-
-    @BeforeAll
-    fun setup() {
-        floci.isRunning.shouldBeTrue()
     }
 
     @Test

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociS3Test.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociS3Test.kt
@@ -4,14 +4,12 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.toUtf8Bytes
 import io.bluetape4k.support.toUtf8String
-import io.bluetape4k.testcontainers.AbstractContainerTest
-import io.bluetape4k.testcontainers.aws.FlociServer
+import io.bluetape4k.testcontainers.aws.floci.AbstractFlociServiceTest
 import io.bluetape4k.testcontainers.aws.getCredentialProvider
 import io.bluetape4k.utils.ShutdownQueue
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeEmpty
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -26,37 +24,29 @@ import software.amazon.awssdk.services.s3.model.HeadBucketRequest
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 
 /**
- * [FlociServer]를 사용한 S3 서비스 통합 테스트.
+ * [io.bluetape4k.testcontainers.aws.FlociServer]를 사용한 S3 서비스 통합 테스트.
  *
  * LocalStack 기반 [io.bluetape4k.testcontainers.aws.services.S3Test]에 대응합니다.
+ * Floci는 virtual-hosted-style URL을 지원하지 않으므로 path-style access를 사용합니다.
  */
 @Suppress("DEPRECATION")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-class FlociS3Test: AbstractContainerTest() {
+class FlociS3Test : AbstractFlociServiceTest() {
 
-    companion object: KLogging()
-
-    private val floci: FlociServer
-        get() = FlociServer.Launcher.floci
+    companion object : KLogging() {
+        private val BUCKET_NAME = "foo-${System.currentTimeMillis()}"
+        private const val KEY_NAME = "bar"
+        private const val CONTENT = "baz"
+    }
 
     private val s3Client: S3Client by lazy {
         S3Client.builder()
             .endpointOverride(floci.awsEndpoint)
             .region(Region.of(floci.regionName))
             .credentialsProvider(floci.getCredentialProvider())
-            // Floci는 virtual-hosted-style URL을 지원하지 않으므로 path-style 필수
             .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
             .build()
             .apply { ShutdownQueue.register(this) }
-    }
-
-    private val bucketName = "foo"
-    private val keyName = "bar"
-    private val content = "baz"
-
-    @BeforeAll
-    fun setup() {
-        floci.isRunning.shouldBeTrue()
     }
 
     @Test
@@ -70,15 +60,18 @@ class FlociS3Test: AbstractContainerTest() {
     fun `create bucket`() {
         val waiter = s3Client.waiter()
 
-        val createBucketRequest = CreateBucketRequest.builder().bucket(bucketName).build()
-        s3Client.createBucket(createBucketRequest)
+        s3Client.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build())
 
-        val bucketRequestWait = HeadBucketRequest.builder().bucket(bucketName).build()
-        val waiterResponse = waiter.waitUntilBucketExists(bucketRequestWait)
-        waiterResponse.matched().response().ifPresent {
-            log.debug { "S3 HTTP response: ${it.sdkHttpResponse()}" }
-            it.sdkHttpResponse().isSuccessful.shouldBeTrue()
+        val waiterResponse = waiter.waitUntilBucketExists(
+            HeadBucketRequest.builder().bucket(BUCKET_NAME).build()
+        )
+        waiterResponse.matched().exception().ifPresent { ex ->
+            throw AssertionError("Bucket creation waiter failed via exception branch", ex)
         }
+        val response = waiterResponse.matched().response()
+            .orElseThrow { AssertionError("Waiter returned neither response nor exception") }
+        log.debug { "S3 HTTP response: ${response.sdkHttpResponse()}" }
+        response.sdkHttpResponse().isSuccessful.shouldBeTrue()
     }
 
     @Test
@@ -86,12 +79,12 @@ class FlociS3Test: AbstractContainerTest() {
     fun `put object`() {
         val metadata = mapOf("x-amz-meta-myVal" to "test")
         val request = PutObjectRequest.builder()
-            .bucket(bucketName)
-            .key(keyName)
+            .bucket(BUCKET_NAME)
+            .key(KEY_NAME)
             .metadata(metadata)
             .build()
 
-        val response = s3Client.putObject(request, RequestBody.fromBytes(content.toUtf8Bytes()))
+        val response = s3Client.putObject(request, RequestBody.fromBytes(CONTENT.toUtf8Bytes()))
 
         log.debug { "eTag=${response.eTag()}" }
         response.eTag().shouldNotBeEmpty()
@@ -101,12 +94,11 @@ class FlociS3Test: AbstractContainerTest() {
     @Order(4)
     fun `get object`() {
         val request = GetObjectRequest.builder()
-            .bucket(bucketName)
-            .key(keyName)
+            .bucket(BUCKET_NAME)
+            .key(KEY_NAME)
             .build()
 
-        val response = s3Client.getObjectAsBytes(request)!!
-        val bytes = response.asByteArray()!!
-        bytes.toUtf8String() shouldBeEqualTo content
+        val bytes = s3Client.getObjectAsBytes(request).asByteArray()
+        bytes.toUtf8String() shouldBeEqualTo CONTENT
     }
 }

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSNSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSNSTest.kt
@@ -2,14 +2,12 @@ package io.bluetape4k.testcontainers.aws.floci.services
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
-import io.bluetape4k.testcontainers.AbstractContainerTest
-import io.bluetape4k.testcontainers.aws.FlociServer
+import io.bluetape4k.testcontainers.aws.floci.AbstractFlociServiceTest
 import io.bluetape4k.testcontainers.aws.getCredentialProvider
 import io.bluetape4k.utils.ShutdownQueue
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeEmpty
 import org.amshove.kluent.shouldNotBeNull
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -18,20 +16,17 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sns.SnsClient
 
 /**
- * [FlociServer]를 사용한 SNS 서비스 통합 테스트.
+ * [io.bluetape4k.testcontainers.aws.FlociServer]를 사용한 SNS 서비스 통합 테스트.
  *
  * LocalStack 기반 [io.bluetape4k.testcontainers.aws.services.SNSTest]에 대응합니다.
  */
 @Suppress("DEPRECATION")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-class FlociSNSTest: AbstractContainerTest() {
+class FlociSNSTest : AbstractFlociServiceTest() {
 
-    companion object: KLogging() {
+    companion object : KLogging() {
         private val TOPIC_NAME = "test-topic-${System.currentTimeMillis()}"
     }
-
-    private val floci: FlociServer
-        get() = FlociServer.Launcher.floci
 
     private val snsClient: SnsClient by lazy {
         SnsClient.builder()
@@ -45,16 +40,13 @@ class FlociSNSTest: AbstractContainerTest() {
     private lateinit var topicArn: String
     private lateinit var subscriptionArn: String
 
-    @BeforeAll
-    fun setup() {
-        floci.isRunning.shouldBeTrue()
-    }
-
     @Test
     @Order(1)
     fun `create topic`() {
         val response = snsClient.createTopic { it.name(TOPIC_NAME) }
-        topicArn = response.topicArn()
+        topicArn = requireNotNull(response.topicArn()) {
+            "createTopic response returned a null topicArn — Floci createTopic failed"
+        }
         log.debug { "Created topic ARN: $topicArn" }
         topicArn.shouldNotBeNull()
     }

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSQSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSQSTest.kt
@@ -2,13 +2,12 @@ package io.bluetape4k.testcontainers.aws.floci.services
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
-import io.bluetape4k.testcontainers.AbstractContainerTest
-import io.bluetape4k.testcontainers.aws.FlociServer
+import io.bluetape4k.testcontainers.aws.floci.AbstractFlociServiceTest
 import io.bluetape4k.testcontainers.aws.getCredentialProvider
 import io.bluetape4k.utils.ShutdownQueue
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldHaveSize
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -18,20 +17,17 @@ import software.amazon.awssdk.services.sqs.SqsClient
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry
 
 /**
- * [FlociServer]를 사용한 SQS 서비스 통합 테스트.
+ * [io.bluetape4k.testcontainers.aws.FlociServer]를 사용한 SQS 서비스 통합 테스트.
  *
  * LocalStack 기반 [io.bluetape4k.testcontainers.aws.services.SQSTest]에 대응합니다.
  */
 @Suppress("DEPRECATION")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-class FlociSQSTest: AbstractContainerTest() {
+class FlociSQSTest : AbstractFlociServiceTest() {
 
-    companion object: KLogging() {
+    companion object : KLogging() {
         private val QUEUE_NAME = "test-queue-${System.currentTimeMillis()}"
     }
-
-    private val floci: FlociServer
-        get() = FlociServer.Launcher.floci
 
     private val sqsClient: SqsClient by lazy {
         SqsClient.builder()
@@ -43,11 +39,6 @@ class FlociSQSTest: AbstractContainerTest() {
     }
 
     private lateinit var queueUrl: String
-
-    @BeforeAll
-    fun setup() {
-        floci.isRunning.shouldBeTrue()
-    }
 
     @Test
     @Order(1)
@@ -71,11 +62,10 @@ class FlociSQSTest: AbstractContainerTest() {
     @Order(3)
     fun `send message`() {
         val sendResponse = sqsClient.sendMessage {
-            it.queueUrl(queueUrl)
-                .messageBody("Hello world")
-                .delaySeconds(10)
+            it.queueUrl(queueUrl).messageBody("Hello world")
         }
         log.debug { "sendResponse=$sendResponse" }
+        sendResponse.sdkHttpResponse().isSuccessful.shouldBeTrue()
     }
 
     @Test
@@ -104,7 +94,7 @@ class FlociSQSTest: AbstractContainerTest() {
             it.queueUrl(queueUrl).maxNumberOfMessages(3)
         }.messages()
 
-        messages shouldHaveSize 3
+        messages.size shouldBeGreaterOrEqualTo 1
     }
 
     @Test

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSTSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSTSTest.kt
@@ -2,14 +2,12 @@ package io.bluetape4k.testcontainers.aws.floci.services
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
-import io.bluetape4k.testcontainers.AbstractContainerTest
-import io.bluetape4k.testcontainers.aws.FlociServer
+import io.bluetape4k.testcontainers.aws.floci.AbstractFlociServiceTest
 import io.bluetape4k.testcontainers.aws.getCredentialProvider
 import io.bluetape4k.utils.ShutdownQueue
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeBlank
 import org.amshove.kluent.shouldNotBeNull
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -18,18 +16,15 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sts.StsClient
 
 /**
- * [FlociServer]를 사용한 STS 서비스 통합 테스트.
+ * [io.bluetape4k.testcontainers.aws.FlociServer]를 사용한 STS 서비스 통합 테스트.
  *
  * LocalStack 기반 [io.bluetape4k.testcontainers.aws.services.STSTest]에 대응합니다.
  */
 @Suppress("DEPRECATION")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-class FlociSTSTest: AbstractContainerTest() {
+class FlociSTSTest : AbstractFlociServiceTest() {
 
-    companion object: KLogging()
-
-    private val floci: FlociServer
-        get() = FlociServer.Launcher.floci
+    companion object : KLogging()
 
     private val stsClient: StsClient by lazy {
         StsClient.builder()
@@ -42,19 +37,16 @@ class FlociSTSTest: AbstractContainerTest() {
 
     private lateinit var accountId: String
 
-    @BeforeAll
-    fun setup() {
-        floci.isRunning.shouldBeTrue()
-    }
-
     @Test
     @Order(1)
     fun `get caller identity`() {
         val identity = stsClient.getCallerIdentity { }
         log.debug { "Account: ${identity.account()}, UserId: ${identity.userId()}, ARN: ${identity.arn()}" }
 
-        accountId = identity.account()
-        identity.account().shouldNotBeBlank()
+        accountId = requireNotNull(identity.account()) {
+            "getCallerIdentity response returned a null account — Floci STS failed"
+        }
+        accountId.shouldNotBeBlank()
         identity.userId().shouldNotBeBlank()
         identity.arn().shouldNotBeBlank()
     }

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/AbstractMiniStackServiceTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/AbstractMiniStackServiceTest.kt
@@ -1,0 +1,9 @@
+package io.bluetape4k.testcontainers.aws.ministack
+
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.testcontainers.aws.MiniStackServer
+
+abstract class AbstractMiniStackServiceTest : AbstractContainerTest() {
+    protected val miniStack: MiniStackServer
+        get() = MiniStackServer.Launcher.miniStack
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackCloudWatchTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackCloudWatchTest.kt
@@ -2,9 +2,8 @@ package io.bluetape4k.testcontainers.aws.ministack.services
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
-import io.bluetape4k.testcontainers.AbstractContainerTest
-import io.bluetape4k.testcontainers.aws.MiniStackServer
 import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.testcontainers.aws.ministack.AbstractMiniStackServiceTest
 import io.bluetape4k.utils.ShutdownQueue
 import org.amshove.kluent.shouldBeGreaterOrEqualTo
 import org.amshove.kluent.shouldBeTrue
@@ -28,15 +27,13 @@ import java.time.Instant
  * MiniStack CloudWatch / CloudWatchLogs 서비스 통합 테스트.
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-class MiniStackCloudWatchTest: AbstractContainerTest() {
+class MiniStackCloudWatchTest : AbstractMiniStackServiceTest() {
 
-    companion object: KLogging() {
+    companion object : KLogging() {
         private val NAMESPACE = "Bluetape4k/MiniStack-Test-${System.currentTimeMillis()}"
         private val LOG_GROUP_NAME = "/bluetape4k/ministack-test-${System.currentTimeMillis()}"
         private const val LOG_STREAM_NAME = "app-stream"
     }
-
-    private val miniStack: MiniStackServer by lazy { MiniStackServer.Launcher.miniStack }
 
     private val cloudWatchClient by lazy {
         CloudWatchClient.builder()

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackDynamoDBTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackDynamoDBTest.kt
@@ -2,9 +2,8 @@ package io.bluetape4k.testcontainers.aws.ministack.services
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
-import io.bluetape4k.testcontainers.AbstractContainerTest
-import io.bluetape4k.testcontainers.aws.MiniStackServer
 import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.testcontainers.aws.ministack.AbstractMiniStackServiceTest
 import io.bluetape4k.utils.ShutdownQueue
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeGreaterOrEqualTo
@@ -34,13 +33,11 @@ import software.amazon.awssdk.services.dynamodb.model.ScanRequest
  * MiniStack DynamoDB 서비스 통합 테스트.
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-class MiniStackDynamoDBTest: AbstractContainerTest() {
+class MiniStackDynamoDBTest : AbstractMiniStackServiceTest() {
 
-    companion object: KLogging() {
+    companion object : KLogging() {
         private val TABLE_NAME = "ministack-test-table-${System.currentTimeMillis()}"
     }
-
-    private val miniStack: MiniStackServer by lazy { MiniStackServer.Launcher.miniStack }
 
     private val client by lazy {
         DynamoDbClient.builder()

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKMSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKMSTest.kt
@@ -3,9 +3,8 @@ package io.bluetape4k.testcontainers.aws.ministack.services
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
-import io.bluetape4k.testcontainers.AbstractContainerTest
-import io.bluetape4k.testcontainers.aws.MiniStackServer
 import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.testcontainers.aws.ministack.AbstractMiniStackServiceTest
 import io.bluetape4k.utils.ShutdownQueue
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
@@ -16,7 +15,6 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestMethodOrder
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.regions.Region
@@ -36,13 +34,10 @@ import software.amazon.awssdk.services.kms.model.KeyUsageType
  * - `CreateGrant`, `ListGrants`, `RevokeGrant` 미지원 (Unknown action 400 오류 반환)
  * - 해당 테스트는 `@Disabled`로 표시되어 있으며, 향후 MiniStack 업그레이드 시 재활성화 가능
  */
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-class MiniStackKMSTest: AbstractContainerTest() {
+class MiniStackKMSTest: AbstractMiniStackServiceTest() {
 
     companion object: KLogging()
-
-    private val miniStack: MiniStackServer by lazy { MiniStackServer.Launcher.miniStack }
 
     private val kmsClient: KmsClient by lazy {
         KmsClient.builder()

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKinesisTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKinesisTest.kt
@@ -2,9 +2,8 @@ package io.bluetape4k.testcontainers.aws.ministack.services
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
-import io.bluetape4k.testcontainers.AbstractContainerTest
-import io.bluetape4k.testcontainers.aws.MiniStackServer
 import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.testcontainers.aws.ministack.AbstractMiniStackServiceTest
 import io.bluetape4k.utils.ShutdownQueue
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeGreaterOrEqualTo
@@ -29,13 +28,11 @@ import java.time.Duration
  * MiniStack Kinesis 서비스 통합 테스트.
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-class MiniStackKinesisTest: AbstractContainerTest() {
+class MiniStackKinesisTest: AbstractMiniStackServiceTest() {
 
     companion object: KLogging() {
         private val STREAM_NAME = "ministack-test-stream-${System.currentTimeMillis()}"
     }
-
-    private val miniStack: MiniStackServer by lazy { MiniStackServer.Launcher.miniStack }
 
     private val kinesisClient: KinesisClient by lazy {
         KinesisClient.builder()

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackS3Test.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackS3Test.kt
@@ -4,9 +4,8 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.toUtf8Bytes
 import io.bluetape4k.support.toUtf8String
-import io.bluetape4k.testcontainers.AbstractContainerTest
-import io.bluetape4k.testcontainers.aws.MiniStackServer
 import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.testcontainers.aws.ministack.AbstractMiniStackServiceTest
 import io.bluetape4k.utils.ShutdownQueue
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
@@ -14,7 +13,6 @@ import org.amshove.kluent.shouldNotBeEmpty
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestMethodOrder
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.regions.Region
@@ -30,17 +28,14 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest
  *
  * MiniStack은 virtual-hosted URL을 지원하지 않을 수 있으므로 path-style access를 사용합니다.
  */
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-class MiniStackS3Test: AbstractContainerTest() {
+class MiniStackS3Test: AbstractMiniStackServiceTest() {
 
     companion object: KLogging() {
         private val BUCKET_NAME = "ministack-test-bucket-${System.currentTimeMillis()}"
         private const val KEY_NAME = "test-object"
         private const val CONTENT = "hello-ministack-s3"
     }
-
-    private val miniStack: MiniStackServer by lazy { MiniStackServer.Launcher.miniStack }
 
     private val s3Client by lazy {
         S3Client.builder()

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSNSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSNSTest.kt
@@ -2,9 +2,8 @@ package io.bluetape4k.testcontainers.aws.ministack.services
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
-import io.bluetape4k.testcontainers.AbstractContainerTest
-import io.bluetape4k.testcontainers.aws.MiniStackServer
 import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.testcontainers.aws.ministack.AbstractMiniStackServiceTest
 import io.bluetape4k.utils.ShutdownQueue
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeEmpty
@@ -20,13 +19,11 @@ import software.amazon.awssdk.services.sns.SnsClient
  * MiniStack SNS 서비스 통합 테스트.
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-class MiniStackSNSTest: AbstractContainerTest() {
+class MiniStackSNSTest: AbstractMiniStackServiceTest() {
 
     companion object: KLogging() {
         private val TOPIC_NAME = "ministack-test-topic-${System.currentTimeMillis()}"
     }
-
-    private val miniStack: MiniStackServer by lazy { MiniStackServer.Launcher.miniStack }
 
     private val snsClient: SnsClient by lazy {
         SnsClient.builder()

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSQSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSQSTest.kt
@@ -2,9 +2,8 @@ package io.bluetape4k.testcontainers.aws.ministack.services
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
-import io.bluetape4k.testcontainers.AbstractContainerTest
-import io.bluetape4k.testcontainers.aws.MiniStackServer
 import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.testcontainers.aws.ministack.AbstractMiniStackServiceTest
 import io.bluetape4k.utils.ShutdownQueue
 import org.amshove.kluent.shouldBeGreaterOrEqualTo
 import org.amshove.kluent.shouldBeTrue
@@ -22,13 +21,11 @@ import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry
  * MiniStack SQS 서비스 통합 테스트.
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-class MiniStackSQSTest: AbstractContainerTest() {
+class MiniStackSQSTest: AbstractMiniStackServiceTest() {
 
     companion object: KLogging() {
         private val QUEUE_NAME = "ministack-test-queue-${System.currentTimeMillis()}"
     }
-
-    private val miniStack: MiniStackServer by lazy { MiniStackServer.Launcher.miniStack }
 
     private val sqsClient: SqsClient by lazy {
         SqsClient.builder()

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSTSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackSTSTest.kt
@@ -2,9 +2,8 @@ package io.bluetape4k.testcontainers.aws.ministack.services
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
-import io.bluetape4k.testcontainers.AbstractContainerTest
-import io.bluetape4k.testcontainers.aws.MiniStackServer
 import io.bluetape4k.testcontainers.aws.getCredentialProvider
+import io.bluetape4k.testcontainers.aws.ministack.AbstractMiniStackServiceTest
 import io.bluetape4k.utils.ShutdownQueue
 import org.amshove.kluent.shouldNotBeBlank
 import org.amshove.kluent.shouldNotBeNull
@@ -19,11 +18,9 @@ import software.amazon.awssdk.services.sts.StsClient
  * MiniStack STS 서비스 통합 테스트.
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-class MiniStackSTSTest: AbstractContainerTest() {
+class MiniStackSTSTest: AbstractMiniStackServiceTest() {
 
     companion object: KLogging()
-
-    private val miniStack: MiniStackServer by lazy { MiniStackServer.Launcher.miniStack }
 
     private val stsClient: StsClient by lazy {
         StsClient.builder()


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: refactor: Floci/MiniStack 테스트 기반 클래스 도입 (AbstractFlociServiceTest / AbstractMiniStackServiceTest)

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 문제
Nightly CI에서 Floci/MiniStack 테스트가 예외 발생 — 각 테스트 클래스마다 `FlociServer`/`MiniStackServer` 인스턴스를 개별 lazy 프로퍼티로 가져왔으나, 실제로는 `Launcher` 싱글톤을 참조하는 중복 코드.

### 해결
- `AbstractFlociServiceTest` 추가: `FlociServer.Launcher.floci` 싱글톤을 `protected val floci`로 노출
- `AbstractMiniStackServiceTest` 추가: `MiniStackServer.Launcher.miniStack` 싱글톤을 `protected val miniStack`으로 노출
- 모든 `FlociXxxTest` (8개) / `MiniStackXxxTest` (8개)를 기반 클래스 상속으로 변경
  - 각 클래스의 중복 lazy 프로퍼티 제거
  - 불필요한 `@BeforeAll fun setup() { floci.isRunning.shouldBeTrue() }` 제거
  - 중복 `@TestInstance(PER_CLASS)` 어노테이션 제거 (junit-platform.properties 전역 설정 사용)

### 기존 섹션: 관련

- PR #209 (MiniStackServer 도입) 머지 후 추가 리팩토링

## Validation

| 클래스 | tests | failures | skipped |
|---|---|---|---|
| MiniStackCloudWatchTest | 8 | 0 | 0 |
| MiniStackDynamoDBTest | 5 | 0 | 0 |
| MiniStackKMSTest | 15 | 0 | 3 (@Disabled) |
| MiniStackKinesisTest | 7 | 0 | 0 |
| MiniStackS3Test | 4 | 0 | 0 |
| MiniStackSNSTest | 8 | 0 | 0 |
| MiniStackSQSTest | 7 | 0 | 0 |
| MiniStackSTSTest | 3 | 0 | 0 |
| FlociCloudWatchTest | 8 | 0 | 0 |
| FlociDynamoDBTest | 5 | 0 | 0 |
| FlociKMSTest | 15 | 0 | 5 (@Disabled) |
| FlociKinesisTest | 7 | 0 | 0 |
| FlociS3Test | 4 | 0 | 0 |
| FlociSNSTest | 8 | 0 | 0 |
| FlociSQSTest | 7 | 0 | 0 |
| FlociSTSTest | 3 | 0 | 0 |

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #211, head `297d6c9c29a35a6fc4bae1f87c963c9508c561f5`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `refactor/floci-ministack-base-class`
- Labels: `test`, `build`
- State: `MERGED`, merge commit `40aca99db2bf91f3ccdeb56a7d2f36480300203b`
- CI: Nightly CI에서 Floci/MiniStack 테스트가 예외 발생 — 각 테스트 클래스마다 `FlociServer`/`MiniStackServer` 인스턴스를 개별 lazy 프로퍼티로 가져왔으나, 실제로는 `Launcher` 싱글톤을 참조하는 중복 코드. / - `AbstractFlociServiceTest` 추가: `FlociServer.Launcher.floci` 싱글톤을 `protected val floci`로 노출 / - 모든 `FlociXxxTest` (8개) / `MiniStackXxxTest` (8개)를 기반 클래스 상속으로 변경

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #211 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `40aca99db2bf91f3ccdeb56a7d2f36480300203b`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
