### PR TITLE
feat(opentelemetry): Coroutines/Flow/WebFlux 트레이싱 API 추가 (#150)

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -994,6 +994,9 @@ object Libs {
 
     val opentelemetry_spring_boot_starter = opentelemetryInstrumentation("spring-boot-starter")
 
+    // https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-spring-webflux-5.3
+    val opentelemetry_spring_webflux = opentelemetryInstrumentation("spring-webflux-5.3")
+
     const val reflectasm = "com.esotericsoftware:reflectasm:${Versions.reflectasm}"
 
     // mongodb 5.x

--- a/docs/superpowers/plans/2026-04-28-opentelemetry-coroutines-plan.md
+++ b/docs/superpowers/plans/2026-04-28-opentelemetry-coroutines-plan.md
@@ -1,0 +1,389 @@
+# OpenTelemetry Coroutines 통합 강화 — Implementation Plan
+
+- **Spec**: `docs/superpowers/specs/2026-04-28-opentelemetry-coroutines-design.md`
+- **Issue**: #150
+- **Branch**: `feat/opentelemetry-coroutines`
+- **Worktree**: `.worktrees/feat/opentelemetry-coroutines`
+- **Module**: `infra/opentelemetry` (`bluetape4k-opentelemetry`)
+- **작성일**: 2026-04-28
+- **작성자**: Claude (Opus 4.7)
+
+---
+
+## 개요
+
+본 plan은 spec(2026-04-28)에서 정의한 4가지 추가 API의 구현 단계를 task 단위로 분해한다. 모든 task는 worktree 안에서 수행하며, Plan Task는 선택 없이 전수 완료 후 PR을 생성한다.
+
+- 기존 API 시그니처/동작은 변경하지 않는다 (binary + source compatible).
+- 신규 의존성은 `compileOnly` 로 추가하여 transitive 영향 0 을 보장한다.
+- CancellationException 계약, configure footgun, 민감 attribute 보안 가이드를 KDoc + 테스트로 강제한다.
+
+---
+
+## Task List
+
+### Task 1 — 기존 시그니처 정찰 및 충돌 검사
+
+- **complexity**: low
+- **목표**: spec §"작업 순서" 1단계. 추가 대상 파일의 현존 시그니처를 정확히 파악해 중복/충돌 여부를 결정한다.
+- **수행 내용**:
+  - `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanSupport.kt` Read.
+  - `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/SpanCoroutineSupport.kt` Read.
+  - `ContextCoroutineSupport.kt`, `TracerSupport.kt`, `OpenTelemetryCoroutineSupport.kt`(있을 시) Read.
+  - `Tracer.withSpan` 이름의 함수가 이미 존재하는지 `ide_find_references` 또는 `ast-grep` 로 확인.
+  - 현존 `useSuspending`, `useSpanSuspending`, `withSpanContext` 시그니처를 plan 본문에 기록 (paramName + default + return).
+- **DoD**:
+  - [ ] 두 파일의 public API 표 작성 완료
+  - [ ] 충돌 0 또는 충돌이 있다면 spec 미세 조정안 명시
+- **산출물**: 본 plan 의 `## 정찰 결과` 섹션에 추가 (Task 1 완료 후).
+
+---
+
+### Task 2 — `Tracer.withSpan` (suspend) 구현
+
+- **complexity**: high
+- **위치**: `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/SpanCoroutineSupport.kt`
+- **목표**: spec §1.1. suspend 한 줄 DSL.
+- **시그니처**:
+  ```kotlin
+  public suspend fun <T> Tracer.withSpan(
+      spanName: String,
+      configure: SpanBuilder.() -> Unit = {},
+      coroutineContext: CoroutineContext = EmptyCoroutineContext,
+      block: suspend (Span) -> T,
+  ): T
+  ```
+- **구현 노트**:
+  - 내부적으로 `spanBuilder(spanName).apply(configure).useSpanSuspending(coroutineContext, block)` 위임.
+  - 파라미터 순서: `(spanName, configure, coroutineContext, block)` — configure 가 coroutineContext 앞.
+  - `configure` 람다 안에서 `.startSpan()` 직접 호출은 이중 Span 생성 — KDoc 경고만 (코드로 강제 불가).
+  - CancellationException 처리는 `useSpanSuspending` 의 기존 규약에 위임.
+- **DoD**:
+  - [ ] 파일에 함수 추가, KDoc(Korean) 포함 (보안 경고 + cancellation 계약 + configure footgun)
+  - [ ] `ide_diagnostics` 0 error / 0 import warning
+  - [ ] 컴파일 통과: `./gradlew :bluetape4k-opentelemetry:compileKotlin`
+
+---
+
+### Task 3 — `Tracer.withSpan` (blocking) 구현
+
+- **complexity**: high
+- **위치**: `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanSupport.kt`
+- **목표**: spec §1.2. blocking 한 줄 DSL.
+- **시그니처**:
+  ```kotlin
+  public inline fun <T> Tracer.withSpan(
+      spanName: String,
+      configure: SpanBuilder.() -> Unit = {},
+      block: (Span) -> T,
+  ): T
+  ```
+- **구현 노트**:
+  - `val span = spanBuilder(spanName).apply(configure).startSpan()`
+  - `span.makeCurrent().use { block(span) }` 패턴.
+  - 정상 종료: `span.setStatus(StatusCode.OK)` → `span.end()` (finally 안에서 보장).
+  - 예외: `span.recordException(t)` + `span.setStatus(StatusCode.ERROR, t.message ?: "unspecified error")` → 재던짐.
+    - **fallback 메시지는 `"unspecified error"` 고정** — `t.javaClass.simpleName` 절대 금지 (내부 클래스명 외부 노출 방지).
+  - `inline` 적용 — 람다 호출 비용 제거. `inline` 함수 내부에서 `recordException` 등 비-public-API 호출이 필요하면 `@PublishedApi internal` 헬퍼로 분리.
+- **DoD**:
+  - [ ] 함수 추가, KDoc(Korean) 포함 (보안 경고 + 코루틴 사용 주의 — Dispatcher 전환 시 ThreadLocal 유실)
+  - [ ] `ide_diagnostics` 0 error
+  - [ ] 컴파일 통과
+
+---
+
+### Task 4 — `FlowSpanSupport.kt` 신규 생성
+
+- **complexity**: high
+- **위치**: `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/FlowSpanSupport.kt` (신규)
+- **목표**: spec §2. `Flow<T>.traced` + `Flow<T>.tracedCollect`.
+- **핵심 설계 원칙 (절대 위반 금지)**:
+  1. **`channelFlow {}` 사용 필수** — `flow {}` 안에서 `withContext` 후 `emit()` 은 Flow invariant 위반(`IllegalStateException`).
+  2. **`withSpanContext` 재사용 금지** — 내부 `finally` 에서 `endSafely()` 를 이미 호출 → 이중 `end()` 발생. OTel Context 전파는 `Context.current().with(span).asContextElement()` 직접 사용.
+  3. **catch 순서 계약**: `CancellationException` 을 일반 `Throwable` 보다 먼저 catch. UNSET 유지, 구조적 동시성 보존.
+  4. **1 collect = 1 Span** — emit 횟수와 무관하게 collect 한 번 = Span 한 개.
+- **시그니처**:
+  ```kotlin
+  public fun <T> Flow<T>.traced(
+      tracer: Tracer,
+      spanName: String,
+      configure: SpanBuilder.() -> Unit = {},
+  ): Flow<T>
+
+  public suspend fun <T> Flow<T>.tracedCollect(
+      tracer: Tracer,
+      spanName: String,
+      configure: SpanBuilder.() -> Unit = {},
+      action: suspend (T) -> Unit,
+  )
+  ```
+- **구현 골격** (spec §2 구현 스케치 그대로):
+  ```kotlin
+  channelFlow {
+      val span = tracer.spanBuilder(spanName).apply(configure).startSpan()
+      val otelContext = span.storeInContext(Context.current())
+      try {
+          withContext(otelContext.asContextElement()) {
+              this@traced.collect { value -> send(value) }
+          }
+          span.setStatus(StatusCode.OK)
+      } catch (ce: CancellationException) {
+          throw ce          // UNSET 유지, ERROR 미기록
+      } catch (t: Throwable) {
+          span.recordException(t)
+          span.setStatus(StatusCode.ERROR, t.message ?: "unspecified error")
+          throw t
+      } finally {
+          span.end()        // 모든 경로 exactly-once
+      }
+  }
+  ```
+  `tracedCollect` 는 `traced(...).collect(action)` 으로 위임.
+- **DoD**:
+  - [ ] 파일 생성, KDoc(Korean) — 보안 경고 + 1-collect-1-Span 의도 + traced/tracedCollect 선택 기준 표
+  - [ ] import: `kotlinx.coroutines.flow.Flow`, `channelFlow`, `kotlinx.coroutines.withContext`, `io.opentelemetry.context.Context`, `io.opentelemetry.extension.kotlin.asContextElement`, OpenTelemetry API
+  - [ ] `ide_diagnostics` 0 error
+  - [ ] 컴파일 통과
+
+---
+
+### Task 5 — WebFlux helper + 의존성 승격
+
+- **complexity**: medium
+- **위치**:
+  - 신규: `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/webflux/WebfluxTracingSupport.kt`
+  - 수정: `infra/opentelemetry/build.gradle.kts`
+- **목표**: spec §3. `OpenTelemetry.webfluxServerTelemetry()` + `createTracingWebFilter()`.
+- **build.gradle.kts 변경**:
+  - `compileOnly(Libs.spring_webflux)` 추가 (현재 `testRuntimeOnly` 라면 승격, 신규라면 추가)
+  - `compileOnly(Libs.opentelemetry_spring_webflux)` 추가 — `buildSrc/Libs.kt` 에 상수가 없으면 추가 (`opentelemetry-spring-webflux-5.3` 좌표 확인 → context7 또는 공식 instrumentation BOM 확인)
+  - `testImplementation(Libs.spring_webflux)` 추가 — 테스트가 webflux 환경 필요시
+  - `testImplementation(Libs.opentelemetry_spring_webflux)` — 테스트용
+- **API**:
+  ```kotlin
+  public fun OpenTelemetry.webfluxServerTelemetry(): SpringWebfluxServerTelemetry =
+      SpringWebfluxServerTelemetry.create(this)
+
+  public fun OpenTelemetry.createTracingWebFilter(): WebFilter =
+      webfluxServerTelemetry().createWebFilterAndRegisterReactorHook()
+  ```
+- **운영 제약 (KDoc 필수)**:
+  - 반드시 `@Bean` 으로 ApplicationContext 초기화 시 1회만 호출.
+  - Reactor `Hooks.onEachOperator` 전역 등록 — 테스트 격리 시 `Hooks.resetOnEachOperator(key)` 권장.
+  - 민감 헤더 캡처 제한: `OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST` 환경변수 가이드.
+- **DoD**:
+  - [ ] `Libs.kt` 에 `opentelemetry_spring_webflux` 정의 (필요 시) — 좌표 검증
+  - [ ] `build.gradle.kts` 의존성 추가
+  - [ ] `webflux/` 패키지로 격리 (classpath 미존재 시 다른 기능에 영향 없도록)
+  - [ ] KDoc(Korean) — 1회 호출 제약 + 민감 헤더 가이드
+  - [ ] 컴파일 통과
+
+---
+
+### Task 6 — 테스트: `Tracer.withSpan` (suspend & blocking)
+
+- **complexity**: medium
+- **위치**: `infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/coroutines/TracerWithSpanTest.kt` (신규)
+  - blocking 테스트는 `infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/trace/TracerWithSpanBlockingTest.kt` (또는 같은 클래스 내 nested)
+- **공통 픽스처**: `InMemorySpanExporter` + `SdkTracerProvider` (기존 모듈 패턴 재사용)
+- **suspend 케이스** (spec §5.1):
+  - [ ] 정상 완료 → name 일치, status OK, parent context 검증
+  - [ ] `withContext(Dispatchers.IO)` 내부 호출 → IO 디스패처에서 current 유지, finished span 1개
+  - [ ] 중첩 호출 (Dispatchers 경계 포함) → child traceId == parent traceId, child parentSpanId == parent spanId
+  - [ ] 일반 예외 → status ERROR, recordException 이벤트 기록, 재던짐
+  - [ ] `CancellationException` → status UNSET, end() 호출, 재던짐 (ERROR 미기록)
+  - [ ] `configure` 로 attribute 추가 → 종료 Span attribute 검증
+  - [ ] **negative**: `configure` 안에서 `.startSpan()` 직접 호출 → 이중 Span 생성 확인 (footgun 문서화)
+- **blocking 케이스** (spec §5.2):
+  - [ ] 정상 완료 → OK + end()
+  - [ ] 예외 → ERROR + recordException + `message ?: "unspecified error"` 검증 + 재던짐
+  - [ ] **negative**: `throw RuntimeException(null)` 처럼 message=null 인 경우 → fallback `"unspecified error"` 검증 (javaClass.simpleName 누출 안 됨)
+  - [ ] 동일 스레드 nested 호출 → parent-child 관계 검증
+- **테스트 도구**: JUnit 5 + MockK + Kluent + `kotlinx-coroutines-test` (`runTest`)
+- **Kluent matcher**: 비교는 `shouldBeEqualTo`, `shouldNotBeNull`, `shouldBeGreaterThan` 등 사용 (`(x == y).shouldBeTrue()` 금지).
+- **DoD**:
+  - [ ] 모든 케이스 통과 — `./gradlew :bluetape4k-opentelemetry:test --tests "*TracerWithSpan*"`
+
+---
+
+### Task 7 — 테스트: `Flow<T>.traced` / `tracedCollect`
+
+- **complexity**: medium
+- **위치**: `infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/coroutines/FlowSpanSupportTest.kt` (신규)
+- **케이스** (spec §5.3):
+  - [ ] Flow 정상 완료 → finished Span **1개**, status OK
+  - [ ] emit 3회 `.toList()` → finished Span **1개** (아이템별 아님)
+  - [ ] Upstream 예외 → ERROR + recordException + 재던짐
+  - [ ] Downstream `take(2)` 정상 종료 → OK + end()
+  - [ ] Downstream cancellation (`scope.cancel()` / `withTimeout`) → status UNSET + end() + ERROR 미기록
+  - [ ] `flowOn(Dispatchers.IO)` 결합 → Span 정상 전파, finished Span 1개
+  - [ ] `tracedCollect` action 안에서 `Span.current()` == traced Span 검증
+  - [ ] **negative**: `Authorization: Bearer xxx` 가 Span attribute 에 없음 검증 (민감 attribute 가이드 강제)
+- **runTest 사용 시 주의**:
+  - `runTest(timeout = 30.seconds)` — coroutines-test 패턴
+  - `@BeforeEach`/`@AfterEach` 도 `runTest { ... }` 로 감싸기
+- **DoD**:
+  - [ ] 모든 케이스 통과 — `./gradlew :bluetape4k-opentelemetry:test --tests "*FlowSpanSupport*"`
+
+---
+
+### Task 8 — 테스트: WebFlux helper
+
+- **complexity**: medium
+- **위치**: `infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/webflux/WebfluxTracingSupportTest.kt` (신규)
+- **케이스** (spec §5.4):
+  - [ ] `OpenTelemetry.createTracingWebFilter()` 호출 성공 (NPE/ClassNotFound 없음) — 의존성 정상 노출
+  - [ ] WebFlux mock 핸들러 GET (Spring `WebTestClient` 또는 직접 `MockServerHttpRequest` + `WebFilterChain`) → 서버 Span 1개, HTTP method/path attribute 검증
+  - [ ] **negative**: `Authorization` 헤더 미포함 — 기본 설정에서 민감 헤더가 Span attribute 로 캡처되지 않음 검증
+- **테스트 격리**: `Hooks.resetOnEachOperator(key)` `@AfterAll` 로 호출 — JVM 전역 hook 정리.
+- **의존성**: `testImplementation(Libs.spring_webflux)`, `testImplementation(Libs.opentelemetry_spring_webflux)` (Task 5 에서 추가).
+- **DoD**:
+  - [ ] 모든 케이스 통과 — `./gradlew :bluetape4k-opentelemetry:test --tests "*WebfluxTracing*"`
+
+---
+
+### Task 9 — 회귀 테스트 + 전체 모듈 테스트
+
+- **complexity**: low
+- **목표**: spec §5.5. 기존 테스트가 변경 없이 통과해야 한다.
+- **수행 내용**:
+  - `./gradlew :bluetape4k-opentelemetry:test` 전수 실행
+  - 통과/실패 카운트 + duration 기록
+  - 실패 시 회귀 원인 분석 — 신규 코드가 기존 API 동작에 영향을 줬는지 점검 (특히 `useSpanSuspending` 위임으로 인한 side effect)
+- **DoD**:
+  - [ ] 전수 통과 (passing count 기록)
+  - [ ] `./gradlew :bluetape4k-opentelemetry:detekt` 통과
+
+---
+
+### Task 10 — KDoc 보강 (모든 신규 public API)
+
+- **complexity**: low
+- **목표**: spec §DoD 3. Korean KDoc + 보안 경고 + 계약 명시.
+- **각 API 별 KDoc 필수 항목**:
+  - 동작 계약 (정상/예외/CancellationException 분기)
+  - 보안 경고 (PII / Authorization 토큰 / 민감 헤더 attribute 추가 금지)
+  - configure footgun (`.startSpan()` 직접 호출 금지, `async`/`launch` 금지)
+  - 코루틴 사용 주의 (suspend vs blocking 변형 선택)
+  - 파라미터 설명 + 예시 코드 (선택)
+- **대상**:
+  - `Tracer.withSpan(suspend)`
+  - `Tracer.withSpan(blocking)`
+  - `Flow<T>.traced`
+  - `Flow<T>.tracedCollect`
+  - `OpenTelemetry.webfluxServerTelemetry()`
+  - `OpenTelemetry.createTracingWebFilter()`
+- **DoD**:
+  - [ ] 모든 신규 public API 에 Korean KDoc — 보안/계약/footgun 누락 0
+  - [ ] 예시 코드 (선택) — 컴파일 가능한 형태로 작성
+
+---
+
+### Task 11 — README.md + README.ko.md 업데이트
+
+- **complexity**: low
+- **위치**: `infra/opentelemetry/README.md`, `infra/opentelemetry/README.ko.md`
+- **구성 순서 (필수)**: Architecture → UML(Mermaid) → Features → Examples
+- **추가 내용**:
+  - **Features** 섹션에 4개 신규 API 항목 추가
+  - **Examples**:
+    - `Tracer.withSpan(suspend)` 예시
+    - `Tracer.withSpan(blocking)` 예시
+    - `Flow<T>.traced` + `tracedCollect` 예시 (`flowOn` 결합 포함)
+    - `WebFlux` `@Bean` 등록 예시 (Spring `@Configuration`)
+  - **Mermaid 다이어그램**:
+    - `withSpan` DSL 흐름 (sequenceDiagram: caller → Tracer → SpanBuilder → Span lifecycle)
+    - `Flow.traced` 생명주기 (sequenceDiagram: collect → channelFlow → withContext(asContextElement) → upstream collect → send → end)
+  - **운영/보안 가이드**:
+    - OTLP exporter TLS (`https://` + `OTEL_EXPORTER_OTLP_CERTIFICATE`)
+    - `SdkTracerProvider.shutdown()` timeout 5–10s 권장
+    - WebFlux 1회 호출 제약 + `Hooks.resetOnEachOperator()` 테스트 격리
+    - `OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST` 헤더 화이트리스트 예시
+  - **언어 전환 링크** (제목 바로 아래): `[한국어](./README.ko.md) | English` / `한국어 | [English](./README.md)`
+- **DoD**:
+  - [ ] README.md (영문) + README.ko.md (한국어) 동기화
+  - [ ] 두 README 모두 Architecture → UML → Features → Examples 순서
+  - [ ] Mermaid 다이어그램 GitHub 렌더링 검증 (vega-lite 사용 금지)
+  - [ ] 언어 전환 링크 포함
+
+---
+
+### Task 12 — CLAUDE.md / 모듈 테이블 확인
+
+- **complexity**: low
+- **목표**: 모듈 테이블 변경 불필요 — 기존 `infra/opentelemetry` 보강이므로 루트 CLAUDE.md 모듈 그룹 표 수정 없음.
+- **수행 내용**:
+  - 루트 `CLAUDE.md` 의 `infra/` 행이 `opentelemetry` 를 포함하는지 확인 (이미 포함되어 있음).
+  - 새 디자인 패턴 (예: WebFlux helper 사용 가이드) 가 다른 모듈에서 재사용된다면 `Key Design Patterns` 섹션에 한 줄 추가 — 단, 본 PR 범위에서는 미루고 후속 PR에서 처리하는 것이 안전.
+- **DoD**:
+  - [ ] 모듈 테이블 검토 후 변경 불필요 확인 기록
+
+---
+
+### Task 13 — `wiki-update` 스킬 실행
+
+- **complexity**: low
+- **목표**: spec/plan 신규 생성 → Obsidian wiki 페이지 업데이트.
+- **수행 내용**:
+  - `/oh-my-claudecode:wiki-update` 또는 `wiki-update` 스킬 호출
+  - spec + plan 파일을 wiki 에 색인하여 후속 검색 (`qmd query`) 가능하게 함
+- **DoD**:
+  - [ ] wiki 업데이트 완료 (skill 응답 확인)
+
+---
+
+### Task 14 — Code Review + PR 생성
+
+- **complexity**: medium
+- **수행 내용**:
+  1. `./bin/repo-status` 로 변경 파일 확인
+  2. Korean + prefix commit (`feat: opentelemetry-coroutines DSL 강화 (#150)`)
+  3. **Code review 실행 (필수)**: `oh-my-claudecode:code-reviewer` 에이전트 호출 → HIGH/CRITICAL 이슈 해소
+  4. `./gradlew :bluetape4k-opentelemetry:test` 결과 + duration PR 본문에 기재
+  5. PR 본문에 spec/plan 링크 + 변경 요약 + 테스트 결과 + DoD 체크리스트 포함
+  6. `gh pr create --base develop` 비대화식 호출
+- **DoD**:
+  - [ ] 모든 plan task 완료 표 (완료 후 plan 대비 비교 표 작성)
+  - [ ] code-reviewer 에이전트 결과 첨부
+  - [ ] 로컬 테스트 결과 PR 본문 포함
+  - [ ] CI 통과
+
+---
+
+## 작업 순서 (의존성 기반)
+
+```
+1 (정찰)
+ → 2, 3, 4 (병렬 가능 — 서로 다른 파일, 다른 함수)
+ → 5 (WebFlux helper, 빌드 의존성 변경 필요)
+ → 6, 7, 8 (테스트, 병렬 가능)
+ → 9 (회귀 테스트)
+ → 10 (KDoc 보강 — 1~5 산출물 대상)
+ → 11 (README) → 12 (CLAUDE.md 검토) → 13 (wiki-update)
+ → 14 (commit + code review + PR)
+```
+
+---
+
+## Plan 대비 완료 보고 양식 (Task 14 에서 작성)
+
+| Task | 상태 | 비고 |
+|------|------|------|
+| 1 | ✅ / ⏳ / ❌ | … |
+| 2 | … | … |
+| … | … | … |
+| 14 | … | … |
+
+---
+
+## 리스크 및 완화
+
+| 리스크 | 완화 |
+|--------|------|
+| `Tracer.withSpan` 이미 존재 → 시그니처 충돌 | Task 1 정찰에서 발견 → spec 미세 조정 + 본 plan 업데이트 |
+| `channelFlow` 사용 missing → `Flow invariant` 위반 | Task 7 테스트에서 emit 3회 + Dispatcher 경계 결합으로 검증 |
+| `withSpanContext` 재사용 → 이중 `end()` | Task 4 구현 노트 명시 + Task 7 테스트로 finished span 카운트 검증 |
+| WebFlux `Hooks` 전역 등록 → 테스트 격리 실패 | Task 8 `@AfterAll Hooks.resetOnEachOperator(key)` |
+| 민감 헤더 (`Authorization`) 누출 | Task 7 + Task 8 negative test + README 운영 가이드 |
+| `inline` blocking `withSpan` 내부 비-public-API 접근 | `@PublishedApi internal` 헬퍼 분리 |
+| Reactor `opentelemetry-spring-webflux-5.3` 좌표 부재 | Task 5 에서 `Libs.kt` 추가 + context7 로 좌표 검증 |

--- a/docs/superpowers/plans/2026-04-28-opentelemetry-coroutines-plan.md
+++ b/docs/superpowers/plans/2026-04-28-opentelemetry-coroutines-plan.md
@@ -29,13 +29,51 @@
 - **수행 내용**:
   - `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanSupport.kt` Read.
   - `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/SpanCoroutineSupport.kt` Read.
-  - `ContextCoroutineSupport.kt`, `TracerSupport.kt`, `OpenTelemetryCoroutineSupport.kt`(있을 시) Read.
+  - `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/ContextCoroutineSupport.kt` Read — `withOtelContext` 등 OTel 컨텍스트 전파 헬퍼 위치.
+  - `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/CompletableResultCodeSupport.kt` Read — `await` + Span 완료 헬퍼 위치.
+  - `TracerSupport.kt` Read.
   - `Tracer.withSpan` 이름의 함수가 이미 존재하는지 `ide_find_references` 또는 `ast-grep` 로 확인.
   - 현존 `useSuspending`, `useSpanSuspending`, `withSpanContext` 시그니처를 plan 본문에 기록 (paramName + default + return).
 - **DoD**:
   - [ ] 두 파일의 public API 표 작성 완료
   - [ ] 충돌 0 또는 충돌이 있다면 spec 미세 조정안 명시
 - **산출물**: 본 plan 의 `## 정찰 결과` 섹션에 추가 (Task 1 완료 후).
+
+---
+
+### Task 1.5 — `SpanSupport.recordFailure` 보안 수정 (Option A)
+
+- **complexity**: medium
+- **위치**: `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanSupport.kt`
+- **목표**: 기존 `recordFailure` 함수의 fallback 메시지가 `error::class.java.simpleName` 을 사용하여 내부 클래스명을 OTLP 백엔드에 노출하는 보안 결함을 수정한다.
+- **수정 내용**:
+  ```kotlin
+  // 수정 전
+  private const val UNSPECIFIED_ERROR = "unspecified error"
+
+  fun Span.recordFailure(error: Throwable, message: String? = null) {
+      recordException(error)
+      setStatus(StatusCode.ERROR, message ?: error.message ?: error::class.java.simpleName)
+  //                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 제거
+  }
+
+  // 수정 후
+  fun Span.recordFailure(error: Throwable, message: String? = null) {
+      recordException(error)
+      setStatus(StatusCode.ERROR, message ?: error.message ?: UNSPECIFIED_ERROR)
+  }
+  ```
+  - `private const val UNSPECIFIED_ERROR = "unspecified error"` 상수 파일 최상단에 정의 (Task 3, 4 에서도 재사용).
+  - 기존 API 시그니처 유지 — binary + source compatible.
+- **회귀 테스트**:
+  - `src/test/kotlin/io/bluetape4k/opentelemetry/trace/SpanSupportTest.kt` (신규 또는 기존 확장)
+  - `throw RuntimeException(null)` → `recordFailure()` 호출 → Span status description 이 `"unspecified error"` 임을 검증 (`.javaClass.simpleName` 누출 안 됨).
+- **DoD**:
+  - [ ] `SpanSupport.kt` 에 `UNSPECIFIED_ERROR` 상수 추가
+  - [ ] `recordFailure` fallback 수정 (`error::class.java.simpleName` 제거)
+  - [ ] 회귀 테스트 추가 + `null` message 케이스 통과
+  - [ ] `ide_diagnostics` 0 error
+  - [ ] 컴파일 통과
 
 ---
 
@@ -54,12 +92,15 @@
   ): T
   ```
 - **구현 노트**:
+  - 진입 즉시 `requireNotBlank(spanName) { "spanName must not be blank" }` 검사.
   - 내부적으로 `spanBuilder(spanName).apply(configure).useSpanSuspending(coroutineContext, block)` 위임.
   - 파라미터 순서: `(spanName, configure, coroutineContext, block)` — configure 가 coroutineContext 앞.
+  - `suspend fun` 이므로 `inline` 불가; `block` 파라미터는 `crossinline` 불가 (`useSpanSuspending` 내부에서 다른 suspend 컨텍스트로 호출될 수 있음). `noinline`으로 선언하거나 일반 suspend 람다로 유지.
   - `configure` 람다 안에서 `.startSpan()` 직접 호출은 이중 Span 생성 — KDoc 경고만 (코드로 강제 불가).
   - CancellationException 처리는 `useSpanSuspending` 의 기존 규약에 위임.
 - **DoD**:
   - [ ] 파일에 함수 추가, KDoc(Korean) 포함 (보안 경고 + cancellation 계약 + configure footgun)
+  - [ ] `requireNotBlank(spanName)` 진입 검사 포함
   - [ ] `ide_diagnostics` 0 error / 0 import warning
   - [ ] 컴파일 통과: `./gradlew :bluetape4k-opentelemetry:compileKotlin`
 
@@ -79,14 +120,17 @@
   ): T
   ```
 - **구현 노트**:
+  - 진입 즉시 `requireNotBlank(spanName) { "spanName must not be blank" }` 검사.
   - `val span = spanBuilder(spanName).apply(configure).startSpan()`
   - `span.makeCurrent().use { block(span) }` 패턴.
   - 정상 종료: `span.setStatus(StatusCode.OK)` → `span.end()` (finally 안에서 보장).
-  - 예외: `span.recordException(t)` + `span.setStatus(StatusCode.ERROR, t.message ?: "unspecified error")` → 재던짐.
-    - **fallback 메시지는 `"unspecified error"` 고정** — `t.javaClass.simpleName` 절대 금지 (내부 클래스명 외부 노출 방지).
-  - `inline` 적용 — 람다 호출 비용 제거. `inline` 함수 내부에서 `recordException` 등 비-public-API 호출이 필요하면 `@PublishedApi internal` 헬퍼로 분리.
+  - 예외: `span.recordException(t)` + `span.setStatus(StatusCode.ERROR, t.message ?: UNSPECIFIED_ERROR)` → 재던짐.
+    - **`UNSPECIFIED_ERROR` 상수 사용** — `SpanSupport.kt` 파일 최상단에 `private const val UNSPECIFIED_ERROR = "unspecified error"` 정의 (Task 1.5에서 추가). `t.javaClass.simpleName` 절대 금지 (내부 클래스명 외부 노출 방지).
+  - `inline` 적용 — 람다 호출 비용 제거. `inline` 함수 내부에서 비-public-API 호출이 필요하면 `@PublishedApi internal` 헬퍼로 분리.
 - **DoD**:
   - [ ] 함수 추가, KDoc(Korean) 포함 (보안 경고 + 코루틴 사용 주의 — Dispatcher 전환 시 ThreadLocal 유실)
+  - [ ] `requireNotBlank(spanName)` 진입 검사 포함
+  - [ ] `UNSPECIFIED_ERROR` 상수 사용 (리터럴 `"unspecified error"` 직접 기재 금지)
   - [ ] `ide_diagnostics` 0 error
   - [ ] 컴파일 통과
 
@@ -117,6 +161,8 @@
       action: suspend (T) -> Unit,
   )
   ```
+- **진입 검사**: `traced`/`tracedCollect` 모두 `requireNotBlank(spanName)` 호출.
+- **`UNSPECIFIED_ERROR` 상수**: `SpanSupport.kt` 에 정의된 상수를 재사용하거나, 이 파일에 `internal const val` 로 별도 정의 (`"unspecified error"` 리터럴 직접 기재 금지).
 - **구현 골격** (spec §2 구현 스케치 그대로):
   ```kotlin
   channelFlow {
@@ -156,7 +202,7 @@
 - **목표**: spec §3. `OpenTelemetry.webfluxServerTelemetry()` + `createTracingWebFilter()`.
 - **build.gradle.kts 변경**:
   - `compileOnly(Libs.spring_webflux)` 추가 (현재 `testRuntimeOnly` 라면 승격, 신규라면 추가)
-  - `compileOnly(Libs.opentelemetry_spring_webflux)` 추가 — `buildSrc/Libs.kt` 에 상수가 없으면 추가 (`opentelemetry-spring-webflux-5.3` 좌표 확인 → context7 또는 공식 instrumentation BOM 확인)
+  - `compileOnly(Libs.opentelemetry_spring_webflux)` 추가 — `buildSrc/Libs.kt` 에 상수가 없으면 추가. 검증된 Maven 좌표: `io.opentelemetry.instrumentation:opentelemetry-spring-webflux-5.3` (OTel instrumentation BOM 버전 관리). **주의**: `opentelemetry-spring-boot-starter`가 아닌 raw `spring-webflux-5.3` 아티팩트 사용.
   - `testImplementation(Libs.spring_webflux)` 추가 — 테스트가 webflux 환경 필요시
   - `testImplementation(Libs.opentelemetry_spring_webflux)` — 테스트용
 - **API**:
@@ -186,6 +232,7 @@
 - **위치**: `infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/coroutines/TracerWithSpanTest.kt` (신규)
   - blocking 테스트는 `infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/trace/TracerWithSpanBlockingTest.kt` (또는 같은 클래스 내 nested)
 - **공통 픽스처**: `InMemorySpanExporter` + `SdkTracerProvider` (기존 모듈 패턴 재사용)
+  - `@BeforeEach fun setup() { inMemoryExporter.reset() }` — 테스트 간 Span 데이터 격리 필수.
 - **suspend 케이스** (spec §5.1):
   - [ ] 정상 완료 → name 일치, status OK, parent context 검증
   - [ ] `withContext(Dispatchers.IO)` 내부 호출 → IO 디스패처에서 current 유지, finished span 1개
@@ -194,10 +241,12 @@
   - [ ] `CancellationException` → status UNSET, end() 호출, 재던짐 (ERROR 미기록)
   - [ ] `configure` 로 attribute 추가 → 종료 Span attribute 검증
   - [ ] **negative**: `configure` 안에서 `.startSpan()` 직접 호출 → 이중 Span 생성 확인 (footgun 문서화)
+  - [ ] **negative**: 빈 문자열 `spanName` → `IllegalArgumentException` 발생 검증 (`requireNotBlank`)
 - **blocking 케이스** (spec §5.2):
   - [ ] 정상 완료 → OK + end()
   - [ ] 예외 → ERROR + recordException + `message ?: "unspecified error"` 검증 + 재던짐
   - [ ] **negative**: `throw RuntimeException(null)` 처럼 message=null 인 경우 → fallback `"unspecified error"` 검증 (javaClass.simpleName 누출 안 됨)
+  - [ ] **negative**: 빈 문자열 `spanName` → `IllegalArgumentException` 발생 검증 (`requireNotBlank`)
   - [ ] 동일 스레드 nested 호출 → parent-child 관계 검증
 - **테스트 도구**: JUnit 5 + MockK + Kluent + `kotlinx-coroutines-test` (`runTest`)
 - **Kluent matcher**: 비교는 `shouldBeEqualTo`, `shouldNotBeNull`, `shouldBeGreaterThan` 등 사용 (`(x == y).shouldBeTrue()` 금지).
@@ -210,6 +259,7 @@
 
 - **complexity**: medium
 - **위치**: `infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/coroutines/FlowSpanSupportTest.kt` (신규)
+- **픽스처**: `@BeforeEach fun setup() { inMemoryExporter.reset() }` — 테스트 간 Span 데이터 격리 필수.
 - **케이스** (spec §5.3):
   - [ ] Flow 정상 완료 → finished Span **1개**, status OK
   - [ ] emit 3회 `.toList()` → finished Span **1개** (아이템별 아님)
@@ -219,6 +269,7 @@
   - [ ] `flowOn(Dispatchers.IO)` 결합 → Span 정상 전파, finished Span 1개
   - [ ] `tracedCollect` action 안에서 `Span.current()` == traced Span 검증
   - [ ] **negative**: `Authorization: Bearer xxx` 가 Span attribute 에 없음 검증 (민감 attribute 가이드 강제)
+  - [ ] **negative**: 빈 문자열 `spanName` → `IllegalArgumentException` 발생 검증 (`requireNotBlank`)
 - **runTest 사용 시 주의**:
   - `runTest(timeout = 30.seconds)` — coroutines-test 패턴
   - `@BeforeEach`/`@AfterEach` 도 `runTest { ... }` 로 감싸기
@@ -253,6 +304,24 @@
 - **DoD**:
   - [ ] 전수 통과 (passing count 기록)
   - [ ] `./gradlew :bluetape4k-opentelemetry:detekt` 통과
+
+---
+
+### Task 9.5 — bluetape4k-patterns 체크리스트 검증
+
+- **complexity**: low
+- **목표**: 코드 완성 후 bluetape4k 공통 패턴 준수 여부를 체계적으로 점검한다.
+- **수행 내용**:
+  - [ ] **KLogging**: 신규 파일에 `companion object : KLogging()` 포함 여부 (또는 top-level 파일이면 파일 레벨 logger 사용)
+  - [ ] **requireNotBlank**: 모든 `spanName` 파라미터 진입부 검사 적용 확인
+  - [ ] **Kluent matchers**: 테스트에서 `(x == y).shouldBeTrue()` 패턴 0건 확인 — `shouldBeEqualTo` / `shouldBeGreaterThan` 등 사용
+  - [ ] **불변성**: 신규 data class 없음 (extension function 전용 파일), 확인 후 pass
+  - [ ] **`@Deprecated` 없음**: `ide_diagnostics` 에서 deprecated API 사용 0건
+  - [ ] **import 정리**: `ide_optimize_imports` 실행 후 불필요 import 0건
+  - [ ] **atomicfu scope**: 메서드 로컬에 `kotlinx.atomicfu.atomic()` 사용 없음 (클래스 프로퍼티만 허용)
+  - [ ] **테스트 resources**: `src/test/resources/junit-platform.properties` + `logback-test.xml` 존재 확인 (신규 모듈이 아니므로 기존 파일 재사용)
+- **DoD**:
+  - [ ] 위 체크리스트 항목 전수 통과 기록
 
 ---
 
@@ -354,10 +423,12 @@
 
 ```
 1 (정찰)
+ → 1.5 (recordFailure 보안 수정 — SpanSupport.kt 변경 + 회귀 테스트)
  → 2, 3, 4 (병렬 가능 — 서로 다른 파일, 다른 함수)
  → 5 (WebFlux helper, 빌드 의존성 변경 필요)
  → 6, 7, 8 (테스트, 병렬 가능)
  → 9 (회귀 테스트)
+ → 9.5 (bluetape4k-patterns 체크리스트 검증)
  → 10 (KDoc 보강 — 1~5 산출물 대상)
  → 11 (README) → 12 (CLAUDE.md 검토) → 13 (wiki-update)
  → 14 (commit + code review + PR)

--- a/docs/superpowers/specs/2026-04-28-opentelemetry-coroutines-design.md
+++ b/docs/superpowers/specs/2026-04-28-opentelemetry-coroutines-design.md
@@ -1,0 +1,355 @@
+# OpenTelemetry Coroutines 통합 강화 — Design Spec
+
+- **Issue**: #150
+- **Branch**: `feat/opentelemetry-coroutines`
+- **Worktree**: `.worktrees/feat/opentelemetry-coroutines`
+- **Module**: `infra/opentelemetry` (`bluetape4k-opentelemetry`)
+- **작성일**: 2026-04-28
+- **작성자**: Claude (Opus 4.7)
+
+---
+
+## 배경 / 목적
+
+`infra/opentelemetry` 모듈은 현재 OpenTelemetry SDK 위에 다음과 같은 Kotlin/Coroutines 친화 API를 이미 제공한다.
+
+- `Span`/`SpanBuilder`에 대한 suspend 빌더(`useSuspending`, `useSpanSuspending`)
+- `withSpanContext` / `withOtelContext` — 코루틴 컨텍스트 안에서 OpenTelemetry `Context`를 안전하게 전파
+- `CompletableResultCode.await()` — Provider flush/shutdown을 코루틴에서 대기
+
+그러나 다음의 사용 시나리오에서 보일러플레이트 또는 부재한 API가 발견되었다.
+
+1. **`Tracer`에서 직접 시작하는 한 번 쓰는 Span 패턴이 길다.**
+   - 사용자는 `tracer.spanBuilder(name).useSpanSuspending { ... }` 또는 `tracer.spanBuilder(name).startSpan().useSuspending { ... }` 처럼 두 단계 호출을 반복적으로 작성해야 한다.
+   - `Tracer.withSpan { ... }` 한 줄 DSL이 있으면 가독성이 크게 개선된다.
+2. **Kotlin `Flow`를 Span으로 감싸는 표준 방법이 없다.**
+   - 현재는 사용자가 `flow { ... }.onStart { span = tracer... }.onCompletion { span?.end() }` 형태를 직접 작성해야 한다.
+   - `CancellationException`을 ERROR 상태로 잘못 기록하는 사례가 빈번하므로 표준 도우미가 필요하다.
+3. **Spring WebFlux 통합이 verbose 하다.**
+   - 공식 instrumentation `SpringWebfluxServerTelemetry.create(otel).createWebFilterAndRegisterReactorHook()` 호출이 길고, Spring `WebFilter` 빈으로 노출하는 표준 helper가 없다.
+
+본 spec 은 위 GAP을 해결하는 **추가 API**를 정의한다. 기존 API의 시그니처/동작은 변경하지 않는다(하위 호환 유지).
+
+### 비목표 (Non-goals)
+
+- OpenTelemetry Java agent 자동 instrumentation 대체.
+- Reactor `Mono`/`Flux` 전반에 대한 커스텀 instrumentation (공식 reactor instrumentation에 위임).
+- Logging bridge / Metrics 신규 API (별도 이슈).
+
+---
+
+## 현존 API 정리
+
+| API | 위치 | 역할 |
+|---|---|---|
+| `Span.useSuspending(waitTimeout, coroutineContext, block)` | `SpanCoroutineSupport.kt` | 이미 시작된 Span을 suspend 블록 안에서 활성화 + end 보장 |
+| `SpanBuilder.useSpanSuspending(coroutineContext, block)` (오버로드 다수) | `SpanCoroutineSupport.kt` | SpanBuilder에서 시작 → suspend 블록 → end 까지 한 번에 |
+| `withSpanContext(span, coroutineContext, block)` | `SpanCoroutineSupport.kt` | suspend 블록 내부에서 Span을 current 로 전파 (코어) |
+| `withOtelContext(coroutineContext, otelContext, block)` | `OpenTelemetryCoroutineSupport.kt` | 임의의 OpenTelemetry `Context`를 코루틴에서 활성화 |
+| `Context.withOtelContext(block)` | `OpenTelemetryCoroutineSupport.kt` | 위의 receiver 변형 |
+| `CompletableResultCode.await()` | `OpenTelemetryCoroutineSupport.kt` | flush/shutdown 결과 await |
+| `Tracer.withSpan(spanName, ...) { span -> ... }` | `SpanSupport.kt` (blocking) | 동기 스코프용 한 줄 DSL — **존재 여부 확인 필요** |
+
+> 본 작업 직전 일부 API는 이미 존재할 수 있다. 구현 단계 첫 step 에서 `SpanSupport.kt` / `SpanCoroutineSupport.kt` 의 실제 시그니처를 확인하고 중복 시 spec 을 미세 조정한다.
+
+내부적으로 `withSpanContext` 가 모든 Span 전파의 구심점이며, `opentelemetry-extension-kotlin` 의 `Context.asContextElement()` 가 `ThreadContextElement` 로 동작하여 `Dispatchers.IO` 등 디스패처 전환에도 Span 이 보존된다.
+
+---
+
+## 추가 API 범위
+
+### 1. `Tracer.withSpan` DSL
+
+#### 1.1 suspend 변형 — `SpanCoroutineSupport.kt`
+
+```kotlin
+/**
+ * [Tracer] 로부터 [spanName] Span 을 시작하고, suspend [block] 의 라이프사이클과 동기화한다.
+ *
+ * - block 정상 완료: Span 상태 OK 후 end()
+ * - block 일반 예외: Span.recordException + setStatus(ERROR) 후 end() — 예외는 재던짐
+ * - block CancellationException: Span 상태 변경 없이 end() 후 예외 재던짐 (구조적 동시성 존중)
+ *
+ * @param spanName Span 이름
+ * @param coroutineContext block 실행 컨텍스트 (기본: 호출자 컨텍스트 유지)
+ * @param configure SpanBuilder 추가 설정 DSL (attribute, kind, parent, links 등)
+ * @param block Span 객체를 인자로 받는 suspend 람다
+ */
+public suspend fun <T> Tracer.withSpan(
+    spanName: String,
+    coroutineContext: CoroutineContext = EmptyCoroutineContext,
+    configure: SpanBuilder.() -> Unit = {},
+    block: suspend (Span) -> T,
+): T
+```
+
+구현 노트:
+- 내부적으로 `spanBuilder(spanName).apply(configure).useSpanSuspending(coroutineContext, block)` 으로 위임.
+- `useSpanSuspending` 의 기존 예외 처리 규약을 그대로 따른다(이미 CancellationException 안전).
+- `coroutineContext` 가 `EmptyCoroutineContext` 인 경우 `withSpanContext` 만 적용하여 dispatcher 전환을 피한다.
+
+#### 1.2 blocking 변형 — `SpanSupport.kt`
+
+```kotlin
+/**
+ * [Tracer] 로부터 [spanName] Span 을 시작하고, 동기 [block] 의 라이프사이클과 동기화한다.
+ *
+ * suspend 가 아닌 일반 코드용. 내부적으로 makeCurrent() 스코프를 사용한다.
+ */
+public inline fun <T> Tracer.withSpan(
+    spanName: String,
+    configure: SpanBuilder.() -> Unit = {},
+    block: (Span) -> T,
+): T
+```
+
+구현 노트:
+- `spanBuilder(spanName).apply(configure).startSpan()` 후 `span.makeCurrent().use { block(span) }`.
+- 예외 발생 시 `span.recordException(t)` + `span.setStatus(StatusCode.ERROR, t.message ?: "")` 후 재던짐.
+- 정상 완료 시 `span.setStatus(StatusCode.OK)` 후 `span.end()`.
+- `inline` 적용으로 람다 호출 비용 제거.
+
+### 2. `Flow<T>.traced` 확장 — `FlowSpanSupport.kt` (신규 파일)
+
+```kotlin
+/**
+ * 업스트림 [Flow] 전체 수명을 [spanName] Span 으로 감싼 새 Flow 를 반환한다.
+ *
+ * - 첫 collect 시작 시 Span 시작
+ * - Flow 정상 완료 시 OK, end()
+ * - Flow 일반 예외 시 ERROR + recordException, end(), 예외 그대로 propagate
+ * - downstream cancellation (CancellationException) 시 상태 변경 없이 end()
+ *
+ * 주의: 이 helper 는 Span 을 "Flow 전체"에 대해 1개 만든다. 각 emit 별 Span 이 필요하면
+ * downstream 에서 `tracer.withSpan` 을 직접 사용해야 한다.
+ */
+public fun <T> Flow<T>.traced(
+    tracer: Tracer,
+    spanName: String,
+    configure: SpanBuilder.() -> Unit = {},
+): Flow<T>
+
+/**
+ * [Flow] 를 collect 하면서 그 전체 수명을 [spanName] Span 으로 감싼다.
+ *
+ * `traced(...).collect(action)` 의 편의 버전. Span 의 makeCurrent 컨텍스트는
+ * `action` 람다에까지 전파된다.
+ */
+public suspend fun <T> Flow<T>.tracedCollect(
+    tracer: Tracer,
+    spanName: String,
+    configure: SpanBuilder.() -> Unit = {},
+    action: suspend (T) -> Unit,
+)
+```
+
+#### 구현 스케치
+
+```kotlin
+public fun <T> Flow<T>.traced(
+    tracer: Tracer,
+    spanName: String,
+    configure: SpanBuilder.() -> Unit = {},
+): Flow<T> = flow {
+    val span = tracer.spanBuilder(spanName).apply(configure).startSpan()
+    var failure: Throwable? = null
+    try {
+        withSpanContext(span) {
+            this@traced.collect { value -> emit(value) }
+        }
+        span.setStatus(StatusCode.OK)
+    } catch (ce: CancellationException) {
+        // 정상 cancellation: Span ERROR 처리하지 않음
+        throw ce
+    } catch (t: Throwable) {
+        failure = t
+        span.recordException(t)
+        span.setStatus(StatusCode.ERROR, t.message ?: t.javaClass.simpleName)
+        throw t
+    } finally {
+        span.end()
+    }
+}
+```
+
+> 위 스케치는 `flow { ... }` 빌더가 emit 시 동일한 코루틴 컨텍스트에서 동작함을 가정한다. `withSpanContext` 가 `ThreadContextElement` 로 동작하므로 dispatcher 전환에도 Span 이 보존된다. 실제 구현 시 `flowOn` 과의 상호작용을 테스트로 검증한다.
+
+`tracedCollect` 는 단순히 `traced(tracer, spanName, configure).collect(action)` 으로 위임한다.
+
+### 3. WebFlux 편의 helper — `WebfluxTracingSupport.kt` (Optional, LOW)
+
+OpenTelemetry 공식 `opentelemetry-spring-webflux-5.3` instrumentation 의 진입점을 한 줄로 노출.
+
+```kotlin
+/**
+ * [SpringWebfluxServerTelemetry] 인스턴스를 생성한다.
+ * 일반적으로 한 번만 호출하여 Bean 으로 등록한다.
+ */
+public fun OpenTelemetry.webfluxServerTelemetry(): SpringWebfluxServerTelemetry =
+    SpringWebfluxServerTelemetry.create(this)
+
+/**
+ * Spring WebFlux 서버용 추적 [WebFilter] 를 생성하고 Reactor hook 을 등록한다.
+ * 반환된 [WebFilter] 를 `@Bean` 으로 노출하면 자동 추적이 활성화된다.
+ */
+public fun OpenTelemetry.createTracingWebFilter(): WebFilter =
+    webfluxServerTelemetry().createWebFilterAndRegisterReactorHook()
+```
+
+조건:
+- `spring-webflux` 가 classpath 에 없으면 import 가 깨지므로, `spring-webflux` 의존성을 `compileOnly` 로 추가한다(현재는 `testRuntimeOnly` 일 가능성 있음 → 확인 필요).
+- 클래스 파일이 누락되어도 모듈의 다른 기능을 깨지 않도록, 별도 `webflux/` 패키지로 격리한다.
+- `opentelemetry-spring-webflux-5.3` 의존성도 `compileOnly` 로 추가.
+
+복잡도가 추가 의존성 정렬을 요구하면 본 helper 는 follow-up 이슈로 미룬다.
+
+---
+
+## 제외 항목 및 이유
+
+| 후보 API | 제외 이유 |
+|---|---|
+| 자체 `TracingWebFilter` 구현 | `SpringWebfluxServerTelemetry.createWebFilterAndRegisterReactorHook()` 가 Reactor hook 등록까지 공식 지원. 재구현 시 유지보수 부담 + 비표준화 위험. |
+| 자체 `SpanContextElement: ThreadContextElement` | `opentelemetry-extension-kotlin` 의 `Context.asContextElement()` 가 동일 역할을 표준으로 제공. 중복 구현 비추천. |
+| 자체 `OpenTelemetryCoroutineContextRestorer` | 위 extension 모듈이 이미 `ThreadContextElement.updateThreadContext` / `restoreThreadContext` 로 처리. |
+| `Mono<T>.traced(...)` / `Flux<T>.traced(...)` 확장 | Reactor 는 공식 `opentelemetry-reactor` instrumentation 영역. WebFlux helper 만으로 충분. |
+| Span 자동 attribute (HTTP method 등) 헬퍼 | 도메인별 instrumentation 의 책임. 이 모듈은 코루틴-Span 결합에 집중. |
+
+---
+
+## 기술 스택
+
+- **언어/런타임**: Kotlin 2.3, JVM 21
+- **OpenTelemetry**: `opentelemetry-api`, `opentelemetry-sdk`, `opentelemetry-extension-kotlin` (기존 의존성 그대로)
+- **Coroutines**: `kotlinx-coroutines-core` (Flow API 포함)
+- **테스트**:
+  - `opentelemetry-sdk-testing` (`InMemorySpanExporter`)
+  - JUnit 5 + MockK + Kluent
+  - `kotlinx-coroutines-test` (`runTest`, `TestDispatcher`)
+- **WebFlux helper (선택)**:
+  - `spring-webflux` — `compileOnly` 승격 검토
+  - `opentelemetry-spring-webflux-5.3` — `compileOnly`
+- **빌드 설정**: detekt, IntelliJ formatter, .editorconfig (no ktlint)
+
+### 모듈 의존성 변경
+
+```kotlin
+// infra/opentelemetry/build.gradle.kts
+dependencies {
+    api(Libs.opentelemetry_api)
+    api(Libs.opentelemetry_sdk)
+    api(Libs.opentelemetry_extension_kotlin)
+    api(Libs.kotlinx_coroutines_core)
+
+    // 신규 (선택): WebFlux helper 활성화 시
+    compileOnly(Libs.spring_webflux)
+    compileOnly(Libs.opentelemetry_spring_webflux)
+
+    testImplementation(Libs.opentelemetry_sdk_testing)
+    testImplementation(Libs.kotlinx_coroutines_test)
+    testImplementation(Libs.spring_webflux) // helper 테스트용
+}
+```
+
+---
+
+## 테스트 전략
+
+테스트는 `InMemorySpanExporter` 를 SDK 에 등록한 뒤 finish 된 Span 을 검증한다. 공통 fixture 는 기존 모듈의 패턴을 재사용한다.
+
+### 5.1 `Tracer.withSpan` (suspend)
+
+| Case | 검증 |
+|---|---|
+| 정상 완료 | Span name 일치, status OK, parent context 가 외부 current 와 동일 |
+| Dispatcher 경계 (`withContext(Dispatchers.IO)`) 내부에서 호출 | Span 이 IO 디스패처에서도 current 로 유지, finished span 1개 |
+| 중첩 호출 | child Span 이 부모 trace id 공유, parent span id 일치 |
+| 예외 발생 | status ERROR, recordException 호출(이벤트로 기록), 예외 재던짐 |
+| `CancellationException` | Span status UNSET 유지, end() 호출, 예외 재던짐 |
+| `configure` 람다로 attribute 추가 | 종료된 Span 의 attribute 검증 |
+
+### 5.2 `Tracer.withSpan` (blocking)
+
+| Case | 검증 |
+|---|---|
+| 정상 완료 | Span OK, end() 호출 |
+| 예외 발생 | Span ERROR, recordException, end() 후 재던짐 |
+| 동일 스레드 nested 호출 | parent-child 관계 검증 |
+
+### 5.3 `Flow<T>.traced`
+
+| Case | 검증 |
+|---|---|
+| Flow 정상 완료 | 1개의 finished Span, status OK |
+| `.toList()` 로 collect — emit 3회 | finished Span 1개 (Flow 단위) |
+| Upstream 예외 | Span ERROR + recordException, downstream 으로 예외 재던짐 |
+| Downstream `take(2)` (정상 종료) | Span OK, end() 호출 |
+| Downstream cancellation (`scope.cancel()`) | Span status UNSET, end() 호출, ERROR 안 기록 |
+| `flowOn(Dispatchers.IO)` 와 결합 | Span 정상 전파 + 1개 finished |
+| `tracedCollect` | 위와 동일 + `action` 안에서 current Span 이 일치 |
+
+### 5.4 WebFlux helper (선택)
+
+| Case | 검증 |
+|---|---|
+| `OpenTelemetry.createTracingWebFilter()` 호출 시 NPE/ClassNotFound 없음 | Spring + OpenTelemetry-WebFlux 의존성 정상 노출 |
+| WebFlux mock 핸들러를 통한 단순 GET | 서버 Span 이 InMemoryExporter 에 1개 기록 |
+
+> WebFlux helper 가 LOW priority 이므로, 의존성 도입 비용이 크면 단위 테스트만(인스턴스 생성/null 아님 검증) 유지한다.
+
+### 5.5 회귀 (Regression)
+
+- 기존 `useSuspending`, `useSpanSuspending`, `withSpanContext`, `withOtelContext`, `CompletableResultCode.await()` 테스트가 그대로 통과해야 한다.
+- 변경된 시그니처 없음을 보장한다(API 추가만 수행).
+
+---
+
+## DoD (Definition of Done)
+
+1. **구현 완료**
+   - [ ] `Tracer.withSpan(suspend)` — `SpanCoroutineSupport.kt`
+   - [ ] `Tracer.withSpan(blocking)` — `SpanSupport.kt`
+   - [ ] `Flow<T>.traced` / `Flow<T>.tracedCollect` — `FlowSpanSupport.kt`
+   - [ ] (선택) `OpenTelemetry.webfluxServerTelemetry()` / `createTracingWebFilter()` — `WebfluxTracingSupport.kt`
+2. **테스트**
+   - [ ] §5.1 / §5.2 / §5.3 케이스 100% 커버
+   - [ ] (선택) §5.4 WebFlux helper 검증
+   - [ ] §5.5 기존 테스트 회귀 zero
+   - [ ] 모듈 단위 `./gradlew :bluetape4k-opentelemetry:test` 전수 통과 (passing count + duration 기록)
+3. **문서**
+   - [ ] 모든 신규 public API 에 Korean KDoc + 예제 포함
+   - [ ] `infra/opentelemetry/README.md` (영문) + `README.ko.md` 동시 업데이트 — Architecture / Features / Examples 섹션
+   - [ ] 필요 시 모듈 README 의 Mermaid 다이어그램에 Flow 추적/Tracer DSL 흐름 반영
+4. **품질 게이트**
+   - [ ] `./gradlew :bluetape4k-opentelemetry:detekt` 통과
+   - [ ] IntelliJ 포맷터 + `.editorconfig` 적용 (no ktlint)
+   - [ ] `ide_diagnostics` / `lsp_diagnostics` import 에러 0
+   - [ ] `code-reviewer` 에이전트 리뷰 후 HIGH/CRITICAL 이슈 해소
+5. **호환성**
+   - [ ] 기존 API 시그니처 변경 없음 (binary + source compatible)
+   - [ ] 의존성 추가는 `compileOnly` (transitive 영향 0)
+6. **운영**
+   - [ ] worktree 안에서 작업 + commit (`feat: opentelemetry coroutines DSL 강화`)
+   - [ ] PR 본문에 테스트 결과 / 수정 근거 / 검증 명령 명시
+   - [ ] PR 생성 후 `oh-my-claudecode:code-reviewer` 결과 첨부
+
+---
+
+## 작업 순서 (참고용 outline)
+
+1. 현행 `SpanSupport.kt` / `SpanCoroutineSupport.kt` 시그니처 정확 확인 → 중복/충돌 조정
+2. `Tracer.withSpan(suspend)` 구현 + 테스트
+3. `Tracer.withSpan(blocking)` 구현 + 테스트
+4. `FlowSpanSupport.kt` 신규 + 테스트
+5. (선택) WebFlux helper + 의존성 승격
+6. README 양언어 + KDoc
+7. detekt / 테스트 / code review
+8. PR 생성
+
+---
+
+## 참고 자료
+
+- [OpenTelemetry Java — `opentelemetry-extension-kotlin`](https://github.com/open-telemetry/opentelemetry-java/tree/main/extensions/kotlin)
+- [`SpringWebfluxServerTelemetry`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/spring/spring-webflux/spring-webflux-5.3/library)
+- 기존 모듈 코드: `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/`

--- a/docs/superpowers/specs/2026-04-28-opentelemetry-coroutines-design.md
+++ b/docs/superpowers/specs/2026-04-28-opentelemetry-coroutines-design.md
@@ -66,19 +66,42 @@
 /**
  * [Tracer] 로부터 [spanName] Span 을 시작하고, suspend [block] 의 라이프사이클과 동기화한다.
  *
- * - block 정상 완료: Span 상태 OK 후 end()
- * - block 일반 예외: Span.recordException + setStatus(ERROR) 후 end() — 예외는 재던짐
- * - block CancellationException: Span 상태 변경 없이 end() 후 예외 재던짐 (구조적 동시성 존중)
+ * ## 동작 계약
+ * - block 정상 완료: Span setStatus(OK) + end()
+ * - block 일반 예외: recordException + setStatus(ERROR) + end() → 예외 재던짐
+ * - block CancellationException: **Span 상태 UNSET 유지** + end() → 예외 재던짐 (구조적 동시성 존중)
+ *   ⚠️ 계약: CancellationException 은 반드시 일반 Throwable 보다 먼저 catch 해야 한다.
+ *   이 순서를 바꾸면 Cancellation 이 ERROR 로 잘못 기록된다.
+ *
+ * ## 파라미터 순서 (H2 반영)
+ * `configure` 가 `coroutineContext` 앞에 위치한다.
+ * `coroutineContext` 를 바꾸지 않는 일반 호출에서 `configure` 를 trailing lambda 로 자연스럽게 사용.
+ *
+ * ## 보안 경고
+ * ⚠️ `configure` 람다에서 PII, 인증 토큰, 비밀번호, Authorization 헤더 등 민감 정보를
+ * attribute 로 추가하지 마십시오. Span attribute 는 OTLP exporter 를 통해 외부 trace
+ * backend 로 전송되며 회수 불가합니다.
+ *
+ * ⚠️ `configure` 람다 안에서 `.startSpan()` 또는 `.build()` 를 직접 호출하지 마십시오.
+ * Span 시작은 `withSpan` 이 처리합니다. 직접 호출 시 이중 Span 이 생성됩니다.
+ *
+ * ⚠️ `configure` 는 blocking 컨텍스트에서 동기적으로 실행됩니다.
+ * 람다 안에서 `async`, `launch` 등 비동기 연산을 수행하지 마십시오.
+ *
+ * ⚠️ 이 함수는 suspend 전용입니다. 코루틴 외부 (일반 blocking 코드) 에서는
+ * blocking 변형 `Tracer.withSpan(spanName, configure, block)` 을 사용하십시오.
+ * blocking 환경에서 이 suspend 버전을 호출하면 ThreadLocal 기반 OTel Context 가
+ * Dispatcher 전환 시 유실될 수 있습니다.
  *
  * @param spanName Span 이름
- * @param coroutineContext block 실행 컨텍스트 (기본: 호출자 컨텍스트 유지)
- * @param configure SpanBuilder 추가 설정 DSL (attribute, kind, parent, links 등)
+ * @param configure SpanBuilder 추가 설정 DSL (attribute, kind, parent, links 등). non-throwing 이어야 함
+ * @param coroutineContext block 실행 추가 컨텍스트 (기본: 호출자 컨텍스트 유지)
  * @param block Span 객체를 인자로 받는 suspend 람다
  */
 public suspend fun <T> Tracer.withSpan(
     spanName: String,
-    coroutineContext: CoroutineContext = EmptyCoroutineContext,
     configure: SpanBuilder.() -> Unit = {},
+    coroutineContext: CoroutineContext = EmptyCoroutineContext,
     block: suspend (Span) -> T,
 ): T
 ```
@@ -86,7 +109,7 @@ public suspend fun <T> Tracer.withSpan(
 구현 노트:
 - 내부적으로 `spanBuilder(spanName).apply(configure).useSpanSuspending(coroutineContext, block)` 으로 위임.
 - `useSpanSuspending` 의 기존 예외 처리 규약을 그대로 따른다(이미 CancellationException 안전).
-- `coroutineContext` 가 `EmptyCoroutineContext` 인 경우 `withSpanContext` 만 적용하여 dispatcher 전환을 피한다.
+- `EmptyCoroutineContext` 인 경우에도 `withContext` 는 호출되나 dispatcher 는 호출자 그대로 유지된다(`getOrCurrent()` 동작).
 
 #### 1.2 blocking 변형 — `SpanSupport.kt`
 
@@ -94,7 +117,22 @@ public suspend fun <T> Tracer.withSpan(
 /**
  * [Tracer] 로부터 [spanName] Span 을 시작하고, 동기 [block] 의 라이프사이클과 동기화한다.
  *
- * suspend 가 아닌 일반 코드용. 내부적으로 makeCurrent() 스코프를 사용한다.
+ * ## 동작 계약
+ * - block 정상 완료: setStatus(OK) + end()
+ * - block 예외: recordException + setStatus(ERROR, message) + end() → 예외 재던짐
+ *
+ * ## 보안 경고
+ * ⚠️ `configure` 람다에서 PII, 인증 토큰 등 민감 정보를 attribute 로 추가하지 마십시오.
+ * ⚠️ `configure` 안에서 `.startSpan()` 을 직접 호출하지 마십시오 (이중 Span 생성).
+ *
+ * ## 코루틴 사용 주의
+ * ⚠️ 이 함수는 `makeCurrent()` (ThreadLocal 기반) 를 사용합니다.
+ * `Dispatchers.IO` 등으로 스레드가 전환되는 코루틴 컨텍스트에서 호출하면 OTel Context 가
+ * 유실됩니다. suspend 코드에서는 반드시 suspend 변형을 사용하십시오.
+ *
+ * @param spanName Span 이름
+ * @param configure SpanBuilder 추가 설정 DSL. non-throwing 이어야 함
+ * @param block Span 객체를 인자로 받는 람다
  */
 public inline fun <T> Tracer.withSpan(
     spanName: String,
@@ -104,24 +142,47 @@ public inline fun <T> Tracer.withSpan(
 ```
 
 구현 노트:
-- `spanBuilder(spanName).apply(configure).startSpan()` 후 `span.makeCurrent().use { block(span) }`.
-- 예외 발생 시 `span.recordException(t)` + `span.setStatus(StatusCode.ERROR, t.message ?: "")` 후 재던짐.
+- `spanBuilder(spanName).apply(configure).startSpan()` 후 `span.makeCurrent().use { ... }` 패턴.
+- 예외 발생 시 `span.recordException(t)` + `span.setStatus(StatusCode.ERROR, t.message ?: "unspecified error")` 후 재던짐.
+  - fallback 을 `t.javaClass.simpleName` 이 아닌 `"unspecified error"` 로 한다 — 내부 클래스명 외부 노출 방지(H2, M5).
 - 정상 완료 시 `span.setStatus(StatusCode.OK)` 후 `span.end()`.
 - `inline` 적용으로 람다 호출 비용 제거.
 
 ### 2. `Flow<T>.traced` 확장 — `FlowSpanSupport.kt` (신규 파일)
 
+#### 설계 원칙 (H1 + H2 반영)
+
+- **1 collect = 1 Span**: `traced()` 는 한 번의 collect 전체를 단일 Span 으로 감싼다.
+  각 emit 별 Span 이 필요하면 `onEach { tracer.withSpan(...) { ... } }` 를 사용한다.
+- **`channelFlow` 사용 필수**: `flow {}` 빌더 안에서 `withContext` 후 `emit()` 하면
+  Flow 불변식 위반(`IllegalStateException`) 이 발생한다. `channelFlow {}` 는 cross-context `send()` 를 허용한다.
+- **`withSpanContext` 직접 사용 금지**: `withSpanContext` 는 내부 `finally` 에서 이미 `endSafely()` 를 호출한다.
+  `Flow.traced` 에서 재사용하면 `span.end()` 이중 호출 + 이미 종료된 Span 에 `setStatus()` 호출이 발생한다.
+  따라서 OTel Context 전파는 `Context.current().with(span).asContextElement()` 만 직접 사용한다.
+
 ```kotlin
 /**
- * 업스트림 [Flow] 전체 수명을 [spanName] Span 으로 감싼 새 Flow 를 반환한다.
+ * 업스트림 [Flow] 전체 수명을 단일 [spanName] Span 으로 감싼 새 Flow 를 반환한다.
  *
- * - 첫 collect 시작 시 Span 시작
- * - Flow 정상 완료 시 OK, end()
- * - Flow 일반 예외 시 ERROR + recordException, end(), 예외 그대로 propagate
- * - downstream cancellation (CancellationException) 시 상태 변경 없이 end()
+ * ## 동작 계약
+ * - collect 시작 시 Span 시작
+ * - Flow 정상 완료 시 setStatus(OK) + end()
+ * - Flow 일반 예외 시 recordException + setStatus(ERROR) + end() → 예외 그대로 propagate
+ * - CancellationException(downstream cancel) 시 **Span 상태 UNSET 유지** + end()
+ *   ⚠️ 계약: CancellationException 은 반드시 일반 Throwable 보다 먼저 catch 해야 한다.
  *
- * 주의: 이 helper 는 Span 을 "Flow 전체"에 대해 1개 만든다. 각 emit 별 Span 이 필요하면
- * downstream 에서 `tracer.withSpan` 을 직접 사용해야 한다.
+ * ## 설계 의도
+ * - 이 함수는 **1 collect = 1 Span** 이다. 아이템별 Span 이 필요하면 `onEach` 를 사용하라.
+ * - 반환된 Flow 를 여러 번 collect 하면 각 collect 마다 별도 Span 이 생성된다 (cold Flow 자연 동작).
+ *
+ * ## 보안 경고
+ * ⚠️ `configure` 람다에서 PII, 인증 토큰, 비밀번호 등 민감 정보를 attribute 로 추가하지 마십시오.
+ * ⚠️ `configure` 안에서 `.startSpan()` 을 직접 호출하지 마십시오 (이중 Span 생성).
+ * ⚠️ `configure` 는 non-throwing blocking 람다여야 합니다.
+ *
+ * @param tracer Span 을 생성할 [Tracer]
+ * @param spanName Span 이름
+ * @param configure SpanBuilder 추가 설정 DSL
  */
 public fun <T> Flow<T>.traced(
     tracer: Tracer,
@@ -130,10 +191,18 @@ public fun <T> Flow<T>.traced(
 ): Flow<T>
 
 /**
- * [Flow] 를 collect 하면서 그 전체 수명을 [spanName] Span 으로 감싼다.
+ * [Flow] 를 collect 하면서 그 전체 수명을 단일 [spanName] Span 으로 감싼다.
  *
- * `traced(...).collect(action)` 의 편의 버전. Span 의 makeCurrent 컨텍스트는
- * `action` 람다에까지 전파된다.
+ * `traced(tracer, spanName, configure).collect(action)` 의 편의 버전.
+ *
+ * ## traced() vs tracedCollect() 선택 기준
+ * | 상황 | 권장 |
+ * |------|------|
+ * | 다운스트림 연산자(map/filter/take 등)와 결합 | `traced()` |
+ * | 단일 collect + action 안에서 current Span 사용 | `tracedCollect()` |
+ * | 다중 terminal 연산 (collect 두 번) | `traced()` — collect 마다 새 Span |
+ *
+ * ⚠️ `configure` 람다에서 PII, 인증 토큰 등 민감 정보를 attribute 로 추가하지 마십시오.
  */
 public suspend fun <T> Flow<T>.tracedCollect(
     tracer: Tracer,
@@ -143,47 +212,69 @@ public suspend fun <T> Flow<T>.tracedCollect(
 )
 ```
 
-#### 구현 스케치
+#### 구현 스케치 (H1 + H2 반영)
 
 ```kotlin
 public fun <T> Flow<T>.traced(
     tracer: Tracer,
     spanName: String,
     configure: SpanBuilder.() -> Unit = {},
-): Flow<T> = flow {
+): Flow<T> = channelFlow {   // ← flow{} 아님: cross-context emit 허용
     val span = tracer.spanBuilder(spanName).apply(configure).startSpan()
-    var failure: Throwable? = null
+    // withSpanContext 재사용 금지: 내부에서 endSafely() 를 이미 호출하므로
+    // OTel Context 전파만 직접 수행
+    val otelContext = span.storeInContext(Context.current())
     try {
-        withSpanContext(span) {
-            this@traced.collect { value -> emit(value) }
+        withContext(otelContext.asContextElement()) {
+            this@traced.collect { value -> send(value) }   // channelFlow: send() 사용
         }
         span.setStatus(StatusCode.OK)
     } catch (ce: CancellationException) {
-        // 정상 cancellation: Span ERROR 처리하지 않음
+        // ⚠️ 계약: 반드시 Throwable 보다 먼저 — UNSET 유지, 구조적 동시성 보존
         throw ce
     } catch (t: Throwable) {
-        failure = t
         span.recordException(t)
-        span.setStatus(StatusCode.ERROR, t.message ?: t.javaClass.simpleName)
+        span.setStatus(StatusCode.ERROR, t.message ?: "unspecified error")
         throw t
     } finally {
-        span.end()
+        span.end()   // 모든 경로(정상/예외/cancel)에서 exactly-once
     }
 }
+
+// tracedCollect 는 traced() 에 위임
+public suspend fun <T> Flow<T>.tracedCollect(
+    tracer: Tracer,
+    spanName: String,
+    configure: SpanBuilder.() -> Unit = {},
+    action: suspend (T) -> Unit,
+): Unit = traced(tracer, spanName, configure).collect(action)
 ```
 
-> 위 스케치는 `flow { ... }` 빌더가 emit 시 동일한 코루틴 컨텍스트에서 동작함을 가정한다. `withSpanContext` 가 `ThreadContextElement` 로 동작하므로 dispatcher 전환에도 Span 이 보존된다. 실제 구현 시 `flowOn` 과의 상호작용을 테스트로 검증한다.
+### 3. WebFlux 편의 helper — `WebfluxTracingSupport.kt` (이번 PR 포함)
 
-`tracedCollect` 는 단순히 `traced(tracer, spanName, configure).collect(action)` 으로 위임한다.
+OpenTelemetry 공식 `opentelemetry-spring-webflux-5.3` instrumentation 의 진입점을 한 줄로 노출한다.
 
-### 3. WebFlux 편의 helper — `WebfluxTracingSupport.kt` (Optional, LOW)
+#### 운영 제약 (H7 반영)
 
-OpenTelemetry 공식 `opentelemetry-spring-webflux-5.3` instrumentation 의 진입점을 한 줄로 노출.
+> ⚠️ `createTracingWebFilter()` 는 내부적으로 Reactor global hook(`Hooks.onEachOperator`) 을 등록한다.
+> - **반드시 Spring ApplicationContext 초기화 시(`@Configuration` `@Bean`) 한 번만 호출**해야 한다.
+> - 앱 시작 후 lazy 로 호출하면 이미 생성된 Reactor pipeline 에는 hook 이 적용되지 않아 silent failure 가 발생한다.
+> - 테스트에서 ApplicationContext 를 재생성하면 hook 이 중복 등록될 수 있다. 테스트 격리 시 `Hooks.resetOnEachOperator(key)` 호출 권장.
+
+#### 보안 경고 (H5 반영)
+
+> ⚠️ 공식 Spring WebFlux instrumentation 은 기본 설정에서 일부 HTTP 헤더를 Span attribute 로 기록할 수 있다.
+> `Authorization`, `Cookie`, `Set-Cookie` 등 민감 헤더가 trace backend 로 유출되지 않도록
+> `OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST` 환경변수로 화이트리스트를 명시적으로 제한해야 한다.
+> 기본값에서 민감 헤더가 캡처되지 않음을 단위 테스트로 검증한다.
 
 ```kotlin
 /**
  * [SpringWebfluxServerTelemetry] 인스턴스를 생성한다.
- * 일반적으로 한 번만 호출하여 Bean 으로 등록한다.
+ * 일반적으로 한 번만 호출하여 Spring `@Bean` 으로 등록한다.
+ *
+ * ⚠️ `createWebFilterAndRegisterReactorHook()` 는 JVM 전역 Reactor hook 을 등록한다.
+ * ApplicationContext 초기화 시점에 한 번만 호출할 것.
  */
 public fun OpenTelemetry.webfluxServerTelemetry(): SpringWebfluxServerTelemetry =
     SpringWebfluxServerTelemetry.create(this)
@@ -191,17 +282,18 @@ public fun OpenTelemetry.webfluxServerTelemetry(): SpringWebfluxServerTelemetry 
 /**
  * Spring WebFlux 서버용 추적 [WebFilter] 를 생성하고 Reactor hook 을 등록한다.
  * 반환된 [WebFilter] 를 `@Bean` 으로 노출하면 자동 추적이 활성화된다.
+ *
+ * ⚠️ 반드시 Spring Bean 생명주기 내에서 1회만 호출할 것.
+ * ⚠️ 기본 설정에서 캡처되는 HTTP 헤더를 확인하고 민감 헤더를 환경변수로 제한할 것.
  */
 public fun OpenTelemetry.createTracingWebFilter(): WebFilter =
     webfluxServerTelemetry().createWebFilterAndRegisterReactorHook()
 ```
 
-조건:
-- `spring-webflux` 가 classpath 에 없으면 import 가 깨지므로, `spring-webflux` 의존성을 `compileOnly` 로 추가한다(현재는 `testRuntimeOnly` 일 가능성 있음 → 확인 필요).
-- 클래스 파일이 누락되어도 모듈의 다른 기능을 깨지 않도록, 별도 `webflux/` 패키지로 격리한다.
-- `opentelemetry-spring-webflux-5.3` 의존성도 `compileOnly` 로 추가.
-
-복잡도가 추가 의존성 정렬을 요구하면 본 helper 는 follow-up 이슈로 미룬다.
+의존성:
+- `spring-webflux` → `compileOnly` 로 추가 (현재 `testRuntimeOnly` → 승격)
+- `opentelemetry-spring-webflux-5.3` → `compileOnly` 추가
+- `webflux/` 패키지로 격리하여 classpath 에 없을 때도 다른 기능을 깨지 않도록 한다.
 
 ---
 
@@ -263,39 +355,40 @@ dependencies {
 |---|---|
 | 정상 완료 | Span name 일치, status OK, parent context 가 외부 current 와 동일 |
 | Dispatcher 경계 (`withContext(Dispatchers.IO)`) 내부에서 호출 | Span 이 IO 디스패처에서도 current 로 유지, finished span 1개 |
-| 중첩 호출 | child Span 이 부모 trace id 공유, parent span id 일치 |
-| 예외 발생 | status ERROR, recordException 호출(이벤트로 기록), 예외 재던짐 |
+| 중첩 호출 (Dispatchers 경계 포함) | child traceId == parent traceId, child parentSpanId == parent spanId |
+| 예외 발생 | status ERROR, recordException 이벤트 기록, 예외 재던짐 |
 | `CancellationException` | Span status UNSET 유지, end() 호출, 예외 재던짐 |
 | `configure` 람다로 attribute 추가 | 종료된 Span 의 attribute 검증 |
+| `configure` 람다에서 `.startSpan()` 직접 호출 | 테스트에서 이중 Span 생성 확인 → 문서화 (negative test) |
 
 ### 5.2 `Tracer.withSpan` (blocking)
 
 | Case | 검증 |
 |---|---|
 | 정상 완료 | Span OK, end() 호출 |
-| 예외 발생 | Span ERROR, recordException, end() 후 재던짐 |
+| 예외 발생 | Span ERROR, recordException, `message ?: "unspecified error"` 검증, end() 후 재던짐 |
 | 동일 스레드 nested 호출 | parent-child 관계 검증 |
 
 ### 5.3 `Flow<T>.traced`
 
 | Case | 검증 |
 |---|---|
-| Flow 정상 완료 | 1개의 finished Span, status OK |
-| `.toList()` 로 collect — emit 3회 | finished Span 1개 (Flow 단위) |
-| Upstream 예외 | Span ERROR + recordException, downstream 으로 예외 재던짐 |
+| Flow 정상 완료 | finished Span **1개**, status OK |
+| emit 3회 `.toList()` | finished Span **1개** (아이템별 아님) |
+| Upstream 예외 | Span ERROR + recordException, 예외 재던짐 |
 | Downstream `take(2)` (정상 종료) | Span OK, end() 호출 |
-| Downstream cancellation (`scope.cancel()`) | Span status UNSET, end() 호출, ERROR 안 기록 |
-| `flowOn(Dispatchers.IO)` 와 결합 | Span 정상 전파 + 1개 finished |
-| `tracedCollect` | 위와 동일 + `action` 안에서 current Span 이 일치 |
+| Downstream cancellation (`scope.cancel()`) | Span status **UNSET**, end() 호출, ERROR 미기록 |
+| `flowOn(Dispatchers.IO)` 와 결합 | Span 정상 전파, finished Span 1개 |
+| `tracedCollect` — action 안에서 parent Span current 검증 | `Span.current()` == traced Span |
+| 민감 attribute negative test | 예: `Authorization: Bearer xxx` 가 Span attribute 에 없음 검증 |
 
-### 5.4 WebFlux helper (선택)
+### 5.4 WebFlux helper
 
 | Case | 검증 |
 |---|---|
-| `OpenTelemetry.createTracingWebFilter()` 호출 시 NPE/ClassNotFound 없음 | Spring + OpenTelemetry-WebFlux 의존성 정상 노출 |
-| WebFlux mock 핸들러를 통한 단순 GET | 서버 Span 이 InMemoryExporter 에 1개 기록 |
-
-> WebFlux helper 가 LOW priority 이므로, 의존성 도입 비용이 크면 단위 테스트만(인스턴스 생성/null 아님 검증) 유지한다.
+| `OpenTelemetry.createTracingWebFilter()` — NPE/ClassNotFound 없음 | 의존성 정상 노출 |
+| WebFlux mock 핸들러 GET | 서버 Span 1개 기록, HTTP method/path attribute 검증 |
+| `Authorization` 헤더가 Span attribute 에 미포함 | 민감 헤더 필터링 negative test |
 
 ### 5.5 회귀 (Regression)
 
@@ -307,31 +400,35 @@ dependencies {
 ## DoD (Definition of Done)
 
 1. **구현 완료**
-   - [ ] `Tracer.withSpan(suspend)` — `SpanCoroutineSupport.kt`
-   - [ ] `Tracer.withSpan(blocking)` — `SpanSupport.kt`
-   - [ ] `Flow<T>.traced` / `Flow<T>.tracedCollect` — `FlowSpanSupport.kt`
-   - [ ] (선택) `OpenTelemetry.webfluxServerTelemetry()` / `createTracingWebFilter()` — `WebfluxTracingSupport.kt`
+   - [ ] `Tracer.withSpan(spanName, configure, coroutineContext, block)` suspend — `SpanCoroutineSupport.kt`
+   - [ ] `Tracer.withSpan(spanName, configure, block)` blocking — `SpanSupport.kt`
+   - [ ] `Flow<T>.traced` / `Flow<T>.tracedCollect` — `FlowSpanSupport.kt` (`channelFlow` 기반)
+   - [ ] `OpenTelemetry.webfluxServerTelemetry()` / `createTracingWebFilter()` — `webflux/WebfluxTracingSupport.kt`
 2. **테스트**
-   - [ ] §5.1 / §5.2 / §5.3 케이스 100% 커버
-   - [ ] (선택) §5.4 WebFlux helper 검증
+   - [ ] §5.1 케이스 전수 — Dispatcher 경계 + 중첩 Span + negative(configure footgun)
+   - [ ] §5.2 케이스 전수 — `"unspecified error"` fallback 검증 포함
+   - [ ] §5.3 케이스 전수 — **1 collect = 1 Span** + 민감 attribute negative test
+   - [ ] §5.4 WebFlux helper — 민감 헤더 미포함 negative test 포함
    - [ ] §5.5 기존 테스트 회귀 zero
-   - [ ] 모듈 단위 `./gradlew :bluetape4k-opentelemetry:test` 전수 통과 (passing count + duration 기록)
+   - [ ] `./gradlew :bluetape4k-opentelemetry:test` 전수 통과
 3. **문서**
-   - [ ] 모든 신규 public API 에 Korean KDoc + 예제 포함
-   - [ ] `infra/opentelemetry/README.md` (영문) + `README.ko.md` 동시 업데이트 — Architecture / Features / Examples 섹션
-   - [ ] 필요 시 모듈 README 의 Mermaid 다이어그램에 Flow 추적/Tracer DSL 흐름 반영
+   - [ ] 모든 신규 public API 에 Korean KDoc (보안 경고 + CancellationException 계약 + configure footgun 금지 포함)
+   - [ ] `README.md` (영문) + `README.ko.md` — Architecture → UML → Features → Examples 순서
+   - [ ] Mermaid 다이어그램: `withSpan` DSL 흐름 + `Flow.traced` 생명주기
 4. **품질 게이트**
    - [ ] `./gradlew :bluetape4k-opentelemetry:detekt` 통과
    - [ ] IntelliJ 포맷터 + `.editorconfig` 적용 (no ktlint)
-   - [ ] `ide_diagnostics` / `lsp_diagnostics` import 에러 0
+   - [ ] `ide_diagnostics` import 에러 0
    - [ ] `code-reviewer` 에이전트 리뷰 후 HIGH/CRITICAL 이슈 해소
 5. **호환성**
    - [ ] 기존 API 시그니처 변경 없음 (binary + source compatible)
-   - [ ] 의존성 추가는 `compileOnly` (transitive 영향 0)
-6. **운영**
-   - [ ] worktree 안에서 작업 + commit (`feat: opentelemetry coroutines DSL 강화`)
-   - [ ] PR 본문에 테스트 결과 / 수정 근거 / 검증 명령 명시
-   - [ ] PR 생성 후 `oh-my-claudecode:code-reviewer` 결과 첨부
+   - [ ] 신규 의존성은 `compileOnly` (transitive 영향 0)
+6. **운영 / 보안 가이드 (README 포함)**
+   - [ ] OTLP exporter TLS 설정 가이드: 운영 환경에서 `https://` 엔드포인트 및 `OTEL_EXPORTER_OTLP_CERTIFICATE` 검증 권장
+   - [ ] `SdkTracerProvider.shutdown()` timeout 권장값(5~10초) 예제
+   - [ ] WebFlux `createTracingWebFilter()` — 1회 호출 제약 + `Hooks.resetOnEachOperator()` 테스트 격리 가이드
+   - [ ] 민감 HTTP 헤더 캡처 제한: `OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST` 환경변수 예시
+   - [ ] worktree 내 commit + PR 생성 후 `oh-my-claudecode:code-reviewer` 결과 첨부
 
 ---
 

--- a/infra/opentelemetry/README.ko.md
+++ b/infra/opentelemetry/README.ko.md
@@ -8,9 +8,12 @@
 
 - **Kotlin 확장 함수**: OpenTelemetry Java SDK를 코틀린스럽게 사용
 - **Coroutines 지원**: `suspend` 함수와 코루틴 컨텍스트 전파
+- **`Tracer.withSpan()`**: 한 번 호출로 Span을 시작·종료하는 suspend/blocking DSL
+- **Flow 트레이싱**: `Flow.traced()` / `Flow.tracedCollect()` — 1 collect = 1 Span
 - **Span 관리**: 자동 리소스 관리를 위한 `use` 패턴
 - **DSL 제공**: Attributes, TracerProvider, MeterProvider 설정을 위한 DSL
-- **Spring Boot 통합**: Spring Boot Starter 지원
+- **Spring Boot 3 WebFlux 통합**: `createTracingWebFilter()` 헬퍼 (Spring Boot 3 전용 — 아래 참고)
+- **Spring Boot Starter 지원**: 자동 설정 OpenTelemetry SDK
 
 ## 의존성
 
@@ -131,6 +134,81 @@ tracer.spanBuilder("recommended").useSpanSuspending(Dispatchers.IO) { span ->
 }
 ```
 
+### 3-A. Tracer.withSpan() — 단일 호출 DSL
+
+`Tracer.withSpan()`은 블록을 단일 Span으로 감싸 시작·상태 설정·종료를 자동으로 처리합니다.
+suspend/blocking 두 가지 변형을 제공합니다.
+
+```kotlin
+import io.bluetape4k.opentelemetry.trace.withSpan
+import io.bluetape4k.opentelemetry.coroutines.withSpan
+
+// suspend 변형 (코루틴 내부)
+val result: String = tracer.withSpan("my-op") { span ->
+  span.setAttribute(AttributeKey.stringKey("key"), "value")
+  "done"
+}
+
+// 시작 전 attribute 설정
+tracer.withSpan("my-op", configure = {
+  setAttribute(AttributeKey.stringKey("env"), "prod")
+  setSpanKind(SpanKind.SERVER)
+}) { span ->
+  doWork()
+}
+
+// 중첩 호출 → parent-child 트레이스 생성
+tracer.withSpan("parent") {
+  tracer.withSpan("child") { doWork() }
+}
+
+// CancellationException → StatusCode.UNSET (ERROR 미기록)
+// 그 외 Throwable     → StatusCode.ERROR + recordException + 재던짐
+```
+
+**Span 생명주기 계약:**
+- 정상 완료 → `StatusCode.OK`, Span 종료
+- `CancellationException` → `StatusCode.UNSET`, Span 종료, 예외 재던짐
+- 그 외 `Throwable` → `StatusCode.ERROR` + `recordException`, Span 종료, 예외 재던짐
+- 예외 메시지 `null` → `"unspecified error"` (내부 클래스명 절대 노출 안 함)
+
+### 3-B. Flow 트레이싱 — `traced()` / `tracedCollect()`
+
+**1 collect = 1 Span** (emit 횟수와 무관).
+
+```kotlin
+import io.bluetape4k.opentelemetry.coroutines.traced
+import io.bluetape4k.opentelemetry.coroutines.tracedCollect
+
+// traced() — collect 전체를 단일 Span으로 감쌈
+flowOf(1, 2, 3)
+    .traced(tracer, "my-flow") {
+        setAttribute(AttributeKey.stringKey("source"), "db")
+    }
+    .collect { item -> process(item) }
+
+// 다른 연산자와 조합 가능 — Span은 전체 collect 기간 동안 유지
+flowOf(1, 2, 3, 4)
+    .traced(tracer, "take-flow")
+    .take(2)
+    .collect { }
+
+// tracedCollect — action이 Span의 OTel Context 안에서 실행
+// action 내부에서 Span.current()는 tracedCollect가 생성한 Span 반환
+flowOf(42).tracedCollect(tracer, "collect-span") { item ->
+    val span = Span.current()  // tracedCollect가 생성한 동일 Span
+    process(item)
+}
+```
+
+**계약:**
+- 정상 완료 → `StatusCode.OK`
+- `CancellationException` (timeout, `take()`, 취소) → `StatusCode.UNSET`
+- 그 외 예외 → `StatusCode.ERROR` + `recordException`, 예외 재던짐
+- `traced()` vs `tracedCollect()` 선택 기준:
+  - `traced()` — 새 Flow 반환. OTel Context는 **producer** 코루틴에만 활성화
+  - `tracedCollect()` — 터미널 연산자. OTel Context는 **producer + consumer(action)** 코루틴 양쪽에 활성화
+
 ### 4. Attributes 관리
 
 ```kotlin
@@ -247,6 +325,30 @@ val compositeExporter = spanExporterOf(
   OtlpGrpcSpanExporter.builder().build()
 )
 ```
+
+### 9. Spring WebFlux 트레이싱 (Spring Boot 3 전용)
+
+> **Spring Boot 버전 제약:**
+> `createTracingWebFilter()`는 `opentelemetry-spring-webflux-5.3` 아티팩트를 사용하며, Spring WebFlux 5.3 / 6.x (Spring Boot 3) 대상입니다.
+> **Spring Boot 4 (Spring Framework 7.x)는 아직 미지원** — OTel instrumentation BOM에서 대응 아티팩트 출시 후 지원 예정입니다.
+
+```kotlin
+import io.bluetape4k.opentelemetry.webflux.createTracingWebFilter
+import io.bluetape4k.opentelemetry.webflux.webfluxServerTelemetry
+
+// @Bean으로 ApplicationContext당 1회만 호출하세요
+@Configuration
+class TracingConfig(private val openTelemetry: OpenTelemetry) {
+
+    @Bean
+    fun tracingWebFilter(): WebFilter = openTelemetry.createTracingWebFilter()
+}
+```
+
+**운영 주의사항:**
+- `createTracingWebFilter()`는 `ApplicationContext`당 1회만 호출하세요. 내부적으로 Reactor `Hooks.onEachOperator`를 전역 등록합니다. 중복 호출 시 훅이 중첩되어 예측 불가능한 동작이 발생합니다.
+- 테스트에서는 `@AfterAll`에서 `Hooks.resetOnEachOperator()`를 호출하여 훅 누수를 방지하세요.
+- `Authorization` 등 민감 헤더는 기본적으로 캡처되지 않습니다. 특정 헤더를 허용하려면 환경변수 `OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST`를 설정하세요. **PII를 포함하는 헤더는 절대 추가하지 마세요.**
 
 ## 아키텍처 다이어그램
 

--- a/infra/opentelemetry/README.md
+++ b/infra/opentelemetry/README.md
@@ -8,9 +8,12 @@ English | [한국어](./README.ko.md)
 
 - **Kotlin extension functions**: Use the OpenTelemetry Java SDK in a Kotlin-idiomatic way
 - **Coroutines support**: Propagate `suspend` function context and coroutine context
+- **`Tracer.withSpan()`**: Single-call DSL for suspend and blocking span management
+- **Flow tracing**: `Flow.traced()` / `Flow.tracedCollect()` — 1 collect = 1 Span
 - **Span management**: `use` pattern for automatic resource cleanup
 - **DSL support**: DSLs for configuring Attributes, TracerProvider, and MeterProvider
-- **Spring Boot integration**: Spring Boot Starter support
+- **Spring Boot 3 WebFlux integration**: `createTracingWebFilter()` helper (Spring Boot 3 only — see note below)
+- **Spring Boot Starter support**: Auto-configured OpenTelemetry SDK
 
 ## Dependency
 
@@ -132,6 +135,81 @@ tracer.spanBuilder("recommended").useSpanSuspending(Dispatchers.IO) { span ->
 }
 ```
 
+### 3-A. Tracer.withSpan() — Single-Call DSL
+
+`Tracer.withSpan()` wraps a block in a single Span, starts it, sets status, and ends it automatically.
+Both suspend and blocking variants are provided.
+
+```kotlin
+import io.bluetape4k.opentelemetry.trace.withSpan
+import io.bluetape4k.opentelemetry.coroutines.withSpan
+
+// Suspend variant (inside a coroutine)
+val result: String = tracer.withSpan("my-op") { span ->
+  span.setAttribute(AttributeKey.stringKey("key"), "value")
+  "done"
+}
+
+// Configure attributes before starting
+tracer.withSpan("my-op", configure = {
+  setAttribute(AttributeKey.stringKey("env"), "prod")
+  setSpanKind(SpanKind.SERVER)
+}) { span ->
+  doWork()
+}
+
+// Nested calls produce parent-child trace
+tracer.withSpan("parent") {
+  tracer.withSpan("child") { doWork() }
+}
+
+// CancellationException → StatusCode.UNSET (not recorded as ERROR)
+// Other Throwable     → StatusCode.ERROR + recordException + rethrown
+```
+
+**Span lifecycle contracts:**
+- Normal completion → `StatusCode.OK`, span ended
+- `CancellationException` → `StatusCode.UNSET`, span ended, exception rethrown
+- Any other `Throwable` → `StatusCode.ERROR` + `recordException`, span ended, exception rethrown
+- `null` exception message → `"unspecified error"` (internal class names never leaked)
+
+### 3-B. Flow Tracing — `traced()` / `tracedCollect()`
+
+**1 collect = 1 Span** (independent of emit count).
+
+```kotlin
+import io.bluetape4k.opentelemetry.coroutines.traced
+import io.bluetape4k.opentelemetry.coroutines.tracedCollect
+
+// traced() wraps the entire collect in a single Span
+flowOf(1, 2, 3)
+    .traced(tracer, "my-flow") {
+        setAttribute(AttributeKey.stringKey("source"), "db")
+    }
+    .collect { item -> process(item) }
+
+// Compose with other operators — Span spans the full collect
+flowOf(1, 2, 3, 4)
+    .traced(tracer, "take-flow")
+    .take(2)
+    .collect { }
+
+// tracedCollect — action runs inside the Span's OTel context
+// Span.current() inside action returns THIS span
+flowOf(42).tracedCollect(tracer, "collect-span") { item ->
+    val span = Span.current()  // same span created by tracedCollect
+    process(item)
+}
+```
+
+**Contracts:**
+- Normal completion → `StatusCode.OK`
+- `CancellationException` (timeout, `take()`, cancellation) → `StatusCode.UNSET`
+- Other exception → `StatusCode.ERROR` + `recordException`, exception rethrown
+- `traced()` vs `tracedCollect()`:
+  - `traced()` — returns a new Flow; OTel context active in the **producer** coroutine
+  - `tracedCollect()` — terminal operator; OTel context active in **both producer and consumer** (action) coroutines
+
 ### 4. Attributes Management
 
 ```kotlin
@@ -248,6 +326,30 @@ val compositeExporter = spanExporterOf(
   OtlpGrpcSpanExporter.builder().build()
 )
 ```
+
+### 9. Spring WebFlux Tracing (Spring Boot 3 Only)
+
+> **Spring Boot version constraint:**
+> `createTracingWebFilter()` uses `opentelemetry-spring-webflux-5.3`, which targets Spring WebFlux 5.3 / 6.x (Spring Boot 3).
+> **Spring Boot 4 (Spring Framework 7.x) is not yet supported** — support will be added once the OTel instrumentation BOM publishes a compatible artifact.
+
+```kotlin
+import io.bluetape4k.opentelemetry.webflux.createTracingWebFilter
+import io.bluetape4k.opentelemetry.webflux.webfluxServerTelemetry
+
+// Register as a @Bean — call only ONCE per ApplicationContext
+@Configuration
+class TracingConfig(private val openTelemetry: OpenTelemetry) {
+
+    @Bean
+    fun tracingWebFilter(): WebFilter = openTelemetry.createTracingWebFilter()
+}
+```
+
+**Operational constraints:**
+- Call `createTracingWebFilter()` exactly once per `ApplicationContext`. It registers a global Reactor `Hooks.onEachOperator`. Multiple calls nest the hook and cause unpredictable behavior.
+- In tests, call `Hooks.resetOnEachOperator()` in `@AfterAll` to prevent hook leakage between test classes.
+- Sensitive headers (`Authorization`, etc.) are **not** captured by default. To allow specific headers, set the environment variable `OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST`. **Never add headers containing PII.**
 
 ## Architecture Diagrams
 

--- a/infra/opentelemetry/build.gradle.kts
+++ b/infra/opentelemetry/build.gradle.kts
@@ -65,6 +65,10 @@ dependencies {
     // Opentelemetry instrumentation for spring boot starter
     implementation(Libs.opentelemetry_spring_boot_starter)
 
+    // Spring WebFlux tracing support (compileOnly — classpath 미존재 시 다른 기능에 영향 없도록)
+    compileOnly(Libs.opentelemetry_spring_webflux)
+    compileOnly(Libs.springBootStarter("webflux"))
+
     // Coroutines
     compileOnly(project(":bluetape4k-coroutines"))
     compileOnly(Libs.kotlinx_coroutines_core)

--- a/infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/FlowSpanSupport.kt
+++ b/infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/FlowSpanSupport.kt
@@ -1,0 +1,131 @@
+package io.bluetape4k.opentelemetry.coroutines
+
+import io.bluetape4k.support.requireNotBlank
+import io.opentelemetry.api.trace.SpanBuilder
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.context.Context
+import io.opentelemetry.extension.kotlin.asContextElement
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.withContext
+
+private const val UNSPECIFIED_ERROR = "unspecified error"
+
+/**
+ * 이 [Flow]의 collect를 단일 [io.opentelemetry.api.trace.Span]으로 감싸는 새로운 [Flow]를 반환합니다.
+ *
+ * ## 동작/계약
+ * - **1 collect = 1 Span**: collect가 한 번 실행될 때마다 Span이 하나 생성됩니다.
+ *   emit 횟수와 무관합니다. 아이템별 Span이 필요하면 `onEach { }` 안에서 직접 Span을 관리하세요.
+ * - 정상 종료 시 [StatusCode.OK]를 설정하고 Span을 종료합니다.
+ * - [CancellationException] (upstream 또는 downstream 취소) 시 상태를 UNSET으로 유지하고 Span을 종료합니다.
+ * - 일반 예외 발생 시 `recordException` + [StatusCode.ERROR] 설정 후 Span을 종료하고 예외를 재던집니다.
+ *   fallback 메시지는 `"unspecified error"` — 내부 클래스명은 절대 노출하지 않습니다.
+ *
+ * ## 구현 주의
+ * - 내부적으로 `channelFlow { }` 를 사용합니다. `flow { }` + `withContext` + `emit()` 조합은
+ *   Flow invariant를 위반하므로 사용하지 않습니다.
+ * - OTel Context 전파에 `span.storeInContext(Context.current()).asContextElement()`를 직접 사용합니다.
+ *   `withSpanContext`는 내부적으로 `endSafely()`를 호출하므로 재사용하면 이중 `end()`가 발생합니다.
+ * - [configure] 람다는 collect마다 새 [SpanBuilder]에서 실행됩니다.
+ *   카운터 증가 등 부수 효과를 [configure] 안에 넣지 마세요.
+ *
+ * ## traced vs tracedCollect 선택 기준
+ * | 시나리오 | 권장 |
+ * |---------|------|
+ * | Flow를 변환 체인에 연결해야 함 | `traced()` |
+ * | collect와 동시에 Span을 설정하고 싶음 | `tracedCollect()` |
+ *
+ * ## 보안 경고
+ * - [configure] 람다에서 PII, Authorization 토큰, 민감 헤더를 attribute로 설정하지 마세요.
+ * - [configure] 람다에서 `.startSpan()`을 직접 호출하면 이중 Span이 생성됩니다 (footgun).
+ *
+ * ```kotlin
+ * flowOf(1, 2, 3)
+ *     .traced(tracer, "my-flow") { setAttribute("key", "value") }
+ *     .collect { println(it) }
+ * ```
+ *
+ * @param tracer OTel [Tracer]
+ * @param spanName Span 이름 (공백 불가)
+ * @param configure [SpanBuilder] 설정 람다 — attribute, kind, parent 등. collect마다 실행됨.
+ * @return Span으로 감싸진 새로운 [Flow]
+ */
+public fun <T> Flow<T>.traced(
+    tracer: Tracer,
+    spanName: String,
+    configure: SpanBuilder.() -> Unit = {},
+): Flow<T> {
+    spanName.requireNotBlank("spanName")
+    return channelFlow {
+        val span = tracer.spanBuilder(spanName).apply(configure).startSpan()
+        try {
+            val otelContext = span.storeInContext(Context.current())
+            withContext(otelContext.asContextElement()) {
+                this@traced.collect { value -> send(value) }
+            }
+            span.setStatus(StatusCode.OK)
+        } catch (ce: CancellationException) {
+            throw ce
+        } catch (t: Throwable) {
+            span.recordException(t)
+            span.setStatus(StatusCode.ERROR, t.message ?: UNSPECIFIED_ERROR)
+            throw t
+        } finally {
+            span.end()
+        }
+    }
+}
+
+/**
+ * 이 [Flow]를 단일 [io.opentelemetry.api.trace.Span]으로 감싸 collect합니다.
+ *
+ * ## 동작/계약
+ * - [traced]와 달리 [action]도 Span의 OTel Context 안에서 실행됩니다.
+ *   따라서 [action] 안에서 `Span.current()`를 호출하면 이 함수가 생성한 Span이 반환됩니다.
+ * - 정상 종료 시 [StatusCode.OK]를 설정하고 Span을 종료합니다.
+ * - [CancellationException] 시 상태를 UNSET으로 유지하고 Span을 종료합니다.
+ * - 일반 예외 발생 시 `recordException` + [StatusCode.ERROR] 설정 후 재던집니다.
+ *
+ * ## [traced] 와의 차이
+ * - `traced()` 는 OTel Context 를 producer(upstream) 코루틴에만 설치합니다.
+ *   `tracedCollect` 는 OTel Context 를 [action] 이 실행되는 consumer 코루틴에도 설치합니다.
+ *
+ * ```kotlin
+ * flowOf(1, 2, 3).tracedCollect(tracer, "my-flow") { item ->
+ *     Span.current()  // 이 Span이 tracedCollect 가 생성한 Span 입니다
+ *     println(item)
+ * }
+ * ```
+ *
+ * @param tracer OTel [Tracer]
+ * @param spanName Span 이름 (공백 불가)
+ * @param configure [SpanBuilder] 설정 람다
+ * @param action collect 시 각 아이템에 대해 실행할 suspend 함수
+ */
+public suspend fun <T> Flow<T>.tracedCollect(
+    tracer: Tracer,
+    spanName: String,
+    configure: SpanBuilder.() -> Unit = {},
+    action: suspend (T) -> Unit,
+) {
+    spanName.requireNotBlank("spanName")
+    val span = tracer.spanBuilder(spanName).apply(configure).startSpan()
+    try {
+        val otelContext = span.storeInContext(Context.current())
+        withContext(otelContext.asContextElement()) {
+            this@tracedCollect.collect { value -> action(value) }
+        }
+        span.setStatus(StatusCode.OK)
+    } catch (ce: CancellationException) {
+        throw ce
+    } catch (t: Throwable) {
+        span.recordException(t)
+        span.setStatus(StatusCode.ERROR, t.message ?: UNSPECIFIED_ERROR)
+        throw t
+    } finally {
+        span.end()
+    }
+}

--- a/infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/SpanCoroutineSupport.kt
+++ b/infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/SpanCoroutineSupport.kt
@@ -3,8 +3,10 @@ package io.bluetape4k.opentelemetry.coroutines
 import io.bluetape4k.coroutines.support.getOrCurrent
 import io.bluetape4k.opentelemetry.trace.endSafely
 import io.bluetape4k.opentelemetry.trace.recordFailure
+import io.bluetape4k.support.requireNotBlank
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanBuilder
+import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
 import io.opentelemetry.extension.kotlin.asContextElement
 import kotlinx.coroutines.CancellationException
@@ -141,6 +143,42 @@ suspend inline fun <T> SpanBuilder.useSuspendSpan(
     coroutineContext,
     block,
 )
+
+/**
+ * suspend 코루틴 환경에서 새로운 [Span]을 생성하고 [block]을 실행한 뒤 Span을 자동으로 종료합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 [SpanBuilder.useSpanSuspending]에 위임합니다.
+ * - [CancellationException]은 상태 변경 없이 그대로 전파합니다 (UNSET 유지, 구조적 동시성 보존).
+ * - 일반 예외는 span에 기록하고 [io.opentelemetry.api.trace.StatusCode.ERROR] 상태로 바꾼 뒤 재던집니다.
+ *
+ * ## 보안 경고
+ * - [configure] 람다에서 PII, Authorization 토큰, 민감 헤더를 attribute로 설정하지 마세요.
+ * - [configure] 람다에서 `.startSpan()`을 직접 호출하면 이중 Span이 생성됩니다 (footgun).
+ * - [configure] 람다에서 `async { }` / `launch { }` 호출 시 OTel Context가 자식 코루틴에 전파되지 않을 수 있습니다.
+ *
+ * ```kotlin
+ * val result = tracer.withSpan("my-op") { span ->
+ *     span.setAttribute("key", "value")
+ *     fetchData()
+ * }
+ * ```
+ *
+ * @param spanName Span 이름 (공백 불가)
+ * @param configure [SpanBuilder] 설정 람다 — attribute, kind, parent 등
+ * @param coroutineContext 추가할 [CoroutineContext] (기본값: [EmptyCoroutineContext])
+ * @param block Span을 인자로 받는 suspend 실행 블록
+ * @return [block]의 실행 결과
+ */
+public suspend fun <T> Tracer.withSpan(
+    spanName: String,
+    configure: SpanBuilder.() -> Unit = {},
+    coroutineContext: CoroutineContext = EmptyCoroutineContext,
+    block: suspend (Span) -> T,
+): T {
+    spanName.requireNotBlank("spanName")
+    return spanBuilder(spanName).apply(configure).useSpanSuspending(coroutineContext, block)
+}
 
 /**
  * Coroutines 환경에서 [span]을 명시적으로 전파합니다.

--- a/infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanSupport.kt
+++ b/infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanSupport.kt
@@ -1,11 +1,15 @@
 package io.bluetape4k.opentelemetry.trace
 
+import io.bluetape4k.support.requireNotBlank
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanBuilder
 import io.opentelemetry.api.trace.SpanContext
 import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.api.trace.Tracer
 import kotlinx.coroutines.CancellationException
 import java.time.Duration
+
+private const val UNSPECIFIED_ERROR = "unspecified error"
 
 
 /**
@@ -102,7 +106,56 @@ internal fun Span.recordFailure(error: Throwable) {
     }
 
     recordException(error)
-    setStatus(StatusCode.ERROR, error.message ?: error::class.java.simpleName)
+    setStatus(StatusCode.ERROR, error.message ?: UNSPECIFIED_ERROR)
+}
+
+/**
+ * blocking 환경에서 새로운 [Span]을 생성하고 [block]을 실행한 뒤 Span을 자동으로 종료합니다.
+ *
+ * ## 동작/계약
+ * - 정상 종료 시 [StatusCode.OK]를 설정하고 Span을 종료합니다.
+ * - 일반 예외 발생 시 `recordException` + [StatusCode.ERROR] 설정 후 재던집니다.
+ *   fallback 메시지는 `"unspecified error"` — 내부 클래스명은 절대 노출하지 않습니다.
+ * - [CancellationException]은 상태 변경 없이 그대로 전파합니다 (UNSET 유지).
+ *
+ * ## 보안 경고
+ * - [configure] 람다에서 PII, Authorization 토큰, 민감 헤더를 attribute로 설정하지 마세요.
+ * - [configure] 람다에서 `.startSpan()`을 직접 호출하면 이중 Span이 생성됩니다 (footgun).
+ *
+ * ## 코루틴 사용 주의
+ * - 이 함수는 blocking 전용입니다. suspend 환경에서는 `SpanCoroutineSupport.kt`의
+ *   `suspend Tracer.withSpan(...)` 을 사용하세요.
+ * - Dispatcher 전환 시 ThreadLocal 기반 OTel Context가 유실될 수 있습니다.
+ *
+ * ```kotlin
+ * val result = tracer.withSpan("my-operation") { span ->
+ *     span.setAttribute("key", "value")
+ *     "done"
+ * }
+ * ```
+ *
+ * @param spanName Span 이름 (공백 불가)
+ * @param configure [SpanBuilder] 설정 람다 — attribute, kind, parent 등
+ * @param block Span을 인자로 받는 실행 블록
+ * @return [block]의 실행 결과
+ */
+public inline fun <T> Tracer.withSpan(
+    spanName: String,
+    configure: SpanBuilder.() -> Unit = {},
+    block: (Span) -> T,
+): T {
+    spanName.requireNotBlank("spanName")
+    val span = spanBuilder(spanName).apply(configure).startSpan()
+    return span.makeCurrent().use {
+        try {
+            block(span).also { span.setStatus(StatusCode.OK) }
+        } catch (e: Throwable) {
+            span.recordFailure(e)
+            throw e
+        } finally {
+            span.end()
+        }
+    }
 }
 
 @PublishedApi

--- a/infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/webflux/WebfluxTracingSupport.kt
+++ b/infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/webflux/WebfluxTracingSupport.kt
@@ -1,0 +1,68 @@
+package io.bluetape4k.opentelemetry.webflux
+
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.instrumentation.spring.webflux.v5_3.SpringWebfluxServerTelemetry
+import org.springframework.web.server.WebFilter
+
+/**
+ * 이 [OpenTelemetry] 인스턴스로 [SpringWebfluxServerTelemetry]를 생성합니다.
+ *
+ * ## Spring Boot 버전 제약
+ * - **Spring Boot 3 전용** — `opentelemetry-spring-webflux-5.3` 아티팩트는 Spring WebFlux 5.3 / 6.x API 기준입니다.
+ * - Spring Boot 4 (Spring Framework 7.x) 지원은 OTel instrumentation BOM에서 대응 아티팩트 출시 후 별도 제공됩니다.
+ *
+ * ## 운영 제약
+ * - **반드시 `@Bean`으로 ApplicationContext 초기화 시 1회만 호출하세요.**
+ *   [createTracingWebFilter]가 내부적으로 Reactor `Hooks.onEachOperator`를 전역 등록합니다.
+ *   중복 호출 시 Reactor 연산자 체인에 훅이 중첩되어 예기치 않은 동작이 발생할 수 있습니다.
+ * - 테스트 격리를 위해 `@AfterAll`에서 `Hooks.resetOnEachOperator(key)`를 호출하세요.
+ *
+ * ## 민감 헤더 캡처 제한
+ * - 기본 설정에서 `Authorization` 등 민감 헤더는 Span attribute로 캡처되지 않습니다.
+ * - 헤더 캡처가 필요한 경우 환경변수 `OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST`에
+ *   허용 헤더 목록을 지정하세요. **PII를 포함하는 헤더는 절대 추가하지 마세요.**
+ *
+ * ```kotlin
+ * @Configuration
+ * class TracingConfig(private val openTelemetry: OpenTelemetry) {
+ *     @Bean
+ *     fun tracingWebFilter(): WebFilter = openTelemetry.createTracingWebFilter()
+ * }
+ * ```
+ *
+ * @return [SpringWebfluxServerTelemetry] 인스턴스
+ * @see createTracingWebFilter
+ */
+public fun OpenTelemetry.webfluxServerTelemetry(): SpringWebfluxServerTelemetry =
+    SpringWebfluxServerTelemetry.create(this)
+
+/**
+ * 이 [OpenTelemetry] 인스턴스로 Spring WebFlux 서버 트레이싱 [WebFilter]를 생성하고
+ * Reactor 전역 훅을 등록합니다.
+ *
+ * ## Spring Boot 버전 제약
+ * - **Spring Boot 3 전용** — `opentelemetry-spring-webflux-5.3` 아티팩트는 Spring WebFlux 5.3 / 6.x API 기준입니다.
+ * - Spring Boot 4 (Spring Framework 7.x) 지원은 OTel instrumentation BOM에서 대응 아티팩트 출시 후 별도 제공됩니다.
+ *
+ * ## 운영 제약
+ * - **반드시 `@Bean`으로 1회만 호출하세요.** 이 함수는 내부적으로 [SpringWebfluxServerTelemetry.createWebFilterAndRegisterReactorHook]을
+ *   호출하여 Reactor `Hooks.onEachOperator`를 전역 등록합니다.
+ * - 테스트 격리를 위해 `@AfterAll`에서 `Hooks.resetOnEachOperator(key)`를 호출하세요.
+ *
+ * ## 보안 경고
+ * - 기본 설정에서 `Authorization` 등 민감 헤더는 Span attribute로 캡처되지 않습니다.
+ * - 헤더 캡처 허용 목록: 환경변수 `OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST`
+ *
+ * ```kotlin
+ * @Configuration
+ * class TracingConfig(private val openTelemetry: OpenTelemetry) {
+ *     @Bean
+ *     fun tracingWebFilter(): WebFilter = openTelemetry.createTracingWebFilter()
+ * }
+ * ```
+ *
+ * @return 서버 요청/응답 Span을 자동으로 생성하는 [WebFilter]
+ * @see webfluxServerTelemetry
+ */
+public fun OpenTelemetry.createTracingWebFilter(): WebFilter =
+    webfluxServerTelemetry().createWebFilterAndRegisterReactorHook()

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/coroutines/FlowSpanSupportTest.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/coroutines/FlowSpanSupportTest.kt
@@ -1,0 +1,198 @@
+package io.bluetape4k.opentelemetry.coroutines
+
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.opentelemetry.AbstractOtelTest
+import io.bluetape4k.opentelemetry.trace.sdkTracerProvider
+import io.bluetape4k.opentelemetry.trace.simpleSpanProcessorOf
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.withTimeout
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldHaveSize
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * [Flow.traced] 및 [Flow.tracedCollect] 동작을 검증합니다.
+ *
+ * 핵심 계약:
+ * - 1 collect = 1 Span (emit 횟수와 무관)
+ * - CancellationException → UNSET (ERROR 미기록)
+ * - 일반 예외 → ERROR + recordException
+ */
+class FlowSpanSupportTest: AbstractOtelTest() {
+
+    companion object: KLoggingChannel()
+
+    private val spanExporter = InMemorySpanExporter.create()
+    private val tracerProvider = sdkTracerProvider {
+        addSpanProcessor(simpleSpanProcessorOf(spanExporter))
+    }
+    private val tracer = tracerProvider.get("io.bluetape4k.otel.flow-span")
+
+    @BeforeEach
+    fun setup() {
+        spanExporter.reset()
+    }
+
+    private fun flush() {
+        tracerProvider.forceFlush().join(1, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun `traced normal completion should produce exactly 1 span with OK status`() = runSuspendIO {
+        flowOf(1, 2, 3)
+            .traced(tracer, "flow-ok")
+            .collect { }
+        flush()
+
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 1
+        finished[0].name shouldBeEqualTo "flow-ok"
+        finished[0].status.statusCode shouldBeEqualTo StatusCode.OK
+    }
+
+    @Test
+    fun `traced with 3 emits should still produce exactly 1 span`() = runSuspendIO {
+        val items = flowOf("a", "b", "c")
+            .traced(tracer, "multi-emit")
+            .toList()
+        flush()
+
+        items shouldHaveSize 3
+        spanExporter.finishedSpanItems shouldHaveSize 1
+    }
+
+    @Test
+    fun `traced upstream exception should set ERROR and rethrow`() = runSuspendIO {
+        val upstream = flow<Int> { throw IllegalStateException("upstream-fail") }
+
+        val ex = kotlin.runCatching {
+            upstream.traced(tracer, "err-flow").collect { }
+        }.exceptionOrNull()
+
+        ex.shouldNotBeNull()
+        (ex is IllegalStateException).shouldBeTrue()
+        flush()
+
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 1
+        finished[0].status.statusCode shouldBeEqualTo StatusCode.ERROR
+        finished[0].events.any { it.name == "exception" }.shouldBeTrue()
+    }
+
+    @Test
+    fun `traced take(2) downstream early completion should produce OK span`() = runSuspendIO {
+        flowOf(1, 2, 3, 4)
+            .traced(tracer, "take-flow")
+            .take(2)
+            .collect { }
+        flush()
+
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 1
+        // channelFlow 의 버퍼로 인해 producer(upstream collect)가 take(2) 취소 전에 완료 → OK
+        finished[0].status.statusCode shouldBeEqualTo StatusCode.OK
+    }
+
+    @Test
+    fun `traced withTimeout cancellation should set UNSET status not ERROR`() = runSuspendIO {
+        val ex = kotlin.runCatching {
+            withTimeout(50.milliseconds) {
+                flow<Int> {
+                    emit(1)
+                    kotlinx.coroutines.delay(1_000)
+                    emit(2)
+                }.traced(tracer, "timeout-flow").collect { }
+            }
+        }.exceptionOrNull()
+
+        ex.shouldNotBeNull()
+        flush()
+
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 1
+        finished[0].status.statusCode shouldBeEqualTo StatusCode.UNSET
+        finished[0].events.any { it.name == "exception" }.shouldBeFalse()
+    }
+
+    @Test
+    fun `traced with flowOn IO dispatcher should propagate span and produce 1 span`() = runSuspendIO {
+        flowOf(1, 2, 3)
+            .flowOn(Dispatchers.IO)
+            .traced(tracer, "flowon-span")
+            .collect { }
+        flush()
+
+        spanExporter.finishedSpanItems shouldHaveSize 1
+        spanExporter.finishedSpanItems[0].name shouldBeEqualTo "flowon-span"
+    }
+
+    @Test
+    fun `tracedCollect action should run inside traced Span context`() = runSuspendIO {
+        var spanInsideAction: Span? = null
+
+        flowOf(42).tracedCollect(tracer, "collect-span") { _ ->
+            spanInsideAction = Span.current()
+        }
+        flush()
+
+        spanInsideAction.shouldNotBeNull()
+        // collect 안에서의 Span이 종료된 traced Span과 동일한 traceId
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 1
+        finished[0].traceId shouldBeEqualTo spanInsideAction!!.spanContext.traceId
+    }
+
+    @Test
+    fun `traced should not capture Authorization header as span attribute`() = runSuspendIO {
+        flowOf("data")
+            .traced(tracer, "secure-flow") {
+                // Authorization 헤더를 attribute로 추가하지 않음 — 이 테스트는 configure에서 민감 attribute를 설정하지 않는 경우를 검증
+                setAttribute(AttributeKey.stringKey("safe-key"), "safe-value")
+            }
+            .collect { }
+        flush()
+
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 1
+        // Authorization attribute가 없음을 검증
+        finished[0].attributes.asMap().keys
+            .none { it.key.contains("Authorization", ignoreCase = true) }
+            .shouldBeTrue()
+    }
+
+    @Test
+    fun `traced with blank spanName should throw IllegalArgumentException`() {
+        assertThrows<IllegalArgumentException> {
+            runSuspendIO {
+                flowOf(1).traced(tracer, "").collect { }
+            }
+        }
+    }
+
+    @Test
+    fun `tracedCollect with blank spanName should throw IllegalArgumentException`() {
+        assertThrows<IllegalArgumentException> {
+            runSuspendIO {
+                flowOf(1).tracedCollect(tracer, "  ") { }
+            }
+        }
+    }
+}

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/coroutines/TracerWithSpanTest.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/coroutines/TracerWithSpanTest.kt
@@ -1,0 +1,223 @@
+package io.bluetape4k.opentelemetry.coroutines
+
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.opentelemetry.AbstractOtelTest
+import io.bluetape4k.opentelemetry.trace.sdkTracerProvider
+import io.bluetape4k.opentelemetry.trace.simpleSpanProcessorOf
+import io.bluetape4k.opentelemetry.trace.withSpan
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldHaveSize
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.TimeUnit
+
+/**
+ * [io.opentelemetry.api.trace.Tracer.withSpan] suspend / blocking 두 오버로드를 검증합니다.
+ */
+class TracerWithSpanTest: AbstractOtelTest() {
+
+    companion object: KLoggingChannel()
+
+    private val spanExporter = InMemorySpanExporter.create()
+    private val tracerProvider = sdkTracerProvider {
+        addSpanProcessor(simpleSpanProcessorOf(spanExporter))
+    }
+    private val tracer = tracerProvider.get("io.bluetape4k.otel.tracer-with-span")
+
+    @BeforeEach
+    fun setup() {
+        spanExporter.reset()
+    }
+
+    private fun flush() {
+        tracerProvider.forceFlush().join(1, TimeUnit.SECONDS)
+    }
+
+    // ── suspend Tracer.withSpan ───────────────────────────────────────────────
+
+    @Test
+    fun `suspend withSpan should end span with matching name`() = runSuspendIO {
+        val result = tracer.withSpan("my-op") { "done" }
+        result shouldBeEqualTo "done"
+        flush()
+
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 1
+        finished[0].name shouldBeEqualTo "my-op"
+    }
+
+    @Test
+    fun `suspend withSpan should propagate context into withContext IO dispatcher`() = runSuspendIO {
+        tracer.withSpan("io-span") {
+            withContext(Dispatchers.IO) {
+                // Dispatcher 전환 후에도 1개의 Span만 생성됨
+            }
+        }
+        flush()
+
+        spanExporter.finishedSpanItems shouldHaveSize 1
+        spanExporter.finishedSpanItems[0].name shouldBeEqualTo "io-span"
+    }
+
+    @Test
+    fun `suspend withSpan nested calls should produce parent-child trace`() = runSuspendIO {
+        tracer.withSpan("parent") {
+            tracer.withSpan("child") { }
+        }
+        flush()
+
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 2
+
+        val parent = finished.find { it.name == "parent" }.shouldNotBeNull()
+        val child = finished.find { it.name == "child" }.shouldNotBeNull()
+
+        child.traceId shouldBeEqualTo parent.traceId
+        child.parentSpanId shouldBeEqualTo parent.spanId
+    }
+
+    @Test
+    fun `suspend withSpan should set ERROR and rethrow on exception`() = runSuspendIO {
+        val failure = IllegalStateException("boom")
+
+        val ex = kotlin.runCatching {
+            tracer.withSpan("err-span") { throw failure }
+        }.exceptionOrNull()
+
+        ex.shouldNotBeNull()
+        (ex is IllegalStateException).shouldBeTrue()
+
+        flush()
+
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 1
+        finished[0].status.statusCode shouldBeEqualTo StatusCode.ERROR
+        finished[0].events.any { it.name == "exception" }.shouldBeTrue()
+    }
+
+    @Test
+    fun `suspend withSpan should NOT record ERROR on CancellationException`() = runSuspendIO {
+        val ex = kotlin.runCatching {
+            tracer.withSpan("cancel-span") { throw CancellationException("cancelled") }
+        }.exceptionOrNull()
+
+        ex.shouldNotBeNull()
+        (ex is CancellationException).shouldBeTrue()
+
+        flush()
+
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 1
+        finished[0].status.statusCode shouldBeEqualTo StatusCode.UNSET
+        finished[0].events.any { it.name == "exception" }.shouldBeFalse()
+    }
+
+    @Test
+    fun `suspend withSpan configure lambda should apply attributes`() = runSuspendIO {
+        tracer.withSpan("attr-span", configure = {
+            setAttribute(AttributeKey.stringKey("env"), "test")
+        }) { }
+        flush()
+
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 1
+        finished[0].attributes[AttributeKey.stringKey("env")] shouldBeEqualTo "test"
+    }
+
+    @Test
+    fun `suspend withSpan with blank spanName should throw IllegalArgumentException`() {
+        assertThrows<IllegalArgumentException> {
+            runSuspendIO {
+                tracer.withSpan("  ") { }
+            }
+        }
+    }
+
+    // ── blocking Tracer.withSpan ──────────────────────────────────────────────
+
+    @Test
+    fun `blocking withSpan should set status OK on normal completion`() = runSuspendIO {
+        val result = tracer.withSpan("block-ok") { "result" }
+        result shouldBeEqualTo "result"
+        flush()
+
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 1
+        finished[0].name shouldBeEqualTo "block-ok"
+        finished[0].status.statusCode shouldBeEqualTo StatusCode.OK
+    }
+
+    @Test
+    fun `blocking withSpan with null message should use unspecified error fallback`() = runSuspendIO {
+        val ex = kotlin.runCatching {
+            tracer.withSpan("block-null-msg") {
+                throw RuntimeException(null as String?)
+            }
+        }.exceptionOrNull()
+
+        ex.shouldNotBeNull()
+
+        flush()
+
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 1
+        finished[0].status.statusCode shouldBeEqualTo StatusCode.ERROR
+        // javaClass.simpleName("RuntimeException") 노출 없이 "unspecified error" 사용
+        finished[0].status.description shouldBeEqualTo "unspecified error"
+        finished[0].status.description.contains("RuntimeException").shouldBeFalse()
+    }
+
+    @Test
+    fun `blocking withSpan should NOT record ERROR on CancellationException`() = runSuspendIO {
+        val ex = kotlin.runCatching {
+            tracer.withSpan("block-cancel") {
+                throw CancellationException("cancelled")
+            }
+        }.exceptionOrNull()
+
+        ex.shouldNotBeNull()
+        (ex is CancellationException).shouldBeTrue()
+
+        flush()
+
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 1
+        finished[0].status.statusCode shouldBeEqualTo StatusCode.UNSET
+        finished[0].events.any { it.name == "exception" }.shouldBeFalse()
+    }
+
+    @Test
+    fun `blocking withSpan nested should produce parent-child trace`() = runSuspendIO {
+        tracer.withSpan("block-parent") {
+            tracer.withSpan("block-child") { }
+        }
+        flush()
+
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 2
+
+        val parent = finished.find { it.name == "block-parent" }.shouldNotBeNull()
+        val child = finished.find { it.name == "block-child" }.shouldNotBeNull()
+
+        child.traceId shouldBeEqualTo parent.traceId
+        child.parentSpanId shouldBeEqualTo parent.spanId
+    }
+
+    @Test
+    fun `blocking withSpan with blank spanName should throw IllegalArgumentException`() {
+        assertThrows<IllegalArgumentException> {
+            tracer.withSpan("") { }
+        }
+    }
+}

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/trace/SpanSupportTest.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/trace/SpanSupportTest.kt
@@ -219,4 +219,32 @@ class SpanSupportTest: AbstractOtelTest() {
         finished[0].name shouldBeEqualTo "dsl-span"
         finished[0].attributes[AttributeKey.stringKey("dsl-key")] shouldBeEqualTo "dsl-value"
     }
+
+    /**
+     * [Task 1.5 회귀] message=null 예외 발생 시 `recordFailure` 가 클래스명 대신 "unspecified error" 를 사용하는지 검증합니다.
+     * 이전에는 `error::class.java.simpleName` 을 사용하여 내부 클래스명("RuntimeException")이 노출됐습니다.
+     */
+    @Test
+    fun `recordFailure with null message should use unspecified error fallback not class name`() = runSuspendIO {
+        spanExporter.reset()
+
+        val ex = kotlin.runCatching {
+            tracer.spanBuilder("null-msg-span").startSpan().use {
+                throw RuntimeException(null as String?)
+            }
+        }.exceptionOrNull()
+
+        ex.shouldNotBeNull()
+
+        flush()
+
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 1
+
+        val span = finished[0]
+        span.status.statusCode shouldBeEqualTo StatusCode.ERROR
+        span.status.description shouldBeEqualTo "unspecified error"
+        // 내부 클래스명이 누출되지 않음을 검증
+        span.status.description.contains("RuntimeException").shouldBeFalse()
+    }
 }

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/webflux/WebfluxTracingSupportTest.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/webflux/WebfluxTracingSupportTest.kt
@@ -1,0 +1,53 @@
+package io.bluetape4k.opentelemetry.webflux
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.opentelemetry.AbstractOtelTest
+import io.bluetape4k.opentelemetry.trace.sdkTracerProvider
+import io.bluetape4k.opentelemetry.trace.simpleSpanProcessorOf
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Hooks
+
+/**
+ * [OpenTelemetry.webfluxServerTelemetry] / [OpenTelemetry.createTracingWebFilter] 스모크 테스트.
+ *
+ * 목표:
+ * - 두 함수가 호출 가능하고 non-null 인스턴스를 반환하는지 확인합니다.
+ * - Reactor 전역 훅이 `@AfterAll`에서 리셋되는지 확인합니다.
+ *
+ * ## 통합 테스트 제한
+ * 실제 HTTP 요청 → Span 생성 검증은 Spring Boot 3 통합 테스트 환경(`@SpringBootTest` + `WebTestClient`)이 필요합니다.
+ * 이 테스트는 wrapper 함수의 API 연결만 검증합니다.
+ */
+class WebfluxTracingSupportTest: AbstractOtelTest() {
+
+    companion object: KLoggingChannel() {
+        private const val REACTOR_HOOK_KEY = "io.opentelemetry.javaagent.shaded.io.opentelemetry.instrumentation.reactornetty.v1_0"
+
+        @JvmStatic
+        @AfterAll
+        fun resetReactorHooks() {
+            // createWebFilterAndRegisterReactorHook이 전역 Hooks.onEachOperator를 등록하므로 테스트 후 해제
+            Hooks.resetOnEachOperator()
+        }
+    }
+
+    private val spanExporter = InMemorySpanExporter.create()
+    private val tracerProvider = sdkTracerProvider {
+        addSpanProcessor(simpleSpanProcessorOf(spanExporter))
+    }
+
+    @Test
+    fun `webfluxServerTelemetry should return non-null SpringWebfluxServerTelemetry`() {
+        val telemetry = loggingOtel.webfluxServerTelemetry()
+        telemetry.shouldNotBeNull()
+    }
+
+    @Test
+    fun `createTracingWebFilter should return non-null WebFilter`() {
+        val webFilter = loggingOtel.createTracingWebFilter()
+        webFilter.shouldNotBeNull()
+    }
+}


### PR DESCRIPTION
## Summary

Closes #150

- PR 제목: feat(opentelemetry): Coroutines/Flow/WebFlux 트레이싱 API 추가 (#150)

Issue #150 — `infra/opentelemetry` 모듈에 Kotlin Coroutines/Flow/Spring WebFlux 트레이싱 API를 추가합니다.

---

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 신규 API

### `Tracer.withSpan()` — suspend / blocking

```kotlin
// suspend (coroutine 내부)
val result = tracer.withSpan("my-op") { span -> doWork() }

// blocking (inline)
val result = tracer.withSpan("my-op") { span -> doWork() }
```

**계약**: 정상 → OK, CancellationException → UNSET, 그 외 → ERROR + recordException

### `Flow.traced()` / `Flow.tracedCollect()`

```kotlin
// traced: 1 collect = 1 Span
flowOf(1, 2, 3).traced(tracer, "my-flow").collect { }

// tracedCollect: action도 OTel Context 안에서 실행
flowOf(42).tracedCollect(tracer, "collect-span") { item ->
    Span.current()  // tracedCollect가 생성한 Span
}
```

### Spring WebFlux 트레이싱 (Spring Boot 3 전용)

```kotlin
@Bean
fun tracingWebFilter(): WebFilter = openTelemetry.createTracingWebFilter()
```

> **제약**: `opentelemetry-spring-webflux-5.3`은 Spring WebFlux 5.3/6.x (Spring Boot 3) 전용.
> Spring Boot 4 지원은 OTel instrumentation BOM 업데이트 후 별도 PR 예정.

---

### 기존 섹션: 보안 수정

`Span.recordFailure` fallback 메시지: `error::class.java.simpleName` → `"unspecified error"`
- 기존 코드가 내부 클래스명을 OTLP 백엔드에 노출하는 보안 결함 수정

---

### 기존 섹션: 코드 리뷰 반영

| 심각도 | 이슈 | 처리 |
|--------|------|------|
| [HIGH] | `storeInContext()` 가 try 블록 외부에서 호출 → span leak 가능 | try 내부로 이동 ✅ |
| [LOW] | redundant `kotlinx.coroutines.flow.collect` import | 제거 ✅ |
| [MEDIUM] | `configure` per-collect 실행 경고 누락 | KDoc 추가 ✅ |

---

## Validation

```
./gradlew :bluetape4k-opentelemetry:test → 73 passing (1m 8s) BUILD SUCCESSFUL
```

| 테스트 클래스 | 추가 케이스 | 검증 내용 |
|-------------|-----------|---------|
| `SpanSupportTest` | +1 | recordFailure null message → "unspecified error" |
| `TracerWithSpanTest` | +14 | suspend/blocking withSpan 전체 시나리오 |
| `FlowSpanSupportTest` | +9 | traced/tracedCollect 계약, 취소, 에러, 보안 |
| `WebfluxTracingSupportTest` | +2 | createTracingWebFilter smoke |

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #150, milestone 없음, assignee 없음
- PR: #214, head `76db7896fde7baf49057119c7a146eb140e750cc`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/opentelemetry-coroutines`
- Labels: `enhancement`
- State: `MERGED`, merge commit `c2220bd80c1764ca7449e91710547958987d40b0`
- CI: | `webflux/WebfluxTracingSupport.kt` | 신규 | `createTracingWebFilter()` (Spring Boot 3 전용) | / | `build.gradle.kts` | 수정 | `opentelemetry-spring-webflux-5.3` compileOnly 추가 | / fun tracingWebFilter(): WebFilter = openTelemetry.createTracingWebFilter()

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #214 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `c2220bd80c1764ca7449e91710547958987d40b0`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
