### PR TITLE
fix: bluetape4k/core 코드 리뷰 지적사항 수정

### DIFF
--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/collections/IterableSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/collections/IterableSupport.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.support.asFloat
 import io.bluetape4k.support.asInt
 import io.bluetape4k.support.asLong
 import io.bluetape4k.support.asString
+import kotlinx.coroutines.CancellationException
 import java.util.*
 
 /**
@@ -328,7 +329,7 @@ inline fun <reified T: Any> Iterable<*>.asArray(): Array<T?> =
  * @see tryMap
  */
 inline fun <T, R> Iterable<T>.mapCatching(mapper: (T) -> R): List<Result<R>> =
-    map { runCatching { mapper(it) } }
+    map { runCatching { mapper(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 
 /**
  * forEach 구문 실행 시 `runCatching` 구문으로 [action] 실행합니다. 예외를 무시합니다.
@@ -342,7 +343,7 @@ inline fun <T, R> Iterable<T>.mapCatching(mapper: (T) -> R): List<Result<R>> =
  * @see forEachCatching
  */
 inline fun <T> Iterable<T>.tryForEach(action: (T) -> Unit) {
-    forEach { runCatching { action(it) } }
+    forEach { runCatching { action(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 }
 
 /**
@@ -363,7 +364,7 @@ inline fun <T> Iterable<T>.tryForEach(action: (T) -> Unit) {
  * @see tryForEach
  */
 inline fun <T> Iterable<T>.forEachCatching(action: (T) -> Unit): List<Result<Unit>> =
-    map { runCatching { action(it) } }
+    map { runCatching { action(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 
 /**
  * [mapper] 실행이 성공한 결과만 추출합니다.
@@ -378,7 +379,7 @@ inline fun <T> Iterable<T>.forEachCatching(action: (T) -> Unit): List<Result<Uni
  * @return 성공한 결과 리스트
  */
 inline fun <T, R: Any> Iterable<T>.mapIfSuccess(mapper: (T) -> R): List<R> =
-    mapNotNull { runCatching { mapper(it) }.getOrNull() }
+    mapNotNull { runCatching { mapper(it) }.onFailure { e -> if (e is CancellationException) throw e }.getOrNull() }
 
 
 /**

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/collections/SequenceSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/collections/SequenceSupport.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.support.asInt
 import io.bluetape4k.support.asLong
 import io.bluetape4k.support.asString
 import io.bluetape4k.support.requireLe
+import kotlinx.coroutines.CancellationException
 
 
 /**
@@ -298,7 +299,7 @@ inline fun <reified T: Any> Sequence<*>.asArray(): Array<T?> = mapTo(ArrayList()
  * @return 변환된 결과를 담은 `Sequence<R>` 객체
  */
 inline fun <T, R: Any> Sequence<T>.mapIfSuccess(crossinline mapper: (T) -> R): Sequence<R> =
-    mapNotNull { runCatching { mapper(it) }.getOrNull() }
+    mapNotNull { runCatching { mapper(it) }.onFailure { e -> if (e is CancellationException) throw e }.getOrNull() }
 
 /**
  * [action] 실행을 [runCatching]으로 감싸서 수행합니다. 예외가 발생해도 다음 요소를 계속 수행합니다.
@@ -309,7 +310,7 @@ inline fun <T, R: Any> Sequence<T>.mapIfSuccess(crossinline mapper: (T) -> R): S
  * ```
  */
 inline fun <T> Sequence<T>.tryForEach(action: (T) -> Unit) {
-    forEach { runCatching { action(it) } }
+    forEach { runCatching { action(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 }
 
 /**
@@ -327,7 +328,7 @@ inline fun <T> Sequence<T>.tryForEach(action: (T) -> Unit) {
  * @see forEachCatching
  */
 inline fun <T, R> Sequence<T>.mapCatching(crossinline mapper: (T) -> R): Sequence<Result<R>> =
-    map { runCatching { mapper(it) } }
+    map { runCatching { mapper(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 
 /**
  * [action] 실행을 [runCatching]으로 감싸서 수행합니다. 예외가 발생해도 다음 요소를 계속 수행합니다.
@@ -343,7 +344,7 @@ inline fun <T, R> Sequence<T>.mapCatching(crossinline mapper: (T) -> R): Sequenc
  * @see mapCatching
  */
 inline fun <T> Sequence<T>.forEachCatching(crossinline action: (T) -> Unit): Sequence<Result<Unit>> {
-    return map { runCatching { action(it) } }
+    return map { runCatching { action(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 }
 
 

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/CompletableFutureSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/CompletableFutureSupport.kt
@@ -8,6 +8,7 @@ import java.util.concurrent.Executor
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import kotlin.time.Duration
 
 @PublishedApi
@@ -543,8 +544,13 @@ fun <V> CompletableFuture<V>.join(duration: Duration): V {
  * @return V 결과값
  * @throws [java.util.concurrent.TimeoutException] 제한된 시간 내에 결과값을 얻지 못한 경우
  */
-fun <V> CompletableFuture<V>.join(duration: Duration, defaultValue: V): V =
-    runCatching { join(duration) ?: defaultValue }.getOrDefault(defaultValue)
+fun <V> CompletableFuture<V>.join(duration: Duration, defaultValue: V): V {
+    return try {
+        join(duration) ?: defaultValue
+    } catch (e: TimeoutException) {
+        defaultValue
+    }
+}
 
 /**
  * 제한된 사간안에 [CompletableFuture]의 결과값을 반환하거나, null을 반환합니다.
@@ -557,5 +563,10 @@ fun <V> CompletableFuture<V>.join(duration: Duration, defaultValue: V): V =
  * @param duration 최대 대기 시간
  * @return V? 결과값 또는 null
  */
-fun <V> CompletableFuture<V>.joinOrNull(duration: Duration): V? =
-    runCatching { get(duration.inWholeNanoseconds, TimeUnit.NANOSECONDS) }.getOrNull()
+fun <V> CompletableFuture<V>.joinOrNull(duration: Duration): V? {
+    return try {
+        get(duration.inWholeNanoseconds, TimeUnit.NANOSECONDS)
+    } catch (e: TimeoutException) {
+        null
+    }
+}

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/ArraySupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/ArraySupport.kt
@@ -1,5 +1,7 @@
 package io.bluetape4k.support
 
+import kotlinx.coroutines.CancellationException
+
 /**
  * 길이가 0인 [BooleanArray] 상수입니다.
  *
@@ -396,7 +398,7 @@ fun <T> Array<T>.setLast(value: T) {
  * @return 각 요소 처리 결과를 담은 [Result] 리스트
  */
 inline fun <T, R> Array<T>.mapCatching(transform: (T) -> R): List<Result<R>> {
-    return map { runCatching { transform(it) } }
+    return map { runCatching { transform(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 }
 
 /**
@@ -409,7 +411,7 @@ inline fun <T, R> Array<T>.mapCatching(transform: (T) -> R): List<Result<R>> {
  * @return 각 요소 처리 결과를 담은 [Result] 리스트
  */
 inline fun <R> CharArray.mapCatching(transform: (Char) -> R): List<Result<R>> {
-    return map { runCatching { transform(it) } }
+    return map { runCatching { transform(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 }
 
 /**
@@ -422,7 +424,7 @@ inline fun <R> CharArray.mapCatching(transform: (Char) -> R): List<Result<R>> {
  * @return 각 요소 처리 결과를 담은 [Result] 리스트
  */
 inline fun <R> ByteArray.mapCatching(transform: (Byte) -> R): List<Result<R>> {
-    return map { runCatching { transform(it) } }
+    return map { runCatching { transform(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 }
 
 /**
@@ -435,7 +437,7 @@ inline fun <R> ByteArray.mapCatching(transform: (Byte) -> R): List<Result<R>> {
  * @return 각 요소 처리 결과를 담은 [Result] 리스트
  */
 inline fun <R> ShortArray.mapCatching(transform: (Short) -> R): List<Result<R>> {
-    return map { runCatching { transform(it) } }
+    return map { runCatching { transform(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 }
 
 /**
@@ -448,7 +450,7 @@ inline fun <R> ShortArray.mapCatching(transform: (Short) -> R): List<Result<R>> 
  * @return 각 요소 처리 결과를 담은 [Result] 리스트
  */
 inline fun <R> IntArray.mapCatching(transform: (Int) -> R): List<Result<R>> {
-    return map { runCatching { transform(it) } }
+    return map { runCatching { transform(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 }
 
 /**
@@ -461,7 +463,7 @@ inline fun <R> IntArray.mapCatching(transform: (Int) -> R): List<Result<R>> {
  * @return 각 요소 처리 결과를 담은 [Result] 리스트
  */
 inline fun <R> LongArray.mapCatching(transform: (Long) -> R): List<Result<R>> {
-    return map { runCatching { transform(it) } }
+    return map { runCatching { transform(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 }
 
 /**
@@ -474,7 +476,7 @@ inline fun <R> LongArray.mapCatching(transform: (Long) -> R): List<Result<R>> {
  * @return 각 요소 처리 결과를 담은 [Result] 리스트
  */
 inline fun <R> FloatArray.mapCatching(transform: (Float) -> R): List<Result<R>> {
-    return map { runCatching { transform(it) } }
+    return map { runCatching { transform(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 }
 
 /**
@@ -487,7 +489,7 @@ inline fun <R> FloatArray.mapCatching(transform: (Float) -> R): List<Result<R>> 
  * @return 각 요소 처리 결과를 담은 [Result] 리스트
  */
 inline fun <R> DoubleArray.mapCatching(transform: (Double) -> R): List<Result<R>> {
-    return map { runCatching { transform(it) } }
+    return map { runCatching { transform(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 }
 
 /**
@@ -501,7 +503,7 @@ inline fun <R> DoubleArray.mapCatching(transform: (Double) -> R): List<Result<R>
  * @return 각 요소 처리 결과를 담은 [Result] 리스트
  */
 inline fun <T> Array<T>.forEachCatching(action: (T) -> Unit): List<Result<Unit>> =
-    map { runCatching { action(it) } }
+    map { runCatching { action(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 
 /**
  * 배열의 각 요소에 [action] 을 수행하며,
@@ -514,7 +516,7 @@ inline fun <T> Array<T>.forEachCatching(action: (T) -> Unit): List<Result<Unit>>
  * @return 각 요소 처리 결과를 담은 [Result] 리스트
  */
 inline fun CharArray.forEachCatching(action: (Char) -> Unit): List<Result<Unit>> =
-    map { runCatching { action(it) } }
+    map { runCatching { action(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 
 /**
  * 배열의 각 요소에 [action] 을 수행하며,
@@ -527,7 +529,7 @@ inline fun CharArray.forEachCatching(action: (Char) -> Unit): List<Result<Unit>>
  * @return 각 요소 처리 결과를 담은 [Result] 리스트
  */
 inline fun ByteArray.forEachCatching(action: (Byte) -> Unit): List<Result<Unit>> =
-    map { runCatching { action(it) } }
+    map { runCatching { action(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 
 /**
  * 배열의 각 요소에 [action] 을 수행하며,
@@ -540,7 +542,7 @@ inline fun ByteArray.forEachCatching(action: (Byte) -> Unit): List<Result<Unit>>
  * @return 각 요소 처리 결과를 담은 [Result] 리스트
  */
 inline fun ShortArray.forEachCatching(action: (Short) -> Unit): List<Result<Unit>> =
-    map { runCatching { action(it) } }
+    map { runCatching { action(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 
 /**
  * 배열의 각 요소에 [action] 을 수행하며,
@@ -553,7 +555,7 @@ inline fun ShortArray.forEachCatching(action: (Short) -> Unit): List<Result<Unit
  * @return 각 요소 처리 결과를 담은 [Result] 리스트
  */
 inline fun IntArray.forEachCatching(action: (Int) -> Unit): List<Result<Unit>> =
-    map { runCatching { action(it) } }
+    map { runCatching { action(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 
 /**
  * 배열의 각 요소에 [action] 을 수행하며,
@@ -566,7 +568,7 @@ inline fun IntArray.forEachCatching(action: (Int) -> Unit): List<Result<Unit>> =
  * @return 각 요소 처리 결과를 담은 [Result] 리스트
  */
 inline fun LongArray.forEachCatching(action: (Long) -> Unit): List<Result<Unit>> =
-    map { runCatching { action(it) } }
+    map { runCatching { action(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 
 /**
  * 배열의 각 요소에 [action] 을 수행하며,
@@ -579,7 +581,7 @@ inline fun LongArray.forEachCatching(action: (Long) -> Unit): List<Result<Unit>>
  * @return 각 요소 처리 결과를 담은 [Result] 리스트
  */
 inline fun FloatArray.forEachCatching(action: (Float) -> Unit): List<Result<Unit>> =
-    map { runCatching { action(it) } }
+    map { runCatching { action(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 
 /**
  * 배열의 각 요소에 [action] 을 수행하며,
@@ -592,7 +594,7 @@ inline fun FloatArray.forEachCatching(action: (Float) -> Unit): List<Result<Unit
  * @return 각 요소 처리 결과를 담은 [Result] 리스트
  */
 inline fun DoubleArray.forEachCatching(action: (Double) -> Unit): List<Result<Unit>> =
-    map { runCatching { action(it) } }
+    map { runCatching { action(it) }.onFailure { e -> if (e is CancellationException) throw e } }
 
 /**
  * 배열의 시작 부분부터 연속으로 등장하는 0 값의 개수를 반환합니다.

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/AssertSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/AssertSupport.kt
@@ -1,13 +1,13 @@
 /**
- * JVM `assert` 기반의 경량 assertion 유틸리티 모음입니다.
+ * `require`/`check` 기반의 경량 assertion 유틸리티 모음입니다.
  *
  * ## 동작/계약
- * - 모든 함수는 Kotlin/JVM의 `assert(...) { ... }`를 사용합니다.
- * - JVM assertions가 비활성화된 경우(기본), 검증이 수행되지 않을 수 있습니다. 필요 시 `-ea` 옵션을 사용하세요.
- * - 실패 시 기본적으로 [AssertionError]가 발생합니다.
+ * - 모든 함수는 Kotlin 표준 라이브러리의 `require(...)` / `check(...)` 를 사용합니다.
+ * - JVM assertions(-ea) 플래그와 무관하게 **항상** 검증이 수행됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  *
- * **주의**: JVM `-ea` (enable assertions) 플래그 없이 실행하면 모든 검증이 무시됩니다.
- * 프로덕션 환경에서의 검증에는 `RequireSupport`의 함수를 사용하세요.
+ * **참고**: 프로덕션 코드에서 계약 검증이 필요한 경우 이 파일의 함수를 사용하세요.
+ * `RequireSupport`의 함수도 동일한 목적으로 사용할 수 있습니다.
  */
 @file:OptIn(ExperimentalContracts::class)
 @file:Suppress("NOTHING_TO_INLINE")
@@ -21,12 +21,9 @@ import kotlin.contracts.contract
  * null이 아닌 값을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  * - Kotlin contracts를 사용하여 스마트 캐스트 힌트를 제공합니다.
- *
- * **주의**: JVM `-ea` (enable assertions) 플래그 없이 실행하면 모든 검증이 무시됩니다.
- * 프로덕션 환경에서의 검증에는 `RequireSupport`의 함수를 사용하세요.
  *
  * ```kotlin
  * val value: String? = "hello"
@@ -38,16 +35,16 @@ inline fun <T: Any> T?.assertNotNull(parameterName: String): T {
     contract {
         returns() implies (this@assertNotNull != null)
     }
-    assert(this != null) { "$parameterName[$this] must not be null." }
-    return this!!
+    require(this != null) { "$parameterName[$this] must not be null." }
+    return this
 }
 
 /**
  * 값이 null임을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  *
  * ```kotlin
  * val value: String? = null
@@ -58,7 +55,7 @@ inline fun <T: Any> T?.assertNull(parameterName: String): T? {
     contract {
         returns() implies (this@assertNull == null)
     }
-    assert(this == null) { "$parameterName[$this] must be null." }
+    require(this == null) { "$parameterName[$this] must be null." }
     return this
 }
 
@@ -66,8 +63,8 @@ inline fun <T: Any> T?.assertNull(parameterName: String): T? {
  * null이 아니고 빈 문자열이 아님을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  * - Kotlin contracts를 사용하여 스마트 캐스트 힌트를 제공합니다.
  *
  * ```kotlin
@@ -81,7 +78,7 @@ inline fun <T: CharSequence> T?.assertNotEmpty(parameterName: String): T {
         returns() implies (this@assertNotEmpty != null)
     }
     val self = this.assertNotNull(parameterName)
-    assert(self.isNotEmpty()) { "$parameterName[$self] must not be empty." }
+    require(self.isNotEmpty()) { "$parameterName[$self] must not be empty." }
     return self
 }
 
@@ -89,8 +86,8 @@ inline fun <T: CharSequence> T?.assertNotEmpty(parameterName: String): T {
  * null이거나 빈 문자열임을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  * - Kotlin contracts를 사용하여 스마트 캐스트 힌트를 제공합니다.
  *
  * ```kotlin
@@ -104,7 +101,7 @@ inline fun <T: CharSequence> T?.assertNullOrEmpty(parameterName: String): T? {
     contract {
         returns() implies (this@assertNullOrEmpty == null)
     }
-    assert(this.isNullOrEmpty()) { "$parameterName[$this] must be null or empty." }
+    require(this.isNullOrEmpty()) { "$parameterName[$this] must be null or empty." }
     return this
 }
 
@@ -112,8 +109,8 @@ inline fun <T: CharSequence> T?.assertNullOrEmpty(parameterName: String): T? {
  * null이 아니고 공백이 아닌 문자열임을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  * - Kotlin contracts를 사용하여 스마트 캐스트 힌트를 제공합니다.
  *
  * ```kotlin
@@ -127,7 +124,7 @@ inline fun <T: CharSequence> T?.assertNotBlank(parameterName: String): T {
         returns() implies (this@assertNotBlank != null)
     }
     val self = this.assertNotNull(parameterName)
-    assert(self.isNotBlank()) { "$parameterName[$self] must not be blank." }
+    require(self.isNotBlank()) { "$parameterName[$self] must not be blank." }
     return self
 }
 
@@ -135,8 +132,8 @@ inline fun <T: CharSequence> T?.assertNotBlank(parameterName: String): T {
  * null이거나 공백 문자열임을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  * - Kotlin contracts를 사용하여 스마트 캐스트 힌트를 제공합니다.
  *
  * ```kotlin
@@ -150,7 +147,7 @@ inline fun <T: CharSequence> T?.assertNullOrBlank(parameterName: String): T? {
     contract {
         returns() implies (this@assertNullOrBlank == null)
     }
-    assert(this.isNullOrBlank()) { "$parameterName[$this] must be null or blank." }
+    require(this.isNullOrBlank()) { "$parameterName[$this] must be null or blank." }
     return this
 }
 
@@ -158,8 +155,8 @@ inline fun <T: CharSequence> T?.assertNullOrBlank(parameterName: String): T? {
  * 지정한 문자열을 포함함을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  *
  * ```kotlin
  * val text: String? = "hello world"
@@ -168,7 +165,7 @@ inline fun <T: CharSequence> T?.assertNullOrBlank(parameterName: String): T? {
  */
 inline fun <T: CharSequence> T?.assertContains(other: CharSequence, parameterName: String): T {
     this.assertNotNull(parameterName)
-    assert(this.contains(other)) { "$parameterName[$this] must contain $other" }
+    require(this.contains(other)) { "$parameterName[$this] must contain $other" }
     return this
 }
 
@@ -176,8 +173,8 @@ inline fun <T: CharSequence> T?.assertContains(other: CharSequence, parameterNam
  * 지정한 접두사로 시작함을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  *
  * ```kotlin
  * val text: String? = "hello world"
@@ -190,7 +187,7 @@ inline fun <T: CharSequence> T?.assertStartsWith(
     ignoreCase: Boolean = false,
 ): T {
     this.assertNotNull(parameterName)
-    assert(this.startsWith(prefix, ignoreCase)) { "$parameterName[$this] must start with $prefix" }
+    require(this.startsWith(prefix, ignoreCase)) { "$parameterName[$this] must start with $prefix" }
     return this
 }
 
@@ -198,8 +195,8 @@ inline fun <T: CharSequence> T?.assertStartsWith(
  * 지정한 접미사로 끝남을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  *
  * ```kotlin
  * val text: String? = "hello world"
@@ -212,7 +209,7 @@ inline fun <T: CharSequence> T?.assertEndsWith(
     ignoreCase: Boolean = false,
 ): T {
     this.assertNotNull(parameterName)
-    assert(this.endsWith(suffix, ignoreCase)) { "$parameterName[$this] must end with $suffix" }
+    require(this.endsWith(suffix, ignoreCase)) { "$parameterName[$this] must end with $suffix" }
     return this
 }
 
@@ -220,8 +217,8 @@ inline fun <T: CharSequence> T?.assertEndsWith(
  * 값이 예상값과 같음을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  *
  * ```kotlin
  * val value = 5
@@ -229,15 +226,15 @@ inline fun <T: CharSequence> T?.assertEndsWith(
  * ```
  */
 inline fun <T> T.assertEquals(expected: T, parameterName: String): T = apply {
-    assert(this == expected) { "$parameterName[$this] must be equal to $expected" }
+    require(this == expected) { "$parameterName[$this] must be equal to $expected" }
 }
 
 /**
  * 값이 지정한 값보다 큼을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  *
  * ```kotlin
  * val value = 10
@@ -245,15 +242,15 @@ inline fun <T> T.assertEquals(expected: T, parameterName: String): T = apply {
  * ```
  */
 inline fun <T: Comparable<T>> T.assertGt(expected: T, parameterName: String): T = apply {
-    assert(this > expected) { "$parameterName[$this] must be greater than $expected." }
+    require(this > expected) { "$parameterName[$this] must be greater than $expected." }
 }
 
 /**
  * 값이 지정한 값보다 크거나 같음을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  *
  * ```kotlin
  * val value = 5
@@ -261,15 +258,15 @@ inline fun <T: Comparable<T>> T.assertGt(expected: T, parameterName: String): T 
  * ```
  */
 inline fun <T: Comparable<T>> T.assertGe(expected: T, parameterName: String): T = apply {
-    assert(this >= expected) { "$parameterName[$this] must be greater than or equal to $expected." }
+    require(this >= expected) { "$parameterName[$this] must be greater than or equal to $expected." }
 }
 
 /**
  * 값이 지정한 값보다 작음을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  *
  * ```kotlin
  * val value = 3
@@ -277,15 +274,15 @@ inline fun <T: Comparable<T>> T.assertGe(expected: T, parameterName: String): T 
  * ```
  */
 inline fun <T: Comparable<T>> T.assertLt(expected: T, parameterName: String): T = apply {
-    assert(this < expected) { "$parameterName[$this] must be less than $expected." }
+    require(this < expected) { "$parameterName[$this] must be less than $expected." }
 }
 
 /**
  * 값이 지정한 값보다 작거나 같음을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  *
  * ```kotlin
  * val value = 5
@@ -293,15 +290,15 @@ inline fun <T: Comparable<T>> T.assertLt(expected: T, parameterName: String): T 
  * ```
  */
 inline fun <T: Comparable<T>> T.assertLe(expected: T, parameterName: String): T = apply {
-    assert(this <= expected) { "$parameterName[$this] must be less than or equal to $expected." }
+    require(this <= expected) { "$parameterName[$this] must be less than or equal to $expected." }
 }
 
 /**
  * 값이 지정한 닫힌 범위 내에 있음을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  * - 범위는 `start..endInclusive` 형태의 닫힌 범위입니다.
  *
  * ```kotlin
@@ -310,15 +307,15 @@ inline fun <T: Comparable<T>> T.assertLe(expected: T, parameterName: String): T 
  * ```
  */
 inline fun <T: Comparable<T>> T.assertInRange(start: T, endInclusive: T, parameterName: String) = apply {
-    assert(this in start..endInclusive) { "$parameterName[$this] must be in range ($start .. $endInclusive)" }
+    require(this in start..endInclusive) { "$parameterName[$this] must be in range ($start .. $endInclusive)" }
 }
 
 /**
  * 값이 지정한 열린 범위 내에 있음을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  * - 범위는 `start..<endExclusive` 형태의 열린 범위입니다.
  *
  * ```kotlin
@@ -327,15 +324,15 @@ inline fun <T: Comparable<T>> T.assertInRange(start: T, endInclusive: T, paramet
  * ```
  */
 inline fun <T: Comparable<T>> T.assertInOpenRange(start: T, endExclusive: T, name: String): T = apply {
-    assert(this in start..<endExclusive) { "$start <= $name[$this] < $endExclusive" }
+    require(this in start..<endExclusive) { "$start <= $name[$this] < $endExclusive" }
 }
 
 /**
  * 값이 0 이상임을 보장합니다. 내부적으로 `toDouble()`로 비교합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  * - NaN, Infinity 등의 특수 값에 주의해야 합니다.
  *
  * ```kotlin
@@ -351,8 +348,8 @@ inline fun <T> T.assertZeroOrPositiveNumber(parameterName: String): T where T: N
  * 값이 0 초과임을 보장합니다. 내부적으로 `toDouble()`로 비교합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  * - NaN, Infinity 등의 특수 값에 주의해야 합니다.
  *
  * ```kotlin
@@ -368,8 +365,8 @@ inline fun <T> T.assertPositiveNumber(parameterName: String): T where T: Number,
  * 값이 0 이하임을 보장합니다. 내부적으로 `toDouble()`로 비교합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  * - NaN, Infinity 등의 특수 값에 주의해야 합니다.
  *
  * ```kotlin
@@ -385,8 +382,8 @@ inline fun <T> T.assertZeroOrNegativeNumber(parameterName: String): T where T: N
  * 값이 0 미만임을 보장합니다. 내부적으로 `toDouble()`로 비교합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  * - NaN, Infinity 등의 특수 값에 주의해야 합니다.
  *
  * ```kotlin
@@ -402,9 +399,9 @@ inline fun <T> T.assertNegativeNumber(parameterName: String): T where T: Number,
  * 컬렉션이 null이 아니고 비어있지 않음을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
  * - null이거나 비어있으면 실패합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  *
  * ```kotlin
  * val list: List<Int>? = listOf(1, 2, 3)
@@ -412,16 +409,16 @@ inline fun <T> T.assertNegativeNumber(parameterName: String): T where T: Number,
  * ```
  */
 inline fun <T> Collection<T>?.assertNotEmpty(parameterName: String) = apply {
-    assert(!this.isNullOrEmpty()) { "$parameterName[$this] must not be null or empty." }
+    require(!this.isNullOrEmpty()) { "$parameterName[$this] must not be null or empty." }
 }
 
 /**
  * 맵이 null이 아니고 비어있지 않음을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
  * - null이거나 비어있으면 실패합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  *
  * ```kotlin
  * val map: Map<String, Int>? = mapOf("a" to 1)
@@ -429,16 +426,16 @@ inline fun <T> Collection<T>?.assertNotEmpty(parameterName: String) = apply {
  * ```
  */
 inline fun <K, V> Map<K, V>?.assertNotEmpty(parameterName: String) = apply {
-    assert(!this.isNullOrEmpty()) { "$parameterName must not be null or empty." }
+    require(!this.isNullOrEmpty()) { "$parameterName must not be null or empty." }
 }
 
 /**
  * 맵이 null이 아니고 비어있지 않으며, 지정한 키를 포함함을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
  * - null이거나 비어있거나 키가 없으면 실패합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  *
  * ```kotlin
  * val map: Map<String, Int>? = mapOf("key" to 1)
@@ -447,7 +444,7 @@ inline fun <K, V> Map<K, V>?.assertNotEmpty(parameterName: String) = apply {
  */
 inline fun <K, V> Map<K, V>?.assertHasKey(key: K, parameterName: String): Map<K, V> {
     assertNotEmpty(parameterName)
-    assert(this!!.containsKey(key)) { "$parameterName must contain key $key" }
+    require(this!!.containsKey(key)) { "$parameterName must contain key $key" }
     return this
 }
 
@@ -455,9 +452,9 @@ inline fun <K, V> Map<K, V>?.assertHasKey(key: K, parameterName: String): Map<K,
  * 맵이 null이 아니고 비어있지 않으며, 지정한 값을 포함함을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
  * - null이거나 비어있거나 값이 없으면 실패합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  *
  * ```kotlin
  * val map: Map<String, Int>? = mapOf("key" to 1)
@@ -466,7 +463,7 @@ inline fun <K, V> Map<K, V>?.assertHasKey(key: K, parameterName: String): Map<K,
  */
 inline fun <K, V> Map<K, V>?.assertHasValue(value: V, parameterName: String): Map<K, V> {
     assertNotEmpty(parameterName)
-    assert(this!!.containsValue(value)) { "$parameterName must contain value $value" }
+    require(this!!.containsValue(value)) { "$parameterName must contain value $value" }
     return this
 }
 
@@ -474,9 +471,9 @@ inline fun <K, V> Map<K, V>?.assertHasValue(value: V, parameterName: String): Ma
  * 맵이 null이 아니고 비어있지 않으며, 지정한 키-값 쌍을 포함함을 보장합니다.
  *
  * ## 동작/계약
- * - `assert` 기반으로 동작하며, JVM assertions가 활성화되어야 합니다.
+ * - `require` 기반으로 동작하며, JVM assertions 플래그와 무관하게 항상 검증됩니다.
  * - null이거나 비어있거나 키-값 쌍이 없으면 실패합니다.
- * - 실패 시 [AssertionError]가 발생합니다.
+ * - 실패 시 [IllegalArgumentException]이 발생합니다.
  *
  * ```kotlin
  * val map: Map<String, Int>? = mapOf("key" to 1)
@@ -485,6 +482,6 @@ inline fun <K, V> Map<K, V>?.assertHasValue(value: V, parameterName: String): Ma
  */
 inline fun <K, V> Map<K, V>?.assertContains(key: K, value: V, parameterName: String): Map<K, V> {
     assertNotEmpty(parameterName)
-    assert(this!![key] == value) { "$parameterName must contain ($key, $value)" }
+    require(this!![key] == value) { "$parameterName must contain ($key, $value)" }
     return this
 }

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/ClassSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/ClassSupport.kt
@@ -85,9 +85,15 @@ fun <T: Any> KClass<T>.newInstanceOrNull(): T? = java.newInstanceOrNull()
 /**
  * 지정한 수형의 인스턴스를 새로 생성합니다. 실패 시에는 null을 반환합니다.
  *
+ * **보안 경고**: [qualifiedName]은 신뢰할 수 없는 외부 입력(사용자 입력, API 파라미터 등)으로부터
+ * 받아서는 안 됩니다. 임의 클래스 인스턴스화는 원격 코드 실행(RCE) 등의 보안 취약점으로 이어질 수 있습니다.
+ * 반드시 허용된 클래스 이름 목록(allowlist) 검증 후 호출하세요.
+ *
  * ```
  * val instance = newInstanceOrNull("java.lang.String") // ""
  * ```
+ *
+ * @throws SecurityException 보안 관리자가 클래스 로딩을 허용하지 않는 경우
  */
 @Suppress("UNCHECKED_CAST")
 fun <T: Any> newInstanceOrNull(

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/TimeoutSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/TimeoutSupport.kt
@@ -1,9 +1,11 @@
 package io.bluetape4k.support
 
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import kotlin.time.Duration
 
 /**
@@ -99,10 +101,16 @@ inline fun <T> asyncRunWithTimeout(timeout: Duration, crossinline action: () -> 
  * @param action 실행할 block
  * @return [action]의 실행 결과, [timeoutMillis] 시간 내에 종료되지 않으면 null
  */
-inline fun <T: Any> withTimeoutOrNull(timeoutMillis: Long, crossinline action: () -> T): T? =
-    runCatching {
+inline fun <T: Any> withTimeoutOrNull(timeoutMillis: Long, crossinline action: () -> T): T? {
+    return try {
         asyncRunWithTimeout(timeoutMillis, action = action).get()
-    }.getOrNull()
+    } catch (e: ExecutionException) {
+        val cause = e.cause
+        if (cause is TimeoutException) null else throw e
+    } catch (e: TimeoutException) {
+        null
+    }
+}
 
 /**
  * Timeout 내에서 [action]을 실행합니다. [action]이 [timeout] 시간 내에 종료되지 않으면 null 을 반환합니다.

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/utils/Networkx.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/utils/Networkx.kt
@@ -205,7 +205,11 @@ object Networkx: KLogging() {
     fun ipToIpBlock(ip: String, prefixLen: Int?): Pair<Int, Int> {
         val arr: List<String> = ip.split('.')
 
-        val pLen = if (arr.size != 4 && prefixLen == null) arr.size * 8 else prefixLen!!
+        val pLen = when {
+            prefixLen != null -> prefixLen
+            arr.size == 4    -> 32
+            else             -> arr.size * 8
+        }
         pLen.requireInRange(0, 32, "prefixLen")
 
         val netIp = ipToInt(arr.padTo(4, "0").joinToString(separator = "."))

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/utils/Runtimex.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/utils/Runtimex.kt
@@ -99,8 +99,6 @@ object Runtimex: KLogging() {
     val usedMemory: Long
         get() = totalMemory - freeMemory
 
-    private const val TWO_GIGA = 2_000_000_000
-
     /**
      * 가비지 컬렉션을 유도하여 메모리를 정리합니다.
      *
@@ -109,14 +107,6 @@ object Runtimex: KLogging() {
      * ```
      */
     fun compactMemory() {
-        try {
-            val unused = arrayListOf<ByteArray>()
-            repeat(128) {
-                unused.add(ByteArray(TWO_GIGA))
-            }
-        } catch (ignored: OutOfMemoryError) {
-            // NOP
-        }
         log.info { "Start Compact memory..." }
         System.gc()
     }

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/collections/CollectionSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/collections/CollectionSupportTest.kt
@@ -63,8 +63,8 @@ class CollectionSupportTest {
         list.swap(1, 1)
         list shouldContainSame listOf(3, 2, 1)
 
-        assertThrows<AssertionError> { list.swap(-1, 1) }
-        assertThrows<AssertionError> { list.swap(0, 3) }
+        assertThrows<IllegalArgumentException> { list.swap(-1, 1) }
+        assertThrows<IllegalArgumentException> { list.swap(0, 3) }
     }
 
     @Test

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/CompletableFutureSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/CompletableFutureSupportTest.kt
@@ -157,4 +157,46 @@ class CompletableFutureSupportTest {
         futureOf { completableFutureOf(42) }.dereference().get() shouldBeEqualTo 42
         futureOf { failedCompletableFutureOf<Int>(RuntimeException("boom")) }.dereference().shouldCauseBe<RuntimeException>()
     }
+
+    @Test
+    fun `join with defaultValue returns result when completed in time`() {
+        // H2 수정 검증: timeout 내 완료 시 정상 결과 반환
+        val future = futureOf { Thread.sleep(50); 42 }
+        future.join(500.milliseconds, 0) shouldBeEqualTo 42
+    }
+
+    @Test
+    fun `join with defaultValue returns default on timeout`() {
+        // H2 수정 검증: timeout 시 defaultValue 반환
+        val future = futureOf { Thread.sleep(2000); 42 }
+        future.join(100.milliseconds, -1) shouldBeEqualTo -1
+    }
+
+    @Test
+    fun `join with defaultValue propagates non-timeout exceptions`() {
+        // H2 수정 검증: TimeoutException 이외의 예외는 rethrow
+        val future = failedCompletableFutureOf<Int>(IllegalStateException("비즈니스 오류"))
+        assertFails { future.join(500.milliseconds, 0) }
+    }
+
+    @Test
+    fun `joinOrNull returns result when completed in time`() {
+        // H2 수정 검증: timeout 내 완료 시 정상 결과 반환
+        val future = futureOf { Thread.sleep(50); 42 }
+        future.joinOrNull(500.milliseconds) shouldBeEqualTo 42
+    }
+
+    @Test
+    fun `joinOrNull returns null on timeout`() {
+        // H2 수정 검증: timeout 시 null 반환
+        val future = futureOf { Thread.sleep(2000); 42 }
+        future.joinOrNull(100.milliseconds) shouldBeEqualTo null
+    }
+
+    @Test
+    fun `joinOrNull propagates non-timeout exceptions`() {
+        // H2 수정 검증: TimeoutException 이외의 예외는 rethrow
+        val future = failedCompletableFutureOf<Int>(IllegalStateException("비즈니스 오류"))
+        assertFails { future.joinOrNull(500.milliseconds) }
+    }
 }

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/ExecutorSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/ExecutorSupportTest.kt
@@ -31,7 +31,7 @@ class ExecutorSupportTest {
 
     @Test
     fun `withWorkStealingPool 은 parallelism 0이면 예외`() {
-        assertThrows<AssertionError> {
+        assertThrows<IllegalArgumentException> {
             withWorkStealingPool(parallelism = 0) { 1 }.get()
         }
     }

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/WorkStealingPoolExamples.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/WorkStealingPoolExamples.kt
@@ -14,7 +14,7 @@ class WorkStealingPoolExamples {
 
     @Test
     fun `invlid parallelism value`() {
-        assertFailsWith<AssertionError> {
+        assertFailsWith<IllegalArgumentException> {
             withWorkStealingPool(0) { 42L }.join()
         }
     }

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/javatimes/QuarterTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/javatimes/QuarterTest.kt
@@ -29,15 +29,15 @@ class QuarterTest {
             Quarter.ofMonth(monthOfYear) shouldBeEqualTo Quarter.of((monthOfYear - 1) / 3 + 1)
         }
 
-        assertFailsWith<AssertionError> {
+        assertFailsWith<IllegalArgumentException> {
             Quarter.ofMonth(0)
         }
 
-        assertFailsWith<AssertionError> {
+        assertFailsWith<IllegalArgumentException> {
             Quarter.ofMonth(-1)
         }
 
-        assertFailsWith<AssertionError> {
+        assertFailsWith<IllegalArgumentException> {
             Quarter.ofMonth(13)
         }
     }

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/AssertSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/AssertSupportTest.kt
@@ -1,8 +1,6 @@
 package io.bluetape4k.support
 
 import io.bluetape4k.logging.KLogging
-import org.amshove.kluent.shouldBeFalse
-import org.amshove.kluent.shouldBeTrue
 import org.junit.jupiter.api.Test
 
 class AssertSupportTest {
@@ -10,126 +8,123 @@ class AssertSupportTest {
     companion object: KLogging()
 
     @Test
-    fun `assertion status flags`() {
-        AssertSupportTest::class.java.classLoader.setClassAssertionStatus(
-            AssertSupportTest::class.qualifiedName, false)
-        AssertSupportTest::class.java.desiredAssertionStatus().shouldBeFalse()
-
-        class TestClass
-        TestClass::class.java.classLoader.setClassAssertionStatus(TestClass::class.qualifiedName, true)
-        TestClass::class.java.desiredAssertionStatus().shouldBeTrue()
-    }
-
-    @Test
     fun `assert null and not-null checks`() {
         var x: Long? = null
-        shouldFailAssert { x.assertNotNull("x").toByteArray() }
+        shouldFailRequire { x.assertNotNull("x").toByteArray() }
         x = 12L; x.assertNotNull("x")
 
         val s: String? = null
         s.assertNull("x")
-        shouldFailAssert { "hello".assertNull("x") }
+        shouldFailRequire { "hello".assertNull("x") }
     }
 
     @Test
     fun `assert string emptiness and blankness`() {
         var x: String? = null
-        shouldFailAssert { x.assertNotEmpty("x") }
-        x = ""; shouldFailAssert { x.assertNotEmpty("x") }
+        shouldFailRequire { x.assertNotEmpty("x") }
+        x = ""; shouldFailRequire { x.assertNotEmpty("x") }
         x = "    "; x.assertNotEmpty("x")
         x = "  \t "; x.assertNotEmpty("x")
 
-        x = null; shouldFailAssert { x.assertNotBlank("x") }
-        x = ""; shouldFailAssert { x.assertNotBlank("x") }
-        x = "    "; shouldFailAssert { x.assertNotBlank("x") }
-        x = "  \t "; shouldFailAssert { x.assertNotBlank("x") }
+        x = null; shouldFailRequire { x.assertNotBlank("x") }
+        x = ""; shouldFailRequire { x.assertNotBlank("x") }
+        x = "    "; shouldFailRequire { x.assertNotBlank("x") }
+        x = "  \t "; shouldFailRequire { x.assertNotBlank("x") }
     }
 
     @Test
     fun `assert null-or-empty and null-or-blank`() {
         val empty: String? = null
         empty.assertNullOrEmpty("x"); "".assertNullOrEmpty("x")
-        shouldFailAssert { "hello".assertNullOrEmpty("x") }
+        shouldFailRequire { "hello".assertNullOrEmpty("x") }
 
         empty.assertNullOrBlank("x"); "".assertNullOrBlank("x"); "   ".assertNullOrBlank("x")
-        shouldFailAssert { "hello".assertNullOrBlank("x") }
+        shouldFailRequire { "hello".assertNullOrBlank("x") }
     }
 
     @Test
     fun `assert string contains startsWith endsWith`() {
         "hello world".assertContains("world", "x")
-        shouldFailAssert { "hello".assertContains("world", "x") }
+        shouldFailRequire { "hello".assertContains("world", "x") }
 
         "hello world".assertStartsWith("hello", "x")
-        shouldFailAssert { "hello world".assertStartsWith("world", "x") }
+        shouldFailRequire { "hello world".assertStartsWith("world", "x") }
         "Hello World".assertStartsWith("hello", "x", ignoreCase = true)
 
         "hello world".assertEndsWith("world", "x")
-        shouldFailAssert { "hello world".assertEndsWith("hello", "x") }
+        shouldFailRequire { "hello world".assertEndsWith("hello", "x") }
         "Hello World".assertEndsWith("WORLD", "x", ignoreCase = true)
     }
 
     @Test
     fun `assert comparable ordering and equality`() {
-        42.assertEquals(42, "x"); shouldFailAssert { 42.assertEquals(99, "x") }
+        42.assertEquals(42, "x"); shouldFailRequire { 42.assertEquals(99, "x") }
 
         10.assertGt(5, "x")
-        shouldFailAssert { 5.assertGt(10, "x") }; shouldFailAssert { 5.assertGt(5, "x") }
+        shouldFailRequire { 5.assertGt(10, "x") }; shouldFailRequire { 5.assertGt(5, "x") }
 
         10.assertGe(5, "x"); 5.assertGe(5, "x")
-        shouldFailAssert { 4.assertGe(5, "x") }
+        shouldFailRequire { 4.assertGe(5, "x") }
 
         5.assertLt(10, "x")
-        shouldFailAssert { 10.assertLt(5, "x") }; shouldFailAssert { 5.assertLt(5, "x") }
+        shouldFailRequire { 10.assertLt(5, "x") }; shouldFailRequire { 5.assertLt(5, "x") }
 
         5.assertLe(10, "x"); 5.assertLe(5, "x")
-        shouldFailAssert { 6.assertLe(5, "x") }
+        shouldFailRequire { 6.assertLe(5, "x") }
     }
 
     @Test
     fun `assert in range and in open range`() {
         5.assertInRange(1, 10, "x"); 1.assertInRange(1, 10, "x"); 10.assertInRange(1, 10, "x")
-        shouldFailAssert { 0.assertInRange(1, 10, "x") }; shouldFailAssert { 11.assertInRange(1, 10, "x") }
+        shouldFailRequire { 0.assertInRange(1, 10, "x") }; shouldFailRequire { 11.assertInRange(1, 10, "x") }
 
         5.assertInOpenRange(1, 10, "x"); 1.assertInOpenRange(1, 10, "x")
-        shouldFailAssert { 10.assertInOpenRange(1, 10, "x") }
+        shouldFailRequire { 10.assertInOpenRange(1, 10, "x") }
     }
 
     @Test
     fun `assert number sign variants`() {
         1.assertPositiveNumber("x"); 0.1.assertPositiveNumber("x")
-        shouldFailAssert { 0.assertPositiveNumber("x") }; shouldFailAssert { (-1).assertPositiveNumber("x") }
+        shouldFailRequire { 0.assertPositiveNumber("x") }; shouldFailRequire { (-1).assertPositiveNumber("x") }
 
         0.assertZeroOrPositiveNumber("x"); 1.assertZeroOrPositiveNumber("x")
-        shouldFailAssert { (-1).assertZeroOrPositiveNumber("x") }
+        shouldFailRequire { (-1).assertZeroOrPositiveNumber("x") }
 
         (-1).assertNegativeNumber("x")
-        shouldFailAssert { 0.assertNegativeNumber("x") }; shouldFailAssert { 1.assertNegativeNumber("x") }
+        shouldFailRequire { 0.assertNegativeNumber("x") }; shouldFailRequire { 1.assertNegativeNumber("x") }
 
         0.assertZeroOrNegativeNumber("x"); (-1).assertZeroOrNegativeNumber("x")
-        shouldFailAssert { 1.assertZeroOrNegativeNumber("x") }
+        shouldFailRequire { 1.assertZeroOrNegativeNumber("x") }
     }
 
     @Test
     fun `assert collection and map not empty`() {
         listOf(1, 2, 3).assertNotEmpty("x")
-        shouldFailAssert { emptyList<Int>().assertNotEmpty("x") }
-        shouldFailAssert { (null as List<Int>?).assertNotEmpty("x") }
+        shouldFailRequire { emptyList<Int>().assertNotEmpty("x") }
+        shouldFailRequire { (null as List<Int>?).assertNotEmpty("x") }
 
         mapOf("a" to 1).assertNotEmpty("x")
-        shouldFailAssert { emptyMap<String, Int>().assertNotEmpty("x") }
-        shouldFailAssert { (null as Map<String, Int>?).assertNotEmpty("x") }
+        shouldFailRequire { emptyMap<String, Int>().assertNotEmpty("x") }
+        shouldFailRequire { (null as Map<String, Int>?).assertNotEmpty("x") }
     }
 
     @Test
     fun `assert map key and value operations`() {
         mapOf("a" to 1, "b" to 2).assertHasKey("a", "x")
-        shouldFailAssert { mapOf("a" to 1).assertHasKey("b", "x") }
+        shouldFailRequire { mapOf("a" to 1).assertHasKey("b", "x") }
 
         mapOf("a" to 1, "b" to 2).assertHasValue(1, "x")
-        shouldFailAssert { mapOf("a" to 1).assertHasValue(99, "x") }
+        shouldFailRequire { mapOf("a" to 1).assertHasValue(99, "x") }
 
         mapOf("a" to 1, "b" to 2).assertContains("a", 1, "x")
-        shouldFailAssert { mapOf("a" to 1).assertContains("a", 99, "x") }
+        shouldFailRequire { mapOf("a" to 1).assertContains("a", 99, "x") }
+    }
+
+    @Test
+    fun `require 기반으로 항상 검증된다 (JVM -ea 플래그 불필요)`() {
+        // assert() 와 달리 require() 는 JVM 플래그 없이도 항상 실행됨을 확인
+        shouldFailRequire { (null as String?).assertNotNull("x") }
+        shouldFailRequire { "".assertNotEmpty("x") }
+        shouldFailRequire { "  ".assertNotBlank("x") }
     }
 }

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/TimeoutSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/TimeoutSupportTest.kt
@@ -182,4 +182,16 @@ class TimeoutSupportTest: AbstractCoreTest() {
         log.debug { "작업 진행 중: ${isWorking.get()}" }
         isWorking.get().shouldBeFalse()
     }
+
+    @Test
+    fun `withTimeoutOrNull은 timeout 외 예외를 null로 삼키지 않고 전파한다`() {
+        // H1 수정 검증: TimeoutException 이외의 예외는 rethrow 되어야 함
+        assertFailsWith<ExecutionException> {
+            withTimeoutOrNull(1000) {
+                throw IllegalStateException("비즈니스 오류")
+                @Suppress("UNREACHABLE_CODE")
+                "result"
+            }
+        }
+    }
 }

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/utils/NetworkxTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/utils/NetworkxTest.kt
@@ -97,4 +97,19 @@ class NetworkxTest {
             Networkx.ipToIpBlock("10.0.0.0", 33)
         }
     }
+
+    @Test
+    fun `ipToIpBlock은 4-octet IP에서 prefixLen null이면 32를 기본값으로 사용한다`() {
+        // C1 수정 검증: arr.size==4 && prefixLen==null 이면 NPE 대신 32를 기본값으로 사용
+        val (netIp, mask) = Networkx.ipToIpBlock("192.168.0.1", null)
+        netIp shouldBeEqualTo Networkx.ipToInt("192.168.0.1")
+        mask shouldBeEqualTo -1  // /32 mask = 0xFFFFFFFF = -1 (Int)
+    }
+
+    @Test
+    fun `ipToIpBlock은 부분 IP에서 prefixLen null이면 octet수 기반 prefix를 사용한다`() {
+        // 2-octet IP: arr.size==2, prefixLen==null → pLen = 16
+        val (_, mask) = Networkx.ipToIpBlock("10.0", null)
+        mask shouldBeEqualTo (-1 shl 16)  // /16 mask
+    }
 }


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: bluetape4k/core 코드 리뷰 지적사항 수정

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### CRITICAL
- `assert()` → `require()`/`check()` 교체 (JVM -ea 없이 no-op 문제)
- `Runtimex.kt`: 256GB 메모리 할당 루프 제거

### HIGH
- `CompletableFutureSupport`: CancellationException 재throw 가드 추가
- `TimeoutSupport`: `withTimeoutOrNull`에서 TimeoutException만 catch

### MEDIUM
- Collections/Sequence/Array: `runCatching` 내 CancellationException 전파 보장
- `ClassSupport`: `newInstanceOrNull` KDoc 보안 경고 추가

## Validation

- bluetape4k-core: 1,563 pass

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #216, head `409d062db857865973425814363af9bfbe9b58bd`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/core-review-issues`
- Labels: `bug`, `documentation`, `chore`, `security`
- State: `MERGED`, merge commit `14960bb05824d0bac127ecda64d646a8091a69d0`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #216 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `14960bb05824d0bac127ecda64d646a8091a69d0`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
