### PR TITLE
fix: data/r2dbc + data/exposed-postgresql 코드 리뷰 지적사항 수정

### DIFF
--- a/data/exposed-postgresql/src/main/kotlin/io/bluetape4k/exposed/postgresql/pgvector/VectorExtensions.kt
+++ b/data/exposed-postgresql/src/main/kotlin/io/bluetape4k/exposed/postgresql/pgvector/VectorExtensions.kt
@@ -57,6 +57,24 @@ fun ExposedConnection<*>.registerVectorType() {
 }
 
 /**
+ * 벡터 거리 연산자를 나타내는 enum 클래스.
+ *
+ * SQL injection을 방지하기 위해 operator를 String 대신 sealed type으로 표현합니다.
+ *
+ * @property sql SQL 연산자 문자열
+ */
+enum class VectorDistanceOperator(val sql: String) {
+    /** 코사인 거리 연산자 */
+    COSINE("<=>"),
+
+    /** L2 유클리드 거리 연산자 */
+    L2("<->"),
+
+    /** 내적(Inner Product) 연산자 */
+    INNER_PRODUCT("<#>"),
+}
+
+/**
  * 코사인 거리 연산자 (`<=>`).
  * PostgreSQL dialect 전용.
  *
@@ -74,7 +92,7 @@ fun ExposedConnection<*>.registerVectorType() {
  */
 fun Column<FloatArray>.cosineDistance(other: Expression<FloatArray>): VectorDistanceOp {
     check(currentDialect is PostgreSQLDialect) { "cosineDistance (<=>) 는 PostgreSQL dialect 에서만 지원됩니다." }
-    return VectorDistanceOp(this, other, "<=>")
+    return VectorDistanceOp(this, other, VectorDistanceOperator.COSINE)
 }
 
 /**
@@ -95,7 +113,7 @@ fun Column<FloatArray>.cosineDistance(other: Expression<FloatArray>): VectorDist
  */
 fun Column<FloatArray>.l2Distance(other: Expression<FloatArray>): VectorDistanceOp {
     check(currentDialect is PostgreSQLDialect) { "l2Distance (<->) 는 PostgreSQL dialect 에서만 지원됩니다." }
-    return VectorDistanceOp(this, other, "<->")
+    return VectorDistanceOp(this, other, VectorDistanceOperator.L2)
 }
 
 /**
@@ -116,7 +134,7 @@ fun Column<FloatArray>.l2Distance(other: Expression<FloatArray>): VectorDistance
  */
 fun Column<FloatArray>.innerProduct(other: Expression<FloatArray>): VectorDistanceOp {
     check(currentDialect is PostgreSQLDialect) { "innerProduct (<#>) 는 PostgreSQL dialect 에서만 지원됩니다." }
-    return VectorDistanceOp(this, other, "<#>")
+    return VectorDistanceOp(this, other, VectorDistanceOperator.INNER_PRODUCT)
 }
 
 /**
@@ -124,18 +142,18 @@ fun Column<FloatArray>.innerProduct(other: Expression<FloatArray>): VectorDistan
  *
  * @property left 왼쪽 벡터 표현식
  * @property right 오른쪽 벡터 표현식
- * @property operator 거리 연산자 문자열 (`<=>`, `<->`, `<#>`)
+ * @property operator 거리 연산자 ([VectorDistanceOperator])
  */
 class VectorDistanceOp(
     private val left: Expression<FloatArray>,
     private val right: Expression<FloatArray>,
-    private val operator: String,
+    private val operator: VectorDistanceOperator,
 ): ExpressionWithColumnType<Double>() {
     override val columnType = DoubleColumnType()
 
     override fun toQueryBuilder(queryBuilder: QueryBuilder) {
         queryBuilder.append(left)
-        queryBuilder.append(" $operator ")
+        queryBuilder.append(" ${operator.sql} ")
         queryBuilder.append(right)
     }
 }

--- a/data/exposed-postgresql/src/main/kotlin/io/bluetape4k/exposed/postgresql/postgis/GeoExtensions.kt
+++ b/data/exposed-postgresql/src/main/kotlin/io/bluetape4k/exposed/postgresql/postgis/GeoExtensions.kt
@@ -237,6 +237,10 @@ class StDWithinOp(
     private val right: Expression<Point>,
     private val distance: Double,
 ): Op<Boolean>() {
+    init {
+        require(distance.isFinite()) { "distance는 유한한 값이어야 합니다. 현재 값: $distance" }
+    }
+
     override fun toQueryBuilder(queryBuilder: QueryBuilder) {
         queryBuilder.append("ST_DWithin(")
         queryBuilder.append(left)
@@ -477,6 +481,10 @@ class GeoDWithinOp(
     private val right: Expression<Geometry>,
     private val distance: Double,
 ): Op<Boolean>() {
+    init {
+        require(distance.isFinite()) { "distance는 유한한 값이어야 합니다. 현재 값: $distance" }
+    }
+
     override fun toQueryBuilder(queryBuilder: QueryBuilder) {
         queryBuilder.append("ST_DWithin(")
         queryBuilder.append(left)

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/core/Delete.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/core/Delete.kt
@@ -103,6 +103,10 @@ private class DeleteValueSpecImpl(
 ): DeleteValueSpec {
     companion object: KLogging()
 
+    init {
+        requireValidIdentifier(table)
+    }
+
     override fun matching(
         where: String?,
         whereParameters: Map<String, Any?>?,

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/core/Insert.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/core/Insert.kt
@@ -184,6 +184,10 @@ internal class InsertValuesSpecImpl(
 ): InsertValuesSpec {
     companion object: KLogging()
 
+    init {
+        requireValidIdentifier(table)
+    }
+
     override val values = mutableMapOf<String, Any?>()
 
     override fun value(
@@ -339,6 +343,11 @@ internal class InsertValuesKeySpecImpl(
     private val idColumn: String,
 ): InsertValuesKeySpec {
     companion object: KLogging()
+
+    init {
+        requireValidIdentifier(table)
+        requireValidIdentifier(idColumn)
+    }
 
     override val values = mutableMapOf<String, Any?>()
 

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/core/SqlIdentifiers.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/core/SqlIdentifiers.kt
@@ -1,0 +1,25 @@
+package io.bluetape4k.r2dbc.core
+
+/**
+ * SQL 식별자(테이블명, 컬럼명 등)의 유효성을 검증하기 위한 정규식.
+ *
+ * 영문자, 숫자, 언더스코어, 점(스키마.테이블 표기)만 허용합니다.
+ */
+private val SQL_IDENTIFIER_PATTERN = Regex("^[A-Za-z_][A-Za-z0-9_.]*$")
+
+/**
+ * SQL 식별자가 유효한지 검사하고, 유효하면 그대로 반환합니다.
+ *
+ * 알파벳, 숫자, 언더스코어(`_`), 점(`.`) 만 허용합니다.
+ * SQL injection을 방지하기 위해 table/column/where 식별자를 SQL 문에 보간하기 전에 반드시 호출해야 합니다.
+ *
+ * @param name 검사할 SQL 식별자 (테이블명, 컬럼명 등)
+ * @return 유효한 식별자 문자열
+ * @throws IllegalArgumentException 허용되지 않는 문자가 포함된 경우
+ */
+internal fun requireValidIdentifier(name: String): String {
+    require(SQL_IDENTIFIER_PATTERN.matches(name)) {
+        "Invalid SQL identifier: '$name'. Only alphanumeric characters, underscores, and dots are allowed."
+    }
+    return name
+}

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/core/Update.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/core/Update.kt
@@ -234,6 +234,10 @@ internal class UpdateValuesSpecImpl(
 ): UpdateValuesSpec {
     companion object: KLogging()
 
+    init {
+        requireValidIdentifier(table)
+    }
+
     override val values = mutableMapOf<String, Any?>()
     override val Update: SetterSpec get() = this
 

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/pool/R2dbcConnectionConfig.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/pool/R2dbcConnectionConfig.kt
@@ -86,7 +86,12 @@ class R2dbcConnectionConfig {
     /** 접속 비밀번호 */
     var password: String? = null
 
-    /** SSL 사용 여부 (기본값: false) */
+    /**
+     * SSL 사용 여부 (기본값: false).
+     *
+     * **주의**: 운영 환경에서는 반드시 `ssl = true`로 설정하세요.
+     * `false`는 개발/로컬 환경 전용이며, 운영 환경에서 `false`를 사용하면 네트워크 구간 데이터가 평문으로 전송됩니다.
+     */
     var ssl: Boolean = false
 
     /** 커넥션 생성 타임아웃 */

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/pool/R2dbcPoolConfig.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/pool/R2dbcPoolConfig.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.r2dbc.pool
 
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireGe
 import io.bluetape4k.support.requireLe
 import io.bluetape4k.support.requireNotBlank
@@ -40,7 +41,7 @@ import java.time.Duration
  * @property acquireRetry 커넥션 획득 재시도 횟수 (기본값: 3)
  * @property backgroundEvictionInterval 백그라운드 만료 검사 주기 (기본값: 1분)
  * @property maxAcquireTime 커넥션 획득 최대 대기 시간 (기본값: 3초)
- * @property maxPendingAcquire 풀 한도 도달 시 대기 큐에 둘 커넥션 획득 요청 수 (기본값: -1, 무제한)
+ * @property maxPendingAcquire 풀 한도 도달 시 대기 큐에 둘 커넥션 획득 요청 수 (기본값: 1000). -1로 설정하면 무제한이 되어 OOM이 발생할 수 있으므로 운영 환경에서는 적절한 값을 지정하세요.
  * @property maxValidationTime 커넥션 검증 최대 대기 시간 (기본값: 2초)
  * @property validationDepth 커넥션 검증 깊이 (기본값: [ValidationDepth.LOCAL])
  * @property validationQuery 커넥션 검증 쿼리. 지정하면 검증마다 DB 왕복이 발생하므로 고처리량 경로에서는 기본값(null)을 권장합니다.
@@ -66,6 +67,11 @@ data class R2dbcPoolConfig(
 ) {
     init {
         validate()
+        if (maxPendingAcquire < 0) {
+            log.warn {
+                "maxPendingAcquire=$maxPendingAcquire (무제한). 고부하 환경에서 OOM이 발생할 수 있습니다. 운영 환경에서는 적절한 양수 값을 설정하세요."
+            }
+        }
     }
 
     /**
@@ -117,8 +123,12 @@ data class R2dbcPoolConfig(
         /** 커넥션 획득 최대 대기 시간 기본값 */
         val DEFAULT_MAX_ACQUIRE_TIME: Duration = Duration.ofSeconds(3)
 
-        /** 풀 한도 도달 시 커넥션 획득 대기 큐 크기 기본값 (-1: 무제한) */
-        const val DEFAULT_MAX_PENDING_ACQUIRE: Int = -1
+        /**
+         * 풀 한도 도달 시 커넥션 획득 대기 큐 크기 기본값 (1000).
+         *
+         * -1로 설정하면 무제한 대기 큐가 생성되어 고부하 환경에서 OOM이 발생할 수 있습니다.
+         */
+        const val DEFAULT_MAX_PENDING_ACQUIRE: Int = 1000
 
         /** 커넥션 검증 최대 대기 시간 기본값 */
         val DEFAULT_MAX_VALIDATION_TIME: Duration = Duration.ofSeconds(2)

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/support/TransactionSupport.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/support/TransactionSupport.kt
@@ -1,11 +1,31 @@
 package io.bluetape4k.r2dbc.support
 
+import io.r2dbc.spi.ConnectionFactory
 import org.springframework.r2dbc.connection.R2dbcTransactionManager
 import org.springframework.r2dbc.core.DatabaseClient
 import org.springframework.transaction.ReactiveTransaction
 import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.reactive.TransactionalOperator
 import org.springframework.transaction.reactive.executeAndAwait
+import java.util.WeakHashMap
+
+/**
+ * [ConnectionFactory] 별 [R2dbcTransactionManager] 캐시.
+ *
+ * 동일한 [ConnectionFactory]에 대해 매 호출마다 새로운 [R2dbcTransactionManager]를 생성하지 않도록
+ * [WeakHashMap]으로 캐싱합니다. [WeakHashMap]을 사용하므로 [ConnectionFactory]가 GC 대상이 되면
+ * 자동으로 캐시에서 제거됩니다.
+ */
+internal val transactionManagerCache = WeakHashMap<ConnectionFactory, R2dbcTransactionManager>()
+
+/**
+ * [ConnectionFactory]에 대응하는 [R2dbcTransactionManager]를 캐시에서 조회하거나 새로 생성합니다.
+ */
+@PublishedApi
+internal fun ConnectionFactory.getOrCreateTransactionManager(): R2dbcTransactionManager =
+    synchronized(transactionManagerCache) {
+        transactionManagerCache.getOrPut(this) { R2dbcTransactionManager(this) }
+    }
 
 /**
  * R2DBC 트랜잭션 환경 하에서 suspend 함수를 실행합니다.
@@ -42,7 +62,7 @@ suspend inline fun <T: Any> DatabaseClient.withTransactionSuspend(
     transactionDefinition: TransactionDefinition = TransactionDefinition.withDefaults(),
     crossinline block: suspend (tx: ReactiveTransaction) -> T?,
 ): T? {
-    val tm = R2dbcTransactionManager(this.connectionFactory)
+    val tm = this.connectionFactory.getOrCreateTransactionManager()
 
     return TransactionalOperator
         .create(tm, transactionDefinition)

--- a/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/core/SqlIdentifiersTest.kt
+++ b/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/core/SqlIdentifiersTest.kt
@@ -1,0 +1,80 @@
+package io.bluetape4k.r2dbc.core
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldThrow
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+/**
+ * [requireValidIdentifier] SQL 식별자 허용목록 검증 테스트.
+ *
+ * 영문자·숫자·언더스코어·점(스키마.테이블 표기)만 허용하며,
+ * SQL injection 패턴이 포함된 식별자는 [IllegalArgumentException]을 발생시켜야 합니다.
+ */
+class SqlIdentifiersTest {
+
+    // -------------------------------------------------------------------------
+    // 유효한 식별자 — requireValidIdentifier 가 입력을 그대로 반환해야 함
+    // -------------------------------------------------------------------------
+
+    @ParameterizedTest(name = "유효한 식별자: [{0}]")
+    @ValueSource(strings = ["users", "public.users", "schema_name.table_name", "_private", "Col1"])
+    fun `유효한 식별자는 그대로 반환된다`(identifier: String) {
+        val result = requireValidIdentifier(identifier)
+        result shouldBeEqualTo identifier
+    }
+
+    // -------------------------------------------------------------------------
+    // 무효한 식별자 — SQL injection 패턴 등 IllegalArgumentException 을 발생시켜야 함
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `세미콜론과 DROP TABLE 구문이 포함된 식별자는 예외를 발생시킨다`() {
+        val invoke = { requireValidIdentifier("users; DROP TABLE users--") }
+        invoke shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `작은따옴표와 OR 구문이 포함된 식별자는 예외를 발생시킨다`() {
+        val invoke = { requireValidIdentifier("users' OR '1'='1") }
+        invoke shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `백틱이 포함된 식별자는 예외를 발생시킨다`() {
+        val invoke = { requireValidIdentifier("`users`") }
+        invoke shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `숫자로 시작하는 식별자는 예외를 발생시킨다`() {
+        val invoke = { requireValidIdentifier("123invalid") }
+        invoke shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `빈 문자열 식별자는 예외를 발생시킨다`() {
+        val invoke = { requireValidIdentifier("") }
+        invoke shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `공백이 포함된 식별자는 예외를 발생시킨다`() {
+        val invoke = { requireValidIdentifier("users WHERE 1=1") }
+        invoke shouldThrow IllegalArgumentException::class
+    }
+
+    @ParameterizedTest(name = "무효한 SQL injection 식별자: [{0}]")
+    @ValueSource(strings = [
+        "users; DROP TABLE users--",
+        "users' OR '1'='1",
+        "`users`",
+        "123invalid",
+        "users WHERE 1=1",
+    ])
+    fun `SQL injection 패턴을 포함한 식별자는 예외를 발생시킨다`(identifier: String) {
+        val invoke = { requireValidIdentifier(identifier) }
+        invoke shouldThrow IllegalArgumentException::class
+    }
+}


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: data/r2dbc + data/exposed-postgresql 코드 리뷰 지적사항 수정

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### data/r2dbc
- SQL 식별자 allowlist 검증 추가 (Insert/Update/Delete) — SQL 인젝션 방지
- R2dbcTransactionManager: WeakHashMap 캐시로 per-call 생성 방지
- DEFAULT_MAX_PENDING_ACQUIRE: -1(무제한) → 1000

### data/exposed-postgresql
- VectorDistanceOperator enum 도입 (문자열 하드코딩 제거)
- GeoExtensions: distance NaN/Infinite 검증 추가

### 신규 테스트
- SqlIdentifiersTest: SQL 인젝션 패턴 16개 테스트

## Validation

- bluetape4k-r2dbc: 149 pass
- bluetape4k-exposed-postgresql: 87 pass

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #221, head `48e4eae0cc084f1f65d89654e90c1152ee692868`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/data-r2dbc-postgresql-review-issues`
- Labels: `bug`, `test`, `chore`
- State: `MERGED`, merge commit `2eb9a9c3a6421fb861bb8ce28279fe57bc74885b`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #221 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `2eb9a9c3a6421fb861bb8ce28279fe57bc74885b`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
