### PR TITLE
fix: testing/mock-web-server + mock-webflux-server 보안 이슈 수정

### DIFF
--- a/testing/mock-web-server/src/main/kotlin/io/bluetape4k/mockserver/admin/AdminController.kt
+++ b/testing/mock-web-server/src/main/kotlin/io/bluetape4k/mockserver/admin/AdminController.kt
@@ -4,8 +4,10 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.info
 import io.bluetape4k.mockserver.jsonplaceholder.JsonplaceholderService
 import org.springframework.cache.annotation.CacheEvict
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -14,12 +16,19 @@ import org.springframework.web.bind.annotation.RestController
  *
  * fixture 재적재, 서버 상태 확인 등 운영 관리 기능을 제공한다.
  *
+ * 모든 관리 엔드포인트는 `X-Admin-Token` 헤더로 인증한다.
+ * 토큰 값은 환경변수 `MOCKSERVER_ADMIN_TOKEN`으로 지정하며,
+ * 미설정 시 개발용 기본값 `"dev-only-token"` 을 사용한다.
+ * **운영 환경에서는 반드시 환경변수로 토큰을 변경해야 한다.**
+ *
  * @param jsonplaceholderService jsonplaceholder 데이터 서비스
  */
 @RestController
 @RequestMapping("/admin")
 class AdminController(private val jsonplaceholderService: JsonplaceholderService) {
-    companion object : KLogging()
+    companion object : KLogging() {
+        private val adminToken = System.getenv("MOCKSERVER_ADMIN_TOKEN") ?: "dev-only-token"
+    }
 
     /**
      * 모든 인메모리 데이터를 fixture 파일로부터 원자적으로 재적재한다.
@@ -27,11 +36,19 @@ class AdminController(private val jsonplaceholderService: JsonplaceholderService
      * jsonplaceholder fixture(posts, comments, albums, photos, todos, users)를
      * 클래스패스 JSON 파일에서 다시 로드하여 인메모리 저장소를 초기 상태로 되돌린다.
      *
-     * @return 재적재 완료 메시지
+     * `X-Admin-Token` 헤더가 없거나 올바르지 않으면 401 응답을 반환한다.
+     *
+     * @param token `X-Admin-Token` 요청 헤더 (필수)
+     * @return 재적재 완료 메시지 또는 401
      */
     @PostMapping("/reset")
     @CacheEvict(value = ["fixture-data"], allEntries = true)
-    fun reset(): ResponseEntity<Map<String, String>> {
+    fun reset(
+        @RequestHeader("X-Admin-Token", required = false) token: String?,
+    ): ResponseEntity<Map<String, String>> {
+        if (token != adminToken) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+        }
         log.info { "Admin reset requested: reloading all fixtures..." }
         jsonplaceholderService.reloadFromFixtures()
         return ResponseEntity.ok(mapOf("status" to "ok", "message" to "All fixtures reloaded"))

--- a/testing/mock-web-server/src/main/kotlin/io/bluetape4k/mockserver/config/HttpsConfiguration.kt
+++ b/testing/mock-web-server/src/main/kotlin/io/bluetape4k/mockserver/config/HttpsConfiguration.kt
@@ -28,8 +28,12 @@ class HttpsConfiguration {
     /**
      * Tomcat에 HTTPS 커넥터를 추가하는 [WebServerFactoryCustomizer] 빈.
      *
+     * keystore 비밀번호는 `bluetape4k.https.key-store-password` 프로퍼티 또는
+     * 환경변수 `BLUETAPE4K_HTTPS_KEY_STORE_PASSWORD`로 지정한다.
+     * **운영 배포 시에는 반드시 환경변수(또는 외부 설정)로 기본값 `"changeit"`을 변경해야 한다.**
+     *
      * @param httpsPort HTTPS 포트 번호 (기본값 443)
-     * @param keyStorePassword PKCS12 keystore 비밀번호
+     * @param keyStorePassword PKCS12 keystore 비밀번호 (기본값 `"changeit"` — 운영 환경에서는 변경 필수)
      */
     @Bean
     fun httpsConnectorCustomizer(

--- a/testing/mock-web-server/src/main/kotlin/io/bluetape4k/mockserver/web/WebContentController.kt
+++ b/testing/mock-web-server/src/main/kotlin/io/bluetape4k/mockserver/web/WebContentController.kt
@@ -31,11 +31,16 @@ class WebContentController(private val loader: WebContentLoader) {
     /**
      * 지정된 이름의 HTML 페이지를 반환한다.
      *
+     * allowlist에 없는 이름이면 404, 그 외 오류는 상위로 전파한다.
+     *
      * @param name 페이지 이름 (home/naver/google/login/article)
      * @return HTML 페이지 또는 404
      */
     @GetMapping("/{name}", produces = [MediaType.TEXT_HTML_VALUE])
     fun byName(@PathVariable name: String): ResponseEntity<String> =
-        runCatching { ResponseEntity.ok(loader.load(name)) }
-            .getOrElse { ResponseEntity.notFound().build() }
+        try {
+            ResponseEntity.ok(loader.load(name))
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.notFound().build()
+        }
 }

--- a/testing/mock-web-server/src/main/kotlin/io/bluetape4k/mockserver/web/WebContentLoader.kt
+++ b/testing/mock-web-server/src/main/kotlin/io/bluetape4k/mockserver/web/WebContentLoader.kt
@@ -13,17 +13,23 @@ import org.springframework.stereotype.Service
  */
 @Service
 class WebContentLoader {
-    companion object : KLogging()
+    companion object : KLogging() {
+        /** 허용된 HTML 페이지 이름 목록. 이 목록에 없는 이름은 로드를 거부한다 (Path Traversal 방지). */
+        internal val ALLOWED_NAMES = setOf("home", "naver", "google", "login", "article")
+    }
 
     /**
      * 지정된 이름의 HTML 파일을 로드한다.
      *
-     * @param name HTML 파일명 (확장자 제외)
+     * allowlist([ALLOWED_NAMES])에 없는 이름은 [IllegalArgumentException]을 던진다.
+     *
+     * @param name HTML 파일명 (확장자 제외). 반드시 [ALLOWED_NAMES] 중 하나여야 한다.
      * @return HTML 문자열
-     * @throws IllegalArgumentException 파일이 존재하지 않는 경우
+     * @throws IllegalArgumentException 허용되지 않은 이름이거나 파일이 존재하지 않는 경우
      */
     @Cacheable("html-content", key = "#name")
     fun load(name: String): String {
+        require(name in ALLOWED_NAMES) { "Resource not allowed: $name" }
         val resource = ClassPathResource("web/html/$name.html")
         require(resource.exists()) { "HTML page not found: $name" }
         return resource.inputStream.reader(Charsets.UTF_8).readText()

--- a/testing/mock-web-server/src/test/kotlin/io/bluetape4k/mockserver/admin/AdminResetContractTest.kt
+++ b/testing/mock-web-server/src/test/kotlin/io/bluetape4k/mockserver/admin/AdminResetContractTest.kt
@@ -21,10 +21,11 @@ class AdminResetContractTest: MockServerTestBase() {
         val delete = Request.Builder().url("$baseUrl/jsonplaceholder/posts/1").delete().build()
         client.newCall(delete).execute().close()
 
-        // 2) /admin/reset → fixture 재적재
+        // 2) /admin/reset → fixture 재적재 (X-Admin-Token 헤더 필수)
         val req = Request.Builder()
             .url("$baseUrl/admin/reset")
             .post("".toRequestBody())
+            .header("X-Admin-Token", "dev-only-token")
             .build()
         client.newCall(req).execute().use { response ->
             response.code shouldBeEqualTo 200

--- a/testing/mock-web-server/src/test/kotlin/io/bluetape4k/mockserver/jsonplaceholder/PostsContractTest.kt
+++ b/testing/mock-web-server/src/test/kotlin/io/bluetape4k/mockserver/jsonplaceholder/PostsContractTest.kt
@@ -117,7 +117,7 @@ class PostsContractTest: AbstractJsonplaceholderContractTest() {
     @Test
     @Order(7)
     fun `POST admin reset restores fixtures and posts are non-empty`() {
-        mockMvc.perform(post("/admin/reset"))
+        mockMvc.perform(post("/admin/reset").header("X-Admin-Token", "dev-only-token"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.status").value("ok"))
             .andDo { log.info { "POST /admin/reset → 200" } }

--- a/testing/mock-webflux-server/src/main/kotlin/io/bluetape4k/mockwebflux/admin/AdminController.kt
+++ b/testing/mock-webflux-server/src/main/kotlin/io/bluetape4k/mockwebflux/admin/AdminController.kt
@@ -4,8 +4,10 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.info
 import io.bluetape4k.mockwebflux.jsonplaceholder.JsonplaceholderService
 import org.springframework.cache.annotation.CacheEvict
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -14,11 +16,17 @@ import org.springframework.web.bind.annotation.RestController
  *
  * fixture 재적재, 서버 상태 확인 등 운영 관리 기능을 제공한다.
  *
+ * 모든 관리 엔드포인트는 `X-Admin-Token` 헤더로 인증한다.
+ * 토큰 값은 환경변수 `MOCKSERVER_ADMIN_TOKEN`으로 지정하며,
+ * 미설정 시 개발용 기본값 `"dev-only-token"` 을 사용한다.
+ * **운영 환경에서는 반드시 환경변수로 토큰을 변경해야 한다.**
+ *
  * ```kotlin
  * // baseUrl == "http://localhost:9999"
  * val client = WebClient.create("http://localhost:9999")
  * // 모든 fixture 데이터를 초기 상태로 재적재
  * val result = client.post().uri("/admin/reset")
+ *     .header("X-Admin-Token", "dev-only-token")
  *     .retrieve().awaitBody<Map<String, String>>()
  * // result["status"] == "ok"
  * ```
@@ -28,7 +36,9 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/admin")
 class AdminController(private val jsonplaceholderService: JsonplaceholderService) {
-    companion object: KLogging()
+    companion object: KLogging() {
+        private val adminToken = System.getenv("MOCKSERVER_ADMIN_TOKEN") ?: "dev-only-token"
+    }
 
     /**
      * 모든 인메모리 데이터를 fixture 파일로부터 원자적으로 재적재한다.
@@ -36,11 +46,19 @@ class AdminController(private val jsonplaceholderService: JsonplaceholderService
      * jsonplaceholder fixture(posts, comments, albums, photos, todos, users)를
      * 클래스패스 JSON 파일에서 다시 로드하여 인메모리 저장소를 초기 상태로 되돌린다.
      *
-     * @return 재적재 완료 메시지
+     * `X-Admin-Token` 헤더가 없거나 올바르지 않으면 401 응답을 반환한다.
+     *
+     * @param token `X-Admin-Token` 요청 헤더 (필수)
+     * @return 재적재 완료 메시지 또는 401
      */
     @PostMapping("/reset")
     @CacheEvict(value = ["fixture-data"], allEntries = true)
-    suspend fun reset(): ResponseEntity<Map<String, String>> {
+    suspend fun reset(
+        @RequestHeader("X-Admin-Token", required = false) token: String?,
+    ): ResponseEntity<Map<String, String>> {
+        if (token != adminToken) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+        }
         log.info { "Admin reset requested: reloading all fixtures..." }
         jsonplaceholderService.reloadFromFixtures()
         return ResponseEntity.ok(mapOf("status" to "ok", "message" to "All fixtures reloaded"))

--- a/testing/mock-webflux-server/src/main/kotlin/io/bluetape4k/mockwebflux/web/WebContentController.kt
+++ b/testing/mock-webflux-server/src/main/kotlin/io/bluetape4k/mockwebflux/web/WebContentController.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.mockwebflux.web
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.requireNotBlank
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.springframework.http.MediaType
@@ -51,13 +52,20 @@ class WebContentController(private val loader: WebContentLoader) {
     /**
      * 지정된 이름의 HTML 페이지를 반환한다.
      *
+     * allowlist에 없는 이름이면 404, [CancellationException]은 재발생, 그 외 오류는 상위로 전파한다.
+     *
      * @param name 페이지 이름 (home/naver/google/login/article)
      * @return HTML 페이지 또는 404
      */
     @GetMapping("/{name}", produces = [MediaType.TEXT_HTML_VALUE])
     suspend fun byName(@PathVariable name: String): ResponseEntity<String> {
         name.requireNotBlank("name")
-        return runCatching { ResponseEntity.ok(withContext(Dispatchers.IO) { loader.load(name) }) }
-            .getOrElse { ResponseEntity.notFound().build() }
+        return try {
+            ResponseEntity.ok(withContext(Dispatchers.IO) { loader.load(name) })
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.notFound().build()
+        }
     }
 }

--- a/testing/mock-webflux-server/src/main/kotlin/io/bluetape4k/mockwebflux/web/WebContentLoader.kt
+++ b/testing/mock-webflux-server/src/main/kotlin/io/bluetape4k/mockwebflux/web/WebContentLoader.kt
@@ -16,20 +16,25 @@ import org.springframework.stereotype.Service
  */
 @Service
 class WebContentLoader {
-    companion object: KLogging()
+    companion object: KLogging() {
+        /** 허용된 HTML 페이지 이름 목록. 이 목록에 없는 이름은 로드를 거부한다 (Path Traversal 방지). */
+        internal val ALLOWED_NAMES = setOf("home", "naver", "google", "login", "article")
+    }
 
     /**
      * 지정된 이름의 HTML 파일을 로드한다.
      *
      * Spring `@Cacheable` 로 결과를 메모리 캐시에 저장한다.
+     * allowlist([ALLOWED_NAMES])에 없는 이름은 [IllegalArgumentException]을 던진다.
      *
-     * @param name HTML 파일명 (확장자 제외)
+     * @param name HTML 파일명 (확장자 제외). 반드시 [ALLOWED_NAMES] 중 하나여야 한다.
      * @return HTML 문자열
-     * @throws IllegalArgumentException 이름이 공백이거나 파일이 존재하지 않는 경우
+     * @throws IllegalArgumentException 이름이 공백이거나 허용되지 않은 이름이거나 파일이 존재하지 않는 경우
      */
     @Cacheable("web-content", key = "#name")
     fun load(name: String): String {
         name.requireNotBlank("name")
+        require(name in ALLOWED_NAMES) { "Resource not allowed: $name" }
         val resource = ClassPathResource("web/html/$name.html")
         require(resource.exists()) { "HTML page not found: $name" }
         return resource.inputStream.reader(Charsets.UTF_8).readText()

--- a/testing/mock-webflux-server/src/test/kotlin/io/bluetape4k/mockwebflux/admin/AdminResetContractTest.kt
+++ b/testing/mock-webflux-server/src/test/kotlin/io/bluetape4k/mockwebflux/admin/AdminResetContractTest.kt
@@ -18,9 +18,10 @@ class AdminResetContractTest: AbstractMockWebfluxServerTest() {
             .exchange()
             .expectStatus().is2xxSuccessful
 
-        // 관리자 리셋 호출
+        // 관리자 리셋 호출 (X-Admin-Token 헤더 필수)
         client.post().uri("/admin/reset")
             .contentType(MediaType.APPLICATION_JSON)
+            .header("X-Admin-Token", "dev-only-token")
             .exchange()
             .expectStatus().isOk
 


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: testing/mock-web-server + mock-webflux-server 보안 이슈 수정

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### CRITICAL
- WebContentLoader: allowlist 검증으로 경로 순회 공격 차단

### HIGH
- AdminController: X-Admin-Token 헤더 인증 추가 (env: MOCKSERVER_ADMIN_TOKEN)
- WebContentController: CancellationException rethrow (WebFlux)

### MEDIUM
- HttpsConfiguration: 기본 키스토어 비밀번호 KDoc 경고

## Validation

- bluetape4k-mock-web-server: 118 pass
- bluetape4k-mock-webflux-server: 51 pass

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #226, head `8129dd1436cb50dbef1f57f6dea24ee76fc1dc39`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/testing-mockservers-review-issues`
- Labels: `bug`, `test`, `chore`, `security`
- State: `MERGED`, merge commit `d5a71c8ef18fa263e18b2fd93012206fd05851e5`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #226 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `d5a71c8ef18fa263e18b2fd93012206fd05851e5`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
