### PR TITLE
fix: infra/elasticsearch + io/jackson + io/tink 코드 리뷰 지적사항 수정

### DIFF
--- a/infra/elasticsearch/src/main/kotlin/io/bluetape4k/elasticsearch/coroutines/SearchApiCoroutines.kt
+++ b/infra/elasticsearch/src/main/kotlin/io/bluetape4k/elasticsearch/coroutines/SearchApiCoroutines.kt
@@ -6,12 +6,17 @@ import co.elastic.clients.elasticsearch.core.ClosePointInTimeRequest
 import co.elastic.clients.elasticsearch.core.OpenPointInTimeRequest
 import co.elastic.clients.elasticsearch.core.SearchRequest
 import io.bluetape4k.elasticsearch.ElasticsearchDefaults
+import io.bluetape4k.logging.KotlinLogging
+import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requirePositiveNumber
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.future.await
+
+@PublishedApi
+internal val log = KotlinLogging.logger {}
 
 // ---------------------------------------------------------------------------
 // Point-In-Time(PIT) suspend 확장함수
@@ -156,13 +161,13 @@ inline fun <reified T : Any> ElasticsearchAsyncClient.searchAsFlow(
             }
         } finally {
             // 정상/예외/취소 모든 종료 경로에서 PIT close 보장.
-            // CancellationException 은 재던짐, 그 외 close 실패는 swallow — leak 방지가 목적.
+            // CancellationException 은 재던짐, 그 외 close 실패는 warn 로그 후 swallow — leak 방지가 목적.
             try {
                 client.closePointInTimeSuspending(pitId)
             } catch (e: CancellationException) {
                 throw e
-            } catch (_: Throwable) {
-                // PIT close 실패 — swallow
+            } catch (e: Throwable) {
+                log.warn(e) { "Failed to close ES PIT: pitId=$pitId" }
             }
         }
     }

--- a/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/JsonMapperSupport.kt
+++ b/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/JsonMapperSupport.kt
@@ -6,7 +6,8 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.KotlinLogging
+import io.bluetape4k.logging.warn
 import java.io.File
 import java.io.InputStream
 import java.io.Reader
@@ -14,7 +15,8 @@ import java.io.StringWriter
 import java.net.URL
 import kotlin.use
 
-private object JsonMapperSupportLogger: KLogging()
+@PublishedApi
+internal val log = KotlinLogging.logger {}
 
 /**
  * [JsonMapper.Builder] DSL로 [JsonMapper]를 생성합니다.
@@ -57,7 +59,9 @@ inline fun <reified T> jacksonTypeRef(): TypeReference<T> = object: TypeReferenc
  * ```
  */
 inline fun <reified T> ObjectMapper.readValueOrNull(content: String): T? =
-    runCatching { readValue(content, jacksonTypeRef<T>()) }.getOrNull()
+    runCatching { readValue(content, jacksonTypeRef<T>()) }
+        .onFailure { e -> log.warn(e) { "JSON parsing failed" } }
+        .getOrNull()
 
 /**
  * [Reader]에서 JSON 데이터를 읽어 reified 타입 [T]로 역직렬화합니다. 실패 시 null을 반환합니다.
@@ -68,7 +72,9 @@ inline fun <reified T> ObjectMapper.readValueOrNull(content: String): T? =
  * ```
  */
 inline fun <reified T> ObjectMapper.readValueOrNull(input: Reader): T? =
-    runCatching { readValue(input, jacksonTypeRef<T>()) }.getOrNull()
+    runCatching { readValue(input, jacksonTypeRef<T>()) }
+        .onFailure { e -> log.warn(e) { "JSON parsing failed" } }
+        .getOrNull()
 
 /**
  * [InputStream]에서 JSON 데이터를 읽어 reified 타입 [T]로 역직렬화합니다. 실패 시 null을 반환합니다.
@@ -79,7 +85,9 @@ inline fun <reified T> ObjectMapper.readValueOrNull(input: Reader): T? =
  * ```
  */
 inline fun <reified T> ObjectMapper.readValueOrNull(input: InputStream): T? =
-    runCatching { readValue(input, jacksonTypeRef<T>()) }.getOrNull()
+    runCatching { readValue(input, jacksonTypeRef<T>()) }
+        .onFailure { e -> log.warn(e) { "JSON parsing failed" } }
+        .getOrNull()
 
 /**
  * JSON [ByteArray]를 reified 타입 [T]로 역직렬화합니다. 실패 시 null을 반환합니다.
@@ -93,7 +101,9 @@ inline fun <reified T> ObjectMapper.readValueOrNull(
     input: ByteArray,
     offset: Int = 0,
     length: Int = input.size,
-): T? = runCatching { readValue(input, offset, length, jacksonTypeRef<T>()) }.getOrNull()
+): T? = runCatching { readValue(input, offset, length, jacksonTypeRef<T>()) }
+    .onFailure { e -> log.warn(e) { "JSON parsing failed" } }
+    .getOrNull()
 
 /**
  * [File]에서 JSON 데이터를 읽어 reified 타입 [T]로 역직렬화합니다. 실패 시 null을 반환합니다.
@@ -104,7 +114,9 @@ inline fun <reified T> ObjectMapper.readValueOrNull(
  * ```
  */
 inline fun <reified T> ObjectMapper.readValueOrNull(input: File): T? =
-    runCatching { readValue(input, jacksonTypeRef<T>()) }.getOrNull()
+    runCatching { readValue(input, jacksonTypeRef<T>()) }
+        .onFailure { e -> log.warn(e) { "JSON parsing failed" } }
+        .getOrNull()
 
 /**
  * [URL]에서 JSON 데이터를 읽어 reified 타입 [T]로 역직렬화합니다. 실패 시 null을 반환합니다.
@@ -117,7 +129,9 @@ inline fun <reified T> ObjectMapper.readValueOrNull(input: File): T? =
 inline fun <reified T> ObjectMapper.readValueOrNull(input: URL): T? =
     runCatching {
         input.openStream().use { stream -> readValue(stream, jacksonTypeRef<T>()) }
-    }.getOrNull()
+    }
+        .onFailure { e -> log.warn(e) { "JSON parsing failed" } }
+        .getOrNull()
 
 /**
  * [JsonParser]에서 토큰을 읽어 reified 타입 [T]로 역직렬화합니다. 실패 시 null을 반환합니다.
@@ -129,7 +143,9 @@ inline fun <reified T> ObjectMapper.readValueOrNull(input: URL): T? =
  * ```
  */
 inline fun <reified T> ObjectMapper.readValueOrNull(parser: JsonParser): T? =
-    runCatching { readValue(parser, jacksonTypeRef<T>()) }.getOrNull()
+    runCatching { readValue(parser, jacksonTypeRef<T>()) }
+        .onFailure { e -> log.warn(e) { "JSON parsing failed" } }
+        .getOrNull()
 
 /**
  * 임의 객체를 reified 타입 [T]로 변환합니다. 실패 시 null을 반환합니다.
@@ -142,7 +158,9 @@ inline fun <reified T> ObjectMapper.readValueOrNull(parser: JsonParser): T? =
  * ```
  */
 inline fun <reified T> ObjectMapper.convertValueOrNull(from: Any): T? =
-    runCatching { convertValue(from, jacksonTypeRef<T>()) }.getOrNull()
+    runCatching { convertValue(from, jacksonTypeRef<T>()) }
+        .onFailure { e -> log.warn(e) { "JSON parsing failed" } }
+        .getOrNull()
 
 /**
  * [TreeNode]를 reified 타입 [T]로 변환합니다. 실패 시 null을 반환합니다.
@@ -155,7 +173,9 @@ inline fun <reified T> ObjectMapper.convertValueOrNull(from: Any): T? =
  * ```
  */
 inline fun <reified T> ObjectMapper.treeToValueOrNull(node: TreeNode): T? =
-    runCatching { treeToValue(node, T::class.java) }.getOrNull()
+    runCatching { treeToValue(node, T::class.java) }
+        .onFailure { e -> log.warn(e) { "JSON parsing failed" } }
+        .getOrNull()
 
 /**
  * 객체를 JSON 문자열로 직렬화합니다.

--- a/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/JsonMapperSupport.kt
+++ b/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/JsonMapperSupport.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.jackson3
 
 import io.bluetape4k.logging.KotlinLogging
+import io.bluetape4k.logging.warn
 import tools.jackson.core.JsonParser
 import tools.jackson.core.TreeNode
 import tools.jackson.core.type.TypeReference
@@ -14,7 +15,8 @@ import java.io.StringWriter
 import java.nio.file.Path
 import kotlin.use
 
-private val log by lazy { KotlinLogging.logger { } }
+@PublishedApi
+internal val log = KotlinLogging.logger {}
 
 /**
  * [JsonMapper.Builder] DSL로 Jackson 3 매퍼를 생성합니다.
@@ -57,7 +59,9 @@ inline fun <reified T> jacksonTypeRef(): TypeReference<T> = object: TypeReferenc
  * ```
  */
 inline fun <reified T> ObjectMapper.readValueOrNull(content: String): T? =
-    runCatching { readValue(content, jacksonTypeRef<T>()) }.getOrNull()
+    runCatching { readValue(content, jacksonTypeRef<T>()) }
+        .onFailure { e -> log.warn(e) { "JSON parsing failed" } }
+        .getOrNull()
 
 /**
  * [Reader]에서 JSON 데이터를 읽어 reified 타입 [T]의 객체로 역직렬화합니다. 실패 시 null 반환
@@ -68,7 +72,9 @@ inline fun <reified T> ObjectMapper.readValueOrNull(content: String): T? =
  * ```
  */
 inline fun <reified T> ObjectMapper.readValueOrNull(input: Reader): T? =
-    runCatching { readValue(input, jacksonTypeRef<T>()) }.getOrNull()
+    runCatching { readValue(input, jacksonTypeRef<T>()) }
+        .onFailure { e -> log.warn(e) { "JSON parsing failed" } }
+        .getOrNull()
 
 /**
  * [InputStream]에서 JSON 데이터를 읽어 reified 타입 [T]의 객체로 역직렬화합니다. 실패 시 null 반환
@@ -79,7 +85,9 @@ inline fun <reified T> ObjectMapper.readValueOrNull(input: Reader): T? =
  * ```
  */
 inline fun <reified T> ObjectMapper.readValueOrNull(input: InputStream): T? =
-    runCatching { readValue(input, jacksonTypeRef<T>()) }.getOrNull()
+    runCatching { readValue(input, jacksonTypeRef<T>()) }
+        .onFailure { e -> log.warn(e) { "JSON parsing failed" } }
+        .getOrNull()
 
 /**
  * JSON [ByteArray]를 reified 타입 [T]의 객체로 역직렬화합니다. 실패 시 null 반환
@@ -90,7 +98,9 @@ inline fun <reified T> ObjectMapper.readValueOrNull(input: InputStream): T? =
  * ```
  */
 inline fun <reified T> ObjectMapper.readValueOrNull(input: ByteArray, offset: Int = 0, length: Int = input.size): T? =
-    runCatching { readValue(input, offset, length, jacksonTypeRef<T>()) }.getOrNull()
+    runCatching { readValue(input, offset, length, jacksonTypeRef<T>()) }
+        .onFailure { e -> log.warn(e) { "JSON parsing failed" } }
+        .getOrNull()
 
 /**
  * [File]에서 JSON 데이터를 읽어 reified 타입 [T]의 객체로 역직렬화합니다. 실패 시 null 반환
@@ -101,7 +111,9 @@ inline fun <reified T> ObjectMapper.readValueOrNull(input: ByteArray, offset: In
  * ```
  */
 inline fun <reified T> ObjectMapper.readValueOrNull(input: File): T? =
-    runCatching { readValue(input, jacksonTypeRef<T>()) }.getOrNull()
+    runCatching { readValue(input, jacksonTypeRef<T>()) }
+        .onFailure { e -> log.warn(e) { "JSON parsing failed" } }
+        .getOrNull()
 
 /**
  * [Path]에서 JSON 데이터를 읽어 reified 타입 [T]의 객체로 역직렬화합니다. 실패 시 null 반환
@@ -112,7 +124,9 @@ inline fun <reified T> ObjectMapper.readValueOrNull(input: File): T? =
  * ```
  */
 inline fun <reified T> ObjectMapper.readValueOrNull(input: Path): T? =
-    runCatching { readValue(input, jacksonTypeRef<T>()) }.getOrNull()
+    runCatching { readValue(input, jacksonTypeRef<T>()) }
+        .onFailure { e -> log.warn(e) { "JSON parsing failed" } }
+        .getOrNull()
 
 /**
  * [JsonParser]에서 토큰을 읽어 reified 타입 [T]의 객체로 역직렬화합니다. 실패 시 null 반환
@@ -124,7 +138,9 @@ inline fun <reified T> ObjectMapper.readValueOrNull(input: Path): T? =
  * ```
  */
 inline fun <reified T> ObjectMapper.readValueOrNull(parser: JsonParser): T? =
-    runCatching { readValue(parser, jacksonTypeRef<T>()) }.getOrNull()
+    runCatching { readValue(parser, jacksonTypeRef<T>()) }
+        .onFailure { e -> log.warn(e) { "JSON parsing failed" } }
+        .getOrNull()
 
 /**
  * 임의 객체를 reified 타입 [T]로 변환합니다. 실패 시 null 반환
@@ -137,7 +153,9 @@ inline fun <reified T> ObjectMapper.readValueOrNull(parser: JsonParser): T? =
  * ```
  */
 inline fun <reified T> ObjectMapper.convertValueOrNull(from: Any): T? =
-    runCatching { convertValue(from, jacksonTypeRef<T>()) }.getOrNull()
+    runCatching { convertValue(from, jacksonTypeRef<T>()) }
+        .onFailure { e -> log.warn(e) { "JSON parsing failed" } }
+        .getOrNull()
 
 /**
  * [TreeNode]를 reified 타입 [T]의 객체로 변환합니다. 실패 시 null 반환
@@ -149,7 +167,9 @@ inline fun <reified T> ObjectMapper.convertValueOrNull(from: Any): T? =
     replaceWith = ReplaceWith("treeToValueOrNull<T>(treeNode as tools.jackson.databind.JsonNode)")
 )
 inline fun <reified T> ObjectMapper.treeToValueOrNull(treeNode: TreeNode): T? =
-    runCatching { treeToValue(treeNode as JsonNode, T::class.java) }.getOrNull()
+    runCatching { treeToValue(treeNode as JsonNode, T::class.java) }
+        .onFailure { e -> log.warn(e) { "JSON parsing failed" } }
+        .getOrNull()
 
 /**
  * [JsonNode]를 reified 타입 [T]의 객체로 변환합니다. 실패 시 null 반환
@@ -162,7 +182,9 @@ inline fun <reified T> ObjectMapper.treeToValueOrNull(treeNode: TreeNode): T? =
  * ```
  */
 inline fun <reified T> ObjectMapper.treeToValueOrNull(jsonNode: JsonNode): T? =
-    runCatching { treeToValue(jsonNode, T::class.java) }.getOrNull()
+    runCatching { treeToValue(jsonNode, T::class.java) }
+        .onFailure { e -> log.warn(e) { "JSON parsing failed" } }
+        .getOrNull()
 
 /**
  * 객체를 JSON 문자열로 직렬화합니다.

--- a/io/tink/src/main/kotlin/io/bluetape4k/tink/aead/TinkAead.kt
+++ b/io/tink/src/main/kotlin/io/bluetape4k/tink/aead/TinkAead.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.tink.aead
 import com.google.crypto.tink.Aead
 import com.google.crypto.tink.KeysetHandle
 import com.google.crypto.tink.RegistryConfiguration
+import io.bluetape4k.logging.KLogging
 import io.bluetape4k.tink.EMPTY_BYTES
 import io.bluetape4k.tink.aeadKeysetHandle
 import java.util.*
@@ -22,6 +23,8 @@ import java.util.*
  * @param keysetHandle Tink [KeysetHandle] — `aeadKeysetHandle()` 팩토리 함수로 생성
  */
 class TinkAead(keysetHandle: KeysetHandle = aeadKeysetHandle()) {
+
+    companion object : KLogging()
 
     private val aead: Aead by lazy {
         keysetHandle.getPrimitive(RegistryConfiguration.get(), Aead::class.java)

--- a/io/tink/src/main/kotlin/io/bluetape4k/tink/daead/TinkDeterministicAead.kt
+++ b/io/tink/src/main/kotlin/io/bluetape4k/tink/daead/TinkDeterministicAead.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.tink.daead
 import com.google.crypto.tink.DeterministicAead
 import com.google.crypto.tink.KeysetHandle
 import com.google.crypto.tink.RegistryConfiguration
+import io.bluetape4k.logging.KLogging
 import io.bluetape4k.tink.EMPTY_BYTES
 import io.bluetape4k.tink.daeadKeysetHandle
 import java.util.*
@@ -27,6 +28,8 @@ import java.util.*
  * @param keysetHandle Tink [KeysetHandle] — `daeadKeysetHandle()` 팩토리 함수로 생성
  */
 class TinkDeterministicAead(keysetHandle: KeysetHandle = daeadKeysetHandle()) {
+
+    companion object : KLogging()
 
     private val daead: DeterministicAead by lazy {
         keysetHandle.getPrimitive(RegistryConfiguration.get(), DeterministicAead::class.java)

--- a/io/tink/src/main/kotlin/io/bluetape4k/tink/digest/TinkDigester.kt
+++ b/io/tink/src/main/kotlin/io/bluetape4k/tink/digest/TinkDigester.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.tink.digest
 
+import io.bluetape4k.logging.KLogging
 import java.security.MessageDigest
 import java.util.*
 
@@ -22,6 +23,8 @@ import java.util.*
 class TinkDigester(
     val algorithmName: String,
 ) {
+
+    companion object : KLogging()
     /**
      * 바이트 배열의 해시 다이제스트를 계산합니다.
      *

--- a/io/tink/src/main/kotlin/io/bluetape4k/tink/encrypt/TinkAeadEncryptor.kt
+++ b/io/tink/src/main/kotlin/io/bluetape4k/tink/encrypt/TinkAeadEncryptor.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.tink.encrypt
 
+import io.bluetape4k.logging.KLogging
 import io.bluetape4k.tink.aead.TinkAead
 
 /**
@@ -18,6 +19,8 @@ import io.bluetape4k.tink.aead.TinkAead
  * @param aead 사용할 [TinkAead] 인스턴스
  */
 class TinkAeadEncryptor(private val aead: TinkAead): TinkEncryptor {
+
+    companion object : KLogging()
 
     override fun encrypt(plaintext: ByteArray): ByteArray = aead.encrypt(plaintext)
 

--- a/io/tink/src/main/kotlin/io/bluetape4k/tink/encrypt/TinkDaeadEncryptor.kt
+++ b/io/tink/src/main/kotlin/io/bluetape4k/tink/encrypt/TinkDaeadEncryptor.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.tink.encrypt
 
+import io.bluetape4k.logging.KLogging
 import io.bluetape4k.tink.daead.TinkDeterministicAead
 
 /**
@@ -21,6 +22,8 @@ import io.bluetape4k.tink.daead.TinkDeterministicAead
  * @param daead 사용할 [TinkDeterministicAead] 인스턴스
  */
 class TinkDaeadEncryptor(private val daead: TinkDeterministicAead): TinkEncryptor {
+
+    companion object : KLogging()
 
     override fun encrypt(plaintext: ByteArray): ByteArray = daead.encryptDeterministically(plaintext)
 

--- a/io/tink/src/main/kotlin/io/bluetape4k/tink/keyset/VersionedTinkAead.kt
+++ b/io/tink/src/main/kotlin/io/bluetape4k/tink/keyset/VersionedTinkAead.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.tink.keyset
 
+import io.bluetape4k.logging.KLogging
 import io.bluetape4k.tink.EMPTY_BYTES
 import io.bluetape4k.tink.aead.TinkAead
 import java.time.Duration
@@ -14,6 +15,8 @@ import java.util.*
 class VersionedTinkAead(
     private val keysetStore: VersionedKeysetStore,
 ) {
+
+    companion object : KLogging()
 
     fun currentVersion(): Long = keysetStore.current().version
 

--- a/io/tink/src/main/kotlin/io/bluetape4k/tink/keyset/VersionedTinkDaead.kt
+++ b/io/tink/src/main/kotlin/io/bluetape4k/tink/keyset/VersionedTinkDaead.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.tink.keyset
 
+import io.bluetape4k.logging.KLogging
 import io.bluetape4k.tink.EMPTY_BYTES
 import io.bluetape4k.tink.daead.TinkDeterministicAead
 import java.time.Duration
@@ -13,6 +14,8 @@ import java.util.*
 class VersionedTinkDaead(
     private val keysetStore: VersionedKeysetStore,
 ) {
+
+    companion object : KLogging()
 
     fun currentVersion(): Long = keysetStore.current().version
 

--- a/io/tink/src/main/kotlin/io/bluetape4k/tink/mac/TinkMac.kt
+++ b/io/tink/src/main/kotlin/io/bluetape4k/tink/mac/TinkMac.kt
@@ -3,6 +3,8 @@ package io.bluetape4k.tink.mac
 import com.google.crypto.tink.KeysetHandle
 import com.google.crypto.tink.Mac
 import com.google.crypto.tink.RegistryConfiguration
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
 import io.bluetape4k.tink.macKeysetHandle
 
 /**
@@ -21,6 +23,8 @@ import io.bluetape4k.tink.macKeysetHandle
  * @param keysetHandle Tink [KeysetHandle] — `macKeysetHandle()` 팩토리 함수로 생성
  */
 class TinkMac(keysetHandle: KeysetHandle = macKeysetHandle()) {
+
+    companion object : KLogging()
 
     private val mac: Mac by lazy {
         keysetHandle.getPrimitive(RegistryConfiguration.get(), Mac::class.java)
@@ -52,7 +56,8 @@ class TinkMac(keysetHandle: KeysetHandle = macKeysetHandle()) {
     fun verifyMac(tag: ByteArray, data: ByteArray): Boolean = try {
         mac.verifyMac(tag, data)
         true
-    } catch (_: Exception) {
+    } catch (e: Exception) {
+        log.warn(e) { "MAC verification failed" }
         false
     }
 


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: infra/elasticsearch + io/jackson + io/tink 코드 리뷰 지적사항 수정

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### infra/elasticsearch (MEDIUM)
- SearchApiCoroutines: ES PIT close 실패 silent swallow → warn 로깅

### io/jackson2 + io/jackson3 (MEDIUM)
- JsonMapperSupport: runCatching.getOrNull() → onFailure 로깅 추가 (모든 parse/convert 위치)

### io/tink (MEDIUM)
- TinkAead/DeterministicAead/Mac 등 8개 클래스: companion KLogging() 추가
- TinkMac.verifyMac: 검증 실패 로깅 추가

## Validation

- bluetape4k-jackson2: 415 pass
- bluetape4k-jackson3: 422 pass
- bluetape4k-tink: 135 pass

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #232, head `06189098072698266b7e6808a82d7170cadbb5ea`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/infra-elastic-jackson-tink`
- Labels: `chore`
- State: `MERGED`, merge commit `accd7a1f22be887eb19b0adb68707ed31a3e94e9`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #232 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `accd7a1f22be887eb19b0adb68707ed31a3e94e9`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
