### PR TITLE
fix: org.lz4 → at.yawk.lz4:1.11.0 으로 마이그레이션 (CVE-2025-12183, CVE-2025-66566)

### DIFF
--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/utils/XXHasher.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/utils/XXHasher.kt
@@ -21,7 +21,7 @@ import java.nio.ByteBuffer
  * val hash3 = XXHasher.hash(null, "world")    // null은 0으로 처리됨
  * ```
  *
- * @see [lz4-java](https://github.com/jpountz/lz4-java)
+ * @see [lz4-java yawkat fork](https://github.com/yawkat/lz4-java) — CVE-2025-12183/CVE-2025-66566 패치 포함 유지보수 버전
  */
 object XXHasher {
 

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -843,7 +843,7 @@ object Libs {
 
     // Compression
     const val snappy_java = "org.xerial.snappy:snappy-java:1.1.10.8"  // https://mvnrepository.com/artifact/org.xerial.snappy/snappy-java
-    // CVE-2025-12183 (CVSS 8.8) + CVE-2025-66566 (CVSS 8.2) 대응 — archived org.lz4 fork 에서 yawkat fork 로 마이그레이션.
+    // SECURITY: CVE-2025-12183 (CVSS 8.8) + CVE-2025-66566 (CVSS 8.2) — archived org.lz4/lz4-java 에서 유지보수 중인 yawkat fork 로 마이그레이션.
     // net.jpountz.lz4.* namespace 동일 (binary-compatible). 소스 코드 변경 불필요.
     const val lz4_java = "at.yawk.lz4:lz4-java:1.11.0"                // https://mvnrepository.com/artifact/at.yawk.lz4/lz4-java
 

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -843,9 +843,9 @@ object Libs {
 
     // Compression
     const val snappy_java = "org.xerial.snappy:snappy-java:1.1.10.8"  // https://mvnrepository.com/artifact/org.xerial.snappy/snappy-java
-    const val lz4_java = "org.lz4:lz4-java:1.8.0"                     // https://mvnrepository.com/artifact/org.lz4/lz4-java
-    // kafka clients 내부에 기존 lz4-java 를 사용한다.
-    // const val lz4_java = "at.yawk.lz4:lz4-java:1.8.1"                     // https://mvnrepository.com/artifact/at.yawk.lz4/lz4-java
+    // CVE-2025-12183 (CVSS 8.8) + CVE-2025-66566 (CVSS 8.2) 대응 — archived org.lz4 fork 에서 yawkat fork 로 마이그레이션.
+    // net.jpountz.lz4.* namespace 동일 (binary-compatible). 소스 코드 변경 불필요.
+    const val lz4_java = "at.yawk.lz4:lz4-java:1.11.0"                // https://mvnrepository.com/artifact/at.yawk.lz4/lz4-java
 
     // https://github.com/hyperxpro/Brotli4j
     const val brotli4j = "com.aayushatharva.brotli4j:brotli4j:1.20.0" // https://mvnrepository.com/artifact/com.aayushatharva.brotli4j/brotli4j

--- a/docs/superpowers/plans/2026-04-28-lz4-yawkat-migration-plan.md
+++ b/docs/superpowers/plans/2026-04-28-lz4-yawkat-migration-plan.md
@@ -1,0 +1,423 @@
+# LZ4 yawkat 마이그레이션 — Implementation Plan
+
+**Date**: 2026-04-28
+**Spec**: `docs/superpowers/specs/2026-04-28-lz4-yawkat-migration-design.md`
+**Issue**: #203
+**Branch**: `feat/lz4-yawkat-migration`
+**Worktree**: `.worktrees/feat-lz4-yawkat-migration`
+
+---
+
+## Goal
+
+Replace `org.lz4:lz4-java:1.8.0` with `at.yawk.lz4:lz4-java:1.11.0` to fix:
+
+- **CVE-2025-12183** (CVSS 8.8)
+- **CVE-2025-66566** (CVSS 8.2)
+
+The yawkat fork keeps the `net.jpountz.lz4.*` package namespace, so it is **binary-compatible** — no Kotlin source changes are required. The migration is a **build-config-only** change, plus runtime exclusion of the abandoned `org.lz4` JAR transitively pulled in by Kafka/Pulsar/etc.
+
+---
+
+## Pre-flight Constraints (Read Before Starting)
+
+1. `org.lz4:lz4-java` upstream repo was archived 2025-12. `1.8.1` is a Sonatype relocation POM (no real JAR) — do **not** bump to `1.8.1`.
+2. BOM `dependencyManagement` swap **does NOT evict different `groupId`**. Eviction must be done via `configurations.all { exclude(group = "org.lz4", module = "lz4-java") }` in each affected module's `build.gradle.kts`.
+3. Transitive sources of `org.lz4:lz4-java`: `kafka-clients`, `spring-kafka`, `reactor-kafka`, `kafka-streams`, possibly `pulsar-client`, `avro`, `redisson`. Run dep-tree scans (T3) before assuming exclusion targets.
+4. 31 build files reference `Libs.lz4_java`. Their `compileClasspath` should pull `at.yawk.lz4:lz4-java:1.11.0` via `Libs.lz4_java` direct ref; the `org.lz4:lz4-java` artifact only appears via Kafka-family transitives.
+5. Native-library coverage check: confirm the new JAR ships native binaries for `linux-x86_64`, `linux-aarch64`, `darwin-aarch64`, `windows-x86_64` so existing CI and Mac dev workstations continue to work.
+
+---
+
+## Task List
+
+### T1 — Update `Libs.lz4_java` GAV (complexity: low)
+
+**File**: `buildSrc/src/main/kotlin/Libs.kt`
+
+**Change**:
+```kotlin
+// before
+const val lz4_java = "org.lz4:lz4-java:1.8.0"
+
+// after
+// CVE-2025-12183 (CVSS 8.8) and CVE-2025-66566 (CVSS 8.2) — migrated to maintained yawkat fork.
+// Keeps net.jpountz.lz4.* namespace (binary-compatible).
+const val lz4_java = "at.yawk.lz4:lz4-java:1.11.0"
+```
+
+**DoD**:
+- [ ] String constant updated to `at.yawk.lz4:lz4-java:1.11.0`
+- [ ] CVE comment present immediately above the constant
+- [ ] `./gradlew help` runs without configuration error
+- [ ] `rg "org.lz4:lz4-java" buildSrc/` returns no matches in `Libs.kt`
+
+**Dependencies**: none
+
+---
+
+### T2 — Replace root-level dependencyManagement pin (complexity: low)
+
+**File**: root `build.gradle.kts`
+
+**Change**: Inside the `dependencyManagement { dependencies { ... } }` block, replace any existing `dependency("org.lz4:lz4-java:...")` pin with `dependency("at.yawk.lz4:lz4-java:1.11.0")`.
+
+**Note**: This is for *version alignment* only. It does **not** evict the `org.lz4:lz4-java` artifact when transitives request it — see T4–T6 for actual eviction.
+
+**DoD**:
+- [ ] Root `build.gradle.kts` no longer pins `org.lz4:lz4-java`
+- [ ] New pin `at.yawk.lz4:lz4-java:1.11.0` present in `dependencyManagement`
+- [ ] `./gradlew help` succeeds
+
+**Dependencies**: T1 (so the version constant is consistent)
+
+---
+
+### T3 — Pre-implementation dep-tree scan (complexity: medium)
+
+**Goal**: Identify every module whose `runtimeClasspath` (or `testRuntimeClasspath`) still contains `org.lz4:lz4-java` after T1 + T2, so we know exactly which `build.gradle.kts` files need exclude blocks (T4–T6).
+
+**Commands**:
+```bash
+# Always run after T1+T2 are committed (locally) so version alignment is in effect.
+./gradlew :bluetape4k-kafka:dependencies --configuration runtimeClasspath        | rg "lz4"
+./gradlew :bluetape4k-testcontainers:dependencies --configuration runtimeClasspath | rg "lz4"
+./gradlew :bluetape4k-pulsar:dependencies --configuration runtimeClasspath       | rg "lz4" 2>/dev/null || true
+./gradlew :bluetape4k-avro:dependencies --configuration runtimeClasspath         | rg "lz4" 2>/dev/null || true
+./gradlew :bluetape4k-redisson:dependencies --configuration runtimeClasspath     | rg "lz4" 2>/dev/null || true
+
+# Spring-boot facades that aggregate kafka:
+./gradlew :bluetape4k-spring-boot3-kafka:dependencies --configuration runtimeClasspath 2>/dev/null | rg "lz4" || true
+./gradlew :bluetape4k-spring-boot4-kafka:dependencies --configuration runtimeClasspath 2>/dev/null | rg "lz4" || true
+
+# Catch-all sweep across every module that references lz4_java in its build.gradle.kts:
+rg -l "Libs\.lz4_java" --type kotlin -g "build.gradle.kts"
+```
+
+**Record**: For each module, note whether `org.lz4:lz4-java` still resolves on the classpath. Build the exclusion target list for T6.
+
+**DoD**:
+- [ ] Dependency reports captured for at least: kafka, testcontainers, pulsar (if module exists), avro (if module exists), redisson, spring-boot3-kafka, spring-boot4-kafka
+- [ ] Final list of modules requiring `configurations.all { exclude }` is documented (will be used by T6)
+- [ ] All modules in the dep-tree list either show only `at.yawk.lz4:lz4-java:1.11.0`, or are flagged for T6 exclusion
+
+**Dependencies**: T1, T2
+
+---
+
+### T4 — Add exclude block to `infra/kafka/build.gradle.kts` (complexity: low)
+
+**File**: `infra/kafka/build.gradle.kts`
+
+**Change**: At top-level (outside `dependencies { }`), add:
+```kotlin
+configurations.all {
+    // CVE-2025-12183 / CVE-2025-66566: evict abandoned org.lz4:lz4-java transitively
+    // pulled by kafka-clients/spring-kafka/reactor-kafka. We use at.yawk.lz4:lz4-java instead.
+    exclude(group = "org.lz4", module = "lz4-java")
+}
+```
+
+**DoD**:
+- [ ] Block placed at top-level of the build script (not nested under `dependencies`)
+- [ ] Comment references both CVE IDs
+- [ ] `./gradlew :bluetape4k-kafka:dependencies --configuration runtimeClasspath | rg "org.lz4"` returns **no matches**
+- [ ] `./gradlew :bluetape4k-kafka:dependencies --configuration runtimeClasspath | rg "at.yawk.lz4"` shows `at.yawk.lz4:lz4-java:1.11.0`
+
+**Dependencies**: T1, T2, T3
+
+---
+
+### T5 — Add exclude block to `testing/testcontainers/build.gradle.kts` (complexity: low)
+
+**File**: `testing/testcontainers/build.gradle.kts`
+
+**Change**: Same top-level `configurations.all { exclude(group = "org.lz4", module = "lz4-java") }` pattern as T4 with the same CVE comment.
+
+**DoD**:
+- [ ] Block placed at top-level
+- [ ] CVE comment present
+- [ ] `./gradlew :bluetape4k-testcontainers:dependencies --configuration runtimeClasspath | rg "org.lz4"` returns no matches
+
+**Dependencies**: T1, T2, T3
+
+---
+
+### T6 — Add exclude blocks to other modules flagged by T3 (complexity: medium)
+
+**Files**: Whichever `build.gradle.kts` files were flagged by T3 — candidates include but are not limited to:
+
+- `infra/pulsar/build.gradle.kts` (if module exists)
+- `io/avro/build.gradle.kts` (if module exists)
+- `infra/redisson/build.gradle.kts`
+- `spring-boot3/kafka/build.gradle.kts`
+- `spring-boot4/kafka/build.gradle.kts`
+- Any other modules from the catch-all `rg -l "Libs\.lz4_java"` sweep that still resolve `org.lz4:lz4-java` on classpath
+
+**Change**: Same top-level `configurations.all { exclude(group = "org.lz4", module = "lz4-java") }` pattern with CVE comment.
+
+**Decision rule**: If T3 dep-tree shows `org.lz4:lz4-java` still resolved on `runtimeClasspath` or `testRuntimeClasspath`, add the exclude block. If only `at.yawk.lz4:lz4-java:1.11.0` resolves, skip.
+
+**DoD**:
+- [ ] Every module flagged by T3 has the exclude block
+- [ ] Per-module re-run of `./gradlew :<module>:dependencies --configuration runtimeClasspath | rg "org.lz4"` returns no matches
+- [ ] No exclude blocks added to modules that don't need them (avoid configuration noise)
+
+**Dependencies**: T3
+
+---
+
+### T7 — Verify clean classpath + native-library coverage (complexity: medium)
+
+**Goal**: Confirm `org.lz4:lz4-java` is fully evicted across the whole project, and the new `at.yawk.lz4:lz4-java:1.11.0` JAR ships every native binary the project needs.
+
+**Commands — eviction sweep** (must produce empty results):
+```bash
+# Project-wide: enumerate every module's runtimeClasspath and testRuntimeClasspath; flag any org.lz4 hit.
+./gradlew :bluetape4k-kafka:dependencies --configuration runtimeClasspath | rg "org.lz4"
+./gradlew :bluetape4k-kafka:dependencies --configuration testRuntimeClasspath | rg "org.lz4"
+./gradlew :bluetape4k-testcontainers:dependencies --configuration runtimeClasspath | rg "org.lz4"
+# Repeat for every module flagged in T3/T6:
+for m in $(rg -l "Libs\.lz4_java" --type kotlin -g "build.gradle.kts" | sed 's|/build.gradle.kts$||;s|^|:bluetape4k-|;s|/|-|g'); do
+  ./gradlew "${m}:dependencies" --configuration runtimeClasspath 2>/dev/null | rg "org.lz4" && echo "FAIL $m"
+done
+```
+
+**Commands — native binaries inventory**:
+```bash
+# Locate the resolved JAR (Gradle cache).
+LZ4_JAR=$(fd -p '.gradle.*at.yawk.lz4.*lz4-java-1.11.0\.jar$' ~/.gradle/caches | head -1)
+unzip -l "$LZ4_JAR" | rg "(linux|darwin|windows|aix|freebsd).*(\.so|\.dylib|\.dll)$"
+```
+**Required entries** (must all be present):
+- `linux/amd64` (a.k.a. `linux-x86_64`)
+- `linux/aarch64`
+- `darwin/aarch64` (Apple Silicon — covers dev workstations)
+- `darwin/x86_64`
+- `win32/amd64`
+
+If any required platform binary is missing, **abort and surface to spec author** — yawkat fork might not cover that platform and we'd need a different remediation.
+
+**DoD**:
+- [ ] Eviction sweep returns empty output for every module
+- [ ] Native-binary inventory contains all five required platforms
+- [ ] If a platform is missing, T7 is marked failed and the issue is escalated (do not proceed to T8)
+
+**Dependencies**: T4, T5, T6
+
+---
+
+### T8 — Test execution: core/io modules (complexity: low)
+
+**Commands**:
+```bash
+./bin/repo-test-summary -- ./gradlew :bluetape4k-core:test
+./bin/repo-test-summary -- ./gradlew :bluetape4k-io:test
+```
+
+**Rationale**: `bluetape4k-io` is the home of `Compressors`/LZ4 wrappers; `bluetape4k-core` provides primitives many modules depend on. These are the most likely to surface a `net.jpountz.lz4` regression.
+
+**DoD**:
+- [ ] `:bluetape4k-core:test` BUILD SUCCESSFUL, all tests pass
+- [ ] `:bluetape4k-io:test` BUILD SUCCESSFUL, all tests pass
+- [ ] Pass count + duration recorded for each
+
+**Dependencies**: T7
+
+---
+
+### T9 — Test execution: infra modules (complexity: low)
+
+**Commands**:
+```bash
+./bin/repo-test-summary -- ./gradlew :bluetape4k-kafka:test
+./bin/repo-test-summary -- ./gradlew :bluetape4k-lettuce:test
+```
+
+**Rationale**: Kafka is the primary consumer of `lz4-java` (compression codec). Lettuce uses LZ4 in custom Redis codecs.
+
+**DoD**:
+- [ ] `:bluetape4k-kafka:test` BUILD SUCCESSFUL
+- [ ] `:bluetape4k-lettuce:test` BUILD SUCCESSFUL
+- [ ] Any test invoking LZ4 compression/decompression confirmed green
+- [ ] Pass count + duration recorded
+
+**Dependencies**: T7
+
+---
+
+### T10 — Test execution: other affected modules (complexity: low)
+
+**Commands**:
+```bash
+./bin/repo-test-summary -- ./gradlew :bluetape4k-testcontainers:test
+./bin/repo-test-summary -- ./gradlew :bluetape4k-hibernate-cache-lettuce:test
+
+# Conditional — run only if the module exists
+fd -t d "^avro$" io/ && ./bin/repo-test-summary -- ./gradlew :bluetape4k-avro:test
+fd -t d "^pulsar$" infra/ && ./bin/repo-test-summary -- ./gradlew :bluetape4k-pulsar:test
+fd -t d "^redisson$" infra/ && ./bin/repo-test-summary -- ./gradlew :bluetape4k-redisson:test
+```
+
+Also run any module that T6 added an exclude block to.
+
+**DoD**:
+- [ ] All applicable module test runs BUILD SUCCESSFUL
+- [ ] Pass count + duration recorded per module
+- [ ] No test failures attributable to the LZ4 swap
+
+**Dependencies**: T7
+
+---
+
+### T11 — README update: `infra/kafka/README.md` (English) (complexity: medium)
+
+**File**: `infra/kafka/README.md`
+
+**Add a new section** (placement: near "Dependencies" or at the end, choose what reads best):
+
+```markdown
+## Security: LZ4 Migration (CVE-2025-12183, CVE-2025-66566)
+
+`org.lz4:lz4-java` was archived in December 2025 and has two unpatched CVEs:
+
+- **CVE-2025-12183** (CVSS 8.8)
+- **CVE-2025-66566** (CVSS 8.2)
+
+This module migrates to the maintained fork **`at.yawk.lz4:lz4-java:1.11.0`**, which keeps the
+`net.jpountz.lz4.*` package namespace and is binary-compatible — no source changes are required.
+
+Because Kafka clients (`kafka-clients`, `spring-kafka`, `reactor-kafka`, `kafka-streams`) still
+declare a transitive dependency on the abandoned `org.lz4:lz4-java`, this module evicts it via:
+
+```kotlin
+configurations.all {
+    exclude(group = "org.lz4", module = "lz4-java")
+}
+```
+
+### Downstream consumers
+
+If your application directly depends on `kafka-clients` (or any of its siblings) **without** going
+through `bluetape4k-kafka`, add the same `configurations.all { exclude(...) }` block to your build
+to ensure the vulnerable JAR is not on your classpath.
+```
+
+**DoD**:
+- [ ] Section added with both CVE IDs
+- [ ] Migration explanation includes "binary-compatible / same package namespace"
+- [ ] Downstream-consumer guidance present
+- [ ] Markdown renders cleanly (no broken code fences)
+
+**Dependencies**: T4 (so the snippet matches the actual code)
+
+---
+
+### T12 — README update: `infra/kafka/README.ko.md` (Korean) (complexity: medium)
+
+**File**: `infra/kafka/README.ko.md`
+
+**Add a new section** (Korean translation of the T11 section):
+
+```markdown
+## 보안: LZ4 마이그레이션 (CVE-2025-12183, CVE-2025-66566)
+
+`org.lz4:lz4-java` 는 2025년 12월에 아카이브되었으며, 두 개의 미해결 CVE 가 있습니다:
+
+- **CVE-2025-12183** (CVSS 8.8)
+- **CVE-2025-66566** (CVSS 8.2)
+
+본 모듈은 유지보수가 지속되는 포크 **`at.yawk.lz4:lz4-java:1.11.0`** 으로 마이그레이션했습니다.
+패키지 네임스페이스 `net.jpountz.lz4.*` 가 동일하므로 **바이너리 호환** 이며, 소스 코드 변경이 필요하지 않습니다.
+
+Kafka 계열 라이브러리 (`kafka-clients`, `spring-kafka`, `reactor-kafka`, `kafka-streams`) 는
+여전히 폐기된 `org.lz4:lz4-java` 를 추이적 의존성으로 선언하므로, 본 모듈에서는 다음과 같이 제거합니다:
+
+```kotlin
+configurations.all {
+    exclude(group = "org.lz4", module = "lz4-java")
+}
+```
+
+### 다운스트림 사용자
+
+`bluetape4k-kafka` 를 거치지 않고 `kafka-clients` 등을 직접 의존하는 애플리케이션이라면,
+취약 JAR 가 classpath 에 포함되지 않도록 동일한 `configurations.all { exclude(...) }` 블록을
+빌드 스크립트에 추가하시기 바랍니다.
+```
+
+**DoD**:
+- [ ] Korean section added with both CVE IDs
+- [ ] Content matches T11 in meaning
+- [ ] Code block identical to README.md
+- [ ] Markdown renders cleanly
+
+**Dependencies**: T11 (keep both READMEs in sync)
+
+---
+
+### T13 — Commit and push (complexity: low)
+
+**Commands**:
+```bash
+git add -A
+git status   # final review
+git commit -m "fix: org.lz4 → at.yawk.lz4:1.11.0 (CVE-2025-12183, CVE-2025-66566)
+
+- buildSrc/Libs.kt: lz4_java GAV swap with CVE comment
+- root build.gradle.kts: dependencyManagement realignment
+- infra/kafka, testing/testcontainers (and other flagged modules): configurations.all exclude org.lz4
+- infra/kafka README.md / README.ko.md: CVE notice + downstream guidance
+
+Issue: #203"
+git push -u origin feat/lz4-yawkat-migration
+```
+
+PR creation is **out of scope** for this plan — the user/PR step happens after this plan's tasks are all green and `oh-my-claudecode:code-reviewer` has approved per the project's MANDATORY pre-PR checklist.
+
+**DoD**:
+- [ ] Commit message uses Korean+prefix-compatible English `fix:` prefix
+- [ ] Commit body lists every modified area
+- [ ] Issue ID `#203` in trailer
+- [ ] `git push -u origin feat/lz4-yawkat-migration` succeeds
+- [ ] Local working tree clean after push
+
+**Dependencies**: T1–T12 all green
+
+---
+
+## Dependency Graph
+
+```
+T1 ──► T2 ──► T3 ──┬─► T4 ──┐
+                   ├─► T5 ──┼──► T7 ──► T8  ──┐
+                   └─► T6 ──┘          ├─► T9 ──┼─► T11 ──► T12 ──► T13
+                                       └─► T10 ─┘
+```
+
+**Parallel opportunities**:
+- T4, T5, T6 are independent — can run in parallel after T3.
+- T8, T9, T10 are independent test runs — can run in parallel after T7.
+- T11 must precede T12 (Korean is translated from English to ensure consistency).
+
+---
+
+## Verification Summary (Whole-Plan DoD)
+
+Before declaring the plan complete:
+
+- [ ] T1–T13 each individually meet their DoD
+- [ ] Project-wide sweep `for module in <flagged>; ./gradlew :$module:dependencies --configuration runtimeClasspath | rg "org.lz4"` produces zero hits
+- [ ] At least the following module test suites pass: core, io, kafka, lettuce, testcontainers, hibernate-cache-lettuce
+- [ ] `infra/kafka/README.md` and `infra/kafka/README.ko.md` both updated and consistent
+- [ ] Branch `feat/lz4-yawkat-migration` pushed
+- [ ] PR creation deferred until pre-PR MANDATORY checklist (CLAUDE.md) is satisfied — including `oh-my-claudecode:code-reviewer` review
+
+---
+
+## Out of Scope
+
+- PR creation (handled separately, per project's MANDATORY pre-PR checklist)
+- Touching modules where `org.lz4:lz4-java` is **not** present on classpath (avoid configuration noise)
+- Bumping `at.yawk.lz4:lz4-java` past `1.11.0` (use latest stable at the time of plan only if `1.11.0` is already superseded — otherwise stay on `1.11.0`)
+- Source-level changes to LZ4 usage sites — none required because the package namespace is preserved

--- a/docs/superpowers/plans/2026-04-28-lz4-yawkat-migration-plan.md
+++ b/docs/superpowers/plans/2026-04-28-lz4-yawkat-migration-plan.md
@@ -5,6 +5,7 @@
 **Issue**: #203
 **Branch**: `feat/lz4-yawkat-migration`
 **Worktree**: `.worktrees/feat-lz4-yawkat-migration`
+**Rev**: v2 (Plan Review 반영)
 
 ---
 
@@ -15,23 +16,47 @@ Replace `org.lz4:lz4-java:1.8.0` with `at.yawk.lz4:lz4-java:1.11.0` to fix:
 - **CVE-2025-12183** (CVSS 8.8)
 - **CVE-2025-66566** (CVSS 8.2)
 
-The yawkat fork keeps the `net.jpountz.lz4.*` package namespace, so it is **binary-compatible** — no Kotlin source changes are required. The migration is a **build-config-only** change, plus runtime exclusion of the abandoned `org.lz4` JAR transitively pulled in by Kafka/Pulsar/etc.
+The yawkat fork keeps the `net.jpountz.lz4.*` package namespace — **binary-compatible**, no Kotlin source changes required. Migration is **build-config-only**.
 
 ---
 
 ## Pre-flight Constraints (Read Before Starting)
 
-1. `org.lz4:lz4-java` upstream repo was archived 2025-12. `1.8.1` is a Sonatype relocation POM (no real JAR) — do **not** bump to `1.8.1`.
+1. `org.lz4:lz4-java` upstream repo was archived 2025-12. `org.lz4:lz4-java:1.8.1` is a Sonatype relocation POM (no real JAR) — do **not** bump to `1.8.1`.
 2. BOM `dependencyManagement` swap **does NOT evict different `groupId`**. Eviction must be done via `configurations.all { exclude(group = "org.lz4", module = "lz4-java") }` in each affected module's `build.gradle.kts`.
 3. Transitive sources of `org.lz4:lz4-java`: `kafka-clients`, `spring-kafka`, `reactor-kafka`, `kafka-streams`, possibly `pulsar-client`, `avro`, `redisson`. Run dep-tree scans (T3) before assuming exclusion targets.
-4. 31 build files reference `Libs.lz4_java`. Their `compileClasspath` should pull `at.yawk.lz4:lz4-java:1.11.0` via `Libs.lz4_java` direct ref; the `org.lz4:lz4-java` artifact only appears via Kafka-family transitives.
-5. Native-library coverage check: confirm the new JAR ships native binaries for `linux-x86_64`, `linux-aarch64`, `darwin-aarch64`, `windows-x86_64` so existing CI and Mac dev workstations continue to work.
+4. 31 build files reference `Libs.lz4_java`. Most are **direct** consumers (no exclude needed); only modules that pull `org.lz4` **transitively** via Kafka/Pulsar/Avro/Redisson need `configurations.all { exclude }`.
+5. Root `build.gradle.kts:376` uses `dependency(Libs.lz4_java)` — a constant reference, NOT a literal GAV string. After T1 changes the constant, T2 is a verification step only (no edit required in root build file).
+6. **Required native binary platforms** (must all be present in the resolved JAR):
+   - `linux/amd64` (linux-x86_64)
+   - `linux/aarch64`
+   - `darwin/aarch64` (Apple Silicon)
+   - `darwin/x86_64` (Intel Mac)
+   - `win32/amd64` (windows-x86_64)
+
+---
+
+## Rollback Plan
+
+The entire migration is a single commit (T13). Rollback is:
+
+```bash
+git revert HEAD
+./gradlew :bluetape4k-kafka:build :bluetape4k-core:build
+```
+
+No Kotlin source files are changed. LZ4 compression format is standard — persisted data requires no reprocessing.
+
+**Abort criteria** (escalate to spec author, do not proceed):
+- T7 native-binary check: any required platform binary is missing
+- T8/T9/T10: test failures directly attributable to `net.jpountz.lz4` API changes (not infra/CI flakiness)
+- Any module classloader error at runtime linking to `net.jpountz.lz4`
 
 ---
 
 ## Task List
 
-### T1 — Update `Libs.lz4_java` GAV (complexity: low)
+### T1 — `Libs.lz4_java` GAV 변경 (complexity: low)
 
 **File**: `buildSrc/src/main/kotlin/Libs.kt`
 
@@ -47,69 +72,80 @@ const val lz4_java = "at.yawk.lz4:lz4-java:1.11.0"
 ```
 
 **DoD**:
-- [ ] String constant updated to `at.yawk.lz4:lz4-java:1.11.0`
-- [ ] CVE comment present immediately above the constant
-- [ ] `./gradlew help` runs without configuration error
-- [ ] `rg "org.lz4:lz4-java" buildSrc/` returns no matches in `Libs.kt`
+- [ ] `lz4_java` 상수가 `at.yawk.lz4:lz4-java:1.11.0` 으로 변경됨
+- [ ] CVE 두 번호 코멘트가 상수 바로 위에 있음
+- [ ] `./gradlew help` 오류 없이 실행됨
+- [ ] `rg "org.lz4:lz4-java" buildSrc/` 결과 없음
 
 **Dependencies**: none
 
 ---
 
-### T2 — Replace root-level dependencyManagement pin (complexity: low)
+### T2 — 루트 `dependencyManagement` 검증 (complexity: low)
 
 **File**: root `build.gradle.kts`
 
-**Change**: Inside the `dependencyManagement { dependencies { ... } }` block, replace any existing `dependency("org.lz4:lz4-java:...")` pin with `dependency("at.yawk.lz4:lz4-java:1.11.0")`.
+> ⛔ **편집 불필요**: 루트 `build.gradle.kts:376` 은 `dependency(Libs.lz4_java)` 상수 참조다.
+> T1 에서 상수 값을 바꾸면 이 라인은 자동으로 `at.yawk.lz4:lz4-java:1.11.0` 을 pin 하게 된다.
+> 이 task 는 그 결과를 검증하는 단계다 — 파일 편집 없음.
 
-**Note**: This is for *version alignment* only. It does **not** evict the `org.lz4:lz4-java` artifact when transitives request it — see T4–T6 for actual eviction.
+**Verification command**:
+```bash
+rg "lz4" build.gradle.kts
+# Expected: dependency(Libs.lz4_java) — constant reference only, no org.lz4 literal
+```
 
 **DoD**:
-- [ ] Root `build.gradle.kts` no longer pins `org.lz4:lz4-java`
-- [ ] New pin `at.yawk.lz4:lz4-java:1.11.0` present in `dependencyManagement`
-- [ ] `./gradlew help` succeeds
+- [ ] 루트 `build.gradle.kts` 에 `"org.lz4:lz4-java"` 리터럴이 없음
+- [ ] `dependency(Libs.lz4_java)` 줄이 그대로 존재함 (상수 참조 유지)
+- [ ] `./gradlew help` 성공
 
-**Dependencies**: T1 (so the version constant is consistent)
+**Dependencies**: T1
 
 ---
 
-### T3 — Pre-implementation dep-tree scan (complexity: medium)
+### T3 — Transitive dep-tree 전체 스캔 (complexity: medium)
 
-**Goal**: Identify every module whose `runtimeClasspath` (or `testRuntimeClasspath`) still contains `org.lz4:lz4-java` after T1 + T2, so we know exactly which `build.gradle.kts` files need exclude blocks (T4–T6).
+**Goal**: `org.lz4:lz4-java` 가 어떤 모듈의 `runtimeClasspath` 에 아직 남아 있는지 파악.
+직접 `Libs.lz4_java` 를 참조하는 31개 모듈은 T1 이후 자동으로 `at.yawk.lz4` 를 사용하므로 exclude 불필요.
+**Kafka/Pulsar/Avro/Redisson 경로로 org.lz4 를 transitive 하게 받는 모듈만 T6 exclude 대상이다.**
 
 **Commands**:
 ```bash
-# Always run after T1+T2 are committed (locally) so version alignment is in effect.
-./gradlew :bluetape4k-kafka:dependencies --configuration runtimeClasspath        | rg "lz4"
+# Primary transitive sources
+./gradlew :bluetape4k-kafka:dependencies --configuration runtimeClasspath | rg "lz4"
 ./gradlew :bluetape4k-testcontainers:dependencies --configuration runtimeClasspath | rg "lz4"
-./gradlew :bluetape4k-pulsar:dependencies --configuration runtimeClasspath       | rg "lz4" 2>/dev/null || true
-./gradlew :bluetape4k-avro:dependencies --configuration runtimeClasspath         | rg "lz4" 2>/dev/null || true
-./gradlew :bluetape4k-redisson:dependencies --configuration runtimeClasspath     | rg "lz4" 2>/dev/null || true
+./gradlew :bluetape4k-pulsar:dependencies --configuration runtimeClasspath | rg "lz4" 2>/dev/null || true
+./gradlew :bluetape4k-avro:dependencies --configuration runtimeClasspath | rg "lz4" 2>/dev/null || true
+./gradlew :bluetape4k-redisson:dependencies --configuration runtimeClasspath | rg "lz4" 2>/dev/null || true
 
-# Spring-boot facades that aggregate kafka:
+# Spring-boot facades
 ./gradlew :bluetape4k-spring-boot3-kafka:dependencies --configuration runtimeClasspath 2>/dev/null | rg "lz4" || true
 ./gradlew :bluetape4k-spring-boot4-kafka:dependencies --configuration runtimeClasspath 2>/dev/null | rg "lz4" || true
-
-# Catch-all sweep across every module that references lz4_java in its build.gradle.kts:
-rg -l "Libs\.lz4_java" --type kotlin -g "build.gradle.kts"
 ```
 
-**Record**: For each module, note whether `org.lz4:lz4-java` still resolves on the classpath. Build the exclusion target list for T6.
+**Decision log** (T3-decision-log): 스캔 후 각 모듈에 대해 다음 표를 작성한다:
+
+| 모듈 | org.lz4 transitive 유입 여부 | T6 exclude 필요 |
+|------|--------------------------|----------------|
+| bluetape4k-kafka | (scan result) | (yes/no) |
+| bluetape4k-testcontainers | (scan result) | (yes/no) |
+| ... | ... | ... |
 
 **DoD**:
-- [ ] Dependency reports captured for at least: kafka, testcontainers, pulsar (if module exists), avro (if module exists), redisson, spring-boot3-kafka, spring-boot4-kafka
-- [ ] Final list of modules requiring `configurations.all { exclude }` is documented (will be used by T6)
-- [ ] All modules in the dep-tree list either show only `at.yawk.lz4:lz4-java:1.11.0`, or are flagged for T6 exclusion
+- [ ] kafka, testcontainers, pulsar, avro, redisson, spring-boot3-kafka, spring-boot4-kafka 스캔 완료
+- [ ] T3-decision-log 표 작성 완료
+- [ ] T6 exclude 대상 목록 확정
 
 **Dependencies**: T1, T2
 
 ---
 
-### T4 — Add exclude block to `infra/kafka/build.gradle.kts` (complexity: low)
+### T4 — `infra/kafka/build.gradle.kts` exclude 추가 (complexity: low)
 
 **File**: `infra/kafka/build.gradle.kts`
 
-**Change**: At top-level (outside `dependencies { }`), add:
+**Change** (top-level, `dependencies {}` 블록 외부):
 ```kotlin
 configurations.all {
     // CVE-2025-12183 / CVE-2025-66566: evict abandoned org.lz4:lz4-java transitively
@@ -119,176 +155,198 @@ configurations.all {
 ```
 
 **DoD**:
-- [ ] Block placed at top-level of the build script (not nested under `dependencies`)
-- [ ] Comment references both CVE IDs
-- [ ] `./gradlew :bluetape4k-kafka:dependencies --configuration runtimeClasspath | rg "org.lz4"` returns **no matches**
-- [ ] `./gradlew :bluetape4k-kafka:dependencies --configuration runtimeClasspath | rg "at.yawk.lz4"` shows `at.yawk.lz4:lz4-java:1.11.0`
+- [ ] 블록이 top-level 에 위치 (dependencies {} 내부 아님)
+- [ ] CVE 두 번호 코멘트 포함
+- [ ] `./gradlew :bluetape4k-kafka:dependencies --configuration runtimeClasspath | rg "org.lz4"` 결과 없음
+- [ ] `./gradlew :bluetape4k-kafka:dependencies --configuration runtimeClasspath | rg "at.yawk.lz4"` 에서 `1.11.0` 확인
 
 **Dependencies**: T1, T2, T3
 
 ---
 
-### T5 — Add exclude block to `testing/testcontainers/build.gradle.kts` (complexity: low)
+### T5 — `testing/testcontainers/build.gradle.kts` exclude 추가 (complexity: low)
 
 **File**: `testing/testcontainers/build.gradle.kts`
 
-**Change**: Same top-level `configurations.all { exclude(group = "org.lz4", module = "lz4-java") }` pattern as T4 with the same CVE comment.
+T4 와 동일한 `configurations.all { exclude(group = "org.lz4", module = "lz4-java") }` 패턴.
 
 **DoD**:
-- [ ] Block placed at top-level
-- [ ] CVE comment present
-- [ ] `./gradlew :bluetape4k-testcontainers:dependencies --configuration runtimeClasspath | rg "org.lz4"` returns no matches
+- [ ] 블록이 top-level 에 위치
+- [ ] CVE 코멘트 포함
+- [ ] `./gradlew :bluetape4k-testcontainers:dependencies --configuration runtimeClasspath | rg "org.lz4"` 결과 없음
 
 **Dependencies**: T1, T2, T3
 
 ---
 
-### T6 — Add exclude blocks to other modules flagged by T3 (complexity: medium)
+### T6 — T3 결과 기반 추가 exclude 적용 (complexity: medium)
 
-**Files**: Whichever `build.gradle.kts` files were flagged by T3 — candidates include but are not limited to:
+**Files**: T3-decision-log 에서 `T6 exclude 필요: yes` 로 표시된 모든 모듈.
+후보: `infra/pulsar`, `io/avro`, `infra/redisson`, spring-boot kafka facades 등.
 
-- `infra/pulsar/build.gradle.kts` (if module exists)
-- `io/avro/build.gradle.kts` (if module exists)
-- `infra/redisson/build.gradle.kts`
-- `spring-boot3/kafka/build.gradle.kts`
-- `spring-boot4/kafka/build.gradle.kts`
-- Any other modules from the catch-all `rg -l "Libs\.lz4_java"` sweep that still resolve `org.lz4:lz4-java` on classpath
+**Change**: T4/T5 와 동일한 `configurations.all { exclude }` 패턴.
 
-**Change**: Same top-level `configurations.all { exclude(group = "org.lz4", module = "lz4-java") }` pattern with CVE comment.
-
-**Decision rule**: If T3 dep-tree shows `org.lz4:lz4-java` still resolved on `runtimeClasspath` or `testRuntimeClasspath`, add the exclude block. If only `at.yawk.lz4:lz4-java:1.11.0` resolves, skip.
+**Decision rule**:
+- T3 dep-tree 에서 `org.lz4:lz4-java` 가 `runtimeClasspath` 또는 `testRuntimeClasspath` 에 보이면 → exclude 추가
+- `at.yawk.lz4:lz4-java:1.11.0` 만 보이거나 lz4 가 없으면 → exclude 불필요 (T3-decision-log 에 `no` 기록)
+- skip 한 모듈도 T3-decision-log 에 명시 (audit trail)
 
 **DoD**:
-- [ ] Every module flagged by T3 has the exclude block
-- [ ] Per-module re-run of `./gradlew :<module>:dependencies --configuration runtimeClasspath | rg "org.lz4"` returns no matches
-- [ ] No exclude blocks added to modules that don't need them (avoid configuration noise)
+- [ ] T3-decision-log 의 모든 `yes` 모듈에 exclude 블록 추가
+- [ ] 각 모듈 `rg "org.lz4"` dep-tree 결과 없음
+- [ ] T3-decision-log skip 항목에 사유 기록
 
 **Dependencies**: T3
 
 ---
 
-### T7 — Verify clean classpath + native-library coverage (complexity: medium)
+### T7 — Classpath 완전 제거 + native library 검증 (complexity: medium)
 
-**Goal**: Confirm `org.lz4:lz4-java` is fully evicted across the whole project, and the new `at.yawk.lz4:lz4-java:1.11.0` JAR ships every native binary the project needs.
+#### 7-A. Eviction sweep (결과 없어야 함)
 
-**Commands — eviction sweep** (must produce empty results):
 ```bash
-# Project-wide: enumerate every module's runtimeClasspath and testRuntimeClasspath; flag any org.lz4 hit.
-./gradlew :bluetape4k-kafka:dependencies --configuration runtimeClasspath | rg "org.lz4"
-./gradlew :bluetape4k-kafka:dependencies --configuration testRuntimeClasspath | rg "org.lz4"
-./gradlew :bluetape4k-testcontainers:dependencies --configuration runtimeClasspath | rg "org.lz4"
-# Repeat for every module flagged in T3/T6:
-for m in $(rg -l "Libs\.lz4_java" --type kotlin -g "build.gradle.kts" | sed 's|/build.gradle.kts$||;s|^|:bluetape4k-|;s|/|-|g'); do
-  ./gradlew "${m}:dependencies" --configuration runtimeClasspath 2>/dev/null | rg "org.lz4" && echo "FAIL $m"
+exit_code=0
+
+for module in bluetape4k-kafka bluetape4k-testcontainers bluetape4k-pulsar bluetape4k-avro bluetape4k-redisson; do
+    result=$(./gradlew ":${module}:dependencies" --configuration runtimeClasspath 2>/dev/null | rg "org.lz4" || true)
+    if [[ -n "$result" ]]; then
+        echo "FAIL ${module}: $result" >&2
+        exit_code=1
+    fi
 done
+
+# T6 에서 추가된 모듈도 포함
+for module in $(cat t3-decision-log.txt | grep "yes" | awk '{print $1}'); do
+    result=$(./gradlew ":${module}:dependencies" --configuration runtimeClasspath 2>/dev/null | rg "org.lz4" || true)
+    if [[ -n "$result" ]]; then
+        echo "FAIL ${module}: $result" >&2
+        exit_code=1
+    fi
+done
+
+exit ${exit_code}
 ```
 
-**Commands — native binaries inventory**:
+#### 7-B. Native binary 플랫폼 커버리지 확인
+
 ```bash
-# Locate the resolved JAR (Gradle cache).
 LZ4_JAR=$(fd -p '.gradle.*at.yawk.lz4.*lz4-java-1.11.0\.jar$' ~/.gradle/caches | head -1)
 unzip -l "$LZ4_JAR" | rg "(linux|darwin|windows|aix|freebsd).*(\.so|\.dylib|\.dll)$"
 ```
-**Required entries** (must all be present):
-- `linux/amd64` (a.k.a. `linux-x86_64`)
-- `linux/aarch64`
-- `darwin/aarch64` (Apple Silicon — covers dev workstations)
-- `darwin/x86_64`
-- `win32/amd64`
 
-If any required platform binary is missing, **abort and surface to spec author** — yawkat fork might not cover that platform and we'd need a different remediation.
+**필수 플랫폼** (모두 존재해야 함):
+- `linux/amd64` (= linux-x86_64)
+- `linux/aarch64`
+- `darwin/aarch64` (Apple Silicon)
+- `darwin/x86_64` (Intel Mac)
+- `win32/amd64` (= windows-x86_64)
+
+플랫폼 누락 시 → **즉시 중단, spec author 에게 에스컬레이션. T8 진행 금지.**
 
 **DoD**:
-- [ ] Eviction sweep returns empty output for every module
-- [ ] Native-binary inventory contains all five required platforms
-- [ ] If a platform is missing, T7 is marked failed and the issue is escalated (do not proceed to T8)
+- [ ] 7-A exit code 0 (모든 모듈에서 org.lz4 없음)
+- [ ] 7-B 5개 플랫폼 binary 모두 확인
 
 **Dependencies**: T4, T5, T6
 
 ---
 
-### T8 — Test execution: core/io modules (complexity: low)
+### T8 — 테스트: core/io 모듈 (complexity: low)
 
-**Commands**:
 ```bash
 ./bin/repo-test-summary -- ./gradlew :bluetape4k-core:test
 ./bin/repo-test-summary -- ./gradlew :bluetape4k-io:test
 ```
 
-**Rationale**: `bluetape4k-io` is the home of `Compressors`/LZ4 wrappers; `bluetape4k-core` provides primitives many modules depend on. These are the most likely to surface a `net.jpountz.lz4` regression.
-
 **DoD**:
-- [ ] `:bluetape4k-core:test` BUILD SUCCESSFUL, all tests pass
-- [ ] `:bluetape4k-io:test` BUILD SUCCESSFUL, all tests pass
-- [ ] Pass count + duration recorded for each
+- [ ] `:bluetape4k-core:test` BUILD SUCCESSFUL
+- [ ] `:bluetape4k-io:test` BUILD SUCCESSFUL
 
 **Dependencies**: T7
 
 ---
 
-### T9 — Test execution: infra modules (complexity: low)
+### T9 — 테스트: infra 모듈 (complexity: low)
 
-**Commands**:
 ```bash
 ./bin/repo-test-summary -- ./gradlew :bluetape4k-kafka:test
 ./bin/repo-test-summary -- ./gradlew :bluetape4k-lettuce:test
 ```
 
-**Rationale**: Kafka is the primary consumer of `lz4-java` (compression codec). Lettuce uses LZ4 in custom Redis codecs.
-
 **DoD**:
 - [ ] `:bluetape4k-kafka:test` BUILD SUCCESSFUL
 - [ ] `:bluetape4k-lettuce:test` BUILD SUCCESSFUL
-- [ ] Any test invoking LZ4 compression/decompression confirmed green
-- [ ] Pass count + duration recorded
 
 **Dependencies**: T7
 
 ---
 
-### T10 — Test execution: other affected modules (complexity: low)
+### T10 — 테스트: 기타 영향 모듈 (complexity: low)
 
-**Commands**:
 ```bash
 ./bin/repo-test-summary -- ./gradlew :bluetape4k-testcontainers:test
 ./bin/repo-test-summary -- ./gradlew :bluetape4k-hibernate-cache-lettuce:test
 
-# Conditional — run only if the module exists
+# 모듈 존재 시 조건부 실행
 fd -t d "^avro$" io/ && ./bin/repo-test-summary -- ./gradlew :bluetape4k-avro:test
 fd -t d "^pulsar$" infra/ && ./bin/repo-test-summary -- ./gradlew :bluetape4k-pulsar:test
 fd -t d "^redisson$" infra/ && ./bin/repo-test-summary -- ./gradlew :bluetape4k-redisson:test
 ```
 
-Also run any module that T6 added an exclude block to.
+T6 에서 exclude 추가된 모듈도 포함하여 실행.
 
 **DoD**:
-- [ ] All applicable module test runs BUILD SUCCESSFUL
-- [ ] Pass count + duration recorded per module
-- [ ] No test failures attributable to the LZ4 swap
+- [ ] 적용 가능한 모든 모듈 BUILD SUCCESSFUL
+- [ ] LZ4 관련 테스트 실패 없음
 
 **Dependencies**: T7
 
 ---
 
-### T11 — README update: `infra/kafka/README.md` (English) (complexity: medium)
+### T11 — Kotlin 소스 변경 없음 검증 (complexity: low)
 
-**File**: `infra/kafka/README.md`
+```bash
+git diff develop...HEAD -- '*.kt' | rg -v '^(\+\+\+|---|\-\-\-)' | rg "^[+-]"
+# Expected: 출력 없음 (build.gradle.kts 제외 kt 파일 변경 없어야 함)
+```
 
-**Add a new section** (placement: near "Dependencies" or at the end, choose what reads best):
+또는:
+```bash
+git diff develop...HEAD --name-only -- '*.kt'
+# Expected: 빈 출력
+```
+
+**DoD**:
+- [ ] `.kt` 파일 변경 없음 (build.gradle.kts 는 OK)
+- [ ] 변경된 파일이 있다면 즉시 원인 파악 + 스펙 위반 여부 확인
+
+**Dependencies**: T8, T9, T10
+
+---
+
+### T12 — README 업데이트: 변경된 모든 모듈 (complexity: medium)
+
+**Scope**: T4, T5, T6 에서 수정된 모든 모듈의 `README.md` + `README.ko.md`.
+
+CLAUDE.md 규칙: "모듈 변경 시 README.md + README.ko.md 동기화 업데이트".
+
+#### T12-A. `infra/kafka/README.md` (English)
+
+보안 섹션 추가:
 
 ```markdown
 ## Security: LZ4 Migration (CVE-2025-12183, CVE-2025-66566)
 
 `org.lz4:lz4-java` was archived in December 2025 and has two unpatched CVEs:
 
-- **CVE-2025-12183** (CVSS 8.8)
-- **CVE-2025-66566** (CVSS 8.2)
+- **CVE-2025-12183** (CVSS 8.8) — out-of-bounds read
+- **CVE-2025-66566** (CVSS 8.2) — uninitialized buffer info leak
 
 This module migrates to the maintained fork **`at.yawk.lz4:lz4-java:1.11.0`**, which keeps the
-`net.jpountz.lz4.*` package namespace and is binary-compatible — no source changes are required.
+`net.jpountz.lz4.*` package namespace (binary-compatible — no source changes required).
 
 Because Kafka clients (`kafka-clients`, `spring-kafka`, `reactor-kafka`, `kafka-streams`) still
-declare a transitive dependency on the abandoned `org.lz4:lz4-java`, this module evicts it via:
+declare a transitive dependency on `org.lz4:lz4-java`, this module evicts it via:
 
 ```kotlin
 configurations.all {
@@ -300,38 +358,24 @@ configurations.all {
 
 If your application directly depends on `kafka-clients` (or any of its siblings) **without** going
 through `bluetape4k-kafka`, add the same `configurations.all { exclude(...) }` block to your build
-to ensure the vulnerable JAR is not on your classpath.
+to prevent the vulnerable JAR from appearing on your classpath.
 ```
 
-**DoD**:
-- [ ] Section added with both CVE IDs
-- [ ] Migration explanation includes "binary-compatible / same package namespace"
-- [ ] Downstream-consumer guidance present
-- [ ] Markdown renders cleanly (no broken code fences)
-
-**Dependencies**: T4 (so the snippet matches the actual code)
-
----
-
-### T12 — README update: `infra/kafka/README.ko.md` (Korean) (complexity: medium)
-
-**File**: `infra/kafka/README.ko.md`
-
-**Add a new section** (Korean translation of the T11 section):
+#### T12-B. `infra/kafka/README.ko.md` (Korean)
 
 ```markdown
 ## 보안: LZ4 마이그레이션 (CVE-2025-12183, CVE-2025-66566)
 
 `org.lz4:lz4-java` 는 2025년 12월에 아카이브되었으며, 두 개의 미해결 CVE 가 있습니다:
 
-- **CVE-2025-12183** (CVSS 8.8)
-- **CVE-2025-66566** (CVSS 8.2)
+- **CVE-2025-12183** (CVSS 8.8) — 범위 초과 읽기(OOB read)
+- **CVE-2025-66566** (CVSS 8.2) — 미초기화 버퍼 정보 유출
 
-본 모듈은 유지보수가 지속되는 포크 **`at.yawk.lz4:lz4-java:1.11.0`** 으로 마이그레이션했습니다.
-패키지 네임스페이스 `net.jpountz.lz4.*` 가 동일하므로 **바이너리 호환** 이며, 소스 코드 변경이 필요하지 않습니다.
+본 모듈은 유지보수가 활발한 포크 **`at.yawk.lz4:lz4-java:1.11.0`** 으로 마이그레이션했습니다.
+패키지 네임스페이스 `net.jpountz.lz4.*` 가 동일하므로 **바이너리 호환** — 소스 코드 변경 불필요.
 
-Kafka 계열 라이브러리 (`kafka-clients`, `spring-kafka`, `reactor-kafka`, `kafka-streams`) 는
-여전히 폐기된 `org.lz4:lz4-java` 를 추이적 의존성으로 선언하므로, 본 모듈에서는 다음과 같이 제거합니다:
+Kafka 계열 라이브러리 (`kafka-clients`, `spring-kafka`, `reactor-kafka`, `kafka-streams`) 가
+여전히 `org.lz4:lz4-java` 를 추이적 의존성으로 선언하므로, 다음과 같이 제거합니다:
 
 ```kotlin
 configurations.all {
@@ -341,48 +385,59 @@ configurations.all {
 
 ### 다운스트림 사용자
 
-`bluetape4k-kafka` 를 거치지 않고 `kafka-clients` 등을 직접 의존하는 애플리케이션이라면,
+`bluetape4k-kafka` 를 거치지 않고 `kafka-clients` 등을 직접 의존하는 경우,
 취약 JAR 가 classpath 에 포함되지 않도록 동일한 `configurations.all { exclude(...) }` 블록을
 빌드 스크립트에 추가하시기 바랍니다.
 ```
 
-**DoD**:
-- [ ] Korean section added with both CVE IDs
-- [ ] Content matches T11 in meaning
-- [ ] Code block identical to README.md
-- [ ] Markdown renders cleanly
+#### T12-C. T6 에서 exclude 추가된 기타 모듈
 
-**Dependencies**: T11 (keep both READMEs in sync)
+T6 에서 수정된 각 모듈의 README.md + README.ko.md 에 다음 간략한 CVE 마이그레이션 안내 추가:
+
+```markdown
+## 참고: LZ4 의존성 마이그레이션
+
+`org.lz4:lz4-java` (CVE-2025-12183, CVE-2025-66566) 보안 이슈로 인해
+`at.yawk.lz4:lz4-java:1.11.0` 으로 마이그레이션되었습니다.
+`net.jpountz.lz4.*` 패키지 네임스페이스가 동일하므로 소스 코드 변경은 불필요합니다.
+```
+
+**DoD**:
+- [ ] T4/T5/T6 에서 수정된 모든 모듈의 README.md + README.ko.md 업데이트
+- [ ] `infra/kafka` README 에 CVE 번호, exclude 코드 블록, downstream 안내 포함
+- [ ] 마크다운 코드 펜스 렌더링 오류 없음
+
+**Dependencies**: T4, T5, T6
 
 ---
 
-### T13 — Commit and push (complexity: low)
+### T13 — Commit + Push (complexity: low)
 
-**Commands**:
 ```bash
 git add -A
-git status   # final review
-git commit -m "fix: org.lz4 → at.yawk.lz4:1.11.0 (CVE-2025-12183, CVE-2025-66566)
+git status   # 최종 확인
 
-- buildSrc/Libs.kt: lz4_java GAV swap with CVE comment
-- root build.gradle.kts: dependencyManagement realignment
-- infra/kafka, testing/testcontainers (and other flagged modules): configurations.all exclude org.lz4
-- infra/kafka README.md / README.ko.md: CVE notice + downstream guidance
+# Kotlin 소스 변경 없음 최종 검증
+git diff --name-only HEAD -- '*.kt' | rg -v 'build.gradle' | head
 
-Issue: #203"
+git commit -m "fix: org.lz4 → at.yawk.lz4:1.11.0 으로 마이그레이션 (CVE-2025-12183, CVE-2025-66566)
+
+- buildSrc/Libs.kt: lz4_java GAV 변경 + CVE 코멘트
+- infra/kafka, testing/testcontainers (+ T6 추가 모듈): configurations.all exclude org.lz4
+- infra/kafka README.md / README.ko.md: CVE 보안 안내 + 다운스트림 마이그레이션 가이드
+
+이슈: #203"
+
 git push -u origin feat/lz4-yawkat-migration
 ```
 
-PR creation is **out of scope** for this plan — the user/PR step happens after this plan's tasks are all green and `oh-my-claudecode:code-reviewer` has approved per the project's MANDATORY pre-PR checklist.
-
 **DoD**:
-- [ ] Commit message uses Korean+prefix-compatible English `fix:` prefix
-- [ ] Commit body lists every modified area
-- [ ] Issue ID `#203` in trailer
-- [ ] `git push -u origin feat/lz4-yawkat-migration` succeeds
-- [ ] Local working tree clean after push
+- [ ] 커밋 메시지 한국어 + `fix:` prefix
+- [ ] `#203` 이슈 참조 포함
+- [ ] `git push` 성공
+- [ ] 워킹 트리 clean
 
-**Dependencies**: T1–T12 all green
+**Dependencies**: T1–T12 모두 완료
 
 ---
 
@@ -390,34 +445,34 @@ PR creation is **out of scope** for this plan — the user/PR step happens after
 
 ```
 T1 ──► T2 ──► T3 ──┬─► T4 ──┐
-                   ├─► T5 ──┼──► T7 ──► T8  ──┐
-                   └─► T6 ──┘          ├─► T9 ──┼─► T11 ──► T12 ──► T13
-                                       └─► T10 ─┘
+                   ├─► T5 ──┼──► T7 ──┬─► T8  ──┐
+                   └─► T6 ──┘         ├─► T9  ──┼──► T11 ──► T12 ──► T13
+                                      └─► T10 ──┘
 ```
 
-**Parallel opportunities**:
-- T4, T5, T6 are independent — can run in parallel after T3.
-- T8, T9, T10 are independent test runs — can run in parallel after T7.
-- T11 must precede T12 (Korean is translated from English to ensure consistency).
+**병렬 실행 가능**:
+- T4, T5, T6 — T3 완료 후 병렬
+- T8, T9, T10 — T7 완료 후 병렬
 
 ---
 
-## Verification Summary (Whole-Plan DoD)
+## Verification Summary (전체 Plan DoD)
 
-Before declaring the plan complete:
-
-- [ ] T1–T13 each individually meet their DoD
-- [ ] Project-wide sweep `for module in <flagged>; ./gradlew :$module:dependencies --configuration runtimeClasspath | rg "org.lz4"` produces zero hits
-- [ ] At least the following module test suites pass: core, io, kafka, lettuce, testcontainers, hibernate-cache-lettuce
-- [ ] `infra/kafka/README.md` and `infra/kafka/README.ko.md` both updated and consistent
-- [ ] Branch `feat/lz4-yawkat-migration` pushed
-- [ ] PR creation deferred until pre-PR MANDATORY checklist (CLAUDE.md) is satisfied — including `oh-my-claudecode:code-reviewer` review
+- [ ] T1–T13 각 task DoD 충족
+- [ ] T7 project-wide eviction sweep exit code 0
+- [ ] 최소 통과 테스트 모듈: core, io, kafka, lettuce, testcontainers, hibernate-cache-lettuce
+- [ ] T11: `.kt` 파일 변경 없음 확인
+- [ ] `infra/kafka/README.md` + `README.ko.md` 업데이트 완료
+- [ ] T6 변경 모듈 README 동기화 완료
+- [ ] `feat/lz4-yawkat-migration` 브랜치 push 완료
+- [ ] PR 생성은 MANDATORY pre-PR 체크리스트 충족 후 별도 진행 (code-reviewer 에이전트 포함)
 
 ---
 
 ## Out of Scope
 
-- PR creation (handled separately, per project's MANDATORY pre-PR checklist)
-- Touching modules where `org.lz4:lz4-java` is **not** present on classpath (avoid configuration noise)
-- Bumping `at.yawk.lz4:lz4-java` past `1.11.0` (use latest stable at the time of plan only if `1.11.0` is already superseded — otherwise stay on `1.11.0`)
-- Source-level changes to LZ4 usage sites — none required because the package namespace is preserved
+- PR 생성 (CLAUDE.md MANDATORY pre-PR 체크리스트 별도)
+- `org.lz4` 가 classpath 에 없는 모듈에 불필요한 exclude 추가
+- `at.yawk.lz4:lz4-java` 를 `1.11.0` 초과로 업그레이드
+- Kotlin 소스 레벨 LZ4 API 변경 — namespace 유지로 불필요
+- `workshop/`, `examples/`, `x-obsoleted/` 디렉토리 수정

--- a/docs/superpowers/specs/2026-04-28-lz4-yawkat-migration-design.md
+++ b/docs/superpowers/specs/2026-04-28-lz4-yawkat-migration-design.md
@@ -1,0 +1,328 @@
+# LZ4 yawkat 마이그레이션 설계 (Issue #203)
+
+- 작성일: 2026-04-28
+- 브랜치: `feat/lz4-yawkat-migration`
+- 워크트리: `.worktrees/feat-lz4-yawkat-migration`
+- 관련 이슈: [#203](https://github.com/bluetape4k/bluetape4k-projects/issues/203)
+- Rev: v2 (2026-04-28, Spec Review 반영)
+
+---
+
+## 1. 배경 및 목표
+
+### 1.1 배경
+
+`org.lz4:lz4-java` (lz4/lz4-java repo) 에서 **2개의 HIGH CVE** 가 보고되었고,
+원본 repo `lz4/lz4-java` 는 **2025년 12월 archived** 상태로 전환되어 유지보수가 중단되었다.
+
+이에 따라 동일 패키지 (`net.jpountz.lz4.*`) namespace 를 유지하면서 fork 형태로 활발히 유지되는
+`at.yawk.lz4:lz4-java` 로 전환한다.
+
+### 1.2 사실 자료 (Step 1-R + Spec Review 결과)
+
+**CVE 현황:**
+
+| CVE | CVSS | 내용 | fix 버전 |
+|-----|------|------|---------|
+| **CVE-2025-12183** | 8.8 HIGH | out-of-bounds read (OOB) | `at.yawk.lz4:lz4-java:1.8.1+` |
+| **CVE-2025-66566** | 8.2 HIGH | Java decompressor 미초기화 버퍼 정보 유출 | `at.yawk.lz4:lz4-java:1.10.1+` |
+
+> **주의**: `org.lz4:lz4-java:1.8.1` 은 실제 JAR 바이너리가 없는 **Sonatype relocation POM** 이다.
+> Gradle 이 이를 resolve 하면 `at.yawk.lz4:lz4-java:1.8.1` 로 리디렉션된다.
+> CVE-2025-66566 은 1.8.1 에서 미패치이므로, relocation 경로로는 CVE 를 완전히 해소할 수 없다.
+> **목표 버전 `1.11.0` 이 두 CVE 모두 패치된 최신 안전 버전이다.**
+
+**아티팩트 현황:**
+
+- **`org.lz4:lz4-java`**: 최신 버전 1.8.1 (relocation POM), 원본 repo 2025-12 archived (유지 중단)
+- **`at.yawk.lz4:lz4-java`**: Maven Central 존재 확인
+  - URL: `repo1.maven.org/maven2/at/yawk/lz4/lz4-java/maven-metadata.xml`
+  - 최신 버전: **1.11.0** (2026-04-09), Maven Central GPG 서명 포함
+  - 버전 히스토리: 1.8.1 → 1.9.0 → 1.10.0 → 1.10.1 (CVE-2025-66566 fix) → 1.10.4 → 1.11.0
+  - Sonatype 이 `org.lz4:lz4-java:1.8.1` 을 `at.yawk.lz4` 로 relocation 한 것은 공식 후계자 인정
+
+**Binary compatibility:**
+- 두 artifact 모두 `net.jpountz.lz4.*` 동일 패키지 namespace
+- CVE-2025-12183 fix 로 `LZ4Factory.nativeInstance()` / `unsafeInstance()` 가 안전한 Java 구현을 반환하도록 변경됨 (native 성능 의존 코드에서 성능 저하 가능 — 기능은 동일)
+
+**직접 사용 모듈**: 30개 모듈 `build.gradle.kts` + 루트 `build.gradle.kts` BOM = 총 31개 파일에서 `Libs.lz4_java` 참조
+(`compileOnly`/`runtimeOnly`/`testImplementation`/`implementation` 혼합)
+
+**Kafka transitive chain (직접 확인됨):**
+- `infra/kafka` — `api(Libs.kafka_clients)`, `implementation(Libs.spring_kafka)`, `implementation(Libs.reactor_kafka)`, `compileOnly(Libs.kafka_streams)`, `testImplementation(Libs.kafka_streams_test_utils)` → 모두 `kafka-clients` → `org.lz4:lz4-java` pull
+- `testing/testcontainers` — `compileOnly(Libs.kafka_clients)`, `compileOnly(Libs.spring_kafka)` → 동일 경로
+
+**추가 transitive chain (구현 전 검증 필요):**
+- `infra/pulsar` — `api(Libs.pulsar_client)`: Pulsar 은 LZ4 codec 내장
+- `io/avro` — `api(Libs.avro)` + `runtimeOnly(Libs.lz4_java)`: Avro LZ4 codec 사용
+- `infra/redisson` / `data/*-redisson` — Redisson 이 LZ4 를 선택적 압축에 사용
+- 기타: `./gradlew dependencies --configuration runtimeClasspath | rg "org.lz4"` 전체 스캔으로 최종 확인
+
+### 1.3 목표
+
+`at.yawk.lz4:lz4-java:1.11.0` 으로 **단일 전환** — `org.lz4:lz4-java` 를 runtime classpath 에서 완전 제거.
+
+CVE-2025-12183 + CVE-2025-66566 동시 패치 + 장기적으로 활발히 유지되는 fork 사용.
+
+### 1.4 승인 체크리스트
+
+- [ ] 두 CVE (CVE-2025-12183, CVE-2025-66566) 의 영향도 및 우선순위 합의
+- [ ] `at.yawk.lz4:lz4-java:1.11.0` 단일 전환 방향 합의
+- [ ] "단일 전환 = runtime classpath 완전 제거 (transitive 포함)" 의미 합의
+
+---
+
+## 2. 리스크 분석
+
+### 2.1 리스크 1 — `org.lz4:lz4-java` transitive 유입 경로 (다수)
+
+`kafka-clients` 뿐만 아니라 `spring_kafka`, `reactor_kafka`, `kafka_streams`, `kafka_streams_test_utils`, `pulsar_client`, `avro` 등이 모두 `org.lz4:lz4-java` 를 transitively pull 한다.
+
+단일 dependency 에 `exclude` 를 적용하는 방식은 **다른 경로를 통해 re-entry 를 막지 못한다**.
+
+**완화 전략 (CRITICAL-1 수정):**
+
+`infra/kafka` 와 `testing/testcontainers` 에서 **module-wide** exclude 적용:
+
+```kotlin
+configurations.all {
+    exclude(group = "org.lz4", module = "lz4-java")
+}
+```
+
+이 방식은 해당 모듈의 모든 configuration (api, implementation, compileOnly, testImplementation, runtimeOnly 등) 에서 `org.lz4:lz4-java` 를 차단한다.
+
+추가로 `infra/pulsar`, `io/avro`, `infra/redisson` 등 다른 경로에서의 유입은 구현 전 dep-tree 전체 스캔으로 확인 후 필요 시 추가 exclude 적용.
+
+**DoD 검증**: `./gradlew dependencies --configuration runtimeClasspath | rg "org.lz4"` 를 영향 모듈 전체에 실행 후 결과 없음 확인.
+
+### 2.2 리스크 2 — Binary-compatible 가정 검증
+
+두 artifact 모두 동일한 `net.jpountz.lz4.*` 패키지를 사용하지만, 다음을 검증해야 한다:
+
+- **Native library 플랫폼 커버리지**: `at.yawk.lz4:lz4-java:1.11.0` JAR 내 native binary 가 Linux x86_64, Linux aarch64, macOS aarch64, macOS x86_64 플랫폼을 지원하는지 확인 필요
+  - `LZ4Factory.fastestInstance()` 가 실제로 JNI 구현(`LZ4JNIFactory`)을 반환하는지 테스트로 assert
+  - 네이티브 로드 실패 시 pure Java 로 fallback (에러 없이 성능만 저하)
+- **API 시그니처 동등성**: 1.11.0 에서 핵심 클래스(`LZ4Factory`, `LZ4Compressor` 등) 시그니처 유지 확인 → 컴파일 + 테스트 통과로 검증
+
+**완화 전략**:
+- exclude 규칙으로 classpath 에 하나의 lz4 artifact 만 존재하게 함
+- DoD 에 native library 플랫폼 검증 항목 추가
+
+### 2.3 리스크 3 — 루트 BOM `dependencyManagement` (버전 정합)
+
+루트 `build.gradle.kts` 의 `dependencyManagement` 블록의 `org.lz4:lz4-java` 핀은 `Libs.lz4_java` 좌표 변경 후 **다른 groupId 의 artifact 를 가리키게 된다**.
+
+> ⛔ **중요 제약**: `dependencyManagement` BOM 핀은 **동일 groupId 내 버전만 강제**한다.
+> `at.yawk.lz4:lz4-java` 를 핀해도 `org.lz4:lz4-java` transitive 유입을 막지 못한다 — groupId 가 다르기 때문.
+> 실제 eviction 은 §2.1 의 `configurations.all { exclude(...) }` 가 수행한다.
+
+따라서 BOM 변경은 `at.yawk.lz4` 의 버전을 일관되게 관리하기 위한 문서화 목적이며, `org.lz4` 제거 메커니즘은 exclude 규칙이다.
+
+**완화 전략**: BOM 에서 `org.lz4:lz4-java` 핀을 `at.yawk.lz4:lz4-java:1.11.0` 으로 교체 (버전 정합) + exclude 규칙 (실제 eviction).
+
+### 2.4 리스크 4 — Rollback
+
+이번 변경은 Kotlin 소스 변경 없이 build.gradle.kts + Libs.kt 만 수정하므로 rollback 이 단순하다.
+
+**Rollback 절차**: `Libs.kt` + `build.gradle.kts` (루트 BOM, infra/kafka, testing/testcontainers) 를 git revert 한 단일 커밋으로 복구. 압축 데이터 형식은 LZ4 표준 포맷으로 두 구현 모두 동일하게 처리하므로 영속화 데이터 재처리 불필요.
+
+### 2.5 승인 체크리스트
+
+- [ ] 4개 리스크가 충분히 식별되었는가
+- [ ] exclude 범위 (`configurations.all`) 가 단일 dependency exclude 보다 안전함에 동의
+- [ ] BOM 변경이 org.lz4 제거 메커니즘이 아님을 확인
+
+---
+
+## 3. 접근 방식 비교
+
+### 3.1 Option A — `org.lz4:lz4-java:1.8.1` 로만 업그레이드 ❌ **기각**
+
+**개요**: artifact 좌표 변경 없이 버전만 1.8.0 → 1.8.1 로 올린다.
+
+> **⚠️ 중요**: `org.lz4:lz4-java:1.8.1` 은 Maven Central 에 **실제 JAR 가 없는 relocation POM** 이다.
+> Gradle 이 resolve 하면 `at.yawk.lz4:lz4-java:1.8.1` 로 자동 리디렉션된다.
+> 즉 Option A 는 의도치 않게 Option B 를 수행하는 것과 같으나, **CVE-2025-66566 이 미패치된 1.8.1 버전으로 고정**된다.
+
+| 구분 | 내용 |
+|------|------|
+| 변경량 | `Libs.lz4_java` 1줄 |
+| CVE-2025-12183 패치 | ✅ (1.8.1 에서 fix) |
+| CVE-2025-66566 패치 | ❌ **미패치** (1.10.1+ 에서 fix) |
+| 장기 유지보수 | ❌ archived repo 의존 지속 |
+| 추가 작업 | 없음 |
+
+### 3.2 Option B — `at.yawk.lz4:lz4-java:1.11.0` 로 전환 ✅ **선택**
+
+**개요**: artifact 자체를 yawkat fork 최신 버전으로 전환.
+
+| 구분 | 내용 |
+|------|------|
+| 변경량 | `Libs.lz4_java` + 루트 BOM + `configurations.all { exclude }` (2개 모듈) + README |
+| CVE-2025-12183 패치 | ✅ |
+| CVE-2025-66566 패치 | ✅ (1.10.1+ 에서 fix, 1.11.0 포함) |
+| 장기 유지보수 | ✅ 활발히 유지 (1.11.0 이 2026-04-09 릴리즈) |
+| 추가 작업 | `configurations.all { exclude }` (2개 모듈) |
+
+### 3.3 선택 사유
+
+- `org.lz4` repo 가 archived → 미래 CVE 발생 시 패치 불가
+- Option A 는 CVE-2025-66566 (CVSS 8.2 HIGH, 정보 유출) 을 미패치
+- yawkat fork 는 `net.jpountz.lz4.*` namespace 를 유지하므로 직접 사용 코드 (30개 모듈) 무수정
+- Sonatype 이 공식 relocation POM 을 통해 yawkat fork 를 후계자로 인정
+
+### 3.4 승인 체크리스트
+
+- [ ] Option A 가 relocation POM 이며 CVE-2025-66566 미패치임에 동의
+- [ ] Option B 의 추가 작업 (`configurations.all { exclude }` × 2 모듈) 이 수용 가능함에 동의
+
+---
+
+## 4. 구현 계획
+
+### 4.0 사전 작업 — Transitive dep-tree 전체 스캔
+
+구현 전, `org.lz4:lz4-java` 가 어떤 경로로 유입되는지 전체 파악:
+
+```bash
+./gradlew dependencies --configuration runtimeClasspath | rg "org.lz4" 2>&1 | sort -u
+```
+
+또는 변경 예상 모듈별:
+
+```bash
+for m in bluetape4k-kafka bluetape4k-testcontainers bluetape4k-pulsar bluetape4k-avro bluetape4k-redisson bluetape4k-lettuce; do
+    echo "=== $m ==="
+    ./gradlew :$m:dependencies --configuration runtimeClasspath | rg "org.lz4"
+done
+```
+
+결과에 따라 §4.1.3-4.1.4 외 추가 exclude 모듈을 결정한다.
+
+### 4.1 변경 대상
+
+#### 4.1.1 `buildSrc/src/main/kotlin/Libs.kt`
+
+```kotlin
+// Before
+const val lz4_java = "org.lz4:lz4-java:1.8.0"                     // https://mvnrepository.com/artifact/org.lz4/lz4-java
+// kafka clients 내부에 기존 lz4-java 를 사용한다.
+// const val lz4_java = "at.yawk.lz4:lz4-java:1.8.1"              // https://mvnrepository.com/artifact/at.yawk.lz4/lz4-java
+
+// After
+// CVE-2025-12183 (CVSS 8.8) + CVE-2025-66566 (CVSS 8.2) fix.
+// org.lz4/lz4-java archived 2025-12. yawkat fork keeps net.jpountz.lz4.* namespace (binary-compatible).
+const val lz4_java = "at.yawk.lz4:lz4-java:1.11.0"                // https://mvnrepository.com/artifact/at.yawk.lz4/lz4-java
+```
+
+#### 4.1.2 루트 `build.gradle.kts` — `dependencyManagement`
+
+`org.lz4:lz4-java` BOM pin → `at.yawk.lz4:lz4-java:1.11.0` 로 교체 (버전 정합 목적; eviction 은 §4.1.3-4.1.4 exclude 가 수행).
+
+#### 4.1.3 `infra/kafka/build.gradle.kts`
+
+```kotlin
+// org.lz4:lz4-java 가 kafka-clients, spring-kafka, reactor-kafka, kafka-streams 경로 모두를 통해 유입된다.
+// 단일 dependency exclude 가 아닌 configuration-wide exclude 로 모든 경로를 차단한다.
+configurations.all {
+    exclude(group = "org.lz4", module = "lz4-java")
+}
+```
+
+#### 4.1.4 `testing/testcontainers/build.gradle.kts`
+
+동일한 `configurations.all { exclude(group = "org.lz4", module = "lz4-java") }` 추가.
+
+#### 4.1.5 추가 exclude (사전 dep-tree 스캔 결과에 따라)
+
+`infra/pulsar`, `io/avro`, `infra/redisson` 등에서 `org.lz4` 유입이 확인되면 동일한 `configurations.all { exclude }` 적용.
+
+#### 4.1.6 README 업데이트
+
+- `infra/kafka/README.md` (영문) — CVE-2025-12183 + CVE-2025-66566 + yawkat 전환 안내 + 직접 lz4 사용자 마이그레이션 가이드
+- `infra/kafka/README.ko.md` (한글) — 동일 내용
+
+README 포함 내용:
+- CVE 배경 (두 CVE 번호 + CVSS)
+- `org.lz4` → `at.yawk.lz4` 전환 근거
+- 직접 `org.lz4:lz4-java` 를 사용하는 다운스트림 사용자를 위한 안내: `at.yawk.lz4:lz4-java:1.11.0` 으로 교체, 코드 변경 불필요 (동일 namespace)
+- kafka-clients 와 함께 사용 시 exclude 안내
+
+### 4.2 변경 불필요 항목
+
+| 항목 | 사유 |
+|------|------|
+| 30개 직접 참조 모듈의 build.gradle.kts | `Libs.lz4_java` 값만 바뀌므로 수정 불필요 |
+| Kotlin 소스 코드 (`net.jpountz.lz4.*` import) | binary-compatible (동일 namespace) |
+| KDoc 신규 작성 | dependency 변경만이므로 public API 변경 없음 |
+
+### 4.3 작업 순서
+
+1. `Libs.kt` 변경 (`org.lz4` → `at.yawk.lz4:1.11.0`)
+2. 루트 `build.gradle.kts` `dependencyManagement` 교체
+3. `infra/kafka/build.gradle.kts` `configurations.all { exclude }` 추가
+4. `testing/testcontainers/build.gradle.kts` 동일
+5. **dep-tree 전체 스캔** — `org.lz4` 흔적 있으면 §4.1.5 에 따라 추가 exclude
+6. `:bluetape4k-kafka:test`, `:bluetape4k-core:test`, `:bluetape4k-io:test`, `:bluetape4k-lettuce:test` 실행
+7. `:bluetape4k-testcontainers:test`, `:bluetape4k-hibernate-cache-lettuce:test`, `:bluetape4k-avro:test` 실행
+8. `infra/kafka/README.md` + `README.ko.md` 업데이트
+9. 커밋 (`fix: org.lz4 → at.yawk.lz4:1.11.0 (CVE-2025-12183, CVE-2025-66566)`)
+10. PR 생성
+
+### 4.4 승인 체크리스트
+
+- [ ] 변경 대상 (Libs.kt, 루트 BOM, kafka, testcontainers, README × 2) 이 충분
+- [ ] `configurations.all { exclude }` 가 단일 dep exclude 보다 안전함에 동의
+- [ ] 사전 dep-tree 스캔 → 추가 exclude 발견 시 반영 계획 합의
+
+---
+
+## 5. DoD (Definition of Done)
+
+| 항목 | 검증 방법 |
+|------|-----------|
+| `at.yawk.lz4:lz4-java:1.11.0` 으로 전환 완료 | `Libs.kt` grep 확인 |
+| 루트 BOM `at.yawk.lz4:lz4-java:1.11.0` 로 교체 | 루트 `build.gradle.kts` grep 확인 |
+| `org.lz4:lz4-java` runtime classpath 에서 완전 제거 | `./gradlew :bluetape4k-kafka:dependencies --configuration runtimeClasspath \| rg "org.lz4"` 결과 없음 |
+| `infra/kafka` + `testing/testcontainers` `configurations.all { exclude }` 적용 | 파일 diff 확인 |
+| 추가 transitive 경로 (pulsar/avro/redisson) dep-tree 스캔 완료 | 스캔 결과 `org.lz4` 없음 또는 추가 exclude 적용 |
+| native library 플랫폼 커버리지 확인 | `at.yawk.lz4:lz4-java:1.11.0` JAR 내 native binary (linux-x86_64, linux-aarch64, darwin-aarch64, darwin-x86_64) 존재 확인 |
+| `:bluetape4k-kafka:test` 통과 | `./gradlew :bluetape4k-kafka:test` |
+| `:bluetape4k-core:test` 통과 | `./gradlew :bluetape4k-core:test` |
+| `:bluetape4k-io:test` 통과 | `./gradlew :bluetape4k-io:test` |
+| `:bluetape4k-lettuce:test` 통과 | `./gradlew :bluetape4k-lettuce:test` |
+| `:bluetape4k-testcontainers:test` 통과 | `./gradlew :bluetape4k-testcontainers:test` |
+| `:bluetape4k-hibernate-cache-lettuce:test` 통과 | `./gradlew :bluetape4k-hibernate-cache-lettuce:test` |
+| `:bluetape4k-avro:test` 통과 | `./gradlew :bluetape4k-avro:test` |
+| `infra/kafka` README.md + README.ko.md 업데이트 (CVE 안내 포함) | 파일 diff 확인 |
+
+### 5.1 승인 체크리스트
+
+- [ ] DoD 14개 항목이 마이그레이션의 완료 기준으로 충분
+- [ ] 검증 방법이 명확하고 실행 가능
+- [ ] `hibernate-cache-lettuce` 테스트 추가 이유 (유일한 `implementation` 범위) 에 동의
+
+---
+
+## 6. Rollback 전략
+
+**Rollback 절차 (단일 commit revert 로 충분):**
+
+```bash
+git revert <commit-hash>
+./gradlew :bluetape4k-kafka:build :bluetape4k-core:build
+```
+
+변경 파일은 `Libs.kt`, 루트 `build.gradle.kts`, `infra/kafka/build.gradle.kts`, `testing/testcontainers/build.gradle.kts`, README 2개 — 소스 코드 변경 없음.
+
+**데이터 호환성**: LZ4 압축 포맷은 표준 포맷이므로 두 구현이 동일하게 처리. 영속화 데이터 재처리 불필요.
+
+---
+
+## 7. 후속 단계
+
+본 spec 승인 후:
+1. **Plan 단계**: 본 spec → 단계별 plan (`docs/superpowers/plans/2026-04-28-lz4-yawkat-migration-plan.md`) 작성
+2. **구현 단계**: §4.0 dep-tree 스캔 → §4.1 변경 → §4.3 작업 순서 실행
+3. **PR 단계**: DoD 전수 검증 → `gh pr create`

--- a/infra/kafka/README.ko.md
+++ b/infra/kafka/README.ko.md
@@ -530,8 +530,21 @@ configurations.all {
 ### 다운스트림 사용자
 
 `bluetape4k-kafka` 를 거치지 않고 `kafka-clients` 등을 직접 의존하는 경우,
-취약 JAR 가 classpath 에 포함되지 않도록 동일한 `configurations.all { exclude(...) }` 블록을
-빌드 스크립트에 추가하시기 바랍니다.
+exclude 블록과 함께 대체 아티팩트를 명시적으로 선언해야 합니다:
+
+```kotlin
+configurations.all {
+    exclude(group = "org.lz4", module = "lz4-java")
+}
+
+dependencies {
+    // runtime 에 net.jpountz.lz4.* 를 제공 — Kafka LZ4 압축 codec 에 필요
+    implementation("at.yawk.lz4:lz4-java:1.11.0")
+}
+```
+
+`bluetape4k-kafka` 를 사용하는 경우 `at.yawk.lz4:lz4-java:1.11.0` 이 `api` 의존성으로
+자동 제공되므로 별도 선언이 불필요합니다.
 
 ## 참고 자료
 

--- a/infra/kafka/README.ko.md
+++ b/infra/kafka/README.ko.md
@@ -508,6 +508,31 @@ io.bluetape4k.kafka
 └── TopicPartitionSupport.kt  # TopicPartition 유틸리티
 ```
 
+## 보안: LZ4 마이그레이션 (CVE-2025-12183, CVE-2025-66566)
+
+`org.lz4:lz4-java` 는 2025년 12월에 아카이브되었으며, 두 개의 미해결 CVE 가 있습니다:
+
+- **CVE-2025-12183** (CVSS 8.8) — 범위 초과 읽기(OOB read)
+- **CVE-2025-66566** (CVSS 8.2) — 미초기화 버퍼 정보 유출
+
+본 모듈은 유지보수가 활발한 포크 **`at.yawk.lz4:lz4-java:1.11.0`** 으로 마이그레이션했습니다.
+패키지 네임스페이스 `net.jpountz.lz4.*` 가 동일하므로 **바이너리 호환** — 소스 코드 변경 불필요.
+
+Kafka 계열 라이브러리 (`kafka-clients`, `spring-kafka`, `reactor-kafka`, `kafka-streams`) 가
+여전히 `org.lz4:lz4-java` 를 추이적 의존성으로 선언하므로, 다음과 같이 제거합니다:
+
+```kotlin
+configurations.all {
+    exclude(group = "org.lz4", module = "lz4-java")
+}
+```
+
+### 다운스트림 사용자
+
+`bluetape4k-kafka` 를 거치지 않고 `kafka-clients` 등을 직접 의존하는 경우,
+취약 JAR 가 classpath 에 포함되지 않도록 동일한 `configurations.all { exclude(...) }` 블록을
+빌드 스크립트에 추가하시기 바랍니다.
+
 ## 참고 자료
 
 - [Apache Kafka Documentation](https://kafka.apache.org/documentation/)

--- a/infra/kafka/README.md
+++ b/infra/kafka/README.md
@@ -530,8 +530,22 @@ configurations.all {
 ### Downstream consumers
 
 If your application directly depends on `kafka-clients` (or any of its siblings) **without** going
-through `bluetape4k-kafka`, add the same `configurations.all { exclude(...) }` block to your build
-to prevent the vulnerable JAR from appearing on your classpath.
+through `bluetape4k-kafka`, add the same `configurations.all { exclude(...) }` block **and** declare
+the replacement explicitly:
+
+```kotlin
+configurations.all {
+    exclude(group = "org.lz4", module = "lz4-java")
+}
+
+dependencies {
+    // Provides net.jpountz.lz4.* at runtime — required for Kafka LZ4 compression codec
+    implementation("at.yawk.lz4:lz4-java:1.11.0")
+}
+```
+
+`bluetape4k-kafka` already exposes `at.yawk.lz4:lz4-java:1.11.0` as an `api` dependency,
+so direct users of this module do not need to add it manually.
 
 ## References
 

--- a/infra/kafka/README.md
+++ b/infra/kafka/README.md
@@ -508,6 +508,31 @@ io.bluetape4k.kafka
 └── TopicPartitionSupport.kt  # TopicPartition utilities
 ```
 
+## Security: LZ4 Migration (CVE-2025-12183, CVE-2025-66566)
+
+`org.lz4:lz4-java` was archived in December 2025 and has two unpatched CVEs:
+
+- **CVE-2025-12183** (CVSS 8.8) — out-of-bounds read
+- **CVE-2025-66566** (CVSS 8.2) — uninitialized buffer info leak
+
+This module migrates to the maintained fork **`at.yawk.lz4:lz4-java:1.11.0`**, which keeps the
+`net.jpountz.lz4.*` package namespace (binary-compatible — no source changes required).
+
+Because Kafka clients (`kafka-clients`, `spring-kafka`, `reactor-kafka`, `kafka-streams`) still
+declare a transitive dependency on `org.lz4:lz4-java`, this module evicts it via:
+
+```kotlin
+configurations.all {
+    exclude(group = "org.lz4", module = "lz4-java")
+}
+```
+
+### Downstream consumers
+
+If your application directly depends on `kafka-clients` (or any of its siblings) **without** going
+through `bluetape4k-kafka`, add the same `configurations.all { exclude(...) }` block to your build
+to prevent the vulnerable JAR from appearing on your classpath.
+
 ## References
 
 - [Apache Kafka Documentation](https://kafka.apache.org/documentation/)

--- a/infra/kafka/build.gradle.kts
+++ b/infra/kafka/build.gradle.kts
@@ -48,7 +48,9 @@ dependencies {
     // Compressors
     compileOnly(Libs.commons_compress)
     compileOnly(Libs.snappy_java)
-    compileOnly(Libs.lz4_java)
+    // at.yawk.lz4:lz4-java 를 api 로 노출: exclude 로 org.lz4 를 제거했으므로
+    // 소비자 classpath 에 at.yawk.lz4:lz4-java:1.11.0 가 반드시 있어야 kafka LZ4 codec 이 동작한다.
+    api(Libs.lz4_java)
     compileOnly(Libs.zstd_jni)
 
     // Coroutines

--- a/infra/kafka/build.gradle.kts
+++ b/infra/kafka/build.gradle.kts
@@ -5,6 +5,12 @@ plugins {
 
 configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+    all {
+        // CVE-2025-12183 (CVSS 8.8) + CVE-2025-66566 (CVSS 8.2):
+        // kafka-clients/spring-kafka/reactor-kafka 가 org.lz4:lz4-java 를 transitively 가져온다.
+        // at.yawk.lz4:lz4-java:1.11.0 (net.jpountz.lz4.* 동일 namespace) 로 대체한다.
+        exclude(group = "org.lz4", module = "lz4-java")
+    }
 }
 
 dependencies {

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/LZ4Compressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/LZ4Compressor.kt
@@ -27,7 +27,7 @@ import net.jpountz.lz4.LZ4Factory
  * val decompressed = compressor.decompress(compressed)
  * ```
  *
- * @see [lz4-java](https://github.com/lz4/lz4-java)
+ * @see [lz4-java yawkat fork](https://github.com/yawkat/lz4-java) — CVE-2025-12183/CVE-2025-66566 패치 포함 유지보수 버전
  */
 class LZ4Compressor: AbstractCompressor() {
 

--- a/testing/testcontainers/build.gradle.kts
+++ b/testing/testcontainers/build.gradle.kts
@@ -1,5 +1,11 @@
 configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+    all {
+        // CVE-2025-12183 (CVSS 8.8) + CVE-2025-66566 (CVSS 8.2):
+        // kafka-clients 등이 org.lz4:lz4-java 를 transitively 가져온다.
+        // at.yawk.lz4:lz4-java:1.11.0 으로 대체한다.
+        exclude(group = "org.lz4", module = "lz4-java")
+    }
 }
 
 // testcontainers 테스트 실행 전 mock-server Docker 이미지를 자동으로 빌드합니다.


### PR DESCRIPTION
## Summary

Closes #203

- PR 제목: fix: org.lz4 → at.yawk.lz4:1.11.0 으로 마이그레이션 (CVE-2025-12183, CVE-2025-66566)

`org.lz4:lz4-java` (원본 repo 2025-12 archived) 를 `at.yawk.lz4:lz4-java:1.11.0` 으로 전환하여 두 CVE 를 패치합니다.

| CVE | CVSS | 내용 |
|-----|------|------|
| CVE-2025-12183 | 8.8 HIGH | out-of-bounds read |
| CVE-2025-66566 | 8.2 HIGH | uninitialized buffer info leak |

두 artifact 모두 `net.jpountz.lz4.*` namespace 사용 → **binary-compatible, 소스 코드 변경 없음**.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

| 파일 | 변경 내용 |
|------|-----------|
| `buildSrc/src/main/kotlin/Libs.kt` | `lz4_java` GAV: `org.lz4:1.8.0` → `at.yawk.lz4:1.11.0`, `// SECURITY:` 코멘트 |
| `infra/kafka/build.gradle.kts` | `configurations.all { exclude org.lz4 }` + `compileOnly` → `api(Libs.lz4_java)` |
| `testing/testcontainers/build.gradle.kts` | `configurations.all { exclude org.lz4 }` |
| `infra/kafka/README.md` | CVE 보안 안내 + downstream users dependency snippet |
| `infra/kafka/README.ko.md` | 동일 한국어 버전 |
| `io/io/.../LZ4Compressor.kt` | `@see` 링크 yawkat fork 로 업데이트 |
| `bluetape4k/core/.../XXHasher.kt` | `@see` 링크 yawkat fork 로 업데이트 |

### 기존 섹션: 설계 결정

- **eviction 메커니즘**: `dependencyManagement` BOM 교체만으로는 다른 groupId 를 제거할 수 없음. `configurations.all { exclude(group="org.lz4", ...) }` 방식으로 모든 configuration 에서 제거.
- **`infra/kafka` api scope**: `org.lz4` 를 exclude 하면 kafka-clients 경로의 LZ4 runtime 공급이 끊김. `api(Libs.lz4_java)` 로 `at.yawk.lz4:1.11.0` 을 소비자 classpath 에 제공.
- **pulsar/avro/redisson**: dep-tree 스캔 결과 org.lz4 transitive 없음 → exclude 불필요.
- **native library**: lz4-java-1.11.0.jar 내 5개 플랫폼 모두 확인 (linux/amd64, linux/aarch64, darwin/aarch64, darwin/x86_64, win32/amd64).

### 기존 섹션: 검증 명령어

```bash
# eviction 확인
./gradlew :bluetape4k-kafka:dependencies --configuration runtimeClasspath | rg "lz4"
# Expected: at.yawk.lz4:lz4-java:1.11.0 only

# 테스트 재현
./gradlew :bluetape4k-kafka:test :bluetape4k-io:test :bluetape4k-core:test
```

Closes #203

## Validation

| 모듈 | 결과 | Tests |
|------|------|-------|
| `bluetape4k-core` | ✅ PASS | 1554 (37.1s) |
| `bluetape4k-io` | ✅ PASS | 848 (6.5s) |
| `bluetape4k-kafka` | ✅ PASS | 252 (40.2s) |
| `bluetape4k-lettuce` | ✅ PASS | 314 (16.3s) |
| `bluetape4k-redisson` | ✅ PASS | 333 (41.9s) |
| `bluetape4k-hibernate-cache-lettuce` | ✅ PASS | 77 (11s) |
| `bluetape4k-avro` | ✅ PASS | 201 (3.1s) |

**총 3379 tests passing**

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #203, milestone 없음, assignee `debop`
- PR: #233, head `1e964fc79c0914cc9c9f8e7016770963334002be`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/lz4-yawkat-migration`
- Labels: `chore`, `security`
- State: `MERGED`, merge commit `247471544dca2b64bc63068575d6023321de9a8b`
- CI: | `infra/kafka/build.gradle.kts` | `configurations.all { exclude org.lz4 }` + `compileOnly` → `api(Libs.lz4_java)` | / | `testing/testcontainers/build.gradle.kts` | `configurations.all { exclude org.lz4 }` | / ./gradlew :bluetape4k-kafka:dependencies --configuration runtimeClasspath | rg "lz4"

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #233 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `247471544dca2b64bc63068575d6023321de9a8b`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
