### PR TITLE
feat: images batch flow 처리 경로 추가

### DIFF
--- a/docs/superpowers/plans/2026-04-28-images-batch-flow-plan.md
+++ b/docs/superpowers/plans/2026-04-28-images-batch-flow-plan.md
@@ -1,0 +1,252 @@
+# utils/images 배치 처리 Flow DSL 구현 계획 — Issue #135
+
+- **Issue**: #135 `[utils/images] 성능 / 배치 처리 (Flow DSL / 썸네일 파이프라인 / Tile 처리)`
+- **Spec**: `docs/superpowers/specs/2026-04-28-images-batch-flow-design.md`
+- **Research**: `docs/superpowers/research/2026-04-28-issue-135-images-batch-research.md`
+- **모듈**: `utils/images` (`bluetape4k-images`)
+- **브랜치**: `feat/issue-135-images-batch-flow`
+- **작성일**: 2026-04-28
+- **상태**: Draft
+
+---
+
+## 1. 구현 원칙
+
+- 새 외부 의존성을 추가하지 않는다.
+- public API와 public type에는 한국어 KDoc을 작성한다.
+- 기본값과 검증 기준값은 magic number로 직접 쓰지 않는다. `const val` 또는 named helper로 정의한다.
+- blocking 이미지 I/O와 writer 호출은 caller가 지정한 `ioDispatcher`에서 실행한다.
+- CPU-bound transform은 caller가 지정한 `transformDispatcher`에서 실행한다.
+- `CancellationException`은 실패 결과로 감싸지 않고 그대로 전파한다.
+- 실패를 skip하는 기본 계약은 result + warn log + callback으로 관측 가능해야 한다.
+
+---
+
+## 2. 파일 계획
+
+### Main
+
+- `utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageBatchDefaults.kt`
+- `utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageBatchFailureStage.kt`
+- `utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageBatchException.kt`
+- `utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageBatchResult.kt`
+- `utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageProcessingOptions.kt`
+- `utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageProcessingDsl.kt`
+- `utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageBatchFlow.kt`
+- `utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageDimensionProbe.kt`
+- `utils/images/src/main/kotlin/io/bluetape4k/images/batch/PixelPermitLimiter.kt`
+- `utils/images/src/main/kotlin/io/bluetape4k/images/thumbnail/ThumbnailFormat.kt`
+- `utils/images/src/main/kotlin/io/bluetape4k/images/thumbnail/ThumbnailOutputName.kt`
+- `utils/images/src/main/kotlin/io/bluetape4k/images/thumbnail/ThumbnailPipeline.kt`
+- `utils/images/src/main/kotlin/io/bluetape4k/images/thumbnail/ThumbnailResult.kt`
+- `utils/images/src/main/kotlin/io/bluetape4k/images/thumbnail/ThumbnailSize.kt`
+- `utils/images/src/main/kotlin/io/bluetape4k/images/tiles/ImageTile.kt`
+- `utils/images/src/main/kotlin/io/bluetape4k/images/tiles/TileProcessor.kt`
+- `utils/images/src/main/kotlin/io/bluetape4k/images/tiles/TileSize.kt`
+
+### Tests
+
+- `utils/images/src/test/kotlin/io/bluetape4k/images/batch/ImageBatchFlowTest.kt`
+- `utils/images/src/test/kotlin/io/bluetape4k/images/batch/ImageProcessingDslTest.kt`
+- `utils/images/src/test/kotlin/io/bluetape4k/images/batch/PixelPermitLimiterTest.kt`
+- `utils/images/src/test/kotlin/io/bluetape4k/images/thumbnail/ThumbnailPipelineTest.kt`
+- `utils/images/src/test/kotlin/io/bluetape4k/images/tiles/TileProcessorTest.kt`
+
+### Docs
+
+- `utils/images/README.md`
+- `utils/images/README.ko.md`
+- `docs/testlogs/2026-04.md`
+- `docs/superpowers/INDEX.md`
+- `docs/superpowers/index/2026-04.md`
+
+---
+
+## 3. Task Plan
+
+### T01 — 기본 모델과 상수 추가
+
+**Complexity**: medium
+
+작업:
+- `ImageBatchDefaults.kt`에 다음을 정의한다.
+  - `const val DEFAULT_MAX_PIXELS = 16_777_216L`
+  - `const val DEFAULT_MAX_IN_FLIGHT_PIXELS = DEFAULT_MAX_PIXELS * 2`
+  - `const val DEFAULT_MAX_TILE_COUNT = 65_536`
+  - `const val JPEG_QUALITY_MIN = 0`
+  - `const val JPEG_QUALITY_MAX = 100`
+  - `const val PERFORMANCE_SAMPLE_IMAGE_COUNT = 100`
+  - tile 테스트용 상수는 test source set에 정의한다.
+  - `fun defaultImageBatchParallelism(): Int`
+- `ImageBatchFailureStage`, `ImageBatchException`, `ImageBatchResult`, `ImageProcessingOptions`를 추가한다.
+- validation은 기존 `requirePositiveNumber`, `requireInRange` 계열을 우선 재사용한다.
+
+검증:
+- `:bluetape4k-images:compileKotlin`
+
+### T02 — Batch Flow DSL 구현
+
+**Complexity**: high
+
+작업:
+- `Flow<Path>.processImages(options, block)`와 `Flow<File>.processImages(...)`를 구현한다.
+- per-image 처리 순서:
+  1. decode 전 dimension probe
+  2. pixel permit 획득
+  3. `ioDispatcher`에서 load
+  4. `transformDispatcher`에서 DSL transform 실행
+  5. `Image` 또는 `WritableImage` result 방출
+  6. `finally`에서 permit 해제
+- `skipFailures = true`는 `Failure` result + warn log + `onFailure` callback을 수행한다.
+- `skipFailures = false`는 `ImageBatchException`을 전파한다.
+- `CancellationException`은 항상 전파한다.
+
+검증:
+- 정상 이미지 N개 처리 success count
+- 깨진 이미지 skip
+- `skipFailures = false` 예외 전파
+- dispatcher 주입 테스트
+- max pixel guard 테스트
+
+### T03 — ImageProcessingDsl 구현
+
+**Complexity**: high
+
+작업:
+- `resize`, `fit`, `gaussianBlur`, `smartCrop`, `filters` bridge를 제공한다.
+- `watermark(text, ...)`는 기존 text watermark DSL을 위임한다.
+- `watermark(logo, position, alpha)`는 logo image overlay를 구현한다.
+- `toJpeg(quality, progressive)`와 `writer(writer)`는 writer 선택만 수행한다.
+- writer 중복 지정은 `IllegalArgumentException`으로 거부한다.
+- `quality`는 `JPEG_QUALITY_MIN..JPEG_QUALITY_MAX`로 검증한다.
+
+검증:
+- DSL 선언 순서 유지
+- logo watermark output dimension 유지 및 픽셀 변화 확인
+- writer 중복 지정 실패
+- quality range 검증
+
+### T04 — Processed image write convenience 구현
+
+**Complexity**: medium
+
+작업:
+- `WritableImage.writeTo(path, ioDispatcher)` 구현
+- `Image.writeTo(path, writer, ioDispatcher)` 구현
+- 기존 `SuspendImageWriter.suspendWrite`의 고정 dispatcher를 우회하고 지정 dispatcher에서 `writer.write(...)`를 직접 호출한다.
+
+검증:
+- JPEG/PNG 쓰기 결과 파일 존재 및 bytes > 0
+- dispatcher 주입 테스트
+
+### T05 — ThumbnailPipeline 구현
+
+**Complexity**: high
+
+작업:
+- `ThumbnailSize`, `ThumbnailCrop`, `ThumbnailFormat`, `ThumbnailOutputName`, `ThumbnailStatus`, `ThumbnailResult`를 추가한다.
+- builder에 `sizes`, `format`, `outputDir`, `outputName`, `parallelism`, `ioDispatcher`, `transformDispatcher`, `maxPixels`, `maxInFlightPixels`, `skipFailures`, `onFailure`를 제공한다.
+- output path containment와 duplicate output path를 검증한다.
+- default output name은 `{sourceHash}_{sourceStem}_{width}x{height}.{extension}`로 생성한다.
+- batch DSL과 동일한 pixel permit 계약을 사용한다.
+
+검증:
+- 3개 size 생성
+- SmartCrop size 검증
+- path traversal 거부
+- duplicate output path 거부
+- failure skip + warn/callback
+
+### T06 — TileProcessor 구현
+
+**Complexity**: high
+
+작업:
+- `TileSize`, `ImageTile`, `TileProcessor`를 추가한다.
+- split은 마지막 row/column 크기를 원본 경계에 맞춘다.
+- process는 `Semaphore(parallelism)`으로 동시 실행 tile 수를 제한한다.
+- merge는 duplicate, missing, out-of-bounds, image dimension mismatch를 검증한다.
+- `maxPixels`, `maxTileCount`를 상수 기본값으로 사용한다.
+
+검증:
+- split geometry
+- 무변환 merge pixel identity
+- tile transform 반영
+- geometry invalid cases
+- max guard
+
+### T07 — README와 예제 갱신
+
+**Complexity**: low
+
+작업:
+- `utils/images/README.md`, `README.ko.md`에 batch, thumbnail, tile 섹션을 추가한다.
+- error handling, ordering, dispatcher, memory guard, timeout/cancellation, output path containment를 명시한다.
+- 예제는 writer 지정 후 `writeTo(...)`까지 보여준다.
+
+검증:
+- README 링크와 코드 조각 명칭이 실제 API와 일치하는지 `rg`로 확인한다.
+
+### T08 — 100-image non-gating 성능 로그
+
+**Complexity**: low
+
+작업:
+- test fixture 복제 또는 synthetic 이미지로 `PERFORMANCE_SAMPLE_IMAGE_COUNT` 입력을 구성한다.
+- `parallelism = 1`과 `parallelism = min(4, availableProcessors)`의 처리 시간을 기록한다.
+- 결과는 assertion이 아니라 `docs/testlogs/2026-04.md`에 환경/입력/시간으로 남긴다.
+
+검증:
+- 로그에 입력 수, 이미지 크기, dispatcher, parallelism, 처리 시간이 포함된다.
+
+### T09 — Superpowers index 갱신
+
+**Complexity**: low
+
+작업:
+- `docs/superpowers/INDEX.md`
+- `docs/superpowers/index/2026-04.md`
+
+검증:
+- spec, plan, research 링크가 모두 상대 경로로 연결된다.
+
+### T10 — 최종 검증
+
+**Complexity**: medium
+
+명령:
+
+```bash
+./bin/repo-test-summary -- ./gradlew :bluetape4k-images:compileKotlin :bluetape4k-images:compileTestKotlin
+./bin/repo-test-summary -- ./gradlew :bluetape4k-images:test
+```
+
+검증 기준:
+- compile/test 통과
+- public API KDoc 누락 없음
+- spec DoD 항목과 plan task가 모두 충족됨
+- root `develop` worktree의 다른 에이전트 변경은 건드리지 않음
+
+---
+
+## 4. 구현 순서
+
+1. T01 모델/상수
+2. T02/T03/T04 batch DSL + write convenience
+3. T05 thumbnail
+4. T06 tile
+5. T07 문서
+6. T08/T09 로그와 index
+7. T10 검증
+
+---
+
+## 5. 리스크와 대응
+
+| Risk | 대응 |
+|------|------|
+| Dispatcher 옵션이 실제 실행 경로와 어긋남 | `suspendApplyFilters`/`suspendWrite` 대신 지정 dispatcher에서 직접 실행 |
+| image watermark가 과도한 API가 됨 | 위치/alpha만 1차 지원, resize는 caller 책임 |
+| pixel permit 누수 | permit 획득/해제 테스트와 cancellation 테스트 추가 |
+| thumbnail path traversal | 파일명 전략 결과를 normalize 후 outputDir containment 검증 |
+| 성능 테스트 flaky | CI pass/fail 기준이 아닌 testlog 기록으로 제한 |

--- a/docs/superpowers/research/2026-04-28-issue-135-images-batch-research.md
+++ b/docs/superpowers/research/2026-04-28-issue-135-images-batch-research.md
@@ -1,0 +1,168 @@
+# Issue #135 사전 조사 — utils/images 배치 이미지 처리
+
+- Issue: #135 `[utils/images] 성능 / 배치 처리 (Flow DSL / 썸네일 파이프라인 / Tile 처리)`
+- Branch: `feat/issue-135-images-batch-flow`
+- Worktree: `.worktrees/feat/issue-135-images-batch-flow`
+- Module: `utils/images` (`bluetape4k-images`)
+- Date: 2026-04-28
+
+## 1. 요구사항 요약
+
+Issue #135는 `utils/images`에 다음 세 기능을 추가하는 작업이다.
+
+1. `Flow<File>.processImages { ... }` 형태의 배치 처리 Flow DSL
+2. 다중 사이즈 썸네일을 생성하는 `ThumbnailPipeline`
+3. 대용량 이미지를 타일 단위로 분할/처리/재조합하는 `TileProcessor`
+
+핵심 제약은 다음과 같다.
+
+- Kotlin Coroutines Flow 기반이어야 한다.
+- blocking 이미지 I/O는 `Dispatchers.IO`에서 실행한다.
+- scrimage 기반 기존 API를 재사용한다.
+- 에러 이미지가 섞여도 정상 이미지는 계속 처리할 수 있어야 한다.
+- 타일 분할 후 무변환 병합 결과는 원본과 픽셀 동일해야 한다.
+
+## 2. 공식 문서 조사
+
+### Kotlinx Coroutines Flow
+
+Context7 `/kotlin/kotlinx.coroutines` 조사 결과:
+
+- `flatMapMerge(concurrency)`는 각 입력을 내부 Flow로 변환한 뒤 지정 동시성으로 병합하는 표준 패턴이다.
+- `flowOn(context)`는 upstream 실행 컨텍스트를 바꾸는 권장 방식이다.
+- blocking file/network I/O는 `Dispatchers.IO` 사용이 권장된다.
+- `buffer()`는 생산/소비 단계를 동시에 실행해 파이프라인 처리량을 높일 수 있다.
+- `catch`는 upstream 예외 처리용이며 fallback emit에도 사용할 수 있다.
+
+적용 결정:
+
+- `Flow<Path>.processImages(...)`는 기존 `mapParallel(parallelism, Dispatchers.IO)`을 재사용해 동시성을 제한한다.
+- `processImages` 내부의 per-image 실패는 전체 Flow 실패가 아니라 `ImageBatchResult.Failure`로 방출할 수 있게 한다.
+- 호출자가 기존 Flow 연산자 `.filterIsInstance`, `.catch`, `.buffer`를 조합할 수 있게 결과 타입을 명시한다.
+
+### Scrimage
+
+Context7 `/sksamuel/scrimage` 조사 결과:
+
+- 로딩: `ImmutableImage.loader().fromFile(...)`, `fromPath(...)`, `fromBytes(...)`
+- 변환: `scaleTo`, `scaleToWidth`, `scaleToHeight`, `cover`, `filter(...)`
+- 필터: `GaussianBlurFilter`, `BlurFilter`, `SharpenFilter` 등
+- 저장: `JpegWriter().withCompression(...)`, `PngWriter.Default/MaxCompression`, `image.bytes(writer)`, `image.output(writer, file)`
+
+적용 결정:
+
+- 기존 `immutableImageOf(path)` / `suspendImmutableImageOf(path)`를 재사용한다.
+- 기존 `SuspendImageWriter`와 `SuspendJpegWriter`를 출력 포맷 추상화로 재사용한다.
+- DSL은 기존 `ImageFilterChain`의 native filter/pixel transform 모델을 직접 활용하되, batch 입력/출력 메타데이터만 새 타입으로 감싼다.
+
+## 3. 기존 코드 조사
+
+### `utils/images`
+
+핵심 파일:
+
+- `utils/images/build.gradle.kts`
+  - 이미 `project(":bluetape4k-coroutines")`, `kotlinx_coroutines_core`, `kotlinx_coroutines_test`, `scrimage_core`, `scrimage_filters` 의존성이 있다.
+  - 새 의존성 없이 구현 가능하다.
+- `utils/images/src/main/kotlin/io/bluetape4k/images/ImmutableImageSupport.kt`
+  - `immutableImageOf(File|Path|ByteArray|InputStream)`와 `suspendImmutableImageOf(File|Path)`가 있다.
+  - `ImmutableImage.suspendBytes(writer)`와 `suspendWrite(writer, destPath)`가 있다.
+- `utils/images/src/main/kotlin/io/bluetape4k/images/coroutines/SuspendImageWriter.kt`
+  - `suspendWrite`가 `Dispatchers.IO`에서 blocking writer 호출을 감싼다.
+- `utils/images/src/main/kotlin/io/bluetape4k/images/coroutines/SuspendJpegWriter.kt`
+  - scrimage `JpegWriter`를 상속하며 `withCompression`, `withProgressive`를 반환 타입 유지 방식으로 제공한다.
+- `utils/images/src/main/kotlin/io/bluetape4k/images/filters/dsl/ImageFilterChain.kt`
+  - `ImageFilterChain`이 native `Filter`와 pixel transform을 누적하고 `PipelineFilter`로 인접 native 필터를 compact 한다.
+- `utils/images/src/main/kotlin/io/bluetape4k/images/filters/dsl/ImageFilterChainBlurOps.kt`
+  - `gaussianBlur(radius)`가 이미 존재하며 입력 검증을 수행한다.
+- `utils/images/src/main/kotlin/io/bluetape4k/images/transforms/dsl/ImageFilterChainTransformOps.kt`
+  - `smartCrop`, `autoCrop`, `rotate`, `flip`, `perspectiveTransform`, `clahe`가 기존 filter chain에 통합되어 있다.
+- `utils/images/src/main/kotlin/io/bluetape4k/images/transforms/SmartCrop.kt`
+  - `smartCropTo(width, height)`와 `suspendSmartCrop(...)`가 존재한다.
+- `utils/images/src/main/kotlin/io/bluetape4k/images/splitter/ImageSplitter.kt`
+  - 긴 이미지를 높이 기준으로 분할해 `Flow<ByteArray>`로 내보내며 `async`/`buffer` 패턴을 사용한다.
+
+테스트/문서:
+
+- `utils/images/src/test/kotlin/io/bluetape4k/images/AbstractImageTest.kt`
+  - 공통 fixture 경로와 `writeToFileAsync(Flow<ByteArray>, ...)` 헬퍼가 있다.
+- `utils/images/src/test/kotlin/io/bluetape4k/images/transforms/SmartCropTest.kt`
+  - smart crop 동작과 suspend variant를 검증한다.
+- `utils/images/src/test/kotlin/io/bluetape4k/images/filters/WatermarkFilterTest.kt`
+  - watermark 결과를 fixture와 비교한다.
+- `utils/images/README.md`, `README.ko.md`
+  - split/compress Flow 사용 예제가 이미 있다.
+
+### `bluetape4k-coroutines`
+
+핵심 파일:
+
+- `bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/mapParallel.kt`
+  - `Flow<T>.mapParallel(parallelism, context, transform)`가 이미 있다.
+  - parallelism은 최소 1로 보정하며, 1이면 일반 `map`, 그 외는 `flatMapMerge(concurrency)` 경로를 사용한다.
+  - 결과 순서는 보장하지 않는다고 KDoc에 명시되어 있다.
+- `bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/AsyncFlow.kt`
+  - 순서 보장 async Flow 래퍼가 있다.
+
+적용 결정:
+
+- Issue #135의 기본 배치 처리 결과 순서는 요구사항에 명시되지 않았고 처리량이 목적이므로 `mapParallel` 재사용이 적합하다.
+- 순서 보장 옵션이 필요해지면 `ordered = true` 옵션으로 `AsyncFlow` 경로를 추가할 수 있으나, 1차 범위에서는 과설계로 본다.
+
+### 관련 이미지 이슈 worktree
+
+현재 `develop`에는 최근 이미지 관련 결과가 이미 반영되어 있다.
+
+- Issue #131: filter/color DSL
+- Issue #132: transforms/smart crop
+- Issue #133: analysis/exif/blur/dominant color
+- Issue #134: format extension
+
+재사용 가능한 요소는 대부분 현재 worktree의 `utils/images`에 이미 존재한다. sibling worktree는 구조 확인용으로만 보며, 복사는 하지 않는다.
+
+## 4. 기술 제약
+
+- Kotlin 2.3 / Java toolchain 기준.
+- `utils/images`는 이미 `bluetape4k-coroutines`에 의존하므로 Flow helper 재사용 가능.
+- 새 외부 의존성은 불필요하다.
+- scrimage `ImmutableImage`는 in-memory 이미지이므로 tile 처리라도 최종 merge는 메모리 사용량이 원본 이상 필요하다.
+- tile 병렬 처리는 CPU-bound transform이면 `Dispatchers.Default`, file I/O/encoding이면 `Dispatchers.IO`가 적합하다. API에는 dispatcher를 주입 가능하게 해야 한다.
+- `ImageSplitter`는 높이 방향 분할 전용이므로 gigapixel tile split/merge 계약에는 직접 재사용하기 어렵다.
+- `ImageFilterChain.compactAndApply`는 현재 `internal`이라 다른 패키지에서 직접 호출할 수 없다. batch DSL이 같은 `filters.dsl` 패키지에 위치하지 않는다면 public apply 함수 또는 별도 execution adapter가 필요하다.
+
+## 5. 채택/부분 채택/스킵 결정
+
+| 대상 | 결정 | 근거 |
+|------|------|------|
+| `suspendImmutableImageOf` | 채택 | Path/File 로딩의 기존 코루틴 API이며 byte 기반 비동기 로딩 계약 보유 |
+| `SuspendImageWriter` / `SuspendJpegWriter` | 채택 | 출력 포맷 추상화가 이미 있고 blocking write를 `Dispatchers.IO`로 감쌈 |
+| `ImageFilterChain` + filter/transform DSL | 채택 | Issue #135 예시의 `gaussianBlur`, `smartCrop`, transform chain을 기존 DSL로 표현 가능 |
+| `mapParallel` | 채택 | `flatMapMerge(concurrency)` 공식 패턴을 이미 모듈화함 |
+| `AsyncFlow` | 부분 채택 | 결과 순서 보장이 별도 요구되면 사용. 기본 batch 처리에는 처리량 우선으로 `mapParallel` 사용 |
+| `ImageSplitter` | 부분 채택 | Flow/async 패턴과 테스트 참고용. 2D tile split/merge에는 새 `TileProcessor` 필요 |
+| 새 외부 라이브러리 | 스킵 | 기존 scrimage/coroutines 의존성으로 구현 가능 |
+
+## 6. 실패 신호와 재현 조건
+
+예상 실패 신호:
+
+- 깨진 이미지 입력에서 전체 Flow가 중단된다.
+- `parallelism <= 0` 입력이 조용히 보정되어 호출자 실수를 숨긴다.
+- thumbnail output path 충돌로 여러 source/size 결과가 덮어써진다.
+- tile split 후 merge 결과의 경계 픽셀이 어긋난다.
+- JPEG 품질 기반 테스트가 픽셀 동일성을 요구해 flaky해진다.
+
+재현/검증 조건:
+
+- 정상 이미지 여러 장 + 깨진 파일 1개를 섞어 `processImages`가 success/failure를 모두 방출하는지 확인한다.
+- 100개 synthetic 이미지 또는 fixture 복제 입력으로 동시성 상한을 검증한다.
+- tile split/merge는 PNG 또는 in-memory `ImmutableImage` 기준으로 무손실 픽셀 동일성을 확인한다.
+- thumbnail은 size별 output file 존재, 크기, failure skip/continue를 확인한다.
+
+## 7. 권장 검증 명령
+
+```bash
+./bin/repo-test-summary -- ./gradlew :bluetape4k-images:test --tests "io.bluetape4k.images.batch.*"
+./bin/repo-test-summary -- ./gradlew :bluetape4k-images:compileKotlin :bluetape4k-images:compileTestKotlin
+./bin/repo-test-summary -- ./gradlew :bluetape4k-images:test
+```

--- a/docs/superpowers/specs/2026-04-28-images-batch-flow-design.md
+++ b/docs/superpowers/specs/2026-04-28-images-batch-flow-design.md
@@ -1,0 +1,621 @@
+# utils/images 배치 처리 Flow DSL 설계 — Issue #135
+
+- **Issue**: #135 `[utils/images] 성능 / 배치 처리 (Flow DSL / 썸네일 파이프라인 / Tile 처리)`
+- **모듈**: `utils/images` (`bluetape4k-images`)
+- **작성일**: 2026-04-28
+- **브랜치**: `feat/issue-135-images-batch-flow`
+- **Worktree**: `.worktrees/feat/issue-135-images-batch-flow`
+- **Research**: `docs/superpowers/research/2026-04-28-issue-135-images-batch-research.md`
+- **상태**: Draft (Step 2-R review 대상)
+
+---
+
+## 1. 문제, 제약, 미확정 사항
+
+### 1.1 문제
+
+`utils/images`는 scrimage 기반 이미지 로딩, 저장, 필터 DSL, 변환, 분석 기능을 갖추고 있다. 그러나 대량 이미지 입력을 처리할 때 호출자는 다음을 직접 조합해야 한다.
+
+- `Flow<Path>` 또는 `Flow<File>`를 이미지로 로딩
+- 필터/변환 DSL 적용
+- 출력 writer 선택 및 저장
+- 병렬 처리 동시성 제한
+- 깨진 입력 이미지 처리
+- 썸네일 크기별 output path 계산
+- 큰 이미지의 tile split/merge 처리
+
+이 조합을 호출자가 매번 직접 작성하면 error handling과 dispatcher 선택이 흔들리고, batch pipeline 코드가 서비스마다 반복된다.
+
+### 1.2 제약
+
+- 새 외부 의존성은 추가하지 않는다. 기존 `scrimage`, `bluetape4k-coroutines`, `kotlinx-coroutines`로 구현한다.
+- blocking 이미지 I/O와 writer 호출은 `Dispatchers.IO` 경로에서 실행한다.
+- CPU-bound pixel/tile transform은 `Dispatchers.Default` 경로에서 실행한다. public API는 `ioDispatcher`와 `transformDispatcher`를 분리해 호출자가 실수로 blocking I/O를 CPU dispatcher에 올리거나 CPU-heavy transform을 IO pool에 몰지 않게 한다.
+- 대용량/악성 이미지 입력은 fail-fast guard를 둔다. Path/File 입력은 가능한 경우 ImageIO reader로 decode 전 dimensions를 probe하고, decode 후에도 `width * height`를 다시 검증한다. decode 전 probe는 `ImageInputStream.use {}`와 `ImageReader.dispose()`를 보장한다.
+- 기존 `ImageFilterChain`, `suspendImmutableImageOf`, `SuspendImageWriter`, `smartCropTo`, `mapParallel`를 우선 재사용한다.
+- public API는 한국어 KDoc을 가진다.
+- 결과 순서 보장은 기본 목표가 아니다. batch 처리량을 우선하며, 순서 의존 요구는 명시 옵션이 생기기 전까지 비목표로 둔다.
+
+### 1.3 미확정/범위 결정
+
+- Issue 예시는 `Flow<File>.processImages { ... }`를 보여주지만, Java NIO 사용성을 위해 `Flow<Path>`를 1차 API로 두고 `Flow<File>`는 위임 overload로 제공한다.
+- `toJpeg(quality = 85)`는 DSL 안에서 "쓰기 가능한 결과"를 만들기 위한 writer 지정으로만 해석한다. 파일은 자동 저장하지 않으며, 저장은 반드시 `WritableImage.writeTo(path)` 또는 thumbnail pipeline이 담당한다. writer를 지정하지 않은 결과와 지정한 결과는 sealed subtype으로 분리해 nullable writer를 피한다.
+- 얼굴/객체 인식 기반 smart crop은 비목표다. 기존 `SmartCrop`의 Sobel saliency 휴리스틱을 재사용한다.
+
+---
+
+## 2. 설계 위험 및 실패 모드
+
+### Risk-1: per-image 실패가 전체 Flow를 중단
+
+깨진 이미지 하나가 `ImmutableImage.loader()`에서 예외를 던지면 기본 Flow는 중단된다.
+
+- **실패 모드**: 100장 중 1장이 깨진 경우 99장 처리 결과도 손실된다.
+- **완화**: 결과 타입을 `ImageBatchResult` sealed interface로 모델링하고 `skipFailures = true` 기본값에서는 `Failure`를 방출한 뒤 다음 입력을 계속 처리한다. `Failure`는 실패 stage, source/output, message, validation details를 포함하며, 기본 구현은 `log.warn(e) { ... }`로 skipped failure를 남긴다. 호출자는 `onFailure` callback으로 counter/metrics를 붙일 수 있다. `CancellationException`은 failure로 감싸지 않고 항상 전파한다.
+- **DoD**: 깨진 파일 포함 batch 테스트에서 success N건 + failure 1건이 모두 방출되어야 한다.
+
+### Risk-2: parallelism 검증 부재
+
+`parallelism = 0`이 조용히 1로 보정되면 호출자 설정 오류가 숨겨진다.
+
+- **완화**: public batch API의 `parallelism`은 `requirePositiveNumber("parallelism")`로 즉시 거부한다. 내부 재사용 함수가 보정하더라도 외부 API 계약은 명시적으로 실패시킨다.
+- **DoD**: `parallelism <= 0` 입력 검증 테스트.
+
+### Risk-3: 결과 순서 오해
+
+`mapParallel`은 `flatMapMerge(concurrency)` 기반이라 결과 순서를 보장하지 않는다.
+
+- **완화**: KDoc/README에 "입력 순서 보장 없음"을 명시한다. 순서가 필요한 사용자는 `parallelism = 1`을 선택하게 한다.
+- **Rejected**: 기본 순서 보장 `AsyncFlow` 적용. 처리량 이슈 해결이 목적이며, 순서 보장을 기본으로 삼으면 API 목적과 맞지 않는다.
+
+### Risk-4: output path 충돌
+
+다중 크기 썸네일 생성 시 `image.jpg`에서 `150x150`, `300x300` 결과가 같은 파일명으로 쓰이면 덮어쓰기 위험이 있다.
+
+- **완화**: 기본 파일명 정책을 `{sourceHash}_{stem}_{width}x{height}.{ext}`로 고정해 서로 다른 디렉터리의 같은 파일명 충돌을 줄인다. 사용자 지정 `ThumbnailOutputName` 전략을 제공하며, 최종 output path set에 중복이 생기면 쓰기 전에 실패한다.
+- **보안 완화**: output name과 extension은 path separator, absolute path, `..`, Windows drive prefix를 거부한다. 최종 경로는 `outputDir.resolve(name).normalize()` 뒤 `outputDir.toAbsolutePath().normalize()` 하위인지 검증한다.
+- **DoD**: 동일 source에서 3개 size를 생성하면 output path 3개가 모두 달라야 한다.
+
+### Risk-5: JPEG 품질 기반 테스트의 픽셀 비교 flaky
+
+JPEG는 손실 압축이라 pixel identity 비교가 불가능하다.
+
+- **완화**: tile split/merge pixel identity는 in-memory `ImmutableImage` 또는 PNG writer 기준으로만 수행한다. JPEG thumbnail은 dimensions/file existence/bytes size를 검증한다.
+
+### Risk-6: tile merge 경계 오차
+
+tile 좌표나 마지막 tile 크기 계산이 틀리면 경계 픽셀이 중복되거나 빠진다.
+
+- **완화**: `ImageTile(x, y, width, height, image)`에 원본 좌표를 보존하고 merge는 좌표 기반으로 그린다.
+- **DoD**: `splitToTiles(tileSize).mergeTiles()`가 원본과 모든 픽셀 동일해야 한다.
+
+### Risk-7: 대용량 이미지 메모리 사용량
+
+scrimage `ImmutableImage`는 in-memory 이미지이므로 gigapixel 이미지를 한 번에 merge하면 메모리 사용량이 크다.
+
+- **완화**: 이번 범위는 in-memory tile 처리 API로 명시하되, `maxPixels`, `maxInFlightPixels`, `maxTileCount` guard를 둔다. 기본값은 `DEFAULT_MAX_PIXELS = 16_777_216L`(16M pixels, ARGB 약 64MB), `DEFAULT_MAX_IN_FLIGHT_PIXELS = DEFAULT_MAX_PIXELS * 2`, `DEFAULT_MAX_TILE_COUNT = 65_536` 같은 named constant로 정의한다. `maxInFlightPixels / maxPixels`로 decode/process 동시성을 상한 조정해 `availableProcessors()`개의 대형 이미지를 동시에 디코딩하지 않는다. 초과 시 decode/processing 전후에 `IllegalArgumentException` 또는 `Failure(stage = VALIDATION)`로 fail-fast 한다. 진짜 out-of-core streaming tile은 별도 이슈로 분리한다.
+- **KDoc 경고**: `TileProcessor`는 메모리 절감이 아니라 tile 단위 병렬 처리 API임을 명시한다.
+
+### Risk-9: timeout/cancellation 계약 불명확
+
+이미지 decode/encode/filter는 파일시스템이나 malformed input에 따라 매우 오래 걸릴 수 있다.
+
+- **완화**: API 내부에서 임의 timeout을 강제하지 않는다. 대신 모든 suspend 경로는 구조적 concurrency 안에서 실행하고 cancellation을 삼키지 않는다. README/KDoc에 per-image timeout이 필요하면 호출자가 `withTimeout`으로 감싸야 함을 명시한다.
+
+### Risk-8: 내부 DSL visibility
+
+`ImageFilterChain.compactAndApply`는 `internal`이라 batch 패키지에서 직접 호출할 수 없다.
+
+- **완화**: `processImages` 구현은 public `applyFilters`를 `withContext(options.transformDispatcher)` 안에서 호출한다. `suspendApplyFilters`는 `Dispatchers.Default`를 고정하므로 이 feature의 dispatcher 주입 계약에는 사용하지 않는다. `compactAndApply` visibility 확장은 하지 않는다.
+
+---
+
+## 3. 접근 방법 비교
+
+### 접근 A: 기존 DSL을 그대로 호출자가 조합
+
+```kotlin
+files.asFlow()
+    .mapParallel(parallelism, Dispatchers.IO) { path ->
+        suspendImmutableImageOf(path)
+            .suspendApplyFilters { gaussianBlur(1) }
+            .suspendWrite(SuspendJpegWriter.Default, output(path))
+    }
+```
+
+- **장점**: 새 API가 거의 필요 없다.
+- **단점**: 실패 이미지 skip, output naming, result metadata, thumbnail 다중 size 처리가 모두 호출자 반복 코드가 된다.
+- **판정**: 스코프 미충족.
+
+### 접근 B: 단일 만능 `ImageBatchPipeline`
+
+```kotlin
+ImageBatchPipeline.builder()
+    .input(files)
+    .transform { ... }
+    .thumbnails { ... }
+    .tiles { ... }
+    .run()
+```
+
+- **장점**: batch 기능을 한 객체에 모을 수 있다.
+- **단점**: Flow 확장 함수 요구사항과 멀어지고, thumbnail/tile까지 한 builder에 섞여 API가 무거워진다.
+- **판정**: 과한 중앙집중 구조라 bluetape4k의 extension/DSL 관례와 맞지 않는다.
+
+### 접근 C: 작고 독립적인 세 API 표면 — **선택**
+
+1. `Flow<Path>.processImages(...)` / `Flow<File>.processImages(...)`
+2. `ThumbnailPipeline`
+3. `TileProcessor`
+
+- **장점**:
+  - Issue의 3개 요구를 각각 독립 API로 제공한다.
+  - 기존 DSL/Writer/Flow helper를 조합하므로 새 추상화가 얇다.
+  - thumbnail과 tile 처리를 batch DSL에 억지로 넣지 않는다.
+- **단점**: 사용자가 세 API를 함께 쓰려면 조합 코드가 필요하다.
+- **판정**: 기존 `utils/images`의 기능별 패키지 분리와 가장 잘 맞는다.
+
+---
+
+## 4. 아키텍처 옵션
+
+### Option 1: `batch/` 패키지 중심
+
+```
+io.bluetape4k.images.batch
+├── ImageBatchProcessing.kt
+├── ImageBatchResult.kt
+├── ImageProcessingDsl.kt
+├── ThumbnailPipeline.kt
+└── TileProcessor.kt
+```
+
+- 단일 batch 패키지에 관련 타입을 모은다.
+- 호출자는 `io.bluetape4k.images.batch.*` 하나만 import하면 된다.
+- tile 처리가 batch와 약간 다른 성격인데도 같은 패키지에 들어간다.
+
+### Option 2: 목적별 패키지 분리
+
+```
+io.bluetape4k.images.batch
+io.bluetape4k.images.thumbnail
+io.bluetape4k.images.tiles
+```
+
+- 기능별 응집도가 높다.
+- README/문서도 기능별로 나누기 쉽다.
+- 파일 수와 import가 늘어난다.
+
+### Option 3: 기존 패키지에 흡수
+
+- `filters.dsl`에 batch DSL 추가
+- `splitter`에 tile 처리 추가
+- top-level에 thumbnail 추가
+
+장점은 파일 이동이 적지만, package responsibility가 흐려진다.
+
+### 선택
+
+**Option 2를 선택**한다.
+
+- `batch`: Flow 입력 처리와 result model
+- `thumbnail`: 다중 size output pipeline
+- `tiles`: tile split/process/merge
+
+기존 `splitter/ImageSplitter`는 긴 이미지를 height 기준으로 byte stream 분할하는 API이므로 2D tile processor와 같은 패키지에 섞지 않는다.
+
+---
+
+## 5. API 설계
+
+### 5.1 Batch Flow DSL
+
+```kotlin
+package io.bluetape4k.images.batch
+
+sealed interface ImageBatchResult {
+    val source: Path
+
+    sealed interface Success : ImageBatchResult {
+        val image: ImmutableImage
+    }
+
+    data class Image(
+        override val source: Path,
+        override val image: ImmutableImage,
+    ) : Success
+
+    data class WritableImage(
+        override val source: Path,
+        override val image: ImmutableImage,
+        val writer: SuspendImageWriter,
+    ) : Success
+
+    data class Failure(
+        override val source: Path,
+        val stage: ImageBatchFailureStage,
+        val cause: Throwable,
+        val message: String,
+        val output: Path? = null,
+        val details: Map<String, String> = emptyMap(),
+    ) : ImageBatchResult
+}
+
+enum class ImageBatchFailureStage {
+    VALIDATION,
+    LOAD,
+    TRANSFORM,
+    WRITE,
+}
+
+data class ImageProcessingOptions(
+    val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    val transformDispatcher: CoroutineDispatcher = Dispatchers.Default,
+    val parallelism: Int = defaultImageBatchParallelism(),
+    val maxPixels: Long = DEFAULT_MAX_PIXELS,
+    val maxInFlightPixels: Long = DEFAULT_MAX_IN_FLIGHT_PIXELS,
+    val skipFailures: Boolean = true,
+    val onFailure: suspend (ImageBatchResult.Failure) -> Unit = {},
+)
+
+@ImageFilterDsl
+class ImageProcessingDsl internal constructor() {
+    fun resize(width: Int, height: Int)
+    fun fit(width: Int, height: Int)
+    fun gaussianBlur(radius: Int = 2)
+    fun watermark(text: String, ...)
+    fun watermark(logo: ImmutableImage, position: Position = Position.BottomRight, alpha: Float = 1.0f)
+    fun smartCrop(width: Int, height: Int)
+    fun toJpeg(quality: Int = 80, progressive: Boolean = false)
+    fun writer(writer: SuspendImageWriter)
+    fun filters(block: ImageFilterChain.() -> Unit)
+}
+
+fun Flow<Path>.processImages(
+    options: ImageProcessingOptions = ImageProcessingOptions(),
+    block: ImageProcessingDsl.() -> Unit,
+): Flow<ImageBatchResult>
+
+fun Flow<File>.processImages(...): Flow<ImageBatchResult>
+```
+
+설계 규칙:
+
+- 기본값과 검증 기준은 magic number로 직접 쓰지 않는다. `DEFAULT_MAX_PIXELS`, `DEFAULT_MAX_IN_FLIGHT_PIXELS`, `DEFAULT_MAX_TILE_COUNT`, `JPEG_QUALITY_MIN`, `JPEG_QUALITY_MAX`, `PERFORMANCE_SAMPLE_IMAGE_COUNT`처럼 의미가 드러나는 top-level `const val` 또는 `val`로 정의한다. `Runtime.getRuntime().availableProcessors()`처럼 런타임 계산이 필요한 값은 `defaultImageBatchParallelism()` 같은 named helper로 감싼다.
+- `ImageProcessingDsl`은 내부적으로 `(ImmutableImage) -> ImmutableImage` steps와 optional writer를 보관한다.
+- `filters { ... }`를 통해 기존 `ImageFilterChain`을 그대로 포함할 수 있다. 구현은 `suspendApplyFilters`를 그대로 호출하지 않고 `withContext(options.transformDispatcher) { image.applyFilters(block) }` 경로를 사용한다. 기존 `suspendApplyFilters`는 `Dispatchers.Default`를 고정하므로 dispatcher 주입 API의 구현 근거로 쓰지 않는다.
+- 선언 순서대로 transform step을 실행한다. `filters {}`도 선언 위치의 한 step으로 적용된다.
+- `watermark(text, ...)`는 기존 text watermark DSL을 위임한다. `watermark(logo, position, alpha)`는 Issue #135 예시의 로고 워터마크를 1차 범위에 포함하며, `ImmutableImage.copy().awt().createGraphics()` 또는 기존 `BufferedImage.drawImage` helper를 사용해 위치 기반 overlay를 구현한다. logo 크기 조정은 caller 책임이며, `alpha`는 `0.0f..1.0f` 범위로 검증한다.
+- `toJpeg`/`writer`를 호출하면 결과는 `ImageBatchResult.WritableImage`가 된다. writer를 지정하지 않으면 `ImageBatchResult.Image`가 된다. 이로써 nullable writer로 인한 런타임 footgun을 제거한다.
+- `toJpeg`/`writer`를 여러 번 호출하면 마지막 값으로 덮어쓰지 않고 `IllegalArgumentException`으로 거부한다.
+- `toJpeg(quality)`는 `JPEG_QUALITY_MIN..JPEG_QUALITY_MAX` 범위로 검증한다.
+- `toJpeg`/`writer`는 writer 선택만 수행하고 파일을 저장하지 않는다. KDoc/README 예제는 반드시 collection + `writeTo`까지 보여준다.
+- 로딩/쓰기 I/O는 `options.ioDispatcher`, resize/filter/smartCrop 등 CPU-bound transform은 `options.transformDispatcher`에서 실행한다.
+- 기존 `SuspendImageWriter.suspendWrite`는 `Dispatchers.IO`를 고정하므로 `writeTo(..., ioDispatcher)` 구현은 `withContext(ioDispatcher) { Files.newOutputStream(path).use { writer.write(image, metadata, it) } }` 방식으로 직접 blocking writer를 감싼다. dispatcher-aware writer overload를 별도 추가하지 않는다.
+- `options.skipFailures = false`이면 첫 실패를 Flow 예외로 전파한다.
+- 실패를 전파할 때는 source/stage context를 가진 `ImageBatchException`으로 감싸되, `CancellationException`은 감싸지 않고 그대로 전파한다.
+- `options.maxPixels`를 decode 전 probe와 decode 후 image dimensions 검증에 적용한다.
+- `options.maxInFlightPixels`는 `WeightedSemaphore` 성격의 내부 pixel permit으로 구현한다. decode 전 probe로 `width * height`를 계산하고, `min(pixelCount, maxPixels)`만큼 permit을 획득한 뒤 load/transform/write result 생성이 끝나면 `finally`에서 해제한다. encoded output bytes와 thumbnail 결과 파일 크기는 계산에 포함하지 않는다. decode 전 dimensions를 알 수 없는 입력은 `maxPixels` permit을 획득한 뒤 decode 후 실제 pixel count로 검증한다. permit 획득 중 cancellation이 발생하면 permit을 누수하지 않는다.
+- ImageIO dimension probe는 `ImageInputStream.use {}`와 `ImageReader.dispose()`를 항상 수행한다.
+
+### 5.2 Processed image convenience
+
+`ImageBatchResult.WritableImage`는 쓰기 편의를 제공한다.
+
+```kotlin
+suspend fun ImageBatchResult.WritableImage.writeTo(
+    path: Path,
+    ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+): Long
+
+suspend fun ImageBatchResult.Image.writeTo(
+    path: Path,
+    writer: SuspendImageWriter,
+    ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+): Long
+```
+
+- `WritableImage.writeTo(path)`는 DSL에서 지정된 writer를 사용한다.
+- `Image.writeTo(path, writer)`는 호출 시점 writer를 필수로 받는다.
+- 두 함수 모두 `ioDispatcher`에서 직접 `writer.write(image, outputStream)`을 호출한다. 기존 `ImmutableImage.suspendWrite(writer, path)`는 `Dispatchers.IO`를 고정하므로 이 API에서는 사용하지 않는다.
+
+### 5.3 ThumbnailPipeline
+
+```kotlin
+package io.bluetape4k.images.thumbnail
+
+data class ThumbnailSize(
+    val width: Int,
+    val height: Int,
+    val crop: ThumbnailCrop = ThumbnailCrop.Fit,
+)
+
+sealed interface ThumbnailCrop {
+    data object Fit : ThumbnailCrop
+    data class Smart(val strategy: SaliencyStrategy = SaliencyStrategy.SobelEnergy) : ThumbnailCrop
+    data object Cover : ThumbnailCrop
+}
+
+data class ThumbnailResult(
+    val source: Path,
+    val size: ThumbnailSize,
+    val output: Path,
+    val status: ThumbnailStatus,
+)
+
+sealed interface ThumbnailStatus {
+    data class Success(val bytes: Long) : ThumbnailStatus
+    data class Failure(
+        val stage: ImageBatchFailureStage,
+        val cause: Throwable,
+        val message: String,
+        val details: Map<String, String> = emptyMap(),
+    ) : ThumbnailStatus
+}
+
+data class ThumbnailFormat(
+    val writer: SuspendImageWriter,
+    val extension: String,
+)
+
+fun interface ThumbnailOutputName {
+    fun outputName(source: Path, size: ThumbnailSize, format: ThumbnailFormat): String
+}
+
+class ThumbnailPipeline private constructor(...) {
+    fun process(sourceImages: Flow<Path>): Flow<ThumbnailResult>
+    fun process(sourceImages: Iterable<Path>): Flow<ThumbnailResult>
+
+    companion object {
+        fun builder(): Builder
+    }
+}
+```
+
+Builder surface:
+
+```kotlin
+ThumbnailPipeline.builder()
+    .sizes(listOf(ThumbnailSize(150, 150, ThumbnailCrop.Smart())))
+    .format(ThumbnailFormat(SuspendJpegWriter.Default.withCompression(80), "jpg"))
+    .outputDir(Path.of("/thumbnails"))
+    .outputName(ThumbnailOutputName { source, size, format -> /* optional custom filename */ })
+    .parallelism(defaultImageBatchParallelism())
+    .ioDispatcher(Dispatchers.IO)
+    .transformDispatcher(Dispatchers.Default)
+    .maxPixels(DEFAULT_MAX_PIXELS)
+    .maxInFlightPixels(DEFAULT_MAX_IN_FLIGHT_PIXELS)
+    .skipFailures(true)
+    .onFailure { failure -> /* metrics/log hook */ }
+    .build()
+```
+
+설계 규칙:
+
+- 기본 output name은 `{sourceHash}_{sourceStem}_{width}x{height}.{extension}`.
+- 사용자 지정 `ThumbnailOutputName`은 source/size/format을 받아 파일명만 반환한다.
+- `ThumbnailFormat`은 writer와 extension을 한 값 객체로 묶는다. `extension`은 blank를 거부하고 leading dot은 제거/정규화한다.
+- output name과 extension은 path separator, absolute path, `..`, Windows drive prefix를 거부한다. 최종 output은 `outputDir.resolve(name).normalize()`가 normalized absolute outputDir 하위인지 확인한다.
+- pipeline은 쓰기 전에 source/size별 output path를 계산해 중복 path가 있으면 전체 Flow를 시작하기 전 validation failure로 거부한다.
+- 각 source/size 조합은 독립 결과를 방출한다.
+- `skipFailures = true`이면 thumbnail 실패를 `ThumbnailStatus.Failure`로 방출하고 기본 `KLogging` warn 로그를 남긴다. `onFailure` callback은 failure마다 호출되어 metrics를 붙일 수 있다.
+- `skipFailures = false`이면 source/size context를 가진 `ImageBatchException`으로 실패를 전파한다. `CancellationException`은 감싸지 않고 그대로 전파한다.
+- Thumbnail pipeline도 `ioDispatcher`, `transformDispatcher`, `maxPixels`, `maxInFlightPixels` 옵션을 갖고 batch DSL과 동일한 pixel permit 계약을 사용한다.
+- `process(...)`는 cold Flow factory이므로 `suspend`가 아니다.
+- `ThumbnailSize.width/height`, builder `parallelism`, `maxPixels`, `maxInFlightPixels`는 양수여야 한다.
+
+### 5.4 TileProcessor
+
+```kotlin
+package io.bluetape4k.images.tiles
+
+data class TileSize(val width: Int, val height: Int)
+
+data class ImageTile(
+    val x: Int,
+    val y: Int,
+    val width: Int,
+    val height: Int,
+    val image: ImmutableImage,
+)
+
+class TileProcessor(
+    val tileSize: TileSize = TileSize(512, 512),
+    val dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    val parallelism: Int = defaultImageBatchParallelism(),
+    val maxPixels: Long = DEFAULT_MAX_PIXELS,
+    val maxTileCount: Int = DEFAULT_MAX_TILE_COUNT,
+) {
+    fun splitToTiles(image: ImmutableImage): List<ImageTile>
+
+    suspend fun processTiles(
+        image: ImmutableImage,
+        transform: suspend (ImageTile) -> ImageTile,
+    ): List<ImageTile>
+
+    fun mergeTiles(
+        tiles: Iterable<ImageTile>,
+        width: Int,
+        height: Int,
+    ): ImmutableImage
+}
+```
+
+설계 규칙:
+
+- `TileSize`, `parallelism`, `maxPixels`, `maxTileCount`는 모두 양수 검증.
+- split 전 source image의 `width * height <= maxPixels`를 검증한다.
+- split 결과 tile 수가 `maxTileCount`를 넘으면 즉시 실패한다.
+- split은 마지막 row/column tile의 width/height를 원본 경계에 맞춰 줄인다.
+- merge는 좌표 기반 draw로 수행한다.
+- `processTiles`의 transform은 tile의 `image`만 바꿀 수 있도록 권장한다. 반환 tile이 좌표/크기까지 바꾸는 경우 `mergeTiles`가 duplicate, missing, out-of-bounds, image dimension mismatch를 검증하고 `IllegalArgumentException`으로 실패한다.
+- `processTiles`는 `coroutineScope { async(dispatcher) { ... } }`와 `Semaphore(parallelism)`으로 동시 실행 tile 수를 제한한다. tile processor는 이미 단일 decoded image를 입력으로 받으므로 `maxInFlightPixels`를 별도로 두지 않는다.
+
+---
+
+## 6. 파일 계획
+
+예상 추가/변경 파일:
+
+```
+utils/images/src/main/kotlin/io/bluetape4k/images/batch/
+├── ImageBatchResult.kt
+├── ImageProcessingDsl.kt
+└── ImageBatchProcessing.kt
+
+utils/images/src/main/kotlin/io/bluetape4k/images/thumbnail/
+├── ThumbnailPipeline.kt
+├── ThumbnailResult.kt
+└── ThumbnailSize.kt
+
+utils/images/src/main/kotlin/io/bluetape4k/images/tiles/
+└── TileProcessor.kt
+
+utils/images/src/test/kotlin/io/bluetape4k/images/batch/
+utils/images/src/test/kotlin/io/bluetape4k/images/thumbnail/
+utils/images/src/test/kotlin/io/bluetape4k/images/tiles/
+
+utils/images/README.md
+utils/images/README.ko.md
+docs/testlogs/2026-04.md
+docs/superpowers/index/2026-04.md
+docs/superpowers/INDEX.md
+```
+
+---
+
+## 7. 테스트 전략
+
+### 7.1 Batch Flow DSL
+
+- 정상 이미지 5개를 처리해 `Success` 5건 방출.
+- 깨진 파일 1개 + 정상 이미지 N개에서 `skipFailures = true`이면 `Failure` 1건 + `Success` N건 방출.
+- `skipFailures = false`이면 Flow collection 중 예외 전파.
+- `parallelism <= 0`은 `IllegalArgumentException`.
+- `writeTo(path, SuspendJpegWriter.Default.withCompression(85))` 결과 파일이 생성되고 byte size > 0.
+- `maxPixels`를 넘는 synthetic image는 validation failure 또는 `IllegalArgumentException`으로 실패.
+- `maxInFlightPixels`에 따라 대형 이미지 batch의 in-flight 처리 수가 제한된다.
+- `onFailure` callback이 failure마다 호출된다.
+
+### 7.2 ThumbnailPipeline
+
+- 한 source에서 3개 size를 생성하면 `ThumbnailResult` 3건과 파일 3개 생성.
+- smart crop thumbnail은 정확한 width/height를 가진다.
+- 깨진 source는 failure result를 방출하고 다른 source/size 처리를 계속한다.
+- `skipFailures = true`에서 기본 warn logging과 `onFailure` callback이 failure마다 실행된다.
+- `skipFailures = false`에서는 `ImageBatchException`이 전파되고 `CancellationException`은 그대로 전파된다.
+- output name collision이 없어야 한다.
+- `ThumbnailFormat(extension = "")`와 `ThumbnailSize(width <= 0)`는 거부된다.
+- output name이 `../evil.jpg`, absolute path, path separator, Windows drive prefix를 포함하면 거부된다.
+
+### 7.3 TileProcessor
+
+- `TILE_TEST_IMAGE_WIDTH x TILE_TEST_IMAGE_HEIGHT` synthetic image를 `TILE_TEST_SIZE` tile로 나누면 마지막 row/column 크기가 올바르다.
+- 무변환 split/merge 결과가 원본과 픽셀 동일하다.
+- tile별 transform을 적용하면 merge 결과가 해당 tile 영역에 반영된다.
+- `tileSize <= 0`, `parallelism <= 0` 검증.
+- duplicate/missing/out-of-bounds tile geometry는 merge에서 결정적으로 실패한다.
+- `maxPixels`, `maxTileCount` 초과 입력은 fail-fast 한다.
+
+### 7.4 성능 회귀
+
+- 단일 스레드 대비 N배 개선을 하드 assertion으로 두지 않는다. CI machine 편차가 크기 때문이다.
+- 대신 동시성 상한/결과 수/실패 지속성을 단위 테스트로 고정한다.
+- `PERFORMANCE_SAMPLE_IMAGE_COUNT = 100` synthetic 이미지 또는 fixture 복제 입력으로 `parallelism = 1`과 `parallelism = min(4, availableProcessors)` 처리 시간을 non-gating test log에 기록한다.
+- 성능 측정은 pass/fail assertion으로 쓰지 않고 `docs/testlogs/2026-04.md`에 입력 수, 이미지 크기, dispatcher, parallelism, 처리 시간만 남긴다.
+
+---
+
+## 8. 문서화
+
+`utils/images/README.md`와 `README.ko.md`에 다음 섹션을 추가한다.
+
+- Batch Image Processing
+- Thumbnail Pipeline
+- Tile Processing
+- Error handling contract
+- Ordering and parallelism notes
+- Memory guard and caller-owned timeout/cancellation notes
+- Output path containment notes
+
+예시는 다음 흐름을 포함한다.
+
+```kotlin
+val results = imageFiles.asFlow()
+    .processImages(
+        options = ImageProcessingOptions(
+            ioDispatcher = Dispatchers.IO,
+            transformDispatcher = Dispatchers.Default,
+            parallelism = 4,
+            maxPixels = DEFAULT_MAX_PIXELS,
+            maxInFlightPixels = DEFAULT_MAX_IN_FLIGHT_PIXELS,
+        )
+    ) {
+        resize(800, 600)
+        gaussianBlur(radius = 1)
+    }
+```
+
+---
+
+## 9. DoD
+
+### API
+
+- [ ] `Flow<Path>.processImages(...)` 공개 API가 추가된다.
+- [ ] `Flow<File>.processImages(...)` 위임 overload가 추가된다.
+- [ ] `ImageProcessingDsl`이 resize/fit/gaussianBlur/smartCrop/writer/toJpeg/filter bridge를 제공한다.
+- [ ] `ImageProcessingDsl`이 text watermark와 logo image watermark를 제공한다.
+- [ ] `ImageBatchResult.Image` / `WritableImage` / `Failure` 결과 타입이 추가된다.
+- [ ] `ImageProcessingOptions`가 `ioDispatcher` / `transformDispatcher` / `maxPixels` / `maxInFlightPixels` / `onFailure`를 제공한다.
+- [ ] `ThumbnailPipeline` builder와 `ThumbnailResult`가 추가된다.
+- [ ] `ThumbnailPipeline`이 `onFailure`, dispatcher, maxPixels, maxInFlightPixels 옵션을 제공한다.
+- [ ] `ThumbnailFormat(writer, extension)` 값 객체가 writer/extension 불일치를 줄인다.
+- [ ] `TileProcessor` split/process/merge API가 추가된다.
+- [ ] 기본값과 테스트 기준값이 magic number가 아니라 의미 있는 `const val`/named helper로 정의된다.
+
+### Behavior
+
+- [ ] 깨진 이미지 입력이 전체 batch를 중단하지 않고 failure result로 방출된다 (`skipFailures = true`).
+- [ ] `skipFailures = false`에서는 원본 예외가 전파된다.
+- [ ] `parallelism`, size, quality, extension, maxPixels, maxInFlightPixels, maxTileCount 등 public 입력값 검증이 있다.
+- [ ] thumbnail output path containment 검증이 path traversal을 거부한다.
+- [ ] 실패 result와 기본 warn logging 또는 `onFailure` callback으로 skipped failure가 관측 가능하다.
+- [ ] I/O와 CPU transform dispatcher가 분리되어 있다.
+- [ ] dispatcher 주입 API는 `suspendApplyFilters`/`SuspendImageWriter.suspendWrite`의 고정 dispatcher를 우회해 지정 dispatcher에서 실행된다.
+- [ ] thumbnail output path는 size별로 충돌하지 않는다.
+- [ ] tile split 후 무변환 merge는 원본과 픽셀 동일하다.
+- [ ] tile merge geometry validation이 duplicate/missing/out-of-bounds/mismatched dimensions를 거부한다.
+
+### Tests
+
+- [ ] batch DSL 성공/실패/입력 검증 테스트가 있다.
+- [ ] thumbnail 다중 size/SmartCrop/failure skip 테스트가 있다.
+- [ ] tile split/merge/pixel identity/validation 테스트가 있다.
+- [ ] maxPixels/maxInFlightPixels/maxTileCount guard 테스트가 있다.
+- [ ] 100개 이미지 batch 처리 시간 non-gating 로그가 있다.
+- [ ] `./bin/repo-test-summary -- ./gradlew :bluetape4k-images:test`가 통과한다.
+
+### Documentation
+
+- [ ] 모든 public API에 한국어 KDoc이 있다.
+- [ ] `utils/images/README.md`와 `README.ko.md`가 batch/thumbnail/tile 사용법을 설명한다.
+- [ ] `docs/superpowers/index/2026-04.md`와 `docs/superpowers/INDEX.md`가 갱신된다.
+- [ ] `docs/testlogs/2026-04.md`에 검증 로그가 추가된다.
+
+---
+
+## 10. 초안 Task 목록
+
+| Task | 내용 | complexity |
+|------|------|------------|
+| T01 | `ImageBatchResult`와 `ImageProcessingDsl` 모델 추가 | medium |
+| T02 | `Flow<Path/File>.processImages` 구현 | high |
+| T03 | batch DSL 테스트 작성 | medium |
+| T04 | `ThumbnailSize`, `ThumbnailResult`, `ThumbnailPipeline` 구현 | high |
+| T05 | thumbnail pipeline 테스트 작성 | medium |
+| T06 | `TileProcessor` split/process/merge 구현 | high |
+| T07 | tile processor pixel identity 테스트 작성 | medium |
+| T08 | 100-image non-gating 성능 로그 작성 | low |
+| T09 | README.md / README.ko.md 갱신 | low |
+| T10 | testlog + superpowers index 갱신 | low |

--- a/docs/superpowers/specs/2026-04-28-images-batch-flow-design.md
+++ b/docs/superpowers/specs/2026-04-28-images-batch-flow-design.md
@@ -505,7 +505,7 @@ docs/superpowers/INDEX.md
 - `skipFailures = true`에서 기본 warn logging과 `onFailure` callback이 failure마다 실행된다.
 - `skipFailures = false`에서는 `ImageBatchException`이 전파되고 `CancellationException`은 그대로 전파된다.
 - output name collision이 없어야 한다.
-- `ThumbnailFormat(extension = "")`와 `ThumbnailSize(width <= 0)`는 거부된다.
+- `ThumbnailFormat(SuspendJpegWriter.Default, "")`와 `ThumbnailSize(width <= 0)`는 거부된다.
 - output name이 `../evil.jpg`, absolute path, path separator, Windows drive prefix를 포함하면 거부된다.
 
 ### 7.3 TileProcessor

--- a/utils/images/README.ko.md
+++ b/utils/images/README.ko.md
@@ -195,6 +195,10 @@ classDiagram
 | `ImageFormat.kt`                                     | 지원 이미지 포맷 열거형                 |
 | `WriteContextExtensions.kt`                          | 쓰기 컨텍스트 확장 함수                 |
 | `IIORegistryUtils.kt`                                | ImageIO 레지스트리 유틸리티            |
+| `batch/ImageBatchFlow.kt`                            | Coroutine Flow 기반 배치 이미지 처리   |
+| `batch/ImageProcessingDsl.kt`                        | 이름 있는 기본값을 쓰는 배치 변환 DSL   |
+| `thumbnail/ThumbnailPipeline.kt`                     | 여러 크기 썸네일 생성 파이프라인        |
+| `tiles/TileProcessor.kt`                             | 타일 분할/병합과 병렬 타일 처리         |
 | `scaler/ImageScaler.kt`                              | 이미지 크기 조절                     |
 | `splitter/ImageSplitter.kt`                          | 이미지 분할                        |
 | `filters/WatermarkFilterSupport.kt`                  | 워터마크 필터                       |
@@ -307,6 +311,81 @@ image.suspendWrite(SuspendWebpWriter.Default, Paths.get("output.webp"))
 // ByteArray로 변환
 val jpegBytes = image.suspendBytes(SuspendJpegWriter.Default)
 val webpBytes = image.suspendBytes(SuspendWebpWriter.Default)
+```
+
+### 배치 이미지 Flow (Issue #135)
+
+```kotlin
+import io.bluetape4k.images.batch.*
+import kotlinx.coroutines.flow.asFlow
+import java.nio.file.Path
+
+val options = ImageProcessingOptions(
+    parallelism = defaultImageBatchParallelism(),
+    maxPixels = DEFAULT_MAX_PIXELS,
+    maxInFlightPixels = DEFAULT_MAX_IN_FLIGHT_PIXELS,
+    skipFailures = true,
+    onFailure = { failure ->
+        // 전체 배치를 중단하지 않고 source/stage/cause를 관측
+    }
+)
+
+listOf(Path.of("a.jpg"), Path.of("b.jpg"))
+    .asFlow()
+    .processImages(options) {
+        resize(width = 320, height = 240)
+        watermark("© bluetape4k")
+        toJpeg(quality = 85)
+    }
+    .writeImagesTo(Path.of("out"), options)
+```
+
+`ImageProcessingDsl`의 변환은 `transformDispatcher`에서 실행되고, 저장 편의 함수는 호출자가 넘긴
+`ioDispatcher`에서 writer를 직접 호출합니다. 배치 기본값은 `DEFAULT_MAX_PIXELS`,
+`DEFAULT_MAX_IN_FLIGHT_PIXELS`, `JPEG_QUALITY_MIN`, `JPEG_QUALITY_MAX`,
+`PERFORMANCE_SAMPLE_IMAGE_COUNT`처럼 이름 있는 상수로 제공합니다.
+더 큰 이미지 세트는 `ImageProcessingOptions.largeJobs()`를 사용하거나
+`maxPixels` / `maxInFlightPixels`를 명시적으로 높여 처리할 수 있습니다.
+
+```kotlin
+val largeOptions = ImageProcessingOptions.largeJobs(
+    parallelism = defaultImageBatchParallelism(),
+    maxPixels = LARGE_JOB_MAX_PIXELS,
+    maxInFlightPixels = LARGE_JOB_MAX_IN_FLIGHT_PIXELS,
+)
+```
+
+### 썸네일 파이프라인
+
+```kotlin
+import io.bluetape4k.images.batch.ImageProcessingOptions
+import io.bluetape4k.images.coroutines.SuspendJpegWriter
+import io.bluetape4k.images.thumbnail.*
+import kotlinx.coroutines.flow.asFlow
+import java.nio.file.Path
+
+val pipeline = ThumbnailPipeline.builder()
+    .outputDirectory(Path.of("thumbs"))
+    .size(width = 320, height = 240, suffix = "small")
+    .format(ThumbnailFormat(SuspendJpegWriter.Default.withCompression(85), "jpg"))
+    .crop(ThumbnailCrop.Smart())
+    .options(ImageProcessingOptions(skipFailures = true))
+    .onFailure { failure ->
+        // failure.stage로 validation/load/transform/write 단계를 구분
+    }
+    .build()
+
+pipeline.process(listOf(Path.of("photo.jpg")).asFlow())
+```
+
+### 타일 처리
+
+```kotlin
+import io.bluetape4k.images.tiles.*
+
+val processor = TileProcessor()
+val tiles = processor.split(image, TileSize(width = 512, height = 512))
+val merged = processor.merge(tiles, image.width, image.height)
 ```
 
 ### TIFF 지원 (Issue #134)

--- a/utils/images/README.md
+++ b/utils/images/README.md
@@ -193,6 +193,10 @@ classDiagram
 | `ImageFormat.kt`                               | Supported image format enum              |
 | `WriteContextExtensions.kt`                    | Write context extensions                 |
 | `IIORegistryUtils.kt`                          | ImageIO registry utilities               |
+| `batch/ImageBatchFlow.kt`                      | Coroutine Flow batch image processing    |
+| `batch/ImageProcessingDsl.kt`                  | Batch transform DSL with named defaults  |
+| `thumbnail/ThumbnailPipeline.kt`               | Multi-size thumbnail pipeline            |
+| `tiles/TileProcessor.kt`                       | Tile split/merge and parallel tile processing |
 | `scaler/ImageScaler.kt`                        | Image resizing                           |
 | `splitter/ImageSplitter.kt`                    | Image splitting                          |
 | `filters/WatermarkFilterSupport.kt`            | Watermark filter                         |
@@ -300,6 +304,80 @@ image.suspendWrite(SuspendWebpWriter.Default, Paths.get("output.webp"))
 // Convert to ByteArray
 val jpegBytes = image.suspendBytes(SuspendJpegWriter.Default)
 val webpBytes = image.suspendBytes(SuspendWebpWriter.Default)
+```
+
+### Batch Image Flow (Issue #135)
+
+```kotlin
+import io.bluetape4k.images.batch.*
+import kotlinx.coroutines.flow.asFlow
+import java.nio.file.Path
+
+val options = ImageProcessingOptions(
+    parallelism = defaultImageBatchParallelism(),
+    maxPixels = DEFAULT_MAX_PIXELS,
+    maxInFlightPixels = DEFAULT_MAX_IN_FLIGHT_PIXELS,
+    skipFailures = true,
+    onFailure = { failure ->
+        // observe source/stage/cause without stopping the whole batch
+    }
+)
+
+listOf(Path.of("a.jpg"), Path.of("b.jpg"))
+    .asFlow()
+    .processImages(options) {
+        resize(width = 320, height = 240)
+        watermark("© bluetape4k")
+        toJpeg(quality = 85)
+    }
+    .writeImagesTo(Path.of("out"), options)
+```
+
+`ImageProcessingDsl` runs transforms on `transformDispatcher` and writes through the caller-provided `ioDispatcher`.
+The batch defaults are named constants such as `DEFAULT_MAX_PIXELS`, `DEFAULT_MAX_IN_FLIGHT_PIXELS`,
+`JPEG_QUALITY_MIN`, `JPEG_QUALITY_MAX`, and `PERFORMANCE_SAMPLE_IMAGE_COUNT`.
+For larger image sets, use `ImageProcessingOptions.largeJobs()` or pass explicit
+`maxPixels` / `maxInFlightPixels` values:
+
+```kotlin
+val largeOptions = ImageProcessingOptions.largeJobs(
+    parallelism = defaultImageBatchParallelism(),
+    maxPixels = LARGE_JOB_MAX_PIXELS,
+    maxInFlightPixels = LARGE_JOB_MAX_IN_FLIGHT_PIXELS,
+)
+```
+
+### Thumbnail Pipeline
+
+```kotlin
+import io.bluetape4k.images.batch.ImageProcessingOptions
+import io.bluetape4k.images.coroutines.SuspendJpegWriter
+import io.bluetape4k.images.thumbnail.*
+import kotlinx.coroutines.flow.asFlow
+import java.nio.file.Path
+
+val pipeline = ThumbnailPipeline.builder()
+    .outputDirectory(Path.of("thumbs"))
+    .size(width = 320, height = 240, suffix = "small")
+    .format(ThumbnailFormat(SuspendJpegWriter.Default.withCompression(85), "jpg"))
+    .crop(ThumbnailCrop.Smart())
+    .options(ImageProcessingOptions(skipFailures = true))
+    .onFailure { failure ->
+        // failure.stage identifies validation/load/transform/write
+    }
+    .build()
+
+pipeline.process(listOf(Path.of("photo.jpg")).asFlow())
+```
+
+### Tile Processing
+
+```kotlin
+import io.bluetape4k.images.tiles.*
+
+val processor = TileProcessor()
+val tiles = processor.split(image, TileSize(width = 512, height = 512))
+val merged = processor.merge(tiles, image.width, image.height)
 ```
 
 ### TIFF Support (Issue #134)

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageBatchDefaults.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageBatchDefaults.kt
@@ -1,0 +1,56 @@
+package io.bluetape4k.images.batch
+
+/**
+ * 배치 이미지 처리의 기본 픽셀 한도입니다.
+ */
+const val DEFAULT_MAX_PIXELS: Long = 16_777_216L
+
+internal const val DEFAULT_MAX_IN_FLIGHT_MULTIPLIER: Long = 2L
+
+/**
+ * 배치 이미지 처리에서 동시에 허용하는 기본 픽셀 총량입니다.
+ */
+const val DEFAULT_MAX_IN_FLIGHT_PIXELS: Long = DEFAULT_MAX_PIXELS * DEFAULT_MAX_IN_FLIGHT_MULTIPLIER
+
+/**
+ * 타일 분할에서 허용하는 기본 최대 타일 수입니다.
+ */
+const val DEFAULT_MAX_TILE_COUNT: Int = 65_536
+
+/**
+ * JPEG 압축 품질의 최소값입니다.
+ */
+const val JPEG_QUALITY_MIN: Int = 0
+
+/**
+ * JPEG 압축 품질의 최대값입니다.
+ */
+const val JPEG_QUALITY_MAX: Int = 100
+
+/**
+ * 비차단 성능 샘플의 기본 이미지 수입니다.
+ */
+const val PERFORMANCE_SAMPLE_IMAGE_COUNT: Int = 100
+
+internal const val LARGE_JOB_MAX_PIXELS_MULTIPLIER: Long = 16L
+internal const val LARGE_JOB_MAX_IN_FLIGHT_MULTIPLIER: Long = 2L
+
+/**
+ * 대용량 배치 처리에서 단일 이미지에 허용하는 기본 픽셀 수입니다.
+ */
+const val LARGE_JOB_MAX_PIXELS: Long = DEFAULT_MAX_PIXELS * LARGE_JOB_MAX_PIXELS_MULTIPLIER
+
+/**
+ * 대용량 배치 처리에서 동시에 허용하는 기본 픽셀 총량입니다.
+ */
+const val LARGE_JOB_MAX_IN_FLIGHT_PIXELS: Long = LARGE_JOB_MAX_PIXELS * LARGE_JOB_MAX_IN_FLIGHT_MULTIPLIER
+
+internal const val MIN_IMAGE_BATCH_PARALLELISM: Int = 1
+internal const val MIN_PIXEL_PERMIT: Long = 1L
+internal const val PIXEL_PERMIT_RETRY_DELAY_MILLIS: Long = 1L
+
+/**
+ * 현재 런타임에 맞춘 이미지 배치 기본 병렬도를 반환합니다.
+ */
+fun defaultImageBatchParallelism(): Int =
+    Runtime.getRuntime().availableProcessors().coerceAtLeast(MIN_IMAGE_BATCH_PARALLELISM)

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageBatchFlow.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageBatchFlow.kt
@@ -1,0 +1,225 @@
+package io.bluetape4k.images.batch
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.coroutines.flow.extensions.mapParallel
+import io.bluetape4k.images.coroutines.SuspendImageWriter
+import io.bluetape4k.images.immutableImageOf
+import io.bluetape4k.logging.KotlinLogging
+import io.bluetape4k.logging.warn
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.coroutines.CoroutineContext
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * [Path] 스트림을 이미지 배치 처리 결과 스트림으로 변환합니다.
+ */
+fun Flow<Path>.processImages(
+    options: ImageProcessingOptions = ImageProcessingOptions(),
+    block: ImageProcessingDsl.() -> Unit,
+): Flow<ImageBatchResult> {
+    val dsl = ImageProcessingDsl().apply(block)
+    val limiter = PixelPermitLimiter(options.maxInFlightPixels)
+
+    return mapParallel(options.parallelism) { source ->
+        processOneImage(source, dsl, options, limiter)
+    }
+}
+
+/**
+ * [File] 스트림을 이미지 배치 처리 결과 스트림으로 변환합니다.
+ */
+fun Flow<File>.processImageFiles(
+    options: ImageProcessingOptions = ImageProcessingOptions(),
+    block: ImageProcessingDsl.() -> Unit,
+): Flow<ImageBatchResult> =
+    map { file -> file.toPath() }.processImages(options, block)
+
+/**
+ * 성공적으로 writer가 선택된 이미지 결과만 저장합니다.
+ */
+fun Flow<ImageBatchResult>.writeImagesTo(
+    outputDirectory: Path,
+    options: ImageProcessingOptions = ImageProcessingOptions(),
+    outputName: (source: Path) -> String = { source -> source.fileName.toString() },
+): Flow<Path> =
+    filterIsInstance<ImageBatchResult.WritableImage>()
+        .mapParallel(options.parallelism) { result ->
+            var output: Path? = null
+            try {
+                output = resolveOutputPath(outputDirectory, outputName(result.source))
+                result.writeTo(output, options.ioDispatcher)
+                output
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                handleWriteFailure(result, output, e, options)
+            }
+        }
+        .filterNotNull()
+
+/**
+ * writer가 선택된 이미지 결과를 지정 경로에 저장합니다.
+ */
+suspend fun ImageBatchResult.WritableImage.writeTo(
+    output: Path,
+    ioDispatcher: CoroutineContext,
+): Long =
+    withContext(ioDispatcher) {
+        output.parent?.let(Files::createDirectories)
+        Files.newOutputStream(output).use { stream ->
+            writer.write(image, stream)
+        }
+        Files.size(output)
+    }
+
+private suspend fun processOneImage(
+    source: Path,
+    dsl: ImageProcessingDsl,
+    options: ImageProcessingOptions,
+    limiter: PixelPermitLimiter,
+): ImageBatchResult {
+    try {
+        val probedPixels = runStage(source, ImageBatchFailureStage.VALIDATION) {
+            withContext(options.ioDispatcher) { probeImagePixelCount(source) }
+        }
+        probedPixels?.requireWithinMaxPixels(source, options.maxPixels)
+
+        val permitPixels = probedPixels ?: options.maxPixels
+        return limiter.withPermit(permitPixels) {
+            val image = runStage(source, ImageBatchFailureStage.LOAD) {
+                withContext(options.ioDispatcher) { immutableImageOf(source) }
+            }
+            image.pixelCount().requireWithinMaxPixels(source, options.maxPixels)
+
+            val transformed = runStage(source, ImageBatchFailureStage.TRANSFORM) {
+                withContext(options.transformDispatcher) { dsl.apply(image) }
+            }
+            transformed.toBatchResult(source, dsl.selectedWriter())
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: ImageBatchException) {
+        return handleFailure(e, options)
+    } catch (e: Throwable) {
+        return handleFailure(
+            ImageBatchException(
+                source = source,
+                stage = ImageBatchFailureStage.TRANSFORM,
+                message = "이미지 배치 처리에 실패했습니다: $source",
+                cause = e,
+            ),
+            options,
+        )
+    }
+}
+
+private suspend inline fun <T> runStage(
+    source: Path,
+    stage: ImageBatchFailureStage,
+    crossinline block: suspend () -> T,
+): T =
+    try {
+        block()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: ImageBatchException) {
+        throw e
+    } catch (e: Throwable) {
+        throw ImageBatchException(
+            source = source,
+            stage = stage,
+            message = "이미지 배치 처리 단계가 실패했습니다. source=$source, stage=$stage",
+            cause = e,
+        )
+    }
+
+private suspend fun handleFailure(
+    exception: ImageBatchException,
+    options: ImageProcessingOptions,
+): ImageBatchResult.Failure {
+    val failure = ImageBatchResult.Failure(
+        source = exception.source,
+        stage = exception.stage,
+        output = exception.output,
+        cause = exception.cause ?: exception,
+    )
+
+    if (!options.skipFailures) {
+        throw exception
+    }
+
+    log.warn(exception) { "이미지 배치 실패를 건너뜁니다. source=${exception.source}, stage=${exception.stage}" }
+    options.onFailure(failure)
+    return failure
+}
+
+private suspend fun handleWriteFailure(
+    result: ImageBatchResult.WritableImage,
+    output: Path?,
+    cause: Throwable,
+    options: ImageProcessingOptions,
+): Path? {
+    val exception = ImageBatchException(
+        source = result.source,
+        stage = ImageBatchFailureStage.WRITE,
+        output = output,
+        message = "이미지 저장에 실패했습니다. source=${result.source}, output=$output",
+        cause = cause,
+    )
+    val failure = ImageBatchResult.Failure(
+        source = result.source,
+        stage = ImageBatchFailureStage.WRITE,
+        output = output,
+        cause = cause,
+    )
+
+    if (!options.skipFailures) {
+        throw exception
+    }
+
+    log.warn(exception) { "이미지 저장 실패를 건너뜁니다. source=${result.source}, output=$output" }
+    options.onFailure(failure)
+    return null
+}
+
+private fun resolveOutputPath(outputDirectory: Path, outputName: String): Path {
+    require(outputName.isNotBlank()) { "outputName은 blank일 수 없습니다." }
+    val base = outputDirectory.toAbsolutePath().normalize()
+    val output = base.resolve(outputName).normalize()
+    require(output.startsWith(base)) {
+        "출력 경로가 outputDirectory를 벗어날 수 없습니다. outputDirectory=$outputDirectory, outputName=$outputName"
+    }
+    return output
+}
+
+private fun ImmutableImage.toBatchResult(
+    source: Path,
+    writer: SuspendImageWriter?,
+): ImageBatchResult =
+    if (writer == null) {
+        ImageBatchResult.Image(source, this)
+    } else {
+        ImageBatchResult.WritableImage(source, this, writer)
+    }
+
+private fun ImmutableImage.pixelCount(): Long =
+    width.toLong() * height.toLong()
+
+private fun Long.requireWithinMaxPixels(source: Path, maxPixels: Long) {
+    if (this > maxPixels) {
+        throw ImageBatchException(
+            source = source,
+            stage = ImageBatchFailureStage.VALIDATION,
+            message = "이미지 픽셀 수가 허용 한도를 초과했습니다. source=$source, pixels=$this, maxPixels=$maxPixels",
+        )
+    }
+}

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageBatchModels.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageBatchModels.kt
@@ -1,0 +1,120 @@
+package io.bluetape4k.images.batch
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.images.coroutines.SuspendImageWriter
+import io.bluetape4k.support.requirePositiveNumber
+import kotlinx.coroutines.Dispatchers
+import java.nio.file.Path
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * 이미지 배치 처리 실패 단계입니다.
+ */
+enum class ImageBatchFailureStage {
+    VALIDATION,
+    LOAD,
+    TRANSFORM,
+    WRITE,
+}
+
+/**
+ * 배치 이미지 처리 실패를 원본 경로와 처리 단계와 함께 전달하는 예외입니다.
+ */
+class ImageBatchException(
+    val source: Path,
+    val stage: ImageBatchFailureStage,
+    val output: Path? = null,
+    message: String,
+    cause: Throwable? = null,
+): RuntimeException(message, cause)
+
+/**
+ * 배치 이미지 처리 결과입니다.
+ */
+sealed interface ImageBatchResult {
+    /**
+     * 입력 이미지 경로입니다.
+     */
+    val source: Path
+
+    /**
+     * 이미지 변환에 성공했지만 writer가 선택되지 않은 결과입니다.
+     */
+    data class Image(
+        override val source: Path,
+        val image: ImmutableImage,
+    ): ImageBatchResult
+
+    /**
+     * 이미지 변환과 writer 선택에 성공한 결과입니다.
+     */
+    data class WritableImage(
+        override val source: Path,
+        val image: ImmutableImage,
+        val writer: SuspendImageWriter,
+    ): ImageBatchResult
+
+    /**
+     * `skipFailures=true`에서 스트림 안으로 전달되는 실패 결과입니다.
+     */
+    data class Failure(
+        override val source: Path,
+        val stage: ImageBatchFailureStage,
+        val output: Path? = null,
+        val cause: Throwable,
+    ): ImageBatchResult
+}
+
+/**
+ * 이미지 배치 처리 옵션입니다.
+ *
+ * @property ioDispatcher 이미지 읽기/쓰기 작업에 사용할 컨텍스트
+ * @property transformDispatcher 이미지 변환 작업에 사용할 컨텍스트
+ * @property parallelism 동시에 처리할 이미지 수
+ * @property maxPixels 단일 이미지 허용 픽셀 수
+ * @property maxInFlightPixels 동시에 처리 중인 이미지의 픽셀 총량
+ * @property skipFailures 실패를 결과로 흘려보낼지 여부
+ * @property onFailure 실패 관측 콜백
+ */
+data class ImageProcessingOptions(
+    val ioDispatcher: CoroutineContext = Dispatchers.IO,
+    val transformDispatcher: CoroutineContext = Dispatchers.Default,
+    val parallelism: Int = defaultImageBatchParallelism(),
+    val maxPixels: Long = DEFAULT_MAX_PIXELS,
+    val maxInFlightPixels: Long = DEFAULT_MAX_IN_FLIGHT_PIXELS,
+    val skipFailures: Boolean = false,
+    val onFailure: suspend (ImageBatchResult.Failure) -> Unit = {},
+) {
+    init {
+        parallelism.requirePositiveNumber("parallelism")
+        maxPixels.requirePositiveNumber("maxPixels")
+        maxInFlightPixels.requirePositiveNumber("maxInFlightPixels")
+    }
+
+    companion object {
+        /**
+         * 큰 이미지/대용량 배치를 위한 옵션을 생성합니다.
+         *
+         * 기본 [ImageProcessingOptions]보다 픽셀 한도를 크게 잡되, 호출자가 명시적으로
+         * `maxPixels`와 `maxInFlightPixels`를 더 조정할 수 있도록 열어둡니다.
+         */
+        fun largeJobs(
+            ioDispatcher: CoroutineContext = Dispatchers.IO,
+            transformDispatcher: CoroutineContext = Dispatchers.Default,
+            parallelism: Int = defaultImageBatchParallelism(),
+            maxPixels: Long = LARGE_JOB_MAX_PIXELS,
+            maxInFlightPixels: Long = LARGE_JOB_MAX_IN_FLIGHT_PIXELS,
+            skipFailures: Boolean = false,
+            onFailure: suspend (ImageBatchResult.Failure) -> Unit = {},
+        ): ImageProcessingOptions =
+            ImageProcessingOptions(
+                ioDispatcher = ioDispatcher,
+                transformDispatcher = transformDispatcher,
+                parallelism = parallelism,
+                maxPixels = maxPixels,
+                maxInFlightPixels = maxInFlightPixels,
+                skipFailures = skipFailures,
+                onFailure = onFailure,
+            )
+    }
+}

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageDimensionProbe.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageDimensionProbe.kt
@@ -1,0 +1,25 @@
+package io.bluetape4k.images.batch
+
+import java.nio.file.Path
+import javax.imageio.ImageIO
+
+/**
+ * 이미지를 완전히 디코딩하지 않고 첫 프레임의 픽셀 수를 읽습니다.
+ */
+fun probeImagePixelCount(path: Path): Long? {
+    val input = ImageIO.createImageInputStream(path.toFile()) ?: return null
+    input.use { stream ->
+        val readers = ImageIO.getImageReaders(stream)
+        if (!readers.hasNext()) {
+            return null
+        }
+
+        val reader = readers.next()
+        try {
+            reader.input = stream
+            return reader.getWidth(0).toLong() * reader.getHeight(0).toLong()
+        } finally {
+            reader.dispose()
+        }
+    }
+}

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageProcessingDsl.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageProcessingDsl.kt
@@ -1,0 +1,150 @@
+package io.bluetape4k.images.batch
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.Position
+import io.bluetape4k.images.coroutines.SuspendImageWriter
+import io.bluetape4k.images.coroutines.SuspendJpegWriter
+import io.bluetape4k.images.filters.WatermarkFilterType
+import io.bluetape4k.images.filters.dsl.ImageFilterChain
+import io.bluetape4k.images.filters.dsl.applyFilters
+import io.bluetape4k.images.filters.dsl.gaussianBlur
+import io.bluetape4k.images.filters.dsl.watermark
+import io.bluetape4k.images.fonts.DEFAULT_FONT
+import io.bluetape4k.images.transforms.SaliencyStrategy
+import io.bluetape4k.images.transforms.smartCropTo
+import io.bluetape4k.support.requireInRange
+import io.bluetape4k.support.requirePositiveNumber
+import java.awt.AlphaComposite
+import java.awt.Color
+import java.awt.Font
+
+/**
+ * 배치 이미지 변환 단계를 선언하는 DSL입니다.
+ */
+class ImageProcessingDsl {
+    private val transforms = mutableListOf<(ImmutableImage) -> ImmutableImage>()
+    private var writer: SuspendImageWriter? = null
+
+    /**
+     * 이미지를 지정 크기로 리사이즈합니다.
+     */
+    fun resize(width: Int, height: Int) {
+        width.requirePositiveNumber("width")
+        height.requirePositiveNumber("height")
+        transforms += { image -> image.scaleTo(width, height) }
+    }
+
+    /**
+     * 이미지를 지정 크기에 맞춥니다.
+     */
+    fun fit(width: Int, height: Int) {
+        width.requirePositiveNumber("width")
+        height.requirePositiveNumber("height")
+        transforms += { image -> image.fit(width, height) }
+    }
+
+    /**
+     * 가우시안 블러 필터를 적용합니다.
+     */
+    fun gaussianBlur(radius: Int) {
+        radius.requirePositiveNumber("radius")
+        filters { gaussianBlur(radius) }
+    }
+
+    /**
+     * 텍스트 워터마크를 적용합니다.
+     */
+    fun watermark(
+        text: String,
+        font: Font = DEFAULT_FONT,
+        type: WatermarkFilterType = WatermarkFilterType.COVER,
+        antiAlias: Boolean = true,
+        alpha: Double = DEFAULT_TEXT_WATERMARK_ALPHA,
+        color: Color = Color.WHITE,
+    ) {
+        filters { watermark(text, font, type, antiAlias, alpha, color) }
+    }
+
+    /**
+     * 로고 이미지를 워터마크로 합성합니다.
+     */
+    fun watermark(
+        logo: ImmutableImage,
+        position: Position = Position.BottomRight,
+        alpha: Float = DEFAULT_IMAGE_WATERMARK_ALPHA,
+    ) {
+        alpha.requireInRange(MIN_IMAGE_WATERMARK_ALPHA, MAX_IMAGE_WATERMARK_ALPHA, "alpha")
+        transforms += { image -> image.overlayLogo(logo, position, alpha) }
+    }
+
+    /**
+     * 살리언시 기반 스마트 크롭을 적용합니다.
+     */
+    fun smartCrop(
+        width: Int,
+        height: Int,
+        strategy: SaliencyStrategy = SaliencyStrategy.SobelEnergy,
+    ) {
+        width.requirePositiveNumber("width")
+        height.requirePositiveNumber("height")
+        transforms += { image -> image.smartCropTo(width, height, strategy) }
+    }
+
+    /**
+     * 필터 DSL 블록을 변환 단계로 추가합니다.
+     */
+    fun filters(block: ImageFilterChain.() -> Unit) {
+        transforms += { image -> image.applyFilters(block) }
+    }
+
+    /**
+     * JPEG writer를 선택합니다.
+     */
+    fun toJpeg(
+        quality: Int = DEFAULT_JPEG_QUALITY,
+        progressive: Boolean = false,
+    ) {
+        quality.requireInRange(JPEG_QUALITY_MIN, JPEG_QUALITY_MAX, "quality")
+        writer(SuspendJpegWriter.Default.withCompression(quality).withProgressive(progressive))
+    }
+
+    /**
+     * 결과 이미지 writer를 직접 선택합니다.
+     */
+    fun writer(writer: SuspendImageWriter) {
+        check(this.writer == null) { "writer는 한 번만 선택할 수 있습니다." }
+        this.writer = writer
+    }
+
+    internal fun apply(image: ImmutableImage): ImmutableImage =
+        transforms.fold(image) { current, transform -> transform(current) }
+
+    internal fun selectedWriter(): SuspendImageWriter? = writer
+
+    private fun ImmutableImage.overlayLogo(
+        logo: ImmutableImage,
+        position: Position,
+        alpha: Float,
+    ): ImmutableImage {
+        val target = copy()
+        val x = position.calculateX(target.width, target.height, logo.width, logo.height).coerceAtLeast(0)
+        val y = position.calculateY(target.width, target.height, logo.width, logo.height).coerceAtLeast(0)
+        val graphics = target.awt().createGraphics()
+        try {
+            graphics.composite = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, alpha)
+            graphics.drawImage(logo.awt(), x, y, null)
+        } finally {
+            graphics.dispose()
+        }
+
+        return target
+    }
+
+    private companion object {
+        private const val DEFAULT_JPEG_QUALITY = 80
+        private const val DEFAULT_TEXT_WATERMARK_ALPHA = 0.1
+        private const val DEFAULT_IMAGE_WATERMARK_ALPHA = 1.0f
+        private const val MIN_IMAGE_WATERMARK_ALPHA = 0.0f
+        private const val MAX_IMAGE_WATERMARK_ALPHA = 1.0f
+    }
+}

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/batch/PixelPermitLimiter.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/batch/PixelPermitLimiter.kt
@@ -1,0 +1,52 @@
+package io.bluetape4k.images.batch
+
+import io.bluetape4k.support.requirePositiveNumber
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal class PixelPermitLimiter(
+    private val maxPixels: Long,
+) {
+    private val mutex = Mutex()
+    private var availablePixels = maxPixels
+
+    init {
+        maxPixels.requirePositiveNumber("maxPixels")
+    }
+
+    suspend fun <T> withPermit(pixelCount: Long, block: suspend () -> T): T {
+        val permits = pixelCount.coerceIn(MIN_PIXEL_PERMIT, maxPixels)
+        acquire(permits)
+        try {
+            return block()
+        } finally {
+            release(permits)
+        }
+    }
+
+    private suspend fun acquire(permits: Long) {
+        while (true) {
+            val acquired = mutex.withLock {
+                if (availablePixels >= permits) {
+                    availablePixels -= permits
+                    true
+                } else {
+                    false
+                }
+            }
+
+            if (acquired) {
+                return
+            }
+
+            delay(PIXEL_PERMIT_RETRY_DELAY_MILLIS)
+        }
+    }
+
+    private suspend fun release(permits: Long) {
+        mutex.withLock {
+            availablePixels = (availablePixels + permits).coerceAtMost(maxPixels)
+        }
+    }
+}

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/thumbnail/ThumbnailModels.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/thumbnail/ThumbnailModels.kt
@@ -1,0 +1,132 @@
+package io.bluetape4k.images.thumbnail
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.images.batch.ImageBatchFailureStage
+import io.bluetape4k.images.coroutines.SuspendImageWriter
+import io.bluetape4k.images.coroutines.SuspendJpegWriter
+import io.bluetape4k.images.transforms.SaliencyStrategy
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
+import java.nio.file.Path
+
+/**
+ * 썸네일 출력 크기입니다.
+ */
+data class ThumbnailSize(
+    val width: Int,
+    val height: Int,
+    val suffix: String = "${width}x$height",
+) {
+    init {
+        width.requirePositiveNumber("width")
+        height.requirePositiveNumber("height")
+        suffix.requireNotBlank("suffix")
+    }
+}
+
+/**
+ * 썸네일 크롭 전략입니다.
+ */
+sealed interface ThumbnailCrop {
+    /**
+     * 지정 크기로 리사이즈합니다.
+     */
+    data object Fit: ThumbnailCrop
+
+    /**
+     * 살리언시 기반 스마트 크롭을 적용합니다.
+     */
+    data class Smart(
+        val strategy: SaliencyStrategy = SaliencyStrategy.SobelEnergy,
+    ): ThumbnailCrop
+}
+
+/**
+ * 썸네일 출력 포맷입니다.
+ */
+data class ThumbnailFormat(
+    val writer: SuspendImageWriter,
+    val extension: String,
+) {
+    val normalizedExtension: String = extension.trim().removePrefix(".").lowercase()
+
+    init {
+        normalizedExtension.requireNotBlank("extension")
+        require(!normalizedExtension.contains(PATH_SEPARATOR)) { "extension은 경로 구분자를 포함할 수 없습니다." }
+        require(!normalizedExtension.contains(WINDOWS_PATH_SEPARATOR)) { "extension은 경로 구분자를 포함할 수 없습니다." }
+    }
+
+    companion object {
+        private const val PATH_SEPARATOR = '/'
+        private const val WINDOWS_PATH_SEPARATOR = '\\'
+
+        /**
+         * JPEG 썸네일 포맷입니다.
+         */
+        val Jpeg: ThumbnailFormat = ThumbnailFormat(SuspendJpegWriter.Default, "jpg")
+    }
+}
+
+/**
+ * 썸네일 출력 이름 생성 함수입니다.
+ */
+fun interface ThumbnailOutputName {
+    /**
+     * 원본 경로와 썸네일 크기로 출력 파일 이름을 생성합니다.
+     */
+    fun create(source: Path, size: ThumbnailSize, format: ThumbnailFormat): String
+
+    companion object {
+        /**
+         * 원본 파일명에 크기 suffix를 붙이는 기본 생성기입니다.
+         */
+        val Default = ThumbnailOutputName { source, size, format ->
+            val fileName = source.fileName.toString()
+            val stem = fileName.substringBeforeLast('.', fileName)
+            "$stem-${size.suffix}.${format.normalizedExtension}"
+        }
+    }
+}
+
+/**
+ * 썸네일 처리 상태입니다.
+ */
+sealed interface ThumbnailStatus {
+    /**
+     * 썸네일 생성에 성공했습니다.
+     */
+    data class Success(
+        val bytes: Long,
+    ): ThumbnailStatus
+
+    /**
+     * 썸네일 생성에 실패했습니다.
+     */
+    data class Failure(
+        val stage: ImageBatchFailureStage,
+        val cause: Throwable,
+    ): ThumbnailStatus
+}
+
+/**
+ * 썸네일 처리 결과입니다.
+ */
+data class ThumbnailResult(
+    val source: Path,
+    val output: Path,
+    val size: ThumbnailSize,
+    val status: ThumbnailStatus,
+    val image: ImmutableImage? = null,
+) {
+    /**
+     * 실패 시점의 처리 단계입니다.
+     */
+    val stage: ImageBatchFailureStage?
+        get() = (status as? ThumbnailStatus.Failure)?.stage
+
+    /**
+     * 실패 원인입니다.
+     */
+    val cause: Throwable?
+        get() = (status as? ThumbnailStatus.Failure)?.cause
+}

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/thumbnail/ThumbnailPipeline.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/thumbnail/ThumbnailPipeline.kt
@@ -1,0 +1,304 @@
+package io.bluetape4k.images.thumbnail
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.coroutines.flow.extensions.mapParallel
+import io.bluetape4k.images.batch.ImageBatchFailureStage
+import io.bluetape4k.images.batch.ImageBatchException
+import io.bluetape4k.images.batch.ImageProcessingOptions
+import io.bluetape4k.images.batch.PixelPermitLimiter
+import io.bluetape4k.images.batch.probeImagePixelCount
+import io.bluetape4k.images.coroutines.SuspendImageWriter
+import io.bluetape4k.images.immutableImageOf
+import io.bluetape4k.images.transforms.smartCropTo
+import io.bluetape4k.logging.KotlinLogging
+import io.bluetape4k.logging.warn
+import io.bluetape4k.support.requirePositiveNumber
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.CoroutineContext
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 여러 크기의 썸네일을 생성하는 파이프라인입니다.
+ */
+class ThumbnailPipeline private constructor(
+    private val outputDirectory: Path,
+    private val sizes: List<ThumbnailSize>,
+    private val crop: ThumbnailCrop,
+    private val format: ThumbnailFormat,
+    private val outputName: ThumbnailOutputName,
+    private val ioDispatcher: CoroutineContext,
+    private val transformDispatcher: CoroutineContext,
+    private val parallelism: Int,
+    private val maxPixels: Long,
+    private val maxInFlightPixels: Long,
+    private val skipFailures: Boolean,
+    private val onFailure: suspend (ThumbnailResult) -> Unit,
+) {
+    /**
+     * 입력 이미지 스트림을 썸네일 결과 스트림으로 처리합니다.
+     */
+    fun process(sourceImages: Flow<Path>): Flow<ThumbnailResult> {
+        val limiter = PixelPermitLimiter(maxInFlightPixels)
+        val seenOutputs = ConcurrentHashMap.newKeySet<Path>()
+
+        return sourceImages
+            .flatMapConcat { source -> sizes.asFlow().map { size -> source to size } }
+            .mapParallel(parallelism) { (source, size) ->
+                processOne(source, size, limiter, seenOutputs)
+            }
+    }
+
+    private suspend fun processOne(
+        source: Path,
+        size: ThumbnailSize,
+        limiter: PixelPermitLimiter,
+        seenOutputs: MutableSet<Path>,
+    ): ThumbnailResult {
+        var output = outputDirectory
+        try {
+            val rawOutputName = runStage(source, output, ImageBatchFailureStage.VALIDATION) {
+                outputName.create(source, size, format)
+            }
+            output = runStage(source, output, ImageBatchFailureStage.VALIDATION) {
+                resolveOutputPath(rawOutputName)
+            }
+            runStage(source, output, ImageBatchFailureStage.VALIDATION) {
+                if (!seenOutputs.add(output)) {
+                    throw IllegalArgumentException("썸네일 출력 경로가 중복됩니다: $output")
+                }
+            }
+
+            val probedPixels = runStage(source, output, ImageBatchFailureStage.VALIDATION) {
+                withContext(ioDispatcher) { probeImagePixelCount(source) }
+            }
+            runStage(source, output, ImageBatchFailureStage.VALIDATION) {
+                probedPixels?.requireWithinMaxPixels(source)
+            }
+            val permitPixels = probedPixels ?: maxPixels
+
+            return limiter.withPermit(permitPixels) {
+                val image = runStage(source, output, ImageBatchFailureStage.LOAD) {
+                    withContext(ioDispatcher) { immutableImageOf(source) }
+                }
+                runStage(source, output, ImageBatchFailureStage.VALIDATION) {
+                    image.pixelCount().requireWithinMaxPixels(source)
+                }
+                val thumbnail = runStage(source, output, ImageBatchFailureStage.TRANSFORM) {
+                    withContext(transformDispatcher) { image.toThumbnail(size, crop) }
+                }
+                val bytes = runStage(source, output, ImageBatchFailureStage.WRITE) {
+                    writeThumbnail(thumbnail, output)
+                }
+                ThumbnailResult(source, output, size, ThumbnailStatus.Success(bytes), thumbnail)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: ImageBatchException) {
+            return handleFailure(e, source, output, size)
+        } catch (e: Throwable) {
+            return handleFailure(
+                ImageBatchException(
+                    source = source,
+                    stage = ImageBatchFailureStage.TRANSFORM,
+                    output = output,
+                    message = "썸네일 생성에 실패했습니다. source=$source, output=$output",
+                    cause = e,
+                ),
+                source,
+                output,
+                size,
+            )
+        }
+    }
+
+    private suspend fun handleFailure(
+        exception: ImageBatchException,
+        source: Path,
+        output: Path,
+        size: ThumbnailSize,
+    ): ThumbnailResult {
+        val result = ThumbnailResult(
+            source = source,
+            output = output,
+            size = size,
+            status = ThumbnailStatus.Failure(exception.stage, exception.cause ?: exception),
+        )
+
+        if (!skipFailures) {
+            throw exception
+        }
+
+        log.warn(exception) { "썸네일 생성을 건너뜁니다. source=$source, output=$output, stage=${exception.stage}" }
+        onFailure(result)
+        return result
+    }
+
+    private suspend inline fun <T> runStage(
+        source: Path,
+        output: Path,
+        stage: ImageBatchFailureStage,
+        crossinline block: suspend () -> T,
+    ): T =
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: ImageBatchException) {
+            throw e
+        } catch (e: Throwable) {
+            throw ImageBatchException(
+                source = source,
+                stage = stage,
+                output = output,
+                message = "썸네일 처리 단계가 실패했습니다. source=$source, output=$output, stage=$stage",
+                cause = e,
+            )
+        }
+
+    private suspend fun writeThumbnail(image: ImmutableImage, output: Path): Long =
+        withContext(ioDispatcher) {
+            output.parent?.let(Files::createDirectories)
+            Files.newOutputStream(output).use { stream ->
+                format.writer.write(image, stream)
+            }
+            Files.size(output)
+        }
+
+    private fun ImmutableImage.toThumbnail(size: ThumbnailSize, crop: ThumbnailCrop): ImmutableImage =
+        when (crop) {
+            ThumbnailCrop.Fit -> scaleTo(size.width, size.height)
+            is ThumbnailCrop.Smart -> smartCropTo(size.width, size.height, crop.strategy)
+        }
+
+    private fun Long.requireWithinMaxPixels(source: Path) {
+        if (this > maxPixels) {
+            throw IllegalArgumentException("이미지 픽셀 수가 허용 한도를 초과했습니다. source=$source, pixels=$this, maxPixels=$maxPixels")
+        }
+    }
+
+    private fun ImmutableImage.pixelCount(): Long =
+        width.toLong() * height.toLong()
+
+    private fun resolveOutputPath(outputName: String): Path {
+        require(outputName.isNotBlank()) { "outputName은 blank일 수 없습니다." }
+        val base = outputDirectory.toAbsolutePath().normalize()
+        val output = base.resolve(outputName).normalize()
+        require(output.startsWith(base)) {
+            "썸네일 출력 경로가 outputDirectory를 벗어날 수 없습니다. outputDirectory=$outputDirectory, outputName=$outputName"
+        }
+        return output
+    }
+
+    /**
+     * [ThumbnailPipeline] 빌더입니다.
+     */
+    class Builder {
+        private var outputDirectory: Path? = null
+        private val sizes = mutableListOf<ThumbnailSize>()
+        private var crop: ThumbnailCrop = ThumbnailCrop.Fit
+        private var format: ThumbnailFormat = ThumbnailFormat.Jpeg
+        private var outputName: ThumbnailOutputName = ThumbnailOutputName.Default
+        private var options: ImageProcessingOptions = ImageProcessingOptions()
+        private var onFailure: suspend (ThumbnailResult) -> Unit = {}
+
+        /**
+         * 출력 디렉터리를 지정합니다.
+         */
+        fun outputDirectory(path: Path): Builder = apply {
+            outputDirectory = path
+        }
+
+        /**
+         * 썸네일 크기를 추가합니다.
+         */
+        fun size(width: Int, height: Int, suffix: String = "${width}x$height"): Builder = apply {
+            sizes += ThumbnailSize(width, height, suffix)
+        }
+
+        /**
+         * 썸네일 크롭 전략을 지정합니다.
+         */
+        fun crop(crop: ThumbnailCrop): Builder = apply {
+            this.crop = crop
+        }
+
+        /**
+         * 출력 포맷을 지정합니다.
+         */
+        fun format(format: ThumbnailFormat): Builder = apply {
+            this.format = format
+        }
+
+        /**
+         * writer를 직접 지정합니다.
+         */
+        fun writer(writer: SuspendImageWriter): Builder = apply {
+            this.format = format.copy(writer = writer)
+        }
+
+        /**
+         * 출력 파일명 생성기를 지정합니다.
+         */
+        fun outputName(outputName: ThumbnailOutputName): Builder = apply {
+            this.outputName = outputName
+        }
+
+        /**
+         * 배치 처리 옵션을 지정합니다.
+         */
+        fun options(options: ImageProcessingOptions): Builder = apply {
+            this.options = options
+        }
+
+        /**
+         * 실패 관측 콜백을 지정합니다.
+         */
+        fun onFailure(onFailure: suspend (ThumbnailResult) -> Unit): Builder = apply {
+            this.onFailure = onFailure
+        }
+
+        /**
+         * 파이프라인을 생성합니다.
+         */
+        fun build(): ThumbnailPipeline {
+            val directory = requireNotNull(outputDirectory) { "outputDirectory를 지정해야 합니다." }
+            val thumbnailSizes = sizes.ifEmpty { listOf(DEFAULT_THUMBNAIL_SIZE) }
+            options.parallelism.requirePositiveNumber("parallelism")
+
+            return ThumbnailPipeline(
+                outputDirectory = directory,
+                sizes = thumbnailSizes,
+                crop = crop,
+                format = format,
+                outputName = outputName,
+                ioDispatcher = options.ioDispatcher,
+                transformDispatcher = options.transformDispatcher,
+                parallelism = options.parallelism,
+                maxPixels = options.maxPixels,
+                maxInFlightPixels = options.maxInFlightPixels,
+                skipFailures = options.skipFailures,
+                onFailure = onFailure,
+            )
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_THUMBNAIL_WIDTH = 320
+        private const val DEFAULT_THUMBNAIL_HEIGHT = 240
+        private val DEFAULT_THUMBNAIL_SIZE = ThumbnailSize(DEFAULT_THUMBNAIL_WIDTH, DEFAULT_THUMBNAIL_HEIGHT)
+
+        /**
+         * [ThumbnailPipeline] 빌더를 생성합니다.
+         */
+        fun builder(): Builder = Builder()
+    }
+}

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/tiles/TileModels.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/tiles/TileModels.kt
@@ -1,0 +1,28 @@
+package io.bluetape4k.images.tiles
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.support.requirePositiveNumber
+
+/**
+ * 타일 크기입니다.
+ */
+data class TileSize(
+    val width: Int,
+    val height: Int,
+) {
+    init {
+        width.requirePositiveNumber("width")
+        height.requirePositiveNumber("height")
+    }
+}
+
+/**
+ * 분할된 이미지 타일입니다.
+ */
+data class ImageTile(
+    val x: Int,
+    val y: Int,
+    val width: Int,
+    val height: Int,
+    val image: ImmutableImage,
+)

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/tiles/TileProcessor.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/tiles/TileProcessor.kt
@@ -1,0 +1,92 @@
+package io.bluetape4k.images.tiles
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.bluetape4k.coroutines.flow.extensions.mapParallel
+import io.bluetape4k.images.batch.DEFAULT_MAX_TILE_COUNT
+import io.bluetape4k.images.batch.defaultImageBatchParallelism
+import io.bluetape4k.support.requirePositiveNumber
+import kotlinx.coroutines.flow.Flow
+import java.awt.image.BufferedImage
+
+/**
+ * 큰 이미지를 타일로 나누고 다시 병합하는 처리기입니다.
+ */
+class TileProcessor(
+    private val maxTileCount: Int = DEFAULT_MAX_TILE_COUNT,
+    private val parallelism: Int = defaultImageBatchParallelism(),
+) {
+    init {
+        maxTileCount.requirePositiveNumber("maxTileCount")
+        parallelism.requirePositiveNumber("parallelism")
+    }
+
+    /**
+     * 이미지를 지정 타일 크기로 분할합니다.
+     */
+    fun split(image: ImmutableImage, tileSize: TileSize): List<ImageTile> {
+        val tilesX = image.width.ceilDiv(tileSize.width)
+        val tilesY = image.height.ceilDiv(tileSize.height)
+        val tileCount = tilesX * tilesY
+        require(tileCount <= maxTileCount) {
+            "타일 수가 허용 한도를 초과했습니다. tileCount=$tileCount, maxTileCount=$maxTileCount"
+        }
+
+        return buildList(tileCount) {
+            for (y in 0 until image.height step tileSize.height) {
+                for (x in 0 until image.width step tileSize.width) {
+                    val width = minOf(tileSize.width, image.width - x)
+                    val height = minOf(tileSize.height, image.height - y)
+                    add(ImageTile(x, y, width, height, image.subimage(x, y, width, height)))
+                }
+            }
+        }
+    }
+
+    /**
+     * 타일 목록을 하나의 이미지로 병합합니다.
+     */
+    fun merge(
+        tiles: Collection<ImageTile>,
+        width: Int,
+        height: Int,
+    ): ImmutableImage {
+        width.requirePositiveNumber("width")
+        height.requirePositiveNumber("height")
+        require(tiles.isNotEmpty()) { "tiles는 비어 있을 수 없습니다." }
+        require(tiles.size <= maxTileCount) {
+            "타일 수가 허용 한도를 초과했습니다. tileCount=${tiles.size}, maxTileCount=$maxTileCount"
+        }
+
+        val output = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+        val graphics = output.createGraphics()
+        try {
+            tiles.sortedWith(compareBy<ImageTile> { it.y }.thenBy { it.x }).forEach { tile ->
+                require(tile.x >= 0 && tile.y >= 0) { "타일 좌표는 0 이상이어야 합니다. tile=$tile" }
+                require(tile.x + tile.width <= width && tile.y + tile.height <= height) {
+                    "타일이 출력 이미지 영역을 벗어났습니다. tile=$tile, width=$width, height=$height"
+                }
+                graphics.drawImage(tile.image.awt(), tile.x, tile.y, null)
+            }
+        } finally {
+            graphics.dispose()
+        }
+
+        return ImmutableImage.wrapAwt(output)
+    }
+
+    /**
+     * 타일 스트림을 병렬 변환합니다.
+     */
+    fun <R> processTiles(
+        tiles: Flow<ImageTile>,
+        transform: suspend (ImageTile) -> R,
+    ): Flow<R> =
+        tiles.mapParallel(parallelism) { tile -> transform(tile) }
+
+    private fun Int.ceilDiv(divisor: Int): Int =
+        (this + divisor - CEIL_DIV_OFFSET) / divisor
+
+    private companion object {
+        private const val CEIL_DIV_OFFSET = 1
+    }
+}

--- a/utils/images/src/test/kotlin/io/bluetape4k/images/batch/ImageBatchFlowTest.kt
+++ b/utils/images/src/test/kotlin/io/bluetape4k/images/batch/ImageBatchFlowTest.kt
@@ -1,0 +1,215 @@
+package io.bluetape4k.images.batch
+
+import io.bluetape4k.images.AbstractImageTest
+import io.bluetape4k.junit5.tempfolder.TempFolder
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.info
+import io.bluetape4k.utils.Resourcex
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.Test
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.nio.file.Files
+import javax.imageio.ImageIO
+import kotlin.system.measureTimeMillis
+
+class ImageBatchFlowTest: AbstractImageTest() {
+
+    companion object: KLoggingChannel() {
+        private const val SOURCE_IMAGE_NAME = "source.jpg"
+        private const val OUTPUT_IMAGE_NAME = "out.jpg"
+        private const val ESCAPED_OUTPUT_NAME = "escape.jpg"
+        private const val PATH_TRAVERSAL_OUTPUT_NAME = "../$ESCAPED_OUTPUT_NAME"
+        private const val BROKEN_IMAGE_NAME = "broken.txt"
+        private const val BROKEN_IMAGE_TEXT = "not an image"
+        private const val TEST_PARALLELISM = 1
+        private const val TEST_THUMB_WIDTH = 96
+        private const val TEST_THUMB_HEIGHT = 64
+        private const val TEST_JPEG_QUALITY = 85
+        private const val TEST_IMAGE_FORMAT = "jpg"
+        private const val PERFORMANCE_SOURCE_WIDTH = 48
+        private const val PERFORMANCE_SOURCE_HEIGHT = 48
+        private const val PERFORMANCE_SAMPLE_WIDTH = 32
+        private const val PERFORMANCE_SAMPLE_HEIGHT = 32
+    }
+
+    @Test
+    fun `processImages applies transform dispatcher path and writes with selected writer`(
+        tempFolder: TempFolder,
+    ) = runTest {
+        val source = tempFolder.copyResource(CAFE_JPG, SOURCE_IMAGE_NAME)
+        val output = tempFolder.root.toPath().resolve(OUTPUT_IMAGE_NAME)
+
+        val result = flowOf(source)
+            .processImages(ImageProcessingOptions(parallelism = TEST_PARALLELISM)) {
+                resize(TEST_THUMB_WIDTH, TEST_THUMB_HEIGHT)
+                toJpeg(quality = TEST_JPEG_QUALITY)
+            }
+            .single()
+
+        result shouldBeInstanceOf ImageBatchResult.WritableImage::class
+        val writable = result as ImageBatchResult.WritableImage
+        writable.image.width shouldBeEqualTo TEST_THUMB_WIDTH
+        writable.image.height shouldBeEqualTo TEST_THUMB_HEIGHT
+
+        val written = writable.writeTo(output, ImageProcessingOptions().ioDispatcher)
+
+        written shouldBeGreaterThan 0L
+        ImageIO.read(output.toFile()).width shouldBeEqualTo TEST_THUMB_WIDTH
+    }
+
+    @Test
+    fun `processImages emits failure and invokes callback when skipFailures is true`(
+        tempFolder: TempFolder,
+    ) = runTest {
+        val source = tempFolder.createFile(BROKEN_IMAGE_NAME).toPath()
+        Files.writeString(source, BROKEN_IMAGE_TEXT)
+        val failures = mutableListOf<ImageBatchResult.Failure>()
+
+        val results = flowOf(source)
+            .processImages(
+                ImageProcessingOptions(
+                    parallelism = TEST_PARALLELISM,
+                    skipFailures = true,
+                    onFailure = { failures += it },
+                )
+            ) {
+                resize(TEST_THUMB_WIDTH, TEST_THUMB_HEIGHT)
+            }
+            .toList()
+
+        results.single() shouldBeInstanceOf ImageBatchResult.Failure::class
+        failures.single().stage shouldBeEqualTo ImageBatchFailureStage.LOAD
+    }
+
+    @Test
+    fun `writeImagesTo emits write failure callback when skipFailures is true`(
+        tempFolder: TempFolder,
+    ) = runTest {
+        val source = tempFolder.copyResource(CAFE_JPG, SOURCE_IMAGE_NAME)
+        val blockedOutput = tempFolder.createDirectory(OUTPUT_IMAGE_NAME).toPath()
+        val failures = mutableListOf<ImageBatchResult.Failure>()
+        val options = ImageProcessingOptions(
+            parallelism = TEST_PARALLELISM,
+            skipFailures = true,
+            onFailure = { failures += it },
+        )
+
+        val outputs = flowOf(source)
+            .processImages(options) {
+                resize(TEST_THUMB_WIDTH, TEST_THUMB_HEIGHT)
+                toJpeg(quality = TEST_JPEG_QUALITY)
+            }
+            .writeImagesTo(
+                outputDirectory = tempFolder.root.toPath(),
+                options = options,
+                outputName = { blockedOutput.fileName.toString() },
+            )
+            .toList()
+
+        outputs.size shouldBeEqualTo 0
+        failures.single().stage shouldBeEqualTo ImageBatchFailureStage.WRITE
+        failures.single().output shouldBeEqualTo blockedOutput
+    }
+
+    @Test
+    fun `writeImagesTo rejects output path traversal`(
+        tempFolder: TempFolder,
+    ) = runTest {
+        val source = tempFolder.copyResource(CAFE_JPG, SOURCE_IMAGE_NAME)
+        val failures = mutableListOf<ImageBatchResult.Failure>()
+        val options = ImageProcessingOptions(
+            parallelism = TEST_PARALLELISM,
+            skipFailures = true,
+            onFailure = { failures += it },
+        )
+
+        val outputs = flowOf(source)
+            .processImages(options) {
+                resize(TEST_THUMB_WIDTH, TEST_THUMB_HEIGHT)
+                toJpeg(quality = TEST_JPEG_QUALITY)
+            }
+            .writeImagesTo(
+                outputDirectory = tempFolder.root.toPath(),
+                options = options,
+                outputName = { PATH_TRAVERSAL_OUTPUT_NAME },
+            )
+            .toList()
+
+        outputs.size shouldBeEqualTo 0
+        failures.single().stage shouldBeEqualTo ImageBatchFailureStage.WRITE
+        Files.exists(tempFolder.root.toPath().parent.resolve(ESCAPED_OUTPUT_NAME)) shouldBeEqualTo false
+    }
+
+    @Test
+    fun `batch defaults are named constants`() {
+        (DEFAULT_MAX_PIXELS > 0L).shouldBeTrue()
+        (DEFAULT_MAX_IN_FLIGHT_PIXELS >= DEFAULT_MAX_PIXELS).shouldBeTrue()
+        (DEFAULT_MAX_TILE_COUNT > 0).shouldBeTrue()
+        JPEG_QUALITY_MIN shouldBeEqualTo 0
+        JPEG_QUALITY_MAX shouldBeEqualTo 100
+        PERFORMANCE_SAMPLE_IMAGE_COUNT shouldBeEqualTo 100
+        defaultImageBatchParallelism() shouldBeGreaterThan 0
+    }
+
+    @Test
+    fun `largeJobs option raises pixel limits explicitly`() {
+        val options = ImageProcessingOptions.largeJobs(parallelism = TEST_PARALLELISM)
+
+        options.maxPixels shouldBeEqualTo LARGE_JOB_MAX_PIXELS
+        options.maxInFlightPixels shouldBeEqualTo LARGE_JOB_MAX_IN_FLIGHT_PIXELS
+        (options.maxPixels > DEFAULT_MAX_PIXELS).shouldBeTrue()
+        (options.maxInFlightPixels > DEFAULT_MAX_IN_FLIGHT_PIXELS).shouldBeTrue()
+    }
+
+    @Test
+    fun `hundred image batch performance sample is logged without threshold gating`(
+        tempFolder: TempFolder,
+    ) = runTest {
+        val source = tempFolder.createTinyImage(SOURCE_IMAGE_NAME)
+        val sources = List(PERFORMANCE_SAMPLE_IMAGE_COUNT) { source }
+        val options = ImageProcessingOptions(parallelism = TEST_PARALLELISM)
+        lateinit var results: List<ImageBatchResult>
+
+        val elapsedMillis = measureTimeMillis {
+            results = sources.asFlow()
+                .processImages(options) {
+                    resize(PERFORMANCE_SAMPLE_WIDTH, PERFORMANCE_SAMPLE_HEIGHT)
+                    toJpeg()
+                }
+                .toList()
+        }
+
+        results.size shouldBeEqualTo PERFORMANCE_SAMPLE_IMAGE_COUNT
+        log.info { "$PERFORMANCE_SAMPLE_IMAGE_COUNT image batch performance sample completed in ${elapsedMillis}ms" }
+    }
+
+    private fun TempFolder.copyResource(resourcePath: String, fileName: String) =
+        createFile(fileName).toPath().also { target ->
+            Resourcex.getInputStream(resourcePath)!!.use { input ->
+                Files.copy(input, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+            }
+        }
+
+    private fun TempFolder.createTinyImage(fileName: String) =
+        createFile(fileName).toPath().also { target ->
+            val image = BufferedImage(PERFORMANCE_SOURCE_WIDTH, PERFORMANCE_SOURCE_HEIGHT, BufferedImage.TYPE_INT_RGB)
+            val graphics = image.createGraphics()
+            try {
+                graphics.color = Color.CYAN
+                graphics.fillRect(0, 0, image.width, image.height)
+            } finally {
+                graphics.dispose()
+            }
+            ImageIO.write(image, TEST_IMAGE_FORMAT, target.toFile())
+        }
+
+}

--- a/utils/images/src/test/kotlin/io/bluetape4k/images/thumbnail/ThumbnailPipelineTest.kt
+++ b/utils/images/src/test/kotlin/io/bluetape4k/images/thumbnail/ThumbnailPipelineTest.kt
@@ -1,0 +1,94 @@
+package io.bluetape4k.images.thumbnail
+
+import io.bluetape4k.images.AbstractImageTest
+import io.bluetape4k.images.batch.ImageBatchFailureStage
+import io.bluetape4k.images.batch.ImageProcessingOptions
+import io.bluetape4k.images.coroutines.SuspendJpegWriter
+import io.bluetape4k.junit5.tempfolder.TempFolder
+import io.bluetape4k.utils.Resourcex
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldThrow
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import javax.imageio.ImageIO
+
+class ThumbnailPipelineTest: AbstractImageTest() {
+
+    @Test
+    fun `thumbnail pipeline writes configured size`(
+        tempFolder: TempFolder,
+    ) = runTest {
+        val source = tempFolder.copyResource(LANDSCAPE_JPG, SOURCE_IMAGE_NAME)
+        val outputDir = tempFolder.createDirectory(OUTPUT_DIRECTORY_NAME).toPath()
+        val pipeline = ThumbnailPipeline.builder()
+            .outputDirectory(outputDir)
+            .size(TEST_THUMB_WIDTH, TEST_THUMB_HEIGHT, TEST_THUMB_SUFFIX)
+            .options(ImageProcessingOptions(parallelism = TEST_PARALLELISM))
+            .build()
+
+        val result = pipeline.process(flowOf(source)).single()
+
+        result.status shouldBeInstanceOf ThumbnailStatus.Success::class
+        Files.exists(result.output).shouldBeTrue()
+        ImageIO.read(result.output.toFile()).width shouldBeEqualTo TEST_THUMB_WIDTH
+        ImageIO.read(result.output.toFile()).height shouldBeEqualTo TEST_THUMB_HEIGHT
+    }
+
+    @Test
+    fun `thumbnail pipeline rejects output path traversal`(
+        tempFolder: TempFolder,
+    ) = runTest {
+        val source = tempFolder.copyResource(LANDSCAPE_JPG, SOURCE_IMAGE_NAME)
+        val outputDir = tempFolder.createDirectory(OUTPUT_DIRECTORY_NAME).toPath()
+        val failures = mutableListOf<ThumbnailResult>()
+        val pipeline = ThumbnailPipeline.builder()
+            .outputDirectory(outputDir)
+            .size(TEST_THUMB_WIDTH, TEST_THUMB_HEIGHT, TEST_THUMB_SUFFIX)
+            .outputName { _, _, _ -> PATH_TRAVERSAL_OUTPUT_NAME }
+            .options(ImageProcessingOptions(parallelism = TEST_PARALLELISM, skipFailures = true))
+            .onFailure { failures += it }
+            .build()
+
+        val results = pipeline.process(flowOf(source)).toList()
+
+        results.single().status shouldBeInstanceOf ThumbnailStatus.Failure::class
+        failures.single().stage shouldBeEqualTo ImageBatchFailureStage.VALIDATION
+        Files.exists(outputDir.parent.resolve(ESCAPED_OUTPUT_NAME)) shouldBeEqualTo false
+    }
+
+    @Test
+    fun `thumbnail format rejects blank and path separator extension`() {
+        val blankExtension = { ThumbnailFormat(SuspendJpegWriter.Default, BLANK_EXTENSION) }
+        val pathExtension = { ThumbnailFormat(SuspendJpegWriter.Default, PATH_EXTENSION) }
+
+        blankExtension shouldThrow IllegalArgumentException::class
+        pathExtension shouldThrow IllegalArgumentException::class
+    }
+
+    private fun TempFolder.copyResource(resourcePath: String, fileName: String) =
+        createFile(fileName).toPath().also { target ->
+            Resourcex.getInputStream(resourcePath)!!.use { input ->
+                Files.copy(input, target, StandardCopyOption.REPLACE_EXISTING)
+            }
+        }
+
+    private companion object {
+        private const val SOURCE_IMAGE_NAME = "source.jpg"
+        private const val OUTPUT_DIRECTORY_NAME = "thumbs"
+        private const val ESCAPED_OUTPUT_NAME = "escape.jpg"
+        private const val PATH_TRAVERSAL_OUTPUT_NAME = "../$ESCAPED_OUTPUT_NAME"
+        private const val BLANK_EXTENSION = " "
+        private const val PATH_EXTENSION = "../jpg"
+        private const val TEST_PARALLELISM = 1
+        private const val TEST_THUMB_WIDTH = 80
+        private const val TEST_THUMB_HEIGHT = 60
+        private const val TEST_THUMB_SUFFIX = "small"
+    }
+}

--- a/utils/images/src/test/kotlin/io/bluetape4k/images/tiles/TileProcessorTest.kt
+++ b/utils/images/src/test/kotlin/io/bluetape4k/images/tiles/TileProcessorTest.kt
@@ -1,0 +1,31 @@
+package io.bluetape4k.images.tiles
+
+import io.bluetape4k.images.AbstractImageTest
+import io.bluetape4k.images.immutableImageOf
+import io.bluetape4k.utils.Resourcex
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.junit.jupiter.api.Test
+
+class TileProcessorTest: AbstractImageTest() {
+
+    @Test
+    fun `split and merge preserve image size`() {
+        val image = immutableImageOf(Resourcex.getInputStream(CAFE_JPG)!!)
+        val processor = TileProcessor(maxTileCount = TEST_MAX_TILE_COUNT, parallelism = TEST_PARALLELISM)
+
+        val tiles = processor.split(image, TileSize(TEST_TILE_WIDTH, TEST_TILE_HEIGHT))
+        val merged = processor.merge(tiles, image.width, image.height)
+
+        tiles.size shouldBeGreaterThan 1
+        merged.width shouldBeEqualTo image.width
+        merged.height shouldBeEqualTo image.height
+    }
+
+    private companion object {
+        private const val TEST_PARALLELISM = 1
+        private const val TEST_MAX_TILE_COUNT = 4096
+        private const val TEST_TILE_WIDTH = 64
+        private const val TEST_TILE_HEIGHT = 64
+    }
+}


### PR DESCRIPTION
## Summary

Closes #135

- PR 제목: feat: images batch flow 처리 경로 추가

- Flow 기반 images batch 처리 DSL과 dispatcher-aware read/transform/write 경로를 추가했습니다.
- ThumbnailPipeline과 TileProcessor를 추가했습니다.
- magic number를 named const로 정리하고, 큰 작업용 ImageProcessingOptions.largeJobs()를 추가했습니다.
- Security/Ops/Kotlin/API 리뷰 후 output path traversal 방어, WRITE stage failure 관측, ThumbnailFormat(writer, extension) 계약 정합성, fit() 종횡비 보존을 보강했습니다.
- README/README.ko.md에 batch, thumbnail, tile, largeJobs 사용 예시를 추가했습니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Step 6-R Review Gate

| Reviewer | 발견 | 조치 |
|---------|------|------|
| Tier 1 Security | HIGH 1건: outputName 기반 path traversal 가능 | ✅ batch/thumbnail output path를 outputDirectory 내부로 normalize+검증, 회귀 테스트 추가 |
| Tier 2 Ops/SRE | HIGH 1건: writeImagesTo 저장 실패가 skipFailures/onFailure로 관측되지 않음 | ✅ WRITE stage failure callback 처리 및 테스트 추가 |
| Tier 3 Structural impact | MEDIUM 1건: ThumbnailFormat이 spec의 writer+extension 계약과 불일치 | ✅ ThumbnailFormat(writer, extension)으로 수정, README/spec 동기화 |
| Tier 4 Kotlin/API quality | MEDIUM 1건: fit()이 scaleTo()로 종횡비를 깨는 구현 | ✅ Scrimage fit() 위임으로 수정 |
| Tier 5 Test/type/silent failure | MEDIUM 2건: path traversal/write failure 회귀 부재, format validation 부재 | ✅ 회귀 테스트 추가 |
| Final | CRITICAL 0, HIGH 0 | ✅ 수정 후 테스트 통과 |

### 기존 섹션: Related

- Issue #135

## Validation

- ./gradlew :bluetape4k-images:test → 349 passing, 8 pending
- ./gradlew :bluetape4k-images:detekt → task 없음(프로젝트에 detekt task 미정의)

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #135, milestone 없음, assignee `debop`
- PR: #234, head `335dcb308f08a83555564b531f3463c911321902`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/issue-135-images-batch-flow`
- Labels: `enhancement`
- State: `MERGED`, merge commit `34f31f57c993838198827c36cc98fab055ca6242`
- CI: - ./gradlew :bluetape4k-images:test → 349 passing, 8 pending / - ./gradlew :bluetape4k-images:detekt → task 없음(프로젝트에 detekt task 미정의)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #234 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `34f31f57c993838198827c36cc98fab055ca6242`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
