### PR TITLE
fix: utils/images 모듈 코드 리뷰 반영 — 코루틴 안티패턴 수정 및 KDoc/README 강화

### DIFF
--- a/utils/images/README.ko.md
+++ b/utils/images/README.ko.md
@@ -313,37 +313,42 @@ val jpegBytes = image.suspendBytes(SuspendJpegWriter.Default)
 val webpBytes = image.suspendBytes(SuspendWebpWriter.Default)
 ```
 
-### 배치 이미지 Flow (Issue #135)
+### 배치 이미지 처리 (Issue #135)
+
+`ImageBatchFlow`는 대량 이미지에 동일한 변환을 적용하는 코루틴 Flow 파이프라인입니다.
+동시성 제어와 픽셀 단위 메모리 한도를 통해 안전하게 대규모 배치 작업을 처리합니다.
 
 ```kotlin
 import io.bluetape4k.images.batch.*
 import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toList
 import java.nio.file.Path
 
+// 배치 옵션 설정
 val options = ImageProcessingOptions(
     parallelism = defaultImageBatchParallelism(),
     maxPixels = DEFAULT_MAX_PIXELS,
     maxInFlightPixels = DEFAULT_MAX_IN_FLIGHT_PIXELS,
-    skipFailures = true,
-    onFailure = { failure ->
-        // 전체 배치를 중단하지 않고 source/stage/cause를 관측
-    }
+    skipFailures = true,                        // 실패 항목 건너뜀, 전체 중단 없음
 )
 
-listOf(Path.of("a.jpg"), Path.of("b.jpg"))
+// 처리 후 결과 경로 수집
+val writtenPaths: List<Path> = listOf(Path.of("a.jpg"), Path.of("b.jpg"))
     .asFlow()
     .processImages(options) {
-        resize(width = 320, height = 240)
-        watermark("© bluetape4k")
-        toJpeg(quality = 85)
+        resize(width = 1280, height = 720)      // 먼저 크기 조절
+        watermark("© bluetape4k")               // 워터마크 오버레이
+        toJpeg(quality = 85)                    // JPEG로 인코딩
     }
-    .writeImagesTo(Path.of("out"), options)
+    .writeImagesTo(Path.of("output"), options)  // 출력 디렉터리에 저장
+    .toList()
 ```
 
-`ImageProcessingDsl`의 변환은 `transformDispatcher`에서 실행되고, 저장 편의 함수는 호출자가 넘긴
-`ioDispatcher`에서 writer를 직접 호출합니다. 배치 기본값은 `DEFAULT_MAX_PIXELS`,
+`ImageProcessingDsl`의 변환은 `transformDispatcher`에서 실행되고, 저장은 호출자가 넘긴
+`ioDispatcher`에서 실행됩니다. 배치 기본값은 `DEFAULT_MAX_PIXELS`,
 `DEFAULT_MAX_IN_FLIGHT_PIXELS`, `JPEG_QUALITY_MIN`, `JPEG_QUALITY_MAX`,
 `PERFORMANCE_SAMPLE_IMAGE_COUNT`처럼 이름 있는 상수로 제공합니다.
+
 더 큰 이미지 세트는 `ImageProcessingOptions.largeJobs()`를 사용하거나
 `maxPixels` / `maxInFlightPixels`를 명시적으로 높여 처리할 수 있습니다.
 
@@ -357,32 +362,83 @@ val largeOptions = ImageProcessingOptions.largeJobs(
 
 ### 썸네일 파이프라인
 
+`ThumbnailPipeline`은 소스 이미지마다 여러 크기의 썸네일을 한 번의 패스로 생성합니다.
+`ThumbnailPipeline.builder()`로 크기·크롭 전략·포맷·오류 처리를 설정하고,
+`process(Flow<Path>)`를 호출하면 결과가 스트리밍됩니다.
+
 ```kotlin
 import io.bluetape4k.images.batch.ImageProcessingOptions
 import io.bluetape4k.images.coroutines.SuspendJpegWriter
 import io.bluetape4k.images.thumbnail.*
 import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.collect
 import java.nio.file.Path
 
+// 이미지당 세 가지 크기의 썸네일을 생성하는 파이프라인 구성
 val pipeline = ThumbnailPipeline.builder()
-    .outputDirectory(Path.of("thumbs"))
-    .size(width = 320, height = 240, suffix = "small")
+    .outputDirectory(Path.of("output/thumbs"))
+    .size(width = 1280, height = 720, suffix = "hd")
+    .size(width = 640,  height = 360, suffix = "md")
+    .size(width = 320,  height = 180, suffix = "sm")
     .format(ThumbnailFormat(SuspendJpegWriter.Default.withCompression(85), "jpg"))
-    .crop(ThumbnailCrop.Smart())
-    .options(ImageProcessingOptions(skipFailures = true))
-    .onFailure { failure ->
-        // failure.stage로 validation/load/transform/write 단계를 구분
+    .crop(ThumbnailCrop.Smart())                // 중요 영역 자동 크롭
+    .options(ImageProcessingOptions(parallelism = 4, skipFailures = true))
+    .onFailure { result ->
+        // result.status에 실패 단계와 원인 포함
+        println("썸네일 실패: ${result.source} → ${result.status}")
     }
     .build()
 
-pipeline.process(listOf(Path.of("photo.jpg")).asFlow())
+// 소스 이미지 스트림을 처리하고 결과 수집
+pipeline
+    .process(listOf(Path.of("photos/photo.jpg"), Path.of("photos/banner.png")).asFlow())
+    .collect { result ->
+        when (val status = result.status) {
+            is ThumbnailStatus.Success ->
+                println("OK  ${result.output.fileName} — ${status.bytes} bytes")
+            is ThumbnailStatus.Failure ->
+                println("ERR ${result.source.fileName} at ${status.stage}")
+        }
+    }
 ```
+
+`ThumbnailCrop` 종류:
+- `ThumbnailCrop.Fit` — 비율을 유지하면서 지정 크기에 맞게 축소 (기본값)
+- `ThumbnailCrop.Smart()` — Sobel 엣지 기반 saliency 크롭 후 정확한 크기로 리사이즈
 
 ### 타일 처리
 
-```kotlin
-import io.bluetape4k.images.tiles.*
+`TileProcessor`는 큰 이미지를 격자 타일로 분할하고, 각 타일을 병렬로 변환한 다음,
+하나의 출력 이미지로 재조립합니다. 이미지 전체를 한 번에 처리하기 어려울 때 유용합니다.
 
+```kotlin
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.filter.GrayscaleFilter
+import io.bluetape4k.images.tiles.*
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toList
+
+val image: ImmutableImage = ImmutableImage.loader().fromFile(File("large.jpg"))
+val processor = TileProcessor(maxTileCount = 256, parallelism = 4)
+
+// 1. 512×512 타일로 분할
+val tiles: List<ImageTile> = processor.split(image, TileSize(width = 512, height = 512))
+
+// 2. 각 타일에 병렬로 변환 적용
+val processedTiles: List<ImageTile> = processor
+    .processTiles(tiles.asFlow()) { tile ->
+        tile.copy(image = tile.image.filter(GrayscaleFilter()))
+    }
+    .toList()
+
+// 3. 원래 크기로 재조립
+val result: ImmutableImage = processor.merge(processedTiles, image.width, image.height)
+result.output(JpegWriter.Default, File("output.jpg"))
+```
+
+단순 분할·병합 (타일별 변환 없음):
+
+```kotlin
 val processor = TileProcessor()
 val tiles = processor.split(image, TileSize(width = 512, height = 512))
 val merged = processor.merge(tiles, image.width, image.height)

--- a/utils/images/README.md
+++ b/utils/images/README.md
@@ -306,36 +306,42 @@ val jpegBytes = image.suspendBytes(SuspendJpegWriter.Default)
 val webpBytes = image.suspendBytes(SuspendWebpWriter.Default)
 ```
 
-### Batch Image Flow (Issue #135)
+### Batch Image Processing (Issue #135)
+
+`ImageBatchFlow` provides a Coroutine Flow pipeline for applying uniform transforms to a large set of
+images with concurrency control and per-pixel memory limits.
 
 ```kotlin
 import io.bluetape4k.images.batch.*
 import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toList
 import java.nio.file.Path
 
+// Configure batch options
 val options = ImageProcessingOptions(
     parallelism = defaultImageBatchParallelism(),
     maxPixels = DEFAULT_MAX_PIXELS,
     maxInFlightPixels = DEFAULT_MAX_IN_FLIGHT_PIXELS,
-    skipFailures = true,
-    onFailure = { failure ->
-        // observe source/stage/cause without stopping the whole batch
-    }
+    skipFailures = true,                        // skip failing images, don't abort
 )
 
-listOf(Path.of("a.jpg"), Path.of("b.jpg"))
+// Process and write results
+val writtenPaths: List<Path> = listOf(Path.of("a.jpg"), Path.of("b.jpg"))
     .asFlow()
     .processImages(options) {
-        resize(width = 320, height = 240)
-        watermark("© bluetape4k")
-        toJpeg(quality = 85)
+        resize(width = 1280, height = 720)      // resize first
+        watermark("© bluetape4k")               // overlay watermark
+        toJpeg(quality = 85)                    // encode as JPEG
     }
-    .writeImagesTo(Path.of("out"), options)
+    .writeImagesTo(Path.of("output"), options)  // write to output directory
+    .toList()
 ```
 
-`ImageProcessingDsl` runs transforms on `transformDispatcher` and writes through the caller-provided `ioDispatcher`.
-The batch defaults are named constants such as `DEFAULT_MAX_PIXELS`, `DEFAULT_MAX_IN_FLIGHT_PIXELS`,
-`JPEG_QUALITY_MIN`, `JPEG_QUALITY_MAX`, and `PERFORMANCE_SAMPLE_IMAGE_COUNT`.
+`ImageProcessingDsl` runs transforms on `transformDispatcher` and writes through the caller-provided
+`ioDispatcher`. The batch defaults are named constants such as `DEFAULT_MAX_PIXELS`,
+`DEFAULT_MAX_IN_FLIGHT_PIXELS`, `JPEG_QUALITY_MIN`, `JPEG_QUALITY_MAX`, and
+`PERFORMANCE_SAMPLE_IMAGE_COUNT`.
+
 For larger image sets, use `ImageProcessingOptions.largeJobs()` or pass explicit
 `maxPixels` / `maxInFlightPixels` values:
 
@@ -349,32 +355,84 @@ val largeOptions = ImageProcessingOptions.largeJobs(
 
 ### Thumbnail Pipeline
 
+`ThumbnailPipeline` generates multiple thumbnail sizes for each source image in a single pass.
+Use `ThumbnailPipeline.builder()` to configure sizes, crop strategy, format, and error handling, then
+call `process(Flow<Path>)` to start streaming results.
+
 ```kotlin
 import io.bluetape4k.images.batch.ImageProcessingOptions
 import io.bluetape4k.images.coroutines.SuspendJpegWriter
 import io.bluetape4k.images.thumbnail.*
 import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.collect
 import java.nio.file.Path
 
+// Build a pipeline that produces three thumbnail sizes per image
 val pipeline = ThumbnailPipeline.builder()
-    .outputDirectory(Path.of("thumbs"))
-    .size(width = 320, height = 240, suffix = "small")
+    .outputDirectory(Path.of("output/thumbs"))
+    .size(width = 1280, height = 720, suffix = "hd")
+    .size(width = 640,  height = 360, suffix = "md")
+    .size(width = 320,  height = 180, suffix = "sm")
     .format(ThumbnailFormat(SuspendJpegWriter.Default.withCompression(85), "jpg"))
-    .crop(ThumbnailCrop.Smart())
-    .options(ImageProcessingOptions(skipFailures = true))
-    .onFailure { failure ->
-        // failure.stage identifies validation/load/transform/write
+    .crop(ThumbnailCrop.Smart())                // saliency-based crop
+    .options(ImageProcessingOptions(parallelism = 4, skipFailures = true))
+    .onFailure { result ->
+        // result.status contains the failed stage and cause
+        println("Thumbnail failed: ${result.source} → ${result.status}")
     }
     .build()
 
-pipeline.process(listOf(Path.of("photo.jpg")).asFlow())
+// Stream source images and collect results
+pipeline
+    .process(listOf(Path.of("photos/photo.jpg"), Path.of("photos/banner.png")).asFlow())
+    .collect { result ->
+        when (val status = result.status) {
+            is ThumbnailStatus.Success ->
+                println("OK  ${result.output.fileName} — ${status.bytes} bytes")
+            is ThumbnailStatus.Failure ->
+                println("ERR ${result.source.fileName} at ${status.stage}")
+        }
+    }
 ```
+
+`ThumbnailCrop` variants:
+- `ThumbnailCrop.Fit` — scale to fit within the bounding box (default)
+- `ThumbnailCrop.Smart()` — saliency-based crop then resize to exact dimensions
 
 ### Tile Processing
 
-```kotlin
-import io.bluetape4k.images.tiles.*
+`TileProcessor` splits large images into a grid of tiles, applies parallel transforms to each tile,
+and reassembles them into a single output image. Useful for applying localised filters to images that
+are too large to process as a whole.
 
+```kotlin
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.filter.GrayscaleFilter
+import io.bluetape4k.images.tiles.*
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toList
+
+val image: ImmutableImage = ImmutableImage.loader().fromFile(File("large.jpg"))
+val processor = TileProcessor(maxTileCount = 256, parallelism = 4)
+
+// 1. Split into 512×512 tiles
+val tiles: List<ImageTile> = processor.split(image, TileSize(width = 512, height = 512))
+
+// 2. Apply a per-tile transform in parallel
+val processedTiles: List<ImageTile> = processor
+    .processTiles(tiles.asFlow()) { tile ->
+        tile.copy(image = tile.image.filter(GrayscaleFilter()))
+    }
+    .toList()
+
+// 3. Reassemble into the original dimensions
+val result: ImmutableImage = processor.merge(processedTiles, image.width, image.height)
+result.output(JpegWriter.Default, File("output.jpg"))
+```
+
+Simple split-and-merge (no per-tile transform):
+
+```kotlin
 val processor = TileProcessor()
 val tiles = processor.split(image, TileSize(width = 512, height = 512))
 val merged = processor.merge(tiles, image.width, image.height)

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageBatchFlow.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageBatchFlow.kt
@@ -21,6 +21,26 @@ private val log = KotlinLogging.logger {}
 
 /**
  * [Path] 스트림을 이미지 배치 처리 결과 스트림으로 변환합니다.
+ *
+ * DSL 블록으로 변환 파이프라인을 선언하고, [ImageProcessingOptions]로 병렬도·픽셀 한도·
+ * 실패 처리 방침을 제어합니다. 처리 결과는 [ImageBatchResult]의 sealed 계층으로 반환됩니다.
+ *
+ * ```kotlin
+ * val outputDir = Path.of("/tmp/output")
+ * val options = ImageProcessingOptions(parallelism = 4, skipFailures = true)
+ *
+ * val writtenPaths: List<Path> = flowOf(Path.of("/images/photo.png"))
+ *     .processImages(options) {
+ *         resize(1280, 720)
+ *         toJpeg(quality = 85)
+ *     }
+ *     .writeImagesTo(outputDir)
+ *     .toList()
+ * ```
+ *
+ * @param options 배치 처리 옵션 (병렬도, 픽셀 한도, 실패 정책 등)
+ * @param block 이미지 변환 단계를 선언하는 DSL 람다
+ * @return 처리 결과([ImageBatchResult]) 스트림
  */
 fun Flow<Path>.processImages(
     options: ImageProcessingOptions = ImageProcessingOptions(),
@@ -36,6 +56,26 @@ fun Flow<Path>.processImages(
 
 /**
  * [File] 스트림을 이미지 배치 처리 결과 스트림으로 변환합니다.
+ *
+ * 내부적으로 [File.toPath]를 통해 [processImages]에 위임합니다.
+ * [java.io.File] 기반 파일 목록에서 바로 배치 처리를 시작할 때 사용합니다.
+ *
+ * ```kotlin
+ * val inputFiles = listOf(File("/images/a.jpg"), File("/images/b.png"))
+ * val outputDir = Path.of("/tmp/output")
+ *
+ * val writtenPaths: List<Path> = inputFiles.asFlow()
+ *     .processImageFiles {
+ *         fit(800, 600)
+ *         toJpeg(quality = 90)
+ *     }
+ *     .writeImagesTo(outputDir)
+ *     .toList()
+ * ```
+ *
+ * @param options 배치 처리 옵션 (병렬도, 픽셀 한도, 실패 정책 등)
+ * @param block 이미지 변환 단계를 선언하는 DSL 람다
+ * @return 처리 결과([ImageBatchResult]) 스트림
  */
 fun Flow<File>.processImageFiles(
     options: ImageProcessingOptions = ImageProcessingOptions(),
@@ -44,7 +84,31 @@ fun Flow<File>.processImageFiles(
     map { file -> file.toPath() }.processImages(options, block)
 
 /**
- * 성공적으로 writer가 선택된 이미지 결과만 저장합니다.
+ * 성공적으로 writer가 선택된 이미지 결과만 [outputDirectory]에 저장합니다.
+ *
+ * [ImageBatchResult.WritableImage] 타입만 필터링하여 저장하므로, writer를 지정하지 않은
+ * [ImageBatchResult.Image] 결과와 실패([ImageBatchResult.Failure]) 결과는 조용히 건너뜁니다.
+ * 저장 성공 시 출력 파일의 [Path]를 반환합니다.
+ *
+ * ```kotlin
+ * val outputDir = Path.of("/tmp/thumbnails")
+ *
+ * val savedPaths: List<Path> = flowOf(Path.of("/images/photo.jpg"))
+ *     .processImages {
+ *         resize(320, 240)
+ *         toJpeg(quality = 75)
+ *     }
+ *     .writeImagesTo(outputDir) { source ->
+ *         // 출력 파일명을 원본 이름에서 파생
+ *         "thumb_${source.fileName}"
+ *     }
+ *     .toList()
+ * ```
+ *
+ * @param outputDirectory 이미지를 저장할 출력 디렉터리 (없으면 자동 생성)
+ * @param options 병렬도·IO 디스패처 설정에 사용하는 처리 옵션
+ * @param outputName 원본 [Path]를 받아 출력 파일명(디렉터리 제외)을 반환하는 함수
+ * @return 저장 완료된 파일 경로 스트림
  */
 fun Flow<ImageBatchResult>.writeImagesTo(
     outputDirectory: Path,

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageBatchModels.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageBatchModels.kt
@@ -68,6 +68,32 @@ sealed interface ImageBatchResult {
 /**
  * 이미지 배치 처리 옵션입니다.
  *
+ * [processImages] / [processImageFiles] / [writeImagesTo]의 동작을 제어합니다.
+ * 기본값으로 간단히 생성하거나, 특수 상황에 맞게 각 파라미터를 조정하세요.
+ *
+ * ```kotlin
+ * // 기본 옵션 — 대부분의 경우에 적합
+ * val defaultOptions = ImageProcessingOptions()
+ *
+ * // 커스텀 옵션 — 병렬도 4, 실패 시 건너뜀, 실패 로그 기록
+ * val options = ImageProcessingOptions(
+ *     parallelism = 4,
+ *     maxPixels = 4_000L * 3_000L,           // 12 MP 제한
+ *     maxInFlightPixels = 100_000_000L,       // 동시 픽셀 1억
+ *     skipFailures = true,
+ *     onFailure = { failure ->
+ *         println("처리 실패: ${failure.source} — ${failure.cause.message}")
+ *     },
+ * )
+ *
+ * flowOf(imagePath)
+ *     .processImages(options) {
+ *         resize(800, 600)
+ *         toJpeg(quality = 85)
+ *     }
+ *     .writeImagesTo(outputDir)
+ * ```
+ *
  * @property ioDispatcher 이미지 읽기/쓰기 작업에 사용할 컨텍스트
  * @property transformDispatcher 이미지 변환 작업에 사용할 컨텍스트
  * @property parallelism 동시에 처리할 이미지 수
@@ -97,6 +123,27 @@ data class ImageProcessingOptions(
          *
          * 기본 [ImageProcessingOptions]보다 픽셀 한도를 크게 잡되, 호출자가 명시적으로
          * `maxPixels`와 `maxInFlightPixels`를 더 조정할 수 있도록 열어둡니다.
+         *
+         * 고해상도 RAW 사진이나 의료·위성 이미지처럼 단일 파일이 수천만 픽셀에 달하는
+         * 워크로드에 적합합니다.
+         *
+         * ```kotlin
+         * // 대용량 배치: 픽셀 한도를 확장하고 실패를 건너뜀
+         * val options = ImageProcessingOptions.largeJobs(
+         *     parallelism = 2,
+         *     skipFailures = true,
+         *     onFailure = { failure ->
+         *         logger.warn { "대용량 이미지 처리 실패: ${failure.source}" }
+         *     },
+         * )
+         *
+         * flowOf(highResImagePath)
+         *     .processImages(options) {
+         *         resize(3840, 2160)   // 4K 다운스케일
+         *         toJpeg(quality = 92)
+         *     }
+         *     .writeImagesTo(outputDir)
+         * ```
          */
         fun largeJobs(
             ioDispatcher: CoroutineContext = Dispatchers.IO,

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageProcessingDsl.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/batch/ImageProcessingDsl.kt
@@ -20,6 +20,30 @@ import java.awt.Font
 
 /**
  * 배치 이미지 변환 단계를 선언하는 DSL입니다.
+ *
+ * [processImages] 또는 [processImageFiles]의 람다 블록으로 사용하며,
+ * 호출 순서대로 변환이 파이프라인에 추가됩니다. 마지막으로 `toJpeg()` 같은
+ * writer 설정을 호출해야 결과를 파일로 저장할 수 있습니다.
+ *
+ * ```kotlin
+ * // 기본 사용 예시: 리사이즈 → 가우시안 블러 → JPEG 저장
+ * flowOf(imagePath)
+ *     .processImages {
+ *         resize(1024, 768)
+ *         gaussianBlur(radius = 3)
+ *         toJpeg(quality = 85)
+ *     }
+ *     .writeImagesTo(outputDir)
+ *
+ * // 워터마크 텍스트 + 스마트 크롭 + JPEG 저장
+ * flowOf(imagePath)
+ *     .processImages {
+ *         smartCrop(width = 800, height = 600)
+ *         watermark("© 2025 Bluetape4k")
+ *         toJpeg(quality = 90, progressive = true)
+ *     }
+ *     .writeImagesTo(outputDir)
+ * ```
  */
 class ImageProcessingDsl {
     private val transforms = mutableListOf<(ImmutableImage) -> ImmutableImage>()
@@ -27,6 +51,19 @@ class ImageProcessingDsl {
 
     /**
      * 이미지를 지정 크기로 리사이즈합니다.
+     *
+     * 원본 비율을 유지하지 않고 [width] × [height]로 강제 스케일합니다.
+     * 비율을 유지하면서 맞추려면 [fit]을 사용하세요.
+     *
+     * ```kotlin
+     * flowOf(imagePath).processImages {
+     *     resize(1920, 1080)
+     *     toJpeg(quality = 90)
+     * }
+     * ```
+     *
+     * @param width 출력 너비 (픽셀, 양수)
+     * @param height 출력 높이 (픽셀, 양수)
      */
     fun resize(width: Int, height: Int) {
         width.requirePositiveNumber("width")
@@ -35,7 +72,20 @@ class ImageProcessingDsl {
     }
 
     /**
-     * 이미지를 지정 크기에 맞춥니다.
+     * 이미지를 원본 비율을 유지하면서 [width] × [height] 경계에 맞춥니다.
+     *
+     * 경계를 벗어나지 않는 최대 크기로 축소·확대하므로 이미지가 잘리지 않습니다.
+     * 비율 무시 강제 스케일링은 [resize]를 사용하세요.
+     *
+     * ```kotlin
+     * flowOf(imagePath).processImages {
+     *     fit(800, 600)
+     *     toJpeg(quality = 85)
+     * }
+     * ```
+     *
+     * @param width 경계 너비 (픽셀, 양수)
+     * @param height 경계 높이 (픽셀, 양수)
      */
     fun fit(width: Int, height: Int) {
         width.requirePositiveNumber("width")
@@ -45,6 +95,17 @@ class ImageProcessingDsl {
 
     /**
      * 가우시안 블러 필터를 적용합니다.
+     *
+     * [radius]가 클수록 더 강한 블러 효과가 적용됩니다.
+     *
+     * ```kotlin
+     * flowOf(imagePath).processImages {
+     *     gaussianBlur(radius = 5)
+     *     toJpeg(quality = 80)
+     * }
+     * ```
+     *
+     * @param radius 블러 반경 (픽셀, 양수)
      */
     fun gaussianBlur(radius: Int) {
         radius.requirePositiveNumber("radius")
@@ -52,7 +113,28 @@ class ImageProcessingDsl {
     }
 
     /**
-     * 텍스트 워터마크를 적용합니다.
+     * 텍스트 워터마크를 이미지에 적용합니다.
+     *
+     * [type]으로 워터마크 배치 방식을 선택하고, [alpha]로 투명도를 조절합니다.
+     * 기본값은 흰색 반투명 전면 커버 워터마크입니다.
+     *
+     * ```kotlin
+     * flowOf(imagePath).processImages {
+     *     watermark(
+     *         text = "© 2025 My Company",
+     *         alpha = 0.15,
+     *         color = Color.WHITE,
+     *     )
+     *     toJpeg(quality = 85)
+     * }
+     * ```
+     *
+     * @param text 워터마크로 표시할 텍스트
+     * @param font 텍스트 폰트 (기본값: [DEFAULT_FONT])
+     * @param type 워터마크 배치 방식 ([WatermarkFilterType])
+     * @param antiAlias 안티앨리어싱 적용 여부
+     * @param alpha 텍스트 투명도 (0.0 ~ 1.0)
+     * @param color 텍스트 색상 (기본값: 흰색)
      */
     fun watermark(
         text: String,
@@ -67,6 +149,26 @@ class ImageProcessingDsl {
 
     /**
      * 로고 이미지를 워터마크로 합성합니다.
+     *
+     * [logo]를 [position] 위치에 [alpha] 투명도로 오버레이합니다.
+     * 텍스트 대신 이미지 로고를 삽입할 때 사용합니다.
+     *
+     * ```kotlin
+     * val logo = ImmutableImage.loader().fromFile(File("logo.png"))
+     *
+     * flowOf(imagePath).processImages {
+     *     watermark(
+     *         logo = logo,
+     *         position = Position.BottomRight,
+     *         alpha = 0.8f,
+     *     )
+     *     toJpeg(quality = 90)
+     * }
+     * ```
+     *
+     * @param logo 워터마크로 사용할 로고 이미지
+     * @param position 로고를 배치할 위치 (기본값: 우측 하단)
+     * @param alpha 로고 불투명도 (0.0f ~ 1.0f, 기본값: 1.0f)
      */
     fun watermark(
         logo: ImmutableImage,
@@ -78,7 +180,25 @@ class ImageProcessingDsl {
     }
 
     /**
-     * 살리언시 기반 스마트 크롭을 적용합니다.
+     * 살리언시(Saliency) 기반 스마트 크롭을 적용합니다.
+     *
+     * [strategy] 알고리즘으로 이미지의 중요 영역을 탐지하여 [width] × [height] 크기로
+     * 가장 의미 있는 부분을 잘라냅니다. 기본 전략은 [SaliencyStrategy.SobelEnergy]입니다.
+     *
+     * ```kotlin
+     * flowOf(imagePath).processImages {
+     *     smartCrop(
+     *         width = 400,
+     *         height = 400,
+     *         strategy = SaliencyStrategy.SobelEnergy,
+     *     )
+     *     toJpeg(quality = 88)
+     * }
+     * ```
+     *
+     * @param width 크롭 후 너비 (픽셀, 양수)
+     * @param height 크롭 후 높이 (픽셀, 양수)
+     * @param strategy 살리언시 탐지 전략 (기본값: [SaliencyStrategy.SobelEnergy])
      */
     fun smartCrop(
         width: Int,
@@ -99,6 +219,20 @@ class ImageProcessingDsl {
 
     /**
      * JPEG writer를 선택합니다.
+     *
+     * 이 함수를 호출하면 변환 결과가 [ImageBatchResult.WritableImage]로 감싸져
+     * [writeImagesTo]로 파일 저장이 가능해집니다. writer는 한 번만 설정할 수 있습니다.
+     *
+     * ```kotlin
+     * flowOf(imagePath).processImages {
+     *     resize(1280, 720)
+     *     // quality 0~100, progressive = true 이면 점진적 로딩 JPEG
+     *     toJpeg(quality = 85, progressive = true)
+     * }
+     * ```
+     *
+     * @param quality JPEG 압축 품질 (0 ~ 100, 기본값: 80)
+     * @param progressive `true`이면 프로그레시브 JPEG로 인코딩
      */
     fun toJpeg(
         quality: Int = DEFAULT_JPEG_QUALITY,

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/batch/PixelPermitLimiter.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/batch/PixelPermitLimiter.kt
@@ -1,15 +1,23 @@
 package io.bluetape4k.images.batch
 
 import io.bluetape4k.support.requirePositiveNumber
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
+/**
+ * 동시에 처리 중인 이미지의 픽셀 총량을 제한하는 가중 세마포어입니다.
+ *
+ * 픽셀 슬롯이 해제될 때까지 대기 코루틴은 실제로 suspend 상태로 진입하며,
+ * 폴링 루프를 사용하지 않습니다.
+ */
 internal class PixelPermitLimiter(
     private val maxPixels: Long,
 ) {
     private val mutex = Mutex()
     private var availablePixels = maxPixels
+    private val waiters = ArrayDeque<CompletableDeferred<Unit>>()
 
     init {
         maxPixels.requirePositiveNumber("maxPixels")
@@ -27,26 +35,29 @@ internal class PixelPermitLimiter(
 
     private suspend fun acquire(permits: Long) {
         while (true) {
-            val acquired = mutex.withLock {
+            val deferred = mutex.withLock {
                 if (availablePixels >= permits) {
                     availablePixels -= permits
-                    true
-                } else {
-                    false
+                    return
                 }
+                CompletableDeferred<Unit>().also { waiters.addLast(it) }
             }
-
-            if (acquired) {
-                return
+            try {
+                deferred.await()
+            } catch (e: CancellationException) {
+                mutex.withLock { waiters.remove(deferred) }
+                throw e
             }
-
-            delay(PIXEL_PERMIT_RETRY_DELAY_MILLIS)
         }
     }
 
     private suspend fun release(permits: Long) {
+        val toWake: List<CompletableDeferred<Unit>>
         mutex.withLock {
             availablePixels = (availablePixels + permits).coerceAtMost(maxPixels)
+            toWake = waiters.toList()
+            waiters.clear()
         }
+        toWake.forEach { it.complete(Unit) }
     }
 }

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/thumbnail/ThumbnailPipeline.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/thumbnail/ThumbnailPipeline.kt
@@ -10,7 +10,7 @@ import io.bluetape4k.images.batch.probeImagePixelCount
 import io.bluetape4k.images.coroutines.SuspendImageWriter
 import io.bluetape4k.images.immutableImageOf
 import io.bluetape4k.images.transforms.smartCropTo
-import io.bluetape4k.logging.KotlinLogging
+import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requirePositiveNumber
 import kotlinx.coroutines.CancellationException
@@ -24,10 +24,52 @@ import java.nio.file.Path
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.CoroutineContext
 
-private val log = KotlinLogging.logger {}
-
 /**
- * 여러 크기의 썸네일을 생성하는 파이프라인입니다.
+ * 여러 크기의 썸네일을 동시에 생성하는 코루틴 기반 파이프라인입니다.
+ *
+ * [builder]로 파이프라인을 구성하고 [process]에 이미지 경로 Flow를 넘기면
+ * 각 원본 이미지에 대해 등록된 모든 크기의 썸네일을 병렬로 생성합니다.
+ *
+ * 픽셀 한도([ImageProcessingOptions.maxPixels])를 초과하는 이미지나 출력 경로가 중복되는
+ * 경우는 VALIDATION 단계 실패로 처리됩니다. [ImageProcessingOptions.skipFailures]가
+ * `true`이면 실패 항목을 건너뛰고 계속 처리하며, `false`(기본값)이면 예외를 던져 중단합니다.
+ *
+ * ```kotlin
+ * import io.bluetape4k.images.batch.ImageProcessingOptions
+ * import io.bluetape4k.images.coroutines.SuspendJpegWriter
+ * import io.bluetape4k.images.thumbnail.*
+ * import kotlinx.coroutines.flow.asFlow
+ * import java.nio.file.Path
+ *
+ * // 1. 파이프라인 구성
+ * val pipeline = ThumbnailPipeline.builder()
+ *     .outputDirectory(Path.of("output/thumbs"))
+ *     .size(width = 1280, height = 720, suffix = "hd")
+ *     .size(width = 640, height = 360, suffix = "md")
+ *     .size(width = 320, height = 180, suffix = "sm")
+ *     .format(ThumbnailFormat(SuspendJpegWriter.Default.withCompression(85), "jpg"))
+ *     .crop(ThumbnailCrop.Smart())
+ *     .options(ImageProcessingOptions(parallelism = 4, skipFailures = true))
+ *     .onFailure { result ->
+ *         println("썸네일 생성 실패: source=${result.source}, stage=${result.status}")
+ *     }
+ *     .build()
+ *
+ * // 2. Flow<Path> 입력을 넘겨 처리
+ * val results = pipeline
+ *     .process(listOf(Path.of("photo1.jpg"), Path.of("photo2.png")).asFlow())
+ *     .toList()
+ *
+ * results.forEach { result ->
+ *     when (val status = result.status) {
+ *         is ThumbnailStatus.Success -> println("생성 완료: ${result.output} (${status.bytes} bytes)")
+ *         is ThumbnailStatus.Failure -> println("생성 실패: ${result.source} at ${status.stage}")
+ *     }
+ * }
+ * ```
+ *
+ * @see builder
+ * @see process
  */
 class ThumbnailPipeline private constructor(
     private val outputDirectory: Path,
@@ -44,7 +86,43 @@ class ThumbnailPipeline private constructor(
     private val onFailure: suspend (ThumbnailResult) -> Unit,
 ) {
     /**
-     * 입력 이미지 스트림을 썸네일 결과 스트림으로 처리합니다.
+     * 입력 이미지 경로 스트림을 썸네일 결과 스트림으로 처리합니다.
+     *
+     * 동일한 출력 경로는 이 파이프라인 인스턴스 내에서 한 번만 처리됩니다.
+     * 같은 출력 경로로 두 번 이상 시도하면 VALIDATION 단계 실패로 처리됩니다.
+     *
+     * 각 소스 이미지에 대해 등록된 모든 크기의 썸네일이 병렬로 생성되며,
+     * 결과는 [ThumbnailResult]의 스트림으로 반환됩니다.
+     *
+     * ```kotlin
+     * import kotlinx.coroutines.flow.asFlow
+     * import kotlinx.coroutines.flow.collect
+     * import java.nio.file.Path
+     *
+     * val pipeline = ThumbnailPipeline.builder()
+     *     .outputDirectory(Path.of("output/thumbs"))
+     *     .size(320, 240, suffix = "small")
+     *     .size(640, 480, suffix = "medium")
+     *     .build()
+     *
+     * // Flow<Path> 입력 — 파일 목록을 asFlow()로 변환
+     * val sourcePaths = listOf(
+     *     Path.of("images/photo1.jpg"),
+     *     Path.of("images/photo2.png"),
+     * ).asFlow()
+     *
+     * pipeline.process(sourcePaths).collect { result ->
+     *     when (val s = result.status) {
+     *         is ThumbnailStatus.Success ->
+     *             println("[OK] ${result.output.fileName} — ${s.bytes} bytes")
+     *         is ThumbnailStatus.Failure ->
+     *             println("[FAIL] ${result.source.fileName} stage=${s.stage}")
+     *     }
+     * }
+     * ```
+     *
+     * @param sourceImages 처리할 원본 이미지 경로의 Flow
+     * @return 각 (소스 × 크기) 조합에 대한 [ThumbnailResult] Flow
      */
     fun process(sourceImages: Flow<Path>): Flow<ThumbnailResult> {
         val limiter = PixelPermitLimiter(maxInFlightPixels)
@@ -181,7 +259,11 @@ class ThumbnailPipeline private constructor(
 
     private fun Long.requireWithinMaxPixels(source: Path) {
         if (this > maxPixels) {
-            throw IllegalArgumentException("이미지 픽셀 수가 허용 한도를 초과했습니다. source=$source, pixels=$this, maxPixels=$maxPixels")
+            throw ImageBatchException(
+                source = source,
+                stage = ImageBatchFailureStage.VALIDATION,
+                message = "이미지 픽셀 수가 허용 한도를 초과했습니다. source=$source, pixels=$this, maxPixels=$maxPixels",
+            )
         }
     }
 
@@ -219,6 +301,23 @@ class ThumbnailPipeline private constructor(
 
         /**
          * 썸네일 크기를 추가합니다.
+         *
+         * 여러 번 호출하여 다양한 크기를 한 번에 등록할 수 있습니다.
+         * [suffix]를 생략하면 `"${width}x${height}"` 형식이 기본값으로 사용됩니다.
+         *
+         * ```kotlin
+         * ThumbnailPipeline.builder()
+         *     .outputDirectory(Path.of("thumbs"))
+         *     .size(width = 1920, height = 1080, suffix = "fhd")   // Full HD
+         *     .size(width = 1280, height = 720,  suffix = "hd")    // HD
+         *     .size(width = 640,  height = 360,  suffix = "sd")    // SD
+         *     .size(width = 320,  height = 180)                    // 기본 suffix = "320x180"
+         *     .build()
+         * ```
+         *
+         * @param width 썸네일 너비 (픽셀)
+         * @param height 썸네일 높이 (픽셀)
+         * @param suffix 출력 파일명에 추가될 크기 접미사 (기본값: `"${width}x${height}"`)
          */
         fun size(width: Int, height: Int, suffix: String = "${width}x$height"): Builder = apply {
             sizes += ThumbnailSize(width, height, suffix)
@@ -267,7 +366,32 @@ class ThumbnailPipeline private constructor(
         }
 
         /**
-         * 파이프라인을 생성합니다.
+         * 설정된 옵션으로 [ThumbnailPipeline]을 생성합니다.
+         *
+         * [outputDirectory]는 필수이며, [size]를 한 번도 호출하지 않은 경우
+         * 기본 크기(320×240)가 자동으로 사용됩니다.
+         *
+         * ```kotlin
+         * import io.bluetape4k.images.batch.ImageProcessingOptions
+         * import io.bluetape4k.images.coroutines.SuspendWebpWriter
+         * import io.bluetape4k.images.thumbnail.*
+         * import java.nio.file.Path
+         *
+         * val pipeline = ThumbnailPipeline.builder()
+         *     .outputDirectory(Path.of("output/thumbs"))
+         *     .size(640, 480, suffix = "medium")
+         *     .size(320, 240, suffix = "small")
+         *     .format(ThumbnailFormat(SuspendWebpWriter.Default, "webp"))
+         *     .crop(ThumbnailCrop.Smart())
+         *     .options(ImageProcessingOptions(parallelism = 4, skipFailures = true))
+         *     .onFailure { result ->
+         *         println("실패: ${result.source} → ${result.status}")
+         *     }
+         *     .build()   // ThumbnailPipeline 인스턴스 반환
+         * ```
+         *
+         * @return 구성된 [ThumbnailPipeline] 인스턴스
+         * @throws IllegalArgumentException [outputDirectory]가 설정되지 않은 경우
          */
         fun build(): ThumbnailPipeline {
             val directory = requireNotNull(outputDirectory) { "outputDirectory를 지정해야 합니다." }
@@ -291,7 +415,7 @@ class ThumbnailPipeline private constructor(
         }
     }
 
-    companion object {
+    companion object: KLoggingChannel() {
         private const val DEFAULT_THUMBNAIL_WIDTH = 320
         private const val DEFAULT_THUMBNAIL_HEIGHT = 240
         private val DEFAULT_THUMBNAIL_SIZE = ThumbnailSize(DEFAULT_THUMBNAIL_WIDTH, DEFAULT_THUMBNAIL_HEIGHT)

--- a/utils/images/src/main/kotlin/io/bluetape4k/images/tiles/TileProcessor.kt
+++ b/utils/images/src/main/kotlin/io/bluetape4k/images/tiles/TileProcessor.kt
@@ -9,7 +9,40 @@ import kotlinx.coroutines.flow.Flow
 import java.awt.image.BufferedImage
 
 /**
- * 큰 이미지를 타일로 나누고 다시 병합하는 처리기입니다.
+ * 큰 이미지를 타일로 분할하고, 각 타일을 병렬 처리한 후 다시 하나의 이미지로 병합하는 처리기입니다.
+ *
+ * [split]으로 이미지를 격자 타일로 잘라내고, [processTiles]로 각 타일에 독립적인 변환을 적용한 다음,
+ * [merge]로 원래 크기의 이미지를 재조립합니다.
+ * 타일 수가 [maxTileCount]를 초과하면 예외가 발생합니다.
+ *
+ * ```kotlin
+ * import com.sksamuel.scrimage.ImmutableImage
+ * import io.bluetape4k.images.tiles.*
+ * import kotlinx.coroutines.flow.asFlow
+ * import kotlinx.coroutines.flow.toList
+ *
+ * val image: ImmutableImage = ImmutableImage.loader().fromFile(File("large-photo.jpg"))
+ * val processor = TileProcessor(maxTileCount = 256, parallelism = 4)
+ *
+ * // 1. 512×512 타일로 분할
+ * val tiles: List<ImageTile> = processor.split(image, TileSize(width = 512, height = 512))
+ *
+ * // 2. 각 타일에 병렬 변환 적용 (예: 그레이스케일 변환)
+ * val processedTiles: List<ImageTile> = processor
+ *     .processTiles(tiles.asFlow()) { tile ->
+ *         tile.copy(image = tile.image.filter(GrayscaleFilter()))
+ *     }
+ *     .toList()
+ *
+ * // 3. 처리된 타일을 원래 크기로 병합
+ * val result: ImmutableImage = processor.merge(processedTiles, image.width, image.height)
+ * ```
+ *
+ * @param maxTileCount 허용되는 최대 타일 수 (기본값: [DEFAULT_MAX_TILE_COUNT])
+ * @param parallelism [processTiles] 병렬 처리 동시성 수준 (기본값: [defaultImageBatchParallelism])
+ * @see split
+ * @see merge
+ * @see processTiles
  */
 class TileProcessor(
     private val maxTileCount: Int = DEFAULT_MAX_TILE_COUNT,
@@ -21,7 +54,31 @@ class TileProcessor(
     }
 
     /**
-     * 이미지를 지정 타일 크기로 분할합니다.
+     * 이미지를 [tileSize] 크기의 격자 타일로 분할합니다.
+     *
+     * 이미지 크기가 타일 크기의 배수가 아닌 경우 가장자리 타일은 더 작을 수 있습니다.
+     * 총 타일 수가 [maxTileCount]를 초과하면 [IllegalArgumentException]이 발생합니다.
+     *
+     * ```kotlin
+     * import com.sksamuel.scrimage.ImmutableImage
+     * import io.bluetape4k.images.tiles.*
+     *
+     * val image: ImmutableImage = ImmutableImage.loader().fromFile(File("large.jpg"))
+     * val processor = TileProcessor()
+     *
+     * // 256×256 타일로 분할 — 1920×1080 이미지 → 8×5 = 40 타일
+     * val tiles: List<ImageTile> = processor.split(image, TileSize(width = 256, height = 256))
+     *
+     * println("타일 수: ${tiles.size}")               // 40
+     * tiles.forEach { tile ->
+     *     println("  (${tile.x}, ${tile.y}) ${tile.width}×${tile.height}")
+     * }
+     * ```
+     *
+     * @param image 분할할 원본 이미지
+     * @param tileSize 각 타일의 목표 크기
+     * @return 좌상단(0,0)부터 행 우선(row-major) 순서로 정렬된 [ImageTile] 목록
+     * @throws IllegalArgumentException 타일 수가 [maxTileCount]를 초과할 경우
      */
     fun split(image: ImmutableImage, tileSize: TileSize): List<ImageTile> {
         val tilesX = image.width.ceilDiv(tileSize.width)
@@ -43,7 +100,37 @@ class TileProcessor(
     }
 
     /**
-     * 타일 목록을 하나의 이미지로 병합합니다.
+     * 타일 컬렉션을 하나의 이미지로 병합합니다.
+     *
+     * 각 타일을 [ImageTile.y] → [ImageTile.x] 순서로 정렬한 뒤 `width × height` 크기의
+     * 새 이미지에 순서대로 합성합니다. 타일이 출력 이미지 영역을 벗어나거나 좌표가 음수이면
+     * [IllegalArgumentException]이 발생합니다.
+     *
+     * ```kotlin
+     * import com.sksamuel.scrimage.ImmutableImage
+     * import io.bluetape4k.images.tiles.*
+     *
+     * val image: ImmutableImage = ImmutableImage.loader().fromFile(File("large.jpg"))
+     * val processor = TileProcessor()
+     *
+     * // 분할 → 변환 → 병합
+     * val tiles = processor.split(image, TileSize(width = 512, height = 512))
+     *
+     * // 각 타일에 밝기 조정 후 원래 크기로 합성
+     * val brightened = tiles.map { tile ->
+     *     tile.copy(image = tile.image.filter(BrightnessFilter(1.2f)))
+     * }
+     * val merged: ImmutableImage = processor.merge(brightened, image.width, image.height)
+     *
+     * merged.output(JpegWriter.Default, File("output.jpg"))
+     * ```
+     *
+     * @param tiles 병합할 [ImageTile] 컬렉션 (순서 무관, 좌표로 재정렬)
+     * @param width 출력 이미지의 너비 (픽셀)
+     * @param height 출력 이미지의 높이 (픽셀)
+     * @return 타일이 합성된 [ImmutableImage]
+     * @throws IllegalArgumentException tiles가 비어있거나, [maxTileCount]를 초과하거나,
+     *   타일 좌표가 출력 이미지 영역을 벗어난 경우
      */
     fun merge(
         tiles: Collection<ImageTile>,
@@ -60,7 +147,7 @@ class TileProcessor(
         val output = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
         val graphics = output.createGraphics()
         try {
-            tiles.sortedWith(compareBy<ImageTile> { it.y }.thenBy { it.x }).forEach { tile ->
+            tiles.sortedWith(TILE_ORDER).forEach { tile ->
                 require(tile.x >= 0 && tile.y >= 0) { "타일 좌표는 0 이상이어야 합니다. tile=$tile" }
                 require(tile.x + tile.width <= width && tile.y + tile.height <= height) {
                     "타일이 출력 이미지 영역을 벗어났습니다. tile=$tile, width=$width, height=$height"
@@ -75,7 +162,36 @@ class TileProcessor(
     }
 
     /**
-     * 타일 스트림을 병렬 변환합니다.
+     * 타일 Flow를 병렬로 변환하여 결과 Flow를 반환합니다.
+     *
+     * 각 타일에 대해 [transform]을 [parallelism] 수준의 동시성으로 실행합니다.
+     * [split]의 결과를 `List.asFlow()`로 변환하여 넘기면 됩니다.
+     *
+     * ```kotlin
+     * import com.sksamuel.scrimage.ImmutableImage
+     * import com.sksamuel.scrimage.filter.GrayscaleFilter
+     * import io.bluetape4k.images.tiles.*
+     * import kotlinx.coroutines.flow.asFlow
+     * import kotlinx.coroutines.flow.toList
+     *
+     * val image: ImmutableImage = ImmutableImage.loader().fromFile(File("large.jpg"))
+     * val processor = TileProcessor(parallelism = 4)
+     * val tiles = processor.split(image, TileSize(256, 256))
+     *
+     * // 각 타일을 병렬로 그레이스케일 변환 → 원본 타일 좌표 유지
+     * val grayTiles: List<ImageTile> = processor
+     *     .processTiles(tiles.asFlow()) { tile ->
+     *         tile.copy(image = tile.image.filter(GrayscaleFilter()))
+     *     }
+     *     .toList()
+     *
+     * // 처리된 타일을 다시 병합
+     * val result = processor.merge(grayTiles, image.width, image.height)
+     * ```
+     *
+     * @param tiles 처리할 [ImageTile]의 Flow
+     * @param transform 각 타일에 적용할 suspend 변환 함수
+     * @return 변환 결과 [R]의 Flow
      */
     fun <R> processTiles(
         tiles: Flow<ImageTile>,
@@ -88,5 +204,6 @@ class TileProcessor(
 
     private companion object {
         private const val CEIL_DIV_OFFSET = 1
+        private val TILE_ORDER: Comparator<ImageTile> = compareBy<ImageTile> { it.y }.thenBy { it.x }
     }
 }

--- a/utils/images/src/test/kotlin/io/bluetape4k/images/AbstractImageTest.kt
+++ b/utils/images/src/test/kotlin/io/bluetape4k/images/AbstractImageTest.kt
@@ -31,7 +31,8 @@ abstract class AbstractImageTest {
         "homer", "labor"
     )
 
-    protected fun getImage(path: String): InputStream = Resourcex.getInputStream(path)!!
+    protected fun getImage(path: String): InputStream =
+        Resourcex.getInputStream(path) ?: error("테스트 리소스를 찾을 수 없습니다: $path")
 
     protected fun writeToFile(bytes: ByteArray, filename: String, format: ImageFormat = ImageFormat.JPG) {
         val path = Paths.get("$BASE_PATH/$filename.${format.name}")

--- a/utils/images/src/test/kotlin/io/bluetape4k/images/batch/ImageBatchFlowTest.kt
+++ b/utils/images/src/test/kotlin/io/bluetape4k/images/batch/ImageBatchFlowTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import kotlin.time.Duration.Companion.seconds
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeGreaterThan
 import org.amshove.kluent.shouldBeInstanceOf
@@ -44,7 +45,7 @@ class ImageBatchFlowTest: AbstractImageTest() {
     @Test
     fun `processImages applies transform dispatcher path and writes with selected writer`(
         tempFolder: TempFolder,
-    ) = runTest {
+    ) = runTest(timeout = 30.seconds) {
         val source = tempFolder.copyResource(CAFE_JPG, SOURCE_IMAGE_NAME)
         val output = tempFolder.root.toPath().resolve(OUTPUT_IMAGE_NAME)
 
@@ -69,7 +70,7 @@ class ImageBatchFlowTest: AbstractImageTest() {
     @Test
     fun `processImages emits failure and invokes callback when skipFailures is true`(
         tempFolder: TempFolder,
-    ) = runTest {
+    ) = runTest(timeout = 30.seconds) {
         val source = tempFolder.createFile(BROKEN_IMAGE_NAME).toPath()
         Files.writeString(source, BROKEN_IMAGE_TEXT)
         val failures = mutableListOf<ImageBatchResult.Failure>()
@@ -93,7 +94,7 @@ class ImageBatchFlowTest: AbstractImageTest() {
     @Test
     fun `writeImagesTo emits write failure callback when skipFailures is true`(
         tempFolder: TempFolder,
-    ) = runTest {
+    ) = runTest(timeout = 30.seconds) {
         val source = tempFolder.copyResource(CAFE_JPG, SOURCE_IMAGE_NAME)
         val blockedOutput = tempFolder.createDirectory(OUTPUT_IMAGE_NAME).toPath()
         val failures = mutableListOf<ImageBatchResult.Failure>()
@@ -123,7 +124,7 @@ class ImageBatchFlowTest: AbstractImageTest() {
     @Test
     fun `writeImagesTo rejects output path traversal`(
         tempFolder: TempFolder,
-    ) = runTest {
+    ) = runTest(timeout = 30.seconds) {
         val source = tempFolder.copyResource(CAFE_JPG, SOURCE_IMAGE_NAME)
         val failures = mutableListOf<ImageBatchResult.Failure>()
         val options = ImageProcessingOptions(
@@ -173,7 +174,7 @@ class ImageBatchFlowTest: AbstractImageTest() {
     @Test
     fun `hundred image batch performance sample is logged without threshold gating`(
         tempFolder: TempFolder,
-    ) = runTest {
+    ) = runTest(timeout = 60.seconds) {
         val source = tempFolder.createTinyImage(SOURCE_IMAGE_NAME)
         val sources = List(PERFORMANCE_SAMPLE_IMAGE_COUNT) { source }
         val options = ImageProcessingOptions(parallelism = TEST_PARALLELISM)
@@ -194,9 +195,9 @@ class ImageBatchFlowTest: AbstractImageTest() {
 
     private fun TempFolder.copyResource(resourcePath: String, fileName: String) =
         createFile(fileName).toPath().also { target ->
-            Resourcex.getInputStream(resourcePath)!!.use { input ->
-                Files.copy(input, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
-            }
+            val input = Resourcex.getInputStream(resourcePath)
+                ?: error("테스트 리소스를 찾을 수 없습니다: $resourcePath")
+            input.use { Files.copy(it, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING) }
         }
 
     private fun TempFolder.createTinyImage(fileName: String) =

--- a/utils/images/src/test/kotlin/io/bluetape4k/images/thumbnail/ThumbnailPipelineTest.kt
+++ b/utils/images/src/test/kotlin/io/bluetape4k/images/thumbnail/ThumbnailPipelineTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import kotlin.time.Duration.Companion.seconds
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
 import org.amshove.kluent.shouldBeTrue
@@ -24,7 +25,7 @@ class ThumbnailPipelineTest: AbstractImageTest() {
     @Test
     fun `thumbnail pipeline writes configured size`(
         tempFolder: TempFolder,
-    ) = runTest {
+    ) = runTest(timeout = 30.seconds) {
         val source = tempFolder.copyResource(LANDSCAPE_JPG, SOURCE_IMAGE_NAME)
         val outputDir = tempFolder.createDirectory(OUTPUT_DIRECTORY_NAME).toPath()
         val pipeline = ThumbnailPipeline.builder()
@@ -44,7 +45,7 @@ class ThumbnailPipelineTest: AbstractImageTest() {
     @Test
     fun `thumbnail pipeline rejects output path traversal`(
         tempFolder: TempFolder,
-    ) = runTest {
+    ) = runTest(timeout = 30.seconds) {
         val source = tempFolder.copyResource(LANDSCAPE_JPG, SOURCE_IMAGE_NAME)
         val outputDir = tempFolder.createDirectory(OUTPUT_DIRECTORY_NAME).toPath()
         val failures = mutableListOf<ThumbnailResult>()
@@ -74,9 +75,9 @@ class ThumbnailPipelineTest: AbstractImageTest() {
 
     private fun TempFolder.copyResource(resourcePath: String, fileName: String) =
         createFile(fileName).toPath().also { target ->
-            Resourcex.getInputStream(resourcePath)!!.use { input ->
-                Files.copy(input, target, StandardCopyOption.REPLACE_EXISTING)
-            }
+            val input = Resourcex.getInputStream(resourcePath)
+                ?: error("테스트 리소스를 찾을 수 없습니다: $resourcePath")
+            input.use { Files.copy(it, target, StandardCopyOption.REPLACE_EXISTING) }
         }
 
     private companion object {


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: utils/images 모듈 코드 리뷰 반영 — 코루틴 안티패턴 수정 및 KDoc/README 강화

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 변경 개요

일일 자동 코드 리뷰 결과 반영. bluetape4k-design 3-tier 리뷰(Tier 4 Kotlin 품질, Tier 6 성능/안정성)에서 발견된 HIGH/MEDIUM 이슈 수정.

### 기존 섹션: 수정 내용

### HIGH 이슈 수정

- **PixelPermitLimiter** ([utils/images/batch/PixelPermitLimiter.kt](utils/images/src/main/kotlin/io/bluetape4k/images/batch/PixelPermitLimiter.kt))
  - `delay(1ms) + while(true)` 폴링 안티패턴 → `CompletableDeferred` 기반 suspend 대기로 교체
  - release 시 대기 코루틴 전체에 신호 전달, CancellationException 안전 처리
  - 경쟁 상황에서 CPU 낭비 및 라이브락 위험 제거

- **ThumbnailPipeline** ([utils/images/thumbnail/ThumbnailPipeline.kt](utils/images/src/main/kotlin/io/bluetape4k/images/thumbnail/ThumbnailPipeline.kt))
  - 파일 레벨 `KotlinLogging.logger {}` → `companion object : KLoggingChannel()` 패턴으로 수정
  - `requireWithinMaxPixels`: `IllegalArgumentException` → `ImageBatchException` (ImageBatchFlow.kt와 불일치 수정)
  - `process()` KDoc에 seenOutputs 1회 처리 계약 명시

### MEDIUM 이슈 수정

- **TileProcessor** ([utils/images/tiles/TileProcessor.kt](utils/images/src/main/kotlin/io/bluetape4k/images/tiles/TileProcessor.kt))
  - `merge()` 내 `compareBy { y }.thenBy { x }` → `companion object` 상수 `TILE_ORDER`로 추출 (호출마다 Comparator 객체 생성 제거)

- **테스트 파일** — `runTest` timeout 누락 수정
  - `ImageBatchFlowTest`: 일반 테스트 `timeout = 30.seconds`, 성능 테스트 `timeout = 60.seconds`
  - `ThumbnailPipelineTest`: `timeout = 30.seconds`

- **AbstractImageTest / copyResource** — `!!.` → `error()` 로 명확한 에러 메시지

### KDoc 강화 (public API 예제 추가)

- `ImageBatchFlow.kt`: `processImages`, `processImageFiles`, `writeImagesTo`
- `ImageProcessingDsl.kt`: 클래스 레벨 + 모든 DSL 함수(`resize`, `fit`, `gaussianBlur`, `watermark`, `smartCrop`, `toJpeg`)
- `ImageBatchModels.kt`: `ImageProcessingOptions`, `ImageProcessingOptions.largeJobs`
- `ThumbnailPipeline.kt`: 클래스 + `process()`, `Builder.size()`, `Builder.build()`
- `TileProcessor.kt`: 클래스 + `split()`, `merge()`, `processTiles()`

### README 최신화

- `README.md` + `README.ko.md`: Batch Image Processing / Thumbnail Pipeline / Tile Processing 섹션 예제 최신화

### 기존 섹션: 코드 리뷰 결과

| Reviewer | Findings | Action |
|---------|----------|--------|
| Tier 4 oh-my-claudecode:code-reviewer | HIGH 3, MEDIUM 4, LOW 1 | ✅ HIGH 전수, MEDIUM 전수 수정 |
| Tier 6 Performance/stability | HIGH 1 (PixelPermitLimiter 폴링), MEDIUM 3 (Comparator, requireWithinMaxPixels, runTest timeout) | ✅ 전수 수정 |
| **Final status** | **CRITICAL 0, HIGH 0** | **✅ PR 생성** |

## Validation

모듈: `:bluetape4k-images`
Tests: 349 passing, 8 pending
Time: 47.4s
Date: 2026-04-29

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #235, head `23b7a278a21f87d0623d499855a96b0f693b7c9d`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `claude/competent-tharp-252fd1`
- Labels: `chore`
- State: `MERGED`, merge commit `3bba669d5f93e10adc59b70d0efb9c574a1ee0fa`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #235 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `3bba669d5f93e10adc59b70d0efb9c574a1ee0fa`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
