### PR TITLE
[codex] Spring Boot 3/4 동기화 이탈 방지

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,6 +26,9 @@
 
 - [ ] 변경된 모듈의 `README.md` + `README.ko.md` 업데이트
 - [ ] 공개 API에 KDoc 추가
+- [ ] `spring-boot3/` 또는 `spring-boot4/` 모듈 추가/변경 시 양쪽 대칭 반영 확인
+- [ ] Spring Boot 4 모듈 변경 시 `Libs.spring_boot4_dependencies` BOM 적용 및 Spring Framework 7.x 호환성 확인
+- [ ] Spring Boot 3/4 모듈 변경 시 `.github/workflows/nightly-tests.yml`의 독립 test task 및 비-demo kover task 등록 확인
 - [ ] `worktree`에서 작업 후 PR 생성
 - [ ] `testing/mock-web-server` 변경 시 Docker 이미지 재빌드:
   `./gradlew :bluetape4k-mock-web-server:jibDockerBuild --no-configuration-cache`

--- a/.github/scripts/check-spring-boot-parity.py
+++ b/.github/scripts/check-spring-boot-parity.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Spring Boot 3/4 모듈 대칭성과 nightly 테스트 등록 상태를 검증한다."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+NIGHTLY_WORKFLOW = ROOT / ".github" / "workflows" / "nightly-tests.yml"
+
+
+def module_dirs(base: str) -> set[str]:
+    base_dir = ROOT / base
+    return {
+        child.name
+        for child in base_dir.iterdir()
+        if child.is_dir() and (child / "build.gradle.kts").is_file()
+    }
+
+
+def project_path(boot: str, module: str) -> str:
+    return f":bluetape4k-spring-boot{boot}-{module}"
+
+
+def main() -> int:
+    errors: list[str] = []
+    modules = {
+        "3": module_dirs("spring-boot3"),
+        "4": module_dirs("spring-boot4"),
+    }
+
+    only_boot3 = sorted(modules["3"] - modules["4"])
+    only_boot4 = sorted(modules["4"] - modules["3"])
+
+    if only_boot3:
+        errors.append(f"spring-boot3에만 있는 모듈: {', '.join(only_boot3)}")
+    if only_boot4:
+        errors.append(f"spring-boot4에만 있는 모듈: {', '.join(only_boot4)}")
+
+    for boot, module_names in modules.items():
+        bom_token = f"spring_boot{boot}_dependencies"
+        base = ROOT / f"spring-boot{boot}"
+        for module in sorted(module_names):
+            build_file = base / module / "build.gradle.kts"
+            if bom_token not in build_file.read_text(encoding="utf-8"):
+                errors.append(f"{build_file.relative_to(ROOT)}: Libs.{bom_token} BOM 적용 누락")
+
+    nightly = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
+    for boot, module_names in modules.items():
+        for module in sorted(module_names):
+            project = project_path(boot, module)
+            expected_test = f"{project}:test"
+            if expected_test not in nightly:
+                errors.append(f"{NIGHTLY_WORKFLOW.relative_to(ROOT)}: {expected_test} 등록 누락")
+
+            if not module.endswith("-demo"):
+                expected_kover = f"{project}:koverXmlReport"
+                if expected_kover not in nightly:
+                    errors.append(f"{NIGHTLY_WORKFLOW.relative_to(ROOT)}: {expected_kover} 등록 누락")
+
+    if errors:
+        print("Spring Boot 3/4 대칭성 검증 실패:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print(
+        "Spring Boot 3/4 대칭성 검증 성공: "
+        f"{len(modules['3'])}개 모듈 쌍, BOM, nightly test 등록 확인"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: gradle/actions/wrapper-validation@v4
 
+  # ── 1-b. Spring Boot 3/4 모듈 대칭성 검증 ─────────────────────────────────
+  spring-boot-parity:
+    name: Spring Boot 3/4 Parity
+    runs-on: ubuntu-latest
+    needs: validate-wrapper
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check Spring Boot 3/4 parity
+        run: python3 .github/scripts/check-spring-boot-parity.py
+
   # ── 2. 전체 빌드 (테스트 제외) ──────────────────────────────────────────
   build:
     name: Build
@@ -583,7 +593,7 @@ jobs:
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
-    needs: [gitleaks, build, test-core, test-io, test-key-utils, test-images-vips, test-infra, test-exposed-jdbc, coverage-report]
+    needs: [gitleaks, validate-wrapper, spring-boot-parity, build, test-core, test-io, test-key-utils, test-images-vips, test-infra, test-exposed-jdbc, coverage-report]
     if: always()
     steps:
       - name: Check all jobs
@@ -591,7 +601,7 @@ jobs:
           RESULTS: ${{ join(needs.*.result, ',') }}
         run: |
           echo "Job results: $RESULTS"
-          if echo "$RESULTS" | grep -qE "failure|cancelled"; then
+          if echo "$RESULTS" | grep -qE "failure|cancelled|skipped"; then
             echo "CI failed"
             exit 1
           fi

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -610,6 +610,10 @@ jobs:
             ./gradlew \
               :bluetape4k-spring-boot3-exposed-jdbc:test \
               :bluetape4k-spring-boot4-exposed-jdbc:test \
+              :bluetape4k-spring-boot3-exposed-jdbc-demo:test \
+              :bluetape4k-spring-boot4-exposed-jdbc-demo:test \
+              :bluetape4k-spring-boot3-exposed-r2dbc-demo:test \
+              :bluetape4k-spring-boot4-exposed-r2dbc-demo:test \
               --parallel
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
@@ -725,7 +729,7 @@ jobs:
           TEST_TASKS: ${{ matrix.test_tasks }}
 
       - name: Generate Kover XML report
-        if: always()
+        if: ${{ always() && matrix.kover_tasks != '' }}
         env:
           KOVER_TASKS: ${{ matrix.kover_tasks }}
         run: |
@@ -942,7 +946,7 @@ jobs:
           TEST_TASKS: ${{ matrix.test_tasks }}
 
       - name: Generate Kover XML report
-        if: always()
+        if: ${{ always() && matrix.kover_tasks != '' }}
         env:
           KOVER_TASKS: ${{ matrix.kover_tasks }}
         run: |
@@ -967,7 +971,7 @@ jobs:
           retention-days: 14
 
   # ── Spring Boot 3 Docker 테스트 — Matrix 병렬 ───────────────────────────
-  # 2 groups run in parallel on separate runners
+  # 3 groups run in parallel on separate runners
   test-spring3-docker:
     name: Test / Spring Boot 3 (${{ matrix.group }})
     runs-on: ubuntu-latest
@@ -998,6 +1002,11 @@ jobs:
               :bluetape4k-spring-boot3-mongodb:koverXmlReport
               :bluetape4k-spring-boot3-cassandra:koverXmlReport
               :bluetape4k-spring-boot3-hibernate-lettuce:koverXmlReport
+          - group: demos
+            test_tasks: >-
+              :bluetape4k-spring-boot3-cassandra-demo:test
+              :bluetape4k-spring-boot3-hibernate-lettuce-demo:test
+            kover_tasks: ""
     steps:
       - uses: actions/checkout@v4
 
@@ -1030,7 +1039,7 @@ jobs:
           TEST_TASKS: ${{ matrix.test_tasks }}
 
       - name: Generate Kover XML report
-        if: always()
+        if: ${{ always() && matrix.kover_tasks != '' }}
         env:
           KOVER_TASKS: ${{ matrix.kover_tasks }}
         run: |
@@ -1055,7 +1064,7 @@ jobs:
           retention-days: 14
 
   # ── Spring Boot 4 Docker 테스트 — Matrix 병렬 ───────────────────────────
-  # 2 groups run in parallel on separate runners
+  # 3 groups run in parallel on separate runners
   test-spring4-docker:
     name: Test / Spring Boot 4 (${{ matrix.group }})
     runs-on: ubuntu-latest
@@ -1086,6 +1095,11 @@ jobs:
               :bluetape4k-spring-boot4-mongodb:koverXmlReport
               :bluetape4k-spring-boot4-cassandra:koverXmlReport
               :bluetape4k-spring-boot4-hibernate-lettuce:koverXmlReport
+          - group: demos
+            test_tasks: >-
+              :bluetape4k-spring-boot4-cassandra-demo:test
+              :bluetape4k-spring-boot4-hibernate-lettuce-demo:test
+            kover_tasks: ""
     steps:
       - uses: actions/checkout@v4
 
@@ -1123,7 +1137,7 @@ jobs:
           TEST_TASKS: ${{ matrix.test_tasks }}
 
       - name: Generate Kover XML report
-        if: always()
+        if: ${{ always() && matrix.kover_tasks != '' }}
         env:
           KOVER_TASKS: ${{ matrix.kover_tasks }}
         run: |

--- a/TODO.md
+++ b/TODO.md
@@ -189,9 +189,9 @@
 - Issue: [#112](https://github.com/bluetape4k/bluetape4k-projects/issues/112)
 현재 13개 모듈 완벽 대칭 — 신규 모듈 추가 시 반드시 양쪽에 동시 구현:
 
-- [ ] 신규 모듈 추가 체크리스트 확립 (PR 템플릿에 반영)
-- [ ] Spring Boot 4 BOM 업데이트 추적 (Spring Framework 7.x 대응)
-- [ ] spring-boot4 모듈 독립 테스트 CI 구성 확인
+- [x] 신규 모듈 추가 체크리스트 확립 (PR 템플릿에 반영, 2026-04-29)
+- [x] Spring Boot 4 BOM 업데이트 추적 (Spring Framework 7.x 대응, `docs/spring-boot3-4-sync.md`)
+- [x] spring-boot4 모듈 독립 테스트 CI 구성 확인 (`Spring Boot 3/4 Parity` + nightly Spring Boot 4 job)
 
 ---
 

--- a/docs/spring-boot3-4-sync.md
+++ b/docs/spring-boot3-4-sync.md
@@ -1,0 +1,41 @@
+# Spring Boot 3 / 4 동기화 유지 정책
+
+Issue #112 기준으로 `spring-boot3/`와 `spring-boot4/`는 같은 하위 모듈 이름을 유지한다. 신규 모듈을 한쪽에만 추가하면 Spring Boot 3/4 사용자 경험이 갈라지므로 PR 단계에서 구조, BOM, CI 등록을 함께 확인한다.
+
+## 모듈 추가 체크리스트
+
+- `spring-boot3/{module}`와 `spring-boot4/{module}`를 동시에 추가한다.
+- 두 모듈 모두 `build.gradle.kts`, `README.md`, `README.ko.md`, 테스트 리소스를 같은 수준으로 둔다.
+- Gradle 프로젝트명은 `:bluetape4k-spring-boot3-{module}`와 `:bluetape4k-spring-boot4-{module}` 형식을 따른다.
+- Spring Boot 4 모듈은 `implementation(platform(Libs.spring_boot4_dependencies))`를 사용한다. 전역 `dependencyManagement`로 Spring Boot 4 BOM을 적용하지 않는다.
+- Spring Boot 4 소스에서 Spring Framework 7.x / Spring Data 4.x / Jakarta EE 11 패키지 또는 API 차이가 있으면 README나 KDoc에 의도를 남긴다.
+- 공통 기능을 한쪽에 먼저 구현한 경우 같은 PR 안에서 다른 쪽도 구현하거나, 의도적인 비대칭이면 PR 설명에 사유와 후속 이슈를 남긴다.
+
+## Spring Boot 4 BOM 업데이트 추적
+
+- 버전 위치: `buildSrc/src/main/kotlin/Libs.kt`
+  - `Plugins.Versions.spring_boot4`
+  - `Versions.spring_boot4`
+  - `Libs.spring_boot4_dependencies`
+- 업데이트 기준:
+  - Spring Boot 4 BOM이 관리하는 Spring Framework 7.x, Spring Data 4.x, Hibernate/Jakarta 계열 버전을 함께 확인한다.
+  - Spring Boot 4 모듈의 `resolutionStrategy` 강제 버전은 BOM으로 흡수 가능한지 업데이트 때마다 재검토한다.
+  - Spring Boot 3 전역 BOM이 Spring Boot 4 classpath를 낮추는지 `dependencyInsight` 또는 대상 모듈 테스트로 확인한다.
+- 권장 검증:
+  - `./bin/repo-test-summary -- ./gradlew :bluetape4k-spring-boot4-core:test`
+  - 변경 모듈별 `./bin/repo-test-summary -- ./gradlew :bluetape4k-spring-boot4-{module}:test`
+  - BOM 업데이트 PR에서는 nightly `Nightly Tests (Testcontainers)`를 `workflow_dispatch`로 실행한다.
+
+## CI 확인 결과
+
+- 일반 CI(`.github/workflows/ci.yml`)에는 `Spring Boot 3/4 Parity` job을 둔다.
+  - `.github/scripts/check-spring-boot-parity.py`가 `spring-boot3/`와 `spring-boot4/`의 하위 모듈 이름이 같은지 확인한다.
+  - 각 모듈의 `build.gradle.kts`가 대응 Spring Boot BOM을 적용하는지 확인한다.
+  - 모든 Spring Boot 3/4 모듈이 nightly `test` task에 등록되어 있는지 확인한다.
+  - 비-demo 모듈은 nightly `koverXmlReport` task에도 등록되어 있는지 확인한다.
+- nightly CI(`.github/workflows/nightly-tests.yml`)는 Spring Boot 4를 독립 job으로 실행한다.
+  - H2 기반 모듈은 `Test / Spring Boot (H2)`에서 Spring Boot 3/4를 나란히 실행한다.
+  - Docker/Testcontainers가 필요한 모듈은 `Test / Spring Boot 4 (...)` matrix job에서 Spring Boot 3 job과 분리 실행한다.
+  - Spring Boot 4 job은 `mock-web-server`와 `mock-webflux-server` 이미지를 별도로 빌드한 뒤 테스트한다.
+
+2026-04-29 확인 기준으로 `spring-boot3/`와 `spring-boot4/`는 각각 13개 모듈이 같은 이름으로 존재하며, 모든 모듈의 nightly `test` 등록과 비-demo 모듈의 `koverXmlReport` 등록을 CI 스크립트가 검증한다.


### PR DESCRIPTION
## Summary

Closes #112

- PR 제목: [codex] Spring Boot 3/4 동기화 이탈 방지

- Spring Boot 3/4 하위 모듈 이름, BOM 적용, nightly 테스트 등록을 검증하는 CI job을 추가했습니다.
- demo 모듈은 test 등록만 확인하고, 비-demo 모듈은 koverXmlReport 등록까지 확인하도록 했습니다.
- PR 템플릿과 동기화 정책 문서, TODO를 Issue #112 기준으로 갱신했습니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 영향

- spring-boot3/4 모듈 추가 또는 변경 시 한쪽만 반영되는 실수를 CI에서 조기에 차단합니다.
- nightly workflow에서 coverage task가 없는 demo matrix는 kover 단계를 건너뜁니다.

### 기존 섹션: 참고

- Related: #112
- GitHub Actions 전체 workflow는 PR에서 확인합니다.

## Validation

- [x] `python3 .github/scripts/check-spring-boot-parity.py`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #112, milestone 없음, assignee 없음
- PR: #238, head `abe3a52e7382cb465068d00b0287f6ee63f992be`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `issue-112-sb3-sb4-sync`
- Labels: `build`
- State: `MERGED`, merge commit `caa43f3472455798392cdc31fe3129d0a9584659`
- CI: - Spring Boot 3/4 하위 모듈 이름, BOM 적용, nightly 테스트 등록을 검증하는 CI job을 추가했습니다. / - spring-boot3/4 모듈 추가 또는 변경 시 한쪽만 반영되는 실수를 CI에서 조기에 차단합니다.

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #238 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `caa43f3472455798392cdc31fe3129d0a9584659`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
