### PR TITLE
feat: probabilistic Bloom Filter 직접 구현 추가

### DIFF
--- a/docs/superpowers/plans/2026-04-29-utils-probabilistic-bloomfilter-plan.md
+++ b/docs/superpowers/plans/2026-04-29-utils-probabilistic-bloomfilter-plan.md
@@ -1,0 +1,114 @@
+# utils/probabilistic Bloom Filter 구현 계획
+
+Spec: `docs/superpowers/specs/2026-04-29-utils-probabilistic-bloomfilter-design.md`
+Issue: #142
+
+## T1. 신규 모듈 골격 추가
+
+- complexity: medium
+- expected files:
+  - `utils/probabilistic/build.gradle.kts`
+  - `utils/probabilistic/src/main/kotlin/io/bluetape4k/probabilistic/...`
+  - `utils/probabilistic/src/test/kotlin/io/bluetape4k/probabilistic/...`
+- work:
+  - `:probabilistic` 자동 include 구조에 맞춰 `utils/probabilistic` 생성
+  - Guava, core, coroutines compileOnly/test 의존성 추가
+- verification:
+  - `./bin/repo-test-summary -- ./gradlew :probabilistic:compileKotlin`
+- docs impact:
+  - 신규 모듈 README 필요
+  - 신규 durable convention은 기존 repo 규칙으로 충분해 AGENTS.md 추가는 불필요
+
+## T2. Bloom Filter 공개 계약과 생성 DSL 구현
+
+- complexity: high
+- expected files:
+  - `BloomFilter.kt`
+  - `MutableBloomFilter.kt`
+  - `SuspendBloomFilter.kt`
+  - `BloomFilterConfig.kt`
+  - `BloomFilters.kt`
+- work:
+  - `expectedInsertions`, `falsePositiveProbability`, `mightContain`, `put`, `approximateElementCount`, `expectedFpp` 계약 정의
+  - `bloomFilter`, `mutableBloomFilter`, `suspendBloomFilter` DSL 구현
+  - `expectedInsertions > 0`, `fpp in (0, 1)` 검증
+- verification:
+  - `./bin/repo-test-summary -- ./gradlew :probabilistic:compileKotlin`
+- docs impact:
+  - 공개 API KDoc 한국어 작성
+
+## T3. Guava 기반 인메모리 구현 작성
+
+- complexity: high
+- expected files:
+  - `bloomfilter/GuavaBloomFilter.kt`
+  - `bloomfilter/InMemoryBloomFilter.kt`
+  - `bloomfilter/InMemoryMutableBloomFilter.kt`
+  - `bloomfilter/InMemorySuspendBloomFilter.kt`
+- work:
+  - Guava `BloomFilter<T>` wrapper 구현
+  - `putAll` 호환성 검증 후 병합
+  - Issue 명시 클래스명 discoverability 제공
+  - suspend wrapper는 dispatcher 전환 없이 메모리 연산만 위임
+- verification:
+  - `./bin/repo-test-summary -- ./gradlew :probabilistic:compileKotlin :probabilistic:compileTestKotlin`
+- docs impact:
+  - README에 `put` 반환값, FPP, `putAll` compatibility, suspend 제약 기록
+
+## T4. 테스트 작성
+
+- complexity: medium
+- expected files:
+  - `BloomFilterConfigTest.kt`
+  - `InMemoryBloomFilterTest.kt`
+  - `InMemorySuspendBloomFilterTest.kt`
+- work:
+  - 입력 검증 회귀 테스트
+  - 삽입 원소 false negative 없음 검증
+  - 관측 FPP가 설정값을 과도하게 넘지 않는지 검증
+  - `putAll` 성공/실패 계약 검증
+  - `runTest` suspend API 검증
+- verification:
+  - `./bin/repo-test-summary -- ./gradlew :probabilistic:test`
+- docs impact:
+  - 테스트명은 한글/계약 중심으로 작성
+
+## T5. README 작성
+
+- complexity: low
+- expected files:
+  - `utils/probabilistic/README.md`
+  - `utils/probabilistic/README.ko.md`
+- work:
+  - 설치/의존성, DSL 예시, suspend 예시, FPP/제한 사항 문서화
+  - Redis 구현은 `infra/lettuce`를 사용하라고 안내
+- verification:
+  - Markdown 링크/코드 블록 육안 검토
+- docs impact:
+  - README.md / README.ko.md 신규 작성
+
+## T6. 검증, 리뷰, 커밋/PR
+
+- complexity: medium
+- expected files:
+  - spec/plan
+  - implementation/docs/test files
+- work:
+  - targeted compile/test 실행
+  - Step 4-S/4-P 조건 판단 및 필요 시 cleanup/perf scan
+  - Step 5 verifier 체크
+  - Step 6-R 6개 리뷰 티어 수행
+  - Lore trailer 포함 커밋, push, PR 생성
+- verification:
+  - `./bin/repo-test-summary -- ./gradlew :probabilistic:test`
+  - `./bin/repo-test-summary -- ./gradlew :probabilistic:compileKotlin :probabilistic:compileTestKotlin`
+- docs impact:
+  - `docs/superpowers/index`는 현 repo에 없음. superpowers index 업데이트는 N/A로 기록
+
+## Pre-Implementation Risk Mitigations
+
+- Guava `put` 반환값을 "신규 확정"으로 문서화하지 않는다.
+- `putAll`은 Guava `isCompatible` 체크 후 수행한다.
+- FPP 테스트는 큰 1M 샘플 대신 deterministic 10k/20k 규모로 구성해 CI 시간을 제한한다.
+- suspend API는 메모리 연산임을 KDoc/README에 반복 기록한다.
+- 공개 API는 `Any` bound를 사용하고, hash/funnel 책임은 caller가 넘긴 `Funnel`에 둔다.

--- a/docs/superpowers/plans/2026-04-29-utils-probabilistic-bloomfilter-plan.md
+++ b/docs/superpowers/plans/2026-04-29-utils-probabilistic-bloomfilter-plan.md
@@ -11,11 +11,11 @@ Issue: #142
   - `utils/probabilistic/src/main/kotlin/io/bluetape4k/probabilistic/...`
   - `utils/probabilistic/src/test/kotlin/io/bluetape4k/probabilistic/...`
 - work:
-  - `:probabilistic` 자동 include 구조에 맞춰 `utils/probabilistic` 생성
+  - `:bluetape4k-probabilistic` 자동 include 구조에 맞춰 `utils/probabilistic` 생성
   - core, coroutines compileOnly/test 의존성 추가
   - Guava/Eclipse Collections 의존성은 추가하지 않음
 - verification:
-  - `./bin/repo-test-summary -- ./gradlew :probabilistic:compileKotlin`
+  - `./bin/repo-test-summary -- ./gradlew :bluetape4k-probabilistic:compileKotlin`
 - docs impact:
   - 신규 모듈 README 필요
   - 신규 durable convention은 기존 repo 규칙으로 충분해 AGENTS.md 추가는 불필요
@@ -36,7 +36,7 @@ Issue: #142
   - `expectedInsertions > 0`, `fpp in (0, 1)` 검증
   - 기본 hash 전략 작성
 - verification:
-  - `./bin/repo-test-summary -- ./gradlew :probabilistic:compileKotlin`
+  - `./bin/repo-test-summary -- ./gradlew :bluetape4k-probabilistic:compileKotlin`
 - docs impact:
   - 공개 API KDoc 한국어 작성
 
@@ -54,7 +54,7 @@ Issue: #142
   - `putAll` 호환성 검증 후 bitset 병합
   - suspend wrapper는 dispatcher 전환 없이 메모리 연산만 위임
 - verification:
-  - `./bin/repo-test-summary -- ./gradlew :probabilistic:compileKotlin :probabilistic:compileTestKotlin`
+  - `./bin/repo-test-summary -- ./gradlew :bluetape4k-probabilistic:compileKotlin :bluetape4k-probabilistic:compileTestKotlin`
 - docs impact:
   - README에 `put` 반환값, FPP, `putAll` compatibility, thread-safe 비보장, suspend 제약 기록
 
@@ -73,7 +73,7 @@ Issue: #142
   - `putAll` 성공/실패 계약 검증
   - `runTest` suspend API 검증
 - verification:
-  - `./bin/repo-test-summary -- ./gradlew :probabilistic:test`
+  - `./bin/repo-test-summary -- ./gradlew :bluetape4k-probabilistic:test`
 - docs impact:
   - 테스트명은 한글/계약 중심으로 작성
 
@@ -105,8 +105,8 @@ Issue: #142
   - Step 6-R 6개 리뷰 티어 수행
   - Lore trailer 포함 커밋, push, PR 생성
 - verification:
-  - `./bin/repo-test-summary -- ./gradlew :probabilistic:test`
-  - `./bin/repo-test-summary -- ./gradlew :probabilistic:compileKotlin :probabilistic:compileTestKotlin`
+  - `./bin/repo-test-summary -- ./gradlew :bluetape4k-probabilistic:test`
+  - `./bin/repo-test-summary -- ./gradlew :bluetape4k-probabilistic:compileKotlin :bluetape4k-probabilistic:compileTestKotlin`
 - docs impact:
   - `docs/superpowers/index`는 현 repo에 없음. superpowers index 업데이트는 N/A로 기록
 

--- a/docs/superpowers/plans/2026-04-29-utils-probabilistic-bloomfilter-plan.md
+++ b/docs/superpowers/plans/2026-04-29-utils-probabilistic-bloomfilter-plan.md
@@ -12,7 +12,8 @@ Issue: #142
   - `utils/probabilistic/src/test/kotlin/io/bluetape4k/probabilistic/...`
 - work:
   - `:probabilistic` 자동 include 구조에 맞춰 `utils/probabilistic` 생성
-  - Guava, core, coroutines compileOnly/test 의존성 추가
+  - core, coroutines compileOnly/test 의존성 추가
+  - Guava/Eclipse Collections 의존성은 추가하지 않음
 - verification:
   - `./bin/repo-test-summary -- ./gradlew :probabilistic:compileKotlin`
 - docs impact:
@@ -28,32 +29,34 @@ Issue: #142
   - `SuspendBloomFilter.kt`
   - `BloomFilterConfig.kt`
   - `BloomFilters.kt`
+  - `BloomHasher.kt`
 - work:
-  - `expectedInsertions`, `falsePositiveProbability`, `mightContain`, `put`, `approximateElementCount`, `expectedFpp` 계약 정의
+  - `expectedInsertions`, `falsePositiveProbability`, `bitSize`, `hashFunctionCount`, `mightContain`, `put`, `approximateElementCount`, `expectedFpp`, `clear` 계약 정의
   - `bloomFilter`, `mutableBloomFilter`, `suspendBloomFilter` DSL 구현
   - `expectedInsertions > 0`, `fpp in (0, 1)` 검증
+  - 기본 hash 전략 작성
 - verification:
   - `./bin/repo-test-summary -- ./gradlew :probabilistic:compileKotlin`
 - docs impact:
   - 공개 API KDoc 한국어 작성
 
-## T3. Guava 기반 인메모리 구현 작성
+## T3. JDK/Kotlin 기반 인메모리 구현 작성
 
 - complexity: high
 - expected files:
-  - `bloomfilter/GuavaBloomFilter.kt`
   - `bloomfilter/InMemoryBloomFilter.kt`
   - `bloomfilter/InMemoryMutableBloomFilter.kt`
   - `bloomfilter/InMemorySuspendBloomFilter.kt`
+  - `bloomfilter/BloomFilterMath.kt`
 - work:
-  - Guava `BloomFilter<T>` wrapper 구현
-  - `putAll` 호환성 검증 후 병합
-  - Issue 명시 클래스명 discoverability 제공
+  - `LongArray` bitset 구현
+  - SHA-256 double hashing offset 생성
+  - `putAll` 호환성 검증 후 bitset 병합
   - suspend wrapper는 dispatcher 전환 없이 메모리 연산만 위임
 - verification:
   - `./bin/repo-test-summary -- ./gradlew :probabilistic:compileKotlin :probabilistic:compileTestKotlin`
 - docs impact:
-  - README에 `put` 반환값, FPP, `putAll` compatibility, suspend 제약 기록
+  - README에 `put` 반환값, FPP, `putAll` compatibility, thread-safe 비보장, suspend 제약 기록
 
 ## T4. 테스트 작성
 
@@ -64,6 +67,7 @@ Issue: #142
   - `InMemorySuspendBloomFilterTest.kt`
 - work:
   - 입력 검증 회귀 테스트
+  - bit size/hash count 계산 검증
   - 삽입 원소 false negative 없음 검증
   - 관측 FPP가 설정값을 과도하게 넘지 않는지 검증
   - `putAll` 성공/실패 계약 검증
@@ -82,6 +86,7 @@ Issue: #142
 - work:
   - 설치/의존성, DSL 예시, suspend 예시, FPP/제한 사항 문서화
   - Redis 구현은 `infra/lettuce`를 사용하라고 안내
+  - Guava/Eclipse Collections 미사용을 명시
 - verification:
   - Markdown 링크/코드 블록 육안 검토
 - docs impact:
@@ -107,8 +112,9 @@ Issue: #142
 
 ## Pre-Implementation Risk Mitigations
 
-- Guava `put` 반환값을 "신규 확정"으로 문서화하지 않는다.
-- `putAll`은 Guava `isCompatible` 체크 후 수행한다.
+- Guava/Eclipse Collections 의존성을 추가하지 않는다.
+- `put` 반환값을 "신규 확정"으로 문서화하지 않는다.
+- `putAll`은 직접 구현의 config/hash compatibility 체크 후 수행한다.
 - FPP 테스트는 큰 1M 샘플 대신 deterministic 10k/20k 규모로 구성해 CI 시간을 제한한다.
+- SHA-256 `MessageDigest`는 ThreadLocal로 재사용해 hot-path 객체 생성을 줄인다.
 - suspend API는 메모리 연산임을 KDoc/README에 반복 기록한다.
-- 공개 API는 `Any` bound를 사용하고, hash/funnel 책임은 caller가 넘긴 `Funnel`에 둔다.

--- a/docs/superpowers/specs/2026-04-29-utils-probabilistic-bloomfilter-design.md
+++ b/docs/superpowers/specs/2026-04-29-utils-probabilistic-bloomfilter-design.md
@@ -12,65 +12,64 @@ Issue #142는 `x-obsoleted/bloomfilter`에 남아 있는 JVM 인메모리 Bloom 
 - 패키지 루트: `io.bluetape4k.probabilistic`
 - 1차 범위: Bloom Filter API와 인메모리 구현
 - 제외 범위: Redis Lua/Redisson/Lettuce 구현, Cuckoo Filter 구현
+- Guava, Eclipse Collections 등 신규 컬렉션/확률 자료구조 의존성을 추가하지 않는다.
 - 공개 API는 한국어 KDoc을 제공한다.
 - README.md / README.ko.md에 사용 예시와 제약을 기록한다.
 - 기존 `x-obsoleted/bloomfilter`는 삭제하지 않고 참조 구현으로 둔다.
-- Guava가 제공하는 `writeTo/readFrom` 직렬화 API는 1차 공개 API 범위에서 제외한다.
 
 ## Step 1-R 연구 요약
 
-- Guava 공식 `BloomFilter` API는 `create(funnel, expectedInsertions, fpp)`, `put`, `mightContain`, `expectedFpp`, `approximateElementCount`, `writeTo/readFrom`을 제공한다.
-- Guava 문서는 예상 삽입 수보다 훨씬 많은 원소를 넣으면 필터 포화로 FPP가 급격히 악화될 수 있음을 명시한다.
-- repo에는 `Libs.guava`가 이미 `buildSrc/src/main/kotlin/Libs.kt`에 정의되어 있고 root dependency management에도 포함되어 있다.
+- `x-obsoleted/bloomfilter`는 직접 Murmur3/BitSet 기반 구현을 제공한다. 다만 `zero-allocation-hashing`, serializer 의존이 있고 mutable 구현은 `String` 전용이라 그대로 승격하지 않는다.
 - `infra/lettuce`의 `BloomFilterOptions`는 `expectedInsertions > 0`, `falseProbability in (0, 1)` 입력 검증 계약을 이미 사용한다.
-- `x-obsoleted/bloomfilter`는 직접 Murmur3/BitSet 구현을 제공하지만 serializer/zero-allocation-hashing 의존과 자체 해시 offset 수식을 갖고 있어 신규 모듈의 1차 안정 구현으로는 리스크가 더 크다.
+- repo에는 `Libs.guava`, `Libs.eclipse_collections`가 이미 있으나, 사용자 결정에 따라 이번 모듈에는 사용하지 않는다.
+- Eclipse Collections는 primitive collections를 제공하지만 Bloom Filter 자체나 JVM `BitSet`보다 이 작업에 더 적합한 bit-level 저장소를 제공하지 않는다.
+- JDK/Kotlin만으로도 `LongArray` 기반 bitset과 SHA-256 double hashing을 사용해 안정적인 Bloom Filter를 구현할 수 있다.
 
 ## 설계 옵션
 
-### 옵션 A: Guava BloomFilter 래퍼
+### 옵션 A: JDK/Kotlin 직접 구현
 
-Guava의 검증된 BloomFilter를 내부 구현으로 사용하고 bluetape4k용 인터페이스/DSL/suspend wrapper를 제공한다.
+`LongArray` bitset, SHA-256 기반 double hashing, Bloom Filter 수식으로 `m`/`k`를 계산하는 구현을 신규 모듈에 작성한다.
 
 장점:
-- 해시 전략, bit size 계산, 직렬화 형식이 검증된 구현에 위임된다.
-- 신규 모듈 구현량과 유지보수 리스크가 낮다.
-- Issue의 "Guava BloomFilter 래퍼 또는 직접 구현" 중 1차 구현 의도와 맞다.
+- 신규 외부 의존성이 없다.
+- 공개 API가 Guava/Eclipse Collections 타입에 묶이지 않는다.
+- 기존 `x-obsoleted`의 직접 구현 의도를 유지하면서 serializer/hash 라이브러리 의존을 제거한다.
 
 단점:
-- Guava `Funnel`을 공개 생성 API에 노출해야 한다.
-- `expectedInsertions`/`fpp`는 생성 시점 계약이며 실제 삽입 수 강제는 하지 않는다.
+- Guava처럼 battle-tested 구현을 위임하지 않으므로 수식/bitset/hash 테스트가 중요하다.
+- SHA-256은 Murmur3보다 느릴 수 있다.
 
 ### 옵션 B: x-obsoleted 직접 구현 패키지 승격
 
 기존 `Hasher`, `BitSet`, `LongArray` 기반 구현을 새 패키지로 옮긴다.
 
 장점:
-- 외부 Guava API 노출 없이 완전한 bluetape4k 구현을 제공할 수 있다.
-- 기존 테스트 일부를 거의 그대로 이전할 수 있다.
+- 기존 코드와 테스트 일부를 거의 그대로 이전할 수 있다.
 
 단점:
-- 기존 mutable 구현은 `String` 전용이고 bucket/lock 로직의 정확성 검증 비용이 크다.
-- serializer와 zero-allocation-hashing 의존이 필요해 신규 유틸 모듈의 표면이 넓어진다.
-- Guava가 이미 제공하는 검증된 기능을 다시 유지보수해야 한다.
+- `zero-allocation-hashing`과 serialization 의존이 남는다.
+- 기존 mutable 구현은 `String` 전용이고 bucket/lock 로직 검증 비용이 크다.
+- 기존 해시 offset 수식은 double hashing 표준 형태보다 검토하기 어렵다.
 
-### 옵션 C: Guava 래퍼 + 직접 구현 내부 백업
+### 옵션 C: Eclipse Collections 내부 저장소 사용
 
-공개 API는 Guava 래퍼로 제공하고, 향후 최적화를 위해 내부 해시/비트셋 유틸을 함께 둔다.
+Eclipse Collections primitive collections를 내부 bit/index 저장소로 사용한다.
 
 장점:
-- 향후 Guava 제거나 성능 최적화 여지가 생긴다.
+- 이미 repo dependency catalog에 존재한다.
 
 단점:
-- 당장 쓰지 않는 코드가 추가되어 테스트/문서/검토 비용이 증가한다.
-- 직접 구현과 Guava 구현의 동작 차이를 계속 맞춰야 한다.
+- Bloom Filter에 필요한 compact bitset에는 `LongArray`가 더 직접적이고 메모리 효율적이다.
+- 신규 모듈 공개/내부 의존성을 늘리는 이점이 없다.
 
 ## 결정
 
-옵션 A를 채택한다. 신규 `utils/probabilistic`는 Guava 기반 1차 구현으로 시작하고, 기존 직접 구현의 수식/테스트 관점만 차용한다.
+옵션 A를 채택한다. `utils/probabilistic`는 Guava/Eclipse Collections 없이 직접 구현한다. 기존 `x-obsoleted` 구현에서는 API 의도, 테스트 관점, Bloom Filter 수식만 차용하고 의존성/해시 구현은 새로 단순화한다.
 
 Rejected:
-- 옵션 B: 검증된 Guava 구현을 대체할 만큼의 성능/의존성 이점이 현재 요구사항에 없다.
-- 옵션 C: 사용하지 않는 내부 구현을 같이 승격하면 신규 모듈의 유지보수 표면이 불필요하게 커진다.
+- 옵션 B: 기존 구현 전체 승격은 불필요한 외부 의존과 String 전용 mutable 구현을 함께 승격한다.
+- 옵션 C: Eclipse Collections는 이 작업의 핵심인 bit-level Bloom Filter 저장소 문제를 더 단순하게 만들지 않는다.
 
 ## API 설계
 
@@ -78,10 +77,13 @@ Rejected:
 interface BloomFilter<T: Any> {
     val expectedInsertions: Long
     val falsePositiveProbability: Double
+    val bitSize: Long
+    val hashFunctionCount: Int
     fun mightContain(element: T): Boolean
     fun put(element: T): Boolean
     fun approximateElementCount(): Long
     fun expectedFpp(): Double
+    fun clear()
 }
 
 interface MutableBloomFilter<T: Any>: BloomFilter<T> {
@@ -91,42 +93,49 @@ interface MutableBloomFilter<T: Any>: BloomFilter<T> {
 interface SuspendBloomFilter<T: Any> {
     val expectedInsertions: Long
     val falsePositiveProbability: Double
+    val bitSize: Long
+    val hashFunctionCount: Int
     suspend fun mightContain(element: T): Boolean
     suspend fun put(element: T): Boolean
     suspend fun approximateElementCount(): Long
     suspend fun expectedFpp(): Double
+    suspend fun clear()
 }
 ```
 
 생성 DSL:
 
 ```kotlin
-val filter = bloomFilter(
+val filter = bloomFilter<String>(
     expectedInsertions = 1_000_000L,
     fpp = 0.01,
-) {
-    Funnels.stringFunnel(Charsets.UTF_8)
-}
+)
 ```
 
 구현 클래스:
 
-- `GuavaBloomFilter<T>`: Guava `com.google.common.hash.BloomFilter<T>` 래퍼
-- `GuavaSuspendBloomFilter<T>`: `GuavaBloomFilter<T>`에 suspend 계약을 입히는 메모리 연산 wrapper
-- `BloomFilterConfig`: `expectedInsertions`, `falsePositiveProbability` 입력 검증을 한 곳에 모은 value/data class
-- `putAll`은 동일한 Guava strategy/bit size/funnel 기반 필터끼리만 허용하고, 호환되지 않으면 `IllegalArgumentException`으로 실패한다.
+- `InMemoryBloomFilter<T>`: `LongArray` bitset 기반 Bloom Filter
+- `InMemoryMutableBloomFilter<T>`: `putAll` 병합이 가능한 동일 구현 alias/클래스
+- `InMemorySuspendBloomFilter<T>`: `InMemoryBloomFilter<T>`에 suspend 계약을 입히는 메모리 연산 wrapper
+- `BloomFilterConfig`: `expectedInsertions`, `falsePositiveProbability` 입력 검증과 `bitSize`, `hashFunctionCount` 계산
+- `BloomHasher<T>`: element를 hash bytes로 변환하는 전략
+- `DefaultBloomHasher`: `String`, `Int`, `Long`, `ByteArray`, `Serializable`, fallback `toString()`을 지원하는 기본 hasher
 
-호환 alias:
+## 내부 구현
 
-- Issue 명시 이름과 discoverability를 위해 `InMemoryBloomFilter<T>` / `InMemorySuspendBloomFilter<T>` typealias 또는 얇은 클래스를 제공한다.
-- `InMemoryMutableBloomFilter`는 "삭제 가능한 mutable"이 아니라 Guava의 `putAll` 가능한 mutable 의미로 제공한다. 삭제는 Bloom Filter 특성상 1차 범위에서 지원하지 않는다.
+- `bitSize = ceil(-n * ln(p) / ln(2)^2)`
+- `hashFunctionCount = max(1, round((bitSize / n) * ln(2)))`
+- SHA-256 digest에서 두 개의 64-bit 값을 뽑고 `hash1 + i * hash2` double hashing으로 offset을 생성한다.
+- bitset은 `LongArray((bitSize + 63) / 64)`로 저장한다.
+- `put`은 하나 이상의 bit가 새로 켜졌으면 `true`, 모두 이미 켜져 있으면 `false`를 반환한다. `false`는 "이미 존재 확정"이 아니라 Bloom Filter 특성상 "이미 존재할 가능성"이다.
+- `putAll`은 `bitSize`, `hashFunctionCount`, `expectedInsertions`, `falsePositiveProbability`가 같은 직접 구현끼리만 허용한다.
+- 기본 구현은 thread-safe를 보장하지 않는다. 동시 접근이 필요하면 호출자가 외부 동기화를 제공해야 한다.
 
 ## 모듈/의존성
 
 `utils/probabilistic/build.gradle.kts`
 
 - `api(project(":bluetape4k-core"))`
-- `api(Libs.guava)`
 - `compileOnly(Libs.kotlinx_coroutines_core)`
 - `testImplementation(project(":bluetape4k-junit5"))`
 - `testImplementation(Libs.kotlinx_coroutines_test)`
@@ -135,17 +144,18 @@ val filter = bloomFilter(
 
 | Risk | Impact | Mitigation |
 |------|--------|------------|
-| Guava `Funnel` 직렬화/동등성 계약을 사용자가 잘못 이해 | compatible merge/serialization 실패 | README와 KDoc에 동일 Funnel 필요성을 명시 |
-| `put` 반환값이 "신규 원소 확정"으로 오해됨 | 호출자가 중복 검출을 과신 | `put`은 bit 변경 여부이며 false면 이미 존재 확정이 아님을 KDoc에 기록 |
-| 예상 삽입 수 초과로 FPP 악화 | 운영 오탐률 상승 | `expectedFpp()`/README로 모니터링 가능성을 안내하고 테스트로 설정 FPP 근방 검증 |
-| suspend API가 I/O 비동기 처리로 오해됨 | 불필요한 dispatcher 전환 기대 | KDoc에 현재 구현은 비블로킹 메모리 연산이라고 명시 |
-| `InMemoryMutableBloomFilter` 이름이 삭제 지원처럼 보임 | API 오용 | 삭제 API를 노출하지 않고 `putAll` 의미의 mutable로 제한, README에 Counting Bloom Filter 아님을 기록 |
-| Guava 직렬화 API를 노출하면 Funnel 직렬화 호환성이 공개 계약이 됨 | 장기 호환성 부담 | 1차 구현에서는 직렬화 API를 공개하지 않고 내부 래퍼의 멤버십 계약만 제공 |
+| 직접 구현 수식 오류 | FPP/메모리 사용량 오류 | `BloomFilterConfig` 단위 테스트로 bit size/hash count 범위 검증 |
+| hash offset 편향 | FPP 악화 | SHA-256 double hashing과 deterministic FPP 회귀 테스트 사용 |
+| `put` 반환값 오해 | 호출자가 중복 검출을 과신 | KDoc/README에 bit 변경 여부라고 명시 |
+| 예상 삽입 수 초과로 FPP 악화 | 운영 오탐률 상승 | `expectedFpp()`와 README 제약 문서화 |
+| suspend API가 I/O 비동기 처리로 오해됨 | 불필요한 dispatcher 전환 기대 | 현재 구현은 비블로킹 메모리 연산이라고 명시 |
+| 동시 접근 오해 | 데이터 경합 | thread-safe 비보장과 외부 동기화 필요성을 KDoc/README에 기록 |
 
 ## Acceptance Criteria
 
 - `:probabilistic` 모듈이 Gradle에 자동 포함되고 컴파일된다.
-- `BloomFilter`, `MutableBloomFilter`, `SuspendBloomFilter` 공개 계약과 Guava 기반 인메모리 구현이 제공된다.
+- Guava/Eclipse Collections 신규 의존성 없이 Bloom Filter 직접 구현이 제공된다.
+- `BloomFilter`, `MutableBloomFilter`, `SuspendBloomFilter` 공개 계약과 인메모리 구현이 제공된다.
 - `bloomFilter` / `suspendBloomFilter` DSL 생성 함수가 동작한다.
 - 입력 검증은 `expectedInsertions > 0`, `fpp in (0, 1)`을 보장한다.
 - 삽입한 원소는 `mightContain == true`를 만족한다.
@@ -166,7 +176,7 @@ val filter = bloomFilter(
 ## Draft Task List
 
 1. 신규 모듈 골격과 Gradle 의존성 추가
-2. Bloom Filter 공개 API/DSL/Guava 래퍼 구현
-3. 입력 검증, FPP, suspend wrapper 테스트 작성
+2. Bloom Filter 공개 API/DSL/직접 구현 작성
+3. 입력 검증, bitset/hash/FPP, suspend wrapper 테스트 작성
 4. README.md / README.ko.md 작성
 5. targeted compile/test 및 리뷰 게이트 수행

--- a/docs/superpowers/specs/2026-04-29-utils-probabilistic-bloomfilter-design.md
+++ b/docs/superpowers/specs/2026-04-29-utils-probabilistic-bloomfilter-design.md
@@ -8,7 +8,7 @@ Issue #142는 `x-obsoleted/bloomfilter`에 남아 있는 JVM 인메모리 Bloom 
 
 ## 요구사항
 
-- 신규 모듈: `utils/probabilistic` (`:probabilistic`)
+- 신규 모듈: `utils/probabilistic` (`:bluetape4k-probabilistic`)
 - 패키지 루트: `io.bluetape4k.probabilistic`
 - 1차 범위: Bloom Filter API와 인메모리 구현
 - 제외 범위: Redis Lua/Redisson/Lettuce 구현, Cuckoo Filter 구현
@@ -153,7 +153,7 @@ val filter = bloomFilter<String>(
 
 ## Acceptance Criteria
 
-- `:probabilistic` 모듈이 Gradle에 자동 포함되고 컴파일된다.
+- `:bluetape4k-probabilistic` 모듈이 Gradle에 자동 포함되고 컴파일된다.
 - Guava/Eclipse Collections 신규 의존성 없이 Bloom Filter 직접 구현이 제공된다.
 - `BloomFilter`, `MutableBloomFilter`, `SuspendBloomFilter` 공개 계약과 인메모리 구현이 제공된다.
 - `bloomFilter` / `suspendBloomFilter` DSL 생성 함수가 동작한다.
@@ -166,8 +166,8 @@ val filter = bloomFilter<String>(
 
 ## DoD
 
-- `./bin/repo-test-summary -- ./gradlew :probabilistic:test` 통과
-- `./bin/repo-test-summary -- ./gradlew :probabilistic:compileKotlin :probabilistic:compileTestKotlin` 통과
+- `./bin/repo-test-summary -- ./gradlew :bluetape4k-probabilistic:test` 통과
+- `./bin/repo-test-summary -- ./gradlew :bluetape4k-probabilistic:compileKotlin :bluetape4k-probabilistic:compileTestKotlin` 통과
 - 공개 API 한국어 KDoc 작성
 - Step 6-R 6개 리뷰 티어 수행
 - Lore commit trailer를 포함한 커밋 작성

--- a/docs/superpowers/specs/2026-04-29-utils-probabilistic-bloomfilter-design.md
+++ b/docs/superpowers/specs/2026-04-29-utils-probabilistic-bloomfilter-design.md
@@ -1,0 +1,172 @@
+# utils/probabilistic Bloom Filter 승격 설계
+
+## 배경
+
+Issue #142는 `x-obsoleted/bloomfilter`에 남아 있는 JVM 인메모리 Bloom Filter 기능 중 Redis 의존이 없는 구현만 선별해 `utils/probabilistic` 신규 모듈로 승격하는 작업이다.
+
+현재 `infra/lettuce`에는 Redis BitSet/Lua 기반 분산 Bloom/Cuckoo Filter 구현이 있으나, 캐시 stampede 방지, 중복 방문 추적, 스팸 URL 후보 검사처럼 단일 JVM 안에서 빠르게 사용할 확률적 멤버십 자료구조가 필요하다.
+
+## 요구사항
+
+- 신규 모듈: `utils/probabilistic` (`:probabilistic`)
+- 패키지 루트: `io.bluetape4k.probabilistic`
+- 1차 범위: Bloom Filter API와 인메모리 구현
+- 제외 범위: Redis Lua/Redisson/Lettuce 구현, Cuckoo Filter 구현
+- 공개 API는 한국어 KDoc을 제공한다.
+- README.md / README.ko.md에 사용 예시와 제약을 기록한다.
+- 기존 `x-obsoleted/bloomfilter`는 삭제하지 않고 참조 구현으로 둔다.
+- Guava가 제공하는 `writeTo/readFrom` 직렬화 API는 1차 공개 API 범위에서 제외한다.
+
+## Step 1-R 연구 요약
+
+- Guava 공식 `BloomFilter` API는 `create(funnel, expectedInsertions, fpp)`, `put`, `mightContain`, `expectedFpp`, `approximateElementCount`, `writeTo/readFrom`을 제공한다.
+- Guava 문서는 예상 삽입 수보다 훨씬 많은 원소를 넣으면 필터 포화로 FPP가 급격히 악화될 수 있음을 명시한다.
+- repo에는 `Libs.guava`가 이미 `buildSrc/src/main/kotlin/Libs.kt`에 정의되어 있고 root dependency management에도 포함되어 있다.
+- `infra/lettuce`의 `BloomFilterOptions`는 `expectedInsertions > 0`, `falseProbability in (0, 1)` 입력 검증 계약을 이미 사용한다.
+- `x-obsoleted/bloomfilter`는 직접 Murmur3/BitSet 구현을 제공하지만 serializer/zero-allocation-hashing 의존과 자체 해시 offset 수식을 갖고 있어 신규 모듈의 1차 안정 구현으로는 리스크가 더 크다.
+
+## 설계 옵션
+
+### 옵션 A: Guava BloomFilter 래퍼
+
+Guava의 검증된 BloomFilter를 내부 구현으로 사용하고 bluetape4k용 인터페이스/DSL/suspend wrapper를 제공한다.
+
+장점:
+- 해시 전략, bit size 계산, 직렬화 형식이 검증된 구현에 위임된다.
+- 신규 모듈 구현량과 유지보수 리스크가 낮다.
+- Issue의 "Guava BloomFilter 래퍼 또는 직접 구현" 중 1차 구현 의도와 맞다.
+
+단점:
+- Guava `Funnel`을 공개 생성 API에 노출해야 한다.
+- `expectedInsertions`/`fpp`는 생성 시점 계약이며 실제 삽입 수 강제는 하지 않는다.
+
+### 옵션 B: x-obsoleted 직접 구현 패키지 승격
+
+기존 `Hasher`, `BitSet`, `LongArray` 기반 구현을 새 패키지로 옮긴다.
+
+장점:
+- 외부 Guava API 노출 없이 완전한 bluetape4k 구현을 제공할 수 있다.
+- 기존 테스트 일부를 거의 그대로 이전할 수 있다.
+
+단점:
+- 기존 mutable 구현은 `String` 전용이고 bucket/lock 로직의 정확성 검증 비용이 크다.
+- serializer와 zero-allocation-hashing 의존이 필요해 신규 유틸 모듈의 표면이 넓어진다.
+- Guava가 이미 제공하는 검증된 기능을 다시 유지보수해야 한다.
+
+### 옵션 C: Guava 래퍼 + 직접 구현 내부 백업
+
+공개 API는 Guava 래퍼로 제공하고, 향후 최적화를 위해 내부 해시/비트셋 유틸을 함께 둔다.
+
+장점:
+- 향후 Guava 제거나 성능 최적화 여지가 생긴다.
+
+단점:
+- 당장 쓰지 않는 코드가 추가되어 테스트/문서/검토 비용이 증가한다.
+- 직접 구현과 Guava 구현의 동작 차이를 계속 맞춰야 한다.
+
+## 결정
+
+옵션 A를 채택한다. 신규 `utils/probabilistic`는 Guava 기반 1차 구현으로 시작하고, 기존 직접 구현의 수식/테스트 관점만 차용한다.
+
+Rejected:
+- 옵션 B: 검증된 Guava 구현을 대체할 만큼의 성능/의존성 이점이 현재 요구사항에 없다.
+- 옵션 C: 사용하지 않는 내부 구현을 같이 승격하면 신규 모듈의 유지보수 표면이 불필요하게 커진다.
+
+## API 설계
+
+```kotlin
+interface BloomFilter<T: Any> {
+    val expectedInsertions: Long
+    val falsePositiveProbability: Double
+    fun mightContain(element: T): Boolean
+    fun put(element: T): Boolean
+    fun approximateElementCount(): Long
+    fun expectedFpp(): Double
+}
+
+interface MutableBloomFilter<T: Any>: BloomFilter<T> {
+    fun putAll(other: MutableBloomFilter<T>)
+}
+
+interface SuspendBloomFilter<T: Any> {
+    val expectedInsertions: Long
+    val falsePositiveProbability: Double
+    suspend fun mightContain(element: T): Boolean
+    suspend fun put(element: T): Boolean
+    suspend fun approximateElementCount(): Long
+    suspend fun expectedFpp(): Double
+}
+```
+
+생성 DSL:
+
+```kotlin
+val filter = bloomFilter(
+    expectedInsertions = 1_000_000L,
+    fpp = 0.01,
+) {
+    Funnels.stringFunnel(Charsets.UTF_8)
+}
+```
+
+구현 클래스:
+
+- `GuavaBloomFilter<T>`: Guava `com.google.common.hash.BloomFilter<T>` 래퍼
+- `GuavaSuspendBloomFilter<T>`: `GuavaBloomFilter<T>`에 suspend 계약을 입히는 메모리 연산 wrapper
+- `BloomFilterConfig`: `expectedInsertions`, `falsePositiveProbability` 입력 검증을 한 곳에 모은 value/data class
+- `putAll`은 동일한 Guava strategy/bit size/funnel 기반 필터끼리만 허용하고, 호환되지 않으면 `IllegalArgumentException`으로 실패한다.
+
+호환 alias:
+
+- Issue 명시 이름과 discoverability를 위해 `InMemoryBloomFilter<T>` / `InMemorySuspendBloomFilter<T>` typealias 또는 얇은 클래스를 제공한다.
+- `InMemoryMutableBloomFilter`는 "삭제 가능한 mutable"이 아니라 Guava의 `putAll` 가능한 mutable 의미로 제공한다. 삭제는 Bloom Filter 특성상 1차 범위에서 지원하지 않는다.
+
+## 모듈/의존성
+
+`utils/probabilistic/build.gradle.kts`
+
+- `api(project(":bluetape4k-core"))`
+- `api(Libs.guava)`
+- `compileOnly(Libs.kotlinx_coroutines_core)`
+- `testImplementation(project(":bluetape4k-junit5"))`
+- `testImplementation(Libs.kotlinx_coroutines_test)`
+
+## 리스크와 대응
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Guava `Funnel` 직렬화/동등성 계약을 사용자가 잘못 이해 | compatible merge/serialization 실패 | README와 KDoc에 동일 Funnel 필요성을 명시 |
+| `put` 반환값이 "신규 원소 확정"으로 오해됨 | 호출자가 중복 검출을 과신 | `put`은 bit 변경 여부이며 false면 이미 존재 확정이 아님을 KDoc에 기록 |
+| 예상 삽입 수 초과로 FPP 악화 | 운영 오탐률 상승 | `expectedFpp()`/README로 모니터링 가능성을 안내하고 테스트로 설정 FPP 근방 검증 |
+| suspend API가 I/O 비동기 처리로 오해됨 | 불필요한 dispatcher 전환 기대 | KDoc에 현재 구현은 비블로킹 메모리 연산이라고 명시 |
+| `InMemoryMutableBloomFilter` 이름이 삭제 지원처럼 보임 | API 오용 | 삭제 API를 노출하지 않고 `putAll` 의미의 mutable로 제한, README에 Counting Bloom Filter 아님을 기록 |
+| Guava 직렬화 API를 노출하면 Funnel 직렬화 호환성이 공개 계약이 됨 | 장기 호환성 부담 | 1차 구현에서는 직렬화 API를 공개하지 않고 내부 래퍼의 멤버십 계약만 제공 |
+
+## Acceptance Criteria
+
+- `:probabilistic` 모듈이 Gradle에 자동 포함되고 컴파일된다.
+- `BloomFilter`, `MutableBloomFilter`, `SuspendBloomFilter` 공개 계약과 Guava 기반 인메모리 구현이 제공된다.
+- `bloomFilter` / `suspendBloomFilter` DSL 생성 함수가 동작한다.
+- 입력 검증은 `expectedInsertions > 0`, `fpp in (0, 1)`을 보장한다.
+- 삽입한 원소는 `mightContain == true`를 만족한다.
+- 미삽입 원소 집합의 관측 FPP가 설정값을 과도하게 넘지 않는다.
+- 호환 가능한 필터끼리 `putAll` 병합이 가능하고, 호환되지 않는 필터 병합은 명시적으로 실패한다.
+- suspend API는 `runTest`로 검증된다.
+- README.md / README.ko.md에 사용법, FPP, 제한 사항이 기록된다.
+
+## DoD
+
+- `./bin/repo-test-summary -- ./gradlew :probabilistic:test` 통과
+- `./bin/repo-test-summary -- ./gradlew :probabilistic:compileKotlin :probabilistic:compileTestKotlin` 통과
+- 공개 API 한국어 KDoc 작성
+- Step 6-R 6개 리뷰 티어 수행
+- Lore commit trailer를 포함한 커밋 작성
+- Issue #142를 닫는 PR 생성
+
+## Draft Task List
+
+1. 신규 모듈 골격과 Gradle 의존성 추가
+2. Bloom Filter 공개 API/DSL/Guava 래퍼 구현
+3. 입력 검증, FPP, suspend wrapper 테스트 작성
+4. README.md / README.ko.md 작성
+5. targeted compile/test 및 리뷰 게이트 수행

--- a/utils/probabilistic/README.ko.md
+++ b/utils/probabilistic/README.ko.md
@@ -1,0 +1,51 @@
+# bluetape4k Probabilistic
+
+JVM 애플리케이션에서 사용할 인메모리 확률적 자료구조 모듈입니다.
+
+현재는 외부 Bloom Filter 구현 의존성 없이 직접 구현한 Bloom Filter를 제공합니다. 내부 구현에 Guava 또는 Eclipse Collections를 사용하지 않습니다.
+
+## Gradle
+
+```kotlin
+dependencies {
+    implementation(project(":bluetape4k-probabilistic"))
+}
+```
+
+## Bloom Filter
+
+```kotlin
+import io.bluetape4k.probabilistic.bloomfilter.bloomFilter
+
+val filter = bloomFilter<String>(
+    expectedInsertions = 1_000_000L,
+    fpp = 0.01,
+)
+
+if (!filter.mightContain(url)) {
+    filter.put(url)
+    crawl(url)
+}
+```
+
+## Coroutine API
+
+```kotlin
+import io.bluetape4k.probabilistic.bloomfilter.suspendBloomFilter
+
+val filter = suspendBloomFilter<String>(expectedInsertions = 100_000L, fpp = 0.01)
+
+filter.put("https://example.com")
+val exists = filter.mightContain("https://example.com")
+```
+
+suspend 구현은 현재 I/O 없는 인메모리 연산입니다. 별도 dispatcher 전환을 수행하지 않습니다.
+
+## 주의 사항
+
+- `mightContain(false)`는 미포함을 보장합니다.
+- `mightContain(true)`는 포함 가능성만 의미하며 오탐이 발생할 수 있습니다.
+- `put(false)`는 대상 bit가 이미 모두 켜져 있었다는 뜻입니다. 원소가 이전에 삽입되었음을 증명하지 않습니다.
+- 기본 구현은 thread-safe가 아닙니다. 동시 쓰기가 필요하면 호출자가 외부에서 동기화해야 합니다.
+- `putAll`은 같은 설정과 hasher로 생성된 호환 필터끼리만 병합합니다.
+- Redis 기반 분산 필터가 필요하면 `infra/lettuce`를 사용하세요.

--- a/utils/probabilistic/README.md
+++ b/utils/probabilistic/README.md
@@ -1,0 +1,51 @@
+# bluetape4k Probabilistic
+
+In-memory probabilistic data structures for JVM applications.
+
+This module currently provides a dependency-free Bloom Filter implementation. It does not use Guava or Eclipse Collections internally.
+
+## Gradle
+
+```kotlin
+dependencies {
+    implementation(project(":bluetape4k-probabilistic"))
+}
+```
+
+## Bloom Filter
+
+```kotlin
+import io.bluetape4k.probabilistic.bloomfilter.bloomFilter
+
+val filter = bloomFilter<String>(
+    expectedInsertions = 1_000_000L,
+    fpp = 0.01,
+)
+
+if (!filter.mightContain(url)) {
+    filter.put(url)
+    crawl(url)
+}
+```
+
+## Coroutine API
+
+```kotlin
+import io.bluetape4k.probabilistic.bloomfilter.suspendBloomFilter
+
+val filter = suspendBloomFilter<String>(expectedInsertions = 100_000L, fpp = 0.01)
+
+filter.put("https://example.com")
+val exists = filter.mightContain("https://example.com")
+```
+
+The suspend implementation is still an in-memory, non-blocking operation. It does not switch dispatchers.
+
+## Notes
+
+- `mightContain(false)` means the element is definitely absent.
+- `mightContain(true)` means the element may exist; false positives are possible.
+- `put(false)` means all target bits were already set. It does not prove the element was previously inserted.
+- The implementation is not thread-safe. Synchronize externally for concurrent writes.
+- `putAll` only merges filters created with compatible settings and hashers.
+- For distributed Redis-backed filters, use `infra/lettuce`.

--- a/utils/probabilistic/build.gradle.kts
+++ b/utils/probabilistic/build.gradle.kts
@@ -1,0 +1,11 @@
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    api(project(":bluetape4k-core"))
+    testImplementation(project(":bluetape4k-junit5"))
+
+    compileOnly(Libs.kotlinx_coroutines_core)
+    testImplementation(Libs.kotlinx_coroutines_test)
+}

--- a/utils/probabilistic/src/main/kotlin/io/bluetape4k/probabilistic/bloomfilter/BloomFilter.kt
+++ b/utils/probabilistic/src/main/kotlin/io/bluetape4k/probabilistic/bloomfilter/BloomFilter.kt
@@ -1,0 +1,63 @@
+package io.bluetape4k.probabilistic.bloomfilter
+
+/**
+ * Bloom Filter는 원소가 집합에 포함될 가능성을 빠르게 검사하는 확률적 자료구조입니다.
+ *
+ * ## 동작/계약
+ * - [mightContain]이 `false`이면 미포함이 보장됩니다.
+ * - [mightContain]이 `true`이면 포함 가능성이 있으며 오탐(false positive)이 발생할 수 있습니다.
+ * - 삭제는 지원하지 않습니다.
+ * - 구현체는 기본적으로 thread-safe를 보장하지 않습니다.
+ *
+ * @param T 필터에 넣을 원소 타입
+ */
+interface BloomFilter<T: Any> {
+
+    /** 필터 생성 시 가정한 예상 삽입 원소 수입니다. */
+    val expectedInsertions: Long
+
+    /** 필터 생성 시 목표로 한 오탐률입니다. */
+    val falsePositiveProbability: Double
+
+    /** 내부 bitset 크기입니다. */
+    val bitSize: Long
+
+    /** 원소 하나당 계산하는 해시 offset 개수입니다. */
+    val hashFunctionCount: Int
+
+    /** 현재 켜진 bit 개수입니다. */
+    val bitCount: Long
+
+    /** 필터가 비어 있는지 여부입니다. */
+    val isEmpty: Boolean get() = bitCount == 0L
+
+    /**
+     * 원소 포함 가능성을 검사합니다.
+     *
+     * @return 미포함이 확정이면 `false`, 포함 가능성이 있으면 `true`
+     */
+    fun mightContain(element: T): Boolean
+
+    /**
+     * 원소를 필터에 추가합니다.
+     *
+     * @return 하나 이상의 bit가 새로 켜졌으면 `true`, 모든 bit가 이미 켜져 있으면 `false`.
+     * `false`는 이미 존재 확정이 아니라 Bloom Filter 특성상 이미 존재할 가능성입니다.
+     */
+    fun put(element: T): Boolean
+
+    /**
+     * 현재 bit 포화도를 기준으로 삽입 원소 수를 근사 계산합니다.
+     */
+    fun approximateElementCount(): Long
+
+    /**
+     * 현재 bit 포화도를 기준으로 기대 오탐률을 계산합니다.
+     */
+    fun expectedFpp(): Double
+
+    /**
+     * 필터 상태를 초기화합니다.
+     */
+    fun clear()
+}

--- a/utils/probabilistic/src/main/kotlin/io/bluetape4k/probabilistic/bloomfilter/BloomFilterConfig.kt
+++ b/utils/probabilistic/src/main/kotlin/io/bluetape4k/probabilistic/bloomfilter/BloomFilterConfig.kt
@@ -1,0 +1,73 @@
+package io.bluetape4k.probabilistic.bloomfilter
+
+import io.bluetape4k.support.requireGt
+import io.bluetape4k.support.requireLt
+import io.bluetape4k.support.requirePositiveNumber
+import kotlin.math.ceil
+import kotlin.math.ln
+import kotlin.math.max
+import kotlin.math.pow
+import kotlin.math.roundToInt
+
+private const val DEFAULT_EXPECTED_INSERTIONS = 1_000_000L
+private const val DEFAULT_FALSE_POSITIVE_PROBABILITY = 0.03
+private const val MAX_SUPPORTED_BIT_SIZE = Int.MAX_VALUE.toLong() * Long.SIZE_BITS
+private val LN_2 = ln(2.0)
+private val LN_2_SQUARED = LN_2 * LN_2
+
+/**
+ * Bloom Filter 생성 설정입니다.
+ *
+ * @property expectedInsertions 예상 삽입 원소 수. 0보다 커야 합니다.
+ * @property falsePositiveProbability 목표 오탐률. `(0, 1)` 배타 구간만 허용합니다.
+ */
+data class BloomFilterConfig(
+    val expectedInsertions: Long = DEFAULT_EXPECTED_INSERTIONS,
+    val falsePositiveProbability: Double = DEFAULT_FALSE_POSITIVE_PROBABILITY,
+) {
+
+    /** 계산된 bitset 크기입니다. */
+    val bitSize: Long
+
+    /** 계산된 해시 함수 개수입니다. */
+    val hashFunctionCount: Int
+
+    init {
+        expectedInsertions.requirePositiveNumber("expectedInsertions")
+        falsePositiveProbability.requireGt(0.0, "falsePositiveProbability")
+        falsePositiveProbability.requireLt(1.0, "falsePositiveProbability")
+
+        val calculatedBitSize = optimalBitSize(expectedInsertions, falsePositiveProbability)
+        require(calculatedBitSize <= MAX_SUPPORTED_BIT_SIZE) {
+            "bitSize must be less than or equal to $MAX_SUPPORTED_BIT_SIZE"
+        }
+
+        bitSize = calculatedBitSize
+        hashFunctionCount = optimalHashFunctionCount(expectedInsertions, calculatedBitSize)
+    }
+}
+
+internal fun optimalBitSize(expectedInsertions: Long, fpp: Double): Long =
+    ceil(-expectedInsertions.toDouble() * ln(fpp) / LN_2_SQUARED).toLong()
+
+internal fun optimalHashFunctionCount(expectedInsertions: Long, bitSize: Long): Int =
+    max(1, ((bitSize.toDouble() / expectedInsertions.toDouble()) * LN_2).roundToInt())
+
+internal fun expectedFpp(bitCount: Long, bitSize: Long, hashFunctionCount: Int): Double {
+    if (bitCount <= 0L) {
+        return 0.0
+    }
+    val fillRatio = bitCount.toDouble() / bitSize.toDouble()
+    return fillRatio.pow(hashFunctionCount.toDouble())
+}
+
+internal fun approximateElementCount(bitCount: Long, bitSize: Long, hashFunctionCount: Int): Long {
+    if (bitCount <= 0L) {
+        return 0L
+    }
+    if (bitCount >= bitSize) {
+        return Long.MAX_VALUE
+    }
+    val fraction = 1.0 - bitCount.toDouble() / bitSize.toDouble()
+    return ceil(-(bitSize.toDouble() / hashFunctionCount.toDouble()) * ln(fraction)).toLong()
+}

--- a/utils/probabilistic/src/main/kotlin/io/bluetape4k/probabilistic/bloomfilter/BloomFilters.kt
+++ b/utils/probabilistic/src/main/kotlin/io/bluetape4k/probabilistic/bloomfilter/BloomFilters.kt
@@ -1,0 +1,35 @@
+package io.bluetape4k.probabilistic.bloomfilter
+
+/**
+ * 인메모리 Bloom Filter를 생성합니다.
+ *
+ * @param expectedInsertions 예상 삽입 원소 수
+ * @param fpp 목표 오탐률
+ * @param hasher 원소를 hash 입력 byte 배열로 변환하는 전략
+ */
+fun <T: Any> bloomFilter(
+    expectedInsertions: Long = 1_000_000L,
+    fpp: Double = 0.03,
+    hasher: BloomHasher<T> = DefaultBloomHasher,
+): InMemoryBloomFilter<T> =
+    InMemoryBloomFilter(BloomFilterConfig(expectedInsertions, fpp), hasher)
+
+/**
+ * 병합 가능한 인메모리 Bloom Filter를 생성합니다.
+ */
+fun <T: Any> mutableBloomFilter(
+    expectedInsertions: Long = 1_000_000L,
+    fpp: Double = 0.03,
+    hasher: BloomHasher<T> = DefaultBloomHasher,
+): InMemoryMutableBloomFilter<T> =
+    InMemoryMutableBloomFilter(BloomFilterConfig(expectedInsertions, fpp), hasher)
+
+/**
+ * suspend API를 제공하는 인메모리 Bloom Filter를 생성합니다.
+ */
+fun <T: Any> suspendBloomFilter(
+    expectedInsertions: Long = 1_000_000L,
+    fpp: Double = 0.03,
+    hasher: BloomHasher<T> = DefaultBloomHasher,
+): InMemorySuspendBloomFilter<T> =
+    InMemorySuspendBloomFilter(BloomFilterConfig(expectedInsertions, fpp), hasher)

--- a/utils/probabilistic/src/main/kotlin/io/bluetape4k/probabilistic/bloomfilter/BloomHasher.kt
+++ b/utils/probabilistic/src/main/kotlin/io/bluetape4k/probabilistic/bloomfilter/BloomHasher.kt
@@ -1,0 +1,97 @@
+package io.bluetape4k.probabilistic.bloomfilter
+
+import java.io.ByteArrayOutputStream
+import java.io.ObjectOutputStream
+import java.io.Serializable
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+/**
+ * Bloom Filter 원소를 안정적인 byte 배열로 변환하는 전략입니다.
+ *
+ * 같은 원소는 항상 같은 byte 배열을 반환해야 하며, [InMemoryBloomFilter.putAll] 병합 대상 필터는 같은 hasher를 사용해야 합니다.
+ */
+fun interface BloomHasher<in T: Any> {
+    /** 원소를 hash 입력 byte 배열로 변환합니다. */
+    fun bytes(element: T): ByteArray
+}
+
+/**
+ * 기본 Bloom Filter hash 입력 변환기입니다.
+ *
+ * `String`, `Int`, `Long`, `ByteArray`, [Serializable]을 직접 지원하고, 나머지는 `toString()` 결과를 UTF-8로 변환합니다.
+ */
+object DefaultBloomHasher: BloomHasher<Any> {
+
+    override fun bytes(element: Any): ByteArray = when (element) {
+        is String       -> element.toByteArray(StandardCharsets.UTF_8)
+        is Int          -> element.toBytes()
+        is Long         -> element.toBytes()
+        is ByteArray    -> element
+        is Serializable -> serializeOrString(element)
+        else            -> element.toString().toByteArray(StandardCharsets.UTF_8)
+    }
+
+    private fun serializeOrString(element: Serializable): ByteArray =
+        runCatching { serialize(element) }
+            .getOrElse { element.toString().toByteArray(StandardCharsets.UTF_8) }
+
+    private fun serialize(element: Serializable): ByteArray {
+        val out = ByteArrayOutputStream()
+        ObjectOutputStream(out).use { it.writeObject(element) }
+        return out.toByteArray()
+    }
+
+    private fun Int.toBytes(): ByteArray =
+        byteArrayOf(
+            (this ushr 24).toByte(),
+            (this ushr 16).toByte(),
+            (this ushr 8).toByte(),
+            this.toByte(),
+        )
+
+    private fun Long.toBytes(): ByteArray =
+        byteArrayOf(
+            (this ushr 56).toByte(),
+            (this ushr 48).toByte(),
+            (this ushr 40).toByte(),
+            (this ushr 32).toByte(),
+            (this ushr 24).toByte(),
+            (this ushr 16).toByte(),
+            (this ushr 8).toByte(),
+            this.toByte(),
+        )
+}
+
+internal object BloomHashSupport {
+
+    private const val HASH_ALGORITHM = "SHA-256"
+    private val digestThreadLocal = ThreadLocal.withInitial { MessageDigest.getInstance(HASH_ALGORITHM) }
+
+    fun indexes(bytes: ByteArray, hashFunctionCount: Int, bitSize: Long): LongArray {
+        val digest = digestThreadLocal.get()
+        digest.reset()
+        val hash = digest.digest(bytes)
+        val hash1 = hash.longAt(0)
+        val hash2 = hash.longAt(8).let { if (it == 0L) 0x9E3779B97F4A7C15UL.toLong() else it }
+
+        return LongArray(hashFunctionCount) { index ->
+            (hash1 + index * hash2).floorMod(bitSize)
+        }
+    }
+
+    private fun ByteArray.longAt(offset: Int): Long =
+        ((this[offset].toLong() and 0xFFL) shl 56) or
+            ((this[offset + 1].toLong() and 0xFFL) shl 48) or
+            ((this[offset + 2].toLong() and 0xFFL) shl 40) or
+            ((this[offset + 3].toLong() and 0xFFL) shl 32) or
+            ((this[offset + 4].toLong() and 0xFFL) shl 24) or
+            ((this[offset + 5].toLong() and 0xFFL) shl 16) or
+            ((this[offset + 6].toLong() and 0xFFL) shl 8) or
+            (this[offset + 7].toLong() and 0xFFL)
+
+    private fun Long.floorMod(modulus: Long): Long {
+        val result = this % modulus
+        return if (result >= 0) result else result + modulus
+    }
+}

--- a/utils/probabilistic/src/main/kotlin/io/bluetape4k/probabilistic/bloomfilter/InMemoryBloomFilter.kt
+++ b/utils/probabilistic/src/main/kotlin/io/bluetape4k/probabilistic/bloomfilter/InMemoryBloomFilter.kt
@@ -1,0 +1,104 @@
+package io.bluetape4k.probabilistic.bloomfilter
+
+import java.util.Arrays
+
+/**
+ * JDK/Kotlin만 사용해 구현한 인메모리 Bloom Filter입니다.
+ *
+ * ## 동작/계약
+ * - 내부 저장소는 [LongArray] bitset입니다.
+ * - 해시 offset은 SHA-256 기반 double hashing으로 계산합니다.
+ * - thread-safe를 보장하지 않으므로 동시 쓰기가 필요하면 외부에서 동기화해야 합니다.
+ */
+open class InMemoryBloomFilter<T: Any>(
+    private val config: BloomFilterConfig = BloomFilterConfig(),
+    private val hasher: BloomHasher<T> = DefaultBloomHasher,
+): MutableBloomFilter<T> {
+
+    override val expectedInsertions: Long = config.expectedInsertions
+    override val falsePositiveProbability: Double = config.falsePositiveProbability
+    override val bitSize: Long = config.bitSize
+    override val hashFunctionCount: Int = config.hashFunctionCount
+
+    private val words = LongArray(wordSize(bitSize))
+    private var activeBitCount: Long = 0L
+
+    override val bitCount: Long
+        get() = activeBitCount
+
+    override fun mightContain(element: T): Boolean {
+        val indexes = indexes(element)
+        return indexes.all { getBit(it) }
+    }
+
+    override fun put(element: T): Boolean {
+        val indexes = indexes(element)
+        var changed = false
+
+        indexes.forEach { index ->
+            if (setBit(index)) {
+                changed = true
+                activeBitCount++
+            }
+        }
+        return changed
+    }
+
+    override fun putAll(other: MutableBloomFilter<T>) {
+        require(other is InMemoryBloomFilter<T>) {
+            "other must be InMemoryBloomFilter"
+        }
+        require(isCompatible(other)) {
+            "BloomFilter config or hasher is not compatible"
+        }
+
+        words.indices.forEach { i ->
+            words[i] = words[i] or other.words[i]
+        }
+        activeBitCount = words.sumOf { it.countOneBits().toLong() }
+    }
+
+    override fun approximateElementCount(): Long =
+        approximateElementCount(bitCount, bitSize, hashFunctionCount)
+
+    override fun expectedFpp(): Double =
+        expectedFpp(bitCount, bitSize, hashFunctionCount)
+
+    override fun clear() {
+        Arrays.fill(words, 0L)
+        activeBitCount = 0L
+    }
+
+    internal fun isCompatible(other: InMemoryBloomFilter<*>): Boolean =
+        expectedInsertions == other.expectedInsertions &&
+            falsePositiveProbability == other.falsePositiveProbability &&
+            bitSize == other.bitSize &&
+            hashFunctionCount == other.hashFunctionCount &&
+            hasher == other.hasher &&
+            words.size == other.words.size
+
+    private fun indexes(element: T): LongArray =
+        BloomHashSupport.indexes(hasher.bytes(element), hashFunctionCount, bitSize)
+
+    private fun getBit(index: Long): Boolean {
+        val wordIndex = (index ushr WORD_SHIFT).toInt()
+        val mask = 1L shl (index and WORD_MASK).toInt()
+        return words[wordIndex] and mask != 0L
+    }
+
+    private fun setBit(index: Long): Boolean {
+        val wordIndex = (index ushr WORD_SHIFT).toInt()
+        val mask = 1L shl (index and WORD_MASK).toInt()
+        val before = words[wordIndex]
+        words[wordIndex] = before or mask
+        return before and mask == 0L
+    }
+
+    private companion object {
+        private const val WORD_SHIFT = 6
+        private const val WORD_MASK = 63L
+
+        private fun wordSize(bitSize: Long): Int =
+            ((bitSize + Long.SIZE_BITS - 1) / Long.SIZE_BITS).toInt()
+    }
+}

--- a/utils/probabilistic/src/main/kotlin/io/bluetape4k/probabilistic/bloomfilter/InMemoryMutableBloomFilter.kt
+++ b/utils/probabilistic/src/main/kotlin/io/bluetape4k/probabilistic/bloomfilter/InMemoryMutableBloomFilter.kt
@@ -1,0 +1,11 @@
+package io.bluetape4k.probabilistic.bloomfilter
+
+/**
+ * 병합 가능한 인메모리 Bloom Filter입니다.
+ *
+ * 삭제 가능한 Counting Bloom Filter가 아니라 [InMemoryBloomFilter]와 같은 bitset OR 병합 구현입니다.
+ */
+class InMemoryMutableBloomFilter<T: Any>(
+    config: BloomFilterConfig = BloomFilterConfig(),
+    hasher: BloomHasher<T> = DefaultBloomHasher,
+): InMemoryBloomFilter<T>(config, hasher)

--- a/utils/probabilistic/src/main/kotlin/io/bluetape4k/probabilistic/bloomfilter/InMemorySuspendBloomFilter.kt
+++ b/utils/probabilistic/src/main/kotlin/io/bluetape4k/probabilistic/bloomfilter/InMemorySuspendBloomFilter.kt
@@ -1,0 +1,47 @@
+package io.bluetape4k.probabilistic.bloomfilter
+
+/**
+ * [InMemoryBloomFilter]를 suspend API로 노출하는 인메모리 Bloom Filter입니다.
+ *
+ * 현재 구현은 dispatcher 전환이나 I/O 없이 delegate의 메모리 연산을 즉시 수행합니다.
+ */
+class InMemorySuspendBloomFilter<T: Any>(
+    private val delegate: InMemoryBloomFilter<T> = InMemoryBloomFilter(),
+): SuspendBloomFilter<T> {
+
+    constructor(
+        config: BloomFilterConfig = BloomFilterConfig(),
+        hasher: BloomHasher<T> = DefaultBloomHasher,
+    ): this(InMemoryBloomFilter(config, hasher))
+
+    override val expectedInsertions: Long
+        get() = delegate.expectedInsertions
+
+    override val falsePositiveProbability: Double
+        get() = delegate.falsePositiveProbability
+
+    override val bitSize: Long
+        get() = delegate.bitSize
+
+    override val hashFunctionCount: Int
+        get() = delegate.hashFunctionCount
+
+    override val bitCount: Long
+        get() = delegate.bitCount
+
+    override suspend fun mightContain(element: T): Boolean =
+        delegate.mightContain(element)
+
+    override suspend fun put(element: T): Boolean =
+        delegate.put(element)
+
+    override suspend fun approximateElementCount(): Long =
+        delegate.approximateElementCount()
+
+    override suspend fun expectedFpp(): Double =
+        delegate.expectedFpp()
+
+    override suspend fun clear() {
+        delegate.clear()
+    }
+}

--- a/utils/probabilistic/src/main/kotlin/io/bluetape4k/probabilistic/bloomfilter/MutableBloomFilter.kt
+++ b/utils/probabilistic/src/main/kotlin/io/bluetape4k/probabilistic/bloomfilter/MutableBloomFilter.kt
@@ -1,0 +1,16 @@
+package io.bluetape4k.probabilistic.bloomfilter
+
+/**
+ * 동일한 설정의 Bloom Filter를 병합할 수 있는 mutable Bloom Filter 계약입니다.
+ *
+ * 삭제 가능한 Counting Bloom Filter가 아니며, [putAll]은 같은 hash/config를 가진 필터의 bitset을 OR 병합합니다.
+ */
+interface MutableBloomFilter<T: Any>: BloomFilter<T> {
+
+    /**
+     * 다른 Bloom Filter의 bitset을 현재 필터로 병합합니다.
+     *
+     * 구현체가 서로 호환되지 않으면 [IllegalArgumentException]을 던집니다.
+     */
+    fun putAll(other: MutableBloomFilter<T>)
+}

--- a/utils/probabilistic/src/main/kotlin/io/bluetape4k/probabilistic/bloomfilter/SuspendBloomFilter.kt
+++ b/utils/probabilistic/src/main/kotlin/io/bluetape4k/probabilistic/bloomfilter/SuspendBloomFilter.kt
@@ -1,0 +1,46 @@
+package io.bluetape4k.probabilistic.bloomfilter
+
+/**
+ * 코루틴 호출 지점에서 사용할 수 있는 Bloom Filter 계약입니다.
+ *
+ * 현재 인메모리 구현은 I/O를 수행하지 않는 비블로킹 메모리 연산이며, dispatcher 전환을 수행하지 않습니다.
+ */
+interface SuspendBloomFilter<T: Any> {
+
+    /** 필터 생성 시 가정한 예상 삽입 원소 수입니다. */
+    val expectedInsertions: Long
+
+    /** 필터 생성 시 목표로 한 오탐률입니다. */
+    val falsePositiveProbability: Double
+
+    /** 내부 bitset 크기입니다. */
+    val bitSize: Long
+
+    /** 원소 하나당 계산하는 해시 offset 개수입니다. */
+    val hashFunctionCount: Int
+
+    /** 현재 켜진 bit 개수입니다. */
+    val bitCount: Long
+
+    /** 필터가 비어 있는지 여부입니다. */
+    val isEmpty: Boolean get() = bitCount == 0L
+
+    /** 원소 포함 가능성을 검사합니다. */
+    suspend fun mightContain(element: T): Boolean
+
+    /**
+     * 원소를 필터에 추가합니다.
+     *
+     * @return 하나 이상의 bit가 새로 켜졌으면 `true`
+     */
+    suspend fun put(element: T): Boolean
+
+    /** 현재 bit 포화도를 기준으로 삽입 원소 수를 근사 계산합니다. */
+    suspend fun approximateElementCount(): Long
+
+    /** 현재 bit 포화도를 기준으로 기대 오탐률을 계산합니다. */
+    suspend fun expectedFpp(): Double
+
+    /** 필터 상태를 초기화합니다. */
+    suspend fun clear()
+}

--- a/utils/probabilistic/src/test/kotlin/io/bluetape4k/probabilistic/bloomfilter/BloomFilterConfigTest.kt
+++ b/utils/probabilistic/src/test/kotlin/io/bluetape4k/probabilistic/bloomfilter/BloomFilterConfigTest.kt
@@ -1,0 +1,42 @@
+package io.bluetape4k.probabilistic.bloomfilter
+
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeInRange
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class BloomFilterConfigTest {
+
+    @Test
+    fun `expectedInsertions 는 양수여야 한다`() {
+        assertThrows<IllegalArgumentException> {
+            BloomFilterConfig(expectedInsertions = 0L)
+        }
+    }
+
+    @Test
+    fun `falsePositiveProbability 는 0과 1 사이여야 한다`() {
+        assertThrows<IllegalArgumentException> {
+            BloomFilterConfig(falsePositiveProbability = 0.0)
+        }
+        assertThrows<IllegalArgumentException> {
+            BloomFilterConfig(falsePositiveProbability = 1.0)
+        }
+    }
+
+    @Test
+    fun `지원 가능한 bitSize 를 초과하면 예외가 발생한다`() {
+        assertThrows<IllegalArgumentException> {
+            BloomFilterConfig(expectedInsertions = Long.MAX_VALUE, falsePositiveProbability = 0.01)
+        }
+    }
+
+    @Test
+    fun `bitSize 와 hashFunctionCount 를 계산한다`() {
+        val config = BloomFilterConfig(expectedInsertions = 10_000L, falsePositiveProbability = 0.01)
+
+        config.bitSize shouldBeGreaterThan 0L
+        config.hashFunctionCount shouldBeGreaterThan 0
+        config.hashFunctionCount shouldBeInRange 1..20
+    }
+}

--- a/utils/probabilistic/src/test/kotlin/io/bluetape4k/probabilistic/bloomfilter/InMemoryBloomFilterTest.kt
+++ b/utils/probabilistic/src/test/kotlin/io/bluetape4k/probabilistic/bloomfilter/InMemoryBloomFilterTest.kt
@@ -1,0 +1,96 @@
+package io.bluetape4k.probabilistic.bloomfilter
+
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeLessThan
+import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.Serializable
+
+class InMemoryBloomFilterTest {
+
+    @Test
+    fun `삽입한 원소는 항상 포함 가능 상태가 된다`() {
+        val filter = bloomFilter<String>(expectedInsertions = 1_000L, fpp = 0.01)
+
+        val values = (1..1_000).map { "value-$it" }
+        values.forEach { filter.put(it).shouldBeTrue() }
+
+        values.all { filter.mightContain(it) }.shouldBeTrue()
+        filter.bitCount shouldBeGreaterThan 0L
+        filter.approximateElementCount() shouldBeGreaterThan 0L
+    }
+
+    @Test
+    fun `clear 는 모든 bit 를 초기화한다`() {
+        val filter = bloomFilter<String>(expectedInsertions = 100L, fpp = 0.01)
+        filter.put("alpha")
+
+        filter.isEmpty.shouldBeFalse()
+        filter.clear()
+
+        filter.isEmpty.shouldBeTrue()
+        filter.mightContain("alpha").shouldBeFalse()
+    }
+
+    @Test
+    fun `관측 오탐률은 설정값을 과도하게 넘지 않는다`() {
+        val filter = bloomFilter<String>(expectedInsertions = 10_000L, fpp = 0.01)
+        val inserted = (1..10_000).map { "inserted-$it" }
+        inserted.forEach { filter.put(it) }
+
+        val falsePositives = (1..20_000).count { filter.mightContain("missing-$it") }
+        val observedFpp = falsePositives.toDouble() / 20_000.0
+
+        observedFpp shouldBeLessThan 0.03
+        filter.expectedFpp() shouldBeLessThan 0.03
+    }
+
+    @Test
+    fun `putAll 은 호환 가능한 필터를 병합한다`() {
+        val left = mutableBloomFilter<String>(expectedInsertions = 1_000L, fpp = 0.01)
+        val right = mutableBloomFilter<String>(expectedInsertions = 1_000L, fpp = 0.01)
+
+        left.put("left")
+        right.put("right")
+
+        left.putAll(right)
+
+        left.mightContain("left").shouldBeTrue()
+        left.mightContain("right").shouldBeTrue()
+    }
+
+    @Test
+    fun `putAll 은 호환되지 않는 필터를 거부한다`() {
+        val left = mutableBloomFilter<String>(expectedInsertions = 1_000L, fpp = 0.01)
+        val right = mutableBloomFilter<String>(expectedInsertions = 2_000L, fpp = 0.01)
+
+        assertThrows<IllegalArgumentException> {
+            left.putAll(right)
+        }
+    }
+
+    @Test
+    fun `기본 hasher 는 다양한 타입을 지원한다`() {
+        val intFilter = bloomFilter<Int>(expectedInsertions = 100L, fpp = 0.01)
+        val longFilter = bloomFilter<Long>(expectedInsertions = 100L, fpp = 0.01)
+        val bytesFilter = bloomFilter<ByteArray>(expectedInsertions = 100L, fpp = 0.01)
+        val objectFilter = bloomFilter<TestPayload>(expectedInsertions = 100L, fpp = 0.01)
+
+        intFilter.put(42)
+        longFilter.put(42L)
+        bytesFilter.put(byteArrayOf(1, 2, 3))
+        objectFilter.put(TestPayload(1, "alpha"))
+
+        intFilter.mightContain(42).shouldBeTrue()
+        longFilter.mightContain(42L).shouldBeTrue()
+        bytesFilter.mightContain(byteArrayOf(1, 2, 3)).shouldBeTrue()
+        objectFilter.mightContain(TestPayload(1, "alpha")).shouldBeTrue()
+    }
+
+    data class TestPayload(
+        val id: Int,
+        val name: String,
+    ): Serializable
+}

--- a/utils/probabilistic/src/test/kotlin/io/bluetape4k/probabilistic/bloomfilter/InMemorySuspendBloomFilterTest.kt
+++ b/utils/probabilistic/src/test/kotlin/io/bluetape4k/probabilistic/bloomfilter/InMemorySuspendBloomFilterTest.kt
@@ -1,0 +1,32 @@
+package io.bluetape4k.probabilistic.bloomfilter
+
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.Test
+
+class InMemorySuspendBloomFilterTest {
+
+    @Test
+    fun `suspend BloomFilter 는 메모리 연산을 위임한다`() = runTest {
+        val filter = suspendBloomFilter<String>(expectedInsertions = 1_000L, fpp = 0.01)
+
+        filter.put("alpha").shouldBeTrue()
+
+        filter.mightContain("alpha").shouldBeTrue()
+        filter.mightContain("missing").shouldBeFalse()
+        filter.approximateElementCount() shouldBeGreaterThan 0L
+    }
+
+    @Test
+    fun `suspend clear 는 필터를 초기화한다`() = runTest {
+        val filter = suspendBloomFilter<String>(expectedInsertions = 1_000L, fpp = 0.01)
+        filter.put("alpha")
+
+        filter.clear()
+
+        filter.isEmpty.shouldBeTrue()
+        filter.mightContain("alpha").shouldBeFalse()
+    }
+}


### PR DESCRIPTION
## Summary

Closes #142

- PR 제목: feat: probabilistic Bloom Filter 직접 구현 추가

### 원문 선행 내용

Closes #142

## Background

Issue #142 promotes the Redis-free in-memory Bloom Filter path from `x-obsoleted/bloomfilter` into a supported utility module. During design review, the implementation direction was narrowed to a dependency-free implementation: no Guava and no Eclipse Collections for Bloom Filter storage.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Added `utils/probabilistic` as `:bluetape4k-probabilistic`.
- Implemented `BloomFilter`, `MutableBloomFilter`, and `SuspendBloomFilter` contracts.
- Added `InMemoryBloomFilter`, `InMemoryMutableBloomFilter`, and `InMemorySuspendBloomFilter`.
- Implemented direct `LongArray` bitset storage with SHA-256 double hashing.
- Added `BloomFilterConfig`, `BloomHasher`, default hasher, and DSL factories.
- Added README.md and README.ko.md with usage and operational constraints.
- Added validation, FPP, `putAll`, default hasher, and suspend API tests.

### 기존 섹션: Spec DoD

Spec: `docs/superpowers/specs/2026-04-29-utils-probabilistic-bloomfilter-design.md`

| Item | Status |
|------|--------|
| `:bluetape4k-probabilistic` module compiles | Done |
| Dependency-free direct implementation | Done |
| BloomFilter/Mutable/Suspend API provided | Done |
| DSL factories work | Done |
| Input validation enforced | Done |
| FPP/putAll/suspend behavior tested | Done |
| README.md and README.ko.md written | Done |

### 기존 섹션: Plan DoD

Plan: `docs/superpowers/plans/2026-04-29-utils-probabilistic-bloomfilter-plan.md`

| Task | Description | Status |
|------|-------------|--------|
| T1 | Module skeleton | Done |
| T2 | Public contracts and DSL | Done |
| T3 | JDK/Kotlin direct implementation | Done |
| T4 | Tests | Done |
| T5 | README docs | Done |
| T6 | Verification, reviews, commits | Done |

### 기존 섹션: Pre-PR Checks

| Item | Status |
|------|--------|
| All local tests passing | Done |
| Step 6-R Tier 1 security review | Done |
| Step 6-R Tier 2 Ops/SRE review | Done |
| Step 6-R Tier 3 structural review | Done |
| Step 6-R Tier 4 code quality review | Done |
| Step 6-R Tier 5 tests/types/silent failure review | Done |
| Step 6-R Tier 6 performance/stability review | Done |
| README.md + README.ko.md updated | Done |
| Korean KDoc for public APIs | Done |
| Worktree work complete | Done |

### 기존 섹션: Commits

```text
b0911c4b2 (feat): probabilistic bloomfilter 직접 구현 추가
776f8ed9a (docs): bloomfilter 직접 구현 설계로 전환
a5bc0ffc0 (docs): probabilistic bloomfilter 승격 설계 고정
```

## Validation

Module: `:bluetape4k-probabilistic`

| Command | Result |
|---------|--------|
| `./bin/repo-test-summary -- ./gradlew :bluetape4k-probabilistic:test` | 12 passing, 0 failed, 0 skipped |
| `./bin/repo-test-summary -- ./gradlew :bluetape4k-probabilistic:compileKotlin :bluetape4k-probabilistic:compileTestKotlin :bluetape4k-probabilistic:test` | BUILD SUCCESSFUL |

Date: 2026-04-29

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #142, milestone 없음, assignee `debop`
- PR: #239, head `b0911c4b23a9dae9a174a499c9baf86fd41e2c3f`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `issue-142-probabilistic-bloomfilter`
- Labels: `enhancement`
- State: `MERGED`, merge commit `31be60ad343604e6a0e3ab40af1acd795692cab7`
- CI: | `./bin/repo-test-summary -- ./gradlew :bluetape4k-probabilistic:test` | 12 passing, 0 failed, 0 skipped | / | `./bin/repo-test-summary -- ./gradlew :bluetape4k-probabilistic:compileKotlin :bluetape4k-probabilistic:compileTestKotlin :bluetape4k-probabilistic:test` | BUILD SUCCESSFUL |

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #239 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `31be60ad343604e6a0e3ab40af1acd795692cab7`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
