### PR TITLE
feat: okio DAEAD 청크 스트리밍 암호화 지원

### DIFF
--- a/docs/superpowers/plans/2026-04-29-daead-chunk-okio-plan.md
+++ b/docs/superpowers/plans/2026-04-29-daead-chunk-okio-plan.md
@@ -1,0 +1,126 @@
+# bluetape4k-okio DAEAD 청크 스트리밍 암호화 구현 계획
+
+Spec: `docs/superpowers/specs/2026-04-29-daead-chunk-okio-design.md`
+Issue: #240
+
+## T1. DAEAD 청크 Sink 구현
+
+- complexity: high
+- expected files:
+  - `io/okio/src/main/kotlin/io/bluetape4k/okio/tink/DaeadChunkEncryptSink.kt`
+- work:
+  - `DEFAULT_DAEAD_CHUNK_SIZE = 64 * 1024` 상수 추가
+  - `DaeadChunkEncryptSink`를 `ForwardingSink` 기반으로 구현
+  - 입력을 내부 plain buffer에 누적하고 `chunkSize` 이상일 때만 완성 청크 암호화
+  - 각 청크를 `[8-byte big-endian ciphertext_len][ciphertext]`로 delegate에 기록
+  - `flush()`는 완성 청크만 기록하고 partial chunk는 유지
+  - `close()`는 남은 partial chunk를 기록한 뒤 delegate close
+  - `chunkSize > 0` 검증과 associatedData 방어적 복사
+  - `Sink.asDaeadChunkEncryptSink(...)` 확장 함수 제공
+- verification:
+  - `./bin/repo-test-summary -- ./gradlew :bluetape4k-okio:compileKotlin`
+- docs impact:
+  - 공개 API 한국어 KDoc 필요
+  - README에 `close()`/`use {}` 필요성 기록
+
+## T2. DAEAD 청크 Source 구현
+
+- complexity: high
+- expected files:
+  - `io/okio/src/main/kotlin/io/bluetape4k/okio/tink/DaeadChunkDecryptSource.kt`
+- work:
+  - `DaeadChunkDecryptSource`를 `ForwardingSource` 기반으로 구현
+  - 내부 plain buffer가 비었을 때 다음 청크 하나만 읽어 복호화
+  - header 첫 바이트 전 EOF는 정상 EOF, partial header/body는 `EOFException`
+  - ciphertext length는 `1..Int.MAX_VALUE`로 제한하고 0/음수는 `IOException`
+  - `byteCount` 음수 거부, 0이면 0 반환
+  - associatedData 방어적 복사
+  - `Source.asDaeadChunkDecryptSource(...)` 확장 함수 제공
+- verification:
+  - `./bin/repo-test-summary -- ./gradlew :bluetape4k-okio:compileKotlin`
+- docs impact:
+  - 공개 API 한국어 KDoc 필요
+  - README에 기존 `TinkDecryptSource`와의 wire format 비호환 기록
+
+## T3. DAEAD 청크 테스트 작성
+
+- complexity: medium
+- expected files:
+  - `io/okio/src/test/kotlin/io/bluetape4k/okio/tink/DaeadChunkEncryptSinkTest.kt`
+  - `io/okio/src/test/kotlin/io/bluetape4k/okio/tink/DaeadChunkDecryptSourceTest.kt`
+- work:
+  - empty input, single chunk, multi chunk round-trip
+  - 여러 small `write()` 호출을 하나의 stream으로 복호화
+  - incremental read와 EOF 계약 검증
+  - chunkSize 검증 실패 테스트
+  - wire format header가 big-endian length를 쓰는지 검증
+  - truncated header, truncated ciphertext, invalid length 실패 테스트
+  - wrong associated data 실패 테스트
+  - associatedData 방어적 복사 테스트
+  - 복호화 첫 read가 전체 ciphertext를 소비하지 않는지 counting Source로 검증
+- verification:
+  - `./bin/repo-test-summary -- ./gradlew :bluetape4k-okio:test --tests "io.bluetape4k.okio.tink.DaeadChunk*Test"`
+- docs impact:
+  - 테스트명은 계약 중심으로 작성
+
+## T4. README 업데이트
+
+- complexity: low
+- expected files:
+  - `io/okio/README.md`
+  - `io/okio/README.ko.md`
+- work:
+  - 기존 Tink AEAD 어댑터 섹션에 전체로드/호환성 주의 추가
+  - DAEAD 청크 스트리밍 섹션 추가
+  - 사용 예시, wire format, deterministic leakage, `close()` 필요성, associated data 제약 기록
+- verification:
+  - Markdown 코드 블록과 링크 육안 검토
+- docs impact:
+  - module behavior 변경이므로 README.md/README.ko.md 업데이트 필수
+  - 새 durable convention은 없으므로 AGENTS.md 업데이트 불필요
+
+## T5. Targeted verification
+
+- complexity: medium
+- expected files:
+  - 변경된 source/test/docs 파일
+- work:
+  - targeted compile/test 실행
+  - 실패 시 원인 분석 후 수정하고 재실행
+  - Step 4-S 조건 판단: 구현 규모가 200 lines 이상이면 cleanup plan 후 중복/과잉 추상화 제거
+  - Step 4-P 조건 판단: 암호화/IO/resource lifecycle 변경이므로 performance/stability scan 수행
+- verification:
+  - `./bin/repo-test-summary -- ./gradlew :bluetape4k-okio:test --tests "io.bluetape4k.okio.tink.DaeadChunk*Test"`
+  - `./bin/repo-test-summary -- ./gradlew :bluetape4k-okio:compileKotlin :bluetape4k-okio:compileTestKotlin`
+- docs impact:
+  - docs/superpowers index 디렉터리는 현재 repo에 없으므로 index 업데이트는 N/A로 기록
+
+## T6. Review, commit, PR
+
+- complexity: medium
+- expected files:
+  - spec/plan
+  - implementation/test/docs files
+- work:
+  - Step 5 verifier로 spec/plan 대비 구현 확인
+  - Step 6 최종 체크리스트 수행
+  - Step 6-R 6개 리뷰 티어 수행
+  - Lore trailer 포함 커밋 작성
+  - branch push 및 Issue #240을 닫는 PR 생성
+  - Step 7 DoD 보고서 작성
+- verification:
+  - `./bin/repo-status`
+  - `git log develop..HEAD --oneline`
+  - `gh pr view --json number,url,title,state`
+- docs impact:
+  - Step 8 knowledge capture에서 새 반복 워크플로우가 없으면 skill/wiki/module AGENTS 업데이트 N/A 기록
+
+## Pre-Implementation Risk Mitigations
+
+- 기존 `TinkEncryptSink` / `TinkDecryptSource` 동작을 바꾸지 않는다.
+- DAEAD 청크 포맷은 기존 Tink AEAD single-ciphertext format과 호환되지 않음을 KDoc/README에 명시한다.
+- Sink는 partial chunk를 `close()`에서 확정하므로 테스트와 README에서 `use {}` 패턴을 고정한다.
+- Source는 header/body exact read helper를 사용해 partial EOF를 명확히 실패시킨다.
+- length header는 `Long`으로 읽되 `1..Int.MAX_VALUE` 범위를 넘어가면 `IOException`으로 거부한다.
+- `associatedData`는 생성 시 `copyOf()`를 수행해 mutable array 변경 영향을 차단한다.
+- 복호화 스트리밍성은 counting Source 테스트로 "첫 read가 전체 ciphertext를 소비하지 않음"을 검증한다.

--- a/docs/superpowers/specs/2026-04-29-daead-chunk-okio-design.md
+++ b/docs/superpowers/specs/2026-04-29-daead-chunk-okio-design.md
@@ -1,0 +1,181 @@
+# bluetape4k-okio DAEAD 청크 스트리밍 암호화 설계
+
+Issue: #240
+
+## 배경
+
+`bluetape4k-okio`의 기존 `TinkEncryptSink`는 `write(source, byteCount)` 호출 단위로 `TinkEncryptor.encrypt()`를 수행한다. 반면 `TinkDecryptSource`는 첫 `read()`에서 delegate `Source` 전체를 `Buffer`에 적재한 뒤 단일 ciphertext로 복호화한다.
+
+이 구조는 두 가지 문제가 있다.
+
+- 대용량 입력에서 복호화가 전체 암호문을 메모리에 올리므로 OOM 위험이 있다.
+- 여러 번의 `write()` 호출로 생성된 암호문은 여러 ciphertext가 이어진 형태인데, 기존 `TinkDecryptSource`는 이를 하나의 ciphertext로 복호화하려 하므로 구조적으로 호환되지 않는다.
+
+Issue #240은 기존 API 호환성을 유지하면서 DAEAD(AES-SIV) 기반 청크형 wire format을 새로 제공해 실제 스트리밍 복호화를 가능하게 하는 작업이다.
+
+## 요구사항
+
+- `io/okio` 모듈에 신규 클래스 `DaeadChunkEncryptSink`, `DaeadChunkDecryptSource`를 추가한다.
+- wire format은 각 청크마다 `[8-byte big-endian ciphertext_len][ciphertext_len bytes ciphertext]`를 반복한다.
+- 기본 평문 청크 크기는 `64 * 1024` bytes다.
+- 암호화 Sink는 입력을 `chunkSize` 단위로 나누어 `TinkDeterministicAead.encryptDeterministically()`로 암호화한다.
+- 복호화 Source는 헤더와 해당 ciphertext만 읽고 복호화한 뒤 caller가 요청한 만큼 반환한다.
+- 복호화는 전체 delegate Source를 메모리에 적재하지 않는다.
+- 기존 `TinkEncryptSink` / `TinkDecryptSource`와 `asTinkEncryptSink` / `asTinkDecryptSource`는 호환성을 위해 유지한다.
+- 공개 API에는 한국어 KDoc을 작성하고 DAEAD 결정성의 패턴 노출 위험을 명시한다.
+- README.md / README.ko.md에 기존 Tink 어댑터와 DAEAD 청크 어댑터의 차이, `close()` 필요성, wire format 호환성 제약을 기록한다.
+
+## Step 1-R 연구 요약
+
+- 기존 `TinkDecryptSource`는 `ensureDecrypted()`에서 delegate Source를 EOF까지 읽고 `encryptor.decrypt(encryptedBuffer.readByteArray())`를 한 번만 호출한다.
+- 기존 `TinkEncryptSink`는 `write()` 호출마다 요청 구간만 암호화하므로 write 호출 경계가 암호문 경계가 된다. 그러나 길이 prefix가 없어 복호화 쪽에서 경계를 복원할 수 없다.
+- `io/okio/build.gradle.kts`는 `bluetape4k-tink`를 `compileOnly`로 사용하고 테스트에서는 `testImplementation` 확장으로 접근한다. 새 클래스도 같은 모듈/패키지에서 구현할 수 있다.
+- `TinkDeterministicAead`는 `encryptDeterministically(plaintext, associatedData)` / `decryptDeterministically(ciphertext, associatedData)`를 제공하고 기본 associated data는 빈 배열이다.
+- Google Tink 공식 문서는 Deterministic AEAD가 동일 plaintext에 동일 ciphertext를 생성하며 AES256_SIV key type을 권장한다고 설명한다. 또한 associated data는 인증되지만 암호화되지 않고, 결정성 때문에 동일 평문 패턴 노출 위험이 있다.
+- Tink 공식 문서는 Deterministic AEAD plaintext/associated data 길이가 `0..2^32 bytes` 범위라고 설명하고, 메시지당 1MB 미만일 때 많은 메시지 암호화에 대한 안정성 기준을 제시한다. 기본 64KB 청크는 이 기준 안에 있다.
+- `io/okio` 테스트는 `Buffer`, Kluent, `assertFailsWith`, helper `readAllTo` 패턴을 사용한다.
+
+## 설계 옵션
+
+### 옵션 A: 신규 DAEAD 청크 Sink/Source 추가
+
+`DaeadChunkEncryptSink`와 `DaeadChunkDecryptSource`를 새로 추가하고 기존 AEAD 기반 `Tink*` 클래스는 그대로 둔다.
+
+장점:
+- 기존 API와 wire format을 깨지 않는다.
+- 청크 길이 prefix로 복호화 경계를 명확히 복원한다.
+- DAEAD 전용 보안/결정성 제약을 KDoc과 README에 별도로 설명할 수 있다.
+
+단점:
+- 사용자는 기존 `asTink*`와 새 `asDaeadChunk*`의 차이를 이해해야 한다.
+- 기존 `TinkDecryptSource`의 전체로드 동작은 호환성 때문에 남는다.
+
+### 옵션 B: 기존 TinkEncryptSink/TinkDecryptSource를 길이 prefix 포맷으로 변경
+
+기존 클래스의 write format을 `[len][ciphertext]` 반복으로 바꾸고 복호화도 해당 포맷을 읽게 한다.
+
+장점:
+- API 이름은 그대로 유지된다.
+- 기존 사용자 코드 변경량이 적다.
+
+단점:
+- 기존 단일 ciphertext 데이터와 호환되지 않는 breaking change다.
+- `TinkEncryptor`는 일반 AEAD와 DAEAD를 모두 감싸므로 결정적 청크 포맷의 보안 특성을 명확히 분리하기 어렵다.
+
+### 옵션 C: Tink Streaming AEAD로 전환
+
+Tink의 Streaming AEAD primitive를 노출하거나 내부에서 사용한다.
+
+장점:
+- 스트리밍 암호화를 위해 설계된 primitive를 사용한다.
+- 결정성 패턴 노출 문제가 없다.
+
+단점:
+- Issue #240은 DAEAD(AES-SIV) 기반 deterministic chunk format을 명시한다.
+- `bluetape4k-tink`에는 현재 Streaming AEAD wrapper가 없다.
+- 새 primitive 도입은 dependency/API 설계 범위가 넓어지고 이번 결함 수정 범위를 넘는다.
+
+## 결정
+
+옵션 A를 채택한다. 기존 `Tink*` API는 유지하고 `DaeadChunk*` API를 추가한다.
+
+Rejected:
+- 옵션 B: 기존 wire format을 깨고 기존 데이터를 읽을 수 없게 만든다.
+- 옵션 C: Issue 요구인 DAEAD deterministic chunk format과 다르며 `bluetape4k-tink` 신규 primitive 설계가 필요하다.
+
+## API 설계
+
+```kotlin
+class DaeadChunkEncryptSink(
+    delegate: Sink,
+    private val daead: TinkDeterministicAead,
+    private val chunkSize: Int = DEFAULT_DAEAD_CHUNK_SIZE,
+    private val associatedData: ByteArray = EMPTY_BYTES,
+): ForwardingSink(delegate)
+
+class DaeadChunkDecryptSource(
+    delegate: Source,
+    private val daead: TinkDeterministicAead,
+    private val associatedData: ByteArray = EMPTY_BYTES,
+): ForwardingSource(delegate)
+
+const val DEFAULT_DAEAD_CHUNK_SIZE: Int = 64 * 1024
+
+fun Sink.asDaeadChunkEncryptSink(
+    daead: TinkDeterministicAead,
+    chunkSize: Int = DEFAULT_DAEAD_CHUNK_SIZE,
+    associatedData: ByteArray = EMPTY_BYTES,
+): DaeadChunkEncryptSink
+
+fun Source.asDaeadChunkDecryptSource(
+    daead: TinkDeterministicAead,
+    associatedData: ByteArray = EMPTY_BYTES,
+): DaeadChunkDecryptSource
+```
+
+Issue에 제시된 확장 함수는 `associatedData` 기본값으로 그대로 충족한다.
+
+## 내부 구현
+
+### DaeadChunkEncryptSink
+
+- 내부 `plainBuffer`에 입력을 누적한다.
+- `write(source, byteCount)`는 `byteCount`를 검증하고 source에서 plainBuffer로 이동한다.
+- plainBuffer가 `chunkSize` 이상이면 `chunkSize` 단위로 청크를 암호화해 delegate에 기록한다.
+- `close()`는 남은 partial chunk를 암호화한 뒤 delegate를 닫는다.
+- `flush()`는 이미 완성된 청크만 기록하고 partial chunk는 유지한 뒤 delegate flush를 호출한다.
+- `chunkSize`는 양수여야 한다.
+- `associatedData`는 생성 시 복사해 호출자가 전달한 `ByteArray`를 나중에 변경해도 암복호화 계약이 흔들리지 않게 한다.
+- empty input은 chunk를 기록하지 않고 닫는다.
+
+### DaeadChunkDecryptSource
+
+- 내부 `plainBuffer`에 현재 복호화된 청크의 남은 평문만 보관한다.
+- `read(sink, byteCount)`는 `byteCount`를 검증하고, plainBuffer가 비어 있으면 다음 chunk 하나만 읽어 복호화한다.
+- chunk header 8 bytes를 완전히 읽지 못하면 `EOFException`을 던진다. 단, header 첫 바이트도 읽기 전에 EOF면 정상 EOF다.
+- ciphertext length는 `1..Int.MAX_VALUE` 범위로 제한한다. 0 또는 음수 길이는 손상된 입력으로 간주해 `IOException`을 던진다.
+- ciphertext 본문을 완전히 읽지 못하면 `EOFException`을 던진다.
+- 복호화 실패는 Tink 예외를 그대로 전파한다.
+- 전체 파일을 읽지 않고 최대 `ciphertext_len + decrypted current chunk` 범위만 메모리에 둔다.
+- `associatedData`는 생성 시 복사해 Source 수명 중 외부 변경 영향을 받지 않게 한다.
+
+## 리스크와 대응
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| 기존 Tink API와 새 DAEAD API 혼동 | 잘못된 Source/Sink 조합으로 복호화 실패 | 클래스/KDoc/README에 wire format 비호환 명시 |
+| partial chunk가 `close()` 전에 기록되지 않음 | 사용자가 close 누락 시 데이터 손실 | KDoc/README에 `use {}` 권장, 테스트로 close finalize 검증 |
+| 손상된 length header | 과도한 메모리 할당 또는 무한 대기 | 길이 범위 검증, truncated header/body EOF 테스트 |
+| 결정적 암호화 패턴 노출 | 동일 청크 plaintext가 동일 ciphertext로 관찰 가능 | KDoc/README에 DAEAD 결정성 경고와 일반 암호화 필요 시 기존 AEAD API 안내 |
+| associated data 불일치 | 정상 데이터 복호화 실패 | associatedData round-trip과 mismatch 실패 테스트 |
+| mutable associatedData 배열 변경 | 같은 Source/Sink 인스턴스의 인증 컨텍스트 변조 | 생성 시 `copyOf()`로 방어적 복사 |
+| 청크 경계 결정성 | 같은 chunkSize/input/key/AD는 같은 wire bytes 생성 | 테스트로 결정성 확인, 문서에 장단점 기록 |
+
+## Acceptance Criteria
+
+- `DaeadChunkEncryptSink`와 `DaeadChunkDecryptSource`가 `io.bluetape4k.okio.tink` 패키지에 추가된다.
+- `asDaeadChunkEncryptSink` / `asDaeadChunkDecryptSource` 확장 함수가 제공된다.
+- 기본 chunk size는 64KB이고, 양수가 아닌 chunk size는 거부된다.
+- wire format은 각 청크를 8-byte big-endian ciphertext length와 ciphertext bytes로 기록한다.
+- empty input, single chunk, multi chunk, small repeated writes, incremental reads가 round-trip 된다.
+- 다중 `write()` 호출로 암호화한 데이터가 정상 복호화된다.
+- truncated header, truncated ciphertext, invalid length, wrong associated data가 실패한다.
+- 복호화 Source는 첫 `read()`에서 전체 ciphertext를 소비하지 않는다.
+- README.md / README.ko.md가 새 DAEAD 청크 API와 제약을 설명한다.
+
+## DoD
+
+- `./bin/repo-test-summary -- ./gradlew :bluetape4k-okio:test --tests "io.bluetape4k.okio.tink.*"` 통과
+- `./bin/repo-test-summary -- ./gradlew :bluetape4k-okio:compileKotlin :bluetape4k-okio:compileTestKotlin` 통과
+- 공개 API 한국어 KDoc 작성
+- README.md / README.ko.md 업데이트
+- Step 6-R 6개 리뷰 티어 수행
+- Lore commit trailer를 포함한 커밋 작성
+- Issue #240을 닫는 PR 생성
+
+## Draft Task List
+
+1. DAEAD 청크 Sink/Source와 확장 함수 구현
+2. DAEAD 청크 round-trip, 손상 입력, 스트리밍 동작 테스트 작성
+3. README.md / README.ko.md에 사용 예시와 제약 업데이트
+4. targeted compile/test, verifier, 리뷰 게이트 수행

--- a/io/okio/README.ko.md
+++ b/io/okio/README.ko.md
@@ -86,7 +86,7 @@ val streamingSource = source.asDecompressSource(Compressors.Streaming.Zstd)
 - `CompressableSink`는 `close()` 시점에 압축 결과가 확정됩니다. 반드시 `close()` 또는 `use {}`를 사용하세요.
 - `StreamingCompressSink`도 footer/finalize 기록을 위해 `close()`가 필요합니다.
 
-### 5. Tink 암호화 (권장)
+### 5. Tink 암호화
 
 Google Tink AEAD 기반 암호화 Sink/Source를 제공합니다.
 
@@ -103,6 +103,35 @@ val decryptSource = source.asTinkDecryptSource(TinkEncryptors.AES256_GCM)
 val result = Buffer()
 decryptSource.read(result, Long.MAX_VALUE)
 ```
+
+레거시 `TinkEncryptSink`는 `write()` 호출마다 독립적으로 암호화하고,
+`TinkDecryptSource`는 delegate source 전체를 읽은 뒤 단일 ciphertext로 복호화합니다.
+기존 단일 ciphertext payload 호환이 필요할 때 이 어댑터를 사용하세요.
+
+대용량 payload 또는 여러 번의 `write()` 호출로 기록되는 데이터에는 DAEAD 청크 어댑터를 사용합니다.
+
+```kotlin
+import io.bluetape4k.okio.tink.*
+import io.bluetape4k.tink.daead.TinkDaeads
+
+val encrypted = Buffer()
+encrypted.asDaeadChunkEncryptSink(TinkDaeads.AES256_SIV).use { encryptSink ->
+    encryptSink.write(buffer, buffer.size)
+}
+
+val decrypted = Buffer()
+encrypted.asDaeadChunkDecryptSource(TinkDaeads.AES256_SIV).use { decryptSource ->
+    decryptSource.read(decrypted, Long.MAX_VALUE)
+}
+```
+
+DAEAD 청크 암호화는 각 frame을 8-byte big-endian ciphertext 길이와 DAEAD ciphertext로 기록합니다.
+기본 평문 청크 크기는 64 KiB입니다. 마지막 partial chunk는 `close()`에서 확정되므로
+암호화 Sink는 반드시 닫아야 하며, `use {}` 사용을 권장합니다.
+
+Deterministic AEAD는 같은 키, 평문, 연관 데이터에 대해 같은 암호문을 생성합니다.
+따라서 반복 평문 청크 패턴이 노출될 수 있습니다. 연관 데이터는 인증되지만 암호화되지 않으며,
+복호화할 때 암호화 시점과 같은 값을 전달해야 합니다.
 
 **암호화 + 압축 조합:**
 
@@ -226,9 +255,11 @@ io.bluetape4k.okio
 │   ├── SinkWithCompressor.kt   # 레거시 호환 압축 Sink
 │   ├── SourceWithCompressor.kt # 레거시 호환 복원 Source
 │   └── Compressable.kt         # 압축 인터페이스
-├── tink/                       # Tink AEAD 암호화 (권장)
+├── tink/                       # Tink AEAD 및 DAEAD 청크 암호화
 │   ├── TinkEncryptSink.kt
-│   └── TinkDecryptSource.kt
+│   ├── TinkDecryptSource.kt
+│   ├── DaeadChunkEncryptSink.kt
+│   └── DaeadChunkDecryptSource.kt
 ├── base64/                     # Base64 인코딩/디코딩
 │   ├── ApacheBase64Sink.kt
 │   ├── ApacheBase64Source.kt
@@ -320,6 +351,19 @@ classDiagram
         -ensureDecrypted()
     }
 
+    class DaeadChunkEncryptSink {
+        -daead: TinkDeterministicAead
+        -plainBuffer: Buffer
+        +write(source: Buffer, byteCount: Long)
+        +close()
+    }
+
+    class DaeadChunkDecryptSource {
+        -daead: TinkDeterministicAead
+        -plainBuffer: Buffer
+        +read(sink: Buffer, byteCount: Long) Long
+    }
+
     class AbstractBase64Sink {
         <<abstract>>
         #getEncodedBuffer(ByteString) Buffer
@@ -343,6 +387,8 @@ classDiagram
 
     ForwardingSink <|-- TinkEncryptSink
     ForwardingSource <|-- TinkDecryptSource
+    ForwardingSink <|-- DaeadChunkEncryptSink
+    ForwardingSource <|-- DaeadChunkDecryptSource
 
     ForwardingSink <|-- AbstractBase64Sink
     AbstractBase64Sink <|-- ApacheBase64Sink
@@ -363,6 +409,8 @@ classDiagram
     style StreamingDecompressSource fill:#FCE4EC,stroke:#F48FB1,color:#AD1457
     style TinkEncryptSink fill:#FCE4EC,stroke:#F48FB1,color:#AD1457
     style TinkDecryptSource fill:#FCE4EC,stroke:#F48FB1,color:#AD1457
+    style DaeadChunkEncryptSink fill:#FCE4EC,stroke:#F48FB1,color:#AD1457
+    style DaeadChunkDecryptSource fill:#FCE4EC,stroke:#F48FB1,color:#AD1457
     style AbstractBase64Sink fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     style AbstractBase64Source fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     style ApacheBase64Sink fill:#E0F2F1,stroke:#80CBC4,color:#00695C

--- a/io/okio/README.md
+++ b/io/okio/README.md
@@ -87,7 +87,7 @@ val streamingSource = source.asDecompressSource(Compressors.Streaming.Zstd)
 - `CompressableSink` finalizes compression at `close()`. Always use `close()` or `use {}`.
 - `StreamingCompressSink` also requires `close()` to write the footer/finalize bytes.
 
-### 5. Tink Encryption (Recommended)
+### 5. Tink Encryption
 
 Provides encryption Sink/Source based on Google Tink AEAD.
 
@@ -104,6 +104,38 @@ val decryptSource = source.asTinkDecryptSource(TinkEncryptors.AES256_GCM)
 val result = Buffer()
 decryptSource.read(result, Long.MAX_VALUE)
 ```
+
+The legacy `TinkEncryptSink` encrypts each `write()` call independently, while
+`TinkDecryptSource` expects a single ciphertext and decrypts it after reading the
+delegate source fully. Keep this adapter for existing single-ciphertext payloads.
+
+For large payloads or data written with multiple `write()` calls, use the DAEAD
+chunk adapter:
+
+```kotlin
+import io.bluetape4k.okio.tink.*
+import io.bluetape4k.tink.daead.TinkDaeads
+
+val encrypted = Buffer()
+encrypted.asDaeadChunkEncryptSink(TinkDaeads.AES256_SIV).use { encryptSink ->
+    encryptSink.write(buffer, buffer.size)
+}
+
+val decrypted = Buffer()
+encrypted.asDaeadChunkDecryptSource(TinkDaeads.AES256_SIV).use { decryptSource ->
+    decryptSource.read(decrypted, Long.MAX_VALUE)
+}
+```
+
+DAEAD chunk encryption writes each frame as an 8-byte big-endian ciphertext
+length followed by the DAEAD ciphertext. The default plaintext chunk size is
+64 KiB. Always close the encrypt sink, preferably with `use {}`, because the
+last partial chunk is finalized on `close()`.
+
+Deterministic AEAD produces the same ciphertext for the same key, plaintext, and
+associated data. This can reveal repeated plaintext chunks. Associated data is
+authenticated but not encrypted, and the same value must be supplied for
+decryption.
 
 **Encryption + Compression combined:**
 
@@ -227,9 +259,11 @@ io.bluetape4k.okio
 │   ├── SinkWithCompressor.kt   # Legacy-compatible compression Sink
 │   ├── SourceWithCompressor.kt # Legacy-compatible decompression Source
 │   └── Compressable.kt         # Compression interface
-├── tink/                       # Tink AEAD encryption (recommended)
+├── tink/                       # Tink AEAD and DAEAD chunk encryption
 │   ├── TinkEncryptSink.kt
-│   └── TinkDecryptSource.kt
+│   ├── TinkDecryptSource.kt
+│   ├── DaeadChunkEncryptSink.kt
+│   └── DaeadChunkDecryptSource.kt
 ├── base64/                     # Base64 encoding/decoding
 │   ├── ApacheBase64Sink.kt
 │   ├── ApacheBase64Source.kt
@@ -322,6 +356,19 @@ classDiagram
         -ensureDecrypted()
     }
 
+    class DaeadChunkEncryptSink {
+        -daead: TinkDeterministicAead
+        -plainBuffer: Buffer
+        +write(source: Buffer, byteCount: Long)
+        +close()
+    }
+
+    class DaeadChunkDecryptSource {
+        -daead: TinkDeterministicAead
+        -plainBuffer: Buffer
+        +read(sink: Buffer, byteCount: Long) Long
+    }
+
     class AbstractBase64Sink {
         <<abstract>>
         #getEncodedBuffer(ByteString) Buffer
@@ -345,6 +392,8 @@ classDiagram
 
     ForwardingSink <|-- TinkEncryptSink
     ForwardingSource <|-- TinkDecryptSource
+    ForwardingSink <|-- DaeadChunkEncryptSink
+    ForwardingSource <|-- DaeadChunkDecryptSource
 
     ForwardingSink <|-- AbstractBase64Sink
     AbstractBase64Sink <|-- ApacheBase64Sink
@@ -365,6 +414,8 @@ classDiagram
     style StreamingDecompressSource fill:#FCE4EC,stroke:#F48FB1,color:#AD1457
     style TinkEncryptSink fill:#FCE4EC,stroke:#F48FB1,color:#AD1457
     style TinkDecryptSource fill:#FCE4EC,stroke:#F48FB1,color:#AD1457
+    style DaeadChunkEncryptSink fill:#FCE4EC,stroke:#F48FB1,color:#AD1457
+    style DaeadChunkDecryptSource fill:#FCE4EC,stroke:#F48FB1,color:#AD1457
     style AbstractBase64Sink fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     style AbstractBase64Source fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     style ApacheBase64Sink fill:#E0F2F1,stroke:#80CBC4,color:#00695C

--- a/io/okio/src/main/kotlin/io/bluetape4k/okio/tink/DaeadChunkDecryptSource.kt
+++ b/io/okio/src/main/kotlin/io/bluetape4k/okio/tink/DaeadChunkDecryptSource.kt
@@ -1,0 +1,137 @@
+package io.bluetape4k.okio.tink
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.requireZeroOrPositiveNumber
+import io.bluetape4k.tink.daead.TinkDeterministicAead
+import okio.Buffer
+import okio.EOFException
+import okio.ForwardingSource
+import okio.Source
+import java.io.IOException
+
+/**
+ * DAEAD 청크 포맷으로 암호화된 데이터를 복호화하여 [Source]로 제공하는 구현체입니다.
+ *
+ * 입력은 `[8-byte big-endian ciphertext length][ciphertext]` 청크의 반복이어야 합니다.
+ * [read]는 필요한 경우 다음 청크 하나만 읽고 복호화하므로 전체 암호문을 메모리에 적재하지 않습니다.
+ *
+ * [TinkDeterministicAead]는 같은 키, 평문, 연관 데이터에 대해 같은 암호문을 생성합니다.
+ * 이 특성 때문에 동일 청크 평문 반복 여부가 노출될 수 있습니다. 또한 [associatedData]는
+ * 인증되지만 암호화되지 않으며, 암호화 시 사용한 값과 동일해야 복호화가 성공합니다.
+ *
+ * @param delegate DAEAD 청크 암호문을 읽을 위임 [Source]
+ * @param daead 청크 복호화에 사용할 DAEAD 래퍼
+ * @param associatedData 청크 인증에 사용할 연관 데이터
+ */
+class DaeadChunkDecryptSource(
+    delegate: Source,
+    private val daead: TinkDeterministicAead,
+    associatedData: ByteArray = ByteArray(0),
+): ForwardingSource(delegate) {
+
+    companion object: KLogging() {
+        private const val CHUNK_HEADER_SIZE = Long.SIZE_BYTES.toLong()
+        private const val MAX_NO_PROGRESS_READS = 8
+    }
+
+    private val associatedData: ByteArray = associatedData.copyOf()
+    private val plainBuffer = Buffer()
+    private var closed = false
+
+    /**
+     * 복호화된 평문을 [sink]에 최대 [byteCount] 바이트만큼 읽어옵니다.
+     *
+     * @param sink 복호화된 평문을 받을 버퍼
+     * @param byteCount 요청할 최대 바이트 수
+     * @return 실제 읽은 바이트 수 또는 EOF 시 -1
+     */
+    override fun read(sink: Buffer, byteCount: Long): Long {
+        if (closed) {
+            throw IOException("closed")
+        }
+        byteCount.requireZeroOrPositiveNumber("byteCount")
+        if (byteCount == 0L) {
+            return 0L
+        }
+
+        if (plainBuffer.size == 0L && !readNextChunk()) {
+            return -1L
+        }
+
+        val bytesToRead = minOf(byteCount, plainBuffer.size)
+        sink.write(plainBuffer, bytesToRead)
+        return bytesToRead
+    }
+
+    /**
+     * 내부 평문 버퍼와 위임 [Source]를 닫습니다.
+     */
+    override fun close() {
+        if (closed) {
+            return
+        }
+        closed = true
+        try {
+            super.close()
+        } finally {
+            plainBuffer.close()
+        }
+    }
+
+    private fun readNextChunk(): Boolean {
+        val header = readExactlyOrNull(CHUNK_HEADER_SIZE) ?: return false
+        val ciphertextLength = header.readLong()
+
+        if (ciphertextLength <= 0L || ciphertextLength > Int.MAX_VALUE) {
+            throw IOException("Invalid DAEAD chunk ciphertext length: $ciphertextLength")
+        }
+
+        val ciphertext = readExactlyOrNull(ciphertextLength)
+            ?: throw EOFException("Truncated DAEAD chunk ciphertext. expected=$ciphertextLength")
+
+        val plaintext = daead.decryptDeterministically(ciphertext.readByteArray(), associatedData)
+        plainBuffer.write(plaintext)
+        return true
+    }
+
+    private fun readExactlyOrNull(byteCount: Long): Buffer? {
+        val buffer = Buffer()
+        var noProgressCount = 0
+
+        while (buffer.size < byteCount) {
+            val bytesRead = super.read(buffer, byteCount - buffer.size)
+            when {
+                bytesRead < 0L -> {
+                    if (buffer.size == 0L) {
+                        return null
+                    }
+                    throw EOFException("Truncated DAEAD chunk. expected=$byteCount actual=${buffer.size}")
+                }
+
+                bytesRead == 0L -> {
+                    noProgressCount++
+                    if (noProgressCount >= MAX_NO_PROGRESS_READS) {
+                        throw IOException("Unable to read DAEAD chunk bytes from source: no progress.")
+                    }
+                }
+
+                else -> noProgressCount = 0
+            }
+        }
+
+        return buffer
+    }
+}
+
+/**
+ * 현재 [Source]를 DAEAD 청크 복호화 [Source]로 변환합니다.
+ *
+ * @param daead 청크 복호화에 사용할 DAEAD 래퍼
+ * @param associatedData 청크 인증에 사용할 연관 데이터
+ * @return DAEAD 청크 복호화 [Source]
+ */
+fun Source.asDaeadChunkDecryptSource(
+    daead: TinkDeterministicAead,
+    associatedData: ByteArray = ByteArray(0),
+): DaeadChunkDecryptSource =
+    DaeadChunkDecryptSource(this, daead, associatedData)

--- a/io/okio/src/main/kotlin/io/bluetape4k/okio/tink/DaeadChunkEncryptSink.kt
+++ b/io/okio/src/main/kotlin/io/bluetape4k/okio/tink/DaeadChunkEncryptSink.kt
@@ -1,0 +1,146 @@
+package io.bluetape4k.okio.tink
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.requireInRange
+import io.bluetape4k.support.requirePositiveNumber
+import io.bluetape4k.tink.daead.TinkDeterministicAead
+import okio.Buffer
+import okio.ForwardingSink
+import okio.Sink
+import java.io.IOException
+
+/**
+ * 평문을 DAEAD 청크 포맷으로 암호화하여 [Sink]에 기록하는 [Sink] 구현체입니다.
+ *
+ * 입력은 [chunkSize] 크기의 평문 청크로 나뉘며, 각 청크는
+ * `[8-byte big-endian ciphertext length][ciphertext]` 형식으로 기록됩니다.
+ * 마지막 partial chunk는 [close] 시점에 기록되므로 반드시 `use {}` 또는 [close]를 호출해야 합니다.
+ *
+ * [TinkDeterministicAead]는 같은 키, 평문, 연관 데이터에 대해 같은 암호문을 생성합니다.
+ * 이 특성 때문에 동일 청크 평문 반복 여부가 노출될 수 있습니다. 결정성이 필요하지 않은 일반
+ * 암호화에는 `TinkEncryptSink`를 사용하세요.
+ *
+ * @param delegate 암호문을 기록할 위임 [Sink]
+ * @param daead 청크 암호화에 사용할 DAEAD 래퍼
+ * @param chunkSize 평문 청크 크기. 기본값은 [DEFAULT_DAEAD_CHUNK_SIZE]입니다.
+ * @param associatedData 청크 인증에 사용할 연관 데이터. 인증되지만 암호화되지는 않습니다.
+ */
+class DaeadChunkEncryptSink(
+    delegate: Sink,
+    private val daead: TinkDeterministicAead,
+    private val chunkSize: Int = DEFAULT_DAEAD_CHUNK_SIZE,
+    associatedData: ByteArray = ByteArray(0),
+): ForwardingSink(delegate) {
+
+    companion object: KLogging()
+
+    private val associatedData: ByteArray = associatedData.copyOf()
+    private val plainBuffer = Buffer()
+    private var closed = false
+
+    init {
+        chunkSize.requirePositiveNumber("chunkSize")
+    }
+
+    /**
+     * [source]에서 [byteCount] 바이트를 읽어 내부 버퍼에 누적한 뒤 완성된 청크를 암호화합니다.
+     *
+     * @param source 평문을 제공하는 버퍼
+     * @param byteCount 처리할 바이트 수
+     */
+    override fun write(source: Buffer, byteCount: Long) {
+        if (closed) {
+            throw IOException("closed")
+        }
+        byteCount.requireInRange(0L, source.size, "byteCount")
+        if (byteCount == 0L) {
+            return
+        }
+
+        plainBuffer.write(source, byteCount)
+        emitCompleteChunks()
+    }
+
+    /**
+     * 완성된 청크만 기록하고 partial chunk는 [close]까지 유지합니다.
+     */
+    override fun flush() {
+        if (!closed) {
+            emitCompleteChunks()
+            super.flush()
+        }
+    }
+
+    /**
+     * 남은 partial chunk를 암호화한 뒤 위임 [Sink]를 닫습니다.
+     */
+    override fun close() {
+        if (closed) {
+            return
+        }
+
+        var thrown: Throwable? = null
+        try {
+            emitRemainingChunk()
+            super.flush()
+        } catch (e: Throwable) {
+            thrown = e
+        } finally {
+            closed = true
+            try {
+                super.close()
+            } catch (closeException: Throwable) {
+                if (thrown == null) {
+                    thrown = closeException
+                } else {
+                    thrown.addSuppressed(closeException)
+                }
+            }
+            plainBuffer.close()
+        }
+
+        thrown?.let { throw it }
+    }
+
+    private fun emitCompleteChunks() {
+        while (plainBuffer.size >= chunkSize) {
+            emitChunk(chunkSize.toLong())
+        }
+    }
+
+    private fun emitRemainingChunk() {
+        if (plainBuffer.size > 0L) {
+            emitChunk(plainBuffer.size)
+        }
+    }
+
+    private fun emitChunk(byteCount: Long) {
+        val plaintext = plainBuffer.readByteArray(byteCount)
+        val ciphertext = daead.encryptDeterministically(plaintext, associatedData)
+        val frame = Buffer()
+            .writeLong(ciphertext.size.toLong())
+            .write(ciphertext)
+
+        super.write(frame, frame.size)
+    }
+}
+
+/**
+ * 현재 [Sink]를 DAEAD 청크 암호화 [Sink]로 변환합니다.
+ *
+ * @param daead 청크 암호화에 사용할 DAEAD 래퍼
+ * @param chunkSize 평문 청크 크기. 기본값은 [DEFAULT_DAEAD_CHUNK_SIZE]입니다.
+ * @param associatedData 청크 인증에 사용할 연관 데이터
+ * @return DAEAD 청크 암호화 [Sink]
+ */
+fun Sink.asDaeadChunkEncryptSink(
+    daead: TinkDeterministicAead,
+    chunkSize: Int = DEFAULT_DAEAD_CHUNK_SIZE,
+    associatedData: ByteArray = ByteArray(0),
+): DaeadChunkEncryptSink =
+    DaeadChunkEncryptSink(this, daead, chunkSize, associatedData)
+
+/**
+ * DAEAD 청크 암호화에서 사용하는 기본 평문 청크 크기입니다.
+ */
+const val DEFAULT_DAEAD_CHUNK_SIZE: Int = 64 * 1024

--- a/io/okio/src/test/kotlin/io/bluetape4k/okio/tink/DaeadChunkDecryptSourceTest.kt
+++ b/io/okio/src/test/kotlin/io/bluetape4k/okio/tink/DaeadChunkDecryptSourceTest.kt
@@ -1,0 +1,176 @@
+package io.bluetape4k.okio.tink
+
+import io.bluetape4k.tink.daead.TinkDaeads
+import okio.Buffer
+import okio.EOFException
+import okio.ForwardingSource
+import okio.Source
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import kotlin.test.assertFailsWith
+
+class DaeadChunkDecryptSourceTest: AbstractTinkEncryptTest() {
+
+    private val daead = TinkDaeads.AES256_SIV
+
+    @Test
+    fun `decrypts single chunk`() {
+        val expected = "hello daead chunk"
+        val encrypted = encrypt(expected.toByteArray(), chunkSize = DEFAULT_DAEAD_CHUNK_SIZE)
+
+        val decrypted = Buffer()
+        encrypted.asDaeadChunkDecryptSource(daead).readAllTo(decrypted)
+
+        decrypted.readUtf8() shouldBeEqualTo expected
+    }
+
+    @Test
+    fun `decrypts multiple chunks with incremental reads`() {
+        val expected = ByteArray(257) { (it % 127).toByte() }
+        val encrypted = encrypt(expected, chunkSize = 17)
+        val source = encrypted.asDaeadChunkDecryptSource(daead)
+        val decrypted = Buffer()
+
+        while (source.read(decrypted, 5L) >= 0L) {
+            // 반복 read 계약 검증
+        }
+
+        decrypted.readByteArray() shouldBeEqualTo expected
+        source.read(Buffer(), 1L) shouldBeEqualTo -1L
+    }
+
+    @Test
+    fun `decrypts data written by multiple small writes`() {
+        val encrypted = Buffer()
+
+        encrypted.asDaeadChunkEncryptSink(daead, chunkSize = 8).use { sink ->
+            listOf("a", "bc", "def", "ghij", "klmno").forEach { text ->
+                val source = Buffer().writeUtf8(text)
+                sink.write(source, source.size)
+            }
+        }
+
+        val decrypted = Buffer()
+        encrypted.asDaeadChunkDecryptSource(daead).readAllTo(decrypted)
+
+        decrypted.readUtf8() shouldBeEqualTo "abcdefghijklmno"
+    }
+
+    @Test
+    fun `read with zero byteCount returns zero`() {
+        val encrypted = encrypt("abc".toByteArray(), chunkSize = 4)
+
+        encrypted.asDaeadChunkDecryptSource(daead).read(Buffer(), 0L) shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `read rejects negative byteCount`() {
+        val encrypted = encrypt("abc".toByteArray(), chunkSize = 4)
+
+        assertFailsWith<IllegalArgumentException> {
+            encrypted.asDaeadChunkDecryptSource(daead).read(Buffer(), -1L)
+        }
+    }
+
+    @Test
+    fun `empty input returns eof`() {
+        Buffer().asDaeadChunkDecryptSource(daead).read(Buffer(), 1L) shouldBeEqualTo -1L
+    }
+
+    @Test
+    fun `truncated header throws eof exception`() {
+        assertFailsWith<EOFException> {
+            Buffer().writeByte(1).asDaeadChunkDecryptSource(daead).read(Buffer(), 1L)
+        }
+    }
+
+    @Test
+    fun `truncated ciphertext throws eof exception`() {
+        val malformed = Buffer().writeLong(16L).write(ByteArray(15))
+
+        assertFailsWith<EOFException> {
+            malformed.asDaeadChunkDecryptSource(daead).read(Buffer(), 1L)
+        }
+    }
+
+    @Test
+    fun `invalid ciphertext length throws io exception`() {
+        assertFailsWith<IOException> {
+            Buffer().writeLong(0L).asDaeadChunkDecryptSource(daead).read(Buffer(), 1L)
+        }
+    }
+
+    @Test
+    fun `wrong associated data fails to decrypt`() {
+        val encrypted = encrypt("secret".toByteArray(), chunkSize = 4, associatedData = byteArrayOf(1))
+
+        assertFailsWith<Exception> {
+            encrypted.asDaeadChunkDecryptSource(daead, associatedData = byteArrayOf(2)).read(Buffer(), 1L)
+        }
+    }
+
+    @Test
+    fun `associated data is defensively copied by decrypt source`() {
+        val encrypted = encrypt("secret".toByteArray(), chunkSize = 4, associatedData = byteArrayOf(1))
+        val associatedData = byteArrayOf(1)
+        val source = encrypted.asDaeadChunkDecryptSource(daead, associatedData = associatedData)
+
+        associatedData[0] = 2
+
+        val decrypted = Buffer()
+        source.readAllTo(decrypted)
+
+        decrypted.readUtf8() shouldBeEqualTo "secret"
+    }
+
+    @Test
+    fun `first read consumes only the next encrypted chunk`() {
+        val plaintext = ByteArray(512) { (it % 64).toByte() }
+        val encrypted = encrypt(plaintext, chunkSize = 64)
+        val encryptedSize = encrypted.size
+        val countingSource = CountingSource(encrypted)
+        val source = countingSource.asDaeadChunkDecryptSource(daead)
+        val decrypted = Buffer()
+
+        source.read(decrypted, 1L) shouldBeEqualTo 1L
+
+        (countingSource.bytesRead < encryptedSize) shouldBeEqualTo true
+    }
+
+    private fun encrypt(
+        plaintext: ByteArray,
+        chunkSize: Int,
+        associatedData: ByteArray = ByteArray(0),
+    ): Buffer {
+        val encrypted = Buffer()
+        encrypted.asDaeadChunkEncryptSink(daead, chunkSize = chunkSize, associatedData = associatedData).use { sink ->
+            sink.write(Buffer().write(plaintext), plaintext.size.toLong())
+        }
+        return encrypted
+    }
+
+    private fun Source.readAllTo(sink: Buffer): Long {
+        var total = 0L
+        while (true) {
+            val bytesRead = read(sink, DEFAULT_BUFFER_SIZE.toLong())
+            if (bytesRead < 0L) {
+                return total
+            }
+            total += bytesRead
+        }
+    }
+
+    private class CountingSource(delegate: Source): ForwardingSource(delegate) {
+        var bytesRead: Long = 0L
+            private set
+
+        override fun read(sink: Buffer, byteCount: Long): Long {
+            val read = super.read(sink, byteCount)
+            if (read > 0L) {
+                bytesRead += read
+            }
+            return read
+        }
+    }
+}

--- a/io/okio/src/test/kotlin/io/bluetape4k/okio/tink/DaeadChunkEncryptSinkTest.kt
+++ b/io/okio/src/test/kotlin/io/bluetape4k/okio/tink/DaeadChunkEncryptSinkTest.kt
@@ -1,0 +1,118 @@
+package io.bluetape4k.okio.tink
+
+import io.bluetape4k.tink.daead.TinkDaeads
+import okio.Buffer
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFailsWith
+
+class DaeadChunkEncryptSinkTest: AbstractTinkEncryptTest() {
+
+    private val daead = TinkDaeads.AES256_SIV
+
+    @Test
+    fun `empty input writes no chunk`() {
+        val encrypted = Buffer()
+
+        encrypted.asDaeadChunkEncryptSink(daead).use {
+            it.flush()
+        }
+
+        encrypted.size shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `single chunk uses big endian ciphertext length header`() {
+        val plaintext = byteArrayOf(1, 2, 3)
+        val expectedCiphertext = daead.encryptDeterministically(plaintext)
+        val encrypted = Buffer()
+
+        encrypted.asDaeadChunkEncryptSink(daead, chunkSize = plaintext.size).use { sink ->
+            sink.write(Buffer().write(plaintext), plaintext.size.toLong())
+        }
+
+        encrypted.readLong() shouldBeEqualTo expectedCiphertext.size.toLong()
+        encrypted.readByteArray() shouldBeEqualTo expectedCiphertext
+    }
+
+    @Test
+    fun `multiple small writes are combined into configured chunks`() {
+        val encrypted = Buffer()
+        val chunks = mutableListOf<Long>()
+
+        encrypted.asDaeadChunkEncryptSink(daead, chunkSize = 4).use { sink ->
+            listOf("ab", "cd", "ef", "gh", "i").forEach { text ->
+                val source = Buffer().writeUtf8(text)
+                sink.write(source, source.size)
+            }
+        }
+
+        val framed = encrypted.clone()
+        while (framed.size > 0L) {
+            val ciphertextLength = framed.readLong()
+            chunks += ciphertextLength
+            framed.skip(ciphertextLength)
+        }
+
+        chunks.size shouldBeEqualTo 3
+    }
+
+    @Test
+    fun `flush does not write partial chunk`() {
+        val encrypted = Buffer()
+        val sink = encrypted.asDaeadChunkEncryptSink(daead, chunkSize = 8)
+
+        sink.write(Buffer().writeUtf8("abc"), 3L)
+        sink.flush()
+
+        encrypted.size shouldBeEqualTo 0L
+
+        sink.close()
+        (encrypted.size > 0L) shouldBeEqualTo true
+    }
+
+    @Test
+    fun `write rejects invalid byteCount`() {
+        val encrypted = Buffer()
+        val sink = encrypted.asDaeadChunkEncryptSink(daead)
+
+        assertFailsWith<IllegalArgumentException> {
+            sink.write(Buffer().writeUtf8("abc"), 4L)
+        }
+    }
+
+    @Test
+    fun `constructor rejects non positive chunk size`() {
+        assertFailsWith<IllegalArgumentException> {
+            Buffer().asDaeadChunkEncryptSink(daead, chunkSize = 0)
+        }
+    }
+
+    @Test
+    fun `associated data is defensively copied by encrypt sink`() {
+        val associatedData = byteArrayOf(1)
+        val encrypted = Buffer()
+        val sink = encrypted.asDaeadChunkEncryptSink(daead, chunkSize = 4, associatedData = associatedData)
+
+        associatedData[0] = 2
+        sink.use {
+            it.write(Buffer().writeUtf8("secret"), 6L)
+        }
+
+        val decrypted = Buffer()
+        encrypted.asDaeadChunkDecryptSource(daead, associatedData = byteArrayOf(1)).readAllTo(decrypted)
+
+        decrypted.readUtf8() shouldBeEqualTo "secret"
+    }
+
+    private fun DaeadChunkDecryptSource.readAllTo(sink: Buffer): Long {
+        var total = 0L
+        while (true) {
+            val bytesRead = read(sink, DEFAULT_BUFFER_SIZE.toLong())
+            if (bytesRead < 0L) {
+                return total
+            }
+            total += bytesRead
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #240

- PR 제목: feat: okio DAEAD 청크 스트리밍 암호화 지원

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Added `DaeadChunkEncryptSink`: buffers plaintext into 64 KiB chunks by default, writes `[8-byte big-endian length][DAEAD ciphertext]`, validates `chunkSize`, and finalizes the last partial chunk on `close()`.
- Added `DaeadChunkDecryptSource`: reads only the next framed ciphertext chunk, validates frame length, detects truncated header/body, and returns decrypted plaintext incrementally without loading the whole source.
- Added `asDaeadChunkEncryptSink` / `asDaeadChunkDecryptSource` extensions with optional associated data.
- Preserved existing `TinkEncryptSink` / `TinkDecryptSource` behavior and documented wire-format separation.
- Added regression tests for empty input, single/multi chunk round-trip, multiple small writes, incremental reads, invalid length, truncated input, wrong associated data, defensive associated data copies, and first-read streaming behavior.
- Updated `io/okio/README.md` and `io/okio/README.ko.md` with examples, wire format, `close()` requirement, and deterministic encryption leakage warning.

### 기존 섹션: Related Issue

Closes #240 - feat: bluetape4k-okio — TinkDecryptSource 스트리밍 복호화 및 DAEAD 청크형 스트리밍 암호화 지원

`TinkDecryptSource`가 전체 delegate Source를 메모리에 올려 단일 ciphertext로 복호화하던 문제를 피하기 위해, 기존 API를 유지한 채 DAEAD(AES-SIV) 청크 wire format을 별도 API로 추가합니다.

### 기존 섹션: Spec DoD

Spec: `docs/superpowers/specs/2026-04-29-daead-chunk-okio-design.md`

| Item | Status |
|------|--------|
| `DaeadChunkEncryptSink` and `DaeadChunkDecryptSource` added under `io.bluetape4k.okio.tink` | Done |
| `asDaeadChunkEncryptSink` / `asDaeadChunkDecryptSource` extensions provided | Done |
| Default chunk size is 64 KiB and non-positive chunk sizes are rejected | Done |
| Wire format uses 8-byte big-endian ciphertext length plus ciphertext bytes per chunk | Done |
| Empty, single chunk, multi chunk, small repeated writes, and incremental reads round-trip | Done |
| Multi-write encrypted data decrypts correctly | Done |
| Truncated header, truncated ciphertext, invalid length, and wrong associated data fail | Done |
| First decrypt read does not consume the full ciphertext stream | Done |
| README.md / README.ko.md document API and constraints | Done |

### 기존 섹션: Plan DoD

Plan: `docs/superpowers/plans/2026-04-29-daead-chunk-okio-plan.md`

| Task | Description | Status |
|------|-------------|--------|
| T1 | DAEAD chunk Sink implementation | Done |
| T2 | DAEAD chunk Source implementation | Done |
| T3 | DAEAD chunk regression tests | Done |
| T4 | README updates | Done |
| T5 | Targeted verification, cleanup, performance/stability scan | Done |
| T6 | Review, commit, PR | Done |

### 기존 섹션: Pre-PR Required Checks

| Item | Status |
|------|--------|
| All local tests passing | Done |
| Step 6-R Tier 1 security review | Done |
| Step 6-R Tier 2 Ops/SRE review | Done |
| Step 6-R Tier 3 structural review | Done |
| Step 6-R Tier 4 code quality review | Done |
| Step 6-R Tier 5 test/type/silent failure review | Done |
| Step 6-R Tier 6 performance/stability review | Done |
| README.md + README.ko.md updated | Done |
| Korean KDoc for public APIs | Done |
| Worktree work complete | Done |

### 기존 섹션: Commits

```text
a02599755 feat: okio DAEAD 청크 스트리밍 암호화 지원
2f3a2c018 docs: DAEAD 청크 okio 설계 기록
```

## Validation

Module: `:bluetape4k-okio`

| Command | Result |
|---------|--------|
| `./bin/repo-test-summary -- ./gradlew :bluetape4k-okio:test --tests "io.bluetape4k.okio.tink.DaeadChunk*Test"` | BUILD SUCCESSFUL, 19 passing |
| `./bin/repo-test-summary -- ./gradlew :bluetape4k-okio:compileKotlin :bluetape4k-okio:compileTestKotlin` | BUILD SUCCESSFUL |
| `./bin/repo-test-summary -- ./gradlew :bluetape4k-okio:test` | BUILD SUCCESSFUL, 1386 passing, 14 pending |
| `./bin/repo-test-summary -- ./gradlew detekt` | BUILD SUCCESSFUL, `:detekt NO-SOURCE` |
| `./bin/repo-test-summary -- ./gradlew :bluetape4k-okio:checkKotlinAbi` | BUILD SUCCESSFUL, ABI tasks skipped/up-to-date |

Date: 2026-04-29

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #240, milestone 없음, assignee `debop`
- PR: #242, head `a02599755517856f6fa3ec87ca46bf4423555b1c`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `issue-240-daead-chunk-okio`
- Labels: `enhancement`
- State: `MERGED`, merge commit `9fdf1c9bfd3e79d77978be3808a80e09414e000a`
- CI: `TinkDecryptSource`가 전체 delegate Source를 메모리에 올려 단일 ciphertext로 복호화하던 문제를 피하기 위해, 기존 API를 유지한 채 DAEAD(AES-SIV) 청크 wire format을 별도 API로 추가합니다. / - Added `DaeadChunkEncryptSink`: buffers plaintext into 64 KiB chunks by default, writes `[8-byte big-endian length][DAEAD ciphertext]`, validates `chunkSize`, and finalizes the last partial chunk on `close()`. / - Added `DaeadChunkDecryptSource`: reads only the next framed ciphertext chunk, validates frame length, detects truncated header/body, and returns decrypted plaintext incrementally without loading the whole source.

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #242 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9fdf1c9bfd3e79d77978be3808a80e09414e000a`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
