### PR TITLE
fix: 일일 코드리뷰 — okio DAEAD 보안/테스트 강화 + images 불변성 버그 수정

### DIFF
--- a/images/images/src/main/kotlin/io/bluetape4k/images/BufferedImageSupport.kt
+++ b/images/images/src/main/kotlin/io/bluetape4k/images/BufferedImageSupport.kt
@@ -236,16 +236,17 @@ fun bufferedImageOf(w: Int, h: Int): BufferedImage {
 /**
  * [InputStream] 정보를 읽어 [BufferedImage]를 생성합니다.
  *
- * ## 동작/계약
- * - 읽기 실패 시 `ImageIO.read`가 `null` 또는 예외를 반환할 수 있습니다.
- *
  * ```kotlin
  * val image = bufferedImageOf(File("photo.jpg").inputStream())
  * // image.width > 0
  * // image.height > 0
  * ```
+ *
+ * @throws IllegalArgumentException 지원하지 않는 포맷이거나 손상된 스트림인 경우
  */
-fun bufferedImageOf(inputStream: InputStream): BufferedImage = ImageIO.read(inputStream)
+fun bufferedImageOf(inputStream: InputStream): BufferedImage =
+    ImageIO.read(inputStream)
+        ?: throw IllegalArgumentException("지원하지 않는 이미지 포맷이거나 손상된 스트림입니다.")
 
 /**
  * [ImageInputStream] 정보를 읽어 [BufferedImage]를 생성합니다.
@@ -255,8 +256,12 @@ fun bufferedImageOf(inputStream: InputStream): BufferedImage = ImageIO.read(inpu
  * val image = bufferedImageOf(iis)
  * // image.width > 0
  * ```
+ *
+ * @throws IllegalArgumentException 지원하지 않는 포맷이거나 손상된 스트림인 경우
  */
-fun bufferedImageOf(inputStream: ImageInputStream): BufferedImage = ImageIO.read(inputStream)
+fun bufferedImageOf(inputStream: ImageInputStream): BufferedImage =
+    ImageIO.read(inputStream)
+        ?: throw IllegalArgumentException("지원하지 않는 이미지 포맷이거나 손상된 ImageInputStream입니다.")
 
 /**
  * [File] 정보를 읽어 [BufferedImage]를 생성합니다.
@@ -266,8 +271,12 @@ fun bufferedImageOf(inputStream: ImageInputStream): BufferedImage = ImageIO.read
  * // image.width > 0
  * // image.height > 0
  * ```
+ *
+ * @throws IllegalArgumentException 지원하지 않는 포맷이거나 손상된 파일인 경우
  */
-fun bufferedImageOf(file: File): BufferedImage = ImageIO.read(file)
+fun bufferedImageOf(file: File): BufferedImage =
+    ImageIO.read(file)
+        ?: throw IllegalArgumentException("지원하지 않는 이미지 포맷이거나 손상된 파일입니다: ${file.path}")
 
 /**
  * [URL] 정보를 읽어 [BufferedImage]를 생성합니다.
@@ -277,8 +286,12 @@ fun bufferedImageOf(file: File): BufferedImage = ImageIO.read(file)
  * val image = bufferedImageOf(url)
  * // image.width > 0
  * ```
+ *
+ * @throws IllegalArgumentException 지원하지 않는 포맷이거나 읽기 실패인 경우
  */
-fun bufferedImageOf(url: URL): BufferedImage = ImageIO.read(url)
+fun bufferedImageOf(url: URL): BufferedImage =
+    ImageIO.read(url)
+        ?: throw IllegalArgumentException("지원하지 않는 이미지 포맷이거나 URL 읽기에 실패했습니다: $url")
 
 /**
  * 이미지 정보를 담은 [bytes]를 읽어 [BufferedImage] 를 생성합니다.
@@ -289,8 +302,12 @@ fun bufferedImageOf(url: URL): BufferedImage = ImageIO.read(url)
  * // image.width > 0
  * // image.height > 0
  * ```
+ *
+ * @throws IllegalArgumentException 지원하지 않는 포맷이거나 손상된 바이트 배열인 경우
  */
-fun bufferedImageOf(bytes: ByteArray): BufferedImage = ImageIO.read(bytes.toInputStream())
+fun bufferedImageOf(bytes: ByteArray): BufferedImage =
+    ImageIO.read(bytes.toInputStream())
+        ?: throw IllegalArgumentException("지원하지 않는 이미지 포맷이거나 손상된 바이트 배열입니다.")
 
 /**
  * [BufferedImage] 정보를 ByteArray 로 변환합니다.

--- a/images/images/src/main/kotlin/io/bluetape4k/images/ImmutableImageSupport.kt
+++ b/images/images/src/main/kotlin/io/bluetape4k/images/ImmutableImageSupport.kt
@@ -211,28 +211,48 @@ fun ImmutableImage.forSuspendWriter(writer: SuspendImageWriter): SuspendWriteCon
 
 
 /**
- * [ImmutableImage]에 그리기 작업 ([action]) 을 수행합니다.
+ * [ImmutableImage]의 복사본에 그리기 작업 ([action])을 수행하고 새 [ImmutableImage]를 반환합니다.
  *
- * ## 동작/계약
- * - 내부 `Graphics2D`는 `finally`에서 항상 `dispose()`됩니다.
- * - 수신 이미지는 `action` 수행 결과에 따라 mutate 됩니다.
+ * 원본 이미지는 변경되지 않습니다. `Graphics2D`는 `finally`에서 항상 `dispose()`됩니다.
  *
  * ```kotlin
- * image.useGraphics { g ->
- *   g.drawRect(0, 0, 10, 10)
+ * val annotated = image.withGraphics { g ->
+ *     g.color = Color.RED
+ *     g.drawRect(0, 0, 10, 10)
  * }
- * // image.width > 0
+ * // image 는 변경되지 않고 annotated 에 사각형이 그려진 새 이미지가 반환된다.
  * ```
  *
- * @param action 그래픽 작업
+ * @param action 복사본에 적용할 그래픽 작업
+ * @return 그래픽 작업이 적용된 새 [ImmutableImage]
  */
-inline fun ImmutableImage.useGraphics(
+inline fun ImmutableImage.withGraphics(
     action: (graphics: Graphics2D) -> Unit,
-) {
-    val graphics: Graphics2D = this.awt().createGraphics()
+): ImmutableImage {
+    val copy = this.copy()
+    val graphics: Graphics2D = copy.awt().createGraphics()
     try {
         action(graphics)
     } finally {
         graphics.dispose()
     }
+    return copy
+}
+
+/**
+ * [ImmutableImage]에 그리기 작업 ([action])을 수행합니다.
+ *
+ * **주의**: 이 함수는 `ImmutableImage`의 내부 backing buffer를 직접 수정합니다.
+ * 불변 계약을 위반하므로 [withGraphics]를 사용하세요.
+ *
+ * @param action 그래픽 작업
+ */
+@Deprecated(
+    message = "ImmutableImage.useGraphics()는 내부 backing buffer를 변경하여 불변 계약을 위반합니다. withGraphics()를 사용하세요.",
+    replaceWith = ReplaceWith("withGraphics(action)"),
+)
+inline fun ImmutableImage.useGraphics(
+    action: (graphics: Graphics2D) -> Unit,
+) {
+    withGraphics(action)
 }

--- a/io/okio/README.ko.md
+++ b/io/okio/README.ko.md
@@ -104,34 +104,47 @@ val result = Buffer()
 decryptSource.read(result, Long.MAX_VALUE)
 ```
 
-레거시 `TinkEncryptSink`는 `write()` 호출마다 독립적으로 암호화하고,
-`TinkDecryptSource`는 delegate source 전체를 읽은 뒤 단일 ciphertext로 복호화합니다.
-기존 단일 ciphertext payload 호환이 필요할 때 이 어댑터를 사용하세요.
+레거시 `TinkEncryptSink`/`TinkDecryptSource` 쌍은 스트림 전체를 **단일 ciphertext**로 취급합니다.
+`TinkEncryptSink`는 `close()` 시점에 암호화를 확정하고, `TinkDecryptSource`는 위임 Source를
+끝까지 읽은 뒤 단일 ciphertext로 복호화합니다. 복수의 `write()` 호출은 복수의 독립 ciphertext를
+생성하므로 `TinkDecryptSource`로 복호화할 수 없습니다. 기존 단일 ciphertext payload 호환이
+필요할 때만 이 어댑터를 사용하세요.
 
 대용량 payload 또는 여러 번의 `write()` 호출로 기록되는 데이터에는 DAEAD 청크 어댑터를 사용합니다.
+복호화는 한 번에 하나의 청크 ciphertext만 메모리에 적재하므로 페이로드 전체를 메모리에 올리지 않습니다:
 
 ```kotlin
 import io.bluetape4k.okio.tink.*
 import io.bluetape4k.tink.daead.TinkDaeads
 
+val daead = TinkDaeads.AES256_SIV
+val contextBytes = "my-context".toByteArray()
+
 val encrypted = Buffer()
-encrypted.asDaeadChunkEncryptSink(TinkDaeads.AES256_SIV).use { encryptSink ->
+encrypted.asDaeadChunkEncryptSink(
+    daead,
+    chunkSize = DEFAULT_DAEAD_CHUNK_SIZE,   // 기본 64 KiB; 필요 시 재정의
+    associatedData = contextBytes,
+).use { encryptSink ->
     encryptSink.write(buffer, buffer.size)
 }
 
 val decrypted = Buffer()
-encrypted.asDaeadChunkDecryptSource(TinkDaeads.AES256_SIV).use { decryptSource ->
+encrypted.asDaeadChunkDecryptSource(
+    daead,
+    associatedData = contextBytes,          // 암호화 시 사용한 값과 동일해야 함
+).use { decryptSource ->
     decryptSource.read(decrypted, Long.MAX_VALUE)
 }
 ```
 
-DAEAD 청크 암호화는 각 frame을 8-byte big-endian ciphertext 길이와 DAEAD ciphertext로 기록합니다.
-기본 평문 청크 크기는 64 KiB입니다. 마지막 partial chunk는 `close()`에서 확정되므로
+DAEAD 청크 암호화는 각 frame을 8-byte big-endian ciphertext 길이(`DEFAULT_DAEAD_CHUNK_SIZE` = 64 KiB)와
+DAEAD ciphertext로 기록합니다. 마지막 partial chunk는 `close()`에서 확정되므로
 암호화 Sink는 반드시 닫아야 하며, `use {}` 사용을 권장합니다.
 
 Deterministic AEAD는 같은 키, 평문, 연관 데이터에 대해 같은 암호문을 생성합니다.
 따라서 반복 평문 청크 패턴이 노출될 수 있습니다. 연관 데이터는 인증되지만 암호화되지 않으며,
-복호화할 때 암호화 시점과 같은 값을 전달해야 합니다.
+**복호화할 때 암호화 시점과 같은 값을 전달해야 합니다**.
 
 **암호화 + 압축 조합:**
 

--- a/io/okio/README.md
+++ b/io/okio/README.md
@@ -105,37 +105,51 @@ val result = Buffer()
 decryptSource.read(result, Long.MAX_VALUE)
 ```
 
-The legacy `TinkEncryptSink` encrypts each `write()` call independently, while
-`TinkDecryptSource` expects a single ciphertext and decrypts it after reading the
-delegate source fully. Keep this adapter for existing single-ciphertext payloads.
+The legacy `TinkEncryptSink`/`TinkDecryptSource` pair treats the entire stream as a
+**single ciphertext**: `TinkEncryptSink` finalizes encryption on `close()`, and
+`TinkDecryptSource` reads the delegate source to completion before producing any
+plaintext. Use this adapter only with existing single-ciphertext payloads; using
+multiple `write()` calls produces multiple independent ciphertexts that
+`TinkDecryptSource` cannot decode.
 
 For large payloads or data written with multiple `write()` calls, use the DAEAD
-chunk adapter:
+chunk adapter instead. Decryption is incremental — only one chunk's ciphertext is
+held in memory at a time, regardless of total payload size:
 
 ```kotlin
 import io.bluetape4k.okio.tink.*
 import io.bluetape4k.tink.daead.TinkDaeads
 
+val daead = TinkDaeads.AES256_SIV
+val contextBytes = "my-context".toByteArray()
+
 val encrypted = Buffer()
-encrypted.asDaeadChunkEncryptSink(TinkDaeads.AES256_SIV).use { encryptSink ->
+encrypted.asDaeadChunkEncryptSink(
+    daead,
+    chunkSize = DEFAULT_DAEAD_CHUNK_SIZE,   // 64 KiB default; override as needed
+    associatedData = contextBytes,
+).use { encryptSink ->
     encryptSink.write(buffer, buffer.size)
 }
 
 val decrypted = Buffer()
-encrypted.asDaeadChunkDecryptSource(TinkDaeads.AES256_SIV).use { decryptSource ->
+encrypted.asDaeadChunkDecryptSource(
+    daead,
+    associatedData = contextBytes,          // must match encryption value
+).use { decryptSource ->
     decryptSource.read(decrypted, Long.MAX_VALUE)
 }
 ```
 
 DAEAD chunk encryption writes each frame as an 8-byte big-endian ciphertext
-length followed by the DAEAD ciphertext. The default plaintext chunk size is
-64 KiB. Always close the encrypt sink, preferably with `use {}`, because the
-last partial chunk is finalized on `close()`.
+length (`DEFAULT_DAEAD_CHUNK_SIZE = 64 KiB`) followed by the DAEAD ciphertext.
+Always close the encrypt sink, preferably with `use {}`, because the last partial
+chunk is finalized on `close()`.
 
 Deterministic AEAD produces the same ciphertext for the same key, plaintext, and
 associated data. This can reveal repeated plaintext chunks. Associated data is
-authenticated but not encrypted, and the same value must be supplied for
-decryption.
+authenticated but not encrypted, and the **same value must be supplied for
+decryption**.
 
 **Encryption + Compression combined:**
 

--- a/io/okio/src/main/kotlin/io/bluetape4k/okio/tink/DaeadChunkDecryptSource.kt
+++ b/io/okio/src/main/kotlin/io/bluetape4k/okio/tink/DaeadChunkDecryptSource.kt
@@ -19,14 +19,36 @@ import java.io.IOException
  * 이 특성 때문에 동일 청크 평문 반복 여부가 노출될 수 있습니다. 또한 [associatedData]는
  * 인증되지만 암호화되지 않으며, 암호화 시 사용한 값과 동일해야 복호화가 성공합니다.
  *
+ * ```kotlin
+ * val daead = TinkDaeads.AES256_SIV
+ * val output = Buffer()
+ *
+ * // 암호화
+ * output.asDaeadChunkEncryptSink(daead).use { sink ->
+ *     sink.write(Buffer().writeUtf8("스트리밍 평문"), 14L)
+ * }
+ *
+ * // 복호화 — 한 번에 하나의 청크만 메모리에 적재
+ * val decrypted = Buffer()
+ * output.asDaeadChunkDecryptSource(daead).use { source ->
+ *     source.read(decrypted, Long.MAX_VALUE)
+ * }
+ * val plaintext = decrypted.readUtf8() // "스트리밍 평문"
+ * ```
+ *
  * @param delegate DAEAD 청크 암호문을 읽을 위임 [Source]
  * @param daead 청크 복호화에 사용할 DAEAD 래퍼
- * @param associatedData 청크 인증에 사용할 연관 데이터
+ * @param associatedData 청크 인증에 사용할 연관 데이터. 암호화 시 사용한 값과 동일해야 합니다.
+ * @param maxCiphertextLength 허용하는 청크 ciphertext 최대 길이 (기본값: [DEFAULT_DAEAD_MAX_CIPHERTEXT_LENGTH]).
+ *   신뢰할 수 없는 소스에서 읽을 때 대규모 메모리 할당 공격을 방어합니다.
+ * @see DaeadChunkEncryptSink
+ * @see TinkDecryptSource
  */
 class DaeadChunkDecryptSource(
     delegate: Source,
     private val daead: TinkDeterministicAead,
     associatedData: ByteArray = ByteArray(0),
+    private val maxCiphertextLength: Long = DEFAULT_DAEAD_MAX_CIPHERTEXT_LENGTH,
 ): ForwardingSource(delegate) {
 
     companion object: KLogging() {
@@ -41,9 +63,13 @@ class DaeadChunkDecryptSource(
     /**
      * 복호화된 평문을 [sink]에 최대 [byteCount] 바이트만큼 읽어옵니다.
      *
+     * 내부 평문 버퍼가 비어 있으면 다음 청크 하나를 읽고 복호화합니다.
+     * 한 번 호출 시 최대 한 청크 분량의 평문만 반환할 수 있습니다.
+     *
      * @param sink 복호화된 평문을 받을 버퍼
      * @param byteCount 요청할 최대 바이트 수
      * @return 실제 읽은 바이트 수 또는 EOF 시 -1
+     * @throws IOException close 이후 호출 시, 또는 스트림 포맷 오류 시
      */
     override fun read(sink: Buffer, byteCount: Long): Long {
         if (closed) {
@@ -84,6 +110,11 @@ class DaeadChunkDecryptSource(
 
         if (ciphertextLength <= 0L || ciphertextLength > Int.MAX_VALUE) {
             throw IOException("Invalid DAEAD chunk ciphertext length: $ciphertextLength")
+        }
+        if (ciphertextLength > maxCiphertextLength) {
+            throw IOException(
+                "DAEAD chunk ciphertext length $ciphertextLength exceeds maxCiphertextLength $maxCiphertextLength"
+            )
         }
 
         val ciphertext = readExactlyOrNull(ciphertextLength)
@@ -126,12 +157,36 @@ class DaeadChunkDecryptSource(
 /**
  * 현재 [Source]를 DAEAD 청크 복호화 [Source]로 변환합니다.
  *
+ * ```kotlin
+ * val daead = TinkDaeads.AES256_SIV
+ * val decrypted = Buffer()
+ *
+ * encryptedSource.asDaeadChunkDecryptSource(
+ *     daead,
+ *     associatedData = "context".toByteArray(),
+ * ).use { source ->
+ *     while (source.read(decrypted, DEFAULT_BUFFER_SIZE.toLong()) >= 0L) { /* drain */ }
+ * }
+ * ```
+ *
  * @param daead 청크 복호화에 사용할 DAEAD 래퍼
- * @param associatedData 청크 인증에 사용할 연관 데이터
+ * @param associatedData 청크 인증에 사용할 연관 데이터. 암호화 시 사용한 값과 동일해야 합니다.
+ * @param maxCiphertextLength 허용하는 청크 ciphertext 최대 길이. 기본값: [DEFAULT_DAEAD_MAX_CIPHERTEXT_LENGTH].
  * @return DAEAD 청크 복호화 [Source]
+ * @see DaeadChunkEncryptSink
  */
 fun Source.asDaeadChunkDecryptSource(
     daead: TinkDeterministicAead,
     associatedData: ByteArray = ByteArray(0),
+    maxCiphertextLength: Long = DEFAULT_DAEAD_MAX_CIPHERTEXT_LENGTH,
 ): DaeadChunkDecryptSource =
-    DaeadChunkDecryptSource(this, daead, associatedData)
+    DaeadChunkDecryptSource(this, daead, associatedData, maxCiphertextLength)
+
+/**
+ * DAEAD 청크 복호화에서 허용하는 기본 최대 ciphertext 길이 (16 MiB)입니다.
+ *
+ * 신뢰할 수 없는 소스로부터 대규모 메모리 할당 공격을 방어하기 위한 상한선입니다.
+ * 암호화 측의 `chunkSize` 가 이 값보다 크면 [DaeadChunkDecryptSource] 생성 시
+ * `maxCiphertextLength` 파라미터를 명시적으로 지정하세요.
+ */
+const val DEFAULT_DAEAD_MAX_CIPHERTEXT_LENGTH: Long = 16L * 1024 * 1024

--- a/io/okio/src/main/kotlin/io/bluetape4k/okio/tink/DaeadChunkEncryptSink.kt
+++ b/io/okio/src/main/kotlin/io/bluetape4k/okio/tink/DaeadChunkEncryptSink.kt
@@ -20,10 +20,24 @@ import java.io.IOException
  * 이 특성 때문에 동일 청크 평문 반복 여부가 노출될 수 있습니다. 결정성이 필요하지 않은 일반
  * 암호화에는 `TinkEncryptSink`를 사용하세요.
  *
+ * ```kotlin
+ * val daead = TinkDaeads.AES256_SIV
+ * val output = Buffer()
+ *
+ * output.asDaeadChunkEncryptSink(daead).use { sink ->
+ *     val plaintext = Buffer().writeUtf8("대용량 스트리밍 평문")
+ *     sink.write(plaintext, plaintext.size)
+ * }
+ * // output 에는 DAEAD 청크 포맷으로 암호화된 데이터가 담겨 있다.
+ * // DaeadChunkDecryptSource 로 복호화하면 원본 평문을 얻을 수 있다.
+ * ```
+ *
  * @param delegate 암호문을 기록할 위임 [Sink]
  * @param daead 청크 암호화에 사용할 DAEAD 래퍼
  * @param chunkSize 평문 청크 크기. 기본값은 [DEFAULT_DAEAD_CHUNK_SIZE]입니다.
  * @param associatedData 청크 인증에 사용할 연관 데이터. 인증되지만 암호화되지는 않습니다.
+ * @see DaeadChunkDecryptSource
+ * @see TinkEncryptSink
  */
 class DaeadChunkEncryptSink(
     delegate: Sink,
@@ -47,6 +61,7 @@ class DaeadChunkEncryptSink(
      *
      * @param source 평문을 제공하는 버퍼
      * @param byteCount 처리할 바이트 수
+     * @throws IOException close 이후 호출 시, 또는 암호화 실패 시
      */
     override fun write(source: Buffer, byteCount: Long) {
         if (closed) {
@@ -63,6 +78,9 @@ class DaeadChunkEncryptSink(
 
     /**
      * 완성된 청크만 기록하고 partial chunk는 [close]까지 유지합니다.
+     *
+     * **주의**: partial chunk는 [close] 시점에만 기록됩니다. `flush()`를 호출해도
+     * partial chunk는 기록되지 않습니다.
      */
     override fun flush() {
         if (!closed) {
@@ -128,10 +146,21 @@ class DaeadChunkEncryptSink(
 /**
  * 현재 [Sink]를 DAEAD 청크 암호화 [Sink]로 변환합니다.
  *
+ * ```kotlin
+ * val daead = TinkDaeads.AES256_SIV
+ * val output = Buffer()
+ *
+ * output.asDaeadChunkEncryptSink(daead, associatedData = "context".toByteArray()).use { sink ->
+ *     sink.write(Buffer().writeUtf8("hello"), 5L)
+ * }
+ * // output 을 DaeadChunkDecryptSource 로 같은 associatedData 를 사용해 복호화하세요.
+ * ```
+ *
  * @param daead 청크 암호화에 사용할 DAEAD 래퍼
- * @param chunkSize 평문 청크 크기. 기본값은 [DEFAULT_DAEAD_CHUNK_SIZE]입니다.
- * @param associatedData 청크 인증에 사용할 연관 데이터
+ * @param chunkSize 평문 청크 크기. 기본값은 [DEFAULT_DAEAD_CHUNK_SIZE] (64 KiB)입니다.
+ * @param associatedData 청크 인증에 사용할 연관 데이터. 복호화 시 동일한 값을 전달해야 합니다.
  * @return DAEAD 청크 암호화 [Sink]
+ * @see DaeadChunkDecryptSource
  */
 fun Sink.asDaeadChunkEncryptSink(
     daead: TinkDeterministicAead,
@@ -141,6 +170,10 @@ fun Sink.asDaeadChunkEncryptSink(
     DaeadChunkEncryptSink(this, daead, chunkSize, associatedData)
 
 /**
- * DAEAD 청크 암호화에서 사용하는 기본 평문 청크 크기입니다.
+ * DAEAD 청크 암호화에서 사용하는 기본 평문 청크 크기 (64 KiB)입니다.
+ *
+ * 암호화 Sink 생성 시 [chunkSize] 파라미터로 이 값을 재정의할 수 있습니다.
+ * [DaeadChunkDecryptSource]는 헤더에서 ciphertext 길이를 읽으므로 복호화 측에서
+ * 별도로 chunkSize 를 지정할 필요가 없습니다.
  */
 const val DEFAULT_DAEAD_CHUNK_SIZE: Int = 64 * 1024

--- a/io/okio/src/test/kotlin/io/bluetape4k/okio/tink/DaeadChunkDecryptSourceTest.kt
+++ b/io/okio/src/test/kotlin/io/bluetape4k/okio/tink/DaeadChunkDecryptSourceTest.kt
@@ -6,6 +6,7 @@ import okio.EOFException
 import okio.ForwardingSource
 import okio.Source
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeLessThan
 import org.junit.jupiter.api.Test
 import java.io.IOException
 import kotlin.test.assertFailsWith
@@ -95,9 +96,26 @@ class DaeadChunkDecryptSourceTest: AbstractTinkEncryptTest() {
     }
 
     @Test
-    fun `invalid ciphertext length throws io exception`() {
+    fun `invalid ciphertext length zero throws io exception`() {
         assertFailsWith<IOException> {
             Buffer().writeLong(0L).asDaeadChunkDecryptSource(daead).read(Buffer(), 1L)
+        }
+    }
+
+    @Test
+    fun `negative ciphertext length throws io exception`() {
+        assertFailsWith<IOException> {
+            Buffer().writeLong(-1L).asDaeadChunkDecryptSource(daead).read(Buffer(), 1L)
+        }
+    }
+
+    @Test
+    fun `ciphertext length exceeding maxCiphertextLength throws io exception`() {
+        val smallMax = 100L
+        val header = Buffer().writeLong(smallMax + 1L)
+
+        assertFailsWith<IOException> {
+            header.asDaeadChunkDecryptSource(daead, maxCiphertextLength = smallMax).read(Buffer(), 1L)
         }
     }
 
@@ -135,7 +153,65 @@ class DaeadChunkDecryptSourceTest: AbstractTinkEncryptTest() {
 
         source.read(decrypted, 1L) shouldBeEqualTo 1L
 
-        (countingSource.bytesRead < encryptedSize) shouldBeEqualTo true
+        countingSource.bytesRead shouldBeLessThan encryptedSize
+    }
+
+    @Test
+    fun `read after close throws IOException`() {
+        val source = encrypt("hello".toByteArray(), chunkSize = 4).asDaeadChunkDecryptSource(daead)
+        source.close()
+
+        assertFailsWith<IOException> {
+            source.read(Buffer(), 1L)
+        }
+    }
+
+    @Test
+    fun `close is idempotent`() {
+        val closeCountingSource = CloseCountingSource(encrypt("hello".toByteArray(), chunkSize = 4))
+        val source = closeCountingSource.asDaeadChunkDecryptSource(daead)
+
+        source.close()
+        source.close()
+
+        closeCountingSource.closeCount shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `stalled source throws IOException after no progress`() {
+        val stalledSource = StalledSource()
+
+        assertFailsWith<IOException> {
+            stalledSource.asDaeadChunkDecryptSource(daead).read(Buffer(), 1L)
+        }
+    }
+
+    @Test
+    fun `round-trip with payload size exact multiple of chunkSize`() {
+        val chunkSize = 16
+        listOf(1, 2, 4).forEach { multiple ->
+            val plaintext = ByteArray(chunkSize * multiple) { (it % 127).toByte() }
+            val encrypted = encrypt(plaintext, chunkSize = chunkSize)
+
+            val decrypted = Buffer()
+            encrypted.asDaeadChunkDecryptSource(daead).readAllTo(decrypted)
+
+            decrypted.readByteArray() shouldBeEqualTo plaintext
+        }
+    }
+
+    @Test
+    fun `round-trip with payload sizes around chunk boundaries`() {
+        val chunkSize = 16
+        listOf(chunkSize - 1, chunkSize, chunkSize + 1, 2 * chunkSize - 1, 2 * chunkSize, 2 * chunkSize + 1).forEach { size ->
+            val plaintext = ByteArray(size) { (it % 251).toByte() }
+            val encrypted = encrypt(plaintext, chunkSize = chunkSize)
+
+            val decrypted = Buffer()
+            encrypted.asDaeadChunkDecryptSource(daead).readAllTo(decrypted)
+
+            decrypted.readByteArray() shouldBeEqualTo plaintext
+        }
     }
 
     private fun encrypt(
@@ -172,5 +248,22 @@ class DaeadChunkDecryptSourceTest: AbstractTinkEncryptTest() {
             }
             return read
         }
+    }
+
+    private class CloseCountingSource(delegate: Source): ForwardingSource(delegate) {
+        var closeCount: Int = 0
+            private set
+
+        override fun close() {
+            closeCount++
+            super.close()
+        }
+    }
+
+    /** 항상 0L 을 반환하여 진행 없음(no progress) 상태를 시뮬레이션하는 [Source]. */
+    private class StalledSource: Source {
+        override fun read(sink: Buffer, byteCount: Long): Long = 0L
+        override fun timeout() = okio.Timeout.NONE
+        override fun close() = Unit
     }
 }

--- a/io/okio/src/test/kotlin/io/bluetape4k/okio/tink/DaeadChunkEncryptSinkTest.kt
+++ b/io/okio/src/test/kotlin/io/bluetape4k/okio/tink/DaeadChunkEncryptSinkTest.kt
@@ -3,7 +3,9 @@ package io.bluetape4k.okio.tink
 import io.bluetape4k.tink.daead.TinkDaeads
 import okio.Buffer
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
 import org.junit.jupiter.api.Test
+import java.io.IOException
 import kotlin.test.assertFailsWith
 
 class DaeadChunkEncryptSinkTest: AbstractTinkEncryptTest() {
@@ -68,7 +70,7 @@ class DaeadChunkEncryptSinkTest: AbstractTinkEncryptTest() {
         encrypted.size shouldBeEqualTo 0L
 
         sink.close()
-        (encrypted.size > 0L) shouldBeEqualTo true
+        encrypted.size shouldBeGreaterThan 0L
     }
 
     @Test
@@ -103,6 +105,90 @@ class DaeadChunkEncryptSinkTest: AbstractTinkEncryptTest() {
         encrypted.asDaeadChunkDecryptSource(daead, associatedData = byteArrayOf(1)).readAllTo(decrypted)
 
         decrypted.readUtf8() shouldBeEqualTo "secret"
+    }
+
+    @Test
+    fun `write after close throws IOException`() {
+        val sink = Buffer().asDaeadChunkEncryptSink(daead)
+        sink.close()
+
+        assertFailsWith<IOException> {
+            sink.write(Buffer().writeUtf8("x"), 1L)
+        }
+    }
+
+    @Test
+    fun `close is idempotent`() {
+        val encrypted = Buffer()
+        val sink = encrypted.asDaeadChunkEncryptSink(daead)
+        sink.write(Buffer().writeUtf8("hello"), 5L)
+
+        sink.close()
+        val sizeAfterFirstClose = encrypted.size
+        sink.close()
+
+        encrypted.size shouldBeEqualTo sizeAfterFirstClose
+    }
+
+    @Test
+    fun `flush after close is no-op`() {
+        val encrypted = Buffer()
+        val sink = encrypted.asDaeadChunkEncryptSink(daead)
+        sink.write(Buffer().writeUtf8("hello"), 5L)
+        sink.close()
+        val sizeAfterClose = encrypted.size
+
+        sink.flush()
+
+        encrypted.size shouldBeEqualTo sizeAfterClose
+    }
+
+    @Test
+    fun `write zero bytes is no-op`() {
+        val encrypted = Buffer()
+        val sink = encrypted.asDaeadChunkEncryptSink(daead, chunkSize = 4)
+
+        sink.write(Buffer(), 0L)
+        sink.flush()
+
+        encrypted.size shouldBeEqualTo 0L
+        sink.close()
+    }
+
+    @Test
+    fun `round-trip with payload size exact multiple of chunkSize`() {
+        val chunkSize = 16
+        listOf(1, 2, 4).forEach { multiple ->
+            val plaintext = ByteArray(chunkSize * multiple) { (it % 127).toByte() }
+            val encrypted = Buffer()
+
+            encrypted.asDaeadChunkEncryptSink(daead, chunkSize = chunkSize).use { sink ->
+                sink.write(Buffer().write(plaintext), plaintext.size.toLong())
+            }
+
+            val decrypted = Buffer()
+            encrypted.asDaeadChunkDecryptSource(daead).readAllTo(decrypted)
+
+            decrypted.readByteArray() shouldBeEqualTo plaintext
+        }
+    }
+
+    @Test
+    fun `round-trip with payload sizes around chunk boundaries`() {
+        val chunkSize = 16
+        listOf(chunkSize - 1, chunkSize, chunkSize + 1, 2 * chunkSize - 1, 2 * chunkSize, 2 * chunkSize + 1).forEach { size ->
+            val plaintext = ByteArray(size) { (it % 251).toByte() }
+            val encrypted = Buffer()
+
+            encrypted.asDaeadChunkEncryptSink(daead, chunkSize = chunkSize).use { sink ->
+                sink.write(Buffer().write(plaintext), plaintext.size.toLong())
+            }
+
+            val decrypted = Buffer()
+            encrypted.asDaeadChunkDecryptSource(daead).readAllTo(decrypted)
+
+            decrypted.readByteArray() shouldBeEqualTo plaintext
+        }
     }
 
     private fun DaeadChunkDecryptSource.readAllTo(sink: Buffer): Long {


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: 일일 코드리뷰 — okio DAEAD 보안/테스트 강화 + images 불변성 버그 수정

일일 자동 코드리뷰(5개 에이전트) 결과 반영. 지난 24시간 병합된 PR #242(okio DAEAD 청크)와 최근 images 모듈에서 발견된 HIGH/CRITICAL 이슈를 수정합니다.

---

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### `io/okio` — DaeadChunkEncryptSink / DaeadChunkDecryptSource

| 항목 | 내용 |
|------|------|
| **[HIGH] KDoc 예제 추가** | 클래스·확장 함수 모두에 `kotlin` 예제 블록 및 `@see` 크로스 레퍼런스 추가 |
| **[HIGH] DoS 방어** | `DaeadChunkDecryptSource`에 `maxCiphertextLength` 파라미터 추가 (기본 16 MiB). 기존 2 GiB → OOM 공격 방어 |
| **[HIGH] 누락 테스트 추가** | write/read-after-close, close-idempotent, flush-after-close, stalled-source, exact-multiple, boundary 등 12개 신규 테스트 (총 32개 → 전부 통과) |
| **[HIGH] README 오류 수정** | 레거시 `TinkEncryptSink` 단일-ciphertext 설명 불일치 수정 + associatedData/스트리밍 특성 추가 |

### `images/images` — ImmutableImageSupport / BufferedImageSupport

| 항목 | 내용 |
|------|------|
| **[CRITICAL] 불변성 위반 수정** | `ImmutableImage.useGraphics()` 는 내부 backing buffer 를 직접 변경하여 불변 계약 위반. `withGraphics()` 를 신규 추가 (복사본에 작업 → 새 ImmutableImage 반환). 기존 `useGraphics()` `@Deprecated` 처리 |
| **[HIGH] null 안전성** | `bufferedImageOf()` 5개 오버로드가 `ImageIO.read()` null 반환을 그대로 노출. `IllegalArgumentException` 발생으로 변경 |

---

### 기존 섹션: 검증 명령

```bash
./gradlew :bluetape4k-okio:test --tests "io.bluetape4k.okio.tink.DaeadChunk*"
./gradlew :bluetape4k-images:test --tests "io.bluetape4k.images.BufferedImageSupportTest"
```

## Validation

```
bluetape4k-okio DaeadChunk* : 32 passing (1.8s)
bluetape4k-images BufferedImageSupportTest : 10 passing (3.2s)
```

---

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #244, head `4f90ba039329d8c72e65a65d7dc5baf6e014c631`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `claude/fervent-snyder-d0e5ba`
- Labels: `documentation`, `chore`
- State: `MERGED`, merge commit `b943d9f76aa4e721b64a4a34375765baf1bbcc55`
- CI: | **[HIGH] DoS 방어** | `DaeadChunkDecryptSource`에 `maxCiphertextLength` 파라미터 추가 (기본 16 MiB). 기존 2 GiB → OOM 공격 방어 | / | **[HIGH] README 오류 수정** | 레거시 `TinkEncryptSink` 단일-ciphertext 설명 불일치 수정 + associatedData/스트리밍 특성 추가 | / ./gradlew :bluetape4k-okio:test --tests "io.bluetape4k.okio.tink.DaeadChunk*"

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #244 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `b943d9f76aa4e721b64a4a34375765baf1bbcc55`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
