### PR TITLE
fix: Kover 커버리지 측정 오류 수정 및 vips 테스트 자동 감지

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,10 +277,10 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 30
 
-  # ── 5-b. images-vips 모듈 테스트 (libvips 설치 필요) ────────────────────────
-  test-images-vips:
-    name: Test / Images Vips
-    runs-on: ubuntu-24.04
+  # ── 5-b. images-vips-java21 테스트 (ubuntu-22.04 — jvips JNI ABI 호환) ──────
+  test-images-vips-java21:
+    name: Test / Images Vips (Java21/JNI)
+    runs-on: ubuntu-22.04
     needs: build
     steps:
       - uses: actions/checkout@v4
@@ -322,6 +322,54 @@ jobs:
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
+      - name: Generate Kover XML report
+        if: always()
+        run: |
+          ./gradlew \
+            :bluetape4k-images-vips-api:koverXmlReport \
+            :bluetape4k-images-vips-java21:koverXmlReport \
+            --parallel
+        continue-on-error: true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-images-vips-java21
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 30
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-images-vips-java21
+          path: '**/build/reports/kover/'
+          retention-days: 30
+
+  # ── 5-c. images-vips-java25 테스트 (ubuntu-24.04 — FFM API, libvips 8.15+) ──
+  test-images-vips-java25:
+    name: Test / Images Vips (Java25/FFM)
+    runs-on: ubuntu-24.04
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install libvips
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libvips-dev
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
       - name: Test images-vips-java25
         uses: nick-fields/retry@v3
         with:
@@ -338,17 +386,14 @@ jobs:
         if: always()
         run: |
           ./gradlew \
-            :bluetape4k-images-vips-api:koverXmlReport \
-            :bluetape4k-images-vips-java21:koverXmlReport \
-            :bluetape4k-images-vips-java25:koverXmlReport \
-            --parallel
+            :bluetape4k-images-vips-java25:koverXmlReport
         continue-on-error: true
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-images-vips
+          name: test-results-images-vips-java25
           path: '**/build/test-results/test/*.xml'
           retention-days: 30
 
@@ -356,7 +401,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-images-vips
+          name: coverage-images-vips-java25
           path: '**/build/reports/kover/'
           retention-days: 30
 
@@ -607,7 +652,7 @@ jobs:
   coverage-report:
     name: Coverage Report
     runs-on: ubuntu-latest
-    needs: [test-core, test-io, test-key-utils, test-images, test-images-vips, test-infra, test-exposed-jdbc]
+    needs: [test-core, test-io, test-key-utils, test-images, test-images-vips-java21, test-images-vips-java25, test-infra, test-exposed-jdbc]
     if: always()
     steps:
       - uses: actions/checkout@v4
@@ -645,7 +690,7 @@ jobs:
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
-    needs: [gitleaks, validate-wrapper, spring-boot-parity, build, test-core, test-io, test-key-utils, test-images, test-images-vips, test-infra, test-exposed-jdbc, coverage-report]
+    needs: [gitleaks, validate-wrapper, spring-boot-parity, build, test-core, test-io, test-key-utils, test-images, test-images-vips-java21, test-images-vips-java25, test-infra, test-exposed-jdbc, coverage-report]
     if: always()
     steps:
       - name: Check all jobs

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -371,9 +371,80 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── images-vips 모듈 테스트 (libvips 설치 필요) ────────────────────────────
-  test-images-vips:
-    name: Test / Images Vips (Nightly)
+  # ── images-vips-java21 테스트 (ubuntu-22.04 — jvips JNI ABI 호환) ─────────
+  test-images-vips-java21:
+    name: Test / Images Vips (Java21/JNI, Nightly)
+    runs-on: ubuntu-22.04
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install libvips
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libvips-dev
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Test images-vips-api and images-vips-java21
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          shell: bash
+          command: |
+            ./gradlew \
+              :bluetape4k-images-vips-api:test \
+              :bluetape4k-images-vips-java21:test \
+              -Dvips.enabled=true \
+              --no-daemon
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Generate Kover XML report
+        if: always()
+        run: |
+          ./gradlew \
+            :bluetape4k-images-vips-api:koverXmlReport \
+            :bluetape4k-images-vips-java21:koverXmlReport \
+            --parallel
+        continue-on-error: true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-test-results-images-vips-java21
+          path: "**/build/test-results/test/*.xml"
+          retention-days: 14
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-coverage-images-vips-java21
+          path: '**/build/reports/kover/'
+          retention-days: 14
+
+      - name: Upload golden diff report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: golden-diffs-images-vips-java21
+          path: '**/build/reports/golden-diffs/vips/'
+          retention-days: 7
+
+  # ── images-vips-java25 테스트 (ubuntu-24.04 — FFM API, libvips 8.15+) ──────
+  test-images-vips-java25:
+    name: Test / Images Vips (Java25/FFM, Nightly)
     runs-on: ubuntu-24.04
     needs: build
     steps:
@@ -394,7 +465,7 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
 
-      - name: Test images-vips modules
+      - name: Test images-vips-java25
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 30
@@ -402,8 +473,6 @@ jobs:
           shell: bash
           command: |
             ./gradlew \
-              :bluetape4k-images-vips-api:test \
-              :bluetape4k-images-vips-java21:test \
               :bluetape4k-images-vips-java25:test \
               -Dvips.enabled=true \
               --no-daemon
@@ -415,17 +484,14 @@ jobs:
         if: always()
         run: |
           ./gradlew \
-            :bluetape4k-images-vips-api:koverXmlReport \
-            :bluetape4k-images-vips-java21:koverXmlReport \
-            :bluetape4k-images-vips-java25:koverXmlReport \
-            --parallel
+            :bluetape4k-images-vips-java25:koverXmlReport
         continue-on-error: true
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: nightly-test-results-images-vips
+          name: nightly-test-results-images-vips-java25
           path: "**/build/test-results/test/*.xml"
           retention-days: 14
 
@@ -433,7 +499,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: nightly-coverage-images-vips
+          name: nightly-coverage-images-vips-java25
           path: '**/build/reports/kover/'
           retention-days: 14
 
@@ -441,7 +507,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: golden-diffs-images-vips
+          name: golden-diffs-images-vips-java25
           path: '**/build/reports/golden-diffs/vips/'
           retention-days: 7
 
@@ -1432,7 +1498,8 @@ jobs:
       - test-io-http
       - test-utils
       - test-images
-      - test-images-vips
+      - test-images-vips-java21
+      - test-images-vips-java25
       - test-misc
       - test-exposed-core
       - test-spring-h2
@@ -1480,7 +1547,8 @@ jobs:
       - test-io-http
       - test-utils
       - test-images
-      - test-images-vips
+      - test-images-vips-java21
+      - test-images-vips-java25
       - test-misc
       - test-exposed-core
       - test-spring-h2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -180,6 +180,24 @@ subprojects {
         }
     }
 
+    // Kotlin 인터페이스 default 메서드 bridge 클래스는 컴파일러 생성 코드 — 커버리지 제외
+    pluginManager.withPlugin(Plugins.kover) {
+        kover {
+            currentProject {
+                instrumentation {
+                    excludedClasses.add("**\$DefaultImpls")
+                }
+            }
+            reports {
+                filters {
+                    excludes {
+                        classes("**\$DefaultImpls")
+                    }
+                }
+            }
+        }
+    }
+
     tasks {
         val signingUsesGpgCmd = resolvePublishingSigningConfig().useGpgCmd
 
@@ -704,6 +722,17 @@ dependencyCheck {
 // ─── Kover 집계 설정 ────────────────────────────────────────────────────
 // 루트 프로젝트에서 모든 측정 대상 서브모듈을 `kover` 의존성으로 등록하여
 // `./gradlew koverXmlReport` / `koverHtmlReport` 실행 시 집계된 리포트를 생성한다.
+kover {
+    reports {
+        filters {
+            excludes {
+                // Kotlin 컴파일러 생성 interface bridge 클래스 — 집계 리포트에서도 제외
+                classes("**\$DefaultImpls")
+            }
+        }
+    }
+}
+
 dependencies {
     subprojects
         .filter { sub ->

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,12 +113,8 @@ subprojects {
         // Atomicfu
         plugin("org.jetbrains.kotlinx.atomicfu")
 
-        // Kover — Kotlin 코드 커버리지 (examples/workshop/-demo/-benchmark/-vips-java* 는 제외)
-        // images-vips-java21/java25: 네이티브 libvips 필요 — CI에서 테스트 항상 skip → 집계 제외
-        if (!path.contains("workshop") && !path.contains("examples") && !path.contains("-demo") &&
-            !path.endsWith("-benchmark") &&
-            name != "bluetape4k-images-vips-java21" && name != "bluetape4k-images-vips-java25"
-        ) {
+        // Kover — Kotlin 코드 커버리지 (examples/workshop/-demo/-benchmark 는 별도 필터링)
+        if (!path.contains("workshop") && !path.contains("examples") && !path.contains("-demo") && !path.endsWith("-benchmark")) {
             plugin(Plugins.kover)
         }
 
@@ -740,10 +736,7 @@ dependencies {
                     !sub.path.contains("workshop") &&
                     !sub.path.contains("examples") &&
                     !sub.path.contains("-demo") &&
-                    !sub.path.endsWith("-benchmark") &&
-                    // 네이티브 libvips 필요 — CI에서 테스트 항상 skip되므로 집계 제외
-                    sub.name != "bluetape4k-images-vips-java21" &&
-                    sub.name != "bluetape4k-images-vips-java25"
+                    !sub.path.endsWith("-benchmark")
         }
         .forEach { sub -> kover(project(sub.path)) }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,8 +113,12 @@ subprojects {
         // Atomicfu
         plugin("org.jetbrains.kotlinx.atomicfu")
 
-        // Kover — Kotlin 코드 커버리지 (examples/workshop/-demo/-benchmark 는 별도 필터링)
-        if (!path.contains("workshop") && !path.contains("examples") && !path.contains("-demo") && !path.endsWith("-benchmark")) {
+        // Kover — Kotlin 코드 커버리지 (examples/workshop/-demo/-benchmark/-vips-java* 는 제외)
+        // images-vips-java21/java25: 네이티브 libvips 필요 — CI에서 테스트 항상 skip → 집계 제외
+        if (!path.contains("workshop") && !path.contains("examples") && !path.contains("-demo") &&
+            !path.endsWith("-benchmark") &&
+            name != "bluetape4k-images-vips-java21" && name != "bluetape4k-images-vips-java25"
+        ) {
             plugin(Plugins.kover)
         }
 
@@ -160,6 +164,19 @@ subprojects {
         atomicfu {
             transformJvm = true
             jvmVariant = "VH"     //  FU, VH, BOTH
+        }
+    }
+
+    // testFixtures 소스셋은 테스트 유틸리티이므로 커버리지 측정에서 제외
+    pluginManager.withPlugin("java-test-fixtures") {
+        pluginManager.withPlugin(Plugins.kover) {
+            kover {
+                currentProject {
+                    sources {
+                        excludedSourceSets.add("testFixtures")
+                    }
+                }
+            }
         }
     }
 
@@ -694,7 +711,10 @@ dependencies {
                     !sub.path.contains("workshop") &&
                     !sub.path.contains("examples") &&
                     !sub.path.contains("-demo") &&
-                    !sub.path.endsWith("-benchmark")
+                    !sub.path.endsWith("-benchmark") &&
+                    // 네이티브 libvips 필요 — CI에서 테스트 항상 skip되므로 집계 제외
+                    sub.name != "bluetape4k-images-vips-java21" &&
+                    sub.name != "bluetape4k-images-vips-java25"
         }
         .forEach { sub -> kover(project(sub.path)) }
 }

--- a/images/images-vips-java21/build.gradle.kts
+++ b/images/images-vips-java21/build.gradle.kts
@@ -23,8 +23,9 @@ tasks.withType<Test>().configureEach {
     // JNI native library: isolate each test class in its own JVM fork
     forkEvery = 1
     maxParallelForks = 1
-    // Skip libvips-dependent tests when native library is unavailable
-    systemProperty("vips.enabled", System.getProperty("vips.enabled", "false"))
+    // 명시적으로 -Dvips.enabled=false/true 를 전달한 경우만 전파한다.
+    // 미설정 시 AbstractJVipsTest 가 JVipsRuntime.init() 결과로 자동 감지한다.
+    System.getProperty("vips.enabled")?.let { systemProperty("vips.enabled", it) }
 }
 
 dependencies {

--- a/images/images-vips-java21/src/test/kotlin/io/bluetape4k/images/vips/java21/AbstractJVipsTest.kt
+++ b/images/images-vips-java21/src/test/kotlin/io/bluetape4k/images/vips/java21/AbstractJVipsTest.kt
@@ -12,13 +12,14 @@ abstract class AbstractJVipsTest {
         @JvmStatic
         @BeforeAll
         fun initRuntime() {
-            val enabled = System.getProperty("vips.enabled", "false").toBoolean()
-            if (!enabled) {
-                assumeTrue(false, "libvips not available — set -Dvips.enabled=true to run these tests")
+            // -Dvips.enabled=false 이면 명시적 opt-out
+            if (System.getProperty("vips.enabled") == "false") {
+                assumeTrue(false, "vips tests disabled via -Dvips.enabled=false")
             }
+            // libvips 자동 감지: init() 실패 시 skip
             runCatching { JVipsRuntime.init() }.onFailure { e ->
                 log.warn("JVipsRuntime.init() failed — skipping vips tests: ${e.message}")
-                assumeTrue(false, "JVipsRuntime initialization failed: ${e.message}")
+                assumeTrue(false, "libvips not available: ${e.message}")
             }
         }
     }

--- a/images/images-vips-java25/build.gradle.kts
+++ b/images/images-vips-java25/build.gradle.kts
@@ -28,8 +28,9 @@ tasks.withType<Test>().configureEach {
     jvmArgs("--enable-native-access=ALL-UNNAMED")
     forkEvery = 1
     maxParallelForks = 1
-    // Skip libvips-dependent tests when native library is unavailable
-    systemProperty("vips.enabled", System.getProperty("vips.enabled", "false"))
+    // 명시적으로 -Dvips.enabled=false/true 를 전달한 경우만 전파한다.
+    // 미설정 시 AbstractFfmVipsTest 가 FfmVipsRuntime.init() 결과로 자동 감지한다.
+    System.getProperty("vips.enabled")?.let { systemProperty("vips.enabled", it) }
     // macOS (Homebrew): libvips lives in /opt/homebrew/lib which dlopen doesn't find by default.
     // FFM SymbolLookup.libraryLookup uses dlopen, not java.library.path — need DYLD_LIBRARY_PATH.
     val homebrewLib = "/opt/homebrew/lib"

--- a/images/images-vips-java25/src/test/kotlin/io/bluetape4k/images/vips/java25/AbstractFfmVipsTest.kt
+++ b/images/images-vips-java25/src/test/kotlin/io/bluetape4k/images/vips/java25/AbstractFfmVipsTest.kt
@@ -12,13 +12,14 @@ abstract class AbstractFfmVipsTest {
         @JvmStatic
         @BeforeAll
         fun initRuntime() {
-            val enabled = System.getProperty("vips.enabled", "false").toBoolean()
-            if (!enabled) {
-                assumeTrue(false, "libvips not available — set -Dvips.enabled=true to run these tests")
+            // -Dvips.enabled=false 이면 명시적 opt-out
+            if (System.getProperty("vips.enabled") == "false") {
+                assumeTrue(false, "vips tests disabled via -Dvips.enabled=false")
             }
+            // libvips 자동 감지: init() 실패 시 skip
             runCatching { FfmVipsRuntime.init() }.onFailure { e ->
                 log.warn("FfmVipsRuntime.init() failed — skipping vips tests: ${e.message}")
-                assumeTrue(false, "FfmVipsRuntime initialization failed: ${e.message}")
+                assumeTrue(false, "libvips not available: ${e.message}")
             }
         }
     }


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: Kover 커버리지 측정 오류 수정 및 vips 테스트 자동 감지

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 1. Kover testFixtures 소스셋 제외
`java-test-fixtures` 플러그인 적용 모듈에서 `testFixtures` 소스셋을 Kover 측정 대상에서 전역 제외.

**영향 모듈**: `images-vips-api`, `exposed-cache`, `cache-core`, `elasticsearch`

변경 전: `images-vips-api` 124/654 = 15.94% (testFixtures 포함)
변경 후: `images-vips-api` 18/45 = 40.0% (main 코드 기준)

### 2. Kotlin $DefaultImpls 브릿지 클래스 제외
Kotlin 인터페이스 default 메서드 구현 시 컴파일러가 생성하는 `$DefaultImpls` 합성 클래스를 Kover 측정에서 전역 제외. 이 클래스들은 직접 호출되지 않아 항상 0%로 측정되어 전체 커버리지를 왜곡했음.

**영향 모듈**: `exposed-jdbc`, `exposed-r2dbc` 등 interface 사용 모듈 전체

변경 전: `exposed-jdbc` 312/371 = 84.1% ($DefaultImpls 포함)
변경 후: `exposed-jdbc` 312/340 = 91.8% ($DefaultImpls 제외)

### 3. vips-java21/25 Kover 제외 철회
CI (ubuntu-latest)에서 libvips 설치 후 `-Dvips.enabled=true`로 테스트를 실행하므로 Kover 제외 불필요. 제외 시 CI의 `:koverXmlReport` 태스크가 없어져 CI가 깨지는 문제도 있음.

### 4. images-vips-java21/25 테스트 자동 감지
`vips.enabled=false` 기본값으로 항상 skip하던 방식에서, `Runtime.init()` 시도 후 실패 시 skip하는 자동 감지로 변경.

**변경 전**: `-Dvips.enabled=true` 없으면 항상 skip
**변경 후**:
- `vips.enabled` 미설정 → `init()` 시도 → libvips 있으면 실행, 없으면 자동 skip
- `-Dvips.enabled=false` → 명시적 opt-out (빠른 로컬 빌드용)
- `-Dvips.enabled=true` (CI) → 기존대로 동작

**효과**: Mac (Homebrew libvips 설치 시) 로컬에서도 테스트 자동 실행됨

## Validation

- `images-vips-api:koverXmlReport`: BUILD SUCCESSFUL, testFixtures 클래스 제거 확인
- `exposed-jdbc:koverXmlReport`: $DefaultImpls 클래스 제거 확인 (312/340 = 91.8%)
- `images-vips-java21:tasks`: 기존 Kover 태스크 정상 존재 확인
- `compileTestKotlin` for java21/java25: 컴파일 성공

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #245, head `0684e945bff32706774a0153c8ec3c050c11b80d`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/kover-coverage-excludes`
- Labels: `build`
- State: `MERGED`, merge commit `e4ae8568712c21aead1e95b18b20c1f07d943453`
- CI: CI (ubuntu-latest)에서 libvips 설치 후 `-Dvips.enabled=true`로 테스트를 실행하므로 Kover 제외 불필요. 제외 시 CI의 `:koverXmlReport` 태스크가 없어져 CI가 깨지는 문제도 있음. / - `-Dvips.enabled=true` (CI) → 기존대로 동작

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #245 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e4ae8568712c21aead1e95b18b20c1f07d943453`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
