### PR TITLE
fix: exposed 가상 스레드 executor 소유권 보장

### DIFF
--- a/data/exposed-jdbc/README.ko.md
+++ b/data/exposed-jdbc/README.ko.md
@@ -144,8 +144,8 @@ val allIds = UserTable
 ### 4. Virtual Thread 트랜잭션
 
 ```kotlin
-import io.bluetape4k.exposed.jdbc.transactions.newVirtualThreadJdbcTransaction
-import io.bluetape4k.exposed.jdbc.transactions.virtualThreadJdbcTransactionAsync
+import io.bluetape4k.exposed.jdbc.newVirtualThreadJdbcTransaction
+import io.bluetape4k.exposed.jdbc.virtualThreadJdbcTransactionAsync
 
 // JDK 21+ Virtual Thread에서 동기 트랜잭션 실행
 val count = newVirtualThreadJdbcTransaction {
@@ -161,6 +161,8 @@ val futures = List(10) { index ->
 }
 val results = futures.awaitAll()
 ```
+
+`executor = null`은 공유 `VirtualThreadExecutor`를 재사용합니다. 커스텀 Executor는 호출자가 소유하며 직접 종료해야 합니다.
 
 ### 5. ExposedPage — 페이징 결과
 
@@ -614,7 +616,7 @@ sequenceDiagram
 | `jdbc/repository/SoftDeletedJdbcRepository.kt`      | Soft Delete 지원 Repository          |
 | `repository/ExposedRepository.kt`                   | (Deprecated) 구 Repository 인터페이스    |
 | `core/SuspendedQuery.kt`                            | 커서 기반 배치 Flow 쿼리                   |
-| `jdbc/transactions/VirtualThreadJdbcTransaction.kt` | Virtual Thread 기반 JDBC 트랜잭션        |
+| `jdbc/VirtualThreadJdbcTransaction.kt`              | Virtual Thread 기반 JDBC 트랜잭션        |
 | `core/transactions/VirtualThreadTransaction.kt`     | (Deprecated) 구 Virtual Thread 트랜잭션 |
 | `core/ImplicitSelectAll.kt`                         | `SELECT *` 형태의 묵시적 전체 조회           |
 | `core/TableExtensions.kt`                           | 테이블 메타데이터 확장 함수                    |

--- a/data/exposed-jdbc/README.md
+++ b/data/exposed-jdbc/README.md
@@ -144,8 +144,8 @@ val allIds = UserTable
 ### 4. Virtual Thread transactions
 
 ```kotlin
-import io.bluetape4k.exposed.jdbc.transactions.newVirtualThreadJdbcTransaction
-import io.bluetape4k.exposed.jdbc.transactions.virtualThreadJdbcTransactionAsync
+import io.bluetape4k.exposed.jdbc.newVirtualThreadJdbcTransaction
+import io.bluetape4k.exposed.jdbc.virtualThreadJdbcTransactionAsync
 
 // Run a synchronous transaction on a JDK 21+ Virtual Thread
 val count = newVirtualThreadJdbcTransaction {
@@ -161,6 +161,8 @@ val futures = List(10) { index ->
 }
 val results = futures.awaitAll()
 ```
+
+Passing `executor = null` reuses the shared `VirtualThreadExecutor`. Custom executors remain caller-owned and must be shut down by the caller.
 
 ### 5. ExposedPage — paginated results
 
@@ -615,7 +617,7 @@ sequenceDiagram
 | `jdbc/repository/SoftDeletedJdbcRepository.kt`      | Soft Delete Repository                         |
 | `repository/ExposedRepository.kt`                   | (Deprecated) Legacy Repository interface       |
 | `core/SuspendedQuery.kt`                            | Cursor-based batch Flow query                  |
-| `jdbc/transactions/VirtualThreadJdbcTransaction.kt` | Virtual Thread-based JDBC transaction          |
+| `jdbc/VirtualThreadJdbcTransaction.kt`              | Virtual Thread-based JDBC transaction          |
 | `core/transactions/VirtualThreadTransaction.kt`     | (Deprecated) Legacy Virtual Thread transaction |
 | `core/ImplicitSelectAll.kt`                         | Implicit `SELECT *` query                      |
 | `core/TableExtensions.kt`                           | Table metadata extension functions             |

--- a/data/exposed-jdbc/src/main/kotlin/io/bluetape4k/exposed/jdbc/VirtualThreadJdbcTransaction.kt
+++ b/data/exposed-jdbc/src/main/kotlin/io/bluetape4k/exposed/jdbc/VirtualThreadJdbcTransaction.kt
@@ -8,7 +8,6 @@ import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.transactions.transactionManager
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
 
 /**
  * 가상 스레드에서 JDBC 트랜잭션을 실행하고 결과를 동기적으로 반환합니다.
@@ -16,7 +15,7 @@ import java.util.concurrent.Executors
  * 내부적으로 [virtualThreadJdbcTransactionAsync]를 호출하고 결과를 블로킹 대기합니다.
  * 가상 스레드를 사용하므로 플랫폼 스레드 풀을 점유하지 않습니다.
  *
- * @param executor 사용할 [ExecutorService] (기본값: [VirtualThreadExecutor] 싱글톤)
+ * @param executor 사용할 [ExecutorService] (기본값: [VirtualThreadExecutor] 싱글톤, null이면 공유 싱글톤 사용)
  * @param db 사용할 [Database] (기본값: null — 현재 기본 데이터베이스 사용)
  * @param transactionIsolation 트랜잭션 격리 수준 (기본값: null — 데이터베이스 기본값 사용)
  * @param readOnly 읽기 전용 트랜잭션 여부 (기본값: false)
@@ -61,7 +60,7 @@ fun <T> newVirtualThreadJdbcTransaction(
  * 현재 트랜잭션의 `readOnly` 설정을 그대로 이어받아 새 트랜잭션을 생성합니다.
  * 외부 트랜잭션과는 독립적인 커넥션을 사용하므로, 중첩 트랜잭션 격리가 필요한 경우에 유용합니다.
  *
- * @param executor 사용할 [ExecutorService] (기본값: [VirtualThreadExecutor] 싱글톤)
+ * @param executor 사용할 [ExecutorService] (기본값: [VirtualThreadExecutor] 싱글톤, null이면 공유 싱글톤 사용)
  * @param statement 트랜잭션 블록 내에서 실행할 람다
  * @return 트랜잭션 블록의 실행 결과 [T]
  *
@@ -94,7 +93,7 @@ fun <T> JdbcTransaction.withVirtualThreadJdbcTransaction(
  * 반환된 [VirtualFuture]에 대해 [VirtualFuture.await]를 호출하면 결과를 블로킹 대기합니다.
  * 여러 [VirtualFuture]를 `awaitAll()`로 한 번에 대기하면 병렬 실행 효과를 얻을 수 있습니다.
  *
- * @param executor 사용할 [ExecutorService] (기본값: [VirtualThreadExecutor] 싱글톤)
+ * @param executor 사용할 [ExecutorService] (기본값: [VirtualThreadExecutor] 싱글톤, null이면 공유 싱글톤 사용)
  * @param db 사용할 [Database] (기본값: null — 현재 기본 데이터베이스 사용)
  * @param transactionIsolation 트랜잭션 격리 수준 (기본값: null — 데이터베이스 기본값 사용)
  * @param readOnly 읽기 전용 트랜잭션 여부 (기본값: false)
@@ -133,7 +132,8 @@ fun <T> virtualThreadJdbcTransactionAsync(
     readOnly: Boolean = false,
     statement: JdbcTransaction.() -> T,
 ): VirtualFuture<T> {
-    val effectiveExecutor = executor ?: Executors.newVirtualThreadPerTaskExecutor()
+    // null은 "새 executor 생성"이 아니라 기본 공유 executor 사용으로 해석해 호출마다 executor가 누수되지 않게 합니다.
+    val effectiveExecutor = executor ?: VirtualThreadExecutor
     require(!effectiveExecutor.isShutdown && !effectiveExecutor.isTerminated) {
         "ExecutorService is already shutdown."
     }

--- a/data/exposed-jdbc/src/test/kotlin/io/bluetape4k/exposed/jdbc/VirtualThreadTransactionTest.kt
+++ b/data/exposed-jdbc/src/test/kotlin/io/bluetape4k/exposed/jdbc/VirtualThreadTransactionTest.kt
@@ -223,6 +223,18 @@ class VirtualThreadTransactionTest: AbstractExposedTest() {
         }
     }
 
+    @ParameterizedTest
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `null executor 는 공유 VirtualThreadExecutor 로 실행된다`(testDB: TestDB) {
+        withTables(testDB, VTester) {
+            val isVirtualThread = newVirtualThreadJdbcTransaction(executor = null) {
+                Thread.currentThread().isVirtual
+            }
+
+            isVirtualThread.shouldBeTrue()
+        }
+    }
+
     /**
      * 이미 종료된(shutdown) executor 를 virtualThreadJdbcTransactionAsync 에 전달하면
      * IllegalArgumentException 이 발생해야 합니다.

--- a/data/exposed-r2dbc/README.ko.md
+++ b/data/exposed-r2dbc/README.ko.md
@@ -423,11 +423,17 @@ val count = virtualThreadTransaction(db = database) {
 
 // 커스텀 Executor 사용
 val executor = Executors.newSingleThreadExecutor()
-val result = virtualThreadTransaction(executor = executor, db = database) {
-    UserTable.insert { it[name] = "Alice" }
-    UserTable.selectAll().count()
+try {
+    val result = virtualThreadTransaction(executor = executor, db = database) {
+        UserTable.insert { it[name] = "Alice" }
+        UserTable.selectAll().count()
+    }
+} finally {
+    executor.shutdown()
 }
 ```
+
+커스텀 Executor는 호출자가 소유합니다. 트랜잭션 헬퍼는 활성 상태만 검증하고, 실행 후 자동으로 종료하지 않습니다.
 
 ## R2DBC Readable 컬럼 값 조회
 

--- a/data/exposed-r2dbc/README.md
+++ b/data/exposed-r2dbc/README.md
@@ -425,11 +425,17 @@ val count = virtualThreadTransaction(db = database) {
 
 // Using a custom Executor
 val executor = Executors.newSingleThreadExecutor()
-val result = virtualThreadTransaction(executor = executor, db = database) {
-    UserTable.insert { it[name] = "Alice" }
-    UserTable.selectAll().count()
+try {
+    val result = virtualThreadTransaction(executor = executor, db = database) {
+        UserTable.insert { it[name] = "Alice" }
+        UserTable.selectAll().count()
+    }
+} finally {
+    executor.shutdown()
 }
 ```
+
+Custom executors are caller-owned. The transaction helper validates that they are active, but it does not shut them down after execution.
 
 ## R2DBC Readable Column Value Access
 

--- a/data/exposed-r2dbc/src/main/kotlin/io/bluetape4k/exposed/r2dbc/VirtualThreadTransaction.kt
+++ b/data/exposed-r2dbc/src/main/kotlin/io/bluetape4k/exposed/r2dbc/VirtualThreadTransaction.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.exposed.r2dbc
 
 import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
 import io.r2dbc.spi.IsolationLevel
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -73,7 +74,9 @@ suspend fun <T> R2dbcTransaction.withVirtualThreadTransaction(
  *
  * ## 동작/계약
  * - [executor]에 맞는 dispatcher를 생성해 `async`로 트랜잭션을 실행합니다.
- * - 사용자 제공 executor를 dispatcher로 만든 경우 실행 완료 후 `close()`로 정리합니다.
+ * - `executor`가 null이면 [VirtualThreadExecutor] 공유 dispatcher를 사용합니다.
+ * - 사용자 제공 [ExecutorService]는 호출자가 소유하므로 이 함수가 종료하거나 닫지 않습니다.
+ * - 이미 종료된 [ExecutorService]를 넘기면 [IllegalArgumentException]을 던집니다.
  * - 반환값은 [Deferred]이며 호출자가 `await()`/`awaitAll()`로 완료를 제어합니다.
  *
  * ```kotlin
@@ -91,21 +94,15 @@ suspend fun <T> virtualThreadTransactionAsync(
     readOnly: Boolean = false,
     statement: suspend R2dbcTransaction.() -> T,
 ): Deferred<T> = coroutineScope {
-    val (dispatcher, shouldClose) = createDispatcher(executor)
+    val dispatcher = createDispatcher(executor)
 
     async(dispatcher) {
-        try {
-            suspendTransaction(
-                db = db,
-                transactionIsolation = transactionIsolation ?: db?.transactionManager?.defaultIsolationLevel,
-                readOnly = readOnly,
-            ) {
-                statement()
-            }
-        } finally {
-            if (shouldClose) {
-                dispatcher.close()
-            }
+        suspendTransaction(
+            db = db,
+            transactionIsolation = transactionIsolation ?: db?.transactionManager?.defaultIsolationLevel,
+            readOnly = readOnly,
+        ) {
+            statement()
         }
     }
 }
@@ -114,9 +111,13 @@ private val virtualThreadDispatcher: ExecutorCoroutineDispatcher by lazy {
     VirtualThreadExecutor.asCoroutineDispatcher()
 }
 
-private fun createDispatcher(executor: ExecutorService?): Pair<ExecutorCoroutineDispatcher, Boolean> {
+private fun createDispatcher(executor: ExecutorService?): CoroutineDispatcher {
     if (executor == null || executor === VirtualThreadExecutor) {
-        return virtualThreadDispatcher to false
+        return virtualThreadDispatcher
     }
-    return executor.asCoroutineDispatcher() to true
+    require(!executor.isShutdown && !executor.isTerminated) {
+        "ExecutorService is already shutdown."
+    }
+    // asCoroutineDispatcher().close()는 원본 ExecutorService를 shutdown하므로 호출자 소유 executor는 닫지 않습니다.
+    return executor.asCoroutineDispatcher()
 }

--- a/data/exposed-r2dbc/src/test/kotlin/io/bluetape4k/exposed/r2dbc/VirtualThreadTransactionTest.kt
+++ b/data/exposed-r2dbc/src/test/kotlin/io/bluetape4k/exposed/r2dbc/VirtualThreadTransactionTest.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldHaveSize
 import org.amshove.kluent.shouldNotBeEmpty
@@ -19,6 +20,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import kotlin.test.assertFailsWith
 
 class VirtualThreadTransactionTest: AbstractExposedR2dbcTest() {
 
@@ -45,6 +47,16 @@ class VirtualThreadTransactionTest: AbstractExposedR2dbcTest() {
                 }
 
                 threadName.shouldContain("vt-custom-executor")
+                executor.isShutdown.shouldBeFalse()
+
+                val secondThreadName = virtualThreadTransaction(
+                    executor = executor,
+                    db = this.db,
+                ) {
+                    Thread.currentThread().name
+                }
+
+                secondThreadName.shouldContain("vt-custom-executor")
             } finally {
                 runCatching {
                     executor.shutdown()
@@ -127,6 +139,22 @@ class VirtualThreadTransactionTest: AbstractExposedR2dbcTest() {
             rows shouldHaveSize 2
             val names = rows.map { it[VirtualThreadTable.name] }.toSet()
             names shouldBeEqualTo setOf("outer-item", "inner-item")
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `종료된 executor 로 트랜잭션 시작 시 IllegalArgumentException 이 발생한다`(testDB: TestDB) = runTest {
+        withTables(testDB, VirtualThreadTable) {
+            val executor = Executors.newSingleThreadExecutor()
+            executor.shutdown()
+            executor.awaitTermination(1, TimeUnit.SECONDS)
+
+            assertFailsWith<IllegalArgumentException> {
+                virtualThreadTransactionAsync(executor = executor, db = this.db) {
+                    VirtualThreadTable.selectAll().count()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: exposed 가상 스레드 executor 소유권 보장

- data/exposed-jdbc, data/exposed-r2dbc의 VirtualThread transaction helper를 6-tier 방식으로 점검했습니다.
- R2DBC helper가 호출자 제공 ExecutorService를 내부에서 닫던 동작을 수정해 custom executor 재사용 계약을 보장했습니다.
- JDBC helper는 executor = null을 공유 VirtualThreadExecutor로 해석하도록 명확히 해 호출마다 executor가 생성되는 누수 위험을 제거했습니다.
- README.md / README.ko.md에 executor 소유권과 실제 import/path를 동기화했습니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 6-tier 리뷰 결과

- Tier 1 Security: secret/credential 노출 및 직접 SQL injection 위험 없음.
- Tier 2 Ops/SRE: executor lifecycle 결함 발견 및 수정.
- Tier 3 Structural: public API 시그니처 유지, 동작 계약만 보강.
- Tier 4 Kotlin/Quality: KDoc/주석으로 lifecycle 이유 명시, diff 최소화.
- Tier 5 Tests/Silent failure: custom executor 재사용, null executor, 종료 executor 회귀 테스트 추가.
- Tier 6 Performance/Stability: 불필요한 executor 생성/종료 부작용 제거.

### 기존 섹션: 참고

- 모듈 단위 detekt 태스크(:bluetape4k-exposed-jdbc:detekt, :bluetape4k-exposed-r2dbc:detekt)는 존재하지 않습니다.

## Validation

- ./gradlew :bluetape4k-exposed-jdbc:test --tests io.bluetape4k.exposed.jdbc.VirtualThreadTransactionTest → 24 passing, 10.3s
- ./gradlew :bluetape4k-exposed-r2dbc:test --tests io.bluetape4k.exposed.r2dbc.VirtualThreadTransactionTest → 21 passing, 10.2s
- ./gradlew :bluetape4k-exposed-core:check :bluetape4k-exposed-dao:check :bluetape4k-exposed-jdbc:check :bluetape4k-exposed-r2dbc:check → BUILD SUCCESSFUL, 1m23s, XML 집계 1325 passing / 54 skipped / 0 failures / 0 errors
- git diff --check → 통과
- ./gradlew detekt → BUILD SUCCESSFUL, detekt NO-SOURCE

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #248, head `4b2ff2b624b64f0b6c7bf1b2b0d98caa865714e2`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `exposed-6tier-review`
- Labels: `bug`
- State: `MERGED`, merge commit `e4c6382c4bf2b05acb4be192af166a58cb7bd582`
- CI: - ./gradlew :bluetape4k-exposed-jdbc:test --tests io.bluetape4k.exposed.jdbc.VirtualThreadTransactionTest → 24 passing, 10.3s / - ./gradlew :bluetape4k-exposed-r2dbc:test --tests io.bluetape4k.exposed.r2dbc.VirtualThreadTransactionTest → 21 passing, 10.2s / - ./gradlew :bluetape4k-exposed-core:check :bluetape4k-exposed-dao:check :bluetape4k-exposed-jdbc:check :bluetape4k-exposed-r2dbc:check → BUILD SUCCESSFUL, 1m23s, XML 집계 1325 passing / 54 skipped / 0 failures / 0 errors

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #248 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e4c6382c4bf2b05acb4be192af166a58cb7bd582`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
