### PR TITLE
fix: exposed redis resilience 설정 검증 보강

### DIFF
--- a/data/exposed-cache/README.ko.md
+++ b/data/exposed-cache/README.ko.md
@@ -178,6 +178,8 @@ Redis 기반 저장소의 선택적 Resilience 설정입니다. `null`(기본값
 | `circuitBreakerEnabled` | `false` | Circuit Breaker 활성화 여부 |
 | `timeoutDuration` | `2초` | Redis 작업 타임아웃 |
 
+`retryMaxAttempts`는 1 이상이어야 하며, `retryWaitDuration`과 `timeoutDuration`은 양수여야 합니다.
+
 ## 쓰기 전략 패턴
 
 ```mermaid

--- a/data/exposed-cache/README.md
+++ b/data/exposed-cache/README.md
@@ -178,6 +178,8 @@ Optional resilience configuration for Redis-backed repositories. Pass `null` (th
 | `circuitBreakerEnabled` | `false` | Enable Circuit Breaker |
 | `timeoutDuration` | `2s` | Redis operation timeout |
 
+`retryMaxAttempts` must be at least 1. `retryWaitDuration` and `timeoutDuration` must be positive.
+
 ## Write Strategy Patterns
 
 ```mermaid

--- a/data/exposed-cache/src/main/kotlin/io/bluetape4k/exposed/cache/redis/RedisRepositoryResilienceConfig.kt
+++ b/data/exposed-cache/src/main/kotlin/io/bluetape4k/exposed/cache/redis/RedisRepositoryResilienceConfig.kt
@@ -22,6 +22,8 @@ import java.time.Duration
  * @property retryExponentialBackoff 지수 백오프 사용 여부 (기본값: true)
  * @property circuitBreakerEnabled Circuit Breaker 활성화 여부 (기본값: false)
  * @property timeoutDuration 타임아웃 시간 (기본값: 2초)
+ *
+ * @throws IllegalArgumentException 재시도 횟수나 시간 설정이 0 이하인 경우
  */
 data class RedisRepositoryResilienceConfig(
     val retryMaxAttempts: Int = 3,
@@ -32,5 +34,18 @@ data class RedisRepositoryResilienceConfig(
 ) : Serializable {
     companion object : KLogging() {
         private const val serialVersionUID = 1L
+    }
+
+    init {
+        // Resilience4j 설정으로 전달되기 전에 잘못된 값을 차단해 Redis 장애 경로의 런타임 실패를 방지합니다.
+        require(retryMaxAttempts >= 1) {
+            "retryMaxAttempts[$retryMaxAttempts] must be at least 1."
+        }
+        require(retryWaitDuration > Duration.ZERO) {
+            "retryWaitDuration[$retryWaitDuration] must be positive."
+        }
+        require(timeoutDuration > Duration.ZERO) {
+            "timeoutDuration[$timeoutDuration] must be positive."
+        }
     }
 }

--- a/data/exposed-cache/src/test/kotlin/io/bluetape4k/exposed/cache/redis/RedisRepositoryResilienceConfigTest.kt
+++ b/data/exposed-cache/src/test/kotlin/io/bluetape4k/exposed/cache/redis/RedisRepositoryResilienceConfigTest.kt
@@ -5,15 +5,15 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.Duration
 
 /**
  * [RedisRepositoryResilienceConfig] 단위 테스트.
  *
- * 기본값 생성, 커스텀 생성, data class 동등성 검증을 수행합니다.
+ * 기본값 생성, 커스텀 생성, data class 동등성, 입력 검증을 수행합니다.
  * Resilience 설정이 잘못 전달될 경우(예: 음수 retryMaxAttempts, 0ms timeout)
- * 실제 Resilience4j 사용 시 런타임 오류가 발생하므로, 추후 검증 로직 추가 시
- * 이 테스트 클래스를 확장하면 된다.
+ * 실제 Resilience4j 사용 시 런타임 오류가 발생하므로 생성 시점에서 차단합니다.
  */
 class RedisRepositoryResilienceConfigTest {
 
@@ -76,6 +76,52 @@ class RedisRepositoryResilienceConfigTest {
         copied.retryMaxAttempts shouldBeEqualTo original.retryMaxAttempts
         copied.retryWaitDuration shouldBeEqualTo original.retryWaitDuration
         copied.timeoutDuration shouldBeEqualTo original.timeoutDuration
+    }
+
+    // ----------------------------------------------------------------
+    // 입력 검증
+    // ----------------------------------------------------------------
+
+    @Test
+    fun `retryMaxAttempts가 0이면 IllegalArgumentException이 발생한다`() {
+        assertThrows<IllegalArgumentException> {
+            RedisRepositoryResilienceConfig(retryMaxAttempts = 0)
+        }
+    }
+
+    @Test
+    fun `retryMaxAttempts가 음수이면 IllegalArgumentException이 발생한다`() {
+        assertThrows<IllegalArgumentException> {
+            RedisRepositoryResilienceConfig(retryMaxAttempts = -1)
+        }
+    }
+
+    @Test
+    fun `retryWaitDuration이 0이면 IllegalArgumentException이 발생한다`() {
+        assertThrows<IllegalArgumentException> {
+            RedisRepositoryResilienceConfig(retryWaitDuration = Duration.ZERO)
+        }
+    }
+
+    @Test
+    fun `retryWaitDuration이 음수이면 IllegalArgumentException이 발생한다`() {
+        assertThrows<IllegalArgumentException> {
+            RedisRepositoryResilienceConfig(retryWaitDuration = Duration.ofMillis(-1))
+        }
+    }
+
+    @Test
+    fun `timeoutDuration이 0이면 IllegalArgumentException이 발생한다`() {
+        assertThrows<IllegalArgumentException> {
+            RedisRepositoryResilienceConfig(timeoutDuration = Duration.ZERO)
+        }
+    }
+
+    @Test
+    fun `timeoutDuration이 음수이면 IllegalArgumentException이 발생한다`() {
+        assertThrows<IllegalArgumentException> {
+            RedisRepositoryResilienceConfig(timeoutDuration = Duration.ofMillis(-1))
+        }
     }
 
     // ----------------------------------------------------------------


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: exposed redis resilience 설정 검증 보강

- exposed-core, exposed-dao, exposed-jdbc, exposed-r2dbc를 제외한 나머지 data/exposed-* 20개 모듈을 6-tier 방식으로 점검했습니다.
- HIGH 신뢰성 이슈로 RedisRepositoryResilienceConfig 입력 검증 누락을 수정했습니다.
- retryMaxAttempts는 1 이상, retryWaitDuration/timeoutDuration은 양수로 생성 시점에 제한합니다.
- README.md / README.ko.md에 설정 계약을 동기화했습니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 6-tier 리뷰 결과

- Tier 1 Security: secret/credential 노출 및 직접 SQL injection 신규 위험 없음.
- Tier 2 Ops/SRE: Redis resilience 설정의 0 이하 값 허용 문제 발견 및 수정.
- Tier 3 Structural: data class 생성자/기본값은 유지하고 입력 계약만 보강.
- Tier 4 Kotlin/Quality: KDoc에 예외 계약 추가, 생성 시점 검증으로 실패 위치 명확화.
- Tier 5 Tests/Silent failure: 0/음수 retry/timeout 회귀 테스트 추가.
- Tier 6 Performance/Stability: 잘못된 timeout/retry 설정이 런타임 장애 경로로 전파되지 않도록 차단.

### 기존 섹션: 참고

- 외부 Redis 장애 주입 통합 테스트는 별도로 수행하지 않았습니다. 이번 변경은 설정 객체의 생성 시점 검증에 한정됩니다.

## Validation

- ./gradlew :bluetape4k-exposed-cache:test --tests io.bluetape4k.exposed.cache.redis.RedisRepositoryResilienceConfigTest → 11 passing, 1.6s
- ./gradlew :bluetape4k-exposed-bigquery:check :bluetape4k-exposed-cache:check :bluetape4k-exposed-clickhouse:check :bluetape4k-exposed-duckdb:check :bluetape4k-exposed-fastjson2:check :bluetape4k-exposed-jackson2:check :bluetape4k-exposed-jackson3:check :bluetape4k-exposed-jdbc-caffeine:check :bluetape4k-exposed-jdbc-lettuce:check :bluetape4k-exposed-jdbc-redisson:check :bluetape4k-exposed-jdbc-tests:check :bluetape4k-exposed-measured:check :bluetape4k-exposed-mysql8:check :bluetape4k-exposed-postgresql:check :bluetape4k-exposed-r2dbc-caffeine:check :bluetape4k-exposed-r2dbc-lettuce:check :bluetape4k-exposed-r2dbc-redisson:check :bluetape4k-exposed-r2dbc-tests:check :bluetape4k-exposed-tink:check :bluetape4k-exposed-trino:check → BUILD SUCCESSFUL, 7m37s, XML 집계 3153 passing / 178 skipped / 0 failures / 0 errors
- git diff --check → 통과
- ./gradlew detekt → BUILD SUCCESSFUL, detekt NO-SOURCE

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #249, head `d2ca8d4cb9c0df2698c8ca224d46bb47b2a07b86`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `exposed-remaining-6tier-review`
- Labels: `chore`
- State: `MERGED`, merge commit `f698b21784d4c48b4a09c4a0e7ae503f6d604554`
- CI: - ./gradlew :bluetape4k-exposed-cache:test --tests io.bluetape4k.exposed.cache.redis.RedisRepositoryResilienceConfigTest → 11 passing, 1.6s / - ./gradlew :bluetape4k-exposed-bigquery:check :bluetape4k-exposed-cache:check :bluetape4k-exposed-clickhouse:check :bluetape4k-exposed-duckdb:check :bluetape4k-exposed-fastjson2:check :bluetape4k-exposed-jackson2:check :bluetape4k-exposed-jackson3:check :bluetape4k-exposed-jdbc-caffeine:check :bluetape4k-exposed-jdbc-lettuce:check :bluetape4k-exposed-jdbc-redisson:check :bluetape4k-exposed-jdbc-tests:check :bluetape4k-exposed-measured:check :bluetape4k-exposed-mysql8:check :bluetape4k-exposed-postgresql:check :bluetape4k-exposed-r2dbc-caffeine:check :bluetape4k-exposed-r2dbc-lettuce:check :bluetape4k-exposed-r2dbc-redisson:check :bluetape4k-exposed-r2dbc-tests:check :bluetape4k-exposed-tink:check :bluetape4k-exposed-trino:check → BUILD SUCCESSFUL, 7m37s, XML 집계 3153 passing / 178 skipped / 0 failures / 0 errors / - ./gradlew detekt → BUILD SUCCESSFUL, detekt NO-SOURCE

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #249 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `f698b21784d4c48b4a09c4a0e7ae503f6d604554`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
