### PR TITLE
feat: StructuredTaskScopes API 개선 — failFast/firstSuccess 추가, all/any deprecated (#255)

### DIFF
--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/ScopedValueSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/ScopedValueSupport.kt
@@ -17,7 +17,7 @@ package io.bluetape4k.concurrent.virtualthread
  *     // 내부 범위를 벗어나면 원래 값으로 복원
  *     println(sv.get()) // "zero"
  *
- *     structuredTaskScopeAll { scope ->
+ *     structuredTaskScopeFailFast { scope ->
  *         scope.fork {
  *             println(sv.get()) // "zero" — Virtual Thread에서도 ScopedValue 상속
  *             -1

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredTaskScopeSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredTaskScopeSupport.kt
@@ -3,79 +3,94 @@ package io.bluetape4k.concurrent.virtualthread
 import java.util.concurrent.ThreadFactory
 
 /**
- * [StructuredTaskScope.ShutdownOnFailure] 를 사용하여 구조화된 작업을 수행합니다.
- *
- * 작업 범위 내에서 다수의 서브 작업을 실행하고, 모든 작업이 완료되도록 대기한 후 결과를 반환한다.
- * 만약 서브 작업 중 하나라도 실패한다면, 즉시 모든 서브 작업을 중단하고, 예외를 던진다.
- *
- * 참고: Kotlin Coroutines 의 [kotlinx.coroutines.coroutineScope]와 작업 방식은 같다.
+ * 실패 전파형(fail-fast) 구조화된 동시성 블록을 실행합니다.
+ * 하나의 subtask라도 실패하면 나머지를 즉시 중단하고 예외를 전파합니다.
  *
  * ```kotlin
  * data class Result(val a: Int, val b: String)
  *
- * val result = structuredTaskScopeAll { scope ->
+ * val result = structuredTaskScopeFailFast { scope ->
  *     val subtask1 = scope.fork { Thread.sleep(100); 42 }
  *     val subtask2 = scope.fork { Thread.sleep(200); "hello" }
- *
  *     scope.join().throwIfFailed()
- *
  *     Result(subtask1.get(), subtask2.get())
  * }
  * // result == Result(a=42, b="hello")
  * ```
  *
  * @param T 반환할 타입
- * @param name StructuredTaskScope 이름 (디버깅용, 기본값: null)
- * @param factory Virtual Thread 팩토리
- * @param block scope 를 인자로 받아 서브 작업을 fork하고 결과를 반환하는 블록
+ * @param name scope 이름 (디버깅용, 기본값: null)
+ * @param factory Virtual Thread 팩토리 (기본값: `VirtualThreads.threadFactory("sts-failfast-")`)
+ * @param block scope를 인자로 받아 서브 작업을 fork하고 결과를 반환하는 블록
  * @return [block]의 실행 결과
  * @throws Exception 서브 작업 중 하나라도 실패하면 해당 예외를 던진다
  */
-fun <T> structuredTaskScopeAll(
+fun <T> structuredTaskScopeFailFast(
     name: String? = null,
-    factory: ThreadFactory = VirtualThreads.threadFactory("sts-all-"),
-    block: (scope: StructuredTaskScopeAll) -> T,
-): T {
-    return StructuredTaskScopes.all(name, factory, block)
-}
-
+    factory: ThreadFactory = VirtualThreads.threadFactory("sts-failfast-"),
+    block: (scope: StructuredTaskScopeFailFast) -> T,
+): T = StructuredTaskScopes.failFast(name, factory, block)
 
 /**
- * [StructuredTaskScope.ShutdownOnSuccess] 를 사용하여 구조화된 작업을 수행합니다.
- *
- * 작업 범위 내에서 다수의 서브 작업을 실행하고, 첫번째 성공한 작업의 결과를 반환하고, 나머지 서브 작업은 중단하도록 한다.
- *
- * 병렬 프로그래밍의 투기적 실행 (여러개를 동시에 실행하고, 첫번째 결과를 취하고, 나머지 작업은 버린다) 또는 ML 의 앙상블 기법과 같다.
+ * 성공 우선형(first-success) 구조화된 동시성 블록을 실행합니다.
+ * 첫 번째 성공한 subtask 결과를 반환하고 나머지를 취소합니다.
  *
  * ```kotlin
- * val result = structuredTaskScopeAny<String> { scope ->
- *     scope.fork {
- *          Thread.sleep(100)
- *          "result1"
- *     }
- *     scope.fork {
- *          Thread.sleep(200)
- *          "result2"
- *     }
- *
- *     scope.join()
- *     scope.result { ExecutionException(it) }
+ * val result = structuredTaskScopeFirstSuccess<String> { scope ->
+ *     scope.fork { Thread.sleep(100); "result1" }
+ *     scope.fork { Thread.sleep(200); "result2" }
+ *     scope.join().result { IllegalStateException("all failed: ${it.message}") }
  * }
  * // 먼저 완료되는 작업의 결과를 반환한다.
  * // result == "result1"
  * ```
  *
  * @param T 반환할 타입
- * @param name StructuredTaskScope 이름 (디버깅용, 기본값: null)
- * @param factory Virtual Thread 팩토리
- * @param block scope 를 인자로 받아 서브 작업을 fork하고 첫 번째 성공 결과를 반환하는 블록
- * @return 가장 먼저 완료된 서브 작업의 결과
+ * @param name scope 이름 (디버깅용, 기본값: null)
+ * @param factory Virtual Thread 팩토리 (기본값: `VirtualThreads.threadFactory("sts-first-")`)
+ * @param block scope를 인자로 받아 서브 작업을 fork하고 첫 번째 성공 결과를 반환하는 블록
+ * @return 가장 먼저 성공한 서브 작업의 결과
  */
+fun <T> structuredTaskScopeFirstSuccess(
+    name: String? = null,
+    factory: ThreadFactory = VirtualThreads.threadFactory("sts-first-"),
+    block: (scope: StructuredTaskScopeFirstSuccess<T>) -> T,
+): T = StructuredTaskScopes.firstSuccess(name, factory, block)
+
+/**
+ * [StructuredTaskScope.ShutdownOnFailure] 를 사용하여 구조화된 작업을 수행합니다.
+ *
+ * @deprecated [structuredTaskScopeFailFast]를 사용하세요. factory 기본값이 추가되고 이름이 의도를 더 명확히 표현합니다.
+ */
+@Suppress("DEPRECATION")
+@Deprecated(
+    message = "structuredTaskScopeFailFast()를 사용하세요.",
+    replaceWith = ReplaceWith(
+        "structuredTaskScopeFailFast(name, factory, block)",
+        "io.bluetape4k.concurrent.virtualthread.structuredTaskScopeFailFast"
+    )
+)
+fun <T> structuredTaskScopeAll(
+    name: String? = null,
+    factory: ThreadFactory = VirtualThreads.threadFactory("sts-all-"),
+    block: (scope: StructuredTaskScopeAll) -> T,
+): T = StructuredTaskScopes.all(name, factory, block)
+
+/**
+ * [StructuredTaskScope.ShutdownOnSuccess] 를 사용하여 구조화된 작업을 수행합니다.
+ *
+ * @deprecated [structuredTaskScopeFirstSuccess]를 사용하세요. factory 기본값이 추가되고 이름이 의도를 더 명확히 표현합니다.
+ */
+@Suppress("DEPRECATION")
+@Deprecated(
+    message = "structuredTaskScopeFirstSuccess()를 사용하세요.",
+    replaceWith = ReplaceWith(
+        "structuredTaskScopeFirstSuccess(name, factory, block)",
+        "io.bluetape4k.concurrent.virtualthread.structuredTaskScopeFirstSuccess"
+    )
+)
 fun <T> structuredTaskScopeAny(
     name: String? = null,
     factory: ThreadFactory = VirtualThreads.threadFactory("sts-any-"),
     block: (scope: StructuredTaskScopeAny<T>) -> T,
-): T {
-    return StructuredTaskScopes.any(name, factory, block)
-}
-
+): T = StructuredTaskScopes.any(name, factory, block)

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopeSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopeSupportTest.kt
@@ -16,6 +16,7 @@ class StructuredScopeSupportTest {
 
     @Nested
     inner class WithAny {
+        @Suppress("DEPRECATION")
         @Test
         fun `첫번째 완료된 작업의 결과를 얻는다`() {
             val result = structuredTaskScopeAny { scope ->
@@ -36,6 +37,7 @@ class StructuredScopeSupportTest {
             result shouldBeEqualTo "result1"
         }
 
+        @Suppress("DEPRECATION")
         @Test
         fun `첫번째 성공한 결과를 반환한다`() {
             val result = structuredTaskScopeAny { scope ->
@@ -55,6 +57,7 @@ class StructuredScopeSupportTest {
             result shouldBeEqualTo "result2"
         }
 
+        @Suppress("DEPRECATION")
         @Test
         fun `모든 작업이 실패한다면, 첫번째 예외를 반환한다`() {
             assertFailsWith<RuntimeException> {
@@ -73,11 +76,44 @@ class StructuredScopeSupportTest {
                 }
             }.cause shouldBeInstanceOf RuntimeException::class
         }
+
+        @Test
+        fun `firstSuccess - 가장 먼저 완료된 작업의 결과를 반환한다`() {
+            val result = structuredTaskScopeFirstSuccess<String> { scope ->
+                scope.fork {
+                    Thread.sleep(10)
+                    "result1"
+                }
+                scope.fork {
+                    Thread.sleep(100)
+                    "result2"
+                }
+                scope.join().result { IllegalStateException("all failed: ${it.message}") }
+            }
+            result shouldBeEqualTo "result1"
+        }
+
+        @Test
+        fun `firstSuccess - 첫번째 작업 실패 시 두번째 성공 결과를 반환한다`() {
+            val result = structuredTaskScopeFirstSuccess<String> { scope ->
+                scope.fork {
+                    Thread.sleep(10)
+                    throw RuntimeException("first failed")
+                }
+                scope.fork {
+                    Thread.sleep(100)
+                    "result2"
+                }
+                scope.join().result { IllegalStateException("all failed: ${it.message}") }
+            }
+            result shouldBeEqualTo "result2"
+        }
     }
 
     @Nested
     inner class WithAll {
 
+        @Suppress("DEPRECATION")
         @Test
         fun `모든 SubTask 들이 완료될 때 결과를 반환한다`() {
             val results: List<String> = structuredTaskScopeAll { scope ->
@@ -97,6 +133,7 @@ class StructuredScopeSupportTest {
             results shouldBeEqualTo listOf("result1", "result2")
         }
 
+        @Suppress("DEPRECATION")
         @Test
         fun `Subtask에서 예외가 발생하면 예외를 던진다`() {
             assertFailsWith<RuntimeException> {
@@ -113,6 +150,35 @@ class StructuredScopeSupportTest {
                     scope.join().throwIfFailed()
 
                     listOf(result1.get(), result2.get())
+                }
+            }
+        }
+
+        @Test
+        fun `failFast - 모든 SubTask 들이 완료될 때 결과를 반환한다`() {
+            val results: List<String> = structuredTaskScopeFailFast { scope ->
+                val result1 = scope.fork {
+                    Thread.sleep(10)
+                    "result1"
+                }
+                val result2 = scope.fork {
+                    Thread.sleep(100)
+                    "result2"
+                }
+                scope.join().throwIfFailed()
+                listOf(result1.get(), result2.get())
+            }
+            results shouldBeEqualTo listOf("result1", "result2")
+        }
+
+        @Test
+        fun `failFast - Subtask 실패 시 예외가 전파되어야 한다`() {
+            assertFailsWith<RuntimeException> {
+                structuredTaskScopeFailFast { scope ->
+                    scope.fork { Thread.sleep(10); "ok" }
+                    scope.fork<String> { throw IllegalStateException("subtask failed") }
+                    scope.join().throwIfFailed()
+                    emptyList<String>()
                 }
             }
         }

--- a/docs/superpowers/plans/2026-05-01-vt-api-cleanup-plan.md
+++ b/docs/superpowers/plans/2026-05-01-vt-api-cleanup-plan.md
@@ -1,0 +1,533 @@
+# [virtualthread] Issue #255 API 통합 — 구현 계획
+
+> **Spec**: docs/superpowers/specs/2026-05-01-vt-api-cleanup-design.md
+> **Branch**: feat/vt-api-cleanup
+> **Date**: 2026-05-01
+
+---
+
+## 현황 요약
+
+| 항목 | 현재 값 |
+|------|--------|
+| `StructuredSubtask.getOrNull()` | 미제공 — FAILED/UNAVAILABLE 상태에서 ISE 위험 |
+| `StructuredTaskScopes.all/any()` | factory 기본값 없음, 이름 모호 |
+| `structuredTaskScopeAll/Any()` | core 편의 함수, deprecated 대상 |
+| Provider SPI `withAll/withAny()` | 이름 모호하나 SPI 특성상 deprecated 제외 |
+
+---
+
+## 태스크 목록
+
+### T1: `StructuredSubtask.get()` KDoc 보강 + `getOrNull()` default 메서드 추가
+
+- **complexity**: high
+- **파일**: `virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopes.kt`
+- **변경 내용**:
+  - `StructuredSubtask.get()` KDoc을 상태별 동작 명세로 교체:
+    - `SUCCESS`: 결과 반환
+    - `FAILED`: `IllegalStateException` throw (실패 원인 예외 자체를 던지지 않음 — 원인은 `exceptionOrNull()`로 조회)
+    - `UNAVAILABLE` (미완료/취소/join 이전): `IllegalStateException` throw
+    - `@see exceptionOrNull`, `@see getOrNull` 참조 추가
+  - `StructuredSubtask` 인터페이스에 `getOrNull(): T?` default 메서드 추가:
+    ```kotlin
+    fun getOrNull(): T? {
+        return if (state() == StructuredTaskScope.Subtask.State.SUCCESS) {
+            try { get() } catch (_: IllegalStateException) { null }
+        } else null
+    }
+    ```
+  - 구현 주의: `state() == SUCCESS`이더라도 scope owner thread의 `join()` 이전 호출 시 JDK `ensureJoinedIfOwner()` 검사로 ISE 발생 가능 → try-catch로 감쌈
+- **완료 기준**:
+  - [ ] `StructuredSubtask.get()` KDoc에 SUCCESS/FAILED/UNAVAILABLE 상태별 동작 명시
+  - [ ] `StructuredSubtask.getOrNull()` default 메서드 인터페이스에 추가
+  - [ ] `getOrNull()` KDoc에 전제 조건(join() 이후 호출), 상태별 동작, 코드 예제 포함
+  - [ ] jdk21/jdk25 구현체 변경 불필요 확인 (default 메서드이므로)
+- **의존성**: 없음 *(T2와 같은 파일 — T1 완료 후 T2 시작)*
+
+---
+
+### T2: `typealias` 추가 (`StructuredTaskScopeFailFast`, `StructuredTaskScopeFirstSuccess`)
+
+- **complexity**: medium
+- **파일**: `virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopes.kt`
+- **변경 내용**:
+  - 파일 상단 또는 인터페이스 선언 이후에 typealias 두 개 추가:
+    ```kotlin
+    /** fail-fast 동작을 하는 [StructuredTaskScopeAll]의 의도 명확 별칭입니다. */
+    typealias StructuredTaskScopeFailFast = StructuredTaskScopeAll
+
+    /** first-success 동작을 하는 [StructuredTaskScopeAny]의 의도 명확 별칭입니다. */
+    typealias StructuredTaskScopeFirstSuccess<T> = StructuredTaskScopeAny<T>
+    ```
+  - `StructuredTaskScopeAll` KDoc에 `@see StructuredTaskScopeFailFast` 마이그레이션 안내 추가
+  - `StructuredTaskScopeAny` KDoc에 `@see StructuredTaskScopeFirstSuccess` 마이그레이션 안내 추가
+  - `StructuredTaskScopeAll.join()` KDoc에 타임아웃 경고 추가:
+    > **주의**: 타임아웃 없이 호출하면 subtask가 무한 차단될 수 있습니다. 프로덕션 코드에서는 [joinUntil]을 사용하세요.
+  - 주의: typealias에는 멤버 KDoc을 붙일 수 없으므로 모든 KDoc은 실제 인터페이스(`StructuredTaskScopeAll`, `StructuredTaskScopeAny`)에 추가
+- **완료 기준**:
+  - [ ] `typealias StructuredTaskScopeFailFast = StructuredTaskScopeAll` 추가
+  - [ ] `typealias StructuredTaskScopeFirstSuccess<T> = StructuredTaskScopeAny<T>` 추가
+  - [ ] `StructuredTaskScopeAll` KDoc에 `@see StructuredTaskScopeFailFast` 포함
+  - [ ] `StructuredTaskScopeAny` KDoc에 `@see StructuredTaskScopeFirstSuccess` 포함
+  - [ ] `StructuredTaskScopeAll.join()` KDoc에 타임아웃 경고 포함
+- **의존성**: T1 완료 후 *(동일 파일 순차 편집)*
+
+---
+
+### T3: `StructuredTaskScopeProvider`에 `withFailFast()`/`withFirstSuccess()` default 메서드 추가
+
+- **complexity**: medium
+- **파일**: `virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopes.kt`
+- **변경 내용**:
+  - `StructuredTaskScopeProvider` 인터페이스에 default 메서드 두 개 추가:
+    ```kotlin
+    /**
+     * 실패 전파형(fail-fast) 블록을 실행합니다.
+     * 기본 구현은 [withAll]에 위임합니다.
+     * @see withAll
+     */
+    fun <T> withFailFast(
+        name: String? = null,
+        factory: ThreadFactory = Thread.ofVirtual().factory(),
+        block: (scope: StructuredTaskScopeFailFast) -> T,
+    ): T = withAll(name, factory, block)
+
+    /**
+     * 성공 우선형(first-success) 블록을 실행합니다.
+     * 기본 구현은 [withAny]에 위임합니다.
+     * @see withAny
+     */
+    fun <T> withFirstSuccess(
+        name: String? = null,
+        factory: ThreadFactory = Thread.ofVirtual().factory(),
+        block: (scope: StructuredTaskScopeFirstSuccess<T>) -> T,
+    ): T = withAny(name, factory, block)
+    ```
+  - `withAll()` KDoc에 `@see withFailFast` 안내 추가 (deprecated 하지 않음 — SPI 안정성 유지)
+  - `withAny()` KDoc에 `@see withFirstSuccess` 안내 추가 (deprecated 하지 않음 — SPI 안정성 유지)
+  - **SPI 결정 재확인**: `withAll`/`withAny`는 jdk21/jdk25 구현체가 `override`하는 SPI 메서드이므로 deprecated 표시하지 않음
+- **완료 기준**:
+  - [ ] `withFailFast()` default 메서드 추가 (`withAll` 위임)
+  - [ ] `withFirstSuccess()` default 메서드 추가 (`withAny` 위임)
+  - [ ] `withAll()` KDoc에 `@see withFailFast` 포함
+  - [ ] `withAny()` KDoc에 `@see withFirstSuccess` 포함
+  - [ ] jdk21/jdk25 구현체 변경 없음 확인 (default 메서드이므로)
+- **의존성**: T2 완료 후 *(typealias가 먼저 정의되어야 `StructuredTaskScopeFailFast`를 파라미터 타입으로 사용 가능)*
+
+---
+
+### T4: `StructuredTaskScopes` object에 `failFast()`/`firstSuccess()` 추가 + `all()`/`any()` `@Deprecated`
+
+- **complexity**: medium
+- **파일**: `virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopes.kt`
+- **변경 내용**:
+  - `StructuredTaskScopes` object에 새 진입 함수 두 개 추가 (factory 기본값 포함):
+    ```kotlin
+    /**
+     * 실패 전파형(fail-fast) scope 블록을 실행합니다.
+     * 하나의 subtask라도 실패하면 나머지를 즉시 중단하고 예외를 전파합니다.
+     *
+     * @param name scope 이름 (디버깅용)
+     * @param factory subtask 실행용 스레드 팩토리 (기본값: [VirtualThreads.threadFactory])
+     * @param block scope 실행 블록
+     */
+    fun <T> failFast(
+        name: String? = null,
+        factory: ThreadFactory = VirtualThreads.threadFactory(),
+        block: (scope: StructuredTaskScopeFailFast) -> T,
+    ): T = provider().withFailFast(name, factory, block)
+
+    /**
+     * 성공 우선형(first-success) scope 블록을 실행합니다.
+     * 첫 번째 성공한 subtask 결과를 반환하고 나머지를 취소합니다.
+     *
+     * @param name scope 이름 (디버깅용)
+     * @param factory subtask 실행용 스레드 팩토리 (기본값: [VirtualThreads.threadFactory])
+     * @param block scope 실행 블록
+     */
+    fun <T> firstSuccess(
+        name: String? = null,
+        factory: ThreadFactory = VirtualThreads.threadFactory(),
+        block: (scope: StructuredTaskScopeFirstSuccess<T>) -> T,
+    ): T = provider().withFirstSuccess(name, factory, block)
+    ```
+  - 기존 `all()` 함수에 `@Deprecated` 추가 (기존 시그니처 유지 — factory 기본값 없음):
+    ```kotlin
+    @Deprecated(
+        message = "failFast()를 사용하세요.",
+        replaceWith = ReplaceWith("failFast(name, factory, block)")
+    )
+    fun <T> all(
+        name: String? = null,
+        factory: ThreadFactory,
+        block: (scope: StructuredTaskScopeAll) -> T,
+    ): T = provider().withAll(name, factory, block)
+    ```
+  - 기존 `any()` 함수에 `@Deprecated` 추가:
+    ```kotlin
+    @Deprecated(
+        message = "firstSuccess()를 사용하세요.",
+        replaceWith = ReplaceWith("firstSuccess(name, factory, block)")
+    )
+    fun <T> any(
+        name: String? = null,
+        factory: ThreadFactory,
+        block: (scope: StructuredTaskScopeAny<T>) -> T,
+    ): T = provider().withAny(name, factory, block)
+    ```
+  - 새 `failFast()`/`firstSuccess()` 함수에 KDoc 예제 포함 (fork → join → get 패턴)
+- **완료 기준**:
+  - [ ] `failFast()` 추가 (factory 기본값: `VirtualThreads.threadFactory()`)
+  - [ ] `firstSuccess()` 추가 (factory 기본값: `VirtualThreads.threadFactory()`)
+  - [ ] `all()`에 `@Deprecated(message, ReplaceWith)` 추가
+  - [ ] `any()`에 `@Deprecated(message, ReplaceWith)` 추가
+  - [ ] KDoc 예제 포함 (fork → join → throwIfFailed/result → get 패턴)
+- **의존성**: T3 완료 후
+
+---
+
+### T5: `StructuredTaskScopeAll`/`StructuredTaskScopeAny` KDoc 보강 (join 타임아웃 경고, @see 안내)
+
+- **complexity**: low
+- **파일**: `virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopes.kt`
+- **변경 내용**:
+  - `StructuredTaskScopeAll` 인터페이스 KDoc 상단 개요에 `@see StructuredTaskScopeFailFast` 추가
+  - `StructuredTaskScopeAll.join()` 함수 KDoc에 타임아웃 경고 추가 (T2에서 이미 처리하므로 중복 체크)
+  - `StructuredTaskScopeAny` 인터페이스 KDoc 상단 개요에 `@see StructuredTaskScopeFirstSuccess` 추가
+  - 각 인터페이스 KDoc의 코드 예제를 새 API(`failFast`, `firstSuccess`)로 업데이트
+  - 주의: T2에서 이미 일부 KDoc 보강을 수행하므로 T5는 남은 보강 항목 처리
+- **완료 기준**:
+  - [ ] `StructuredTaskScopeAll` KDoc에 `@see StructuredTaskScopeFailFast` 및 `failFast {}` 사용 안내 포함
+  - [ ] `StructuredTaskScopeAny` KDoc에 `@see StructuredTaskScopeFirstSuccess` 및 `firstSuccess {}` 사용 안내 포함
+  - [ ] KDoc 예제에서 `factory = Thread.ofVirtual().factory()` 명시적 지정 제거 (기본값 사용 가이드)
+- **의존성**: T2 완료 후 *(T4와 병렬 가능)*
+
+---
+
+### T6: API 모듈 테스트 추가 (`getOrNull()`, `failFast()`, `firstSuccess()`)
+
+- **complexity**: medium
+- **파일**: `virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt`
+- **변경 내용**:
+  - `failFast` 정상 경로 테스트: 모든 subtask 성공 → 결과 수집
+    ```kotlin
+    @Test
+    fun `failFast scope 으로 두 subtask 를 합산해야 한다`() { ... }
+    ```
+  - `failFast` 실패 전파 테스트: 하나 실패 시 나머지 취소 + 예외 전파
+    ```kotlin
+    @Test
+    fun `failFast scope 내 subtask 실패 시 예외가 전파되어야 한다`() { ... }
+    ```
+  - `failFast` factory 기본값 테스트: `factory` 파라미터 생략 가능 확인 (P3 해결 검증)
+    ```kotlin
+    @Test
+    fun `failFast scope factory 기본값으로 실행되어야 한다`() { ... }
+    ```
+  - `firstSuccess` 정상 경로 테스트: 첫 성공 반환 + 나머지 취소
+    ```kotlin
+    @Test
+    fun `firstSuccess scope 가 가장 먼저 완료된 subtask 결과를 반환해야 한다`() { ... }
+    ```
+  - `firstSuccess` 전체 실패 테스트: 모든 subtask 실패 시 예외 전파
+    ```kotlin
+    @Test
+    fun `firstSuccess scope 모든 subtask 실패 시 mapper 예외가 발생해야 한다`() { ... }
+    ```
+  - `getOrNull()` SUCCESS 상태 테스트: join() 이후 정상 결과 반환
+    ```kotlin
+    @Test
+    fun `getOrNull 은 SUCCESS 상태에서 결과를 반환해야 한다`() { ... }
+    ```
+  - `getOrNull()` FAILED 상태 테스트: join() 이후 FAILED subtask → null 반환 (ISE 아님)
+    ```kotlin
+    @Test
+    fun `getOrNull 은 FAILED 상태에서 null 을 반환해야 한다`() { ... }
+    ```
+  - `getOrNull()` UNAVAILABLE 상태 테스트: `ShutdownOnFailure` scope에서 shutdown으로 취소된 subtask를 `join()` 이후 확인 → null 반환
+    - **주의**: join() **이전** 호출로 테스트하지 말 것 (KDoc 전제 조건 위반)
+    ```kotlin
+    @Test
+    fun `getOrNull 은 UNAVAILABLE 상태에서 null 을 반환해야 한다`() { ... }
+    ```
+  - `getOrNull()` join 이전 호출 안전성 테스트: `state() == SUCCESS`이나 join() 전 → try-catch로 null 반환
+    ```kotlin
+    @Test
+    fun `getOrNull 은 join 이전 호출에서도 null 을 안전하게 반환해야 한다`() { ... }
+    ```
+  - scope 리소스 해제 테스트: `close()` 보장 (use{} 블록 정상 종료 확인)
+  - 기존 `all scope`/`any scope` 테스트는 그대로 유지 (회귀 방지)
+  - Kluent 매처 사용: `shouldBeEqualTo`, `shouldBeNull`, `shouldNotBeNull`, `shouldBeInstanceOf`
+- **완료 기준**:
+  - [ ] `failFast` 정상/실패/기본값 테스트 3건 추가
+  - [ ] `firstSuccess` 정상/전체실패 테스트 2건 추가
+  - [ ] `getOrNull` SUCCESS/FAILED/UNAVAILABLE/join전 테스트 4건 추가
+  - [ ] 기존 테스트 전부 통과 (회귀 없음)
+- **의존성**: T1, T4 완료 후
+
+---
+
+### T7: `bluetape4k/core` — `structuredTaskScopeFailFast {}`/`structuredTaskScopeFirstSuccess {}` 추가 + 기존 deprecated
+
+- **complexity**: medium
+- **파일**: `bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredTaskScopeSupport.kt`
+- **변경 내용**:
+  - 새 편의 함수 두 개 추가:
+    ```kotlin
+    /**
+     * 실패 전파형(fail-fast) 구조화된 동시성 블록을 실행합니다.
+     *
+     * @param name scope 이름 (디버깅용, 기본값: null)
+     * @param factory Virtual Thread 팩토리 (기본값: `VirtualThreads.threadFactory("sts-failfast-")`)
+     * @param block scope 실행 블록
+     * @return [block]의 실행 결과
+     */
+    fun <T> structuredTaskScopeFailFast(
+        name: String? = null,
+        factory: ThreadFactory = VirtualThreads.threadFactory("sts-failfast-"),
+        block: (scope: StructuredTaskScopeFailFast) -> T,
+    ): T = StructuredTaskScopes.failFast(name, factory, block)
+
+    /**
+     * 성공 우선형(first-success) 구조화된 동시성 블록을 실행합니다.
+     *
+     * @param name scope 이름 (디버깅용, 기본값: null)
+     * @param factory Virtual Thread 팩토리 (기본값: `VirtualThreads.threadFactory("sts-first-")`)
+     * @param block scope 실행 블록
+     * @return 가장 먼저 성공한 서브 작업의 결과
+     */
+    fun <T> structuredTaskScopeFirstSuccess(
+        name: String? = null,
+        factory: ThreadFactory = VirtualThreads.threadFactory("sts-first-"),
+        block: (scope: StructuredTaskScopeFirstSuccess<T>) -> T,
+    ): T = StructuredTaskScopes.firstSuccess(name, factory, block)
+    ```
+  - 기존 `structuredTaskScopeAll()` 함수에 deprecated 처리:
+    ```kotlin
+    @Suppress("DEPRECATION")
+    @Deprecated(
+        message = "structuredTaskScopeFailFast()를 사용하세요.",
+        replaceWith = ReplaceWith(
+            "structuredTaskScopeFailFast(name, factory, block)",
+            "io.bluetape4k.concurrent.virtualthread.structuredTaskScopeFailFast"
+        )
+    )
+    fun <T> structuredTaskScopeAll(
+        name: String? = null,
+        factory: ThreadFactory = VirtualThreads.threadFactory("sts-all-"),
+        block: (scope: StructuredTaskScopeAll) -> T,
+    ): T = StructuredTaskScopes.all(name, factory, block)
+    ```
+  - 기존 `structuredTaskScopeAny()` 함수에 deprecated 처리:
+    ```kotlin
+    @Suppress("DEPRECATION")
+    @Deprecated(
+        message = "structuredTaskScopeFirstSuccess()를 사용하세요.",
+        replaceWith = ReplaceWith(
+            "structuredTaskScopeFirstSuccess(name, factory, block)",
+            "io.bluetape4k.concurrent.virtualthread.structuredTaskScopeFirstSuccess"
+        )
+    )
+    fun <T> structuredTaskScopeAny(
+        name: String? = null,
+        factory: ThreadFactory = VirtualThreads.threadFactory("sts-any-"),
+        block: (scope: StructuredTaskScopeAny<T>) -> T,
+    ): T = StructuredTaskScopes.any(name, factory, block)
+    ```
+  - **주의**: deprecated 함수 내부에서 `StructuredTaskScopes.all()`/`StructuredTaskScopes.any()` 호출 시 해당 함수도 deprecated이므로 `@Suppress("DEPRECATION")`이 반드시 필요
+- **완료 기준**:
+  - [ ] `structuredTaskScopeFailFast {}` 추가 (KDoc 포함)
+  - [ ] `structuredTaskScopeFirstSuccess {}` 추가 (KDoc 포함)
+  - [ ] `structuredTaskScopeAll {}` `@Deprecated(message, ReplaceWith)` 추가
+  - [ ] `structuredTaskScopeAny {}` `@Deprecated(message, ReplaceWith)` 추가
+  - [ ] deprecated 함수에 `@Suppress("DEPRECATION")` 추가
+  - [ ] 컴파일 경고 없음 확인
+- **의존성**: T4 완료 후
+
+---
+
+### T8: `bluetape4k/core` 모듈 테스트 — 새 편의 함수 테스트 추가
+
+- **complexity**: medium
+- **파일**: `bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopeSupportTest.kt`
+- **변경 내용**:
+  - `WithAll` Nested 클래스 안에 `structuredTaskScopeFailFast {}` 기반 테스트 추가:
+    ```kotlin
+    @Test
+    fun `structuredTaskScopeFailFast 으로 모든 SubTask 들이 완료될 때 결과를 반환한다`() { ... }
+
+    @Test
+    fun `structuredTaskScopeFailFast 에서 Subtask 예외 발생 시 예외를 던진다`() { ... }
+    ```
+  - `WithAny` Nested 클래스 안에 `structuredTaskScopeFirstSuccess {}` 기반 테스트 추가:
+    ```kotlin
+    @Test
+    fun `structuredTaskScopeFirstSuccess 로 첫번째 완료된 작업의 결과를 얻는다`() { ... }
+
+    @Test
+    fun `structuredTaskScopeFirstSuccess 로 첫번째 성공한 결과를 반환한다`() { ... }
+    ```
+  - 기존 `structuredTaskScopeAll {}`/`structuredTaskScopeAny {}` 테스트는 그대로 유지 (회귀 방지 + deprecated API 동작 검증)
+  - `@EnabledForJreRange(min = JRE.JAVA_21)` 어노테이션 유지
+  - Kluent 매처 사용: `shouldBeEqualTo`, `shouldBeInstanceOf` 등
+- **완료 기준**:
+  - [ ] `structuredTaskScopeFailFast` 테스트 2건 추가 (정상/실패)
+  - [ ] `structuredTaskScopeFirstSuccess` 테스트 2건 추가 (정상/첫성공)
+  - [ ] 기존 `structuredTaskScopeAll`/`structuredTaskScopeAny` 테스트 전부 통과
+- **의존성**: T7 완료 후
+
+---
+
+### T9: 전체 빌드 검증
+
+- **complexity**: low
+- **파일**: 없음 (빌드 명령 실행)
+- **변경 내용**:
+  - 4개 모듈 통합 테스트 실행:
+    ```bash
+    ./gradlew :bluetape4k-virtualthread-api:test \
+              :bluetape4k-virtualthread-jdk21:test \
+              :bluetape4k-virtualthread-jdk25:test \
+              :bluetape4k-core:test
+    ```
+  - 실패 시 오류 메시지 분석 후 T1~T8 중 해당 태스크 재작업
+  - jdk21/jdk25 구현체 변경 없음 확인 (기존 테스트 통과 확인)
+  - 브레이킹 체인지 없음 확인 (`@Deprecated`만 추가, 삭제 없음)
+- **완료 기준**:
+  - [ ] `bluetape4k-virtualthread-api` 테스트 전부 통과
+  - [ ] `bluetape4k-virtualthread-jdk21` 테스트 전부 통과 (변경 없음)
+  - [ ] `bluetape4k-virtualthread-jdk25` 테스트 전부 통과 (변경 없음)
+  - [ ] `bluetape4k-core` 테스트 전부 통과
+  - [ ] deprecated 경고만 발생, 컴파일 오류 없음
+- **의존성**: T6, T8 완료 후
+
+---
+
+### T10: README 업데이트 — 결정 트리 추가 및 API 예제 교체 (8개 파일)
+
+- **complexity**: low
+- **파일**:
+  - `virtualthread/api/README.md`
+  - `virtualthread/api/README.ko.md`
+  - `virtualthread/jdk21/README.md`
+  - `virtualthread/jdk21/README.ko.md`
+  - `virtualthread/jdk25/README.md`
+  - `virtualthread/jdk25/README.ko.md`
+  - `virtualthread/README.md`
+  - `virtualthread/README.ko.md`
+- **변경 내용**:
+  - `virtualthread/api/README.md`, `README.ko.md`: 결정 트리(Decision Tree) 섹션 추가 (Spec 섹션 3.4.2 내용 그대로), API 레퍼런스에서 `all`/`any` → `failFast`/`firstSuccess` 교체
+  - `virtualthread/jdk21/README.md`, `README.ko.md`: 예제 코드 `StructuredTaskScopes.all(factory = ...)` → `StructuredTaskScopes.failFast {}` 교체 (각 line 187 / line 186)
+  - `virtualthread/jdk25/README.md`, `README.ko.md`: 예제 코드 `StructuredTaskScopes.all(factory = ...)` → `StructuredTaskScopes.failFast {}` 교체 (각 line 214 / line 212)
+  - `virtualthread/README.md`, `README.ko.md`: 상위 모듈 개요에서 새 API 이름(`failFast`, `firstSuccess`) 반영
+  - 결정 트리 Mermaid 다이어그램 또는 텍스트 형식으로 삽입 (Spec의 ASCII 트리 그대로 사용 가능)
+  - 모든 영문 README 수정 후 한국어 README 동일하게 적용
+- **완료 기준**:
+  - [ ] `virtualthread/api/README.md` — 결정 트리 추가 + `all`/`any` → `failFast`/`firstSuccess` 교체
+  - [ ] `virtualthread/api/README.ko.md` — 동일 (한국어)
+  - [ ] `virtualthread/jdk21/README.md` — 예제 코드 교체
+  - [ ] `virtualthread/jdk21/README.ko.md` — 예제 코드 교체 (한국어)
+  - [ ] `virtualthread/jdk25/README.md` — 예제 코드 교체
+  - [ ] `virtualthread/jdk25/README.ko.md` — 예제 코드 교체 (한국어)
+  - [ ] `virtualthread/README.md` — 새 API 이름 반영
+  - [ ] `virtualthread/README.ko.md` — 새 API 이름 반영 (한국어)
+- **의존성**: T4 완료 후 *(T6, T7, T8과 병렬 가능)*
+
+---
+
+## 실행 순서
+
+| 순서 | 태스크 | 설명 | 병렬 가능 여부 |
+|------|--------|------|---------------|
+| 1 | T1 | `getOrNull()` default 메서드 + `get()` KDoc 보강 | - (시작점) |
+| 2 | T2 | `typealias` 추가 + `join()` 타임아웃 경고 KDoc | T1 완료 후 (동일 파일 순차) |
+| 3 | T3 | `withFailFast()`/`withFirstSuccess()` default 메서드 추가 | T2 완료 후 |
+| 4 | T4 | `failFast()`/`firstSuccess()` 추가 + `all()`/`any()` deprecated | T3 완료 후 |
+| 5 | T5 | `StructuredTaskScopeAll`/`Any` KDoc 보강 | T4와 병렬 가능 (T2 완료 후) |
+| 5 | T10 | README 8개 파일 업데이트 | T4와 병렬 가능 |
+| 6 | T6 | API 모듈 테스트 추가 | T4 완료 후 (T5, T10과 병렬) |
+| 6 | T7 | core 모듈 편의 함수 추가 + deprecated | T4 완료 후 (T6, T10과 병렬) |
+| 7 | T8 | core 모듈 테스트 추가 | T7 완료 후 |
+| 8 | T9 | 전체 빌드 검증 (4개 모듈) | T6, T8 완료 후 |
+
+### 병렬 실행 가능 그룹
+
+```
+T1 → T2 → T3 → T4 ─┬─ T5 (병렬)
+                     ├─ T6 (병렬)
+                     ├─ T7 ─ T8 (순차)
+                     └─ T10 (병렬)
+                          └─ (T5, T6, T8 모두 완료) → T9
+```
+
+---
+
+## 수정 대상 파일 전체 목록
+
+| 파일 | 태스크 | 변경 유형 |
+|------|--------|----------|
+| `virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopes.kt` | T1, T2, T3, T4, T5 | 인터페이스 확장, KDoc 보강, deprecated 추가 |
+| `virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt` | T6 | 테스트 추가 |
+| `bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredTaskScopeSupport.kt` | T7 | 편의 함수 추가, deprecated 추가 |
+| `bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopeSupportTest.kt` | T8 | 테스트 추가 |
+| `virtualthread/api/README.md` | T10 | 결정 트리, API 교체 |
+| `virtualthread/api/README.ko.md` | T10 | 결정 트리, API 교체 (한국어) |
+| `virtualthread/jdk21/README.md` | T10 | 예제 코드 교체 |
+| `virtualthread/jdk21/README.ko.md` | T10 | 예제 코드 교체 (한국어) |
+| `virtualthread/jdk25/README.md` | T10 | 예제 코드 교체 |
+| `virtualthread/jdk25/README.ko.md` | T10 | 예제 코드 교체 (한국어) |
+| `virtualthread/README.md` | T10 | 새 API 이름 반영 |
+| `virtualthread/README.ko.md` | T10 | 새 API 이름 반영 (한국어) |
+
+**변경하지 않는 파일**:
+- `virtualthread/jdk21/src/main/.../Jdk21StructuredTaskScopeProvider.kt` — default 메서드로 자동 상속
+- `virtualthread/jdk25/src/main/.../Jdk25StructuredTaskScopeProvider.kt` — default 메서드로 자동 상속
+
+---
+
+## 핵심 구현 제약 사항
+
+| 항목 | 결정 | 근거 |
+|------|------|------|
+| `typealias` vs 독립 인터페이스 | `typealias` 채택 | 반환 타입 불일치 문제로 독립 인터페이스 기각 (Spec 섹션 3.1.1) |
+| Provider SPI `withAll`/`withAny` deprecated | **하지 않음** | jdk21/jdk25 override SPI — deprecated 시 구현체에 경고 전파 (Spec 섹션 3.4.1) |
+| `getOrNull()` 구현 패턴 | `try { get() } catch (_: IllegalStateException) { null }` | join() 전 호출 시 JDK `ensureJoinedIfOwner()` 검사 우회 |
+| deprecated 함수 내 deprecated API 호출 | `@Suppress("DEPRECATION")` 필수 | `structuredTaskScopeAll` → `StructuredTaskScopes.all()` 호출 체인 |
+| `autoJoin` 파라미터 | **도입하지 않음** | YAGNI (Spec 섹션 3.3.3) |
+| join() warn 로그 | **추가하지 않음** | 노이즈 과다 → KDoc 경고로 대체 (Spec 섹션 3.3.2) |
+
+---
+
+## 빌드 검증 명령
+
+```bash
+./gradlew :bluetape4k-virtualthread-api:test \
+          :bluetape4k-virtualthread-jdk21:test \
+          :bluetape4k-virtualthread-jdk25:test \
+          :bluetape4k-core:test
+```
+
+---
+
+## DoD 체크리스트
+
+- [ ] `virtualthread/api` — `typealias StructuredTaskScopeFailFast`, `StructuredTaskScopeFirstSuccess` 추가
+- [ ] `virtualthread/api` — `StructuredSubtask.getOrNull()` default 메서드 구현 + KDoc
+- [ ] `virtualthread/api` — `StructuredSubtask.get()` KDoc 상태별 동작 명시
+- [ ] `virtualthread/api` — `StructuredTaskScopeProvider.withFailFast()`/`withFirstSuccess()` default 메서드 추가
+- [ ] `virtualthread/api` — `withAll()`/`withAny()` KDoc `@see` 안내 추가 (deprecated 아님)
+- [ ] `virtualthread/api` — `StructuredTaskScopes.failFast()`/`firstSuccess()` 추가 (factory 기본값 포함)
+- [ ] `virtualthread/api` — `all()`/`any()` `@Deprecated(message, ReplaceWith)` 추가
+- [ ] `virtualthread/api` — `StructuredTaskScopeAll.join()` KDoc 타임아웃 경고 추가
+- [ ] `virtualthread/jdk21` — 변경 없음 확인 (기존 테스트 그대로 통과)
+- [ ] `virtualthread/jdk25` — 변경 없음 확인 (기존 테스트 그대로 통과)
+- [ ] `bluetape4k/core` — `structuredTaskScopeFailFast {}`/`structuredTaskScopeFirstSuccess {}` 추가
+- [ ] `bluetape4k/core` — `structuredTaskScopeAll {}`/`structuredTaskScopeAny {}` `@Deprecated` 추가
+- [ ] `bluetape4k/core` — deprecated 함수에 `@Suppress("DEPRECATION")` 추가
+- [ ] 새 API 테스트 추가 (`failFast`, `firstSuccess`, `getOrNull`) — T6, T8
+- [ ] 기존 테스트 전부 통과 (회귀 없음)
+- [ ] KDoc 갱신 (모든 public API — 새 추가 + 기존 보강)
+- [ ] README.md / README.ko.md 결정 트리 추가 및 API 예제 교체 (8개 파일)
+- [ ] `./gradlew :bluetape4k-virtualthread-api:test :bluetape4k-virtualthread-jdk21:test :bluetape4k-virtualthread-jdk25:test :bluetape4k-core:test` 통과
+- [ ] 브레이킹 체인지 없음 확인 (`@Deprecated`만 추가, 삭제 없음)

--- a/docs/superpowers/plans/2026-05-01-vt-api-cleanup-plan.md
+++ b/docs/superpowers/plans/2026-05-01-vt-api-cleanup-plan.md
@@ -89,7 +89,7 @@
      */
     fun <T> withFailFast(
         name: String? = null,
-        factory: ThreadFactory = Thread.ofVirtual().factory(),
+        factory: ThreadFactory = VirtualThreads.threadFactory(),
         block: (scope: StructuredTaskScopeFailFast) -> T,
     ): T = withAll(name, factory, block)
 
@@ -100,10 +100,14 @@
      */
     fun <T> withFirstSuccess(
         name: String? = null,
-        factory: ThreadFactory = Thread.ofVirtual().factory(),
+        factory: ThreadFactory = VirtualThreads.threadFactory(),
         block: (scope: StructuredTaskScopeFirstSuccess<T>) -> T,
     ): T = withAny(name, factory, block)
     ```
+  - **[수정 #7] factory 기본값 통일**: `Thread.ofVirtual().factory()` → `VirtualThreads.threadFactory()` 사용
+    - `VirtualThreads.threadFactory()`는 fallback 환경에서 플랫폼 스레드 팩토리를 안전하게 반환
+    - `Thread.ofVirtual().factory()`는 가상 스레드 미지원 환경에서 throw할 수 있음
+    - `StructuredTaskScopes.failFast()`(T4)도 동일 이유로 `VirtualThreads.threadFactory()` 사용 — 두 진입점의 기본값 일관성 유지
   - `withAll()` KDoc에 `@see withFailFast` 안내 추가 (deprecated 하지 않음 — SPI 안정성 유지)
   - `withAny()` KDoc에 `@see withFirstSuccess` 안내 추가 (deprecated 하지 않음 — SPI 안정성 유지)
   - **SPI 결정 재확인**: `withAll`/`withAny`는 jdk21/jdk25 구현체가 `override`하는 SPI 메서드이므로 deprecated 표시하지 않음
@@ -156,7 +160,10 @@
     ```kotlin
     @Deprecated(
         message = "failFast()를 사용하세요.",
-        replaceWith = ReplaceWith("failFast(name, factory, block)")
+        replaceWith = ReplaceWith(
+            "failFast(name, factory, block)",
+            "io.bluetape4k.concurrent.virtualthread.StructuredTaskScopes"
+        )
     )
     fun <T> all(
         name: String? = null,
@@ -168,7 +175,10 @@
     ```kotlin
     @Deprecated(
         message = "firstSuccess()를 사용하세요.",
-        replaceWith = ReplaceWith("firstSuccess(name, factory, block)")
+        replaceWith = ReplaceWith(
+            "firstSuccess(name, factory, block)",
+            "io.bluetape4k.concurrent.virtualthread.StructuredTaskScopes"
+        )
     )
     fun <T> any(
         name: String? = null,
@@ -176,6 +186,7 @@
         block: (scope: StructuredTaskScopeAny<T>) -> T,
     ): T = provider().withAny(name, factory, block)
     ```
+  - **[수정 #2] `ReplaceWith` import 경로 완성**: IDE quick-fix가 외부 호출 지점에서 `StructuredTaskScopes`를 자동 임포트할 수 있도록 두 번째 인자에 FQN 추가
   - 새 `failFast()`/`firstSuccess()` 함수에 KDoc 예제 포함 (fork → join → get 패턴)
 - **완료 기준**:
   - [ ] `failFast()` 추가 (factory 기본값: `VirtualThreads.threadFactory()`)
@@ -235,6 +246,7 @@
     @Test
     fun `firstSuccess scope 모든 subtask 실패 시 mapper 예외가 발생해야 한다`() { ... }
     ```
+    - **[수정 #4] 예외 타입 명시**: jdk21 `ShutdownOnSuccess.result()` 전체 실패 시 → `StructuredTaskScope.FailedException` 발생. jdk25 `Joiner.anySuccessfulResultOrThrow()` → 동일 예외. 테스트에서 `shouldThrow<StructuredTaskScope.FailedException>` (또는 상위 타입 `Exception`) assertion 필수
   - `getOrNull()` SUCCESS 상태 테스트: join() 이후 정상 결과 반환
     ```kotlin
     @Test
@@ -246,23 +258,52 @@
     fun `getOrNull 은 FAILED 상태에서 null 을 반환해야 한다`() { ... }
     ```
   - `getOrNull()` UNAVAILABLE 상태 테스트: `ShutdownOnFailure` scope에서 shutdown으로 취소된 subtask를 `join()` 이후 확인 → null 반환
-    - **주의**: join() **이전** 호출로 테스트하지 말 것 (KDoc 전제 조건 위반)
-    ```kotlin
-    @Test
-    fun `getOrNull 은 UNAVAILABLE 상태에서 null 을 반환해야 한다`() { ... }
-    ```
+    - **[수정 #1][CRITICAL] 결정론적 재현 패턴**: `CountDownLatch(2)`로 타이밍 제어
+      ```kotlin
+      @Test
+      fun `getOrNull 은 UNAVAILABLE 상태에서 null 을 반환해야 한다`() {
+          val subtaskStarted = CountDownLatch(1)   // subtask가 실행 시작했음을 신호
+          val proceedToFail  = CountDownLatch(1)   // 실패 subtask에게 진행 허가
+          var cancelledTask: StructuredSubtask<Int>? = null
+
+          StructuredTaskScopes.failFast<Int> { scope ->
+              // subtask1: 즉시 실패하여 scope shutdown 트리거
+              scope.fork { 
+                  subtaskStarted.countDown()        // subtask2가 실행 중임을 신호
+                  proceedToFail.await()             // 명시적으로 대기 후 실패
+                  throw RuntimeException("forced failure")
+              }
+              // subtask2: block 상태로 유지되다가 shutdown에 의해 취소됨
+              cancelledTask = scope.fork { 
+                  subtaskStarted.await()            // subtask1이 시작했을 때
+                  proceedToFail.countDown()         // subtask1에게 실패 허가
+                  Thread.sleep(10_000)              // scope shutdown 전까지 block
+                  42
+              }
+              scope.join()
+              // join 이후 scope shutdown으로 취소된 subtask의 상태 확인
+              cancelledTask!!.getOrNull()           // UNAVAILABLE → null
+          } 
+          // 또는 try-catch로 예외를 잡고 cancelledTask의 getOrNull() 확인
+          cancelledTask!!.state() shouldBeEqualTo UNAVAILABLE
+          cancelledTask!!.getOrNull().shouldBeNull()
+      }
+      ```
+    - **구현 주의**: `Jdk21AllScope.delegate`(private) 직접 접근 불가 → scope shutdown을 통해 간접 취소 유도. `CountDownLatch`로 실패 subtask와 block subtask 간 타이밍 결정론적 제어
   - `getOrNull()` join 이전 호출 안전성 테스트: `state() == SUCCESS`이나 join() 전 → try-catch로 null 반환
+    - **[수정 #5] 분류 주의**: 이 테스트는 **내부 방어(internal defense)** 테스트이며 공개 API 계약(public contract) 테스트가 아님. `getOrNull()`의 KDoc 전제 조건은 "join() 이후 호출"이고 join() 이전 호출은 미정의 동작. 테스트 이름에 `(내부 방어)` 명시
     ```kotlin
     @Test
-    fun `getOrNull 은 join 이전 호출에서도 null 을 안전하게 반환해야 한다`() { ... }
+    fun `getOrNull 은 join 이전 호출에서도 null 을 안전하게 반환해야 한다 (내부 방어)`() { ... }
     ```
   - scope 리소스 해제 테스트: `close()` 보장 (use{} 블록 정상 종료 확인)
   - 기존 `all scope`/`any scope` 테스트는 그대로 유지 (회귀 방지)
   - Kluent 매처 사용: `shouldBeEqualTo`, `shouldBeNull`, `shouldNotBeNull`, `shouldBeInstanceOf`
 - **완료 기준**:
   - [ ] `failFast` 정상/실패/기본값 테스트 3건 추가
-  - [ ] `firstSuccess` 정상/전체실패 테스트 2건 추가
-  - [ ] `getOrNull` SUCCESS/FAILED/UNAVAILABLE/join전 테스트 4건 추가
+  - [ ] `firstSuccess` 정상/전체실패 테스트 2건 추가 (전체실패 시 `StructuredTaskScope.FailedException` assertion 포함)
+  - [ ] `getOrNull` SUCCESS/FAILED/UNAVAILABLE(CountDownLatch)/join전(내부방어) 테스트 4건 추가
+  - [ ] **[수정 #3] `joinUntil()` 타임아웃 테스트 1건 추가**: scope 내 subtask가 제한 시간 내 완료되지 않을 때 `TimeoutException` 발생 확인 (Spec 섹션 4 명시 요구사항)
   - [ ] 기존 테스트 전부 통과 (회귀 없음)
 - **의존성**: T1, T4 완료 후
 
@@ -371,10 +412,17 @@
   - 기존 `structuredTaskScopeAll {}`/`structuredTaskScopeAny {}` 테스트는 그대로 유지 (회귀 방지 + deprecated API 동작 검증)
   - `@EnabledForJreRange(min = JRE.JAVA_21)` 어노테이션 유지
   - Kluent 매처 사용: `shouldBeEqualTo`, `shouldBeInstanceOf` 등
+  - **[수정 #8] `@Suppress("DEPRECATION")` 대상 파일 명시**:
+    - `bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredTaskScopeSupport.kt`
+      → `structuredTaskScopeAll` 내부에서 `StructuredTaskScopes.all()` 호출 시 `@Suppress("DEPRECATION")` 필요
+    - `testing/junit5` 모듈: `VirtualFuture`/`structuredTaskScopeAll` 등 deprecated API 사용 여부 사전 확인
+      → 사용 중이면 `@Suppress("DEPRECATION")` 추가 또는 새 API로 마이그레이션
+    - `utils/workflow` 모듈: `virtualFuture {}`, `structuredTaskScopeAll` 등 사용 여부 확인 후 동일 처리
 - **완료 기준**:
   - [ ] `structuredTaskScopeFailFast` 테스트 2건 추가 (정상/실패)
   - [ ] `structuredTaskScopeFirstSuccess` 테스트 2건 추가 (정상/첫성공)
   - [ ] 기존 `structuredTaskScopeAll`/`structuredTaskScopeAny` 테스트 전부 통과
+  - [ ] T7 파일 `@Suppress("DEPRECATION")` 필요 위치 확인 + 적용
 - **의존성**: T7 완료 후
 
 ---
@@ -384,13 +432,18 @@
 - **complexity**: low
 - **파일**: 없음 (빌드 명령 실행)
 - **변경 내용**:
-  - 4개 모듈 통합 테스트 실행:
+  - **[수정 #6] 검증 범위 확장**: deprecated API를 사용 중인 downstream 모듈의 컴파일 경고 발생 여부 확인 필수
+  - 6개 모듈 통합 빌드/테스트 실행:
     ```bash
     ./gradlew :bluetape4k-virtualthread-api:test \
               :bluetape4k-virtualthread-jdk21:test \
               :bluetape4k-virtualthread-jdk25:test \
-              :bluetape4k-core:test
+              :bluetape4k-core:test \
+              :bluetape4k-junit5:compileTestKotlin \
+              :bluetape4k-workflow:compileTestKotlin
     ```
+  - `testing/junit5`와 `utils/workflow` 모듈은 **테스트 실행 없이 컴파일만** 확인 (deprecated 경고 발생 여부 확인)
+    - 경고 발생 시: 해당 파일에 `@Suppress("DEPRECATION")` 추가하거나 새 API로 마이그레이션 (T8에서 식별)
   - 실패 시 오류 메시지 분석 후 T1~T8 중 해당 태스크 재작업
   - jdk21/jdk25 구현체 변경 없음 확인 (기존 테스트 통과 확인)
   - 브레이킹 체인지 없음 확인 (`@Deprecated`만 추가, 삭제 없음)
@@ -399,6 +452,8 @@
   - [ ] `bluetape4k-virtualthread-jdk21` 테스트 전부 통과 (변경 없음)
   - [ ] `bluetape4k-virtualthread-jdk25` 테스트 전부 통과 (변경 없음)
   - [ ] `bluetape4k-core` 테스트 전부 통과
+  - [ ] `bluetape4k-junit5` 컴파일 성공 (deprecated 경고 처리 확인)
+  - [ ] `bluetape4k-workflow` 컴파일 성공 (deprecated 경고 처리 확인)
   - [ ] deprecated 경고만 발생, 컴파일 오류 없음
 - **의존성**: T6, T8 완료 후
 
@@ -502,10 +557,15 @@ T1 → T2 → T3 → T4 ─┬─ T5 (병렬)
 ## 빌드 검증 명령
 
 ```bash
+# 핵심 4개 모듈 전체 테스트
 ./gradlew :bluetape4k-virtualthread-api:test \
           :bluetape4k-virtualthread-jdk21:test \
           :bluetape4k-virtualthread-jdk25:test \
           :bluetape4k-core:test
+
+# downstream 모듈 컴파일 검증 (deprecated 경고 처리 확인)
+./gradlew :bluetape4k-junit5:compileTestKotlin \
+          :bluetape4k-workflow:compileTestKotlin
 ```
 
 ---
@@ -525,9 +585,14 @@ T1 → T2 → T3 → T4 ─┬─ T5 (병렬)
 - [ ] `bluetape4k/core` — `structuredTaskScopeFailFast {}`/`structuredTaskScopeFirstSuccess {}` 추가
 - [ ] `bluetape4k/core` — `structuredTaskScopeAll {}`/`structuredTaskScopeAny {}` `@Deprecated` 추가
 - [ ] `bluetape4k/core` — deprecated 함수에 `@Suppress("DEPRECATION")` 추가
-- [ ] 새 API 테스트 추가 (`failFast`, `firstSuccess`, `getOrNull`) — T6, T8
+- [ ] 새 API 테스트 추가 (`failFast`, `firstSuccess`, `getOrNull`, `joinUntil`) — T6, T8
+- [ ] getOrNull() UNAVAILABLE 테스트: CountDownLatch 기반 결정론적 재현 사용
+- [ ] firstSuccess 전체 실패 테스트: `StructuredTaskScope.FailedException` assertion 포함
 - [ ] 기존 테스트 전부 통과 (회귀 없음)
 - [ ] KDoc 갱신 (모든 public API — 새 추가 + 기존 보강)
 - [ ] README.md / README.ko.md 결정 트리 추가 및 API 예제 교체 (8개 파일)
+- [ ] `@Suppress("DEPRECATION")` 대상 파일 처리 완료 (`StructuredTaskScopeSupport.kt`, `junit5`, `workflow` 확인)
 - [ ] `./gradlew :bluetape4k-virtualthread-api:test :bluetape4k-virtualthread-jdk21:test :bluetape4k-virtualthread-jdk25:test :bluetape4k-core:test` 통과
+- [ ] `./gradlew :bluetape4k-junit5:compileTestKotlin :bluetape4k-workflow:compileTestKotlin` 오류 없음
 - [ ] 브레이킹 체인지 없음 확인 (`@Deprecated`만 추가, 삭제 없음)
+- [ ] `withFailFast()`/`failFast()` factory 기본값 통일 확인 (둘 다 `VirtualThreads.threadFactory()`)

--- a/docs/superpowers/plans/2026-05-01-vt-api-cleanup-plan.md
+++ b/docs/superpowers/plans/2026-05-01-vt-api-cleanup-plan.md
@@ -186,7 +186,14 @@
         block: (scope: StructuredTaskScopeAny<T>) -> T,
     ): T = provider().withAny(name, factory, block)
     ```
-  - **[수정 #2] `ReplaceWith` import 경로 완성**: IDE quick-fix가 외부 호출 지점에서 `StructuredTaskScopes`를 자동 임포트할 수 있도록 두 번째 인자에 FQN 추가
+  - **[수정 #2 + LOW] `ReplaceWith` 표현식 + import 경로 완성**: IDE quick-fix가 외부 호출 지점에서 `StructuredTaskScopes`를 자동 임포트할 수 있도록 두 번째 인자에 FQN 추가. 또한 표현식 자체도 `StructuredTaskScopes.failFast(...)` 형태로 명시해야 IDE가 `StructuredTaskScopes` 컨텍스트를 정확히 인식:
+    ```kotlin
+    // 수정 전
+    replaceWith = ReplaceWith("failFast(name, factory, block)", "io...StructuredTaskScopes")
+    // 수정 후
+    replaceWith = ReplaceWith("StructuredTaskScopes.failFast(name, factory, block)", "io.bluetape4k.concurrent.virtualthread.StructuredTaskScopes")
+    ```
+    `any()` → `firstSuccess()`도 동일하게 `StructuredTaskScopes.firstSuccess(...)` 형태로 변경
   - 새 `failFast()`/`firstSuccess()` 함수에 KDoc 예제 포함 (fork → join → get 패턴)
 - **완료 기준**:
   - [ ] `failFast()` 추가 (factory 기본값: `VirtualThreads.threadFactory()`)
@@ -219,7 +226,19 @@
 ### T6: API 모듈 테스트 추가 (`getOrNull()`, `failFast()`, `firstSuccess()`)
 
 - **complexity**: medium
-- **파일**: `virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt`
+- **파일**:
+  - `virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt`
+  - `virtualthread/api/build.gradle.kts` ← **[수정 신규] testRuntimeOnly 추가 필수**
+- **[수정 HIGH] build.gradle.kts 선행 변경**: `StructuredTaskScopes.provider()`는 ServiceLoader 기반이므로 test runtime에 구현체가 없으면 `IllegalStateException` 발생. 테스트가 실행 가능하려면:
+  ```kotlin
+  // virtualthread/api/build.gradle.kts에 추가
+  dependencies {
+      ...
+      testRuntimeOnly(project(":bluetape4k-virtualthread-jdk21"))  // ServiceLoader provider 등록
+  }
+  ```
+  - 기존 `StructuredScopesTest.kt`의 주석 "test 런타임에는 jdk21 provider가 등록되어 있으므로"도 이 변경으로 비로소 보장됨
+  - `testRuntimeOnly`이므로 컴파일 타임/배포 classpath에는 포함되지 않음 — 순환 의존성 없음
 - **변경 내용**:
   - `failFast` 정상 경로 테스트: 모든 subtask 성공 → 결과 수집
     ```kotlin
@@ -246,7 +265,19 @@
     @Test
     fun `firstSuccess scope 모든 subtask 실패 시 mapper 예외가 발생해야 한다`() { ... }
     ```
-    - **[수정 #4] 예외 타입 명시**: jdk21 `ShutdownOnSuccess.result()` 전체 실패 시 → `StructuredTaskScope.FailedException` 발생. jdk25 `Joiner.anySuccessfulResultOrThrow()` → 동일 예외. 테스트에서 `shouldThrow<StructuredTaskScope.FailedException>` (또는 상위 타입 `Exception`) assertion 필수
+    - **[수정 #4 재수정] 예외 타입 수정**: `StructuredTaskScopeAny.result(mapper)` 계약상 모든 subtask 실패 시 `mapper`가 반환하는 `RuntimeException`을 throw. `StructuredTaskScope.FailedException`이 아님. 기존 `any scope 모든 subtask 실패 시 mapper 예외가 발생해야 한다` 테스트(line 133)가 `assertFailsWith<IllegalStateException>`을 사용하는 것과 동일한 패턴 적용:
+      ```kotlin
+      // 잘못된 assertion (수정 전)
+      shouldThrow<StructuredTaskScope.FailedException> { ... }
+      // 올바른 assertion (수정 후)
+      assertFailsWith<IllegalStateException> {
+          StructuredTaskScopes.firstSuccess<String> { scope ->
+              scope.fork<String> { throw RuntimeException("task1 fail") }
+              scope.fork<String> { throw RuntimeException("task2 fail") }
+              scope.join().result { IllegalStateException("all failed: ${it.message}") }
+          }
+      }
+      ```
   - `getOrNull()` SUCCESS 상태 테스트: join() 이후 정상 결과 반환
     ```kotlin
     @Test
@@ -259,6 +290,7 @@
     ```
   - `getOrNull()` UNAVAILABLE 상태 테스트: `ShutdownOnFailure` scope에서 shutdown으로 취소된 subtask를 `join()` 이후 확인 → null 반환
     - **[수정 #1][CRITICAL] 결정론적 재현 패턴**: `CountDownLatch(2)`로 타이밍 제어
+    - **[수정 HIGH] 타입 불일치 수정**: `failFast<Int>` 블록의 마지막 표현식이 `cancelledTask!!.getOrNull()`이면 `Int?`를 반환 → 타입 불일치. `failFast<Unit>` + `try-catch` 구조로 수정:
       ```kotlin
       @Test
       fun `getOrNull 은 UNAVAILABLE 상태에서 null 을 반환해야 한다`() {
@@ -266,26 +298,28 @@
           val proceedToFail  = CountDownLatch(1)   // 실패 subtask에게 진행 허가
           var cancelledTask: StructuredSubtask<Int>? = null
 
-          StructuredTaskScopes.failFast<Int> { scope ->
-              // subtask1: 즉시 실패하여 scope shutdown 트리거
-              scope.fork { 
-                  subtaskStarted.countDown()        // subtask2가 실행 중임을 신호
-                  proceedToFail.await()             // 명시적으로 대기 후 실패
-                  throw RuntimeException("forced failure")
+          // failFast<Unit>으로 블록 반환 타입 문제 회피
+          runCatching {
+              StructuredTaskScopes.failFast<Unit> { scope ->
+                  // subtask1: 실패하여 scope shutdown 트리거
+                  scope.fork<Unit> { 
+                      subtaskStarted.countDown()        // subtask2가 준비됨을 신호
+                      proceedToFail.await()             // 실패 시점 제어
+                      throw RuntimeException("forced failure")
+                  }
+                  // subtask2: block 상태로 유지되다가 shutdown에 의해 취소됨
+                  cancelledTask = scope.fork { 
+                      subtaskStarted.await()            // subtask1이 시작한 후
+                      proceedToFail.countDown()         // subtask1에게 실패 신호
+                      Thread.sleep(10_000)              // scope shutdown 전까지 block
+                      42
+                  }
+                  scope.join().throwIfFailed()          // subtask1 실패 → 예외 전파
               }
-              // subtask2: block 상태로 유지되다가 shutdown에 의해 취소됨
-              cancelledTask = scope.fork { 
-                  subtaskStarted.await()            // subtask1이 시작했을 때
-                  proceedToFail.countDown()         // subtask1에게 실패 허가
-                  Thread.sleep(10_000)              // scope shutdown 전까지 block
-                  42
-              }
-              scope.join()
-              // join 이후 scope shutdown으로 취소된 subtask의 상태 확인
-              cancelledTask!!.getOrNull()           // UNAVAILABLE → null
-          } 
-          // 또는 try-catch로 예외를 잡고 cancelledTask의 getOrNull() 확인
-          cancelledTask!!.state() shouldBeEqualTo UNAVAILABLE
+          }
+          // join() 이후 scope shutdown으로 취소된 subtask의 상태 확인
+          cancelledTask.shouldNotBeNull()
+          cancelledTask!!.state() shouldBeEqualTo StructuredTaskScope.Subtask.State.UNAVAILABLE
           cancelledTask!!.getOrNull().shouldBeNull()
       }
       ```
@@ -300,9 +334,10 @@
   - 기존 `all scope`/`any scope` 테스트는 그대로 유지 (회귀 방지)
   - Kluent 매처 사용: `shouldBeEqualTo`, `shouldBeNull`, `shouldNotBeNull`, `shouldBeInstanceOf`
 - **완료 기준**:
+  - [ ] `virtualthread/api/build.gradle.kts`에 `testRuntimeOnly(project(":bluetape4k-virtualthread-jdk21"))` 추가
   - [ ] `failFast` 정상/실패/기본값 테스트 3건 추가
-  - [ ] `firstSuccess` 정상/전체실패 테스트 2건 추가 (전체실패 시 `StructuredTaskScope.FailedException` assertion 포함)
-  - [ ] `getOrNull` SUCCESS/FAILED/UNAVAILABLE(CountDownLatch)/join전(내부방어) 테스트 4건 추가
+  - [ ] `firstSuccess` 정상/전체실패 테스트 2건 추가 (전체실패 시 **mapper가 반환한 예외 타입** assertion — `assertFailsWith<IllegalStateException>` 패턴)
+  - [ ] `getOrNull` SUCCESS/FAILED/UNAVAILABLE(CountDownLatch + `failFast<Unit>` 구조)/join전(내부방어) 테스트 4건 추가
   - [ ] **[수정 #3] `joinUntil()` 타임아웃 테스트 1건 추가**: scope 내 subtask가 제한 시간 내 완료되지 않을 때 `TimeoutException` 발생 확인 (Spec 섹션 4 명시 요구사항)
   - [ ] 기존 테스트 전부 통과 (회귀 없음)
 - **의존성**: T1, T4 완료 후
@@ -418,6 +453,11 @@
     - `testing/junit5` 모듈: `VirtualFuture`/`structuredTaskScopeAll` 등 deprecated API 사용 여부 사전 확인
       → 사용 중이면 `@Suppress("DEPRECATION")` 추가 또는 새 API로 마이그레이션
     - `utils/workflow` 모듈: `virtualFuture {}`, `structuredTaskScopeAll` 등 사용 여부 확인 후 동일 처리
+  - **[수정 MEDIUM] deprecated 경고 정책 명시**:
+    - **프로덕션 소스 (`src/main`)**: 경고 없음 목표 — `@Suppress("DEPRECATION")` 필수 적용
+    - **테스트 소스 (`src/test`)**: 기존 deprecated API 동작 검증을 위해 `@Deprecated` 함수 직접 호출하는 경우 경고 허용 (`@Suppress` 선택 적용)
+    - **Downstream 모듈** (StructuredScopesTest, StructuredScopeSupportTest, utils/workflow, testing/junit5): 경고 허용 — 이번 PR 범위 내 마이그레이션 대상 아님. T9에서 컴파일 오류만 없으면 통과
+    - **Examples** (`examples/virtualthreads-demo`): 이번 PR 범위 외(out-of-scope). 후속 PR에서 처리
 - **완료 기준**:
   - [ ] `structuredTaskScopeFailFast` 테스트 2건 추가 (정상/실패)
   - [ ] `structuredTaskScopeFirstSuccess` 테스트 2건 추가 (정상/첫성공)
@@ -444,6 +484,7 @@
     ```
   - `testing/junit5`와 `utils/workflow` 모듈은 **테스트 실행 없이 컴파일만** 확인 (deprecated 경고 발생 여부 확인)
     - 경고 발생 시: 해당 파일에 `@Suppress("DEPRECATION")` 추가하거나 새 API로 마이그레이션 (T8에서 식별)
+  - **[수정 MEDIUM] examples out-of-scope 리스크 명시**: `examples/virtualthreads-demo`는 deprecated core helper(`structuredTaskScopeAll` 등)를 직접 사용할 가능성 있음. 이번 PR에서는 examples 컴파일을 검증 범위에 포함하지 않음 — 후속 PR에서 처리. 리스크: examples가 deprecated warning으로 인해 빌드 실패할 경우 별도 `@Suppress` 적용 필요
   - 실패 시 오류 메시지 분석 후 T1~T8 중 해당 태스크 재작업
   - jdk21/jdk25 구현체 변경 없음 확인 (기존 테스트 통과 확인)
   - 브레이킹 체인지 없음 확인 (`@Deprecated`만 추가, 삭제 없음)
@@ -523,6 +564,7 @@ T1 → T2 → T3 → T4 ─┬─ T5 (병렬)
 | 파일 | 태스크 | 변경 유형 |
 |------|--------|----------|
 | `virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopes.kt` | T1, T2, T3, T4, T5 | 인터페이스 확장, KDoc 보강, deprecated 추가 |
+| `virtualthread/api/build.gradle.kts` | T6 | `testRuntimeOnly(project(":bluetape4k-virtualthread-jdk21"))` 추가 |
 | `virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt` | T6 | 테스트 추가 |
 | `bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredTaskScopeSupport.kt` | T7 | 편의 함수 추가, deprecated 추가 |
 | `bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopeSupportTest.kt` | T8 | 테스트 추가 |
@@ -586,8 +628,8 @@ T1 → T2 → T3 → T4 ─┬─ T5 (병렬)
 - [ ] `bluetape4k/core` — `structuredTaskScopeAll {}`/`structuredTaskScopeAny {}` `@Deprecated` 추가
 - [ ] `bluetape4k/core` — deprecated 함수에 `@Suppress("DEPRECATION")` 추가
 - [ ] 새 API 테스트 추가 (`failFast`, `firstSuccess`, `getOrNull`, `joinUntil`) — T6, T8
-- [ ] getOrNull() UNAVAILABLE 테스트: CountDownLatch 기반 결정론적 재현 사용
-- [ ] firstSuccess 전체 실패 테스트: `StructuredTaskScope.FailedException` assertion 포함
+- [ ] getOrNull() UNAVAILABLE 테스트: CountDownLatch + `failFast<Unit>` + try-catch 구조로 타입 불일치 없이 결정론적 재현
+- [ ] firstSuccess 전체 실패 테스트: `StructuredTaskScope.FailedException` 아닌 **mapper가 반환한 예외 타입** assertion (`assertFailsWith<IllegalStateException>`)
 - [ ] 기존 테스트 전부 통과 (회귀 없음)
 - [ ] KDoc 갱신 (모든 public API — 새 추가 + 기존 보강)
 - [ ] README.md / README.ko.md 결정 트리 추가 및 API 예제 교체 (8개 파일)

--- a/docs/superpowers/specs/2026-05-01-vt-api-cleanup-design.md
+++ b/docs/superpowers/specs/2026-05-01-vt-api-cleanup-design.md
@@ -36,7 +36,7 @@
 |---|------|------|-----------------|
 | P1 | 명칭 | `StructuredTaskScopeAll` — "All"이 "모두 완료" 의미인지 "모두 성공" 의미인지 불명확. 실제 동작은 fail-fast (하나 실패 시 전체 중단) | `StructuredScopes.kt:56` |
 | P2 | 명칭 | `StructuredTaskScopeAny` — "Any"가 "아무 결과" vs "첫 성공 결과" 혼동 가능. 실제 동작은 first-success | `StructuredScopes.kt:93` |
-| P3 | 사용성 | `StructuredTaskScopes.all/any`에 `factory` 기본값 없음 → 매 호출마다 `factory = Thread.ofVirtual().factory()` boilerplate 필수 | `StructuredScopes.kt:252,277` (vs Provider 인터페이스 `StructuredScopes.kt:138`에는 기본값 있음) |
+| P3 | 사용성 | `StructuredTaskScopes.all/any`에 `factory` 기본값 없음 → 매 호출마다 `factory = Thread.ofVirtual().factory()` boilerplate 필수 | `StructuredScopes.kt:251,276` (vs Provider 인터페이스 `StructuredScopes.kt:138`에는 기본값 있음) |
 | P4 | 중복 | `structuredTaskScopeAll/Any` (core) ↔ `StructuredTaskScopes.all/any` (api) 동일 기능, 진입점 혼란 | `StructuredTaskScopeSupport.kt:34-40` vs `StructuredScopes.kt:251-255` |
 | P5 | 안정성 | `StructuredSubtask.get()` KDoc에 FAILED/CANCELLED/RUNNING 상태별 동작 미명시 | `StructuredScopes.kt:29` |
 | P6 | 안정성 | `getOrNull()` 미제공 — 실패/취소 subtask 결과를 안전하게 조회할 방법 없음 | `StructuredScopes.kt:27-36` |
@@ -134,24 +134,22 @@ interface StructuredTaskScopeFirstSuccess<T> : AutoCloseable {
 }
 ```
 
-**결정 변경: `typealias` 대신 독립 인터페이스 채택**
+> **[SUPERSEDED — 최종 채택 아님]** 아래 텍스트는 검토 과정의 중간 결론으로, 최종 결정과 다릅니다. 구현자는 이 섹션을 구현 지침으로 사용하지 마세요. 최종 결정은 바로 아래 **"최종 결정: typealias + 새 진입 함수"** 를 따르세요.
 
-`typealias`는 `@Deprecated` 어노테이션을 붙일 수 없고, 기존 인터페이스에 deprecated를 걸면 새 이름(typealias)도 함께 deprecated 처리되는 문제가 있다. 따라서:
-
-- 새 인터페이스를 canonical로 정의
-- 기존 인터페이스 `StructuredTaskScopeAll`/`StructuredTaskScopeAny`는 새 인터페이스를 상속하면서 `@Deprecated` 처리
-- jdk21/jdk25 구현체는 **새 인터페이스를 구현**하도록 변경 (기존 인터페이스 extends 새 인터페이스이므로 하위 호환)
+독립 인터페이스 채택 검토: `typealias`는 `@Deprecated` 어노테이션을 붙일 수 없다. 기존 인터페이스에 deprecated를 걸면 새 이름(typealias)도 함께 deprecated 처리되는 문제도 있다. 그래서 독립 인터페이스를 canonical로 두고, 기존 인터페이스를 상속 wrapper로 전환하는 방식을 검토했으나 — 반환 타입 불일치 문제로 기각됨:
 
 ```kotlin
-// 기존 인터페이스를 deprecated wrapper로 전환
+// [SUPERSEDED — 구현 금지] 아래 deprecated wrapper 방식은 반환 타입 불일치로 컴파일 오류 발생
+// interface StructuredTaskScopeAll : StructuredTaskScopeFailFast 형태로 바꾸면
+// join(): StructuredTaskScopeAll 반환 타입이 join(): StructuredTaskScopeFailFast 와 충돌
 @Deprecated(
     message = "StructuredTaskScopeAll → StructuredTaskScopeFailFast 로 이름이 변경되었습니다.",
     replaceWith = ReplaceWith("StructuredTaskScopeFailFast")
 )
-interface StructuredTaskScopeAll : StructuredTaskScopeFailFast
+interface StructuredTaskScopeAll : StructuredTaskScopeFailFast  // 컴파일 오류 발생
 ```
 
-**주의**: 이 접근은 기존 `StructuredTaskScopeAll`의 반환 타입이 `StructuredTaskScopeAll` → `StructuredTaskScopeFailFast`로 변경되므로 메서드 시그니처 불일치가 발생한다. 이를 해결하기 위해 **실질적으로는 기존 인터페이스를 유지하되, `typealias`로 새 이름을 제공하는 방식**이 가장 안전하다.
+반환 타입 충돌 이유: 기존 `StructuredTaskScopeAll.join(): StructuredTaskScopeAll`이 새 인터페이스 기준 `join(): StructuredTaskScopeFailFast`와 시그니처 불일치 → **독립 인터페이스 접근 최종 기각**.
 
 **최종 결정: typealias + 새 진입 함수**
 
@@ -297,6 +295,8 @@ fun <T> structuredTaskScopeFirstSuccess(
 ): T = StructuredTaskScopes.firstSuccess(name, factory, block)
 
 // 기존 함수 deprecated
+// 주의: 내부에서 deprecated API(StructuredTaskScopes.all/any)를 호출하므로 @Suppress("DEPRECATION") 필수
+@Suppress("DEPRECATION")
 @Deprecated(
     message = "structuredTaskScopeFailFast()를 사용하세요.",
     replaceWith = ReplaceWith(
@@ -310,6 +310,7 @@ fun <T> structuredTaskScopeAll(
     block: (scope: StructuredTaskScopeAll) -> T,
 ): T = StructuredTaskScopes.all(name, factory, block)
 
+@Suppress("DEPRECATION")
 @Deprecated(
     message = "structuredTaskScopeFirstSuccess()를 사용하세요.",
     replaceWith = ReplaceWith(
@@ -370,13 +371,14 @@ interface StructuredSubtask<T> {
      * // a는 SUCCESS → 42, b는 FAILED → null
      * ```
      *
-     * > join 전 호출이 우려되면 `runCatching { get() }.getOrNull()`을 직접 사용하세요.
+     * > **구현 주의**: `state() == SUCCESS`이더라도 scope owner thread가 `join()` 이전에 호출하면
+     * > JDK 내부 `ensureJoinedIfOwner()` 검사로 인해 `get()`이 `IllegalStateException`을 던집니다.
+     * > 따라서 구현은 `get()` 호출을 try-catch로 감쌉니다.
      */
     fun getOrNull(): T? {
-        return when (state()) {
-            StructuredTaskScope.Subtask.State.SUCCESS -> get()
-            else -> null
-        }
+        return if (state() == StructuredTaskScope.Subtask.State.SUCCESS) {
+            try { get() } catch (_: IllegalStateException) { null }
+        } else null
     }
 
     fun state(): StructuredTaskScope.Subtask.State
@@ -495,8 +497,16 @@ interface StructuredTaskScopeAll : AutoCloseable {
 
 | 변경 | 설명 |
 |------|------|
-| `StructuredScopesTest` — `failFast`/`firstSuccess` 경로 테스트 추가 | 새 API 커버리지 |
-| `getOrNull()` 테스트 추가 | SUCCESS/FAILED/UNAVAILABLE 각 상태 |
+| `StructuredScopesTest` — `failFast` 정상 경로 테스트 추가 | 모든 subtask 성공 → 결과 수집 |
+| `StructuredScopesTest` — `failFast` 실패 전파 테스트 추가 | 하나 실패 시 나머지 취소 + 예외 전파 확인 |
+| `StructuredScopesTest` — `firstSuccess` 정상 경로 테스트 추가 | 첫 성공 반환 + 나머지 취소 확인 |
+| `StructuredScopesTest` — `firstSuccess` 전체 실패 테스트 추가 | 모든 subtask 실패 시 예외 전파 |
+| `StructuredScopesTest` — scope 리소스 해제 테스트 | `close()` 보장 (use{} 블록 정상 종료 확인) |
+| `StructuredScopesTest` — `joinUntil()` 타임아웃 테스트 | 데드라인 초과 시 동작 확인 |
+| `getOrNull()` SUCCESS 상태 테스트 | join() 이후 정상 결과 반환 |
+| `getOrNull()` FAILED 상태 테스트 | join() 이후 실패 subtask → null 반환 (ISE 아님) |
+| `getOrNull()` UNAVAILABLE 상태 테스트 | **방법**: `ShutdownOnFailure` scope에서 shutdown으로 취소된 subtask를 `join()` 이후에 확인 → null 반환. join() **이전** 호출로 테스트하지 말 것 (KDoc 전제 조건 위반) |
+| `getOrNull()` join 이전 호출 안전성 테스트 | `state() == SUCCESS`이나 join() 전 → try-catch로 null 반환 확인 |
 
 ### virtualthread/jdk21 (`Jdk21StructuredTaskScopeProvider.kt`)
 
@@ -538,8 +548,8 @@ interface StructuredTaskScopeAll : AutoCloseable {
 
 | # | 태스크 | 모듈 | 의존성 |
 |---|--------|------|--------|
-| T1 | `StructuredSubtask.getOrNull()` default 메서드 추가 + `get()` KDoc 보강 | `virtualthread/api` | — *(T2와 병렬 실행 가능)* |
-| T2 | `typealias` 추가 (`StructuredTaskScopeFailFast`, `StructuredTaskScopeFirstSuccess`) | `virtualthread/api` | — *(T1과 병렬 실행 가능)* |
+| T1 | `StructuredSubtask.getOrNull()` default 메서드 추가 + `get()` KDoc 보강 | `virtualthread/api` | — *(T2와 같은 파일 수정 — T1 완료 후 T2 시작)* |
+| T2 | `typealias` 추가 (`StructuredTaskScopeFailFast`, `StructuredTaskScopeFirstSuccess`) | `virtualthread/api` | T1 *(T1과 같은 파일: `StructuredScopes.kt` — 순차 실행)* |
 | T3 | `StructuredTaskScopeProvider`에 `withFailFast()`/`withFirstSuccess()` default 메서드 추가 + `withAll`/`withAny` KDoc `@see` 안내 추가 (deprecated 아님) | `virtualthread/api` | T2 |
 | T4 | `StructuredTaskScopes`에 `failFast()`/`firstSuccess()` 추가 (factory 기본값) + `all`/`any` `@Deprecated` | `virtualthread/api` | T3 |
 | T5 | `StructuredTaskScopeAll`/`StructuredTaskScopeAny` KDoc 보강 (`@see`, join 타임아웃 경고) | `virtualthread/api` | T2 |
@@ -568,9 +578,7 @@ interface StructuredTaskScopeAll : AutoCloseable {
 - [ ] 새 API 테스트 추가 (`failFast`, `firstSuccess`, `getOrNull`)
 - [ ] KDoc 갱신 (모든 public API — 새 추가 + 기존 보강)
 - [ ] README.md / README.ko.md 결정 트리 추가 및 API 예제 교체 (8개 파일: `virtualthread/api` ×2, `virtualthread/jdk21` ×2, `virtualthread/jdk25` ×2, `virtualthread/` root ×2)
-- [ ] `./gradlew :bluetape4k-virtualthread-api:test :bluetape4k-virtualthread-jdk21:test :bluetape4k-virtualthread-jdk25:test :bluetape4k-core:test` 통과
-- [ ] `./gradlew :bluetape4k-virtualthread-jdk21:test` 통과
-- [ ] `./gradlew :bluetape4k-core:test` 통과
+- [ ] `./gradlew :bluetape4k-virtualthread-api:test :bluetape4k-virtualthread-jdk21:test :bluetape4k-virtualthread-jdk25:test :bluetape4k-core:test` 통과 (4개 모듈 통합 검증)
 - [ ] 브레이킹 체인지 없음 확인 (`@Deprecated`만 추가, 삭제 없음)
 
 ---

--- a/docs/superpowers/specs/2026-05-01-vt-api-cleanup-design.md
+++ b/docs/superpowers/specs/2026-05-01-vt-api-cleanup-design.md
@@ -1,0 +1,599 @@
+# [virtualthread] D: API 통합 — 사용성·명칭 직관성·안정성 개선
+
+> **Issue**: #255
+> **Branch**: `feat/vt-api-cleanup`
+> **Date**: 2026-05-01
+> **Status**: Approved
+
+---
+
+## 1. 현상 분석 (As-Is)
+
+### 1.1 코드 지형도
+
+| 모듈 | 파일 | 역할 |
+|------|------|------|
+| `virtualthread/api` | `StructuredScopes.kt` | `StructuredSubtask<T>`, `StructuredTaskScopeAll`, `StructuredTaskScopeAny<T>` 인터페이스, `StructuredTaskScopeProvider` SPI, `StructuredTaskScopes` 진입 object |
+| `virtualthread/api` | `VirtualThreadRuntime.kt` | 런타임 추상화 인터페이스 |
+| `virtualthread/api` | `VirtualThreads.kt` | ServiceLoader 기반 런타임 선택 object, `threadFactory()`, `executorService()` |
+| `virtualthread/jdk21` | `Jdk21StructuredTaskScopeProvider.kt` | `ShutdownOnFailure`/`ShutdownOnSuccess` 기반 구현 |
+| `virtualthread/jdk25` | `Jdk25StructuredTaskScopeProvider.kt` | `Joiner.awaitAll`/`anySuccessfulResultOrThrow` 기반 구현 |
+| `bluetape4k/core` | `StructuredTaskScopeSupport.kt` | `structuredTaskScopeAll {}` / `structuredTaskScopeAny {}` 편의 함수 |
+
+### 1.2 외부 소비처 (Blast Radius)
+
+| 소비 모듈 | 파일 | 사용 API |
+|-----------|------|----------|
+| `utils/workflow` | `ParallelWorkFlow.kt:75,125` | `StructuredTaskScopes.all()`, `.any()` |
+| `testing/junit5` | `StructuredTaskScopeTester.kt:147` | `StructuredTaskScopes.all()` |
+| `examples/virtualthreads-demo` | `StructuredConcurrencyExamples.kt:37,72` | `structuredTaskScopeAll {}`, `structuredTaskScopeAny {}` |
+| `examples/virtualthreads-demo` | `Rule5UseThreadLocalCarefully.kt:66` | `structuredTaskScopeAll {}` |
+| `bluetape4k/core` (test) | `StructuredScopeSupportTest.kt` | `structuredTaskScopeAll {}`, `structuredTaskScopeAny {}` |
+
+### 1.3 식별된 문제
+
+| # | 범주 | 문제 | 근거 (file:line) |
+|---|------|------|-----------------|
+| P1 | 명칭 | `StructuredTaskScopeAll` — "All"이 "모두 완료" 의미인지 "모두 성공" 의미인지 불명확. 실제 동작은 fail-fast (하나 실패 시 전체 중단) | `StructuredScopes.kt:56` |
+| P2 | 명칭 | `StructuredTaskScopeAny` — "Any"가 "아무 결과" vs "첫 성공 결과" 혼동 가능. 실제 동작은 first-success | `StructuredScopes.kt:93` |
+| P3 | 사용성 | `StructuredTaskScopes.all/any`에 `factory` 기본값 없음 → 매 호출마다 `factory = Thread.ofVirtual().factory()` boilerplate 필수 | `StructuredScopes.kt:252,277` (vs Provider 인터페이스 `StructuredScopes.kt:138`에는 기본값 있음) |
+| P4 | 중복 | `structuredTaskScopeAll/Any` (core) ↔ `StructuredTaskScopes.all/any` (api) 동일 기능, 진입점 혼란 | `StructuredTaskScopeSupport.kt:34-40` vs `StructuredScopes.kt:251-255` |
+| P5 | 안정성 | `StructuredSubtask.get()` KDoc에 FAILED/CANCELLED/RUNNING 상태별 동작 미명시 | `StructuredScopes.kt:29` |
+| P6 | 안정성 | `getOrNull()` 미제공 — 실패/취소 subtask 결과를 안전하게 조회할 방법 없음 | `StructuredScopes.kt:27-36` |
+| P7 | 가이드 | `Dispatchers.VT` vs `executorService()` vs `structuredTaskScopeAll` 선택 기준 문서 없음 | README 전체 |
+
+---
+
+## 2. 설계 접근법 비교
+
+### Option A: 인터페이스 이름 변경 + 기존 deprecated (권장)
+
+새 인터페이스명(`StructuredTaskScopeFailFast`, `StructuredTaskScopeFirstSuccess`)을 추가하고, 기존 인터페이스는 `typealias` + `@Deprecated` 처리.
+
+| 장점 | 단점 |
+|------|------|
+| 명칭이 동작 의도를 직접 전달 | 임시 중복: 전환기에 2세트의 이름 공존 |
+| IDE가 `ReplaceWith` 자동 마이그레이션 안내 | `typealias`가 아닌 별도 인터페이스면 구현체 2벌 필요 |
+| 외부 코드 즉시 깨지지 않음 (하위 호환) | |
+
+### Option B: 인터페이스 유지, 진입 함수(StructuredTaskScopes.*)만 개선
+
+인터페이스명은 `All`/`Any` 그대로 두고, `StructuredTaskScopes.failFast {}`/`firstSuccess {}` 진입 함수만 추가.
+
+| 장점 | 단점 |
+|------|------|
+| 최소 변경량 (함수 2개 + KDoc) | 인터페이스 이름 `StructuredTaskScopeAll` 은 여전히 혼란 유발 |
+| jdk21/jdk25 구현체 변경 불필요 | Provider SPI의 `withAll`/`withAny` 이름도 여전히 불명확 |
+| 안정성 매우 높음 | 장기적으로 코드 리딩 시 불편 지속 |
+
+### Option C: 완전 새 API (v2) 별도 패키지
+
+`io.bluetape4k.concurrent.virtualthread.v2` 패키지에 완전히 새로운 API 도입.
+
+| 장점 | 단점 |
+|------|------|
+| 깨끗한 설계, 레거시 잔재 없음 | **YAGNI 위반**: 현 사용자 규모에서 과도한 투자 |
+| 향후 확장 자유도 높음 | 패키지 분리 → 의존성 복잡도 증가 |
+| | ServiceLoader 이중 관리 필요 |
+| | 기존 v1 유지보수 부담 잔존 |
+
+### 선택: Option A (변형)
+
+**Option A를 기반으로 하되, `typealias` 전략으로 구현체 중복을 제거한다.**
+
+근거:
+1. 인터페이스 이름이 라이브러리 사용자에게 가장 많이 노출되는 API 표면이므로 명칭 개선 효과 극대화
+2. `typealias`를 사용하면 jdk21/jdk25 구현체를 수정하지 않아도 됨 (바이너리 호환)
+3. `StructuredTaskScopes` object의 진입 함수도 동시 개선하여 진입점 명확화
+4. Option B의 장점(최소 변경)도 `typealias`로 대부분 확보
+
+### Antithesis (Option A 반론 — steelman)
+
+Option B가 더 나은 경우: `typealias` + `@Deprecated`를 인터페이스에 적용하면, 인터페이스를 구현하는 **외부 코드**(bluetape4k 외부에서 `StructuredTaskScopeAll`을 직접 implements 하는 코드)가 존재할 때 deprecation 경고가 해당 코드에도 전파된다. 현재 SPI가 내부용이므로 실질적 위험은 낮지만, 라이브러리 특성상 예상치 못한 외부 소비자가 있을 수 있다. Option B는 이 위험을 완전히 회피한다.
+
+### Tradeoff Tension
+
+명칭 직관성(사용자 경험) vs 전환 비용(deprecation 노이즈). 인터페이스까지 개선하면 장기 가독성은 좋아지지만, 전환기에 모든 기존 사용처에 deprecation 경고가 발생한다. `typealias` 방식은 이 tension을 최소화하지만 완전히 제거하지는 못한다.
+
+---
+
+## 3. 상세 설계
+
+### 3.1 명칭 개선 (Naming)
+
+#### 3.1.1 새 인터페이스 (canonical)
+
+> **[REJECTED]** — 아래 독립 인터페이스 접근법은 반환 타입 불일치(`join(): StructuredTaskScopeFailFast` vs `join(): StructuredTaskScopeAll`) 문제로 기각됨. **최종 결정: typealias** (line 154 이하 참조).
+
+```kotlin
+// StructuredScopes.kt 에 추가
+
+/**
+ * 모든 작업 완료를 기다리고, 하나라도 실패하면 즉시 전체를 중단하는 fail-fast scope입니다.
+ * 
+ * 기존 [StructuredTaskScopeAll]과 동일한 인터페이스이며, 동작 의도를 명확히 전달합니다.
+ */
+interface StructuredTaskScopeFailFast : AutoCloseable {
+    fun <T> fork(task: () -> T): StructuredSubtask<T>
+    fun join(): StructuredTaskScopeFailFast
+    fun joinUntil(deadline: java.time.Instant): StructuredTaskScopeFailFast = join()
+    fun throwIfFailed(handler: (e: Throwable) -> Unit = {}): StructuredTaskScopeFailFast
+    override fun close()
+}
+
+/**
+ * 첫 번째 성공 결과를 선택하는 first-success scope입니다.
+ * 
+ * 기존 [StructuredTaskScopeAny]와 동일한 인터페이스이며, 동작 의도를 명확히 전달합니다.
+ */
+interface StructuredTaskScopeFirstSuccess<T> : AutoCloseable {
+    fun <V : T> fork(task: () -> V): StructuredSubtask<V>
+    fun join(): StructuredTaskScopeFirstSuccess<T>
+    fun result(mapper: (Throwable) -> RuntimeException): T
+    override fun close()
+}
+```
+
+**결정 변경: `typealias` 대신 독립 인터페이스 채택**
+
+`typealias`는 `@Deprecated` 어노테이션을 붙일 수 없고, 기존 인터페이스에 deprecated를 걸면 새 이름(typealias)도 함께 deprecated 처리되는 문제가 있다. 따라서:
+
+- 새 인터페이스를 canonical로 정의
+- 기존 인터페이스 `StructuredTaskScopeAll`/`StructuredTaskScopeAny`는 새 인터페이스를 상속하면서 `@Deprecated` 처리
+- jdk21/jdk25 구현체는 **새 인터페이스를 구현**하도록 변경 (기존 인터페이스 extends 새 인터페이스이므로 하위 호환)
+
+```kotlin
+// 기존 인터페이스를 deprecated wrapper로 전환
+@Deprecated(
+    message = "StructuredTaskScopeAll → StructuredTaskScopeFailFast 로 이름이 변경되었습니다.",
+    replaceWith = ReplaceWith("StructuredTaskScopeFailFast")
+)
+interface StructuredTaskScopeAll : StructuredTaskScopeFailFast
+```
+
+**주의**: 이 접근은 기존 `StructuredTaskScopeAll`의 반환 타입이 `StructuredTaskScopeAll` → `StructuredTaskScopeFailFast`로 변경되므로 메서드 시그니처 불일치가 발생한다. 이를 해결하기 위해 **실질적으로는 기존 인터페이스를 유지하되, `typealias`로 새 이름을 제공하는 방식**이 가장 안전하다.
+
+**최종 결정: typealias + 새 진입 함수**
+
+```kotlin
+// StructuredScopes.kt — 기존 인터페이스 유지, typealias로 새 이름 제공
+/** fail-fast 동작을 하는 [StructuredTaskScopeAll]의 의도 명확 별칭입니다. */
+typealias StructuredTaskScopeFailFast = StructuredTaskScopeAll
+
+/** first-success 동작을 하는 [StructuredTaskScopeAny]의 의도 명확 별칭입니다. */
+typealias StructuredTaskScopeFirstSuccess<T> = StructuredTaskScopeAny<T>
+```
+
+이유:
+- `typealias`는 **Kotlin source-level 별칭**이며, JVM 바이너리에는 기존 타입(`StructuredTaskScopeAll`)만 남음 → Java 소비자는 새 이름 사용 불가 (Kotlin-only 개선)
+- 기존 코드 **전혀 변경 불필요** (바이너리 호환)
+- jdk21/jdk25 구현체 수정 없음
+- 새 Kotlin 사용자는 `StructuredTaskScopeFailFast` 이름으로 진입 가능
+- 기존 `StructuredTaskScopeAll` 이름은 KDoc에 `@see StructuredTaskScopeFailFast` 안내 추가
+
+> **한계**: Java 소비자가 있는 환경에서는 바이너리 수준의 명칭 이전 효과 없음. 이 프로젝트의 주 소비자가 Kotlin이므로 허용 가능한 트레이드오프.
+
+#### 3.1.2 Provider 인터페이스 확장
+
+```kotlin
+// StructuredTaskScopeProvider 에 추가
+interface StructuredTaskScopeProvider {
+    // ... 기존 멤버 유지 ...
+
+    /**
+     * 실패 전파형(fail-fast) 블록을 실행합니다.
+     * 기본 구현은 [withAll]에 위임합니다.
+     */
+    fun <T> withFailFast(
+        name: String? = null,
+        factory: ThreadFactory = Thread.ofVirtual().factory(),
+        block: (scope: StructuredTaskScopeFailFast) -> T,
+    ): T = withAll(name, factory, block)
+
+    /**
+     * 성공 우선형(first-success) 블록을 실행합니다.
+     * 기본 구현은 [withAny]에 위임합니다.
+     */
+    fun <T> withFirstSuccess(
+        name: String? = null,
+        factory: ThreadFactory = Thread.ofVirtual().factory(),
+        block: (scope: StructuredTaskScopeFirstSuccess<T>) -> T,
+    ): T = withAny(name, factory, block)
+}
+```
+
+**SPI 설계 결정**: `withAll`/`withAny`는 **deprecated하지 않음**.
+
+근거:
+- `StructuredTaskScopeProvider`는 jdk21/jdk25 구현체가 `override`하는 SPI 메서드
+- deprecated로 표시하면 두 구현체가 deprecated 메서드를 계속 `override`해야 하고, 외부 Provider 구현자에게도 경고 전파
+- **목표는 사용자 진입점 개선**이므로 `StructuredTaskScopes.all/any`(object 레벨)와 core helper만 deprecated 처리로 충분
+- `withAll`/`withAny`는 KDoc에 `@see withFailFast`/`@see withFirstSuccess` 안내만 추가
+
+#### 3.1.3 StructuredTaskScopes object 확장
+
+```kotlin
+object StructuredTaskScopes : KLogging() {
+    // ... 기존 providers, provider(), providerName() 유지 ...
+
+    /**
+     * 실패 전파형(fail-fast) scope 블록을 실행합니다.
+     *
+     * 하나의 subtask라도 실패하면 나머지를 즉시 중단하고 예외를 전파합니다.
+     *
+     * @param name scope 이름 (디버깅용)
+     * @param factory subtask 실행용 스레드 팩토리 (기본값: `VirtualThreads.threadFactory()`)
+     * @param block scope 실행 블록
+     */
+    fun <T> failFast(
+        name: String? = null,
+        factory: ThreadFactory = VirtualThreads.threadFactory(),
+        block: (scope: StructuredTaskScopeFailFast) -> T,
+    ): T = provider().withFailFast(name, factory, block)
+
+    /**
+     * 성공 우선형(first-success) scope 블록을 실행합니다.
+     *
+     * 첫 번째 성공한 subtask 결과를 반환하고 나머지를 취소합니다.
+     *
+     * @param name scope 이름 (디버깅용)
+     * @param factory subtask 실행용 스레드 팩토리 (기본값: `VirtualThreads.threadFactory()`)
+     * @param block scope 실행 블록
+     */
+    fun <T> firstSuccess(
+        name: String? = null,
+        factory: ThreadFactory = VirtualThreads.threadFactory(),
+        block: (scope: StructuredTaskScopeFirstSuccess<T>) -> T,
+    ): T = provider().withFirstSuccess(name, factory, block)
+
+    // 기존 all/any에 @Deprecated 추가
+    @Deprecated(
+        message = "failFast()를 사용하세요.",
+        replaceWith = ReplaceWith("failFast(name, factory, block)")
+    )
+    fun <T> all(
+        name: String? = null,
+        factory: ThreadFactory,  // 기본값 없음 — 기존 시그니처 유지
+        block: (scope: StructuredTaskScopeAll) -> T,
+    ): T = provider().withAll(name, factory, block)
+
+    @Deprecated(
+        message = "firstSuccess()를 사용하세요.",
+        replaceWith = ReplaceWith("firstSuccess(name, factory, block)")
+    )
+    fun <T> any(
+        name: String? = null,
+        factory: ThreadFactory,  // 기본값 없음 — 기존 시그니처 유지
+        block: (scope: StructuredTaskScopeAny<T>) -> T,
+    ): T = provider().withAny(name, factory, block)
+}
+```
+
+**핵심**: 새 함수 `failFast()`/`firstSuccess()`에는 `factory` 기본값 추가 → P3 해결.
+
+### 3.2 사용성 개선 (Usability)
+
+#### 3.2.1 core 편의 함수 교체
+
+```kotlin
+// StructuredTaskScopeSupport.kt
+
+/**
+ * 실패 전파형(fail-fast) 구조화된 동시성 블록을 실행합니다.
+ */
+fun <T> structuredTaskScopeFailFast(
+    name: String? = null,
+    factory: ThreadFactory = VirtualThreads.threadFactory("sts-failfast-"),
+    block: (scope: StructuredTaskScopeFailFast) -> T,
+): T = StructuredTaskScopes.failFast(name, factory, block)
+
+/**
+ * 성공 우선형(first-success) 구조화된 동시성 블록을 실행합니다.
+ */
+fun <T> structuredTaskScopeFirstSuccess(
+    name: String? = null,
+    factory: ThreadFactory = VirtualThreads.threadFactory("sts-first-"),
+    block: (scope: StructuredTaskScopeFirstSuccess<T>) -> T,
+): T = StructuredTaskScopes.firstSuccess(name, factory, block)
+
+// 기존 함수 deprecated
+@Deprecated(
+    message = "structuredTaskScopeFailFast()를 사용하세요.",
+    replaceWith = ReplaceWith(
+        "structuredTaskScopeFailFast(name, factory, block)",
+        "io.bluetape4k.concurrent.virtualthread.structuredTaskScopeFailFast"
+    )
+)
+fun <T> structuredTaskScopeAll(
+    name: String? = null,
+    factory: ThreadFactory = VirtualThreads.threadFactory("sts-all-"),
+    block: (scope: StructuredTaskScopeAll) -> T,
+): T = StructuredTaskScopes.all(name, factory, block)
+
+@Deprecated(
+    message = "structuredTaskScopeFirstSuccess()를 사용하세요.",
+    replaceWith = ReplaceWith(
+        "structuredTaskScopeFirstSuccess(name, factory, block)",
+        "io.bluetape4k.concurrent.virtualthread.structuredTaskScopeFirstSuccess"
+    )
+)
+fun <T> structuredTaskScopeAny(
+    name: String? = null,
+    factory: ThreadFactory = VirtualThreads.threadFactory("sts-any-"),
+    block: (scope: StructuredTaskScopeAny<T>) -> T,
+): T = StructuredTaskScopes.any(name, factory, block)
+```
+
+### 3.3 안정성 개선 (Stability)
+
+#### 3.3.1 `StructuredSubtask.getOrNull()` 추가
+
+```kotlin
+interface StructuredSubtask<T> {
+    /** subtask 성공 결과를 반환합니다.
+     *
+     * ## 상태별 동작 (JDK `Subtask.get()` 계약 그대로)
+     * - `SUCCESS`: 결과를 반환합니다.
+     * - `FAILED`: **`IllegalStateException`을 던집니다** (실패 원인은 `exceptionOrNull()`로 조회).
+     * - `UNAVAILABLE` (미완료/취소/join 이전): **`IllegalStateException`을 던집니다**.
+     *
+     * > **주의**: FAILED 상태에서 실패 원인 예외 자체를 던지지 않습니다.
+     * > 원인 예외 조회는 `exceptionOrNull()`을, null-safe 결과 조회는 [getOrNull]을 사용하세요.
+     */
+    fun get(): T
+
+    /**
+     * subtask 성공 결과를 반환하고, 실패/취소/미완료 상태에서는 `null`을 반환합니다.
+     *
+     * **전제 조건**: scope의 `join()`이 완료된 이후에 호출해야 합니다.
+     * `join()` 전에 호출하면 subtask가 `SUCCESS`이더라도 [get]이 `IllegalStateException`을 던질 수 있습니다
+     * (JDK 계약상 "join 이후" 조건도 요구하기 때문).
+     *
+     * ## 상태별 동작 (join() 이후 호출 기준)
+     * - `SUCCESS`: 결과를 반환합니다.
+     * - `FAILED`: `null`을 반환합니다 (예외를 던지지 않음).
+     * - `UNAVAILABLE` (join 전 또는 취소): `null`을 반환합니다.
+     *
+     * ```kotlin
+     * // failFast 예제: b가 실패해도 a 결과를 안전하게 수집
+     * val results = StructuredTaskScopes.failFast { scope ->
+     *     val a = scope.fork { 42 }
+     *     // b는 join 전에 반드시 실패하도록 즉시 throw
+     *     val b = scope.fork<Int> { Thread.sleep(1); throw RuntimeException("fail") }
+     *     try {
+     *         scope.join()
+     *         scope.throwIfFailed()
+     *     } catch (_: Exception) { }
+     *     // join() 완료 후 안전 조회
+     *     listOfNotNull(a.getOrNull(), b.getOrNull())
+     * }
+     * // a는 SUCCESS → 42, b는 FAILED → null
+     * ```
+     *
+     * > join 전 호출이 우려되면 `runCatching { get() }.getOrNull()`을 직접 사용하세요.
+     */
+    fun getOrNull(): T? {
+        return when (state()) {
+            StructuredTaskScope.Subtask.State.SUCCESS -> get()
+            else -> null
+        }
+    }
+
+    fun state(): StructuredTaskScope.Subtask.State
+    fun exceptionOrNull(): Throwable?
+}
+```
+
+`getOrNull()`은 인터페이스 default 메서드로 제공하므로 **jdk21/jdk25 구현체 변경 불필요**.
+
+#### 3.3.2 `join()` 타임아웃 없는 호출 warn 로그
+
+Provider 구현체 레벨(jdk21/jdk25)의 `AllScope.join()` 내부에 warn 로그를 추가하는 것은 **과도한 노이즈**를 유발한다. 모든 정상 사용에서도 `join()` → `throwIfFailed()` 순서로 호출하므로 매번 warn이 발생한다.
+
+**대안**: KDoc 경고로 대체하고, `joinUntil()` 사용 권장 가이드를 README에 포함한다.
+
+```kotlin
+// StructuredScopes.kt — StructuredTaskScopeAll.join() KDoc 보강
+// (typealias에는 멤버 KDoc을 붙일 수 없으므로, 실제 수정 대상은 StructuredTaskScopeAll)
+interface StructuredTaskScopeAll : AutoCloseable {
+    /**
+     * 등록된 subtask 완료를 대기합니다.
+     *
+     * **주의**: 타임아웃 없이 호출하면 subtask가 무한 차단될 수 있습니다.
+     * 프로덕션 코드에서는 [joinUntil]을 사용하여 데드라인을 설정하세요.
+     *
+     * @see StructuredTaskScopeFailFast
+     */
+    fun join(): StructuredTaskScopeAll
+}
+```
+
+> **구현 주의**: `StructuredTaskScopeFailFast`는 `typealias`이므로 별도 인터페이스 선언이나 KDoc 멤버를 가질 수 없다. join() 타임아웃 경고는 **`StructuredTaskScopeAll.join()`에 직접 추가**해야 한다.
+
+#### 3.3.3 `autoJoin` 파라미터 평가
+
+`withFailFast(autoJoin = true)` 파라미터를 추가하면 `block` 실행 전 자동으로 `join()` + `throwIfFailed()`를 호출하는 편의를 제공할 수 있다. 그러나:
+
+- `fork()` → `join()` → `get()` 순서가 사용자에게 명시적이어야 구조화된 동시성의 의미가 전달됨
+- `autoJoin`이 `true`이면 block 안에서 subtask 결과를 조합하는 일반 패턴이 깨짐 (join 후 block에서 get 호출 불필요해지는 것이 아니라, block 반환 시점 이후에 join이 일어나야 하므로 의미론적 혼란)
+
+**결정**: `autoJoin` 파라미터 **도입하지 않음** (YAGNI).
+
+### 3.4 중복 제거 및 사용 가이드
+
+#### 3.4.1 Deprecation 계획
+
+| 기존 API | 새 API | 위치 | Deprecated 시점 |
+|----------|--------|------|----------------|
+| `StructuredTaskScopes.all()` | `StructuredTaskScopes.failFast()` | `virtualthread/api` | 이번 PR |
+| `StructuredTaskScopes.any()` | `StructuredTaskScopes.firstSuccess()` | `virtualthread/api` | 이번 PR |
+| `structuredTaskScopeAll {}` | `structuredTaskScopeFailFast {}` | `bluetape4k/core` | 이번 PR |
+| `structuredTaskScopeAny {}` | `structuredTaskScopeFirstSuccess {}` | `bluetape4k/core` | 이번 PR |
+
+> **Provider SPI 제외**: `StructuredTaskScopeProvider.withAll()`/`withAny()`는 deprecated 대상에서 **제외**한다.
+> jdk21/jdk25 구현체가 `override`하는 SPI 메서드이므로, deprecated 표시 시 구현체와 외부 Provider 구현자에게 경고가 전파된다.
+> 대신 KDoc에 `@see withFailFast`/`@see withFirstSuccess` 안내만 추가한다.
+
+**제거 시점**: 다음 major 버전 (2.0) — 현재 PR에서는 제거하지 않음.
+
+#### 3.4.2 README 결정 트리
+
+`virtualthread/api/README.md` 및 `README.ko.md`에 다음 결정 트리 추가:
+
+```
+## API 선택 가이드 (Decision Tree)
+
+어떤 API를 사용해야 할까?
+
+┌─ Coroutines 기반 코드인가?
+│  ├─ YES → `Dispatchers.VT` 또는 `withVirtualContext {}`
+│  │         (코루틴 스케줄러로 가상 스레드 활용)
+│  └─ NO ──┐
+│           │
+├─ 여러 작업을 동시에 실행하고 구조적으로 관리해야 하는가?
+│  ├─ YES ──┐
+│  │        ├─ 모두 성공해야 하는가? (하나 실패 시 전체 중단)
+│  │        │  └─ `StructuredTaskScopes.failFast { scope -> ... }`
+│  │        │
+│  │        └─ 가장 먼저 성공한 결과만 필요한가?
+│  │           └─ `StructuredTaskScopes.firstSuccess { scope -> ... }`
+│  │
+│  └─ NO ──┐
+│           │
+├─ 단일 비동기 작업을 Future로 실행하고 싶은가?
+│  └─ YES → `virtualFuture { ... }` (VirtualFuture<T> 반환)
+│
+└─ Java ExecutorService와 통합해야 하는가?
+   └─ YES → `VirtualThreads.executorService()` (.use { } 권장)
+```
+
+---
+
+## 4. 변경 파일 목록
+
+### virtualthread/api (`StructuredScopes.kt`)
+
+| 변경 | 설명 |
+|------|------|
+| `typealias StructuredTaskScopeFailFast` 추가 | `= StructuredTaskScopeAll` |
+| `typealias StructuredTaskScopeFirstSuccess<T>` 추가 | `= StructuredTaskScopeAny<T>` |
+| `StructuredSubtask.getOrNull()` default 메서드 추가 | 안전한 null 반환 |
+| `StructuredSubtask.get()` KDoc 보강 | 상태별 동작 명시 |
+| `StructuredTaskScopeAll` KDoc에 `@see StructuredTaskScopeFailFast` 추가 | 마이그레이션 안내 |
+| `StructuredTaskScopeAny` KDoc에 `@see StructuredTaskScopeFirstSuccess` 추가 | 마이그레이션 안내 |
+| `StructuredTaskScopeAll.join()` KDoc에 타임아웃 경고 추가 | 안정성 |
+| `StructuredTaskScopeProvider.withFailFast()` default 메서드 추가 | `withAll()` 위임 |
+| `StructuredTaskScopeProvider.withFirstSuccess()` default 메서드 추가 | `withAny()` 위임 |
+| `StructuredTaskScopeProvider.withAll()` KDoc에 `@see withFailFast` 추가 | 마이그레이션 안내 (deprecated 하지 않음 — SPI) |
+| `StructuredTaskScopeProvider.withAny()` KDoc에 `@see withFirstSuccess` 추가 | 마이그레이션 안내 (deprecated 하지 않음 — SPI) |
+| `StructuredTaskScopes.failFast()` 추가 (factory 기본값 포함) | 새 진입점 |
+| `StructuredTaskScopes.firstSuccess()` 추가 (factory 기본값 포함) | 새 진입점 |
+| `StructuredTaskScopes.all()` `@Deprecated` 추가 | 마이그레이션 |
+| `StructuredTaskScopes.any()` `@Deprecated` 추가 | 마이그레이션 |
+
+### virtualthread/api (테스트)
+
+| 변경 | 설명 |
+|------|------|
+| `StructuredScopesTest` — `failFast`/`firstSuccess` 경로 테스트 추가 | 새 API 커버리지 |
+| `getOrNull()` 테스트 추가 | SUCCESS/FAILED/UNAVAILABLE 각 상태 |
+
+### virtualthread/jdk21 (`Jdk21StructuredTaskScopeProvider.kt`)
+
+| 변경 | 설명 |
+|------|------|
+| 변경 없음 | `withFailFast()`/`withFirstSuccess()`는 Provider 인터페이스 default 메서드로 위임 |
+
+### virtualthread/jdk25 (`Jdk25StructuredTaskScopeProvider.kt`)
+
+| 변경 | 설명 |
+|------|------|
+| 변경 없음 | `withFailFast()`/`withFirstSuccess()`는 Provider 인터페이스 default 메서드로 위임 |
+
+### bluetape4k/core (`StructuredTaskScopeSupport.kt`)
+
+| 변경 | 설명 |
+|------|------|
+| `structuredTaskScopeFailFast {}` 추가 | 새 편의 함수 |
+| `structuredTaskScopeFirstSuccess {}` 추가 | 새 편의 함수 |
+| `structuredTaskScopeAll {}` `@Deprecated` 추가 | 마이그레이션 |
+| `structuredTaskScopeAny {}` `@Deprecated` 추가 | 마이그레이션 |
+
+### README 파일
+
+| 파일 | 변경 | 근거 |
+|------|------|------|
+| `virtualthread/api/README.md` | 결정 트리 추가 + API 레퍼런스에서 `all`/`any` → `failFast`/`firstSuccess` 교체 | 주 문서 |
+| `virtualthread/api/README.ko.md` | 결정 트리 추가 + API 레퍼런스에서 `all`/`any` → `failFast`/`firstSuccess` 교체 | 주 문서 (한국어) |
+| `virtualthread/jdk21/README.md` | 예제 코드 `StructuredTaskScopes.all` → `StructuredTaskScopes.failFast` 교체 | 실제 사용 예제 포함 (line 187) |
+| `virtualthread/jdk21/README.ko.md` | 예제 코드 `StructuredTaskScopes.all` → `StructuredTaskScopes.failFast` 교체 | 실제 사용 예제 포함 (line 186) |
+| `virtualthread/jdk25/README.md` | 예제 코드 `StructuredTaskScopes.all` → `StructuredTaskScopes.failFast` 교체 | 실제 사용 예제 포함 (line 214) |
+| `virtualthread/jdk25/README.ko.md` | 예제 코드 `StructuredTaskScopes.all` → `StructuredTaskScopes.failFast` 교체 | 실제 사용 예제 포함 (line 212) |
+| `virtualthread/README.md` | 상위 모듈 개요 — 새 API 이름 반영 | 모듈 루트 README |
+| `virtualthread/README.ko.md` | 상위 모듈 개요 — 새 API 이름 반영 (한국어) | 모듈 루트 README |
+
+---
+
+## 5. 작업 순서 (Task List)
+
+| # | 태스크 | 모듈 | 의존성 |
+|---|--------|------|--------|
+| T1 | `StructuredSubtask.getOrNull()` default 메서드 추가 + `get()` KDoc 보강 | `virtualthread/api` | — *(T2와 병렬 실행 가능)* |
+| T2 | `typealias` 추가 (`StructuredTaskScopeFailFast`, `StructuredTaskScopeFirstSuccess`) | `virtualthread/api` | — *(T1과 병렬 실행 가능)* |
+| T3 | `StructuredTaskScopeProvider`에 `withFailFast()`/`withFirstSuccess()` default 메서드 추가 + `withAll`/`withAny` KDoc `@see` 안내 추가 (deprecated 아님) | `virtualthread/api` | T2 |
+| T4 | `StructuredTaskScopes`에 `failFast()`/`firstSuccess()` 추가 (factory 기본값) + `all`/`any` `@Deprecated` | `virtualthread/api` | T3 |
+| T5 | `StructuredTaskScopeAll`/`StructuredTaskScopeAny` KDoc 보강 (`@see`, join 타임아웃 경고) | `virtualthread/api` | T2 |
+| T6 | API 모듈 테스트: `getOrNull()`, `failFast()`, `firstSuccess()` 테스트 추가 | `virtualthread/api` | T1,T4 |
+| T7 | `structuredTaskScopeFailFast {}`/`structuredTaskScopeFirstSuccess {}` 추가 + 기존 deprecated | `bluetape4k/core` | T4 |
+| T8 | core 모듈 테스트: 새 편의 함수 테스트 추가 | `bluetape4k/core` | T7 |
+| T9 | 전체 빌드 검증: `./gradlew :bluetape4k-virtualthread-api:test :bluetape4k-virtualthread-jdk21:test :bluetape4k-virtualthread-jdk25:test :bluetape4k-core:test` | — | T6,T8 |
+| T10 | README 업데이트: 결정 트리 추가 및 API 예제 교체 (8개 파일: api×2, jdk21×2, jdk25×2, root×2) | `virtualthread/*` | T4 |
+
+---
+
+## 6. DoD (Definition of Done)
+
+- [ ] `virtualthread/api` — `typealias StructuredTaskScopeFailFast`, `StructuredTaskScopeFirstSuccess` 추가
+- [ ] `virtualthread/api` — `StructuredTaskScopeProvider.withFailFast()`/`withFirstSuccess()` default 메서드 추가
+- [ ] `virtualthread/api` — `StructuredTaskScopes.failFast()`/`firstSuccess()` 추가 (factory 기본값 포함)
+- [ ] `virtualthread/api` — `all()`/`any()`에 `@Deprecated(message, ReplaceWith)` 추가
+- [ ] `virtualthread/api` — `withAll()`/`withAny()`에 `@see` KDoc 안내 추가 (deprecated 하지 않음 — SPI 안정성 유지)
+- [ ] `virtualthread/jdk21` — 변경 없음 확인 (기존 테스트 그대로 통과)
+- [ ] `virtualthread/jdk25` — 변경 없음 확인 (기존 테스트 그대로 통과)
+- [ ] `bluetape4k/core` — `structuredTaskScopeFailFast {}`/`structuredTaskScopeFirstSuccess {}` 추가
+- [ ] `bluetape4k/core` — 기존 `structuredTaskScopeAll`/`structuredTaskScopeAny`에 `@Deprecated(message, ReplaceWith)` 추가
+- [ ] `StructuredSubtask.getOrNull()` default 메서드 구현 + 테스트
+- [ ] `StructuredSubtask.get()` / `StructuredTaskScopeAll.join()` KDoc 보강
+- [ ] 기존 테스트 전부 통과 (회귀 없음)
+- [ ] 새 API 테스트 추가 (`failFast`, `firstSuccess`, `getOrNull`)
+- [ ] KDoc 갱신 (모든 public API — 새 추가 + 기존 보강)
+- [ ] README.md / README.ko.md 결정 트리 추가 및 API 예제 교체 (8개 파일: `virtualthread/api` ×2, `virtualthread/jdk21` ×2, `virtualthread/jdk25` ×2, `virtualthread/` root ×2)
+- [ ] `./gradlew :bluetape4k-virtualthread-api:test :bluetape4k-virtualthread-jdk21:test :bluetape4k-virtualthread-jdk25:test :bluetape4k-core:test` 통과
+- [ ] `./gradlew :bluetape4k-virtualthread-jdk21:test` 통과
+- [ ] `./gradlew :bluetape4k-core:test` 통과
+- [ ] 브레이킹 체인지 없음 확인 (`@Deprecated`만 추가, 삭제 없음)
+
+---
+
+## 7. 변경하지 않는 것 (Out of Scope)
+
+| 항목 | 이유 |
+|------|------|
+| `VirtualThreadRuntime`/`VirtualThreads` 이름 변경 | 현재 명확함, 개선 불필요 |
+| `VirtualFuture`/`VirtualFutureExtensions` 변경 | 이번 이슈 범위 밖 |
+| `VirtualThreadDispatcher`/`VirtualThreadReactorScheduler` 변경 | 이번 이슈 범위 밖 |
+| `autoJoin` 파라미터 | YAGNI (섹션 3.3.3 참조) |
+| join() warn 로그 | 노이즈 과다 (섹션 3.3.2 참조) — KDoc 경고로 대체 |
+| `CoroutineSupport.kt` 변경 | 이름 명확, 변경 불필요 |
+| `examples/` 코드 마이그레이션 | deprecated 경고만 발생, 별도 PR로 처리 가능 |
+| `utils/workflow`, `testing/junit5` 마이그레이션 | deprecated 경고만 발생, 별도 후속 작업 |
+
+---
+
+## 8. 리스크 및 완화
+
+| 리스크 | 확률 | 영향 | 완화 |
+|--------|------|------|------|
+| 기존 인터페이스를 deprecated하지 않는 한 기존 이름(`StructuredTaskScopeAll`) 사용자에게 경고를 줄 수 없음 (`@Deprecated typealias`는 새 이름에 경고를 붙이는 반대 방향이라 실익 없음) | 확실 | 낮음 | KDoc `@see StructuredTaskScopeFailFast` + 진입 함수(`all`/`any`) deprecated로 대체 효과 확보 |
+| Provider default 메서드 추가 시 외부 구현체 영향 | 매우 낮음 | 낮음 | default 구현 제공으로 기존 구현체 변경 불필요 |
+| `getOrNull()` default 메서드의 UNAVAILABLE 상태 판별 | 낮음 | 중간 | `StructuredTaskScope.Subtask.State.SUCCESS`만 체크, 나머지 전부 null 반환 |

--- a/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/concurrency/StructuredTaskScopeTester.kt
+++ b/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/concurrency/StructuredTaskScopeTester.kt
@@ -144,7 +144,7 @@ class StructuredTaskScopeTester: StressTester<StructuredTaskScopeTester> {
         }
 
         val factory = this.factory ?: Thread.ofVirtual().factory()
-        StructuredTaskScopes.all("stressTester", factory) { scope ->
+        StructuredTaskScopes.failFast("stressTester", factory) { scope ->
             repeat(roundsPerWorker) {
                 testBlocks.forEach { block ->
                     scope.fork { block() }

--- a/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/core/ParallelWorkFlow.kt
+++ b/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/core/ParallelWorkFlow.kt
@@ -72,7 +72,7 @@ class ParallelWorkFlow(
         val deadline = Instant.now().plusMillis(timeout.inWholeMilliseconds)
 
         return try {
-            StructuredTaskScopes.all(name = flowName, factory = factory) { scope ->
+            StructuredTaskScopes.failFast(name = flowName, factory = factory) { scope ->
                 val tasks = works.map { work ->
                     val workName = (work as? NamedWork)?.name ?: work.javaClass.simpleName
                     scope.fork {
@@ -122,7 +122,7 @@ class ParallelWorkFlow(
         val failedReports = java.util.concurrent.ConcurrentLinkedQueue<WorkReport>()
 
         return runCatching {
-            StructuredTaskScopes.any<WorkReport>(name = flowName, factory = factory) { scope ->
+            StructuredTaskScopes.firstSuccess<WorkReport>(name = flowName, factory = factory) { scope ->
                 works.forEach { work ->
                     val workName = (work as? NamedWork)?.name ?: work.javaClass.simpleName
                     scope.fork {

--- a/virtualthread/api/README.ko.md
+++ b/virtualthread/api/README.ko.md
@@ -49,47 +49,67 @@ interface VirtualThreadRuntime {
 
 Java의 StructuredTaskScope API를 추상화하여 JDK 버전에 관계없이 사용할 수 있습니다.
 
-#### ShutdownOnFailure 패턴 (All)
+#### API 선택 가이드
 
-모든 서브태스크가 성공해야 하며, 하나라도 실패하면 전체 스코프가 중단됩니다.
+```
+모든 서브태스크가 성공해야 하는가?
+  └─ Yes → failFast { }       (첫 번째 실패 시 나머지를 즉시 취소)
+첫 번째 성공 결과만 필요한가?
+  └─ Yes → firstSuccess { }   (첫 번째 성공 시 나머지를 취소)
+```
+
+#### `failFast` — 전체 성공 보장
+
+모든 서브태스크가 성공해야 하며, 하나라도 실패하면 나머지를 즉시 취소합니다.
 
 ```kotlin
 import io.bluetape4k.concurrent.virtualthread.StructuredTaskScopes
 
-val results = StructuredTaskScopes.all(
-    name = "fetch-all-data",
-    factory = VirtualThreads.threadFactory("data-")
-) { scope ->
+val results = StructuredTaskScopes.failFast { scope ->
     val task1 = scope.fork { fetchUserData() }
     val task2 = scope.fork { fetchOrderData() }
     val task3 = scope.fork { fetchInventoryData() }
 
-    scope.join()
-        .throwIfFailed { error ->
-            println("Failed: ${error.message}")
-        }
-
+    scope.join().throwIfFailed()
     Triple(task1.get(), task2.get(), task3.get())
 }
 ```
 
-#### ShutdownOnSuccess 패턴 (Any)
+#### `firstSuccess` — 첫 번째 성공 반환
 
-여러 서브태스크 중 하나라도 성공하면 나머지는 중단됩니다.
+가장 먼저 성공한 서브태스크 결과를 반환하고, 나머지는 취소합니다.
 
 ```kotlin
-val fastestResult = StructuredTaskScopes.any<String>(
-    name = "race-apis",
-    factory = VirtualThreads.threadFactory("api-")
-) { scope ->
+val fastestResult = StructuredTaskScopes.firstSuccess<String> { scope ->
     scope.fork { fetchFromApi1() }
     scope.fork { fetchFromApi2() }
     scope.fork { fetchFromApi3() }
 
-    scope.join()
-        .result { error -> RuntimeException("All APIs failed", error) }
+    scope.join().result { error -> RuntimeException("All APIs failed", error) }
 }
 ```
+
+#### `getOrNull()` — 안전한 결과 접근
+
+`StructuredSubtask.getOrNull()`은 `join()` 이전 호출 또는 실패/취소 상태에서 예외 대신 `null`을 반환합니다.
+
+```kotlin
+StructuredTaskScopes.failFast { scope ->
+    val task = scope.fork { 42 }
+    scope.join().throwIfFailed()
+    task.getOrNull()   // 42 (SUCCESS 상태)
+    // FAILED / UNAVAILABLE 상태에서는 null 반환
+}
+```
+
+#### Deprecated API 마이그레이션
+
+`all()`과 `any()`는 deprecated되었습니다. 다음과 같이 마이그레이션하세요:
+
+| 기존 | 신규 |
+|------|------|
+| `StructuredTaskScopes.all(...) { }` | `StructuredTaskScopes.failFast { }` |
+| `StructuredTaskScopes.any(...) { }` | `StructuredTaskScopes.firstSuccess { }` |
 
 ## ServiceLoader 메커니즘
 
@@ -197,14 +217,18 @@ classDiagram
         +providerName: String
         +priority: Int
         +isSupported() Boolean
+        +withFailFast(name, factory, block) T
+        +withFirstSuccess(name, factory, block) T
         +withAll(name, factory, block) T
         +withAny(name, factory, block) T
     }
 
     class StructuredTaskScopes {
         <<object>>
-        +all(name, factory, block) T
-        +any(name, factory, block) T
+        +failFast(name, factory, block) T
+        +firstSuccess(name, factory, block) T
+        +all(name, factory, block) T ~~deprecated~~
+        +any(name, factory, block) T ~~deprecated~~
     }
 
     class Jdk21VirtualThreadRuntime {

--- a/virtualthread/api/README.md
+++ b/virtualthread/api/README.md
@@ -95,7 +95,6 @@ val fastestResult = StructuredTaskScopes.firstSuccess<String> { scope ->
 `StructuredSubtask.getOrNull()` returns `null` instead of throwing when called before `join()` or when the subtask failed/was cancelled.
 
 ```kotlin
-val result: StructuredSubtask<Int>?
 StructuredTaskScopes.failFast { scope ->
     val task = scope.fork { 42 }
     scope.join().throwIfFailed()

--- a/virtualthread/api/README.md
+++ b/virtualthread/api/README.md
@@ -50,47 +50,68 @@ interface VirtualThreadRuntime {
 
 Abstracts Java's `StructuredTaskScope` API so it can be used consistently across JDK versions.
 
-#### `ShutdownOnFailure` Pattern (`all`)
+#### Choosing the Right API
 
-All subtasks must succeed. If any subtask fails, the entire scope is cancelled.
+```
+Need all subtasks to succeed?
+  └─ Yes → failFast { }        (cancels others on first failure)
+Need the first success?
+  └─ Yes → firstSuccess { }    (cancels others on first success)
+```
+
+#### `failFast` — All Must Succeed
+
+All subtasks must succeed. If any subtask fails, the rest are cancelled immediately.
 
 ```kotlin
 import io.bluetape4k.concurrent.virtualthread.StructuredTaskScopes
 
-val results = StructuredTaskScopes.all(
-    name = "fetch-all-data",
-    factory = VirtualThreads.threadFactory("data-")
-) { scope ->
+val results = StructuredTaskScopes.failFast { scope ->
     val task1 = scope.fork { fetchUserData() }
     val task2 = scope.fork { fetchOrderData() }
     val task3 = scope.fork { fetchInventoryData() }
 
-    scope.join()
-        .throwIfFailed { error ->
-            println("Failed: ${error.message}")
-        }
-
+    scope.join().throwIfFailed()
     Triple(task1.get(), task2.get(), task3.get())
 }
 ```
 
-#### `ShutdownOnSuccess` Pattern (`any`)
+#### `firstSuccess` — First Winner Takes All
 
-As soon as one of the subtasks succeeds, the remaining subtasks are cancelled.
+Returns the result of the first subtask to succeed. Remaining subtasks are cancelled.
 
 ```kotlin
-val fastestResult = StructuredTaskScopes.any<String>(
-    name = "race-apis",
-    factory = VirtualThreads.threadFactory("api-")
-) { scope ->
+val fastestResult = StructuredTaskScopes.firstSuccess<String> { scope ->
     scope.fork { fetchFromApi1() }
     scope.fork { fetchFromApi2() }
     scope.fork { fetchFromApi3() }
 
-    scope.join()
-        .result { error -> RuntimeException("All APIs failed", error) }
+    scope.join().result { error -> RuntimeException("All APIs failed", error) }
 }
 ```
+
+#### `getOrNull()` — Safe Result Access
+
+`StructuredSubtask.getOrNull()` returns `null` instead of throwing when called before `join()` or when the subtask failed/was cancelled.
+
+```kotlin
+val result: StructuredSubtask<Int>?
+StructuredTaskScopes.failFast { scope ->
+    val task = scope.fork { 42 }
+    scope.join().throwIfFailed()
+    task.getOrNull()   // 42 (SUCCESS state)
+    // or null if FAILED / UNAVAILABLE
+}
+```
+
+#### Deprecated APIs
+
+`all()` and `any()` are deprecated. Migrate as follows:
+
+| Before | After |
+|--------|-------|
+| `StructuredTaskScopes.all(...) { }` | `StructuredTaskScopes.failFast { }` |
+| `StructuredTaskScopes.any(...) { }` | `StructuredTaskScopes.firstSuccess { }` |
 
 ## `ServiceLoader` Mechanism
 
@@ -199,14 +220,18 @@ classDiagram
         +providerName: String
         +priority: Int
         +isSupported() Boolean
+        +withFailFast(name, factory, block) T
+        +withFirstSuccess(name, factory, block) T
         +withAll(name, factory, block) T
         +withAny(name, factory, block) T
     }
 
     class StructuredTaskScopes {
         <<object>>
-        +all(name, factory, block) T
-        +any(name, factory, block) T
+        +failFast(name, factory, block) T
+        +firstSuccess(name, factory, block) T
+        +all(name, factory, block) T ~~deprecated~~
+        +any(name, factory, block) T ~~deprecated~~
     }
 
     class Jdk21VirtualThreadRuntime {

--- a/virtualthread/api/build.gradle.kts
+++ b/virtualthread/api/build.gradle.kts
@@ -5,4 +5,6 @@ configurations {
 dependencies {
     implementation(project(":bluetape4k-logging"))
     testImplementation(project(":bluetape4k-junit5"))
+    // ServiceLoader로 등록된 StructuredTaskScopeProvider 구현체를 test runtime에 제공
+    testRuntimeOnly(project(":bluetape4k-virtualthread-jdk21"))
 }

--- a/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopes.kt
+++ b/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopes.kt
@@ -13,10 +13,11 @@ import java.util.concurrent.ThreadFactory
  *
  * ## 동작/계약
  * - 구현체는 JDK별 `StructuredTaskScope.Subtask`를 감싸 동일 API를 제공합니다.
- * - [get]은 성공 상태에서 결과를 반환하고 실패 상태에서는 예외를 전파할 수 있습니다.
+ * - [get]은 subtask 상태에 따라 결과 반환 또는 예외를 던집니다.
+ * - 안전한 결과 접근은 [getOrNull]을 사용하세요.
  *
  * ```kotlin
- * val value = StructuredTaskScopes.all(factory = Thread.ofVirtual().factory()) { scope ->
+ * val value = StructuredTaskScopes.failFast { scope ->
  *     val task = scope.fork { 1 + 1 }
  *     scope.join().throwIfFailed()
  *     task.get()
@@ -25,7 +26,18 @@ import java.util.concurrent.ThreadFactory
  * ```
  */
 interface StructuredSubtask<T> {
-    /** subtask 성공 결과를 반환합니다. */
+    /**
+     * subtask 결과를 반환합니다.
+     *
+     * ## 상태별 동작
+     * - **SUCCESS**: 결과를 반환합니다.
+     * - **FAILED**: `IllegalStateException`을 던집니다. 실패 원인은 [exceptionOrNull]로 조회하세요.
+     * - **UNAVAILABLE** (미완료 / 취소 / [join] 이전 호출): `IllegalStateException`을 던집니다.
+     *
+     * @throws IllegalStateException FAILED 또는 UNAVAILABLE 상태, 또는 [join] 이전 호출 시
+     * @see exceptionOrNull
+     * @see getOrNull
+     */
     fun get(): T
 
     /** subtask 현재 상태를 반환합니다. */
@@ -33,18 +45,51 @@ interface StructuredSubtask<T> {
 
     /** subtask 실패 원인을 반환하고, 실패하지 않았으면 `null`을 반환합니다. */
     fun exceptionOrNull(): Throwable?
+
+    /**
+     * subtask 결과를 안전하게 반환합니다. 결과를 얻을 수 없으면 `null`을 반환합니다.
+     *
+     * ## 동작/계약
+     * - **전제 조건**: scope owner thread가 [join] 또는 [StructuredTaskScopeAll.joinUntil]을 완료한 이후에 호출하세요.
+     * - SUCCESS 상태이면 [get] 결과를 반환합니다.
+     * - FAILED 또는 UNAVAILABLE 상태이면 `null`을 반환합니다.
+     * - `state() == SUCCESS`이더라도 [join] 이전 호출 시 JDK 내부의 `ensureJoinedIfOwner()` 검사로
+     *   `IllegalStateException`이 발생할 수 있으므로 try-catch로 안전하게 처리합니다.
+     *
+     * ```kotlin
+     * StructuredTaskScopes.failFast { scope ->
+     *     val task = scope.fork { 42 }
+     *     scope.join().throwIfFailed()
+     *     task.getOrNull()   // 42
+     * }
+     * ```
+     *
+     * @return SUCCESS 상태이면 결과값, 그 외 `null`
+     */
+    fun getOrNull(): T? {
+        return if (state() == StructuredTaskScope.Subtask.State.SUCCESS) {
+            try {
+                get()
+            } catch (_: IllegalStateException) {
+                null
+            }
+        } else null
+    }
 }
 
 /**
  * 모든 작업 완료를 기다리고, 실패가 있으면 예외를 전파하는 scope 추상화입니다.
+ * fail-fast 동작을 합니다 — 하나의 subtask라도 실패하면 나머지를 즉시 중단하고 예외를 전파합니다.
  *
  * ## 동작/계약
  * - [fork]로 추가한 작업들을 [join] 이후 [throwIfFailed]로 일괄 실패 검사할 수 있습니다.
  * - 타임아웃이 필요하면 [joinUntil]을 사용하세요. 데드라인 초과 시 `TimeoutException`이 발생합니다.
  * - [close]는 리소스 정리 및 미완료 작업 취소를 수행할 수 있으므로 `use` 블록 사용을 권장합니다.
  *
+ * **의도 명확 별칭**: [StructuredTaskScopeFailFast]를 사용하면 fail-fast 의도가 더 명확해집니다.
+ *
  * ```kotlin
- * val sum = StructuredTaskScopes.all(factory = Thread.ofVirtual().factory()) { scope ->
+ * val sum = StructuredTaskScopes.failFast { scope ->
  *     val a = scope.fork { 1 }
  *     val b = scope.fork { 2 }
  *     scope.join().throwIfFailed()
@@ -52,12 +97,20 @@ interface StructuredSubtask<T> {
  * }
  * // sum == 3
  * ```
+ *
+ * @see StructuredTaskScopeFailFast
+ * @see StructuredTaskScopes.failFast
  */
 interface StructuredTaskScopeAll: AutoCloseable {
     /** 새 subtask를 scope에 등록합니다. */
     fun <T> fork(task: () -> T): StructuredSubtask<T>
 
-    /** 등록된 subtask 완료를 대기합니다. */
+    /**
+     * 등록된 subtask 완료를 대기합니다.
+     *
+     * **주의**: 타임아웃 없이 호출하면 subtask가 무한 차단될 수 있습니다.
+     * 프로덕션 코드에서는 [joinUntil]을 사용하세요.
+     */
     fun join(): StructuredTaskScopeAll
 
     /**
@@ -75,20 +128,34 @@ interface StructuredTaskScopeAll: AutoCloseable {
 }
 
 /**
+ * fail-fast 동작을 하는 [StructuredTaskScopeAll]의 의도 명확 별칭입니다.
+ *
+ * @see StructuredTaskScopeAll
+ * @see StructuredTaskScopes.failFast
+ */
+typealias StructuredTaskScopeFailFast = StructuredTaskScopeAll
+
+/**
  * 첫 성공 결과를 선택하는 scope 추상화입니다.
+ * first-success 동작을 합니다 — 첫 번째 성공한 subtask 결과를 반환하고 나머지를 취소합니다.
  *
  * ## 동작/계약
  * - 여러 작업을 [fork]한 뒤 [join]과 [result]를 통해 첫 성공 결과를 얻습니다.
  * - 모든 작업이 실패하면 [result]에서 [mapper]가 만든 RuntimeException이 발생합니다.
  *
+ * **의도 명확 별칭**: [StructuredTaskScopeFirstSuccess]를 사용하면 first-success 의도가 더 명확해집니다.
+ *
  * ```kotlin
- * val winner = StructuredTaskScopes.any<String>(factory = Thread.ofVirtual().factory()) { scope ->
+ * val winner = StructuredTaskScopes.firstSuccess<String> { scope ->
  *     scope.fork { "slow" }
  *     scope.fork { "fast" }
- *     scope.join().result { IllegalStateException(it) }
+ *     scope.join().result { IllegalStateException("all failed: ${it.message}") }
  * }
  * // winner.isNotBlank() == true
  * ```
+ *
+ * @see StructuredTaskScopeFirstSuccess
+ * @see StructuredTaskScopes.firstSuccess
  */
 interface StructuredTaskScopeAny<T>: AutoCloseable {
     /** 새 subtask를 scope에 등록합니다. */
@@ -103,6 +170,14 @@ interface StructuredTaskScopeAny<T>: AutoCloseable {
     /** scope 자원을 정리합니다. */
     override fun close()
 }
+
+/**
+ * first-success 동작을 하는 [StructuredTaskScopeAny]의 의도 명확 별칭입니다.
+ *
+ * @see StructuredTaskScopeAny
+ * @see StructuredTaskScopes.firstSuccess
+ */
+typealias StructuredTaskScopeFirstSuccess<T> = StructuredTaskScopeAny<T>
 
 /**
  * JDK별 StructuredTaskScope 구현체를 제공하는 SPI 인터페이스입니다.
@@ -132,10 +207,11 @@ interface StructuredTaskScopeProvider {
      * @param name scope 이름(지원 구현에서만 적용)
      * @param factory subtask 실행용 스레드 팩토리
      * @param block 실행 블록
+     * @see withFailFast
      */
     fun <T> withAll(
         name: String? = null,
-        factory: ThreadFactory = Thread.ofVirtual().factory(),
+        factory: ThreadFactory = VirtualThreads.threadFactory(),
         block: (scope: StructuredTaskScopeAll) -> T,
     ): T
 
@@ -145,12 +221,43 @@ interface StructuredTaskScopeProvider {
      * @param name scope 이름(지원 구현에서만 적용)
      * @param factory subtask 실행용 스레드 팩토리
      * @param block 실행 블록
+     * @see withFirstSuccess
      */
     fun <T> withAny(
         name: String? = null,
-        factory: ThreadFactory = Thread.ofVirtual().factory(),
+        factory: ThreadFactory = VirtualThreads.threadFactory(),
         block: (scope: StructuredTaskScopeAny<T>) -> T,
     ): T
+
+    /**
+     * 실패 전파형(fail-fast) 블록을 실행합니다.
+     * 기본 구현은 [withAll]에 위임합니다.
+     *
+     * @param name scope 이름
+     * @param factory subtask 실행용 스레드 팩토리 (기본값: [VirtualThreads.threadFactory])
+     * @param block 실행 블록
+     * @see withAll
+     */
+    fun <T> withFailFast(
+        name: String? = null,
+        factory: ThreadFactory = VirtualThreads.threadFactory(),
+        block: (scope: StructuredTaskScopeFailFast) -> T,
+    ): T = withAll(name, factory, block)
+
+    /**
+     * 성공 우선형(first-success) 블록을 실행합니다.
+     * 기본 구현은 [withAny]에 위임합니다.
+     *
+     * @param name scope 이름
+     * @param factory subtask 실행용 스레드 팩토리 (기본값: [VirtualThreads.threadFactory])
+     * @param block 실행 블록
+     * @see withAny
+     */
+    fun <T> withFirstSuccess(
+        name: String? = null,
+        factory: ThreadFactory = VirtualThreads.threadFactory(),
+        block: (scope: StructuredTaskScopeFirstSuccess<T>) -> T,
+    ): T = withAny(name, factory, block)
 }
 
 /**
@@ -159,10 +266,10 @@ interface StructuredTaskScopeProvider {
  * ## 동작/계약
  * - ServiceLoader provider를 [StructuredTaskScopeProvider.priority] 내림차순으로 정렬해 선택합니다.
  * - 선택 가능한 provider가 없으면 즉시 예외를 발생시킵니다.
- * - `all`/`any`는 선택된 provider 구현에 위임됩니다.
+ * - [failFast]/[firstSuccess]는 선택된 provider 구현에 위임됩니다.
  *
  * ```kotlin
- * val result = StructuredTaskScopes.all(factory = Thread.ofVirtual().factory()) { scope ->
+ * val result = StructuredTaskScopes.failFast { scope ->
  *     val a = scope.fork { 1 }
  *     val b = scope.fork { 2 }
  *     scope.join().throwIfFailed()
@@ -229,25 +336,74 @@ object StructuredTaskScopes: KLogging() {
     fun providerName(): String = provider().providerName
 
     /**
-     * 실패 전파형(all) scope 블록을 실행합니다.
+     * 실패 전파형(fail-fast) scope 블록을 실행합니다.
+     * 하나의 subtask라도 실패하면 나머지를 즉시 중단하고 예외를 전파합니다.
      *
      * ## 동작/계약
-     * - block 내부에서 [StructuredTaskScopeAll] API로 subtask를 등록/대기/실패 검사합니다.
+     * - block 내부에서 [StructuredTaskScopeFailFast] API로 subtask를 등록/대기/실패 검사합니다.
      * - 실제 scope 구현은 선택된 provider에 의해 결정됩니다.
      *
      * ```kotlin
-     * val value = StructuredTaskScopes.all(factory = Thread.ofVirtual().factory()) { scope ->
-     *     val task = scope.fork { 42 }
+     * val sum = StructuredTaskScopes.failFast { scope ->
+     *     val a = scope.fork { 1 }
+     *     val b = scope.fork { 2 }
      *     scope.join().throwIfFailed()
-     *     task.get()
+     *     a.get() + b.get()
      * }
-     * // value == 42
+     * // sum == 3
      * ```
      *
-     * @param name scope 이름
-     * @param factory subtask 실행용 스레드 팩토리
+     * @param name scope 이름 (디버깅용, 기본값: null)
+     * @param factory subtask 실행용 스레드 팩토리 (기본값: [VirtualThreads.threadFactory])
      * @param block scope 실행 블록
+     * @return [block]의 실행 결과
      */
+    fun <T> failFast(
+        name: String? = null,
+        factory: ThreadFactory = VirtualThreads.threadFactory(),
+        block: (scope: StructuredTaskScopeFailFast) -> T,
+    ): T = provider().withFailFast(name, factory, block)
+
+    /**
+     * 성공 우선형(first-success) scope 블록을 실행합니다.
+     * 첫 번째 성공한 subtask 결과를 반환하고 나머지를 취소합니다.
+     *
+     * ## 동작/계약
+     * - block 내부에서 [StructuredTaskScopeFirstSuccess] API로 첫 성공 결과를 선택합니다.
+     * - 모든 subtask가 실패하면 [StructuredTaskScopeAny.result]에서 mapper 예외가 발생합니다.
+     *
+     * ```kotlin
+     * val winner = StructuredTaskScopes.firstSuccess<String> { scope ->
+     *     scope.fork { "slow" }
+     *     scope.fork { "fast" }
+     *     scope.join().result { IllegalStateException("all failed: ${it.message}") }
+     * }
+     * // winner.isNotBlank() == true
+     * ```
+     *
+     * @param name scope 이름 (디버깅용, 기본값: null)
+     * @param factory subtask 실행용 스레드 팩토리 (기본값: [VirtualThreads.threadFactory])
+     * @param block scope 실행 블록
+     * @return 가장 먼저 성공한 subtask의 결과
+     */
+    fun <T> firstSuccess(
+        name: String? = null,
+        factory: ThreadFactory = VirtualThreads.threadFactory(),
+        block: (scope: StructuredTaskScopeFirstSuccess<T>) -> T,
+    ): T = provider().withFirstSuccess(name, factory, block)
+
+    /**
+     * 실패 전파형(all) scope 블록을 실행합니다.
+     *
+     * @deprecated [failFast]를 사용하세요. factory 기본값이 추가되고 이름이 의도를 더 명확히 표현합니다.
+     */
+    @Deprecated(
+        message = "failFast()를 사용하세요.",
+        replaceWith = ReplaceWith(
+            "StructuredTaskScopes.failFast(name, factory, block)",
+            "io.bluetape4k.concurrent.virtualthread.StructuredTaskScopes"
+        )
+    )
     fun <T> all(
         name: String? = null,
         factory: ThreadFactory,
@@ -257,22 +413,15 @@ object StructuredTaskScopes: KLogging() {
     /**
      * 성공 우선형(any) scope 블록을 실행합니다.
      *
-     * ## 동작/계약
-     * - block 내부에서 [StructuredTaskScopeAny] API로 첫 성공 결과를 선택합니다.
-     * - 모든 작업 실패 시 [StructuredTaskScopeAny.result]에서 mapper 예외가 발생합니다.
-     *
-     * ```kotlin
-     * val value = StructuredTaskScopes.any<String>(factory = Thread.ofVirtual().factory()) { scope ->
-     *     scope.fork { "fast" }
-     *     scope.join().result { IllegalStateException(it) }
-     * }
-     * // value == "fast"
-     * ```
-     *
-     * @param name scope 이름
-     * @param factory subtask 실행용 스레드 팩토리
-     * @param block scope 실행 블록
+     * @deprecated [firstSuccess]를 사용하세요. factory 기본값이 추가되고 이름이 의도를 더 명확히 표현합니다.
      */
+    @Deprecated(
+        message = "firstSuccess()를 사용하세요.",
+        replaceWith = ReplaceWith(
+            "StructuredTaskScopes.firstSuccess(name, factory, block)",
+            "io.bluetape4k.concurrent.virtualthread.StructuredTaskScopes"
+        )
+    )
     fun <T> any(
         name: String? = null,
         factory: ThreadFactory,

--- a/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt
+++ b/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt
@@ -3,7 +3,7 @@ package io.bluetape4k.concurrent.virtualthread
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeGreaterThan
 import org.amshove.kluent.shouldBeInstanceOf
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldBeTrue
@@ -46,7 +46,7 @@ class StructuredScopesTest {
     @Test
     fun `provider priority 가 양수여야 한다`() {
         val provider = StructuredTaskScopes.provider()
-        (provider.priority > 0).shouldBeTrue()
+        provider.priority.shouldBeGreaterThan(0)
     }
 
     // ── 기존 all/any 회귀 테스트 (deprecated API 동작 검증) ─────────────────────

--- a/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt
+++ b/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt
@@ -298,10 +298,12 @@ class StructuredScopesTest {
                     throw RuntimeException("forced failure")
                 }
                 // subtask2: block 상태에서 shutdown에 의해 취소됨 (UNAVAILABLE)
+                // neverRelease 는 해제되지 않으므로 shutdown 시 반드시 UNAVAILABLE 상태가 됨
+                val neverRelease = CountDownLatch(1)
                 cancelledTask = scope.fork {
                     subtaskStarted.await()
                     proceedToFail.countDown()
-                    Thread.sleep(10_000)
+                    neverRelease.await()
                     42
                 }
                 scope.join().throwIfFailed()

--- a/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt
+++ b/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt
@@ -10,7 +10,10 @@ import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeBlank
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.StructuredTaskScope
+import java.util.concurrent.TimeoutException
 import kotlin.test.assertFailsWith
 
 /**
@@ -21,8 +24,7 @@ class StructuredScopesTest {
 
     companion object: KLogging()
 
-    // StructuredTaskScopes.provider() 는 jdk21/jdk25 provider 가 classpath 에 없을 때 ISE 를 던지지만,
-    // test 런타임에는 jdk21 provider 가 등록되어 있으므로 정상 반환됩니다.
+    // test runtime에는 jdk21 provider (testRuntimeOnly)가 classpath에 등록되어 있으므로 정상 반환됩니다.
     @Test
     fun `provider 반환 이름이 비어있지 않아야 한다`() {
         val provider = StructuredTaskScopes.provider()
@@ -47,6 +49,9 @@ class StructuredScopesTest {
         (provider.priority > 0).shouldBeTrue()
     }
 
+    // ── 기존 all/any 회귀 테스트 (deprecated API 동작 검증) ─────────────────────
+
+    @Suppress("DEPRECATION")
     @Test
     fun `all scope 으로 두 subtask 를 합산해야 한다`() {
         val result = StructuredTaskScopes.all(factory = Thread.ofVirtual().factory()) { scope ->
@@ -58,6 +63,7 @@ class StructuredScopesTest {
         result shouldBeEqualTo 30
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `all scope 내 subtask 실패 시 예외가 전파되어야 한다`() {
         assertFailsWith<RuntimeException> {
@@ -70,6 +76,7 @@ class StructuredScopesTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `all scope throwIfFailed 핸들러가 호출되어야 한다`() {
         var handlerCalled = false
@@ -85,8 +92,6 @@ class StructuredScopesTest {
 
     @Test
     fun `all scope joinUntil 기본 구현이 join 을 호출해야 한다`() {
-        // StructuredTaskScopeAll.joinUntil 기본 구현 (interface default) 테스트
-        // 직접 mock 구현체를 만들어 joinUntil 이 join 위임을 검증
         var joinCalled = false
         val scope = object : StructuredTaskScopeAll {
             override fun <T> fork(task: () -> T): StructuredSubtask<T> {
@@ -107,11 +112,11 @@ class StructuredScopesTest {
             override fun close() {}
         }
 
-        // joinUntil 기본 구현은 join() 을 호출한다
-        scope.joinUntil(java.time.Instant.now().plusSeconds(5))
+        scope.joinUntil(Instant.now().plusSeconds(5))
         joinCalled.shouldBeTrue()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `any scope 가 가장 먼저 완료된 subtask 결과를 반환해야 한다`() {
         val result = StructuredTaskScopes.any<String>(factory = Thread.ofVirtual().factory()) { scope ->
@@ -128,6 +133,7 @@ class StructuredScopesTest {
         result shouldBeEqualTo "fast"
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `any scope 모든 subtask 실패 시 mapper 예외가 발생해야 한다`() {
         assertFailsWith<IllegalStateException> {
@@ -139,6 +145,7 @@ class StructuredScopesTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `all scope name 파라미터를 지정해도 정상 동작해야 한다`() {
         val result = StructuredTaskScopes.all(name = "test-scope", factory = Thread.ofVirtual().factory()) { scope ->
@@ -149,6 +156,7 @@ class StructuredScopesTest {
         result shouldBeEqualTo 42
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `subtask 성공 상태와 결과를 확인해야 한다`() {
         var capturedSubtask: StructuredSubtask<Int>? = null
@@ -163,6 +171,7 @@ class StructuredScopesTest {
         subtask.exceptionOrNull().shouldBeNull()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `subtask 실패 상태에서 exceptionOrNull 이 예외를 반환해야 한다`() {
         var capturedSubtask: StructuredSubtask<Int>? = null
@@ -176,5 +185,173 @@ class StructuredScopesTest {
         val subtask = capturedSubtask.shouldNotBeNull()
         subtask.state() shouldBeEqualTo StructuredTaskScope.Subtask.State.FAILED
         subtask.exceptionOrNull().shouldNotBeNull().shouldBeInstanceOf<RuntimeException>()
+    }
+
+    // ── failFast 신규 API 테스트 ────────────────────────────────────────────────
+
+    @Test
+    fun `failFast scope 으로 두 subtask 를 합산해야 한다`() {
+        val result = StructuredTaskScopes.failFast { scope ->
+            val a = scope.fork { 10 }
+            val b = scope.fork { 20 }
+            scope.join().throwIfFailed()
+            a.get() + b.get()
+        }
+        result shouldBeEqualTo 30
+    }
+
+    @Test
+    fun `failFast scope 내 subtask 실패 시 예외가 전파되어야 한다`() {
+        assertFailsWith<RuntimeException> {
+            StructuredTaskScopes.failFast { scope ->
+                scope.fork { 1 }
+                scope.fork<Int> { throw IllegalStateException("subtask failed") }
+                scope.join().throwIfFailed()
+                0
+            }
+        }
+    }
+
+    @Test
+    fun `failFast scope factory 기본값으로 실행되어야 한다`() {
+        // factory 파라미터 생략 → VirtualThreads.threadFactory() 기본값 사용
+        val result = StructuredTaskScopes.failFast { scope ->
+            val task = scope.fork { 42 }
+            scope.join().throwIfFailed()
+            task.get()
+        }
+        result shouldBeEqualTo 42
+    }
+
+    // ── firstSuccess 신규 API 테스트 ────────────────────────────────────────────
+
+    @Test
+    fun `firstSuccess scope 가 가장 먼저 완료된 subtask 결과를 반환해야 한다`() {
+        val result = StructuredTaskScopes.firstSuccess<String> { scope ->
+            scope.fork {
+                Thread.sleep(50)
+                "slow"
+            }
+            scope.fork {
+                Thread.sleep(10)
+                "fast"
+            }
+            scope.join().result { IllegalStateException("all failed: ${it.message}") }
+        }
+        result shouldBeEqualTo "fast"
+    }
+
+    @Test
+    fun `firstSuccess scope 모든 subtask 실패 시 mapper 예외가 발생해야 한다`() {
+        // result(mapper)의 mapper가 만든 예외가 throw — StructuredTaskScope.FailedException 아님
+        assertFailsWith<IllegalStateException> {
+            StructuredTaskScopes.firstSuccess<String> { scope ->
+                scope.fork<String> { throw RuntimeException("task1 fail") }
+                scope.fork<String> { throw RuntimeException("task2 fail") }
+                scope.join().result { IllegalStateException("all failed: ${it.message}") }
+            }
+        }
+    }
+
+    // ── getOrNull 테스트 ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `getOrNull 은 SUCCESS 상태에서 결과를 반환해야 한다`() {
+        var capturedSubtask: StructuredSubtask<Int>? = null
+        StructuredTaskScopes.failFast { scope ->
+            capturedSubtask = scope.fork { 42 }
+            scope.join().throwIfFailed()
+        }
+        capturedSubtask.shouldNotBeNull()
+        capturedSubtask!!.state() shouldBeEqualTo StructuredTaskScope.Subtask.State.SUCCESS
+        capturedSubtask!!.getOrNull() shouldBeEqualTo 42
+    }
+
+    @Test
+    fun `getOrNull 은 FAILED 상태에서 null 을 반환해야 한다`() {
+        var capturedSubtask: StructuredSubtask<Int>? = null
+        runCatching {
+            StructuredTaskScopes.failFast { scope ->
+                capturedSubtask = scope.fork<Int> { throw RuntimeException("fail") }
+                scope.join().throwIfFailed()
+                0
+            }
+        }
+        capturedSubtask.shouldNotBeNull()
+        capturedSubtask!!.state() shouldBeEqualTo StructuredTaskScope.Subtask.State.FAILED
+        capturedSubtask!!.getOrNull().shouldBeNull()
+    }
+
+    @Test
+    fun `getOrNull 은 UNAVAILABLE 상태에서 null 을 반환해야 한다`() {
+        val subtaskStarted = CountDownLatch(1)
+        val proceedToFail = CountDownLatch(1)
+        var cancelledTask: StructuredSubtask<Int>? = null
+
+        // failFast<Unit>: 블록 반환 타입을 Unit으로 지정해 타입 불일치 방지
+        runCatching {
+            StructuredTaskScopes.failFast<Unit> { scope ->
+                // subtask1: 실패하여 scope shutdown 트리거
+                scope.fork<Unit> {
+                    subtaskStarted.countDown()
+                    proceedToFail.await()
+                    throw RuntimeException("forced failure")
+                }
+                // subtask2: block 상태에서 shutdown에 의해 취소됨 (UNAVAILABLE)
+                cancelledTask = scope.fork {
+                    subtaskStarted.await()
+                    proceedToFail.countDown()
+                    Thread.sleep(10_000)
+                    42
+                }
+                scope.join().throwIfFailed()
+            }
+        }
+
+        cancelledTask.shouldNotBeNull()
+        cancelledTask!!.state() shouldBeEqualTo StructuredTaskScope.Subtask.State.UNAVAILABLE
+        cancelledTask!!.getOrNull().shouldBeNull()
+    }
+
+    @Test
+    fun `getOrNull 은 join 이전 호출에서도 null 을 안전하게 반환해야 한다 (내부 방어)`() {
+        // 이 테스트는 내부 방어(internal defense) 테스트입니다.
+        // getOrNull()의 KDoc 전제 조건은 "join() 이후 호출"이며, join() 이전 호출은 미정의 동작입니다.
+        // ISE-safe try-catch가 join() 이전 상황에서도 안전하게 null을 반환함을 검증합니다.
+        val ready = CountDownLatch(1)
+        val hold = CountDownLatch(1)
+        var earlySubtask: StructuredSubtask<Int>? = null
+
+        StructuredTaskScopes.failFast { scope ->
+            earlySubtask = scope.fork {
+                ready.countDown()
+                hold.await()
+                99
+            }
+            ready.await()
+            // join() 이전에 getOrNull() 호출 — ISE 가 아니라 null 반환이어야 한다
+            val result = earlySubtask!!.getOrNull()
+            result.shouldBeNull()
+            hold.countDown()
+            scope.join().throwIfFailed()
+            earlySubtask!!.getOrNull() shouldBeEqualTo 99
+        }
+    }
+
+    // ── joinUntil 타임아웃 테스트 ───────────────────────────────────────────────
+
+    @Test
+    fun `joinUntil 데드라인 초과 시 TimeoutException 이 발생해야 한다`() {
+        assertFailsWith<TimeoutException> {
+            StructuredTaskScopes.failFast { scope ->
+                scope.fork {
+                    Thread.sleep(10_000)
+                    42
+                }
+                // 100ms 데드라인 — subtask보다 훨씬 짧음
+                scope.joinUntil(Instant.now().plusMillis(100)).throwIfFailed()
+                0
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #255

- PR 제목: feat: StructuredTaskScopes API 개선 — failFast/firstSuccess 추가, all/any deprecated (#255)

Issue #255 구현 — virtualthread API 사용성·명칭 직관성·안정성 개선

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 신규 API
- `StructuredTaskScopes.failFast { }` — ShutdownOnFailure 패턴의 직관적 명칭
- `StructuredTaskScopes.firstSuccess { }` — ShutdownOnSuccess 패턴의 직관적 명칭
- `StructuredSubtask.getOrNull()` — join() 이전/실패/취소 상태에서 안전하게 null 반환
- typealias `StructuredTaskScopeFailFast`, `StructuredTaskScopeFirstSuccess<T>`
- `StructuredTaskScopeProvider`: `withFailFast()`/`withFirstSuccess()` default 메서드 추가

### Deprecated API
- `StructuredTaskScopes.all()` → `failFast()` 으로 마이그레이션
- `StructuredTaskScopes.any()` → `firstSuccess()` 으로 마이그레이션
- `structuredTaskScopeAll()` → `structuredTaskScopeFailFast()`
- `structuredTaskScopeAny()` → `structuredTaskScopeFirstSuccess()`

### 테스트 보강
- UNAVAILABLE 취소 상태 (CountDownLatch 기반 결정적 재현)
- joinUntil 타임아웃 (TimeoutException)
- getOrNull() — SUCCESS / FAILED / UNAVAILABLE / join() 이전 4가지 케이스
- failFast / firstSuccess 정상·실패 케이스

### 기타
- `virtualthread/api/build.gradle.kts`: `testRuntimeOnly(jdk21)` 추가 (ServiceLoader 테스트)
- README.md / README.ko.md: API 선택 가이드, 마이그레이션 표, 클래스 다이어그램 업데이트

### 기존 섹션: 핵심 설계 결정

- **getOrNull() ISE-safe**: `state() == SUCCESS`여도 join() 이전에는 JDK 내부 `ensureJoinedIfOwner()`가 ISE를 던짐 → try-catch로 방어
- **factory 기본값 통일**: `withFailFast()`/`failFast()` 모두 `VirtualThreads.threadFactory()` 사용 (환경 독립)
- **SPI 안정성 유지**: `withAll()`/`withAny()`는 deprecated 없음 — `withFailFast`/`withFirstSuccess`가 delegate

Closes #255

## Validation

| 모듈 | 결과 |
|------|------|
| `:bluetape4k-virtualthread-api:test` | 29 passing ✅ |
| `:bluetape4k-virtualthread-jdk21:test` + jdk25 | 17 passing ✅ |
| `:bluetape4k-core:test` | passing ✅ |
| `:bluetape4k-junit5:compileTestKotlin` | BUILD SUCCESSFUL ✅ |
| `:bluetape4k-workflow:compileTestKotlin` | BUILD SUCCESSFUL ✅ |

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #255, milestone 없음, assignee `debop`
- PR: #264, head `efbaaf977886dd86f55cf983d4bbe8c59ae17407`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/vt-api-cleanup`
- Labels: 없음
- State: `MERGED`, merge commit `edd57e48520a1af65078ecb7fa72b3854a449e57`
- CI: - `virtualthread/api/build.gradle.kts`: `testRuntimeOnly(jdk21)` 추가 (ServiceLoader 테스트)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #264 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `edd57e48520a1af65078ecb7fa72b3854a449e57`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
