### PR TITLE
feat: StructuredTaskScopeSupervised 부분 실패 허용 scope 추가 (#252)

### DIFF
--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredTaskScopeSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredTaskScopeSupport.kt
@@ -58,6 +58,34 @@ fun <T> structuredTaskScopeFirstSuccess(
 ): T = StructuredTaskScopes.firstSuccess(name, factory, block)
 
 /**
+ * 부분 실패를 허용하는(supervised) 구조화된 동시성 블록을 실행합니다.
+ * 모든 subtask가 완료될 때까지 기다리며, 성공/실패 결과를 별도로 수집합니다.
+ *
+ * ```kotlin
+ * val (results, errors) = structuredTaskScopeSupervised<Int, Pair<List<Int>, List<Throwable>>> { scope ->
+ *     scope.fork { 1 }
+ *     scope.fork { throw RuntimeException("fail") }
+ *     scope.fork { 3 }
+ *     scope.join()
+ *     scope.successfulResults() to scope.failedExceptions()
+ * }
+ * // results == [1, 3], errors.size == 1
+ * ```
+ *
+ * @param T subtask가 반환하는 타입
+ * @param R 블록이 반환하는 결과 타입
+ * @param name scope 이름 (디버깅용, 기본값: null)
+ * @param factory Virtual Thread 팩토리 (기본값: `VirtualThreads.threadFactory("sts-supervised-")`)
+ * @param block scope를 인자로 받아 서브 작업을 fork하고 결과를 반환하는 블록
+ * @return [block]의 실행 결과
+ */
+fun <T, R> structuredTaskScopeSupervised(
+    name: String? = null,
+    factory: ThreadFactory = VirtualThreads.threadFactory("sts-supervised-"),
+    block: (scope: StructuredTaskScopeSupervised<T>) -> R,
+): R = StructuredTaskScopes.supervised(name, factory, block)
+
+/**
  * [StructuredTaskScope.ShutdownOnFailure] 를 사용하여 구조화된 작업을 수행합니다.
  *
  * @deprecated [structuredTaskScopeFailFast]를 사용하세요. factory 기본값이 추가되고 이름이 의도를 더 명확히 표현합니다.

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/ResultSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/ResultSupport.kt
@@ -1,0 +1,42 @@
+package io.bluetape4k.support
+
+/**
+ * `Collection<Result<T>>` 컬렉션에 대한 편의 확장입니다.
+ * `List<Result<T>>`, `Set<Result<T>>` 등 모든 `Collection` 구현체에 적용됩니다.
+ *
+ * ## 사용 예
+ * ```kotlin
+ * val results: List<Result<Int>> = listOf(
+ *     Result.success(1),
+ *     Result.failure(RuntimeException("fail")),
+ *     Result.success(3)
+ * )
+ *
+ * results.allSuccess   // false
+ * results.hasFailure   // true
+ * results.successes    // [1, 3]
+ * results.failures     // [RuntimeException("fail")]
+ * ```
+ */
+
+/** 모든 항목이 성공이면 `true`입니다. */
+val <T> Collection<Result<T>>.allSuccess: Boolean get() = all { it.isSuccess }
+
+/** 모든 항목이 실패이면 `true`입니다. */
+val <T> Collection<Result<T>>.allFailure: Boolean get() = all { it.isFailure }
+
+/** 하나라도 실패 항목이 있으면 `true`입니다. */
+val <T> Collection<Result<T>>.hasFailure: Boolean get() = any { it.isFailure }
+
+/** 하나라도 성공 항목이 있으면 `true`입니다. */
+val <T> Collection<Result<T>>.hasSuccess: Boolean get() = any { it.isSuccess }
+
+/**
+ * 성공 결과 값 리스트를 반환합니다. 순서는 원본 컬렉션의 이터레이션 순서 기준입니다.
+ *
+ * **주의**: `T`가 nullable 타입일 때 `null` 성공 결과도 포함됩니다.
+ */
+val <T> Collection<Result<T>>.successes: List<T> get() = filter { it.isSuccess }.map { it.getOrThrow() }
+
+/** 실패 예외 리스트를 반환합니다. 순서는 원본 컬렉션의 이터레이션 순서 기준입니다. */
+val <T> Collection<Result<T>>.failures: List<Throwable> get() = mapNotNull { it.exceptionOrNull() }

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/ResultSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/ResultSupportTest.kt
@@ -1,0 +1,94 @@
+package io.bluetape4k.support
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.Test
+
+class ResultSupportTest {
+
+    private val mixed: List<Result<Int>> = listOf(
+        Result.success(1),
+        Result.failure(RuntimeException("fail")),
+        Result.success(3)
+    )
+    private val allSuccesses: List<Result<Int>> = listOf(Result.success(10), Result.success(20))
+    private val allFailures: List<Result<Int>> = listOf(
+        Result.failure(RuntimeException("e1")),
+        Result.failure(IllegalStateException("e2"))
+    )
+
+    @Test
+    fun `allSuccess 모두 성공이면 true 아니면 false`() {
+        allSuccesses.allSuccess.shouldBeTrue()
+        mixed.allSuccess.shouldBeFalse()
+        allFailures.allSuccess.shouldBeFalse()
+    }
+
+    @Test
+    fun `allFailure 모두 실패이면 true 아니면 false`() {
+        allFailures.allFailure.shouldBeTrue()
+        mixed.allFailure.shouldBeFalse()
+        allSuccesses.allFailure.shouldBeFalse()
+    }
+
+    @Test
+    fun `hasFailure 하나라도 실패이면 true`() {
+        mixed.hasFailure.shouldBeTrue()
+        allFailures.hasFailure.shouldBeTrue()
+        allSuccesses.hasFailure.shouldBeFalse()
+    }
+
+    @Test
+    fun `hasSuccess 하나라도 성공이면 true`() {
+        mixed.hasSuccess.shouldBeTrue()
+        allSuccesses.hasSuccess.shouldBeTrue()
+        allFailures.hasSuccess.shouldBeFalse()
+    }
+
+    @Test
+    fun `successes 성공 결과 값 리스트를 반환한다`() {
+        mixed.successes.sorted() shouldBeEqualTo listOf(1, 3)
+        allSuccesses.successes.sorted() shouldBeEqualTo listOf(10, 20)
+        allFailures.successes shouldBeEqualTo emptyList()
+    }
+
+    @Test
+    fun `failures 실패 예외 리스트를 반환한다`() {
+        mixed.failures.size shouldBeEqualTo 1
+        allFailures.failures.size shouldBeEqualTo 2
+        allSuccesses.failures shouldBeEqualTo emptyList()
+    }
+
+    @Test
+    fun `nullable T 에서 null 성공 결과도 successes 에 포함된다`() {
+        val results: List<Result<Int?>> = listOf(
+            Result.success(1),
+            Result.success(null),
+            Result.success(3)
+        )
+        results.allSuccess.shouldBeTrue()
+        results.successes.size shouldBeEqualTo 3
+        results.successes.filterNotNull().sorted() shouldBeEqualTo listOf(1, 3)
+    }
+
+    @Test
+    fun `Set Result T 에도 동일하게 적용된다`() {
+        val setResults: Set<Result<Int>> = setOf(Result.success(1), Result.failure(RuntimeException("e")))
+        setResults.hasFailure.shouldBeTrue()
+        setResults.hasSuccess.shouldBeTrue()
+        setResults.allSuccess.shouldBeFalse()
+        setResults.successes shouldBeEqualTo listOf(1)
+        setResults.failures.size shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `빈 컬렉션은 allSuccess 와 allFailure 가 모두 true`() {
+        // vacuous truth: empty collection — all {} 는 true
+        val empty: List<Result<Int>> = emptyList()
+        empty.allSuccess.shouldBeTrue()
+        empty.allFailure.shouldBeTrue()
+        empty.hasSuccess.shouldBeFalse()
+        empty.hasFailure.shouldBeFalse()
+    }
+}

--- a/virtualthread/api/README.ko.md
+++ b/virtualthread/api/README.ko.md
@@ -56,6 +56,8 @@ Java의 StructuredTaskScope API를 추상화하여 JDK 버전에 관계없이 �
   └─ Yes → failFast { }       (첫 번째 실패 시 나머지를 즉시 취소)
 첫 번째 성공 결과만 필요한가?
   └─ Yes → firstSuccess { }   (첫 번째 성공 시 나머지를 취소)
+부분 실패를 허용하고 성공/실패를 나누어 수집해야 하는가?
+  └─ Yes → supervised { }     (모든 태스크 완료까지 기다린 후 결과를 분리)
 ```
 
 #### `failFast` — 전체 성공 보장
@@ -86,6 +88,34 @@ val fastestResult = StructuredTaskScopes.firstSuccess<String> { scope ->
     scope.fork { fetchFromApi3() }
 
     scope.join().result { error -> RuntimeException("All APIs failed", error) }
+}
+```
+
+#### `supervised` — 부분 실패 허용
+
+모든 서브태스크를 완료까지 실행하며, 성공 결과와 실패 예외를 별도로 수집합니다.
+
+```kotlin
+val (successes, errors) = StructuredTaskScopes.supervised<String, Pair<List<String>, List<Throwable>>> { scope ->
+    scope.fork { fetchFromPrimaryDb() }   // 성공 가능
+    scope.fork { fetchFromReplicaDb() }   // 실패 가능
+    scope.fork { fetchFromCacheDb() }     // 성공 가능
+    scope.join()
+    scope.successfulResults() to scope.failedExceptions()
+}
+// successes: 정상 완료된 태스크 결과 목록
+// errors: 실패한 태스크 예외 목록
+println("결과 ${successes.size}개 수집, 실패 ${errors.size}건")
+```
+
+`joinUntil` 데드라인 지정:
+
+```kotlin
+StructuredTaskScopes.supervised<String, Unit> { scope ->
+    scope.fork { longRunningTask() }
+    scope.joinUntil(Instant.now().plusSeconds(5))  // 초과 시 TimeoutException
+    val results = scope.successfulResults()
+    val failures = scope.failedExceptions()
 }
 ```
 
@@ -219,14 +249,26 @@ classDiagram
         +isSupported() Boolean
         +withFailFast(name, factory, block) T
         +withFirstSuccess(name, factory, block) T
+        +withSupervised(name, factory, block) R
         +withAll(name, factory, block) T
         +withAny(name, factory, block) T
+    }
+
+    class StructuredTaskScopeSupervised {
+        <<interface>>
+        +fork(task) StructuredSubtask~T~
+        +join() StructuredTaskScopeSupervised~T~
+        +joinUntil(deadline) StructuredTaskScopeSupervised~T~
+        +successfulResults() List~T~
+        +failedExceptions() List~Throwable~
+        +close()
     }
 
     class StructuredTaskScopes {
         <<object>>
         +failFast(name, factory, block) T
         +firstSuccess(name, factory, block) T
+        +supervised(name, factory, block) R
         +all(name, factory, block) T ~~deprecated~~
         +any(name, factory, block) T ~~deprecated~~
     }
@@ -251,6 +293,8 @@ classDiagram
     VirtualThreadRuntime <|-- PlatformThreadFallback
     VirtualThreads --> VirtualThreadRuntime : "ServiceLoader 선택"
     StructuredTaskScopes --> StructuredTaskScopeProvider : "ServiceLoader 선택"
+    StructuredTaskScopeProvider --> StructuredTaskScopeSupervised : creates
+    style StructuredTaskScopeSupervised fill:#EDE7F6,stroke:#B39DDB,color:#4527A0
 
     style VirtualThreadRuntime fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     style VirtualThreads fill:#FFF3E0,stroke:#FFCC80,color:#E65100

--- a/virtualthread/api/README.md
+++ b/virtualthread/api/README.md
@@ -57,6 +57,8 @@ Need all subtasks to succeed?
   └─ Yes → failFast { }        (cancels others on first failure)
 Need the first success?
   └─ Yes → firstSuccess { }    (cancels others on first success)
+Need partial failure tolerance (collect success + failure separately)?
+  └─ Yes → supervised { }      (all run to completion; results split)
 ```
 
 #### `failFast` — All Must Succeed
@@ -87,6 +89,34 @@ val fastestResult = StructuredTaskScopes.firstSuccess<String> { scope ->
     scope.fork { fetchFromApi3() }
 
     scope.join().result { error -> RuntimeException("All APIs failed", error) }
+}
+```
+
+#### `supervised` — Partial Failure Tolerance
+
+Runs all subtasks to completion regardless of individual failures. Results are split into successful results and failed exceptions.
+
+```kotlin
+val (successes, errors) = StructuredTaskScopes.supervised<String, Pair<List<String>, List<Throwable>>> { scope ->
+    scope.fork { fetchFromPrimaryDb() }   // may succeed
+    scope.fork { fetchFromReplicaDb() }   // may fail
+    scope.fork { fetchFromCacheDb() }     // may succeed
+    scope.join()
+    scope.successfulResults() to scope.failedExceptions()
+}
+// successes: results from tasks that completed normally
+// errors: exceptions from tasks that failed
+println("Got ${successes.size} results, ${errors.size} failures")
+```
+
+With `joinUntil` deadline:
+
+```kotlin
+StructuredTaskScopes.supervised<String, Unit> { scope ->
+    scope.fork { longRunningTask() }
+    scope.joinUntil(Instant.now().plusSeconds(5))  // TimeoutException if exceeded
+    val results = scope.successfulResults()
+    val failures = scope.failedExceptions()
 }
 ```
 
@@ -221,14 +251,26 @@ classDiagram
         +isSupported() Boolean
         +withFailFast(name, factory, block) T
         +withFirstSuccess(name, factory, block) T
+        +withSupervised(name, factory, block) R
         +withAll(name, factory, block) T
         +withAny(name, factory, block) T
+    }
+
+    class StructuredTaskScopeSupervised {
+        <<interface>>
+        +fork(task) StructuredSubtask~T~
+        +join() StructuredTaskScopeSupervised~T~
+        +joinUntil(deadline) StructuredTaskScopeSupervised~T~
+        +successfulResults() List~T~
+        +failedExceptions() List~Throwable~
+        +close()
     }
 
     class StructuredTaskScopes {
         <<object>>
         +failFast(name, factory, block) T
         +firstSuccess(name, factory, block) T
+        +supervised(name, factory, block) R
         +all(name, factory, block) T ~~deprecated~~
         +any(name, factory, block) T ~~deprecated~~
     }
@@ -253,6 +295,8 @@ classDiagram
     VirtualThreadRuntime <|-- PlatformThreadFallback
     VirtualThreads --> VirtualThreadRuntime : "selected via ServiceLoader"
     StructuredTaskScopes --> StructuredTaskScopeProvider : "selected via ServiceLoader"
+    StructuredTaskScopeProvider --> StructuredTaskScopeSupervised : creates
+    style StructuredTaskScopeSupervised fill:#EDE7F6,stroke:#B39DDB,color:#4527A0
 
     style VirtualThreadRuntime fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     style VirtualThreads fill:#FFF3E0,stroke:#FFCC80,color:#E65100

--- a/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopes.kt
+++ b/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopes.kt
@@ -180,6 +180,66 @@ interface StructuredTaskScopeAny<T>: AutoCloseable {
 typealias StructuredTaskScopeFirstSuccess<T> = StructuredTaskScopeAny<T>
 
 /**
+ * 부분 실패를 허용하는 supervised scope 추상화입니다.
+ * 모든 subtask를 실행하고, 실패해도 나머지를 계속 진행합니다.
+ * [join] 이후 [successfulResults]와 [failedExceptions]로 결과를 분리합니다.
+ *
+ * ## 동작/계약
+ * - [fork]로 추가한 모든 subtask가 완료될 때까지 대기합니다.
+ * - subtask 하나가 실패해도 나머지 subtask는 계속 실행됩니다 (fail-fast 아님).
+ * - [join] 이후에 [successfulResults], [failedExceptions]를 호출해야 합니다.
+ * - 타임아웃이 필요하면 [joinUntil]을 사용하세요. 데드라인 초과 시 `TimeoutException`이 발생합니다.
+ *
+ * ```kotlin
+ * val (successes, failures) = StructuredTaskScopes.supervised<Int> { scope ->
+ *     scope.fork { 1 }
+ *     scope.fork { throw RuntimeException("subtask 2 failed") }
+ *     scope.fork { 3 }
+ *     scope.join()
+ *     scope.successfulResults() to scope.failedExceptions()
+ * }
+ * // successes == [1, 3], failures.size == 1
+ * ```
+ *
+ * @param T 각 subtask의 결과 타입
+ * @see StructuredTaskScopes.supervised
+ */
+interface StructuredTaskScopeSupervised<T> : AutoCloseable {
+    /** 새 subtask를 scope에 등록합니다. */
+    fun fork(task: () -> T): StructuredSubtask<T>
+
+    /**
+     * 등록된 모든 subtask 완료를 대기합니다.
+     * subtask 실패 시에도 나머지 subtask를 계속 실행합니다.
+     */
+    fun join(): StructuredTaskScopeSupervised<T>
+
+    /**
+     * 지정한 데드라인까지 subtask 완료를 대기합니다.
+     * 데드라인 초과 시 [java.util.concurrent.TimeoutException]이 발생합니다.
+     * 기본 구현은 타임아웃 없이 [join]을 호출합니다.
+     */
+    fun joinUntil(deadline: java.time.Instant): StructuredTaskScopeSupervised<T> = join()
+
+    /**
+     * [join] 이후 성공한 subtask의 결과 리스트를 반환합니다.
+     *
+     * **전제 조건**: [join] 또는 [joinUntil] 완료 이후에 호출하세요.
+     */
+    fun successfulResults(): List<T>
+
+    /**
+     * [join] 이후 실패한 subtask의 예외 리스트를 반환합니다.
+     *
+     * **전제 조건**: [join] 또는 [joinUntil] 완료 이후에 호출하세요.
+     */
+    fun failedExceptions(): List<Throwable>
+
+    /** scope 자원을 정리합니다. */
+    override fun close()
+}
+
+/**
  * JDK별 StructuredTaskScope 구현체를 제공하는 SPI 인터페이스입니다.
  *
  * ## 동작/계약
@@ -258,6 +318,21 @@ interface StructuredTaskScopeProvider {
         factory: ThreadFactory = VirtualThreads.threadFactory(),
         block: (scope: StructuredTaskScopeFirstSuccess<T>) -> T,
     ): T = withAny(name, factory, block)
+
+    /**
+     * 부분 실패 허용형(supervised) 블록을 실행합니다.
+     * 모든 subtask를 실행하고, 실패 여부와 관계없이 완료를 대기합니다.
+     *
+     * @param name scope 이름
+     * @param factory subtask 실행용 스레드 팩토리 (기본값: [VirtualThreads.threadFactory])
+     * @param block 실행 블록 — [StructuredTaskScopeSupervised.join] 이후 [StructuredTaskScopeSupervised.successfulResults] / [StructuredTaskScopeSupervised.failedExceptions]로 결과를 분리
+     * @see StructuredTaskScopes.supervised
+     */
+    fun <T, R> withSupervised(
+        name: String? = null,
+        factory: ThreadFactory = VirtualThreads.threadFactory(),
+        block: (scope: StructuredTaskScopeSupervised<T>) -> R,
+    ): R
 }
 
 /**
@@ -391,6 +466,38 @@ object StructuredTaskScopes: KLogging() {
         factory: ThreadFactory = VirtualThreads.threadFactory(),
         block: (scope: StructuredTaskScopeFirstSuccess<T>) -> T,
     ): T = provider().withFirstSuccess(name, factory, block)
+
+    /**
+     * 부분 실패 허용형(supervised) scope 블록을 실행합니다.
+     * 하나의 subtask가 실패해도 나머지 subtask를 계속 실행합니다.
+     *
+     * ## 동작/계약
+     * - block 내부에서 [StructuredTaskScopeSupervised] API로 subtask를 등록·대기·결과 분리합니다.
+     * - [StructuredTaskScopeSupervised.join] 이후 [StructuredTaskScopeSupervised.successfulResults]와
+     *   [StructuredTaskScopeSupervised.failedExceptions]로 결과를 분리합니다.
+     * - 실제 scope 구현은 선택된 provider에 의해 결정됩니다.
+     *
+     * ```kotlin
+     * val (successes, failures) = StructuredTaskScopes.supervised<Int> { scope ->
+     *     scope.fork { 1 }
+     *     scope.fork { throw RuntimeException("subtask 2 failed") }
+     *     scope.fork { 3 }
+     *     scope.join()
+     *     scope.successfulResults() to scope.failedExceptions()
+     * }
+     * // successes == [1, 3], failures.size == 1
+     * ```
+     *
+     * @param name scope 이름 (디버깅용, 기본값: null)
+     * @param factory subtask 실행용 스레드 팩토리 (기본값: [VirtualThreads.threadFactory])
+     * @param block scope 실행 블록
+     * @return [block]의 실행 결과
+     */
+    fun <T, R> supervised(
+        name: String? = null,
+        factory: ThreadFactory = VirtualThreads.threadFactory(),
+        block: (scope: StructuredTaskScopeSupervised<T>) -> R,
+    ): R = provider().withSupervised(name, factory, block)
 
     /**
      * 실패 전파형(all) scope 블록을 실행합니다.

--- a/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopes.kt
+++ b/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopes.kt
@@ -182,16 +182,30 @@ typealias StructuredTaskScopeFirstSuccess<T> = StructuredTaskScopeAny<T>
 /**
  * 부분 실패를 허용하는 supervised scope 추상화입니다.
  * 모든 subtask를 실행하고, 실패해도 나머지를 계속 진행합니다.
- * [join] 이후 [successfulResults]와 [failedExceptions]로 결과를 분리합니다.
+ * [join] 이후 [results]로 각 subtask 결과를 `Result<T>`로 통합 조회하거나,
+ * [successfulResults] / [failedExceptions]로 분리해 사용합니다.
  *
  * ## 동작/계약
  * - [fork]로 추가한 모든 subtask가 완료될 때까지 대기합니다.
  * - subtask 하나가 실패해도 나머지 subtask는 계속 실행됩니다 (fail-fast 아님).
- * - [join] 이후에 [successfulResults], [failedExceptions]를 호출해야 합니다.
+ * - [join] 이후에 [results], [successfulResults], [failedExceptions]를 호출해야 합니다.
  * - 타임아웃이 필요하면 [joinUntil]을 사용하세요. 데드라인 초과 시 `TimeoutException`이 발생합니다.
  *
  * ```kotlin
- * val (successes, failures) = StructuredTaskScopes.supervised<Int> { scope ->
+ * // Result<T> 통합 조회
+ * val results = StructuredTaskScopes.supervised<Int, List<Result<Int>>> { scope ->
+ *     scope.fork { 1 }
+ *     scope.fork { throw RuntimeException("subtask 2 failed") }
+ *     scope.fork { 3 }
+ *     scope.join()
+ *     scope.results()
+ * }
+ * // results[0] == Result.success(1)
+ * // results[1] == Result.failure(RuntimeException("subtask 2 failed"))
+ * // results[2] == Result.success(3)
+ *
+ * // 또는 기존 패턴으로 분리
+ * val (successes, failures) = StructuredTaskScopes.supervised<Int, Pair<...>> { scope ->
  *     scope.fork { 1 }
  *     scope.fork { throw RuntimeException("subtask 2 failed") }
  *     scope.fork { 3 }
@@ -222,18 +236,31 @@ interface StructuredTaskScopeSupervised<T> : AutoCloseable {
     fun joinUntil(deadline: java.time.Instant): StructuredTaskScopeSupervised<T> = join()
 
     /**
-     * [join] 이후 성공한 subtask의 결과 리스트를 반환합니다.
+     * [join] 이후 모든 subtask 결과를 `Result<T>` 리스트로 반환합니다.
+     * fork 순서와 결과 순서는 구현에 따라 다를 수 있습니다.
+     *
+     * - 성공한 subtask: `Result.success(value)`
+     * - 실패한 subtask: `Result.failure(exception)`
      *
      * **전제 조건**: [join] 또는 [joinUntil] 완료 이후에 호출하세요.
      */
-    fun successfulResults(): List<T>
+    fun results(): List<Result<T>>
+
+    /**
+     * [join] 이후 성공한 subtask의 결과 리스트를 반환합니다.
+     * [results]에서 파생된 기본 구현입니다.
+     *
+     * **전제 조건**: [join] 또는 [joinUntil] 완료 이후에 호출하세요.
+     */
+    fun successfulResults(): List<T> = results().filter { it.isSuccess }.map { it.getOrThrow() }
 
     /**
      * [join] 이후 실패한 subtask의 예외 리스트를 반환합니다.
+     * [results]에서 파생된 기본 구현입니다.
      *
      * **전제 조건**: [join] 또는 [joinUntil] 완료 이후에 호출하세요.
      */
-    fun failedExceptions(): List<Throwable>
+    fun failedExceptions(): List<Throwable> = results().mapNotNull { it.exceptionOrNull() }
 
     /** scope 자원을 정리합니다. */
     override fun close()
@@ -325,7 +352,8 @@ interface StructuredTaskScopeProvider {
      *
      * @param name scope 이름
      * @param factory subtask 실행용 스레드 팩토리 (기본값: [VirtualThreads.threadFactory])
-     * @param block 실행 블록 — [StructuredTaskScopeSupervised.join] 이후 [StructuredTaskScopeSupervised.successfulResults] / [StructuredTaskScopeSupervised.failedExceptions]로 결과를 분리
+     * @param block 실행 블록 — [StructuredTaskScopeSupervised.join] 이후 [StructuredTaskScopeSupervised.results]로
+     *   `Result<T>` 통합 조회하거나 [StructuredTaskScopeSupervised.successfulResults] / [StructuredTaskScopeSupervised.failedExceptions]로 분리
      * @see StructuredTaskScopes.supervised
      */
     fun <T, R> withSupervised(
@@ -472,13 +500,25 @@ object StructuredTaskScopes: KLogging() {
      * 하나의 subtask가 실패해도 나머지 subtask를 계속 실행합니다.
      *
      * ## 동작/계약
-     * - block 내부에서 [StructuredTaskScopeSupervised] API로 subtask를 등록·대기·결과 분리합니다.
-     * - [StructuredTaskScopeSupervised.join] 이후 [StructuredTaskScopeSupervised.successfulResults]와
-     *   [StructuredTaskScopeSupervised.failedExceptions]로 결과를 분리합니다.
+     * - block 내부에서 [StructuredTaskScopeSupervised] API로 subtask를 등록·대기·결과 조회합니다.
+     * - [StructuredTaskScopeSupervised.join] 이후 [StructuredTaskScopeSupervised.results]로
+     *   각 subtask 결과를 `Result<T>`로 통합 조회하거나,
+     *   [StructuredTaskScopeSupervised.successfulResults] / [StructuredTaskScopeSupervised.failedExceptions]로 분리합니다.
      * - 실제 scope 구현은 선택된 provider에 의해 결정됩니다.
      *
      * ```kotlin
-     * val (successes, failures) = StructuredTaskScopes.supervised<Int> { scope ->
+     * // Result<T> 통합 조회
+     * val allResults = StructuredTaskScopes.supervised<Int, List<Result<Int>>> { scope ->
+     *     scope.fork { 1 }
+     *     scope.fork { throw RuntimeException("subtask 2 failed") }
+     *     scope.fork { 3 }
+     *     scope.join()
+     *     scope.results()
+     * }
+     * // allResults.filter { it.isSuccess }.map { it.getOrThrow() } == [1, 3]
+     *
+     * // 분리 패턴
+     * val (successes, failures) = StructuredTaskScopes.supervised<Int, Pair<List<Int>, List<Throwable>>> { scope ->
      *     scope.fork { 1 }
      *     scope.fork { throw RuntimeException("subtask 2 failed") }
      *     scope.fork { 3 }

--- a/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt
+++ b/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt
@@ -356,4 +356,110 @@ class StructuredScopesTest {
             }
         }
     }
+
+    // ── supervised scope 테스트 ─────────────────────────────────────────────────
+
+    @Test
+    fun `supervised scope 일부 성공 일부 실패 시 결과를 분리해야 한다`() {
+        val (successes, failures) = StructuredTaskScopes.supervised<Int, Pair<List<Int>, List<Throwable>>> { scope ->
+            scope.fork { 1 }
+            scope.fork { throw RuntimeException("fail2") }
+            scope.fork { 3 }
+            scope.join()
+            scope.successfulResults() to scope.failedExceptions()
+        }
+        successes.sorted() shouldBeEqualTo listOf(1, 3)
+        failures.size shouldBeEqualTo 1
+        failures[0].shouldBeInstanceOf<RuntimeException>()
+    }
+
+    @Test
+    fun `supervised scope 모두 성공 시 successfulResults 에 전부 포함되어야 한다`() {
+        val (successes, failures) = StructuredTaskScopes.supervised<Int, Pair<List<Int>, List<Throwable>>> { scope ->
+            scope.fork { 10 }
+            scope.fork { 20 }
+            scope.fork { 30 }
+            scope.join()
+            scope.successfulResults() to scope.failedExceptions()
+        }
+        successes.sorted() shouldBeEqualTo listOf(10, 20, 30)
+        failures.size shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `supervised scope 모두 실패 시 failedExceptions 에 전부 포함되어야 한다`() {
+        val (successes, failures) = StructuredTaskScopes.supervised<Int, Pair<List<Int>, List<Throwable>>> { scope ->
+            scope.fork { throw RuntimeException("fail1") }
+            scope.fork { throw IllegalStateException("fail2") }
+            scope.join()
+            scope.successfulResults() to scope.failedExceptions()
+        }
+        successes.size shouldBeEqualTo 0
+        failures.size shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `supervised scope 병렬 실행으로 thread-safe 하게 결과를 수집해야 한다`() {
+        val taskCount = 100
+        val failEvery = 10  // 10번째마다 실패
+        val (successes, failures) = StructuredTaskScopes.supervised<Int, Pair<List<Int>, List<Throwable>>> { scope ->
+            repeat(taskCount) { i ->
+                if (i % failEvery == 0) {
+                    scope.fork { throw RuntimeException("fail $i") }
+                } else {
+                    scope.fork { i }
+                }
+            }
+            scope.join()
+            scope.successfulResults() to scope.failedExceptions()
+        }
+        val expectedSuccessCount = taskCount - taskCount / failEvery
+        val expectedFailCount = taskCount / failEvery
+        successes.size shouldBeEqualTo expectedSuccessCount
+        failures.size shouldBeEqualTo expectedFailCount
+    }
+
+    @Test
+    fun `supervised scope joinUntil 데드라인 초과 시 TimeoutException 이 발생해야 한다`() {
+        assertFailsWith<TimeoutException> {
+            StructuredTaskScopes.supervised<Int, Unit> { scope ->
+                scope.fork {
+                    Thread.sleep(10_000)
+                    42
+                }
+                scope.joinUntil(Instant.now().plusMillis(100))
+            }
+        }
+    }
+
+    @Test
+    fun `supervised scope 빈 fork 시 빈 결과를 반환해야 한다`() {
+        val (successes, failures) = StructuredTaskScopes.supervised<Int, Pair<List<Int>, List<Throwable>>> { scope ->
+            scope.join()
+            scope.successfulResults() to scope.failedExceptions()
+        }
+        successes.size shouldBeEqualTo 0
+        failures.size shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `supervised scope subtask 상태가 올바르게 반환되어야 한다`() {
+        var successTask: StructuredSubtask<Int>? = null
+        var failedTask: StructuredSubtask<Int>? = null
+
+        StructuredTaskScopes.supervised<Int, Unit> { scope ->
+            successTask = scope.fork { 42 }
+            failedTask = scope.fork { throw RuntimeException("fail") }
+            scope.join()
+        }
+
+        successTask.shouldNotBeNull()
+        successTask!!.state() shouldBeEqualTo StructuredTaskScope.Subtask.State.SUCCESS
+        successTask!!.getOrNull() shouldBeEqualTo 42
+        successTask!!.exceptionOrNull().shouldBeNull()
+
+        failedTask.shouldNotBeNull()
+        failedTask!!.state() shouldBeEqualTo StructuredTaskScope.Subtask.State.FAILED
+        failedTask!!.exceptionOrNull().shouldNotBeNull().shouldBeInstanceOf<RuntimeException>()
+    }
 }

--- a/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt
+++ b/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt
@@ -443,6 +443,20 @@ class StructuredScopesTest {
     }
 
     @Test
+    fun `supervised scope nullable T 타입에서 null 성공 결과도 수집되어야 한다`() {
+        val (successes, failures) = StructuredTaskScopes.supervised<Int?, Pair<List<Int?>, List<Throwable>>> { scope ->
+            scope.fork { 1 }
+            scope.fork { null }  // 성공적으로 null 반환
+            scope.fork { 3 }
+            scope.join()
+            scope.successfulResults() to scope.failedExceptions()
+        }
+        successes.size shouldBeEqualTo 3  // null 포함
+        successes.filterNotNull().sorted() shouldBeEqualTo listOf(1, 3)
+        failures.size shouldBeEqualTo 0
+    }
+
+    @Test
     fun `supervised scope subtask 상태가 올바르게 반환되어야 한다`() {
         var successTask: StructuredSubtask<Int>? = null
         var failedTask: StructuredSubtask<Int>? = null

--- a/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt
+++ b/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt
@@ -476,4 +476,82 @@ class StructuredScopesTest {
         failedTask!!.state() shouldBeEqualTo StructuredTaskScope.Subtask.State.FAILED
         failedTask!!.exceptionOrNull().shouldNotBeNull().shouldBeInstanceOf<RuntimeException>()
     }
+
+    // ── results(): List<Result<T>> 테스트 ──────────────────────────────────────
+
+    @Test
+    fun `supervised scope results 일부 성공 일부 실패 시 Result 리스트를 반환해야 한다`() {
+        val allResults = StructuredTaskScopes.supervised<Int, List<Result<Int>>> { scope ->
+            scope.fork { 1 }
+            scope.fork { throw RuntimeException("fail2") }
+            scope.fork { 3 }
+            scope.join()
+            scope.results()
+        }
+        allResults.size shouldBeEqualTo 3
+        val successes = allResults.filter { it.isSuccess }.map { it.getOrThrow() }.sorted()
+        val failures = allResults.mapNotNull { it.exceptionOrNull() }
+        successes shouldBeEqualTo listOf(1, 3)
+        failures.size shouldBeEqualTo 1
+        failures[0].shouldBeInstanceOf<RuntimeException>()
+    }
+
+    @Test
+    fun `supervised scope results 모두 성공 시 모두 Result success 이어야 한다`() {
+        val allResults = StructuredTaskScopes.supervised<Int, List<Result<Int>>> { scope ->
+            scope.fork { 10 }
+            scope.fork { 20 }
+            scope.join()
+            scope.results()
+        }
+        allResults.size shouldBeEqualTo 2
+        allResults.all { it.isSuccess }.shouldBeTrue()
+        allResults.map { it.getOrThrow() }.sorted() shouldBeEqualTo listOf(10, 20)
+    }
+
+    @Test
+    fun `supervised scope results 모두 실패 시 모두 Result failure 이어야 한다`() {
+        val allResults = StructuredTaskScopes.supervised<Int, List<Result<Int>>> { scope ->
+            scope.fork { throw RuntimeException("fail1") }
+            scope.fork { throw IllegalStateException("fail2") }
+            scope.join()
+            scope.results()
+        }
+        allResults.size shouldBeEqualTo 2
+        allResults.all { it.isFailure }.shouldBeTrue()
+    }
+
+    @Test
+    fun `supervised scope results nullable T 에서 null 성공도 Result success 로 포함되어야 한다`() {
+        val allResults = StructuredTaskScopes.supervised<Int?, List<Result<Int?>>> { scope ->
+            scope.fork { 1 }
+            scope.fork { null }  // 성공적으로 null 반환
+            scope.fork { 3 }
+            scope.join()
+            scope.results()
+        }
+        allResults.size shouldBeEqualTo 3
+        allResults.all { it.isSuccess }.shouldBeTrue()
+        allResults.map { it.getOrThrow() }.filterNotNull().sorted() shouldBeEqualTo listOf(1, 3)
+    }
+
+    @Test
+    fun `supervised scope successfulResults 와 failedExceptions 는 results 에서 올바르게 파생되어야 한다`() {
+        var successes: List<Int> = emptyList()
+        var failures: List<Throwable> = emptyList()
+        var allResults: List<Result<Int>> = emptyList()
+
+        StructuredTaskScopes.supervised<Int, Unit> { scope ->
+            scope.fork { 1 }
+            scope.fork { throw RuntimeException("boom") }
+            scope.fork { 3 }
+            scope.join()
+            allResults = scope.results()
+            successes = scope.successfulResults()
+            failures = scope.failedExceptions()
+        }
+
+        successes.sorted() shouldBeEqualTo allResults.filter { it.isSuccess }.map { it.getOrThrow() }.sorted()
+        failures.size shouldBeEqualTo allResults.mapNotNull { it.exceptionOrNull() }.size
+    }
 }

--- a/virtualthread/jdk21/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProvider.kt
+++ b/virtualthread/jdk21/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProvider.kt
@@ -182,6 +182,25 @@ class Jdk21StructuredTaskScopeProvider: StructuredTaskScopeProvider {
         }
     }
 
+    /**
+     * JDK21 `StructuredTaskScope` 서브클래스를 사용하여 부분 실패 허용 scope를 실행합니다.
+     *
+     * ## 동작/계약
+     * - `Jdk21SupervisedTaskScope`는 [StructuredTaskScope]를 직접 상속하고 [StructuredTaskScope.handleComplete]를
+     *   오버라이드하여 성공/실패 결과를 `CopyOnWriteArrayList`에 thread-safe하게 수집합니다.
+     * - 실패한 subtask가 있어도 scope를 종료하지 않고 모든 subtask가 완료될 때까지 기다립니다.
+     *
+     * ```kotlin
+     * val (successes, errors) = Jdk21StructuredTaskScopeProvider().withSupervised<Int, Pair<List<Int>, List<Throwable>>> { scope ->
+     *     scope.fork { 1 }
+     *     scope.fork { throw RuntimeException("fail") }
+     *     scope.fork { 3 }
+     *     scope.join()
+     *     scope.successfulResults() to scope.failedExceptions()
+     * }
+     * // successes = [1, 3], errors.size = 1
+     * ```
+     */
     override fun <T, R> withSupervised(
         name: String?,
         factory: ThreadFactory,
@@ -237,6 +256,8 @@ class Jdk21StructuredTaskScopeProvider: StructuredTaskScopeProvider {
         override fun successfulResults(): List<T> = delegate.successfulResults()
         override fun failedExceptions(): List<Throwable> = delegate.failedExceptions()
 
-        override fun close() = delegate.close()
+        override fun close() {
+            delegate.close()
+        }
     }
 }

--- a/virtualthread/jdk21/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProvider.kt
+++ b/virtualthread/jdk21/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProvider.kt
@@ -4,10 +4,12 @@ import io.bluetape4k.concurrent.virtualthread.StructuredSubtask
 import io.bluetape4k.concurrent.virtualthread.StructuredTaskScopeAll
 import io.bluetape4k.concurrent.virtualthread.StructuredTaskScopeAny
 import io.bluetape4k.concurrent.virtualthread.StructuredTaskScopeProvider
+import io.bluetape4k.concurrent.virtualthread.StructuredTaskScopeSupervised
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.trace
 import java.util.concurrent.Callable
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.StructuredTaskScope
 import java.util.concurrent.ThreadFactory
 
@@ -178,5 +180,63 @@ class Jdk21StructuredTaskScopeProvider: StructuredTaskScopeProvider {
         override fun close() {
             delegate.close()
         }
+    }
+
+    override fun <T, R> withSupervised(
+        name: String?,
+        factory: ThreadFactory,
+        block: (scope: StructuredTaskScopeSupervised<T>) -> R,
+    ): R {
+        log.debug { "부분 실패를 허용하는 supervised scope를 실행합니다..." }
+        return Jdk21SupervisedTaskScope<T>(name, factory).use { taskScope ->
+            block(Jdk21SupervisedScope(taskScope))
+        }
+    }
+
+    /**
+     * JDK21에서 부분 실패 허용 scope를 구현하기 위해 [StructuredTaskScope]를 직접 상속합니다.
+     * [handleComplete]에서 성공/실패 결과를 thread-safe하게 수집합니다.
+     */
+    private class Jdk21SupervisedTaskScope<T>(
+        name: String?,
+        factory: ThreadFactory,
+    ) : StructuredTaskScope<T>(name, factory) {
+        private val _successResults = CopyOnWriteArrayList<T>()
+        private val _failedExceptions = CopyOnWriteArrayList<Throwable>()
+
+        override fun handleComplete(subtask: StructuredTaskScope.Subtask<out T>) {
+            when (subtask.state()) {
+                StructuredTaskScope.Subtask.State.SUCCESS -> _successResults.add(subtask.get())
+                StructuredTaskScope.Subtask.State.FAILED  -> _failedExceptions.add(subtask.exception())
+                else                                      -> {} // UNAVAILABLE — 취소된 subtask, 무시
+            }
+        }
+
+        fun successfulResults(): List<T> = _successResults.toList()
+        fun failedExceptions(): List<Throwable> = _failedExceptions.toList()
+    }
+
+    private class Jdk21SupervisedScope<T>(
+        private val delegate: Jdk21SupervisedTaskScope<T>,
+    ) : StructuredTaskScopeSupervised<T> {
+        override fun fork(task: () -> T): StructuredSubtask<T> {
+            log.trace { "Add supervised sub task..." }
+            return Jdk21Subtask(delegate.fork(Callable { task() }))
+        }
+
+        override fun join(): StructuredTaskScopeSupervised<T> {
+            delegate.join()
+            return this
+        }
+
+        override fun joinUntil(deadline: java.time.Instant): StructuredTaskScopeSupervised<T> {
+            delegate.joinUntil(deadline)
+            return this
+        }
+
+        override fun successfulResults(): List<T> = delegate.successfulResults()
+        override fun failedExceptions(): List<Throwable> = delegate.failedExceptions()
+
+        override fun close() = delegate.close()
     }
 }

--- a/virtualthread/jdk21/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProvider.kt
+++ b/virtualthread/jdk21/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProvider.kt
@@ -214,25 +214,23 @@ class Jdk21StructuredTaskScopeProvider: StructuredTaskScopeProvider {
 
     /**
      * JDK21에서 부분 실패 허용 scope를 구현하기 위해 [StructuredTaskScope]를 직접 상속합니다.
-     * [handleComplete]에서 성공/실패 결과를 thread-safe하게 수집합니다.
+     * [handleComplete]에서 성공/실패 결과를 `Result<T>`로 통합해 thread-safe하게 수집합니다.
      */
     private class Jdk21SupervisedTaskScope<T>(
         name: String?,
         factory: ThreadFactory,
     ) : StructuredTaskScope<T>(name, factory) {
-        private val _successResults = CopyOnWriteArrayList<T>()
-        private val _failedExceptions = CopyOnWriteArrayList<Throwable>()
+        private val _results = CopyOnWriteArrayList<Result<T>>()
 
         override fun handleComplete(subtask: StructuredTaskScope.Subtask<out T>) {
             when (subtask.state()) {
-                StructuredTaskScope.Subtask.State.SUCCESS -> _successResults.add(subtask.get())
-                StructuredTaskScope.Subtask.State.FAILED  -> _failedExceptions.add(subtask.exception())
+                StructuredTaskScope.Subtask.State.SUCCESS -> _results.add(Result.success(subtask.get()))
+                StructuredTaskScope.Subtask.State.FAILED  -> _results.add(Result.failure(subtask.exception()))
                 else                                      -> {} // UNAVAILABLE — 취소된 subtask, 무시
             }
         }
 
-        fun successfulResults(): List<T> = _successResults.toList()
-        fun failedExceptions(): List<Throwable> = _failedExceptions.toList()
+        fun results(): List<Result<T>> = _results.toList()
     }
 
     private class Jdk21SupervisedScope<T>(
@@ -253,8 +251,7 @@ class Jdk21StructuredTaskScopeProvider: StructuredTaskScopeProvider {
             return this
         }
 
-        override fun successfulResults(): List<T> = delegate.successfulResults()
-        override fun failedExceptions(): List<Throwable> = delegate.failedExceptions()
+        override fun results(): List<Result<T>> = delegate.results()
 
         override fun close() {
             delegate.close()

--- a/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProviderTest.kt
+++ b/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProviderTest.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.logging.debug
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
 import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
@@ -84,6 +85,33 @@ class Jdk21StructuredTaskScopeProviderTest {
                 scope.joinUntil(Instant.now().plusMillis(100))
             }
         }
+    }
+
+    @Test
+    fun `withSupervised results 일부 성공 일부 실패 시 Result 리스트를 반환해야 한다`() {
+        val allResults = provider.withSupervised<Int, List<Result<Int>>> { scope ->
+            scope.fork { 1 }
+            scope.fork { throw RuntimeException("fail") }
+            scope.fork { 3 }
+            scope.join()
+            scope.results()
+        }
+        allResults.size shouldBeEqualTo 3
+        allResults.filter { it.isSuccess }.map { it.getOrThrow() }.sorted() shouldBeEqualTo listOf(1, 3)
+        allResults.mapNotNull { it.exceptionOrNull() }.size shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `withSupervised results nullable T null 성공도 Result success 로 포함되어야 한다`() {
+        val allResults = provider.withSupervised<Int?, List<Result<Int?>>> { scope ->
+            scope.fork { 1 }
+            scope.fork { null }
+            scope.fork { 3 }
+            scope.join()
+            scope.results()
+        }
+        allResults.size shouldBeEqualTo 3
+        allResults.all { it.isSuccess }.shouldBeTrue()
     }
 
     @Test

--- a/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProviderTest.kt
+++ b/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProviderTest.kt
@@ -3,9 +3,14 @@ package io.bluetape4k.concurrent.virtualthread.jdk21
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
+import java.time.Instant
+import java.util.concurrent.TimeoutException
 import kotlin.test.assertFailsWith
 
 @EnabledForJreRange(min = JRE.JAVA_21)
@@ -41,6 +46,42 @@ class Jdk21StructuredTaskScopeProviderTest {
                 scope.fork<Int> { throw IllegalStateException("boom") }
                 scope.join().throwIfFailed()
                 0
+            }
+        }
+    }
+
+    @Test
+    fun `withSupervised 일부 성공 일부 실패 시 결과를 분리해야 한다`() {
+        val (successes, failures) = provider.withSupervised<Int, Pair<List<Int>, List<Throwable>>> { scope ->
+            scope.fork { 1 }
+            scope.fork { throw RuntimeException("fail") }
+            scope.fork { 3 }
+            scope.join()
+            scope.successfulResults() to scope.failedExceptions()
+        }
+        successes.sorted() shouldBeEqualTo listOf(1, 3)
+        failures.size shouldBeEqualTo 1
+        failures[0].shouldBeInstanceOf<RuntimeException>()
+    }
+
+    @Test
+    fun `withSupervised 모두 성공 시 successfulResults 에 전부 포함되어야 한다`() {
+        val (successes, failures) = provider.withSupervised<Int, Pair<List<Int>, List<Throwable>>> { scope ->
+            scope.fork { 10 }
+            scope.fork { 20 }
+            scope.join()
+            scope.successfulResults() to scope.failedExceptions()
+        }
+        successes.sorted() shouldBeEqualTo listOf(10, 20)
+        failures.size shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `withSupervised joinUntil 데드라인 초과 시 TimeoutException 이 발생해야 한다`() {
+        assertFailsWith<TimeoutException> {
+            provider.withSupervised<Int, Unit> { scope ->
+                scope.fork { Thread.sleep(10_000); 42 }
+                scope.joinUntil(Instant.now().plusMillis(100))
             }
         }
     }

--- a/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
+++ b/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
@@ -328,11 +328,10 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
             return this
         }
 
-        override fun successfulResults(): List<T> =
-            subtasks.filter { it.isSuccess() }
-                .map { it.get() }
-
-        override fun failedExceptions(): List<Throwable> = subtasks.mapNotNull { it.exceptionOrNull() }
+        override fun results(): List<Result<T>> = subtasks.map { subtask ->
+            val exc = subtask.exceptionOrNull()
+            if (exc != null) Result.failure(exc) else Result.success(subtask.get())
+        }
 
         override fun close() {
             try {

--- a/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
+++ b/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
@@ -4,12 +4,14 @@ import io.bluetape4k.concurrent.virtualthread.StructuredSubtask
 import io.bluetape4k.concurrent.virtualthread.StructuredTaskScopeAll
 import io.bluetape4k.concurrent.virtualthread.StructuredTaskScopeAny
 import io.bluetape4k.concurrent.virtualthread.StructuredTaskScopeProvider
+import io.bluetape4k.concurrent.virtualthread.StructuredTaskScopeSupervised
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.trace
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.Callable
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.StructuredTaskScope
 import java.util.concurrent.ThreadFactory
@@ -235,6 +237,70 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
 
         override fun close() {
             delegate.close()
+        }
+    }
+
+    override fun <T, R> withSupervised(
+        name: String?,
+        factory: ThreadFactory,
+        block: (scope: StructuredTaskScopeSupervised<T>) -> R,
+    ): R {
+        log.debug { "부분 실패를 허용하는 supervised scope를 실행합니다..." }
+        val scope = StructuredTaskScope.open<T, Void>(
+            StructuredTaskScope.Joiner.awaitAll(),
+            configure(name, factory)
+        )
+        return scope.use { block(Jdk25SupervisedScope(it)) }
+    }
+
+    private class Jdk25SupervisedScope<T>(
+        private val delegate: StructuredTaskScope<T, Void>,
+    ) : StructuredTaskScopeSupervised<T> {
+        private val subtasks = CopyOnWriteArrayList<Jdk25Subtask<T>>()
+
+        override fun fork(task: () -> T): StructuredSubtask<T> {
+            log.trace { "Add supervised sub task..." }
+            val subtask = Jdk25Subtask(delegate.fork(Callable { task() }))
+            subtasks += subtask
+            return subtask
+        }
+
+        override fun join(): StructuredTaskScopeSupervised<T> {
+            delegate.join()
+            return this
+        }
+
+        override fun joinUntil(deadline: Instant): StructuredTaskScopeSupervised<T> {
+            val remaining = Duration.between(Instant.now(), deadline)
+            if (remaining.isNegative || remaining.isZero) {
+                throw TimeoutException("Deadline already passed")
+            }
+            val ownerThread = Thread.currentThread()
+            val scheduler = ScheduledThreadPoolExecutor(1) { r -> Thread(r, "jdk25-supervised-timeout") }
+            scheduler.schedule({ ownerThread.interrupt() }, remaining.toMillis(), TimeUnit.MILLISECONDS)
+            try {
+                delegate.join()
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+                throw TimeoutException("joinUntil deadline exceeded")
+            } finally {
+                scheduler.shutdownNow()
+            }
+            return this
+        }
+
+        override fun successfulResults(): List<T> =
+            subtasks.filter { it.state() == StructuredTaskScope.Subtask.State.SUCCESS }
+                .mapNotNull { it.getOrNull() }
+
+        override fun failedExceptions(): List<Throwable> = subtasks.mapNotNull { it.exceptionOrNull() }
+
+        override fun close() {
+            try {
+                delegate.close()
+            } finally {
+                subtasks.clear()
+            }
         }
     }
 }

--- a/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
+++ b/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
@@ -159,7 +159,7 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
     private class Jdk25AllScope(
         private val delegate: StructuredTaskScope<Any?, Void>,
     ): StructuredTaskScopeAll {
-        private val subtasks = mutableListOf<Jdk25Subtask<*>>()
+        private val subtasks = CopyOnWriteArrayList<Jdk25Subtask<*>>()
 
         override fun <T> fork(task: () -> T): StructuredSubtask<T> {
             log.trace { "Add sub task..." }
@@ -179,14 +179,24 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
                 throw TimeoutException("Deadline already passed")
             }
             val ownerThread = Thread.currentThread()
-            val scheduler = ScheduledThreadPoolExecutor(1) { r -> Thread(r, "jdk25-scope-timeout") }
-            scheduler.schedule({ ownerThread.interrupt() }, remaining.toMillis(), TimeUnit.MILLISECONDS)
+            val scheduler = ScheduledThreadPoolExecutor(1) { r ->
+                Thread(r, "jdk25-scope-timeout").apply { isDaemon = true }
+            }
+            val timeoutFuture = scheduler.schedule(
+                { ownerThread.interrupt() },
+                remaining.toMillis(),
+                TimeUnit.MILLISECONDS
+            )
             try {
                 delegate.join()
+                // 성공적으로 join된 경우, 타이머가 이미 발동됐을 수 있는 spurious interrupt를 클리어
+                Thread.interrupted()
             } catch (e: InterruptedException) {
-                Thread.currentThread().interrupt()
+                // 타이머가 발생시킨 interrupt — 소비하고 TimeoutException으로 변환
+                Thread.interrupted()
                 throw TimeoutException("joinUntil deadline exceeded")
             } finally {
+                timeoutFuture.cancel(false)
                 scheduler.shutdownNow()
             }
             return this
@@ -240,6 +250,25 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
         }
     }
 
+    /**
+     * JDK25 `Joiner.awaitAll()`을 사용하여 부분 실패 허용 scope를 실행합니다.
+     *
+     * ## 동작/계약
+     * - `StructuredTaskScope.open<T, Void>(Joiner.awaitAll(), ...)`로 scope를 생성합니다.
+     * - `awaitAll()`은 subtask 실패 시에도 나머지를 취소하지 않고 모두 완료까지 기다립니다.
+     * - join 후 [Jdk25SupervisedScope.successfulResults]와 [Jdk25SupervisedScope.failedExceptions]로 결과를 분리합니다.
+     *
+     * ```kotlin
+     * val (successes, errors) = Jdk25StructuredTaskScopeProvider().withSupervised<Int, Pair<List<Int>, List<Throwable>>> { scope ->
+     *     scope.fork { 1 }
+     *     scope.fork { throw RuntimeException("fail") }
+     *     scope.fork { 3 }
+     *     scope.join()
+     *     scope.successfulResults() to scope.failedExceptions()
+     * }
+     * // successes = [1, 3], errors.size = 1
+     * ```
+     */
     override fun <T, R> withSupervised(
         name: String?,
         factory: ThreadFactory,
@@ -276,22 +305,32 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
                 throw TimeoutException("Deadline already passed")
             }
             val ownerThread = Thread.currentThread()
-            val scheduler = ScheduledThreadPoolExecutor(1) { r -> Thread(r, "jdk25-supervised-timeout") }
-            scheduler.schedule({ ownerThread.interrupt() }, remaining.toMillis(), TimeUnit.MILLISECONDS)
+            val scheduler = ScheduledThreadPoolExecutor(1) { r ->
+                Thread(r, "jdk25-supervised-timeout").apply { isDaemon = true }
+            }
+            val timeoutFuture = scheduler.schedule(
+                { ownerThread.interrupt() },
+                remaining.toMillis(),
+                TimeUnit.MILLISECONDS
+            )
             try {
                 delegate.join()
+                // 성공적으로 join된 경우, 타이머가 이미 발동됐을 수 있는 spurious interrupt를 클리어
+                Thread.interrupted()
             } catch (e: InterruptedException) {
-                Thread.currentThread().interrupt()
+                // 타이머가 발생시킨 interrupt — 소비하고 TimeoutException으로 변환
+                Thread.interrupted()
                 throw TimeoutException("joinUntil deadline exceeded")
             } finally {
+                timeoutFuture.cancel(false)
                 scheduler.shutdownNow()
             }
             return this
         }
 
         override fun successfulResults(): List<T> =
-            subtasks.filter { it.state() == StructuredTaskScope.Subtask.State.SUCCESS }
-                .mapNotNull { it.getOrNull() }
+            subtasks.filter { it.isSuccess() }
+                .map { it.get() }
 
         override fun failedExceptions(): List<Throwable> = subtasks.mapNotNull { it.exceptionOrNull() }
 

--- a/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderTest.kt
+++ b/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderTest.kt
@@ -3,9 +3,12 @@ package io.bluetape4k.concurrent.virtualthread.jdk25
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledOnJre
 import org.junit.jupiter.api.condition.JRE
+import java.time.Instant
+import java.util.concurrent.TimeoutException
 import kotlin.test.assertFailsWith
 
 @EnabledOnJre(JRE.JAVA_25)
@@ -42,6 +45,42 @@ class Jdk25StructuredTaskScopeProviderTest {
                 scope.fork<Int> { error("boom") }
                 scope.join().throwIfFailed()
                 0
+            }
+        }
+    }
+
+    @Test
+    fun `withSupervised 일부 성공 일부 실패 시 결과를 분리해야 한다`() {
+        val (successes, failures) = provider.withSupervised<Int, Pair<List<Int>, List<Throwable>>> { scope ->
+            scope.fork { 1 }
+            scope.fork { throw RuntimeException("fail") }
+            scope.fork { 3 }
+            scope.join()
+            scope.successfulResults() to scope.failedExceptions()
+        }
+        successes.sorted() shouldBeEqualTo listOf(1, 3)
+        failures.size shouldBeEqualTo 1
+        failures[0].shouldBeInstanceOf<RuntimeException>()
+    }
+
+    @Test
+    fun `withSupervised 모두 성공 시 successfulResults 에 전부 포함되어야 한다`() {
+        val (successes, failures) = provider.withSupervised<Int, Pair<List<Int>, List<Throwable>>> { scope ->
+            scope.fork { 10 }
+            scope.fork { 20 }
+            scope.join()
+            scope.successfulResults() to scope.failedExceptions()
+        }
+        successes.sorted() shouldBeEqualTo listOf(10, 20)
+        failures.size shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `withSupervised joinUntil 데드라인 초과 시 TimeoutException 이 발생해야 한다`() {
+        assertFailsWith<TimeoutException> {
+            provider.withSupervised<Int, Unit> { scope ->
+                scope.fork { Thread.sleep(10_000); 42 }
+                scope.joinUntil(Instant.now().plusMillis(100))
             }
         }
     }

--- a/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderTest.kt
+++ b/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderTest.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldBeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledOnJre
 import org.junit.jupiter.api.condition.JRE
@@ -83,6 +84,33 @@ class Jdk25StructuredTaskScopeProviderTest {
                 scope.joinUntil(Instant.now().plusMillis(100))
             }
         }
+    }
+
+    @Test
+    fun `withSupervised results 일부 성공 일부 실패 시 Result 리스트를 반환해야 한다`() {
+        val allResults = provider.withSupervised<Int, List<Result<Int>>> { scope ->
+            scope.fork { 1 }
+            scope.fork { throw RuntimeException("fail") }
+            scope.fork { 3 }
+            scope.join()
+            scope.results()
+        }
+        allResults.size shouldBeEqualTo 3
+        allResults.filter { it.isSuccess }.map { it.getOrThrow() }.sorted() shouldBeEqualTo listOf(1, 3)
+        allResults.mapNotNull { it.exceptionOrNull() }.size shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `withSupervised results nullable T null 성공도 Result success 로 포함되어야 한다`() {
+        val allResults = provider.withSupervised<Int?, List<Result<Int?>>> { scope ->
+            scope.fork { 1 }
+            scope.fork { null }
+            scope.fork { 3 }
+            scope.join()
+            scope.results()
+        }
+        allResults.size shouldBeEqualTo 3
+        allResults.all { it.isSuccess }.shouldBeTrue()
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #252

- PR 제목: feat: StructuredTaskScopeSupervised 부분 실패 허용 scope 추가 (#252)

Issue #252: 부분 실패를 허용하는 `StructuredTaskScopeSupervised<T>` 구현.

모든 subtask를 완료까지 실행하며, 성공 결과와 실패 예외를 별도로 수집합니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 신규 API (`virtualthread/api`)
- `StructuredTaskScopeSupervised<T>` 인터페이스: `fork`, `join`, `joinUntil`, `successfulResults`, `failedExceptions`, `close`
- `StructuredTaskScopes.supervised<T,R>()` 진입 함수
- `StructuredTaskScopeProvider.withSupervised<T,R>()` 추상 메서드
- `structuredTaskScopeSupervised<T,R>()` 확장 함수 (core 모듈)

### JDK21 구현 (`virtualthread/jdk21`)
- `Jdk21SupervisedTaskScope<T>`: `StructuredTaskScope<T>` 상속, `handleComplete()` 오버라이드
- `CopyOnWriteArrayList`로 thread-safe 결과 수집

### JDK25 구현 (`virtualthread/jdk25`)
- `Jdk25SupervisedScope<T>`: `Joiner.awaitAll()` 사용 (실패 시 취소 없음)
- `CopyOnWriteArrayList`로 subtask 추적

### 6-tier 코드 리뷰 반영 수정
- **\[CRITICAL\]** `successfulResults()`: `mapNotNull` → `map { it.get() }` (nullable T 드롭 방지)
- **\[HIGH\]** `joinUntil` interrupt 처리: isDaemon=true, spurious interrupt 클리어
- **\[HIGH\]** `Jdk25AllScope.subtasks`: `CopyOnWriteArrayList`로 교체
- **\[HIGH\]** `Jdk21SupervisedScope.close()`: 플랫폼 타입 경고 제거 (블록 바디)
- **\[HIGH\]** `withSupervised` override KDoc 추가 (jdk21/jdk25)

### 기존 섹션: 검증 명령어

```bash
./gradlew :bluetape4k-virtualthread-api:test :bluetape4k-virtualthread-jdk21:test
```

## Validation

```
모듈: :bluetape4k-virtualthread-api + :bluetape4k-virtualthread-jdk21
결과: 37 passing (0 failed, 0 skipped)
```

테스트 커버리지:
- partial success/fail (성공/실패 분리)
- all-success (전체 성공)
- all-fail (전체 실패)
- nullable T (null 성공 결과 포함)
- thread-safety stress (100 tasks 병렬)
- joinUntil 데드라인 초과
- empty fork
- subtask 상태 검증
- per-provider 테스트 (jdk21, jdk25 각각)

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #252, milestone 없음, assignee `debop`
- PR: #270, head `bbb16c830cc6858e66d7a55401953544fa75cc52`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/supervised-scope`
- Labels: `enhancement`
- State: `MERGED`, merge commit `3fbe44e329df325738086b630fd2f09ae503558f`
- CI: ./gradlew :bluetape4k-virtualthread-api:test :bluetape4k-virtualthread-jdk21:test

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #270 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `3fbe44e329df325738086b630fd2f09ae503558f`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
