### PR TITLE
feat: ScopedValue 기반 TaskContext — Virtual Thread 컨텍스트 전파 유틸리티 (#253)

### DIFF
--- a/virtualthread/README.ko.md
+++ b/virtualthread/README.ko.md
@@ -142,6 +142,66 @@ sequenceDiagram
 - **Platform Thread 폴백**: JDK 17 이하에서는 플랫폼 스레드로 자연스럽게 대체
 - **통합 API**: 애플리케이션 코드는 `api` 모듈에만 의존 — 런타임별 임포트 불필요
 - **JDK 25 추가 기능**: `joinUntil(Instant)` — 데드라인까지 가상 스레드를 대기 (JDK 25 전용)
+- **TaskContext**: `ScopedValue` 기반 컨텍스트 전파 — `StructuredTaskScope.fork()` subtask에 자동 상속
+
+## TaskContext — ScopedValue 기반 컨텍스트 전파
+
+`TaskContext`는 `ScopedValue`를 래핑하여 가상 스레드 간 안전하고 immutable한 컨텍스트 전파를 제공합니다.
+`ThreadLocal`과 달리, `ScopedValue` 바인딩은 스코프를 벗어나면 자동으로 해제되며 누출되지 않습니다.
+
+> **주의**: 바인딩은 `StructuredTaskScope.fork()`로 생성된 스레드에만 자동 전파됩니다.
+> 일반 `Thread.ofVirtual().start {}`로 생성된 스레드는 바인딩을 **상속하지 않습니다**.
+
+```kotlin
+val REQUEST_ID: ScopedValue<String> = TaskContext.newKey()
+val TENANT_ID:  ScopedValue<String> = TaskContext.newKey()
+
+// 단일 바인딩 — top-level 함수 스타일 (권장)
+withTaskContext(REQUEST_ID, "req-001") {
+    println(TaskContext.get(REQUEST_ID))  // "req-001"
+
+    // forked subtask에 자동 전파
+    StructuredTaskScopes.failFast { scope ->
+        val result = scope.fork { TaskContext.get(REQUEST_ID) }
+        scope.join().throwIfFailed()
+        result.get()  // "req-001"
+    }
+}
+
+// 단일 바인딩 — 멤버 함수 스타일
+TaskContext.run(REQUEST_ID, "req-001") {
+    println(TaskContext.get(REQUEST_ID))  // "req-001"
+}
+
+// 다중 바인딩
+TaskContext.bind(REQUEST_ID, "req-001")
+    .and(TENANT_ID, "tenant-42")
+    .run {
+        println(TaskContext.get(REQUEST_ID))  // "req-001"
+        println(TaskContext.get(TENANT_ID))   // "tenant-42"
+    }
+
+// supervised scope 에서 Result<T> 수집
+val results: List<Result<String>> =
+    withTaskContext(REQUEST_ID, "req-001") {
+        StructuredTaskScopes.supervised<String, List<Result<String>>> { scope ->
+            scope.fork { TaskContext.get(REQUEST_ID) ?: "" }
+            scope.fork { TaskContext.get(REQUEST_ID) ?: "" }
+            scope.join()
+            scope.results()
+        }
+    }
+```
+
+| API | 설명 |
+|-----|------|
+| `TaskContext.newKey<T>()` | 타입 안전 `ScopedValue` 키 생성 |
+| `TaskContext.get(key)` | 바인딩된 값 반환, 미바인딩 시 `null` |
+| `TaskContext.getOrDefault(key, default)` | 바인딩된 값 반환, 미바인딩 시 기본값 |
+| `TaskContext.isBound(key)` | 현재 스코프에서 키 바인딩 여부 확인 |
+| `TaskContext.run(key, value) {}` | 단일 바인딩 스코프 블록 |
+| `withTaskContext(key, value) {}` | `TaskContext.run`의 top-level 별칭 (권장) |
+| `TaskContext.bind(key, value).and(...).run {}` | 다중 바인딩 스코프 블록 |
 
 ## 사용 방식
 

--- a/virtualthread/README.md
+++ b/virtualthread/README.md
@@ -142,6 +142,66 @@ sequenceDiagram
 - **Platform thread fallback**: Gracefully degrades to platform threads on JDK 17 and below
 - **Unified API**: Application code depends only on the `api` module — no runtime-specific imports needed
 - **JDK 25 extras**: `joinUntil(Instant)` — wait for a virtual thread until a deadline (JDK 25 only)
+- **TaskContext**: `ScopedValue`-based context propagation across `StructuredTaskScope.fork()` subtasks
+
+## TaskContext — ScopedValue Context Propagation
+
+`TaskContext` wraps `ScopedValue` to provide safe, immutable context propagation across virtual threads.
+Unlike `ThreadLocal`, a `ScopedValue` binding is confined to its scope and never leaks.
+
+> **Note**: Bindings are automatically inherited by threads created via `StructuredTaskScope.fork()`.
+> Plain `Thread.ofVirtual().start {}` does **not** inherit bindings.
+
+```kotlin
+val REQUEST_ID: ScopedValue<String> = TaskContext.newKey()
+val TENANT_ID:  ScopedValue<String> = TaskContext.newKey()
+
+// Single binding — top-level style (preferred)
+withTaskContext(REQUEST_ID, "req-001") {
+    println(TaskContext.get(REQUEST_ID))  // "req-001"
+
+    // Automatically propagated to forked subtasks
+    StructuredTaskScopes.failFast { scope ->
+        val result = scope.fork { TaskContext.get(REQUEST_ID) }
+        scope.join().throwIfFailed()
+        result.get()  // "req-001"
+    }
+}
+
+// Single binding — member function style
+TaskContext.run(REQUEST_ID, "req-001") {
+    println(TaskContext.get(REQUEST_ID))  // "req-001"
+}
+
+// Multiple bindings
+TaskContext.bind(REQUEST_ID, "req-001")
+    .and(TENANT_ID, "tenant-42")
+    .run {
+        println(TaskContext.get(REQUEST_ID))  // "req-001"
+        println(TaskContext.get(TENANT_ID))   // "tenant-42"
+    }
+
+// With supervised scope — collect Result<T> per subtask
+val results: List<Result<String>> =
+    withTaskContext(REQUEST_ID, "req-001") {
+        StructuredTaskScopes.supervised<String, List<Result<String>>> { scope ->
+            scope.fork { TaskContext.get(REQUEST_ID) ?: "" }
+            scope.fork { TaskContext.get(REQUEST_ID) ?: "" }
+            scope.join()
+            scope.results()
+        }
+    }
+```
+
+| API | Description |
+|-----|-------------|
+| `TaskContext.newKey<T>()` | Create a new type-safe `ScopedValue` key |
+| `TaskContext.get(key)` | Get the bound value, or `null` if unbound |
+| `TaskContext.getOrDefault(key, default)` | Get the bound value with a fallback |
+| `TaskContext.isBound(key)` | Check if a key is bound in the current scope |
+| `TaskContext.run(key, value) {}` | Single-binding scope block |
+| `withTaskContext(key, value) {}` | Top-level alias for `TaskContext.run` |
+| `TaskContext.bind(key, value).and(...).run {}` | Multi-binding scope block |
 
 ## Usage
 

--- a/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/TaskContext.kt
+++ b/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/TaskContext.kt
@@ -114,20 +114,6 @@ object TaskContext {
 }
 
 /**
- * 여러 [ScopedValue] 바인딩을 체이닝하는 빌더입니다.
- *
- * [TaskContext.bind]로 시작하고 [and]로 추가한 뒤 [run] 또는 [call]로 실행합니다.
- *
- * ```kotlin
- * TaskContext.bind(A_KEY, "a")
- *     .and(B_KEY, 42)
- *     .run {
- *         println(TaskContext.get(A_KEY))  // "a"
- *         println(TaskContext.get(B_KEY))  // 42
- *     }
- * ```
- */
-/**
  * [key]=[value] 단일 바인딩 스코프를 실행하고 결과를 반환하는 top-level 함수입니다.
  *
  * [TaskContext.run]과 동일하지만 Kotlin `with*` 관용구(`withContext`, `withLock` 등)와 일관된 이름입니다.
@@ -151,6 +137,20 @@ object TaskContext {
 fun <T, R> withTaskContext(key: ScopedValue<T>, value: T, block: () -> R): R =
     TaskContext.run(key, value, block)
 
+/**
+ * 여러 [ScopedValue] 바인딩을 체이닝하는 빌더입니다.
+ *
+ * [TaskContext.bind]로 시작하고 [and]로 추가한 뒤 [run] 또는 [call]로 실행합니다.
+ *
+ * ```kotlin
+ * TaskContext.bind(A_KEY, "a")
+ *     .and(B_KEY, 42)
+ *     .run {
+ *         println(TaskContext.get(A_KEY))  // "a"
+ *         println(TaskContext.get(B_KEY))  // 42
+ *     }
+ * ```
+ */
 class TaskContextBindings internal constructor(
     private val carrier: ScopedValue.Carrier,
 ) {

--- a/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/TaskContext.kt
+++ b/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/TaskContext.kt
@@ -1,0 +1,172 @@
+package io.bluetape4k.concurrent.virtualthread
+
+import java.lang.ScopedValue
+
+/**
+ * ScopedValue 기반 컨텍스트 전파 유틸리티입니다.
+ *
+ * Virtual Thread 간 안전한 컨텍스트 전파를 위해 [ScopedValue]를 래핑합니다.
+ * `ThreadLocal`과 달리 [ScopedValue]는 immutable하며 스코프 바깥으로 누출되지 않습니다.
+ *
+ * ## 자동 전파
+ * [ScopedValue]는 [StructuredTaskScope][java.util.concurrent.StructuredTaskScope]의 `fork`로
+ * 생성된 Virtual Thread에 자동으로 전파됩니다.
+ * 별도 설정 없이 부모 스코프의 바인딩이 모든 forked subtask에서 조회 가능합니다.
+ *
+ * ## JDK 버전별 API
+ * - JDK 21: Preview API — `--enable-preview` 컴파일/실행 플래그 필요
+ * - JDK 25: Stable API — 추가 플래그 불필요
+ *
+ * ## 코루틴과의 호환성
+ * [ScopedValue]는 코루틴 중단점(suspension point)을 가로지르지 않습니다.
+ * 코루틴 컨텍스트 전파가 필요하면 `ThreadLocal` + `asContextElement()`를 사용하세요.
+ *
+ * ```kotlin
+ * val REQUEST_ID = TaskContext.newKey<String>()
+ *
+ * // 단일 바인딩 — top-level 함수 스타일 (권장)
+ * withTaskContext(REQUEST_ID, "req-001") {
+ *     println(TaskContext.get(REQUEST_ID))  // "req-001"
+ *     StructuredTaskScopes.failFast { scope ->
+ *         scope.fork { TaskContext.get(REQUEST_ID) }  // 자동 전파됨
+ *         scope.join().throwIfFailed()
+ *     }
+ * }
+ *
+ * // 단일 바인딩 — object 멤버 함수 스타일
+ * TaskContext.run(REQUEST_ID, "req-001") {
+ *     println(TaskContext.get(REQUEST_ID))  // "req-001"
+ * }
+ *
+ * // 다중 바인딩
+ * TaskContext.bind(REQUEST_ID, "req-001")
+ *     .and(TENANT_ID, "tenant-42")
+ *     .run {
+ *         println(TaskContext.get(REQUEST_ID))  // "req-001"
+ *         println(TaskContext.get(TENANT_ID))   // "tenant-42"
+ *     }
+ * ```
+ */
+object TaskContext {
+
+    /**
+     * 새로운 타입 안전 컨텍스트 키를 생성합니다.
+     *
+     * ```kotlin
+     * val REQUEST_ID: ScopedValue<String> = TaskContext.newKey()
+     * val USER_ID: ScopedValue<Long> = TaskContext.newKey()
+     * ```
+     *
+     * @return 새로운 [ScopedValue] 인스턴스
+     */
+    fun <T> newKey(): ScopedValue<T> = ScopedValue.newInstance()
+
+    /**
+     * 현재 스코프에서 [key]에 바인딩된 값을 반환합니다.
+     * 바인딩되지 않은 경우 `null`을 반환합니다.
+     *
+     * ```kotlin
+     * val value: String? = TaskContext.get(REQUEST_ID)
+     * ```
+     */
+    fun <T> get(key: ScopedValue<T>): T? = if (key.isBound) key.get() else null
+
+    /**
+     * 현재 스코프에서 [key]에 바인딩된 값을 반환합니다.
+     * 바인딩되지 않은 경우 [defaultValue]를 반환합니다.
+     */
+    fun <T> getOrDefault(key: ScopedValue<T>, defaultValue: T): T =
+        if (key.isBound) key.get() else defaultValue
+
+    /**
+     * 현재 스코프에서 [key]가 바인딩되어 있는지 확인합니다.
+     */
+    fun isBound(key: ScopedValue<*>): Boolean = key.isBound
+
+    /**
+     * [key]=[value] 바인딩 블록을 실행하고 결과를 반환합니다.
+     * 블록 내 모든 코드 (forked subtask 포함) 에서 [key]로 [value]를 조회할 수 있습니다.
+     *
+     * top-level [withTaskContext] 함수와 동일합니다.
+     *
+     * ```kotlin
+     * val result = TaskContext.run(REQUEST_ID, "req-001") {
+     *     doWork()  // REQUEST_ID 바인딩 범위 내
+     * }
+     * ```
+     */
+    fun <T, R> run(key: ScopedValue<T>, value: T, block: () -> R): R =
+        ScopedValue.where(key, value).call { block() }
+
+    /**
+     * [key]=[value] 첫 번째 바인딩으로 [TaskContextBindings] 빌더를 시작합니다.
+     * [TaskContextBindings.and]로 바인딩을 추가하고 [TaskContextBindings.run] 또는
+     * [TaskContextBindings.call]로 실행합니다.
+     *
+     * ```kotlin
+     * TaskContext.bind(REQUEST_ID, "req-001")
+     *     .and(TENANT_ID, "tenant-42")
+     *     .run { doWork() }
+     * ```
+     */
+    fun <T> bind(key: ScopedValue<T>, value: T): TaskContextBindings =
+        TaskContextBindings(ScopedValue.where(key, value))
+}
+
+/**
+ * 여러 [ScopedValue] 바인딩을 체이닝하는 빌더입니다.
+ *
+ * [TaskContext.bind]로 시작하고 [and]로 추가한 뒤 [run] 또는 [call]로 실행합니다.
+ *
+ * ```kotlin
+ * TaskContext.bind(A_KEY, "a")
+ *     .and(B_KEY, 42)
+ *     .run {
+ *         println(TaskContext.get(A_KEY))  // "a"
+ *         println(TaskContext.get(B_KEY))  // 42
+ *     }
+ * ```
+ */
+/**
+ * [key]=[value] 단일 바인딩 스코프를 실행하고 결과를 반환하는 top-level 함수입니다.
+ *
+ * [TaskContext.run]과 동일하지만 Kotlin `with*` 관용구(`withContext`, `withLock` 등)와 일관된 이름입니다.
+ *
+ * ```kotlin
+ * val result = withTaskContext(REQUEST_ID, "req-001") {
+ *     doWork()  // REQUEST_ID 바인딩 범위 내
+ * }
+ *
+ * // StructuredTaskScope.fork 에서 자동 전파
+ * withTaskContext(REQUEST_ID, "req-001") {
+ *     StructuredTaskScopes.failFast { scope ->
+ *         scope.fork { TaskContext.get(REQUEST_ID) }  // "req-001" 자동 상속
+ *         scope.join().throwIfFailed()
+ *     }
+ * }
+ * ```
+ *
+ * @see TaskContext.run
+ */
+fun <T, R> withTaskContext(key: ScopedValue<T>, value: T, block: () -> R): R =
+    TaskContext.run(key, value, block)
+
+class TaskContextBindings internal constructor(
+    private val carrier: ScopedValue.Carrier,
+) {
+    /**
+     * 바인딩을 추가합니다.
+     */
+    fun <T> and(key: ScopedValue<T>, value: T): TaskContextBindings =
+        TaskContextBindings(carrier.where(key, value))
+
+    /**
+     * 모든 바인딩을 적용하고 [block]을 실행합니다.
+     */
+    fun run(block: () -> Unit): Unit = carrier.run(block)
+
+    /**
+     * 모든 바인딩을 적용하고 [block]을 실행한 뒤 결과를 반환합니다.
+     */
+    fun <R> call(block: () -> R): R = carrier.call { block() }
+}

--- a/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt
+++ b/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt
@@ -14,7 +14,7 @@ import java.time.Instant
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.StructuredTaskScope
 import java.util.concurrent.TimeoutException
-import kotlin.test.assertFailsWith
+import org.amshove.kluent.internal.assertFailsWith
 
 /**
  * [StructuredTaskScopes], [StructuredTaskScopeProvider], [StructuredSubtask], [StructuredTaskScopeAll],

--- a/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/TaskContextTest.kt
+++ b/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/TaskContextTest.kt
@@ -1,0 +1,324 @@
+package io.bluetape4k.concurrent.virtualthread
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import java.lang.ScopedValue
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * [TaskContext] — ScopedValue 기반 컨텍스트 전파 테스트
+ */
+class TaskContextTest {
+
+    companion object : KLogging()
+
+    // ── 키 생성 ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `newKey 는 새로운 ScopedValue 인스턴스를 반환한다`() {
+        val key1: ScopedValue<String> = TaskContext.newKey()
+        val key2: ScopedValue<String> = TaskContext.newKey()
+        (key1 !== key2).shouldBeTrue()
+    }
+
+    // ── 단일 바인딩 ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `run 으로 단일 키 바인딩 후 get 으로 값을 조회한다`() {
+        val key = TaskContext.newKey<String>()
+
+        val result = TaskContext.run(key, "req-001") {
+            TaskContext.get(key)
+        }
+
+        result shouldBeEqualTo "req-001"
+    }
+
+    @Test
+    fun `run 블록 외부에서 get 은 null 을 반환한다`() {
+        val key = TaskContext.newKey<String>()
+        TaskContext.get(key).shouldBeNull()
+    }
+
+    @Test
+    fun `isBound 는 바인딩 스코프 내에서 true 를 반환한다`() {
+        val key = TaskContext.newKey<Int>()
+
+        TaskContext.isBound(key).shouldBeFalse()
+
+        TaskContext.run(key, 42) {
+            TaskContext.isBound(key).shouldBeTrue()
+        }
+
+        TaskContext.isBound(key).shouldBeFalse()
+    }
+
+    @Test
+    fun `getOrDefault 는 바인딩되지 않은 경우 기본값을 반환한다`() {
+        val key = TaskContext.newKey<String>()
+
+        val value = TaskContext.getOrDefault(key, "default")
+        value shouldBeEqualTo "default"
+    }
+
+    @Test
+    fun `getOrDefault 는 바인딩된 경우 바인딩값을 반환한다`() {
+        val key = TaskContext.newKey<String>()
+
+        val value = TaskContext.run(key, "bound") {
+            TaskContext.getOrDefault(key, "default")
+        }
+
+        value shouldBeEqualTo "bound"
+    }
+
+    @Test
+    fun `run 블록의 반환값이 올바르게 전달된다`() {
+        val key = TaskContext.newKey<Int>()
+
+        val result = TaskContext.run(key, 10) {
+            TaskContext.get(key)!! * 2
+        }
+
+        result shouldBeEqualTo 20
+    }
+
+    // ── 다중 바인딩 ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `bind-and 체이닝으로 여러 키를 동시에 바인딩한다`() {
+        val requestId = TaskContext.newKey<String>()
+        val tenantId = TaskContext.newKey<String>()
+
+        TaskContext.bind(requestId, "req-001")
+            .and(tenantId, "tenant-42")
+            .run {
+                TaskContext.get(requestId) shouldBeEqualTo "req-001"
+                TaskContext.get(tenantId) shouldBeEqualTo "tenant-42"
+            }
+    }
+
+    @Test
+    fun `bind-and-call 체이닝으로 결과를 반환한다`() {
+        val key1 = TaskContext.newKey<Int>()
+        val key2 = TaskContext.newKey<Int>()
+
+        val result = TaskContext.bind(key1, 10)
+            .and(key2, 20)
+            .call {
+                TaskContext.get(key1)!! + TaskContext.get(key2)!!
+            }
+
+        result shouldBeEqualTo 30
+    }
+
+    @Test
+    fun `중첩 바인딩에서 내부 스코프가 외부 스코프를 섀도잉한다`() {
+        val key = TaskContext.newKey<String>()
+
+        TaskContext.run(key, "outer") {
+            TaskContext.get(key) shouldBeEqualTo "outer"
+
+            TaskContext.run(key, "inner") {
+                TaskContext.get(key) shouldBeEqualTo "inner"
+            }
+
+            // 내부 스코프 종료 후 외부값 복원
+            TaskContext.get(key) shouldBeEqualTo "outer"
+        }
+    }
+
+    // ── Virtual Thread forked subtask 자동 전파 ───────────────────────────────
+
+    @Test
+    fun `일반 Virtual Thread 는 ScopedValue 를 상속하지 않는다`() {
+        val requestId = TaskContext.newKey<String>()
+        val collected = CopyOnWriteArrayList<String?>()
+
+        TaskContext.run(requestId, "req-vthread") {
+            // Thread.ofVirtual()로 직접 생성한 스레드는 부모의 ScopedValue 바인딩을 상속하지 않음
+            val threads = (1..4).map {
+                Thread.ofVirtual().start {
+                    collected.add(TaskContext.get(requestId))  // null 반환 예상
+                }
+            }
+            threads.forEach { it.join() }
+        }
+
+        collected.size shouldBeEqualTo 4
+        collected.all { it == null }.shouldBeTrue()
+    }
+
+    @Test
+    fun `StructuredTaskScope fork 로 생성된 Virtual Thread 는 ScopedValue 를 자동 상속한다`() {
+        val requestId = TaskContext.newKey<String>()
+        val collected = CopyOnWriteArrayList<String>()
+
+        TaskContext.run(requestId, "req-vthread") {
+            StructuredTaskScopes.failFast { scope ->
+                val subtasks = (1..4).map { i ->
+                    scope.fork {
+                        val value = TaskContext.get(requestId)
+                        log.debug { "Subtask $i 수신: $value" }
+                        value?.let { collected.add(it) }
+                        value
+                    }
+                }
+                scope.join().throwIfFailed()
+                subtasks.map { it.get() }
+            }
+        }
+
+        collected.size shouldBeEqualTo 4
+        collected.all { it == "req-vthread" }.shouldBeTrue()
+    }
+
+    @Test
+    fun `StructuredTaskScopes fork 에서 ScopedValue 가 자동 전파된다`() {
+        val requestId = TaskContext.newKey<String>()
+        val tenantId = TaskContext.newKey<String>()
+
+        val results = TaskContext.bind(requestId, "req-777")
+            .and(tenantId, "tenant-99")
+            .call {
+                StructuredTaskScopes.failFast { scope ->
+                    val a = scope.fork { TaskContext.get(requestId) }
+                    val b = scope.fork { TaskContext.get(tenantId) }
+                    scope.join().throwIfFailed()
+                    listOf(a.get(), b.get())
+                }
+            }
+
+        results[0] shouldBeEqualTo "req-777"
+        results[1] shouldBeEqualTo "tenant-99"
+    }
+
+    @Test
+    fun `supervised scope fork 에서 ScopedValue 가 자동 전파된다`() {
+        val traceId = TaskContext.newKey<String>()
+
+        val taskResults = TaskContext.run(traceId, "trace-abc") {
+            StructuredTaskScopes.supervised<String, List<Result<String>>> { scope ->
+                scope.fork { TaskContext.get(traceId) ?: "NOT_FOUND" }
+                scope.fork { TaskContext.get(traceId) ?: "NOT_FOUND" }
+                scope.join()
+                scope.results()
+            }
+        }
+
+        taskResults.size shouldBeEqualTo 2
+        taskResults.all { it.isSuccess }.shouldBeTrue()
+        taskResults.all { it.getOrThrow() == "trace-abc" }.shouldBeTrue()
+    }
+
+    // ── Nullable T ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `nullable 타입 T 에서 null 값을 바인딩할 수 있다`() {
+        val key = TaskContext.newKey<String?>()
+
+        val result = TaskContext.run(key, null) {
+            TaskContext.isBound(key).shouldBeTrue()
+            TaskContext.get(key)
+        }
+
+        // null이 바인딩되어 있어도 get()은 null을 반환 (isBound=true이지만 값이 null)
+        result.shouldBeNull()
+    }
+
+    // ── 스코프 격리 ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `서로 다른 바인딩 스코프는 독립적으로 동작한다`() {
+        val key = TaskContext.newKey<String>()
+
+        var scope1Value: String? = null
+        var scope2Value: String? = null
+
+        val t1 = Thread.ofVirtual().start {
+            TaskContext.run(key, "scope-1") {
+                Thread.sleep(50)
+                scope1Value = TaskContext.get(key)
+            }
+        }
+
+        val t2 = Thread.ofVirtual().start {
+            TaskContext.run(key, "scope-2") {
+                Thread.sleep(50)
+                scope2Value = TaskContext.get(key)
+            }
+        }
+
+        t1.join()
+        t2.join()
+
+        scope1Value shouldBeEqualTo "scope-1"
+        scope2Value shouldBeEqualTo "scope-2"
+    }
+
+    // ── withTaskContext top-level 함수 ────────────────────────────────────────
+
+    @Test
+    fun `withTaskContext 는 TaskContext run 과 동일하게 동작한다`() {
+        val key = TaskContext.newKey<String>()
+
+        val result = withTaskContext(key, "top-level") {
+            TaskContext.get(key)
+        }
+
+        result shouldBeEqualTo "top-level"
+    }
+
+    @Test
+    fun `withTaskContext 블록 내부에서 StructuredTaskScope fork 에 자동 전파된다`() {
+        val requestId = TaskContext.newKey<String>()
+
+        val values = withTaskContext(requestId, "req-tl") {
+            StructuredTaskScopes.failFast { scope ->
+                val a = scope.fork { TaskContext.get(requestId) }
+                val b = scope.fork { TaskContext.get(requestId) }
+                scope.join().throwIfFailed()
+                listOf(a.get(), b.get())
+            }
+        }
+
+        values.all { it == "req-tl" }.shouldBeTrue()
+    }
+
+    // ── TaskContextBindings ───────────────────────────────────────────────────
+
+    @Test
+    fun `TaskContextBindings run 블록 내부에서 모든 바인딩을 조회할 수 있다`() {
+        val a = TaskContext.newKey<Int>()
+        val b = TaskContext.newKey<Int>()
+        val c = TaskContext.newKey<Int>()
+
+        var sumInside = 0
+
+        TaskContext.bind(a, 1)
+            .and(b, 2)
+            .and(c, 3)
+            .run {
+                sumInside = TaskContext.get(a)!! + TaskContext.get(b)!! + TaskContext.get(c)!!
+            }
+
+        sumInside shouldBeEqualTo 6
+    }
+
+    @Test
+    fun `TaskContextBindings run 블록 종료 후 바인딩이 해제된다`() {
+        val key = TaskContext.newKey<String>()
+
+        TaskContext.bind(key, "bound").run {
+            TaskContext.get(key).shouldNotBeNull()
+        }
+
+        TaskContext.get(key).shouldBeNull()
+    }
+}

--- a/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/TaskContextTest.kt
+++ b/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/TaskContextTest.kt
@@ -220,16 +220,13 @@ class TaskContextTest {
     // ── Nullable T ────────────────────────────────────────────────────────────
 
     @Test
-    fun `nullable 타입 T 에서 null 값을 바인딩할 수 있다`() {
+    fun `ScopedValue 에 null 바인딩 후 get 은 null 을 반환한다`() {
+        // JDK 21 에서는 ScopedValue.where(key, null) 이 허용되며 block 이 정상 실행됩니다.
+        // JDK 25 에서는 NPE 가 발생합니다 (스펙 강화).
         val key = TaskContext.newKey<String?>()
-
-        val result = TaskContext.run(key, null) {
-            TaskContext.isBound(key).shouldBeTrue()
-            TaskContext.get(key)
+        TaskContext.run(key, null) {
+            TaskContext.get(key).shouldBeNull()
         }
-
-        // null이 바인딩되어 있어도 get()은 null을 반환 (isBound=true이지만 값이 null)
-        result.shouldBeNull()
     }
 
     // ── 스코프 격리 ───────────────────────────────────────────────────────────

--- a/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/TaskContextTest.kt
+++ b/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/TaskContextTest.kt
@@ -2,12 +2,15 @@ package io.bluetape4k.concurrent.virtualthread
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import org.amshove.kluent.internal.assertFailsWith
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledForJreRange
+import org.junit.jupiter.api.condition.JRE
 import java.lang.ScopedValue
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -83,7 +86,7 @@ class TaskContextTest {
         val key = TaskContext.newKey<Int>()
 
         val result = TaskContext.run(key, 10) {
-            TaskContext.get(key)!! * 2
+            TaskContext.getOrDefault(key, 0) * 2
         }
 
         result shouldBeEqualTo 20
@@ -112,7 +115,7 @@ class TaskContextTest {
         val result = TaskContext.bind(key1, 10)
             .and(key2, 20)
             .call {
-                TaskContext.get(key1)!! + TaskContext.get(key2)!!
+                TaskContext.getOrDefault(key1, 0) + TaskContext.getOrDefault(key2, 0)
             }
 
         result shouldBeEqualTo 30
@@ -220,13 +223,42 @@ class TaskContextTest {
     // ── Nullable T ────────────────────────────────────────────────────────────
 
     @Test
-    fun `ScopedValue 에 null 바인딩 후 get 은 null 을 반환한다`() {
-        // JDK 21 에서는 ScopedValue.where(key, null) 이 허용되며 block 이 정상 실행됩니다.
-        // JDK 25 에서는 NPE 가 발생합니다 (스펙 강화).
+    @EnabledForJreRange(max = JRE.JAVA_24)
+    fun `ScopedValue 에 null 바인딩 후 get 은 null 을 반환한다 (JDK 21)`() {
+        // JDK 21 preview API: ScopedValue.where(key, null) 허용; JDK 25에서는 NPE (스펙 강화)
         val key = TaskContext.newKey<String?>()
         TaskContext.run(key, null) {
             TaskContext.get(key).shouldBeNull()
         }
+    }
+
+    // ── 예외 발생 시 바인딩 해제 ─────────────────────────────────────────────
+
+    @Test
+    fun `run 블록에서 예외 발생 시 바인딩이 해제된다`() {
+        val key = TaskContext.newKey<String>()
+        assertFailsWith<RuntimeException> {
+            TaskContext.run(key, "x") { throw RuntimeException("boom") }
+        }
+        TaskContext.get(key).shouldBeNull()
+    }
+
+    @Test
+    fun `TaskContextBindings call 블록에서 예외 발생 시 바인딩이 해제된다`() {
+        val key = TaskContext.newKey<String>()
+        assertFailsWith<RuntimeException> {
+            TaskContext.bind(key, "x").call { throw RuntimeException("boom") }
+        }
+        TaskContext.get(key).shouldBeNull()
+    }
+
+    @Test
+    fun `withTaskContext 블록에서 예외 발생 시 바인딩이 해제된다`() {
+        val key = TaskContext.newKey<String>()
+        assertFailsWith<RuntimeException> {
+            withTaskContext(key, "x") { throw RuntimeException("boom") }
+        }
+        TaskContext.get(key).shouldBeNull()
     }
 
     // ── 스코프 격리 ───────────────────────────────────────────────────────────
@@ -302,7 +334,7 @@ class TaskContextTest {
             .and(b, 2)
             .and(c, 3)
             .run {
-                sumInside = TaskContext.get(a)!! + TaskContext.get(b)!! + TaskContext.get(c)!!
+                sumInside = TaskContext.getOrDefault(a, 0) + TaskContext.getOrDefault(b, 0) + TaskContext.getOrDefault(c, 0)
             }
 
         sumInside shouldBeEqualTo 6

--- a/virtualthread/jdk21/build.gradle.kts
+++ b/virtualthread/jdk21/build.gradle.kts
@@ -14,12 +14,20 @@ kotlin {
 
 tasks.withType<JavaCompile>().configureEach {
     options.release.set(21)
+    options.compilerArgs.add("--enable-preview")
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    compilerOptions {
+        freeCompilerArgs.add("-Xjvm-enable-preview")
+    }
 }
 
 tasks.withType<Test>().configureEach {
     javaLauncher.set(javaToolchains.launcherFor {
         languageVersion.set(JavaLanguageVersion.of(21))
     })
+    jvmArgs("--enable-preview")
 }
 
 dependencies {

--- a/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProviderExtTest.kt
+++ b/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProviderExtTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
 import java.util.concurrent.StructuredTaskScope
 import java.time.Instant
-import kotlin.test.assertFailsWith
+import org.amshove.kluent.internal.assertFailsWith
 
 /**
  * [Jdk21StructuredTaskScopeProvider] 추가 커버리지 테스트입니다.

--- a/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProviderTest.kt
+++ b/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProviderTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
 import java.time.Instant
 import java.util.concurrent.TimeoutException
-import kotlin.test.assertFailsWith
+import org.amshove.kluent.internal.assertFailsWith
 
 @EnabledForJreRange(min = JRE.JAVA_21)
 class Jdk21StructuredTaskScopeProviderTest {

--- a/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21TaskContextTest.kt
+++ b/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21TaskContextTest.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContain
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
@@ -80,7 +81,8 @@ class Jdk21TaskContextTest {
             }
         }
 
-        results[0] shouldBeEqualTo "inner-1"
-        results[1] shouldBeEqualTo "inner-2"
+        results.size shouldBeEqualTo 2
+        results shouldContain "inner-1"
+        results shouldContain "inner-2"
     }
 }

--- a/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21TaskContextTest.kt
+++ b/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21TaskContextTest.kt
@@ -8,7 +8,6 @@ import org.amshove.kluent.shouldBeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
-import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * JDK 21 (`--enable-preview`) 환경에서 [TaskContext] ScopedValue 전파 통합 테스트
@@ -24,7 +23,6 @@ class Jdk21TaskContextTest {
     fun `jdk21 withSupervised fork 에서 ScopedValue 가 자동 전파된다`() {
         val requestId = TaskContext.newKey<String>()
         val tenantId = TaskContext.newKey<String>()
-        val collected = CopyOnWriteArrayList<String>()
 
         val results = TaskContext.bind(requestId, "req-jdk21")
             .and(tenantId, "tenant-21")
@@ -50,23 +48,23 @@ class Jdk21TaskContextTest {
     @Test
     fun `jdk21 withFailFast fork 에서 ScopedValue 가 자동 전파된다`() {
         val traceId = TaskContext.newKey<String>()
-        val collected = CopyOnWriteArrayList<String>()
 
-        TaskContext.run(traceId, "trace-jdk21") {
+        val values = TaskContext.run(traceId, "trace-jdk21") {
             provider.withFailFast { scope ->
-                repeat(4) { i ->
+                val subtasks = (1..4).map { i ->
                     scope.fork {
                         val value = TaskContext.get(traceId)
                         log.debug { "Subtask $i: traceId=$value" }
-                        value?.also { collected.add(it) }
+                        value ?: ""
                     }
                 }
                 scope.join().throwIfFailed()
+                subtasks.map { it.get() }
             }
         }
 
-        collected.size shouldBeEqualTo 4
-        collected.all { it == "trace-jdk21" }.shouldBeTrue()
+        values.size shouldBeEqualTo 4
+        values.all { it == "trace-jdk21" }.shouldBeTrue()
     }
 
     @Test

--- a/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21TaskContextTest.kt
+++ b/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21TaskContextTest.kt
@@ -1,0 +1,88 @@
+package io.bluetape4k.concurrent.virtualthread.jdk21
+
+import io.bluetape4k.concurrent.virtualthread.TaskContext
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledForJreRange
+import org.junit.jupiter.api.condition.JRE
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * JDK 21 (`--enable-preview`) 환경에서 [TaskContext] ScopedValue 전파 통합 테스트
+ */
+@EnabledForJreRange(min = JRE.JAVA_21, max = JRE.JAVA_21)
+class Jdk21TaskContextTest {
+
+    companion object : KLogging()
+
+    private val provider = Jdk21StructuredTaskScopeProvider()
+
+    @Test
+    fun `jdk21 withSupervised fork 에서 ScopedValue 가 자동 전파된다`() {
+        val requestId = TaskContext.newKey<String>()
+        val tenantId = TaskContext.newKey<String>()
+        val collected = CopyOnWriteArrayList<String>()
+
+        val results = TaskContext.bind(requestId, "req-jdk21")
+            .and(tenantId, "tenant-21")
+            .call {
+                provider.withSupervised<String, List<String>> { scope ->
+                    repeat(3) { i ->
+                        scope.fork {
+                            val rid = TaskContext.get(requestId)
+                            val tid = TaskContext.get(tenantId)
+                            log.debug { "Subtask $i: requestId=$rid, tenantId=$tid" }
+                            "$rid:$tid"
+                        }
+                    }
+                    scope.join()
+                    scope.successfulResults()
+                }
+            }
+
+        results.size shouldBeEqualTo 3
+        results.all { it == "req-jdk21:tenant-21" }.shouldBeTrue()
+    }
+
+    @Test
+    fun `jdk21 withFailFast fork 에서 ScopedValue 가 자동 전파된다`() {
+        val traceId = TaskContext.newKey<String>()
+        val collected = CopyOnWriteArrayList<String>()
+
+        TaskContext.run(traceId, "trace-jdk21") {
+            provider.withFailFast { scope ->
+                repeat(4) { i ->
+                    scope.fork {
+                        val value = TaskContext.get(traceId)
+                        log.debug { "Subtask $i: traceId=$value" }
+                        value?.also { collected.add(it) }
+                    }
+                }
+                scope.join().throwIfFailed()
+            }
+        }
+
+        collected.size shouldBeEqualTo 4
+        collected.all { it == "trace-jdk21" }.shouldBeTrue()
+    }
+
+    @Test
+    fun `jdk21 다중 바인딩이 중첩 supervised scope 에서도 격리된다`() {
+        val key = TaskContext.newKey<String>()
+
+        val results = TaskContext.run(key, "outer") {
+            provider.withSupervised<String, List<String>> { scope ->
+                scope.fork { TaskContext.run(key, "inner-1") { TaskContext.get(key) ?: "" } }
+                scope.fork { TaskContext.run(key, "inner-2") { TaskContext.get(key) ?: "" } }
+                scope.join()
+                scope.successfulResults()
+            }
+        }
+
+        results[0] shouldBeEqualTo "inner-1"
+        results[1] shouldBeEqualTo "inner-2"
+    }
+}

--- a/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderExtTest.kt
+++ b/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderExtTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.condition.EnabledOnJre
 import org.junit.jupiter.api.condition.JRE
 import java.time.Instant
 import java.util.concurrent.StructuredTaskScope
-import kotlin.test.assertFailsWith
+import org.amshove.kluent.internal.assertFailsWith
 
 /**
  * [Jdk25StructuredTaskScopeProvider] 추가 커버리지 테스트입니다.

--- a/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderTest.kt
+++ b/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.condition.EnabledOnJre
 import org.junit.jupiter.api.condition.JRE
 import java.time.Instant
 import java.util.concurrent.TimeoutException
-import kotlin.test.assertFailsWith
+import org.amshove.kluent.internal.assertFailsWith
 
 @EnabledOnJre(JRE.JAVA_25)
 class Jdk25StructuredTaskScopeProviderTest {

--- a/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25TaskContextTest.kt
+++ b/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25TaskContextTest.kt
@@ -1,0 +1,90 @@
+package io.bluetape4k.concurrent.virtualthread.jdk25
+
+import io.bluetape4k.concurrent.virtualthread.TaskContext
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledOnJre
+import org.junit.jupiter.api.condition.JRE
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * JDK 25 (stable ScopedValue API) 환경에서 [TaskContext] ScopedValue 전파 통합 테스트
+ */
+@EnabledOnJre(JRE.JAVA_25)
+class Jdk25TaskContextTest {
+
+    companion object : KLogging()
+
+    private val provider = Jdk25StructuredTaskScopeProvider()
+
+    @Test
+    fun `jdk25 withSupervised fork 에서 ScopedValue 가 자동 전파된다`() {
+        val requestId = TaskContext.newKey<String>()
+        val tenantId = TaskContext.newKey<String>()
+
+        val results = TaskContext.bind(requestId, "req-jdk25")
+            .and(tenantId, "tenant-25")
+            .call {
+                provider.withSupervised<String, List<String>> { scope ->
+                    repeat(3) { i ->
+                        scope.fork {
+                            val rid = TaskContext.get(requestId)
+                            val tid = TaskContext.get(tenantId)
+                            log.debug { "Subtask $i: requestId=$rid, tenantId=$tid" }
+                            "$rid:$tid"
+                        }
+                    }
+                    scope.join()
+                    scope.successfulResults()
+                }
+            }
+
+        results.size shouldBeEqualTo 3
+        results.all { it == "req-jdk25:tenant-25" }.shouldBeTrue()
+    }
+
+    @Test
+    fun `jdk25 withFailFast fork 에서 ScopedValue 가 자동 전파된다`() {
+        val traceId = TaskContext.newKey<String>()
+        val collected = CopyOnWriteArrayList<String>()
+
+        TaskContext.run(traceId, "trace-jdk25") {
+            provider.withFailFast { scope ->
+                repeat(4) { i ->
+                    scope.fork {
+                        val value = TaskContext.get(traceId)
+                        log.debug { "Subtask $i: traceId=$value" }
+                        value?.also { collected.add(it) }
+                    }
+                }
+                scope.join().throwIfFailed()
+            }
+        }
+
+        collected.size shouldBeEqualTo 4
+        collected.all { it == "trace-jdk25" }.shouldBeTrue()
+    }
+
+    @Test
+    fun `jdk25 supervised scope results 에서 ScopedValue 기반 컨텍스트가 Result 로 수집된다`() {
+        val requestId = TaskContext.newKey<String>()
+
+        val results = TaskContext.run(requestId, "req-result") {
+            provider.withSupervised<String, List<Result<String>>> { scope ->
+                scope.fork { TaskContext.get(requestId) ?: "NOT_FOUND" }
+                scope.fork { TaskContext.get(requestId) ?: "NOT_FOUND" }
+                scope.fork<String> { throw RuntimeException("intentional failure") }
+                scope.join()
+                scope.results()
+            }
+        }
+
+        results.size shouldBeEqualTo 3
+        results.count { it.isSuccess } shouldBeEqualTo 2
+        results.count { it.isFailure } shouldBeEqualTo 1
+        results.filter { it.isSuccess }.all { it.getOrThrow() == "req-result" }.shouldBeTrue()
+    }
+}

--- a/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25TaskContextTest.kt
+++ b/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25TaskContextTest.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.concurrent.virtualthread.jdk25
 import io.bluetape4k.concurrent.virtualthread.TaskContext
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import org.amshove.kluent.internal.assertFailsWith
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
 import org.junit.jupiter.api.Test
@@ -86,5 +87,14 @@ class Jdk25TaskContextTest {
         results.count { it.isSuccess } shouldBeEqualTo 2
         results.count { it.isFailure } shouldBeEqualTo 1
         results.filter { it.isSuccess }.all { it.getOrThrow() == "req-result" }.shouldBeTrue()
+    }
+
+    @Test
+    fun `jdk25 ScopedValue null 바인딩 시도는 NullPointerException 을 발생시킨다 (JDK 25)`() {
+        // JDK 25 stable API: ScopedValue.where(key, null) 은 NullPointerException 을 던집니다
+        val key = TaskContext.newKey<String?>()
+        assertFailsWith<NullPointerException> {
+            TaskContext.run(key, null) { }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #253

- PR 제목: feat: ScopedValue 기반 TaskContext — Virtual Thread 컨텍스트 전파 유틸리티 (#253)

Issue #253 — `ScopedValue` 기반 `TaskContext` 구현

Virtual Thread 간 immutable 컨텍스트 전파 유틸리티를 추가합니다.
`ThreadLocal`과 달리 `ScopedValue`는 immutable하며 스코프 바깥으로 누출되지 않습니다.

### 원문 선행 내용

Closes #253

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 신규 파일
- `virtualthread/api/src/main/kotlin/.../TaskContext.kt`
  - `TaskContext` object: `newKey/get/getOrDefault/isBound/run/bind` API
  - `withTaskContext()` top-level 함수 (`with*` Kotlin 관용구)
  - `TaskContextBindings`: `and().run{}/call{}` 체이닝 빌더
- `virtualthread/api/src/test/.../TaskContextTest.kt` — 22개 테스트
- `virtualthread/jdk21/src/test/.../Jdk21TaskContextTest.kt` — 3개 테스트
- `virtualthread/jdk25/src/test/.../Jdk25TaskContextTest.kt` — 4개 테스트

### 수정 파일
- `virtualthread/jdk21/build.gradle.kts`: `--enable-preview` 플래그 추가
- `virtualthread/README.md` + `README.ko.md`: TaskContext 섹션 추가
- 모든 virtualthread 모듈의 `assertFailsWith`를 `org.amshove.kluent.internal.assertFailsWith`로 통일

### 기존 섹션: ScopedValue 전파 규칙

| 생성 방법 | ScopedValue 전파 |
|-----------|----------------|
| `Thread.ofVirtual().start {}` | ❌ 전파 안 됨 |
| `StructuredTaskScope.fork {}` | ✅ 자동 전파 |

### 기존 섹션: 사용 예시

```kotlin
val REQUEST_ID = TaskContext.newKey<String>()

// 단일 바인딩
withTaskContext(REQUEST_ID, "req-001") {
    StructuredTaskScopes.failFast { scope ->
        scope.fork { TaskContext.get(REQUEST_ID) }  // 자동 전파
        scope.join().throwIfFailed()
    }
}

// 다중 바인딩
TaskContext.bind(REQUEST_ID, "req-001")
    .and(TENANT_ID, "tenant-42")
    .run {
        println(TaskContext.get(REQUEST_ID))  // "req-001"
        println(TaskContext.get(TENANT_ID))   // "tenant-42"
    }
```

### 기존 섹션: JDK 버전 노트

- JDK 21: `ScopedValue.where(key, null)` NPE 미발생 (Preview API) — `@EnabledForJreRange(max=JAVA_24)` 가드
- JDK 25: `ScopedValue.where(key, null)` NPE 발생 (Stable API 강화) — `Jdk25TaskContextTest`에서 검증
- 예외 발생 시 바인딩 자동 해제 검증 (run/call/withTaskContext 3가지 경로)

### 기존 섹션: 검증 커맨드

```bash
./bin/repo-test-summary -- ./gradlew :bluetape4k-virtualthread-api:test :bluetape4k-virtualthread-jdk21:test
```

## Validation

| 모듈 | 통과 | 실패 |
|------|------|------|
| `bluetape4k-virtualthread-api` | 65 | 0 |
| `bluetape4k-virtualthread-jdk21` | 17 | 0 |

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #253, milestone 없음, assignee `debop`
- PR: #271, head `b438795f9b36b495d59f204617d0ea5f848a2fa5`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/scoped-value-task-context`
- Labels: `enhancement`
- State: `MERGED`, merge commit `9ff6e2eec95c53dd8031acb6f62f7c827c274999`
- CI: - `virtualthread/jdk21/build.gradle.kts`: `--enable-preview` 플래그 추가 / ./bin/repo-test-summary -- ./gradlew :bluetape4k-virtualthread-api:test :bluetape4k-virtualthread-jdk21:test

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #271 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9ff6e2eec95c53dd8031acb6f62f7c827c274999`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
