### PR TITLE
fix: virtualthread timeout 버그 수정 및 JDK 호환성 개선 (#266 #268 #269)

### DIFF
--- a/docs/lessons/2026-05-01-virtualthread-timeout-fixes.md
+++ b/docs/lessons/2026-05-01-virtualthread-timeout-fixes.md
@@ -1,0 +1,222 @@
+# Lessons Learned — virtualthread timeout 버그 수정 (2026-05-01)
+
+**관련 PR**: #272  
+**수정 이슈**: #266, #268, #269  
+**영향 모듈**: `virtualthread/api`, `virtualthread/jdk21`, `virtualthread/jdk25`, `testing/junit5`, `utils/workflow`
+
+---
+
+## L1: interface default impl이 deadline을 무시할 수 있다
+
+### 문제
+
+```kotlin
+// 인터페이스 기본 구현
+fun joinUntil(deadline: Instant): StructuredTaskScopeAll = join()
+```
+
+컴파일/실행 모두 정상이지만, deadline 인자가 완전히 무시된다.
+구현체가 재정의하지 않으면 언제나 무한 대기 — 버그가 아니라 정상처럼 보인다.
+
+### 교훈
+
+- **deadline을 받는 메서드는 abstract 강제** — 기본 구현 제공 금지.
+- 인터페이스에 `joinUntil` 같은 타임아웃 메서드 추가 시 **반드시 timeout 테스트** 추가.
+- `= join()` 패턴은 "편의 기본값"처럼 보이지만 의미론적 버그다.
+
+---
+
+## L2: `runCatching` 안에서 던지는 예외는 outer `try-catch`에 도달하지 않는다
+
+### 문제
+
+```kotlin
+return try {
+    runCatching {
+        scope.joinUntil(deadline)  // TimeoutException 던짐
+        ...
+    }.getOrElse { ... }           // TimeoutException이 여기서 삼켜짐
+} catch (e: TimeoutException) {   // ← 절대 도달하지 않는 dead code
+    WorkReport.Cancelled(context)
+}
+```
+
+`TimeoutException`이 `runCatching`에 잡혀 `getOrElse`로 전달된다.
+outer `catch (TimeoutException)`은 dead code가 되고, 잘못된 `WorkReport.Failure`가 반환된다.
+
+### 수정
+
+```kotlin
+}.getOrElse { throwable ->
+    if (throwable is TimeoutException) throw throwable  // outer catch로 전파
+    // ... 기존 실패 처리
+}
+```
+
+### 교훈
+
+- `runCatching`과 `try-catch`를 **혼용할 때 예외 흐름을 명시적으로 추적**해야 한다.
+- `runCatching` 블록 내부에서 특정 예외를 외부로 전파하려면 `getOrElse`에서 rethrow 필요.
+- 테스트 없이는 이 버그가 발견되지 않는다 — **모든 `catch` 분기에 테스트 필수**.
+
+---
+
+## L3: JDK preview API는 stable 전환 시 바이너리 불호환이 발생한다
+
+### 문제
+
+```kotlin
+// JDK21 preview API
+ScopedValue.where(key, value).call { block() }
+// → ScopedValue.Carrier.call(java.util.concurrent.Callable)
+```
+
+JDK24+에서 `call(java.util.concurrent.Callable)` → `call(ScopedValue.CallableOp)`으로 변경.
+컴파일은 성공하지만 JDK25 런타임에서 `NoSuchMethodError` 발생.
+
+### 수정
+
+```kotlin
+// run(Runnable)은 JDK21/25 모두 안정적
+var captured: Result<R>? = null
+ScopedValue.where(key, value).run { captured = runCatching { block() } }
+return checkNotNull(captured) { "..." }.getOrThrow()
+```
+
+### 교훈
+
+- **JDK 버전 경계를 가로지르는 코드는 stable API만 사용**.
+- `--enable-preview` 플래그로 컴파일한 코드는 major 버전 업 시 바이너리 불호환 가능성 있음.
+- preview API 사용 부분은 별도 모듈(`jdk21`, `jdk25`)로 격리하고, 공용 `api` 모듈은 stable API만.
+- cross-JDK 테스트(`@EnabledForJreRange(min = JRE.JAVA_21)`)로 두 버전 모두 검증 필수.
+
+---
+
+## L4: 중복 구현은 버그 수정 시 N배 비용
+
+### 문제
+
+```kotlin
+// Jdk25AllScope.joinUntil  — 25줄
+// Jdk25AnyScope.joinUntil  — 25줄 (copy-paste)
+// Jdk25SupervisedScope.joinUntil — 25줄 (copy-paste)
+```
+
+`toMillis()` 정밀도 버그 하나를 고치거나 race condition 주석을 추가하려면 3곳 모두 수정.
+
+### 수정
+
+```kotlin
+companion object {
+    internal fun interruptJoinUntil(
+        deadline: Instant,
+        threadName: String,
+        joinAction: () -> Unit,  // InterruptedException을 전파해야 함
+    ) { ... }
+}
+// 각 scope: 1줄
+override fun joinUntil(deadline: Instant): StructuredTaskScopeAll {
+    interruptJoinUntil(deadline, "jdk25-scope-timeout") { delegate.join() }
+    return this
+}
+```
+
+### 교훈
+
+- **처음부터 헬퍼 추출**. 나중에 발견하면 refactor + 수정 2단계 필요.
+- 동일한 패턴이 3곳 이상 반복되면 즉시 추상화.
+- companion object 헬퍼는 nested class에서도 접근 가능 — Kotlin에서 유효한 패턴.
+
+---
+
+## L5: `@EnabledOnJre(JRE.JAVA_25)` vs `@EnabledForJreRange(min = JRE.JAVA_25)`
+
+### 문제
+
+```kotlin
+@EnabledOnJre(JRE.JAVA_25)  // JDK25 전용 — JDK26에서 자동 skip
+```
+
+JDK26 출시 시 `@EnabledOnJre(JRE.JAVA_25)` 테스트는 자동으로 비활성화된다.
+"JDK25 stable API 사용"이 의도인데, 이 테스트는 미래 버전에서도 실행되어야 한다.
+
+### 수정
+
+```kotlin
+@EnabledForJreRange(min = JRE.JAVA_25)  // JDK25 이상 모두 실행
+```
+
+### 교훈
+
+- 특정 버전의 **기능/API**를 테스트하는 경우 → `@EnabledForJreRange(min = ...)` 사용.
+- 특정 버전의 **버그/동작**을 테스트하는 경우 → `@EnabledOnJre(...)` 사용.
+- 새 JDK stable API 기반 테스트는 항상 `min =` 형식으로 작성.
+
+---
+
+## L6: interrupt 기반 타임아웃에서 외부 interrupt와 타이머 interrupt를 구분할 수 없다
+
+### 문제
+
+JDK25 `StructuredTaskScope`에는 `joinUntil(Instant)` API가 없다.
+`ScheduledThreadPoolExecutor`로 owner thread를 interrupt하는 방식으로 구현했으나:
+
+```kotlin
+} catch (e: InterruptedException) {
+    // 이것이 타이머 interrupt인지, 외부 interrupt인지 알 수 없다
+    throw TimeoutException("joinUntil deadline exceeded")
+}
+```
+
+외부 `Thread.interrupt()` 호출도 `TimeoutException`으로 변환된다.
+
+### 완화책
+
+```kotlin
+// 타이머가 실제로 발동했는지 확인하는 volatile flag 사용 (개선 여지)
+@Volatile var timedOut = false
+val timeoutFuture = scheduler.schedule({
+    timedOut = true
+    ownerThread.interrupt()
+}, ...)
+```
+
+### 교훈
+
+- interrupt 기반 타임아웃은 **JDK 공식 API(`joinUntil`)가 없을 때만** 사용하는 workaround.
+- volatile flag로 타이머 발동 여부를 기록하면 외부 interrupt와 구분 가능 (현재는 미적용).
+- JDK가 공식 API를 제공하면 즉시 교체해야 한다 — 주석으로 TODO 마킹.
+
+---
+
+## L7: deadline 계산은 fork 루프 시작 전에 해야 한다
+
+### 문제
+
+```kotlin
+repeat(roundsPerWorker) { testBlocks.forEach { scope.fork { it() } } }
+// ← fork 루프 후 deadline 계산 → fork 소요 시간만큼 timeout 윈도우가 줄어든다
+val joined = timeout?.let { scope.joinUntil(Instant.now().plusMillis(it.inWholeMilliseconds)) }
+```
+
+### 수정
+
+```kotlin
+// fork 루프 전에 deadline 계산
+val deadline = timeout?.let { Instant.now().plusMillis(it.inWholeMilliseconds) }
+repeat(roundsPerWorker) { testBlocks.forEach { scope.fork { it() } } }
+val joined = deadline?.let { scope.joinUntil(it) } ?: scope.join()
+```
+
+### 교훈
+
+- **deadline은 "작업 시작 전" 기준으로 계산** — "join 직전" 기준이 아니다.
+- `ParallelWorkFlow.executeAll`이 이미 올바른 패턴을 사용하고 있었다 — 기존 코드에서 먼저 학습.
+
+---
+
+## 참고
+
+- PR #272: <https://github.com/bluetape4k/bluetape4k-projects/pull/272>
+- 관련 이슈: #266, #268, #269
+- 기존 PR: #271 (TaskContext ScopedValue 구현 — #265, #267 처리)

--- a/testing/junit5/README.ko.md
+++ b/testing/junit5/README.ko.md
@@ -110,6 +110,7 @@ classDiagram
     class StructuredTaskScopeTester {
         +rounds(n) StructuredTaskScopeTester
         +add(block) StructuredTaskScopeTester
+        +withTimeout(duration) StructuredTaskScopeTester
         +run()
     }
 
@@ -360,6 +361,13 @@ StructuredTaskScopeTester()
     .rounds(1000)
     .add { processRequest() }
     .add { handleResponse() }
+    .run()
+
+// withTimeout — 걸린 테스트를 TimeoutException으로 감지
+StructuredTaskScopeTester()
+    .rounds(100)
+    .withTimeout(5.seconds)   // 5초 초과 시 TimeoutException
+    .add { processRequest() }
     .run()
 ```
 

--- a/testing/junit5/README.md
+++ b/testing/junit5/README.md
@@ -110,6 +110,7 @@ classDiagram
     class StructuredTaskScopeTester {
         +rounds(n) StructuredTaskScopeTester
         +add(block) StructuredTaskScopeTester
+        +withTimeout(duration) StructuredTaskScopeTester
         +run()
     }
 
@@ -234,6 +235,13 @@ SuspendedJobTester()
 // Virtual Threads (Java 21+)
 StructuredTaskScopeTester()
     .rounds(1000)
+    .add { processRequest() }
+    .run()
+
+// With timeout — hangs are caught as TimeoutException
+StructuredTaskScopeTester()
+    .rounds(100)
+    .withTimeout(5.seconds)   // run() throws TimeoutException if not done in 5s
     .add { processRequest() }
     .run()
 ```

--- a/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/concurrency/StructuredTaskScopeTester.kt
+++ b/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/concurrency/StructuredTaskScopeTester.kt
@@ -7,7 +7,9 @@ import io.bluetape4k.junit5.tester.StressTester.Companion.MAX_ROUNDS_PER_WORKER
 import io.bluetape4k.junit5.tester.StressTester.Companion.MIN_ROUNDS_PER_WORKER
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
+import java.time.Instant
 import java.util.concurrent.ThreadFactory
+import kotlin.time.Duration
 
 /**
  * Java 21/25 StructuredTaskScope 기반으로 테스트 블록을 병렬 실행합니다.
@@ -35,6 +37,7 @@ class StructuredTaskScopeTester: StressTester<StructuredTaskScopeTester> {
 
     private val testBlocks = mutableListOf<() -> Unit>()
     private var factory: ThreadFactory? = null
+    private var timeout: Duration? = null
 
     /**
      * 실행에 사용할 [ThreadFactory]를 지정합니다.
@@ -51,6 +54,25 @@ class StructuredTaskScopeTester: StressTester<StructuredTaskScopeTester> {
      */
     fun withFactory(factory: ThreadFactory) = apply {
         this.factory = factory
+    }
+
+    /**
+     * 전체 실행에 적용할 타임아웃을 설정합니다.
+     *
+     * ## 동작/계약
+     * - 설정 시 [run]에서 [io.bluetape4k.concurrent.virtualthread.StructuredTaskScopeAll.joinUntil]을 사용합니다.
+     * - 타임아웃 초과 시 [java.util.concurrent.TimeoutException]이 발생합니다.
+     *
+     * ```kotlin
+     * StructuredTaskScopeTester()
+     *     .rounds(100)
+     *     .withTimeout(5.seconds)
+     *     .add { heavyWork() }
+     *     .run()
+     * ```
+     */
+    fun withTimeout(duration: Duration) = apply {
+        this.timeout = duration
     }
 
     /**
@@ -148,10 +170,12 @@ class StructuredTaskScopeTester: StressTester<StructuredTaskScopeTester> {
             repeat(roundsPerWorker) {
                 testBlocks.forEach { block ->
                     scope.fork { block() }
-
                 }
             }
-            scope.join().throwIfFailed {
+            val joined = timeout
+                ?.let { scope.joinUntil(Instant.now().plusMillis(it.inWholeMilliseconds)) }
+                ?: scope.join()
+            joined.throwIfFailed {
                 log.error(it) { "Test blocks failed with exception." }
             }
         }

--- a/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/concurrency/StructuredTaskScopeTester.kt
+++ b/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/concurrency/StructuredTaskScopeTester.kt
@@ -166,15 +166,15 @@ class StructuredTaskScopeTester: StressTester<StructuredTaskScopeTester> {
         }
 
         val factory = this.factory ?: Thread.ofVirtual().factory()
+        // deadline은 fork 루프 시작 전에 계산 — fork 자체 소요 시간이 timeout을 잠식하지 않도록
+        val deadline = timeout?.let { Instant.now().plusMillis(it.inWholeMilliseconds) }
         StructuredTaskScopes.failFast("stressTester", factory) { scope ->
             repeat(roundsPerWorker) {
                 testBlocks.forEach { block ->
                     scope.fork { block() }
                 }
             }
-            val joined = timeout
-                ?.let { scope.joinUntil(Instant.now().plusMillis(it.inWholeMilliseconds)) }
-                ?: scope.join()
+            val joined = deadline?.let { scope.joinUntil(it) } ?: scope.join()
             joined.throwIfFailed {
                 log.error(it) { "Test blocks failed with exception." }
             }

--- a/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/core/ParallelWorkFlow.kt
+++ b/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/core/ParallelWorkFlow.kt
@@ -119,41 +119,47 @@ class ParallelWorkFlow(
      */
     private fun executeAny(context: WorkContext): WorkReport {
         val factory = Thread.ofVirtual().name("$flowName-", 0).factory()
+        val deadline = Instant.now().plusMillis(timeout.inWholeMilliseconds)
         val failedReports = java.util.concurrent.ConcurrentLinkedQueue<WorkReport>()
 
-        return runCatching {
-            StructuredTaskScopes.firstSuccess<WorkReport>(name = flowName, factory = factory) { scope ->
-                works.forEach { work ->
-                    val workName = (work as? NamedWork)?.name ?: work.javaClass.simpleName
-                    scope.fork {
-                        log.debug { "$flowName: '$workName' 병렬 실행 시작 (ANY)" }
-                        val report = runCatching { work.execute(context) }
-                            .getOrElse { e ->
-                                log.debug { "$flowName: '$workName' 예외 발생 - ${e.message}" }
-                                WorkReport.Failure(context, e)
-                            }
-                        log.debug { "$flowName: '$workName' 실행 완료 - status=${report.status}" }
+        return try {
+            runCatching {
+                StructuredTaskScopes.firstSuccess<WorkReport>(name = flowName, factory = factory) { scope ->
+                    works.forEach { work ->
+                        val workName = (work as? NamedWork)?.name ?: work.javaClass.simpleName
+                        scope.fork {
+                            log.debug { "$flowName: '$workName' 병렬 실행 시작 (ANY)" }
+                            val report = runCatching { work.execute(context) }
+                                .getOrElse { e ->
+                                    log.debug { "$flowName: '$workName' 예외 발생 - ${e.message}" }
+                                    WorkReport.Failure(context, e)
+                                }
+                            log.debug { "$flowName: '$workName' 실행 완료 - status=${report.status}" }
 
-                        if (report.isSuccess) {
-                            log.debug { "$flowName: '$workName' 성공 — 나머지 취소 (ANY)" }
-                            report
-                        } else {
-                            failedReports.add(report)
-                            throw WorkNotSuccessException(report)
+                            if (report.isSuccess) {
+                                log.debug { "$flowName: '$workName' 성공 — 나머지 취소 (ANY)" }
+                                report
+                            } else {
+                                failedReports.add(report)
+                                throw WorkNotSuccessException(report)
+                            }
                         }
                     }
-                }
 
-                scope.join().result { e ->
-                    RuntimeException("$flowName: 모든 작업이 실패했습니다", e)
+                    scope.joinUntil(deadline).result { e ->
+                        RuntimeException("$flowName: 모든 작업이 실패했습니다", e)
+                    }
                 }
+            }.getOrElse {
+                // 모두 실패한 경우 failedReports에서 우선순위로 반환
+                failedReports.firstOrNull { it.isAborted }
+                    ?: failedReports.firstOrNull { it.isCancelled }
+                    ?: failedReports.firstOrNull { it.isFailure }
+                    ?: WorkReport.failure(context, RuntimeException("$flowName: 모든 작업이 실패했습니다"))
             }
-        }.getOrElse {
-            // 모두 실패한 경우 failedReports에서 우선순위로 반환
-            failedReports.firstOrNull { it.isAborted }
-                ?: failedReports.firstOrNull { it.isCancelled }
-                ?: failedReports.firstOrNull { it.isFailure }
-                ?: WorkReport.failure(context, RuntimeException("$flowName: 모든 작업이 실패했습니다"))
+        } catch (e: TimeoutException) {
+            log.debug { "$flowName: timeout 초과 ($timeout) - Cancelled 반환 (ANY)" }
+            WorkReport.Cancelled(context)
         }
     }
 

--- a/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/core/ParallelWorkFlow.kt
+++ b/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/core/ParallelWorkFlow.kt
@@ -150,7 +150,9 @@ class ParallelWorkFlow(
                         RuntimeException("$flowName: 모든 작업이 실패했습니다", e)
                     }
                 }
-            }.getOrElse {
+            }.getOrElse { throwable ->
+                // TimeoutException은 outer catch로 전파 (runCatching이 삼킴 방지)
+                if (throwable is TimeoutException) throw throwable
                 // 모두 실패한 경우 failedReports에서 우선순위로 반환
                 failedReports.firstOrNull { it.isAborted }
                     ?: failedReports.firstOrNull { it.isCancelled }

--- a/virtualthread/api/README.ko.md
+++ b/virtualthread/api/README.ko.md
@@ -108,14 +108,31 @@ val (successes, errors) = StructuredTaskScopes.supervised<String, Pair<List<Stri
 println("결과 ${successes.size}개 수집, 실패 ${errors.size}건")
 ```
 
-`joinUntil` 데드라인 지정:
+`joinUntil` 데드라인 지정 — 모든 scope 타입(`All`, `Any`, `Supervised`) 지원:
 
 ```kotlin
+// Supervised scope — joinUntil로 데드라인 지정
 StructuredTaskScopes.supervised<String, Unit> { scope ->
     scope.fork { longRunningTask() }
     scope.joinUntil(Instant.now().plusSeconds(5))  // 초과 시 TimeoutException
     val results = scope.successfulResults()
     val failures = scope.failedExceptions()
+}
+
+// failFast (all-scope) — 데드라인 + 실패 전파
+StructuredTaskScopes.failFast { scope ->
+    scope.fork { processA() }
+    scope.fork { processB() }
+    scope.joinUntil(Instant.now().plusSeconds(10))
+        .throwIfFailed()
+}
+
+// firstSuccess (any-scope) — 가장 빠른 성공 + 데드라인
+StructuredTaskScopes.firstSuccess<String> { scope ->
+    scope.fork { slowTask() }
+    scope.fork { fastTask() }
+    scope.joinUntil(Instant.now().plusMillis(500))
+        .result { RuntimeException("모든 작업 실패 또는 타임아웃", it) }
 }
 ```
 
@@ -252,6 +269,24 @@ classDiagram
         +withSupervised(name, factory, block) R
         +withAll(name, factory, block) T
         +withAny(name, factory, block) T
+    }
+
+    class StructuredTaskScopeAll {
+        <<interface>>
+        +fork(task) StructuredSubtask~T~
+        +join() StructuredTaskScopeAll
+        +joinUntil(deadline) StructuredTaskScopeAll
+        +throwIfFailed(handler) StructuredTaskScopeAll
+        +close()
+    }
+
+    class StructuredTaskScopeAny~T~ {
+        <<interface>>
+        +fork(task) StructuredSubtask~T~
+        +join() StructuredTaskScopeAny~T~
+        +joinUntil(deadline) StructuredTaskScopeAny~T~
+        +result(mapper) T
+        +close()
     }
 
     class StructuredTaskScopeSupervised {

--- a/virtualthread/api/README.md
+++ b/virtualthread/api/README.md
@@ -112,11 +112,28 @@ println("Got ${successes.size} results, ${errors.size} failures")
 With `joinUntil` deadline:
 
 ```kotlin
+// Supervised scope — all 3 scope types support joinUntil
 StructuredTaskScopes.supervised<String, Unit> { scope ->
     scope.fork { longRunningTask() }
     scope.joinUntil(Instant.now().plusSeconds(5))  // TimeoutException if exceeded
     val results = scope.successfulResults()
     val failures = scope.failedExceptions()
+}
+
+// failFast (all-scope) with deadline
+StructuredTaskScopes.failFast { scope ->
+    scope.fork { processA() }
+    scope.fork { processB() }
+    scope.joinUntil(Instant.now().plusSeconds(10))
+        .throwIfFailed()
+}
+
+// firstSuccess (any-scope) with deadline
+StructuredTaskScopes.firstSuccess<String> { scope ->
+    scope.fork { slowTask() }
+    scope.fork { fastTask() }
+    scope.joinUntil(Instant.now().plusMillis(500))
+        .result { RuntimeException("All tasks failed or timed out", it) }
 }
 ```
 
@@ -254,6 +271,24 @@ classDiagram
         +withSupervised(name, factory, block) R
         +withAll(name, factory, block) T
         +withAny(name, factory, block) T
+    }
+
+    class StructuredTaskScopeAll {
+        <<interface>>
+        +fork(task) StructuredSubtask~T~
+        +join() StructuredTaskScopeAll
+        +joinUntil(deadline) StructuredTaskScopeAll
+        +throwIfFailed(handler) StructuredTaskScopeAll
+        +close()
+    }
+
+    class StructuredTaskScopeAny~T~ {
+        <<interface>>
+        +fork(task) StructuredSubtask~T~
+        +join() StructuredTaskScopeAny~T~
+        +joinUntil(deadline) StructuredTaskScopeAny~T~
+        +result(mapper) T
+        +close()
     }
 
     class StructuredTaskScopeSupervised {

--- a/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopes.kt
+++ b/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopes.kt
@@ -116,9 +116,8 @@ interface StructuredTaskScopeAll: AutoCloseable {
     /**
      * 지정한 데드라인까지 subtask 완료를 대기합니다.
      * 데드라인 초과 시 [java.util.concurrent.TimeoutException]이 발생합니다.
-     * 기본 구현은 타임아웃 없이 [join]을 호출합니다.
      */
-    fun joinUntil(deadline: java.time.Instant): StructuredTaskScopeAll = join()
+    fun joinUntil(deadline: java.time.Instant): StructuredTaskScopeAll
 
     /** 실패한 subtask가 있으면 [handler]를 호출한 뒤 예외를 전파합니다. */
     fun throwIfFailed(handler: (e: Throwable) -> Unit = {}): StructuredTaskScopeAll
@@ -163,6 +162,12 @@ interface StructuredTaskScopeAny<T>: AutoCloseable {
 
     /** 등록된 subtask 완료를 대기합니다. */
     fun join(): StructuredTaskScopeAny<T>
+
+    /**
+     * 지정한 데드라인까지 subtask 완료를 대기합니다.
+     * 데드라인 초과 시 [java.util.concurrent.TimeoutException]이 발생합니다.
+     */
+    fun joinUntil(deadline: java.time.Instant): StructuredTaskScopeAny<T>
 
     /** 첫 성공 결과를 반환하거나 실패 시 [mapper]로 예외를 변환해 던집니다. */
     fun result(mapper: (Throwable) -> RuntimeException): T
@@ -231,9 +236,8 @@ interface StructuredTaskScopeSupervised<T> : AutoCloseable {
     /**
      * 지정한 데드라인까지 subtask 완료를 대기합니다.
      * 데드라인 초과 시 [java.util.concurrent.TimeoutException]이 발생합니다.
-     * 기본 구현은 타임아웃 없이 [join]을 호출합니다.
      */
-    fun joinUntil(deadline: java.time.Instant): StructuredTaskScopeSupervised<T> = join()
+    fun joinUntil(deadline: java.time.Instant): StructuredTaskScopeSupervised<T>
 
     /**
      * [join] 이후 모든 subtask 결과를 `Result<T>` 리스트로 반환합니다.

--- a/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/TaskContext.kt
+++ b/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/TaskContext.kt
@@ -101,7 +101,7 @@ object TaskContext {
         // run(Runnable)은 JDK21/25 모두 안정적이므로 capture 패턴 사용.
         var captured: Result<R>? = null
         ScopedValue.where(key, value).run { captured = runCatching { block() } }
-        return captured!!.getOrThrow()
+        return checkNotNull(captured) { "ScopedValue.Carrier.run did not execute block" }.getOrThrow()
     }
 
     /**
@@ -180,6 +180,6 @@ class TaskContextBindings internal constructor(
         // run(Runnable)은 JDK21/25 모두 안정적이므로 capture 패턴 사용.
         var captured: Result<R>? = null
         carrier.run { captured = runCatching { block() } }
-        return captured!!.getOrThrow()
+        return checkNotNull(captured) { "ScopedValue.Carrier.run did not execute block" }.getOrThrow()
     }
 }

--- a/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/TaskContext.kt
+++ b/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/TaskContext.kt
@@ -95,8 +95,14 @@ object TaskContext {
      * }
      * ```
      */
-    fun <T, R> run(key: ScopedValue<T>, value: T, block: () -> R): R =
-        ScopedValue.where(key, value).call { block() }
+    fun <T, R> run(key: ScopedValue<T>, value: T, block: () -> R): R {
+        // ScopedValue.Carrier.call(Callable) — JDK21 preview API.
+        // JDK24+에서 call() 인자 타입이 CallableOp으로 변경되어 바이너리 불호환.
+        // run(Runnable)은 JDK21/25 모두 안정적이므로 capture 패턴 사용.
+        var captured: Result<R>? = null
+        ScopedValue.where(key, value).run { captured = runCatching { block() } }
+        return captured!!.getOrThrow()
+    }
 
     /**
      * [key]=[value] 첫 번째 바인딩으로 [TaskContextBindings] 빌더를 시작합니다.
@@ -168,5 +174,12 @@ class TaskContextBindings internal constructor(
     /**
      * 모든 바인딩을 적용하고 [block]을 실행한 뒤 결과를 반환합니다.
      */
-    fun <R> call(block: () -> R): R = carrier.call { block() }
+    fun <R> call(block: () -> R): R {
+        // carrier.call(Callable) — JDK21 preview API.
+        // JDK24+에서 call() 인자 타입이 CallableOp으로 변경되어 바이너리 불호환.
+        // run(Runnable)은 JDK21/25 모두 안정적이므로 capture 패턴 사용.
+        var captured: Result<R>? = null
+        carrier.run { captured = runCatching { block() } }
+        return captured!!.getOrThrow()
+    }
 }

--- a/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt
+++ b/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt
@@ -91,8 +91,8 @@ class StructuredScopesTest {
     }
 
     @Test
-    fun `all scope joinUntil 기본 구현이 join 을 호출해야 한다`() {
-        var joinCalled = false
+    fun `all scope joinUntil 구현체가 deadline 을 위임할 수 있어야 한다`() {
+        var joinUntilCalled = false
         val scope = object : StructuredTaskScopeAll {
             override fun <T> fork(task: () -> T): StructuredSubtask<T> {
                 @Suppress("UNCHECKED_CAST")
@@ -103,8 +103,10 @@ class StructuredScopesTest {
                 }
             }
 
-            override fun join(): StructuredTaskScopeAll {
-                joinCalled = true
+            override fun join(): StructuredTaskScopeAll = this
+
+            override fun joinUntil(deadline: Instant): StructuredTaskScopeAll {
+                joinUntilCalled = true
                 return this
             }
 
@@ -113,7 +115,7 @@ class StructuredScopesTest {
         }
 
         scope.joinUntil(Instant.now().plusSeconds(5))
-        joinCalled.shouldBeTrue()
+        joinUntilCalled.shouldBeTrue()
     }
 
     @Suppress("DEPRECATION")

--- a/virtualthread/jdk21/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProvider.kt
+++ b/virtualthread/jdk21/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProvider.kt
@@ -174,6 +174,11 @@ class Jdk21StructuredTaskScopeProvider: StructuredTaskScopeProvider {
             return this
         }
 
+        override fun joinUntil(deadline: java.time.Instant): StructuredTaskScopeAny<T> {
+            delegate.joinUntil(deadline)
+            return this
+        }
+
         override fun result(mapper: (Throwable) -> RuntimeException): T =
             delegate.result(mapper)
 

--- a/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProviderTest.kt
+++ b/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProviderTest.kt
@@ -115,6 +115,27 @@ class Jdk21StructuredTaskScopeProviderTest {
     }
 
     @Test
+    fun `withAll joinUntil 데드라인 초과 시 TimeoutException 이 발생해야 한다`() {
+        assertFailsWith<TimeoutException> {
+            provider.withAll { scope ->
+                scope.fork { Thread.sleep(10_000); 42 }
+                scope.joinUntil(Instant.now().plusMillis(100))
+                scope.throwIfFailed()
+            }
+        }
+    }
+
+    @Test
+    fun `withAll joinUntil 내 데드라인 이전에 완료되면 정상 결과를 반환해야 한다`() {
+        val result = provider.withAll { scope ->
+            val task = scope.fork { 42 }
+            scope.joinUntil(Instant.now().plusSeconds(5)).throwIfFailed()
+            task.get()
+        }
+        result shouldBeEqualTo 42
+    }
+
+    @Test
     fun `withAny should return first success`() {
         val result = provider.withAny { scope ->
             scope.fork {
@@ -128,6 +149,25 @@ class Jdk21StructuredTaskScopeProviderTest {
                 "fast"
             }
             scope.join().result { IllegalStateException(it) }
+        }
+        result shouldBeEqualTo "fast"
+    }
+
+    @Test
+    fun `withAny joinUntil 데드라인 초과 시 TimeoutException 이 발생해야 한다`() {
+        assertFailsWith<TimeoutException> {
+            provider.withAny<String> { scope ->
+                scope.fork { Thread.sleep(10_000); "slow" }
+                scope.joinUntil(Instant.now().plusMillis(100)).result { RuntimeException(it) }
+            }
+        }
+    }
+
+    @Test
+    fun `withAny joinUntil 내 데드라인 이전에 완료되면 정상 결과를 반환해야 한다`() {
+        val result = provider.withAny<String> { scope ->
+            scope.fork { "fast" }
+            scope.joinUntil(Instant.now().plusSeconds(5)).result { RuntimeException(it) }
         }
         result shouldBeEqualTo "fast"
     }

--- a/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
+++ b/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
@@ -238,6 +238,35 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
             return this
         }
 
+        override fun joinUntil(deadline: Instant): StructuredTaskScopeAny<T> {
+            val remaining = Duration.between(Instant.now(), deadline)
+            if (remaining.isNegative || remaining.isZero) {
+                throw TimeoutException("Deadline already passed")
+            }
+            val ownerThread = Thread.currentThread()
+            val scheduler = ScheduledThreadPoolExecutor(1) { r ->
+                Thread(r, "jdk25-any-scope-timeout").apply { isDaemon = true }
+            }
+            val timeoutFuture = scheduler.schedule(
+                { ownerThread.interrupt() },
+                remaining.toMillis(),
+                TimeUnit.MILLISECONDS
+            )
+            try {
+                val joined = runCatching { delegate.join() }
+                if (joined.exceptionOrNull() is InterruptedException) {
+                    Thread.interrupted()
+                    throw TimeoutException("joinUntil deadline exceeded")
+                }
+                joinedResult = joined
+                Thread.interrupted()
+            } finally {
+                timeoutFuture.cancel(false)
+                scheduler.shutdownNow()
+            }
+            return this
+        }
+
         override fun result(mapper: (Throwable) -> RuntimeException): T {
             val result = joinedResult ?: runCatching { delegate.join() }
             return result.getOrElse { throwable ->

--- a/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
+++ b/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
@@ -49,6 +49,48 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
 
         /** provider 우선순위 값입니다. */
         const val PRIORITY = JAVA_VERSION
+
+        /**
+         * JDK25 scope 구현체들에서 공유하는 interrupt 기반 타임아웃 패턴입니다.
+         *
+         * [joinAction]이 실행되는 동안 [deadline]이 초과되면 owner thread를 interrupt하여
+         * [InterruptedException]을 발생시키고, 이를 [TimeoutException]으로 변환합니다.
+         *
+         * ## 계약
+         * - [joinAction]은 [InterruptedException]을 catch하지 않고 전파해야 합니다.
+         * - JDK25 `StructuredTaskScope`는 `joinUntil(Instant)` API가 없으므로 이 패턴으로 대체합니다.
+         *
+         * @throws TimeoutException [deadline] 초과 시
+         */
+        internal fun interruptJoinUntil(
+            deadline: Instant,
+            threadName: String,
+            joinAction: () -> Unit,
+        ) {
+            val remaining = Duration.between(Instant.now(), deadline)
+            if (remaining.isNegative || remaining.isZero) {
+                throw TimeoutException("Deadline already passed")
+            }
+            val ownerThread = Thread.currentThread()
+            val scheduler = ScheduledThreadPoolExecutor(1) { r ->
+                Thread(r, threadName).apply { isDaemon = true }
+            }
+            val timeoutFuture = scheduler.schedule(
+                { ownerThread.interrupt() },
+                remaining.toNanos(),
+                TimeUnit.NANOSECONDS
+            )
+            try {
+                joinAction()
+                Thread.interrupted()
+            } catch (e: InterruptedException) {
+                Thread.interrupted()
+                throw TimeoutException("joinUntil deadline exceeded")
+            } finally {
+                timeoutFuture.cancel(false)
+                scheduler.shutdownNow()
+            }
+        }
     }
 
     override val providerName: String = PROVIDER_NAME
@@ -174,31 +216,7 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
         }
 
         override fun joinUntil(deadline: Instant): StructuredTaskScopeAll {
-            val remaining = Duration.between(Instant.now(), deadline)
-            if (remaining.isNegative || remaining.isZero) {
-                throw TimeoutException("Deadline already passed")
-            }
-            val ownerThread = Thread.currentThread()
-            val scheduler = ScheduledThreadPoolExecutor(1) { r ->
-                Thread(r, "jdk25-scope-timeout").apply { isDaemon = true }
-            }
-            val timeoutFuture = scheduler.schedule(
-                { ownerThread.interrupt() },
-                remaining.toMillis(),
-                TimeUnit.MILLISECONDS
-            )
-            try {
-                delegate.join()
-                // 성공적으로 join된 경우, 타이머가 이미 발동됐을 수 있는 spurious interrupt를 클리어
-                Thread.interrupted()
-            } catch (e: InterruptedException) {
-                // 타이머가 발생시킨 interrupt — 소비하고 TimeoutException으로 변환
-                Thread.interrupted()
-                throw TimeoutException("joinUntil deadline exceeded")
-            } finally {
-                timeoutFuture.cancel(false)
-                scheduler.shutdownNow()
-            }
+            interruptJoinUntil(deadline, "jdk25-scope-timeout") { delegate.join() }
             return this
         }
 
@@ -239,30 +257,14 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
         }
 
         override fun joinUntil(deadline: Instant): StructuredTaskScopeAny<T> {
-            val remaining = Duration.between(Instant.now(), deadline)
-            if (remaining.isNegative || remaining.isZero) {
-                throw TimeoutException("Deadline already passed")
-            }
-            val ownerThread = Thread.currentThread()
-            val scheduler = ScheduledThreadPoolExecutor(1) { r ->
-                Thread(r, "jdk25-any-scope-timeout").apply { isDaemon = true }
-            }
-            val timeoutFuture = scheduler.schedule(
-                { ownerThread.interrupt() },
-                remaining.toMillis(),
-                TimeUnit.MILLISECONDS
-            )
-            try {
-                val joined = runCatching { delegate.join() }
-                if (joined.exceptionOrNull() is InterruptedException) {
-                    Thread.interrupted()
-                    throw TimeoutException("joinUntil deadline exceeded")
+            interruptJoinUntil(deadline, "jdk25-any-scope-timeout") {
+                // InterruptedException은 interruptJoinUntil의 catch 블록으로 전파; 나머지는 capture
+                try {
+                    joinedResult = Result.success(delegate.join())
+                } catch (e: Exception) {
+                    if (e is InterruptedException) throw e
+                    joinedResult = Result.failure(e)
                 }
-                joinedResult = joined
-                Thread.interrupted()
-            } finally {
-                timeoutFuture.cancel(false)
-                scheduler.shutdownNow()
             }
             return this
         }
@@ -329,31 +331,7 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
         }
 
         override fun joinUntil(deadline: Instant): StructuredTaskScopeSupervised<T> {
-            val remaining = Duration.between(Instant.now(), deadline)
-            if (remaining.isNegative || remaining.isZero) {
-                throw TimeoutException("Deadline already passed")
-            }
-            val ownerThread = Thread.currentThread()
-            val scheduler = ScheduledThreadPoolExecutor(1) { r ->
-                Thread(r, "jdk25-supervised-timeout").apply { isDaemon = true }
-            }
-            val timeoutFuture = scheduler.schedule(
-                { ownerThread.interrupt() },
-                remaining.toMillis(),
-                TimeUnit.MILLISECONDS
-            )
-            try {
-                delegate.join()
-                // 성공적으로 join된 경우, 타이머가 이미 발동됐을 수 있는 spurious interrupt를 클리어
-                Thread.interrupted()
-            } catch (e: InterruptedException) {
-                // 타이머가 발생시킨 interrupt — 소비하고 TimeoutException으로 변환
-                Thread.interrupted()
-                throw TimeoutException("joinUntil deadline exceeded")
-            } finally {
-                timeoutFuture.cancel(false)
-                scheduler.shutdownNow()
-            }
+            interruptJoinUntil(deadline, "jdk25-supervised-timeout") { delegate.join() }
             return this
         }
 

--- a/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderExtTest.kt
+++ b/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderExtTest.kt
@@ -10,7 +10,7 @@ import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeBlank
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.condition.EnabledOnJre
+import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
 import java.time.Instant
 import java.util.concurrent.StructuredTaskScope
@@ -22,7 +22,7 @@ import org.amshove.kluent.internal.assertFailsWith
  * - AllScope/AnyScope 추가 시나리오 (name, joinUntil, subtask 상태)
  * - Jdk25Subtask 상태 검증
  */
-@EnabledOnJre(JRE.JAVA_25)
+@EnabledForJreRange(min = JRE.JAVA_25)
 class Jdk25StructuredTaskScopeProviderExtTest {
 
     companion object: KLoggingChannel()

--- a/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderTest.kt
+++ b/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderTest.kt
@@ -6,13 +6,13 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
 import org.amshove.kluent.shouldBeTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.condition.EnabledOnJre
+import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
 import java.time.Instant
 import java.util.concurrent.TimeoutException
 import org.amshove.kluent.internal.assertFailsWith
 
-@EnabledOnJre(JRE.JAVA_25)
+@EnabledForJreRange(min = JRE.JAVA_25)
 class Jdk25StructuredTaskScopeProviderTest {
 
     companion object: KLoggingChannel()
@@ -114,6 +114,27 @@ class Jdk25StructuredTaskScopeProviderTest {
     }
 
     @Test
+    fun `withAll joinUntil 데드라인 초과 시 TimeoutException 이 발생해야 한다`() {
+        assertFailsWith<TimeoutException> {
+            provider.withAll { scope ->
+                scope.fork { Thread.sleep(10_000); 42 }
+                scope.joinUntil(Instant.now().plusMillis(100))
+                scope.throwIfFailed()
+            }
+        }
+    }
+
+    @Test
+    fun `withAll joinUntil 내 데드라인 이전에 완료되면 정상 결과를 반환해야 한다`() {
+        val result = provider.withAll { scope ->
+            val task = scope.fork { 42 }
+            scope.joinUntil(Instant.now().plusSeconds(5)).throwIfFailed()
+            task.get()
+        }
+        result shouldBeEqualTo 42
+    }
+
+    @Test
     fun `withAny should return first success`() {
         val result = provider.withAny { scope ->
             scope.fork {
@@ -129,6 +150,25 @@ class Jdk25StructuredTaskScopeProviderTest {
             scope.join().result { IllegalStateException(it) }
         }
 
+        result shouldBeEqualTo "fast"
+    }
+
+    @Test
+    fun `withAny joinUntil 데드라인 초과 시 TimeoutException 이 발생해야 한다`() {
+        assertFailsWith<TimeoutException> {
+            provider.withAny<String> { scope ->
+                scope.fork { Thread.sleep(10_000); "slow" }
+                scope.joinUntil(Instant.now().plusMillis(100)).result { RuntimeException(it) }
+            }
+        }
+    }
+
+    @Test
+    fun `withAny joinUntil 내 데드라인 이전에 완료되면 정상 결과를 반환해야 한다`() {
+        val result = provider.withAny<String> { scope ->
+            scope.fork { "fast" }
+            scope.joinUntil(Instant.now().plusSeconds(5)).result { RuntimeException(it) }
+        }
         result shouldBeEqualTo "fast"
     }
 }

--- a/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25TaskContextTest.kt
+++ b/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25TaskContextTest.kt
@@ -7,14 +7,14 @@ import org.amshove.kluent.internal.assertFailsWith
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.condition.EnabledOnJre
+import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * JDK 25 (stable ScopedValue API) 환경에서 [TaskContext] ScopedValue 전파 통합 테스트
  */
-@EnabledOnJre(JRE.JAVA_25)
+@EnabledForJreRange(min = JRE.JAVA_25)
 class Jdk25TaskContextTest {
 
     companion object : KLogging()
@@ -77,7 +77,7 @@ class Jdk25TaskContextTest {
             provider.withSupervised<String, List<Result<String>>> { scope ->
                 scope.fork { TaskContext.get(requestId) ?: "NOT_FOUND" }
                 scope.fork { TaskContext.get(requestId) ?: "NOT_FOUND" }
-                scope.fork<String> { throw RuntimeException("intentional failure") }
+                scope.fork { throw RuntimeException("intentional failure") }
                 scope.join()
                 scope.results()
             }


### PR DESCRIPTION
## Summary

Closes #266, #268, #269

- PR 제목: fix: virtualthread timeout 버그 수정 및 JDK 호환성 개선 (#266 #268 #269)

GitHub Issue #266, #268, #269를 수정합니다.
Issue #265, #267은 PR #271에서 처리되었습니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### fix #268: `joinUntil` 기본 구현이 deadline을 무시하던 버그

`StructuredTaskScopeAll`, `StructuredTaskScopeSupervised`의 인터페이스에 `joinUntil(deadline: Instant) = join()` 기본 구현이 있어 deadline이 완전히 무시되는 문제 수정.

- `joinUntil`을 **abstract**로 변경하여 모든 구현체가 deadline 위임을 강제하도록 수정

### fix #266: `StructuredTaskScopeAny`에 `joinUntil` 추가

`StructuredTaskScopeAny` 인터페이스에 `joinUntil` 메서드가 없어 `ParallelWorkFlow.executeAny()`의 timeout 기능이 작동하지 않던 문제 수정.

- `StructuredTaskScopeAny<T>`에 `joinUntil(deadline: Instant)` 추가
- `Jdk21AnyScope`: `ShutdownOnSuccess.joinUntil()` 위임
- `Jdk25AnyScope`: interrupt 기반 타임아웃 구현
- `ParallelWorkFlow.executeAny()`: deadline 계산 후 `joinUntil()` 사용 + `TimeoutException` → `WorkReport.Cancelled` 변환 수정

### fix #269: `StructuredTaskScopeTester.run()` 무한 대기 방지

테스트 중 subtask가 행(hang)될 경우 테스트 스위트 전체가 무한 대기하는 문제 수정.

- `withTimeout(Duration)` 빌더 메서드 추가
- `run()`에서 timeout 설정 시 `joinUntil()` 사용

### fix: `TaskContext` JDK21/JDK25 바이너리 호환성

`ScopedValue.Carrier.call(Callable)` → JDK24+에서 `call(ScopedValue.CallableOp)`으로 변경되어 바이너리 불호환 발생.

- `TaskContext.run()`과 `TaskContextBindings.call()` 모두 `run(Runnable)` + `runCatching` capture 패턴으로 수정

### refactor: JDK25 `joinUntil` 중복 제거

JDK25 3개 scope (`Jdk25AllScope`, `Jdk25AnyScope`, `Jdk25SupervisedScope`)의 거의 동일한 interrupt 기반 `joinUntil` 구현을 companion object의 `interruptJoinUntil()` 헬퍼로 추출.

- `toMillis()` → `toNanos()` + `TimeUnit.NANOSECONDS` 로 정밀도 개선
- `captured!!` → `checkNotNull(captured)` 변환 (프로젝트 규칙: `!!` 사용 금지)

### test: JDK25 forward compatibility

- `@EnabledOnJre(JRE.JAVA_25)` → `@EnabledForJreRange(min = JRE.JAVA_25)` 변경 (JDK25+ 모두 실행)

### 기존 섹션: 검증 명령

```bash
./gradlew :bluetape4k-virtualthread-api:test :bluetape4k-virtualthread-jdk21:test :bluetape4k-workflow:test :bluetape4k-junit5:test
```

Closes #266
Closes #268
Closes #269

## Validation

| 모듈 | 결과 |
|------|------|
| `:bluetape4k-virtualthread-api` | ✅ passing |
| `:bluetape4k-virtualthread-jdk21` | ✅ passing |
| `:bluetape4k-workflow` | ✅ passing |
| `:bluetape4k-junit5` | ✅ **251 passing** (7.3s) |

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #266, #268, #269, milestone 없음, assignee `debop`
- PR: #272, head `d5465290fa4cdc72de9dbca2d35f79253f8e85b1`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/vthread-timeout-fixes`
- Labels: `bug`
- State: `MERGED`, merge commit `e325721a5821e38a6d298b0acc2efda3226f701d`
- CI: ./gradlew :bluetape4k-virtualthread-api:test :bluetape4k-virtualthread-jdk21:test :bluetape4k-workflow:test :bluetape4k-junit5:test

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #272 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e325721a5821e38a6d298b0acc2efda3226f701d`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
