### PR TITLE
feat: Coroutines-StructuredTaskScope 브릿지 추가 (#254)

### DIFF
--- a/bluetape4k/coroutines/README.ko.md
+++ b/bluetape4k/coroutines/README.ko.md
@@ -302,6 +302,71 @@ val vtScope = VirtualThreadCoroutineScope()
 - `ThreadPoolCoroutineScope`: 고정 크기 풀, 명시적 `close()` 필요
 - `VirtualThreadCoroutineScope`: 가상 스레드 디스패처 기반 스코프
 
+### 구조화된 동시성 — StructuredTaskScope 브릿지
+
+`StructuredConcurrency.kt`는 JDK `StructuredTaskScope`(가상 스레드 구조화된 동시성)와 Kotlin Coroutines를 연결하며, `Dispatchers.VT`에서 실행되는 DSL 스타일 suspend 함수를 제공합니다.
+
+#### suspend 진입점
+
+| 함수 | 동작 | 내부 구현 |
+|---|---|---|
+| `taskScope { }` | Fail-fast: 첫 실패 시 나머지 subtask 즉시 중단 | `StructuredTaskScopes.failFast` |
+| `failFastTaskScope { }` | `taskScope`의 의도 명확 별칭 | `StructuredTaskScopes.failFast` |
+| `firstSuccessTaskScope<T> { }` | First-success: 가장 빠른 성공 결과 반환, 나머지 취소 | `StructuredTaskScopes.firstSuccess` |
+| `supervisedTaskScope<T, R> { }` | Supervised: 모든 subtask 실행, 부분 실패 허용 | `StructuredTaskScopes.supervised` |
+
+#### async(비동기) 진입점
+
+| 함수 | 반환값 | 용도 |
+|---|---|---|
+| `CoroutineScope.asyncTaskScope { }` | `Deferred<T>` | `awaitAll`로 병렬 fail-fast scope |
+| `CoroutineScope.asyncSupervisedTaskScope<T, R> { }` | `Deferred<R>` | `awaitAll`로 병렬 supervised scope |
+
+블록 내부에서 `this`가 scope이므로 `fork { }`, `join()`, `throwIfFailed()`, `results()` 등을 직접 호출합니다.
+
+```kotlin
+import io.bluetape4k.coroutines.taskScope
+import io.bluetape4k.coroutines.firstSuccessTaskScope
+import io.bluetape4k.coroutines.supervisedTaskScope
+import io.bluetape4k.coroutines.asyncTaskScope
+
+// Fail-fast: 모든 subtask 성공 필요
+val sum = taskScope {
+    val a = fork { fetchA() }
+    val b = fork { fetchB() }
+    join().throwIfFailed()
+    a.get() + b.get()
+}
+
+// First-success: 가장 빠른 소스 선택
+val result = firstSuccessTaskScope<String> {
+    fork { fetchFromPrimary() }
+    fork { fetchFromFallback() }
+    join().result { IllegalStateException("모든 소스 실패") }
+}
+
+// Supervised: 부분 실패 허용
+val allResults = supervisedTaskScope<Int, List<Result<Int>>> {
+    fork { 1 }
+    fork { throw RuntimeException("subtask 실패") }
+    fork { 3 }
+    join()
+    results()
+}
+// allResults.filter { it.isSuccess }.map { it.getOrThrow() } == [1, 3]
+
+// Async: 병렬 fail-fast scope
+val d1 = asyncTaskScope { val t = fork { fetchA() }; join().throwIfFailed(); t.get() }
+val d2 = asyncTaskScope { val t = fork { fetchB() }; join().throwIfFailed(); t.get() }
+val (r1, r2) = awaitAll(d1, d2)
+```
+
+동작 특성:
+
+- 모든 suspend 변형은 `withContext(Dispatchers.VT)` 내에서 실행 — blocking `join()`이 가상 스레드로 오프로드됨
+- `async` 변형은 즉시 `Deferred<T>`를 반환하며 백그라운드에서 실행; 실패를 테스트할 때는 `supervisorScope { }`로 격리 필요
+- `joinUntil(deadline)` 데드라인 초과 시 `TimeoutException` 발생
+
 ### Reactor 컨텍스트 헬퍼
 
 Reactor 전용 헬퍼는 `io.bluetape4k.coroutines.reactor`에 있습니다.

--- a/bluetape4k/coroutines/README.md
+++ b/bluetape4k/coroutines/README.md
@@ -302,6 +302,71 @@ val vtScope = VirtualThreadCoroutineScope()
 - `ThreadPoolCoroutineScope`: fixed-size pool with explicit `close()`
 - `VirtualThreadCoroutineScope`: virtual-thread dispatcher backed scope
 
+### Structured Concurrency — StructuredTaskScope Bridge
+
+`StructuredConcurrency.kt` bridges JDK `StructuredTaskScope` (virtual-thread structured concurrency) with Kotlin Coroutines, providing DSL-style suspend functions that run on `Dispatchers.VT`.
+
+#### Suspend entry points
+
+| Function | Behavior | Underlying |
+|---|---|---|
+| `taskScope { }` | Fail-fast: first failure cancels remaining tasks | `StructuredTaskScopes.failFast` |
+| `failFastTaskScope { }` | Alias for `taskScope` with explicit name | `StructuredTaskScopes.failFast` |
+| `firstSuccessTaskScope<T> { }` | First-success: returns earliest success, cancels rest | `StructuredTaskScopes.firstSuccess` |
+| `supervisedTaskScope<T, R> { }` | Supervised: all tasks run; partial failures allowed | `StructuredTaskScopes.supervised` |
+
+#### Async (non-blocking) entry points
+
+| Function | Returns | Usage |
+|---|---|---|
+| `CoroutineScope.asyncTaskScope { }` | `Deferred<T>` | Parallel fail-fast scopes via `awaitAll` |
+| `CoroutineScope.asyncSupervisedTaskScope<T, R> { }` | `Deferred<R>` | Parallel supervised scopes via `awaitAll` |
+
+Inside each block, `this` is the scope — call `fork { }`, `join()`, `throwIfFailed()`, `results()`, etc. directly.
+
+```kotlin
+import io.bluetape4k.coroutines.taskScope
+import io.bluetape4k.coroutines.firstSuccessTaskScope
+import io.bluetape4k.coroutines.supervisedTaskScope
+import io.bluetape4k.coroutines.asyncTaskScope
+
+// Fail-fast: all tasks must succeed
+val sum = taskScope {
+    val a = fork { fetchA() }
+    val b = fork { fetchB() }
+    join().throwIfFailed()
+    a.get() + b.get()
+}
+
+// First-success: fastest source wins
+val result = firstSuccessTaskScope<String> {
+    fork { fetchFromPrimary() }
+    fork { fetchFromFallback() }
+    join().result { IllegalStateException("all sources failed") }
+}
+
+// Supervised: partial failures tolerated
+val allResults = supervisedTaskScope<Int, List<Result<Int>>> {
+    fork { 1 }
+    fork { throw RuntimeException("subtask failed") }
+    fork { 3 }
+    join()
+    results()
+}
+// allResults.filter { it.isSuccess }.map { it.getOrThrow() } == [1, 3]
+
+// Async: parallel fail-fast scopes
+val d1 = asyncTaskScope { val t = fork { fetchA() }; join().throwIfFailed(); t.get() }
+val d2 = asyncTaskScope { val t = fork { fetchB() }; join().throwIfFailed(); t.get() }
+val (r1, r2) = awaitAll(d1, d2)
+```
+
+Behavior notes:
+
+- All suspend variants run inside `withContext(Dispatchers.VT)` — blocking `join()` is offloaded to virtual threads
+- `async` variants start immediately and return `Deferred<T>`; use `supervisorScope { }` in tests when expecting failures
+- `joinUntil(deadline)` triggers `TimeoutException` on deadline breach
+
 ### Reactor Context Helpers
 
 Reactor-specific helpers live in `io.bluetape4k.coroutines.reactor`.

--- a/bluetape4k/coroutines/build.gradle.kts
+++ b/bluetape4k/coroutines/build.gradle.kts
@@ -35,8 +35,16 @@ configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
 }
 
+val currentJvmMajor = JavaVersion.current().majorVersion.toInt()
+
 dependencies {
     api(project(":bluetape4k-core"))
+    api(project(":bluetape4k-virtualthread-api"))
+    if (currentJvmMajor >= 25) {
+        compileOnly(project(":bluetape4k-virtualthread-jdk25"))
+    } else {
+        compileOnly(project(":bluetape4k-virtualthread-jdk21"))
+    }
     testImplementation(project(":bluetape4k-junit5"))
 
     // Coroutines

--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/StructuredConcurrency.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/StructuredConcurrency.kt
@@ -1,0 +1,207 @@
+package io.bluetape4k.coroutines
+
+import io.bluetape4k.concurrent.virtualthread.StructuredTaskScopeAll
+import io.bluetape4k.concurrent.virtualthread.StructuredTaskScopeAny
+import io.bluetape4k.concurrent.virtualthread.StructuredTaskScopeSupervised
+import io.bluetape4k.concurrent.virtualthread.StructuredTaskScopes
+import io.bluetape4k.concurrent.virtualthread.VT
+import io.bluetape4k.concurrent.virtualthread.VirtualThreads
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
+import java.util.concurrent.ThreadFactory
+
+/**
+ * Fail-fast `StructuredTaskScope`를 코루틴에서 사용할 수 있는 suspend 함수입니다.
+ *
+ * ## 동작/계약
+ * - `Dispatchers.VT`(가상 스레드)에서 [StructuredTaskScopes.failFast]를 실행합니다.
+ * - 하나의 subtask라도 실패하면 나머지를 즉시 취소하고 예외를 전파합니다.
+ * - 코루틴 취소 시 scope 내 미완료 작업을 정리합니다.
+ *
+ * ```kotlin
+ * val sum = taskScope {
+ *     val a = fork { 1 }
+ *     val b = fork { 2 }
+ *     join().throwIfFailed()
+ *     a.get() + b.get()
+ * }
+ * // sum == 3
+ * ```
+ *
+ * @param name scope 이름 (디버깅용, 기본값: null)
+ * @param factory subtask 실행용 스레드 팩토리 (기본값: [VirtualThreads.threadFactory])
+ * @param block scope 실행 블록 — `this`가 [StructuredTaskScopeAll]
+ * @return [block]의 실행 결과
+ * @see StructuredTaskScopes.failFast
+ */
+suspend fun <T> taskScope(
+    name: String? = null,
+    factory: ThreadFactory = VirtualThreads.threadFactory(),
+    block: StructuredTaskScopeAll.() -> T,
+): T = withContext(Dispatchers.VT) {
+    StructuredTaskScopes.failFast(name, factory) { scope -> block(scope) }
+}
+
+/**
+ * Fail-fast `StructuredTaskScope`를 코루틴에서 사용할 수 있는 suspend 함수입니다.
+ *
+ * [taskScope]의 이름이 의도를 더 명확히 표현하는 별칭입니다.
+ *
+ * ```kotlin
+ * val sum = failFastTaskScope {
+ *     val a = fork { 1 }
+ *     val b = fork { 2 }
+ *     join().throwIfFailed()
+ *     a.get() + b.get()
+ * }
+ * // sum == 3
+ * ```
+ *
+ * @see taskScope
+ */
+suspend fun <T> failFastTaskScope(
+    name: String? = null,
+    factory: ThreadFactory = VirtualThreads.threadFactory(),
+    block: StructuredTaskScopeAll.() -> T,
+): T = taskScope(name, factory, block)
+
+/**
+ * First-success `StructuredTaskScope`를 코루틴에서 사용할 수 있는 suspend 함수입니다.
+ *
+ * ## 동작/계약
+ * - `Dispatchers.VT`(가상 스레드)에서 [StructuredTaskScopes.firstSuccess]를 실행합니다.
+ * - 첫 번째 성공한 subtask 결과를 반환하고 나머지를 취소합니다.
+ * - 모든 subtask가 실패하면 [StructuredTaskScopeAny.result]의 mapper 예외가 발생합니다.
+ *
+ * ```kotlin
+ * val winner = firstSuccessTaskScope<String> {
+ *     fork { fetchFromPrimary() }
+ *     fork { fetchFromFallback() }
+ *     join().result { IllegalStateException("모든 소스 실패: ${it.message}") }
+ * }
+ * ```
+ *
+ * @param name scope 이름 (디버깅용, 기본값: null)
+ * @param factory subtask 실행용 스레드 팩토리 (기본값: [VirtualThreads.threadFactory])
+ * @param block scope 실행 블록 — `this`가 [StructuredTaskScopeAny]<T>
+ * @return 가장 먼저 성공한 subtask의 결과
+ * @see StructuredTaskScopes.firstSuccess
+ */
+suspend fun <T> firstSuccessTaskScope(
+    name: String? = null,
+    factory: ThreadFactory = VirtualThreads.threadFactory(),
+    block: StructuredTaskScopeAny<T>.() -> T,
+): T = withContext(Dispatchers.VT) {
+    StructuredTaskScopes.firstSuccess(name, factory) { scope -> block(scope) }
+}
+
+/**
+ * Supervised `StructuredTaskScope`를 코루틴에서 사용할 수 있는 suspend 함수입니다.
+ *
+ * ## 동작/계약
+ * - `Dispatchers.VT`(가상 스레드)에서 [StructuredTaskScopes.supervised]를 실행합니다.
+ * - 하나의 subtask가 실패해도 나머지 subtask를 계속 실행합니다 (fail-fast 아님).
+ * - [join] 이후 [results]로 `Result<T>` 통합 조회하거나, [successfulResults] / [failedExceptions]로 분리합니다.
+ *
+ * ```kotlin
+ * val allResults = supervisedTaskScope<Int, List<Result<Int>>> {
+ *     fork { 1 }
+ *     fork { throw RuntimeException("실패") }
+ *     fork { 3 }
+ *     join()
+ *     results()
+ * }
+ * // allResults.filter { it.isSuccess }.map { it.getOrThrow() } == [1, 3]
+ * ```
+ *
+ * @param name scope 이름 (디버깅용, 기본값: null)
+ * @param factory subtask 실행용 스레드 팩토리 (기본값: [VirtualThreads.threadFactory])
+ * @param block scope 실행 블록 — `this`가 [StructuredTaskScopeSupervised]<T>
+ * @return [block]의 실행 결과
+ * @see StructuredTaskScopes.supervised
+ */
+suspend fun <T, R> supervisedTaskScope(
+    name: String? = null,
+    factory: ThreadFactory = VirtualThreads.threadFactory(),
+    block: StructuredTaskScopeSupervised<T>.() -> R,
+): R = withContext(Dispatchers.VT) {
+    StructuredTaskScopes.supervised(name, factory) { scope -> block(scope) }
+}
+
+/**
+ * Fail-fast `StructuredTaskScope`를 비동기 [Deferred]로 실행합니다.
+ *
+ * ## 동작/계약
+ * - `Dispatchers.VT`(가상 스레드)에서 [StructuredTaskScopes.failFast]를 비동기 실행합니다.
+ * - 즉시 [Deferred]를 반환하고, 실제 실행은 백그라운드에서 진행됩니다.
+ * - [Deferred.await] 시 결과 또는 예외를 받습니다.
+ * - 코루틴 취소 시 scope 내 미완료 작업을 정리합니다.
+ *
+ * ```kotlin
+ * // 여러 StructuredTaskScope를 병렬로 실행
+ * val deferred1 = asyncTaskScope {
+ *     val a = fork { fetchData("source1") }
+ *     join().throwIfFailed()
+ *     a.get()
+ * }
+ * val deferred2 = asyncTaskScope {
+ *     val b = fork { fetchData("source2") }
+ *     join().throwIfFailed()
+ *     b.get()
+ * }
+ * val (result1, result2) = awaitAll(deferred1, deferred2)
+ * ```
+ *
+ * @param name scope 이름 (디버깅용, 기본값: null)
+ * @param factory subtask 실행용 스레드 팩토리 (기본값: [VirtualThreads.threadFactory])
+ * @param block scope 실행 블록 — `this`가 [StructuredTaskScopeAll]
+ * @return 결과를 나타내는 [Deferred]
+ * @see taskScope
+ * @see StructuredTaskScopes.failFast
+ */
+fun <T> CoroutineScope.asyncTaskScope(
+    name: String? = null,
+    factory: ThreadFactory = VirtualThreads.threadFactory(),
+    block: StructuredTaskScopeAll.() -> T,
+): Deferred<T> = async(Dispatchers.VT) {
+    StructuredTaskScopes.failFast(name, factory) { scope -> block(scope) }
+}
+
+/**
+ * Supervised `StructuredTaskScope`를 비동기 [Deferred]로 실행합니다.
+ *
+ * ## 동작/계약
+ * - `Dispatchers.VT`(가상 스레드)에서 [StructuredTaskScopes.supervised]를 비동기 실행합니다.
+ * - 즉시 [Deferred]를 반환하고, 실제 실행은 백그라운드에서 진행됩니다.
+ * - 하나의 subtask가 실패해도 나머지를 계속 실행합니다 (fail-fast 아님).
+ * - [Deferred.await] 시 최종 결과(성공/실패 혼합 가능)를 받습니다.
+ *
+ * ```kotlin
+ * val deferred = asyncSupervisedTaskScope<Int, List<Result<Int>>> {
+ *     fork { 1 }
+ *     fork { throw RuntimeException("실패") }
+ *     fork { 3 }
+ *     join()
+ *     results()
+ * }
+ * val allResults = deferred.await()
+ * // allResults.filter { it.isSuccess }.size == 2
+ * ```
+ *
+ * @param name scope 이름 (디버깅용, 기본값: null)
+ * @param factory subtask 실행용 스레드 팩토리 (기본값: [VirtualThreads.threadFactory])
+ * @param block scope 실행 블록 — `this`가 [StructuredTaskScopeSupervised]<T>
+ * @return 결과를 나타내는 [Deferred]
+ * @see supervisedTaskScope
+ * @see StructuredTaskScopes.supervised
+ */
+fun <T, R> CoroutineScope.asyncSupervisedTaskScope(
+    name: String? = null,
+    factory: ThreadFactory = VirtualThreads.threadFactory(),
+    block: StructuredTaskScopeSupervised<T>.() -> R,
+): Deferred<R> = async(Dispatchers.VT) {
+    StructuredTaskScopes.supervised(name, factory) { scope -> block(scope) }
+}

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/StructuredConcurrencyTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/StructuredConcurrencyTest.kt
@@ -1,0 +1,429 @@
+package io.bluetape4k.coroutines
+
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.supervisorScope
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContainAll
+import org.amshove.kluent.shouldHaveSize
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+
+class StructuredConcurrencyTest {
+
+    companion object: KLoggingChannel()
+
+    // --- taskScope (fail-fast) ---
+
+    @Test
+    fun `taskScope - 두 subtask 합산`() = runSuspendIO {
+        val sum = taskScope {
+            val a = fork { 1 }
+            val b = fork { 2 }
+            join().throwIfFailed()
+            a.get() + b.get()
+        }
+        sum shouldBeEqualTo 3
+    }
+
+    @Test
+    fun `taskScope - 여러 subtask 병렬 실행`() = runSuspendIO {
+        val count = 10
+        val sum = taskScope {
+            val tasks = (1..count).map { i -> fork { i } }
+            join().throwIfFailed()
+            tasks.sumOf { it.get() }
+        }
+        sum shouldBeEqualTo (1..count).sum()
+    }
+
+    @Test
+    fun `taskScope - subtask 실패 시 예외 전파`() = runSuspendIO {
+        assertThrows<RuntimeException> {
+            taskScope<Int> {
+                fork { throw RuntimeException("subtask 실패") }
+                join().throwIfFailed()
+                0
+            }
+        }
+    }
+
+    @Test
+    fun `taskScope - 하나 실패 시 다른 subtask 중단`() = runSuspendIO {
+        val counter = AtomicInteger(0)
+        assertThrows<RuntimeException> {
+            taskScope<Unit> {
+                fork { throw RuntimeException("빠른 실패") }
+                fork {
+                    Thread.sleep(500)
+                    counter.incrementAndGet()
+                }
+                join().throwIfFailed()
+            }
+        }
+        // 빠른 실패로 인해 두 번째 subtask가 실행 완료되지 않아야 함
+        counter.get() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `taskScope - name 파라미터 지정`() = runSuspendIO {
+        val result = taskScope(name = "test-scope") {
+            val t = fork { 42 }
+            join().throwIfFailed()
+            t.get()
+        }
+        result shouldBeEqualTo 42
+    }
+
+    @Test
+    fun `taskScope - getOrNull은 실패 subtask에 null 반환`() = runSuspendIO {
+        val captured = mutableListOf<io.bluetape4k.concurrent.virtualthread.StructuredSubtask<Int>>()
+        assertThrows<RuntimeException> {
+            taskScope<Int> {
+                captured += fork<Int> { throw RuntimeException("실패") }
+                fork { 42 }
+                join().throwIfFailed()
+                0
+            }
+        }
+        (captured.first().getOrNull() == null).shouldBeTrue()
+    }
+
+    // --- failFastTaskScope (alias) ---
+
+    @Test
+    fun `failFastTaskScope - taskScope와 동일하게 동작`() = runSuspendIO {
+        val result = failFastTaskScope {
+            val t = fork { "hello" }
+            join().throwIfFailed()
+            t.get()
+        }
+        result shouldBeEqualTo "hello"
+    }
+
+    // --- firstSuccessTaskScope ---
+
+    @Test
+    fun `firstSuccessTaskScope - 첫 번째 성공 결과 반환`() = runSuspendIO {
+        val winner = firstSuccessTaskScope<String> {
+            fork { "slow" }
+            fork { "fast" }
+            join().result { IllegalStateException("모두 실패: ${it.message}") }
+        }
+        winner.shouldNotBeNull()
+        log.debug { "winner: $winner" }
+    }
+
+    @Test
+    fun `firstSuccessTaskScope - 모두 실패 시 mapper 예외 발생`() = runSuspendIO {
+        assertThrows<IllegalStateException> {
+            firstSuccessTaskScope<String> {
+                fork { throw RuntimeException("실패 1") }
+                fork { throw RuntimeException("실패 2") }
+                join().result { e -> IllegalStateException("모두 실패: ${e.message}") }
+            }
+        }
+    }
+
+    @Test
+    fun `firstSuccessTaskScope - 하나만 성공하면 그 결과 반환`() = runSuspendIO {
+        val result = firstSuccessTaskScope<Int> {
+            fork { throw RuntimeException("실패") }
+            fork { 99 }
+            join().result { IllegalStateException("모두 실패") }
+        }
+        result shouldBeEqualTo 99
+    }
+
+    @Test
+    fun `firstSuccessTaskScope - 여러 소스에서 가장 빠른 결과 선택`() = runSuspendIO {
+        val result = firstSuccessTaskScope<String> {
+            fork {
+                Thread.sleep(200)
+                "느린 소스"
+            }
+            fork {
+                Thread.sleep(10)
+                "빠른 소스"
+            }
+            join().result { IllegalStateException("모두 실패") }
+        }
+        result shouldBeEqualTo "빠른 소스"
+    }
+
+    // --- supervisedTaskScope ---
+
+    @Test
+    fun `supervisedTaskScope - 부분 실패 허용`() = runSuspendIO {
+        val results = supervisedTaskScope<Int, List<Result<Int>>> {
+            fork { 1 }
+            fork { throw RuntimeException("subtask 2 실패") }
+            fork { 3 }
+            join()
+            results()
+        }
+        results shouldHaveSize 3
+        results.count { it.isSuccess } shouldBeEqualTo 2
+        results.count { it.isFailure } shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `supervisedTaskScope - successfulResults 반환`() = runSuspendIO {
+        val successes = supervisedTaskScope<Int, List<Int>> {
+            fork { 10 }
+            fork { throw RuntimeException("실패") }
+            fork { 30 }
+            join()
+            successfulResults()
+        }
+        successes shouldContainAll listOf(10, 30)
+    }
+
+    @Test
+    fun `supervisedTaskScope - failedExceptions 반환`() = runSuspendIO {
+        val failures = supervisedTaskScope<Int, List<Throwable>> {
+            fork { 1 }
+            fork { throw RuntimeException("오류 A") }
+            fork { throw IllegalArgumentException("오류 B") }
+            join()
+            failedExceptions()
+        }
+        failures shouldHaveSize 2
+        failures.any { it is RuntimeException && it.message == "오류 A" }.shouldBeTrue()
+        failures.any { it is IllegalArgumentException && it.message == "오류 B" }.shouldBeTrue()
+    }
+
+    @Test
+    fun `supervisedTaskScope - 모든 subtask 성공 시 results 모두 success`() = runSuspendIO {
+        val results = supervisedTaskScope<Int, List<Result<Int>>> {
+            fork { 1 }
+            fork { 2 }
+            fork { 3 }
+            join()
+            results()
+        }
+        results.all { it.isSuccess }.shouldBeTrue()
+        results.map { it.getOrThrow() }.sum() shouldBeEqualTo 6
+    }
+
+    @Test
+    fun `supervisedTaskScope - 모든 subtask 실패 시 results 모두 failure`() = runSuspendIO {
+        val results = supervisedTaskScope<Int, List<Result<Int>>> {
+            fork { throw RuntimeException("실패 1") }
+            fork { throw RuntimeException("실패 2") }
+            join()
+            results()
+        }
+        results.all { it.isFailure }.shouldBeTrue()
+    }
+
+    @Test
+    fun `supervisedTaskScope - 빈 결과`() = runSuspendIO {
+        val results = supervisedTaskScope<Int, List<Result<Int>>> {
+            join()
+            results()
+        }
+        results shouldHaveSize 0
+    }
+
+    // --- asyncTaskScope ---
+
+    @Test
+    fun `asyncTaskScope - Deferred 반환 후 await`() = runSuspendIO {
+        val deferred = asyncTaskScope {
+            val t = fork { 100 }
+            join().throwIfFailed()
+            t.get()
+        }
+        deferred.await() shouldBeEqualTo 100
+    }
+
+    @Test
+    fun `asyncTaskScope - 복수 Deferred 병렬 실행`() = runSuspendIO {
+        val deferred1 = asyncTaskScope {
+            val t = fork { 10 }
+            join().throwIfFailed()
+            t.get()
+        }
+        val deferred2 = asyncTaskScope {
+            val t = fork { 20 }
+            join().throwIfFailed()
+            t.get()
+        }
+        val (r1, r2) = awaitAll(deferred1, deferred2)
+        r1 + r2 shouldBeEqualTo 30
+    }
+
+    @Test
+    fun `asyncTaskScope - 실패 시 await에서 예외 발생`() = runSuspendIO {
+        // async 예외가 parent scope로 전파되지 않도록 supervisorScope로 격리
+        supervisorScope {
+            val deferred = asyncTaskScope<Int> {
+                fork { throw RuntimeException("비동기 실패") }
+                join().throwIfFailed()
+                0
+            }
+            val result = runCatching { deferred.await() }
+            result.isFailure.shouldBeTrue()
+            result.exceptionOrNull().shouldBeInstanceOf<RuntimeException>()
+        }
+    }
+
+    @Test
+    fun `asyncTaskScope - 여러 scope 동시 실행 후 합산`() = runSuspendIO {
+        val count = 5
+        val deferreds = (1..count).map { i ->
+            asyncTaskScope {
+                val t = fork { i * 10 }
+                join().throwIfFailed()
+                t.get()
+            }
+        }
+        val total = awaitAll(*deferreds.toTypedArray()).sum()
+        total shouldBeEqualTo (1..count).sumOf { it * 10 }
+    }
+
+    // --- asyncSupervisedTaskScope ---
+
+    @Test
+    fun `asyncSupervisedTaskScope - Deferred로 supervised 실행`() = runSuspendIO {
+        val deferred = asyncSupervisedTaskScope<Int, List<Result<Int>>> {
+            fork { 1 }
+            fork { throw RuntimeException("실패") }
+            fork { 3 }
+            join()
+            results()
+        }
+        val results = deferred.await()
+        results shouldHaveSize 3
+        results.count { it.isSuccess } shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `asyncSupervisedTaskScope - successfulResults만 반환`() = runSuspendIO {
+        val deferred = asyncSupervisedTaskScope<String, List<String>> {
+            fork { "A" }
+            fork { throw RuntimeException("실패") }
+            fork { "C" }
+            join()
+            successfulResults()
+        }
+        val successes = deferred.await()
+        successes shouldContainAll listOf("A", "C")
+    }
+
+    // --- 리소스 해제 및 Edge case ---
+
+    @Test
+    fun `taskScope - 빈 scope 실행`() = runSuspendIO {
+        val result = taskScope {
+            join().throwIfFailed()
+            42
+        }
+        result shouldBeEqualTo 42
+    }
+
+    @Test
+    fun `taskScope - 대량 subtask 처리`() = runSuspendIO {
+        val count = 1000
+        val sum = taskScope {
+            val tasks = (1..count).map { i -> fork { i } }
+            join().throwIfFailed()
+            tasks.sumOf { it.get() }
+        }
+        sum shouldBeEqualTo (1..count).sum()
+    }
+
+    @Test
+    fun `taskScope - subtask 결과 타입 다양성`() = runSuspendIO {
+        val result = taskScope {
+            val intTask = fork { 42 }
+            val strTask = fork { "hello" }
+            join().throwIfFailed()
+            "${intTask.get()}-${strTask.get()}"
+        }
+        result shouldBeEqualTo "42-hello"
+    }
+
+    @Test
+    fun `supervisedTaskScope - 부분 결과로 집계 가능`() = runSuspendIO {
+        val successCount = supervisedTaskScope<Int, Int> {
+            repeat(10) { i ->
+                fork { if (i % 2 == 0) i else throw RuntimeException("홀수 실패 $i") }
+            }
+            join()
+            successfulResults().size
+        }
+        successCount shouldBeEqualTo 5
+    }
+
+    @Test
+    fun `taskScope joinUntil - 데드라인 초과 시 TimeoutException`() = runSuspendIO {
+        val deadline = java.time.Instant.now().plusMillis(50)
+        assertThrows<TimeoutException> {
+            taskScope<Unit> {
+                fork { Thread.sleep(5000) }
+                joinUntil(deadline).throwIfFailed()
+            }
+        }
+    }
+
+    @Test
+    fun `supervisedTaskScope joinUntil - 데드라인 초과 시 TimeoutException`() = runSuspendIO {
+        val deadline = java.time.Instant.now().plusMillis(50)
+        assertThrows<TimeoutException> {
+            supervisedTaskScope<Int, List<Result<Int>>> {
+                fork { Thread.sleep(5000); 1 }
+                joinUntil(deadline)
+                results()
+            }
+        }
+    }
+
+    @Test
+    fun `asyncTaskScope - 여러 번 중첩 실행 가능`() = runSuspendIO {
+        val result = taskScope {
+            val inner = fork {
+                // 내부에서는 blocking 코드 (가상 스레드에서 실행 중)
+                42
+            }
+            join().throwIfFailed()
+            inner.get()
+        }
+        result shouldBeEqualTo 42
+    }
+
+    @Test
+    fun `supervisedTaskScope - results 순서 확인`() = runSuspendIO {
+        val counter = AtomicInteger(0)
+        val results = supervisedTaskScope<Int, List<Result<Int>>> {
+            repeat(5) { fork { counter.incrementAndGet() } }
+            join()
+            results()
+        }
+        results shouldHaveSize 5
+        results.count { it.isSuccess } shouldBeEqualTo 5
+        results.mapNotNull { it.getOrNull() }.sum() shouldBeEqualTo (1..5).sum()
+    }
+
+    @Test
+    fun `taskScope - Dispatchers VT 에서 실행 확인`() = runSuspendIO {
+        val threadName = taskScope {
+            val t = fork { Thread.currentThread().name }
+            join().throwIfFailed()
+            t.get()
+        }
+        log.debug { "Executing thread: $threadName" }
+        threadName.shouldNotBeNull()
+        // 가상 스레드는 이름에 "VirtualThread" 혹은 프리픽스 포함
+        threadName.contains("vt-", ignoreCase = true).shouldBeTrue()
+    }
+}


### PR DESCRIPTION
## Summary

Closes #254

- PR 제목: feat: Coroutines-StructuredTaskScope 브릿지 추가 (#254)

Issue #254 — Coroutines 통합 강화: JDK `StructuredTaskScope`와 Kotlin Coroutines 브릿지 구현

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 신규 파일

**`StructuredConcurrency.kt`** (`bluetape4k/coroutines`)

| 함수 | 동작 |
|---|---|
| `taskScope { }` | Fail-fast DSL. `Dispatchers.VT`에서 실행. `fork {}` 중 하나라도 실패하면 즉시 예외 전파 |
| `failFastTaskScope { }` | `taskScope`의 의도 명확 별칭 |
| `firstSuccessTaskScope<T> { }` | 첫 번째 성공 subtask 결과 반환, 나머지 취소 |
| `supervisedTaskScope<T, R> { }` | 모든 subtask 실행, 부분 실패 허용. `results()`/`successfulResults()`/`failedExceptions()`로 분리 조회 |
| `CoroutineScope.asyncTaskScope { }` | `Deferred<T>` 즉시 반환, 백그라운드 fail-fast 실행 |
| `CoroutineScope.asyncSupervisedTaskScope<T, R> { }` | `Deferred<R>` 즉시 반환, 백그라운드 supervised 실행 |

모든 suspend 함수는 `withContext(Dispatchers.VT)`로 블로킹 `join()`을 가상 스레드에 오프로드합니다.

### 수정 파일

**`build.gradle.kts`** (`bluetape4k/coroutines`)
- `api(project(":bluetape4k-virtualthread-api"))` 추가
- JVM 버전별 if/else: Java 25+ → jdk25, 그 외 → jdk21 (`compileOnly`)

### 테스트

**`StructuredConcurrencyTest.kt`** — 32개 테스트

- 기본 동작: 합산, 병렬 실행, 부분 실패
- Edge case: 빈 scope, 대량 subtask(1000개), 타입 다양성
- 리소스 해제: `joinUntil` 데드라인 초과 → `TimeoutException`
- Cancellation: fail-fast 시 다른 subtask 중단 확인
- async 패턴: `supervisorScope`로 격리 후 await 실패 검증

### 기존 섹션: 관련 이슈

Closes #254 (Epic #256 마지막 sub-issue)

## Validation

```
Module : :bluetape4k-coroutines
Result : 549 passing
Time   : 21s
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #254, milestone 없음, assignee 없음
- PR: #273, head `2d800fea856c6ccc1919331683f5203ae2c61503`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/task-scope`
- Labels: 없음
- State: `MERGED`, merge commit `d6b936bc777e07677d0919b91fef8a9f3fdb45ec`
- CI: **`build.gradle.kts`** (`bluetape4k/coroutines`)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #273 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `d6b936bc777e07677d0919b91fef8a9f3fdb45ec`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
