### PR TITLE
fix: grpc-protoc-gen-grpc-kotlin classifier 'jdk8@jar' 명시

### DIFF
--- a/io/grpc/build.gradle.kts
+++ b/io/grpc/build.gradle.kts
@@ -24,7 +24,7 @@ protobuf {
             artifact = libs.grpc.protoc.gen.grpc.java.get().toString()
         }
         id("grpcKt") {
-            artifact = libs.grpc.protoc.gen.grpc.kotlin.get().toString()
+            artifact = "io.grpc:protoc-gen-grpc-kotlin:${libs.versions.grpc.kotlin.get()}:jdk8@jar"
         }
     }
     generateProtoTasks {


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: grpc-protoc-gen-grpc-kotlin classifier 'jdk8@jar' 명시

### 원문 선행 내용

CI 오류 'Could not find protoc-gen-grpc-kotlin-1.5.0-linux-x86_64.exe' 수정. classifier 보존을 위해 build.gradle.kts에서 직접 string 사용.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

CI 오류 'Could not find protoc-gen-grpc-kotlin-1.5.0-linux-x86_64.exe' 수정. classifier 보존을 위해 build.gradle.kts에서 직접 string 사용.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #277, head `3fab98603ec31a00d40ade8fa8d4c470ff90255f`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/grpc-protoc-kotlin-classifier`
- Labels: 없음
- State: `MERGED`, merge commit `fff9cf82e7bcaa261119a2cce2f3829446b10478`
- CI: CI 오류 'Could not find protoc-gen-grpc-kotlin-1.5.0-linux-x86_64.exe' 수정. classifier 보존을 위해 build.gradle.kts에서 직접 string 사용.

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #277 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `fff9cf82e7bcaa261119a2cce2f3829446b10478`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
