### PR TITLE
Potential fix for code scanning alert no. 48: Cross-site scripting

### DIFF
--- a/spring-boot3/hibernate-lettuce-demo/src/main/kotlin/io/bluetape4k/examples/cache/lettuce/controller/CacheController.kt
+++ b/spring-boot3/hibernate-lettuce-demo/src/main/kotlin/io/bluetape4k/examples/cache/lettuce/controller/CacheController.kt
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.util.HtmlUtils
 
 @RestController
 @RequestMapping("/api/cache")
@@ -50,7 +51,8 @@ class CacheController(private val entityManagerFactory: EntityManagerFactory) {
         val cache = factory.getCaches()[region]
             ?: return ResponseEntity.notFound().build()
         cache.clearLocal()
-        return ResponseEntity.ok("Evicted local cache (L1 only) for region: $region")
+        val safeRegion = HtmlUtils.htmlEscape(region)
+        return ResponseEntity.ok("Evicted local cache (L1 only) for region: $safeRegion")
     }
 
     @DeleteMapping("/evict")

--- a/spring-boot4/hibernate-lettuce-demo/src/main/kotlin/io/bluetape4k/examples/cache/lettuce/controller/CacheController.kt
+++ b/spring-boot4/hibernate-lettuce-demo/src/main/kotlin/io/bluetape4k/examples/cache/lettuce/controller/CacheController.kt
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.util.HtmlUtils
 
 @RestController
 @RequestMapping("/api/cache")
@@ -50,7 +51,8 @@ class CacheController(private val entityManagerFactory: EntityManagerFactory) {
         val cache = factory.getCaches()[region]
             ?: return ResponseEntity.notFound().build()
         cache.clearLocal()
-        return ResponseEntity.ok("Evicted local cache (L1 only) for region: $region")
+        val safeRegion = HtmlUtils.htmlEscape(region)
+        return ResponseEntity.ok("Evicted local cache (L1 only) for region: $safeRegion")
     }
 
     @DeleteMapping("/evict")


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: Potential fix for code scanning alert no. 48: Cross-site scripting

### 원문 선행 내용

Potential fix for [https://github.com/bluetape4k/bluetape4k-projects/security/code-scanning/48](https://github.com/bluetape4k/bluetape4k-projects/security/code-scanning/48)

The best fix is to apply **contextual output encoding** before including `region` in the response message.  
For this controller, use Spring’s built-in HTML escaping (`org.springframework.web.util.HtmlUtils.htmlEscape`) and return the escaped value in the message. This preserves functionality (the same message content semantics) while preventing injected markup/script from being interpreted as HTML.

Apply this same change in both files:

- `spring-boot3/.../CacheController.kt`
- `spring-boot4/.../CacheController.kt`

Changes needed:
1. Add import: `org.springframework.web.util.HtmlUtils`
2. In `evictRegion`, create an escaped variable from `region`
3. Use escaped variable in `ResponseEntity.ok(...)`

No new methods/classes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

Potential fix for [https://github.com/bluetape4k/bluetape4k-projects/security/code-scanning/48](https://github.com/bluetape4k/bluetape4k-projects/security/code-scanning/48)

The best fix is to apply **contextual output encoding** before including `region` in the response message.  
For this controller, use Spring’s built-in HTML escaping (`org.springframework.web.util.HtmlUtils.htmlEscape`) and return the escaped value in the message. This preserves functionality (the same message content semantics) while preventing injected markup/script from being interpreted as HTML.

Apply this same change in both files:

- `spring-boot3/.../CacheController.kt`
- `spring-boot4/.../CacheController.kt`

Changes needed:
1. Add import: `org.springframework.web.util.HtmlUtils`
2. In `evictRegion`, create an escaped variable from `region`
3. Use escaped variable in `ResponseEntity.ok(...)`

No new methods/classes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #282, head `bea7520d054b4b3e71cae55573f1c126c634931f`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `alert-autofix-48`
- Labels: `security`
- State: `MERGED`, merge commit `8ad771e58ab6574072b1408dcf30f05c335cd8ad`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #282 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `8ad771e58ab6574072b1408dcf30f05c335cd8ad`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
