### PR TITLE
Potential fix for code scanning alert no. 43: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 18 * * *'  # 매일 03:00 KST (18:00 UTC)
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: nightly-tests
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: Potential fix for code scanning alert no. 43: Workflow does not contain permissions

### 원문 선행 내용

Potential fix for [https://github.com/bluetape4k/bluetape4k-projects/security/code-scanning/43](https://github.com/bluetape4k/bluetape4k-projects/security/code-scanning/43)

Add an explicit `permissions` block to the workflow so all jobs (including `nightly-status`) get least-privilege token access by default.

Best single fix without changing behavior: in `.github/workflows/nightly-tests.yml`, add a root-level:

```yml
permissions:
  contents: read
```

Place it after `workflow_dispatch` (before `concurrency` is typical). This preserves existing functionality for checkout/artifact usage while restricting token scope versus implicit defaults. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

Potential fix for [https://github.com/bluetape4k/bluetape4k-projects/security/code-scanning/43](https://github.com/bluetape4k/bluetape4k-projects/security/code-scanning/43)

Add an explicit `permissions` block to the workflow so all jobs (including `nightly-status`) get least-privilege token access by default.

Best single fix without changing behavior: in `.github/workflows/nightly-tests.yml`, add a root-level:

```yml
permissions:
  contents: read
```

Place it after `workflow_dispatch` (before `concurrency` is typical). This preserves existing functionality for checkout/artifact usage while restricting token scope versus implicit defaults. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #283, head `888334aaa723ddfa4e2cc0e03b9837f99fb2cf71`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `alert-autofix-43`
- Labels: `security`
- State: `MERGED`, merge commit `ecf78b909b41a9944d8d351e754bc8a36d7a3d09`
- CI: Add an explicit `permissions` block to the workflow so all jobs (including `nightly-status`) get least-privilege token access by default. / Place it after `workflow_dispatch` (before `concurrency` is typical). This preserves existing functionality for checkout/artifact usage while restricting token scope versus implicit defaults. No imports, methods, or additional definitions are needed.

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #283 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `ecf78b909b41a9944d8d351e754bc8a36d7a3d09`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
