### PR TITLE
Potential fix for code scanning alert no. 45: Failure to use secure cookies

### DIFF
--- a/testing/mock-web-server/src/main/kotlin/io/bluetape4k/mockserver/httpbin/HttpbinAdvancedController.kt
+++ b/testing/mock-web-server/src/main/kotlin/io/bluetape4k/mockserver/httpbin/HttpbinAdvancedController.kt
@@ -70,7 +70,12 @@ class HttpbinAdvancedController {
         response: HttpServletResponse,
     ): ResponseEntity<Any> {
         params.forEach { (name, value) ->
-            response.addCookie(Cookie(name, value).apply { path = "/" })
+            response.addCookie(
+                Cookie(name, value).apply {
+                    path = "/"
+                    secure = true
+                }
+            )
         }
         return ResponseEntity.status(302).location(URI("/httpbin/cookies")).build()
     }
@@ -86,6 +91,7 @@ class HttpbinAdvancedController {
                 Cookie(name, "").apply {
                     path = "/"
                     maxAge = 0
+                    secure = true
                 }
             )
         }


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: Potential fix for code scanning alert no. 45: Failure to use secure cookies

### 원문 선행 내용

Potential fix for [https://github.com/bluetape4k/bluetape4k-projects/security/code-scanning/45](https://github.com/bluetape4k/bluetape4k-projects/security/code-scanning/45)

일반적으로는 `HttpServletResponse`에 쿠키를 추가하기 전에 해당 `Cookie` 객체에 `secure = true`를 설정해야 합니다. (Kotlin에서는 Java의 `setSecure(true)`에 대응해 프로퍼티 할당 사용 가능)

이 파일에서는 다음 두 위치를 수정하는 것이 가장 적절합니다.

- `setCookies(...)`의 쿠키 생성부 (기존: `path`만 설정)
- `deleteCookies(...)`의 삭제용 쿠키 생성부 (기존: `path`, `maxAge`만 설정)

기능 변화 없이 가장 안전한 방법은 기존 `apply { ... }` 블록 안에 `secure = true`를 추가하는 것입니다. 추가 import/메서드/정의는 필요 없습니다.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

Potential fix for [https://github.com/bluetape4k/bluetape4k-projects/security/code-scanning/45](https://github.com/bluetape4k/bluetape4k-projects/security/code-scanning/45)

일반적으로는 `HttpServletResponse`에 쿠키를 추가하기 전에 해당 `Cookie` 객체에 `secure = true`를 설정해야 합니다. (Kotlin에서는 Java의 `setSecure(true)`에 대응해 프로퍼티 할당 사용 가능)

이 파일에서는 다음 두 위치를 수정하는 것이 가장 적절합니다.

- `setCookies(...)`의 쿠키 생성부 (기존: `path`만 설정)
- `deleteCookies(...)`의 삭제용 쿠키 생성부 (기존: `path`, `maxAge`만 설정)

기능 변화 없이 가장 안전한 방법은 기존 `apply { ... }` 블록 안에 `secure = true`를 추가하는 것입니다. 추가 import/메서드/정의는 필요 없습니다.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #287, head `5438b003cbce139bdfe42b1ac74fcf0f0fe449b5`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `alert-autofix-45`
- Labels: `security`
- State: `MERGED`, merge commit `ae13b44df05d3693a534a4c9b51b525cc1e29063`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #287 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `ae13b44df05d3693a534a4c9b51b525cc1e29063`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
