### PR TITLE
(feat): infra kafka4 모듈 추가

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -798,10 +798,12 @@ jobs:
           - group: kafka-resilience
             test_tasks: >-
               :bluetape4k-kafka:test
+              :bluetape4k-kafka4:test
               :bluetape4k-resilience4j:test
               :bluetape4k-bucket4j:test
             kover_tasks: >-
               :bluetape4k-kafka:koverXmlReport
+              :bluetape4k-kafka4:koverXmlReport
               :bluetape4k-resilience4j:koverXmlReport
               :bluetape4k-bucket4j:koverXmlReport
             needs_mock_server: false

--- a/docs/superpowers/plans/2026-05-03-kafka4-module-plan.md
+++ b/docs/superpowers/plans/2026-05-03-kafka4-module-plan.md
@@ -13,6 +13,8 @@
 | 모듈 전략 | `infra/kafka` 유지, `infra/kafka4` 병렬 신규 생성 |
 | Spring BOM | `implementation(platform(libs.spring.boot4.dependencies))` |
 | Spring Kafka alias | `spring-kafka4 = 4.0.5`, `spring-kafka4-test = 4.0.5` 별도 추가 |
+| Reactor Kafka alias | `reactor-kafka4` 별도 추가로 Kafka 4 classpath 경계 유지 |
+| Kafka artifact 정렬 | `infra/kafka4` 내부에서 `org.apache.kafka` group을 `kafka4` version ref로 강제 |
 | Jackson | Jackson 3 (`bluetape4k-jackson3`, `tools.jackson.*`, Spring Kafka 4 Jackson classes) |
 | Embedded Kafka | KRaft 전용, `kraft = true` 제거 |
 | Streams branch DSL | `KafkaStreamBrancher` 대신 Kafka Streams native `split/branch/defaultBranch` |
@@ -23,7 +25,7 @@
 
 1. `infra/kafka`를 `infra/kafka4`로 복사한다.
 2. `infra/kafka4/build.gradle.kts`를 Kafka 4 / Boot 4 / Jackson 3 기준으로 수정한다.
-3. `gradle/libs.versions.toml`에 `spring-kafka4` aliases를 추가한다.
+3. `gradle/libs.versions.toml`에 `spring-kafka4`와 `reactor-kafka4` aliases를 추가한다.
 4. `./gradlew projects` 또는 targeted Gradle task로 `:bluetape4k-kafka4` 등록을 확인한다.
 
 ### Phase B: 컴파일 포팅
@@ -49,17 +51,18 @@
 
 ### Phase E: 검증 / 리뷰 / PR
 
-17. `./bin/repo-test-summary -- ./gradlew :bluetape4k-kafka4:compileKotlin`
-18. `./bin/repo-test-summary -- ./gradlew :bluetape4k-kafka4:compileTestKotlin`
-19. `./bin/repo-test-summary -- ./gradlew :bluetape4k-kafka4:test`
-20. `git diff --check`
-21. Tier 4 code review: 컴파일 리스크, dependency 경계, README/KDoc 체크
-22. Lore commit 생성, push, PR 생성
+17. `.github/workflows/nightly-tests.yml`의 infra matrix에 `:bluetape4k-kafka4:test`와 `:bluetape4k-kafka4:koverXmlReport`를 추가한다.
+18. `./bin/repo-test-summary -- ./gradlew :bluetape4k-kafka4:compileKotlin`
+19. `./bin/repo-test-summary -- ./gradlew :bluetape4k-kafka4:compileTestKotlin`
+20. `./bin/repo-test-summary -- ./gradlew :bluetape4k-kafka4:test`
+21. `git diff --check`
+22. Tier 4 code review: 컴파일 리스크, dependency 경계, README/KDoc 체크
+23. Lore commit 생성, push, PR 생성
 
 ## 2. 회귀 기준
 
 - 기존 `infra/kafka` 파일을 수정하지 않는다. 단, catalog alias 추가는 공용 catalog 변경으로 허용한다.
 - `spring-kafka` 3.x alias는 그대로 유지한다.
 - `spring-kafka4` alias만 `infra/kafka4`에서 사용한다.
+- Kafka 4 모듈의 test/runtime classpath에 Kafka 3 artifact가 섞이지 않도록 `org.apache.kafka` group을 정렬한다.
 - `README.md`와 `README.ko.md` 둘 중 하나만 갱신된 상태로 커밋하지 않는다.
-

--- a/docs/superpowers/plans/2026-05-03-kafka4-module-plan.md
+++ b/docs/superpowers/plans/2026-05-03-kafka4-module-plan.md
@@ -1,0 +1,65 @@
+# Plan: infra/kafka4 모듈 신규 생성
+
+- **Spec**: `docs/superpowers/specs/2026-05-03-kafka4-module-design.md`
+- **Issue**: #281
+- **Branch**: `feat/kafka4-module`
+- **Date**: 2026-05-03
+- **Status**: Ready for execution
+
+## 0. 결정사항
+
+| 항목 | 결정 |
+|---|---|
+| 모듈 전략 | `infra/kafka` 유지, `infra/kafka4` 병렬 신규 생성 |
+| Spring BOM | `implementation(platform(libs.spring.boot4.dependencies))` |
+| Spring Kafka alias | `spring-kafka4 = 4.0.5`, `spring-kafka4-test = 4.0.5` 별도 추가 |
+| Jackson | Jackson 3 (`bluetape4k-jackson3`, `tools.jackson.*`, Spring Kafka 4 Jackson classes) |
+| Embedded Kafka | KRaft 전용, `kraft = true` 제거 |
+| Streams branch DSL | `KafkaStreamBrancher` 대신 Kafka Streams native `split/branch/defaultBranch` |
+
+## 1. 작업 순서
+
+### Phase A: 모듈 스캐폴딩
+
+1. `infra/kafka`를 `infra/kafka4`로 복사한다.
+2. `infra/kafka4/build.gradle.kts`를 Kafka 4 / Boot 4 / Jackson 3 기준으로 수정한다.
+3. `gradle/libs.versions.toml`에 `spring-kafka4` aliases를 추가한다.
+4. `./gradlew projects` 또는 targeted Gradle task로 `:bluetape4k-kafka4` 등록을 확인한다.
+
+### Phase B: 컴파일 포팅
+
+5. main source compile을 실행한다.
+6. Spring Kafka 4 / Kafka 4 제거 API를 확인해 좁게 수정한다.
+7. Jackson 2 imports를 Jackson 3 또는 Spring Kafka 4 Jackson classes로 치환한다.
+8. 한국어 KDoc은 기존 public API의 KDoc을 유지하고, 신규/변경 public API가 생기면 한국어 KDoc을 추가한다.
+
+### Phase C: 테스트 포팅
+
+9. `@EmbeddedKafka(kraft = true)`를 제거한다.
+10. Spring Boot embedded broker mapping은 `bootstrapServersProperty` 또는 `${spring.embedded.kafka.brokers}` 방식으로 정리한다.
+11. `KafkaStreamBrancher` 테스트를 Kafka Streams native branching API로 변경한다.
+12. `compileTestKotlin`을 실행해 test API 차이를 정리한다.
+13. `:bluetape4k-kafka4:test`를 실행한다.
+
+### Phase D: 문서
+
+14. `infra/kafka4/README.md` 작성
+15. `infra/kafka4/README.ko.md` 작성
+16. 두 README에 compatibility 표, dependency snippet, Mermaid diagram, test command를 포함한다.
+
+### Phase E: 검증 / 리뷰 / PR
+
+17. `./bin/repo-test-summary -- ./gradlew :bluetape4k-kafka4:compileKotlin`
+18. `./bin/repo-test-summary -- ./gradlew :bluetape4k-kafka4:compileTestKotlin`
+19. `./bin/repo-test-summary -- ./gradlew :bluetape4k-kafka4:test`
+20. `git diff --check`
+21. Tier 4 code review: 컴파일 리스크, dependency 경계, README/KDoc 체크
+22. Lore commit 생성, push, PR 생성
+
+## 2. 회귀 기준
+
+- 기존 `infra/kafka` 파일을 수정하지 않는다. 단, catalog alias 추가는 공용 catalog 변경으로 허용한다.
+- `spring-kafka` 3.x alias는 그대로 유지한다.
+- `spring-kafka4` alias만 `infra/kafka4`에서 사용한다.
+- `README.md`와 `README.ko.md` 둘 중 하나만 갱신된 상태로 커밋하지 않는다.
+

--- a/docs/superpowers/specs/2026-05-03-kafka4-module-design.md
+++ b/docs/superpowers/specs/2026-05-03-kafka4-module-design.md
@@ -1,0 +1,102 @@
+# Spec: infra/kafka4 모듈 신규 생성
+
+- **Issue**: #281
+- **Branch**: `feat/kafka4-module` (worktree: `.worktrees/feat-kafka4-module`)
+- **Date**: 2026-05-03
+- **Status**: Reviewed
+
+## 1. 배경 / 목적
+
+`infra/kafka`는 Kafka 3.9.x와 Spring Kafka 3.x를 기준으로 유지한다. Kafka 4.x 클라이언트와 Spring Kafka 4.x는 ZooKeeper 제거, KRaft 전용 embedded broker, Jackson 3 지원, Spring Framework 7 / Spring Boot 4 의존성 때문에 기존 모듈에 섞으면 호환성 경계가 흐려진다.
+
+이 작업은 신규 `infra/kafka4` 모듈을 추가해 다음을 제공한다.
+
+1. `:bluetape4k-kafka4` 아티팩트 자동 등록
+2. Kafka 4.2.0 client/streams API 기반 core, codec, coroutine, streams DSL 포팅
+3. Spring Kafka 4.0.5 + Spring Boot 4.0.6 BOM 기준 test/support 포팅
+4. `README.md` / `README.ko.md`로 Kafka 3 모듈과 Kafka 4 모듈의 경계를 문서화
+
+## 2. 조사 요약
+
+### 공식 문서 근거
+
+- Spring Kafka 4.0.5 문서는 Kafka 4 전환으로 ZooKeeper 기반 기능이 제거되고 embedded test framework가 KRaft 전용이라고 설명한다.
+- `@EmbeddedKafka`의 `kraft` 속성은 제거되었고 KRaft가 유일한 모드다.
+- Spring Kafka 4는 Jackson 3 클래스를 제공하며 Jackson 2 클래스는 deprecated 호환 경로다.
+- Spring Boot 4.0.6 Kafka 문서는 `@EnableKafkaStreams`와 `KafkaStreamsConfiguration` 자동 설정 조건을 유지하고, embedded broker 주소는 `bootstrapServersProperty = "spring.kafka.bootstrap-servers"` 또는 `${spring.embedded.kafka.brokers}` 매핑으로 주입한다고 안내한다.
+- Spring 공식 release note는 Spring Kafka 4.0.5가 Spring Boot 4.0.6에 통합된다고 명시한다.
+
+### Repo 근거
+
+- `settings.gradle.kts`는 `includeModules("infra", withBaseDir = false)`로 `infra/kafka4`를 `:bluetape4k-kafka4`로 자동 등록한다.
+- `gradle/libs.versions.toml`에는 `kafka4-*` alias가 이미 준비되어 있지만 Spring Kafka 4 별도 alias는 아직 없다.
+- Spring Boot 4 모듈들은 `implementation(platform(libs.spring.boot4.dependencies))`를 직접 선언해 root Spring Boot 3 dependency management의 다운그레이드를 피한다.
+- `infra/kafka`는 Kafka core, codecs, coroutines, Spring Kafka extensions, test utils, Kafka Streams DSL을 한 모듈에 제공한다.
+
+## 3. 범위
+
+### 포함
+
+- `infra/kafka4/build.gradle.kts` 생성
+- `gradle/libs.versions.toml`에 `spring-kafka4` version ref와 `spring-kafka4`, `spring-kafka4-test` aliases 추가
+- `infra/kafka` 소스와 테스트를 `infra/kafka4`로 포팅
+- Spring Kafka 4 / Boot 4 차이 반영
+  - `@EmbeddedKafka(kraft = true)` 제거
+  - Kafka Streams branch 테스트는 `KafkaStreamBrancher` 제거 후 Kafka Streams `split().branch().defaultBranch()` API 사용
+  - Jackson 3 serializer/deserializer/serde 사용
+  - Spring Boot 4 BOM 적용
+- 영어/한국어 README 작성
+- targeted compile/test 검증
+
+### 제외
+
+- 기존 `infra/kafka` 변경 또는 제거
+- Boot 4 starter/auto-configuration 신설
+- Kafka Queue/share consumer 신규 API 래퍼 추가
+- 공개 API 이름을 Kafka 4 전용으로 재설계
+
+## 4. 설계 선택지
+
+| 선택지 | 내용 | 장점 | 단점 | 결정 |
+|---|---|---|---|---|
+| A | `infra/kafka`를 Kafka 4로 직접 업그레이드 | 중복 없음 | Kafka 3/Spring Kafka 3 사용자 깨짐 | 거절 |
+| B | `infra/kafka4` 신규 모듈에 기존 API를 포팅 | 호환성 경계 명확, issue 목적 부합 | 일부 코드 중복 | 채택 |
+| C | core와 spring 통합을 `infra/kafka4` / `spring-boot4/kafka`로 분리 | 의존성 그래프 가장 엄격 | 이번 issue 범위보다 큼 | 후속 후보 |
+
+## 5. 주요 리스크 / 완화
+
+### R1. Spring Boot 3 BOM이 Spring Kafka 4 의존성을 다운그레이드
+
+완화: `infra/kafka4`는 Spring Boot 4 모듈 패턴처럼 `implementation(platform(libs.spring.boot4.dependencies))`를 선언하고, Spring Kafka 의존성은 `spring-kafka4` alias로 분리한다.
+
+### R2. Spring Kafka 4에서 제거된 API로 컴파일 실패
+
+완화: 먼저 `infra/kafka`를 기계적으로 복사한 뒤 targeted compile로 제거 API를 검출한다. 확인된 변화는 Spring Kafka 4 문서 기반으로 좁게 수정한다.
+
+### R3. Embedded Kafka KRaft 변경으로 테스트가 불안정
+
+완화: `@EmbeddedKafka(kraft = true)`를 제거하고 Boot 문서의 `bootstrapServersProperty` 또는 `${spring.embedded.kafka.brokers}` 방식만 사용한다. 실패 시 Spring Kafka 테스트만 축소 재현한 뒤 수정한다.
+
+### R4. Jackson 2/3 혼용
+
+완화: Kafka 4 모듈은 Spring Kafka 4의 Jackson 3 경로에 맞춰 `bluetape4k-jackson3`, `tools.jackson.*`, `JacksonJsonSerializer/Deserializer/Serde`를 사용한다.
+
+## 6. Acceptance Criteria
+
+- `:bluetape4k-kafka4` Gradle project가 자동 등록된다.
+- `./gradlew :bluetape4k-kafka4:compileKotlin` 통과
+- `./gradlew :bluetape4k-kafka4:compileTestKotlin` 통과
+- 가능한 범위에서 `./gradlew :bluetape4k-kafka4:test` 통과
+- `README.md`와 `README.ko.md`가 Kafka 4 / Spring Boot 4 전용 모듈임을 설명한다.
+- `infra/kafka` 기존 동작은 변경하지 않는다.
+
+## 7. Spec Review
+
+| 관점 | 검토 결과 | 반영 |
+|---|---|---|
+| Developer | 전체 포팅은 크지만 기존 API 경계를 유지하면 사용자가 Kafka 3/4를 선택 가능하다. | `infra/kafka` 불변, 신규 모듈 병렬 추가 |
+| Security | Kafka LZ4 transitive CVE 대응은 기존 `infra/kafka`의 exclude + `at.yawk.lz4` 유지가 필요하다. | build.gradle에 동일 exclude 유지 |
+| Ops/SRE | Embedded Kafka KRaft 전용 변화와 test runtime 안정성이 가장 큰 위험이다. | `kraft` 제거와 targeted test를 acceptance에 포함 |
+| User/Caller | Kafka 3 모듈과 Kafka 4 모듈의 선택 기준이 문서에 보여야 한다. | README 양쪽에 compatibility 표 포함 |
+| Critic | Spring Kafka 4 alias 분리가 없으면 기존 Kafka 3 모듈까지 같이 흔들린다. | `spring-kafka4` alias 신규 추가 |
+

--- a/docs/superpowers/specs/2026-05-03-kafka4-module-design.md
+++ b/docs/superpowers/specs/2026-05-03-kafka4-module-design.md
@@ -29,7 +29,7 @@
 ### Repo 근거
 
 - `settings.gradle.kts`는 `includeModules("infra", withBaseDir = false)`로 `infra/kafka4`를 `:bluetape4k-kafka4`로 자동 등록한다.
-- `gradle/libs.versions.toml`에는 `kafka4-*` alias가 이미 준비되어 있지만 Spring Kafka 4 별도 alias는 아직 없다.
+- `gradle/libs.versions.toml`에는 `kafka4-*` alias가 이미 준비되어 있지만 Spring Kafka 4 별도 alias는 아직 없다. `reactor-kafka`는 root BOM 영향으로 Kafka 3 라인과 섞일 수 있어 Kafka 4 모듈 전용 alias가 필요하다.
 - Spring Boot 4 모듈들은 `implementation(platform(libs.spring.boot4.dependencies))`를 직접 선언해 root Spring Boot 3 dependency management의 다운그레이드를 피한다.
 - `infra/kafka`는 Kafka core, codecs, coroutines, Spring Kafka extensions, test utils, Kafka Streams DSL을 한 모듈에 제공한다.
 
@@ -47,6 +47,7 @@
   - Spring Boot 4 BOM 적용
 - 영어/한국어 README 작성
 - targeted compile/test 검증
+- GitHub Nightly Tests workflow의 infra matrix에 `:bluetape4k-kafka4:test`와 kover report task 추가
 
 ### 제외
 
@@ -67,7 +68,7 @@
 
 ### R1. Spring Boot 3 BOM이 Spring Kafka 4 의존성을 다운그레이드
 
-완화: `infra/kafka4`는 Spring Boot 4 모듈 패턴처럼 `implementation(platform(libs.spring.boot4.dependencies))`를 선언하고, Spring Kafka 의존성은 `spring-kafka4` alias로 분리한다.
+완화: `infra/kafka4`는 Spring Boot 4 모듈 패턴처럼 `implementation(platform(libs.spring.boot4.dependencies))`를 선언하고, Spring Kafka 의존성은 `spring-kafka4` alias로 분리한다. 테스트 런타임에서는 `org.apache.kafka` artifact 전체를 `kafka4` version ref로 정렬해 Spring Boot 3 root dependency management의 Kafka 3.x 다운그레이드를 차단한다.
 
 ### R2. Spring Kafka 4에서 제거된 API로 컴파일 실패
 
@@ -88,6 +89,7 @@
 - `./gradlew :bluetape4k-kafka4:compileTestKotlin` 통과
 - 가능한 범위에서 `./gradlew :bluetape4k-kafka4:test` 통과
 - `README.md`와 `README.ko.md`가 Kafka 4 / Spring Boot 4 전용 모듈임을 설명한다.
+- `.github/workflows/nightly-tests.yml`이 `:bluetape4k-kafka4:test`를 실행한다.
 - `infra/kafka` 기존 동작은 변경하지 않는다.
 
 ## 7. Spec Review
@@ -99,4 +101,4 @@
 | Ops/SRE | Embedded Kafka KRaft 전용 변화와 test runtime 안정성이 가장 큰 위험이다. | `kraft` 제거와 targeted test를 acceptance에 포함 |
 | User/Caller | Kafka 3 모듈과 Kafka 4 모듈의 선택 기준이 문서에 보여야 한다. | README 양쪽에 compatibility 표 포함 |
 | Critic | Spring Kafka 4 alias 분리가 없으면 기존 Kafka 3 모듈까지 같이 흔들린다. | `spring-kafka4` alias 신규 추가 |
-
+| Implementation | Spring Kafka 4 test runtime에서 일부 Kafka artifact가 root BOM에 의해 Kafka 3.x로 내려가면 embedded broker가 `MetadataVersion`/`Feature` class 오류로 실패한다. | `reactor-kafka4` alias와 Kafka group resolution strategy 추가 |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -99,6 +99,7 @@ elasticsearch-java = "9.3.3"
 kafka3 = "3.9.2"    # Server-side: spring-kafka 3.x embedded test (EmbeddedKafkaKraftBroker)
 kafka4 = "4.2.0"    # Client-side: kafka-clients, kafka-streams (production)
 spring-kafka = "3.3.13"
+spring-kafka4 = "4.0.5"
 
 timefold-solver = "1.33.0"
 
@@ -794,6 +795,9 @@ kafka4-server-common = { module = "org.apache.kafka:kafka-server-common", versio
 kafka4-storage = { module = "org.apache.kafka:kafka-storage", version.ref = "kafka4" }
 kafka4-storage-api = { module = "org.apache.kafka:kafka-storage-api", version.ref = "kafka4" }
 kafka4-scala213 = { module = "org.apache.kafka:kafka_2.13", version.ref = "kafka4" }
+spring-kafka4 = { module = "org.springframework.kafka:spring-kafka", version.ref = "spring-kafka4" }
+spring-kafka4-test = { module = "org.springframework.kafka:spring-kafka-test", version.ref = "spring-kafka4" }
+reactor-kafka4 = { module = "io.projectreactor.kafka:reactor-kafka", version = "1.3.25" }
 spring-kafka = { module = "org.springframework.kafka:spring-kafka", version.ref = "spring-kafka" }
 spring-kafka-test = { module = "org.springframework.kafka:spring-kafka-test", version.ref = "spring-kafka" }
 

--- a/infra/kafka4/README.ko.md
+++ b/infra/kafka4/README.ko.md
@@ -1,0 +1,153 @@
+# Module bluetape4k-kafka4
+
+[English](./README.md) | 한국어
+
+`bluetape4k-kafka4`는 bluetape4k Kafka 유틸리티의 Kafka 4.x 라인입니다.
+기존 `bluetape4k-kafka`와 같은 Kotlin 우선 API 형태를 유지하되 Kafka 4.2.x,
+Spring Kafka 4.x, Spring Boot 4, Jackson 3 기준으로 컴파일합니다.
+
+## 호환성
+
+| 모듈 | Kafka | Spring Kafka | Spring Boot | Jackson | 비고 |
+|---|---:|---:|---:|---:|---|
+| `bluetape4k-kafka` | 3.9.x | 3.3.x | 3.x | Jackson 2 | 기존 Kafka 3 라인 |
+| `bluetape4k-kafka4` | 4.2.x | 4.0.x | 4.x | Jackson 3 | Kafka 4 라인, Embedded Kafka는 KRaft 전용 |
+
+두 모듈은 같은 `io.bluetape4k.kafka` API 패키지를 제공합니다. 중복 패키지 경계를
+의도적으로 관리하는 경우가 아니라면 한 애플리케이션 런타임 classpath에는 둘 중 하나만
+선택하세요.
+
+## 특징
+
+- Kafka producer/consumer 작업을 위한 coroutine 래퍼.
+- `KafkaTemplate`, producer factory, listener container, test utility를 위한
+  Spring Kafka 확장 함수.
+- Kafka 4 기준으로 컴파일되는 Kafka Streams helper와 테스트.
+- 문자열, 바이트 배열, Jackson 3 JSON, JDK 직렬화, Kryo, Fory, LZ4/Snappy/Zstd
+  압축 payload codec.
+- Spring Kafka 4의 KRaft 전용 embedded broker 테스트 지원.
+
+## 의존성
+
+### Gradle Kotlin DSL
+
+```kotlin
+dependencies {
+    implementation("io.github.bluetape4k:bluetape4k-kafka4:$version")
+}
+```
+
+### Maven
+
+```xml
+<dependency>
+    <groupId>io.github.bluetape4k</groupId>
+    <artifactId>bluetape4k-kafka4</artifactId>
+    <version>${version}</version>
+</dependency>
+```
+
+## 의존성 경계
+
+```mermaid
+flowchart LR
+    app[Application] --> kafka4[bluetape4k-kafka4]
+    kafka4 --> clients[Kafka clients 4.2.x]
+    kafka4 --> spring[Spring Kafka 4.0.x]
+    kafka4 --> boot[Spring Boot 4 BOM]
+    kafka4 --> jackson[bluetape4k-jackson3]
+    kafka4 --> reactor[reactor-kafka]
+```
+
+`infra/kafka4/build.gradle.kts`는 모든 `org.apache.kafka` artifact를 이 모듈의
+Kafka 4 버전으로 정렬합니다. root dependency management가 Kafka 3 artifact를
+Kafka 4 test/runtime classpath에 섞는 것을 막기 위한 조치입니다.
+
+## Producer
+
+```kotlin
+import io.bluetape4k.kafka.producerOf
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.serialization.StringSerializer
+
+val producer = producerOf<String, String>(
+    mapOf(
+        "bootstrap.servers" to "localhost:9092",
+        "acks" to "all",
+        "key.serializer" to StringSerializer::class.java,
+        "value.serializer" to StringSerializer::class.java,
+    )
+)
+
+producer.send(ProducerRecord("events", "key", "value"))
+producer.close()
+```
+
+## Coroutine Producer
+
+```kotlin
+import io.bluetape4k.kafka.coroutines.suspendSend
+import org.apache.kafka.clients.producer.ProducerRecord
+
+suspend fun sendEvent() {
+    val metadata = producer.suspendSend(ProducerRecord("events", "key", "value"))
+    println("sent partition=${metadata.partition()} offset=${metadata.offset()}")
+}
+```
+
+## Spring Kafka
+
+```kotlin
+import io.bluetape4k.kafka.spring.suspendSend
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class EventPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+) {
+    suspend fun publish(value: String) {
+        kafkaTemplate.suspendSend("events", "key", value)
+    }
+}
+```
+
+Spring Kafka 4는 Kafka 3 라인보다 key/value generic의 non-null 경계를 엄격하게
+적용합니다. tombstone/null-value 계약이 명확한 경우가 아니라면 template과 factory에는
+non-null value type을 우선 사용하세요.
+
+## Jackson 3 Codec
+
+```kotlin
+import io.bluetape4k.kafka.codec.KafkaCodecs
+
+val codec = KafkaCodecs.Jackson
+val bytes = codec.serialize("events", mapOf("name" to "spring-kafka-4"))
+val decoded = codec.deserialize("events", bytes)
+```
+
+Jackson codec은 `bluetape4k-jackson3`와 `tools.jackson.*` API를 사용합니다.
+
+## Embedded Kafka 테스트
+
+Spring Kafka 4의 embedded broker는 KRaft 전용입니다. Spring Kafka 3 전환기에 쓰던
+`kraft = true` 속성은 사용하지 않습니다.
+
+```kotlin
+import org.springframework.kafka.test.context.EmbeddedKafka
+
+@EmbeddedKafka(
+    partitions = 1,
+    topics = ["events"],
+    bootstrapServersProperty = "spring.kafka.bootstrap-servers",
+)
+class EventKafkaTest
+```
+
+## 검증
+
+```bash
+./gradlew :bluetape4k-kafka4:compileKotlin
+./gradlew :bluetape4k-kafka4:compileTestKotlin
+./gradlew :bluetape4k-kafka4:test
+```

--- a/infra/kafka4/README.md
+++ b/infra/kafka4/README.md
@@ -1,0 +1,154 @@
+# Module bluetape4k-kafka4
+
+English | [한국어](./README.ko.md)
+
+`bluetape4k-kafka4` is the Kafka 4.x line of the bluetape4k Kafka utilities.
+It keeps the same Kotlin-first API shape as `bluetape4k-kafka`, but is compiled
+against Kafka 4.2.x, Spring Kafka 4.x, Spring Boot 4, and Jackson 3.
+
+## Compatibility
+
+| Module | Kafka | Spring Kafka | Spring Boot | Jackson | Notes |
+|---|---:|---:|---:|---:|---|
+| `bluetape4k-kafka` | 3.9.x | 3.3.x | 3.x | Jackson 2 | Existing Kafka 3 line |
+| `bluetape4k-kafka4` | 4.2.x | 4.0.x | 4.x | Jackson 3 | Kafka 4 line, KRaft-only embedded tests |
+
+Do not put both modules on the same runtime classpath unless you intentionally
+manage the duplicate `io.bluetape4k.kafka` API package boundary. Choose one line
+per application.
+
+## Features
+
+- Coroutine wrappers for Kafka producer and consumer operations.
+- Spring Kafka extensions for `KafkaTemplate`, producer factories, listener
+  containers, and test utilities.
+- Kafka Streams helpers and test coverage compiled against Kafka 4.
+- Codecs for string, byte array, Jackson 3 JSON, JDK serialization, Kryo, Fory,
+  and compressed payloads with LZ4, Snappy, or Zstd.
+- Embedded Kafka test support through Spring Kafka 4's KRaft-only broker.
+
+## Dependency
+
+### Gradle Kotlin DSL
+
+```kotlin
+dependencies {
+    implementation("io.github.bluetape4k:bluetape4k-kafka4:$version")
+}
+```
+
+### Maven
+
+```xml
+<dependency>
+    <groupId>io.github.bluetape4k</groupId>
+    <artifactId>bluetape4k-kafka4</artifactId>
+    <version>${version}</version>
+</dependency>
+```
+
+## Dependency Boundary
+
+```mermaid
+flowchart LR
+    app[Application] --> kafka4[bluetape4k-kafka4]
+    kafka4 --> clients[Kafka clients 4.2.x]
+    kafka4 --> spring[Spring Kafka 4.0.x]
+    kafka4 --> boot[Spring Boot 4 BOM]
+    kafka4 --> jackson[bluetape4k-jackson3]
+    kafka4 --> reactor[reactor-kafka]
+```
+
+`infra/kafka4/build.gradle.kts` also aligns all `org.apache.kafka` artifacts to
+the Kafka 4 version used by this module. This prevents the root dependency
+management from pulling Kafka 3 artifacts into the Kafka 4 test/runtime
+classpath.
+
+## Producer
+
+```kotlin
+import io.bluetape4k.kafka.producerOf
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.serialization.StringSerializer
+
+val producer = producerOf<String, String>(
+    mapOf(
+        "bootstrap.servers" to "localhost:9092",
+        "acks" to "all",
+        "key.serializer" to StringSerializer::class.java,
+        "value.serializer" to StringSerializer::class.java,
+    )
+)
+
+producer.send(ProducerRecord("events", "key", "value"))
+producer.close()
+```
+
+## Coroutine Producer
+
+```kotlin
+import io.bluetape4k.kafka.coroutines.suspendSend
+import org.apache.kafka.clients.producer.ProducerRecord
+
+suspend fun sendEvent() {
+    val metadata = producer.suspendSend(ProducerRecord("events", "key", "value"))
+    println("sent partition=${metadata.partition()} offset=${metadata.offset()}")
+}
+```
+
+## Spring Kafka
+
+```kotlin
+import io.bluetape4k.kafka.spring.suspendSend
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class EventPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+) {
+    suspend fun publish(value: String) {
+        kafkaTemplate.suspendSend("events", "key", value)
+    }
+}
+```
+
+Spring Kafka 4 uses non-null key/value generic boundaries more strictly than the
+Kafka 3 line. Prefer non-null value types in templates and factories unless your
+application has an explicit tombstone/null-value contract.
+
+## Jackson 3 Codec
+
+```kotlin
+import io.bluetape4k.kafka.codec.KafkaCodecs
+
+val codec = KafkaCodecs.Jackson
+val bytes = codec.serialize("events", mapOf("name" to "spring-kafka-4"))
+val decoded = codec.deserialize("events", bytes)
+```
+
+The Jackson codec uses `bluetape4k-jackson3` and `tools.jackson.*` APIs.
+
+## Embedded Kafka Tests
+
+Spring Kafka 4 embedded brokers are KRaft-only. Do not use `kraft = true`; that
+flag belonged to the Spring Kafka 3 transition period.
+
+```kotlin
+import org.springframework.kafka.test.context.EmbeddedKafka
+
+@EmbeddedKafka(
+    partitions = 1,
+    topics = ["events"],
+    bootstrapServersProperty = "spring.kafka.bootstrap-servers",
+)
+class EventKafkaTest
+```
+
+## Verification
+
+```bash
+./gradlew :bluetape4k-kafka4:compileKotlin
+./gradlew :bluetape4k-kafka4:compileTestKotlin
+./gradlew :bluetape4k-kafka4:test
+```

--- a/infra/kafka4/build.gradle.kts
+++ b/infra/kafka4/build.gradle.kts
@@ -1,0 +1,79 @@
+plugins {
+    kotlin("plugin.spring")
+    kotlin("plugin.noarg")
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+    all {
+        // CVE-2025-12183 (CVSS 8.8) + CVE-2025-66566 (CVSS 8.2):
+        // kafka-clients/spring-kafka/reactor-kafka 가 org.lz4:lz4-java 를 transitively 가져온다.
+        // at.yawk.lz4:lz4-java:1.11.0 (net.jpountz.lz4.* 동일 namespace) 로 대체한다.
+        exclude(group = "org.lz4", module = "lz4-java")
+
+        resolutionStrategy.eachDependency {
+            if (requested.group == "org.apache.kafka") {
+                useVersion(libs.versions.kafka4.get())
+                because("kafka4 모듈: root BOM의 kafka3.x 다운그레이드 방지")
+            }
+        }
+    }
+}
+
+dependencies {
+    implementation(platform(libs.spring.boot4.dependencies))
+    api(project(":bluetape4k-core"))
+    api(project(":bluetape4k-io"))
+    compileOnly(project(":bluetape4k-resilience4j"))
+    testImplementation(project(":bluetape4k-junit5"))
+    testImplementation(project(":bluetape4k-testcontainers"))
+
+    // Kafka (kafka4: 4.2.x — spring-kafka 4.x compatible)
+    api(libs.kafka4.clients)
+    compileOnly(libs.kafka4.streams)
+    compileOnly(libs.kafka4.generator)
+    testImplementation(libs.kafka4.streams.test.utils)
+    testRuntimeOnly(libs.kafka4.server.common)
+    testImplementation(libs.testcontainers.kafka)
+
+    // Spring Kafka
+    implementation(libs.spring.kafka4)
+    compileOnly(libs.spring.kafka4.test)
+    implementation(project(":bluetape4k-spring-boot4-core"))
+    implementation("org.springframework.data:spring-data-commons")
+
+    // Jackson 3
+    implementation(project(":bluetape4k-jackson3"))
+    implementation(libs.jackson3.databind)
+    implementation(libs.jackson3.module.kotlin)
+    implementation(libs.jackson3.module.blackbird)
+
+    // Codecs
+    compileOnly(libs.kryo5)
+    compileOnly(libs.fory.kotlin)  // new Apache Fory
+
+    // Compressors
+    compileOnly(libs.commons.compress)
+    compileOnly(libs.snappy.java)
+    // at.yawk.lz4:lz4-java 를 api 로 노출: exclude 로 org.lz4 를 제거했으므로
+    // 소비자 classpath 에 at.yawk.lz4:lz4-java:1.11.0 가 반드시 있어야 kafka LZ4 codec 이 동작한다.
+    api(libs.lz4.java)
+    compileOnly(libs.zstd.jni)
+
+    // Coroutines
+    implementation(project(":bluetape4k-coroutines"))
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.reactor)
+    testImplementation(libs.kotlinx.coroutines.test)
+
+    // Reactor
+    implementation(libs.reactor.kafka4)
+    implementation(libs.reactor.kotlin.extensions)
+    testImplementation(libs.reactor.test)
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test") {
+        exclude(group = "junit", module = "junit")
+        exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
+        exclude(module = "mockito-core")
+    }
+}

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/ConsumerSupport.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/ConsumerSupport.kt
@@ -1,0 +1,64 @@
+package io.bluetape4k.kafka
+
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.serialization.Deserializer
+import java.util.*
+
+/**
+ * [KafkaConsumer]를 생성합니다.
+ *
+ * ```
+ * val consumer = consumerOf(
+ *    mapOf(
+ *      "bootstrap.servers" to "localhost:9092",
+ *      "group.id" to "test",
+ *      "enable.auto.commit" to "true",
+ *      "auto.commit.interval.ms" to "1000",
+ *    ),
+ *    StringDeserializer(),
+ *    StringDeserializer(),
+ * )
+ * ```
+ *
+ * @param configs Kafka Consumer 설정
+ * @param keyDeserializer Key Deserializer
+ * @param valueDeserializer Value Deserializer
+ * @return [KafkaConsumer] 인스턴스
+ */
+fun <K, V> consumerOf(
+    configs: Map<String, Any?>,
+    keyDeserializer: Deserializer<K>? = null,
+    valueDeserializer: Deserializer<V>? = null,
+): Consumer<K, V> {
+    return KafkaConsumer(configs, keyDeserializer, valueDeserializer)
+}
+
+/**
+ * [KafkaConsumer]를 생성합니다.
+ *
+ * ```
+ * val consumer = consumerOf(
+ *   Properties().apply {
+ *    put("bootstrap.servers", "localhost:9092")
+ *    put("group.id", "test")
+ *    put("enable.auto.commit", "true")
+ *    put("auto.commit.interval.ms", "1000")
+ *   },
+ *   StringDeserializer(),
+ *   StringDeserializer(),
+ * )
+ * ```
+ *
+ * @param props Kafka Consumer 설정
+ * @param keyDeserializer Key Deserializer
+ * @param valueDeserializer Value Deserializer
+ * @return [KafkaConsumer] 인스턴스
+ */
+fun <K, V> consumerOf(
+    props: Properties,
+    keyDeserializer: Deserializer<K>? = null,
+    valueDeserializer: Deserializer<V>? = null,
+): Consumer<K, V> {
+    return KafkaConsumer(props, keyDeserializer, valueDeserializer)
+}

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt
@@ -1,0 +1,87 @@
+package io.bluetape4k.kafka
+
+import io.bluetape4k.support.asDoubleOrNull
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.Producer
+import org.apache.kafka.common.serialization.Serializer
+import java.util.*
+
+/**
+ * [KafkaProducer]를 생성합니다.
+ *
+ * ```
+ * val producer = producerOf(
+ *      mapOf(
+ *          "bootstrap.servers" to "localhost:9092",
+ *          "acks" to "all",
+ *          "retries" to 3,
+ *      ),
+ *      StringSerializer(),
+ *      StringSerializer(),
+ * )
+ * ```
+ *
+ * @param configs Kafka Producer 설정
+ * @param keySerializer Key Serializer
+ * @param valueSerializer Value Serializer
+ * @return [KafkaProducer] 인스턴스
+ */
+fun <K, V> producerOf(
+    configs: Map<String, Any?>,
+    keySerializer: Serializer<K>? = null,
+    valueSerializer: Serializer<V>? = null,
+): Producer<K, V> = KafkaProducer(configs, keySerializer, valueSerializer)
+
+/**
+ * [KafkaProducer]를 생성합니다.
+ *
+ * ```
+ * val producer = producerOf(
+ *      Properties().apply {
+ *          put("bootstrap.servers", "localhost:9092")
+ *          put("acks", "all")
+ *          put("retries", 3)
+ *      },
+ *      StringSerializer(),
+ *      StringSerializer(),
+ * )
+ * ```
+ *
+ * @param props Kafka Producer 설정
+ * @param keySerializer Key Serializer
+ * @param valueSerializer Value Serializer
+ * @return [KafkaProducer] 인스턴스
+ */
+fun <K, V> producerOf(
+    props: Properties,
+    keySerializer: Serializer<K>? = null,
+    valueSerializer: Serializer<V>? = null,
+): Producer<K, V> = KafkaProducer(props, keySerializer, valueSerializer)
+
+/**
+ * Producer 의 metrics 측정 값을 조회합니다.
+ *
+ * ```
+ * val sendCount = producer.getMetricValue("record-send-total")
+ * ```
+ * @param metricName metric name to retrieve
+ * @return metric 값
+ */
+fun <K, V> Producer<K, V>.getMetricValue(metricName: String): Double =
+    getMetricValueOrNull(metricName)?.asDoubleOrNull() ?: 0.0
+
+/**
+ * Producer 의 metrics 측정 값을 조회합니다.
+ *
+ * ```
+ * val sendCount = producer.getMetricValue("record-send-total")
+ * ```
+ * @param metricName metric name to retrieve
+ * @return metric 값
+ */
+fun <K, V> Producer<K, V>.getMetricValueOrNull(metricName: String): Any? =
+    metrics()
+        .entries
+        .find { it.key.name() == metricName }
+        ?.value
+        ?.metricValue()

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/TopicPartitionSupport.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/TopicPartitionSupport.kt
@@ -1,0 +1,47 @@
+package io.bluetape4k.kafka
+
+import io.bluetape4k.support.requireNotBlank
+import org.apache.kafka.common.TopicPartition
+
+/**
+ * `"topic-partition"` 형식 문자열을 [TopicPartition]으로 변환합니다.
+ *
+ * ## 동작/계약
+ * - 내부적으로 [topicPartitionOf]에 그대로 위임합니다.
+ * - 입력 형식 검증/예외 처리 규칙은 [topicPartitionOf]를 따릅니다.
+ * - 수신 문자열은 변경되지 않습니다.
+ *
+ * ```kotlin
+ * val tp = "orders-2".toTopicPartition()
+ * // tp.topic() == "orders"
+ * // tp.partition() == 2
+ * ```
+ */
+fun String.toTopicPartition(): TopicPartition = topicPartitionOf(this)
+
+/**
+ * `"topic-partition"` 형식 문자열을 [TopicPartition]으로 파싱합니다.
+ *
+ * ## 동작/계약
+ * - [tp]가 blank면 `assertNotBlank("tp")` 검증으로 예외가 발생합니다.
+ * - 마지막 `-`를 구분자로 사용해 topic/partition을 분리합니다.
+ * - 구분자가 없거나 partition이 정수가 아니면 `IllegalArgumentException`/`NumberFormatException`이 발생합니다.
+ *
+ * ```kotlin
+ * val tp = topicPartitionOf("payments-7")
+ * // tp.topic() == "payments"
+ * // tp.partition() == 7
+ * ```
+ */
+fun topicPartitionOf(tp: String): TopicPartition {
+    tp.requireNotBlank("tp")
+
+    val index = tp.lastIndexOf('-')
+    if (index < 0) {
+        throw IllegalArgumentException("Not found kafka topic-position delimiter (-)")
+    } else {
+        val topic = tp.substring(0, index)
+        val partition = tp.substring(index + 1)
+        return TopicPartition(topic, partition.toInt())
+    }
+}

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
@@ -1,0 +1,174 @@
+package io.bluetape4k.kafka.codec
+
+import io.bluetape4k.io.serializer.BinarySerializer
+import io.bluetape4k.io.serializer.BinarySerializers
+import org.apache.kafka.common.header.Headers
+
+/**
+ * [BinarySerializer]를 이용한 Kafka Codec
+ *
+ * ```kotlin
+ * val codec = KryoKafkaCodec()
+ * val data = listOf("a", "b", "c")
+ * val bytes = codec.serialize("topic", null, data)
+ * val restored = codec.deserialize("topic", null, bytes)
+ * // restored == listOf("a", "b", "c")
+ * ```
+ */
+abstract class BinaryKafkaCodec(
+    private val serializer: BinarySerializer,
+): AbstractKafkaCodec<Any?>() {
+
+    override fun doSerialize(topic: String?, headers: Headers?, graph: Any?): ByteArray {
+        return serializer.serialize(graph)
+    }
+
+    override fun doDeserialize(topic: String?, headers: Headers?, bytes: ByteArray): Any? {
+        return serializer.deserialize(bytes)
+    }
+}
+
+/**
+ * JDK 직렬화를 이용한 Kafka Codec
+ *
+ * ```kotlin
+ * val codec = JdkKafkaCodec()
+ * val bytes = codec.serialize("topic", null, "hello")
+ * val result = codec.deserialize("topic", null, bytes)
+ * // result == "hello"
+ * ```
+ */
+class JdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.Jdk)
+
+/**
+ * Kryo 직렬화를 이용한 Kafka Codec
+ *
+ * ```kotlin
+ * val codec = KryoKafkaCodec()
+ * val bytes = codec.serialize("topic", null, 42)
+ * val result = codec.deserialize("topic", null, bytes)
+ * // result == 42
+ * ```
+ */
+class KryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.Kryo)
+
+/**
+ * Fory 직렬화를 이용한 Kafka Codec
+ *
+ * ```kotlin
+ * val codec = ForyKafkaCodec()
+ * val bytes = codec.serialize("topic", null, "hello")
+ * val result = codec.deserialize("topic", null, bytes)
+ * // result == "hello"
+ * ```
+ */
+class ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.Fory)
+
+/**
+ * LZ4 압축 + JDK 직렬화를 이용한 Kafka Codec
+ *
+ * ```kotlin
+ * val codec = LZ4JdkKafkaCodec()
+ * val bytes = codec.serialize("topic", null, "hello")
+ * val result = codec.deserialize("topic", null, bytes)
+ * // result == "hello"
+ * ```
+ */
+class LZ4JdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Jdk)
+
+/**
+ * LZ4 압축 + Kryo 직렬화를 이용한 Kafka Codec
+ *
+ * ```kotlin
+ * val codec = LZ4KryoKafkaCodec()
+ * val bytes = codec.serialize("topic", null, listOf(1, 2, 3))
+ * val result = codec.deserialize("topic", null, bytes)
+ * // result == listOf(1, 2, 3)
+ * ```
+ */
+class LZ4KryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Kryo)
+
+/**
+ * LZ4 압축 + Fory 직렬화를 이용한 Kafka Codec
+ *
+ * ```kotlin
+ * val codec = LZ4ForyKafkaCodec()
+ * val bytes = codec.serialize("topic", null, "hello")
+ * val result = codec.deserialize("topic", null, bytes)
+ * // result == "hello"
+ * ```
+ */
+class LZ4ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Fory)
+
+/**
+ * Snappy 압축 + JDK 직렬화를 이용한 Kafka Codec
+ *
+ * ```kotlin
+ * val codec = SnappyJdkKafkaCodec()
+ * val bytes = codec.serialize("topic", null, "hello")
+ * val result = codec.deserialize("topic", null, bytes)
+ * // result == "hello"
+ * ```
+ */
+class SnappyJdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyJdk)
+
+/**
+ * Snappy 압축 + Kryo 직렬화를 이용한 Kafka Codec
+ *
+ * ```kotlin
+ * val codec = SnappyKryoKafkaCodec()
+ * val bytes = codec.serialize("topic", null, mapOf("k" to "v"))
+ * val result = codec.deserialize("topic", null, bytes)
+ * // result is a Map with k -> v
+ * ```
+ */
+class SnappyKryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyKryo)
+
+/**
+ * Snappy 압축 + Fory 직렬화를 이용한 Kafka Codec
+ *
+ * ```kotlin
+ * val codec = SnappyForyKafkaCodec()
+ * val bytes = codec.serialize("topic", null, "hello")
+ * val result = codec.deserialize("topic", null, bytes)
+ * // result == "hello"
+ * ```
+ */
+class SnappyForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyFory)
+
+
+/**
+ * Zstd 압축 + JDK 직렬화를 이용한 Kafka Codec
+ *
+ * ```kotlin
+ * val codec = ZstdJdkKafkaCodec()
+ * val bytes = codec.serialize("topic", null, "hello")
+ * val result = codec.deserialize("topic", null, bytes)
+ * // result == "hello"
+ * ```
+ */
+class ZstdJdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.ZstdJdk)
+
+/**
+ * Zstd 압축 + Kryo 직렬화를 이용한 Kafka Codec
+ *
+ * ```kotlin
+ * val codec = ZstdKryoKafkaCodec()
+ * val bytes = codec.serialize("topic", null, listOf("a", "b"))
+ * val result = codec.deserialize("topic", null, bytes)
+ * // result == listOf("a", "b")
+ * ```
+ */
+class ZstdKryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.ZstdKryo)
+
+/**
+ * Zstd 압축 + Fory 직렬화를 이용한 Kafka Codec
+ *
+ * ```kotlin
+ * val codec = ZstdForyKafkaCodec()
+ * val bytes = codec.serialize("topic", null, "hello")
+ * val result = codec.deserialize("topic", null, bytes)
+ * // result == "hello"
+ * ```
+ */
+class ZstdForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.ZstdFory)

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/ByteArrayKafkaCodec.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/ByteArrayKafkaCodec.kt
@@ -1,0 +1,34 @@
+package io.bluetape4k.kafka.codec
+
+import org.apache.kafka.common.header.Headers
+
+/**
+ * ByteArray를 직렬화/역직렬화하는 Kafka Codec입니다.
+ *
+ * 이 Codec은 데이터를 변환하지 않고 그대로 전달하므로,
+ * 이미 직렬화된 바이너리 데이터를 Kafka로 전송할 때 유용합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val codec = ByteArrayKafkaCodec()
+ * val bytes = "Hello".toByteArray()
+ * val serialized = codec.serialize("topic", bytes)
+ * val deserialized = codec.deserialize("topic", serialized)
+ * ```
+ *
+ * @see KafkaCodecs.ByteArray
+ */
+class ByteArrayKafkaCodec: AbstractKafkaCodec<ByteArray>() {
+
+    override fun doSerialize(
+        topic: String?,
+        headers: Headers?,
+        graph: ByteArray,
+    ): ByteArray = graph
+
+    override fun doDeserialize(
+        topic: String?,
+        headers: Headers?,
+        bytes: ByteArray,
+    ): ByteArray = bytes
+}

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodec.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodec.kt
@@ -1,0 +1,34 @@
+package io.bluetape4k.kafka.codec
+
+import io.bluetape4k.jackson3.Jackson
+import io.bluetape4k.support.emptyByteArray
+import org.apache.kafka.common.header.Headers
+import tools.jackson.databind.json.JsonMapper
+
+/**
+ * Kafka 키나 메시지를 JSON으로 직렬화/역직렬화하는 Kafka Codec
+ *
+ * ```kotlin
+ * val codec = JacksonKafkaCodec()
+ * val data = mapOf("id" to 1, "name" to "debop")
+ * val bytes = codec.serialize("my-topic", null, data)
+ * val result = codec.deserialize("my-topic", null, bytes)
+ * // result is a Map with id=1, name="debop"
+ * ```
+ *
+ * @param mapper Jackson [JsonMapper] 인스턴스
+ */
+class JacksonKafkaCodec(
+    private val mapper: JsonMapper = Jackson.defaultJsonMapper,
+): AbstractKafkaCodec<Any?>() {
+
+    override fun doSerialize(topic: String?, headers: Headers?, graph: Any?): ByteArray {
+        return graph?.let { mapper.writeValueAsBytes(it) } ?: emptyByteArray
+    }
+
+    override fun doDeserialize(topic: String?, headers: Headers?, bytes: ByteArray): Any? {
+        val clazz = getValueType(headers)
+        return if (bytes.isEmpty()) null
+        else mapper.readValue(bytes, clazz)
+    }
+}

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
@@ -1,0 +1,138 @@
+package io.bluetape4k.kafka.codec
+
+import io.bluetape4k.LibraryName
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.error
+import io.bluetape4k.logging.warn
+import io.bluetape4k.support.classIsPresent
+import io.bluetape4k.support.toUtf8Bytes
+import io.bluetape4k.support.toUtf8String
+import org.apache.kafka.common.header.Headers
+import org.apache.kafka.common.serialization.Deserializer
+import org.apache.kafka.common.serialization.Serializer
+import java.io.Closeable
+
+/**
+ * Kafka 의 [Serializer], [Deserializer] 기능을 한번에 제공하는 Codec 입니다.
+ *
+ * ```kotlin
+ * val codec = KafkaCodecs.String
+ * val serialized = codec.serialize("my-topic", "hello")
+ * val deserialized = codec.deserialize("my-topic", serialized)
+ * // deserialized == "hello"
+ * ```
+ *
+ * @param T 메시지 Value 의 수형
+ */
+interface KafkaCodec<T>:
+    Serializer<T>,
+    Deserializer<T>,
+    Closeable {
+    override fun configure(
+        configs: MutableMap<String, *>?,
+        isKey: Boolean,
+    ) {
+        // Nothing to do
+    }
+
+    override fun serialize(
+        topic: String?,
+        data: T?,
+    ): ByteArray = serialize(topic, null, data)
+
+    override fun deserialize(
+        topic: String?,
+        data: ByteArray?,
+    ): T? = deserialize(topic, null, data)
+
+    override fun close() {
+        // Nothing to do
+    }
+}
+
+/**
+ * [KafkaCodec]의 기본 추상 구현체입니다.
+ *
+ * 직렬화 시 헤더에 Value 타입 정보를 기록하고, 역직렬화 시 이를 참조합니다.
+ *
+ * ```kotlin
+ * val codec = JacksonKafkaCodec()
+ * val serialized = codec.serialize("my-topic", mapOf("key" to "value"))
+ * val deserialized = codec.deserialize("my-topic", serialized)
+ * // deserialized is a Map with key -> value
+ * ```
+ *
+ * **보안 경고**: 이 코덱은 Kafka 헤더의 `bluetape4k.kafka.codec.value.type` 값을 기반으로
+ * 클래스를 동적으로 로드합니다. 신뢰할 수 없는 Kafka 브로커 또는 외부 네트워크에서
+ * 수신된 메시지에 이 코덱을 사용하면 임의 클래스 로딩 취약점이 발생할 수 있습니다.
+ * 반드시 신뢰할 수 있는 내부 Kafka 브로커 환경에서만 사용하십시오.
+ */
+abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
+    companion object: KLogging() {
+        const val VALUE_TYPE_KEY = "$LibraryName.kafka.codec.value.type"
+
+        @JvmStatic
+        fun defaultCodec(): KafkaCodec<Any?> = JacksonKafkaCodec()
+    }
+
+    protected abstract fun doSerialize(
+        topic: String?,
+        headers: Headers?,
+        graph: T,
+    ): ByteArray
+
+    protected abstract fun doDeserialize(
+        topic: String?,
+        headers: Headers?,
+        bytes: ByteArray,
+    ): T?
+
+    override fun serialize(
+        topic: String?,
+        headers: Headers?,
+        data: T?,
+    ): ByteArray? =
+        data?.run {
+            setValueType(headers, data.javaClass)
+            doSerialize(topic, headers, this)
+        }
+
+    override fun deserialize(
+        topic: String?,
+        headers: Headers?,
+        data: ByteArray?,
+    ): T? =
+        try {
+            data?.run { doDeserialize(topic, headers, this) }
+        } catch (e: Throwable) {
+            log.warn(e) { "Fail to deserialize data. topic=$topic, headerKeys=${headers?.map { it.key() }}, data=$data. Returning null (poison pill skipped)." }
+            null
+        }
+
+    protected fun setValueType(
+        headers: Headers?,
+        valueType: Class<T & Any>,
+    ) {
+        headers?.add(VALUE_TYPE_KEY, valueType.name.toUtf8Bytes())
+    }
+
+    protected fun getValueType(headers: Headers?): Class<*> {
+        val clazzName =
+            headers?.lastHeader(VALUE_TYPE_KEY)?.value()?.toUtf8String()
+                ?: return Any::class.java
+
+        return try {
+            when {
+                classIsPresent(clazzName) -> {
+                    Class.forName(clazzName, false, Thread.currentThread().contextClassLoader)
+                }
+                else -> {
+                    Any::class.java
+                }
+            }
+        } catch (e: Exception) {
+            log.error(e) { "Fail to load value type. clazzName=$clazzName" }
+            Any::class.java
+        }
+    }
+}

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodecs.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodecs.kt
@@ -1,0 +1,47 @@
+package io.bluetape4k.kafka.codec
+
+/**
+ * 다양한 Kafka Codec 인스턴스를 제공하는 Object입니다.
+ *
+ * 문자열, 바이트 배열, JSON 직렬화 및 다양한 바이너리 직렬화(JDK, Kryo, FST)와
+ * 압축 알고리즘(LZ4, Snappy, Zstd)을 조합한 Codec을 제공합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * // 문자열 Codec 사용
+ * val stringCodec = KafkaCodecs.String
+ *
+ * // JSON Codec 사용
+ * val jacksonCodec = KafkaCodecs.Jackson
+ *
+ * // LZ4 압축 + Kryo 직렬화 Codec 사용
+ * val lz4KryoCodec = KafkaCodecs.Lz4Kryo
+ * ```
+ *
+ * @see KafkaCodec
+ * @see StringKafkaCodec
+ * @see JacksonKafkaCodec
+ * @see BinaryKafkaCodec
+ */
+object KafkaCodecs {
+    val String by lazy { StringKafkaCodec() }
+    val ByteArray by lazy { ByteArrayKafkaCodec() }
+
+    val Jackson by lazy { JacksonKafkaCodec() }
+
+    val Jdk by lazy { JdkKafkaCodec() }
+    val Kryo by lazy { KryoKafkaCodec() }
+    val Fory by lazy { ForyKafkaCodec() }
+
+    val LZ4Jdk by lazy { LZ4JdkKafkaCodec() }
+    val Lz4Kryo by lazy { LZ4KryoKafkaCodec() }
+    val Lz4Fory by lazy { LZ4ForyKafkaCodec() }
+
+    val SnappyJdk by lazy { SnappyJdkKafkaCodec() }
+    val SnappyKryo by lazy { SnappyKryoKafkaCodec() }
+    val SnappyFory by lazy { SnappyForyKafkaCodec() }
+
+    val ZstdJdk by lazy { ZstdJdkKafkaCodec() }
+    val ZstdKryo by lazy { ZstdKryoKafkaCodec() }
+    val ZstdFory by lazy { ZstdForyKafkaCodec() }
+}

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/StringKafkaCodec.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/StringKafkaCodec.kt
@@ -1,0 +1,81 @@
+package io.bluetape4k.kafka.codec
+
+import io.bluetape4k.logging.KLogging
+import org.apache.kafka.common.header.Headers
+import java.nio.charset.Charset
+
+/**
+ * Kafka 메시지의 Key 와 Value의 타입이 문자열인 경우에 사용하는 [KafkaCodec] 입니다.
+ *
+ * ```kotlin
+ * val codec = StringKafkaCodec()
+ * val bytes = codec.serialize("my-topic", "hello")
+ * val result = codec.deserialize("my-topic", bytes)
+ * // result == "hello"
+ * ```
+ */
+class StringKafkaCodec: AbstractKafkaCodec<String>() {
+    companion object: KLogging() {
+        @JvmField
+        val DefaultEncoding = Charsets.UTF_8
+
+        private const val SERIALIZER_ENCODING = "serializer.encoding"
+        private const val KEY_SERIALIZER_ENCODING = "key.$SERIALIZER_ENCODING"
+        private const val VALUE_SERIALIZER_ENCODING = "value.$SERIALIZER_ENCODING"
+
+        private const val DESERIALIZER_ENCODING = "deserializer.encoding"
+        private const val KEY_DESERIALIZER_ENCODING = "key.$DESERIALIZER_ENCODING"
+        private const val VALUE_DESERIALIZER_ENCODING = "value.$DESERIALIZER_ENCODING"
+    }
+
+    private var serializerEncoding = DefaultEncoding
+    private var deserializerEncoding = DefaultEncoding
+
+    override fun configure(
+        configs: MutableMap<String, *>?,
+        isKey: Boolean,
+    ) {
+        configs?.run {
+            serializerEncoding = getSerializerEncoding(this, isKey)
+            deserializerEncoding = getDeserializerEncoding(this, isKey)
+        }
+    }
+
+    override fun doSerialize(
+        topic: String?,
+        headers: Headers?,
+        graph: String,
+    ): ByteArray = graph.toByteArray(serializerEncoding)
+
+    override fun doDeserialize(
+        topic: String?,
+        headers: Headers?,
+        bytes: ByteArray,
+    ): String? = if (bytes.isEmpty()) null else bytes.toString(deserializerEncoding)
+
+    private fun getSerializerEncoding(
+        configs: Map<String, *>,
+        isKey: Boolean,
+    ): Charset {
+        val propertyName = if (isKey) KEY_SERIALIZER_ENCODING else VALUE_SERIALIZER_ENCODING
+        val encodingValue = configs[propertyName] ?: configs[SERIALIZER_ENCODING]
+
+        return when (encodingValue) {
+            is String -> runCatching { Charset.forName(encodingValue) }.getOrDefault(DefaultEncoding)
+            else -> DefaultEncoding
+        }
+    }
+
+    private fun getDeserializerEncoding(
+        configs: Map<String, *>,
+        isKey: Boolean,
+    ): Charset {
+        val propertyName = if (isKey) KEY_DESERIALIZER_ENCODING else VALUE_DESERIALIZER_ENCODING
+        val encodingValue = configs[propertyName] ?: configs[DESERIALIZER_ENCODING]
+
+        return when (encodingValue) {
+            is String -> runCatching { Charset.forName(encodingValue) }.getOrDefault(DefaultEncoding)
+            else -> DefaultEncoding
+        }
+    }
+}

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/coroutines/ProducerCoroutines.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/coroutines/ProducerCoroutines.kt
@@ -1,0 +1,136 @@
+package io.bluetape4k.kafka.coroutines
+
+import io.bluetape4k.coroutines.flow.async
+import io.bluetape4k.coroutines.support.awaitSuspending
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.flow.onCompletion
+import org.apache.kafka.clients.producer.Producer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+
+/**
+ * Coroutine 환경 하에서 Producer를 이용하여 메시지를 producing 합니다.
+ *
+ * ```
+ * val producer = producerOf(
+ *    mapOf(
+ *      "bootstrap.servers" to "localhost:9092",
+ *      "acks" to "all",
+ *      "retries" to 3,
+ *    ),
+ *    StringSerializer(),
+ *    StringSerializer(),
+ * )
+ * val record = ProducerRecord("test-topic", "test-key", "test-value")
+ * producer.suspendSend(record)
+ * ```
+ *
+ *
+ * @param record 발행할 메시지 ([ProducerRecord])
+ * @return 발행 결과를 표현하는 [RecordMetadata] instance
+ */
+suspend fun <K, V> Producer<K, V>.suspendSend(record: ProducerRecord<K, V>): RecordMetadata {
+    return send(record).awaitSuspending()
+}
+
+/**
+ * 복수의 [ProducerRecord] 를 producing 하면서, 결과들을 Flow로 반환하도록 합니다.
+ *
+ * flush()는 에러/취소 시에도 onCompletion이 호출되므로 cause 가 없는 정상 완료 시에만
+ * 호출한다. 에러 상황에서 flush()를 호출하면 이미 실패한 send 의 결과를 강제 대기하여
+ * 불필요하게 블로킹되거나 예외를 덮어쓸 위험이 있다.
+ *
+ * ```
+ * val records = flow {
+ *      emit(ProducerRecord("test-topic", "test-key", "test-value"))
+ *      emit(ProducerRecord("test-topic", "test-key2", "test-value2"))
+ *      emit(ProducerRecord("test-topic", "test-key3", "test-value3"))
+ * }
+ * producer.sendFlow(records)
+ * ```
+ *
+ * @param records producing 할 record의 flow
+ * @return producing 된 결과 ([RecordMetadata])의 flow
+ */
+suspend fun <K, V> Producer<K, V>.sendAsFlow(records: Flow<ProducerRecord<K, V>>): Flow<RecordMetadata> {
+    return records
+        .buffer()
+        .async {
+            suspendSend(it)
+        }
+        // cause != null 이면 에러/취소 — flush() 호출 시 블로킹 위험이 있으므로 정상 완료 시에만 실행
+        .onCompletion { cause -> if (cause == null) flush() }
+}
+
+
+/**
+ * 복수의 [ProducerRecord] 를 producing 하면서, 마지막 producing 한 결과만 반환하게 한다.
+ *
+ * flush()는 에러/취소 시에도 onCompletion이 호출되므로 cause 가 없는 정상 완료 시에만
+ * 호출한다. 에러 상황에서 flush()를 호출하면 이미 실패한 send 의 결과를 강제 대기하여
+ * 불필요하게 블로킹되거나 예외를 덮어쓸 위험이 있다.
+ *
+ * ```
+ * val records = flow {
+ *      emit(ProducerRecord("test-topic", "test-key", "test-value"))
+ *      emit(ProducerRecord("test-topic", "test-key2", "test-value2"))
+ *      emit(ProducerRecord("test-topic", "test-key3", "test-value3"))
+ * }
+ * producer.sendFlowParallel(records)
+ * ```
+ *
+ * @param records producing 할 record의 flow
+ * @return 마지막 record에 대한 producing 한 결과
+ */
+suspend fun <K, V> Producer<K, V>.sendAsFlowParallel(
+    records: Flow<ProducerRecord<K, V>>,
+): RecordMetadata {
+    return records
+        .buffer()
+        .async {
+            suspendSend(it)
+        }
+        // cause != null 이면 에러/취소 — flush() 호출 시 블로킹 위험이 있으므로 정상 완료 시에만 실행
+        .onCompletion { cause -> if (cause == null) flush() }
+        .last()
+}
+
+/**
+ * 발송만 하고, 결과 값은 받지 않습니다.
+ *
+ * needFlush=true 이더라도 에러/취소 상황에서는 flush()를 호출하지 않는다.
+ * onCompletion의 cause 파라미터로 정상 완료 여부를 판별하며,
+ * 에러 중 flush() 호출은 이미 실패한 send 요청을 강제 대기하여 스레드를 블로킹할 수 있다.
+ *
+ * ```
+ * val records = flow {
+ *      emit(ProducerRecord("test-topic", "test-key", "test-value"))
+ *      emit(ProducerRecord("test-topic", "test-key2", "test-value2"))
+ *      emit(ProducerRecord("test-topic", "test-key3", "test-value3"))
+ * }
+ * producer.sendAndForget(records, needFlush = false)
+ * ```
+ *
+ * @param records producing 할 record의 flow
+ * @param needFlush 정상 완료 후 flush() 호출 여부
+ */
+suspend fun <K, V> Producer<K, V>.sendAndForget(
+    records: Flow<ProducerRecord<K, V>>,
+    needFlush: Boolean = false,
+) {
+    records
+        .buffer()
+        .async {
+            send(it).awaitSuspending()
+        }
+        // cause != null 이면 에러/취소 — 에러 중 flush() 호출은 불필요한 블로킹을 유발한다
+        .onCompletion { cause ->
+            if (needFlush && cause == null) {
+                flush()
+            }
+        }
+        .collect()
+}

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/KafkaOperationsExtensions.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/KafkaOperationsExtensions.kt
@@ -1,0 +1,212 @@
+package io.bluetape4k.kafka.spring
+
+import kotlinx.coroutines.future.await
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.springframework.kafka.core.KafkaOperations
+import org.springframework.kafka.support.SendResult
+import org.springframework.messaging.Message
+
+/**
+ * [KafkaOperations] 발송을 suspend 함수로 실행합니다.
+ *
+ * ```
+ * val kafkaTemplate: KafkaTemplate<String, String> = ...
+ * val result = kafkaTemplate.suspendSend(producerRecordOf("topic", "key", "value"))
+ * ```
+ *
+ * @param record 전송할 [ProducerRecord]
+ * @return [SendResult] 발송 결과
+ */
+suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSend(record: ProducerRecord<K, V>): SendResult<K, V> =
+    send(record).await()
+
+@Deprecated(
+    message = "Use `suspendSend` instead.",
+    replaceWith = ReplaceWith("suspendSend(record)")
+)
+suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(record: ProducerRecord<K, V>): SendResult<K, V> =
+    send(record).await()
+
+/**
+ * [KafkaOperations] 발송을 suspend 함수로 실행합니다.
+ *
+ * ```
+ * val kafkaTemplate: KafkaTemplate<String, String> = ...
+ * val result = kafkaTemplate.suspendSend(messageOf("topic", "value"))
+ * ```
+ *
+ * @param message 전송할 [Message]
+ * @return [SendResult] 발송 결과
+ * @see Message
+ */
+suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSend(message: Message<*>): SendResult<K, V> =
+    send(message).await()
+
+@Deprecated(
+    message = "Use `suspendSend` instead.",
+    replaceWith = ReplaceWith("suspendSend(message)")
+)
+suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(message: Message<*>): SendResult<K, V> =
+    send(message).await()
+
+/**
+ * [KafkaOperations] 발송을 suspend 함수로 실행합니다.
+ *
+ * ```kotlin
+ * val kafkaTemplate: KafkaTemplate<String, String> = ...
+ * val result = kafkaTemplate.suspendSend("my-topic", "hello")
+ * // result.recordMetadata.topic() == "my-topic"
+ * ```
+ *
+ * @param topic 발송할 토픽
+ * @param value 발송할 값
+ * @return [SendResult] 발송 결과
+ */
+suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSend(topic: String, value: V): SendResult<K, V> =
+    send(topic, value).await()
+
+@Deprecated(
+    message = "Use `suspendSend` instead.",
+    replaceWith = ReplaceWith("suspendSend(topic, value)")
+)
+suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(topic: String, value: V): SendResult<K, V> =
+    send(topic, value).await()
+
+/**
+ * [KafkaOperations] 발송을 suspend 함수로 실행합니다.
+ *
+ * ```kotlin
+ * val kafkaTemplate: KafkaTemplate<String, String> = ...
+ * val result = kafkaTemplate.suspendSend("my-topic", "my-key", "hello")
+ * // result.recordMetadata.topic() == "my-topic"
+ * ```
+ *
+ * @param topic 발송할 토픽
+ * @param key 발송할 키
+ * @param value 발송할 값
+ * @return [SendResult] 발송 결과
+ */
+suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSend(topic: String, key: K, value: V): SendResult<K, V> =
+    send(topic, key, value).await()
+
+@Deprecated(
+    message = "Use `suspendSend` instead.",
+    replaceWith = ReplaceWith("suspendSend(topic, key, value)")
+)
+suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(topic: String, key: K, value: V): SendResult<K, V> =
+    send(topic, key, value).await()
+
+/**
+ * [KafkaOperations] 발송을 suspend 함수로 실행합니다.
+ *
+ * ```kotlin
+ * val kafkaTemplate: KafkaTemplate<String, String> = ...
+ * val result = kafkaTemplate.suspendSend("my-topic", partition = 0, key = "my-key", value = "hello")
+ * // result.recordMetadata.partition() == 0
+ * ```
+ *
+ * @param topic 발송할 토픽
+ * @param partition 발송할 파티션
+ * @param key 발송할 키
+ * @param value 발송할 값
+ * @return [SendResult] 발송 결과
+ */
+suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSend(
+    topic: String,
+    partition: Int,
+    key: K,
+    value: V,
+): SendResult<K, V> =
+    send(topic, partition, key, value).await()
+
+@Deprecated(
+    message = "Use `suspendSend` instead.",
+    replaceWith = ReplaceWith("suspendSend(topic, partition, key, value)")
+)
+suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(
+    topic: String,
+    partition: Int,
+    key: K,
+    value: V,
+): SendResult<K, V> =
+    send(topic, partition, key, value).await()
+
+/**
+ * [KafkaOperations] 발송을 suspend 함수로 실행합니다.
+ *
+ * ```kotlin
+ * val kafkaTemplate: KafkaTemplate<String, String> = ...
+ * val result = kafkaTemplate.suspendSend(
+ *     topic = "my-topic",
+ *     partition = 0,
+ *     timestamp = System.currentTimeMillis(),
+ *     key = "my-key",
+ *     value = "hello"
+ * )
+ * // result.recordMetadata.partition() == 0
+ * ```
+ *
+ * @param topic 발송할 토픽
+ * @param partition 발송할 파티션
+ * @param timestamp 발송할 타임스탬프
+ * @param key 발송할 키
+ * @param value 발송할 값
+ * @return [SendResult] 발송 결과
+ */
+suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSend(
+    topic: String,
+    partition: Int,
+    timestamp: Long,
+    key: K,
+    value: V,
+): SendResult<K, V> =
+    send(topic, partition, timestamp, key, value).await()
+
+@Deprecated(
+    message = "Use `suspendSend` instead.",
+    replaceWith = ReplaceWith("suspendSend(topic, partition, timestamp, key, value)")
+)
+suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(
+    topic: String,
+    partition: Int,
+    timestamp: Long,
+    key: K,
+    value: V,
+): SendResult<K, V> =
+    send(topic, partition, timestamp, key, value).await()
+
+
+/**
+ * [KafkaOperations] 기본 Topic으로 발송하는 작업을 suspend 함수로 실행합니다.
+ *
+ * @param value 발송할 값
+ * @return [SendResult] 발송 결과
+ * @see KafkaOperations.sendDefault
+ */
+suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSendDefault(value: V): SendResult<K, V> =
+    sendDefault(value).await()
+
+@Deprecated(
+    message = "Use `suspendSendDefault` instead.",
+    replaceWith = ReplaceWith("suspendSendDefault(value)")
+)
+suspend fun <K: Any, V: Any> KafkaOperations<K, V>.awaitSendDefault(value: V): SendResult<K, V> =
+    sendDefault(value).await()
+
+/**
+ * [KafkaOperations] 기본 Topic으로 발송하는 작업을 suspend 함수로 실행합니다.
+ *
+ * @param key 발송할 키
+ * @param value 발송할 값
+ * @return [SendResult] 발송 결과
+ * @see KafkaOperations.sendDefault
+ */
+suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSendDefault(key: K, value: V): SendResult<K, V> =
+    sendDefault(key, value).await()
+
+@Deprecated(
+    message = "Use `suspendSendDefault` instead.",
+    replaceWith = ReplaceWith("suspendSendDefault(key, value)")
+)
+suspend fun <K: Any, V: Any> KafkaOperations<K, V>.awaitSendDefault(key: K, value: V): SendResult<K, V> =
+    sendDefault(key, value).await()

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt
@@ -1,0 +1,180 @@
+@file:Suppress("removal", "DEPRECATION")
+
+package io.bluetape4k.kafka.spring.core
+
+import io.bluetape4k.coroutines.flow.async
+import io.bluetape4k.support.asDouble
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.apache.kafka.common.Metric
+import org.springframework.kafka.core.KafkaOperations
+import org.springframework.kafka.support.SendResult
+import java.util.concurrent.Future
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Coroutines 환경 하에서 [KafkaOperations]를 이용하여 메시지를 전송합니다
+ *
+ * ```
+ * val kafkaOperations: KafkaOperations<String, String> = ...
+ * val result = kafkaOperations.sendSuspending(ProducerRecord("topic", "key", "value"))
+ * ```
+ *
+ * @param K Key type   메시지 키 타입
+ * @param V Value type 메시지 값 타입
+ * @param record 전송할 정보 [ProducerRecord]
+ * @return 발송 결과 정보 [SendResult]
+ */
+suspend inline fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSend(record: ProducerRecord<K, V>): SendResult<K, V> =
+    suspendCancellableCoroutine { cont ->
+        val result: Future<RecordMetadata>? =
+            execute { producer ->
+                producer.send(record) { metadata, exception ->
+                    if (exception != null) {
+                        cont.resumeWithException(exception)
+                    } else {
+                        cont.resume(SendResult(record, metadata))
+                    }
+                }
+            }
+        cont.invokeOnCancellation {
+            result?.cancel(true)
+        }
+    }
+
+@Deprecated(
+    message = "Use `suspendSend` instead.",
+    replaceWith = ReplaceWith("suspendSend(record)")
+)
+suspend inline fun <K: Any, V: Any> KafkaOperations<K, V>.awaitSend(record: ProducerRecord<K, V>): SendResult<K, V> =
+    suspendCancellableCoroutine { cont ->
+        val result: Future<RecordMetadata>? =
+            execute { producer ->
+                producer.send(record) { metadata, exception ->
+                    if (exception != null) {
+                        cont.resumeWithException(exception)
+                    } else {
+                        cont.resume(SendResult(record, metadata))
+                    }
+                }
+            }
+        cont.invokeOnCancellation {
+            result?.cancel(true)
+        }
+    }
+
+@Deprecated(
+    message = "Use `suspendSend` instead.",
+    replaceWith = ReplaceWith("suspendSend(record)")
+)
+suspend inline fun <K: Any, V: Any> KafkaOperations<K, V>.sendSuspending(record: ProducerRecord<K, V>): SendResult<K, V> =
+    suspendCancellableCoroutine { cont ->
+        val result: Future<RecordMetadata>? =
+            execute { producer ->
+                producer.send(record) { metadata, exception ->
+                    if (exception != null) {
+                        cont.resumeWithException(exception)
+                    } else {
+                        cont.resume(SendResult(record, metadata))
+                    }
+                }
+            }
+        cont.invokeOnCancellation {
+            result?.cancel(true)
+        }
+    }
+
+/**
+ * 복수의 [ProducerRecord] 를 producing 하면서, 마지막 producing 한 결과만 반환하게 한다.
+ *
+ * ```
+ * val kafkaOperations: KafkaOperations<String, String> = ...
+ * val records = flow {
+ *    emit(ProducerRecord("topic", "key1", "value1"))
+ *    emit(ProducerRecord("topic", "key2", "value2"))
+ *    emit(ProducerRecord("topic", "key3", "value3"))
+ * }
+ * val result = kafkaOperations.sendFlowAsParallel(records)
+ * ```
+ *
+ * @param records producing 할 record의 flow
+ * @return 마지막 record에 대한 producing 한 결과
+ */
+suspend inline fun <K: Any, V: Any> KafkaOperations<K, V>.sendFlowAsParallel(
+    records: Flow<ProducerRecord<K, V>>,
+): SendResult<K, V> =
+    records
+        .async {
+            suspendSend(it)
+        }.onCompletion { flush() }
+        .last()
+
+/**
+ * 발송만 하고, 결과 값은 받지 않습니다.
+ *
+ * ```
+ * val kafkaOperations: KafkaOperations<String, String> = ...
+ * val records = flow {
+ *   emit(ProducerRecord("topic", "key1", "value1"))
+ *   emit(ProducerRecord("topic", "key2", "value2"))
+ *   emit(ProducerRecord("topic", "key3", "value3"))
+ * }
+ *
+ * kafkaOperations.sendAndForget(records)
+ * ```
+ *
+ * @param records producing 할 record의 flow
+ */
+suspend inline fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndForget(
+    records: Flow<ProducerRecord<K, V>>,
+    needFlush: Boolean = false,
+) {
+    records
+        .async {
+            suspendSend(it)
+        }.onCompletion {
+            if (needFlush) flush()
+        }.collect()
+}
+
+/**
+ * Producer 의 metrics 측정 값을 조회합니다.
+ *
+ * ```
+ * val metric = producer.getMetric("record-send-total")
+ * ```
+ * @param metricName metric name to retrieve
+ * @return [Metric] 인스턴스 또는 null
+ */
+fun <K: Any, V: Any> KafkaOperations<K, V>.getMetric(metricName: String): Metric? =
+    metrics().entries.find { it.key.name() == metricName }?.value
+
+/**
+ * Producer 의 metrics 측정 값을 조회합니다.
+ *
+ * ```
+ * val sendCount = producer.getMetricValue("record-send-total")
+ * ```
+ * @param metricName metric name to retrieve
+ * @return metric 값
+ */
+fun <K: Any, V: Any> KafkaOperations<K, V>.getMetricValue(metricName: String): Double =
+    getMetric(metricName)?.metricValue().asDouble(0.0)
+
+/**
+ * Producer 의 metrics 측정 값을 조회합니다.
+ *
+ * ```
+ * val sendCount = producer.getMetricValue("record-send-total")
+ * ```
+ * @param metricName metric name to retrieve
+ * @return metric 값
+ */
+fun <K: Any, V: Any> KafkaOperations<K, V>.getMetricValueOrNull(metricName: String): Any? =
+    getMetric(metricName)?.metricValue()

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/ProducerFactorySupport.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/ProducerFactorySupport.kt
@@ -1,0 +1,68 @@
+package io.bluetape4k.kafka.spring.core
+
+import org.springframework.kafka.core.KafkaResourceHolder
+import org.springframework.kafka.core.ProducerFactory
+import org.springframework.kafka.core.ProducerFactoryUtils
+import java.time.Duration
+
+/**
+ * 현 트랜잭션과 동기화된 Kafka 리소스를 얻습니다.
+ *
+ * ```kotlin
+ * val holder = transactionalResourceHolderOf(producerFactory)
+ * val producer = holder.producer
+ * // producer를 사용하여 메시지 전송
+ * holder.release()
+ * ```
+ *
+ * @param producerFactory ProducerFactory instance.
+ * @param <K> 키 타입
+ * @param <V> 값 타입
+ * @return [KafkaResourceHolder] instance.
+ */
+fun <K: Any, V: Any> transactionalResourceHolderOf(
+    producerFactory: ProducerFactory<K, V>,
+): KafkaResourceHolder<K, V> =
+    ProducerFactoryUtils.getTransactionalResourceHolder(producerFactory)
+
+
+/**
+ * 현 트랜잭션과 동기화된 Kafka 리소스를 얻습니다.
+ *
+ * ```kotlin
+ * val holder = transactionalResourceHolderOf(
+ *     producerFactory,
+ *     closeTimeout = Duration.ofSeconds(5),
+ *     txIdPrefix = "tx-"
+ * )
+ * // holder.producer를 사용하여 메시지 전송
+ * holder.release()
+ * ```
+ *
+ * @param producerFactory ProducerFactory instance.
+ * @param closeTimeout Producer 종료 시간.
+ * @param txIdPrefix 트랜잭션 ID prefix.
+ * @return [KafkaResourceHolder] instance.
+ */
+fun <K: Any, V: Any> transactionalResourceHolderOf(
+    producerFactory: ProducerFactory<K, V>,
+    closeTimeout: Duration,
+    txIdPrefix: String? = null,
+): KafkaResourceHolder<K, V> =
+    ProducerFactoryUtils.getTransactionalResourceHolder(producerFactory, txIdPrefix, closeTimeout)
+
+/**
+ * Kafka Resource 를 해제합니다.
+ *
+ * ```kotlin
+ * val holder = transactionalResourceHolderOf(producerFactory)
+ * try {
+ *     holder.producer.send(ProducerRecord("topic", "key", "value"))
+ * } finally {
+ *     holder.release()
+ * }
+ * ```
+ */
+fun <K: Any, V: Any> KafkaResourceHolder<K, V>.release() {
+    ProducerFactoryUtils.releaseResources(this)
+}

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplate.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplate.kt
@@ -1,0 +1,501 @@
+package io.bluetape4k.kafka.spring.core
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requireNotEmpty
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.reactive.asFlow
+import kotlinx.coroutines.reactor.awaitSingle
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp
+import org.apache.kafka.common.Metric
+import org.apache.kafka.common.MetricName
+import org.apache.kafka.common.PartitionInfo
+import org.apache.kafka.common.TopicPartition
+import org.springframework.beans.factory.DisposableBean
+import reactor.kafka.receiver.KafkaReceiver
+import reactor.kafka.receiver.ReceiverOptions
+import reactor.kafka.receiver.ReceiverRecord
+import reactor.kafka.sender.TransactionManager
+import java.io.Closeable
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.regex.Pattern
+
+/**
+ * Coroutine 환경에서 Kafka Consumer 기능을 제공하는 구현체입니다.
+ *
+ * ```
+ * val receiverOptions = ReceiverOptions.create<String, String>(
+ *      mapOf(
+ *          "bootstrap.servers" to "localhost:9092",
+ *          "group.id" to "test-group",
+ *          "auto.offset.reset" to "earliest",
+ *          "enable.auto.commit" to "false",
+ *          "key.deserializer" to StringDeserializer::class.java,
+ *          "value.deserializer" to StringDeserializer::class.java,
+ *          "topic" to "test-topic",
+ *          "max.poll.records" to "1",
+ *          "max.poll.interval.ms" to "1000",
+ *          "session.timeout.ms" to "15000",
+ *          "heartbeat.interval.ms" to "5000",
+ *          "auto.commit.interval.ms" to "1000",
+ *      )
+ * )
+ * val consumer = SuspendKafkaConsumerTemplate(receiverOptions)
+ * consumer.receive().collect { record ->
+ *     println("Received: ${record.value()}")
+ *     record.receiver.commit(record.receiver.assignment())
+ *     // record.receiver.commit(record.receiver.assignment(), record.offset())
+ *     // record.receiver.commit(record.receiver.assignment(), record.offset(), record.partition())
+ *     // record.receiver.commit(record.receiver.assignment(), record.offset(), record.partition(), record.topic())
+ * }
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @property receiver [KafkaReceiver] instance.
+ *
+ * @see [org.springframework.kafka.core.reactive.ReactiveKafkaConsumerTemplate]
+ */
+class SuspendKafkaConsumerTemplate<K, V> private constructor(
+    private val receiver: KafkaReceiver<K, V>,
+): CoroutineScope, Closeable, DisposableBean {
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val closed = AtomicBoolean(false)
+
+    override val coroutineContext = scope.coroutineContext
+
+    companion object: KLoggingChannel() {
+        @JvmStatic
+        operator fun <K, V> invoke(receiverOptions: ReceiverOptions<K, V>): SuspendKafkaConsumerTemplate<K, V> =
+            SuspendKafkaConsumerTemplate(KafkaReceiver.create(receiverOptions))
+
+        @JvmStatic
+        operator fun <K, V> invoke(receiver: KafkaReceiver<K, V>): SuspendKafkaConsumerTemplate<K, V> =
+            SuspendKafkaConsumerTemplate(receiver)
+    }
+
+    /**
+     * 레코드를 수동 acknowledgment 방식으로 수신합니다.
+     *
+     * ```kotlin
+     * val consumer = SuspendKafkaConsumerTemplate(receiverOptions)
+     * consumer.receive().collect { record ->
+     *     println("Received: ${record.value()}")
+     *     record.receiverOffset().acknowledge()
+     * }
+     * ```
+     */
+    fun receive(): Flow<ReceiverRecord<K, V>> = receiver.receive().asFlow()
+
+    /**
+     * 레코드를 자동 acknowledgment 방식으로 수신합니다.
+     *
+     * ```kotlin
+     * val consumer = SuspendKafkaConsumerTemplate(receiverOptions)
+     * consumer.receiveAutoAck().collect { record ->
+     *     println("Received: ${record.value()}")
+     *     // offset은 자동으로 커밋됨
+     * }
+     * ```
+     */
+    fun receiveAutoAck(): Flow<ConsumerRecord<K, V>> = receiver.receiveAutoAck().concatMap { it }.asFlow()
+
+    /**
+     * Returns a {@link Flux} of consumer record batches that may be used for exactly once
+     * delivery semantics. A new transaction is started for each inner Flux and it is the
+     * responsibility of the consuming application to commit or abort the transaction
+     * using {@link TransactionManager#commit()} or {@link TransactionManager#abort()}
+     * after processing the Flux. The next batch of consumer records will be delivered only
+     * after the previous flux terminates. Offsets of records dispatched on each inner Flux
+     * are committed using the provided <code>transactionManager</code> within the transaction
+     * started for that Flux.
+     * <p> Example usage:
+     * <pre>
+     * {@code
+     * KafkaSender<Integer, Person> sender = sender(senderOptions());
+     * ReceiverOptions<Integer, Person> receiverOptions = receiverOptions(Collections.singleton(sourceTopic));
+     * KafkaReceiver<Integer, Person> receiver = KafkaReceiver.create(receiverOptions);
+     * receiver.receiveExactlyOnce(sender.transactionManager())
+     * 	 .concatMap(f -> sendAndCommit(f))
+     *	 .onErrorResume(e -> sender.transactionManager().abort().then(Mono.error(e)))
+     *	 .doOnCancel(() -> close());
+     *
+     * Flux<SenderResult<Integer>> sendAndCommit(Flux<ConsumerRecord<Integer, Person>> flux) {
+     * 	return sender.send(flux.map(r -> SenderRecord.<Integer, Person, Integer>create(transform(r.value()), r.key())))
+     *			.concatWith(sender.transactionManager().commit());
+     * }
+     * }
+     * </pre>
+     * @param transactionManager Transaction manager used to begin new transaction for each
+     *        inner Flux and commit offsets within that transaction
+     * @return Flux of consumer record batches processed within a transaction
+     */
+    fun receiveExactlyOnce(transactionManager: TransactionManager): Flow<Flow<ConsumerRecord<K, V>>> =
+        receiver.receiveExactlyOnce(transactionManager).map { it.asFlow() }.asFlow()
+
+    private suspend inline fun <T> doOnConsumer(
+        crossinline function: (Consumer<K, V>) -> T,
+    ): T = receiver.doOnConsumer { function(it) }.awaitSingle()
+
+    /**
+     * 지정한 topic 목록으로 consumer를 구독시킵니다.
+     *
+     * @param topics 구독할 topic 목록
+     */
+    suspend fun subscribe(vararg topics: String) {
+        topics.requireNotEmpty("topics")
+        topics.forEach { it.requireNotBlank("topics") }
+        doOnConsumer { it.subscribe(topics.asList()) }
+    }
+
+    /**
+     * 정규식 패턴과 일치하는 topic을 구독시킵니다.
+     *
+     * @param pattern 구독할 topic 패턴
+     */
+    suspend fun subscribe(pattern: Pattern) {
+        doOnConsumer { it.subscribe(pattern) }
+    }
+
+    /**
+     * 지정한 파티션들을 직접 할당합니다.
+     *
+     * @param partitions 직접 할당할 파티션 목록
+     */
+    suspend fun assign(vararg partitions: TopicPartition) {
+        doOnConsumer { it.assign(partitions.asList()) }
+    }
+
+    /**
+     * 현재 구독/할당을 모두 해제합니다.
+     */
+    suspend fun unsubscribe() {
+        doOnConsumer { it.unsubscribe() }
+    }
+
+    /**
+     * 현재 consumer에 할당된 파티션 목록을 반환합니다.
+     */
+    suspend fun assignment(): Set<TopicPartition> = doOnConsumer { it.assignment() }
+
+    /**
+     * 현재 consumer의 구독 topic 목록을 반환합니다.
+     */
+    suspend fun subscription(): Set<String> = doOnConsumer { it.subscription() }
+
+    /**
+     * 지정한 파티션의 offset으로 이동합니다.
+     *
+     * ```kotlin
+     * val partition = TopicPartition("my-topic", 0)
+     * consumer.seek(partition, 100L)
+     * // 이후 poll은 offset 100부터 시작됩니다
+     * ```
+     *
+     * @param partition 이동할 파티션
+     * @param offset 이동할 offset
+     */
+    suspend fun seek(
+        partition: TopicPartition,
+        offset: Long,
+    ) {
+        doOnConsumer { consumer ->
+            consumer.seek(partition, offset)
+        }
+    }
+
+    /**
+     * 지정한 timestamp 시점에 가장 가까운 offset으로 이동합니다.
+     *
+     * @param partition 이동할 대상 파티션
+     * @param timestamp 찾을 timestamp(epoch millis)
+     * @return seek에 사용한 offset. 해당 timestamp가 없으면 `null`
+     */
+    suspend fun seekToTimestamp(
+        partition: TopicPartition,
+        timestamp: Long,
+    ): Long? {
+        val offset = offsetsForTimes(mapOf(partition to timestamp))[partition]?.offset()
+        if (offset != null) {
+            seek(partition, offset)
+        }
+        return offset
+    }
+
+    /**
+     * 지정한 파티션들의 offset을 처음으로 이동합니다.
+     *
+     * ```kotlin
+     * val partition = TopicPartition("my-topic", 0)
+     * consumer.seekToBeginning(partition)
+     * // 이후 poll은 파티션의 처음 offset부터 시작됩니다
+     * ```
+     *
+     * @param partitions 처음으로 이동할 파티션 목록
+     */
+    suspend fun seekToBeginning(vararg partitions: TopicPartition) {
+        doOnConsumer { consumer ->
+            consumer.seekToBeginning(partitions.asList())
+        }
+    }
+
+    /**
+     * 지정한 파티션들의 offset을 끝으로 이동합니다.
+     *
+     * ```kotlin
+     * val partition = TopicPartition("my-topic", 0)
+     * consumer.seekToEnd(partition)
+     * // 이후 poll은 파티션의 끝 offset부터 시작됩니다
+     * ```
+     *
+     * @param partitions 끝으로 이동할 파티션 목록
+     */
+    suspend fun seekToEnd(vararg partitions: TopicPartition) {
+        doOnConsumer { consumer ->
+            consumer.seekToEnd(partitions.asList())
+        }
+    }
+
+    /**
+     * 지정한 파티션의 현재 fetch position을 반환합니다.
+     *
+     * ```kotlin
+     * val partition = TopicPartition("my-topic", 0)
+     * val pos = consumer.partition(partition)
+     * // pos는 다음 fetch 할 offset
+     * ```
+     *
+     * @param partition 조회할 파티션
+     * @return 현재 position (다음 fetch할 offset)
+     */
+    suspend fun partition(partition: TopicPartition): Long = doOnConsumer { it.position(partition) }
+
+    /**
+     * 지정한 파티션의 현재 position을 반환합니다.
+     */
+    suspend fun position(partition: TopicPartition): Long = doOnConsumer { it.position(partition) }
+
+    /**
+     * 지정한 파티션들의 커밋된 offset 정보를 반환합니다.
+     *
+     * Kafka Consumer API에서 committed()는 Map 값이 nullable 입니다.
+     * 아직 한 번도 커밋된 적 없는 파티션은 null을 반환하며,
+     * 이를 non-null 타입으로 선언하면 런타임 NPE가 발생할 수 있습니다.
+     *
+     * ```kotlin
+     * val partition = TopicPartition("my-topic", 0)
+     * val committed = consumer.committed(setOf(partition))
+     * // committed[partition]?.offset() 이 마지막으로 커밋된 offset
+     * // committed[partition] 이 null 이면 해당 파티션은 커밋 이력 없음
+     * ```
+     *
+     * @param partitions 조회할 파티션 집합
+     * @return 파티션별 커밋 정보 맵 (커밋 이력 없는 파티션은 null)
+     */
+    suspend fun committed(partitions: Set<TopicPartition>): Map<TopicPartition, OffsetAndMetadata?> =
+        doOnConsumer {
+            // Kafka Consumer.committed()의 Java 반환 타입은 Map<TopicPartition, OffsetAndMetadata>이지만,
+            // 실제로는 커밋 이력 없는 파티션에 대해 null 값을 포함한다 (플랫폼 타입).
+            // non-null로 선언하면 런타임에 NPE가 발생하므로 nullable로 선언한다.
+            @Suppress("UNCHECKED_CAST")
+            it.committed(partitions) as Map<TopicPartition, OffsetAndMetadata?>
+        }
+
+    /**
+     * 지정한 offset들을 동기 커밋합니다.
+     *
+     * @param offsets 커밋할 topic-partition별 offset metadata
+     */
+    suspend fun commit(offsets: Map<TopicPartition, OffsetAndMetadata>) {
+        doOnConsumer { it.commitSync(offsets) }
+    }
+
+    /**
+     * 지정한 파티션들의 현재 position을 offset으로 계산해 동기 커밋합니다.
+     *
+     * 파티션을 생략하면 현재 assignment 전체를 커밋합니다.
+     *
+     * @param partitions 현재 position을 커밋할 파티션 목록
+     * @return 실제로 커밋한 offset metadata 맵
+     */
+    suspend fun commitCurrentOffsets(vararg partitions: TopicPartition): Map<TopicPartition, OffsetAndMetadata> =
+        doOnConsumer { consumer ->
+            val targets = if (partitions.isNotEmpty()) partitions.toSet() else consumer.assignment()
+            if (targets.isEmpty()) {
+                return@doOnConsumer emptyMap()
+            }
+            val currentAssignment = consumer.assignment()
+            require(targets.all { it in currentAssignment }) {
+                "Cannot commit offsets for unassigned partitions. targets=$targets, assignment=$currentAssignment"
+            }
+            val offsets = targets.associateWith { topicPartition ->
+                OffsetAndMetadata(consumer.position(topicPartition))
+            }
+            consumer.commitSync(offsets)
+            offsets
+        }
+
+    /**
+     * 지정한 토픽의 파티션 정보를 반환합니다.
+     *
+     * ```kotlin
+     * val partitions = consumer.partitionsFromConsumerFor("my-topic")
+     * // partitions.size가 파티션 수
+     * ```
+     *
+     * @param topic 조회할 토픽 이름
+     * @return 파티션 정보 목록
+     */
+    suspend fun partitionsFromConsumerFor(topic: String): List<PartitionInfo> = doOnConsumer { it.partitionsFor(topic) }
+
+    /**
+     * 현재 일시 정지된 파티션 집합을 반환합니다.
+     *
+     * ```kotlin
+     * val paused = consumer.paused()
+     * // paused에 일시 정지된 파티션이 포함됨
+     * ```
+     *
+     * @return 일시 정지된 파티션 집합
+     */
+    suspend fun paused(): Set<TopicPartition> = doOnConsumer { it.paused() }
+
+    /**
+     * 지정한 파티션들을 일시 정지합니다.
+     *
+     * ```kotlin
+     * val partition = TopicPartition("my-topic", 0)
+     * consumer.pause(partition)
+     * // 이후 poll에서 해당 파티션은 레코드를 반환하지 않습니다
+     * ```
+     *
+     * @param partitions 일시 정지할 파티션 목록
+     */
+    suspend fun pause(vararg partitions: TopicPartition) {
+        doOnConsumer { it.pause(partitions.asList()) }
+    }
+
+    /**
+     * 일시 정지된 파티션들을 재개합니다.
+     *
+     * ```kotlin
+     * val partition = TopicPartition("my-topic", 0)
+     * consumer.resume(partition)
+     * // 이후 poll에서 해당 파티션이 다시 레코드를 반환합니다
+     * ```
+     *
+     * @param partitions 재개할 파티션 목록
+     */
+    suspend fun resume(vararg partitions: TopicPartition) {
+        doOnConsumer { it.resume(partitions.asList()) }
+    }
+
+    /**
+     * Consumer 의 메트릭 정보를 반환합니다.
+     *
+     * ```kotlin
+     * val metrics = consumer.metricsFromConsumer()
+     * val fetchRate = metrics.entries.find { it.key.name() == "fetch-rate" }?.value?.metricValue()
+     * ```
+     *
+     * @return 메트릭 이름과 값의 맵
+     */
+    suspend fun metricsFromConsumer(): Map<MetricName, Metric> = doOnConsumer { it.metrics() }
+
+    /**
+     * Consumer가 접근 가능한 모든 토픽 목록을 반환합니다.
+     *
+     * ```kotlin
+     * val topics = consumer.listTopics()
+     * // topics.keys에 토픽 이름 목록이 포함됨
+     * ```
+     *
+     * @return 토픽 이름과 파티션 정보 목록의 맵
+     */
+    suspend fun listTopics(): Map<String, List<PartitionInfo>> = doOnConsumer { it.listTopics() }
+
+    /**
+     * 지정한 timestamp에 해당하는 파티션별 offset 정보를 반환합니다.
+     *
+     * Kafka Consumer.offsetsForTimes()의 반환 타입은 Map 값이 nullable 입니다.
+     * 해당 timestamp 이후의 메시지가 없는 파티션은 null이 반환되며,
+     * non-null 타입으로 선언하면 런타임 NPE 위험이 있습니다.
+     *
+     * ```kotlin
+     * val partition = TopicPartition("my-topic", 0)
+     * val ts = System.currentTimeMillis() - 60_000
+     * val offsets = consumer.offsetsForTimes(mapOf(partition to ts))
+     * // offsets[partition]?.offset() 이 ts 시점의 offset
+     * // offsets[partition] 이 null 이면 해당 timestamp 이후 메시지 없음
+     * ```
+     *
+     * @param timestampsToSearch 파티션별 timestamp 맵
+     * @return 파티션별 offset 정보 맵 (해당 시각 이후 메시지 없으면 null)
+     */
+    suspend fun offsetsForTimes(
+        timestampsToSearch: Map<TopicPartition, Long>,
+    ): Map<TopicPartition, OffsetAndTimestamp?> =
+        doOnConsumer {
+            // Kafka Consumer.offsetsForTimes()의 Java 반환 타입은 Map<TopicPartition, OffsetAndTimestamp>이지만,
+            // 해당 timestamp 이후 메시지가 없는 파티션은 null 값을 반환한다 (플랫폼 타입).
+            // 이를 non-null 타입으로 받으면 런타임에 NPE가 발생하므로 nullable로 선언한다.
+            @Suppress("UNCHECKED_CAST")
+            it.offsetsForTimes(timestampsToSearch) as Map<TopicPartition, OffsetAndTimestamp?>
+        }
+
+    /**
+     * 지정한 파티션들의 처음 offset을 반환합니다.
+     *
+     * ```kotlin
+     * val partition = TopicPartition("my-topic", 0)
+     * val offsets = consumer.beginningOffsets(partition)
+     * // offsets[partition] 이 처음 offset
+     * ```
+     *
+     * @param partitions 조회할 파티션 목록
+     * @return 파티션별 처음 offset 맵
+     */
+    suspend fun beginningOffsets(vararg partitions: TopicPartition): Map<TopicPartition, Long> =
+        doOnConsumer {
+            it.beginningOffsets(partitions.asList())
+        }
+
+    /**
+     * 지정한 파티션들의 끝 offset을 반환합니다.
+     *
+     * ```kotlin
+     * val partition = TopicPartition("my-topic", 0)
+     * val offsets = consumer.endOffsets(partition)
+     * // offsets[partition] 이 끝 offset (다음에 쓸 위치)
+     * ```
+     *
+     * @param partitions 조회할 파티션 목록
+     * @return 파티션별 끝 offset 맵
+     */
+    suspend fun endOffsets(vararg partitions: TopicPartition): Map<TopicPartition, Long> =
+        doOnConsumer {
+            it.endOffsets(partitions.asList())
+        }
+
+    override fun close() {
+        doClose()
+    }
+
+    override fun destroy() {
+        doClose()
+    }
+
+    private fun doClose() {
+        if (closed.compareAndSet(false, true)) {
+            scope.cancel("SuspendKafkaConsumerTemplate closed")
+            (receiver as? AutoCloseable)?.close()
+        }
+    }
+}

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
@@ -1,0 +1,303 @@
+package io.bluetape4k.kafka.spring.core
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.reactive.asFlow
+import kotlinx.coroutines.reactor.asFlux
+import kotlinx.coroutines.reactor.awaitSingle
+import org.apache.kafka.clients.producer.Producer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.Metric
+import org.apache.kafka.common.MetricName
+import org.apache.kafka.common.PartitionInfo
+import org.springframework.beans.factory.DisposableBean
+import org.springframework.kafka.support.KafkaHeaders
+import org.springframework.kafka.support.converter.MessagingMessageConverter
+import org.springframework.kafka.support.converter.RecordMessageConverter
+import org.springframework.messaging.Message
+import reactor.core.publisher.Flux
+import reactor.kafka.sender.KafkaSender
+import reactor.kafka.sender.SenderOptions
+import reactor.kafka.sender.SenderRecord
+import reactor.kafka.sender.SenderResult
+import reactor.kafka.sender.TransactionManager
+import java.io.Closeable
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Coroutine 환경에서 사용하는 Kafka ProducerTemplate 기능을 제공합니다.
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @property sender [KafkaSender] instance.
+ * @property messageConverter [RecordMessageConverter] instance.
+ *
+ * @see [org.springframework.kafka.core.reactive.ReactiveKafkaProducerTemplate]
+ */
+class SuspendKafkaProducerTemplate<K, V> private constructor(
+    private val sender: KafkaSender<K, V>,
+    private val messageConverter: RecordMessageConverter,
+): CoroutineScope, Closeable, DisposableBean {
+
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val closed = AtomicBoolean(false)
+
+    override val coroutineContext = scope.coroutineContext
+
+    companion object: KLoggingChannel() {
+        /**
+         * Create an instance of [SuspendKafkaProducerTemplate] with the provided configuration.
+         *
+         * @param senderOptions [SenderOptions] instance.
+         * @param messageConverter [RecordMessageConverter] instance.
+         * @return [SuspendKafkaProducerTemplate] instance.
+         */
+        @JvmStatic
+        operator fun <K, V> invoke(
+            senderOptions: SenderOptions<K, V>,
+            messageConverter: RecordMessageConverter = MessagingMessageConverter(),
+        ): SuspendKafkaProducerTemplate<K, V> {
+            return SuspendKafkaProducerTemplate(KafkaSender.create(senderOptions), messageConverter)
+        }
+
+        @JvmStatic
+        operator fun <K, V> invoke(
+            sender: KafkaSender<K, V>,
+            messageConverter: RecordMessageConverter = MessagingMessageConverter(),
+        ): SuspendKafkaProducerTemplate<K, V> {
+            return SuspendKafkaProducerTemplate(sender, messageConverter)
+        }
+    }
+
+    /**
+     * 트랜잭션 컨텍스트 안에서 [SenderRecord] Flow를 발송합니다.
+     *
+     * ```kotlin
+     * val records = flowOf(
+     *     SenderRecord.create(ProducerRecord("topic", "key", "value"), Unit)
+     * )
+     * producer.sendTransactionally(records).collect { result ->
+     *     println("Sent: ${result.recordMetadata().offset()}")
+     * }
+     * ```
+     *
+     * @param records 발송할 [SenderRecord] Flow
+     * @return 발송 결과 [SenderResult] Flow
+     */
+    fun <T> sendTransactionally(records: Flow<SenderRecord<K, V, T>>): Flow<SenderResult<T>> {
+        val result = sender.sendTransactionally(Flux.just(records.asFlux()))
+        return result.flatMap { it }.asFlow()
+    }
+
+    /**
+     * 트랜잭션 컨텍스트 안에서 단일 [SenderRecord]를 발송합니다.
+     *
+     * ```kotlin
+     * val record = SenderRecord.create(ProducerRecord("topic", "key", "value"), Unit)
+     * val result = producer.sendTransactionally(record)
+     * // result.recordMetadata().offset() 이 발송된 offset
+     * ```
+     *
+     * @param record 발송할 [SenderRecord]
+     * @return 발송 결과 [SenderResult]
+     */
+    suspend fun <T> sendTransactionally(record: SenderRecord<K, V, T>): SenderResult<T> {
+        return sendTransactionally(flowOf(record)).first()
+    }
+
+    /**
+     * 지정한 토픽에 값을 발송합니다.
+     *
+     * ```kotlin
+     * val result = producer.send("my-topic", "hello")
+     * // result.recordMetadata().topic() == "my-topic"
+     * ```
+     *
+     * @param topic 발송할 토픽
+     * @param value 발송할 값
+     * @return 발송 결과 [SenderResult]
+     */
+    suspend fun send(topic: String, value: V): SenderResult<Unit> {
+        return send(ProducerRecord(topic, value))
+    }
+
+    /**
+     * 지정한 토픽에 키와 값을 발송합니다.
+     *
+     * ```kotlin
+     * val result = producer.send("my-topic", "my-key", "hello")
+     * // result.recordMetadata().topic() == "my-topic"
+     * ```
+     *
+     * @param topic 발송할 토픽
+     * @param key 발송할 키
+     * @param value 발송할 값
+     * @return 발송 결과 [SenderResult]
+     */
+    suspend fun send(topic: String, key: K, value: V): SenderResult<Unit> {
+        return send(ProducerRecord(topic, key, value))
+    }
+
+    /**
+     * 지정한 토픽의 파티션에 키와 값을 발송합니다.
+     *
+     * ```kotlin
+     * val result = producer.send("my-topic", partition = 0, key = "my-key", value = "hello")
+     * // result.recordMetadata().partition() == 0
+     * ```
+     *
+     * @param topic 발송할 토픽
+     * @param partition 발송할 파티션
+     * @param key 발송할 키
+     * @param value 발송할 값
+     * @return 발송 결과 [SenderResult]
+     */
+    suspend fun send(topic: String, partition: Int, key: K, value: V): SenderResult<Unit> {
+        return send(ProducerRecord(topic, partition, key, value))
+    }
+
+    /**
+     * 지정한 토픽으로 메시지를 변환하여 발송합니다.
+     *
+     * ```kotlin
+     * val message = MessageBuilder.withPayload("hello")
+     *     .setHeader(KafkaHeaders.TOPIC, "my-topic")
+     *     .build()
+     * val result = producer.send("my-topic", message)
+     * ```
+     *
+     * @param topic 발송할 토픽
+     * @param message 발송할 Spring [Message]
+     * @return 발송 결과 [SenderResult]
+     */
+    @Suppress("UNCHECKED_CAST")
+    suspend fun send(topic: String, message: Message<*>): SenderResult<Unit> {
+        val typedRecord = messageConverter.fromMessage(message, topic) as ProducerRecord<K, V>
+
+        val correlationId = message.headers[KafkaHeaders.CORRELATION_ID, ByteArray::class.java]
+        if (correlationId != null) {
+            typedRecord.headers().add(KafkaHeaders.CORRELATION_ID, correlationId)
+        }
+        return send(typedRecord)
+    }
+
+    /**
+     * [ProducerRecord]를 발송합니다.
+     *
+     * ```kotlin
+     * val record = ProducerRecord("my-topic", "key", "value")
+     * val result = producer.send(record)
+     * // result.recordMetadata().topic() == "my-topic"
+     * ```
+     *
+     * @param record 발송할 [ProducerRecord]
+     * @return 발송 결과 [SenderResult]
+     */
+    suspend fun send(record: ProducerRecord<K, V>): SenderResult<Unit> {
+        return send(SenderRecord.create(record, Unit))
+    }
+
+    /**
+     * 단일 [SenderRecord]를 발송합니다.
+     *
+     * ```kotlin
+     * val record = SenderRecord.create(ProducerRecord("topic", "key", "value"), Unit)
+     * val result = producer.send(record)
+     * // result.recordMetadata().offset() 이 발송된 offset
+     * ```
+     *
+     * @param record 발송할 [SenderRecord]
+     * @return 발송 결과 [SenderResult]
+     */
+    suspend fun <T> send(record: SenderRecord<K, V, T>): SenderResult<T> {
+        return send(flowOf(record)).first()
+    }
+
+    /**
+     * [SenderRecord] Flow를 발송하고 결과 Flow를 반환합니다.
+     *
+     * ```kotlin
+     * val records = flowOf(
+     *     SenderRecord.create(ProducerRecord("topic", "k1", "v1"), Unit),
+     *     SenderRecord.create(ProducerRecord("topic", "k2", "v2"), Unit),
+     * )
+     * producer.send(records).collect { result ->
+     *     println("offset=${result.recordMetadata().offset()}")
+     * }
+     * ```
+     *
+     * @param records 발송할 [SenderRecord] Flow
+     * @return 발송 결과 [SenderResult] Flow
+     */
+    fun <T> send(records: Flow<SenderRecord<K, V, T>>): Flow<SenderResult<T>> {
+        return sender.send(records.asFlux()).asFlow()
+    }
+
+    /**
+     * 지정한 토픽의 파티션 정보를 반환합니다.
+     *
+     * ```kotlin
+     * val partitions = producer.partitionsFromProducerFor("my-topic")
+     * // partitions.size가 파티션 수
+     * ```
+     *
+     * @param topic 조회할 토픽 이름
+     * @return 파티션 정보 목록
+     */
+    suspend fun partitionsFromProducerFor(topic: String): List<PartitionInfo> {
+        return doOnProducer { it.partitionsFor(topic) }
+    }
+
+    /**
+     * Producer 의 메트릭 정보를 반환합니다.
+     *
+     * ```kotlin
+     * val metrics = producer.metricsFromProducer()
+     * val sendCount = metrics.entries.find { it.key.name() == "record-send-total" }?.value?.metricValue()
+     * ```
+     *
+     * @return 메트릭 이름과 값의 맵
+     */
+    suspend fun metricsFromProducer(): Map<MetricName, Metric> {
+        return doOnProducer { producer -> producer.metrics() }
+    }
+
+    /**
+     * Producer 에 직접 접근하여 [action]을 실행합니다.
+     *
+     * ```kotlin
+     * val partitions = producer.doOnProducer { it.partitionsFor("my-topic") }
+     * // partitions.size가 파티션 수
+     * ```
+     *
+     * @param action Producer 에 적용할 액션
+     * @return 액션 실행 결과
+     */
+    suspend fun <T> doOnProducer(action: (producer: Producer<K, V>) -> T): T {
+        return sender.doOnProducer { action(it) }.awaitSingle()
+    }
+
+    val transactionManager: TransactionManager
+        get() = sender.transactionManager()
+
+    override fun close() {
+        doClose()
+    }
+
+    override fun destroy() {
+        doClose()
+    }
+
+    private fun doClose() {
+        if (closed.compareAndSet(false, true)) {
+            scope.cancel("SuspendKafkaProducerTemplate closed")
+            sender.close()
+        }
+    }
+}

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/listener/ListenerUtils.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/listener/ListenerUtils.kt
@@ -1,0 +1,59 @@
+package io.bluetape4k.kafka.spring.listener
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.springframework.kafka.listener.ListenerType
+import org.springframework.kafka.listener.ListenerUtils
+import org.springframework.kafka.listener.MessageListenerContainer
+
+/**
+ * 리스너 객체로부터 [ListenerType]을 결정합니다.
+ *
+ * 이 함수는 리스너가 Record Listener인지 Batch Listener인지 등을 판별합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val listenerType = listenerTypeOf(myListener)
+ * when (listenerType) {
+ *     ListenerType.RECORD -> println("Record listener")
+ *     ListenerType.BATCH -> println("Batch listener")
+ *     else -> println("Other listener type")
+ * }
+ * ```
+ *
+ * @param listener 리스너 객체
+ * @return [ListenerType] 리스너 유형
+ */
+fun listenerTypeOf(listener: Any): ListenerType = ListenerUtils.determineListenerType(listener)
+
+/**
+ * 중단 가능한 sleep을 수행합니다.
+ *
+ * 컨테이너가 중지되면 sleep이 즉시 종료됩니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * container.stoppableSleep(5000)  // 5초 sleep, 중단 가능
+ * ```
+ *
+ * @param interval sleep 시간 (밀리초)
+ */
+fun MessageListenerContainer.stoppableSleep(interval: Long) {
+    ListenerUtils.stoppableSleep(this, interval)
+}
+
+/**
+ * 주어진 오프셋으로 [OffsetAndMetadata]를 생성합니다.
+ *
+ * 컨테이너의 설정에 따라 적절한 메타데이터를 포함한 OffsetAndMetadata를 생성합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val offsetAndMetadata = container.createOffsetAndMetadata(100L)
+ * consumer.commitSync(mapOf(topicPartition to offsetAndMetadata))
+ * ```
+ *
+ * @param offset 커밋할 오프셋
+ * @return [OffsetAndMetadata] 인스턴스
+ */
+fun MessageListenerContainer.createOffsetAndMetadata(offset: Long): OffsetAndMetadata =
+    ListenerUtils.createOffsetAndMetadata(this, offset)

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/listener/adapter/AdapterUtils.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/listener/adapter/AdapterUtils.kt
@@ -1,0 +1,41 @@
+package io.bluetape4k.kafka.spring.listener.adapter
+
+import org.springframework.kafka.listener.adapter.AdapterUtils
+import org.springframework.kafka.listener.adapter.ConsumerRecordMetadata
+
+/**
+ * 인자 배열로부터 [ConsumerRecordMetadata]를 추출합니다.
+ *
+ * 메시지 리스너 메소드의 인자들에서 ConsumerRecordMetadata를 검색합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * @KafkaListener(topics = ["test-topic"])
+ * fun listen(message: String, @Header(KafkaHeaders.RECEIVED_KEY) key: String) {
+ *     val metadata = consumerRecordMetadataFromArray(message, key)
+ *     // metadata 처리
+ * }
+ * ```
+ *
+ * @param datas 메시지 리스너 인자 배열
+ * @return [ConsumerRecordMetadata] 또는 null
+ */
+fun consumerRecordMetadataFromArray(vararg datas: Any): Any? = AdapterUtils.buildConsumerRecordMetadataFromArray(*datas)
+
+/**
+ * 데이터 객체로부터 [ConsumerRecordMetadata]를 추출합니다.
+ *
+ * 주어진 데이터 객체가 ConsumerRecordMetadata를 포함하고 있으면 반환합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val metadata = consumerRecordMetadataOf(someData)
+ * metadata?.let {
+ *     println("Topic: ${it.topic()}, Partition: ${it.partition()}, Offset: ${it.offset()}")
+ * }
+ * ```
+ *
+ * @param data 데이터 객체
+ * @return [ConsumerRecordMetadata] 또는 null
+ */
+fun consumerRecordMetadataOf(data: Any): ConsumerRecordMetadata? = AdapterUtils.buildConsumerRecordMetadata(data)

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/support/KafkaUtils.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/support/KafkaUtils.kt
@@ -1,0 +1,38 @@
+package io.bluetape4k.kafka.spring.support
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.springframework.kafka.support.KafkaUtils
+
+/**
+ * [ProducerRecord]를 포맷된 문자열로 변환합니다.
+ *
+ * 로깅이나 디버깅 목적으로 ProducerRecord의 내용을 읽기 쉬운 형태로 변환합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val record = ProducerRecord("topic", "key", "value")
+ * println(record.prettyString())
+ * // 출력: ProducerRecord(topic=topic, partition=null, timestamp=null, key=key, value=value, headers=RecordHeaders(headers = [], isReadOnly = false))
+ * ```
+ *
+ * @return 포맷된 문자열 표현
+ */
+fun ProducerRecord<*, *>.prettyString(): String = KafkaUtils.format(this)
+
+/**
+ * [ConsumerRecord]를 포맷된 문자열로 변환합니다.
+ *
+ * 로깅이나 디버깅 목적으로 ConsumerRecord의 내용을 읽기 쉬운 형태로 변환합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * consumer.poll(Duration.ofSeconds(1)).forEach { record ->
+ *     println(record.prettyString())
+ *     // 출력: ConsumerRecord(topic = my-topic, partition = 0, offset = 42, key = my-key, value = my-value)
+ * }
+ * ```
+ *
+ * @return 포맷된 문자열 표현
+ */
+fun ConsumerRecord<*, *>.prettyString(): String = KafkaUtils.format(this)

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/test/utils/KafkaTestUtils.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/test/utils/KafkaTestUtils.kt
@@ -1,0 +1,145 @@
+package io.bluetape4k.kafka.spring.test.utils
+
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.common.TopicPartition
+import org.springframework.kafka.test.EmbeddedKafkaBroker
+import org.springframework.kafka.test.utils.KafkaTestUtils
+import java.time.Duration
+
+/**
+ * EmbeddedKafkaBroker에서 Producer 설정을 생성합니다.
+ *
+ * 테스트용 Kafka Producer를 생성하기 위한 설정 맵을 반환합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * @Autowired
+ * lateinit var embeddedKafka: EmbeddedKafkaBroker
+ *
+ * val producer = KafkaProducer<String, String>(
+ *     embeddedKafka.producerProps(),
+ *     StringSerializer(),
+ *     StringSerializer()
+ * )
+ * ```
+ *
+ * @return Producer 설정 맵
+ */
+fun EmbeddedKafkaBroker.producerProps(): MutableMap<String, Any> = KafkaTestUtils.producerProps(this)
+
+/**
+ * EmbeddedKafkaBroker에서 Consumer 설정을 생성합니다.
+ *
+ * 테스트용 Kafka Consumer를 생성하기 위한 설정 맵을 반환합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * @Autowired
+ * lateinit var embeddedKafka: EmbeddedKafkaBroker
+ *
+ * val consumer = KafkaConsumer<String, String>(
+ *     embeddedKafka.consumerProps("test-group", autoCommit = false),
+ *     StringDeserializer(),
+ *     StringDeserializer()
+ * )
+ * ```
+ *
+ * @param group Consumer 그룹 ID
+ * @param autoCommit 자동 커밋 여부
+ * @return Consumer 설정 맵
+ */
+fun EmbeddedKafkaBroker.consumerProps(
+    group: String,
+    autoCommit: Boolean = false,
+): MutableMap<String, Any> = KafkaTestUtils.consumerProps(this.brokersAsString, group, autoCommit.toString())
+
+/**
+ * 지정된 토픽과 파티션의 마지막 오프셋을 조회합니다.
+ *
+ * 테스트에서 특정 파티션의 끝 오프셋을 확인할 때 유용합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val endOffsets = consumer.getEndOffsets("test-topic", 0, 1, 2)
+ * endOffsets.forEach { (topicPartition, offset) ->
+ *     println("Partition ${topicPartition.partition()}: offset $offset")
+ * }
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param topic 토픽 이름
+ * @param partitions 파티션 번호들
+ * @return 파티션별 마지막 오프셋 맵
+ */
+fun <K: Any, V: Any> Consumer<K, V>.getEndOffsets(
+    topic: String,
+    vararg partitions: Int,
+): Map<TopicPartition, Long> = KafkaTestUtils.getEndOffsets(this, topic, *partitions.toTypedArray())
+
+/**
+ * 지정된 토픽에서 단일 레코드를 가져옵니다.
+ *
+ * 테스트에서 특정 토픽의 메시지를 하나만 수신할 때 사용합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val record = consumer.getSingleRecord("test-topic", Duration.ofSeconds(5))
+ * println("Received: ${record.value()}")
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param topic 토픽 이름
+ * @param timeout 대기 시간
+ * @return 수신된 ConsumerRecord
+ */
+fun <K: Any, V: Any> Consumer<K, V>.getSingleRecord(
+    topic: String,
+    timeout: Duration = Duration.ofSeconds(10),
+): ConsumerRecord<K, V> = KafkaTestUtils.getSingleRecord(this, topic, timeout)
+
+/**
+ * Consumer에서 레코드들을 가져옵니다.
+ *
+ * 테스트에서 여러 메시지를 수신할 때 사용합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val records = consumer.getRecords(Duration.ofSeconds(5), minRecords = 3)
+ * records.forEach { record ->
+ *     println("Received: ${record.value()}")
+ * }
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param timeout 대기 시간
+ * @param minRecords 최소 수신할 레코드 수 (-1이면 시간 만료까지 대기)
+ * @return 수신된 ConsumerRecords
+ */
+fun <K: Any, V: Any> Consumer<K, V>.getRecords(
+    timeout: Duration = Duration.ofSeconds(10),
+    minRecords: Int = -1,
+): ConsumerRecords<K, V> = KafkaTestUtils.getRecords(this, timeout, minRecords)
+
+/**
+ * 객체의 속성 값을 가져옵니다.
+ *
+ * 중첩된 속성에 접근할 때 유용합니다 (예: "innerBean.property").
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val propertyValue: String = someBean.getPropertyValue("config.name")
+ * ```
+ *
+ * @param T 속성 값 타입
+ * @param path 속성 경로 (점 표기법 지원)
+ * @return 속성 값
+ */
+inline fun <reified T: Any> Any.getPropertyValue(path: String): T =
+    requireNotNull(KafkaTestUtils.getPropertyValue(this, path, T::class.java)) {
+        "Property value is null. path=$path, type=${T::class.java.name}"
+    }

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/StreamConfig.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/StreamConfig.kt
@@ -1,0 +1,21 @@
+package io.bluetape4k.kafka.streams
+
+import org.apache.kafka.common.config.ConfigDef
+import org.apache.kafka.streams.StreamsConfig
+
+/**
+ * Kafka Streams 기본 설정 정의([ConfigDef])를 제공합니다.
+ *
+ * ## 동작/계약
+ * - `StreamsConfig.configDef()` 결과를 모듈 전역 상수로 노출합니다.
+ * - 설정 키/문서/타입 메타데이터 조회에 사용할 수 있습니다.
+ * - 실행 시점에 값이 변경되지 않는 불변 참조입니다.
+ *
+ * ```kotlin
+ * val hasAppId = streamsConfigDef.configKeys().containsKey("application.id")
+ * // hasAppId == true
+ * ```
+ *
+ * @see StreamsConfig
+ */
+val streamsConfigDef: ConfigDef = StreamsConfig.configDef()

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/Branched.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/Branched.kt
@@ -1,0 +1,74 @@
+@file:JvmMultifileClass
+@file:JvmName("KStreamKt")
+
+package io.bluetape4k.kafka.streams.kstream
+
+import org.apache.kafka.streams.kstream.Branched
+import org.apache.kafka.streams.kstream.KStream
+
+/**
+ * Kafka Streams에서 브랜치(분기) 작업을 수행할 때 사용할 [Branched] 인스턴스를 생성합니다.
+ *
+ * 브랜치 이름을 지정하여 브랜치 작업을 구성합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val branched = branchedOf<String, String>("valid-branch")
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param name 브랜치 이름
+ * @return [Branched] 인스턴스
+ */
+fun <K, V> branchedOf(name: String): Branched<K, V> = Branched.`as`(name)
+
+/**
+ * Kafka Streams에서 브랜치(분기) 작업을 수행할 때 사용할 [Branched] 인스턴스를 생성합니다.
+ *
+ * 브랜치 처리 함수를 지정하여 브랜치 작업을 구성합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val branched = branchedOf<String, String>(
+ *     chain = { stream -> stream.filter { _, value -> value.startsWith("A") } },
+ *     name = "starts-with-a"
+ * )
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param chain 브랜치 처리 함수
+ * @param name 브랜치 이름 (선택적)
+ * @return [Branched] 인스턴스
+ */
+@JvmName("branchedWithFunction")
+fun <K, V> branchedOf(
+    chain: (KStream<K, V>) -> KStream<K, V>,
+    name: String? = null,
+): Branched<K, V> = Branched.withFunction(chain, name)
+
+/**
+ * Kafka Streams에서 브랜치(분기) 작업을 수행할 때 사용할 [Branched] 인스턴스를 생성합니다.
+ *
+ * 브랜치 소비 함수를 지정하여 브랜치 작업을 구성합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val branched = branchedOf<String, String>(
+ *     chain = { stream -> stream.to("output-topic") },
+ *     name = "output-branch"
+ * )
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param chain 브랜치 소비 함수
+ * @param name 브랜치 이름 (선택적)
+ * @return [Branched] 인스턴스
+ */
+@JvmName("branchedWithConsumer")
+fun <K, V> branchedOf(
+    chain: (KStream<K, V>) -> Unit,
+    name: String? = null,
+): Branched<K, V> = Branched.withConsumer(chain, name)

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/Consumed.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/Consumed.kt
@@ -1,0 +1,39 @@
+@file:JvmMultifileClass
+@file:JvmName("KStreamKt")
+
+package io.bluetape4k.kafka.streams.kstream
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.streams.Topology
+import org.apache.kafka.streams.kstream.Consumed
+import org.apache.kafka.streams.processor.TimestampExtractor
+
+/**
+ * Kafka Streams에서 토픽을 소비할 때 사용할 [Consumed] 인스턴스를 생성합니다.
+ *
+ * [Consumed]는 토픽에서 데이터를 읽어올 때 필요한 Serde와 설정을 정의합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val consumed = consumedOf(
+ *     keySerde = Serdes.String(),
+ *     valueSerde = Serdes.String(),
+ *     resetPolicy = Topology.AutoOffsetReset.EARLIEST
+ * )
+ * val stream = builder.stream("input-topic", consumed)
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param keySerde 키를 직렬화/역직렬화할 Serde
+ * @param valueSerde 값을 직렬화/역직렬화할 Serde
+ * @param timestampExtractor 레코드의 타임스탬프를 추출할 extractor (선택적)
+ * @param resetPolicy 오프셋 리셋 정책 (선택적)
+ * @return [Consumed] 인스턴스
+ */
+fun <K, V> consumedOf(
+    keySerde: Serde<K>,
+    valueSerde: Serde<V>,
+    timestampExtractor: TimestampExtractor? = null,
+    resetPolicy: Topology.AutoOffsetReset? = null,
+): Consumed<K, V> = Consumed.with(keySerde, valueSerde, timestampExtractor, resetPolicy)

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/Grouped.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/Grouped.kt
@@ -1,0 +1,54 @@
+@file:JvmMultifileClass
+@file:JvmName("KStreamKt")
+
+package io.bluetape4k.kafka.streams.kstream
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.streams.kstream.Grouped
+
+/**
+ * Kafka Streams에서 그룹화 작업을 수행할 때 사용할 [Grouped] 인스턴스를 생성합니다.
+ *
+ * 프로세서 이름을 지정하여 Topology에서 식별 가능한 이름을 부여합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val grouped = groupedOf<String, String>("group-by-key")
+ * val groupedStream = stream.groupByKey(grouped)
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param processorName Topology에서 사용할 프로세서 이름
+ * @return [Grouped] 인스턴스
+ */
+fun <K, V> groupedOf(processorName: String): Grouped<K, V> = Grouped.`as`(processorName)
+
+/**
+ * Kafka Streams에서 그룹화 작업을 수행할 때 사용할 [Grouped] 인스턴스를 생성합니다.
+ *
+ * [Grouped]는 KStream을 그룹화하거나 KTable을 그룹화할 때 필요한 Serde와
+ * 작업 이름을 정의합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val grouped = groupedOf(
+ *     keySerde = Serdes.String(),
+ *     valueSerde = Serdes.Long().asSerde(),
+ *     name = "group-by-user"
+ * )
+ * val groupedStream = stream.groupByKey(grouped)
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param keySerde 키를 직렬화/역직렬화할 Serde
+ * @param valueSerde 값을 직렬화/역직렬화할 Serde
+ * @param name 그룹화 작업의 이름 (선택적)
+ * @return [Grouped] 인스턴스
+ */
+fun <K, V> groupedOf(
+    keySerde: Serde<K>,
+    valueSerde: Serde<V>,
+    name: String? = null,
+): Grouped<K, V> = Grouped.with(name, keySerde, valueSerde)

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/Joined.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/Joined.kt
@@ -1,0 +1,59 @@
+@file:JvmMultifileClass
+@file:JvmName("KStreamKt")
+
+package io.bluetape4k.kafka.streams.kstream
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.streams.kstream.Joined
+
+/**
+ * Kafka Streams에서 두 개의 KStream을 조인할 때 사용할 [Joined] 인스턴스를 생성합니다.
+ *
+ * [Joined]는 KStream-KStream 조인 작업에서 양쪽 스트림의 Serde와
+ * 조인 작업의 이름을 정의합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val joined = joinedOf(
+ *     keySerde = Serdes.String(),
+ *     valueSerde = Serdes.String(),
+ *     otherValueSerde = Serdes.Long().asSerde(),
+ *     name = "stream-join"
+ * )
+ * val joinedStream = leftStream.join(rightStream, joiner, joined)
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 왼쪽 스트림의 값 타입
+ * @param V0 오른쪽 스트림의 값 타입
+ * @param keySerde 키를 직렬화/역직렬화할 Serde
+ * @param valueSerde 왼쪽 스트림 값을 직렬화/역직렬화할 Serde
+ * @param otherValueSerde 오른쪽 스트림 값을 직렬화/역직렬화할 Serde
+ * @param name 조인 작업의 이름 (선택적)
+ * @return [Joined] 인스턴스
+ */
+fun <K, V, V0> joinedOf(
+    keySerde: Serde<K>,
+    valueSerde: Serde<V>,
+    otherValueSerde: Serde<V0>,
+    name: String? = null,
+): Joined<K, V, V0> = Joined.with(keySerde, valueSerde, otherValueSerde, name)
+
+/**
+ * Kafka Streams에서 두 개의 KStream을 조인할 때 사용할 [Joined] 인스턴스를 생성합니다.
+ *
+ * 조인 작업의 이름만 지정하여 Topology에서 식별 가능한 이름을 부여합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val joined = joinedOf<String, String, Long>("user-order-join")
+ * val joinedStream = leftStream.join(rightStream, joiner, joined)
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 왼쪽 스트림의 값 타입
+ * @param V0 오른쪽 스트림의 값 타입
+ * @param name Topology에서 사용할 조인 작업의 이름
+ * @return [Joined] 인스턴스
+ */
+fun <K, V, V0> joinedOf(name: String): Joined<K, V, V0> = Joined.`as`(name)

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/Materialized.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/Materialized.kt
@@ -1,0 +1,148 @@
+@file:JvmMultifileClass
+@file:JvmName("KStreamKt")
+
+package io.bluetape4k.kafka.streams.kstream
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.common.utils.Bytes
+import org.apache.kafka.streams.kstream.Materialized
+import org.apache.kafka.streams.kstream.Materialized.StoreType
+import org.apache.kafka.streams.processor.StateStore
+import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier
+import org.apache.kafka.streams.state.KeyValueStore
+import org.apache.kafka.streams.state.SessionBytesStoreSupplier
+import org.apache.kafka.streams.state.SessionStore
+import org.apache.kafka.streams.state.WindowBytesStoreSupplier
+import org.apache.kafka.streams.state.WindowStore
+
+/**
+ * Kafka Streams에서 상태 저장소를 구성할 때 사용할 [Materialized] 인스턴스를 생성합니다.
+ *
+ * 저장소 유형을 지정하여 Materialized 인스턴스를 생성합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val materialized = materializedOf<String, String, KeyValueStore<Bytes, ByteArray>>(
+ *     Materialized.StoreType.IN_MEMORY
+ * )
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param S StateStore 하위 타입
+ * @param storeType 저장소 유형 (IN_MEMORY, ROCKS_DB 등)
+ * @return [Materialized] 인스턴스
+ */
+fun <K, V, S: StateStore> materializedOf(storeType: StoreType): Materialized<K, V, S> = Materialized.`as`(storeType)
+
+/**
+ * Kafka Streams에서 상태 저장소를 구성할 때 사용할 [Materialized] 인스턴스를 생성합니다.
+ *
+ * 저장소 이름을 지정하여 Materialized 인스턴스를 생성합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val materialized = materializedOf<String, String, KeyValueStore<Bytes, ByteArray>>("my-store")
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param S StateStore 하위 타입
+ * @param storeName 저장소 이름
+ * @return [Materialized] 인스턴스
+ */
+fun <K, V, S: StateStore> materializedOf(storeName: String): Materialized<K, V, S> = Materialized.`as`(storeName)
+
+/**
+ * Kafka Streams에서 상태 저장소를 구성할 때 사용할 [Materialized] 인스턴스를 생성합니다.
+ *
+ * 키와 값의 Serde를 지정하여 Materialized 인스턴스를 생성합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val materialized = materializedOf(
+ *     keySerde = Serdes.String(),
+ *     valueSerde = Serdes.Long().asSerde()
+ * )
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param S StateStore 하위 타입
+ * @param keySerde 키를 직렬화/역직렬화할 Serde
+ * @param valueSerde 값을 직렬화/역직렬화할 Serde
+ * @return [Materialized] 인스턴스
+ */
+fun <K, V, S: StateStore> materializedOf(
+    keySerde: Serde<K>,
+    valueSerde: Serde<V>,
+): Materialized<K, V, S> = Materialized.with(keySerde, valueSerde)
+
+/**
+ * Kafka Streams에서 윈도우 상태 저장소를 구성할 때 사용할 [Materialized] 인스턴스를 생성합니다.
+ *
+ * WindowBytesStoreSupplier를 사용하여 윈도우 저장소를 구성합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val windowSupplier = Stores.windowStoreBuilder(
+ *     Stores.persistentWindowStore("window-store", Duration.ofHours(1), Duration.ofMinutes(5), false),
+ *     Serdes.String(),
+ *     Serdes.Long()
+ * ).build()
+ * val materialized = materializedOf<String, Long>(windowSupplier)
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param supplier WindowBytesStoreSupplier 인스턴스
+ * @return [Materialized] 인스턴스
+ */
+fun <K, V> materializedOf(supplier: WindowBytesStoreSupplier): Materialized<K, V, WindowStore<Bytes, ByteArray>> =
+    Materialized.`as`(supplier)
+
+/**
+ * Kafka Streams에서 세션 상태 저장소를 구성할 때 사용할 [Materialized] 인스턴스를 생성합니다.
+ *
+ * SessionBytesStoreSupplier를 사용하여 세션 저장소를 구성합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val sessionSupplier = Stores.sessionStoreBuilder(
+ *     Stores.persistentSessionStore("session-store", Duration.ofMinutes(30)),
+ *     Serdes.String(),
+ *     Serdes.Long()
+ * ).build()
+ * val materialized = materializedOf<String, Long>(sessionSupplier)
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param supplier SessionBytesStoreSupplier 인스턴스
+ * @return [Materialized] 인스턴스
+ */
+fun <K, V> materializedOf(supplier: SessionBytesStoreSupplier): Materialized<K, V, SessionStore<Bytes, ByteArray>> =
+    Materialized.`as`(supplier)
+
+/**
+ * Kafka Streams에서 키-값 상태 저장소를 구성할 때 사용할 [Materialized] 인스턴스를 생성합니다.
+ *
+ * KeyValueBytesStoreSupplier를 사용하여 키-값 저장소를 구성합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val kvSupplier = Stores.keyValueStoreBuilder(
+ *     Stores.persistentKeyValueStore("kv-store"),
+ *     Serdes.String(),
+ *     Serdes.Long()
+ * ).build()
+ * val materialized = materializedOf<String, Long>(kvSupplier)
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param supplier KeyValueBytesStoreSupplier 인스턴스
+ * @return [Materialized] 인스턴스
+ */
+fun <K, V> materializedOf(supplier: KeyValueBytesStoreSupplier): Materialized<K, V, KeyValueStore<Bytes, ByteArray>> =
+    Materialized.`as`(supplier)

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/Produced.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/Produced.kt
@@ -1,0 +1,55 @@
+@file:JvmMultifileClass
+@file:JvmName("KStreamKt")
+
+package io.bluetape4k.kafka.streams.kstream
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.streams.kstream.Produced
+import org.apache.kafka.streams.processor.StreamPartitioner
+
+/**
+ * Kafka Streams에서 토픽으로 데이터를 생산할 때 사용할 [Produced] 인스턴스를 생성합니다.
+ *
+ * [Produced]는 KStream의 데이터를 출력 토픽으로 복사할 때 필요한 Serde와
+ * 파티셔닝 전략을 정의합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val produced = producedOf(
+ *     keySerde = Serdes.String(),
+ *     valueSerde = Serdes.String(),
+ *     partitioner = CustomPartitioner()
+ * )
+ * stream.to("output-topic", produced)
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param keySerde 키를 직렬화할 Serde
+ * @param valueSerde 값을 직렬화할 Serde
+ * @param partitioner 파티션 할당 전략 (선택적)
+ * @return [Produced] 인스턴스
+ */
+fun <K, V> producedOf(
+    keySerde: Serde<K>,
+    valueSerde: Serde<V>,
+    partitioner: StreamPartitioner<K, V>? = null,
+): Produced<K, V> = Produced.with(keySerde, valueSerde, partitioner)
+
+/**
+ * Kafka Streams에서 토픽으로 데이터를 생산할 때 사용할 [Produced] 인스턴스를 생성합니다.
+ *
+ * 프로세서 이름을 지정하여 Topology에서 식별 가능한 이름을 부여합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val produced = producedOf<String, String>("output-processor")
+ * stream.to("output-topic", produced)
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param processorName Topology에서 사용할 프로세서 이름
+ * @return [Produced] 인스턴스
+ */
+fun <K, V> producedOf(processorName: String): Produced<K, V> = Produced.`as`(processorName)

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/Repartitioned.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/Repartitioned.kt
@@ -1,0 +1,92 @@
+@file:JvmMultifileClass
+@file:JvmName("KStreamKt")
+
+package io.bluetape4k.kafka.streams.kstream
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.streams.kstream.Repartitioned
+import org.apache.kafka.streams.processor.StreamPartitioner
+
+/**
+ * Kafka Streams에서 데이터를 리파티셔닝할 때 사용할 [Repartitioned] 인스턴스를 생성합니다.
+ *
+ * 작업 이름을 지정하여 리파티셔닝 작업을 구성합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val repartitioned = repartitionedOf<String, String>("repartition-step")
+ * val repartitionedStream = stream.repartition(repartitioned)
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param name 리파티셔닝 작업의 이름
+ * @return [Repartitioned] 인스턴스
+ */
+fun <K, V> repartitionedOf(name: String): Repartitioned<K, V> = Repartitioned.`as`(name)
+
+/**
+ * Kafka Streams에서 데이터를 리파티셔닝할 때 사용할 [Repartitioned] 인스턴스를 생성합니다.
+ *
+ * 키와 값의 Serde를 지정하여 리파티셔닝 작업을 구성합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val repartitioned = repartitionedOf(
+ *     keySerde = Serdes.String(),
+ *     valueSerde = Serdes.Long().asSerde()
+ * )
+ * val repartitionedStream = stream.repartition(repartitioned)
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param keySerde 키를 직렬화/역직렬화할 Serde
+ * @param valueSerde 값을 직렬화/역직렬화할 Serde
+ * @return [Repartitioned] 인스턴스
+ */
+fun <K, V> repartitionedOf(
+    keySerde: Serde<K>,
+    valueSerde: Serde<V>,
+): Repartitioned<K, V> = Repartitioned.with(keySerde, valueSerde)
+
+/**
+ * Kafka Streams에서 데이터를 리파티셔닝할 때 사용할 [Repartitioned] 인스턴스를 생성합니다.
+ *
+ * 커스텀 파티셔너를 지정하여 리파티셔닝 작업을 구성합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val partitioner = StreamPartitioner<String, String> { topic, key, value, numPartitions ->
+ *     key.hashCode() % numPartitions
+ * }
+ * val repartitioned = repartitionedOf(partitioner)
+ * val repartitionedStream = stream.repartition(repartitioned)
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param partitioner 파티션 할당 전략
+ * @return [Repartitioned] 인스턴스
+ */
+fun <K, V> repartitionedOf(partitioner: StreamPartitioner<K, V>): Repartitioned<K, V> =
+    Repartitioned.streamPartitioner(partitioner)
+
+/**
+ * Kafka Streams에서 데이터를 리파티셔닝할 때 사용할 [Repartitioned] 인스턴스를 생성합니다.
+ *
+ * 파티션 수를 지정하여 리파티셔닝 작업을 구성합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val repartitioned = repartitionedOf<String, String>(6)
+ * val repartitionedStream = stream.repartition(repartitioned)
+ * ```
+ *
+ * @param K 키 타입
+ * @param V 값 타입
+ * @param numberOfPartitions 파티션 수
+ * @return [Repartitioned] 인스턴스
+ */
+fun <K, V> repartitionedOf(numberOfPartitions: Int): Repartitioned<K, V> =
+    Repartitioned.numberOfPartitions(numberOfPartitions)

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/StreamJoined.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/StreamJoined.kt
@@ -1,0 +1,81 @@
+@file:JvmMultifileClass
+@file:JvmName("KStreamKt")
+
+package io.bluetape4k.kafka.streams.kstream
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.streams.kstream.StreamJoined
+import org.apache.kafka.streams.state.WindowBytesStoreSupplier
+
+/**
+ * Kafka Streams에서 스트림-스트림 조인을 수행할 때 사용할 [StreamJoined] 인스턴스를 생성합니다.
+ *
+ * 양쪽 스트림의 윈도우 저장소를 지정하여 스트림 조인을 구성합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val leftStore = Stores.persistentWindowStore("left-store", Duration.ofMinutes(5), Duration.ofMinutes(1), true)
+ * val rightStore = Stores.persistentWindowStore("right-store", Duration.ofMinutes(5), Duration.ofMinutes(1), true)
+ * val streamJoined = streamJoinedOf<String, String, String>(leftStore, rightStore)
+ * val joinedStream = leftStream.join(rightStream, joiner, streamJoined)
+ * ```
+ *
+ * @param K 키 타입
+ * @param V1 왼쪽 스트림의 값 타입
+ * @param V2 오른쪽 스트림의 값 타입
+ * @param storeSupplier 왼쪽 스트림의 윈도우 저장소 공급자
+ * @param otherStoreSupplier 오른쪽 스트림의 윈도우 저장소 공급자
+ * @return [StreamJoined] 인스턴스
+ */
+fun <K, V1, V2> streamJoinedOf(
+    storeSupplier: WindowBytesStoreSupplier,
+    otherStoreSupplier: WindowBytesStoreSupplier,
+): StreamJoined<K, V1, V2> = StreamJoined.with(storeSupplier, otherStoreSupplier)
+
+/**
+ * Kafka Streams에서 스트림-스트림 조인을 수행할 때 사용할 [StreamJoined] 인스턴스를 생성합니다.
+ *
+ * 저장소 이름을 지정하여 스트림 조인을 구성합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val streamJoined = streamJoinedOf<String, String, String>("stream-join-store")
+ * val joinedStream = leftStream.join(rightStream, joiner, streamJoined)
+ * ```
+ *
+ * @param K 키 타입
+ * @param V1 왼쪽 스트림의 값 타입
+ * @param V2 오른쪽 스트림의 값 타입
+ * @param storeName 저장소 이름
+ * @return [StreamJoined] 인스턴스
+ */
+fun <K, V1, V2> streamJoinedOf(storeName: String): StreamJoined<K, V1, V2> = StreamJoined.`as`(storeName)
+
+/**
+ * Kafka Streams에서 스트림-스트림 조인을 수행할 때 사용할 [StreamJoined] 인스턴스를 생성합니다.
+ *
+ * 키와 양쪽 스트림의 값에 대한 Serde를 지정하여 스트림 조인을 구성합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val streamJoined = streamJoinedOf(
+ *     keySerde = Serdes.String(),
+ *     valueSerde = Serdes.String(),
+ *     otherValueSerde = Serdes.Long().asSerde()
+ * )
+ * val joinedStream = leftStream.join(rightStream, joiner, streamJoined)
+ * ```
+ *
+ * @param K 키 타입
+ * @param V1 왼쪽 스트림의 값 타입
+ * @param V2 오른쪽 스트림의 값 타입
+ * @param keySerde 키를 직렬화/역직렬화할 Serde
+ * @param valueSerde 왼쪽 스트림 값을 직렬화/역직렬화할 Serde
+ * @param otherValueSerde 오른쪽 스트림 값을 직렬화/역직렬화할 Serde
+ * @return [StreamJoined] 인스턴스
+ */
+fun <K, V1, V2> streamJoinedOf(
+    keySerde: Serde<K>,
+    valueSerde: Serde<V1>,
+    otherValueSerde: Serde<V2>,
+): StreamJoined<K, V1, V2> = StreamJoined.with(keySerde, valueSerde, otherValueSerde)

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/TableJoined.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/TableJoined.kt
@@ -1,0 +1,53 @@
+@file:JvmMultifileClass
+@file:JvmName("KStreamKt")
+
+package io.bluetape4k.kafka.streams.kstream
+
+import org.apache.kafka.streams.kstream.TableJoined
+import org.apache.kafka.streams.processor.StreamPartitioner
+
+/**
+ * Kafka Streams에서 KTable-KTable 조인을 수행할 때 사용할 [TableJoined] 인스턴스를 생성합니다.
+ *
+ * 양쪽 테이블의 파티셔너를 지정하여 테이블 조인을 구성합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val leftPartitioner = StreamPartitioner<String, Void> { topic, key, value, numPartitions ->
+ *     key.hashCode() % numPartitions
+ * }
+ * val rightPartitioner = StreamPartitioner<Int, Void> { topic, key, value, numPartitions ->
+ *     key % numPartitions
+ * }
+ * val tableJoined = tableJoinedOf(leftPartitioner, rightPartitioner)
+ * val joinedTable = leftTable.join(rightTable, joiner, tableJoined)
+ * ```
+ *
+ * @param K 왼쪽 테이블의 키 타입
+ * @param K0 오른쪽 테이블의 키 타입
+ * @param partitioner 왼쪽 테이블의 파티셔너
+ * @param otherPartitioner 오른쪽 테이블의 파티셔너
+ * @return [TableJoined] 인스턴스
+ */
+fun <K, K0> tableJoinedOf(
+    partitioner: StreamPartitioner<K, Void>,
+    otherPartitioner: StreamPartitioner<K0, Void>,
+): TableJoined<K, K0> = TableJoined.with(partitioner, otherPartitioner)
+
+/**
+ * Kafka Streams에서 KTable-KTable 조인을 수행할 때 사용할 [TableJoined] 인스턴스를 생성합니다.
+ *
+ * 작업 이름을 지정하여 테이블 조인을 구성합니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val tableJoined = tableJoinedOf<String, Int>("table-join")
+ * val joinedTable = leftTable.join(rightTable, joiner, tableJoined)
+ * ```
+ *
+ * @param K 왼쪽 테이블의 키 타입
+ * @param K0 오른쪽 테이블의 키 타입
+ * @param name 테이블 조인 작업의 이름
+ * @return [TableJoined] 인스턴스
+ */
+fun <K, K0> tableJoinedOf(name: String): TableJoined<K, K0> = TableJoined.`as`(name)

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/Windowed.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/Windowed.kt
@@ -1,0 +1,29 @@
+@file:JvmMultifileClass
+@file:JvmName("KStreamKt")
+
+package io.bluetape4k.kafka.streams.kstream
+
+import org.apache.kafka.streams.kstream.Window
+import org.apache.kafka.streams.kstream.Windowed
+
+/**
+ * Kafka Streams에서 윈도우된 키를 생성합니다.
+ *
+ * [Windowed]는 시간 윈도우와 관련된 키를 표현하며,
+ * 윈도우 집계 작업에서 사용됩니다.
+ *
+ * 사용 예시:
+ * ```kotlin
+ * val timeWindow = TimeWindow.of(Duration.ofMinutes(0), Duration.ofMinutes(5))
+ * val windowedKey = windowedOf("user-123", timeWindow)
+ * ```
+ *
+ * @param K 키 타입
+ * @param key 원본 키 값
+ * @param window 시간 윈도우
+ * @return [Windowed] 인스턴스
+ */
+fun <K> windowedOf(
+    key: K,
+    window: Window,
+): Windowed<K> = Windowed(key, window)

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/AbstractKafkaTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/AbstractKafkaTest.kt
@@ -1,0 +1,23 @@
+package io.bluetape4k.kafka
+
+import io.bluetape4k.LibraryName
+import io.bluetape4k.junit5.faker.Fakers
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.testcontainers.mq.KafkaServer
+
+abstract class AbstractKafkaTest {
+
+    companion object: KLoggingChannel() {
+        const val TEST_TOPIC_NAME = "$LibraryName.kafka.test-topic.1"
+        const val REPEAT_SIZE = 3
+
+        @JvmStatic
+        protected val kafka: KafkaServer by lazy { KafkaServer.Launcher.kafka }
+
+        @JvmStatic
+        protected val faker = Fakers.faker
+
+        @JvmStatic
+        protected fun randomString(): String = Fakers.randomString(1024, 4096)
+    }
+}

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/ConsumerSupportTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/ConsumerSupportTest.kt
@@ -1,0 +1,152 @@
+package io.bluetape4k.kafka
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.testcontainers.mq.KafkaServer
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeEmpty
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+/**
+ * [ConsumerSupport] 및 Consumer 관련 유틸리티 함수에 대한 테스트 클래스입니다.
+ */
+class ConsumerSupportTest: AbstractKafkaTest() {
+    companion object: KLoggingChannel()
+
+    private lateinit var producer: org.apache.kafka.clients.producer.Producer<String, String>
+    private lateinit var consumer: org.apache.kafka.clients.consumer.Consumer<String, String>
+    private val testGroupId = "$TEST_TOPIC_NAME-consumer-group"
+
+    @BeforeEach
+    fun setup() {
+        producer = KafkaServer.Launcher.createStringProducer()
+        consumer =
+            consumerOf<String, String>(
+                mapOf(
+                    "bootstrap.servers" to KafkaServer.Launcher.kafka.bootstrapServers,
+                    "group.id" to testGroupId,
+                    "key.deserializer" to org.apache.kafka.common.serialization.StringDeserializer::class.java,
+                    "value.deserializer" to org.apache.kafka.common.serialization.StringDeserializer::class.java,
+                    "auto.offset.reset" to "earliest",
+                ),
+            )
+        consumer.subscribe(listOf(TEST_TOPIC_NAME))
+    }
+
+    @AfterEach
+    fun tearDown() {
+        consumer.close()
+        producer.close()
+    }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `consumerOf로 Consumer 생성`() {
+        val customConsumer =
+            consumerOf<String, String>(
+                mapOf(
+                    "bootstrap.servers" to KafkaServer.Launcher.kafka.bootstrapServers,
+                    "group.id" to "$testGroupId-custom",
+                    "key.deserializer" to org.apache.kafka.common.serialization.StringDeserializer::class.java,
+                    "value.deserializer" to org.apache.kafka.common.serialization.StringDeserializer::class.java,
+                    "auto.offset.reset" to "earliest",
+                ),
+            )
+
+        customConsumer.shouldNotBeNull()
+        customConsumer.close()
+    }
+
+    @Test
+    fun `Consumer는 토픽에서 메시지를 수신`() {
+        // 메시지 전송
+        val key = "test-key"
+        val value = "test-value-${System.currentTimeMillis()}"
+        val record = ProducerRecord(TEST_TOPIC_NAME, key, value)
+        producer.send(record).get()
+        producer.flush()
+
+        // 메시지 수신
+        var receivedRecord: ConsumerRecord<String, String>? = null
+        val timeout = System.currentTimeMillis() + 10000
+
+        while (System.currentTimeMillis() < timeout && receivedRecord == null) {
+            val records = consumer.poll(Duration.ofMillis(100))
+            for (r in records) {
+                if (r.value() == value) {
+                    receivedRecord = r
+                    break
+                }
+            }
+        }
+
+        receivedRecord.shouldNotBeNull()
+        receivedRecord.key() shouldBeEqualTo key
+        receivedRecord.value() shouldBeEqualTo value
+        receivedRecord.topic() shouldBeEqualTo TEST_TOPIC_NAME
+    }
+
+    @Test
+    fun `Consumer 구독 목록 확인`() {
+        val subscription = consumer.subscription()
+        subscription.shouldNotBeEmpty()
+        subscription shouldBeEqualTo setOf(TEST_TOPIC_NAME)
+    }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `여러 메시지 수신`() {
+        val messageCount = 5
+        val sentMessages = mutableListOf<String>()
+
+        // 메시지 전송
+        repeat(messageCount) { i ->
+            val value = "message-$i-${System.currentTimeMillis()}"
+            sentMessages.add(value)
+            val record = ProducerRecord(TEST_TOPIC_NAME, "key-$i", value)
+            producer.send(record).get()
+        }
+        producer.flush()
+
+        // 메시지 수신
+        val receivedMessages = mutableListOf<String>()
+        val timeout = System.currentTimeMillis() + 15000
+
+        while (System.currentTimeMillis() < timeout && receivedMessages.size < messageCount) {
+            val records = consumer.poll(Duration.ofMillis(100))
+            for (r in records) {
+                if (sentMessages.contains(r.value())) {
+                    receivedMessages.add(r.value())
+                }
+            }
+        }
+
+        receivedMessages.size shouldBeEqualTo messageCount
+    }
+
+    @Test
+    fun `Consumer 메트릭 조회`() {
+        val metrics = consumer.metrics()
+        metrics.shouldNotBeNull()
+    }
+
+    @Test
+    fun `Consumer는 정상적으로 종료`() {
+        val testConsumer =
+            consumerOf<String, String>(
+                mapOf(
+                    "bootstrap.servers" to KafkaServer.Launcher.kafka.bootstrapServers,
+                    "group.id" to "$testGroupId-close-test",
+                    "key.deserializer" to org.apache.kafka.common.serialization.StringDeserializer::class.java,
+                    "value.deserializer" to org.apache.kafka.common.serialization.StringDeserializer::class.java,
+                    "auto.offset.reset" to "earliest",
+                ),
+            )
+        testConsumer.shouldNotBeNull()
+        testConsumer.close()
+    }
+}

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/ProducerSupportTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/ProducerSupportTest.kt
@@ -1,0 +1,102 @@
+package io.bluetape4k.kafka
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.testcontainers.mq.KafkaServer
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
+
+/**
+ * [ProducerSupport] 및 Producer 관련 유틸리티 함수에 대한 테스트 클래스입니다.
+ */
+class ProducerSupportTest: AbstractKafkaTest() {
+    companion object: KLoggingChannel()
+
+    private lateinit var producer: org.apache.kafka.clients.producer.Producer<String, String>
+
+    @BeforeEach
+    fun setup() {
+        producer = KafkaServer.Launcher.createStringProducer()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        producer.close()
+    }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `producerOf로 Producer 생성`() {
+        val customProducer =
+            producerOf<String, String>(
+                mapOf(
+                    "bootstrap.servers" to KafkaServer.Launcher.kafka.bootstrapServers,
+                    "key.serializer" to org.apache.kafka.common.serialization.StringSerializer::class.java,
+                    "value.serializer" to org.apache.kafka.common.serialization.StringSerializer::class.java,
+                    "acks" to "all",
+                    "retries" to 3,
+                ),
+            )
+
+        customProducer.shouldNotBeNull()
+        customProducer.close()
+    }
+
+    @Test
+    fun `Producer 메트릭 값 조회`() {
+        // 메시지 전송
+        val record = ProducerRecord(TEST_TOPIC_NAME, "test-key", "test-value")
+        producer.send(record).get()
+
+        // 메트릭 조회
+        val sendTotal = producer.getMetricValue("record-send-total")
+        sendTotal shouldBeGreaterOrEqualTo 0.0
+
+        val retryTotal = producer.getMetricValue("record-retry-total")
+        retryTotal shouldBeGreaterOrEqualTo 0.0
+    }
+
+    @Test
+    fun `존재하지 않는 메트릭은 0을 반환`() {
+        val value = producer.getMetricValue("non-existent-metric")
+        value shouldBeEqualTo 0.0
+    }
+
+    @Test
+    fun `getMetricValueOrNull로 메트릭 조회`() {
+        val sendTotal = producer.getMetricValueOrNull("record-send-total")
+        sendTotal.shouldNotBeNull()
+    }
+
+    @Test
+    fun `존재하지 않는 메트릭은 null 반환`() {
+        val value = producer.getMetricValueOrNull("non-existent-metric")
+        value.shouldBeNull()
+    }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `메시지 전송 후 메트릭 증가 확인`() {
+        val initialSendTotal = producer.getMetricValue("record-send-total")
+
+        // 여러 메시지 전송
+        repeat(5) { i ->
+            val record = ProducerRecord(TEST_TOPIC_NAME, "key-$i", "value-$i")
+            producer.send(record).get()
+        }
+
+        val finalSendTotal = producer.getMetricValue("record-send-total")
+        finalSendTotal shouldBeGreaterOrEqualTo initialSendTotal + 5
+    }
+
+    @Test
+    fun `Producer는 정상적으로 종료`() {
+        val testProducer = KafkaServer.Launcher.createStringProducer()
+        testProducer.shouldNotBeNull()
+        testProducer.close()
+    }
+}

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/TopicPartitionSupportTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/TopicPartitionSupportTest.kt
@@ -1,0 +1,118 @@
+package io.bluetape4k.kafka
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import org.amshove.kluent.internal.assertFailsWith
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldThrow
+import org.amshove.kluent.withMessage
+import org.apache.kafka.common.TopicPartition
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.ValueSource
+
+/**
+ * [TopicPartition] 관련 유틸리티 함수에 대한 테스트 클래스입니다.
+ */
+class TopicPartitionSupportTest: AbstractKafkaTest() {
+    companion object: KLoggingChannel()
+
+    @ParameterizedTest
+    @CsvSource(
+        "test-topic-0, test-topic, 0",
+        "my.topic.name-5, my.topic.name, 5",
+        "a-1, a, 1",
+        "topic-with-many-dashes-123, topic-with-many-dashes, 123",
+        "user.events-42, user.events, 42",
+    )
+    fun `유효한 topic-partition 문자열 파싱`(
+        input: String,
+        expectedTopic: String,
+        expectedPartition: Int,
+    ) {
+        val tp = input.toTopicPartition()
+
+        tp.topic() shouldBeEqualTo expectedTopic
+        tp.partition() shouldBeEqualTo expectedPartition
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "test-topic-0, test-topic, 0",
+        "my.topic.name-5, my.topic.name, 5",
+        "a-1, a, 1",
+        "topic-with-many-dashes-123, topic-with-many-dashes, 123",
+    )
+    fun `topicPartitionOf 함수로 파싱`(
+        input: String,
+        expectedTopic: String,
+        expectedPartition: Int,
+    ) {
+        val tp = topicPartitionOf(input)
+
+        tp.topic() shouldBeEqualTo expectedTopic
+        tp.partition() shouldBeEqualTo expectedPartition
+    }
+
+    @Test
+    fun `TopicPartition 객체 생성 검증`() {
+        val tp = TopicPartition("test-topic", 0)
+        tp.topic() shouldBeEqualTo "test-topic"
+        tp.partition() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `여러 파티션 번호 파싱`() {
+        val partitions = listOf(0, 1, 2, 10, 100, 999)
+        val topic = "multi-partition-topic"
+
+        partitions.forEach { partition ->
+            val tp = "$topic-$partition".toTopicPartition()
+            tp.topic() shouldBeEqualTo topic
+            tp.partition() shouldBeEqualTo partition
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["", "   "])
+    fun `빈 문자열은 예외 발생`(input: String) {
+
+        assertFailsWith<IllegalArgumentException> {
+            input.toTopicPartition()
+        }
+    }
+
+    @Test
+    fun `구분자가 없는 문자열은 예외 발생`() {
+        val exception = { "invalidtopicname".toTopicPartition() }
+        exception shouldThrow IllegalArgumentException::class withMessage "Not found kafka topic-position delimiter (-)"
+    }
+
+    @Test
+    fun `숫자가 아닌 파티션 번호는 예외 발생`() {
+        val exception = { "topic-abc".toTopicPartition() }
+        exception shouldThrow NumberFormatException::class
+    }
+
+    @Test
+    fun `음수 파티션 번호 파싱`() {
+        // "test-topic--1"에서 마지막 -를 기준으로 split하면 ["test-topic-", "1"]
+        val tp = "test-topic--1".toTopicPartition()
+        tp.topic() shouldBeEqualTo "test-topic-"
+        tp.partition() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `마지막 대시를 기준으로 파싱`() {
+        val tp = "topic-with-dashes-123".toTopicPartition()
+        tp.topic() shouldBeEqualTo "topic-with-dashes"
+        tp.partition() shouldBeEqualTo 123
+    }
+
+    @Test
+    fun `복합 토픽 이름 파싱`() {
+        val tp = "com.company.service.events-7".toTopicPartition()
+        tp.topic() shouldBeEqualTo "com.company.service.events"
+        tp.partition() shouldBeEqualTo 7
+    }
+}

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/AbstractKafkaCodecTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/AbstractKafkaCodecTest.kt
@@ -1,0 +1,78 @@
+package io.bluetape4k.kafka.codec
+
+import io.bluetape4k.junit5.random.RandomValue
+import io.bluetape4k.junit5.random.RandomizedTest
+import io.bluetape4k.kafka.AbstractKafkaTest
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.trace
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldNotBeEmpty
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.kafka.common.header.internals.RecordHeaders
+import org.junit.jupiter.api.RepeatedTest
+import java.io.Serializable
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+
+@RandomizedTest
+abstract class AbstractKafkaCodecTest: AbstractKafkaTest() {
+
+    companion object: KLoggingChannel()
+
+    abstract val codec: KafkaCodec<Any?>
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `codec simple object`(@RandomValue data: MessageData) {
+        val headers = RecordHeaders()
+        val bytes = codec.serialize(TEST_TOPIC_NAME, headers, data)
+        bytes.shouldNotBeEmpty()
+
+        val actual = codec.deserialize(TEST_TOPIC_NAME, headers, bytes) as MessageData
+
+        log.trace { "actual=$actual" }
+
+        actual.shouldNotBeNull()
+        actual shouldBeInstanceOf MessageData::class
+        actual shouldBeEqualTo data
+    }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `codec object graph`(@RandomValue master: MasterData) {
+        master.details.shouldNotBeEmpty()
+
+        val headers = RecordHeaders()
+        val bytes = codec.serialize(TEST_TOPIC_NAME, headers, master)
+        bytes.shouldNotBeEmpty()
+
+        val actual = codec.deserialize(TEST_TOPIC_NAME, headers, bytes) as MasterData
+
+        log.trace { "actual=$actual" }
+
+        actual.shouldNotBeNull()
+        actual.name shouldBeEqualTo master.name
+        actual.createdAt shouldBeEqualTo master.createdAt
+        actual.amount shouldBeEqualTo master.amount
+    }
+
+    data class MessageData(
+        val name: String,
+        val description: String?,
+        val createdAt: LocalDateTime? = LocalDateTime.now(),
+        val amount: BigDecimal? = null,
+    ): Serializable
+
+    data class MasterData(
+        val name: String,
+        val createdAt: Instant? = Instant.now(),
+        val amount: BigDecimal? = null,
+        val details: List<DetailData> = listOf(),
+    ): Serializable
+
+    data class DetailData(
+        val name: String,
+        val createdAt: OffsetDateTime? = OffsetDateTime.now(),
+    ): Serializable
+}

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/ByteArrayKafkaCodecTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/ByteArrayKafkaCodecTest.kt
@@ -1,0 +1,104 @@
+package io.bluetape4k.kafka.codec
+
+import io.bluetape4k.kafka.AbstractKafkaTest
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import java.util.*
+
+/**
+ * [ByteArrayKafkaCodec]에 대한 테스트 클래스입니다.
+ */
+class ByteArrayKafkaCodecTest: AbstractKafkaTest() {
+    companion object: KLoggingChannel()
+
+    private val codec = ByteArrayKafkaCodec()
+
+    @Test
+    fun `바이트 배열 직렬화는 동일한 배열을 반환`() {
+        val original = "Hello, Kafka!".toByteArray()
+        val bytes = codec.serialize(TEST_TOPIC_NAME, original)
+
+        bytes.shouldNotBeNull()
+        bytes shouldBeEqualTo original
+    }
+
+    @Test
+    fun `바이트 배열 역직렬화는 동일한 배열을 반환`() {
+        val original = "Test data".toByteArray()
+        val deserialized = codec.deserialize(TEST_TOPIC_NAME, original)
+
+        deserialized.shouldNotBeNull()
+        deserialized shouldBeEqualTo original
+    }
+
+    @Test
+    fun `빈 바이트 배열 직렬화`() {
+        val emptyArray = ByteArray(0)
+        val bytes = codec.serialize(TEST_TOPIC_NAME, emptyArray)
+
+        bytes.shouldNotBeNull()
+        bytes shouldBeEqualTo emptyArray
+    }
+
+    @Test
+    fun `빈 바이트 배열 역직렬화`() {
+        val emptyArray = ByteArray(0)
+        val deserialized = codec.deserialize(TEST_TOPIC_NAME, emptyArray)
+
+        deserialized.shouldNotBeNull()
+        deserialized shouldBeEqualTo emptyArray
+    }
+
+    @Test
+    fun `큰 바이트 배열 직렬화`() {
+        val largeArray = randomString().toByteArray()
+        val bytes = codec.serialize(TEST_TOPIC_NAME, largeArray)
+
+        bytes.shouldNotBeNull()
+        bytes shouldBeEqualTo largeArray
+    }
+
+    @Test
+    fun `null 값 직렬화는 null을 반환`() {
+        val bytes = codec.serialize(TEST_TOPIC_NAME, null, null as ByteArray?)
+        bytes.shouldBeNull()
+    }
+
+    @Test
+    fun `이진 데이터 직렬화 및 역직렬화`() {
+        val binaryData = ByteArray(256) { it.toByte() }
+        val bytes = codec.serialize(TEST_TOPIC_NAME, binaryData)
+        val deserialized = codec.deserialize(TEST_TOPIC_NAME, bytes)
+
+        deserialized.shouldNotBeNull()
+        deserialized shouldBeEqualTo binaryData
+    }
+
+    @Test
+    fun `랜덤 바이트 데이터 직렬화`() {
+        val random = Random()
+        val randomData = ByteArray(1024)
+        random.nextBytes(randomData)
+
+        val bytes = codec.serialize(TEST_TOPIC_NAME, randomData)
+        val deserialized = codec.deserialize(TEST_TOPIC_NAME, bytes)
+
+        deserialized.shouldNotBeNull()
+        deserialized shouldBeEqualTo randomData
+    }
+
+    @Test
+    fun `직렬화 후 역직렬화는 원본 데이터를 보존`() {
+        val originalText = "Binary data: \u0000\u0001\u0002\u0003\u00FF"
+        val original = originalText.toByteArray(Charsets.ISO_8859_1)
+
+        val serialized = codec.serialize(TEST_TOPIC_NAME, original)
+        val deserialized = codec.deserialize(TEST_TOPIC_NAME, serialized)
+
+        deserialized.shouldNotBeNull()
+        deserialized shouldBeEqualTo original
+    }
+}

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/KafkaCodecTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/KafkaCodecTest.kt
@@ -1,0 +1,71 @@
+package io.bluetape4k.kafka.codec
+
+import org.junit.jupiter.api.Nested
+
+class KafkaCodecTest {
+
+    @Nested
+    inner class JacksonCodecTest: AbstractKafkaCodecTest() {
+        override val codec: KafkaCodec<Any?> = KafkaCodecs.Jackson
+    }
+
+    @Nested
+    inner class JdkKafkaCodecTest: AbstractKafkaCodecTest() {
+        override val codec: KafkaCodec<Any?> = KafkaCodecs.Jdk
+    }
+
+    @Nested
+    inner class KryoKafkaCodecTest: AbstractKafkaCodecTest() {
+        override val codec: KafkaCodec<Any?> = KafkaCodecs.Kryo
+    }
+
+    @Nested
+    inner class ForyKafkaCodecTest: AbstractKafkaCodecTest() {
+        override val codec: KafkaCodec<Any?> = KafkaCodecs.Fory
+    }
+
+    @Nested
+    inner class Lz4JdkKafkaCodecTest: AbstractKafkaCodecTest() {
+        override val codec: KafkaCodec<Any?> = KafkaCodecs.LZ4Jdk
+    }
+
+    @Nested
+    inner class Lz4KryoKafkaCodecTest: AbstractKafkaCodecTest() {
+        override val codec: KafkaCodec<Any?> = KafkaCodecs.Lz4Kryo
+    }
+
+    @Nested
+    inner class Lz4ForyKafkaCodecTest: AbstractKafkaCodecTest() {
+        override val codec: KafkaCodec<Any?> = KafkaCodecs.Lz4Fory
+    }
+
+    @Nested
+    inner class SnappyJdkKafkaCodecTest: AbstractKafkaCodecTest() {
+        override val codec: KafkaCodec<Any?> = KafkaCodecs.SnappyJdk
+    }
+
+    @Nested
+    inner class SnappyKryoKafkaCodecTest: AbstractKafkaCodecTest() {
+        override val codec: KafkaCodec<Any?> = KafkaCodecs.SnappyKryo
+    }
+
+    @Nested
+    inner class SnappyForyKafkaCodecTest: AbstractKafkaCodecTest() {
+        override val codec: KafkaCodec<Any?> = KafkaCodecs.SnappyFory
+    }
+
+    @Nested
+    inner class ZstdJdkKafkaCodecTest: AbstractKafkaCodecTest() {
+        override val codec: KafkaCodec<Any?> = KafkaCodecs.ZstdJdk
+    }
+
+    @Nested
+    inner class ZstdKryoKafkaCodecTest: AbstractKafkaCodecTest() {
+        override val codec: KafkaCodec<Any?> = KafkaCodecs.ZstdKryo
+    }
+
+    @Nested
+    inner class ZstdForyKafkaCodecTest: AbstractKafkaCodecTest() {
+        override val codec: KafkaCodec<Any?> = KafkaCodecs.ZstdFory
+    }
+}

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/StringKafkaCodecTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/StringKafkaCodecTest.kt
@@ -1,0 +1,170 @@
+package io.bluetape4k.kafka.codec
+
+import io.bluetape4k.kafka.AbstractKafkaTest
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+/**
+ * [StringKafkaCodec]에 대한 테스트 클래스입니다.
+ */
+class StringKafkaCodecTest: AbstractKafkaTest() {
+    companion object: KLoggingChannel()
+
+    private val codec = StringKafkaCodec()
+
+    @Test
+    fun `기본 문자열 직렬화 및 역직렬화`() {
+        val original = "Hello, Kafka!"
+        val bytes = codec.serialize(TEST_TOPIC_NAME, original)
+        val deserialized = codec.deserialize(TEST_TOPIC_NAME, bytes)
+
+        deserialized shouldBeEqualTo original
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["a", "Hello World", "한글 테스트", "日本語テスト", "🚀🎉💻"])
+    fun `다양한 문자열 직렬화 및 역직렬화`(input: String) {
+        val bytes = codec.serialize(TEST_TOPIC_NAME, input)
+        val deserialized = codec.deserialize(TEST_TOPIC_NAME, bytes)
+
+        deserialized shouldBeEqualTo input
+    }
+
+    @Test
+    fun `빈 문자열 직렬화 및 역직렬화는 null 반환`() {
+        val input = ""
+        val bytes = codec.serialize(TEST_TOPIC_NAME, input)
+        val deserialized = codec.deserialize(TEST_TOPIC_NAME, bytes)
+
+        // 빈 문자열은 역직렬화 시 null로 반환됨 (StringKafkaCodec의 동작)
+        deserialized.shouldBeNull()
+    }
+
+    @Test
+    fun `null 값 직렬화는 null을 반환`() {
+        val bytes = codec.serialize(TEST_TOPIC_NAME, null, null as String?)
+        bytes.shouldBeNull()
+    }
+
+    @Test
+    fun `빈 바이트 배열 역직렬화는 null을 반환`() {
+        val result = codec.deserialize(TEST_TOPIC_NAME, ByteArray(0))
+        result.shouldBeNull()
+    }
+
+    @Test
+    fun `긴 문자열 직렬화 및 역직렬화`() {
+        val longString = randomString()
+        val bytes = codec.serialize(TEST_TOPIC_NAME, longString)
+        val deserialized = codec.deserialize(TEST_TOPIC_NAME, bytes)
+
+        deserialized shouldBeEqualTo longString
+    }
+
+    @Test
+    fun `멀티라인 문자열 직렬화 및 역직렬화`() {
+        val multilineString =
+            """
+            첫 번째 줄
+            두 번째 줄
+            세 번째 줄
+
+            공백 줄 포함
+            """.trimIndent()
+
+        val bytes = codec.serialize(TEST_TOPIC_NAME, multilineString)
+        val deserialized = codec.deserialize(TEST_TOPIC_NAME, bytes)
+
+        deserialized shouldBeEqualTo multilineString
+    }
+
+    @Test
+    fun `특수 문자가 포함된 문자열 직렬화`() {
+        val specialString = "Special chars: \t\n\r!@#$%^&*()_+-=[]{}|;':\",./<>?"
+        val bytes = codec.serialize(TEST_TOPIC_NAME, specialString)
+        val deserialized = codec.deserialize(TEST_TOPIC_NAME, bytes)
+
+        deserialized shouldBeEqualTo specialString
+    }
+
+    @Test
+    fun `UTF-8 인코딩으로 다국어 문자열 처리`() {
+        val utf8String = "English: Hello, 한국어: 안녕하세요, 日本語: こんにちは, 中文: 你好, العربية: مرحبا"
+        val bytes = codec.serialize(TEST_TOPIC_NAME, utf8String)
+        val deserialized = codec.deserialize(TEST_TOPIC_NAME, bytes)
+
+        deserialized shouldBeEqualTo utf8String
+    }
+
+    @Test
+    fun `deserializer 인코딩 설정이 올바르게 적용되는지 검증`() {
+        val codec = StringKafkaCodec()
+        val configs =
+            mutableMapOf<String, Any?>(
+                "deserializer.encoding" to "UTF-16",
+                "serializer.encoding" to "UTF-16"
+            )
+        codec.configure(configs, false)
+
+        val original = "Hello, Kafka!"
+        val bytes = codec.serialize(TEST_TOPIC_NAME, original)
+        val deserialized = codec.deserialize(TEST_TOPIC_NAME, bytes)
+
+        deserialized shouldBeEqualTo original
+    }
+
+    @Test
+    fun `key용 deserializer 인코딩 설정이 올바르게 적용되는지 검증`() {
+        val codec = StringKafkaCodec()
+        val configs =
+            mutableMapOf<String, Any?>(
+                "key.deserializer.encoding" to "UTF-16",
+                "key.serializer.encoding" to "UTF-16"
+            )
+        codec.configure(configs, true)
+
+        val original = "Key Value"
+        val bytes = codec.serialize(TEST_TOPIC_NAME, original)
+        val deserialized = codec.deserialize(TEST_TOPIC_NAME, bytes)
+
+        deserialized shouldBeEqualTo original
+    }
+
+    @Test
+    fun `value용 deserializer 인코딩 설정이 올바르게 적용되는지 검증`() {
+        val codec = StringKafkaCodec()
+        val configs =
+            mutableMapOf<String, Any?>(
+                "value.deserializer.encoding" to "UTF-16",
+                "value.serializer.encoding" to "UTF-16"
+            )
+        codec.configure(configs, false)
+
+        val original = "Value Data"
+        val bytes = codec.serialize(TEST_TOPIC_NAME, original)
+        val deserialized = codec.deserialize(TEST_TOPIC_NAME, bytes)
+
+        deserialized shouldBeEqualTo original
+    }
+
+    @Test
+    fun `잘못된 인코딩 이름은 기본 인코딩으로 폴백`() {
+        val codec = StringKafkaCodec()
+        val configs =
+            mutableMapOf<String, Any?>(
+                "serializer.encoding" to "INVALID-ENCODING",
+                "deserializer.encoding" to "INVALID-ENCODING"
+            )
+        codec.configure(configs, false)
+
+        val original = "Fallback Test"
+        val bytes = codec.serialize(TEST_TOPIC_NAME, original)
+        val deserialized = codec.deserialize(TEST_TOPIC_NAME, bytes)
+
+        deserialized shouldBeEqualTo original
+    }
+}

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/coroutines/ProducerSupportTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/coroutines/ProducerSupportTest.kt
@@ -1,0 +1,170 @@
+package io.bluetape4k.kafka.coroutines
+
+import io.bluetape4k.concurrent.asCompletableFuture
+import io.bluetape4k.concurrent.sequence
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.junit5.random.RandomValue
+import io.bluetape4k.junit5.random.RandomizedTest
+import io.bluetape4k.kafka.AbstractKafkaTest
+import io.bluetape4k.kafka.getMetricValue
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import io.bluetape4k.testcontainers.mq.KafkaServer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.runBlocking
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.junit.jupiter.api.RepeatedTest
+import kotlin.system.measureTimeMillis
+
+@RandomizedTest
+class ProducerSupportTest: AbstractKafkaTest() {
+
+    companion object: KLoggingChannel() {
+        private const val MESSAGE_SIZE = 10
+
+        fun randomStrings(size: Int = MESSAGE_SIZE): List<String> {
+            return List(size) { randomString() }
+        }
+    }
+
+    private val producer = KafkaServer.Launcher.createStringProducer()
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `send one message with future`(@RandomValue message: String) = runSuspendIO {
+        val record = ProducerRecord<String, String>(TEST_TOPIC_NAME, null, message)
+
+        val future = producer.send(record).asCompletableFuture()
+        producer.flush()
+        val metadata = future.await()
+        metadata.verifyRecordMetadata()
+    }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `send one message in suspend`(@RandomValue message: String) = runSuspendIO {
+        val record = ProducerRecord<String, String>(TEST_TOPIC_NAME, null, message)
+
+        val metadata = producer.suspendSend(record)
+        metadata.verifyRecordMetadata()
+    }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `send many messages with future`() {
+        val messages = randomStrings()
+
+        measureSendRecords(MESSAGE_SIZE) {
+            val futures = messages.map { message ->
+                val record = ProducerRecord<String, String>(TEST_TOPIC_NAME, null, message)
+                producer.send(record).asCompletableFuture()
+            }
+
+            val metadatas = futures.sequence().get()
+            metadatas.forEach { metadata ->
+                metadata.verifyRecordMetadata()
+            }
+        }
+    }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `send many messages with suspend`() {
+        val messages = randomStrings()
+
+        measureSendRecords(MESSAGE_SIZE) {
+            val tasks = messages.map { message ->
+                val record = ProducerRecord<String, String>(TEST_TOPIC_NAME, null, message)
+                async(Dispatchers.IO) {
+                    producer.suspendSend(record)
+                }
+            }
+
+            tasks.awaitAll().forEach { metadata ->
+                metadata.verifyRecordMetadata()
+            }
+        }
+    }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `send flow messages all async`() {
+        val messages = randomStrings()
+
+        measureSendRecords(MESSAGE_SIZE) {
+            val sendTime = measureTimeMillis {
+                val records = messages.asFlow()
+                    .map {
+                        ProducerRecord<String, String>(TEST_TOPIC_NAME, null, it)
+                    }
+
+                val lastResult = producer.sendAsFlow(records).last()
+                lastResult.verifyRecordMetadata()
+            }
+            log.debug { "Send time=$sendTime" }
+        }
+    }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `send flow messages as parallel mode`() {
+        val messages = randomStrings()
+
+        measureSendRecords(MESSAGE_SIZE) {
+            val sendTime = measureTimeMillis {
+                val records = messages.asFlow()
+                    .map { ProducerRecord<String, String>(TEST_TOPIC_NAME, null, it) }
+
+                val lastResult = producer.sendAsFlowParallel(records)
+                lastResult.verifyRecordMetadata()
+            }
+            log.debug { "Send time=$sendTime" }
+        }
+    }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `send and forget flow messages`() {
+        val messages = randomStrings()
+
+        runBlocking(Dispatchers.IO) {
+            val prevSentTotal = producer.getMetricValue("record-send-total")
+
+            val sendTime = measureTimeMillis {
+                val records = messages.asFlow()
+                    .map { ProducerRecord<String, String>(TEST_TOPIC_NAME, null, it) }
+
+                producer.sendAndForget(records, true)
+            }
+
+            log.debug { "Send time=$sendTime" }
+            val currSentTotal = producer.getMetricValue("record-send-total") - prevSentTotal
+            log.debug { "Current sent count=$currSentTotal" }
+        }
+    }
+
+    private fun measureSendRecords(
+        expectCount: Int = MESSAGE_SIZE,
+        block: suspend CoroutineScope.() -> Unit,
+    ) {
+        runBlocking(Dispatchers.IO) {
+            val prevSentTotal = producer.getMetricValue("record-send-total")
+
+            block()
+
+            val currSentTotal = producer.getMetricValue("record-send-total") - prevSentTotal
+            log.debug { "Current sent count=$currSentTotal" }
+            currSentTotal.toInt() shouldBeGreaterOrEqualTo expectCount
+        }
+    }
+
+    private fun RecordMetadata.verifyRecordMetadata() {
+        topic() shouldBeEqualTo TEST_TOPIC_NAME
+        partition() shouldBeGreaterOrEqualTo 0
+        // ACK >= 1 이어야만 유효합니다.
+        // offset() shouldBeGreaterOrEqualTo 0
+    }
+}

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/spring/KafkaOperationsExtensionsTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/spring/KafkaOperationsExtensionsTest.kt
@@ -1,0 +1,149 @@
+package io.bluetape4k.kafka.spring
+
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.kafka.AbstractKafkaTest
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.testcontainers.mq.KafkaServer
+import io.bluetape4k.testcontainers.mq.Spring
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.DisposableBean
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.core.ProducerFactory
+import org.springframework.messaging.support.MessageBuilder
+
+/**
+ * [KafkaOperationsExtensions]의 suspendSend 오버로드들에 대한 통합 테스트입니다.
+ *
+ * Spring KafkaTemplate 을 실제 Kafka(testcontainer)와 함께 사용하여
+ * suspend 확장 함수들이 올바르게 동작하는지 검증합니다.
+ */
+class KafkaOperationsExtensionsTest: AbstractKafkaTest() {
+
+    companion object: KLoggingChannel() {
+        // 다른 테스트와 토픽이 겹치면 offset 불일치로 검증이 어려우므로 전용 토픽 사용
+        private const val TOPIC = "$TEST_TOPIC_NAME-ops-ext"
+    }
+
+    private lateinit var producerFactory: ProducerFactory<String, String>
+    private lateinit var kafkaTemplate: KafkaTemplate<String, String>
+
+    @BeforeEach
+    fun setup() {
+        producerFactory = KafkaServer.Launcher.Spring.getStringProducerFactory()
+        kafkaTemplate = KafkaTemplate(producerFactory, true).apply {
+            setDefaultTopic(TOPIC)
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        // DefaultKafkaProducerFactory 는 DisposableBean 을 구현하므로 destroy() 로 내부 Producer 를 해제한다.
+        // 해제하지 않으면 테스트 반복 시 Kafka 브로커 연결이 축적되어 리소스가 누수된다.
+        (producerFactory as? DisposableBean)?.destroy()
+    }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `suspendSend ProducerRecord 로 메시지 발송`() = runSuspendIO {
+        val record = ProducerRecord<String, String>(TOPIC, "key-1", "value-${System.currentTimeMillis()}")
+
+        // suspendSend(ProducerRecord) 오버로드 검증
+        val result = kafkaTemplate.suspendSend(record)
+
+        result.shouldNotBeNull()
+        result.recordMetadata.topic() shouldBeEqualTo TOPIC
+    }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `suspendSend topic-value 로 메시지 발송`() = runSuspendIO {
+        val value = "value-${System.currentTimeMillis()}"
+
+        // suspendSend(topic, value) 오버로드 검증
+        val result = kafkaTemplate.suspendSend(TOPIC, value)
+
+        result.shouldNotBeNull()
+        result.recordMetadata.topic() shouldBeEqualTo TOPIC
+    }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `suspendSend topic-key-value 로 메시지 발송`() = runSuspendIO {
+        val key = "key-kv"
+        val value = "value-${System.currentTimeMillis()}"
+
+        // suspendSend(topic, key, value) 오버로드 검증
+        val result = kafkaTemplate.suspendSend(TOPIC, key, value)
+
+        result.shouldNotBeNull()
+        result.recordMetadata.topic() shouldBeEqualTo TOPIC
+    }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `suspendSend topic-partition-key-value 로 파티션 지정 발송`() = runSuspendIO {
+        val partition = 0
+        val key = "key-partition"
+        val value = "value-${System.currentTimeMillis()}"
+
+        // suspendSend(topic, partition, key, value) 오버로드 검증
+        val result = kafkaTemplate.suspendSend(TOPIC, partition, key, value)
+
+        result.shouldNotBeNull()
+        result.recordMetadata.topic() shouldBeEqualTo TOPIC
+        result.recordMetadata.partition() shouldBeEqualTo partition
+    }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `suspendSend topic-partition-timestamp-key-value 로 타임스탬프 지정 발송`() = runSuspendIO {
+        val partition = 0
+        val timestamp = System.currentTimeMillis()
+        val key = "key-ts"
+        val value = "value-$timestamp"
+
+        // suspendSend(topic, partition, timestamp, key, value) 오버로드 검증
+        val result = kafkaTemplate.suspendSend(TOPIC, partition, timestamp, key, value)
+
+        result.shouldNotBeNull()
+        result.recordMetadata.topic() shouldBeEqualTo TOPIC
+        result.recordMetadata.partition() shouldBeEqualTo partition
+    }
+
+    @Test
+    fun `suspendSend Spring Message 로 메시지 발송`() = runSuspendIO {
+        val payload = "message-payload-${System.currentTimeMillis()}"
+        // Spring Message 는 KafkaTemplate.defaultTopic 으로 라우팅된다.
+        val message = MessageBuilder.withPayload(payload).build()
+
+        // suspendSend(Message) 오버로드 검증
+        val result = kafkaTemplate.suspendSend(message)
+
+        result.shouldNotBeNull()
+        result.recordMetadata.topic() shouldBeEqualTo TOPIC
+    }
+
+    @Test
+    fun `suspendSendDefault 기본 토픽으로 value 발송`() = runSuspendIO {
+        val value = "default-value-${System.currentTimeMillis()}"
+
+        // suspendSendDefault(value) 오버로드 검증 — KafkaTemplate.defaultTopic 사용
+        val result = kafkaTemplate.suspendSendDefault(value)
+
+        result.shouldNotBeNull()
+        result.recordMetadata.topic() shouldBeEqualTo TOPIC
+    }
+
+    @Test
+    fun `suspendSendDefault 기본 토픽으로 key-value 발송`() = runSuspendIO {
+        val key = "default-key"
+        val value = "default-value-${System.currentTimeMillis()}"
+
+        // suspendSendDefault(key, value) 오버로드 검증 — KafkaTemplate.defaultTopic 사용
+        val result = kafkaTemplate.suspendSendDefault(key, value)
+
+        result.shouldNotBeNull()
+        result.recordMetadata.topic() shouldBeEqualTo TOPIC
+    }
+}

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplateTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplateTest.kt
@@ -1,0 +1,209 @@
+package io.bluetape4k.kafka.spring.core
+
+import io.bluetape4k.kafka.AbstractKafkaTest
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.testcontainers.mq.KafkaServer
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp
+import org.apache.kafka.common.TopicPartition
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.DisposableBean
+import reactor.core.publisher.Mono
+import reactor.kafka.receiver.KafkaReceiver
+import reactor.kafka.receiver.ReceiverOptions
+import java.util.*
+import java.util.function.Function
+import java.util.regex.Pattern
+import kotlin.test.assertFailsWith
+
+/**
+ * [SuspendKafkaConsumerTemplate]에 대한 테스트 클래스입니다.
+ */
+class SuspendKafkaConsumerTemplateTest: AbstractKafkaTest() {
+    companion object: KLoggingChannel() {
+        private val CONSUMER_GROUP = "$TEST_TOPIC_NAME-consumer-template-group"
+    }
+
+    private val receiver = mockk<KafkaReceiver<String, String>>()
+    private val consumer = mockk<Consumer<String, String>>(relaxUnitFun = true)
+    private val closableReceiver = mockk<KafkaReceiver<String, String>>(
+        relaxUnitFun = true,
+        moreInterfaces = arrayOf(AutoCloseable::class, DisposableBean::class)
+    )
+
+    @BeforeEach
+    fun setupMocks() {
+        clearMocks(receiver, consumer, closableReceiver)
+    }
+
+    @Test
+    fun `ConsumerTemplate 생성`() {
+        val receiverOptions =
+            ReceiverOptions
+                .create<String, String>(
+                    mapOf(
+                        "bootstrap.servers" to KafkaServer.Launcher.kafka.bootstrapServers,
+                        "group.id" to CONSUMER_GROUP,
+                        "key.deserializer" to org.apache.kafka.common.serialization.StringDeserializer::class.java,
+                        "value.deserializer" to org.apache.kafka.common.serialization.StringDeserializer::class.java,
+                        "auto.offset.reset" to "earliest",
+                    ),
+                ).subscription(listOf(TEST_TOPIC_NAME))
+
+        val template = SuspendKafkaConsumerTemplate(receiverOptions)
+        template.shouldNotBeNull()
+    }
+
+    @Test
+    fun `구독과 구독 해제를 관리한다`() = runTest {
+        val subscription = linkedSetOf<String>()
+
+        every { consumer.subscribe(any<List<String>>()) } answers {
+            subscription.clear()
+            subscription.addAll(firstArg())
+        }
+        every { consumer.subscription() } answers { subscription.toSet() }
+        every { consumer.unsubscribe() } answers { subscription.clear() }
+        stubDoOnConsumer(receiver, consumer)
+
+        val template = SuspendKafkaConsumerTemplate(receiver)
+
+        template.subscribe("topic-a", "topic-b")
+        template.subscription() shouldBeEqualTo setOf("topic-a", "topic-b")
+
+        template.unsubscribe()
+        template.subscription() shouldBeEqualTo emptySet()
+
+        verify(exactly = 1) { consumer.subscribe(listOf("topic-a", "topic-b")) }
+        verify(exactly = 1) { consumer.unsubscribe() }
+    }
+
+    @Test
+    fun `정규식 기반 구독을 지원한다`() = runTest {
+        val patternSlot = slot<Pattern>()
+
+        every { consumer.subscribe(capture(patternSlot)) } returns Unit
+        stubDoOnConsumer(receiver, consumer)
+
+        val template = SuspendKafkaConsumerTemplate(receiver)
+        template.subscribe(Pattern.compile("orders-.*"))
+
+        patternSlot.captured.pattern() shouldBeEqualTo "orders-.*"
+    }
+
+    @Test
+    fun `빈 topic 목록은 구독을 허용하지 않는다`() = runTest {
+        stubDoOnConsumer(receiver, consumer)
+        val template = SuspendKafkaConsumerTemplate(receiver)
+
+        assertFailsWith<IllegalArgumentException> {
+            template.subscribe()
+        }
+        assertFailsWith<IllegalArgumentException> {
+            template.subscribe(" ")
+        }
+    }
+
+    @Test
+    fun `파티션 할당과 현재 위치 기준 커밋을 지원한다`() = runTest {
+        val partition0 = TopicPartition(TEST_TOPIC_NAME, 0)
+        val partition1 = TopicPartition(TEST_TOPIC_NAME, 1)
+        val assignment = linkedSetOf(partition0, partition1)
+        val commitSlot = slot<Map<TopicPartition, OffsetAndMetadata>>()
+
+        every { consumer.assign(any<List<TopicPartition>>()) } answers { Unit }
+        every { consumer.assignment() } returns assignment
+        every { consumer.position(partition0) } returns 11L
+        every { consumer.position(partition1) } returns 29L
+        every { consumer.commitSync(capture(commitSlot)) } answers { Unit }
+        stubDoOnConsumer(receiver, consumer)
+
+        val template = SuspendKafkaConsumerTemplate(receiver)
+
+        template.assign(partition0, partition1)
+        val committed = template.commitCurrentOffsets()
+
+        committed[partition0]?.offset() shouldBeEqualTo 11L
+        committed[partition1]?.offset() shouldBeEqualTo 29L
+        commitSlot.captured[partition0]?.offset() shouldBeEqualTo 11L
+        commitSlot.captured[partition1]?.offset() shouldBeEqualTo 29L
+    }
+
+    @Test
+    fun `timestamp 기준 seek 를 지원한다`() = runTest {
+        val partition = TopicPartition(TEST_TOPIC_NAME, 0)
+        val timestamp = 1_700_000_000_000L
+
+        every { consumer.offsetsForTimes(mapOf(partition to timestamp)) } returns
+                mapOf(partition to OffsetAndTimestamp(42L, timestamp, Optional.empty()))
+        every { consumer.seek(partition, 42L) } answers { Unit }
+        stubDoOnConsumer(receiver, consumer)
+
+        val template = SuspendKafkaConsumerTemplate(receiver)
+        val offset = template.seekToTimestamp(partition, timestamp)
+
+        offset shouldBeEqualTo 42L
+        verify(exactly = 1) { consumer.seek(partition, 42L) }
+    }
+
+    @Test
+    fun `할당되지 않은 파티션은 현재 위치 커밋을 허용하지 않는다`() = runTest {
+        val assigned = TopicPartition(TEST_TOPIC_NAME, 0)
+        val unassigned = TopicPartition(TEST_TOPIC_NAME, 1)
+
+        every { consumer.assignment() } returns setOf(assigned)
+        stubDoOnConsumer(receiver, consumer)
+
+        val template = SuspendKafkaConsumerTemplate(receiver)
+
+        val error = assertFailsWith<IllegalArgumentException> {
+            template.commitCurrentOffsets(unassigned)
+        }
+
+        error.message.shouldNotBeNull() shouldContain "unassigned partitions"
+    }
+
+    @Test
+    fun `템플릿 종료 시 내부 CoroutineScope 를 취소한다`() = runTest {
+        stubDoOnConsumer(closableReceiver, consumer)
+        val template = SuspendKafkaConsumerTemplate(closableReceiver)
+        val blocker = CompletableDeferred<Unit>()
+        lateinit var launchedJob: Job
+
+        launchedJob = template.launch {
+            blocker.await()
+        }
+
+        template.close()
+        launchedJob.cancelAndJoin()
+
+        (template.coroutineContext[Job]?.isCancelled ?: false).shouldBeTrue()
+        verify(exactly = 1) { (closableReceiver as AutoCloseable).close() }
+    }
+
+    private fun stubDoOnConsumer(
+        receiver: KafkaReceiver<String, String>,
+        consumer: Consumer<String, String>,
+    ) {
+        every { receiver.doOnConsumer<Any?>(any()) } answers {
+            val callback = firstArg<Function<Consumer<String, String>, Any?>>()
+            Mono.justOrEmpty(callback.apply(consumer))
+        }
+    }
+}

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplateTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplateTest.kt
@@ -1,0 +1,145 @@
+package io.bluetape4k.kafka.spring.core
+
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.kafka.AbstractKafkaTest
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.testcontainers.mq.KafkaServer
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
+import org.springframework.kafka.support.converter.RecordMessageConverter
+import reactor.kafka.sender.KafkaSender
+import reactor.kafka.sender.SenderOptions
+
+/**
+ * [SuspendKafkaProducerTemplate]에 대한 테스트 클래스입니다.
+ */
+class SuspendKafkaProducerTemplateTest: AbstractKafkaTest() {
+    companion object: KLoggingChannel()
+
+    private lateinit var producerTemplate: SuspendKafkaProducerTemplate<String, String>
+    private val sender = mockk<KafkaSender<String, String>>(relaxUnitFun = true)
+    private val converter = mockk<RecordMessageConverter>()
+
+    @BeforeEach
+    fun setup() {
+        clearMocks(sender, converter)
+        val senderOptions =
+            SenderOptions.create<String, String>(
+                mapOf(
+                    "bootstrap.servers" to KafkaServer.Launcher.kafka.bootstrapServers,
+                    "key.serializer" to org.apache.kafka.common.serialization.StringSerializer::class.java,
+                    "value.serializer" to org.apache.kafka.common.serialization.StringSerializer::class.java,
+                    "acks" to "all",
+                    "retries" to 3,
+                ),
+            )
+        producerTemplate = SuspendKafkaProducerTemplate(senderOptions)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        producerTemplate.close()
+    }
+
+    @Test
+    fun `ProducerTemplate 생성`() {
+        producerTemplate.shouldNotBeNull()
+    }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `토픽과 값으로 메시지 발송`() =
+        runSuspendIO {
+            val value = "test-value-${System.currentTimeMillis()}"
+
+            val result = producerTemplate.send(TEST_TOPIC_NAME, value)
+
+            result.shouldNotBeNull()
+            result.recordMetadata().topic() shouldBeEqualTo TEST_TOPIC_NAME
+        }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `토픽과 키, 값으로 메시지 발송`() =
+        runSuspendIO {
+            val key = "test-key"
+            val value = "test-value-${System.currentTimeMillis()}"
+
+            val result = producerTemplate.send(TEST_TOPIC_NAME, key, value)
+
+            result.shouldNotBeNull()
+            result.recordMetadata().topic() shouldBeEqualTo TEST_TOPIC_NAME
+        }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `파티션 지정하여 메시지 발송`() =
+        runSuspendIO {
+            val partition = 0
+            val key = "test-key"
+            val value = "test-value-${System.currentTimeMillis()}"
+
+            val result = producerTemplate.send(TEST_TOPIC_NAME, partition, key, value)
+
+            result.shouldNotBeNull()
+            result.recordMetadata().topic() shouldBeEqualTo TEST_TOPIC_NAME
+            result.recordMetadata().partition() shouldBeEqualTo partition
+        }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `ProducerRecord로 메시지 발송`() =
+        runSuspendIO {
+            val record = ProducerRecord(TEST_TOPIC_NAME, "test-key", "test-value-${System.currentTimeMillis()}")
+
+            val result = producerTemplate.send(record)
+
+            result.shouldNotBeNull()
+            result.recordMetadata().topic() shouldBeEqualTo TEST_TOPIC_NAME
+        }
+
+    @Test
+    fun `파티션 정보 조회`() =
+        runSuspendIO {
+            val partitions = producerTemplate.partitionsFromProducerFor(TEST_TOPIC_NAME)
+
+            partitions.shouldNotBeNull()
+            partitions.size shouldBeGreaterOrEqualTo 1
+        }
+
+    @Test
+    fun `메트릭 정보 조회`() =
+        runSuspendIO {
+            val metrics = producerTemplate.metricsFromProducer()
+
+            metrics.shouldNotBeNull()
+        }
+
+    @Test
+    fun `템플릿 종료 시 내부 CoroutineScope 를 취소한다`() = runTest {
+        val template = SuspendKafkaProducerTemplate(sender)
+        val blocker = CompletableDeferred<Unit>()
+        lateinit var launchedJob: Job
+
+        launchedJob = template.launch {
+            blocker.await()
+        }
+
+        template.close()
+        launchedJob.cancelAndJoin()
+
+        (template.coroutineContext[Job]?.isCancelled ?: false).shouldBeTrue()
+    }
+
+}

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/spring/support/KafkaUtilsTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/spring/support/KafkaUtilsTest.kt
@@ -1,0 +1,116 @@
+package io.bluetape4k.kafka.spring.support
+
+import io.bluetape4k.kafka.AbstractKafkaTest
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldNotBeEmpty
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.junit.jupiter.api.Test
+
+/**
+ * [KafkaUtils]의 포맷팅 유틸리티 함수에 대한 테스트 클래스입니다.
+ */
+class KafkaUtilsTest: AbstractKafkaTest() {
+    companion object: KLoggingChannel()
+
+    @Test
+    fun `ProducerRecord를 포맷된 문자열로 변환`() {
+        val record =
+            ProducerRecord(
+                "test-topic",
+                0,
+                System.currentTimeMillis(),
+                "test-key",
+                "test-value",
+            )
+
+        val formatted = record.prettyString()
+
+        formatted.shouldNotBeEmpty()
+        formatted shouldContain "test-topic"
+        formatted shouldContain "test-key"
+        formatted shouldContain "test-value"
+    }
+
+    @Test
+    fun `키가 없는 ProducerRecord 포맷팅`() {
+        val record =
+            ProducerRecord<String, String>(
+                "test-topic",
+                null,
+                "test-value",
+            )
+
+        val formatted = record.prettyString()
+
+        formatted.shouldNotBeEmpty()
+        formatted shouldContain "test-topic"
+        formatted shouldContain "test-value"
+    }
+
+    @Test
+    fun `ConsumerRecord를 포맷된 문자열로 변환`() {
+        val record =
+            ConsumerRecord<String, String>(
+                "test-topic",
+                0,
+                42L,
+                "test-key",
+                "test-value",
+            )
+
+        val formatted = record.prettyString()
+
+        formatted.shouldNotBeEmpty()
+        formatted shouldContain "test-topic"
+        // Spring Kafka의 format 결과는 기본적으로 toString()과 유사하며
+        // key와 value가 항상 포함되지는 않을 수 있음
+    }
+
+    @Test
+    fun `빈 값을 가진 ProducerRecord 포맷팅`() {
+        val record =
+            ProducerRecord<String, String>(
+                "empty-topic",
+                "",
+                "",
+            )
+
+        val formatted = record.prettyString()
+
+        formatted.shouldNotBeEmpty()
+        formatted shouldContain "empty-topic"
+    }
+
+    @Test
+    fun `특수 문자가 포함된 레코드 포맷팅`() {
+        val record =
+            ProducerRecord(
+                "special-topic",
+                "key-with-special-chars-!@#",
+                "value-with-newline\nand-tab\there",
+            )
+
+        val formatted = record.prettyString()
+
+        formatted.shouldNotBeEmpty()
+        formatted shouldContain "special-topic"
+    }
+
+    @Test
+    fun `긴 값을 가진 레코드 포맷팅`() {
+        val longValue = "a".repeat(1000)
+        val record =
+            ProducerRecord<String, String>(
+                "long-topic",
+                "long-key",
+                longValue,
+            )
+
+        val formatted = record.prettyString()
+
+        formatted.shouldNotBeEmpty()
+        formatted shouldContain "long-topic"
+    }
+}

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/streams/kstream/KStreamDslTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/streams/kstream/KStreamDslTest.kt
@@ -1,0 +1,220 @@
+package io.bluetape4k.kafka.streams.kstream
+
+import io.bluetape4k.kafka.AbstractKafkaTest
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.kafka.common.serialization.Serdes
+import org.apache.kafka.streams.Topology
+import org.apache.kafka.streams.kstream.Branched
+import org.apache.kafka.streams.kstream.Consumed
+import org.apache.kafka.streams.kstream.Grouped
+import org.apache.kafka.streams.kstream.Joined
+import org.apache.kafka.streams.kstream.KStream
+import org.apache.kafka.streams.kstream.Materialized
+import org.apache.kafka.streams.kstream.Produced
+import org.apache.kafka.streams.kstream.Repartitioned
+import org.apache.kafka.streams.kstream.StreamJoined
+import org.apache.kafka.streams.kstream.TableJoined
+import org.apache.kafka.streams.state.KeyValueStore
+import org.junit.jupiter.api.Test
+
+/**
+ * Kafka Streams KStream DSL 관련 유틸리티 함수에 대한 테스트 클래스입니다.
+ */
+class KStreamDslTest: AbstractKafkaTest() {
+    companion object: KLoggingChannel()
+
+    @Test
+    fun `consumedOf로 Consumed 인스턴스 생성`() {
+        val keySerde = Serdes.String()
+        val valueSerde = Serdes.String()
+
+        val consumed: Consumed<String, String> =
+            consumedOf(
+                keySerde = keySerde,
+                valueSerde = valueSerde,
+                resetPolicy = Topology.AutoOffsetReset.EARLIEST,
+            )
+
+        consumed.shouldNotBeNull()
+    }
+
+    @Test
+    fun `producedOf로 Produced 인스턴스 생성`() {
+        val keySerde = Serdes.String()
+        val valueSerde = Serdes.String()
+
+        val produced: Produced<String, String> =
+            producedOf(
+                keySerde = keySerde,
+                valueSerde = valueSerde,
+            )
+
+        produced.shouldNotBeNull()
+    }
+
+    @Test
+    fun `producedOf with processor name`() {
+        val produced: Produced<String, String> = producedOf<String, String>("output-processor")
+
+        produced.shouldNotBeNull()
+    }
+
+    @Test
+    fun `joinedOf로 Joined 인스턴스 생성`() {
+        val keySerde = Serdes.String()
+        val valueSerde = Serdes.String()
+        val otherValueSerde = Serdes.Long()
+
+        val joined: Joined<String, String, Long> =
+            joinedOf(
+                keySerde = keySerde,
+                valueSerde = valueSerde,
+                otherValueSerde = otherValueSerde,
+                name = "stream-join",
+            )
+
+        joined.shouldNotBeNull()
+    }
+
+    @Test
+    fun `joinedOf with name only`() {
+        val joined: Joined<String, String, Long> = joinedOf<String, String, Long>("join-name")
+
+        joined.shouldNotBeNull()
+    }
+
+    @Test
+    fun `groupedOf로 Grouped 인스턴스 생성`() {
+        val keySerde = Serdes.String()
+        val valueSerde = Serdes.Long()
+
+        val grouped: Grouped<String, Long> =
+            groupedOf(
+                keySerde = keySerde,
+                valueSerde = valueSerde,
+                name = "group-by-key",
+            )
+
+        grouped.shouldNotBeNull()
+    }
+
+    @Test
+    fun `groupedOf with processor name`() {
+        val grouped: Grouped<String, String> = groupedOf<String, String>("group-processor")
+
+        grouped.shouldNotBeNull()
+    }
+
+    @Test
+    fun `materializedOf with store name`() {
+        val materialized: Materialized<String, Long, KeyValueStore<org.apache.kafka.common.utils.Bytes, ByteArray>> =
+            materializedOf("count-store")
+
+        materialized.shouldNotBeNull()
+    }
+
+    @Test
+    fun `materializedOf with serdes`() {
+        val keySerde = Serdes.String()
+        val valueSerde = Serdes.Long()
+
+        val materialized: Materialized<String, Long, KeyValueStore<org.apache.kafka.common.utils.Bytes, ByteArray>> =
+            materializedOf(keySerde, valueSerde)
+
+        materialized.shouldNotBeNull()
+    }
+
+    @Test
+    fun `streamJoinedOf with name`() {
+        val streamJoined: StreamJoined<String, String, Long> = streamJoinedOf<String, String, Long>("stream-join-store")
+
+        streamJoined.shouldNotBeNull()
+    }
+
+    @Test
+    fun `streamJoinedOf with serdes`() {
+        val keySerde = Serdes.String()
+        val valueSerde = Serdes.String()
+        val otherValueSerde = Serdes.Long()
+
+        val streamJoined: StreamJoined<String, String, Long> =
+            streamJoinedOf(
+                keySerde = keySerde,
+                valueSerde = valueSerde,
+                otherValueSerde = otherValueSerde,
+            )
+
+        streamJoined.shouldNotBeNull()
+    }
+
+    @Test
+    fun `repartitionedOf with name`() {
+        val repartitioned: Repartitioned<String, String> = repartitionedOf<String, String>("repartition-step")
+
+        repartitioned.shouldNotBeNull()
+    }
+
+    @Test
+    fun `repartitionedOf with serdes`() {
+        val keySerde = Serdes.String()
+        val valueSerde = Serdes.Long()
+
+        val repartitioned: Repartitioned<String, Long> =
+            repartitionedOf(
+                keySerde = keySerde,
+                valueSerde = valueSerde,
+            )
+
+        repartitioned.shouldNotBeNull()
+    }
+
+    @Test
+    fun `repartitionedOf with partition count`() {
+        val repartitioned: Repartitioned<String, String> = repartitionedOf<String, String>(6)
+
+        repartitioned.shouldNotBeNull()
+    }
+
+    @Test
+    fun `tableJoinedOf with name`() {
+        val tableJoined: TableJoined<String, Int> = tableJoinedOf<String, Int>("table-join")
+
+        tableJoined.shouldNotBeNull()
+    }
+
+    @Test
+    fun `branchedOf with name`() {
+        val branched: Branched<String, String> = branchedOf<String, String>("valid-branch")
+
+        branched.shouldNotBeNull()
+    }
+
+    @Test
+    fun `branchedOf with function`() {
+        val filterFunction: (KStream<String, String>) -> KStream<String, String> = { stream ->
+            stream.filter { _, value -> value.startsWith("A") }
+        }
+
+        val branched: Branched<String, String> =
+            branchedOf(
+                chain = filterFunction,
+                name = "starts-with-a",
+            )
+
+        branched.shouldNotBeNull()
+    }
+
+    @Test
+    fun `branchedOf with consumer`() {
+        val consumerFunction: (KStream<String, String>) -> Unit = { _ -> }
+
+        val branched: Branched<String, String> =
+            branchedOf(
+                chain = consumerFunction,
+                name = "consumer-branch",
+            )
+
+        branched.shouldNotBeNull()
+    }
+}

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversion2Tests.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversion2Tests.kt
@@ -1,0 +1,154 @@
+package org.springframework.kafka.annotation
+
+import io.bluetape4k.jackson3.Jackson
+import io.bluetape4k.kafka.spring.test.utils.consumerProps
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.support.uninitialized
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldBeTrue
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.StringSerializer
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.config.KafkaListenerContainerFactory
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.core.ProducerFactory
+import org.springframework.kafka.support.converter.BytesJacksonJsonMessageConverter
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+import org.springframework.kafka.support.serializer.FailedDeserializationInfo
+import org.springframework.kafka.support.serializer.JacksonJsonDeserializer
+import org.springframework.kafka.test.EmbeddedKafkaBroker
+import org.springframework.kafka.test.context.EmbeddedKafka
+import org.springframework.kafka.test.utils.KafkaTestUtils
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@SpringBootTest
+@EmbeddedKafka(topics = ["blc.2.1"], partitions = 1)
+class BatchListenerConversion2Tests {
+
+    companion object: KLoggingChannel() {
+        private const val DEFAULT_TEST_GROUP_ID = "blc2"
+    }
+
+    @Autowired
+    private val config: Config = uninitialized()
+
+    @Autowired
+    private val template: KafkaTemplate<Int, Any> = uninitialized()
+
+    @Test
+    fun `conversion error`() {
+        val listener = this.config.listener1()
+        val topic = "blc.2.1"
+
+        template.send(topic, """{ "bar": "baz" }""")
+        template.send(topic, "JUNK")
+        template.send(topic, """{ "bar": "qux" }""")
+
+        listener.latch1.await(10, TimeUnit.SECONDS).shouldBeTrue()
+        listener.badFoo shouldBeInstanceOf BadFoo::class
+        listener.receivedFoos shouldBeEqualTo 2
+    }
+
+    @Configuration
+    @EnableKafka
+    class Config {
+
+        @Autowired
+        private val embeddedKafka: EmbeddedKafkaBroker = uninitialized()
+
+        @Bean
+        fun kafkaListenerContainerFactory(
+            embeddedKafka: EmbeddedKafkaBroker,
+            template: KafkaTemplate<Int, Any>,
+        ): KafkaListenerContainerFactory<*> {
+            return ConcurrentKafkaListenerContainerFactory<Int, Foo>().apply {
+                setConsumerFactory(consumerFactory())
+                setBatchListener(true)
+                setReplyTemplate(template())
+            }
+        }
+
+        @Bean
+        fun consumerFactory(): DefaultKafkaConsumerFactory<Int, Foo> {
+            return DefaultKafkaConsumerFactory(consumerConfigs())
+        }
+
+        @Bean
+        fun consumerConfigs(): Map<String, Any> {
+            return embeddedKafka.consumerProps(DEFAULT_TEST_GROUP_ID, false).apply {
+                put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer::class.java)
+                put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JacksonJsonDeserializer::class.java)
+                put(ErrorHandlingDeserializer.VALUE_FUNCTION, FailedFooProvider::class.java)
+                put(JacksonJsonDeserializer.VALUE_DEFAULT_TYPE, Foo::class.java.name)
+            }
+        }
+
+        @Bean
+        fun template(): KafkaTemplate<Int, Any> {
+            return KafkaTemplate(producerFactory())
+        }
+
+        @Bean
+        fun converter(): BytesJacksonJsonMessageConverter = BytesJacksonJsonMessageConverter(Jackson.defaultJsonMapper)
+
+        @Bean
+        fun producerFactory(): ProducerFactory<Int, Any> {
+            return DefaultKafkaProducerFactory(producerConfigs())
+        }
+
+        @Bean
+        fun producerConfigs(): Map<String, Any> {
+            val props = KafkaTestUtils.producerProps(embeddedKafka)
+            props[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java
+            return props
+        }
+
+        @Bean
+        fun listener1() = Listener()
+
+    }
+
+    class Listener {
+        internal val latch1 = CountDownLatch(3)
+
+        @Volatile
+        internal var badFoo: Foo? = null
+
+        @Volatile
+        internal var receivedFoos: Int = 0
+
+        @KafkaListener(id = "deser", topics = ["blc.2.1"])
+        fun listen1(foos: List<Foo>) {
+            foos.forEach { f ->
+                if (f.bar == null) {
+                    this.badFoo = f
+                } else {
+                    receivedFoos++
+                }
+                latch1.countDown()
+            }
+        }
+    }
+
+    open class Foo(var bar: String? = null) {
+        override fun toString(): String = "Foo [bar=$bar]"
+    }
+
+    class BadFoo(val failedDeserializationInfo: FailedDeserializationInfo): Foo(null)
+
+    class FailedFooProvider: java.util.function.Function<FailedDeserializationInfo, Foo> {
+        override fun apply(failedDeserializationInfo: FailedDeserializationInfo): Foo {
+            return BadFoo(failedDeserializationInfo)
+        }
+    }
+}

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
@@ -1,0 +1,353 @@
+package org.springframework.kafka.annotation
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import io.bluetape4k.jackson3.Jackson
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.info
+import io.bluetape4k.logging.trace
+import io.bluetape4k.logging.warn
+import io.bluetape4k.spring.messaging.support.message
+import io.bluetape4k.spring.messaging.support.messageOf
+import io.bluetape4k.support.uninitialized
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeEmpty
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.serialization.ByteArraySerializer
+import org.apache.kafka.common.serialization.BytesDeserializer
+import org.apache.kafka.common.serialization.BytesSerializer
+import org.apache.kafka.common.serialization.StringSerializer
+import org.apache.kafka.common.utils.Bytes
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.KafkaException
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.config.KafkaListenerContainerFactory
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.core.ProducerFactory
+import org.springframework.kafka.listener.BatchListenerFailedException
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer
+import org.springframework.kafka.listener.DefaultErrorHandler
+import org.springframework.kafka.support.KafkaHeaders
+import org.springframework.kafka.support.converter.BatchMessagingMessageConverter
+import org.springframework.kafka.support.converter.BytesJacksonJsonMessageConverter
+import org.springframework.kafka.support.converter.ConversionException
+import org.springframework.kafka.support.serializer.DelegatingByTypeSerializer
+import org.springframework.kafka.test.EmbeddedKafkaBroker
+import org.springframework.kafka.test.context.EmbeddedKafka
+import org.springframework.kafka.test.utils.KafkaTestUtils
+import org.springframework.messaging.Message
+import org.springframework.messaging.handler.annotation.Header
+import org.springframework.messaging.handler.annotation.SendTo
+import java.io.Serializable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@SpringBootTest
+@EmbeddedKafka(partitions = 1, topics = ["blc1", "blc2", "blc3", "blc4", "blc5", "blc6", "blc6.DLT"])
+class BatchListenerConversionTests {
+
+    companion object: KLoggingChannel() {
+        private const val DEFAULT_TEST_GROUP_ID = "blc"
+        private const val AWAIT_TIME_SECONDS = 3L
+    }
+
+    @Autowired
+    private val config: Config = uninitialized()
+
+    @Autowired
+    private val listener1: Listener = uninitialized()
+
+    @Autowired
+    private val listener2: Listener = uninitialized()
+
+    @Autowired
+    private val template: KafkaTemplate<Int, Any> = uninitialized()
+
+    @Test
+    fun `context loading`() {
+        listener1.shouldNotBeNull()
+        listener2.shouldNotBeNull()
+        template.shouldNotBeNull()
+    }
+
+    @Test
+    fun `batch of pojos`() {
+        doTest(listener1, "blc1")
+        doTest(listener2, "blc2")
+    }
+
+    private fun doTest(listener: Listener, topic: String) {
+        template.send(messageOf(Foo("bar"), mapOf(KafkaHeaders.TOPIC to topic)))
+
+        listener.latch1.await(AWAIT_TIME_SECONDS, TimeUnit.SECONDS).shouldBeTrue()
+        listener.latch2.await(AWAIT_TIME_SECONDS, TimeUnit.SECONDS).shouldBeTrue()
+        listener.received!!.shouldNotBeEmpty()
+        listener.received!![0] shouldBeInstanceOf Foo::class
+        listener.received!![0].bar shouldBeEqualTo "bar"
+        listener.receivedTopics!![0] shouldBeEqualTo topic
+        listener.receivedPartitions!![0] shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `batch of pojo messages`() {
+        val topic = "blc3"
+        template.send(messageOf(Foo("bar"), mapOf(KafkaHeaders.TOPIC to topic)))
+        val listener = this.config.listener3()
+
+        listener.latch1.await(AWAIT_TIME_SECONDS, TimeUnit.SECONDS).shouldBeTrue()
+        listener.received!!.size shouldBeGreaterThan 0
+    }
+
+    @Test
+    fun `batch replies with @SendTo`() {
+        val listener = this.config.listener4()
+        val topic = "blc4"
+        template.send(messageOf(Foo("bar"), mapOf(KafkaHeaders.TOPIC to topic)))
+
+        listener.latch1.await(AWAIT_TIME_SECONDS, TimeUnit.SECONDS).shouldBeTrue()
+        val received = listener.received!!
+        received.size shouldBeGreaterThan 0
+        received[0] shouldBeInstanceOf Foo::class
+        received[0].bar shouldBeEqualTo "bar"
+
+        val replies = listener.replies!!
+        replies.size shouldBeGreaterThan 0
+        replies[0] shouldBeInstanceOf Foo::class
+        replies[0].bar shouldBeEqualTo "BAR"
+    }
+
+    @Test
+    fun `conversion error`() {
+        template.send("blc6", 0, 0, """{ "bar": "baz" }""")
+        template.send("blc6", 0, 0, "JUNK")
+        template.send("blc6", 0, 0, """{ "bar": "qux" }""")
+
+        val listener5 = this.config.listener5()
+        listener5.latch1.await(AWAIT_TIME_SECONDS, TimeUnit.SECONDS).shouldBeTrue()
+        listener5.received shouldBeEqualTo listOf(Foo("baz"), Foo("qux"))
+
+        // FIXME: 역직렬화에 실패하면 DLT 로 보내야 하는데, 최신 버전은 이게 작동을 하지 않는다
+        // listener5.latch2.await(AWAIT_TIME_SECONDS, TimeUnit.SECONDS).shouldBeTrue()
+        // listener5.dlt shouldBeEqualTo "JUNK"
+    }
+
+    @Configuration
+    @EnableKafka
+    class Config {
+
+        @Bean
+        fun kafkaListenerContainerFactory(
+            embeddedKafka: EmbeddedKafkaBroker,
+            template: KafkaTemplate<Int, Any>,
+        ): KafkaListenerContainerFactory<*> {
+            val factory = ConcurrentKafkaListenerContainerFactory<Int, Foo>()
+            factory.setConsumerFactory(consumerFactory(embeddedKafka))
+            factory.setBatchListener(true)
+            factory.setBatchMessageConverter(BatchMessagingMessageConverter(converter()))
+            factory.setReplyTemplate(template(embeddedKafka))
+
+            val errorHandler = DefaultErrorHandler(DeadLetterPublishingRecoverer(template))
+            errorHandler.setLogLevel(KafkaException.Level.DEBUG)
+            factory.setCommonErrorHandler(errorHandler)
+            return factory
+        }
+
+        @Bean
+        fun consumerFactory(embeddedKafka: EmbeddedKafkaBroker): DefaultKafkaConsumerFactory<Int, Foo> {
+            return DefaultKafkaConsumerFactory(consumerConfigs(embeddedKafka))
+        }
+
+        @Bean
+        fun consumerConfigs(embeddedKafka: EmbeddedKafkaBroker): Map<String, Any> {
+            return KafkaTestUtils.consumerProps(DEFAULT_TEST_GROUP_ID, "false", embeddedKafka).apply {
+                put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer::class.java)
+                put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, 1000)
+                put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, 500)
+            }
+        }
+
+        @Bean
+        fun template(embeddedKafka: EmbeddedKafkaBroker): KafkaTemplate<Int, Any> {
+            return KafkaTemplate(producerFactory(embeddedKafka)).apply {
+                setMessageConverter(converter())
+            }
+        }
+
+        @Bean
+        fun converter(): BytesJacksonJsonMessageConverter {
+            return BytesJacksonJsonMessageConverter(Jackson.defaultJsonMapper)
+        }
+
+        @Bean
+        fun producerFactory(embeddedKafka: EmbeddedKafkaBroker): ProducerFactory<Int, Any> {
+            return DefaultKafkaProducerFactory(
+                producerConfigs(embeddedKafka), null, DelegatingByTypeSerializer(
+                    mapOf(
+                        ByteArray::class.java to ByteArraySerializer(),
+                        Bytes::class.java to BytesSerializer(),
+                        String::class.java to StringSerializer()
+                    )
+                )
+            )
+        }
+
+        @Bean
+        fun producerConfigs(embeddedKafka: EmbeddedKafkaBroker): Map<String, Any> {
+            return KafkaTestUtils.producerProps(embeddedKafka)
+        }
+
+        @Bean
+        fun listener1(cf: KafkaListenerContainerFactory<*>): Listener {
+            return Listener("blc1", cf)
+        }
+
+        @Bean
+        fun listener2(cf: KafkaListenerContainerFactory<*>): Listener {
+            return Listener("blc2", cf)
+        }
+
+        @Bean
+        fun listener3() = Listener3()
+
+        @Bean
+        fun listener4() = Listener4()
+
+        @Bean
+        fun listener5() = Listener5()
+    }
+
+    class Listener(
+        private val topic: String,
+        private val cf: KafkaListenerContainerFactory<*>,
+    ) {
+
+        internal val latch1 = CountDownLatch(1)
+        internal val latch2 = CountDownLatch(1)
+
+        internal var received: List<Foo>? = null
+        internal var receivedTopics: List<String>? = null
+        internal var receivedPartitions: List<Int>? = null
+
+        val containerFactory: KafkaListenerContainerFactory<*> get() = this.cf
+
+        @KafkaListener(
+            topics = ["#{__listener.topic}"],
+            groupId = "#{__listener.topic}.group",
+            containerFactory = "#{__listener.containerFactory}"
+        )
+        fun listen1(
+            foos: List<Foo>,
+            @Header(KafkaHeaders.RECEIVED_TOPIC) topics: List<String>,
+            @Header(KafkaHeaders.RECEIVED_PARTITION) partitions: List<Int>,
+        ) {
+            if (this.received == null) {
+                this.received = foos
+            }
+            this.receivedTopics = topics
+            this.receivedPartitions = partitions
+            this.latch1.countDown()
+        }
+
+        @KafkaListener(beanRef = "__x", topics = ["#{__x.topic}"], groupId = "#{__x.topic}.group2")
+        fun listen2(foos: List<Foo>) {
+            log.trace { "foos=${foos.joinToString()}" }
+            this.latch2.countDown()
+        }
+
+        fun getTopic(): String = this.topic
+    }
+
+    class Listener3 {
+        internal val latch1 = CountDownLatch(1)
+        internal var received: List<Foo>? = null
+
+        @KafkaListener(topics = ["blc3"], groupId = "blc3")
+        fun listen1(foos: List<Foo>) {
+            if (this.received == null) {
+                this.received = foos
+            }
+            this.latch1.countDown()
+        }
+    }
+
+    class Listener4 {
+        internal val latch1 = CountDownLatch(1)
+        internal var received: List<Foo>? = null
+        internal var replies: List<Foo>? = null
+
+        @KafkaListener(topics = ["blc4"], groupId = "blc4")
+        @SendTo
+        fun listen1(foos: List<Foo>): Collection<Message<*>> {
+            if (this.received == null) {
+                this.received = foos
+            }
+
+            return foos.map { f ->
+                message(Foo(f.bar.uppercase())) {
+                    setHeader(KafkaHeaders.TOPIC, "blc5")
+                    setHeader(KafkaHeaders.KEY, 42)
+                }
+            }
+        }
+
+        @KafkaListener(topics = ["blc5"], groupId = "blc5")
+        fun listen2(foos: List<Foo>) {
+            this.replies = foos
+            this.latch1.countDown()
+        }
+    }
+
+    class Listener5 {
+        companion object: KLogging()
+
+        internal val latch1 = CountDownLatch(2)
+        internal val latch2 = CountDownLatch(1)
+
+        internal val received = mutableListOf<Foo>()
+
+        @Volatile
+        internal var dlt: String? = null
+
+        @KafkaListener(topics = ["blc6"], groupId = "blc6")
+        @SendTo
+        fun listen5(
+            foos: List<Foo?>,
+            @Header(KafkaHeaders.CONVERSION_FAILURES) conversionFailures: List<ConversionException?>,
+        ) {
+            log.info { "foos=${foos.joinToString()}" }
+            this.latch1.countDown()
+            foos.forEachIndexed { i, foo ->
+                if (foo == null && conversionFailures[i] != null) {
+                    // FIXME: 기존에는 BatchListenerFailedException 이 발생시키면, DLT로 보내는데, 버전 업 이후 작동을 하지 않는다
+                    log.warn(conversionFailures[i]) { "JSON 파싱 예외가 발생하여, DLT 로 보냅니다." }
+                    throw BatchListenerFailedException("Conversion error", conversionFailures[i], i)
+                } else {
+                    this.received.add(foo!!)
+                }
+            }
+        }
+
+        @KafkaListener(
+            topics = ["blc6.DLT"],
+            groupId = "blc6.DLT",
+            properties = [ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG + ":org.apache.kafka.common.serialization.StringDeserializer"]
+        )
+        fun listen5Dlt(input: String) {
+            log.warn { "JSON 파싱 예외가 발생하여, DLT 로 보냅니다. input=$input" }
+            this.dlt = input
+            this.latch2.countDown()
+        }
+    }
+
+    data class Foo @JsonCreator constructor(var bar: String): Serializable
+}

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/annotation/ContainerFactoryTests.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/annotation/ContainerFactoryTests.kt
@@ -1,0 +1,47 @@
+package org.springframework.kafka.annotation
+
+import io.bluetape4k.kafka.spring.test.utils.getPropertyValue
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContainSame
+import org.junit.jupiter.api.Test
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.core.ConsumerFactory
+import java.util.concurrent.atomic.AtomicBoolean
+
+class ContainerFactoryTests {
+
+    companion object: KLoggingChannel()
+
+    @Test
+    fun `config container`() {
+        val factory = ConcurrentKafkaListenerContainerFactory<String, String>()
+        factory.setAutoStartup(false)
+        factory.setConcurrency(22)
+
+        val cf = mockk<ConsumerFactory<String, String>>(relaxUnitFun = true)
+        factory.setConsumerFactory(cf)
+        factory.setPhase(42)
+        factory.containerProperties.ackCount = 123
+
+        val customized = AtomicBoolean(false)
+        factory.setContainerCustomizer {
+            customized.compareAndSet(false, true)
+        }
+
+        val container = factory.createContainer("foo")
+
+        container.isAutoStartup.shouldBeFalse()
+        container.phase shouldBeEqualTo 42
+        container.containerProperties.ackCount shouldBeEqualTo 123
+        container.getPropertyValue<Int>("concurrency") shouldBeEqualTo 22
+        customized.get().shouldBeTrue()
+
+        val container2 = factory.createContainer("foo")
+        container.containerProperties.kafkaConsumerProperties shouldContainSame container2.containerProperties.kafkaConsumerProperties
+    }
+
+}

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/core/CustomKafkaExamples.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/core/CustomKafkaExamples.kt
@@ -1,0 +1,130 @@
+package org.springframework.kafka.core
+
+import io.bluetape4k.kafka.codec.JacksonKafkaCodec
+import io.bluetape4k.kafka.codec.StringKafkaCodec
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import io.bluetape4k.testcontainers.mq.KafkaServer
+import io.bluetape4k.testcontainers.mq.Spring
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.until
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.annotation.EnableKafka
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.support.KafkaHeaders
+import org.springframework.messaging.handler.annotation.Header
+import org.springframework.messaging.handler.annotation.Headers
+import org.springframework.messaging.handler.annotation.Payload
+import java.io.Serializable
+
+@SpringBootTest
+class CustomKafkaExamples {
+
+    data class Greeting(
+        val name: String,
+        val message: String,
+    ): Serializable
+
+    @Configuration
+    @EnableKafka
+    class TestConfiguration {
+
+        @Bean
+        fun producerProperties(): MutableMap<String, Any?> {
+            return KafkaServer.Launcher.getProducerProperties().apply {
+                this[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = StringKafkaCodec::class.java
+                this[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = JacksonKafkaCodec::class.java
+            }
+        }
+
+        @Bean
+        fun producerFactory(): ProducerFactory<String, Greeting> {
+            return KafkaServer.Launcher.Spring.getProducerFactory(producerProperties())
+        }
+
+        @Bean
+        fun consumerProperties(): MutableMap<String, Any?> {
+            return KafkaServer.Launcher.getConsumerProperties().apply {
+                this[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringKafkaCodec::class.java
+                this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = JacksonKafkaCodec::class.java
+            }
+        }
+
+        @Bean
+        fun consumerFactory(): ConsumerFactory<String, Greeting> {
+            return KafkaServer.Launcher.Spring.getConsumerFactory(consumerProperties())
+        }
+
+        @Bean
+        fun kafkaTemplate(
+            producerFactory: ProducerFactory<String, Greeting>,
+            consumerFactory: ConsumerFactory<String, Greeting>,
+        ): KafkaTemplate<String, Greeting> {
+            return KafkaTemplate(producerFactory, true).apply {
+                setDefaultTopic(CUSTOM_TOPIC_NAME)
+                setConsumerFactory(consumerFactory)
+            }
+        }
+
+        @Bean
+        fun kafkaListenerContainerFactory(
+            consumerFactory: ConsumerFactory<String, Greeting>,
+        ): ConcurrentKafkaListenerContainerFactory<String, Greeting> {
+            return KafkaServer.Launcher.Spring.getConcurrentKafkaListenerContainerFactory(consumerFactory)
+        }
+    }
+
+    companion object: KLoggingChannel() {
+        private const val CUSTOM_TOPIC_NAME = "custom.kafka.string-topic.1"
+    }
+
+    @Autowired
+    private lateinit var kafkaTemplate: KafkaTemplate<String, Greeting>
+
+    private val receiveCounter = atomic(0)
+
+    @Test
+    fun `context loading`() {
+        kafkaTemplate.shouldNotBeNull()
+    }
+
+    @Test
+    fun `send greeting`() = runTest {
+        val key = "custom key"
+        val message = Greeting("debop", "hello, ")
+
+        val result = kafkaTemplate.send(CUSTOM_TOPIC_NAME, key, message).await()
+        log.debug { "produceRecord=${result.producerRecord}" }
+        log.debug { "recordMetadata=${result.recordMetadata}" }
+
+        await until { receiveCounter.value >= 2 }
+    }
+
+    @KafkaListener(topics = [CUSTOM_TOPIC_NAME], groupId = "custom")
+    private fun listen(message: Greeting) {
+        log.debug { "Received Message in group foo: $message" }
+        receiveCounter.incrementAndGet()
+    }
+
+    @KafkaListener(topics = [CUSTOM_TOPIC_NAME], groupId = "custom-with-header")
+    private fun listenWithHeaders(
+        @Payload message: Greeting,
+        @Header(KafkaHeaders.RECEIVED_PARTITION) partition: Int,
+        @Header(KafkaHeaders.OFFSET) offset: Long,
+        @Headers headers: Map<String, Any>,
+    ) {
+        log.debug { "Received message: [$message], partition=$partition, offset=$offset, headers=$headers" }
+        receiveCounter.incrementAndGet()
+    }
+}

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/core/KafkaTemplateTests.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/core/KafkaTemplateTests.kt
@@ -1,0 +1,384 @@
+package org.springframework.kafka.core
+
+import io.bluetape4k.concurrent.onFailure
+import io.bluetape4k.concurrent.onSuccess
+import io.bluetape4k.kafka.spring.test.utils.consumerProps
+import io.bluetape4k.kafka.spring.test.utils.getSingleRecord
+import io.bluetape4k.kafka.spring.test.utils.producerProps
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import io.bluetape4k.spring.messaging.support.message
+import io.bluetape4k.support.toUtf8String
+import io.bluetape4k.support.uninitialized
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContainSame
+import org.amshove.kluent.shouldHaveSize
+import org.amshove.kluent.shouldNotBeEmpty
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.producer.Producer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.apache.kafka.common.TopicPartition
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.runner.RunWith
+import org.springframework.aop.framework.ProxyFactory
+import org.springframework.kafka.core.KafkaTemplateTests.Companion.INT_KEY_TOPIC
+import org.springframework.kafka.core.KafkaTemplateTests.Companion.STRING_KEY_TOPIC
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.kafka.support.CompositeProducerListener
+import org.springframework.kafka.support.JsonKafkaHeaderMapper
+import org.springframework.kafka.support.KafkaHeaders
+import org.springframework.kafka.support.KafkaUtils
+import org.springframework.kafka.support.ProducerListener
+import org.springframework.kafka.support.SendResult
+import org.springframework.kafka.support.TopicPartitionOffset
+import org.springframework.kafka.support.converter.MessagingMessageConverter
+import org.springframework.kafka.test.EmbeddedKafkaBroker
+import org.springframework.kafka.test.condition.EmbeddedKafkaCondition
+import org.springframework.kafka.test.context.EmbeddedKafka
+import org.springframework.kafka.test.utils.KafkaTestUtils
+import org.springframework.messaging.Message
+import org.springframework.test.context.junit4.SpringRunner
+import java.util.*
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+@RunWith(SpringRunner::class)
+@EmbeddedKafka(topics = [INT_KEY_TOPIC, STRING_KEY_TOPIC])
+class KafkaTemplateTests {
+
+    companion object: KLoggingChannel() {
+        private const val INT_KEY_TOPIC = "intKeyTopic"
+        private const val STRING_KEY_TOPIC = "stringKeyTopic"
+    }
+
+    private var embeddedKafka: EmbeddedKafkaBroker = uninitialized()
+    private var consumer: Consumer<Int, String> = uninitialized()
+
+    private val noopListener: ProducerFactory.Listener<String, String> =
+        object: ProducerFactory.Listener<String, String> {
+            override fun producerAdded(id: String, producer: Producer<String, String>) {}
+            override fun producerRemoved(id: String, producer: Producer<String, String>) {}
+        }
+
+    private val noopProducerPostProcessor =
+        ProducerPostProcessor { processor: Producer<String, String> -> processor }
+
+    @BeforeAll
+    fun setUp() {
+        embeddedKafka = requireNotNull(EmbeddedKafkaCondition.getBroker())
+        val consumerProps = embeddedKafka.consumerProps("KafkaTemplatetests" + UUID.randomUUID(), false)
+        val cf = DefaultKafkaConsumerFactory<Int, String>(consumerProps)
+        consumer = cf.createConsumer()
+        embeddedKafka.consumeFromAnEmbeddedTopic(consumer, INT_KEY_TOPIC)
+    }
+
+    @AfterAll
+    fun tearDown() {
+        consumer.close()
+    }
+
+    @Test
+    fun `send message`() {
+        val senderProps = embeddedKafka.producerProps()
+        val pf = DefaultKafkaProducerFactory<Int, String>(senderProps)
+        val wrapper = AtomicReference<Producer<Int, String>>(null)
+        pf.addPostProcessor { producer ->
+            val prox = ProxyFactory()
+            prox.setTarget(producer)
+            @Suppress("UNCHECKED_CAST")
+            val proxy = prox.proxy as Producer<Int, String>
+            wrapper.set(proxy)
+            proxy
+        }
+        val template = KafkaTemplate(pf, true)
+        template.setDefaultTopic(INT_KEY_TOPIC)
+        template.setConsumerFactory(
+            DefaultKafkaConsumerFactory(
+                embeddedKafka.consumerProps("xx", false)
+            )
+        )
+
+        // val initialRecords = template.receive(listOf(TopicPartitionOffset(INT_KEY_TOPIC, 1, 1L)))
+        // initialRecords.shouldBeEmpty()
+
+        template.sendDefault("foo")
+        consumer.getSingleRecord(INT_KEY_TOPIC).value() shouldBeEqualTo "foo"
+
+        template.sendDefault(0, 2, "bar")
+        var received: ConsumerRecord<Int, String> = consumer.getSingleRecord(INT_KEY_TOPIC)
+        with(received) {
+            partition() shouldBeEqualTo 0
+            key() shouldBeEqualTo 2
+            value() shouldBeEqualTo "bar"
+        }
+
+        template.sendDefault(1, 3, "qux")
+        consumer.getSingleRecord(INT_KEY_TOPIC).apply {
+            partition() shouldBeEqualTo 1
+            key() shouldBeEqualTo 3
+            value() shouldBeEqualTo "qux"
+        }
+
+        val message = message("fiz") {
+            setHeader(KafkaHeaders.TOPIC, INT_KEY_TOPIC)
+            setHeader(KafkaHeaders.PARTITION, 0)
+            setHeader(KafkaHeaders.KEY, 2)
+        }
+        template.send(message)
+        consumer.getSingleRecord(INT_KEY_TOPIC).apply {
+            partition() shouldBeEqualTo 0
+            key() shouldBeEqualTo 2
+            value() shouldBeEqualTo "fiz"
+        }
+
+        val message2 = message("buz") {
+            setHeader(KafkaHeaders.PARTITION, 1)
+            setHeader(KafkaHeaders.KEY, 2)
+        }
+        template.send(message2)
+        received = consumer.getSingleRecord(INT_KEY_TOPIC).apply {
+            partition() shouldBeEqualTo 1
+            key() shouldBeEqualTo 2
+            value() shouldBeEqualTo "buz"
+        }
+
+        val metrics = template.execute { it.metrics() }
+        metrics.shouldNotBeNull().shouldNotBeEmpty()
+        val metrics2 = template.metrics()
+        metrics2.shouldNotBeEmpty()
+
+        val partitions = template.partitionsFor(INT_KEY_TOPIC)
+        partitions.shouldNotBeEmpty() shouldHaveSize 2
+        KafkaTestUtils.getPropertyValue(pf.createProducer(), "delegate") shouldBeEqualTo wrapper.get()
+
+        // 마지막에 수신한 buz
+        val receive = template.receive(INT_KEY_TOPIC, 1, received.offset())!!
+        with(receive) {
+            partition() shouldBeEqualTo 1
+            key() shouldBeEqualTo 2
+            value() shouldBeEqualTo "buz"
+        }
+
+        val records = template.receive(
+            listOf(
+                TopicPartitionOffset(INT_KEY_TOPIC, 1, 1L),
+                TopicPartitionOffset(INT_KEY_TOPIC, 0, 1L),
+                TopicPartitionOffset(INT_KEY_TOPIC, 0, 0L),
+                TopicPartitionOffset(INT_KEY_TOPIC, 1, 0L),
+            )
+        )
+        records.count() shouldBeEqualTo 4
+        val partition2 = records.partitions()
+        partition2 shouldContainSame setOf(TopicPartition(INT_KEY_TOPIC, 1), TopicPartition(INT_KEY_TOPIC, 0))
+
+        records.records(TopicPartition(INT_KEY_TOPIC, 1)).map { it.offset() } shouldContainSame listOf(0L, 1L)
+        records.records(TopicPartition(INT_KEY_TOPIC, 0)).map { it.offset() } shouldContainSame listOf(0L, 1L)
+
+        pf.destroy()
+    }
+
+    @Test
+    fun `send message with timestamp`() {
+        val senderProps = embeddedKafka.producerProps()
+        val pf = DefaultKafkaProducerFactory<Int, String>(senderProps)
+        val template = KafkaTemplate(pf, true).apply {
+            setDefaultTopic(INT_KEY_TOPIC)
+        }
+
+        template.sendDefault(0, 1487694048607L, 0, "foo-ts1")
+        consumer.getSingleRecord(INT_KEY_TOPIC).apply {
+            partition() shouldBeEqualTo 0
+            timestamp() shouldBeEqualTo 1487694048607L
+            value() shouldBeEqualTo "foo-ts1"
+        }
+
+        template.send(INT_KEY_TOPIC, 1, 1487694048610L, 0, "foo-ts2")
+        consumer.getSingleRecord(INT_KEY_TOPIC).apply {
+            partition() shouldBeEqualTo 1
+            timestamp() shouldBeEqualTo 1487694048610L
+            value() shouldBeEqualTo "foo-ts2"
+        }
+
+        val metrics = template.execute { it.metrics() }
+        metrics.shouldNotBeNull().shouldNotBeEmpty()
+
+        val metrics2 = template.metrics()
+        metrics2.shouldNotBeEmpty()
+
+        val partitions = template.partitionsFor(INT_KEY_TOPIC)
+        partitions.shouldNotBeEmpty() shouldHaveSize 2
+        partitions.forEach {
+            log.debug { "partition=$it" }
+        }
+
+        pf.destroy()
+    }
+
+    @Test
+    fun `send with message`() {
+        val senderProps = embeddedKafka.producerProps()
+        val pf = DefaultKafkaProducerFactory<Int, String>(senderProps)
+        val template = KafkaTemplate(pf, true)
+
+        val message1 = message("foo-message") {
+            setHeader(KafkaHeaders.TOPIC, INT_KEY_TOPIC)
+            setHeader(KafkaHeaders.PARTITION, 0)
+            setHeader("foo", "bar")
+            setHeader(KafkaHeaders.RECEIVED_TOPIC, "dummy")
+        }
+        template.send(message1)
+
+        val r1 = consumer.getSingleRecord(INT_KEY_TOPIC)
+        r1.value() shouldBeEqualTo "foo-message"
+
+        val iterator = r1.headers().iterator()
+
+        iterator.hasNext().shouldBeTrue()
+        var next = iterator.next()
+        next.value().toUtf8String() shouldBeEqualTo "bar"
+
+        iterator.hasNext().shouldBeTrue()
+        next = iterator.next()
+        next.key() shouldBeEqualTo JsonKafkaHeaderMapper.JSON_TYPES
+
+        r1.headers().forEach {
+            log.debug { "Received message header. key=${it.key()}, value=${it.value().toUtf8String()}" }
+        }
+
+        val message2 = message("foo-message-2") {
+            setHeader(KafkaHeaders.TOPIC, INT_KEY_TOPIC)
+            setHeader(KafkaHeaders.PARTITION, 0)
+            setHeader(KafkaHeaders.TIMESTAMP, 1487694048615L)
+            setHeader("foo", "bar")
+        }
+        template.send(message2)
+
+        val r2 = consumer.getSingleRecord(INT_KEY_TOPIC)
+        r2.value() shouldBeEqualTo "foo-message-2"
+        r2.timestamp() shouldBeEqualTo 1487694048615L
+
+        val messageConverter = MessagingMessageConverter()
+
+        val ack = mockk<Acknowledgment>(relaxUnitFun = true)
+        val mockConsumer = mockk<Consumer<*, *>>(relaxUnitFun = true)
+        KafkaUtils.setConsumerGroupId("test.group.id")
+        val recordToMessage: Message<*> = messageConverter.toMessage(r2, ack, mockConsumer, String::class.java)
+
+        with(recordToMessage.headers) {
+            get(KafkaHeaders.TIMESTAMP_TYPE) shouldBeEqualTo "CREATE_TIME"
+            get(KafkaHeaders.RECEIVED_TIMESTAMP) shouldBeEqualTo 1487694048615L
+            get(KafkaHeaders.RECEIVED_TOPIC) shouldBeEqualTo INT_KEY_TOPIC
+            get(KafkaHeaders.ACKNOWLEDGMENT) shouldBeEqualTo ack
+            get("foo") shouldBeEqualTo "bar"
+            get(KafkaHeaders.GROUP_ID) shouldBeEqualTo "test.group.id"
+        }
+        recordToMessage.payload shouldBeEqualTo "foo-message-2"
+
+        KafkaUtils.clearConsumerGroupId()
+        pf.destroy()
+    }
+
+    @Test
+    fun `with producer listener`() {
+        val senderProps = embeddedKafka.producerProps()
+        val pf = DefaultKafkaProducerFactory<Int, String>(senderProps)
+        val template = KafkaTemplate(pf).apply { setDefaultTopic(INT_KEY_TOPIC) }
+        val latch = CountDownLatch(2)
+        val records = mutableListOf<ProducerRecord<Int, String>>()
+        val meta = mutableListOf<RecordMetadata>()
+        val onErrorDelegateCalls = AtomicInteger(0)
+
+        class PL: ProducerListener<Int, String> {
+            override fun onSuccess(producerRecord: ProducerRecord<Int, String>, recordMetadata: RecordMetadata) {
+                records.add(producerRecord)
+                meta.add(recordMetadata)
+                latch.countDown()
+            }
+
+            override fun onError(
+                producerRecord: ProducerRecord<Int, String>,
+                recordMetadata: RecordMetadata?,
+                exception: Exception,
+            ) {
+                onErrorDelegateCalls.incrementAndGet()
+            }
+        }
+
+        val pl1 = PL()
+        val pl2 = PL()
+        val cpl = CompositeProducerListener(pl1, pl2)
+        template.setProducerListener(cpl)
+        template.sendDefault("foo")
+        template.flush()
+
+        latch.await(10, TimeUnit.SECONDS).shouldBeTrue()
+        records[0].value() shouldBeEqualTo "foo"
+        records[1].value() shouldBeEqualTo "foo"
+        meta[0].topic() shouldBeEqualTo INT_KEY_TOPIC
+        meta[1].topic() shouldBeEqualTo INT_KEY_TOPIC
+
+        consumer.getSingleRecord(INT_KEY_TOPIC)
+        pf.destroy()
+        cpl.onError(
+            records[0],
+            RecordMetadata(TopicPartition(INT_KEY_TOPIC, -1), 0L, 0, 0L, 0, 0),
+            RuntimeException("x")
+        )
+        onErrorDelegateCalls.get() shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `with producer record listener`() {
+        val senderProps = embeddedKafka.producerProps()
+        val pf = DefaultKafkaProducerFactory<Int, String>(senderProps)
+        val template = KafkaTemplate(pf).apply { setDefaultTopic(INT_KEY_TOPIC) }
+        val latch = CountDownLatch(1)
+        template.setProducerListener(object: ProducerListener<Int, String> {
+            override fun onSuccess(producerRecord: ProducerRecord<Int, String>, recordMetadata: RecordMetadata) {
+                latch.countDown()
+            }
+        })
+
+        template.sendDefault("foo")
+        template.flush()
+        latch.await(10, TimeUnit.SECONDS).shouldBeTrue()
+
+        // Drain the topic
+        consumer.getSingleRecord(INT_KEY_TOPIC)
+        pf.destroy()
+    }
+
+    @Test
+    fun `produce with callback`() {
+        val senderProps = embeddedKafka.producerProps()
+        val pf = DefaultKafkaProducerFactory<Int, String>(senderProps)
+        val template = KafkaTemplate(pf, true).apply { setDefaultTopic(INT_KEY_TOPIC) }
+
+        val future = template.sendDefault("foo")
+        template.flush()
+
+        val latch = CountDownLatch(1)
+        val theResult = AtomicReference<SendResult<Int, String>>(null)
+
+        future.onSuccess { result ->
+            theResult.set(result)
+            latch.countDown()
+        }
+            .onFailure {
+                throw it
+            }
+
+        consumer.getSingleRecord(INT_KEY_TOPIC).value() shouldBeEqualTo "foo"
+        latch.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        pf.destroy()
+    }
+}

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/core/SimpleKafkaExamples.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/core/SimpleKafkaExamples.kt
@@ -1,0 +1,162 @@
+package org.springframework.kafka.core
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import io.bluetape4k.support.uninitialized
+import io.bluetape4k.testcontainers.mq.KafkaServer
+import io.bluetape4k.testcontainers.mq.Spring
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.until
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.annotation.EnableKafka
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.config.KafkaListenerContainerFactory
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.kafka.support.KafkaHeaders
+import org.springframework.messaging.handler.annotation.Header
+import org.springframework.messaging.handler.annotation.Payload
+
+@SpringBootTest
+class SimpleKafkaExamples {
+
+    @Configuration
+    @EnableKafka
+    class TestConfiguration {
+        @Bean
+        fun producerFactory(): ProducerFactory<String, String> {
+            return KafkaServer.Launcher.Spring.getStringProducerFactory()
+        }
+
+        @Bean
+        fun consumerFactory(): ConsumerFactory<String, String> {
+            return KafkaServer.Launcher.Spring.getStringConsumerFactory()
+        }
+
+        @Bean
+        fun kafkaTemplate(
+            producerFactory: ProducerFactory<String, String>,
+            consumerFactory: ConsumerFactory<String, String>,
+        ): KafkaTemplate<String, String> {
+            return KafkaTemplate(producerFactory, true).apply {
+                setDefaultTopic(SIMPLE_TOPIC_NAME)
+                setConsumerFactory(consumerFactory)
+            }
+        }
+
+        @Bean
+        fun kafkaListenerContainerFactory(
+            consumerFactory: ConsumerFactory<String, String>,
+        ): ConcurrentKafkaListenerContainerFactory<String, String> {
+            return KafkaServer.Launcher.Spring.getConcurrentKafkaListenerContainerFactory(consumerFactory)
+        }
+
+        @Bean
+        fun kafkaManualAckListenerContainerFactory(
+            consumerFactory: ConsumerFactory<String, String>,
+        ): KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, String>> {
+            return KafkaServer.Launcher.Spring
+                .getKafkaManualAckListenerContainerFactory(consumerFactory)
+        }
+    }
+
+    companion object: KLoggingChannel() {
+        private const val SIMPLE_TOPIC_NAME = "simple.kafka.string-topic.1"
+    }
+
+    @Autowired
+    private val kafkaTemplate: KafkaTemplate<String, String> = uninitialized()
+
+    private val consumedCounter = atomic(0)
+    private var consumed by consumedCounter
+
+    @BeforeEach
+    fun beforeEach() {
+        consumed = 0
+    }
+
+    @Test
+    fun `context loading`() {
+        kafkaTemplate.shouldNotBeNull()
+    }
+
+    @Test
+    fun `send string message`() = runTest {
+        val key = "simple key"
+        val message = "simple message"
+
+        val result1 = kafkaTemplate.send(SIMPLE_TOPIC_NAME, key, message).await()
+        log.debug { "produceRecord=${result1.producerRecord}" }
+        log.debug { "recordMetadata=${result1.recordMetadata}" }
+        result1.recordMetadata.hasTimestamp().shouldBeTrue()
+        result1.recordMetadata.hasOffset().shouldBeTrue()
+
+        val result2 = kafkaTemplate.send(SIMPLE_TOPIC_NAME, key, message).await()
+        log.debug { "produceRecord=${result2.producerRecord}" }
+        log.debug { "recordMetadata=${result2.recordMetadata}" }
+        result2.recordMetadata.hasTimestamp().shouldBeTrue()
+        result2.recordMetadata.hasOffset().shouldBeTrue()
+
+        // 테스트용 Kafka 라서 partition 은 하나만 갖도록 한다
+        result2.recordMetadata.partition() shouldBeEqualTo result1.recordMetadata.partition()
+        result2.recordMetadata.offset() shouldBeGreaterThan result1.recordMetadata.offset()
+
+        await until { consumed >= 2 * 3 }
+        log.debug { "all consumer has been consumed." }
+    }
+
+    @KafkaListener(
+        topics = [SIMPLE_TOPIC_NAME],
+        groupId = "simple-group",
+        containerFactory = "kafkaManualAckListenerContainerFactory"
+    )
+    private fun listen(message: String, ack: Acknowledgment) {
+        log.debug { "Receive Message in group simple-group: $message" }
+        consumedCounter.incrementAndGet()
+        runCatching { ack.acknowledge() }
+    }
+
+    @KafkaListener(
+        topics = [SIMPLE_TOPIC_NAME],
+        groupId = "with-header",
+        containerFactory = "kafkaManualAckListenerContainerFactory"
+    )
+    private fun listenWithHeaders(
+        @Payload message: String,
+        @Header(KafkaHeaders.RECEIVED_PARTITION) partition: Int,
+        @Header(KafkaHeaders.OFFSET) offset: Long,
+        ack: Acknowledgment,
+    ) {
+        log.debug { "Received message: [$message], partition=$partition, offset=$offset" }
+        consumedCounter.incrementAndGet()
+        runCatching { ack.acknowledge() }
+    }
+
+    @KafkaListener(
+        topics = [SIMPLE_TOPIC_NAME],
+        groupId = "with-record",
+        containerFactory = "kafkaManualAckListenerContainerFactory"
+    )
+    private fun listenWithHeaders(
+        record: ConsumerRecord<String, String>,
+        ack: Acknowledgment,
+    ) {
+        log.debug { "Received message: record=$record" }
+        consumedCounter.incrementAndGet()
+        runCatching { ack.acknowledge() }
+    }
+}

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/streams/HeaderEnricherTest.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/streams/HeaderEnricherTest.kt
@@ -1,0 +1,59 @@
+package org.springframework.kafka.streams
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+
+class HeaderEnricherTest {
+
+    companion object: KLoggingChannel() {
+        private const val INPUT = "input"
+        private const val OUTPUT = "output"
+    }
+
+    //    @Test
+    //    fun `enrich header with driver`() {
+    //        val builder = StreamsBuilder()
+    //        val headers = mutableMapOf<String, Expression>()
+    //        headers.put("foo", LiteralExpression("bar"))
+    //        val parser = SpelExpressionParser()
+    //        headers.put("spel", parser.parseExpression("""context.timestamp() + '_' + key + '_' + value"""))
+    //        val enricher = HeaderEnricher<String, String>(headers)
+    //
+    //        val stream = builder.stream<String, String>(INPUT)
+    //
+    //        stream
+    //            .transform({ enricher })
+    //            .to(OUTPUT)
+    //
+    //        val config = Properties()
+    //        config.put(StreamsConfig.APPLICATION_ID_CONFIG, "test")
+    //        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999")
+    //        config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde::class.java)
+    //        config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde::class.java)
+    //
+    //        val driver = TopologyTestDriver(builder.build(), config)
+    //
+    //        val inputTopic = driver.createInputTopic(
+    //            INPUT,
+    //            StringSerializer(),
+    //            StringSerializer()
+    //        )
+    //
+    //        inputTopic.pipeInput("key1", "value1")
+    //
+    //        val outputTopic = driver.createOutputTopic(
+    //            OUTPUT,
+    //            StringDeserializer(),
+    //            StringDeserializer()
+    //        )
+    //
+    //        val result = outputTopic.readRecord()
+    //        result.headers.lastHeader("foo").shouldNotBeNull()
+    //        result.headers.lastHeader("foo").value() shouldBeEqualTo "bar".toUtf8Bytes()
+    //        result.headers.lastHeader("spel").shouldNotBeNull()
+    //
+    //        log.debug { "spel=${result.headers.lastHeader("spel").value().toUtf8String()}" }
+    //        result.headers.lastHeader("spel").value().toUtf8String().endsWith("key1_value1").shouldBeTrue()
+    //
+    //        driver.close()
+    //    }
+}

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/streams/KafkaStreamsBranchTests.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/streams/KafkaStreamsBranchTests.kt
@@ -1,0 +1,156 @@
+package org.springframework.kafka.streams
+
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.kafka.spring.test.utils.consumerProps
+import io.bluetape4k.kafka.spring.test.utils.getRecords
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.support.asBoolean
+import io.bluetape4k.support.uninitialized
+import org.amshove.kluent.shouldContainSame
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.serialization.Serdes
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.streams.StreamsBuilder
+import org.apache.kafka.streams.StreamsConfig
+import org.apache.kafka.streams.kstream.Consumed
+import org.apache.kafka.streams.kstream.KStream
+import org.apache.kafka.streams.kstream.Produced
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.annotation.EnableKafkaStreams
+import org.springframework.kafka.annotation.KafkaStreamsDefaultConfiguration
+import org.springframework.kafka.config.KafkaStreamsConfiguration
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.core.ProducerFactory
+import org.springframework.kafka.streams.KafkaStreamsBranchTests.Companion.FALSE_TOPIC
+import org.springframework.kafka.streams.KafkaStreamsBranchTests.Companion.TRUE_FALSE_INPUT_TOPIC
+import org.springframework.kafka.streams.KafkaStreamsBranchTests.Companion.TRUE_TOPIC
+import org.springframework.kafka.support.KafkaStreamBrancher
+import org.springframework.kafka.test.EmbeddedKafkaBroker
+import org.springframework.kafka.test.context.EmbeddedKafka
+import org.springframework.kafka.test.utils.KafkaTestUtils
+
+@SpringBootTest
+@EmbeddedKafka(
+    partitions = 1,
+    topics = [TRUE_TOPIC, FALSE_TOPIC, TRUE_FALSE_INPUT_TOPIC]
+)
+class KafkaStreamsBranchTests {
+
+    companion object: KLoggingChannel() {
+        internal const val TRUE_TOPIC = "true-output-topic"
+        internal const val FALSE_TOPIC = "false-output-topic"
+        internal const val TRUE_FALSE_INPUT_TOPIC = "input-topic"
+    }
+
+    @Autowired
+    private val kafkaTemplate: KafkaTemplate<String, String> = uninitialized()
+
+    @Autowired
+    private val embeddedKafka: EmbeddedKafkaBroker = uninitialized()
+
+    @Test
+    fun `branching stream`() {
+        val falseConsumer = createConsumer()
+        this.embeddedKafka.consumeFromEmbeddedTopics(falseConsumer, FALSE_TOPIC)
+
+        val trueConsumer = createConsumer()
+        this.embeddedKafka.consumeFromEmbeddedTopics(trueConsumer, TRUE_TOPIC)
+
+        this.kafkaTemplate.sendDefault(true.toString())
+        this.kafkaTemplate.sendDefault(true.toString())
+        this.kafkaTemplate.sendDefault(false.toString())
+
+        val trueRecords = trueConsumer.getRecords()
+        val falseRecords = falseConsumer.getRecords()
+
+        val trueValues = trueRecords.map { it.value() }
+        val falseValues = falseRecords.map { it.value() }
+
+        trueValues shouldContainSame listOf("true", "true")
+        falseValues shouldContainSame listOf("false")
+
+        falseConsumer.close()
+        trueConsumer.close()
+    }
+
+    private fun createConsumer(): Consumer<String, String> {
+        val consumerProps = embeddedKafka.consumerProps(Base58.randomString(8), false)
+        consumerProps[ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG] = 10_000
+
+        val kafkaConsumerFactory =
+            DefaultKafkaConsumerFactory(consumerProps, StringDeserializer(), StringDeserializer())
+
+        return kafkaConsumerFactory.createConsumer()
+    }
+
+    @Configuration
+    @EnableKafkaStreams
+    class KafkaStreamsConfig {
+
+        @Value($$"${$${EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS}}")
+        val brokerAddresses: String = uninitialized()
+
+        @Bean
+        fun producerConfigs(): Map<String, Any> {
+            return KafkaTestUtils.producerProps(this.brokerAddresses)
+        }
+
+        @Bean
+        fun producerFactory(): ProducerFactory<String, String> {
+            return DefaultKafkaProducerFactory(producerConfigs())
+        }
+
+        @Bean
+        fun kafkaTemplate(): KafkaTemplate<String, String> {
+            return KafkaTemplate(producerFactory(), true).apply {
+                setDefaultTopic(TRUE_FALSE_INPUT_TOPIC)
+            }
+        }
+
+        @Bean(name = [KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME])
+        fun kStreamsConfigs(): KafkaStreamsConfiguration? {
+            val props: MutableMap<String, Any> = HashMap()
+            props[StreamsConfig.APPLICATION_ID_CONFIG] = "testStreams"
+            props[StreamsConfig.BOOTSTRAP_SERVERS_CONFIG] = this.brokerAddresses
+            props[StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG] = Serdes.String().javaClass.name
+            props[StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG] = Serdes.String().javaClass.name
+            props[StreamsConfig.COMMIT_INTERVAL_MS_CONFIG] = "100"
+            return KafkaStreamsConfiguration(props)
+        }
+
+        @Bean
+        fun trueFalseStream(kStreamBuilder: StreamsBuilder): KStream<String, String> {
+            return KafkaStreamBrancher<String, String>()
+                .branch(
+                    { _, value ->
+                        value.asBoolean()
+                    },
+                    { ks ->
+                        ks.to(TRUE_TOPIC, Produced.with(Serdes.String(), Serdes.String()))
+                    }
+                )
+                .branch(
+                    { _, value ->
+                        !value.asBoolean()
+                    },
+                    { ks ->
+                        ks.to(FALSE_TOPIC, Produced.with(Serdes.String(), Serdes.String()))
+                    }
+                )
+                .onTopOf(
+                    kStreamBuilder.stream(
+                        TRUE_FALSE_INPUT_TOPIC,
+                        Consumed.with(Serdes.String(), Serdes.String())
+                    )
+                )
+        }
+    }
+}

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/streams/KafkaStreamsTests.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/streams/KafkaStreamsTests.kt
@@ -1,0 +1,261 @@
+package org.springframework.kafka.streams
+
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.kafka.spring.test.utils.getPropertyValue
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.trace
+import io.bluetape4k.support.toUtf8Bytes
+import io.bluetape4k.support.uninitialized
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.serialization.Serdes
+import org.apache.kafka.streams.KafkaStreams
+import org.apache.kafka.streams.KeyValue
+import org.apache.kafka.streams.StreamsBuilder
+import org.apache.kafka.streams.StreamsConfig
+import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler
+import org.apache.kafka.streams.kstream.KStream
+import org.apache.kafka.streams.kstream.Materialized
+import org.apache.kafka.streams.kstream.Printed
+import org.apache.kafka.streams.kstream.Repartitioned
+import org.apache.kafka.streams.kstream.TimeWindows
+import org.apache.kafka.streams.kstream.ValueMapper
+import org.apache.kafka.streams.kstream.Windowed
+import org.apache.kafka.streams.processor.WallclockTimestampExtractor
+import org.apache.kafka.streams.processor.internals.StreamThread
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.expression.Expression
+import org.springframework.expression.common.LiteralExpression
+import org.springframework.expression.spel.standard.SpelExpressionParser
+import org.springframework.kafka.annotation.EnableKafka
+import org.springframework.kafka.annotation.EnableKafkaStreams
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.annotation.KafkaStreamsDefaultConfiguration
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.config.KafkaListenerContainerFactory
+import org.springframework.kafka.config.KafkaStreamsConfiguration
+import org.springframework.kafka.config.StreamsBuilderFactoryBean
+import org.springframework.kafka.config.StreamsBuilderFactoryBeanConfigurer
+import org.springframework.kafka.core.ConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.core.ProducerFactory
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer
+import org.springframework.kafka.streams.KafkaStreamsTests.Companion.FOOS
+import org.springframework.kafka.streams.KafkaStreamsTests.Companion.STREAMING_TOPIC1
+import org.springframework.kafka.support.serializer.JacksonJsonSerde
+import org.springframework.kafka.test.EmbeddedKafkaBroker
+import org.springframework.kafka.test.context.EmbeddedKafka
+import org.springframework.kafka.test.utils.KafkaTestUtils
+import org.springframework.test.context.TestPropertySource
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+@SpringBootTest
+@TestPropertySource(properties = ["streaming.topic.two=streamingTopic2"])
+@EmbeddedKafka(
+    partitions = 1,
+    topics = [STREAMING_TOPIC1, $$"${streaming.topic.two}", FOOS],
+    brokerProperties = [
+        $$"auto.create.topics.enable=${topics.authCreate:false}",
+        $$"delete.topic.enable=${topic.delete:true}"
+    ],
+    brokerPropertiesLocation = $$"classpath:/${broker.filename:broker}.properties"
+)
+class KafkaStreamsTests {
+
+    companion object: KLoggingChannel() {
+        internal const val STREAMING_TOPIC1 = "streamingTopic1"
+        internal const val FOOS = "foos"
+    }
+
+    @Autowired
+    private val kafkaTemplate: KafkaTemplate<Int, String> = uninitialized()
+
+    @Autowired
+    private val resultFuture: CompletableFuture<ConsumerRecord<*, String>?> = uninitialized()
+
+    @Autowired
+    private val streamsBuilderFactoryBean: StreamsBuilderFactoryBean = uninitialized()
+
+    @Autowired
+    private val embeddedKafka: EmbeddedKafkaBroker = uninitialized()
+
+    @Value($$"${streaming.topic.two}")
+    private var streamingTopic2: String = ""
+
+    @Autowired
+    private val stateChangeCalled: AtomicBoolean = uninitialized()
+
+    @Test
+    fun `test KStreams`() {
+//        with(this.embeddedKafka.getKafkaServer(0).config()) {
+//            autoCreateTopicsEnable().shouldBeFalse()
+//            deleteTopicEnable().shouldBeTrue()
+//            brokerId() shouldBeEqualTo 2
+//        }
+        this.streamsBuilderFactoryBean.stop()
+
+        val stateLatch = CountDownLatch(1)
+
+        this.streamsBuilderFactoryBean.setStateListener { _, _ -> stateLatch.countDown() }
+        val exceptionHandler = mockk<StreamsUncaughtExceptionHandler>(relaxUnitFun = true)
+        this.streamsBuilderFactoryBean.setStreamsUncaughtExceptionHandler(exceptionHandler)
+
+        this.streamsBuilderFactoryBean.start()
+
+        val payload1 = "foo" + Base58.randomString(32) // UUID.randomUUID().toString()
+        val payload2 = "foo" + Base58.randomString(32) // UUID.randomUUID().toString()
+
+        this.kafkaTemplate.sendDefault(0, payload1)
+        this.kafkaTemplate.sendDefault(0, payload2)
+        this.kafkaTemplate.flush()
+
+        val result = resultFuture.get(600, TimeUnit.SECONDS)
+
+        result.shouldNotBeNull()
+
+        result.topic() shouldBeEqualTo streamingTopic2
+        result.value() shouldBeEqualTo (payload1.uppercase() + payload2.uppercase())
+        result.headers().lastHeader("foo").shouldNotBeNull()
+        result.headers().lastHeader("foo").value() shouldBeEqualTo "bar".toUtf8Bytes()
+        result.headers().lastHeader("spel").shouldNotBeNull()
+
+        stateLatch.await(10, TimeUnit.SECONDS).shouldBeTrue()
+
+        val kafkaStreams = this.streamsBuilderFactoryBean.kafkaStreams!!
+        val threads = kafkaStreams.getPropertyValue<List<StreamThread>>("threads")
+        threads[0].uncaughtExceptionHandler.shouldNotBeNull()
+
+        this.stateChangeCalled.get().shouldBeTrue()
+    }
+
+    @Configuration
+    @EnableKafka
+    @EnableKafkaStreams
+    class KafkaStreamsConfig {
+
+        @Value($$"${$${EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS}}")
+        val brokerAddresses: String = uninitialized()
+
+
+        @Value($$"${streaming.topic.two}")
+        private val streamingTopic2: String? = null
+
+        @Bean
+        fun producerFactory(): ProducerFactory<Int, String> {
+            return DefaultKafkaProducerFactory(producerConfigs())
+        }
+
+        @Bean
+        fun producerConfigs(): Map<String, Any> {
+            return KafkaTestUtils.producerProps(this.brokerAddresses)
+        }
+
+        @Bean
+        fun template(): KafkaTemplate<Int, String> {
+            return KafkaTemplate(producerFactory(), true).apply {
+                setDefaultTopic(STREAMING_TOPIC1)
+            }
+        }
+
+        @Bean(name = [KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME])
+        fun kStreamsConfigs(): KafkaStreamsConfiguration? {
+            val props: MutableMap<String, Any> = HashMap()
+            props[StreamsConfig.APPLICATION_ID_CONFIG] = "testStreams"
+            props[StreamsConfig.BOOTSTRAP_SERVERS_CONFIG] = this.brokerAddresses
+            props[StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG] = Serdes.Integer().javaClass.name
+            props[StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG] = Serdes.String().javaClass.name
+            props[StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG] = WallclockTimestampExtractor::class.java.name
+            props[StreamsConfig.COMMIT_INTERVAL_MS_CONFIG] = "100"
+            return KafkaStreamsConfiguration(props)
+        }
+
+        @Bean
+        fun stateChangeCalled(): AtomicBoolean {
+            return AtomicBoolean()
+        }
+
+        @Bean
+        fun customizer(): StreamsBuilderFactoryBeanConfigurer {
+            return StreamsBuilderFactoryBeanConfigurer { fb: StreamsBuilderFactoryBean ->
+                fb.setStateListener { newState: KafkaStreams.State?, oldState: KafkaStreams.State? ->
+                    log.trace { "newState=$newState, oldState=$oldState" }
+                    stateChangeCalled().set(true)
+                }
+            }
+        }
+
+        @Bean
+        fun kStream(kStreamBuilder: StreamsBuilder): KStream<Int, String> {
+            val stream = kStreamBuilder.stream<Int, String>(STREAMING_TOPIC1)
+            val headers: MutableMap<String, Expression> = HashMap()
+            headers["foo"] = LiteralExpression("bar")
+            val parser = SpelExpressionParser()
+            headers["spel"] = parser.parseExpression("context.timestamp() + key + value")
+
+            stream.mapValues(ValueMapper { it.uppercase() })
+                .mapValues { name: String? -> Foo(name!!) }
+                .repartition(Repartitioned.with(Serdes.Integer(), object: JacksonJsonSerde<Foo>() {}))
+                .mapValues(ValueMapper { it.name })
+                .groupByKey()
+                .windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofMillis(1000)))
+                .reduce(
+                    { value1: String, value2: String -> value1 + value2 },
+                    Materialized.`as`("windowStore")
+                )
+                .toStream()
+                .map { windowedId: Windowed<Int>, value: String ->
+                    KeyValue(windowedId.key(), value)
+                }
+                .filter { _: Int?, s: String -> s.length > 40 }
+                .process<Int, String>({ HeaderEnricherProcessor(headers) })
+                .to(streamingTopic2)
+            stream.print(Printed.toSysOut())
+            return stream
+        }
+
+        @Bean
+        fun consumerConfigs(): Map<String, Any> {
+            return KafkaTestUtils.consumerProps(brokerAddresses, "testGroup", "false")
+        }
+
+        @Bean
+        fun consumerFactory(): ConsumerFactory<Int, String> {
+            return DefaultKafkaConsumerFactory(consumerConfigs())
+        }
+
+        @Bean
+        fun kafkaListenerContainerFactory(): KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<Int, String>>? {
+            return ConcurrentKafkaListenerContainerFactory<Int, String>().apply {
+                this.setConsumerFactory(consumerFactory())
+            }
+        }
+
+
+        @Bean
+        fun resultFuture(): CompletableFuture<ConsumerRecord<*, String?>?> {
+            return CompletableFuture()
+        }
+
+
+        @KafkaListener(topics = [$$"${streaming.topic.two}"])
+        fun listener(payload: ConsumerRecord<*, String?>?) {
+            resultFuture().complete(payload)
+        }
+    }
+
+    data class Foo(var name: String)
+}

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/streams/WordCountExamples.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/streams/WordCountExamples.kt
@@ -1,0 +1,199 @@
+package org.springframework.kafka.streams
+
+import io.bluetape4k.kafka.streams.kstream.consumedOf
+import io.bluetape4k.kafka.streams.kstream.groupedOf
+import io.bluetape4k.kafka.streams.kstream.materializedOf
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.support.uninitialized
+import org.amshove.kluent.shouldContainSame
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.kafka.common.serialization.LongDeserializer
+import org.apache.kafka.common.serialization.Serdes
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.common.serialization.StringSerializer
+import org.apache.kafka.streams.KeyValue
+import org.apache.kafka.streams.StreamsBuilder
+import org.apache.kafka.streams.StreamsConfig
+import org.apache.kafka.streams.TopologyTestDriver
+import org.apache.kafka.streams.kstream.KStream
+import org.apache.kafka.streams.kstream.KTable
+import org.apache.kafka.streams.kstream.Printed
+import org.apache.kafka.streams.kstream.ValueMapper
+import org.apache.kafka.streams.processor.WallclockTimestampExtractor
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.annotation.EnableKafka
+import org.springframework.kafka.annotation.EnableKafkaStreams
+import org.springframework.kafka.annotation.KafkaStreamsDefaultConfiguration
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.config.KafkaListenerContainerFactory
+import org.springframework.kafka.config.KafkaStreamsConfiguration
+import org.springframework.kafka.core.ConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.core.ProducerFactory
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer
+import org.springframework.kafka.streams.WordCountExamples.Companion.INPUT_TOPIC
+import org.springframework.kafka.streams.WordCountExamples.Companion.OUTPUT_TOPIC
+import org.springframework.kafka.test.EmbeddedKafkaBroker
+import org.springframework.kafka.test.context.EmbeddedKafka
+import org.springframework.kafka.test.utils.KafkaTestUtils
+import org.springframework.test.context.ActiveProfiles
+import java.util.*
+
+@SpringBootTest
+@ActiveProfiles("test")
+@EmbeddedKafka(
+    partitions = 1,
+    topics = [INPUT_TOPIC, OUTPUT_TOPIC],
+    brokerProperties = [
+        $$"auto.create.topics.enable=${topics.autoCreate:false}",
+        $$"delete.topic.enable=${topic.delete:true}"
+    ],
+    brokerPropertiesLocation = $$"classpath:/${broker.filename:broker}.properties"
+)
+class WordCountExamples {
+
+    companion object: KLoggingChannel() {
+        internal const val INPUT_TOPIC = "word-input-topic"
+        internal const val OUTPUT_TOPIC = "word-output-topic"
+    }
+
+    @Autowired
+    private val embeddedKafka: EmbeddedKafkaBroker = uninitialized()
+
+    @Autowired
+    private val template: KafkaTemplate<String, String> = uninitialized()
+
+    @Autowired
+    private val wordCountProcessor: WordCountProcessor = uninitialized()
+
+    @Autowired
+    private val streamsBuilder: StreamsBuilder = uninitialized()
+
+    @Test
+    fun `context loading`() {
+        template.shouldNotBeNull()
+    }
+
+    @Test
+    fun `word counting`() {
+        val topology = streamsBuilder.build()
+
+        TopologyTestDriver(topology, Properties()).use {
+            val inputTopic = it.createInputTopic(INPUT_TOPIC, StringSerializer(), StringSerializer())
+            val outputTopic = it.createOutputTopic(OUTPUT_TOPIC, StringDeserializer(), LongDeserializer())
+
+            inputTopic.pipeInput("key", "hello world")
+            inputTopic.pipeInput("key2", "hello")
+
+            outputTopic.readKeyValuesToList() shouldContainSame listOf(
+                KeyValue.pair("hello", 1L),
+                KeyValue.pair("world", 1L),
+                KeyValue.pair("hello", 2L)
+            )
+        }
+    }
+
+    @Configuration
+    @EnableKafka
+    @EnableKafkaStreams
+    class Config {
+
+        companion object {
+            private const val EMBEDDED_BROKERS_PROPERTY =
+                $$"${$${EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS}}"
+        }
+
+        @Value(EMBEDDED_BROKERS_PROPERTY)
+        val brokerAddresses: String = uninitialized()
+
+        @Bean
+        fun producerConfig(): Map<String, Any> {
+            return KafkaTestUtils.producerProps(brokerAddresses)
+        }
+
+        @Bean
+        fun producerFactory(): ProducerFactory<String, String> {
+            return DefaultKafkaProducerFactory(producerConfig())
+        }
+
+        @Bean
+        fun kafkaTemplate(): KafkaTemplate<String, String> {
+            return KafkaTemplate(producerFactory())
+        }
+
+        @Value($$"${spring.kafka.streams.state-dir:streams-state}")
+        private var stateStoreLocation: String? = null
+
+        @Bean(name = [KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME])
+        fun kStreamsConfigs(): KafkaStreamsConfiguration? {
+            val props: MutableMap<String, Any> = HashMap()
+            props[StreamsConfig.APPLICATION_ID_CONFIG] = "wordcount-app"
+            props[StreamsConfig.BOOTSTRAP_SERVERS_CONFIG] = this.brokerAddresses
+            props[StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG] = Serdes.Integer().javaClass.name
+            props[StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG] = Serdes.String().javaClass.name
+            props[StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG] = WallclockTimestampExtractor::class.java.name
+            props[StreamsConfig.COMMIT_INTERVAL_MS_CONFIG] = "100"
+
+            // configure the state location to allow tests to use clean state for every run
+            props[StreamsConfig.STATE_DIR_CONFIG] = stateStoreLocation ?: "streams-state"
+            return KafkaStreamsConfiguration(props)
+        }
+
+        @Bean
+        fun wordCountProcessor(streamsBuilder: StreamsBuilder): WordCountProcessor {
+            return WordCountProcessor().apply {
+                buildPipeline(streamsBuilder)
+            }
+        }
+
+        @Bean
+        fun consumerConfigs(): Map<String, Any> {
+            return KafkaTestUtils.consumerProps(brokerAddresses, "testGroup", "false")
+        }
+
+        @Bean
+        fun consumerFactory(): ConsumerFactory<Int, String> {
+            return DefaultKafkaConsumerFactory(consumerConfigs())
+        }
+
+        @Bean
+        fun kafkaListenerContainerFactory(): KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<Int, String>>? {
+            return ConcurrentKafkaListenerContainerFactory<Int, String>().apply {
+                this.setConsumerFactory(consumerFactory())
+            }
+        }
+    }
+
+    class WordCountProcessor {
+        companion object: KLogging() {
+            private val SERDE_STRING = Serdes.String()
+        }
+
+        fun buildPipeline(streamsBuilder: StreamsBuilder) {
+            val messageStream: KStream<String, String> = streamsBuilder.stream(
+                INPUT_TOPIC,
+                consumedOf(SERDE_STRING, SERDE_STRING)
+            )
+
+            val wordCounts: KTable<String, Long> = messageStream
+                .mapValues(ValueMapper { it.lowercase() })
+                .flatMapValues { value -> value.split("\\W+".toRegex()) }
+                .groupBy(
+                    { _, word -> word },
+                    groupedOf(SERDE_STRING, SERDE_STRING)
+                )
+                .count(materializedOf("counts"))
+
+            wordCounts.toStream().apply { print(Printed.toSysOut()) }
+                .to(OUTPUT_TOPIC)
+        }
+    }
+}

--- a/infra/kafka4/src/test/resources/application-test.yaml
+++ b/infra/kafka4/src/test/resources/application-test.yaml
@@ -1,0 +1,5 @@
+spring:
+    kafka:
+        streams:
+            state:
+                dir: ${java.io.tmpdir}/streams-state

--- a/infra/kafka4/src/test/resources/broker.properties
+++ b/infra/kafka4/src/test/resources/broker.properties
@@ -1,0 +1,2 @@
+delete.topic.enable=false
+# broker.id removed: KRaft mode manages node.id automatically via KafkaClusterTestKit

--- a/infra/kafka4/src/test/resources/jaas-sample-kafka-only.conf
+++ b/infra/kafka4/src/test/resources/jaas-sample-kafka-only.conf
@@ -1,0 +1,7 @@
+KafkaClient {
+  com.sun.security.auth.module.Krb5LoginModule required
+  useKeyTab = true
+  storeKey = true
+  keyTab = "/etc/security/keytabs/kafka_client.keytab"
+  principal = "kafka-client-1@EXAMPLE.COM";
+};

--- a/infra/kafka4/src/test/resources/junit-platform.properties
+++ b/infra/kafka4/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/infra/kafka4/src/test/resources/logback-test.xml
+++ b/infra/kafka4/src/test/resources/logback-test.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <!-- @formatter:off -->
+    <springProperty scope="context" name="APP_NAME" source="spring.application.name"/>
+
+    <!-- You can override this to have a custom pattern -->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %highlight(${LOG_LEVEL_PATTERN:-%5p}) %magenta(${PID:- }) %clr(---){faint} %clr([%25.25t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+
+    <!-- Appender to log to console -->
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <!-- Minimum logging level to be presented in the console logs-->
+            <level>DEBUG</level>
+        </filter>
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+    <!-- formatter:on -->
+
+    <logger name="io.bluetape4k.kafka" level="DEBUG"/>
+    <logger name="org.springframework.kafka" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary

Closes #281

- PR 제목: (feat): infra kafka4 모듈 추가

- Closes #281
- `infra/kafka4` 신규 모듈을 추가해 Kafka 4.2.x + Spring Kafka 4.0.x + Spring Boot 4 + Jackson 3 경계를 분리했습니다.
- `spring-kafka4`, `spring-kafka4-test`, `reactor-kafka4` catalog alias를 추가하고 kafka4 모듈 내부에서 `org.apache.kafka` artifact를 Kafka 4 버전으로 정렬했습니다.
- `README.md` / `README.ko.md`에 Kafka 3/4 호환성 표, dependency boundary, KRaft-only Embedded Kafka 사용법을 문서화했습니다.
- Nightly Tests infra matrix에 `:bluetape4k-kafka4:test`와 `:bluetape4k-kafka4:koverXmlReport`를 추가했습니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- `./gradlew :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka4:compileTestKotlin :bluetape4k-kafka4:test --rerun-tasks --console=plain` — 251 tests passing, 56s
- `./gradlew :bluetape4k-kafka4:koverXmlReport --console=plain` — PASS
- `./gradlew :bluetape4k-kafka4:koverXmlReport --dry-run --console=plain` — PASS, task graph resolves
- `git diff --cached --check` — PASS before commit

### 기존 섹션: Notes

- `:bluetape4k-kafka4:detekt`는 해당 프로젝트에 task가 없어 실행하지 않았습니다.
- Embedded Kafka shutdown 중 Kafka 내부 snapshot cleanup 경고가 로그에 출력되지만 Gradle test task는 성공합니다.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #281, milestone 없음, assignee `debop`
- PR: #293, head `34c3af74ddb94ffbdcdabf159e6521872df4f98a`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/kafka4-module`
- Labels: `enhancement`
- State: `MERGED`, merge commit `a4b6eda7bfb918fd29d31d799afd3be268b08261`
- CI: - `./gradlew :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka4:compileTestKotlin :bluetape4k-kafka4:test --rerun-tasks --console=plain` — 251 tests passing, 56s / - `./gradlew :bluetape4k-kafka4:koverXmlReport --console=plain` — PASS / - `./gradlew :bluetape4k-kafka4:koverXmlReport --dry-run --console=plain` — PASS, task graph resolves

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #293 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `a4b6eda7bfb918fd29d31d799afd3be268b08261`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
