### PR TITLE
(test): cassandra demo keyspace 재생성 경합 방지

### DIFF
--- a/spring-boot4/cassandra-demo/src/test/kotlin/io/bluetape4k/examples/cassandra/AbstractCassandraTest.kt
+++ b/spring-boot4/cassandra-demo/src/test/kotlin/io/bluetape4k/examples/cassandra/AbstractCassandraTest.kt
@@ -4,9 +4,12 @@ import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.Version
 import io.bluetape4k.junit5.faker.Fakers
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.testcontainers.storage.CassandraServer
 import io.bluetape4k.testcontainers.storage.getCassandraReleaseVersion
 import org.springframework.beans.factory.annotation.Autowired
+import java.util.concurrent.ConcurrentHashMap
 
 abstract class AbstractCassandraTest {
 
@@ -16,9 +19,32 @@ abstract class AbstractCassandraTest {
         @JvmStatic
         protected val faker = Fakers.faker
 
+        private val initializedKeyspaces = ConcurrentHashMap.newKeySet<String>()
+
         @JvmStatic
         protected fun randomString() =
             Fakers.randomString(1024, 2048)
+
+        /**
+         * 동일 테스트 JVM 안에서 지정한 keyspace를 한 번만 재생성합니다.
+         *
+         * 여러 Spring Cassandra 테스트 컨텍스트가 같은 keyspace와 공유 세션을 사용하므로,
+         * 최초 컨텍스트에서만 초기화하고 이후 컨텍스트는 기존 스키마를 재사용합니다.
+         */
+        fun recreateKeyspaceOnce(keyspace: String = DEFAULT_KEYSPACE) {
+            keyspace.requireNotBlank("keyspace")
+
+            if (initializedKeyspaces.add(keyspace)) {
+                try {
+                    CassandraServer.Launcher.recreateKeyspace(keyspace)
+                } catch (e: Throwable) {
+                    initializedKeyspaces.remove(keyspace)
+                    throw e
+                }
+            } else {
+                log.debug { "Keyspace already initialized. keyspace=[$keyspace]" }
+            }
+        }
     }
 
     @Autowired

--- a/spring-boot4/cassandra-demo/src/test/kotlin/io/bluetape4k/examples/cassandra/AbstractReactiveCassandraTestConfiguration.kt
+++ b/spring-boot4/cassandra-demo/src/test/kotlin/io/bluetape4k/examples/cassandra/AbstractReactiveCassandraTestConfiguration.kt
@@ -6,10 +6,12 @@ import io.bluetape4k.examples.cassandra.domain.model.AllPossibleTypes
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.testcontainers.storage.CassandraServer
 import org.springframework.boot.persistence.autoconfigure.EntityScan
+import org.springframework.context.annotation.Configuration
 import org.springframework.data.cassandra.config.AbstractReactiveCassandraConfiguration
 import org.springframework.data.cassandra.config.SchemaAction
 import org.springframework.data.cassandra.config.SessionBuilderConfigurer
 
+@Configuration(proxyBeanMethods = false)
 @EntityScan(basePackageClasses = [AllPossibleTypes::class])
 abstract class AbstractReactiveCassandraTestConfiguration: AbstractReactiveCassandraConfiguration() {
 
@@ -34,7 +36,7 @@ abstract class AbstractReactiveCassandraTestConfiguration: AbstractReactiveCassa
 
         init {
             // default keyspace 를 재생성합니다.
-            CassandraServer.Launcher.recreateKeyspace(DEFAULT_KEYSPACE)
+            AbstractCassandraTest.recreateKeyspaceOnce(DEFAULT_KEYSPACE)
         }
     }
 
@@ -46,7 +48,7 @@ abstract class AbstractReactiveCassandraTestConfiguration: AbstractReactiveCassa
 
     override fun getLocalDataCenter(): String = CassandraServer.LOCAL_DATACENTER1
 
-    override fun getSchemaAction(): SchemaAction = SchemaAction.RECREATE
+    override fun getSchemaAction(): SchemaAction = SchemaAction.CREATE_IF_NOT_EXISTS
 
     override fun getRequiredSession(): CqlSession = sharedSession
 


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: (test): cassandra demo keyspace 재생성 경합 방지

- Spring Boot 4 Cassandra demo 테스트 keyspace 초기화를 JVM당 1회로 제한
- sharedSession 재사용은 유지하면서 컨텍스트별 SchemaAction을 CREATE_IF_NOT_EXISTS로 변경
- 반복 RECREATE로 인한 Cassandra 연결 끊김/후속 테스트 연쇄 실패를 방지

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Risk

- 테스트 전용 설정 2파일만 변경한 좁은 범위
- 전체 저장소 build는 실행하지 않음

## Validation

- ./bin/repo-test-summary -- ./gradlew :bluetape4k-spring-boot4-cassandra-demo:test
  - 58 tests, 0 failures, 2 skipped, 100% successful

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #294, head `bbc1ad65028ce35c4118da4e3c8d295438d3b430`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/cassandra-demo-tests`
- Labels: 없음
- State: `MERGED`, merge commit `ce71330462b023f36490eb94bf7ab2066246e800`
- CI: - ./bin/repo-test-summary -- ./gradlew :bluetape4k-spring-boot4-cassandra-demo:test

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #294 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `ce71330462b023f36490eb94bf7ab2066246e800`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
