### PR TITLE
fix(kafka4): 6-tier 코드리뷰 결과 반영 — 안전 가드 회복 + KDoc 표류 수정

### DIFF
--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/TopicPartitionSupport.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/TopicPartitionSupport.kt
@@ -23,7 +23,7 @@ fun String.toTopicPartition(): TopicPartition = topicPartitionOf(this)
  * `"topic-partition"` 형식 문자열을 [TopicPartition]으로 파싱합니다.
  *
  * ## 동작/계약
- * - [tp]가 blank면 `assertNotBlank("tp")` 검증으로 예외가 발생합니다.
+ * - [tp]가 blank면 `requireNotBlank("tp")` 검증으로 [IllegalArgumentException]이 발생합니다.
  * - 마지막 `-`를 구분자로 사용해 topic/partition을 분리합니다.
  * - 구분자가 없거나 partition이 정수가 아니면 `IllegalArgumentException`/`NumberFormatException`이 발생합니다.
  *

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodecs.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodecs.kt
@@ -3,7 +3,7 @@ package io.bluetape4k.kafka.codec
 /**
  * 다양한 Kafka Codec 인스턴스를 제공하는 Object입니다.
  *
- * 문자열, 바이트 배열, JSON 직렬화 및 다양한 바이너리 직렬화(JDK, Kryo, FST)와
+ * 문자열, 바이트 배열, JSON 직렬화 및 다양한 바이너리 직렬화(JDK, Kryo, Fory)와
  * 압축 알고리즘(LZ4, Snappy, Zstd)을 조합한 Codec을 제공합니다.
  *
  * 사용 예시:

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/coroutines/ProducerCoroutines.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/coroutines/ProducerCoroutines.kt
@@ -49,7 +49,7 @@ suspend fun <K, V> Producer<K, V>.suspendSend(record: ProducerRecord<K, V>): Rec
  *      emit(ProducerRecord("test-topic", "test-key2", "test-value2"))
  *      emit(ProducerRecord("test-topic", "test-key3", "test-value3"))
  * }
- * producer.sendFlow(records)
+ * producer.sendAsFlow(records)
  * ```
  *
  * @param records producing 할 record의 flow
@@ -79,7 +79,7 @@ suspend fun <K, V> Producer<K, V>.sendAsFlow(records: Flow<ProducerRecord<K, V>>
  *      emit(ProducerRecord("test-topic", "test-key2", "test-value2"))
  *      emit(ProducerRecord("test-topic", "test-key3", "test-value3"))
  * }
- * producer.sendFlowParallel(records)
+ * producer.sendAsFlowParallel(records)
  * ```
  *
  * @param records producing 할 record의 flow

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt
@@ -23,7 +23,7 @@ import kotlin.coroutines.resumeWithException
  *
  * ```
  * val kafkaOperations: KafkaOperations<String, String> = ...
- * val result = kafkaOperations.sendSuspending(ProducerRecord("topic", "key", "value"))
+ * val result = kafkaOperations.suspendSend(ProducerRecord("topic", "key", "value"))
  * ```
  *
  * @param K Key type   메시지 키 타입
@@ -112,7 +112,9 @@ suspend inline fun <K: Any, V: Any> KafkaOperations<K, V>.sendFlowAsParallel(
     records
         .async {
             suspendSend(it)
-        }.onCompletion { flush() }
+        }
+        // cause != null 이면 에러/취소 — flush() 호출 시 블로킹 위험이 있으므로 정상 완료 시에만 실행
+        .onCompletion { cause -> if (cause == null) flush() }
         .last()
 
 /**
@@ -138,9 +140,12 @@ suspend inline fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndForget(
     records
         .async {
             suspendSend(it)
-        }.onCompletion {
-            if (needFlush) flush()
-        }.collect()
+        }
+        // cause != null 이면 에러/취소 — 에러 중 flush() 호출은 불필요한 블로킹을 유발한다
+        .onCompletion { cause ->
+            if (needFlush && cause == null) flush()
+        }
+        .collect()
 }
 
 /**

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
@@ -178,7 +178,11 @@ class SuspendKafkaProducerTemplate<K, V> private constructor(
      */
     @Suppress("UNCHECKED_CAST")
     suspend fun send(topic: String, message: Message<*>): SenderResult<Unit> {
-        val typedRecord = messageConverter.fromMessage(message, topic) as ProducerRecord<K, V>
+        val producerRecord = messageConverter.fromMessage(message, topic)
+        require(producerRecord is ProducerRecord<*, *>) {
+            "RecordMessageConverter returned ${producerRecord?.javaClass?.name ?: "null"} for topic=$topic"
+        }
+        val typedRecord = producerRecord as ProducerRecord<K, V>
 
         val correlationId = message.headers[KafkaHeaders.CORRELATION_ID, ByteArray::class.java]
         if (correlationId != null) {

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/Materialized.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/Materialized.kt
@@ -60,9 +60,9 @@ fun <K, V, S: StateStore> materializedOf(storeName: String): Materialized<K, V, 
  *
  * 사용 예시:
  * ```kotlin
- * val materialized = materializedOf(
+ * val materialized = materializedOf<String, Long, KeyValueStore<Bytes, ByteArray>>(
  *     keySerde = Serdes.String(),
- *     valueSerde = Serdes.Long().asSerde()
+ *     valueSerde = Serdes.Long(),
  * )
  * ```
  *
@@ -85,11 +85,9 @@ fun <K, V, S: StateStore> materializedOf(
  *
  * 사용 예시:
  * ```kotlin
- * val windowSupplier = Stores.windowStoreBuilder(
- *     Stores.persistentWindowStore("window-store", Duration.ofHours(1), Duration.ofMinutes(5), false),
- *     Serdes.String(),
- *     Serdes.Long()
- * ).build()
+ * val windowSupplier = Stores.persistentWindowStore(
+ *     "window-store", Duration.ofHours(1), Duration.ofMinutes(5), false,
+ * )
  * val materialized = materializedOf<String, Long>(windowSupplier)
  * ```
  *
@@ -108,11 +106,9 @@ fun <K, V> materializedOf(supplier: WindowBytesStoreSupplier): Materialized<K, V
  *
  * 사용 예시:
  * ```kotlin
- * val sessionSupplier = Stores.sessionStoreBuilder(
- *     Stores.persistentSessionStore("session-store", Duration.ofMinutes(30)),
- *     Serdes.String(),
- *     Serdes.Long()
- * ).build()
+ * val sessionSupplier = Stores.persistentSessionStore(
+ *     "session-store", Duration.ofMinutes(30),
+ * )
  * val materialized = materializedOf<String, Long>(sessionSupplier)
  * ```
  *
@@ -131,11 +127,7 @@ fun <K, V> materializedOf(supplier: SessionBytesStoreSupplier): Materialized<K, 
  *
  * 사용 예시:
  * ```kotlin
- * val kvSupplier = Stores.keyValueStoreBuilder(
- *     Stores.persistentKeyValueStore("kv-store"),
- *     Serdes.String(),
- *     Serdes.Long()
- * ).build()
+ * val kvSupplier = Stores.persistentKeyValueStore("kv-store")
  * val materialized = materializedOf<String, Long>(kvSupplier)
  * ```
  *

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/StreamJoined.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/StreamJoined.kt
@@ -61,7 +61,7 @@ fun <K, V1, V2> streamJoinedOf(storeName: String): StreamJoined<K, V1, V2> = Str
  * val streamJoined = streamJoinedOf(
  *     keySerde = Serdes.String(),
  *     valueSerde = Serdes.String(),
- *     otherValueSerde = Serdes.Long().asSerde()
+ *     otherValueSerde = Serdes.Long(),
  * )
  * val joinedStream = leftStream.join(rightStream, joiner, streamJoined)
  * ```

--- a/infra/kafka4/src/test/resources/jaas-sample-kafka-only.conf
+++ b/infra/kafka4/src/test/resources/jaas-sample-kafka-only.conf
@@ -1,7 +1,13 @@
+/*
+ * SAMPLE ONLY — DO NOT USE IN PRODUCTION.
+ * Replace keyTab/principal with values supplied by your secret manager
+ * (HashiCorp Vault, AWS Secrets Manager, Kubernetes Secret 등).
+ * EXAMPLE.COM realm and the fixed kafka-client-1 principal are placeholders.
+ */
 KafkaClient {
   com.sun.security.auth.module.Krb5LoginModule required
   useKeyTab = true
   storeKey = true
-  keyTab = "/etc/security/keytabs/kafka_client.keytab"
-  principal = "kafka-client-1@EXAMPLE.COM";
+  keyTab = "${kafka.client.keytab.path:/etc/security/keytabs/kafka_client.keytab}"
+  principal = "${kafka.client.principal:kafka-client-1@EXAMPLE.COM}";
 };


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix(kafka4): 6-tier 코드리뷰 결과 반영 — 안전 가드 회복 + KDoc 표류 수정

## Background

지난 24시간 내 추가된 `infra/kafka4/` 모듈(commit `34c3af74d`)에 대해
bluetape4k-design 의 6-tier 리뷰 파이프라인 중 4종 에이전트를 병렬 실행:

| Tier | Agent | 목적 |
|------|-------|------|
| 1 | `oh-my-claudecode:code-reviewer` | 일반 품질 / Kotlin idiom / 동시성 |
| 2 | `oh-my-claudecode:security-reviewer` | OWASP Top 10 / 역직렬화 / SASL |
| 3 | `pr-review-toolkit:pr-test-analyzer` | 테스트 커버리지 격차 |
| 4 | `pr-review-toolkit:comment-analyzer` | KDoc 정확성 / 표류 |

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 변경 요약

### HIGH — 안전 가드 회복

- **`SuspendKafkaProducerTemplate.send(topic, Message)`** 에서 kafka3 형제 모듈에
  존재하던 `require(producerRecord is ProducerRecord<*, *>)` 가드가 누락되어
  있었다. Spring Kafka 4 의 platform-type null 반환 시 진단 메시지 없이
  ClassCastException/NPE 가 발생하던 회귀를 수정.

### MEDIUM — 코루틴 취소/오류 시 블로킹 위험

- **`KafkaOperationExtensions.sendFlowAsParallel` / `sendAndForget`** 의
  `onCompletion` 콜백이 `cause` 무시하고 항상 `flush()` 를 호출했다.
  에러/취소 상황에서 이미 실패한 send 결과를 강제 대기하여 코루틴이
  블로킹되는 위험을 제거. sibling `ProducerCoroutines.kt:65,97,130` 이
  이미 적용한 `cause == null` 가드 패턴으로 통일.

### MEDIUM — 보안

- **`jaas-sample-kafka-only.conf`** 에 production-shaped 한 고정 principal/keytab
  가 포함되어 있었다. placeholder 변수와 시크릿 매니저 사용 안내 헤더 추가.

### KDoc 표류 수정 (comment-analyzer 결과)

| 파일 | 문제 | 조치 |
|------|------|------|
| `Materialized.kt` | `Serdes.Long().asSerde()` (존재하지 않는 호출) | `Serdes.Long()` |
| `Materialized.kt` | `Stores.windowStoreBuilder(...).build()` 시그니처 불일치 | `Stores.persistent*Store(...)` 직접 호출 |
| `StreamJoined.kt` | `Serdes.Long().asSerde()` | `Serdes.Long()` |
| `ProducerCoroutines.kt` | 예제 호출명 `sendFlow` / `sendFlowParallel` | `sendAsFlow` / `sendAsFlowParallel` |
| `KafkaOperationExtensions.kt` | 예제의 Deprecated API `sendSuspending` | `suspendSend` |
| `TopicPartitionSupport.kt` | KDoc 의 `assertNotBlank` (AssertionError) | `requireNotBlank` (IllegalArgumentException) |
| `KafkaCodecs.kt` | 모듈 설명의 가상의 \"FST\" | 실제 제공 코덱 \"Fory\" |

### 기존 섹션: 후속 과제 (이 PR 범위 외)

다음 항목은 보안 리뷰가 발견했으나 sibling `infra/kafka/` (kafka3) 에도 동일하게
존재하는 선행 이슈이므로 별도 PR 로 분리:

- [x] `KafkaCodec.getValueType` 의 header-driven `Class.forName` 역직렬화 RCE
      (`JdkKafkaCodec` + 가젯 라이브러리 시 RCE, Jackson3/Kryo 의 임의 클래스 로드)
- [x] `BinaryKafkaCodecs` LZ4/Snappy/Zstd decompression 크기 제한 부재 (zip-bomb)
- [x] `KafkaCodec` poison-pill swallowing — null 반환 대신 `DeserializationException` 재던지기 + Micrometer counter
- [x] `KafkaTestUtils.getPropertyValue` 시그니처 변화 (T → T 비-null) 마이그레이션 가이드
- [x] `BatchListenerConversionTests` 의 DLT TODO — Spring Kafka 4 에서 DLT 라우팅이
      "더 이상 동작하지 않는다" 고 코멘트만 남긴 채 silent pass 중. `@Disabled` 또는 fix.

### 기존 섹션: 참고

- code-reviewer 가 LOW 로 분류한 `Producer.suspendSend` cancellation propagation 부재는
  kafka3 와 동일 패턴이라 이번 PR 에서 다루지 않음.
- KDoc 표류 중 #8~#11, #13~#15 (Deprecated 오버로드 KDoc 누락 등) 은 가시적 회귀가
  아니므로 별도 정리.

🤖 Generated by scheduled task `bluetape4k-daily-code-review`

## Validation

```bash
./gradlew :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka4:compileTestKotlin
# BUILD SUCCESSFUL

./gradlew :bluetape4k-kafka4:test
# BUILD SUCCESSFUL — 251 passing (42.2s)
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #295, head `301766251f827197763d37274df88d7aef109c4f`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `claude/sweet-volhard-11d17c`
- Labels: `documentation`, `chore`
- State: `MERGED`, merge commit `4344493f3daddeb8706cada9b63326d55b6f80fc`
- CI: - **`jaas-sample-kafka-only.conf`** 에 production-shaped 한 고정 principal/keytab / ./gradlew :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka4:compileTestKotlin / ./gradlew :bluetape4k-kafka4:test

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #295 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `4344493f3daddeb8706cada9b63326d55b6f80fc`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
