### PR TITLE
fix(kafka4): 6-tier 코드리뷰 후속 — CancellationException 보존 + silent fallback 가시화

### DIFF
--- a/infra/kafka4/README.ko.md
+++ b/infra/kafka4/README.ko.md
@@ -128,6 +128,20 @@ val decoded = codec.deserialize("events", bytes)
 
 Jackson codec은 `bluetape4k-jackson3`와 `tools.jackson.*` API를 사용합니다.
 
+### Poison-pill 정책
+
+`AbstractKafkaCodec.deserialize` 는 명시적인 poison-pill 정책을 가진다.
+
+| Throwable 종류        | 동작                                                |
+|-----------------------|-----------------------------------------------------|
+| 일반 `Exception`      | WARN 로그 + `null` 반환 (consumer 루프 진행 보장)   |
+| `CancellationException` | **재던짐** — 코루틴 취소 신호 보존                   |
+| `Error` (OOM, StackOverflow 등) | **전파** — JVM 손상 상태를 은폐하지 않음        |
+
+영구 손실을 막으려면 Spring-Kafka 의 `ErrorHandlingDeserializer` +
+`DeadLetterPublishingRecoverer` 와 함께 사용하여 poison record 를 DLQ 토픽으로
+라우팅하라.
+
 ## Embedded Kafka 테스트
 
 Spring Kafka 4의 embedded broker는 KRaft 전용입니다. Spring Kafka 3 전환기에 쓰던

--- a/infra/kafka4/README.md
+++ b/infra/kafka4/README.md
@@ -129,6 +129,20 @@ val decoded = codec.deserialize("events", bytes)
 
 The Jackson codec uses `bluetape4k-jackson3` and `tools.jackson.*` APIs.
 
+### Poison-pill Policy
+
+`AbstractKafkaCodec.deserialize` exposes a documented poison-pill policy:
+
+| Throwable type        | Behavior                                         |
+|-----------------------|--------------------------------------------------|
+| Generic `Exception`   | WARN log + return `null` (consumer loop continues) |
+| `CancellationException` | **Rethrown** — coroutine cancellation is preserved |
+| `Error` (OOM, StackOverflow, …) | **Propagated** — JVM corruption is not hidden |
+
+For permanent loss prevention, combine with Spring-Kafka's
+`ErrorHandlingDeserializer` and `DeadLetterPublishingRecoverer` to route
+poisoned records to a DLQ topic.
+
 ## Embedded Kafka Tests
 
 Spring Kafka 4 embedded brokers are KRaft-only. Do not use `kraft = true`; that

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
@@ -7,6 +7,7 @@ import io.bluetape4k.logging.warn
 import io.bluetape4k.support.classIsPresent
 import io.bluetape4k.support.toUtf8Bytes
 import io.bluetape4k.support.toUtf8String
+import kotlinx.coroutines.CancellationException
 import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.serialization.Deserializer
 import org.apache.kafka.common.serialization.Serializer
@@ -97,6 +98,22 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
             doSerialize(topic, headers, this)
         }
 
+    /**
+     * 헤더의 [VALUE_TYPE_KEY] 를 참조해 역직렬화한다.
+     *
+     * **Poison-pill 정책**:
+     * - `Exception` 발생 시 WARN 로그를 남기고 `null` 을 반환해 컨슈머 루프 진행을 막지 않는다.
+     * - 영구 손실을 막으려면 Spring-Kafka 의 `ErrorHandlingDeserializer` + `DeadLetterPublishingRecoverer` 를 함께 사용하라.
+     *
+     * **흡수하지 않는 예외**:
+     * - [CancellationException] — 항상 재던진다 (코루틴 취소 신호 보존).
+     * - [Error] (OOM/StackOverflow 등) — JVM 상태가 손상된 상황에서 swallow 하면 위험하므로 그대로 전파한다.
+     *
+     * ```kotlin
+     * val codec = KafkaCodecs.Jackson
+     * val payload = codec.deserialize("orders", headers, bytes) // null 이면 poison pill — 메트릭/DLQ 로 라우팅 권장
+     * ```
+     */
     override fun deserialize(
         topic: String?,
         headers: Headers?,
@@ -104,8 +121,12 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
     ): T? =
         try {
             data?.run { doDeserialize(topic, headers, this) }
-        } catch (e: Throwable) {
-            log.warn(e) { "Fail to deserialize data. topic=$topic, headerKeys=${headers?.map { it.key() }}, data=$data. Returning null (poison pill skipped)." }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) {
+                "Fail to deserialize data. topic=$topic, headerKeys=${headers?.map { it.key() }}, dataSize=${data?.size}. Returning null (poison pill skipped)."
+            }
             null
         }
 

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/StringKafkaCodec.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/StringKafkaCodec.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.kafka.codec
 
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
 import org.apache.kafka.common.header.Headers
 import java.nio.charset.Charset
 
@@ -59,11 +60,7 @@ class StringKafkaCodec: AbstractKafkaCodec<String>() {
     ): Charset {
         val propertyName = if (isKey) KEY_SERIALIZER_ENCODING else VALUE_SERIALIZER_ENCODING
         val encodingValue = configs[propertyName] ?: configs[SERIALIZER_ENCODING]
-
-        return when (encodingValue) {
-            is String -> runCatching { Charset.forName(encodingValue) }.getOrDefault(DefaultEncoding)
-            else -> DefaultEncoding
-        }
+        return resolveCharsetOrDefault(encodingValue, propertyName)
     }
 
     private fun getDeserializerEncoding(
@@ -72,10 +69,23 @@ class StringKafkaCodec: AbstractKafkaCodec<String>() {
     ): Charset {
         val propertyName = if (isKey) KEY_DESERIALIZER_ENCODING else VALUE_DESERIALIZER_ENCODING
         val encodingValue = configs[propertyName] ?: configs[DESERIALIZER_ENCODING]
+        return resolveCharsetOrDefault(encodingValue, propertyName)
+    }
 
-        return when (encodingValue) {
-            is String -> runCatching { Charset.forName(encodingValue) }.getOrDefault(DefaultEncoding)
+    /**
+     * 설정값을 [Charset] 으로 변환한다. 잘못된 charset 명이면 [DefaultEncoding] 으로 fallback 하되,
+     * silent fallback 으로 producer/consumer 인코딩 불일치(mojibake) 가 디버깅 불가능해지지 않도록 WARN 을 남긴다.
+     */
+    private fun resolveCharsetOrDefault(value: Any?, propertyName: String): Charset =
+        when (value) {
+            is String -> runCatching { Charset.forName(value) }
+                .onFailure { e ->
+                    log.warn(e) {
+                        "Invalid charset name. property=$propertyName, value=$value. " +
+                            "Falling back to ${DefaultEncoding.name()}. Producer/consumer 인코딩 불일치 위험을 확인하세요."
+                    }
+                }
+                .getOrDefault(DefaultEncoding)
             else -> DefaultEncoding
         }
-    }
 }

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplate.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplate.kt
@@ -1,6 +1,8 @@
 package io.bluetape4k.kafka.spring.core
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.error
+import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requireNotEmpty
 import kotlinx.coroutines.CoroutineScope
@@ -495,7 +497,14 @@ class SuspendKafkaConsumerTemplate<K, V> private constructor(
     private fun doClose() {
         if (closed.compareAndSet(false, true)) {
             scope.cancel("SuspendKafkaConsumerTemplate closed")
-            (receiver as? AutoCloseable)?.close()
+            val closeable = receiver as? AutoCloseable
+            if (closeable == null) {
+                // reactor-kafka 의 KafkaReceiver 가 AutoCloseable 을 구현하지 않은 경우 — 자원 누수 가능성을 명시적으로 노출한다.
+                log.warn { "KafkaReceiver does not implement AutoCloseable; underlying Kafka consumer connection may leak. receiverClass=${receiver.javaClass.name}" }
+            } else {
+                runCatching { closeable.close() }
+                    .onFailure { e -> log.error(e) { "Failed to close KafkaReceiver. receiverClass=${receiver.javaClass.name}" } }
+            }
         }
     }
 }

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/AbstractKafkaCodecPoisonPillTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/AbstractKafkaCodecPoisonPillTest.kt
@@ -1,0 +1,67 @@
+package io.bluetape4k.kafka.codec
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.CancellationException
+import org.amshove.kluent.internal.assertFailsWith
+import org.amshove.kluent.shouldBeNull
+import org.apache.kafka.common.header.Headers
+import org.apache.kafka.common.header.internals.RecordHeaders
+import org.junit.jupiter.api.Test
+
+/**
+ * [AbstractKafkaCodec.deserialize] 의 poison-pill 정책과 예외 통과 정책을 검증한다.
+ *
+ * - 일반 [Exception] → WARN 로그 + null 반환 (consumer 루프 진행 보장)
+ * - [CancellationException] → 항상 재던짐 (코루틴 취소 신호 보존)
+ * - [Error] → 그대로 전파 (JVM 손상 상태 은폐 금지)
+ */
+class AbstractKafkaCodecPoisonPillTest {
+
+    companion object: KLoggingChannel()
+
+    private class FakeException: RuntimeException("fake deserialize failure")
+
+    private class ThrowingCodec(private val toThrow: Throwable): AbstractKafkaCodec<String>() {
+        override fun doSerialize(topic: String?, headers: Headers?, graph: String): ByteArray =
+            graph.toByteArray()
+
+        override fun doDeserialize(topic: String?, headers: Headers?, bytes: ByteArray): String? {
+            throw toThrow
+        }
+    }
+
+    @Test
+    fun `general Exception is swallowed and returns null`() {
+        val codec = ThrowingCodec(FakeException())
+        val headers = RecordHeaders()
+        val result = codec.deserialize("test-topic", headers, byteArrayOf(1, 2, 3))
+        result.shouldBeNull()
+    }
+
+    @Test
+    fun `CancellationException is rethrown not swallowed`() {
+        val codec = ThrowingCodec(CancellationException("coroutine cancelled"))
+        val headers = RecordHeaders()
+        assertFailsWith<CancellationException> {
+            codec.deserialize("test-topic", headers, byteArrayOf(1, 2, 3))
+        }
+    }
+
+    @Test
+    fun `Error is propagated not swallowed`() {
+        val codec = ThrowingCodec(OutOfMemoryError("simulated"))
+        val headers = RecordHeaders()
+        assertFailsWith<OutOfMemoryError> {
+            codec.deserialize("test-topic", headers, byteArrayOf(1, 2, 3))
+        }
+    }
+
+    @Test
+    fun `null data returns null without invoking doDeserialize`() {
+        // doDeserialize 가 호출되면 예외가 던져지므로, null 입력에서 doDeserialize 가 호출되지 않음을 보장
+        val codec = ThrowingCodec(FakeException())
+        val headers = RecordHeaders()
+        val result = codec.deserialize("test-topic", headers, null as ByteArray?)
+        result.shouldBeNull()
+    }
+}


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix(kafka4): 6-tier 코드리뷰 후속 — CancellationException 보존 + silent fallback 가시화

## Background

24시간 내 추가된 `bluetape4k-kafka4` 모듈에 대해 `bluetape4k-design` 의 6-tier 리뷰 게이트를 완성한다. 이전 fix 커밋(179444804)이 4-tier(code-reviewer / security-reviewer / pr-test-analyzer / comment-analyzer)만 적용했으므로, 누락된 Tier 2/3/5/6 (Ops/SRE, structural, silent-failure, performance) 를 병렬 실행하여 CRITICAL/HIGH 항목을 처리했다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: CRITICAL

- **AbstractKafkaCodec.deserialize 가 `catch (e: Throwable)` 로 모든 예외를 흡수**
  - `CancellationException` swallow → 코루틴 취소 신호 손실 (스코프 누수)
  - `OutOfMemoryError` 등 JVM 손상 신호도 WARN 로그 한 줄로 은폐
  - **수정**: `CancellationException` 재던짐, `Error` 미catch, 일반 `Exception` 만 poison-pill 처리

### 기존 섹션: HIGH

| 위치 | 문제 | 수정 |
|------|------|------|
| `KafkaCodec.kt:108` | WARN 로그가 ByteArray 식별 해시 (`data=$data`) 기록 — 진단 가치 0, 포이즌 폭주 시 비용 큼 | `dataSize=${data?.size}` |
| `SuspendKafkaConsumerTemplate.kt:498` | `(receiver as? AutoCloseable)?.close()` — KafkaReceiver 미구현 시 close skip → connection leak | 미구현 시 WARN, 실패 시 ERROR 로그 |
| `StringKafkaCodec.kt:64,77` | `runCatching { Charset.forName(...) }.getOrDefault(UTF_8)` — `\"UTC-8\"` 같은 오타가 silent UTF-8 fallback 으로 mojibake 디버깅 불가 | fallback 시 WARN 로그로 가시화 |

### 기존 섹션: KDoc 강화

- `AbstractKafkaCodec.deserialize` 에 poison-pill 정책 KDoc + 사용 예제 추가
  - Exception → null
  - CancellationException → rethrow
  - Error → propagate
  - DLQ 라우팅 권장사항 명시

### 기존 섹션: README

`infra/kafka4/README.md` + `README.ko.md` 에 **Poison-pill Policy** 표 + DLQ 권장사항 추가.

### 기존 섹션: 후속 과제 (이 PR 범위 외)

별도 Issue 로 등록:
- `KafkaCodec.getValueType` 의 `Class.forName` 실패 시 `Any::class.java` 다운그레이드 (silent class-loading 문제 은폐)
- `SuspendKafkaProducerTemplate.doClose()` 의 `sender.close()` 예외 무처리
- `KafkaCodec.setValueType` 이 매 record 헤더에 FQN 기록 (perf + 동적 클래스 로딩 보안)
- `BinaryKafkaCodecs` (LZ4/Snappy/Zstd) 의 decompression 크기 제한 부재 (kafka3 도 동일한 선행 이슈)

## Validation

새 테스트 클래스: `AbstractKafkaCodecPoisonPillTest`
- ✅ `general Exception is swallowed and returns null`
- ✅ `CancellationException is rethrown not swallowed`
- ✅ `Error is propagated not swallowed` (OOM 시뮬레이션)
- ✅ `null data returns null without invoking doDeserialize`

```bash
./gradlew :bluetape4k-kafka4:compileKotlin    # BUILD SUCCESSFUL (24s)
./gradlew :bluetape4k-kafka4:test             # 255 passing (이전 251 + 새 4) (42.8s)
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #302, head `80fc2528a298e25c45eeb94fc8e38ad95bb15798`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `okclaude/kafka4-6tier-followup`
- Labels: `bug`
- State: `MERGED`, merge commit `25f10f94c440503677b2370162a934f7ff505af7`
- CI: ./gradlew :bluetape4k-kafka4:compileKotlin    # BUILD SUCCESSFUL (24s) / ./gradlew :bluetape4k-kafka4:test             # 255 passing (이전 251 + 새 4) (42.8s)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #302 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `25f10f94c440503677b2370162a934f7ff505af7`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
