### PR TITLE
feat: Wave1 보안 패치 — RCE allowlist, Snappy decompression bomb, JdkKafkaCodec 지원 중단

### DIFF
--- a/infra/kafka/README.ko.md
+++ b/infra/kafka/README.ko.md
@@ -157,7 +157,7 @@ val compressed = lz4KryoCodec.serialize("test-topic", largeObject)
 | `KafkaCodecs.String`    | UTF-8 문자열 직렬화        |
 | `KafkaCodecs.ByteArray` | 바이트 배열 직접 전달         |
 | `KafkaCodecs.Jackson`   | JSON 직렬화             |
-| `KafkaCodecs.Jdk`       | **사용 중단** — Java 직렬화 (RCE 위험, Kryo 사용 권장) |
+| `KafkaCodecs.Jdk`       | **사용 중단** — Java 직렬화 (RCE 위험, Fory 사용 권장) |
 | `KafkaCodecs.Kryo`      | Kryo 바이너리 직렬화        |
 | `KafkaCodecs.Fory`      | Fory 바이너리 직렬화 (고성능, 권장) |
 | `KafkaCodecs.LZ4Jdk`    | LZ4 압축 + Java 직렬화    |

--- a/infra/kafka/README.ko.md
+++ b/infra/kafka/README.ko.md
@@ -157,13 +157,35 @@ val compressed = lz4KryoCodec.serialize("test-topic", largeObject)
 | `KafkaCodecs.String`    | UTF-8 문자열 직렬화        |
 | `KafkaCodecs.ByteArray` | 바이트 배열 직접 전달         |
 | `KafkaCodecs.Jackson`   | JSON 직렬화             |
-| `KafkaCodecs.Jdk`       | Java 직렬화             |
+| `KafkaCodecs.Jdk`       | **사용 중단** — Java 직렬화 (RCE 위험, Kryo 사용 권장) |
 | `KafkaCodecs.Kryo`      | Kryo 바이너리 직렬화        |
-| `KafkaCodecs.Fory`      | FST 바이너리 직렬화         |
+| `KafkaCodecs.Fory`      | Fory 바이너리 직렬화 (고성능, 권장) |
 | `KafkaCodecs.LZ4Jdk`    | LZ4 압축 + Java 직렬화    |
 | `KafkaCodecs.Lz4Kryo`   | LZ4 압축 + Kryo 직렬화    |
 | `KafkaCodecs.SnappyJdk` | Snappy 압축 + Java 직렬화 |
 | `KafkaCodecs.ZstdKryo`  | Zstd 압축 + Kryo 직렬화   |
+
+#### 보안: 클래스 로딩 허용 목록
+
+`AbstractKafkaCodec` 은 Kafka 헤더 `bluetape4k.kafka.codec.value.type` 에서
+역직렬화 대상 클래스를 로드합니다. 공격자가 이 헤더를 조작하면 임의 클래스 로딩(RCE)이
+가능합니다.
+
+`allowedTypePackages` 를 오버라이드하여 로드 가능한 패키지를 제한하세요:
+
+```kotlin
+class SecureJacksonCodec : JacksonKafkaCodec() {
+    override val allowedTypePackages = setOf(
+        "com.example.dto",
+        "io.bluetape4k.domain",
+    )
+}
+```
+
+| `allowedTypePackages` 값 | 동작 |
+|--------------------------|------|
+| `emptySet()` (기본값) | 모든 클래스 허용 — 하위 호환, 신뢰 환경 전용 |
+| 비어 있지 않은 집합 | 나열된 패키지 하위 클래스만 허용; 그 외 poison-pill `null` |
 
 ### 5. Spring KafkaTemplate과 Coroutines
 

--- a/infra/kafka/README.md
+++ b/infra/kafka/README.md
@@ -157,7 +157,7 @@ Available codecs:
 | `KafkaCodecs.String`    | UTF-8 string serialization              |
 | `KafkaCodecs.ByteArray` | Raw byte array passthrough              |
 | `KafkaCodecs.Jackson`   | JSON serialization                      |
-| `KafkaCodecs.Jdk`       | **Deprecated** — JDK serialization (RCE risk, use Kryo) |
+| `KafkaCodecs.Jdk`       | **Deprecated** — JDK serialization (RCE risk, use Fory) |
 | `KafkaCodecs.Kryo`      | Kryo binary serialization               |
 | `KafkaCodecs.Fory`      | FST binary serialization                |
 | `KafkaCodecs.LZ4Jdk`    | LZ4 compression + Java serialization    |

--- a/infra/kafka/README.md
+++ b/infra/kafka/README.md
@@ -157,13 +157,35 @@ Available codecs:
 | `KafkaCodecs.String`    | UTF-8 string serialization              |
 | `KafkaCodecs.ByteArray` | Raw byte array passthrough              |
 | `KafkaCodecs.Jackson`   | JSON serialization                      |
-| `KafkaCodecs.Jdk`       | Java serialization                      |
+| `KafkaCodecs.Jdk`       | **Deprecated** — JDK serialization (RCE risk, use Kryo) |
 | `KafkaCodecs.Kryo`      | Kryo binary serialization               |
 | `KafkaCodecs.Fory`      | FST binary serialization                |
 | `KafkaCodecs.LZ4Jdk`    | LZ4 compression + Java serialization    |
 | `KafkaCodecs.Lz4Kryo`   | LZ4 compression + Kryo serialization    |
 | `KafkaCodecs.SnappyJdk` | Snappy compression + Java serialization |
 | `KafkaCodecs.ZstdKryo`  | Zstd compression + Kryo serialization   |
+
+#### Security: Class Loading Allowlist
+
+`AbstractKafkaCodec` loads the deserialization target class from the Kafka
+header `bluetape4k.kafka.codec.value.type`. If that header can be set by an
+attacker, arbitrary class loading (RCE) is possible.
+
+Override `allowedTypePackages` to restrict which packages may be loaded:
+
+```kotlin
+class SecureJacksonCodec : JacksonKafkaCodec() {
+    override val allowedTypePackages = setOf(
+        "com.example.dto",
+        "io.bluetape4k.domain",
+    )
+}
+```
+
+| `allowedTypePackages` value | Effect |
+|-----------------------------|--------|
+| `emptySet()` (default) | All classes allowed — backward-compatible, trusted environments only |
+| Non-empty set | Only classes under listed package prefixes allowed; others → poison-pill `null` |
 
 ### 5. Spring KafkaTemplate with Coroutines
 

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
@@ -32,7 +32,7 @@ abstract class BinaryKafkaCodec(
  * JDK 직렬화를 이용한 Kafka Codec
  *
  * **보안 경고**: JDK 직렬화는 역직렬화 과정에서 임의 코드 실행(RCE) 취약점이 있습니다.
- * [KryoKafkaCodec] 또는 [JacksonKafkaCodec]을 사용하십시오.
+ * 성능과 보안 모두 우수한 [ForyKafkaCodec]을 사용하십시오.
  *
  * ```kotlin
  * val codec = JdkKafkaCodec()
@@ -42,8 +42,8 @@ abstract class BinaryKafkaCodec(
  * ```
  */
 @Deprecated(
-    message = "JDK 직렬화는 역직렬화 과정에서 임의 코드 실행(RCE) 취약점이 있습니다. KryoKafkaCodec 또는 JacksonKafkaCodec을 사용하세요.",
-    replaceWith = ReplaceWith("KryoKafkaCodec()")
+    message = "JDK 직렬화는 역직렬화 과정에서 임의 코드 실행(RCE) 취약점이 있습니다. 성능과 보안 모두 우수한 ForyKafkaCodec을 사용하세요.",
+    replaceWith = ReplaceWith("ForyKafkaCodec()")
 )
 class JdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.Jdk)
 

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
@@ -31,6 +31,9 @@ abstract class BinaryKafkaCodec(
 /**
  * JDK 직렬화를 이용한 Kafka Codec
  *
+ * **보안 경고**: JDK 직렬화는 역직렬화 과정에서 임의 코드 실행(RCE) 취약점이 있습니다.
+ * [KryoKafkaCodec] 또는 [JacksonKafkaCodec]을 사용하십시오.
+ *
  * ```kotlin
  * val codec = JdkKafkaCodec()
  * val bytes = codec.serialize("topic", null, "hello")
@@ -38,6 +41,10 @@ abstract class BinaryKafkaCodec(
  * // result == "hello"
  * ```
  */
+@Deprecated(
+    message = "JDK 직렬화는 역직렬화 과정에서 임의 코드 실행(RCE) 취약점이 있습니다. KryoKafkaCodec 또는 JacksonKafkaCodec을 사용하세요.",
+    replaceWith = ReplaceWith("KryoKafkaCodec()")
+)
 class JdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.Jdk)
 
 /**

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
@@ -2,7 +2,6 @@ package io.bluetape4k.kafka.codec
 
 import io.bluetape4k.LibraryName
 import io.bluetape4k.logging.KLogging
-import io.bluetape4k.logging.error
 import io.bluetape4k.logging.warn
 import io.bluetape4k.support.classIsPresent
 import io.bluetape4k.support.toUtf8Bytes
@@ -64,8 +63,8 @@ interface KafkaCodec<T>:
  *
  * **보안 경고**: 이 코덱은 Kafka 헤더의 `bluetape4k.kafka.codec.value.type` 값을 기반으로
  * 클래스를 동적으로 로드합니다. 신뢰할 수 없는 Kafka 브로커 또는 외부 네트워크에서
- * 수신된 메시지에 이 코덱을 사용하면 임의 클래스 로딩 취약점이 발생할 수 있습니다.
- * 반드시 신뢰할 수 있는 내부 Kafka 브로커 환경에서만 사용하십시오.
+ * 수신된 메시지에 이 코덱을 사용하면 임의 클래스 로딩(RCE) 취약점이 발생할 수 있습니다.
+ * 보안이 필요한 환경에서는 반드시 [allowedTypePackages]에 허용된 패키지를 지정하십시오.
  */
 abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
     companion object: KLogging() {
@@ -74,6 +73,20 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
         @JvmStatic
         fun defaultCodec(): KafkaCodec<Any?> = JacksonKafkaCodec()
     }
+
+    /**
+     * 헤더에서 로드를 허용하는 클래스 패키지 접두사 목록.
+     *
+     * - **빈 집합(기본값)**: 모든 클래스 허용 (하위 호환, 신뢰 환경 전용)
+     * - **비어 있지 않은 집합**: 나열된 패키지로 시작하는 클래스만 허용 (권장, 보안 환경)
+     *
+     * ```kotlin
+     * class SecureJacksonCodec: JacksonKafkaCodec() {
+     *     override val allowedTypePackages = setOf("com.example.dto", "io.bluetape4k.domain")
+     * }
+     * ```
+     */
+    open val allowedTypePackages: Set<String> = emptySet()
 
     protected abstract fun doSerialize(
         topic: String?,
@@ -121,18 +134,20 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
             headers?.lastHeader(VALUE_TYPE_KEY)?.value()?.toUtf8String()
                 ?: return Any::class.java
 
+        if (allowedTypePackages.isNotEmpty() && allowedTypePackages.none { clazzName.startsWith(it) }) {
+            throw IllegalArgumentException(
+                "클래스 '$clazzName'은 허용된 패키지 목록에 없습니다. allowedTypePackages=$allowedTypePackages"
+            )
+        }
+
+        if (!classIsPresent(clazzName)) {
+            throw IllegalArgumentException("클래스를 클래스패스에서 찾을 수 없습니다. clazzName=$clazzName")
+        }
+
         return try {
-            when {
-                classIsPresent(clazzName) -> {
-                    Class.forName(clazzName, false, Thread.currentThread().contextClassLoader)
-                }
-                else -> {
-                    Any::class.java
-                }
-            }
+            Class.forName(clazzName, false, Thread.currentThread().contextClassLoader)
         } catch (e: Exception) {
-            log.error(e) { "Fail to load value type. clazzName=$clazzName" }
-            Any::class.java
+            throw IllegalArgumentException("클래스 로딩 실패. clazzName=$clazzName", e)
         }
     }
 }

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.logging.warn
 import io.bluetape4k.support.classIsPresent
 import io.bluetape4k.support.toUtf8Bytes
 import io.bluetape4k.support.toUtf8String
+import kotlinx.coroutines.CancellationException
 import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.serialization.Deserializer
 import org.apache.kafka.common.serialization.Serializer
@@ -110,6 +111,22 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
             doSerialize(topic, headers, this)
         }
 
+    /**
+     * 헤더의 [VALUE_TYPE_KEY] 를 참조해 역직렬화한다.
+     *
+     * **Poison-pill 정책**:
+     * - `Exception` 발생 시 WARN 로그를 남기고 `null` 을 반환해 컨슈머 루프 진행을 막지 않는다.
+     * - 영구 손실을 막으려면 Spring-Kafka 의 `ErrorHandlingDeserializer` + `DeadLetterPublishingRecoverer` 를 함께 사용하라.
+     *
+     * **흡수하지 않는 예외**:
+     * - [CancellationException] — 항상 재던진다 (코루틴 취소 신호 보존).
+     * - [Error] (OOM/StackOverflow 등) — JVM 상태가 손상된 상황에서 swallow 하면 위험하므로 그대로 전파한다.
+     *
+     * ```kotlin
+     * val codec = KafkaCodecs.Jackson
+     * val payload = codec.deserialize("orders", headers, bytes) // null 이면 poison pill — 메트릭/DLQ 로 라우팅 권장
+     * ```
+     */
     override fun deserialize(
         topic: String?,
         headers: Headers?,
@@ -117,8 +134,12 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
     ): T? =
         try {
             data?.run { doDeserialize(topic, headers, this) }
-        } catch (e: Throwable) {
-            log.warn(e) { "Fail to deserialize data. topic=$topic, headerKeys=${headers?.map { it.key() }}, data=$data. Returning null (poison pill skipped)." }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) {
+                "Fail to deserialize data. topic=$topic, headerKeys=${headers?.map { it.key() }}, dataSize=${data?.size}. Returning null (poison pill skipped)."
+            }
             null
         }
 
@@ -134,7 +155,9 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
             headers?.lastHeader(VALUE_TYPE_KEY)?.value()?.toUtf8String()
                 ?: return Any::class.java
 
-        if (allowedTypePackages.isNotEmpty() && allowedTypePackages.none { clazzName.startsWith(it) }) {
+        if (allowedTypePackages.isNotEmpty() &&
+            allowedTypePackages.none { clazzName == it || clazzName.startsWith("$it.") }
+        ) {
             throw IllegalArgumentException(
                 "클래스 '$clazzName'은 허용된 패키지 목록에 없습니다. allowedTypePackages=$allowedTypePackages"
             )

--- a/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/codec/AbstractKafkaCodecPoisonPillTest.kt
+++ b/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/codec/AbstractKafkaCodecPoisonPillTest.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.kafka.codec
 
-import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.KLogging
 import kotlinx.coroutines.CancellationException
 import org.amshove.kluent.shouldBeNull
 import org.apache.kafka.common.header.Headers
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 /**
- * [AbstractKafkaCodec.deserialize] 의 poison-pill 정책과 예외 통과 정책을 검증한다.
+ * [AbstractKafkaCodec.deserialize] 의 poison-pill 정책과 예외 통과 정책을 검증한다 (kafka3).
  *
  * - 일반 [Exception] → WARN 로그 + null 반환 (consumer 루프 진행 보장)
  * - [CancellationException] → 항상 재던짐 (코루틴 취소 신호 보존)
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.assertThrows
  */
 class AbstractKafkaCodecPoisonPillTest {
 
-    companion object: KLoggingChannel()
+    companion object: KLogging()
 
     private class FakeException: RuntimeException("fake deserialize failure")
 
@@ -58,7 +58,6 @@ class AbstractKafkaCodecPoisonPillTest {
 
     @Test
     fun `null data returns null without invoking doDeserialize`() {
-        // doDeserialize 가 호출되면 예외가 던져지므로, null 입력에서 doDeserialize 가 호출되지 않음을 보장
         val codec = ThrowingCodec(FakeException())
         val headers = RecordHeaders()
         val result = codec.deserialize("test-topic", headers, null as ByteArray?)

--- a/infra/kafka4/README.ko.md
+++ b/infra/kafka4/README.ko.md
@@ -142,6 +142,36 @@ Jackson codec은 `bluetape4k-jackson3`와 `tools.jackson.*` API를 사용합니�
 `DeadLetterPublishingRecoverer` 와 함께 사용하여 poison record 를 DLQ 토픽으로
 라우팅하라.
 
+### 보안: 클래스 로딩 허용 목록
+
+`AbstractKafkaCodec` 은 Kafka 헤더 `bluetape4k.kafka.codec.value.type` 에서
+역직렬화 대상 클래스를 로드합니다. 이 헤더를 공격자가 조작할 수 있는 환경(신뢰할 수
+없는 브로커, 외부 네트워크)에서는 임의 클래스 로딩(RCE)이 가능합니다.
+
+`allowedTypePackages` 를 오버라이드하여 로드 가능한 패키지를 제한하세요:
+
+```kotlin
+class SecureJacksonCodec : JacksonKafkaCodec() {
+    override val allowedTypePackages = setOf(
+        "com.example.dto",
+        "io.bluetape4k.domain",
+    )
+}
+```
+
+| `allowedTypePackages` 값 | 동작 |
+|--------------------------|------|
+| `emptySet()` (기본값) | 모든 클래스 허용 — 하위 호환, 신뢰 환경 전용 |
+| 비어 있지 않은 집합 | 나열된 패키지 하위 클래스만 허용; 그 외 `IllegalArgumentException` → poison-pill (`null`) |
+
+> **경고:** 기본값 `emptySet()` 은 하위 호환성을 위해 모든 클래스 로딩을 허용합니다.
+> Kafka 브로커를 완전히 신뢰할 수 없는 프로덕션 환경에서는 반드시 명시적 패키지를 지정하십시오.
+
+### 보안: JdkKafkaCodec 지원 중단
+
+`JdkKafkaCodec` 은 JDK 역직렬화 RCE 위험으로 인해 `@Deprecated` 처리되었습니다.
+`KryoKafkaCodec` 또는 `JacksonKafkaCodec` 을 사용하세요.
+
 ## Embedded Kafka 테스트
 
 Spring Kafka 4의 embedded broker는 KRaft 전용입니다. Spring Kafka 3 전환기에 쓰던

--- a/infra/kafka4/README.ko.md
+++ b/infra/kafka4/README.ko.md
@@ -170,7 +170,7 @@ class SecureJacksonCodec : JacksonKafkaCodec() {
 ### 보안: JdkKafkaCodec 지원 중단
 
 `JdkKafkaCodec` 은 JDK 역직렬화 RCE 위험으로 인해 `@Deprecated` 처리되었습니다.
-`KryoKafkaCodec` 또는 `JacksonKafkaCodec` 을 사용하세요.
+성능과 보안 모두 우수한 `ForyKafkaCodec` 을 사용하세요.
 
 ## Embedded Kafka 테스트
 

--- a/infra/kafka4/README.md
+++ b/infra/kafka4/README.md
@@ -143,6 +143,38 @@ For permanent loss prevention, combine with Spring-Kafka's
 `ErrorHandlingDeserializer` and `DeadLetterPublishingRecoverer` to route
 poisoned records to a DLQ topic.
 
+### Security: Class Loading Allowlist
+
+`AbstractKafkaCodec` loads the deserialization target class from the Kafka
+header `bluetape4k.kafka.codec.value.type`. If that header can be set by an
+attacker (untrusted broker or external network), arbitrary class loading (RCE)
+is possible.
+
+Override `allowedTypePackages` to restrict which packages may be loaded:
+
+```kotlin
+class SecureJacksonCodec : JacksonKafkaCodec() {
+    override val allowedTypePackages = setOf(
+        "com.example.dto",
+        "io.bluetape4k.domain",
+    )
+}
+```
+
+| `allowedTypePackages` value | Effect |
+|-----------------------------|--------|
+| `emptySet()` (default) | All classes allowed — backward-compatible, trusted environments only |
+| Non-empty set | Only classes under listed package prefixes are allowed; others throw `IllegalArgumentException` → poison-pill (`null`) |
+
+> **Warning:** The default `emptySet()` maintains backward compatibility but
+> allows any class to be loaded. Set explicit packages in production when the
+> Kafka broker is not fully trusted.
+
+### Security: JdkKafkaCodec Deprecated
+
+`JdkKafkaCodec` is deprecated due to JDK deserialization RCE risks. Use
+`KryoKafkaCodec` or `JacksonKafkaCodec` instead.
+
 ## Embedded Kafka Tests
 
 Spring Kafka 4 embedded brokers are KRaft-only. Do not use `kraft = true`; that

--- a/infra/kafka4/README.md
+++ b/infra/kafka4/README.md
@@ -173,7 +173,7 @@ class SecureJacksonCodec : JacksonKafkaCodec() {
 ### Security: JdkKafkaCodec Deprecated
 
 `JdkKafkaCodec` is deprecated due to JDK deserialization RCE risks. Use
-`KryoKafkaCodec` or `JacksonKafkaCodec` instead.
+`ForyKafkaCodec` instead — it is both faster and safer.
 
 ## Embedded Kafka Tests
 

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
@@ -32,7 +32,7 @@ abstract class BinaryKafkaCodec(
  * JDK 직렬화를 이용한 Kafka Codec
  *
  * **보안 경고**: JDK 직렬화는 역직렬화 과정에서 임의 코드 실행(RCE) 취약점이 있습니다.
- * [KryoKafkaCodec] 또는 [JacksonKafkaCodec]을 사용하십시오.
+ * 성능과 보안 모두 우수한 [ForyKafkaCodec]을 사용하십시오.
  *
  * ```kotlin
  * val codec = JdkKafkaCodec()
@@ -42,8 +42,8 @@ abstract class BinaryKafkaCodec(
  * ```
  */
 @Deprecated(
-    message = "JDK 직렬화는 역직렬화 과정에서 임의 코드 실행(RCE) 취약점이 있습니다. KryoKafkaCodec 또는 JacksonKafkaCodec을 사용하세요.",
-    replaceWith = ReplaceWith("KryoKafkaCodec()")
+    message = "JDK 직렬화는 역직렬화 과정에서 임의 코드 실행(RCE) 취약점이 있습니다. 성능과 보안 모두 우수한 ForyKafkaCodec을 사용하세요.",
+    replaceWith = ReplaceWith("ForyKafkaCodec()")
 )
 class JdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.Jdk)
 

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
@@ -31,6 +31,9 @@ abstract class BinaryKafkaCodec(
 /**
  * JDK 직렬화를 이용한 Kafka Codec
  *
+ * **보안 경고**: JDK 직렬화는 역직렬화 과정에서 임의 코드 실행(RCE) 취약점이 있습니다.
+ * [KryoKafkaCodec] 또는 [JacksonKafkaCodec]을 사용하십시오.
+ *
  * ```kotlin
  * val codec = JdkKafkaCodec()
  * val bytes = codec.serialize("topic", null, "hello")
@@ -38,6 +41,10 @@ abstract class BinaryKafkaCodec(
  * // result == "hello"
  * ```
  */
+@Deprecated(
+    message = "JDK 직렬화는 역직렬화 과정에서 임의 코드 실행(RCE) 취약점이 있습니다. KryoKafkaCodec 또는 JacksonKafkaCodec을 사용하세요.",
+    replaceWith = ReplaceWith("KryoKafkaCodec()")
+)
 class JdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.Jdk)
 
 /**

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
@@ -2,7 +2,6 @@ package io.bluetape4k.kafka.codec
 
 import io.bluetape4k.LibraryName
 import io.bluetape4k.logging.KLogging
-import io.bluetape4k.logging.error
 import io.bluetape4k.logging.warn
 import io.bluetape4k.support.classIsPresent
 import io.bluetape4k.support.toUtf8Bytes
@@ -65,8 +64,8 @@ interface KafkaCodec<T>:
  *
  * **보안 경고**: 이 코덱은 Kafka 헤더의 `bluetape4k.kafka.codec.value.type` 값을 기반으로
  * 클래스를 동적으로 로드합니다. 신뢰할 수 없는 Kafka 브로커 또는 외부 네트워크에서
- * 수신된 메시지에 이 코덱을 사용하면 임의 클래스 로딩 취약점이 발생할 수 있습니다.
- * 반드시 신뢰할 수 있는 내부 Kafka 브로커 환경에서만 사용하십시오.
+ * 수신된 메시지에 이 코덱을 사용하면 임의 클래스 로딩(RCE) 취약점이 발생할 수 있습니다.
+ * 보안이 필요한 환경에서는 반드시 [allowedTypePackages]에 허용된 패키지를 지정하십시오.
  */
 abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
     companion object: KLogging() {
@@ -75,6 +74,20 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
         @JvmStatic
         fun defaultCodec(): KafkaCodec<Any?> = JacksonKafkaCodec()
     }
+
+    /**
+     * 헤더에서 로드를 허용하는 클래스 패키지 접두사 목록.
+     *
+     * - **빈 집합(기본값)**: 모든 클래스 허용 (하위 호환, 신뢰 환경 전용)
+     * - **비어 있지 않은 집합**: 나열된 패키지로 시작하는 클래스만 허용 (권장, 보안 환경)
+     *
+     * ```kotlin
+     * class SecureJacksonCodec: JacksonKafkaCodec() {
+     *     override val allowedTypePackages = setOf("com.example.dto", "io.bluetape4k.domain")
+     * }
+     * ```
+     */
+    open val allowedTypePackages: Set<String> = emptySet()
 
     protected abstract fun doSerialize(
         topic: String?,
@@ -142,18 +155,20 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
             headers?.lastHeader(VALUE_TYPE_KEY)?.value()?.toUtf8String()
                 ?: return Any::class.java
 
+        if (allowedTypePackages.isNotEmpty() && allowedTypePackages.none { clazzName.startsWith(it) }) {
+            throw IllegalArgumentException(
+                "클래스 '$clazzName'은 허용된 패키지 목록에 없습니다. allowedTypePackages=$allowedTypePackages"
+            )
+        }
+
+        if (!classIsPresent(clazzName)) {
+            throw IllegalArgumentException("클래스를 클래스패스에서 찾을 수 없습니다. clazzName=$clazzName")
+        }
+
         return try {
-            when {
-                classIsPresent(clazzName) -> {
-                    Class.forName(clazzName, false, Thread.currentThread().contextClassLoader)
-                }
-                else -> {
-                    Any::class.java
-                }
-            }
+            Class.forName(clazzName, false, Thread.currentThread().contextClassLoader)
         } catch (e: Exception) {
-            log.error(e) { "Fail to load value type. clazzName=$clazzName" }
-            Any::class.java
+            throw IllegalArgumentException("클래스 로딩 실패. clazzName=$clazzName", e)
         }
     }
 }

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
@@ -155,7 +155,9 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
             headers?.lastHeader(VALUE_TYPE_KEY)?.value()?.toUtf8String()
                 ?: return Any::class.java
 
-        if (allowedTypePackages.isNotEmpty() && allowedTypePackages.none { clazzName.startsWith(it) }) {
+        if (allowedTypePackages.isNotEmpty() &&
+            allowedTypePackages.none { clazzName == it || clazzName.startsWith("$it.") }
+        ) {
             throw IllegalArgumentException(
                 "클래스 '$clazzName'은 허용된 패키지 목록에 없습니다. allowedTypePackages=$allowedTypePackages"
             )

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/KafkaCodecAllowlistTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/KafkaCodecAllowlistTest.kt
@@ -78,6 +78,27 @@ class KafkaCodecAllowlistTest {
     }
 
     @Test
+    fun `패키지 prefix spoofing 차단 - 허용 패키지와 유사하지만 다른 패키지는 거부`() {
+        // "io.bluetape4k.kafka.codec" 허용 시 "io.bluetape4k.kafka.codecEvil" 차단 검증
+        val openCodec = TestJsonCodec()
+        val restrictedCodec = TestJsonCodec(allowedTypePackages = setOf("io.bluetape4k.kafka.codec"))
+
+        val headers = RecordHeaders()
+        // SimpleMessage 직렬화 후 헤더 값을 spoofing된 패키지명으로 교체
+        val data = SimpleMessage("spoof test")
+        openCodec.serialize(topic, headers, data)
+
+        // 헤더의 VALUE_TYPE_KEY 값을 허용 패키지와 유사한 악의적 패키지명으로 덮어씀
+        val spoofedClass = "io.bluetape4k.kafka.codecEvil.MaliciousClass"
+        headers.remove(AbstractKafkaCodec.VALUE_TYPE_KEY)
+        headers.add(AbstractKafkaCodec.VALUE_TYPE_KEY, spoofedClass.toByteArray(Charsets.UTF_8))
+
+        // startsWith("io.bluetape4k.kafka.codec") = true이지만 패키지 경계(".") 없어서 차단돼야 함
+        val result = restrictedCodec.deserialize(topic, headers, """{"content":"spoof test"}""".toByteArray())
+        result.shouldBeNull()
+    }
+
+    @Test
     fun `헤더에 클래스 정보 없으면 Any 타입으로 역직렬화 성공`() {
         val codec = TestJsonCodec()
         val headers: Headers? = null

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/KafkaCodecAllowlistTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/KafkaCodecAllowlistTest.kt
@@ -1,0 +1,90 @@
+package io.bluetape4k.kafka.codec
+
+import io.bluetape4k.jackson3.Jackson
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.emptyByteArray
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.apache.kafka.common.header.Headers
+import org.apache.kafka.common.header.internals.RecordHeaders
+import org.junit.jupiter.api.Test
+import tools.jackson.databind.json.JsonMapper
+
+/**
+ * [AbstractKafkaCodec.allowedTypePackages] 허용 목록 검증 테스트 (#296/#303).
+ *
+ * - emptySet() 기본값: 모든 클래스 허용 (하위 호환)
+ * - 허용 패키지 지정 시: 목록 외 클래스 → IllegalArgumentException → deserialize null 반환 (poison-pill)
+ * - 허용 패키지에 속하는 클래스: 정상 처리
+ */
+class KafkaCodecAllowlistTest {
+
+    companion object: KLogging()
+
+    private val topic = "test-topic"
+    private val mapper: JsonMapper = Jackson.defaultJsonMapper
+
+    private inner class TestJsonCodec(
+        override val allowedTypePackages: Set<String> = emptySet(),
+    ): AbstractKafkaCodec<Any?>() {
+
+        override fun doSerialize(topic: String?, headers: Headers?, graph: Any?): ByteArray =
+            graph?.let { mapper.writeValueAsBytes(it) } ?: emptyByteArray
+
+        override fun doDeserialize(topic: String?, headers: Headers?, bytes: ByteArray): Any? {
+            val clazz = getValueType(headers)
+            return if (bytes.isEmpty()) null else mapper.readValue(bytes, clazz)
+        }
+    }
+
+    data class SimpleMessage(val content: String)
+
+    @Test
+    fun `emptySet 기본값 - 모든 클래스 허용`() {
+        val codec = TestJsonCodec()
+        val headers = RecordHeaders()
+        val data = SimpleMessage("hello")
+        val bytes = codec.serialize(topic, headers, data)
+
+        val result = codec.deserialize(topic, headers, bytes)
+        result.shouldNotBeNull()
+    }
+
+    @Test
+    fun `제한 코덱 - 허용 패키지 클래스는 정상 처리`() {
+        val codec = TestJsonCodec(allowedTypePackages = setOf("io.bluetape4k.kafka.codec"))
+        val headers = RecordHeaders()
+        val data = SimpleMessage("world")
+        val bytes = codec.serialize(topic, headers, data)
+
+        // SimpleMessage는 io.bluetape4k.kafka.codec 패키지 → 허용됨
+        val result = codec.deserialize(topic, headers, bytes)
+        result.shouldNotBeNull()
+    }
+
+    @Test
+    fun `제한 코덱 - 허용 패키지 외 클래스는 null 반환 (poison-pill)`() {
+        val openCodec = TestJsonCodec()
+        val restrictedCodec = TestJsonCodec(allowedTypePackages = setOf("io.bluetape4k.kafka.codec"))
+
+        // openCodec으로 직렬화 → 헤더에 java.util.LinkedHashMap 타입 주입
+        val headers = RecordHeaders()
+        val data = mapOf("key" to "value")
+        val bytes = openCodec.serialize(topic, headers, data)
+
+        // restrictedCodec은 io.bluetape4k.kafka.codec만 허용 → java.util.* 차단 → null
+        val result = restrictedCodec.deserialize(topic, headers, bytes)
+        result.shouldBeNull()
+    }
+
+    @Test
+    fun `헤더에 클래스 정보 없으면 Any 타입으로 역직렬화 성공`() {
+        val codec = TestJsonCodec()
+        val headers: Headers? = null
+        val bytes = """{"key":"value"}""".toByteArray()
+
+        // 헤더 없음 → getValueType() returns Any::class.java → Jackson이 LinkedHashMap으로 역직렬화
+        val result = codec.deserialize(topic, headers, bytes)
+        result.shouldNotBeNull()
+    }
+}

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/SnappyCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/SnappyCompressor.kt
@@ -20,6 +20,10 @@ import org.xerial.snappy.Snappy
  */
 class SnappyCompressor: AbstractCompressor() {
 
+    companion object {
+        private const val MAX_DECOMPRESSED_SIZE = 256 * 1024 * 1024  // 256 MB
+    }
+
     /**
      * I/O 압축에서 `doCompress` 함수를 제공합니다.
      */
@@ -29,8 +33,17 @@ class SnappyCompressor: AbstractCompressor() {
 
     /**
      * I/O 압축에서 `doDecompress` 함수를 제공합니다.
+     *
+     * 압축 해제 전에 원본 크기를 확인하여 과도한 메모리 할당을 방지합니다 (decompression bomb 방어).
      */
     override fun doDecompress(compressed: ByteArray): ByteArray {
+        val uncompressedSize = Snappy.uncompressedLength(compressed)
+        require(uncompressedSize >= 0) {
+            "uncompressedSize가 음수입니다. 손상된 데이터일 수 있습니다. uncompressedSize=$uncompressedSize"
+        }
+        require(uncompressedSize <= MAX_DECOMPRESSED_SIZE) {
+            "uncompressedSize가 허용 한도(256MB)를 초과합니다. 손상되거나 악의적인 데이터일 수 있습니다. uncompressedSize=$uncompressedSize"
+        }
         return Snappy.uncompress(compressed)
     }
 }

--- a/io/io/src/test/kotlin/io/bluetape4k/io/compressor/SnappyDecompressionBombTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/compressor/SnappyDecompressionBombTest.kt
@@ -1,0 +1,68 @@
+package io.bluetape4k.io.compressor
+
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldNotBeEmpty
+import org.junit.jupiter.api.Test
+import org.xerial.snappy.Snappy
+
+/**
+ * [SnappyCompressor] decompression bomb 방어 테스트.
+ *
+ * - 256MB 초과 uncompressed_length를 선언하는 페이로드에 대해 emptyByteArray 반환 검증
+ * - 정상 데이터는 정상 처리됨 검증
+ * - AbstractCompressor의 예외 → emptyByteArray 변환 정책 경유
+ */
+class SnappyDecompressionBombTest {
+
+    companion object: KLogging()
+
+    private val compressor = SnappyCompressor()
+
+    @Test
+    fun `정상 데이터는 압축 해제 성공`() {
+        val original = "Hello, Snappy! 압축 테스트".toByteArray()
+        val compressed = compressor.compress(original)
+        val restored = compressor.decompress(compressed)
+        restored.shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `decompress - 256MB 초과 선언 페이로드는 emptyByteArray 반환`() {
+        // Snappy 헤더: varint로 인코딩된 uncompressed_length (256MB + 1)
+        // AbstractCompressor.decompress()가 예외를 emptyByteArray로 변환함
+        val fakeCompressed = encodeSnappyHeader(256L * 1024 * 1024 + 1)
+
+        val result = compressor.decompress(fakeCompressed)
+        result.shouldBeEmpty()
+    }
+
+    @Test
+    fun `decompress - 정확히 256MB 이하는 require 통과 (실제 압축 데이터 사용)`() {
+        // 소규모 정상 데이터로 정상 경로 검증 (1MB 미만)
+        val data = ByteArray(1024) { it.toByte() }
+        val compressed = Snappy.compress(data)
+
+        val uncompressedSize = Snappy.uncompressedLength(compressed)
+        assert(uncompressedSize <= 256 * 1024 * 1024) { "테스트 데이터 크기가 한도 초과" }
+
+        val result = compressor.decompress(compressed)
+        result.shouldNotBeEmpty()
+    }
+
+    /**
+     * Snappy 스트림 헤더를 흉내 낸 바이트 배열 생성.
+     * uncompressed_length varint만 포함 — [Snappy.uncompressedLength] 호출로 읽힘.
+     */
+    private fun encodeSnappyHeader(uncompressedSize: Long): ByteArray {
+        val buf = mutableListOf<Byte>()
+        var v = uncompressedSize
+        while (v > 127) {
+            buf.add(((v and 0x7F) or 0x80).toByte())
+            v = v ushr 7
+        }
+        buf.add((v and 0x7F).toByte())
+        buf.addAll(listOf(0, 0, 0, 0, 0).map { it.toByte() })
+        return buf.toByteArray()
+    }
+}


### PR DESCRIPTION
## Summary

Closes #296, #297, #299, #303, #306

- PR 제목: feat: Wave1 보안 패치 — RCE allowlist, Snappy decompression bomb, JdkKafkaCodec 지원 중단

kafka3/kafka4 코덱 및 io 모듈의 보안 취약점 수정. Issues #296, #297, #299, #303, #306 해결.

---

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### #296 / #303: AbstractKafkaCodec — RCE 방어 (allowlist)

`getValueType()`이 Kafka 헤더의 `bluetape4k.kafka.codec.value.type` 값을 `Class.forName()`으로 로드할 때 아무런 제한이 없었음 → 공격자가 헤더를 조작하면 임의 클래스 로딩(RCE) 가능.

**수정:**
- `open val allowedTypePackages: Set<String> = emptySet()` 프로퍼티 추가
  - `emptySet()` (기본값) = 모든 클래스 허용 (하위 호환)
  - 비어 있지 않은 집합 = `"$pkg."` 경계 검사로 prefix spoofing 차단
- allowlist 위반 → `IllegalArgumentException` → poison-pill `null` + WARN 로그
- 클래스 미발견 시 `Any::class.java` silent fallback 제거

```kotlin
class SecureJacksonCodec : JacksonKafkaCodec() {
    override val allowedTypePackages = setOf("com.example.dto", "io.bluetape4k.domain")
}
```

### #297 / #306: SnappyCompressor — decompression bomb 방어

`Snappy.uncompressedLength()` 로 압축 해제 전 원본 크기 확인, 256MB 초과 시 `IllegalArgumentException` (LZ4/Zstd와 동일).

### #299: JdkKafkaCodec — `@Deprecated` 추가

JDK 역직렬화 RCE 위험 경고 + `KryoKafkaCodec` 마이그레이션 안내.

### kafka3 catch(Throwable) → kafka4 parity

`CancellationException` 재던지기 + `Error` 전파 (kafka4와 동일하게 맞춤).

---

### 기존 섹션: 관련 이슈

- Closes #296
- Closes #297
- Closes #299
- Closes #303
- Closes #306
- Opens #308 (`AbstractCompressor` 예외 삼킴 → Wave 2 이후)

## Validation

| 모듈 | 결과 |
|------|------|
| `:bluetape4k-io` | 910 passing |
| `:bluetape4k-kafka4` | 260 passing |
| `:bluetape4k-kafka` | 256 passing |

신규 테스트: `SnappyDecompressionBombTest` (3개), `KafkaCodecAllowlistTest` (5개), `AbstractKafkaCodecPoisonPillTest` kafka3 (4개)

---

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #296, #297, #299, #303, #306, milestone 없음, assignee 없음
- PR: #309, head `3cf02aa1c31d3dc6bf6ea3f797f1f431990e5975`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/kafka-security-wave1`
- Labels: 없음
- State: `MERGED`, merge commit `bc7a4395a4c60506baf588c91873dee171d6a617`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #309 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `bc7a4395a4c60506baf588c91873dee171d6a617`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
