### PR TITLE
fix: Kafka Wave 2 — suspendSend 취소 전파 / doClose 예외 처리 / DLT 테스트 분리 (#300 #301 #304)

### DIFF
--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/coroutines/ProducerCoroutines.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/coroutines/ProducerCoroutines.kt
@@ -1,15 +1,17 @@
 package io.bluetape4k.kafka.coroutines
 
 import io.bluetape4k.coroutines.flow.async
-import io.bluetape4k.coroutines.support.awaitSuspending
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.apache.kafka.clients.producer.Producer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.RecordMetadata
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
  * Coroutine 환경 하에서 Producer를 이용하여 메시지를 producing 합니다.
@@ -32,9 +34,14 @@ import org.apache.kafka.clients.producer.RecordMetadata
  * @param record 발행할 메시지 ([ProducerRecord])
  * @return 발행 결과를 표현하는 [RecordMetadata] instance
  */
-suspend fun <K, V> Producer<K, V>.suspendSend(record: ProducerRecord<K, V>): RecordMetadata {
-    return send(record).awaitSuspending()
-}
+suspend fun <K, V> Producer<K, V>.suspendSend(record: ProducerRecord<K, V>): RecordMetadata =
+    suspendCancellableCoroutine { cont ->
+        val future = send(record) { metadata, exception ->
+            if (exception != null) cont.resumeWithException(exception)
+            else cont.resume(metadata!!)
+        }
+        cont.invokeOnCancellation { future.cancel(true) }
+    }
 
 /**
  * 복수의 [ProducerRecord] 를 producing 하면서, 결과들을 Flow로 반환하도록 합니다.
@@ -124,7 +131,7 @@ suspend fun <K, V> Producer<K, V>.sendAndForget(
     records
         .buffer()
         .async {
-            send(it).awaitSuspending()
+            suspendSend(it)
         }
         // cause != null 이면 에러/취소 — 에러 중 flush() 호출은 불필요한 블로킹을 유발한다
         .onCompletion { cause ->

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
@@ -302,8 +302,11 @@ class SuspendKafkaProducerTemplate<K, V> private constructor(
     private fun doClose() {
         if (closed.compareAndSet(false, true)) {
             scope.cancel("SuspendKafkaProducerTemplate closed")
-            runCatching { sender.close() }
-                .onFailure { e -> log.error(e) { "KafkaSender 종료 중 예외 발생." } }
+            try {
+                sender.close()
+            } catch (e: Exception) {
+                log.error(e) { "KafkaSender 종료 중 예외 발생." }
+            }
         }
     }
 }

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.kafka.spring.core
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.error
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -301,7 +302,8 @@ class SuspendKafkaProducerTemplate<K, V> private constructor(
     private fun doClose() {
         if (closed.compareAndSet(false, true)) {
             scope.cancel("SuspendKafkaProducerTemplate closed")
-            sender.close()
+            runCatching { sender.close() }
+                .onFailure { e -> log.error(e) { "KafkaSender 종료 중 예외 발생." } }
         }
     }
 }

--- a/infra/kafka/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
+++ b/infra/kafka/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
@@ -22,6 +22,7 @@ import org.apache.kafka.common.serialization.BytesDeserializer
 import org.apache.kafka.common.serialization.BytesSerializer
 import org.apache.kafka.common.serialization.StringSerializer
 import org.apache.kafka.common.utils.Bytes
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -135,10 +136,19 @@ class BatchListenerConversionTests {
         val listener5 = this.config.listener5()
         listener5.latch1.await(AWAIT_TIME_SECONDS, TimeUnit.SECONDS).shouldBeTrue()
         listener5.received shouldBeEqualTo listOf(Foo("baz"), Foo("qux"))
+    }
 
-        // FIXME: 역직렬화에 실패하면 DLT 로 보내야 하는데, 최신 버전은 이게 작동을 하지 않는다
-        // listener5.latch2.await(AWAIT_TIME_SECONDS, TimeUnit.SECONDS).shouldBeTrue()
-        // listener5.dlt shouldBeEqualTo "JUNK"
+    @Disabled("DLT 라우팅이 최신 Spring Kafka 버전에서 작동하지 않음 — 추적: GitHub Issue #300")
+    @Test
+    fun `conversion error routes to DLT`() {
+        template.send("blc6", 0, 0, """{ "bar": "baz" }""")
+        template.send("blc6", 0, 0, "JUNK")
+        template.send("blc6", 0, 0, """{ "bar": "qux" }""")
+
+        val listener5 = this.config.listener5()
+        listener5.latch1.await(AWAIT_TIME_SECONDS, TimeUnit.SECONDS).shouldBeTrue()
+        listener5.latch2.await(AWAIT_TIME_SECONDS, TimeUnit.SECONDS).shouldBeTrue()
+        listener5.dlt shouldBeEqualTo "JUNK"
     }
 
     @Configuration

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/coroutines/ProducerCoroutines.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/coroutines/ProducerCoroutines.kt
@@ -1,15 +1,17 @@
 package io.bluetape4k.kafka.coroutines
 
 import io.bluetape4k.coroutines.flow.async
-import io.bluetape4k.coroutines.support.awaitSuspending
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.apache.kafka.clients.producer.Producer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.RecordMetadata
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
  * Coroutine 환경 하에서 Producer를 이용하여 메시지를 producing 합니다.
@@ -32,9 +34,14 @@ import org.apache.kafka.clients.producer.RecordMetadata
  * @param record 발행할 메시지 ([ProducerRecord])
  * @return 발행 결과를 표현하는 [RecordMetadata] instance
  */
-suspend fun <K, V> Producer<K, V>.suspendSend(record: ProducerRecord<K, V>): RecordMetadata {
-    return send(record).awaitSuspending()
-}
+suspend fun <K, V> Producer<K, V>.suspendSend(record: ProducerRecord<K, V>): RecordMetadata =
+    suspendCancellableCoroutine { cont ->
+        val future = send(record) { metadata, exception ->
+            if (exception != null) cont.resumeWithException(exception)
+            else cont.resume(metadata!!)
+        }
+        cont.invokeOnCancellation { future.cancel(true) }
+    }
 
 /**
  * 복수의 [ProducerRecord] 를 producing 하면서, 결과들을 Flow로 반환하도록 합니다.
@@ -124,7 +131,7 @@ suspend fun <K, V> Producer<K, V>.sendAndForget(
     records
         .buffer()
         .async {
-            send(it).awaitSuspending()
+            suspendSend(it)
         }
         // cause != null 이면 에러/취소 — 에러 중 flush() 호출은 불필요한 블로킹을 유발한다
         .onCompletion { cause ->

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
@@ -302,8 +302,11 @@ class SuspendKafkaProducerTemplate<K, V> private constructor(
     private fun doClose() {
         if (closed.compareAndSet(false, true)) {
             scope.cancel("SuspendKafkaProducerTemplate closed")
-            runCatching { sender.close() }
-                .onFailure { e -> log.error(e) { "KafkaSender 종료 중 예외 발생." } }
+            try {
+                sender.close()
+            } catch (e: Exception) {
+                log.error(e) { "KafkaSender 종료 중 예외 발생." }
+            }
         }
     }
 }

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.kafka.spring.core
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.error
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -301,7 +302,8 @@ class SuspendKafkaProducerTemplate<K, V> private constructor(
     private fun doClose() {
         if (closed.compareAndSet(false, true)) {
             scope.cancel("SuspendKafkaProducerTemplate closed")
-            sender.close()
+            runCatching { sender.close() }
+                .onFailure { e -> log.error(e) { "KafkaSender 종료 중 예외 발생." } }
         }
     }
 }

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
@@ -22,6 +22,7 @@ import org.apache.kafka.common.serialization.BytesDeserializer
 import org.apache.kafka.common.serialization.BytesSerializer
 import org.apache.kafka.common.serialization.StringSerializer
 import org.apache.kafka.common.utils.Bytes
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -135,10 +136,19 @@ class BatchListenerConversionTests {
         val listener5 = this.config.listener5()
         listener5.latch1.await(AWAIT_TIME_SECONDS, TimeUnit.SECONDS).shouldBeTrue()
         listener5.received shouldBeEqualTo listOf(Foo("baz"), Foo("qux"))
+    }
 
-        // FIXME: 역직렬화에 실패하면 DLT 로 보내야 하는데, 최신 버전은 이게 작동을 하지 않는다
-        // listener5.latch2.await(AWAIT_TIME_SECONDS, TimeUnit.SECONDS).shouldBeTrue()
-        // listener5.dlt shouldBeEqualTo "JUNK"
+    @Disabled("DLT 라우팅이 최신 Spring Kafka 버전에서 작동하지 않음 — 추적: GitHub Issue #300")
+    @Test
+    fun `conversion error routes to DLT`() {
+        template.send("blc6", 0, 0, """{ "bar": "baz" }""")
+        template.send("blc6", 0, 0, "JUNK")
+        template.send("blc6", 0, 0, """{ "bar": "qux" }""")
+
+        val listener5 = this.config.listener5()
+        listener5.latch1.await(AWAIT_TIME_SECONDS, TimeUnit.SECONDS).shouldBeTrue()
+        listener5.latch2.await(AWAIT_TIME_SECONDS, TimeUnit.SECONDS).shouldBeTrue()
+        listener5.dlt shouldBeEqualTo "JUNK"
     }
 
     @Configuration


### PR DESCRIPTION
## Summary

Closes #300, #301, #304

- PR 제목: fix: Kafka Wave 2 — suspendSend 취소 전파 / doClose 예외 처리 / DLT 테스트 분리 (#300 #301 #304)

Wave 1 (보안 패치, PR #309) 이후 Wave 2 버그 수정 3종을 묶어 처리합니다.  
kafka3 / kafka4 모듈 모두 동일하게 적용했습니다.

---

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 변경 내역

### #301 — `Producer.suspendSend` 코루틴 취소 전파

**문제**  
기존 `send(record).awaitSuspending()` 는 `FutureToCompletableFutureWrapper` 를 내부적으로 사용합니다.  
코루틴이 취소되면 래퍼 `CompletableFuture` 는 cancel 되지만, 실제 Kafka `Future<RecordMetadata>` 의 내부 참조는 래퍼가 소유하고 있어 continuation 이 계속 살아 있습니다.  
즉, 취소 이후에도 continuation 참조가 메모리에 남아 Kafka 브로커 응답을 기다립니다.

**수정**  
callback 기반 `send(record) { metadata, exception -> ... }` API 로 전환 + `suspendCancellableCoroutine` 패턴:

```kotlin
suspend fun <K, V> Producer<K, V>.suspendSend(record: ProducerRecord<K, V>): RecordMetadata =
    suspendCancellableCoroutine { cont ->
        val future = send(record) { metadata, exception ->
            if (exception != null) cont.resumeWithException(exception)
            else cont.resume(metadata!!)
        }
        cont.invokeOnCancellation { future.cancel(true) }
    }
```

> **참고**: `KafkaProducer` 가 `future.cancel(true)` 호출 시 실제 in-flight 네트워크 전송을 중단하지는 않습니다.  
> 이 수정의 핵심은 continuation 누출 제거이며, 취소 즉시 호출자 코루틴이 unblock 됩니다.

`sendAndForget` 내부도 `suspendSend()` 로 통일했습니다.

---

### #304 — `SuspendKafkaProducerTemplate.doClose()` 예외 삼킴

**문제**  
`sender.close()` 에서 예외가 발생하면 스택 언와인드 후 `closed` 플래그 이후 코드가 실행되지 않습니다.

**수정**  
`try/catch(Exception)` 으로 예외를 잡아 ERROR 로그 출력 후 계속 진행:

```kotlin
try {
    sender.close()
} catch (e: Exception) {
    log.error(e) { "KafkaSender 종료 중 예외 발생." }
}
```

> `runCatching` 대신 `catch(Exception)` 을 명시하여 JVM `Error` (`OutOfMemoryError` 등) 와  
> `CancellationException` 은 전파되도록 합니다.

---

### #300 — `BatchListenerConversionTests` DLT silent-pass

**문제**  
`conversion error` 테스트에서 DLT 단언이 `// FIXME` 주석으로 비활성화된 채 테스트가 통과 — 실제 DLT 라우팅 검증 없음.

**수정**  
정상 흐름 검증과 DLT 검증을 분리:

- 기존 `conversion error` 테스트 → 정상 흐름 (`Foo("baz"), Foo("qux")` 수신) 만 검증
- 새 `conversion error routes to DLT` 테스트 → `@Disabled("DLT 라우팅이 최신 Spring Kafka 버전에서 작동하지 않음 — 추적: GitHub Issue #300")`

JUnit 리포트에 skipped 로 명시적으로 표시됩니다.

---

### 기존 섹션: 코드 리뷰 처리

- HIGH: `runCatching` → `try/catch(Exception)` 교체 완료
- MEDIUM: `@Disabled` 이유에 이슈 번호 명시 (`GitHub Issue #300`) 완료

### 기존 섹션: 검증 명령

```bash
./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka:compileTestKotlin
./gradlew :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka4:compileTestKotlin
./gradlew :bluetape4k-kafka:test :bluetape4k-kafka4:test
```

### 기존 섹션: 관련 이슈

Closes #301  
Closes #304  
Closes #300 (pending — DLT 라우팅 수정 시 완전 해결)

## Validation

| 모듈 | passing | pending/disabled | duration |
|------|--------:|:---:|---------|
| `bluetape4k-kafka` (Spring Kafka 3.x) | 256 | 1 | ~39s |
| `bluetape4k-kafka4` (Spring Kafka 4.x) | 260 | 1 | ~41s |

```bash
./gradlew :bluetape4k-kafka:test :bluetape4k-kafka4:test
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #300, #301, #304, milestone 없음, assignee 없음
- PR: #310, head `a947b51d21f2faa586300682eaba22382f7b43d5`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/kafka-bugfix-wave2`
- Labels: `bug`
- State: `MERGED`, merge commit `a8bf132029447c599cd0b858d51cdba0d6ca7b71`
- CI: ./gradlew :bluetape4k-kafka:test :bluetape4k-kafka4:test / ./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka:compileTestKotlin / ./gradlew :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka4:compileTestKotlin

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #310 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `a8bf132029447c599cd0b858d51cdba0d6ca7b71`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
