### PR TITLE
feat: Kafka Wave 3 — 타입 헤더 opt-out, getMetricValue deprecated (Issues #305, #307)

### DIFF
--- a/infra/kafka/README.ko.md
+++ b/infra/kafka/README.ko.md
@@ -171,10 +171,16 @@ val compressed = lz4KryoCodec.serialize("test-topic", largeObject)
 컨슈머가 타입을 정적으로 이미 알고 있다면 비활성화할 수 있습니다:
 
 ```kotlin
-class NoHeaderJacksonCodec : JacksonKafkaCodec() {
+// Fory/Kryo 기반 코덱은 헤더 없이 안전하게 작동합니다
+class NoHeaderForyCodec : ForyKafkaCodec() {
     override val writeValueTypeHeader = false
 }
 ```
+
+> **`JacksonKafkaCodec` 주의**: Jackson은 역직렬화 시 헤더에서 대상 타입을 결정합니다.
+> `doDeserialize`를 함께 오버라이드하지 않고 `writeValueTypeHeader = false`만 설정하면
+> `LinkedHashMap`으로 역직렬화되어 타입 손상이 발생합니다.
+> 헤더를 안전하게 비활성화하려면 `ForyKafkaCodec` 또는 `KryoKafkaCodec`을 사용하세요.
 
 | `writeValueTypeHeader` | 동작 |
 |------------------------|------|

--- a/infra/kafka/README.ko.md
+++ b/infra/kafka/README.ko.md
@@ -165,6 +165,22 @@ val compressed = lz4KryoCodec.serialize("test-topic", largeObject)
 | `KafkaCodecs.SnappyJdk` | Snappy 압축 + Java 직렬화 |
 | `KafkaCodecs.ZstdKryo`  | Zstd 압축 + Kryo 직렬화   |
 
+#### 성능: 타입 헤더 쓰기 비활성화
+
+`AbstractKafkaCodec` 은 기본적으로 매 레코드 헤더에 value 타입의 Java FQN 을 기록합니다.
+컨슈머가 타입을 정적으로 이미 알고 있다면 비활성화할 수 있습니다:
+
+```kotlin
+class NoHeaderJacksonCodec : JacksonKafkaCodec() {
+    override val writeValueTypeHeader = false
+}
+```
+
+| `writeValueTypeHeader` | 동작 |
+|------------------------|------|
+| `true` (기본값) | 매 레코드에 FQN 헤더 기록 — 다형성 역직렬화 지원 |
+| `false` | 헤더 생략 — 대역폭 오버헤드 없음. 컨슈머가 타입을 정적으로 알고 있을 때 사용. |
+
 #### 보안: 클래스 로딩 허용 목록
 
 `AbstractKafkaCodec` 은 Kafka 헤더 `bluetape4k.kafka.codec.value.type` 에서

--- a/infra/kafka/README.md
+++ b/infra/kafka/README.md
@@ -165,6 +165,23 @@ Available codecs:
 | `KafkaCodecs.SnappyJdk` | Snappy compression + Java serialization |
 | `KafkaCodecs.ZstdKryo`  | Zstd compression + Kryo serialization   |
 
+#### Performance: Opt-out of Value-Type Header
+
+By default, `AbstractKafkaCodec` writes the Java FQN of the value type to every
+record header (`bluetape4k.kafka.codec.value.type`). Disable it when the consumer
+already knows the type statically:
+
+```kotlin
+class NoHeaderJacksonCodec : JacksonKafkaCodec() {
+    override val writeValueTypeHeader = false
+}
+```
+
+| `writeValueTypeHeader` | Effect |
+|------------------------|--------|
+| `true` (default) | FQN written to every record header — polymorphic deserialization works |
+| `false` | Header omitted — no bandwidth overhead, smaller attack surface. Consumer must know the type statically. |
+
 #### Security: Class Loading Allowlist
 
 `AbstractKafkaCodec` loads the deserialization target class from the Kafka

--- a/infra/kafka/README.md
+++ b/infra/kafka/README.md
@@ -172,10 +172,16 @@ record header (`bluetape4k.kafka.codec.value.type`). Disable it when the consume
 already knows the type statically:
 
 ```kotlin
-class NoHeaderJacksonCodec : JacksonKafkaCodec() {
+// Fory/Kryo codecs work safely without the header
+class NoHeaderForyCodec : ForyKafkaCodec() {
     override val writeValueTypeHeader = false
 }
 ```
+
+> **Note for `JacksonKafkaCodec`:** Jackson uses the header to determine the target type at
+> deserialization time. Setting `writeValueTypeHeader = false` without also overriding
+> `doDeserialize` causes it to fall back to `LinkedHashMap` (silent type corruption).
+> Use `ForyKafkaCodec` or `KryoKafkaCodec` when you want to disable the header safely.
 
 | `writeValueTypeHeader` | Effect |
 |------------------------|--------|

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt
@@ -72,7 +72,7 @@ fun <K, V> producerOf(
  */
 @Deprecated(
     message = "메트릭 이름이 없거나 오타인 경우 0.0을 반환하여 실제 0.0 값과 구별할 수 없습니다. getMetricValueOrNull()을 사용하세요.",
-    replaceWith = ReplaceWith("getMetricValueOrNull(metricName)")
+    replaceWith = ReplaceWith("getMetricValueOrNull(metricName).asDouble()", "io.bluetape4k.support.asDouble")
 )
 fun <K, V> Producer<K, V>.getMetricValue(metricName: String): Double =
     getMetricValueOrNull(metricName)?.asDoubleOrNull() ?: 0.0

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt
@@ -61,23 +61,30 @@ fun <K, V> producerOf(
 /**
  * Producer 의 metrics 측정 값을 조회합니다.
  *
+ * **경고**: 메트릭 이름이 없거나 오타인 경우 `0.0`을 반환하여 실제 `0.0` 값과 구별할 수 없습니다.
+ * 대신 [getMetricValueOrNull]을 사용하세요.
+ *
  * ```
- * val sendCount = producer.getMetricValue("record-send-total")
+ * val sendCount = producer.getMetricValueOrNull("record-send-total").asDouble()
  * ```
  * @param metricName metric name to retrieve
- * @return metric 값
+ * @return metric 값 (메트릭이 없으면 0.0 — 실제 0과 구별 불가)
  */
+@Deprecated(
+    message = "메트릭 이름이 없거나 오타인 경우 0.0을 반환하여 실제 0.0 값과 구별할 수 없습니다. getMetricValueOrNull()을 사용하세요.",
+    replaceWith = ReplaceWith("getMetricValueOrNull(metricName)")
+)
 fun <K, V> Producer<K, V>.getMetricValue(metricName: String): Double =
     getMetricValueOrNull(metricName)?.asDoubleOrNull() ?: 0.0
 
 /**
- * Producer 의 metrics 측정 값을 조회합니다.
+ * Producer 의 metrics 측정 값을 조회합니다. 메트릭이 없으면 `null`을 반환합니다.
  *
  * ```
- * val sendCount = producer.getMetricValue("record-send-total")
+ * val sendCount = producer.getMetricValueOrNull("record-send-total").asDouble()
  * ```
  * @param metricName metric name to retrieve
- * @return metric 값
+ * @return metric 값, 메트릭이 없으면 `null`
  */
 fun <K, V> Producer<K, V>.getMetricValueOrNull(metricName: String): Any? =
     metrics()

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
@@ -89,6 +89,21 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
      */
     open val allowedTypePackages: Set<String> = emptySet()
 
+    /**
+     * 직렬화 시 `bluetape4k.kafka.codec.value.type` 헤더에 Java FQN을 기록할지 여부.
+     *
+     * - `true` (기본값): 매 레코드에 타입 헤더를 기록합니다. 다형성 역직렬화 시 필요하지만
+     *   대역폭·저장 오버헤드가 발생하며 외부 공격자가 헤더를 조작할 수 있는 attack surface를 넓힙니다.
+     * - `false`: 헤더를 생략합니다. 컨슈머가 타입을 정적으로 알고 있는 경우(typed codec) 권장합니다.
+     *
+     * ```kotlin
+     * class NoHeaderJacksonCodec: JacksonKafkaCodec() {
+     *     override val writeValueTypeHeader = false
+     * }
+     * ```
+     */
+    open val writeValueTypeHeader: Boolean = true
+
     protected abstract fun doSerialize(
         topic: String?,
         headers: Headers?,
@@ -107,7 +122,7 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
         data: T?,
     ): ByteArray? =
         data?.run {
-            setValueType(headers, data.javaClass)
+            if (writeValueTypeHeader) setValueType(headers, data.javaClass)
             doSerialize(topic, headers, this)
         }
 

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
@@ -94,10 +94,14 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
      *
      * - `true` (기본값): 매 레코드에 타입 헤더를 기록합니다. 다형성 역직렬화 시 필요하지만
      *   대역폭·저장 오버헤드가 발생하며 외부 공격자가 헤더를 조작할 수 있는 attack surface를 넓힙니다.
-     * - `false`: 헤더를 생략합니다. 컨슈머가 타입을 정적으로 알고 있는 경우(typed codec) 권장합니다.
+     * - `false`: 헤더를 생략합니다. 역직렬화 시 타입 헤더를 읽지 않는 바이너리 코덱
+     *   ([ForyKafkaCodec], [KryoKafkaCodec])에서 권장합니다.
+     *   [JacksonKafkaCodec]은 역직렬화 시 헤더에서 타입을 로드하므로 `false` 설정 시
+     *   `doDeserialize`도 함께 오버라이드해야 합니다.
      *
      * ```kotlin
-     * class NoHeaderJacksonCodec: JacksonKafkaCodec() {
+     * // Fory/Kryo 기반 코덱은 헤더 없이 안전하게 작동합니다
+     * class NoHeaderForyCodec: ForyKafkaCodec() {
      *     override val writeValueTypeHeader = false
      * }
      * ```

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt
@@ -162,14 +162,14 @@ fun <K, V> KafkaOperations<K, V>.getMetric(metricName: String): Metric? =
  * 대신 [getMetricValueOrNull]을 사용하세요.
  *
  * ```
- * val sendCount = producer.getMetricValueOrNull("record-send-total") ?: 0.0
+ * val sendCount = producer.getMetricValueOrNull("record-send-total").asDouble()
  * ```
  * @param metricName metric name to retrieve
  * @return metric 값 (메트릭이 없으면 0.0 — 실제 0과 구별 불가)
  */
 @Deprecated(
     message = "메트릭 이름이 없거나 오타인 경우 0.0을 반환하여 실제 0.0 값과 구별할 수 없습니다. getMetricValueOrNull()을 사용하세요.",
-    replaceWith = ReplaceWith("getMetricValueOrNull(metricName)")
+    replaceWith = ReplaceWith("getMetricValueOrNull(metricName).asDouble()", "io.bluetape4k.support.asDouble")
 )
 fun <K, V> KafkaOperations<K, V>.getMetricValue(metricName: String): Double =
     getMetric(metricName)?.metricValue().asDouble(0.0)
@@ -178,7 +178,7 @@ fun <K, V> KafkaOperations<K, V>.getMetricValue(metricName: String): Double =
  * Producer 의 metrics 측정 값을 조회합니다. 메트릭이 없으면 `null`을 반환합니다.
  *
  * ```
- * val sendCount = producer.getMetricValueOrNull("record-send-total") ?: 0.0
+ * val sendCount = producer.getMetricValueOrNull("record-send-total").asDouble()
  * ```
  * @param metricName metric name to retrieve
  * @return metric 값, 메트릭이 없으면 `null`

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt
@@ -158,22 +158,29 @@ fun <K, V> KafkaOperations<K, V>.getMetric(metricName: String): Metric? =
 /**
  * Producer 의 metrics 측정 값을 조회합니다.
  *
+ * **경고**: 메트릭 이름이 없거나 오타인 경우 `0.0`을 반환하여 실제 `0.0` 값과 구별할 수 없습니다.
+ * 대신 [getMetricValueOrNull]을 사용하세요.
+ *
  * ```
- * val sendCount = producer.getMetricValue("record-send-total")
+ * val sendCount = producer.getMetricValueOrNull("record-send-total") ?: 0.0
  * ```
  * @param metricName metric name to retrieve
- * @return metric 값
+ * @return metric 값 (메트릭이 없으면 0.0 — 실제 0과 구별 불가)
  */
+@Deprecated(
+    message = "메트릭 이름이 없거나 오타인 경우 0.0을 반환하여 실제 0.0 값과 구별할 수 없습니다. getMetricValueOrNull()을 사용하세요.",
+    replaceWith = ReplaceWith("getMetricValueOrNull(metricName)")
+)
 fun <K, V> KafkaOperations<K, V>.getMetricValue(metricName: String): Double =
     getMetric(metricName)?.metricValue().asDouble(0.0)
 
 /**
- * Producer 의 metrics 측정 값을 조회합니다.
+ * Producer 의 metrics 측정 값을 조회합니다. 메트릭이 없으면 `null`을 반환합니다.
  *
  * ```
- * val sendCount = producer.getMetricValue("record-send-total")
+ * val sendCount = producer.getMetricValueOrNull("record-send-total") ?: 0.0
  * ```
  * @param metricName metric name to retrieve
- * @return metric 값
+ * @return metric 값, 메트릭이 없으면 `null`
  */
 fun <K, V> KafkaOperations<K, V>.getMetricValueOrNull(metricName: String): Any? = getMetric(metricName)?.metricValue()

--- a/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/ProducerSupportTest.kt
+++ b/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/ProducerSupportTest.kt
@@ -1,8 +1,8 @@
 package io.bluetape4k.kafka
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.support.asDouble
 import io.bluetape4k.testcontainers.mq.KafkaServer
-import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeGreaterOrEqualTo
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldNotBeNull
@@ -54,17 +54,11 @@ class ProducerSupportTest: AbstractKafkaTest() {
         producer.send(record).get()
 
         // 메트릭 조회
-        val sendTotal = producer.getMetricValue("record-send-total")
+        val sendTotal = producer.getMetricValueOrNull("record-send-total").asDouble()
         sendTotal shouldBeGreaterOrEqualTo 0.0
 
-        val retryTotal = producer.getMetricValue("record-retry-total")
+        val retryTotal = producer.getMetricValueOrNull("record-retry-total").asDouble()
         retryTotal shouldBeGreaterOrEqualTo 0.0
-    }
-
-    @Test
-    fun `존재하지 않는 메트릭은 0을 반환`() {
-        val value = producer.getMetricValue("non-existent-metric")
-        value shouldBeEqualTo 0.0
     }
 
     @Test
@@ -81,7 +75,7 @@ class ProducerSupportTest: AbstractKafkaTest() {
 
     @RepeatedTest(REPEAT_SIZE)
     fun `메시지 전송 후 메트릭 증가 확인`() {
-        val initialSendTotal = producer.getMetricValue("record-send-total")
+        val initialSendTotal = producer.getMetricValueOrNull("record-send-total").asDouble()
 
         // 여러 메시지 전송
         repeat(5) { i ->
@@ -89,7 +83,7 @@ class ProducerSupportTest: AbstractKafkaTest() {
             producer.send(record).get()
         }
 
-        val finalSendTotal = producer.getMetricValue("record-send-total")
+        val finalSendTotal = producer.getMetricValueOrNull("record-send-total").asDouble()
         finalSendTotal shouldBeGreaterOrEqualTo initialSendTotal + 5
     }
 

--- a/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/coroutines/ProducerSupportTest.kt
+++ b/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/coroutines/ProducerSupportTest.kt
@@ -6,8 +6,9 @@ import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.junit5.random.RandomValue
 import io.bluetape4k.junit5.random.RandomizedTest
 import io.bluetape4k.kafka.AbstractKafkaTest
-import io.bluetape4k.kafka.getMetricValue
+import io.bluetape4k.kafka.getMetricValueOrNull
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.support.asDouble
 import io.bluetape4k.logging.debug
 import io.bluetape4k.testcontainers.mq.KafkaServer
 import kotlinx.coroutines.CoroutineScope
@@ -131,7 +132,7 @@ class ProducerSupportTest: AbstractKafkaTest() {
         val messages = randomStrings()
 
         runBlocking(Dispatchers.IO) {
-            val prevSentTotal = producer.getMetricValue("record-send-total")
+            val prevSentTotal = producer.getMetricValueOrNull("record-send-total").asDouble()
 
             val sendTime = measureTimeMillis {
                 val records = messages.asFlow()
@@ -141,7 +142,7 @@ class ProducerSupportTest: AbstractKafkaTest() {
             }
 
             log.debug { "Send time=$sendTime" }
-            val currSentTotal = producer.getMetricValue("record-send-total") - prevSentTotal
+            val currSentTotal = producer.getMetricValueOrNull("record-send-total").asDouble() - prevSentTotal
             log.debug { "Current sent count=$currSentTotal" }
         }
     }
@@ -151,11 +152,11 @@ class ProducerSupportTest: AbstractKafkaTest() {
         block: suspend CoroutineScope.() -> Unit,
     ) {
         runBlocking(Dispatchers.IO) {
-            val prevSentTotal = producer.getMetricValue("record-send-total")
+            val prevSentTotal = producer.getMetricValueOrNull("record-send-total").asDouble()
 
             block()
 
-            val currSentTotal = producer.getMetricValue("record-send-total") - prevSentTotal
+            val currSentTotal = producer.getMetricValueOrNull("record-send-total").asDouble() - prevSentTotal
             log.debug { "Current sent count=$currSentTotal" }
             currSentTotal.toInt() shouldBeGreaterOrEqualTo expectCount
         }

--- a/infra/kafka4/README.ko.md
+++ b/infra/kafka4/README.ko.md
@@ -152,10 +152,16 @@ Jackson codec은 `bluetape4k-jackson3`와 `tools.jackson.*` API를 사용합니�
 컨슈머가 타입을 정적으로 이미 알고 있다면 헤더 쓰기를 비활성화할 수 있습니다:
 
 ```kotlin
-class NoHeaderJacksonCodec : JacksonKafkaCodec() {
+// Fory/Kryo 기반 코덱은 헤더 없이 안전하게 작동합니다
+class NoHeaderForyCodec : ForyKafkaCodec() {
     override val writeValueTypeHeader = false
 }
 ```
+
+> **`JacksonKafkaCodec` 주의**: Jackson은 역직렬화 시 헤더에서 대상 타입을 결정합니다.
+> `doDeserialize`를 함께 오버라이드하지 않고 `writeValueTypeHeader = false`만 설정하면
+> `LinkedHashMap`으로 역직렬화되어 타입 손상이 발생합니다.
+> 헤더를 안전하게 비활성화하려면 `ForyKafkaCodec` 또는 `KryoKafkaCodec`을 사용하세요.
 
 | `writeValueTypeHeader` | 동작 |
 |------------------------|------|

--- a/infra/kafka4/README.ko.md
+++ b/infra/kafka4/README.ko.md
@@ -142,6 +142,26 @@ Jackson codec은 `bluetape4k-jackson3`와 `tools.jackson.*` API를 사용합니�
 `DeadLetterPublishingRecoverer` 와 함께 사용하여 poison record 를 DLQ 토픽으로
 라우팅하라.
 
+### 성능: 타입 헤더 쓰기 비활성화
+
+`AbstractKafkaCodec` 은 기본적으로 매 레코드 헤더에 value 타입의 Java FQN 을 기록합니다
+(`bluetape4k.kafka.codec.value.type`). 다형성 역직렬화에 필요하지만,
+처리량이 높은 토픽에서는 대역폭·저장 오버헤드가 발생하며 아래 설명하는
+클래스 로딩 attack surface 도 넓어집니다.
+
+컨슈머가 타입을 정적으로 이미 알고 있다면 헤더 쓰기를 비활성화할 수 있습니다:
+
+```kotlin
+class NoHeaderJacksonCodec : JacksonKafkaCodec() {
+    override val writeValueTypeHeader = false
+}
+```
+
+| `writeValueTypeHeader` | 동작 |
+|------------------------|------|
+| `true` (기본값) | 매 레코드에 FQN 헤더 기록 — 다형성 역직렬화 지원 |
+| `false` | 헤더 생략 — 대역폭 오버헤드 없음, attack surface 축소. 컨슈머가 타입을 정적으로 알고 있을 때 사용. |
+
 ### 보안: 클래스 로딩 허용 목록
 
 `AbstractKafkaCodec` 은 Kafka 헤더 `bluetape4k.kafka.codec.value.type` 에서

--- a/infra/kafka4/README.md
+++ b/infra/kafka4/README.md
@@ -143,6 +143,26 @@ For permanent loss prevention, combine with Spring-Kafka's
 `ErrorHandlingDeserializer` and `DeadLetterPublishingRecoverer` to route
 poisoned records to a DLQ topic.
 
+### Performance: Opt-out of Value-Type Header
+
+By default, `AbstractKafkaCodec` writes the Java FQN of the value type to every
+record header (`bluetape4k.kafka.codec.value.type`). This enables polymorphic
+deserialization but adds bandwidth and storage overhead for high-throughput topics.
+It also widens the class-loading attack surface described below.
+
+If your consumer already knows the value type statically, disable the header:
+
+```kotlin
+class NoHeaderJacksonCodec : JacksonKafkaCodec() {
+    override val writeValueTypeHeader = false
+}
+```
+
+| `writeValueTypeHeader` | Effect |
+|------------------------|--------|
+| `true` (default) | FQN written to every record header — polymorphic deserialization works |
+| `false` | Header omitted — no bandwidth overhead, smaller attack surface. Consumer must know the type statically. |
+
 ### Security: Class Loading Allowlist
 
 `AbstractKafkaCodec` loads the deserialization target class from the Kafka

--- a/infra/kafka4/README.md
+++ b/infra/kafka4/README.md
@@ -153,10 +153,16 @@ It also widens the class-loading attack surface described below.
 If your consumer already knows the value type statically, disable the header:
 
 ```kotlin
-class NoHeaderJacksonCodec : JacksonKafkaCodec() {
+// Fory/Kryo codecs work safely without the header
+class NoHeaderForyCodec : ForyKafkaCodec() {
     override val writeValueTypeHeader = false
 }
 ```
+
+> **Note for `JacksonKafkaCodec`:** Jackson uses the header to determine the target type at
+> deserialization time. Setting `writeValueTypeHeader = false` without also overriding
+> `doDeserialize` causes it to fall back to `LinkedHashMap` (silent type corruption).
+> Use `ForyKafkaCodec` or `KryoKafkaCodec` when you want to disable the header safely.
 
 | `writeValueTypeHeader` | Effect |
 |------------------------|--------|

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt
@@ -72,7 +72,7 @@ fun <K, V> producerOf(
  */
 @Deprecated(
     message = "메트릭 이름이 없거나 오타인 경우 0.0을 반환하여 실제 0.0 값과 구별할 수 없습니다. getMetricValueOrNull()을 사용하세요.",
-    replaceWith = ReplaceWith("getMetricValueOrNull(metricName)")
+    replaceWith = ReplaceWith("getMetricValueOrNull(metricName).asDouble()", "io.bluetape4k.support.asDouble")
 )
 fun <K, V> Producer<K, V>.getMetricValue(metricName: String): Double =
     getMetricValueOrNull(metricName)?.asDoubleOrNull() ?: 0.0

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt
@@ -61,23 +61,30 @@ fun <K, V> producerOf(
 /**
  * Producer 의 metrics 측정 값을 조회합니다.
  *
+ * **경고**: 메트릭 이름이 없거나 오타인 경우 `0.0`을 반환하여 실제 `0.0` 값과 구별할 수 없습니다.
+ * 대신 [getMetricValueOrNull]을 사용하세요.
+ *
  * ```
- * val sendCount = producer.getMetricValue("record-send-total")
+ * val sendCount = producer.getMetricValueOrNull("record-send-total").asDouble()
  * ```
  * @param metricName metric name to retrieve
- * @return metric 값
+ * @return metric 값 (메트릭이 없으면 0.0 — 실제 0과 구별 불가)
  */
+@Deprecated(
+    message = "메트릭 이름이 없거나 오타인 경우 0.0을 반환하여 실제 0.0 값과 구별할 수 없습니다. getMetricValueOrNull()을 사용하세요.",
+    replaceWith = ReplaceWith("getMetricValueOrNull(metricName)")
+)
 fun <K, V> Producer<K, V>.getMetricValue(metricName: String): Double =
     getMetricValueOrNull(metricName)?.asDoubleOrNull() ?: 0.0
 
 /**
- * Producer 의 metrics 측정 값을 조회합니다.
+ * Producer 의 metrics 측정 값을 조회합니다. 메트릭이 없으면 `null`을 반환합니다.
  *
  * ```
- * val sendCount = producer.getMetricValue("record-send-total")
+ * val sendCount = producer.getMetricValueOrNull("record-send-total").asDouble()
  * ```
  * @param metricName metric name to retrieve
- * @return metric 값
+ * @return metric 값, 메트릭이 없으면 `null`
  */
 fun <K, V> Producer<K, V>.getMetricValueOrNull(metricName: String): Any? =
     metrics()

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
@@ -89,6 +89,21 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
      */
     open val allowedTypePackages: Set<String> = emptySet()
 
+    /**
+     * 직렬화 시 `bluetape4k.kafka.codec.value.type` 헤더에 Java FQN을 기록할지 여부.
+     *
+     * - `true` (기본값): 매 레코드에 타입 헤더를 기록합니다. 다형성 역직렬화 시 필요하지만
+     *   대역폭·저장 오버헤드가 발생하며 외부 공격자가 헤더를 조작할 수 있는 attack surface를 넓힙니다.
+     * - `false`: 헤더를 생략합니다. 컨슈머가 타입을 정적으로 알고 있는 경우(typed codec) 권장합니다.
+     *
+     * ```kotlin
+     * class NoHeaderJacksonCodec: JacksonKafkaCodec() {
+     *     override val writeValueTypeHeader = false
+     * }
+     * ```
+     */
+    open val writeValueTypeHeader: Boolean = true
+
     protected abstract fun doSerialize(
         topic: String?,
         headers: Headers?,
@@ -107,7 +122,7 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
         data: T?,
     ): ByteArray? =
         data?.run {
-            setValueType(headers, data.javaClass)
+            if (writeValueTypeHeader) setValueType(headers, data.javaClass)
             doSerialize(topic, headers, this)
         }
 

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
@@ -94,10 +94,14 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
      *
      * - `true` (기본값): 매 레코드에 타입 헤더를 기록합니다. 다형성 역직렬화 시 필요하지만
      *   대역폭·저장 오버헤드가 발생하며 외부 공격자가 헤더를 조작할 수 있는 attack surface를 넓힙니다.
-     * - `false`: 헤더를 생략합니다. 컨슈머가 타입을 정적으로 알고 있는 경우(typed codec) 권장합니다.
+     * - `false`: 헤더를 생략합니다. 역직렬화 시 타입 헤더를 읽지 않는 바이너리 코덱
+     *   ([ForyKafkaCodec], [KryoKafkaCodec])에서 권장합니다.
+     *   [JacksonKafkaCodec]은 역직렬화 시 헤더에서 타입을 로드하므로 `false` 설정 시
+     *   `doDeserialize`도 함께 오버라이드해야 합니다.
      *
      * ```kotlin
-     * class NoHeaderJacksonCodec: JacksonKafkaCodec() {
+     * // Fory/Kryo 기반 코덱은 헤더 없이 안전하게 작동합니다
+     * class NoHeaderForyCodec: ForyKafkaCodec() {
      *     override val writeValueTypeHeader = false
      * }
      * ```

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt
@@ -163,23 +163,30 @@ fun <K: Any, V: Any> KafkaOperations<K, V>.getMetric(metricName: String): Metric
 /**
  * Producer 의 metrics 측정 값을 조회합니다.
  *
+ * **경고**: 메트릭 이름이 없거나 오타인 경우 `0.0`을 반환하여 실제 `0.0` 값과 구별할 수 없습니다.
+ * 대신 [getMetricValueOrNull]을 사용하세요.
+ *
  * ```
- * val sendCount = producer.getMetricValue("record-send-total")
+ * val sendCount = producer.getMetricValueOrNull("record-send-total") ?: 0.0
  * ```
  * @param metricName metric name to retrieve
- * @return metric 값
+ * @return metric 값 (메트릭이 없으면 0.0 — 실제 0과 구별 불가)
  */
+@Deprecated(
+    message = "메트릭 이름이 없거나 오타인 경우 0.0을 반환하여 실제 0.0 값과 구별할 수 없습니다. getMetricValueOrNull()을 사용하세요.",
+    replaceWith = ReplaceWith("getMetricValueOrNull(metricName)")
+)
 fun <K: Any, V: Any> KafkaOperations<K, V>.getMetricValue(metricName: String): Double =
     getMetric(metricName)?.metricValue().asDouble(0.0)
 
 /**
- * Producer 의 metrics 측정 값을 조회합니다.
+ * Producer 의 metrics 측정 값을 조회합니다. 메트릭이 없으면 `null`을 반환합니다.
  *
  * ```
- * val sendCount = producer.getMetricValue("record-send-total")
+ * val sendCount = producer.getMetricValueOrNull("record-send-total") ?: 0.0
  * ```
  * @param metricName metric name to retrieve
- * @return metric 값
+ * @return metric 값, 메트릭이 없으면 `null`
  */
 fun <K: Any, V: Any> KafkaOperations<K, V>.getMetricValueOrNull(metricName: String): Any? =
     getMetric(metricName)?.metricValue()

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt
@@ -167,14 +167,14 @@ fun <K: Any, V: Any> KafkaOperations<K, V>.getMetric(metricName: String): Metric
  * 대신 [getMetricValueOrNull]을 사용하세요.
  *
  * ```
- * val sendCount = producer.getMetricValueOrNull("record-send-total") ?: 0.0
+ * val sendCount = producer.getMetricValueOrNull("record-send-total").asDouble()
  * ```
  * @param metricName metric name to retrieve
  * @return metric 값 (메트릭이 없으면 0.0 — 실제 0과 구별 불가)
  */
 @Deprecated(
     message = "메트릭 이름이 없거나 오타인 경우 0.0을 반환하여 실제 0.0 값과 구별할 수 없습니다. getMetricValueOrNull()을 사용하세요.",
-    replaceWith = ReplaceWith("getMetricValueOrNull(metricName)")
+    replaceWith = ReplaceWith("getMetricValueOrNull(metricName).asDouble()", "io.bluetape4k.support.asDouble")
 )
 fun <K: Any, V: Any> KafkaOperations<K, V>.getMetricValue(metricName: String): Double =
     getMetric(metricName)?.metricValue().asDouble(0.0)
@@ -183,7 +183,7 @@ fun <K: Any, V: Any> KafkaOperations<K, V>.getMetricValue(metricName: String): D
  * Producer 의 metrics 측정 값을 조회합니다. 메트릭이 없으면 `null`을 반환합니다.
  *
  * ```
- * val sendCount = producer.getMetricValueOrNull("record-send-total") ?: 0.0
+ * val sendCount = producer.getMetricValueOrNull("record-send-total").asDouble()
  * ```
  * @param metricName metric name to retrieve
  * @return metric 값, 메트릭이 없으면 `null`

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/ProducerSupportTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/ProducerSupportTest.kt
@@ -1,8 +1,8 @@
 package io.bluetape4k.kafka
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.support.asDouble
 import io.bluetape4k.testcontainers.mq.KafkaServer
-import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeGreaterOrEqualTo
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldNotBeNull
@@ -54,17 +54,11 @@ class ProducerSupportTest: AbstractKafkaTest() {
         producer.send(record).get()
 
         // 메트릭 조회
-        val sendTotal = producer.getMetricValue("record-send-total")
+        val sendTotal = producer.getMetricValueOrNull("record-send-total").asDouble()
         sendTotal shouldBeGreaterOrEqualTo 0.0
 
-        val retryTotal = producer.getMetricValue("record-retry-total")
+        val retryTotal = producer.getMetricValueOrNull("record-retry-total").asDouble()
         retryTotal shouldBeGreaterOrEqualTo 0.0
-    }
-
-    @Test
-    fun `존재하지 않는 메트릭은 0을 반환`() {
-        val value = producer.getMetricValue("non-existent-metric")
-        value shouldBeEqualTo 0.0
     }
 
     @Test
@@ -81,7 +75,7 @@ class ProducerSupportTest: AbstractKafkaTest() {
 
     @RepeatedTest(REPEAT_SIZE)
     fun `메시지 전송 후 메트릭 증가 확인`() {
-        val initialSendTotal = producer.getMetricValue("record-send-total")
+        val initialSendTotal = producer.getMetricValueOrNull("record-send-total").asDouble()
 
         // 여러 메시지 전송
         repeat(5) { i ->
@@ -89,7 +83,7 @@ class ProducerSupportTest: AbstractKafkaTest() {
             producer.send(record).get()
         }
 
-        val finalSendTotal = producer.getMetricValue("record-send-total")
+        val finalSendTotal = producer.getMetricValueOrNull("record-send-total").asDouble()
         finalSendTotal shouldBeGreaterOrEqualTo initialSendTotal + 5
     }
 

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/coroutines/ProducerSupportTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/coroutines/ProducerSupportTest.kt
@@ -6,8 +6,9 @@ import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.junit5.random.RandomValue
 import io.bluetape4k.junit5.random.RandomizedTest
 import io.bluetape4k.kafka.AbstractKafkaTest
-import io.bluetape4k.kafka.getMetricValue
+import io.bluetape4k.kafka.getMetricValueOrNull
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.support.asDouble
 import io.bluetape4k.logging.debug
 import io.bluetape4k.testcontainers.mq.KafkaServer
 import kotlinx.coroutines.CoroutineScope
@@ -131,7 +132,7 @@ class ProducerSupportTest: AbstractKafkaTest() {
         val messages = randomStrings()
 
         runBlocking(Dispatchers.IO) {
-            val prevSentTotal = producer.getMetricValue("record-send-total")
+            val prevSentTotal = producer.getMetricValueOrNull("record-send-total").asDouble()
 
             val sendTime = measureTimeMillis {
                 val records = messages.asFlow()
@@ -141,7 +142,7 @@ class ProducerSupportTest: AbstractKafkaTest() {
             }
 
             log.debug { "Send time=$sendTime" }
-            val currSentTotal = producer.getMetricValue("record-send-total") - prevSentTotal
+            val currSentTotal = producer.getMetricValueOrNull("record-send-total").asDouble() - prevSentTotal
             log.debug { "Current sent count=$currSentTotal" }
         }
     }
@@ -151,11 +152,11 @@ class ProducerSupportTest: AbstractKafkaTest() {
         block: suspend CoroutineScope.() -> Unit,
     ) {
         runBlocking(Dispatchers.IO) {
-            val prevSentTotal = producer.getMetricValue("record-send-total")
+            val prevSentTotal = producer.getMetricValueOrNull("record-send-total").asDouble()
 
             block()
 
-            val currSentTotal = producer.getMetricValue("record-send-total") - prevSentTotal
+            val currSentTotal = producer.getMetricValueOrNull("record-send-total").asDouble() - prevSentTotal
             log.debug { "Current sent count=$currSentTotal" }
             currSentTotal.toInt() shouldBeGreaterOrEqualTo expectCount
         }


### PR DESCRIPTION
## Summary

Closes #305, #307

- PR 제목: feat: Kafka Wave 3 — 타입 헤더 opt-out, getMetricValue deprecated (Issues #305, #307)

Issue #305, #307을 처리한 Wave 3 Enhancement PR.  
kafka3(`bluetape4k-kafka`) 와 kafka4(`bluetape4k-kafka4`) 양쪽 모두 동기화 적용.

---

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### Issue #305 — `AbstractKafkaCodec` 타입 헤더 opt-out

| 파일 | 변경 |
|------|------|
| `infra/kafka/src/main/kotlin/.../codec/KafkaCodec.kt` | `writeValueTypeHeader: Boolean = true` 추가 |
| `infra/kafka4/src/main/kotlin/.../codec/KafkaCodec.kt` | 동일 |
| `infra/kafka/README.md` / `README.ko.md` | 성능 섹션 추가; `NoHeaderForyCodec` 예제 및 Jackson 주의사항 |
| `infra/kafka4/README.md` / `README.ko.md` | 동일 |

`writeValueTypeHeader = false`로 오버라이드하면 매 레코드에 FQN 헤더 기록을 생략해  
대역폭·저장 오버헤드 감소 및 attack surface 축소. `ForyKafkaCodec`/`KryoKafkaCodec` 권장.

> **주의**: `JacksonKafkaCodec`은 역직렬화 시 헤더에서 타입을 결정하므로
> `writeValueTypeHeader = false` 설정 시 `doDeserialize`도 함께 오버라이드해야 합니다.
> 그렇지 않으면 `LinkedHashMap`으로 역직렬화되는 타입 손상이 발생합니다.

### Issue #307 — `getMetricValue` deprecated → `getMetricValueOrNull` 사용 유도

| 파일 | 변경 |
|------|------|
| `infra/kafka/src/main/kotlin/.../ProducerSupport.kt` | `@Deprecated` + `ReplaceWith("getMetricValueOrNull(metricName).asDouble()", ...)` |
| `infra/kafka4/src/main/kotlin/.../ProducerSupport.kt` | 동일 |
| `infra/kafka/src/main/kotlin/.../KafkaOperationExtensions.kt` | 동일 |
| `infra/kafka4/src/main/kotlin/.../KafkaOperationExtensions.kt` | 동일 |
| 각 테스트 파일 | `getMetricValue` → `getMetricValueOrNull().asDouble()` 마이그레이션 |

`getMetricValue`는 메트릭 미존재 시 실제 `0.0`과 구별 불가한 `0.0`을 반환하는 결함이 있었음.  
`getMetricValueOrNull`은 미존재 시 `null` 반환 → `.asDouble()`으로 변환.

---

### 기존 섹션: 코드 리뷰 HIGH 이슈 수정 (커밋 `db821ab`)

| HIGH # | 내용 | 수정 |
|--------|------|------|
| #1 | `ReplaceWith`에 `.asDouble()` 및 import 누락 | `ReplaceWith("getMetricValueOrNull(metricName).asDouble()", "io.bluetape4k.support.asDouble")` |
| #2 | KDoc/README 예제가 `NoHeaderJacksonCodec` — 역직렬화 타입 손상 위험 | `NoHeaderForyCodec: ForyKafkaCodec()` 예제로 교체 + Jackson 주의사항 추가 |
| #3 | KDoc 예제 `?: 0.0`이 `Any`를 반환 (타입 오류) | `.asDouble()` 으로 수정 |

---

### 기존 섹션: 검증 명령

```bash
./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka4:compileKotlin
./gradlew :bluetape4k-kafka:test :bluetape4k-kafka4:test
```

---

### 기존 섹션: 관련 이슈

- Closes #305
- Closes #307
- Related: #10 (KafkaStreamsTests KRaft flaky)

## Validation

| 모듈 | 통과 | 실패 |
|------|------|------|
| `bluetape4k-kafka` | 255 | 1 (KafkaStreamsTests — KRaft 타이밍 flaky, Issue #10) |
| `bluetape4k-kafka4` | 260 | 0 |

`KafkaStreamsTests.test KStreams` 실패는 KRaft 브로커 초기화 타이밍 경합으로 인한  
pre-existing flaky test이며 이번 변경과 무관합니다. Issue #10으로 별도 추적.

---

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #305, #307, milestone 없음, assignee 없음
- PR: #314, head `db821abf88c0b76cb95f129b55f4c53464d55948`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/kafka-enhancement-wave3`
- Labels: `enhancement`, `chore`
- State: `MERGED`, merge commit `200b5c9e030022fa1ea0a3354894724e5922348f`
- CI: ./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka4:compileKotlin / ./gradlew :bluetape4k-kafka:test :bluetape4k-kafka4:test

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #314 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `200b5c9e030022fa1ea0a3354894724e5922348f`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
