### PR TITLE
fix: KafkaStreamsTests KRaft 타이밍 flaky 수정 (Issue #315)

### DIFF
--- a/infra/kafka/src/test/kotlin/org/springframework/kafka/streams/KafkaStreamsTests.kt
+++ b/infra/kafka/src/test/kotlin/org/springframework/kafka/streams/KafkaStreamsTests.kt
@@ -102,29 +102,34 @@ class KafkaStreamsTests {
 
     @Test
     fun `test KStreams`() {
-//        with(this.embeddedKafka.getKafkaServer(0).config()) {
-//            autoCreateTopicsEnable().shouldBeFalse()
-//            deleteTopicEnable().shouldBeTrue()
-//            brokerId() shouldBeEqualTo 2
-//        }
         this.streamsBuilderFactoryBean.stop()
 
+        // runningLatch: Streams 가 RUNNING 상태에 도달할 때만 countdown.
+        // stop() 후 start() 시 KRaft 리더 선출 + changelog 복구 완료까지 대기하지 않으면
+        // NotLeaderOrFollowerException / snapshot NoSuchFileException 으로 resultFuture 가 영원히 완료되지 않음.
+        val runningLatch = CountDownLatch(1)
         val stateLatch = CountDownLatch(1)
 
-        this.streamsBuilderFactoryBean.setStateListener { _, _ -> stateLatch.countDown() }
+        this.streamsBuilderFactoryBean.setStateListener { newState, _ ->
+            stateLatch.countDown()
+            if (newState == KafkaStreams.State.RUNNING) runningLatch.countDown()
+        }
         val exceptionHandler = mockk<StreamsUncaughtExceptionHandler>(relaxUnitFun = true)
         this.streamsBuilderFactoryBean.setStreamsUncaughtExceptionHandler(exceptionHandler)
 
         this.streamsBuilderFactoryBean.start()
 
-        val payload1 = "foo" + Base58.randomString(32) // UUID.randomUUID().toString()
-        val payload2 = "foo" + Base58.randomString(32) // UUID.randomUUID().toString()
+        // Streams 가 RUNNING 이 될 때까지 대기 — 메시지 전송 전에 파이프라인 준비 완료 보장
+        runningLatch.await(60, TimeUnit.SECONDS).shouldBeTrue()
+
+        val payload1 = "foo" + Base58.randomString(32)
+        val payload2 = "foo" + Base58.randomString(32)
 
         this.kafkaTemplate.sendDefault(0, payload1)
         this.kafkaTemplate.sendDefault(0, payload2)
         this.kafkaTemplate.flush()
 
-        val result = resultFuture.get(600, TimeUnit.SECONDS)
+        val result = resultFuture.get(60, TimeUnit.SECONDS)
 
         result.shouldNotBeNull()
 


### PR DESCRIPTION
## Summary

Closes #315

- PR 제목: fix: KafkaStreamsTests KRaft 타이밍 flaky 수정 (Issue #315)

## Background

`KafkaStreamsTests.test KStreams` 에서 `streamsBuilderFactoryBean.stop()` + `start()` 후
Streams 가 `RUNNING` 상태에 도달하기 전에 즉시 메시지를 전송했음.

이 때 KRaft embedded broker 는 changelog 파티션 리더 선출과 snapshot 복구를 진행 중이어서
`NotLeaderOrFollowerException` / `NoSuchFileException(snapshot)` 이 발생.
Streams 가 재시도하는 동안 `resultFuture.get(600, SECONDS)` 가 타임아웃.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 수정

`KafkaStreams.State.RUNNING` 일 때만 countdown 하는 `runningLatch` 를 추가하고,
메시지 전송 전에 `runningLatch.await(60, SECONDS)` 로 파이프라인 준비 완료를 보장.

```kotlin
val runningLatch = CountDownLatch(1)

this.streamsBuilderFactoryBean.setStateListener { newState, _ ->
    stateLatch.countDown()
    if (newState == KafkaStreams.State.RUNNING) runningLatch.countDown()
}

this.streamsBuilderFactoryBean.start()

// RUNNING 보장 후 메시지 전송
runningLatch.await(60, TimeUnit.SECONDS).shouldBeTrue()
```

`resultFuture.get` 타임아웃도 600 → 60초로 단축 (RUNNING 후 60초면 충분).

### 기존 섹션: 관련 이슈

- Closes #315

## Validation

```
bluetape4k-kafka: 255 passing (41.9s)  — 0 failures
```

`KafkaStreamsTests.test KStreams` 포함 전체 통과.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #315, milestone 없음, assignee 없음
- PR: #316, head `2f117dc3766bf40cc1dca725c88bc82648ca5d3f`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/kafka-streams-kraft-flaky`
- Labels: `bug`
- State: `MERGED`, merge commit `30a6a36db60ae036732c6935bbdb02949180041d`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #316 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `30a6a36db60ae036732c6935bbdb02949180041d`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
