### PR TITLE
fix: AbstractCompressor.compress/decompress 예외 삼킴 제거 (Issue #308)

### DIFF
--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/AbstractCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/AbstractCompressor.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
 import io.bluetape4k.support.emptyByteArray
 import io.bluetape4k.support.isNullOrEmpty
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * [Compressor]의 최상위 추상화 클래스입니다.
@@ -98,6 +99,8 @@ abstract class AbstractCompressor: Compressor {
         if (plain.isNullOrEmpty()) return null
         return try {
             doCompress(plain!!)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             log.error(e) { "Fail to compress. plain size=${plain?.size}" }
             null
@@ -123,6 +126,8 @@ abstract class AbstractCompressor: Compressor {
         if (compressed.isNullOrEmpty()) return null
         return try {
             doDecompress(compressed!!)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             log.error(e) { "Fail to decompress. compressed size=${compressed?.size}" }
             null

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/AbstractCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/AbstractCompressor.kt
@@ -2,7 +2,6 @@ package io.bluetape4k.io.compressor
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
-import io.bluetape4k.logging.warn
 import io.bluetape4k.support.emptyByteArray
 import io.bluetape4k.support.isNullOrEmpty
 
@@ -12,15 +11,15 @@ import io.bluetape4k.support.isNullOrEmpty
  * ## Null/Empty 처리 정책
  * - `compress(null)` 또는 `compress(emptyByteArray)`: 빈 [ByteArray]를 반환합니다.
  * - `decompress(null)` 또는 `decompress(emptyByteArray)`: 빈 [ByteArray]를 반환합니다.
- * - 압축/해제 실패 시 예외를 전파하지 않고 빈 [ByteArray]를 반환합니다.
+ * - 압축/해제 실패 시 예외를 그대로 전파합니다.
  *
- * ## 손상 데이터 주의
- * `compress()`/`decompress()` 는 예외를 삼키고 빈 배열을 반환합니다. 데이터 손실 없이 오류를 명확히
- * 처리해야 하는 경우에는 [compressOrNull] / [decompressOrNull] 을 사용하세요.
+ * ## 예외 처리
+ * `compress()`/`decompress()` 는 내부 예외를 호출자에게 전파합니다.
+ * 실패 시 `null`을 반환받으려면 [compressOrNull] / [decompressOrNull] 을 사용하세요.
  *
  * ## 구현 방법
  * [doCompress]와 [doDecompress]를 구현하면 됩니다.
- * null/empty 체크와 예외 처리는 이 클래스에서 담당합니다.
+ * null/empty 체크는 이 클래스에서 담당합니다.
  *
  * ```kotlin
  * class MyCompressor: AbstractCompressor() {
@@ -42,8 +41,8 @@ abstract class AbstractCompressor: Compressor {
     /**
      * [plain] 데이터를 압축합니다.
      *
-     * 정책: 압축 실패 시 예외를 전파하지 않고 `emptyByteArray`를 반환합니다.
-     * 오류를 명확히 처리해야 하는 경우 [compressOrNull]을 사용하세요.
+     * null/empty 입력은 빈 [ByteArray]를 반환합니다. 압축 실패 시 예외를 전파합니다.
+     * 실패 시 `null`을 받으려면 [compressOrNull]을 사용하세요.
      *
      * ```
      * val compressor = GzipCompressor()
@@ -52,24 +51,18 @@ abstract class AbstractCompressor: Compressor {
      *
      * @param plain 원본 데이터
      * @return 압축된 데이터
+     * @throws Exception 압축 실패 시
      */
     override fun compress(plain: ByteArray?): ByteArray {
-        if (plain.isNullOrEmpty()) {
-            return emptyByteArray
-        }
-        return try {
-            doCompress(plain!!)
-        } catch (e: Throwable) {
-            log.error(e) { "Fail to compress. return emptyByteArray by design." }
-            emptyByteArray
-        }
+        if (plain.isNullOrEmpty()) return emptyByteArray
+        return doCompress(plain!!)
     }
 
     /**
      * 압축된 데이터([compressed])를 복원하여 [ByteArray]로 반환합니다.
      *
-     * 정책: 복원 실패 시 예외를 전파하지 않고 `emptyByteArray`를 반환합니다.
-     * 손상 데이터를 명확히 처리해야 하는 경우 [decompressOrNull]을 사용하세요.
+     * null/empty 입력은 빈 [ByteArray]를 반환합니다. 복원 실패 시 예외를 전파합니다.
+     * 손상 데이터를 `null`로 처리하려면 [decompressOrNull]을 사용하세요.
      *
      * ```
      * val compressor = GzipCompressor()
@@ -78,18 +71,12 @@ abstract class AbstractCompressor: Compressor {
      * ```
      *
      * @param compressed 압축된 데이터
-     * @return 복원된 데이터 (압축되지 않은 원본 데이터)
+     * @return 복원된 데이터
+     * @throws Exception 복원 실패 시 (손상 데이터, 크기 제한 초과 등)
      */
     override fun decompress(compressed: ByteArray?): ByteArray {
-        if (compressed.isNullOrEmpty()) {
-            return emptyByteArray
-        }
-        return try {
-            doDecompress(compressed!!)
-        } catch (e: Throwable) {
-            log.error(e) { "Fail to decompress. return emptyByteArray by design. compressed size=${compressed?.size}" }
-            emptyByteArray
-        }
+        if (compressed.isNullOrEmpty()) return emptyByteArray
+        return doDecompress(compressed!!)
     }
 
     /**
@@ -108,12 +95,13 @@ abstract class AbstractCompressor: Compressor {
      * @return 압축된 데이터 또는 `null`
      */
     fun compressOrNull(plain: ByteArray?): ByteArray? {
-        if (plain.isNullOrEmpty()) {
-            return null
+        if (plain.isNullOrEmpty()) return null
+        return try {
+            doCompress(plain!!)
+        } catch (e: Exception) {
+            log.error(e) { "Fail to compress. plain size=${plain?.size}" }
+            null
         }
-        return runCatching { doCompress(plain!!) }
-            .onFailure { log.error(it) { "Fail to compress. compressed size=${plain?.size}" } }
-            .getOrNull()
     }
 
     /**
@@ -132,11 +120,12 @@ abstract class AbstractCompressor: Compressor {
      * @return 복원된 데이터 또는 `null`
      */
     fun decompressOrNull(compressed: ByteArray?): ByteArray? {
-        if (compressed.isNullOrEmpty()) {
-            return null
+        if (compressed.isNullOrEmpty()) return null
+        return try {
+            doDecompress(compressed!!)
+        } catch (e: Exception) {
+            log.error(e) { "Fail to decompress. compressed size=${compressed?.size}" }
+            null
         }
-        return runCatching { doDecompress(compressed!!) }
-            .onFailure { log.error(it) { "Fail to decompress. compressed size=${compressed?.size}" } }
-            .getOrNull()
     }
 }

--- a/io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorEdgeCaseTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorEdgeCaseTest.kt
@@ -171,7 +171,7 @@ class CompressorEdgeCaseTest {
     }
 
     @Test
-    fun `LZ4Compressor 압축 데이터 헤더 손상 시 예외를 처리한다`() {
+    fun `LZ4Compressor 압축 데이터 헤더 손상 시 예외를 던진다`() {
         val compressor = LZ4Compressor()
         val input = "Hello, LZ4!".toByteArray()
         val compressed = compressor.compress(input)
@@ -183,9 +183,13 @@ class CompressorEdgeCaseTest {
         corrupted[2] = 0xFF.toByte()
         corrupted[3] = 0xFF.toByte()
 
-        // AbstractCompressor는 예외를 삼키고 emptyByteArray를 반환하도록 설계되어 있음
-        val result = compressor.decompress(corrupted)
-        result shouldBeEqualTo emptyByteArray
+        // 손상 데이터는 예외를 전파 — silent failure 제거
+        org.junit.jupiter.api.assertThrows<Exception> {
+            compressor.decompress(corrupted)
+        }
+
+        // decompressOrNull 은 예외를 삼키고 null 반환
+        compressor.decompressOrNull(corrupted) shouldBeEqualTo null
     }
 
     @Test

--- a/io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorNullableApiTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorNullableApiTest.kt
@@ -115,12 +115,17 @@ class CompressorNullableApiTest {
     }
 
     @Test
-    fun `decompressOrNull 은 손상된 GZip 데이터에 null 을 반환한다`() {
+    fun `GZip 손상 데이터 - decompress 는 예외, decompressOrNull 은 null`() {
         val compressor = GZipCompressor()
 
         // GZip 매직 바이트(0x1f 0x8b)를 무효화하면 반드시 파싱 실패
         val corrupted = byteArrayOf(0x00, 0x00, 0x01, 0x02, 0x03)
 
+        // decompress: 예외 전파 — silent failure 제거 검증
+        org.junit.jupiter.api.assertThrows<Exception> {
+            compressor.decompress(corrupted)
+        }
+        // decompressOrNull: null 반환
         compressor.decompressOrNull(corrupted).shouldBeNull()
     }
 

--- a/io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorNullableApiTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorNullableApiTest.kt
@@ -15,7 +15,7 @@ import java.util.stream.Stream
  *
  * - 정상 입력: 압축/해제 결과 반환
  * - null / empty 입력: `null` 반환
- * - 손상 데이터 역직렬화: `null` 반환 (compress 와 달리 emptyByteArray 대신 null)
+ * - 손상 데이터 역직렬화: `decompress` 는 예외 전파, `decompressOrNull` 은 `null` 반환
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CompressorNullableApiTest {
@@ -125,7 +125,7 @@ class CompressorNullableApiTest {
     }
 
     @Test
-    fun `decompressOrNull vs decompress - 손상 데이터에 대한 반환값이 다르다`() {
+    fun `decompressOrNull vs decompress - 손상 데이터에 대한 동작이 다르다`() {
         val compressor = LZ4Compressor()
         val input = "contrast test".toByteArray()
         val compressed = compressor.compress(input)
@@ -136,11 +136,12 @@ class CompressorNullableApiTest {
         corrupted[2] = 0xFF.toByte()
         corrupted[3] = 0xFF.toByte()
 
-        // decompress: emptyByteArray 반환 (기존 계약 유지)
-        val decompressResult = compressor.decompress(corrupted)
-        decompressResult shouldBeEqualTo ByteArray(0)
+        // decompress: 예외 전파 — 호출자가 오류를 인지하고 처리
+        org.junit.jupiter.api.assertThrows<Exception> {
+            compressor.decompress(corrupted)
+        }
 
-        // decompressOrNull: null 반환 (손상 여부를 호출자가 구분 가능)
+        // decompressOrNull: null 반환 — 손상 여부를 호출자가 null 로 구분 가능
         compressor.decompressOrNull(corrupted).shouldBeNull()
     }
 }

--- a/io/io/src/test/kotlin/io/bluetape4k/io/compressor/SnappyDecompressionBombTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/compressor/SnappyDecompressionBombTest.kt
@@ -1,17 +1,16 @@
 package io.bluetape4k.io.compressor
 
 import io.bluetape4k.logging.KLogging
-import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldNotBeEmpty
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.xerial.snappy.Snappy
 
 /**
  * [SnappyCompressor] decompression bomb 방어 테스트.
  *
- * - 256MB 초과 uncompressed_length를 선언하는 페이로드에 대해 emptyByteArray 반환 검증
+ * - 256MB 초과 uncompressed_length를 선언하는 페이로드에 대해 [IllegalArgumentException] 전파 검증
  * - 정상 데이터는 정상 처리됨 검증
- * - AbstractCompressor의 예외 → emptyByteArray 변환 정책 경유
  */
 class SnappyDecompressionBombTest {
 
@@ -28,13 +27,14 @@ class SnappyDecompressionBombTest {
     }
 
     @Test
-    fun `decompress - 256MB 초과 선언 페이로드는 emptyByteArray 반환`() {
+    fun `decompress - 256MB 초과 선언 페이로드는 IllegalArgumentException 전파`() {
         // Snappy 헤더: varint로 인코딩된 uncompressed_length (256MB + 1)
-        // AbstractCompressor.decompress()가 예외를 emptyByteArray로 변환함
+        // Wave 1 패치의 require() 검사가 AbstractCompressor.decompress()를 통해 호출자에게 전파됨
         val fakeCompressed = encodeSnappyHeader(256L * 1024 * 1024 + 1)
 
-        val result = compressor.decompress(fakeCompressed)
-        result.shouldBeEmpty()
+        assertThrows<IllegalArgumentException> {
+            compressor.decompress(fakeCompressed)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #308

- PR 제목: fix: AbstractCompressor.compress/decompress 예외 삼킴 제거 (Issue #308)

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### `AbstractCompressor.kt`

| 메서드 | 변경 전 | 변경 후 |
|--------|---------|---------|
| `compress()` | `catch(Throwable)` → `emptyByteArray` | 예외 그대로 전파 |
| `decompress()` | `catch(Throwable)` → `emptyByteArray` | 예외 그대로 전파 |
| `compressOrNull()` | `runCatching` (CancellationException/Error 삼킴) | `catch(CancellationException) { throw e }` + `catch(Exception)` |
| `decompressOrNull()` | 동일 | 동일 |

### 테스트 업데이트

| 파일 | 변경 |
|------|------|
| `SnappyDecompressionBombTest` | 256MB 초과 → `emptyByteArray` 기대 → `assertThrows<IllegalArgumentException>` |
| `CompressorNullableApiTest` | `decompress(corrupted)` 가 `emptyByteArray` 반환 기대 → `assertThrows<Exception>` |
| `CompressorNullableApiTest` | GZip 손상 데이터에 `decompress` 예외 전파 어서션 추가 (LZ4 와 동일한 양방향 계약) |
| `CompressorEdgeCaseTest` | LZ4 손상 헤더 → `emptyByteArray` 기대 → `assertThrows<Exception>` + `decompressOrNull null` 추가 |

---

### 기존 섹션: 문제 (Issue #308)

`AbstractCompressor.compress()` / `decompress()` 가 `catch(Throwable)` 로 모든 예외를 삼키고 `emptyByteArray` 를 반환했음.

- **silent failure**: 손상 데이터 / 포맷 오류가 빈 배열로 마스킹
- **Wave 1 패치 무력화**: `SnappyCompressor`, `LZ4Compressor` 에 추가한 256MB 크기 제한 `require()` 예외가 `AbstractCompressor` 에서 삼켜져 호출자에 전달되지 않음

---

### 기존 섹션: Breaking Change

손상 데이터 / 크기 제한 초과 시 `emptyByteArray` 대신 예외가 전파됩니다.  
예외 없이 계속 동작해야 하는 코드는 `compressOrNull()` / `decompressOrNull()` 로 교체하세요.

---

### 기존 섹션: 관련 이슈

- Closes #308
- Related: #297 / #306 (Wave 1 — 256MB 크기 제한 패치)

## Validation

```
bluetape4k-io: 910 passing (7.1s)  — 0 failures
```

---

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #308, milestone 없음, assignee 없음
- PR: #317, head `342bac139e44570a55a0321bcc6bd3f52ee0935f`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/compressor-silent-failure`
- Labels: 없음
- State: `MERGED`, merge commit `a26a6ace12629df0aa8c646a6a7d876a364a0d99`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #317 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `a26a6ace12629df0aa8c646a6a7d876a364a0d99`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
