### PR TITLE
test: infra/lettuce + cache-core 테스트 커버리지 80% 달성

### DIFF
--- a/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/cache2k/Cache2kSupportExtTest.kt
+++ b/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/cache2k/Cache2kSupportExtTest.kt
@@ -1,0 +1,90 @@
+package io.bluetape4k.cache.cache2k
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import kotlin.test.assertFailsWith
+
+class Cache2kSupportExtTest {
+
+    companion object: KLogging()
+
+    @Test
+    fun `defaultCache2kManager는 null이 아니다`() {
+        defaultCache2kManager.shouldNotBeNull()
+    }
+
+    @Test
+    fun `defaultCache2kManager는 동일 인스턴스를 반환한다`() {
+        val m1 = defaultCache2kManager
+        val m2 = defaultCache2kManager
+        (m1 === m2) shouldBeEqualTo true
+    }
+
+    @Test
+    fun `cache2kConfiguration - 이름과 설정으로 Cache2kConfig 생성`() {
+        val cacheName = "config-test-${System.nanoTime()}"
+        val config = cache2kConfiguration<String, Int>(cacheName) {
+            entryCapacity = 500
+            expireAfterWrite = Duration.ofSeconds(30)
+        }
+
+        config.shouldNotBeNull()
+        config.name shouldBeEqualTo cacheName
+        config.entryCapacity shouldBeEqualTo 500L
+    }
+
+    @Test
+    fun `cache2kConfiguration - 빈 name이면 IllegalArgumentException 발생`() {
+        assertFailsWith<IllegalArgumentException> {
+            cache2kConfiguration<String, Int>("") { }
+        }
+    }
+
+    @Test
+    fun `getCache2k - 존재하지 않는 캐시는 null 반환`() {
+        val result = getCache2k<String, Int>("non-existent-cache-${System.nanoTime()}")
+        result shouldBeEqualTo null
+    }
+
+    @Test
+    fun `getOrCreateCache2k - 새 캐시 생성 후 반환`() {
+        val cacheName = "get-or-create-test-${System.nanoTime()}"
+        val cache = getOrCreateCache2k<String, Int>(cacheName) {
+            name(cacheName)
+            entryCapacity(100)
+        }
+
+        cache.shouldNotBeNull()
+        cache.put("hello", 42)
+        cache.get("hello") shouldBeEqualTo 42
+
+        cache.close()
+    }
+
+    @Test
+    fun `getOrCreateCache2k - 빈 name이면 IllegalArgumentException 발생`() {
+        assertFailsWith<IllegalArgumentException> {
+            getOrCreateCache2k<String, Int>("") { }
+        }
+    }
+
+    @Test
+    fun `cache2k builder - 이름과 entryCapacity 설정`() {
+        val cacheName = "builder-test-${System.nanoTime()}"
+        val cache = cache2k<String, String> {
+            name(cacheName)
+            entryCapacity(200)
+        }.build()
+
+        cache.shouldNotBeNull()
+        cache.name shouldBeEqualTo cacheName
+
+        cache.put("key", "value")
+        cache.get("key") shouldBeEqualTo "value"
+
+        cache.close()
+    }
+}

--- a/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/JCacheEntryEventListenerTest.kt
+++ b/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/JCacheEntryEventListenerTest.kt
@@ -1,0 +1,96 @@
+package io.bluetape4k.cache.jcache
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.Test
+import javax.cache.configuration.MutableCacheEntryListenerConfiguration
+
+class JCacheEntryEventListenerTest {
+
+    companion object: KLogging()
+
+    private fun frontCache(name: String = "front-${System.nanoTime()}") =
+        JCaching.Caffeine.getOrCreate<String, String>(name)
+
+    private fun backCache(name: String = "back-${System.nanoTime()}") =
+        JCaching.Caffeine.getOrCreate<String, String>(name)
+
+    @Test
+    fun `onCreated - back cache에 추가되면 front cache에 동기화`() {
+        val front = frontCache()
+        val back = backCache()
+
+        val listener = JCacheEntryEventListener(front)
+        val config = MutableCacheEntryListenerConfiguration({ listener }, null, false, true)
+        back.registerCacheEntryListener(config)
+
+        back.put("key1", "value1")
+        Thread.sleep(100) // listener 전파 대기
+
+        front.containsKey("key1").shouldBeTrue()
+        front.get("key1") shouldBeEqualTo "value1"
+
+        front.close()
+        back.close()
+    }
+
+    @Test
+    fun `onUpdated - back cache 업데이트가 front에 반영`() {
+        val front = frontCache()
+        val back = backCache()
+
+        val listener = JCacheEntryEventListener(front)
+        val config = MutableCacheEntryListenerConfiguration({ listener }, null, false, true)
+        back.registerCacheEntryListener(config)
+
+        back.put("k", "v1")
+        Thread.sleep(100)
+        back.put("k", "v2")
+        Thread.sleep(100)
+
+        front.get("k") shouldBeEqualTo "v2"
+
+        front.close()
+        back.close()
+    }
+
+    @Test
+    fun `onRemoved - back cache 삭제가 front에 반영`() {
+        val front = frontCache()
+        val back = backCache()
+
+        front.put("key1", "value1")
+        val listener = JCacheEntryEventListener(front)
+        val config = MutableCacheEntryListenerConfiguration({ listener }, null, false, true)
+        back.registerCacheEntryListener(config)
+
+        back.put("key1", "value1")
+        Thread.sleep(100)
+        back.remove("key1")
+        Thread.sleep(100)
+
+        front.containsKey("key1").shouldBeFalse()
+
+        front.close()
+        back.close()
+    }
+
+    @Test
+    fun `closed front cache - 이벤트를 무시한다`() {
+        val front = frontCache()
+        front.close()
+
+        val back = backCache()
+        val listener = JCacheEntryEventListener(front)
+        val config = MutableCacheEntryListenerConfiguration({ listener }, null, false, true)
+        back.registerCacheEntryListener(config)
+
+        // 예외 없이 완료되어야 함
+        back.put("key1", "value1")
+        Thread.sleep(100)
+
+        back.close()
+    }
+}

--- a/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/JCacheSupportExtTest.kt
+++ b/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/JCacheSupportExtTest.kt
@@ -1,0 +1,122 @@
+package io.bluetape4k.cache.jcache
+
+import com.github.benmanes.caffeine.jcache.spi.CaffeineCachingProvider
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.Test
+import javax.cache.Cache
+
+class JCacheSupportExtTest {
+
+    companion object: KLogging()
+
+    @Test
+    fun `jcacheManagerOf - qualified name 으로 CacheManager 반환`() {
+        val manager = jcacheManagerOf(CaffeineCachingProvider::class.qualifiedName!!)
+        manager.shouldNotBeNull()
+    }
+
+    @Test
+    fun `jcacheConfigurationOf - cacheLoaderFactory 설정 시 람다 실행`() {
+        val backCache = JCaching.Caffeine.getOrCreate<String, Any>("jcache-loader-source-${System.nanoTime()}")
+        backCache.put("loader-key", "loader-value")
+
+        val config = jcacheConfigurationOf<String, Any>(
+            cacheLoaderFactory = { backCache.cacheLoader() },
+            isReadThrough = true,
+        )
+
+        config.shouldNotBeNull()
+        config.isReadThrough shouldBeEqualTo true
+
+        backCache.close()
+    }
+
+    @Test
+    fun `jcacheConfigurationOf - cacheWriterFactory 설정 시 람다 실행`() {
+        val backCache = JCaching.Caffeine.getOrCreate<String, Any>("jcache-writer-dest-${System.nanoTime()}")
+
+        val config = jcacheConfigurationOf<String, Any>(
+            cacheWriterFactory = { backCache.cacheWriter() },
+            isWriteThrough = true,
+        )
+
+        config.shouldNotBeNull()
+        config.isWriteThrough shouldBeEqualTo true
+
+        backCache.close()
+    }
+
+    @Test
+    fun `cacheLoader - load 와 loadAll 이 동작한다`() {
+        val cache = JCaching.Caffeine.getOrCreate<String, Any>("jcache-loader-test-${System.nanoTime()}")
+        cache.put("key1", "value1")
+        cache.put("key2", "value2")
+
+        val loader = cache.cacheLoader()
+
+        loader.load("key1") shouldBeEqualTo "value1"
+        loader.load("key2") shouldBeEqualTo "value2"
+
+        val all = loader.loadAll(mutableListOf("key1", "key2"))
+        all["key1"] shouldBeEqualTo "value1"
+        all["key2"] shouldBeEqualTo "value2"
+
+        cache.close()
+    }
+
+    @Test
+    fun `cacheWriter - write 와 delete 가 동작한다`() {
+        val cache = JCaching.Caffeine.getOrCreate<String, Any>("jcache-writer-test-${System.nanoTime()}")
+
+        val writer = cache.cacheWriter()
+
+        val entry = object: Cache.Entry<String, Any> {
+            override fun getKey(): String = "write-key"
+            override fun getValue(): Any = "write-value"
+            override fun <T: Any?> unwrap(clazz: Class<T>?): T = clazz!!.cast(this)
+        }
+
+        writer.write(entry)
+        cache.get("write-key") shouldBeEqualTo "write-value"
+
+        writer.delete("write-key")
+        val result = cache.get("write-key")
+        // delete 후 null 이어야 한다
+        result shouldBeEqualTo null
+
+        cache.close()
+    }
+
+    @Test
+    fun `cacheWriter - writeAll 과 deleteAll 이 동작한다`() {
+        val cache = JCaching.Caffeine.getOrCreate<String, Any>("jcache-writer-all-test-${System.nanoTime()}")
+
+        val writer = cache.cacheWriter()
+
+        val entries = mutableListOf<Cache.Entry<String, Any>>(
+            object: Cache.Entry<String, Any> {
+                override fun getKey(): String = "wk1"
+                override fun getValue(): Any = "wv1"
+                override fun <T: Any?> unwrap(clazz: Class<T>?): T = clazz!!.cast(this)
+            },
+            object: Cache.Entry<String, Any> {
+                override fun getKey(): String = "wk2"
+                override fun getValue(): Any = "wv2"
+                override fun <T: Any?> unwrap(clazz: Class<T>?): T = clazz!!.cast(this)
+            }
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        writer.writeAll(entries as MutableCollection<javax.cache.Cache.Entry<out String, out Any>>)
+        cache.get("wk1") shouldBeEqualTo "wv1"
+        cache.get("wk2") shouldBeEqualTo "wv2"
+
+        writer.deleteAll(mutableListOf("wk1", "wk2"))
+        cache.get("wk1") shouldBeEqualTo null
+        cache.get("wk2") shouldBeEqualTo null
+
+        cache.close()
+    }
+}

--- a/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/JCachingTest.kt
+++ b/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/JCachingTest.kt
@@ -1,0 +1,76 @@
+package io.bluetape4k.cache.jcache
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.Test
+
+class JCachingTest {
+
+    companion object: KLogging()
+
+    @Test
+    fun `JCaching Cache2k - getOrCreate 캐시 생성`() {
+        val cache = JCaching.Cache2k.getOrCreate<String, Int>("jcaching-cache2k-test")
+        cache.shouldNotBeNull()
+
+        cache.put("key1", 100)
+        cache.get("key1") shouldBeEqualTo 100
+        cache.containsKey("key1").shouldBeTrue()
+        cache.containsKey("missing").shouldBeFalse()
+        cache["missing"].shouldBeNull()
+
+        cache.remove("key1").shouldBeTrue()
+        cache.containsKey("key1").shouldBeFalse()
+    }
+
+    @Test
+    fun `JCaching Caffeine - getOrCreate 캐시 생성`() {
+        val cache = JCaching.Caffeine.getOrCreate<String, String>("jcaching-caffeine-test")
+        cache.shouldNotBeNull()
+
+        cache.putIfAbsent("hello", "world").shouldBeTrue()
+        cache.putIfAbsent("hello", "other").shouldBeFalse()
+        cache.get("hello") shouldBeEqualTo "world"
+
+        cache.close()
+    }
+
+    @Test
+    fun `JCaching EhCache - getOrCreate 캐시 생성`() {
+        val cache = JCaching.EhCache.getOrCreate<String, Long>("jcaching-ehcache-test")
+        cache.shouldNotBeNull()
+
+        cache.put("count", 42L)
+        cache.get("count") shouldBeEqualTo 42L
+
+        cache.remove("count")
+        cache.get("count").shouldBeNull()
+
+        cache.close()
+    }
+
+    @Test
+    fun `JCaching Cache2k cacheManager - 동일 인스턴스 반환`() {
+        val m1 = JCaching.Cache2k.cacheManager
+        val m2 = JCaching.Cache2k.cacheManager
+        (m1 === m2).shouldBeTrue()
+    }
+
+    @Test
+    fun `JCaching Caffeine cacheManager - 동일 인스턴스 반환`() {
+        val m1 = JCaching.Caffeine.cacheManager
+        val m2 = JCaching.Caffeine.cacheManager
+        (m1 === m2).shouldBeTrue()
+    }
+
+    @Test
+    fun `JCaching EhCache cacheManager - 동일 인스턴스 반환`() {
+        val m1 = JCaching.EhCache.cacheManager
+        val m2 = JCaching.EhCache.cacheManager
+        (m1 === m2).shouldBeTrue()
+    }
+}

--- a/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListenerTest.kt
+++ b/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListenerTest.kt
@@ -1,0 +1,110 @@
+package io.bluetape4k.cache.jcache
+
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.coEvery
+import org.junit.jupiter.api.Test
+import javax.cache.event.CacheEntryEvent
+import javax.cache.event.EventType
+
+class SuspendJCacheEntryEventListenerTest {
+
+    companion object: KLoggingChannel()
+
+    private fun mockEvent(key: String, value: String, eventType: EventType): CacheEntryEvent<String, String> {
+        val event = mockk<CacheEntryEvent<String, String>>()
+        every { event.key } returns key
+        every { event.value } returns value
+        every { event.eventType } returns eventType
+        every { event.source } returns mockk(relaxed = true)
+        return event
+    }
+
+    @Test
+    fun `onCreated - targetCache에 putAll 이 호출된다`() {
+        val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        every { targetCache.isClosed() } returns false
+        coEvery { targetCache.putAll(any()) } returns Unit
+
+        val listener = SuspendJCacheEntryEventListener(targetCache)
+        val event = mockEvent("k1", "v1", EventType.CREATED)
+
+        listener.onCreated(mutableListOf(event))
+        Thread.sleep(200)
+
+        coVerify { targetCache.putAll(mapOf("k1" to "v1")) }
+    }
+
+    @Test
+    fun `onUpdated - targetCache에 putAll 이 호출된다`() {
+        val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        every { targetCache.isClosed() } returns false
+        coEvery { targetCache.putAll(any()) } returns Unit
+
+        val listener = SuspendJCacheEntryEventListener(targetCache)
+        val event = mockEvent("k2", "v2", EventType.UPDATED)
+
+        listener.onUpdated(mutableListOf(event))
+        Thread.sleep(200)
+
+        coVerify { targetCache.putAll(mapOf("k2" to "v2")) }
+    }
+
+    @Test
+    fun `onRemoved - targetCache에 removeAll 이 호출된다`() {
+        val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        every { targetCache.isClosed() } returns false
+        coEvery { targetCache.removeAll(any<Set<String>>()) } returns Unit
+
+        val listener = SuspendJCacheEntryEventListener(targetCache)
+        val event = mockEvent("k3", "v3", EventType.REMOVED)
+
+        listener.onRemoved(mutableListOf(event))
+        Thread.sleep(200)
+
+        coVerify { targetCache.removeAll(setOf("k3")) }
+    }
+
+    @Test
+    fun `onExpired - targetCache에 removeAll 이 호출된다`() {
+        val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        every { targetCache.isClosed() } returns false
+        coEvery { targetCache.removeAll(any<Set<String>>()) } returns Unit
+
+        val listener = SuspendJCacheEntryEventListener(targetCache)
+        val event = mockEvent("k4", "v4", EventType.EXPIRED)
+
+        listener.onExpired(mutableListOf(event))
+        Thread.sleep(200)
+
+        coVerify { targetCache.removeAll(setOf("k4")) }
+    }
+
+    @Test
+    fun `targetCache 가 closed 이면 이벤트를 무시한다`() {
+        val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        every { targetCache.isClosed() } returns true
+
+        val listener = SuspendJCacheEntryEventListener(targetCache)
+        val event = mockEvent("k5", "v5", EventType.CREATED)
+
+        // 예외 없이 완료되어야 하며, putAll 이 호출되지 않아야 한다
+        listener.onCreated(mutableListOf(event))
+        Thread.sleep(100)
+
+        coVerify(exactly = 0) { targetCache.putAll(any()) }
+    }
+
+    @Test
+    fun `close - scope 가 취소된다`() {
+        val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        every { targetCache.isClosed() } returns false
+
+        val listener = SuspendJCacheEntryEventListener(targetCache)
+
+        // 예외 없이 완료되어야 한다
+        listener.close()
+    }
+}

--- a/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryTest.kt
+++ b/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryTest.kt
@@ -1,0 +1,42 @@
+package io.bluetape4k.cache.jcache
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.Test
+
+class SuspendJCacheEntryTest {
+
+    companion object: KLogging()
+
+    @Test
+    fun `key와 value를 올바르게 반환`() {
+        val entry = SuspendJCacheEntry("user:1", 42)
+        entry.getKey() shouldBeEqualTo "user:1"
+        entry.getValue() shouldBeEqualTo 42
+    }
+
+    @Test
+    fun `unwrap - 호환 타입이면 인스턴스 반환`() {
+        val entry = SuspendJCacheEntry("k", "v")
+        entry.unwrap(SuspendJCacheEntry::class.java).shouldNotBeNull()
+    }
+
+    @Test
+    fun `unwrap - 비호환 타입이면 null 반환`() {
+        val entry = SuspendJCacheEntry("k", "v")
+        entry.unwrap(String::class.java).shouldBeNull()
+    }
+
+    @Test
+    fun `data class equals와 copy`() {
+        val e1 = SuspendJCacheEntry("k", 1)
+        val e2 = SuspendJCacheEntry("k", 1)
+        val e3 = e1.copy(entryValue = 2)
+
+        (e1 == e2).shouldBeEqualTo(true)
+        (e1 == e3).shouldBeEqualTo(false)
+        e3.getValue() shouldBeEqualTo 2
+    }
+}

--- a/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/GetFailureStrategyTest.kt
+++ b/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/GetFailureStrategyTest.kt
@@ -1,0 +1,32 @@
+package io.bluetape4k.cache.nearcache
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.Test
+
+class GetFailureStrategyTest {
+
+    companion object: KLogging()
+
+    @Test
+    fun `enum 값이 2개 존재`() {
+        GetFailureStrategy.entries shouldHaveSize 2
+    }
+
+    @Test
+    fun `RETURN_FRONT_OR_NULL 값 확인`() {
+        GetFailureStrategy.RETURN_FRONT_OR_NULL.name shouldBeEqualTo "RETURN_FRONT_OR_NULL"
+    }
+
+    @Test
+    fun `PROPAGATE_EXCEPTION 값 확인`() {
+        GetFailureStrategy.PROPAGATE_EXCEPTION.name shouldBeEqualTo "PROPAGATE_EXCEPTION"
+    }
+
+    @Test
+    fun `valueOf 변환`() {
+        GetFailureStrategy.valueOf("RETURN_FRONT_OR_NULL") shouldBeEqualTo GetFailureStrategy.RETURN_FRONT_OR_NULL
+        GetFailureStrategy.valueOf("PROPAGATE_EXCEPTION") shouldBeEqualTo GetFailureStrategy.PROPAGATE_EXCEPTION
+    }
+}

--- a/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/NearCacheResilienceConfigBuilderTest.kt
+++ b/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/NearCacheResilienceConfigBuilderTest.kt
@@ -1,0 +1,84 @@
+package io.bluetape4k.cache.nearcache
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import kotlin.test.assertFailsWith
+
+class NearCacheResilienceConfigBuilderTest {
+
+    companion object: KLogging()
+
+    @Test
+    fun `기본값으로 NearCacheResilienceConfig DSL 빌더 생성`() {
+        val config = nearCacheResilienceConfig { }
+
+        config.retryMaxAttempts shouldBeEqualTo 3
+        config.retryWaitDuration shouldBeEqualTo Duration.ofMillis(500)
+        config.retryExponentialBackoff shouldBeEqualTo true
+        config.getFailureStrategy shouldBeEqualTo GetFailureStrategy.RETURN_FRONT_OR_NULL
+    }
+
+    @Test
+    fun `커스텀 값으로 NearCacheResilienceConfig DSL 빌더 생성`() {
+        val config = nearCacheResilienceConfig {
+            retryMaxAttempts = 5
+            retryWaitDuration = Duration.ofSeconds(1)
+            retryExponentialBackoff = false
+            getFailureStrategy = GetFailureStrategy.PROPAGATE_EXCEPTION
+        }
+
+        config.retryMaxAttempts shouldBeEqualTo 5
+        config.retryWaitDuration shouldBeEqualTo Duration.ofSeconds(1)
+        config.retryExponentialBackoff.shouldBeFalse()
+        config.getFailureStrategy shouldBeEqualTo GetFailureStrategy.PROPAGATE_EXCEPTION
+    }
+
+    @Test
+    fun `builder build - 기본값으로 생성`() {
+        val builder = NearCacheResilienceConfigBuilder()
+        val config = builder.build()
+
+        config.retryMaxAttempts shouldBeEqualTo 3
+        config.retryWaitDuration shouldBeEqualTo Duration.ofMillis(500)
+        config.retryExponentialBackoff.shouldBeTrue()
+        config.getFailureStrategy shouldBeEqualTo GetFailureStrategy.RETURN_FRONT_OR_NULL
+    }
+
+    @Test
+    fun `builder build - 커스텀 값으로 생성`() {
+        val builder = NearCacheResilienceConfigBuilder().apply {
+            retryMaxAttempts = 10
+            retryWaitDuration = Duration.ofSeconds(2)
+            retryExponentialBackoff = false
+            getFailureStrategy = GetFailureStrategy.PROPAGATE_EXCEPTION
+        }
+        val config = builder.build()
+
+        config.retryMaxAttempts shouldBeEqualTo 10
+        config.retryWaitDuration shouldBeEqualTo Duration.ofSeconds(2)
+        config.retryExponentialBackoff.shouldBeFalse()
+        config.getFailureStrategy shouldBeEqualTo GetFailureStrategy.PROPAGATE_EXCEPTION
+    }
+
+    @Test
+    fun `retryMaxAttempts 가 0 이하면 IllegalArgumentException 발생`() {
+        assertFailsWith<IllegalArgumentException> {
+            nearCacheResilienceConfig {
+                retryMaxAttempts = 0
+            }
+        }
+    }
+
+    @Test
+    fun `retryMaxAttempts 가 음수이면 IllegalArgumentException 발생`() {
+        assertFailsWith<IllegalArgumentException> {
+            nearCacheResilienceConfig {
+                retryMaxAttempts = -1
+            }
+        }
+    }
+}

--- a/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/NearCacheStatisticsTest.kt
+++ b/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/NearCacheStatisticsTest.kt
@@ -1,0 +1,59 @@
+package io.bluetape4k.cache.nearcache
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.Test
+
+class NearCacheStatisticsTest {
+
+    companion object: KLogging()
+
+    @Test
+    fun `hitRate - 모든 값이 0이면 0_0 반환`() {
+        val stats = DefaultNearCacheStatistics()
+        stats.hitRate shouldBeEqualTo 0.0
+    }
+
+    @Test
+    fun `hitRate - localHits만 있으면 1_0`() {
+        val stats = DefaultNearCacheStatistics(localHits = 10)
+        stats.hitRate shouldBeEqualTo 1.0
+    }
+
+    @Test
+    fun `hitRate - backHits만 있으면 1_0`() {
+        val stats = DefaultNearCacheStatistics(backHits = 5)
+        stats.hitRate shouldBeEqualTo 1.0
+    }
+
+    @Test
+    fun `hitRate - backMisses만 있으면 0_0`() {
+        val stats = DefaultNearCacheStatistics(backMisses = 3)
+        stats.hitRate shouldBeEqualTo 0.0
+    }
+
+    @Test
+    fun `hitRate - 혼합 케이스 계산`() {
+        val stats = DefaultNearCacheStatistics(
+            localHits = 10,
+            backHits = 1,
+            backMisses = 1
+        )
+        // (10+1) / (10+1+1) = 11/12
+        val expected = 11.0 / 12.0
+        assert(kotlin.math.abs(stats.hitRate - expected) < 1e-9) {
+            "Expected $expected but was ${stats.hitRate}"
+        }
+    }
+
+    @Test
+    fun `data class 기본값`() {
+        val stats = DefaultNearCacheStatistics()
+        stats.localHits shouldBeEqualTo 0L
+        stats.localMisses shouldBeEqualTo 0L
+        stats.localSize shouldBeEqualTo 0L
+        stats.localEvictions shouldBeEqualTo 0L
+        stats.backHits shouldBeEqualTo 0L
+        stats.backMisses shouldBeEqualTo 0L
+    }
+}

--- a/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/BackJCacheCommandTest.kt
+++ b/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/BackJCacheCommandTest.kt
@@ -1,0 +1,66 @@
+package io.bluetape4k.cache.nearcache.jcache
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.Test
+
+class BackJCacheCommandTest {
+
+    companion object: KLogging()
+
+    @Test
+    fun `Put - key와 value 보관`() {
+        val cmd = BackJCacheCommand.Put("hello", 5)
+        cmd.key shouldBeEqualTo "hello"
+        cmd.value shouldBeEqualTo 5
+        (cmd is BackJCacheCommand<*, *>).shouldBeTrue()
+    }
+
+    @Test
+    fun `PutAll - entries 보관`() {
+        val entries = mapOf("a" to 1, "b" to 2)
+        val cmd = BackJCacheCommand.PutAll<String, Int>(entries)
+        cmd.entries shouldBeEqualTo entries
+    }
+
+    @Test
+    fun `Remove - key 보관`() {
+        val cmd = BackJCacheCommand.Remove<String, Int>("key1")
+        cmd.key shouldBeEqualTo "key1"
+    }
+
+    @Test
+    fun `RemoveAll - keys 보관`() {
+        val keys = setOf("k1", "k2", "k3")
+        val cmd = BackJCacheCommand.RemoveAll<String, Int>(keys)
+        cmd.keys shouldBeEqualTo keys
+    }
+
+    @Test
+    fun `ClearBack - 인스턴스 생성`() {
+        val cmd = BackJCacheCommand.ClearBack<String, Int>()
+        (cmd is BackJCacheCommand.ClearBack).shouldBeTrue()
+    }
+
+    @Test
+    fun `sealed interface - when 분기`() {
+        val cmds: List<BackJCacheCommand<String, Int>> = listOf(
+            BackJCacheCommand.Put("k", 1),
+            BackJCacheCommand.PutAll(mapOf("a" to 2)),
+            BackJCacheCommand.Remove("r"),
+            BackJCacheCommand.RemoveAll(setOf("x")),
+            BackJCacheCommand.ClearBack(),
+        )
+        val types = cmds.map { cmd ->
+            when (cmd) {
+                is BackJCacheCommand.Put -> "Put"
+                is BackJCacheCommand.PutAll -> "PutAll"
+                is BackJCacheCommand.Remove -> "Remove"
+                is BackJCacheCommand.RemoveAll -> "RemoveAll"
+                is BackJCacheCommand.ClearBack -> "ClearBack"
+            }
+        }
+        types shouldBeEqualTo listOf("Put", "PutAll", "Remove", "RemoveAll", "ClearBack")
+    }
+}

--- a/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientNearJCacheConfigBuilderTest.kt
+++ b/infra/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientNearJCacheConfigBuilderTest.kt
@@ -1,0 +1,119 @@
+package io.bluetape4k.cache.nearcache.jcache
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.cache.nearcache.GetFailureStrategy
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import kotlin.test.assertFailsWith
+
+class ResilientNearJCacheConfigBuilderTest {
+
+    companion object: KLogging()
+
+    @Test
+    fun `기본값으로 ResilientNearJCacheConfig DSL 빌더 생성`() {
+        val config = resilientNearJCacheConfig<String, Int> { }
+
+        config.cacheName shouldBeEqualTo "resilient-near-cache"
+        config.maxLocalSize shouldBeEqualTo 10_000L
+        config.frontExpireAfterWrite shouldBeEqualTo Duration.ofMinutes(30)
+        config.frontExpireAfterAccess.shouldBeNull()
+        config.recordStats.shouldBeFalse()
+        config.writeQueueCapacity shouldBeEqualTo 1024
+        config.retryMaxAttempts shouldBeEqualTo 3
+        config.retryWaitDuration shouldBeEqualTo Duration.ofMillis(500)
+        config.retryExponentialBackoff.shouldBeTrue()
+        config.getFailureStrategy shouldBeEqualTo GetFailureStrategy.RETURN_FRONT_OR_NULL
+    }
+
+    @Test
+    fun `커스텀 값으로 ResilientNearJCacheConfig DSL 빌더 생성`() {
+        val config = resilientNearJCacheConfig<String, String> {
+            cacheName = "my-resilient-cache"
+            maxLocalSize = 5000L
+            frontExpireAfterWrite = Duration.ofMinutes(10)
+            frontExpireAfterAccess = Duration.ofMinutes(5)
+            recordStats = true
+            writeQueueCapacity = 512
+            retryMaxAttempts = 5
+            retryWaitDuration = Duration.ofSeconds(1)
+            retryExponentialBackoff = false
+            getFailureStrategy = GetFailureStrategy.PROPAGATE_EXCEPTION
+        }
+
+        config.cacheName shouldBeEqualTo "my-resilient-cache"
+        config.maxLocalSize shouldBeEqualTo 5000L
+        config.frontExpireAfterWrite shouldBeEqualTo Duration.ofMinutes(10)
+        config.frontExpireAfterAccess.shouldNotBeNull()
+        config.frontExpireAfterAccess shouldBeEqualTo Duration.ofMinutes(5)
+        config.recordStats.shouldBeTrue()
+        config.writeQueueCapacity shouldBeEqualTo 512
+        config.retryMaxAttempts shouldBeEqualTo 5
+        config.retryWaitDuration shouldBeEqualTo Duration.ofSeconds(1)
+        config.retryExponentialBackoff.shouldBeFalse()
+        config.getFailureStrategy shouldBeEqualTo GetFailureStrategy.PROPAGATE_EXCEPTION
+    }
+
+    @Test
+    fun `builder build - 기본값으로 생성`() {
+        val builder = ResilientNearJCacheConfigBuilder<String, Int>()
+        val config = builder.build()
+
+        config.cacheName shouldBeEqualTo "resilient-near-cache"
+        config.maxLocalSize shouldBeEqualTo 10_000L
+        config.frontExpireAfterAccess.shouldBeNull()
+        config.recordStats.shouldBeFalse()
+    }
+
+    @Test
+    fun `builder build - frontExpireAfterAccess 설정 가능`() {
+        val builder = ResilientNearJCacheConfigBuilder<String, String>().apply {
+            frontExpireAfterAccess = Duration.ofMinutes(15)
+        }
+        val config = builder.build()
+
+        config.frontExpireAfterAccess.shouldNotBeNull()
+        config.frontExpireAfterAccess shouldBeEqualTo Duration.ofMinutes(15)
+    }
+
+    @Test
+    fun `builder build - frontExpireAfterAccess null 유지`() {
+        val config = resilientNearJCacheConfig<String, Int> {
+            frontExpireAfterAccess = null
+        }
+
+        config.frontExpireAfterAccess.shouldBeNull()
+    }
+
+    @Test
+    fun `retryMaxAttempts 가 0 이하면 IllegalArgumentException 발생`() {
+        assertFailsWith<IllegalArgumentException> {
+            resilientNearJCacheConfig<String, Int> {
+                retryMaxAttempts = 0
+            }
+        }
+    }
+
+    @Test
+    fun `maxLocalSize 가 0 이하면 IllegalArgumentException 발생`() {
+        assertFailsWith<IllegalArgumentException> {
+            resilientNearJCacheConfig<String, Int> {
+                maxLocalSize = 0L
+            }
+        }
+    }
+
+    @Test
+    fun `writeQueueCapacity 가 0 이하면 IllegalArgumentException 발생`() {
+        assertFailsWith<IllegalArgumentException> {
+            resilientNearJCacheConfig<String, Int> {
+                writeQueueCapacity = 0
+            }
+        }
+    }
+}

--- a/infra/lettuce/build.gradle.kts
+++ b/infra/lettuce/build.gradle.kts
@@ -12,6 +12,14 @@ sourceSets {
     create("benchmark")
 }
 
+kover {
+    currentProject {
+        sources {
+            excludedSourceSets.add("benchmark")
+        }
+    }
+}
+
 kotlin {
     target {
         compilations.getByName("benchmark").associateWith(compilations.getByName("main"))

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/RedisCommandSupportsTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/RedisCommandSupportsTest.kt
@@ -1,0 +1,65 @@
+package io.bluetape4k.redis.lettuce
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+class RedisCommandSupportsTest: AbstractLettuceTest() {
+
+    @AfterEach
+    fun teardown() {
+        RedisCommandSupports.clearCache()
+    }
+
+    @Test
+    fun `supports - 기본 명령어 GET은 항상 지원`() {
+        RedisCommandSupports.supports(client, "GET").shouldBeTrue()
+    }
+
+    @Test
+    fun `supports - 알 수 없는 명령어도 예외 없이 완료`() {
+        val result = runCatching { RedisCommandSupports.supports(client, "NONEXISTENTCMD12345") }
+        result.isSuccess.shouldBeTrue()
+    }
+
+    @Test
+    fun `supports - 동일 명령어 재조회는 캐시에서 반환`() {
+        RedisCommandSupports.supports(client, "SET").shouldBeTrue()
+        RedisCommandSupports.supports(client, "SET").shouldBeTrue()
+    }
+
+    @Test
+    fun `supports - 대소문자 무관하게 동작`() {
+        val upper = RedisCommandSupports.supports(client, "HSET")
+        val lower = RedisCommandSupports.supports(client, "hset")
+        upper shouldBeEqualTo lower
+    }
+
+    @Test
+    fun `supportsHSetEx - Redis 서버 버전에 따라 결과 반환`() {
+        // 결과에 관계없이 예외 없이 완료되어야 함
+        val result = runCatching { RedisCommandSupports.supportsHSetEx(client) }
+        result.isSuccess.shouldBeTrue()
+    }
+
+    @Test
+    fun `supportsLMPop - Redis 7+에서 지원`() {
+        val result = runCatching { RedisCommandSupports.supportsLMPop(client) }
+        result.isSuccess.shouldBeTrue()
+    }
+
+    @Test
+    fun `supportsWaitAof - Redis 7_2+에서 지원`() {
+        val result = runCatching { RedisCommandSupports.supportsWaitAof(client) }
+        result.isSuccess.shouldBeTrue()
+    }
+
+    @Test
+    fun `clearCache - 캐시를 초기화한다`() {
+        RedisCommandSupports.supports(client, "GET")
+        RedisCommandSupports.clearCache()
+        RedisCommandSupports.supports(client, "GET").shouldBeTrue()
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/RedisFutureSupportTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/RedisFutureSupportTest.kt
@@ -1,0 +1,68 @@
+package io.bluetape4k.redis.lettuce
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.redis.lettuce.LettuceTestUtils.asyncCommands
+import kotlinx.coroutines.future.await
+import org.junit.jupiter.api.Test
+
+class RedisFutureSupportTest: AbstractLettuceTest() {
+
+    companion object: KLoggingChannel() {
+        private const val ITEM_SIZE = 20
+    }
+
+    @Test
+    fun `awaitSuspending - RedisFuture 결과를 suspend로 대기`() = runSuspendIO {
+        val keyName = randomName()
+        asyncCommands.set(keyName, "value").awaitSuspending() shouldBeEqualTo "OK"
+        asyncCommands.get(keyName).awaitSuspending() shouldBeEqualTo "value"
+        asyncCommands.del(keyName).await()
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `suspendAwait - deprecated 버전도 정상 동작`() = runSuspendIO {
+        val keyName = randomName()
+        asyncCommands.set(keyName, "hello").suspendAwait() shouldBeEqualTo "OK"
+        asyncCommands.del(keyName).await()
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `coAwait - deprecated 버전도 정상 동작`() = runSuspendIO {
+        val keyName = randomName()
+        asyncCommands.set(keyName, "world").coAwait() shouldBeEqualTo "OK"
+        asyncCommands.del(keyName).await()
+    }
+
+    @Test
+    fun `awaitAll - 빈 컬렉션은 빈 리스트 반환`() = runSuspendIO {
+        val result = emptyList<io.lettuce.core.RedisFuture<String>>().awaitAll()
+        result shouldHaveSize 0
+    }
+
+    @Test
+    fun `awaitAll - 복수 RedisFuture 일괄 대기`() = runSuspendIO {
+        val keyName = randomName()
+        val futures = List(ITEM_SIZE) { i ->
+            asyncCommands.hset(keyName, i.toString(), i)
+        }
+        val results = futures.awaitAll()
+        results shouldHaveSize ITEM_SIZE
+        asyncCommands.del(keyName).await()
+    }
+
+    @Test
+    fun `sequence - RedisFuture 컬렉션을 CompletableFuture로 변환`() {
+        val keyName = randomName()
+        val futures = List(ITEM_SIZE) { i ->
+            asyncCommands.hset(keyName, i.toString(), i)
+        }.sequence()
+        val results = futures.get()
+        results shouldHaveSize ITEM_SIZE
+        asyncCommands.del(keyName).get()
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/filter/Murmur3Test.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/filter/Murmur3Test.kt
@@ -1,0 +1,65 @@
+package io.bluetape4k.redis.lettuce.filter
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.Test
+
+class Murmur3Test {
+
+    companion object: KLogging()
+
+    @Test
+    fun `hash128x64 - 빈 바이트 배열 처리`() {
+        val result = Murmur3.hash128x64(ByteArray(0))
+        result shouldHaveSize 2
+    }
+
+    @Test
+    fun `hash128x64 - 동일 입력은 동일 해시`() {
+        val data = "hello world".toByteArray()
+        val h1 = Murmur3.hash128x64(data)
+        val h2 = Murmur3.hash128x64(data)
+        h1[0] shouldBeEqualTo h2[0]
+        h1[1] shouldBeEqualTo h2[1]
+    }
+
+    @Test
+    fun `hash128x64 - 다른 입력은 다른 해시`() {
+        val h1 = Murmur3.hash128x64("foo".toByteArray())
+        val h2 = Murmur3.hash128x64("bar".toByteArray())
+        assert(h1[0] != h2[0] || h1[1] != h2[1]) { "Hash collision for foo vs bar" }
+    }
+
+    @Test
+    fun `hash128x64 - seed 변경시 다른 해시`() {
+        val data = "test".toByteArray()
+        val h1 = Murmur3.hash128x64(data, seed = 0L)
+        val h2 = Murmur3.hash128x64(data, seed = 42L)
+        assert(h1[0] != h2[0] || h1[1] != h2[1]) { "Seed should change hash" }
+    }
+
+    @Test
+    fun `hash128x64 - 15바이트 이하 tail 처리`() {
+        for (len in 1..15) {
+            val data = ByteArray(len) { it.toByte() }
+            val result = Murmur3.hash128x64(data)
+            result shouldHaveSize 2
+        }
+    }
+
+    @Test
+    fun `hash128x64 - 16바이트 이상 블록 처리`() {
+        val data = ByteArray(64) { it.toByte() }
+        val result = Murmur3.hash128x64(data)
+        result shouldHaveSize 2
+    }
+
+    @Test
+    fun `hash128x64 - 알려진 벡터 검증`() {
+        val data = "The quick brown fox".toByteArray(Charsets.UTF_8)
+        val result = Murmur3.hash128x64(data, 0L)
+        result shouldHaveSize 2
+        assert(result[0] != 0L || result[1] != 0L)
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceStringMapTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceStringMapTest.kt
@@ -1,0 +1,77 @@
+package io.bluetape4k.redis.lettuce.map
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.redis.lettuce.AbstractLettuceTest
+import io.bluetape4k.redis.lettuce.LettuceClients
+import io.bluetape4k.redis.lettuce.LettuceTestUtils
+import io.lettuce.core.codec.StringCodec
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class LettuceStringMapTest: AbstractLettuceTest() {
+
+    companion object: KLoggingChannel() {
+        private val connection by lazy { LettuceClients.connect(LettuceTestUtils.client, StringCodec.UTF8) }
+    }
+
+    private lateinit var map: LettuceStringMap
+
+    @BeforeEach
+    fun setup() {
+        map = LettuceStringMap(connection, randomName())
+    }
+
+    @AfterEach
+    fun teardown() {
+        map.clear()
+    }
+
+    @Test
+    fun `put and get - 기본 CRUD`() {
+        map.put("key1", "value1").shouldBeTrue()
+        map.get("key1") shouldBeEqualTo "value1"
+
+        map.put("key1", "updated").shouldBeFalse()
+        map.get("key1") shouldBeEqualTo "updated"
+    }
+
+    @Test
+    fun `get - 존재하지 않는 키는 null 반환`() {
+        map.get("notexist").shouldBeNull()
+    }
+
+    @Test
+    fun `putIfAbsent - 없을 때만 설정`() {
+        map.putIfAbsent("key1", "first").shouldBeTrue()
+        map.putIfAbsent("key1", "second").shouldBeFalse()
+        map.get("key1") shouldBeEqualTo "first"
+    }
+
+    @Test
+    fun `size and isEmpty`() {
+        map.isEmpty().shouldBeTrue()
+        map.put("a", "1")
+        map.put("b", "2")
+        map.size() shouldBeEqualTo 2L
+        map.isEmpty().shouldBeFalse()
+    }
+
+    @Test
+    fun `putAll and keys`() {
+        map.putAll(mapOf("x" to "1", "y" to "2", "z" to "3"))
+        map.keySet() shouldHaveSize 3
+    }
+
+    @Test
+    fun `remove - 필드 삭제`() {
+        map.put("key1", "val")
+        map.remove("key1") shouldBeEqualTo 1L
+        map.containsKey("key1").shouldBeFalse()
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendStringMapTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendStringMapTest.kt
@@ -1,0 +1,78 @@
+package io.bluetape4k.redis.lettuce.map
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.redis.lettuce.AbstractLettuceTest
+import io.bluetape4k.redis.lettuce.LettuceClients
+import io.bluetape4k.redis.lettuce.LettuceTestUtils
+import io.lettuce.core.codec.StringCodec
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class LettuceSuspendStringMapTest: AbstractLettuceTest() {
+
+    companion object: KLoggingChannel() {
+        private val connection by lazy { LettuceClients.connect(LettuceTestUtils.client, StringCodec.UTF8) }
+    }
+
+    private lateinit var map: LettuceSuspendStringMap
+
+    @BeforeEach
+    fun setup() {
+        map = LettuceSuspendStringMap(connection, randomName())
+    }
+
+    @AfterEach
+    fun teardown() = runSuspendIO {
+        map.clear()
+    }
+
+    @Test
+    fun `put and get - 기본 CRUD`() = runSuspendIO {
+        map.put("key1", "value1").shouldBeTrue()
+        map.get("key1") shouldBeEqualTo "value1"
+
+        map.put("key1", "updated").shouldBeFalse()
+        map.get("key1") shouldBeEqualTo "updated"
+    }
+
+    @Test
+    fun `get - 존재하지 않는 키는 null 반환`() = runSuspendIO {
+        map.get("notexist").shouldBeNull()
+    }
+
+    @Test
+    fun `putIfAbsent - 없을 때만 설정`() = runSuspendIO {
+        map.putIfAbsent("key1", "first").shouldBeTrue()
+        map.putIfAbsent("key1", "second").shouldBeFalse()
+        map.get("key1") shouldBeEqualTo "first"
+    }
+
+    @Test
+    fun `size and isEmpty`() = runSuspendIO {
+        map.isEmpty().shouldBeTrue()
+        map.put("a", "1")
+        map.put("b", "2")
+        map.size() shouldBeEqualTo 2L
+        map.isEmpty().shouldBeFalse()
+    }
+
+    @Test
+    fun `putAll and keySet`() = runSuspendIO {
+        map.putAll(mapOf("x" to "1", "y" to "2", "z" to "3"))
+        map.keySet() shouldHaveSize 3
+    }
+
+    @Test
+    fun `remove - 필드 삭제`() = runSuspendIO {
+        map.put("key1", "val")
+        map.remove("key1") shouldBeEqualTo 1L
+        map.containsKey("key1").shouldBeFalse()
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMapTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMapTest.kt
@@ -1,0 +1,92 @@
+package io.bluetape4k.redis.lettuce.map
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.redis.lettuce.AbstractLettuceTest
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+class LettuceSuspendedLoadedMapTest: AbstractLettuceTest() {
+
+    companion object: KLoggingChannel()
+
+    private fun newMap(
+        loader: SuspendedMapLoader<String, String>? = null,
+        writer: SuspendedMapWriter<String, String>? = null,
+        config: LettuceCacheConfig = LettuceCacheConfig.READ_WRITE_THROUGH,
+    ): LettuceSuspendedLoadedMap<String, String> =
+        LettuceSuspendedLoadedMap(
+            client = client,
+            loader = loader,
+            writer = writer,
+            config = config.copy(keyPrefix = "suspend-loaded-test:${randomName()}")
+        )
+
+    @Test
+    fun `get - loader가 null이면 캐시 미스 시 null 반환`() = runSuspendIO {
+        newMap().use { map ->
+            map.get("nonexistent").shouldBeNull()
+        }
+    }
+
+    @Test
+    fun `get - Read-through - 캐시 미스 시 loader 호출 후 캐싱`() = runSuspendIO {
+        val callCount = AtomicInteger(0)
+        val loader = object: SuspendedMapLoader<String, String> {
+            override suspend fun load(key: String): String {
+                callCount.incrementAndGet()
+                return "loaded-$key"
+            }
+
+            override suspend fun loadAllKeys(): List<String> = emptyList()
+        }
+
+        newMap(loader = loader).use { map ->
+            val value = map.get("key1")
+            value shouldBeEqualTo "loaded-key1"
+            callCount.get() shouldBeEqualTo 1
+
+            // 두 번째 조회는 캐시 히트 → loader 미호출
+            map.get("key1") shouldBeEqualTo "loaded-key1"
+            callCount.get() shouldBeEqualTo 1
+        }
+    }
+
+    @Test
+    fun `set - Write-through - writer 호출`() = runSuspendIO {
+        val written = mutableMapOf<String, String>()
+        val writer = object: SuspendedMapWriter<String, String> {
+            override suspend fun write(map: Map<String, String>) {
+                written.putAll(map)
+            }
+
+            override suspend fun delete(keys: Collection<String>) {
+                keys.forEach { written.remove(it) }
+            }
+        }
+
+        newMap(writer = writer).use { map ->
+            map.set("key1", "value1")
+            written["key1"] shouldBeEqualTo "value1"
+        }
+    }
+
+    @Test
+    fun `get - NONE 모드 - loader 없이 Redis만 사용`() = runSuspendIO {
+        newMap(config = LettuceCacheConfig.READ_ONLY).use { map ->
+            map.get("key1").shouldBeNull()
+            map.set("key1", "direct")
+            map.get("key1") shouldBeEqualTo "direct"
+        }
+    }
+
+    @Test
+    fun `close - 리소스 정리`() = runSuspendIO {
+        val map = newMap()
+        map.shouldNotBeNull()
+        map.close()
+    }
+}


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: test: infra/lettuce + cache-core 테스트 커버리지 80% 달성

`infra/lettuce`와 `infra/cache-core` 모듈의 테스트 커버리지를 80% 이상으로 달성했습니다.

| 모듈 | 이전 | 이후 | 달성 |
|------|------|------|------|
| `infra/lettuce` | 67.71% | **80.04%** | ✅ |
| `infra/cache-core` | 71.45% | **80.34%** | ✅ |

---

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: infra/lettuce 변경 사항

### build.gradle.kts
- `benchmark` sourceSet을 kover 측정에서 제외 (`LettuceCodecBenchmark` 46줄이 0% 커버리지로 측정에 포함되던 문제 수정)

### 신규 테스트 파일 (6개)
| 파일 | 검증 내용 |
|------|-----------|
| `RedisCommandSupportsTest` | `supports()` 캐싱/대소문자 처리/`clearCache()` |
| `RedisFutureSupportTest` | `awaitSuspending()`, `awaitAll()`, `sequence()` |
| `LettuceStringMapTest` | `LettuceStringMap` CRUD |
| `LettuceSuspendStringMapTest` | `LettuceSuspendStringMap` CRUD (suspend) |
| `LettuceSuspendedLoadedMapTest` | Read-through / Write-through / NONE 모드 |
| `filter/Murmur3Test` | `internal object Murmur3` 해시 함수 (동일 패키지) |

---

### 기존 섹션: infra/cache-core 변경 사항

### 신규 테스트 파일 (11개)
| 파일 | 검증 내용 |
|------|-----------|
| `JCachingTest` | Cache2k / Caffeine / EhCache 팩토리 |
| `JCacheEntryEventListenerTest` | onCreated / onUpdated / onRemoved 이벤트 |
| `JCacheSupportExtTest` | `jcacheManagerOf`, `cacheLoader`, `cacheWriter` |
| `SuspendJCacheEntryTest` | 불변 엔트리 data class |
| `SuspendJCacheEntryEventListenerTest` | 코루틴 기반 리스너 (MockK) |
| `NearCacheStatisticsTest` | `hitRate` 계산 |
| `GetFailureStrategyTest` | enum 값 검증 |
| `BackJCacheCommandTest` | sealed interface 분기 |
| `NearCacheResilienceConfigBuilderTest` | DSL 빌더 |
| `ResilientNearJCacheConfigBuilderTest` | DSL 빌더 |
| `Cache2kSupportExtTest` | `cache2kConfiguration`, `getOrCreateCache2k` |

---

### 기존 섹션: 주요 발견 및 수정

- **benchmark sourceSet**: kover가 production code로 인식하여 측정에 포함 → `excludedSourceSets.add("benchmark")` 추가
- **internal 클래스 테스트**: `Murmur3Test`를 동일 패키지(`filter/`)에 배치해야 컴파일 가능
- **Cache2kBuilder vs Cache2kConfig**: 람다 receiver 타입에 따라 API가 다름 (메서드 vs 프로퍼티)
- **Java wildcard generics**: `CacheWriter.writeAll()` 호출 시 `@Suppress("UNCHECKED_CAST")` + 명시적 캐스트 필요
- **kover XML 분석**: `koverXmlReport` 파싱으로 missed lines 기준 우선순위 결정 → 효율적인 커버리지 개선

### 기존 섹션: 검증 명령어

```bash
./gradlew :bluetape4k-lettuce:koverXmlReport
./gradlew :bluetape4k-cache-core:koverXmlReport
```

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #329, head `da885644f63705ccdebfec49f2e22bc6ba4c9691`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/test-coverage-lettuce-cache`
- Labels: `test`
- State: `MERGED`, merge commit `026499f56620001e8f6f381de9ecf5c7baae97ee`
- CI: ### build.gradle.kts / ./gradlew :bluetape4k-lettuce:koverXmlReport / ./gradlew :bluetape4k-cache-core:koverXmlReport

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #329 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `026499f56620001e8f6f381de9ecf5c7baae97ee`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
