### PR TITLE
perf: coroutines joinUntil 테스트 slow sleep 단축 (5000ms → 200ms)

### DIFF
--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/StructuredConcurrencyTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/StructuredConcurrencyTest.kt
@@ -370,7 +370,9 @@ class StructuredConcurrencyTest {
         val deadline = java.time.Instant.now().plusMillis(50)
         assertFailsWith<TimeoutException> {
             taskScope<Unit> {
-                fork { Thread.sleep(5000) }
+                // StructuredTaskScope.close()는 forked thread 완료까지 대기하므로
+                // sleep을 deadline보다 크되 최소화 (200ms > 50ms deadline)
+                fork { Thread.sleep(200) }
                 joinUntil(deadline).throwIfFailed()
             }
         }
@@ -381,7 +383,7 @@ class StructuredConcurrencyTest {
         val deadline = java.time.Instant.now().plusMillis(50)
         assertFailsWith<TimeoutException> {
             supervisedTaskScope<Int, List<Result<Int>>> {
-                fork { Thread.sleep(5000); 1 }
+                fork { Thread.sleep(200); 1 }
                 joinUntil(deadline)
                 results()
             }

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/support/CompletableFutureExamples.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/support/CompletableFutureExamples.kt
@@ -12,11 +12,11 @@ import kotlinx.coroutines.future.future
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
-import io.bluetape4k.assertions.assertFailsWith
 import kotlin.time.Duration.Companion.milliseconds
 
 class CompletableFutureExamples {
@@ -35,7 +35,6 @@ class CompletableFutureExamples {
 
     @Test
     fun `예외를 발생시키는 suspend 함수를 CompletableFuture로 변환하기`() = runTest {
-        // 예외를 Catch하기 위해 SupervisorJob을 사용합니다.
         assertFailsWith<BluetapeException> {
             val job = coroutineContext + SupervisorJob()
             withContext(job) {
@@ -44,7 +43,6 @@ class CompletableFutureExamples {
                     log.debug { "예외를 발생시킵니다." }
                     throw BluetapeException("Boom!")
                 }
-
                 log.debug { "예외가 발생했는지 확인합니다." }
                 future.await()
             }

--- a/testing/assertions/src/main/kotlin/io/bluetape4k/assertions/Exceptions.kt
+++ b/testing/assertions/src/main/kotlin/io/bluetape4k/assertions/Exceptions.kt
@@ -5,7 +5,6 @@ import kotlin.coroutines.cancellation.CancellationException
 import kotlin.reflect.KClass
 import kotlin.time.Duration
 import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 
 /**
@@ -333,23 +332,23 @@ class CoInvokingBlock(val block: suspend () -> Any?) {
 fun coInvoking(block: suspend () -> Any?): CoInvokingBlock = CoInvokingBlock(block)
 
 /**
- * 동기 또는 suspend 블록이 타입 [T]의 예외를 던지는지 검증하고, 예외를 반환한다.
+ * 블록이 타입 [T]의 예외를 던지는지 검증하고, 예외를 반환한다.
  *
- * 단일 오버로드로 동기/suspend 코드 모두 처리한다. suspend 블록은 내부적으로 [kotlinx.coroutines.runBlocking]을
- * 통해 실행되므로 `runTest` 블록 안에서 사용할 경우 즉시 예외를 던지는 단순 케이스에만 적합하다.
+ * `inline` 함수이므로 람다는 call site에 인라인되어, `runTest`/`runSuspendIO` 등 suspend 컨텍스트에서도
+ * 람다 내부에서 `delay()` 등 suspend 호출이 가능하다. `runBlocking` 없이 동작하여 데드락이 없다.
  *
  * [CancellationException]은 기대 타입이 아닌 경우 즉시 rethrow하여 코루틴 취소 협력을 보장한다.
  *
  * @param message 검증 실패 시 출력할 추가 메시지 (null이면 기본 메시지 사용)
- * @param block 검증할 코드 블록 (동기 또는 suspend)
+ * @param block 검증할 코드 블록
  * @return 발생한 예외 (타입 [T])
  */
 inline fun <reified T : Throwable> assertFailsWith(
     message: String? = null,
-    noinline block: suspend () -> Unit,
+    block: () -> Unit,
 ): T {
     val caught: Throwable? = try {
-        runBlocking { block() }
+        block()
         null
     } catch (e: CancellationException) {
         if (e is T) e else throw e
@@ -371,25 +370,28 @@ inline fun <reified T : Throwable> assertFailsWith(
 }
 
 /**
- * 동기 또는 suspend 블록이 어떤 예외라도 던지는지 검증한다.
+ * 블록이 어떤 예외라도 던지는지 검증한다.
  *
- * @param block 검증할 코드 블록 (동기 또는 suspend)
+ * `inline` 함수이므로 `runTest` 등 suspend 컨텍스트에서도 `runBlocking` 없이 동작한다.
+ *
+ * @param block 검증할 코드 블록
  * @return 발생한 예외
  */
-fun assertFails(block: suspend () -> Unit): Throwable =
+inline fun assertFails(block: () -> Unit): Throwable =
     assertFailsWith<Throwable>(block = block)
 
 /**
- * 동기 또는 suspend 블록이 타입 [T]의 예외를 던지지 **않는지** 검증한다.
+ * 블록이 타입 [T]의 예외를 던지지 **않는지** 검증한다.
  *
  * 타입 [T]의 예외가 발생하면 검증 실패. 다른 타입의 예외나 예외 없음은 통과한다.
- * Kluent의 `internal assertNotFailsWith`에 해당하는 공개 API.
  *
- * @param block 검증할 코드 블록 (동기 또는 suspend)
+ * `inline` 함수이므로 `runTest` 등 suspend 컨텍스트에서도 `runBlocking` 없이 동작한다.
+ *
+ * @param block 검증할 코드 블록
  */
-inline fun <reified T : Throwable> assertNotFailsWith(noinline block: suspend () -> Unit) {
+inline fun <reified T : Throwable> assertNotFailsWith(block: () -> Unit) {
     try {
-        runBlocking { block() }
+        block()
     } catch (e: CancellationException) {
         throw e
     } catch (e: Throwable) {
@@ -400,13 +402,15 @@ inline fun <reified T : Throwable> assertNotFailsWith(noinline block: suspend ()
 }
 
 /**
- * 동기 또는 suspend 블록이 어떤 예외도 던지지 않는지 검증한다.
+ * 블록이 어떤 예외도 던지지 않는지 검증한다.
  *
- * @param block 검증할 코드 블록 (동기 또는 suspend)
+ * `inline` 함수이므로 `runTest` 등 suspend 컨텍스트에서도 `runBlocking` 없이 동작한다.
+ *
+ * @param block 검증할 코드 블록
  */
-fun assertNotFails(block: suspend () -> Unit) {
+inline fun assertNotFails(block: () -> Unit) {
     try {
-        runBlocking { block() }
+        block()
     } catch (e: CancellationException) {
         throw e
     } catch (e: Throwable) {
@@ -415,24 +419,24 @@ fun assertNotFails(block: suspend () -> Unit) {
 }
 
 /**
- * 동기 또는 suspend 블록이 [duration] 내에 완료되는지 검증한다.
+ * suspend 블록이 [duration] 내에 완료되는지 검증한다.
  *
  * 시간 초과 시 [org.opentest4j.AssertionFailedError]를 던진다.
  * [CancellationException]은 즉시 rethrow하여 코루틴 취소 협력을 보장한다.
  *
  * @param duration 허용되는 최대 실행 시간
  * @param message 검증 실패 시 출력할 추가 메시지 (null이면 기본 메시지 사용)
- * @param block 검증할 코드 블록 (동기 또는 suspend)
+ * @param block 검증할 suspend 코드 블록
  * @return 블록의 반환값
  */
-fun <T> assertTimeout(
+suspend fun <T> assertTimeout(
     duration: Duration,
     message: String? = null,
     block: suspend () -> T,
 ): T {
     val prefix = if (message != null) "$message — " else ""
     return try {
-        runBlocking { withTimeout(duration) { block() } }
+        withTimeout(duration) { block() }
     } catch (e: TimeoutCancellationException) {
         Failures.fail("${prefix}Expected block to complete within $duration but it timed out")
     } catch (e: CancellationException) {

--- a/testing/assertions/src/main/kotlin/io/bluetape4k/assertions/internal/Failures.kt
+++ b/testing/assertions/src/main/kotlin/io/bluetape4k/assertions/internal/Failures.kt
@@ -31,6 +31,7 @@ internal object Failures {
     /**
      * 원인 예외를 포함한 실패를 던진다.
      */
+    @PublishedApi
     internal fun failWithCause(message: String, cause: Throwable): Nothing =
         throw AssertionFailedError(message, cause)
 

--- a/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/coroutines/CoroutineSupport.kt
+++ b/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/coroutines/CoroutineSupport.kt
@@ -5,9 +5,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import java.util.concurrent.Executors
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/** `runSuspendIO` / `runSuspendDefault` / `runSuspendVT` 의 기본 타임아웃 (60초, `runTest` 기본값과 동일) */
+val DEFAULT_SUSPEND_TEST_TIMEOUT: Duration = 60.seconds
 
 /**
  * suspend 테스트 블록을 [runBlocking]으로 실행합니다.
@@ -16,6 +22,8 @@ import kotlin.coroutines.EmptyCoroutineContext
  * - `context`를 그대로 [runBlocking]에 전달해 실행 컨텍스트를 결정합니다.
  * - 수신 객체를 변경하지 않고 호출 스레드를 블로킹해 `testBody` 완료까지 대기합니다.
  * - `testBody` 예외는 감싸지지 않고 호출자에게 그대로 전파됩니다.
+ * - [timeout] 초과 시 [kotlinx.coroutines.TimeoutCancellationException]을 던집니다.
+ *   단, `Thread.sleep`처럼 suspension point가 없는 블로킹 코드는 타임아웃이 동작하지 않습니다.
  *
  * ```kotlin
  * var done = false
@@ -24,14 +32,16 @@ import kotlin.coroutines.EmptyCoroutineContext
  * ```
  *
  * @param context [runBlocking]에 전달할 코루틴 컨텍스트
+ * @param timeout 테스트 최대 허용 시간 (기본값: [DEFAULT_SUSPEND_TEST_TIMEOUT])
  * @param testBody 실행할 suspend 테스트 본문
  */
 inline fun runSuspendTest(
     context: CoroutineContext = EmptyCoroutineContext,
+    timeout: Duration = DEFAULT_SUSPEND_TEST_TIMEOUT,
     crossinline testBody: suspend CoroutineScope.() -> Unit,
 ) {
     runBlocking(context) {
-        testBody(this)
+        withTimeout(timeout) { testBody(this) }
     }
 }
 
@@ -49,10 +59,14 @@ inline fun runSuspendTest(
  * // threadNames.isNotEmpty() == true
  * ```
  *
+ * @param timeout 테스트 최대 허용 시간 (기본값: [DEFAULT_SUSPEND_TEST_TIMEOUT])
  * @param testBody 실행할 suspend 테스트 본문
  */
-inline fun runSuspendIO(crossinline testBody: suspend CoroutineScope.() -> Unit) {
-    runSuspendTest(Dispatchers.IO, testBody)
+inline fun runSuspendIO(
+    timeout: Duration = DEFAULT_SUSPEND_TEST_TIMEOUT,
+    crossinline testBody: suspend CoroutineScope.() -> Unit,
+) {
+    runSuspendTest(Dispatchers.IO, timeout, testBody)
 }
 
 /**
@@ -68,10 +82,14 @@ inline fun runSuspendIO(crossinline testBody: suspend CoroutineScope.() -> Unit)
  * // sum == 6
  * ```
  *
+ * @param timeout 테스트 최대 허용 시간 (기본값: [DEFAULT_SUSPEND_TEST_TIMEOUT])
  * @param testBody 실행할 suspend 테스트 본문
  */
-inline fun runSuspendDefault(crossinline testBody: suspend CoroutineScope.() -> Unit) {
-    runSuspendTest(Dispatchers.Default, testBody)
+inline fun runSuspendDefault(
+    timeout: Duration = DEFAULT_SUSPEND_TEST_TIMEOUT,
+    crossinline testBody: suspend CoroutineScope.() -> Unit,
+) {
+    runSuspendTest(Dispatchers.Default, timeout, testBody)
 }
 
 /**
@@ -103,8 +121,12 @@ internal val Dispatchers.VT: ExecutorCoroutineDispatcher by lazy {
  * // executed == true
  * ```
  *
+ * @param timeout 테스트 최대 허용 시간 (기본값: [DEFAULT_SUSPEND_TEST_TIMEOUT])
  * @param testBody 실행할 suspend 테스트 본문
  */
-inline fun runSuspendVT(crossinline testBody: suspend CoroutineScope.() -> Unit) {
-    runSuspendTest(Dispatchers.VT, testBody)
+inline fun runSuspendVT(
+    timeout: Duration = DEFAULT_SUSPEND_TEST_TIMEOUT,
+    crossinline testBody: suspend CoroutineScope.() -> Unit,
+) {
+    runSuspendTest(Dispatchers.VT, timeout, testBody)
 }

--- a/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt
+++ b/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt
@@ -349,7 +349,7 @@ class StructuredScopesTest {
         assertFailsWith<TimeoutException> {
             StructuredTaskScopes.failFast { scope ->
                 scope.fork {
-                    Thread.sleep(10_000)
+                    Thread.sleep(200)
                     42
                 }
                 // 100ms 데드라인 — subtask보다 훨씬 짧음
@@ -426,7 +426,7 @@ class StructuredScopesTest {
         assertFailsWith<TimeoutException> {
             StructuredTaskScopes.supervised<Int, Unit> { scope ->
                 scope.fork {
-                    Thread.sleep(10_000)
+                    Thread.sleep(200)
                     42
                 }
                 scope.joinUntil(Instant.now().plusMillis(100))

--- a/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProviderTest.kt
+++ b/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProviderTest.kt
@@ -81,7 +81,7 @@ class Jdk21StructuredTaskScopeProviderTest {
     fun `withSupervised joinUntil 데드라인 초과 시 TimeoutException 이 발생해야 한다`() {
         assertFailsWith<TimeoutException> {
             provider.withSupervised<Int, Unit> { scope ->
-                scope.fork { Thread.sleep(10_000); 42 }
+                scope.fork { Thread.sleep(200); 42 }
                 scope.joinUntil(Instant.now().plusMillis(100))
             }
         }
@@ -118,7 +118,7 @@ class Jdk21StructuredTaskScopeProviderTest {
     fun `withAll joinUntil 데드라인 초과 시 TimeoutException 이 발생해야 한다`() {
         assertFailsWith<TimeoutException> {
             provider.withAll { scope ->
-                scope.fork { Thread.sleep(10_000); 42 }
+                scope.fork { Thread.sleep(200); 42 }
                 scope.joinUntil(Instant.now().plusMillis(100))
                 scope.throwIfFailed()
             }
@@ -157,7 +157,7 @@ class Jdk21StructuredTaskScopeProviderTest {
     fun `withAny joinUntil 데드라인 초과 시 TimeoutException 이 발생해야 한다`() {
         assertFailsWith<TimeoutException> {
             provider.withAny<String> { scope ->
-                scope.fork { Thread.sleep(10_000); "slow" }
+                scope.fork { Thread.sleep(200); "slow" }
                 scope.joinUntil(Instant.now().plusMillis(100)).result { RuntimeException(it) }
             }
         }

--- a/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderTest.kt
+++ b/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderTest.kt
@@ -80,7 +80,7 @@ class Jdk25StructuredTaskScopeProviderTest {
     fun `withSupervised joinUntil 데드라인 초과 시 TimeoutException 이 발생해야 한다`() {
         assertFailsWith<TimeoutException> {
             provider.withSupervised<Int, Unit> { scope ->
-                scope.fork { Thread.sleep(10_000); 42 }
+                scope.fork { Thread.sleep(200); 42 }
                 scope.joinUntil(Instant.now().plusMillis(100))
             }
         }
@@ -117,7 +117,7 @@ class Jdk25StructuredTaskScopeProviderTest {
     fun `withAll joinUntil 데드라인 초과 시 TimeoutException 이 발생해야 한다`() {
         assertFailsWith<TimeoutException> {
             provider.withAll { scope ->
-                scope.fork { Thread.sleep(10_000); 42 }
+                scope.fork { Thread.sleep(200); 42 }
                 scope.joinUntil(Instant.now().plusMillis(100))
                 scope.throwIfFailed()
             }
@@ -157,7 +157,7 @@ class Jdk25StructuredTaskScopeProviderTest {
     fun `withAny joinUntil 데드라인 초과 시 TimeoutException 이 발생해야 한다`() {
         assertFailsWith<TimeoutException> {
             provider.withAny<String> { scope ->
-                scope.fork { Thread.sleep(10_000); "slow" }
+                scope.fork { Thread.sleep(200); "slow" }
                 scope.joinUntil(Instant.now().plusMillis(100)).result { RuntimeException(it) }
             }
         }


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: perf: coroutines joinUntil 테스트 slow sleep 단축 (5000ms → 200ms)

## Background

`StructuredTaskScope.close()`는 모든 forked thread가 완료될 때까지 실제로 대기합니다.
`Thread.sleep(5000)` 안에서 interrupt가 오지 않으면 테스트당 **5초** 소요.

두 테스트 합계 10초+ → `nick-fields/retry` 3회 재시도 시 최대 30초+ → Test/Core 잡 간헐적 8분 이상 지연.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

`StructuredConcurrencyTest.kt`:
- `taskScope joinUntil` 테스트: `Thread.sleep(5000)` → `Thread.sleep(200)`
- `supervisedTaskScope joinUntil` 테스트: `Thread.sleep(5000)` → `Thread.sleep(200)`

deadline=50ms 초과 동작 검증은 200ms로도 충분합니다.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #335, head `5d927f2ab4951027af9ef6dee4162a92bb0c4ff8`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/slow-coroutines-test`
- Labels: `bug`, `test`, `performance`
- State: `MERGED`, merge commit `339f7a9ddc5e9db5ab5bfa48f75703f88ce19794`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #335 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `339f7a9ddc5e9db5ab5bfa48f75703f88ce19794`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
