### PR TITLE
fix: runSuspendIO 타임아웃 3분, BluetapeHttpServer eager init

### DIFF
--- a/spring-boot3/core/src/test/kotlin/io/bluetape4k/spring/tests/AbstractSpringTest.kt
+++ b/spring-boot3/core/src/test/kotlin/io/bluetape4k/spring/tests/AbstractSpringTest.kt
@@ -7,9 +7,9 @@ abstract class AbstractSpringTest {
 
     companion object: KLogging() {
         @JvmStatic
-        protected val httpbin by lazy { BluetapeHttpServer.Launcher.bluetapeHttpServer }
+        protected val httpbin = BluetapeHttpServer.Launcher.bluetapeHttpServer
 
         @JvmStatic
-        protected val baseUrl by lazy { httpbin.httpbinUrl }
+        protected val baseUrl = httpbin.httpbinUrl
     }
 }

--- a/spring-boot4/core/src/test/kotlin/io/bluetape4k/spring/tests/AbstractSpringTest.kt
+++ b/spring-boot4/core/src/test/kotlin/io/bluetape4k/spring/tests/AbstractSpringTest.kt
@@ -6,9 +6,9 @@ import io.bluetape4k.testcontainers.http.BluetapeHttpServer
 abstract class AbstractSpringTest {
     companion object: KLogging() {
         @JvmStatic
-        protected val httpbin by lazy { BluetapeHttpServer.Launcher.bluetapeHttpServer }
+        protected val httpbin = BluetapeHttpServer.Launcher.bluetapeHttpServer
 
         @JvmStatic
-        protected val baseUrl by lazy { httpbin.httpbinUrl }
+        protected val baseUrl = httpbin.httpbinUrl
     }
 }

--- a/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/coroutines/CoroutineSupport.kt
+++ b/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/coroutines/CoroutineSupport.kt
@@ -12,8 +12,8 @@ import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
-/** `runSuspendIO` / `runSuspendDefault` / `runSuspendVT` 의 기본 타임아웃 (60초, `runTest` 기본값과 동일) */
-val DEFAULT_SUSPEND_TEST_TIMEOUT: Duration = 60.seconds
+/** `runSuspendIO` / `runSuspendDefault` / `runSuspendVT` 의 기본 타임아웃 (3분 — Testcontainers 컨테이너 시작 포함 CI 환경 대응) */
+val DEFAULT_SUSPEND_TEST_TIMEOUT: Duration = 180.seconds
 
 /**
  * suspend 테스트 블록을 [runBlocking]으로 실행합니다.


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: runSuspendIO 타임아웃 3분, BluetapeHttpServer eager init

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 문제
CI에서 `spring-boot4-core` 테스트 간헐적 실패:
```
WebClientExtensionsTest > Get ✘ httGet httpbin() (1m)
Caused by: kotlinx.coroutines.TimeoutCancellationException: Timed out waiting for 60000 ms
```

`BluetapeHttpServer` (Testcontainers 기반 내부 httpbin 서버)가 `lazy` 초기화 방식이라 `runSuspendIO { }` 블록 내부에서 컨테이너 시작 → 60초 타임아웃 초과

### 수정
1. `DEFAULT_SUSPEND_TEST_TIMEOUT`: 60s → 180s (3분)  
   GitHub Actions에서 Docker 이미지 pull + 컨테이너 시작 시간 수용
2. `AbstractSpringTest` (spring-boot3, spring-boot4): `BluetapeHttpServer` `lazy` → eager init  
   companion object 초기화 시 컨테이너 시작 → runSuspendIO 타임아웃 영역 밖에서 처리

## Validation

- `:bluetape4k-junit5:build` ✅
- `:bluetape4k-spring-boot3-core:build` ✅  
- `:bluetape4k-spring-boot4-core:build` ✅

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #337, head `4991ba81af18d48b1defd8f6033529747831c8f7`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/suspend-timeout`
- Labels: 없음
- State: `MERGED`, merge commit `1c8223db36c5af0e5e96fa7814aed82aa6a4cdb2`
- CI: CI에서 `spring-boot4-core` 테스트 간헐적 실패:

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #337 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `1c8223db36c5af0e5e96fa7814aed82aa6a4cdb2`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
