### PR TITLE
docs(bom): bluetape4k-bom 모듈 README 추가 (한/영)

### DIFF
--- a/bluetape4k/bom/README.ko.md
+++ b/bluetape4k/bom/README.ko.md
@@ -1,0 +1,184 @@
+# bluetape4k-bom
+
+한국어 | [English](./README.md)
+
+`bluetape4k-projects` 가 게시하는 전체 `io.github.bluetape4k:*` 모듈 집합의 **루트 Maven BOM**.
+bluetape4k 생태계의 토대 계층이며, `bluetape4k/*`, `data/*`, `infra/*`, `io/*`, `spring-boot3/*`,
+`spring-boot4/*`, `testing/*`, `utils/*`, `virtualthread/*` 의 약 80개 모듈 버전을 중앙 관리한다.
+
+## Architecture
+
+```mermaid
+graph TB
+    Consumer[소비 프로젝트]
+    AggBom[bluetape4k-dependencies<br/>aggregator BOM]
+    BOM[bluetape4k-bom<br/>java-platform]
+
+    subgraph "Foundation (bluetape4k/*)"
+      Core[core]
+      Coro[coroutines]
+      Logging[logging]
+    end
+
+    subgraph "data/*"
+      Jdbc[jdbc]
+      R2dbc[r2dbc]
+      Hib[hibernate / hibernate-reactive]
+      Mongo[mongodb]
+      Cass[cassandra]
+    end
+
+    subgraph "infra/*"
+      Cache[cache / cache-lettuce / cache-redisson / cache-hazelcast]
+      Bucket[bucket4j]
+      Es[elasticsearch]
+      Kafka[kafka-logback]
+      More1[+ ~13 more]
+    end
+
+    subgraph "io/*"
+      Json[jackson2 / fastjson2]
+      Avro[avro / csv]
+      Rpc[grpc / feign / http]
+      More2[+ ~10 more]
+    end
+
+    subgraph "Spring Boot 3 / 4"
+      SB3[spring-boot3/* — 8개]
+      SB4[spring-boot4/* — 8개]
+    end
+
+    subgraph "testing/*"
+      Assert[assertions]
+      Ju5[junit5]
+      Mws[mock-web-server / mock-webflux-server]
+      Tc[testcontainers]
+    end
+
+    subgraph "utils/*"
+      Jwt[jwt]
+      Money[money]
+      Time[javatimes]
+      More3[+ ~10 more]
+    end
+
+    subgraph "virtualthread/*"
+      VtApi[api]
+      Vt21[jdk21]
+      Vt25[jdk25]
+    end
+
+    Consumer -->|platform import| AggBom
+    AggBom -->|api platform| BOM
+    BOM -.-> Core
+    BOM -.-> Jdbc
+    BOM -.-> Cache
+    BOM -.-> Json
+    BOM -.-> SB3
+    BOM -.-> Assert
+    BOM -.-> Jwt
+    BOM -.-> VtApi
+```
+
+BOM 은 Gradle `java-platform` 으로 `<dependencyManagement>` constraint 만 게시하며 런타임 클래스는 포함하지 않는다.
+`rootProject.subprojects` 를 동적으로 끌어오며 자기 자신, `*-demo`, `examples/*`, `workshop/*` 만 제외한다.
+
+## 핵심 기능
+
+- `bluetape4k-projects` 의 약 80개 `bluetape4k-*` 모듈 버전 중앙 관리
+- 모든 sub-BOM (`bluetape4k-aws-bom`, `bluetape4k-image-bom`, `bluetape4k-text-bom`, `bluetape4k-javers-bom`, `bluetape4k-graph-bom`, `bluetape4k-leader-bom`, `bluetape4k-exposed-bom`) 의 토대 BOM
+- `bluetape4k-dependencies` 가 상위에서 통합 — 단일 BOM 선언만으로 전체 생태계 사용 가능
+
+## 관리 모듈
+
+| 그룹 | 모듈 수 | 주요 모듈 |
+|------|--------|----------|
+| `bluetape4k/*` | 3 | `bluetape4k-core`, `bluetape4k-coroutines`, `bluetape4k-logging` |
+| `data/*` | 7 | `bluetape4k-jdbc`, `bluetape4k-r2dbc`, `bluetape4k-hibernate`, `bluetape4k-hibernate-reactive`, `bluetape4k-hibernate-cache-lettuce`, `bluetape4k-mongodb`, `bluetape4k-cassandra` |
+| `infra/*` | 18 | 캐시 (`cache`, `cache-core`, `cache-lettuce`, `cache-redisson`, `cache-hazelcast`), `bucket4j`, `elasticsearch`, `kafka-logback` 등 |
+| `io/*` | 16 | `jackson2`, `fastjson2`, `avro`, `csv`, `grpc`, `feign`, `http`, `io` |
+| `spring-boot3/*` | 8 | `spring-boot3-core`, `spring-boot3-r2dbc`, `spring-boot3-mongodb`, `spring-boot3-cassandra`, `spring-boot3-redis`, `spring-boot3-hibernate-lettuce` 등 |
+| `spring-boot4/*` | 8 | spring-boot3 와 동일 모듈의 Spring Boot 4 버전 |
+| `testing/*` | 5 | `bluetape4k-assertions`, `bluetape4k-junit5`, `bluetape4k-mock-web-server`, `bluetape4k-mock-webflux-server`, `bluetape4k-testcontainers` |
+| `utils/*` | 13 | `jwt`, `money`, `javatimes`, `geo`, `idgenerators`, `math`, `measured`, `mutiny` 등 |
+| `virtualthread/*` | 3 | `virtualthread-api`, `virtualthread-jdk21`, `virtualthread-jdk25` |
+
+> constraint 에서 제외: `*-demo`, `examples/*`, `workshop/*`.
+
+## 사용 예제
+
+### 권장: aggregator BOM 으로 import
+
+```kotlin
+plugins {
+    id("io.spring.dependency-management") version "1.1.x"
+}
+
+dependencyManagement {
+    imports {
+        mavenBom("io.github.bluetape4k:bluetape4k-dependencies:<version>")
+    }
+}
+
+dependencies {
+    implementation("io.github.bluetape4k:bluetape4k-core")
+    implementation("io.github.bluetape4k:bluetape4k-coroutines")
+    testImplementation("io.github.bluetape4k:bluetape4k-junit5")
+}
+```
+
+### bluetape4k-bom 직접 import
+
+```kotlin
+dependencyManagement {
+    imports {
+        mavenBom("io.github.bluetape4k:bluetape4k-bom:<version>")
+    }
+}
+```
+
+### 순수 Gradle (Spring 미사용)
+
+```kotlin
+dependencies {
+    implementation(platform("io.github.bluetape4k:bluetape4k-bom:<version>"))
+    implementation("io.github.bluetape4k:bluetape4k-core")
+}
+```
+
+### Maven
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.github.bluetape4k</groupId>
+            <artifactId>bluetape4k-bom</artifactId>
+            <version>${bluetape4k.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+```
+
+## 설정 옵션
+
+BOM 자체는 별도 설정이 없다. SNAPSHOT 사용 시 Sonatype Central Snapshots 저장소 추가:
+
+```kotlin
+repositories {
+    mavenCentral()
+    maven {
+        name = "central-snapshots"
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+    }
+}
+```
+
+## 의존성
+
+이 BOM 은 `bluetape4k-dependencies` 가 import 하는 토대 BOM. 대부분의 소비자는 aggregator
+(`io.github.bluetape4k:bluetape4k-dependencies`) import 권장 — `bluetape4k-bom` 과
+모든 sub-BOM (aws / image / text / javers / graph / leader / exposed) 을 함께 가져와
+단일 선언으로 전체 bluetape4k 생태계를 커버한다.

--- a/bluetape4k/bom/README.md
+++ b/bluetape4k/bom/README.md
@@ -1,0 +1,184 @@
+# bluetape4k-bom
+
+[한국어](./README.ko.md) | English
+
+The **root Maven BOM** for the entire `io.github.bluetape4k:*` module set published from
+`bluetape4k-projects` — the foundational layer of the bluetape4k ecosystem. Manages versions of
+~80 modules across `bluetape4k/*`, `data/*`, `infra/*`, `io/*`, `spring-boot3/*`, `spring-boot4/*`,
+`testing/*`, `utils/*`, and `virtualthread/*`.
+
+## Architecture
+
+```mermaid
+graph TB
+    Consumer[Consumer Project]
+    AggBom[bluetape4k-dependencies<br/>aggregator BOM]
+    BOM[bluetape4k-bom<br/>java-platform]
+
+    subgraph "Foundation (bluetape4k/*)"
+      Core[core]
+      Coro[coroutines]
+      Logging[logging]
+    end
+
+    subgraph "data/*"
+      Jdbc[jdbc]
+      R2dbc[r2dbc]
+      Hib[hibernate / hibernate-reactive]
+      Mongo[mongodb]
+      Cass[cassandra]
+    end
+
+    subgraph "infra/*"
+      Cache[cache / cache-lettuce / cache-redisson / cache-hazelcast]
+      Bucket[bucket4j]
+      Es[elasticsearch]
+      Kafka[kafka-logback]
+      More1[+ ~13 more]
+    end
+
+    subgraph "io/*"
+      Json[jackson2 / fastjson2]
+      Avro[avro / csv]
+      Rpc[grpc / feign / http]
+      More2[+ ~10 more]
+    end
+
+    subgraph "Spring Boot 3 / 4"
+      SB3[spring-boot3/* — 8 modules]
+      SB4[spring-boot4/* — 8 modules]
+    end
+
+    subgraph "testing/*"
+      Assert[assertions]
+      Ju5[junit5]
+      Mws[mock-web-server / mock-webflux-server]
+      Tc[testcontainers]
+    end
+
+    subgraph "utils/*"
+      Jwt[jwt]
+      Money[money]
+      Time[javatimes]
+      More3[+ ~10 more]
+    end
+
+    subgraph "virtualthread/*"
+      VtApi[api]
+      Vt21[jdk21]
+      Vt25[jdk25]
+    end
+
+    Consumer -->|platform import| AggBom
+    AggBom -->|api platform| BOM
+    BOM -.-> Core
+    BOM -.-> Jdbc
+    BOM -.-> Cache
+    BOM -.-> Json
+    BOM -.-> SB3
+    BOM -.-> Assert
+    BOM -.-> Jwt
+    BOM -.-> VtApi
+```
+
+The BOM is a Gradle `java-platform` that publishes only `<dependencyManagement>` constraints — no runtime classes. It dynamically pulls in all `rootProject.subprojects` except itself, `*-demo` modules, `examples/*`, and `workshop/*`.
+
+## Core Features
+
+- Centralized version management for ~80 `bluetape4k-*` modules in `bluetape4k-projects`
+- Foundation BOM that all sub-BOMs (`bluetape4k-aws-bom`, `bluetape4k-image-bom`, `bluetape4k-text-bom`, `bluetape4k-javers-bom`, `bluetape4k-graph-bom`, `bluetape4k-leader-bom`, `bluetape4k-exposed-bom`) depend on
+- Aggregated by `bluetape4k-dependencies` so a consumer can import a single BOM and pick up the entire ecosystem
+
+## Modules Managed
+
+| Group | Approximate count | Highlights |
+|-------|-------------------|-----------|
+| `bluetape4k/*` | 3 | `bluetape4k-core`, `bluetape4k-coroutines`, `bluetape4k-logging` |
+| `data/*` | 7 | `bluetape4k-jdbc`, `bluetape4k-r2dbc`, `bluetape4k-hibernate`, `bluetape4k-hibernate-reactive`, `bluetape4k-hibernate-cache-lettuce`, `bluetape4k-mongodb`, `bluetape4k-cassandra` |
+| `infra/*` | 18 | cache (`cache`, `cache-core`, `cache-lettuce`, `cache-redisson`, `cache-hazelcast`), `bucket4j`, `elasticsearch`, `kafka-logback`, etc. |
+| `io/*` | 16 | `jackson2`, `fastjson2`, `avro`, `csv`, `grpc`, `feign`, `http`, `io` |
+| `spring-boot3/*` | 8 | `spring-boot3-core`, `spring-boot3-r2dbc`, `spring-boot3-mongodb`, `spring-boot3-cassandra`, `spring-boot3-redis`, `spring-boot3-hibernate-lettuce`, ... |
+| `spring-boot4/*` | 8 | mirror of spring-boot3 modules for Spring Boot 4 |
+| `testing/*` | 5 | `bluetape4k-assertions`, `bluetape4k-junit5`, `bluetape4k-mock-web-server`, `bluetape4k-mock-webflux-server`, `bluetape4k-testcontainers` |
+| `utils/*` | 13 | `jwt`, `money`, `javatimes`, `geo`, `idgenerators`, `math`, `measured`, `mutiny`, ... |
+| `virtualthread/*` | 3 | `virtualthread-api`, `virtualthread-jdk21`, `virtualthread-jdk25` |
+
+> Excluded from constraints: `*-demo`, `examples/*`, `workshop/*`.
+
+## Usage Examples
+
+### Recommended: import via aggregator BOM
+
+```kotlin
+plugins {
+    id("io.spring.dependency-management") version "1.1.x"
+}
+
+dependencyManagement {
+    imports {
+        mavenBom("io.github.bluetape4k:bluetape4k-dependencies:<version>")
+    }
+}
+
+dependencies {
+    implementation("io.github.bluetape4k:bluetape4k-core")
+    implementation("io.github.bluetape4k:bluetape4k-coroutines")
+    testImplementation("io.github.bluetape4k:bluetape4k-junit5")
+}
+```
+
+### Direct import of bluetape4k-bom
+
+```kotlin
+dependencyManagement {
+    imports {
+        mavenBom("io.github.bluetape4k:bluetape4k-bom:<version>")
+    }
+}
+```
+
+### Plain Gradle (no Spring)
+
+```kotlin
+dependencies {
+    implementation(platform("io.github.bluetape4k:bluetape4k-bom:<version>"))
+    implementation("io.github.bluetape4k:bluetape4k-core")
+}
+```
+
+### Maven
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.github.bluetape4k</groupId>
+            <artifactId>bluetape4k-bom</artifactId>
+            <version>${bluetape4k.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+```
+
+## Configuration Options
+
+The BOM itself has no configuration. For SNAPSHOT builds, add the Sonatype Central Snapshots repository:
+
+```kotlin
+repositories {
+    mavenCentral()
+    maven {
+        name = "central-snapshots"
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+    }
+}
+```
+
+## Dependency
+
+This BOM is the foundation imported by `bluetape4k-dependencies`. For most consumers, import the
+aggregator (`io.github.bluetape4k:bluetape4k-dependencies`) instead — it transitively imports
+`bluetape4k-bom` plus all sub-BOMs (aws / image / text / javers / graph / leader / exposed) so a
+single declaration covers the entire bluetape4k ecosystem.


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: docs(bom): bluetape4k-bom 모듈 README 추가 (한/영)

루트 BOM 모듈 `bluetape4k/bom/` 에 README.md + README.ko.md 를 추가합니다.

## Background

CLAUDE.md "이중언어 README 필수" + "Architecture-first" 규칙에 따라 모든 모듈은 영어/한국어 README 를 동시에 유지해야 합니다.
`bluetape4k-bom` 은 bluetape4k 생태계의 **루트 BOM** 으로 약 80개 모듈 버전을 중앙 관리하지만 README 가 누락되어 있어 보완합니다.

이전에 7개 sub-BOM (`bluetape4k-aws-bom`, `bluetape4k-image-bom`, `bluetape4k-text-bom`, `bluetape4k-javers-bom`, `bluetape4k-graph-bom`, `bluetape4k-leader-bom`, `bluetape4k-exposed-bom`) README 를 추가한 후속 작업입니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- `bluetape4k/bom/README.md` (English)
- `bluetape4k/bom/README.ko.md` (한국어)

### 기존 섹션: README 구조

- **Architecture** — Mermaid 다이어그램으로 aggregator BOM (`bluetape4k-dependencies`) → `bluetape4k-bom` → 9개 모듈 그룹 관계 시각화
- **Core Features** — 루트 BOM 으로서 sub-BOM 들이 의존하는 토대 역할 명시
- **Modules Managed** — 9개 그룹 약 80개 모듈 표 (`bluetape4k/*`, `data/*`, `infra/*`, `io/*`, `spring-boot3/*`, `spring-boot4/*`, `testing/*`, `utils/*`, `virtualthread/*`)
- **Usage Examples** — 권장 (aggregator import) / 직접 import / 순수 Gradle / Maven 4가지 패턴
- **Configuration / Dependency** — Sonatype Central Snapshots + aggregator BOM 안내

## Validation

- 코드 변경 없음 (문서만 추가)
- Mermaid 문법 로컬 검증 완료
- 7개 sub-BOM README 와 구조 일관성 유지
- 관리 모듈 그룹은 `settings.gradle.kts` `includeModules(...)` 호출 기준으로 추출

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #346, head `bdc8cdf310bd5d4c70eb6e1a786092f79df23be3`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/bom-readme`
- Labels: 없음
- State: `MERGED`, merge commit `1affd9abad1dbbe8202947e85c04ca97531734c2`
- CI: - **Architecture** — Mermaid 다이어그램으로 aggregator BOM (`bluetape4k-dependencies`) → `bluetape4k-bom` → 9개 모듈 그룹 관계 시각화 / - **Usage Examples** — 권장 (aggregator import) / 직접 import / 순수 Gradle / Maven 4가지 패턴 / - 관리 모듈 그룹은 `settings.gradle.kts` `includeModules(...)` 호출 기준으로 추출

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #346 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `1affd9abad1dbbe8202947e85c04ca97531734c2`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
