### PR TITLE
Document infra deprecated cleanup inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Collection assertion helper `shouldNotContainAny` was added ([#342](https://github.com/bluetape4k/bluetape4k-projects/pull/342)).
 - Case-insensitive string assertions `assertEqualsIgnoringCase` and `assertNotEqualsIgnoringCase` were added ([#343](https://github.com/bluetape4k/bluetape4k-projects/pull/343)).
 - `bluetape4k-bom` module README files were added in English and Korean ([#346](https://github.com/bluetape4k/bluetape4k-projects/pull/346)).
+- `infra/` deprecated API inventory and follow-up cleanup PR split were documented ([#110](https://github.com/bluetape4k/bluetape4k-projects/issues/110)).
 
 ### Changed
 

--- a/WIP.md
+++ b/WIP.md
@@ -2,14 +2,15 @@
 
 Snapshot: 2026-05-09 KST
 Scope: open GitHub issues assigned to `debop`, created on or after 2026-01-01.
-Open count: 14 issues.
+Open count: 11 issues after this PR closes `#110` and completed Spring Boot
+policy items are removed from active WIP.
 
 ## Current Direction
 
 This repo is now the core/shared library baseline after several domain groups
-were split into independent repositories. Active work should reduce build
-surface, lock the Spring Boot 4-only policy, and prepare the next extraction
-steps.
+were split into independent repositories. Active work should keep the split
+tracker current, reduce deprecated infra surface, and prepare the next
+extraction steps.
 
 Historical completed items from the old monorepo TODO are intentionally omitted
 from this active WIP. Use closed issues and `CHANGELOG.md` for completed work.
@@ -18,10 +19,7 @@ from this active WIP. Use closed issues and `CHANGELOG.md` for completed work.
 
 | Priority | Issue | Difficulty | Notes |
 |---|---|---:|---|
-| P0 | [#280](https://github.com/bluetape4k/bluetape4k-projects/issues/280) Spring Boot 4-only policy | M | 1.7.x is the last Boot 3 line; 2.0+ uses versionless `spring-boot` names. |
-| P0 | [#263](https://github.com/bluetape4k/bluetape4k-projects/issues/263) remove Boot 3 and rename Boot 4 modules | XL | Spring Boot 3.5 OSS support ends 2026-06-30; removes Boot 3 and renames `spring-boot4` to `spring-boot`. |
 | P0 | [#257](https://github.com/bluetape4k/bluetape4k-projects/issues/257) monorepo split epic | XL | Program tracker. Keep phase state updated as repo splits close. |
-| P1 | [#110](https://github.com/bluetape4k/bluetape4k-projects/issues/110) infra deprecated inventory | M | Inventory before more extraction work. |
 | P1 | [#333](https://github.com/bluetape4k/bluetape4k-projects/issues/333) extract cache modules | XL | Next major extraction after Spring Boot policy/removal lane stabilizes. |
 | P2 | [#149](https://github.com/bluetape4k/bluetape4k-projects/issues/149) utils/vector | M | Foundation for AI utilities. |
 | P2 | [#151](https://github.com/bluetape4k/bluetape4k-projects/issues/151) LLM/vector Testcontainers | L | Test foundation for AI/vector work. |
@@ -36,16 +34,17 @@ from this active WIP. Use closed issues and `CHANGELOG.md` for completed work.
 ## Dependency Map
 
 ```text
-#280 Boot 4-only policy decision
-  -> dependencies repo #8 first official Spring Boot aliases
-  -> #263 Spring Boot 3 removal + spring-boot4 -> spring-boot rename
-      -> exposed repo #3 Spring Boot 3 removal + spring-boot4 -> spring-boot rename
+#280 Boot 4-only policy decision (documented)
+  -> dependencies repo #8 first official Spring Boot aliases (closed)
+  -> #263 Spring Boot 3 removal + spring-boot4 -> spring-boot rename (closed)
+      -> exposed repo #3 Spring Boot 3 removal + spring-boot4 -> spring-boot rename (closed)
 
 #257 monorepo split tracker
   -> #333 cache extraction
   -> #262 data extraction (deferred)
 
-#110 infra deprecated inventory
+#110 infra deprecated inventory (documented in docs/infra-deprecated-inventory.md)
+  -> follow-up deprecated cleanup PRs
   -> safer extraction/refactor planning
 
 #149 vector utilities
@@ -62,8 +61,8 @@ from this active WIP. Use closed issues and `CHANGELOG.md` for completed work.
 
 | Lane | Limit | Current next |
 |---|---:|---|
-| Policy / breaking cleanup | 1 | `#280`, then `#263`. |
-| Extraction planning | 1 | `#110`, then `#333`. |
+| Policy / breaking cleanup | 1 | Keep `#257` updated as split phases close. |
+| Extraction planning | 1 | `#333` after deprecated cleanup issues are split. |
 | AI/vector | 1 | `#149` or `#151`, not `#148` first. |
 | Docs polish | 1 PR | `#323/#324/#325` together. |
 
@@ -71,6 +70,7 @@ from this active WIP. Use closed issues and `CHANGELOG.md` for completed work.
 
 | Candidate | Action |
 |---|---|
-| `#280` vs `#263` | Resolved direction: 1.7.x is the last Boot 3 line; 2.0+ removes Boot 3 and renames Boot 4 modules to versionless `spring-boot`. |
+| `#280` vs `#263` | Resolved direction documented in PR #348; both are removed from the active queue. |
+| `#110` | Inventory documented in `docs/infra-deprecated-inventory.md`; close after this PR merges. |
 | `#251` | Close as not planned or convert into an ADR when a concrete state-machine decision is active. |
 | `#262` | Keep deferred; do not start until exposed split and Spring Boot direction are settled. |

--- a/docs/infra-deprecated-inventory.md
+++ b/docs/infra-deprecated-inventory.md
@@ -1,0 +1,116 @@
+# infra Deprecated API Inventory
+
+Snapshot: 2026-05-09 KST
+Issue: [#110](https://github.com/bluetape4k/bluetape4k-projects/issues/110)
+
+This inventory records every tracked `infra/` source file that currently declares
+`@Deprecated`. It is a planning document only; code removal and replacement
+work should happen in follow-up PRs.
+
+## Summary
+
+| Decision | Count | Meaning |
+|---|---:|---|
+| Delete | 18 files | Deprecated API has a direct replacement and should not remain in the next cleanup line. |
+| Replace call sites first | 6 files | Repo-local tests or samples still exercise the deprecated API and must move first. |
+| Keep | 0 files | No deprecated `infra/` API needs long-term retention. |
+
+`infra/kafka4` mirrors several `infra/kafka` deprecated APIs, so the current
+scope is larger than the original 12-file issue comment.
+
+## Inventory
+
+| # | Module | File | Deprecated API | Current usage | Decision | Replacement |
+|---:|---|---|---|---|---|---|
+| 1 | `bucket4j` | `infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/RateLimitResult.kt` | Secondary constructor `(consumedTokens, availableTokens)` | `RateLimitResultTest` covers compatibility only | Delete after test rewrite | `RateLimitResult.consumed(...)` / `rejected(...)` |
+| 2 | `cache-core` | `infra/cache-core/src/main/kotlin/io/bluetape4k/cache/caffeine/CaffeineSupport.kt` | `AsyncCache.getSuspending(...)` | KDoc sample only | Delete | `AsyncCache.suspendGet(...)` |
+| 3 | `cache-lettuce` | `infra/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceSuspendNearCache.kt` | `clearFrontCache()` | Definition only | Delete | `clearLocal()` |
+| 4 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt` | `Producer.getMetricValue(...)` | Definition only | Delete | `getMetricValueOrNull(...).asDouble()` |
+| 5 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt` | `JdkKafkaCodec` | `KafkaCodecTest` still tests `KafkaCodecs.Jdk` | Replace tests, then delete | `ForyKafkaCodec` or `KryoKafkaCodec` |
+| 6 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/KafkaOperationsExtensions.kt` | `sendAndAwait(...)`, `awaitSendDefault(...)` overloads | Definition only | Delete | `suspendSend(...)` / `suspendSendDefault(...)` |
+| 7 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt` | `awaitSend(...)`, `sendSuspending(...)`, `getMetricValue(...)` | KDoc/definition only | Delete | `suspendSend(...)`, `getMetricValueOrNull(...).asDouble()` |
+| 8 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt` | `Producer.getMetricValue(...)` | Definition only | Delete | `getMetricValueOrNull(...).asDouble()` |
+| 9 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt` | `JdkKafkaCodec` | `KafkaCodecTest` still tests `KafkaCodecs.Jdk` | Replace tests, then delete | `ForyKafkaCodec` or `KryoKafkaCodec` |
+| 10 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/KafkaOperationsExtensions.kt` | `sendAndAwait(...)`, `awaitSendDefault(...)` overloads | Definition only | Delete | `suspendSend(...)` / `suspendSendDefault(...)` |
+| 11 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt` | `awaitSend(...)`, `sendSuspending(...)`, `getMetricValue(...)` | Definition only | Delete | `suspendSend(...)`, `getMetricValueOrNull(...).asDouble()` |
+| 12 | `lettuce` | `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/LettuceConst.kt` | `DEFAULT_DELIMETER` typo | Definition only | Delete | `DEFAULT_DELIMITER` |
+| 13 | `lettuce` | `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/RedisFutureSupport.kt` | `suspendAwait()`, `coAwait()` | `RedisFutureSupportTest` compatibility tests | Replace tests, then delete | `awaitSuspending()` |
+| 14 | `opentelemetry` | `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/SpanCoroutineSupport.kt` | `SpanBuilder.useSuspendSpan(...)` overloads | One compatibility test path | Replace tests, then delete | `useSpanSuspending(...)` |
+| 15 | `opentelemetry` | `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanExporterSupport.kt` | `spanExportOf(...)` | Definition only | Delete | `spanExporterOf(...)` |
+| 16 | `opentelemetry` | `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanProcessorSupport.kt` | `batchSpanProcess(...)` | Definition only | Delete | `batchSpanProcessorOf(...)` |
+| 17 | `redisson` | `infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/RedissonConst.kt` | `DEFAULT_DELIMETER` typo | Definition only | Delete | `DEFAULT_DELIMITER` |
+| 18 | `resilience4j` | `infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/SuspendDecorators.kt` | `decoreate()` typo overloads | Definition only | Delete | `decorate()` |
+
+## Follow-Up PR Split
+
+### PR A: Kafka deprecated surface cleanup
+
+Scope:
+
+- `infra/kafka`
+- `infra/kafka4`
+
+Tasks:
+
+- Remove `sendAndAwait`, `awaitSend`, `awaitSendDefault`, and `sendSuspending`
+  aliases after confirming no repo-local callers remain.
+- Remove `getMetricValue(...)` aliases.
+- Replace `KafkaCodecs.Jdk` compatibility tests with supported codecs or remove
+  the JDK-only compatibility case.
+- Remove `JdkKafkaCodec` and any public factory/registry entry that exposes it,
+  while keeping compressed JDK-backed codecs only if they are intentionally still
+  supported outside this issue.
+
+Validation:
+
+- `./gradlew :bluetape4k-kafka:test :bluetape4k-kafka4:test --no-daemon`
+
+### PR B: Cache, Redis, OpenTelemetry, and Resilience4j aliases
+
+Scope:
+
+- `infra/cache-core`
+- `infra/cache-lettuce`
+- `infra/lettuce`
+- `infra/redisson`
+- `infra/opentelemetry`
+- `infra/resilience4j`
+
+Tasks:
+
+- Remove typo aliases: `DEFAULT_DELIMETER`, `decoreate()`.
+- Remove coroutine alias APIs: `getSuspending`, `clearFrontCache`,
+  `suspendAwait`, `coAwait`, `useSuspendSpan`.
+- Remove naming aliases: `spanExportOf`, `batchSpanProcess`.
+- Rewrite compatibility tests to exercise the canonical APIs only.
+
+Validation:
+
+- `./gradlew :bluetape4k-cache-core:test :bluetape4k-cache-lettuce:test :bluetape4k-lettuce:test :bluetape4k-redisson:test :bluetape4k-opentelemetry:test :bluetape4k-resilience4j:test --no-daemon`
+
+### PR C: Bucket4j result factory cleanup
+
+Scope:
+
+- `infra/bucket4j`
+
+Tasks:
+
+- Remove the deprecated `RateLimitResult(consumedTokens, availableTokens)`
+  constructor.
+- Rewrite compatibility tests to assert the canonical factory methods and
+  validation paths.
+
+Validation:
+
+- `./gradlew :bluetape4k-bucket4j:test --no-daemon`
+
+## Notes For Follow-Up Work
+
+- This issue intentionally does not delete code.
+- Keep each cleanup PR small enough to review API removal and test migration
+  separately.
+- When a cleanup PR removes public API, add the migration note to
+  `CHANGELOG.md` under `Unreleased / Changed`.
+- Prefer removal over keeping compatibility aliases because this repository is
+  already preparing breaking 2.0+ cleanup work.


### PR DESCRIPTION
## Summary

Closes #110

- PR 제목: Document infra deprecated cleanup inventory

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: What changed

- Added `docs/infra-deprecated-inventory.md` with the current tracked `infra/` deprecated API inventory.
- Expanded the original 12-file issue scope to the current 18 source files, including mirrored `infra/kafka4` deprecated APIs.
- Split follow-up cleanup into Kafka/Kafka4, cache-redis-otel-resilience, and Bucket4j PR lanes.
- Updated `WIP.md` to remove completed Spring Boot standardization items from the active queue and point `#110` at the new inventory.
- Added an Unreleased CHANGELOG entry for the inventory.

### 기존 섹션: Why

`#110` is explicitly planning-only. The cleanup should not delete public deprecated APIs until the current source surface, replacement APIs, remaining local compatibility tests, and follow-up PR boundaries are written down in the repo.

`projects #280` was also completed by PR #348 and has been closed with that link.

Closes #110.

### 기존 섹션: Impact

- No production code changes.
- Follow-up cleanup PRs can remove deprecated APIs in smaller reviewable groups.
- Active WIP now points at `#257/#333` after this planning item merges.

### 기존 섹션: Not tested

- Gradle build was not run because this PR changes documentation only.

## Validation

- `git diff --check`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #110, milestone 없음, assignee `debop`
- PR: #349, head `bfe7950286d6465651671c40676c99647121b0ce`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/projects-infra-deprecated-inventory`
- Labels: `documentation`
- State: `MERGED`, merge commit `4cb3d142a8a32186347b3381706ab875647738d8`
- CI: `#110` is explicitly planning-only. The cleanup should not delete public deprecated APIs until the current source surface, replacement APIs, remaining local compatibility tests, and follow-up PR boundaries are written down in the repo. / - Gradle build was not run because this PR changes documentation only.

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #349 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `4cb3d142a8a32186347b3381706ab875647738d8`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
