### PR TITLE
fix: projects Nightly 회귀 보정

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -472,11 +472,9 @@ jobs:
           - group: cache-misc
             test_tasks: >-
               :bluetape4k-micrometer:test
-              :bluetape4k-cache:test
               :bluetape4k-cache-hazelcast:test
             kover_tasks: >-
               :bluetape4k-micrometer:koverXmlReport
-              :bluetape4k-cache:koverXmlReport
               :bluetape4k-cache-hazelcast:koverXmlReport
             needs_mock_server: true
           -   group: search-messaging
@@ -514,7 +512,7 @@ jobs:
           shell: bash
           command: |
             read -ra tasks <<< "$TEST_TASKS"
-            ./gradlew "${tasks[@]}"
+            ./gradlew "${tasks[@]}" --max-workers=1
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           TEST_TASKS: ${{ matrix.test_tasks }}
@@ -595,7 +593,7 @@ jobs:
           shell: bash
           command: |
             read -ra tasks <<< "$TEST_TASKS"
-            ./gradlew "${tasks[@]}"
+            ./gradlew "${tasks[@]}" --max-workers=1
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           TEST_TASKS: ${{ matrix.test_tasks }}
@@ -689,7 +687,7 @@ jobs:
           shell: bash
           command: |
             read -ra tasks <<< "$TEST_TASKS"
-            ./gradlew "${tasks[@]}"
+            ./gradlew "${tasks[@]}" --max-workers=1
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           TEST_TASKS: ${{ matrix.test_tasks }}

--- a/examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/cachestrategy/CacheApplication.kt
+++ b/examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/cachestrategy/CacheApplication.kt
@@ -2,11 +2,15 @@ package io.bluetape4k.examples.redisson.coroutines.cachestrategy
 
 import io.bluetape4k.logging.KLogging
 import org.redisson.spring.starter.RedissonAutoConfigurationV2
+import org.redisson.spring.starter.RedissonAutoConfigurationV4
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 @SpringBootApplication(
-    exclude = [RedissonAutoConfigurationV2::class]
+    exclude = [
+        RedissonAutoConfigurationV2::class,
+        RedissonAutoConfigurationV4::class,
+    ]
 )
 class CacheApplication {
     companion object: KLogging()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -785,6 +785,7 @@ kafka-streams = { module = "org.apache.kafka:kafka-streams", version.ref = "kafk
 kafka-streams-test-utils = { module = "org.apache.kafka:kafka-streams-test-utils", version.ref = "kafka3" }
 kafka-metadata = { module = "org.apache.kafka:kafka-metadata", version.ref = "kafka3" }
 kafka-raft = { module = "org.apache.kafka:kafka-raft", version.ref = "kafka3" }
+kafka-server = { module = "org.apache.kafka:kafka-server", version.ref = "kafka3" }
 kafka-server-common = { module = "org.apache.kafka:kafka-server-common", version.ref = "kafka3" }
 kafka-storage = { module = "org.apache.kafka:kafka-storage", version.ref = "kafka3" }
 kafka-storage-api = { module = "org.apache.kafka:kafka-storage-api", version.ref = "kafka3" }

--- a/infra/kafka/build.gradle.kts
+++ b/infra/kafka/build.gradle.kts
@@ -26,6 +26,8 @@ dependencies {
     compileOnly(libs.kafka.streams)
     compileOnly(libs.kafka.generator)
     testImplementation(libs.kafka.streams.test.utils)
+    testRuntimeOnly(libs.kafka.server)
+    testRuntimeOnly(libs.kafka.server.common)
     testImplementation(libs.testcontainers.kafka)
 
     // Spring Kafka

--- a/infra/opentelemetry/build.gradle.kts
+++ b/infra/opentelemetry/build.gradle.kts
@@ -77,6 +77,7 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
 
     // Spring Boot
+    testImplementation("org.springframework.boot:spring-boot-webtestclient")
     testImplementation("org.springframework.boot:spring-boot-starter-webflux")
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(group = "junit", module = "junit")

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/examples/javaagent/IndexControllerTest.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/examples/javaagent/IndexControllerTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import kotlin.time.Duration.Companion.milliseconds
@@ -21,6 +22,7 @@ import kotlin.time.Duration.Companion.milliseconds
     classes = [OtelSpringBootApp::class],
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
+@AutoConfigureWebTestClient
 class IndexControllerTest(
     @param:Autowired private val client: WebTestClient,
 ): AbstractOtelTest() {

--- a/testing/testcontainers/build.gradle.kts
+++ b/testing/testcontainers/build.gradle.kts
@@ -80,7 +80,7 @@ dependencies {
     compileOnly(libs.mongodb.driver.kotlin.extensions)
 
     // Cassandra
-    compileOnly(libs.testcontainers.cassandra)
+    api(libs.testcontainers.cassandra)
     compileOnly(libs.cassandra.java.driver.core)
     compileOnly(libs.cassandra.java.driver.query.builder)
 


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: projects Nightly 회귀 보정

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Nightly cache-misc에서 제거된 `:bluetape4k-cache` / `:bluetape4k-cache:koverXmlReport` 항목을 삭제했습니다.
- Docker-heavy Nightly matrix의 Gradle 테스트 실행을 `--max-workers=1`로 제한했습니다.
- Kafka 테스트 런타임에 `org.apache.kafka:kafka-server`와 `org.apache.kafka:kafka-server-common`을 추가했습니다.
- OpenTelemetry Spring Boot 테스트에 `spring-boot-webtestclient`와 `@AutoConfigureWebTestClient`를 추가했습니다.
- Redisson Spring Boot 4 auto-configuration도 테스트 앱에서 제외했습니다.
- Cassandra Testcontainers wrapper를 downstream compile/runtime에서 사용할 수 있도록 `api`로 노출했습니다.

### 기존 섹션: 변경 배경

projects develop Nightly `25614279833`에서 dependency refresh 이후 다음 회귀가 확인되었습니다.

- `Test / Infra (cache-misc)`: cache reorg 이후 삭제된 `:bluetape4k-cache` task를 계속 참조했습니다.
- `Test / Infra (kafka-resilience)`: Kafka 4 테스트 런타임에서 `kafka-server` / `kafka-server-common` ABI가 필요합니다.
- `Test / Misc`: Spring Boot 4에서 `WebTestClient` 자동 설정이 `spring-boot-webtestclient`로 분리되어 테스트 컨텍스트 주입이 실패합니다.
- `Test / Spring Boot (batch-nosql, demos)`: Cassandra/Mongo/Redis류 Docker 테스트가 Gradle parallel worker로 한 job 안에서 동시에 떠서 runner 메모리/접속 안정성이 낮았습니다.

### 기존 섹션: 남은 확인

- 이 PR 병합 후 develop Nightly workflow_dispatch로 최종 snapshot 배포 경로를 다시 확인해야 합니다.

## Validation

- `git diff --check`
- `./gradlew :bluetape4k-kafka:test :bluetape4k-opentelemetry:test :bluetape4k-examples-redisson-demo:test :bluetape4k-testcontainers:test --continue --max-workers=1 --no-daemon --no-configuration-cache --console=plain`
  - Kafka 256개, OpenTelemetry 73개, Redisson demo 89개 통과
  - `:bluetape4k-testcontainers:test`는 로컬 Docker에서 PostGIS container exit 139 한 건으로 실패했고, Cassandra API 노출 경로와 나머지 컨테이너 테스트는 진행 확인했습니다.
- Nightly 실패 그룹 재현 명령을 `--max-workers=1`로 실행해 cache-misc stale task 제거와 Kafka/OpenTelemetry 계열 통과를 확인했습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #353, head `669ed6139ccaad78775ea6306199db16cf3c2a60`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/projects-nightly-followup-fixes`
- Labels: 없음
- State: `MERGED`, merge commit `a57c9557bc847149df188193d8a198407860f4ff`
- CI: - `Test / Spring Boot (batch-nosql, demos)`: Cassandra/Mongo/Redis류 Docker 테스트가 Gradle parallel worker로 한 job 안에서 동시에 떠서 runner 메모리/접속 안정성이 낮았습니다. / - Docker-heavy Nightly matrix의 Gradle 테스트 실행을 `--max-workers=1`로 제한했습니다. / - `./gradlew :bluetape4k-kafka:test :bluetape4k-opentelemetry:test :bluetape4k-examples-redisson-demo:test :bluetape4k-testcontainers:test --continue --max-workers=1 --no-daemon --no-configuration-cache --console=plain`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #353 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `a57c9557bc847149df188193d8a198407860f4ff`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
