### PR TITLE
Nightly Docker shard 재배치

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -718,7 +718,8 @@ jobs:
           retention-days: 14
 
   # ── Testcontainers (nightly 전용) — Matrix 병렬 ──────────────────────────
-  # 5 groups run in parallel; test packages filtered via --tests per group
+  # Heavy Docker families are split into narrower shards so one slow container
+  # does not hold the full nightly critical path.
   test-testcontainers:
     name: Test / Testcontainers (${{ matrix.group }})
     runs-on: ubuntu-latest
@@ -727,28 +728,114 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - group: database
-            test_patterns: io.bluetape4k.testcontainers.database.*
+          - group: database-core
+            test_patterns: >-
+              io.bluetape4k.testcontainers.database.MariaDBServerTest
+              io.bluetape4k.testcontainers.database.MySQL5ServerTest
+              io.bluetape4k.testcontainers.database.MySQL8ServerTest
+              io.bluetape4k.testcontainers.database.PostgreSQLServerTest
+              io.bluetape4k.testcontainers.database.PgvectorServerTest
+              io.bluetape4k.testcontainers.database.PostgisServerTest
+            timeout_minutes: 25
+            max_attempts: 2
             needs_mock_servers: false
-          - group: storage
-            test_patterns: io.bluetape4k.testcontainers.storage.*
+          - group: database-analytics
+            test_patterns: >-
+              io.bluetape4k.testcontainers.database.ClickHouseServerTest
+              io.bluetape4k.testcontainers.database.CockroachServerTest
+              io.bluetape4k.testcontainers.database.TrinoServerTest
+            timeout_minutes: 25
+            max_attempts: 2
             needs_mock_servers: false
-          - group: mq
-            test_patterns: io.bluetape4k.testcontainers.mq.*
+          - group: database-contract
+            test_patterns: >-
+              io.bluetape4k.testcontainers.database.JdbcServerSupportTest
+              io.bluetape4k.testcontainers.database.R2dbcServerSupportTest
+            timeout_minutes: 10
+            max_attempts: 1
             needs_mock_servers: false
-          - group: infra-http
+          - group: storage-cassandra
+            test_patterns: io.bluetape4k.testcontainers.storage.CassandraServerTest
+            timeout_minutes: 20
+            max_attempts: 2
+            needs_mock_servers: false
+          - group: storage-search
+            test_patterns: >-
+              io.bluetape4k.testcontainers.storage.ElasticsearchOssServerTest
+              io.bluetape4k.testcontainers.storage.ElasticsearchServerTest
+              io.bluetape4k.testcontainers.storage.OpenSearchServerTest
+            timeout_minutes: 25
+            max_attempts: 2
+            needs_mock_servers: false
+          - group: storage-cache
+            test_patterns: >-
+              io.bluetape4k.testcontainers.storage.HazelcastServerTest
+              io.bluetape4k.testcontainers.storage.Ignite2ServerTest
+              io.bluetape4k.testcontainers.storage.Ignite3ServerTest
+              io.bluetape4k.testcontainers.storage.InfluxDBServerTest
+              io.bluetape4k.testcontainers.storage.MinIOServerTest
+              io.bluetape4k.testcontainers.storage.MongoDBServerTest
+              io.bluetape4k.testcontainers.storage.RedisClusterServerTest
+              io.bluetape4k.testcontainers.storage.RedisServerTest
+            timeout_minutes: 25
+            max_attempts: 2
+            needs_mock_servers: false
+          - group: mq-kafka
+            test_patterns: >-
+              io.bluetape4k.testcontainers.mq.KafkaServerTest
+              io.bluetape4k.testcontainers.mq.RedpandaServerTest
+            timeout_minutes: 20
+            max_attempts: 2
+            needs_mock_servers: false
+          - group: mq-brokers
+            test_patterns: >-
+              io.bluetape4k.testcontainers.mq.NatsServerTest
+              io.bluetape4k.testcontainers.mq.PulsarServerTest
+              io.bluetape4k.testcontainers.mq.RabbitMQServerTest
+            timeout_minutes: 20
+            max_attempts: 2
+            needs_mock_servers: false
+          - group: infra
             test_patterns: >-
               io.bluetape4k.testcontainers.infra.*
-              io.bluetape4k.testcontainers.http.*
-            needs_mock_servers: true
-          - group: graphdb-misc
+            timeout_minutes: 25
+            max_attempts: 2
+            needs_mock_servers: false
+          - group: http
             test_patterns: >-
-              io.bluetape4k.testcontainers.graphdb.*
+              io.bluetape4k.testcontainers.http.*
+            timeout_minutes: 25
+            max_attempts: 2
+            needs_mock_servers: true
+          - group: graphdb-falkordb
+            test_patterns: io.bluetape4k.testcontainers.graphdb.FalkorDBServerTest
+            timeout_minutes: 12
+            max_attempts: 2
+            needs_mock_servers: false
+          - group: graphdb-memgraph
+            test_patterns: io.bluetape4k.testcontainers.graphdb.MemgraphServerTest
+            timeout_minutes: 12
+            max_attempts: 2
+            needs_mock_servers: false
+          - group: graphdb-neo4j
+            test_patterns: io.bluetape4k.testcontainers.graphdb.Neo4jServerTest
+            timeout_minutes: 12
+            max_attempts: 2
+            needs_mock_servers: false
+          - group: graphdb-postgresql-age
+            test_patterns: io.bluetape4k.testcontainers.graphdb.PostgreSQLAgeServerTest
+            timeout_minutes: 12
+            max_attempts: 2
+            needs_mock_servers: false
+          - group: misc-contract
+            test_patterns: >-
               io.bluetape4k.testcontainers.GenericContainerExtensionsSupportTest
               io.bluetape4k.testcontainers.GenericServerSupportTest
               io.bluetape4k.testcontainers.GenericServerTest
               io.bluetape4k.testcontainers.PropertyExportingServerContractTest
               io.bluetape4k.testcontainers.RegisterSystemPropertiesTest
+            timeout_minutes: 8
+            max_attempts: 1
             needs_mock_servers: false
     steps:
       - uses: actions/checkout@v4
@@ -778,8 +865,8 @@ jobs:
       - name: Test testcontainers (${{ matrix.group }})
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 60
-          max_attempts: 3
+          timeout_minutes: ${{ matrix.timeout_minutes }}
+          max_attempts: ${{ matrix.max_attempts }}
           shell: bash
           command: |
             read -ra patterns <<< "$TEST_PATTERNS"


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: Nightly Docker shard 재배치

- `Test / Testcontainers`의 큰 Docker 묶음을 더 작은 shard로 재배치했습니다.
- `graphdb-misc`는 `graphdb-falkordb`, `graphdb-memgraph`, `graphdb-neo4j`, `graphdb-postgresql-age`, `misc-contract`로 분리했습니다.
- `database`, `storage`, `mq`, `infra-http`도 `database-core/analytics/contract`, `storage-cassandra/search/cache`, `mq-kafka/brokers`, `infra`, `http`로 분리했습니다.
- shard별 `timeout_minutes`와 `max_attempts`를 명시해 hang 시 전체 Nightly 지연 시간을 제한했습니다.

## Background

- 기존 `graphdb-misc`는 로컬 동일 패턴이 60 tests / 55초에 통과했지만, GitHub Actions에서는 45분 이상 `Test testcontainers (graphdb-misc)` step에 머물렀습니다.
- 기존 Testcontainers shard의 retry 예산은 사실상 `60분 x 3회`라서, 단일 컨테이너 hang이 Nightly와 Publish Snapshot 경로를 장시간 막을 수 있었습니다.
- Cassandra/Elasticsearch/OpenSearch 계열처럼 Docker 메모리 사용량이 큰 테스트는 단일 storage 묶음에 넣으면 지연 원인을 바로 특정하기 어렵습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 변경 전 -> 변경 후

- `database` -> `database-core`, `database-analytics`, `database-contract`
- `storage` -> `storage-cassandra`, `storage-search`, `storage-cache`
- `mq` -> `mq-kafka`, `mq-brokers`
- `infra-http` -> `infra`, `http`
- `graphdb-misc` -> `graphdb-falkordb`, `graphdb-memgraph`, `graphdb-neo4j`, `graphdb-postgresql-age`, `misc-contract`
- timeout/retry: broad shard `60분 x 3회` -> shard별 `8~25분 x 1~2회`

### 기존 섹션: 후속

- 병합 후 현재 장시간 Nightly를 취소하고 새 Nightly를 재실행합니다.
- 실패 또는 timeout 발생 시 shard 이름으로 느린 이미지/서비스를 바로 특정합니다.

## Validation

- `actionlint .github/workflows/nightly-tests.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nightly-tests.yml")'`
- 명시 테스트 패턴이 실제 테스트 파일과 모두 매칭됨을 확인
- Gradle dry-run: `:bluetape4k-testcontainers:test --tests ... --dry-run`
- 로컬 graphdb/misc 동일 패턴 검증: 60 tests passed in 55s

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #356, head `25c1ddddcbd0ceb355ce9083c7b4ed3e496d974e`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/projects-split-graphdb-nightly`
- Labels: 없음
- State: `MERGED`, merge commit `de797b76c0075e7122a434c324d80e2db10746ac`
- CI: - Gradle dry-run: `:bluetape4k-testcontainers:test --tests ... --dry-run`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #356 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `de797b76c0075e7122a434c324d80e2db10746ac`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
