### PR TITLE
Nightly Docker command timeout 강제

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -862,6 +862,10 @@ jobs:
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
+      - name: Pre-pull Memgraph Docker image
+        if: ${{ matrix.group == 'graphdb-memgraph' }}
+        run: timeout --kill-after=60s 10m docker pull memgraph/memgraph:3.9.0
+
       - name: Test testcontainers (${{ matrix.group }})
         uses: nick-fields/retry@v3
         with:
@@ -874,10 +878,19 @@ jobs:
             for pattern in "${patterns[@]}"; do
               tests_args+=(--tests "${pattern}")
             done
-            ./gradlew :bluetape4k-testcontainers:test "${tests_args[@]}"
+            if [[ "$NEEDS_MOCK_SERVERS" != "true" ]]; then
+              tests_args+=(
+                -x :bluetape4k-mock-web-server:jibDockerBuild
+                -x :bluetape4k-mock-webflux-server:jibDockerBuild
+              )
+            fi
+            timeout --kill-after=60s "${TEST_TIMEOUT_MINUTES}m" \
+              ./gradlew :bluetape4k-testcontainers:test "${tests_args[@]}"
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           TEST_PATTERNS: ${{ matrix.test_patterns }}
+          TEST_TIMEOUT_MINUTES: ${{ matrix.timeout_minutes }}
+          NEEDS_MOCK_SERVERS: ${{ matrix.needs_mock_servers }}
 
       - name: Generate Kover XML report
         if: always()


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: Nightly Docker command timeout 강제

- Testcontainers matrix의 Gradle test command를 Ubuntu `timeout`으로 직접 감쌉니다.
- `graphdb-memgraph` shard는 `memgraph/memgraph:3.9.0`을 명시적으로 pre-pull해 Docker pull/startup 병목을 log에 드러냅니다.
- mock server가 필요 없는 shard에서는 `:bluetape4k-mock-web-server:jibDockerBuild`, `:bluetape4k-mock-webflux-server:jibDockerBuild`를 `-x`로 제외합니다.

## Background

- `graphdb-memgraph` shard는 최종적으로 `Timeout of 720000ms hit`로 실패했고, 실패 전 `:bluetape4k-testcontainers:test`에서 12분 동안 멈췄습니다.
- 로컬 동일 테스트는 전체 47초, mock Jib 제외 시 29초, 실제 테스트 6개는 4.4초에 통과했습니다.
- 기존 Gradle test dependency 때문에 Memgraph만 선택해도 mock-web-server/mock-webflux-server Docker image build가 같이 실행됐습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 변경 전 -> 변경 후

- 변경 전: `./gradlew :bluetape4k-testcontainers:test ...`
- 변경 후: `timeout --kill-after=60s "${TEST_TIMEOUT_MINUTES}m" ./gradlew :bluetape4k-testcontainers:test ...`
- 변경 전: 모든 Testcontainers shard가 mock server Jib image build dependency를 그대로 수행
- 변경 후: `needs_mock_servers=false` shard는 mock Jib image build를 제외
- 변경 전: Memgraph image pull/startup이 Testcontainers 내부에서 묵묵히 진행
- 변경 후: Memgraph image를 별도 step에서 pre-pull해 Docker 병목을 분리

### 기존 섹션: 후속

- 병합 후 새 Nightly를 재실행합니다.
- Memgraph가 CI에서 계속 느리면 pre-pull step log로 Docker Hub pull 병목과 container startup 병목을 분리합니다.

## Validation

- `actionlint .github/workflows/nightly-tests.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nightly-tests.yml")'`
- `git diff --check`
- 로컬 `MemgraphServerTest` + mock Jib 제외: 6 tests passed, 전체 29s / 테스트 실행 4.4s

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #357, head `de04d8bff74021e80db957128bbfb64da783be53`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/projects-enforce-nightly-command-timeout`
- Labels: 없음
- State: `MERGED`, merge commit `12d225ef5450de1897ab95f62f784f4dff8ed7c1`
- CI: - Testcontainers matrix의 Gradle test command를 Ubuntu `timeout`으로 직접 감쌉니다. / - 기존 Gradle test dependency 때문에 Memgraph만 선택해도 mock-web-server/mock-webflux-server Docker image build가 같이 실행됐습니다. / - 변경 전: `./gradlew :bluetape4k-testcontainers:test ...`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #357 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `12d225ef5450de1897ab95f62f784f4dff8ed7c1`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
