### PR TITLE
Memgraph Testcontainers 최신 이미지 사용

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -864,7 +864,7 @@ jobs:
 
       - name: Pre-pull Memgraph Docker image
         if: ${{ matrix.group == 'graphdb-memgraph' }}
-        run: timeout --kill-after=60s 10m docker pull memgraph/memgraph:3.9.0
+        run: timeout --kill-after=60s 10m docker pull memgraph/memgraph:latest
 
       - name: Test testcontainers (${{ matrix.group }})
         uses: nick-fields/retry@v3

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/graphdb/MemgraphServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/graphdb/MemgraphServer.kt
@@ -11,6 +11,7 @@ import io.bluetape4k.utils.ShutdownQueue
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.utility.DockerImageName
+import java.time.Duration
 
 /**
  * [Memgraph](https://memgraph.com/) 그래프 데이터베이스를 Testcontainers로 실행합니다.
@@ -43,8 +44,8 @@ class MemgraphServer private constructor(
         /** Memgraph 공식 Docker 이미지 이름 */
         const val IMAGE = "memgraph/memgraph"
 
-        /** 기본으로 사용하는 Memgraph 이미지 태그 — Memgraph 3.9.0 최신 안정 버전 */
-        const val TAG = "3.9.0"
+        /** 기본으로 사용하는 Memgraph 이미지 태그 — Docker Hub 최신 안정 버전 */
+        const val TAG = "latest"
 
         /** 시스템 프로퍼티 접두사에 사용되는 서버 이름 */
         const val NAME = "memgraph"
@@ -54,6 +55,9 @@ class MemgraphServer private constructor(
 
         /** Memgraph 로그 서버 포트 */
         const val LOG_PORT = 7444
+
+        /** CI 에서 컨테이너 startup hang 이 길어지지 않도록 제한합니다. */
+        private val START_TIMEOUT: Duration = Duration.ofMinutes(3)
 
         /**
          * [DockerImageName]을 직접 지정하여 [MemgraphServer] 인스턴스를 생성합니다.
@@ -124,9 +128,10 @@ class MemgraphServer private constructor(
     init {
         addExposedPorts(BOLT_PORT, LOG_PORT)
         withReuse(reuse)
+        withStartupAttempts(1)
         addEnv("MEMGRAPH", "--telemetry-enabled=false")
         withCommand("--telemetry-enabled=false")
-        waitingFor(Wait.forListeningPort())
+        waitingFor(Wait.forListeningPort().withStartupTimeout(START_TIMEOUT))
 
         if (useDefaultPort) {
             exposeCustomPorts(BOLT_PORT, LOG_PORT)


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: Memgraph Testcontainers 최신 이미지 사용

- `MemgraphServer` 기본 Docker tag를 `3.9.0`에서 `latest`로 변경합니다.
- Nightly `graphdb-memgraph` pre-pull도 `memgraph/memgraph:latest`로 맞춥니다.
- Memgraph startup wait에 3분 timeout과 startup attempt 1회를 명시해 CI hang을 빠르게 드러냅니다.

## Background

- Docker Hub 기준 `latest`와 `3.9.0`은 현재 동일 digest입니다.
- 하지만 GitHub Actions에서는 pre-pull 성공 후에도 `:bluetape4k-testcontainers:test` 단계에서 Memgraph shard가 장시간 멈췄습니다.
- 사용자가 제안한 최신 tag 정책을 반영하면서, 다음 실패 시 Testcontainers startup timeout으로 원인을 더 짧게 확인할 수 있게 합니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 변경 전 -> 변경 후

- `MemgraphServer.TAG`: `3.9.0` -> `latest`
- Nightly pre-pull: `memgraph/memgraph:3.9.0` -> `memgraph/memgraph:latest`
- startup wait: 기본 Testcontainers 대기 -> `Wait.forListeningPort().withStartupTimeout(3분)` + `withStartupAttempts(1)`

### 기존 섹션: 후속

- 병합 후 새 Nightly를 다시 실행합니다.
- 계속 실패하면 tag 문제가 아니라 GitHub runner에서 Memgraph startup/Bolt readiness가 막히는 문제로 보고 로그 기반으로 별도 수정합니다.

## Validation

- Docker Hub tag 확인: `latest`와 `3.9.0` digest 동일
- `actionlint .github/workflows/nightly-tests.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nightly-tests.yml")'`
- `git diff --check`
- 로컬 `MemgraphServerTest` + mock Jib 제외: 6 tests passed, 전체 35s / 테스트 실행 5.4s

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #358, head `fcbc2a3365fa35cbcf51ace9b169eec283680145`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/projects-memgraph-latest-tag`
- Labels: 없음
- State: `MERGED`, merge commit `98dbb6696fa1163f1dc3c530acedf26a14a89272`
- CI: - Memgraph startup wait에 3분 timeout과 startup attempt 1회를 명시해 CI hang을 빠르게 드러냅니다.

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #358 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `98dbb6696fa1163f1dc3c530acedf26a14a89272`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
