### PR TITLE
Memgraph Nightly 테스트 lifecycle 안정화

### DIFF
--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/graphdb/MemgraphServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/graphdb/MemgraphServerTest.kt
@@ -3,36 +3,22 @@ package io.bluetape4k.testcontainers.graphdb
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.GraphDatabase
-import io.bluetape4k.assertions.assertFailsWith
 
 @TestInstance(Lifecycle.PER_CLASS)
 class MemgraphServerTest: AbstractContainerTest() {
 
     companion object: KLogging()
 
-    private lateinit var memgraph: MemgraphServer
-
-    @BeforeAll
-    fun beforeAll() {
-        memgraph = MemgraphServer().apply { start() }
-    }
-
-    @AfterAll
-    fun afterAll() {
-        if(this::memgraph.isInitialized && memgraph.isRunning) {
-            memgraph.close()
-        }
-    }
+    private val memgraph: MemgraphServer by lazy { MemgraphServer.Launcher.memgraph }
 
     @Test
     fun `Memgraph 서버가 실행 중이어야 한다`() {


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: Memgraph Nightly 테스트 lifecycle 안정화

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- `MemgraphServerTest`가 직접 `MemgraphServer()`를 생성하고 `@AfterAll`에서 닫던 흐름을 제거했습니다.
- `bluetape4k-graph`의 Memgraph 테스트처럼 `MemgraphServer.Launcher.memgraph` 싱글턴 lifecycle을 사용하도록 맞췄습니다.

### 기존 섹션: 이유

최신 `develop` Nightly는 최종 성공했지만, Memgraph shard가 첫 attempt에서 12분 timeout 후 두 번째 attempt에서 6개 테스트를 9초에 통과했습니다. workflow timeout을 늘리기보다 컨테이너 lifecycle을 graph repo에서 성공 중인 패턴과 맞춰 직접 shutdown 경로를 피합니다.

### 기존 섹션: 미검증

- 이 로컬 머신은 Testcontainers용 Docker 환경을 찾지 못해 Memgraph 컨테이너 테스트를 로컬에서 직접 실행하지 못했습니다.

## Validation

- `./gradlew :bluetape4k-testcontainers:compileTestKotlin`
- `git diff --check`
- GitHub Nightly Tests run `25618371832` 성공 확인

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #359, head `c0032b26e4746a8fdc45ee479fd12dd2869e4a76`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/bluetape4k-projects-memgraph-nightly-fix`
- Labels: 없음
- State: `MERGED`, merge commit `a8529a5415ba00c7f148675a0d3c699c804f064d`
- CI: - `./gradlew :bluetape4k-testcontainers:compileTestKotlin`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #359 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `a8529a5415ba00c7f148675a0d3c699c804f064d`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
