### PR TITLE
test: harden okio suspended source contracts

### DIFF
--- a/docs/superpowers/plans/2026-05-11-okio-review-tests-docs-plan.md
+++ b/docs/superpowers/plans/2026-05-11-okio-review-tests-docs-plan.md
@@ -1,0 +1,71 @@
+# io/okio Review, Tests, and Docs Plan
+
+## Plan
+
+1. Fix P1 no-progress behavior in `RealBufferedSuspendedSource`.
+   - Add a shared guarded read helper.
+   - Use it in `request`, `skip`, `select`, `readAll(SuspendedSink)`, and `indexOf` loops.
+2. Fix P1 cancellation propagation in `RealBufferedSuspendedSource.close()`.
+   - Rethrow `CancellationException`.
+   - Continue logging non-cancellation close failures.
+3. Add edge and coroutine stability tests.
+   - No-progress tests for looping buffered source APIs.
+   - Close cancellation propagation test.
+   - `SuspendedJobTester` pipe producer-consumer stress test.
+4. Update public docs.
+   - Korean KDoc for buffered suspended source no-progress contract.
+   - README.md and README.ko.md coroutine safety notes.
+   - README.md and README.ko.md Okio strengths, recommended usage scenarios, and anti-patterns.
+5. Run strict gate verification.
+   - `git diff --check`
+   - `./gradlew :bluetape4k-okio:compileTestKotlin --no-build-cache`
+   - targeted tests where feasible.
+   - GitHub CI after PR creation.
+
+## 6-Tier Gate
+
+| Tier | Gate | Result Before Patch | Exit Requirement |
+|---|---|---|---|
+| 1 | Public API contract | No signature changes required; KDoc missing no-progress contract. | Public contract documented without binary API breakage. |
+| 2 | Correctness / edge cases | P1 no-progress loops found. | Repeated `0L` delegate reads throw `IOException`. |
+| 3 | Coroutine / concurrency safety | P1 cancellation swallow and P2 missing stress test found. | Cancellation rethrows; `SuspendedJobTester` coverage added. |
+| 4 | Resource lifecycle | Close path logs ordinary close failures. | Cancellation is not hidden; close remains idempotent. |
+| 5 | Documentation / examples | README lacked the new safety contract and practical Okio guidance. | README.md and README.ko.md synchronized with safety notes, strengths, usage scenarios, and anti-patterns. |
+| 6 | Verification / maintainability | Existing tests cover many happy paths, but not these gates. | Targeted compile/tests and CI status recorded. |
+
+## P0/P1 Gate
+
+| Priority | Finding | Status | Validation |
+|---|---|---|---|
+| P0 | None | Closed | No P0 found in current scope |
+| P1 | `RealBufferedSuspendedSource` no-progress loops | Closed | `BufferedSuspendSourceTest` targeted tests passed |
+| P1 | `RealBufferedSuspendedSource.close()` swallows cancellation | Closed | Cancellation regression test passed |
+| P1 | `RealBufferedSuspendedSource.close()` swallowed ordinary close `IOException` | Closed | IOException regression test passed |
+| P1 | `readUtf8LineStrict(limit)` exact-limit CRLF branch could index beyond requested bytes and return the line with `\r` | Closed | CRLF exact-limit regression test passed |
+| P1 | Single-read APIs could pass repeated delegate `0L` reads through as `0` | Closed | ByteArray/Buffer no-progress tests passed |
+| P1 | Drain helpers needed explicit no-progress verification | Closed | `readUtf8`, `readByteArray`, `readByteString` no-progress tests passed |
+
+## Advisor Review
+
+Claude Code Opus advisor is required by the bluetape4k design workflow when available.
+
+Artifact: `.omx/artifacts/claude-okio-review-20260511.md`
+
+| Priority | Finding | Decision | Follow-up |
+|---|---|---|---|
+| P1 | `close()` swallowed non-cancellation `IOException` | Accepted | Rethrow and add regression test |
+| P1 | `readUtf8LineStrict(limit)` exact-limit CRLF branch could OOB and return wrong slice | Accepted | Use `request(scanLength + 1L)` and `readUtf8Line(scanLength)`; add test |
+| P1 | Single-read APIs lacked no-progress contract | Accepted | Guard `read(ByteArray)` and `read(Buffer)`; add tests |
+| P1 | Drain helpers needed explicit no-progress tests | Accepted | Add `readUtf8`, `readByteArray`, `readByteString` tests |
+| P2 | No-progress reset path untested | Accepted | Add recovering delegate test |
+| P2 | Pipe stress coverage thin | Partially accepted | Keep stable producer-consumer `SuspendedJobTester`; rejected a cancellation-wakes-reader stress variant after it proved scheduler-sensitive locally |
+| P2 | Decimal/hex no-progress and zero-byte request coverage could be more explicit | Accepted | Added focused tests for decimal/hex no-progress and `request(0)` |
+
+## Verification Evidence
+
+| Command | Result |
+|---|---|
+| `./gradlew :bluetape4k-okio:compileTestKotlin --no-build-cache` | Passed |
+| `./gradlew :bluetape4k-okio:test --tests "io.bluetape4k.okio.coroutines.BufferedSuspendSourceTest" --tests "io.bluetape4k.okio.coroutines.SuspendedPipeTest" --no-build-cache` | Passed, 75 tests |
+| `./gradlew :bluetape4k-okio:test --no-build-cache` | Passed, 1420 tests, 14 pending |
+| `git diff --check` | Passed |

--- a/docs/superpowers/specs/2026-05-11-okio-review-tests-docs-design.md
+++ b/docs/superpowers/specs/2026-05-11-okio-review-tests-docs-design.md
@@ -1,0 +1,39 @@
+# io/okio Review, Tests, and Docs Design
+
+## Scope
+
+- Module: `io/okio`
+- Work type: strict 6-Tier code review, edge test hardening, public KDoc and README update.
+- Verification mode: local targeted compile/test plus GitHub CI.
+
+## Findings
+
+| Priority | Finding | Evidence | Required Action |
+|---|---|---|---|
+| P0 | None | No release-blocking crash/data-loss path found in current review scope. | N/A |
+| P1 | `RealBufferedSuspendedSource` can loop forever if the delegate `SuspendedSource.read()` repeatedly returns `0L` while callers wait for more bytes. | `request`, `skip`, `select`, `readAll(SuspendedSink)`, and `indexOf` loops read repeatedly without the no-progress guard used by `SuspendedSource.readAll`, sink interop, compression, and Tink code. | Add a shared no-progress read guard and edge tests for each looping path. |
+| P1 | `RealBufferedSuspendedSource.close()` can swallow coroutine cancellation. | `close()` catches `Exception` and logs it; `CancellationException` is an `Exception` and should be rethrown per bluetape4k coroutine rules. | Rethrow `CancellationException` before logging other exceptions and add a regression test. |
+| P1 | `RealBufferedSuspendedSource.close()` can hide ordinary close failures. | External advisor flagged divergence from Okio close propagation; callers could miss `IOException` from the delegate close. | Rethrow non-cancellation close exceptions after logging. |
+| P1 | `readUtf8LineStrict(limit)` exact-limit CRLF branch was under-tested. | External advisor flagged the branch as requiring `scanLength + 1L` before indexing `buffer[scanLength]` and CRLF stripping via `readUtf8Line(scanLength)`. | Fix branch and add CRLF exact-limit regression test. |
+| P1 | Single-read APIs and drain helpers needed explicit no-progress coverage. | External advisor flagged `read(ByteArray)`, `read(Buffer)`, `readUtf8`, `readByteArray`, and `readByteString`. | Add guards/tests for single reads and explicit tests for drain helpers. |
+| P2 | Coroutine pipe tests do not stress lock/condition behavior with the repository-approved coroutine stress helper. | `SuspendedPipeTest` covers basic/cancel/fold behavior but not repeated concurrent producer-consumer cycles. | Add `SuspendedJobTester` coverage. |
+| P2 | README/KDoc do not document the no-progress protection contract for buffered suspended sources. | README coroutine section explains async I/O but not repeated 0-byte delegate reads. | Add concise English/Korean docs and KDoc contract. |
+| P2 | README lacks practical Okio adoption guidance. | README lists features, but does not explain Okio strengths, recommended usage scenarios, or anti-patterns. | Add synchronized English/Korean guidance sections. |
+
+## Acceptance Criteria
+
+- P0/P1 gate closes with zero remaining P0/P1 findings.
+- `RealBufferedSuspendedSource` throws `IOException` after repeated no-progress delegate reads on looping APIs instead of spinning forever.
+- `RealBufferedSuspendedSource.close()` rethrows `CancellationException` and ordinary close `IOException`.
+- `readUtf8LineStrict(limit)` handles exact-limit CRLF without leaving `\r` or `\n` behind.
+- New tests cover request/skip/select/indexOf/readAll no-progress paths, close cancellation, and `SuspendedJobTester` pipe concurrency.
+- README.md and README.ko.md stay synchronized for the new coroutine safety contract and Okio guidance.
+
+## Step Checklist Completion Report
+
+| Item | Status | Notes |
+|---|---|---|
+| Worktree created | Done | `.worktrees/okio-review-tests-docs` from `origin/develop` |
+| Current repo evidence checked | Done | Source, tests, README, build file inspected |
+| User intent clear | Done | Apply strict 6-Tier review and fix/test/docs for `io/okio` |
+| Review-only boundary | N/A | User asked to work on the module, not review-only |

--- a/io/okio/README.ko.md
+++ b/io/okio/README.ko.md
@@ -7,6 +7,87 @@
 `bluetape4k-okio`는 Square의 [Okio](https://square.github.io/okio/) 라이브러리를 기반으로 한 고성능 I/O 확장 모듈입니다. Okio의 `Source`/
 `Sink` 추상화 위에 압축, 암호화, Base64 인코딩, NIO 채널 통합, Kotlin Coroutines 비동기 I/O 등을 제공합니다.
 
+## Okio를 쓰는 이유
+
+Okio는 `java.io`와 `java.nio`를 직접 사용할 때 자주 생기는 장황한 코드, 불필요한 할당, 애매한
+read 계약을 줄이기 위한 실용적인 I/O 계층입니다. 핵심 모델은 작습니다. 데이터는 `Source`와
+`Sink`를 통해 흐르고, 호출자는 보통 `BufferedSource`, `BufferedSink`, `Buffer`, `ByteString`으로
+작업합니다.
+
+주요 장점:
+
+- **조합 가능한 스트림 파이프라인**: 압축, 암호화, Base64, hashing, channel adapter를
+  `Source`/`Sink` 위의 작은 decorator로 단계적으로 조합할 수 있습니다.
+- **효율적인 버퍼링**: `Buffer`는 재사용 가능한 segment로 byte를 저장하며, buffer 간 데이터
+  이동 시 매번 전체 byte를 복사하지 않아도 됩니다.
+- **값으로 다루는 바이너리 데이터**: `ByteString`은 immutable byte sequence이므로 비교, 인코딩,
+  디코딩, hashing, 모듈 경계 전달에 적합합니다.
+- **byte와 text를 하나의 API로 처리**: raw byte, UTF-8, primitive number, line-oriented protocol을
+  같은 buffered API로 다룰 수 있어 byte stream과 reader/writer wrapper를 오갈 필요가 줄어듭니다.
+- **더 안전한 I/O 계약**: `Timeout`, 단순한 `Source`/`Sink` 인터페이스, buffered read를 통해
+  `InputStream.available()` 또는 single-byte read에 의존하는 오류를 피할 수 있습니다.
+- **테스트 용이성**: `Buffer`는 source와 sink 역할을 모두 할 수 있어 codec/protocol 로직을 파일,
+  socket, 임시 stream 없이 검증하기 쉽습니다.
+- **이 모듈의 coroutine 확장**: `SuspendedSource`, `SuspendedSink`, suspended file/socket channel,
+  `SuspendedPipe`를 통해 Okio 스타일 pipeline을 structured concurrency 코드에서도 사용할 수 있습니다.
+
+## 추천 사용 시나리오
+
+다음 요구가 있다면 `bluetape4k-okio` 사용을 권장합니다:
+
+- **Protocol 또는 payload codec**: binary protocol, framed message, length-prefixed record,
+  checksum, UTF-8 line parser를 `Buffer`와 `BufferedSource` 기반으로 구현할 때.
+- **Streaming transformation**: `Source`/`Sink` 형태를 유지하면서 압축, 복원, 암호화, 복호화,
+  Base64 인코딩을 조합해야 할 때.
+- **대용량 payload 처리**: payload 전체를 하나의 byte array로 올리면 안 되는 경우 streaming
+  compressor, DAEAD chunk encryption, buffered copy를 사용할 때.
+- **레거시 I/O와 현대적 I/O 연결**: `InputStream`, `OutputStream`, `ReadableByteChannel`,
+  `WritableByteChannel`, `FileChannel`을 하나의 Okio 기반 pipeline으로 맞출 때.
+- **Coroutine 기반 서비스**: 호출자가 이미 structured concurrency를 사용하고 있고 raw stream
+  호출로 coroutine dispatcher를 blocking하면 안 되는 경우 suspended file/socket adapter와
+  `SuspendedPipe`를 사용할 때.
+- **I/O 코드의 결정적 테스트**: source와 sink를 `Buffer`로 모델링하고, 파일/socket 테스트는
+  integration boundary에만 둘 때.
+- **보안 민감 payload envelope**: payload가 여러 번 나뉘어 기록되고 associated data를 각 frame과
+  함께 인증해야 할 때 DAEAD chunk encryption을 사용할 때.
+
+권장 기본값:
+
+- 리소스를 소유하는 source/sink는 항상 `use {}`로 감쌉니다.
+- 크기를 알 수 없거나 큰 payload에는 streaming adapter를 우선 사용합니다.
+- 여러 번의 write로 만들어지는 암호화 payload에는 DAEAD chunk encryption을 우선 사용합니다.
+- 프로토콜 요구가 없다면 압축을 먼저 적용하고 그 결과를 암호화합니다.
+- public immutable boundary에는 `ByteString`, 내부 mutable 작업 영역에는 `Buffer`를 사용합니다.
+- coroutine 코드에서는 blocking stream을 직접 감싸기보다 `SuspendedSource`/`SuspendedSink`와
+  suspended buffered API를 사용합니다.
+
+## Anti-Patterns
+
+이 모듈을 사용할 때 다음 패턴은 피하세요:
+
+- **`InputStream.available()`에 의존하지 마세요.** read 가능 여부 판단에는 `request`, `require`,
+  `exhausted`, `readUtf8Line`, protocol-specific length check 같은 buffered Okio API를 사용하세요.
+- **hot path에서 raw stream을 1 byte씩 읽지 마세요.** source를 buffer로 감싸고 `BufferedSource`에서
+  byte, string, primitive 값을 읽으세요.
+- **입력이 제한되어 있고 신뢰할 수 있는 경우가 아니면 `readByteArray()`나 `readUtf8()`로 큰 stream을
+  한 번에 materialize하지 마세요.** sink로 streaming하거나 frame 단위로 처리하세요.
+- **압축/암호화 sink의 `close()`를 빠뜨리지 마세요.** 일부 adapter는 footer, frame, ciphertext를
+  close 시점에 확정합니다.
+- **multi-write payload에 legacy `TinkEncryptSink`를 사용하지 마세요.** write마다 독립 ciphertext가
+  만들어지는 반면 matching decrypt source는 단일 ciphertext를 기대합니다. incremental write에는
+  DAEAD chunk encryption을 사용하세요.
+- **DAEAD 복호화에 다른 associated data를 넘기지 마세요.** associated data는 인증 대상이며 암호화
+  시점과 완전히 같은 값을 사용해야 합니다.
+- **coroutine cancellation을 삼키지 마세요.** 특히 `close()`나 cleanup 경로에서 broad exception
+  handling 전에 `CancellationException`을 다시 던져야 합니다.
+- **양수 read 요청에 `0L`을 반복 반환하는 `SuspendedSource`를 구현하지 마세요.** 양수 read는 진행,
+  진행 가능 시점까지 suspend, EOF의 `-1L` 중 하나여야 합니다. Buffered suspended source는 무한 루프를
+  막기 위해 반복 no-progress read 이후 빠르게 실패합니다.
+- **ownership 규칙 없이 mutable `Buffer`를 여러 thread/coroutine에서 공유하지 마세요.** 경계를
+  넘길 때는 `SuspendedPipe`, immutable `ByteString`, 또는 상위 queue/channel을 사용하세요.
+- **one-shot adapter와 streaming adapter를 혼용하지 마세요.** one-shot 압축/복원은 전체 payload를
+  버퍼링합니다. 입력이 제한되지 않았다면 streaming adapter가 더 안전한 기본값입니다.
+
 ## 주요 기능
 
 ### 1. Buffer / ByteString 유틸리티
@@ -203,6 +284,11 @@ suspend fun writeFileAsync(path: String, data: ByteArray) {
 val socketSource = SuspendedSocketChannelSource(socketChannel)
 val socketSink = SuspendedSocketChannelSink(socketChannel)
 ```
+
+버퍼링된 suspended source는 잘못 구현되었거나 non-blocking 성격의 delegate가 양수 read 요청에
+`0L`을 반복 반환하는 상황을 방어합니다. `request`, `skip`, `select`, `indexOf`,
+`readAll`처럼 추가 데이터가 필요한 연산은 무한 루프 대신 반복 no-progress read 이후
+`IOException`을 던집니다.
 
 **Suspended Pipe (생산자-소비자 패턴):**
 

--- a/io/okio/README.md
+++ b/io/okio/README.md
@@ -8,6 +8,103 @@ English | [한국어](./README.ko.md)
 `Source`/
 `Sink` abstractions, it provides compression, encryption, Base64 encoding, NIO channel integration, and Kotlin Coroutines async I/O.
 
+## Why Okio
+
+Okio is a pragmatic replacement layer for the parts of `java.io` and `java.nio`
+that tend to create awkward, allocation-heavy, or error-prone code. The core
+model is intentionally small: data flows through `Source` and `Sink`, and callers
+usually work with `BufferedSource`, `BufferedSink`, `Buffer`, and `ByteString`.
+
+Key strengths:
+
+- **Composable stream pipeline**: compression, encryption, Base64, hashing, and
+  channel adapters can be layered as small decorators around `Source`/`Sink`.
+- **Efficient buffering**: `Buffer` stores bytes in reusable segments and can move
+  data between buffers without copying every byte.
+- **Binary data as values**: `ByteString` makes immutable bytes easy to compare,
+  encode, decode, hash, and pass across module boundaries.
+- **One API for bytes and text**: the same buffered API handles raw bytes,
+  UTF-8, primitive numbers, and line-oriented protocols without switching
+  between byte streams and reader/writer wrappers.
+- **Safer I/O contracts**: `Timeout`, compact `Source`/`Sink` interfaces, and
+  buffered reads avoid common `InputStream.available()` and single-byte-read
+  pitfalls.
+- **Testability**: `Buffer` can stand in for both a source and a sink, so most
+  codec and protocol logic can be tested without files, sockets, or temp
+  streams.
+- **Coroutine-friendly extensions in this module**: `SuspendedSource`,
+  `SuspendedSink`, suspended file/socket channels, and `SuspendedPipe` make Okio
+  style pipelines usable from structured concurrency code.
+
+## Recommended Usage Scenarios
+
+Use `bluetape4k-okio` when your code needs one or more of these behaviors:
+
+- **Protocol or payload codecs**: implement binary protocols, framed messages,
+  length-prefixed records, checksums, or UTF-8 line parsers with `Buffer` and
+  `BufferedSource`.
+- **Streaming transformations**: compress, decompress, encrypt, decrypt, or
+  Base64-encode data while preserving the `Source`/`Sink` shape of the pipeline.
+- **Large payload processing**: prefer streaming compressors, DAEAD chunk
+  encryption, and buffered copying when payloads should not be materialized as a
+  single byte array.
+- **Bridging legacy and modern I/O**: adapt `InputStream`, `OutputStream`,
+  `ReadableByteChannel`, `WritableByteChannel`, and `FileChannel` into a common
+  Okio-based pipeline.
+- **Coroutine-based services**: use suspended file/socket adapters and
+  `SuspendedPipe` when the caller is already using structured concurrency and
+  should not block a coroutine dispatcher with raw stream operations.
+- **Deterministic tests for I/O code**: model sources and sinks with `Buffer`,
+  then add file/socket tests only for the integration boundary.
+- **Security-sensitive payload envelopes**: use DAEAD chunk encryption when the
+  payload is written incrementally and associated data must be authenticated with
+  every frame.
+
+Recommended defaults:
+
+- Prefer `use {}` around every source and sink that owns a resource.
+- Prefer streaming adapters for unknown or large payload sizes.
+- Prefer DAEAD chunk encryption for multi-write encrypted payloads.
+- Keep compression before encryption unless the protocol explicitly requires the
+  opposite order.
+- Treat `ByteString` as the public immutable boundary type and `Buffer` as the
+  mutable working area.
+- In coroutine code, prefer `SuspendedSource`/`SuspendedSink` and the suspended
+  buffered APIs instead of wrapping blocking stream calls directly.
+
+## Anti-Patterns
+
+Avoid these patterns when using this module:
+
+- **Do not rely on `InputStream.available()`** to decide whether a read can
+  complete. Use buffered Okio reads such as `request`, `require`, `exhausted`,
+  `readUtf8Line`, or protocol-specific length checks.
+- **Do not read one byte at a time from raw streams** in hot paths. Buffer the
+  source and consume bytes, strings, or primitives through `BufferedSource`.
+- **Do not materialize large streams with `readByteArray()` or `readUtf8()`**
+  unless the input is bounded and trusted. Stream to a sink or process frames
+  incrementally.
+- **Do not forget `close()` on compression or encryption sinks**. Some adapters
+  finalize footers, frames, or ciphertext only when closed.
+- **Do not use legacy `TinkEncryptSink` for multi-write payloads**. It creates
+  independent ciphertexts per write while the matching decrypt source expects a
+  single ciphertext. Use DAEAD chunk encryption for incremental writes.
+- **Do not reuse mismatched associated data** for DAEAD decryption. Associated
+  data is authenticated and must be identical to the encryption value.
+- **Do not swallow coroutine cancellation**. Re-throw `CancellationException`
+  before broad exception handling, especially around `close()` and cleanup paths.
+- **Do not implement a `SuspendedSource` that repeatedly returns `0L` for
+  positive read requests**. A positive read should either make progress, suspend
+  until progress is possible, or return `-1L` at EOF. Buffered suspended sources
+  fail fast after repeated no-progress reads to avoid infinite loops.
+- **Do not share a mutable `Buffer` across concurrent writers/readers without
+  ownership discipline**. Use `SuspendedPipe`, immutable `ByteString`, or a
+  higher-level queue/channel when ownership crosses coroutine or thread
+  boundaries.
+- **Do not mix one-shot and streaming adapters accidentally**. One-shot
+  compression/decompression buffers the full payload; streaming adapters are the
+  safer default for unbounded input.
+
 ## Key Features
 
 ### 1. Buffer / ByteString Utilities
@@ -208,6 +305,11 @@ suspend fun writeFileAsync(path: String, data: ByteArray) {
 val socketSource = SuspendedSocketChannelSource(socketChannel)
 val socketSink = SuspendedSocketChannelSink(socketChannel)
 ```
+
+Buffered suspended sources guard against broken or non-blocking delegates that
+repeatedly return `0L` for positive read requests. Operations that need more
+data, such as `request`, `skip`, `select`, `indexOf`, and `readAll`, throw an
+`IOException` after repeated no-progress reads instead of spinning forever.
 
 **Suspended Pipe (producer-consumer pattern):**
 

--- a/io/okio/src/main/kotlin/io/bluetape4k/okio/coroutines/RealBufferedSuspendedSource.kt
+++ b/io/okio/src/main/kotlin/io/bluetape4k/okio/coroutines/RealBufferedSuspendedSource.kt
@@ -7,11 +7,13 @@ import io.bluetape4k.okio.coroutines.internal.ForwardSuspendedSource
 import io.bluetape4k.support.requireInRange
 import io.bluetape4k.support.requireZeroOrPositiveNumber
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CancellationException
 import okio.Buffer
 import okio.ByteString
 import okio.EOFException
 import okio.Options
 import okio.Timeout
+import java.io.IOException
 
 /**
  * [SuspendedSource]에 내부 버퍼를 추가하여 효율적인 읽기를 제공하는 [BufferedSuspendedSource]를 반환합니다.
@@ -24,6 +26,10 @@ import okio.Timeout
  * // line == "hello world"
  * bufferedSource.close()
  * ```
+ *
+ * ## 동작/계약
+ * - 하위 [SuspendedSource.read]가 양수 `byteCount` 요청에 대해 `0L`을 반복 반환하면
+ *   무한 대기를 막기 위해 [IOException]을 던집니다.
  */
 fun SuspendedSource.buffered(): BufferedSuspendedSource = RealBufferedSuspendedSource(this)
 
@@ -64,8 +70,11 @@ class RealBufferedSuspendedSource(
         byteCount.requireZeroOrPositiveNumber("byteCount")
         checkNotClosed()
 
+        var noProgressCount = 0
         while (buffer.size < byteCount) {
-            if (source.read(buffer, SEGMENT_SIZE) == -1L) {
+            val read = readIntoBufferOrThrowNoProgress("request bytes", noProgressCount)
+            noProgressCount = read.noProgressCount
+            if (read.byteCount == -1L) {
                 return false
             }
         }
@@ -181,13 +190,22 @@ class RealBufferedSuspendedSource(
     override suspend fun skip(byteCount: Long) {
         checkNotClosed()
         var remaining = byteCount
+        var noProgressCount = 0
         while (remaining > 0L) {
-            if (buffer.size == 0L && source.read(buffer, SEGMENT_SIZE) == -1L) {
-                throw EOFException("source exhausted. buffer size is 0 and cannot read more")
+            if (buffer.size == 0L) {
+                val read = readIntoBufferOrThrowNoProgress("skip bytes", noProgressCount)
+                noProgressCount = read.noProgressCount
+                if (read.byteCount == -1L) {
+                    throw EOFException("source exhausted. buffer size is 0 and cannot read more")
+                }
+                if (read.byteCount == 0L) {
+                    continue
+                }
             }
             val toSkip = minOf(remaining, buffer.size)
             buffer.skip(toSkip)
             remaining -= toSkip
+            noProgressCount = 0
         }
     }
 
@@ -215,6 +233,7 @@ class RealBufferedSuspendedSource(
     override suspend fun select(options: Options): Int {
         checkNotClosed()
 
+        var noProgressCount = 0
         while (true) {
             var needsMoreData = false
             for (i in 0 until options.size) {
@@ -233,7 +252,9 @@ class RealBufferedSuspendedSource(
                 }
             }
             if (!needsMoreData) return -1
-            if (source.read(buffer, SEGMENT_SIZE) == -1L) return -1
+            val read = readIntoBufferOrThrowNoProgress("select options", noProgressCount)
+            noProgressCount = read.noProgressCount
+            if (read.byteCount == -1L) return -1
         }
     }
 
@@ -270,10 +291,12 @@ class RealBufferedSuspendedSource(
             "offset=$offset, byteCount=$byteCount, sink.size=${sink.size}"
         }
         checkNotClosed()
+        var noProgressCount = 0
         if (buffer.size == 0L) {
-            val read = source.read(buffer, SEGMENT_SIZE)
-            if (read == -1L) {
-                return -1
+            while (buffer.size == 0L) {
+                val read = readIntoBufferOrThrowNoProgress("read bytes", noProgressCount)
+                noProgressCount = read.noProgressCount
+                if (read.byteCount == -1L) return -1
             }
         }
         val toRead = minOf(byteCount.toLong(), buffer.size).toInt()
@@ -288,10 +311,13 @@ class RealBufferedSuspendedSource(
         if (byteCount == 0L) return 0L
         checkNotClosed()
 
+        var noProgressCount = 0
         if (buffer.size == 0L) {
-            val read = source.read(buffer, SEGMENT_SIZE)
-            if (read == -1L)
-                return -1L
+            while (buffer.size == 0L) {
+                val read = readIntoBufferOrThrowNoProgress("read buffer", noProgressCount)
+                noProgressCount = read.noProgressCount
+                if (read.byteCount == -1L) return -1L
+            }
         }
 
         val toRead = minOf(byteCount, buffer.size)
@@ -338,11 +364,17 @@ class RealBufferedSuspendedSource(
     override suspend fun readAll(sink: SuspendedSink): Long {
         checkNotClosed()
         var totalBytesWritten = 0L
-        while (source.read(buffer, SEGMENT_SIZE) != -1L) {
+        var noProgressCount = 0
+        while (true) {
+            val read = readIntoBufferOrThrowNoProgress("read all bytes", noProgressCount)
+            noProgressCount = read.noProgressCount
+            if (read.byteCount == -1L) break
+            if (read.byteCount == 0L) continue
             val emitByteCount = buffer.completeSegmentByteCount()
             if (emitByteCount > 0L) {
                 totalBytesWritten += emitByteCount
                 sink.write(buffer, emitByteCount)
+                noProgressCount = 0
             }
         }
         if (buffer.size > 0L) {
@@ -402,10 +434,10 @@ class RealBufferedSuspendedSource(
             return buffer.readUtf8Line(newline)
         }
         if (scanLength < Long.MAX_VALUE &&
-            request(scanLength) &&
+            request(scanLength + 1L) &&
             buffer[scanLength - 1].toInt() == '\r'.code &&
             buffer[scanLength].toInt() == '\n'.code) {
-            return buffer.readUtf8(scanLength)      // The line was 'limit' UTF-8 bytes followed by \r\n.
+            return buffer.readUtf8Line(scanLength)  // The line was 'limit' UTF-8 bytes followed by \r\n.
         }
         val data = Buffer()
         buffer.copyTo(data, 0, minOf(32, buffer.size))
@@ -435,6 +467,7 @@ class RealBufferedSuspendedSource(
         fromIndex.requireInRange(0, toIndex, "fromIndex")
 
         var current = fromIndex
+        var noProgressCount = 0
         while (current < toIndex) {
             val result = buffer.indexOf(b, current, toIndex)
             if (result != -1L) {
@@ -444,9 +477,13 @@ class RealBufferedSuspendedSource(
             // The byte wasn't in the buffer. Give up if we've already reached our target size or if the
             // underlying stream is exhausted.
             val lastBufferSize = buffer.size
-            if (lastBufferSize >= toIndex || source.read(buffer, SEGMENT_SIZE) == -1L) {
+            if (lastBufferSize >= toIndex) {
                 return -1L
             }
+            val read = readIntoBufferOrThrowNoProgress("find byte", noProgressCount)
+            noProgressCount = read.noProgressCount
+            if (read.byteCount == -1L) return -1L
+            if (read.byteCount == 0L) continue
             // Continue the search from where we left off.
             current = maxOf(current, lastBufferSize)
         }
@@ -459,6 +496,7 @@ class RealBufferedSuspendedSource(
     override suspend fun indexOf(bytes: ByteString, fromIndex: Long): Long {
         checkNotClosed()
         var current = fromIndex
+        var noProgressCount = 0
         while (true) {
             val result = buffer.indexOf(bytes, current)
             if (result >= 0L) {
@@ -466,9 +504,10 @@ class RealBufferedSuspendedSource(
             }
 
             val lastBufferSize = buffer.size
-            if (source.read(buffer, SEGMENT_SIZE) == -1L) {
-                return -1L
-            }
+            val read = readIntoBufferOrThrowNoProgress("find byte string", noProgressCount)
+            noProgressCount = read.noProgressCount
+            if (read.byteCount == -1L) return -1L
+            if (read.byteCount == 0L) continue
 
             // Keep searching, picking up from where we left off.
             current = maxOf(current, lastBufferSize)
@@ -521,8 +560,11 @@ class RealBufferedSuspendedSource(
         if (closed.compareAndSet(false, true)) {
             try {
                 source.close()
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 log.error(e) { "Error closing source[$source]" }
+                throw e
             }
         }
     }
@@ -535,6 +577,26 @@ class RealBufferedSuspendedSource(
     private fun checkNotClosed() {
         check(!closed.value) { "RealBufferedSuspendedSource is closed" }
     }
+
+    private suspend fun readIntoBufferOrThrowNoProgress(
+        operation: String,
+        noProgressCount: Int,
+    ): ReadAttempt {
+        val read = source.read(buffer, SEGMENT_SIZE)
+        if (read == 0L) {
+            val nextCount = noProgressCount + 1
+            if (nextCount >= SuspendedSource.MAX_NO_PROGRESS_READS) {
+                throw IOException("Unable to $operation from SuspendedSource: no progress.")
+            }
+            return ReadAttempt(read, nextCount)
+        }
+        return ReadAttempt(read, 0)
+    }
+
+    private data class ReadAttempt(
+        val byteCount: Long,
+        val noProgressCount: Int,
+    )
 
     private fun Buffer.readUtf8Line(newline: Long): String = when {
         newline > 0L && this[newline - 1].toInt() == '\r'.code -> {

--- a/io/okio/src/test/kotlin/io/bluetape4k/okio/coroutines/BufferedSuspendSourceTest.kt
+++ b/io/okio/src/test/kotlin/io/bluetape4k/okio/coroutines/BufferedSuspendSourceTest.kt
@@ -9,6 +9,7 @@ import okio.ByteString
 import okio.EOFException
 import okio.Options
 import okio.ByteString.Companion.encodeUtf8
+import kotlinx.coroutines.CancellationException
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
@@ -16,6 +17,7 @@ import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
 import io.bluetape4k.assertions.assertFailsWith
+import java.io.IOException
 
 class BufferedSuspendSourceTest: AbstractOkioTest() {
 
@@ -44,6 +46,41 @@ class BufferedSuspendSourceTest: AbstractOkioTest() {
             buffer.write(source, byteCount)
         }
         override suspend fun flush() {}
+        override suspend fun close() {}
+    }
+
+    private class NoProgressSuspendedSource: SuspendedSource {
+        override suspend fun read(sink: Buffer, byteCount: Long): Long = 0L
+        override suspend fun close() {}
+        override fun timeout() = okio.Timeout.NONE
+    }
+
+    private class CancellationOnCloseSource: SuspendedSource {
+        override suspend fun read(sink: Buffer, byteCount: Long): Long = -1L
+        override suspend fun close() {
+            throw CancellationException("close cancelled")
+        }
+    }
+
+    private class IOExceptionOnCloseSource: SuspendedSource {
+        override suspend fun read(sink: Buffer, byteCount: Long): Long = -1L
+        override suspend fun close() {
+            throw IOException("close failed")
+        }
+    }
+
+    private class RecoveringSuspendedSource(
+        private val text: String,
+        private val zeroReadsBeforeProgress: Int,
+    ): SuspendedSource {
+        private var reads = 0
+        private val data = Buffer().writeUtf8(text)
+
+        override suspend fun read(sink: Buffer, byteCount: Long): Long {
+            if (reads++ < zeroReadsBeforeProgress) return 0L
+            return data.read(sink, minOf(byteCount, data.size))
+        }
+
         override suspend fun close() {}
     }
 
@@ -111,6 +148,15 @@ class BufferedSuspendSourceTest: AbstractOkioTest() {
     }
 
     @Test
+    fun `readDecimalLong throws when delegate repeatedly reports no progress`() = runSuspendIO {
+        val source = NoProgressSuspendedSource().buffered()
+
+        assertFailsWith<IOException> {
+            source.readDecimalLong()
+        }
+    }
+
+    @Test
     fun `readHexadecimalUnsignedLong reads hex number`() = runSuspendIO {
         val buffer = Buffer().writeUtf8("deadbeef rest")
         val source = FakeSuspendedSource(buffer).buffered()
@@ -122,6 +168,15 @@ class BufferedSuspendSourceTest: AbstractOkioTest() {
         val buffer = Buffer().writeUtf8("1A2B rest")
         val source = FakeSuspendedSource(buffer).buffered()
         source.readHexadecimalUnsignedLong() shouldBeEqualTo 0x1A2BL
+    }
+
+    @Test
+    fun `readHexadecimalUnsignedLong throws when delegate repeatedly reports no progress`() = runSuspendIO {
+        val source = NoProgressSuspendedSource().buffered()
+
+        assertFailsWith<IOException> {
+            source.readHexadecimalUnsignedLong()
+        }
     }
 
     @Test
@@ -224,6 +279,15 @@ class BufferedSuspendSourceTest: AbstractOkioTest() {
     }
 
     @Test
+    fun `read into ByteArray throws when delegate repeatedly reports no progress`() = runSuspendIO {
+        val source = NoProgressSuspendedSource().buffered()
+
+        assertFailsWith<IOException> {
+            source.read(ByteArray(4))
+        }
+    }
+
+    @Test
     fun `read into Buffer returns read byte count`() = runSuspendIO {
         val bytes = byteArrayOf(10, 20, 30)
         val buffer = Buffer().write(bytes)
@@ -240,6 +304,15 @@ class BufferedSuspendSourceTest: AbstractOkioTest() {
         val source = FakeSuspendedSource(buffer).buffered()
         val sink = Buffer()
         source.read(sink, 1L) shouldBeEqualTo -1L
+    }
+
+    @Test
+    fun `read into Buffer throws when delegate repeatedly reports no progress`() = runSuspendIO {
+        val source = NoProgressSuspendedSource().buffered()
+
+        assertFailsWith<IOException> {
+            source.read(Buffer(), 1L)
+        }
     }
 
     @Test
@@ -355,6 +428,16 @@ class BufferedSuspendSourceTest: AbstractOkioTest() {
     }
 
     @Test
+    fun `readUtf8LineStrict strips CRLF when line length equals limit`() = runSuspendIO {
+        val buffer = Buffer().writeUtf8("hello\r\nnext")
+        val source = FakeSuspendedSource(buffer).buffered()
+
+        source.readUtf8LineStrict(5L) shouldBeEqualTo "hello"
+        source.readUtf8Line() shouldBeEqualTo "next"
+        source.readUtf8Line().shouldBeNull()
+    }
+
+    @Test
     fun `readUtf8CodePoint reads ASCII character`() = runSuspendIO {
         val buffer = Buffer().writeUtf8("A")
         val source = FakeSuspendedSource(buffer).buffered()
@@ -383,6 +466,49 @@ class BufferedSuspendSourceTest: AbstractOkioTest() {
     }
 
     @Test
+    fun `request zero bytes returns true without reading delegate`() = runSuspendIO {
+        val source = NoProgressSuspendedSource().buffered()
+
+        source.request(0L).shouldBeTrue()
+    }
+
+    @Test
+    fun `request throws when delegate repeatedly reports no progress`() = runSuspendIO {
+        val source = NoProgressSuspendedSource().buffered()
+
+        assertFailsWith<IOException> {
+            source.request(1L)
+        }
+    }
+
+    @Test
+    fun `request resets no progress counter when delegate later makes progress`() = runSuspendIO {
+        val source = RecoveringSuspendedSource("done", zeroReadsBeforeProgress = 2).buffered()
+
+        source.request(4L).shouldBeTrue()
+        source.readUtf8() shouldBeEqualTo "done"
+    }
+
+    @Test
+    fun `skip throws when delegate repeatedly reports no progress`() = runSuspendIO {
+        val source = NoProgressSuspendedSource().buffered()
+
+        assertFailsWith<IOException> {
+            source.skip(1L)
+        }
+    }
+
+    @Test
+    fun `select throws when delegate repeatedly reports no progress`() = runSuspendIO {
+        val source = NoProgressSuspendedSource().buffered()
+        val options = Options.of("hello".encodeUtf8())
+
+        assertFailsWith<IOException> {
+            source.select(options)
+        }
+    }
+
+    @Test
     fun `indexOf finds byte in specified range`() = runSuspendIO {
         val buffer = Buffer().writeUtf8("hello world")
         val source = FakeSuspendedSource(buffer).buffered()
@@ -397,6 +523,15 @@ class BufferedSuspendSourceTest: AbstractOkioTest() {
     }
 
     @Test
+    fun `indexOf byte throws when delegate repeatedly reports no progress`() = runSuspendIO {
+        val source = NoProgressSuspendedSource().buffered()
+
+        assertFailsWith<IOException> {
+            source.indexOf('x'.code.toByte(), 0L, 1L)
+        }
+    }
+
+    @Test
     fun `indexOf ByteString finds substring`() = runSuspendIO {
         val buffer = Buffer().writeUtf8("hello world")
         val source = FakeSuspendedSource(buffer).buffered()
@@ -408,6 +543,15 @@ class BufferedSuspendSourceTest: AbstractOkioTest() {
         val buffer = Buffer().writeUtf8("hello world")
         val source = FakeSuspendedSource(buffer).buffered()
         source.indexOf("xyz".encodeUtf8(), 0L) shouldBeEqualTo -1L
+    }
+
+    @Test
+    fun `indexOf ByteString throws when delegate repeatedly reports no progress`() = runSuspendIO {
+        val source = NoProgressSuspendedSource().buffered()
+
+        assertFailsWith<IOException> {
+            source.indexOf("xyz".encodeUtf8(), 0L)
+        }
     }
 
     @Test
@@ -458,5 +602,59 @@ class BufferedSuspendSourceTest: AbstractOkioTest() {
         val source = fake.buffered()
         source.close()
         fake.closed.shouldBeTrue()
+    }
+
+    @Test
+    fun `readAll throws when delegate repeatedly reports no progress`() = runSuspendIO {
+        val source = NoProgressSuspendedSource().buffered()
+
+        assertFailsWith<IOException> {
+            source.readAll(FakeSuspendedSink(Buffer()))
+        }
+    }
+
+    @Test
+    fun `readUtf8 throws when delegate repeatedly reports no progress`() = runSuspendIO {
+        val source = NoProgressSuspendedSource().buffered()
+
+        assertFailsWith<IOException> {
+            source.readUtf8()
+        }
+    }
+
+    @Test
+    fun `readByteArray throws when delegate repeatedly reports no progress`() = runSuspendIO {
+        val source = NoProgressSuspendedSource().buffered()
+
+        assertFailsWith<IOException> {
+            source.readByteArray()
+        }
+    }
+
+    @Test
+    fun `readByteString throws when delegate repeatedly reports no progress`() = runSuspendIO {
+        val source = NoProgressSuspendedSource().buffered()
+
+        assertFailsWith<IOException> {
+            source.readByteString()
+        }
+    }
+
+    @Test
+    fun `close rethrows cancellation from underlying source`() = runSuspendIO {
+        val source = CancellationOnCloseSource().buffered()
+
+        assertFailsWith<CancellationException> {
+            source.close()
+        }
+    }
+
+    @Test
+    fun `close rethrows IOException from underlying source`() = runSuspendIO {
+        val source = IOExceptionOnCloseSource().buffered()
+
+        assertFailsWith<IOException> {
+            source.close()
+        }
     }
 }

--- a/io/okio/src/test/kotlin/io/bluetape4k/okio/coroutines/SuspendedPipeTest.kt
+++ b/io/okio/src/test/kotlin/io/bluetape4k/okio/coroutines/SuspendedPipeTest.kt
@@ -1,9 +1,12 @@
 package io.bluetape4k.okio.coroutines
 
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.okio.AbstractOkioTest
 import io.bluetape4k.okio.bufferOf
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import net.datafaker.Faker
 import okio.Buffer
 import okio.IOException
@@ -93,5 +96,32 @@ class SuspendedPipeTest: AbstractOkioTest() {
         assertFailsWith<IllegalStateException> {
             pipe.source.read(Buffer(), 10)
         }
+    }
+
+    @Test
+    fun `SuspendedJobTester - concurrent producer consumer cycles remain stable`() = runSuspendIO {
+        SuspendedJobTester()
+            .workers(4)
+            .rounds(32)
+            .add {
+                val pipe = SuspendedPipe(8L)
+
+                coroutineScope {
+                    val writer = async {
+                        val source = bufferOf("ping")
+                        pipe.sink.write(source, source.size)
+                        pipe.sink.close()
+                    }
+                    val reader = async {
+                        val sink = Buffer()
+                        pipe.source.readAll(sink)
+                        sink.readUtf8()
+                    }
+
+                    writer.await()
+                    reader.await() shouldBeEqualTo "ping"
+                }
+            }
+            .run()
     }
 }


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: test: harden okio suspended source contracts

- Hardened `RealBufferedSuspendedSource` against repeated no-progress delegate reads across buffered read paths and single-read APIs.
- Preserved coroutine cancellation semantics and now rethrows delegate close failures after logging.
- Added edge coverage for no-progress reads, exact-limit CRLF line handling, close failure propagation, and `SuspendedPipe` producer-consumer stress via `SuspendedJobTester`.
- Expanded `io/okio` README docs in English and Korean with Okio strengths, recommended usage scenarios, anti-patterns, and the suspended no-progress contract.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 6-Tier Review Result

| Tier | Result |
|---|---|
| Public API contract | No binary signature changes; Korean KDoc added for the buffered suspended source no-progress contract. |
| Correctness / edge cases | Repeated `0L` reads now fail with `IOException` instead of spinning or returning no progress to callers. |
| Coroutine / concurrency safety | `CancellationException` is rethrown; `SuspendedJobTester` producer-consumer stress coverage added. |
| Resource lifecycle | Delegate close `IOException` is no longer swallowed. |
| Documentation / examples | README.md and README.ko.md are synchronized with safety notes, advantages, scenarios, and anti-patterns. |
| Verification / maintainability | Targeted and full `bluetape4k-okio` tests passed locally. |

### 기존 섹션: P0/P1 Gate

| Priority | Finding | Status | Evidence |
|---|---|---|---|
| P0 | None | Closed | No P0 found in current review scope. |
| P1 | `RealBufferedSuspendedSource` looping APIs could spin forever if a delegate repeatedly returned `0L`. | Closed | Shared no-progress guard plus request/skip/select/indexOf/readAll tests. |
| P1 | `RealBufferedSuspendedSource.close()` swallowed `CancellationException`. | Closed | Cancellation regression test passes. |
| P1 | `RealBufferedSuspendedSource.close()` swallowed ordinary delegate close `IOException`. | Closed | IOException close propagation regression test passes. |
| P1 | `readUtf8LineStrict(limit)` exact-limit CRLF branch could request too few bytes and return the wrong slice. | Closed | Exact-limit CRLF regression test passes. |
| P1 | Single-read APIs could surface repeated delegate `0L` reads as `0` instead of making progress or failing. | Closed | ByteArray/Buffer no-progress tests pass. |
| P1 | Drain helpers lacked explicit no-progress coverage. | Closed | `readUtf8`, `readByteArray`, `readByteString`, decimal, and hex no-progress tests pass. |

Latest integrated findings: P0 = 0, P1 = 0.

### 기존 섹션: Verification

- `./gradlew :bluetape4k-okio:compileTestKotlin --no-build-cache` passed.
- `./gradlew :bluetape4k-okio:test --tests "io.bluetape4k.okio.coroutines.BufferedSuspendSourceTest" --tests "io.bluetape4k.okio.coroutines.SuspendedPipeTest" --no-build-cache` passed, 75 tests.
- `./gradlew :bluetape4k-okio:test --no-build-cache` passed, 1420 tests, 14 pending.
- `git diff --check` passed after the README expansion.

### 기존 섹션: Notes

- External Claude Opus advisor was used as the required second-opinion gate; accepted P1 findings are reflected above.
- A scheduler-sensitive pipe cancellation stress variant was rejected after local hang risk; stable `SuspendedJobTester` producer-consumer stress coverage remains.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #380, head `145877eba02e221c0ac290ad26dcb031c73d7aa7`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/okio-review-tests-docs`
- Labels: `documentation`, `test`, `chore`
- State: `MERGED`, merge commit `f6407664db944405f310839c4729d379bc6a018b`
- CI: | P1 | Drain helpers lacked explicit no-progress coverage. | Closed | `readUtf8`, `readByteArray`, `readByteString`, decimal, and hex no-progress tests pass. | / - `./gradlew :bluetape4k-okio:compileTestKotlin --no-build-cache` passed. / - `./gradlew :bluetape4k-okio:test --tests "io.bluetape4k.okio.coroutines.BufferedSuspendSourceTest" --tests "io.bluetape4k.okio.coroutines.SuspendedPipeTest" --no-build-cache` passed, 75 tests.

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #380 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `f6407664db944405f310839c4729d379bc6a018b`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
