### PR TITLE
[fix] Harden Jackson3 streaming EOF contracts

### DIFF
--- a/docs/superpowers/plans/2026-05-11-jackson3-review-tests-docs-plan.md
+++ b/docs/superpowers/plans/2026-05-11-jackson3-review-tests-docs-plan.md
@@ -1,0 +1,34 @@
+# Jackson3 Review, Tests, and Docs Plan
+
+## Plan
+
+1. Add explicit logical EOF APIs to `AsyncJsonParser` and `SuspendJsonParser`.
+2. Refactor token draining into private helpers so normal chunk feed and EOF drain use the same path.
+3. Add edge tests for complete EOF and truncated EOF in callback and suspend parser variants.
+4. Update Korean KDoc and add short code comments explaining the EOF contract.
+5. Remove stale Jasypt `@JsonEncrypt` README content and add Jackson3 advantages, recommended scenarios, anti-patterns, and EOF usage notes to both READMEs.
+6. Run targeted compile/tests and full module tests.
+7. Run external Claude advisor review for P0/P1 convergence, integrate any P0/P1 findings, then commit and open a draft PR.
+
+## Review Gate Tracking
+
+| Iteration | P0 | P1 | Action |
+|-----------|----|----|--------|
+| Baseline | 0 | 1 | Implement EOF terminal APIs and EOF edge tests. |
+| Advisor 1 | 0 | 6 | Add feed readiness checks, length validation, cancellation checkpoints, broader EOF tests, and remove stale Jasypt mentions. |
+| Advisor 2 | 0 | 0 | Gate closed; no remaining P0/P1 findings. |
+
+## Verification Commands
+
+```bash
+./gradlew :bluetape4k-jackson3:compileTestKotlin --no-build-cache
+./gradlew :bluetape4k-jackson3:test --tests "io.bluetape4k.jackson3.async.AsyncJsonParserTest" --tests "io.bluetape4k.jackson3.async.SuspendJsonParserTest" --no-build-cache
+./gradlew :bluetape4k-jackson3:test --no-build-cache
+git diff --check
+```
+
+## Rollback Notes
+
+- The new EOF APIs are additive.
+- Existing incremental `consume(...)` behavior is intentionally preserved.
+- README cleanup is documentation-only and tracks current source files.

--- a/docs/superpowers/specs/2026-05-11-jackson3-review-tests-docs-design.md
+++ b/docs/superpowers/specs/2026-05-11-jackson3-review-tests-docs-design.md
@@ -1,0 +1,60 @@
+# Jackson3 Review, Tests, and Docs Design
+
+## Scope
+
+- Target module: `io/jackson3` (`bluetape4k-jackson3`).
+- Apply the bluetape4k 6-Tier review gate until no P0/P1 findings remain.
+- Add missing edge tests, Korean KDoc examples for public API changes, explanatory code comments for non-obvious behavior, and synchronized README updates.
+- Keep changes scoped to Jackson3 async parsing and documentation drift found during review.
+
+## 6-Tier Review Summary
+
+| Tier | Result | Notes |
+|------|--------|-------|
+| API contract | P1 found | Non-blocking parsers had no explicit logical EOF path, so truncated final JSON could remain undetected. |
+| Correctness | P1 found | EOF is required by Jackson `NonBlockingInputFeeder.endOfInput()` to convert incomplete input into a parse failure. |
+| Concurrency/coroutines | No P0/P1 | `SuspendJsonParser` does not swallow coroutine cancellation in `onNodeDone`; no shared-thread use is introduced. |
+| Security/data safety | No P0/P1 | Tink encryption implementation was not changed; README drift around legacy Jasypt docs is documentation risk only. |
+| Tests | P1 coverage gap | Existing tests covered malformed tokens but not truncated-at-EOF streams. |
+| Documentation | P2 found | README references nonexistent legacy `@JsonEncrypt` Jasypt files/modules in this module. |
+
+## P0/P1 Findings
+
+| Priority | Finding | Resolution |
+|----------|---------|------------|
+| P0 | None | N/A |
+| P1 | `AsyncJsonParser`/`SuspendJsonParser` cannot signal logical stream end, so callers cannot force Jackson to report truncated final JSON. | Add explicit `endOfInput()` APIs, a suspend `consumeComplete()` convenience, KDoc examples, and EOF edge tests. |
+| P1 | Parser feed could silently skip a new chunk if Jackson was not ready for more input. | Drain pending tokens first, then fail fast with `check` instead of ignoring data. |
+| P1 | `consume(bytes, length)` accepted invalid length values. | Validate `length` with `requireInRange(0, bytes.size, "length")` and add range tests. |
+| P1 | Suspend parser drain loop had no explicit cancellation checkpoint. | Add `currentCoroutineContext().ensureActive()` while draining available tokens. |
+| P1 | EOF tests covered only one truncation shape. | Add number, unterminated string, and dangling escape truncation cases for both parsers. |
+
+## P2/P3 Findings
+
+| Priority | Finding | Resolution |
+|----------|---------|------------|
+| P2 | README documents legacy Jasypt `@JsonEncrypt` classes that do not exist under `io/jackson3/src/main/kotlin`. | Remove stale Jasypt guidance and document only `@JsonTinkEncrypt` for Jackson3. |
+| P2 | README lacks a compact decision guide for Jackson3 advantages, recommended scenarios, and anti-patterns. | Add English/Korean sections and keep both READMEs synchronized. |
+
+## Design Decisions
+
+- Preserve `consume(...)` as an incremental feed API. Existing tests and expected usage call `consume` multiple times for partial arrays and repeated roots.
+- Add EOF as an explicit terminal operation rather than treating every `Flow` completion as EOF. This avoids breaking callers that use several finite flows to model one longer logical stream.
+- Add `consumeComplete(flow)` for finite suspend streams where Flow completion is the logical input boundary.
+- Keep code comments short and focused on why EOF is required and why `consume` remains incremental.
+
+## Acceptance Criteria
+
+- `AsyncJsonParser.endOfInput()` throws on truncated final JSON and does not emit extra roots for complete input.
+- `SuspendJsonParser.consumeComplete(...)` throws on truncated final JSON and succeeds for complete input.
+- Public API KDoc explains incremental feed vs completed stream usage in Korean with examples.
+- README.md and README.ko.md describe Jackson3 advantages, recommended scenarios, anti-patterns, and the EOF contract.
+- Latest integrated 6-Tier gate shows `P0 = 0` and `P1 = 0`.
+
+## Review Gate Closure
+
+| Iteration | Reviewer | P0 | P1 | Notes |
+|-----------|----------|----|----|-------|
+| Baseline | Codex 6-Tier | 0 | 1 | Missing logical EOF contract found. |
+| Advisor 1 | Claude Opus 4.7 | 0 | 6 | Feed readiness, length validation, coroutine cancellation, README drift, and EOF coverage gaps found. |
+| Advisor 2 | Claude Opus 4.7 | 0 | 0 | All prior P1 findings resolved. Artifact: `.omx/artifacts/claude-jackson3-rereview-20260511.md`. |

--- a/io/jackson3/README.ko.md
+++ b/io/jackson3/README.ko.md
@@ -8,6 +8,31 @@
 
 Jackson 2.x(`bluetape4k-jackson2`)와 동일한 기능 구조를 제공하면서, Jackson 3.x의 새로운 API와 패키지 구조(`tools.jackson.*`)를 따릅니다.
 
+## bluetape4k에서 Jackson3를 쓰는 장점
+
+- Kotlin 우선 매퍼 구성: `jsonMapper { }`와 `Jackson.defaultJsonMapper`가 Kotlin 모듈 기본값을 한곳에 모읍니다.
+- 안전한 확장 함수: `readValueOrNull`, `writeAsString`, `writeAsBytes`로 자주 쓰는 직렬화 경로를 간결하게 표현합니다.
+- 스트리밍 친화 파싱: 콜백/코루틴 파서가 전체 응답을 먼저 버퍼링하지 않고 루트 JSON 노드 단위로 처리합니다.
+- 보안 확장: Tink 기반 필드 암호화와 필드 마스킹을 Jackson 모델 애너테이션으로 연결할 수 있습니다.
+- 포맷 선택성: 바이너리/텍스트 포맷은 `compileOnly`로 두고, 애플리케이션이 필요한 런타임 포맷만 추가합니다.
+
+## 추천 사용 시나리오
+
+- 새 Kotlin 코드가 Jackson 3.x와 `tools.jackson.*` 패키지를 기준으로 작성될 때 사용하세요.
+- bluetape4k serializer 계약, 캐시 payload, 단순 JSON byte/string 변환에는 `JacksonSerializer`를 사용하세요.
+- 실패 시 `null` 반환이 호출자 계약에 맞고, 누락 데이터와 잘못된 데이터를 구분할 수 있을 때 ObjectMapper 확장 함수를 사용하세요.
+- Netty, WebSocket, TCP, 메시지 리스너처럼 콜백으로 청크를 받는 코드는 `AsyncJsonParser`를 사용하세요.
+- 하나의 유한한 `Flow<ByteArray>`가 완성된 논리 스트림을 나타내면 `SuspendJsonParser.consumeComplete(flow)`를 사용하세요.
+- 직렬화된 JSON 문서 안에서 보호해야 하는 문자열 필드에만 `@JsonTinkEncrypt`를 사용하세요.
+
+## Anti-Patterns
+
+- Jackson 2.x import를 이 모듈로 복사하지 마세요. Jackson 3.x API는 `tools.jackson.*`에 있고, 일부 annotation만 `com.fasterxml.jackson.annotation`에 남아 있습니다.
+- 제거된 `activateDefaultTyping()` 동작에 의존하지 마세요. 명시적인 다형성 모델이나 sealed hierarchy를 사용하세요.
+- 잘못된 JSON을 감사하거나 호출자에게 알려야 하는 경로에는 `readValueOrNull`을 쓰지 말고 예외를 던지는 Jackson API를 사용하세요.
+- 네트워크/파일 스트림을 끝낼 때 `endOfInput()` 또는 `consumeComplete(...)`를 생략하지 마세요. 마지막 JSON 토큰이 잘렸는데도 “추가 입력 대기”처럼 보일 수 있습니다.
+- `consume(flow)` 완료를 EOF로 해석하지 마세요. 이 메서드는 이후 청크를 더 붙일 수 있는 증분 공급 API입니다.
+
 ## Jackson 2.x vs 3.x
 
 | 항목            | Jackson 2.x                             | Jackson 3.x                            |
@@ -102,12 +127,13 @@ val parser = AsyncJsonParser { root ->
 }
 parser.consume(chunk1)
 parser.consume(chunk2)
+parser.endOfInput()
 
 // 코루틴 기반 파싱
 val suspendParser = SuspendJsonParser { root ->
     processNode(root)  // suspend 가능
 }
-suspendParser.consume(byteArrayFlow)
+suspendParser.consumeComplete(byteArrayFlow)
 ```
 
 언제 어떤 파서를 쓰면 좋은지:
@@ -115,6 +141,7 @@ suspendParser.consume(byteArrayFlow)
 - `AsyncJsonParser`: Netty, WebSocket, TCP, 메시지 리스너처럼 `ByteArray` 청크를 콜백으로 받는 push 스타일 코드
 - `SuspendJsonParser`: `Flow<ByteArray>` 기반 파이프라인, `WebClient`/파일/브로커 스트림처럼 suspend 후처리가 필요한 코드
 - 두 파서 모두 연속된 여러 JSON 루트와 루트 스칼라 JSON(`"text"`, `123`, `true`, `null`)를 처리할 수 있습니다.
+- 콜백 스트림이 끝나면 `endOfInput()`을 호출하고, 유한한 Flow는 `consumeComplete(flow)`를 사용하세요. Jackson은 이 EOF 신호를 받아야 마지막 JSON이 잘린 경우 오류로 판정합니다.
 
 ### 4-1. WebClient 스트리밍 예제
 
@@ -150,7 +177,7 @@ val chunkFlow = webClient.get()
     }
     .asFlow()
 
-parser.consume(chunkFlow)
+parser.consumeComplete(chunkFlow)
 ```
 
 이미 청크를 콜백으로 받고 있다면 같은 시나리오에서도 `AsyncJsonParser`가 더 자연스럽습니다.
@@ -169,27 +196,7 @@ data class User(
 )
 ```
 
-### 6. 필드 암호화 (@JsonEncrypt / @JsonTinkEncrypt)
-
-#### Jasypt 기반 (`@JsonEncrypt`) — Deprecated
-
-```kotlin
-import io.bluetape4k.jackson3.crypto.JsonEncrypt
-import io.bluetape4k.jackson3.crypto.JsonEncryptModule
-
-data class User(
-    val username: String,
-    @get:JsonEncrypt          // AES 기본 암호화 (Jasypt)
-    val password: String,
-)
-
-// JsonEncryptModule 등록 필요
-val mapper = Jackson.createDefaultJsonMapper().rebuild()
-    .addModule(JsonEncryptModule())
-    .build()
-```
-
-#### Google Tink 기반 (`@JsonTinkEncrypt`) — 권장
+### 6. 필드 암호화 (@JsonTinkEncrypt)
 
 `bluetape4k-tink` 의존성이 필요하며, `JsonTinkEncryptModule`을 매퍼에 등록해야 합니다.
 
@@ -339,10 +346,6 @@ classDiagram
         +createDefaultJsonMapper() JsonMapper
     }
 
-    class JsonEncryptModule {
-        +setupModule(context)
-    }
-
     class JsonTinkEncryptModule {
         +setupModule(context)
     }
@@ -357,7 +360,6 @@ classDiagram
 
     JsonSerializer <|.. JacksonSerializer
     JacksonSerializer --> Jackson : 사용
-    Jackson --> JsonEncryptModule : 등록
     Jackson --> JsonTinkEncryptModule : 등록
     Jackson --> JsonMaskerModule : 등록
     Jackson --> JsonUuidModule : 등록
@@ -365,7 +367,6 @@ classDiagram
     style JsonSerializer fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     style JacksonSerializer fill:#E0F2F1,stroke:#80CBC4,color:#00695C
     style Jackson fill:#FFF3E0,stroke:#FFCC80,color:#E65100
-    style JsonEncryptModule fill:#E0F2F1,stroke:#80CBC4,color:#00695C
     style JsonTinkEncryptModule fill:#E0F2F1,stroke:#80CBC4,color:#00695C
     style JsonMaskerModule fill:#E0F2F1,stroke:#80CBC4,color:#00695C
     style JsonUuidModule fill:#E0F2F1,stroke:#80CBC4,color:#00695C
@@ -410,9 +411,8 @@ dependencies {
     implementation("tools.jackson.dataformat:jackson-dataformat-csv3")
     implementation("tools.jackson.dataformat:jackson-dataformat-toml3")
 
-    // 암호화 (선택적)
-    implementation(project(":bluetape4k-crypto"))  // @JsonEncrypt (Jasypt) 사용 시
-    implementation(project(":bluetape4k-tink"))    // @JsonTinkEncrypt (Google Tink) 사용 시
+    // 암호화 (선택적, @JsonTinkEncrypt 사용 시)
+    implementation(project(":bluetape4k-tink"))
 }
 ```
 
@@ -429,12 +429,6 @@ io.bluetape4k.jackson3
 │   ├── AsyncJsonParser.kt        # 콜백 기반 비동기 파서
 │   └── SuspendJsonParser.kt      # 코루틴 기반 파서
 ├── crypto/                                       # 필드 암호화
-│   ├── JsonEncrypt.kt                            # @JsonEncrypt 어노테이션 (Jasypt, Deprecated)
-│   ├── JsonEncryptModule.kt                      # Jasypt Module 등록
-│   ├── JsonEncryptAnnotationInterospector.kt     # Jasypt Introspector
-│   ├── JsonEncryptSerializer.kt                  # Jasypt 암호화 직렬화기
-│   ├── JsonEncryptDeserializer.kt                # Jasypt 복호화 역직렬화기
-│   ├── JsonEncryptors.kt                         # Encryptor 캐시 관리
 │   ├── TinkEncryptAlgorithm.kt                   # Tink 알고리즘 enum
 │   ├── JsonTinkEncrypt.kt                        # @JsonTinkEncrypt 어노테이션 (Google Tink)
 │   ├── JsonTinkEncryptModule.kt                  # Tink Module 등록

--- a/io/jackson3/README.md
+++ b/io/jackson3/README.md
@@ -9,6 +9,31 @@ English | [한국어](./README.ko.md)
 It provides the same feature set as Jackson 2.x (
 `bluetape4k-jackson2`), while following the new Jackson 3.x API and package structure (`tools.jackson.*`).
 
+## Why Jackson3 in bluetape4k
+
+- Kotlin-first mapper setup: `jsonMapper { }` and `Jackson.defaultJsonMapper` keep Kotlin module defaults in one place.
+- Safer extension functions: `readValueOrNull`, `writeAsString`, and `writeAsBytes` make common serialization paths concise.
+- Streaming-ready parsing: callback and coroutine parsers process root JSON nodes without buffering a whole response first.
+- Security extensions: Tink-backed field encryption and field masking can be attached to Jackson models through annotations.
+- Format flexibility: binary/text format modules are compile-only here, so applications can add only the runtime formats they use.
+
+## Recommended Usage Scenarios
+
+- Prefer this module for new Kotlin code that already targets Jackson 3.x and `tools.jackson.*` packages.
+- Use `JacksonSerializer` for bluetape4k serializer contracts, cache payloads, and simple byte/string JSON conversion.
+- Use ObjectMapper extensions when failure-as-null is acceptable and the caller can distinguish missing data from invalid data.
+- Use `AsyncJsonParser` for callback-style chunk feeds such as Netty, WebSocket, TCP, and message listeners.
+- Use `SuspendJsonParser.consumeComplete(flow)` when a finite `Flow<ByteArray>` represents one complete logical stream.
+- Use `@JsonTinkEncrypt` only for string fields that must be protected inside serialized JSON documents.
+
+## Anti-Patterns
+
+- Do not copy Jackson 2.x imports into this module. Jackson 3.x APIs live under `tools.jackson.*`, except annotations that still come from `com.fasterxml.jackson.annotation`.
+- Do not rely on removed `activateDefaultTyping()` behavior. Prefer explicit polymorphic models or sealed hierarchies.
+- Do not use `readValueOrNull` when invalid JSON must be audited or surfaced to callers; use throwing Jackson APIs instead.
+- Do not finish a network/file stream without calling `endOfInput()` or `consumeComplete(...)`; otherwise a truncated final JSON token may look like "waiting for more input."
+- Do not treat `consume(flow)` completion as EOF. It is an incremental feed API for callers that may append more chunks later.
+
 ## Jackson 2.x vs 3.x
 
 | Item             | Jackson 2.x                             | Jackson 3.x                               |
@@ -103,12 +128,13 @@ val parser = AsyncJsonParser { root ->
 }
 parser.consume(chunk1)
 parser.consume(chunk2)
+parser.endOfInput()
 
 // Coroutine-based parsing
 val suspendParser = SuspendJsonParser { root ->
     processNode(root)  // suspendable
 }
-suspendParser.consume(byteArrayFlow)
+suspendParser.consumeComplete(byteArrayFlow)
 ```
 
 When to use each parser:
@@ -118,6 +144,7 @@ When to use each parser:
 - `SuspendJsonParser`: `Flow<ByteArray>`-based pipelines where post-processing must be suspendable —
   `WebClient`, file streams, broker streams, etc.
 - Both parsers handle multiple consecutive JSON roots and scalar JSON roots (`"text"`, `123`, `true`, `null`).
+- Call `endOfInput()` when a callback stream ends, or use `consumeComplete(flow)` for a finite Flow. Jackson needs that EOF signal to report truncated final JSON.
 
 ### 4-1. WebClient Streaming Example
 
@@ -154,7 +181,7 @@ val chunkFlow = webClient.get()
     }
     .asFlow()
 
-parser.consume(chunkFlow)
+parser.consumeComplete(chunkFlow)
 ```
 
 If you are already receiving chunks via callbacks, `AsyncJsonParser` is more natural for the same scenario.
@@ -173,27 +200,7 @@ data class User(
 )
 ```
 
-### 6. Field Encryption (@JsonEncrypt / @JsonTinkEncrypt)
-
-#### Jasypt-based (`@JsonEncrypt`) — Deprecated
-
-```kotlin
-import io.bluetape4k.jackson3.crypto.JsonEncrypt
-import io.bluetape4k.jackson3.crypto.JsonEncryptModule
-
-data class User(
-    val username: String,
-    @get:JsonEncrypt          // AES encryption via Jasypt
-    val password: String,
-)
-
-// JsonEncryptModule must be registered
-val mapper = Jackson.createDefaultJsonMapper().rebuild()
-    .addModule(JsonEncryptModule())
-    .build()
-```
-
-#### Google Tink-based (`@JsonTinkEncrypt`) — Recommended
+### 6. Field Encryption (@JsonTinkEncrypt)
 
 Requires the `bluetape4k-tink` dependency and explicit registration of `JsonTinkEncryptModule`.
 
@@ -345,10 +352,6 @@ classDiagram
         +createDefaultJsonMapper() JsonMapper
     }
 
-    class JsonEncryptModule {
-        +setupModule(context)
-    }
-
     class JsonTinkEncryptModule {
         +setupModule(context)
     }
@@ -363,7 +366,6 @@ classDiagram
 
     JsonSerializer <|.. JacksonSerializer
     JacksonSerializer --> Jackson : uses
-    Jackson --> JsonEncryptModule : registers
     Jackson --> JsonTinkEncryptModule : registers
     Jackson --> JsonMaskerModule : registers
     Jackson --> JsonUuidModule : registers
@@ -371,7 +373,6 @@ classDiagram
     style JsonSerializer fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     style JacksonSerializer fill:#E0F2F1,stroke:#80CBC4,color:#00695C
     style Jackson fill:#FFF3E0,stroke:#FFCC80,color:#E65100
-    style JsonEncryptModule fill:#E0F2F1,stroke:#80CBC4,color:#00695C
     style JsonTinkEncryptModule fill:#E0F2F1,stroke:#80CBC4,color:#00695C
     style JsonMaskerModule fill:#E0F2F1,stroke:#80CBC4,color:#00695C
     style JsonUuidModule fill:#E0F2F1,stroke:#80CBC4,color:#00695C
@@ -416,9 +417,8 @@ dependencies {
     implementation("tools.jackson.dataformat:jackson-dataformat-csv3")
     implementation("tools.jackson.dataformat:jackson-dataformat-toml3")
 
-    // Encryption (optional)
-    implementation(project(":bluetape4k-crypto"))  // for @JsonEncrypt (Jasypt)
-    implementation(project(":bluetape4k-tink"))    // for @JsonTinkEncrypt (Google Tink)
+    // Encryption (optional, for @JsonTinkEncrypt)
+    implementation(project(":bluetape4k-tink"))
 }
 ```
 
@@ -435,12 +435,6 @@ io.bluetape4k.jackson3
 │   ├── AsyncJsonParser.kt        # Callback-based async parser
 │   └── SuspendJsonParser.kt      # Coroutine-based parser
 ├── crypto/                                       # Field encryption
-│   ├── JsonEncrypt.kt                            # @JsonEncrypt annotation (Jasypt, Deprecated)
-│   ├── JsonEncryptModule.kt                      # Jasypt Module registration
-│   ├── JsonEncryptAnnotationInterospector.kt     # Jasypt Introspector
-│   ├── JsonEncryptSerializer.kt                  # Jasypt encryption serializer
-│   ├── JsonEncryptDeserializer.kt                # Jasypt decryption deserializer
-│   ├── JsonEncryptors.kt                         # Encryptor cache management
 │   ├── TinkEncryptAlgorithm.kt                   # Tink algorithm enum
 │   ├── JsonTinkEncrypt.kt                        # @JsonTinkEncrypt annotation (Google Tink)
 │   ├── JsonTinkEncryptModule.kt                  # Tink Module registration

--- a/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/async/AsyncJsonParser.kt
+++ b/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/async/AsyncJsonParser.kt
@@ -9,6 +9,7 @@ import io.bluetape4k.jackson3.createArray
 import io.bluetape4k.jackson3.createNode
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
+import io.bluetape4k.support.requireInRange
 import jakarta.json.stream.JsonParsingException
 import tools.jackson.core.JsonToken
 import tools.jackson.core.ObjectReadContext
@@ -25,6 +26,7 @@ import java.util.*
  *
  * ## 동작/계약
  * - [consume] 호출 시 입력 청크를 공급하고 가능한 토큰을 즉시 처리합니다.
+ * - 입력 스트림이 끝나면 [endOfInput]을 호출해 마지막 JSON이 잘리지 않았는지 검증합니다.
  * - 루트 노드가 완성될 때마다 [onNodeDone] 콜백을 호출합니다.
  * - 루트가 객체/배열뿐 아니라 문자열, 숫자, 불리언, null 같은 스칼라여도 [JsonNode]로 전달합니다.
  * - 비정상 토큰 시퀀스는 [JsonParsingException]으로 전파됩니다.
@@ -52,6 +54,7 @@ import java.util.*
  *        DataBufferUtils.release(buffer)
  *        parser.consume(bytes)
  *    }
+ *    .doOnComplete { parser.endOfInput() }
  *    .blockLast()
  * ```
  *
@@ -141,13 +144,45 @@ class AsyncJsonParser(
         bytes: ByteArray,
         length: Int = bytes.size,
     ) {
+        length.requireInRange(0, bytes.size, "length")
+
         val feeder = parser.nonBlockingInputFeeder()
 
-        // 입력이 필요한 경우에만 데이터 제공
-        if (feeder.needMoreInput()) {
-            feeder.feedInput(bytes, 0, length)
+        // 이전 청크가 남아 있으면 먼저 비워서 새 입력을 조용히 버리는 상황을 막습니다.
+        if (!feeder.needMoreInput()) {
+            drainAvailableTokens()
         }
 
+        check(feeder.needMoreInput()) {
+            "Jackson non-blocking parser is not ready for more input. Drain previous input before feeding a new chunk."
+        }
+
+        // Jackson non-blocking parser는 이전 청크를 모두 소비한 뒤에만 다음 청크를 받을 수 있습니다.
+        feeder.feedInput(bytes, 0, length)
+
+        drainAvailableTokens()
+    }
+
+    /**
+     * 더 이상 입력이 없음을 파서에 알리고 남은 토큰을 모두 처리합니다.
+     *
+     * Jackson non-blocking parser는 EOF 신호를 받아야 `{"id":`처럼 마지막 청크가 잘린 입력을
+     * 정상적인 입력 부족 상태가 아니라 파싱 오류로 판정할 수 있습니다. 여러 청크를 계속 공급해야 한다면
+     * 모든 [consume] 호출이 끝난 뒤 한 번만 호출하세요.
+     *
+     * ```kotlin
+     * val roots = mutableListOf<JsonNode>()
+     * val parser = AsyncJsonParser { roots += it }
+     * parser.consume("""{"id":1}""".toByteArray())
+     * parser.endOfInput()
+     * ```
+     */
+    fun endOfInput() {
+        parser.nonBlockingInputFeeder().endOfInput()
+        drainAvailableTokens()
+    }
+
+    private fun drainAvailableTokens() {
         var token: JsonToken?
         do {
             token = parser.nextToken()

--- a/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/async/SuspendJsonParser.kt
+++ b/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/async/SuspendJsonParser.kt
@@ -9,8 +9,11 @@ import io.bluetape4k.jackson3.createArray
 import io.bluetape4k.jackson3.createNode
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.error
+import io.bluetape4k.support.requireInRange
 import jakarta.json.stream.JsonParsingException
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.ensureActive
 import tools.jackson.core.JsonToken
 import tools.jackson.core.ObjectReadContext
 import tools.jackson.core.json.JsonFactory
@@ -26,6 +29,7 @@ import java.util.*
  *
  * ## 동작/계약
  * - [consume]는 Flow를 수집하며 청크를 non-blocking parser에 공급합니다.
+ * - 완료된 입력 Flow라면 [consumeComplete]를 사용해 마지막 JSON이 잘리지 않았는지 검증합니다.
  * - 루트 노드 완성 시마다 [onNodeDone] suspend 콜백을 호출합니다.
  * - 루트가 객체/배열뿐 아니라 문자열, 숫자, 불리언, null 같은 스칼라여도 [JsonNode]로 전달합니다.
  * - 비정상 토큰 시퀀스는 [JsonParsingException]으로 전파됩니다.
@@ -53,7 +57,7 @@ import java.util.*
  *    }
  *    .asFlow()
  *
- * parser.consume(chunkFlow)
+ * parser.consumeComplete(chunkFlow)
  * ```
  *
  * ```kotlin
@@ -128,6 +132,7 @@ class SuspendJsonParser(
      * - Flow 요소를 순서대로 읽어 파서 입력으로 사용합니다.
      * - 루트 완성 시 [onNodeDone]을 호출합니다.
      * - 하나의 Flow 안에 여러 JSON 루트가 연속으로 들어와도 순서대로 처리합니다.
+     * - 이 메서드는 입력 종료를 의미하지 않습니다. 완료된 단일 입력 스트림은 [consumeComplete]를 사용하세요.
      * - 파싱 예외는 [jakarta.json.stream.JsonParsingException]으로 전파됩니다.
      *
      * ```kotlin
@@ -140,20 +145,75 @@ class SuspendJsonParser(
         val feeder = parser.nonBlockingInputFeeder()
 
         flow.collect { bytes ->
-            if (feeder.needMoreInput()) {
-                feeder.feedInput(bytes, 0, bytes.size)
-            }
-
-            while (true) {
-                val token = parser.nextToken()
-                if (token == null || token == JsonToken.NOT_AVAILABLE) {
-                    break
-                }
-
-                // JsonNode 빌드되면 onNodeDone 호출
-                buildTree(token)?.let { onNodeDone(it) }
-            }
+            // consume은 증분 공급 API라서 Flow 완료를 EOF로 보지 않습니다.
+            // 기존 호출자는 여러 Flow를 이어 붙여 하나의 논리 스트림을 구성할 수 있습니다.
+            feedInput(bytes, bytes.size)
+            drainAvailableTokens()
         }
+    }
+
+    private suspend fun feedInput(
+        bytes: ByteArray,
+        length: Int,
+    ) {
+        length.requireInRange(0, bytes.size, "length")
+        val feeder = parser.nonBlockingInputFeeder()
+
+        // 이전 청크가 남아 있으면 먼저 비워서 새 입력을 조용히 버리는 상황을 막습니다.
+        if (!feeder.needMoreInput()) {
+            drainAvailableTokens()
+        }
+
+        check(feeder.needMoreInput()) {
+            "Jackson non-blocking parser is not ready for more input. Drain previous input before feeding a new chunk."
+        }
+
+        // Jackson non-blocking parser는 이전 청크를 모두 소비한 뒤에만 다음 청크를 받을 수 있습니다.
+        feeder.feedInput(bytes, 0, length)
+    }
+
+    private suspend fun drainAvailableTokens() {
+        while (true) {
+            currentCoroutineContext().ensureActive()
+
+            val token = parser.nextToken()
+            if (token == null || token == JsonToken.NOT_AVAILABLE) {
+                break
+            }
+
+            buildTree(token)?.let { onNodeDone(it) }
+        }
+    }
+
+    /**
+     * [Flow]를 하나의 완료된 JSON 입력 스트림으로 소비합니다.
+     *
+     * [consume]과 달리 Flow 수집이 끝난 뒤 [endOfInput]을 호출하므로 마지막 청크가
+     * `{"id":`처럼 잘린 경우 Jackson 파싱 예외가 발생합니다. 부분 Flow를 여러 번 이어 붙이는
+     * 사용법에서는 [consume]을 호출하고, 마지막 입력 뒤 [endOfInput]을 직접 호출하세요.
+     *
+     * ```kotlin
+     * val roots = mutableListOf<JsonNode>()
+     * val parser = SuspendJsonParser { roots += it }
+     * parser.consumeComplete(flowOf("""{"id":1}""".toByteArray()))
+     * ```
+     *
+     * @param flow 완료된 JSON 입력을 구성하는 바이트 청크 Flow
+     */
+    suspend fun consumeComplete(flow: Flow<ByteArray>) {
+        consume(flow)
+        endOfInput()
+    }
+
+    /**
+     * 더 이상 입력이 없음을 파서에 알리고 남은 토큰을 모두 처리합니다.
+     *
+     * Jackson non-blocking parser는 명시적인 EOF 신호를 받아야 미완성 JSON을 오류로 확정합니다.
+     * 모든 [consume] 호출이 끝난 뒤 한 번만 호출하세요.
+     */
+    suspend fun endOfInput() {
+        parser.nonBlockingInputFeeder().endOfInput()
+        drainAvailableTokens()
     }
 
     /**

--- a/io/jackson3/src/test/kotlin/io/bluetape4k/jackson3/async/AsyncJsonParserTest.kt
+++ b/io/jackson3/src/test/kotlin/io/bluetape4k/jackson3/async/AsyncJsonParserTest.kt
@@ -188,6 +188,62 @@ class AsyncJsonParserTest {
     }
 
     @Test
+    fun `완성된 JSON 입력 종료를 알려도 추가 노드가 생성되지 않는다`() {
+        val parsed = AtomicInteger(0)
+        val parser = AsyncJsonParser { parsed.incrementAndGet() }
+
+        parser.consume("""{"key":"value"}""".toByteArray())
+        parser.endOfInput()
+
+        parsed.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `잘린 JSON 입력 종료 시 StreamReadException 이 발생한다`() {
+        val parser = AsyncJsonParser { /* 도달하지 않아야 함 */ }
+
+        parser.consume("""{"key":""".toByteArray())
+
+        assertFailsWith<tools.jackson.core.exc.StreamReadException> {
+            parser.endOfInput()
+        }
+    }
+
+    @Test
+    fun `여러 형태의 잘린 JSON 입력 종료 시 StreamReadException 이 발생한다`() {
+        val truncatedInputs =
+            listOf(
+                """{"id":12""",
+                """"unterm""",
+                "{\"a\":\"b\\",
+            )
+
+        truncatedInputs.forEach { input ->
+            val parser = AsyncJsonParser { /* 도달하지 않아야 함 */ }
+
+            parser.consume(input.toByteArray())
+
+            assertFailsWith<tools.jackson.core.exc.StreamReadException> {
+                parser.endOfInput()
+            }
+        }
+    }
+
+    @Test
+    fun `consume length 가 바이트 배열 범위를 벗어나면 IllegalArgumentException 이 발생한다`() {
+        val parser = AsyncJsonParser { /* 도달하지 않아야 함 */ }
+        val bytes = "{}".toByteArray()
+
+        assertFailsWith<IllegalArgumentException> {
+            parser.consume(bytes, -1)
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            parser.consume(bytes, bytes.size + 1)
+        }
+    }
+
+    @Test
     fun `중첩 객체를 포함한 단순 JSON 을 올바르게 파싱한다`() {
         val parsed = AtomicInteger(0)
         val parser = AsyncJsonParser { parsed.incrementAndGet() }

--- a/io/jackson3/src/test/kotlin/io/bluetape4k/jackson3/async/SuspendJsonParserTest.kt
+++ b/io/jackson3/src/test/kotlin/io/bluetape4k/jackson3/async/SuspendJsonParserTest.kt
@@ -211,6 +211,58 @@ class SuspendJsonParserTest {
         }
 
     @Test
+    fun `완성된 Flow 입력은 consumeComplete 로 종료 검증까지 수행한다`() =
+        runTest {
+            val parsed = AtomicInteger(0)
+            val parser = SuspendJsonParser { parsed.incrementAndGet() }
+
+            parser.consumeComplete(flowOf("""{"key":"value"}""".toByteArray()))
+
+            parsed.get() shouldBeEqualTo 1
+        }
+
+    @Test
+    fun `잘린 Flow 입력을 consumeComplete 로 처리하면 StreamReadException 이 발생한다`() =
+        runTest {
+            val parser = SuspendJsonParser { /* 도달하지 않아야 함 */ }
+
+            assertFailsWith<tools.jackson.core.exc.StreamReadException> {
+                parser.consumeComplete(flowOf("""{"key":""".toByteArray()))
+            }
+        }
+
+    @Test
+    fun `여러 형태의 잘린 Flow 입력을 consumeComplete 로 처리하면 StreamReadException 이 발생한다`() =
+        runTest {
+            val truncatedInputs =
+                listOf(
+                    """{"id":12""",
+                    """"unterm""",
+                    "{\"a\":\"b\\",
+                )
+
+            truncatedInputs.forEach { input ->
+                val parser = SuspendJsonParser { /* 도달하지 않아야 함 */ }
+
+                assertFailsWith<tools.jackson.core.exc.StreamReadException> {
+                    parser.consumeComplete(flowOf(input.toByteArray()))
+                }
+            }
+        }
+
+    @Test
+    fun `증분 consume 후 잘린 입력 종료를 알리면 StreamReadException 이 발생한다`() =
+        runTest {
+            val parser = SuspendJsonParser { /* 도달하지 않아야 함 */ }
+
+            parser.consume(flowOf("""{"key":""".toByteArray()))
+
+            assertFailsWith<tools.jackson.core.exc.StreamReadException> {
+                parser.endOfInput()
+            }
+        }
+
+    @Test
     fun `단순 JSON 객체를 올바르게 파싱한다`() =
         runTest {
             val parsed = AtomicInteger(0)


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: [fix] Harden Jackson3 streaming EOF contracts

- Added explicit logical EOF APIs for Jackson3 async parsers: `AsyncJsonParser.endOfInput()`, `SuspendJsonParser.endOfInput()`, and `SuspendJsonParser.consumeComplete(...)`.
- Hardened chunk feeding with `requireInRange` length validation, pending-token drain, fail-fast readiness checks, and coroutine cancellation checkpoints.
- Added EOF edge tests for truncated objects, numbers, strings, and dangling escapes.
- Updated `README.md` / `README.ko.md` with Jackson3 advantages, recommended scenarios, anti-patterns, EOF guidance, and removed stale Jasypt `JsonEncrypt` documentation.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: P0/P1 Gate

| Priority | Finding | Status |
|---|---|---|
| P0 | None | Closed |
| P1 | Missing logical EOF contract allowed truncated final JSON to remain in input-wait state. | Fixed with `endOfInput()` / `consumeComplete(...)` and EOF tests. |
| P1 | Chunk feed could silently skip data if Jackson feeder was not ready. | Fixed with drain-before-feed plus fail-fast `check`. |
| P1 | `consume(bytes, length)` did not validate `length`. | Fixed with `requireInRange(0, bytes.size, \"length\")` and tests. |
| P1 | Suspend drain loop lacked an explicit cancellation checkpoint. | Fixed with `currentCoroutineContext().ensureActive()`. |
| P1 | EOF truncation tests covered only one shape. | Fixed with number, unterminated string, and dangling escape cases. |
| P1 | README still documented nonexistent legacy Jasypt encryption path. | Removed stale `JsonEncrypt`/Jasypt docs from both READMEs. |

Final advisor re-review: P0=0, P1=0 (`.omx/artifacts/claude-jackson3-rereview-20260511.md`, local artifact).

### 기존 섹션: Verification

- `./gradlew :bluetape4k-jackson3:compileTestKotlin --no-build-cache --no-daemon`
- `./gradlew :bluetape4k-jackson3:test --tests "io.bluetape4k.jackson3.async.AsyncJsonParserTest" --tests "io.bluetape4k.jackson3.async.SuspendJsonParserTest" --no-build-cache --no-daemon` (27 passing)
- `./gradlew :bluetape4k-jackson3:test --no-build-cache --no-daemon` (430 passing, 1 pending)
- `git diff --check`

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #390, head `4c15a96bbe7276fe1404560a5fea6c4718dc4bd7`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/jackson3-review-tests-docs`
- Labels: `bug`, `documentation`, `test`
- State: `MERGED`, merge commit `f42e212dbd9fa67543b1ee773c18c4a4e211c237`
- CI: - Added explicit logical EOF APIs for Jackson3 async parsers: `AsyncJsonParser.endOfInput()`, `SuspendJsonParser.endOfInput()`, and `SuspendJsonParser.consumeComplete(...)`. / | P1 | Suspend drain loop lacked an explicit cancellation checkpoint. | Fixed with `currentCoroutineContext().ensureActive()`. | / - `./gradlew :bluetape4k-jackson3:compileTestKotlin --no-build-cache --no-daemon`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #390 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `f42e212dbd9fa67543b1ee773c18c4a4e211c237`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
