### PR TITLE
[fix] Harden Jackson2 streaming EOF contracts

### DIFF
--- a/docs/superpowers/plans/2026-05-11-jackson2-review-tests-docs-plan.md
+++ b/docs/superpowers/plans/2026-05-11-jackson2-review-tests-docs-plan.md
@@ -1,0 +1,35 @@
+# Jackson2 Review, Tests, and Docs Plan
+
+## Plan
+
+1. Add explicit logical EOF APIs to `AsyncJsonParser` and `SuspendJsonParser`.
+2. Refactor token draining into private helpers used by normal consume and EOF.
+3. Add feed readiness checks, input length validation, and coroutine cancellation checkpoints.
+4. Add async parser edge tests for complete EOF, invalid length, and several truncated JSON states.
+5. Update Korean KDoc and add explanatory comments around non-obvious stream safety behavior.
+6. Update README.md and README.ko.md with Jackson2 advantages, recommended scenarios, anti-patterns, EOF guidance, and Tink-only encryption docs.
+7. Run compile, targeted async tests, full module tests, `git diff --check`, and external advisor re-review until P0/P1 = 0.
+8. Commit with Lore trailers, push branch, and open a draft PR.
+
+## Review Gate Tracking
+
+| Iteration | P0 | P1 | Action |
+|-----------|----|----|--------|
+| Baseline | 0 | 4 | Implement EOF terminal APIs, feed validation, cancellation checkpoint, and edge tests. |
+| Advisor iteration 1 | 0 | 8 | Added lifecycle/throws KDoc, post-EOF tests, cancellation propagation coverage, README anti-pattern fix, and empty/partial length tests. |
+| Advisor iteration 2 | 0 | 0 | Gate closed; fixed P2 docs drift and low-risk P3 cleanup/tests before final validation. |
+
+## Verification Commands
+
+```bash
+./gradlew :bluetape4k-jackson2:compileTestKotlin --no-build-cache --no-daemon
+./gradlew :bluetape4k-jackson2:test --tests "io.bluetape4k.jackson.async.AsyncJsonParserTest" --tests "io.bluetape4k.jackson.async.SuspendJsonParserTest" --no-build-cache --no-daemon
+./gradlew :bluetape4k-jackson2:test --no-build-cache --no-daemon
+git diff --check
+```
+
+## Rollback Notes
+
+- New EOF APIs are additive.
+- Existing incremental `consume(...)` behavior is preserved.
+- README cleanup tracks current source files and removes stale docs only.

--- a/docs/superpowers/specs/2026-05-11-jackson2-review-tests-docs-design.md
+++ b/docs/superpowers/specs/2026-05-11-jackson2-review-tests-docs-design.md
@@ -1,0 +1,63 @@
+# Jackson2 Review, Tests, and Docs Design
+
+## Scope
+
+- Target module: `io/jackson2` (`bluetape4k-jackson2`).
+- Apply bluetape4k 6-Tier review until no P0/P1 findings remain.
+- Add missing edge tests, Korean KDoc examples for public API changes, explanatory comments for non-obvious behavior, and synchronized README updates.
+- Keep changes scoped to async parser stream safety and documentation drift found during review.
+
+## 6-Tier Review Summary
+
+| Tier | Result | Notes |
+|------|--------|-------|
+| API contract | P1 found | Non-blocking parsers expose `consume` but no logical EOF operation, despite Jackson requiring `endOfInput()` to validate final truncated input. |
+| Correctness | P1 found | `consume` only feeds when `needMoreInput()` is true and otherwise silently skips a new chunk. |
+| Coroutines | P1 found | `SuspendJsonParser` can drain many tokens without an explicit cancellation checkpoint. |
+| Security/data safety | No P0/P1 in code | Tink encryption code remains unchanged; README has stale Jasypt `JsonEncrypt` references to nonexistent source files. |
+| Tests | P1 gap | Existing async tests do not cover truncated-at-EOF, multiple truncation shapes, or invalid `length`. |
+| Documentation | P2 found | README lacks advantages/scenarios/anti-patterns and still documents legacy Jasypt `JsonEncrypt` classes that are not present in `io/jackson2`. |
+
+## P0/P1 Findings
+
+| Priority | Finding | Resolution |
+|----------|---------|------------|
+| P0 | None | N/A |
+| P1 | Async parsers cannot signal logical EOF, so truncated final JSON can remain in "waiting for more input" state. | Add `endOfInput()` APIs, `SuspendJsonParser.consumeComplete(...)`, KDoc examples, and EOF edge tests. |
+| P1 | New chunks can be silently skipped when Jackson feeder is not ready. | Drain pending tokens first, then fail fast with `check` before feeding. |
+| P1 | `consume(bytes, length)` accepts invalid length values. | Validate `length` with `requireInRange(0, bytes.size, "length")`. |
+| P1 | Suspend token drain lacks an explicit cancellation checkpoint. | Add `currentCoroutineContext().ensureActive()` in the drain loop. |
+| P1 | Advisor iteration found public lifecycle/throws docs, post-EOF tests, and cancellation regression coverage still incomplete. | Added lifecycle KDoc, `JsonParseException` throws docs, post-EOF/double EOF tests, empty Flow test, and cancellation propagation test. |
+
+## P2/P3 Findings
+
+| Priority | Finding | Resolution |
+|----------|---------|------------|
+| P2 | README documents legacy `JsonEncrypt`/Jasypt files that do not exist in this module. | Remove stale Jasypt guidance and document Tink-only field encryption for Jackson2. |
+| P2 | README lacks a practical decision guide. | Add advantages, recommended scenarios, and anti-patterns to English/Korean READMEs. |
+| P2 | `JacksonSerializer` catches `Throwable`. | Defer unless advisor escalates; this module is synchronous and current serializer tests cover public failure wrapping. |
+| P2 | Class diagram implied `AsyncJsonParser` depends on `SuspendJsonParser`. | Removed the misleading dependency edge from both READMEs. |
+| P2 | EOF KDoc did not mention Jackson `JsonParseException`. | Added `JsonParseException` throws docs to public consume/EOF APIs. |
+
+## Design Decisions
+
+- Preserve `consume(...)` as incremental feed API because existing callers/tests supply partial arrays and repeated roots across multiple calls.
+- Add EOF as an explicit terminal operation. Flow completion remains incremental by default for backward compatibility.
+- Add `consumeComplete(flow)` for finite suspend streams where Flow completion is the logical input boundary.
+- Keep comments short and targeted to why EOF and drain-before-feed are necessary.
+
+## Acceptance Criteria
+
+- `AsyncJsonParser.endOfInput()` and `SuspendJsonParser.consumeComplete(...)` throw on truncated final JSON.
+- Multiple truncation states are covered: cut object value, cut number, unterminated string, dangling escape.
+- `consume(bytes, length)` rejects invalid length.
+- Public API KDoc is Korean and includes examples.
+- README.md and README.ko.md are synchronized and no longer reference nonexistent Jasypt files/classes.
+- Latest integrated review gate shows `P0 = 0` and `P1 = 0`.
+
+## Final Gate Evidence
+
+| Review | P0 | P1 | Notes |
+|--------|----|----|-------|
+| Claude advisor initial review | 0 | 8 | Lifecycle docs/tests, cancellation coverage, README anti-pattern, and length-boundary gaps found. |
+| Claude advisor re-review | 0 | 0 | Remaining items were P2/P3 only; P2 docs drift and cheap P3 tests/simplifications were also addressed. |

--- a/io/jackson2/README.ko.md
+++ b/io/jackson2/README.ko.md
@@ -8,6 +8,28 @@
 
 기본 JsonMapper 구성, ObjectMapper 확장 함수, 비동기 JSON 파싱, UUID Base62 인코딩, 필드 암호화, 필드 마스킹 등 Jackson 생태계를 Kotlin 환경에서 편리하게 사용할 수 있는 기능을 제공합니다.
 
+## bluetape4k에서 Jackson2를 쓰는 장점
+
+- 널리 배포된 Jackson 2.x API를 유지하면서 Kotlin 친화적인 mapper 기본값과 확장 함수를 제공합니다.
+- JSON, 바이너리 포맷, UUID Base62 인코딩, 필드 마스킹, Tink 기반 필드 암호화를 한 모듈에서 다룹니다.
+- 콜백 기반 바이트 청크와 코루틴 `Flow<ByteArray>` 파이프라인을 모두 처리하는 스트리밍 파서를 제공합니다.
+- 비동기 파서에 명시적인 EOF API를 제공해 마지막 JSON이 잘렸을 때 "추가 입력 대기"가 아니라 빠르게 실패하도록 합니다.
+
+## 추천 사용 시나리오
+
+- 서비스 전반에서 Kotlin-ready `JsonMapper`가 필요하면 `Jackson.defaultJsonMapper`를 사용합니다.
+- cache, messaging, storage 계층에서 공통 `JsonSerializer` 계약이 필요하면 `JacksonSerializer`를 사용합니다.
+- Netty, WebSocket, TCP, listener처럼 바이트 청크를 하나씩 받는 push 스타일 코드는 `AsyncJsonParser`를 사용합니다.
+- HTTP 응답, 파일 스트림, broker payload처럼 완료되는 `Flow<ByteArray>`는 `SuspendJsonParser.consumeComplete(flow)`를 사용합니다.
+- JSON 문서 내부에 암호문을 유지해야 하는 필드 단위 암호화에는 `@JsonTinkEncrypt`를 사용합니다.
+
+## Anti-Patterns
+
+- 완료되는 스트림에서 `endOfInput()` 또는 `consumeComplete(flow)`를 생략하지 마십시오. Jackson non-blocking parser는 잘린 JSON을 보고하려면 명시적인 EOF 신호가 필요합니다.
+- `endOfInput()` 또는 `consumeComplete(flow)` 이후 같은 파서를 재사용하지 마십시오. 논리 스트림마다 새 파서를 생성합니다.
+- 필드 암호화를 TLS, DB 접근 제어, 키 교체, 감사 정책의 대체재로 사용하지 마십시오.
+- 모든 Jackson dataformat 의존성을 기본으로 추가하지 마십시오. 애플리케이션이 실제로 읽거나 쓰는 포맷만 런타임에 추가합니다.
+
 ## 주요 기능
 
 ### 1. JsonMapper DSL
@@ -99,12 +121,13 @@ val parser = AsyncJsonParser { root ->
 }
 parser.consume(chunk1)
 parser.consume(chunk2)
+parser.endOfInput()
 
 // 코루틴 기반 파싱
 val suspendParser = SuspendJsonParser { root ->
     processNode(root)  // suspend 가능
 }
-suspendParser.consume(byteArrayFlow)
+suspendParser.consumeComplete(byteArrayFlow)
 ```
 
 언제 어떤 파서를 쓰면 좋은지:
@@ -112,6 +135,7 @@ suspendParser.consume(byteArrayFlow)
 - `AsyncJsonParser`: Netty, WebSocket, TCP, 메시지 리스너처럼 `ByteArray` 청크를 콜백으로 받는 push 스타일 코드
 - `SuspendJsonParser`: `Flow<ByteArray>` 기반 파이프라인, `WebClient`/파일/브로커 스트림처럼 suspend 후처리가 필요한 코드
 - 두 파서 모두 연속된 여러 JSON 루트와 루트 스칼라 JSON(`"text"`, `123`, `true`, `null`)를 처리할 수 있습니다.
+- 콜백 스트림은 더 이상 바이트가 없을 때 `endOfInput()`을 호출하고, 완료되는 `Flow` 스트림은 `consumeComplete(flow)`를 사용합니다.
 
 ### 4-1. WebClient 스트리밍 예제
 
@@ -147,7 +171,7 @@ val chunkFlow = webClient.get()
     }
     .asFlow()
 
-parser.consume(chunkFlow)
+parser.consumeComplete(chunkFlow)
 ```
 
 같은 상황에서 이미 청크를 콜백으로 받고 있다면 `AsyncJsonParser`가 더 단순합니다.
@@ -171,24 +195,9 @@ data class User(
 // { "userId": "6gVuscij1cec8CelrpHU5h", "plainId": "413684f2-..." }
 ```
 
-### 6. 필드 암호화 (@JsonEncrypt / @JsonTinkEncrypt)
+### 6. 필드 암호화 (@JsonTinkEncrypt)
 
 민감한 데이터를 JSON 직렬화 시 자동으로 암호화/복호화합니다.
-
-#### Jasypt 기반 (`@JsonEncrypt`) — Deprecated
-
-```kotlin
-import io.bluetape4k.jackson.crypto.JsonEncrypt
-
-data class User(
-    val username: String,
-    @field:JsonEncrypt          // AES 기본 암호화 (Jasypt)
-    val password: String,
-)
-
-// 직렬화: { "username": "debop", "password": "N1E79rV_n0d0eaZ..." }
-// 역직렬화 시 자동 복호화
-```
 
 #### Google Tink 기반 (`@JsonTinkEncrypt`) — 권장
 
@@ -317,15 +326,14 @@ classDiagram
     class AsyncJsonParser {
         -callback: (JsonNode) -> Unit
         +consume(bytes: ByteArray)
+        +endOfInput()
     }
 
     class SuspendJsonParser {
         -callback: suspend (JsonNode) -> Unit
         +consume(flow: Flow~ByteArray~)
-    }
-
-    class JsonEncrypt {
-        <<annotation>>
+        +consumeComplete(flow: Flow~ByteArray~)
+        +endOfInput()
     }
 
     class JsonTinkEncrypt {
@@ -345,14 +353,11 @@ classDiagram
 
     JsonSerializer <|.. JacksonSerializer
     JacksonSerializer --> Jackson : 사용
-    AsyncJsonParser --> SuspendJsonParser
-
     style JsonSerializer fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     style JacksonSerializer fill:#E0F2F1,stroke:#80CBC4,color:#00695C
     style Jackson fill:#FFF3E0,stroke:#FFCC80,color:#E65100
     style AsyncJsonParser fill:#F3E5F5,stroke:#CE93D8,color:#6A1B9A
     style SuspendJsonParser fill:#F3E5F5,stroke:#CE93D8,color:#6A1B9A
-    style JsonEncrypt fill:#FFFDE7,stroke:#FFF176,color:#F57F17
     style JsonTinkEncrypt fill:#FFFDE7,stroke:#FFF176,color:#F57F17
     style JsonMasker fill:#FFFDE7,stroke:#FFF176,color:#F57F17
     style JsonUuidEncoder fill:#FFFDE7,stroke:#FFF176,color:#F57F17
@@ -447,7 +452,6 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-toml")
 
     // 암호화 (선택적)
-    implementation(project(":bluetape4k-crypto"))  // @JsonEncrypt (Jasypt) 사용 시
     implementation(project(":bluetape4k-tink"))    // @JsonTinkEncrypt (Google Tink) 사용 시
 }
 ```
@@ -465,10 +469,6 @@ io.bluetape4k.jackson
 │   ├── AsyncJsonParser.kt        # 콜백 기반 비동기 파서
 │   └── SuspendJsonParser.kt      # 코루틴 기반 파서
 ├── crypto/                           # 필드 암호화
-│   ├── JsonEncrypt.kt                # @JsonEncrypt 어노테이션 (Jasypt, Deprecated)
-│   ├── JsonEncryptSerializer.kt      # 암호화 직렬화기
-│   ├── JsonEncryptDeserializer.kt    # 복호화 역직렬화기
-│   ├── JsonEncryptors.kt             # Encryptor 캐시 관리
 │   ├── TinkEncryptAlgorithm.kt       # Tink 알고리즘 enum
 │   ├── JsonTinkEncrypt.kt            # @JsonTinkEncrypt 어노테이션 (Google Tink)
 │   ├── JsonTinkEncryptSerializer.kt  # Tink 암호화 직렬화기

--- a/io/jackson2/README.md
+++ b/io/jackson2/README.md
@@ -9,6 +9,28 @@ English | [한국어](./README.ko.md)
 It provides convenient access to the Jackson ecosystem in Kotlin, covering default `JsonMapper` configuration,
 `ObjectMapper` extensions, async JSON parsing, UUID Base62 encoding, field-level encryption, and field masking.
 
+## Why Jackson2 in bluetape4k
+
+- Keeps the widely deployed Jackson 2.x API while adding Kotlin-first mapper defaults and extension functions.
+- Provides one module for JSON, binary formats, UUID Base62 encoding, field masking, and Tink-backed field encryption.
+- Exposes streaming parsers that work with callback-style byte chunks and coroutine `Flow<ByteArray>` pipelines.
+- Uses explicit EOF APIs for non-blocking parsing so truncated final JSON fails fast instead of being treated as "more input may arrive later".
+
+## Recommended Usage Scenarios
+
+- Use `Jackson.defaultJsonMapper` when services need a shared Kotlin-ready `JsonMapper`.
+- Use `JacksonSerializer` behind cache, messaging, or storage abstractions that depend on the common `JsonSerializer` contract.
+- Use `AsyncJsonParser` for Netty, WebSocket, TCP, and listener callbacks that receive byte chunks one by one.
+- Use `SuspendJsonParser.consumeComplete(flow)` for finite `Flow<ByteArray>` streams such as HTTP responses, file streams, and broker payloads.
+- Use `@JsonTinkEncrypt` for field-level encryption where ciphertext can stay inside JSON documents.
+
+## Anti-Patterns
+
+- Do not omit `endOfInput()` or `consumeComplete(flow)` for a finite stream. Jackson's non-blocking parser needs an explicit EOF signal to report truncated JSON.
+- Do not reuse a parser after `endOfInput()` or `consumeComplete(flow)`. Create a new parser for each logical stream.
+- Do not use field encryption as a replacement for transport security, database access control, key rotation, or audit policy.
+- Do not add every Jackson dataformat dependency by default. Add only the runtime formats the application actually reads or writes.
+
 ## Architecture
 
 ### Class Structure
@@ -36,15 +58,14 @@ classDiagram
     class AsyncJsonParser {
         -callback: (JsonNode) -> Unit
         +consume(bytes: ByteArray)
+        +endOfInput()
     }
 
     class SuspendJsonParser {
         -callback: suspend (JsonNode) -> Unit
         +consume(flow: Flow~ByteArray~)
-    }
-
-    class JsonEncrypt {
-        <<annotation>>
+        +consumeComplete(flow: Flow~ByteArray~)
+        +endOfInput()
     }
 
     class JsonTinkEncrypt {
@@ -64,14 +85,11 @@ classDiagram
 
     JsonSerializer <|.. JacksonSerializer
     JacksonSerializer --> Jackson : uses
-    AsyncJsonParser --> SuspendJsonParser
-
     style JsonSerializer fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     style JacksonSerializer fill:#E0F2F1,stroke:#80CBC4,color:#00695C
     style Jackson fill:#FFF3E0,stroke:#FFCC80,color:#E65100
     style AsyncJsonParser fill:#F3E5F5,stroke:#CE93D8,color:#6A1B9A
     style SuspendJsonParser fill:#F3E5F5,stroke:#CE93D8,color:#6A1B9A
-    style JsonEncrypt fill:#FFFDE7,stroke:#FFF176,color:#F57F17
     style JsonTinkEncrypt fill:#FFFDE7,stroke:#FFF176,color:#F57F17
     style JsonMasker fill:#FFFDE7,stroke:#FFF176,color:#F57F17
     style JsonUuidEncoder fill:#FFFDE7,stroke:#FFF176,color:#F57F17
@@ -182,12 +200,13 @@ When to use each parser:
 - `SuspendJsonParser`: `Flow<ByteArray>`-based pipelines where post-processing must be suspendable —
   `WebClient`, file streams, broker streams, etc.
 - Both parsers handle multiple consecutive JSON roots and scalar JSON roots (`"text"`, `123`, `true`, `null`).
+- Call `endOfInput()` for callback streams or `consumeComplete(flow)` for finite `Flow` streams when no more bytes will arrive.
 
 ### 5. UUID Base62 Encoding
 
 Encodes UUIDs as Base62 strings for compact JSON storage.
 
-### 6. Field Encryption (@JsonEncrypt / @JsonTinkEncrypt)
+### 6. Field Encryption (@JsonTinkEncrypt)
 
 Automatically encrypts and decrypts sensitive fields during JSON serialization.
 
@@ -296,12 +315,13 @@ val parser = AsyncJsonParser { root ->
 }
 parser.consume(chunk1)
 parser.consume(chunk2)
+parser.endOfInput()
 
 // Coroutine-based parsing
 val suspendParser = SuspendJsonParser { root ->
     processNode(root)  // suspendable
 }
-suspendParser.consume(byteArrayFlow)
+suspendParser.consumeComplete(byteArrayFlow)
 ```
 
 ### UUID Base62 Encoding
@@ -377,10 +397,6 @@ io.bluetape4k.jackson
 │   ├── AsyncJsonParser.kt        # Callback-based async parser
 │   └── SuspendJsonParser.kt      # Coroutine-based parser
 ├── crypto/                           # Field encryption
-│   ├── JsonEncrypt.kt                # @JsonEncrypt annotation (Jasypt, Deprecated)
-│   ├── JsonEncryptSerializer.kt      # Encryption serializer
-│   ├── JsonEncryptDeserializer.kt    # Decryption deserializer
-│   ├── JsonEncryptors.kt             # Encryptor cache management
 │   ├── TinkEncryptAlgorithm.kt       # Tink algorithm enum
 │   ├── JsonTinkEncrypt.kt            # @JsonTinkEncrypt annotation (Google Tink)
 │   ├── JsonTinkEncryptSerializer.kt  # Tink encryption serializer
@@ -413,7 +429,6 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-toml")
 
     // Encryption (optional)
-    implementation(project(":bluetape4k-crypto"))  // for @JsonEncrypt (Jasypt)
     implementation(project(":bluetape4k-tink"))    // for @JsonTinkEncrypt (Google Tink)
 }
 ```

--- a/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/async/AsyncJsonParser.kt
+++ b/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/async/AsyncJsonParser.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.jackson.async
 
 import com.fasterxml.jackson.core.JsonFactory
+import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.core.JsonToken
 import com.fasterxml.jackson.core.json.async.NonBlockingJsonParser
 import com.fasterxml.jackson.databind.JsonNode
@@ -15,6 +16,7 @@ import io.bluetape4k.jackson.createArray
 import io.bluetape4k.jackson.createNode
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
+import io.bluetape4k.support.requireInRange
 import jakarta.json.stream.JsonParsingException
 import java.io.Serializable
 import java.util.*
@@ -24,6 +26,8 @@ import java.util.*
  *
  * ## 동작/계약
  * - [consume] 호출 시 입력 청크를 파서에 공급하고 가능한 토큰을 즉시 처리합니다.
+ * - 입력 스트림이 끝나면 [endOfInput]을 호출해 마지막 JSON이 잘리지 않았는지 검증합니다.
+ * - [endOfInput] 호출 후에는 같은 파서를 재사용할 수 없고, 새 논리 스트림은 새 파서로 처리해야 합니다.
  * - 루트 노드가 완성될 때마다 [onNodeDone] 콜백을 호출합니다.
  * - 루트가 객체/배열뿐 아니라 문자열, 숫자, 불리언, null 같은 스칼라여도 [JsonNode]로 전달합니다.
  * - 토큰 시퀀스가 비정상적이면 [JsonParsingException]을 발생시킵니다.
@@ -51,6 +55,7 @@ import java.util.*
  *        DataBufferUtils.release(buffer)
  *        parser.consume(bytes)
  *    }
+ *    .doOnComplete { parser.endOfInput() }
  *    .blockLast()
  * ```
  *
@@ -121,15 +126,54 @@ class AsyncJsonParser(
      *
      * @param bytes JSON 데이터 청크
      * @param length 처리할 바이트 수
+     * @throws IllegalArgumentException [length]가 `0..bytes.size` 범위를 벗어난 경우
+     * @throws IllegalStateException 이미 [endOfInput]을 호출했거나 Jackson 파서가 더 이상 입력을 받지 않는 경우
+     * @throws JsonParseException Jackson이 입력 바이트를 파싱할 수 없는 경우
+     * @throws JsonParsingException 토큰 시퀀스가 비정상적인 경우
      */
     fun consume(bytes: ByteArray, length: Int = bytes.size) {
+        length.requireInRange(0, bytes.size, "length")
+
         val feeder = parser.nonBlockingInputFeeder
 
-        // 입력이 필요한 경우에만 데이터 제공
-        if (feeder.needMoreInput()) {
-            feeder.feedInput(bytes, 0, length)
+        // 이전 청크가 남아 있으면 먼저 비워서 새 입력을 조용히 버리는 상황을 막습니다.
+        if (!feeder.needMoreInput()) {
+            drainAvailableTokens()
         }
 
+        check(feeder.needMoreInput()) {
+            "Jackson non-blocking parser is not accepting more input. endOfInput() was likely called; create a new parser for the next logical stream."
+        }
+
+        // Jackson non-blocking parser는 이전 청크를 모두 소비한 뒤에만 다음 청크를 받을 수 있습니다.
+        feeder.feedInput(bytes, 0, length)
+
+        drainAvailableTokens()
+    }
+
+    /**
+     * 더 이상 입력이 없음을 파서에 알리고 남은 토큰을 모두 처리합니다.
+     *
+     * Jackson non-blocking parser는 EOF 신호를 받아야 `{"id":`처럼 마지막 청크가 잘린 입력을
+     * 정상적인 입력 부족 상태가 아니라 파싱 오류로 판정할 수 있습니다. 여러 청크를 계속 공급해야 한다면
+     * 모든 [consume] 호출이 끝난 뒤 한 번만 호출하세요.
+     *
+     * ```kotlin
+     * val roots = mutableListOf<JsonNode>()
+     * val parser = AsyncJsonParser { roots += it }
+     * parser.consume("""{"id":1}""".toByteArray())
+     * parser.endOfInput()
+     * ```
+     *
+     * @throws JsonParseException 마지막 JSON 입력이 잘렸거나 Jackson이 입력 바이트를 파싱할 수 없는 경우
+     * @throws JsonParsingException 토큰 시퀀스가 비정상적인 경우
+     */
+    fun endOfInput() {
+        parser.nonBlockingInputFeeder.endOfInput()
+        drainAvailableTokens()
+    }
+
+    private fun drainAvailableTokens() {
         var token: JsonToken?
         do {
             token = parser.nextToken()

--- a/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/async/SuspendJsonParser.kt
+++ b/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/async/SuspendJsonParser.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.jackson.async
 
 import com.fasterxml.jackson.core.JsonFactory
+import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.core.JsonToken
 import com.fasterxml.jackson.core.json.async.NonBlockingJsonParser
 import com.fasterxml.jackson.databind.JsonNode
@@ -16,6 +17,8 @@ import io.bluetape4k.jackson.createNode
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.error
 import jakarta.json.stream.JsonParsingException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import java.io.Serializable
 import java.util.*
@@ -25,6 +28,8 @@ import java.util.*
  *
  * ## 동작/계약
  * - [consume]는 Flow를 수집하며 입력 청크를 non-blocking parser에 공급합니다.
+ * - 완료된 입력 Flow라면 [consumeComplete]를 사용해 마지막 JSON이 잘리지 않았는지 검증합니다.
+ * - [endOfInput] 또는 [consumeComplete] 호출 후에는 같은 파서를 재사용할 수 없습니다.
  * - 루트 노드가 완성될 때마다 suspend 콜백 [onNodeDone]을 호출합니다.
  * - 루트가 객체/배열뿐 아니라 문자열, 숫자, 불리언, null 같은 스칼라여도 [JsonNode]로 전달합니다.
  * - 토큰 시퀀스가 비정상적이면 [JsonParsingException]을 발생시킵니다.
@@ -52,7 +57,7 @@ import java.util.*
  *    }
  *    .asFlow()
  *
- * parser.consume(chunkFlow)
+ * parser.consumeComplete(chunkFlow)
  * ```
  *
  * ```kotlin
@@ -114,30 +119,97 @@ class SuspendJsonParser(
      * - 루트 노드가 완성될 때마다 [onNodeDone]을 suspend 호출합니다.
      * - 파싱 예외는 [JsonParsingException]으로 전파됩니다.
      * - 하나의 Flow 안에 여러 JSON 루트가 연속으로 들어와도 순서대로 콜백을 호출합니다.
+     * - 이 메서드는 입력 종료를 의미하지 않습니다. 완료된 단일 입력 스트림은 [consumeComplete]를 사용하세요.
      *
      * ```kotlin
      * parser.consume(flowOf("{\"name\":\"debop\"}".toByteArray()))
      * // onNodeDone이 1회 호출됨
      * ```
      * @param flow JSON 바이트 청크 Flow
+     * @throws IllegalStateException 이미 [endOfInput]을 호출했거나 Jackson 파서가 더 이상 입력을 받지 않는 경우
+     * @throws JsonParseException Jackson이 입력 바이트를 파싱할 수 없는 경우
+     * @throws JsonParsingException 토큰 시퀀스가 비정상적인 경우
      */
     suspend fun consume(flow: Flow<ByteArray>) {
+        flow.collect { bytes ->
+            // consume은 증분 공급 API라서 Flow 완료를 EOF로 보지 않습니다.
+            // 기존 호출자는 여러 Flow를 이어 붙여 하나의 논리 스트림을 구성할 수 있습니다.
+            feedInput(bytes)
+            drainAvailableTokens()
+        }
+    }
+
+    private suspend fun feedInput(bytes: ByteArray) {
+        currentCoroutineContext().ensureActive()
         val feeder = parser.nonBlockingInputFeeder
 
-        flow.collect { bytes ->
-            if (feeder.needMoreInput()) {
-                feeder.feedInput(bytes, 0, bytes.size)
+        // 이전 청크가 남아 있으면 먼저 비워서 새 입력을 조용히 버리는 상황을 막습니다.
+        if (!feeder.needMoreInput()) {
+            drainAvailableTokens()
+        }
+
+        check(feeder.needMoreInput()) {
+            "Jackson non-blocking parser is not accepting more input. endOfInput() was likely called; create a new parser for the next logical stream."
+        }
+
+        // Jackson non-blocking parser는 이전 청크를 모두 소비한 뒤에만 다음 청크를 받을 수 있습니다.
+        feeder.feedInput(bytes, 0, bytes.size)
+    }
+
+    /**
+     * [Flow]를 하나의 완료된 JSON 입력 스트림으로 소비합니다.
+     *
+     * [consume]과 달리 Flow 수집이 끝난 뒤 [endOfInput]을 호출하므로 마지막 청크가
+     * `{"id":`처럼 잘린 경우 Jackson 파싱 예외가 발생합니다. 부분 Flow를 여러 번 이어 붙이는
+     * 사용법에서는 [consume]을 호출하고, 마지막 입력 뒤 [endOfInput]을 직접 호출하세요.
+     *
+     * ```kotlin
+     * val roots = mutableListOf<JsonNode>()
+     * val parser = SuspendJsonParser { roots += it }
+     * parser.consumeComplete(flowOf("""{"id":1}""".toByteArray()))
+     * ```
+     *
+     * @param flow 완료된 JSON 입력을 구성하는 바이트 청크 Flow
+     * @throws IllegalStateException 이미 [endOfInput]을 호출했거나 Jackson 파서가 더 이상 입력을 받지 않는 경우
+     * @throws JsonParseException Jackson이 입력 바이트를 파싱할 수 없는 경우
+     * @throws JsonParsingException 토큰 시퀀스가 비정상적인 경우
+     */
+    suspend fun consumeComplete(flow: Flow<ByteArray>) {
+        consume(flow)
+        endOfInput()
+    }
+
+    /**
+     * 더 이상 입력이 없음을 파서에 알리고 남은 토큰을 모두 처리합니다.
+     *
+     * Jackson non-blocking parser는 명시적인 EOF 신호를 받아야 미완성 JSON을 오류로 확정합니다.
+     * 모든 [consume] 호출이 끝난 뒤 한 번만 호출하세요.
+     *
+     * ```kotlin
+     * val roots = mutableListOf<JsonNode>()
+     * val parser = SuspendJsonParser { roots += it }
+     * parser.consume(flowOf("""{"id":1}""".toByteArray()))
+     * parser.endOfInput()
+     * ```
+     *
+     * @throws JsonParseException 마지막 JSON 입력이 잘렸거나 Jackson이 입력 바이트를 파싱할 수 없는 경우
+     * @throws JsonParsingException 토큰 시퀀스가 비정상적인 경우
+     */
+    suspend fun endOfInput() {
+        parser.nonBlockingInputFeeder.endOfInput()
+        drainAvailableTokens()
+    }
+
+    private suspend fun drainAvailableTokens() {
+        while (true) {
+            currentCoroutineContext().ensureActive()
+
+            val token = parser.nextToken()
+            if (token == null || token == JsonToken.NOT_AVAILABLE) {
+                break
             }
 
-            while (true) {
-                val token = parser.nextToken()
-                if (token == null || token == JsonToken.NOT_AVAILABLE) {
-                    break
-                }
-
-                // JsonNode 빌드되면 onNodeDone 호출
-                buildTree(token)?.let { onNodeDone(it) }
-            }
+            buildTree(token)?.let { onNodeDone(it) }
         }
     }
 

--- a/io/jackson2/src/test/kotlin/io/bluetape4k/jackson/async/AsyncJsonParserTest.kt
+++ b/io/jackson2/src/test/kotlin/io/bluetape4k/jackson/async/AsyncJsonParserTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.treeToValue
 import io.bluetape4k.jackson.Jackson
 import io.bluetape4k.jackson.treeToValueOrNull
 import io.bluetape4k.jackson.writeAsBytes
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.toUtf8String
@@ -156,6 +157,91 @@ class AsyncJsonParserTest {
             }
         }
         parser.consume("]".toByteArray())
+        parsed.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `완성된 JSON 입력 종료를 알려도 추가 노드가 생성되지 않는다`() {
+        val parsed = AtomicInteger(0)
+        val parser = AsyncJsonParser { parsed.incrementAndGet() }
+
+        parser.consume("""{"key":"value"}""".toByteArray())
+        parser.endOfInput()
+
+        parsed.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `잘린 JSON 입력 종료 시 JsonParseException 이 발생한다`() {
+        val truncatedInputs =
+            listOf(
+                """{"key":""",
+                """{"id":12""",
+                """"unterm""",
+                "{\"a\":\"b\\",
+            )
+
+        truncatedInputs.forEach { input ->
+            val parser = AsyncJsonParser { /* 도달하지 않아야 함 */ }
+
+            parser.consume(input.toByteArray())
+
+            assertFailsWith<com.fasterxml.jackson.core.JsonParseException> {
+                parser.endOfInput()
+            }
+        }
+    }
+
+    @Test
+    fun `consume length 가 바이트 배열 범위를 벗어나면 IllegalArgumentException 이 발생한다`() {
+        val parser = AsyncJsonParser { /* 도달하지 않아야 함 */ }
+        val bytes = "{}".toByteArray()
+
+        assertFailsWith<IllegalArgumentException> {
+            parser.consume(bytes, -1)
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            parser.consume(bytes, bytes.size + 1)
+        }
+    }
+
+    @Test
+    fun `빈 청크와 부분 length 입력도 유효한 범위로 처리한다`() {
+        val parsed = AtomicInteger(0)
+        val parser = AsyncJsonParser { parsed.incrementAndGet() }
+
+        parser.consume(ByteArray(0))
+        parsed.get() shouldBeEqualTo 0
+
+        // length는 같은 ByteArray 안에서 실제 JSON으로 볼 prefix만 선택할 때 사용됩니다.
+        parser.consume("{}tail".toByteArray(), "{}".toByteArray().size)
+        parser.endOfInput()
+
+        parsed.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `endOfInput 이후 같은 파서에 다시 입력하면 IllegalStateException 이 발생한다`() {
+        val parser = AsyncJsonParser { /* 파서 수명주기만 검증 */ }
+
+        parser.consume("{}".toByteArray())
+        parser.endOfInput()
+
+        assertFailsWith<IllegalStateException> {
+            parser.consume("{}".toByteArray())
+        }
+    }
+
+    @Test
+    fun `endOfInput 은 두 번 호출해도 추가 노드를 만들지 않는다`() {
+        val parsed = AtomicInteger(0)
+        val parser = AsyncJsonParser { parsed.incrementAndGet() }
+
+        parser.consume("{}".toByteArray())
+        parser.endOfInput()
+        parser.endOfInput()
+
         parsed.get() shouldBeEqualTo 1
     }
 

--- a/io/jackson2/src/test/kotlin/io/bluetape4k/jackson/async/SuspendJsonParserTest.kt
+++ b/io/jackson2/src/test/kotlin/io/bluetape4k/jackson/async/SuspendJsonParserTest.kt
@@ -6,9 +6,11 @@ import com.fasterxml.jackson.module.kotlin.treeToValue
 import io.bluetape4k.jackson.Jackson
 import io.bluetape4k.jackson.treeToValueOrNull
 import io.bluetape4k.jackson.writeAsBytes
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.toUtf8String
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flowOf
@@ -163,6 +165,94 @@ class SuspendJsonParserTest {
         }
         parser.consume(flowOf("]".toByteArray()))
 
+        parsed.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `완성된 Flow 입력은 consumeComplete 로 종료 검증까지 수행한다`() = runTest {
+        val parsed = AtomicInteger(0)
+        val parser = SuspendJsonParser { parsed.incrementAndGet() }
+
+        parser.consumeComplete(flowOf("""{"key":"value"}""".toByteArray()))
+
+        parsed.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `빈 Flow 를 consumeComplete 로 처리하면 노드를 만들지 않는다`() = runTest {
+        val parsed = AtomicInteger(0)
+        val parser = SuspendJsonParser { parsed.incrementAndGet() }
+
+        parser.consumeComplete(flowOf())
+
+        parsed.get() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `잘린 Flow 입력을 consumeComplete 로 처리하면 JsonParseException 이 발생한다`() = runTest {
+        val truncatedInputs =
+            listOf(
+                """{"key":""",
+                """{"id":12""",
+                """"unterm""",
+                "{\"a\":\"b\\",
+            )
+
+        truncatedInputs.forEach { input ->
+            val parser = SuspendJsonParser { /* 도달하지 않아야 함 */ }
+
+            assertFailsWith<com.fasterxml.jackson.core.JsonParseException> {
+                parser.consumeComplete(flowOf(input.toByteArray()))
+            }
+        }
+    }
+
+    @Test
+    fun `증분 consume 후 잘린 입력 종료를 알리면 JsonParseException 이 발생한다`() = runTest {
+        val parser = SuspendJsonParser { /* 도달하지 않아야 함 */ }
+
+        parser.consume(flowOf("""{"key":""".toByteArray()))
+
+        assertFailsWith<com.fasterxml.jackson.core.JsonParseException> {
+            parser.endOfInput()
+        }
+    }
+
+    @Test
+    fun `consumeComplete 이후 같은 파서에 다시 입력하면 IllegalStateException 이 발생한다`() = runTest {
+        val parser = SuspendJsonParser { /* 파서 수명주기만 검증 */ }
+
+        parser.consumeComplete(flowOf("{}".toByteArray()))
+
+        assertFailsWith<IllegalStateException> {
+            parser.consume(flowOf("{}".toByteArray()))
+        }
+    }
+
+    @Test
+    fun `endOfInput 은 두 번 호출해도 추가 노드를 만들지 않는다`() = runTest {
+        val parsed = AtomicInteger(0)
+        val parser = SuspendJsonParser { parsed.incrementAndGet() }
+
+        parser.consume(flowOf("{}".toByteArray()))
+        parser.endOfInput()
+        parser.endOfInput()
+
+        parsed.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `consume 는 코루틴 취소를 지연하지 않고 전파한다`() = runTest {
+        val parsed = AtomicInteger(0)
+        val parser = SuspendJsonParser {
+            parsed.incrementAndGet()
+            // 콜백 취소는 구조화된 동시성의 정상 신호이므로 래핑하지 않고 그대로 전파되어야 합니다.
+            throw CancellationException("cancel parser callback")
+        }
+
+        assertFailsWith<CancellationException> {
+            parser.consume(flowOf("{}{}{}{}{}{}".toByteArray()))
+        }
         parsed.get() shouldBeEqualTo 1
     }
 


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: [fix] Harden Jackson2 streaming EOF contracts

- Hardened Jackson2 async parsers with explicit EOF handling via `AsyncJsonParser.endOfInput()`, `SuspendJsonParser.endOfInput()`, and `SuspendJsonParser.consumeComplete(flow)`.
- Added drain-before-feed checks, post-EOF lifecycle failures, coroutine cancellation checkpoints, and edge tests for truncated JSON, empty input, partial length, and double EOF.
- Updated English/Korean READMEs with Jackson2 advantages, recommended scenarios, anti-patterns, EOF guidance, and removed stale Jasypt/JsonEncrypt references.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 6-Tier P0/P1 Gate

| Iteration | P0 | P1 | Notes |
|---|---:|---:|---|
| Baseline local review | 0 | 4 | Missing EOF API, silent chunk skip risk, invalid length gap, suspend cancellation checkpoint gap. |
| Claude advisor iteration 1 | 0 | 8 | Lifecycle docs/tests, cancellation coverage, README anti-pattern, empty/partial length gaps. |
| Claude advisor re-review | 0 | 0 | Gate closed. Remaining P2/P3 cleanup was also addressed where low risk. |

### 기존 섹션: Verification

- `./gradlew :bluetape4k-jackson2:compileTestKotlin --no-build-cache --no-daemon`
- `./gradlew :bluetape4k-jackson2:test --tests "io.bluetape4k.jackson.async.AsyncJsonParserTest" --tests "io.bluetape4k.jackson.async.SuspendJsonParserTest" --no-build-cache --no-daemon` -> 25 passing after rebase
- `./gradlew :bluetape4k-jackson2:test --no-build-cache --no-daemon` -> 428 passing, 1 pending locally
- `git diff --check`
- Claude advisor re-review artifact: `.omx/artifacts/claude-jackson2-review-20260511-rerun2.md` (P0=0, P1=0)

### 기존 섹션: Notes

- Full repository build was not run.
- GitHub Actions may wait on runner allocation; local module validation above is the completion evidence for this PR.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #396, head `9babc494e749ecdfc3dafd95a3fefd17b1f4054d`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/jackson2-review-tests-docs`
- Labels: `bug`, `documentation`, `test`
- State: `MERGED`, merge commit `fd9dc6a3f539855970ea7b610cf0ee3cb28f3951`
- CI: - Hardened Jackson2 async parsers with explicit EOF handling via `AsyncJsonParser.endOfInput()`, `SuspendJsonParser.endOfInput()`, and `SuspendJsonParser.consumeComplete(flow)`. / - `./gradlew :bluetape4k-jackson2:compileTestKotlin --no-build-cache --no-daemon` / - `./gradlew :bluetape4k-jackson2:test --tests "io.bluetape4k.jackson.async.AsyncJsonParserTest" --tests "io.bluetape4k.jackson.async.SuspendJsonParserTest" --no-build-cache --no-daemon` -> 25 passing after rebase

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #396 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `fd9dc6a3f539855970ea7b610cf0ee3cb28f3951`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
