### PR TITLE
chore: Redis client major 업데이트 guard 추가

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,13 @@ updates:
       - dependency-name: "org.springframework.boot:*"
         update-types:
           - "version-update:semver-major"
+      # Redis client major baselines start here, then align outward after validation.
+      - dependency-name: "io.lettuce:lettuce-core"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "org.redisson:*"
+        update-types:
+          - "version-update:semver-major"
       - dependency-name: "org.apache.kafka:*"
         update-types:
           - "version-update:semver-major"


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: chore: Redis client major 업데이트 guard 추가

- Redis client(Lettuce/Redisson) semver-major Dependabot PR을 자동 생성하지 않도록 설정했습니다.
- Redis client major baseline은 `bluetape4k-projects`에서 먼저 검증한 뒤 다른 repo로 정렬하는 정책을 따릅니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### 요약
- Redis client(Lettuce/Redisson) semver-major Dependabot PR을 자동 생성하지 않도록 설정했습니다.
- Redis client major baseline은 `bluetape4k-projects`에서 먼저 검증한 뒤 다른 repo로 정렬하는 정책을 따릅니다.

### 검증
- Ruby YAML parse 통과
- 중앙 version drift report에서 Lettuce/Redisson 정렬 확인

## Validation

- Ruby YAML parse 통과
- 중앙 version drift report에서 Lettuce/Redisson 정렬 확인

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #399, head `a0fb41b210946210247c1845b5676f5902b07980`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `chore/redis-client-major-guard`
- Labels: `chore`, `build`
- State: `MERGED`, merge commit `0978e78e4d7060ef5864caf9ab1a150261f8b7ab`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #399 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `0978e78e4d7060ef5864caf9ab1a150261f8b7ab`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
