### PR TITLE
[fix] Harden cache-core suspend recovery contracts

### DIFF
--- a/cache/cache-core/README.ko.md
+++ b/cache/cache-core/README.ko.md
@@ -14,9 +14,7 @@
 - **Resilient Decorator**: `ResilientNearCacheDecorator`,
   `ResilientSuspendNearCacheDecorator` (retry + failure strategy)
   - `NearCacheResilienceConfig.retryMaxAttempts`와 `retryWaitDuration`은 0보다 커야 함
-- **JCache NearCache**: `JCacheNearCache<V>` — JCache 호환 백엔드용 NearCacheOperations 구현
-- **Legacy Near Cache**: `NearCache<K,V>`, `SuspendNearCache<K,V>` (기존 호환)
-- **Memorizer 추상화**: `Memorizer`, `AsyncMemorizer`, `SuspendMemorizer` (구 인터페이스)
+- **JCache NearCache**: `NearJCache<K,V>`, `SuspendNearJCache<K,V>` — JCache 호환 2-tier 캐시 구현
 - **Memoizer 추상화**: `Memoizer`, `AsyncMemoizer`, `SuspendMemoizer` (신 인터페이스)
 - **로컬 캐시 Provider** (구 `cache-local` 통합):
   - **Caffeine**: `CaffeineSupport`, `CaffeineSuspendCache`, `CaffeineMemorizer`
@@ -38,6 +36,29 @@ dependencies {
 ### NearCache 통일 인터페이스
 
 모든 NearCache 백엔드(Lettuce, Hazelcast, Redisson, JCache)가 공통 인터페이스를 구현합니다.
+
+#### Coroutine 취소와 retry
+
+`ResilientSuspendNearCacheDecorator`는 일반 예외에 대해서만 retry를 적용합니다.
+`CancellationException`은 코루틴 취소 신호이므로 retry하지 않고 즉시 전파합니다.
+
+#### Suspend Memoizer 실패 복구
+
+`SuspendMemoizer` 구현체는 같은 키의 동시 호출을 in-flight `Deferred`로 병합합니다.
+evaluator가 실패하거나 호출 코루틴이 취소되면 해당 in-flight 항목을 제거하여, 다음 호출이
+같은 실패를 재사용하지 않고 새 계산으로 복구할 수 있게 합니다.
+
+```kotlin
+var attempts = 0
+val memo = suspendMemoizer<String, Int> { key ->
+    attempts += 1
+    if (attempts == 1) error("일시적 실패")
+    key.length
+}
+
+runCatching { memo("recover") }  // 최초 1회 실패
+val value = memo("recover")      // 새로 계산하여 7 반환
+```
 
 #### NearCache get() 동작 시퀀스 (front miss → back lookup → front fill)
 
@@ -388,7 +409,6 @@ suspendNear.close()
 | `NearCacheResilienceConfig`             | cache-core      | retry + failure strategy 설정                        |
 | `ResilientNearCacheDecorator<V>`        | cache-core      | Decorator: Resilience4j retry + GetFailureStrategy |
 | `ResilientSuspendNearCacheDecorator<V>` | cache-core      | Decorator suspend 버전                               |
-| `JCacheNearCache<V>`                    | cache-core      | JCache 호환 백엔드용 구현                                  |
 | `LettuceNearCache<V>`                   | cache-lettuce   | RESP3 CLIENT TRACKING 기반                           |
 | `LettuceSuspendNearCache<V>`            | cache-lettuce   | Lettuce coroutines 버전                              |
 | `HazelcastNearCache<V>`                 | cache-hazelcast | IMap + EntryListener invalidation                  |

--- a/cache/cache-core/README.md
+++ b/cache/cache-core/README.md
@@ -12,9 +12,8 @@ English | [한국어](./README.ko.md)
 - **Coroutines cache abstractions**: `SuspendCache`, `SuspendCacheEntry`
 - **Unified NearCache interfaces**: `NearCacheOperations<V>`, `SuspendNearCacheOperations<V>`, `NearCacheStatistics`
 - **Resilient decorators**: `ResilientNearCacheDecorator`, `ResilientSuspendNearCacheDecorator`
-- **JCache NearCache**: `JCacheNearCache<V>`
-- **Legacy Near Cache**: `NearCache<K,V>`, `SuspendNearCache<K,V>`
-- **Memorizer and Memoizer abstractions** for sync, async, and suspend flows
+- **JCache NearCache**: `NearJCache<K,V>`, `SuspendNearJCache<K,V>`
+- **Memoizer abstractions** for sync, async, and suspend flows
 - **Local cache providers**: Caffeine, Cache2k, and Ehcache
 
 ## Installation
@@ -50,12 +49,32 @@ Typical usage patterns:
 - resilience decorators in front of remote NearCache implementations
 - memoizers for repeatable, computation-heavy functions
 
+### Suspend Memoizer Failure Recovery
+
+Suspend memoizers merge concurrent calls for the same key through an in-flight
+`Deferred`. If the evaluator fails or the caller is cancelled, that in-flight
+entry is removed so a later call can recompute instead of replaying a stale
+failure.
+
+```kotlin
+var attempts = 0
+val memo = suspendMemoizer<String, Int> { key ->
+    attempts += 1
+    if (attempts == 1) error("temporary backend failure")
+    key.length
+}
+
+runCatching { memo("recover") }  // fails once
+val value = memo("recover")      // recomputes and returns 7
+```
+
 ## Recommended Usage Patterns
 
 - Use `cache-core` directly when local cache and common abstractions are enough.
 - Use provider modules such as Hazelcast, Lettuce, or Redisson when remote storage or invalidation is required.
 - Prefer the newer `Memoizer` / `AsyncMemoizer` / `SuspendMemoizer` abstractions for new code.
-- Use the legacy near-cache APIs only for backward compatibility.
+- Use `NearCacheOperations` / `SuspendNearCacheOperations` for provider-neutral two-tier cache contracts.
+- Suspend resilience decorators do not retry `CancellationException`; coroutine cancellation is propagated immediately.
 
 ## Architecture Diagrams
 

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/SuspendMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/SuspendMemoizer.kt
@@ -6,12 +6,17 @@ package io.bluetape4k.cache.memoizer
  * ## 동작/계약
  * - 동일 입력에 대한 suspend 계산 결과를 재사용합니다.
  * - 동시 호출 병합/경쟁 조건 처리 방식은 구현체에 따릅니다.
+ * - evaluator 실패 또는 코루틴 취소는 성공 결과처럼 캐시하면 안 됩니다.
+ *   다음 호출은 같은 실패를 재사용하지 않고 새 계산을 시도해야 합니다.
  * - [clear] 호출 시 저장된 캐시 엔트리를 제거해야 합니다.
  *
  * ```kotlin
  * val memo: SuspendMemoizer<String, Int> = suspendMemoizer { it.length }
  * val size = memo("abcd")
  * // size == 4
+ *
+ * // 일시적 실패는 in-flight 항목에 고정되지 않아야 합니다.
+ * // 이후 같은 키 호출은 새 계산으로 복구할 수 있어야 합니다.
  * ```
  */
 interface SuspendMemoizer<in T: Any, out R: Any>: suspend (T) -> R {

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/cache2k/Cache2kSuspendMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/cache2k/Cache2kSuspendMemoizer.kt
@@ -74,15 +74,23 @@ class Cache2kSuspendMemoizer<in T: Any, out R: Any>(
         // 2단계: per-key Deferred로 중복 evaluator 실행 방지.
         // computeIfAbsent는 atomic이므로 같은 키에 대해 Deferred가 하나만 생성된다.
         return coroutineScope {
+            var createdByThisCall = false
             val deferred = inflightMap.computeIfAbsent(input) {
+                createdByThisCall = true
                 async {
                     evaluator(input)
                 }
             }
-            val result = deferred.await()
-            this@Cache2kSuspendMemoizer.cache.put(input, result)
-            inflightMap.remove(input, deferred)
-            result
+            try {
+                val result = deferred.await()
+                this@Cache2kSuspendMemoizer.cache.put(input, result)
+                result
+            } finally {
+                // evaluator 실패 후에도 in-flight 항목을 정리해 다음 호출이 재시도할 수 있게 한다.
+                if (createdByThisCall || deferred.isCompleted) {
+                    inflightMap.remove(input, deferred)
+                }
+            }
         }
     }
 

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineSuspendMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineSuspendMemoizer.kt
@@ -72,15 +72,23 @@ class CaffeineSuspendMemoizer<T: Any, R: Any>(
         // computeIfAbsent는 atomic이므로 같은 키에 대해 Deferred가 하나만 생성된다.
         // evaluator는 Deferred 내부에서 실행되므로 lock을 보유하지 않아 재귀 호출이 안전하다.
         return coroutineScope {
+            var createdByThisCall = false
             val deferred = inflightMap.computeIfAbsent(input) {
+                createdByThisCall = true
                 async {
                     evaluator(input)
                 }
             }
-            val result = deferred.await()
-            cache.put(input, result)
-            inflightMap.remove(input, deferred)
-            result
+            try {
+                val result = deferred.await()
+                cache.put(input, result)
+                result
+            } finally {
+                // 실패/취소된 Deferred를 제거해야 같은 키의 다음 호출이 새 계산으로 복구할 수 있다.
+                if (createdByThisCall || deferred.isCompleted) {
+                    inflightMap.remove(input, deferred)
+                }
+            }
         }
     }
 

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/ehcache/EhCacheSuspendMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/ehcache/EhCacheSuspendMemoizer.kt
@@ -74,15 +74,23 @@ class EhCacheSuspendMemoizer<T: Any, R: Any>(
         // 2단계: per-key Deferred로 중복 evaluator 실행 방지.
         // computeIfAbsent는 atomic이므로 같은 키에 대해 Deferred가 하나만 생성된다.
         return coroutineScope {
+            var createdByThisCall = false
             val deferred = inflightMap.computeIfAbsent(input) {
+                createdByThisCall = true
                 async {
                     evaluator(input)
                 }
             }
-            val result = deferred.await()
-            cache.put(input, result)
-            inflightMap.remove(input, deferred)
-            result
+            try {
+                val result = deferred.await()
+                cache.put(input, result)
+                result
+            } finally {
+                // 실패한 Deferred를 남기지 않아야 transient evaluator 실패 후 복구된다.
+                if (createdByThisCall || deferred.isCompleted) {
+                    inflightMap.remove(input, deferred)
+                }
+            }
         }
     }
 

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/inmemory/InMemorySuspendMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/inmemory/InMemorySuspendMemoizer.kt
@@ -61,17 +61,25 @@ class InMemorySuspendMemoizer<in T: Any, out R: Any>(
         // computeIfAbsent는 atomic이므로 같은 키에 대해 Deferred가 하나만 생성된다.
         // evaluator는 Deferred 내부에서 실행되므로 lock을 보유하지 않아 재귀 호출이 안전하다.
         return coroutineScope {
+            var createdByThisCall = false
             val deferred = inflightMap.computeIfAbsent(input) {
+                createdByThisCall = true
                 async {
                     log.trace { "Cache miss for key: $input, evaluating..." }
                     evaluator(input)
                 }
             }
-            val result = deferred.await()
-            // 결과를 resultCache에 저장하고 inflight 항목 제거
-            resultCache[input] = result
-            inflightMap.remove(input, deferred)
-            result
+            try {
+                val result = deferred.await()
+                resultCache[input] = result
+                result
+            } finally {
+                // 실패/취소된 Deferred가 남으면 이후 같은 키 호출이 영구적으로 같은 실패를 재사용한다.
+                // 다만 다른 waiter가 취소된 것만으로 진행 중인 계산을 제거하지 않도록 생성자 또는 완료 상태에서만 제거한다.
+                if (createdByThisCall || deferred.isCompleted) {
+                    inflightMap.remove(input, deferred)
+                }
+            }
         }
     }
 

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/ResilientSuspendNearCacheDecorator.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/ResilientSuspendNearCacheDecorator.kt
@@ -39,6 +39,9 @@ class ResilientSuspendNearCacheDecorator<V: Any>(
             RetryConfig
                 .custom<Any>()
                 .maxAttempts(config.retryMaxAttempts)
+                // CancellationException은 코루틴 취소 신호이므로 retry 대상이 아니다.
+                // resilience4j-kotlin의 executeSuspendFunction은 Exception을 catch하므로 명시적으로 제외한다.
+                .ignoreExceptions(CancellationException::class.java)
                 .intervalFunction(
                     if (config.retryExponentialBackoff) {
                         IntervalFunction.ofExponentialBackoff(config.retryWaitDuration.toMillis())
@@ -182,7 +185,14 @@ class ResilientSuspendNearCacheDecorator<V: Any>(
     // -- Lifecycle --
 
     override suspend fun close() {
-        runCatching { delegate.close() }
+        try {
+            delegate.close()
+        } catch (e: CancellationException) {
+            // close() 중 취소된 코루틴도 정상 취소 흐름을 유지해야 한다.
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "close() 실패를 무시합니다. cacheName=$cacheName" }
+        }
     }
 }
 

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/memoizer/cache2k/Cache2KSuspendMemoizerTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/memoizer/cache2k/Cache2KSuspendMemoizerTest.kt
@@ -4,10 +4,15 @@ import io.bluetape4k.cache.cache2k.cache2k
 import io.bluetape4k.cache.memoizer.AbstractSuspendMemoizerTest
 import io.bluetape4k.cache.memoizer.SuspendFactorialProvider
 import io.bluetape4k.cache.memoizer.SuspendFibonacciProvider
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.junit5.coroutines.runSuspendDefault
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import kotlinx.coroutines.delay
 import org.cache2k.Cache
+import org.junit.jupiter.api.Test
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
 
 class Cache2KSuspendMemoizerTest: AbstractSuspendMemoizerTest() {
@@ -40,5 +45,28 @@ class Cache2KSuspendMemoizerTest: AbstractSuspendMemoizerTest() {
         }.build()
 
         override val cachedCalc: suspend (Long) -> Long = cache.suspendMemoizer { calc(it) }
+    }
+
+    @Test
+    fun `evaluator 실패 후 같은 키를 다시 호출하면 새 계산으로 복구된다`() = runSuspendDefault {
+        val localCache = cache2k<String, Int> {
+            this.name("suspend-recovery-${System.nanoTime()}")
+            this.executor(Executors.newVirtualThreadPerTaskExecutor())
+        }.build()
+        val evalCount = AtomicInteger(0)
+        val memo = localCache.suspendMemoizer { key: String ->
+            if (evalCount.incrementAndGet() == 1) {
+                error("transient failure")
+            }
+            key.length
+        }
+
+        assertFailsWith<IllegalStateException> {
+            memo("recover")
+        }
+
+        memo("recover") shouldBeEqualTo 7
+        evalCount.get() shouldBeEqualTo 2
+        localCache.close()
     }
 }

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineSuspendMemoizerTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineSuspendMemoizerTest.kt
@@ -7,6 +7,9 @@ import io.bluetape4k.cache.caffeine.caffeine
 import io.bluetape4k.cache.memoizer.AbstractSuspendMemoizerTest
 import io.bluetape4k.cache.memoizer.SuspendFactorialProvider
 import io.bluetape4k.cache.memoizer.SuspendFibonacciProvider
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeLessOrEqualTo
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.junit5.coroutines.runSuspendDefault
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import kotlinx.coroutines.delay
@@ -14,6 +17,7 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import org.junit.jupiter.api.Test
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
 
 class CaffeineSuspendMemoizerTest: AbstractSuspendMemoizerTest() {
@@ -56,5 +60,37 @@ class CaffeineSuspendMemoizerTest: AbstractSuspendMemoizerTest() {
         // clear 후에는 캐시에서 직접 조회해도 null이어야 한다.
         localCache.getIfPresent("hello").shouldBeNull()
         localCache.getIfPresent("world").shouldBeNull()
+    }
+
+    @Test
+    fun `evaluator 실패 후 같은 키를 다시 호출하면 새 계산으로 복구된다`() = runSuspendDefault {
+        val localCache = caffeine.cache<String, Int>()
+        val evalCount = AtomicInteger(0)
+        val memo = localCache.suspendMemoizer { key: String ->
+            if (evalCount.incrementAndGet() == 1) {
+                error("transient failure")
+            }
+            key.length
+        }
+
+        assertFailsWith<IllegalStateException> {
+            memo("recover")
+        }
+
+        // 실패한 in-flight Deferred가 제거되어야 이후 동시 호출들이 새 계산을 공유한다.
+        SuspendedJobTester()
+            .workers(8)
+            .rounds(2)
+            .add {
+                memo("recover") shouldBeEqualTo 7
+            }
+            .run()
+
+        memo("recover") shouldBeEqualTo 7
+        localCache.getIfPresent("recover") shouldBeEqualTo 7
+
+        // Caffeine의 executor 스케줄링에 따라 복구 계산 직후 일부 경합이 생길 수 있다.
+        // 핵심 계약은 실패한 Deferred를 재사용하지 않고 성공 값을 다시 캐시하는 것이다.
+        evalCount.get() shouldBeLessOrEqualTo 3
     }
 }

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/memoizer/ehcache/EhcacheSuspendMemoizerTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/memoizer/ehcache/EhcacheSuspendMemoizerTest.kt
@@ -5,7 +5,12 @@ import io.bluetape4k.cache.ehcache.getOrCreateCache
 import io.bluetape4k.cache.memoizer.AbstractSuspendMemoizerTest
 import io.bluetape4k.cache.memoizer.SuspendFactorialProvider
 import io.bluetape4k.cache.memoizer.SuspendFibonacciProvider
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.junit5.coroutines.runSuspendDefault
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
 
 class EhcacheSuspendMemoizerTest: AbstractSuspendMemoizerTest() {
 
@@ -26,5 +31,24 @@ class EhcacheSuspendMemoizerTest: AbstractSuspendMemoizerTest() {
     override val fibonacci: SuspendFibonacciProvider = object: SuspendFibonacciProvider {
         private val cache = ehcacheManager.getOrCreateCache<Long, Long>("suspend-fibonacci")
         override val cachedCalc: suspend (Long) -> Long = cache.suspendMemoizer { calc(it) }
+    }
+
+    @Test
+    fun `evaluator 실패 후 같은 키를 다시 호출하면 새 계산으로 복구된다`() = runSuspendDefault {
+        val localCache = ehcacheManager.getOrCreateCache<String, Int>("suspend-recovery-${System.nanoTime()}")
+        val evalCount = AtomicInteger(0)
+        val memo = localCache.suspendMemoizer { key: String ->
+            if (evalCount.incrementAndGet() == 1) {
+                error("transient failure")
+            }
+            key.length
+        }
+
+        assertFailsWith<IllegalStateException> {
+            memo("recover")
+        }
+
+        memo("recover") shouldBeEqualTo 7
+        evalCount.get() shouldBeEqualTo 2
     }
 }

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/memoizer/inmemory/InMemorySuspendMemoizerTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/memoizer/inmemory/InMemorySuspendMemoizerTest.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.cache.memoizer.inmemory
 import io.bluetape4k.cache.memoizer.AbstractSuspendMemoizerTest
 import io.bluetape4k.cache.memoizer.SuspendFactorialProvider
 import io.bluetape4k.cache.memoizer.SuspendFibonacciProvider
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.junit5.coroutines.runSuspendDefault
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.trace
@@ -61,5 +62,23 @@ class InMemorySuspendMemoizerTest: AbstractSuspendMemoizerTest() {
         results.forEach { it shouldBeEqualTo 5 }
         // per-key Deferred 패턴 덕분에 evaluator가 1회만 실행됨
         evalCount.get() shouldBeLessOrEqualTo 2
+    }
+
+    @Test
+    fun `evaluator 실패 후 같은 키를 다시 호출하면 새 계산으로 복구된다`() = runSuspendDefault {
+        val evalCount = AtomicInteger(0)
+        val memo = InMemorySuspendMemoizer<String, Int> { key ->
+            if (evalCount.incrementAndGet() == 1) {
+                error("transient failure")
+            }
+            key.length
+        }
+
+        assertFailsWith<IllegalStateException> {
+            memo("recover")
+        }
+
+        memo("recover") shouldBeEqualTo 7
+        evalCount.get() shouldBeEqualTo 2
     }
 }

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/ResilientSuspendNearCacheDecoratorTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/ResilientSuspendNearCacheDecoratorTest.kt
@@ -12,6 +12,7 @@ import io.bluetape4k.assertions.shouldBeNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import io.bluetape4k.assertions.assertFailsWith
+import kotlinx.coroutines.CancellationException
 import java.time.Duration
 
 /**
@@ -180,5 +181,40 @@ class ResilientSuspendNearCacheDecoratorTest {
             propagated = true
         }
         propagated shouldBeEqualTo true
+    }
+
+    /**
+     * resilience4j-kotlin은 suspend block의 Exception을 잡아 retry 여부를 판단한다.
+     * CancellationException을 ignoreExceptions로 제외하지 않으면 취소 신호도 retry되어 구조적 동시성이 깨진다.
+     */
+    @Test
+    fun `put - CancellationException은 retry 하지 않고 즉시 재전파된다`() {
+        coEvery { delegate.put("key1", "value1") } throws CancellationException("cancel put")
+
+        val cache = ResilientSuspendNearCacheDecorator(
+            delegate,
+            NearCacheResilienceConfig(
+                retryMaxAttempts = 3,
+                retryWaitDuration = Duration.ofMillis(10),
+                getFailureStrategy = GetFailureStrategy.RETURN_FRONT_OR_NULL
+            )
+        )
+
+        assertFailsWith<CancellationException> {
+            runSuspendIO { cache.put("key1", "value1") }
+        }
+        coVerify(exactly = 1) { delegate.put("key1", "value1") }
+    }
+
+    @Test
+    fun `close - CancellationException은 runCatching 으로 삼키지 않는다`() {
+        coEvery { delegate.close() } throws CancellationException("cancel close")
+
+        val cache = ResilientSuspendNearCacheDecorator(delegate)
+
+        assertFailsWith<CancellationException> {
+            runSuspendIO { cache.close() }
+        }
+        coVerify(exactly = 1) { delegate.close() }
     }
 }

--- a/docs/lessons/2026-05-11-cache-core-suspend-recovery.md
+++ b/docs/lessons/2026-05-11-cache-core-suspend-recovery.md
@@ -1,0 +1,84 @@
+# Cache-Core Suspend 복구 계약 교훈
+
+## 배경
+
+`cache/cache-core` 모듈은 이전 bluetape4k 모듈 리뷰와 동일하게 6-Tier
+P0/P1 gate를 적용해 리뷰했다. 실제 위험은 캐시 provider 연결 코드보다
+coroutine lifecycle 계약에 있었다. 특히 suspend resilience decorator와
+suspend memoizer에서 취소, 실패, 동시 호출이 만나는 지점이 취약했다.
+
+이번 리뷰 범위는 다음 코드였다.
+
+- `ResilientSuspendNearCacheDecorator`
+- `InMemorySuspendMemoizer`
+- `CaffeineSuspendMemoizer`
+- `Cache2kSuspendMemoizer`
+- `EhCacheSuspendMemoizer`
+- public `SuspendMemoizer` 계약 KDoc
+- `cache/cache-core/README.md`, `README.ko.md`
+
+## 결정 및 발견
+
+P0는 없었다.
+
+P1은 2건이었다.
+
+첫째, suspend retry wrapper가 `Exception`을 catch하는 외부 라이브러리에
+의존하면 `CancellationException`도 retry될 수 있다. 이번 경우
+resilience4j-kotlin의 `executeSuspendFunction` 경로가 문제였다.
+coroutine 취소는 실패가 아니라 취소 신호이므로 retry 대상에서 명시적으로
+제외해야 한다.
+
+둘째, suspend memoizer의 in-flight map에 실패하거나 취소된 `Deferred`가
+남으면 안 된다. 실패한 `Deferred`는 성공한 캐시 값이 아니다. 이것이 같은
+key에 계속 남아 있으면 이후 호출이 새 계산을 시작하지 못하고 이전 실패만
+반복해서 재사용할 수 있다.
+
+`runCatching`도 같은 이유로 조심해야 한다. `runCatching`은
+`CancellationException`을 잡기 때문에 suspend `close()`에서 일반 예외를
+삼키려면 `try/catch`를 직접 쓰고 cancellation은 먼저 재전파해야 한다.
+
+## 결과
+
+이번 cache-core 수정으로 다음 계약을 코드와 테스트에 반영했다.
+
+- suspend resilience wrapper는 `CancellationException`을 retry하지 않는다.
+- suspend lifecycle 메서드는 일반 close 실패를 기록하고 무시하더라도
+  cancellation은 반드시 다시 던진다.
+- suspend memoizer는 실패하거나 취소된 in-flight `Deferred`를 제거한다.
+- transient failure 이후 같은 key 호출은 새 계산으로 복구되고, 성공 결과는
+  다시 정상 캐시된다.
+- public KDoc과 README 예제에 evaluator 실패와 coroutine 취소가 성공 값처럼
+  memoize되지 않는다는 계약을 명시했다.
+
+Caffeine 테스트에서는 추가 교훈도 있었다. 동시 복구를 검증할 때 provider
+executor 스케줄링에 따라 계산 횟수가 약간 흔들릴 수 있다. 이런 테스트는
+정확한 실행 횟수보다 사용자에게 보이는 계약과 최종 캐시 상태를 먼저
+검증해야 한다.
+
+## 검증
+
+이번 작업에서 확인한 로컬 증거는 다음과 같다.
+
+- Caffeine 복구 edge test:
+  `./gradlew :bluetape4k-cache-core:test --tests '*CaffeineSuspendMemoizerTest'`
+- cache-core 전체 테스트:
+  `./gradlew :bluetape4k-cache-core:test`
+- 전체 결과: `444 passing`
+- 커밋 전 `git diff --check` 통과
+- PR #400 본문에 최종 gate 결과 `P0=0`, `P1=0` 기록
+
+## 향후 지침
+
+- suspend retry/circuit-breaker wrapper를 리뷰할 때는
+  `CancellationException`이 retry되지 않고 즉시 전파되는 테스트를 반드시
+  추가한다.
+- suspend lifecycle 코드에서 `runCatching`을 쓰지 않는다. 꼭 써야 한다면
+  cancellation 재전파가 먼저 보장되는 구조인지 별도 테스트로 증명한다.
+- in-flight memoization에서는 실패하거나 취소된 `Deferred`를 `finally`에서
+  제거한다. transient failure가 특정 key를 영구적으로 오염시키면 안 된다.
+- `SuspendedJobTester`로 동시성 테스트를 추가할 때는 최종 상태와 public
+  contract를 우선 검증한다. scheduler 경계를 완전히 소유하지 않는 구현에서
+  정확한 evaluator 실행 횟수를 강하게 단정하지 않는다.
+- public 계약이 바뀌면 코드 수정과 같은 PR에서 KDoc, README.md,
+  README.ko.md를 함께 갱신한다.


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: [fix] Harden cache-core suspend recovery contracts

- `cache/cache-core`에 6-Tier review gate를 적용하고 P0/P1이 남지 않도록 수정했습니다.
- `ResilientSuspendNearCacheDecorator`에서 `CancellationException`이 retry되거나 `close()`에서 삼켜지지 않도록 보강했습니다.
- suspend memoizer의 transient failure/cancellation 이후 같은 key가 실패한 `Deferred`에 고착되지 않도록 in-flight 정리를 보강했습니다.
- public suspend memoizer KDoc, README/README.ko 예제와 명칭 drift를 최신화했습니다.
- 이번 작업에서 재사용할 교훈을 `docs/lessons/2026-05-11-cache-core-suspend-recovery.md`에 한글로 정리했습니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 6-Tier P0/P1 결과

- P0: 없음
- P1: `executeSuspendFunction`이 `Exception`을 catch하는 구조라 `CancellationException`이 retry 대상이 될 수 있었고, `close()`의 `runCatching`이 cancellation을 삼킬 수 있었습니다.
- P1: suspend memoizer에서 evaluator 실패/취소 시 `inflightMap`의 failed `Deferred`가 남아 같은 key의 후속 호출이 새 계산으로 복구되지 못할 수 있었습니다.

## Validation

- `./gradlew :bluetape4k-cache-core:test --tests '*CaffeineSuspendMemoizerTest'`
- `./gradlew :bluetape4k-cache-core:test`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #400, head `6f936bb7f0060c8a38452fd5f7e170c2bc417663`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/cache-core-review-tests-docs`
- Labels: `bug`, `test`, `chore`
- State: `MERGED`, merge commit `1a0edbdc2626f2a9c2190a279322771d1f0a096a`
- CI: - `./gradlew :bluetape4k-cache-core:test --tests '*CaffeineSuspendMemoizerTest'` / - `./gradlew :bluetape4k-cache-core:test`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #400 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `1a0edbdc2626f2a9c2190a279322771d1f0a096a`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
