### PR TITLE
[cache-lettuce] suspend lifecycle 계약 보강

### DIFF
--- a/cache/cache-lettuce/README.ko.md
+++ b/cache/cache-lettuce/README.ko.md
@@ -598,6 +598,22 @@ cacheName="orders", key="user:123" → Redis key: "orders:user:123"
 
 `close()` 는 리소스(리스너, executor, 연결 핸들)를 해제할 뿐 **데이터를 삭제하지 않습니다**. 과거 구현은 `close()` 내부에서 `clear()` 를 수행해 JSR-107 계약을 위반했으므로 제거되었습니다. 종료 시점에 데이터를 비우려면 `close()` 이전에 `clear()` 를 명시적으로 호출하세요.
 
+`LettuceSuspendJCache.close()` 도 래핑한 `LettuceJCache` 와 같은 계약을 따릅니다. suspend cache manager의 close 경로는 호출자 취소가 요청되어도 non-cancellable 정리 구간에서 나머지 캐시 wrapper close를 먼저 시도합니다. 개별 cache close가 `CancellationException` 을 명시적으로 던지면 잔여 정리를 끝낸 뒤 다시 던집니다.
+
+### `LettuceSuspendMemoizer` — transient failure 및 cancellation 복구
+
+suspend memoizer의 in-flight 항목은 계산 조율 상태이지 영구 캐시 값이 아닙니다. evaluator가 실패하거나 취소되면 해당 in-flight `Deferred`를 예외 완료 후 제거해, 다음 같은 key 호출이 새 계산으로 복구될 수 있게 합니다.
+
+```kotlin
+val attempts = AtomicInteger(0)
+val memoizer = suspendMap.suspendMemoizer<Int, Int> { key ->
+    if (attempts.incrementAndGet() == 1) error("temporary failure")
+    key * key
+}
+
+// 첫 실패는 성공 값처럼 캐시되지 않으므로 다음 호출에서 다시 계산한다.
+```
+
 ### `LettuceJCache.putAll` — 존재 여부 조회 배치화
 
 `CacheEntryListener` 가 등록된 경우 CREATED/UPDATED 이벤트 구분을 위해 키별로 `HEXISTS` 를 `N` 번 호출하던 비용을 단일 `HMGET` 한 번으로 줄였습니다. 엔트리 개수와 무관하게 roundtrip 이 1회로 고정됩니다.

--- a/cache/cache-lettuce/README.md
+++ b/cache/cache-lettuce/README.md
@@ -218,6 +218,22 @@ Bulk deletes issue `UNLINK` instead of `DEL`. Large keys are evicted on a backgr
 
 `close()` releases resources (listeners, executors, connection handles) but does **not** delete data. Previously `close()` also ran `clear()`, which violated the JSR-107 contract. If you need data removal on shutdown, call `clear()` explicitly before `close()`.
 
+`LettuceSuspendJCache.close()` follows the same contract through its wrapped `LettuceJCache`. Suspend cache managers also protect close cleanup from caller cancellation: remaining cache wrappers are closed in a non-cancellable cleanup section. If an individual cache close explicitly throws `CancellationException`, the manager finishes the remaining cleanup first and then rethrows it.
+
+### `LettuceSuspendMemoizer` — transient failure and cancellation recovery
+
+Suspend memoizer in-flight entries are coordination state, not durable cache entries. If an evaluator fails or is cancelled, the in-flight `Deferred` is completed exceptionally and removed so the next call for the same key can start a fresh computation.
+
+```kotlin
+val attempts = AtomicInteger(0)
+val memoizer = suspendMap.suspendMemoizer<Int, Int> { key ->
+    if (attempts.incrementAndGet() == 1) error("temporary failure")
+    key * key
+}
+
+// The first failed call is not cached as a value; the next call recomputes.
+```
+
 ### `LettuceJCache.putAll` — existence check batching
 
 When `CacheEntryListener` is registered, CREATED/UPDATED event classification used to cost `N × HEXISTS` roundtrips. It now uses a single `HMGET` to fetch the existence bitmap in one shot — O(1) roundtrips regardless of entry count.

--- a/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceSuspendCacheManager.kt
+++ b/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceSuspendCacheManager.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.cache.jcache
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.info
+import io.bluetape4k.logging.warn
 import io.bluetape4k.redis.lettuce.RedisCommandSupports
 import io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodec
 import io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodecs
@@ -9,6 +10,9 @@ import io.bluetape4k.support.requireNotBlank
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
 import io.lettuce.core.RedisClient
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import java.util.concurrent.ConcurrentHashMap
 
 @OptIn(ExperimentalLettuceCoroutinesApi::class)
@@ -173,7 +177,9 @@ class LettuceSuspendCacheManager(
      *
      * ## 동작/계약
      * - 최초 1회만 실제 종료 로직이 수행되며 이후 호출은 즉시 반환합니다.
-     * - 각 캐시 종료 중 예외는 `runCatching`으로 무시하고 다음 캐시 종료를 계속합니다.
+     * - 종료 도중 외부 코루틴 취소가 요청되어도 [NonCancellable] 정리 구간에서 나머지 캐시 close를 먼저 시도합니다.
+     * - 개별 `cache.close()`가 [CancellationException]을 명시적으로 던지면 잔여 캐시 close 후 다시 던집니다.
+     * - 각 캐시 종료 중 일반 예외는 기록하고 다음 캐시 종료를 계속합니다.
      * - 종료 후 `getOrCreate/getCache/destroyCache`는 `IllegalStateException`을 발생시킵니다.
      *
      * ```kotlin
@@ -188,9 +194,20 @@ class LettuceSuspendCacheManager(
         if (closed.compareAndSet(expect = false, update = true)) {
             log.info { "Close LettuceSuspendCacheManager." }
 
-            caches.values.forEach { cache ->
-                runCatching { cache.close() }
+            var cancellation: CancellationException? = null
+            withContext(NonCancellable) {
+                caches.values.forEach { cache ->
+                    try {
+                        cache.close()
+                    } catch (e: CancellationException) {
+                        // cache.close() 자체가 취소 예외를 던진 경우에도 잔여 캐시 정리를 끝낸 뒤 호출자에게 전달한다.
+                        cancellation = cancellation ?: e
+                    } catch (e: Exception) {
+                        log.warn(e) { "LettuceSuspendCacheManager cache close failed. cacheName=${cache.name}" }
+                    }
+                }
             }
+            cancellation?.let { throw it }
         }
     }
 

--- a/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceSuspendJCache.kt
+++ b/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceSuspendJCache.kt
@@ -21,7 +21,8 @@ import javax.cache.event.CacheEntryListener
  * ## 동작/계약
  * - 캐시 항목은 Redis hash(`cacheName`)에 `hset/hget/hdel` 계열 명령으로 저장/조회합니다.
  * - `configuration.ttlSeconds` 가 지정되면 `supportsHSetEx` 여부에 따라 `HSETEX + EXPIRE`(Redis 8+) 또는 `HSET/HMSET + EXPIRE`(Redis 7 이하)로 동작합니다. 분기는 초기화 시점에 1회 결정됩니다.
- * - `close()`는 내부적으로 `clear()`를 수행해 Redis hash 키를 삭제합니다.
+ * - `close()`는 JCache 계약과 동일하게 리소스만 해제하며 Redis hash 데이터는 삭제하지 않습니다.
+ *   데이터 삭제가 필요하면 `close()` 전에 [clear]를 명시적으로 호출하세요.
  * - [CacheEntryListener] 등록을 지원하며, 등록된 리스너에게 [Channel] 기반 비동기 이벤트를 전파합니다.
  *
  * ```kotlin

--- a/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/memoizer/LettuceSuspendMemoizer.kt
+++ b/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/memoizer/LettuceSuspendMemoizer.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.redis.lettuce.map.LettuceSuspendMap
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -26,6 +27,7 @@ fun <K: Any, V: Any> LettuceSuspendMap<V>.suspendMemoizer(evaluator: suspend (K)
  * [LettuceSuspendMap]을 사용하여 함수 실행 결과를 코루틴 기반으로 메모이제이션하는 구현체입니다.
  *
  * 동일 JVM에서 동시 요청 시 in-flight 연산을 공유하여 중복 실행을 방지합니다.
+ * evaluator 실패 또는 코루틴 취소는 성공 값처럼 캐시하지 않으며, 다음 같은 key 호출은 새 계산을 시도합니다.
  *
  * ```kotlin
  * val connection = redisClient.connect(LettuceLongCodec)
@@ -68,6 +70,10 @@ class LettuceSuspendMemoizer<K: Any, V: Any>(
             val winner = if (isNew) evaluated else (map.get(key.toString()) ?: evaluated)
             deferred.complete(winner)
             return winner
+        } catch (e: CancellationException) {
+            // CancellationException은 coroutine 취소 신호이므로 실패 공유 후 즉시 재전파한다.
+            deferred.completeExceptionally(e)
+            throw e
         } catch (e: Throwable) {
             deferred.completeExceptionally(e)
             throw e

--- a/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceSuspendNearCache.kt
+++ b/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceSuspendNearCache.kt
@@ -21,6 +21,7 @@ import io.lettuce.core.api.coroutines.RedisCoroutinesCommands
 import io.lettuce.core.api.coroutines.multi
 import io.lettuce.core.codec.RedisCodec
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.future.await
 
 /**
@@ -397,10 +398,24 @@ class LettuceSuspendNearCache<V: Any>(
      */
     override suspend fun close() {
         if (closed.compareAndSet(expect = false, update = true)) {
-            runCatching { trackingListener.close() }
-            runCatching { connection.close() }
-            runCatching { frontCache.close() }
+            closeResource("trackingListener") { trackingListener.close() }
+            closeResource("connection") { connection.close() }
+            closeResource("frontCache") { frontCache.close() }
             log.debug { "LettuceSuspendNearCache [${config.cacheName}] closed" }
+        }
+    }
+
+    private inline fun closeResource(
+        resourceName: String,
+        block: () -> Unit,
+    ) {
+        try {
+            block()
+        } catch (e: CancellationException) {
+            // 방어적으로라도 취소 신호는 일반 close 실패처럼 삼키지 않는다.
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "LettuceSuspendNearCache resource close failed. cacheName=$cacheName, resource=$resourceName" }
         }
     }
 

--- a/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceSuspendJCacheManagerTest.kt
+++ b/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceSuspendJCacheManagerTest.kt
@@ -33,6 +33,26 @@ class LettuceSuspendJCacheManagerTest {
     }
 
     @Test
+    fun `manager close releases wrappers but keeps redis data`() = runSuspendIO {
+        val cacheName = "lettuce-suspend-manager-close-" + UUID.randomUUID().encodeBase62()
+        val manager = LettuceSuspendCacheManager(redisClient, defaultCodec = LettuceBinaryCodecs.lz4Fory())
+        val cache = manager.getOrCreate<String>(cacheName)
+
+        cache.put("key", "value")
+        manager.close()
+
+        val reopenedManager = LettuceSuspendCacheManager(redisClient, defaultCodec = LettuceBinaryCodecs.lz4Fory())
+        try {
+            // close()는 JCache 계약상 Redis hash 데이터를 삭제하지 않는다. 새 wrapper로 다시 읽을 수 있어야 한다.
+            val reopened = reopenedManager.getOrCreate<String>(cacheName)
+            reopened.get("key") shouldBeEqualTo "value"
+        } finally {
+            runCatching { reopenedManager.destroyCache(cacheName) }
+            runCatching { reopenedManager.close() }
+        }
+    }
+
+    @Test
     fun `closed manager rejects further operations`() {
         val manager = LettuceSuspendCacheManager(redisClient, defaultCodec = LettuceBinaryCodecs.lz4Fory())
         runSuspendIO { manager.close() }

--- a/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/memoizer/LettuceSuspendMemoizerTest.kt
+++ b/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/memoizer/LettuceSuspendMemoizerTest.kt
@@ -1,11 +1,23 @@
 package io.bluetape4k.cache.memoizer
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.cache.RedisServers
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.redis.lettuce.LettuceClients
 import io.bluetape4k.redis.lettuce.codec.LettuceIntCodec
 import io.bluetape4k.redis.lettuce.codec.LettuceLongCodec
 import io.bluetape4k.redis.lettuce.map.LettuceSuspendMap
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.junit.jupiter.api.Test
+import org.testcontainers.utility.Base58
+import java.util.concurrent.atomic.AtomicInteger
+
 class LettuceSuspendMemoizerTest: AbstractSuspendMemoizerTest() {
 
     companion object: KLogging() {
@@ -16,7 +28,7 @@ class LettuceSuspendMemoizerTest: AbstractSuspendMemoizerTest() {
     private val heavyMap = LettuceSuspendMap<Int>(intConnection, "memoizer:lettuce:suspend:heavy")
 
     override val heavyFunc: suspend (Int) -> Int = heavyMap.suspendMemoizer { x ->
-        Thread.sleep(100)
+        delay(100)
         x * x
     }
 
@@ -30,5 +42,80 @@ class LettuceSuspendMemoizerTest: AbstractSuspendMemoizerTest() {
         override val cachedCalc: suspend (Long) -> Long =
             LettuceSuspendMap<Long>(longConnection, "memoizer:lettuce:suspend:fibonacci")
                 .suspendMemoizer { calc(it) }
+    }
+
+    @Test
+    fun `evaluator 실패 후 같은 key를 다시 호출하면 새 계산으로 복구된다`() = runSuspendIO {
+        val map = LettuceSuspendMap<Int>(
+            intConnection,
+            "memoizer:lettuce:suspend:recovery:" + Base58.randomString(8)
+        )
+        map.clear()
+        val evalCount = AtomicInteger(0)
+        val memoizer = map.suspendMemoizer<Int, Int> { key ->
+            if (evalCount.incrementAndGet() == 1) {
+                error("transient failure")
+            }
+            key * key
+        }
+
+        assertFailsWith<IllegalStateException> {
+            memoizer(7)
+        }
+
+        // 실패한 in-flight Deferred가 제거되어야 같은 key가 이전 실패에 고착되지 않는다.
+        memoizer(7) shouldBeEqualTo 49
+        memoizer(7) shouldBeEqualTo 49
+        evalCount.get() shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `evaluator 취소 후 같은 key를 다시 호출하면 새 계산으로 복구된다`() = runSuspendIO {
+        val map = LettuceSuspendMap<Int>(
+            intConnection,
+            "memoizer:lettuce:suspend:cancel:" + Base58.randomString(8)
+        )
+        map.clear()
+        val evalCount = AtomicInteger(0)
+        val memoizer = map.suspendMemoizer<Int, Int> { key ->
+            if (evalCount.incrementAndGet() == 1) {
+                throw CancellationException("test cancellation")
+            }
+            key * key
+        }
+
+        assertFailsWith<CancellationException> {
+            memoizer(9)
+        }
+
+        // CancellationException도 성공 값처럼 저장하거나 in-flight에 남기지 않는다.
+        memoizer(9) shouldBeEqualTo 81
+        evalCount.get() shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `evaluator job 취소 후 같은 key를 다시 호출하면 새 계산으로 복구된다`() = runSuspendIO {
+        val map = LettuceSuspendMap<Int>(
+            intConnection,
+            "memoizer:lettuce:suspend:job-cancel:" + Base58.randomString(8)
+        )
+        map.clear()
+        val started = CompletableDeferred<Unit>()
+        val evalCount = AtomicInteger(0)
+        val memoizer = map.suspendMemoizer<Int, Int> { key ->
+            if (evalCount.incrementAndGet() == 1) {
+                started.complete(Unit)
+                delay(Long.MAX_VALUE)
+            }
+            key * key
+        }
+
+        val job = launch { memoizer(11) }
+        started.await()
+        job.cancelAndJoin()
+
+        // 실제 Job 취소 경로에서도 in-flight 항목이 정리되어 다음 호출이 새 계산으로 복구된다.
+        memoizer(11) shouldBeEqualTo 121
+        evalCount.get() shouldBeEqualTo 2
     }
 }

--- a/docs/lessons/2026-05-11-cache-lettuce-suspend-close-memoizer.md
+++ b/docs/lessons/2026-05-11-cache-lettuce-suspend-close-memoizer.md
@@ -1,0 +1,39 @@
+# Cache Lettuce Suspend Close 및 Memoizer 복구 Lessons
+
+## Context
+
+`cache/cache-lettuce` 모듈의 6-Tier 코드 리뷰, 누락 테스트 보강, 공개 API KDoc/README 정비를 진행했다. 핵심 범위는 `LettuceSuspendJCache`, `LettuceSuspendCacheManager`, `LettuceSuspendNearCache`, `LettuceSuspendMemoizer`의 suspend lifecycle 계약이었다.
+
+## Decision or Finding
+
+P0는 없었다. P1은 두 가지였다.
+
+- `runCatching` 기반 close 정리는 `CancellationException`을 일반 실패처럼 삼킬 수 있다. suspend API의 close 경로에서는 취소 신호를 명시적으로 재전파해야 한다.
+- `LettuceSuspendJCache.close()` KDoc이 Redis 데이터를 지운다고 설명했지만 실제 JCache 계약은 resource close와 data clear를 분리한다. 공개 API 문서가 구현과 다르면 사용자에게 데이터 삭제/보존 계약을 잘못 전달한다.
+
+추가로 확인한 P2는 다음과 같다.
+
+- 매니저 close 중 일부 cache close가 실패하거나 취소 예외를 던져도 나머지 cache close를 먼저 시도해야 한다.
+- memoizer의 in-flight `Deferred`는 영구 캐시 값이 아니라 동시성 조율 상태다. evaluator 실패나 취소가 in-flight에 남으면 같은 key의 다음 호출이 복구되지 못한다.
+- 예제의 transient failure는 실제로 두 번째 호출에서 성공하는 형태여야 한다. 같은 key를 계속 실패시키는 예제는 복구 계약을 설명하지 못한다.
+
+## Outcome
+
+- `LettuceSuspendNearCache.close()`는 resource별 close 실패를 로그로 남기되 `CancellationException`은 삼키지 않도록 바꿨다.
+- `LettuceSuspendCacheManager.close()`는 `NonCancellable` 정리 구간에서 등록 cache close를 끝까지 시도하고, 개별 cache close가 `CancellationException`을 명시적으로 던진 경우 잔여 정리 후 재전파하도록 정리했다.
+- `LettuceSuspendJCache.close()` KDoc과 README는 `close()`가 데이터를 삭제하지 않는다는 JCache 계약을 기준으로 맞췄다.
+- `LettuceSuspendMemoizer`는 evaluator 실패, 명시적 cancellation, 실제 `Job.cancel()` 경로 모두에서 in-flight 항목이 제거되고 같은 key가 새 계산으로 복구되는 테스트를 갖게 됐다.
+
+## Verification
+
+- `./gradlew :bluetape4k-cache-lettuce:compileKotlin :bluetape4k-cache-lettuce:compileTestKotlin :bluetape4k-cache-lettuce:test --tests '*LettuceSuspendMemoizerTest'` 통과.
+- `./gradlew :bluetape4k-cache-lettuce:test` 통과: 353 passing, 4 pending.
+- `git diff --check` 통과.
+- 외부 6-Tier 최종 게이트 결과: P0 없음, P1 없음.
+
+## Future Guidance
+
+- suspend close 경로에서 `runCatching`을 사용할 때는 `CancellationException`이 삼켜지는지 먼저 확인한다. 필요하면 `try/catch`로 분해해 취소 신호를 명시적으로 재전파한다.
+- close가 resource 해제인지 data 삭제인지 KDoc, README, 테스트에서 같은 용어로 고정한다. `close()`와 `clear()/destroy()`의 계약을 섞지 않는다.
+- memoizer 복구 테스트는 실패 예외, 명시적 `CancellationException`, 실제 `Job.cancel()`을 분리해 둔다. 세 경로는 모두 in-flight cleanup을 검증하지만, 실패 원인이 다르다.
+- transient failure 예제는 반드시 재시도에서 성공하도록 작성한다. 그래야 사용자가 실패 결과를 캐시하지 않는다는 계약을 바로 이해할 수 있다.


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: [cache-lettuce] suspend lifecycle 계약 보강

`cache/cache-lettuce` 모듈의 6-Tier 코드 리뷰 결과를 반영해 suspend close/memoizer lifecycle 계약을 보강했습니다.

- `LettuceSuspendNearCache.close()`가 `CancellationException`을 삼키지 않도록 `runCatching` 기반 close를 분해했습니다.
- `LettuceSuspendCacheManager.close()`가 non-cancellable 정리 구간에서 등록 cache close를 끝까지 시도하도록 정리했습니다.
- `LettuceSuspendJCache.close()` KDoc/README를 JCache close 계약에 맞춰 데이터 보존 의미로 수정했습니다.
- suspend memoizer 실패, 명시적 cancellation, 실제 `Job.cancel()` 복구 테스트를 추가했습니다.
- Lessons를 `docs/lessons/2026-05-11-cache-lettuce-suspend-close-memoizer.md`에 한국어로 기록했습니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 6-Tier P0/P1 Gate

초기 리뷰 결과:

| 등급 | 항목 | 조치 |
| --- | --- | --- |
| P0 | 없음 | - |
| P1 | suspend close 경로에서 `runCatching`이 `CancellationException`을 삼킬 수 있음 | `try/catch` 및 `NonCancellable` 정리 구간으로 보강 |
| P1 | `LettuceSuspendJCache.close()` KDoc이 데이터 삭제처럼 설명됨 | JCache close/clear 계약에 맞춰 KDoc/README 수정 |

최종 외부 6-Tier 게이트: P0 없음, P1 없음. P2로 지적된 실제 `Job.cancel()` 경로 테스트와 README 표현 보정도 반영했습니다.

### 기존 섹션: 비고

`qmd update`는 실행했지만 현재 컬렉션이 루트 repo 문서 경로를 기준으로 하므로, worktree 내부의 새 Lessons 파일은 merge 후 루트 worktree에 들어오면 정상 인덱싱됩니다.

## Validation

- `./gradlew :bluetape4k-cache-lettuce:compileKotlin :bluetape4k-cache-lettuce:compileTestKotlin :bluetape4k-cache-lettuce:test --tests '*LettuceSuspendMemoizerTest'`
- `./gradlew :bluetape4k-cache-lettuce:test` → 354 passing, 4 pending
- `git diff --check`
- `qmd update && qmd embed --max-docs-per-batch 16`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #406, head `55eeab9b2568de531531b129c5b1eb5a59656351`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/cache-lettuce-review-tests-docs`
- Labels: `bug`, `documentation`, `chore`
- State: `MERGED`, merge commit `0248a82a61a890f5c15fd39dbf25a9d98bef6e71`
- CI: - `./gradlew :bluetape4k-cache-lettuce:compileKotlin :bluetape4k-cache-lettuce:compileTestKotlin :bluetape4k-cache-lettuce:test --tests '*LettuceSuspendMemoizerTest'` / - `./gradlew :bluetape4k-cache-lettuce:test` → 354 passing, 4 pending

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #406 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `0248a82a61a890f5c15fd39dbf25a9d98bef6e71`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
