### PR TITLE
[cache-redisson] suspend lifecycle와 README API drift 보강

### DIFF
--- a/cache/cache-redisson/README.ko.md
+++ b/cache/cache-redisson/README.ko.md
@@ -2,590 +2,114 @@
 
 [English](./README.md) | 한국어
 
-`bluetape4k-cache-redisson`은 Redisson 기반 JCache Provider, Coroutines 캐시 구현, Memoizer, 그리고 다양한 **2-Tier Near Cache
-** 구현을 제공합니다.
+`bluetape4k-cache-redisson`은 Redisson 기반 cache adapter를 bluetape4k cache API에 맞춰 제공합니다. 핵심 범위는 Redisson JCache 연동, coroutine 친화 wrapper, Redisson `RLocalCachedMap` 기반 near cache, Redis-backed memoizer입니다.
 
-> 기존 `bluetape4k-cache-redisson-near` 모듈이 이 모듈에 통합되었습니다.
+## 제공 API
 
-## 제공 기능
+| API | Package | 목적 |
+| --- | --- | --- |
+| `RedissonJCaching` | `jcache` | Redisson JCache provider helper |
+| `RedissonSuspendJCache<K, V>` | `jcache` | Redisson JCache를 감싼 `SuspendJCache` |
+| `RedissonNearCache<V>` | `nearcache` | `RLocalCachedMap` 기반 동기 `NearCacheOperations` |
+| `RedissonSuspendNearCache<V>` | `nearcache` | `RLocalCachedMap` 기반 suspend `SuspendNearCacheOperations` |
+| `RedissonCaches` | root package | JCache, suspend JCache, near cache factory |
+| `RedissonMemoizer<T, R>` | `memoizer` | 동기 Redis-backed memoizer |
+| `RedissonAsyncMemoizer<T, R>` | `memoizer` | `CompletableFuture`/`CompletionStage` memoizer |
+| `RedissonSuspendMemoizer<T, R>` | `memoizer` | key별 in-flight 공유를 제공하는 coroutine memoizer |
 
-| 클래스                                         | 패키지         | 설명                                                                              |
-|---------------------------------------------|-------------|---------------------------------------------------------------------------------|
-| `org.redisson.jcache.JCachingProvider`      | —           | Redisson JCache Provider                                                        |
-| `RedissonNearCachingProvider`               | `nearcache` | Redisson Near Cache JCache Provider                                             |
-| `RedissonSuspendCache`                      | `jcache`    | JCache 기반 코루틴 캐시                                                                |
-| `RedissonNearCache`                         | `nearcache` | Caffeine(front) + Redisson LocalCachedMap(back) 2-Tier Near Cache               |
-| `RedissonSuspendNearCache`                  | `nearcache` | Near Cache 코루틴 래퍼                                                               |
-| `RedissonResp3NearCache<V>`                 | `nearcache` | Redisson(RBucket) + Lettuce RESP3(invalidation) 하이브리드 NearCache — write-through |
-| `RedissonResp3SuspendNearCache<V>`          | `nearcache` | RESP3 하이브리드 NearCache 코루틴 구현 — write-through                                    |
-| `ResilientRedissonResp3NearCache<V>`        | `nearcache` | RESP3 하이브리드 + write-behind + Resilience4j retry (동기)                            |
-| `ResilientRedissonResp3SuspendNearCache<V>` | `nearcache` | RESP3 하이브리드 + write-behind + Resilience4j retry (코루틴)                           |
-| `RedissonMemoizer<T, R>`                    | `memoizer`  | RMap 기반 동기 메모이저                                                                 |
-| `RedissonAsyncMemoizer<T, R>`               | `memoizer`  | RMap 기반 비동기(CompletableFuture) 메모이저                                             |
-| `RedissonSuspendMemoizer<T, R>`             | `memoizer`  | RMap 기반 suspend 메모이저                                                            |
-
-`RedissonNearCacheConfig` 제약:
-
-- `cacheName`은 공백일 수 없습니다.
-- `maxLocalSize`는 0보다 커야 합니다.
-- `timeToLive`, `maxIdle`은 지정 시 0보다 커야 합니다.
+이 모듈은 RESP3 hybrid near-cache class를 제공하지 않습니다. Redisson-managed local caching이 필요하면 실제 public API인 `RedissonNearCache` / `RedissonSuspendNearCache`를 사용하세요.
 
 ## 의존성
 
 ```kotlin
-// build.gradle.kts
 dependencies {
     implementation("io.github.bluetape4k:bluetape4k-cache-redisson:$bluetape4kVersion")
-
-    // RESP3 NearCache 사용 시 — Redis 6.0+ 필요
-    // (lettuce-core는 bluetape4k-cache-redisson에 포함됨)
 }
 ```
 
-## 사용 예시
+## 권장 사용 시나리오
 
-### 1. RedissonSuspendCache
+- 이미 Redisson을 사용하고 있고 bluetape4k의 `JCache`, `SuspendJCache`, `NearCacheOperations`, `SuspendNearCacheOperations`와 맞춘 cache API가 필요할 때.
+- 같은 JVM 안에서 같은 key의 중복 계산을 줄이고, 완료된 값은 Redis `RMap`에 저장하는 memoizer가 필요할 때.
+- 별도 local cache와 Redis invalidation 계층을 직접 유지하지 않고 Redisson `RLocalCachedMap`의 invalidation 동작을 사용하고 싶을 때.
+- coroutine call site에서 Redisson async operation을 blocking 없이 `await()`하고 싶을 때.
 
-JCache 기반 코루틴 캐시입니다.
+## Anti-Patterns
 
-```kotlin
-import io.bluetape4k.cache.jcache.RedissonSuspendCache
-import io.bluetape4k.cache.jcache.jcacheConfiguration
+- `close()`를 데이터 삭제로 해석하지 마세요. `close()`는 wrapper/provider resource lifecycle 계약이고, entry 삭제는 `clear()` 또는 `clearAll()`을 명시적으로 호출해야 합니다.
+- 이 모듈에 없는 RESP3 helper API를 문서화하거나 호출하지 마세요. 현재 public surface는 위 표의 Redisson/JCache/RLocalCachedMap 기반 API입니다.
+- 외부 side effect가 있는 비멱등 연산을 memoizer evaluator에 넣지 마세요. evaluator 실패나 취소는 성공 값으로 캐시되지 않으므로 재시도 시 evaluator가 다시 실행될 수 있습니다.
+- `RedissonSuspendMemoizer`의 in-flight 공유를 JVM 간 분산 락처럼 기대하지 마세요. 완료 값은 Redis에 저장되지만 in-flight 조율 map은 프로세스 로컬입니다.
 
-val config = jcacheConfiguration<String, Any> { }
-val suspendCache = RedissonSuspendCache("redis-cache", redissonClient, config)
+## 예제
 
-suspendCache.put("key", "value")
-val value = suspendCache.get("key")
-```
-
----
-
-## 클래스 구조
-
-### RedissonNearCache 계층
-
-```mermaid
-classDiagram
-    class NearCacheOperations {
-        <<interface>>
-        +cacheName: String
-        +isClosed: Boolean
-        +get(key) V?
-        +getAll(keys) Map
-        +put(key, value)
-        +putIfAbsent(key, value) V?
-        +remove(key)
-        +clearLocal()
-        +clearAll()
-        +stats() NearCacheStatistics
-        +close()
-    }
-
-    class SuspendNearCacheOperations {
-        <<interface>>
-        +cacheName: String
-        +isClosed: Boolean
-        +get(key) V?
-        +put(key, value)
-        +remove(key)
-        +clearLocal()
-        +clearAll()
-        +stats() NearCacheStatistics
-        +close()
-    }
-
-    class RedissonNearCache {
-        -redisson: RedissonClient
-        -config: RedissonNearCacheConfig
-        -codec: Codec
-        -localCachedMap: RLocalCachedMap
-    }
-
-    class RedissonSuspendNearCache {
-        -redisson: RedissonClient
-        -config: RedissonNearCacheConfig
-        -codec: Codec
-        -localCachedMap: RLocalCachedMap
-    }
-
-    class RedissonNearCacheConfig {
-        +cacheName: String
-        +maxLocalSize: Int
-        +evictionPolicy: EvictionPolicy
-        +syncStrategy: SyncStrategy
-        +reconnectionStrategy: ReconnectionStrategy
-        +timeToLive: Duration?
-        +maxIdle: Duration?
-    }
-
-    class RLocalCachedMap {
-        <<Redisson내장2tier>>
-        +get(key) V?
-        +put(key, value)
-        +getAsync(key) RFuture
-        +putAsync(key, value) RFuture
-        +clearLocalCache()
-        +cachedKeySet() Set
-    }
-
-    NearCacheOperations <|.. RedissonNearCache
-    SuspendNearCacheOperations <|.. RedissonSuspendNearCache
-    RedissonNearCache --> RLocalCachedMap: localCachedMap
-    RedissonNearCache --> RedissonNearCacheConfig: config
-    RedissonSuspendNearCache --> RLocalCachedMap: localCachedMap
-    RedissonSuspendNearCache --> RedissonNearCacheConfig: config
-
-    style NearCacheOperations fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
-    style SuspendNearCacheOperations fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
-    style RedissonNearCache fill:#E0F2F1,stroke:#80CBC4,color:#00695C
-    style RedissonSuspendNearCache fill:#F3E5F5,stroke:#CE93D8,color:#6A1B9A
-    style RedissonNearCacheConfig fill:#F57F17,stroke:#E65100,color:#000000
-    style RLocalCachedMap fill:#ECEFF1,stroke:#B0BEC5,color:#37474F
-
-```
-
-### RLocalCachedMap 내장 Invalidation 흐름
-
-```mermaid
-sequenceDiagram
-    participant App1 as Application (인스턴스 1)
-    participant NC1 as RedissonNearCache (인스턴스 1)
-    participant LCM1 as RLocalCachedMap (인스턴스 1)
-    participant Redis as Redis Server
-    participant LCM2 as RLocalCachedMap (인스턴스 2)
-    participant NC2 as RedissonNearCache (인스턴스 2)
-    Note over LCM1, LCM2: Redisson이 pub/sub 기반 자동 invalidation 관리
-    App1 ->> NC1: put("key", newValue)
-    NC1 ->> LCM1: put("key", newValue)
-    LCM1 ->> Redis: SET key newValue
-    LCM1 ->> Redis: PUBLISH invalidation topic
-    Note over Redis, LCM2: Redisson pub/sub invalidation 전파
-    Redis ->> LCM2: SUB invalidation ("key")
-    LCM2 ->> LCM2: 로컬 캐시에서 "key" 제거
-    Note over NC2: 다음 get("key") 시 Redis에서 최신값 조회
-    App1 ->> NC2: get("key")
-    NC2 ->> LCM2: get("key")
-    LCM2 ->> Redis: GET key
-    Redis -->> LCM2: newValue
-    LCM2 -->> NC2: newValue
-    NC2 -->> App1: newValue
-```
-
----
-
-### 2. Redisson Near Cache (2-Tier)
-
-Caffeine 로컬 캐시 + Redisson LocalCachedMap 분산 캐시를 조합한 2-tier Near Cache입니다.
-
-```kotlin
-import io.bluetape4k.cache.nearcache.RedissonNearCache
-import io.bluetape4k.cache.nearcache.RedissonNearCacheConfig
-
-val nearConfig = RedissonNearCacheConfig<String, Any>()
-val nearCache = RedissonNearCache<String, Any>("redis-near", redissonClient, nearConfig)
-
-nearCache.put("key", "value")
-val value = nearCache.get("key")   // 로컬 Caffeine에서 우선 조회
-```
-
-### 3. RedissonSuspendNearCache (코루틴)
-
-```kotlin
-import io.bluetape4k.cache.nearcache.RedissonSuspendNearCache
-
-val nearSuspend = RedissonSuspendNearCache<String, Any>("redis-near-suspend", redissonClient)
-nearSuspend.put("key", "value")
-val value = nearSuspend.get("key")
-```
-
----
-
-### 4. Memoizer — 함수 결과 Redis 캐싱
-
-`RMap`을 사용해 함수 호출 결과를 Redis에 저장하고, 동일 키 재호출 시 저장된 값을 반환합니다. 같은 JVM에서 동일 키가 동시에 요청되면 in-flight 연산을 공유하여 중복 실행을 방지합니다.
-
-#### 동기 Memoizer
-
-```kotlin
-import io.bluetape4k.cache.memoizer.RedissonMemoizer
-
-val map: RMap<Int, Int> = redissonClient.getMap("squares")
-
-// RMap 확장 함수로 생성
-val memoizer = map.memoizer { key -> key * key }
-
-val result1 = memoizer(5)   // 25 — 계산 후 Redis에 저장
-val result2 = memoizer(5)   // 25 — Redis에서 반환
-
-// 함수에 직접 연결하는 방식도 지원
-val fn: (Int) -> Int = { it * it }
-val memoizer2 = fn.memoizer(map)
-```
-
-#### 비동기 Memoizer (CompletableFuture)
-
-```kotlin
-import io.bluetape4k.cache.memoizer.RedissonAsyncMemoizer
-
-val asyncMemoizer = map.asyncMemoizer { key ->
-    CompletableFuture.supplyAsync { key * key }
-}
-
-val future = asyncMemoizer(5)   // CompletableFuture<Int>
-val result = future.get()       // 25
-```
-
-#### suspend Memoizer (코루틴)
-
-```kotlin
-import io.bluetape4k.cache.memoizer.RedissonSuspendMemoizer
-
-val suspendMemoizer = map.suspendMemoizer { key ->
-    // suspend 함수 호출 가능
-    computeExpensive(key)
-}
-
-val result = suspendMemoizer(5)   // suspend 호출
-```
-
----
-
-### 5. Spring Boot 설정 (Near Cache Provider 사용)
-
-```kotlin
-@Configuration
-@EnableCaching
-class CacheConfig {
-    @Bean
-    fun cacheManager(redissonClient: RedissonClient): CacheManager {
-        val config = RedissonNearCacheConfig<String, Any>()
-        return RedissonNearCacheManager(redissonClient, config)
-    }
-}
-```
-
-또는 `application.properties`:
-
-```properties
-spring.cache.jcache.provider=io.bluetape4k.cache.nearcache.RedissonNearCachingProvider
-```
-
-### 6. Spring `@Cacheable`과 함께 사용
-
-```kotlin
-@Service
-class UserService {
-    @Cacheable("users")
-    fun findUser(id: Long): User = TODO()
-}
-```
-
----
-
-### 7. RESP3 NearCache (Redisson + Lettuce RESP3 하이브리드)
-
-기존 JCache 기반 Near Cache의 bulk 연산 이벤트 미발행 버그를 해결한 하이브리드 구현입니다. 데이터 연산은 Redisson
-`RBucket`을 사용하고, invalidation은 Lettuce RESP3 CLIENT TRACKING push를 사용합니다.
-
-> **Redis 6.0+ 필요**: RESP3 프로토콜과 CLIENT TRACKING은 Redis 6.0 이상에서만 지원됩니다.
-
-#### 아키텍처
-
-```
-Application
-    |
-[RedissonResp3NearCache]
-    |
-+--------+---------+------------------+
-|        |         |                  |
-Front   Back     Tracking
-Caffeine Redisson  Lettuce RESP3
-(local) (RBucket)  (CLIENT TRACKING push)
-```
-
-- **Read**: front hit → return / front miss → Redisson GET + Lettuce tracking GET → front 저장 → return
-- **Write**: front put + Redisson SET (write-through)
-- **Invalidation**: 다른 클라이언트가 키를 변경하면 RESP3 CLIENT TRACKING push → 로컬 캐시 자동 무효화
-
-#### RESP3 Lettuce RedisClient 설정
-
-```kotlin
-import io.lettuce.core.ClientOptions
-import io.lettuce.core.RedisClient
-import io.lettuce.core.protocol.ProtocolVersion
-
-val resp3Client = RedisClient.create("redis://localhost:6379").also { client ->
-    client.options = ClientOptions.builder()
-        .protocolVersion(ProtocolVersion.RESP3)
-        .build()
-}
-```
-
-#### 동기 버전
-
-```kotlin
-import io.bluetape4k.cache.nearcache.RedissonResp3NearCache
-import io.bluetape4k.cache.nearcache.RedissonResp3NearCacheConfig
-
-val config = RedissonResp3NearCacheConfig(
-    cacheName = "my-cache",
-    maxLocalSize = 10_000,
-    frontExpireAfterWrite = Duration.ofMinutes(30),
-    redisTtl = null,              // Redis TTL (null = 만료 없음)
-    useRespProtocol3 = true,      // RESP3 CLIENT TRACKING 활성화
-)
-val nearCache = RedissonResp3NearCache(
-    redisson = redissonClient,
-    redisClient = resp3Client,
-    config = config,
-)
-
-nearCache.put("key", "value")
-nearCache.get("key")       // 로컬 Caffeine에서 우선 조회
-nearCache.clearLocal()     // 로컬 캐시만 초기화 (Redis 유지)
-nearCache.clearAll()       // 로컬 + Redis 모두 초기화
-nearCache.close()
-```
-
-#### Suspend (코루틴) 버전
-
-```kotlin
-import io.bluetape4k.cache.nearcache.RedissonResp3SuspendNearCache
-
-val suspendCache = RedissonResp3SuspendNearCache(
-    redisson = redissonClient,
-    redisClient = resp3Client,
-    config = config,
-)
-
-suspendCache.put("key", "value")
-val value = suspendCache.get("key")
-suspendCache.close()
-```
-
-#### NOLOOP 동작 주의사항
-
-Redisson 데이터 연결과 Lettuce tracking 연결은 서로 다른 연결입니다. 따라서 자신이 Redisson으로 쓴 키도 Lettuce tracking 연결에 invalidation이 전파될 수 있습니다. 이는
-`bluetape4k-cache-lettuce`의 단일 연결 방식(NOLOOP 보장)과 다른 동작입니다.
-
----
-
-### 8. ResilientRedissonResp3NearCache (write-behind + retry)
-
-RESP3 하이브리드 NearCache에 write-behind 패턴과 Resilience4j Retry를 추가한 구현입니다. Redis 일시 장애 시에도 로컬 캐시는 정상 동작하고, Redis 쓰기는 백그라운드에서 재시도합니다.
-
-#### 아키텍처
-
-```
-Application
-    |
-[ResilientRedissonResp3NearCache]
-    |
-+--------+------------------+------------------+
-|        |                  |                  |
-Front   Write Queue        Tracking
-Caffeine (LinkedBlocking    Lettuce RESP3
-(즉시)   Queue / Channel)   (CLIENT TRACKING push)
-         |
-         Consumer (virtualThread / coroutine)
-         (Resilience4j Retry → Redisson RBucket set/delete)
-```
-
-- **write-behind**: put/remove → front 즉시 반영, Redis 쓰기는 백그라운드 큐로 비동기 처리
-- **tombstone**: pending delete 키를 추적하여 stale read 방지
-- **retry**: Resilience4j Retry로 Redis 쓰기 실패 시 자동 재시도
-- **invalidation**: Lettuce RESP3 CLIENT TRACKING push → 로컬 캐시 무효화
-
-#### 동기 버전
-
-```kotlin
-import io.bluetape4k.cache.nearcache.ResilientRedissonResp3NearCache
-import io.bluetape4k.cache.nearcache.ResilientRedissonResp3NearCacheConfig
-import io.bluetape4k.cache.nearcache.RedissonResp3NearCacheConfig
-
-val cache = ResilientRedissonResp3NearCache<String>(
-    redisson = redissonClient,
-    redisClient = resp3Client,
-    config = ResilientRedissonResp3NearCacheConfig(
-        base = RedissonResp3NearCacheConfig(cacheName = "orders"),
-        retryMaxAttempts = 3,
-        retryWaitDuration = Duration.ofMillis(200),
-        writeQueueCapacity = 1024,
-    ),
-)
-
-cache.put("key", "value")    // front 즉시 반영, Redis는 write-behind
-cache.get("key")             // front hit → 즉시 반환
-cache.localCacheSize()       // 로컬 Caffeine 크기
-cache.backCacheSize()        // Redis 키 개수
-cache.clearAll()             // front 즉시 초기화, Redis는 write-behind
-cache.close()
-```
-
-#### Suspend (코루틴) 버전
-
-```kotlin
-import io.bluetape4k.cache.nearcache.ResilientRedissonResp3SuspendNearCache
-
-val cache = ResilientRedissonResp3SuspendNearCache<String>(
-    redisson = redissonClient,
-    redisClient = resp3Client,
-    config = ResilientRedissonResp3NearCacheConfig(
-        base = RedissonResp3NearCacheConfig(cacheName = "sessions"),
-    ),
-)
-
-cache.put("session-1", "token-abc")
-val token = cache.get("session-1")
-cache.close()
-```
-
-#### ResilientRedissonResp3NearCacheConfig 옵션
-
-| 옵션                        | 기본값                              | 설명                    |
-|---------------------------|----------------------------------|-----------------------|
-| `base`                    | `RedissonResp3NearCacheConfig()` | 기본 RESP3 NearCache 설정 |
-| `writeQueueCapacity`      | `1024`                           | write-behind 큐 최대 용량  |
-| `retryMaxAttempts`        | `3`                              | Redis 쓰기 최대 재시도 횟수    |
-| `retryWaitDuration`       | `500ms`                          | 재시도 대기 시간             |
-| `retryExponentialBackoff` | `true`                           | 지수 백오프 사용 여부          |
-| `getFailureStrategy`      | `RETURN_FRONT_OR_NULL`           | Redis GET 실패 시 동작 전략  |
-
----
-
-## JCache 기반 NearCache (nearcache.jcache 패키지)
-
-`NearJCache<K,V>` /
-`SuspendNearJCache<K,V>`는 JCache 인터페이스를 직접 구현하는 2-tier 캐시입니다. Caffeine(front) + Redisson JCache(back) 구조입니다.
-
-```mermaid
-classDiagram
-    class NearJCache~K_V~ {
-        +frontCache: JCache~K_V~
-        +backCache: JCache~K_V~
-        -config: NearJCacheConfig~K_V~
-        +invoke(config, backCache) NearJCache
-    }
-
-    class SuspendNearJCache~K_V~ {
-        -frontCache: SuspendJCache~K_V~
-        -backCache: SuspendJCache~K_V~
-        +invoke(front, back) SuspendNearJCache
-        +get(key: K) V?
-        +put(key: K, value: V)
-        +close()
-    }
-
-    class RedissonSuspendJCache~K_V~ {
-        -redisson: RedissonClient
-        -cacheName: String
-        RMap 기반 SuspendJCache
-    }
-
-    class CaffeineSuspendJCache~K_V~ {
-        Caffeine AsyncCache 기반
-        (frontCache 역할)
-    }
-
-    class NearJCacheConfig~K_V~ {
-        +cacheName: String
-        +isSynchronous: Boolean
-        +syncRemoteTimeout: Long
-    }
-
-    NearJCache --> NearJCacheConfig
-    SuspendNearJCache --> CaffeineSuspendJCache: frontCache
-    SuspendNearJCache --> RedissonSuspendJCache: backCache
-```
-
-### 팩토리 네이밍 규칙
-
-| 함수명                       | 반환 타입                           | 설명                     |
-|---------------------------|---------------------------------|------------------------|
-| `nearJCache()`            | `NearJCache<K,V>`               | JCache 기반 동기 2-Tier    |
-| `suspendNearJCache()`     | `SuspendNearJCache<K,V>`        | JCache 기반 코루틴 2-Tier   |
-| `nearCache()`             | `NearCacheOperations<V>`        | RLocalCachedMap 기반 동기  |
-| `suspendNearCache()`      | `SuspendNearCacheOperations<V>` | RLocalCachedMap 기반 코루틴 |
-| `resp3NearCache()`        | `NearCacheOperations<V>`        | RESP3 하이브리드 동기         |
-| `resp3SuspendNearCache()` | `SuspendNearCacheOperations<V>` | RESP3 하이브리드 코루틴        |
-
-### NearJCache 사용 예
-
-```kotlin
-// NearJCache (동기)
-val cache = RedissonCaches.nearJCache<String, String>("orders-near-jcache", redisson)
-cache.put("order-1", "data")
-val value = cache.get("order-1")   // front(Caffeine) → back(Redisson JCache) 순으로 조회
-cache.close()
-
-// SuspendNearJCache (코루틴)
-val suspendCache = RedissonCaches.suspendNearJCache<String, String>("sessions-near-jcache", redisson)
-suspendCache.put("session-1", "token-abc")
-val token = suspendCache.get("session-1")
-suspendCache.close()
-```
-
----
-
-## Factory (RedissonCaches)
-
-`RedissonCaches` 오브젝트를 사용하면 모든 캐시 타입을 한 곳에서 생성할 수 있습니다.
+### Suspend JCache
 
 ```kotlin
 import io.bluetape4k.cache.RedissonCaches
+import javax.cache.configuration.MutableConfiguration
 
-// JCache
-val jcache = RedissonCaches.jcache<String, String>("my-cache", redisson)
+val cache = RedissonCaches.suspendJCache<String, String>(
+    redisson = redissonClient,
+    cacheName = "users",
+    configuration = MutableConfiguration<String, String>().apply {
+        setTypes(String::class.java, String::class.java)
+    },
+)
 
-// SuspendCache
-val sc = RedissonCaches.suspendCache<String, String>("my-cache", redisson)
+cache.put("u:1", "debop")
+val user = cache.get("u:1")
+// user == "debop"
 
-// NearJCache — JCache 기반 2-Tier (동기)
-val nearJCache = RedissonCaches.nearJCache<String, String>("my-near-jcache", redisson)
-
-// SuspendNearJCache — JCache 기반 2-Tier (코루틴)
-val suspendNearJCache = RedissonCaches.suspendNearJCache<String, String>("my-near-jcache", redisson)
-
-// NearCache — RLocalCachedMap 기반 (동기)
-val near = RedissonCaches.nearCache<String>("my-near", redisson)
-
-// SuspendNearCache — RLocalCachedMap 기반 (코루틴)
-val suspendNear = RedissonCaches.suspendNearCache<String>("my-near", redisson)
-
-// RESP3 NearCache (Redisson + Lettuce tracking)
-val resp3 = RedissonCaches.resp3NearCache<String>(redisson, redisClient)
-
-// RESP3 SuspendNearCache
-val resp3Suspend = RedissonCaches.resp3SuspendNearCache<String>(redisson, redisClient)
-
-// Resilient RESP3 NearCache
-val resilient = RedissonCaches.resilientResp3NearCache<String>(redisson, redisClient)
-
-// Resilient RESP3 SuspendNearCache
-val resilientSuspend = RedissonCaches.resilientResp3SuspendNearCache<String>(redisson, redisClient)
+cache.close()
 ```
 
----
-
-## CachingProvider 등록 목록
-
-`META-INF/services/javax.cache.spi.CachingProvider`에 등록된 Provider:
-
-```
-org.redisson.jcache.JCachingProvider
-io.bluetape4k.cache.nearcache.RedissonNearCachingProvider
-```
-
-클래스패스에 여러 Provider가 공존할 때는 명시적으로 지정하세요:
+### Native Redisson Near Cache
 
 ```kotlin
-val provider = Caching.getCachingProvider("io.bluetape4k.cache.nearcache.RedissonNearCachingProvider")
+import io.bluetape4k.cache.RedissonCaches
+import io.bluetape4k.cache.nearcache.RedissonNearCacheConfig
+
+val nearCache = RedissonCaches.nearCache<String>(
+    redisson = redissonClient,
+    config = RedissonNearCacheConfig(cacheName = "products"),
+)
+
+nearCache.put("p:1", "keyboard")
+val product = nearCache.get("p:1")
+nearCache.clearLocal()   // local tier만 정리
+nearCache.clearAll()     // local + Redis tier 모두 정리
+nearCache.close()
 ```
 
-## Redis 버전 요구사항
+### Suspend Memoizer
 
-| 기능                                         | 최소 Redis 버전 |
-|--------------------------------------------|-------------|
-| JCache, Near Cache (LocalCachedMap 기반)     | Redis 5.0+  |
-| RESP3 NearCache, Resilient RESP3 NearCache | Redis 6.0+  |
+```kotlin
+import io.bluetape4k.cache.memoizer.suspendMemoizer
+import org.redisson.client.codec.IntegerCodec
+
+val map = redissonClient.getMap<Int, Int>("memoizer:squares", IntegerCodec())
+val memoizer = map.suspendMemoizer { key ->
+    expensiveSquare(key)
+}
+
+val first = memoizer(7)   // 계산 후 49 저장
+val second = memoizer(7)  // 캐시된 49 반환
+```
+
+evaluator가 실패하거나 취소되면 in-flight 항목은 예외 완료 후 제거됩니다. 따라서 같은 key의 다음 호출은 실패한 `Deferred`에 고착되지 않고 새 계산을 시작합니다.
+
+## Lifecycle Notes
+
+- `RedissonSuspendJCache.close()`는 감싼 Redisson JCache에 close를 위임하며 저장된 entry를 삭제하지 않습니다.
+- `RedissonSuspendNearCache.close()`는 local cached map wrapper를 destroy하고 wrapper를 닫힘 상태로 표시합니다. entry 삭제는 `clearAll()`의 책임입니다.
+- suspend close 경로는 `runCatching`으로 `CancellationException`을 삼키지 않고 호출자에게 전파합니다.
+
+## 검증 초점
+
+관련 테스트는 다음 축을 포함합니다.
+
+- JCache CRUD와 close/data-preservation 동작.
+- native near-cache read/write/clear/stat 동작.
+- `MultithreadingTester`, `StructuredTaskScopeTester`, `SuspendedJobTester` 기반 memoizer thread, virtual-thread, coroutine 경합.
+- suspend memoizer evaluator 실패, 명시적 cancellation, 실제 `Job.cancel()` 복구.

--- a/cache/cache-redisson/README.md
+++ b/cache/cache-redisson/README.md
@@ -2,18 +2,22 @@
 
 English | [한국어](./README.ko.md)
 
-`bluetape4k-cache-redisson` provides a Redisson-based JCache provider, coroutine-friendly cache implementations, memoizers, and multiple
-**2-tier Near Cache** implementations.
+`bluetape4k-cache-redisson` provides Redisson-backed cache adapters for the bluetape4k cache APIs. It focuses on JCache integration, coroutine-friendly wrappers, Redisson `RLocalCachedMap` near caches, and Redis-backed memoizers.
 
-> The former `bluetape4k-cache-redisson-near` module was merged into this module.
+## Provided APIs
 
-## Provided Features
+| API | Package | Purpose |
+| --- | --- | --- |
+| `RedissonJCaching` | `jcache` | Redisson JCache provider helper |
+| `RedissonSuspendJCache<K, V>` | `jcache` | `SuspendJCache` wrapper over Redisson JCache |
+| `RedissonNearCache<V>` | `nearcache` | synchronous `NearCacheOperations` backed by `RLocalCachedMap` |
+| `RedissonSuspendNearCache<V>` | `nearcache` | suspend `SuspendNearCacheOperations` backed by `RLocalCachedMap` |
+| `RedissonCaches` | root package | factory methods for JCache, suspend JCache, and near caches |
+| `RedissonMemoizer<T, R>` | `memoizer` | synchronous Redis-backed memoizer |
+| `RedissonAsyncMemoizer<T, R>` | `memoizer` | `CompletableFuture`/`CompletionStage` memoizer |
+| `RedissonSuspendMemoizer<T, R>` | `memoizer` | coroutine memoizer with per-key in-flight sharing |
 
-- Redisson JCache provider and near-cache JCache provider
-- `RedissonSuspendCache`
-- `RedissonNearCache` / `RedissonSuspendNearCache`
-- RESP3 hybrid near-cache variants backed by Redisson storage plus Lettuce invalidation
-- sync / async / suspend memoizers based on `RMap`
+This module does not expose RESP3 hybrid near-cache classes. Use the actual `RedissonNearCache` / `RedissonSuspendNearCache` APIs when you want Redisson-managed local caching.
 
 ## Dependency
 
@@ -23,142 +27,89 @@ dependencies {
 }
 ```
 
-RESP3 near-cache usage requires Redis 6.0 or newer.
+## Recommended Scenarios
 
-## Usage Examples
+- You already use Redisson and want cache APIs aligned with bluetape4k `JCache`, `SuspendJCache`, `NearCacheOperations`, or `SuspendNearCacheOperations`.
+- You need a Redis-backed memoizer that shares in-flight work inside one JVM and stores completed values in `RMap`.
+- You want Redisson's `RLocalCachedMap` invalidation behavior instead of maintaining a separate local cache plus Redis synchronization layer.
+- You need coroutine call sites to await Redisson async operations without blocking application threads.
 
-Typical usage includes:
+## Anti-Patterns
 
-- `RedissonSuspendCache`
-- local-plus-remote near caching through `RedissonNearCache`
-- coroutine near cache through `RedissonSuspendNearCache`
-- memoization of expensive function results in Redis
-- Spring Boot integration through a Redisson cache manager or explicit provider configuration
+- Do not treat `close()` as data deletion. `close()` releases the wrapper/provider resource; use `clear()` or `clearAll()` when entries must be removed.
+- Do not document or call non-existent RESP3 helper APIs from this module. The public surface is the Redisson/JCache/RLocalCachedMap set listed above.
+- Do not use a memoizer for non-idempotent side effects. Failed or cancelled evaluator calls are not cached as successful values, so retries can re-run the evaluator.
+- Do not expect `RedissonSuspendMemoizer` in-flight sharing to cross JVM boundaries. Redis stores completed values, but the in-flight coordination map is process-local.
 
-## Class Structure
+## Examples
 
-The core structure includes:
+### Suspend JCache
 
-- `NearCacheOperations` / `SuspendNearCacheOperations`
-- `RedissonNearCache` / `RedissonSuspendNearCache`
-- `RedissonNearCacheConfig`
-- Redisson's built-in `RLocalCachedMap`
+```kotlin
+import io.bluetape4k.cache.RedissonCaches
+import javax.cache.configuration.MutableConfiguration
 
-The Korean README includes the detailed class diagram and invalidation sequence for `RLocalCachedMap`.
+val cache = RedissonCaches.suspendJCache<String, String>(
+    redisson = redissonClient,
+    cacheName = "users",
+    configuration = MutableConfiguration<String, String>().apply {
+        setTypes(String::class.java, String::class.java)
+    },
+)
 
-## Architecture Diagrams
+cache.put("u:1", "debop")
+val user = cache.get("u:1")
+// user == "debop"
 
-### RedissonNearCache Class Hierarchy
-
-```mermaid
-classDiagram
-    class NearCacheOperations {
-        <<interface>>
-        +get(key) V?
-        +put(key, value)
-        +remove(key)
-        +clearLocal()
-        +clearAll()
-        +stats() NearCacheStatistics
-    }
-
-    class SuspendNearCacheOperations {
-        <<interface>>
-        +get(key) V?
-        +put(key, value)
-        +remove(key)
-        +clearLocal()
-        +clearAll()
-        +stats() NearCacheStatistics
-    }
-
-    class RedissonNearCache {
-        -redisson: RedissonClient
-        -localCachedMap: RLocalCachedMap
-        -config: RedissonNearCacheConfig
-    }
-
-    class RedissonSuspendNearCache {
-        -redisson: RedissonClient
-        -localCachedMap: RLocalCachedMap
-        -config: RedissonNearCacheConfig
-    }
-
-    class RedissonResp3NearCache {
-        -redisson: RedissonClient
-        -lettuceClient: RedisClient
-        -frontCache: Cache
-    }
-
-    class RedissonResp3SuspendNearCache {
-        -redisson: RedissonClient
-        -lettuceClient: RedisClient
-        -frontCache: Cache
-    }
-
-    NearCacheOperations <|.. RedissonNearCache
-    NearCacheOperations <|.. RedissonResp3NearCache
-    SuspendNearCacheOperations <|.. RedissonSuspendNearCache
-    SuspendNearCacheOperations <|.. RedissonResp3SuspendNearCache
-
-    style NearCacheOperations fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
-    style SuspendNearCacheOperations fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
-    style RedissonNearCache fill:#E0F2F1,stroke:#80CBC4,color:#00695C
-    style RedissonSuspendNearCache fill:#F3E5F5,stroke:#CE93D8,color:#6A1B9A
-    style RedissonResp3NearCache fill:#FCE4EC,stroke:#F48FB1,color:#AD1457
-    style RedissonResp3SuspendNearCache fill:#FCE4EC,stroke:#F48FB1,color:#AD1457
+cache.close()
 ```
 
-### NearCache Flow (RLocalCachedMap)
+### Native Redisson Near Cache
 
-```mermaid
-sequenceDiagram
-    participant App as Application
-    participant NC as RedissonNearCache
-    participant L1 as Local Cache (Caffeine)
-    participant L2 as Redis Server
+```kotlin
+import io.bluetape4k.cache.RedissonCaches
+import io.bluetape4k.cache.nearcache.RedissonNearCacheConfig
 
-    App->>NC: get("key")
-    NC->>L1: get("key")
-    alt L1 hit
-        L1-->>NC: value
-        NC-->>App: value
-    else L1 miss
-        L1-->>NC: null
-        NC->>L2: GET key
-        alt L2 hit
-            L2-->>NC: value
-            NC->>L1: put("key", value)
-            NC-->>App: value
-        else L2 miss
-            L2-->>NC: null
-            NC-->>App: null
-        end
-    end
+val nearCache = RedissonCaches.nearCache<String>(
+    redisson = redissonClient,
+    config = RedissonNearCacheConfig(cacheName = "products"),
+)
 
-    Note over L2,L1: Pub/Sub invalidation
-    L2-)NC: invalidation message
-    NC->>L1: evict("key")
+nearCache.put("p:1", "keyboard")
+val product = nearCache.get("p:1")
+nearCache.clearLocal()   // local tier only
+nearCache.clearAll()     // local + Redis tiers
+nearCache.close()
 ```
 
-## JCache-Based NearCache (`nearcache.jcache` package)
+### Suspend Memoizer
 
-In addition to the native near-cache implementations, this module also supports JCache-oriented near-cache setups for applications that need to stay aligned with the standard JCache contract.
+```kotlin
+import io.bluetape4k.cache.memoizer.suspendMemoizer
+import org.redisson.client.codec.IntegerCodec
 
-## Factory (`RedissonCaches`)
+val map = redissonClient.getMap<Int, Int>("memoizer:squares", IntegerCodec())
+val memoizer = map.suspendMemoizer { key ->
+    expensiveSquare(key)
+}
 
-`RedissonCaches` provides factory methods for:
+val first = memoizer(7)   // computes and stores 49
+val second = memoizer(7)  // returns cached 49
+```
 
-- JCache and suspend cache
-- native near caches
-- RESP3 hybrid near caches
-- resilient near-cache variants
+If the evaluator fails or is cancelled, the in-flight entry is completed exceptionally and removed. The next call for the same key starts a fresh computation instead of being stuck on a stale failed deferred.
 
-## Registered `CachingProvider` List
+## Lifecycle Notes
 
-When multiple JCache providers are available, explicitly choose the Redisson provider where necessary, especially when using umbrella modules or Spring cache auto-configuration.
+- `RedissonSuspendJCache.close()` delegates to the wrapped Redisson JCache and does not delete stored entries.
+- `RedissonSuspendNearCache.close()` destroys the local cached map wrapper and marks the wrapper closed; entry deletion remains the responsibility of `clearAll()`.
+- Suspend close paths preserve `CancellationException` rather than swallowing it through `runCatching`.
 
-## Redis Version Requirements
+## Verification Focus
 
-- Standard Redisson near-cache features work with ordinary Redisson-compatible Redis setups.
-- RESP3 hybrid near-cache features require Redis 6.0 or newer because `CLIENT TRACKING` depends on RESP3 support.
+Relevant test coverage includes:
+
+- JCache CRUD and close/data-preservation behavior.
+- Native near-cache read/write/clear/stat behavior.
+- Memoizer thread, virtual-thread, and coroutine contention using `MultithreadingTester`, `StructuredTaskScopeTester`, and `SuspendedJobTester`.
+- Suspend memoizer evaluator failure, explicit cancellation, and real `Job.cancel()` recovery.

--- a/cache/cache-redisson/src/main/kotlin/io/bluetape4k/cache/jcache/RedissonSuspendJCache.kt
+++ b/cache/cache-redisson/src/main/kotlin/io/bluetape4k/cache/jcache/RedissonSuspendJCache.kt
@@ -1,8 +1,10 @@
 package io.bluetape4k.cache.jcache
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -30,7 +32,7 @@ import javax.cache.configuration.MutableConfiguration
  * - 캐시 데이터 저장소는 외부 [cache] 인스턴스를 그대로 사용합니다.
  *
  * ```kotlin
- * val cache = RedissonSuspendCache<String, String>("users", redisson)
+ * val cache = RedissonSuspendJCache<String, String>("users", redisson)
  * cache.put("u:1", "debop")
  * val value = cache.get("u:1")
  * // value == "debop"
@@ -48,7 +50,7 @@ class RedissonSuspendJCache<K: Any, V: Any>(private val cache: JCache<K, V>): Su
          * - 반환 객체는 동일 캐시 이름을 공유하는 JCache 인스턴스를 래핑합니다.
          *
          * ```kotlin
-         * val cache = RedissonSuspendCache("users", redisson, MutableConfiguration<String, String>())
+         * val cache = RedissonSuspendJCache("users", redisson, MutableConfiguration<String, String>())
          * // cache.isClosed() == false
          * ```
          */
@@ -75,7 +77,7 @@ class RedissonSuspendJCache<K: Any, V: Any>(private val cache: JCache<K, V>): Su
          * - 같은 이름 캐시가 이미 존재하면 해당 캐시를 재사용합니다.
          *
          * ```kotlin
-         * val cache = RedissonSuspendCache<String, Int>("scores", config)
+         * val cache = RedissonSuspendJCache<String, Int>("scores", config)
          * cache.put("u1", 10)
          * // cache.get("u1") == 10
          * ```
@@ -106,7 +108,16 @@ class RedissonSuspendJCache<K: Any, V: Any>(private val cache: JCache<K, V>): Su
     }
 
     override suspend fun close() {
-        withContext(Dispatchers.IO) { runCatching { cache.close() } }
+        withContext(Dispatchers.IO) {
+            try {
+                cache.close()
+            } catch (e: CancellationException) {
+                // suspend close 경로에서는 취소 신호를 일반 close 실패처럼 삼키지 않는다.
+                throw e
+            } catch (e: Exception) {
+                log.warn(e) { "RedissonSuspendJCache close failed." }
+            }
+        }
     }
 
     override fun isClosed(): Boolean = cache.isClosed

--- a/cache/cache-redisson/src/main/kotlin/io/bluetape4k/cache/memoizer/RedissonSuspendMemoizer.kt
+++ b/cache/cache-redisson/src/main/kotlin/io/bluetape4k/cache/memoizer/RedissonSuspendMemoizer.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.cache.memoizer
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.future.await
@@ -51,13 +52,13 @@ fun <T: Any, R: Any> (suspend (T) -> R).memoizer(map: RMap<T, R>): RedissonSuspe
  * 1. 캐시 miss 시 [CompletableDeferred]를 `inFlight`에 등록한다.
  * 2. 동일 키를 동시에 요청한 다른 코루틴은 등록된 deferred를 `await()`으로 대기한다.
  * 3. 먼저 등록한 코루틴이 [evaluator]를 실행하고 결과를 Redis에 저장한 뒤 deferred를 완료시킨다.
- * 4. 완료 후 `inFlight`에서 해당 키를 제거한다.
+ * 4. 완료 후 `inFlight`에서 해당 키를 제거한다. evaluator 실패나 취소는 성공 값으로 저장하지 않는다.
  *
  * ## 코루틴 취소 주의사항
  * 대기 중인 코루틴이 취소되면 해당 코루틴의 `await()` 호출은 [kotlinx.coroutines.CancellationException]을
  * 던지지만, in-flight deferred 자체는 자동으로 취소되지 않습니다.
  * 즉, [evaluator]를 실행 중인 코루틴이 취소되지 않는 한 연산은 계속 진행됩니다.
- * 취소 전파가 필요한 경우 별도의 취소 처리 로직이 필요합니다.
+ * evaluator를 실행 중인 코루틴이 실패하거나 취소되면 같은 키의 다음 호출은 새 계산을 시작합니다.
  *
  * ```kotlin
  * val map: RMap<Int, Int> = redisson.getMap("squares")
@@ -84,7 +85,7 @@ class RedissonSuspendMemoizer<T: Any, R: Any>(
      * - Redis([map])에 캐시된 값이 있으면 즉시 반환한다.
      * - 캐시 miss 시 [evaluator]를 실행하고 결과를 Redis에 저장한 뒤 반환한다.
      * - 동일 키에 대한 동시 요청은 동일한 [Deferred]를 공유하여 [evaluator] 중복 실행을 방지한다.
-     * - [evaluator]에서 예외가 발생하면 deferred를 예외 상태로 완료하고 예외를 다시 던진다.
+     * - [evaluator]에서 예외나 취소가 발생하면 deferred를 예외 상태로 완료하고 예외를 다시 던진다.
      *
      * @param key 조회할 키
      * @return 키에 대응하는 값
@@ -107,6 +108,10 @@ class RedissonSuspendMemoizer<T: Any, R: Any>(
             val winner = map.putIfAbsentAsync(key, evaluated).await() ?: evaluated
             deferred.complete(winner)
             return winner
+        } catch (e: CancellationException) {
+            // CancellationException은 coroutine 취소 신호이므로 실패 공유 후 즉시 재전파한다.
+            deferred.completeExceptionally(e)
+            throw e
         } catch (e: Throwable) {
             deferred.completeExceptionally(e)
             throw e

--- a/cache/cache-redisson/src/main/kotlin/io/bluetape4k/cache/nearcache/RedissonSuspendNearCache.kt
+++ b/cache/cache-redisson/src/main/kotlin/io/bluetape4k/cache/nearcache/RedissonSuspendNearCache.kt
@@ -2,8 +2,10 @@ package io.bluetape4k.cache.nearcache
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
 import io.bluetape4k.redis.redisson.codec.RedissonCodecs
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.future.await
 import org.redisson.api.RLocalCachedMap
 import org.redisson.api.RedissonClient
@@ -196,7 +198,14 @@ class RedissonSuspendNearCache<V: Any>(
      */
     override suspend fun close() {
         if (closed.compareAndSet(expect = false, update = true)) {
-            runCatching { localCachedMap.destroy() }
+            try {
+                localCachedMap.destroy()
+            } catch (e: CancellationException) {
+                // 방어적으로라도 취소 신호는 close 실패 로그로 소비하지 않고 호출자에게 전달한다.
+                throw e
+            } catch (e: Exception) {
+                log.warn(e) { "RedissonSuspendNearCache close failed. cacheName=${config.cacheName}" }
+            }
             log.debug { "RedissonSuspendNearCache [${config.cacheName}] closed" }
         }
     }

--- a/cache/cache-redisson/src/test/kotlin/io/bluetape4k/cache/RedissonCachesTest.kt
+++ b/cache/cache-redisson/src/test/kotlin/io/bluetape4k/cache/RedissonCachesTest.kt
@@ -34,7 +34,7 @@ class RedissonCachesTest {
     }
 
     @Test
-    fun `suspendCache 팩토리는 RedissonSuspendCache 인스턴스를 반환한다`() {
+    fun `suspendJCache 팩토리는 RedissonSuspendJCache 인스턴스를 반환한다`() {
         val name = RedisServers.randomName()
         val cache = RedissonCaches.suspendJCache<String, String>(redisson, name)
         try {

--- a/cache/cache-redisson/src/test/kotlin/io/bluetape4k/cache/jcache/RedissonSuspendJCacheTest.kt
+++ b/cache/cache-redisson/src/test/kotlin/io/bluetape4k/cache/jcache/RedissonSuspendJCacheTest.kt
@@ -1,8 +1,11 @@
 package io.bluetape4k.cache.jcache
 
 import io.bluetape4k.cache.RedisServers
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.codec.encodeBase62
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import org.junit.jupiter.api.Test
 import java.util.*
 import javax.cache.configuration.MutableConfiguration
 
@@ -16,4 +19,24 @@ class RedissonSuspendJCacheTest: AbstractSuspendJCacheTest() {
             RedisServers.redisson,
             MutableConfiguration()
         )
+
+    @Test
+    fun `close releases wrapper but keeps Redisson JCache data`() = runSuspendIO {
+        val cacheName = "redis-suspend-cache-close-" + UUID.randomUUID().encodeBase62()
+        val configuration = MutableConfiguration<String, String>().apply {
+            setTypes(String::class.java, String::class.java)
+        }
+        val cache = RedissonSuspendJCache(cacheName, RedisServers.redisson, configuration)
+        cache.put("close-key", "close-value")
+        cache.close()
+
+        val reopened = RedissonSuspendJCache(cacheName, RedisServers.redisson, configuration)
+        try {
+            // close()는 resource lifecycle 계약이며 저장된 cache entry 삭제는 clear()가 담당한다.
+            reopened.get("close-key") shouldBeEqualTo "close-value"
+        } finally {
+            reopened.clear()
+            reopened.close()
+        }
+    }
 }

--- a/cache/cache-redisson/src/test/kotlin/io/bluetape4k/cache/memoizer/RedissonSuspendMemoizerTest.kt
+++ b/cache/cache-redisson/src/test/kotlin/io/bluetape4k/cache/memoizer/RedissonSuspendMemoizerTest.kt
@@ -1,14 +1,19 @@
 package io.bluetape4k.cache.memoizer
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.cache.RedisServers.randomName
 import io.bluetape4k.cache.RedisServers.redisson
 import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.junit5.coroutines.runSuspendIO
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
-import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 import org.redisson.client.codec.IntegerCodec
 import org.redisson.client.codec.LongCodec
@@ -112,6 +117,81 @@ class RedissonSuspendMemoizerTest: AbstractSuspendMemoizerTest() {
                     memoizer(9) shouldBeEqualTo 81
                 }
                 .run()
+        } finally {
+            map.delete()
+        }
+    }
+
+    @Test
+    fun `evaluator 실패 후 같은 key를 다시 호출하면 새 계산으로 복구된다`() = runSuspendIO {
+        val map = redisson.getMap<Int, Int>(randomName(), IntegerCodec()).apply { clear() }
+        val evaluateCount = AtomicInteger(0)
+        val memoizer = map.suspendMemoizer { key ->
+            if (evaluateCount.incrementAndGet() == 1) {
+                error("transient failure")
+            }
+            key * key
+        }
+
+        try {
+            assertFailsWith<IllegalStateException> {
+                memoizer(7)
+            }
+
+            // 실패한 in-flight Deferred가 제거되어야 같은 key가 이전 실패에 고착되지 않는다.
+            memoizer(7) shouldBeEqualTo 49
+            memoizer(7) shouldBeEqualTo 49
+            evaluateCount.get() shouldBeEqualTo 2
+        } finally {
+            map.delete()
+        }
+    }
+
+    @Test
+    fun `evaluator 취소 후 같은 key를 다시 호출하면 새 계산으로 복구된다`() = runSuspendIO {
+        val map = redisson.getMap<Int, Int>(randomName(), IntegerCodec()).apply { clear() }
+        val evaluateCount = AtomicInteger(0)
+        val memoizer = map.suspendMemoizer { key ->
+            if (evaluateCount.incrementAndGet() == 1) {
+                throw CancellationException("test cancellation")
+            }
+            key * key
+        }
+
+        try {
+            assertFailsWith<CancellationException> {
+                memoizer(9)
+            }
+
+            // CancellationException도 성공 값처럼 저장하거나 in-flight에 남기지 않는다.
+            memoizer(9) shouldBeEqualTo 81
+            evaluateCount.get() shouldBeEqualTo 2
+        } finally {
+            map.delete()
+        }
+    }
+
+    @Test
+    fun `evaluator job 취소 후 같은 key를 다시 호출하면 새 계산으로 복구된다`() = runSuspendIO {
+        val map = redisson.getMap<Int, Int>(randomName(), IntegerCodec()).apply { clear() }
+        val started = CompletableDeferred<Unit>()
+        val evaluateCount = AtomicInteger(0)
+        val memoizer = map.suspendMemoizer { key ->
+            if (evaluateCount.incrementAndGet() == 1) {
+                started.complete(Unit)
+                delay(Long.MAX_VALUE)
+            }
+            key * key
+        }
+
+        try {
+            val job = launch { memoizer(11) }
+            started.await()
+            job.cancelAndJoin()
+
+            // 실제 Job 취소 경로에서도 in-flight 항목이 정리되어 다음 호출이 새 계산으로 복구된다.
+            memoizer(11) shouldBeEqualTo 121
+            evaluateCount.get() shouldBeEqualTo 2
         } finally {
             map.delete()
         }

--- a/docs/lessons/2026-05-11-cache-redisson-doc-api-cancellation.md
+++ b/docs/lessons/2026-05-11-cache-redisson-doc-api-cancellation.md
@@ -1,0 +1,37 @@
+# Cache Redisson 문서/API Drift 및 Cancellation Lessons
+
+## Context
+
+`cache/cache-redisson` 모듈의 6-Tier 코드 리뷰, 누락 테스트 보강, 공개 API KDoc/README 정비를 진행했다. 이전 `cache/cache-lettuce` 작업과 같은 관점으로 suspend close cancellation, JCache close/clear 계약, memoizer 실패/취소 복구, README의 실제 public API 일치 여부를 검토했다.
+
+## Decision or Finding
+
+P0는 없었다. P1은 두 가지였다.
+
+- suspend close 경로에서 `runCatching`을 사용하면 `CancellationException`이 일반 실패처럼 소비될 수 있다. `RedissonSuspendJCache.close()`와 `RedissonSuspendNearCache.close()`는 취소 신호를 명시적으로 재전파해야 한다.
+- README가 현재 모듈에 존재하지 않는 RESP3/Resilient RESP3 API와 `RedissonSuspendCache` 이름을 설명하고 있었다. public API 문서가 실제 source set과 다르면 사용자는 존재하지 않는 class/factory를 따라가게 된다.
+
+P2로는 suspend memoizer의 실패/취소 복구 테스트가 부족했다. 구현은 `finally`에서 `inFlight.remove(key, deferred)`를 수행하고 있었지만, evaluator 실패, 명시적 `CancellationException`, 실제 `Job.cancel()` 경로가 모두 테스트로 잠겨 있지는 않았다.
+
+## Outcome
+
+- `RedissonSuspendJCache.close()`와 `RedissonSuspendNearCache.close()`는 `try/catch`로 분해해 `CancellationException`을 재전파하고 일반 close 실패는 warn 로그로 남기도록 정리했다.
+- `RedissonSuspendMemoizer`는 `CancellationException`을 별도 catch로 분리해 취소 의미를 코드에서 명시했다.
+- `RedissonSuspendMemoizerTest`에 evaluator 실패, 명시적 cancellation, 실제 `Job.cancel()` 후 같은 key 복구 테스트를 추가했다.
+- `RedissonSuspendJCacheTest`에 close 후 Redisson JCache 데이터가 보존되는 테스트를 추가했다.
+- README.md/README.ko.md는 실제 제공 API 중심으로 다시 작성하고, 존재하지 않는 RESP3 helper 문서와 `RedissonSuspendCache` 명칭을 제거했다.
+
+## Verification
+
+- `./gradlew :bluetape4k-cache-redisson:compileKotlin :bluetape4k-cache-redisson:compileTestKotlin` 통과.
+- `./gradlew :bluetape4k-cache-redisson:compileKotlin :bluetape4k-cache-redisson:compileTestKotlin :bluetape4k-cache-redisson:test --tests '*RedissonSuspendMemoizerTest' --tests '*RedissonSuspendJCacheTest'` 통과: 35 passing.
+- `./gradlew :bluetape4k-cache-redisson:test` 통과: 348 passing, 4 pending.
+- `git diff --check` 통과.
+- 문서/API drift 검색에서 `RedissonSuspendCache`, `RedissonResp3*`, `ResilientRedissonResp3*` 등 삭제 대상 public API 명칭이 README와 main/test source에 남지 않았음을 확인했다.
+
+## Future Guidance
+
+- README를 갱신할 때는 `rg`로 실제 class/factory 이름을 먼저 대조한다. 이전 모듈 또는 삭제된 실험 기능의 문서가 남아 있으면 P1급 public API drift로 취급한다.
+- suspend close 경로에서 `runCatching`을 쓰면 `CancellationException`이 삼켜지는지 먼저 확인한다. 취소 신호는 일반 close 실패 로그와 분리한다.
+- Redisson JCache wrapper에서도 `close()`와 `clear()`를 같은 의미로 섞지 않는다. close는 resource lifecycle, clear는 data lifecycle이다.
+- memoizer 복구 테스트는 실패 예외, 명시적 `CancellationException`, 실제 `Job.cancel()`을 모두 분리해 둔다. 구현이 `finally` cleanup을 갖고 있더라도 테스트가 없으면 이후 변경에서 쉽게 깨진다.


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: [cache-redisson] suspend lifecycle와 README API drift 보강

`cache/cache-redisson` 모듈의 6-Tier 코드 리뷰 결과를 반영해 suspend lifecycle, memoizer 복구 테스트, README public API drift를 정리했습니다.

- `RedissonSuspendJCache.close()`와 `RedissonSuspendNearCache.close()`에서 `CancellationException`을 삼키지 않도록 `runCatching` 경로를 분해했습니다.
- `RedissonSuspendMemoizer`에 cancellation 전파 의도를 명시하고, 실패/취소/실제 `Job.cancel()` 복구 테스트를 추가했습니다.
- `RedissonSuspendJCache.close()`가 데이터를 삭제하지 않는 close/clear 계약 테스트를 추가했습니다.
- README.md/README.ko.md에서 실제 source set에 없는 RESP3 helper API와 `RedissonSuspendCache` 명칭을 제거하고 현재 public API 중심으로 갱신했습니다.
- Lessons를 `docs/lessons/2026-05-11-cache-redisson-doc-api-cancellation.md`에 한국어로 기록했습니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 6-Tier P0/P1 Gate

초기 리뷰 결과:

| 등급 | 항목 | 조치 |
| --- | --- | --- |
| P0 | 없음 | - |
| P1 | suspend close 경로에서 `runCatching`이 `CancellationException`을 삼킬 수 있음 | `try/catch`로 분해하고 취소 예외 재전파 |
| P1 | README가 존재하지 않는 RESP3/Resilient RESP3 API와 `RedissonSuspendCache` 이름을 문서화 | 실제 public API 목록과 예제로 재작성 |

최종 로컬 게이트: P0 없음, P1 없음. Claude/Gemini 외부 CLI는 이번 diff에서 정상 결과를 반환하지 않아 로컬 6-Tier 점검과 테스트 증거로 종료했습니다.

### 기존 섹션: 비고

문서 drift 확인을 위해 `RedissonSuspendCache`, `RedissonResp3*`, `ResilientRedissonResp3*`, `resp3NearCache`, `resilientResp3` 잔존 검색을 수행했고 README/main/test source에서 삭제 대상 명칭이 남지 않았음을 확인했습니다.

## Validation

- `./gradlew :bluetape4k-cache-redisson:compileKotlin :bluetape4k-cache-redisson:compileTestKotlin`
- `./gradlew :bluetape4k-cache-redisson:compileKotlin :bluetape4k-cache-redisson:compileTestKotlin :bluetape4k-cache-redisson:test --tests '*RedissonSuspendMemoizerTest' --tests '*RedissonSuspendJCacheTest'` → 35 passing
- `./gradlew :bluetape4k-cache-redisson:test` → 348 passing, 4 pending
- `git diff --check`
- `qmd update && qmd embed --max-docs-per-batch 16`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #410, head `06052a0c60241ea2675b35e8ace5ef2097682087`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/cache-redisson-review-tests-docs`
- Labels: `bug`, `documentation`, `chore`
- State: `MERGED`, merge commit `b135e00a065623ade39ad7a6a2b94f566c22a91b`
- CI: - `./gradlew :bluetape4k-cache-redisson:compileKotlin :bluetape4k-cache-redisson:compileTestKotlin` / - `./gradlew :bluetape4k-cache-redisson:compileKotlin :bluetape4k-cache-redisson:compileTestKotlin :bluetape4k-cache-redisson:test --tests '*RedissonSuspendMemoizerTest' --tests '*RedissonSuspendJCacheTest'` → 35 passing / - `./gradlew :bluetape4k-cache-redisson:test` → 348 passing, 4 pending

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #410 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `b135e00a065623ade39ad7a6a2b94f566c22a91b`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
