### PR TITLE
build: projects NMCP 기준선을 1.5.0으로 정렬

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,7 +86,7 @@ subprojects {
         resolutionStrategy.eachDependency {
             if (requested.group == "org.jetbrains.kotlinx" && requested.name.startsWith("kotlinx-serialization")) {
                 useVersion("1.9.0")
-                because("nmcp 1.4.4 runtime compatibility (avoid serialization ABI mismatch)")
+                because("nmcp runtime compatibility (avoid serialization ABI mismatch)")
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -158,7 +158,7 @@ shadow = "9.3.1"  # https://mvnrepository.com/artifact/com.gradleup.shadow/shado
 protobuf-plugin = "0.10.0"  # https://mvnrepository.com/artifact/com.google.protobuf/protobuf-gradle-plugin
 avro-plugin = "1.9.1"  # https://mvnrepository.com/artifact/com.github.davidmc24.gradle.plugin/gradle-avro-plugin
 graalvm-native = "1.1.0"  # https://mvnrepository.com/artifact/org.graalvm.buildtools/native-gradle-plugin
-nmcp = "1.4.4"  # https://mvnrepository.com/artifact/com.gradleup.nmcp/nmcp
+nmcp = "1.5.0"  # https://mvnrepository.com/artifact/com.gradleup.nmcp/nmcp
 dependency-check = "12.2.2"  # https://mvnrepository.com/artifact/org.owasp/dependency-check-gradle
 
 [plugins]


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: build: projects NMCP 기준선을 1.5.0으로 정렬

- `bluetape4k-projects`의 `nmcp` 플러그인 기준 버전을 1.4.4에서 1.5.0으로 올립니다.
- nmcp 호환성용 kotlinx-serialization 고정 사유 문구에서 특정 이전 버전명을 제거했습니다.

## Background

- `bluetape4k-projects`가 공통 버전 기준 저장소인데, 다른 repo에는 nmcp 1.5.0 업데이트가 생성/반영된 반면 projects에는 Dependabot PR이 생성되지 않았습니다.
- downstream repo 정렬 전에 기준 저장소를 먼저 맞춥니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: 참고

- 실제 Central Portal publish는 외부 배포 side effect라 실행하지 않았습니다.
- dry-run 중 기존 publish POM/configuration-cache 경고는 출력되지만 빌드는 성공했습니다.

## Validation

- `./gradlew help tasks --all --no-daemon`
- `./gradlew publishAggregationToCentralPortal --dry-run --no-daemon`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #412, head `bc19ce7f21db3ee966ab95d428876aa88c41a427`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/nmcp-1.5-baseline`
- Labels: 없음
- State: `MERGED`, merge commit `742a41cf84319edb01170b1767d9719824a4f08a`
- CI: - `./gradlew help tasks --all --no-daemon` / - `./gradlew publishAggregationToCentralPortal --dry-run --no-daemon`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #412 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `742a41cf84319edb01170b1767d9719824a4f08a`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
