### PR TITLE
chore: Nightly workflow 이름 통일

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,7 +389,7 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 30
 
-  # ── 나머지 모듈 → Nightly Tests에서 실행 ─────────────────────────────────
+  # ── 나머지 모듈 → Nightly에서 실행 ─────────────────────────────────
   # utils 전체, misc, data, spring3-docker, spring4-docker,
   # testcontainers 는 nightly-tests.yml (매일 03:00 KST) 에서 실행
   # exposed 모듈은 bluetape4k-exposed 독립 레포로 분리됨 (#334)

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1,4 +1,4 @@
-name: Nightly Tests (Testcontainers)
+name: Nightly
 
 on:
   schedule:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   workflow_run:
-    workflows: ["Nightly Tests (Testcontainers)"]
+    workflows: ["Nightly"]
     types: [completed]
     branches: [develop]
   workflow_dispatch:
@@ -29,7 +29,7 @@ jobs:
   publish:
     name: Publish SNAPSHOT to Maven Central
     runs-on: ubuntu-latest
-    # workflow_run: Nightly Tests 성공 시에만 실행. 수동 dispatch는 항상 실행.
+    # workflow_run: Nightly 성공 시에만 실행. 수동 dispatch는 항상 실행.
     if: |
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'

--- a/docs/superpowers/specs/2026-05-03-kafka4-module-design.md
+++ b/docs/superpowers/specs/2026-05-03-kafka4-module-design.md
@@ -47,7 +47,7 @@
   - Spring Boot 4 BOM 적용
 - 영어/한국어 README 작성
 - targeted compile/test 검증
-- GitHub Nightly Tests workflow의 infra matrix에 `:bluetape4k-kafka4:test`와 kover report task 추가
+- GitHub Nightly workflow의 infra matrix에 `:bluetape4k-kafka4:test`와 kover report task 추가
 
 ### 제외
 


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: chore: Nightly workflow 이름 통일

- Rename `Nightly Tests (Testcontainers)` workflow display name to `Nightly`
- Update `publish-snapshot.yml` workflow_run reference to the new display name
- Update nearby comments/docs that referenced the old workflow name

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- git diff --check
- ruby YAML parse for ci/nightly/publish-snapshot workflows
- rg confirmed no `Nightly Tests` references remain

Not-tested: rename 이후 workflow dispatch는 merge 후 확인해야 합니다.

Co-authored-by: OmX <omx@oh-my-codex.dev>

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #414, head `8a4c34fde0961f986bc87fd36c3cbc656edcaf94`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `chore/rename-nightly-workflow`
- Labels: 없음
- State: `MERGED`, merge commit `95cadf075782d94fd4bd4fe430ac2b21a7fad1fb`
- CI: - ruby YAML parse for ci/nightly/publish-snapshot workflows

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #414 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `95cadf075782d94fd4bd4fe430ac2b21a7fad1fb`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
