### PR TITLE
feat: idgenerator Ktor 예제 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,9 @@ import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.report.ReportMergeTask
 import nmcp.NmcpAggregationExtension
 import nmcp.NmcpExtension
+import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import java.io.File
 
 plugins {
     base
@@ -77,8 +79,22 @@ allprojects {
 // where `libs` is not in scope (different receiver type in the lambda).
 val rootLibs = libs
 
+fun Project.isSampleOrBenchmarkProject(): Boolean {
+    val relativeProjectDir = rootDir.toPath()
+        .relativize(projectDir.toPath())
+        .toString()
+        .replace(File.separatorChar, '/')
+
+    return relativeProjectDir == "workshop" ||
+            relativeProjectDir.startsWith("workshop/") ||
+            relativeProjectDir == "examples" ||
+            relativeProjectDir.startsWith("examples/") ||
+            name.contains("-demo") ||
+            name.endsWith("-benchmark")
+}
+
 subprojects {
-    if (!path.contains("workshop") && !path.contains("examples") && !path.contains("-demo") && !path.endsWith("-benchmark")) {
+    if (!isSampleOrBenchmarkProject()) {
         apply(plugin = "com.gradleup.nmcp")
     }
 
@@ -119,7 +135,7 @@ subprojects {
         plugin("org.jetbrains.kotlinx.atomicfu")
 
         // Kover — Kotlin 코드 커버리지 (examples/workshop/-demo/-benchmark 는 별도 필터링)
-        if (!path.contains("workshop") && !path.contains("examples") && !path.contains("-demo") && !path.endsWith("-benchmark")) {
+        if (!isSampleOrBenchmarkProject()) {
             plugin("org.jetbrains.kotlinx.kover")
         }
 
@@ -622,7 +638,7 @@ subprojects {
      */
     publishing {
         publications {
-            if (!project.path.contains("workshop") && !project.path.contains("examples") && !project.path.contains("-demo") && !project.path.endsWith("-benchmark")) {
+            if (!project.isSampleOrBenchmarkProject()) {
                 create<MavenPublication>("Bluetape4k") {
                     val binaryJar = components["java"]
 
@@ -658,10 +674,7 @@ subprojects {
 
     configurePublishingSigning(
         publicationName = "Bluetape4k",
-        enabled = !project.path.contains("workshop") &&
-                !project.path.contains("examples") &&
-                !project.path.contains("-demo") &&
-                !project.path.endsWith("-benchmark"),
+        enabled = !project.isSampleOrBenchmarkProject(),
     )
 
     tasks.withType<GenerateMavenPom>().configureEach {
@@ -682,7 +695,7 @@ subprojects {
 }
 
 val publishableProjects = subprojects.filterNot { project ->
-    project.path.contains("workshop") || project.path.contains("examples") || project.path.contains("-demo") || project.path.endsWith("-benchmark")
+    project.isSampleOrBenchmarkProject()
 }
 
 extensions.configure<NmcpAggregationExtension>("nmcpAggregation") {
@@ -734,10 +747,7 @@ dependencies {
     subprojects
         .filter { sub ->
             sub.name != "bluetape4k-bom" &&
-                    !sub.path.contains("workshop") &&
-                    !sub.path.contains("examples") &&
-                    !sub.path.contains("-demo") &&
-                    !sub.path.endsWith("-benchmark")
+                    !sub.isSampleOrBenchmarkProject()
         }
         .forEach { sub -> kover(project(sub.path)) }
 }

--- a/docs/lessons/2026-05-12-issue-419-idgenerator-ktor-example.md
+++ b/docs/lessons/2026-05-12-issue-419-idgenerator-ktor-example.md
@@ -1,0 +1,28 @@
+# Issue #419 idgenerator Ktor 예제 작업 기록
+
+## 배경
+
+#419는 idgenerator 예제 중 Ktor 범위를 Spring Boot 예제 이슈에서 분리한 작업이다.
+
+## 결정
+
+- 실행 가능한 Ktor 예제는 `examples/ktor/idgenerator-ktor`에 둔다.
+- `settings.gradle.kts`에는 `includeModules("examples/ktor", false, false)`를 추가해 `:idgenerator-ktor`로 등록한다.
+- 명시적 `/ids/{type}` route와 generic `/idgen/{type}` route를 모두 제공하되, 뒤에서는 하나의 registry를 공유한다.
+- `includeModules("examples/ktor", false, false)`처럼 project path에 `examples`가 빠질 수 있으므로, 배포/Kover 제외 판정은 Gradle path만 보지 않고 `projectDir`가 `examples/**` 아래인지도 확인한다.
+
+## 결과
+
+새 모듈은 UUID v4, UUID v7, ULID, KSUID, Snowflake, Flake 단건/배치 endpoint를 제공한다.
+
+## 검증
+
+```bash
+./gradlew :idgenerator-ktor:compileKotlin :idgenerator-ktor:test --parallel
+```
+
+결과: 테스트 6개 통과.
+
+## 다음 작업자를 위한 메모
+
+중첩 예제를 custom project name으로 등록할 때는 root Gradle의 `project.path.contains("examples")` 기반 필터가 더 이상 예제 모듈을 잡지 못할 수 있다. 새 예제 모듈을 추가하면 배포, Kover, 집계 task 제외 조건을 함께 확인해야 한다.

--- a/examples/ktor/idgenerator-ktor/README.ko.md
+++ b/examples/ktor/idgenerator-ktor/README.ko.md
@@ -1,0 +1,90 @@
+# idgenerator Ktor 예제
+
+[English](./README.md) | 한국어
+
+bluetape4k `idgenerators`를 HTTP endpoint로 노출하는 실행 가능한 Ktor application입니다.
+
+## 구조
+
+```mermaid
+flowchart LR
+    Client[HTTP client] --> Routes[Ktor routes]
+    Routes --> Registry[IdGeneratorRegistry]
+    Registry --> UUID[UUID v4/v7]
+    Registry --> ULID[ULID]
+    Registry --> KSUID[KSUID]
+    Registry --> Snowflake[Snowflake]
+    Registry --> Flake[Flake]
+```
+
+명시적 `/ids/...` route와 generic `/idgen/{type}` route는 같은 registry를 공유합니다. route 스타일은 두 가지를 모두 보여주되 ID 생성 로직은 중복하지 않습니다.
+
+## 실행
+
+```bash
+./gradlew :idgenerator-ktor:run
+```
+
+application은 `0.0.0.0:8080`에서 실행됩니다.
+
+## 테스트
+
+```bash
+./gradlew :idgenerator-ktor:compileKotlin :idgenerator-ktor:test
+```
+
+## Endpoints
+
+### 명시적 Route
+
+```bash
+curl http://localhost:8080/ids/uuid-v4
+curl http://localhost:8080/ids/uuid-v7
+curl http://localhost:8080/ids/ulid
+curl http://localhost:8080/ids/ksuid
+curl http://localhost:8080/ids/snowflake
+curl http://localhost:8080/ids/flake
+```
+
+### 명시적 Batch Route
+
+```bash
+curl 'http://localhost:8080/ids/uuid-v7/batch?size=10'
+curl 'http://localhost:8080/ids/snowflake/batch?size=10'
+```
+
+`size`는 `1..100` 범위여야 합니다. 생략하면 `10`을 사용합니다.
+
+### Generic Route
+
+```bash
+curl http://localhost:8080/idgen/uuid-v7
+curl 'http://localhost:8080/idgen/uuid-v7/batch?size=10'
+```
+
+지원하는 `{type}` 값:
+
+- `uuid-v4`
+- `uuid-v7`
+- `ulid`
+- `ksuid`
+- `snowflake`
+- `flake`
+
+### Metadata
+
+```bash
+curl http://localhost:8080/generators
+curl http://localhost:8080/health
+```
+
+## Generator 선택 기준
+
+| Type | 사용 기준 |
+|---|---|
+| `uuid-v4` | 랜덤 UUID 호환성이 충분할 때 |
+| `uuid-v7` | UUID 형식을 유지하면서 시간 정렬 특성이 필요할 때 |
+| `ulid` | 짧고 사전순 정렬 가능한 문자열 ID가 필요할 때 |
+| `ksuid` | timestamp와 random payload를 포함한 K-sortable ID가 필요할 때 |
+| `snowflake` | 분산 시스템에서 쓰기 좋은 compact numeric ID가 필요할 때 |
+| `flake` | Boundary 스타일 128-bit Base62 ID가 필요할 때 |

--- a/examples/ktor/idgenerator-ktor/README.md
+++ b/examples/ktor/idgenerator-ktor/README.md
@@ -1,0 +1,90 @@
+# idgenerator Ktor Example
+
+English | [한국어](./README.ko.md)
+
+Runnable Ktor application that exposes bluetape4k `idgenerators` through HTTP endpoints.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Client[HTTP client] --> Routes[Ktor routes]
+    Routes --> Registry[IdGeneratorRegistry]
+    Registry --> UUID[UUID v4/v7]
+    Registry --> ULID[ULID]
+    Registry --> KSUID[KSUID]
+    Registry --> Snowflake[Snowflake]
+    Registry --> Flake[Flake]
+```
+
+The explicit `/ids/...` routes and generic `/idgen/{type}` routes share the same registry, so the example shows both route styles without duplicating ID generation logic.
+
+## Run
+
+```bash
+./gradlew :idgenerator-ktor:run
+```
+
+The application listens on `0.0.0.0:8080`.
+
+## Test
+
+```bash
+./gradlew :idgenerator-ktor:compileKotlin :idgenerator-ktor:test
+```
+
+## Endpoints
+
+### Explicit Routes
+
+```bash
+curl http://localhost:8080/ids/uuid-v4
+curl http://localhost:8080/ids/uuid-v7
+curl http://localhost:8080/ids/ulid
+curl http://localhost:8080/ids/ksuid
+curl http://localhost:8080/ids/snowflake
+curl http://localhost:8080/ids/flake
+```
+
+### Explicit Batch Routes
+
+```bash
+curl 'http://localhost:8080/ids/uuid-v7/batch?size=10'
+curl 'http://localhost:8080/ids/snowflake/batch?size=10'
+```
+
+`size` must be in `1..100`. If omitted, it defaults to `10`.
+
+### Generic Routes
+
+```bash
+curl http://localhost:8080/idgen/uuid-v7
+curl 'http://localhost:8080/idgen/uuid-v7/batch?size=10'
+```
+
+Supported `{type}` values:
+
+- `uuid-v4`
+- `uuid-v7`
+- `ulid`
+- `ksuid`
+- `snowflake`
+- `flake`
+
+### Metadata
+
+```bash
+curl http://localhost:8080/generators
+curl http://localhost:8080/health
+```
+
+## Generator Choice
+
+| Type | Use when |
+|---|---|
+| `uuid-v4` | Random UUID compatibility is enough. |
+| `uuid-v7` | You want UUID format with time-sortable behavior. |
+| `ulid` | You want compact lexicographically sortable string IDs. |
+| `ksuid` | You want K-sortable IDs with embedded timestamp and random payload. |
+| `snowflake` | You want compact numeric IDs suitable for distributed systems. |
+| `flake` | You want Boundary-style 128-bit Base62 IDs. |

--- a/examples/ktor/idgenerator-ktor/build.gradle.kts
+++ b/examples/ktor/idgenerator-ktor/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    application
+    alias(libs.plugins.kotlin.serialization)
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+application {
+    mainClass.set("io.bluetape4k.examples.ktor.idgenerator.IdGeneratorKtorApplicationKt")
+}
+
+dependencies {
+    implementation(project(":bluetape4k-idgenerators"))
+
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.cio)
+    implementation(libs.ktor.server.content.negotiation)
+    implementation(libs.ktor.server.status.pages)
+    implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.kotlinx.serialization.json)
+
+    runtimeOnly(libs.logback.classic)
+
+    testImplementation(project(":bluetape4k-junit5"))
+    testImplementation(libs.ktor.server.test.host)
+}

--- a/examples/ktor/idgenerator-ktor/src/main/kotlin/io/bluetape4k/examples/ktor/idgenerator/IdGeneratorKtorApplication.kt
+++ b/examples/ktor/idgenerator-ktor/src/main/kotlin/io/bluetape4k/examples/ktor/idgenerator/IdGeneratorKtorApplication.kt
@@ -1,0 +1,228 @@
+package io.bluetape4k.examples.ktor.idgenerator
+
+import io.bluetape4k.idgenerators.flake.Flake
+import io.bluetape4k.idgenerators.ksuid.KsuidGenerator
+import io.bluetape4k.idgenerators.snowflake.SnowflakeGenerator
+import io.bluetape4k.idgenerators.ulid.UlidGenerator
+import io.bluetape4k.idgenerators.uuid.Uuid
+import io.bluetape4k.idgenerators.uuid.UuidGenerator
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.application.install
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.request.ApplicationRequest
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.Routing
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+private const val DEFAULT_BATCH_SIZE = 10
+private const val MAX_BATCH_SIZE = 100
+
+/**
+ * Configures the Ktor idgenerator example application.
+ *
+ * ## Contract
+ * - Explicit `/ids/{type}` routes and generic `/idgen/{type}` routes share the same registry.
+ * - Batch generation accepts `size` in `1..100`; omitted `size` defaults to `10`.
+ * - Unsupported generator types and invalid batch sizes return HTTP 400 JSON errors.
+ *
+ * ```kotlin
+ * embeddedServer(CIO, port = 8080) {
+ *     idGeneratorKtorModule()
+ * }.start(wait = true)
+ * ```
+ */
+internal fun Application.idGeneratorKtorModule(
+    registry: IdGeneratorRegistry = IdGeneratorRegistry.default(),
+) {
+    install(ContentNegotiation) {
+        json(Json {
+            prettyPrint = true
+        })
+    }
+    install(StatusPages) {
+        exception<UnknownGeneratorTypeException> { call, cause ->
+            call.respond(
+                HttpStatusCode.BadRequest,
+                ErrorResponse("unsupported_generator_type", cause.message ?: "Unsupported generator type")
+            )
+        }
+        exception<InvalidBatchSizeException> { call, cause ->
+            call.respond(
+                HttpStatusCode.BadRequest,
+                ErrorResponse("invalid_batch_size", cause.message ?: "Invalid batch size")
+            )
+        }
+    }
+    routing {
+        idGeneratorRoutes(registry)
+    }
+}
+
+fun main() {
+    embeddedServer(CIO, host = "0.0.0.0", port = 8080) {
+        idGeneratorKtorModule()
+    }.start(wait = true)
+}
+
+internal fun Routing.idGeneratorRoutes(registry: IdGeneratorRegistry) {
+    get("/health") {
+        call.respond(HealthResponse())
+    }
+    get("/generators") {
+        call.respond(registry.toResponse())
+    }
+
+    registry.types.forEach { type ->
+        get("/ids/$type") {
+            call.respond(registry.nextIdResponse(type))
+        }
+        get("/ids/$type/batch") {
+            call.respond(registry.nextIdsResponse(type, call.batchSize()))
+        }
+    }
+
+    get("/idgen/{type}") {
+        call.respond(registry.nextIdResponse(call.generatorType()))
+    }
+    get("/idgen/{type}/batch") {
+        call.respond(registry.nextIdsResponse(call.generatorType(), call.batchSize()))
+    }
+}
+
+internal class IdGeneratorRegistry(
+    generators: Map<String, () -> String>,
+) {
+    private val generators: Map<String, () -> String> = generators.toMap()
+    val types: List<String> = generators.keys.toList()
+
+    init {
+        require(generators.isNotEmpty()) { "generators must not be empty" }
+        require(generators.keys.all { it.isNotBlank() }) { "generator type must not be blank" }
+    }
+
+    fun nextId(type: String): String =
+        generator(type).invoke()
+
+    fun nextIds(type: String, size: Int): List<String> {
+        if (size !in 1..MAX_BATCH_SIZE) {
+            throw InvalidBatchSizeException(size.toString())
+        }
+        return List(size) { nextId(type) }
+    }
+
+    fun nextIdResponse(type: String): IdResponse =
+        IdResponse(type = type, id = nextId(type))
+
+    fun nextIdsResponse(type: String, size: Int): IdBatchResponse =
+        IdBatchResponse(type = type, size = size, ids = nextIds(type, size))
+
+    fun toResponse(): GeneratorsResponse =
+        GeneratorsResponse(
+            generators = types.map { type ->
+                GeneratorResponse(
+                    type = type,
+                    endpoint = "/ids/$type",
+                    batchEndpoint = "/ids/$type/batch?size=$DEFAULT_BATCH_SIZE"
+                )
+            },
+            genericEndpoints = listOf(
+                "/idgen/{type}",
+                "/idgen/{type}/batch?size=$DEFAULT_BATCH_SIZE"
+            )
+        )
+
+    private fun generator(type: String): () -> String =
+        generators[type] ?: throw UnknownGeneratorTypeException(type, types)
+
+    companion object {
+        fun default(): IdGeneratorRegistry {
+            val uuidV4 = UuidGenerator(Uuid.V4)
+            val uuidV7 = UuidGenerator(Uuid.V7)
+            val ulid = UlidGenerator()
+            val ksuid = KsuidGenerator()
+            val snowflake = SnowflakeGenerator()
+            val flake = Flake()
+
+            return IdGeneratorRegistry(
+                linkedMapOf(
+                    "uuid-v4" to { uuidV4.nextUUID().toString() },
+                    "uuid-v7" to { uuidV7.nextUUID().toString() },
+                    "ulid" to { ulid.nextId() },
+                    "ksuid" to { ksuid.nextId() },
+                    "snowflake" to { snowflake.nextId().toString() },
+                    "flake" to { flake.nextIdAsString() }
+                )
+            )
+        }
+    }
+}
+
+internal class UnknownGeneratorTypeException(
+    type: String,
+    supportedTypes: List<String>,
+): IllegalArgumentException("Unsupported generator type: $type. Supported types: ${supportedTypes.joinToString()}")
+
+internal class InvalidBatchSizeException(
+    size: String,
+): IllegalArgumentException("Invalid batch size: $size. Expected range is 1..$MAX_BATCH_SIZE")
+
+@Serializable
+internal data class IdResponse(
+    val type: String,
+    val id: String,
+)
+
+@Serializable
+internal data class IdBatchResponse(
+    val type: String,
+    val size: Int,
+    val ids: List<String>,
+)
+
+@Serializable
+internal data class GeneratorResponse(
+    val type: String,
+    val endpoint: String,
+    val batchEndpoint: String,
+)
+
+@Serializable
+internal data class GeneratorsResponse(
+    val generators: List<GeneratorResponse>,
+    val genericEndpoints: List<String>,
+)
+
+@Serializable
+internal data class HealthResponse(
+    val status: String = "UP",
+)
+
+@Serializable
+internal data class ErrorResponse(
+    val error: String,
+    val message: String,
+)
+
+private fun ApplicationCall.generatorType(): String =
+    parameters["type"] ?: throw UnknownGeneratorTypeException("", emptyList())
+
+private fun ApplicationCall.batchSize(): Int =
+    request.batchSize()
+
+private fun ApplicationRequest.batchSize(): Int {
+    val rawSize = queryParameters["size"] ?: return DEFAULT_BATCH_SIZE
+    return rawSize.toIntOrNull()
+        ?.takeIf { it in 1..MAX_BATCH_SIZE }
+        ?: throw InvalidBatchSizeException(rawSize)
+}

--- a/examples/ktor/idgenerator-ktor/src/test/kotlin/io/bluetape4k/examples/ktor/idgenerator/IdGeneratorKtorApplicationTest.kt
+++ b/examples/ktor/idgenerator-ktor/src/test/kotlin/io/bluetape4k/examples/ktor/idgenerator/IdGeneratorKtorApplicationTest.kt
@@ -1,0 +1,157 @@
+package io.bluetape4k.examples.ktor.idgenerator
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import io.bluetape4k.utils.Runtimex
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class IdGeneratorKtorApplicationTest {
+
+    companion object {
+        private val ExplicitTypes = listOf(
+            "uuid-v4",
+            "uuid-v7",
+            "ulid",
+            "ksuid",
+            "snowflake",
+            "flake"
+        )
+        private const val BATCH_SIZE = 7
+        private const val CONCURRENCY_COUNT = 512
+    }
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+    }
+
+    @Test
+    fun `all explicit single id endpoints return non blank ids`() = testApplication {
+        application {
+            idGeneratorKtorModule()
+        }
+
+        ExplicitTypes.forEach { type ->
+            val response = client.get("/ids/$type")
+            response.status shouldBeEqualTo HttpStatusCode.OK
+
+            val body = json.decodeFromString<IdResponse>(response.bodyAsText())
+            body.type shouldBeEqualTo type
+            body.id.isNotBlank() shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `all explicit batch endpoints return requested unique ids`() = testApplication {
+        application {
+            idGeneratorKtorModule()
+        }
+
+        ExplicitTypes.forEach { type ->
+            val response = client.get("/ids/$type/batch?size=$BATCH_SIZE")
+            response.status shouldBeEqualTo HttpStatusCode.OK
+
+            val body = json.decodeFromString<IdBatchResponse>(response.bodyAsText())
+            body.type shouldBeEqualTo type
+            body.size shouldBeEqualTo BATCH_SIZE
+            body.ids shouldHaveSize BATCH_SIZE
+            body.ids.distinct() shouldHaveSize BATCH_SIZE
+            body.ids.all { it.isNotBlank() } shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `generic idgen routes use the same registry as explicit routes`() = testApplication {
+        val counter = AtomicInteger()
+        val registry = IdGeneratorRegistry(
+            mapOf("uuid-v7" to { "shared-${counter.incrementAndGet()}" })
+        )
+        application {
+            idGeneratorKtorModule(registry)
+        }
+
+        val explicit = json.decodeFromString<IdResponse>(
+            client.get("/ids/uuid-v7").bodyAsText()
+        )
+        val generic = json.decodeFromString<IdResponse>(
+            client.get("/idgen/uuid-v7").bodyAsText()
+        )
+        val genericBatch = json.decodeFromString<IdBatchResponse>(
+            client.get("/idgen/uuid-v7/batch?size=3").bodyAsText()
+        )
+
+        explicit.id shouldBeEqualTo "shared-1"
+        generic.id shouldBeEqualTo "shared-2"
+        genericBatch.ids shouldBeEqualTo listOf("shared-3", "shared-4", "shared-5")
+    }
+
+    @Test
+    fun `metadata and health endpoints return supported generators`() = testApplication {
+        application {
+            idGeneratorKtorModule()
+        }
+
+        val health = json.decodeFromString<HealthResponse>(
+            client.get("/health").bodyAsText()
+        )
+        health.status shouldBeEqualTo "UP"
+
+        val generators = json.decodeFromString<GeneratorsResponse>(
+            client.get("/generators").bodyAsText()
+        )
+        generators.generators.map { it.type } shouldBeEqualTo ExplicitTypes
+        generators.genericEndpoints shouldBeEqualTo listOf(
+            "/idgen/{type}",
+            "/idgen/{type}/batch?size=10"
+        )
+    }
+
+    @Test
+    fun `bad type and bad size return bad request`() = testApplication {
+        application {
+            idGeneratorKtorModule()
+        }
+
+        client.get("/idgen/unknown").status shouldBeEqualTo HttpStatusCode.BadRequest
+        client.get("/idgen/uuid-v7/batch?size=0").status shouldBeEqualTo HttpStatusCode.BadRequest
+        client.get("/idgen/uuid-v7/batch?size=101").status shouldBeEqualTo HttpStatusCode.BadRequest
+        client.get("/ids/uuid-v7/batch?size=not-number").status shouldBeEqualTo HttpStatusCode.BadRequest
+    }
+
+    @Test
+    fun `SuspendedJobTester proves selected endpoints return unique ids concurrently`() = testApplication {
+        application {
+            idGeneratorKtorModule()
+        }
+
+        listOf("/ids/uuid-v7", "/ids/snowflake").forEach { endpoint ->
+            val idMap = ConcurrentHashMap<String, Int>()
+
+            SuspendedJobTester()
+                .workers(Runtimex.availableProcessors)
+                .rounds(CONCURRENCY_COUNT)
+                .add {
+                    val response = client.get(endpoint)
+                    response.status shouldBeEqualTo HttpStatusCode.OK
+
+                    val id = json.decodeFromString<IdResponse>(response.bodyAsText()).id
+                    id.shouldNotBeNull()
+                    idMap.putIfAbsent(id, 1).shouldBeNull()
+                }.run()
+
+            idMap.keys shouldHaveSize CONCURRENCY_COUNT
+        }
+    }
+}

--- a/examples/ktor/idgenerator-ktor/src/test/resources/junit-platform.properties
+++ b/examples/ktor/idgenerator-ktor/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/examples/ktor/idgenerator-ktor/src/test/resources/logback-test.xml
+++ b/examples/ktor/idgenerator-ktor/src/test/resources/logback-test.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <!-- @formatter:off -->
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%24.24t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <!-- @formatter:on -->
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.examples.ktor.idgenerator" level="DEBUG"/>
+    <logger name="io.bluetape4k.idgenerators" level="INFO"/>
+
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+
+</configuration>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ blockhound = "1.0.16.RELEASE"  # https://mvnrepository.com/artifact/io.projectre
 
 mutiny = "3.2.0"  # https://mvnrepository.com/artifact/io.smallrye.reactive/mutiny
 vertx = "5.0.12"  # https://mvnrepository.com/artifact/io.vertx/vertx-dependencies
+ktor = "3.4.3"  # https://mvnrepository.com/artifact/io.ktor/ktor-server-core
 
 swagger = "2.2.49"  # https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-core
 springdoc-openapi = "3.0.3"  # https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-api
@@ -229,6 +230,14 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 kotlinx-serialization-json-jvm = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json-jvm", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-properties = { module = "org.jetbrains.kotlinx:kotlinx-serialization-properties", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "kotlinx-serialization" }
+
+# Ktor
+ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
+ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
+ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
+ktor-server-status-pages = { module = "io.ktor:ktor-server-status-pages", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 
 # Kotlinx AtomicFU
 kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "kotlinx-atomicfu" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,6 +27,7 @@ includeModules("virtualthread", withProjectName = true, withBaseDir = true)
 
 // Examples (library style examples)
 includeModules("examples", withProjectName = true, withBaseDir = true)
+includeModules("examples/ktor", false, false)
 
 fun includeModules(baseDir: String, withProjectName: Boolean = true, withBaseDir: Boolean = true) {
     files("$rootDir/$baseDir").files


### PR DESCRIPTION
## Summary

Closes #419

- PR 제목: feat: idgenerator Ktor 예제 추가

- `examples/ktor/idgenerator-ktor` Ktor 예제 application을 추가했습니다.
- UUID v4, UUID v7, ULID, KSUID, Snowflake, Flake 단건/배치 endpoint를 제공합니다.
- 명시적 `/ids/...` route와 generic `/idgen/{type}` route가 같은 `IdGeneratorRegistry`를 공유하도록 구성했습니다.
- `includeModules("examples/ktor", false, false)`로 `:idgenerator-ktor`를 등록했습니다.
- nested examples 모듈이 배포/Kover 대상에 들어가지 않도록 root Gradle 예제 판정을 `projectDir` 기준으로 보강했습니다.
- 작업 기록을 `docs/lessons/2026-05-12-issue-419-idgenerator-ktor-example.md`에 남겼습니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- Closes #419
- #420 Examples workflow 분리는 후속 PR에서 처리합니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### 요약

- `examples/ktor/idgenerator-ktor` Ktor 예제 application을 추가했습니다.
- UUID v4, UUID v7, ULID, KSUID, Snowflake, Flake 단건/배치 endpoint를 제공합니다.
- 명시적 `/ids/...` route와 generic `/idgen/{type}` route가 같은 `IdGeneratorRegistry`를 공유하도록 구성했습니다.
- `includeModules("examples/ktor", false, false)`로 `:idgenerator-ktor`를 등록했습니다.
- nested examples 모듈이 배포/Kover 대상에 들어가지 않도록 root Gradle 예제 판정을 `projectDir` 기준으로 보강했습니다.
- 작업 기록을 `docs/lessons/2026-05-12-issue-419-idgenerator-ktor-example.md`에 남겼습니다.

### 범위

- Closes #419
- #420 Examples workflow 분리는 후속 PR에서 처리합니다.

### 테스트

```bash
./gradlew :idgenerator-ktor:compileKotlin :idgenerator-ktor:test --parallel
```

결과: `IdGeneratorKtorApplicationTest` 6개 통과.

## Validation

```bash
./gradlew :idgenerator-ktor:compileKotlin :idgenerator-ktor:test --parallel
```

결과: `IdGeneratorKtorApplicationTest` 6개 통과.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #419, milestone 없음, assignee `debop`
- PR: #421, head `a0b814dbbd056c1282e6deba69cfdfcbcb8dcbaf`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `issue-419-idgenerator-ktor`
- Labels: 없음
- State: `MERGED`, merge commit `897cb2ebf91bb6d52921d6d992972955c38de2d4`
- CI: - nested examples 모듈이 배포/Kover 대상에 들어가지 않도록 root Gradle 예제 판정을 `projectDir` 기준으로 보강했습니다. / ./gradlew :idgenerator-ktor:compileKotlin :idgenerator-ktor:test --parallel

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #421 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `897cb2ebf91bb6d52921d6d992972955c38de2d4`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
