### PR TITLE
feat: idgenerator Spring Boot 예제 제공

### DIFF
--- a/WIP.md
+++ b/WIP.md
@@ -1,7 +1,7 @@
 # WIP - bluetape4k-projects
 
-Snapshot: 2026-05-11 KST
-Scope: open GitHub issues assigned to `debop`, created on or after 2026-01-01. Open count: 11 issues.
+Snapshot: 2026-05-12 KST
+Scope: open GitHub issues assigned to `debop`, created on or after 2026-01-01. Open count: 13 issues.
 
 ## Current Direction
 
@@ -17,6 +17,8 @@ Historical completed items from the old monorepo TODO are intentionally omitted 
 |---|---|---:|---|
 | P0 | [#257](https://github.com/bluetape4k/bluetape4k-projects/issues/257) monorepo split epic | XL | Program tracker. Keep phase state updated as repo splits close. |
 | P2 | [#364](https://github.com/bluetape4k/bluetape4k-projects/issues/364) Spring annotation reified utilities | S | Add shared Kotlin idioms for Spring `AnnotatedElementUtils` / `AnnotationUtils`; unblocks leader/AWS cleanup. |
+| P2 | [#416](https://github.com/bluetape4k/bluetape4k-projects/issues/416) idgenerator Spring Boot example | S | Add Spring Boot REST demo before examples workflow split; keep Ktor scope in `#419`. |
+| P2 | [#420](https://github.com/bluetape4k/bluetape4k-projects/issues/420) Examples GitHub Actions 분리 | S | Move example verification out of Nightly after `#416/#419` examples are in place. |
 | P2 | [#149](https://github.com/bluetape4k/bluetape4k-projects/issues/149) utils/vector | M | Foundation for AI utilities. |
 | P2 | [#151](https://github.com/bluetape4k/bluetape4k-projects/issues/151) LLM/vector Testcontainers | L | Test foundation for AI/vector work. |
 | P2 | [#148](https://github.com/bluetape4k/bluetape4k-projects/issues/148) utils/ai epic | XL | Split after `#149/#151` scope is clear. |
@@ -55,6 +57,10 @@ Historical completed items from the old monorepo TODO are intentionally omitted 
 #324 KDoc
 #325 CHANGELOG
   -> one small docs PR is preferred
+
+#416 Spring Boot idgenerator example
+#419 Ktor idgenerator example
+  -> #420 Examples workflow split
 ```
 
 ## WIP Limits
@@ -64,6 +70,7 @@ Historical completed items from the old monorepo TODO are intentionally omitted 
 | Policy / breaking cleanup |     1 | Keep `#257` updated as split phases close. |
 | Extraction planning       |     1 | Keep `#257` current; `#262` is deferred.   |
 | Shared Spring utilities   |     1 | `#364` as a small API PR before downstream cleanup. |
+| Examples                  |     1 | Finish `#416`, then `#420`; keep `#419` in its own PR. |
 | AI/vector                 |     1 | `#149` or `#151`, not `#148` first.        |
 | Docs polish               |  1 PR | `#323/#324/#325` together.                 |
 

--- a/docs/lessons/2026-05-12-issue-416-idgenerator-spring-demo.md
+++ b/docs/lessons/2026-05-12-issue-416-idgenerator-spring-demo.md
@@ -1,0 +1,25 @@
+# Issue 416 idgenerator Spring Boot demo
+
+## Context
+
+#416은 `bluetape4k-idgenerators`를 Spring Boot에서 바로 참고할 수 있는 예제로 제공하는 작업이다. #419의 Ktor 예제와 범위를 나누되, endpoint 스타일은 명시적 `/ids/*`와 generic `/idgen/{type}`을 모두 제공하는 방향으로 정리했다.
+
+## Decision
+
+- 새 예제는 기존 Spring Boot demo 계열과 맞춰 `spring-boot/idgenerator-demo`에 둔다.
+- `IdGeneratorConfiguration`에서 generator Bean 등록 방식을 드러내고, `IdGeneratorRegistry`가 REST type과 generator를 매핑한다.
+- 사용자가 선호한 명시적 endpoint를 유지하면서, 재사용성이 좋은 `/idgen/{type}`도 함께 제공한다.
+- unique ID 검증은 endpoint 테스트에서 `SuspendedJobTester`를 사용해 병렬 요청으로 증명한다.
+
+## Outcome
+
+Spring Boot 애플리케이션, REST controller/service/registry/configuration, README.md/README.ko.md, 테스트 리소스와 lesson 문서를 추가했다.
+
+## Verification Evidence
+
+- `./gradlew :bluetape4k-spring-boot-idgenerator-demo:compileKotlin :bluetape4k-spring-boot-idgenerator-demo:compileTestKotlin --parallel` 성공.
+- `./gradlew :bluetape4k-spring-boot-idgenerator-demo:test --parallel` 성공, `IdGeneratorDemoApplicationTest` 7개 통과.
+
+## Future Guidance
+
+idgenerator 예제는 endpoint를 줄이지 말고 명시적 endpoint와 generic endpoint를 함께 유지한다. 테스트에는 단순 응답 확인뿐 아니라 병렬 unique ID 검증을 포함한다.

--- a/spring-boot/idgenerator-demo/README.ko.md
+++ b/spring-boot/idgenerator-demo/README.ko.md
@@ -1,0 +1,79 @@
+# bluetape4k Spring Boot idgenerator demo
+
+[English](./README.md) | 한국어
+
+이 예제는 `bluetape4k-idgenerators`를 Spring Boot REST 애플리케이션으로 노출하는 방법을 보여줍니다.
+Ktor 예제는 #419에서 별도로 다룹니다.
+
+## 아키텍처
+
+```mermaid
+flowchart LR
+    C["IdGeneratorController"] --> S["IdGeneratorService"]
+    S --> R["IdGeneratorRegistry"]
+    R --> UV4["UuidGenerator\\nUUID v4"]
+    R --> UV7["UuidGenerator\\nUUID v7"]
+    R --> UL["UlidGenerator"]
+    R --> KS["KsuidGenerator"]
+    R --> SN["SnowflakeGenerator"]
+    R --> FL["Flake"]
+    P["IdGeneratorProperties"] --> S
+```
+
+## 설정
+
+```yaml
+bluetape4k:
+  id-generator:
+    default-batch-size: 10
+    max-batch-size: 100
+```
+
+`IdGeneratorConfiguration`은 각 generator를 Spring Bean으로 등록합니다. `IdGeneratorRegistry`는 REST
+type 이름을 실제 generator에 매핑하고, `IdGeneratorService`는 batch size 검증을 담당합니다.
+
+## 엔드포인트
+
+명시적 엔드포인트:
+
+| Method | Path |
+|---|---|
+| GET | `/ids/uuid-v4` |
+| GET | `/ids/uuid-v7` |
+| GET | `/ids/ulid` |
+| GET | `/ids/ksuid` |
+| GET | `/ids/snowflake` |
+| GET | `/ids/flake` |
+| GET | `/ids/{type}/batch?size=10` |
+
+Generic 엔드포인트:
+
+| Method | Path |
+|---|---|
+| GET | `/idgen/{type}` |
+| GET | `/idgen/{type}/batch?size=10` |
+| GET | `/generators` |
+| GET | `/health` |
+
+지원 type은 `uuid-v4`, `uuid-v7`, `ulid`, `ksuid`, `snowflake`, `flake`입니다.
+
+## 사용법
+
+```bash
+./gradlew :bluetape4k-spring-boot-idgenerator-demo:bootRun
+```
+
+```bash
+curl http://localhost:8080/ids/uuid-v7
+curl 'http://localhost:8080/idgen/snowflake/batch?size=5'
+curl http://localhost:8080/generators
+```
+
+## 테스트
+
+```bash
+./gradlew :bluetape4k-spring-boot-idgenerator-demo:test
+```
+
+테스트는 Spring Boot 애플리케이션을 로드하고 모든 REST endpoint를 검증합니다. 또한 `SuspendedJobTester`로
+UUID v7과 Snowflake 병렬 요청이 중복 없는 ID를 반환함을 증명합니다.

--- a/spring-boot/idgenerator-demo/README.md
+++ b/spring-boot/idgenerator-demo/README.md
@@ -1,0 +1,79 @@
+# bluetape4k Spring Boot idgenerator demo
+
+English | [한국어](./README.ko.md)
+
+This example shows how to expose `bluetape4k-idgenerators` through a Spring Boot REST application.
+The Ktor version is tracked separately in issue #419.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    C["IdGeneratorController"] --> S["IdGeneratorService"]
+    S --> R["IdGeneratorRegistry"]
+    R --> UV4["UuidGenerator\\nUUID v4"]
+    R --> UV7["UuidGenerator\\nUUID v7"]
+    R --> UL["UlidGenerator"]
+    R --> KS["KsuidGenerator"]
+    R --> SN["SnowflakeGenerator"]
+    R --> FL["Flake"]
+    P["IdGeneratorProperties"] --> S
+```
+
+## Configuration
+
+```yaml
+bluetape4k:
+  id-generator:
+    default-batch-size: 10
+    max-batch-size: 100
+```
+
+`IdGeneratorConfiguration` registers each generator as a Spring Bean. `IdGeneratorRegistry` maps the REST
+type name to the concrete generator and `IdGeneratorService` applies batch-size validation.
+
+## Endpoints
+
+Explicit endpoints:
+
+| Method | Path |
+|---|---|
+| GET | `/ids/uuid-v4` |
+| GET | `/ids/uuid-v7` |
+| GET | `/ids/ulid` |
+| GET | `/ids/ksuid` |
+| GET | `/ids/snowflake` |
+| GET | `/ids/flake` |
+| GET | `/ids/{type}/batch?size=10` |
+
+Generic endpoints:
+
+| Method | Path |
+|---|---|
+| GET | `/idgen/{type}` |
+| GET | `/idgen/{type}/batch?size=10` |
+| GET | `/generators` |
+| GET | `/health` |
+
+Supported types are `uuid-v4`, `uuid-v7`, `ulid`, `ksuid`, `snowflake`, and `flake`.
+
+## Usage
+
+```bash
+./gradlew :bluetape4k-spring-boot-idgenerator-demo:bootRun
+```
+
+```bash
+curl http://localhost:8080/ids/uuid-v7
+curl 'http://localhost:8080/idgen/snowflake/batch?size=5'
+curl http://localhost:8080/generators
+```
+
+## Tests
+
+```bash
+./gradlew :bluetape4k-spring-boot-idgenerator-demo:test
+```
+
+The tests load the Spring Boot application, verify all REST endpoints, and use `SuspendedJobTester`
+to prove that parallel UUID v7 and Snowflake requests return unique IDs.

--- a/spring-boot/idgenerator-demo/build.gradle.kts
+++ b/spring-boot/idgenerator-demo/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    kotlin("plugin.spring")
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    implementation(platform(libs.spring.boot.dependencies))
+
+    implementation(project(":bluetape4k-idgenerators"))
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    implementation(libs.jackson3.module.kotlin)
+    implementation(libs.jackson3.module.blackbird)
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-webtestclient")
+    testImplementation(project(":bluetape4k-spring-boot-core"))
+    testImplementation(project(":bluetape4k-junit5"))
+}

--- a/spring-boot/idgenerator-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/IdGeneratorDemoApplication.kt
+++ b/spring-boot/idgenerator-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/IdGeneratorDemoApplication.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.examples.idgenerator
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.runApplication
+
+/**
+ * bluetape4k idgenerator Spring Boot 예제 애플리케이션입니다.
+ *
+ * ## 동작/계약
+ * - `IdGenerator` 구현체를 Spring Bean으로 등록하고 REST controller에서 주입받아 사용합니다.
+ * - `/ids/...` 명시적 endpoint와 `/idgen/{type}` generic endpoint를 모두 제공합니다.
+ *
+ * ```kotlin
+ * fun main(args: Array<String>) {
+ *     runApplication<IdGeneratorDemoApplication>(*args)
+ * }
+ * ```
+ */
+@ConfigurationPropertiesScan
+@SpringBootApplication(proxyBeanMethods = false)
+class IdGeneratorDemoApplication
+
+fun main(args: Array<String>) {
+    runApplication<IdGeneratorDemoApplication>(*args)
+}

--- a/spring-boot/idgenerator-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/config/IdGeneratorConfiguration.kt
+++ b/spring-boot/idgenerator-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/config/IdGeneratorConfiguration.kt
@@ -1,0 +1,50 @@
+package io.bluetape4k.examples.idgenerator.config
+
+import io.bluetape4k.idgenerators.flake.Flake
+import io.bluetape4k.idgenerators.ksuid.KsuidGenerator
+import io.bluetape4k.idgenerators.snowflake.SnowflakeGenerator
+import io.bluetape4k.idgenerators.ulid.UlidGenerator
+import io.bluetape4k.idgenerators.uuid.Uuid
+import io.bluetape4k.idgenerators.uuid.UuidGenerator
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * idgenerator 구현체를 Spring Bean으로 등록하는 예제 설정입니다.
+ *
+ * ## 동작/계약
+ * - 같은 타입의 UUID generator는 Bean 이름으로 구분합니다.
+ * - Controller와 Service는 concrete generator 대신 registry를 통해 문자열 type을 generator에 매핑합니다.
+ *
+ * ```kotlin
+ * @Autowired
+ * lateinit var uuidV7Generator: UuidGenerator
+ * ```
+ */
+@Configuration(proxyBeanMethods = false)
+class IdGeneratorConfiguration {
+
+    @Bean
+    fun uuidV4Generator(): UuidGenerator =
+        UuidGenerator(Uuid.V4)
+
+    @Bean
+    fun uuidV7Generator(): UuidGenerator =
+        UuidGenerator(Uuid.V7)
+
+    @Bean
+    fun ulidGenerator(): UlidGenerator =
+        UlidGenerator()
+
+    @Bean
+    fun ksuidGenerator(): KsuidGenerator =
+        KsuidGenerator()
+
+    @Bean
+    fun snowflakeGenerator(): SnowflakeGenerator =
+        SnowflakeGenerator()
+
+    @Bean
+    fun flakeGenerator(): Flake =
+        Flake()
+}

--- a/spring-boot/idgenerator-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/config/IdGeneratorProperties.kt
+++ b/spring-boot/idgenerator-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/config/IdGeneratorProperties.kt
@@ -1,0 +1,23 @@
+package io.bluetape4k.examples.idgenerator.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * ID batch 발급 예제에서 사용하는 설정 속성입니다.
+ *
+ * ## 동작/계약
+ * - `defaultBatchSize`는 size query parameter가 없을 때 사용합니다.
+ * - `maxBatchSize`는 예제 API가 한 번에 발급하는 ID 개수를 제한합니다.
+ *
+ * ```yaml
+ * bluetape4k:
+ *   id-generator:
+ *     default-batch-size: 10
+ *     max-batch-size: 100
+ * ```
+ */
+@ConfigurationProperties(prefix = "bluetape4k.id-generator")
+data class IdGeneratorProperties(
+    val defaultBatchSize: Int = 10,
+    val maxBatchSize: Int = 100,
+)

--- a/spring-boot/idgenerator-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorController.kt
+++ b/spring-boot/idgenerator-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorController.kt
@@ -1,0 +1,79 @@
+package io.bluetape4k.examples.idgenerator.controller
+
+import io.bluetape4k.examples.idgenerator.service.IdGeneratorRegistry
+import io.bluetape4k.examples.idgenerator.service.IdGeneratorService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * idgenerator Spring Boot REST 예제 controller입니다.
+ *
+ * ## 동작/계약
+ * - `/ids/{type}` 계열은 명시적이고 복사하기 쉬운 endpoint를 제공합니다.
+ * - `/idgen/{type}` 계열은 type을 path variable로 받는 generic endpoint를 제공합니다.
+ *
+ * ```http
+ * GET /ids/uuid-v7
+ * GET /idgen/snowflake/batch?size=10
+ * ```
+ */
+@RestController
+class IdGeneratorController(
+    private val service: IdGeneratorService,
+    private val registry: IdGeneratorRegistry,
+) {
+
+    @GetMapping("/ids/uuid-v4")
+    fun uuidV4(): IdResponse =
+        service.generate("uuid-v4")
+
+    @GetMapping("/ids/uuid-v7")
+    fun uuidV7(): IdResponse =
+        service.generate("uuid-v7")
+
+    @GetMapping("/ids/ulid")
+    fun ulid(): IdResponse =
+        service.generate("ulid")
+
+    @GetMapping("/ids/ksuid")
+    fun ksuid(): IdResponse =
+        service.generate("ksuid")
+
+    @GetMapping("/ids/snowflake")
+    fun snowflake(): IdResponse =
+        service.generate("snowflake")
+
+    @GetMapping("/ids/flake")
+    fun flake(): IdResponse =
+        service.generate("flake")
+
+    @GetMapping("/ids/{type}/batch")
+    fun batch(
+        @PathVariable type: String,
+        @RequestParam(required = false) size: Int?,
+    ): IdBatchResponse =
+        service.generateBatch(type, size)
+
+    @GetMapping("/idgen/{type}")
+    fun generate(
+        @PathVariable type: String,
+    ): IdResponse =
+        service.generate(type)
+
+    @GetMapping("/idgen/{type}/batch")
+    fun generateBatch(
+        @PathVariable type: String,
+        @RequestParam(required = false) size: Int?,
+    ): IdBatchResponse =
+        service.generateBatch(type, size)
+
+    @GetMapping("/generators")
+    fun generators(): GeneratorsResponse =
+        service.generators()
+
+    @GetMapping("/health")
+    fun health(): HealthResponse =
+        HealthResponse(status = "UP", supportedTypes = registry.supportedTypes)
+}

--- a/spring-boot/idgenerator-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorExceptionHandler.kt
+++ b/spring-boot/idgenerator-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorExceptionHandler.kt
@@ -1,0 +1,46 @@
+package io.bluetape4k.examples.idgenerator.controller
+
+import io.bluetape4k.examples.idgenerator.service.InvalidBatchSizeException
+import io.bluetape4k.examples.idgenerator.service.UnsupportedGeneratorTypeException
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+/**
+ * idgenerator REST 예제의 입력 검증 오류를 JSON 응답으로 변환합니다.
+ *
+ * ## 동작/계약
+ * - 지원하지 않는 type과 batch size 오류는 HTTP 400으로 응답합니다.
+ * - 예제 API 사용자가 문제를 재현할 수 있도록 path와 message를 포함합니다.
+ */
+@RestControllerAdvice
+class IdGeneratorExceptionHandler {
+
+    @ExceptionHandler(UnsupportedGeneratorTypeException::class)
+    fun handleUnsupportedType(
+        ex: UnsupportedGeneratorTypeException,
+        request: HttpServletRequest,
+    ): ResponseEntity<ErrorResponse> =
+        badRequest(ex.message ?: "Unsupported generator type", request)
+
+    @ExceptionHandler(InvalidBatchSizeException::class)
+    fun handleInvalidBatchSize(
+        ex: InvalidBatchSizeException,
+        request: HttpServletRequest,
+    ): ResponseEntity<ErrorResponse> =
+        badRequest(ex.message ?: "Invalid batch size", request)
+
+    private fun badRequest(message: String, request: HttpServletRequest): ResponseEntity<ErrorResponse> =
+        ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(
+                ErrorResponse(
+                    status = HttpStatus.BAD_REQUEST.value(),
+                    error = HttpStatus.BAD_REQUEST.reasonPhrase,
+                    message = message,
+                    path = request.requestURI,
+                ),
+            )
+}

--- a/spring-boot/idgenerator-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorResponses.kt
+++ b/spring-boot/idgenerator-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorResponses.kt
@@ -1,0 +1,62 @@
+package io.bluetape4k.examples.idgenerator.controller
+
+import java.time.Instant
+
+/**
+ * 단건 ID 발급 응답입니다.
+ *
+ * ## 동작/계약
+ * - [type]은 요청한 generator type입니다.
+ * - [id]는 문자열로 직렬화된 새 ID입니다.
+ */
+data class IdResponse(
+    val type: String,
+    val id: String,
+)
+
+/**
+ * 배치 ID 발급 응답입니다.
+ *
+ * ## 동작/계약
+ * - [size]는 실제 생성된 ID 개수입니다.
+ * - [ids]는 요청 순서대로 생성된 문자열 ID 목록입니다.
+ */
+data class IdBatchResponse(
+    val type: String,
+    val size: Int,
+    val ids: List<String>,
+)
+
+/**
+ * 지원 generator 목록 응답입니다.
+ */
+data class GeneratorsResponse(
+    val generators: List<GeneratorResponse>,
+)
+
+/**
+ * 단일 generator 설명 응답입니다.
+ */
+data class GeneratorResponse(
+    val type: String,
+    val description: String,
+)
+
+/**
+ * 예제 애플리케이션 상태 응답입니다.
+ */
+data class HealthResponse(
+    val status: String,
+    val supportedTypes: Set<String>,
+)
+
+/**
+ * 입력 검증 실패 응답입니다.
+ */
+data class ErrorResponse(
+    val status: Int,
+    val error: String,
+    val message: String,
+    val path: String,
+    val timestamp: Instant = Instant.now(),
+)

--- a/spring-boot/idgenerator-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/service/IdGeneratorRegistry.kt
+++ b/spring-boot/idgenerator-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/service/IdGeneratorRegistry.kt
@@ -1,0 +1,98 @@
+package io.bluetape4k.examples.idgenerator.service
+
+import io.bluetape4k.idgenerators.IdGenerator
+import io.bluetape4k.idgenerators.flake.Flake
+import io.bluetape4k.idgenerators.ksuid.KsuidGenerator
+import io.bluetape4k.idgenerators.snowflake.SnowflakeGenerator
+import io.bluetape4k.idgenerators.ulid.UlidGenerator
+import io.bluetape4k.idgenerators.uuid.UuidGenerator
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+
+/**
+ * REST API의 문자열 type을 실제 ID generator Bean에 매핑합니다.
+ *
+ * ## 동작/계약
+ * - 지원 type은 `uuid-v4`, `uuid-v7`, `ulid`, `ksuid`, `snowflake`, `flake`입니다.
+ * - registry는 generator 구현체를 직접 노출하지 않고 문자열 ID 생성 함수로 감쌉니다.
+ *
+ * ```kotlin
+ * val next = registry.get("uuid-v7").nextId()
+ * ```
+ */
+@Component
+class IdGeneratorRegistry(
+    @Qualifier("uuidV4Generator") uuidV4Generator: UuidGenerator,
+    @Qualifier("uuidV7Generator") uuidV7Generator: UuidGenerator,
+    ulidGenerator: UlidGenerator,
+    ksuidGenerator: KsuidGenerator,
+    snowflakeGenerator: SnowflakeGenerator,
+    flakeGenerator: Flake,
+) {
+    private val entries: Map<String, IdGeneratorEntry> =
+        listOf(
+            IdGeneratorEntry(
+                type = "uuid-v4",
+                description = "Random UUID v4",
+                nextId = uuidV4Generator::nextIdAsString,
+            ),
+            IdGeneratorEntry(
+                type = "uuid-v7",
+                description = "Time-ordered UUID v7",
+                nextId = uuidV7Generator::nextIdAsString,
+            ),
+            IdGeneratorEntry(
+                type = "ulid",
+                description = "Monotonic ULID string",
+                nextId = ulidGenerator::nextIdAsString,
+            ),
+            IdGeneratorEntry(
+                type = "ksuid",
+                description = "K-Sortable Unique Identifier string",
+                nextId = ksuidGenerator::nextIdAsString,
+            ),
+            IdGeneratorEntry(
+                type = "snowflake",
+                description = "Twitter-style Snowflake long ID",
+                nextId = snowflakeGenerator::nextIdAsString,
+            ),
+            IdGeneratorEntry(
+                type = "flake",
+                description = "Boundary-style 128-bit Flake ID encoded as Base62",
+                nextId = flakeGenerator::nextIdAsString,
+            ),
+        ).associateBy { it.type }
+
+    val supportedTypes: Set<String>
+        get() = entries.keys
+
+    fun all(): List<IdGeneratorEntry> =
+        entries.values.toList()
+
+    fun get(type: String): IdGeneratorEntry =
+        entries[type] ?: throw UnsupportedGeneratorTypeException(type, supportedTypes)
+}
+
+/**
+ * REST API에서 사용할 ID generator 항목입니다.
+ *
+ * ## 동작/계약
+ * - [nextId]는 매 호출마다 새 문자열 ID를 반환합니다.
+ * - type과 description은 endpoint 문서와 `/generators` 응답에 사용합니다.
+ */
+data class IdGeneratorEntry(
+    val type: String,
+    val description: String,
+    private val nextId: () -> String,
+) {
+    fun nextId(): String =
+        nextId.invoke()
+}
+
+/**
+ * 지원하지 않는 generator type을 요청했을 때 발생하는 예외입니다.
+ */
+class UnsupportedGeneratorTypeException(
+    val generatorType: String,
+    val supportedTypes: Set<String>,
+): IllegalArgumentException("Unsupported generator type: $generatorType")

--- a/spring-boot/idgenerator-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/service/IdGeneratorService.kt
+++ b/spring-boot/idgenerator-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/service/IdGeneratorService.kt
@@ -1,0 +1,64 @@
+package io.bluetape4k.examples.idgenerator.service
+
+import io.bluetape4k.examples.idgenerator.config.IdGeneratorProperties
+import io.bluetape4k.examples.idgenerator.controller.GeneratorResponse
+import io.bluetape4k.examples.idgenerator.controller.GeneratorsResponse
+import io.bluetape4k.examples.idgenerator.controller.IdBatchResponse
+import io.bluetape4k.examples.idgenerator.controller.IdResponse
+import org.springframework.stereotype.Service
+
+/**
+ * ID 발급 API의 애플리케이션 유스케이스를 담당합니다.
+ *
+ * ## 동작/계약
+ * - 단건 발급은 registry의 generator를 한 번 호출합니다.
+ * - 배치 발급은 `1..maxBatchSize` 범위로 검증한 뒤 요청 수만큼 ID를 생성합니다.
+ *
+ * ```kotlin
+ * val response = idGeneratorService.generate("uuid-v7")
+ * ```
+ */
+@Service
+class IdGeneratorService(
+    private val registry: IdGeneratorRegistry,
+    private val properties: IdGeneratorProperties,
+) {
+
+    fun generate(type: String): IdResponse {
+        val entry = registry.get(type)
+        return IdResponse(type = entry.type, id = entry.nextId())
+    }
+
+    fun generateBatch(type: String, size: Int?): IdBatchResponse {
+        val entry = registry.get(type)
+        val batchSize = validateBatchSize(size ?: properties.defaultBatchSize)
+        val ids = List(batchSize) { entry.nextId() }
+
+        return IdBatchResponse(type = entry.type, size = ids.size, ids = ids)
+    }
+
+    fun generators(): GeneratorsResponse =
+        GeneratorsResponse(
+            generators =
+                registry
+                    .all()
+                    .map { entry ->
+                        GeneratorResponse(type = entry.type, description = entry.description)
+                    },
+        )
+
+    private fun validateBatchSize(size: Int): Int {
+        if (size !in 1..properties.maxBatchSize) {
+            throw InvalidBatchSizeException(size, properties.maxBatchSize)
+        }
+        return size
+    }
+}
+
+/**
+ * batch size가 예제 API의 허용 범위를 벗어났을 때 발생하는 예외입니다.
+ */
+class InvalidBatchSizeException(
+    val batchSize: Int,
+    val maxBatchSize: Int,
+): IllegalArgumentException("Batch size must be between 1 and $maxBatchSize: $batchSize")

--- a/spring-boot/idgenerator-demo/src/main/resources/application.yaml
+++ b/spring-boot/idgenerator-demo/src/main/resources/application.yaml
@@ -1,0 +1,10 @@
+bluetape4k:
+  id-generator:
+    default-batch-size: 10
+    max-batch-size: 100
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health

--- a/spring-boot/idgenerator-demo/src/test/kotlin/io/bluetape4k/examples/idgenerator/IdGeneratorDemoApplicationTest.kt
+++ b/spring-boot/idgenerator-demo/src/test/kotlin/io/bluetape4k/examples/idgenerator/IdGeneratorDemoApplicationTest.kt
@@ -1,0 +1,165 @@
+package io.bluetape4k.examples.idgenerator
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.assertions.shouldNotBeBlank
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.examples.idgenerator.controller.ErrorResponse
+import io.bluetape4k.examples.idgenerator.controller.GeneratorsResponse
+import io.bluetape4k.examples.idgenerator.controller.HealthResponse
+import io.bluetape4k.examples.idgenerator.controller.IdBatchResponse
+import io.bluetape4k.examples.idgenerator.controller.IdResponse
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.spring.tests.httpGet
+import io.bluetape4k.utils.Runtimex
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.http.HttpStatus
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import java.util.concurrent.ConcurrentHashMap
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = [
+        "bluetape4k.id-generator.default-batch-size=5",
+        "bluetape4k.id-generator.max-batch-size=20",
+    ],
+)
+class IdGeneratorDemoApplicationTest {
+
+    @LocalServerPort
+    private val port: Int = 0
+
+    private val client: WebTestClient by lazy {
+        WebTestClient
+            .bindToServer()
+            .baseUrl("http://localhost:$port")
+            .build()
+    }
+
+    @Test
+    fun `explicit id endpoints generate ids`() {
+        val endpoints =
+            mapOf(
+                "/ids/uuid-v4" to "uuid-v4",
+                "/ids/uuid-v7" to "uuid-v7",
+                "/ids/ulid" to "ulid",
+                "/ids/ksuid" to "ksuid",
+                "/ids/snowflake" to "snowflake",
+                "/ids/flake" to "flake",
+            )
+
+        endpoints.forEach { (endpoint, type) ->
+            getOk<IdResponse>(endpoint)
+                .also {
+                    it.type shouldBeEqualTo type
+                    it.id.shouldNotBeBlank()
+                }
+        }
+    }
+
+    @Test
+    fun `generic idgen endpoint generates ids`() {
+        getOk<IdResponse>("/idgen/uuid-v7")
+            .also {
+                it.type shouldBeEqualTo "uuid-v7"
+                it.id.shouldNotBeBlank()
+            }
+    }
+
+    @Test
+    fun `batch endpoints generate unique ids`() {
+        val legacyResponse = getOk<IdBatchResponse>("/ids/uuid-v7/batch?size=7")
+        val genericResponse = getOk<IdBatchResponse>("/idgen/snowflake/batch?size=7")
+
+        listOf(legacyResponse, genericResponse).forEach { response ->
+            response.size shouldBeEqualTo 7
+            response.ids shouldHaveSize 7
+            response.ids.distinct() shouldHaveSize 7
+            response.ids.all { id -> id.isNotBlank() }.shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `default batch size comes from properties`() {
+        getOk<IdBatchResponse>("/idgen/ulid/batch")
+            .also {
+                it.type shouldBeEqualTo "ulid"
+                it.size shouldBeEqualTo 5
+                it.ids shouldHaveSize 5
+                it.ids.distinct() shouldHaveSize 5
+            }
+    }
+
+    @Test
+    fun `generators and health endpoints expose supported types`() {
+        val generatorResponse = getOk<GeneratorsResponse>("/generators")
+        val healthResponse = getOk<HealthResponse>("/health")
+
+        val expectedTypes = setOf("uuid-v4", "uuid-v7", "ulid", "ksuid", "snowflake", "flake")
+
+        generatorResponse
+            .generators
+            .map { it.type }
+            .toSet() shouldBeEqualTo expectedTypes
+
+        healthResponse.status shouldBeEqualTo "UP"
+        healthResponse.supportedTypes shouldBeEqualTo expectedTypes
+    }
+
+    @Test
+    fun `invalid type and batch size return bad request`() {
+        val typeResponse = getBadRequest("/idgen/unknown")
+        val sizeResponse = getBadRequest("/idgen/uuid-v7/batch?size=21")
+
+        typeResponse.status shouldBeEqualTo HttpStatus.BAD_REQUEST.value()
+        typeResponse.message.contains("Unsupported generator type").shouldBeTrue()
+
+        sizeResponse.status shouldBeEqualTo HttpStatus.BAD_REQUEST.value()
+        sizeResponse.message.contains("Batch size must be between 1 and 20").shouldBeTrue()
+    }
+
+    @Test
+    fun `parallel requests generate unique uuid v7 and snowflake ids`() =
+        runSuspendIO {
+            val ids = ConcurrentHashMap<String, Boolean>()
+
+            SuspendedJobTester()
+                .workers(Runtimex.availableProcessors)
+                .rounds(Runtimex.availableProcessors)
+                .add {
+                    val id = getOk<IdResponse>("/idgen/uuid-v7").id
+                    id.shouldNotBeBlank()
+                    ids.putIfAbsent(id, true).shouldBeNull()
+                }
+                .add {
+                    val id = getOk<IdResponse>("/idgen/snowflake").id
+                    id.shouldNotBeBlank()
+                    ids.putIfAbsent(id, true).shouldBeNull()
+                }
+                .run()
+        }
+
+    private inline fun <reified T: Any> getOk(path: String): T =
+        client
+            .httpGet(path, HttpStatus.OK)
+            .expectBody<T>()
+            .returnResult()
+            .responseBody
+            .shouldNotBeNull()
+
+    private fun getBadRequest(path: String): ErrorResponse =
+        client
+            .httpGet(path, HttpStatus.BAD_REQUEST)
+            .expectBody<ErrorResponse>()
+            .returnResult()
+            .responseBody
+            .shouldNotBeNull()
+}

--- a/spring-boot/idgenerator-demo/src/test/resources/junit-platform.properties
+++ b/spring-boot/idgenerator-demo/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/spring-boot/idgenerator-demo/src/test/resources/logback-test.xml
+++ b/spring-boot/idgenerator-demo/src/test/resources/logback-test.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <!-- @formatter:off -->
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%24.24t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <!-- @formatter:on -->
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.examples.idgenerator" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
## Summary

Closes #416

- PR 제목: feat: idgenerator Spring Boot 예제 제공

#416의 Spring Boot idgenerator 예제를 추가합니다. Ktor 예제는 #419 PR과 분리하고, 이 PR은 Spring Boot 4 기준의 REST 예제와 문서/테스트에만 집중합니다.

Closes #416

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- `spring-boot/idgenerator-demo` 모듈 추가
- `UuidGenerator`, `UlidGenerator`, `KsuidGenerator`, `SnowflakeGenerator`, `Flake` Bean 등록 예제 추가
- 명시적 endpoint와 generic endpoint를 모두 제공
  - `/ids/uuid-v4`, `/ids/uuid-v7`, `/ids/ulid`, `/ids/ksuid`, `/ids/snowflake`, `/ids/flake`
  - `/ids/{type}/batch?size=10`
  - `/idgen/{type}`, `/idgen/{type}/batch?size=10`
  - `/generators`, `/health`
- Spring Boot 4 테스트 스타일에 맞춰 `WebTestClient`를 사용하고, `bluetape4k-spring-boot-core`의 `httpGet` helper 재사용
- `SuspendedJobTester`로 병렬 요청의 unique ID 발급 검증 추가
- `README.md`, `README.ko.md`, `docs/lessons/2026-05-12-issue-416-idgenerator-spring-demo.md` 추가
- `WIP.md`에 #416/#420 예제 작업 흐름 반영

### 기존 섹션: 후속 작업

- #420에서 기존 `examples/*`와 신규 예제 검증을 Nightly에서 별도 Examples Action으로 분리합니다.

## Validation

- `./gradlew :bluetape4k-spring-boot-idgenerator-demo:compileKotlin :bluetape4k-spring-boot-idgenerator-demo:compileTestKotlin --parallel`
- `./gradlew :bluetape4k-spring-boot-idgenerator-demo:test --parallel`
  - `IdGeneratorDemoApplicationTest` 7개 통과

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #416, milestone 없음, assignee `debop`
- PR: #422, head `c1210f21ac77316603d28ed17dbb8a0781b695b7`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `issue-416-idgenerator-spring`
- Labels: 없음
- State: `MERGED`, merge commit `fd31a3ba09ceb31b6a832468c51d4c87df54554d`
- CI: - `./gradlew :bluetape4k-spring-boot-idgenerator-demo:compileKotlin :bluetape4k-spring-boot-idgenerator-demo:compileTestKotlin --parallel` / - `./gradlew :bluetape4k-spring-boot-idgenerator-demo:test --parallel`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #422 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `fd31a3ba09ceb31b6a832468c51d4c87df54554d`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
