### PR TITLE
ci: Examples workflow 분리

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,115 @@
+name: Examples
+
+on:
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - 'examples/**'
+      - 'spring-boot/idgenerator-demo/**'
+      - 'settings.gradle.kts'
+      - 'build.gradle.kts'
+      - 'buildSrc/**'
+      - 'gradle/**'
+      - 'gradle.properties'
+      - '.github/workflows/examples.yml'
+      - 'utils/idgenerators/**'
+      - 'bluetape4k/**'
+      - 'io/**'
+      - 'infra/**'
+      - 'cache/**'
+      - 'virtualthread/**'
+  push:
+    branches: [develop]
+    paths:
+      - 'examples/**'
+      - 'spring-boot/idgenerator-demo/**'
+      - 'settings.gradle.kts'
+      - 'build.gradle.kts'
+      - 'buildSrc/**'
+      - 'gradle/**'
+      - 'gradle.properties'
+      - '.github/workflows/examples.yml'
+      - 'utils/idgenerators/**'
+      - 'bluetape4k/**'
+      - 'io/**'
+      - 'infra/**'
+      - 'cache/**'
+      - 'virtualthread/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: examples-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  JAVA_VERSION: '21'
+  JAVA_DISTRIBUTION: 'temurin'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  test-examples:
+    name: Test Examples
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: wrapper
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
+
+      - name: Compile and test examples
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tasks=(
+            :bluetape4k-examples-coroutines-demo:compileKotlin
+            :bluetape4k-examples-coroutines-demo:test
+            :bluetape4k-examples-jpa-querydsl-demo:compileKotlin
+            :bluetape4k-examples-jpa-querydsl-demo:test
+            :bluetape4k-examples-redisson-demo:compileKotlin
+            :bluetape4k-examples-redisson-demo:test
+            :bluetape4k-examples-virtualthreads-demo:compileKotlin
+            :bluetape4k-examples-virtualthreads-demo:test
+          )
+
+          if [[ -f examples/ktor/idgenerator-ktor/build.gradle.kts ]]; then
+            tasks+=(
+              :idgenerator-ktor:compileKotlin
+              :idgenerator-ktor:test
+            )
+          fi
+
+          if [[ -f spring-boot/idgenerator-demo/build.gradle.kts ]]; then
+            tasks+=(
+              :bluetape4k-spring-boot-idgenerator-demo:compileKotlin
+              :bluetape4k-spring-boot-idgenerator-demo:test
+            )
+          fi
+
+          ./gradlew "${tasks[@]}" --parallel
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Upload example test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: examples-test-results
+          path: |
+            examples/**/build/test-results/test/**
+            examples/**/build/reports/tests/test/**
+            spring-boot/idgenerator-demo/build/test-results/test/**
+            spring-boot/idgenerator-demo/build/reports/tests/test/**
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -303,8 +303,27 @@ jobs:
           gradle-version: wrapper
           cache-read-only: false
 
-      - name: Build (compile only)
-        run: ./gradlew build -x test --parallel
+      - name: Build (compile only, excluding examples)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          excluded_tasks=(
+            -x :bluetape4k-examples-coroutines-demo:build
+            -x :bluetape4k-examples-jpa-querydsl-demo:build
+            -x :bluetape4k-examples-redisson-demo:build
+            -x :bluetape4k-examples-virtualthreads-demo:build
+          )
+
+          projects="$(./gradlew -q projects)"
+          if grep -q -- "--- Project ':idgenerator-ktor'" <<< "$projects"; then
+            excluded_tasks+=(-x :idgenerator-ktor:build)
+          fi
+          if grep -q -- "--- Project ':bluetape4k-spring-boot-idgenerator-demo'" <<< "$projects"; then
+            excluded_tasks+=(-x :bluetape4k-spring-boot-idgenerator-demo:build)
+          fi
+
+          ./gradlew build -x test "${excluded_tasks[@]}" --parallel
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 

--- a/docs/lessons/2026-05-12-issue-420-examples-workflow.md
+++ b/docs/lessons/2026-05-12-issue-420-examples-workflow.md
@@ -26,6 +26,8 @@ Examples workflow와 Nightly example 제외 로직을 추가했다.
   - redisson demo: 89 passing.
   - virtualthreads demo: 32 passing.
 - `./gradlew build -x test ... --dry-run | rg "bluetape4k-examples|idgenerator-ktor|spring-boot-idgenerator-demo"` 결과 match 없음으로 Nightly build exclusion 확인.
+- 첫 GitHub Actions 실행에서 `examples/virtualthreads-demo`의 `Example3_CreateStartedAndUnstartedVirtualThread`가 virtual thread 상태를 `RUNNABLE`로 고정 기대해 CI에서 `TIMED_WAITING`을 관측하며 실패했다. 상태값 대신 latch로 시작/생존 여부를 검증하도록 안정화했다.
+- `./gradlew :bluetape4k-examples-virtualthreads-demo:test --parallel` 성공, virtualthreads demo 32개 통과.
 
 ## Future Guidance
 

--- a/docs/lessons/2026-05-12-issue-420-examples-workflow.md
+++ b/docs/lessons/2026-05-12-issue-420-examples-workflow.md
@@ -1,0 +1,32 @@
+# Issue 420 Examples workflow 분리
+
+## Context
+
+#420은 예제 모듈을 Nightly의 라이브러리 회귀 테스트 범위에서 분리하고, 사용 예제 전용 GitHub Actions workflow로 검증하는 작업이다. 기존 `examples/*` 네 모듈과 후속 idgenerator 예제들이 대상이다.
+
+## Decision
+
+- `.github/workflows/examples.yml`을 새로 만들고 workflow 이름은 `Examples`로 둔다.
+- 기존 `examples/*` 네 모듈은 Examples workflow에서 compile/test를 직접 실행한다.
+- #419 Ktor 예제와 #416 Spring Boot 예제는 별도 PR 순서에 영향받지 않도록 모듈 파일이 있을 때만 task를 추가한다.
+- Nightly의 root `build -x test`는 example module build task를 제외해 예제 compile을 Examples workflow로 옮긴다.
+- 예제 coverage는 업로드하지 않고 test result artifact만 보관한다.
+
+## Outcome
+
+Examples workflow와 Nightly example 제외 로직을 추가했다.
+
+## Verification Evidence
+
+- `ruby -e 'require "yaml"; ...' .github/workflows/examples.yml .github/workflows/nightly-tests.yml` 성공.
+- `./gradlew -q projects | rg "bluetape4k-examples|idgenerator-ktor|spring-boot-idgenerator-demo"`로 현재 branch의 기존 examples 4개 모듈만 확인.
+- `./gradlew :bluetape4k-examples-coroutines-demo:compileKotlin :bluetape4k-examples-coroutines-demo:test :bluetape4k-examples-jpa-querydsl-demo:compileKotlin :bluetape4k-examples-jpa-querydsl-demo:test :bluetape4k-examples-redisson-demo:compileKotlin :bluetape4k-examples-redisson-demo:test :bluetape4k-examples-virtualthreads-demo:compileKotlin :bluetape4k-examples-virtualthreads-demo:test --parallel` 성공.
+  - coroutines demo: 125 passing, 2 pending.
+  - jpa-querydsl demo: 42 passing, 1 pending.
+  - redisson demo: 89 passing.
+  - virtualthreads demo: 32 passing.
+- `./gradlew build -x test ... --dry-run | rg "bluetape4k-examples|idgenerator-ktor|spring-boot-idgenerator-demo"` 결과 match 없음으로 Nightly build exclusion 확인.
+
+## Future Guidance
+
+새 예제 모듈을 추가할 때는 Nightly가 아니라 `.github/workflows/examples.yml`에 등록한다. 다른 PR과 순서가 엮이는 예제 모듈은 파일 존재 여부를 확인한 뒤 task를 추가해 독립 PR을 깨지 않게 한다.

--- a/examples/virtualthreads-demo/src/test/kotlin/io/bluetape4k/examples/virtualthreads/part1/Example3_CreateStartedAndUnstartedVirtualThread.kt
+++ b/examples/virtualthreads-demo/src/test/kotlin/io/bluetape4k/examples/virtualthreads/part1/Example3_CreateStartedAndUnstartedVirtualThread.kt
@@ -3,7 +3,10 @@ package io.bluetape4k.examples.virtualthreads.part1
 import io.bluetape4k.examples.virtualthreads.AbstractVirtualThreadTest
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class Example3_CreateStartedAndUnstartedVirtualThread: AbstractVirtualThreadTest() {
 
@@ -12,26 +15,40 @@ class Example3_CreateStartedAndUnstartedVirtualThread: AbstractVirtualThreadTest
     @Test
     fun `자동 시작하는 Virtual Thread 생성하기`() {
         val builder = Thread.ofVirtual()
+        val started = CountDownLatch(1)
+        val release = CountDownLatch(1)
 
         val thread = builder.start {
-            Thread.sleep(1000)
+            started.countDown()
+            release.await(1, TimeUnit.SECONDS)
             println("Virtual thread running")
         }
-        thread.state shouldBeEqualTo Thread.State.RUNNABLE
+
+        started.await(1, TimeUnit.SECONDS).shouldBeTrue()
+        thread.isVirtual.shouldBeTrue()
+        thread.isAlive.shouldBeTrue()
+        release.countDown()
         thread.join()
     }
 
     @Test
     fun `수동으로 시작하는 Virtual Thread 생성하기`() {
         val builder = Thread.ofVirtual()
+        val started = CountDownLatch(1)
+        val release = CountDownLatch(1)
 
         val thread = builder.unstarted {
+            started.countDown()
+            release.await(1, TimeUnit.SECONDS)
             println("Virtual thread running")
         }
         thread.state shouldBeEqualTo Thread.State.NEW
         thread.start()
 
-        thread.state shouldBeEqualTo Thread.State.RUNNABLE
+        started.await(1, TimeUnit.SECONDS).shouldBeTrue()
+        thread.isVirtual.shouldBeTrue()
+        thread.isAlive.shouldBeTrue()
+        release.countDown()
         thread.join()
     }
 }


### PR DESCRIPTION
## Summary

Closes #420

- PR 제목: ci: Examples workflow 분리

#420의 요청대로 예제 모듈 검증을 Nightly에서 분리해 별도 `Examples` GitHub Actions workflow로 이동합니다.

Closes #420

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- `.github/workflows/examples.yml` 추가
  - `pull_request`, `push` on `develop`, `workflow_dispatch` 지원
  - `examples/**`, 예제 참조 핵심 모듈, Gradle 설정 변경 시 실행
  - 기존 `examples/*` 4개 모듈 compile/test 실행
  - test result artifact 업로드
- Nightly build job 변경
  - root `build -x test`는 유지하되 기존 examples build task를 명시적으로 제외
  - #419 Ktor 예제 `:idgenerator-ktor`와 #416 Spring Boot 예제 `:bluetape4k-spring-boot-idgenerator-demo`는 모듈이 존재할 때만 Nightly에서 제외하고 Examples workflow에서 실행되도록 조건 처리
- `docs/lessons/2026-05-12-issue-420-examples-workflow.md` 추가

### 기존 섹션: 참고

#416/#419는 별도 PR이므로, 이 PR에서는 해당 모듈이 아직 없어도 workflow가 실패하지 않도록 파일 존재 조건으로 task를 추가합니다.

## Validation

- YAML 파싱 확인
  - `ruby -e 'require "yaml"; ...' .github/workflows/examples.yml .github/workflows/nightly-tests.yml`
- 현재 branch의 examples 모듈 확인
  - `./gradlew -q projects | rg "bluetape4k-examples|idgenerator-ktor|spring-boot-idgenerator-demo"`
- Examples workflow task 목록과 동일한 로컬 검증
  - `./gradlew :bluetape4k-examples-coroutines-demo:compileKotlin :bluetape4k-examples-coroutines-demo:test :bluetape4k-examples-jpa-querydsl-demo:compileKotlin :bluetape4k-examples-jpa-querydsl-demo:test :bluetape4k-examples-redisson-demo:compileKotlin :bluetape4k-examples-redisson-demo:test :bluetape4k-examples-virtualthreads-demo:compileKotlin :bluetape4k-examples-virtualthreads-demo:test --parallel`
  - coroutines demo: 125 passing, 2 pending
  - jpa-querydsl demo: 42 passing, 1 pending
  - redisson demo: 89 passing
  - virtualthreads demo: 32 passing
- Nightly exclusion dry-run
  - examples 관련 task match 없음 확인

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #420, milestone 없음, assignee `debop`
- PR: #423, head `afddaaaad379c011cdaead2659b9669a1d5354eb`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `issue-420-examples-workflow`
- Labels: 없음
- State: `MERGED`, merge commit `4be0ac19e6bf6664251b51884c09a014187b54cb`
- CI: - `examples/**`, 예제 참조 핵심 모듈, Gradle 설정 변경 시 실행 / - `./gradlew -q projects | rg "bluetape4k-examples|idgenerator-ktor|spring-boot-idgenerator-demo"` / - `./gradlew :bluetape4k-examples-coroutines-demo:compileKotlin :bluetape4k-examples-coroutines-demo:test :bluetape4k-examples-jpa-querydsl-demo:compileKotlin :bluetape4k-examples-jpa-querydsl-demo:test :bluetape4k-examples-redisson-demo:compileKotlin :bluetape4k-examples-redisson-demo:test :bluetape4k-examples-virtualthreads-demo:compileKotlin :bluetape4k-examples-virtualthreads-demo:test --parallel`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #423 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `4be0ac19e6bf6664251b51884c09a014187b54cb`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
