### PR TITLE
Harden DAEAD chunk framing and virtual-thread coverage

### DIFF
--- a/docs/lessons/2026-05-13-daead-chunk-vt-followup.md
+++ b/docs/lessons/2026-05-13-daead-chunk-vt-followup.md
@@ -1,0 +1,51 @@
+# DAEAD Chunk and Virtual Thread Follow-up Lessons
+
+## Context
+
+Post-merge review of PRs #242, #264, #271, and #293 found that the DAEAD chunk
+format authenticated each chunk independently but did not bind chunk order or a
+final-frame marker. The same review also found that Virtual Thread tests covered
+direct fork/join flows but did not use the bluetape4k-junit5 stress harnesses.
+
+## Decision or Finding
+
+Security-sensitive chunked encryption must authenticate stream structure, not
+only each ciphertext payload. Per-frame DAEAD associated data must include at
+least the caller-provided associated data, a monotonically increasing chunk
+index, and final-frame state. Tests must include reorder, duplicate,
+whole-frame truncation, and trailing-data-after-final cases.
+
+For Virtual Thread and StructuredTaskScope changes, direct examples are not
+enough. Add `StructuredTaskScopeTester`, `MultithreadingTester`, or
+`SuspendedJobTester` coverage when the behavior depends on concurrency,
+coroutine scheduling, or virtual-thread propagation.
+
+## Outcome
+
+- DAEAD chunk frames now carry a final flag and bind chunk index/final state into
+  DAEAD associated data. The v2 frame format is intentionally not
+  wire-compatible with the previous length-only frames.
+- DAEAD tests now reject reordered, duplicated, final-frame-dropped, and
+  trailing-data-after-final streams.
+- `StructuredTaskScopeTester` coverage was added for `StructuredTaskScopes` and
+  `TaskContext` propagation.
+- StructuredTaskScope provider discovery now skips broken ServiceLoader entries
+  instead of stopping discovery.
+
+## Verification
+
+Targeted verification should include:
+
+- `repo-test-summary -- ./gradlew :bluetape4k-okio:test --tests "io.bluetape4k.okio.tink.DaeadChunk*Test"`
+- `repo-test-summary -- ./gradlew :bluetape4k-virtualthread-api:test --tests "io.bluetape4k.concurrent.virtualthread.*Test"`
+- `git diff --check`
+
+## Future Guidance
+
+When adding framed encryption formats, include adversarial frame-level tests:
+reorder, duplicate, drop final, truncate header/body, wrong associated data, and
+trailing data after final. Keep empty payload coverage because empty streams
+still need an authenticated final marker. When reviewing concurrency changes,
+explicitly check whether the appropriate bluetape4k-junit5 harness is used;
+otherwise add it in the follow-up PR rather than relying only on single-shot
+examples.

--- a/io/okio/README.ko.md
+++ b/io/okio/README.ko.md
@@ -219,9 +219,12 @@ encrypted.asDaeadChunkDecryptSource(
 }
 ```
 
-DAEAD 청크 암호화는 각 frame을 8-byte big-endian ciphertext 길이(`DEFAULT_DAEAD_CHUNK_SIZE` = 64 KiB)와
-DAEAD ciphertext로 기록합니다. 마지막 partial chunk는 `close()`에서 확정되므로
+DAEAD 청크 암호화는 각 frame을 `[1-byte flags][8-byte big-endian ciphertext length][ciphertext]`
+형식으로 기록합니다. `DEFAULT_DAEAD_CHUNK_SIZE`는 64 KiB입니다. 청크 index와 final-frame flag는
+DAEAD associated data에 바인딩되므로 frame 순서 변경, 중복 재생, whole-frame truncation은 복호화 중
+실패하며, final frame 뒤에 trailing data가 남아도 실패합니다. final frame은 `close()`에서 기록되므로
 암호화 Sink는 반드시 닫아야 하며, `use {}` 사용을 권장합니다.
+이는 v2 DAEAD chunk format이며 기존 `[8-byte length][ciphertext]` frame과 wire-compatible하지 않습니다.
 
 Deterministic AEAD는 같은 키, 평문, 연관 데이터에 대해 같은 암호문을 생성합니다.
 따라서 반복 평문 청크 패턴이 노출될 수 있습니다. 연관 데이터는 인증되지만 암호화되지 않으며,

--- a/io/okio/README.md
+++ b/io/okio/README.md
@@ -238,10 +238,15 @@ encrypted.asDaeadChunkDecryptSource(
 }
 ```
 
-DAEAD chunk encryption writes each frame as an 8-byte big-endian ciphertext
-length (`DEFAULT_DAEAD_CHUNK_SIZE = 64 KiB`) followed by the DAEAD ciphertext.
-Always close the encrypt sink, preferably with `use {}`, because the last partial
-chunk is finalized on `close()`.
+DAEAD chunk encryption writes each frame as `[1-byte flags][8-byte big-endian
+ciphertext length][ciphertext]`. `DEFAULT_DAEAD_CHUNK_SIZE` is 64 KiB. The
+chunk index and final-frame flag are bound into DAEAD associated data so frame
+reorder, duplicate replay, whole-frame truncation, and trailing data after the
+final frame fail during decryption.
+This is the v2 DAEAD chunk format and is not wire-compatible with older
+`[8-byte length][ciphertext]` frames.
+Always close the encrypt sink, preferably with `use {}`, because the final frame
+is written on `close()`.
 
 Deterministic AEAD produces the same ciphertext for the same key, plaintext, and
 associated data. This can reveal repeated plaintext chunks. Associated data is

--- a/io/okio/src/main/kotlin/io/bluetape4k/okio/tink/DaeadChunkDecryptSource.kt
+++ b/io/okio/src/main/kotlin/io/bluetape4k/okio/tink/DaeadChunkDecryptSource.kt
@@ -10,37 +10,41 @@ import okio.Source
 import java.io.IOException
 
 /**
- * DAEAD 청크 포맷으로 암호화된 데이터를 복호화하여 [Source]로 제공하는 구현체입니다.
+ * Decrypts a DAEAD chunk stream and exposes plaintext through [Source].
  *
- * 입력은 `[8-byte big-endian ciphertext length][ciphertext]` 청크의 반복이어야 합니다.
- * [read]는 필요한 경우 다음 청크 하나만 읽고 복호화하므로 전체 암호문을 메모리에 적재하지 않습니다.
+ * Input must be a sequence of `[1-byte flags][8-byte big-endian ciphertext length][ciphertext]`
+ * frames. [read] decrypts at most the next encrypted chunk when the internal
+ * plaintext buffer is empty, so it never loads the whole ciphertext stream into memory.
+ * The chunk index and final-frame flag are bound into DAEAD associated data, so
+ * chunk reorder, deletion, and duplicate replay fail with authentication or EOF errors.
  *
- * [TinkDeterministicAead]는 같은 키, 평문, 연관 데이터에 대해 같은 암호문을 생성합니다.
- * 이 특성 때문에 동일 청크 평문 반복 여부가 노출될 수 있습니다. 또한 [associatedData]는
- * 인증되지만 암호화되지 않으며, 암호화 시 사용한 값과 동일해야 복호화가 성공합니다.
+ * [TinkDeterministicAead] produces the same ciphertext for the same key,
+ * plaintext, and associated data. This can reveal repeated plaintext chunks.
+ * [associatedData] is authenticated but not encrypted and must match the value
+ * used during encryption.
  *
  * ```kotlin
  * val daead = TinkDaeads.AES256_SIV
  * val output = Buffer()
  *
- * // 암호화
+ * // Encrypt
  * output.asDaeadChunkEncryptSink(daead).use { sink ->
- *     sink.write(Buffer().writeUtf8("스트리밍 평문"), 14L)
+ *     sink.write(Buffer().writeUtf8("streaming plaintext"), 19L)
  * }
  *
- * // 복호화 — 한 번에 하나의 청크만 메모리에 적재
+ * // Decrypt — only one chunk is loaded at a time.
  * val decrypted = Buffer()
  * output.asDaeadChunkDecryptSource(daead).use { source ->
  *     source.read(decrypted, Long.MAX_VALUE)
  * }
- * val plaintext = decrypted.readUtf8() // "스트리밍 평문"
+ * val plaintext = decrypted.readUtf8() // "streaming plaintext"
  * ```
  *
- * @param delegate DAEAD 청크 암호문을 읽을 위임 [Source]
- * @param daead 청크 복호화에 사용할 DAEAD 래퍼
- * @param associatedData 청크 인증에 사용할 연관 데이터. 암호화 시 사용한 값과 동일해야 합니다.
- * @param maxCiphertextLength 허용하는 청크 ciphertext 최대 길이 (기본값: [DEFAULT_DAEAD_MAX_CIPHERTEXT_LENGTH]).
- *   신뢰할 수 없는 소스에서 읽을 때 대규모 메모리 할당 공격을 방어합니다.
+ * @param delegate source of DAEAD chunk ciphertext frames.
+ * @param daead DAEAD wrapper used to decrypt each chunk.
+ * @param associatedData caller-provided associated data. It must match the encryption value.
+ * @param maxCiphertextLength maximum allowed ciphertext length per frame.
+ *   Defaults to [DEFAULT_DAEAD_MAX_CIPHERTEXT_LENGTH] to limit memory allocation from untrusted sources.
  * @see DaeadChunkEncryptSink
  * @see TinkDecryptSource
  */
@@ -52,24 +56,27 @@ class DaeadChunkDecryptSource(
 ): ForwardingSource(delegate) {
 
     companion object: KLogging() {
-        private const val CHUNK_HEADER_SIZE = Long.SIZE_BYTES.toLong()
+        private const val CHUNK_HEADER_SIZE = 1L + Long.SIZE_BYTES
+        private const val TRAILING_PROBE_BYTE_COUNT = 64L
         private const val MAX_NO_PROGRESS_READS = 8
     }
 
     private val associatedData: ByteArray = associatedData.copyOf()
     private val plainBuffer = Buffer()
     private var closed = false
+    private var finished = false
+    private var chunkIndex = 0L
 
     /**
-     * 복호화된 평문을 [sink]에 최대 [byteCount] 바이트만큼 읽어옵니다.
+     * Reads up to [byteCount] decrypted plaintext bytes into [sink].
      *
-     * 내부 평문 버퍼가 비어 있으면 다음 청크 하나를 읽고 복호화합니다.
-     * 한 번 호출 시 최대 한 청크 분량의 평문만 반환할 수 있습니다.
+     * When the internal plaintext buffer is empty, this source reads and decrypts
+     * the next encrypted chunk. A single call returns at most one chunk of plaintext.
      *
-     * @param sink 복호화된 평문을 받을 버퍼
-     * @param byteCount 요청할 최대 바이트 수
-     * @return 실제 읽은 바이트 수 또는 EOF 시 -1
-     * @throws IOException close 이후 호출 시, 또는 스트림 포맷 오류 시
+     * @param sink target plaintext buffer.
+     * @param byteCount maximum requested byte count.
+     * @return number of bytes read, or `-1` after the authenticated final frame.
+     * @throws IOException after close or when the stream format/authentication is invalid.
      */
     override fun read(sink: Buffer, byteCount: Long): Long {
         if (closed) {
@@ -80,7 +87,10 @@ class DaeadChunkDecryptSource(
             return 0L
         }
 
-        if (plainBuffer.size == 0L && !readNextChunk()) {
+        while (plainBuffer.size == 0L && !finished) {
+            readNextChunk()
+        }
+        if (plainBuffer.size == 0L && finished) {
             return -1L
         }
 
@@ -90,7 +100,7 @@ class DaeadChunkDecryptSource(
     }
 
     /**
-     * 내부 평문 버퍼와 위임 [Source]를 닫습니다.
+     * Closes the internal plaintext buffer and delegate [Source].
      */
     override fun close() {
         if (closed) {
@@ -104,9 +114,15 @@ class DaeadChunkDecryptSource(
         }
     }
 
-    private fun readNextChunk(): Boolean {
-        val header = readExactlyOrNull(CHUNK_HEADER_SIZE) ?: return false
+    private fun readNextChunk() {
+        val header = readExactly(CHUNK_HEADER_SIZE)
+        val flags = header.readByte().toInt()
         val ciphertextLength = header.readLong()
+        val finalChunk = when (flags) {
+            DAEAD_CHUNK_NON_FINAL_FLAG -> false
+            DAEAD_CHUNK_FINAL_FLAG -> true
+            else -> throw IOException("Invalid DAEAD chunk flags: $flags")
+        }
 
         if (ciphertextLength <= 0L || ciphertextLength > Int.MAX_VALUE) {
             throw IOException("Invalid DAEAD chunk ciphertext length: $ciphertextLength")
@@ -117,15 +133,46 @@ class DaeadChunkDecryptSource(
             )
         }
 
-        val ciphertext = readExactlyOrNull(ciphertextLength)
-            ?: throw EOFException("Truncated DAEAD chunk ciphertext. expected=$ciphertextLength")
+        val ciphertext = readExactly(ciphertextLength)
 
-        val plaintext = daead.decryptDeterministically(ciphertext.readByteArray(), associatedData)
+        // The flag is part of AD; changing final/non-final state invalidates the frame.
+        val plaintext = daead.decryptDeterministically(
+            ciphertext.readByteArray(),
+            daeadChunkAssociatedData(associatedData, chunkIndex, finalChunk)
+        )
+        chunkIndex++
         plainBuffer.write(plaintext)
-        return true
+        if (finalChunk) {
+            ensureNoTrailingData()
+            finished = true
+        }
     }
 
-    private fun readExactlyOrNull(byteCount: Long): Buffer? {
+    private fun ensureNoTrailingData() {
+        val probe = Buffer()
+        var noProgressCount = 0
+
+        while (true) {
+            val bytesRead = super.read(probe, TRAILING_PROBE_BYTE_COUNT)
+            when {
+                bytesRead < 0L -> return
+
+                bytesRead == 0L -> {
+                    noProgressCount++
+                    if (noProgressCount >= MAX_NO_PROGRESS_READS) {
+                        throw IOException("Unable to verify DAEAD chunk stream EOF: no progress.")
+                    }
+                }
+
+                else -> {
+                    // Final frame authentication is only complete when no trailing frame bytes remain.
+                    throw IOException("Trailing DAEAD chunk data after final frame.")
+                }
+            }
+        }
+    }
+
+    private fun readExactly(byteCount: Long): Buffer {
         val buffer = Buffer()
         var noProgressCount = 0
 
@@ -133,9 +180,6 @@ class DaeadChunkDecryptSource(
             val bytesRead = super.read(buffer, byteCount - buffer.size)
             when {
                 bytesRead < 0L -> {
-                    if (buffer.size == 0L) {
-                        return null
-                    }
                     throw EOFException("Truncated DAEAD chunk. expected=$byteCount actual=${buffer.size}")
                 }
 
@@ -155,7 +199,7 @@ class DaeadChunkDecryptSource(
 }
 
 /**
- * 현재 [Source]를 DAEAD 청크 복호화 [Source]로 변환합니다.
+ * Wraps this [Source] as a DAEAD chunk decryption source.
  *
  * ```kotlin
  * val daead = TinkDaeads.AES256_SIV
@@ -169,10 +213,11 @@ class DaeadChunkDecryptSource(
  * }
  * ```
  *
- * @param daead 청크 복호화에 사용할 DAEAD 래퍼
- * @param associatedData 청크 인증에 사용할 연관 데이터. 암호화 시 사용한 값과 동일해야 합니다.
- * @param maxCiphertextLength 허용하는 청크 ciphertext 최대 길이. 기본값: [DEFAULT_DAEAD_MAX_CIPHERTEXT_LENGTH].
- * @return DAEAD 청크 복호화 [Source]
+ * @param daead DAEAD wrapper used to decrypt each chunk.
+ * @param associatedData caller-provided associated data. It must match the encryption value.
+ * @param maxCiphertextLength maximum allowed ciphertext length per frame.
+ *   Defaults to [DEFAULT_DAEAD_MAX_CIPHERTEXT_LENGTH].
+ * @return DAEAD chunk decryption [Source].
  * @see DaeadChunkEncryptSink
  */
 fun Source.asDaeadChunkDecryptSource(
@@ -183,10 +228,10 @@ fun Source.asDaeadChunkDecryptSource(
     DaeadChunkDecryptSource(this, daead, associatedData, maxCiphertextLength)
 
 /**
- * DAEAD 청크 복호화에서 허용하는 기본 최대 ciphertext 길이 (16 MiB)입니다.
+ * Default maximum ciphertext length accepted by DAEAD chunk decryption (16 MiB).
  *
- * 신뢰할 수 없는 소스로부터 대규모 메모리 할당 공격을 방어하기 위한 상한선입니다.
- * 암호화 측의 `chunkSize` 가 이 값보다 크면 [DaeadChunkDecryptSource] 생성 시
- * `maxCiphertextLength` 파라미터를 명시적으로 지정하세요.
+ * This bounds memory allocation when reading from untrusted sources. If the
+ * encryption side uses a larger plaintext chunk size, pass an explicit
+ * `maxCiphertextLength` when creating [DaeadChunkDecryptSource].
  */
 const val DEFAULT_DAEAD_MAX_CIPHERTEXT_LENGTH: Long = 16L * 1024 * 1024

--- a/io/okio/src/main/kotlin/io/bluetape4k/okio/tink/DaeadChunkEncryptSink.kt
+++ b/io/okio/src/main/kotlin/io/bluetape4k/okio/tink/DaeadChunkEncryptSink.kt
@@ -10,32 +10,35 @@ import okio.Sink
 import java.io.IOException
 
 /**
- * 평문을 DAEAD 청크 포맷으로 암호화하여 [Sink]에 기록하는 [Sink] 구현체입니다.
+ * Encrypts plaintext into a DAEAD chunk stream and writes it to a delegate [Sink].
  *
- * 입력은 [chunkSize] 크기의 평문 청크로 나뉘며, 각 청크는
- * `[8-byte big-endian ciphertext length][ciphertext]` 형식으로 기록됩니다.
- * 마지막 partial chunk는 [close] 시점에 기록되므로 반드시 `use {}` 또는 [close]를 호출해야 합니다.
+ * Input is split into plaintext chunks of [chunkSize]. Each encrypted frame is
+ * written as `[1-byte flags][8-byte big-endian ciphertext length][ciphertext]`.
+ * The last partial chunk is finalized on [close], so callers must use `use {}`
+ * or close this sink explicitly. The chunk index and final-frame flag are bound
+ * into DAEAD associated data, so chunk reorder, deletion, and duplicate replay
+ * fail during decryption.
  *
- * [TinkDeterministicAead]는 같은 키, 평문, 연관 데이터에 대해 같은 암호문을 생성합니다.
- * 이 특성 때문에 동일 청크 평문 반복 여부가 노출될 수 있습니다. 결정성이 필요하지 않은 일반
- * 암호화에는 `TinkEncryptSink`를 사용하세요.
+ * [TinkDeterministicAead] produces the same ciphertext for the same key,
+ * plaintext, and associated data. This can reveal repeated plaintext chunks.
+ * Use `TinkEncryptSink` when deterministic encryption is not required.
  *
  * ```kotlin
  * val daead = TinkDaeads.AES256_SIV
  * val output = Buffer()
  *
  * output.asDaeadChunkEncryptSink(daead).use { sink ->
- *     val plaintext = Buffer().writeUtf8("대용량 스트리밍 평문")
+ *     val plaintext = Buffer().writeUtf8("large streaming plaintext")
  *     sink.write(plaintext, plaintext.size)
  * }
- * // output 에는 DAEAD 청크 포맷으로 암호화된 데이터가 담겨 있다.
- * // DaeadChunkDecryptSource 로 복호화하면 원본 평문을 얻을 수 있다.
+ * // output now contains DAEAD chunk frames.
+ * // Decrypt with DaeadChunkDecryptSource to restore the plaintext.
  * ```
  *
- * @param delegate 암호문을 기록할 위임 [Sink]
- * @param daead 청크 암호화에 사용할 DAEAD 래퍼
- * @param chunkSize 평문 청크 크기. 기본값은 [DEFAULT_DAEAD_CHUNK_SIZE]입니다.
- * @param associatedData 청크 인증에 사용할 연관 데이터. 인증되지만 암호화되지는 않습니다.
+ * @param delegate target [Sink] for ciphertext frames.
+ * @param daead DAEAD wrapper used to encrypt each chunk.
+ * @param chunkSize plaintext chunk size. Defaults to [DEFAULT_DAEAD_CHUNK_SIZE].
+ * @param associatedData caller-provided associated data. It is authenticated but not encrypted.
  * @see DaeadChunkDecryptSource
  * @see TinkEncryptSink
  */
@@ -51,17 +54,18 @@ class DaeadChunkEncryptSink(
     private val associatedData: ByteArray = associatedData.copyOf()
     private val plainBuffer = Buffer()
     private var closed = false
+    private var chunkIndex = 0L
 
     init {
         chunkSize.requirePositiveNumber("chunkSize")
     }
 
     /**
-     * [source]에서 [byteCount] 바이트를 읽어 내부 버퍼에 누적한 뒤 완성된 청크를 암호화합니다.
+     * Reads [byteCount] bytes from [source], buffers them, and emits complete encrypted chunks.
      *
-     * @param source 평문을 제공하는 버퍼
-     * @param byteCount 처리할 바이트 수
-     * @throws IOException close 이후 호출 시, 또는 암호화 실패 시
+     * @param source plaintext buffer.
+     * @param byteCount number of bytes to consume.
+     * @throws IOException after close or when encryption/write fails.
      */
     override fun write(source: Buffer, byteCount: Long) {
         if (closed) {
@@ -77,10 +81,10 @@ class DaeadChunkEncryptSink(
     }
 
     /**
-     * 완성된 청크만 기록하고 partial chunk는 [close]까지 유지합니다.
+     * Emits only chunks known to be non-final and keeps the last possible final chunk until [close].
      *
-     * **주의**: partial chunk는 [close] 시점에만 기록됩니다. `flush()`를 호출해도
-     * partial chunk는 기록되지 않습니다.
+     * Note: `flush()` also keeps a buffered chunk of exactly [chunkSize] bytes because
+     * it may be the final chunk unless more plaintext arrives.
      */
     override fun flush() {
         if (!closed) {
@@ -90,7 +94,7 @@ class DaeadChunkEncryptSink(
     }
 
     /**
-     * 남은 partial chunk를 암호화한 뒤 위임 [Sink]를 닫습니다.
+     * Encrypts the remaining final chunk and closes the delegate [Sink].
      */
     override fun close() {
         if (closed) {
@@ -99,7 +103,7 @@ class DaeadChunkEncryptSink(
 
         var thrown: Throwable? = null
         try {
-            emitRemainingChunk()
+            emitFinalChunk()
             super.flush()
         } catch (e: Throwable) {
             thrown = e
@@ -132,30 +136,34 @@ class DaeadChunkEncryptSink(
     }
 
     private fun emitCompleteChunks() {
-        while (plainBuffer.size >= chunkSize) {
-            emitChunk(chunkSize.toLong())
+        while (plainBuffer.size > chunkSize) {
+            emitChunk(chunkSize.toLong(), finalChunk = false)
         }
     }
 
-    private fun emitRemainingChunk() {
-        if (plainBuffer.size > 0L) {
-            emitChunk(plainBuffer.size)
-        }
+    private fun emitFinalChunk() {
+        emitChunk(plainBuffer.size, finalChunk = true)
     }
 
-    private fun emitChunk(byteCount: Long) {
+    private fun emitChunk(byteCount: Long, finalChunk: Boolean) {
         val plaintext = plainBuffer.readByteArray(byteCount)
-        val ciphertext = daead.encryptDeterministically(plaintext, associatedData)
+        // Bind stream position into AD so whole-frame reorder/drop/duplicate attacks fail authentication.
+        val ciphertext = daead.encryptDeterministically(
+            plaintext,
+            daeadChunkAssociatedData(associatedData, chunkIndex, finalChunk)
+        )
         val frame = Buffer()
+            .writeByte(if (finalChunk) DAEAD_CHUNK_FINAL_FLAG else DAEAD_CHUNK_NON_FINAL_FLAG)
             .writeLong(ciphertext.size.toLong())
             .write(ciphertext)
 
         super.write(frame, frame.size)
+        chunkIndex++
     }
 }
 
 /**
- * 현재 [Sink]를 DAEAD 청크 암호화 [Sink]로 변환합니다.
+ * Wraps this [Sink] as a DAEAD chunk encryption sink.
  *
  * ```kotlin
  * val daead = TinkDaeads.AES256_SIV
@@ -164,13 +172,13 @@ class DaeadChunkEncryptSink(
  * output.asDaeadChunkEncryptSink(daead, associatedData = "context".toByteArray()).use { sink ->
  *     sink.write(Buffer().writeUtf8("hello"), 5L)
  * }
- * // output 을 DaeadChunkDecryptSource 로 같은 associatedData 를 사용해 복호화하세요.
+ * // Decrypt output with DaeadChunkDecryptSource and the same associatedData.
  * ```
  *
- * @param daead 청크 암호화에 사용할 DAEAD 래퍼
- * @param chunkSize 평문 청크 크기. 기본값은 [DEFAULT_DAEAD_CHUNK_SIZE] (64 KiB)입니다.
- * @param associatedData 청크 인증에 사용할 연관 데이터. 복호화 시 동일한 값을 전달해야 합니다.
- * @return DAEAD 청크 암호화 [Sink]
+ * @param daead DAEAD wrapper used to encrypt each chunk.
+ * @param chunkSize plaintext chunk size. Defaults to [DEFAULT_DAEAD_CHUNK_SIZE] (64 KiB).
+ * @param associatedData caller-provided associated data. Decryption must use the same value.
+ * @return DAEAD chunk encryption [Sink].
  * @see DaeadChunkDecryptSource
  */
 fun Sink.asDaeadChunkEncryptSink(
@@ -181,10 +189,30 @@ fun Sink.asDaeadChunkEncryptSink(
     DaeadChunkEncryptSink(this, daead, chunkSize, associatedData)
 
 /**
- * DAEAD 청크 암호화에서 사용하는 기본 평문 청크 크기 (64 KiB)입니다.
+ * Default plaintext chunk size for DAEAD chunk encryption (64 KiB).
  *
- * 암호화 Sink 생성 시 [chunkSize] 파라미터로 이 값을 재정의할 수 있습니다.
- * [DaeadChunkDecryptSource]는 헤더에서 ciphertext 길이를 읽으므로 복호화 측에서
- * 별도로 chunkSize 를 지정할 필요가 없습니다.
+ * Override this with the [chunkSize] parameter when constructing the encryption sink.
+ * [DaeadChunkDecryptSource] reads ciphertext lengths from frame headers, so the
+ * decrypting side does not need the plaintext chunk size.
  */
 const val DEFAULT_DAEAD_CHUNK_SIZE: Int = 64 * 1024
+
+internal const val DAEAD_CHUNK_NON_FINAL_FLAG: Int = 0
+internal const val DAEAD_CHUNK_FINAL_FLAG: Int = 1
+
+private const val DAEAD_CHUNK_ASSOCIATED_DATA_DOMAIN = "bluetape4k-okio-daead-chunk-v2"
+
+// Domain separation + caller AD + frame metadata form the authenticated stream context.
+internal fun daeadChunkAssociatedData(
+    associatedData: ByteArray,
+    chunkIndex: Long,
+    finalChunk: Boolean,
+): ByteArray =
+    Buffer()
+        .writeUtf8(DAEAD_CHUNK_ASSOCIATED_DATA_DOMAIN)
+        .writeByte(0)
+        .writeInt(associatedData.size)
+        .write(associatedData)
+        .writeLong(chunkIndex)
+        .writeByte(if (finalChunk) DAEAD_CHUNK_FINAL_FLAG else DAEAD_CHUNK_NON_FINAL_FLAG)
+        .readByteArray()

--- a/io/okio/src/test/kotlin/io/bluetape4k/okio/tink/DaeadChunkDecryptSourceTest.kt
+++ b/io/okio/src/test/kotlin/io/bluetape4k/okio/tink/DaeadChunkDecryptSourceTest.kt
@@ -1,15 +1,16 @@
 package io.bluetape4k.okio.tink
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeLessThan
 import io.bluetape4k.tink.daead.TinkDaeads
 import okio.Buffer
 import okio.EOFException
 import okio.ForwardingSource
 import okio.Source
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeLessThan
 import org.junit.jupiter.api.Test
 import java.io.IOException
-import io.bluetape4k.assertions.assertFailsWith
+import java.security.GeneralSecurityException
 
 class DaeadChunkDecryptSourceTest: AbstractTinkEncryptTest() {
 
@@ -34,7 +35,7 @@ class DaeadChunkDecryptSourceTest: AbstractTinkEncryptTest() {
         val decrypted = Buffer()
 
         while (source.read(decrypted, 5L) >= 0L) {
-            // 반복 read 계약 검증
+            // Exercise the repeated-read contract across decrypted chunk boundaries.
         }
 
         decrypted.readByteArray() shouldBeEqualTo expected
@@ -75,8 +76,17 @@ class DaeadChunkDecryptSourceTest: AbstractTinkEncryptTest() {
     }
 
     @Test
-    fun `empty input returns eof`() {
-        Buffer().asDaeadChunkDecryptSource(daead).read(Buffer(), 1L) shouldBeEqualTo -1L
+    fun `encrypted empty input returns eof`() {
+        val encrypted = encrypt(ByteArray(0), chunkSize = 4)
+
+        encrypted.asDaeadChunkDecryptSource(daead).read(Buffer(), 1L) shouldBeEqualTo -1L
+    }
+
+    @Test
+    fun `raw empty input without final marker throws eof exception`() {
+        assertFailsWith<EOFException> {
+            Buffer().asDaeadChunkDecryptSource(daead).read(Buffer(), 1L)
+        }
     }
 
     @Test
@@ -88,7 +98,10 @@ class DaeadChunkDecryptSourceTest: AbstractTinkEncryptTest() {
 
     @Test
     fun `truncated ciphertext throws eof exception`() {
-        val malformed = Buffer().writeLong(16L).write(ByteArray(15))
+        val malformed = Buffer()
+            .writeByte(DAEAD_CHUNK_NON_FINAL_FLAG)
+            .writeLong(16L)
+            .write(ByteArray(15))
 
         assertFailsWith<EOFException> {
             malformed.asDaeadChunkDecryptSource(daead).read(Buffer(), 1L)
@@ -98,21 +111,31 @@ class DaeadChunkDecryptSourceTest: AbstractTinkEncryptTest() {
     @Test
     fun `invalid ciphertext length zero throws io exception`() {
         assertFailsWith<IOException> {
-            Buffer().writeLong(0L).asDaeadChunkDecryptSource(daead).read(Buffer(), 1L)
+            Buffer()
+                .writeByte(DAEAD_CHUNK_NON_FINAL_FLAG)
+                .writeLong(0L)
+                .asDaeadChunkDecryptSource(daead)
+                .read(Buffer(), 1L)
         }
     }
 
     @Test
     fun `negative ciphertext length throws io exception`() {
         assertFailsWith<IOException> {
-            Buffer().writeLong(-1L).asDaeadChunkDecryptSource(daead).read(Buffer(), 1L)
+            Buffer()
+                .writeByte(DAEAD_CHUNK_NON_FINAL_FLAG)
+                .writeLong(-1L)
+                .asDaeadChunkDecryptSource(daead)
+                .read(Buffer(), 1L)
         }
     }
 
     @Test
     fun `ciphertext length exceeding maxCiphertextLength throws io exception`() {
         val smallMax = 100L
-        val header = Buffer().writeLong(smallMax + 1L)
+        val header = Buffer()
+            .writeByte(DAEAD_CHUNK_NON_FINAL_FLAG)
+            .writeLong(smallMax + 1L)
 
         assertFailsWith<IOException> {
             header.asDaeadChunkDecryptSource(daead, maxCiphertextLength = smallMax).read(Buffer(), 1L)
@@ -123,8 +146,53 @@ class DaeadChunkDecryptSourceTest: AbstractTinkEncryptTest() {
     fun `wrong associated data fails to decrypt`() {
         val encrypted = encrypt("secret".toByteArray(), chunkSize = 4, associatedData = byteArrayOf(1))
 
-        assertFailsWith<Exception> {
+        assertFailsWith<GeneralSecurityException> {
             encrypted.asDaeadChunkDecryptSource(daead, associatedData = byteArrayOf(2)).read(Buffer(), 1L)
+        }
+    }
+
+    @Test
+    fun `reordered chunks fail to decrypt`() {
+        val frames = encrypt("abcdefgh".toByteArray(), chunkSize = 4).readFrames()
+        val reordered = Buffer()
+            .write(frames[1])
+            .write(frames[0])
+
+        assertFailsWith<GeneralSecurityException> {
+            reordered.asDaeadChunkDecryptSource(daead).readAllTo(Buffer())
+        }
+    }
+
+    @Test
+    fun `dropped final chunk fails to decrypt`() {
+        val frames = encrypt("abcdefgh".toByteArray(), chunkSize = 4).readFrames()
+        val truncated = Buffer().write(frames.first())
+
+        assertFailsWith<EOFException> {
+            truncated.asDaeadChunkDecryptSource(daead).readAllTo(Buffer())
+        }
+    }
+
+    @Test
+    fun `duplicated chunk fails to decrypt`() {
+        val frames = encrypt("abcdefgh".toByteArray(), chunkSize = 4).readFrames()
+        val duplicated = Buffer()
+            .write(frames[0])
+            .write(frames[0])
+            .write(frames[1])
+
+        assertFailsWith<GeneralSecurityException> {
+            duplicated.asDaeadChunkDecryptSource(daead).readAllTo(Buffer())
+        }
+    }
+
+    @Test
+    fun `trailing data after final chunk fails to decrypt`() {
+        val tampered = encrypt("secret".toByteArray(), chunkSize = 4)
+            .writeByte(DAEAD_CHUNK_NON_FINAL_FLAG)
+
+        assertFailsWith<IOException> {
+            tampered.asDaeadChunkDecryptSource(daead).readAllTo(Buffer())
         }
     }
 
@@ -237,6 +305,20 @@ class DaeadChunkDecryptSourceTest: AbstractTinkEncryptTest() {
         }
     }
 
+    private fun Buffer.readFrames(): List<ByteArray> {
+        val frames = mutableListOf<ByteArray>()
+        while (size > 0L) {
+            val frame = Buffer()
+            val flags = readByte()
+            val ciphertextLength = readLong()
+            frame.writeByte(flags.toInt())
+            frame.writeLong(ciphertextLength)
+            frame.write(this, ciphertextLength)
+            frames += frame.readByteArray()
+        }
+        return frames
+    }
+
     private class CountingSource(delegate: Source): ForwardingSource(delegate) {
         var bytesRead: Long = 0L
             private set
@@ -260,7 +342,7 @@ class DaeadChunkDecryptSourceTest: AbstractTinkEncryptTest() {
         }
     }
 
-    /** 항상 0L 을 반환하여 진행 없음(no progress) 상태를 시뮬레이션하는 [Source]. */
+    /** Simulates a source that repeatedly returns 0L without making progress. */
     private class StalledSource: Source {
         override fun read(sink: Buffer, byteCount: Long): Long = 0L
         override fun timeout() = okio.Timeout.NONE

--- a/io/okio/src/test/kotlin/io/bluetape4k/okio/tink/DaeadChunkEncryptSinkTest.kt
+++ b/io/okio/src/test/kotlin/io/bluetape4k/okio/tink/DaeadChunkEncryptSinkTest.kt
@@ -16,26 +16,31 @@ class DaeadChunkEncryptSinkTest: AbstractTinkEncryptTest() {
     private val daead = TinkDaeads.AES256_SIV
 
     @Test
-    fun `empty input writes no chunk`() {
+    fun `empty input writes final marker`() {
         val encrypted = Buffer()
 
         encrypted.asDaeadChunkEncryptSink(daead).use {
             it.flush()
         }
 
-        encrypted.size shouldBeEqualTo 0L
+        encrypted.readByte().toInt() shouldBeEqualTo DAEAD_CHUNK_FINAL_FLAG
+        encrypted.readLong().shouldBeGreaterThan(0L)
     }
 
     @Test
-    fun `single chunk uses big endian ciphertext length header`() {
+    fun `single chunk uses final flag and big endian ciphertext length header`() {
         val plaintext = byteArrayOf(1, 2, 3)
-        val expectedCiphertext = daead.encryptDeterministically(plaintext)
+        val expectedCiphertext = daead.encryptDeterministically(
+            plaintext,
+            daeadChunkAssociatedData(ByteArray(0), chunkIndex = 0L, finalChunk = true)
+        )
         val encrypted = Buffer()
 
         encrypted.asDaeadChunkEncryptSink(daead, chunkSize = plaintext.size).use { sink ->
             sink.write(Buffer().write(plaintext), plaintext.size.toLong())
         }
 
+        encrypted.readByte().toInt() shouldBeEqualTo DAEAD_CHUNK_FINAL_FLAG
         encrypted.readLong() shouldBeEqualTo expectedCiphertext.size.toLong()
         encrypted.readByteArray() shouldBeEqualTo expectedCiphertext
     }
@@ -54,6 +59,7 @@ class DaeadChunkEncryptSinkTest: AbstractTinkEncryptTest() {
 
         val framed = encrypted.clone()
         while (framed.size > 0L) {
+            framed.readByte()
             val ciphertextLength = framed.readLong()
             chunks += ciphertextLength
             framed.skip(ciphertextLength)

--- a/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopes.kt
+++ b/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopes.kt
@@ -389,14 +389,29 @@ object StructuredTaskScopes: KLogging() {
 
     private val providers: List<StructuredTaskScopeProvider> by lazy {
         val loader = ServiceLoader.load(StructuredTaskScopeProvider::class.java)
-        val iterator = loader.iterator()
+        discoverStructuredTaskScopeProviders(loader.iterator())
+    }
+
+    internal fun discoverStructuredTaskScopeProviders(
+        iterator: Iterator<StructuredTaskScopeProvider>,
+    ): List<StructuredTaskScopeProvider> {
         val discovered = mutableListOf<StructuredTaskScopeProvider>()
 
         while (true) {
-            val provider = runCatching {
-                if (!iterator.hasNext()) return@runCatching null
-                iterator.next()
+            val hasNext = runCatching {
+                iterator.hasNext()
+            }.onFailure { error ->
+                log.warn(error) { "Stopping StructuredTaskScopeProvider discovery after ServiceLoader.hasNext() failed." }
             }.getOrNull() ?: break
+            if (!hasNext) {
+                break
+            }
+            // A broken service entry must not hide later providers that are valid for this runtime.
+            val provider = runCatching {
+                iterator.next()
+            }.onFailure { error ->
+                log.warn(error) { "Skipping failed StructuredTaskScopeProvider entry." }
+            }.getOrNull() ?: continue
 
             runCatching {
                 if (provider.isSupported()) {
@@ -408,7 +423,7 @@ object StructuredTaskScopes: KLogging() {
             }
         }
 
-        discovered.sortedByDescending { it.priority }
+        return discovered.sortedByDescending { it.priority }
     }
 
     /**

--- a/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt
+++ b/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/StructuredScopesTest.kt
@@ -1,7 +1,6 @@
 package io.bluetape4k.concurrent.virtualthread
 
-import io.bluetape4k.logging.KLogging
-import io.bluetape4k.logging.debug
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeInstanceOf
@@ -9,12 +8,17 @@ import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeBlank
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.concurrency.StructuredTaskScopeTester
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
 import org.junit.jupiter.api.Test
 import java.time.Instant
+import java.util.ServiceConfigurationError
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.StructuredTaskScope
+import java.util.concurrent.ThreadFactory
 import java.util.concurrent.TimeoutException
-import io.bluetape4k.assertions.assertFailsWith
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * [StructuredTaskScopes], [StructuredTaskScopeProvider], [StructuredSubtask], [StructuredTaskScopeAll],
@@ -47,6 +51,23 @@ class StructuredScopesTest {
     fun `provider priority 가 양수여야 한다`() {
         val provider = StructuredTaskScopes.provider()
         provider.priority.shouldBeGreaterThan(0)
+    }
+
+    @Test
+    fun `provider discovery skips broken next entries`() {
+        val providers = StructuredTaskScopes.discoverStructuredTaskScopeProviders(
+            FailingNextThenProviderIterator(TestStructuredTaskScopeProvider("valid-provider", priority = 10))
+        )
+
+        providers.size shouldBeEqualTo 1
+        providers.first().providerName shouldBeEqualTo "valid-provider"
+    }
+
+    @Test
+    fun `provider discovery stops cleanly when hasNext fails`() {
+        val providers = StructuredTaskScopes.discoverStructuredTaskScopeProviders(FailingHasNextIterator())
+
+        providers shouldBeEqualTo emptyList<StructuredTaskScopeProvider>()
     }
 
     // ── 기존 all/any 회귀 테스트 (deprecated API 동작 검증) ─────────────────────
@@ -219,6 +240,27 @@ class StructuredScopesTest {
             task.get()
         }
         result shouldBeEqualTo 42
+    }
+
+    @Test
+    fun `StructuredTaskScopeTester 로 failFast API 를 반복 검증한다`() {
+        val completed = AtomicInteger()
+
+        StructuredTaskScopeTester()
+            .rounds(32)
+            .add {
+                val result = StructuredTaskScopes.failFast { scope ->
+                    val a = scope.fork { 10 }
+                    val b = scope.fork { 20 }
+                    scope.join().throwIfFailed()
+                    a.get() + b.get()
+                }
+                result shouldBeEqualTo 30
+                completed.incrementAndGet()
+            }
+            .run()
+
+        completed.get() shouldBeEqualTo 32
     }
 
     // ── firstSuccess 신규 API 테스트 ────────────────────────────────────────────
@@ -550,5 +592,50 @@ class StructuredScopesTest {
 
         successes.sorted() shouldBeEqualTo allResults.filter { it.isSuccess }.map { it.getOrThrow() }.sorted()
         failures.size shouldBeEqualTo allResults.mapNotNull { it.exceptionOrNull() }.size
+    }
+
+    private class FailingNextThenProviderIterator(
+        private val provider: StructuredTaskScopeProvider,
+    ): Iterator<StructuredTaskScopeProvider> {
+        private var index = 0
+
+        override fun hasNext(): Boolean = index < 2
+
+        override fun next(): StructuredTaskScopeProvider =
+            when (index++) {
+                0 -> throw ServiceConfigurationError("broken provider entry")
+                1 -> provider
+                else -> throw NoSuchElementException()
+            }
+    }
+
+    private class FailingHasNextIterator: Iterator<StructuredTaskScopeProvider> {
+        override fun hasNext(): Boolean = throw ServiceConfigurationError("broken provider index")
+        override fun next(): StructuredTaskScopeProvider = throw NoSuchElementException()
+    }
+
+    private class TestStructuredTaskScopeProvider(
+        override val providerName: String,
+        override val priority: Int,
+    ): StructuredTaskScopeProvider {
+        override fun isSupported(): Boolean = true
+
+        override fun <T> withAll(
+            name: String?,
+            factory: ThreadFactory,
+            block: (scope: StructuredTaskScopeAll) -> T,
+        ): T = error("not used")
+
+        override fun <T> withAny(
+            name: String?,
+            factory: ThreadFactory,
+            block: (scope: StructuredTaskScopeAny<T>) -> T,
+        ): T = error("not used")
+
+        override fun <T, R> withSupervised(
+            name: String?,
+            factory: ThreadFactory,
+            block: (scope: StructuredTaskScopeSupervised<T>) -> R,
+        ): R = error("not used")
     }
 }

--- a/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/TaskContextTest.kt
+++ b/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/TaskContextTest.kt
@@ -8,11 +8,13 @@ import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.concurrency.StructuredTaskScopeTester
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
 import java.lang.ScopedValue
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * [TaskContext] — ScopedValue 기반 컨텍스트 전파 테스트
@@ -200,6 +202,25 @@ class TaskContextTest {
 
         results[0] shouldBeEqualTo "req-777"
         results[1] shouldBeEqualTo "tenant-99"
+    }
+
+    @Test
+    fun `StructuredTaskScopeTester 반복 실행에서도 ScopedValue 가 자동 전파된다`() {
+        val requestId = TaskContext.newKey<String>()
+        val completed = AtomicInteger()
+
+        TaskContext.run(requestId, "req-stress") {
+            StructuredTaskScopeTester()
+                .rounds(32)
+                .add {
+                    TaskContext.get(requestId) shouldBeEqualTo "req-stress"
+                    completed.incrementAndGet()
+                }
+                .run()
+        }
+
+        completed.get() shouldBeEqualTo 32
+        TaskContext.get(requestId).shouldBeNull()
     }
 
     @Test


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: Harden DAEAD chunk framing and virtual-thread coverage

Follow-up from the post-merge review of PRs #293, #242, #264, and #271.

- introduce DAEAD chunk format v2 with frame flags, authenticated chunk index/final state, and trailing-data rejection
- harden StructuredTaskScope provider discovery so broken ServiceLoader entries do not hide valid providers
- add bluetape4k-junit5 `StructuredTaskScopeTester` coverage for virtual-thread APIs
- document the DAEAD v2 wire-format incompatibility and add a lessons entry

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- `repo-test-summary -- ./gradlew :bluetape4k-okio:test --tests "io.bluetape4k.okio.tink.DaeadChunk*Test" --rerun-tasks`
- `repo-test-summary -- ./gradlew :bluetape4k-virtualthread-api:test --tests "io.bluetape4k.concurrent.virtualthread.*Test" --rerun-tasks`
- `repo-test-summary -- ./gradlew :bluetape4k-virtualthread-jdk21:test --tests "io.bluetape4k.concurrent.virtualthread.jdk21.Jdk21TaskContextTest" --rerun-tasks`
- `git diff --check`
- Claude advisor re-review: No remaining P0/P1/P2 findings

### 기존 섹션: Notes

- DAEAD chunk v2 is intentionally not wire-compatible with older `[8-byte length][ciphertext]` frames.
- Full repository build was not run.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #427, head `b40848a91ce9bbea424d74737d328eb34b95148d`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/daead-vt-followups`
- Labels: 없음
- State: `MERGED`, merge commit `9338962785e0c354e6230e9c51b6f34b8e7a0a46`
- CI: - `repo-test-summary -- ./gradlew :bluetape4k-okio:test --tests "io.bluetape4k.okio.tink.DaeadChunk*Test" --rerun-tasks` / - `repo-test-summary -- ./gradlew :bluetape4k-virtualthread-api:test --tests "io.bluetape4k.concurrent.virtualthread.*Test" --rerun-tasks` / - `repo-test-summary -- ./gradlew :bluetape4k-virtualthread-jdk21:test --tests "io.bluetape4k.concurrent.virtualthread.jdk21.Jdk21TaskContextTest" --rerun-tasks`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #427 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9338962785e0c354e6230e9c51b6f34b8e7a0a46`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
