### PR TITLE
feat(states): add reactive runtime and nested transitions

### DIFF
--- a/docs/lessons/2026-05-14-issue-251-states-comparison.md
+++ b/docs/lessons/2026-05-14-issue-251-states-comparison.md
@@ -1,0 +1,19 @@
+## Issue 251 States Comparison
+
+Context: Issue #251 asked for a comparison between `utils/states` and
+`joost-klitsie/StateMachine`, then follow-up improvement issues.
+
+Decision: Do not add the external library as a dependency. Treat it as a design
+reference because it is KMP/UI-oriented, small, and has no detected GitHub
+license metadata.
+
+Outcome: Split the findings into focused follow-up issues: #436 for a reactive
+event/effect runtime, #437 for nested state DSL, and #438 for README positioning
+guidance.
+
+Verification: Checked issue #251, qmd history, local `utils/states` APIs and
+README files, and external repository README/source/release metadata.
+
+Future agents: Keep `bluetape4k-states` JVM/backend-focused. Borrow event,
+effect, side-effect lifecycle, and nested DSL ideas only when they fit the
+existing sync/suspend FSM contracts.

--- a/docs/lessons/2026-05-14-issue-436-438-states-runtime-dsl-docs.md
+++ b/docs/lessons/2026-05-14-issue-436-438-states-runtime-dsl-docs.md
@@ -1,0 +1,27 @@
+## Issue 436-438 States Runtime DSL Docs
+
+Context: Issues #436, #437, and #438 extended `utils/states` after the
+StateMachine comparison in #251.
+
+Decision: Keep `bluetape4k-states` Kotlin/JVM focused. Add an optional reactive
+runtime in a separate package, and implement nested state-family transitions by
+extending transition resolution instead of replacing the existing flat DSL.
+
+Outcome: Added inherited transition resolution, `reactiveStateMachine`, one-time
+effects, lifecycle side effects, keyed side-effect restart control, tests, and
+English/Korean README positioning guidance. PR review then tightened reactive
+lifecycle behavior: follow-up events are queued asynchronously, transition
+cancellation still restarts target side effects, `close()` cancels active side
+effects and rejects later sends, and side-effect registry updates are protected
+by an explicit lock.
+
+Verification: Ran IDE diagnostics on touched Kotlin files with zero errors. Ran
+`./gradlew :bluetape4k-states:test --no-configuration-cache`; result was
+57 passing and BUILD SUCCESSFUL. Claude follow-up review found no blocking,
+high, or medium issues after the lifecycle fixes.
+
+Future agents: Preserve exact transition precedence over inherited transitions.
+Keep reactive runtime optional; do not move UI/Compose or KMP concerns into this
+module without a separate design issue. For reactive side effects, keep
+`close()` and `restartSideEffects()` lifecycle updates coordinated; a thread-safe
+map alone is not enough for compound check/cancel/replace operations.

--- a/docs/superpowers/research/2026-05-14-issue-251-states-statemachine-comparison.md
+++ b/docs/superpowers/research/2026-05-14-issue-251-states-statemachine-comparison.md
@@ -1,0 +1,59 @@
+## Issue #251 — states vs joost-klitsie/StateMachine comparison
+
+날짜: 2026-05-14
+
+## 목적
+
+`joost-klitsie/StateMachine`을 분석해 `utils/states`와 비교하고,
+`bluetape4k-states`에 반영할 개선 이슈를 도출한다.
+
+## 외부 라이브러리 요약
+
+- 저장소: `joost-klitsie/StateMachine`
+- 최신 릴리스: `release/0.3.0` (2026-01-29)
+- GitHub 메타데이터: 약 45 stars, 4 forks, open issue 1개
+- 라이선스: GitHub metadata 기준 감지되지 않음
+- 성격: Kotlin Multiplatform, presentation-layer 중심
+- 핵심 API: `stateMachine<State, Effect, Event>(scope, initialState)`,
+  `send(event)`, `StateFlow` 구현, `consumeEffects`, `sideEffect`,
+  `nestedState`, `state`, `onEvent`, `trigger(effect)`
+
+## `utils/states` 현재 위치
+
+- Kotlin/JVM backend-friendly FSM 모듈
+- Sync `StateMachine<S, E>`와 suspend `SuspendStateMachineInterface<S, E>` 제공
+- `TransitionResult<S, E>`를 명시적으로 반환
+- guard, final states, `canTransition`, `allowedEvents`, `isInFinalState` 제공
+- suspend 구현은 `stateFlow`를 노출
+- 의존성은 `bluetape4k-core`, `bluetape4k-coroutines`, Kotlin coroutines 중심
+
+## 비교 결론
+
+외부 라이브러리를 직접 의존성으로 들이지 않는다.
+
+이유:
+
+- bluetape4k는 JVM backend library scope가 중심이다.
+- 외부 라이브러리는 UI/ViewModel/Compose 친화적인 이벤트-효과 런타임이다.
+- 라이선스가 GitHub metadata에서 확인되지 않아 dependency risk가 있다.
+- 작은 프로젝트 표면과 초기 릴리스 단계라 장기 안정성 근거가 약하다.
+
+하지만 다음 아이디어는 가치가 있다.
+
+- event queue 기반 `send(event)` API
+- one-time effect flow
+- 상태 진입/이탈에 묶인 lifecycle side effect
+- key 기반 side effect restart 제어
+- nested state DSL과 parent-level shared transition
+
+## 등록한 후속 이슈
+
+- #436 — Reactive event/effect runtime
+- #437 — Nested state DSL
+- #438 — README comparison and positioning guidance
+
+## 검증
+
+- GitHub issue #251 본문 확인
+- `utils/states` 파일/README/API 표면 확인
+- 외부 저장소 README, Gradle, source/test tree, release/open issue metadata 확인

--- a/utils/states/README.ko.md
+++ b/utils/states/README.ko.md
@@ -2,7 +2,8 @@
 
 [English](./README.md) | 한국어
 
-Kotlin DSL 기반 유한 상태 머신(FSM) 라이브러리입니다. 동기 및 코루틴 FSM을 모두 지원하며, Guard 조건과 StateFlow 기반 상태 관찰 기능을 제공합니다.
+JVM backend/library 코드를 위한 Kotlin DSL 기반 유한 상태 머신(FSM) 라이브러리입니다. 동기 FSM, 코루틴 FSM,
+선택적 reactive event/effect runtime, Guard 조건, nested state-family 전이, StateFlow 기반 상태 관찰을 제공합니다.
 
 ## 아키텍처
 
@@ -178,9 +179,21 @@ classDiagram
 - **타입 안전 DSL**: `stateMachine {}`, `suspendStateMachine {}` DSL로 간결하게 FSM 정의
 - **동기 FSM**: `AtomicReference` CAS 기반 Thread-Safe 상태 전이
 - **코루틴 FSM**: `Mutex` + `StateFlow` 기반 suspend 전이 및 상태 관찰
+- **Reactive runtime**: `reactiveStateMachine {}` 기반 event queue, one-time effect, lifecycle side effect
+- **Nested state-family 전이**: `state<ParentState>()`로 sealed state family에 공통 전이 등록
 - **Guard 조건**: 전이 전 조건 검증 지원
 - **종료 상태 일관성**: 종료 상태에 도달하면 `canTransition()`은 `false`, `allowedEvents()`는 빈 집합을 반환
 - **clinic-appointment 패턴**: Map 기반 전이 + suspend 콜백 패턴 채택
+
+## 모듈 포지셔닝
+
+`bluetape4k-states`는 backend workflow, domain service, library 코드에서 작은 Kotlin/JVM FSM이 필요할 때 사용합니다.
+명시적 `TransitionResult`, guard, final-state 검사, 결정적인 테스트가 중요한 경우에 맞습니다.
+
+주 관심사가 ViewModel/Compose 상태, multiplatform UI target, UI lifecycle 통합이라면 UI/presentation-layer state
+machine을 선택하는 편이 낫습니다. [`joost-klitsie/StateMachine`](https://github.com/joost-klitsie/StateMachine)은
+event/effect와 nested-state 아이디어의 참고 자료일 뿐, 이 모듈의 의존성이 아닙니다. 비교와 개선 작업은 #436,
+#437, #438에서 추적합니다.
 
 ## 상태 전이 다이어그램 예시
 
@@ -309,6 +322,59 @@ val fsm = stateMachine<State, Event> {
         guard { state, event -> (event as ApproveEvent).approvedBy != null }
     }
 }
+```
+
+### Nested State-Family 전이
+
+sealed parent type에 매칭되는 모든 상태에 inherited transition을 등록할 수 있습니다. 정확한 state 전이가 있으면
+그 전이가 inherited transition보다 우선합니다.
+
+```kotlin
+sealed interface OrderState
+data object Created: OrderState
+sealed interface ActiveOrder: OrderState
+data object Paid: ActiveOrder
+data object Packed: ActiveOrder
+data object Cancelled: OrderState
+
+sealed class OrderEvent {
+    data object Cancel: OrderEvent()
+}
+
+val fsm = stateMachine<OrderState, OrderEvent> {
+    initialState = Paid
+    finalStates = setOf(Cancelled)
+
+    transition(state<ActiveOrder>(), on<OrderEvent.Cancel>(), to = Cancelled)
+}
+```
+
+### Reactive Event/Effect Runtime
+
+event queue, one-time effect, lifecycle-managed state side effect가 필요할 때 `reactiveStateMachine {}`를 사용합니다.
+더 작은 명시적 FSM이면 기존 sync/suspend API가 더 적합합니다.
+
+```kotlin
+val machine = reactiveStateMachine<OrderState, OrderEvent, OrderEffect>(scope) {
+    initialState = Created
+    finalStates = setOf(Cancelled)
+
+    transition(Created, on<OrderEvent.Cancel>(), to = Cancelled) {
+        effect { _, _, _ -> emit(OrderEffect.ShowCancelledMessage) }
+    }
+
+    onState(state<ActiveOrder>()) {
+        sideEffect(key = { state -> state::class }) {
+            auditOrderState(it)
+        }
+    }
+}
+
+val effectJob = launch {
+    machine.effects.collect { effect -> handle(effect) }
+}
+
+machine.send(OrderEvent.Cancel)
 ```
 
 ## 상태 전이 시퀀스 다이어그램

--- a/utils/states/README.md
+++ b/utils/states/README.md
@@ -2,8 +2,9 @@
 
 English | [한국어](./README.ko.md)
 
-A Kotlin DSL-based finite state machine (FSM) library. It supports both synchronous and coroutine-based FSMs, along with guard conditions and
-`StateFlow`-based state observation.
+A Kotlin DSL-based finite state machine (FSM) library for JVM backend and library code. It supports synchronous,
+coroutine-based, and optional reactive event/effect state machines, along with guard conditions, nested state-family
+transitions, and `StateFlow`-based state observation.
 
 ## Architecture
 
@@ -180,9 +181,21 @@ classDiagram
 - **Type-safe DSL**: concise FSM definitions with `stateMachine {}` and `suspendStateMachine {}`
 - **Synchronous FSM**: thread-safe state transitions based on `AtomicReference` CAS
 - **Coroutine FSM**: suspend transitions and state observation based on `Mutex` + `StateFlow`
+- **Reactive runtime**: optional event queue, one-time effects, and lifecycle side effects through `reactiveStateMachine {}`
+- **Nested state-family transitions**: register shared transitions for sealed state families with `state<ParentState>()`
 - **Guard conditions**: validate conditions before transitions
 - **Final state consistency**: once a final state is reached, `canTransition()` returns `false` and `allowedEvents()` returns an empty set
 - **clinic-appointment pattern**: adopts a map-based transition model plus suspend callback pattern
+
+## Module Positioning
+
+Use `bluetape4k-states` when you need a small Kotlin/JVM FSM for backend workflows, domain services, or libraries where
+explicit `TransitionResult` values, guards, final-state checks, and deterministic tests matter.
+
+Use a UI/presentation-layer state machine when the primary concern is ViewModel or Compose state, multiplatform UI
+targets, and UI lifecycle integration. The [`joost-klitsie/StateMachine`](https://github.com/joost-klitsie/StateMachine)
+project is a useful design reference for event/effect and nested-state ideas, but it is not a dependency of this module.
+The comparison work is tracked through #436, #437, and #438.
 
 ## Example State Diagrams
 
@@ -311,6 +324,58 @@ val fsm = stateMachine<State, Event> {
         guard { state, event -> (event as ApproveEvent).approvedBy != null }
     }
 }
+```
+
+### Nested State-Family Transitions
+
+Register an inherited transition for every state matching a sealed parent type. Exact state transitions still win.
+
+```kotlin
+sealed interface OrderState
+data object Created: OrderState
+sealed interface ActiveOrder: OrderState
+data object Paid: ActiveOrder
+data object Packed: ActiveOrder
+data object Cancelled: OrderState
+
+sealed class OrderEvent {
+    data object Cancel: OrderEvent()
+}
+
+val fsm = stateMachine<OrderState, OrderEvent> {
+    initialState = Paid
+    finalStates = setOf(Cancelled)
+
+    transition(state<ActiveOrder>(), on<OrderEvent.Cancel>(), to = Cancelled)
+}
+```
+
+### Reactive Event/Effect Runtime
+
+Use `reactiveStateMachine {}` when callers need queued events, one-time effects, and lifecycle-managed state side
+effects. The core sync/suspend FSM APIs remain smaller and more explicit.
+
+```kotlin
+val machine = reactiveStateMachine<OrderState, OrderEvent, OrderEffect>(scope) {
+    initialState = Created
+    finalStates = setOf(Cancelled)
+
+    transition(Created, on<OrderEvent.Cancel>(), to = Cancelled) {
+        effect { _, _, _ -> emit(OrderEffect.ShowCancelledMessage) }
+    }
+
+    onState(state<ActiveOrder>()) {
+        sideEffect(key = { state -> state::class }) {
+            auditOrderState(it)
+        }
+    }
+}
+
+val effectJob = launch {
+    machine.effects.collect { effect -> handle(effect) }
+}
+
+machine.send(OrderEvent.Cancel)
 ```
 
 ## State Transition Sequence Diagrams

--- a/utils/states/src/main/kotlin/io/bluetape4k/states/core/DefaultStateMachine.kt
+++ b/utils/states/src/main/kotlin/io/bluetape4k/states/core/DefaultStateMachine.kt
@@ -36,12 +36,14 @@ class DefaultStateMachine<S: Any, E: Any>(
     override val initialState: S,
     override val finalStates: Set<S>,
     private val transitions: Map<TransitionKey<S, E>, TransitionTarget<S, E>>,
+    private val parentTransitions: Map<ParentTransitionKey<S, E>, TransitionTarget<S, E>> = emptyMap(),
     private val onTransitionCallback: ((S, E, S) -> Unit)? = null,
 ): StateMachine<S, E> {
 
     companion object: KLogging()
 
     private val _currentState = AtomicReference(initialState)
+    private val registry = TransitionRegistry(transitions, parentTransitions)
 
     override val currentState: S
         get() = _currentState.get()
@@ -71,8 +73,7 @@ class DefaultStateMachine<S: Any, E: Any>(
             throw StateMachineException("이미 종료 상태입니다: $previous")
         }
 
-        val key = TransitionKey(previous, event::class.java)
-        val target = transitions[key]
+        val target = registry.resolve(previous, event)?.target
             ?: throw StateMachineException(
                 "허용되지 않은 전이: $previous + ${event::class.simpleName}. " +
                         "허용된 이벤트: ${allowedEvents().map { it.simpleName }}"
@@ -123,8 +124,7 @@ class DefaultStateMachine<S: Any, E: Any>(
         val state = currentState
         if (state in finalStates) return false
 
-        val key = TransitionKey(state, event::class.java)
-        val target = transitions[key] ?: return false
+        val target = registry.resolve(state, event)?.target ?: return false
         return target.guard?.invoke(state, event) ?: true
     }
 
@@ -148,9 +148,6 @@ class DefaultStateMachine<S: Any, E: Any>(
         val state = currentState
         if (state in finalStates) return emptySet()
 
-        return transitions.keys
-            .filter { it.state == state }
-            .map { it.eventType }
-            .toSet()
+        return registry.allowedEvents(state)
     }
 }

--- a/utils/states/src/main/kotlin/io/bluetape4k/states/core/ParentTransitionKey.kt
+++ b/utils/states/src/main/kotlin/io/bluetape4k/states/core/ParentTransitionKey.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.states.core
+
+import java.io.Serializable
+
+/**
+ * Identifies an inherited transition registered for a state family.
+ *
+ * Exact state transitions still have precedence. Parent transitions are used
+ * when the current state is an instance of [stateType] and no exact transition
+ * matches the same event type.
+ *
+ * @param S state type
+ * @param E event type
+ * @property stateType parent state class or interface
+ * @property eventType event class
+ */
+data class ParentTransitionKey<S: Any, E: Any>(
+    val stateType: Class<out S>,
+    val eventType: Class<out E>,
+): Serializable {
+
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+

--- a/utils/states/src/main/kotlin/io/bluetape4k/states/core/StateMachineDsl.kt
+++ b/utils/states/src/main/kotlin/io/bluetape4k/states/core/StateMachineDsl.kt
@@ -75,6 +75,7 @@ class StateMachineBuilder<S: Any, E: Any> {
     var finalStates: Set<S> = emptySet()
 
     private val transitions = mutableMapOf<TransitionKey<S, E>, TransitionTarget<S, E>>()
+    private val parentTransitions = mutableMapOf<ParentTransitionKey<S, E>, TransitionTarget<S, E>>()
     private var onTransitionCallback: ((S, E, S) -> Unit)? = null
 
     /**
@@ -98,6 +99,23 @@ class StateMachineBuilder<S: Any, E: Any> {
     }
 
     /**
+     * Registers an inherited transition for every state matching [from].
+     *
+     * Exact state transitions have precedence over inherited transitions.
+     */
+    fun transition(
+        from: Class<out S>,
+        eventType: Class<out E>,
+        to: S,
+        block: TransitionBuilder<S, E>.() -> Unit = {},
+    ) {
+        val builder = TransitionBuilder<S, E>().apply(block)
+        val key = ParentTransitionKey(from, eventType)
+        val target = TransitionTarget(to, builder.guardFunction)
+        parentTransitions[key] = target
+    }
+
+    /**
      * 전이 콜백을 설정합니다.
      *
      * @param callback 이전 상태, 이벤트, 다음 상태를 받는 콜백
@@ -109,12 +127,33 @@ class StateMachineBuilder<S: Any, E: Any> {
     /**
      * [DefaultStateMachine]을 생성합니다.
      */
-    fun build(): StateMachine<S, E> = DefaultStateMachine(
-        initialState = initialState,
-        finalStates = finalStates,
-        transitions = transitions.toMap(),
-        onTransitionCallback = onTransitionCallback,
-    )
+    fun build(): StateMachine<S, E> {
+        val exactTransitions = transitions.toMap()
+        val inheritedTransitions = parentTransitions.toMap()
+        validateInheritedTransitions(exactTransitions, inheritedTransitions)
+
+        return DefaultStateMachine(
+            initialState = initialState,
+            finalStates = finalStates,
+            transitions = exactTransitions,
+            parentTransitions = inheritedTransitions,
+            onTransitionCallback = onTransitionCallback,
+        )
+    }
+
+    private fun validateInheritedTransitions(
+        exactTransitions: Map<TransitionKey<S, E>, TransitionTarget<S, E>>,
+        inheritedTransitions: Map<ParentTransitionKey<S, E>, TransitionTarget<S, E>>,
+    ) {
+        val knownStates = buildSet {
+            add(initialState)
+            addAll(finalStates)
+            addAll(exactTransitions.keys.map { it.state })
+            addAll(exactTransitions.values.map { it.state })
+            addAll(inheritedTransitions.values.map { it.state })
+        }
+        TransitionRegistry(exactTransitions, inheritedTransitions).validateKnownStates(knownStates)
+    }
 }
 
 /**
@@ -149,6 +188,7 @@ class SuspendStateMachineBuilder<S: Any, E: Any> {
     var finalStates: Set<S> = emptySet()
 
     private val transitions = mutableMapOf<TransitionKey<S, E>, TransitionTarget<S, E>>()
+    private val parentTransitions = mutableMapOf<ParentTransitionKey<S, E>, TransitionTarget<S, E>>()
     private var onTransitionCallback: (suspend (S, E, S) -> Unit)? = null
 
     /**
@@ -172,6 +212,23 @@ class SuspendStateMachineBuilder<S: Any, E: Any> {
     }
 
     /**
+     * Registers an inherited transition for every state matching [from].
+     *
+     * Exact state transitions have precedence over inherited transitions.
+     */
+    fun transition(
+        from: Class<out S>,
+        eventType: Class<out E>,
+        to: S,
+        block: TransitionBuilder<S, E>.() -> Unit = {},
+    ) {
+        val builder = TransitionBuilder<S, E>().apply(block)
+        val key = ParentTransitionKey(from, eventType)
+        val target = TransitionTarget(to, builder.guardFunction)
+        parentTransitions[key] = target
+    }
+
+    /**
      * suspend 전이 콜백을 설정합니다.
      *
      * @param callback 이전 상태, 이벤트, 다음 상태를 받는 suspend 콜백
@@ -183,12 +240,26 @@ class SuspendStateMachineBuilder<S: Any, E: Any> {
     /**
      * [SuspendStateMachine]을 생성합니다.
      */
-    fun build(): SuspendStateMachineInterface<S, E> = SuspendStateMachine(
-        initialState = initialState,
-        finalStates = finalStates,
-        transitions = transitions.toMap(),
-        onTransitionCallback = onTransitionCallback,
-    )
+    fun build(): SuspendStateMachineInterface<S, E> {
+        val exactTransitions = transitions.toMap()
+        val inheritedTransitions = parentTransitions.toMap()
+        val knownStates = buildSet {
+            add(initialState)
+            addAll(finalStates)
+            addAll(exactTransitions.keys.map { it.state })
+            addAll(exactTransitions.values.map { it.state })
+            addAll(inheritedTransitions.values.map { it.state })
+        }
+        TransitionRegistry(exactTransitions, inheritedTransitions).validateKnownStates(knownStates)
+
+        return SuspendStateMachine(
+            initialState = initialState,
+            finalStates = finalStates,
+            transitions = exactTransitions,
+            parentTransitions = inheritedTransitions,
+            onTransitionCallback = onTransitionCallback,
+        )
+    }
 }
 
 /**
@@ -244,3 +315,12 @@ fun <S: Any, E: Any> suspendStateMachine(
  * @return 이벤트 클래스 객체
  */
 inline fun <reified E: Any> on(): Class<E> = E::class.java
+
+/**
+ * Returns a state class for inherited transition registration.
+ *
+ * ```kotlin
+ * transition(state<OrderState.Payable>(), on<OrderEvent.Cancel>(), to = OrderState.Cancelled)
+ * ```
+ */
+inline fun <reified S: Any> state(): Class<S> = S::class.java

--- a/utils/states/src/main/kotlin/io/bluetape4k/states/core/TransitionRegistry.kt
+++ b/utils/states/src/main/kotlin/io/bluetape4k/states/core/TransitionRegistry.kt
@@ -1,0 +1,121 @@
+package io.bluetape4k.states.core
+
+import io.bluetape4k.states.api.StateMachineException
+import java.util.ArrayDeque
+
+internal class TransitionRegistry<S: Any, E: Any>(
+    private val exactTransitions: Map<TransitionKey<S, E>, TransitionTarget<S, E>>,
+    private val parentTransitions: Map<ParentTransitionKey<S, E>, TransitionTarget<S, E>>,
+) {
+
+    fun resolve(state: S, event: E): TransitionMatch<S, E>? {
+        val eventType = event::class.java
+        val exactKey = TransitionKey(state, eventType)
+        exactTransitions[exactKey]?.let { target ->
+            return TransitionMatch(target, exactKey, null)
+        }
+
+        val parentMatches = parentTransitions
+            .mapNotNull { (key, target) ->
+                if (key.eventType != eventType) {
+                    null
+                } else {
+                    inheritanceDistance(state::class.java, key.stateType)
+                        ?.let { distance -> ParentMatch(key, target, distance) }
+                }
+            }
+
+        if (parentMatches.isEmpty()) {
+            return null
+        }
+
+        val nearestDistance = parentMatches.minOf { it.distance }
+        val nearest = parentMatches.filter { it.distance == nearestDistance }
+        if (nearest.size > 1) {
+            throw StateMachineException(
+                "Ambiguous inherited transition: state=$state, event=${eventType.simpleName}, " +
+                        "parents=${nearest.map { it.key.stateType.simpleName }}"
+            )
+        }
+
+        return nearest.single().let { match ->
+            TransitionMatch(match.target, null, match.key)
+        }
+    }
+
+    fun allowedEvents(state: S): Set<Class<out E>> {
+        val exactEvents = exactTransitions.keys
+            .filter { it.state == state }
+            .map { it.eventType }
+
+        val parentEvents = parentTransitions.keys
+            .filter { it.stateType.isInstance(state) }
+            .map { it.eventType }
+
+        return (exactEvents + parentEvents).toSet()
+    }
+
+    fun validateKnownStates(knownStates: Set<S>) {
+        if (parentTransitions.size < 2 || knownStates.isEmpty()) {
+            return
+        }
+
+        val parentKeysByEvent = parentTransitions.keys.groupBy { it.eventType }
+        parentKeysByEvent.forEach { (eventType, keys) ->
+            knownStates.forEach { state ->
+                val matches = keys.mapNotNull { key ->
+                    inheritanceDistance(state::class.java, key.stateType)
+                        ?.let { distance -> key to distance }
+                }
+                if (matches.size > 1) {
+                    val nearestDistance = matches.minOf { it.second }
+                    val nearest = matches.filter { it.second == nearestDistance }
+                    if (nearest.size > 1) {
+                        throw StateMachineException(
+                            "Ambiguous inherited transition: state=$state, event=${eventType.simpleName}, " +
+                                    "parents=${nearest.map { it.first.stateType.simpleName }}"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun inheritanceDistance(actualType: Class<*>, expectedParent: Class<*>): Int? {
+        if (!expectedParent.isAssignableFrom(actualType)) {
+            return null
+        }
+
+        val visited = mutableSetOf<Class<*>>()
+        val queue = ArrayDeque<Pair<Class<*>, Int>>()
+        queue.add(actualType to 0)
+
+        while (queue.isNotEmpty()) {
+            val (type, distance) = queue.removeFirst()
+            if (!visited.add(type)) {
+                continue
+            }
+            if (type == expectedParent) {
+                return distance
+            }
+
+            type.superclass?.let { queue.add(it to distance + 1) }
+            type.interfaces.forEach { queue.add(it to distance + 1) }
+        }
+
+        return null
+    }
+
+    private class ParentMatch<S: Any, E: Any>(
+        val key: ParentTransitionKey<S, E>,
+        val target: TransitionTarget<S, E>,
+        val distance: Int,
+    )
+}
+
+internal class TransitionMatch<S: Any, E: Any>(
+    val target: TransitionTarget<S, E>,
+    val exactKey: TransitionKey<S, E>?,
+    val parentKey: ParentTransitionKey<S, E>?,
+)
+

--- a/utils/states/src/main/kotlin/io/bluetape4k/states/coroutines/SuspendStateMachine.kt
+++ b/utils/states/src/main/kotlin/io/bluetape4k/states/coroutines/SuspendStateMachine.kt
@@ -5,7 +5,9 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.states.api.StateMachineException
 import io.bluetape4k.states.api.SuspendStateMachineInterface
 import io.bluetape4k.states.api.TransitionResult
+import io.bluetape4k.states.core.ParentTransitionKey
 import io.bluetape4k.states.core.TransitionKey
+import io.bluetape4k.states.core.TransitionRegistry
 import io.bluetape4k.states.core.TransitionTarget
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -44,6 +46,7 @@ class SuspendStateMachine<S: Any, E: Any>(
     override val initialState: S,
     override val finalStates: Set<S>,
     private val transitions: Map<TransitionKey<S, E>, TransitionTarget<S, E>>,
+    private val parentTransitions: Map<ParentTransitionKey<S, E>, TransitionTarget<S, E>> = emptyMap(),
     private val onTransitionCallback: (suspend (S, E, S) -> Unit)? = null,
 ): SuspendStateMachineInterface<S, E> {
 
@@ -51,6 +54,7 @@ class SuspendStateMachine<S: Any, E: Any>(
 
     private val mutex = Mutex()
     private val _stateFlow = MutableStateFlow(initialState)
+    private val registry = TransitionRegistry(transitions, parentTransitions)
 
     override val stateFlow: StateFlow<S> = _stateFlow.asStateFlow()
 
@@ -82,8 +86,7 @@ class SuspendStateMachine<S: Any, E: Any>(
             throw StateMachineException("이미 종료 상태입니다: $previous")
         }
 
-        val key = TransitionKey(previous, event::class.java)
-        val target = transitions[key]
+        val target = registry.resolve(previous, event)?.target
             ?: throw StateMachineException(
                 "허용되지 않은 전이: $previous + ${event::class.simpleName}. " +
                         "허용된 이벤트: ${allowedEvents().map { it.simpleName }}"
@@ -129,8 +132,7 @@ class SuspendStateMachine<S: Any, E: Any>(
         val state = currentState
         if (state in finalStates) return false
 
-        val key = TransitionKey(state, event::class.java)
-        val target = transitions[key] ?: return false
+        val target = registry.resolve(state, event)?.target ?: return false
         return target.guard?.invoke(state, event) ?: true
     }
 
@@ -154,9 +156,6 @@ class SuspendStateMachine<S: Any, E: Any>(
         val state = currentState
         if (state in finalStates) return emptySet()
 
-        return transitions.keys
-            .filter { it.state == state }
-            .map { it.eventType }
-            .toSet()
+        return registry.allowedEvents(state)
     }
 }

--- a/utils/states/src/main/kotlin/io/bluetape4k/states/reactive/DefaultReactiveStateMachine.kt
+++ b/utils/states/src/main/kotlin/io/bluetape4k/states/reactive/DefaultReactiveStateMachine.kt
@@ -1,0 +1,208 @@
+package io.bluetape4k.states.reactive
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
+import io.bluetape4k.states.api.StateMachineException
+import io.bluetape4k.states.api.TransitionResult
+import io.bluetape4k.states.core.ParentTransitionKey
+import io.bluetape4k.states.core.TransitionKey
+import io.bluetape4k.states.core.TransitionRegistry
+import io.bluetape4k.states.core.TransitionTarget
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock as withJvmLock
+
+internal class DefaultReactiveStateMachine<S: Any, E: Any, F: Any>(
+    override val initialState: S,
+    override val finalStates: Set<S>,
+    transitions: Map<TransitionKey<S, E>, TransitionTarget<S, E>>,
+    parentTransitions: Map<ParentTransitionKey<S, E>, TransitionTarget<S, E>>,
+    private val transitionEffects: Map<TransitionKey<S, E>, suspend ReactiveEffectScope<E, F>.(S, E, S) -> Unit>,
+    private val parentTransitionEffects: Map<ParentTransitionKey<S, E>, suspend ReactiveEffectScope<E, F>.(S, E, S) -> Unit>,
+    private val sideEffects: List<ReactiveSideEffect<S, E, F>>,
+    parentScope: CoroutineScope,
+): ReactiveStateMachine<S, E, F> {
+
+    companion object: KLogging()
+
+    private val machineJob = SupervisorJob(parentScope.coroutineContext[Job])
+    private val machineScope = CoroutineScope(parentScope.coroutineContext + machineJob)
+    private val mutex = Mutex()
+    private val registry = TransitionRegistry(transitions, parentTransitions)
+    private val sideEffectsLock = ReentrantLock()
+    private val activeSideEffects = mutableMapOf<Int, ActiveSideEffect>()
+    private val _stateFlow = MutableStateFlow(initialState)
+    private val _effects = MutableSharedFlow<F>(replay = 0, extraBufferCapacity = 64)
+    @Volatile
+    private var closed = false
+
+    override val stateFlow: StateFlow<S> = _stateFlow.asStateFlow()
+    override val effects = _effects.asSharedFlow()
+    override val value: S
+        get() = _stateFlow.value
+    override val replayCache: List<S>
+        get() = stateFlow.replayCache
+    override val currentState: S
+        get() = _stateFlow.value
+
+    init {
+        restartSideEffects(initialState)
+    }
+
+    override suspend fun collect(collector: FlowCollector<S>): Nothing {
+        stateFlow.collect(collector)
+    }
+
+    override suspend fun send(event: E): TransitionResult<S, E> = mutex.withLock {
+        if (closed) {
+            throw StateMachineException("State machine is closed.")
+        }
+
+        val previous = _stateFlow.value
+
+        if (previous in finalStates) {
+            throw StateMachineException("이미 종료 상태입니다: $previous")
+        }
+
+        val match = registry.resolve(previous, event)
+            ?: throw StateMachineException(
+                "허용되지 않은 전이: $previous + ${event::class.simpleName}. " +
+                        "허용된 이벤트: ${allowedEvents().map { it.simpleName }}"
+            )
+        val target = match.target
+        val guardResult = target.guard?.invoke(previous, event) ?: true
+        if (!guardResult) {
+            throw StateMachineException("Guard 조건 실패: $previous + ${event::class.simpleName}")
+        }
+
+        _stateFlow.value = target.state
+        log.debug { "$previous --[${event::class.simpleName}]--> ${target.state}" }
+
+        try {
+            val effectScope = ReactiveEffectScope<E, F>(
+                emitEffect = { effect -> _effects.emit(effect) },
+                sendEvent = { nextEvent -> launchFollowUpEvent(nextEvent) },
+            )
+            match.exactKey?.let { key ->
+                transitionEffects[key]?.invoke(effectScope, previous, event, target.state)
+            }
+            match.parentKey?.let { key ->
+                parentTransitionEffects[key]?.invoke(effectScope, previous, event, target.state)
+            }
+        } finally {
+            restartSideEffects(target.state)
+        }
+
+        TransitionResult(
+            previousState = previous,
+            event = event,
+            currentState = target.state,
+        )
+    }
+
+    override fun canTransition(event: E): Boolean {
+        val state = currentState
+        if (state in finalStates) return false
+
+        val target = registry.resolve(state, event)?.target ?: return false
+        return target.guard?.invoke(state, event) ?: true
+    }
+
+    override fun allowedEvents(): Set<Class<out E>> {
+        val state = currentState
+        if (state in finalStates) return emptySet()
+
+        return registry.allowedEvents(state)
+    }
+
+    override fun close() {
+        sideEffectsLock.withJvmLock {
+            if (closed) {
+                return
+            }
+            closed = true
+            activeSideEffects.values.forEach { it.job.cancel() }
+            activeSideEffects.clear()
+        }
+        machineScope.cancel()
+    }
+
+    private fun restartSideEffects(state: S) {
+        sideEffectsLock.withJvmLock {
+            if (closed) {
+                return
+            }
+
+            val desired = sideEffects
+                .mapIndexedNotNull { index, sideEffect ->
+                    if (sideEffect.matches(state)) {
+                        index to sideEffect.key(state)
+                    } else {
+                        null
+                    }
+                }
+                .toMap()
+
+            activeSideEffects
+                .filter { (index, active) -> desired[index] != active.key }
+                .keys
+                .toList()
+                .forEach { index ->
+                    activeSideEffects.remove(index)?.job?.cancel()
+                }
+
+            desired.forEach { (index, key) ->
+                if (activeSideEffects[index]?.key == key) {
+                    return@forEach
+                }
+
+                val sideEffect = sideEffects[index]
+                val effectScope = ReactiveEffectScope<E, F>(
+                    emitEffect = { effect -> _effects.emit(effect) },
+                    sendEvent = { event -> launchFollowUpEvent(event) },
+                )
+                val job = machineScope.launch {
+                    sideEffect.block.invoke(effectScope, state)
+                }
+                activeSideEffects[index] = ActiveSideEffect(key, job)
+            }
+        }
+    }
+
+    private class ActiveSideEffect(
+        val key: Any?,
+        val job: Job,
+    )
+
+    private fun launchFollowUpEvent(event: E) {
+        if (closed) {
+            return
+        }
+        machineScope.launch {
+            if (closed) {
+                return@launch
+            }
+            try {
+                send(event)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log.warn(e) { "Follow-up event failed: ${event::class.simpleName}" }
+            }
+        }
+    }
+}

--- a/utils/states/src/main/kotlin/io/bluetape4k/states/reactive/ReactiveEffectScope.kt
+++ b/utils/states/src/main/kotlin/io/bluetape4k/states/reactive/ReactiveEffectScope.kt
@@ -1,0 +1,32 @@
+package io.bluetape4k.states.reactive
+
+/**
+ * Scope available to reactive transition and state side-effect handlers.
+ *
+ * Effects are one-time outputs and are not part of persistent state. Handlers
+ * may also enqueue a follow-up event through [send]. Follow-up events are
+ * scheduled on the owning machine and are processed after the current handler
+ * returns.
+ *
+ * @param E event type
+ * @param F effect type
+ */
+class ReactiveEffectScope<E: Any, F: Any> internal constructor(
+    private val emitEffect: suspend (F) -> Unit,
+    private val sendEvent: suspend (E) -> Unit,
+) {
+
+    /**
+     * Emits a one-time effect.
+     */
+    suspend fun emit(effect: F) {
+        emitEffect(effect)
+    }
+
+    /**
+     * Enqueues a follow-up event to the owning reactive state machine.
+     */
+    suspend fun send(event: E) {
+        sendEvent(event)
+    }
+}

--- a/utils/states/src/main/kotlin/io/bluetape4k/states/reactive/ReactiveStateMachine.kt
+++ b/utils/states/src/main/kotlin/io/bluetape4k/states/reactive/ReactiveStateMachine.kt
@@ -1,0 +1,45 @@
+package io.bluetape4k.states.reactive
+
+import io.bluetape4k.states.api.BaseStateMachine
+import io.bluetape4k.states.api.TransitionResult
+import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Coroutine-first state machine with queued events and one-time effects.
+ *
+ * This API is optional and separate from the core synchronous and suspending
+ * FSM APIs. It is useful when callers need a long-lived runtime that exposes
+ * current state, accepts events, emits one-time effects, and owns lifecycle
+ * side effects.
+ *
+ * @param S state type
+ * @param E event type
+ * @param F one-time effect type
+ */
+@OptIn(ExperimentalForInheritanceCoroutinesApi::class)
+interface ReactiveStateMachine<S: Any, E: Any, F: Any>: BaseStateMachine<S, E>, StateFlow<S>, AutoCloseable {
+
+    /**
+     * State stream backed by this machine.
+     */
+    val stateFlow: StateFlow<S>
+
+    /**
+     * One-time effects emitted by transition and state side-effect handlers.
+     */
+    val effects: Flow<F>
+
+    /**
+     * Sends [event] through the sequential event processor.
+     *
+     * @throws io.bluetape4k.states.api.StateMachineException when the machine is closed
+     */
+    suspend fun send(event: E): TransitionResult<S, E>
+
+    /**
+     * Cancels active state side effects and rejects later [send] calls.
+     */
+    override fun close()
+}

--- a/utils/states/src/main/kotlin/io/bluetape4k/states/reactive/ReactiveStateMachineDsl.kt
+++ b/utils/states/src/main/kotlin/io/bluetape4k/states/reactive/ReactiveStateMachineDsl.kt
@@ -1,0 +1,204 @@
+package io.bluetape4k.states.reactive
+
+import io.bluetape4k.states.api.StateMachineException
+import io.bluetape4k.states.core.ParentTransitionKey
+import io.bluetape4k.states.core.StateMachineDsl
+import io.bluetape4k.states.core.TransitionKey
+import io.bluetape4k.states.core.TransitionRegistry
+import io.bluetape4k.states.core.TransitionTarget
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * Configures a reactive transition.
+ *
+ * @param S state type
+ * @param E event type
+ * @param F effect type
+ */
+@StateMachineDsl
+class ReactiveTransitionBuilder<S: Any, E: Any, F: Any> {
+
+    internal var guardFunction: ((S, E) -> Boolean)? = null
+        private set
+
+    internal var effectHandler: (suspend ReactiveEffectScope<E, F>.(S, E, S) -> Unit)? = null
+        private set
+
+    /**
+     * Sets a guard condition for this transition.
+     */
+    fun guard(predicate: (S, E) -> Boolean) {
+        guardFunction = predicate
+    }
+
+    /**
+     * Sets an effect handler that runs after a successful transition.
+     */
+    fun effect(handler: suspend ReactiveEffectScope<E, F>.(S, E, S) -> Unit) {
+        effectHandler = handler
+    }
+}
+
+/**
+ * Configures lifecycle side effects for a state or state family.
+ */
+@StateMachineDsl
+class ReactiveStateBuilder<S: Any, E: Any, F: Any> internal constructor(
+    private val register: (ReactiveSideEffect<S, E, F>) -> Unit,
+    private val matcher: ReactiveStateMatcher<S>,
+) {
+
+    /**
+     * Starts [block] whenever the matching state is active.
+     */
+    fun sideEffect(block: suspend ReactiveEffectScope<E, F>.(S) -> Unit) {
+        sideEffect(key = { it }, block = block)
+    }
+
+    /**
+     * Starts [block] whenever the matching state is active and restarts it only
+     * when [key] changes.
+     */
+    fun sideEffect(
+        key: (S) -> Any?,
+        block: suspend ReactiveEffectScope<E, F>.(S) -> Unit,
+    ) {
+        register(ReactiveSideEffect(matcher, key, block))
+    }
+}
+
+/**
+ * Builder for [ReactiveStateMachine].
+ */
+@StateMachineDsl
+class ReactiveStateMachineBuilder<S: Any, E: Any, F: Any> internal constructor(
+    private val scope: CoroutineScope,
+) {
+
+    lateinit var initialState: S
+    var finalStates: Set<S> = emptySet()
+
+    private val transitions = mutableMapOf<TransitionKey<S, E>, TransitionTarget<S, E>>()
+    private val parentTransitions = mutableMapOf<ParentTransitionKey<S, E>, TransitionTarget<S, E>>()
+    private val transitionEffects =
+        mutableMapOf<TransitionKey<S, E>, suspend ReactiveEffectScope<E, F>.(S, E, S) -> Unit>()
+    private val parentTransitionEffects =
+        mutableMapOf<ParentTransitionKey<S, E>, suspend ReactiveEffectScope<E, F>.(S, E, S) -> Unit>()
+    private val sideEffects = mutableListOf<ReactiveSideEffect<S, E, F>>()
+
+    /**
+     * Registers an exact state transition.
+     */
+    fun transition(
+        from: S,
+        eventType: Class<out E>,
+        to: S,
+        block: ReactiveTransitionBuilder<S, E, F>.() -> Unit = {},
+    ) {
+        val builder = ReactiveTransitionBuilder<S, E, F>().apply(block)
+        val key = TransitionKey(from, eventType)
+        transitions[key] = TransitionTarget(to, builder.guardFunction)
+        builder.effectHandler?.let { transitionEffects[key] = it }
+    }
+
+    /**
+     * Registers an inherited transition for a state family.
+     */
+    fun transition(
+        from: Class<out S>,
+        eventType: Class<out E>,
+        to: S,
+        block: ReactiveTransitionBuilder<S, E, F>.() -> Unit = {},
+    ) {
+        val builder = ReactiveTransitionBuilder<S, E, F>().apply(block)
+        val key = ParentTransitionKey(from, eventType)
+        parentTransitions[key] = TransitionTarget(to, builder.guardFunction)
+        builder.effectHandler?.let { parentTransitionEffects[key] = it }
+    }
+
+    /**
+     * Configures side effects for one exact state value.
+     */
+    fun onState(
+        state: S,
+        block: ReactiveStateBuilder<S, E, F>.() -> Unit,
+    ) {
+        ReactiveStateBuilder(::registerSideEffect, ReactiveStateMatcher.Exact(state)).apply(block)
+    }
+
+    /**
+     * Configures side effects for every state matching [stateType].
+     */
+    fun onState(
+        stateType: Class<out S>,
+        block: ReactiveStateBuilder<S, E, F>.() -> Unit,
+    ) {
+        ReactiveStateBuilder(::registerSideEffect, ReactiveStateMatcher.Parent(stateType)).apply(block)
+    }
+
+    /**
+     * Creates a reactive state machine.
+     */
+    fun build(): ReactiveStateMachine<S, E, F> {
+        val exactTransitions = transitions.toMap()
+        val inheritedTransitions = parentTransitions.toMap()
+        val knownStates = buildSet {
+            add(initialState)
+            addAll(finalStates)
+            addAll(exactTransitions.keys.map { it.state })
+            addAll(exactTransitions.values.map { it.state })
+            addAll(inheritedTransitions.values.map { it.state })
+        }
+        TransitionRegistry(exactTransitions, inheritedTransitions).validateKnownStates(knownStates)
+
+        if (exactTransitions.isEmpty() && inheritedTransitions.isEmpty()) {
+            throw StateMachineException("Reactive state machine requires at least one transition")
+        }
+
+        return DefaultReactiveStateMachine(
+            initialState = initialState,
+            finalStates = finalStates,
+            transitions = exactTransitions,
+            parentTransitions = inheritedTransitions,
+            transitionEffects = transitionEffects.toMap(),
+            parentTransitionEffects = parentTransitionEffects.toMap(),
+            sideEffects = sideEffects.toList(),
+            parentScope = scope,
+        )
+    }
+
+    private fun registerSideEffect(sideEffect: ReactiveSideEffect<S, E, F>) {
+        sideEffects += sideEffect
+    }
+}
+
+/**
+ * Creates a [ReactiveStateMachine].
+ */
+fun <S: Any, E: Any, F: Any> reactiveStateMachine(
+    scope: CoroutineScope,
+    block: ReactiveStateMachineBuilder<S, E, F>.() -> Unit,
+): ReactiveStateMachine<S, E, F> =
+    ReactiveStateMachineBuilder<S, E, F>(scope).apply(block).build()
+
+internal sealed class ReactiveStateMatcher<S: Any> {
+
+    abstract fun matches(state: S): Boolean
+
+    class Exact<S: Any>(private val expectedState: S): ReactiveStateMatcher<S>() {
+        override fun matches(state: S): Boolean = state == expectedState
+    }
+
+    class Parent<S: Any>(private val expectedType: Class<out S>): ReactiveStateMatcher<S>() {
+        override fun matches(state: S): Boolean = expectedType.isInstance(state)
+    }
+}
+
+internal class ReactiveSideEffect<S: Any, E: Any, F: Any>(
+    private val matcher: ReactiveStateMatcher<S>,
+    val key: (S) -> Any?,
+    val block: suspend ReactiveEffectScope<E, F>.(S) -> Unit,
+) {
+
+    fun matches(state: S): Boolean = matcher.matches(state)
+}

--- a/utils/states/src/test/kotlin/io/bluetape4k/states/core/NestedStateMachineDslTest.kt
+++ b/utils/states/src/test/kotlin/io/bluetape4k/states/core/NestedStateMachineDslTest.kt
@@ -1,0 +1,101 @@
+package io.bluetape4k.states.core
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.states.api.StateMachineException
+import org.junit.jupiter.api.Test
+
+class NestedStateMachineDslTest {
+
+    private sealed interface Step
+    private data object Draft: Step
+    private sealed interface Active: Step
+    private data object Review: Active
+    private data object Approved: Active
+    private data object Archived: Step
+    private data object Cancelled: Step
+
+    private sealed class Event {
+        data object Submit: Event()
+        data object Approve: Event()
+        data object Cancel: Event()
+        data object Archive: Event()
+    }
+
+    private sealed interface LeftBranch: Step
+    private sealed interface RightBranch: Step
+    private data object SharedState: LeftBranch, RightBranch
+
+    @Test fun `nested transition applies to matching state family`() {
+        val machine = stateMachine<Step, Event> {
+            initialState = Review
+            transition(state<Active>(), on<Event.Cancel>(), to = Cancelled)
+        }
+
+        machine.canTransition(Event.Cancel).shouldBeTrue()
+        machine.allowedEvents() shouldBeEqualTo setOf(Event.Cancel::class.java)
+
+        val result = machine.transition(Event.Cancel)
+
+        result.previousState shouldBeEqualTo Review
+        result.currentState shouldBeEqualTo Cancelled
+    }
+
+    @Test fun `exact transition overrides nested transition`() {
+        val machine = stateMachine<Step, Event> {
+            initialState = Review
+            transition(state<Active>(), on<Event.Cancel>(), to = Cancelled)
+            transition(Review, on<Event.Cancel>(), to = Archived)
+        }
+
+        machine.transition(Event.Cancel).currentState shouldBeEqualTo Archived
+    }
+
+    @Test fun `nested guard participates in canTransition`() {
+        val machine = stateMachine<Step, Event> {
+            initialState = Approved
+            transition(state<Active>(), on<Event.Archive>(), to = Archived) {
+                guard { state, _ -> state == Approved }
+            }
+        }
+
+        machine.canTransition(Event.Archive).shouldBeTrue()
+        machine.transition(Event.Archive).currentState shouldBeEqualTo Archived
+    }
+
+    @Test fun `nested guard rejection returns false from canTransition`() {
+        val machine = stateMachine<Step, Event> {
+            initialState = Review
+            transition(state<Active>(), on<Event.Archive>(), to = Archived) {
+                guard { state, _ -> state == Approved }
+            }
+        }
+
+        machine.canTransition(Event.Archive).shouldBeFalse()
+    }
+
+    @Test fun `ambiguous nested transitions fail during build`() {
+        assertFailsWith<StateMachineException> {
+            stateMachine<Step, Event> {
+                initialState = SharedState
+                transition(state<LeftBranch>(), on<Event.Cancel>(), to = Cancelled)
+                transition(state<RightBranch>(), on<Event.Cancel>(), to = Archived)
+            }
+        }
+    }
+
+    @Test fun `final state suppresses inherited transitions`() {
+        val machine = stateMachine<Step, Event> {
+            initialState = Review
+            finalStates = setOf(Review)
+            transition(state<Active>(), on<Event.Cancel>(), to = Cancelled)
+        }
+
+        machine.isInFinalState().shouldBeTrue()
+        machine.canTransition(Event.Cancel).shouldBeFalse()
+        machine.allowedEvents() shouldBeEqualTo emptySet()
+    }
+}
+

--- a/utils/states/src/test/kotlin/io/bluetape4k/states/reactive/ReactiveStateMachineTest.kt
+++ b/utils/states/src/test/kotlin/io/bluetape4k/states/reactive/ReactiveStateMachineTest.kt
@@ -1,0 +1,267 @@
+package io.bluetape4k.states.reactive
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.states.api.StateMachineException
+import io.bluetape4k.states.core.on
+import io.bluetape4k.states.core.state
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReactiveStateMachineTest {
+
+    private sealed interface Step
+    private data object A: Step
+    private data object B: Step
+    private data object Done: Step
+    private data class Editing(val id: Int, val text: String): Step
+
+    private sealed class Event {
+        data object Flip: Event()
+        data object Finish: Event()
+        data object Change: Event()
+        data object Cancel: Event()
+    }
+
+    private sealed class Effect {
+        data object Flipped: Effect()
+    }
+
+    @Test fun `send processes concurrent events sequentially`() = runTest {
+        val machine = reactiveStateMachine<Step, Event, Effect>(backgroundScope) {
+            initialState = A
+            transition(A, on<Event.Flip>(), to = B)
+            transition(B, on<Event.Flip>(), to = A)
+        }
+
+        List(20) {
+            async { machine.send(Event.Flip) }
+        }.awaitAll()
+
+        machine.currentState shouldBeEqualTo A
+        machine.close()
+    }
+
+    @Test fun `transition effects are delivered as one-time effects`() = runTest {
+        val machine = reactiveStateMachine<Step, Event, Effect>(backgroundScope) {
+            initialState = A
+            transition(A, on<Event.Flip>(), to = B) {
+                effect { _, _, _ -> emit(Effect.Flipped) }
+            }
+        }
+        val effects = mutableListOf<Effect>()
+        val collector = backgroundScope.launch {
+            machine.effects.take(1).toList(effects)
+        }
+        runCurrent()
+
+        machine.send(Event.Flip)
+        collector.join()
+
+        effects shouldBeEqualTo listOf(Effect.Flipped)
+        machine.stateFlow.value shouldBeEqualTo B
+        machine.close()
+    }
+
+    @Test fun `state side effect starts on entry and cancels on exit`() = runTest {
+        var starts = 0
+        var cancellations = 0
+        val machine = reactiveStateMachine<Step, Event, Effect>(backgroundScope) {
+            initialState = A
+            transition(A, on<Event.Flip>(), to = B)
+            onState(A) {
+                sideEffect {
+                    starts++
+                    try {
+                        awaitCancellation()
+                    } finally {
+                        cancellations++
+                    }
+                }
+            }
+        }
+        runCurrent()
+
+        machine.send(Event.Flip)
+        runCurrent()
+
+        starts shouldBeEqualTo 1
+        cancellations shouldBeEqualTo 1
+        machine.close()
+    }
+
+    @Test fun `keyed side effect does not restart when logical key is unchanged`() = runTest {
+        var starts = 0
+        val first = Editing(1, "a")
+        val second = Editing(1, "b")
+        val third = Editing(1, "c")
+        val machine = reactiveStateMachine<Step, Event, Effect>(backgroundScope) {
+            initialState = first
+            transition(first, on<Event.Change>(), to = second)
+            transition(second, on<Event.Change>(), to = third)
+            onState(state<Editing>()) {
+                sideEffect(key = { (it as Editing).id }) {
+                    starts++
+                    awaitCancellation()
+                }
+            }
+        }
+        runCurrent()
+
+        machine.send(Event.Change)
+        machine.send(Event.Change)
+        runCurrent()
+
+        starts shouldBeEqualTo 1
+        machine.currentState shouldBeEqualTo third
+        machine.close()
+    }
+
+    @Test fun `side effect without key restarts when matching state data changes`() = runTest {
+        var starts = 0
+        val first = Editing(1, "a")
+        val second = Editing(1, "b")
+        val machine = reactiveStateMachine<Step, Event, Effect>(backgroundScope) {
+            initialState = first
+            transition(first, on<Event.Change>(), to = second)
+            onState(state<Editing>()) {
+                sideEffect {
+                    starts++
+                    awaitCancellation()
+                }
+            }
+        }
+        runCurrent()
+
+        machine.send(Event.Change)
+        runCurrent()
+
+        starts shouldBeEqualTo 2
+        machine.close()
+    }
+
+    @Test fun `transition effect can enqueue follow-up event without deadlock`() = runTest {
+        val machine = reactiveStateMachine<Step, Event, Effect>(backgroundScope) {
+            initialState = A
+            transition(A, on<Event.Flip>(), to = B) {
+                effect { _, _, _ -> send(Event.Finish) }
+            }
+            transition(B, on<Event.Finish>(), to = Done)
+        }
+
+        machine.send(Event.Flip)
+        runCurrent()
+
+        machine.currentState shouldBeEqualTo Done
+        machine.close()
+    }
+
+    @Test fun `failed follow-up event does not cancel the machine`() = runTest {
+        val machine = reactiveStateMachine<Step, Event, Effect>(backgroundScope) {
+            initialState = A
+            transition(A, on<Event.Flip>(), to = B) {
+                effect { _, _, _ -> send(Event.Finish) }
+            }
+            transition(B, on<Event.Flip>(), to = A)
+        }
+
+        machine.send(Event.Flip)
+        runCurrent()
+        machine.currentState shouldBeEqualTo B
+
+        machine.send(Event.Flip)
+
+        machine.currentState shouldBeEqualTo A
+        machine.close()
+    }
+
+    @Test fun `cancellation from transition effect is propagated`() = runTest {
+        val machine = reactiveStateMachine<Step, Event, Effect>(backgroundScope) {
+            initialState = A
+            transition(A, on<Event.Flip>(), to = B) {
+                effect { _, _, _ -> throw CancellationException("cancelled by test") }
+            }
+        }
+
+        assertFailsWith<CancellationException> {
+            machine.send(Event.Flip)
+        }
+        machine.close()
+    }
+
+    @Test fun `transition effect cancellation still restarts state side effects`() = runTest {
+        var initialStarts = 0
+        var initialCancellations = 0
+        var targetStarts = 0
+        val machine = reactiveStateMachine<Step, Event, Effect>(backgroundScope) {
+            initialState = A
+            transition(A, on<Event.Flip>(), to = B) {
+                effect { _, _, _ -> throw CancellationException("cancelled by test") }
+            }
+            onState(A) {
+                sideEffect {
+                    initialStarts++
+                    try {
+                        awaitCancellation()
+                    } finally {
+                        initialCancellations++
+                    }
+                }
+            }
+            onState(B) {
+                sideEffect {
+                    targetStarts++
+                    awaitCancellation()
+                }
+            }
+        }
+        runCurrent()
+
+        assertFailsWith<CancellationException> {
+            machine.send(Event.Flip)
+        }
+        runCurrent()
+
+        machine.currentState shouldBeEqualTo B
+        initialStarts shouldBeEqualTo 1
+        initialCancellations shouldBeEqualTo 1
+        targetStarts shouldBeEqualTo 1
+        machine.close()
+    }
+
+    @Test fun `close cancels side effects and rejects future events`() = runTest {
+        var cancellations = 0
+        val machine = reactiveStateMachine<Step, Event, Effect>(backgroundScope) {
+            initialState = A
+            transition(A, on<Event.Flip>(), to = B)
+            onState(A) {
+                sideEffect {
+                    try {
+                        awaitCancellation()
+                    } finally {
+                        cancellations++
+                    }
+                }
+            }
+        }
+        runCurrent()
+
+        machine.close()
+        runCurrent()
+
+        cancellations shouldBeEqualTo 1
+        assertFailsWith<StateMachineException> {
+            machine.send(Event.Flip)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #436, #437, #438

- PR 제목: feat(states): add reactive runtime and nested transitions

- Add inherited state-family transitions for `utils/states` with exact-transition precedence and ambiguity validation.
- Add optional `reactiveStateMachine` runtime with sequential `send(event)`, one-time effects, lifecycle side effects, and keyed side-effect restart control.
- Harden reactive lifecycle behavior after review: follow-up events are queued asynchronously, follow-up failures are logged without cancelling the machine, transition cancellation still restarts target side effects, and `close()` cancels active side effects while rejecting later sends.
- Update English/Korean README positioning guidance and examples after the #251 StateMachine comparison.
- Add research/lesson notes for the StateMachine comparison and the states runtime/DSL work.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Issues

Closes #436
Closes #437
Closes #438

Related: #251

### 기존 섹션: Notes

- `joost-klitsie/StateMachine` remains a design reference only, not a dependency.
- The reactive runtime stays optional and separate from the existing sync/suspend FSM APIs.
- Exact transitions intentionally override inherited state-family transitions.

## Validation

- IDE import optimization/diagnostics on touched Kotlin files: 0 errors.
- `./gradlew :bluetape4k-states:test --no-configuration-cache`
  - Result: 57 passing, BUILD SUCCESSFUL.
- Claude PR follow-up review:
  - Initial HIGH findings addressed: side-effect lifecycle race, cancellation restart consistency, follow-up event failure handling, useless catch/rethrow.
  - Final follow-up review: no blocking, high, or medium issues.
- `git merge-tree $(git merge-base HEAD origin/develop) origin/develop HEAD`: no conflict markers reported.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #436, #437, #438, milestone 없음, assignee `debop`
- PR: #439, head `d968339043918a29c71332c75567a9242bdba102`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/states-reactive-dsl`
- Labels: `enhancement`
- State: `MERGED`, merge commit `340f3f5141c74de775938058f98c15091ecae595`
- CI: - `./gradlew :bluetape4k-states:test --no-configuration-cache`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #439 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `340f3f5141c74de775938058f98c15091ecae595`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
