### PR TITLE
docs: align compressor and cache migration docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Changed
 
-- Cache modules were reorganized under `cache/` while preserving existing Gradle project names, Maven artifact IDs, and Kotlin packages ([#350](https://github.com/bluetape4k/bluetape4k-projects/pull/350)).
+- Cache modules were reorganized under `cache/` while preserving existing Gradle project names, Maven artifact IDs, and Kotlin packages; users do not need to change `io.bluetape4k.cache.*` imports for the folder move ([#350](https://github.com/bluetape4k/bluetape4k-projects/pull/350), [#354](https://github.com/bluetape4k/bluetape4k-projects/issues/354)).
 - Spring Boot 4 became the standard Spring Boot line, with migration follow-up fixes and versionless `spring-boot/*` modules ([#348](https://github.com/bluetape4k/bluetape4k-projects/pull/348), [#351](https://github.com/bluetape4k/bluetape4k-projects/pull/351)).
 - Gradle catalog의 Spring Boot/Spring Cloud BOM alias를 `spring.boot.dependencies`와 `spring.cloud.dependencies`로 단일화했습니다.
 - Nightly and Examples workflows were split and tuned for tiered Testcontainers, Docker shard timeouts, Memgraph images, Kover report behavior, Spring Boot 4-only checks, and graphdb retry policy ([#355](https://github.com/bluetape4k/bluetape4k-projects/pull/355), [#356](https://github.com/bluetape4k/bluetape4k-projects/pull/356), [#357](https://github.com/bluetape4k/bluetape4k-projects/pull/357), [#358](https://github.com/bluetape4k/bluetape4k-projects/pull/358), [#363](https://github.com/bluetape4k/bluetape4k-projects/pull/363), [#366](https://github.com/bluetape4k/bluetape4k-projects/pull/366), [#367](https://github.com/bluetape4k/bluetape4k-projects/pull/367), [#413](https://github.com/bluetape4k/bluetape4k-projects/pull/413), [#414](https://github.com/bluetape4k/bluetape4k-projects/pull/414), [#423](https://github.com/bluetape4k/bluetape4k-projects/pull/423), [#424](https://github.com/bluetape4k/bluetape4k-projects/pull/424)).
@@ -33,9 +33,21 @@
 - Dependency baselines were refreshed across build plugins, GitHub Actions, Spring, Pulsar, Hibernate, GeoTools, Protobuf, OpenTelemetry instrumentation, and other library groups ([#378](https://github.com/bluetape4k/bluetape4k-projects/pull/378), [#382](https://github.com/bluetape4k/bluetape4k-projects/pull/382), [#383](https://github.com/bluetape4k/bluetape4k-projects/pull/383), [#384](https://github.com/bluetape4k/bluetape4k-projects/pull/384), [#386](https://github.com/bluetape4k/bluetape4k-projects/pull/386), [#387](https://github.com/bluetape4k/bluetape4k-projects/pull/387), [#388](https://github.com/bluetape4k/bluetape4k-projects/pull/388), [#389](https://github.com/bluetape4k/bluetape4k-projects/pull/389), [#392](https://github.com/bluetape4k/bluetape4k-projects/pull/392), [#393](https://github.com/bluetape4k/bluetape4k-projects/pull/393), [#394](https://github.com/bluetape4k/bluetape4k-projects/pull/394), [#397](https://github.com/bluetape4k/bluetape4k-projects/pull/397), [#401](https://github.com/bluetape4k/bluetape4k-projects/pull/401), [#402](https://github.com/bluetape4k/bluetape4k-projects/pull/402), [#403](https://github.com/bluetape4k/bluetape4k-projects/pull/403), [#404](https://github.com/bluetape4k/bluetape4k-projects/pull/404), [#405](https://github.com/bluetape4k/bluetape4k-projects/pull/405), [#407](https://github.com/bluetape4k/bluetape4k-projects/pull/407), [#408](https://github.com/bluetape4k/bluetape4k-projects/pull/408), [#409](https://github.com/bluetape4k/bluetape4k-projects/pull/409)).
 - WIP and README image documentation were refreshed after the idgenerator example lane completed ([#417](https://github.com/bluetape4k/bluetape4k-projects/pull/417), [#425](https://github.com/bluetape4k/bluetape4k-projects/pull/425), [#429](https://github.com/bluetape4k/bluetape4k-projects/pull/429)).
 
+### Breaking Changes
+
+- `AbstractCompressor.compress()` and `AbstractCompressor.decompress()` now propagate compression/decompression failures instead of returning `emptyByteArray` for failed non-empty input ([#317](https://github.com/bluetape4k/bluetape4k-projects/pull/317), [#325](https://github.com/bluetape4k/bluetape4k-projects/issues/325)).
+
+#### Migration
+
+| Previous expectation | Replacement |
+| --- | --- |
+| Failed `compress()` returns `emptyByteArray` | Use `compressOrNull()` when failures should return `null`, or catch the propagated exception from `compress()`. |
+| Failed `decompress()` returns `emptyByteArray` | Use `decompressOrNull()` when corrupt input should return `null`, or catch the propagated exception from `decompress()`. |
+| Corrupt compressed data is ignored | Use `decompressOrNull()` for nullable recovery, or catch the propagated exception from `decompress()`. |
+
 ### Fixed
 
-- `AbstractCompressor.compress/decompress` no longer swallows exceptions, preserving the breaking behavior change explicitly ([#317](https://github.com/bluetape4k/bluetape4k-projects/pull/317)).
+- `AbstractCompressor.compress/decompress` no longer swallows exceptions; this behavior change is documented as a breaking change in this release ([#317](https://github.com/bluetape4k/bluetape4k-projects/pull/317)).
 - `runSuspendIO` timeout was increased and `BluetapeHttpServer` eager initialization was fixed ([#337](https://github.com/bluetape4k/bluetape4k-projects/pull/337)).
 - Kafka Wave 1-3 security, cancellation, DLT, and metrics follow-ups were applied ([#309](https://github.com/bluetape4k/bluetape4k-projects/pull/309), [#310](https://github.com/bluetape4k/bluetape4k-projects/pull/310), [#314](https://github.com/bluetape4k/bluetape4k-projects/pull/314)).
 - Code scanning findings for workflow permissions, archive extraction, and secure cookie handling were addressed across multiple follow-up PRs ([#311](https://github.com/bluetape4k/bluetape4k-projects/pull/311), [#312](https://github.com/bluetape4k/bluetape4k-projects/pull/312), [#313](https://github.com/bluetape4k/bluetape4k-projects/pull/313), [#286](https://github.com/bluetape4k/bluetape4k-projects/pull/286), [#287](https://github.com/bluetape4k/bluetape4k-projects/pull/287), [#288](https://github.com/bluetape4k/bluetape4k-projects/pull/288)).

--- a/cache/cache-core/README.ko.md
+++ b/cache/cache-core/README.ko.md
@@ -6,6 +6,17 @@
 
 > 기존 `bluetape4k-cache-local` 모듈이 이 모듈에 통합되었습니다.
 
+## 패키지 / import 안정성
+
+cache 폴더 재편으로 소스 위치는 `cache/cache-core/`가 되었지만 Gradle 프로젝트 이름, Maven artifact, Kotlin
+package는 유지됩니다.
+
+- Gradle project: `:bluetape4k-cache-core`
+- Maven artifact: `io.github.bluetape4k:bluetape4k-cache-core`
+- Kotlin package root: `io.bluetape4k.cache`
+
+이번 재편으로 인한 사용자 import 변경은 필요하지 않습니다.
+
 ## 제공 기능
 
 - **JCache 공통 유틸리티**: `JCaching`, `jcacheManager`, `jcacheConfiguration` 등

--- a/cache/cache-core/README.md
+++ b/cache/cache-core/README.md
@@ -6,6 +6,17 @@ English | [한국어](./README.ko.md)
 
 > The former `bluetape4k-cache-local` module was merged into this module.
 
+## Package / Import Stability
+
+The cache folder reorganization moved this module under `cache/cache-core/`, but
+the Gradle project name, Maven artifact ID, and Kotlin packages remain stable:
+
+- Gradle project: `:bluetape4k-cache-core`
+- Maven artifact: `io.github.bluetape4k:bluetape4k-cache-core`
+- Kotlin package root: `io.bluetape4k.cache`
+
+No user import migration is required for the reorganization.
+
 ## Provided Features
 
 - **Common JCache utilities**: `JCaching`, `jcacheManager`, `jcacheConfiguration`, and more

--- a/cache/cache-hazelcast/README.ko.md
+++ b/cache/cache-hazelcast/README.ko.md
@@ -7,6 +7,17 @@ Near Cache**를 제공합니다.
 
 > 기존 `bluetape4k-cache-hazelcast-near` 모듈이 이 모듈에 통합되었습니다.
 
+## 패키지 / import 안정성
+
+cache 폴더 재편으로 소스 위치는 `cache/cache-hazelcast/`가 되었지만 Gradle 프로젝트 이름, Maven artifact,
+Kotlin package는 유지됩니다.
+
+- Gradle project: `:bluetape4k-cache-hazelcast`
+- Maven artifact: `io.github.bluetape4k:bluetape4k-cache-hazelcast`
+- Kotlin package root: `io.bluetape4k.cache`
+
+이번 재편으로 인한 사용자 import 변경은 필요하지 않습니다.
+
 ## 제공 기능
 
 | 클래스                                     | 설명                                                                 |

--- a/cache/cache-hazelcast/README.md
+++ b/cache/cache-hazelcast/README.md
@@ -7,6 +7,17 @@ English | [한국어](./README.ko.md)
 
 > The former `bluetape4k-cache-hazelcast-near` module was merged into this module.
 
+## Package / Import Stability
+
+The cache folder reorganization moved this module under `cache/cache-hazelcast/`,
+but the Gradle project name, Maven artifact ID, and Kotlin packages remain stable:
+
+- Gradle project: `:bluetape4k-cache-hazelcast`
+- Maven artifact: `io.github.bluetape4k:bluetape4k-cache-hazelcast`
+- Kotlin package root: `io.bluetape4k.cache`
+
+No user import migration is required for the reorganization.
+
 ## Provided Features
 
 - `HazelcastJCaching`

--- a/cache/cache-lettuce/README.ko.md
+++ b/cache/cache-lettuce/README.ko.md
@@ -4,6 +4,17 @@
 
 `bluetape4k-cache-lettuce`는 Lettuce(Redis) 기반 JCache Provider와 NearCache 구현을 제공합니다.
 
+## 패키지 / import 안정성
+
+cache 폴더 재편으로 소스 위치는 `cache/cache-lettuce/`가 되었지만 Gradle 프로젝트 이름, Maven artifact,
+Kotlin package는 유지됩니다.
+
+- Gradle project: `:bluetape4k-cache-lettuce`
+- Maven artifact: `io.github.bluetape4k:bluetape4k-cache-lettuce`
+- Kotlin package root: `io.bluetape4k.cache`
+
+이번 재편으로 인한 사용자 import 변경은 필요하지 않습니다.
+
 ## 설치
 
 ```kotlin

--- a/cache/cache-lettuce/README.md
+++ b/cache/cache-lettuce/README.md
@@ -4,6 +4,17 @@ English | [한국어](./README.ko.md)
 
 `bluetape4k-cache-lettuce` provides a Lettuce (Redis)-based JCache provider and NearCache implementations.
 
+## Package / Import Stability
+
+The cache folder reorganization moved this module under `cache/cache-lettuce/`,
+but the Gradle project name, Maven artifact ID, and Kotlin packages remain stable:
+
+- Gradle project: `:bluetape4k-cache-lettuce`
+- Maven artifact: `io.github.bluetape4k:bluetape4k-cache-lettuce`
+- Kotlin package root: `io.bluetape4k.cache`
+
+No user import migration is required for the reorganization.
+
 ## Installation
 
 ```kotlin

--- a/cache/cache-redisson/README.ko.md
+++ b/cache/cache-redisson/README.ko.md
@@ -4,6 +4,17 @@
 
 `bluetape4k-cache-redisson`은 Redisson 기반 cache adapter를 bluetape4k cache API에 맞춰 제공합니다. 핵심 범위는 Redisson JCache 연동, coroutine 친화 wrapper, Redisson `RLocalCachedMap` 기반 near cache, Redis-backed memoizer입니다.
 
+## 패키지 / import 안정성
+
+cache 폴더 재편으로 소스 위치는 `cache/cache-redisson/`이 되었지만 Gradle 프로젝트 이름, Maven artifact,
+Kotlin package는 유지됩니다.
+
+- Gradle project: `:bluetape4k-cache-redisson`
+- Maven artifact: `io.github.bluetape4k:bluetape4k-cache-redisson`
+- Kotlin package root: `io.bluetape4k.cache`
+
+이번 재편으로 인한 사용자 import 변경은 필요하지 않습니다.
+
 ## 제공 API
 
 | API | Package | 목적 |

--- a/cache/cache-redisson/README.md
+++ b/cache/cache-redisson/README.md
@@ -4,6 +4,17 @@ English | [한국어](./README.ko.md)
 
 `bluetape4k-cache-redisson` provides Redisson-backed cache adapters for the bluetape4k cache APIs. It focuses on JCache integration, coroutine-friendly wrappers, Redisson `RLocalCachedMap` near caches, and Redis-backed memoizers.
 
+## Package / Import Stability
+
+The cache folder reorganization moved this module under `cache/cache-redisson/`,
+but the Gradle project name, Maven artifact ID, and Kotlin packages remain stable:
+
+- Gradle project: `:bluetape4k-cache-redisson`
+- Maven artifact: `io.github.bluetape4k:bluetape4k-cache-redisson`
+- Kotlin package root: `io.bluetape4k.cache`
+
+No user import migration is required for the reorganization.
+
 ## Provided APIs
 
 | API | Package | Purpose |

--- a/cache/hibernate-cache-lettuce/README.ko.md
+++ b/cache/hibernate-cache-lettuce/README.ko.md
@@ -1,4 +1,4 @@
-# infra-hibernate-cache-lettuce
+# Module bluetape4k-hibernate-cache-lettuce
 
 [English](./README.md) | 한국어
 
@@ -7,6 +7,17 @@ Hibernate 7.2 **2nd Level Cache** 구현체 — Lettuce Near Cache(Caffeine L1 +
 
 > Near Cache 코어는 `bluetape4k-projects` 의 `bluetape4k-cache-lettuce` 모듈을 사용한다.
 > Spring Boot 4와 통합하려면 [`spring-boot/hibernate-lettuce`](../../spring-boot/hibernate-lettuce/README.ko.md) 참조.
+
+## 패키지 / import 안정성
+
+cache 폴더 재편으로 소스 위치는 `cache/hibernate-cache-lettuce/`가 되었지만 Gradle 프로젝트 이름, Maven
+artifact, Kotlin package는 유지됩니다.
+
+- Gradle project: `:bluetape4k-hibernate-cache-lettuce`
+- Maven artifact: `io.github.bluetape4k:bluetape4k-hibernate-cache-lettuce`
+- Kotlin package root: `io.bluetape4k.hibernate.cache.lettuce`
+
+이번 재편으로 인한 사용자 import 변경은 필요하지 않습니다.
 
 ## 요구 사항
 
@@ -94,7 +105,7 @@ flowchart TD
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation(project(":hibernate-cache-lettuce"))
+    implementation(project(":bluetape4k-hibernate-cache-lettuce"))
 
     // 런타임 직렬화 (필수 - bluetape4k-io의 optional 의존성이므로 명시 필요)
     implementation(Libs.fory_kotlin)  // Apache Fory

--- a/cache/hibernate-cache-lettuce/README.md
+++ b/cache/hibernate-cache-lettuce/README.md
@@ -1,4 +1,4 @@
-# infra-hibernate-cache-lettuce
+# Module bluetape4k-hibernate-cache-lettuce
 
 English | [한국어](./README.ko.md)
 
@@ -7,6 +7,18 @@ Hibernate 7.2 **2nd Level Cache** implementation backed by Lettuce Near Cache (C
 
 > The Near Cache core uses the `bluetape4k-cache-lettuce` module from `bluetape4k-projects`.
 > For Spring Boot 4 integration, see [`spring-boot/hibernate-lettuce`](../../spring-boot/hibernate-lettuce/README.md).
+
+## Package / Import Stability
+
+The cache folder reorganization moved this module under
+`cache/hibernate-cache-lettuce/`, but the Gradle project name, Maven artifact ID,
+and Kotlin packages remain stable:
+
+- Gradle project: `:bluetape4k-hibernate-cache-lettuce`
+- Maven artifact: `io.github.bluetape4k:bluetape4k-hibernate-cache-lettuce`
+- Kotlin package root: `io.bluetape4k.hibernate.cache.lettuce`
+
+No user import migration is required for the reorganization.
 
 ## Requirements
 
@@ -94,7 +106,7 @@ flowchart TD
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation(project(":hibernate-cache-lettuce"))
+    implementation(project(":bluetape4k-hibernate-cache-lettuce"))
 
     // Runtime serialization (required — must be declared explicitly since bluetape4k-io uses optional dependencies)
     implementation(Libs.fory_kotlin)  // Apache Fory

--- a/docs/lessons/2026-05-14-issues-323-324-325-354-docs-audit.md
+++ b/docs/lessons/2026-05-14-issues-323-324-325-354-docs-audit.md
@@ -1,0 +1,30 @@
+## Issues 323-324-325-354 Docs Audit
+
+Context: Issues #323, #324, #325, and #354 were documentation-focused follow-ups:
+compressor exception propagation docs, concrete compressor KDoc `@throws`, the
+CHANGELOG migration note, and cache README/KDoc drift after the cache folder
+reorganization.
+
+Decision: Batch them in one documentation PR because they share the same user
+contract surface: README/KDoc/CHANGELOG accuracy after previous API and folder
+reorganization changes.
+
+Outcome: Updated `io/io` README diagrams to show exception propagation for
+`compress()`/`decompress()`, documented nullable recovery via
+`compressOrNull()`/`decompressOrNull()`, replaced broad `Exception` KDoc in
+`AbstractCompressor`, added algorithm-specific compressor KDoc `@throws`, and
+expanded the cache README pairs with package/import stability notes. Also fixed
+the stale hibernate cache module title and Gradle project reference.
+
+Verification: Checked issue bodies for #323, #324, #325, and #354. Ran
+`git diff --check`, stale wording searches, cache README import symbol audit
+(44 imports), `./gradlew projects --no-configuration-cache`, targeted dependency
+insight for `commons-compress:1.28.0`, and targeted compile for `:bluetape4k-io`
+plus the affected cache modules. Claude review flagged CHANGELOG wording,
+Snappy exception KDoc, and a conditional Apache Zstd builder risk; those were
+fixed or resolved with version and compile evidence.
+
+Future agents: For docs-only cache reorganization follow-ups, distinguish source
+folder moves from public package/artifact changes. For compressor APIs, keep the
+throwing and nullable contracts side by side so callers can choose explicit
+exception handling or `null` recovery.

--- a/io/io/README.ko.md
+++ b/io/io/README.ko.md
@@ -142,8 +142,13 @@ sequenceDiagram
         AC-->>C: emptyByteArray
     else 유효한 데이터
         AC->>Impl: doCompress(plain)
-        Impl-->>AC: compressed: ByteArray
-        AC-->>C: compressed
+        alt 성공
+            Impl-->>AC: compressed: ByteArray
+            AC-->>C: compressed
+        else 실패
+            Impl--xAC: IOException / IllegalArgumentException / 라이브러리 예외
+            AC--xC: 동일 예외 전파
+        end
     end
 
     C->>AC: decompress(compressed: ByteArray?)
@@ -152,10 +157,20 @@ sequenceDiagram
         AC-->>C: emptyByteArray
     else 유효한 데이터
         AC->>Impl: doDecompress(compressed)
-        Impl-->>AC: plain: ByteArray
-        AC-->>C: plain
+        alt 성공
+            Impl-->>AC: plain: ByteArray
+            AC-->>C: plain
+        else 실패
+            Impl--xAC: IOException / IllegalArgumentException / 라이브러리 예외
+            AC--xC: 동일 예외 전파
+        end
     end
 ```
+
+`compress()`와 `decompress()`는 예외 전파 API입니다. null 또는 empty 입력은
+`emptyByteArray`를 반환하지만, 구현체 압축/복원 실패는 호출자에게 그대로 전파됩니다.
+손상 입력이나 압축 실패를 예외 대신 `null`로 표현하려면
+`compressOrNull()` / `decompressOrNull()`을 사용하세요.
 
 ### serialize/deserialize 흐름
 

--- a/io/io/README.md
+++ b/io/io/README.md
@@ -142,8 +142,13 @@ sequenceDiagram
         AC-->>C: emptyByteArray
     else valid data
         AC->>Impl: doCompress(plain)
-        Impl-->>AC: compressed: ByteArray
-        AC-->>C: compressed
+        alt success
+            Impl-->>AC: compressed: ByteArray
+            AC-->>C: compressed
+        else failure
+            Impl--xAC: IOException / IllegalArgumentException / library exception
+            AC--xC: throws same exception
+        end
     end
 
     C->>AC: decompress(compressed: ByteArray?)
@@ -152,10 +157,20 @@ sequenceDiagram
         AC-->>C: emptyByteArray
     else valid data
         AC->>Impl: doDecompress(compressed)
-        Impl-->>AC: plain: ByteArray
-        AC-->>C: plain
+        alt success
+            Impl-->>AC: plain: ByteArray
+            AC-->>C: plain
+        else failure
+            Impl--xAC: IOException / IllegalArgumentException / library exception
+            AC--xC: throws same exception
+        end
     end
 ```
+
+`compress()` and `decompress()` are throwing APIs: null or empty input returns
+`emptyByteArray`, but implementation failures are propagated to the caller. Use
+`compressOrNull()` / `decompressOrNull()` when corrupt input or compression
+failure should be represented as `null` instead of an exception.
 
 ### serialize/deserialize Flow
 
@@ -324,8 +339,8 @@ base.combineSafe("/etc/passwd")
 
 #### Nullable Compressor API
 
-`AbstractCompressor` provides safe nullable variants that return `null` instead of throwing or
-returning `emptyByteArray` on failure:
+`AbstractCompressor` provides safe nullable variants for callers that prefer
+`null` recovery over thrown compression/decompression failures:
 
 ```kotlin
 val compressed = compressor.compressOrNull(input)   // null if input null/empty

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/AbstractCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/AbstractCompressor.kt
@@ -4,28 +4,38 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
 import io.bluetape4k.support.emptyByteArray
 import io.bluetape4k.support.isNullOrEmpty
+import java.io.IOException
 import kotlin.coroutines.cancellation.CancellationException
 
 /**
- * [Compressor]의 최상위 추상화 클래스입니다.
+ * Base implementation for [Compressor].
  *
- * ## Null/Empty 처리 정책
- * - `compress(null)` 또는 `compress(emptyByteArray)`: 빈 [ByteArray]를 반환합니다.
- * - `decompress(null)` 또는 `decompress(emptyByteArray)`: 빈 [ByteArray]를 반환합니다.
- * - 압축/해제 실패 시 예외를 그대로 전파합니다.
+ * ## Null and empty input contract
+ * - `compress(null)` and `compress(emptyByteArray)`: return an empty [ByteArray].
+ * - `decompress(null)` and `decompress(emptyByteArray)`: return an empty [ByteArray].
+ * - Compression and decompression failures are propagated to the caller.
  *
- * ## 예외 처리
- * `compress()`/`decompress()` 는 내부 예외를 호출자에게 전파합니다.
- * 실패 시 `null`을 반환받으려면 [compressOrNull] / [decompressOrNull] 을 사용하세요.
+ * ## Failure handling
+ * [compress] and [decompress] are throwing APIs. Use [compressOrNull] or
+ * [decompressOrNull] when a failure should be represented as `null`.
  *
- * ## 구현 방법
- * [doCompress]와 [doDecompress]를 구현하면 됩니다.
- * null/empty 체크는 이 클래스에서 담당합니다.
+ * Common propagated failures are:
+ * - [IOException] for stream or codec I/O failures.
+ * - [IllegalArgumentException] for invalid input or defensive size-limit checks.
+ * - Algorithm-specific runtime failures such as `net.jpountz.lz4.LZ4Exception`,
+ *   `org.xerial.snappy.SnappyException`, `org.xerial.snappy.SnappyError`,
+ *   `com.github.luben.zstd.ZstdException`, or `java.util.zip.ZipException`.
+ *
+ * Implementation classes document their codec-specific failure types.
+ *
+ * ## Implementation guide
+ * Implement [doCompress] and [doDecompress]. This base class owns the null and
+ * empty input checks.
  *
  * ```kotlin
  * class MyCompressor: AbstractCompressor() {
- *     override fun doCompress(plain: ByteArray): ByteArray = /* 압축 구현 */
- *     override fun doDecompress(compressed: ByteArray): ByteArray = /* 해제 구현 */
+ *     override fun doCompress(plain: ByteArray): ByteArray = /* compression */
+ *     override fun doDecompress(compressed: ByteArray): ByteArray = /* decompression */
  * }
  * ```
  *
@@ -40,19 +50,20 @@ abstract class AbstractCompressor: Compressor {
     protected abstract fun doDecompress(compressed: ByteArray): ByteArray
 
     /**
-     * [plain] 데이터를 압축합니다.
+     * Compresses [plain] data.
      *
-     * null/empty 입력은 빈 [ByteArray]를 반환합니다. 압축 실패 시 예외를 전파합니다.
-     * 실패 시 `null`을 받으려면 [compressOrNull]을 사용하세요.
+     * Null or empty input returns an empty [ByteArray]. Compression failures are
+     * propagated to the caller. Use [compressOrNull] when failure should return `null`.
      *
      * ```
      * val compressor = GzipCompressor()
      * val compressed = compressor.compress("Hello, World!".toByteArray())
      * ```
      *
-     * @param plain 원본 데이터
-     * @return 압축된 데이터
-     * @throws Exception 압축 실패 시
+     * @param plain source data
+     * @return compressed data
+     * @throws IOException when the underlying codec fails during stream or buffer I/O
+     * @throws IllegalArgumentException when input validation or defensive size-limit checks fail
      */
     override fun compress(plain: ByteArray?): ByteArray {
         if (plain.isNullOrEmpty()) return emptyByteArray
@@ -60,10 +71,11 @@ abstract class AbstractCompressor: Compressor {
     }
 
     /**
-     * 압축된 데이터([compressed])를 복원하여 [ByteArray]로 반환합니다.
+     * Decompresses [compressed] data.
      *
-     * null/empty 입력은 빈 [ByteArray]를 반환합니다. 복원 실패 시 예외를 전파합니다.
-     * 손상 데이터를 `null`로 처리하려면 [decompressOrNull]을 사용하세요.
+     * Null or empty input returns an empty [ByteArray]. Decompression failures are
+     * propagated to the caller. Use [decompressOrNull] when corrupt input should
+     * return `null`.
      *
      * ```
      * val compressor = GzipCompressor()
@@ -71,9 +83,10 @@ abstract class AbstractCompressor: Compressor {
      * val plain = compressor.decompress(compressed)
      * ```
      *
-     * @param compressed 압축된 데이터
-     * @return 복원된 데이터
-     * @throws Exception 복원 실패 시 (손상 데이터, 크기 제한 초과 등)
+     * @param compressed compressed data
+     * @return decompressed data
+     * @throws IOException when the underlying codec fails during stream or buffer I/O
+     * @throws IllegalArgumentException when corrupt input, invalid headers, or defensive size-limit checks fail
      */
     override fun decompress(compressed: ByteArray?): ByteArray {
         if (compressed.isNullOrEmpty()) return emptyByteArray
@@ -81,9 +94,9 @@ abstract class AbstractCompressor: Compressor {
     }
 
     /**
-     * [plain] 데이터를 압축하여 반환합니다. 입력이 null/empty이거나 압축 실패 시 `null`을 반환합니다.
+     * Compresses [plain] and returns `null` for null/empty input or compression failure.
      *
-     * `compress()`와 달리 실패를 `null`로 명시적으로 표현하므로, 데이터 손실 없이 오류를 처리할 수 있습니다.
+     * Unlike [compress], this method represents failure as `null`.
      *
      * ```kotlin
      * val result = compressor.compressOrNull(corruptData)
@@ -92,8 +105,8 @@ abstract class AbstractCompressor: Compressor {
      * }
      * ```
      *
-     * @param plain 원본 데이터
-     * @return 압축된 데이터 또는 `null`
+     * @param plain source data
+     * @return compressed data or `null`
      */
     fun compressOrNull(plain: ByteArray?): ByteArray? {
         if (plain.isNullOrEmpty()) return null
@@ -108,9 +121,9 @@ abstract class AbstractCompressor: Compressor {
     }
 
     /**
-     * 압축된 데이터([compressed])를 복원하여 반환합니다. 입력이 null/empty이거나 복원 실패 시 `null`을 반환합니다.
+     * Decompresses [compressed] and returns `null` for null/empty input or decompression failure.
      *
-     * `decompress()`와 달리 실패를 `null`로 명시적으로 표현하므로, 손상 데이터를 빈 배열과 구분할 수 있습니다.
+     * Unlike [decompress], this method represents failure as `null`.
      *
      * ```kotlin
      * val result = compressor.decompressOrNull(suspectData)
@@ -119,8 +132,8 @@ abstract class AbstractCompressor: Compressor {
      * }
      * ```
      *
-     * @param compressed 압축된 데이터
-     * @return 복원된 데이터 또는 `null`
+     * @param compressed compressed data
+     * @return decompressed data or `null`
      */
     fun decompressOrNull(compressed: ByteArray?): ByteArray? {
         if (compressed.isNullOrEmpty()) return null

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ApacheDeflateCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ApacheDeflateCompressor.kt
@@ -4,6 +4,7 @@ import org.apache.commons.compress.compressors.deflate.DeflateCompressorInputStr
 import org.apache.commons.compress.compressors.deflate.DeflateCompressorOutputStream
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.IOException
 
 /**
  * Apache Commons Compress 라이브러리의 [DeflateCompressorOutputStream]을 이용한 Deflate 압축기
@@ -18,6 +19,7 @@ import java.io.ByteArrayOutputStream
  *
  * @see [DeflateCompressorOutputStream]
  * @see [DeflateCompressorInputStream]
+ * @throws IOException when Apache Commons Compress stream processing fails.
  */
 class ApacheDeflateCompressor: AbstractCompressor() {
     /**

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ApacheGZipCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ApacheGZipCompressor.kt
@@ -4,6 +4,7 @@ import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.IOException
 
 /**
  * Apache Commons Compress 라이브러리의 [GzipCompressorOutputStream]을 이용한 GZip 압축기
@@ -18,6 +19,7 @@ import java.io.ByteArrayOutputStream
  *
  * @see [GzipCompressorOutputStream]
  * @see [GzipCompressorInputStream]
+ * @throws IOException when Apache Commons Compress stream processing fails.
  */
 class ApacheGZipCompressor: AbstractCompressor() {
     /**

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ApacheZstdCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ApacheZstdCompressor.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.io.compressor
 
 import com.github.luben.zstd.Zstd
+import com.github.luben.zstd.ZstdException
 import io.bluetape4k.io.compressor.ApacheZstdCompressor.Companion.DEFAULT_LEVEL
 import io.bluetape4k.logging.KLogging
 import org.apache.commons.compress.compressors.zstandard.ZstdCompressorInputStream
@@ -31,6 +32,8 @@ import java.io.ByteArrayOutputStream
  *
  * @see [ZstdCompressorInputStream]
  * @see [ZstdCompressorOutputStream]
+ * @throws java.io.IOException when Apache Commons Compress stream processing fails.
+ * @throws ZstdException when zstd-jni codec processing fails.
  */
 class ApacheZstdCompressor private constructor(val level: Int): AbstractCompressor() {
 
@@ -53,10 +56,14 @@ class ApacheZstdCompressor private constructor(val level: Int): AbstractCompress
      */
     override fun doCompress(plain: ByteArray): ByteArray {
         val output = ByteArrayOutputStream(plain.size)
-        ZstdCompressorOutputStream(output, level).use { zstd ->
-            zstd.write(plain)
-            zstd.flush()
-        }
+        ZstdCompressorOutputStream.builder()
+            .setOutputStream(output)
+            .setLevel(level)
+            .get()
+            .use { zstd ->
+                zstd.write(plain)
+                zstd.flush()
+            }
         return output.toByteArray()
     }
 

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/BZip2Compressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/BZip2Compressor.kt
@@ -4,6 +4,7 @@ import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.IOException
 
 /**
  * BZip2 알고리즘을 사용한 Compressor
@@ -19,6 +20,8 @@ import java.io.ByteArrayOutputStream
  * @param bufferSize 내부 버퍼 크기 (기본값: [DEFAULT_BUFFER_SIZE])
  * @see [BZip2CompressorInputStream]
  * @see [BZip2CompressorOutputStream]
+ * @throws IllegalArgumentException when [bufferSize] is not greater than zero.
+ * @throws IOException when BZip2 stream processing fails.
  */
 class BZip2Compressor(
     private val bufferSize: Int = DEFAULT_BUFFER_SIZE,

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/BlockLZ4Compressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/BlockLZ4Compressor.kt
@@ -4,6 +4,7 @@ import org.apache.commons.compress.compressors.lz4.BlockLZ4CompressorInputStream
 import org.apache.commons.compress.compressors.lz4.BlockLZ4CompressorOutputStream
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.IOException
 
 /**
  * Apache Compress 라이브러리의 Block LZ4 알고리즘을 사용한 Compressor
@@ -18,6 +19,7 @@ import java.io.ByteArrayOutputStream
  *
  * @see [BlockLZ4CompressorInputStream]
  * @see [BlockLZ4CompressorOutputStream]
+ * @throws IOException when Apache Commons Compress Block LZ4 stream processing fails.
  */
 class BlockLZ4Compressor: AbstractCompressor() {
     /**

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/DeflateCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/DeflateCompressor.kt
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.util.zip.DeflaterOutputStream
 import java.util.zip.InflaterInputStream
+import java.util.zip.ZipException
 
 /**
  * JDK Deflate 알고리즘을 이용한 압축기
@@ -18,6 +19,8 @@ import java.util.zip.InflaterInputStream
  *
  * @see [DeflaterOutputStream]
  * @see [InflaterInputStream]
+ * @throws java.io.IOException when Deflate stream processing fails.
+ * @throws ZipException when the payload is corrupt or not valid Deflate data.
  */
 class DeflateCompressor: AbstractCompressor() {
 

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/FramedLZ4Compressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/FramedLZ4Compressor.kt
@@ -4,6 +4,7 @@ import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorInputStrea
 import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorOutputStream
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.IOException
 
 /**
  * Apache Commons Compress FramedLZ4 알고리즘을 이용한 압축기
@@ -18,6 +19,7 @@ import java.io.ByteArrayOutputStream
  *
  * @see [FramedLZ4CompressorInputStream]
  * @see [FramedLZ4CompressorOutputStream]
+ * @throws IOException when Apache Commons Compress framed LZ4 stream processing fails.
  */
 class FramedLZ4Compressor: AbstractCompressor() {
 

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/FramedSnappyCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/FramedSnappyCompressor.kt
@@ -4,6 +4,7 @@ import org.apache.commons.compress.compressors.snappy.FramedSnappyCompressorInpu
 import org.apache.commons.compress.compressors.snappy.FramedSnappyCompressorOutputStream
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.IOException
 
 /**
  * Apache Commons Compress의 Framed Snappy 알고리즘을 사용한 Compressor
@@ -18,6 +19,7 @@ import java.io.ByteArrayOutputStream
  *
  * @see [FramedSnappyCompressorOutputStream]
  * @see [FramedSnappyCompressorInputStream]
+ * @throws IOException when Apache Commons Compress framed Snappy stream processing fails.
  */
 class FramedSnappyCompressor: AbstractCompressor() {
 

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/GZipCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/GZipCompressor.kt
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
+import java.util.zip.ZipException
 
 /**
  * JDK GZip 알고리즘을 이용한 압축/복원
@@ -18,6 +19,8 @@ import java.util.zip.GZIPOutputStream
  *
  * @see [GZIPOutputStream]
  * @see [GZIPInputStream]
+ * @throws java.io.IOException when GZip stream processing fails.
+ * @throws ZipException when the payload is corrupt or not valid GZip data.
  */
 class GZipCompressor(
     private val bufferSize: Int = DEFAULT_BUFFER_SIZE,

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/LZ4Compressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/LZ4Compressor.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.io.compressor
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.toByteArray
 import io.bluetape4k.support.toInt
+import net.jpountz.lz4.LZ4Exception
 import net.jpountz.lz4.LZ4Factory
 
 /**
@@ -28,6 +29,8 @@ import net.jpountz.lz4.LZ4Factory
  * ```
  *
  * @see [lz4-java yawkat fork](https://github.com/yawkat/lz4-java) — CVE-2025-12183/CVE-2025-66566 패치 포함 유지보수 버전
+ * @throws IllegalArgumentException when the stored source-size header is negative or exceeds the 256 MB limit.
+ * @throws LZ4Exception when LZ4 block compression or decompression fails.
  */
 class LZ4Compressor: AbstractCompressor() {
 

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/SnappyCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/SnappyCompressor.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.io.compressor
 
 import org.xerial.snappy.Snappy
+import org.xerial.snappy.SnappyError
 
 /**
  * Snappy 알고리즘을 사용한 Compressor
@@ -17,6 +18,9 @@ import org.xerial.snappy.Snappy
  * ```
  *
  * @see [FramedSnappyCompressor]
+ * @throws IllegalArgumentException when source-size validation fails or exceeds the 256 MB limit.
+ * @throws SnappyError when the Snappy native library or codec reports a state error.
+ * @throws org.xerial.snappy.SnappyException when the Snappy codec reports a codec failure.
  */
 class SnappyCompressor: AbstractCompressor() {
 

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ZipCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ZipCompressor.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.support.requirePositiveNumber
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.util.zip.ZipEntry
+import java.util.zip.ZipException
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
 
@@ -20,6 +21,8 @@ import java.util.zip.ZipOutputStream
  *
  * @see [ZipOutputStream]
  * @see [ZipInputStream]
+ * @throws java.io.IOException when the ZIP entry is missing or stream processing fails.
+ * @throws ZipException when the payload is corrupt or not valid ZIP data.
  */
 class ZipCompressor(
     private val bufferSize: Int = DEFAULT_BUFFER_SIZE,

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ZstdCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ZstdCompressor.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.io.compressor
 
 import com.github.luben.zstd.Zstd
+import com.github.luben.zstd.ZstdException
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.trace
 import io.bluetape4k.support.toByteArray
@@ -28,6 +29,9 @@ import org.apache.commons.compress.compressors.zstandard.ZstdUtils
  * 참고: [zstd-jni](https://github.com/luben/zstd-jni)
  *
  * @property level 압축 레벨
+ * @throws IllegalArgumentException when the stored source-size header is negative or exceeds the 256 MB limit.
+ * @throws IllegalStateException when the Zstd compression API returns an error code.
+ * @throws ZstdException when zstd-jni codec processing fails.
  */
 class ZstdCompressor private constructor(val level: Int): AbstractCompressor() {
 


### PR DESCRIPTION
## Summary

Closes #323, #324, #325, #354

- PR 제목: docs: align compressor and cache migration docs

- Update `io/io` README Mermaid flows to show compressor success/failure branches and clarify throwing APIs versus nullable recovery APIs.
- Replace broad compressor KDoc failure wording with concrete `IOException`, `IllegalArgumentException`, and implementation-specific codec failure types.
- Add CHANGELOG breaking-change migration guidance for `AbstractCompressor.compress()` / `decompress()` exception propagation.
- Document cache module package/import stability after the `cache/` folder reorganization, and fix stale hibernate cache module title/project coordinates.
- Replace the deprecated Apache Zstd output-stream constructor with the equivalent builder API supported by Commons Compress 1.28.0 so touched code has no unresolved deprecation warning.
- Capture a concise lesson for future compressor/cache documentation follow-ups.

Closes #323
Closes #324
Closes #325
Closes #354

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

- Update `io/io` README Mermaid flows to show compressor success/failure branches and clarify throwing APIs versus nullable recovery APIs.
- Replace broad compressor KDoc failure wording with concrete `IOException`, `IllegalArgumentException`, and implementation-specific codec failure types.
- Add CHANGELOG breaking-change migration guidance for `AbstractCompressor.compress()` / `decompress()` exception propagation.
- Document cache module package/import stability after the `cache/` folder reorganization, and fix stale hibernate cache module title/project coordinates.
- Replace the deprecated Apache Zstd output-stream constructor with the equivalent builder API supported by Commons Compress 1.28.0 so touched code has no unresolved deprecation warning.
- Capture a concise lesson for future compressor/cache documentation follow-ups.

Closes #323
Closes #324
Closes #325
Closes #354

### Review

- Claude review found CHANGELOG wording and Snappy KDoc issues; both were fixed.
- Claude re-review raised a conditional Apache Zstd builder concern; resolved with `commons-compress:1.28.0` dependency evidence and successful compile.
- No remaining P0/P1 blocker from Claude after the Zstd resolution pass.

### Validation

- `git diff --check`
- stale wording search for broad `@throws Exception`, stale hibernate project path, stale `emptyByteArray` failure wording, and rejected CHANGELOG phrasing
- README import symbol audit: 44 imports checked against `cache/` sources
- `./gradlew projects --no-configuration-cache | rg ':bluetape4k-(cache-core|cache-lettuce|cache-redisson|cache-hazelcast|hibernate-cache-lettuce)'`
- `./gradlew :bluetape4k-io:dependencyInsight --configuration compileClasspath --dependency commons-compress --no-configuration-cache`
- `./gradlew :bluetape4k-io:compileKotlin :bluetape4k-cache-core:compileKotlin :bluetape4k-cache-lettuce:compileKotlin :bluetape4k-cache-redisson:compileKotlin :bluetape4k-cache-hazelcast:compileKotlin :bluetape4k-hibernate-cache-lettuce:compileKotlin --no-configuration-cache`

Not run: full repository test suite; this is a documentation/KDoc-focused change.

## Validation

- `git diff --check`
- stale wording search for broad `@throws Exception`, stale hibernate project path, stale `emptyByteArray` failure wording, and rejected CHANGELOG phrasing
- README import symbol audit: 44 imports checked against `cache/` sources
- `./gradlew projects --no-configuration-cache | rg ':bluetape4k-(cache-core|cache-lettuce|cache-redisson|cache-hazelcast|hibernate-cache-lettuce)'`
- `./gradlew :bluetape4k-io:dependencyInsight --configuration compileClasspath --dependency commons-compress --no-configuration-cache`
- `./gradlew :bluetape4k-io:compileKotlin :bluetape4k-cache-core:compileKotlin :bluetape4k-cache-lettuce:compileKotlin :bluetape4k-cache-redisson:compileKotlin :bluetape4k-cache-hazelcast:compileKotlin :bluetape4k-hibernate-cache-lettuce:compileKotlin --no-configuration-cache`

Not run: full repository test suite; this is a documentation/KDoc-focused change.

## Review Notes

- Claude review found CHANGELOG wording and Snappy KDoc issues; both were fixed.
- Claude re-review raised a conditional Apache Zstd builder concern; resolved with `commons-compress:1.28.0` dependency evidence and successful compile.
- No remaining P0/P1 blocker from Claude after the Zstd resolution pass.

## Metadata

- Issue: #323, #324, #325, #354, milestone 없음, assignee `debop`
- PR: #441, head `0e03bad7ad69f5ace0a730f14f708a2edfd16e21`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `docs/cache-compressor-docs`
- Labels: `documentation`, `infra/io`
- State: `MERGED`, merge commit `fc236f354a489ed39bd1dba6c8f4ecdf5c499d99`
- CI: - Replace broad compressor KDoc failure wording with concrete `IOException`, `IllegalArgumentException`, and implementation-specific codec failure types. / - Capture a concise lesson for future compressor/cache documentation follow-ups. / - `./gradlew projects --no-configuration-cache | rg ':bluetape4k-(cache-core|cache-lettuce|cache-redisson|cache-hazelcast|hibernate-cache-lettuce)'`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #441 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `fc236f354a489ed39bd1dba6c8f4ecdf5c499d99`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
