### PR TITLE
feat: harden bucket4j rate-limit facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Unsigned range assertion coverage and helpers were added to the assertion DSL ([#360](https://github.com/bluetape4k/bluetape4k-projects/pull/360)).
 - `bluetape4k-idgenerators` examples were added for Ktor and Spring Boot 4, with dedicated REST endpoints and tests ([#421](https://github.com/bluetape4k/bluetape4k-projects/pull/421), [#422](https://github.com/bluetape4k/bluetape4k-projects/pull/422)).
 - Governance and agent guidance docs were expanded for lessons capture, Kover coverage policy, dependency governance, and qmd knowledge retrieval ([#370](https://github.com/bluetape4k/bluetape4k-projects/pull/370), [#373](https://github.com/bluetape4k/bluetape4k-projects/pull/373), [#377](https://github.com/bluetape4k/bluetape4k-projects/pull/377), [#398](https://github.com/bluetape4k/bluetape4k-projects/pull/398)).
+- `bluetape4k-bucket4j` `RateLimitDiagnostics`, `RateLimitRejectionReason`, and rejected-result `retryAfter` were added to make retry and rejection reporting independent from Bucket4j probe types ([#434](https://github.com/bluetape4k/bluetape4k-projects/issues/434)).
 
 ### Changed
 
@@ -32,15 +33,21 @@
 - Dependabot assignment and dependency compatibility guard policies were adjusted, including Redis client major-version guards and compatibility-line dependency restoration ([#379](https://github.com/bluetape4k/bluetape4k-projects/pull/379), [#395](https://github.com/bluetape4k/bluetape4k-projects/pull/395), [#399](https://github.com/bluetape4k/bluetape4k-projects/pull/399), [#411](https://github.com/bluetape4k/bluetape4k-projects/pull/411), [#412](https://github.com/bluetape4k/bluetape4k-projects/pull/412)).
 - Dependency baselines were refreshed across build plugins, GitHub Actions, Spring, Pulsar, Hibernate, GeoTools, Protobuf, OpenTelemetry instrumentation, and other library groups ([#378](https://github.com/bluetape4k/bluetape4k-projects/pull/378), [#382](https://github.com/bluetape4k/bluetape4k-projects/pull/382), [#383](https://github.com/bluetape4k/bluetape4k-projects/pull/383), [#384](https://github.com/bluetape4k/bluetape4k-projects/pull/384), [#386](https://github.com/bluetape4k/bluetape4k-projects/pull/386), [#387](https://github.com/bluetape4k/bluetape4k-projects/pull/387), [#388](https://github.com/bluetape4k/bluetape4k-projects/pull/388), [#389](https://github.com/bluetape4k/bluetape4k-projects/pull/389), [#392](https://github.com/bluetape4k/bluetape4k-projects/pull/392), [#393](https://github.com/bluetape4k/bluetape4k-projects/pull/393), [#394](https://github.com/bluetape4k/bluetape4k-projects/pull/394), [#397](https://github.com/bluetape4k/bluetape4k-projects/pull/397), [#401](https://github.com/bluetape4k/bluetape4k-projects/pull/401), [#402](https://github.com/bluetape4k/bluetape4k-projects/pull/402), [#403](https://github.com/bluetape4k/bluetape4k-projects/pull/403), [#404](https://github.com/bluetape4k/bluetape4k-projects/pull/404), [#405](https://github.com/bluetape4k/bluetape4k-projects/pull/405), [#407](https://github.com/bluetape4k/bluetape4k-projects/pull/407), [#408](https://github.com/bluetape4k/bluetape4k-projects/pull/408), [#409](https://github.com/bluetape4k/bluetape4k-projects/pull/409)).
 - WIP and README image documentation were refreshed after the idgenerator example lane completed ([#417](https://github.com/bluetape4k/bluetape4k-projects/pull/417), [#425](https://github.com/bluetape4k/bluetape4k-projects/pull/425), [#429](https://github.com/bluetape4k/bluetape4k-projects/pull/429)).
+- `bluetape4k-bucket4j` now validates prefixed bucket keys at 512 bytes, documents provider lifecycle/expiration ownership, supports distributed coroutine operation timeouts while retaining the Java one-argument constructor overload, and preserves identified-bandwidth configuration replacement behavior ([#434](https://github.com/bluetape4k/bluetape4k-projects/issues/434)).
 
 ### Breaking Changes
 
+- `RateLimitResult(consumedTokens, availableTokens)` was removed. Use `RateLimitResult.consumed(...)` or `RateLimitResult.rejected(...)` and read the new `diagnostics` / `retryAfter` fields for retry guidance ([#434](https://github.com/bluetape4k/bluetape4k-projects/issues/434)).
+- `RateLimitResult` primary constructor, `copy(...)`, and `componentN()` shape changed because `diagnostics` was added. Recompile Kotlin callers and update Java callers that construct or destructure the value type directly ([#434](https://github.com/bluetape4k/bluetape4k-projects/issues/434)).
 - `AbstractCompressor.compress()` and `AbstractCompressor.decompress()` now propagate compression/decompression failures instead of returning `emptyByteArray` for failed non-empty input ([#317](https://github.com/bluetape4k/bluetape4k-projects/pull/317), [#325](https://github.com/bluetape4k/bluetape4k-projects/issues/325)).
 
 #### Migration
 
 | Previous expectation | Replacement |
 | --- | --- |
+| `RateLimitResult(consumedTokens, availableTokens)` | `RateLimitResult.consumed(consumedTokens, availableTokens)` or `RateLimitResult.rejected(availableTokens)` |
+| Inspect Bucket4j probe types for retry delay | Use `RateLimitResult.retryAfter` or `result.diagnostics.nanosToWaitForRefill` |
+| Distributed suspend calls can wait indefinitely on the async store | Use `DistributedSuspendRateLimiter(provider, defaultTimeout = ...)` or `consume(key, tokens, timeout)` |
 | Failed `compress()` returns `emptyByteArray` | Use `compressOrNull()` when failures should return `null`, or catch the propagated exception from `compress()`. |
 | Failed `decompress()` returns `emptyByteArray` | Use `decompressOrNull()` when corrupt input should return `null`, or catch the propagated exception from `decompress()`. |
 | Corrupt compressed data is ignored | Use `decompressOrNull()` for nullable recovery, or catch the propagated exception from `decompress()`. |

--- a/docs/infra-deprecated-inventory.md
+++ b/docs/infra-deprecated-inventory.md
@@ -11,7 +11,7 @@ work should happen in follow-up PRs.
 
 | Decision | Count | Meaning |
 |---|---:|---|
-| Delete | 18 files | Deprecated API has a direct replacement and should not remain in the next cleanup line. |
+| Delete | 17 files | Deprecated API has a direct replacement and should not remain in the next cleanup line. |
 | Replace call sites first | 6 files | Repo-local tests or samples still exercise the deprecated API and must move first. |
 | Keep | 0 files | No deprecated `infra/` API needs long-term retention. |
 
@@ -22,24 +22,23 @@ scope is larger than the original 12-file issue comment.
 
 | # | Module | File | Deprecated API | Current usage | Decision | Replacement |
 |---:|---|---|---|---|---|---|
-| 1 | `bucket4j` | `infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/RateLimitResult.kt` | Secondary constructor `(consumedTokens, availableTokens)` | `RateLimitResultTest` covers compatibility only | Delete after test rewrite | `RateLimitResult.consumed(...)` / `rejected(...)` |
-| 2 | `cache-core` | `cache/core/src/main/kotlin/io/bluetape4k/cache/caffeine/CaffeineSupport.kt` | `AsyncCache.getSuspending(...)` | KDoc sample only | Delete | `AsyncCache.suspendGet(...)` |
-| 3 | `cache-lettuce` | `cache/lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceSuspendNearCache.kt` | `clearFrontCache()` | Definition only | Delete | `clearLocal()` |
-| 4 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt` | `Producer.getMetricValue(...)` | Definition only | Delete | `getMetricValueOrNull(...).asDouble()` |
-| 5 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt` | `JdkKafkaCodec` | `KafkaCodecTest` still tests `KafkaCodecs.Jdk` | Replace tests, then delete | `ForyKafkaCodec` or `KryoKafkaCodec` |
-| 6 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/KafkaOperationsExtensions.kt` | `sendAndAwait(...)`, `awaitSendDefault(...)` overloads | Definition only | Delete | `suspendSend(...)` / `suspendSendDefault(...)` |
-| 7 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt` | `awaitSend(...)`, `sendSuspending(...)`, `getMetricValue(...)` | KDoc/definition only | Delete | `suspendSend(...)`, `getMetricValueOrNull(...).asDouble()` |
-| 8 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt` | `Producer.getMetricValue(...)` | Definition only | Delete | `getMetricValueOrNull(...).asDouble()` |
-| 9 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt` | `JdkKafkaCodec` | `KafkaCodecTest` still tests `KafkaCodecs.Jdk` | Replace tests, then delete | `ForyKafkaCodec` or `KryoKafkaCodec` |
-| 10 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/KafkaOperationsExtensions.kt` | `sendAndAwait(...)`, `awaitSendDefault(...)` overloads | Definition only | Delete | `suspendSend(...)` / `suspendSendDefault(...)` |
-| 11 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt` | `awaitSend(...)`, `sendSuspending(...)`, `getMetricValue(...)` | Definition only | Delete | `suspendSend(...)`, `getMetricValueOrNull(...).asDouble()` |
-| 12 | `lettuce` | `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/LettuceConst.kt` | `DEFAULT_DELIMETER` typo | Definition only | Delete | `DEFAULT_DELIMITER` |
-| 13 | `lettuce` | `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/RedisFutureSupport.kt` | `suspendAwait()`, `coAwait()` | `RedisFutureSupportTest` compatibility tests | Replace tests, then delete | `awaitSuspending()` |
-| 14 | `opentelemetry` | `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/SpanCoroutineSupport.kt` | `SpanBuilder.useSuspendSpan(...)` overloads | One compatibility test path | Replace tests, then delete | `useSpanSuspending(...)` |
-| 15 | `opentelemetry` | `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanExporterSupport.kt` | `spanExportOf(...)` | Definition only | Delete | `spanExporterOf(...)` |
-| 16 | `opentelemetry` | `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanProcessorSupport.kt` | `batchSpanProcess(...)` | Definition only | Delete | `batchSpanProcessorOf(...)` |
-| 17 | `redisson` | `infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/RedissonConst.kt` | `DEFAULT_DELIMETER` typo | Definition only | Delete | `DEFAULT_DELIMITER` |
-| 18 | `resilience4j` | `infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/SuspendDecorators.kt` | `decoreate()` typo overloads | Definition only | Delete | `decorate()` |
+| 1 | `cache-core` | `cache/core/src/main/kotlin/io/bluetape4k/cache/caffeine/CaffeineSupport.kt` | `AsyncCache.getSuspending(...)` | KDoc sample only | Delete | `AsyncCache.suspendGet(...)` |
+| 2 | `cache-lettuce` | `cache/lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceSuspendNearCache.kt` | `clearFrontCache()` | Definition only | Delete | `clearLocal()` |
+| 3 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt` | `Producer.getMetricValue(...)` | Definition only | Delete | `getMetricValueOrNull(...).asDouble()` |
+| 4 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt` | `JdkKafkaCodec` | `KafkaCodecTest` still tests `KafkaCodecs.Jdk` | Replace tests, then delete | `ForyKafkaCodec` or `KryoKafkaCodec` |
+| 5 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/KafkaOperationsExtensions.kt` | `sendAndAwait(...)`, `awaitSendDefault(...)` overloads | Definition only | Delete | `suspendSend(...)` / `suspendSendDefault(...)` |
+| 6 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt` | `awaitSend(...)`, `sendSuspending(...)`, `getMetricValue(...)` | KDoc/definition only | Delete | `suspendSend(...)`, `getMetricValueOrNull(...).asDouble()` |
+| 7 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt` | `Producer.getMetricValue(...)` | Definition only | Delete | `getMetricValueOrNull(...).asDouble()` |
+| 8 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt` | `JdkKafkaCodec` | `KafkaCodecTest` still tests `KafkaCodecs.Jdk` | Replace tests, then delete | `ForyKafkaCodec` or `KryoKafkaCodec` |
+| 9 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/KafkaOperationsExtensions.kt` | `sendAndAwait(...)`, `awaitSendDefault(...)` overloads | Definition only | Delete | `suspendSend(...)` / `suspendSendDefault(...)` |
+| 10 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt` | `awaitSend(...)`, `sendSuspending(...)`, `getMetricValue(...)` | Definition only | Delete | `suspendSend(...)`, `getMetricValueOrNull(...).asDouble()` |
+| 11 | `lettuce` | `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/LettuceConst.kt` | `DEFAULT_DELIMETER` typo | Definition only | Delete | `DEFAULT_DELIMITER` |
+| 12 | `lettuce` | `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/RedisFutureSupport.kt` | `suspendAwait()`, `coAwait()` | `RedisFutureSupportTest` compatibility tests | Replace tests, then delete | `awaitSuspending()` |
+| 13 | `opentelemetry` | `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/SpanCoroutineSupport.kt` | `SpanBuilder.useSuspendSpan(...)` overloads | One compatibility test path | Replace tests, then delete | `useSpanSuspending(...)` |
+| 14 | `opentelemetry` | `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanExporterSupport.kt` | `spanExportOf(...)` | Definition only | Delete | `spanExporterOf(...)` |
+| 15 | `opentelemetry` | `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanProcessorSupport.kt` | `batchSpanProcess(...)` | Definition only | Delete | `batchSpanProcessorOf(...)` |
+| 16 | `redisson` | `infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/RedissonConst.kt` | `DEFAULT_DELIMETER` typo | Definition only | Delete | `DEFAULT_DELIMITER` |
+| 17 | `resilience4j` | `infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/SuspendDecorators.kt` | `decoreate()` typo overloads | Definition only | Delete | `decorate()` |
 
 ## Follow-Up PR Split
 
@@ -88,26 +87,11 @@ Validation:
 
 - `./gradlew :bluetape4k-cache-core:test :bluetape4k-cache-lettuce:test :bluetape4k-lettuce:test :bluetape4k-redisson:test :bluetape4k-opentelemetry:test :bluetape4k-resilience4j:test --no-daemon`
 
-### PR C: Bucket4j result factory cleanup
-
-Scope:
-
-- `infra/bucket4j`
-
-Tasks:
-
-- Remove the deprecated `RateLimitResult(consumedTokens, availableTokens)`
-  constructor.
-- Rewrite compatibility tests to assert the canonical factory methods and
-  validation paths.
-
-Validation:
-
-- `./gradlew :bluetape4k-bucket4j:test --no-daemon`
-
 ## Notes For Follow-Up Work
 
-- This issue intentionally does not delete code.
+- Bucket4j `RateLimitResult(consumedTokens, availableTokens)` cleanup was
+  completed by issue #434.
+- This inventory intentionally does not delete the remaining code.
 - Keep each cleanup PR small enough to review API removal and test migration
   separately.
 - When a cleanup PR removes public API, add the migration note to

--- a/docs/lessons/2026-05-14-issue-434-bucket4j-facade.md
+++ b/docs/lessons/2026-05-14-issue-434-bucket4j-facade.md
@@ -1,0 +1,47 @@
+# Issue 434 Bucket4j Facade Hardening
+
+## Context
+
+Issue #434 hardened `infra/bucket4j` as a focused Kotlin/JVM Bucket4j facade.
+The risk was broad API drift: `RateLimitResult` needed stable retry diagnostics,
+distributed suspend behavior needed explicit cancellation/timeout semantics, and
+distributed providers needed safer key/policy lifecycle documentation.
+
+## Decision
+
+- Keep the module boundary narrow: token-bucket rate limiting only; retry,
+  timeout policy composition, circuit breakers, bulkheads, and fallback stay in
+  Resilience4j.
+- Make `RateLimitResult` own stable bluetape4k diagnostics instead of exposing
+  Bucket4j probe types.
+- Enforce a 512-byte prefixed bucket key limit before local or distributed
+  bucket resolution.
+- Preserve Java ergonomics for `DistributedSuspendRateLimiter` with
+  `@JvmOverloads` while adding an optional async-store timeout.
+
+## Outcome
+
+- `RateLimitDiagnostics`, `RateLimitRejectionReason`, and `retryAfter` now cover
+  rejection diagnostics.
+- The deprecated `RateLimitResult(consumedTokens, availableTokens)` constructor
+  was removed and the deprecated inventory was updated.
+- README files now document provider lifecycle, Redis expiration ownership,
+  bandwidth IDs for configuration replacement, async support, and module
+  boundary.
+
+## Verification
+
+- `./gradlew :bluetape4k-bucket4j:compileTestKotlin --no-configuration-cache`
+- `./gradlew :bluetape4k-bucket4j:test --no-configuration-cache` (121 tests)
+- `./gradlew :bluetape4k-bucket4j:koverVerify --no-configuration-cache`
+- Claude review reported no P0/P1 findings; low-risk P2 redaction, docs, and
+  key-boundary test suggestions were applied.
+
+## Future Agent Notes
+
+- Do not add retry or circuit-breaker policy behavior to this module; document
+  integration points and keep those policies in Resilience4j.
+- When changing Bucket4j configuration replacement examples, keep stable
+  `Bandwidth.id(...)` values in both English and Korean README files.
+- When adding public result fields to data classes, check Kotlin `copy` /
+  `componentN` and Java constructor compatibility explicitly.

--- a/docs/superpowers/plans/2026-05-14-issue-434-bucket4j-facade-plan.md
+++ b/docs/superpowers/plans/2026-05-14-issue-434-bucket4j-facade-plan.md
@@ -1,0 +1,212 @@
+# Issue 434 Bucket4j Facade Plan
+
+Date: 2026-05-14
+Issue: #434
+Spec: `docs/superpowers/specs/2026-05-14-issue-434-bucket4j-facade-design.md`
+Module: `:bluetape4k-bucket4j`
+
+## Task Plan
+
+### T1a. Result Constructor Cleanup
+
+- Remove deprecated secondary `RateLimitResult(consumedTokens, availableTokens)`
+  constructor.
+- Update `CHANGELOG.md` for the breaking constructor removal.
+
+Validation:
+
+- Remove deprecated-constructor tests.
+- Confirm no production/test references to removed constructor remain.
+- Grep dependent examples/workshops for `RateLimitResult(`, `component`, and
+  `copy(` callers.
+
+### T1b. Result Diagnostics Contract
+
+- Add `RateLimitRejectionReason`.
+- Add nested `RateLimitDiagnostics` with `nanosToWaitForRefill`,
+  `nanosToWaitForReset`, and rejection reason.
+- Make `RateLimitDiagnostics` implement `Serializable`.
+- Add derived `retryAfter` on `RateLimitResult`.
+- Add `serialVersionUID` to result and diagnostics data classes.
+- Add `RateLimitDiagnostics.EMPTY` to avoid repeat allocations for the common
+  no-diagnostics path.
+- Keep factory methods as the primary construction path:
+  - `consumed(consumedTokens, availableTokens, diagnostics = RateLimitDiagnostics.EMPTY)`
+  - `rejected(availableTokens, diagnostics = RateLimitDiagnostics.rejected(...))`
+  - `error(cause)`
+
+Validation:
+
+- Update `RateLimitResultTest`.
+- Add serialization round-trip and error redaction tests.
+- Add KDoc/comment stating `RateLimitRejectionReason` is additive-only and enum
+  names must remain stable; JVM enum serialization is sufficient.
+
+### T1c. Public Error Redaction
+
+- Sanitize public `errorMessage` values with a 256-character cap and URI
+  `user:pass@host` credential redaction; do not fall back to raw
+  `Throwable.toString()`. Header/query-token redaction is out of scope for this
+  issue and can be added if a concrete caller passes those values as exception
+  messages.
+- Keep server-side logs unchanged except for existing debug/warn levels: the
+  redaction rule applies to public `RateLimitResult`, while application logs are
+  operator-controlled and already local to the service.
+
+Validation:
+
+- Redaction unit tests cover URI credentials, no-message exception, and cap
+  length.
+
+### T1d. Provider Key-Size Enforcement
+
+- Add `MAX_BUCKET_KEY_BYTES` and a shared validation helper for serialized
+  bucket keys.
+- Enforce the cap in `AbstractLocalBucketProvider`, `BucketProxyProvider`, and
+  `AsyncBucketProxyProvider` after prefix application.
+- Keep default prefix behavior but document that production callers should pass
+  application/policy-specific prefixes.
+
+Validation:
+
+- Add local and distributed provider unit tests that reject oversized keys.
+
+### T2. Probe Diagnostic Mapping
+
+- Update `toRateLimitResult(ConsumptionProbe, requestedTokens)` to preserve
+  retry-after/reset timing.
+- Normalize `diagnostics.nanosToWaitForRefill = 0` when `probe.isConsumed` even
+  if the upstream probe exposes a refill timing.
+- Keep boolean overload deterministic with zero diagnostics.
+- Extend probe usage tests for rejected diagnostics.
+
+Validation:
+
+- `RateLimiterProbeUsageTest` checks rejected `nanosToWaitForRefill`,
+  `nanosToWaitForReset`, and `retryAfter`.
+- `RateLimiterProbeUsageTest` checks consumed probes set refill wait to `0` and
+  preserve reset wait.
+- `retryAfter` is `null` when refill nanos is zero or negative.
+
+### T3. Coroutine Behavior Coverage
+
+- Add or strengthen focused cancellation tests for `SuspendLocalBucket` waiting
+  behavior.
+- Confirm suspend rate limiters still rethrow `CancellationException`.
+- Add a slow `CompletableFuture` distributed suspend test that cancels while
+  awaiting and proves no `RateLimitResult.error` is returned.
+- Add `DistributedSuspendRateLimiter` timeout behavior with a limiter-scoped
+  default and a concrete per-call overload.
+- Implement timeout as an optional `defaultTimeout: kotlin.time.Duration? =
+  null` constructor parameter on `DistributedSuspendRateLimiter`. The existing
+  `SuspendRateLimiter.consume(key, numToken)` interface method uses that default.
+- Document this constructor change in `CHANGELOG.md`; Kotlin callers keep source
+  compatibility through the default value, but Java constructor callers need to
+  use the new constructor shape if they instantiate directly.
+- Add concrete overload
+  `consume(key: String, numToken: Long, timeout: kotlin.time.Duration?)`.
+- Keep `LocalSuspendRateLimiter` constructor unchanged because local immediate
+  consume does not await remote I/O.
+- Update `SuspendRateLimiter` KDoc to clarify immediate-consume semantics and
+  implementation-specific timeout behavior.
+
+Validation:
+
+- `SuspendedLocalBucketTest`.
+- Existing local/distributed suspend rate limiter tests.
+
+### T4. Configuration Replacement Coverage
+
+- Add tests for bandwidth IDs in `bucketConfiguration`.
+- Add a local Bucket4j `replaceConfiguration(..., PROPORTIONALLY)` test using
+  matching IDs.
+- Add Lettuce and Redisson async proxy configuration replacement tests with
+  matching bandwidth IDs when Testcontainers are available.
+- If a local Testcontainers blocker prevents either backend test, record the
+  exact blocker in the PR body and `docs/lessons/`.
+  Use `docs/lessons/2026-05-14-issue-434-bucket4j-facade.md` for the blocker
+  note when needed.
+
+Validation:
+
+- `ConfigurationSupportTest`.
+
+### T5. Documentation Refresh
+
+- Update `infra/bucket4j/README.md`.
+- Update `infra/bucket4j/README.ko.md`.
+- Cover module boundary, result diagnostics, provider lifecycle/expiration,
+  async distributed support decision, configuration replacement with IDs,
+  burst plus sustained examples, coroutine behavior, and
+  Bucket4j-vs-Resilience4j guidance.
+- Document timeout/cancellation behavior and that an in-flight Redis operation
+  may complete after coroutine cancellation.
+- Document production key-prefix guidance and serialized bucket key size cap.
+- Update `docs/infra-deprecated-inventory.md` to remove or mark the
+  `RateLimitResult` item as completed.
+
+Validation:
+
+- Grep README symbol names against source.
+- Keep public GitHub/CHANGELOG/KDoc language policy intact.
+- Run stale deprecated constructor search.
+
+### T6. Verification and Review
+
+- Run `git diff --check`.
+- Run stale deprecated-constructor search.
+- Run targeted tests:
+  `./gradlew :bluetape4k-bucket4j:test --no-configuration-cache`.
+- Run `./gradlew :bluetape4k-bucket4j:compileKotlin --no-configuration-cache`
+  before tests if API edits surface compile errors.
+- Run `./gradlew :bluetape4k-bucket4j:detekt --no-configuration-cache` when the
+  task exists; if the module does not expose a detekt task, record that gap.
+- Run `./gradlew :bluetape4k-bucket4j:koverXmlReport --no-configuration-cache`
+  or the nearest available Kover report task; if unavailable, record the gap.
+- Inspect the Kover XML/report for the new `RateLimitDiagnostics` and redaction
+  helper surfaces when the report is available.
+- Grep repo callers for `RateLimitResult(`, `component`, and `copy(` in
+  `infra/bucket4j`, examples, and workshops.
+- Run targeted compile if tests fail before test execution.
+- Run Claude advisor/review gates and integrate all P0/P1 findings.
+- Capture a concise lesson under `docs/lessons/`.
+
+## Risks
+
+- Removing the deprecated constructor is a public API break. It is explicitly
+  accepted by issue #434 and the deprecated inventory.
+- Adding diagnostics changes `RateLimitResult.copy()` and data-class member
+  surface. Keep the new diagnostic data in one nested value to minimize
+  destructuring/copy churn and document the break in CHANGELOG.
+- Adding `diagnostics` changes data-class `componentN()` arity. Existing
+  `component1` through `component4` remain, but downstream destructuring using
+  all components may need source changes; document this separately from
+  constructor removal.
+- Redis integration tests depend on Testcontainers. If local Docker is blocked,
+  run non-container unit tests plus report the validation gap; GitHub CI must
+  still prove the full module.
+- Adding too broad an async wrapper would expand the public surface. Keep this
+  issue limited to the existing `DistributedSuspendRateLimiter` path.
+
+## Review Notes
+
+### Claude Code Opus Advisor
+
+Artifact: `.omx/artifacts/claude-issue-434-bucket4j-plan-review-20260514-102810.md`
+
+| Priority | Finding | Decision | Follow-up |
+| --- | --- | --- | --- |
+| P0 | Provider key-size cap was in spec but not plan. | Accepted. | Added T1d implementation and tests. |
+| P0 | Factory signature updates were unspecified. | Accepted. | Added T1b canonical factory signatures and diagnostics constant. |
+| P0 | Distributed timeout contract was unresolved. | Accepted. | Added constructor default, concrete overload, interface KDoc, and local stability decision. |
+| P0 | Consumed probe refill-wait normalization was unspecified. | Accepted. | Added T2 normalization and tests. |
+| P0 | Key-size validation test missing. | Accepted. | Added T1d validation. |
+| P1/P2 | Detekt/Kover/componentN/rollback/test blocker details needed. | Accepted. | Added T6 tasks, risk bullet, and blocker note path. |
+
+### Claude Code Opus Advisor Re-review
+
+Artifact: `.omx/artifacts/claude-issue-434-bucket4j-plan-rereview-20260514-103044.md`
+
+Result: P0=0, P1=0. Accepted P2 clarifications for explicit `Serializable`,
+zero/negative retry-after boundary, bounded URI credential redaction scope, Java
+constructor CHANGELOG note, and Kover surface inspection.

--- a/docs/superpowers/specs/2026-05-14-issue-434-bucket4j-facade-design.md
+++ b/docs/superpowers/specs/2026-05-14-issue-434-bucket4j-facade-design.md
@@ -1,0 +1,231 @@
+# Issue 434 Bucket4j Facade Design
+
+Date: 2026-05-14
+Issue: #434
+Module: `:bluetape4k-bucket4j`
+
+## Context
+
+`infra/bucket4j` is the bluetape4k token-bucket rate-limit facade. It should stay
+focused on Bucket4j-backed local and distributed token consumption, while
+`infra/resilience4j` owns retry, circuit breaker, bulkhead, time limiter, cache,
+and decorator policy composition.
+
+The module already has:
+
+- local and distributed `RateLimiter` / `SuspendRateLimiter` implementations;
+- `LocalBucketProvider`, `LocalSuspendBucketProvider`, `BucketProxyProvider`,
+  and `AsyncBucketProxyProvider`;
+- Lettuce and Redisson proxy-manager helpers;
+- coroutine `SuspendLocalBucket` that uses `delay` instead of thread blocking;
+- Redis-backed integration tests and README pairs.
+
+The remaining gap is contract hardening: `RateLimitResult` still has a
+deprecated compatibility constructor, rejection diagnostics do not expose
+Bucket4j probe retry/reset timing, and docs do not yet make provider lifecycle,
+expiration, configuration replacement, and Bucket4j-vs-Resilience4j boundaries
+explicit enough.
+
+This issue is allowed to make a documented public API break inside the current
+unreleased line: removing the deprecated `RateLimitResult(consumedTokens,
+availableTokens)` compatibility constructor. The change must be called out in
+`CHANGELOG.md`, and current repo references must be verified with `rg` before
+merge.
+
+## Evidence
+
+- Local catalog pins Bucket4j `8.18.0`.
+- Bucket4j `ConsumptionProbe` exposes `isConsumed`, `remainingTokens`,
+  `nanosToWaitForRefill`, and `nanosToWaitForReset`.
+- Bucket4j `Bucket` and `AsyncBucketProxy` support
+  `replaceConfiguration(BucketConfiguration, TokensInheritanceStrategy)`.
+- Bucket4j `BandwidthBuilder` supports `id(String)` for stable bandwidth
+  mapping during configuration replacement.
+- Bucket4j Lettuce and Redisson docs show explicit expiration-after-write
+  configuration via `ExpirationAfterWriteStrategy`.
+- Bucket4j listener events are client-side for distributed buckets; aggregated
+  metrics require caller-side aggregation.
+
+## Goals
+
+1. Keep `infra/bucket4j` as a focused Kotlin/JVM rate-limit facade over
+   Bucket4j.
+2. Stabilize `RateLimitResult` around explicit status-based factories and probe
+   diagnostics.
+3. Keep cancellation propagation deterministic for coroutine paths.
+4. Document provider ownership, Redis key prefixing, expiration strategy, and
+   async distributed support.
+5. Document and test safe configuration replacement with identified bandwidth
+   IDs.
+
+## Non-goals
+
+- No Bucket4j internals port.
+- No KMP/Kotlin Native support.
+- No new distributed backend dependency.
+- No retry/circuit-breaker/fallback policy inside `infra/bucket4j`.
+- No Spring Boot auto-configuration unless a separate concrete user gap is
+  proven.
+
+## Proposed Design
+
+### Public Boundary
+
+`bluetape4k-bucket4j` owns:
+
+- token-bucket consumption by key;
+- local and Redis-distributed Bucket4j bucket resolution;
+- sync and coroutine `consume(key, numToken)` facades;
+- neutral `RateLimitResult` diagnostics.
+
+It does not own:
+
+- retry/backoff policy;
+- fallback behavior;
+- circuit breaking;
+- resilience decorator composition.
+
+Callers may compose `RateLimitResult` with `bluetape4k-resilience4j`, but the
+Bucket4j module should not depend on resilience policy.
+
+### Result Contract
+
+Remove the deprecated `RateLimitResult(consumedTokens, availableTokens)`
+constructor and require explicit factory or primary-constructor use.
+
+Extend `RateLimitResult` with a nested `RateLimitDiagnostics` value instead of
+adding several top-level constructor fields. This limits `componentN()`/`copy()`
+blast radius while still making probe data available.
+
+- `nanosToWaitForRefill`: retry-after timing from `ConsumptionProbe` for
+  rejected attempts.
+- `nanosToWaitForReset`: full-reset timing from `ConsumptionProbe`.
+- `rejectionReason`: module-owned enum for rejected results, initially
+  `INSUFFICIENT_TOKENS`.
+- `retryAfter`: derived nullable `java.time.Duration` for caller-friendly
+  retry headers.
+
+Do not expose `ConsumptionProbe` directly through public `RateLimitResult`.
+Both `RateLimitResult` and `RateLimitDiagnostics` must implement
+`Serializable` and declare `serialVersionUID`.
+`RateLimitRejectionReason` values are additive-only: future changes may append
+new reasons, but existing enum names must not be renamed or reordered.
+
+Status semantics:
+
+| Status | `consumedTokens` | `availableTokens` | `diagnostics.nanosToWaitForRefill` | `diagnostics.nanosToWaitForReset` | `diagnostics.rejectionReason` | `retryAfter` |
+| --- | --- | --- | --- | --- | --- | --- |
+| `CONSUMED` | requested token count | remaining tokens | `0` | probe reset nanos | `null` | `null` |
+| `REJECTED` | `0` | remaining tokens | probe refill nanos | probe reset nanos | `INSUFFICIENT_TOKENS` | `Duration.ofNanos(nanosToWaitForRefill)` when positive |
+| `ERROR` | `0` | `0` | `0` | `0` | `null` | `null` |
+
+`RateLimitResult.error(cause)` should sanitize diagnostics for API consumers:
+cap messages at 256 characters, redact URI credentials, avoid stack traces, and
+avoid falling back to raw `Throwable.toString()`. Detailed exception data belongs
+in logs, not in the result object.
+
+### Coroutine Contract
+
+`SuspendLocalBucket.consume` / `tryConsume` continue to use `delay` for waits.
+`LocalSuspendRateLimiter` and `DistributedSuspendRateLimiter` must rethrow
+`CancellationException` and convert only non-cancellation failures to
+`RateLimitResult.error`.
+
+`SuspendRateLimiter.consume` remains an immediate consume attempt; it does not
+wait for token refill. Waiting behavior stays on `SuspendLocalBucket` for local
+bucket operations.
+
+`DistributedSuspendRateLimiter` should support a caller-configurable timeout for
+the underlying `AsyncBucketProxy` future. The interface method may use a
+limiter-scoped default timeout, and the concrete class may expose a per-call
+timeout overload. On timeout, return `RateLimitResult.error`; on coroutine
+cancellation, rethrow `CancellationException`. If cancellation happens while a
+Redis operation is in flight, token state may still be changed server-side; this
+must be documented.
+
+HTTP `Retry-After` conversion is caller-owned. The module exposes exact
+nanosecond diagnostics; HTTP adapters should round up to the protocol unit they
+emit, commonly at least one second for positive retry delays.
+
+### Distributed Provider Contract
+
+`BucketProxyProvider` and `AsyncBucketProxyProvider` own key namespacing and
+Bucket4j proxy construction only. They do not own Redis client lifecycle, do not
+read token state during resolve, and should document that callers own Redis
+client shutdown.
+
+Lettuce and Redisson helper docs should state that callers should set an
+`ExpirationAfterWriteStrategy` for production Redis storage.
+
+The default key prefix is a development-safe namespace, not an application
+isolation strategy. Production callers should pass an application/policy-specific
+prefix. Provider code should cap serialized bucket key size to avoid Redis
+memory amplification from unbounded user input.
+
+Async distributed support is accepted through the existing
+`AsyncBucketProxyProvider` plus `DistributedSuspendRateLimiter` path. A broader
+general-purpose suspend wrapper for every `AsyncBucketProxy` method is rejected
+for this issue because it would duplicate Bucket4j's async API and expand the
+public surface beyond rate limiting.
+
+### Configuration Evolution
+
+README examples should show burst plus sustained bandwidths with stable IDs:
+
+- `id("burst")`
+- `id("sustained")`
+
+Tests should cover that bandwidth IDs survive the DSL and that a Bucket4j local
+bucket can replace configuration using `TokensInheritanceStrategy.PROPORTIONALLY`.
+Distributed `AsyncBucketProxy.replaceConfiguration(..., PROPORTIONALLY)` should
+also be covered on at least the existing Lettuce and Redisson integration paths
+when Testcontainers are available.
+
+## Acceptance Criteria
+
+- [ ] `RateLimitResult` deprecated compatibility constructor is removed.
+- [ ] `RateLimitResult` exposes nested retry-after/reset diagnostics without
+      exposing Bucket4j internals.
+- [ ] `RateLimitResult` / diagnostics serialization policy is explicit and
+      `serialVersionUID` is declared.
+- [ ] `RateLimitResult.error` redacts/caps public error messages.
+- [ ] Rejected probe conversion preserves `nanosToWaitForRefill` and
+      `nanosToWaitForReset`.
+- [ ] Coroutine cancellation propagation remains covered for local waiting and
+      distributed async `await`; cancellation is not converted to
+      `RateLimitResult.error`.
+- [ ] Distributed suspend calls have a documented timeout contract.
+- [ ] Configuration replacement with identified bandwidth IDs is tested.
+- [ ] Distributed configuration replacement is tested through async proxy paths
+      or an explicit Testcontainers blocker is recorded in the PR body and
+      `docs/lessons/`.
+- [ ] Bucket key size validation is tested.
+- [ ] README English/Korean pairs document module boundary, local vs
+      distributed examples, coroutine behavior, provider lifecycle/expiration,
+      async distributed support, configuration replacement, and
+      Bucket4j-vs-Resilience4j guidance.
+- [ ] Targeted `:bluetape4k-bucket4j:test` passes.
+
+## Review Notes
+
+### Claude Code Opus Advisor
+
+Artifact: `.omx/artifacts/claude-issue-434-bucket4j-spec-review-20260514-102314.md`
+
+| Priority | Finding | Decision | Follow-up |
+| --- | --- | --- | --- |
+| P0 | Deprecated constructor removal and result-shape expansion need explicit binary-break handling. | Accepted. | Spec now documents the unreleased public break, repo-wide reference check, nested diagnostics, and CHANGELOG requirement. |
+| P0 | Diagnostic nanos semantics are undefined. | Accepted. | Added status semantics table and `retryAfter` derivation. |
+| P0 | Distributed suspend `await()` has no timeout contract. | Accepted. | Added limiter-scoped/per-call timeout requirement and cancellation-state note. |
+| P0 | `errorMessage` can leak raw exception data. | Accepted. | Added redaction/capping requirement. |
+| P0 | Cancellation and distributed configuration replacement tests are missing. | Accepted. | Added explicit acceptance criteria. |
+| P1 | Key prefix/key length and listener/observability boundaries need clarity. | Accepted. | Added provider key-size and production prefix guidance; README will document listener/aggregation ownership. |
+| P1 | Public KDoc language must be English. | Accepted. | New/changed public KDoc will be English per workspace AGENTS policy. |
+
+### Claude Code Opus Advisor Re-review
+
+Artifact: `.omx/artifacts/claude-issue-434-bucket4j-spec-rereview-20260514-102705.md`
+
+Result: P0=0, P1=0. Accepted P2 clarifications for reset-nanos semantics,
+Testcontainers blocker location, HTTP retry-after rounding ownership, 256-char
+redaction cap, and additive-only rejection-reason evolution.

--- a/infra/bucket4j/README.ko.md
+++ b/infra/bucket4j/README.ko.md
@@ -13,8 +13,10 @@ Bucket4j 기반으로 애플리케이션 레벨 Rate Limiter를 구성하기 위
 - **Probe 기반 결과 계산**: 소비 성공 여부와 남은 토큰 수를 `ConsumptionProbe` 한 번의 조회 결과로 계산해 추가 토큰 조회를 줄임
 - **Bucket 구성 DSL**: `bucketConfiguration { ... }`, `addBandwidth { ... }` 헬퍼 제공
 - **Redis ProxyManager 헬퍼**: Lettuce/Redisson용 `*ProxyManagerOf` 유틸 제공
-- **결과 상태 표준화**: `RateLimitResult(status, consumedTokens, availableTokens)`로 소비/거절/오류를 일관되게 반환
-- **요청 검증 내장**: 빈 key, `0 이하 token`, 정책 상한(`MAX_TOKENS_PER_REQUEST`) 초과 요청을 사전에 차단
+- **안정적인 결과 계약**:
+  `RateLimitResult(status, consumedTokens, availableTokens, errorMessage, diagnostics)`로 소비/거절/오류를 일관되게 반환
+- **재시도 진단 정보**: 거절 결과에서 `retryAfter`, refill/reset nanos, 안정적인 `RateLimitRejectionReason` 제공
+- **요청 검증 내장**: 빈 key, 직렬화된 key 512 bytes 초과, `0 이하 token`, 정책 상한(`MAX_TOKENS_PER_REQUEST`) 초과 요청을 사전에 차단
 
 ## 클래스 구조
 
@@ -39,12 +41,21 @@ classDiagram
         +consumedTokens: Long
         +availableTokens: Long
         +errorMessage: String?
+        +diagnostics: RateLimitDiagnostics
+        +retryAfter: Duration?
         +isConsumed: Boolean
         +isRejected: Boolean
         +isError: Boolean
-        +consumed(consumedTokens, availableTokens) RateLimitResult
-        +rejected(availableTokens) RateLimitResult
+        +consumed(consumedTokens, availableTokens, diagnostics) RateLimitResult
+        +rejected(availableTokens, diagnostics) RateLimitResult
         +error(cause) RateLimitResult
+    }
+
+    class RateLimitDiagnostics {
+        +nanosToWaitForRefill: Long
+        +nanosToWaitForReset: Long
+        +rejectionReason: RateLimitRejectionReason?
+        +rejected(nanosToWaitForRefill, nanosToWaitForReset, rejectionReason) RateLimitDiagnostics
     }
 
     class RateLimitStatus {
@@ -52,6 +63,11 @@ classDiagram
         CONSUMED
         REJECTED
         ERROR
+    }
+
+    class RateLimitRejectionReason {
+        <<enumeration>>
+        INSUFFICIENT_TOKENS
     }
 
     class LocalRateLimiter {
@@ -71,7 +87,9 @@ classDiagram
 
     class DistributedSuspendRateLimiter {
         -asyncBucketProxyProvider: AsyncBucketProxyProvider
+        -defaultTimeout: Duration?
         +consume(key, numToken) RateLimitResult
+        +consume(key, numToken, timeout) RateLimitResult
     }
 
     class AbstractLocalBucketProvider~T~ {
@@ -119,11 +137,15 @@ classDiagram
     BucketProxyProvider <-- DistributedRateLimiter
     AsyncBucketProxyProvider <-- DistributedSuspendRateLimiter
     RateLimitResult --> RateLimitStatus
+    RateLimitResult --> RateLimitDiagnostics
+    RateLimitDiagnostics --> RateLimitRejectionReason
 
     style RateLimiter fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     style SuspendRateLimiter fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     style RateLimitResult fill:#F57F17,stroke:#E65100,color:#000000
+    style RateLimitDiagnostics fill:#FFF3E0,stroke:#FFB74D,color:#E65100
     style RateLimitStatus fill:#F57F17,stroke:#E65100,color:#000000
+    style RateLimitRejectionReason fill:#FFF3E0,stroke:#FFB74D,color:#E65100
     style LocalRateLimiter fill:#E0F2F1,stroke:#80CBC4,color:#00695C
     style LocalSuspendRateLimiter fill:#F3E5F5,stroke:#CE93D8,color:#6A1B9A
     style DistributedRateLimiter fill:#E0F2F1,stroke:#80CBC4,color:#00695C
@@ -154,11 +176,11 @@ sequenceDiagram
     LocalRateLimiter ->> LocalBucket: tryConsumeAndReturnRemaining(1)
 
     alt 토큰 충분 (CONSUMED)
-        LocalBucket -->> LocalRateLimiter: probe { isConsumed=true, remaining=9 }
-        LocalRateLimiter -->> Caller: RateLimitResult(CONSUMED, consumed=1, available=9)
+        LocalBucket -->> LocalRateLimiter: probe { isConsumed=true, remaining=9, resetNanos=... }
+        LocalRateLimiter -->> Caller: RateLimitResult(CONSUMED, consumed=1, available=9, diagnostics)
     else 토큰 부족 (REJECTED)
-        LocalBucket -->> LocalRateLimiter: probe { isConsumed=false, remaining=0 }
-        LocalRateLimiter -->> Caller: RateLimitResult(REJECTED, consumed=0, available=0)
+        LocalBucket -->> LocalRateLimiter: probe { isConsumed=false, remaining=0, refillNanos=... }
+        LocalRateLimiter -->> Caller: RateLimitResult(REJECTED, consumed=0, available=0, retryAfter)
     else 오류 발생 (ERROR)
         LocalBucket -->> LocalRateLimiter: Exception
         LocalRateLimiter -->> Caller: RateLimitResult(ERROR, errorMessage=...)
@@ -183,11 +205,14 @@ sequenceDiagram
     alt 토큰 충분
         Redis -->> AsyncBucketProxy: consumed=1, remaining=99
         AsyncBucketProxy -->> DistributedSuspendRateLimiter: CompletableFuture (await)
-        DistributedSuspendRateLimiter -->> Caller: RateLimitResult(CONSUMED, 1, 99)
+        DistributedSuspendRateLimiter -->> Caller: RateLimitResult(CONSUMED, 1, 99, diagnostics)
     else 토큰 부족
-        Redis -->> AsyncBucketProxy: consumed=0, remaining=0
+        Redis -->> AsyncBucketProxy: consumed=0, remaining=0, refill wait
         AsyncBucketProxy -->> DistributedSuspendRateLimiter: CompletableFuture (await)
-        DistributedSuspendRateLimiter -->> Caller: RateLimitResult(REJECTED, 0, 0)
+        DistributedSuspendRateLimiter -->> Caller: RateLimitResult(REJECTED, 0, 0, retryAfter)
+    else timeout 또는 저장소 오류
+        AsyncBucketProxy -->> DistributedSuspendRateLimiter: failure
+        DistributedSuspendRateLimiter -->> Caller: RateLimitResult(ERROR, errorMessage)
     end
 ```
 
@@ -200,6 +225,7 @@ sequenceDiagram
 - **코루틴 친화 구현**: `SuspendLocalBucket`, `LocalSuspendRateLimiter`, `DistributedSuspendRateLimiter`
 - **Redis 연동 초기화 단순화**: `lettuceBasedProxyManagerOf`, `redissonBasedProxyManagerOf`
 - **추가 원격 조회 최소화**: distributed/local rate limiter는 잔여 토큰 계산을 위해 별도 `availableTokens` 조회를 하지 않음
+- **Facade 경계 명확화**: 이 모듈은 token-bucket rate limiting만 담당합니다. retry, timeout, circuit breaker, bulkhead, fallback 정책은 Resilience4j를 사용하세요.
 
 ## 의존성 추가
 
@@ -208,8 +234,8 @@ dependencies {
     implementation("io.github.bluetape4k:bluetape4k-bucket4j:${version}")
 
     // Redis 기반 분산 Rate Limiter 사용 시
-    implementation("io.lettuce:lettuce-core") // 또는 redisson
-    implementation("com.bucket4j:bucket4j-redis")
+    implementation("io.lettuce:lettuce-core") // 또는 org.redisson:redisson
+    implementation("com.bucket4j:bucket4j_jdk17-lettuce") // 또는 bucket4j_jdk17-redisson
 }
 ```
 
@@ -226,7 +252,7 @@ val bucketProvider = LocalBucketProvider(config)
 val rateLimiter: RateLimiter<String> = LocalRateLimiter(bucketProvider)
 
 val result = rateLimiter.consume("user:1001", 1)
-// result.status, result.consumedTokens, result.availableTokens
+// result.status, result.consumedTokens, result.availableTokens, result.retryAfter
 ```
 
 ### 2) Distributed Rate Limiter (Redis + Lettuce)
@@ -265,6 +291,7 @@ when (result.status) {
     }
     RateLimitStatus.REJECTED -> {
         // 토큰 부족으로 거절됨
+        // result.retryAfter를 애플리케이션 정책으로 반올림해 429 Retry-After에 사용할 수 있음
     }
     RateLimitStatus.ERROR -> {
         // Redis 장애/통신 오류 등
@@ -275,17 +302,61 @@ when (result.status) {
 
 > 참고: `SuspendRateLimiter.consume`은 내부적으로 대기하지 않는 즉시 소비 시도 API입니다. 토큰 부족 시 `REJECTED`가 즉시 반환되며, 재시도/백오프는 호출자 정책으로 처리합니다.
 
+### 4) 분산 코루틴 Timeout
+
+```kotlin
+val rateLimiter = DistributedSuspendRateLimiter(
+    asyncBucketProxyProvider = asyncBucketProxyProvider,
+    defaultTimeout = 100.milliseconds,
+)
+
+val result = rateLimiter.consume("tenant:a:user:42", 1)
+```
+
+timeout은 비동기 Redis 작업 시간을 제한합니다. timeout은 `RateLimitStatus.ERROR`로 반환되며, 코루틴 취소는 여전히 `CancellationException`으로 전파됩니다. 취소 후에도 이미 전송된 Redis 명령은 완료될 수 있습니다.
+호출별 timeout overload는 `DistributedSuspendRateLimiter` 구체 타입에서 사용할 수 있습니다. `SuspendRateLimiter`로 주입받는 코드는 bean 생성 시 `defaultTimeout`을 설정하세요.
+
+### 5) Bandwidth ID 기반 Configuration Replacement
+
+```kotlin
+val initial = bucketConfiguration {
+    addBandwidth {
+        Bandwidth.builder()
+            .capacity(10)
+            .refillGreedy(10, Duration.ofMinutes(1))
+            .id("per-minute")
+            .build()
+    }
+}
+
+val replacement = bucketConfiguration {
+    addBandwidth {
+        Bandwidth.builder()
+            .capacity(20)
+            .refillGreedy(20, Duration.ofMinutes(1))
+            .id("per-minute")
+            .build()
+    }
+}
+
+bucket.replaceConfiguration(replacement, TokensInheritanceStrategy.PROPORTIONALLY)
+```
+
+설정을 교체하기 전에 안정적인 bandwidth ID를 지정하세요. ID가 일치하지 않으면 Bucket4j가 변경된 limit 사이에서 토큰을 안전하게 상속할 수 없습니다.
+
 ## Public API 계약 메모
 
 - `RateLimiter.consume`, `SuspendRateLimiter.consume`은 모두 `key`와 `numToken`을 먼저 검증합니다.
-  `key`는 blank일 수 없고, `numToken`은 `1..MAX_TOKENS_PER_REQUEST` 범위여야 합니다.
+  `key`는 blank일 수 없고, prefix가 적용된 직렬화 key는 512 bytes 이하여야 하며, `numToken`은 `1..MAX_TOKENS_PER_REQUEST` 범위여야 합니다.
 - `DistributedRateLimiter`, `DistributedSuspendRateLimiter`는
   `ConsumptionProbe` 한 번으로 소비 여부와 잔여 토큰을 계산합니다. 따라서 결과를 만들기 위해 추가 Redis round-trip을 발생시키지 않습니다.
 - `BucketProxyProvider`,
   `AsyncBucketProxyProvider`는 기본 prefix를 사용해 bucket key를 namespacing 합니다. 운영 환경에서 여러 rate limit 정책이 같은 Redis를 공유한다면 prefix를 명시적으로 분리하는 것이 안전합니다.
+- Redis client 생명주기, connection pool, shutdown, expiration strategy는 호출자가 소유합니다. 분산 버킷은 정책 TTL에 맞는 Bucket4j expiration after write 전략을 구성하세요.
 - `LocalBucketProvider`, `LocalSuspendBucketProvider`는 같은 key에 대해 동일한 버킷 상태를 재사용합니다.
 - `SuspendLocalBucket.tryConsume(maxWaitTime)`는 대기가 필요하면 코루틴을 `delay`로 일시 중단하고, 취소 시 `CancellationException`을 그대로 전파합니다.
-- `RateLimitResult.error(cause)`는 예외 메시지를 `errorMessage`에 보존해 상위 계층이 로깅/메트릭 태깅에 재사용할 수 있게 합니다.
+- `RateLimitResult.error(cause)`는 정제된 public message를 `errorMessage`에 저장합니다. URI user-info credential은 redaction되고 메시지는 256자로 제한됩니다.
+- `RateLimitResult.retryAfter`는 거절 결과의 Bucket4j refill nanos에서만 계산됩니다. HTTP header 반올림 정책은 애플리케이션이 소유합니다.
 
 ## Spring Boot 환경 구성
 

--- a/infra/bucket4j/README.md
+++ b/infra/bucket4j/README.md
@@ -15,10 +15,12 @@ A wrapper and utility module for building application-level rate limiters using 
   `ConsumptionProbe` query, avoiding extra token lookups
 - **Bucket configuration DSL**: `bucketConfiguration { ... }` and `addBandwidth { ... }` helpers
 - **Redis ProxyManager helpers**: `*ProxyManagerOf` utilities for Lettuce and Redisson
-- **Standardized result state**:
-  `RateLimitResult(status, consumedTokens, availableTokens)` consistently represents consumed, rejected, and error outcomes
-- **Built-in request validation**: Rejects blank keys, tokens <= 0, and requests exceeding the policy maximum (
-  `MAX_TOKENS_PER_REQUEST`) upfront
+- **Stable result contract**:
+  `RateLimitResult(status, consumedTokens, availableTokens, errorMessage, diagnostics)` consistently represents consumed, rejected, and error outcomes
+- **Retry diagnostics**: Rejected results expose `retryAfter`, refill/reset nanos, and a stable
+  `RateLimitRejectionReason`
+- **Built-in request validation**: Rejects blank keys, serialized keys above 512 bytes, tokens <= 0, and requests
+  exceeding the policy maximum (`MAX_TOKENS_PER_REQUEST`) upfront
 
 ## Class Structure
 
@@ -43,12 +45,21 @@ classDiagram
         +consumedTokens: Long
         +availableTokens: Long
         +errorMessage: String?
+        +diagnostics: RateLimitDiagnostics
+        +retryAfter: Duration?
         +isConsumed: Boolean
         +isRejected: Boolean
         +isError: Boolean
-        +consumed(consumedTokens, availableTokens) RateLimitResult
-        +rejected(availableTokens) RateLimitResult
+        +consumed(consumedTokens, availableTokens, diagnostics) RateLimitResult
+        +rejected(availableTokens, diagnostics) RateLimitResult
         +error(cause) RateLimitResult
+    }
+
+    class RateLimitDiagnostics {
+        +nanosToWaitForRefill: Long
+        +nanosToWaitForReset: Long
+        +rejectionReason: RateLimitRejectionReason?
+        +rejected(nanosToWaitForRefill, nanosToWaitForReset, rejectionReason) RateLimitDiagnostics
     }
 
     class RateLimitStatus {
@@ -56,6 +67,11 @@ classDiagram
         CONSUMED
         REJECTED
         ERROR
+    }
+
+    class RateLimitRejectionReason {
+        <<enumeration>>
+        INSUFFICIENT_TOKENS
     }
 
     class LocalRateLimiter {
@@ -75,7 +91,9 @@ classDiagram
 
     class DistributedSuspendRateLimiter {
         -asyncBucketProxyProvider: AsyncBucketProxyProvider
+        -defaultTimeout: Duration?
         +consume(key, numToken) RateLimitResult
+        +consume(key, numToken, timeout) RateLimitResult
     }
 
     class AbstractLocalBucketProvider~T~ {
@@ -123,11 +141,15 @@ classDiagram
     BucketProxyProvider <-- DistributedRateLimiter
     AsyncBucketProxyProvider <-- DistributedSuspendRateLimiter
     RateLimitResult --> RateLimitStatus
+    RateLimitResult --> RateLimitDiagnostics
+    RateLimitDiagnostics --> RateLimitRejectionReason
 
     style RateLimiter fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     style SuspendRateLimiter fill:#E3F2FD,stroke:#90CAF9,color:#1565C0
     style RateLimitResult fill:#F57F17,stroke:#E65100,color:#000000
+    style RateLimitDiagnostics fill:#FFF3E0,stroke:#FFB74D,color:#E65100
     style RateLimitStatus fill:#F57F17,stroke:#E65100,color:#000000
+    style RateLimitRejectionReason fill:#FFF3E0,stroke:#FFB74D,color:#E65100
     style LocalRateLimiter fill:#E0F2F1,stroke:#80CBC4,color:#00695C
     style LocalSuspendRateLimiter fill:#F3E5F5,stroke:#CE93D8,color:#6A1B9A
     style DistributedRateLimiter fill:#E0F2F1,stroke:#80CBC4,color:#00695C
@@ -158,11 +180,11 @@ sequenceDiagram
     LocalRateLimiter ->> LocalBucket: tryConsumeAndReturnRemaining(1)
 
     alt Sufficient tokens (CONSUMED)
-        LocalBucket -->> LocalRateLimiter: probe { isConsumed=true, remaining=9 }
-        LocalRateLimiter -->> Caller: RateLimitResult(CONSUMED, consumed=1, available=9)
+        LocalBucket -->> LocalRateLimiter: probe { isConsumed=true, remaining=9, resetNanos=... }
+        LocalRateLimiter -->> Caller: RateLimitResult(CONSUMED, consumed=1, available=9, diagnostics)
     else Insufficient tokens (REJECTED)
-        LocalBucket -->> LocalRateLimiter: probe { isConsumed=false, remaining=0 }
-        LocalRateLimiter -->> Caller: RateLimitResult(REJECTED, consumed=0, available=0)
+        LocalBucket -->> LocalRateLimiter: probe { isConsumed=false, remaining=0, refillNanos=... }
+        LocalRateLimiter -->> Caller: RateLimitResult(REJECTED, consumed=0, available=0, retryAfter)
     else Error (ERROR)
         LocalBucket -->> LocalRateLimiter: Exception
         LocalRateLimiter -->> Caller: RateLimitResult(ERROR, errorMessage=...)
@@ -187,11 +209,14 @@ sequenceDiagram
     alt Sufficient tokens
         Redis -->> AsyncBucketProxy: consumed=1, remaining=99
         AsyncBucketProxy -->> DistributedSuspendRateLimiter: CompletableFuture (await)
-        DistributedSuspendRateLimiter -->> Caller: RateLimitResult(CONSUMED, 1, 99)
+        DistributedSuspendRateLimiter -->> Caller: RateLimitResult(CONSUMED, 1, 99, diagnostics)
     else Insufficient tokens
-        Redis -->> AsyncBucketProxy: consumed=0, remaining=0
+        Redis -->> AsyncBucketProxy: consumed=0, remaining=0, refill wait
         AsyncBucketProxy -->> DistributedSuspendRateLimiter: CompletableFuture (await)
-        DistributedSuspendRateLimiter -->> Caller: RateLimitResult(REJECTED, 0, 0)
+        DistributedSuspendRateLimiter -->> Caller: RateLimitResult(REJECTED, 0, 0, retryAfter)
+    else Timeout or store failure
+        AsyncBucketProxy -->> DistributedSuspendRateLimiter: failure
+        DistributedSuspendRateLimiter -->> Caller: RateLimitResult(ERROR, errorMessage)
     end
 ```
 
@@ -207,6 +232,8 @@ sequenceDiagram
 - **Simplified Redis initialization**: `lettuceBasedProxyManagerOf`, `redissonBasedProxyManagerOf`
 - **Minimized extra remote calls**: Distributed and local rate limiters do not issue additional
   `availableTokens` queries to build results
+- **Facade boundary**: This module owns token-bucket rate limiting only. Use Resilience4j for retry, timeout,
+  circuit breaker, bulkhead, and fallback policies.
 
 ## Dependency
 
@@ -215,8 +242,8 @@ dependencies {
     implementation("io.github.bluetape4k:bluetape4k-bucket4j:${version}")
 
     // For Redis-based distributed rate limiting
-    implementation("io.lettuce:lettuce-core") // or redisson
-    implementation("com.bucket4j:bucket4j-redis")
+    implementation("io.lettuce:lettuce-core") // or org.redisson:redisson
+    implementation("com.bucket4j:bucket4j_jdk17-lettuce") // or bucket4j_jdk17-redisson
 }
 ```
 
@@ -233,7 +260,7 @@ val bucketProvider = LocalBucketProvider(config)
 val rateLimiter: RateLimiter<String> = LocalRateLimiter(bucketProvider)
 
 val result = rateLimiter.consume("user:1001", 1)
-// result.status, result.consumedTokens, result.availableTokens
+// result.status, result.consumedTokens, result.availableTokens, result.retryAfter
 ```
 
 ### 2) Distributed Rate Limiter (Redis + Lettuce)
@@ -272,6 +299,7 @@ when (result.status) {
     }
     RateLimitStatus.REJECTED -> {
         // Rejected due to insufficient tokens
+        // Use result.retryAfter for a 429 Retry-After policy after application-level rounding
     }
     RateLimitStatus.ERROR -> {
         // Redis failure or communication error
@@ -284,20 +312,70 @@ when (result.status) {
 `SuspendRateLimiter.consume` attempts immediate consumption internally without waiting. When tokens are insufficient,
 `REJECTED` is returned immediately. Retry/backoff logic is the caller's responsibility.
 
+### 4) Distributed Coroutine Timeout
+
+```kotlin
+val rateLimiter = DistributedSuspendRateLimiter(
+    asyncBucketProxyProvider = asyncBucketProxyProvider,
+    defaultTimeout = 100.milliseconds,
+)
+
+val result = rateLimiter.consume("tenant:a:user:42", 1)
+```
+
+The timeout bounds the async Redis operation. A timeout returns `RateLimitStatus.ERROR`; coroutine cancellation still
+throws `CancellationException`. The in-flight Redis command can still complete after the coroutine is cancelled.
+The per-call timeout overload is available on `DistributedSuspendRateLimiter`; code injected as `SuspendRateLimiter`
+should configure `defaultTimeout` at bean construction time.
+
+### 5) Configuration Replacement With Bandwidth IDs
+
+```kotlin
+val initial = bucketConfiguration {
+    addBandwidth {
+        Bandwidth.builder()
+            .capacity(10)
+            .refillGreedy(10, Duration.ofMinutes(1))
+            .id("per-minute")
+            .build()
+    }
+}
+
+val replacement = bucketConfiguration {
+    addBandwidth {
+        Bandwidth.builder()
+            .capacity(20)
+            .refillGreedy(20, Duration.ofMinutes(1))
+            .id("per-minute")
+            .build()
+    }
+}
+
+bucket.replaceConfiguration(replacement, TokensInheritanceStrategy.PROPORTIONALLY)
+```
+
+Assign stable bandwidth IDs before replacing a configuration. Without matching IDs, Bucket4j cannot safely inherit
+tokens across changed limits.
+
 ## Public API Contract Notes
 
 - Both `RateLimiter.consume` and `SuspendRateLimiter.consume` validate `key` and `numToken` first.
-  `key` must not be blank, and `numToken` must be in the range `1..MAX_TOKENS_PER_REQUEST`.
+  `key` must not be blank, the prefixed serialized key must be at most 512 bytes, and `numToken` must be in the range
+  `1..MAX_TOKENS_PER_REQUEST`.
 - `DistributedRateLimiter` and
   `DistributedSuspendRateLimiter` derive the consumption outcome and remaining tokens from a single
   `ConsumptionProbe`, so no extra Redis round-trips are made to build results.
 - `BucketProxyProvider` and
   `AsyncBucketProxyProvider` namespace bucket keys using a default prefix. In production, if multiple rate limiting policies share the same Redis instance, it is safer to use distinct prefixes.
+- Callers own Redis client lifecycle, connection pooling, shutdown, and expiration strategy. For distributed buckets,
+  configure Bucket4j expiration after write according to the policy TTL.
 - `LocalBucketProvider` and `LocalSuspendBucketProvider` reuse the same bucket state for the same key.
 - `SuspendLocalBucket.tryConsume(maxWaitTime)` suspends the coroutine with
   `delay` when waiting is needed, and propagates `CancellationException` unchanged on cancellation.
-- `RateLimitResult.error(cause)` preserves the exception message in
-  `errorMessage` so that higher layers can reuse it for logging or metric tagging.
+- `RateLimitResult.error(cause)` stores a sanitized public message in `errorMessage`. URI user-info credentials are
+  redacted and messages are capped at 256 characters.
+- `RateLimitResult.retryAfter` is derived from Bucket4j refill nanos for rejected results only. HTTP header rounding
+  remains an application policy.
 
 ## Spring Boot Configuration
 

--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/BucketKeyValidation.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/BucketKeyValidation.kt
@@ -1,0 +1,23 @@
+package io.bluetape4k.bucket4j
+
+import io.bluetape4k.support.toUtf8Bytes
+
+/**
+ * Maximum serialized bucket-key size accepted by bluetape4k Bucket4j providers.
+ *
+ * The cap is applied after the provider prefix is appended. It prevents
+ * unbounded user-provided keys from amplifying local cache or Redis memory use.
+ */
+const val MAX_BUCKET_KEY_BYTES: Int = 512
+
+internal fun validateBucketKeySize(bucketKey: String, name: String = "bucketKey"): String {
+    validateBucketKeySize(bucketKey.toUtf8Bytes(), name)
+    return bucketKey
+}
+
+internal fun validateBucketKeySize(bucketKey: ByteArray, name: String = "bucketKey"): ByteArray {
+    require(bucketKey.size <= MAX_BUCKET_KEY_BYTES) {
+        "$name must be at most $MAX_BUCKET_KEY_BYTES bytes after prefix encoding. actual=${bucketKey.size}"
+    }
+    return bucketKey
+}

--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/distributed/AsyncBucketProxyProvider.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/distributed/AsyncBucketProxyProvider.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.bucket4j.distributed
 
+import io.bluetape4k.bucket4j.validateBucketKeySize
 import io.bluetape4k.concurrent.completableFutureOf
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
@@ -11,12 +12,14 @@ import io.github.bucket4j.distributed.AsyncBucketProxy
 import io.github.bucket4j.distributed.proxy.AsyncProxyManager
 
 /**
- * 비동기 원격 저장소 기반 [AsyncBucketProxy]를 key별로 조회하는 provider 입니다.
+ * Provider that resolves distributed Bucket4j [AsyncBucketProxy] instances by key.
  *
- * ## 동작/계약
- * - [resolveBucket]은 blank key를 허용하지 않습니다.
- * - 실제 원격 bucket key는 [keyPrefix] + `key`를 UTF-8 바이트 배열로 직렬화해 구성합니다.
- * - resolve 시점에는 proxy 생성/조회만 수행하고, 잔여 토큰 조회 같은 추가 비동기 호출은 하지 않습니다.
+ * ## Contract
+ * - [resolveBucket] rejects blank keys.
+ * - The remote bucket key is `[keyPrefix] + key` encoded as UTF-8 bytes.
+ * - The prefixed serialized key must be at most `MAX_BUCKET_KEY_BYTES`.
+ * - Resolution only builds an async proxy and does not issue an extra
+ *   remaining-token read.
  *
  * ```kotlin
  * class UserBasedAsyncBucketProvider(
@@ -33,9 +36,10 @@ import io.github.bucket4j.distributed.proxy.AsyncProxyManager
  * }
  * ```
  *
- * @property asyncProxyManager Bucket4j [AsyncProxyManager] 인스턴스
- * @property bucketConfiguration Bucket Configuration
- * @property keyPrefix Bucket Key Prefix. Redis namespace 충돌 방지를 위해 기본 prefix가 적용됩니다.
+ * @property asyncProxyManager Bucket4j async proxy manager.
+ * @property bucketConfiguration bucket configuration used for new remote
+ * buckets.
+ * @property keyPrefix remote-key namespace prefix.
  */
 open class AsyncBucketProxyProvider(
     protected val asyncProxyManager: AsyncProxyManager<ByteArray>,
@@ -48,21 +52,19 @@ open class AsyncBucketProxyProvider(
     }
 
     /**
-     * [key]에 해당하는 [AsyncBucketProxy]를 반환합니다.
+     * Resolves the [AsyncBucketProxy] for [key].
      *
-     * ## 동작/계약
-     * - [key]는 blank일 수 없습니다.
-     * - 반환값은 같은 key에 대해 동일한 원격 상태를 바라봅니다.
-     * - future completion과 토큰 잔량 조회는 호출자가 명시적으로 수행해야 합니다.
-     *
-     * @param key Bucket 소유자 (Rate Limit 적용 대상) Key
-     * @return [Bucket] 인스턴스
+     * ## Contract
+     * - [key] must not be blank.
+     * - Calls with the same key point at the same remote bucket state.
+     * - Future completion and remaining-token reads are caller-owned; this
+     *   method only resolves the async proxy.
      */
     fun resolveBucket(key: String): AsyncBucketProxy {
         key.requireNotBlank("key")
         log.debug { "Resolving AsyncBucketProxy for key: $key" }
-        // Prefix는 getBucketKey 에서 단일 책임으로 처리한다.
-        val bucketKey = getBucketKey(key)
+        // Keep prefix ownership in getBucketKey so overrides have one boundary.
+        val bucketKey = validateBucketKeySize(getBucketKey(key))
 
         return asyncProxyManager.builder()
             .build(bucketKey) { completableFutureOf(bucketConfiguration) }
@@ -72,9 +74,9 @@ open class AsyncBucketProxyProvider(
     }
 
     /**
-     * 실제 원격 저장소에 사용할 async bucket key를 생성합니다.
+     * Builds the serialized bucket key for the remote store.
      *
-     * 기본 구현은 [keyPrefix]를 붙인 뒤 UTF-8 바이트 배열로 변환합니다.
+     * The default implementation prefixes [key] and encodes it as UTF-8 bytes.
      */
     protected open fun getBucketKey(key: String): ByteArray {
         return "$keyPrefix$key".toUtf8Bytes()

--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/distributed/BucketProxyProvider.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/distributed/BucketProxyProvider.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.bucket4j.distributed
 
+import io.bluetape4k.bucket4j.validateBucketKeySize
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.requireNotBlank
@@ -10,12 +11,14 @@ import io.github.bucket4j.distributed.BucketProxy
 import io.github.bucket4j.distributed.proxy.ProxyManager
 
 /**
- * 원격 저장소 기반 [BucketProxy]를 key별로 조회하는 provider 입니다.
+ * Provider that resolves distributed Bucket4j [BucketProxy] instances by key.
  *
- * ## 동작/계약
- * - [resolveBucket]은 blank key를 허용하지 않습니다.
- * - 실제 원격 bucket key는 [keyPrefix] + `key`를 UTF-8 바이트 배열로 직렬화해 구성합니다.
- * - resolve 시점에는 bucket 생성/조회만 수행하고, 잔여 토큰 조회 같은 추가 원격 호출은 하지 않습니다.
+ * ## Contract
+ * - [resolveBucket] rejects blank keys.
+ * - The remote bucket key is `[keyPrefix] + key` encoded as UTF-8 bytes.
+ * - The prefixed serialized key must be at most `MAX_BUCKET_KEY_BYTES`.
+ * - Resolution only builds a proxy and does not issue an extra remaining-token
+ *   read.
  *
  * ```kotlin
  * class UserBasedBucketProvider(
@@ -32,9 +35,10 @@ import io.github.bucket4j.distributed.proxy.ProxyManager
  * }
  * ```
  *
- * @property proxyManager Bucket4j [ProxyManager] 인스턴스
- * @property bucketConfiguration Bucket Configuration
- * @property keyPrefix Bucket Key Prefix. Redis namespace 충돌 방지를 위해 기본 prefix가 적용됩니다.
+ * @property proxyManager Bucket4j proxy manager.
+ * @property bucketConfiguration bucket configuration used for new remote
+ * buckets.
+ * @property keyPrefix remote-key namespace prefix.
  */
 open class BucketProxyProvider(
     protected val proxyManager: ProxyManager<ByteArray>,
@@ -47,21 +51,19 @@ open class BucketProxyProvider(
     }
 
     /**
-     * [key]에 해당하는 [BucketProxy]를 반환합니다.
+     * Resolves the [BucketProxy] for [key].
      *
-     * ## 동작/계약
-     * - [key]는 blank일 수 없습니다.
-     * - 반환값은 같은 key에 대해 동일한 원격 상태를 바라봅니다.
-     * - 토큰 잔량 조회는 호출자가 명시적으로 수행해야 하며, 이 메서드는 resolve만 담당합니다.
-     *
-     * @param key Bucket 소유자 (Rate Limit 적용 대상) Key
-     * @return [Bucket] 인스턴스
+     * ## Contract
+     * - [key] must not be blank.
+     * - Calls with the same key point at the same remote bucket state.
+     * - Remaining-token reads are caller-owned; this method only resolves the
+     *   proxy.
      */
     fun resolveBucket(key: String): BucketProxy {
         key.requireNotBlank("key")
         log.debug { "Resolving bucket for key: $key" }
-        // Prefix는 getBucketKey 에서 단일 책임으로 처리한다.
-        val bucketKey = getBucketKey(key)
+        // Keep prefix ownership in getBucketKey so overrides have one boundary.
+        val bucketKey = validateBucketKeySize(getBucketKey(key))
 
         return proxyManager.builder()
             .build(bucketKey) { bucketConfiguration }
@@ -71,9 +73,9 @@ open class BucketProxyProvider(
     }
 
     /**
-     * 실제 원격 저장소에 사용할 bucket key를 생성합니다.
+     * Builds the serialized bucket key for the remote store.
      *
-     * 기본 구현은 [keyPrefix]를 붙인 뒤 UTF-8 바이트 배열로 변환합니다.
+     * The default implementation prefixes [key] and encodes it as UTF-8 bytes.
      */
     protected open fun getBucketKey(key: String): ByteArray {
         return "$keyPrefix$key".toUtf8Bytes()

--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/local/AbstractLocalBucketProvider.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/local/AbstractLocalBucketProvider.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.bucket4j.local
 
 import com.github.benmanes.caffeine.cache.LoadingCache
+import io.bluetape4k.bucket4j.validateBucketKeySize
 import io.bluetape4k.cache.caffeine.caffeine
 import io.bluetape4k.cache.caffeine.loadingCache
 import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
@@ -13,12 +14,16 @@ import io.github.bucket4j.local.LocalBucket
 import java.time.Duration
 
 /**
- * Custom Key 기반 (예: userId) 의 Local Bucket을 제공합니다.
+ * Base provider for key-based local Bucket4j buckets.
  *
- * [resolveBucket]은 빈 key를 허용하지 않으며, key prefix를 적용한 캐시 키로 버킷을 조회합니다.
+ * ## Contract
+ * - [resolveBucket] rejects blank keys.
+ * - The local cache key is `[keyPrefix] + key`.
+ * - The prefixed key must be at most `MAX_BUCKET_KEY_BYTES` UTF-8 bytes.
+ * - The same key resolves to the same cached local bucket until cache expiry.
  *
- * @property bucketConfiguration [BucketConfiguration] 인스턴스
- * @property keyPrefix Bucket Key Prefix
+ * @property bucketConfiguration bucket configuration used for new buckets.
+ * @property keyPrefix cache-key namespace prefix.
  */
 abstract class AbstractLocalBucketProvider<T: LocalBucket>(
     protected val bucketConfiguration: BucketConfiguration,
@@ -27,16 +32,16 @@ abstract class AbstractLocalBucketProvider<T: LocalBucket>(
     companion object: KLogging() {
         const val DEFAULT_KEY_PREFIX = "bluetape4k.rate-limit.key."
 
-        /** 버킷 캐시의 최대 엔트리 수 */
+        /** Maximum number of local bucket cache entries. */
         const val DEFAULT_CACHE_MAX_SIZE = 100_000L
 
-        /** 버킷 캐시의 접근 후 만료 시간 */
+        /** Access-based expiration for local bucket cache entries. */
         @JvmStatic
         val DEFAULT_CACHE_EXPIRE_AFTER_ACCESS: Duration = Duration.ofHours(6)
     }
 
     /**
-     * Custom Key: [Bucket] 을 저장하는 캐시
+     * Cache storing one local bucket per prefixed key.
      */
     protected open val cache: LoadingCache<String, T> by lazy {
         caffeine {
@@ -48,29 +53,22 @@ abstract class AbstractLocalBucketProvider<T: LocalBucket>(
         }
     }
 
-    /**
-     * Bucket을 생성합니다.
-     *
-     * @return [Bucket]
-     */
+    /** Creates a new local bucket for cache misses. */
     protected abstract fun createBucket(): T
 
     /**
-     * [key]에 key prefix를 결합하여 캐시 키를 반환합니다.
+     * Returns the prefixed cache key for [key].
      *
      * ```kotlin
      * val provider = LocalBucketProvider(bucketConfiguration, keyPrefix = "app.rate.")
      * val cacheKey = provider.getBucketKey("user-42")
      * // cacheKey == "app.rate.user-42"
      * ```
-     *
-     * @param key 원본 키
-     * @return prefix가 적용된 캐시 키
      */
     protected open fun getBucketKey(key: String): String = "$keyPrefix$key"
 
     /**
-     * [key]에 해당하는 [LocalBucket]을 제공합니다.
+     * Resolves the local bucket for [key].
      *
      * ```kotlin
      * val config = BucketConfiguration.builder()
@@ -82,14 +80,13 @@ abstract class AbstractLocalBucketProvider<T: LocalBucket>(
      * // result.remainingTokens == 9
      * ```
      *
-     * @param key Custom Key
-     * @return [LocalBucket] 인스턴스
-     * @throws IllegalArgumentException key가 blank인 경우
+     * @throws IllegalArgumentException when [key] is blank or the prefixed key
+     * exceeds `MAX_BUCKET_KEY_BYTES`.
      */
     open fun resolveBucket(key: String): T {
         key.requireNotBlank("key")
         log.debug { "Loading local bucket. key=$key" }
-        val bucketKey = getBucketKey(key)
+        val bucketKey = validateBucketKeySize(getBucketKey(key))
 
         return cache
             .get(bucketKey)

--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/RateLimitResult.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/RateLimitResult.kt
@@ -1,99 +1,172 @@
 package io.bluetape4k.bucket4j.ratelimit
 
 import java.io.Serializable
+import java.time.Duration
 
 /**
- * 토큰 소비 시도 결과 상태를 나타냅니다.
+ * Result status for a rate-limit token consumption attempt.
  *
- * ## 동작/계약
- * - [CONSUMED]는 요청 토큰이 정상 소비된 상태입니다.
- * - [REJECTED]는 가용 토큰 부족으로 소비가 거절된 상태입니다.
- * - [ERROR]는 소비 처리 중 예외가 발생한 상태입니다.
- *
- * ```kotlin
- * val status = RateLimitStatus.CONSUMED
- * // status.name == "CONSUMED"
- * ```
+ * ## Contract
+ * - [CONSUMED] means the requested tokens were consumed.
+ * - [REJECTED] means the bucket did not have enough available tokens.
+ * - [ERROR] means the provider failed while resolving or consuming from a bucket.
  */
 enum class RateLimitStatus {
-    /** 요청 토큰이 정상 소비됨 */
+    /** Requested tokens were consumed. */
     CONSUMED,
 
-    /** 토큰 부족으로 소비 거절됨 */
+    /** Consumption was rejected because the bucket had insufficient tokens. */
     REJECTED,
 
-    /** 처리 중 오류가 발생함 */
+    /** Provider or bucket processing failed. */
     ERROR
 }
 
 /**
- * Rate limit 토큰 소비 결과를 나타내는 값 객체입니다.
+ * Stable rejection reason owned by bluetape4k.
  *
- * ## 동작/계약
- * - [status]에 따라 [consumedTokens], [availableTokens], [errorMessage] 해석이 달라집니다.
- * - [isConsumed]/[isRejected]/[isError]는 [status] 비교 결과를 그대로 반환합니다.
- * - `consumed/rejected/error` 팩토리 메서드는 상태별 권장 생성 경로입니다.
+ * Values are additive-only: existing names must not be renamed or reordered
+ * because callers may persist or exhaustively match them.
+ */
+enum class RateLimitRejectionReason {
+    /** The bucket had fewer available tokens than requested. */
+    INSUFFICIENT_TOKENS
+}
+
+/**
+ * Diagnostic data derived from Bucket4j probes without exposing upstream types.
  *
- * ```kotlin
- * val result = RateLimitResult.consumed(consumedTokens = 1, availableTokens = 9)
- * // result.isConsumed == true
- * // result.availableTokens == 9
- * ```
+ * ## Contract
+ * - [nanosToWaitForRefill] is positive only when a rejected caller can retry
+ *   after waiting for token refill.
+ * - [nanosToWaitForReset] is the observed time until the bucket is fully
+ *   refilled when the upstream probe provides it.
+ * - [rejectionReason] is set only for [RateLimitStatus.REJECTED] results.
+ */
+data class RateLimitDiagnostics(
+    val nanosToWaitForRefill: Long = 0,
+    val nanosToWaitForReset: Long = 0,
+    val rejectionReason: RateLimitRejectionReason? = null,
+): Serializable {
+
+    init {
+        require(nanosToWaitForRefill >= 0) {
+            "nanosToWaitForRefill must be greater than or equal to 0. nanosToWaitForRefill=$nanosToWaitForRefill"
+        }
+        require(nanosToWaitForReset >= 0) {
+            "nanosToWaitForReset must be greater than or equal to 0. nanosToWaitForReset=$nanosToWaitForReset"
+        }
+    }
+
+    companion object {
+        private const val serialVersionUID: Long = 1L
+
+        @JvmField
+        val EMPTY: RateLimitDiagnostics = RateLimitDiagnostics()
+
+        @JvmStatic
+        fun rejected(
+            nanosToWaitForRefill: Long,
+            nanosToWaitForReset: Long,
+            rejectionReason: RateLimitRejectionReason = RateLimitRejectionReason.INSUFFICIENT_TOKENS,
+        ): RateLimitDiagnostics =
+            RateLimitDiagnostics(nanosToWaitForRefill, nanosToWaitForReset, rejectionReason)
+    }
+}
+
+/**
+ * Value object returned by bluetape4k rate limiters.
+ *
+ * ## Contract
+ * - [status] defines how [consumedTokens], [availableTokens], [diagnostics], and
+ *   [errorMessage] should be interpreted.
+ * - [isConsumed], [isRejected], and [isError] are status predicates.
+ * - Factory methods are the preferred construction path.
  */
 data class RateLimitResult(
-    /** 토큰 소비 결과 상태입니다. */
+    /** Token consumption result status. */
     val status: RateLimitStatus,
-    /** 실제로 소비된 토큰 수입니다. */
+    /** Number of tokens consumed by this attempt. */
     val consumedTokens: Long = 0,
-    /** 소비 시도 이후 관측된 잔여 토큰 수입니다. */
+    /** Remaining tokens observed after the attempt. */
     val availableTokens: Long,
-    /** 오류 발생 시 상위 계층에서 로깅/메트릭 태깅에 사용할 메시지입니다. */
+    /** Public, sanitized error message for logging or metric tags. */
     val errorMessage: String? = null,
+    /** Probe diagnostics for retry-after and rejection reporting. */
+    val diagnostics: RateLimitDiagnostics = RateLimitDiagnostics.EMPTY,
 ): Serializable {
 
     init {
         require(consumedTokens >= 0) { "consumedTokens must be greater than or equal to 0. consumedTokens=$consumedTokens" }
         require(availableTokens >= 0) { "availableTokens must be greater than or equal to 0. availableTokens=$availableTokens" }
+        require(status == RateLimitStatus.REJECTED || diagnostics.rejectionReason == null) {
+            "rejectionReason is meaningful only for REJECTED results. status=$status, rejectionReason=${diagnostics.rejectionReason}"
+        }
     }
 
-    @Deprecated(
-        message = "Use status-based factory methods or the primary constructor with explicit status.",
-        replaceWith = ReplaceWith("RateLimitResult.consumed(consumedTokens, availableTokens)")
-    )
-    constructor(consumedTokens: Long, availableTokens: Long): this(
-        status = if (consumedTokens > 0) RateLimitStatus.CONSUMED else RateLimitStatus.REJECTED,
-        consumedTokens = consumedTokens,
-        availableTokens = availableTokens,
-    )
-
-    /** 소비 성공 여부를 반환합니다. */
+    /** Whether this attempt consumed tokens. */
     val isConsumed: Boolean get() = status == RateLimitStatus.CONSUMED
 
-    /** 소비 거절 여부를 반환합니다. */
+    /** Whether this attempt was rejected. */
     val isRejected: Boolean get() = status == RateLimitStatus.REJECTED
 
-    /** 오류 발생 여부를 반환합니다. */
+    /** Whether this attempt failed with provider or bucket error. */
     val isError: Boolean get() = status == RateLimitStatus.ERROR
 
+    /** Caller-friendly retry delay for rejected attempts, or `null` when absent. */
+    val retryAfter: Duration?
+        get() = diagnostics.nanosToWaitForRefill
+            .takeIf { status == RateLimitStatus.REJECTED && it > 0 }
+            ?.let(Duration::ofNanos)
+
     companion object {
-        /** 소비 성공 결과를 생성합니다. */
-        @JvmStatic
-        fun consumed(consumedTokens: Long, availableTokens: Long): RateLimitResult =
-            RateLimitResult(RateLimitStatus.CONSUMED, consumedTokens, availableTokens)
+        private const val serialVersionUID: Long = 1L
+        private const val MAX_ERROR_MESSAGE_LENGTH = 256
 
-        /** 소비 거절 결과를 생성합니다. */
-        @JvmStatic
-        fun rejected(availableTokens: Long): RateLimitResult =
-            RateLimitResult(RateLimitStatus.REJECTED, 0, availableTokens)
+        private val URI_CREDENTIALS = Regex("([a-zA-Z][a-zA-Z0-9+.-]*://)([^/\\s]+)@")
 
-        /** 오류 결과를 생성합니다. */
+        /** Creates a consumed result. */
+        @JvmStatic
+        fun consumed(
+            consumedTokens: Long,
+            availableTokens: Long,
+            diagnostics: RateLimitDiagnostics = RateLimitDiagnostics.EMPTY,
+        ): RateLimitResult =
+            RateLimitResult(RateLimitStatus.CONSUMED, consumedTokens, availableTokens, diagnostics = diagnostics)
+
+        /** Creates a rejected result. */
+        @JvmStatic
+        fun rejected(
+            availableTokens: Long,
+            diagnostics: RateLimitDiagnostics = RateLimitDiagnostics.rejected(
+                nanosToWaitForRefill = 0,
+                nanosToWaitForReset = 0,
+            ),
+        ): RateLimitResult =
+            RateLimitResult(RateLimitStatus.REJECTED, 0, availableTokens, diagnostics = diagnostics)
+
+        /** Creates an error result with a public sanitized message. */
         @JvmStatic
         fun error(cause: Throwable? = null): RateLimitResult =
             RateLimitResult(
                 status = RateLimitStatus.ERROR,
                 consumedTokens = 0,
                 availableTokens = 0,
-                errorMessage = cause?.message ?: cause?.toString()
+                errorMessage = sanitizeErrorMessage(cause)
             )
+
+        internal fun sanitizeErrorMessage(cause: Throwable?): String? {
+            if (cause == null) return null
+
+            val source = cause.message
+                ?.takeIf { it.isNotBlank() }
+                ?: cause.javaClass.name
+
+            return source
+                .replace(URI_CREDENTIALS) { matchResult ->
+                    "${matchResult.groupValues[1]}<redacted>@"
+                }
+                .take(MAX_ERROR_MESSAGE_LENGTH)
+        }
     }
 }

--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/RateLimitValidation.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/RateLimitValidation.kt
@@ -35,8 +35,21 @@ internal inline fun toRateLimitResult(
     requestedTokens: Long,
 ): RateLimitResult {
     return if (probe.isConsumed) {
-        RateLimitResult.consumed(requestedTokens, probe.remainingTokens)
+        RateLimitResult.consumed(
+            consumedTokens = requestedTokens,
+            availableTokens = probe.remainingTokens,
+            diagnostics = RateLimitDiagnostics(
+                nanosToWaitForRefill = 0,
+                nanosToWaitForReset = probe.nanosToWaitForReset,
+            ),
+        )
     } else {
-        RateLimitResult.rejected(probe.remainingTokens)
+        RateLimitResult.rejected(
+            availableTokens = probe.remainingTokens,
+            diagnostics = RateLimitDiagnostics.rejected(
+                nanosToWaitForRefill = probe.nanosToWaitForRefill,
+                nanosToWaitForReset = probe.nanosToWaitForReset,
+            ),
+        )
     }
 }

--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/SuspendRateLimiter.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/SuspendRateLimiter.kt
@@ -1,12 +1,15 @@
 package io.bluetape4k.bucket4j.ratelimit
 
 /**
- * 코루틴 환경에서 토큰 소비를 제공하는 suspend rate limiter 인터페이스입니다.
+ * Coroutine-based rate limiter interface.
  *
- * ## 동작/계약
- * - [consume]은 대기 없이 즉시 소비를 시도하고 결과를 반환합니다.
- * - 성공/거절/오류 상태는 [RateLimitResult]로 표현됩니다.
- * - 코루틴 취소는 구현체가 가로채지 않고 호출자에게 전파해야 합니다.
+ * ## Contract
+ * - [consume] attempts immediate token consumption and returns without waiting
+ *   for token refill.
+ * - Success, rejection, and provider failure are represented by [RateLimitResult].
+ * - Coroutine cancellation must be propagated to the caller unchanged.
+ * - Distributed implementations may provide implementation-specific timeout
+ *   configuration for the underlying async store operation.
  *
  * ```kotlin
  * val result = suspendRateLimiter.consume("user:1", 1)
@@ -16,12 +19,13 @@ package io.bluetape4k.bucket4j.ratelimit
 interface SuspendRateLimiter<K> {
 
     /**
-     * 지정한 [key] 버킷에서 [numToken] 만큼 토큰을 비동기로 소비 시도합니다.
+     * Attempts to consume [numToken] tokens from the bucket identified by [key].
      *
-     * ## 동작/계약
-     * - [numToken] 기본값은 `1`입니다.
-     * - 소비 성공 시 consumed, 토큰 부족 시 rejected 결과를 반환합니다.
-     * - 코루틴 취소 시 `CancellationException`이 그대로 전파됩니다.
+     * ## Contract
+     * - [numToken] defaults to `1`.
+     * - Returns a consumed result on success and a rejected result when tokens
+     *   are insufficient.
+     * - Propagates `CancellationException` unchanged.
      *
      * ```kotlin
      * val result = suspendRateLimiter.consume("api-key", 2)

--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/distributed/DistributedSuspendRateLimiter.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/distributed/DistributedSuspendRateLimiter.kt
@@ -9,65 +9,80 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.future.await
+import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration
 
 /**
- * 분산 환경에서 즉시 소비 시도 계약을 제공하는 코루틴용 rate limiter 구현체입니다.
+ * Coroutine rate limiter for distributed Bucket4j async proxies.
  *
- * ## 동작/계약
- * - [consume]은 원격 버킷에 대해 대기 없는 즉시 소비를 시도합니다.
- * - 소비 결과와 잔여 토큰은 `ConsumptionProbe` 한 번의 조회 결과로 해석합니다.
- * - 코루틴 취소는 `ERROR`로 감싸지 않고 그대로 전파합니다.
+ * ## Contract
+ * - [consume] attempts immediate token consumption without waiting for refill.
+ * - Consumption outcome and remaining tokens are derived from one
+ *   `ConsumptionProbe`.
+ * - Coroutine cancellation is propagated unchanged.
+ * - [defaultTimeout] converts slow async store operations into an
+ *   [RateLimitResult.error] result; it is not a retry or refill wait timeout.
  *
  * ```kotlin
  * val rateLimiter = DistributedSuspendRateLimiter(asyncBucketProxyProvider)
  * val result: RateLimitResult = rateLimiter.consume("key", 1)
  *
  * when (result.status) {
- *     RateLimitStatus.CONSUMED -> {
- *         // Rate Limit 적용 성공
- *     }
- *     RateLimitStatus.REJECTED -> {
- *         // 토큰 부족으로 거절
- *     }
- *     RateLimitStatus.ERROR -> {
- *         // 오류 발생 시 result.errorMessage 확인
- *     }
+ *     RateLimitStatus.CONSUMED -> Unit
+ *     RateLimitStatus.REJECTED -> check(result.diagnostics.rejectionReason != null)
+ *     RateLimitStatus.ERROR -> check(result.errorMessage != null)
  * }
  * ```
  *
- * @property asyncBucketProxyProvider [AsyncBucketProxyProvider] 인스턴스.
- * 원격 저장소(Redis 등)에 연결된 async bucket proxy를 제공합니다.
+ * @property asyncBucketProxyProvider provider for async bucket proxies backed by
+ * a remote store such as Redis.
  */
-class DistributedSuspendRateLimiter(
+class DistributedSuspendRateLimiter @JvmOverloads constructor(
     private val asyncBucketProxyProvider: AsyncBucketProxyProvider,
+    private val defaultTimeout: Duration? = null,
 ): SuspendRateLimiter<String> {
 
     companion object: KLoggingChannel()
 
     /**
-     * [key] 기준으로 [numToken] 갯수만큼 즉시 소비 시도합니다. 결과는 [RateLimitResult]로 반환됩니다.
+     * Attempts immediate consumption of [numToken] tokens for [key].
      *
-     * ```kotlin
-     * val rateLimiter = DistributedSuspendRateLimiter(asyncBucketProxyProvider)
-     * val result = rateLimiter.consume("user-42", 1L)
-     * // result.isConsumed == true (토큰 여유가 있는 경우)
-     * // result.remainingTokens >= 0
-     * ```
-     *
-     * @param key      Rate Limit 적용 대상 Key
-     * @param numToken 소비할 토큰 수
-     * @return [RateLimitResult] 토큰 소비 결과
-     *
-     * @throws CancellationException 코루틴 취소 시 그대로 전파
+     * @throws CancellationException when the coroutine is cancelled.
      */
     override suspend fun consume(key: String, numToken: Long): RateLimitResult {
+        return consume(key, numToken, defaultTimeout)
+    }
+
+    /**
+     * Attempts immediate token consumption with an optional timeout for the
+     * underlying async distributed bucket operation.
+     *
+     * Timeout is reported as [RateLimitResult.error]. Coroutine cancellation is
+     * propagated unchanged.
+     *
+     * This overload is intentionally available on the concrete distributed
+     * implementation only. Code typed as [SuspendRateLimiter] should configure
+     * [defaultTimeout] on the bean instead.
+     */
+    suspend fun consume(key: String, numToken: Long, timeout: Duration?): RateLimitResult {
         validateRateLimitRequest(key, numToken)
         log.debug { "rate limit for key=$key, numToken=$numToken" }
 
         return try {
             val bucketProxy = asyncBucketProxyProvider.resolveBucket(key)
-            toRateLimitResult(bucketProxy.tryConsumeAndReturnRemaining(numToken).await(), numToken)
+            val probe = if (timeout == null) {
+                bucketProxy.tryConsumeAndReturnRemaining(numToken).await()
+            } else {
+                withTimeout(timeout) {
+                    bucketProxy.tryConsumeAndReturnRemaining(numToken).await()
+                }
+            }
+            toRateLimitResult(probe, numToken)
+        } catch (e: TimeoutCancellationException) {
+            log.warn(e) { "Rate Limiter timed out. key=$key" }
+            RateLimitResult.error(e)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/ConfigurationSupportTest.kt
+++ b/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/ConfigurationSupportTest.kt
@@ -3,6 +3,8 @@ package io.bluetape4k.bucket4j
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.github.bucket4j.Bucket
+import io.github.bucket4j.TokensInheritanceStrategy
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import io.bluetape4k.assertions.assertFailsWith
@@ -71,5 +73,33 @@ class ConfigurationSupportTest {
                 addBandwidth { error("bandwidth 생성 실패") }
             }
         }
+    }
+
+    @Test
+    fun `bandwidth id 는 configuration replacement 를 위해 보존된다`() {
+        val config = bucketConfiguration {
+            addLimit { it.capacity(10).refillGreedy(10, Duration.ofSeconds(1)).id("burst") }
+            addLimit { it.capacity(100).refillGreedy(100, Duration.ofMinutes(1)).id("sustained") }
+        }
+
+        config.bandwidths.map { it.id } shouldBeEqualTo listOf("burst", "sustained")
+    }
+
+    @Test
+    fun `identified bandwidth 는 replaceConfiguration 에서 proportional token 을 보존한다`() {
+        val initial = bucketConfiguration {
+            addLimit { it.capacity(10).refillGreedy(10, Duration.ofSeconds(1)).id("burst") }
+        }
+        val replacement = bucketConfiguration {
+            addLimit { it.capacity(20).refillGreedy(20, Duration.ofSeconds(1)).id("burst") }
+        }
+        val bucket = Bucket.builder()
+            .addLimit(initial.bandwidths.first())
+            .build()
+
+        bucket.tryConsume(5)
+        bucket.replaceConfiguration(replacement, TokensInheritanceStrategy.PROPORTIONALLY)
+
+        bucket.availableTokens shouldBeEqualTo 10
     }
 }

--- a/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/coroutines/SuspendedLocalBucketTest.kt
+++ b/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/coroutines/SuspendedLocalBucketTest.kt
@@ -7,6 +7,7 @@ import io.github.bucket4j.BandwidthBuilder
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -149,6 +150,20 @@ class SuspendedLocalBucketTest: AbstractBucket4jTest() {
             runCurrent() // delay 지점까지 진입
             job.cancelAndJoin()
             job.isCancelled.shouldBeTrue()
+        }
+
+        @Test
+        fun `대기 중 취소되면 CancellationException 을 전파한다`() = runTest {
+            val task = async {
+                bucket.consume(9L) // 최소 4초 대기
+            }
+
+            runCurrent()
+            task.cancel(CancellationException("cancel waiting bucket"))
+
+            assertFailsWith<CancellationException> {
+                task.await()
+            }
         }
     }
 }

--- a/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/distributed/AbstractAsyncBucketProxyProviderTest.kt
+++ b/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/distributed/AbstractAsyncBucketProxyProviderTest.kt
@@ -1,16 +1,17 @@
 package io.bluetape4k.bucket4j.distributed
 
+import io.bluetape4k.bucket4j.MAX_BUCKET_KEY_BYTES
 import io.bluetape4k.bucket4j.bucketConfiguration
-import io.bluetape4k.codec.Base58
-import io.bluetape4k.logging.coroutines.KLoggingChannel
-import kotlinx.coroutines.future.await
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
@@ -70,6 +71,26 @@ abstract class AbstractAsyncBucketProxyProviderTest {
     fun `빈 key 는 허용하지 않는다`() = runTest {
         assertFailsWith<IllegalArgumentException> {
             bucketProvider.resolveBucket(" ")
+        }
+    }
+
+    @Test
+    fun `serialized bucket key size cap 을 초과한 key 는 허용하지 않는다`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            bucketProvider.resolveBucket("x".repeat(MAX_BUCKET_KEY_BYTES + 1))
+        }
+    }
+
+    @Test
+    fun `serialized bucket key size cap 은 prefix 포함 경계값으로 적용한다`() = runTest {
+        val prefixBytes = AsyncBucketProxyProvider.DEFAULT_KEY_PREFIX.toByteArray().size
+        val maxKey = "x".repeat(MAX_BUCKET_KEY_BYTES - prefixBytes)
+        val oversizedKey = "x".repeat(MAX_BUCKET_KEY_BYTES - prefixBytes + 1)
+
+        bucketProvider.resolveBucket(maxKey).availableTokens.await() shouldBeEqualTo INITIAL_TOKEN
+
+        assertFailsWith<IllegalArgumentException> {
+            bucketProvider.resolveBucket(oversizedKey)
         }
     }
 }

--- a/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/distributed/AbstractBucketProxyProviderTest.kt
+++ b/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/distributed/AbstractBucketProxyProviderTest.kt
@@ -1,13 +1,14 @@
 package io.bluetape4k.bucket4j.distributed
 
+import io.bluetape4k.bucket4j.MAX_BUCKET_KEY_BYTES
 import io.bluetape4k.bucket4j.bucketConfiguration
-import io.bluetape4k.codec.Base58
-import io.bluetape4k.logging.KLogging
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.logging.KLogging
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
@@ -66,6 +67,26 @@ abstract class AbstractBucketProxyProviderTest {
     fun `빈 key 는 허용하지 않는다`() {
         assertFailsWith<IllegalArgumentException> {
             bucketProvider.resolveBucket(" ")
+        }
+    }
+
+    @Test
+    fun `serialized bucket key size cap 을 초과한 key 는 허용하지 않는다`() {
+        assertFailsWith<IllegalArgumentException> {
+            bucketProvider.resolveBucket("x".repeat(MAX_BUCKET_KEY_BYTES + 1))
+        }
+    }
+
+    @Test
+    fun `serialized bucket key size cap 은 prefix 포함 경계값으로 적용한다`() {
+        val prefixBytes = BucketProxyProvider.DEFAULT_KEY_PREFIX.toByteArray().size
+        val maxKey = "x".repeat(MAX_BUCKET_KEY_BYTES - prefixBytes)
+        val oversizedKey = "x".repeat(MAX_BUCKET_KEY_BYTES - prefixBytes + 1)
+
+        bucketProvider.resolveBucket(maxKey).availableTokens shouldBeEqualTo INITIAL_TOKEN
+
+        assertFailsWith<IllegalArgumentException> {
+            bucketProvider.resolveBucket(oversizedKey)
         }
     }
 }

--- a/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/distributed/redis/LettuceAsyncBucketProxyProviderTest.kt
+++ b/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/distributed/redis/LettuceAsyncBucketProxyProviderTest.kt
@@ -1,18 +1,22 @@
 package io.bluetape4k.bucket4j.distributed.redis
 
 import io.bluetape4k.bucket4j.TestRedisServer
+import io.bluetape4k.bucket4j.bucketConfiguration
 import io.bluetape4k.bucket4j.distributed.AbstractAsyncBucketProxyProviderTest
 import io.bluetape4k.bucket4j.distributed.AsyncBucketProxyProvider
 import io.bluetape4k.codec.Base58
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.github.bucket4j.TokensInheritanceStrategy
 import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy
 import io.github.bucket4j.distributed.proxy.ClientSideConfig
 import io.github.bucket4j.distributed.proxy.ExecutionStrategy
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.test.runTest
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotContain
 import org.junit.jupiter.api.Test
+import java.time.Duration
 import java.util.concurrent.Executors
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
@@ -64,5 +68,34 @@ class LettuceAsyncBucketProxyProviderTest: AbstractAsyncBucketProxyProviderTest(
         } finally {
             connection.close()
         }
+    }
+
+    @Test
+    fun `async proxy 는 identified bandwidth configuration replacement 를 지원한다`() = runTest {
+        val redisClient = TestRedisServer.lettuceClient()
+        val initial = bucketConfiguration {
+            addLimit { it.capacity(10).refillGreedy(10, Duration.ofSeconds(1)).id("burst") }
+        }
+        val replacement = bucketConfiguration {
+            addLimit { it.capacity(20).refillGreedy(20, Duration.ofSeconds(1)).id("burst") }
+        }
+        val proxyManager = lettuceBasedProxyManagerOf(redisClient) {
+            ClientSideConfig.getDefault()
+                .withExpirationAfterWriteStrategy(
+                    ExpirationAfterWriteStrategy.basedOnTimeForRefillingBucketUpToMax(90.seconds.toJavaDuration())
+                )
+                .withExecutionStrategy(ExecutionStrategy.background(Executors.newVirtualThreadPerTaskExecutor()))
+        }
+        val provider = AsyncBucketProxyProvider(
+            proxyManager.asAsync(),
+            initial,
+            "bluetape4k:rate-limit:replace:${Base58.randomString(6)}:",
+        )
+        val bucket = provider.resolveBucket("user-${Base58.randomString(6)}")
+
+        bucket.tryConsume(5).await().shouldBeTrue()
+        bucket.replaceConfiguration(replacement, TokensInheritanceStrategy.PROPORTIONALLY).await()
+
+        bucket.availableTokens.await() shouldBeEqualTo 10
     }
 }

--- a/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/distributed/redis/RedissonAsyncBucketProxyProviderTest.kt
+++ b/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/distributed/redis/RedissonAsyncBucketProxyProviderTest.kt
@@ -1,12 +1,21 @@
 package io.bluetape4k.bucket4j.distributed.redis
 
 import io.bluetape4k.bucket4j.TestRedisServer
+import io.bluetape4k.bucket4j.bucketConfiguration
 import io.bluetape4k.bucket4j.distributed.AbstractAsyncBucketProxyProviderTest
 import io.bluetape4k.bucket4j.distributed.AsyncBucketProxyProvider
+import io.bluetape4k.codec.Base58
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.github.bucket4j.TokensInheritanceStrategy
 import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy
 import io.github.bucket4j.distributed.proxy.ClientSideConfig
 import io.github.bucket4j.distributed.proxy.ExecutionStrategy
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.test.runTest
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.Test
+import java.time.Duration
 import java.util.concurrent.Executors
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
@@ -30,5 +39,34 @@ class RedissonAsyncBucketProxyProviderTest: AbstractAsyncBucketProxyProviderTest
         }
 
         AsyncBucketProxyProvider(redissonProxyManager.asAsync(), defaultBucketConfiguration)
+    }
+
+    @Test
+    fun `async proxy 는 identified bandwidth configuration replacement 를 지원한다`() = runTest {
+        val redisson = TestRedisServer.redissonClient()
+        val initial = bucketConfiguration {
+            addLimit { it.capacity(10).refillGreedy(10, Duration.ofSeconds(1)).id("burst") }
+        }
+        val replacement = bucketConfiguration {
+            addLimit { it.capacity(20).refillGreedy(20, Duration.ofSeconds(1)).id("burst") }
+        }
+        val proxyManager = redissonBasedProxyManagerOf(redisson) {
+            ClientSideConfig.getDefault()
+                .withExpirationAfterWriteStrategy(
+                    ExpirationAfterWriteStrategy.basedOnTimeForRefillingBucketUpToMax(90.seconds.toJavaDuration())
+                )
+                .withExecutionStrategy(ExecutionStrategy.background(Executors.newVirtualThreadPerTaskExecutor()))
+        }
+        val provider = AsyncBucketProxyProvider(
+            proxyManager.asAsync(),
+            initial,
+            "bluetape4k:rate-limit:replace:${Base58.randomString(6)}:",
+        )
+        val bucket = provider.resolveBucket("user-${Base58.randomString(6)}")
+
+        bucket.tryConsume(5).await().shouldBeTrue()
+        bucket.replaceConfiguration(replacement, TokensInheritanceStrategy.PROPORTIONALLY).await()
+
+        bucket.availableTokens.await() shouldBeEqualTo 10
     }
 }

--- a/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/local/AbstractLocalBucketProviderTest.kt
+++ b/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/local/AbstractLocalBucketProviderTest.kt
@@ -1,14 +1,15 @@
 package io.bluetape4k.bucket4j.local
 
-import io.bluetape4k.codec.Base58
-import io.bluetape4k.logging.KLogging
-import io.github.bucket4j.local.LocalBucket
+import io.bluetape4k.bucket4j.MAX_BUCKET_KEY_BYTES
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeEqualTo
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.logging.KLogging
+import io.github.bucket4j.local.LocalBucket
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 
 abstract class AbstractLocalBucketProviderTest {
 
@@ -59,6 +60,26 @@ abstract class AbstractLocalBucketProviderTest {
     fun `빈 key 는 허용하지 않는다`() {
         assertFailsWith<IllegalArgumentException> {
             bucketProvider.resolveBucket(" ")
+        }
+    }
+
+    @Test
+    fun `serialized bucket key size cap 을 초과한 key 는 허용하지 않는다`() {
+        assertFailsWith<IllegalArgumentException> {
+            bucketProvider.resolveBucket("x".repeat(MAX_BUCKET_KEY_BYTES + 1))
+        }
+    }
+
+    @Test
+    fun `serialized bucket key size cap 은 prefix 포함 경계값으로 적용한다`() {
+        val prefixBytes = AbstractLocalBucketProvider.DEFAULT_KEY_PREFIX.toByteArray().size
+        val maxKey = "x".repeat(MAX_BUCKET_KEY_BYTES - prefixBytes)
+        val oversizedKey = "x".repeat(MAX_BUCKET_KEY_BYTES - prefixBytes + 1)
+
+        bucketProvider.resolveBucket(maxKey)
+
+        assertFailsWith<IllegalArgumentException> {
+            bucketProvider.resolveBucket(oversizedKey)
         }
     }
 }

--- a/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/ratelimit/RateLimitResultTest.kt
+++ b/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/ratelimit/RateLimitResultTest.kt
@@ -1,11 +1,18 @@
 package io.bluetape4k.bucket4j.ratelimit
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotContain
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import java.time.Duration
 
 class RateLimitResultTest {
     @Test
@@ -15,6 +22,8 @@ class RateLimitResultTest {
         result.status shouldBeEqualTo RateLimitStatus.CONSUMED
         result.consumedTokens shouldBeEqualTo 2
         result.availableTokens shouldBeEqualTo 8
+        result.diagnostics shouldBeEqualTo RateLimitDiagnostics.EMPTY
+        result.retryAfter.shouldBeNull()
         result.isConsumed.shouldBeTrue()
         result.isRejected.shouldBeFalse()
         result.isError.shouldBeFalse()
@@ -22,11 +31,21 @@ class RateLimitResultTest {
 
     @Test
     fun `rejected factory 는 consumedTokens 를 0으로 고정한다`() {
-        val result = RateLimitResult.rejected(availableTokens = 3)
+        val result = RateLimitResult.rejected(
+            availableTokens = 3,
+            diagnostics = RateLimitDiagnostics.rejected(
+                nanosToWaitForRefill = 1_000,
+                nanosToWaitForReset = 10_000,
+            ),
+        )
 
         result.status shouldBeEqualTo RateLimitStatus.REJECTED
         result.consumedTokens shouldBeEqualTo 0
         result.availableTokens shouldBeEqualTo 3
+        result.diagnostics.nanosToWaitForRefill shouldBeEqualTo 1_000
+        result.diagnostics.nanosToWaitForReset shouldBeEqualTo 10_000
+        result.diagnostics.rejectionReason shouldBeEqualTo RateLimitRejectionReason.INSUFFICIENT_TOKENS
+        result.retryAfter shouldBeEqualTo Duration.ofNanos(1_000)
         result.isConsumed.shouldBeFalse()
         result.isRejected.shouldBeTrue()
         result.isError.shouldBeFalse()
@@ -57,7 +76,7 @@ class RateLimitResultTest {
     }
 
     @Test
-    fun `error factory 는 예외 메시지가 없으면 예외 타입 정보를 보존한다`() {
+    fun `error factory 는 예외 메시지가 없으면 예외 타입 이름을 보존한다`() {
         val result = RateLimitResult.error(IllegalStateException())
 
         result.status shouldBeEqualTo RateLimitStatus.ERROR
@@ -65,30 +84,40 @@ class RateLimitResultTest {
     }
 
     @Test
-    @Suppress("DEPRECATION")
-    fun `deprecated 생성자는 consumedTokens 가 양수이면 consumed 로 해석한다`() {
-        val result = RateLimitResult(consumedTokens = 3, availableTokens = 7)
+    fun `error factory 는 URI credential 을 redaction 한다`() {
+        val result = RateLimitResult.error(
+            IllegalStateException("redis://user:secret@localhost:6379 is unavailable")
+        )
 
-        result.status shouldBeEqualTo RateLimitStatus.CONSUMED
-        result.isConsumed.shouldBeTrue()
-        result.consumedTokens shouldBeEqualTo 3
-        result.availableTokens shouldBeEqualTo 7
+        result.errorMessage.shouldNotContain("secret")
+        result.errorMessage shouldBeEqualTo "redis://<redacted>@localhost:6379 is unavailable"
     }
 
     @Test
-    @Suppress("DEPRECATION")
-    fun `deprecated 생성자는 consumedTokens 가 0이면 rejected 로 해석한다`() {
-        val result = RateLimitResult(consumedTokens = 0, availableTokens = 4)
+    fun `error factory 는 at sign 을 포함한 URI credential 을 redaction 한다`() {
+        val result = RateLimitResult.error(
+            IllegalStateException("redis://user:p@ss@localhost:6379 is unavailable")
+        )
 
-        result.status shouldBeEqualTo RateLimitStatus.REJECTED
-        result.isRejected.shouldBeTrue()
+        result.errorMessage.shouldNotContain("p@ss")
+        result.errorMessage shouldBeEqualTo "redis://<redacted>@localhost:6379 is unavailable"
     }
 
     @Test
-    @Suppress("DEPRECATION")
-    fun `deprecated 생성자는 음수 consumedTokens 를 허용하지 않는다`() {
+    fun `error factory 는 public message 를 256자로 제한한다`() {
+        val result = RateLimitResult.error(IllegalStateException("x".repeat(300)))
+
+        result.errorMessage?.length shouldBeEqualTo 256
+    }
+
+    @Test
+    fun `primary constructor 는 음수 consumedTokens 를 허용하지 않는다`() {
         assertFailsWith<IllegalArgumentException> {
-            RateLimitResult(consumedTokens = -1, availableTokens = 4)
+            RateLimitResult(
+                status = RateLimitStatus.CONSUMED,
+                consumedTokens = -1,
+                availableTokens = 4,
+            )
         }
     }
 
@@ -101,6 +130,65 @@ class RateLimitResultTest {
                 availableTokens = -1,
             )
         }
+    }
+
+    @Test
+    fun `rejectionReason 은 rejected 결과에만 허용된다`() {
+        assertFailsWith<IllegalArgumentException> {
+            RateLimitResult.consumed(
+                consumedTokens = 1,
+                availableTokens = 1,
+                diagnostics = RateLimitDiagnostics(
+                    rejectionReason = RateLimitRejectionReason.INSUFFICIENT_TOKENS
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `retryAfter 는 refill nanos 가 0이면 null 이다`() {
+        val result = RateLimitResult.rejected(
+            availableTokens = 0,
+            diagnostics = RateLimitDiagnostics.rejected(
+                nanosToWaitForRefill = 0,
+                nanosToWaitForReset = 5_000,
+            ),
+        )
+
+        result.retryAfter.shouldBeNull()
+    }
+
+    @Test
+    fun `diagnostics 는 음수 nanos 를 허용하지 않는다`() {
+        assertFailsWith<IllegalArgumentException> {
+            RateLimitDiagnostics(nanosToWaitForRefill = -1)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            RateLimitDiagnostics(nanosToWaitForReset = -1)
+        }
+    }
+
+    @Test
+    fun `result 와 diagnostics 는 Java serialization round trip 을 지원한다`() {
+        val source = RateLimitResult.rejected(
+            availableTokens = 0,
+            diagnostics = RateLimitDiagnostics.rejected(
+                nanosToWaitForRefill = 1_000,
+                nanosToWaitForReset = 10_000,
+            ),
+        )
+
+        val bytes = ByteArrayOutputStream().use { bytes ->
+            ObjectOutputStream(bytes).use { it.writeObject(source) }
+            bytes.toByteArray()
+        }
+        val restored = ObjectInputStream(ByteArrayInputStream(bytes)).use {
+            it.readObject() as RateLimitResult
+        }
+
+        restored shouldBeEqualTo source
+        restored.errorMessage.shouldBeNull()
+        restored.toString() shouldContain "RateLimitResult"
     }
 
     @Test
@@ -119,5 +207,6 @@ class RateLimitResultTest {
         result.status shouldBeEqualTo RateLimitStatus.REJECTED
         result.consumedTokens shouldBeEqualTo 0
         result.availableTokens shouldBeEqualTo 3
+        result.diagnostics.rejectionReason shouldBeEqualTo RateLimitRejectionReason.INSUFFICIENT_TOKENS
     }
 }

--- a/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/ratelimit/RateLimiterProbeUsageTest.kt
+++ b/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/ratelimit/RateLimiterProbeUsageTest.kt
@@ -28,13 +28,15 @@ class RateLimiterProbeUsageTest {
         val bucketProvider = mockk<LocalBucketProvider>()
         val bucket = mockk<LocalBucket>()
         every { bucketProvider.resolveBucket("user:1") } returns bucket
-        every { bucket.tryConsumeAndReturnRemaining(3) } returns ConsumptionProbe.consumed(7, 0)
+        every { bucket.tryConsumeAndReturnRemaining(3) } returns ConsumptionProbe.consumed(7, 123)
 
         val result = LocalRateLimiter(bucketProvider).consume("user:1", 3)
 
         result.status shouldBeEqualTo RateLimitStatus.CONSUMED
         result.consumedTokens shouldBeEqualTo 3
         result.availableTokens shouldBeEqualTo 7
+        result.diagnostics.nanosToWaitForRefill shouldBeEqualTo 0
+        result.diagnostics.nanosToWaitForReset shouldBeEqualTo 123
 
         verify(exactly = 1) { bucket.tryConsumeAndReturnRemaining(3) }
         verify(exactly = 0) { bucket.availableTokens }
@@ -45,13 +47,16 @@ class RateLimiterProbeUsageTest {
         val bucketProvider = mockk<BucketProxyProvider>()
         val bucket = mockk<BucketProxy>()
         every { bucketProvider.resolveBucket("user:1") } returns bucket
-        every { bucket.tryConsumeAndReturnRemaining(2) } returns ConsumptionProbe.rejected(8, 11, 11)
+        every { bucket.tryConsumeAndReturnRemaining(2) } returns ConsumptionProbe.rejected(8, 11, 22)
 
         val result = DistributedRateLimiter(bucketProvider).consume("user:1", 2)
 
         result.status shouldBeEqualTo RateLimitStatus.REJECTED
         result.consumedTokens shouldBeEqualTo 0
         result.availableTokens shouldBeEqualTo 8
+        result.diagnostics.nanosToWaitForRefill shouldBeEqualTo 11
+        result.diagnostics.nanosToWaitForReset shouldBeEqualTo 22
+        result.diagnostics.rejectionReason shouldBeEqualTo RateLimitRejectionReason.INSUFFICIENT_TOKENS
 
         verify(exactly = 1) { bucket.tryConsumeAndReturnRemaining(2) }
         verify(exactly = 0) { bucket.availableTokens }
@@ -62,13 +67,15 @@ class RateLimiterProbeUsageTest {
         val bucketProvider = mockk<LocalSuspendBucketProvider>()
         val bucket = mockk<SuspendLocalBucket>()
         every { bucketProvider.resolveBucket("user:1") } returns bucket
-        every { bucket.tryConsumeAndReturnRemaining(4) } returns ConsumptionProbe.consumed(6, 0)
+        every { bucket.tryConsumeAndReturnRemaining(4) } returns ConsumptionProbe.consumed(6, 456)
 
         val result = LocalSuspendRateLimiter(bucketProvider).consume("user:1", 4)
 
         result.status shouldBeEqualTo RateLimitStatus.CONSUMED
         result.consumedTokens shouldBeEqualTo 4
         result.availableTokens shouldBeEqualTo 6
+        result.diagnostics.nanosToWaitForRefill shouldBeEqualTo 0
+        result.diagnostics.nanosToWaitForReset shouldBeEqualTo 456
 
         verify(exactly = 1) { bucket.tryConsumeAndReturnRemaining(4) }
         verify(exactly = 0) { bucket.availableTokens }

--- a/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/ratelimit/distributed/LettuceSuspendRateLimiterTest.kt
+++ b/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/ratelimit/distributed/LettuceSuspendRateLimiterTest.kt
@@ -6,18 +6,24 @@ import io.bluetape4k.bucket4j.distributed.redis.lettuceBasedProxyManagerOf
 import io.bluetape4k.bucket4j.ratelimit.AbstractSuspendRateLimiterTest
 import io.bluetape4k.bucket4j.ratelimit.RateLimitStatus
 import io.bluetape4k.bucket4j.ratelimit.SuspendRateLimiter
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.github.bucket4j.ConsumptionProbe
+import io.github.bucket4j.distributed.AsyncBucketProxy
 import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy
 import io.github.bucket4j.distributed.proxy.ClientSideConfig
 import io.github.bucket4j.distributed.proxy.ExecutionStrategy
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
-import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
-import io.bluetape4k.assertions.assertFailsWith
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
@@ -64,5 +70,46 @@ class LettuceSuspendRateLimiterTest: AbstractSuspendRateLimiterTest() {
         assertFailsWith<CancellationException> {
             limiter.consume(randomKey(), 1)
         }
+    }
+
+    @Test
+    fun `distributed await 중 취소되면 CancellationException 을 전파한다`() = runTest {
+        val bucket = mockk<AsyncBucketProxy>()
+        val pending = CompletableFuture<ConsumptionProbe>()
+        every { bucket.tryConsumeAndReturnRemaining(any()) } returns pending
+
+        val provider = mockk<AsyncBucketProxyProvider>()
+        every { provider.resolveBucket(any()) } returns bucket
+
+        val limiter = DistributedSuspendRateLimiter(provider)
+        val task = async {
+            limiter.consume(randomKey(), 1)
+        }
+
+        task.cancel(CancellationException("cancel distributed wait"))
+
+        assertFailsWith<CancellationException> {
+            task.await()
+        }
+    }
+
+    @Test
+    fun `distributed await timeout 은 error 결과로 반환한다`() = runTest {
+        val bucket = mockk<AsyncBucketProxy>()
+        val pending = CompletableFuture<ConsumptionProbe>()
+        every { bucket.tryConsumeAndReturnRemaining(any()) } returns pending
+
+        val provider = mockk<AsyncBucketProxyProvider>()
+        every { provider.resolveBucket(any()) } returns bucket
+
+        val limiter = DistributedSuspendRateLimiter(provider, defaultTimeout = 10.milliseconds)
+        val deferred = async {
+            limiter.consume(randomKey(), 1)
+        }
+
+        advanceTimeBy(10.milliseconds)
+
+        val result = deferred.await()
+        result.status shouldBeEqualTo RateLimitStatus.ERROR
     }
 }


### PR DESCRIPTION
## Summary

Closes #434

- PR 제목: feat: harden bucket4j rate-limit facade

- Add stable `RateLimitDiagnostics`, `RateLimitRejectionReason`, and rejected-result `retryAfter` to the Bucket4j facade.
- Remove the deprecated `RateLimitResult(consumedTokens, availableTokens)` constructor and update the deprecated infra inventory.
- Enforce a 512-byte prefixed bucket-key limit across local and distributed providers.
- Add distributed suspend timeout support while preserving Java one-argument constructor ergonomics with `@JvmOverloads`.
- Refresh English/Korean README docs, CHANGELOG, design/plan artifacts, and lesson notes.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Breaking Changes

- `RateLimitResult` primary constructor/data-class shape changed by adding `diagnostics`.
- The deprecated secondary constructor `RateLimitResult(consumedTokens, availableTokens)` was removed.

### 기존 섹션: Verification

- `./gradlew :bluetape4k-bucket4j:compileTestKotlin --no-configuration-cache`
- `./gradlew :bluetape4k-bucket4j:test --no-configuration-cache --rerun-tasks` (121 passing)
- `./gradlew :bluetape4k-bucket4j:koverVerify :bluetape4k-bucket4j:koverXmlReport --no-configuration-cache`
- `git diff --check`
- `javap` confirmed `DistributedSuspendRateLimiter(AsyncBucketProxyProvider)` remains available
- Claude review: no P0/P1 findings; low-risk P2 suggestions were applied

Closes #434

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #434, milestone 없음, assignee `debop`
- PR: #442, head `0603b174f8da2f842f5aae6f25bc1927e72d467e`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/issue-434-bucket4j-facade`
- Labels: `enhancement`, `design`, `refactor`
- State: `MERGED`, merge commit `c8e0b425055a81e4ce90d83f2cd0fd34f89c00ee`
- CI: - `./gradlew :bluetape4k-bucket4j:compileTestKotlin --no-configuration-cache` / - `./gradlew :bluetape4k-bucket4j:test --no-configuration-cache --rerun-tasks` (121 passing) / - `./gradlew :bluetape4k-bucket4j:koverVerify :bluetape4k-bucket4j:koverXmlReport --no-configuration-cache`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #442 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `c8e0b425055a81e4ce90d83f2cd0fd34f89c00ee`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
