### PR TITLE
build: migrate supported Jackson consumers to Jackson3

### DIFF
--- a/data/cassandra/build.gradle.kts
+++ b/data/cassandra/build.gradle.kts
@@ -24,7 +24,7 @@ configurations {
 dependencies {
     api(project(":bluetape4k-io"))
     api(project(":bluetape4k-coroutines"))
-    testImplementation(project(":bluetape4k-jackson2"))
+    testImplementation(project(":bluetape4k-jackson3"))
     testImplementation(project(":bluetape4k-junit5"))
     testImplementation(project(":bluetape4k-testcontainers"))
 

--- a/data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/examples/json/JacksonJsonFunctionExamples.kt
+++ b/data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/examples/json/JacksonJsonFunctionExamples.kt
@@ -7,8 +7,6 @@ import com.datastax.oss.driver.api.querybuilder.QueryBuilder.function
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder.insertInto
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder.selectFrom
 import com.datastax.oss.driver.api.querybuilder.select.Selector
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import io.bluetape4k.cassandra.AbstractCassandraTest
 import io.bluetape4k.cassandra.CqlSessionProvider
 import io.bluetape4k.cassandra.cql.getStringOrEmpty
@@ -17,9 +15,9 @@ import io.bluetape4k.cassandra.data.setValue
 import io.bluetape4k.cassandra.querybuilder.bindMarker
 import io.bluetape4k.cassandra.querybuilder.inValues
 import io.bluetape4k.cassandra.querybuilder.literal
-import io.bluetape4k.jackson.Jackson
-import io.bluetape4k.jackson.readValueOrNull
-import io.bluetape4k.jackson.writeAsString
+import io.bluetape4k.jackson3.Jackson
+import io.bluetape4k.jackson3.readValueOrNull
+import io.bluetape4k.jackson3.writeAsString
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.assertions.shouldBeEqualTo
@@ -27,6 +25,8 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.JsonNodeFactory
 import java.io.Serializable
 
 class JacksonJsonFunctionExamples: AbstractCassandraTest() {

--- a/data/hibernate-reactive/build.gradle.kts
+++ b/data/hibernate-reactive/build.gradle.kts
@@ -90,7 +90,7 @@ dependencies {
     // Converter 사용 시
     // compileOnly(project(":bluetape4k-crypto"))
     compileOnly(project(":bluetape4k-tink"))
-    testImplementation(project(":bluetape4k-jackson2"))
+    testImplementation(project(":bluetape4k-jackson3"))
 
     testImplementation(libs.kryo)
     testImplementation(libs.fory.kotlin)  // new Apache Fory

--- a/data/hibernate/build.gradle.kts
+++ b/data/hibernate/build.gradle.kts
@@ -117,9 +117,9 @@ dependencies {
     // Converter
     // compileOnly(project(":bluetape4k-crypto"))
     compileOnly(project(":bluetape4k-tink"))
-    compileOnly(project(":bluetape4k-jackson2"))
-    compileOnly(libs.jackson.module.kotlin)
-    compileOnly(libs.jackson.module.blackbird)
+    compileOnly(project(":bluetape4k-jackson3"))
+    compileOnly(libs.jackson3.module.kotlin)
+    compileOnly(libs.jackson3.module.blackbird)
 
     compileOnly(libs.kryo)
     compileOnly(libs.fory.kotlin)  // new Apache Fory

--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/AbstractObjectAsJsonConverter.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/AbstractObjectAsJsonConverter.kt
@@ -1,13 +1,13 @@
 package io.bluetape4k.hibernate.converters
 
-import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.json.JsonMapper
-import io.bluetape4k.jackson.Jackson
+import io.bluetape4k.jackson3.Jackson
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
 import io.bluetape4k.logging.trace
 import jakarta.persistence.AttributeConverter
 import jakarta.persistence.Converter
+import tools.jackson.core.JacksonException
+import tools.jackson.databind.json.JsonMapper
 
 /**
  * Object를 JSON 포맷으로 렌더링된 문자열로 저장하고, 로드 시에는 원래 Object로 변환하는 Converter 입니다.
@@ -42,7 +42,7 @@ abstract class AbstractObjectAsJsonConverter<T: Any>(
 
         return try {
             attribute?.run { jsonMapper.writeValueAsString(this) }
-        } catch (e: JsonProcessingException) {
+        } catch (e: JacksonException) {
             log.error(e) { "Fail to write as json string. $attribute" }
             null
         }
@@ -53,7 +53,7 @@ abstract class AbstractObjectAsJsonConverter<T: Any>(
 
         return try {
             dbData?.run { jsonMapper.readValue(this, classType) }
-        } catch (e: JsonProcessingException) {
+        } catch (e: JacksonException) {
             log.error(e) { "Fail to read json string. $dbData" }
             null
         }

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/converter/JsonStringConverterTest.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/converter/JsonStringConverterTest.kt
@@ -1,13 +1,13 @@
 package io.bluetape4k.hibernate.converter
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.module.kotlin.treeToValue
 import io.bluetape4k.hibernate.AbstractHibernateTest
-import io.bluetape4k.jackson.Jackson
+import io.bluetape4k.jackson3.Jackson
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import org.junit.jupiter.api.Test
+import tools.jackson.databind.JsonNode
+import tools.jackson.module.kotlin.treeToValue
 
 class JsonStringConverterTest: AbstractHibernateTest() {
 

--- a/data/mongodb/build.gradle.kts
+++ b/data/mongodb/build.gradle.kts
@@ -6,7 +6,7 @@ configurations {
 dependencies {
     api(project(":bluetape4k-io"))
     api(project(":bluetape4k-coroutines"))
-    testImplementation(project(":bluetape4k-jackson2"))
+    testImplementation(project(":bluetape4k-jackson3"))
     testImplementation(project(":bluetape4k-junit5"))
     testImplementation(project(":bluetape4k-testcontainers"))
     testImplementation(libs.testcontainers.mongodb)

--- a/data/r2dbc/build.gradle.kts
+++ b/data/r2dbc/build.gradle.kts
@@ -104,8 +104,8 @@ dependencies {
     testImplementation(project(":bluetape4k-junit5"))
 
     // Jackson
-    compileOnly(project(":bluetape4k-jackson2"))
-    compileOnly(libs.jackson.module.kotlin)
+    compileOnly(project(":bluetape4k-jackson3"))
+    compileOnly(libs.jackson3.module.kotlin)
 
     // Coroutines
     api(project(":bluetape4k-coroutines"))

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/convert/postgresql/JsonToMapConverter.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/convert/postgresql/JsonToMapConverter.kt
@@ -1,13 +1,13 @@
 package io.bluetape4k.r2dbc.convert.postgresql
 
-import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
 import io.r2dbc.postgresql.codec.Json
 import org.springframework.core.convert.converter.Converter
 import org.springframework.data.convert.ReadingConverter
+import tools.jackson.core.JacksonException
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.readValue
 
 /**
  * PostgreSQL의 Json 타입을 Map\<String, Any?\>로 변환하는 Converter입니다.
@@ -22,7 +22,7 @@ class JsonToMapConverter(private val mapper: ObjectMapper): Converter<Json, Map<
     override fun convert(source: Json): Map<String, Any?> {
         return try {
             mapper.readValue(source.asString())
-        } catch (e: JsonProcessingException) {
+        } catch (e: JacksonException) {
             log.error(e) { "Fail to parse Json: $source" }
             emptyMap()
         }

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/convert/postgresql/MapToJsonConverter.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/convert/postgresql/MapToJsonConverter.kt
@@ -1,12 +1,12 @@
 package io.bluetape4k.r2dbc.convert.postgresql
 
-import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.ObjectMapper
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
 import io.r2dbc.postgresql.codec.Json
 import org.springframework.core.convert.converter.Converter
 import org.springframework.data.convert.WritingConverter
+import tools.jackson.core.JacksonException
+import tools.jackson.databind.ObjectMapper
 
 /**
  * Map\<String, Any?\>를 PostgreSQL의 Json 타입으로 변환하는 Converter입니다.
@@ -28,7 +28,7 @@ class MapToJsonConverter(
      */
     override fun convert(source: Map<String, Any?>): Json = try {
         Json.of(mapper.writeValueAsString(source))
-    } catch (e: JsonProcessingException) {
+    } catch (e: JacksonException) {
         log.error(e) { "Fail to serialize map to Json. source=$source" }
         Json.of("{}")
     }

--- a/docs/lessons/2026-05-14-issue-446-jackson3-consumers.md
+++ b/docs/lessons/2026-05-14-issue-446-jackson3-consumers.md
@@ -1,0 +1,30 @@
+# Issue 446 Jackson3 Consumers
+
+## Context
+
+Spring Boot 4 uses Jackson 3, so supported modules that only consumed
+`bluetape4k-jackson2` were migrated to `bluetape4k-jackson3`.
+
+## Decision
+
+Convert modules whose local code or dependencies can compile against
+`tools.jackson.*` and `io.bluetape4k.jackson3.*`. Keep upstream integrations
+that still require Jackson 2, such as Retrofit's Jackson converter, JJWT
+Jackson, and Spring Kafka 3.x converters.
+
+## Outcome
+
+Supported data, IO, Feign, HTTP, Vert.x, NATS, Micrometer, gRPC, Cassandra,
+Hibernate, MongoDB, R2DBC, Geo, and Redisson demo dependencies now use
+Jackson3. Jackson2-only upstream integrations remain unchanged.
+
+## Verification
+
+- `./gradlew :bluetape4k-cassandra:testClasses :bluetape4k-hibernate:testClasses :bluetape4k-hibernate-reactive:testClasses :bluetape4k-mongodb:testClasses :bluetape4k-r2dbc:testClasses :bluetape4k-examples-redisson-demo:testClasses :bluetape4k-micrometer:testClasses :bluetape4k-nats:testClasses :bluetape4k-feign:testClasses :bluetape4k-grpc:testClasses :bluetape4k-http:testClasses :bluetape4k-vertx:testClasses :bluetape4k-geo:testClasses`
+- `./gradlew :bluetape4k-geo:testClasses`
+
+## Future Notes
+
+Do not migrate a module just because it references Jackson2 by name. First
+check whether upstream adapters expose a Jackson3 API on the actual resolved
+classpath.

--- a/examples/redisson-demo/build.gradle.kts
+++ b/examples/redisson-demo/build.gradle.kts
@@ -33,10 +33,10 @@ dependencies {
     testImplementation(libs.caffeine.jcache)
 
     // JSON
-    testImplementation(project(":bluetape4k-jackson2"))
-    testImplementation(libs.jackson.module.kotlin)
-    testImplementation(libs.jackson.module.blackbird)
-    testImplementation(libs.jackson.dataformat.protobuf)
+    testImplementation(project(":bluetape4k-jackson3"))
+    testImplementation(libs.jackson3.module.kotlin)
+    testImplementation(libs.jackson3.module.blackbird)
+    testImplementation(libs.jackson3.dataformat.protobuf)
 
     // Coroutines
     testImplementation(project(":bluetape4k-coroutines"))

--- a/infra/micrometer/build.gradle.kts
+++ b/infra/micrometer/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     api(project(":bluetape4k-core"))
     implementation(project(":bluetape4k-cache-core"))
     testImplementation(project(":bluetape4k-http"))
-    testImplementation(project(":bluetape4k-jackson2"))
+    testImplementation(project(":bluetape4k-jackson3"))
     testImplementation(project(":bluetape4k-junit5"))
     testImplementation(project(":bluetape4k-testcontainers"))
 
@@ -50,9 +50,9 @@ dependencies {
 
 
     // Jackson 2
-    implementation(project(":bluetape4k-jackson2"))
-    implementation(libs.jackson.module.kotlin)
-    implementation(libs.jackson.module.blackbird)
+    implementation(project(":bluetape4k-jackson3"))
+    implementation(libs.jackson3.module.kotlin)
+    implementation(libs.jackson3.module.blackbird)
 
     implementation(libs.vertx.core)
     testImplementation(project(":bluetape4k-vertx"))

--- a/infra/nats/build.gradle.kts
+++ b/infra/nats/build.gradle.kts
@@ -20,11 +20,11 @@ dependencies {
     compileOnly(libs.kotlinx.coroutines.reactor)
     testImplementation(libs.kotlinx.coroutines.test)
 
-    // Jackson (테스트 페이로드 인코딩용) — bluetape4k-jackson2가 나머지 전이 포함
-    testImplementation(project(":bluetape4k-jackson2"))
-    testImplementation(libs.jackson.databind)
-    testImplementation(libs.jackson.module.kotlin)
-    compileOnly(libs.jackson.module.blackbird)
+    // Jackson (테스트 페이로드 인코딩용) — bluetape4k-jackson3가 나머지 전이 포함
+    testImplementation(project(":bluetape4k-jackson3"))
+    testImplementation(libs.jackson3.databind)
+    testImplementation(libs.jackson3.module.kotlin)
+    compileOnly(libs.jackson3.module.blackbird)
 
     // Compressors / Serializers (테스트 페이로드용)
     testImplementation(libs.lz4.java)

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/examples/EncodingExample.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/examples/EncodingExample.kt
@@ -1,9 +1,8 @@
 package io.bluetape4k.nats.client.examples
 
-import com.fasterxml.jackson.module.kotlin.readValue
 import io.bluetape4k.io.serializer.BinarySerializer
 import io.bluetape4k.io.serializer.BinarySerializers
-import io.bluetape4k.jackson.Jackson
+import io.bluetape4k.jackson3.Jackson
 import io.bluetape4k.junit5.faker.Fakers
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
@@ -14,6 +13,7 @@ import io.nats.client.JetStream
 import io.nats.client.api.StorageType
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Nested
+import tools.jackson.module.kotlin.readValue
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest

--- a/io/feign/build.gradle.kts
+++ b/io/feign/build.gradle.kts
@@ -63,12 +63,12 @@ dependencies {
     compileOnly(libs.vertx.lang.kotlin)
     compileOnly(libs.vertx.lang.kotlin.coroutines)
 
-    // Jackson (2.14 와 2.13 이 혼용되어서 jackson-core, jackson-databind 를 모두 지정해주어야 한다)
-    api(project(":bluetape4k-jackson2"))
-    api(libs.jackson.core)
-    api(libs.jackson.databind)
-    api(libs.jackson.module.kotlin)
-    compileOnly(libs.jackson.module.blackbird)
+    // Jackson
+    api(project(":bluetape4k-jackson3"))
+    api(libs.jackson3.core)
+    api(libs.jackson3.databind)
+    api(libs.jackson3.module.kotlin)
+    compileOnly(libs.jackson3.module.blackbird)
 
     // Fastjson2
     compileOnly(project(":bluetape4k-fastjson2"))

--- a/io/feign/src/main/kotlin/io/bluetape4k/feign/codec/JacksonDecoder2.kt
+++ b/io/feign/src/main/kotlin/io/bluetape4k/feign/codec/JacksonDecoder2.kt
@@ -1,8 +1,5 @@
 package io.bluetape4k.feign.codec
 
-import com.fasterxml.jackson.core.JsonParseException
-import com.fasterxml.jackson.databind.json.JsonMapper
-import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import feign.Response
 import feign.Util
 import feign.codec.DecodeException
@@ -10,12 +7,15 @@ import feign.codec.Decoder
 import feign.codec.DefaultDecoder
 import io.bluetape4k.feign.bodyAsReader
 import io.bluetape4k.feign.isJsonBody
-import io.bluetape4k.jackson.Jackson
+import io.bluetape4k.jackson3.Jackson
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.error
 import io.bluetape4k.logging.trace
 import io.bluetape4k.support.closeSafe
+import tools.jackson.core.exc.StreamReadException
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.jacksonTypeRef
 import java.io.BufferedReader
 import java.io.IOException
 import java.io.Reader
@@ -109,7 +109,7 @@ class JacksonDecoder2 private constructor(
             reader.reset()
             log.trace { "Read json format response body. target type=$type" }
             return mapper.readValue(reader, mapper.constructType(type))
-        } catch (e: JsonParseException) {
+        } catch (e: StreamReadException) {
             log.error(e) { "Fail to read json format response body. type=$type" }
 
             if (e.cause is IOException) {

--- a/io/feign/src/main/kotlin/io/bluetape4k/feign/codec/JacksonEncoder2.kt
+++ b/io/feign/src/main/kotlin/io/bluetape4k/feign/codec/JacksonEncoder2.kt
@@ -1,12 +1,12 @@
 package io.bluetape4k.feign.codec
 
-import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.json.JsonMapper
 import feign.RequestTemplate
 import feign.codec.EncodeException
 import feign.codec.Encoder
-import io.bluetape4k.jackson.Jackson
+import io.bluetape4k.jackson3.Jackson
 import io.bluetape4k.logging.KLogging
+import tools.jackson.core.JacksonException
+import tools.jackson.databind.json.JsonMapper
 import java.lang.reflect.Type
 
 /**
@@ -60,7 +60,7 @@ class JacksonEncoder2 private constructor(
         try {
             val javaType = mapper.typeFactory.constructType(bodyType)
             template.body(mapper.writerFor(javaType).writeValueAsBytes(obj), Charsets.UTF_8)
-        } catch (e: JsonProcessingException) {
+        } catch (e: JacksonException) {
             throw EncodeException(e.message, e)
         }
     }

--- a/io/feign/src/main/kotlin/io/bluetape4k/feign/codec/JacksonIteratorDecoder2.kt
+++ b/io/feign/src/main/kotlin/io/bluetape4k/feign/codec/JacksonIteratorDecoder2.kt
@@ -1,10 +1,5 @@
 package io.bluetape4k.feign.codec
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.core.JsonToken
-import com.fasterxml.jackson.databind.ObjectReader
-import com.fasterxml.jackson.databind.RuntimeJsonMappingException
-import com.fasterxml.jackson.databind.json.JsonMapper
 import feign.Response
 import feign.Util
 import feign.codec.DecodeException
@@ -12,10 +7,15 @@ import feign.codec.Decoder
 import feign.codec.DefaultDecoder
 import io.bluetape4k.feign.bodyAsReader
 import io.bluetape4k.feign.isJsonBody
-import io.bluetape4k.jackson.Jackson
+import io.bluetape4k.jackson3.Jackson
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.actualIteratorTypeArgument
 import io.bluetape4k.support.closeSafe
+import tools.jackson.core.JacksonException
+import tools.jackson.core.JsonParser
+import tools.jackson.core.JsonToken
+import tools.jackson.databind.ObjectReader
+import tools.jackson.databind.json.JsonMapper
 import java.io.BufferedReader
 import java.io.Closeable
 import java.io.IOException
@@ -96,7 +96,7 @@ class JacksonIteratorDecoder2 private constructor(
             }
             reader.reset()
             return JacksonIterator<Any?>(type.actualIteratorTypeArgument(), mapper, response, reader)
-        } catch (e: RuntimeJsonMappingException) {
+        } catch (e: JacksonException) {
             reader.closeSafe()
             if (e.cause is IOException) {
                 throw e.cause as IOException
@@ -126,7 +126,7 @@ class JacksonIteratorDecoder2 private constructor(
         reader: Reader,
     ): Iterator<T>, Closeable {
 
-        private val parser: JsonParser = mapper.factory.createParser(reader)
+        private val parser: JsonParser = mapper.createParser(reader)
         private val objectReader: ObjectReader = mapper.reader().forType(mapper.constructType(type))
 
         private var nextLoaded = false

--- a/io/feign/src/test/kotlin/io/bluetape4k/feign/clients/AbstractClientTest.kt
+++ b/io/feign/src/test/kotlin/io/bluetape4k/feign/clients/AbstractClientTest.kt
@@ -1,6 +1,5 @@
 package io.bluetape4k.feign.clients
 
-import com.fasterxml.jackson.databind.json.JsonMapper
 import feign.CollectionFormat
 import feign.FeignException
 import feign.Headers
@@ -20,7 +19,8 @@ import io.bluetape4k.http.okhttp3.mock.baseUrl
 import io.bluetape4k.http.okhttp3.mock.enqueueBody
 import io.bluetape4k.io.compressor.Compressors
 import io.bluetape4k.io.toUtf8String
-import io.bluetape4k.jackson.Jackson
+import io.bluetape4k.jackson3.Jackson
+import tools.jackson.databind.json.JsonMapper
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.closeSafe

--- a/io/feign/src/test/kotlin/io/bluetape4k/feign/clients/AbstractCoroutineClientTest.kt
+++ b/io/feign/src/test/kotlin/io/bluetape4k/feign/clients/AbstractCoroutineClientTest.kt
@@ -1,6 +1,5 @@
 package io.bluetape4k.feign.clients
 
-import com.fasterxml.jackson.databind.json.JsonMapper
 import feign.Headers
 import feign.Param
 import feign.RequestLine
@@ -14,8 +13,9 @@ import io.bluetape4k.feign.coroutines.client
 import io.bluetape4k.http.okhttp3.mock.baseUrl
 import io.bluetape4k.http.okhttp3.mock.enqueueBody
 import io.bluetape4k.http.okhttp3.mock.enqueueBodyWithDelay
-import io.bluetape4k.jackson.Jackson
-import io.bluetape4k.jackson.writeAsString
+import io.bluetape4k.jackson3.Jackson
+import io.bluetape4k.jackson3.writeAsString
+import tools.jackson.databind.json.JsonMapper
 import io.bluetape4k.junit5.coroutines.runSuspendTest
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.support.closeSafe

--- a/io/feign/src/test/kotlin/io/bluetape4k/feign/clients/AbstractHttpbinTest.kt
+++ b/io/feign/src/test/kotlin/io/bluetape4k/feign/clients/AbstractHttpbinTest.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.feign.clients
 
-import com.fasterxml.jackson.databind.json.JsonMapper
 import io.bluetape4k.feign.AbstractFeignTest
 import io.bluetape4k.feign.services.HttpbinAnythingResponse
 import io.bluetape4k.feign.services.Post
-import io.bluetape4k.jackson.Jackson
+import io.bluetape4k.jackson3.Jackson
+import tools.jackson.databind.json.JsonMapper
 import io.bluetape4k.junit5.random.RandomizedTest
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.trace

--- a/io/feign/src/test/kotlin/io/bluetape4k/feign/coroutines/FeignCoroutineBuilderSupportTest.kt
+++ b/io/feign/src/test/kotlin/io/bluetape4k/feign/coroutines/FeignCoroutineBuilderSupportTest.kt
@@ -8,8 +8,8 @@ import io.bluetape4k.feign.codec.JacksonDecoder2
 import io.bluetape4k.feign.codec.JacksonEncoder2
 import io.bluetape4k.http.okhttp3.mock.baseUrl
 import io.bluetape4k.http.okhttp3.mock.enqueueBody
-import io.bluetape4k.jackson.Jackson
-import io.bluetape4k.jackson.writeAsString
+import io.bluetape4k.jackson3.Jackson
+import io.bluetape4k.jackson3.writeAsString
 import io.bluetape4k.junit5.coroutines.runSuspendTest
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.support.closeSafe

--- a/io/feign/src/test/kotlin/io/bluetape4k/feign/spring/HttpbinClientConfiguration.kt
+++ b/io/feign/src/test/kotlin/io/bluetape4k/feign/spring/HttpbinClientConfiguration.kt
@@ -1,9 +1,9 @@
 package io.bluetape4k.feign.spring
 
-import com.fasterxml.jackson.databind.json.JsonMapper
 import feign.codec.Decoder
 import io.bluetape4k.feign.codec.JacksonDecoder2
-import io.bluetape4k.jackson.Jackson
+import io.bluetape4k.jackson3.Jackson
+import tools.jackson.databind.json.JsonMapper
 import io.bluetape4k.logging.KLogging
 import org.springframework.context.annotation.Bean
 

--- a/io/grpc/build.gradle.kts
+++ b/io/grpc/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
     api(project(":bluetape4k-protobuf"))
     api(project(":bluetape4k-core"))
     api(project(":bluetape4k-io"))
-    api(project(":bluetape4k-jackson2"))
+    api(project(":bluetape4k-jackson3"))
     api(project(":bluetape4k-netty"))
     testImplementation(project(":bluetape4k-junit5"))
 

--- a/io/http/build.gradle.kts
+++ b/io/http/build.gradle.kts
@@ -84,10 +84,10 @@ dependencies {
     compileOnly(libs.vertx.lang.kotlin.coroutines)
 
     // Jackson
-    compileOnly(project(":bluetape4k-jackson2"))
-    compileOnly(libs.jackson.databind)
-    compileOnly(libs.jackson.module.kotlin)
-    compileOnly(libs.jackson.module.blackbird)
+    compileOnly(project(":bluetape4k-jackson3"))
+    compileOnly(libs.jackson3.databind)
+    compileOnly(libs.jackson3.module.kotlin)
+    compileOnly(libs.jackson3.module.blackbird)
 
     // Fastjson2
     compileOnly(project(":bluetape4k-fastjson2"))

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/fluent/FluentResponseHandling.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/fluent/FluentResponseHandling.kt
@@ -1,12 +1,10 @@
 package io.bluetape4k.http.hc5.fluent
 
 import com.alibaba.fastjson2.JSON
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.module.kotlin.readValue
 import io.bluetape4k.http.hc5.AbstractHc5Test
 import io.bluetape4k.io.toString
 import io.bluetape4k.io.toUtf8String
-import io.bluetape4k.jackson.Jackson
+import io.bluetape4k.jackson3.Jackson
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import jakarta.json.JsonException
@@ -14,6 +12,8 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import org.apache.hc.client5.http.ClientProtocolException
 import org.apache.hc.client5.http.HttpResponseException
 import org.apache.hc.core5.http.ContentType
+import tools.jackson.databind.JsonNode
+import tools.jackson.module.kotlin.readValue
 import org.apache.hc.core5.http.HttpStatus
 import org.junit.jupiter.api.Test
 import javax.xml.parsers.ParserConfigurationException

--- a/io/http/src/test/kotlin/io/bluetape4k/http/okhttp3/examples/Recipes.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/okhttp3/examples/Recipes.kt
@@ -13,8 +13,8 @@ import io.bluetape4k.http.okhttp3.executeAsync
 import io.bluetape4k.http.okhttp3.okhttp3Client
 import io.bluetape4k.http.okhttp3.okhttp3RequestOf
 import io.bluetape4k.http.okhttp3.print
-import io.bluetape4k.jackson.Jackson
-import io.bluetape4k.jackson.writeAsString
+import io.bluetape4k.jackson3.Jackson
+import io.bluetape4k.jackson3.writeAsString
 import io.bluetape4k.junit5.random.RandomValue
 import io.bluetape4k.junit5.random.RandomizedTest
 import io.bluetape4k.junit5.tempfolder.TempFolder

--- a/io/http/src/test/kotlin/io/bluetape4k/http/okhttp3/mock/MockWebServerExamples.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/okhttp3/mock/MockWebServerExamples.kt
@@ -1,12 +1,11 @@
 package io.bluetape4k.http.okhttp3.mock
 
-import com.fasterxml.jackson.module.kotlin.readValue
 import io.bluetape4k.LibraryName
 import io.bluetape4k.http.okhttp3.bodyAsString
 import io.bluetape4k.http.okhttp3.execute
 import io.bluetape4k.http.okhttp3.okhttp3Client
 import io.bluetape4k.http.okhttp3.okhttp3Request
-import io.bluetape4k.jackson.Jackson
+import io.bluetape4k.jackson3.Jackson
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import okhttp3.OkHttpClient
@@ -14,6 +13,7 @@ import okhttp3.mockwebserver.MockWebServer
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContain
+import tools.jackson.module.kotlin.readValue
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/io/vertx/build.gradle.kts
+++ b/io/vertx/build.gradle.kts
@@ -30,9 +30,9 @@ dependencies {
     implementation(libs.vertx.pg.client)
     compileOnly(libs.vertx.jdbc.client)
     compileOnly(libs.agroal.pool)
-    compileOnly(project(":bluetape4k-jackson2"))
-    compileOnly(libs.jackson.module.kotlin)
-    compileOnly(libs.jackson.module.blackbird)
+    compileOnly(project(":bluetape4k-jackson3"))
+    compileOnly(libs.jackson3.module.kotlin)
+    compileOnly(libs.jackson3.module.blackbird)
     implementation(libs.mybatis.dynamic.sql)
 
     // Coroutines

--- a/io/vertx/src/main/kotlin/io/bluetape4k/vertx/sqlclient/templates/RowMapperSupport.kt
+++ b/io/vertx/src/main/kotlin/io/bluetape4k/vertx/sqlclient/templates/RowMapperSupport.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.vertx.sqlclient.templates
 
-import com.fasterxml.jackson.databind.json.JsonMapper
-import com.fasterxml.jackson.module.kotlin.readValue
-import io.bluetape4k.jackson.Jackson
+import io.bluetape4k.jackson3.Jackson
 import io.vertx.sqlclient.Row
 import io.vertx.sqlclient.templates.RowMapper
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.readValue
 
 // 현재로서는 Jackson 을 이용하여 Row -> JSON -> Record 로 만드는 방법 밖에는 없을 듯 ...
 // NOTE: alias 같은 게 포함되어 있는 경우에 제대로 작동하지 않습니다.

--- a/utils/geo/build.gradle.kts
+++ b/utils/geo/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
     testImplementation(project(":bluetape4k-junit5"))
 
     // geocode: Google Maps Services
-    compileOnly(project(":bluetape4k-jackson2"))
+    compileOnly(project(":bluetape4k-jackson3"))
     compileOnly(project(":bluetape4k-resilience4j"))
     compileOnly(project(":bluetape4k-feign"))
     compileOnly(libs.feign.core)

--- a/utils/geo/src/test/kotlin/io/bluetape4k/geocode/JsonSerializationTest.kt
+++ b/utils/geo/src/test/kotlin/io/bluetape4k/geocode/JsonSerializationTest.kt
@@ -1,19 +1,19 @@
 package io.bluetape4k.geocode
 
-import com.fasterxml.jackson.module.kotlin.readValue
 import io.bluetape4k.AbstractValueObject
 import io.bluetape4k.ToStringBuilder
 import io.bluetape4k.geocode.bing.BingAddress
 import io.bluetape4k.geocode.google.GoogleAddress
-import io.bluetape4k.jackson.Jackson
-import io.bluetape4k.jackson.readValueOrNull
-import io.bluetape4k.jackson.writeAsString
+import io.bluetape4k.jackson3.Jackson
+import io.bluetape4k.jackson3.readValueOrNull
+import io.bluetape4k.jackson3.writeAsString
 import io.bluetape4k.junit5.random.RandomValue
 import io.bluetape4k.junit5.random.RandomizedTest
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.hashOf
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.RepeatedTest
+import tools.jackson.module.kotlin.readValue
 import java.util.*
 
 @RandomizedTest

--- a/utils/geo/src/test/kotlin/io/bluetape4k/geocode/bing/BingMapServiceTest.kt
+++ b/utils/geo/src/test/kotlin/io/bluetape4k/geocode/bing/BingMapServiceTest.kt
@@ -1,10 +1,9 @@
 package io.bluetape4k.geocode.bing
 
-import com.fasterxml.jackson.module.kotlin.readValue
 import io.bluetape4k.geocode.AbstractGeocodeTest
 import io.bluetape4k.geocode.Geocode
 import io.bluetape4k.geocode.bing.BingMapModel.toBingAddress
-import io.bluetape4k.jackson.Jackson
+import io.bluetape4k.jackson3.Jackson
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
@@ -14,6 +13,7 @@ import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import tools.jackson.module.kotlin.readValue
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 

--- a/utils/geo/src/test/kotlin/io/bluetape4k/geoip2/AbstractGeoipTest.kt
+++ b/utils/geo/src/test/kotlin/io/bluetape4k/geoip2/AbstractGeoipTest.kt
@@ -1,13 +1,13 @@
 package io.bluetape4k.geoip2
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies
-import com.fasterxml.jackson.databind.json.JsonMapper
 import com.maxmind.geoip2.model.CityResponse
 import com.maxmind.geoip2.model.CountryResponse
-import io.bluetape4k.jackson.Jackson
+import io.bluetape4k.jackson3.Jackson
 import io.bluetape4k.logging.KLogging
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeAll
+import tools.jackson.databind.PropertyNamingStrategies
+import tools.jackson.databind.json.JsonMapper
 
 abstract class AbstractGeoipTest {
 
@@ -31,9 +31,9 @@ abstract class AbstractGeoipTest {
          */
         @JvmStatic
         protected val jsonMapper: JsonMapper by lazy {
-            Jackson.defaultJsonMapper.apply {
-                setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
-            }
+            Jackson.defaultJsonMapper.rebuild()
+                .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .build() as JsonMapper
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #446

- PR 제목: build: migrate supported Jackson consumers to Jackson3

### 원문 선행 내용

Closes #446\n\n## Summary\n- Move supported Jackson2-only consumers to bluetape4k-jackson3/tools.jackson.\n- Keep Retrofit, JJWT, Spring Kafka 3.x, and dual-line compatibility modules on Jackson2 because their resolved APIs still require Jackson2.\n- Add a lesson documenting the support-check rule.\n\n## Verification\n- ./gradlew :bluetape4k-cassandra:testClasses :bluetape4k-hibernate:testClasses :bluetape4k-hibernate-reactive:testClasses :bluetape4k-mongodb:testClasses :bluetape4k-r2dbc:testClasses :bluetape4k-examples-redisson-demo:testClasses :bluetape4k-micrometer:testClasses :bluetape4k-nats:testClasses :bluetape4k-feign:testClasses :bluetape4k-grpc:testClasses :bluetape4k-http:testClasses :bluetape4k-vertx:testClasses :bluetape4k-geo:testClasses\n- ./gradlew :bluetape4k-geo:testClasses

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

Closes #446\n\n## Summary\n- Move supported Jackson2-only consumers to bluetape4k-jackson3/tools.jackson.\n- Keep Retrofit, JJWT, Spring Kafka 3.x, and dual-line compatibility modules on Jackson2 because their resolved APIs still require Jackson2.\n- Add a lesson documenting the support-check rule.\n\n## Verification\n- ./gradlew :bluetape4k-cassandra:testClasses :bluetape4k-hibernate:testClasses :bluetape4k-hibernate-reactive:testClasses :bluetape4k-mongodb:testClasses :bluetape4k-r2dbc:testClasses :bluetape4k-examples-redisson-demo:testClasses :bluetape4k-micrometer:testClasses :bluetape4k-nats:testClasses :bluetape4k-feign:testClasses :bluetape4k-grpc:testClasses :bluetape4k-http:testClasses :bluetape4k-vertx:testClasses :bluetape4k-geo:testClasses\n- ./gradlew :bluetape4k-geo:testClasses

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #446, milestone 없음, assignee `debop`
- PR: #447, head `b3ac3bacdf99438800c7ff3301a1c6a248fffb8c`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `build/issue-446-jackson3-consumers`
- Labels: 없음
- State: `MERGED`, merge commit `a3758bfb9ccdabfd2be9eb4cb0a01f6b2b0ea6cc`
- CI: Closes #446\n\n## Summary\n- Move supported Jackson2-only consumers to bluetape4k-jackson3/tools.jackson.\n- Keep Retrofit, JJWT, Spring Kafka 3.x, and dual-line compatibility modules on Jackson2 because their resolved APIs still require Jackson2.\n- Add a lesson documenting the support-check rule.\n\n## Verification\n- ./gradlew :bluetape4k-cassandra:testClasses :bluetape4k-hibernate:testClasses :bluetape4k-hibernate-reactive:testClasses :bluetape4k-mongodb:testClasses :bluetape4k-r2dbc:testClasses :bluetape4k-examples-redisson-demo:testClasses :bluetape4k-micrometer:testClasses :bluetape4k-nats:testClasses :bluetape4k-feign:testClasses :bluetape4k-grpc:testClasses :bluetape4k-http:testClasses :bluetape4k-vertx:testClasses :bluetape4k-geo:testClasses\n- ./gradlew :bluetape4k-geo:testClasses

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #447 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `a3758bfb9ccdabfd2be9eb4cb0a01f6b2b0ea6cc`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
