### PR TITLE
fix: stabilize Jackson3 nightly regressions

### DIFF
--- a/data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/examples/json/JacksonJsonFunctionExamples.kt
+++ b/data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/examples/json/JacksonJsonFunctionExamples.kt
@@ -2,7 +2,6 @@ package io.bluetape4k.cassandra.examples.json
 
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.cql.BoundStatement
-import com.datastax.oss.driver.api.core.type.codec.ExtraTypeCodecs
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder.function
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder.insertInto
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder.selectFrom
@@ -10,7 +9,6 @@ import com.datastax.oss.driver.api.querybuilder.select.Selector
 import io.bluetape4k.cassandra.AbstractCassandraTest
 import io.bluetape4k.cassandra.CqlSessionProvider
 import io.bluetape4k.cassandra.cql.getStringOrEmpty
-import io.bluetape4k.cassandra.data.getValue
 import io.bluetape4k.cassandra.data.setValue
 import io.bluetape4k.cassandra.querybuilder.bindMarker
 import io.bluetape4k.cassandra.querybuilder.inValues
@@ -25,8 +23,6 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
-import tools.jackson.databind.JsonNode
-import tools.jackson.databind.node.JsonNodeFactory
 import java.io.Serializable
 
 class JacksonJsonFunctionExamples: AbstractCassandraTest() {
@@ -36,9 +32,6 @@ class JacksonJsonFunctionExamples: AbstractCassandraTest() {
             val name: String? = null,
             val age: Int? = null,
         ): Serializable
-
-        private val USER_CODEC = ExtraTypeCodecs.json(User::class.java)
-        private val JSON_NODE_CODEC = ExtraTypeCodecs.json(JsonNode::class.java)
     }
 
     private val mapper = Jackson.defaultJsonMapper
@@ -69,9 +62,7 @@ class JacksonJsonFunctionExamples: AbstractCassandraTest() {
         val session = CqlSessionProvider.getOrCreateSession(
             "jackson_examples",
             { newCqlSessionBuilder() }
-        ) {
-            addTypeCodecs(USER_CODEC, JSON_NODE_CODEC)
-        }
+        ) {}
         createSchema(session)
         insertFromJson(session)
         selectToJson(session)
@@ -99,19 +90,27 @@ class JacksonJsonFunctionExamples: AbstractCassandraTest() {
     private fun insertFromJson(session: CqlSession) {
         val alice = User("alice", 30)
         val bob = User("bob", 35)
+        val aliceJson = mapper.writeAsString(alice)
+        val bobJson = mapper.writeAsString(bob)
 
-        val aliceScores = JsonNodeFactory.instance.objectNode()
-            .put("call_of_duty", 4.8)
-            .put("pokemon_go", 9.7)
+        val aliceScoresJson = mapper.writeAsString(
+            mapOf(
+                "call_of_duty" to 4.8F,
+                "pokemon_go" to 9.7F,
+            )
+        )
 
-        val bobScores = JsonNodeFactory.instance.objectNode()
-            .put("zelda", 8.3)
-            .put("pokemon_go", 12.4)
+        val bobScoresJson = mapper.writeAsString(
+            mapOf(
+                "zelda" to 8.3F,
+                "pokemon_go" to 12.4F,
+            )
+        )
 
         val stmt = insertInto("json_jackson_function")
             .value("id", 1.literal())
-            .value("user", function("fromJson", alice.literal(session.context.codecRegistry)))
-            .value("scores", function("fromJson", aliceScores.literal(session.context.codecRegistry)))
+            .value("user", function("fromJson", aliceJson.literal()))
+            .value("scores", function("fromJson", aliceScoresJson.literal()))
             .build()
 
         log.debug { "query=${stmt.query}" }
@@ -127,10 +126,10 @@ class JacksonJsonFunctionExamples: AbstractCassandraTest() {
 
         val bs = ps.bind()
             .setValue<BoundStatement, Int>("id", 2)
-            .setValue<BoundStatement, User>("user", bob)
-            .setValue<BoundStatement, JsonNode>("scores", bobScores)
-        // .set("user", bob, User::class.java)
-        // .set("scores", bobScores, JsonNode::class.java)
+            .setValue<BoundStatement, String>("user", bobJson)
+            .setValue<BoundStatement, String>("scores", bobScoresJson)
+        // .set("user", bobJson, String::class.java)
+        // .set("scores", bobScoresJson, String::class.java)
         session.execute(bs)
     }
 
@@ -148,10 +147,12 @@ class JacksonJsonFunctionExamples: AbstractCassandraTest() {
 
         rows.forEach { row ->
             val id = row.getInt("id")
-            val user = row.getValue<User>("user")
             val userJson = row.getStringOrEmpty("user")
-            val scores = row.getValue<JsonNode>("scores")
+            val user = mapper.readValueOrNull<User>(userJson)
+            user.shouldNotBeNull()
             val scoresJson = row.getStringOrEmpty("scores")
+            val scores = mapper.readValueOrNull<Map<String, Float>>(scoresJson)
+            scores.shouldNotBeNull()
 
             log.debug {
                 """

--- a/docs/lessons/2026-05-14-issue-450-jackson3-nightly-regressions.md
+++ b/docs/lessons/2026-05-14-issue-450-jackson3-nightly-regressions.md
@@ -1,0 +1,32 @@
+# Issue 450 Jackson3 Nightly Regressions
+
+## Context
+
+Nightly after the Jackson3 consumer migration failed in `bluetape4k-projects`.
+The failing jobs were `Test / IO HTTP` and `Test / Data (nosql)`.
+
+## Decision
+
+Use a Jackson3 object reader without `FAIL_ON_TRAILING_TOKENS` for iterator
+stream decoding, because each iterator element is read from a parser that still
+has later array elements available. For Cassandra JSON function examples, pass
+Jackson3-generated JSON text to `fromJson` instead of routing Jackson3 nodes or
+objects through DataStax JSON codecs.
+
+## Outcome
+
+The failing Feign iterator test and Cassandra JSON function test now pass
+locally with the Jackson3 runtime.
+
+## Verification
+
+- `./gradlew :bluetape4k-feign:test --tests io.bluetape4k.feign.codec.JacksonIteratorDecoder2Test`
+- `./gradlew :bluetape4k-cassandra:test --tests io.bluetape4k.cassandra.examples.json.JacksonJsonFunctionExamples`
+- `./gradlew :bluetape4k-cassandra:test --tests io.bluetape4k.cassandra.examples.json.JacksonJsonFunctionExamples --rerun-tasks`
+
+## Future Notes
+
+For Jackson3 streaming readers, check strict trailing-token behavior when
+reading multiple values from one parser. For Cassandra `fromJson`, prefer
+explicit JSON text over driver JSON codecs unless the codec is known to support
+the exact Jackson major version in use.

--- a/io/feign/src/main/kotlin/io/bluetape4k/feign/codec/JacksonIteratorDecoder2.kt
+++ b/io/feign/src/main/kotlin/io/bluetape4k/feign/codec/JacksonIteratorDecoder2.kt
@@ -14,6 +14,7 @@ import io.bluetape4k.support.closeSafe
 import tools.jackson.core.JacksonException
 import tools.jackson.core.JsonParser
 import tools.jackson.core.JsonToken
+import tools.jackson.databind.DeserializationFeature
 import tools.jackson.databind.ObjectReader
 import tools.jackson.databind.json.JsonMapper
 import java.io.BufferedReader
@@ -127,7 +128,9 @@ class JacksonIteratorDecoder2 private constructor(
     ): Iterator<T>, Closeable {
 
         private val parser: JsonParser = mapper.createParser(reader)
-        private val objectReader: ObjectReader = mapper.reader().forType(mapper.constructType(type))
+        private val objectReader: ObjectReader = mapper.reader()
+            .without(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+            .forType(mapper.constructType(type))
 
         private var nextLoaded = false
         private var nextElement: T? = null


### PR DESCRIPTION
## Summary

Closes #450

- PR 제목: fix: stabilize Jackson3 nightly regressions

- Disable Jackson3 trailing-token validation for Feign iterator element reads.
- Pass explicit Jackson3 JSON text into Cassandra `fromJson` examples instead of using DataStax JSON codecs for Jackson3 values.
- Add a lesson for the Jackson3 Nightly regression.

### 원문 선행 내용

Closes #450

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- `./gradlew :bluetape4k-feign:test --tests io.bluetape4k.feign.codec.JacksonIteratorDecoder2Test`
- `./gradlew :bluetape4k-cassandra:test --tests io.bluetape4k.cassandra.examples.json.JacksonJsonFunctionExamples`
- `./gradlew :bluetape4k-cassandra:test --tests io.bluetape4k.cassandra.examples.json.JacksonJsonFunctionExamples --rerun-tasks`

### 기존 섹션: Notes

- Full local `:bluetape4k-cassandra:test` remained unstable after repeated local Testcontainers runs with `ClosedConnectionException` in unrelated examples, so CI/Nightly is the merge gate.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #450, milestone 없음, assignee `debop`
- PR: #451, head `e010668e3185750c28bfe56c53972177aedf56aa`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/issue-450-jackson3-nightly-regressions`
- Labels: 없음
- State: `MERGED`, merge commit `b168b32eede8a21b3f737b25fe078b21f6a8a31e`
- CI: - Pass explicit Jackson3 JSON text into Cassandra `fromJson` examples instead of using DataStax JSON codecs for Jackson3 values. / - `./gradlew :bluetape4k-feign:test --tests io.bluetape4k.feign.codec.JacksonIteratorDecoder2Test` / - `./gradlew :bluetape4k-cassandra:test --tests io.bluetape4k.cassandra.examples.json.JacksonJsonFunctionExamples`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #451 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `b168b32eede8a21b3f737b25fe078b21f6a8a31e`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
