### PR TITLE
[docs] Mark OpenTelemetry WebFlux helper as legacy

### DIFF
--- a/infra/opentelemetry/README.ko.md
+++ b/infra/opentelemetry/README.ko.md
@@ -12,7 +12,8 @@
 - **Flow 트레이싱**: `Flow.traced()` / `Flow.tracedCollect()` — 1 collect = 1 Span
 - **Span 관리**: 자동 리소스 관리를 위한 `use` 패턴
 - **DSL 제공**: Attributes, TracerProvider, MeterProvider 설정을 위한 DSL
-- **Spring Boot 3 WebFlux 통합**: `createTracingWebFilter()` 헬퍼 (Spring Boot 3 전용 — 아래 참고)
+- **레거시 WebFlux 트레이싱 헬퍼**: `createTracingWebFilter()`는 이전
+  Spring WebFlux API를 대상으로 하며, 마이그레이션 참고용으로만 유지합니다.
 - **Spring Boot Starter 지원**: 자동 설정 OpenTelemetry SDK
 
 ## 의존성
@@ -326,11 +327,11 @@ val compositeExporter = spanExporterOf(
 )
 ```
 
-### 9. Spring WebFlux 트레이싱 (Spring Boot 3 전용)
+### 9. 레거시 Spring WebFlux 트레이싱 헬퍼
 
 > **Spring Boot 버전 제약:**
 > `createTracingWebFilter()`는 `opentelemetry-spring-webflux-5.3` 아티팩트를 사용하며, Spring WebFlux 5.3 / 6.x (Spring Boot 3) 대상입니다.
-> **Spring Boot 4 (Spring Framework 7.x)는 아직 미지원** — OTel instrumentation BOM에서 대응 아티팩트 출시 후 지원 예정입니다.
+> 현재 bluetape4k의 Spring 연동은 Spring Boot 4.x만 지원합니다. OTel instrumentation BOM에서 Spring Framework 7 대응 아티팩트를 제공하기 전까지 이 헬퍼를 새 Spring Boot 4 애플리케이션에 사용하지 마세요.
 
 ```kotlin
 import io.bluetape4k.opentelemetry.webflux.createTracingWebFilter

--- a/infra/opentelemetry/README.md
+++ b/infra/opentelemetry/README.md
@@ -12,7 +12,8 @@ English | [한국어](./README.ko.md)
 - **Flow tracing**: `Flow.traced()` / `Flow.tracedCollect()` — 1 collect = 1 Span
 - **Span management**: `use` pattern for automatic resource cleanup
 - **DSL support**: DSLs for configuring Attributes, TracerProvider, and MeterProvider
-- **Spring Boot 3 WebFlux integration**: `createTracingWebFilter()` helper (Spring Boot 3 only — see note below)
+- **Legacy WebFlux tracing helper**: `createTracingWebFilter()` targets the
+  older Spring WebFlux API and is retained for migration reference only
 - **Spring Boot Starter support**: Auto-configured OpenTelemetry SDK
 
 ## Dependency
@@ -327,11 +328,11 @@ val compositeExporter = spanExporterOf(
 )
 ```
 
-### 9. Spring WebFlux Tracing (Spring Boot 3 Only)
+### 9. Legacy Spring WebFlux Tracing Helper
 
 > **Spring Boot version constraint:**
 > `createTracingWebFilter()` uses `opentelemetry-spring-webflux-5.3`, which targets Spring WebFlux 5.3 / 6.x (Spring Boot 3).
-> **Spring Boot 4 (Spring Framework 7.x) is not yet supported** — support will be added once the OTel instrumentation BOM publishes a compatible artifact.
+> Current bluetape4k Spring integrations support Spring Boot 4.x only. Do not use this helper for new Spring Boot 4 applications until the OTel instrumentation BOM publishes a Spring Framework 7-compatible artifact.
 
 ```kotlin
 import io.bluetape4k.opentelemetry.webflux.createTracingWebFilter


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: [docs] Mark OpenTelemetry WebFlux helper as legacy

- Reframe the OpenTelemetry WebFlux helper as legacy migration reference instead of current Spring Boot 3 support.
- Keep both English and Korean README files aligned with the Spring Boot 4.x-only support policy.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Notes

- Documentation-only change; no runtime tests were run.

## Validation

- git diff --check
- README search for Spring Boot 3/4 compatibility phrases returned no matches

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #453, head `12154380caa12c08a131dbb7d6538aea59a637ac`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `docs/spring-boot-4-only-opentelemetry`
- Labels: 없음
- State: `MERGED`, merge commit `f56423c813e37094f03d772502a488636fe5bc9d`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #453 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `f56423c813e37094f03d772502a488636fe5bc9d`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
