### PR TITLE
feat: add optional Ktor Client helpers to io/http (#418)

### DIFF
--- a/docs/lessons/2026-05-15-ktor-http-client-addition.md
+++ b/docs/lessons/2026-05-15-ktor-http-client-addition.md
@@ -1,0 +1,58 @@
+# Lessons Learned — Ktor Client addition to io/http (2026-05-15)
+
+**관련 PR**: #454
+**영향 모듈**: `:bluetape4k-http`
+
+## L1: Ktor suspend-native 특성으로 executeSuspending 브리지 불필요
+
+### 문제
+기존 HC5/OkHttp3/Vert.x 백엔드는 blocking/async API를 suspend로 연결하는 브리지(`executeSuspending`)가 필요했다.
+
+### 교훈
+Ktor Client는 이미 suspend-native이므로 별도 브리지 없이 `client.get()` 등을 직접 coroutine 컨텍스트에서 호출 가능하다.
+새로운 suspend-native 라이브러리를 추가할 때 기존 패턴(bridging)을 그대로 적용하지 않도록 주의.
+
+---
+
+## L2: Ktor Client CIO는 HTTP/2 미지원 — README에 명시 필수
+
+### 문제
+CIO 엔진이 HTTP/1.x만 지원한다는 사실을 문서화하지 않으면 HTTP/2 필요 팀이 잘못 채택할 수 있다.
+
+### 교훈
+백엔드 추가 시 지원하지 않는 프로토콜/기능을 README에 "intentionally not supported" 형태로 명시.
+"Unsupported must be explicit" 원칙 적용.
+
+---
+
+## L3: compileOnly 백엔드 추가 시 버전 카탈로그 선 확인
+
+### 문제
+Ktor client 추가 전에 `ktor = "3.4.3"` 버전이 이미 카탈로그에 존재했다.
+중복 버전 항목을 만들 뻔했다.
+
+### 교훈
+새 의존성 추가 전에 `grep -r "libraryname" gradle/libs.versions.toml` 로 기존 버전 항목 확인 필수.
+버전 항목은 하나만 유지, 라이브러리 항목만 추가.
+
+---
+
+## L4: HttpClientConfig<*> 대신 CIOEngineConfig 명시 필요
+
+### 문제
+issue 제안 코드의 `HttpClientConfig<*>.() -> Unit`은 Ktor generic `<T : HttpClientEngineConfig>` 서명과 타입 불일치로 컴파일 오류 발생.
+
+### 교훈
+Ktor Client factory는 제네릭이다. CIO 전용 factory 함수는 `HttpClientConfig<CIOEngineConfig>.() -> Unit`으로 명시해야 컴파일.
+Issue 제안 코드는 pseudocode일 수 있으므로 실제 API 시그니처 확인 후 구현.
+
+---
+
+## L5: Codex CLI oh-my-codex 인프라 오류 대응
+
+### 문제
+`omc ask codex` 실행 시 `patch-oh-my-codex: failed to remove co-author requirement` 오류로 2회 모두 실패.
+
+### 교훈
+Codex CLI가 사용 불가한 경우 Tier 4 Claude 리뷰로 대체 수행하고 DoD/PR 코멘트에 사유 명시.
+`omc ask codex` 실패 시 artifact 파일(`.omc/artifacts/ask/`) 확인으로 exit code 및 오류 내용 파악 가능.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -232,6 +232,9 @@ kotlinx-serialization-properties = { module = "org.jetbrains.kotlinx:kotlinx-ser
 kotlinx-serialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "kotlinx-serialization" }
 
 # Ktor
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
 ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }

--- a/io/http/README.ko.md
+++ b/io/http/README.ko.md
@@ -460,11 +460,14 @@ io.bluetape4k.http
 dependencies {
     implementation(project(":bluetape4k-http"))
 
-    // 선택적 의존성 (필요한 것만 추가)
-    implementation("com.squareup.okhttp3:okhttp")           // OkHttp3
-    implementation("io.vertx:vertx-core")                    // Vert.x
-    implementation("io.ktor:ktor-client-core")               // Ktor Client (엔진 선택)
-    implementation("io.ktor:ktor-client-cio")                // Ktor CIO 엔진 (HTTP/1.x)
+    // Apache HttpComponents 5 (기본 백엔드)
+    implementation("org.apache.httpcomponents.client5:httpclient5")
+
+    // 선택적 백엔드 — 사용할 백엔드만 compileOnly로 추가
+    compileOnly("com.squareup.okhttp3:okhttp")               // OkHttp3
+    compileOnly("io.vertx:vertx-core")                       // Vert.x
+    compileOnly("io.ktor:ktor-client-core")                  // Ktor Client (엔진 선택)
+    compileOnly("io.ktor:ktor-client-cio")                   // Ktor CIO 엔진 (HTTP/1.x)
 }
 ```
 

--- a/io/http/README.ko.md
+++ b/io/http/README.ko.md
@@ -460,14 +460,13 @@ io.bluetape4k.http
 dependencies {
     implementation(project(":bluetape4k-http"))
 
-    // Apache HttpComponents 5 (기본 백엔드)
-    implementation("org.apache.httpcomponents.client5:httpclient5")
-
-    // 선택적 백엔드 — 사용할 백엔드만 compileOnly로 추가
-    compileOnly("com.squareup.okhttp3:okhttp")               // OkHttp3
-    compileOnly("io.vertx:vertx-core")                       // Vert.x
-    compileOnly("io.ktor:ktor-client-core")                  // Ktor Client (엔진 선택)
-    compileOnly("io.ktor:ktor-client-cio")                   // Ktor CIO 엔진 (HTTP/1.x)
+    // 사용할 백엔드만 compileOnly로 추가.
+    // 애플리케이션 프로젝트에서 런타임에 필요한 경우 implementation으로 변경하세요.
+    compileOnly("org.apache.httpcomponents.client5:httpclient5") // HC5
+    compileOnly("com.squareup.okhttp3:okhttp")                   // OkHttp3
+    compileOnly("io.vertx:vertx-core")                           // Vert.x
+    compileOnly("io.ktor:ktor-client-core")                      // Ktor Client (엔진 선택)
+    compileOnly("io.ktor:ktor-client-cio")                       // Ktor CIO 엔진 (HTTP/1.x)
 }
 ```
 

--- a/io/http/README.ko.md
+++ b/io/http/README.ko.md
@@ -6,7 +6,7 @@
 
 `bluetape4k-http`는 다양한 HTTP 클라이언트 라이브러리를 Kotlin 확장 함수와 DSL로 통합하여 제공하는 모듈입니다.
 
-Apache HttpComponents 5, OkHttp3, Vert.x HttpClient 등을 일관된 방식으로 사용할 수 있으며, Kotlin Coroutines와 Virtual Threads를 기본 지원합니다.
+Apache HttpComponents 5, OkHttp3, Vert.x HttpClient, Ktor Client 등을 일관된 방식으로 사용할 수 있으며, Kotlin Coroutines와 Virtual Threads를 기본 지원합니다.
 
 ## 아키텍처
 
@@ -21,7 +21,7 @@ flowchart TD
 
     subgraph bluetape4k-http
         EXT[executeSuspending\n확장 함수]
-        DSL[Builder DSL\nhttpAsyncClient / okhttp3Client / vertxHttpClientOf]
+        DSL[Builder DSL\nhttpAsyncClient / okhttp3Client / vertxHttpClientOf / ktorCioHttpClientOf]
     end
 
     subgraph Backends["HTTP 클라이언트 백엔드"]
@@ -30,6 +30,7 @@ flowchart TD
         HC5CA[HC5 캐싱\ncachingHttpAsyncClient]
         OKH[OkHttp3\nokhttp3Client]
         VTX[Vert.x HttpClient\nvertxHttpClientOf]
+        KTOR[Ktor CIO\nktorCioHttpClientOf]
     end
 
     APP --> CO
@@ -40,11 +41,13 @@ flowchart TD
     DSL --> HC5CA
     DSL --> OKH
     DSL --> VTX
+    DSL --> KTOR
     HC5A --> SERVER[(HTTP 서버)]
     HC5C --> SERVER
     HC5CA --> SERVER
     OKH --> SERVER
     VTX --> SERVER
+    KTOR --> SERVER
 
     classDef coreStyle fill:#E8F5E9,stroke:#A5D6A7,color:#2E7D32,font-weight:bold
     classDef asyncStyle fill:#F3E5F5,stroke:#CE93D8,color:#6A1B9A
@@ -55,7 +58,7 @@ flowchart TD
     class APP coreStyle
     class CO asyncStyle
     class EXT,DSL utilStyle
-    class HC5A,HC5C,HC5CA,OKH,VTX serviceStyle
+    class HC5A,HC5C,HC5CA,OKH,VTX,KTOR serviceStyle
     class SERVER extStyle
 ```
 
@@ -304,6 +307,9 @@ val vertxClient = vertxHttpClientOf(options)
 | HC5 Async         | HTTP/1.1, HTTP/2 | 비동기, Coroutines 통합    | 고성능 비동기 통신    |
 | OkHttp3           | HTTP/1.1, HTTP/2 | 경량, Virtual Thread 기본 | 범용 HTTP 클라이언트 |
 | Vert.x HttpClient | HTTP/1.1, HTTP/2 | 이벤트 루프 기반             | Vert.x 생태계 통합 |
+| Ktor CIO          | HTTP/1.x         | suspend-native, 경량, Ktor 플러그인 생태계 | Ktor 기반 앱 / 코루틴 우선 호출 |
+
+> **참고**: Ktor CIO는 HTTP/2를 지원하지 않습니다. HTTP/2가 필요한 경우 HC5 Async, JDK, 또는 OkHttp3를 사용하세요.
 
 ## 성능 벤치마크
 
@@ -442,8 +448,10 @@ io.bluetape4k.http
 │   ├── CachingRequestInterceptor.kt
 │   ├── CachingResponseInterceptor.kt
 │   └── mock/               # MockWebServer 유틸리티
-└── vertx/                  # Vert.x HttpClient
-    └── VertxHttpClientSupport.kt
+├── vertx/                  # Vert.x HttpClient
+│   └── VertxHttpClientSupport.kt
+└── ktor/                   # Ktor Client (선택적, suspend-native)
+    └── KtorHttpClientSupport.kt
 ```
 
 ## 의존성
@@ -455,6 +463,8 @@ dependencies {
     // 선택적 의존성 (필요한 것만 추가)
     implementation("com.squareup.okhttp3:okhttp")           // OkHttp3
     implementation("io.vertx:vertx-core")                    // Vert.x
+    implementation("io.ktor:ktor-client-core")               // Ktor Client (엔진 선택)
+    implementation("io.ktor:ktor-client-cio")                // Ktor CIO 엔진 (HTTP/1.x)
 }
 ```
 
@@ -485,10 +495,12 @@ dependencies {
 | `hc5/ssl` | ✅ | `SslSupportTest` |
 | `jdk` | ✅ | `JdkHttpClientSupportTest`, `JdkHttpClientCoroutinesTest` |
 | `okhttp3` | ✅ | 다수의 테스트 |
+| `ktor` | ✅ | `KtorHttpClientSupportTest` |
 
 ## 참고
 
 - [Apache HttpComponents 5](https://hc.apache.org/httpcomponents-client-5.4.x/)
 - [OkHttp](https://square.github.io/okhttp/)
 - [Vert.x HttpClient](https://vertx.io/docs/vertx-core/kotlin/)
+- [Ktor Client](https://ktor.io/docs/client-create-and-configure.html)
 - [httpbin.org](https://httpbin.org/) - HTTP 테스트용 API

--- a/io/http/README.md
+++ b/io/http/README.md
@@ -450,14 +450,13 @@ io.bluetape4k.http
 dependencies {
     implementation(project(":bluetape4k-http"))
 
-    // Apache HttpComponents 5 (primary backend)
-    implementation("org.apache.httpcomponents.client5:httpclient5")
-
-    // Optional backends — add compileOnly for each backend you use
-    compileOnly("com.squareup.okhttp3:okhttp")               // OkHttp3
-    compileOnly("io.vertx:vertx-core")                       // Vert.x
-    compileOnly("io.ktor:ktor-client-core")                  // Ktor Client (any engine)
-    compileOnly("io.ktor:ktor-client-cio")                   // Ktor CIO engine (HTTP/1.x)
+    // Add compileOnly for each backend you use.
+    // Change to implementation in application projects where runtime availability is required.
+    compileOnly("org.apache.httpcomponents.client5:httpclient5") // HC5
+    compileOnly("com.squareup.okhttp3:okhttp")                   // OkHttp3
+    compileOnly("io.vertx:vertx-core")                           // Vert.x
+    compileOnly("io.ktor:ktor-client-core")                      // Ktor Client (any engine)
+    compileOnly("io.ktor:ktor-client-cio")                       // Ktor CIO engine (HTTP/1.x)
 }
 ```
 

--- a/io/http/README.md
+++ b/io/http/README.md
@@ -6,7 +6,7 @@ English | [한국어](./README.ko.md)
 
 `bluetape4k-http` integrates multiple HTTP client libraries through Kotlin extension functions and DSLs.
 
-It provides a consistent interface for Apache HttpComponents 5, OkHttp3, and Vert.x HttpClient, with built-in support for Kotlin Coroutines and Virtual Threads.
+It provides a consistent interface for Apache HttpComponents 5, OkHttp3, Vert.x HttpClient, and Ktor Client, with built-in support for Kotlin Coroutines and Virtual Threads.
 
 ## Architecture
 
@@ -21,7 +21,7 @@ flowchart TD
 
     subgraph bluetape4k-http
         EXT[executeSuspending\nextension functions]
-        DSL[Builder DSLs\nhttpAsyncClient / okhttp3Client / vertxHttpClientOf]
+        DSL[Builder DSLs\nhttpAsyncClient / okhttp3Client / vertxHttpClientOf / ktorCioHttpClientOf]
     end
 
     subgraph Backends["HTTP Client Backends"]
@@ -30,6 +30,7 @@ flowchart TD
         HC5CA[HC5 Caching\ncachingHttpAsyncClient]
         OKH[OkHttp3\nokhttp3Client]
         VTX[Vert.x HttpClient\nvertxHttpClientOf]
+        KTOR[Ktor CIO\nktorCioHttpClientOf]
     end
 
     APP --> CO
@@ -40,11 +41,13 @@ flowchart TD
     DSL --> HC5CA
     DSL --> OKH
     DSL --> VTX
+    DSL --> KTOR
     HC5A --> SERVER[(HTTP Server)]
     HC5C --> SERVER
     HC5CA --> SERVER
     OKH --> SERVER
     VTX --> SERVER
+    KTOR --> SERVER
 
     classDef coreStyle fill:#E8F5E9,stroke:#A5D6A7,color:#2E7D32,font-weight:bold
     classDef asyncStyle fill:#F3E5F5,stroke:#CE93D8,color:#6A1B9A
@@ -55,7 +58,7 @@ flowchart TD
     class APP coreStyle
     class CO asyncStyle
     class EXT,DSL utilStyle
-    class HC5A,HC5C,HC5CA,OKH,VTX serviceStyle
+    class HC5A,HC5C,HC5CA,OKH,VTX,KTOR serviceStyle
     class SERVER extStyle
 ```
 
@@ -380,6 +383,20 @@ Async / coroutine modes can exceed this ceiling without blocking threads.
 | Cache persistence across restarts | OkHttp3 + DiskLruCache |
 | General high-throughput (no caching needed) | HC5 Classic VirtualThread or OkHttp3 |
 | High-latency async bulk requests | HC5 Async Coroutines or Vert.x WebClient |
+| Ktor-based apps / coroutine-first calls | Ktor CIO |
+
+## Backend Comparison
+
+| Client | Protocol | Characteristics | Use case |
+|--------|----------|-----------------|----------|
+| HC5 Async | HTTP/1.x, HTTP/2 | Full-featured, caching, SSL, Virtual Thread | Enterprise backend, high-throughput |
+| HC5 Classic | HTTP/1.x, HTTP/2 | Synchronous, VirtualThread support | Legacy code, blocking I/O |
+| OkHttp3 | HTTP/1.x, HTTP/2 | Interceptors, DiskLruCache, MockWebServer | General-purpose, Android-compatible |
+| JDK | HTTP/1.x, HTTP/2 | Standard library, no extra dependency | Minimal footprint, Java-native |
+| Vert.x | HTTP/1.x, HTTP/2 | Event-loop, reactive, ALPN | Vert.x-based applications |
+| Ktor CIO | HTTP/1.x | Suspend-native, Ktor plugin ecosystem, lightweight | Ktor-based apps/libraries and coroutine-first calls |
+
+> **Note**: Ktor CIO does not support HTTP/2. For HTTP/2 use cases, prefer HC5 Async, JDK, or OkHttp3.
 
 ## Coroutines Support
 
@@ -421,8 +438,10 @@ io.bluetape4k.http
 │   ├── CachingRequestInterceptor.kt
 │   ├── CachingResponseInterceptor.kt
 │   └── mock/               # MockWebServer utilities
-└── vertx/                  # Vert.x HttpClient
-    └── VertxHttpClientSupport.kt
+├── vertx/                  # Vert.x HttpClient
+│   └── VertxHttpClientSupport.kt
+└── ktor/                   # Ktor Client (optional, suspend-native)
+    └── KtorHttpClientSupport.kt
 ```
 
 ## Dependencies
@@ -434,6 +453,8 @@ dependencies {
     // Optional (add only what you need)
     implementation("com.squareup.okhttp3:okhttp")           // OkHttp3
     implementation("io.vertx:vertx-core")                    // Vert.x
+    implementation("io.ktor:ktor-client-core")               // Ktor Client (any engine)
+    implementation("io.ktor:ktor-client-cio")                // Ktor CIO engine (HTTP/1.x)
 }
 ```
 
@@ -466,10 +487,12 @@ Covered packages:
 | `hc5/ssl` | ✅ | `SslSupportTest` |
 | `jdk` | ✅ | `JdkHttpClientSupportTest`, `JdkHttpClientCoroutinesTest` |
 | `okhttp3` | ✅ | Multiple tests |
+| `ktor` | ✅ | `KtorHttpClientSupportTest` |
 
 ## References
 
 - [Apache HttpComponents 5](https://hc.apache.org/httpcomponents-client-5.4.x/)
 - [OkHttp](https://square.github.io/okhttp/)
 - [Vert.x HttpClient](https://vertx.io/docs/vertx-core/kotlin/)
+- [Ktor Client](https://ktor.io/docs/client-create-and-configure.html)
 - [httpbin.org](https://httpbin.org/) - HTTP testing API

--- a/io/http/README.md
+++ b/io/http/README.md
@@ -450,11 +450,14 @@ io.bluetape4k.http
 dependencies {
     implementation(project(":bluetape4k-http"))
 
-    // Optional (add only what you need)
-    implementation("com.squareup.okhttp3:okhttp")           // OkHttp3
-    implementation("io.vertx:vertx-core")                    // Vert.x
-    implementation("io.ktor:ktor-client-core")               // Ktor Client (any engine)
-    implementation("io.ktor:ktor-client-cio")                // Ktor CIO engine (HTTP/1.x)
+    // Apache HttpComponents 5 (primary backend)
+    implementation("org.apache.httpcomponents.client5:httpclient5")
+
+    // Optional backends — add compileOnly for each backend you use
+    compileOnly("com.squareup.okhttp3:okhttp")               // OkHttp3
+    compileOnly("io.vertx:vertx-core")                       // Vert.x
+    compileOnly("io.ktor:ktor-client-core")                  // Ktor Client (any engine)
+    compileOnly("io.ktor:ktor-client-cio")                   // Ktor CIO engine (HTTP/1.x)
 }
 ```
 

--- a/io/http/build.gradle.kts
+++ b/io/http/build.gradle.kts
@@ -76,6 +76,11 @@ dependencies {
     compileOnly(libs.caffeine)
     compileOnly(libs.caffeine.jcache)
 
+    // Ktor Client
+    compileOnly(libs.ktor.client.core)
+    compileOnly(libs.ktor.client.cio)
+    testImplementation(libs.ktor.client.mock)
+
     // Vertx
     compileOnly(project(":bluetape4k-vertx"))
     compileOnly(libs.vertx.core)

--- a/io/http/src/main/kotlin/io/bluetape4k/http/ktor/KtorHttpClientSupport.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/ktor/KtorHttpClientSupport.kt
@@ -1,0 +1,59 @@
+package io.bluetape4k.http.ktor
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.HttpClientEngineConfig
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.engine.cio.CIOEngineConfig
+
+/**
+ * Creates an [HttpClient] with the given [engineFactory] and optional [block] configuration.
+ *
+ * ## Behavior / Contract
+ * - The caller owns the returned [HttpClient] and is responsible for calling [HttpClient.close].
+ * - No plugins, defaults, or policies are installed; configuration is entirely up to the caller.
+ * - `ktor-client-core` and the chosen engine artifact are declared `compileOnly` in this module.
+ *   Consumers must add the required Ktor artifacts to their own compile classpath.
+ *
+ * ```kotlin
+ * val client = ktorHttpClientOf(CIO) {
+ *     engine {
+ *         requestTimeout = 10_000
+ *     }
+ * }
+ * client.use { /* requests */ }
+ * ```
+ *
+ * @param engineFactory the Ktor [HttpClientEngineFactory] to use (e.g. [CIO], OkHttp, Java)
+ * @param block optional [HttpClientConfig] DSL block applied after engine selection
+ * @return a new [HttpClient] instance
+ */
+fun <T : HttpClientEngineConfig> ktorHttpClientOf(
+    engineFactory: HttpClientEngineFactory<T>,
+    block: HttpClientConfig<T>.() -> Unit = {},
+): HttpClient = HttpClient(engineFactory, block)
+
+/**
+ * Creates an [HttpClient] backed by the Ktor CIO engine.
+ *
+ * ## Behavior / Contract
+ * - CIO is suspend-native and supports HTTP/1.x only. It does not support HTTP/2.
+ * - For HTTP/2 use cases prefer HC5 Async, JDK, or OkHttp engines.
+ * - The caller owns the returned [HttpClient] and is responsible for calling [HttpClient.close].
+ *
+ * ```kotlin
+ * val client = ktorCioHttpClientOf {
+ *     engine {
+ *         requestTimeout = 10_000
+ *     }
+ * }
+ * client.use { /* requests */ }
+ * ```
+ *
+ * @param block optional [HttpClientConfig] DSL block for CIO-specific configuration
+ * @return a new [HttpClient] backed by the CIO engine
+ */
+fun ktorCioHttpClientOf(
+    block: HttpClientConfig<CIOEngineConfig>.() -> Unit = {},
+): HttpClient = HttpClient(CIO, block)

--- a/io/http/src/test/kotlin/io/bluetape4k/http/ktor/KtorHttpClientSupportTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/ktor/KtorHttpClientSupportTest.kt
@@ -1,0 +1,60 @@
+package io.bluetape4k.http.ktor
+
+import io.bluetape4k.http.AbstractHttpTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.KLogging
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.assertions.shouldNotBeBlank
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class KtorHttpClientSupportTest : AbstractHttpTest() {
+
+    companion object : KLogging()
+
+    @Test
+    fun `ktorCioHttpClientOf creates CIO-backed client`() {
+        val client = ktorCioHttpClientOf()
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `ktorCioHttpClientOf applies config block`() {
+        val client = ktorCioHttpClientOf {
+            engine {
+                requestTimeout = 5_000
+            }
+        }
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `ktorCioHttpClientOf GET request returns 200`() = runSuspendIO {
+        val client = ktorCioHttpClientOf()
+        try {
+            val response = client.get("$httpbinBaseUrl/get")
+            response.status shouldBeEqualTo HttpStatusCode.OK
+            response.bodyAsText().shouldNotBeBlank()
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `ktorHttpClientOf with CIO engine GET request returns 200`() = runSuspendIO {
+        val client = ktorHttpClientOf(io.ktor.client.engine.cio.CIO)
+        try {
+            val response = client.get("$httpbinBaseUrl/get")
+            response.status shouldBeEqualTo HttpStatusCode.OK
+        } finally {
+            client.close()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #418

- PR 제목: feat: add optional Ktor Client helpers to io/http (#418)

Adds `io.bluetape4k.http.ktor` package with minimal Ktor Client factory helpers to the `bluetape4k-http` module.

Closes #418

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### New files
- `io/http/src/main/kotlin/io/bluetape4k/http/ktor/KtorHttpClientSupport.kt` — two factory functions
- `io/http/src/test/kotlin/io/bluetape4k/http/ktor/KtorHttpClientSupportTest.kt` — 4 tests using BluetapeHttpServer

### Modified files
- `gradle/libs.versions.toml` — added `ktor-client-core`, `ktor-client-cio`, `ktor-client-mock` entries (Ktor 3.4.3 version already existed)
- `io/http/build.gradle.kts` — `compileOnly` for core+cio, `testImplementation` for mock
- `io/http/README.md` — Ktor CIO in backend comparison table, architecture diagram, module structure, dependencies, references
- `io/http/README.ko.md` — same updates in Korean

### 기존 섹션: API

```kotlin
// Generic factory for any Ktor engine
fun <T : HttpClientEngineConfig> ktorHttpClientOf(
    engineFactory: HttpClientEngineFactory<T>,
    block: HttpClientConfig<T>.() -> Unit = {},
): HttpClient

// Convenience factory for CIO engine (HTTP/1.x)
fun ktorCioHttpClientOf(
    block: HttpClientConfig<CIOEngineConfig>.() -> Unit = {},
): HttpClient
```

### 기존 섹션: Design decisions

- Follows the existing optional backend model: `compileOnly` dependencies, consumers add what they need
- No common `BluetapeHttpClient` abstraction introduced (non-goal per issue)
- No plugins, no opinionated defaults — caller owns full configuration and lifecycle
- CIO is HTTP/1.x only; README documents this limitation explicitly

### 기존 섹션: Verification commands

```bash
./gradlew :bluetape4k-http:compileKotlin :bluetape4k-http:compileTestKotlin
./gradlew :bluetape4k-http:test --tests "io.bluetape4k.http.ktor.*"
```

### 기존 섹션: Notes

- Codex review attempted but skipped due to `oh-my-codex` CLI infrastructure failure (patch error)
- Tier 4 Claude code review performed; `compileOnly` consumer requirement added to KDoc

## Validation

```
Module : :bluetape4k-http
Result : 4 passing, 0 failed, 0 skipped
Time   : 5.4s
Command: ./gradlew :bluetape4k-http:test --tests "io.bluetape4k.http.ktor.*"
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #418, milestone 없음, assignee `debop`
- PR: #454, head `ac05d2cc3c1011ed1eaa9617b6a4b57c664fb6f5`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/issue-418-ktor-http-client`
- Labels: 없음
- State: `MERGED`, merge commit `f6f9a5cfc1a410b07119e0256211df8076149c2b`
- CI: - `gradle/libs.versions.toml` — added `ktor-client-core`, `ktor-client-cio`, `ktor-client-mock` entries (Ktor 3.4.3 version already existed) / - `io/http/build.gradle.kts` — `compileOnly` for core+cio, `testImplementation` for mock / - `io/http/README.md` — Ktor CIO in backend comparison table, architecture diagram, module structure, dependencies, references

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #454 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `f6f9a5cfc1a410b07119e0256211df8076149c2b`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
