### PR TITLE
feat: add GrafanaServer to testcontainers infra package (#448)

### DIFF
--- a/docs/lessons/2026-05-15-grafana-server.md
+++ b/docs/lessons/2026-05-15-grafana-server.md
@@ -1,0 +1,52 @@
+# Lessons Learned — GrafanaServer testcontainers (2026-05-15)
+
+**관련 PR**: #455
+**영향 모듈**: `:bluetape4k-testcontainers`
+
+## L1: Apache HttpComponents 5 fluent API — `basicAuth`는 존재하지 않음
+
+### 문제
+`Request.basicAuth(user, password)` 호출 시 컴파일 오류 (`Unresolved reference`). HC5 fluent `Request`에는 `basicAuth` 메서드가 없다.
+
+### 교훈
+HC5 fluent API로 Basic Auth를 설정할 때는 `addHeader("Authorization", "Basic <base64>")` 형식으로 직접 추가해야 한다.
+
+---
+
+## L2: Apache HttpComponents 5 timeout 타입은 `java.time.Duration`이 아님
+
+### 문제
+`connectTimeout(Duration.ofSeconds(10))` 호출 시 타입 불일치 컴파일 오류. HC5의 `connectTimeout` / `responseTimeout`은 `org.apache.hc.core5.util.Timeout`을 요구한다.
+
+### 교훈
+HC5 fluent API 타임아웃은 `Timeout.ofSeconds(N)` 사용. `java.time.Duration`은 `HttpWaitStrategy`(Testcontainers) 에서만 사용.
+
+---
+
+## L3: `withXxx` 네이밍 — Testcontainers 관례와 충돌
+
+### 문제
+Testcontainers 전체 생태계에서 `withXxx()` 메서드는 컨테이너 시작 전 설정 용도. 그러나 `withPrometheusDataSource` / `withDashboard`는 시작 후 HTTP 호출이 필요한 메서드다. 코드 리뷰에서 두 리뷰어 모두 지적.
+
+### 교훈
+이슈에서 지정한 메서드명이라 유지했지만, 향후 유사 패턴 설계 시 `provision*` / `add*` 접두사를 사용하는 것이 의도를 더 명확히 전달한다.
+
+---
+
+## L4: JSON string interpolation — URL 이스케이프 필수
+
+### 문제
+`"url":"$prometheusUrl"` 형태의 raw string interpolation은 URL에 `"` 또는 `\`가 포함될 경우 malformed JSON을 생성.
+
+### 교훈
+JSON body에 외부 입력값을 인라인할 때는 최소한 `replace("\\", "\\\\").replace("\"", "\\\"")` 이스케이프를 적용. 이상적으로는 JSON 라이브러리를 사용.
+
+---
+
+## L5: 테스트 assertion은 동작 결과를 직접 검증해야 함
+
+### 문제
+초기 datasource 프로비저닝 테스트가 `server.isRunning.shouldBeTrue()`만 검사 — 프로비저닝이 실제로 성공했는지 무관한 assertion이었음 (코드 리뷰에서 "tautological" 지적).
+
+### 교훈
+provisioning/side-effect 테스트는 반드시 해당 동작의 결과를 API 호출로 검증: `GET /api/datasources` → response body에 `"Prometheus"` 포함 여부.

--- a/testing/testcontainers/build.gradle.kts
+++ b/testing/testcontainers/build.gradle.kts
@@ -163,6 +163,9 @@ dependencies {
     compileOnly(libs.testcontainers.vault)
     compileOnly(libs.vault.java.driver)
 
+    // Apache HttpComponents 5 — used by GrafanaServer for Grafana HTTP API provisioning
+    implementation(libs.httpclient5.fluent)
+
     // OkHttp
     testImplementation(libs.okhttp3)
 

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/GrafanaServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/GrafanaServer.kt
@@ -1,0 +1,200 @@
+package io.bluetape4k.testcontainers.infra
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.testcontainers.GenericServer
+import io.bluetape4k.testcontainers.PropertyExportingServer
+import io.bluetape4k.testcontainers.exposeCustomPorts
+import io.bluetape4k.utils.ShutdownQueue
+import org.apache.hc.client5.http.fluent.Request
+import org.apache.hc.core5.http.ContentType
+import org.apache.hc.core5.util.Timeout
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy
+import org.testcontainers.utility.DockerImageName
+import java.time.Duration
+import java.util.Base64
+
+/**
+ * Runs a [Grafana](https://grafana.com/) server in Docker for integration tests.
+ *
+ * Follows the same `GenericServer + Launcher` pattern as [PrometheusServer].
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * val grafana = GrafanaServer().apply { start() }
+ * // grafana.url → "http://localhost:<mappedPort>"
+ *
+ * // Provision a Prometheus datasource after start:
+ * grafana.withPrometheusDataSource("http://prometheus-host:9090")
+ * ```
+ *
+ * ## Behavior / Contract
+ *
+ * - Wait strategy: `GET /api/health` returns HTTP 200 before the container is considered ready.
+ * - Default credentials: admin / admin.
+ * - [withPrometheusDataSource] and [withDashboard] must be called **after** [start].
+ */
+class GrafanaServer private constructor(
+    imageName: DockerImageName,
+    useDefaultPort: Boolean,
+    reuse: Boolean,
+): GenericContainer<GrafanaServer>(imageName), GenericServer, PropertyExportingServer {
+
+    companion object: KLogging() {
+        /** Grafana Docker Hub image name. */
+        const val IMAGE = "grafana/grafana"
+
+        /** Default Docker image tag. */
+        const val TAG = "11.6.1"
+
+        /** Server identifier used for system property registration. */
+        const val NAME = "grafana"
+
+        /** Grafana HTTP port. */
+        const val PORT = 3000
+
+        /** Default admin username. */
+        const val ADMIN_USER = "admin"
+
+        /** Default admin password. */
+        const val ADMIN_PASSWORD = "admin"
+
+        /**
+         * Creates a [GrafanaServer] from a pre-built [DockerImageName].
+         *
+         * @param imageName      Fully qualified Docker image name with tag.
+         * @param useDefaultPort When `true`, binds port [PORT] to the same fixed host port.
+         * @param reuse          Whether to reuse an existing container across test runs.
+         */
+        @JvmStatic
+        operator fun invoke(
+            imageName: DockerImageName,
+            useDefaultPort: Boolean = false,
+            reuse: Boolean = true,
+        ): GrafanaServer = GrafanaServer(imageName, useDefaultPort, reuse)
+
+        /**
+         * Creates a [GrafanaServer] by image name and tag.
+         *
+         * @param image          Docker image name; blank value throws [IllegalArgumentException].
+         * @param tag            Docker image tag; blank value throws [IllegalArgumentException].
+         * @param useDefaultPort When `true`, binds port [PORT] to the same fixed host port.
+         * @param reuse          Whether to reuse an existing container across test runs.
+         */
+        @JvmStatic
+        operator fun invoke(
+            image: String = IMAGE,
+            tag: String = TAG,
+            useDefaultPort: Boolean = false,
+            reuse: Boolean = true,
+        ): GrafanaServer {
+            image.requireNotBlank("image")
+            tag.requireNotBlank("tag")
+            val imageName = DockerImageName.parse(image).withTag(tag)
+            return GrafanaServer(imageName, useDefaultPort, reuse)
+        }
+    }
+
+    override val port: Int get() = getMappedPort(PORT)
+    override val url: String get() = "http://$host:$port"
+
+    override val propertyNamespace: String = NAME
+
+    override fun propertyKeys(): Set<String> = setOf("host", "port", "url")
+
+    override fun properties(): Map<String, String> = mapOf(
+        "host" to host,
+        "port" to port.toString(),
+        "url" to url,
+    )
+
+    init {
+        addExposedPort(PORT)
+        withReuse(reuse)
+        withEnv("GF_SECURITY_ADMIN_USER", ADMIN_USER)
+        withEnv("GF_SECURITY_ADMIN_PASSWORD", ADMIN_PASSWORD)
+
+        setWaitStrategy(
+            HttpWaitStrategy()
+                .forPort(PORT)
+                .forPath("/api/health")
+                .forStatusCode(200)
+                .withStartupTimeout(Duration.ofSeconds(60))
+        )
+
+        if (useDefaultPort) {
+            exposeCustomPorts(PORT)
+        }
+    }
+
+    override fun start() {
+        super.start()
+        writeToSystemProperties()
+    }
+
+    /**
+     * Provisions a Prometheus datasource in Grafana via the HTTP API.
+     *
+     * Must be called **after** [start].
+     *
+     * @param prometheusUrl Base URL of the Prometheus server (e.g. `"http://prometheus:9090"`).
+     * @throws RuntimeException if the Grafana API returns a non-2xx status.
+     */
+    fun withPrometheusDataSource(prometheusUrl: String): GrafanaServer = apply {
+        prometheusUrl.requireNotBlank("prometheusUrl")
+        val escapedUrl = prometheusUrl.replace("\\", "\\\\").replace("\"", "\\\"")
+        val body = """{"name":"Prometheus","type":"prometheus","url":"$escapedUrl","access":"proxy","isDefault":true}"""
+        grafanaPost("/api/datasources", body)
+    }
+
+    /**
+     * Provisions a dashboard in Grafana from a JSON model string.
+     *
+     * Must be called **after** [start].
+     *
+     * @param dashboardJson Grafana dashboard JSON (the value of the `dashboard` property in the import format).
+     * @throws RuntimeException if the Grafana API returns a non-2xx status.
+     */
+    fun withDashboard(dashboardJson: String): GrafanaServer = apply {
+        dashboardJson.requireNotBlank("dashboardJson")
+        val body = """{"dashboard":$dashboardJson,"overwrite":true,"folderId":0}"""
+        grafanaPost("/api/dashboards/db", body)
+    }
+
+    private fun grafanaPost(path: String, jsonBody: String) {
+        val credentials = Base64.getEncoder().encodeToString("$ADMIN_USER:$ADMIN_PASSWORD".toByteArray())
+        val response = Request.post("$url$path")
+            .addHeader("Accept", "application/json")
+            .addHeader("Authorization", "Basic $credentials")
+            .bodyString(jsonBody, ContentType.APPLICATION_JSON)
+            .connectTimeout(Timeout.ofSeconds(10))
+            .responseTimeout(Timeout.ofSeconds(10))
+            .execute()
+            .returnResponse()
+
+        check(response.code in 200..299) {
+            "Grafana API POST $path returned ${response.code}"
+        }
+    }
+
+    /**
+     * Singleton launcher for reuse across tests.
+     */
+    object Launcher {
+        val grafana: GrafanaServer by lazy {
+            GrafanaServer().apply {
+                start()
+                ShutdownQueue.register(this)
+            }
+        }
+
+        val defaultGrafana: GrafanaServer by lazy {
+            GrafanaServer(useDefaultPort = true).apply {
+                start()
+                ShutdownQueue.register(this)
+            }
+        }
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/GrafanaServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/GrafanaServerTest.kt
@@ -1,0 +1,89 @@
+package io.bluetape4k.testcontainers.infra
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import org.apache.hc.client5.http.fluent.Request
+import org.junit.jupiter.api.Test
+
+class GrafanaServerTest: AbstractContainerTest() {
+
+    companion object: KLogging()
+
+    @Test
+    fun `launch grafana server`() {
+        GrafanaServer().use { server ->
+            server.start()
+            server.isRunning.shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `launch grafana server with default port`() {
+        GrafanaServer(useDefaultPort = true).use { server ->
+            server.start()
+            server.isRunning.shouldBeTrue()
+            server.port shouldBeEqualTo GrafanaServer.PORT
+        }
+    }
+
+    @Test
+    fun `GET api health returns 200`() {
+        GrafanaServer().use { server ->
+            server.start()
+            val statusCode = Request.get("${server.url}/api/health")
+                .execute()
+                .returnResponse()
+                .code
+            statusCode shouldBeEqualTo 200
+        }
+    }
+
+    @Test
+    fun `provision prometheus datasource and verify via api`() {
+        GrafanaServer().use { server ->
+            server.start()
+            server.withPrometheusDataSource("http://prometheus:9090")
+
+            val body = Request.get("${server.url}/api/datasources")
+                .addHeader("Authorization", basicAuth(GrafanaServer.ADMIN_USER, GrafanaServer.ADMIN_PASSWORD))
+                .execute()
+                .returnContent()
+                .asString()
+
+            body shouldContain "Prometheus"
+        }
+    }
+
+    @Test
+    fun `provision dashboard and verify via api`() {
+        val minimalDashboard = """{"title":"Test Dashboard","panels":[],"schemaVersion":36}"""
+
+        GrafanaServer().use { server ->
+            server.start()
+            server.withDashboard(minimalDashboard)
+
+            val body = Request.get("${server.url}/api/search?type=dash-db")
+                .addHeader("Authorization", basicAuth(GrafanaServer.ADMIN_USER, GrafanaServer.ADMIN_PASSWORD))
+                .execute()
+                .returnContent()
+                .asString()
+
+            body shouldContain "Test Dashboard"
+        }
+    }
+
+    @Test
+    fun `blank image or tag is not allowed`() {
+        assertFailsWith<IllegalArgumentException> { GrafanaServer(image = " ") }
+        assertFailsWith<IllegalArgumentException> { GrafanaServer(tag = " ") }
+    }
+
+    private fun basicAuth(user: String, password: String): String {
+        val encoded = java.util.Base64.getEncoder().encodeToString("$user:$password".toByteArray())
+        return "Basic $encoded"
+    }
+}


### PR DESCRIPTION
## Summary

Closes #448

- PR 제목: feat: add GrafanaServer to testcontainers infra package (#448)

Closes #448

Adds `GrafanaServer` to the `testing/testcontainers` infra package, following the same `GenericServer + Launcher` pattern as `PrometheusServer`.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

| File | Change |
|------|--------|
| `testing/testcontainers/build.gradle.kts` | Add `implementation(libs.httpclient5.fluent)` |
| `infra/GrafanaServer.kt` | New — `GrafanaServer` class |
| `infra/GrafanaServerTest.kt` | New — 6 integration tests |

- **Image**: `grafana/grafana:11.6.1`
- **Port**: 3000
- **Wait strategy**: `HttpWaitStrategy` polling `GET /api/health` for HTTP 200 (60s timeout)
- **HTTP provisioning**: Apache HttpComponents 5 fluent API for `withPrometheusDataSource` / `withDashboard` calls from the JVM side
- **Launcher**: `Launcher.grafana` and `Launcher.defaultGrafana` singletons matching `PrometheusServer.Launcher` pattern

### 기존 섹션: Acceptance Criteria

- [x] `GrafanaServer` starts; `GET /api/health` returns 200
- [x] `Launcher.grafana` singleton matches `PrometheusServer.Launcher` pattern
- [x] `withPrometheusDataSource(url)` provisions Prometheus datasource (verified via `GET /api/datasources`)
- [x] `withDashboard(json)` loads dashboard JSON (verified via `GET /api/search`)
- [x] Unit test in `testing/testcontainers` module

## Validation

```
Module : :bluetape4k-testcontainers
Tests  : 6 passing, 0 failed, 0 skipped
Time   : 12.457s
Command: ./gradlew :bluetape4k-testcontainers:test --tests "io.bluetape4k.testcontainers.infra.GrafanaServerTest"
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #448, milestone 없음, assignee `debop`
- PR: #455, head `ddd162e6bd5255ec3cb2a5383f849c9c0908454b`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/issue-448-grafana-server`
- Labels: `enhancement`, `test`
- State: `MERGED`, merge commit `991ac37412634c13ae9159904ba4467fd9b2d042`
- CI: | `testing/testcontainers/build.gradle.kts` | Add `implementation(libs.httpclient5.fluent)` | / Command: ./gradlew :bluetape4k-testcontainers:test --tests "io.bluetape4k.testcontainers.infra.GrafanaServerTest"

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #455 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `991ac37412634c13ae9159904ba4467fd9b2d042`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
