### PR TITLE
feat: add K3sServer to testcontainers infra package (#449)

### DIFF
--- a/docs/lessons/2026-05-15-k3s-server.md
+++ b/docs/lessons/2026-05-15-k3s-server.md
@@ -1,0 +1,41 @@
+# Lessons Learned — K3sServer testcontainers (2026-05-15)
+
+**관련 PR**: (생성 예정)
+**영향 모듈**: `:bluetape4k-testcontainers`
+
+## L1: K3sContainer의 `kubeConfigYaml`은 Jackson YAML pretty-printer로 직렬화됨
+
+### 문제
+`yaml.contains("server: https://")` assertion 실패. 실제 YAML은 Jackson이 URL 값을 따옴표로 감싸서 `server: "https://..."` 형태로 출력한다.
+
+### 교훈
+testcontainers K3sContainer는 kubeconfig를 Jackson YAML `writerWithDefaultPrettyPrinter()`로 재직렬화한다. 문자열 비교 시 `"https://"` 전체를 포함하는 형태로 검사하거나, 포트 번호만 확인하는 방식을 사용해야 한다.
+
+---
+
+## L2: `@Tag("k8s")` 태그만으로는 CI 실행 차단 불충분
+
+### 문제
+`@Tag("k8s")`는 선언적 메타데이터일 뿐이고, Gradle `useJUnitPlatform { excludeTags("k8s") }`가 없으면 일반 CI에서도 K3s 테스트가 실행된다. GitHub Actions `ubuntu-latest`는 비권한 환경이므로 K3s가 시작 실패한다.
+
+### 교훈
+K8s/Docker privileged 테스트는 반드시:
+1. `build.gradle.kts` `tasks.test { useJUnitPlatform { excludeTags("k8s") } }` 추가
+2. 별도 `k8sTest` task로 privileged runner에서만 실행
+
+---
+
+## L3: `kubernetesClient()` 반환 객체 자동 정리
+
+### 결정
+`kubernetesClient()`에서 생성한 `KubernetesClient`를 `ShutdownQueue.register(it)`로 등록. 호출자가 `.use { }` 없이도 JVM 종료 시 자동 정리된다.
+
+---
+
+## L4: reuse=true 컨테이너의 리소스 충돌
+
+### 문제
+`create namespace/lease → assert → delete` 시퀀스에서 중간에 테스트가 실패하면 리소스가 남아 다음 실행에서 `AlreadyExistsException` 발생.
+
+### 교훈
+singleton 컨테이너를 재사용할 때 각 테스트는 `try/finally`로 cleanup을 보장하거나 `@AfterEach`에서 `runCatching { }` 패턴으로 리소스를 제거해야 한다.

--- a/testing/testcontainers/build.gradle.kts
+++ b/testing/testcontainers/build.gradle.kts
@@ -40,6 +40,26 @@ kover {
 tasks.test {
     dependsOn(":bluetape4k-mock-web-server:jibDockerBuild")
     dependsOn(":bluetape4k-mock-webflux-server:jibDockerBuild")
+    useJUnitPlatform {
+        // K3s requires a privileged Docker runner. Excluded from regular CI by default.
+        // Enable with: ./gradlew :bluetape4k-testcontainers:test -PincludeK8s
+        if (!project.hasProperty("includeK8s")) {
+            excludeTags("k8s")
+        }
+    }
+}
+
+// Separate task for k8s-tagged tests (nightly privileged runner).
+tasks.register<Test>("k8sTest") {
+    description = "Runs @Tag(\"k8s\") tests — requires a privileged Docker runner."
+    group = "verification"
+    dependsOn(":bluetape4k-mock-web-server:jibDockerBuild")
+    dependsOn(":bluetape4k-mock-webflux-server:jibDockerBuild")
+    useJUnitPlatform {
+        includeTags("k8s")
+    }
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
 }
 
 dependencies {
@@ -110,6 +130,11 @@ dependencies {
     api(libs.testcontainers.cassandra)
     compileOnly(libs.cassandra.java.driver.core)
     compileOnly(libs.cassandra.java.driver.query.builder)
+
+    // Kubernetes (K3s)
+    api(libs.testcontainers.k3s)
+    compileOnly(libs.fabric8.kubernetes.client)
+    testImplementation(libs.fabric8.kubernetes.client)
 
     // Graph DB (Neo4j)
     compileOnly(libs.testcontainers.neo4j)

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/K3sServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/K3sServer.kt
@@ -1,0 +1,149 @@
+package io.bluetape4k.testcontainers.infra
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.testcontainers.GenericServer
+import io.bluetape4k.testcontainers.PropertyExportingServer
+import io.bluetape4k.testcontainers.exposeCustomPorts
+import io.bluetape4k.utils.ShutdownQueue
+import io.fabric8.kubernetes.client.Config
+import io.fabric8.kubernetes.client.KubernetesClient
+import io.fabric8.kubernetes.client.KubernetesClientBuilder
+import org.testcontainers.k3s.K3sContainer
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * Runs a [K3s](https://k3s.io/) lightweight Kubernetes cluster in Docker for integration tests.
+ *
+ * Extends the native testcontainers [K3sContainer] and adds the bluetape4k
+ * `GenericServer + Launcher` pattern.
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * val k3s = K3sServer().apply { start() }
+ * val client = k3s.kubernetesClient()
+ * client.namespaces().list().items  // at least 1 (default)
+ * ```
+ *
+ * ## Behavior / Contract
+ *
+ * - Requires a Docker daemon that supports `--privileged` mode (handled by [K3sContainer]).
+ * - Wait strategy: K3s API server ready (handled by [K3sContainer]).
+ * - [kubernetesClient] must be called **after** [start].
+ * - CI note: K3s requires a privileged Docker runner. Tag tests with `@Tag("k8s")` for nightly-only.
+ */
+class K3sServer private constructor(
+    imageName: DockerImageName,
+    useDefaultPort: Boolean,
+    reuse: Boolean,
+): K3sContainer(imageName), GenericServer, PropertyExportingServer {
+
+    companion object: KLogging() {
+        /** K3s Docker Hub image name. */
+        const val IMAGE = "rancher/k3s"
+
+        /** Default Docker image tag. */
+        const val TAG = "v1.32.4-k3s1"
+
+        /** Server identifier used for system property registration. */
+        const val NAME = "k3s"
+
+        /** Kubernetes API server port. */
+        const val API_PORT = 6443
+
+        /**
+         * Creates a [K3sServer] from a pre-built [DockerImageName].
+         *
+         * @param imageName      Fully qualified Docker image name with tag.
+         * @param useDefaultPort When `true`, binds port [API_PORT] to the same fixed host port.
+         * @param reuse          Whether to reuse an existing container across test runs.
+         */
+        @JvmStatic
+        operator fun invoke(
+            imageName: DockerImageName,
+            useDefaultPort: Boolean = false,
+            reuse: Boolean = true,
+        ): K3sServer = K3sServer(imageName, useDefaultPort, reuse)
+
+        /**
+         * Creates a [K3sServer] by image name and tag.
+         *
+         * @param image          Docker image name; blank value throws [IllegalArgumentException].
+         * @param tag            Docker image tag; blank value throws [IllegalArgumentException].
+         * @param useDefaultPort When `true`, binds port [API_PORT] to the same fixed host port.
+         * @param reuse          Whether to reuse an existing container across test runs.
+         */
+        @JvmStatic
+        operator fun invoke(
+            image: String = IMAGE,
+            tag: String = TAG,
+            useDefaultPort: Boolean = false,
+            reuse: Boolean = true,
+        ): K3sServer {
+            image.requireNotBlank("image")
+            tag.requireNotBlank("tag")
+            val imageName = DockerImageName.parse(image).withTag(tag)
+            return K3sServer(imageName, useDefaultPort, reuse)
+        }
+    }
+
+    override val port: Int get() = getMappedPort(API_PORT)
+    override val url: String get() = "https://$host:$port"
+
+    /** Kubeconfig YAML with the server URL patched to the mapped host and port. */
+    val kubeConfig: String get() = kubeConfigYaml
+
+    override val propertyNamespace: String = NAME
+
+    override fun propertyKeys(): Set<String> = setOf("host", "port", "url")
+
+    override fun properties(): Map<String, String> = mapOf(
+        "host" to host,
+        "port" to port.toString(),
+        "url" to url,
+    )
+
+    init {
+        withReuse(reuse)
+
+        if (useDefaultPort) {
+            exposeCustomPorts(API_PORT)
+        }
+    }
+
+    override fun start() {
+        super.start()
+        writeToSystemProperties()
+    }
+
+    /**
+     * Returns a fabric8 [KubernetesClient] pre-configured for this K3s cluster.
+     *
+     * Must be called **after** [start]. Each call returns a **new** client instance
+     * registered in [ShutdownQueue] — it will be closed on JVM shutdown automatically.
+     * Use `.use { }` to close earlier when the client is no longer needed.
+     *
+     * **Runtime dependency required**: consumers must add `io.fabric8:kubernetes-client`
+     * to their runtime classpath; this library declares it as `compileOnly`.
+     */
+    fun kubernetesClient(): KubernetesClient {
+        val config = Config.fromKubeconfig(kubeConfig)
+        return KubernetesClientBuilder().withConfig(config).build()
+            .also { ShutdownQueue.register(it) }
+    }
+
+    /**
+     * Singleton launcher for reuse across tests.
+     *
+     * Note: K3s containers are slow to start. Prefer the singleton over creating new instances per test class.
+     */
+    object Launcher {
+        val k3s: K3sServer by lazy {
+            K3sServer().apply {
+                start()
+                ShutdownQueue.register(this)
+            }
+        }
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/K3sServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/K3sServerTest.kt
@@ -1,0 +1,94 @@
+package io.bluetape4k.testcontainers.infra
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.fabric8.kubernetes.api.model.NamespaceBuilder
+import io.fabric8.kubernetes.api.model.coordination.v1.LeaseBuilder
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+
+@Tag("k8s")
+class K3sServerTest: AbstractContainerTest() {
+
+    companion object: KLogging() {
+        private val k3s: K3sServer by lazy { K3sServer.Launcher.k3s }
+    }
+
+    @AfterEach
+    fun cleanup() {
+        runCatching {
+            k3s.kubernetesClient().use { it.namespaces().withName("test-ns").delete() }
+        }
+        runCatching {
+            k3s.kubernetesClient().use { it.leases().inNamespace("default").withName("test-lease").delete() }
+        }
+    }
+
+    @Test
+    fun `launch k3s server`() {
+        k3s.isRunning.shouldBeTrue()
+    }
+
+    @Test
+    fun `api server reachable at mapped port`() {
+        (k3s.port in 1..65535).shouldBeTrue()
+        k3s.port shouldBeEqualTo k3s.getMappedPort(K3sServer.API_PORT)
+    }
+
+    @Test
+    fun `kubeConfig returns valid yaml with patched server url`() {
+        val yaml = k3s.kubeConfig
+        yaml.shouldNotBeNull()
+        yaml.contains("https://").shouldBeTrue()         // protocol is HTTPS
+        yaml.contains(":${k3s.port}").shouldBeTrue()    // mapped port is patched in
+    }
+
+    @Test
+    fun `kubernetesClient can list nodes with at least one ready`() {
+        k3s.kubernetesClient().use { client ->
+            val nodes = client.nodes().list().items
+            (nodes.size >= 1).shouldBeTrue()
+            val allReady = nodes.all { node ->
+                node.status.conditions.any { it.type == "Ready" && it.status == "True" }
+            }
+            allReady.shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `create and delete namespace`() {
+        k3s.kubernetesClient().use { client ->
+            val ns = NamespaceBuilder()
+                .withNewMetadata().withName("test-ns").endMetadata()
+                .build()
+            client.namespaces().resource(ns).create()
+            try {
+                client.namespaces().withName("test-ns").get().shouldNotBeNull()
+            } finally {
+                client.namespaces().withName("test-ns").delete()
+            }
+        }
+    }
+
+    @Test
+    fun `create get and delete Lease object`() {
+        k3s.kubernetesClient().use { client ->
+            val lease = LeaseBuilder()
+                .withNewMetadata()
+                .withName("test-lease")
+                .withNamespace("default")
+                .endMetadata()
+                .build()
+            client.leases().inNamespace("default").resource(lease).create()
+            try {
+                client.leases().inNamespace("default").withName("test-lease").get().shouldNotBeNull()
+            } finally {
+                client.leases().inNamespace("default").withName("test-lease").delete()
+            }
+        }
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/K3sServerValidationTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/K3sServerValidationTest.kt
@@ -1,0 +1,25 @@
+package io.bluetape4k.testcontainers.infra
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Validation tests for [K3sServer] that do not require a running container.
+ * These run in regular CI without a privileged Docker runner.
+ */
+class K3sServerValidationTest: AbstractContainerTest() {
+
+    companion object: KLogging()
+
+    @Test
+    fun `blank image is not allowed`() {
+        assertFailsWith<IllegalArgumentException> { K3sServer(image = " ") }
+    }
+
+    @Test
+    fun `blank tag is not allowed`() {
+        assertFailsWith<IllegalArgumentException> { K3sServer(tag = " ") }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #449

- PR 제목: feat: add K3sServer to testcontainers infra package (#449)

Closes #449

Adds `K3sServer` to the `testing/testcontainers` infra package using the native `testcontainers-k3s` module.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

| File | Change |
|------|--------|
| `testing/testcontainers/build.gradle.kts` | Add k3s + fabric8 deps; `excludeTags("k8s")` + `k8sTest` task |
| `infra/K3sServer.kt` | New — `K3sServer` extending `K3sContainer` |
| `infra/K3sServerTest.kt` | New — 6 integration tests (`@Tag("k8s")`) |
| `infra/K3sServerValidationTest.kt` | New — 2 validation tests (no container, runs in CI) |

- **Base class**: `K3sContainer` (testcontainers-k3s 2.0.5) — privileged mode, wait strategy, kubeconfig extraction handled automatically
- **Image**: `rancher/k3s:v1.32.4-k3s1` (current latest)
- **API port**: 6443 (mapped)
- **kubernetesClient()**: returns fabric8 `KubernetesClient` pre-configured from `kubeConfig`, registered in `ShutdownQueue`
- **CI safety**: `@Tag("k8s")` + `excludeTags("k8s")` in default `test` task; separate `k8sTest` task for privileged runner

### 기존 섹션: Acceptance Criteria

- [x] `K3sServer` starts; API server reachable at `getMappedPort(6443)`
- [x] `kubeConfig` returns valid YAML with correct server URL
- [x] `kubernetesClient()` can list nodes — 1 node ready
- [x] `Launcher.k3s` singleton follows existing pattern
- [x] Integration test: create Namespace, create/get/delete Lease object
- [x] Privileged runner requirement documented in KDoc + lessons doc

## Validation

```
k8sTest (privileged): 6/6 passing  (14.7s)  — @Tag("k8s")
test    (regular CI):  2/2 passing  (0.9s)   — K3sServerValidationTest
Total:  8 tests, 0 failed
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #449, milestone 없음, assignee `debop`
- PR: #456, head `421b69f1c5f7c14d6b54bd62ae72443cc869e62c`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/issue-449-k3s-server`
- Labels: `enhancement`, `test`
- State: `MERGED`, merge commit `57ad806eabff3f9567f2e0b615c4195112114a6f`
- CI: | `testing/testcontainers/build.gradle.kts` | Add k3s + fabric8 deps; `excludeTags("k8s")` + `k8sTest` task | / | `infra/K3sServerValidationTest.kt` | New — 2 validation tests (no container, runs in CI) | / - **CI safety**: `@Tag("k8s")` + `excludeTags("k8s")` in default `test` task; separate `k8sTest` task for privileged runner

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #456 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `57ad806eabff3f9567f2e0b615c4195112114a6f`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
