### PR TITLE
ci: fix graphdb-memgraph timeout and remove from smoke scope

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -212,7 +212,7 @@ jobs:
               {
                   "group": "graphdb-memgraph",
                   "test_patterns": "io.bluetape4k.testcontainers.graphdb.MemgraphServerTest",
-                  "timeout_minutes": 12,
+                  "timeout_minutes": 25,
                   "max_attempts": 2,
                   "needs_mock_servers": False,
               },
@@ -261,7 +261,7 @@ jobs:
 
           scope = os.environ["SCOPE"]
           groups_by_scope = {
-              "smoke": ["database-contract", "misc-contract", "graphdb-memgraph", "aws-core"],
+              "smoke": ["database-contract", "misc-contract", "aws-core"],
               "full": [group["group"] for group in all_groups],
               "testcontainers": [group["group"] for group in all_groups],
               "graphdb": [


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: ci: fix graphdb-memgraph timeout and remove from smoke scope

## Background

Nightly run [#25878757380](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/25878757380) failed with exit code 124 (timeout) on the `graphdb-memgraph` job.

`nick-fields/retry` reported:
```
Attempt 1 failed. Reason: Child_process exited with error code 124
Final attempt failed. Child_process exited with error code 124
```

**Root causes:**
1. `timeout_minutes: 12` is too short — Memgraph container startup + test execution consistently exceeds 12 minutes
2. `graphdb-memgraph` was included in the `smoke` scope, which runs daily and is intended to be lightweight/fast

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

| File | Change |
|---|---|
| `nightly-tests.yml` | `graphdb-memgraph` `timeout_minutes`: 12 → 25 |
| `nightly-tests.yml` | Remove `graphdb-memgraph` from `smoke` scope |

**Smoke scope after:** `["database-contract", "misc-contract", "aws-core"]`
**Full/graphdb scopes:** unchanged — `graphdb-memgraph` still runs there with 25-minute timeout

### 기존 섹션: Verification

Plan script logic verified locally for all scopes (smoke, full, testcontainers, graphdb, aws). All assertions passed.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #460, head `e9b9e26772c61eefb07abe53c027bb7cf1cddf31`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/nightly-graphdb-memgraph-timeout`
- Labels: 없음
- State: `MERGED`, merge commit `ac7db1fb08d0da35c84fa5c972beb12f65471688`
- CI: Nightly run [#25878757380](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/25878757380) failed with exit code 124 (timeout) on the `graphdb-memgraph` job.

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #460 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `ac7db1fb08d0da35c84fa5c972beb12f65471688`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
