### PR TITLE
test: add PrometheusGrafanaIntegrationTest — Prometheus + Grafana observability stack (#457)

### DIFF
--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/PrometheusGrafanaIntegrationTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/PrometheusGrafanaIntegrationTest.kt
@@ -20,8 +20,10 @@ class PrometheusGrafanaIntegrationTest: AbstractContainerTest() {
         val prometheus: PrometheusServer by lazy { PrometheusServer.Launcher.prometheus }
         val grafana: GrafanaServer by lazy { GrafanaServer.Launcher.grafana }
 
+        // Stable UID ensures overwrite:true deduplicates correctly on container reuse
+        private const val DASHBOARD_UID = "bluetape4k-prometheus-integration"
         private val DASHBOARD_JSON =
-            """{"title":"Prometheus Integration","panels":[],"schemaVersion":36}"""
+            """{"uid":"$DASHBOARD_UID","title":"Prometheus Integration","panels":[],"schemaVersion":36}"""
 
         private fun basicAuth(): String {
             val encoded = Base64.getEncoder()
@@ -29,13 +31,17 @@ class PrometheusGrafanaIntegrationTest: AbstractContainerTest() {
             return "Basic $encoded"
         }
 
-        private fun datasourceExists(): Boolean {
-            val code = Request.get("${grafana.url}/api/datasources/name/Prometheus")
-                .addHeader("Authorization", basicAuth())
-                .execute()
-                .returnResponse()
-                .code
-            return code == 200
+        // Returns true only when a Prometheus datasource pointing at the current prometheus.url exists.
+        // Handles container reuse: a stale datasource with a different URL is treated as absent.
+        private fun datasourceUpToDate(): Boolean {
+            val body = runCatching {
+                Request.get("${grafana.url}/api/datasources/name/Prometheus")
+                    .addHeader("Authorization", basicAuth())
+                    .execute()
+                    .returnContent()
+                    .asString()
+            }.getOrNull() ?: return false
+            return body.contains(prometheus.url)
         }
     }
 
@@ -44,12 +50,12 @@ class PrometheusGrafanaIntegrationTest: AbstractContainerTest() {
         prometheus.isRunning.shouldBeTrue()
         grafana.isRunning.shouldBeTrue()
 
-        // Idempotent: skip POST if datasource already exists (container reuse)
-        if (!datasourceExists()) {
+        // Idempotent: only provision when datasource is absent or points at a stale URL
+        if (!datasourceUpToDate()) {
             grafana.withPrometheusDataSource(prometheus.url)
         }
 
-        // withDashboard uses overwrite:true — safe to call on every run
+        // Stable UID + overwrite:true → idempotent across container reuse
         grafana.withDashboard(DASHBOARD_JSON)
     }
 
@@ -76,7 +82,7 @@ class PrometheusGrafanaIntegrationTest: AbstractContainerTest() {
 
     @Test
     fun `provisioned dashboard is retrievable via api`() {
-        val body = Request.get("${grafana.url}/api/search?type=dash-db")
+        val body = Request.get("${grafana.url}/api/dashboards/uid/$DASHBOARD_UID")
             .addHeader("Authorization", basicAuth())
             .execute()
             .returnContent()

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/PrometheusGrafanaIntegrationTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/PrometheusGrafanaIntegrationTest.kt
@@ -1,0 +1,87 @@
+package io.bluetape4k.testcontainers.infra
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import org.apache.hc.client5.http.fluent.Request
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.Base64
+
+@Tag("infra")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PrometheusGrafanaIntegrationTest: AbstractContainerTest() {
+
+    companion object: KLogging() {
+        val prometheus: PrometheusServer by lazy { PrometheusServer.Launcher.prometheus }
+        val grafana: GrafanaServer by lazy { GrafanaServer.Launcher.grafana }
+
+        private val DASHBOARD_JSON =
+            """{"title":"Prometheus Integration","panels":[],"schemaVersion":36}"""
+
+        private fun basicAuth(): String {
+            val encoded = Base64.getEncoder()
+                .encodeToString("${GrafanaServer.ADMIN_USER}:${GrafanaServer.ADMIN_PASSWORD}".toByteArray())
+            return "Basic $encoded"
+        }
+
+        private fun datasourceExists(): Boolean {
+            val code = Request.get("${grafana.url}/api/datasources/name/Prometheus")
+                .addHeader("Authorization", basicAuth())
+                .execute()
+                .returnResponse()
+                .code
+            return code == 200
+        }
+    }
+
+    @BeforeAll
+    fun setup() {
+        prometheus.isRunning.shouldBeTrue()
+        grafana.isRunning.shouldBeTrue()
+
+        // Idempotent: skip POST if datasource already exists (container reuse)
+        if (!datasourceExists()) {
+            grafana.withPrometheusDataSource(prometheus.url)
+        }
+
+        // withDashboard uses overwrite:true — safe to call on every run
+        grafana.withDashboard(DASHBOARD_JSON)
+    }
+
+    @Test
+    fun `prometheus is reachable`() {
+        val statusCode = Request.get("${prometheus.url}/-/ready")
+            .execute()
+            .returnResponse()
+            .code
+        statusCode shouldBeEqualTo 200
+    }
+
+    @Test
+    fun `grafana datasource is connected to prometheus`() {
+        val body = Request.get("${grafana.url}/api/datasources")
+            .addHeader("Authorization", basicAuth())
+            .execute()
+            .returnContent()
+            .asString()
+
+        body shouldContain "Prometheus"
+        body shouldContain prometheus.url
+    }
+
+    @Test
+    fun `provisioned dashboard is retrievable via api`() {
+        val body = Request.get("${grafana.url}/api/search?type=dash-db")
+            .addHeader("Authorization", basicAuth())
+            .execute()
+            .returnContent()
+            .asString()
+
+        body shouldContain "Prometheus Integration"
+    }
+}


### PR DESCRIPTION
## Summary

Closes #457

- PR 제목: test: add PrometheusGrafanaIntegrationTest — Prometheus + Grafana observability stack (#457)

Closes #457

Adds `PrometheusGrafanaIntegrationTest` demonstrating `PrometheusServer` and `GrafanaServer` used together as a typical observability stack for integration tests.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

| File | Description |
|---|---|
| `testing/testcontainers/src/test/kotlin/.../PrometheusGrafanaIntegrationTest.kt` | New integration test (87 lines) |

### 기존 섹션: Design Decisions

- **Launcher singletons**: both containers use `Launcher.prometheus` / `Launcher.grafana` `by lazy` singletons per project convention
- **Idempotent `@BeforeAll`**: datasource provisioning checks `GET /api/datasources/name/Prometheus` first; skips `POST` on HTTP 200 (container reuse / `testcontainers.reuse.enable=true`)
- **Dashboard provisioning**: `withDashboard` uses `overwrite:true` internally — idempotent by design, safe to call on every run; moved to `@BeforeAll` to avoid side-effects inside `@Test` methods

### 기존 섹션: Acceptance Criteria

- [x] Both containers start via `Launcher` singletons
- [x] `withPrometheusDataSource(prometheus.url)` called once in `@BeforeAll`
- [x] Test verifies datasource reachable via `GET /api/datasources`
- [x] Test provisions and retrieves a minimal dashboard

## Validation

```
./gradlew :bluetape4k-testcontainers:test \
  --tests "io.bluetape4k.testcontainers.infra.PrometheusGrafanaIntegrationTest"

✔ prometheus is reachable()
✔ grafana datasource is connected to prometheus()
✔ provisioned dashboard is retrievable via api()

3 passing (6s) — BUILD SUCCESSFUL
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #457, milestone 없음, assignee `debop`
- PR: #462, head `abd4e44c19b3886e34ee1240cae4b626ad3847e6`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/issue-457-prometheus-grafana-integration`
- Labels: `examples`
- State: `MERGED`, merge commit `da56fca62bcd5fdf496ad254c92407e8062dee9e`
- CI: ## Design Decisions / ./gradlew :bluetape4k-testcontainers:test \

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #462 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `da56fca62bcd5fdf496ad254c92407e8062dee9e`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
