### PR TITLE
test: raise infra/kafka4 test coverage from 62% to 80.2% (issue #461)

### DIFF
--- a/docs/lessons/2026-05-15-kafka4-coverage.md
+++ b/docs/lessons/2026-05-15-kafka4-coverage.md
@@ -1,0 +1,62 @@
+# Lessons Learned — kafka4 coverage (2026-05-15)
+
+**관련 PR**: #464
+**영향 모듈**: `:bluetape4k-kafka4` (`infra/kafka4`)
+
+## L1: Kafka 4의 StreamPartitioner는 Optional<Set<Integer>>를 반환한다
+
+### 문제
+`StreamPartitioner` 람다에서 `Int`를 반환하는 코드를 작성했더니 컴파일 에러 발생.
+Kafka 4에서 `StreamPartitioner.partitions()` 반환 타입이 `Optional<Set<Integer>>`로 변경되었다.
+
+### 교훈
+Kafka Streams kstream DSL 테스트 작성 시, `StreamPartitioner` 람다는
+`Optional.of(setOf(partition))` 형태로 반환해야 한다.
+
+```kotlin
+val partitioner = StreamPartitioner<String, String> { _, key, _, numPartitions ->
+    Optional.of(setOf(Math.abs(key.hashCode()) % numPartitions))
+}
+```
+
+---
+
+## L2: KafkaOperationExtensions.kt의 함수는 통합 테스트가 필요하다
+
+### 문제
+`suspendSend`, `sendFlowAsParallel`, `sendAndForget` 등 `suspend inline` 확장 함수들은
+MockK로 단위 테스트하기 어렵다. `KafkaOperations.execute()` 내부에서
+콜백 방식으로 동작하기 때문이다.
+
+### 교훈
+`suspendCancellableCoroutine` + `execute { producer -> producer.send(...) { ... } }` 패턴의
+함수는 반드시 실제 Kafka 브로커(Testcontainers)를 이용한 통합 테스트로 커버해야 한다.
+`KafkaOperationsExtensionsTest` 패턴(AbstractKafkaTest + KafkaServer.Launcher.Spring.getStringProducerFactory)을 재사용한다.
+
+---
+
+## L3: 커버리지 목표 달성에는 낮은 패키지 먼저 파악 후 우선순위 선정이 효율적
+
+### 문제
+커버리지 보고서의 전체 수치만 보면 어느 파일이 병목인지 알기 어렵다.
+
+### 교훈
+`koverXmlReport` 생성 후 Python으로 XML 파싱하여 패키지/파일별 미커버 라인 수를
+내림차순으로 정렬하면, 최소한의 테스트로 최대 커버리지 향상을 달성할 수 있다.
+
+```python
+import xml.etree.ElementTree as ET
+tree = ET.parse("build/reports/kover/report.xml")
+# counter[@type='LINE'] per sourcefile 추출 후 missed 내림차순 정렬
+```
+
+---
+
+## L4: MCP GitHub 플러그인은 private repo에서 404를 반환한다
+
+### 문제
+`mcp__plugin_github_github__create_pull_request` 도구가 private repo에서 404 에러 반환.
+
+### 교훈
+bluetape4k-projects는 private repo이므로 모든 GitHub 작업은 `gh` CLI를 사용해야 한다.
+`gh pr create`, `gh pr view`, `gh issue create` 등을 활용한다.

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensionsIntegrationTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensionsIntegrationTest.kt
@@ -1,0 +1,130 @@
+@file:Suppress("removal", "DEPRECATION")
+
+package io.bluetape4k.kafka.spring.core
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.kafka.AbstractKafkaTest
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.testcontainers.mq.KafkaServer
+import io.bluetape4k.testcontainers.mq.Spring
+import kotlinx.coroutines.flow.flow
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.DisposableBean
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.core.ProducerFactory
+
+/**
+ * Integration tests for [KafkaOperationExtensions] using a real Kafka broker (Testcontainers).
+ *
+ * Covers: suspendSend, awaitSend, sendSuspending, sendFlowAsParallel, sendAndForget.
+ */
+class KafkaOperationExtensionsIntegrationTest: AbstractKafkaTest() {
+
+    companion object: KLoggingChannel() {
+        private const val TOPIC = "$TEST_TOPIC_NAME-ops-core-ext"
+    }
+
+    private lateinit var producerFactory: ProducerFactory<String, String>
+    private lateinit var kafkaTemplate: KafkaTemplate<String, String>
+
+    @BeforeEach
+    fun setup() {
+        producerFactory = KafkaServer.Launcher.Spring.getStringProducerFactory()
+        kafkaTemplate = KafkaTemplate(producerFactory, true).apply {
+            setDefaultTopic(TOPIC)
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        (producerFactory as? DisposableBean)?.destroy()
+    }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `suspendSend ProducerRecord 로 메시지 발송`() = runSuspendIO {
+        val record = ProducerRecord<String, String>(TOPIC, "key-1", "value-${System.currentTimeMillis()}")
+
+        val result = kafkaTemplate.suspendSend(record)
+
+        result.shouldNotBeNull()
+        result.recordMetadata.topic() shouldBeEqualTo TOPIC
+    }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `awaitSend deprecated - ProducerRecord 로 메시지 발송`() = runSuspendIO {
+        val record = ProducerRecord<String, String>(TOPIC, "key-await", "value-${System.currentTimeMillis()}")
+
+        @Suppress("DEPRECATION")
+        val result = kafkaTemplate.awaitSend(record)
+
+        result.shouldNotBeNull()
+        result.recordMetadata.topic() shouldBeEqualTo TOPIC
+    }
+
+    @RepeatedTest(REPEAT_SIZE)
+    fun `sendSuspending deprecated - ProducerRecord 로 메시지 발송`() = runSuspendIO {
+        val record = ProducerRecord<String, String>(TOPIC, "key-suspending", "value-${System.currentTimeMillis()}")
+
+        @Suppress("DEPRECATION")
+        val result = kafkaTemplate.sendSuspending(record)
+
+        result.shouldNotBeNull()
+        result.recordMetadata.topic() shouldBeEqualTo TOPIC
+    }
+
+    @Test
+    fun `sendFlowAsParallel - Flow 의 모든 레코드를 병렬 발송하고 마지막 결과 반환`() = runSuspendIO {
+        val records = flow {
+            repeat(3) { i ->
+                emit(ProducerRecord<String, String>(TOPIC, "flow-key-$i", "flow-value-$i"))
+            }
+        }
+
+        val result = kafkaTemplate.sendFlowAsParallel(records)
+
+        result.shouldNotBeNull()
+        result.recordMetadata.topic() shouldBeEqualTo TOPIC
+    }
+
+    @Test
+    fun `sendAndForget - Flow 의 모든 레코드를 발송하고 결과 무시`() = runSuspendIO {
+        val records = flow {
+            repeat(3) { i ->
+                emit(ProducerRecord<String, String>(TOPIC, "forget-key-$i", "forget-value-$i"))
+            }
+        }
+
+        // Should complete without throwing
+        kafkaTemplate.sendAndForget(records)
+    }
+
+    @Test
+    fun `sendAndForget needFlush true - 발송 후 flush 호출`() = runSuspendIO {
+        val records = flow {
+            repeat(2) { i ->
+                emit(ProducerRecord<String, String>(TOPIC, "flush-key-$i", "flush-value-$i"))
+            }
+        }
+
+        kafkaTemplate.sendAndForget(records, needFlush = true)
+    }
+
+    @Test
+    fun `getMetricValue deprecated - 존재하는 메트릭 이름으로 double 값 반환`() = runSuspendIO {
+        // Trigger a send to ensure metrics are populated
+        val record = ProducerRecord<String, String>(TOPIC, "metric-key", "metric-value")
+        kafkaTemplate.suspendSend(record)
+
+        @Suppress("DEPRECATION")
+        val value: Double = kafkaTemplate.getMetricValue("record-send-total")
+
+        value shouldBeGreaterOrEqualTo 0.0
+    }
+}

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensionsTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensionsTest.kt
@@ -1,0 +1,91 @@
+package io.bluetape4k.kafka.spring.core
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.KLogging
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.apache.kafka.common.Metric
+import org.apache.kafka.common.MetricName
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.kafka.core.KafkaOperations
+
+/**
+ * [getMetric], [getMetricValueOrNull] 확장 함수에 대한 MockK 단위 테스트입니다.
+ *
+ * suspendSend, sendFlowAsParallel, sendAndForget은 실제 Kafka 서버가 필요하므로
+ * 이 테스트에서는 제외합니다.
+ */
+class KafkaOperationExtensionsTest {
+
+    companion object : KLogging()
+
+    private lateinit var kafkaOps: KafkaOperations<String, String>
+    private lateinit var metricName: MetricName
+    private lateinit var metric: Metric
+
+    @BeforeEach
+    fun setup() {
+        kafkaOps = mockk(relaxed = true)
+        metricName = mockk()
+        metric = mockk()
+
+        every { metricName.name() } returns "record-send-total"
+        every { kafkaOps.metrics() } returns mapOf(metricName to metric)
+    }
+
+    @Test
+    fun `getMetric - 존재하는 메트릭 이름으로 조회 시 Metric 반환`() {
+        // Act
+        val result = kafkaOps.getMetric("record-send-total")
+
+        // Assert
+        result.shouldNotBeNull()
+
+        verify(exactly = 1) { kafkaOps.metrics() }
+        confirmVerified(kafkaOps)
+    }
+
+    @Test
+    fun `getMetric - 존재하지 않는 메트릭 이름으로 조회 시 null 반환`() {
+        // Act
+        val result = kafkaOps.getMetric("nonexistent")
+
+        // Assert
+        result.shouldBeNull()
+
+        verify(exactly = 1) { kafkaOps.metrics() }
+        confirmVerified(kafkaOps)
+    }
+
+    @Test
+    fun `getMetricValueOrNull - 존재하는 메트릭 이름으로 조회 시 메트릭 값 반환`() {
+        // Arrange
+        every { metric.metricValue() } returns 42.0
+
+        // Act
+        val result = kafkaOps.getMetricValueOrNull("record-send-total")
+
+        // Assert
+        result shouldBeEqualTo 42.0
+
+        verify(exactly = 1) { kafkaOps.metrics() }
+        confirmVerified(kafkaOps)
+    }
+
+    @Test
+    fun `getMetricValueOrNull - 존재하지 않는 메트릭 이름으로 조회 시 null 반환`() {
+        // Act
+        val result = kafkaOps.getMetricValueOrNull("nonexistent")
+
+        // Assert
+        result.shouldBeNull()
+
+        verify(exactly = 1) { kafkaOps.metrics() }
+        confirmVerified(kafkaOps)
+    }
+}

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/spring/core/ProducerFactorySupportTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/spring/core/ProducerFactorySupportTest.kt
@@ -1,0 +1,48 @@
+package io.bluetape4k.kafka.spring.core
+
+import io.bluetape4k.logging.KLogging
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.kafka.core.KafkaResourceHolder
+import org.springframework.kafka.core.ProducerFactoryUtils
+
+/**
+ * [KafkaResourceHolder.release] 확장 함수에 대한 단위 테스트입니다.
+ *
+ * [ProducerFactoryUtils.releaseResources]는 static 메서드이므로 [mockkStatic]을 사용합니다.
+ */
+class ProducerFactorySupportTest {
+
+    companion object : KLogging()
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(ProducerFactoryUtils::class)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(ProducerFactoryUtils::class)
+    }
+
+    @Test
+    fun `release - KafkaResourceHolder release 호출 시 ProducerFactoryUtils releaseResources 위임`() {
+        // Arrange
+        val holder = mockk<KafkaResourceHolder<String, String>>(relaxed = true)
+        every { ProducerFactoryUtils.releaseResources(any<KafkaResourceHolder<*, *>>()) } returns Unit
+
+        // Act
+        holder.release()
+
+        // Assert
+        verify(exactly = 1) { ProducerFactoryUtils.releaseResources(holder) }
+        confirmVerified(holder)
+    }
+}

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/spring/listener/ListenerUtilsTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/spring/listener/ListenerUtilsTest.kt
@@ -1,0 +1,77 @@
+package io.bluetape4k.kafka.spring.listener
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.KLogging
+import io.mockk.every
+import io.mockk.mockk
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.junit.jupiter.api.Test
+import org.springframework.kafka.listener.AcknowledgingMessageListener
+import org.springframework.kafka.listener.ContainerProperties
+import org.springframework.kafka.listener.ListenerType
+import org.springframework.kafka.listener.MessageListener
+import org.springframework.kafka.listener.MessageListenerContainer
+import org.springframework.kafka.support.Acknowledgment
+
+/**
+ * [listenerTypeOf], [stoppableSleep], [createOffsetAndMetadata] 확장 함수에 대한 단위 테스트입니다.
+ */
+class ListenerUtilsTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `MessageListener SAM 구현체 전달 시 ListenerType SIMPLE 반환`() {
+        // Arrange
+        val listener = MessageListener<String, String> { _ -> /* no-op */ }
+
+        // Act
+        val listenerType = listenerTypeOf(listener)
+
+        // Assert
+        listenerType shouldBeEqualTo ListenerType.SIMPLE
+    }
+
+    @Test
+    fun `AcknowledgingMessageListener 구현체 전달 시 ListenerType ACKNOWLEDGING 반환`() {
+        // Arrange
+        val listener = AcknowledgingMessageListener<String, String> { _: ConsumerRecord<String, String>, _: Acknowledgment? -> /* no-op */ }
+
+        // Act
+        val listenerType = listenerTypeOf(listener)
+
+        // Assert
+        listenerType shouldBeEqualTo ListenerType.ACKNOWLEDGING
+    }
+
+    @Test
+    fun `stoppableSleep - 컨테이너가 중지 상태이면 예외 없이 완료`() {
+        // Arrange
+        val container = mockk<MessageListenerContainer>(relaxed = true)
+        every { container.isRunning } returns false
+
+        // Act & Assert - 예외가 발생하지 않아야 함
+        // stoppableSleep 내부에서 isRunning 외 다른 mock 호출이 있을 수 있으므로 confirmVerified 미사용
+        container.stoppableSleep(50L)
+    }
+
+    @Test
+    fun `createOffsetAndMetadata - 지정한 오프셋으로 OffsetAndMetadata 생성`() {
+        // Arrange
+        // offsetAndMetadataProvider가 null인 실제 ContainerProperties를 사용해야
+        // ListenerUtils가 new OffsetAndMetadata(offset) 경로를 타서 정확한 offset 값을 반환함
+        val containerProps = ContainerProperties("test-topic")
+        // offsetAndMetadataProvider 기본값이 null이므로 별도 설정 불필요
+
+        val container = mockk<MessageListenerContainer>(relaxed = true)
+        every { container.containerProperties } returns containerProps
+
+        // Act
+        val metadata = container.createOffsetAndMetadata(100L)
+
+        // Assert
+        metadata.shouldNotBeNull()
+        metadata.offset() shouldBeEqualTo 100L
+    }
+}

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/spring/listener/adapter/AdapterUtilsTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/spring/listener/adapter/AdapterUtilsTest.kt
@@ -1,0 +1,40 @@
+package io.bluetape4k.kafka.spring.listener.adapter
+
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.Test
+
+/**
+ * [consumerRecordMetadataFromArray], [consumerRecordMetadataOf] 확장 함수에 대한 단위 테스트입니다.
+ */
+class AdapterUtilsTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `consumerRecordMetadataFromArray - 빈 배열 전달 시 null 반환`() {
+        // Act
+        val result = consumerRecordMetadataFromArray()
+
+        // Assert
+        result.shouldBeNull()
+    }
+
+    @Test
+    fun `consumerRecordMetadataFromArray - ConsumerRecordMetadata가 아닌 문자열 전달 시 null 반환`() {
+        // Act
+        val result = consumerRecordMetadataFromArray("non-metadata-string")
+
+        // Assert
+        result.shouldBeNull()
+    }
+
+    @Test
+    fun `consumerRecordMetadataOf - ConsumerRecordMetadata가 아닌 문자열 전달 시 null 반환`() {
+        // Act
+        val result = consumerRecordMetadataOf("non-metadata-string")
+
+        // Assert
+        result.shouldBeNull()
+    }
+}

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/streams/StreamConfigTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/streams/StreamConfigTest.kt
@@ -1,0 +1,33 @@
+package io.bluetape4k.kafka.streams
+
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.Test
+
+class StreamConfigTest {
+    companion object: KLogging()
+
+    @Test
+    fun `streamsConfigDef는 not null이다`() {
+        streamsConfigDef.shouldNotBeNull()
+    }
+
+    @Test
+    fun `streamsConfigDef는 application_id 설정 키를 포함한다`() {
+        val hasAppId = streamsConfigDef.configKeys().containsKey("application.id")
+        hasAppId.shouldBeTrue()
+    }
+
+    @Test
+    fun `streamsConfigDef는 bootstrap_servers 설정 키를 포함한다`() {
+        val hasBootstrap = streamsConfigDef.configKeys().containsKey("bootstrap.servers")
+        hasBootstrap.shouldBeTrue()
+    }
+
+    @Test
+    fun `streamsConfigDef는 비어있지 않다`() {
+        val keys = streamsConfigDef.configKeys()
+        keys.isNotEmpty().shouldBeTrue()
+    }
+}

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/streams/kstream/KStreamDslTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/streams/kstream/KStreamDslTest.kt
@@ -1,9 +1,12 @@
 package io.bluetape4k.kafka.streams.kstream
 
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.kafka.AbstractKafkaTest
 import io.bluetape4k.logging.coroutines.KLoggingChannel
-import io.bluetape4k.assertions.shouldNotBeNull
+import io.mockk.mockk
 import org.apache.kafka.common.serialization.Serdes
+import org.apache.kafka.common.utils.Bytes
 import org.apache.kafka.streams.Topology
 import org.apache.kafka.streams.kstream.Branched
 import org.apache.kafka.streams.kstream.Consumed
@@ -15,178 +18,239 @@ import org.apache.kafka.streams.kstream.Produced
 import org.apache.kafka.streams.kstream.Repartitioned
 import org.apache.kafka.streams.kstream.StreamJoined
 import org.apache.kafka.streams.kstream.TableJoined
+import org.apache.kafka.streams.kstream.Window
+import org.apache.kafka.streams.kstream.Windowed
+import org.apache.kafka.streams.processor.StreamPartitioner
+import org.apache.kafka.streams.processor.WallclockTimestampExtractor
+import java.util.Optional
 import org.apache.kafka.streams.state.KeyValueStore
+import org.apache.kafka.streams.state.SessionStore
+import org.apache.kafka.streams.state.Stores
+import org.apache.kafka.streams.state.WindowStore
 import org.junit.jupiter.api.Test
+import java.time.Duration
 
-/**
- * Kafka Streams KStream DSL 관련 유틸리티 함수에 대한 테스트 클래스입니다.
- */
 class KStreamDslTest: AbstractKafkaTest() {
     companion object: KLoggingChannel()
 
     @Test
     fun `consumedOf로 Consumed 인스턴스 생성`() {
-        val keySerde = Serdes.String()
-        val valueSerde = Serdes.String()
-
         val consumed: Consumed<String, String> =
             consumedOf(
-                keySerde = keySerde,
-                valueSerde = valueSerde,
+                keySerde = Serdes.String(),
+                valueSerde = Serdes.String(),
                 resetPolicy = Topology.AutoOffsetReset.EARLIEST,
             )
+        consumed.shouldNotBeNull()
+    }
 
+    @Test
+    fun `consumedOf with timestamp extractor`() {
+        val consumed: Consumed<String, String> =
+            consumedOf(
+                keySerde = Serdes.String(),
+                valueSerde = Serdes.String(),
+                timestampExtractor = WallclockTimestampExtractor(),
+            )
         consumed.shouldNotBeNull()
     }
 
     @Test
     fun `producedOf로 Produced 인스턴스 생성`() {
-        val keySerde = Serdes.String()
-        val valueSerde = Serdes.String()
-
         val produced: Produced<String, String> =
             producedOf(
-                keySerde = keySerde,
-                valueSerde = valueSerde,
+                keySerde = Serdes.String(),
+                valueSerde = Serdes.String(),
             )
-
         produced.shouldNotBeNull()
     }
 
     @Test
     fun `producedOf with processor name`() {
         val produced: Produced<String, String> = producedOf<String, String>("output-processor")
-
         produced.shouldNotBeNull()
     }
 
     @Test
     fun `joinedOf로 Joined 인스턴스 생성`() {
-        val keySerde = Serdes.String()
-        val valueSerde = Serdes.String()
-        val otherValueSerde = Serdes.Long()
-
         val joined: Joined<String, String, Long> =
             joinedOf(
-                keySerde = keySerde,
-                valueSerde = valueSerde,
-                otherValueSerde = otherValueSerde,
+                keySerde = Serdes.String(),
+                valueSerde = Serdes.String(),
+                otherValueSerde = Serdes.Long(),
                 name = "stream-join",
             )
-
         joined.shouldNotBeNull()
     }
 
     @Test
     fun `joinedOf with name only`() {
         val joined: Joined<String, String, Long> = joinedOf<String, String, Long>("join-name")
-
         joined.shouldNotBeNull()
     }
 
     @Test
     fun `groupedOf로 Grouped 인스턴스 생성`() {
-        val keySerde = Serdes.String()
-        val valueSerde = Serdes.Long()
-
         val grouped: Grouped<String, Long> =
             groupedOf(
-                keySerde = keySerde,
-                valueSerde = valueSerde,
+                keySerde = Serdes.String(),
+                valueSerde = Serdes.Long(),
                 name = "group-by-key",
             )
-
         grouped.shouldNotBeNull()
     }
 
     @Test
     fun `groupedOf with processor name`() {
         val grouped: Grouped<String, String> = groupedOf<String, String>("group-processor")
-
         grouped.shouldNotBeNull()
     }
 
     @Test
     fun `materializedOf with store name`() {
-        val materialized: Materialized<String, Long, KeyValueStore<org.apache.kafka.common.utils.Bytes, ByteArray>> =
+        val materialized: Materialized<String, Long, KeyValueStore<Bytes, ByteArray>> =
             materializedOf("count-store")
-
         materialized.shouldNotBeNull()
     }
 
     @Test
     fun `materializedOf with serdes`() {
-        val keySerde = Serdes.String()
-        val valueSerde = Serdes.Long()
+        val materialized: Materialized<String, Long, KeyValueStore<Bytes, ByteArray>> =
+            materializedOf(Serdes.String(), Serdes.Long())
+        materialized.shouldNotBeNull()
+    }
 
-        val materialized: Materialized<String, Long, KeyValueStore<org.apache.kafka.common.utils.Bytes, ByteArray>> =
-            materializedOf(keySerde, valueSerde)
+    @Test
+    fun `materializedOf with store type`() {
+        val materialized: Materialized<String, String, KeyValueStore<Bytes, ByteArray>> =
+            materializedOf(Materialized.StoreType.IN_MEMORY)
+        materialized.shouldNotBeNull()
+    }
 
+    @Test
+    fun `materializedOf with KeyValueBytesStoreSupplier`() {
+        val supplier = Stores.persistentKeyValueStore("kv-store")
+        val materialized: Materialized<String, Long, KeyValueStore<Bytes, ByteArray>> =
+            materializedOf(supplier)
+        materialized.shouldNotBeNull()
+    }
+
+    @Test
+    fun `materializedOf with WindowBytesStoreSupplier`() {
+        val supplier = Stores.persistentWindowStore(
+            "window-store",
+            Duration.ofHours(1),
+            Duration.ofMinutes(5),
+            false,
+        )
+        val materialized: Materialized<String, Long, WindowStore<Bytes, ByteArray>> =
+            materializedOf(supplier)
+        materialized.shouldNotBeNull()
+    }
+
+    @Test
+    fun `materializedOf with SessionBytesStoreSupplier`() {
+        val supplier = Stores.persistentSessionStore("session-store", Duration.ofMinutes(30))
+        val materialized: Materialized<String, Long, SessionStore<Bytes, ByteArray>> =
+            materializedOf(supplier)
         materialized.shouldNotBeNull()
     }
 
     @Test
     fun `streamJoinedOf with name`() {
-        val streamJoined: StreamJoined<String, String, Long> = streamJoinedOf<String, String, Long>("stream-join-store")
-
+        val streamJoined: StreamJoined<String, String, Long> =
+            streamJoinedOf<String, String, Long>("stream-join-store")
         streamJoined.shouldNotBeNull()
     }
 
     @Test
     fun `streamJoinedOf with serdes`() {
-        val keySerde = Serdes.String()
-        val valueSerde = Serdes.String()
-        val otherValueSerde = Serdes.Long()
-
         val streamJoined: StreamJoined<String, String, Long> =
             streamJoinedOf(
-                keySerde = keySerde,
-                valueSerde = valueSerde,
-                otherValueSerde = otherValueSerde,
+                keySerde = Serdes.String(),
+                valueSerde = Serdes.String(),
+                otherValueSerde = Serdes.Long(),
             )
-
         streamJoined.shouldNotBeNull()
     }
 
     @Test
     fun `repartitionedOf with name`() {
         val repartitioned: Repartitioned<String, String> = repartitionedOf<String, String>("repartition-step")
-
         repartitioned.shouldNotBeNull()
     }
 
     @Test
     fun `repartitionedOf with serdes`() {
-        val keySerde = Serdes.String()
-        val valueSerde = Serdes.Long()
-
         val repartitioned: Repartitioned<String, Long> =
-            repartitionedOf(
-                keySerde = keySerde,
-                valueSerde = valueSerde,
-            )
-
+            repartitionedOf(keySerde = Serdes.String(), valueSerde = Serdes.Long())
         repartitioned.shouldNotBeNull()
     }
 
     @Test
     fun `repartitionedOf with partition count`() {
         val repartitioned: Repartitioned<String, String> = repartitionedOf<String, String>(6)
-
         repartitioned.shouldNotBeNull()
     }
 
     @Test
     fun `tableJoinedOf with name`() {
         val tableJoined: TableJoined<String, Int> = tableJoinedOf<String, Int>("table-join")
-
         tableJoined.shouldNotBeNull()
+    }
+
+    @Test
+    fun `tableJoinedOf with partitioners`() {
+        val leftPartitioner = StreamPartitioner<String, Void> { _, key, _, numPartitions ->
+            Optional.of(setOf(Math.abs(key.hashCode()) % numPartitions))
+        }
+        val rightPartitioner = StreamPartitioner<Int, Void> { _, key, _, numPartitions ->
+            Optional.of(setOf(Math.abs(key) % numPartitions))
+        }
+        val tableJoined: TableJoined<String, Int> = tableJoinedOf(leftPartitioner, rightPartitioner)
+        tableJoined.shouldNotBeNull()
+    }
+
+    @Test
+    fun `repartitionedOf with partitioner`() {
+        val partitioner = StreamPartitioner<String, String> { _, key, _, numPartitions ->
+            Optional.of(setOf(Math.abs(key.hashCode()) % numPartitions))
+        }
+        val repartitioned: Repartitioned<String, String> = repartitionedOf(partitioner)
+        repartitioned.shouldNotBeNull()
+    }
+
+    @Test
+    fun `streamJoinedOf with window store suppliers`() {
+        val leftStore = Stores.persistentWindowStore(
+            "left-join-store",
+            java.time.Duration.ofMinutes(5),
+            java.time.Duration.ofMinutes(1),
+            true,
+        )
+        val rightStore = Stores.persistentWindowStore(
+            "right-join-store",
+            java.time.Duration.ofMinutes(5),
+            java.time.Duration.ofMinutes(1),
+            true,
+        )
+        val streamJoined: StreamJoined<String, String, Long> = streamJoinedOf(leftStore, rightStore)
+        streamJoined.shouldNotBeNull()
+    }
+
+    @Test
+    fun `windowedOf로 Windowed 인스턴스 생성`() {
+        val window = mockk<Window>(relaxed = true)
+        val windowed: Windowed<String> = windowedOf("user-123", window)
+
+        windowed.shouldNotBeNull()
+        windowed.key() shouldBeEqualTo "user-123"
+        windowed.window() shouldBeEqualTo window
     }
 
     @Test
     fun `branchedOf with name`() {
         val branched: Branched<String, String> = branchedOf<String, String>("valid-branch")
-
         branched.shouldNotBeNull()
     }
 
@@ -195,26 +259,16 @@ class KStreamDslTest: AbstractKafkaTest() {
         val filterFunction: (KStream<String, String>) -> KStream<String, String> = { stream ->
             stream.filter { _, value -> value.startsWith("A") }
         }
-
         val branched: Branched<String, String> =
-            branchedOf(
-                chain = filterFunction,
-                name = "starts-with-a",
-            )
-
+            branchedOf(chain = filterFunction, name = "starts-with-a")
         branched.shouldNotBeNull()
     }
 
     @Test
     fun `branchedOf with consumer`() {
         val consumerFunction: (KStream<String, String>) -> Unit = { _ -> }
-
         val branched: Branched<String, String> =
-            branchedOf(
-                chain = consumerFunction,
-                name = "consumer-branch",
-            )
-
+            branchedOf(chain = consumerFunction, name = "consumer-branch")
         branched.shouldNotBeNull()
     }
 }


### PR DESCRIPTION
## Summary

Closes #461

- PR 제목: test: raise infra/kafka4 test coverage from 62% to 80.2% (issue #461)

Raises `infra/kafka4` module line coverage from **62.06% → 80.2%** (303/378 lines covered), exceeding the 80% target.

Closes #461

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### New test files

| File | Covers |
|------|--------|
| `StreamConfigTest.kt` | `streamsConfigDef` (application.id, bootstrap.servers keys) |
| `KafkaOperationExtensionsTest.kt` | `getMetric`, `getMetricValueOrNull` (unit, MockK) |
| `KafkaOperationExtensionsIntegrationTest.kt` | `suspendSend`, `awaitSend`, `sendSuspending`, `sendFlowAsParallel`, `sendAndForget`, `getMetricValue` (integration, real Kafka via Testcontainers) |
| `ProducerFactorySupportTest.kt` | `ProducerFactorySupport.release()` delegates to `ProducerFactoryUtils.releaseResources()` |
| `ListenerUtilsTest.kt` | `listenerTypeOf`, `stoppableSleep`, `createOffsetAndMetadata` |
| `AdapterUtilsTest.kt` | `toNullIfEmpty` for arrays and strings |

### Extended test file

- `KStreamDslTest.kt` — added overload coverage for:
  - `consumedOf(timestampExtractor)`, `materializedOf(StoreType)`, `materializedOf(KeyValueBytesStoreSupplier)`, `materializedOf(WindowBytesStoreSupplier)`, `materializedOf(SessionBytesStoreSupplier)`, `windowedOf`, `tableJoinedOf(partitioner, otherPartitioner)`, `repartitionedOf(partitioner)`, `streamJoinedOf(storeSupplier, otherStoreSupplier)`

### 기존 섹션: Verification

```bash
./gradlew :bluetape4k-kafka4:test :bluetape4k-kafka4:koverXmlReport
# LINE: 80.2% (303/378)
```

### 기존 섹션: Per-package line coverage (after)

| Package | Coverage |
|---------|----------|
| `io.bluetape4k.kafka.spring.core` | 69.5% (107/154) |
| `io.bluetape4k.kafka.spring.listener` | 100.0% (3/3) |
| `io.bluetape4k.kafka.spring.listener.adapter` | 100.0% (2/2) |
| `io.bluetape4k.kafka.streams` | 100.0% (1/1) |
| `io.bluetape4k.kafka.streams.kstream` | 85.0% (34/40) |
| `io.bluetape4k.kafka.codec` | 96.8% (91/94) |
| `io.bluetape4k.kafka.coroutines` | 96.6% (28/29) |
| **TOTAL** | **80.2% (303/378)** |

## Validation

```
Module  : :bluetape4k-kafka4
Command : ./gradlew :bluetape4k-kafka4:test
Result  : all tests passing
Coverage: LINE 80.2% (303/378)
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #461, milestone 없음, assignee `debop`
- PR: #464, head `c966a830da83ebd23c8b0076f1ad5e437808b238`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `test/issue-461-kafka4-coverage`
- Labels: `test`
- State: `MERGED`, merge commit `635ddb8523af766110c6c60b355357d26095d4a3`
- CI: Command : ./gradlew :bluetape4k-kafka4:test / ./gradlew :bluetape4k-kafka4:test :bluetape4k-kafka4:koverXmlReport

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #464 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `635ddb8523af766110c6c60b355357d26095d4a3`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
