### PR TITLE
test: add K3s workload deployment example

### DIFF
--- a/docs/lessons/2026-05-16-issue-459-k3s-workload-example.md
+++ b/docs/lessons/2026-05-16-issue-459-k3s-workload-example.md
@@ -1,0 +1,36 @@
+# Issue 459 K3s workload example
+
+## Context
+
+Issue #459 asked for a practical `K3sServer` integration-test example that goes
+beyond node listing and demonstrates Kubernetes workload resources against a
+real K3s API server.
+
+## Decision
+
+Add a dedicated `K3sWorkloadExampleTest` under `testing/testcontainers` instead
+of expanding `K3sServerTest`. The new file keeps the basic server smoke tests
+separate from workload examples and uses the existing `@Tag("k8s")`/`k8sTest`
+path for privileged-runner execution.
+
+## Outcome
+
+The example covers ConfigMap CRUD, Deployment-backed Service readiness, and
+Secret value decoding. Each test closes its Kubernetes client, performs
+idempotent pre-cleanup that waits for stale resources to disappear, and cleans
+created resources with `try/finally` so the singleton K3s container can be
+reused safely.
+
+## Verification
+
+- `./gradlew :bluetape4k-testcontainers:compileTestKotlin --no-daemon --console=plain`
+  passed.
+- `./gradlew :bluetape4k-testcontainers:k8sTest --tests 'io.bluetape4k.testcontainers.infra.K3sWorkloadExampleTest' --no-daemon --no-configuration-cache --console=plain`
+  passed with 3 tests executed.
+
+## Next Time
+
+When adding K3s examples, keep long-running or privileged Docker scenarios under
+`@Tag("k8s")`, run the dedicated `k8sTest` task locally when Docker supports it,
+and use both wait-backed pre-cleanup and `finally` cleanup for
+singleton-container safety.

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/K3sWorkloadExampleTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/K3sWorkloadExampleTest.kt
@@ -1,0 +1,261 @@
+package io.bluetape4k.testcontainers.infra
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder
+import io.fabric8.kubernetes.api.model.IntOrString
+import io.fabric8.kubernetes.api.model.SecretBuilder
+import io.fabric8.kubernetes.api.model.ServiceBuilder
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder
+import io.fabric8.kubernetes.client.KubernetesClient
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.Base64
+
+@Tag("k8s")
+class K3sWorkloadExampleTest: AbstractContainerTest() {
+
+    companion object: KLogging() {
+        private const val NAMESPACE = "default"
+        private const val APP_LABEL_KEY = "app"
+        private const val APP_LABEL_VALUE = "k3s-workload-example"
+        private const val CONFIG_MAP_NAME = "k3s-example-config"
+        private const val DEPLOYMENT_NAME = "k3s-example-deployment"
+        private const val SERVICE_NAME = "k3s-example-service"
+        private const val SECRET_NAME = "k3s-example-secret"
+
+        private val k3s: K3sServer by lazy { K3sServer.Launcher.k3s }
+    }
+
+    @Test
+    fun `deploy ConfigMap and read updated value`() {
+        k3s.kubernetesClient().use { client ->
+            deleteConfigMapIfExists(client)
+            val configMap = ConfigMapBuilder()
+                .withNewMetadata()
+                .withName(CONFIG_MAP_NAME)
+                .withNamespace(NAMESPACE)
+                .endMetadata()
+                .addToData("feature.enabled", "true")
+                .build()
+
+            client.configMaps().inNamespace(NAMESPACE).resource(configMap).create()
+            try {
+                val found = client.configMaps().inNamespace(NAMESPACE).withName(CONFIG_MAP_NAME).get()
+
+                found.shouldNotBeNull()
+                found.data["feature.enabled"] shouldBeEqualTo "true"
+
+                client.configMaps().inNamespace(NAMESPACE).withName(CONFIG_MAP_NAME).edit { current ->
+                    ConfigMapBuilder(current)
+                        .addToData("refresh.interval", "30s")
+                        .build()
+                }
+
+                val updated = client.configMaps().inNamespace(NAMESPACE).withName(CONFIG_MAP_NAME).get()
+                updated.shouldNotBeNull()
+                updated.data["refresh.interval"] shouldBeEqualTo "30s"
+            } finally {
+                deleteConfigMapIfExists(client)
+            }
+        }
+    }
+
+    @Test
+    fun `deploy Deployment and Service and verify a running pod backs the service`() {
+        k3s.kubernetesClient().use { client ->
+            deleteServiceIfExists(client)
+            deleteDeploymentIfExists(client)
+            val deployment = DeploymentBuilder()
+                .withNewMetadata()
+                .withName(DEPLOYMENT_NAME)
+                .withNamespace(NAMESPACE)
+                .addToLabels(APP_LABEL_KEY, APP_LABEL_VALUE)
+                .endMetadata()
+                .withNewSpec()
+                .withReplicas(1)
+                .withNewSelector()
+                .addToMatchLabels(APP_LABEL_KEY, APP_LABEL_VALUE)
+                .endSelector()
+                .withNewTemplate()
+                .withNewMetadata()
+                .addToLabels(APP_LABEL_KEY, APP_LABEL_VALUE)
+                .endMetadata()
+                .withNewSpec()
+                .addNewContainer()
+                .withName("app")
+                .withImage("busybox:1.36")
+                .withCommand("sh", "-c", "sleep 3600")
+                .addNewPort()
+                .withContainerPort(8080)
+                .endPort()
+                .endContainer()
+                .endSpec()
+                .endTemplate()
+                .endSpec()
+                .build()
+            val service = ServiceBuilder()
+                .withNewMetadata()
+                .withName(SERVICE_NAME)
+                .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                .addToSelector(APP_LABEL_KEY, APP_LABEL_VALUE)
+                .addNewPort()
+                .withName("http")
+                .withPort(80)
+                .withTargetPort(IntOrString(8080))
+                .endPort()
+                .endSpec()
+                .build()
+
+            var deploymentCreated = false
+            var serviceCreated = false
+            try {
+                client.apps().deployments().inNamespace(NAMESPACE).resource(deployment).create()
+                deploymentCreated = true
+                client.services().inNamespace(NAMESPACE).resource(service).create()
+                serviceCreated = true
+
+                awaitDeploymentReady(client, DEPLOYMENT_NAME).shouldBeTrue()
+
+                val foundService = client.services().inNamespace(NAMESPACE).withName(SERVICE_NAME).get()
+                foundService.shouldNotBeNull()
+                foundService.spec.selector[APP_LABEL_KEY] shouldBeEqualTo APP_LABEL_VALUE
+
+                awaitServiceEndpointReady(client, SERVICE_NAME).shouldBeTrue()
+            } finally {
+                if (serviceCreated) {
+                    deleteServiceIfExists(client)
+                }
+                if (deploymentCreated) {
+                    deleteDeploymentIfExists(client)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `create Secret and read decoded value`() {
+        k3s.kubernetesClient().use { client ->
+            deleteSecretIfExists(client)
+            val token = "k3s-secret-token"
+            val secret = SecretBuilder()
+                .withNewMetadata()
+                .withName(SECRET_NAME)
+                .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withType("Opaque")
+                .addToData("api-token", Base64.getEncoder().encodeToString(token.toByteArray(UTF_8)))
+                .build()
+
+            client.secrets().inNamespace(NAMESPACE).resource(secret).create()
+            try {
+                val found = client.secrets().inNamespace(NAMESPACE).withName(SECRET_NAME).get()
+                found.shouldNotBeNull()
+
+                val decoded = String(Base64.getDecoder().decode(found.data["api-token"]), UTF_8)
+                decoded shouldBeEqualTo token
+            } finally {
+                deleteSecretIfExists(client)
+            }
+        }
+    }
+
+    private fun awaitDeploymentReady(client: KubernetesClient, name: String): Boolean {
+        repeat(90) {
+            val deployment = client.apps().deployments().inNamespace(NAMESPACE).withName(name).get()
+            val readyReplicas = deployment?.status?.readyReplicas ?: 0
+            val availableReplicas = deployment?.status?.availableReplicas ?: 0
+            if (readyReplicas >= 1 && availableReplicas >= 1) {
+                return true
+            }
+            sleepOneSecond()
+        }
+        return false
+    }
+
+    private fun awaitServiceEndpointReady(client: KubernetesClient, name: String): Boolean {
+        repeat(90) {
+            val endpoints = client.endpoints().inNamespace(NAMESPACE).withName(name).get()
+            val hasReadyAddress = endpoints?.subsets.orEmpty().any { subset ->
+                subset.addresses.orEmpty().isNotEmpty()
+            }
+            if (hasReadyAddress) {
+                return true
+            }
+            sleepOneSecond()
+        }
+        return false
+    }
+
+    private fun sleepOneSecond() {
+        try {
+            Thread.sleep(1_000)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        }
+    }
+
+    private fun deleteConfigMapIfExists(client: KubernetesClient) {
+        deleteIfExists(
+            kind = "ConfigMap",
+            name = CONFIG_MAP_NAME,
+            delete = { client.configMaps().inNamespace(NAMESPACE).withName(CONFIG_MAP_NAME).delete() },
+            exists = { client.configMaps().inNamespace(NAMESPACE).withName(CONFIG_MAP_NAME).get() != null },
+        )
+    }
+
+    private fun deleteServiceIfExists(client: KubernetesClient) {
+        deleteIfExists(
+            kind = "Service",
+            name = SERVICE_NAME,
+            delete = { client.services().inNamespace(NAMESPACE).withName(SERVICE_NAME).delete() },
+            exists = { client.services().inNamespace(NAMESPACE).withName(SERVICE_NAME).get() != null },
+        )
+    }
+
+    private fun deleteDeploymentIfExists(client: KubernetesClient) {
+        deleteIfExists(
+            kind = "Deployment",
+            name = DEPLOYMENT_NAME,
+            delete = { client.apps().deployments().inNamespace(NAMESPACE).withName(DEPLOYMENT_NAME).delete() },
+            exists = { client.apps().deployments().inNamespace(NAMESPACE).withName(DEPLOYMENT_NAME).get() != null },
+        )
+    }
+
+    private fun deleteSecretIfExists(client: KubernetesClient) {
+        deleteIfExists(
+            kind = "Secret",
+            name = SECRET_NAME,
+            delete = { client.secrets().inNamespace(NAMESPACE).withName(SECRET_NAME).delete() },
+            exists = { client.secrets().inNamespace(NAMESPACE).withName(SECRET_NAME).get() != null },
+        )
+    }
+
+    private fun deleteIfExists(
+        kind: String,
+        name: String,
+        delete: () -> Unit,
+        exists: () -> Boolean,
+    ) {
+        runCatching {
+            delete()
+            repeat(30) {
+                if (!exists()) {
+                    return
+                }
+                sleepOneSecond()
+            }
+            log.warn { "K3s pre-cleanup timed out. kind=$kind, name=$name" }
+        }.onFailure { e ->
+            log.warn(e) { "K3s pre-cleanup failed. kind=$kind, name=$name" }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #459

- PR 제목: test: add K3s workload deployment example

- Add `K3sWorkloadExampleTest` for real K3s workload examples.
- Cover ConfigMap CRUD, Deployment-backed Service readiness, and Secret decoding.
- Keep the tests under `@Tag("k8s")` so they run via the privileged-runner `k8sTest` task.
- Add a lesson note for future K3s workload examples.

### 원문 선행 내용

Fixes #459

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- `./gradlew :bluetape4k-testcontainers:compileTestKotlin --no-daemon --console=plain`
- `./gradlew :bluetape4k-testcontainers:k8sTest --tests 'io.bluetape4k.testcontainers.infra.K3sWorkloadExampleTest' --no-daemon --no-configuration-cache --console=plain`\n\n## DoD\n- [x] Uses `K3sServer.Launcher.k3s` singleton.\n- [x] Tagged `@Tag("k8s")`.\n- [x] Includes ConfigMap, workload lifecycle, and Secret tests.\n- [x] Uses `try/finally` cleanup for created Kubernetes resources.\n- [x] No dependency on `bluetape4k-leader` or external application libraries.\n- [x] Lessons committed before PR creation.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #459, milestone 없음, assignee `debop`
- PR: #465, head `329bf6efde11e2160432817fc3dc77756da62e73`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `test/issue-459-k3s-workload-example`
- Labels: 없음
- State: `MERGED`, merge commit `5e88492923013c02d8702794a31ff2a65ab01413`
- CI: - `./gradlew :bluetape4k-testcontainers:compileTestKotlin --no-daemon --console=plain` / - `./gradlew :bluetape4k-testcontainers:k8sTest --tests 'io.bluetape4k.testcontainers.infra.K3sWorkloadExampleTest' --no-daemon --no-configuration-cache --console=plain`\n\n## DoD\n- [x] Uses `K3sServer.Launcher.k3s` singleton.\n- [x] Tagged `@Tag("k8s")`.\n- [x] Includes ConfigMap, workload lifecycle, and Secret tests.\n- [x] Uses `try/finally` cleanup for created Kubernetes resources.\n- [x] No dependency on `bluetape4k-leader` or external application libraries.\n- [x] Lessons committed before PR creation.

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #465 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `5e88492923013c02d8702794a31ff2a65ab01413`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
