### PR TITLE
docs: add GrafanaServer and K3sServer to testcontainers README

### DIFF
--- a/testing/testcontainers/README.ko.md
+++ b/testing/testcontainers/README.ko.md
@@ -194,6 +194,8 @@ flowchart TD
         CN["ConsulServer"]
         VT["VaultServer"]
         PR["PrometheusServer"]
+        GF["GrafanaServer"]
+        K3["K3sServer"]
         ZK["ZooKeeperServer"]
         TX["ToxiproxyServer"]
         KC["KeycloakServer"]
@@ -256,7 +258,7 @@ flowchart TD
     class RD,RDC,MGO,CS,ES,ESO,OS,MN,IFL,HZ,IG2,IG3 storageStyle
     class NJ,MG,FK,PA graphStyle
     class KF,RB,PL,NT,RP mqStyle
-    class CN,VT,PR,ZK,TX,KC,ZP infraStyle
+    class CN,VT,PR,GF,K3,ZK,TX,KC,ZP infraStyle
     class TR sqlStyle
     class WM,NG,BHS,BWS mockStyle
     class LS deprecatedStyle
@@ -280,7 +282,7 @@ flowchart TD
 - **AWS 에뮬레이터**: `AwsEmulatorServer` 공통 인터페이스; `FlociServer`(GraalVM Native, 권장), `LocalStackServer`(@Deprecated)
 - **임베디드 SQS**: `ElasticMqServer` — Docker 없이 JVM 내 SQS 서버 실행
 - **메일 테스트**: `MailpitServer` — SMTP + Web UI로 이메일 통합 테스트 지원
-- **관측성**: `ZipkinServer` — 분산 추적 (`openzipkin/zipkin-slim:2.23`)
+- **관측성**: `ZipkinServer` — 분산 추적 (`openzipkin/zipkin-slim:2.23`), `GrafanaServer` — 대시보드 + 데이터소스 프로비저닝 (`grafana/grafana:11.6.1`), `K3sServer` — 경량 Kubernetes 클러스터 (`rancher/k3s`; `--privileged` Docker 모드 필요)
 - **고정 포트 매핑 옵션**: `useDefaultPort=true` 설정 시 기본 포트로 바인딩
 - **시스템 프로퍼티 자동 등록**: 컨테이너 시작 시 연결 정보 자동 등록
 - **Spring Boot 설정 단순화**: `${testcontainers...}` placeholder로 연결 정보 주입
@@ -323,6 +325,8 @@ flowchart TD
 | ElasticMqServer     | `elasticmq`     | `host`, `port`, `url`, `sqsEndpoint`                                                |
 | MailpitServer       | `mailpit`       | `host`, `port`, `url`, `smtpPort`, `uiPort`, `uiUrl`                               |
 | PrometheusServer    | `prometheus`    | `host`, `port`, `url`, `server-port`, `pushgateway-port`, `graphite-exporter-port`  |
+| GrafanaServer       | `grafana`       | `host`, `port`, `url`                                                               |
+| K3sServer           | `k3s`           | `host`, `port`, `url`                                                               |
 | ConsulServer        | `consul`        | `host`, `port`, `url`, `dns-port`, `http-port`, `rpc-port`                          |
 | JaegerServer          | `jaeger`           | `host`, `port`, `url`, `frontend-port`, `zipkin-port`, `config-port`, `thrift-port` |
 | ElasticsearchOssServer| `elasticsearch-oss`| `host`, `port`, `url`                                                               |
@@ -524,6 +528,39 @@ println("Admin Token: ${influxDB.adminToken}")
 println("Bucket: ${influxDB.bucket}")
 println("Organization: ${influxDB.organization}")
 ```
+
+### Grafana
+
+```kotlin
+// 싱글턴 런처
+val grafana = GrafanaServer.Launcher.grafana
+
+// 시작 후 Prometheus 데이터소스 등록
+grafana.withPrometheusDataSource("http://prometheus:9090")
+
+// 대시보드 JSON 으로 대시보드 등록
+// grafana.withDashboard(dashboardJsonString)
+
+println("Grafana URL: ${grafana.url}")  // http://host:<port>
+// 기본 자격증명: admin / admin
+```
+
+### K3s (Kubernetes)
+
+```kotlin
+// 싱글턴 런처 — K3s는 시작이 느리므로 테스트 간 싱글턴 사용 권장
+val k3s = K3sServer.Launcher.k3s
+
+// fabric8 Kubernetes 클라이언트 빌드
+val client = k3s.kubernetesClient()
+client.use {
+    println(it.namespaces().list().items)
+}
+```
+
+> **주의**: K3s는 `--privileged` Docker 모드가 필요합니다. `K3sServer`를 사용하는 테스트에는
+> `@Tag("k8s")`를 붙여 권한 있는 런너를 사용하는 nightly CI 에서만 실행되도록 제한하세요.
+> 테스트 런타임 클래스패스에 `io.fabric8:kubernetes-client` 의존성을 추가해야 합니다.
 
 ### 카오스 테스트 (Toxiproxy)
 

--- a/testing/testcontainers/README.md
+++ b/testing/testcontainers/README.md
@@ -194,6 +194,8 @@ flowchart TD
         CN["ConsulServer"]
         VT["VaultServer"]
         PR["PrometheusServer"]
+        GF["GrafanaServer"]
+        K3["K3sServer"]
         ZK["ZooKeeperServer"]
         TX["ToxiproxyServer"]
         KC["KeycloakServer"]
@@ -256,7 +258,7 @@ flowchart TD
     class RD,RDC,MGO,CS,ES,ESO,OS,MN,IFL,HZ,IG2,IG3 storageStyle
     class NJ,MG,FK,PA graphStyle
     class KF,RB,PL,NT,RP mqStyle
-    class CN,VT,PR,ZK,TX,KC,ZP infraStyle
+    class CN,VT,PR,GF,K3,ZK,TX,KC,ZP infraStyle
     class TR sqlStyle
     class WM,NG,BHS,BWS mockStyle
     class LS deprecatedStyle
@@ -275,7 +277,7 @@ flowchart TD
 - **Mail testing**: `MailpitServer` provides SMTP + Web UI for email integration tests
 - **LLM support**: `ChromaDBServer` (vector DB, port 8000), `OllamaServer` (local LLM inference, port 11434)
 - **Distributed cache/grid**: `HazelcastServer` (5.x slim), `Ignite2Server`, `Ignite3Server` (auto cluster-init)
-- **Observability**: `ZipkinServer` (distributed tracing, `openzipkin/zipkin-slim:2.23`)
+- **Observability**: `ZipkinServer` (distributed tracing, `openzipkin/zipkin-slim:2.23`), `GrafanaServer` (dashboards + datasource provisioning, `grafana/grafana:11.6.1`), `K3sServer` (lightweight Kubernetes cluster, `rancher/k3s`; requires `--privileged` Docker mode)
 - Shared `GenericServer` / `GenericContainer` utilities
 - Automatic PostgreSQL extension activation for PostGIS and pgvector
 - Declarative activation of extra PostgreSQL extensions through `withExtensions()`
@@ -318,6 +320,8 @@ Every server implements
 | ElasticMqServer     | `elasticmq`     | `host`, `port`, `url`, `sqsEndpoint`                                                |
 | MailpitServer       | `mailpit`       | `host`, `port`, `url`, `smtpPort`, `uiPort`, `uiUrl`                               |
 | PrometheusServer    | `prometheus`    | `host`, `port`, `url`, `server-port`, `pushgateway-port`, `graphite-exporter-port`  |
+| GrafanaServer       | `grafana`       | `host`, `port`, `url`                                                               |
+| K3sServer           | `k3s`           | `host`, `port`, `url`                                                               |
 | ConsulServer        | `consul`        | `host`, `port`, `url`, `dns-port`, `http-port`, `rpc-port`                          |
 | JaegerServer        | `jaeger`        | `host`, `port`, `url`, `frontend-port`, `zipkin-port`, `config-port`, `thrift-port` |
 | ElasticsearchOssServer| `elasticsearch-oss`| `host`, `port`, `url`                                                               |
@@ -516,6 +520,39 @@ println("Admin Token: ${influxDB.adminToken}")
 println("Bucket: ${influxDB.bucket}")
 println("Organization: ${influxDB.organization}")
 ```
+
+### Grafana
+
+```kotlin
+// Singleton launcher
+val grafana = GrafanaServer.Launcher.grafana
+
+// Provision a Prometheus datasource after start
+grafana.withPrometheusDataSource("http://prometheus:9090")
+
+// Provision a dashboard from JSON
+// grafana.withDashboard(dashboardJsonString)
+
+println("Grafana URL: ${grafana.url}")  // http://host:<port>
+// Default credentials: admin / admin
+```
+
+### K3s (Kubernetes)
+
+```kotlin
+// Singleton launcher — K3s is slow to start; prefer the singleton across tests
+val k3s = K3sServer.Launcher.k3s
+
+// Build a fabric8 Kubernetes client
+val client = k3s.kubernetesClient()
+client.use {
+    println(it.namespaces().list().items)
+}
+```
+
+> **Note**: K3s requires `--privileged` Docker mode. Tag tests that use `K3sServer`
+> with `@Tag("k8s")` so they can be confined to nightly CI runs where a privileged
+> runner is available. Add `io.fabric8:kubernetes-client` to the test runtime classpath.
 
 ### Toxiproxy (Chaos Testing)
 


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: docs: add GrafanaServer and K3sServer to testcontainers README

Updates testcontainers README (English and Korean) to document the two new
infra servers that were added recently:

- feat: add GrafanaServer to testcontainers infra package (#448, #455)
- feat: add K3sServer to testcontainers infra package (#449, #456)

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

Both `README.md` and `README.ko.md` updated with:

1. **Architecture diagram** — Added `GrafanaServer` and `K3sServer` nodes to the `Infra` subgraph
2. **Property export table** — Added `grafana` and `k3s` namespace rows
3. **Usage examples** — Added `### Grafana` and `### K3s (Kubernetes)` example sections

Notable documentation notes added:
- K3s requires `--privileged` Docker runner — tag tests with `@Tag("k8s")` for nightly-only CI
- `kubernetesClient()` requires runtime dep `io.fabric8:kubernetes-client`
- `GrafanaServer.withPrometheusDataSource()` must be called after `start()`

No code changes.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #466, head `03e8308ee950813d86b63db85bf247cacbe62c1f`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `docs/testcontainers-readme-grafana-k3s`
- Labels: `documentation`
- State: `MERGED`, merge commit `70177e303f888a6a0a875e0f9ceafb1e648bff7c`
- CI: - K3s requires `--privileged` Docker runner — tag tests with `@Tag("k8s")` for nightly-only CI

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #466 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `70177e303f888a6a0a875e0f9ceafb1e648bff7c`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
