### PR TITLE
fix: stabilize nightly Memgraph and Elasticsearch tests

### DIFF
--- a/docs/lessons/2026-05-16-elasticsearch-coroutines-timeout.md
+++ b/docs/lessons/2026-05-16-elasticsearch-coroutines-timeout.md
@@ -1,0 +1,33 @@
+# Elasticsearch Coroutines Timeout
+
+## Context
+
+Nightly full verification for the Memgraph CI fix passed `graphdb-memgraph`,
+but failed in `Test / Infra (search-messaging)`. The failing module was
+`:bluetape4k-elasticsearch:test`, specifically `ElasticsearchCoroutinesTest`.
+
+## Decision or Finding
+
+The failing tests were bounded by `runTest(timeout = 30.seconds)`. On GitHub
+Actions, Elasticsearch container I/O plus index refresh calls can exceed that
+limit under runner load. Sibling Elasticsearch coroutine integration tests
+already use 60-second timeouts for similar external I/O paths.
+
+## Outcome
+
+`ElasticsearchCoroutinesTest` now uses 60-second `runTest` timeouts for setup,
+teardown, and CRUD/search integration tests. This keeps the tests bounded while
+allowing realistic CI latency.
+
+## Verification
+
+- Local targeted class: `:bluetape4k-elasticsearch:test --tests io.bluetape4k.elasticsearch.coroutines.ElasticsearchCoroutinesTest` passed in 31 seconds.
+- GitHub Nightly full attempt 1 and failed-job rerun both failed before this
+  change with `UncompletedCoroutinesError: After waiting for 30s`.
+
+## Future Guidance
+
+For coroutine tests that call real containers or remote-style clients, avoid
+30-second `runTest` limits unless the underlying operation is deterministic and
+purely local. Match sibling integration tests that already account for CI
+runner latency.

--- a/docs/lessons/2026-05-16-nightly-memgraph-timeout.md
+++ b/docs/lessons/2026-05-16-nightly-memgraph-timeout.md
@@ -1,0 +1,33 @@
+# Nightly Memgraph Timeout
+
+## Context
+
+Nightly full run `25942332959` failed only in `Test / Testcontainers (graphdb-memgraph)`.
+The Memgraph job reached `:bluetape4k-testcontainers:test` and then hit the
+outer GitHub Actions timeout twice without a JUnit failure report.
+
+## Decision or Finding
+
+`MemgraphServer` waited only for a listening port. For Memgraph, this can leave
+CI failures opaque because the test process may hang until the workflow timeout.
+Use a combined startup wait (`Memgraph` startup log plus listening port) and add
+preemptive JUnit timeouts around the integration test class.
+
+## Outcome
+
+`MemgraphServerTest` now starts an isolated container in `BeforeAll`, closes it
+in `AfterAll`, caps the full class at 5 minutes, and gives the Bolt query test a
+3-minute timeout. This keeps CI failures inside JUnit/Gradle instead of waiting
+for the 25-minute Actions wrapper.
+
+## Verification
+
+- IDE diagnostics: `MemgraphServer.kt` and `MemgraphServerTest.kt` reported 0 problems.
+- Targeted test: `:bluetape4k-testcontainers:test --tests io.bluetape4k.testcontainers.graphdb.MemgraphServerTest` passed in 11 seconds.
+
+## Future Guidance
+
+For Testcontainers services that have known readiness logs, prefer log plus
+port wait strategies. For CI-only hangs, add a JUnit-level timeout close to the
+test boundary so retry logs show a real test failure instead of only process
+exit code 124.

--- a/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/ElasticsearchCoroutinesTest.kt
+++ b/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/ElasticsearchCoroutinesTest.kt
@@ -51,13 +51,13 @@ class ElasticsearchCoroutinesTest : AbstractElasticsearchTest() {
     private lateinit var indexName: String
 
     @BeforeEach
-    fun setUp() = runTest(timeout = 30.seconds) {
+    fun setUp() = runTest(timeout = 60.seconds) {
         indexName = ElasticsearchTestFixtures.randomIndexName("crud-test")
         asyncClient.createTestIndex(indexName).await()
     }
 
     @AfterEach
-    fun tearDown() = runTest(timeout = 30.seconds) {
+    fun tearDown() = runTest(timeout = 60.seconds) {
         runCatching { asyncClient.deleteTestIndex(indexName).await() }
     }
 
@@ -66,7 +66,7 @@ class ElasticsearchCoroutinesTest : AbstractElasticsearchTest() {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `인덱스 생성 후 존재 확인 그리고 삭제가 순서대로 동작한다`() = runTest(timeout = 30.seconds) {
+    fun `인덱스 생성 후 존재 확인 그리고 삭제가 순서대로 동작한다`() = runTest(timeout = 60.seconds) {
         val tmpIndex = ElasticsearchTestFixtures.randomIndexName("lifecycle-test")
 
         // 생성
@@ -91,7 +91,7 @@ class ElasticsearchCoroutinesTest : AbstractElasticsearchTest() {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `문서 색인 후 조회하면 동일한 내용을 반환한다`() = runTest(timeout = 30.seconds) {
+    fun `문서 색인 후 조회하면 동일한 내용을 반환한다`() = runTest(timeout = 60.seconds) {
         val docId = "doc-1"
         val doc = TestDocument(
             title = "Elasticsearch 소개",
@@ -127,7 +127,7 @@ class ElasticsearchCoroutinesTest : AbstractElasticsearchTest() {
     }
 
     @Test
-    fun `문서 색인 후 업데이트하면 변경된 내용이 반영된다`() = runTest(timeout = 30.seconds) {
+    fun `문서 색인 후 업데이트하면 변경된 내용이 반영된다`() = runTest(timeout = 60.seconds) {
         val docId = "doc-update"
         val original = TestDocument(title = "원본 제목", content = "원본 내용", score = 1.0)
 
@@ -163,7 +163,7 @@ class ElasticsearchCoroutinesTest : AbstractElasticsearchTest() {
     }
 
     @Test
-    fun `문서 색인 후 삭제하면 조회되지 않는다`() = runTest(timeout = 30.seconds) {
+    fun `문서 색인 후 삭제하면 조회되지 않는다`() = runTest(timeout = 60.seconds) {
         val docId = "doc-delete"
         val doc = TestDocument(title = "삭제 대상", content = "삭제될 내용")
 
@@ -197,7 +197,7 @@ class ElasticsearchCoroutinesTest : AbstractElasticsearchTest() {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `색인된 문서는 exists 가 true 를 반환한다`() = runTest(timeout = 30.seconds) {
+    fun `색인된 문서는 exists 가 true 를 반환한다`() = runTest(timeout = 60.seconds) {
         val docId = "exists-doc"
         asyncClient.indexSuspending<TestDocument> {
             index(indexName)
@@ -214,7 +214,7 @@ class ElasticsearchCoroutinesTest : AbstractElasticsearchTest() {
     }
 
     @Test
-    fun `없는 문서는 exists 가 false 를 반환한다`() = runTest(timeout = 30.seconds) {
+    fun `없는 문서는 exists 가 false 를 반환한다`() = runTest(timeout = 60.seconds) {
         val exists = asyncClient.existsSuspending {
             index(indexName)
             id("non-existent-id")
@@ -227,7 +227,7 @@ class ElasticsearchCoroutinesTest : AbstractElasticsearchTest() {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `match_all 쿼리로 색인된 전체 문서를 조회한다`() = runTest(timeout = 30.seconds) {
+    fun `match_all 쿼리로 색인된 전체 문서를 조회한다`() = runTest(timeout = 60.seconds) {
         val docs = listOf(
             TestDocument(title = "문서 A", content = "내용 A", tags = listOf("alpha")),
             TestDocument(title = "문서 B", content = "내용 B", tags = listOf("beta")),
@@ -254,7 +254,7 @@ class ElasticsearchCoroutinesTest : AbstractElasticsearchTest() {
     }
 
     @Test
-    fun `term 쿼리로 특정 태그를 가진 문서를 조회한다`() = runTest(timeout = 30.seconds) {
+    fun `term 쿼리로 특정 태그를 가진 문서를 조회한다`() = runTest(timeout = 60.seconds) {
         val targetTag = "kotlin"
         asyncClient.indexSuspending<TestDocument> {
             index(indexName)

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/graphdb/MemgraphServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/graphdb/MemgraphServer.kt
@@ -10,6 +10,8 @@ import io.bluetape4k.testcontainers.graphdb.MemgraphServer.Companion.TAG
 import io.bluetape4k.utils.ShutdownQueue
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy.Mode.WITH_OUTER_TIMEOUT
 import org.testcontainers.utility.DockerImageName
 import java.time.Duration
 
@@ -58,6 +60,8 @@ class MemgraphServer private constructor(
 
         /** CI 에서 컨테이너 startup hang 이 길어지지 않도록 제한합니다. */
         private val START_TIMEOUT: Duration = Duration.ofMinutes(3)
+
+        private const val READY_LOG_REGEX = ".*You are running Memgraph v.*"
 
         /**
          * [DockerImageName]을 직접 지정하여 [MemgraphServer] 인스턴스를 생성합니다.
@@ -131,7 +135,12 @@ class MemgraphServer private constructor(
         withStartupAttempts(1)
         addEnv("MEMGRAPH", "--telemetry-enabled=false")
         withCommand("--telemetry-enabled=false")
-        waitingFor(Wait.forListeningPort().withStartupTimeout(START_TIMEOUT))
+        waitingFor(
+            WaitAllStrategy(WITH_OUTER_TIMEOUT)
+                .withStrategy(Wait.forLogMessage(READY_LOG_REGEX, 1))
+                .withStrategy(Wait.forListeningPort())
+                .withStartupTimeout(START_TIMEOUT)
+        )
 
         if (useDefaultPort) {
             exposeCustomPorts(BOLT_PORT, LOG_PORT)

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/graphdb/MemgraphServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/graphdb/MemgraphServerTest.kt
@@ -7,21 +7,37 @@ import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Config
 import org.neo4j.driver.GraphDatabase
 import java.util.concurrent.TimeUnit
 
 @TestInstance(Lifecycle.PER_CLASS)
+@Timeout(value = 5, unit = TimeUnit.MINUTES, threadMode = SEPARATE_THREAD)
 class MemgraphServerTest: AbstractContainerTest() {
 
     companion object: KLogging()
 
-    private val memgraph: MemgraphServer by lazy { MemgraphServer.Launcher.memgraph }
+    private lateinit var memgraph: MemgraphServer
+
+    @BeforeAll
+    fun beforeAll() {
+        memgraph = MemgraphServer().apply { start() }
+    }
+
+    @AfterAll
+    fun afterAll() {
+        if (this::memgraph.isInitialized && memgraph.isRunning) {
+            memgraph.close()
+        }
+    }
 
     @Test
     fun `Memgraph 서버가 실행 중이어야 한다`() {
@@ -41,7 +57,7 @@ class MemgraphServerTest: AbstractContainerTest() {
     }
 
     @Test
-    @Timeout(45)
+    @Timeout(value = 3, unit = TimeUnit.MINUTES, threadMode = SEPARATE_THREAD)
     fun `Neo4j Driver로 Bolt 연결 후 쿼리를 실행할 수 있어야 한다`() {
         val config = Config.builder()
             .withConnectionTimeout(10, TimeUnit.SECONDS)


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: stabilize nightly Memgraph and Elasticsearch tests

- Bound Memgraph Testcontainers readiness with startup log plus listening port checks.
- Add JUnit-level timeouts and explicit lifecycle handling for `MemgraphServerTest`.
- Relax `ElasticsearchCoroutinesTest` coroutine integration timeouts from 30s to 60s after repeated Nightly full failures under CI runner latency.
- Add lessons for the Memgraph and Elasticsearch timeout fixes.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- IDE diagnostics: `MemgraphServer.kt`, `MemgraphServerTest.kt`, and `ElasticsearchCoroutinesTest.kt` had no blocking errors.
- Local: `./gradlew :bluetape4k-testcontainers:test --tests io.bluetape4k.testcontainers.graphdb.MemgraphServerTest -x :bluetape4k-mock-web-server:jibDockerBuild -x :bluetape4k-mock-webflux-server:jibDockerBuild --no-daemon`
- Local: `./gradlew :bluetape4k-elasticsearch:test --tests io.bluetape4k.elasticsearch.coroutines.ElasticsearchCoroutinesTest --no-daemon --max-workers=1`
- Nightly full: https://github.com/bluetape4k/bluetape4k-projects/actions/runs/25945861550 passed, 39/39 jobs successful.

### 기존 섹션: Notes

- Earlier Nightly full attempt showed `graphdb-memgraph` fixed but exposed a separate `search-messaging` Elasticsearch coroutine timeout. The failed-job rerun reproduced the Elasticsearch timeout, so this PR includes the narrow timeout adjustment.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #467, head `b8583098d6bc401c96915565ef4a851c6307c4a9`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/nightly-memgraph-timeout`
- Labels: 없음
- State: `MERGED`, merge commit `c21c40511d199d3a4e91c75b1890d66fd0f2c385`
- CI: - Add JUnit-level timeouts and explicit lifecycle handling for `MemgraphServerTest`. / - Relax `ElasticsearchCoroutinesTest` coroutine integration timeouts from 30s to 60s after repeated Nightly full failures under CI runner latency. / - Local: `./gradlew :bluetape4k-testcontainers:test --tests io.bluetape4k.testcontainers.graphdb.MemgraphServerTest -x :bluetape4k-mock-web-server:jibDockerBuild -x :bluetape4k-mock-webflux-server:jibDockerBuild --no-daemon`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #467 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `c21c40511d199d3a4e91c75b1890d66fd0f2c385`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
