### PR TITLE
chore: complete QueryDSL paging example

### DIFF
--- a/docs/lessons/2026-05-16-issue-108-querydsl-paging.md
+++ b/docs/lessons/2026-05-16-issue-108-querydsl-paging.md
@@ -1,0 +1,33 @@
+# Issue 108 QueryDSL Paging
+
+## Context
+
+Issue #108 requested completion of the unfinished QueryDSL example in
+`examples/jpa-querydsl-demo`. The current source did not contain the issue-body
+`findByName*` methods; the active TODOs were the three paging methods in
+`MemberRepositoryImpl`.
+
+## Decision
+
+Implement the current repository contract by completing
+`searchPageSimple`, `searchPageComplex`, and `searchPageExtremeCountQuery`.
+Use explicit QueryDSL count queries instead of deprecated `fetchCount()`, and
+map supported Spring `Sort` properties to QueryDSL `OrderSpecifier`s manually.
+
+## Outcome
+
+The example now returns `Page<MemberTeamDto>` for all three paging methods and
+has a repository test covering filtered content, total count, and sorting.
+
+## Verification
+
+- `rg 'TODO\("Not yet implemented"\)' MemberRepositoryImpl.kt`: no matches.
+- `./gradlew :bluetape4k-examples-jpa-querydsl-demo:test --tests 'io.bluetape4k.examples.jpa.querydsl.domain.repository.JpaRepositoryTest'`: 3 tests passed.
+- `./gradlew :bluetape4k-examples-jpa-querydsl-demo:test`: 44 tests executed, 1 skipped, build successful.
+- IntelliJ diagnostics on touched Kotlin files: 0 problems.
+
+## Future Guard
+
+`QuerydslRepositorySupport.applyPagination()` can generate Hibernate 7-invalid
+paths such as `member.age` for Spring `Sort`. For this example, prefer explicit
+QueryDSL `orderBy` mapping when pageable sorting matters.

--- a/examples/jpa-querydsl-demo/src/main/kotlin/io/bluetape4k/examples/jpa/querydsl/domain/repository/MemberRepositoryImpl.kt
+++ b/examples/jpa-querydsl-demo/src/main/kotlin/io/bluetape4k/examples/jpa/querydsl/domain/repository/MemberRepositoryImpl.kt
@@ -1,6 +1,10 @@
 package io.bluetape4k.examples.jpa.querydsl.domain.repository
 
+import com.querydsl.core.types.Order
+import com.querydsl.core.types.OrderSpecifier
 import com.querydsl.core.types.Projections
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQuery
 import com.querydsl.jpa.impl.JPAQueryFactory
 import io.bluetape4k.examples.jpa.querydsl.domain.dto.MemberSearchCondition
 import io.bluetape4k.examples.jpa.querydsl.domain.dto.MemberTeamDto
@@ -9,8 +13,11 @@ import io.bluetape4k.examples.jpa.querydsl.domain.model.QMember
 import io.bluetape4k.examples.jpa.querydsl.domain.model.QTeam
 import io.bluetape4k.logging.KLogging
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
+import org.springframework.data.support.PageableExecutionUtils
 
 class MemberRepositoryImpl: QuerydslRepositorySupport(Member::class.java), MemberRepositoryCustom {
 
@@ -22,6 +29,28 @@ class MemberRepositoryImpl: QuerydslRepositorySupport(Member::class.java), Membe
     private val qteam = QTeam.team
 
     override fun search(condition: MemberSearchCondition): List<MemberTeamDto> {
+        return selectMemberTeams(condition).fetch()
+    }
+
+    override fun searchPageSimple(condition: MemberSearchCondition, pageable: Pageable): Page<MemberTeamDto> {
+        val content = fetchPageContent(condition, pageable)
+        return PageImpl(content, pageable, countMembers(condition))
+    }
+
+    override fun searchPageComplex(condition: MemberSearchCondition, pageable: Pageable): Page<MemberTeamDto> {
+        val content = fetchPageContent(condition, pageable)
+        return PageableExecutionUtils.getPage(content, pageable) { countMembers(condition) }
+    }
+
+    override fun searchPageExtremeCountQuery(
+        condition: MemberSearchCondition,
+        pageable: Pageable,
+    ): Page<MemberTeamDto> {
+        val content = fetchPageContent(condition, pageable)
+        return PageableExecutionUtils.getPage(content, pageable) { countMembersExtreme(condition) }
+    }
+
+    private fun selectMemberTeams(condition: MemberSearchCondition): JPAQuery<MemberTeamDto> {
         // Projections.constructor 를 이용하여 DTO를 바로 제공한다
         val projection = Projections.constructor(
             MemberTeamDto::class.java,
@@ -29,36 +58,81 @@ class MemberRepositoryImpl: QuerydslRepositorySupport(Member::class.java), Membe
             qmember.name,
             qmember.age,
             qteam.id,
-            qteam.name
-        )
-
-        val whereClauses = listOfNotNull(
-            condition.memberName?.let { qmember.name.eq(it) },
-            condition.teamName?.let { qteam.name.eq(it) },
-            condition.ageGoe?.let { qmember.age.goe(it) },
-            condition.ageLoe?.let { qmember.age.loe(it) },
+            qteam.name,
         )
 
         return queryFactory
             .select(projection)
             .from(qmember)
             .leftJoin(qmember.team(), qteam)
-            .where(*whereClauses.toTypedArray())
+            .where(*whereClauses(condition))
+    }
+
+    private fun fetchPageContent(condition: MemberSearchCondition, pageable: Pageable): List<MemberTeamDto> {
+        return selectMemberTeams(condition)
+            .applyPageable(pageable)
             .fetch()
     }
 
-    override fun searchPageSimple(condition: MemberSearchCondition, pageable: Pageable): Page<MemberTeamDto> {
-        TODO("Not yet implemented")
+    private fun countMembers(condition: MemberSearchCondition): Long {
+        return queryFactory
+            .select(qmember.count())
+            .from(qmember)
+            .leftJoin(qmember.team(), qteam)
+            .where(*whereClauses(condition))
+            .fetchOne()
+            ?: 0L
     }
 
-    override fun searchPageComplex(condition: MemberSearchCondition, pageable: Pageable): Page<MemberTeamDto> {
-        TODO("Not yet implemented")
+    private fun countMembersExtreme(condition: MemberSearchCondition): Long {
+        if (condition.teamName == null) {
+            return queryFactory
+                .select(qmember.count())
+                .from(qmember)
+                .where(*memberWhereClauses(condition))
+                .fetchOne()
+                ?: 0L
+        }
+
+        return countMembers(condition)
     }
 
-    override fun searchPageExtremeCountQuery(
-        condition: MemberSearchCondition,
-        pageable: Pageable,
-    ): Page<MemberTeamDto> {
-        TODO("Not yet implemented")
+    private fun whereClauses(condition: MemberSearchCondition): Array<BooleanExpression> {
+        return listOfNotNull(
+            *memberWhereClauses(condition),
+            condition.teamName?.let { qteam.name.eq(it) },
+        ).toTypedArray()
+    }
+
+    private fun memberWhereClauses(condition: MemberSearchCondition): Array<BooleanExpression> {
+        return listOfNotNull(
+            condition.memberName?.let { qmember.name.eq(it) },
+            condition.ageGoe?.let { qmember.age.goe(it) },
+            condition.ageLoe?.let { qmember.age.loe(it) },
+        ).toTypedArray()
+    }
+
+    private fun JPAQuery<MemberTeamDto>.applyPageable(pageable: Pageable): JPAQuery<MemberTeamDto> {
+        pageable.sort.forEach { order ->
+            orderBy(order.toOrderSpecifier())
+        }
+
+        return if (pageable.isPaged) {
+            offset(pageable.offset).limit(pageable.pageSize.toLong())
+        } else {
+            this
+        }
+    }
+
+    private fun Sort.Order.toOrderSpecifier(): OrderSpecifier<*> {
+        val direction = if (isAscending) Order.ASC else Order.DESC
+        return when (property) {
+            "id", "member.id"     -> OrderSpecifier(direction, qmember.id)
+            "name", "member.name" -> OrderSpecifier(direction, qmember.name)
+            "age", "member.age"   -> OrderSpecifier(direction, qmember.age)
+            "team.id"             -> OrderSpecifier(direction, qteam.id)
+            "team.name"           -> OrderSpecifier(direction, qteam.name)
+            else                  -> throw IllegalArgumentException("Unsupported member search sort property: $property")
+        }
     }
 }

--- a/examples/jpa-querydsl-demo/src/test/kotlin/io/bluetape4k/examples/jpa/querydsl/domain/repository/JpaRepositoryTest.kt
+++ b/examples/jpa-querydsl-demo/src/test/kotlin/io/bluetape4k/examples/jpa/querydsl/domain/repository/JpaRepositoryTest.kt
@@ -4,10 +4,13 @@ import io.bluetape4k.examples.jpa.querydsl.domain.AbstractDomainTest
 import io.bluetape4k.examples.jpa.querydsl.domain.dto.MemberSearchCondition
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 
 class JpaRepositoryTest(
     @param:Autowired private val memberRepo: MemberRepository,
@@ -28,5 +31,37 @@ class JpaRepositoryTest(
             log.debug { it }
         }
         memberTeamDtos shouldHaveSize 1
+    }
+
+    @Test
+    fun `search page methods return filtered page`() {
+        val searchCond = MemberSearchCondition(teamName = "teamA", ageGoe = 10, ageLoe = 30)
+        val pageable = PageRequest.of(0, 5, Sort.by("age").ascending())
+
+        val pages = listOf(
+            memberRepo.searchPageSimple(searchCond, pageable),
+            memberRepo.searchPageComplex(searchCond, pageable),
+            memberRepo.searchPageExtremeCountQuery(searchCond, pageable),
+        )
+
+        pages.forEach { page ->
+            page.content shouldHaveSize 5
+            page.totalElements shouldBeEqualTo 11L
+            page.content.first().member.name shouldBeEqualTo "member-10"
+            page.content.last().member.name shouldBeEqualTo "member-18"
+        }
+    }
+
+    @Test
+    fun `search extreme count query supports member-only count condition`() {
+        val searchCond = MemberSearchCondition(ageGoe = 10, ageLoe = 30)
+        val pageable = PageRequest.of(0, 10, Sort.by("age").ascending())
+
+        val page = memberRepo.searchPageExtremeCountQuery(searchCond, pageable)
+
+        page.content shouldHaveSize 10
+        page.totalElements shouldBeEqualTo 21L
+        page.content.first().member.name shouldBeEqualTo "member-10"
+        page.content.last().member.name shouldBeEqualTo "member-19"
     }
 }


### PR DESCRIPTION
## Summary

Closes #108

- PR 제목: chore: complete QueryDSL paging example

### 원문 선행 내용

Fixes #108

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Implemented the three unfinished `MemberRepositoryImpl` paging methods.
- Reused the existing QueryDSL DTO projection and condition filters across list/page queries.
- Added explicit pageable sorting via QueryDSL `OrderSpecifier` mapping to avoid Hibernate 7 path issues from Spring `Sort` translation.
- Added an optimized extreme count path that skips the team join when no team filter is needed.
- Added repository tests for all paging methods and the member-only extreme count path.
- Added a concise lessons entry for future QueryDSL paging work.

### 기존 섹션: DoD checklist

- [x] `TODO("Not yet implemented")` removed from `MemberRepositoryImpl`.
- [x] Targeted repository test passed.
- [x] Full `:bluetape4k-examples-jpa-querydsl-demo:test` passed.
- [x] IntelliJ diagnostics on touched Kotlin files reported 0 problems.
- [x] README checked; no behavior-facing documentation update required.
- [x] Lesson committed before PR creation.

### 기존 섹션: Verification

- `./gradlew :bluetape4k-examples-jpa-querydsl-demo:test --tests 'io.bluetape4k.examples.jpa.querydsl.domain.repository.JpaRepositoryTest'`\n- `./gradlew :bluetape4k-examples-jpa-querydsl-demo:test`\n- IntelliJ diagnostics on touched Kotlin files: 0 problems\n\n## Notes\n\nClaude advisor review found no remaining P0/P1 findings after the optimized count path and test coverage were added.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #108, milestone 없음, assignee `debop`
- PR: #469, head `77247dd4de1ec1c165475e4147098297802de183`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `chore/issue-108-querydsl-demo`
- Labels: `chore`, `examples`
- State: `MERGED`, merge commit `e760bd037590b0abf733da11f380c1ee930b6ade`
- CI: - Added explicit pageable sorting via QueryDSL `OrderSpecifier` mapping to avoid Hibernate 7 path issues from Spring `Sort` translation. / - Added a concise lessons entry for future QueryDSL paging work. / - [x] README checked; no behavior-facing documentation update required.

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #469 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e760bd037590b0abf733da11f380c1ee930b6ade`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
