### PR TITLE
fix: replace synchronized with ReentrantLock in CacheCoroutines and TransactionSupport (#473)

### DIFF
--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/support/TransactionSupport.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/support/TransactionSupport.kt
@@ -8,6 +8,8 @@ import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.reactive.TransactionalOperator
 import org.springframework.transaction.reactive.executeAndAwait
 import java.util.WeakHashMap
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 /**
  * [ConnectionFactory] 별 [R2dbcTransactionManager] 캐시.
@@ -16,6 +18,7 @@ import java.util.WeakHashMap
  * [WeakHashMap]으로 캐싱합니다. [WeakHashMap]을 사용하므로 [ConnectionFactory]가 GC 대상이 되면
  * 자동으로 캐시에서 제거됩니다.
  */
+private val transactionManagerLock = ReentrantLock()
 internal val transactionManagerCache = WeakHashMap<ConnectionFactory, R2dbcTransactionManager>()
 
 /**
@@ -23,7 +26,7 @@ internal val transactionManagerCache = WeakHashMap<ConnectionFactory, R2dbcTrans
  */
 @PublishedApi
 internal fun ConnectionFactory.getOrCreateTransactionManager(): R2dbcTransactionManager =
-    synchronized(transactionManagerCache) {
+    transactionManagerLock.withLock {
         transactionManagerCache.getOrPut(this) { R2dbcTransactionManager(this) }
     }
 

--- a/docs/lessons/2026-05-16-synchronized-to-reentrantlock.md
+++ b/docs/lessons/2026-05-16-synchronized-to-reentrantlock.md
@@ -1,0 +1,50 @@
+# Lesson: synchronized → ReentrantLock/Mutex 마이그레이션 (#473)
+
+## 배경
+
+코루틴/가상스레드 환경에서 `synchronized` 블록은 carrier thread를 pin하여 스케줄러 효율을 저하시킨다.
+JVM virtual thread(JDK 21+)는 `synchronized` monitor lock을 만나면 blocking되며, OS thread를 점유한 채 대기한다.
+CLAUDE.md 규칙: "코루틴/가상스레드 코드에서 `synchronized` 금지, `reentrantLock()` 사용"
+
+## 변경 대상
+
+| 파일 | 기존 | 변경 |
+|------|------|------|
+| `infra/resilience4j/src/main/kotlin/.../CacheCoroutines.kt` | `Collections.synchronizedMap(WeakHashMap)` + `synchronized(locksByCache)` × 2 | `ReentrantLock` + `lock.withLock {}` |
+| `data/r2dbc/src/main/kotlin/.../TransactionSupport.kt` | `synchronized(transactionManagerCache)` | `private val transactionManagerLock = ReentrantLock()` + `transactionManagerLock.withLock {}` |
+
+## 핵심 결정 사항
+
+### WeakHashMap 유지
+
+`Collections.synchronizedMap(WeakHashMap())` 패턴을 `WeakHashMap + ReentrantLock`으로 분리했다.
+`WeakHashMap`을 `ConcurrentHashMap`으로 교체하지 않은 이유:
+- GC-based cleanup이 목적. `Cache<*, *>` 또는 `ConnectionFactory` 참조가 사라지면 자동 제거.
+- `ConcurrentHashMap`은 강한 참조를 유지하므로 메모리 누수 가능성.
+
+### scope discipline
+
+코드 리뷰 중 `CacheCoroutineLocks.mutexFor`에 pre-existing race를 발견했다:
+- `computeIfAbsent(key) { Mutex() }` 가 `lock` 밖에서 실행되어,
+- `release()`가 inner map을 제거하는 순간 orphaned map에 Mutex가 생성될 수 있음.
+
+**이 버그는 이 PR에서 수정하지 않았다.** 이유:
+- Type-C Bug Fix 규칙: "요청 범위 밖의 변경 금지"
+- #473은 `synchronized` → `ReentrantLock` 마이그레이션이 목적
+- Race fix는 별도 이슈 #477로 추적
+
+## 검증
+
+- `infra/resilience4j`: 279 tests passing
+- `data/r2dbc`: 165 tests passing
+
+## 교훈
+
+1. **WeakHashMap 보호 패턴**: `Collections.synchronizedMap(WeakHashMap())` 대신 `WeakHashMap + ReentrantLock`이 가상스레드 안전하고 의도가 명확함.
+2. **scope discipline**: 코드 리뷰에서 pre-existing 버그를 발견해도 현재 PR 범위 밖이면 별도 이슈로 분리. 하나의 PR에 여러 fix를 묶으면 리뷰와 bisect가 어려워짐.
+3. **computeIfAbsent와 외부 lock의 결합**: inner ConcurrentHashMap의 `computeIfAbsent`는 락 없이도 원자적이지만, 외부 lock이 해제된 후 inner map 자체가 교체될 수 있는 구조에서는 여전히 race가 발생함. 관련 fix: #477.
+
+## 관련 이슈
+
+- #473: synchronized → ReentrantLock (이 PR)
+- #477: CacheCoroutineLocks mutexFor/release race — `computeIfAbsent` lock 밖 실행 (후속)

--- a/infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/cache/CacheCoroutines.kt
+++ b/infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/cache/CacheCoroutines.kt
@@ -7,16 +7,18 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import java.util.*
+import java.util.WeakHashMap
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 @PublishedApi
 internal object CacheCoroutineLocks {
-    private val locksByCache =
-        Collections.synchronizedMap(WeakHashMap<Cache<*, *>, ConcurrentHashMap<Any, Mutex>>())
+    private val lock = ReentrantLock()
+    private val locksByCache = WeakHashMap<Cache<*, *>, ConcurrentHashMap<Any, Mutex>>()
 
     fun mutexFor(cache: Cache<*, *>, key: Any): Mutex {
-        val locks = synchronized(locksByCache) {
+        val locks = lock.withLock {
             locksByCache.getOrPut(cache) { ConcurrentHashMap() }
         }
         return locks.computeIfAbsent(key) { Mutex() }
@@ -25,7 +27,7 @@ internal object CacheCoroutineLocks {
     fun release(cache: Cache<*, *>, key: Any, mutex: Mutex) {
         if (mutex.isLocked) return
 
-        synchronized(locksByCache) {
+        lock.withLock {
             val locks = locksByCache[cache] ?: return
             locks.remove(key, mutex)
             if (locks.isEmpty()) {


### PR DESCRIPTION
## Summary

Closes #473

- PR 제목: fix: replace synchronized with ReentrantLock in CacheCoroutines and TransactionSupport (#473)

Replaces `synchronized` monitor locks with `ReentrantLock` in two production files, eliminating virtual-thread carrier-thread pinning.

Closes #473

## Background

`synchronized {}` blocks pin the OS carrier thread when used inside coroutines or virtual threads. This blocks the JVM's virtual-thread scheduler and can degrade throughput significantly under concurrent load.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### `infra/resilience4j/src/main/kotlin/.../CacheCoroutines.kt`

- **Before**: `Collections.synchronizedMap(WeakHashMap<...>())` guarded by two `synchronized(locksByCache)` blocks
- **After**: Plain `WeakHashMap` guarded by a single `ReentrantLock`; inner `ConcurrentHashMap<Any, Mutex>` retained for per-key coroutine `Mutex` storage

`WeakHashMap` is intentionally kept (not replaced with `ConcurrentHashMap`) so that `Cache<*, *>` keys are GC'd when no longer referenced.

### `data/r2dbc/src/main/kotlin/.../TransactionSupport.kt`

- **Before**: `synchronized(transactionManagerCache) { ... }`
- **After**: `private val transactionManagerLock = ReentrantLock()` + `transactionManagerLock.withLock { ... }`

Same rationale: `WeakHashMap` provides GC-based cleanup for `ConnectionFactory` keys.

### 기존 섹션: Note on Pre-existing Race

During code review, a pre-existing race was identified in `CacheCoroutineLocks.mutexFor` where `computeIfAbsent` runs outside the outer lock — tracked separately as #477. That race is intentionally **not** fixed in this PR (scope discipline: Type-C bug fix is surgical).

## Validation

| Module | Result |
|--------|--------|
| `:bluetape4k-resilience4j` | 279 passing ✅ |
| `:bluetape4k-r2dbc` | 165 passing ✅ |

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #473, milestone 없음, assignee 없음
- PR: #478, head `4e844683b766cb5d480413e7bfd24e12ff3cc882`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/synchronized-to-reentrantlock`
- Labels: `bug`, `1.8.0-before`
- State: `MERGED`, merge commit `7e0f6573b9026616aa9b0f7f132a3089831b656c`
- CI: During code review, a pre-existing race was identified in `CacheCoroutineLocks.mutexFor` where `computeIfAbsent` runs outside the outer lock — tracked separately as #477. That race is intentionally **not** fixed in this PR (scope discipline: Type-C bug fix is surgical).

## DoD Status

- [x] Virtual-thread pinning hazard removed
- [x] WeakHashMap GC semantics preserved
- [x] Tests passing (two affected modules)
- [x] Pre-existing race filed separately (#477)
- [x] Lessons committed (`docs/lessons/2026-05-16-synchronized-to-reentrantlock.md`)

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #478 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `7e0f6573b9026616aa9b0f7f132a3089831b656c`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
