### PR TITLE
fix: eliminate race conditions in CacheCoroutineLocks mutexFor/release (#477)

### DIFF
--- a/docs/lessons/2026-05-16-cache-coroutine-locks-race.md
+++ b/docs/lessons/2026-05-16-cache-coroutine-locks-race.md
@@ -66,7 +66,7 @@ fun release(cache: Cache<*, *>, key: Any, mutex: Mutex) {
 
 **Option B (reference counting) 이번 PR에서 선택하지 않은 이유:**
 - ref-counting 자체는 outer ReentrantLock 안에서 안전하다 (mutexFor에서 증가, release에서 감소, 그 사이 count≥1이므로 제거 불가)
-- 버그 수정의 외과적 범위를 유지하기 위해 복잡도를 최소화; ref-counting은 #XXX에서 follow-up으로 처리
+- 버그 수정의 외과적 범위를 유지하기 위해 복잡도를 최소화; ref-counting은 #499에서 follow-up으로 처리
 - WeakHashMap GC 모델이 Cache 인스턴스 수명 기반 회수를 제공하고, JCache provider(Caffeine 등)가 key cardinality를 자체적으로 제한하므로 메모리 위험 실질적으로 낮음
 
 ---

--- a/docs/lessons/2026-05-16-cache-coroutine-locks-race.md
+++ b/docs/lessons/2026-05-16-cache-coroutine-locks-race.md
@@ -1,0 +1,114 @@
+# CacheCoroutineLocks — 복합 연산 경쟁 조건 수정 (Issue #477)
+
+날짜: 2026-05-16
+이슈: #477
+모듈: `infra/resilience4j` — `io.bluetape4k.resilience4j.cache.CacheCoroutineLocks`
+
+---
+
+## 근본 원인
+
+`CacheCoroutineLocks`에 두 가지 경쟁 조건이 존재했다.
+
+### 버그 1 (HIGH): mutexFor — lock 범위 밖 복합 연산
+
+```kotlin
+// 기존 코드
+fun mutexFor(cache: Cache<*, *>, key: Any): Mutex {
+    val locks = lock.withLock {
+        locksByCache.getOrPut(cache) { ConcurrentHashMap() }   // (A)
+    }                                                           // ← lock 해제
+    return locks.computeIfAbsent(key) { Mutex() }              // (B) lock 없음
+}
+```
+
+경쟁 창:
+- T1: (A) 에서 inner map M 획득 → outer lock 해제
+- T2: `release()` 가 M 를 비우고 `locksByCache` 에서 제거
+- T3: `mutexFor()` 가 새 inner map M' 에 Mutex3 생성
+- T1: (B) 에서 고아된 M 에 Mutex1 생성
+- 결과: T1과 T3이 동일 key에 대해 서로 다른 Mutex를 보유 → per-key 직렬화 보장 파괴
+
+### 버그 2 (MEDIUM): release — TOCTOU isLocked 검사
+
+```kotlin
+fun release(cache: Cache<*, *>, key: Any, mutex: Mutex) {
+    if (mutex.isLocked) return           // lock 없이 검사
+    lock.withLock {
+        locks.remove(key, mutex)         // 검사와 제거 사이 window 존재
+    }
+}
+```
+
+- T_a: `mutexFor()` 에서 Mutex1 획득, 아직 `withLock` 호출 전
+- T_b: `release()` 가 `isLocked == false` 확인 → Mutex1 제거
+- T_c: `mutexFor()` 에서 새 Mutex2 획득
+- T_a와 T_c: 동일 key에 대해 동시 실행
+
+---
+
+## 수정 방법: Option A (no-op release)
+
+```kotlin
+fun mutexFor(cache: Cache<*, *>, key: Any): Mutex = lock.withLock {
+    locksByCache.getOrPut(cache) { HashMap() }.getOrPut(key) { Mutex() }
+}
+
+fun release(cache: Cache<*, *>, key: Any, mutex: Mutex) {
+    // 의도적 no-op.
+    // Per-key Mutex 항목을 제거하지 않는다.
+    // 제거하면 concurrent caller가 Mutex 참조를 획득한 후 아직 withLock을 호출하기
+    // 전에 새 caller가 다른 Mutex를 받을 수 있다 — per-key 직렬화 보장 파괴.
+    // WeakHashMap이 Cache key가 GC될 때 entire inner map을 회수하므로
+    // 메모리는 Cache 수명 단위로 제한된다.
+}
+```
+
+**Option B (reference counting) 선택하지 않은 이유:**
+- 카운터 자체도 동일한 TOCTOU 문제를 갖는다
+- 구현 복잡도 증가 대비 이득 없음
+- WeakHashMap GC 모델이 이미 Cache 수명 기반 회수를 제공한다
+
+---
+
+## 추가 수정 사항
+
+| 항목 | 변경 내용 |
+|------|-----------|
+| `ConcurrentHashMap` 제거 | 모든 접근이 `lock.withLock` 안에 있으므로 plain `HashMap`으로 충분 |
+| `cacheKey as Any` 캐스트 제거 | `val cacheKey: K & Any` intersection type으로 캐스트 불필요 |
+
+---
+
+## 메모리 트레이드오프
+
+- **기존**: per-key Mutex를 사용 후 제거 → 작은 메모리 공간, 경쟁 조건 존재
+- **수정 후**: Mutex를 Cache 수명 동안 유지 → O(distinct keys) 메모리, 경쟁 조건 없음
+- JCache provider (Caffeine 등)가 이미 key 개수를 제한하므로 메모리 누수 우려 없음
+
+---
+
+## RED/GREEN 검증 노트
+
+테스트가 버그 코드에서도 통과(RED 실패 없음)한 이유:
+- `mutexFor` 내 lock 해제 → `computeIfAbsent` 사이 경쟁 창은 1-2 instruction
+- OS 스케줄러가 이 창에서 선점하는 경우가 드물어 stress test도 통과
+- 경쟁 조건은 코드 분석으로 증명되었고, 수정의 정확성도 코드 분석으로 검증
+
+---
+
+## 삭제한 multi-key 스트레스 테스트
+
+추가했던 `executeSuspendFunction 은 다중 key 동시 miss 에서 key 별로 loader 를 한 번만 실행한다` 테스트는 삭제:
+- 첫 번째 miss 후 JCache가 warm 되어 이후 호출이 모두 캐시 적중
+- `callCount == 1` 조건이 버그 코드에서도 통과 → 회귀 감지 불가
+- 기존 `executeSuspendFunction 은 동일 key 동시 miss 에서 loader 를 한 번만 실행한다` 가 contract를 충분히 커버
+
+---
+
+## 향후 가이드
+
+- `synchronized` 또는 `ConcurrentHashMap`의 복합 연산은 원자성을 보장하지 않는다
+- `getOrPut` 체이닝은 반드시 하나의 lock.withLock 안에서 실행해야 한다
+- per-key Mutex 패턴에서 "사용 후 제거" 전략은 TOCTOU를 유발한다; 유지 전략 또는 reference counting 필요
+- 경쟁 조건 버그는 stress test로 재현이 어려울 수 있으므로 코드 분석을 우선한다

--- a/docs/lessons/2026-05-16-cache-coroutine-locks-race.md
+++ b/docs/lessons/2026-05-16-cache-coroutine-locks-race.md
@@ -64,10 +64,10 @@ fun release(cache: Cache<*, *>, key: Any, mutex: Mutex) {
 }
 ```
 
-**Option B (reference counting) 선택하지 않은 이유:**
-- 카운터 자체도 동일한 TOCTOU 문제를 갖는다
-- 구현 복잡도 증가 대비 이득 없음
-- WeakHashMap GC 모델이 이미 Cache 수명 기반 회수를 제공한다
+**Option B (reference counting) 이번 PR에서 선택하지 않은 이유:**
+- ref-counting 자체는 outer ReentrantLock 안에서 안전하다 (mutexFor에서 증가, release에서 감소, 그 사이 count≥1이므로 제거 불가)
+- 버그 수정의 외과적 범위를 유지하기 위해 복잡도를 최소화; ref-counting은 #XXX에서 follow-up으로 처리
+- WeakHashMap GC 모델이 Cache 인스턴스 수명 기반 회수를 제공하고, JCache provider(Caffeine 등)가 key cardinality를 자체적으로 제한하므로 메모리 위험 실질적으로 낮음
 
 ---
 

--- a/infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/cache/CacheCoroutines.kt
+++ b/infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/cache/CacheCoroutines.kt
@@ -8,32 +8,27 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.util.WeakHashMap
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
 @PublishedApi
 internal object CacheCoroutineLocks {
     private val lock = ReentrantLock()
-    private val locksByCache = WeakHashMap<Cache<*, *>, ConcurrentHashMap<Any, Mutex>>()
+    // Plain HashMap is sufficient because all access is under lock.
+    // WeakHashMap: the inner map is GC'd when the Cache key becomes unreachable.
+    private val locksByCache = WeakHashMap<Cache<*, *>, HashMap<Any, Mutex>>()
 
-    fun mutexFor(cache: Cache<*, *>, key: Any): Mutex {
-        val locks = lock.withLock {
-            locksByCache.getOrPut(cache) { ConcurrentHashMap() }
-        }
-        return locks.computeIfAbsent(key) { Mutex() }
+    fun mutexFor(cache: Cache<*, *>, key: Any): Mutex = lock.withLock {
+        locksByCache.getOrPut(cache) { HashMap() }.getOrPut(key) { Mutex() }
     }
 
     fun release(cache: Cache<*, *>, key: Any, mutex: Mutex) {
-        if (mutex.isLocked) return
-
-        lock.withLock {
-            val locks = locksByCache[cache] ?: return
-            locks.remove(key, mutex)
-            if (locks.isEmpty()) {
-                locksByCache.remove(cache)
-            }
-        }
+        // Per-key Mutex entries are intentionally not removed here.
+        // Removing an entry while a concurrent caller holds the Mutex reference
+        // but has not yet acquired it would allow a new caller to receive a
+        // different Mutex for the same key — breaking the per-key serialization
+        // guarantee. The WeakHashMap reclaims the entire inner map when the
+        // Cache key becomes unreachable, so memory is bounded per Cache lifetime.
     }
 }
 
@@ -122,8 +117,8 @@ suspend inline fun <K, V> Cache<K, V>.executeSuspendFunction(
     key: K,
     crossinline loader: suspend (K) -> V,
 ): V {
-    val cacheKey = requireNotNull(key) { "cache key must not be null" }
-    val mutex = CacheCoroutineLocks.mutexFor(this, cacheKey as Any)
+    val cacheKey: K & Any = requireNotNull(key) { "cache key must not be null" }
+    val mutex = CacheCoroutineLocks.mutexFor(this, cacheKey)
 
     return try {
         mutex.withLock {
@@ -152,6 +147,6 @@ suspend inline fun <K, V> Cache<K, V>.executeSuspendFunction(
             value
         }
     } finally {
-        CacheCoroutineLocks.release(this, cacheKey as Any, mutex)
+        CacheCoroutineLocks.release(this, cacheKey, mutex)
     }
 }


### PR DESCRIPTION
## Summary

Closes #477

- PR 제목: fix: eliminate race conditions in CacheCoroutineLocks mutexFor/release (#477)

Fixes two race conditions in `CacheCoroutineLocks` that could break per-key mutex serialization, allowing concurrent cache loaders to run simultaneously for the same cache key.

### 원문 선행 내용

Closes #477
Related: #499

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

| Item | Change |
|------|--------|
| `ConcurrentHashMap` removed | All access is under `lock.withLock {}`; plain `HashMap` is sufficient |
| `cacheKey as Any` cast removed | Use `K & Any` intersection type (definitively non-null) |

### 기존 섹션: Root Causes

### Bug 1 (HIGH): composite operation outside lock scope

```kotlin
// Before — computeIfAbsent ran OUTSIDE lock.withLock {}
fun mutexFor(cache: Cache<*, *>, key: Any): Mutex {
    val locks = lock.withLock {
        locksByCache.getOrPut(cache) { ConcurrentHashMap() }  // (A) lock released here
    }
    return locks.computeIfAbsent(key) { Mutex() }             // (B) no lock → race window
}
```

Race: T1 acquires inner map M → lock released → T2 calls `release()` and removes M → T3 creates new inner map M' with Mutex3 → T1 inserts Mutex1 into orphaned M. Result: T1 and T3 hold different Mutex instances for the same key.

### Bug 2 (MEDIUM): TOCTOU `isLocked` check

```kotlin
// Before — isLocked check outside lock
fun release(cache: Cache<*, *>, key: Any, mutex: Mutex) {
    if (mutex.isLocked) return           // read-check-act window
    lock.withLock { locks.remove(key, mutex) }
}
```

### 기존 섹션: Fix (Option A — no-op release)

```kotlin
// After — entire composite operation inside single lock
fun mutexFor(cache: Cache<*, *>, key: Any): Mutex = lock.withLock {
    locksByCache.getOrPut(cache) { HashMap() }.getOrPut(key) { Mutex() }
}

fun release(cache: Cache<*, *>, key: Any, mutex: Mutex) {
    // Intentional no-op. Per-key Mutex entries are not removed.
    // WeakHashMap reclaims the entire inner map when the Cache key becomes
    // unreachable, bounding memory per Cache lifetime.
}
```

**Why not Option B (reference counting)?** Ref-counting under the outer ReentrantLock is safe (count ≥ 1 between mutexFor and release prevents premature removal). Deferred to keep this fix surgical. Tracked in #499.

### 기존 섹션: Memory Trade-off

- Before: per-key Mutex removed after use → small footprint, race condition present
- After: Mutex retained per Cache lifetime → O(distinct keys), no race condition
- JCache providers (Caffeine etc.) already bound key cardinality

### 기존 섹션: Verification

```bash
./gradlew :infra:bluetape4k-resilience4j:test
```

### 기존 섹션: Follow-up

- #499: Add reference-counting for per-key Mutex cleanup (Codex P2)

## Validation

```
Module: :infra:bluetape4k-resilience4j
Tests: 37 passing, 0 failed, 0 skipped
Time: 7.2s
```

Key test: `executeSuspendFunction 은 동일 key 동시 miss 에서 loader 를 한 번만 실행한다`
— two coroutines racing on the same key; loader must execute exactly once.

## Review Notes

- Opus advisor review: P0=0, P1=0
- Codex CLI review: P0=0, P1=0, P2=1 (per-key retention for high-churn caches → tracked in #499)

## Metadata

- Issue: #477, milestone 없음, assignee 없음
- PR: #500, head `c0d92c842bc9d62c714b9ce46003a843fcaa1947`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/cache-coroutine-locks-race`
- Labels: `bug`, `1.8.0-before`
- State: `MERGED`, merge commit `b9567f8b5087413075a850973657cc51931b8c42`
- CI: | `ConcurrentHashMap` removed | All access is under `lock.withLock {}`; plain `HashMap` is sufficient | / — two coroutines racing on the same key; loader must execute exactly once. / ./gradlew :infra:bluetape4k-resilience4j:test

## DoD Status

- [x] All tests passing (37/37)
- [x] Tier 4 code review: CRITICAL/HIGH = 0
- [x] Opus advisor review: P0/P1 = 0
- [x] Codex CLI review: P0/P1 = 0
- [x] Lessons committed: `docs/lessons/2026-05-16-cache-coroutine-locks-race.md`
- [x] English KDoc updated on changed public API
- [x] README locale set: no behavioral change to document

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #500 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `b9567f8b5087413075a850973657cc51931b8c42`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
