### PR TITLE
fix: clear stale Resumable waiter on cancellation and propagate cancel to wrapped Future

### DIFF
--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/FutureSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/FutureSupport.kt
@@ -40,12 +40,13 @@ fun <T> Future<T>.asCompletableFuture(): CompletableFuture<T> = when (this@asCom
 /**
  * [Future]를 [CompletableFuture]로 변환하는 래퍼.
  * Virtual thread에서 [Future.get]으로 블로킹 대기하여 폴링 오버헤드를 제거합니다.
+ * [cancel]은 래핑된 Future에도 전파되어 불필요한 작업을 중단시킵니다.
  */
-private class FutureToCompletableFutureWrapper<T>(future: Future<T>): CompletableFuture<T>() {
+private class FutureToCompletableFutureWrapper<T>(private val wrapped: Future<T>): CompletableFuture<T>() {
     init {
         Thread.ofVirtual().name("future-wrapper").start {
             try {
-                complete(future.get())
+                complete(wrapped.get())
             } catch (e: CancellationException) {
                 cancel(true)
             } catch (e: ExecutionException) {
@@ -54,5 +55,10 @@ private class FutureToCompletableFutureWrapper<T>(future: Future<T>): Completabl
                 completeExceptionally(e)
             }
         }
+    }
+
+    override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
+        wrapped.cancel(mayInterruptIfRunning)
+        return super.cancel(mayInterruptIfRunning)
     }
 }

--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/Resumable.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/Resumable.kt
@@ -44,12 +44,13 @@ open class Resumable {
     private val continuation by continuationRef
 
     /**
-     * 외부에서 [resume] 신호가 올 때까지 현재 코루틴을 대기시킵니다.
+     * Suspends the current coroutine until [resume] is called externally.
      *
-     * ## 동작/계약
-     * - 이미 재개된 상태면 suspend 없이 즉시 반환합니다.
-     * - 다른 코루틴이 이미 대기 중이면 `IllegalStateException`이 발생합니다.
-     * - 복귀 직후 내부 continuation 슬롯을 `null`로 되돌립니다.
+     * ## Behaviour / Contract
+     * - Returns immediately without suspending if already in the READY state.
+     * - Throws `IllegalStateException` if another coroutine is already waiting.
+     * - Clears the internal continuation slot before returning.
+     * - Cancellation clears the waiter slot so a subsequent `await()` succeeds normally.
      */
     suspend fun await() {
         suspendCancellableCoroutine { cont ->
@@ -63,6 +64,11 @@ open class Resumable {
                     throw IllegalStateException("Only one thread can await a Resumable")
                 }
                 if (continuationRef.compareAndSet(current, cont)) {
+                    // Clear only this continuation on cancellation; leave READY intact if
+                    // resume() already replaced it before the handler fires.
+                    cont.invokeOnCancellation {
+                        continuationRef.compareAndSet(cont, null)
+                    }
                     break
                 }
             }

--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/support/FutureSupport.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/support/FutureSupport.kt
@@ -9,10 +9,11 @@ import java.util.concurrent.Future
 /**
  * `Future`를 중단 가능 방식으로 대기하고 완료 값을 반환합니다.
  *
- * ## 동작/계약
- * - `CompletionStage` 구현체면 `await()`를 사용해 바로 대기합니다.
- * - 그 외 `Future`는 `asCompletableFuture()`로 변환해 `await()`로 대기합니다.
- * - 이미 취소된 `Future`면 `CancellationException`을 던집니다.
+ * ## Behaviour / Contract
+ * - Delegates to `await()` directly when the receiver is a `CompletionStage`.
+ * - Wraps other `Future` types via `asCompletableFuture()` then awaits.
+ * - Throws `CancellationException` if the `Future` is already cancelled.
+ * - Cancelling the caller propagates to the underlying `Future` via `cancel(false)`.
  *
  * ```kotlin
  * val future = java.util.concurrent.CompletableFuture.completedFuture(42)

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/ResumableTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/ResumableTest.kt
@@ -1,8 +1,12 @@
 package io.bluetape4k.coroutines.flow.extensions
 
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -28,5 +32,57 @@ class ResumableTest {
         resumable.resume()
         delay(10.milliseconds)
         resumable.await()
+    }
+
+    @Test
+    fun `cancelled await clears slot so subsequent await succeeds`() = runTest {
+        val resumable = Resumable()
+
+        // Cancel a waiting coroutine before resume() is called.
+        val job = launch {
+            resumable.await()
+        }
+
+        yield() // let the launched coroutine install its continuation
+        job.cancel()
+        job.join() // wait until cancellation is processed
+
+        // The slot must be cleared. A new await() + resume() must not throw
+        // "Only one thread can await a Resumable".
+        var reached = false
+        launch {
+            resumable.await()
+            reached = true
+        }
+        yield()
+        resumable.resume()
+        yield()
+
+        reached shouldBeEqualTo true
+    }
+
+    @Test
+    fun `READY fast path still works after invokeOnCancellation change`() = runTest {
+        val resumable = Resumable()
+
+        // resume() fires before await() — READY is set.
+        resumable.resume()
+
+        // An await() on a READY Resumable returns immediately (no suspension).
+        // The invokeOnCancellation handler must not overwrite the null reset
+        // that getAndSet(null) performs at the end of await().
+        resumable.await()
+
+        // A subsequent resume+await cycle must still work.
+        var reached = false
+        launch {
+            resumable.await()
+            reached = true
+        }
+        yield()
+        resumable.resume()
+        yield()
+
+        reached shouldBeEqualTo true
     }
 }

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/support/FutureSupportTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/support/FutureSupportTest.kt
@@ -1,5 +1,7 @@
 package io.bluetape4k.coroutines.support
 
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.junit5.coroutines.runSuspendDefault
@@ -10,9 +12,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.future.future
-import io.bluetape4k.assertions.shouldBeEqualTo
+import kotlinx.coroutines.launch
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.FutureTask
@@ -25,6 +26,7 @@ class FutureSupportTest {
     companion object: KLoggingChannel() {
         private const val ITEM_COUNT = 128
         private const val DELAY_TIME = 100L
+        private const val CANCEL_PROPAGATION_DELAY_MS = 50L
     }
 
     @Test
@@ -78,5 +80,23 @@ class FutureSupportTest {
         assertFailsWith<CancellationException> {
             cancelled.await()
         }
+    }
+
+    @Test
+    fun `awaitSuspending 취소 시 하위 Future도 취소된다`() = runSuspendDefault {
+        // FutureTask that is never started — future.get() inside the wrapper blocks
+        // until the task is started or cancelled.
+        val task = FutureTask { "never" }
+
+        val job = launch(Dispatchers.IO) {
+            task.awaitSuspending<String>()
+        }
+
+        // Give the wrapper's virtual thread time to start and block on task.get().
+        delay(CANCEL_PROPAGATION_DELAY_MS.milliseconds)
+        job.cancel()
+        job.join()
+
+        task.isCancelled shouldBeEqualTo true
     }
 }

--- a/docs/lessons/2026-05-16-coroutine-cancellation-primitives.md
+++ b/docs/lessons/2026-05-16-coroutine-cancellation-primitives.md
@@ -1,0 +1,116 @@
+# Lesson: Coroutine Cancellation Primitives — Stale Waiters and Uncancelled Futures
+
+**Date:** 2026-05-16
+**Issue:** #483
+**Branch:** `fix/coroutine-cancellation-primitives`
+**PR:** (pending)
+
+---
+
+## Root Cause
+
+### Bug 1 — Resumable stale waiter
+
+`Resumable.await()` installs a `Continuation` into `continuationRef` via CAS inside
+`suspendCancellableCoroutine`, but previously registered no `invokeOnCancellation` handler.
+
+When the awaiting coroutine was cancelled before `resume()` was called, the continuation
+remained in the slot. A subsequent `await()` call found the slot occupied and threw
+`IllegalStateException("Only one thread can await a Resumable")`, even though the original
+awaiter was long gone.
+
+### Bug 2 — FutureToCompletableFutureWrapper uncancelled underlying Future
+
+`FutureToCompletableFutureWrapper` (in `bluetape4k-core`) wraps a plain `Future<T>` using a
+virtual thread that blocks on `future.get()`. The class did not override `cancel()`, so
+coroutine cancellation (which calls `CompletableFuture.cancel()`) only marked the wrapper as
+cancelled — the virtual thread continued blocking on `future.get()` indefinitely, leaking the
+underlying work.
+
+---
+
+## Decision
+
+**Bug 1 fix** — register `invokeOnCancellation` immediately after the CAS succeeds:
+
+```kotlin
+if (continuationRef.compareAndSet(current, cont)) {
+    // CAS-clear only this cont; leave READY intact if resume() already replaced it.
+    cont.invokeOnCancellation {
+        continuationRef.compareAndSet(cont, null)
+    }
+    break
+}
+```
+
+Key invariant: `compareAndSet(cont, null)` (not `set(null)`) preserves a READY sentinel
+placed by a concurrent `resume()`. If `resume()` wins first, the CAS comparand is READY ≠
+cont, so the cancellation handler is a no-op and READY is unaffected.
+
+**Bug 2 fix** — override `cancel()` in `FutureToCompletableFutureWrapper`:
+
+```kotlin
+override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
+    wrapped.cancel(mayInterruptIfRunning)
+    return super.cancel(mayInterruptIfRunning)
+}
+```
+
+Order matters: cancel `wrapped` first so the virtual thread's `future.get()` unblocks,
+then call `super.cancel()`. The virtual thread may re-enter `cancel(true)` from its
+`CancellationException` catch block — this is safe because `CompletableFuture.cancel()` is
+idempotent on already-cancelled state.
+
+---
+
+## Outcome
+
+- `Resumable`: cancelled `await()` now clears the slot; next `await()` + `resume()` pair
+  succeeds without `IllegalStateException`.
+- `FutureToCompletableFutureWrapper`: coroutine cancellation propagates to the underlying
+  `Future`, stopping the virtual thread's blocking work.
+- 7 tests pass (5 pre-existing + 2 new for `Resumable`, 4 pre-existing + 1 new for
+  `FutureSupport`).
+
+---
+
+## Verification Evidence
+
+```
+io.bluetape4k.coroutines.flow.extensions.ResumableTest ✔ correct state
+io.bluetape4k.coroutines.flow.extensions.ResumableTest ✔ cancelled await clears slot so subsequent await succeeds
+io.bluetape4k.coroutines.flow.extensions.ResumableTest ✔ READY fast path still works after invokeOnCancellation change
+io.bluetape4k.coroutines.support.FutureSupportTest     ✔ Massive future as CompletableFuture in multi-threads
+io.bluetape4k.coroutines.support.FutureSupportTest     ✔ Massive Future as CompletableFuture in Coroutines
+io.bluetape4k.coroutines.support.FutureSupportTest     ✔ 취소된 Future는 await 시 CancellationException을 던진다
+io.bluetape4k.coroutines.support.FutureSupportTest     ✔ awaitSuspending 취소 시 하위 Future도 취소된다
+7 passing (2.1s)
+```
+
+---
+
+## Review Findings Resolved
+
+| Severity | Finding | Resolution |
+|----------|---------|------------|
+| LOW | KDoc language mix in `Resumable.await()` | Converted full block to English |
+| LOW | KDoc language mix in `awaitSuspending()` | Converted full block to English |
+| LOW | Test `catch (CancellationException)` without rethrow | Removed try/catch entirely |
+| LOW | Magic `50.milliseconds` literal in test | Extracted to `CANCEL_PROPAGATION_DELAY_MS` const |
+
+---
+
+## Future Guidance
+
+- **`suspendCancellableCoroutine` + CAS install pattern**: always register
+  `invokeOnCancellation` using `compareAndSet(cont, null)` — not `set(null)` — so that a
+  concurrent sentinel set by a producer is not clobbered.
+- **`invokeOnCancellation` fires synchronously** when the coroutine is already cancelled at
+  registration time, so there is no "registered too late" window.
+- **READY fast path does not suspend**: when `cont.resumeWith()` fires inside the CancellableCoroutine
+  lambda, no cancellation window exists and `invokeOnCancellation` need not be registered.
+- **CompletableFuture wrappers must override `cancel()`** if they launch background threads or
+  virtual threads that block on the wrapped resource. Omitting the override leaks the thread.
+- **cancel order in wrappers**: cancel the wrapped resource first, then call
+  `super.cancel()`. The wrapper's virtual thread can re-enter `cancel()` from its catch block;
+  this is safe because `CompletableFuture.cancel()` is idempotent.


### PR DESCRIPTION
## Summary

Closes #483

- PR 제목: fix: clear stale Resumable waiter on cancellation and propagate cancel to wrapped Future

Fixes two cancellation bugs in coroutine primitives (issue #483).

### Bug 1 — Resumable stale waiter

`Resumable.await()` installed a continuation via CAS but registered no `invokeOnCancellation` handler. A cancelled awaiter left its `Continuation` in the slot, causing the next `await()` call to throw `IllegalStateException("Only one thread can await a Resumable")`.

**Fix:** register `cont.invokeOnCancellation { continuationRef.compareAndSet(cont, null) }` after CAS succeeds. Uses `compareAndSet` (not `set`) so a concurrent READY sentinel placed by `resume()` is preserved.

### Bug 2 — FutureToCompletableFutureWrapper uncancelled underlying Future

`FutureToCompletableFutureWrapper` (in `bluetape4k-core`) spawns a virtual thread that blocks on `future.get()`. Without a `cancel()` override, coroutine cancellation only marked the wrapper CompletableFuture as cancelled — the virtual thread kept blocking on `future.get()` indefinitely.

**Fix:** override `cancel(mayInterruptIfRunning)` to call `wrapped.cancel(mayInterruptIfRunning)` before `super.cancel(...)`.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

| File | Change |
|------|--------|
| `bluetape4k/core/.../concurrent/FutureSupport.kt` | Add `cancel()` override to `FutureToCompletableFutureWrapper` |
| `bluetape4k/coroutines/.../flow/extensions/Resumable.kt` | Register `invokeOnCancellation` after CAS; convert KDoc to English |
| `bluetape4k/coroutines/.../support/FutureSupport.kt` | Convert KDoc to English with cancellation contract bullet |
| `bluetape4k/coroutines/.../flow/extensions/ResumableTest.kt` | +2 regression tests |
| `bluetape4k/coroutines/.../support/FutureSupportTest.kt` | +1 regression test |
| `docs/lessons/2026-05-16-coroutine-cancellation-primitives.md` | Lessons document |

### 기존 섹션: Verification Commands

```bash
./gradlew :bluetape4k-coroutines:test --tests "io.bluetape4k.coroutines.flow.extensions.ResumableTest"
./gradlew :bluetape4k-coroutines:test --tests "io.bluetape4k.coroutines.support.FutureSupportTest"
```

Closes #483

## Validation

```
io.bluetape4k.coroutines.flow.extensions.ResumableTest ✔ correct state
io.bluetape4k.coroutines.flow.extensions.ResumableTest ✔ cancelled await clears slot so subsequent await succeeds
io.bluetape4k.coroutines.flow.extensions.ResumableTest ✔ READY fast path still works after invokeOnCancellation change
io.bluetape4k.coroutines.support.FutureSupportTest     ✔ Massive future as CompletableFuture in multi-threads
io.bluetape4k.coroutines.support.FutureSupportTest     ✔ Massive Future as CompletableFuture in Coroutines
io.bluetape4k.coroutines.support.FutureSupportTest     ✔ 취소된 Future는 await 시 CancellationException을 던진다
io.bluetape4k.coroutines.support.FutureSupportTest     ✔ awaitSuspending 취소 시 하위 Future도 취소된다
7 passing (2.1s)
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #483, milestone 없음, assignee `debop`
- PR: #501, head `0f831619a3f1387727a64f7574ccc6f2c2be9fe1`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/coroutine-cancellation-primitives`
- Labels: `bug`
- State: `MERGED`, merge commit `e9aecc5ebea1f698a1c42ebafe23e73ab4523184`
- CI: ./gradlew :bluetape4k-coroutines:test --tests "io.bluetape4k.coroutines.flow.extensions.ResumableTest" / ./gradlew :bluetape4k-coroutines:test --tests "io.bluetape4k.coroutines.support.FutureSupportTest"

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #501 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e9aecc5ebea1f698a1c42ebafe23e73ab4523184`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
