### PR TITLE
fix: rethrow CancellationException in tryObserveSuspending and tryWithObservationSuspending

### DIFF
--- a/docs/lessons/2026-05-16-micrometer-cancellation-swallow.md
+++ b/docs/lessons/2026-05-16-micrometer-cancellation-swallow.md
@@ -1,0 +1,80 @@
+# Lesson: Micrometer suspend try* wrappers swallow coroutine cancellation
+
+**Date:** 2026-05-16
+**Issue:** #488
+**Branch:** `fix/micrometer-cancellation-swallow`
+**PR:** (pending)
+
+---
+
+## Root Cause
+
+`tryObserveSuspending` and `tryWithObservationSuspending` wrapped their entire body in
+`runCatching {}`. Because `runCatching` is implemented as a blanket `try { } catch (e:
+Throwable) { Result.failure(e) }`, it catches `CancellationException` and returns it as
+`Result.failure(CancellationException)` instead of rethrowing.
+
+The inner helpers (`withObservationContextSuspending`) already rethrow `CancellationException`
+correctly (lines 196-198, 235-237). But the outer `runCatching` intercepted the rethrow and
+swallowed it, violating structured concurrency.
+
+---
+
+## Decision
+
+Replace `runCatching` with explicit try/catch that distinguishes cancellation from failure:
+
+```kotlin
+return try {
+    Result.success(innerCall() ?: throw NoSuchElementException())
+} catch (e: CancellationException) {
+    throw e
+} catch (e: Throwable) {
+    Result.failure(e)
+}
+```
+
+The `catch (CancellationException)` block must precede `catch (Throwable)` because
+`CancellationException` is a subtype of `IllegalStateException` which is a subtype of
+`Throwable`. Ordering matters.
+
+---
+
+## Outcome
+
+- Both `tryObserveSuspending` and `tryWithObservationSuspending` now propagate
+  `CancellationException` to the parent job.
+- `Result.failure` is returned only for non-cancellation `Throwable`.
+- 9 tests pass (7 pre-existing + 2 new cancellation regression tests).
+
+---
+
+## Verification Evidence
+
+```
+io.bluetape4k.micrometer.observation.coroutines.ObservationCoroutinesSupportTest ✔ tryObserveSuspending - cancellation propagates to parent job
+io.bluetape4k.micrometer.observation.coroutines.ObservationCoroutinesSupportTest ✔ tryWithObservationSuspending - cancellation propagates to parent job
+9 passing (2.3s)
+```
+
+---
+
+## Future Guidance
+
+- **`runCatching {}` must never wrap `suspend` calls.** It silently converts
+  `CancellationException` into `Result.failure`, breaking structured concurrency.
+  Use explicit `try/catch` instead.
+- **Catch ordering:** `CancellationException` before `Throwable` — always.
+- **Test pattern for cancellation propagation:**
+  ```kotlin
+  var cancelled = false
+  var result: Result<T>? = null
+  val job = launch {
+      try { result = suspendWrapper() }
+      catch (e: CancellationException) { cancelled = true; throw e }
+  }
+  yield(); job.cancel(); job.join()
+  cancelled shouldBeEqualTo true
+  result shouldBeEqualTo null  // must not have returned Result.failure
+  ```
+  Asserting both `cancelled == true` AND `result == null` pins the full contract.

--- a/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/observation/coroutines/ObservationCoroutinesSupport.kt
+++ b/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/observation/coroutines/ObservationCoroutinesSupport.kt
@@ -84,7 +84,12 @@ suspend inline fun <T: Any> Observation.observeSuspending(
     }
 
 /**
- * [observeSuspending] 결과를 [Result] 로 감싸 예외를 호출자에게 위임하지 않습니다.
+ * Wraps [observeSuspending] in a [Result], returning failure for non-cancellation errors.
+ *
+ * ## Behaviour / Contract
+ * - Returns `Result.success(value)` when the block completes normally.
+ * - Returns `Result.failure(exception)` for non-cancellation exceptions.
+ * - Rethrows [CancellationException] so structured cancellation is preserved.
  *
  * ```kotlin
  * val registry = ObservationRegistry.create()
@@ -96,18 +101,25 @@ suspend inline fun <T: Any> Observation.observeSuspending(
  * // result.getOrNull() == "observed-result"
  * ```
  *
- * @param T 결과 타입
- * @param block Observation 컨텍스트를 받아 실행할 suspend 블록
- * @return 성공 시 블록 결과, 실패 시 예외를 담은 [Result]
+ * @param T result type
+ * @param block suspend block receiving the [Observation.Context]
+ * @return [Result] wrapping the block result or the non-cancellation failure
  */
 suspend inline fun <T: Any> Observation.tryObserveSuspending(
     crossinline block: suspend (Observation.Context) -> T?,
-): Result<T> =
-    runCatching {
-        withObservationContextSuspending { ctx: Observation.Context ->
-            block(ctx)
-        } ?: throw NoSuchElementException()
+): Result<T> {
+    return try {
+        Result.success(
+            withObservationContextSuspending { ctx: Observation.Context ->
+                block(ctx)
+            } ?: throw NoSuchElementException()
+        )
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        Result.failure(e)
     }
+}
 
 /**
  * 이름을 기준으로 새 [Observation]을 만들고 suspend 블록을 실행합니다.
@@ -136,7 +148,12 @@ suspend inline fun <T: Any> withObservationSuspending(
     }
 
 /**
- * [withObservationSuspending] 결과를 [Result] 로 감싸 반환합니다.
+ * Wraps [withObservationSuspending] in a [Result], returning failure for non-cancellation errors.
+ *
+ * ## Behaviour / Contract
+ * - Returns `Result.success(value)` when the block completes normally.
+ * - Returns `Result.failure(exception)` for non-cancellation exceptions.
+ * - Rethrows [CancellationException] so structured cancellation is preserved.
  *
  * ```kotlin
  * val registry = ObservationRegistry.create()
@@ -147,20 +164,27 @@ suspend inline fun <T: Any> withObservationSuspending(
  * // result.getOrNull() == "user-data"
  * ```
  *
- * @param T 결과 타입
- * @param name Observation 이름
- * @param registry Observation 등록 대상 [ObservationRegistry]
- * @param block Observation 이 바인딩된 상태로 실행할 suspend 블록
- * @return 성공 시 블록 결과, 실패 시 예외를 담은 [Result]
+ * @param T result type
+ * @param name observation name
+ * @param registry [ObservationRegistry] to register the observation with
+ * @param block suspend block to execute under the observation
+ * @return [Result] wrapping the block result or the non-cancellation failure
  */
 suspend inline fun <T: Any> tryWithObservationSuspending(
     name: String,
     registry: ObservationRegistry,
     crossinline block: suspend () -> T,
-): Result<T> =
-    runCatching {
-        withObservationSuspending(name, registry, block) ?: throw NoSuchElementException()
+): Result<T> {
+    return try {
+        Result.success(
+            withObservationSuspending(name, registry, block) ?: throw NoSuchElementException()
+        )
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        Result.failure(e)
     }
+}
 
 /**
  * Suspend 함수 실행 시 Micrometer Observation을 이용하여 관찰(Observe)할 수 있도록 합니다.

--- a/infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/observation/coroutines/ObservationCoroutinesSupportTest.kt
+++ b/infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/observation/coroutines/ObservationCoroutinesSupportTest.kt
@@ -9,7 +9,10 @@ import io.bluetape4k.micrometer.observation.AbstractObservationTest
 import io.bluetape4k.micrometer.observation.start
 import io.micrometer.observation.Observation
 import io.micrometer.observation.tck.ObservationRegistryAssert
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
@@ -170,5 +173,58 @@ class ObservationCoroutinesSupportTest: AbstractObservationTest() {
 
         ObservationRegistryAssert.assertThat(observationRegistry)
             .doesNotHaveAnyRemainingCurrentObservation()
+    }
+
+    @Test
+    fun `tryObserveSuspending - cancellation propagates to parent job`() = runTest {
+        val name = Base58.randomString(8)
+        val observation = observationRegistry.start(name)
+
+        var cancelled = false
+        var result: Result<String>? = null
+        val job = launch {
+            try {
+                result = observation.tryObserveSuspending<String> { _ ->
+                    delay(100.milliseconds)  // arbitrary under runTest virtual time
+                    "never"
+                }
+            } catch (e: CancellationException) {
+                cancelled = true
+                throw e
+            }
+        }
+
+        yield()
+        job.cancel()
+        job.join()
+
+        cancelled shouldBeEqualTo true
+        result shouldBeEqualTo null  // wrapper must not return Result.failure; it must rethrow
+    }
+
+    @Test
+    fun `tryWithObservationSuspending - cancellation propagates to parent job`() = runTest {
+        val name = "observer.cancel." + Base58.randomString(8)
+
+        var cancelled = false
+        var result: Result<String>? = null
+        val job = launch {
+            try {
+                result = tryWithObservationSuspending<String>(name, observationRegistry) {
+                    delay(100.milliseconds)  // arbitrary under runTest virtual time
+                    "never"
+                }
+            } catch (e: CancellationException) {
+                cancelled = true
+                throw e
+            }
+        }
+
+        yield()
+        job.cancel()
+        job.join()
+
+        cancelled shouldBeEqualTo true
+        result shouldBeEqualTo null  // wrapper must not return Result.failure; it must rethrow
     }
 }


### PR DESCRIPTION
## Summary

Closes #488

- PR 제목: fix: rethrow CancellationException in tryObserveSuspending and tryWithObservationSuspending

Fixes issue #488: Micrometer suspend `try*` wrappers swallowed coroutine cancellation via `runCatching`.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

Replaced `runCatching` with explicit `try/catch`:

```kotlin
return try {
    Result.success(innerCall() ?: throw NoSuchElementException())
} catch (e: CancellationException) {
    throw e
} catch (e: Throwable) {
    Result.failure(e)
}
```

| File | Change |
|------|--------|
| `infra/micrometer/.../ObservationCoroutinesSupport.kt` | Replace `runCatching` in 2 functions; update KDoc to English |
| `infra/micrometer/.../ObservationCoroutinesSupportTest.kt` | +2 cancellation regression tests |
| `docs/lessons/2026-05-16-micrometer-cancellation-swallow.md` | Lessons document |

### 기존 섹션: Root Cause

`tryObserveSuspending` and `tryWithObservationSuspending` wrapped their body in `runCatching {}`. Because `runCatching` has a blanket `catch (Throwable)`, it caught `CancellationException` and returned `Result.failure(CancellationException)` instead of rethrowing — breaking structured concurrency for callers.

### 기존 섹션: Verification

```bash
./gradlew :bluetape4k-micrometer:test --tests "io.bluetape4k.micrometer.observation.coroutines.ObservationCoroutinesSupportTest"
```

Closes #488

## Validation

```
io.bluetape4k.micrometer.observation.coroutines.ObservationCoroutinesSupportTest ✔ tryObserveSuspending - cancellation propagates to parent job
io.bluetape4k.micrometer.observation.coroutines.ObservationCoroutinesSupportTest ✔ tryWithObservationSuspending - cancellation propagates to parent job
9 passing (2.3s)
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #488, milestone 없음, assignee `debop`
- PR: #502, head `646a71e15322a35616b539a284a1561ec9763fb9`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/micrometer-cancellation-swallow`
- Labels: `bug`
- State: `MERGED`, merge commit `60ad3b2430f8bf94f99f8ed8503786f3525be2fc`
- CI: Replaced `runCatching` with explicit `try/catch`: / ./gradlew :bluetape4k-micrometer:test --tests "io.bluetape4k.micrometer.observation.coroutines.ObservationCoroutinesSupportTest"

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #502 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `60ad3b2430f8bf94f99f8ed8503786f3525be2fc`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
