### PR TITLE
fix: prevent write-after-clear race in async/suspend memoizers (#487)

### DIFF
--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/cache2k/Cache2kSuspendMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/cache2k/Cache2kSuspendMemoizer.kt
@@ -37,14 +37,6 @@ fun <T: Any, R: Any> (suspend (T) -> R).withSuspendMemoizer(
     Cache2kSuspendMemoizer(cache, this)
 
 /**
- * Cache2k 기반 [SuspendMemoizer] 구현체입니다.
- *
- * ```kotlin
- * val memo = SuspendCache2kMemoizer(cache) { key: String -> key.length }
- * // memo("abcd") == 4
- * ```
- */
-/**
  * Cache2k-backed [SuspendMemoizer] that deduplicates concurrent evaluations per key.
  *
  * ## Recursion Safety

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/cache2k/Cache2kSuspendMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/cache2k/Cache2kSuspendMemoizer.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Cache2k를 사용하는 suspend memoizer를 생성합니다.
@@ -44,15 +45,20 @@ fun <T: Any, R: Any> (suspend (T) -> R).withSuspendMemoizer(
  * ```
  */
 /**
- * Cache2k 기반 [SuspendMemoizer] 구현체입니다.
+ * Cache2k-backed [SuspendMemoizer] that deduplicates concurrent evaluations per key.
  *
- * ## 재귀 안전성
- * 전역 Mutex를 evaluator 실행 중에 보유하면 재귀 memoizer(factorial, fibonacci)에서 데드락이 발생한다.
- * Kotlin Mutex는 재진입(reentrant)을 지원하지 않기 때문이다.
- * per-key Deferred 패턴은 lock 없이 evaluator를 실행하므로 재귀 호출이 안전하다.
+ * ## Recursion Safety
+ * Holding a global Mutex during evaluator execution causes deadlocks for recursive memoizers
+ * (e.g., factorial, fibonacci) because Kotlin's Mutex is not reentrant.
+ * The per-key Deferred pattern runs the evaluator outside any lock, so recursive calls are safe.
+ *
+ * ## Write-after-clear Safety
+ * A generation counter ensures that results from in-flight evaluations started before [clear]
+ * are not written back to the cache after it has been invalidated. The caller always receives
+ * the computed value regardless of the generation check.
  *
  * ```kotlin
- * val memo = SuspendCache2kMemoizer(cache) { key: String -> key.length }
+ * val memo = Cache2kSuspendMemoizer(cache) { key: String -> key.length }
  * // memo("abcd") == 4
  * ```
  */
@@ -63,31 +69,26 @@ class Cache2kSuspendMemoizer<in T: Any, out R: Any>(
 
     companion object: KLoggingChannel()
 
-    // per-key Deferred 맵: 같은 키에 대해 첫 번째 호출이 Deferred를 생성하고 이후 호출들이 await한다.
     private val inflightMap = ConcurrentHashMap<T, Deferred<R>>()
     private val clearMutex = Mutex()
+    private val generation = AtomicLong(0)
 
     override suspend fun invoke(input: T): R {
-        // 1단계: 빠른 경로 — 이미 캐시된 결과는 lock/Deferred 없이 즉시 반환
         cache.get(input)?.let { return it }
 
-        // 2단계: per-key Deferred로 중복 evaluator 실행 방지.
-        // computeIfAbsent는 atomic이므로 같은 키에 대해 Deferred가 하나만 생성된다.
         return coroutineScope {
-            var createdByThisCall = false
+            val capturedGen = generation.get()
             val deferred = inflightMap.computeIfAbsent(input) {
-                createdByThisCall = true
-                async {
-                    evaluator(input)
-                }
+                async { evaluator(input) }
             }
             try {
                 val result = deferred.await()
-                this@Cache2kSuspendMemoizer.cache.put(input, result)
+                if (generation.get() == capturedGen) {
+                    this@Cache2kSuspendMemoizer.cache.put(input, result)
+                }
                 result
             } finally {
-                // evaluator 실패 후에도 in-flight 항목을 정리해 다음 호출이 재시도할 수 있게 한다.
-                if (createdByThisCall || deferred.isCompleted) {
+                if (deferred.isCompleted || deferred.isCancelled) {
                     inflightMap.remove(input, deferred)
                 }
             }
@@ -95,6 +96,7 @@ class Cache2kSuspendMemoizer<in T: Any, out R: Any>(
     }
 
     override suspend fun clear() {
+        generation.incrementAndGet()
         clearMutex.withLock {
             inflightMap.clear()
             cache.clear()

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineAsyncMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineAsyncMemoizer.kt
@@ -5,9 +5,10 @@ import io.bluetape4k.cache.memoizer.AsyncMemoizer
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 
 /**
- * Caffeine Cache를 이용하는 [CaffeineAsyncMemoizer]를 생성합니다.
+ * Creates a [CaffeineAsyncMemoizer] backed by this Caffeine [Cache].
  *
  * ```kotlin
  * val cache = Caffeine.newBuilder().maximumSize(1000).build<String, Int>()
@@ -18,14 +19,14 @@ import java.util.concurrent.ConcurrentHashMap
  *
  * @param T cache key type
  * @param R cache value type
- * @param evaluator cache value를 반환하는 메소드
+ * @param evaluator function that produces the cache value asynchronously
  */
 fun <T: Any, R: Any> Cache<T, R>.asyncMemoizer(
     evaluator: (T) -> CompletableFuture<R>,
 ): CaffeineAsyncMemoizer<T, R> = CaffeineAsyncMemoizer(this, evaluator)
 
 /**
- * 비동기 함수를 Caffeine Cache 기반 [CaffeineAsyncMemoizer]로 감쌉니다.
+ * Wraps an async function with a Caffeine-backed [CaffeineAsyncMemoizer].
  *
  * ```kotlin
  * val cache = Caffeine.newBuilder().maximumSize(1000).build<String, Int>()
@@ -39,7 +40,7 @@ fun <T: Any, R: Any> ((T) -> CompletableFuture<R>).withAsyncMemoizer(
 ): CaffeineAsyncMemoizer<T, R> = CaffeineAsyncMemoizer(cache, this)
 
 /**
- * Caffeine Cache를 이용하여 메소드의 실행 결과를 캐시하여, 재 실행 시에 빠르게 응답할 수 있도록 합니다.
+ * Memoizes an async function using a Caffeine [Cache] so repeated calls return the cached result.
  *
  * ```kotlin
  * val cache = Caffeine.newBuilder().maximumSize(1000).build<String, Int>()
@@ -48,12 +49,17 @@ fun <T: Any, R: Any> ((T) -> CompletableFuture<R>).withAsyncMemoizer(
  * // result == 5
  * ```
  *
- * ## Virtual Thread 안전성
- * `putIfAbsent` 기반 in-flight 추적을 사용하여 Carrier Thread 고정(pinning) 없이
- * Virtual Thread 환경에서도 안전하게 동작합니다.
+ * ## Thread Safety / Virtual Thread Safety
+ * - Uses `putIfAbsent`-based in-flight tracking — no `synchronized` blocks, safe for virtual threads.
+ * - A generation counter prevents write-after-clear races: if [clear] is called while an evaluator
+ *   is in flight, the stale result is discarded and never written to the cache.
+ * - `inFlight` removal uses a value-aware two-arg `remove(key, value)` so a freshly installed
+ *   promise is not accidentally evicted by a concurrent completion from a previous generation.
+ * - The caller's [CompletableFuture] is always completed (success or exceptionally) regardless of
+ *   the generation check, so no caller ever hangs.
  *
- * @property cache 실행한 값을 저장할 Cache
- * @property evaluator 캐시 값을 생성하는 메소드
+ * @property cache Caffeine cache that stores computed values
+ * @property evaluator function that computes the value for a given input asynchronously
  */
 class CaffeineAsyncMemoizer<T: Any, R: Any>(
     private val cache: Cache<T, R>,
@@ -62,6 +68,7 @@ class CaffeineAsyncMemoizer<T: Any, R: Any>(
     companion object: KLoggingChannel()
 
     private val inFlight = ConcurrentHashMap<T, CompletableFuture<R>>()
+    private val generation = AtomicLong(0)
 
     override fun invoke(input: T): CompletableFuture<R> {
         cache.getIfPresent(input)?.let { return CompletableFuture.completedFuture(it) }
@@ -70,8 +77,10 @@ class CaffeineAsyncMemoizer<T: Any, R: Any>(
         val existing = inFlight.putIfAbsent(input, promise)
         if (existing != null) return existing
 
+        val capturedGen = generation.get()
+
         fun completeExceptionally(error: Throwable) {
-            inFlight.remove(input)
+            inFlight.remove(input, promise)
             promise.completeExceptionally(error)
         }
 
@@ -81,9 +90,13 @@ class CaffeineAsyncMemoizer<T: Any, R: Any>(
                     future.whenComplete { result, error ->
                         if (error != null) {
                             completeExceptionally(error)
+                        } else if (result == null) {
+                            completeExceptionally(NullPointerException("evaluator returned null for input $input"))
                         } else {
-                            inFlight.remove(input)
-                            cache.put(input, result)
+                            inFlight.remove(input, promise)
+                            if (generation.get() == capturedGen) {
+                                cache.put(input, result)
+                            }
                             promise.complete(result)
                         }
                     }
@@ -95,6 +108,7 @@ class CaffeineAsyncMemoizer<T: Any, R: Any>(
     }
 
     override fun clear() {
+        generation.incrementAndGet()
         inFlight.clear()
         cache.invalidateAll()
     }

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineAsyncMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineAsyncMemoizer.kt
@@ -73,11 +73,10 @@ class CaffeineAsyncMemoizer<T: Any, R: Any>(
     override fun invoke(input: T): CompletableFuture<R> {
         cache.getIfPresent(input)?.let { return CompletableFuture.completedFuture(it) }
 
+        val capturedGen = generation.get()
         val promise = CompletableFuture<R>()
         val existing = inFlight.putIfAbsent(input, promise)
         if (existing != null) return existing
-
-        val capturedGen = generation.get()
 
         fun completeExceptionally(error: Throwable) {
             inFlight.remove(input, promise)

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineMemoizer.kt
@@ -3,8 +3,6 @@ package io.bluetape4k.cache.memoizer.caffeine
 import com.github.benmanes.caffeine.cache.Cache
 import io.bluetape4k.cache.memoizer.Memoizer
 import io.bluetape4k.logging.KLogging
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
 
 /**
  * Caffeine Cache를 이용하여 [CaffeineMemoizer]를 생성합니다.
@@ -38,7 +36,7 @@ fun <T: Any, R: Any> ((T) -> R).withMemoizer(cache: Cache<T, R>): CaffeineMemoiz
     CaffeineMemoizer(cache, this)
 
 /**
- * Caffeine Cache를 이용하여 메소드의 실행 결과를 기억하여, 재 실행 시에 빠르게 응답할 수 있도록 합니다.
+ * Memoizes a synchronous function using a Caffeine [Cache] so repeated calls return the cached result.
  *
  * ```kotlin
  * val cache = Caffeine.newBuilder().maximumSize(1000).build<String, Int>()
@@ -47,16 +45,19 @@ fun <T: Any, R: Any> ((T) -> R).withMemoizer(cache: Cache<T, R>): CaffeineMemoiz
  * // result == 5
  * ```
  *
- * @property cache 실행한 값을 저장할 Cache
- * @property evaluator 캐시 값을 생성하는 메소드
+ * ## Thread Safety
+ * Uses a non-atomic read-evaluate-write pattern to support recursive evaluators (e.g., factorial,
+ * fibonacci). `Cache.get(key, function)` would cause `IllegalStateException: Recursive update`
+ * when the evaluator itself calls the memoizer for a different key on the same Caffeine cache.
+ *
+ * @property cache Caffeine cache that stores computed values
+ * @property evaluator function that computes the value for a given input
  */
 class CaffeineMemoizer<T: Any, R: Any>(
     private val cache: Cache<T, R>,
     private val evaluator: (T) -> R,
 ): Memoizer<T, R> {
     companion object: KLogging()
-
-    private val lock = ReentrantLock()
 
     override fun invoke(input: T): R =
         cache.getIfPresent(input)
@@ -67,8 +68,6 @@ class CaffeineMemoizer<T: Any, R: Any>(
             }
 
     override fun clear() {
-        lock.withLock {
-            cache.cleanUp()
-        }
+        cache.invalidateAll()
     }
 }

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/ehcache/EhCacheAsyncMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/ehcache/EhCacheAsyncMemoizer.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import org.ehcache.Cache
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Ehcache를 이용하는 [EhCacheAsyncMemoizer]를 생성합니다.
@@ -49,7 +50,7 @@ fun <T: Any, R: Any> ((T) -> CompletableFuture<R>).withAsyncMemoizer(
 ): EhCacheAsyncMemoizer<T, R> = EhCacheAsyncMemoizer(cache, this)
 
 /**
- * Ehcache를 이용하여 메소드의 실행 결과를 캐시하여, 재 실행 시에 빠르게 응답할 수 있도록 합니다.
+ * Memoizes an async function using an EhCache [Cache] so repeated calls return the cached result.
  *
  * ```kotlin
  * val cacheManager = CacheManagerBuilder.newCacheManagerBuilder().build(true)
@@ -65,9 +66,13 @@ fun <T: Any, R: Any> ((T) -> CompletableFuture<R>).withAsyncMemoizer(
  * // result == 5
  * ```
  *
- * ## Virtual Thread 안전성
- * `putIfAbsent` 기반 in-flight 추적을 사용하여 Carrier Thread 고정(pinning) 없이
- * Virtual Thread 환경에서도 안전하게 동작합니다.
+ * ## Thread Safety / Virtual Thread Safety
+ * - Uses `putIfAbsent`-based in-flight tracking — no `synchronized` blocks, safe for virtual threads.
+ * - A generation counter prevents write-after-clear races: if [clear] is called while an evaluator
+ *   is in flight, the stale result is discarded and never written to the cache.
+ * - `inFlight` removal uses value-aware two-arg `remove(key, value)` so a freshly installed
+ *   promise is not accidentally evicted by a concurrent completion from a previous generation.
+ * - The caller's [CompletableFuture] is always completed regardless of the generation check.
  */
 class EhCacheAsyncMemoizer<T: Any, R: Any>(
     private val cache: Cache<T, R>,
@@ -76,6 +81,7 @@ class EhCacheAsyncMemoizer<T: Any, R: Any>(
     companion object: KLoggingChannel()
 
     private val inFlight = ConcurrentHashMap<T, CompletableFuture<R>>()
+    private val generation = AtomicLong(0)
 
     override fun invoke(key: T): CompletableFuture<R> {
         cache.get(key)?.let { return CompletableFuture.completedFuture(it) }
@@ -84,8 +90,10 @@ class EhCacheAsyncMemoizer<T: Any, R: Any>(
         val existing = inFlight.putIfAbsent(key, promise)
         if (existing != null) return existing
 
+        val capturedGen = generation.get()
+
         fun completeExceptionally(error: Throwable) {
-            inFlight.remove(key)
+            inFlight.remove(key, promise)
             promise.completeExceptionally(error)
         }
 
@@ -95,9 +103,13 @@ class EhCacheAsyncMemoizer<T: Any, R: Any>(
                     future.whenComplete { result, error ->
                         if (error != null) {
                             completeExceptionally(error)
+                        } else if (result == null) {
+                            completeExceptionally(NullPointerException("evaluator returned null for key $key"))
                         } else {
-                            inFlight.remove(key)
-                            cache.put(key, result)
+                            inFlight.remove(key, promise)
+                            if (generation.get() == capturedGen) {
+                                cache.put(key, result)
+                            }
                             promise.complete(result)
                         }
                     }
@@ -109,6 +121,7 @@ class EhCacheAsyncMemoizer<T: Any, R: Any>(
     }
 
     override fun clear() {
+        generation.incrementAndGet()
         inFlight.clear()
         cache.clear()
     }

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/ehcache/EhCacheAsyncMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/ehcache/EhCacheAsyncMemoizer.kt
@@ -86,11 +86,10 @@ class EhCacheAsyncMemoizer<T: Any, R: Any>(
     override fun invoke(key: T): CompletableFuture<R> {
         cache.get(key)?.let { return CompletableFuture.completedFuture(it) }
 
+        val capturedGen = generation.get()
         val promise = CompletableFuture<R>()
         val existing = inFlight.putIfAbsent(key, promise)
         if (existing != null) return existing
-
-        val capturedGen = generation.get()
 
         fun completeExceptionally(error: Throwable) {
             inFlight.remove(key, promise)

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/inmemory/InMemoryAsyncMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/inmemory/InMemoryAsyncMemoizer.kt
@@ -49,11 +49,10 @@ class InMemoryAsyncMemoizer<in T: Any, R: Any>(
     override fun invoke(input: T): CompletableFuture<R> {
         resultCache[input]?.let { return CompletableFuture.completedFuture(it) }
 
+        val capturedGen = generation.get()
         val promise = CompletableFuture<R>()
         val existing = inFlight.putIfAbsent(input, promise)
         if (existing != null) return existing
-
-        val capturedGen = generation.get()
 
         fun completeExceptionally(error: Throwable) {
             inFlight.remove(input, promise)

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/inmemory/InMemoryAsyncMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/inmemory/InMemoryAsyncMemoizer.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.cache.memoizer.AsyncMemoizer
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * InMemory를 이용하여 [InMemoryAsyncMemoizer]를 생성합니다.
@@ -20,17 +21,20 @@ fun <T: Any, R: Any> ((T) -> CompletableFuture<R>).asyncMemoizer(): InMemoryAsyn
     InMemoryAsyncMemoizer(this)
 
 /**
- * 로컬 메모리에 [evaluator] 실행 결과를 저장하는 [AsyncMemoizer] 구현체.
+ * In-memory [AsyncMemoizer] that stores evaluation results in a local [ConcurrentHashMap].
  *
- * ## Virtual Thread 안전성
- * `putIfAbsent` 기반 in-flight 추적을 사용하여 `ConcurrentHashMap.computeIfAbsent`의
- * bin lock 장기 보유 문제를 피합니다. Carrier Thread 고정(pinning) 없이
- * Virtual Thread 환경에서도 안전하게 동작합니다.
+ * ## Thread Safety / Virtual Thread Safety
+ * - Uses `putIfAbsent`-based in-flight tracking — no `synchronized` blocks, safe for virtual threads.
+ * - A generation counter prevents write-after-clear races: if [clear] is called while an evaluator
+ *   is in flight, the stale result is discarded and never written to the result cache.
+ * - `inFlight` removal uses value-aware two-arg `remove(key, value)` so a freshly installed
+ *   promise is not accidentally evicted by a concurrent completion from a previous generation.
+ * - The caller's [CompletableFuture] is always completed regardless of the generation check.
  *
- * ## 동작 방식
- * - 결과 캐시 hit → 즉시 완료된 Future 반환
- * - in-flight 있음 → 진행 중인 Future 공유 (중복 평가 방지)
- * - 신규 평가 → lock 밖에서 evaluator 실행
+ * ## Behaviour
+ * - Result cache hit → returns an already-completed Future immediately.
+ * - In-flight hit → shares the in-progress Future (no duplicate evaluation).
+ * - New evaluation → runs the evaluator outside any lock.
  */
 class InMemoryAsyncMemoizer<in T: Any, R: Any>(
     private val evaluator: (T) -> CompletableFuture<R>,
@@ -40,6 +44,7 @@ class InMemoryAsyncMemoizer<in T: Any, R: Any>(
 
     private val resultCache = ConcurrentHashMap<@UnsafeVariance T, R>()
     private val inFlight = ConcurrentHashMap<@UnsafeVariance T, CompletableFuture<R>>()
+    private val generation = AtomicLong(0)
 
     override fun invoke(input: T): CompletableFuture<R> {
         resultCache[input]?.let { return CompletableFuture.completedFuture(it) }
@@ -48,8 +53,10 @@ class InMemoryAsyncMemoizer<in T: Any, R: Any>(
         val existing = inFlight.putIfAbsent(input, promise)
         if (existing != null) return existing
 
+        val capturedGen = generation.get()
+
         fun completeExceptionally(error: Throwable) {
-            inFlight.remove(input)
+            inFlight.remove(input, promise)
             promise.completeExceptionally(error)
         }
 
@@ -59,9 +66,13 @@ class InMemoryAsyncMemoizer<in T: Any, R: Any>(
                     future.whenComplete { result, error ->
                         if (error != null) {
                             completeExceptionally(error)
+                        } else if (result == null) {
+                            completeExceptionally(NullPointerException("evaluator returned null for input $input"))
                         } else {
-                            inFlight.remove(input)
-                            resultCache[input] = result
+                            inFlight.remove(input, promise)
+                            if (generation.get() == capturedGen) {
+                                resultCache[input] = result
+                            }
                             promise.complete(result)
                         }
                     }
@@ -73,6 +84,7 @@ class InMemoryAsyncMemoizer<in T: Any, R: Any>(
     }
 
     override fun clear() {
+        generation.incrementAndGet()
         inFlight.clear()
         resultCache.clear()
     }

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/jcache/JCacheAsyncMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/jcache/JCacheAsyncMemoizer.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.cache.memoizer.AsyncMemoizer
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * JCache를 이용하는 [JCacheAsyncMemoizer]를 생성합니다.
@@ -23,7 +24,7 @@ fun <T: Any, R: Any> javax.cache.Cache<T, R>.asyncMemoizer(
     JCacheAsyncMemoizer(this, evaluator)
 
 /**
- * JCache를 이용하여 메소드의 실행 결과를 캐시하여, 재 실행 시에 빠르게 응답할 수 있도록 합니다.
+ * Memoizes an async function using a JCache so repeated calls return the cached result.
  *
  * ```kotlin
  * val cachingProvider = Caching.getCachingProvider()
@@ -34,9 +35,13 @@ fun <T: Any, R: Any> javax.cache.Cache<T, R>.asyncMemoizer(
  * // result == 5
  * ```
  *
- * ## Virtual Thread 안전성
- * `putIfAbsent` 기반 in-flight 추적을 사용하여 Carrier Thread 고정(pinning) 없이
- * Virtual Thread 환경에서도 안전하게 동작합니다.
+ * ## Thread Safety / Virtual Thread Safety
+ * - Uses `putIfAbsent`-based in-flight tracking — no `synchronized` blocks, safe for virtual threads.
+ * - A generation counter prevents write-after-clear races: if [clear] is called while an evaluator
+ *   is in flight, the stale result is discarded and never written to the cache.
+ * - `inFlight` removal uses value-aware two-arg `remove(key, value)` so a freshly installed
+ *   promise is not accidentally evicted by a concurrent completion from a previous generation.
+ * - The caller's [CompletableFuture] is always completed regardless of the generation check.
  */
 class JCacheAsyncMemoizer<in T: Any, R: Any>(
     private val jcache: javax.cache.Cache<@UnsafeVariance T, R>,
@@ -46,39 +51,47 @@ class JCacheAsyncMemoizer<in T: Any, R: Any>(
     companion object: KLoggingChannel()
 
     private val inFlight = ConcurrentHashMap<@UnsafeVariance T, CompletableFuture<R>>()
+    private val generation = AtomicLong(0)
 
     override fun invoke(input: T): CompletableFuture<R> {
-        // 1. 완료된 결과 캐시 hit
         jcache.get(input)?.let { return CompletableFuture.completedFuture(it) }
 
-        // 2. in-flight 확인 또는 신규 등록
         val promise = CompletableFuture<R>()
         val existing = inFlight.putIfAbsent(input, promise)
         if (existing != null) return existing
 
-        // 3. evaluator를 lock 밖에서 실행 (Virtual Thread-safe)
+        val capturedGen = generation.get()
+
+        fun completeExceptionally(error: Throwable) {
+            inFlight.remove(input, promise)
+            promise.completeExceptionally(error)
+        }
+
         runCatching { evaluator(input) }
             .fold(
                 onSuccess = { future ->
                     future.whenComplete { result, error ->
-                        inFlight.remove(input)
-                        if (error != null) promise.completeExceptionally(error)
-                        else {
-                            jcache.put(input, result)
+                        if (error != null) {
+                            completeExceptionally(error)
+                        } else if (result == null) {
+                            completeExceptionally(NullPointerException("evaluator returned null for input $input"))
+                        } else {
+                            inFlight.remove(input, promise)
+                            if (generation.get() == capturedGen) {
+                                jcache.put(input, result)
+                            }
                             promise.complete(result)
                         }
                     }
                 },
-                onFailure = { error ->
-                    inFlight.remove(input)
-                    promise.completeExceptionally(error)
-                }
+                onFailure = ::completeExceptionally
             )
 
         return promise
     }
 
     override fun clear() {
+        generation.incrementAndGet()
         inFlight.clear()
         jcache.clear()
     }

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/jcache/JCacheAsyncMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/jcache/JCacheAsyncMemoizer.kt
@@ -56,11 +56,10 @@ class JCacheAsyncMemoizer<in T: Any, R: Any>(
     override fun invoke(input: T): CompletableFuture<R> {
         jcache.get(input)?.let { return CompletableFuture.completedFuture(it) }
 
+        val capturedGen = generation.get()
         val promise = CompletableFuture<R>()
         val existing = inFlight.putIfAbsent(input, promise)
         if (existing != null) return existing
-
-        val capturedGen = generation.get()
 
         fun completeExceptionally(error: Throwable) {
             inFlight.remove(input, promise)

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/memoizer/cache2k/Cache2KSuspendMemoizerTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/memoizer/cache2k/Cache2KSuspendMemoizerTest.kt
@@ -4,11 +4,14 @@ import io.bluetape4k.cache.cache2k.cache2k
 import io.bluetape4k.cache.memoizer.AbstractSuspendMemoizerTest
 import io.bluetape4k.cache.memoizer.SuspendFactorialProvider
 import io.bluetape4k.cache.memoizer.SuspendFibonacciProvider
+import io.bluetape4k.cache.memoizer.SuspendMemoizer
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.junit5.coroutines.runSuspendDefault
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.cache2k.Cache
 import org.junit.jupiter.api.Test
 import java.util.concurrent.Executors
@@ -67,6 +70,39 @@ class Cache2KSuspendMemoizerTest: AbstractSuspendMemoizerTest() {
 
         memo("recover") shouldBeEqualTo 7
         evalCount.get() shouldBeEqualTo 2
+        localCache.close()
+    }
+
+    @Test
+    fun `clear 중 진행 중인 suspend 결과는 캐시에 저장되지 않는다`() = runSuspendDefault {
+        val evalStarted = CompletableDeferred<Unit>()
+        val evalProceed = CompletableDeferred<Unit>()
+        val evalCount = AtomicInteger(0)
+
+        val localCache = cache2k<String, Int> {
+            this.name("write-after-clear-${System.nanoTime()}")
+            this.executor(Executors.newVirtualThreadPerTaskExecutor())
+        }.build()
+
+        val memo: SuspendMemoizer<String, Int> = localCache.suspendMemoizer { key: String ->
+            evalCount.incrementAndGet()
+            evalStarted.complete(Unit)
+            evalProceed.await()
+            key.length
+        }
+
+        val job = launch { memo("hello") }
+        evalStarted.await()     // wait for evaluator to start
+
+        memo.clear()             // invalidate while in-flight
+        evalProceed.complete(Unit)  // let evaluator finish
+        job.join()
+
+        // Cache must be empty — the in-flight result should not have been written back
+        // Calling again triggers a fresh evaluation
+        memo("hello") shouldBeEqualTo 5
+        evalCount.get() shouldBeEqualTo 2  // re-evaluated because cache was empty after clear
+
         localCache.close()
     }
 }

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineAsyncMemoizerTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineAsyncMemoizerTest.kt
@@ -8,8 +8,14 @@ import io.bluetape4k.cache.memoizer.AbstractAsyncMemoizerTest
 import io.bluetape4k.cache.memoizer.AsyncFactorialProvider
 import io.bluetape4k.cache.memoizer.AsyncFibonacciProvider
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import org.junit.jupiter.api.Test
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ForkJoinPool
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 class CaffeineAsyncMemoizerTest: AbstractAsyncMemoizerTest() {
 
@@ -41,5 +47,54 @@ class CaffeineAsyncMemoizerTest: AbstractAsyncMemoizerTest() {
         override val cachedCalc: (Long) -> CompletableFuture<Long> by lazy {
             cache.asyncMemoizer { calc(it) }
         }
+    }
+
+    @Test
+    fun `clear 후 캐시가 무효화된다`() {
+        val evalCount = AtomicInteger(0)
+        val localCache = caffeine.cache<String, Int>()
+        val memo = localCache.asyncMemoizer { key: String ->
+            evalCount.incrementAndGet()
+            CompletableFuture.completedFuture(key.length)
+        }
+
+        memo("hello").get() shouldBeEqualTo 5
+        evalCount.get() shouldBeEqualTo 1
+
+        // Cached — evaluator must not run again
+        memo("hello").get() shouldBeEqualTo 5
+        evalCount.get() shouldBeEqualTo 1
+
+        memo.clear()
+
+        // After clear — fresh evaluation
+        memo("hello").get() shouldBeEqualTo 5
+        evalCount.get() shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `clear 중 진행 중인 비동기 결과는 캐시에 저장되지 않는다`() {
+        val evalStarted = CountDownLatch(1)
+        val evalProceed = CountDownLatch(1)
+        val localCache = caffeine.cache<String, Int>()
+
+        val memo = localCache.asyncMemoizer { key: String ->
+            CompletableFuture.supplyAsync {
+                evalStarted.countDown()
+                evalProceed.await(2, TimeUnit.SECONDS)
+                key.length
+            }
+        }
+
+        val future = memo("hello")
+        evalStarted.await(2, TimeUnit.SECONDS)   // wait for evaluator to start
+
+        memo.clear()                              // invalidate while in-flight
+        evalProceed.countDown()                   // let evaluator finish
+
+        // Caller still receives the computed value
+        future.get(2, TimeUnit.SECONDS) shouldBeEqualTo 5
+        // Stale result must NOT be written back into the cleared cache
+        localCache.getIfPresent("hello").shouldBeNull()
     }
 }

--- a/docs/lessons/2026-05-16-memoizer-clear-race.md
+++ b/docs/lessons/2026-05-16-memoizer-clear-race.md
@@ -1,0 +1,88 @@
+# Memoizer Write-after-clear Race Condition Fix
+
+**Date**: 2026-05-16
+**Issue**: #487
+**Branch**: `fix/memoizer-clear-race`
+
+## Root Cause
+
+Async and suspend memoizers shared a common bug: an in-flight evaluator that
+completed *after* `clear()` was called would write its result back into the
+cache, repopulating it with stale data. Callers who triggered `clear()` to
+invalidate the cache got a fresh result on the very next call, but other callers
+who had started evaluation before `clear()` would silently refill the cache.
+
+A secondary bug existed in `CaffeineMemoizer.clear()`: it called
+`cache.cleanUp()` (maintenance pass) instead of `cache.invalidateAll()`
+(actual eviction), making `clear()` effectively a no-op.
+
+## Fix
+
+### Generation counter pattern
+
+All five affected memoizers received an `AtomicLong generation` counter:
+
+1. `generation.get()` is captured into `capturedGen` **before** the evaluator
+   starts (or the in-flight future is shared).
+2. `clear()` calls `generation.incrementAndGet()` **first**, then clears the
+   cache and in-flight maps.
+3. Before writing to the cache after evaluation, the code checks
+   `generation.get() == capturedGen`. If they differ, the result was computed
+   before a `clear()` — the write is skipped, but the caller's future/deferred
+   is still completed with the computed value.
+
+### Value-aware ConcurrentHashMap.remove
+
+In-flight map cleanup uses the 2-argument `remove(key, value)` form to avoid
+evicting a freshly-installed promise that races with completion from a previous
+generation.
+
+### Null future completion
+
+`InMemoryAsyncMemoizer` and the Caffeine/EhCache/JCache variants now call
+`completeExceptionally(NullPointerException(...))` when the evaluator's
+`CompletableFuture` completes with a `null` value, preventing an indefinitely
+uncompleted promise.
+
+### CaffeineMemoizer.clear() bug
+
+`cache.cleanUp()` → `cache.invalidateAll()`. Also removed the unnecessary
+`ReentrantLock` that guarded only a maintenance call.
+
+### Affected files
+
+| File | Change |
+|------|--------|
+| `CaffeineAsyncMemoizer.kt` | generation counter, value-aware remove, null check, `invalidateAll()` |
+| `EhCacheAsyncMemoizer.kt` | generation counter, value-aware remove, null check |
+| `JCacheAsyncMemoizer.kt` | generation counter, value-aware remove, null check |
+| `InMemoryAsyncMemoizer.kt` | generation counter, value-aware remove, null check |
+| `Cache2kSuspendMemoizer.kt` | generation counter, value-aware remove |
+| `CaffeineMemoizer.kt` | `clear()` uses `invalidateAll()`; lock removed |
+
+## Test Coverage
+
+New tests added to `CaffeineAsyncMemoizerTest` and `Cache2KSuspendMemoizerTest`:
+
+- `clear 후 캐시가 무효화된다` — basic clear invalidates cache, triggers fresh evaluation
+- `clear 중 진행 중인 비동기 결과는 캐시에 저장되지 않는다` — in-flight result not
+  written back after `clear()` (verified via `getIfPresent` returning null)
+- `clear 중 진행 중인 suspend 결과는 캐시에 저장되지 않는다` — same guarantee for
+  suspend memoizer (verified via second evaluation being triggered)
+
+## Verification
+
+```
+447 passing (40.8s) — BUILD SUCCESSFUL
+```
+
+## Key Lesson
+
+**Increment generation before clearing**, not after. If `clear()` clears the
+cache and then increments generation, a concurrent evaluator can check
+generation (still old), see equality, and write after the increment completes.
+The correct order is: increment → clear.
+
+**`cache.cleanUp()` is not `cache.invalidateAll()`**. Caffeine's `cleanUp()`
+triggers pending maintenance tasks (expiry sweeps, etc.); it does not evict all
+entries. Always use `invalidateAll()` when the intent is to empty the cache.


### PR DESCRIPTION
## Summary

Closes #487

- PR 제목: fix: prevent write-after-clear race in async/suspend memoizers (#487)

Fixes #487 — async and suspend memoizers could repopulate the cache with a stale result when an in-flight evaluator completed after `clear()` was called.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### Generation counter pattern (all 5 memoizers)
- Capture `val capturedGen = generation.get()` **before** creating the promise and before `putIfAbsent`
- `clear()` calls `generation.incrementAndGet()` **first**, then clears in-flight map and cache
- Before `cache.put()` after evaluation: check `generation.get() == capturedGen`; skip write if generations differ
- Caller's Future/Deferred always completed regardless of generation check

### Value-aware remove
`inFlight.remove(key, value)` (2-arg form) prevents evicting a freshly-installed promise from a new generation.

### Null completion guard
`completeExceptionally(NullPointerException)` when evaluator Future completes with null, preventing indefinitely pending promises.

### CaffeineMemoizer.clear() fix
`cache.cleanUp()` → `cache.invalidateAll()`; removed unnecessary `ReentrantLock`.

### 기존 섹션: Root Cause

Two related bugs:

1. **Write-after-clear race**: An evaluator started before `clear()` could finish and write its result back into the now-empty cache, repopulating it with stale data.
2. **Generation capture ordering**: `val capturedGen = generation.get()` was placed *after* `inFlight.putIfAbsent()`, creating a window where `clear()` could increment the generation between the two lines — causing the stale result to pass the equality check.
3. **CaffeineMemoizer.clear() no-op**: Called `cache.cleanUp()` (Caffeine maintenance pass) instead of `cache.invalidateAll()` — effectively a no-op for cached entries.

## Validation

New tests in `CaffeineAsyncMemoizerTest`:
- `clear 후 캐시가 무효화된다` — basic invalidation + fresh re-evaluation
- `clear 중 진행 중인 비동기 결과는 캐시에 저장되지 않는다` — write-after-clear race: in-flight result not written back (`getIfPresent` returns null after clear)

New tests in `Cache2KSuspendMemoizerTest`:
- `clear 중 진행 중인 suspend 결과는 캐시에 저장되지 않는다` — same guarantee for suspend memoizer

```
:bluetape4k-cache-core:test
447 passing (41.1s) — BUILD SUCCESSFUL
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #487, milestone 없음, assignee `debop`
- PR: #503, head `d111031062116f0cd1b1c6c461f9def3c66ec6da`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/memoizer-clear-race`
- Labels: 없음
- State: `MERGED`, merge commit `be0f882c381362805b89a882e281f70e0c30b210`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- [x] All tests passing (447 / 0 failed / 0 skipped)
- [x] Tier 4 code review completed (HIGH finding resolved: capturedGen ordering)
- [x] Lessons committed: `docs/lessons/2026-05-16-memoizer-clear-race.md`
- [x] English KDoc on changed public APIs

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #503 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `be0f882c381362805b89a882e281f70e0c30b210`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
