### PR TITLE
fix: LettuceSuspendedLoadedMap write-behind retry silently drops entries (#486)

### DIFF
--- a/docs/lessons/2026-05-16-lettuce-write-behind-drop.md
+++ b/docs/lessons/2026-05-16-lettuce-write-behind-drop.md
@@ -1,0 +1,104 @@
+# LettuceSuspendedLoadedMap Write-Behind Drop Fix
+
+**Date**: 2026-05-16
+**Issue**: #486
+**Branch**: `fix/lettuce-write-behind-drop`
+
+## Root Cause
+
+Two silent failure paths in `LettuceSuspendedLoadedMap`:
+
+### 1. trySend result ignored on retry
+
+When `flushBatch()` encountered a writer failure and the retry count was below
+`MAX_DEAD_LETTER_RETRY`, it attempted to requeue each entry via:
+
+```kotlin
+writeBehindChannel?.trySend(Triple(k, v, retryCount))
+```
+
+The `ChannelResult` returned by `trySend` was silently discarded. If the channel
+was full or closed at that moment (e.g., another burst of writes had filled it,
+or `close()` had been called), the entry was simply dropped with no log and no
+dead-letter record.
+
+### 2. close() cancelled the caller's CoroutineScope
+
+`close()` ended with `scope.cancel()`. When the caller passed a shared scope
+(a common pattern for application-wide coroutine supervisors), all coroutines
+running in that scope were cancelled — not just the write-behind consumer job.
+
+## Fix
+
+### trySend result check
+
+Extracted a `writeToDeadLetter(batch: Map<K, V>)` helper. The retry branch
+now checks the `ChannelResult`:
+
+```kotlin
+val dropped = mutableMapOf<K, V>()
+entries.forEach { (k, v, _) ->
+    val result = writeBehindChannel?.trySend(Triple(k, v, retryCount))
+    if (result == null || result.isFailure) {
+        log.warn { "Requeue failed for key=$k (attempt $retryCount): channel full or closed" }
+        dropped[k] = v
+    }
+}
+if (dropped.isNotEmpty()) {
+    writeToDeadLetter(dropped)
+}
+```
+
+The dead-letter exhaustion path (`retryCount >= MAX_DEAD_LETTER_RETRY`) was
+also refactored to call `writeToDeadLetter` instead of duplicating the HSET +
+LPUSH logic.
+
+### Scope ownership fix
+
+Added a private `ownedJob` (`SupervisorJob` child of the provided scope) and
+`ownedScope` built from it. `writeBehindJob` is launched on `ownedScope`.
+`close()` cancels `ownedJob` only:
+
+```kotlin
+private val ownedJob = SupervisorJob(parent = scope.coroutineContext[Job])
+private val ownedScope = CoroutineScope(scope.coroutineContext + ownedJob)
+// ...
+override fun close() {
+    writeBehindChannel?.close()
+    writeBehindJob?.let { job ->
+        runBlocking(Dispatchers.IO) {
+            withTimeout(...) { job.join() }
+        }
+    }
+    ownedJob.cancel()   // not scope.cancel()
+    ...
+}
+```
+
+## Test Coverage
+
+Two new tests in `LettuceSuspendedLoadedMapTest`:
+
+- `close - 공유 scope를 취소하지 않는다` — passes a shared scope, closes the map,
+  asserts `sharedScope.isActive == true`
+- `write-behind - writer 실패 후 재시도 소진 시 dead-letter에 기록된다` — always-failing
+  writer exhausts `MAX_DEAD_LETTER_RETRY` retries, verifies the key appears in the
+  Redis dead-letter list
+
+## Verification
+
+```
+:bluetape4k-lettuce:test
+322 passing (14.1s) — BUILD SUCCESSFUL
+```
+
+## Key Lessons
+
+**Never discard a `ChannelResult` from `trySend`.** A `trySend` on a full or
+closed channel returns failure silently. Always check the result and route
+undeliverable messages to a dead-letter or log them explicitly.
+
+**The owner of a `CoroutineScope` is the one who should cancel it.** If a class
+receives a scope parameter, it should create a child job/scope internally and
+cancel only that child on `close()`. Cancelling the provided scope is a contract
+violation that affects all callers sharing the scope.

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMap.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMap.kt
@@ -14,8 +14,8 @@ import io.lettuce.core.api.async.RedisAsyncCommands
 import io.lettuce.core.codec.StringCodec
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.future.await
@@ -83,6 +83,11 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
 
     private val ttlSeconds = config.ttl.seconds
 
+    // Internal job owned by this instance; child of the provided scope's job.
+    // close() cancels ownedJob only — never the caller's scope.
+    private val ownedJob = SupervisorJob(parent = scope.coroutineContext[Job])
+    private val ownedScope = CoroutineScope(scope.coroutineContext + ownedJob)
+
     // Write-behind: Channel + coroutine consumer
     private val writeBehindChannel: Channel<Triple<K, V, Int>>? =
         if (config.writeMode == WriteMode.WRITE_BEHIND) {
@@ -93,7 +98,7 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
 
     private val writeBehindJob =
         writeBehindChannel?.let {
-            scope.launch { consumeWriteBehindChannel() }
+            ownedScope.launch { consumeWriteBehindChannel() }
         }
 
     private fun redisKey(key: K): String = "${config.keyPrefix}:${keySerializer(key)}"
@@ -291,6 +296,19 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
         }
     }
 
+    private suspend fun writeToDeadLetter(batch: Map<K, V>) {
+        // HSET (recovery values) first; LPUSH (monitoring keys) only on success.
+        // Two commands use different codec connections so MULTI/EXEC is not possible.
+        runCatching {
+            val deadLetterKey = "${config.keyPrefix}:dead-letter"
+            val deadLetterValuesKey = "${config.keyPrefix}:dead-letter:values"
+            val valueMap = batch.entries.associate { (k, v) -> keySerializer(k) to v }
+            asyncCommands.hset(deadLetterValuesKey, valueMap).await()
+            val serializedKeys = batch.keys.map { keySerializer(it) }
+            strAsyncCommands.lpush(deadLetterKey, *serializedKeys.toTypedArray()).await()
+        }.onFailure { ex -> log.error(ex) { "Dead letter 기록 실패" } }
+    }
+
     private suspend fun flushBatch(entries: List<Triple<K, V, Int>>) {
         if (entries.isEmpty()) return
         val batch = entries.associate { it.first to it.second }
@@ -299,24 +317,19 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
                 val retryCount = entries.first().third + 1
                 log.error(e) { "Write-behind flush 실패 (attempt $retryCount): ${batch.keys}" }
                 if (retryCount < MAX_DEAD_LETTER_RETRY) {
+                    val dropped = mutableMapOf<K, V>()
                     entries.forEach { (k, v, _) ->
-                        writeBehindChannel?.trySend(Triple(k, v, retryCount))
+                        val result = writeBehindChannel?.trySend(Triple(k, v, retryCount))
+                        if (result == null || result.isFailure) {
+                            log.warn { "Requeue failed for key=$k (attempt $retryCount): channel full or closed" }
+                            dropped[k] = v
+                        }
+                    }
+                    if (dropped.isNotEmpty()) {
+                        writeToDeadLetter(dropped)
                     }
                 } else {
-                    runCatching {
-                        // 개선: HSET(복구용 값)을 먼저 저장한 후 LPUSH(모니터링용 키 목록)를 저장합니다.
-                        //       두 명령은 서로 다른 codec connection을 사용하므로 MULTI/EXEC 불가.
-                        //       HSET 실패 시 LPUSH를 건너뛰어 복구 불가 상태(모니터링 오탐)를 방지합니다.
-                        val deadLetterKey = "${config.keyPrefix}:dead-letter"
-                        val deadLetterValuesKey = "${config.keyPrefix}:dead-letter:values"
-                        val valueMap = batch.entries.associate { (k, v) -> keySerializer(k) to v }
-                        // HSET 먼저: 실패 시 LPUSH 건너뜀 (복구 데이터 우선)
-                        asyncCommands.hset(deadLetterValuesKey, valueMap).await()
-                        val serializedKeys = batch.keys.map { keySerializer(it) }
-                        strAsyncCommands
-                            .lpush(deadLetterKey, *serializedKeys.toTypedArray())
-                            .await()
-                    }.onFailure { ex -> log.error(ex) { "Dead letter 기록 실패" } }
+                    writeToDeadLetter(batch)
                 }
             }
     }
@@ -333,7 +346,7 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
                 }
             }
         }
-        scope.cancel()
+        ownedJob.cancel()
         if (lazyStrConnection.isInitialized()) lazyStrConnection.value.close()
         connection.close()
     }

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMapTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMapTest.kt
@@ -2,11 +2,21 @@ package io.bluetape4k.redis.lettuce.map
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.redis.lettuce.AbstractLettuceTest
+import io.lettuce.core.codec.StringCodec
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.isActive
 import org.junit.jupiter.api.Test
+import java.time.Duration
 import java.util.concurrent.atomic.AtomicInteger
 
 class LettuceSuspendedLoadedMapTest: AbstractLettuceTest() {
@@ -88,5 +98,52 @@ class LettuceSuspendedLoadedMapTest: AbstractLettuceTest() {
         val map = newMap()
         map.shouldNotBeNull()
         map.close()
+    }
+
+    @Test
+    fun `close - 공유 scope를 취소하지 않는다`() = runSuspendIO {
+        val sharedScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val map = LettuceSuspendedLoadedMap<String, String>(
+            client = client,
+            scope = sharedScope,
+            config = LettuceCacheConfig.READ_ONLY.copy(keyPrefix = "scope-test:${randomName()}")
+        )
+        map.close()
+        // Shared scope must still be active — close() must not cancel a caller-provided scope
+        sharedScope.isActive.shouldBeTrue()
+        sharedScope.cancel()
+    }
+
+    @Test
+    fun `write-behind - writer 실패 후 재시도 소진 시 dead-letter에 기록된다`() = runSuspendIO {
+        val prefix = "dead-letter-test:${randomName()}"
+        val config = LettuceCacheConfig.WRITE_BEHIND.copy(
+            keyPrefix = prefix,
+            writeBehindDelay = Duration.ofMillis(20),
+            writeBehindBatchSize = 1,
+        )
+        val failingWriter = object: SuspendedMapWriter<String, String> {
+            override suspend fun write(map: Map<String, String>) {
+                throw RuntimeException("simulated write failure")
+            }
+
+            override suspend fun delete(keys: Collection<String>) {}
+        }
+
+        LettuceSuspendedLoadedMap<String, String>(client = client, writer = failingWriter, config = config).use { map ->
+            map.set("deadkey", "deadvalue")
+            // Allow 3 retry cycles: each cycle ≈ writeBehindDelay (20ms) → ~60ms minimum
+            delay(400L)
+        }
+
+        // Verify dead-letter list contains the key
+        val strConn = client.connect(StringCodec.UTF8)
+        try {
+            val deadLetterKey = "$prefix:dead-letter"
+            val keys = strConn.async().lrange(deadLetterKey, 0L, -1L).await()
+            keys.contains("deadkey").shouldBeTrue()
+        } finally {
+            strConn.close()
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #486

- PR 제목: fix: LettuceSuspendedLoadedMap write-behind retry silently drops entries (#486)

Fixes #486 — `LettuceSuspendedLoadedMap` write-behind retry ignored the `ChannelResult` from `trySend`, silently dropping entries when the channel was full or closed. Additionally, `close()` cancelled the caller-provided `CoroutineScope` instead of only the internal job.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### trySend result check
Extracted `writeToDeadLetter(batch)` helper. Retry branch now checks `ChannelResult`:
```kotlin
val dropped = mutableMapOf<K, V>()
entries.forEach { (k, v, _) ->
    val result = writeBehindChannel?.trySend(Triple(k, v, retryCount))
    if (result == null || result.isFailure) {
        log.warn { "Requeue failed for key=$k: channel full or closed" }
        dropped[k] = v
    }
}
if (dropped.isNotEmpty()) writeToDeadLetter(dropped)
```

### Scope ownership
```kotlin
private val ownedJob = SupervisorJob(parent = scope.coroutineContext[Job])
private val ownedScope = CoroutineScope(scope.coroutineContext + ownedJob)
// close() now calls ownedJob.cancel() instead of scope.cancel()
```

### 기존 섹션: Root Cause

### 1. trySend result ignored
```kotlin
// Before — ChannelResult discarded
entries.forEach { (k, v, _) ->
    writeBehindChannel?.trySend(Triple(k, v, retryCount))
}
```
If the channel was full or closed, entries were silently dropped with no log and no dead-letter record.

### 2. close() cancelled caller's CoroutineScope
`close()` called `scope.cancel()`, which cancelled any external scope passed by the caller, affecting unrelated coroutines sharing that scope.

## Validation

```
:bluetape4k-lettuce:test
322 passing (14.1s) — BUILD SUCCESSFUL
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #486, milestone 없음, assignee `debop`
- PR: #504, head `52737f548204042de3027d0004b57f932cdc0fd2`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/lettuce-write-behind-drop`
- Labels: 없음
- State: `MERGED`, merge commit `a62c197972dc00622473c37fae605176a6ddb160`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- [x] All tests passing (322 / 0 failed / 0 skipped)
- [x] New tests: shared-scope not cancelled on close; retry-exhausted entries in Redis dead-letter
- [x] Lessons committed: `docs/lessons/2026-05-16-lettuce-write-behind-drop.md`

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #504 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `a62c197972dc00622473c37fae605176a6ddb160`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
