### PR TITLE
fix: LettuceLoadedMap getAll skips loader fallback after MGET failure (#485)

### DIFF
--- a/docs/lessons/2026-05-16-lettuce-getall-mget-fallback.md
+++ b/docs/lessons/2026-05-16-lettuce-getall-mget-fallback.md
@@ -1,0 +1,92 @@
+# LettuceLoadedMap getAll MGET Fallback Fix
+
+**Date**: 2026-05-16
+**Issue**: #485
+**Branch**: `fix/lettuce-getall-fallback`
+
+## Root Cause
+
+`LettuceLoadedMap.getAll()` and `LettuceSuspendedLoadedMap.getAll()` both used:
+
+```kotlin
+val values = runCatching { commands.mget(*redisKeys) }
+    .onFailure { log.warn(it) { "Redis MGET 실패, loader fallback: ..." } }
+    .getOrNull() ?: emptyList()
+```
+
+When MGET failed, `values` became `emptyList()`. The subsequent `forEachIndexed`
+loop never iterated, so `missedKeys` remained empty. The loader was never invoked
+and callers received an empty result instead of fetched values.
+
+The log message said "loader fallback" but the code path made it impossible.
+
+## Fix
+
+### Sync (LettuceLoadedMap.kt)
+
+```kotlin
+val mgetResult = runCatching { commands.mget(*redisKeys) }
+    .onFailure { log.warn(it) { "Redis MGET 실패, loader fallback: ..." } }
+    .getOrNull()
+
+val missedKeys: MutableList<K>
+if (mgetResult == null) {
+    // MGET failed entirely — treat all requested keys as cache misses
+    missedKeys = keyList.toMutableList()
+} else {
+    missedKeys = mutableListOf()
+    mgetResult.forEachIndexed { i, kv ->
+        if (kv != null && kv.hasValue()) result[keyList[i]] = kv.value
+        else missedKeys.add(keyList[i])
+    }
+}
+```
+
+### Suspend (LettuceSuspendedLoadedMap.kt)
+
+Same logic, plus replaced `runCatching { asyncCommands.mget(...).await() }` (which
+swallows `CancellationException`) with explicit try/catch that rethrows
+`CancellationException`:
+
+```kotlin
+val mgetResult = try {
+    asyncCommands.mget(*redisKeys).await()
+} catch (e: CancellationException) {
+    throw e
+} catch (e: Exception) {
+    log.warn(e) { "Redis MGET 실패, loader fallback: ..." }
+    null
+}
+```
+
+Also replaced the SETEX `runCatching` block with the same explicit try/catch.
+
+## Test Coverage
+
+New tests in `LettuceLoadedMapTest` and `LettuceSuspendedLoadedMapTest`:
+
+- `getAll - 모든 키가 캐시 미스인 경우 loader로 모두 처리한다` — all keys absent from
+  Redis, verifies all keys go through the loader and results are returned
+- `getAll - 일부 캐시 미스 키는 loader로 Read-through한다` (suspend) — partial miss
+  scenario added to the suspend test class (was missing entirely)
+
+Note: the `mgetResult == null` path (MGET throws) is verified by static analysis.
+Integration-level simulation of MGET failure requires a mock-based unit test or
+a broken-connection fixture, which can be added as a follow-up.
+
+## Verification
+
+```
+:bluetape4k-lettuce:test
+67 passing (6.2s) — BUILD SUCCESSFUL
+```
+
+## Key Lesson
+
+**`getOrNull() ?: emptyList()` silently converts an error into an empty result.**
+When the intent is "treat failure as all-miss", populate `missedKeys` explicitly
+from `keyList`. Never infer missed keys by iterating a fallback empty collection.
+
+**`runCatching {}` must not wrap `suspend` calls.** It swallows
+`CancellationException`, breaking coroutine structured concurrency. Use explicit
+try/catch with `CancellationException` rethrow in all suspend paths.

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceLoadedMap.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceLoadedMap.kt
@@ -167,18 +167,24 @@ class LettuceLoadedMap<K: Any, V: Any>(
         val keyList = keys.toList()
         val redisKeys = keyList.map { redisKey(it) }.toTypedArray()
 
-        val values = runCatching { commands.mget(*redisKeys) }
+        val mgetResult = runCatching { commands.mget(*redisKeys) }
             .onFailure { log.warn(it) { "Redis MGET 실패, loader fallback: ${redisKeys.take(5)}..." } }
-            .getOrNull() ?: emptyList()
+            .getOrNull()
 
         val result = mutableMapOf<K, V>()
-        val missedKeys = mutableListOf<K>()
+        val missedKeys: MutableList<K>
 
-        values.forEachIndexed { i, kv ->
-            if (kv != null && kv.hasValue()) {
-                result[keyList[i]] = kv.value
-            } else {
-                missedKeys.add(keyList[i])
+        if (mgetResult == null) {
+            // MGET failed entirely — treat all requested keys as cache misses
+            missedKeys = keyList.toMutableList()
+        } else {
+            missedKeys = mutableListOf()
+            mgetResult.forEachIndexed { i, kv ->
+                if (kv != null && kv.hasValue()) {
+                    result[keyList[i]] = kv.value
+                } else {
+                    missedKeys.add(keyList[i])
+                }
             }
         }
 

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMap.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMap.kt
@@ -12,6 +12,7 @@ import io.lettuce.core.SetArgs
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.api.async.RedisAsyncCommands
 import io.lettuce.core.codec.StringCodec
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -176,16 +177,29 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
         val keyList = keys.toList()
         val redisKeys = keyList.map { redisKey(it) }.toTypedArray()
 
-        val values = runCatching { asyncCommands.mget(*redisKeys).await() }.getOrNull() ?: emptyList()
+        val mgetResult = try {
+            asyncCommands.mget(*redisKeys).await()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "Redis MGET 실패, loader fallback: ${redisKeys.take(5)}..." }
+            null
+        }
 
         val result = mutableMapOf<K, V>()
-        val missedKeys = mutableListOf<K>()
+        val missedKeys: MutableList<K>
 
-        values.forEachIndexed { i, kv ->
-            if (kv != null && kv.hasValue()) {
-                result[keyList[i]] = kv.value
-            } else {
-                missedKeys.add(keyList[i])
+        if (mgetResult == null) {
+            // MGET failed entirely — treat all requested keys as cache misses
+            missedKeys = keyList.toMutableList()
+        } else {
+            missedKeys = mutableListOf()
+            mgetResult.forEachIndexed { i, kv ->
+                if (kv != null && kv.hasValue()) {
+                    result[keyList[i]] = kv.value
+                } else {
+                    missedKeys.add(keyList[i])
+                }
             }
         }
 
@@ -193,9 +207,13 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
             for (key in missedKeys) {
                 val value = loader.load(key) ?: continue
                 result[key] = value
-                runCatching {
+                try {
                     asyncCommands.set(redisKey(key), value, SetArgs().ex(ttlSeconds)).await()
-                }.onFailure { log.warn(it) { "Redis SETEX 실패: ${redisKey(key)}" } }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log.warn(e) { "Redis SETEX 실패: ${redisKey(key)}" }
+                }
             }
         }
         return result

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceLoadedMapTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceLoadedMapTest.kt
@@ -248,6 +248,29 @@ class LettuceLoadedMapTest: AbstractLettuceTest() {
         }
     }
 
+    @Test
+    fun `getAll - 모든 키가 캐시 미스인 경우 loader로 모두 처리한다`() {
+        val loaderCallCount = AtomicInteger(0)
+        val loader =
+            object: MapLoader<String, String> {
+                override fun load(key: String): String {
+                    loaderCallCount.incrementAndGet()
+                    return "fallback-$key"
+                }
+
+                override fun loadAllKeys(): Iterable<String> = emptyList()
+            }
+
+        newMap(loader = loader).use { map ->
+            // No pre-populated keys — all will be cache misses
+            val result = map.getAll(setOf("k1", "k2", "k3"))
+            result["k1"] shouldBeEqualTo "fallback-k1"
+            result["k2"] shouldBeEqualTo "fallback-k2"
+            result["k3"] shouldBeEqualTo "fallback-k3"
+            loaderCallCount.get() shouldBeEqualTo 3
+        }
+    }
+
     // =========================================================================
     // deleteAll / clear
     // =========================================================================

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMapTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMapTest.kt
@@ -146,4 +146,47 @@ class LettuceSuspendedLoadedMapTest: AbstractLettuceTest() {
             strConn.close()
         }
     }
+
+    @Test
+    fun `getAll - 일부 캐시 미스 키는 loader로 Read-through한다`() = runSuspendIO {
+        val loaderCallCount = AtomicInteger(0)
+        val loader = object: SuspendedMapLoader<String, String> {
+            override suspend fun load(key: String): String {
+                loaderCallCount.incrementAndGet()
+                return "from-db-$key"
+            }
+
+            override suspend fun loadAllKeys(): List<String> = emptyList()
+        }
+
+        newMap(loader = loader).use { map ->
+            map.set("k1", "cached-v1")
+            val result = map.getAll(setOf("k1", "k2", "k3"))
+            result["k1"] shouldBeEqualTo "cached-v1"
+            result["k2"] shouldBeEqualTo "from-db-k2"
+            result["k3"] shouldBeEqualTo "from-db-k3"
+            loaderCallCount.get() shouldBeEqualTo 2
+        }
+    }
+
+    @Test
+    fun `getAll - 모든 키가 캐시 미스인 경우 loader로 모두 처리한다`() = runSuspendIO {
+        val loaderCallCount = AtomicInteger(0)
+        val loader = object: SuspendedMapLoader<String, String> {
+            override suspend fun load(key: String): String {
+                loaderCallCount.incrementAndGet()
+                return "fallback-$key"
+            }
+
+            override suspend fun loadAllKeys(): List<String> = emptyList()
+        }
+
+        newMap(loader = loader).use { map ->
+            val result = map.getAll(setOf("k1", "k2", "k3"))
+            result["k1"] shouldBeEqualTo "fallback-k1"
+            result["k2"] shouldBeEqualTo "fallback-k2"
+            result["k3"] shouldBeEqualTo "fallback-k3"
+            loaderCallCount.get() shouldBeEqualTo 3
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Closes #485

- PR 제목: fix: LettuceLoadedMap getAll skips loader fallback after MGET failure (#485)

Fixes #485 — `LettuceLoadedMap.getAll()` and `LettuceSuspendedLoadedMap.getAll()` both used `getOrNull() ?: emptyList()` on MGET failure. This produced an empty iteration, leaving `missedKeys` empty and the loader never invoked — callers received an empty result despite having a loader configured.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

```kotlin
val mgetResult = runCatching { commands.mget(*redisKeys) }.getOrNull()
if (mgetResult == null) {
    missedKeys = keyList.toMutableList()  // all keys treated as misses
} else {
    mgetResult.forEachIndexed { ... }  // normal partial-miss path
}
```

Suspend path also replaces `runCatching { ...await() }` with explicit try/catch to avoid swallowing `CancellationException`.

### 기존 섹션: Root Cause

```kotlin
// Before — MGET failure → emptyList() → missedKeys never populated
val values = runCatching { commands.mget(*redisKeys) }
    .getOrNull() ?: emptyList()
values.forEachIndexed { i, kv -> ... }  // never iterates
```

## Validation

```
:bluetape4k-lettuce:test
67 passing (6.2s) — BUILD SUCCESSFUL
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #485, milestone 없음, assignee `debop`
- PR: #505, head `e4a702015f5bd189adbe46f2a585d46614b67c65`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/lettuce-getall-fallback`
- Labels: 없음
- State: `MERGED`, merge commit `b245b0c52a3371bb20c61739889cd2946509a189`
- CI: Suspend path also replaces `runCatching { ...await() }` with explicit try/catch to avoid swallowing `CancellationException`.

## DoD Status

- [x] All tests passing (67 / 0 failed / 0 skipped)
- [x] New tests: all-miss and partial-miss loader fallback (sync + suspend)
- [x] CancellationException not swallowed in suspend path
- [x] Lessons committed: `docs/lessons/2026-05-16-lettuce-getall-mget-fallback.md`

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #505 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `b245b0c52a3371bb20c61739889cd2946509a189`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
