### PR TITLE
fix: move Kryo obtain/release inside supplyAsync to prevent pool leak on cancellation (#480)

### DIFF
--- a/docs/lessons/2026-05-16-kryo-async-leak.md
+++ b/docs/lessons/2026-05-16-kryo-async-leak.md
@@ -1,0 +1,85 @@
+# withKryoAsync Kryo Pool Leak on Cancellation
+
+**Date**: 2026-05-16
+**Issue**: #480
+**Branch**: `fix/kryo-async-leak`
+
+## Root Cause
+
+`withKryoAsync` obtained the `Kryo` instance **outside** `supplyAsync` and released it via `whenCompleteAsync`:
+
+```kotlin
+// BEFORE (leak risk)
+val kryo = KryoProvider.obtainKryo()                  // obtained on caller thread
+return CompletableFuture.supplyAsync { func(kryo) }
+    .whenCompleteAsync { _, _ -> KryoProvider.releaseKryo(kryo) }  // may not run on cancellation
+```
+
+Two leak paths:
+1. **Cancel before start**: The caller obtains the `Kryo` on its own thread, but if the returned
+   future is cancelled before `supplyAsync` runs, `whenCompleteAsync` is never triggered and the
+   instance is never released.
+2. **`whenCompleteAsync` stage cancelled**: `whenCompleteAsync` returns a new `CompletableFuture`.
+   If that stage is cancelled or the callback does not fire (e.g., when the parent stage completes
+   exceptionally and the new stage is immediately cancelled), `releaseKryo` is skipped.
+
+## Fix
+
+Move `obtainKryo` and `releaseKryo` **inside** the `supplyAsync` lambda, using `try/finally`:
+
+```kotlin
+// AFTER (fix)
+return CompletableFuture.supplyAsync {
+    val kryo = KryoProvider.obtainKryo()
+    try {
+        func(kryo)
+    } finally {
+        KryoProvider.releaseKryo(kryo)
+    }
+}
+```
+
+- If the future is cancelled **before** the supplier runs, `obtainKryo` is never called — no leak.
+- If the future is cancelled **during** execution, the supplier continues to completion on the
+  worker thread; `finally` runs unconditionally and releases the instance before the worker exits.
+- Exception in `func` also triggers `finally`, consistent with the synchronous `withKryo` pattern.
+
+## Test Coverage
+
+New `KryoSupportTest.kt` covers all five helper functions:
+
+- `withKryo` — normal path and exception path (pool returned in both cases)
+- `withKryoOutput` — normal path and exception path
+- `withKryoInput` — normal path and exception path
+- `withKryoAsync` — normal path, null return, exception path (pool not exhausted after 20 failures),
+  cancellation path (latch-based synchronization, no `Thread.sleep`)
+- `withKryoSuspending` — normal path and exception path
+
+The cancellation test uses a `funcCompleted` `CountDownLatch` signalled from the user-func's
+`finally` block. Because the framework's `releaseKryo` executes immediately after the user func
+returns (including its `finally`), waiting on `funcCompleted` is sufficient synchronization without
+an arbitrary `Thread.sleep`.
+
+## Key Lessons
+
+**Obtain resources inside the task boundary, not outside it.**
+When an async task may be cancelled before it starts, any resource obtained before `supplyAsync`
+is at risk of leaking. Always scope `obtain`/`release` pairs to the executor lambda, using
+`try/finally` to guarantee release on all exit paths (success, exception, interrupt).
+
+**`whenCompleteAsync` does not guarantee callback execution on cancellation.**
+It returns a new `CompletableFuture`; if that new stage is cancelled, the callback may not run.
+Use `try/finally` inside the supplier instead of a completion callback for resource release.
+
+**`Thread.sleep` in concurrency tests is flaky.**
+Use `CountDownLatch` or similar explicit signalling. The `funcCompleted` latch pattern here
+(signal from user `finally`, framework release follows immediately) gives deterministic
+synchronization without arbitrary delays.
+
+## Verification
+
+```
+:bluetape4k-io:test
+  KryoSupportTest  12 passing (2s)
+  Full module      925 passing (9.7s) — BUILD SUCCESSFUL
+```

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/KryoSupport.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/KryoSupport.kt
@@ -88,8 +88,16 @@ inline fun <T> withKryoInput(
 }
 
 /**
- * Kryo 를 이용한 비동기 작업을 [CompletableFuture]로 반환합니다.
- * Kryo 가 thread-safe 하지 않으므로 풀에서 인스턴스를 대여하고, 작업 완료 후 자동 반환합니다.
+ * Executes a Kryo serialization task asynchronously and returns a [CompletableFuture].
+ *
+ * A [Kryo] instance is obtained from the pool **on the executor thread** (inside [CompletableFuture.supplyAsync]),
+ * not on the caller thread. It is released via a `finally` block regardless of success or exception.
+ *
+ * ## Behavior / Contract
+ * - If the returned future is cancelled before the supplier runs, no [Kryo] instance is ever obtained.
+ * - If the future is cancelled while the supplier is running, the supplier continues to completion
+ *   on the worker thread; the `finally` block releases the [Kryo] instance before the worker exits.
+ * - The [func] block must not leave the [Kryo] instance in an inconsistent state across threads.
  *
  * ```kotlin
  * val future: CompletableFuture<ByteArray?> = withKryoAsync {
@@ -97,21 +105,24 @@ inline fun <T> withKryoInput(
  *     writeClassAndObject(output, "Hello, Async Kryo!")
  *     output.toBytes()
  * }
- * val bytes = future.get()  // 비동기 결과 획득
+ * val bytes = future.get()
  * ```
  *
- * @param T 반환 수형
- * @param func [Kryo] 인스턴스를 수신자로 비동기 실행할 작업 블록
- * @return 작업 결과를 담은 [CompletableFuture]
+ * @param T return type
+ * @param func block executed with a [Kryo] receiver on the async executor thread
+ * @return [CompletableFuture] holding the result, or null
  */
 inline fun <T: Any> withKryoAsync(
     crossinline func: Kryo.() -> T?,
 ): CompletableFuture<T?> {
-    val kryo = KryoProvider.obtainKryo()
-    return CompletableFuture.supplyAsync { func(kryo) }
-        .whenCompleteAsync { _, _ ->
+    return CompletableFuture.supplyAsync {
+        val kryo = KryoProvider.obtainKryo()
+        try {
+            func(kryo)
+        } finally {
             KryoProvider.releaseKryo(kryo)
         }
+    }
 }
 
 /**

--- a/io/io/src/test/kotlin/io/bluetape4k/io/serializer/KryoSupportTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/serializer/KryoSupportTest.kt
@@ -1,0 +1,252 @@
+package io.bluetape4k.io.serializer
+
+import com.esotericsoftware.kryo.io.Input
+import com.esotericsoftware.kryo.io.Output
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.KLogging
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
+
+class KryoSupportTest {
+
+    companion object : KLogging()
+
+    // ── withKryo ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `withKryo - 정상 실행 후 Kryo 인스턴스가 풀에 반환된다`() {
+        val result = withKryo {
+            val output = Output(256)
+            writeClassAndObject(output, "hello-kryo")
+            output.toBytes()
+        }
+        result.shouldNotBeNull()
+
+        // Verify: subsequent call still works (pool was properly returned)
+        val text = withKryo {
+            val input = Input(result)
+            readClassAndObject(input) as String
+        }
+        text shouldBeEqualTo "hello-kryo"
+    }
+
+    @Test
+    fun `withKryo - 예외 발생 시에도 Kryo 인스턴스가 풀에 반환된다`() {
+        repeat(10) {
+            runCatching {
+                withKryo<Unit> { throw RuntimeException("test error $it") }
+            }
+        }
+
+        // Pool not exhausted — normal call still works
+        val result = withKryo {
+            val output = Output(256)
+            writeClassAndObject(output, 42L)
+            output.toBytes()
+        }
+        result.shouldNotBeNull()
+    }
+
+    // ── withKryoOutput ────────────────────────────────────────────────────────
+
+    @Test
+    fun `withKryoOutput - 정상 실행 후 Output 인스턴스가 풀에 반환된다`() {
+        val bytes = withKryoOutput { output ->
+            output.reset()
+            withKryo { writeObject(output, "output-test") }
+            output.toBytes()
+        }
+        bytes.shouldNotBeNull()
+
+        // Verify: second call still works
+        val bytes2 = withKryoOutput { output ->
+            output.reset()
+            withKryo { writeObject(output, "output-test-2") }
+            output.toBytes()
+        }
+        bytes2.shouldNotBeNull()
+    }
+
+    @Test
+    fun `withKryoOutput - 예외 발생 시에도 Output 인스턴스가 풀에 반환된다`() {
+        repeat(10) {
+            runCatching {
+                withKryoOutput<Unit> { throw RuntimeException("output error $it") }
+            }
+        }
+
+        // Pool not exhausted
+        val bytes = withKryoOutput { output ->
+            output.reset()
+            withKryo { writeObject(output, "after-error") }
+            output.toBytes()
+        }
+        bytes.shouldNotBeNull()
+    }
+
+    // ── withKryoInput ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `withKryoInput - 정상 실행 후 Input 인스턴스가 풀에 반환된다`() {
+        val bytes = withKryoOutput { output ->
+            output.reset()
+            withKryo { writeObject(output, "input-test") }
+            output.toBytes()
+        }
+
+        val text = withKryoInput { input ->
+            input.setBuffer(bytes)
+            withKryo { readObject(input, String::class.java) }
+        }
+        text shouldBeEqualTo "input-test"
+    }
+
+    @Test
+    fun `withKryoInput - 예외 발생 시에도 Input 인스턴스가 풀에 반환된다`() {
+        repeat(10) {
+            runCatching {
+                withKryoInput<Unit> { throw RuntimeException("input error $it") }
+            }
+        }
+
+        // Pool not exhausted
+        val bytes = withKryoOutput { output ->
+            output.reset()
+            withKryo { writeObject(output, "after-input-error") }
+            output.toBytes()
+        }
+        val text = withKryoInput { input ->
+            input.setBuffer(bytes)
+            withKryo { readObject(input, String::class.java) }
+        }
+        text shouldBeEqualTo "after-input-error"
+    }
+
+    // ── withKryoAsync ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `withKryoAsync - 정상 실행 시 올바른 결과를 반환한다`() {
+        val future = withKryoAsync {
+            val output = Output(256)
+            writeClassAndObject(output, "async-kryo")
+            output.toBytes()
+        }
+
+        val bytes = checkNotNull(future.get(5, TimeUnit.SECONDS)) { "withKryoAsync returned null" }
+
+        val text = withKryo {
+            val input = Input(bytes)
+            readClassAndObject(input) as String
+        }
+        text shouldBeEqualTo "async-kryo"
+    }
+
+    @Test
+    fun `withKryoAsync - null 반환도 허용된다`() {
+        val future = withKryoAsync<String> { null }
+        val result = future.get(5, TimeUnit.SECONDS)
+        result.shouldBeNull()
+    }
+
+    @Test
+    fun `withKryoAsync - func 예외 발생 시 Kryo가 풀에 반환되고 이후 호출이 정상 동작한다`() {
+        // Trigger exception path many times
+        repeat(20) {
+            val future = withKryoAsync<String> { throw RuntimeException("async error $it") }
+            assertThrows<ExecutionException> { future.get(5, TimeUnit.SECONDS) }
+        }
+
+        // Pool must not be exhausted — new call still works
+        val future = withKryoAsync {
+            val output = Output(256)
+            writeClassAndObject(output, "after-async-error")
+            output.toBytes()
+        }
+        val bytes = future.get(5, TimeUnit.SECONDS)
+        bytes.shouldNotBeNull()
+    }
+
+    @Test
+    fun `withKryoAsync - Future 취소 시 Kryo가 풀에 반환되고 이후 호출이 정상 동작한다`() {
+        val taskStarted = CountDownLatch(1)
+        val releaseTask = CountDownLatch(1)
+        val funcCompleted = CountDownLatch(1)  // signals user-func finally ran
+
+        val future = withKryoAsync {
+            taskStarted.countDown()
+            try {
+                releaseTask.await(10, TimeUnit.SECONDS)
+                "should-not-complete"
+            } finally {
+                // Framework's releaseKryo() runs immediately after this
+                funcCompleted.countDown()
+            }
+        }
+
+        // Wait until supplier has started and obtained Kryo
+        taskStarted.await(5, TimeUnit.SECONDS)
+
+        // Cancel with interrupt — the finally block inside supplyAsync still runs
+        future.cancel(true)
+
+        // Unblock the supplier so it can reach the finally block
+        releaseTask.countDown()
+
+        // Wait for user-func's finally to complete (framework's releaseKryo follows immediately after)
+        funcCompleted.await(5, TimeUnit.SECONDS)
+
+        assertThrows<CancellationException> { future.get() }
+
+        // Kryo must have been released — subsequent calls still work
+        repeat(5) { i ->
+            val next = withKryoAsync {
+                val output = Output(256)
+                writeClassAndObject(output, "post-cancel-$i")
+                output.toBytes()
+            }
+            val bytes = next.get(5, TimeUnit.SECONDS)
+            bytes.shouldNotBeNull()
+        }
+    }
+
+    // ── withKryoSuspending ────────────────────────────────────────────────────
+
+    @Test
+    fun `withKryoSuspending - 정상 실행 시 올바른 결과를 반환한다`() = runTest {
+        val bytes = checkNotNull(withKryoSuspending {
+            val output = Output(256)
+            writeClassAndObject(output, "suspend-kryo")
+            output.toBytes()
+        }) { "withKryoSuspending returned null" }
+
+        val text = withKryoSuspending {
+            val input = Input(bytes)
+            readClassAndObject(input) as String
+        }
+        text shouldBeEqualTo "suspend-kryo"
+    }
+
+    @Test
+    fun `withKryoSuspending - 예외 발생 시에도 Kryo가 풀에 반환된다`() = runTest {
+        repeat(10) {
+            runCatching {
+                withKryoSuspending<Unit> { throw RuntimeException("suspend error $it") }
+            }
+        }
+
+        // Pool not exhausted
+        val result = withKryoSuspending {
+            val output = Output(256)
+            writeClassAndObject(output, "after-suspend-error")
+            output.toBytes()
+        }
+        result.shouldNotBeNull()
+    }
+}


### PR DESCRIPTION
## Summary

Closes #480

- PR 제목: fix: move Kryo obtain/release inside supplyAsync to prevent pool leak on cancellation (#480)

Closes #480

`withKryoAsync` obtained the `Kryo` instance **outside** `supplyAsync` and released it via
`whenCompleteAsync`. Two leak paths existed:

1. **Cancel before start** — Kryo obtained on caller thread; if future is cancelled before the
   supplier runs, `whenCompleteAsync` never fires → instance never returned to pool.
2. **`whenCompleteAsync` stage cancelled** — the callback attached to the dependent stage may not
   execute if that stage is cancelled or completes exceptionally without triggering it.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

Move `obtainKryo()` and `releaseKryo()` inside the `supplyAsync` lambda with `try/finally`:

```kotlin
// BEFORE
val kryo = KryoProvider.obtainKryo()
return CompletableFuture.supplyAsync { func(kryo) }
    .whenCompleteAsync { _, _ -> KryoProvider.releaseKryo(kryo) }

// AFTER
return CompletableFuture.supplyAsync {
    val kryo = KryoProvider.obtainKryo()
    try { func(kryo) } finally { KryoProvider.releaseKryo(kryo) }
}
```

- Cancel **before** start → `obtainKryo` never called, nothing to leak.
- Cancel **during** execution → worker thread runs `finally` before exiting.
- Exception in `func` → `finally` runs, consistent with synchronous `withKryo`.

| File | Change |
|------|--------|
| `io/io/src/main/kotlin/.../KryoSupport.kt` | Fix `withKryoAsync`; rewrite KDoc in English |
| `io/io/src/test/kotlin/.../KryoSupportTest.kt` | New: covers all 5 `withKryo*` helpers |
| `docs/lessons/2026-05-16-kryo-async-leak.md` | Lessons document |

### 기존 섹션: DoD Checklist

| Item | Status |
|------|--------|
| All tests passing | ✅ |
| Tier 4 code review (CRITICAL/HIGH@HIGH-confidence = 0) | ✅ |
| English KDoc updated | ✅ |
| Lessons committed | ✅ |
| README locale set synced | ⏭️ N/A (no behavior/API surface change) |

## Validation

```
KryoSupportTest  12 passing (2s)
Full module      925 passing (9.7s) — BUILD SUCCESSFUL
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #480, milestone 없음, assignee `debop`
- PR: #508, head `0e5eec306068b754d4c65edbc40bd7d99a3faef7`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/kryo-async-leak`
- Labels: 없음
- State: `MERGED`, merge commit `aaf432f4ea224e68ba3b62c97179874880f10c82`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #508 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `aaf432f4ea224e68ba3b62c97179874880f10c82`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
