### PR TITLE
fix: replace TOCTOU createTempDirectory with atomic Files.createTempDirectory (#479)

### DIFF
--- a/docs/lessons/2026-05-16-create-temp-directory-toctou.md
+++ b/docs/lessons/2026-05-16-create-temp-directory-toctou.md
@@ -1,0 +1,62 @@
+# createTempDirectory TOCTOU Race Fix
+
+**Date**: 2026-05-16
+**Issue**: #479
+**Branch**: `fix/create-temp-directory`
+
+## Root Cause
+
+`createTempDirectory` used a three-step sequence with a time-of-check/time-of-use (TOCTOU) race:
+
+```kotlin
+// BEFORE (racy)
+val dir = File.createTempFile(prefix, suffix)  // 1. create temp FILE
+dir.deleteRecursively()                         // 2. delete it
+dir.mkdirs()                                    // 3. recreate as directory
+```
+
+Between step 2 and step 3, another process can claim the same path. Additionally, neither
+`deleteRecursively()` nor `mkdirs()` return values were checked, so failure was silently
+ignored and the function returned as if a valid directory was created.
+
+## Fix
+
+Replace the racy sequence with the JDK atomic `Files.createTempDirectory` API:
+
+```kotlin
+// AFTER (atomic)
+val dir = Files.createTempDirectory(prefix).toFile()
+```
+
+`Files.createTempDirectory` creates the directory in a single atomic OS syscall — there is no
+window for another process to claim the path.
+
+The `suffix` parameter is retained in the signature for API compatibility but is now ignored.
+The generated directory name no longer ends with the suffix value (e.g., no `.dir` extension);
+`Files.createTempDirectory` generates its own unique numeric suffix.
+
+## Test Coverage
+
+Three new tests in `FileSupportTest`:
+
+1. **Atomic creation** — asserts the returned path exists and `isDirectory == true`.
+2. **Uniqueness** — two sequential calls produce distinct canonical paths.
+3. **Concurrent uniqueness** — 50 concurrent calls on 8 threads all produce unique,
+   existing directories, demonstrating the race-free property.
+
+## Key Lessons
+
+**Use JDK atomic filesystem APIs for temporary resources.**
+`File.createTempFile` + delete + mkdir is a classic TOCTOU pattern. `Files.createTempDirectory`
+(and `Files.createTempFile`) are designed to create resources atomically. Prefer them always.
+
+**Check return values for filesystem operations.**
+`deleteRecursively()` and `mkdirs()` return `Boolean` indicating success. In the old code
+both were ignored, meaning silent failure was possible. The new code avoids these operations
+entirely; the shutdown hook uses `runCatching` to log failures without masking the primary result.
+
+## Verification
+
+```
+:bluetape4k-io:test (FileSupportTest)  16 passing (2.1s) — BUILD SUCCESSFUL
+```

--- a/io/io/src/main/kotlin/io/bluetape4k/io/FileSupport.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/FileSupport.kt
@@ -21,6 +21,7 @@ import java.io.OutputStreamWriter
 import java.nio.ByteBuffer
 import java.nio.channels.AsynchronousFileChannel
 import java.nio.charset.Charset
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
 import java.util.concurrent.CompletableFuture
@@ -113,19 +114,29 @@ fun createFile(path: String): File {
 }
 
 /**
- * 임시 디렉토리를 생성합니다. [deleteAtExit]가 true라면 프로그램 종료 시 삭제할 수 있습니다.
+ * Creates a temporary directory using the JDK atomic [Files.createTempDirectory] API.
  *
- * ```
- * val tempDir = createTempDirectory()
+ * ## Behavior / Contract
+ * - The directory is created atomically — there is no delete-then-mkdir race (TOCTOU).
+ * - If [deleteAtExit] is `true`, a JVM shutdown hook deletes the directory and all its contents.
+ * - The [suffix] parameter is kept for API compatibility but is **ignored**; [Files.createTempDirectory]
+ *   generates a unique numeric suffix automatically. The resulting directory name does **not** include
+ *   the [suffix] value (e.g., no `.dir` extension), unlike the previous implementation.
+ * - [prefix] must not contain path separators; otherwise [Files.createTempDirectory] throws
+ *   [java.nio.file.InvalidPathException].
+ *
+ * ```kotlin
+ * val tempDir = createTempDirectory("myapp-")
+ * // tempDir.exists() == true && tempDir.isDirectory == true
  * ```
  *
- * @param deleteAtExit Boolean 프로그램 종료 시 삭제할 것인가 여부
- * @return File 생성된 임시 디렉토리
+ * @param prefix prefix for the directory name
+ * @param suffix ignored; retained for binary compatibility
+ * @param deleteAtExit if `true`, registers a shutdown hook to delete the directory on JVM exit
+ * @return the created temporary directory
  */
 fun createTempDirectory(prefix: String = "temp", suffix: String = "dir", deleteAtExit: Boolean = true): File {
-    val dir = File.createTempFile(prefix, suffix)
-    dir.deleteRecursively()
-    dir.mkdirs()
+    val dir = Files.createTempDirectory(prefix).toFile()
 
     if (deleteAtExit) {
         Runtimex.addShutdownHook {

--- a/io/io/src/test/kotlin/io/bluetape4k/io/FileSupportTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/FileSupportTest.kt
@@ -15,12 +15,11 @@ import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
 
 @RandomizedTest
 @TempFolderTest
@@ -136,21 +135,18 @@ class FileSupportTest: AbstractIOTest() {
 
     @Test
     fun `createTempDirectory는 동시 호출에서도 충돌 없이 고유한 디렉토리를 생성한다`() {
-        val count = 50
         val created = CopyOnWriteArrayList<String>()
-        val executor = Executors.newFixedThreadPool(8)
         try {
-            repeat(count) {
-                executor.submit {
+            MultithreadingTester()
+                .workers(8)
+                .rounds(10)
+                .add {
                     val dir = createTempDirectory(prefix = "test-concurrent-", deleteAtExit = false)
                     created.add(dir.canonicalPath)
                 }
-            }
-            executor.shutdown()
-            executor.awaitTermination(10, TimeUnit.SECONDS)
+                .run()
 
-            created.size shouldBeEqualTo count
-            created.toSet().size shouldBeEqualTo count  // all paths unique
+            created.toSet().size shouldBeEqualTo created.size  // all paths unique
             created.all { java.io.File(it).isDirectory }.shouldBeTrue()
         } finally {
             created.forEach { java.io.File(it).deleteRecursively() }

--- a/io/io/src/test/kotlin/io/bluetape4k/io/FileSupportTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/FileSupportTest.kt
@@ -19,7 +19,7 @@ import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
-import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.ConcurrentLinkedQueue
 
 @RandomizedTest
 @TempFolderTest
@@ -135,7 +135,7 @@ class FileSupportTest: AbstractIOTest() {
 
     @Test
     fun `createTempDirectory는 동시 호출에서도 충돌 없이 고유한 디렉토리를 생성한다`() {
-        val created = CopyOnWriteArrayList<String>()
+        val created = ConcurrentLinkedQueue<String>()
         try {
             MultithreadingTester()
                 .workers(8)
@@ -146,8 +146,9 @@ class FileSupportTest: AbstractIOTest() {
                 }
                 .run()
 
-            created.toSet().size shouldBeEqualTo created.size  // all paths unique
-            created.all { java.io.File(it).isDirectory }.shouldBeTrue()
+            val paths = created.toList()
+            paths.toSet().size shouldBeEqualTo paths.size  // all paths unique
+            paths.all { java.io.File(it).isDirectory }.shouldBeTrue()
         } finally {
             created.forEach { java.io.File(it).deleteRecursively() }
         }

--- a/io/io/src/test/kotlin/io/bluetape4k/io/FileSupportTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/FileSupportTest.kt
@@ -12,9 +12,15 @@ import io.bluetape4k.logging.debug
 import kotlinx.coroutines.future.await
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 @RandomizedTest
 @TempFolderTest
@@ -100,5 +106,54 @@ class FileSupportTest: AbstractIOTest() {
         path.writeAsync("abc".toByteArray(), append = false).join()
 
         path.readAllBytesAsync().join().decodeToString() shouldBeEqualTo "abc"
+    }
+
+    @Test
+    fun `createTempDirectory는 존재하는 디렉토리를 원자적으로 생성한다`() {
+        val dir = createTempDirectory(prefix = "test-atomic-", deleteAtExit = false)
+        try {
+            dir.shouldNotBeNull()
+            dir.exists().shouldBeTrue()
+            dir.isDirectory.shouldBeTrue()
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `createTempDirectory는 서로 다른 고유한 경로를 반환한다`() {
+        val dir1 = createTempDirectory(prefix = "test-unique-", deleteAtExit = false)
+        val dir2 = createTempDirectory(prefix = "test-unique-", deleteAtExit = false)
+        try {
+            dir1.canonicalPath shouldNotBeEqualTo dir2.canonicalPath
+            dir1.isDirectory.shouldBeTrue()
+            dir2.isDirectory.shouldBeTrue()
+        } finally {
+            dir1.deleteRecursively()
+            dir2.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `createTempDirectory는 동시 호출에서도 충돌 없이 고유한 디렉토리를 생성한다`() {
+        val count = 50
+        val created = CopyOnWriteArrayList<String>()
+        val executor = Executors.newFixedThreadPool(8)
+        try {
+            repeat(count) {
+                executor.submit {
+                    val dir = createTempDirectory(prefix = "test-concurrent-", deleteAtExit = false)
+                    created.add(dir.canonicalPath)
+                }
+            }
+            executor.shutdown()
+            executor.awaitTermination(10, TimeUnit.SECONDS)
+
+            created.size shouldBeEqualTo count
+            created.toSet().size shouldBeEqualTo count  // all paths unique
+            created.all { java.io.File(it).isDirectory }.shouldBeTrue()
+        } finally {
+            created.forEach { java.io.File(it).deleteRecursively() }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #479

- PR 제목: fix: replace TOCTOU createTempDirectory with atomic Files.createTempDirectory (#479)

Closes #479

`createTempDirectory` used `File.createTempFile` + `deleteRecursively` + `mkdirs` — a three-step sequence with a TOCTOU race window and unchecked return values.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

Replace with the JDK atomic API:

```kotlin
// BEFORE (racy)
val dir = File.createTempFile(prefix, suffix)
dir.deleteRecursively()  // return value ignored
dir.mkdirs()             // return value ignored

// AFTER (atomic)
val dir = Files.createTempDirectory(prefix).toFile()
```

The `suffix` parameter is retained for API compatibility but is now ignored. KDoc documents this behavioral change.

| File | Change |
|------|--------|
| `io/io/src/main/kotlin/.../FileSupport.kt` | Atomic fix; English KDoc with behavioral notes |
| `io/io/src/test/kotlin/.../FileSupportTest.kt` | 3 new tests (atomic, sequential unique, 50-thread concurrent) |
| `docs/lessons/2026-05-16-create-temp-directory-toctou.md` | Lessons document |

### 기존 섹션: DoD Checklist

| Item | Status |
|------|--------|
| All tests passing | ✅ |
| Tier 4 code review (CRITICAL/HIGH@HIGH-confidence = 0) | ✅ |
| English KDoc updated | ✅ |
| Lessons committed | ✅ |
| README locale set synced | ⏭️ N/A |

## Validation

```
FileSupportTest  16 passing (2.1s) — BUILD SUCCESSFUL
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #479, milestone 없음, assignee `debop`
- PR: #509, head `f3674840169c28fb818b16a4f36bccc97fc45a2d`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/create-temp-directory`
- Labels: 없음
- State: `MERGED`, merge commit `cfc4a1343e5cea9dc4fb1ea9b1fcb0eb1806de82`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #509 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `cfc4a1343e5cea9dc4fb1ea9b1fcb0eb1806de82`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
