### PR TITLE
fix: KafkaCodec type header allowlist — emptySet now denies all (secure default)

### DIFF
--- a/docs/lessons/2026-05-16-kafka-codec-type-allowlist.md
+++ b/docs/lessons/2026-05-16-kafka-codec-type-allowlist.md
@@ -1,0 +1,63 @@
+# KafkaCodec 타입 허용 목록(allowlist) 보안 강화
+
+## 날짜
+
+2026-05-16
+
+## 관련 이슈
+
+- #481 (KafkaCodec type header allowlist)
+- #471 (Release 1.8.0 hard blockers)
+
+## 근본 원인
+
+`AbstractKafkaCodec.getValueType()`은 Kafka 메시지 헤더의 `bluetape4k.kafka.codec.value.type` 값을 기반으로
+`Class.forName()`을 호출해 클래스를 동적으로 로드한다.
+
+기존 구현에서는 `allowedTypePackages = emptySet()`가 **모든 클래스를 허용**하는 동작으로 설계되었다.
+이는 신뢰할 수 없는 Kafka 브로커나 외부 네트워크에서 수신된 메시지에 임의 클래스 로딩(RCE) 취약점을 유발할 수 있다.
+
+## 결정
+
+`emptySet()` 기본값의 의미를 **deny all (모든 클래스 차단)** 으로 변경한다.
+
+| 설정 | 1.8.0 이전 | 1.8.0+ |
+|------|-----------|--------|
+| `emptySet()` | 모든 클래스 허용 (unsafe) | 모든 클래스 차단 (secure default) |
+| 특정 패키지 집합 | 허용 목록만 허용 | 동일 |
+| `ALLOW_ALL_TYPES_UNSAFE` | — | 구 동작 복원 (opt-in) |
+
+## 구현 변경
+
+### `AbstractKafkaCodec`
+
+- `ALLOW_ALL_TYPES_UNSAFE = setOf("*")` companion 상수 추가 — 구 동작 opt-in 시 사용
+- `getValueType()` 로직 수정: `"*"` → bypass, `emptySet()` → deny all, 비어 있지 않은 집합 → 패키지 접두사 검사
+
+### `JacksonKafkaCodec`
+
+- `allowedTypePackages: Set<String> = emptySet()` 생성자 파라미터로 노출
+- `final` 클래스 유지 (서브클래싱 대신 생성자 파라미터로 구성)
+
+## 발견된 설계 실수
+
+초기 테스트 작성 시 `JacksonKafkaCodec`을 anonymous object로 서브클래싱하려 했으나
+Kotlin의 기본 `final` 클래스 제한으로 컴파일 오류 발생.
+생성자 파라미터를 통한 구성 방식이 더 명확하고 관용적인 패턴이다.
+
+## 검증
+
+- `JacksonKafkaCodecSecurityTest` (kafka3, kafka4) 신규 추가: 4개 보안 테스트
+  1. emptySet 기본값 → 헤더 클래스 거부 → null 반환
+  2. 명시적 패키지 허용 → 정상 역직렬화
+  3. ALLOW_ALL_TYPES_UNSAFE opt-in → 구 동작 복원
+  4. 허용 목록 외 패키지 → 거부 → null 반환
+- `KafkaCodecTest.JacksonCodecTest` 업데이트: `allowedTypePackages = setOf("io.bluetape4k.kafka.codec")`
+- `KafkaCodecAllowlistTest` (kafka4) 업데이트: 첫 번째 테스트 기대값 수정 (deny-all 반영)
+- kafka3: 112 passing, kafka4: 117 passing
+
+## 향후 지침
+
+- `JacksonKafkaCodec` 사용 시 `allowedTypePackages`를 명시적으로 지정하는 것을 권장
+- Spring Bean 등록 시 `KafkaCodecs.Jackson` 싱글톤 대신 직접 생성하여 패키지 목록을 지정하라
+- 신뢰할 수 있는 내부 환경에서만 `ALLOW_ALL_TYPES_UNSAFE`를 사용하라

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodec.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodec.kt
@@ -7,20 +7,25 @@ import io.bluetape4k.support.emptyByteArray
 import org.apache.kafka.common.header.Headers
 
 /**
- * Kafka 키나 메시지를 JSON으로 직렬화/역직렬화하는 Kafka Codec
+ * Kafka codec that serializes and deserializes messages as JSON using Jackson.
  *
  * ```kotlin
- * val codec = JacksonKafkaCodec()
- * val data = mapOf("id" to 1, "name" to "debop")
- * val bytes = codec.serialize("my-topic", null, data)
- * val result = codec.deserialize("my-topic", null, bytes)
- * // result is a Map with id=1, name="debop"
+ * // Safe: only allow DTOs in your own package
+ * val codec = JacksonKafkaCodec(allowedTypePackages = setOf("com.example.dto"))
+ * val bytes = codec.serialize("my-topic", null, MyDto("hello"))
+ * val result = codec.deserialize("my-topic", null, bytes) as MyDto
+ *
+ * // Unsafe legacy mode (allow any class from the header)
+ * val legacyCodec = JacksonKafkaCodec(allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE)
  * ```
  *
- * @param mapper Jackson [JsonMapper] 인스턴스
+ * @param mapper Jackson [JsonMapper] instance
+ * @param allowedTypePackages package prefix allowlist for class loading from the type header;
+ *   empty set (default) denies all — safe for untrusted topics
  */
 class JacksonKafkaCodec(
     private val mapper: JsonMapper = Jackson.defaultJsonMapper,
+    override val allowedTypePackages: Set<String> = emptySet(),
 ): AbstractKafkaCodec<Any?>() {
 
     override fun doSerialize(topic: String?, headers: Headers?, graph: Any?): ByteArray {

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
@@ -93,22 +93,25 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
     /**
      * Package prefix allowlist for types loaded from the [VALUE_TYPE_KEY] header.
      *
+     * Each entry is matched against the incoming class name as follows:
+     * - **Exact match**: `clazzName == entry` — allows a specific fully-qualified class name.
+     * - **Package prefix**: `clazzName.startsWith("$entry.")` — allows all classes under that package.
+     *
+     * Semantics by value:
      * - **Empty set (default)**: deny all — no class is loaded from the header.
-     *   This is the safe default for untrusted or shared Kafka topics.
-     * - **Non-empty set**: allow only classes whose fully-qualified name equals one of
-     *   the entries or starts with `"<entry>."`.
-     * - **[ALLOW_ALL_TYPES_UNSAFE]**: bypass all checks (pre-1.8.0 behavior, unsafe).
+     *   Safe default for untrusted or shared Kafka topics.
+     * - **Non-empty set**: allow only classes whose FQN exactly equals or starts with `"<entry>."`.
+     * - **[ALLOW_ALL_TYPES_UNSAFE]**: bypass all checks (pre-1.8.0 allow-all behavior, unsafe).
      *
      * ```kotlin
-     * // Safe: only allow DTOs in your own package
-     * class SecureJacksonCodec : JacksonKafkaCodec() {
-     *     override val allowedTypePackages = setOf("com.example.dto", "io.bluetape4k.domain")
-     * }
+     * // Safe: allow all DTOs under a specific package
+     * val codec = JacksonKafkaCodec(allowedTypePackages = setOf("com.example.dto"))
      *
-     * // Unsafe (legacy): allow any class from the header
-     * class LegacyJacksonCodec : JacksonKafkaCodec() {
-     *     override val allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
-     * }
+     * // Also safe: allow only one specific class
+     * val singleClass = JacksonKafkaCodec(allowedTypePackages = setOf("com.example.dto.OrderEvent"))
+     *
+     * // Unsafe legacy mode (opt-in only)
+     * val legacy = JacksonKafkaCodec(allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE)
      * ```
      */
     open val allowedTypePackages: Set<String> = emptySet()
@@ -203,6 +206,10 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
             if (allowedTypePackages.isEmpty() ||
                 allowedTypePackages.none { clazzName == it || clazzName.startsWith("$it.") }
             ) {
+                log.warn {
+                    "[SECURITY] Rejected class '$clazzName' from Kafka header — not in allowedTypePackages=$allowedTypePackages. " +
+                    "If intentional, add the package to allowedTypePackages or use ALLOW_ALL_TYPES_UNSAFE (unsafe)."
+                }
                 throw IllegalArgumentException(
                     "Class '$clazzName' is not in allowedTypePackages=$allowedTypePackages. " +
                     "Add the package to allowedTypePackages, or set allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE " +

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
@@ -71,19 +71,43 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
     companion object: KLogging() {
         const val VALUE_TYPE_KEY = "$LibraryName.kafka.codec.value.type"
 
+        /**
+         * Sentinel value for [allowedTypePackages] that bypasses all package checks.
+         *
+         * Use only in fully trusted, internal deployments where all Kafka producers are
+         * controlled. Assigning this constant re-enables the pre-1.8.0 allow-all behavior.
+         *
+         * ```kotlin
+         * class LegacyJacksonCodec : JacksonKafkaCodec() {
+         *     override val allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
+         * }
+         * ```
+         */
+        @JvmField
+        val ALLOW_ALL_TYPES_UNSAFE: Set<String> = setOf("*")
+
         @JvmStatic
         fun defaultCodec(): KafkaCodec<Any?> = JacksonKafkaCodec()
     }
 
     /**
-     * 헤더에서 로드를 허용하는 클래스 패키지 접두사 목록.
+     * Package prefix allowlist for types loaded from the [VALUE_TYPE_KEY] header.
      *
-     * - **빈 집합(기본값)**: 모든 클래스 허용 (하위 호환, 신뢰 환경 전용)
-     * - **비어 있지 않은 집합**: 나열된 패키지로 시작하는 클래스만 허용 (권장, 보안 환경)
+     * - **Empty set (default)**: deny all — no class is loaded from the header.
+     *   This is the safe default for untrusted or shared Kafka topics.
+     * - **Non-empty set**: allow only classes whose fully-qualified name equals one of
+     *   the entries or starts with `"<entry>."`.
+     * - **[ALLOW_ALL_TYPES_UNSAFE]**: bypass all checks (pre-1.8.0 behavior, unsafe).
      *
      * ```kotlin
-     * class SecureJacksonCodec: JacksonKafkaCodec() {
+     * // Safe: only allow DTOs in your own package
+     * class SecureJacksonCodec : JacksonKafkaCodec() {
      *     override val allowedTypePackages = setOf("com.example.dto", "io.bluetape4k.domain")
+     * }
+     *
+     * // Unsafe (legacy): allow any class from the header
+     * class LegacyJacksonCodec : JacksonKafkaCodec() {
+     *     override val allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
      * }
      * ```
      */
@@ -174,12 +198,17 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
             headers?.lastHeader(VALUE_TYPE_KEY)?.value()?.toUtf8String()
                 ?: return Any::class.java
 
-        if (allowedTypePackages.isNotEmpty() &&
-            allowedTypePackages.none { clazzName == it || clazzName.startsWith("$it.") }
-        ) {
-            throw IllegalArgumentException(
-                "클래스 '$clazzName'은 허용된 패키지 목록에 없습니다. allowedTypePackages=$allowedTypePackages"
-            )
+        // "*" sentinel bypasses all checks (ALLOW_ALL_TYPES_UNSAFE)
+        if (!allowedTypePackages.contains("*")) {
+            if (allowedTypePackages.isEmpty() ||
+                allowedTypePackages.none { clazzName == it || clazzName.startsWith("$it.") }
+            ) {
+                throw IllegalArgumentException(
+                    "Class '$clazzName' is not in allowedTypePackages=$allowedTypePackages. " +
+                    "Add the package to allowedTypePackages, or set allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE " +
+                    "to allow all types (unsafe)."
+                )
+            }
         }
 
         if (!classIsPresent(clazzName)) {

--- a/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodecSecurityTest.kt
+++ b/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodecSecurityTest.kt
@@ -1,0 +1,91 @@
+package io.bluetape4k.kafka.codec
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.KLogging
+import org.apache.kafka.common.header.internals.RecordHeaders
+import org.junit.jupiter.api.Test
+
+/**
+ * Security tests for [JacksonKafkaCodec] type allowlist enforcement.
+ *
+ * Verifies that:
+ * - Untrusted class names in the `VALUE_TYPE_KEY` header are rejected by default (empty allowedTypePackages)
+ * - Explicitly allowed packages are deserialized correctly
+ * - [AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE] opt-in restores legacy allow-all behavior
+ */
+class JacksonKafkaCodecSecurityTest {
+
+    companion object: KLogging()
+
+    private data class TrustedDto(val value: String)
+
+    @Test
+    fun `untrusted header class is rejected when allowedTypePackages is empty`() {
+        val codec = JacksonKafkaCodec() // default: allowedTypePackages = emptySet()
+
+        val writingCodec = JacksonKafkaCodec(
+            allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
+        )
+        val headers = RecordHeaders()
+        val dto = TrustedDto("hello")
+        val bytes = writingCodec.serialize("topic", headers, dto)
+        bytes.shouldNotBeNull()
+
+        // empty allowedTypePackages → rejected → null (poison-pill)
+        val result = codec.deserialize("topic", headers, bytes)
+        result.shouldBeNull()
+    }
+
+    @Test
+    fun `allowed package is deserialized correctly`() {
+        val codec = JacksonKafkaCodec(
+            allowedTypePackages = setOf("io.bluetape4k.kafka.codec")
+        )
+
+        val headers = RecordHeaders()
+        val dto = TrustedDto("world")
+        val bytes = codec.serialize("topic", headers, dto)
+        bytes.shouldNotBeNull()
+
+        val result = codec.deserialize("topic", headers, bytes) as TrustedDto
+        result.shouldNotBeNull()
+        result.value shouldBeEqualTo "world"
+    }
+
+    @Test
+    fun `ALLOW_ALL_TYPES_UNSAFE opt-in restores legacy behavior`() {
+        val codec = JacksonKafkaCodec(
+            allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
+        )
+
+        val headers = RecordHeaders()
+        val dto = TrustedDto("unsafe-but-intentional")
+        val bytes = codec.serialize("topic", headers, dto)
+        bytes.shouldNotBeNull()
+
+        val result = codec.deserialize("topic", headers, bytes) as TrustedDto
+        result.shouldNotBeNull()
+        result.value shouldBeEqualTo "unsafe-but-intentional"
+    }
+
+    @Test
+    fun `class outside allowedTypePackages is rejected`() {
+        val writingCodec = JacksonKafkaCodec(
+            allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
+        )
+        val readingCodec = JacksonKafkaCodec(
+            allowedTypePackages = setOf("com.example.trusted")
+        )
+
+        val headers = RecordHeaders()
+        val dto = TrustedDto("blocked")
+        val bytes = writingCodec.serialize("topic", headers, dto)
+        bytes.shouldNotBeNull()
+
+        // io.bluetape4k.kafka.codec not in com.example.trusted → rejected → null
+        val result = readingCodec.deserialize("topic", headers, bytes)
+        result.shouldBeNull()
+    }
+}

--- a/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/codec/KafkaCodecTest.kt
+++ b/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/codec/KafkaCodecTest.kt
@@ -6,7 +6,9 @@ class KafkaCodecTest {
 
     @Nested
     inner class JacksonCodecTest: AbstractKafkaCodecTest() {
-        override val codec: KafkaCodec<Any?> = KafkaCodecs.Jackson
+        override val codec: KafkaCodec<Any?> = JacksonKafkaCodec(
+            allowedTypePackages = setOf("io.bluetape4k.kafka.codec")
+        )
     }
 
     @Nested

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodec.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodec.kt
@@ -6,20 +6,25 @@ import org.apache.kafka.common.header.Headers
 import tools.jackson.databind.json.JsonMapper
 
 /**
- * Kafka 키나 메시지를 JSON으로 직렬화/역직렬화하는 Kafka Codec
+ * Kafka codec that serializes and deserializes messages as JSON using Jackson.
  *
  * ```kotlin
- * val codec = JacksonKafkaCodec()
- * val data = mapOf("id" to 1, "name" to "debop")
- * val bytes = codec.serialize("my-topic", null, data)
- * val result = codec.deserialize("my-topic", null, bytes)
- * // result is a Map with id=1, name="debop"
+ * // Safe: only allow DTOs in your own package
+ * val codec = JacksonKafkaCodec(allowedTypePackages = setOf("com.example.dto"))
+ * val bytes = codec.serialize("my-topic", null, MyDto("hello"))
+ * val result = codec.deserialize("my-topic", null, bytes) as MyDto
+ *
+ * // Unsafe legacy mode (allow any class from the header)
+ * val legacyCodec = JacksonKafkaCodec(allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE)
  * ```
  *
- * @param mapper Jackson [JsonMapper] 인스턴스
+ * @param mapper Jackson [JsonMapper] instance
+ * @param allowedTypePackages package prefix allowlist for class loading from the type header;
+ *   empty set (default) denies all — safe for untrusted topics
  */
 class JacksonKafkaCodec(
     private val mapper: JsonMapper = Jackson.defaultJsonMapper,
+    override val allowedTypePackages: Set<String> = emptySet(),
 ): AbstractKafkaCodec<Any?>() {
 
     override fun doSerialize(topic: String?, headers: Headers?, graph: Any?): ByteArray {

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
@@ -93,22 +93,25 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
     /**
      * Package prefix allowlist for types loaded from the [VALUE_TYPE_KEY] header.
      *
+     * Each entry is matched against the incoming class name as follows:
+     * - **Exact match**: `clazzName == entry` — allows a specific fully-qualified class name.
+     * - **Package prefix**: `clazzName.startsWith("$entry.")` — allows all classes under that package.
+     *
+     * Semantics by value:
      * - **Empty set (default)**: deny all — no class is loaded from the header.
-     *   This is the safe default for untrusted or shared Kafka topics.
-     * - **Non-empty set**: allow only classes whose fully-qualified name equals one of
-     *   the entries or starts with `"<entry>."`.
-     * - **[ALLOW_ALL_TYPES_UNSAFE]**: bypass all checks (pre-1.8.0 behavior, unsafe).
+     *   Safe default for untrusted or shared Kafka topics.
+     * - **Non-empty set**: allow only classes whose FQN exactly equals or starts with `"<entry>."`.
+     * - **[ALLOW_ALL_TYPES_UNSAFE]**: bypass all checks (pre-1.8.0 allow-all behavior, unsafe).
      *
      * ```kotlin
-     * // Safe: only allow DTOs in your own package
-     * class SecureJacksonCodec : JacksonKafkaCodec() {
-     *     override val allowedTypePackages = setOf("com.example.dto", "io.bluetape4k.domain")
-     * }
+     * // Safe: allow all DTOs under a specific package
+     * val codec = JacksonKafkaCodec(allowedTypePackages = setOf("com.example.dto"))
      *
-     * // Unsafe (legacy): allow any class from the header
-     * class LegacyJacksonCodec : JacksonKafkaCodec() {
-     *     override val allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
-     * }
+     * // Also safe: allow only one specific class
+     * val singleClass = JacksonKafkaCodec(allowedTypePackages = setOf("com.example.dto.OrderEvent"))
+     *
+     * // Unsafe legacy mode (opt-in only)
+     * val legacy = JacksonKafkaCodec(allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE)
      * ```
      */
     open val allowedTypePackages: Set<String> = emptySet()
@@ -203,6 +206,10 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
             if (allowedTypePackages.isEmpty() ||
                 allowedTypePackages.none { clazzName == it || clazzName.startsWith("$it.") }
             ) {
+                log.warn {
+                    "[SECURITY] Rejected class '$clazzName' from Kafka header — not in allowedTypePackages=$allowedTypePackages. " +
+                    "If intentional, add the package to allowedTypePackages or use ALLOW_ALL_TYPES_UNSAFE (unsafe)."
+                }
                 throw IllegalArgumentException(
                     "Class '$clazzName' is not in allowedTypePackages=$allowedTypePackages. " +
                     "Add the package to allowedTypePackages, or set allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE " +

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
@@ -71,19 +71,43 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
     companion object: KLogging() {
         const val VALUE_TYPE_KEY = "$LibraryName.kafka.codec.value.type"
 
+        /**
+         * Sentinel value for [allowedTypePackages] that bypasses all package checks.
+         *
+         * Use only in fully trusted, internal deployments where all Kafka producers are
+         * controlled. Assigning this constant re-enables the pre-1.8.0 allow-all behavior.
+         *
+         * ```kotlin
+         * class LegacyJacksonCodec : JacksonKafkaCodec() {
+         *     override val allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
+         * }
+         * ```
+         */
+        @JvmField
+        val ALLOW_ALL_TYPES_UNSAFE: Set<String> = setOf("*")
+
         @JvmStatic
         fun defaultCodec(): KafkaCodec<Any?> = JacksonKafkaCodec()
     }
 
     /**
-     * 헤더에서 로드를 허용하는 클래스 패키지 접두사 목록.
+     * Package prefix allowlist for types loaded from the [VALUE_TYPE_KEY] header.
      *
-     * - **빈 집합(기본값)**: 모든 클래스 허용 (하위 호환, 신뢰 환경 전용)
-     * - **비어 있지 않은 집합**: 나열된 패키지로 시작하는 클래스만 허용 (권장, 보안 환경)
+     * - **Empty set (default)**: deny all — no class is loaded from the header.
+     *   This is the safe default for untrusted or shared Kafka topics.
+     * - **Non-empty set**: allow only classes whose fully-qualified name equals one of
+     *   the entries or starts with `"<entry>."`.
+     * - **[ALLOW_ALL_TYPES_UNSAFE]**: bypass all checks (pre-1.8.0 behavior, unsafe).
      *
      * ```kotlin
-     * class SecureJacksonCodec: JacksonKafkaCodec() {
+     * // Safe: only allow DTOs in your own package
+     * class SecureJacksonCodec : JacksonKafkaCodec() {
      *     override val allowedTypePackages = setOf("com.example.dto", "io.bluetape4k.domain")
+     * }
+     *
+     * // Unsafe (legacy): allow any class from the header
+     * class LegacyJacksonCodec : JacksonKafkaCodec() {
+     *     override val allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
      * }
      * ```
      */
@@ -174,12 +198,17 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
             headers?.lastHeader(VALUE_TYPE_KEY)?.value()?.toUtf8String()
                 ?: return Any::class.java
 
-        if (allowedTypePackages.isNotEmpty() &&
-            allowedTypePackages.none { clazzName == it || clazzName.startsWith("$it.") }
-        ) {
-            throw IllegalArgumentException(
-                "클래스 '$clazzName'은 허용된 패키지 목록에 없습니다. allowedTypePackages=$allowedTypePackages"
-            )
+        // "*" sentinel bypasses all checks (ALLOW_ALL_TYPES_UNSAFE)
+        if (!allowedTypePackages.contains("*")) {
+            if (allowedTypePackages.isEmpty() ||
+                allowedTypePackages.none { clazzName == it || clazzName.startsWith("$it.") }
+            ) {
+                throw IllegalArgumentException(
+                    "Class '$clazzName' is not in allowedTypePackages=$allowedTypePackages. " +
+                    "Add the package to allowedTypePackages, or set allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE " +
+                    "to allow all types (unsafe)."
+                )
+            }
         }
 
         if (!classIsPresent(clazzName)) {

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodecSecurityTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodecSecurityTest.kt
@@ -1,0 +1,91 @@
+package io.bluetape4k.kafka.codec
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.KLogging
+import org.apache.kafka.common.header.internals.RecordHeaders
+import org.junit.jupiter.api.Test
+
+/**
+ * Security tests for [JacksonKafkaCodec] type allowlist enforcement.
+ *
+ * Verifies that:
+ * - Untrusted class names in the `VALUE_TYPE_KEY` header are rejected by default (empty allowedTypePackages)
+ * - Explicitly allowed packages are deserialized correctly
+ * - [AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE] opt-in restores legacy allow-all behavior
+ */
+class JacksonKafkaCodecSecurityTest {
+
+    companion object: KLogging()
+
+    private data class TrustedDto(val value: String)
+
+    @Test
+    fun `untrusted header class is rejected when allowedTypePackages is empty`() {
+        val codec = JacksonKafkaCodec() // default: allowedTypePackages = emptySet()
+
+        val writingCodec = JacksonKafkaCodec(
+            allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
+        )
+        val headers = RecordHeaders()
+        val dto = TrustedDto("hello")
+        val bytes = writingCodec.serialize("topic", headers, dto)
+        bytes.shouldNotBeNull()
+
+        // empty allowedTypePackages → rejected → null (poison-pill)
+        val result = codec.deserialize("topic", headers, bytes)
+        result.shouldBeNull()
+    }
+
+    @Test
+    fun `allowed package is deserialized correctly`() {
+        val codec = JacksonKafkaCodec(
+            allowedTypePackages = setOf("io.bluetape4k.kafka.codec")
+        )
+
+        val headers = RecordHeaders()
+        val dto = TrustedDto("world")
+        val bytes = codec.serialize("topic", headers, dto)
+        bytes.shouldNotBeNull()
+
+        val result = codec.deserialize("topic", headers, bytes) as TrustedDto
+        result.shouldNotBeNull()
+        result.value shouldBeEqualTo "world"
+    }
+
+    @Test
+    fun `ALLOW_ALL_TYPES_UNSAFE opt-in restores legacy behavior`() {
+        val codec = JacksonKafkaCodec(
+            allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
+        )
+
+        val headers = RecordHeaders()
+        val dto = TrustedDto("unsafe-but-intentional")
+        val bytes = codec.serialize("topic", headers, dto)
+        bytes.shouldNotBeNull()
+
+        val result = codec.deserialize("topic", headers, bytes) as TrustedDto
+        result.shouldNotBeNull()
+        result.value shouldBeEqualTo "unsafe-but-intentional"
+    }
+
+    @Test
+    fun `class outside allowedTypePackages is rejected`() {
+        val writingCodec = JacksonKafkaCodec(
+            allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
+        )
+        val readingCodec = JacksonKafkaCodec(
+            allowedTypePackages = setOf("com.example.trusted")
+        )
+
+        val headers = RecordHeaders()
+        val dto = TrustedDto("blocked")
+        val bytes = writingCodec.serialize("topic", headers, dto)
+        bytes.shouldNotBeNull()
+
+        // io.bluetape4k.kafka.codec not in com.example.trusted → rejected → null
+        val result = readingCodec.deserialize("topic", headers, bytes)
+        result.shouldBeNull()
+    }
+}

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/KafkaCodecAllowlistTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/KafkaCodecAllowlistTest.kt
@@ -11,11 +11,11 @@ import org.junit.jupiter.api.Test
 import tools.jackson.databind.json.JsonMapper
 
 /**
- * [AbstractKafkaCodec.allowedTypePackages] 허용 목록 검증 테스트 (#296/#303).
+ * [AbstractKafkaCodec.allowedTypePackages] allowlist validation tests.
  *
- * - emptySet() 기본값: 모든 클래스 허용 (하위 호환)
- * - 허용 패키지 지정 시: 목록 외 클래스 → IllegalArgumentException → deserialize null 반환 (poison-pill)
- * - 허용 패키지에 속하는 클래스: 정상 처리
+ * - emptySet() default: deny all — no class is loaded from the header (secure default since 1.8.0)
+ * - Non-empty allowedTypePackages: only matching classes are allowed; others → IllegalArgumentException → null (poison-pill)
+ * - [AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE]: bypass all checks (pre-1.8.0 allow-all, unsafe)
  */
 class KafkaCodecAllowlistTest {
 
@@ -40,14 +40,15 @@ class KafkaCodecAllowlistTest {
     data class SimpleMessage(val content: String)
 
     @Test
-    fun `emptySet 기본값 - 모든 클래스 허용`() {
-        val codec = TestJsonCodec()
+    fun `emptySet 기본값 - 모든 클래스 차단 (deny-all secure default)`() {
+        val codec = TestJsonCodec() // emptySet → deny all
         val headers = RecordHeaders()
         val data = SimpleMessage("hello")
         val bytes = codec.serialize(topic, headers, data)
 
+        // emptySet() means deny all: class name in header is rejected → null (poison-pill)
         val result = codec.deserialize(topic, headers, bytes)
-        result.shouldNotBeNull()
+        result.shouldBeNull()
     }
 
     @Test

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/KafkaCodecTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/KafkaCodecTest.kt
@@ -6,7 +6,9 @@ class KafkaCodecTest {
 
     @Nested
     inner class JacksonCodecTest: AbstractKafkaCodecTest() {
-        override val codec: KafkaCodec<Any?> = KafkaCodecs.Jackson
+        override val codec: KafkaCodec<Any?> = JacksonKafkaCodec(
+            allowedTypePackages = setOf("io.bluetape4k.kafka.codec")
+        )
     }
 
     @Nested


### PR DESCRIPTION
## Summary

Closes #481

- PR 제목: fix: KafkaCodec type header allowlist — emptySet now denies all (secure default)

### 원문 선행 내용

Fixes #481 (part of #471 — Release 1.8.0 hard blockers).

## Background

`AbstractKafkaCodec.getValueType()` dynamically loads classes from the `bluetape4k.kafka.codec.value.type` Kafka message header via `Class.forName()`. The previous implementation treated `allowedTypePackages = emptySet()` as **allow-all**, enabling arbitrary class-loading (RCE) from untrusted brokers.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

| File | Change |
|------|--------|
| `AbstractKafkaCodec` (kafka3 + kafka4) | `ALLOW_ALL_TYPES_UNSAFE = setOf("*")` sentinel; `emptySet()` now denies all |
| `JacksonKafkaCodec` (kafka3 + kafka4) | `allowedTypePackages` exposed as constructor param |
| `KafkaCodecTest` (kafka3 + kafka4) | `JacksonCodecTest` passes explicit `allowedTypePackages` |
| `KafkaCodecAllowlistTest` (kafka4) | Updated deny-all test expectation |
| `JacksonKafkaCodecSecurityTest` (kafka3 + kafka4) | New — 4 security tests per module |
| `docs/lessons/2026-05-16-kafka-codec-type-allowlist.md` | Lessons document |

### 기존 섹션: New semantics

| Setting | Before 1.8.0 | 1.8.0+ |
|---------|--------------|--------|
| `emptySet()` | allow all (unsafe) | deny all (secure default) |
| specific packages | allowlist | same |
| `ALLOW_ALL_TYPES_UNSAFE` | — | legacy opt-in |

### 기존 섹션: Migration

```kotlin
// Safe: specify trusted packages
val codec = JacksonKafkaCodec(allowedTypePackages = setOf("com.example.dto"))

// Legacy allow-all (unsafe, opt-in only)
val legacyCodec = JacksonKafkaCodec(allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE)
```

## Validation

- kafka3: `./gradlew :bluetape4k-kafka:test --tests "io.bluetape4k.kafka.codec.*"` → **112 passing**
- kafka4: `./gradlew :bluetape4k-kafka4:test --tests "io.bluetape4k.kafka.codec.*"` → **117 passing**

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #481, milestone 없음, assignee `debop`
- PR: #510, head `09697338f290d749df8965d67a76dc1fb3f7ee29`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/kafka-codec-type-allowlist`
- Labels: 없음
- State: `MERGED`, merge commit `dc9ba24dce1454636feffd411a244ed2996187fd`
- CI: | `KafkaCodecTest` (kafka3 + kafka4) | `JacksonCodecTest` passes explicit `allowedTypePackages` | / | specific packages | allowlist | same | / // Safe: specify trusted packages

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #510 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `dc9ba24dce1454636feffd411a244ed2996187fd`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
