### PR TITLE
fix: fix BatchListenerFailedException DLT routing in Spring Kafka 3.3 (#472)

### DIFF
--- a/docs/lessons/2026-05-16-issue-472-batch-listener-dlt-routing.md
+++ b/docs/lessons/2026-05-16-issue-472-batch-listener-dlt-routing.md
@@ -1,0 +1,85 @@
+# Issue #472: BatchListenerFailedException DLT 라우팅 수정
+
+**날짜**: 2026-05-16
+**브랜치**: `fix/batch-listener-dlt-routing`
+**관련 이슈**: #472
+
+## 루트 원인
+
+### 원인 1: Spring Kafka 3.3 DLT 토픽 suffix 변경
+
+Spring Kafka 3.3에서 `DeadLetterPublishingRecoverer`의 기본 DLT 토픽 suffix가 변경되었다:
+
+| 버전 | 기본 suffix | 예시 |
+|------|------------|------|
+| Spring Kafka 3.2 이전 | `.DLT` (대문자, 점) | `blc6.DLT` |
+| Spring Kafka 3.3+ | `-dlt` (소문자, 하이픈) | `blc6-dlt` |
+
+`DeadLetterPublishingRecoverer` 소스:
+```java
+DEFAULT_DESTINATION_RESOLVER = (cr, e) -> new TopicPartition(cr.topic() + "-dlt", cr.partition());
+```
+
+테스트는 `blc6.DLT` 토픽을 구독하고 있었지만, recoverer는 `blc6-dlt`로 발행했다.
+→ DLT 메시지가 consume되지 않아 latch2가 countdown되지 않음.
+
+### 원인 2: DefaultErrorHandler 재시도 횟수 초과
+
+`DefaultErrorHandler` 기본값: `FixedBackOff(0, 9)` = 10번 시도.  
+`FETCH_MAX_WAIT_MS=500ms` × 10번 = ~5초 > 테스트 타임아웃 3초.
+
+DLT 라우팅이 3초 내에 완료되지 못해 `latch2.await(3s)`가 timeout 반환.
+
+## 디버깅 방법
+
+Spring Kafka 로그에서 DLT 발행 성공 메시지 확인:
+```
+DEBUG DeadLetterPublishingRecoverer: Successful dead-letter publication: blc6-0@1 to blc6-dlt-0@0
+```
+
+`blc6-dlt-0@0` 형식 = `<topic>-<partition>@<offset>` → DLT 토픽이 `blc6-dlt`임을 알 수 있다.
+
+## 수정 사항
+
+### 1. DLT 토픽 이름 업데이트
+
+```diff
+-@EmbeddedKafka(..., topics = ["blc6", "blc6.DLT"])
++@EmbeddedKafka(..., topics = ["blc6", "blc6-dlt"])
+
+-@KafkaListener(topics = ["blc6.DLT"], groupId = "blc6.DLT", ...)
++@KafkaListener(topics = ["blc6-dlt"], groupId = "blc6-dlt", ...)
+```
+
+### 2. 즉시 DLT 라우팅 설정
+
+```diff
+-val errorHandler = DefaultErrorHandler(DeadLetterPublishingRecoverer(template))
++val errorHandler = DefaultErrorHandler(DeadLetterPublishingRecoverer(template), FixedBackOff(0L, 0L))
+```
+
+`FixedBackOff(0L, 0L)`: interval=0ms, maxAttempts=0 → 첫 실패 즉시 DLT 라우팅.
+
+### 3. 테스트 실행 순서 보장
+
+`Listener5`는 Spring 싱글톤 빈으로 두 테스트가 상태를 공유한다.  
+`conversion error`가 `conversion error routes to DLT` 전에 실행되어야 한다.
+
+```kotlin
+@TestMethodOrder(MethodOrderer.MethodName::class)
+```
+
+JUnit 5 MethodName 정렬은 `Method.getName()`을 사용 →  
+`"conversion error"` < `"conversion error routes to DLT"` (prefix ordering).
+
+## 테스트 결과
+
+- `bluetape4k-kafka`: 6/6 pass ✓
+- `bluetape4k-kafka4`: 6/6 pass ✓
+
+## 교훈
+
+1. **Spring Kafka 버전 업그레이드 시 DLT suffix 확인 필수**: 3.3부터 `.DLT` → `-dlt`.
+2. **`DeadLetterPublishingRecoverer` 로그 확인**: `to <topic>-<partition>@<offset>` 패턴으로 실제 DLT 토픽 이름 파악 가능.
+3. **`DefaultErrorHandler` 재시도 횟수**: 테스트 타임아웃보다 (재시도 × poll 대기시간)이 크면 항상 타임아웃 → `FixedBackOff(0L, 0L)` 사용.
+4. **싱글톤 Spring 빈 공유 테스트**: CountDownLatch 상태 공유 시 실행 순서를 명시적으로 제어해야 한다.

--- a/infra/kafka/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
+++ b/infra/kafka/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
@@ -22,8 +22,9 @@ import org.apache.kafka.common.serialization.BytesDeserializer
 import org.apache.kafka.common.serialization.BytesSerializer
 import org.apache.kafka.common.serialization.StringSerializer
 import org.apache.kafka.common.utils.Bytes
-import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Bean
@@ -38,6 +39,7 @@ import org.springframework.kafka.core.ProducerFactory
 import org.springframework.kafka.listener.BatchListenerFailedException
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer
 import org.springframework.kafka.listener.DefaultErrorHandler
+import org.springframework.util.backoff.FixedBackOff
 import org.springframework.kafka.support.KafkaHeaders
 import org.springframework.kafka.support.converter.BatchMessagingMessageConverter
 import org.springframework.kafka.support.converter.BytesJsonMessageConverter
@@ -54,7 +56,8 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 @SpringBootTest
-@EmbeddedKafka(kraft = true, partitions = 1, topics = ["blc1", "blc2", "blc3", "blc4", "blc5", "blc6", "blc6.DLT"])
+@EmbeddedKafka(kraft = true, partitions = 1, topics = ["blc1", "blc2", "blc3", "blc4", "blc5", "blc6", "blc6-dlt"])
+@TestMethodOrder(MethodOrderer.MethodName::class)
 class BatchListenerConversionTests {
 
     companion object: KLoggingChannel() {
@@ -138,7 +141,6 @@ class BatchListenerConversionTests {
         listener5.received shouldBeEqualTo listOf(Foo("baz"), Foo("qux"))
     }
 
-    @Disabled("DLT 라우팅이 최신 Spring Kafka 버전에서 작동하지 않음 — 추적: GitHub Issue #300")
     @Test
     fun `conversion error routes to DLT`() {
         template.send("blc6", 0, 0, """{ "bar": "baz" }""")
@@ -166,7 +168,7 @@ class BatchListenerConversionTests {
             factory.setBatchMessageConverter(BatchMessagingMessageConverter(converter()))
             factory.setReplyTemplate(template(embeddedKafka))
 
-            val errorHandler = DefaultErrorHandler(DeadLetterPublishingRecoverer(template))
+            val errorHandler = DefaultErrorHandler(DeadLetterPublishingRecoverer(template), FixedBackOff(0L, 0L))
             errorHandler.setLogLevel(KafkaException.Level.DEBUG)
             factory.setCommonErrorHandler(errorHandler)
             return factory
@@ -338,7 +340,6 @@ class BatchListenerConversionTests {
             this.latch1.countDown()
             foos.forEachIndexed { i, foo ->
                 if (foo == null && conversionFailures[i] != null) {
-                    // FIXME: 기존에는 BatchListenerFailedException 이 발생시키면, DLT로 보내는데, 버전 업 이후 작동을 하지 않는다 
                     log.warn(conversionFailures[i]) { "JSON 파싱 예외가 발생하여, DLT 로 보냅니다." }
                     throw BatchListenerFailedException("Conversion error", conversionFailures[i], i)
                 } else {
@@ -348,8 +349,8 @@ class BatchListenerConversionTests {
         }
 
         @KafkaListener(
-            topics = ["blc6.DLT"],
-            groupId = "blc6.DLT",
+            topics = ["blc6-dlt"],
+            groupId = "blc6-dlt",
             properties = [ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG + ":org.apache.kafka.common.serialization.StringDeserializer"]
         )
         fun listen5Dlt(input: String) {

--- a/infra/kafka/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
+++ b/infra/kafka/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
@@ -39,7 +39,6 @@ import org.springframework.kafka.core.ProducerFactory
 import org.springframework.kafka.listener.BatchListenerFailedException
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer
 import org.springframework.kafka.listener.DefaultErrorHandler
-import org.springframework.util.backoff.FixedBackOff
 import org.springframework.kafka.support.KafkaHeaders
 import org.springframework.kafka.support.converter.BatchMessagingMessageConverter
 import org.springframework.kafka.support.converter.BytesJsonMessageConverter
@@ -51,6 +50,7 @@ import org.springframework.kafka.test.utils.KafkaTestUtils
 import org.springframework.messaging.Message
 import org.springframework.messaging.handler.annotation.Header
 import org.springframework.messaging.handler.annotation.SendTo
+import org.springframework.util.backoff.FixedBackOff
 import java.io.Serializable
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
@@ -39,7 +39,6 @@ import org.springframework.kafka.core.ProducerFactory
 import org.springframework.kafka.listener.BatchListenerFailedException
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer
 import org.springframework.kafka.listener.DefaultErrorHandler
-import org.springframework.util.backoff.FixedBackOff
 import org.springframework.kafka.support.KafkaHeaders
 import org.springframework.kafka.support.converter.BatchMessagingMessageConverter
 import org.springframework.kafka.support.converter.BytesJacksonJsonMessageConverter
@@ -51,6 +50,7 @@ import org.springframework.kafka.test.utils.KafkaTestUtils
 import org.springframework.messaging.Message
 import org.springframework.messaging.handler.annotation.Header
 import org.springframework.messaging.handler.annotation.SendTo
+import org.springframework.util.backoff.FixedBackOff
 import java.io.Serializable
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
@@ -22,8 +22,9 @@ import org.apache.kafka.common.serialization.BytesDeserializer
 import org.apache.kafka.common.serialization.BytesSerializer
 import org.apache.kafka.common.serialization.StringSerializer
 import org.apache.kafka.common.utils.Bytes
-import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Bean
@@ -38,6 +39,7 @@ import org.springframework.kafka.core.ProducerFactory
 import org.springframework.kafka.listener.BatchListenerFailedException
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer
 import org.springframework.kafka.listener.DefaultErrorHandler
+import org.springframework.util.backoff.FixedBackOff
 import org.springframework.kafka.support.KafkaHeaders
 import org.springframework.kafka.support.converter.BatchMessagingMessageConverter
 import org.springframework.kafka.support.converter.BytesJacksonJsonMessageConverter
@@ -54,7 +56,8 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 @SpringBootTest
-@EmbeddedKafka(partitions = 1, topics = ["blc1", "blc2", "blc3", "blc4", "blc5", "blc6", "blc6.DLT"])
+@EmbeddedKafka(partitions = 1, topics = ["blc1", "blc2", "blc3", "blc4", "blc5", "blc6", "blc6-dlt"])
+@TestMethodOrder(MethodOrderer.MethodName::class)
 class BatchListenerConversionTests {
 
     companion object: KLoggingChannel() {
@@ -138,7 +141,6 @@ class BatchListenerConversionTests {
         listener5.received shouldBeEqualTo listOf(Foo("baz"), Foo("qux"))
     }
 
-    @Disabled("DLT 라우팅이 최신 Spring Kafka 버전에서 작동하지 않음 — 추적: GitHub Issue #300")
     @Test
     fun `conversion error routes to DLT`() {
         template.send("blc6", 0, 0, """{ "bar": "baz" }""")
@@ -166,7 +168,7 @@ class BatchListenerConversionTests {
             factory.setBatchMessageConverter(BatchMessagingMessageConverter(converter()))
             factory.setReplyTemplate(template(embeddedKafka))
 
-            val errorHandler = DefaultErrorHandler(DeadLetterPublishingRecoverer(template))
+            val errorHandler = DefaultErrorHandler(DeadLetterPublishingRecoverer(template), FixedBackOff(0L, 0L))
             errorHandler.setLogLevel(KafkaException.Level.DEBUG)
             factory.setCommonErrorHandler(errorHandler)
             return factory
@@ -338,7 +340,6 @@ class BatchListenerConversionTests {
             this.latch1.countDown()
             foos.forEachIndexed { i, foo ->
                 if (foo == null && conversionFailures[i] != null) {
-                    // FIXME: 기존에는 BatchListenerFailedException 이 발생시키면, DLT로 보내는데, 버전 업 이후 작동을 하지 않는다
                     log.warn(conversionFailures[i]) { "JSON 파싱 예외가 발생하여, DLT 로 보냅니다." }
                     throw BatchListenerFailedException("Conversion error", conversionFailures[i], i)
                 } else {
@@ -348,8 +349,8 @@ class BatchListenerConversionTests {
         }
 
         @KafkaListener(
-            topics = ["blc6.DLT"],
-            groupId = "blc6.DLT",
+            topics = ["blc6-dlt"],
+            groupId = "blc6-dlt",
             properties = [ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG + ":org.apache.kafka.common.serialization.StringDeserializer"]
         )
         fun listen5Dlt(input: String) {


### PR DESCRIPTION
## Summary

Closes #472

- PR 제목: fix: fix BatchListenerFailedException DLT routing in Spring Kafka 3.3 (#472)

Fixes #472 —  DLT routing broken after Spring Kafka 3.3 upgrade.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

| File | Change |
|------|--------|
| `kafka/BatchListenerConversionTests.kt` | Topic `blc6.DLT` → `blc6-dlt`; `FixedBackOff(0L, 0L)`; `@TestMethodOrder` |
| `kafka4/BatchListenerConversionTests.kt` | Same changes; remove `@Disabled` |

### 기존 섹션: Root Causes

### 1. Spring Kafka 3.3 changed the default DLT topic suffix

| Version | Default suffix | Example |
|---------|---------------|---------|
| Spring Kafka ≤ 3.2 | `.DLT` | `blc6.DLT` |
| Spring Kafka ≥ 3.3 | `-dlt` | `blc6-dlt` |

The test listeners subscribed to `blc6.DLT`, but `DeadLetterPublishingRecoverer` published to `blc6-dlt`. The DLT messages were never consumed, so `latch2.await(3s)` always timed out.

**Confirmed via log:**
```
Successful dead-letter publication: blc6-0@1 to blc6-dlt-0@0
```

### 2. DefaultErrorHandler retry count exceeded test timeout

Default `FixedBackOff(0, 9)` = 10 attempts × FETCH_MAX_WAIT_MS=500ms ≈ 5s > 3s timeout. DLT routing was never reached within the test window.

### 기존 섹션: Verification

```bash
./gradlew :bluetape4k-kafka:test :bluetape4k-kafka4:test --tests "*BatchListenerConversionTests" -x detekt
```

## Validation

```
bluetape4k-kafka  : 6/6 pass ✅
bluetape4k-kafka4 : 6/6 pass ✅
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #472, milestone 없음, assignee `debop`
- PR: #511, head `77b174152b53f5e1be5b3f5189a0d3a3508a0daa`, milestone `1.8.0`, assignee `debop`
- Base: `develop`, head branch `fix/batch-listener-dlt-routing`
- Labels: 없음
- State: `MERGED`, merge commit `8104d744f79220c1dcc76158f7efdbb70e947a55`
- CI: ./gradlew :bluetape4k-kafka:test :bluetape4k-kafka4:test --tests "*BatchListenerConversionTests" -x detekt

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #511 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `8104d744f79220c1dcc76158f7efdbb70e947a55`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
