### PR TITLE
fix: Lettuce runBlocking/runCatching + Retrofit HC5/Vert.x cancel+tag + HC5 Feign tests (#476, #484, #489, #506, #507)

### DIFF
--- a/docs/lessons/2026-05-16-retrofit-hc5-vertx-cancel-tag-fix.md
+++ b/docs/lessons/2026-05-16-retrofit-hc5-vertx-cancel-tag-fix.md
@@ -1,0 +1,84 @@
+# Retrofit HC5 / Vert.x cancel() propagation and tag() storage fix
+
+**Date**: 2026-05-16
+**Issues**: #484, #489
+**PR**: #512
+
+## Root Cause
+
+### cancel() — incomplete propagation
+
+Both `Hc5CallFactory.AsyncClientCall` and `VertxCallFactory.VertxCall` called `promise?.cancel(true)`,
+which cancels the `CompletableFuture` but **not** the underlying network request.
+The HC5 `Future<SimpleHttpResponse>` and the Vert.x `HttpClientRequest` continued running,
+blocking the thread until the 30-second `callTimeout` expired.
+
+`isCanceled()` was derived from `promise?.isCancelled ?: false`, which is also wrong:
+it returns `false` until `cancel()` has already executed, so pre-execute reads always return false.
+
+### tag() — silent no-ops
+
+All four `tag()` overloads in both factories had no backing store.
+`tag(type, computeIfAbsent)` computed and discarded the value every time;
+`tag(type)` always returned null.
+
+### #489 — premature @Disabled
+
+`ApacheHc5HttpbinCoroutineJacksonTest` and `ApacheHc5HttpbinCoroutineFastjsonTest` both had
+an empty `@Disabled` override of `get post's comments()`. The underlying parent test passes
+correctly with `AsyncApacheHttp5Client` — the disable was not needed and was suppressing coverage.
+
+## Fix
+
+### Hc5CallFactory
+
+- Added `@Volatile var hc5Future: Future<SimpleHttpResponse>? = null`.
+  Assigned immediately after `asyncClient.execute()` returns.
+- `cancel()` now calls `hc5Future?.cancel(true)` in addition to `promise?.cancel(true)`.
+- Added `@Volatile var cancelled = false`; `isCanceled()` returns `cancelled` directly.
+- Post-assignment race guard in `executeAsync()`: if `cancelled` is already true when
+  `hc5Future` is assigned, cancel it immediately.
+- Replaced tag no-ops with `ConcurrentHashMap<Class<*>, Any>` keyed by `type.java`.
+
+### VertxCallFactory
+
+- Added `@Volatile var vertxRequest: HttpClientRequest? = null`.
+  Assigned inside the `onSuccess` handler before `req.send()`.
+- `cancel()` calls `vertxRequest?.reset()` (Vert.x 5.x `reset()` is idempotent).
+- Same `@Volatile cancelled` pattern and post-assignment race guard as HC5.
+- Same `ConcurrentHashMap` tag storage.
+
+### #489
+
+Removed the `@Disabled` override and its empty body from both HC5 coroutine test classes.
+
+## Thread Safety Analysis
+
+The volatile read/write pair on `cancelled` + `hc5Future`/`vertxRequest` is sufficient under JMM:
+- Path A: `cancel()` runs first → sets `cancelled=true`, reads `hc5Future=null` (no-op) →
+  `executeAsync()` assigns `hc5Future`, checks `cancelled=true`, cancels immediately.
+- Path B: `executeAsync()` assigns first → `cancel()` reads non-null `hc5Future`, cancels it.
+
+Both paths are covered; no additional lock is needed.
+
+## Verification
+
+Regression tests added to `Hc5HttpClientTest` and `VertxHttpClientTest`:
+
+1. `cancel sets isCanceled to true immediately before execute` — isCanceled() authority contract.
+2. `cancel during enqueue propagates to underlying request and fires onFailure promptly` —
+   `SocketPolicy.NO_RESPONSE` + 5 s `CountDownLatch`; without fix hangs 30 s and fails.
+3. `tag computeIfAbsent caches and returns same instance on repeated calls` — `shouldBeSameInstanceAs`.
+4. `tag read returns null when tag has not been set`.
+
+Results: 24 tests (Hc5HttpClientTest), 24 tests (VertxHttpClientTest) — 0 failures, 0 skipped.
+Feign: 232 tests — 0 failures, 0 skipped (2 previously disabled tests now pass).
+
+## Future Guidance
+
+- `CompletableFuture.cancel(true)` only transitions the future's state — it does NOT propagate
+  to any underlying blocking operation. Always capture and cancel the real async handle.
+- `isCanceled()` must reflect user intent (`cancelled` flag), not future state.
+- `tag()` read and `tag(type, computeIfAbsent)` overloads must share a single backing map;
+  use `ConcurrentHashMap<Class<*>, Any>` keyed by `type.java` for type-safe, concurrent access.
+- Vert.x `HttpClientRequest.reset()` is idempotent in 5.x. Document this when relying on it.

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMap.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMap.kt
@@ -121,14 +121,24 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
      */
     suspend fun get(key: K): V? {
         val redisKey = redisKey(key)
-        val cached = runCatching { asyncCommands.get(redisKey).await() }
-            .onFailure { log.warn(it) { "Redis GET 실패, loader fallback: $redisKey" } }
-            .getOrNull()
+        val cached = try {
+            asyncCommands.get(redisKey).await()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "Redis GET 실패, loader fallback: $redisKey" }
+            null
+        }
         if (cached != null) return cached
         val loader = loader ?: return null
         val value = loader.load(key) ?: return null
-        runCatching { asyncCommands.set(redisKey, value, SetArgs().ex(ttlSeconds)).await() }
-            .onFailure { log.warn(it) { "Redis SETEX 실패: $redisKey" } }
+        try {
+            asyncCommands.set(redisKey, value, SetArgs().ex(ttlSeconds)).await()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "Redis SETEX 실패: $redisKey" }
+        }
         return value
     }
 
@@ -317,41 +327,55 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
     private suspend fun writeToDeadLetter(batch: Map<K, V>) {
         // HSET (recovery values) first; LPUSH (monitoring keys) only on success.
         // Two commands use different codec connections so MULTI/EXEC is not possible.
-        runCatching {
+        try {
             val deadLetterKey = "${config.keyPrefix}:dead-letter"
             val deadLetterValuesKey = "${config.keyPrefix}:dead-letter:values"
             val valueMap = batch.entries.associate { (k, v) -> keySerializer(k) to v }
             asyncCommands.hset(deadLetterValuesKey, valueMap).await()
             val serializedKeys = batch.keys.map { keySerializer(it) }
             strAsyncCommands.lpush(deadLetterKey, *serializedKeys.toTypedArray()).await()
-        }.onFailure { ex -> log.error(ex) { "Dead letter 기록 실패" } }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.error(e) { "Dead letter 기록 실패" }
+        }
     }
 
     private suspend fun flushBatch(entries: List<Triple<K, V, Int>>) {
         if (entries.isEmpty()) return
         val batch = entries.associate { it.first to it.second }
-        runCatching { writer?.write(batch) }
-            .onFailure { e ->
-                val retryCount = entries.first().third + 1
-                log.error(e) { "Write-behind flush 실패 (attempt $retryCount): ${batch.keys}" }
-                if (retryCount < MAX_DEAD_LETTER_RETRY) {
-                    val dropped = mutableMapOf<K, V>()
-                    entries.forEach { (k, v, _) ->
-                        val result = writeBehindChannel?.trySend(Triple(k, v, retryCount))
-                        if (result == null || result.isFailure) {
-                            log.warn { "Requeue failed for key=$k (attempt $retryCount): channel full or closed" }
-                            dropped[k] = v
-                        }
+        try {
+            writer?.write(batch)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            val retryCount = entries.first().third + 1
+            log.error(e) { "Write-behind flush 실패 (attempt $retryCount): ${batch.keys}" }
+            if (retryCount < MAX_DEAD_LETTER_RETRY) {
+                val dropped = mutableMapOf<K, V>()
+                entries.forEach { (k, v, _) ->
+                    val result = writeBehindChannel?.trySend(Triple(k, v, retryCount))
+                    if (result == null || result.isFailure) {
+                        log.warn { "Requeue failed for key=$k (attempt $retryCount): channel full or closed" }
+                        dropped[k] = v
                     }
-                    if (dropped.isNotEmpty()) {
-                        writeToDeadLetter(dropped)
-                    }
-                } else {
-                    writeToDeadLetter(batch)
                 }
+                if (dropped.isNotEmpty()) {
+                    writeToDeadLetter(dropped)
+                }
+            } else {
+                writeToDeadLetter(batch)
             }
+        }
     }
 
+    /**
+     * Releases resources held by this map.
+     *
+     * **In coroutine contexts**: prefer [suspendClose] to avoid blocking the thread.
+     * This method uses [runBlocking] internally and will block the calling thread
+     * while waiting for the write-behind job to finish flushing.
+     */
     override fun close() {
         // 1. 채널을 먼저 닫아 새 write 차단 (producer가 IllegalStateException을 던짐)
         writeBehindChannel?.close()
@@ -362,6 +386,26 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
                 withTimeout(config.writeBehindShutdownTimeout.toMillis()) {
                     job.join()
                 }
+            }
+        }
+        ownedJob.cancel()
+        if (lazyStrConnection.isInitialized()) lazyStrConnection.value.close()
+        connection.close()
+    }
+
+    /**
+     * Releases resources held by this map without blocking the calling thread.
+     *
+     * This is the coroutine-safe alternative to [close]. Call this from a coroutine
+     * context to avoid thread blocking while waiting for the write-behind job to drain.
+     */
+    suspend fun suspendClose() {
+        // 1. 채널을 먼저 닫아 새 write 차단
+        writeBehindChannel?.close()
+        // 2. write-behind job이 drain을 마칠 때까지 suspend로 대기
+        writeBehindJob?.let { job ->
+            withTimeout(config.writeBehindShutdownTimeout.toMillis()) {
+                job.join()
             }
         }
         ownedJob.cancel()

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMap.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMap.kt
@@ -22,8 +22,10 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.time.delay
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import java.io.Closeable
 
@@ -381,16 +383,21 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
         writeBehindChannel?.close()
         // 2. writeBehindJob이 채널을 drain하고 자연스럽게 종료될 때까지 대기
         //    취소 전에 join해야 남은 배치가 손실 없이 flush됨
-        writeBehindJob?.let { job ->
-            runBlocking(Dispatchers.IO) {
-                withTimeout(config.writeBehindShutdownTimeout.toMillis()) {
-                    job.join()
+        try {
+            writeBehindJob?.let { job ->
+                runBlocking(Dispatchers.IO) {
+                    withTimeout(config.writeBehindShutdownTimeout.toMillis()) {
+                        job.join()
+                    }
                 }
             }
+        } catch (e: Exception) {
+            log.warn(e) { "Write-behind job drain timed out or failed during close()" }
+        } finally {
+            ownedJob.cancel()
+            if (lazyStrConnection.isInitialized()) lazyStrConnection.value.close()
+            connection.close()
         }
-        ownedJob.cancel()
-        if (lazyStrConnection.isInitialized()) lazyStrConnection.value.close()
-        connection.close()
     }
 
     /**
@@ -402,14 +409,22 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
     suspend fun suspendClose() {
         // 1. 채널을 먼저 닫아 새 write 차단
         writeBehindChannel?.close()
-        // 2. write-behind job이 drain을 마칠 때까지 suspend로 대기
-        writeBehindJob?.let { job ->
-            withTimeout(config.writeBehindShutdownTimeout.toMillis()) {
-                job.join()
+        // 2. write-behind job이 drain을 마칠 때까지 suspend로 대기.
+        //    NonCancellable 컨텍스트에서 실행해 호출자 취소에도 정리 블록이 실행되도록 보장.
+        try {
+            writeBehindJob?.let { job ->
+                withContext(NonCancellable) {
+                    withTimeout(config.writeBehindShutdownTimeout.toMillis()) {
+                        job.join()
+                    }
+                }
             }
+        } catch (e: Exception) {
+            log.warn(e) { "Write-behind job drain timed out or failed during suspendClose()" }
+        } finally {
+            ownedJob.cancel()
+            if (lazyStrConnection.isInitialized()) lazyStrConnection.value.close()
+            connection.close()
         }
-        ownedJob.cancel()
-        if (lazyStrConnection.isInitialized()) lazyStrConnection.value.close()
-        connection.close()
     }
 }

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMapMockTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMapMockTest.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.redis.lettuce.map
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.junit5.coroutines.runSuspendIO
+import kotlin.test.assertFailsWith
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisFuture
@@ -145,13 +146,44 @@ class LettuceSuspendedLoadedMapMockTest {
 
         val map = buildMap(asyncCommands, loader = loader)
 
-        var caughtCancellation = false
-        try {
+        assertFailsWith<CancellationException> {
             map.get("key1")
-        } catch (e: CancellationException) {
-            caughtCancellation = true
         }
-        // CancellationException must propagate out of get(), not be swallowed
-        caughtCancellation shouldBeEqualTo true
+    }
+
+    @Test
+    fun `get - CancellationException from asyncCommands await is rethrown, not swallowed`() = runSuspendIO {
+        // This test verifies the actual fix: runCatching { await() } → try/catch that rethrows CE.
+        // A future completed with CancellationException must escape get(), not be silently swallowed.
+        val asyncCommands = mockk<RedisAsyncCommands<String, String>>(relaxed = true)
+        every { asyncCommands.get(any<String>()) } returns
+            failedRedisFuture(CancellationException("redis command cancelled"))
+
+        val map = buildMap(asyncCommands, loader = null)
+
+        assertFailsWith<CancellationException> {
+            map.get("key1")
+        }
+    }
+
+    @Test
+    fun `get - CancellationException from asyncCommands SET await is rethrown`() = runSuspendIO {
+        // Verifies the SETEX path: CE from set().await() must not be swallowed.
+        val asyncCommands = mockk<RedisAsyncCommands<String, String>>(relaxed = true)
+
+        // GET misses (null) → loader returns value → SET fails with CE
+        every { asyncCommands.get(any<String>()) } returns completedRedisFuture(null)
+        every { asyncCommands.set(any(), any(), any<SetArgs>()) } returns
+            failedRedisFuture(CancellationException("set cancelled"))
+
+        val loader = mockk<SuspendedMapLoader<String, String>>()
+        coEvery { loader.load("key1") } returns "value1"
+        coEvery { loader.loadAllKeys() } returns emptyList()
+
+        val map = buildMap(asyncCommands, loader = loader)
+
+        assertFailsWith<CancellationException> {
+            map.get("key1")
+        }
     }
 }

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMapMockTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMapMockTest.kt
@@ -1,0 +1,157 @@
+package io.bluetape4k.redis.lettuce.map
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.lettuce.core.RedisClient
+import io.lettuce.core.RedisFuture
+import io.lettuce.core.SetArgs
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.async.RedisAsyncCommands
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+/**
+ * MockK-based unit tests for [LettuceSuspendedLoadedMap] failure paths.
+ *
+ * These tests exercise:
+ * - Redis GET failure → loader fallback (CancellationException not swallowed)
+ * - Redis SET failure after load (logged, not thrown)
+ * - CancellationException propagation (never swallowed by try/catch)
+ *
+ * No real Redis connection is needed; all Lettuce async commands are mocked.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LettuceSuspendedLoadedMapMockTest {
+
+    companion object : KLoggingChannel()
+
+    /** Minimal [RedisFuture] implementation backed by [CompletableFuture]. */
+    private class TestRedisFuture<T> : CompletableFuture<T>(), RedisFuture<T> {
+        override fun getError(): String? =
+            if (isCompletedExceptionally) "completed exceptionally" else null
+
+        override fun await(timeout: Long, unit: TimeUnit): Boolean =
+            try {
+                get(timeout, unit)
+                true
+            } catch (_: TimeoutException) {
+                false
+            }
+    }
+
+    private fun <T> completedRedisFuture(value: T): RedisFuture<T> =
+        TestRedisFuture<T>().apply { complete(value) }
+
+    private fun <T> failedRedisFuture(error: Throwable): RedisFuture<T> =
+        TestRedisFuture<T>().apply { completeExceptionally(error) }
+
+    private fun buildMap(
+        asyncCommands: RedisAsyncCommands<String, String>,
+        loader: SuspendedMapLoader<String, String>? = null,
+        writer: SuspendedMapWriter<String, String>? = null,
+        config: LettuceCacheConfig = LettuceCacheConfig.READ_WRITE_THROUGH.copy(keyPrefix = "mock-test"),
+    ): LettuceSuspendedLoadedMap<String, String> {
+        val connection = mockk<StatefulRedisConnection<String, String>>(relaxed = true)
+        every { connection.async() } returns asyncCommands
+
+        val client = mockk<RedisClient>(relaxed = true)
+        every { client.connect<String, String>(any()) } returns connection
+
+        return LettuceSuspendedLoadedMap(
+            client = client,
+            loader = loader,
+            writer = writer,
+            config = config,
+        )
+    }
+
+    @Test
+    fun `get - Redis GET failure falls back to loader`() = runSuspendIO {
+        val asyncCommands = mockk<RedisAsyncCommands<String, String>>(relaxed = true)
+        val loader = mockk<SuspendedMapLoader<String, String>>()
+
+        // Redis GET throws a runtime exception (simulates connection error)
+        every { asyncCommands.get(any<String>()) } returns
+            failedRedisFuture(RuntimeException("Redis down"))
+
+        // Loader returns a value from the DB
+        coEvery { loader.load("key1") } returns "db-value"
+        coEvery { loader.loadAllKeys() } returns emptyList()
+
+        // Redis SET after load also fails — should be silently logged, not thrown
+        every { asyncCommands.set(any<String>(), any(), any<SetArgs>()) } returns
+            failedRedisFuture(RuntimeException("Redis SET down"))
+
+        val map = buildMap(asyncCommands, loader = loader)
+        val result = map.get("key1")
+
+        result shouldBeEqualTo "db-value"
+        coVerify(exactly = 1) { loader.load("key1") }
+    }
+
+    @Test
+    fun `get - Redis GET failure with no loader returns null`() = runSuspendIO {
+        val asyncCommands = mockk<RedisAsyncCommands<String, String>>(relaxed = true)
+
+        every { asyncCommands.get(any<String>()) } returns
+            failedRedisFuture(RuntimeException("Redis down"))
+
+        val map = buildMap(asyncCommands, loader = null)
+        val result = map.get("missing")
+
+        result.shouldBeNull()
+    }
+
+    @Test
+    fun `get - loader returns null when key not found in DB`() = runSuspendIO {
+        val asyncCommands = mockk<RedisAsyncCommands<String, String>>(relaxed = true)
+        val loader = mockk<SuspendedMapLoader<String, String>>()
+
+        every { asyncCommands.get(any<String>()) } returns
+            failedRedisFuture(RuntimeException("Redis down"))
+
+        coEvery { loader.load("missing") } returns null
+        coEvery { loader.loadAllKeys() } returns emptyList()
+
+        val map = buildMap(asyncCommands, loader = loader)
+        val result = map.get("missing")
+
+        result.shouldBeNull()
+        coVerify(exactly = 1) { loader.load("missing") }
+    }
+
+    @Test
+    fun `get - CancellationException from loader is rethrown, not swallowed`() = runSuspendIO {
+        val asyncCommands = mockk<RedisAsyncCommands<String, String>>(relaxed = true)
+
+        // Redis GET fails → loader fallback path
+        every { asyncCommands.get(any<String>()) } returns
+            failedRedisFuture(RuntimeException("Redis down"))
+
+        // Loader itself throws CancellationException (e.g. caller cancelled during load)
+        val loader = mockk<SuspendedMapLoader<String, String>>()
+        coEvery { loader.load(any()) } throws CancellationException("cancelled during load")
+        coEvery { loader.loadAllKeys() } returns emptyList()
+
+        val map = buildMap(asyncCommands, loader = loader)
+
+        var caughtCancellation = false
+        try {
+            map.get("key1")
+        } catch (e: CancellationException) {
+            caughtCancellation = true
+        }
+        // CancellationException must propagate out of get(), not be swallowed
+        caughtCancellation shouldBeEqualTo true
+    }
+}

--- a/io/feign/src/test/kotlin/io/bluetape4k/feign/clients/hc5/ApacheHc5HttpbinCoroutineFastjsonTest.kt
+++ b/io/feign/src/test/kotlin/io/bluetape4k/feign/clients/hc5/ApacheHc5HttpbinCoroutineFastjsonTest.kt
@@ -9,8 +9,6 @@ import io.bluetape4k.feign.codec.FeignFastjsonDecoder
 import io.bluetape4k.feign.codec.FeignFastjsonEncoder
 import io.bluetape4k.feign.coroutines.coroutineFeignBuilder
 import io.bluetape4k.logging.coroutines.KLoggingChannel
-import org.junit.jupiter.api.Disabled
-import org.junit.jupiter.api.Test
 
 class ApacheHc5HttpbinCoroutineFastjsonTest: AbstractHttpbinCoroutineTest() {
 
@@ -24,11 +22,5 @@ class ApacheHc5HttpbinCoroutineFastjsonTest: AbstractHttpbinCoroutineTest() {
             logger(Slf4jLogger(javaClass))
             logLevel(Logger.Level.FULL)
         }
-    }
-
-    @Disabled("Apache Hc5 Client 에서 예외가 발생한다")
-    @Test
-    override fun `get post's comments`() {
-        // 예외가 발생한다.
     }
 }

--- a/io/feign/src/test/kotlin/io/bluetape4k/feign/clients/hc5/ApacheHc5HttpbinCoroutineJacksonTest.kt
+++ b/io/feign/src/test/kotlin/io/bluetape4k/feign/clients/hc5/ApacheHc5HttpbinCoroutineJacksonTest.kt
@@ -9,8 +9,6 @@ import io.bluetape4k.feign.codec.JacksonDecoder2
 import io.bluetape4k.feign.codec.JacksonEncoder2
 import io.bluetape4k.feign.coroutines.coroutineFeignBuilder
 import io.bluetape4k.logging.coroutines.KLoggingChannel
-import org.junit.jupiter.api.Disabled
-import org.junit.jupiter.api.Test
 
 class ApacheHc5HttpbinCoroutineJacksonTest: AbstractHttpbinCoroutineTest() {
 
@@ -24,11 +22,5 @@ class ApacheHc5HttpbinCoroutineJacksonTest: AbstractHttpbinCoroutineTest() {
             logger(Slf4jLogger(javaClass))
             logLevel(Logger.Level.FULL)
         }
-    }
-
-    @Disabled("Apache Hc5 Client 에서 예외가 발생한다")
-    @Test
-    override fun `get post's comments`() {
-        // 예외가 발생한다.
     }
 }

--- a/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/clients/hc5/Hc5CallFactory.kt
+++ b/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/clients/hc5/Hc5CallFactory.kt
@@ -15,7 +15,9 @@ import org.apache.hc.core5.reactor.IOReactorStatus
 import java.io.IOException
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutionException
+import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
 
@@ -117,6 +119,13 @@ class Hc5CallFactory private constructor(
         private val promiseRef = atomic<CompletableFuture<okhttp3.Response>?>(null)
         private var promise by promiseRef
         private val timeout = callTimeout.toTimeout()
+        private val tags = ConcurrentHashMap<Class<*>, Any>()
+
+        @Volatile
+        private var cancelled = false
+
+        @Volatile
+        private var hc5Future: Future<SimpleHttpResponse>? = null
 
         override fun execute(): okhttp3.Response {
             log.debug { "Execute Hc5Call. request=$okRequest" }
@@ -154,7 +163,7 @@ class Hc5CallFactory private constructor(
 
             val simpleRequest = okRequest.toSimpleHttpRequest()
 
-            asyncClient.execute(simpleRequest, object: FutureCallback<SimpleHttpResponse> {
+            hc5Future = asyncClient.execute(simpleRequest, object: FutureCallback<SimpleHttpResponse> {
                 override fun completed(result: SimpleHttpResponse) {
                     try {
                         val okResponse: okhttp3.Response = result.toOkHttp3Response(okRequest)
@@ -173,6 +182,11 @@ class Hc5CallFactory private constructor(
                 }
             })
 
+            // If cancel() was called before hc5Future was assigned, cancel now
+            if (cancelled) {
+                hc5Future?.cancel(true)
+            }
+
             return promise
         }
 
@@ -181,15 +195,13 @@ class Hc5CallFactory private constructor(
         }
 
         override fun cancel() {
-            promise?.let { promise ->
-                if (!promise.cancel(true)) {
-                    log.warn { "Cannot cancel promise. $promise" }
-                }
-            }
+            cancelled = true
+            promise?.cancel(true)
+            hc5Future?.cancel(true)
         }
 
         override fun isCanceled(): Boolean {
-            return promise?.isCancelled ?: false
+            return cancelled
         }
 
         override fun clone(): okhttp3.Call {
@@ -204,13 +216,19 @@ class Hc5CallFactory private constructor(
             return timeout
         }
 
-        override fun <T: Any> tag(type: KClass<T>): T? = null
+        @Suppress("UNCHECKED_CAST")
+        override fun <T: Any> tag(type: KClass<T>): T? = tags[type.java] as? T
 
-        override fun <T> tag(type: Class<out T>): T? = null
+        @Suppress("UNCHECKED_CAST")
+        override fun <T> tag(type: Class<out T>): T? = tags[type] as? T
 
-        override fun <T: Any> tag(type: KClass<T>, computeIfAbsent: () -> T): T = computeIfAbsent()
+        @Suppress("UNCHECKED_CAST")
+        override fun <T: Any> tag(type: KClass<T>, computeIfAbsent: () -> T): T =
+            tags.computeIfAbsent(type.java) { computeIfAbsent() } as T
 
-        override fun <T: Any> tag(type: Class<T>, computeIfAbsent: () -> T): T = computeIfAbsent()
+        @Suppress("UNCHECKED_CAST")
+        override fun <T: Any> tag(type: Class<T>, computeIfAbsent: () -> T): T =
+            tags.computeIfAbsent(type) { computeIfAbsent() } as T
 
         private fun throwAlreadyExecuted() {
             error("Already executed. request=$okRequest")

--- a/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/clients/hc5/Hc5CallFactory.kt
+++ b/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/clients/hc5/Hc5CallFactory.kt
@@ -217,18 +217,20 @@ class Hc5CallFactory private constructor(
         }
 
         @Suppress("UNCHECKED_CAST")
-        override fun <T: Any> tag(type: KClass<T>): T? = tags[type.java] as? T
+        override fun <T: Any> tag(type: KClass<T>): T? =
+            (tags[type.java] ?: okRequest.tag(type.java)) as? T
 
         @Suppress("UNCHECKED_CAST")
-        override fun <T> tag(type: Class<out T>): T? = tags[type] as? T
+        override fun <T> tag(type: Class<out T>): T? =
+            (tags[type] ?: okRequest.tag(type)) as? T
 
         @Suppress("UNCHECKED_CAST")
         override fun <T: Any> tag(type: KClass<T>, computeIfAbsent: () -> T): T =
-            tags.computeIfAbsent(type.java) { computeIfAbsent() } as T
+            tags.computeIfAbsent(type.java) { okRequest.tag(type.java) ?: computeIfAbsent() } as T
 
         @Suppress("UNCHECKED_CAST")
         override fun <T: Any> tag(type: Class<T>, computeIfAbsent: () -> T): T =
-            tags.computeIfAbsent(type) { computeIfAbsent() } as T
+            tags.computeIfAbsent(type) { okRequest.tag(type) ?: computeIfAbsent() } as T
 
         private fun throwAlreadyExecuted() {
             error("Already executed. request=$okRequest")

--- a/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/clients/vertx/VertxCallFactory.kt
+++ b/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/clients/vertx/VertxCallFactory.kt
@@ -188,6 +188,8 @@ class VertxCallFactory private constructor(
         override fun cancel() {
             cancelled = true
             promise?.cancel(true)
+            // reset() is idempotent in Vert.x 5.x (returns false on subsequent calls),
+            // so a concurrent double-reset between executeAsync and cancel() is safe.
             vertxRequest?.reset()
         }
 

--- a/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/clients/vertx/VertxCallFactory.kt
+++ b/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/clients/vertx/VertxCallFactory.kt
@@ -8,10 +8,12 @@ import io.bluetape4k.logging.warn
 import io.bluetape4k.okio.toTimeout
 import io.bluetape4k.retrofit2.toIOException
 import io.vertx.core.http.HttpClient
+import io.vertx.core.http.HttpClientRequest
 import io.vertx.kotlin.core.http.requestOptionsOf
 import kotlinx.atomicfu.atomic
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
@@ -104,6 +106,13 @@ class VertxCallFactory private constructor(
         private val promiseRef = atomic<CompletableFuture<okhttp3.Response>?>(null)
         private var promise by promiseRef
         private val timeout = callTimeout.toTimeout()
+        private val tags = ConcurrentHashMap<Class<*>, Any>()
+
+        @Volatile
+        private var cancelled = false
+
+        @Volatile
+        private var vertxRequest: HttpClientRequest? = null
 
         override fun execute(): okhttp3.Response {
             log.debug { "Execute VertxCall. request=$okRequest" }
@@ -147,10 +156,17 @@ class VertxCallFactory private constructor(
 
             client.request(options)
                 .onSuccess { clientRequest ->
-                    val vertxRequest = okRequest.toVertxHttpClientRequest(clientRequest)
-                    log.trace { "Send vertx request ... request=$vertxRequest, version=${vertxRequest.version()}" }
+                    val req = okRequest.toVertxHttpClientRequest(clientRequest)
+                    vertxRequest = req
+                    log.trace { "Send vertx request ... request=$req, version=${req.version()}" }
 
-                    vertxRequest.send()
+                    // If cancel() was called before vertxRequest was assigned, reset now
+                    if (cancelled) {
+                        req.reset()
+                        return@onSuccess
+                    }
+
+                    req.send()
                         .onSuccess { vertxResponse ->
                             vertxResponse.toOkResponse(okRequest, promise)
                         }
@@ -170,15 +186,13 @@ class VertxCallFactory private constructor(
         }
 
         override fun cancel() {
-            promise?.let { promise ->
-                if (!promise.cancel(true)) {
-                    log.warn { "Cannot cancel promise. $promise" }
-                }
-            }
+            cancelled = true
+            promise?.cancel(true)
+            vertxRequest?.reset()
         }
 
         override fun isCanceled(): Boolean {
-            return promise?.isCancelled ?: false
+            return cancelled
         }
 
         override fun clone(): okhttp3.Call {
@@ -193,13 +207,19 @@ class VertxCallFactory private constructor(
             return timeout
         }
 
-        override fun <T: Any> tag(type: KClass<T>): T? = null
+        @Suppress("UNCHECKED_CAST")
+        override fun <T: Any> tag(type: KClass<T>): T? = tags[type.java] as? T
 
-        override fun <T> tag(type: Class<out T>): T? = null
+        @Suppress("UNCHECKED_CAST")
+        override fun <T> tag(type: Class<out T>): T? = tags[type] as? T
 
-        override fun <T: Any> tag(type: KClass<T>, computeIfAbsent: () -> T): T = computeIfAbsent()
+        @Suppress("UNCHECKED_CAST")
+        override fun <T: Any> tag(type: KClass<T>, computeIfAbsent: () -> T): T =
+            tags.computeIfAbsent(type.java) { computeIfAbsent() } as T
 
-        override fun <T: Any> tag(type: Class<T>, computeIfAbsent: () -> T): T = computeIfAbsent()
+        @Suppress("UNCHECKED_CAST")
+        override fun <T: Any> tag(type: Class<T>, computeIfAbsent: () -> T): T =
+            tags.computeIfAbsent(type) { computeIfAbsent() } as T
 
         private fun throwAlreadyExecuted() {
             error("Already executed. request=$okRequest")

--- a/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/clients/vertx/VertxCallFactory.kt
+++ b/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/clients/vertx/VertxCallFactory.kt
@@ -160,9 +160,11 @@ class VertxCallFactory private constructor(
                     vertxRequest = req
                     log.trace { "Send vertx request ... request=$req, version=${req.version()}" }
 
-                    // If cancel() was called before vertxRequest was assigned, reset now
+                    // If cancel() was called before vertxRequest was assigned, reset and
+                    // complete the promise so enqueue() callbacks fire and execute() unblocks.
                     if (cancelled) {
                         req.reset()
+                        promise.cancel(true)
                         return@onSuccess
                     }
 
@@ -210,18 +212,20 @@ class VertxCallFactory private constructor(
         }
 
         @Suppress("UNCHECKED_CAST")
-        override fun <T: Any> tag(type: KClass<T>): T? = tags[type.java] as? T
+        override fun <T: Any> tag(type: KClass<T>): T? =
+            (tags[type.java] ?: okRequest.tag(type.java)) as? T
 
         @Suppress("UNCHECKED_CAST")
-        override fun <T> tag(type: Class<out T>): T? = tags[type] as? T
+        override fun <T> tag(type: Class<out T>): T? =
+            (tags[type] ?: okRequest.tag(type)) as? T
 
         @Suppress("UNCHECKED_CAST")
         override fun <T: Any> tag(type: KClass<T>, computeIfAbsent: () -> T): T =
-            tags.computeIfAbsent(type.java) { computeIfAbsent() } as T
+            tags.computeIfAbsent(type.java) { okRequest.tag(type.java) ?: computeIfAbsent() } as T
 
         @Suppress("UNCHECKED_CAST")
         override fun <T: Any> tag(type: Class<T>, computeIfAbsent: () -> T): T =
-            tags.computeIfAbsent(type) { computeIfAbsent() } as T
+            tags.computeIfAbsent(type) { okRequest.tag(type) ?: computeIfAbsent() } as T
 
         private fun throwAlreadyExecuted() {
             error("Already executed. request=$okRequest")

--- a/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/client/hc5/Hc5HttpClientTest.kt
+++ b/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/client/hc5/Hc5HttpClientTest.kt
@@ -1,13 +1,119 @@
 package io.bluetape4k.retrofit2.client.hc5
 
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.retrofit2.client.AbstractClientTest
 import io.bluetape4k.retrofit2.clients.hc5.hc5CallFactoryOf
 import okhttp3.Call
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class Hc5HttpClientTest: AbstractClientTest() {
 
     companion object: KLogging()
 
     override val callFactory: Call.Factory = hc5CallFactoryOf()
+
+    // --- cancel / tag contract regression tests (#484) ---
+
+    private lateinit var cancelTestServer: MockWebServer
+
+    @BeforeEach
+    fun beforeCancelTest() {
+        cancelTestServer = MockWebServer().apply { start() }
+    }
+
+    @AfterEach
+    fun afterCancelTest() {
+        runCatching { cancelTestServer.shutdown() }
+    }
+
+    @Test
+    fun `cancel sets isCanceled to true immediately before execute`() {
+        cancelTestServer.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE))
+
+        val request = Request.Builder()
+            .url(cancelTestServer.url("/"))
+            .build()
+        val call = callFactory.newCall(request)
+
+        call.isCanceled().shouldBeFalse()
+        call.cancel()
+        call.isCanceled().shouldBeTrue()
+    }
+
+    /**
+     * Verifies that cancel() propagates to the underlying HC5 request, not just the CompletableFuture.
+     *
+     * Without underlying request cancellation the server never sends a response (NO_RESPONSE policy),
+     * so onFailure would only be called after the 30s callTimeout. The latch would not be counted
+     * down within 5 seconds, causing the test to fail. With cancellation propagated to the HC5
+     * Future, the request is aborted immediately and onFailure fires within milliseconds.
+     */
+    @Test
+    fun `cancel during enqueue propagates to underlying request and fires onFailure promptly`() {
+        cancelTestServer.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE))
+
+        val request = Request.Builder()
+            .url(cancelTestServer.url("/"))
+            .build()
+        val call = callFactory.newCall(request)
+        val latch = CountDownLatch(1)
+
+        call.enqueue(object: okhttp3.Callback {
+            override fun onFailure(call: okhttp3.Call, e: java.io.IOException) {
+                latch.countDown()
+            }
+            override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
+                response.close()
+                latch.countDown()
+            }
+        })
+        call.cancel()
+
+        // If cancel propagates to the HC5 future, onFailure fires well within 5 s.
+        // Without propagation the request would hang for the full 30 s callTimeout.
+        latch.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        call.isCanceled().shouldBeTrue()
+    }
+
+    @Test
+    fun `tag computeIfAbsent caches and returns same instance on repeated calls`() {
+        val request = Request.Builder()
+            .url(cancelTestServer.url("/"))
+            .build()
+        val call = callFactory.newCall(request)
+
+        data class MyTag(val value: String)
+
+        val first = call.tag(MyTag::class) { MyTag("hello") }
+        first.shouldNotBeNull()
+
+        val second = call.tag(MyTag::class) { MyTag("world") }
+        // computeIfAbsent: second call must return same cached instance
+        second shouldBeSameInstanceAs first
+    }
+
+    @Test
+    fun `tag read returns null when tag has not been set`() {
+        val request = Request.Builder()
+            .url(cancelTestServer.url("/"))
+            .build()
+        val call = callFactory.newCall(request)
+
+        data class UnsetTag(val x: Int)
+
+        call.tag(UnsetTag::class).shouldBeNull()
+    }
 }

--- a/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/client/hc5/Hc5HttpClientTest.kt
+++ b/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/client/hc5/Hc5HttpClientTest.kt
@@ -116,4 +116,18 @@ class Hc5HttpClientTest: AbstractClientTest() {
 
         call.tag(UnsetTag::class).shouldBeNull()
     }
+
+    @Test
+    fun `tag seeded from request is visible on call`() {
+        data class RequestMeta(val id: Int)
+
+        val meta = RequestMeta(42)
+        val request = Request.Builder()
+            .url(cancelTestServer.url("/"))
+            .tag(RequestMeta::class.java, meta)
+            .build()
+        val call = callFactory.newCall(request)
+
+        call.tag(RequestMeta::class) shouldBeSameInstanceAs meta
+    }
 }

--- a/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/client/vertx/VertxHttpClientTest.kt
+++ b/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/client/vertx/VertxHttpClientTest.kt
@@ -1,9 +1,23 @@
 package io.bluetape4k.retrofit2.client.vertx
 
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.retrofit2.client.AbstractClientTest
 import io.bluetape4k.retrofit2.clients.vertx.vertxCallFactoryOf
 import okhttp3.Call
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class VertxHttpClientTest: AbstractClientTest() {
 
@@ -11,4 +25,95 @@ class VertxHttpClientTest: AbstractClientTest() {
 
     override val callFactory: Call.Factory = vertxCallFactoryOf()
 
+    // --- cancel / tag contract regression tests (#484) ---
+
+    private lateinit var cancelTestServer: MockWebServer
+
+    @BeforeEach
+    fun beforeCancelTest() {
+        cancelTestServer = MockWebServer().apply { start() }
+    }
+
+    @AfterEach
+    fun afterCancelTest() {
+        runCatching { cancelTestServer.shutdown() }
+    }
+
+    @Test
+    fun `cancel sets isCanceled to true immediately before execute`() {
+        cancelTestServer.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE))
+
+        val request = Request.Builder()
+            .url(cancelTestServer.url("/"))
+            .build()
+        val call = callFactory.newCall(request)
+
+        call.isCanceled().shouldBeFalse()
+        call.cancel()
+        call.isCanceled().shouldBeTrue()
+    }
+
+    /**
+     * Verifies that cancel() propagates to the underlying Vert.x request via reset(), not just the CompletableFuture.
+     *
+     * Without underlying request cancellation the server never sends a response (NO_RESPONSE policy),
+     * so onFailure would only be called after the 30s callTimeout. The latch would not be counted
+     * down within 5 seconds, causing the test to fail. With cancellation propagated via
+     * HttpClientRequest.reset(), the request is aborted immediately and onFailure fires within milliseconds.
+     */
+    @Test
+    fun `cancel during enqueue propagates to underlying Vertx request and fires onFailure promptly`() {
+        cancelTestServer.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE))
+
+        val request = Request.Builder()
+            .url(cancelTestServer.url("/"))
+            .build()
+        val call = callFactory.newCall(request)
+        val latch = CountDownLatch(1)
+
+        call.enqueue(object: okhttp3.Callback {
+            override fun onFailure(call: okhttp3.Call, e: java.io.IOException) {
+                latch.countDown()
+            }
+            override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
+                response.close()
+                latch.countDown()
+            }
+        })
+        call.cancel()
+
+        // If cancel propagates to the Vert.x request, onFailure fires well within 5 s.
+        // Without propagation the request would hang for the full 30 s callTimeout.
+        latch.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        call.isCanceled().shouldBeTrue()
+    }
+
+    @Test
+    fun `tag computeIfAbsent caches and returns same instance on repeated calls`() {
+        val request = Request.Builder()
+            .url(cancelTestServer.url("/"))
+            .build()
+        val call = callFactory.newCall(request)
+
+        data class MyTag(val value: String)
+
+        val first = call.tag(MyTag::class) { MyTag("hello") }
+        first.shouldNotBeNull()
+
+        val second = call.tag(MyTag::class) { MyTag("world") }
+        // computeIfAbsent: second call must return same cached instance
+        second shouldBeSameInstanceAs first
+    }
+
+    @Test
+    fun `tag read returns null when tag has not been set`() {
+        val request = Request.Builder()
+            .url(cancelTestServer.url("/"))
+            .build()
+        val call = callFactory.newCall(request)
+
+        data class UnsetTag(val x: Int)
+
+        call.tag(UnsetTag::class).shouldBeNull()
+    }
 }

--- a/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/client/vertx/VertxHttpClientTest.kt
+++ b/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/client/vertx/VertxHttpClientTest.kt
@@ -116,4 +116,43 @@ class VertxHttpClientTest: AbstractClientTest() {
 
         call.tag(UnsetTag::class).shouldBeNull()
     }
+
+    @Test
+    fun `cancel before enqueue still fires onFailure callback`() {
+        cancelTestServer.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE))
+
+        val request = Request.Builder()
+            .url(cancelTestServer.url("/"))
+            .build()
+        val call = callFactory.newCall(request)
+        call.cancel()
+
+        val latch = CountDownLatch(1)
+        call.enqueue(object: okhttp3.Callback {
+            override fun onFailure(call: okhttp3.Call, e: java.io.IOException) {
+                latch.countDown()
+            }
+            override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
+                response.close()
+                latch.countDown()
+            }
+        })
+
+        // Promise must be completed (cancelled) even when cancel() precedes enqueue().
+        latch.await(5, TimeUnit.SECONDS).shouldBeTrue()
+    }
+
+    @Test
+    fun `tag seeded from request is visible on call`() {
+        data class RequestMeta(val id: Int)
+
+        val meta = RequestMeta(42)
+        val request = Request.Builder()
+            .url(cancelTestServer.url("/"))
+            .tag(RequestMeta::class.java, meta)
+            .build()
+        val call = callFactory.newCall(request)
+
+        call.tag(RequestMeta::class) shouldBeSameInstanceAs meta
+    }
 }

--- a/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/api/WorkAdapters.kt
+++ b/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/api/WorkAdapters.kt
@@ -20,16 +20,22 @@ fun Work.asSuspend(): SuspendWork = SuspendWork { ctx ->
 }
 
 /**
- * 코루틴 [SuspendWork]를 동기 [Work]로 변환합니다.
+ * Converts a coroutine [SuspendWork] to a blocking [Work].
  *
- * 내부에서 [runBlocking]을 사용하므로 코루틴 컨텍스트 내에서는 사용하지 마세요.
+ * Uses [runBlocking] internally. **Do not call from a coroutine context** —
+ * doing so may cause deadlocks or thread starvation. Use [SuspendWork] directly
+ * in coroutine contexts instead.
  *
  * ```kotlin
  * val blockingWork = suspendWork.asBlocking()
  * ```
  *
- * @return 변환된 [Work]
+ * @return converted [Work]
  */
+@Deprecated(
+    message = "asBlocking() uses runBlocking and risks deadlock in coroutine contexts. Use SuspendWork directly instead.",
+    level = DeprecationLevel.WARNING
+)
 fun SuspendWork.asBlocking(): Work = Work { ctx ->
     runBlocking { execute(ctx) }
 }

--- a/utils/workflow/src/test/kotlin/io/bluetape4k/workflow/api/WorkAdapterTest.kt
+++ b/utils/workflow/src/test/kotlin/io/bluetape4k/workflow/api/WorkAdapterTest.kt
@@ -56,6 +56,7 @@ class WorkAdapterTest: AbstractWorkflowTest() {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `SuspendWork asBlocking 정상 변환`() {
         val suspendWork = SuspendWork { ctx -> WorkReport.success(ctx) }
         val blockingWork = suspendWork.asBlocking()
@@ -66,6 +67,7 @@ class WorkAdapterTest: AbstractWorkflowTest() {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `SuspendWork asBlocking 결과가 원본 SuspendWork와 동일`() {
         val ctx = WorkContext()
         ctx["input"] = 42


### PR DESCRIPTION
## Summary

Closes #476

- PR 제목: fix: Lettuce runBlocking/runCatching + Retrofit HC5/Vert.x cancel+tag + HC5 Feign tests (#476, #484, #489, #506, #507)

Fixes #476, #484, #489, #506, #507

---

### #484 - Retrofit HC5 + Vert.x Call cancel/tag contract

**Problem**: `cancel()` only cancelled the `CompletableFuture` but not the underlying HTTP request. `isCanceled()` was unreliable (derived from future state). `tag()` methods returned null/discarded values without storage.

**Fix**:
- `Hc5CallFactory`: capture the `Future<SimpleHttpResponse>` returned by `asyncClient.execute()` as `hc5Future` and call `hc5Future?.cancel(true)` in `cancel()`. Add `@Volatile var cancelled` flag for authoritative `isCanceled()`. Handle the race where `cancel()` is called before `hc5Future` is assigned.
- `VertxCallFactory`: capture `HttpClientRequest` as `vertxRequest` and call `vertxRequest?.reset()` in `cancel()`. Skip `req.send()` if already cancelled. Same `@Volatile cancelled` flag.
- Both: replace `tag()` no-ops with `ConcurrentHashMap<Class<*>, Any>` backing store. Read variants cast from map keyed by `type.java`; compute-if-absent variants delegate to `ConcurrentHashMap.computeIfAbsent`.

### #489 - Apache HC5 Feign coroutine tests re-enable

**Problem**: `ApacheHc5HttpbinCoroutineJacksonTest` and `ApacheHc5HttpbinCoroutineFastjsonTest` had `get post's comments()` disabled with empty override.

**Fix**: Removed the `@Disabled` override entirely. The parent `AbstractHttpbinCoroutineTest.get post's comments()` implementation works correctly with `AsyncApacheHttp5Client`.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary
Fixes #476, #484, #489, #506, #507

---

### #484 - Retrofit HC5 + Vert.x Call cancel/tag contract

**Problem**: `cancel()` only cancelled the `CompletableFuture` but not the underlying HTTP request. `isCanceled()` was unreliable (derived from future state). `tag()` methods returned null/discarded values without storage.

**Fix**:
- `Hc5CallFactory`: capture the `Future<SimpleHttpResponse>` returned by `asyncClient.execute()` as `hc5Future` and call `hc5Future?.cancel(true)` in `cancel()`. Add `@Volatile var cancelled` flag for authoritative `isCanceled()`. Handle the race where `cancel()` is called before `hc5Future` is assigned.
- `VertxCallFactory`: capture `HttpClientRequest` as `vertxRequest` and call `vertxRequest?.reset()` in `cancel()`. Skip `req.send()` if already cancelled. Same `@Volatile cancelled` flag.
- Both: replace `tag()` no-ops with `ConcurrentHashMap<Class<*>, Any>` backing store. Read variants cast from map keyed by `type.java`; compute-if-absent variants delegate to `ConcurrentHashMap.computeIfAbsent`.

### #489 - Apache HC5 Feign coroutine tests re-enable

**Problem**: `ApacheHc5HttpbinCoroutineJacksonTest` and `ApacheHc5HttpbinCoroutineFastjsonTest` had `get post's comments()` disabled with empty override.

**Fix**: Removed the `@Disabled` override entirely. The parent `AbstractHttpbinCoroutineTest.get post's comments()` implementation works correctly with `AsyncApacheHttp5Client`.

### Test Results
- `bluetape4k-retrofit2`: all tests pass (0 failures, 0 skipped)
- `bluetape4k-feign`: 232 tests pass (0 failures, 0 skipped) — 2 previously permanently skipped tests now pass

## Validation

- `bluetape4k-retrofit2`: all tests pass (0 failures, 0 skipped)
- `bluetape4k-feign`: 232 tests pass (0 failures, 0 skipped) — 2 previously permanently skipped tests now pass

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #476, milestone `1.8.0`, assignee `debop`
- PR: #512, head `eff344549f99f2a69a499ebe70d97c480a5b2119`, milestone `1.8.0`, assignee `debop`
- Base: `develop`, head branch `fix/lettuce-runblocking-cancellation`
- Labels: `bug`, `1.8.0-before`
- State: `MERGED`, merge commit `ce31d067963ea25d4be8e3acb9687e9bd381d9e6`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #512 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `ce31d067963ea25d4be8e3acb9687e9bd381d9e6`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
