### PR TITLE
fix: add reference-counting for per-key Mutex cleanup in CacheCoroutineLocks (#499)

### DIFF
--- a/infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/cache/CacheCoroutines.kt
+++ b/infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/cache/CacheCoroutines.kt
@@ -14,21 +14,49 @@ import kotlin.concurrent.withLock
 @PublishedApi
 internal object CacheCoroutineLocks {
     private val lock = ReentrantLock()
+
+    /**
+     * Holds a [Mutex] and its active reference count.
+     *
+     * All fields are mutated exclusively under [CacheCoroutineLocks.lock], so no
+     * additional synchronization is required inside this class.
+     */
+    private class MutexEntry(val mutex: Mutex, var refCount: Int = 0)
+
     // Plain HashMap is sufficient because all access is under lock.
     // WeakHashMap: the inner map is GC'd when the Cache key becomes unreachable.
-    private val locksByCache = WeakHashMap<Cache<*, *>, HashMap<Any, Mutex>>()
+    private val locksByCache = WeakHashMap<Cache<*, *>, HashMap<Any, MutexEntry>>()
 
+    /**
+     * Returns the per-key [Mutex] for [cache] + [key], incrementing its reference
+     * count. Every call to [mutexFor] must be paired with exactly one call to
+     * [release] to prevent unbounded memory growth.
+     */
     fun mutexFor(cache: Cache<*, *>, key: Any): Mutex = lock.withLock {
-        locksByCache.getOrPut(cache) { HashMap() }.getOrPut(key) { Mutex() }
+        val entry = locksByCache.getOrPut(cache) { HashMap() }
+            .getOrPut(key) { MutexEntry(Mutex()) }
+        entry.refCount++
+        entry.mutex
     }
 
-    fun release(cache: Cache<*, *>, key: Any, mutex: Mutex) {
-        // Per-key Mutex entries are intentionally not removed here.
-        // Removing an entry while a concurrent caller holds the Mutex reference
-        // but has not yet acquired it would allow a new caller to receive a
-        // different Mutex for the same key — breaking the per-key serialization
-        // guarantee. The WeakHashMap reclaims the entire inner map when the
-        // Cache key becomes unreachable, so memory is bounded per Cache lifetime.
+    /**
+     * Decrements the reference count for [cache] + [key]. When the count reaches
+     * zero no caller holds a reference to the entry, so it is safe to remove it
+     * from the map. Because removal happens under [lock] and only after the count
+     * is confirmed to be zero, no concurrent [mutexFor] call for the same key can
+     * observe the stale entry — they either see the existing entry (refCount > 0)
+     * or create a fresh one.
+     */
+    fun release(cache: Cache<*, *>, key: Any, mutex: Mutex) = lock.withLock {
+        val perCache = locksByCache[cache] ?: return@withLock
+        val entry = perCache[key] ?: return@withLock
+        entry.refCount--
+        if (entry.refCount <= 0) {
+            perCache.remove(key)
+            if (perCache.isEmpty()) {
+                locksByCache.remove(cache)
+            }
+        }
     }
 }
 

--- a/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/cache/CacheExtensionsTest.kt
+++ b/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/cache/CacheExtensionsTest.kt
@@ -153,4 +153,30 @@ class CacheExtensionsTest {
 
         thrown.message shouldBeEqualTo cancellation.message
     }
+
+    @Test
+    fun `CacheCoroutineLocks release removes mutex entry when all callers release`() = runSuspendTest {
+        val jcache = CaffeineJCacheProvider.getJCache<String, String>("refcount-test")
+        val cache = Cache.of(jcache)
+        val key = "refcount-test-key"
+
+        // Two callers acquire a Mutex for the same key — they must get the same instance.
+        val mutex1 = CacheCoroutineLocks.mutexFor(cache, key)
+        val mutex2 = CacheCoroutineLocks.mutexFor(cache, key)
+        (mutex1 === mutex2) shouldBeEqualTo true
+
+        // Release one of the two references — entry must still be alive.
+        CacheCoroutineLocks.release(cache, key, mutex1)
+        val mutex3 = CacheCoroutineLocks.mutexFor(cache, key)
+        (mutex3 === mutex1) shouldBeEqualTo true   // same entry still present
+
+        // Release all remaining references (mutex2 + mutex3 = 2 remaining).
+        CacheCoroutineLocks.release(cache, key, mutex2)
+        CacheCoroutineLocks.release(cache, key, mutex3)
+
+        // Entry has been removed. A fresh mutexFor call must create a new Mutex instance.
+        val mutex4 = CacheCoroutineLocks.mutexFor(cache, key)
+        (mutex4 === mutex1) shouldBeEqualTo false  // new Mutex after full release
+        CacheCoroutineLocks.release(cache, key, mutex4)
+    }
 }


### PR DESCRIPTION
## Summary

Closes #499

- PR 제목: fix: add reference-counting for per-key Mutex cleanup in CacheCoroutineLocks (#499)

Fixes #499

Per-key `Mutex` entries in `CacheCoroutineLocks` now use reference-counting to prevent unbounded memory growth in high-cardinality key scenarios.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### `CacheCoroutines.kt`
- Introduced private `MutexEntry` class holding a `Mutex` and an integer `refCount`
- `mutexFor`: increments `refCount` before returning the `Mutex`
- `release`: decrements `refCount`; removes the entry (and parent map if empty) when count reaches zero
- All operations remain under `lock.withLock {}` — no new race conditions introduced
- Removal is safe because it only happens when `refCount == 0`, meaning no caller currently holds a reference; concurrent `mutexFor` calls either see the existing entry (while `refCount > 0`) or create a fresh one

### `CacheExtensionsTest.kt`
- Added `CacheCoroutineLocks release removes mutex entry when all callers release` test
  - Verifies two callers for the same key receive the same `Mutex` instance
  - Verifies partial release keeps the entry alive
  - Verifies full release causes the next `mutexFor` call to create a new `Mutex` instance

## Validation

```
./gradlew :bluetape4k-resilience4j:test --tests "io.bluetape4k.resilience4j.cache.*" -x detekt
```

- CacheExtensionsTest: **7 passed, 0 failed, 0 skipped** (including new ref-count test)
- All cache test classes: BUILD SUCCESSFUL

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #499, milestone `1.8.0`, assignee `debop`
- PR: #513, head `9208100a22a28417450b5741464ba958947a024e`, milestone `1.8.0`, assignee `debop`
- Base: `develop`, head branch `fix/cache-mutex-refcount`
- Labels: `bug`, `1.8.0-before`
- State: `MERGED`, merge commit `7238d5b42be5521d27e664928368063489616753`
- CI: ./gradlew :bluetape4k-resilience4j:test --tests "io.bluetape4k.resilience4j.cache.*" -x detekt

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #513 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `7238d5b42be5521d27e664928368063489616753`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
