### PR TITLE
fix: correct near-cache suspend event propagation and clarify Hazelcast backend constraint (#490)

### DIFF
--- a/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/jcache/AbstractSuspendNearJCacheTest.kt
+++ b/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/jcache/AbstractSuspendNearJCacheTest.kt
@@ -49,11 +49,27 @@ abstract class AbstractSuspendNearJCacheTest
     protected val frontCoCache1 by lazy { createFrontSuspendCache(Duration.ofMinutes(5)) }
     protected val frontCoCache2 by lazy { createFrontSuspendCache(Duration.ofMinutes(10)) }
 
+    /**
+     * Creates a [SuspendNearJCache] for the given front and back caches.
+     *
+     * Override in subclasses that cannot register a listener (e.g. Hazelcast, which requires
+     * [javax.cache.configuration.CacheEntryListenerConfiguration] to be Serializable for cluster
+     * distribution) to call [SuspendNearJCache.withoutListener] instead.
+     *
+     * The default implementation calls [SuspendNearJCache.invoke] which registers a
+     * [io.bluetape4k.cache.jcache.SuspendJCacheEntryEventListener] on [backSuspendJCache] so that
+     * mutations propagate from back → front.
+     */
+    protected open fun createSuspendNearJCache(
+        front: SuspendJCache<String, Any>,
+        back: SuspendJCache<String, Any>,
+    ): SuspendNearJCache<String, Any> = SuspendNearJCache.invoke(front, back)
+
     protected val suspendNearJCache1: SuspendNearJCache<String, Any> by lazy {
-        SuspendNearJCache(frontCoCache1, backSuspendJCache)
+        createSuspendNearJCache(frontCoCache1, backSuspendJCache)
     }
     protected val suspendNearJCache2: SuspendNearJCache<String, Any> by lazy {
-        SuspendNearJCache(frontCoCache2, backSuspendJCache)
+        createSuspendNearJCache(frontCoCache2, backSuspendJCache)
     }
 
     @BeforeEach

--- a/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
+++ b/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
@@ -7,7 +7,12 @@ import io.bluetape4k.logging.KLogging
 import org.junit.jupiter.api.Disabled
 import javax.cache.configuration.MutableConfiguration
 
-@Disabled("Hazelcast 가 MutableCacheEntryListenerConfiguration 이 Serializable 이 아니라고 해서 지원할 수 없습니다.")
+@Disabled(
+    "이유: Hazelcast는 MutableCacheEntryListenerConfiguration을 클러스터 전체에 직렬화하여 배포하므로 " +
+        "non-Serializable 리스너(JCacheEntryEventListener)를 등록할 수 없습니다. " +
+        "HazelcastSerializationException: NotSerializableException. " +
+        "Tracked: #490"
+)
 class HazelcastNearJCacheTest: AbstractNearJCacheTest() {
 
     companion object: KLogging()

--- a/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastSuspendNearJCacheTest.kt
+++ b/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastSuspendNearJCacheTest.kt
@@ -8,7 +8,12 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import org.junit.jupiter.api.Disabled
 import java.time.Duration
 
-@Disabled("HazelcastSuspendNearJCache 가 EventListener 제대로 동작하지 않습니다")
+@Disabled(
+    "이유: Hazelcast는 CacheEntryListenerConfiguration을 클러스터 전체에 직렬화하여 배포하므로 " +
+        "CaffeineSuspendJCache(non-Serializable)를 캡처한 SuspendJCacheEntryEventListener를 등록할 수 없습니다. " +
+        "HazelcastSerializationException: NotSerializableException(CaffeineSuspendJCache). " +
+        "Tracked: #490"
+)
 class HazelcastSuspendNearJCacheTest: AbstractSuspendNearJCacheTest() {
 
     companion object: KLoggingChannel()

--- a/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/LettuceSuspendNearJCacheTest.kt
+++ b/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/LettuceSuspendNearJCacheTest.kt
@@ -7,7 +7,6 @@ import io.bluetape4k.cache.jcache.SuspendJCache
 import io.bluetape4k.codec.Base58
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodecs
-import org.junit.jupiter.api.Disabled
 import java.time.Duration
 
 /**
@@ -17,7 +16,6 @@ import java.time.Duration
  * [io.bluetape4k.cache.jcache.LettuceSuspendJCache]의 Channel 기반 [javax.cache.event.CacheEntryListener] 지원으로
  * 이벤트 전파가 동작합니다.
  */
-@Disabled("LettuceSuspendNearJCache 의 EventListener 가 동작하지 않습니다.")
 class LettuceSuspendNearJCacheTest: AbstractSuspendNearJCacheTest() {
 
     companion object: KLoggingChannel()

--- a/cache/cache-redisson/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/RedissonSuspendNearJCacheTest.kt
+++ b/cache/cache-redisson/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/RedissonSuspendNearJCacheTest.kt
@@ -6,7 +6,6 @@ import io.bluetape4k.cache.jcache.RedissonSuspendJCache
 import io.bluetape4k.cache.jcache.SuspendJCache
 import io.bluetape4k.codec.Base58
 import io.bluetape4k.logging.coroutines.KLoggingChannel
-import org.junit.jupiter.api.Disabled
 import java.time.Duration
 
 /**
@@ -14,7 +13,6 @@ import java.time.Duration
  *
  * Caffeine front + Redisson SuspendCache back 2-tier SuspendNearCache 패턴을 검증합니다.
  */
-@Disabled("버그가 많아 일단 테스트에서 제외한다.")
 class RedissonSuspendNearJCacheTest: AbstractSuspendNearJCacheTest() {
 
     companion object: KLoggingChannel()

--- a/docs/lessons/2026-05-16-nearcache-event-propagation.md
+++ b/docs/lessons/2026-05-16-nearcache-event-propagation.md
@@ -1,0 +1,107 @@
+# Near-Cache Event Propagation: Root Cause and Per-Backend Verdict
+
+**Issue**: #490  
+**Branch**: fix/nearcache-event-propagation  
+**Date**: 2026-05-16
+
+## Root Cause
+
+`AbstractSuspendNearJCacheTest` created `suspendNearJCache1`/`2` by calling the
+`SuspendNearJCache` **internal constructor** directly:
+
+```kotlin
+// BEFORE (broken) — bypasses listener registration
+protected val suspendNearJCache1 by lazy {
+    SuspendNearJCache(frontCoCache1, backSuspendJCache)
+}
+```
+
+`SuspendNearJCache` has an `internal constructor(frontCache, backCache)` and a
+companion `operator fun invoke(frontCache, backCache)` with identical parameter types.
+Because testFixtures live in the **same module** as main source, the `internal`
+constructor is visible, and Kotlin resolves `SuspendNearJCache(front, back)` to the
+**constructor**, not the companion `invoke`. The companion `invoke` is the only path
+that registers `SuspendJCacheEntryEventListener` on the back cache, so no events
+ever propagated → every cross-cache propagation assertion timed out.
+
+The sync `AbstractNearJCacheTest` was unaffected because it calls
+`NearJCache(nearCacheCfg, backCache)` which maps to the companion `invoke(nearCacheCfg,
+backCache)` — different parameter types from the constructor — so there was never ambiguity.
+
+## Fix
+
+Added an `open fun createSuspendNearJCache(front, back)` hook to the test fixture,
+with default body `SuspendNearJCache.invoke(front, back)` (explicit companion call):
+
+```kotlin
+// AFTER (correct) — explicit companion invoke registers listener
+protected open fun createSuspendNearJCache(
+    front: SuspendJCache<String, Any>,
+    back: SuspendJCache<String, Any>,
+): SuspendNearJCache<String, Any> = SuspendNearJCache.invoke(front, back)
+
+protected val suspendNearJCache1 by lazy { createSuspendNearJCache(frontCoCache1, backSuspendJCache) }
+protected val suspendNearJCache2 by lazy { createSuspendNearJCache(frontCoCache2, backSuspendJCache) }
+```
+
+The `open` hook allows Hazelcast (and any future backend) to override with
+`SuspendNearJCache.withoutListener(front, back)` when listener registration is
+structurally impossible.
+
+## Per-Backend Verdicts
+
+### Lettuce (cache-lettuce)
+**Verdict A — re-enabled.**  
+`LettuceJCache.dispatchEvent()` is in-process (`ConcurrentHashMap` of listeners, called
+synchronously after each mutation). Once the fixture bug was fixed, all 19 test
+methods pass. Removed `@Disabled`.
+
+### Redisson (cache-redisson)
+**Verdict A — re-enabled.**  
+After the fixture fix, all tests pass. The `SuspendNearJCache` implementation already
+works around Redisson's `removeAll`/`replace` event gaps via explicit per-key removes.
+Prior `@Disabled("버그가 많아 일단 테스트에서 제외한다.")` was stale. Removed `@Disabled`.
+
+### Hazelcast sync (cache-hazelcast — HazelcastNearJCacheTest)
+**Verdict B — kept disabled with precise reason.**  
+Hazelcast cluster-distributes `MutableCacheEntryListenerConfiguration` by Java
+serialization. `JCacheEntryEventListener` holds a reference to the front `JCache`
+(Caffeine) which is not `Serializable`. Registration throws
+`HazelcastSerializationException: NotSerializableException`. Updated `@Disabled`
+message with `Tracked: #490`.
+
+### Hazelcast suspend (cache-hazelcast — HazelcastSuspendNearJCacheTest)
+**Verdict B — kept disabled with precise reason.**  
+Same structural constraint as sync: `SuspendJCacheEntryEventListener` captures a
+`CaffeineSuspendJCache` (not `Serializable`). Registration throws
+`HazelcastSerializationException: NotSerializableException(CaffeineSuspendJCache)`.
+Updated `@Disabled` message with `Tracked: #490`.
+
+## Lesson: Kotlin Companion Invoke vs Internal Constructor Ambiguity
+
+When a class has both an `internal constructor(A, B)` and a companion
+`operator fun invoke(A, B)` with **identical parameter types**, code in the same
+module calling `ClassName(a, b)` resolves to the **constructor**, not the companion
+`invoke`. This is the opposite of what you might assume if you only looked at
+visibility from outside the module.
+
+**Always use `ClassName.invoke(...)` or `ClassName.Companion.invoke(...)` explicitly**
+when the companion invoke is the intended entry point and the constructor must be
+bypassed. Alternatively, make the constructor `private` to eliminate the ambiguity.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `cache/cache-core/src/testFixtures/.../AbstractSuspendNearJCacheTest.kt` | Added `createSuspendNearJCache` hook; default calls `SuspendNearJCache.invoke(...)` |
+| `cache/cache-lettuce/src/test/.../LettuceSuspendNearJCacheTest.kt` | Removed `@Disabled` |
+| `cache/cache-redisson/src/test/.../RedissonSuspendNearJCacheTest.kt` | Removed `@Disabled` |
+| `cache/cache-hazelcast/src/test/.../HazelcastNearJCacheTest.kt` | Updated `@Disabled` with precise reason + `Tracked: #490` |
+| `cache/cache-hazelcast/src/test/.../HazelcastSuspendNearJCacheTest.kt` | Updated `@Disabled` with precise reason + `Tracked: #490` |
+
+## Test Results
+
+- `bluetape4k-cache-core:test --tests "*NearJCache*"` → BUILD SUCCESSFUL
+- `bluetape4k-cache-lettuce:test --tests "*NearJCache*"` → BUILD SUCCESSFUL (was failing)
+- `bluetape4k-cache-redisson:test --tests "*NearJCache*"` → BUILD SUCCESSFUL (was disabled)
+- `bluetape4k-cache-hazelcast:test --tests "*NearJCache*"` → BUILD SUCCESSFUL (Hazelcast tests skipped per @Disabled)


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: correct near-cache suspend event propagation and clarify Hazelcast backend constraint (#490)

Fixes near-cache event propagation for Lettuce and Redisson suspend backends, and documents the structural constraint that prevents Hazelcast from supporting JCache listener registration.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

Added an `open fun createSuspendNearJCache(front, back)` hook to the test fixture base class. Default calls `SuspendNearJCache.invoke(front, back)` explicitly:

```kotlin
// AFTER — explicit companion invoke registers listener
protected open fun createSuspendNearJCache(
    front: SuspendJCache<String, Any>,
    back: SuspendJCache<String, Any>,
): SuspendNearJCache<String, Any> = SuspendNearJCache.invoke(front, back)
```

### 기존 섹션: Root Cause

`AbstractSuspendNearJCacheTest` created `suspendNearJCache1`/`2` by calling the **internal constructor** of `SuspendNearJCache` directly:

```kotlin
// BEFORE — calls internal constructor, bypasses listener registration
SuspendNearJCache(frontCoCache1, backSuspendJCache)
```

`SuspendNearJCache` has both an `internal constructor(frontCache, backCache)` and a companion `operator fun invoke(frontCache, backCache)` with **identical parameter types**. Since testFixtures are in the same module, the internal constructor is visible, and Kotlin resolves `SuspendNearJCache(front, back)` to the **constructor**, not the companion `invoke`. The listener registration happens only in the companion `invoke`, so no events ever propagated.

### 기존 섹션: Per-Backend Verdicts

| Backend | Before | After | Reason |
|---|---|---|---|
| Lettuce suspend | `@Disabled` (stale) | **Enabled, all pass** | In-process `dispatchEvent()` works correctly |
| Redisson suspend | `@Disabled` (vague) | **Enabled, all pass** | `SuspendNearJCache` workarounds cover Redisson event gaps |
| Hazelcast sync | `@Disabled` (imprecise) | `@Disabled` (precise + Tracked) | `MutableCacheEntryListenerConfiguration` must be Serializable; listeners are not |
| Hazelcast suspend | `@Disabled` (vague) | `@Disabled` (precise + Tracked) | Same: `CaffeineSuspendJCache` is not Serializable |

### 기존 섹션: Lesson

When a class has both an `internal constructor(A, B)` and a companion `operator fun invoke(A, B)` with **identical parameter types**, same-module code calling `ClassName(a, b)` resolves to the **constructor**, not the companion invoke. Always call `ClassName.invoke(...)` explicitly when the companion invoke is the intended entry point.

## Validation

```
./gradlew :bluetape4k-cache-core:test :bluetape4k-cache-lettuce:test :bluetape4k-cache-redisson:test :bluetape4k-cache-hazelcast:test --tests "*NearJCache*" -x detekt
BUILD SUCCESSFUL in 2m 11s
```

- `LettuceSuspendNearJCacheTest`: all 19 tests PASSED (was `@Disabled`)
- `RedissonSuspendNearJCacheTest`: all 19 tests PASSED (was `@Disabled`)
- `HazelcastNearJCacheTest`: SKIPPED per `@Disabled` (structural constraint confirmed empirically)
- `HazelcastSuspendNearJCacheTest`: SKIPPED per `@Disabled` (structural constraint confirmed empirically)
- `Cache2KNearJJCacheTest`: unchanged, still passing

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #490, milestone `1.8.0`, assignee debop
- PR: #514, head `b18fea97693798a21714d253ca5be9ab48df5c35`, milestone `1.8.0`, assignee `debop`
- Base: `develop`, head branch `fix/nearcache-event-propagation`
- Labels: `bug`, `1.8.0-before`
- State: `MERGED`, merge commit `0fc608f6b0631b687ee900106b7ff013186fa9fa`
- CI: Added an `open fun createSuspendNearJCache(front, back)` hook to the test fixture base class. Default calls `SuspendNearJCache.invoke(front, back)` explicitly: / // AFTER — explicit companion invoke registers listener / | Hazelcast sync | `@Disabled` (imprecise) | `@Disabled` (precise + Tracked) | `MutableCacheEntryListenerConfiguration` must be Serializable; listeners are not |
## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #514 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `0fc608f6b0631b687ee900106b7ff013186fa9fa`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
