### PR TITLE
fix(kafka): use instance-based codec config to honour allowedTypePackages in CustomKafkaExamples

### DIFF
--- a/docs/lessons/2026-05-17-kafka-jackson-codec-allowed-types.md
+++ b/docs/lessons/2026-05-17-kafka-jackson-codec-allowed-types.md
@@ -1,0 +1,53 @@
+# Kafka JacksonKafkaCodec: allowedTypePackages Security Feature Breaks Tests (2026-05-17)
+
+## Root Cause
+
+`JacksonKafkaCodec` introduced a `allowedTypePackages` allowlist in 1.8.0 (empty by default).
+When a codec is configured via class reference in Kafka producer/consumer properties:
+
+```kotlin
+this[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = JacksonKafkaCodec::class.java
+```
+
+Kafka instantiates the class with its no-arg constructor, which sets `allowedTypePackages = emptySet()`.
+At deserialization time, `getValueType()` rejects any class name from the Kafka type header
+because nothing matches the empty set — throwing `IllegalArgumentException`.
+
+Spring Kafka catches the deserializer exception and delivers a `KafkaNull` payload to the listener.
+The listener method expects a typed object (`Greeting`), so Spring throws
+`MethodArgumentNotValidException: Payload value must not be empty`.
+The listener never increments the counter, and `await until { counter >= 2 }` times out.
+
+The CI failure presented as `ConditionTimeoutException` (10 s default), masking the real cause.
+
+## Fix
+
+Switch from class-reference-based to instance-based serializer/deserializer configuration
+so `allowedTypePackages` can be set explicitly:
+
+```kotlin
+private fun valueCodec() = JacksonKafkaCodec(
+    allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
+)
+
+@Bean
+@Suppress("UNCHECKED_CAST")
+fun producerFactory(): ProducerFactory<String, Greeting> {
+    return KafkaServer.Launcher.Spring.getProducerFactory(
+        keySerializer = StringKafkaCodec(),
+        valueSerializer = valueCodec()
+    ) as ProducerFactory<String, Greeting>
+}
+```
+
+Also raised the Awaitility timeout from the 10 s default to 30 s as a safety buffer for CI load.
+
+## Lesson
+
+When `JacksonKafkaCodec` (or any `AbstractKafkaCodec` subclass) is configured via class reference
+in Kafka properties, the no-arg constructor is used — `allowedTypePackages` is always empty.
+Tests using class-reference-based codec config will silently fail after the 1.8.0 security upgrade.
+
+**Rule**: In tests that deserialize typed objects with `JacksonKafkaCodec`, always use
+instance-based factory configuration (via `KafkaServer.Launcher.Spring.getProducerFactory(serializer, ...)`)
+rather than `*_CLASS_CONFIG = SomeCodec::class.java`.

--- a/infra/kafka/src/test/kotlin/org/springframework/kafka/core/CustomKafkaExamples.kt
+++ b/infra/kafka/src/test/kotlin/org/springframework/kafka/core/CustomKafkaExamples.kt
@@ -1,5 +1,6 @@
 package org.springframework.kafka.core
 
+import io.bluetape4k.kafka.codec.AbstractKafkaCodec
 import io.bluetape4k.kafka.codec.JacksonKafkaCodec
 import io.bluetape4k.kafka.codec.StringKafkaCodec
 import io.bluetape4k.logging.coroutines.KLoggingChannel
@@ -10,8 +11,6 @@ import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.test.runTest
 import io.bluetape4k.assertions.shouldNotBeNull
-import org.apache.kafka.clients.consumer.ConsumerConfig
-import org.apache.kafka.clients.producer.ProducerConfig
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.until
 import org.junit.jupiter.api.Test
@@ -27,6 +26,7 @@ import org.springframework.messaging.handler.annotation.Header
 import org.springframework.messaging.handler.annotation.Headers
 import org.springframework.messaging.handler.annotation.Payload
 import java.io.Serializable
+import java.time.Duration
 
 @SpringBootTest
 class CustomKafkaExamples {
@@ -40,30 +40,29 @@ class CustomKafkaExamples {
     @EnableKafka
     class TestConfiguration {
 
-        @Bean
-        fun producerProperties(): MutableMap<String, Any?> {
-            return KafkaServer.Launcher.getProducerProperties().apply {
-                this[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = StringKafkaCodec::class.java
-                this[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = JacksonKafkaCodec::class.java
-            }
-        }
+        // Use instance-based serializers so allowedTypePackages can be configured.
+        // Class-reference config uses the default constructor (allowedTypePackages=emptySet),
+        // which rejects all types from the Kafka type header (security feature added in 1.8.0).
+        private fun valueCodec() = JacksonKafkaCodec(
+            allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
+        )
 
         @Bean
+        @Suppress("UNCHECKED_CAST")
         fun producerFactory(): ProducerFactory<String, Greeting> {
-            return KafkaServer.Launcher.Spring.getProducerFactory(producerProperties())
+            return KafkaServer.Launcher.Spring.getProducerFactory(
+                keySerializer = StringKafkaCodec(),
+                valueSerializer = valueCodec()
+            ) as ProducerFactory<String, Greeting>
         }
 
         @Bean
-        fun consumerProperties(): MutableMap<String, Any?> {
-            return KafkaServer.Launcher.getConsumerProperties().apply {
-                this[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringKafkaCodec::class.java
-                this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = JacksonKafkaCodec::class.java
-            }
-        }
-
-        @Bean
+        @Suppress("UNCHECKED_CAST")
         fun consumerFactory(): ConsumerFactory<String, Greeting> {
-            return KafkaServer.Launcher.Spring.getConsumerFactory(consumerProperties())
+            return KafkaServer.Launcher.Spring.getConsumerFactory(
+                keyDeserializer = StringKafkaCodec(),
+                valueDeserializer = valueCodec()
+            ) as ConsumerFactory<String, Greeting>
         }
 
         @Bean
@@ -108,7 +107,7 @@ class CustomKafkaExamples {
         log.debug { "produceRecord=${result.producerRecord}" }
         log.debug { "recordMetadata=${result.recordMetadata}" }
 
-        await until { receiveCounter.value >= 2 }
+        await.atMost(Duration.ofSeconds(30)) until { receiveCounter.value >= 2 }
     }
 
     @KafkaListener(topics = [CUSTOM_TOPIC_NAME], groupId = "custom")

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/core/CustomKafkaExamples.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/core/CustomKafkaExamples.kt
@@ -1,5 +1,6 @@
 package org.springframework.kafka.core
 
+import io.bluetape4k.kafka.codec.AbstractKafkaCodec
 import io.bluetape4k.kafka.codec.JacksonKafkaCodec
 import io.bluetape4k.kafka.codec.StringKafkaCodec
 import io.bluetape4k.logging.coroutines.KLoggingChannel
@@ -10,8 +11,6 @@ import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.test.runTest
 import io.bluetape4k.assertions.shouldNotBeNull
-import org.apache.kafka.clients.consumer.ConsumerConfig
-import org.apache.kafka.clients.producer.ProducerConfig
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.until
 import org.junit.jupiter.api.Test
@@ -27,6 +26,7 @@ import org.springframework.messaging.handler.annotation.Header
 import org.springframework.messaging.handler.annotation.Headers
 import org.springframework.messaging.handler.annotation.Payload
 import java.io.Serializable
+import java.time.Duration
 
 @SpringBootTest
 class CustomKafkaExamples {
@@ -40,30 +40,29 @@ class CustomKafkaExamples {
     @EnableKafka
     class TestConfiguration {
 
-        @Bean
-        fun producerProperties(): MutableMap<String, Any?> {
-            return KafkaServer.Launcher.getProducerProperties().apply {
-                this[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = StringKafkaCodec::class.java
-                this[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = JacksonKafkaCodec::class.java
-            }
-        }
+        // Use instance-based serializers so allowedTypePackages can be configured.
+        // Class-reference config uses the default constructor (allowedTypePackages=emptySet),
+        // which rejects all types from the Kafka type header (security feature added in 1.8.0).
+        private fun valueCodec() = JacksonKafkaCodec(
+            allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
+        )
 
         @Bean
+        @Suppress("UNCHECKED_CAST")
         fun producerFactory(): ProducerFactory<String, Greeting> {
-            return KafkaServer.Launcher.Spring.getProducerFactory(producerProperties())
+            return KafkaServer.Launcher.Spring.getProducerFactory(
+                keySerializer = StringKafkaCodec(),
+                valueSerializer = valueCodec()
+            ) as ProducerFactory<String, Greeting>
         }
 
         @Bean
-        fun consumerProperties(): MutableMap<String, Any?> {
-            return KafkaServer.Launcher.getConsumerProperties().apply {
-                this[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringKafkaCodec::class.java
-                this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = JacksonKafkaCodec::class.java
-            }
-        }
-
-        @Bean
+        @Suppress("UNCHECKED_CAST")
         fun consumerFactory(): ConsumerFactory<String, Greeting> {
-            return KafkaServer.Launcher.Spring.getConsumerFactory(consumerProperties())
+            return KafkaServer.Launcher.Spring.getConsumerFactory(
+                keyDeserializer = StringKafkaCodec(),
+                valueDeserializer = valueCodec()
+            ) as ConsumerFactory<String, Greeting>
         }
 
         @Bean
@@ -108,7 +107,7 @@ class CustomKafkaExamples {
         log.debug { "produceRecord=${result.producerRecord}" }
         log.debug { "recordMetadata=${result.recordMetadata}" }
 
-        await until { receiveCounter.value >= 2 }
+        await.atMost(Duration.ofSeconds(30)) until { receiveCounter.value >= 2 }
     }
 
     @KafkaListener(topics = [CUSTOM_TOPIC_NAME], groupId = "custom")


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix(kafka): use instance-based codec config to honour allowedTypePackages in CustomKafkaExamples

Fixes `CustomKafkaExamples > send greeting()` failing in Nightly CI with `ConditionTimeoutException`.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

Switch from class-reference-based to instance-based serializer/deserializer config:

```kotlin
private fun valueCodec() = JacksonKafkaCodec(
    allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
)

@Bean @Suppress("UNCHECKED_CAST")
fun producerFactory(): ProducerFactory<String, Greeting> {
    return KafkaServer.Launcher.Spring.getProducerFactory(
        keySerializer = StringKafkaCodec(),
        valueSerializer = valueCodec()
    ) as ProducerFactory<String, Greeting>
}
```

Also raised Awaitility timeout from 10 s default to 30 s for CI load headroom.

### 기존 섹션: Root Cause

`JacksonKafkaCodec` introduced an `allowedTypePackages` allowlist in 1.8.0 (empty by default).

When configured via class reference in Kafka properties:
```kotlin
this[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = JacksonKafkaCodec::class.java
```
Kafka instantiates it with its no-arg constructor → `allowedTypePackages = emptySet()`.

At deserialization time, `getValueType()` rejects the `Greeting` class from the Kafka type header → Spring Kafka delivers `KafkaNull` to the listener → listener throws `MethodArgumentNotValidException` (Payload value must not be empty) → counter never increments → `await until { counter >= 2 }` times out.

The surface failure in CI was `ConditionTimeoutException` at line 103, which masked the real deserialization failure.

## Validation

```
./gradlew :bluetape4k-kafka:test
291 passing (46.5s) ✅
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #515, head `a26b8ee1fae027540441444304ac5b2755b2be19`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/kafka-flaky-timeout`
- Labels: 없음
- State: `MERGED`, merge commit `e11228c4b550b9ffa0681a8aaf97209167ccf5b8`
- CI: Fixes `CustomKafkaExamples > send greeting()` failing in Nightly CI with `ConditionTimeoutException`. / The surface failure in CI was `ConditionTimeoutException` at line 103, which masked the real deserialization failure. / Also raised Awaitility timeout from 10 s default to 30 s for CI load headroom.

## DoD Status

- [x] Tests passing: 291 passing, 0 failing
- [x] Root cause identified
- [x] Lessons committed: `docs/lessons/2026-05-17-kafka-jackson-codec-allowed-types.md`

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #515 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e11228c4b550b9ffa0681a8aaf97209167ccf5b8`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
