### PR TITLE
docs(kafka): fix allowedTypePackages table — emptySet() denies all since 1.8.0

### DIFF
--- a/infra/kafka/README.ko.md
+++ b/infra/kafka/README.ko.md
@@ -211,8 +211,9 @@ class SecureJacksonCodec : JacksonKafkaCodec() {
 
 | `allowedTypePackages` 값 | 동작 |
 |--------------------------|------|
-| `emptySet()` (기본값) | 모든 클래스 허용 — 하위 호환, 신뢰 환경 전용 |
-| 비어 있지 않은 집합 | 나열된 패키지 하위 클래스만 허용; 그 외 poison-pill `null` |
+| `emptySet()` (기본값) | **모든 클래스 차단** — 타입 헤더에서 클래스를 로드하지 않음. 신뢰할 수 없거나 공유된 토픽에 대한 안전한 기본값. |
+| 비어 있지 않은 집합 | 나열된 패키지 접두사와 일치하는 FQN 클래스만 허용; 그 외 poison-pill `null` 반환. |
+| `AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE` | 모든 검사 우회 — 1.8.0 이전의 허용-전체 동작 복원. 완전히 신뢰할 수 있는 내부 환경에서만 사용. |
 
 ### 5. Spring KafkaTemplate과 Coroutines
 

--- a/infra/kafka/README.md
+++ b/infra/kafka/README.md
@@ -212,8 +212,9 @@ class SecureJacksonCodec : JacksonKafkaCodec() {
 
 | `allowedTypePackages` value | Effect |
 |-----------------------------|--------|
-| `emptySet()` (default) | All classes allowed — backward-compatible, trusted environments only |
-| Non-empty set | Only classes under listed package prefixes allowed; others → poison-pill `null` |
+| `emptySet()` (default) | **Deny all** — no class is loaded from the type header. Safe default for untrusted or shared topics. |
+| Non-empty set | Only classes whose FQN equals or starts with a listed prefix are allowed; others → poison-pill `null`. |
+| `AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE` | Bypass all checks — restores pre-1.8.0 allow-all behavior. Use only in fully trusted, internally controlled deployments. |
 
 ### 5. Spring KafkaTemplate with Coroutines
 


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: docs(kafka): fix allowedTypePackages table — emptySet() denies all since 1.8.0

## Background

`infra/kafka/README.md` and `infra/kafka/README.ko.md` documented the pre-1.8.0 allow-all behavior for the `emptySet()` default:

```
| emptySet() (default) | All classes allowed — backward-compatible, trusted environments only |
```

As of 1.8.0 (PR #510), `emptySet()` **denies all** class loading from the type header — it is the secure default.
The code and the KDoc in `AbstractKafkaCodec` and `JacksonKafkaCodec` are correct. Only these README tables were wrong.

A user reading the old table would believe the default is unsafe and might explicitly set `ALLOW_ALL_TYPES_UNSAFE`, defeating the security fix.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Fix `emptySet()` row to document the deny-all behavior
- Add `ALLOW_ALL_TYPES_UNSAFE` row to make the opt-out path explicit
- Apply the same fix to `README.ko.md`

### 기존 섹션: Verification

```bash
grep -A3 'allowedTypePackages' infra/kafka/README.md
grep -A3 'allowedTypePackages' infra/kafka/README.ko.md
```

Both tables should now show: `emptySet()` → **Deny all**.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #520, head `43acc2a3cc77218fbff343021e46e3e108f9d057`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `docs/kafka-readme-allowlist-security`
- Labels: 없음
- State: `MERGED`, merge commit `9687aa8cece21336e4c76ac8f2b602949953b5cc`
- CI: A user reading the old table would believe the default is unsafe and might explicitly set `ALLOW_ALL_TYPES_UNSAFE`, defeating the security fix. / - Add `ALLOW_ALL_TYPES_UNSAFE` row to make the opt-out path explicit

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #520 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9687aa8cece21336e4c76ac8f2b602949953b5cc`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
