### PR TITLE
chore: parameterize snapshot publishing

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -79,7 +79,7 @@ jobs:
           PY
 
       - name: Publish SNAPSHOT
-        run: ./gradlew publishAggregationToCentralSnapshots --no-daemon --no-configuration-cache --no-build-cache
+        run: ./gradlew publishAggregationToCentralSnapshots -PsnapshotVersion=-SNAPSHOT --no-daemon --no-configuration-cache --no-build-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}

--- a/docs/lessons/2026-05-17-snapshot-version-parameterization.md
+++ b/docs/lessons/2026-05-17-snapshot-version-parameterization.md
@@ -1,0 +1,15 @@
+# Snapshot Version Parameterization
+
+Context: Central Portal releases should not require editing `gradle.properties`
+only to remove `-SNAPSHOT`.
+
+Decision: Keep `snapshotVersion=` empty by default and let
+`publish-snapshot.yml` pass `-PsnapshotVersion=-SNAPSHOT`.
+
+Outcome: `develop` stays release-ready, while snapshot publishing remains
+explicit in the workflow command.
+
+Verification: `actionlint .github/workflows/publish-snapshot.yml`.
+
+Future guard: Do not reintroduce `snapshotVersion=-SNAPSHOT` as the default in
+`gradle.properties`.

--- a/gradle.properties
+++ b/gradle.properties
@@ -77,4 +77,4 @@ centralSnapshotsParallelism=8
 #
 projectGroup=io.github.bluetape4k
 baseVersion=1.9.0
-snapshotVersion=-SNAPSHOT
+snapshotVersion=


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: chore: parameterize snapshot publishing

- keep snapshotVersion empty by default so the working tree stays release-ready
- pass -PsnapshotVersion=-SNAPSHOT from publish-snapshot.yml only
- add a lesson entry to preserve the release workflow decision

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- actionlint .github/workflows/publish-snapshot.yml

### 기존 섹션: Notes

- This PR does not publish artifacts, create tags, or trigger a release.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #523, head `5d418db243c07f1351ec66b371ce21ecd2b2df6d`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `chore/snapshot-version-parameterization`
- Labels: 없음
- State: `MERGED`, merge commit `427c1b79b3f880fcdb9791d38f0b046bd48ede56`
- CI: - add a lesson entry to preserve the release workflow decision

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #523 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `427c1b79b3f880fcdb9791d38f0b046bd48ede56`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
