### PR TITLE
fix: restore Spring Kafka 4 compatibility line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,11 @@ updates:
       - dependency-name: "org.springframework.boot:*"
         update-types:
           - "version-update:semver-major"
+      # Spring Kafka 3/4 compatibility aliases share the same Maven coordinate.
+      # Dependabot cannot preserve that version-catalog contract, so manage both
+      # aliases manually.
+      - dependency-name: "spring-kafka*"
+      - dependency-name: "org.springframework.kafka:*"
       # Redis client major baselines start here, then align outward after validation.
       - dependency-name: "io.lettuce:lettuce-core"
         update-types:
@@ -60,9 +65,6 @@ updates:
         update-types:
           - "version-update:semver-major"
       - dependency-name: "org.apache.kafka:*"
-        update-types:
-          - "version-update:semver-major"
-      - dependency-name: "org.springframework.kafka:*"
         update-types:
           - "version-update:semver-major"
       - dependency-name: "io.projectreactor.kafka:*"

--- a/docs/lessons/2026-05-18-spring-kafka4-dependabot-rollback.md
+++ b/docs/lessons/2026-05-18-spring-kafka4-dependabot-rollback.md
@@ -1,0 +1,29 @@
+# Spring Kafka 4 Dependabot Rollback
+
+## Context
+
+Dependabot PR #524 changed the `spring-kafka4` version-catalog alias from
+`4.0.5` to `3.3.15` in `gradle/libs.versions.toml`.
+
+## Decision
+
+Restore `spring-kafka4` to `4.0.5` and ignore `org.springframework.kafka:*`
+and `spring-kafka*` version-alias updates in Dependabot.
+
+## Outcome
+
+Spring Kafka 3 and Spring Kafka 4 compatibility lines stay manually managed.
+Dependabot cannot infer that both aliases use the same Maven coordinate with
+different compatibility baselines.
+
+## Verification
+
+- Checked `origin/develop` for `bluetape4k-projects`.
+- Compared all non-archived `bluetape4k` GitHub repositories for compatibility
+  alias drift across Spring Boot, Jackson, Kafka, and Spring Kafka lines.
+
+## Future Guard
+
+When a version catalog keeps multiple aliases for one Maven coordinate, do not
+let Dependabot update that coordinate unless the aliases can be split or grouped
+without collapsing compatibility lines.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -111,7 +111,7 @@ elasticsearch-java = "9.4.0"  # https://mvnrepository.com/artifact/co.elastic.cl
 kafka3 = "3.9.2"  # https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients; Server-side: spring-kafka 3.x embedded test (EmbeddedKafkaKraftBroker)
 kafka4 = "4.2.0"  # https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients; Client-side: kafka-clients, kafka-streams (production)
 spring-kafka = "3.3.13"  # https://mvnrepository.com/artifact/org.springframework.kafka/spring-kafka
-spring-kafka4 = "3.3.15"  # https://mvnrepository.com/artifact/org.springframework.kafka/spring-kafka
+spring-kafka4 = "4.0.5"  # https://mvnrepository.com/artifact/org.springframework.kafka/spring-kafka
 
 timefold-solver = "2.0.0"  # https://mvnrepository.com/artifact/ai.timefold.solver/timefold-solver-bom
 


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: restore Spring Kafka 4 compatibility line

- restore `spring-kafka4` from `3.3.15` to `4.0.5` after Dependabot collapsed the Spring Kafka 4 compatibility alias onto the 3.x line
- make Spring Kafka compatibility-line updates manual with `spring-kafka*` and `org.springframework.kafka:*` Dependabot ignores
- record the rollback lesson and org-wide compatibility alias audit

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Org-wide audit

- BAD drift found only in `bluetape4k-projects` and `bluetape4k-exposed`: `spring-kafka4 = 3.3.15`
- `jackson2`/`jackson3`, `spring-boot3`/`spring-boot4`, and `kafka3`/`kafka4` major lines are otherwise aligned across non-archived `bluetape4k` repositories

### 기존 섹션: Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'`\n- `./gradlew -q projects`\n- `git diff --check`\n- org-wide remote compatibility alias audit via `gh repo list` + `gh api contents/gradle/libs.versions.toml`\n- Local 6-tier review: P0/P1 = 0\n\n## Advisor\n- Claude Code CLI version check passed (`2.1.143`), but full, short, and `omx ask claude` advisor attempts returned no output and were terminated. Artifact recorded at workspace `.omx/artifacts/claude-spring-kafka4-rollback-20260518.md`.\n\n## Not tested\n- full Gradle build; catalog/config-only rollback

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #525, head `922c0b0052e963749a876a08dc5c1e7ec4258c83`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/restore-spring-kafka4`
- Labels: `dependencies`
- State: `MERGED`, merge commit `c46ac2402942301c1fa566e5889c0863d4159b96`
- CI: - `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'`\n- `./gradlew -q projects`\n- `git diff --check`\n- org-wide remote compatibility alias audit via `gh repo list` + `gh api contents/gradle/libs.versions.toml`\n- Local 6-tier review: P0/P1 = 0\n\n## Advisor\n- Claude Code CLI version check passed (`2.1.143`), but full, short, and `omx ask claude` advisor attempts returned no output and were terminated. Artifact recorded at workspace `.omx/artifacts/claude-spring-kafka4-rollback-20260518.md`.\n\n## Not tested\n- full Gradle build; catalog/config-only rollback

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #525 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `c46ac2402942301c1fa566e5889c0863d4159b96`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
