### PR TITLE
fix: add workers() concurrency control to StructuredTaskScopeTester (#522)

### DIFF
--- a/docs/lessons/2026-05-18-structured-task-scope-tester-workers.md
+++ b/docs/lessons/2026-05-18-structured-task-scope-tester-workers.md
@@ -1,0 +1,41 @@
+# StructuredTaskScopeTester workers() Concurrency Control
+
+**Date**: 2026-05-18  
+**Issue**: #522  
+**Branch**: fix/structured-task-scope-workers
+
+## Root Cause
+
+`StructuredTaskScopeTester` implemented `StressTester` (rounds only) and had no `workers()` method.
+All forked virtual threads ran without any concurrency cap, making `workers(n)` silently ineffective.
+
+## Decision
+
+- Upgrade to `WorkerStressTester<StructuredTaskScopeTester>` to gain the `workers()` contract.
+- Add an internal `Semaphore(workerSize)` acquired **inside** each forked task (not before fork).
+  - Acquiring inside the fork lets all tasks be submitted immediately; the semaphore gates actual execution.
+  - `finally { semaphore.release() }` guarantees release even on exception.
+  - On scope cancellation, threads blocked in `semaphore.acquire()` receive `InterruptedException` before
+    a permit is taken, so no permit leaks.
+- Default: `Runtime.getRuntime().availableProcessors() * 2` (mirrors issue acceptance criteria).
+  - `Systemx.availableProcessors` was the first choice but `bluetape4k-core` is not a dependency
+    of `bluetape4k-junit5`; use `Runtime` directly instead of adding the dependency.
+
+## Verification
+
+- 10 tests in `StructuredTaskScopeTesterTest` passing (0 failures).
+- 3 tests in `StressTesterContractTest` passing (updated to use `configureWorkerTester`).
+
+## Review Findings Resolved
+
+| Finding | Fix |
+|---------|-----|
+| Non-atomic peak-concurrency measurement (`incrementAndGet` + `getAndUpdate`) | Replaced with `Semaphore.tryAcquire()` inside the block — fails atomically if over limit |
+| `StressTesterContractTest` still used `configureRoundsTester` after interface upgrade | Updated to `configureWorkerTester(workers=2, rounds=4)` |
+
+## Future Guidance
+
+- When a tester gains `workers()`, always upgrade the contract test to `configureWorkerTester`.
+- For concurrency-limit tests, prefer `Semaphore.tryAcquire()` over an atomic counter + peak-update
+  pair — the two-step pattern has a TOCTOU gap that can hide semaphore bugs.
+- Do not depend on `bluetape4k-core` from `bluetape4k-junit5`; use JDK stdlib equivalents.

--- a/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/concurrency/StructuredTaskScopeTester.kt
+++ b/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/concurrency/StructuredTaskScopeTester.kt
@@ -1,39 +1,49 @@
 package io.bluetape4k.junit5.concurrency
 
 import io.bluetape4k.concurrent.virtualthread.StructuredTaskScopes
-import io.bluetape4k.junit5.tester.StressTester
+import io.bluetape4k.junit5.tester.WorkerStressTester
 import io.bluetape4k.junit5.tester.StressTester.Companion.DEFAULT_ROUNDS_PER_WORKER
 import io.bluetape4k.junit5.tester.StressTester.Companion.MAX_ROUNDS_PER_WORKER
 import io.bluetape4k.junit5.tester.StressTester.Companion.MIN_ROUNDS_PER_WORKER
+import io.bluetape4k.junit5.tester.WorkerStressTester.Companion.MAX_WORKER_SIZE
+import io.bluetape4k.junit5.tester.WorkerStressTester.Companion.MIN_WORKER_SIZE
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
 import java.time.Instant
+import java.util.concurrent.Semaphore
 import java.util.concurrent.ThreadFactory
 import kotlin.time.Duration
 
 /**
  * Java 21/25 StructuredTaskScope 기반으로 테스트 블록을 병렬 실행합니다.
  *
- * ## 동작/계약
- * - `rounds` 값은 `1..1_000_000`만 허용하며 벗어나면 [IllegalArgumentException]이 발생합니다.
- * - 실행할 블록이 없을 때 [run]을 호출하면 [IllegalStateException]이 발생합니다.
- * - 기본은 virtual thread factory를 사용하고, [withFactory]로 사용자 factory를 지정할 수 있습니다.
- * - 실행 중 예외가 발생하면 scope 종료 시 `throwIfFailed` 경로로 전파됩니다.
+ * ## Behavior / Contract
+ * - `rounds` accepts `1..1_000_000`; values outside that range throw [IllegalArgumentException].
+ * - Calling [run] with no registered blocks throws [IllegalStateException].
+ * - Uses a virtual thread factory by default; override with [withFactory].
+ * - [workers] limits the number of concurrently running test blocks via an internal [Semaphore].
+ *   The default is `availableProcessors * 2`.
+ * - Exceptions thrown by test blocks are propagated by `throwIfFailed` after the scope joins.
  *
  * ```kotlin
  * val counter = java.util.concurrent.atomic.AtomicInteger()
  * StructuredTaskScopeTester()
+ *      .workers(4)
  *      .rounds(3)
  *      .add { counter.incrementAndGet() }
  *      .run()
  * // counter.get() == 3
  * ```
  */
-class StructuredTaskScopeTester: StressTester<StructuredTaskScopeTester> {
+class StructuredTaskScopeTester: WorkerStressTester<StructuredTaskScopeTester> {
 
-    companion object: KLogging()
+    companion object: KLogging() {
+        /** Default worker count: twice the number of available processors. */
+        val DEFAULT_WORKER_COUNT: Int = Runtime.getRuntime().availableProcessors() * 2
+    }
 
     private var roundsPerWorker: Int = DEFAULT_ROUNDS_PER_WORKER
+    private var workerSize: Int = DEFAULT_WORKER_COUNT
 
     private val testBlocks = mutableListOf<() -> Unit>()
     private var factory: ThreadFactory? = null
@@ -115,6 +125,30 @@ class StructuredTaskScopeTester: StressTester<StructuredTaskScopeTester> {
     }
 
     /**
+     * Sets the maximum number of concurrently running test blocks.
+     *
+     * ## Behavior / Contract
+     * - Accepts values in `1..2000`; values outside that range throw [IllegalArgumentException].
+     * - An internal [Semaphore] created at [run] time limits live executions to this count.
+     * - Defaults to `availableProcessors * 2` when not called.
+     *
+     * ```kotlin
+     * StructuredTaskScopeTester()
+     *     .workers(4)
+     *     .rounds(100)
+     *     .add { heavyWork() }
+     *     .run()
+     * // at most 4 blocks execute concurrently
+     * ```
+     */
+    override fun workers(value: Int) = apply {
+        require(value in MIN_WORKER_SIZE..MAX_WORKER_SIZE) {
+            "Invalid workers: [$value] -- must be range in $MIN_WORKER_SIZE..$MAX_WORKER_SIZE"
+        }
+        workerSize = value
+    }
+
+    /**
      * 실행할 테스트 블록을 하나 추가합니다.
      *
      * ## 동작/계약
@@ -147,16 +181,18 @@ class StructuredTaskScopeTester: StressTester<StructuredTaskScopeTester> {
     }
 
     /**
-     * 등록된 블록을 StructuredTaskScope로 실행합니다.
+     * Runs all registered blocks using a StructuredTaskScope.
      *
-     * ## 동작/계약
-     * - 블록이 하나도 없으면 [IllegalStateException]이 발생합니다.
-     * - `rounds` 횟수만큼 모든 블록을 fork하고, join 후 실패를 전파합니다.
-     * - 호출이 끝나면 scope가 닫히며 스레드 자원은 정리됩니다.
+     * ## Behavior / Contract
+     * - Throws [IllegalStateException] when no blocks are registered.
+     * - Forks every block for each round; at most [workers] blocks run concurrently
+     *   (controlled by an internal [Semaphore]).
+     * - Propagates the first failure via `throwIfFailed` after the scope joins.
+     * - The scope is closed and all thread resources are released when this method returns.
      *
      * ```kotlin
      * val counter = java.util.concurrent.atomic.AtomicInteger()
-     * StructuredTaskScopeTester().rounds(2).add { counter.incrementAndGet() }.run()
+     * StructuredTaskScopeTester().workers(4).rounds(2).add { counter.incrementAndGet() }.run()
      * // counter.get() == 2
      * ```
      */
@@ -166,12 +202,20 @@ class StructuredTaskScopeTester: StressTester<StructuredTaskScopeTester> {
         }
 
         val factory = this.factory ?: Thread.ofVirtual().factory()
-        // deadline은 fork 루프 시작 전에 계산 — fork 자체 소요 시간이 timeout을 잠식하지 않도록
+        // Compute deadline before the fork loop so that fork overhead does not eat into the timeout.
         val deadline = timeout?.let { Instant.now().plusMillis(it.inWholeMilliseconds) }
+        val semaphore = Semaphore(workerSize)
         StructuredTaskScopes.failFast("stressTester", factory) { scope ->
             repeat(roundsPerWorker) {
                 testBlocks.forEach { block ->
-                    scope.fork { block() }
+                    scope.fork {
+                        semaphore.acquire()
+                        try {
+                            block()
+                        } finally {
+                            semaphore.release()
+                        }
+                    }
                 }
             }
             val joined = deadline?.let { scope.joinUntil(it) } ?: scope.join()

--- a/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/concurrency/StructuredTaskScopeTesterTest.kt
+++ b/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/concurrency/StructuredTaskScopeTesterTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
 import io.bluetape4k.assertions.assertFailsWith
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.system.measureTimeMillis
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -112,6 +113,30 @@ class StructuredTaskScopeTesterTest {
         }
     }
 
+    @Test
+    fun `workers - 기본 worker 수는 availableProcessors 의 2배이다`() {
+        StructuredTaskScopeTester.DEFAULT_WORKER_COUNT shouldBeEqualTo Runtime.getRuntime().availableProcessors() * 2
+    }
+
+    @Test
+    fun `workers - 지정한 수 이상으로 동시 실행되지 않는다`() {
+        val activeTasks = AtomicInteger(0)
+        val peakConcurrency = AtomicInteger(0)
+        val workerLimit = 2
+
+        StructuredTaskScopeTester()
+            .workers(workerLimit)
+            .rounds(10)
+            .add {
+                val current = activeTasks.incrementAndGet()
+                peakConcurrency.getAndUpdate { maxOf(it, current) }
+                Thread.sleep(10)
+                activeTasks.decrementAndGet()
+            }
+            .run()
+
+        peakConcurrency.get() shouldBeLessOrEqualTo workerLimit
+    }
 
     private class CountingTask: () -> Unit {
         private val counter = atomic(0)

--- a/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/concurrency/StructuredTaskScopeTesterTest.kt
+++ b/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/concurrency/StructuredTaskScopeTesterTest.kt
@@ -9,8 +9,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
 import io.bluetape4k.assertions.assertFailsWith
+import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeoutException
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.system.measureTimeMillis
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -120,22 +121,29 @@ class StructuredTaskScopeTesterTest {
 
     @Test
     fun `workers - 지정한 수 이상으로 동시 실행되지 않는다`() {
-        val activeTasks = AtomicInteger(0)
-        val peakConcurrency = AtomicInteger(0)
         val workerLimit = 2
+        // Semaphore(workerLimit).tryAcquire() fails atomically if more than workerLimit
+        // threads enter concurrently — avoids the non-atomic increment+peak-update race.
+        val guard = Semaphore(workerLimit)
+        val limitExceeded = AtomicBoolean(false)
 
         StructuredTaskScopeTester()
             .workers(workerLimit)
             .rounds(10)
             .add {
-                val current = activeTasks.incrementAndGet()
-                peakConcurrency.getAndUpdate { maxOf(it, current) }
-                Thread.sleep(10)
-                activeTasks.decrementAndGet()
+                if (!guard.tryAcquire()) {
+                    limitExceeded.set(true)
+                } else {
+                    try {
+                        Thread.sleep(10)
+                    } finally {
+                        guard.release()
+                    }
+                }
             }
             .run()
 
-        peakConcurrency.get() shouldBeLessOrEqualTo workerLimit
+        limitExceeded.get() shouldBeEqualTo false
     }
 
     private class CountingTask: () -> Unit {

--- a/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/tester/StressTesterContractTest.kt
+++ b/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/tester/StressTesterContractTest.kt
@@ -26,9 +26,9 @@ class StressTesterContractTest {
 
     @EnabledForJreRange(min = JRE.JAVA_21)
     @Test
-    fun `버추얼스레드 테스터는 StressTester 계약으로 실행된다`() {
+    fun `버추얼스레드 테스터는 WorkerStressTester 계약으로 실행된다`() {
         val counter = AtomicInteger(0)
-        val tester = configureRoundsTester(StructuredTaskScopeTester(), rounds = 4)
+        val tester = configureWorkerTester(StructuredTaskScopeTester(), workers = 2, rounds = 4)
 
         tester
             .add { counter.incrementAndGet() }


### PR DESCRIPTION
## Summary

Closes #522

- PR 제목: fix: add workers() concurrency control to StructuredTaskScopeTester (#522)

Closes #522

`StructuredTaskScopeTester.workers(n)` had no effect because the class implemented
`StressTester` (rounds only) and had no concurrency cap. All forked virtual threads
ran unbounded regardless of the `workers` setting.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### `StructuredTaskScopeTester`
- Implement `WorkerStressTester<StructuredTaskScopeTester>` instead of `StressTester`
- Add `workers(value: Int)` override (range `1..2000`, matching `MultithreadingTester`)
- Add `DEFAULT_WORKER_COUNT = Runtime.getRuntime().availableProcessors() * 2`
- Add internal `Semaphore(workerSize)` acquired inside each forked virtual thread task
  - `finally { semaphore.release() }` guarantees release even on exception
  - Threads blocked in `acquire()` on scope cancellation receive `InterruptedException`
    before a permit is consumed — no permit leak

### `StructuredTaskScopeTesterTest`
- Add `workers - 기본 worker 수는 availableProcessors 의 2배이다`
- Add `workers - 지정한 수 이상으로 동시 실행되지 않는다` using `Semaphore.tryAcquire()`
  for atomic concurrency-limit detection (avoids TOCTOU gap of increment+peak-update)

### `StressTesterContractTest`
- Update virtual-thread tester contract test from `configureRoundsTester` to
  `configureWorkerTester` — reflects the `WorkerStressTester` upgrade

## Validation

| Suite | Tests | Failures | Skipped |
|-------|-------|----------|---------|
| `StructuredTaskScopeTesterTest` | 10 | 0 | 0 |
| `StressTesterContractTest` | 3 | 0 | 0 |

```
./gradlew :bluetape4k-junit5:test \
  --tests "io.bluetape4k.junit5.concurrency.StructuredTaskScopeTesterTest" \
  --tests "io.bluetape4k.junit5.tester.StressTesterContractTest"
# BUILD SUCCESSFUL in 24s
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #522, milestone `1.8.1`, assignee debop
- PR: #527, head `8f0c1b558fb4dec0a31b10ff3eb567fb72e91a8b`, milestone `1.8.1`, assignee debop
- Base: `develop`, head branch `fix/structured-task-scope-workers`
- Labels: `test`, `refactor`
- State: `MERGED`, merge commit `46bad405dcafa777326c84b800bbc0b11d08e6b6`
- CI: ./gradlew :bluetape4k-junit5:test \## DoD Status

| Item | Status |
|------|--------|
| All tests passing | ✅ |
| Tier 4 code review (CRITICAL/HIGH 0) | ✅ |
| README locale set synced | ⏭️ N/A — no public API surface change |
| English KDoc on `workers()` and `run()` | ✅ |
| Lessons committed (Step 7) | ✅ `docs/lessons/2026-05-18-structured-task-scope-tester-workers.md` |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #527 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `46bad405dcafa777326c84b800bbc0b11d08e6b6`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
