### PR TITLE
test: migrate infra/io concurrency tests to MultithreadingTester (#532)

### DIFF
--- a/docs/lessons/2026-05-18-infra-io-concurrency-migration.md
+++ b/docs/lessons/2026-05-18-infra-io-concurrency-migration.md
@@ -1,0 +1,112 @@
+# Infra/IO Concurrency Test Migration
+
+**Date**: 2026-05-18
+**Issue**: #532 (sub-issue of #528)
+**Branch**: test/migrate-infra-io-concurrency
+
+## Scope Findings
+
+From 16 files matching `Executors.new*()`:
+
+| File | Pattern | Decision |
+|------|---------|----------|
+| `WorkContextTest.kt` | `Executors.newFixedThreadPool` + `CountDownLatch` | ✅ Migrated |
+| `RetrofitMetricsSupportTest.kt` | `Executors.newFixedThreadPool` + `CountDownLatch(1)` start latch | ✅ Migrated |
+| `CompressorEdgeCaseTest.kt` | `Executors.newFixedThreadPool` + `CountDownLatch` | ✅ Migrated |
+| `SerializerEdgeCaseTest.kt` (×2 tests) | `Executors.newFixedThreadPool` + `CountDownLatch` | ✅ Migrated |
+| `LettuceAtomicLongTest.kt` | `companion executor by lazy` + `CountDownLatch` | ✅ Migrated |
+| `LettuceLockTest.kt` | `companion executor by lazy` + `CountDownLatch` | ✅ Migrated |
+| `LettuceSemaphoreTest.kt` | `companion executor by lazy` + `CountDownLatch` | ✅ Migrated |
+| `VirtualThreads.kt` | Production code | ❌ Keep |
+| `LimitConcurrencyExamples.kt` | Semaphore backpressure demo | ❌ Keep |
+| `FluentAsyncExample.kt` | Executor passed to async HTTP API | ❌ Keep |
+| `ClientWithRequestFuture.kt` | Executor as HTTP client argument | ❌ Keep |
+| `RouteGuideServiceTest.kt` | `asCoroutineDispatcher()` — coroutine dispatcher arg | ❌ Keep |
+| `VertxFutureBulkheadSupportTest.kt` | Exactly 2 tasks testing bulkhead semantics | ❌ Keep |
+| `TimeoutTest.kt` | `TestingExecutors` from OkIO library (testing timeout behavior) | ❌ Keep |
+
+## Migration Patterns Applied
+
+### Simple stress driver (most common)
+```kotlin
+// Before
+val executor = Executors.newFixedThreadPool(N)
+val latch = CountDownLatch(N)
+repeat(N) {
+    executor.submit { work(); latch.countDown() }
+}
+latch.await(30, TimeUnit.SECONDS)
+executor.shutdown()
+
+// After
+MultithreadingTester()
+    .workers(N)
+    .rounds(1)
+    .add { work() }
+    .run()
+```
+
+### workers × rounds pattern (threadCount × iterationsPerThread)
+```kotlin
+// Before
+repeat(threadCount) {
+    executor.submit {
+        repeat(iterationsPerThread) { ctx.compute(...) }
+        latch.countDown()
+    }
+}
+
+// After
+MultithreadingTester()
+    .workers(threadCount)
+    .rounds(iterationsPerThread)
+    .add { ctx.compute(...) }
+    .run()
+```
+
+### Per-worker identity preservation (SerializerEdgeCaseTest)
+When each thread needs a unique index for result tracking:
+```kotlin
+val counter = AtomicInteger(0)
+val results = ConcurrentHashMap<Int, Item>()
+MultithreadingTester()
+    .workers(THREAD_COUNT)
+    .rounds(1)
+    .add {
+        val idx = counter.getAndIncrement()
+        val item = Item(idx, "thread-$idx")
+        val bytes = serializer.serialize(item)
+        results[idx] = serializer.deserialize(bytes)
+    }
+    .run()
+results.size shouldBeEqualTo THREAD_COUNT
+```
+
+### Removed errorCount pattern
+`MultithreadingTester` propagates exceptions directly — no need for `AtomicInteger errorCount`. The pattern:
+```kotlin
+// Obsolete
+try { work() } catch (e: Throwable) { errorCount.incrementAndGet() } finally { latch.countDown() }
+errorCount.get() shouldBeEqualTo 0
+
+// MultithreadingTester: exception from work() fails the test directly
+```
+
+### companion `executor by lazy` removal
+Lettuce tests had `private val executor by lazy { Executors.newFixedThreadPool(N) }` in companion objects — shared across all tests but only used in one stress test. After migration, the field was removed entirely.
+
+## Keep Signals (non-stress patterns)
+
+| Signal | Example | Decision |
+|--------|---------|----------|
+| Executor passed to async/HTTP API constructor | `Executors.newFixedThreadPool(2)` → `AsyncCloseableHttpClient` | Keep |
+| `.asCoroutineDispatcher()` suffix | gRPC test | Keep |
+| Exactly 2 tasks for API behavior (not load) | Bulkhead allowed/rejected | Keep |
+| Custom executor class from test framework | `TestingExecutors.newFixedThreadPool` | Keep |
+| Semaphore for backpressure inside example | Cassandra demo | Keep |
+
+## Future Guidance
+
+- `companion object executor by lazy` is a strong migration signal — it exists only to be shared across test methods, but if only one test actually uses it as a stress driver, migrate that test and remove the field.
+- `MultithreadingTester` exceptions propagate as `AssertionError` wrapping the original — no need for try/catch inside `add {}` blocks for error counting.
+- For parameterized tests (`@MethodSource`), `MultithreadingTester` works identically — the parameter is captured by the lambda closure.

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/atomic/LettuceAtomicLongTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/atomic/LettuceAtomicLongTest.kt
@@ -13,16 +13,12 @@ import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalLettuceCoroutinesApi::class)
 class LettuceAtomicLongTest: AbstractLettuceTest() {
 
     companion object: KLogging() {
         private val connection by lazy { LettuceClients.connect(LettuceTestUtils.client, StringCodec.UTF8) }
-        private val executor by lazy { Executors.newFixedThreadPool(10) }
     }
 
     private lateinit var atomicLong: LettuceAtomicLong
@@ -115,19 +111,16 @@ class LettuceAtomicLongTest: AbstractLettuceTest() {
     fun `동시성 - 여러 스레드에서 incrementAndGet`() {
         val threadCount = 10
         val iterationsPerThread = 100
-        val latch = CountDownLatch(threadCount)
 
-        repeat(threadCount) {
-            executor.submit {
+        MultithreadingTester()
+            .workers(threadCount)
+            .rounds(iterationsPerThread)
+            .add {
                 val counter = LettuceAtomicLong(connection, atomicLong.key)
-                repeat(iterationsPerThread) {
-                    counter.incrementAndGet()
-                }
-                latch.countDown()
+                counter.incrementAndGet()
             }
-        }
+            .run()
 
-        latch.await(30, TimeUnit.SECONDS)
         atomicLong.get() shouldBeEqualTo (threadCount * iterationsPerThread).toLong()
     }
 

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceLockTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceLockTest.kt
@@ -16,9 +16,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import io.bluetape4k.assertions.assertFailsWith
 import java.time.Duration
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 @OptIn(ExperimentalLettuceCoroutinesApi::class)
@@ -26,7 +23,6 @@ class LettuceLockTest: AbstractLettuceTest() {
 
     companion object: KLogging() {
         private val connection by lazy { LettuceClients.connect(LettuceTestUtils.client, StringCodec.UTF8) }
-        private val executor by lazy { Executors.newFixedThreadPool(5) }
     }
 
     private lateinit var lock: LettuceLock
@@ -78,23 +74,21 @@ class LettuceLockTest: AbstractLettuceTest() {
 
     @Test
     fun `동시성 - 여러 스레드에서 하나만 락 획득`() {
-        val threadCount = 5
         val acquiredCount = AtomicInteger(0)
-        val latch = CountDownLatch(threadCount)
 
-        repeat(threadCount) {
-            executor.submit {
+        MultithreadingTester()
+            .workers(5)
+            .rounds(1)
+            .add {
                 val threadLock = LettuceLock(connection, lock.lockKey, Duration.ofSeconds(5))
                 if (threadLock.tryLock(waitTime = Duration.ofMillis(100))) {
                     acquiredCount.incrementAndGet()
                     Thread.sleep(100)
                     threadLock.unlock()
                 }
-                latch.countDown()
             }
-        }
+            .run()
 
-        latch.await(5, TimeUnit.SECONDS)
         acquiredCount.get() shouldBeEqualTo 1
     }
 

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/semaphore/LettuceSemaphoreTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/semaphore/LettuceSemaphoreTest.kt
@@ -15,9 +15,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import io.bluetape4k.assertions.assertFailsWith
 import java.time.Duration
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 @OptIn(ExperimentalLettuceCoroutinesApi::class)
@@ -26,7 +23,6 @@ class LettuceSemaphoreTest: AbstractLettuceTest() {
     companion object: KLogging() {
         const val TOTAL_PERMITS = 3
         private val connection by lazy { LettuceClients.connect(LettuceTestUtils.client) }
-        private val executor by lazy { Executors.newFixedThreadPool(10) }
     }
 
     private lateinit var semaphore: LettuceSemaphore
@@ -98,10 +94,11 @@ class LettuceSemaphoreTest: AbstractLettuceTest() {
     fun `동시성 - 최대 TOTAL_PERMITS개만 동시 접근 허용`() {
         val maxConcurrent = AtomicInteger(0)
         val concurrent = AtomicInteger(0)
-        val latch = CountDownLatch(10)
 
-        repeat(10) {
-            executor.submit {
+        MultithreadingTester()
+            .workers(10)
+            .rounds(1)
+            .add {
                 val s = LettuceSemaphore(connection, semaphore.semaphoreKey, TOTAL_PERMITS)
                 if (s.tryAcquire()) {
                     val current = concurrent.incrementAndGet()
@@ -110,11 +107,9 @@ class LettuceSemaphoreTest: AbstractLettuceTest() {
                     concurrent.decrementAndGet()
                     s.release()
                 }
-                latch.countDown()
             }
-        }
+            .run()
 
-        latch.await(10, TimeUnit.SECONDS)
         maxConcurrent.get() shouldBeGreaterOrEqualTo 1
     }
 

--- a/infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/instrument/retrofit2/RetrofitMetricsSupportTest.kt
+++ b/infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/instrument/retrofit2/RetrofitMetricsSupportTest.kt
@@ -7,10 +7,9 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
 import retrofit2.Response
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import java.io.IOException
 import java.time.Duration
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
 
 class RetrofitMetricsSupportTest {
 
@@ -102,20 +101,14 @@ class RetrofitMetricsSupportTest {
 
         val threadCount = 8
         val callsPerThread = 20
-        val latch = CountDownLatch(1)
-        val executor = Executors.newFixedThreadPool(threadCount)
 
-        val futures = List(threadCount) {
-            executor.submit {
-                latch.await()
-                repeat(callsPerThread) {
-                    recorder.recordTiming(tags, Duration.ofMillis(5))
-                }
+        MultithreadingTester()
+            .workers(threadCount)
+            .rounds(callsPerThread)
+            .add {
+                recorder.recordTiming(tags, Duration.ofMillis(5))
             }
-        }
-        latch.countDown()
-        futures.forEach { it.get() }
-        executor.shutdown()
+            .run()
 
         val timer = registry.find(MicrometerRetrofitMetricsRecorder.METRICS_KEY).tags(tags).timer()
         timer.shouldNotBeNull()

--- a/io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorEdgeCaseTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorEdgeCaseTest.kt
@@ -12,9 +12,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import java.util.stream.Stream
 import io.bluetape4k.assertions.assertFailsWith
 
@@ -141,34 +139,16 @@ class CompressorEdgeCaseTest {
     @MethodSource("fastCompressors")
     fun `멀티스레드 환경에서 동시 압축이 안전하게 동작한다`(compressor: Compressor) {
         val input = "Concurrent compression test data: bluetape4k ".repeat(100).toByteArray()
-        val executor = Executors.newFixedThreadPool(THREAD_COUNT)
-        val latch = CountDownLatch(THREAD_COUNT)
-        val errorCount = java.util.concurrent.atomic.AtomicInteger(0)
-        val results = java.util.concurrent.CopyOnWriteArrayList<ByteArray>()
 
-        repeat(THREAD_COUNT) { _ ->
-            executor.submit {
-                try {
-                    val compressed = compressor.compress(input)
-                    val decompressed = compressor.decompress(compressed)
-                    results.add(decompressed)
-                } catch (e: Throwable) {
-                    errorCount.incrementAndGet()
-                    log.debug(e) { "Concurrent compression error: ${e.message}" }
-                } finally {
-                    latch.countDown()
-                }
+        MultithreadingTester()
+            .workers(THREAD_COUNT)
+            .rounds(1)
+            .add {
+                val compressed = compressor.compress(input)
+                val decompressed = compressor.decompress(compressed)
+                (decompressed contentEquals input).shouldBeTrue()
             }
-        }
-
-        latch.await(30, TimeUnit.SECONDS)
-        executor.shutdown()
-
-        errorCount.get() shouldBeEqualTo 0
-        results.size shouldBeEqualTo THREAD_COUNT
-        results.forEach { result ->
-            (result contentEquals input).shouldBeTrue()
-        }
+            .run()
     }
 
     @Test

--- a/io/io/src/test/kotlin/io/bluetape4k/io/serializer/SerializerEdgeCaseTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/serializer/SerializerEdgeCaseTest.kt
@@ -14,9 +14,7 @@ import java.io.Serializable
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import java.util.stream.Stream
 import io.bluetape4k.assertions.assertFailsWith
 
@@ -182,30 +180,21 @@ class SerializerEdgeCaseTest {
     fun `멀티스레드 환경에서 동시 직렬화가 안전하게 동작한다`(serializer: BinarySerializer) {
         data class Item(val id: Int, val name: String) : Serializable
 
-        val executor = Executors.newFixedThreadPool(THREAD_COUNT)
-        val latch = CountDownLatch(THREAD_COUNT)
-        val errorCount = java.util.concurrent.atomic.AtomicInteger(0)
+        val counter = java.util.concurrent.atomic.AtomicInteger(0)
         val results = java.util.concurrent.ConcurrentHashMap<Int, Item>()
 
-        repeat(THREAD_COUNT) { idx ->
-            val item = Item(idx, "thread-$idx")
-            executor.submit {
-                try {
-                    val bytes = serializer.serialize(item)
-                    val deserialized = serializer.deserialize<Item>(bytes)
-                    if (deserialized != null) results[idx] = deserialized
-                } catch (e: Throwable) {
-                    errorCount.incrementAndGet()
-                } finally {
-                    latch.countDown()
-                }
+        MultithreadingTester()
+            .workers(THREAD_COUNT)
+            .rounds(1)
+            .add {
+                val idx = counter.getAndIncrement()
+                val item = Item(idx, "thread-$idx")
+                val bytes = serializer.serialize(item)
+                val deserialized = serializer.deserialize<Item>(bytes)
+                if (deserialized != null) results[idx] = deserialized
             }
-        }
+            .run()
 
-        latch.await(30, TimeUnit.SECONDS)
-        executor.shutdown()
-
-        errorCount.get() shouldBeEqualTo 0
         results.size shouldBeEqualTo THREAD_COUNT
         repeat(THREAD_COUNT) { idx ->
             results[idx].shouldNotBeNull()
@@ -268,35 +257,22 @@ class SerializerEdgeCaseTest {
 
     @Test
     fun `KryoProvider 멀티스레드 환경에서 안전하게 동작한다`() {
-        val executor = Executors.newFixedThreadPool(THREAD_COUNT)
-        val latch = CountDownLatch(THREAD_COUNT)
-        val errorCount = java.util.concurrent.atomic.AtomicInteger(0)
-
-        repeat(THREAD_COUNT) { idx ->
-            executor.submit {
+        MultithreadingTester()
+            .workers(THREAD_COUNT)
+            .rounds(1)
+            .add {
+                val kryo = KryoProvider.obtainKryo()
                 try {
-                    val kryo = KryoProvider.obtainKryo()
+                    val output = KryoProvider.obtainOutput()
                     try {
-                        // Kryo로 간단한 직렬화 수행
-                        val output = KryoProvider.obtainOutput()
-                        try {
-                            kryo.writeObject(output, "thread-safe-test-$idx")
-                        } finally {
-                            KryoProvider.releaseOutput(output)
-                        }
+                        kryo.writeObject(output, "thread-safe-test")
                     } finally {
-                        KryoProvider.releaseKryo(kryo)
+                        KryoProvider.releaseOutput(output)
                     }
-                } catch (e: Throwable) {
-                    errorCount.incrementAndGet()
                 } finally {
-                    latch.countDown()
+                    KryoProvider.releaseKryo(kryo)
                 }
             }
-        }
-
-        latch.await(30, TimeUnit.SECONDS)
-        executor.shutdown()
-        errorCount.get() shouldBeEqualTo 0
+            .run()
     }
 }

--- a/utils/workflow/src/test/kotlin/io/bluetape4k/workflow/api/WorkContextTest.kt
+++ b/utils/workflow/src/test/kotlin/io/bluetape4k/workflow/api/WorkContextTest.kt
@@ -4,11 +4,9 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
 
 class WorkContextTest: AbstractWorkflowTest() {
 
@@ -130,22 +128,16 @@ class WorkContextTest: AbstractWorkflowTest() {
     fun `병렬 compute 스레드 안전성`() {
         val threadCount = 10
         val incrementsPerThread = 100
-        val latch = CountDownLatch(threadCount)
-        val executor = Executors.newFixedThreadPool(threadCount)
 
         ctx["counter"] = 0
 
-        repeat(threadCount) {
-            executor.submit {
-                repeat(incrementsPerThread) {
-                    ctx.compute("counter") { _, old -> ((old as? Int) ?: 0) + 1 }
-                }
-                latch.countDown()
+        MultithreadingTester()
+            .workers(threadCount)
+            .rounds(incrementsPerThread)
+            .add {
+                ctx.compute("counter") { _, old -> ((old as? Int) ?: 0) + 1 }
             }
-        }
-
-        latch.await(5, TimeUnit.SECONDS)
-        executor.shutdown()
+            .run()
 
         val finalCount: Int? = ctx["counter"]
         finalCount shouldBeEqualTo threadCount * incrementsPerThread


### PR DESCRIPTION
## Summary

Closes #532

- PR 제목: test: migrate infra/io concurrency tests to MultithreadingTester (#532)

Closes #532 (sub-issue of #528)

Migrate raw concurrency stress patterns in infra/io test files to the
blessed `MultithreadingTester` harness.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Changes (7 files migrated)

| Module | File | Pattern removed |
|--------|------|-----------------|
| `bluetape4k-workflow` | `WorkContextTest` | `Executors` + `CountDownLatch` |
| `bluetape4k-micrometer` | `RetrofitMetricsSupportTest` | `Executors` + `CountDownLatch(1)` start-latch |
| `bluetape4k-io` | `CompressorEdgeCaseTest` | `Executors` + `CountDownLatch` + `CopyOnWriteArrayList` |
| `bluetape4k-io` | `SerializerEdgeCaseTest` (×2 tests) | `Executors` + `CountDownLatch` + `ConcurrentHashMap` |
| `bluetape4k-lettuce` | `LettuceAtomicLongTest` | `companion executor by lazy` + `CountDownLatch` |
| `bluetape4k-lettuce` | `LettuceLockTest` | `companion executor by lazy` + `CountDownLatch` |
| `bluetape4k-lettuce` | `LettuceSemaphoreTest` | `companion executor by lazy` + `CountDownLatch` |

### 기존 섹션: Files kept unchanged (9 files — not stress drivers)

- `VirtualThreads.kt` — production code
- `LimitConcurrencyExamples.kt` — semaphore backpressure demo
- `FluentAsyncExample.kt`, `ClientWithRequestFuture.kt` — executor as HTTP API arg
- `RouteGuideServiceTest.kt` — executor as coroutine dispatcher (`.asCoroutineDispatcher()`)
- `VertxFutureBulkheadSupportTest.kt` — exactly 2 tasks testing bulkhead semantics
- `TimeoutTest.kt` — `TestingExecutors` from OkIO library

### 기존 섹션: Verification

```
./gradlew :bluetape4k-workflow:test :bluetape4k-micrometer:test :bluetape4k-io:test :bluetape4k-lettuce:test
BUILD SUCCESSFUL in 49s
331 passing, 0 failed
```

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #532, milestone `1.8.1`, assignee 없음
- PR: #537, head `e789e10036c58f251e78c3f9989c1c6a6c2b6708`, milestone `1.8.1`, assignee debop
- Base: `develop`, head branch `test/migrate-infra-io-concurrency`
- Labels: 없음
- State: `MERGED`, merge commit `a0cbc3875f66b2604fc89df6960da083b9c16ef4`
- CI: ./gradlew :bluetape4k-workflow:test :bluetape4k-micrometer:test :bluetape4k-io:test :bluetape4k-lettuce:test / - [x] Per-worker identity preserved via `AtomicInteger.getAndIncrement()` (SerializerEdgeCaseTest)## DoD Status

- [x] Tests passing (331 passing, 0 failed)
- [x] `companion executor by lazy` fields removed from 3 Lettuce test classes
- [x] `errorCount` pattern removed (MultithreadingTester propagates exceptions directly)
- [x] Per-worker identity preserved via `AtomicInteger.getAndIncrement()` (SerializerEdgeCaseTest)
- [x] Lessons committed: `docs/lessons/2026-05-18-infra-io-concurrency-migration.md`

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #537 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `a0cbc3875f66b2604fc89df6960da083b9c16ef4`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
