### PR TITLE
fix: expose near cache close failures

### DIFF
--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/ResilientNearCacheDecorator.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/ResilientNearCacheDecorator.kt
@@ -154,7 +154,11 @@ class ResilientNearCacheDecorator<V: Any>(
     // -- Lifecycle --
 
     override fun close() {
-        runCatching { delegate.close() }
+        try {
+            delegate.close()
+        } catch (e: Exception) {
+            log.warn(e) { "Ignoring close() failure. cacheName=$cacheName" }
+        }
     }
 }
 

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/ResilientNearCacheDecoratorTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/ResilientNearCacheDecoratorTest.kt
@@ -6,7 +6,9 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.junit5.output.InMemoryLogbackAppender
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import io.bluetape4k.assertions.assertFailsWith
@@ -130,6 +132,22 @@ class ResilientNearCacheDecoratorTest {
 
         cache.close()
         verify(exactly = 1) { delegate.close() }
+    }
+
+    @Test
+    fun `close - delegate 실패 시 예외를 삼키고 로그만 남김`() {
+        every { delegate.close() } throws RuntimeException("close failure")
+        val cache = ResilientNearCacheDecorator(delegate)
+        val appender = InMemoryLogbackAppender(ResilientNearCacheDecorator::class)
+
+        try {
+            cache.close()
+
+            verify(exactly = 1) { delegate.close() }
+            appender.lastMessage shouldContain "Ignoring close() failure. cacheName=test-cache"
+        } finally {
+            appender.close()
+        }
     }
 
     @Test

--- a/docs/lessons/2026-05-19-issue-542-near-cache-close.md
+++ b/docs/lessons/2026-05-19-issue-542-near-cache-close.md
@@ -1,0 +1,33 @@
+# Issue 542 Near Cache Close Failure
+
+## Context
+
+`ResilientNearCacheDecorator.close()` ignored delegate close failures with bare
+`runCatching`, making shutdown resource leaks silent.
+
+## Decision
+
+Align the blocking decorator with the suspend decorator: delegate `close()` is
+called directly, and non-fatal failures are logged with the cache name while the
+close path remains best-effort. Keep lifecycle log messages in English so ops
+teams can grep them consistently.
+
+## Outcome
+
+The close path now emits a warning instead of silently discarding the failure.
+A targeted unit test locks both the non-throwing lifecycle behavior and the
+warning log message.
+
+## Verification
+
+`./gradlew :bluetape4k-cache-core:test --tests "io.bluetape4k.cache.nearcache.ResilientNearCacheDecoratorTest"` passed with 9 tests.
+
+Claude Code Opus review initially flagged the missing log assertion as P2.
+After adding `InMemoryLogbackAppender` coverage and changing the message to
+English, rereview reported no remaining P0/P1/P2 findings.
+
+## Future Guard
+
+Do not use bare `runCatching { close() }` in resource lifecycle code unless the
+failure is intentionally logged or otherwise observable. Tests should lock the
+observable lifecycle signal, not just the absence of an exception.


### PR DESCRIPTION
## Summary

Closes #542

- PR 제목: fix: expose near cache close failures

### 원문 선행 내용

Fixes #542

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Replaced bare `runCatching` in `ResilientNearCacheDecorator.close()` with explicit try/catch logging.
- Added regression coverage for delegate close failure.
- Added lesson note for lifecycle close failures.

### 기존 섹션: Verification

- `./gradlew :bluetape4k-cache-core:test --tests "io.bluetape4k.cache.nearcache.ResilientNearCacheDecoratorTest"`

### 기존 섹션: Notes

- IntelliJ diagnostics were unavailable because this worktree was not open in the IDE MCP project list. Gradle compile/test was used as fallback.
- Full repository build not run.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #542, milestone `1.8.1`, assignee debop
- PR: #548, head `93c7326de8f4636da7b9c5aae3485cfc3b6df442`, milestone `1.8.1`, assignee debop
- Base: `develop`, head branch `fix/issue-542-near-cache-close`
- Labels: `bug`
- State: `MERGED`, merge commit `fbb4c1a3991a20cf3d195c393a132253af3a3e14`
- CI: - Replaced bare `runCatching` in `ResilientNearCacheDecorator.close()` with explicit try/catch logging. / - `./gradlew :bluetape4k-cache-core:test --tests "io.bluetape4k.cache.nearcache.ResilientNearCacheDecoratorTest"` / - IntelliJ diagnostics were unavailable because this worktree was not open in the IDE MCP project list. Gradle compile/test was used as fallback.## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #548 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `fbb4c1a3991a20cf3d195c393a132253af3a3e14`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
