### PR TITLE
fix: preserve BehaviorSubject emitError delivery

### DIFF
--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/BehaviorSubject.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/BehaviorSubject.kt
@@ -190,11 +190,12 @@ class BehaviorSubject<T> private constructor(
         current = DONE
 
         collectors.getAndSet(TERMINATED).forEach { innerCollector ->
-            runCatching {
+            try {
                 innerCollector.consumeReady.await()
                 innerCollector.resume()
-            }.onFailure { e ->
-                if (e is CancellationException) throw e
+            } catch (e: CancellationException) {
+                currentCoroutineContext().ensureActive()
+            } catch (e: Throwable) {
                 log.error(e) { "BehaviorSubject.emitError 알림 실패. innerCollector=$innerCollector" }
             }
         }
@@ -224,13 +225,12 @@ class BehaviorSubject<T> private constructor(
         current = DONE
 
         collectors.getAndSet(TERMINATED).forEach { innerCollector ->
-            runCatching {
+            try {
                 innerCollector.consumeReady.await()
                 innerCollector.resume()
-            }.onFailure { e ->
-                if (e is CancellationException) {
-                    currentCoroutineContext().ensureActive()
-                }
+            } catch (e: CancellationException) {
+                currentCoroutineContext().ensureActive()
+            } catch (e: Throwable) {
                 log.error(e) { "Fail to complete. innerCollector=$innerCollector" }
             }
         }

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/SubjectCancellationTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/SubjectCancellationTest.kt
@@ -217,6 +217,89 @@ class SubjectCancellationTest {
     }
 
     @Test
+    fun `BehaviorSubject emitError preserves timeout cancellation while collector is busy`() = runTest {
+        val subject = BehaviorSubject<Int>()
+        val collectorEntered = CompletableDeferred<Unit>()
+        val releaseCollector = CompletableDeferred<Unit>()
+
+        val job = launch {
+            subject.collect {
+                collectorEntered.complete(Unit)
+                releaseCollector.await()
+            }
+        }
+
+        subject.awaitCollector()
+        subject.emit(1)
+        collectorEntered.await()
+
+        assertFailsWith<TimeoutCancellationException> {
+            withTimeout(10.milliseconds) {
+                subject.emitError(IllegalStateException("boom"))
+            }
+        }
+
+        releaseCollector.complete(Unit)
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `BehaviorSubject emitError continues after a collector is cancelled`() = runTest {
+        val subject = BehaviorSubject<Int>()
+        val emittedError = IllegalStateException("boom")
+        val secondCollectorError = CompletableDeferred<Throwable>()
+
+        val firstJob = launch {
+            subject.collect { /* consume */ }
+        }
+        val secondJob = launch {
+            try {
+                subject.collect { /* consume */ }
+            } catch (e: IllegalStateException) {
+                secondCollectorError.complete(e)
+            }
+        }
+
+        subject.awaitCollectors(2)
+
+        firstJob.cancel()
+        subject.emitError(emittedError)
+
+        withTimeout(1.seconds) {
+            secondCollectorError.await()
+        } shouldBeInstanceOf IllegalStateException::class
+
+        firstJob.cancelAndJoin()
+        secondJob.cancelAndJoin()
+    }
+
+    @Test
+    fun `BehaviorSubject complete continues after a collector is cancelled`() = runTest {
+        val subject = BehaviorSubject<Int>()
+        val secondCollectorCompleted = CompletableDeferred<Unit>()
+
+        val firstJob = launch {
+            subject.collect { /* consume */ }
+        }
+        val secondJob = launch {
+            subject.collect { /* consume */ }
+            secondCollectorCompleted.complete(Unit)
+        }
+
+        subject.awaitCollectors(2)
+
+        firstJob.cancel()
+        subject.complete()
+
+        withTimeout(1.seconds) {
+            secondCollectorCompleted.await()
+        }
+
+        firstJob.cancelAndJoin()
+        secondJob.cancelAndJoin()
+    }
+
+    @Test
     fun `PublishSubject complete preserves timeout cancellation while collector is busy`() = runTest {
         val subject = PublishSubject<Int>()
         val collectorEntered = CompletableDeferred<Unit>()

--- a/docs/lessons/2026-05-19-issue-543-behavior-subject-emit-error.md
+++ b/docs/lessons/2026-05-19-issue-543-behavior-subject-emit-error.md
@@ -1,0 +1,39 @@
+# Issue 543 BehaviorSubject Terminal Cancellation
+
+## Context
+
+`BehaviorSubject.emitError()` rethrew every `CancellationException` raised while
+notifying collectors. That made a collector-local cancellation able to interrupt
+terminal error notification for the remaining collectors. Claude review also
+found the adjacent `complete()` path logged collector-local cancellation as an
+error after preserving parent cancellation.
+
+## Decision
+
+Use the same parent-cancellation guard shape for `emitError()` and `complete()`:
+catch `CancellationException`, call `currentCoroutineContext().ensureActive()`,
+and continue when the emitter coroutine is still active. Avoid broad
+`Throwable` catches in newly added coroutine tests when a narrower exception is
+expected.
+
+## Outcome
+
+`BehaviorSubject` terminal paths now preserve parent cancellation while allowing
+notification to continue after a cancelled collector. Tests cover both
+`emitError()` and `complete()` continuation after collector cancellation.
+
+## Verification
+
+`./gradlew :bluetape4k-coroutines:test --tests "io.bluetape4k.coroutines.flow.extensions.subject.SubjectCancellationTest"` passed with 12 tests.
+
+Claude Code Opus rereview reported no remaining P0/P1/P2 findings after
+aligning `complete()` and adding the symmetric test. A later
+`bluetape4k-patterns` pass narrowed the newly added test catch block from
+`Throwable` to `IllegalStateException`.
+
+## Future Guard
+
+Subject terminal paths should distinguish parent coroutine cancellation from
+collector-local cancellation before rethrowing `CancellationException`. When
+adding coroutine tests, catch only the expected exception unless the test is
+explicitly about broad collector failure handling.


### PR DESCRIPTION
## Summary

Closes #543

- PR 제목: fix: preserve BehaviorSubject emitError delivery

### 원문 선행 내용

Fixes #543

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Updated `BehaviorSubject.emitError()` to distinguish parent coroutine cancellation from collector-local cancellation.
- Added regression tests for timeout cancellation preservation and remaining collector delivery after one collector is cancelled.
- Added lesson note for subject terminal cancellation handling.

### 기존 섹션: Verification

- `./gradlew :bluetape4k-coroutines:test --tests "io.bluetape4k.coroutines.flow.extensions.subject.SubjectCancellationTest"`

### 기존 섹션: Notes

- IntelliJ diagnostics were unavailable because this worktree was not open in the IDE MCP project list. Gradle compile/test was used as fallback.
- Full repository build not run.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #543, milestone `1.8.1`, assignee debop
- PR: #549, head `e334a6079fe4b46de3e0d1d6f0c0484d368cc56f`, milestone `1.8.1`, assignee debop
- Base: `develop`, head branch `fix/issue-543-behavior-subject-emit-error`
- Labels: `bug`
- State: `MERGED`, merge commit `2fa82149157813d7c08c3a9b7c1d1e13d7af650c`
- CI: - `./gradlew :bluetape4k-coroutines:test --tests "io.bluetape4k.coroutines.flow.extensions.subject.SubjectCancellationTest"` / - IntelliJ diagnostics were unavailable because this worktree was not open in the IDE MCP project list. Gradle compile/test was used as fallback.## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #549 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `2fa82149157813d7c08c3a9b7c1d1e13d7af650c`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
