### PR TITLE
fix: preserve null numeric properties

### DIFF
--- a/docs/lessons/2026-05-20-issue-491-propsmapper-empty-numeric-null.md
+++ b/docs/lessons/2026-05-20-issue-491-propsmapper-empty-numeric-null.md
@@ -1,0 +1,33 @@
+# Issue 491 Java Properties Empty Numeric Nulls
+
+## Context
+
+`JavaPropsMapper` reads Java Properties values as untyped strings. Empty
+properties such as `maxWaitMillis=` and `idleTimeout=` were deserialized into
+nullable numeric Kotlin constructor parameters as `0`, which made generated
+properties fail to round-trip against the original `null` model.
+
+## Decision
+
+Keep the fix local to `JacksonText.Props.defaultMapper` for Jackson 2 and
+Jackson 3. Apply Jackson coercion metadata for numeric logical types and add a
+Properties-only numeric module that maps an empty string to `null` for boxed
+numeric types before parsing non-empty values normally.
+
+## Outcome
+
+The disabled named datasource properties round-trip tests are enabled in both
+Jackson 2 and Jackson 3. Empty nullable numeric properties now deserialize as
+`null`; other text formats and CSV mapper defaults are unchanged.
+
+## Verification
+
+`./gradlew :bluetape4k-jackson2:test --tests 'io.bluetape4k.jackson.text.datasources.ParseNamedDataSourcePropertiesTest' :bluetape4k-jackson3:test --tests 'io.bluetape4k.jackson3.text.datasources.ParseNamedDataSourcePropertiesTest' --console=plain --no-configuration-cache` passed with 4 tests per module.
+
+`./gradlew :bluetape4k-jackson2:test :bluetape4k-jackson3:test --console=plain --no-configuration-cache` passed with 430 Jackson 2 tests and 432 Jackson 3 tests.
+
+## Future Guard
+
+Do not broaden Java Properties coercion fixes into CSV/TOML/YAML mappers unless
+their own tests prove the same bug. Java Properties scalar handling is format
+specific, so keep future coercion modules attached only to the affected mapper.

--- a/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/text/JacksonText.kt
+++ b/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/text/JacksonText.kt
@@ -1,9 +1,16 @@
 package io.bluetape4k.jackson.text
 
 import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.cfg.CoercionAction
+import com.fasterxml.jackson.databind.cfg.CoercionInputShape
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.databind.type.LogicalType
 import com.fasterxml.jackson.dataformat.csv.CsvFactory
 import com.fasterxml.jackson.dataformat.csv.CsvMapper
 import com.fasterxml.jackson.dataformat.javaprop.JavaPropsFactory
@@ -25,6 +32,8 @@ import io.bluetape4k.jackson.text.JacksonText.Toml.defaultSerializer
 import io.bluetape4k.jackson.text.JacksonText.Yaml.defaultFactory
 import io.bluetape4k.jackson.text.JacksonText.Yaml.defaultMapper
 import io.bluetape4k.jackson.text.JacksonText.Yaml.defaultSerializer
+import java.math.BigDecimal
+import java.math.BigInteger
 
 /**
  * Jackson 텍스트 포맷(CSV/Properties/TOML/YAML) 기본 mapper/factory/serializer를 제공합니다.
@@ -185,6 +194,13 @@ object JacksonText {
                 .disable(*disabledSerializationFeatures)
                 .enable(*enabledDeserializationFeatures)
                 .disable(*disabledDeserializationFeatures)
+                .withCoercionConfig(LogicalType.Integer) {
+                    it.setCoercion(CoercionInputShape.EmptyString, CoercionAction.AsNull)
+                }
+                .withCoercionConfig(LogicalType.Float) {
+                    it.setCoercion(CoercionInputShape.EmptyString, CoercionAction.AsNull)
+                }
+                .addModule(PropsNullableNumberModule)
                 .build()
         }
 
@@ -229,6 +245,46 @@ object JacksonText {
             PropsJacksonSerializer(defaultMapper)
         }
     }
+
+    private object PropsNullableNumberModule: SimpleModule() {
+        init {
+            addDeserializer(Byte::class.javaObjectType, object: StdDeserializer<Byte>(Byte::class.javaObjectType) {
+                override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): Byte? =
+                    p.propsValueAsStringOrNull()?.toByte()
+            })
+            addDeserializer(Short::class.javaObjectType, object: StdDeserializer<Short>(Short::class.javaObjectType) {
+                override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): Short? =
+                    p.propsValueAsStringOrNull()?.toShort()
+            })
+            addDeserializer(Int::class.javaObjectType, object: StdDeserializer<Int>(Int::class.javaObjectType) {
+                override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): Int? =
+                    p.propsValueAsStringOrNull()?.toInt()
+            })
+            addDeserializer(Long::class.javaObjectType, object: StdDeserializer<Long>(Long::class.javaObjectType) {
+                override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): Long? =
+                    p.propsValueAsStringOrNull()?.toLong()
+            })
+            addDeserializer(Float::class.javaObjectType, object: StdDeserializer<Float>(Float::class.javaObjectType) {
+                override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): Float? =
+                    p.propsValueAsStringOrNull()?.toFloat()
+            })
+            addDeserializer(Double::class.javaObjectType, object: StdDeserializer<Double>(Double::class.javaObjectType) {
+                override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): Double? =
+                    p.propsValueAsStringOrNull()?.toDouble()
+            })
+            addDeserializer(BigInteger::class.java, object: StdDeserializer<BigInteger>(BigInteger::class.java) {
+                override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): BigInteger? =
+                    p.propsValueAsStringOrNull()?.toBigInteger()
+            })
+            addDeserializer(BigDecimal::class.java, object: StdDeserializer<BigDecimal>(BigDecimal::class.java) {
+                override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): BigDecimal? =
+                    p.propsValueAsStringOrNull()?.toBigDecimal()
+            })
+        }
+    }
+
+    private fun JsonParser.propsValueAsStringOrNull(): String? =
+        valueAsString?.takeUnless { it.isEmpty() }
 
     /**
      * TOML 포맷 기본 구성 요소를 제공합니다.

--- a/io/jackson2/src/test/kotlin/io/bluetape4k/jackson/text/datasources/ParseNamedDataSourcePropertiesTest.kt
+++ b/io/jackson2/src/test/kotlin/io/bluetape4k/jackson/text/datasources/ParseNamedDataSourcePropertiesTest.kt
@@ -16,7 +16,6 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.util.*
@@ -86,7 +85,6 @@ class ParseNamedDataSourcePropertiesTest: AbstractJacksonTextTest() {
         """.trimMargin()
 
 
-        @Disabled("PropsMapper 에 버그가 있다. 미지정 속성은 null 이 되어야 하는데, maxWaitMillis=0 으로 지정된다.")
         @Test
         fun `generate datasource properties to properties format and parse`() {
             val bluetape4k = Bluetape4kProperty(mapOf("default" to default, "read" to read))
@@ -106,7 +104,7 @@ class ParseNamedDataSourcePropertiesTest: AbstractJacksonTextTest() {
             parsedRead shouldBeEqualTo read
         }
 
-        @Disabled("PropsMapper 에 버그가 있다. 미지정 속성은 null 이 되어야 하는데, maxWaitMillis=0 으로 지정된다.")
+        @Test
         fun `generate datasource properties to properties and parse`() {
             val bluetape4k = Bluetape4kProperty(mapOf("default" to default, "read" to read))
             val root = RootProperty(bluetape4k)

--- a/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/text/JacksonText.kt
+++ b/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/text/JacksonText.kt
@@ -14,9 +14,16 @@ import io.bluetape4k.jackson3.text.JacksonText.Yaml.defaultFactory
 import io.bluetape4k.jackson3.text.JacksonText.Yaml.defaultMapper
 import io.bluetape4k.jackson3.text.JacksonText.Yaml.defaultSerializer
 import io.bluetape4k.logging.KLogging
+import tools.jackson.core.JsonParser
 import tools.jackson.databind.DeserializationFeature
+import tools.jackson.databind.DeserializationContext
 import tools.jackson.databind.SerializationFeature
+import tools.jackson.databind.cfg.CoercionAction
+import tools.jackson.databind.cfg.CoercionInputShape
+import tools.jackson.databind.deser.std.StdDeserializer
 import tools.jackson.databind.json.JsonMapper
+import tools.jackson.databind.module.SimpleModule
+import tools.jackson.databind.type.LogicalType
 import tools.jackson.dataformat.csv.CsvFactory
 import tools.jackson.dataformat.csv.CsvMapper
 import tools.jackson.dataformat.javaprop.JavaPropsFactory
@@ -25,6 +32,8 @@ import tools.jackson.dataformat.toml.TomlFactory
 import tools.jackson.dataformat.toml.TomlMapper
 import tools.jackson.dataformat.yaml.YAMLFactory
 import tools.jackson.dataformat.yaml.YAMLMapper
+import java.math.BigDecimal
+import java.math.BigInteger
 
 /**
  * Jackson 3 텍스트 포맷(CSV/Properties/TOML/YAML) 기본 mapper/factory/serializer를 제공합니다.
@@ -171,6 +180,13 @@ object JacksonText: KLogging() {
                 .disable(*disabledSerializationFeatures)
                 .enable(*enabledDeserializationFeatures)
                 .disable(*disabledDeserializationFeatures)
+                .withCoercionConfig(LogicalType.Integer) {
+                    it.setCoercion(CoercionInputShape.EmptyString, CoercionAction.AsNull)
+                }
+                .withCoercionConfig(LogicalType.Float) {
+                    it.setCoercion(CoercionInputShape.EmptyString, CoercionAction.AsNull)
+                }
+                .addModule(PropsNullableNumberModule)
                 .build()
         }
 
@@ -215,6 +231,46 @@ object JacksonText: KLogging() {
             PropsJacksonSerializer(defaultMapper)
         }
     }
+
+    private object PropsNullableNumberModule: SimpleModule() {
+        init {
+            addDeserializer(Byte::class.javaObjectType, object: StdDeserializer<Byte>(Byte::class.javaObjectType) {
+                override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): Byte? =
+                    p.propsValueAsStringOrNull()?.toByte()
+            })
+            addDeserializer(Short::class.javaObjectType, object: StdDeserializer<Short>(Short::class.javaObjectType) {
+                override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): Short? =
+                    p.propsValueAsStringOrNull()?.toShort()
+            })
+            addDeserializer(Int::class.javaObjectType, object: StdDeserializer<Int>(Int::class.javaObjectType) {
+                override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): Int? =
+                    p.propsValueAsStringOrNull()?.toInt()
+            })
+            addDeserializer(Long::class.javaObjectType, object: StdDeserializer<Long>(Long::class.javaObjectType) {
+                override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): Long? =
+                    p.propsValueAsStringOrNull()?.toLong()
+            })
+            addDeserializer(Float::class.javaObjectType, object: StdDeserializer<Float>(Float::class.javaObjectType) {
+                override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): Float? =
+                    p.propsValueAsStringOrNull()?.toFloat()
+            })
+            addDeserializer(Double::class.javaObjectType, object: StdDeserializer<Double>(Double::class.javaObjectType) {
+                override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): Double? =
+                    p.propsValueAsStringOrNull()?.toDouble()
+            })
+            addDeserializer(BigInteger::class.java, object: StdDeserializer<BigInteger>(BigInteger::class.java) {
+                override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): BigInteger? =
+                    p.propsValueAsStringOrNull()?.toBigInteger()
+            })
+            addDeserializer(BigDecimal::class.java, object: StdDeserializer<BigDecimal>(BigDecimal::class.java) {
+                override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): BigDecimal? =
+                    p.propsValueAsStringOrNull()?.toBigDecimal()
+            })
+        }
+    }
+
+    private fun JsonParser.propsValueAsStringOrNull(): String? =
+        getValueAsString()?.takeUnless { it.isEmpty() }
 
     /**
      * TOML 포맷 기본 구성 요소를 제공합니다.

--- a/io/jackson3/src/test/kotlin/io/bluetape4k/jackson3/text/datasources/ParseNamedDataSourcePropertiesTest.kt
+++ b/io/jackson3/src/test/kotlin/io/bluetape4k/jackson3/text/datasources/ParseNamedDataSourcePropertiesTest.kt
@@ -12,7 +12,6 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import tools.jackson.databind.json.JsonMapper
@@ -88,7 +87,6 @@ class ParseNamedDataSourcePropertiesTest: AbstractJacksonTextTest() {
         """.trimMargin()
 
 
-        @Disabled("PropsMapper 에 버그가 있다. 미지정 속성은 null 이 되어야 하는데, maxWaitMillis=0 으로 지정된다.")
         @Test
         fun `generate datasource properties to properties format and parse`() {
             val bluetape4k = Bluetape4kProperty(mapOf("default" to default, "read" to read))
@@ -108,7 +106,7 @@ class ParseNamedDataSourcePropertiesTest: AbstractJacksonTextTest() {
             parsedRead shouldBeEqualTo read
         }
 
-        @Disabled("PropsMapper 에 버그가 있다. 미지정 속성은 null 이 되어야 하는데, maxWaitMillis=0 으로 지정된다.")
+        @Test
         fun `generate datasource properties to properties and parse`() {
             val bluetape4k = Bluetape4kProperty(mapOf("default" to default, "read" to read))
             val root = RootProperty(bluetape4k)


### PR DESCRIPTION
## Summary

Closes #491

- PR 제목: fix: preserve null numeric properties

- Fix Java Properties parsing for empty nullable numeric values in Jackson 2 and Jackson 3 Props mappers.
- Re-enable the named datasource properties round-trip tests that documented `maxWaitMillis=` becoming `0` instead of `null`.
- Add a lesson note for future Props-only coercion changes.

Fixes #491.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary
- Fix Java Properties parsing for empty nullable numeric values in Jackson 2 and Jackson 3 Props mappers.
- Re-enable the named datasource properties round-trip tests that documented `maxWaitMillis=` becoming `0` instead of `null`.
- Add a lesson note for future Props-only coercion changes.

Fixes #491.

### Validation
- Reproduced the bug by enabling the disabled tests; Jackson 3 failed with `maxWaitMillis=0` instead of `null` before the fix.
- `./gradlew :bluetape4k-jackson2:test --tests 'io.bluetape4k.jackson.text.datasources.ParseNamedDataSourcePropertiesTest' :bluetape4k-jackson3:test --tests 'io.bluetape4k.jackson3.text.datasources.ParseNamedDataSourcePropertiesTest' --console=plain --no-configuration-cache`
- `./gradlew :bluetape4k-jackson2:test :bluetape4k-jackson3:test --console=plain --no-configuration-cache`
- After rebase onto `origin/develop`, reran the targeted Jackson2/Jackson3 named datasource properties tests successfully.

### Review
- Current-session review completed per updated workflow; no Claude Code CLI or Codex CLI review was used.
- Review finding fixed before PR: removed accidental CSV mapper coercion so the change remains Props-specific.

## Validation

- Reproduced the bug by enabling the disabled tests; Jackson 3 failed with `maxWaitMillis=0` instead of `null` before the fix.
- `./gradlew :bluetape4k-jackson2:test --tests 'io.bluetape4k.jackson.text.datasources.ParseNamedDataSourcePropertiesTest' :bluetape4k-jackson3:test --tests 'io.bluetape4k.jackson3.text.datasources.ParseNamedDataSourcePropertiesTest' --console=plain --no-configuration-cache`
- `./gradlew :bluetape4k-jackson2:test :bluetape4k-jackson3:test --console=plain --no-configuration-cache`
- After rebase onto `origin/develop`, reran the targeted Jackson2/Jackson3 named datasource properties tests successfully.

## Review Notes

- Current-session review completed per updated workflow; no Claude Code CLI or Codex CLI review was used.
- Review finding fixed before PR: removed accidental CSV mapper coercion so the change remains Props-specific.

## Metadata

- Issue: #491, milestone `1.8.1`, assignee debop
- PR: #554, head `21db0c826dcb628521f14e9d176e823802c6064f`, milestone `1.8.1`, assignee debop
- Base: `develop`, head branch `fix/issue-491-propsmapper-null-numeric`
- Labels: `bug`, `infra/io`, `1.8.0-after`
- State: `MERGED`, merge commit `01910c1fc47f55a9198815282bdbc32847db98e2`
- CI: - Add a lesson note for future Props-only coercion changes. / - `./gradlew :bluetape4k-jackson2:test --tests 'io.bluetape4k.jackson.text.datasources.ParseNamedDataSourcePropertiesTest' :bluetape4k-jackson3:test --tests 'io.bluetape4k.jackson3.text.datasources.ParseNamedDataSourcePropertiesTest' --console=plain --no-configuration-cache` / - `./gradlew :bluetape4k-jackson2:test :bluetape4k-jackson3:test --console=plain --no-configuration-cache`## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #554 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `01910c1fc47f55a9198815282bdbc32847db98e2`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
