### PR TITLE
feat: define codec trust profiles

### DIFF
--- a/docs/lessons/2026-05-20-issue-492-codec-trust-profiles.md
+++ b/docs/lessons/2026-05-20-issue-492-codec-trust-profiles.md
@@ -1,0 +1,36 @@
+# Issue 492 Codec Trust Profiles
+
+## Context
+
+Issue #492 needed a shared trust-profile vocabulary, explicit unsafe legacy
+codec modes, Kafka secure/legacy examples, and tests for one representative
+codec.
+
+## Decision
+
+Add `SerializationTrustProfile` as shared public vocabulary and document codec
+defaults in `docs/security/serialization-trust-profiles.md`. Harden protobuf
+dynamic type loading by making `RedissonProtobufCodec` default to
+`AllowListedTypes` with Kryo5 fallback and by tightening package-prefix matching
+in both `RedissonProtobufCodec` and `ProtobufSerializer`.
+
+## Outcome
+
+Kafka/Kafka4 docs now describe `emptySet()` as deny-all and show explicit
+allowlist and unsafe legacy examples. Redisson protobuf unsafe legacy behavior
+is available only through `ALLOW_ALL_CLASSES_UNSAFE`. Prefix spoofing and blank
+allowlist entries are rejected by tests.
+
+## Verification
+
+- IntelliJ reformat/import optimization ran for touched Kotlin files.
+- `./gradlew :bluetape4k-io:test --tests 'io.bluetape4k.io.serializer.SerializationTrustProfileTest' :bluetape4k-protobuf:test :bluetape4k-kafka:test --tests 'io.bluetape4k.kafka.codec.JacksonKafkaCodecSecurityTest' :bluetape4k-kafka4:test --tests 'io.bluetape4k.kafka.codec.JacksonKafkaCodecSecurityTest' --tests 'io.bluetape4k.kafka.codec.KafkaCodecAllowlistTest' --console=plain --no-configuration-cache` passed.
+- `javap` confirmed `RedissonProtobufCodec` keeps no-arg, `Codec`, `Set`, `(Codec, Set)`, and Redisson class-loader constructors.
+- `git diff --check` passed.
+
+## Next Time
+
+When documenting deny-all defaults, scan existing README snippets for examples
+that still imply default polymorphic round-trips. Also check named-argument
+constructor examples against the actual public Kotlin API before publishing
+migration docs.

--- a/docs/security/serialization-trust-profiles.md
+++ b/docs/security/serialization-trust-profiles.md
@@ -1,0 +1,43 @@
+# Serialization Trust Profiles
+
+bluetape4k codecs use four trust profiles to describe how much serialized data
+can influence deserialization.
+
+| Profile | Dynamic type loading | Default safety boundary | Examples |
+|---|---|---|---|
+| `TrustedInternal` | May load classes chosen by data written inside the same trusted deployment. | Use only for private caches or queues controlled by one application boundary. | Redisson Fory/Kryo defaults, Redisson Jackson/Fastjson when `allowedPackagePrefixes = null`. |
+| `AllowListedTypes` | Loads only classes allowed by package prefixes, class names, or object input filters. | Suitable for shared infrastructure and mixed producer/consumer deployments. | Kafka Jackson codecs with `allowedTypePackages`, `ProtobufSerializer`, `RedissonProtobufCodec`, secure Kryo/Fory factories, JDK object input filter. |
+| `NoDynamicTypeLoading` | Serialized data does not choose a class. | Safest shape when the caller already knows the value type. | Static value-type JSON serializers and non-polymorphic decode APIs. |
+| `UnsafeLegacyCompatibility` | Restores allow-all legacy behavior through an explicit unsafe name. | Temporary migration only in fully trusted internal deployments. | `AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE`, `RedissonProtobufCodec.ALLOW_ALL_CLASSES_UNSAFE`. |
+
+## Defaults
+
+| Area | Default profile | Notes |
+|---|---|---|
+| Kafka 3/4 Jackson codecs | `AllowListedTypes` | `emptySet()` denies all dynamic class loading; configure package prefixes for production or use `ALLOW_ALL_TYPES_UNSAFE` only for trusted legacy migration. |
+| ProtobufSerializer | `AllowListedTypes` | Defaults to `io.bluetape4k.` and `com.google.protobuf.`. |
+| RedissonProtobufCodec | `AllowListedTypes` | Uses the same default prefixes as `ProtobufSerializer` and Kryo5 fallback for non-Protobuf values; legacy allow-all requires `ALLOW_ALL_CLASSES_UNSAFE`. |
+| Redisson Jackson3/Fastjson2 | `TrustedInternal` by default | Set `allowedPackagePrefixes` to move JSONB/polymorphic JSON use into `AllowListedTypes`. |
+| Kryo/Fory binary serializers | `TrustedInternal` by default | Use secure factories when data crosses a shared or untrusted boundary. |
+| JDK binary serializer | `AllowListedTypes` | Applies the default JDK object input filter and remains deprecated for new general use. |
+
+## Migration Guidance
+
+For shared Kafka topics, Redis keys, queues, or any boundary where a producer can
+be outside the current process trust boundary, prefer `AllowListedTypes` or
+`NoDynamicTypeLoading`.
+
+Use unsafe legacy constants only as an intentional migration bridge:
+
+```kotlin
+// Kafka legacy compatibility: trusted internal deployments only.
+override val allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
+
+// Redisson Protobuf legacy compatibility: trusted internal deployments only.
+val codec = RedissonProtobufCodec(
+    allowedClassPrefixes = RedissonProtobufCodec.ALLOW_ALL_CLASSES_UNSAFE,
+)
+```
+
+Replace unsafe settings with narrow package prefixes once all stored payloads and
+producers are known.

--- a/docs/superpowers/plans/2026-05-20-issue-492-codec-trust-profiles-plan.md
+++ b/docs/superpowers/plans/2026-05-20-issue-492-codec-trust-profiles-plan.md
@@ -1,0 +1,77 @@
+# Issue 492 Codec Trust Profiles Plan
+
+## Tasks
+
+1. Add `SerializationTrustProfile` to `bluetape4k-io`.
+   - English KDoc for each profile.
+   - Include a stable display name for public docs.
+   - Add a focused unit test for profile names.
+
+2. Harden `RedissonProtobufCodec`.
+   - Add `allowedClassPrefixes` with default
+     `ProtobufSerializer.DEFAULT_ALLOWED_PREFIXES`.
+   - Add `ALLOW_ALL_CLASSES_UNSAFE` as the explicit legacy bypass.
+   - Use `RedissonCodecs.Kryo5` as the default non-Protobuf fallback.
+   - Add a public `allowedClassPrefixes` constructor so README snippets compile.
+   - Validate `Any.typeUrl` class names before `Class.forName`.
+   - Reject blank prefixes and package-prefix spoofing.
+   - Preserve fallback decoding for non-protobuf payloads.
+   - Rethrow `SecurityException`; do not silently fall back after a trust
+     boundary violation.
+   - Preserve Redisson class-loader constructors.
+
+3. Tighten `ProtobufSerializer` allowlist matching.
+   - Reject blank custom prefixes.
+   - Match exact class names or package-boundary prefixes only.
+   - Add prefix-spoofing regression tests.
+
+4. Add representative tests.
+   - Default codec rejects an untrusted protobuf `Any.typeUrl`.
+   - Explicit unsafe opt-in attempts legacy class loading; for a missing class
+     it falls through to the existing fallback path instead of throwing the
+     allowlist `SecurityException`.
+   - Public `allowedClassPrefixes` constructor supports named-argument examples.
+   - Prefix spoofing and blank prefixes are rejected.
+   - Existing protobuf and fallback round-trip tests continue to pass.
+
+5. Update public docs.
+   - Add `docs/security/serialization-trust-profiles.md`.
+   - Update `io/io` README pair for profile vocabulary.
+   - Update `io/protobuf` README pair for protobuf and Redisson protobuf
+     defaults.
+   - Update `infra/redisson` README pair for trusted-internal vs allowlisted
+     codecs.
+   - Update Kafka and Kafka4 README pairs with secure and unsafe legacy
+     examples; fix Kafka4 `emptySet()` drift.
+
+6. Run verification.
+   - IntelliJ diagnostics/reformat/imports for touched Kotlin files.
+   - `./gradlew :bluetape4k-io:test --tests 'io.bluetape4k.io.serializer.SerializationTrustProfileTest' --console=plain --no-configuration-cache`
+   - `./gradlew :bluetape4k-protobuf:test --tests 'io.bluetape4k.protobuf.serializers.redis.RedissonProtobufCodecTest' --console=plain --no-configuration-cache`
+   - Targeted Kafka/Kafka4 codec tests after README/source consistency review if no code changed there.
+   - `git diff --check`.
+
+7. Run current-session Step 6-R review, write lesson, commit, push, create PR,
+   add PR review comment, and wait for CI.
+
+## Risks And Rollback
+
+| Risk | Mitigation |
+|---|---|
+| Redisson protobuf default reject breaks deployments using non-bluetape4k package protobuf classes. | Document `allowedClassPrefixes` and `ALLOW_ALL_CLASSES_UNSAFE` migration path. |
+| Constructor change breaks Redisson dynamic codec creation. | Keep class-loader constructors and add tests around default construction behavior through existing codec list. |
+| Docs drift from Kafka behavior. | Grep source for `allowedTypePackages` and `ALLOW_ALL_TYPES_UNSAFE`; update both Kafka README pairs. |
+
+## Step 3-R Session Review
+
+External Claude/Codex CLI advisor passes are intentionally skipped by user
+directive for this session. Review was performed in the current Codex session.
+
+| Perspective | P0 | P1 | P2/P3 | Plan edit |
+|---|---:|---:|---|---|
+| Implementer | 0 | 0 | P2: constructor compatibility needs explicit task. | Added class-loader constructor preservation. |
+| Test engineer | 0 | 0 | P2: unsafe opt-in should be tested without requiring a real untrusted class. | Test expects no allowlist exception and fallback path behavior. |
+| Architect | 0 | 0 | P2: shared enum should not force immediate serializer interface refactor. | Non-goal recorded in spec. |
+| Delivery/docs | 0 | 0 | P2: README localized pairs must be updated together. | README pair list included. |
+
+Step 3-R convergence: `P0 = 0`, `P1 = 0`.

--- a/docs/superpowers/specs/2026-05-20-issue-492-codec-trust-profiles-design.md
+++ b/docs/superpowers/specs/2026-05-20-issue-492-codec-trust-profiles-design.md
@@ -1,0 +1,96 @@
+# Issue 492 Codec Trust Profiles Design
+
+## Context
+
+Issue #492 asks for public serialization trust profiles, explicit unsafe legacy
+modes, Kafka secure/legacy examples, and representative tests proving safe
+defaults plus explicit opt-in behavior.
+
+The current code already has several security controls, but the vocabulary is
+inconsistent:
+
+- Kafka 3/4 Jackson codecs use `allowedTypePackages`; `emptySet()` denies all
+  dynamic class loading and `ALLOW_ALL_TYPES_UNSAFE` explicitly restores the
+  legacy allow-all mode.
+- `ProtobufSerializer` uses allowlisted type URL prefixes by default.
+- `RedissonProtobufCodec` reads `Any.typeUrl`, loads that class name directly,
+  and falls back only when protobuf decoding fails. It lacks an allowlist API.
+- Redisson Jackson/Fastjson codecs expose `allowedPackagePrefixes`, where
+  `null` is the legacy trusted-internal behavior.
+- `KryoBinarySerializer` and `ForyBinarySerializer` are trusted-internal binary
+  serializers; their `secure` factories provide allowlisted variants.
+- `JdkBinarySerializer` applies a default object input filter and remains
+  deprecated for general use.
+
+## Trust Profiles
+
+Public docs and API should use these names:
+
+| Profile | Meaning | Typical use |
+|---|---|---|
+| `TrustedInternal` | Deserializes only data written by the same trusted deployment boundary. | Private caches, in-memory queues, sealed internal Redis/Kafka deployments. |
+| `AllowListedTypes` | Dynamic class/type loading is permitted only for configured package prefixes or filters. | Shared infrastructure, topic/cache boundaries, mixed producers. |
+| `NoDynamicTypeLoading` | Caller supplies the target type statically; serialized data does not choose a class. | JSON value-type codecs and non-polymorphic APIs. |
+| `UnsafeLegacyCompatibility` | Previous allow-all behavior is available only through an explicit unsafe name/configuration. | Temporary migration from older wire formats or trusted legacy deployments. |
+
+## Scope
+
+Implement a bounded API and documentation change:
+
+1. Add a small public enum in `bluetape4k-io` to make the trust profile names
+   stable and reusable across codec docs.
+2. Harden `RedissonProtobufCodec` to match `ProtobufSerializer` by default:
+   allow only `ProtobufSerializer.DEFAULT_ALLOWED_PREFIXES`, expose
+   `allowedClassPrefixes`, use Kryo5 fallback for non-Protobuf values, and let
+   callers opt into legacy compatibility with an explicit unsafe constant.
+3. Tighten `ProtobufSerializer` custom allowlist matching so package-prefix
+   spoofing and blank prefixes are rejected consistently with the Redisson
+   protobuf codec.
+4. Keep existing Kafka runtime behavior. Fix Kafka4 README drift where it says
+   `emptySet()` allows all even though the code denies all.
+5. Add public docs describing profile defaults and migration choices.
+6. Add representative tests for default-safe and explicit opt-in behavior using
+   `RedissonProtobufCodec`, because it currently has the clearest gap.
+
+## Non-Goals
+
+- Do not rewrite every serializer to a common interface in this PR.
+- Do not change Kafka wire format or `allowedTypePackages` semantics.
+- Do not change Redisson Jackson/Fastjson defaults in this PR; document their
+  trusted-internal default and existing allowlist option.
+- Do not introduce new dependencies.
+
+## Compatibility
+
+`RedissonProtobufCodec` must preserve current default success for bluetape4k and
+Google protobuf messages. Intended behavior changes are rejecting a protobuf
+`Any.typeUrl` whose class name is outside the allowlist before class loading
+occurs, rejecting spoofed/blank allowlist prefixes, and using Kryo5 instead of
+JDK fallback for non-Protobuf payloads.
+
+An explicit unsafe opt-in constant should be available for legacy deployments
+that stored protobuf `Any` messages using application package names outside the
+default prefixes.
+
+## Acceptance Mapping
+
+| Issue acceptance | Design response |
+|---|---|
+| Public docs describe codec trust profiles and defaults. | Add central codec trust profile docs and link/update affected README files. |
+| Unsafe legacy modes explicit in API names/config. | Document `ALLOW_ALL_TYPES_UNSAFE` and add `RedissonProtobufCodec.ALLOW_ALL_CLASSES_UNSAFE`. |
+| At least Kafka docs include secure and legacy examples. | Update Kafka and Kafka4 README pairs with secure/legacy examples and corrected defaults. |
+| Tests cover default-safe and explicit opt-in behavior for one representative codec. | Add Redisson protobuf tests for rejected untrusted type URL and explicit unsafe opt-in. |
+
+## Step 2-R Session Review
+
+External Claude/Codex CLI advisor passes are intentionally skipped by user
+directive for this session. Review was performed in the current Codex session.
+
+| Perspective | P0 | P1 | P2/P3 | Verdict |
+|---|---:|---:|---|---|
+| Developer | 0 | 0 | P2: avoid broad serializer interface in this PR. | Scope stays bounded. |
+| Security | 0 | 0 | P2: document Redisson Jackson/Fastjson trusted-internal defaults. | Added to docs scope. |
+| Ops/SRE | 0 | 0 | P3: migration rollback should be explicit. | Unsafe opt-in and fallback behavior recorded. |
+| User/caller | 0 | 0 | P2: Kafka4 README drift must be fixed. | Included as required task. |
+
+Step 2-R convergence: `P0 = 0`, `P1 = 0`.

--- a/infra/kafka/README.ko.md
+++ b/infra/kafka/README.ko.md
@@ -131,6 +131,7 @@ while (true) {
 ### 4. Kafka Codecs 사용
 
 ```kotlin
+import io.bluetape4k.kafka.codec.JacksonKafkaCodec
 import io.bluetape4k.kafka.codec.KafkaCodecs
 
 // 문자열 Codec
@@ -138,8 +139,12 @@ val stringCodec = KafkaCodecs.String
 val bytes = stringCodec.serialize("test-topic", "Hello Kafka")
 val message = stringCodec.deserialize("test-topic", bytes)
 
-// Jackson JSON Codec
-val jacksonCodec = KafkaCodecs.Jackson
+// 명시적 허용 목록을 사용하는 Jackson JSON Codec
+class ExampleJacksonCodec : JacksonKafkaCodec() {
+    override val allowedTypePackages = setOf("java.util")
+}
+
+val jacksonCodec = ExampleJacksonCodec()
 val data = mapOf("name" to "John", "age" to 30)
 val jsonBytes = jacksonCodec.serialize("test-topic", data)
 val decoded = jacksonCodec.deserialize("test-topic", jsonBytes)
@@ -194,6 +199,9 @@ class NoHeaderForyCodec : ForyKafkaCodec() {
 
 #### 보안: 클래스 로딩 허용 목록
 
+신뢰 프로필: 기본값은 `AllowListedTypes`입니다. `UnsafeLegacyCompatibility`는
+`AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE`를 통해서만 사용하세요.
+
 `AbstractKafkaCodec` 은 Kafka 헤더 `bluetape4k.kafka.codec.value.type` 에서
 역직렬화 대상 클래스를 로드합니다. 공격자가 이 헤더를 조작하면 임의 클래스 로딩(RCE)이
 가능합니다.
@@ -214,6 +222,14 @@ class SecureJacksonCodec : JacksonKafkaCodec() {
 | `emptySet()` (기본값) | **모든 클래스 차단** — 타입 헤더에서 클래스를 로드하지 않음. 신뢰할 수 없거나 공유된 토픽에 대한 안전한 기본값. |
 | 비어 있지 않은 집합 | 나열된 패키지 접두사와 일치하는 FQN 클래스만 허용; 그 외 poison-pill `null` 반환. |
 | `AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE` | 모든 검사 우회 — 1.8.0 이전의 허용-전체 동작 복원. 완전히 신뢰할 수 있는 내부 환경에서만 사용. |
+
+레거시 마이그레이션 예시:
+
+```kotlin
+class LegacyTrustedJacksonCodec : JacksonKafkaCodec() {
+    override val allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
+}
+```
 
 ### 5. Spring KafkaTemplate과 Coroutines
 

--- a/infra/kafka/README.md
+++ b/infra/kafka/README.md
@@ -131,6 +131,7 @@ while (true) {
 ### 4. Using Kafka Codecs
 
 ```kotlin
+import io.bluetape4k.kafka.codec.JacksonKafkaCodec
 import io.bluetape4k.kafka.codec.KafkaCodecs
 
 // String codec
@@ -138,8 +139,12 @@ val stringCodec = KafkaCodecs.String
 val bytes = stringCodec.serialize("test-topic", "Hello Kafka")
 val message = stringCodec.deserialize("test-topic", bytes)
 
-// Jackson JSON codec
-val jacksonCodec = KafkaCodecs.Jackson
+// Jackson JSON codec with an explicit allowlist
+class ExampleJacksonCodec : JacksonKafkaCodec() {
+    override val allowedTypePackages = setOf("java.util")
+}
+
+val jacksonCodec = ExampleJacksonCodec()
 val data = mapOf("name" to "John", "age" to 30)
 val jsonBytes = jacksonCodec.serialize("test-topic", data)
 val decoded = jacksonCodec.deserialize("test-topic", jsonBytes)
@@ -195,6 +200,9 @@ class NoHeaderForyCodec : ForyKafkaCodec() {
 
 #### Security: Class Loading Allowlist
 
+Trust profile: `AllowListedTypes` by default. Use
+`UnsafeLegacyCompatibility` only through `AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE`.
+
 `AbstractKafkaCodec` loads the deserialization target class from the Kafka
 header `bluetape4k.kafka.codec.value.type`. If that header can be set by an
 attacker, arbitrary class loading (RCE) is possible.
@@ -215,6 +223,14 @@ class SecureJacksonCodec : JacksonKafkaCodec() {
 | `emptySet()` (default) | **Deny all** — no class is loaded from the type header. Safe default for untrusted or shared topics. |
 | Non-empty set | Only classes whose FQN equals or starts with a listed prefix are allowed; others → poison-pill `null`. |
 | `AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE` | Bypass all checks — restores pre-1.8.0 allow-all behavior. Use only in fully trusted, internally controlled deployments. |
+
+Legacy migration example:
+
+```kotlin
+class LegacyTrustedJacksonCodec : JacksonKafkaCodec() {
+    override val allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
+}
+```
 
 ### 5. Spring KafkaTemplate with Coroutines
 

--- a/infra/kafka4/README.ko.md
+++ b/infra/kafka4/README.ko.md
@@ -111,9 +111,13 @@ non-null value type을 우선 사용하세요.
 ## Jackson 3 Codec
 
 ```kotlin
-import io.bluetape4k.kafka.codec.KafkaCodecs
+import io.bluetape4k.kafka.codec.JacksonKafkaCodec
 
-val codec = KafkaCodecs.Jackson
+class ExampleJacksonCodec : JacksonKafkaCodec() {
+    override val allowedTypePackages = setOf("java.util")
+}
+
+val codec = ExampleJacksonCodec()
 val bytes = codec.serialize("events", mapOf("name" to "spring-kafka-4"))
 val decoded = codec.deserialize("events", bytes)
 ```
@@ -182,6 +186,9 @@ class NoHeaderForyCodec : ForyKafkaCodec() {
 
 ### 보안: 클래스 로딩 허용 목록
 
+신뢰 프로필: 기본값은 `AllowListedTypes`입니다. `UnsafeLegacyCompatibility`는
+`AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE`를 통해서만 사용하세요.
+
 `AbstractKafkaCodec` 은 Kafka 헤더 `bluetape4k.kafka.codec.value.type` 에서
 역직렬화 대상 클래스를 로드합니다. 이 헤더를 공격자가 조작할 수 있는 환경(신뢰할 수
 없는 브로커, 외부 네트워크)에서는 임의 클래스 로딩(RCE)이 가능합니다.
@@ -199,11 +206,17 @@ class SecureJacksonCodec : JacksonKafkaCodec() {
 
 | `allowedTypePackages` 값 | 동작 |
 |--------------------------|------|
-| `emptySet()` (기본값) | 모든 클래스 허용 — 하위 호환, 신뢰 환경 전용 |
-| 비어 있지 않은 집합 | 나열된 패키지 하위 클래스만 허용; 그 외 `IllegalArgumentException` → poison-pill (`null`) |
+| `emptySet()` (기본값) | **모든 클래스 차단** — 타입 헤더에서 클래스를 로드하지 않음. 신뢰할 수 없거나 공유된 토픽에 대한 안전한 기본값. |
+| 비어 있지 않은 집합 | 나열된 패키지 접두사와 일치하는 FQN 클래스만 허용; 그 외 poison-pill `null` 반환. |
+| `AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE` | 모든 검사 우회 — 1.8.0 이전의 허용-전체 동작 복원. 완전히 신뢰할 수 있는 내부 환경에서만 사용. |
 
-> **경고:** 기본값 `emptySet()` 은 하위 호환성을 위해 모든 클래스 로딩을 허용합니다.
-> Kafka 브로커를 완전히 신뢰할 수 없는 프로덕션 환경에서는 반드시 명시적 패키지를 지정하십시오.
+레거시 마이그레이션 예시:
+
+```kotlin
+class LegacyTrustedJacksonCodec : JacksonKafkaCodec() {
+    override val allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
+}
+```
 
 ### 보안: JdkKafkaCodec 지원 중단
 

--- a/infra/kafka4/README.md
+++ b/infra/kafka4/README.md
@@ -112,9 +112,13 @@ application has an explicit tombstone/null-value contract.
 ## Jackson 3 Codec
 
 ```kotlin
-import io.bluetape4k.kafka.codec.KafkaCodecs
+import io.bluetape4k.kafka.codec.JacksonKafkaCodec
 
-val codec = KafkaCodecs.Jackson
+class ExampleJacksonCodec : JacksonKafkaCodec() {
+    override val allowedTypePackages = setOf("java.util")
+}
+
+val codec = ExampleJacksonCodec()
 val bytes = codec.serialize("events", mapOf("name" to "spring-kafka-4"))
 val decoded = codec.deserialize("events", bytes)
 ```
@@ -183,6 +187,9 @@ class NoHeaderForyCodec : ForyKafkaCodec() {
 
 ### Security: Class Loading Allowlist
 
+Trust profile: `AllowListedTypes` by default. Use
+`UnsafeLegacyCompatibility` only through `AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE`.
+
 `AbstractKafkaCodec` loads the deserialization target class from the Kafka
 header `bluetape4k.kafka.codec.value.type`. If that header can be set by an
 attacker (untrusted broker or external network), arbitrary class loading (RCE)
@@ -201,12 +208,17 @@ class SecureJacksonCodec : JacksonKafkaCodec() {
 
 | `allowedTypePackages` value | Effect |
 |-----------------------------|--------|
-| `emptySet()` (default) | All classes allowed — backward-compatible, trusted environments only |
-| Non-empty set | Only classes under listed package prefixes are allowed; others throw `IllegalArgumentException` → poison-pill (`null`) |
+| `emptySet()` (default) | **Deny all** — no class is loaded from the type header. Safe default for untrusted or shared topics. |
+| Non-empty set | Only classes whose FQN equals or starts with a listed prefix are allowed; others → poison-pill `null`. |
+| `AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE` | Bypass all checks — restores pre-1.8.0 allow-all behavior. Use only in fully trusted, internally controlled deployments. |
 
-> **Warning:** The default `emptySet()` maintains backward compatibility but
-> allows any class to be loaded. Set explicit packages in production when the
-> Kafka broker is not fully trusted.
+Legacy migration example:
+
+```kotlin
+class LegacyTrustedJacksonCodec : JacksonKafkaCodec() {
+    override val allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
+}
+```
 
 ### Security: JdkKafkaCodec Deprecated
 

--- a/infra/redisson/README.ko.md
+++ b/infra/redisson/README.ko.md
@@ -148,6 +148,17 @@ Codec 클래스:
 - `ZstdCodec` — Zstd 압축 래퍼
 - `GzipCodec` — GZip 압축 래퍼
 
+#### Codec 신뢰 프로필
+
+공통 프로필 용어는 [Serialization Trust Profiles](../../docs/security/serialization-trust-profiles.md)를
+참고하세요.
+
+| Codec 계열 | 기본 프로필 | 공유 경계에서 더 안전한 선택 |
+|---|---|---|
+| `ForyCodec`, `Kryo5Codec`, 압축 변형 | `TrustedInternal` | 하나의 배포 경계가 제어하는 private Redis 데이터에만 사용하거나, 가능한 경우 secure serializer/factory를 선택합니다. |
+| `allowedPackagePrefixes = null`인 `Jackson3Codec` / `Fastjson2Codec` | `TrustedInternal` | `allowedPackagePrefixes`를 지정해 `AllowListedTypes`로 사용합니다. |
+| `Fastjson2Codec(allowedPackagePrefixes = setOf(...))` | `AllowListedTypes` | 저장 DTO 패키지 범위만큼만 좁게 접두사를 유지합니다. |
+
 #### 사용 목적별 팩토리 함수
 
 `RedissonCodecs`는 내부 구현을 몰라도 적절한 Codec을 쉽게 선택할 수 있는 사용 목적 기반 팩토리 함수를 제공합니다:

--- a/infra/redisson/README.md
+++ b/infra/redisson/README.md
@@ -149,6 +149,17 @@ Codec classes:
 - `ZstdCodec` — Zstd compression wrapper.
 - `GzipCodec` — GZip compression wrapper.
 
+#### Codec Trust Profiles
+
+See [Serialization Trust Profiles](../../docs/security/serialization-trust-profiles.md)
+for the shared profile vocabulary.
+
+| Codec family | Default profile | Safer shared-boundary option |
+|---|---|---|
+| `ForyCodec`, `Kryo5Codec`, and compressed variants | `TrustedInternal` | Use only for private Redis data controlled by one deployment boundary, or choose a secure serializer/factory where available. |
+| `Jackson3Codec` / `Fastjson2Codec` with `allowedPackagePrefixes = null` | `TrustedInternal` | Set `allowedPackagePrefixes` for `AllowListedTypes`. |
+| `Fastjson2Codec(allowedPackagePrefixes = setOf(...))` | `AllowListedTypes` | Keep prefixes as narrow as the stored DTO packages allow. |
+
 #### Use-Case Factory Functions
 
 `RedissonCodecs` provides use-case-oriented factory functions so you can select the right codec without knowing the internals:

--- a/io/io/README.ko.md
+++ b/io/io/README.ko.md
@@ -122,6 +122,20 @@ Virtual Threads를 활용한 경량 스레드 기반 비동기 처리를 지원�
 
 ### 6. 보안 기능
 
+#### 직렬화 신뢰 프로필
+
+Codec 문서는 `SerializationTrustProfile` 이름으로 역직렬화 신뢰 경계를 설명합니다:
+
+| 프로필 | 의미 |
+|---|---|
+| `TrustedInternal` | 완전히 신뢰하는 내부 경계에서 쓴 데이터만 읽습니다. |
+| `AllowListedTypes` | 동적 클래스/타입 로딩을 패키지 접두사, 클래스명, object input filter로 제한합니다. |
+| `NoDynamicTypeLoading` | 호출자가 대상 타입을 정적으로 제공하며, 직렬화 데이터가 클래스를 선택하지 않습니다. |
+| `UnsafeLegacyCompatibility` | 명시적인 unsafe 이름으로만 레거시 허용-전체 동작을 켭니다. |
+
+Codec 기본값과 마이그레이션 지침은 [Serialization Trust Profiles](../../docs/security/serialization-trust-profiles.md)를
+참고하세요.
+
 #### JDK 직렬화 필터 (JEP 290)
 
 `JdkBinarySerializer`는 이제 기본적으로 `JDK_DEFAULT_OBJECT_INPUT_FILTER`를 적용합니다.

--- a/io/io/README.md
+++ b/io/io/README.md
@@ -119,6 +119,21 @@ Supports lightweight async processing using Virtual Threads.
 
 ### 6. Security Features
 
+#### Serialization Trust Profiles
+
+Codec documentation uses `SerializationTrustProfile` names to describe the
+deserialization boundary:
+
+| Profile | Meaning |
+|---|---|
+| `TrustedInternal` | Data is read only from a fully trusted internal boundary. |
+| `AllowListedTypes` | Dynamic class/type loading is restricted by package prefixes, class names, or object input filters. |
+| `NoDynamicTypeLoading` | The caller supplies the target type statically; serialized data does not choose the class. |
+| `UnsafeLegacyCompatibility` | Legacy allow-all behavior is enabled only through an explicit unsafe name. |
+
+See [Serialization Trust Profiles](../../docs/security/serialization-trust-profiles.md)
+for codec defaults and migration guidance.
+
 #### JDK Serialization Filter (JEP 290)
 
 `JdkBinarySerializer` now applies `JDK_DEFAULT_OBJECT_INPUT_FILTER` by default, which only allows

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/SerializationTrustProfile.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/SerializationTrustProfile.kt
@@ -1,0 +1,36 @@
+package io.bluetape4k.io.serializer
+
+/**
+ * Describes the trust boundary expected by a serialization codec.
+ *
+ * These profiles are documentation and configuration vocabulary for codecs
+ * that differ in how much serialized data can influence deserialization.
+ */
+enum class SerializationTrustProfile(
+    /**
+     * Stable display name used in public documentation.
+     */
+    val displayName: String,
+) {
+    /**
+     * Data is read only from a fully trusted internal boundary.
+     */
+    TRUSTED_INTERNAL("TrustedInternal"),
+
+    /**
+     * Dynamic type loading is allowed only for configured package prefixes,
+     * class names, or object input filters.
+     */
+    ALLOW_LISTED_TYPES("AllowListedTypes"),
+
+    /**
+     * The caller supplies the target type statically; serialized data does not
+     * choose the class to instantiate.
+     */
+    NO_DYNAMIC_TYPE_LOADING("NoDynamicTypeLoading"),
+
+    /**
+     * Legacy allow-all behavior is enabled explicitly for migration.
+     */
+    UNSAFE_LEGACY_COMPATIBILITY("UnsafeLegacyCompatibility"),
+}

--- a/io/io/src/test/kotlin/io/bluetape4k/io/serializer/SerializationTrustProfileTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/serializer/SerializationTrustProfileTest.kt
@@ -1,0 +1,17 @@
+package io.bluetape4k.io.serializer
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class SerializationTrustProfileTest {
+
+    @Test
+    fun `trust profile display names are stable`() {
+        SerializationTrustProfile.entries.map { it.displayName } shouldBeEqualTo listOf(
+            "TrustedInternal",
+            "AllowListedTypes",
+            "NoDynamicTypeLoading",
+            "UnsafeLegacyCompatibility",
+        )
+    }
+}

--- a/io/protobuf/README.ko.md
+++ b/io/protobuf/README.ko.md
@@ -34,6 +34,8 @@ Google Protocol Buffers 메시지 처리를 위한 Kotlin 확장 라이브러리
 
 ### 보안: ProtobufSerializer 허용 목록
 
+신뢰 프로필: `AllowListedTypes`.
+
 `ProtobufSerializer`는 역직렬화 전에 각 `Any` 메시지의 `typeUrl`을 허용 목록과 대조합니다.
 허용 목록에 없는 접두사를 가진 클래스는 `SecurityException`을 발생시킵니다 (`BinarySerializationException`으로 래핑).
 
@@ -59,6 +61,24 @@ val expandedSerializer = ProtobufSerializer(
 ```
 
 비 Protobuf 객체에 대한 폴백 직렬화기도 JDK 역직렬화 RCE 위험을 피하기 위해 `Jdk`에서 `Kryo`로 변경되었습니다.
+
+`RedissonProtobufCodec`도 Redis 값에 같은 기본 허용 목록을 사용하며, 비 Protobuf
+값의 fallback에는 Kryo5를 사용합니다. 레거시 신뢰 환경에서 이전 허용-전체 동작이
+임시로 필요하면 명시적으로 설정하세요:
+
+```kotlin
+val codec = RedissonProtobufCodec(
+    allowedClassPrefixes = RedissonProtobufCodec.ALLOW_ALL_CLASSES_UNSAFE,
+)
+```
+
+프로덕션에서는 좁은 커스텀 허용 목록을 권장합니다:
+
+```kotlin
+val codec = RedissonProtobufCodec(
+    allowedClassPrefixes = ProtobufSerializer.DEFAULT_ALLOWED_PREFIXES + setOf("com.example.proto.")
+)
+```
 
 ## 사용 예시
 

--- a/io/protobuf/README.md
+++ b/io/protobuf/README.md
@@ -34,6 +34,8 @@ A Kotlin extension library for working with Google Protocol Buffers messages.
 
 ### Security: ProtobufSerializer Allowlist
 
+Trust profile: `AllowListedTypes`.
+
 `ProtobufSerializer` checks the `typeUrl` of each `Any` message against an allowlist before deserializing.
 Classes whose prefix is not in the allowlist throw `SecurityException` (wrapped as `BinarySerializationException`).
 
@@ -59,6 +61,25 @@ val expandedSerializer = ProtobufSerializer(
 ```
 
 The fallback serializer for non-Protobuf objects was also changed from `Jdk` to `Kryo` to avoid JDK deserialization RCE risks.
+
+`RedissonProtobufCodec` uses the same default allowlist for Redis values and
+uses Kryo5 as the fallback for non-Protobuf values. For legacy trusted
+deployments that need the old allow-all behavior temporarily, configure it
+explicitly:
+
+```kotlin
+val codec = RedissonProtobufCodec(
+    allowedClassPrefixes = RedissonProtobufCodec.ALLOW_ALL_CLASSES_UNSAFE,
+)
+```
+
+Prefer a narrow custom allowlist for production:
+
+```kotlin
+val codec = RedissonProtobufCodec(
+    allowedClassPrefixes = ProtobufSerializer.DEFAULT_ALLOWED_PREFIXES + setOf("com.example.proto.")
+)
+```
 
 ## Usage Examples
 

--- a/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializer.kt
+++ b/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializer.kt
@@ -38,6 +38,12 @@ class ProtobufSerializer(
     private val fallback: BinarySerializer = BinarySerializers.Kryo,
     private val allowedClassPrefixes: Set<String> = DEFAULT_ALLOWED_PREFIXES,
 ): AbstractBinarySerializer() {
+    init {
+        require(allowedClassPrefixes.all { it.isNotBlank() }) {
+            "allowedClassPrefixes must not contain blank entries."
+        }
+    }
+
     companion object {
         private val messageTypes = ConcurrentHashMap<String, Class<out ProtoMessage>>()
 
@@ -69,7 +75,7 @@ class ProtobufSerializer(
             val className = protoAny.typeUrl.substringAfterLast("/")
 
             // 보안: 허용 목록에 없는 클래스는 로딩 거부
-            require(allowedClassPrefixes.any { className.startsWith(it) }) {
+            require(allowedClassPrefixes.any { className.matchesAllowedPrefix(it) }) {
                 "신뢰할 수 없는 Protobuf 클래스: $className. allowedClassPrefixes에 추가하세요."
             }
 
@@ -87,4 +93,10 @@ class ProtobufSerializer(
             fallback.deserialize(bytes)
         }
     }
+
+    private fun String.matchesAllowedPrefix(prefix: String): Boolean =
+        this == prefix || startsWith(prefix.ensurePackagePrefix())
+
+    private fun String.ensurePackagePrefix(): String =
+        if (endsWith(".")) this else "$this."
 }

--- a/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodec.kt
+++ b/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodec.kt
@@ -4,6 +4,7 @@ import com.google.protobuf.Message
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.netty.buffer.getBytes
+import io.bluetape4k.protobuf.serializers.ProtobufSerializer
 import io.bluetape4k.redis.redisson.codec.RedissonCodecs
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
@@ -17,31 +18,69 @@ import java.util.concurrent.ConcurrentHashMap
 typealias AnyMessage = com.google.protobuf.Any
 
 /**
- * Protobuf 메시지를 Redisson에서 사용하기 위한 Codec입니다.
+ * Redisson codec for Protobuf messages.
  *
- * ## 동작/계약
- * - [com.google.protobuf.Message] 인스턴스는 `Any.pack(message).toByteArray()`로 직렬화합니다.
- * - 역직렬화 시 `typeUrl`의 클래스명을 기반으로 Message 타입을 캐시해 언패킹합니다.
- * - Protobuf 경로 실패 시 [fallbackCodec]에 위임합니다.
+ * ## Contract
+ * - [com.google.protobuf.Message] values are encoded with `Any.pack(message).toByteArray()`.
+ * - During decoding, the class name from `Any.typeUrl` is validated against [allowedClassPrefixes]
+ *   before class loading.
+ * - Non-Protobuf payloads are delegated to [fallbackCodec].
+ * - A trust-boundary violation throws [SecurityException] instead of falling back silently.
  *
  * ```kotlin
  * val codec = RedissonProtobufCodec()
- * // Redisson Config에 codec을 등록하면 Protobuf 직렬화가 적용됩니다.
+ * // Register the codec in Redisson Config to store Protobuf messages.
  * ```
  *
- * @property fallbackCodec Protobuf 처리 실패 시 사용하는 fallback Codec입니다.
+ * @property fallbackCodec fallback codec for non-Protobuf payloads.
+ * @property allowedClassPrefixes package prefixes allowed for Protobuf `Any.typeUrl` class names.
  */
-class RedissonProtobufCodec(
-    private val fallbackCodec: Codec = RedissonCodecs.Jdk,
+class RedissonProtobufCodec private constructor(
+    private val fallbackCodec: Codec = RedissonCodecs.Kryo5,
+    private val allowedClassPrefixes: Set<String> = ProtobufSerializer.DEFAULT_ALLOWED_PREFIXES,
+    private val classLoader: ClassLoader? = null,
 ): BaseCodec() {
-    // classLoader를 인자로 받는 보조 생성자는 Redisson에서 환경설정 정보를 바탕으로 동적으로 Codec 생성 시에 필요합니다.
-    @Suppress("UNUSED_PARAMETER")
-    constructor(classLoader: ClassLoader): this()
-    constructor(classLoader: ClassLoader, codec: RedissonProtobufCodec): this(copy(classLoader, codec.fallbackCodec))
+    init {
+        if (allowedClassPrefixes != ALLOW_ALL_CLASSES_UNSAFE) {
+            require(allowedClassPrefixes.all { it.isNotBlank() }) {
+                "allowedClassPrefixes must not contain blank entries."
+            }
+        }
+    }
+
+    constructor(): this(RedissonCodecs.Kryo5, ProtobufSerializer.DEFAULT_ALLOWED_PREFIXES, null)
+
+    constructor(
+        fallbackCodec: Codec,
+    ): this(fallbackCodec, ProtobufSerializer.DEFAULT_ALLOWED_PREFIXES, null)
+
+    constructor(
+        allowedClassPrefixes: Set<String>,
+    ): this(RedissonCodecs.Kryo5, allowedClassPrefixes, null)
+
+    constructor(
+        fallbackCodec: Codec,
+        allowedClassPrefixes: Set<String>,
+    ): this(fallbackCodec, allowedClassPrefixes, null)
+
+    // Redisson requires class-loader constructors for dynamic codec creation from configuration.
+    constructor(classLoader: ClassLoader): this(RedissonCodecs.Kryo5, ProtobufSerializer.DEFAULT_ALLOWED_PREFIXES, classLoader)
+    constructor(classLoader: ClassLoader, codec: RedissonProtobufCodec): this(
+        fallbackCodec = copy(classLoader, codec.fallbackCodec),
+        allowedClassPrefixes = codec.allowedClassPrefixes,
+        classLoader = classLoader,
+    )
 
     companion object: KLogging() {
-        private val classCache = ConcurrentHashMap<String, Class<Message>>()
+        /**
+         * Explicit migration profile that restores legacy allow-all Protobuf class loading.
+         *
+         * Use only for fully trusted internal Redis deployments while migrating to an allowlist.
+         */
+        val ALLOW_ALL_CLASSES_UNSAFE: Set<String> = setOf("*")
     }
+
+    private val classCache = ConcurrentHashMap<String, Class<Message>>()
 
     private val encoder: Encoder =
         Encoder { graph ->
@@ -63,11 +102,15 @@ class RedissonProtobufCodec(
                 val bytes = buf.getBytes(copy = false)
                 val any = AnyMessage.parseFrom(bytes)
                 val className = any.typeUrl.substringAfterLast("/")
+                validateClassName(className)
                 val clazz =
                     classCache.computeIfAbsent(className) {
-                        Class.forName(it) as Class<Message>
+                        Class.forName(it, false, classLoader ?: Thread.currentThread().contextClassLoader)
+                            as Class<Message>
                     }
                 any.unpack(clazz)
+            } catch (e: SecurityException) {
+                throw e
             } catch (e: Throwable) {
                 log.debug(e) {
                     "Decoding: Protobuf 메시지가 아닙니다. fallbackCodec[$fallbackCodec] 사용."
@@ -79,4 +122,22 @@ class RedissonProtobufCodec(
     override fun getValueEncoder(): Encoder = encoder
 
     override fun getValueDecoder(): Decoder<Any> = decoder
+
+    private fun validateClassName(className: String) {
+        if (className.isBlank()) {
+            throw SecurityException("Protobuf Any typeUrl does not contain a class name.")
+        }
+        if (
+            allowedClassPrefixes != ALLOW_ALL_CLASSES_UNSAFE &&
+            allowedClassPrefixes.none { className.matchesAllowedPrefix(it) }
+        ) {
+            throw SecurityException("Untrusted Protobuf class: $className. Add the package to allowedClassPrefixes.")
+        }
+    }
+
+    private fun String.matchesAllowedPrefix(prefix: String): Boolean =
+        this == prefix || startsWith(prefix.ensurePackagePrefix())
+
+    private fun String.ensurePackagePrefix(): String =
+        if (endsWith(".")) this else "$this."
 }

--- a/io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializerSecurityTest.kt
+++ b/io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializerSecurityTest.kt
@@ -118,6 +118,33 @@ class ProtobufSerializerSecurityTest {
         restored shouldBeEqualTo message
     }
 
+    @Test
+    fun `커스텀 allowedClassPrefixes 는 패키지 prefix spoofing 을 차단한다`() {
+        val spoofedClass = "io.bluetape4kevil.Payload"
+        val craftedAny = Any.newBuilder()
+            .setTypeUrl("type.googleapis.com/$spoofedClass")
+            .setValue(com.google.protobuf.ByteString.copyFromUtf8("payload"))
+            .build()
+        val bytes = craftedAny.toByteArray()
+
+        val serializer = ProtobufSerializer(
+            allowedClassPrefixes = setOf("io.bluetape4k")
+        )
+
+        val ex = assertFailsWith<BinarySerializationException> {
+            serializer.deserialize<kotlin.Any>(bytes)
+        }
+        val secEx = generateSequence(ex.cause) { it.cause }.filterIsInstance<SecurityException>().firstOrNull()
+        (secEx?.message?.contains(spoofedClass) == true).shouldBeTrue()
+    }
+
+    @Test
+    fun `커스텀 allowedClassPrefixes 는 빈 접두사를 거부한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            ProtobufSerializer(allowedClassPrefixes = setOf(""))
+        }
+    }
+
     // ────────────────────────────────────────────────────────────────────────────
     // DEFAULT_ALLOWED_PREFIXES 내용 검증
     // ────────────────────────────────────────────────────────────────────────────

--- a/io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodecTest.kt
+++ b/io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodecTest.kt
@@ -1,17 +1,23 @@
 package io.bluetape4k.protobuf.serializers.redis
 
 import com.google.protobuf.timestamp
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.junit5.faker.Fakers
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.protobuf.redis.messages.copy
 import io.bluetape4k.protobuf.redis.messages.redisNestedMessage
 import io.bluetape4k.protobuf.redis.messages.redisSimpleMessage
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.netty.buffer.Unpooled
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import org.redisson.client.codec.BaseCodec
 import org.redisson.client.codec.Codec
 import org.redisson.client.handler.State
+import org.redisson.client.protocol.Decoder
+import org.redisson.client.protocol.Encoder
 import java.io.Serializable
 import java.time.Instant
 
@@ -36,7 +42,22 @@ class RedissonProtobufCodecTest: AbstractRedissonTest() {
     data class CustomData(
         val id: Int,
         val name: String,
-    ): Serializable
+    ): Serializable {
+        companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    private class SentinelFallbackCodec(
+        private val decoded: Any,
+    ): BaseCodec() {
+        private val encoder = Encoder { Unpooled.EMPTY_BUFFER }
+        private val decoder = Decoder<Any> { _, _ -> decoded }
+
+        override fun getValueEncoder(): Encoder = encoder
+
+        override fun getValueDecoder(): Decoder<Any> = decoder
+    }
 
     private fun Instant.toProtobufTimestamp(): com.google.protobuf.Timestamp {
         val source = this
@@ -97,6 +118,71 @@ class RedissonProtobufCodecTest: AbstractRedissonTest() {
     fun `codec for protobuf nested message`(codec: Codec) {
         repeat(REPEAT_SIZE) {
             codec.verifyCodec(newNestedMessage())
+        }
+    }
+
+    @Test
+    fun `default codec rejects untrusted protobuf typeUrl before class loading`() {
+        val bytes = AnyMessage.newBuilder()
+            .setTypeUrl("type.googleapis.com/untrusted.payload.UntrustedPayload")
+            .build()
+            .toByteArray()
+
+        val codec = RedissonProtobufCodec()
+
+        assertFailsWith<SecurityException> {
+            codec.valueDecoder.decode(Unpooled.wrappedBuffer(bytes), State())
+        }
+    }
+
+    @Test
+    fun `unsafe opt-in bypasses allowlist and keeps fallback behavior`() {
+        val fallbackValue = "fallback-after-legacy-class-lookup"
+        val bytes = AnyMessage.newBuilder()
+            .setTypeUrl("type.googleapis.com/untrusted.payload.MissingProtoMessage")
+            .build()
+            .toByteArray()
+
+        val codec = RedissonProtobufCodec(
+            fallbackCodec = SentinelFallbackCodec(fallbackValue),
+            allowedClassPrefixes = RedissonProtobufCodec.ALLOW_ALL_CLASSES_UNSAFE,
+        )
+
+        val actual = codec.valueDecoder.decode(Unpooled.wrappedBuffer(bytes), State())
+
+        actual shouldBeEqualTo fallbackValue
+    }
+
+    @Test
+    fun `custom allowlist constructor supports named allowedClassPrefixes`() {
+        val codec = RedissonProtobufCodec(
+            allowedClassPrefixes = setOf("io.bluetape4k.protobuf.redis.messages")
+        )
+        val origin = newSimpleMessage()
+
+        codec.verifyCodec(origin)
+    }
+
+    @Test
+    fun `allowlist rejects prefix spoofing`() {
+        val bytes = AnyMessage.newBuilder()
+            .setTypeUrl("type.googleapis.com/io.bluetape4kevil.Payload")
+            .build()
+            .toByteArray()
+
+        val codec = RedissonProtobufCodec(
+            allowedClassPrefixes = setOf("io.bluetape4k")
+        )
+
+        assertFailsWith<SecurityException> {
+            codec.valueDecoder.decode(Unpooled.wrappedBuffer(bytes), State())
+        }
+    }
+
+    @Test
+    fun `allowlist rejects blank prefixes`() {
+        assertFailsWith<IllegalArgumentException> {
+            RedissonProtobufCodec(allowedClassPrefixes = setOf(""))
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #492

- PR 제목: feat: define codec trust profiles

Fixes #492.

Defines serialization trust profiles and documents safe/default/legacy codec behavior across Kafka, Redisson, io, and Protobuf modules. Hardens Protobuf dynamic type loading by tightening allowlist matching and making `RedissonProtobufCodec` default to allowlisted Protobuf classes with Kryo5 fallback.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Added `SerializationTrustProfile` public vocabulary.
- Added `docs/security/serialization-trust-profiles.md` with codec defaults and migration guidance.
- Added explicit `RedissonProtobufCodec.ALLOW_ALL_CLASSES_UNSAFE` migration opt-in.
- Changed `RedissonProtobufCodec` default fallback from JDK serialization to Kryo5.
- Tightened `ProtobufSerializer` and `RedissonProtobufCodec` allowlist matching to reject blank prefixes and package-prefix spoofing.
- Corrected Kafka4 docs where `emptySet()` was incorrectly documented as allow-all.
- Updated Kafka/Kafka4 docs with secure allowlist and unsafe legacy examples.
- Updated multilingual README pairs and added spec, plan, and lesson artifacts.

### 기존 섹션: Step 6-R Current-Session Review

No Claude Code CLI or Codex CLI review was used, per user directive. Native subagent review plus local review were used.

Initial review findings:

| Priority | Finding | Resolution |
|---|---|---|
| P1 | `RedissonProtobufCodec` defaulted to JDK fallback while docs claimed safer fallback. | Changed default fallback to `RedissonCodecs.Kryo5`; documented it. |
| P1 | Class cache was global and keyed only by class name. | Moved cache to codec instance scope so Redisson class-loader constructor instances do not share class cache. |
| P1 | README named-argument `allowedClassPrefixes` examples did not match public constructors. | Added public `constructor(allowedClassPrefixes: Set<String>)` and verified with tests/javap. |
| P2 | Kafka docs implied default Jackson round-trip despite deny-all default. | Changed snippets to use custom allowlisted Jackson codecs. |
| P2 | Redisson protobuf allowlist used raw prefix matching. | Added package-boundary matching and tests; applied same hardening to `ProtobufSerializer`. |

Final convergence: P0=0, P1=0.

### 기존 섹션: Verification

- IntelliJ reformat/import optimization for touched Kotlin files.
- `./gradlew :bluetape4k-io:test --tests 'io.bluetape4k.io.serializer.SerializationTrustProfileTest' :bluetape4k-protobuf:test :bluetape4k-kafka:test --tests 'io.bluetape4k.kafka.codec.JacksonKafkaCodecSecurityTest' :bluetape4k-kafka4:test --tests 'io.bluetape4k.kafka.codec.JacksonKafkaCodecSecurityTest' --tests 'io.bluetape4k.kafka.codec.KafkaCodecAllowlistTest' --console=plain --no-configuration-cache`
- `javap` confirmed `RedissonProtobufCodec` keeps no-arg, `Codec`, `Set`, `(Codec, Set)`, and Redisson class-loader constructors.
- `git diff --check`

### 기존 섹션: Not Tested

- Full repository test suite.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #492, milestone `1.8.1`, assignee debop
- PR: #555, head `8db63aa6d11e35bae187bc03f2bf23d3994a6164`, milestone `1.8.1`, assignee debop
- Base: `develop`, head branch `feat/issue-492-codec-trust-profiles`
- Labels: `enhancement`, `security`, `1.8.0-after`
- State: `MERGED`, merge commit `de3aed67b9509ba9b57839c7a2724dbf756ccbc6`
- CI: - Added explicit `RedissonProtobufCodec.ALLOW_ALL_CLASSES_UNSAFE` migration opt-in. / - `./gradlew :bluetape4k-io:test --tests 'io.bluetape4k.io.serializer.SerializationTrustProfileTest' :bluetape4k-protobuf:test :bluetape4k-kafka:test --tests 'io.bluetape4k.kafka.codec.JacksonKafkaCodecSecurityTest' :bluetape4k-kafka4:test --tests 'io.bluetape4k.kafka.codec.JacksonKafkaCodecSecurityTest' --tests 'io.bluetape4k.kafka.codec.KafkaCodecAllowlistTest' --console=plain --no-configuration-cache`## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #555 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `de3aed67b9509ba9b57839c7a2724dbf756ccbc6`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
