### PR TITLE
feat: add near-cache capability matrix

### DIFF
--- a/cache/cache-core/README.ko.md
+++ b/cache/cache-core/README.ko.md
@@ -44,6 +44,17 @@ dependencies {
 
 ## 제공 기능 (상세)
 
+## Near-Cache Capability Matrix
+
+Native/JCache NearCache 지원 경계는
+[Near-Cache Backend Capability Matrix](../../docs/cache/near-cache-capability-matrix.md)에 정리되어 있습니다.
+
+- Lettuce, Hazelcast IMap, Redisson native NearCache는 공통
+  `NearCacheOperations` / `SuspendNearCacheOperations` conformance fixture를 상속합니다.
+- Lettuce와 Redisson JCache NearCache는 listener 기반이며 공통 JCache conformance fixture를 상속합니다.
+- Hazelcast JCache factory는 listener 없이 생성되는 degraded 모드입니다. 직접 listener-backed 생성은 unsupported로 테스트합니다.
+- Caffeine과 Cache2k는 분산 back cache와 조합하지 않는 한 local provider입니다.
+
 ### NearCache 통일 인터페이스
 
 모든 NearCache 백엔드(Lettuce, Hazelcast, Redisson, JCache)가 공통 인터페이스를 구현합니다.

--- a/cache/cache-core/README.md
+++ b/cache/cache-core/README.md
@@ -39,6 +39,21 @@ Add the appropriate provider module if you need distributed caching.
 
 ## Detailed Features
 
+## Near-Cache Capability Matrix
+
+The shared support boundary for native and JCache near-cache variants is tracked
+in [Near-Cache Backend Capability Matrix](../../docs/cache/near-cache-capability-matrix.md).
+
+- Lettuce, Hazelcast IMap, and Redisson native near caches are covered by the
+  shared `NearCacheOperations` / `SuspendNearCacheOperations` conformance
+  fixtures.
+- Lettuce and Redisson JCache near caches are listener-backed and covered by the
+  shared JCache conformance fixtures.
+- Hazelcast JCache factory methods are listener-free by design; direct
+  listener-backed construction is unsupported and tested explicitly.
+- Caffeine and Cache2k are local providers unless paired with a distributed back
+  cache through a supported near-cache implementation.
+
 ### Unified NearCache Interface
 
 All NearCache backends, including Lettuce, Hazelcast, Redisson, and JCache-based implementations, share a common interface.

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/Cache2KNearJJCacheTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/Cache2KNearJJCacheTest.kt
@@ -4,6 +4,9 @@ import io.bluetape4k.cache.jcache.JCache
 import io.bluetape4k.cache.jcache.JCaching
 import io.bluetape4k.cache.jcache.jcacheConfiguration
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.assertions.assertFailsWith
+import org.awaitility.core.ConditionTimeoutException
+import org.junit.jupiter.api.Test
 import javax.cache.expiry.EternalExpiryPolicy
 
 class Cache2KNearJJCacheTest: AbstractNearJCacheTest() {
@@ -17,7 +20,10 @@ class Cache2KNearJJCacheTest: AbstractNearJCacheTest() {
         }
     )
 
+    @Test
     override fun `removeAll - 모든 캐시를 삭제하면 다른 캐시에도 반영된다`() {
-        // FIXME: Cache2k 에서는 예외가 발생한다
+        assertFailsWith<ConditionTimeoutException> {
+            super.`removeAll - 모든 캐시를 삭제하면 다른 캐시에도 반영된다`()
+        }
     }
 }

--- a/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/AbstractNearCacheOperationsTest.kt
+++ b/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/AbstractNearCacheOperationsTest.kt
@@ -72,6 +72,17 @@ abstract class AbstractNearCacheOperationsTest<V: Any> {
     }
 
     @RepeatedTest(TEST_SIZE)
+    fun `put - value remains readable after local eviction`() {
+        val key = randomKey()
+        val value = sampleValue()
+
+        cache.put(key, value)
+        cache.clearLocal()
+
+        cache.get(key) shouldBeEqualTo value
+    }
+
+    @RepeatedTest(TEST_SIZE)
     fun `getAll - batch read`() {
         val entries = (1..5).associate { randomKey() to sampleValue() }
         cache.putAll(entries)
@@ -110,6 +121,19 @@ abstract class AbstractNearCacheOperationsTest<V: Any> {
 
         cache.put(key, value)
         cache.replace(key, newValue).shouldBeTrue()
+        cache.get(key) shouldBeEqualTo newValue
+    }
+
+    @RepeatedTest(TEST_SIZE)
+    fun `replace - updated value remains readable after local eviction`() {
+        val key = randomKey()
+        val value = sampleValue()
+        val newValue = anotherValue()
+
+        cache.put(key, value)
+        cache.replace(key, newValue).shouldBeTrue()
+        cache.clearLocal()
+
         cache.get(key) shouldBeEqualTo newValue
     }
 

--- a/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/AbstractSuspendNearCacheOperationsTest.kt
+++ b/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/AbstractSuspendNearCacheOperationsTest.kt
@@ -75,6 +75,18 @@ abstract class AbstractSuspendNearCacheOperationsTest<V: Any> {
         }
 
     @RepeatedTest(TEST_SIZE)
+    fun `put - value remains readable after local eviction`() =
+        runSuspendIO {
+            val key = randomKey()
+            val value = sampleValue()
+
+            cache.put(key, value)
+            cache.clearLocal()
+
+            cache.get(key) shouldBeEqualTo value
+        }
+
+    @RepeatedTest(TEST_SIZE)
     fun `getAll - batch read`() =
         runSuspendIO {
             val entries = (1..5).associate { randomKey() to sampleValue() }
@@ -116,6 +128,20 @@ abstract class AbstractSuspendNearCacheOperationsTest<V: Any> {
 
             cache.put(key, value)
             cache.replace(key, newValue).shouldBeTrue()
+            cache.get(key) shouldBeEqualTo newValue
+        }
+
+    @RepeatedTest(TEST_SIZE)
+    fun `replace - updated value remains readable after local eviction`() =
+        runSuspendIO {
+            val key = randomKey()
+            val value = sampleValue()
+            val newValue = anotherValue()
+
+            cache.put(key, value)
+            cache.replace(key, newValue).shouldBeTrue()
+            cache.clearLocal()
+
             cache.get(key) shouldBeEqualTo newValue
         }
 

--- a/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/jcache/AbstractNearJCacheTest.kt
+++ b/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/jcache/AbstractNearJCacheTest.kt
@@ -18,7 +18,6 @@ import org.awaitility.kotlin.await
 import org.awaitility.kotlin.until
 import org.awaitility.kotlin.untilNull
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
@@ -79,23 +78,25 @@ abstract class AbstractNearJCacheTest {
         nearJCache2[key] shouldBeEqualTo value
     }
 
-    // TODO: 실제 시나리오를 만들기 힘듬 (시점 차이) -> Mockk 로 대체해야 함
-    @Disabled("시나리오 미비 -> Mockk 으로 대체해야 함")
     @RepeatedTest(TEST_SIZE)
     fun `getDeeply - front miss면 back cache에서 조회하고 front cache를 채운다`() {
         val key = randomKey()
         val value = randomValue()
+        val config = NearJCacheConfig<String, Any>(cacheName = "front-" + randomKey())
+        val frontCache =
+            config.cacheManagerFactory.create().createCache(config.cacheName, config.frontCacheConfiguration)
+        val nearJCache = NearJCache(frontCache, backCache, config)
 
-        backCache.put(key, value)
-        nearJCache1.clear()
-        nearJCache2.clear()
+        try {
+            backCache.put(key, value)
+            nearJCache.containsKey(key).shouldBeFalse()
 
-        nearJCache1[key].shouldBeNull()
-        nearJCache2[key].shouldBeNull()
-
-        nearJCache1.getDeeply(key) shouldBeEqualTo value
-        nearJCache1[key] shouldBeEqualTo value
-        backCache[key] shouldBeEqualTo value
+            nearJCache.getDeeply(key) shouldBeEqualTo value
+            nearJCache[key] shouldBeEqualTo value
+            backCache[key] shouldBeEqualTo value
+        } finally {
+            nearJCache.close()
+        }
     }
 
     @RepeatedTest(TEST_SIZE)

--- a/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/jcache/AbstractSuspendNearJCacheTest.kt
+++ b/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/jcache/AbstractSuspendNearJCacheTest.kt
@@ -23,7 +23,6 @@ import io.bluetape4k.assertions.shouldNotBeEmpty
 import org.awaitility.kotlin.atMost
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
@@ -98,19 +97,22 @@ abstract class AbstractSuspendNearJCacheTest
         suspendNearJCache2.get(key) shouldBeEqualTo value
     }
 
-    // TODO: 실제 시나리오를 만들기 힘듬 (시점 차이) -> Mockk 로 대체해야 함
-    @Disabled("시나리오 미비 -> Mockk 으로 대체해야 함")
     @RepeatedTest(TEST_SIZE)
     fun `getDeeply - front miss면 back cache에서 조회하고 front cache를 채운다`() = runSuspendIO {
         val key = getKey()
         val value = getValue()
+        val frontCache = createFrontSuspendCache(Duration.ofMinutes(5))
+        val nearJCache = SuspendNearJCache.withoutListener(frontCache, backSuspendJCache)
 
-        backSuspendJCache.put(key, value)
-        suspendNearJCache1.clear()
+        try {
+            backSuspendJCache.put(key, value)
+            frontCache.get(key).shouldBeNull()
 
-        suspendNearJCache1.getDeeply(key) shouldBeEqualTo value
-        await atMost (awaitTimeout) untilSuspending { suspendNearJCache1.containsKey(key) }
-        suspendNearJCache1.get(key) shouldBeEqualTo value
+            nearJCache.getDeeply(key) shouldBeEqualTo value
+            frontCache.get(key) shouldBeEqualTo value
+        } finally {
+            nearJCache.close()
+        }
     }
 
     @RepeatedTest(TEST_SIZE)

--- a/cache/cache-hazelcast/README.ko.md
+++ b/cache/cache-hazelcast/README.ko.md
@@ -92,6 +92,17 @@ val resilient = HazelcastCaches.resilientNearCache<String>(hazelcastInstance, ne
 
 > Hazelcast client JCache는 리스너를 클러스터에 직렬화해서 전파하므로, `SuspendNearJCache`는 `withoutListener(front, back)`로 생성됩니다.
 
+### Near-Cache Capability
+
+Hazelcast IMap native NearCache는 공통 `NearCacheOperations` /
+`SuspendNearCacheOperations` conformance suite에서 supported로 검증됩니다.
+
+Hazelcast JCache NearCache factory는 listener 없이 생성되는 degraded 모드입니다.
+read-through와 write-through는 지원하지만 peer front-cache propagation은 보장하지 않습니다.
+직접 listener-backed `NearJCache` / `SuspendNearJCache` 생성은 unsupported이며 active test로 고정합니다.
+
+전체 행렬은 [Near-Cache Backend Capability Matrix](../../docs/cache/near-cache-capability-matrix.md)를 참고하세요.
+
 ### NearJCache 사용 예
 
 ```kotlin

--- a/cache/cache-hazelcast/README.md
+++ b/cache/cache-hazelcast/README.md
@@ -53,6 +53,20 @@ dependencies {
 The Korean README includes the full class diagrams and listener-related notes, including why `SuspendNearJCache` uses
 `withoutListener(front, back)` for the Hazelcast client case.
 
+## Near-Cache Capability
+
+Hazelcast IMap native near caches are fully supported by the shared
+`NearCacheOperations` / `SuspendNearCacheOperations` conformance suites.
+
+Hazelcast JCache near-cache factories are intentionally listener-free because
+Hazelcast distributes JCache listener configuration through serialization and
+the current listener captures non-serializable front-cache state. Factory-created
+JCache near caches support read-through and write-through, but peer front-cache
+propagation is not promised. Direct listener-backed construction is unsupported
+and covered by explicit tests.
+
+See the full [Near-Cache Backend Capability Matrix](../../docs/cache/near-cache-capability-matrix.md).
+
 ## Class Structure
 
 The main pieces are:

--- a/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
+++ b/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
@@ -2,31 +2,61 @@ package io.bluetape4k.cache.nearcache.jcache
 
 import io.bluetape4k.cache.HazelcastCaches
 import io.bluetape4k.cache.HazelcastServers
+import io.bluetape4k.cache.HazelcastServers.hazelcastClient
 import io.bluetape4k.cache.jcache.JCache
 import io.bluetape4k.logging.KLogging
-import org.junit.jupiter.api.Disabled
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import com.hazelcast.nio.serialization.HazelcastSerializationException
+import org.junit.jupiter.api.Test
+import org.testcontainers.utility.Base58
 import javax.cache.configuration.MutableConfiguration
 
-@Disabled(
-    "이유: Hazelcast는 MutableCacheEntryListenerConfiguration을 클러스터 전체에 직렬화하여 배포하므로 " +
-        "non-Serializable 리스너(JCacheEntryEventListener)를 등록할 수 없습니다. " +
-        "HazelcastSerializationException: NotSerializableException. " +
-        "Tracked: #490"
-)
-class HazelcastNearJCacheTest: AbstractNearJCacheTest() {
+class HazelcastNearJCacheTest {
 
     companion object: KLogging()
 
-    override val backCache: JCache<String, Any> by lazy {
+    private fun backCache(cacheName: String): JCache<String, Any> {
         val config = MutableConfiguration<String, Any>().apply {
             setTypes(String::class.java, Any::class.java)
         }
-
-        HazelcastCaches.jcache(
-            HazelcastServers.hazelcastClient,
-            "hazelcast-backcache",
-            config
-        )
+        return HazelcastCaches.jcache(HazelcastServers.hazelcastClient, cacheName, config)
     }
 
+    @Test
+    fun `direct listener-backed NearJCache is unsupported for Hazelcast JCache`() {
+        val cacheName = "hazelcast-backcache-" + Base58.randomString(6)
+        val config = NearJCacheConfig<String, Any>(cacheName = "hazelcast-front-" + Base58.randomString(6))
+        val backCache = backCache(cacheName)
+
+        val failure = assertFailsWith<HazelcastSerializationException> {
+            NearJCache(config, backCache)
+        }
+        failure.message shouldContain "MutableCacheEntryListenerConfiguration"
+        failure.stackTraceToString() shouldContain "NotSerializableException"
+        failure.stackTraceToString() shouldContain "com.github.benmanes.caffeine.jcache.CacheProxy"
+    }
+
+    @Test
+    fun `factory creates listener-free NearJCache with read-through and write-through`() {
+        val cacheName = "hazelcast-near-jcache-" + Base58.randomString(6)
+        val cache =
+            HazelcastCaches.nearJCache<String, String>(hazelcastClient) {
+                this.cacheName = cacheName
+            }
+
+        try {
+            cache.put("k", "v")
+            cache.get("k") shouldBeEqualTo "v"
+
+            cache.clear()
+            cache.get("k").shouldBeNull()
+            cache.getDeeply("k") shouldBeEqualTo "v"
+        } finally {
+            cache.clearAllCache()
+            cache.close()
+        }
+    }
 }

--- a/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastSuspendNearJCacheTest.kt
+++ b/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastSuspendNearJCacheTest.kt
@@ -2,30 +2,63 @@ package io.bluetape4k.cache.nearcache.jcache
 
 import io.bluetape4k.cache.HazelcastCaches
 import io.bluetape4k.cache.HazelcastServers
+import io.bluetape4k.cache.HazelcastServers.hazelcastClient
 import io.bluetape4k.cache.jcache.CaffeineSuspendJCache
 import io.bluetape4k.cache.jcache.SuspendJCache
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
-import org.junit.jupiter.api.Disabled
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldBeEqualTo
+import com.hazelcast.nio.serialization.HazelcastSerializationException
+import org.junit.jupiter.api.Test
+import org.testcontainers.utility.Base58
 import java.time.Duration
 
-@Disabled(
-    "이유: Hazelcast는 CacheEntryListenerConfiguration을 클러스터 전체에 직렬화하여 배포하므로 " +
-        "CaffeineSuspendJCache(non-Serializable)를 캡처한 SuspendJCacheEntryEventListener를 등록할 수 없습니다. " +
-        "HazelcastSerializationException: NotSerializableException(CaffeineSuspendJCache). " +
-        "Tracked: #490"
-)
-class HazelcastSuspendNearJCacheTest: AbstractSuspendNearJCacheTest() {
+class HazelcastSuspendNearJCacheTest {
 
     companion object: KLoggingChannel()
 
-    override val backSuspendJCache: SuspendJCache<String, Any> =
-        HazelcastCaches.suspendJCache(HazelcastServers.hazelcastClient, "back-suspend-jcache")
-
-    override fun createFrontSuspendCache(expireAfterAccess: Duration): SuspendJCache<String, Any> {
-        return CaffeineSuspendJCache {
-            expireAfterAccess(expireAfterAccess)
+    private fun frontCache(): SuspendJCache<String, Any> =
+        CaffeineSuspendJCache {
+            expireAfterAccess(Duration.ofMinutes(5))
             maximumSize(100_000)
         }
+
+    @Test
+    fun `direct listener-backed SuspendNearJCache is unsupported for Hazelcast JCache`() = runSuspendIO {
+        val backCache =
+            HazelcastCaches.suspendJCache<String, Any>(
+                HazelcastServers.hazelcastClient,
+                "hazelcast-suspend-back-" + Base58.randomString(6),
+            )
+        val frontCache = frontCache()
+
+        val failure = assertFailsWith<HazelcastSerializationException> {
+            SuspendNearJCache.invoke(frontCache, backCache)
+        }
+        failure.message shouldContain "MutableCacheEntryListenerConfiguration"
+        failure.stackTraceToString() shouldContain "NotSerializableException"
+        failure.stackTraceToString() shouldContain "io.bluetape4k.cache.jcache.CaffeineSuspendJCache"
     }
 
+    @Test
+    fun `factory creates listener-free SuspendNearJCache with read-through and write-through`() = runSuspendIO {
+        val cacheName = "hazelcast-suspend-near-jcache-" + Base58.randomString(6)
+        val cache =
+            HazelcastCaches.suspendNearJCache<String, String>(hazelcastClient) {
+                this.cacheName = cacheName
+            }
+
+        try {
+            cache.put("k", "v")
+            cache.get("k") shouldBeEqualTo "v"
+
+            cache.clear()
+            cache.get("k") shouldBeEqualTo "v"
+        } finally {
+            cache.clearAll()
+            cache.close()
+        }
+    }
 }

--- a/cache/cache-lettuce/README.ko.md
+++ b/cache/cache-lettuce/README.ko.md
@@ -87,6 +87,14 @@ Caffeine(로컬) + Redis(분산) 2단계 캐시로, RESP3 CLIENT TRACKING을 통
 | `CaffeineLocalCache<K, V>`              | Caffeine 기반 LocalCache 구현                          |
 | `TrackingInvalidationListener<V>`       | RESP3 CLIENT TRACKING push 리스너                     |
 
+### Near-Cache Capability
+
+Lettuce native/JCache NearCache는 공통 conformance suite에서 supported로 검증됩니다.
+Native `LettuceNearCache` / `LettuceSuspendNearCache`는 Redis RESP3 `CLIENT TRACKING`과 write-through를 사용합니다.
+JCache 변형은 cache-entry listener로 peer front-cache 전파를 지원합니다.
+
+전체 행렬은 [Near-Cache Backend Capability Matrix](../../docs/cache/near-cache-capability-matrix.md)를 참고하세요.
+
 `LettuceCacheConfig`/`LettuceNearCacheConfig` 사용 시:
 
 - 배치 크기, 큐 크기, 재시도 횟수, local cache 크기는 0보다 커야 합니다.

--- a/cache/cache-lettuce/README.md
+++ b/cache/cache-lettuce/README.md
@@ -32,6 +32,15 @@ dependencies {
 - JCache-based `NearJCache` / `SuspendNearJCache`
 - RESP3 `CLIENT TRACKING` invalidation support
 
+## Near-Cache Capability
+
+Lettuce native and JCache near-cache variants are fully supported by the shared
+conformance suites. Native `LettuceNearCache` and `LettuceSuspendNearCache` use
+Redis RESP3 `CLIENT TRACKING` plus explicit write-through. JCache variants
+register cache-entry listeners and support peer front-cache propagation.
+
+See the full [Near-Cache Backend Capability Matrix](../../docs/cache/near-cache-capability-matrix.md).
+
 ## Factory (`LettuceCaches`)
 
 `LettuceCaches` exposes factory methods for:

--- a/cache/cache-redisson/README.ko.md
+++ b/cache/cache-redisson/README.ko.md
@@ -30,6 +30,14 @@ Kotlin package는 유지됩니다.
 
 이 모듈은 RESP3 hybrid near-cache class를 제공하지 않습니다. Redisson-managed local caching이 필요하면 실제 public API인 `RedissonNearCache` / `RedissonSuspendNearCache`를 사용하세요.
 
+## Near-Cache Capability
+
+Redisson native/JCache NearCache는 공통 conformance suite에서 supported로 검증됩니다.
+Native `RedissonNearCache` / `RedissonSuspendNearCache`는 Redisson `RLocalCachedMap` invalidation을 사용합니다.
+JCache 변형은 cache-entry listener를 등록하며, Redisson bulk event가 발생하지 않는 경로는 entry별 removal로 전파합니다.
+
+전체 행렬은 [Near-Cache Backend Capability Matrix](../../docs/cache/near-cache-capability-matrix.md)를 참고하세요.
+
 ## 의존성
 
 ```kotlin

--- a/cache/cache-redisson/README.md
+++ b/cache/cache-redisson/README.md
@@ -30,6 +30,16 @@ No user import migration is required for the reorganization.
 
 This module does not expose RESP3 hybrid near-cache classes. Use the actual `RedissonNearCache` / `RedissonSuspendNearCache` APIs when you want Redisson-managed local caching.
 
+## Near-Cache Capability
+
+Redisson native and JCache near-cache variants are fully supported by the shared
+conformance suites. Native `RedissonNearCache` and `RedissonSuspendNearCache`
+use Redisson `RLocalCachedMap` invalidation. JCache variants register
+cache-entry listeners; bulk propagation paths remove entries one by one where
+Redisson does not emit bulk events.
+
+See the full [Near-Cache Backend Capability Matrix](../../docs/cache/near-cache-capability-matrix.md).
+
 ## Dependency
 
 ```kotlin

--- a/docs/cache/near-cache-capability-matrix.md
+++ b/docs/cache/near-cache-capability-matrix.md
@@ -1,0 +1,53 @@
+# Near-Cache Backend Capability Matrix
+
+This matrix defines the supported near-cache behavior for cache modules. It is a
+runtime support boundary, not just a test inventory.
+
+Capability states:
+
+- `Supported`: implemented and covered by the shared conformance fixtures.
+- `Factory degraded`: factory methods intentionally avoid listener
+  registration; read-through and write-through work, but peer front-cache
+  propagation is not promised.
+- `Local only`: usable as a local/front cache or local JCache provider; it does
+  not provide distributed back-cache invalidation by itself.
+- `Unsupported`: direct construction is expected to fail or is not part of the
+  public contract.
+
+## Native NearCache APIs
+
+Native APIs implement `NearCacheOperations<V>` or
+`SuspendNearCacheOperations<V>`.
+
+| Backend | Sync near-cache | Suspend near-cache | Listener or invalidation source | put/replace/remove propagation | removeAll semantics | Back cache scope | Conformance |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Lettuce | Supported | Supported | Redis RESP3 `CLIENT TRACKING` plus explicit write-through | Supported | Removes selected keys from front and Redis back cache | Distributed Redis | `AbstractNearCacheOperationsTest`, `AbstractSuspendNearCacheOperationsTest` |
+| Hazelcast IMap | Supported | Supported | Hazelcast `IMap` entry listener | Supported | Removes selected keys from front and IMap back cache | Distributed Hazelcast map | `AbstractNearCacheOperationsTest`, `AbstractSuspendNearCacheOperationsTest` |
+| Redisson `RLocalCachedMap` | Supported | Supported | Redisson local cached map invalidation | Supported | Removes selected keys from local and Redis-backed map | Distributed Redis via Redisson | `AbstractNearCacheOperationsTest`, `AbstractSuspendNearCacheOperationsTest` |
+| Caffeine | Local only | Local only | Local cache events only | Local only | Local only | Local JVM | Covered as front/local cache, not native distributed near-cache |
+| Cache2k | Local only | Not provided as native suspend near-cache | Local cache events only | Local only | Local only | Local JVM | Covered as local/JCache provider, not native distributed near-cache |
+
+## JCache NearCache APIs
+
+JCache APIs implement `NearJCache<K,V>` or `SuspendNearJCache<K,V>`.
+
+| Back provider | Sync `NearJCache` | Suspend `SuspendNearJCache` | Listener registration | Peer front propagation | removeAll semantics | Back cache scope | Conformance |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Lettuce JCache | Supported | Supported | Supported | Supported | Supported through per-entry removal where needed | Distributed Redis | `AbstractNearJCacheTest`, `AbstractSuspendNearJCacheTest` |
+| Redisson JCache | Supported | Supported | Supported | Supported | Supported through per-entry removal where needed | Distributed Redis via Redisson | `AbstractNearJCacheTest`, `AbstractSuspendNearJCacheTest` |
+| Hazelcast JCache direct listener construction | Unsupported | Unsupported | Unsupported: listener configuration must be serializable for cluster distribution | Unsupported | Unsupported in listener-backed direct construction | Distributed Hazelcast JCache | Explicit unsupported tests in `cache-hazelcast` |
+| Hazelcast factory methods | Factory degraded | Factory degraded | Not registered intentionally | Not promised | `clearAllCache` / `clearAll` clear front and back for the local wrapper; listener propagation is not promised | Distributed Hazelcast JCache | Explicit factory behavior tests in `cache-hazelcast` |
+| Cache2k JCache | Supported except whole-cache `removeAll()` propagation | Not provided | Local provider listener | Same-JVM only | Whole-cache `removeAll()` propagation is explicitly unsupported by conformance test | Local JVM | `AbstractNearJCacheTest` with explicit unsupported override |
+| Caffeine JCache/front | Local only | Supported as front `SuspendJCache` | Local provider listener | Same-JVM only | Local/front only unless paired with a distributed back cache | Local JVM | Used as front cache in suspend JCache conformance |
+| Ehcache JCache | Supported | Not provided in this suite | Local provider listener | Same-JVM only | Supported by the sync JCache fixture | Local JVM | `AbstractNearJCacheTest` |
+
+## Test Ownership
+
+- `cache-core/src/testFixtures/.../AbstractNearCacheOperationsTest.kt` and
+  `AbstractSuspendNearCacheOperationsTest.kt` define native near-cache
+  conformance.
+- `cache-core/src/testFixtures/.../jcache/AbstractNearJCacheTest.kt` and
+  `AbstractSuspendNearJCacheTest.kt` define JCache near-cache conformance.
+- Backend modules inherit these fixtures for supported combinations.
+- Unsupported combinations must use active tests that assert the unsupported or
+  degraded behavior; disabled test classes are not an acceptable support marker.

--- a/docs/lessons/2026-05-20-issue-493-near-cache-capability-matrix.md
+++ b/docs/lessons/2026-05-20-issue-493-near-cache-capability-matrix.md
@@ -1,0 +1,51 @@
+# Issue #493 Near-Cache Capability Matrix
+
+## Context
+
+Issue #493 required a documented backend capability matrix and inherited
+conformance tests for near-cache behavior across local and distributed cache
+providers.
+
+## Decision
+
+Keep the support boundary documentation-first and fixture-based:
+
+- Native Lettuce, Hazelcast IMap, and Redisson near caches keep sharing the
+  `NearCacheOperations` / `SuspendNearCacheOperations` fixtures.
+- JCache-backed Lettuce and Redisson near caches keep sharing the JCache
+  fixtures.
+- Hazelcast JCache listener-backed construction is unsupported because listener
+  configuration must be serializable for cluster distribution.
+- Hazelcast factories remain listener-free degraded support for read-through and
+  write-through behavior.
+- Cache2k whole-cache JCache `removeAll()` propagation is an explicit
+  unsupported conformance case, not a silent skip.
+
+## Outcome
+
+Added `docs/cache/near-cache-capability-matrix.md`, linked it from cache module
+README pairs, strengthened shared conformance tests, and replaced disabled
+Hazelcast JCache tests with active unsupported/degraded behavior tests.
+
+## Verification
+
+Ran the targeted downstream conformance suite:
+
+```text
+./gradlew :bluetape4k-cache-core:test ... :bluetape4k-cache-hazelcast:test ... :bluetape4k-cache-lettuce:test ... :bluetape4k-cache-redisson:test ... --console=plain --no-configuration-cache
+BUILD SUCCESSFUL
+cache-core: 134 tests
+cache-hazelcast: 47 tests
+cache-lettuce: 184 tests
+cache-redisson: 244 tests
+```
+
+Also verified `@Disabled` is absent from the near-cache test scope and
+`git diff --check` passes.
+
+## Future Guidance
+
+For near-cache capability changes, update the matrix first, then require each
+supported backend to inherit the same fixture. Unsupported combinations should
+be active tests or explicit matrix exclusions, never disabled abstract tests.
+

--- a/docs/superpowers/plans/2026-05-20-issue-493-near-cache-capability-matrix-plan.md
+++ b/docs/superpowers/plans/2026-05-20-issue-493-near-cache-capability-matrix-plan.md
@@ -1,0 +1,50 @@
+# Issue #493 Near-Cache Capability Matrix Plan
+
+## Step 1 - Matrix Documentation
+
+- Add `docs/cache/near-cache-capability-matrix.md`.
+- Cover native NearCache, JCache NearCache, sync near-cache, suspend
+  near-cache, event listener registration, propagation, `removeAll`, and
+  distributed/local back-cache behavior.
+- Mark Caffeine and Cache2k local-only/provider-only combinations explicitly.
+- Link the matrix from `cache-core`, `cache-lettuce`, `cache-hazelcast`, and
+  `cache-redisson` README pairs.
+
+## Step 2 - Conformance Fixture Strengthening
+
+- Add operation-level tests that verify `put`, `replace`, `remove`, and
+  `removeAll` effects survive `clearLocal()` and therefore reached the back
+  tier.
+- Keep the tests in `cache-core` test fixtures so supported backends inherit the
+  same suite.
+
+## Step 3 - Unsupported Behavior Tests
+
+- Replace disabled Hazelcast JCache tests with active tests.
+- Assert direct listener-backed `NearJCache.invoke` /
+  `SuspendNearJCache.invoke` is unsupported for Hazelcast JCache.
+- Assert Hazelcast factory methods still create listener-free near caches for
+  read-through/write-through use.
+- Replace the Cache2k silent `removeAll()` skip with an explicit unsupported
+  assertion or a passing conformance implementation if behavior has changed.
+- Keep unsupported combinations active in tests or documented as local-only
+  exclusions in the matrix.
+
+## Step 4 - Verification
+
+- Run IDE reformat/imports and diagnostics for touched Kotlin files.
+- Run targeted Gradle tests for:
+  - `:bluetape4k-cache-core`
+  - `:bluetape4k-cache-hazelcast`
+  - `:bluetape4k-cache-lettuce` near-cache conformance classes that inherit the
+    changed fixtures
+  - `:bluetape4k-cache-redisson` near-cache conformance classes that inherit the
+    changed fixtures
+- Run `git diff --check`.
+
+## Step 5 - Review, Lesson, PR
+
+- Current-session review only; no Claude/Codex CLI review.
+- Resolve P0/P1 findings before PR.
+- Add a concise lesson under `docs/lessons/`.
+- Commit with Lore trailers, push, create PR assigned to `debop`.

--- a/docs/superpowers/specs/2026-05-20-issue-493-near-cache-capability-matrix-design.md
+++ b/docs/superpowers/specs/2026-05-20-issue-493-near-cache-capability-matrix-design.md
@@ -1,0 +1,78 @@
+# Issue #493 Near-Cache Capability Matrix Design
+
+## Context
+
+Issue #493 asks for a documented near-cache backend capability matrix and a
+shared conformance suite for Cache2k, Caffeine, Hazelcast, Lettuce, and Redisson
+variants.
+
+Current repository evidence:
+
+- `cache-core` already owns shared test fixtures for `NearCacheOperations`,
+  `SuspendNearCacheOperations`, `NearJCache`, and `SuspendNearJCache`.
+- Lettuce, Hazelcast, and Redisson native near-cache implementations already
+  inherit the operation-level fixtures.
+- Lettuce, Redisson, Cache2k, and Ehcache JCache variants inherit the JCache
+  fixtures.
+- Hazelcast JCache listener registration is intentionally unsupported because
+  Hazelcast distributes JCache listener configuration through serialization and
+  the current listener captures non-serializable front-cache state.
+
+## Scope
+
+This change documents and tests the existing support boundary instead of
+introducing a new backend abstraction.
+
+In scope:
+
+- Add a docs-level capability matrix for native near-cache and JCache near-cache
+  variants, with explicit sync and suspend axes.
+- Update cache module README pairs with the matrix or a link to the matrix.
+- Strengthen shared operation conformance tests for write propagation after
+  local eviction.
+- Replace disabled Hazelcast JCache tests with explicit unsupported/degraded
+  behavior tests.
+- Remove silent conformance skips where a backend has an unsupported operation.
+- Mark Caffeine and Cache2k local-only/provider-only combinations explicitly in
+  the matrix instead of implying distributed near-cache support.
+
+Out of scope:
+
+- Changing Hazelcast JCache listener serialization.
+- Adding distributed invalidation to local-only Caffeine or Cache2k providers.
+- Changing public cache API names.
+
+## Capability Model
+
+Capability states:
+
+- `Supported`: behavior is implemented and covered by shared conformance tests.
+- `Factory degraded`: factory intentionally creates a near cache without listener
+  registration; write-through and read-through work, but peer front-cache
+  propagation is not promised.
+- `Local only`: backend can be used as a local/front or local JCache provider,
+  but does not provide distributed back-cache invalidation by itself.
+- `Unsupported`: direct listener-backed construction is expected to fail or is
+  not part of the public contract.
+
+## Acceptance Mapping
+
+- Public matrix: `docs/cache/near-cache-capability-matrix.md` plus README links.
+- Same conformance suite: direct supported backends continue to inherit
+  `AbstractNearCacheOperationsTest` and `AbstractSuspendNearCacheOperationsTest`;
+  JCache variants continue to inherit `AbstractNearJCacheTest` and
+  `AbstractSuspendNearJCacheTest` where supported.
+- Unsupported combinations: Hazelcast JCache direct listener registration is
+  tested as unsupported; Hazelcast factories are tested as listener-free
+  degraded support; Cache2k JCache whole-cache `removeAll()` propagation is
+  tested as explicitly unsupported; Caffeine and Cache2k local-only combinations
+  are documented as exclusions from distributed near-cache behavior.
+- Disabled tests: disabled Hazelcast JCache test classes are replaced by active
+  explicit behavior tests.
+
+## Risks
+
+- Container-backed cache tests can be slow and must run serially.
+- Existing Cache2k `removeAll()` behavior is not equivalent to distributed
+  backends; the conformance override must assert this explicitly instead of
+  hiding it.


### PR DESCRIPTION
## Summary

Closes #493

- PR 제목: feat: add near-cache capability matrix

- Add `docs/cache/near-cache-capability-matrix.md` covering native and JCache near-cache support states.
- Link the matrix from cache-core, Hazelcast, Lettuce, and Redisson README files in English and Korean.
- Extend shared near-cache conformance fixtures with post-front-eviction read-through checks.
- Replace disabled Hazelcast JCache suites and Cache2k silent skip with active supported/unsupported contract tests.

### 원문 선행 내용

Fixes #493

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Acceptance

- Native sync/suspend near-cache behavior is covered for Lettuce, Hazelcast IMap, and Redisson.
- JCache sync/suspend behavior is covered for Lettuce and Redisson through the shared fixtures.
- Hazelcast JCache direct listener construction is explicitly unsupported; factory-created listener-free wrappers are tested as degraded support.
- Cache2k whole-cache `removeAll()` propagation is explicitly unsupported by test instead of silently skipped.
- Caffeine and Cache2k local-only/provider-only combinations are documented in the matrix.

### 기존 섹션: Notes

- Full repository build was not run.

## Validation

- `./gradlew :bluetape4k-cache-core:test --tests ... :bluetape4k-cache-hazelcast:test --tests ... :bluetape4k-cache-lettuce:test --tests ... :bluetape4k-cache-redisson:test --tests ... --console=plain --no-configuration-cache`
- `./gradlew :bluetape4k-cache-core:test --tests io.bluetape4k.cache.nearcache.jcache.Cache2KNearJJCacheTest.removeAll... :bluetape4k-cache-hazelcast:test --tests io.bluetape4k.cache.nearcache.jcache.HazelcastNearJCacheTest --tests io.bluetape4k.cache.nearcache.jcache.HazelcastSuspendNearJCacheTest --console=plain --no-configuration-cache`
- IntelliJ diagnostics on touched Hazelcast Kotlin tests: 0 errors.
- `git diff --check`
- `rg @Disabled|Disabled\\(` near-cache test scope: no matches.
- `rg assertFailsWith<Exception>` touched near-cache test scope: no matches.

## Review Notes

- Step 6-R was performed in the current Codex session/native subagent, with no Claude Code CLI call.
- P0/P1 findings: 0.
- Medium finding about broad unsupported exception assertions was addressed by asserting concrete Hazelcast serialization and Cache2k timeout contracts.

## Metadata

- Issue: #493, milestone `1.9.0`, assignee debop
- PR: #557, head `953258b7b2f3e026c862c6f9792d3cf86b62ac8c`, milestone `1.9.0`, assignee debop
- Base: `develop`, head branch `feat/issue-493-near-cache-matrix`
- Labels: `enhancement`, `test`
- State: `MERGED`, merge commit `e07eef06f433575e3bcc434d0c701237af82fb85`
- CI: - Hazelcast JCache direct listener construction is explicitly unsupported; factory-created listener-free wrappers are tested as degraded support. / - Cache2k whole-cache `removeAll()` propagation is explicitly unsupported by test instead of silently skipped. / - `./gradlew :bluetape4k-cache-core:test --tests ... :bluetape4k-cache-hazelcast:test --tests ... :bluetape4k-cache-lettuce:test --tests ... :bluetape4k-cache-redisson:test --tests ... --console=plain --no-configuration-cache`## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #557 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e07eef06f433575e3bcc434d0c701237af82fb85`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
