### PR TITLE
test: enforce coroutine cancellation contracts

### DIFF
--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/ResumableTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/ResumableTest.kt
@@ -1,8 +1,8 @@
 package io.bluetape4k.coroutines.flow.extensions
 
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.junit5.coroutines.assertCancellationClearsWaiter
 import io.bluetape4k.logging.coroutines.KLoggingChannel
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
@@ -38,27 +38,10 @@ class ResumableTest {
     fun `cancelled await clears slot so subsequent await succeeds`() = runTest {
         val resumable = Resumable()
 
-        // Cancel a waiting coroutine before resume() is called.
-        val job = launch {
-            resumable.await()
-        }
-
-        yield() // let the launched coroutine install its continuation
-        job.cancel()
-        job.join() // wait until cancellation is processed
-
-        // The slot must be cleared. A new await() + resume() must not throw
-        // "Only one thread can await a Resumable".
-        var reached = false
-        launch {
-            resumable.await()
-            reached = true
-        }
-        yield()
-        resumable.resume()
-        yield()
-
-        reached shouldBeEqualTo true
+        assertCancellationClearsWaiter(
+            awaiter = { resumable.await() },
+            releaser = { resumable.resume() },
+        )
     }
 
     @Test

--- a/docs/lessons/2026-05-20-issue-494-cancellation-contracts.md
+++ b/docs/lessons/2026-05-20-issue-494-cancellation-contracts.md
@@ -1,0 +1,42 @@
+# Issue 494 Cancellation Contracts
+
+Date: 2026-05-20
+Issue: #494
+
+## Context
+
+Coroutine wrappers in multiple modules needed a reusable way to prove that
+`CancellationException` is rethrown, waiter slots are cleared after cancellation,
+and underlying resources such as Retrofit calls are cancelled.
+
+## Decision
+
+Add cancellation contract helpers to `bluetape4k-junit5` instead of copying
+launch/cancel scaffolding into each module. Keep the helper signatures on core
+coroutine and `Duration` types so they remain usable from normal coroutine tests.
+
+## Outcome
+
+- Added `resultOfNonCancellation` and `runCatchingNonCancellation` for
+  `Result`-style wrappers that must preserve structured cancellation.
+- Added helper assertions for propagation, cancelled waiter cleanup, and
+  resource cancellation.
+- Replaced local cancellation scaffolding in `bluetape4k-coroutines` and
+  `bluetape4k-micrometer`.
+- Added a real MockWebServer delayed-response cancellation test for
+  `bluetape4k-retrofit2`.
+- Documented usage and checklist in the English and Korean JUnit5 READMEs.
+
+## Verification
+
+- `./gradlew :bluetape4k-junit5:compileKotlin :bluetape4k-junit5:test --console=plain --no-configuration-cache`
+- `./gradlew :bluetape4k-coroutines:test --tests '*ResumableTest' --console=plain --no-configuration-cache`
+- `./gradlew :bluetape4k-micrometer:test --tests '*ObservationCoroutinesSupportTest' --console=plain --no-configuration-cache`
+- `./gradlew :bluetape4k-retrofit2:test --tests '*SuspendRetrofitCallSupportTest' --console=plain --no-configuration-cache`
+- `git diff --check`
+
+## Future Guidance
+
+When adding suspend wrappers that return `Result`, do not use plain
+`runCatching` around suspend calls. Use `runCatchingNonCancellation`, or rethrow
+`CancellationException` explicitly before converting non-cancellation failures.

--- a/docs/superpowers/plans/2026-05-20-issue-494-cancellation-contracts-plan.md
+++ b/docs/superpowers/plans/2026-05-20-issue-494-cancellation-contracts-plan.md
@@ -1,0 +1,186 @@
+# Issue 494 Cancellation Contracts Plan
+
+Date: 2026-05-20
+Issue: #494
+Spec: `docs/superpowers/specs/2026-05-20-issue-494-cancellation-contracts-design.md`
+
+## Execution Plan
+
+### 1. Add Shared Helpers
+
+File:
+
+- `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/coroutines/CancellationContracts.kt`
+
+Tasks:
+
+- Add `assertCancellationPropagates`.
+- Add `assertCancellationClearsWaiter`.
+- Add `assertResourceCancelledOnCoroutineCancellation`.
+- Add `resultOfNonCancellation`.
+- Add `runCatchingNonCancellation`.
+- Write English KDoc with contracts and examples.
+
+### 2. Add Helper Self-Tests
+
+File:
+
+- `testing/junit5/src/test/kotlin/io/bluetape4k/junit5/coroutines/CancellationContractsTest.kt`
+
+Tasks:
+
+- Prove cancellation helper catches swallowed cancellation.
+- Prove non-cancellation result helpers return `Result.failure`.
+- Prove cancellation result helpers rethrow `CancellationException`.
+- Prove resource-cancel helper checks the supplied cancellation predicate.
+
+### 3. Adopt in `:bluetape4k-coroutines`
+
+File:
+
+- `bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/ResumableTest.kt`
+
+Tasks:
+
+- Replace local cancelled-waiter scaffolding with
+  `assertCancellationClearsWaiter`.
+- Keep the READY fast-path regression test because it verifies a separate state
+  transition.
+
+### 4. Adopt in `:bluetape4k-micrometer`
+
+File:
+
+- `infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/observation/coroutines/ObservationCoroutinesSupportTest.kt`
+
+Tasks:
+
+- Replace repeated launch/cancel/result scaffolding with
+  `assertCancellationPropagates`.
+- Keep observation registry cleanup assertions where they exist.
+
+### 5. Adopt in `:bluetape4k-retrofit2`
+
+File:
+
+- `io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/SuspendRetrofitCallSupportTest.kt`
+
+Tasks:
+
+- Add a local MockWebServer delayed-response test that starts a real Retrofit
+  call, cancels the coroutine, and verifies `Call.isCanceled`.
+- Use `assertResourceCancelledOnCoroutineCancellation` with a `beforeCancel`
+  hook that waits until the server receives the request.
+
+### 6. Documentation
+
+Files:
+
+- `testing/junit5/README.md`
+- `testing/junit5/README.ko.md`
+
+Tasks:
+
+- Add the cancellation helpers to key features.
+- Add usage examples.
+- Add checklist:
+  - rethrow `CancellationException`,
+  - clear waiters/continuations,
+  - cancel underlying futures/HTTP calls,
+  - never wrap suspend code in plain `runCatching` unless cancellation is
+    rethrown first.
+
+### 7. Validation
+
+Run in order:
+
+```bash
+./gradlew :bluetape4k-junit5:compileKotlin :bluetape4k-junit5:test --console=plain --no-configuration-cache
+./gradlew :bluetape4k-coroutines:test --tests '*ResumableTest' --console=plain --no-configuration-cache
+./gradlew :bluetape4k-micrometer:test --tests '*ObservationCoroutinesSupportTest' --console=plain --no-configuration-cache
+./gradlew :bluetape4k-retrofit2:test --tests '*SuspendRetrofitCallSupportTest' --console=plain --no-configuration-cache
+git diff --check
+```
+
+Also run IDE diagnostics on touched Kotlin files when available.
+
+### 8. Review and PR
+
+- Run current-session Step 6-R review on the changed diff.
+- Resolve P0/P1 findings.
+- Add `docs/lessons/2026-05-20-issue-494-cancellation-contracts.md`.
+- Commit with Lore protocol.
+- Push and open PR linked to #494.
+- Watch GitHub checks.
+
+## Rollback Plan
+
+If the shared helper API proves unstable during implementation:
+
+- Keep `runCatchingNonCancellation` and the narrow propagation helper.
+- Defer waiter/resource helper broadening to a follow-up issue.
+- Preserve representative tests locally without weakening existing runtime
+  coverage.
+
+## Step 3-R Current-Session Review
+
+Claude Code CLI advisor was intentionally skipped because the user explicitly
+disabled Claude usage for this session. Codex current-session review covered the
+implementer, test engineer, architect, and delivery perspectives.
+
+### Findings
+
+| Priority | Perspective | Finding | Decision |
+|---|---|---|---|
+| P2 | Test engineer | Helper self-tests must include a negative case so `assertCancellationPropagates` cannot pass when cancellation is swallowed. | Accepted: Step 2 explicitly includes swallowed-cancellation proof. |
+| P2 | Architect | New helper APIs expose coroutine-test contracts from `:bluetape4k-junit5`; avoid tying signatures to `kotlinx.coroutines.test` types. | Accepted: helper APIs use `CoroutineScope`, `Duration`, and core coroutine types only. |
+| P2 | Delivery | README docs should live in `testing/junit5` rather than each adopted module to avoid repeated checklist drift. | Accepted: documentation task is centralized in the helper module README pair. |
+| P3 | Ops/SRE | MockWebServer request wait must be bounded so cancellation tests cannot hang. | Accepted: Retrofit task uses a bounded `takeRequest` hook. |
+
+### Convergence
+
+- P0: 0
+- P1: 0
+- Open user questions: none
+
+## Step 6-R Current-Session Review
+
+Claude Code CLI advisor was intentionally skipped because the user explicitly
+disabled Claude usage for this session. A native `code-reviewer` subagent was
+started for an additional cross-check, but it did not return within the bounded
+review window and was shut down. The final gate is based on current-session
+six-tier review plus targeted validation.
+
+### Findings
+
+| Tier | Scope | P0 | P1 | P2/P3 | Result |
+|---|---|---:|---:|---|---|
+| 1 Security | Test helpers, tests, README docs | 0 | 0 | None | No secrets, auth, input, or deserialization surface introduced. |
+| 2 Ops/SRE | Cancellation cleanup and bounded waits | 0 | 0 | None | Helper waits are timeout-bounded; Retrofit request wait is bounded. |
+| 3 Structural | `bluetape4k-junit5` public helper API | 0 | 0 | None | API stays in testing module and depends only on core coroutine/Duration types. |
+| 4 Kotlin/Quality | Changed Kotlin files | 0 | 0 | P2 fixed | Converted helper failure path so cancellation-to-non-cancellation conversion fails as an assertion instead of escaping as an arbitrary exception. |
+| 5 Tests/Types | Self-tests and representative module adoption | 0 | 0 | None | Added positive and negative propagation tests, waiter cleanup, and resource cancellation coverage. |
+| 6 Perf/Stability | Final diff | 0 | 0 | None | No unbounded polling or sleeps; hardcoded waits are bounded test-only probes. |
+
+### Validation Evidence
+
+```bash
+./gradlew :bluetape4k-junit5:compileKotlin :bluetape4k-junit5:test --console=plain --no-configuration-cache
+# SUCCESS: 269 tests
+
+./gradlew :bluetape4k-coroutines:test --tests '*ResumableTest' \
+  :bluetape4k-micrometer:test --tests '*ObservationCoroutinesSupportTest' \
+  :bluetape4k-retrofit2:test --tests '*SuspendRetrofitCallSupportTest' \
+  --console=plain --no-configuration-cache
+# SUCCESS: 3 + 9 + 6 tests
+
+git diff --check
+# clean
+```
+
+### Convergence
+
+- P0: 0
+- P1: 0
+- Remaining risk: Gradle emits existing deprecation warnings in unrelated
+  dependency/test modules; no warning was introduced in the new helper contract.

--- a/docs/superpowers/specs/2026-05-20-issue-494-cancellation-contracts-design.md
+++ b/docs/superpowers/specs/2026-05-20-issue-494-cancellation-contracts-design.md
@@ -1,0 +1,164 @@
+# Issue 494 Cancellation Contracts Design
+
+Date: 2026-05-20
+Issue: #494
+Repository: bluetape4k-projects
+
+## Context
+
+Several coroutine-facing modules recently needed cancellation fixes:
+
+- `bluetape4k-coroutines` primitives must clear stale waiters when a suspended
+  caller is cancelled.
+- `infra/micrometer` suspend `Result` wrappers must not turn
+  `CancellationException` into `Result.failure`.
+- `io/retrofit2` suspend adapters must cancel the underlying HTTP call when the
+  coroutine is cancelled.
+
+The current tests cover these behaviours locally, but each module repeats its
+own cancellation scaffolding. Issue #494 asks for reusable contract helpers and
+representative adoption across these categories.
+
+## External API Evidence
+
+Kotlin official docs checked on 2026-05-20:
+
+- `suspendCancellableCoroutine` throws `CancellationException` when the current
+  job is cancelled while suspended and provides a prompt cancellation guarantee.
+- `invokeOnCancellation` handlers can run at any time, can run concurrently with
+  callback code, must be fast/non-blocking/thread-safe, and must not throw.
+- `CancellationException` is the normal cancellation signal for cancellable
+  suspending functions.
+
+Design consequence: helper APIs should verify cancellation is rethrown, resource
+cleanup callbacks run, and test code does not mask cancellation behind
+`runCatching`.
+
+## Goals
+
+1. Add reusable JUnit/coroutine contract helpers in `:bluetape4k-junit5`.
+2. Provide a `Result` helper that catches non-cancellation failures only.
+3. Apply helpers to at least three representative modules:
+   - `:bluetape4k-coroutines`
+   - `:infra:micrometer`
+   - `:io:retrofit2`
+4. Document the cancellation checklist and the `runCatching` rule in
+   `testing/junit5` README files.
+5. Keep tests local and CI-friendly; no external services or Testcontainers.
+
+## Non-Goals
+
+- Do not introduce a new production module.
+- Do not rewrite every existing cancellation test in this PR.
+- Do not change runtime behaviour unless a representative test exposes a bug.
+- Do not add new external dependencies.
+
+## Design
+
+### Helper Location
+
+Add `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/coroutines/CancellationContracts.kt`.
+
+Rationale:
+
+- `:bluetape4k-junit5` is already the shared test utility artifact.
+- The representative modules already depend on it for tests.
+- Keeping helpers in test infrastructure avoids pulling test-only contracts into
+  runtime modules.
+
+### Proposed Helper APIs
+
+```kotlin
+suspend fun <T> assertCancellationPropagates(
+    timeout: Duration = 5.seconds,
+    operation: suspend CoroutineScope.() -> T,
+)
+
+suspend fun assertCancellationClearsWaiter(
+    timeout: Duration = 5.seconds,
+    awaiter: suspend () -> Unit,
+    releaser: () -> Unit,
+)
+
+suspend fun <T> assertResourceCancelledOnCoroutineCancellation(
+    timeout: Duration = 5.seconds,
+    beforeCancel: suspend () -> Unit = { yield() },
+    resourceCancelled: () -> Boolean,
+    operation: suspend CoroutineScope.() -> T,
+)
+
+inline fun <T> resultOfNonCancellation(block: () -> T): Result<T>
+suspend inline fun <T> runCatchingNonCancellation(
+    crossinline block: suspend () -> T,
+): Result<T>
+```
+
+The names are intentionally explicit. These are test contracts, not generic
+assertion primitives.
+
+### Representative Adoption
+
+- `ResumableTest`: replace local cancelled-waiter scaffolding with
+  `assertCancellationClearsWaiter`.
+- `ObservationCoroutinesSupportTest`: replace repeated cancellation propagation
+  scaffolding with `assertCancellationPropagates`.
+- `SuspendRetrofitCallSupportTest`: add/replace a suspend HTTP cancellation test
+  using `assertResourceCancelledOnCoroutineCancellation` and `MockWebServer`.
+
+### Documentation
+
+Update `testing/junit5/README.md` and `README.ko.md`:
+
+- Add cancellation contract helpers to the feature list.
+- Add a short coroutine cancellation checklist.
+- State that `runCatching` is not acceptable around suspend APIs unless
+  `CancellationException` is rethrown first; use
+  `runCatchingNonCancellation`/`resultOfNonCancellation` when returning
+  `Result`.
+
+## Compatibility
+
+- New public test utility APIs require English KDoc.
+- Existing tests may keep their Korean names/comments.
+- Helper APIs rely on existing dependencies already available from
+  `:bluetape4k-junit5`: kotlinx.coroutines, bluetape4k assertions, and Kotlin
+  test/JUnit infrastructure.
+
+## Acceptance Criteria Mapping
+
+- Shared test helper or fixture exists:
+  `CancellationContracts.kt`.
+- At least three representative modules use it:
+  coroutines, micrometer, retrofit2.
+- Documentation states when `runCatching` is not acceptable:
+  `testing/junit5` README pair.
+- CI can run tests without external services:
+  representative tests use local coroutine test scheduler and MockWebServer.
+
+## Risks
+
+- Cancellation tests can be flaky if they race on startup. Mitigation: helpers
+  use `withTimeout`, `yield`, and caller-provided `beforeCancel` hooks where the
+  resource must be known to have started.
+- Public helper names may become hard to rename after release. Mitigation:
+  choose explicit contract names now and keep scope limited to test utilities.
+
+## Step 2-R Current-Session Review
+
+Claude Code CLI advisor was intentionally skipped because the user explicitly
+disabled Claude usage for this session. Codex current-session review covered the
+developer, security, Ops/SRE, and caller perspectives.
+
+### Findings
+
+| Priority | Perspective | Finding | Decision |
+|---|---|---|---|
+| P2 | Developer | `assertResourceCancelledOnCoroutineCancellation` can race unless the caller can prove the wrapped request/future started. | Accepted in design: helper includes a caller-provided `beforeCancel` hook and the Retrofit adoption waits for MockWebServer to receive the request. |
+| P2 | Caller | Plain `runCatching` misuse is easy to reintroduce unless docs mention the rule near helper examples. | Accepted in design: README checklist explicitly covers this and points to non-cancellation helpers. |
+| P3 | Ops/SRE | Helper assertion failures should be timeout-bounded to avoid hanging CI jobs. | Accepted in design: helpers use bounded waits. |
+
+### Convergence
+
+- P0: 0
+- P1: 0
+- Open user questions: none

--- a/infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/observation/coroutines/ObservationCoroutinesSupportTest.kt
+++ b/infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/observation/coroutines/ObservationCoroutinesSupportTest.kt
@@ -1,6 +1,10 @@
 package io.bluetape4k.micrometer.observation.coroutines
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.codec.Base58
+import io.bluetape4k.junit5.coroutines.assertCancellationPropagates
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
@@ -9,15 +13,10 @@ import io.bluetape4k.micrometer.observation.AbstractObservationTest
 import io.bluetape4k.micrometer.observation.start
 import io.micrometer.observation.Observation
 import io.micrometer.observation.tck.ObservationRegistryAssert
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 import kotlin.time.Duration.Companion.milliseconds
 
 class ObservationCoroutinesSupportTest: AbstractObservationTest() {
@@ -180,51 +179,31 @@ class ObservationCoroutinesSupportTest: AbstractObservationTest() {
         val name = Base58.randomString(8)
         val observation = observationRegistry.start(name)
 
-        var cancelled = false
-        var result: Result<String>? = null
-        val job = launch {
-            try {
-                result = observation.tryObserveSuspending<String> { _ ->
-                    delay(100.milliseconds)  // arbitrary under runTest virtual time
-                    "never"
-                }
-            } catch (e: CancellationException) {
-                cancelled = true
-                throw e
+        assertCancellationPropagates {
+            observation.tryObserveSuspending<String> { _ ->
+                delay(100.milliseconds)  // arbitrary under runTest virtual time
+                "never"
             }
         }
 
         yield()
-        job.cancel()
-        job.join()
-
-        cancelled shouldBeEqualTo true
-        result shouldBeEqualTo null  // wrapper must not return Result.failure; it must rethrow
+        ObservationRegistryAssert.assertThat(observationRegistry)
+            .doesNotHaveAnyRemainingCurrentObservation()
     }
 
     @Test
     fun `tryWithObservationSuspending - cancellation propagates to parent job`() = runTest {
         val name = "observer.cancel." + Base58.randomString(8)
 
-        var cancelled = false
-        var result: Result<String>? = null
-        val job = launch {
-            try {
-                result = tryWithObservationSuspending<String>(name, observationRegistry) {
-                    delay(100.milliseconds)  // arbitrary under runTest virtual time
-                    "never"
-                }
-            } catch (e: CancellationException) {
-                cancelled = true
-                throw e
+        assertCancellationPropagates {
+            tryWithObservationSuspending<String>(name, observationRegistry) {
+                delay(100.milliseconds)  // arbitrary under runTest virtual time
+                "never"
             }
         }
 
         yield()
-        job.cancel()
-        job.join()
-
-        cancelled shouldBeEqualTo true
-        result shouldBeEqualTo null  // wrapper must not return Result.failure; it must rethrow
+        ObservationRegistryAssert.assertThat(observationRegistry)
+            .doesNotHaveAnyRemainingCurrentObservation()
     }
 }

--- a/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/SuspendRetrofitCallSupportTest.kt
+++ b/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/SuspendRetrofitCallSupportTest.kt
@@ -1,20 +1,23 @@
 package io.bluetape4k.retrofit2
 
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.http.okhttp3.mock.baseUrl
+import io.bluetape4k.junit5.coroutines.assertResourceCancelledOnCoroutineCancellation
+import io.bluetape4k.junit5.coroutines.runCatchingNonCancellation
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.retrofit2.services.TestService
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeTrue
-import io.bluetape4k.assertions.shouldNotBeNull
+import retrofit2.Call
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 import retrofit2.converter.scalars.ScalarsConverterFactory
+import java.util.concurrent.TimeUnit
 
 /**
  * [suspendExecute] 확장 함수 단위 테스트입니다.
@@ -61,7 +64,7 @@ class SuspendRetrofitCallSupportTest {
     fun `suspendExecute with network error propagates exception`() = runSuspendIO {
         server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
 
-        runCatching {
+        runCatchingNonCancellation {
             api.get().suspendExecute()
         }.isFailure.shouldBeTrue()
     }
@@ -88,19 +91,23 @@ class SuspendRetrofitCallSupportTest {
     }
 
     @Test
-    fun `suspendExecute invokes cancelHandler on cancelled call`() = runSuspendIO {
-        // Enqueue a response so the call has something to resolve
-        server.enqueue(MockResponse().setBody("ok"))
+    fun `suspendExecute cancels underlying call when coroutine is cancelled`() = runSuspendIO {
+        server.enqueue(
+            MockResponse()
+                .setBody("late")
+                .setBodyDelay(5, TimeUnit.SECONDS)
+        )
 
-        val call = api.get()
-        // Cancel before executing - should trigger cancel path
-        call.cancel()
+        lateinit var call: Call<String>
 
-        var cancelHandlerCalled = false
-        runCatching {
-            call.suspendExecute(cancelHandler = { cancelHandlerCalled = true })
+        assertResourceCancelledOnCoroutineCancellation(
+            beforeCancel = {
+                server.takeRequest(1, TimeUnit.SECONDS).shouldNotBeNull()
+            },
+            resourceCancelled = { call.isCanceled },
+        ) {
+            call = api.get()
+            call.suspendExecute()
         }
-        // Either the handler was called or an exception was thrown for the cancelled call
-        // Both are valid outcomes; the key is no unhandled exception propagation
     }
 }

--- a/testing/junit5/README.ko.md
+++ b/testing/junit5/README.ko.md
@@ -22,6 +22,7 @@ JUnit 5 테스트 작성 시 반복 코드를 줄여주는 확장 라이브러�
 - **Random/Faker 확장**: 랜덤/가짜 데이터 주입
 - **System Property 확장**: 테스트 중 시스템 속성 설정/복원
 - **Awaitility + Coroutines**: suspend 조건 대기 유틸
+- **Coroutine Cancellation Contracts**: cancellation 전파, waiter 정리, resource cancellation 검증
 - **Stress Tester**: 멀티스레드/가상스레드/코루틴 기반 스트레스 테스트
 - **Parameter Source 확장**: FieldSource 기반 인자 제공
 - **Mermaid 리포트**: 테스트 실행 결과를 Mermaid Gantt 타임라인으로 출력
@@ -219,7 +220,45 @@ fun `suspend 조건 대기`() = runSuspendTest {
 }
 ```
 
-### 8. Stress Tester
+### 8. Coroutine Cancellation Contracts
+
+callback, future, HTTP call, 공유 waiter를 감싸는 suspend API는 cancellation 계약을 명시적으로 테스트하세요.
+
+```kotlin
+@Test
+fun `wrapper rethrows cancellation`() = runTest {
+    assertCancellationPropagates {
+        client.tryFetchSuspending {
+            delay(Long.MAX_VALUE)
+        }
+    }
+}
+
+@Test
+fun `cancelled waiter does not block the next waiter`() = runTest {
+    assertCancellationClearsWaiter(
+        awaiter = { gate.await() },
+        releaser = { gate.resume() },
+    )
+}
+
+@Test
+fun `cancellation cancels the underlying call`() = runSuspendIO {
+    assertResourceCancelledOnCoroutineCancellation(
+        beforeCancel = { waitUntilRequestStarted() },
+        resourceCancelled = { call.isCanceled },
+    ) {
+        call.suspendExecute()
+    }
+}
+```
+
+suspend API에서 cancellation 전파가 필요하다면 plain `runCatching`으로 감싸면 안 됩니다.
+`CancellationException`은 structured concurrency의 cancellation 신호이므로 반드시 다시 던져야 합니다.
+non-cancellation 실패만 `Result`로 반환하려면 `runCatchingNonCancellation` 또는
+`resultOfNonCancellation`을 사용하세요.
+
+### 9. Stress Tester
 
 #### 실행 모델 요약
 
@@ -260,7 +299,7 @@ StructuredTaskScopeTester()
     .run()
 ```
 
-### 9. Coroutine Support
+### 10. Coroutine Support
 
 ```kotlin
 @Test
@@ -288,7 +327,7 @@ fun `Virtual Thread 환경 테스트`() = runSuspendVT {
 }
 ```
 
-### 10. FieldSource (Parameterized Test)
+### 11. FieldSource (Parameterized Test)
 
 ```kotlin
 class FieldSourceTest {
@@ -308,7 +347,7 @@ class FieldSourceTest {
 }
 ```
 
-### 11. Mermaid 리포트
+### 12. Mermaid 리포트
 
 ```bash
 # 테스트 실행 및 Mermaid 리포트 추출
@@ -330,6 +369,8 @@ class FieldSourceTest {
 - 콘솔 출력을 검증해야 할 때는 `OutputCapture`를 사용하세요.
 - 샘플 값에는 하드코딩 대신 `FakeValue`/`Fakers` 프로바이더를 활용하세요.
 - 동시성 테스트에는 제공되는 Stress Tester 헬퍼를 재사용하세요 — 라운드 수가 증가해도 worker 수를 일정하게 유지합니다.
+- suspend API는 `CancellationException`을 다시 던지고, cancellation 시 등록된 waiter/continuation을 정리하며, 감싼 future 또는 HTTP call을 취소해야 합니다.
+- suspend API를 plain `runCatching`으로 감싸지 마세요. 필요하다면 cancellation을 다시 던지는 `runCatchingNonCancellation`을 사용하세요.
 
 ## 의존성 추가
 

--- a/testing/junit5/README.md
+++ b/testing/junit5/README.md
@@ -22,6 +22,7 @@ An extension library that reduces repetitive boilerplate in JUnit 5 tests.
 - Random/Faker data injection — inject fake or randomized objects into test fields/parameters
 - System property helpers — set properties before a test and restore them after
 - Awaitility + coroutine helpers — `suspendUntil` / `awaitSuspending`
+- Coroutine cancellation contracts — verify propagation, waiter cleanup, and resource cancellation
 - Stress-testing utilities — `MultithreadingTester`, `SuspendedJobTester`, `StructuredTaskScopeTester`
 - Parameter-source extensions — `FieldSource` for parameterized tests
 - Mermaid-based reporting — Gantt timeline of test execution
@@ -150,6 +151,43 @@ fun `io dispatcher test`() = runSuspendIO {
 }
 ```
 
+### Coroutine Cancellation Contracts
+
+Use the cancellation contract helpers when a suspend API wraps callbacks, futures, HTTP calls, or shared waiters.
+
+```kotlin
+@Test
+fun `wrapper rethrows cancellation`() = runTest {
+    assertCancellationPropagates {
+        client.tryFetchSuspending {
+            delay(Long.MAX_VALUE)
+        }
+    }
+}
+
+@Test
+fun `cancelled waiter does not block the next waiter`() = runTest {
+    assertCancellationClearsWaiter(
+        awaiter = { gate.await() },
+        releaser = { gate.resume() },
+    )
+}
+
+@Test
+fun `cancellation cancels the underlying call`() = runSuspendIO {
+    assertResourceCancelledOnCoroutineCancellation(
+        beforeCancel = { waitUntilRequestStarted() },
+        resourceCancelled = { call.isCanceled },
+    ) {
+        call.suspendExecute()
+    }
+}
+```
+
+Do not wrap suspend APIs in plain `runCatching` when cancellation must propagate. `CancellationException` is the
+structured concurrency signal and must be rethrown. Use `runCatchingNonCancellation` or `resultOfNonCancellation`
+when an API intentionally returns `Result` for non-cancellation failures.
+
 ### SystemProperty
 
 ```kotlin
@@ -194,6 +232,8 @@ class FieldSourceTest {
 - Capture stdout/stderr when assertions depend on console output.
 - Prefer `FakeValue` / `Fakers` providers for sample values instead of hardcoded data.
 - Use the provided stress-testing helpers for concurrency-heavy tests — they maintain a stable worker pool regardless of round count.
+- For suspend APIs, rethrow `CancellationException`, clear registered waiters/continuations on cancellation, and cancel wrapped futures or HTTP calls.
+- Avoid plain `runCatching` around suspend APIs unless `CancellationException` is caught and rethrown before producing `Result.failure`.
 
 ## Adding the Dependency
 

--- a/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/coroutines/CancellationContracts.kt
+++ b/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/coroutines/CancellationContracts.kt
@@ -1,0 +1,207 @@
+package io.bluetape4k.junit5.coroutines
+
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Default timeout for coroutine cancellation contract checks.
+ */
+val DEFAULT_CANCELLATION_CONTRACT_TIMEOUT: Duration = 5.seconds
+
+/**
+ * Runs [block] and captures non-cancellation failures as [Result.failure].
+ *
+ * ## Behaviour / Contract
+ * - Returns [Result.success] when [block] completes normally.
+ * - Returns [Result.failure] for non-cancellation exceptions.
+ * - Rethrows [CancellationException] so structured coroutine cancellation is
+ *   preserved.
+ *
+ * ```kotlin
+ * val result = resultOfNonCancellation { parseValue() }
+ * ```
+ */
+inline fun <T> resultOfNonCancellation(block: () -> T): Result<T> {
+    return try {
+        Result.success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        Result.failure(e)
+    }
+}
+
+/**
+ * Runs suspend [block] and captures non-cancellation failures as [Result.failure].
+ *
+ * ## Behaviour / Contract
+ * - Returns [Result.success] when [block] completes normally.
+ * - Returns [Result.failure] for non-cancellation exceptions.
+ * - Rethrows [CancellationException]. Use this instead of plain `runCatching`
+ *   around suspend APIs that must preserve structured cancellation.
+ *
+ * ```kotlin
+ * val result = runCatchingNonCancellation { client.fetch() }
+ * ```
+ */
+suspend inline fun <T> runCatchingNonCancellation(
+    crossinline block: suspend () -> T,
+): Result<T> {
+    return try {
+        Result.success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        Result.failure(e)
+    }
+}
+
+/**
+ * Asserts that cancelling the launched coroutine is observed as
+ * [CancellationException] inside [operation].
+ *
+ * ## Behaviour / Contract
+ * - Starts [operation] immediately in a child coroutine.
+ * - Cancels the child after it reaches the first suspension point.
+ * - Fails if [operation] completes normally or turns cancellation into another
+ *   result/exception type.
+ *
+ * ```kotlin
+ * assertCancellationPropagates {
+ *     wrapperReturningResult {
+ *         delay(Long.MAX_VALUE)
+ *     }
+ * }
+ * ```
+ */
+suspend fun <T> assertCancellationPropagates(
+    timeout: Duration = DEFAULT_CANCELLATION_CONTRACT_TIMEOUT,
+    operation: suspend CoroutineScope.() -> T,
+) {
+    var outcome: Result<T>? = null
+
+    coroutineScope {
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            try {
+                outcome = Result.success(operation())
+            } catch (e: CancellationException) {
+                outcome = Result.failure(e)
+            } catch (e: Throwable) {
+                outcome = Result.failure(e)
+            }
+        }
+
+        yield()
+        job.cancel(CancellationException("Coroutine cancellation contract probe"))
+        withTimeout(timeout) {
+            job.join()
+        }
+    }
+
+    outcome?.exceptionOrNull().shouldBeInstanceOf<CancellationException>()
+}
+
+/**
+ * Asserts that cancelling one suspended waiter clears its registration and does
+ * not block the next waiter.
+ *
+ * ## Behaviour / Contract
+ * - Starts [awaiter] once and cancels it while suspended.
+ * - Starts [awaiter] again, calls [releaser], and verifies that the second
+ *   waiter completes within [timeout].
+ *
+ * ```kotlin
+ * assertCancellationClearsWaiter(
+ *     awaiter = { gate.await() },
+ *     releaser = { gate.resume() },
+ * )
+ * ```
+ */
+suspend fun assertCancellationClearsWaiter(
+    timeout: Duration = DEFAULT_CANCELLATION_CONTRACT_TIMEOUT,
+    awaiter: suspend () -> Unit,
+    releaser: () -> Unit,
+) {
+    coroutineScope {
+        val first = launch(start = CoroutineStart.UNDISPATCHED) {
+            awaiter()
+        }
+
+        first.cancel(CancellationException("Waiter cancellation contract probe"))
+        withTimeout(timeout) {
+            first.join()
+        }
+
+        val second = launch(start = CoroutineStart.UNDISPATCHED) {
+            awaiter()
+        }
+
+        releaser()
+        withTimeout(timeout) {
+            second.join()
+        }
+        second.isCompleted.shouldBeTrue()
+    }
+}
+
+/**
+ * Asserts that cancelling a coroutine also cancels the underlying resource used
+ * by [operation].
+ *
+ * ## Behaviour / Contract
+ * - Starts [operation] immediately in a child coroutine.
+ * - Runs [beforeCancel] so tests can wait until a future, HTTP call, or callback
+ *   registration is known to have started.
+ * - Cancels the coroutine and verifies [resourceCancelled].
+ * - Fails if cancellation is converted to a non-cancellation outcome.
+ *
+ * ```kotlin
+ * assertResourceCancelledOnCoroutineCancellation(
+ *     beforeCancel = { waitUntilRequestStarted() },
+ *     resourceCancelled = { call.isCanceled },
+ * ) {
+ *     call.suspendExecute()
+ * }
+ * ```
+ */
+suspend fun <T> assertResourceCancelledOnCoroutineCancellation(
+    timeout: Duration = DEFAULT_CANCELLATION_CONTRACT_TIMEOUT,
+    beforeCancel: suspend () -> Unit = { yield() },
+    resourceCancelled: () -> Boolean,
+    operation: suspend CoroutineScope.() -> T,
+) {
+    var outcome: Result<T>? = null
+
+    coroutineScope {
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            try {
+                outcome = Result.success(operation())
+            } catch (e: CancellationException) {
+                outcome = Result.failure(e)
+            } catch (e: Throwable) {
+                outcome = Result.failure(e)
+            }
+        }
+
+        withTimeout(timeout) {
+            beforeCancel()
+        }
+        job.cancel(CancellationException("Resource cancellation contract probe"))
+        withTimeout(timeout) {
+            job.join()
+        }
+    }
+
+    resourceCancelled().shouldBeTrue()
+    outcome?.exceptionOrNull().shouldBeInstanceOf<CancellationException>()
+}

--- a/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/coroutines/CancellationContractsTest.kt
+++ b/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/coroutines/CancellationContractsTest.kt
@@ -1,0 +1,111 @@
+package io.bluetape4k.junit5.coroutines
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.junit.jupiter.api.Test
+
+class CancellationContractsTest {
+
+    @Test
+    fun `resultOfNonCancellation returns failure for non cancellation exception`() {
+        val result = resultOfNonCancellation {
+            throw IllegalStateException("boom")
+        }
+
+        result.isFailure.shouldBeTrue()
+        result.exceptionOrNull().shouldBeInstanceOf<IllegalStateException>()
+    }
+
+    @Test
+    fun `resultOfNonCancellation rethrows CancellationException`() {
+        assertFailsWith<CancellationException> {
+            resultOfNonCancellation {
+                throw CancellationException("cancel")
+            }
+        }
+    }
+
+    @Test
+    fun `runCatchingNonCancellation returns failure for non cancellation exception`() = runTest {
+        val result = runCatchingNonCancellation {
+            throw IllegalStateException("boom")
+        }
+
+        result.isFailure.shouldBeTrue()
+        result.exceptionOrNull().shouldBeInstanceOf<IllegalStateException>()
+    }
+
+    @Test
+    fun `runCatchingNonCancellation rethrows CancellationException`() = runTest {
+        assertFailsWith<CancellationException> {
+            runCatchingNonCancellation {
+                throw CancellationException("cancel")
+            }
+        }
+    }
+
+    @Test
+    fun `assertCancellationPropagates passes when operation rethrows cancellation`() = runTest {
+        assertCancellationPropagates {
+            delay(Long.MAX_VALUE)
+        }
+    }
+
+    @Test
+    fun `assertCancellationPropagates fails when operation swallows cancellation`() = runTest {
+        assertFailsWith<AssertionError> {
+            assertCancellationPropagates {
+                try {
+                    delay(Long.MAX_VALUE)
+                } catch (e: CancellationException) {
+                    // Swallowing cancellation must fail the contract.
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `assertCancellationPropagates fails when operation converts cancellation`() = runTest {
+        assertFailsWith<AssertionError> {
+            assertCancellationPropagates {
+                try {
+                    delay(Long.MAX_VALUE)
+                } catch (e: CancellationException) {
+                    throw IllegalStateException("converted", e)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `assertCancellationClearsWaiter completes second waiter`() = runTest {
+        val release = CompletableDeferred<Unit>()
+
+        assertCancellationClearsWaiter(
+            awaiter = { release.await() },
+            releaser = { release.complete(Unit) },
+        )
+    }
+
+    @Test
+    fun `assertResourceCancelledOnCoroutineCancellation verifies resource cancellation`() = runTest {
+        var cancelled = false
+
+        assertResourceCancelledOnCoroutineCancellation(
+            beforeCancel = { yield() },
+            resourceCancelled = { cancelled },
+        ) {
+            try {
+                delay(Long.MAX_VALUE)
+            } finally {
+                cancelled = true
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #494

- PR 제목: test: enforce coroutine cancellation contracts

- Add shared coroutine cancellation contract helpers in `bluetape4k-junit5`.
- Add self-tests for cancellation propagation, cancellation conversion failure, waiter cleanup, and resource cancellation.
- Adopt the helpers in `bluetape4k-coroutines`, `bluetape4k-micrometer`, and `bluetape4k-retrofit2`.
- Document cancellation-safe `Result` wrappers and checklist in English/Korean JUnit5 READMEs.

Closes #494

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Step 6-R Review

| Tier | P0 | P1 | Result |
|---|---:|---:|---|
| Security | 0 | 0 | Test helper/docs-only surface; no secret/auth/input boundary introduced. |
| Ops/SRE | 0 | 0 | Waits are timeout-bounded; Retrofit request wait is bounded. |
| Structural | 0 | 0 | Helper API stays in `bluetape4k-junit5` and depends on core coroutine/Duration types. |
| Kotlin/Quality | 0 | 0 | Cancellation-to-non-cancellation conversion now fails as an assertion. |
| Tests/Types | 0 | 0 | Positive/negative helper self-tests plus representative module adoption. |
| Perf/Stability | 0 | 0 | No unbounded polling/sleeps; hardcoded waits are bounded test probes. |

Claude Code CLI advisor was intentionally skipped because Claude usage was disabled for this session. A native code-reviewer subagent was attempted, but it did not return within the bounded review window; current-session six-tier review and targeted validation were used as the gate.

### 기존 섹션: Verification

- `./gradlew :bluetape4k-junit5:compileKotlin :bluetape4k-junit5:test --console=plain --no-configuration-cache`
- `./gradlew :bluetape4k-coroutines:test --tests '*ResumableTest' :bluetape4k-micrometer:test --tests '*ObservationCoroutinesSupportTest' :bluetape4k-retrofit2:test --tests '*SuspendRetrofitCallSupportTest' --console=plain --no-configuration-cache`
- `git diff --check`

### 기존 섹션: Notes

- Gradle emitted existing deprecation warnings in unrelated dependency/test modules; no warning was introduced in the new helper contract.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #494, milestone `1.8.1`, assignee debop
- PR: #563, head `09f6f04f31b21896479bc1a976c04a63f861728f`, milestone `1.8.1`, assignee debop
- Base: `develop`, head branch `feat/issue-494-cancellation-contracts`
- Labels: `enhancement`, `test`, `1.8.0-after`
- State: `MERGED`, merge commit `db150e5c8039b2dc7d425faeb10d4836e32071e6`
- CI: - `./gradlew :bluetape4k-junit5:compileKotlin :bluetape4k-junit5:test --console=plain --no-configuration-cache` / - `./gradlew :bluetape4k-coroutines:test --tests '*ResumableTest' :bluetape4k-micrometer:test --tests '*ObservationCoroutinesSupportTest' :bluetape4k-retrofit2:test --tests '*SuspendRetrofitCallSupportTest' --console=plain --no-configuration-cache` / - Gradle emitted existing deprecation warnings in unrelated dependency/test modules; no warning was introduced in the new helper contract.## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #563 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `db150e5c8039b2dc7d425faeb10d4836e32071e6`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
