### PR TITLE
chore: gate unsafe Kafka JDK codecs

### DIFF
--- a/docs/infra-deprecated-inventory.md
+++ b/docs/infra-deprecated-inventory.md
@@ -12,11 +12,15 @@ work should happen in follow-up PRs.
 | Decision | Count | Meaning |
 |---|---:|---|
 | Delete | 17 files | Deprecated API has a direct replacement and should not remain in the next cleanup line. |
-| Replace call sites first | 6 files | Repo-local tests or samples still exercise the deprecated API and must move first. |
+| Replace call sites first | 4 files | Repo-local tests or samples still exercise the deprecated API and must move first. |
 | Keep | 0 files | No deprecated `infra/` API needs long-term retention. |
 
 `infra/kafka4` mirrors several `infra/kafka` deprecated APIs, so the current
 scope is larger than the original 12-file issue comment.
+
+2026-05-20 update: `kafka`/`kafka4` JDK-backed Kafka codecs are now staged as
+`@BluetapeObsoleteApi` + `DeprecationLevel.ERROR`; final API removal remains the
+next breaking cleanup step.
 
 ## Inventory
 
@@ -25,11 +29,11 @@ scope is larger than the original 12-file issue comment.
 | 1 | `cache-core` | `cache/core/src/main/kotlin/io/bluetape4k/cache/caffeine/CaffeineSupport.kt` | `AsyncCache.getSuspending(...)` | KDoc sample only | Delete | `AsyncCache.suspendGet(...)` |
 | 2 | `cache-lettuce` | `cache/lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceSuspendNearCache.kt` | `clearFrontCache()` | Definition only | Delete | `clearLocal()` |
 | 3 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt` | `Producer.getMetricValue(...)` | Definition only | Delete | `getMetricValueOrNull(...).asDouble()` |
-| 4 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt` | `JdkKafkaCodec` | `KafkaCodecTest` still tests `KafkaCodecs.Jdk` | Replace tests, then delete | `ForyKafkaCodec` or `KryoKafkaCodec` |
+| 4 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt` | `JdkKafkaCodec` | Definition only; compile-error gated | Delete in breaking cleanup | `ForyKafkaCodec` or `KryoKafkaCodec` |
 | 5 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/KafkaOperationsExtensions.kt` | `sendAndAwait(...)`, `awaitSendDefault(...)` overloads | Definition only | Delete | `suspendSend(...)` / `suspendSendDefault(...)` |
 | 6 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt` | `awaitSend(...)`, `sendSuspending(...)`, `getMetricValue(...)` | KDoc/definition only | Delete | `suspendSend(...)`, `getMetricValueOrNull(...).asDouble()` |
 | 7 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt` | `Producer.getMetricValue(...)` | Definition only | Delete | `getMetricValueOrNull(...).asDouble()` |
-| 8 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt` | `JdkKafkaCodec` | `KafkaCodecTest` still tests `KafkaCodecs.Jdk` | Replace tests, then delete | `ForyKafkaCodec` or `KryoKafkaCodec` |
+| 8 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt` | `JdkKafkaCodec` | Definition only; compile-error gated | Delete in breaking cleanup | `ForyKafkaCodec` or `KryoKafkaCodec` |
 | 9 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/KafkaOperationsExtensions.kt` | `sendAndAwait(...)`, `awaitSendDefault(...)` overloads | Definition only | Delete | `suspendSend(...)` / `suspendSendDefault(...)` |
 | 10 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt` | `awaitSend(...)`, `sendSuspending(...)`, `getMetricValue(...)` | Definition only | Delete | `suspendSend(...)`, `getMetricValueOrNull(...).asDouble()` |
 | 11 | `lettuce` | `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/LettuceConst.kt` | `DEFAULT_DELIMETER` typo | Definition only | Delete | `DEFAULT_DELIMITER` |
@@ -54,11 +58,9 @@ Tasks:
 - Remove `sendAndAwait`, `awaitSend`, `awaitSendDefault`, and `sendSuspending`
   aliases after confirming no repo-local callers remain.
 - Remove `getMetricValue(...)` aliases.
-- Replace `KafkaCodecs.Jdk` compatibility tests with supported codecs or remove
-  the JDK-only compatibility case.
-- Remove `JdkKafkaCodec` and any public factory/registry entry that exposes it,
-  while keeping compressed JDK-backed codecs only if they are intentionally still
-  supported outside this issue.
+- Remove `JdkKafkaCodec` and compressed JDK-backed public factory/registry
+  entries after the `@BluetapeObsoleteApi` + `DeprecationLevel.ERROR` staging
+  period.
 
 Validation:
 

--- a/docs/lessons/2026-05-20-issue-539-binary-kafka-codecs.md
+++ b/docs/lessons/2026-05-20-issue-539-binary-kafka-codecs.md
@@ -1,0 +1,34 @@
+# Issue 539 - Binary Kafka Codecs
+
+## Context
+
+`JdkKafkaCodec` and compressed JDK-backed Kafka codecs were already deprecated
+because JDK deserialization is unsafe for untrusted bytes. Issue #539 asked to
+stage the migration before final removal.
+
+## Decision
+
+Apply the new `@BluetapeObsoleteApi` marker and raise Kotlin deprecation to
+`DeprecationLevel.ERROR` for the JDK-backed kafka/kafka4 codec APIs. Keep the
+registry entries only as explicit compatibility bridges and point callers to the
+Fory variants.
+
+## Outcome
+
+- Added `bluetape4k-annotations` as an API dependency for kafka/kafka4.
+- Marked direct and compressed JDK codec classes and registry properties as
+  obsolete/error-gated.
+- Removed JDK codec coverage from codec round-trip tests; safe Kryo/Fory
+  variants remain covered.
+- Updated README codec tables and the deprecated inventory note.
+
+## Verification
+
+- `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka:test --tests 'io.bluetape4k.kafka.codec.KafkaCodecTest' --console=plain --no-configuration-cache`
+- `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka4:test --tests 'io.bluetape4k.kafka.codec.KafkaCodecTest' --console=plain --no-configuration-cache`
+
+## Future Guidance
+
+For #474, remove these compatibility APIs in the breaking cleanup slice rather
+than re-testing JDK deserialization. Prefer Fory for new examples and migration
+docs.

--- a/infra/kafka/README.ko.md
+++ b/infra/kafka/README.ko.md
@@ -162,16 +162,16 @@ val compressed = lz4ForyCodec.serialize("test-topic", largeObject)
 | `KafkaCodecs.String`    | UTF-8 문자열 직렬화        |
 | `KafkaCodecs.ByteArray` | 바이트 배열 직접 전달         |
 | `KafkaCodecs.Jackson`   | JSON 직렬화             |
-| `KafkaCodecs.Jdk`       | **사용 중단** — Java 직렬화 (RCE 위험, Fory 사용 권장) |
+| `KafkaCodecs.Jdk`       | **Obsolete / 컴파일 오류 게이트** — Java 직렬화 (RCE 위험, Fory 사용 권장) |
 | `KafkaCodecs.Kryo`      | Kryo 바이너리 직렬화        |
 | `KafkaCodecs.Fory`      | Fory 바이너리 직렬화 (고성능, 권장) |
-| `KafkaCodecs.LZ4Jdk`    | LZ4 압축 + Java 직렬화    |
+| `KafkaCodecs.LZ4Jdk`    | **Obsolete / 컴파일 오류 게이트** — LZ4 압축 + Java 직렬화 |
 | `KafkaCodecs.Lz4Kryo`   | LZ4 압축 + Kryo 직렬화    |
 | `KafkaCodecs.Lz4Fory`   | LZ4 압축 + Fory 직렬화    |
-| `KafkaCodecs.SnappyJdk` | Snappy 압축 + Java 직렬화 |
+| `KafkaCodecs.SnappyJdk` | **Obsolete / 컴파일 오류 게이트** — Snappy 압축 + Java 직렬화 |
 | `KafkaCodecs.SnappyKryo` | Snappy 압축 + Kryo 직렬화 |
 | `KafkaCodecs.SnappyFory` | Snappy 압축 + Fory 직렬화 |
-| `KafkaCodecs.ZstdJdk`   | Zstd 압축 + Java 직렬화   |
+| `KafkaCodecs.ZstdJdk`   | **Obsolete / 컴파일 오류 게이트** — Zstd 압축 + Java 직렬화 |
 | `KafkaCodecs.ZstdKryo`  | Zstd 압축 + Kryo 직렬화   |
 | `KafkaCodecs.ZstdFory`  | Zstd 압축 + Fory 직렬화   |
 
@@ -432,7 +432,7 @@ io.bluetape4k.kafka
 │   ├── KafkaCodec.kt         # 기본 Codec 인터페이스
 │   ├── KafkaCodecs.kt        # Codec 인스턴스 제공
 │   ├── JacksonKafkaCodec.kt  # JSON 직렬화
-│   ├── BinaryKafkaCodecs.kt  # 바이너리 직렬화 (JDK, Kryo, Fory)
+│   ├── BinaryKafkaCodecs.kt  # 바이너리 직렬화 (Kryo, Fory; obsolete JDK 호환)
 │   ├── StringKafkaCodec.kt   # 문자열 직렬화
 │   └── ByteArrayKafkaCodec.kt # 바이트 배열 직렬화
 ├── coroutines/               # Coroutine 지원

--- a/infra/kafka/README.md
+++ b/infra/kafka/README.md
@@ -162,16 +162,16 @@ Available codecs:
 | `KafkaCodecs.String`    | UTF-8 string serialization              |
 | `KafkaCodecs.ByteArray` | Raw byte array passthrough              |
 | `KafkaCodecs.Jackson`   | JSON serialization                      |
-| `KafkaCodecs.Jdk`       | **Deprecated** — JDK serialization (RCE risk, use Fory) |
+| `KafkaCodecs.Jdk`       | **Obsolete / compile-error gated** — JDK serialization (RCE risk, use Fory) |
 | `KafkaCodecs.Kryo`      | Kryo binary serialization               |
 | `KafkaCodecs.Fory`      | Fory binary serialization               |
-| `KafkaCodecs.LZ4Jdk`    | LZ4 compression + Java serialization    |
+| `KafkaCodecs.LZ4Jdk`    | **Obsolete / compile-error gated** — LZ4 compression + Java serialization |
 | `KafkaCodecs.Lz4Kryo`   | LZ4 compression + Kryo serialization    |
 | `KafkaCodecs.Lz4Fory`   | LZ4 compression + Fory serialization    |
-| `KafkaCodecs.SnappyJdk` | Snappy compression + Java serialization |
+| `KafkaCodecs.SnappyJdk` | **Obsolete / compile-error gated** — Snappy compression + Java serialization |
 | `KafkaCodecs.SnappyKryo` | Snappy compression + Kryo serialization |
 | `KafkaCodecs.SnappyFory` | Snappy compression + Fory serialization |
-| `KafkaCodecs.ZstdJdk`   | Zstd compression + Java serialization   |
+| `KafkaCodecs.ZstdJdk`   | **Obsolete / compile-error gated** — Zstd compression + Java serialization |
 | `KafkaCodecs.ZstdKryo`  | Zstd compression + Kryo serialization   |
 | `KafkaCodecs.ZstdFory`  | Zstd compression + Fory serialization   |
 
@@ -433,7 +433,7 @@ io.bluetape4k.kafka
 │   ├── KafkaCodec.kt         # Base codec interface
 │   ├── KafkaCodecs.kt        # Codec instances
 │   ├── JacksonKafkaCodec.kt  # JSON serialization
-│   ├── BinaryKafkaCodecs.kt  # Binary serialization (JDK, Kryo, Fory)
+│   ├── BinaryKafkaCodecs.kt  # Binary serialization (Kryo, Fory; obsolete JDK compatibility)
 │   ├── StringKafkaCodec.kt   # String serialization
 │   └── ByteArrayKafkaCodec.kt # Byte array serialization
 ├── coroutines/               # Coroutine support

--- a/infra/kafka/build.gradle.kts
+++ b/infra/kafka/build.gradle.kts
@@ -14,6 +14,7 @@ configurations {
 }
 
 dependencies {
+    api(project(":bluetape4k-annotations"))
     implementation(platform(libs.spring.boot.dependencies))
     api(project(":bluetape4k-core"))
     api(project(":bluetape4k-io"))

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.kafka.codec
 
+import io.bluetape4k.annotations.BluetapeObsoleteApi
 import io.bluetape4k.io.serializer.BinarySerializer
 import io.bluetape4k.io.serializer.BinarySerializers
 import org.apache.kafka.common.header.Headers
@@ -29,22 +30,27 @@ abstract class BinaryKafkaCodec(
 }
 
 /**
- * JDK 직렬화를 이용한 Kafka Codec
+ * Kafka codec backed by JDK serialization.
  *
- * **보안 경고**: JDK 직렬화는 역직렬화 과정에서 임의 코드 실행(RCE) 취약점이 있습니다.
- * 성능과 보안 모두 우수한 [ForyKafkaCodec]을 사용하십시오.
+ * ## Security
+ *
+ * JDK deserialization can execute attacker-controlled object graphs when
+ * untrusted bytes are decoded. Use [ForyKafkaCodec] for new code.
  *
  * ```kotlin
- * val codec = JdkKafkaCodec()
+ * val codec = ForyKafkaCodec()
  * val bytes = codec.serialize("topic", null, "hello")
  * val result = codec.deserialize("topic", null, bytes)
  * // result == "hello"
  * ```
  */
+@BluetapeObsoleteApi
 @Deprecated(
-    message = "JDK 직렬화는 역직렬화 과정에서 임의 코드 실행(RCE) 취약점이 있습니다. 성능과 보안 모두 우수한 ForyKafkaCodec을 사용하세요.",
-    replaceWith = ReplaceWith("ForyKafkaCodec()")
+    message = "JDK serialization is unsafe for untrusted bytes. Use ForyKafkaCodec instead.",
+    replaceWith = ReplaceWith("ForyKafkaCodec()"),
+    level = DeprecationLevel.ERROR,
 )
+@Suppress("DEPRECATION")
 class JdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.Jdk)
 
 /**
@@ -72,15 +78,26 @@ class KryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.Kryo)
 class ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.Fory)
 
 /**
- * LZ4 압축 + JDK 직렬화를 이용한 Kafka Codec
+ * Kafka codec backed by LZ4-compressed JDK serialization.
+ *
+ * ## Security
+ *
+ * JDK deserialization can execute attacker-controlled object graphs when
+ * untrusted bytes are decoded. Use [LZ4ForyKafkaCodec] for new code.
  *
  * ```kotlin
- * val codec = LZ4JdkKafkaCodec()
+ * val codec = LZ4ForyKafkaCodec()
  * val bytes = codec.serialize("topic", null, "hello")
  * val result = codec.deserialize("topic", null, bytes)
  * // result == "hello"
  * ```
  */
+@BluetapeObsoleteApi
+@Deprecated(
+    message = "JDK serialization is unsafe for untrusted bytes. Use LZ4ForyKafkaCodec instead.",
+    replaceWith = ReplaceWith("LZ4ForyKafkaCodec()"),
+    level = DeprecationLevel.ERROR,
+)
 class LZ4JdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Jdk)
 
 /**
@@ -108,15 +125,26 @@ class LZ4KryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Kryo)
 class LZ4ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Fory)
 
 /**
- * Snappy 압축 + JDK 직렬화를 이용한 Kafka Codec
+ * Kafka codec backed by Snappy-compressed JDK serialization.
+ *
+ * ## Security
+ *
+ * JDK deserialization can execute attacker-controlled object graphs when
+ * untrusted bytes are decoded. Use [SnappyForyKafkaCodec] for new code.
  *
  * ```kotlin
- * val codec = SnappyJdkKafkaCodec()
+ * val codec = SnappyForyKafkaCodec()
  * val bytes = codec.serialize("topic", null, "hello")
  * val result = codec.deserialize("topic", null, bytes)
  * // result == "hello"
  * ```
  */
+@BluetapeObsoleteApi
+@Deprecated(
+    message = "JDK serialization is unsafe for untrusted bytes. Use SnappyForyKafkaCodec instead.",
+    replaceWith = ReplaceWith("SnappyForyKafkaCodec()"),
+    level = DeprecationLevel.ERROR,
+)
 class SnappyJdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyJdk)
 
 /**
@@ -143,17 +171,27 @@ class SnappyKryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyKryo)
  */
 class SnappyForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyFory)
 
-
 /**
- * Zstd 압축 + JDK 직렬화를 이용한 Kafka Codec
+ * Kafka codec backed by Zstd-compressed JDK serialization.
+ *
+ * ## Security
+ *
+ * JDK deserialization can execute attacker-controlled object graphs when
+ * untrusted bytes are decoded. Use [ZstdForyKafkaCodec] for new code.
  *
  * ```kotlin
- * val codec = ZstdJdkKafkaCodec()
+ * val codec = ZstdForyKafkaCodec()
  * val bytes = codec.serialize("topic", null, "hello")
  * val result = codec.deserialize("topic", null, bytes)
  * // result == "hello"
  * ```
  */
+@BluetapeObsoleteApi
+@Deprecated(
+    message = "JDK serialization is unsafe for untrusted bytes. Use ZstdForyKafkaCodec instead.",
+    replaceWith = ReplaceWith("ZstdForyKafkaCodec()"),
+    level = DeprecationLevel.ERROR,
+)
 class ZstdJdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.ZstdJdk)
 
 /**

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodecs.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodecs.kt
@@ -1,9 +1,11 @@
 package io.bluetape4k.kafka.codec
 
+import io.bluetape4k.annotations.BluetapeObsoleteApi
+
 /**
  * 다양한 Kafka Codec 인스턴스를 제공하는 Object입니다.
  *
- * 문자열, 바이트 배열, JSON 직렬화 및 다양한 바이너리 직렬화(JDK, Kryo, Fory)와
+ * 문자열, 바이트 배열, JSON 직렬화 및 다양한 바이너리 직렬화(Kryo, Fory)와
  * 압축 알고리즘(LZ4, Snappy, Zstd)을 조합한 Codec을 제공합니다.
  *
  * 사용 예시:
@@ -29,19 +31,55 @@ object KafkaCodecs {
 
     val Jackson by lazy { JacksonKafkaCodec() }
 
+    @BluetapeObsoleteApi
+    @Deprecated(
+        message = "JDK serialization is unsafe for untrusted bytes. Use KafkaCodecs.Fory instead.",
+        replaceWith = ReplaceWith("KafkaCodecs.Fory"),
+        level = DeprecationLevel.ERROR,
+    )
+    @OptIn(BluetapeObsoleteApi::class)
+    @Suppress("DEPRECATION_ERROR")
     val Jdk by lazy { JdkKafkaCodec() }
+
     val Kryo by lazy { KryoKafkaCodec() }
     val Fory by lazy { ForyKafkaCodec() }
 
+    @BluetapeObsoleteApi
+    @Deprecated(
+        message = "JDK serialization is unsafe for untrusted bytes. Use KafkaCodecs.Lz4Fory instead.",
+        replaceWith = ReplaceWith("KafkaCodecs.Lz4Fory"),
+        level = DeprecationLevel.ERROR,
+    )
+    @OptIn(BluetapeObsoleteApi::class)
+    @Suppress("DEPRECATION_ERROR")
     val LZ4Jdk by lazy { LZ4JdkKafkaCodec() }
+
     val Lz4Kryo by lazy { LZ4KryoKafkaCodec() }
     val Lz4Fory by lazy { LZ4ForyKafkaCodec() }
 
+    @BluetapeObsoleteApi
+    @Deprecated(
+        message = "JDK serialization is unsafe for untrusted bytes. Use KafkaCodecs.SnappyFory instead.",
+        replaceWith = ReplaceWith("KafkaCodecs.SnappyFory"),
+        level = DeprecationLevel.ERROR,
+    )
+    @OptIn(BluetapeObsoleteApi::class)
+    @Suppress("DEPRECATION_ERROR")
     val SnappyJdk by lazy { SnappyJdkKafkaCodec() }
+
     val SnappyKryo by lazy { SnappyKryoKafkaCodec() }
     val SnappyFory by lazy { SnappyForyKafkaCodec() }
 
+    @BluetapeObsoleteApi
+    @Deprecated(
+        message = "JDK serialization is unsafe for untrusted bytes. Use KafkaCodecs.ZstdFory instead.",
+        replaceWith = ReplaceWith("KafkaCodecs.ZstdFory"),
+        level = DeprecationLevel.ERROR,
+    )
+    @OptIn(BluetapeObsoleteApi::class)
+    @Suppress("DEPRECATION_ERROR")
     val ZstdJdk by lazy { ZstdJdkKafkaCodec() }
+
     val ZstdKryo by lazy { ZstdKryoKafkaCodec() }
     val ZstdFory by lazy { ZstdForyKafkaCodec() }
 }

--- a/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/codec/KafkaCodecTest.kt
+++ b/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/codec/KafkaCodecTest.kt
@@ -12,11 +12,6 @@ class KafkaCodecTest {
     }
 
     @Nested
-    inner class JdkKafkaCodecTest: AbstractKafkaCodecTest() {
-        override val codec: KafkaCodec<Any?> = KafkaCodecs.Jdk
-    }
-
-    @Nested
     inner class KryoKafkaCodecTest: AbstractKafkaCodecTest() {
         override val codec: KafkaCodec<Any?> = KafkaCodecs.Kryo
     }
@@ -24,11 +19,6 @@ class KafkaCodecTest {
     @Nested
     inner class ForyKafkaCodecTest: AbstractKafkaCodecTest() {
         override val codec: KafkaCodec<Any?> = KafkaCodecs.Fory
-    }
-
-    @Nested
-    inner class Lz4JdkKafkaCodecTest: AbstractKafkaCodecTest() {
-        override val codec: KafkaCodec<Any?> = KafkaCodecs.LZ4Jdk
     }
 
     @Nested
@@ -42,11 +32,6 @@ class KafkaCodecTest {
     }
 
     @Nested
-    inner class SnappyJdkKafkaCodecTest: AbstractKafkaCodecTest() {
-        override val codec: KafkaCodec<Any?> = KafkaCodecs.SnappyJdk
-    }
-
-    @Nested
     inner class SnappyKryoKafkaCodecTest: AbstractKafkaCodecTest() {
         override val codec: KafkaCodec<Any?> = KafkaCodecs.SnappyKryo
     }
@@ -54,11 +39,6 @@ class KafkaCodecTest {
     @Nested
     inner class SnappyForyKafkaCodecTest: AbstractKafkaCodecTest() {
         override val codec: KafkaCodec<Any?> = KafkaCodecs.SnappyFory
-    }
-
-    @Nested
-    inner class ZstdJdkKafkaCodecTest: AbstractKafkaCodecTest() {
-        override val codec: KafkaCodec<Any?> = KafkaCodecs.ZstdJdk
     }
 
     @Nested

--- a/infra/kafka4/README.ko.md
+++ b/infra/kafka4/README.ko.md
@@ -23,8 +23,8 @@ Spring Kafka 4.x, Spring Boot 4, Jackson 3 기준으로 컴파일합니다.
 - `KafkaTemplate`, producer factory, listener container, test utility를 위한
   Spring Kafka 확장 함수.
 - Kafka 4 기준으로 컴파일되는 Kafka Streams helper와 테스트.
-- 문자열, 바이트 배열, Jackson 3 JSON, JDK 직렬화, Kryo, Fory, LZ4/Snappy/Zstd
-  압축 payload codec.
+- 문자열, 바이트 배열, Jackson 3 JSON, Kryo, Fory, LZ4/Snappy/Zstd 압축 payload
+  codec. JDK 직렬화 codec은 obsolete 호환 API이며 명시적 opt-in이 필요합니다.
 - Spring Kafka 4의 KRaft 전용 embedded broker 테스트 지원.
 
 ## 의존성
@@ -131,16 +131,16 @@ Jackson codec은 `bluetape4k-jackson3`와 `tools.jackson.*` API를 사용합니�
 | `KafkaCodecs.String` | UTF-8 문자열 직렬화 |
 | `KafkaCodecs.ByteArray` | 바이트 배열 직접 전달 |
 | `KafkaCodecs.Jackson` | Jackson 3 JSON 직렬화 |
-| `KafkaCodecs.Jdk` | **사용 중단** — Java 직렬화 (RCE 위험, Fory 사용 권장) |
+| `KafkaCodecs.Jdk` | **Obsolete / 컴파일 오류 게이트** — Java 직렬화 (RCE 위험, Fory 사용 권장) |
 | `KafkaCodecs.Kryo` | Kryo 바이너리 직렬화 |
 | `KafkaCodecs.Fory` | Fory 바이너리 직렬화 |
-| `KafkaCodecs.LZ4Jdk` | LZ4 압축 + Java 직렬화 |
+| `KafkaCodecs.LZ4Jdk` | **Obsolete / 컴파일 오류 게이트** — LZ4 압축 + Java 직렬화 |
 | `KafkaCodecs.Lz4Kryo` | LZ4 압축 + Kryo 직렬화 |
 | `KafkaCodecs.Lz4Fory` | LZ4 압축 + Fory 직렬화 |
-| `KafkaCodecs.SnappyJdk` | Snappy 압축 + Java 직렬화 |
+| `KafkaCodecs.SnappyJdk` | **Obsolete / 컴파일 오류 게이트** — Snappy 압축 + Java 직렬화 |
 | `KafkaCodecs.SnappyKryo` | Snappy 압축 + Kryo 직렬화 |
 | `KafkaCodecs.SnappyFory` | Snappy 압축 + Fory 직렬화 |
-| `KafkaCodecs.ZstdJdk` | Zstd 압축 + Java 직렬화 |
+| `KafkaCodecs.ZstdJdk` | **Obsolete / 컴파일 오류 게이트** — Zstd 압축 + Java 직렬화 |
 | `KafkaCodecs.ZstdKryo` | Zstd 압축 + Kryo 직렬화 |
 | `KafkaCodecs.ZstdFory` | Zstd 압축 + Fory 직렬화 |
 
@@ -218,10 +218,11 @@ class LegacyTrustedJacksonCodec : JacksonKafkaCodec() {
 }
 ```
 
-### 보안: JdkKafkaCodec 지원 중단
+### 보안: JDK Kafka Codec Obsolete
 
-`JdkKafkaCodec` 은 JDK 역직렬화 RCE 위험으로 인해 `@Deprecated` 처리되었습니다.
-성능과 보안 모두 우수한 `ForyKafkaCodec` 을 사용하세요.
+`JdkKafkaCodec` 과 압축 JDK 기반 codec은 JDK 역직렬화 RCE 위험 때문에 obsolete
+API입니다. `@BluetapeObsoleteApi` 와 `DeprecationLevel.ERROR` 로 표시되며,
+Fory 계열 codec을 사용하세요.
 
 ## Embedded Kafka 테스트
 

--- a/infra/kafka4/README.md
+++ b/infra/kafka4/README.md
@@ -23,8 +23,9 @@ per application.
 - Spring Kafka extensions for `KafkaTemplate`, producer factories, listener
   containers, and test utilities.
 - Kafka Streams helpers and test coverage compiled against Kafka 4.
-- Codecs for string, byte array, Jackson 3 JSON, JDK serialization, Kryo, Fory,
-  and compressed payloads with LZ4, Snappy, or Zstd.
+- Codecs for string, byte array, Jackson 3 JSON, Kryo, Fory, and compressed
+  payloads with LZ4, Snappy, or Zstd. JDK serialization codecs are obsolete
+  compatibility APIs and require explicit opt-in.
 - Embedded Kafka test support through Spring Kafka 4's KRaft-only broker.
 
 ## Dependency
@@ -132,16 +133,16 @@ Available codecs:
 | `KafkaCodecs.String` | UTF-8 string serialization |
 | `KafkaCodecs.ByteArray` | Raw byte array passthrough |
 | `KafkaCodecs.Jackson` | Jackson 3 JSON serialization |
-| `KafkaCodecs.Jdk` | **Deprecated** — JDK serialization (RCE risk, use Fory) |
+| `KafkaCodecs.Jdk` | **Obsolete / compile-error gated** — JDK serialization (RCE risk, use Fory) |
 | `KafkaCodecs.Kryo` | Kryo binary serialization |
 | `KafkaCodecs.Fory` | Fory binary serialization |
-| `KafkaCodecs.LZ4Jdk` | LZ4 compression + Java serialization |
+| `KafkaCodecs.LZ4Jdk` | **Obsolete / compile-error gated** — LZ4 compression + Java serialization |
 | `KafkaCodecs.Lz4Kryo` | LZ4 compression + Kryo serialization |
 | `KafkaCodecs.Lz4Fory` | LZ4 compression + Fory serialization |
-| `KafkaCodecs.SnappyJdk` | Snappy compression + Java serialization |
+| `KafkaCodecs.SnappyJdk` | **Obsolete / compile-error gated** — Snappy compression + Java serialization |
 | `KafkaCodecs.SnappyKryo` | Snappy compression + Kryo serialization |
 | `KafkaCodecs.SnappyFory` | Snappy compression + Fory serialization |
-| `KafkaCodecs.ZstdJdk` | Zstd compression + Java serialization |
+| `KafkaCodecs.ZstdJdk` | **Obsolete / compile-error gated** — Zstd compression + Java serialization |
 | `KafkaCodecs.ZstdKryo` | Zstd compression + Kryo serialization |
 | `KafkaCodecs.ZstdFory` | Zstd compression + Fory serialization |
 
@@ -220,10 +221,11 @@ class LegacyTrustedJacksonCodec : JacksonKafkaCodec() {
 }
 ```
 
-### Security: JdkKafkaCodec Deprecated
+### Security: JDK Kafka Codecs Obsolete
 
-`JdkKafkaCodec` is deprecated due to JDK deserialization RCE risks. Use
-`ForyKafkaCodec` instead — it is both faster and safer.
+`JdkKafkaCodec` and compressed JDK-backed codecs are obsolete due to JDK
+deserialization RCE risks. They are marked with `@BluetapeObsoleteApi` and
+`DeprecationLevel.ERROR`; use the Fory variants instead.
 
 ## Embedded Kafka Tests
 

--- a/infra/kafka4/build.gradle.kts
+++ b/infra/kafka4/build.gradle.kts
@@ -21,6 +21,7 @@ configurations {
 }
 
 dependencies {
+    api(project(":bluetape4k-annotations"))
     implementation(platform(libs.spring.boot.dependencies))
     api(project(":bluetape4k-core"))
     api(project(":bluetape4k-io"))

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.kafka.codec
 
+import io.bluetape4k.annotations.BluetapeObsoleteApi
 import io.bluetape4k.io.serializer.BinarySerializer
 import io.bluetape4k.io.serializer.BinarySerializers
 import org.apache.kafka.common.header.Headers
@@ -29,22 +30,27 @@ abstract class BinaryKafkaCodec(
 }
 
 /**
- * JDK 직렬화를 이용한 Kafka Codec
+ * Kafka codec backed by JDK serialization.
  *
- * **보안 경고**: JDK 직렬화는 역직렬화 과정에서 임의 코드 실행(RCE) 취약점이 있습니다.
- * 성능과 보안 모두 우수한 [ForyKafkaCodec]을 사용하십시오.
+ * ## Security
+ *
+ * JDK deserialization can execute attacker-controlled object graphs when
+ * untrusted bytes are decoded. Use [ForyKafkaCodec] for new code.
  *
  * ```kotlin
- * val codec = JdkKafkaCodec()
+ * val codec = ForyKafkaCodec()
  * val bytes = codec.serialize("topic", null, "hello")
  * val result = codec.deserialize("topic", null, bytes)
  * // result == "hello"
  * ```
  */
+@BluetapeObsoleteApi
 @Deprecated(
-    message = "JDK 직렬화는 역직렬화 과정에서 임의 코드 실행(RCE) 취약점이 있습니다. 성능과 보안 모두 우수한 ForyKafkaCodec을 사용하세요.",
-    replaceWith = ReplaceWith("ForyKafkaCodec()")
+    message = "JDK serialization is unsafe for untrusted bytes. Use ForyKafkaCodec instead.",
+    replaceWith = ReplaceWith("ForyKafkaCodec()"),
+    level = DeprecationLevel.ERROR,
 )
+@Suppress("DEPRECATION")
 class JdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.Jdk)
 
 /**
@@ -72,15 +78,26 @@ class KryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.Kryo)
 class ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.Fory)
 
 /**
- * LZ4 압축 + JDK 직렬화를 이용한 Kafka Codec
+ * Kafka codec backed by LZ4-compressed JDK serialization.
+ *
+ * ## Security
+ *
+ * JDK deserialization can execute attacker-controlled object graphs when
+ * untrusted bytes are decoded. Use [LZ4ForyKafkaCodec] for new code.
  *
  * ```kotlin
- * val codec = LZ4JdkKafkaCodec()
+ * val codec = LZ4ForyKafkaCodec()
  * val bytes = codec.serialize("topic", null, "hello")
  * val result = codec.deserialize("topic", null, bytes)
  * // result == "hello"
  * ```
  */
+@BluetapeObsoleteApi
+@Deprecated(
+    message = "JDK serialization is unsafe for untrusted bytes. Use LZ4ForyKafkaCodec instead.",
+    replaceWith = ReplaceWith("LZ4ForyKafkaCodec()"),
+    level = DeprecationLevel.ERROR,
+)
 class LZ4JdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Jdk)
 
 /**
@@ -108,15 +125,26 @@ class LZ4KryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Kryo)
 class LZ4ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Fory)
 
 /**
- * Snappy 압축 + JDK 직렬화를 이용한 Kafka Codec
+ * Kafka codec backed by Snappy-compressed JDK serialization.
+ *
+ * ## Security
+ *
+ * JDK deserialization can execute attacker-controlled object graphs when
+ * untrusted bytes are decoded. Use [SnappyForyKafkaCodec] for new code.
  *
  * ```kotlin
- * val codec = SnappyJdkKafkaCodec()
+ * val codec = SnappyForyKafkaCodec()
  * val bytes = codec.serialize("topic", null, "hello")
  * val result = codec.deserialize("topic", null, bytes)
  * // result == "hello"
  * ```
  */
+@BluetapeObsoleteApi
+@Deprecated(
+    message = "JDK serialization is unsafe for untrusted bytes. Use SnappyForyKafkaCodec instead.",
+    replaceWith = ReplaceWith("SnappyForyKafkaCodec()"),
+    level = DeprecationLevel.ERROR,
+)
 class SnappyJdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyJdk)
 
 /**
@@ -143,17 +171,27 @@ class SnappyKryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyKryo)
  */
 class SnappyForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyFory)
 
-
 /**
- * Zstd 압축 + JDK 직렬화를 이용한 Kafka Codec
+ * Kafka codec backed by Zstd-compressed JDK serialization.
+ *
+ * ## Security
+ *
+ * JDK deserialization can execute attacker-controlled object graphs when
+ * untrusted bytes are decoded. Use [ZstdForyKafkaCodec] for new code.
  *
  * ```kotlin
- * val codec = ZstdJdkKafkaCodec()
+ * val codec = ZstdForyKafkaCodec()
  * val bytes = codec.serialize("topic", null, "hello")
  * val result = codec.deserialize("topic", null, bytes)
  * // result == "hello"
  * ```
  */
+@BluetapeObsoleteApi
+@Deprecated(
+    message = "JDK serialization is unsafe for untrusted bytes. Use ZstdForyKafkaCodec instead.",
+    replaceWith = ReplaceWith("ZstdForyKafkaCodec()"),
+    level = DeprecationLevel.ERROR,
+)
 class ZstdJdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.ZstdJdk)
 
 /**

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodecs.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodecs.kt
@@ -1,9 +1,11 @@
 package io.bluetape4k.kafka.codec
 
+import io.bluetape4k.annotations.BluetapeObsoleteApi
+
 /**
  * 다양한 Kafka Codec 인스턴스를 제공하는 Object입니다.
  *
- * 문자열, 바이트 배열, JSON 직렬화 및 다양한 바이너리 직렬화(JDK, Kryo, Fory)와
+ * 문자열, 바이트 배열, JSON 직렬화 및 다양한 바이너리 직렬화(Kryo, Fory)와
  * 압축 알고리즘(LZ4, Snappy, Zstd)을 조합한 Codec을 제공합니다.
  *
  * 사용 예시:
@@ -29,19 +31,55 @@ object KafkaCodecs {
 
     val Jackson by lazy { JacksonKafkaCodec() }
 
+    @BluetapeObsoleteApi
+    @Deprecated(
+        message = "JDK serialization is unsafe for untrusted bytes. Use KafkaCodecs.Fory instead.",
+        replaceWith = ReplaceWith("KafkaCodecs.Fory"),
+        level = DeprecationLevel.ERROR,
+    )
+    @OptIn(BluetapeObsoleteApi::class)
+    @Suppress("DEPRECATION_ERROR")
     val Jdk by lazy { JdkKafkaCodec() }
+
     val Kryo by lazy { KryoKafkaCodec() }
     val Fory by lazy { ForyKafkaCodec() }
 
+    @BluetapeObsoleteApi
+    @Deprecated(
+        message = "JDK serialization is unsafe for untrusted bytes. Use KafkaCodecs.Lz4Fory instead.",
+        replaceWith = ReplaceWith("KafkaCodecs.Lz4Fory"),
+        level = DeprecationLevel.ERROR,
+    )
+    @OptIn(BluetapeObsoleteApi::class)
+    @Suppress("DEPRECATION_ERROR")
     val LZ4Jdk by lazy { LZ4JdkKafkaCodec() }
+
     val Lz4Kryo by lazy { LZ4KryoKafkaCodec() }
     val Lz4Fory by lazy { LZ4ForyKafkaCodec() }
 
+    @BluetapeObsoleteApi
+    @Deprecated(
+        message = "JDK serialization is unsafe for untrusted bytes. Use KafkaCodecs.SnappyFory instead.",
+        replaceWith = ReplaceWith("KafkaCodecs.SnappyFory"),
+        level = DeprecationLevel.ERROR,
+    )
+    @OptIn(BluetapeObsoleteApi::class)
+    @Suppress("DEPRECATION_ERROR")
     val SnappyJdk by lazy { SnappyJdkKafkaCodec() }
+
     val SnappyKryo by lazy { SnappyKryoKafkaCodec() }
     val SnappyFory by lazy { SnappyForyKafkaCodec() }
 
+    @BluetapeObsoleteApi
+    @Deprecated(
+        message = "JDK serialization is unsafe for untrusted bytes. Use KafkaCodecs.ZstdFory instead.",
+        replaceWith = ReplaceWith("KafkaCodecs.ZstdFory"),
+        level = DeprecationLevel.ERROR,
+    )
+    @OptIn(BluetapeObsoleteApi::class)
+    @Suppress("DEPRECATION_ERROR")
     val ZstdJdk by lazy { ZstdJdkKafkaCodec() }
+
     val ZstdKryo by lazy { ZstdKryoKafkaCodec() }
     val ZstdFory by lazy { ZstdForyKafkaCodec() }
 }

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/KafkaCodecTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/KafkaCodecTest.kt
@@ -12,11 +12,6 @@ class KafkaCodecTest {
     }
 
     @Nested
-    inner class JdkKafkaCodecTest: AbstractKafkaCodecTest() {
-        override val codec: KafkaCodec<Any?> = KafkaCodecs.Jdk
-    }
-
-    @Nested
     inner class KryoKafkaCodecTest: AbstractKafkaCodecTest() {
         override val codec: KafkaCodec<Any?> = KafkaCodecs.Kryo
     }
@@ -24,11 +19,6 @@ class KafkaCodecTest {
     @Nested
     inner class ForyKafkaCodecTest: AbstractKafkaCodecTest() {
         override val codec: KafkaCodec<Any?> = KafkaCodecs.Fory
-    }
-
-    @Nested
-    inner class Lz4JdkKafkaCodecTest: AbstractKafkaCodecTest() {
-        override val codec: KafkaCodec<Any?> = KafkaCodecs.LZ4Jdk
     }
 
     @Nested
@@ -42,11 +32,6 @@ class KafkaCodecTest {
     }
 
     @Nested
-    inner class SnappyJdkKafkaCodecTest: AbstractKafkaCodecTest() {
-        override val codec: KafkaCodec<Any?> = KafkaCodecs.SnappyJdk
-    }
-
-    @Nested
     inner class SnappyKryoKafkaCodecTest: AbstractKafkaCodecTest() {
         override val codec: KafkaCodec<Any?> = KafkaCodecs.SnappyKryo
     }
@@ -54,11 +39,6 @@ class KafkaCodecTest {
     @Nested
     inner class SnappyForyKafkaCodecTest: AbstractKafkaCodecTest() {
         override val codec: KafkaCodec<Any?> = KafkaCodecs.SnappyFory
-    }
-
-    @Nested
-    inner class ZstdJdkKafkaCodecTest: AbstractKafkaCodecTest() {
-        override val codec: KafkaCodec<Any?> = KafkaCodecs.ZstdJdk
     }
 
     @Nested


### PR DESCRIPTION
## Summary

Closes #539

- PR 제목: chore: gate unsafe Kafka JDK codecs

- Mark JDK-backed kafka/kafka4 codec classes and registry properties as `@BluetapeObsoleteApi`.
- Raise the same APIs to `DeprecationLevel.ERROR` and point replacements to Fory variants.
- Remove JDK codec round-trip test coverage while keeping Kryo/Fory coverage.
- Update README codec tables, deprecated inventory, and issue lesson notes.

Closes #539
Refs #474

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Current-session review

- Native code-reviewer pass found one stale deprecated-inventory note; fixed before PR.
- No blocker remains for `@RequiresOptIn`/`@Deprecated(ERROR)` usage, annotation dependency exposure, or security messaging.

### 기존 섹션: Notes

- This keeps binary/source symbols available as explicit compatibility bridges. Final removal remains the #474 breaking cleanup step.

## Validation

- IntelliJ imports optimized for touched Kotlin files.
- IntelliJ index ready; file diagnostics were not fresh because files were not open in the editor.
- `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka:test --tests 'io.bluetape4k.kafka.codec.KafkaCodecTest' --console=plain --no-configuration-cache`
- `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka4:test --tests 'io.bluetape4k.kafka.codec.KafkaCodecTest' --console=plain --no-configuration-cache`
- `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka:test --tests 'io.bluetape4k.kafka.codec.KafkaCodecTest' :bluetape4k-kafka4:test --tests 'io.bluetape4k.kafka.codec.KafkaCodecTest' --console=plain --no-configuration-cache`
- `git diff --check`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #539, milestone `1.8.1`, assignee `debop`
- PR: #564, head `a3d2d9828636e0943c7366b5c682ff4b8bca1958`, milestone `1.8.1`, assignee `debop`
- Base: `develop`, head branch `chore/issue-539-binary-kafka-codecs`
- Labels: `chore`, `security`
- State: `MERGED`, merge commit `9fb74c250eb3cd3a84ea2c0128e1fd5109976948`
- CI: - `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka:test --tests 'io.bluetape4k.kafka.codec.KafkaCodecTest' --console=plain --no-configuration-cache` / - `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka4:test --tests 'io.bluetape4k.kafka.codec.KafkaCodecTest' --console=plain --no-configuration-cache` / - `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka:test --tests 'io.bluetape4k.kafka.codec.KafkaCodecTest' :bluetape4k-kafka4:test --tests 'io.bluetape4k.kafka.codec.KafkaCodecTest' --console=plain --no-configuration-cache`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #564 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9fb74c250eb3cd3a84ea2c0128e1fd5109976948`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
