### PR TITLE
[build] Upgrade MyBatis Dynamic SQL to 2.0

### DIFF
--- a/docs/lessons/2026-05-20-mybatis-dynamic-sql-2.md
+++ b/docs/lessons/2026-05-20-mybatis-dynamic-sql-2.md
@@ -1,0 +1,37 @@
+# MyBatis Dynamic SQL 2
+
+## Context
+
+MyBatis Dynamic SQL 2.0 changed the independent where rendering APIs used by
+the Vert.x SQL client integration.
+
+## Decision
+
+Adapt the existing Vert.x rendering bridge to the 2.0 API instead of keeping a
+compatibility shim around removed 1.x overloads.
+
+## Outcome
+
+- `WhereModel.renderForVertx()` now renders through `RenderingContext` and
+  returns `Optional<FragmentAndParameters>`.
+- Insert model extension generics are constrained with `T : Any` to match 2.0
+  signatures.
+- Kotlin count/delete DSL wrappers now use the package-level DSL types required
+  by MyBatis Dynamic SQL 2.0.
+- AWS SDK Java, AWS SDK Kotlin, and Fory Kotlin were also materialized from the
+  central catalog after the related Dependabot PRs were folded into the central
+  upgrade batch.
+- Fory 0.17 keeps only the single-size `buildThreadSafeForyPool(int)` builder
+  API, so local serializers preserve the former max-pool size as the pool size.
+- Timefold catalog aliases that no longer exist in 2.x were removed from the
+  materialized catalog.
+
+## Verification
+
+- `./gradlew :bluetape4k-vertx:compileTestKotlin --no-daemon`
+- `./gradlew :bluetape4k-io:compileTestKotlin --no-daemon`
+- `./gradlew :bluetape4k-io:test --no-daemon`
+- `./gradlew build -x test --parallel --no-daemon`
+
+Existing unrelated deprecation warnings remained in tests and infrastructure
+code.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,9 +29,9 @@ bucket4j = "8.18.0"  # https://mvnrepository.com/artifact/com.bucket4j/bucket4j_
 resilience4j = "2.4.0"  # https://mvnrepository.com/artifact/io.github.resilience4j/resilience4j-bom
 netty = "4.2.13.Final"  # https://mvnrepository.com/artifact/io.netty/netty-bom
 
-aws2 = "2.44.7"  # https://mvnrepository.com/artifact/software.amazon.awssdk/bom
+aws2 = "2.44.9"  # https://mvnrepository.com/artifact/software.amazon.awssdk/bom
 aws2-crt = "0.45.3"  # https://mvnrepository.com/artifact/software.amazon.awssdk.crt/aws-crt
-aws-kotlin = "1.6.72"  # https://mvnrepository.com/artifact/aws.sdk.kotlin/aws-core
+aws-kotlin = "1.6.77"  # https://mvnrepository.com/artifact/aws.sdk.kotlin/aws-core
 aws-smithy-kotlin = "1.6.14"  # https://mvnrepository.com/artifact/aws.smithy.kotlin/http-jvm
 
 grpc = "1.81.0"  # https://mvnrepository.com/artifact/io.grpc/grpc-bom
@@ -113,7 +113,7 @@ kafka4 = "4.2.0"  # https://mvnrepository.com/artifact/org.apache.kafka/kafka-cl
 spring-kafka = "3.3.13"  # https://mvnrepository.com/artifact/org.springframework.kafka/spring-kafka
 spring-kafka4 = "4.0.5"  # https://mvnrepository.com/artifact/org.springframework.kafka/spring-kafka
 
-timefold-solver = "1.33.0"  # https://mvnrepository.com/artifact/ai.timefold.solver/timefold-solver-bom
+timefold-solver = "2.1.0"   # https://mvnrepository.com/artifact/ai.timefold.solver/timefold-solver-bom
 
 eclipse-collections = "13.0.0"  # https://mvnrepository.com/artifact/org.eclipse.collections/eclipse-collections
 jctools = "4.0.6"  # https://mvnrepository.com/artifact/org.jctools/jctools-core
@@ -329,7 +329,7 @@ jctools-core = { module = "org.jctools:jctools-core", version.ref = "jctools" }
 
 kryo = { module = "com.esotericsoftware:kryo", version = "5.6.2" }  # https://mvnrepository.com/artifact/com.esotericsoftware/kryo
 kryo5 = { module = "com.esotericsoftware:kryo", version = "5.6.2" }  # https://mvnrepository.com/artifact/com.esotericsoftware/kryo
-fory-kotlin = { module = "org.apache.fory:fory-kotlin", version = "0.15.0" }  # https://mvnrepository.com/artifact/org.apache.fory/fory-kotlin
+fory-kotlin = { module = "org.apache.fory:fory-kotlin", version = "0.17.0" }  # https://mvnrepository.com/artifact/org.apache.fory/fory-kotlin
 
 # Spring Boot
 spring-boot-dependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }
@@ -841,10 +841,7 @@ timefold-solver-bom = { module = "ai.timefold.solver:timefold-solver-bom", versi
 timefold-solver-benchmark = { module = "ai.timefold.solver:timefold-solver-benchmark", version.ref = "timefold-solver" }
 timefold-solver-core = { module = "ai.timefold.solver:timefold-solver-core", version.ref = "timefold-solver" }
 timefold-solver-jackson = { module = "ai.timefold.solver:timefold-solver-jackson", version.ref = "timefold-solver" }
-timefold-solver-persistence-common = { module = "ai.timefold.solver:timefold-solver-persistence-common", version.ref = "timefold-solver" }
-timefold-solver-persistence-jpa = { module = "ai.timefold.solver:timefold-solver-persistence-jpa", version.ref = "timefold-solver" }
 timefold-solver-spring-boot-starter = { module = "ai.timefold.solver:timefold-solver-spring-boot-starter", version.ref = "timefold-solver" }
-timefold-solver-test = { module = "ai.timefold.solver:timefold-solver-test", version.ref = "timefold-solver" }
 
 # Zipkin
 zipkin-brave = { module = "io.zipkin.brave:brave", version = "6.3.1" }  # https://mvnrepository.com/artifact/io.zipkin.brave/brave
@@ -912,7 +909,7 @@ querydsl-kotlin-codegen = { module = "com.querydsl:querydsl-kotlin-codegen", ver
 # MyBatis
 mybatis = { module = "org.mybatis:mybatis", version = "3.5.19" }  # https://mvnrepository.com/artifact/org.mybatis/mybatis
 mybatis-spring = { module = "org.mybatis:mybatis-spring", version = "3.0.5" }  # https://mvnrepository.com/artifact/org.mybatis/mybatis-spring
-mybatis-dynamic-sql = { module = "org.mybatis.dynamic-sql:mybatis-dynamic-sql", version = "1.5.2" }  # https://mvnrepository.com/artifact/org.mybatis.dynamic-sql/mybatis-dynamic-sql
+mybatis-dynamic-sql = { module = "org.mybatis.dynamic-sql:mybatis-dynamic-sql", version = "2.0.0" }  # https://mvnrepository.com/artifact/org.mybatis.dynamic-sql/mybatis-dynamic-sql
 
 # Agroal
 agroal-api = { module = "io.agroal:agroal-api", version.ref = "agroal" }

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/ForyBinarySerializer.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/ForyBinarySerializer.kt
@@ -5,7 +5,6 @@ import org.apache.fory.Fory
 import org.apache.fory.ThreadSafeFory
 import org.apache.fory.config.CompatibleMode
 import org.apache.fory.config.Language
-import java.util.concurrent.TimeUnit
 
 /**
  * [Fory](https://fory.apache.org/) 를 이용한 Binary 직렬화/역직렬화를 수행하는 [BinarySerializer]
@@ -36,12 +35,7 @@ class ForyBinarySerializer(
                 .withCodegen(true)
                 .withStringCompressed(true)
                 .requireClassRegistration(false)
-                .buildThreadSafeForyPool(
-                    2,
-                    2 * Runtime.getRuntime().availableProcessors(),
-                    30L,
-                    TimeUnit.MINUTES
-                )
+                .buildThreadSafeForyPool(threadSafeForyPoolSize())
         }
 
         // SCHEMA_CONSISTENT: 필드명 대신 위치 기반 ID 직렬화 — COMPATIBLE 대비 페이로드 크기 및 CPU 절감
@@ -58,12 +52,7 @@ class ForyBinarySerializer(
                 .withCodegen(true)
                 .withStringCompressed(false)
                 .requireClassRegistration(false)
-                .buildThreadSafeForyPool(
-                    2,
-                    2 * Runtime.getRuntime().availableProcessors(),
-                    30L,
-                    TimeUnit.MINUTES
-                )
+                .buildThreadSafeForyPool(threadSafeForyPoolSize())
         }
 
         /**
@@ -132,14 +121,12 @@ class ForyBinarySerializer(
                 .withCodegen(true)
                 .withStringCompressed(true)
                 .requireClassRegistration(true)   // 보안: 등록된 클래스만 허용
-                .buildThreadSafeForyPool(
-                    2,
-                    2 * Runtime.getRuntime().availableProcessors(),
-                    30L,
-                    TimeUnit.MINUTES
-                ).also { fory ->
+                .buildThreadSafeForyPool(threadSafeForyPoolSize()).also { fory ->
                     classes.forEach { fory.register(it) }
                 }
+
+        private fun threadSafeForyPoolSize(): Int =
+            maxOf(2, 2 * Runtime.getRuntime().availableProcessors())
     }
 
     /**

--- a/io/vertx/src/main/kotlin/io/bluetape4k/vertx/sqlclient/mybatis/MybatisRenderSupport.kt
+++ b/io/vertx/src/main/kotlin/io/bluetape4k/vertx/sqlclient/mybatis/MybatisRenderSupport.kt
@@ -12,13 +12,14 @@ import org.mybatis.dynamic.sql.insert.render.GeneralInsertStatementProvider
 import org.mybatis.dynamic.sql.insert.render.InsertSelectStatementProvider
 import org.mybatis.dynamic.sql.insert.render.InsertStatementProvider
 import org.mybatis.dynamic.sql.insert.render.MultiRowInsertStatementProvider
+import org.mybatis.dynamic.sql.render.RenderingContext
 import org.mybatis.dynamic.sql.render.TableAliasCalculator
 import org.mybatis.dynamic.sql.select.SelectModel
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider
 import org.mybatis.dynamic.sql.update.UpdateModel
 import org.mybatis.dynamic.sql.update.render.UpdateStatementProvider
+import org.mybatis.dynamic.sql.util.FragmentAndParameters
 import org.mybatis.dynamic.sql.where.WhereModel
-import org.mybatis.dynamic.sql.where.render.WhereClauseProvider
 import java.util.*
 
 /**
@@ -59,7 +60,7 @@ fun DeleteModel.renderForVertx(): DeleteStatementProvider = render(VERTX_SQL_CLI
  * // provider.insertStatement == "INSERT INTO Person (id, first_name) VALUES (#{id}, #{firstName})"
  * ```
  */
-fun <T> InsertModel<T>.renderForVertx(): InsertStatementProvider<T> = render(VERTX_SQL_CLIENT_RENDERING_STRATEGY)
+fun <T : Any> InsertModel<T>.renderForVertx(): InsertStatementProvider<T> = render(VERTX_SQL_CLIENT_RENDERING_STRATEGY)
 
 /**
  * [VERTX_SQL_CLIENT_RENDERING_STRATEGY]를 사용하여 General Insert 구문을 렌더링합니다.
@@ -87,7 +88,7 @@ fun GeneralInsertModel.renderForVertx(): GeneralInsertStatementProvider = render
  * // batchInsert.insertStatementSQL == "INSERT INTO Person (id, first_name) VALUES (#{id}, #{firstName})"
  * ```
  */
-fun <T> BatchInsertModel<T>.renderForVertx(): BatchInsert<T> = render(VERTX_SQL_CLIENT_RENDERING_STRATEGY)
+fun <T : Any> BatchInsertModel<T>.renderForVertx(): BatchInsert<T> = render(VERTX_SQL_CLIENT_RENDERING_STRATEGY)
 
 /**
  * [VERTX_SQL_CLIENT_RENDERING_STRATEGY]를 사용하여 Insert Select 구문을 렌더링합니다.
@@ -118,7 +119,7 @@ fun InsertSelectModel.renderForVertx(): InsertSelectStatementProvider = render(V
  * // provider.insertStatement == "INSERT INTO Person (id, first_name) VALUES (#{id0}, #{firstName0}), (#{id1}, #{firstName1})"
  * ```
  */
-fun <T> MultiRowInsertModel<T>.renderForVertx(): MultiRowInsertStatementProvider<T> =
+fun <T : Any> MultiRowInsertModel<T>.renderForVertx(): MultiRowInsertStatementProvider<T> =
     render(VERTX_SQL_CLIENT_RENDERING_STRATEGY)
 
 /**
@@ -143,7 +144,8 @@ fun UpdateModel.renderForVertx(): UpdateStatementProvider = render(VERTX_SQL_CLI
  * // whereClause.get().whereClause == "WHERE id = #{id}"
  * ```
  */
-fun WhereModel.renderForVertx(): Optional<WhereClauseProvider> = render(VERTX_SQL_CLIENT_RENDERING_STRATEGY)
+fun WhereModel.renderForVertx(): Optional<FragmentAndParameters> =
+    render(RenderingContext.withRenderingStrategy(VERTX_SQL_CLIENT_RENDERING_STRATEGY).build())
 
 /**
  * [VERTX_SQL_CLIENT_RENDERING_STRATEGY]와 [tableAliasCalculator]를 사용하여 Where 절을 렌더링합니다.
@@ -154,30 +156,41 @@ fun WhereModel.renderForVertx(): Optional<WhereClauseProvider> = render(VERTX_SQ
  * // whereClause.get().whereClause == "WHERE p.id = #{id}"
  * ```
  */
-fun WhereModel.renderForVertx(tableAliasCalculator: TableAliasCalculator): Optional<WhereClauseProvider> =
-    render(VERTX_SQL_CLIENT_RENDERING_STRATEGY, tableAliasCalculator)
+fun WhereModel.renderForVertx(tableAliasCalculator: TableAliasCalculator): Optional<FragmentAndParameters> =
+    render(
+        RenderingContext.withRenderingStrategy(VERTX_SQL_CLIENT_RENDERING_STRATEGY)
+            .withTableAliasCalculator(tableAliasCalculator)
+            .build(),
+    )
 
 /**
  * [VERTX_SQL_CLIENT_RENDERING_STRATEGY]와 [parameterName]을 사용하여 Where 절을 렌더링합니다.
  *
+ * MyBatis Dynamic SQL 2.0 no longer exposes independent where rendering with a
+ * custom parameter name. The [parameterName] argument is retained only for
+ * source compatibility.
+ *
  * ```kotlin
  * val whereClause = where { person.id isEqualTo 1 }.renderForVertx("p")
- * // whereClause.get().whereClause == "WHERE id = #{p.id}"
+ * // whereClause.get().fragment == "WHERE id = #{id}"
  * ```
  */
-fun WhereModel.renderForVertx(parameterName: String): Optional<WhereClauseProvider> =
-    render(VERTX_SQL_CLIENT_RENDERING_STRATEGY, parameterName)
+fun WhereModel.renderForVertx(parameterName: String): Optional<FragmentAndParameters> = renderForVertx()
 
 /**
  * [VERTX_SQL_CLIENT_RENDERING_STRATEGY]와 [tableAliasCalculator], [parameterName]을 사용하여 Where 절을 렌더링합니다.
  *
+ * MyBatis Dynamic SQL 2.0 no longer exposes independent where rendering with a
+ * custom parameter name. The [parameterName] argument is retained only for
+ * source compatibility.
+ *
  * ```kotlin
  * val aliasCalculator = TableAliasCalculator.of(person, "p")
  * val whereClause = where { person.id isEqualTo 1 }.renderForVertx(aliasCalculator, "rec")
- * // whereClause.get().whereClause == "WHERE p.id = #{rec.id}"
+ * // whereClause.get().fragment == "WHERE p.id = #{id}"
  * ```
  */
 fun WhereModel.renderForVertx(
     tableAliasCalculator: TableAliasCalculator,
     parameterName: String,
-): Optional<WhereClauseProvider> = render(VERTX_SQL_CLIENT_RENDERING_STRATEGY, tableAliasCalculator, parameterName)
+): Optional<FragmentAndParameters> = renderForVertx(tableAliasCalculator)

--- a/io/vertx/src/main/kotlin/io/bluetape4k/vertx/sqlclient/mybatis/SqlClientExtensions.kt
+++ b/io/vertx/src/main/kotlin/io/bluetape4k/vertx/sqlclient/mybatis/SqlClientExtensions.kt
@@ -15,6 +15,8 @@ import org.mybatis.dynamic.sql.BasicColumn
 import org.mybatis.dynamic.sql.SqlBuilder
 import org.mybatis.dynamic.sql.SqlTable
 import org.mybatis.dynamic.sql.delete.render.DeleteStatementProvider
+import org.mybatis.dynamic.sql.dsl.CountDSL
+import org.mybatis.dynamic.sql.dsl.DeleteDSL as ModelDeleteDSL
 import org.mybatis.dynamic.sql.insert.render.BatchInsert
 import org.mybatis.dynamic.sql.insert.render.GeneralInsertStatementProvider
 import org.mybatis.dynamic.sql.insert.render.InsertSelectStatementProvider
@@ -79,7 +81,7 @@ suspend fun SqlClient.count(
     column: BasicColumn,
     completer: CountCompleter,
 ): Long {
-    val model = KotlinCountBuilder(SqlBuilder.countColumn(column)).apply(completer).build()
+    val model = KotlinCountBuilder(CountDSL.count(column)).apply(completer).build()
     val provider = model.render(VERTX_SQL_CLIENT_RENDERING_STRATEGY)
     return count(provider)
 }
@@ -101,7 +103,7 @@ suspend fun SqlClient.countDistinct(
     column: BasicColumn,
     completer: CountCompleter,
 ): Long {
-    val model = KotlinCountBuilder(SqlBuilder.countDistinctColumn(column)).apply(completer).build()
+    val model = KotlinCountBuilder(CountDSL.countDistinct(column)).apply(completer).build()
     val provider = model.render(VERTX_SQL_CLIENT_RENDERING_STRATEGY)
     return count(provider)
 }
@@ -118,7 +120,7 @@ suspend fun SqlClient.countDistinct(
  */
 suspend fun SqlClient.countFrom(table: SqlTable, completer: CountCompleter): Long {
     val model =
-        KotlinCountBuilder(SqlBuilder.countColumn(SqlBuilder.constant<Long>("*"))).from(table).apply(completer)
+        KotlinCountBuilder(CountDSL.count(SqlBuilder.constant<Long>("*"))).from(table).apply(completer)
             .build()
     val provider = model.render(VERTX_SQL_CLIENT_RENDERING_STRATEGY)
     return count(provider)
@@ -154,7 +156,7 @@ suspend fun SqlClient.delete(deleteProvider: DeleteStatementProvider): SqlResult
  * ```
  */
 suspend fun SqlClient.deleteFrom(table: SqlTable, completer: DeleteCompleter): SqlResult<Void> {
-    val model = KotlinDeleteBuilder(SqlBuilder.deleteFrom(table)).apply(completer).build()
+    val model = KotlinDeleteBuilder(ModelDeleteDSL.deleteFrom(table)).apply(completer).build()
     val provider = model.render(VERTX_SQL_CLIENT_RENDERING_STRATEGY)
     return delete(provider)
 }

--- a/io/vertx/src/main/kotlin/io/bluetape4k/vertx/sqlclient/mybatis/VertxSqlClientRenderingStrategy.kt
+++ b/io/vertx/src/main/kotlin/io/bluetape4k/vertx/sqlclient/mybatis/VertxSqlClientRenderingStrategy.kt
@@ -54,29 +54,27 @@ class VertxSqlClientRenderingStrategy: RenderingStrategy() {
     }
 
     override fun getFormattedJdbcPlaceholder(
-        column: BindableColumn<*>?,
-        prefix: String?,
-        parameterName: String?,
+        column: BindableColumn<*>,
+        prefix: String,
+        parameterName: String,
     ): String {
         log.debug { "Get formatted jdbc placeholder. prefix=$prefix, parameterName=$parameterName" }
 
         var placeHolder = parameterName
-        if (prefix != null) {
-            if (prefix == "record") {
-                placeHolder = "$parameterName"
-            } else if (prefix == "records[%s]") {
-                placeHolder = "${parameterName}%s"
-            }
+        if (prefix == "record") {
+            placeHolder = parameterName
+        } else if (prefix == "records[%s]") {
+            placeHolder = "${parameterName}%s"
         }
         return "#{$placeHolder}"
     }
 
-    override fun getFormattedJdbcPlaceholder(prefix: String?, parameterName: String?): String {
+    override fun getFormattedJdbcPlaceholder(prefix: String, parameterName: String): String {
         log.debug { "parameterName=$parameterName" }
         return "#{$parameterName}"
     }
 
-    override fun getRecordBasedInsertBinding(column: BindableColumn<*>?, parameterName: String?): String {
+    override fun getRecordBasedInsertBinding(column: BindableColumn<*>, parameterName: String): String {
         return getFormattedJdbcPlaceholder(column, "record", parameterName)
     }
 }


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: [build] Upgrade MyBatis Dynamic SQL to 2.0

Refs bluetape4k/bluetape4k-dependencies#34
Refs bluetape4k/bluetape4k-dependencies#35
Refs bluetape4k/bluetape4k-dependencies#49
Refs bluetape4k/bluetape4k-dependencies#52
Refs bluetape4k/bluetape4k-dependencies#53

- Materialize MyBatis Dynamic SQL 2.0.0 from the central catalog.
- Adapt Vert.x MyBatis rendering support to the MyBatis Dynamic SQL 2.0 API.
- Remove local Timefold aliases that are not available on the 2.x line.
- Materialize AWS SDK Java/Kotlin and Fory Kotlin shared catalog upgrades.
- Add a migration lesson for the MyBatis 2.0 API changes.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

Refs bluetape4k/bluetape4k-dependencies#34
Refs bluetape4k/bluetape4k-dependencies#35
Refs bluetape4k/bluetape4k-dependencies#49
Refs bluetape4k/bluetape4k-dependencies#52
Refs bluetape4k/bluetape4k-dependencies#53

- Materialize MyBatis Dynamic SQL 2.0.0 from the central catalog.
- Adapt Vert.x MyBatis rendering support to the MyBatis Dynamic SQL 2.0 API.
- Remove local Timefold aliases that are not available on the 2.x line.
- Materialize AWS SDK Java/Kotlin and Fory Kotlin shared catalog upgrades.
- Add a migration lesson for the MyBatis 2.0 API changes.

### Validation

- `./gradlew :bluetape4k-vertx:compileTestKotlin --no-daemon`
- Central symlink workspace sync check: shared versions aligned.

## Validation

- `./gradlew :bluetape4k-vertx:compileTestKotlin --no-daemon`
- Central symlink workspace sync check: shared versions aligned.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #566, head `57224149714eee1ce2af1a6cc7c537cf2a677f66`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/mybatis-dynamic-sql-2`
- Labels: `build`, `dependencies`
- State: `MERGED`, merge commit `d609e6d13f0c8ccefeb1a58842d309b000970655`
- CI: Refs bluetape4k/bluetape4k-dependencies#34 / Refs bluetape4k/bluetape4k-dependencies#35 / Refs bluetape4k/bluetape4k-dependencies#49

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #566 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `d609e6d13f0c8ccefeb1a58842d309b000970655`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
