### PR TITLE
[test] Add disabled-test release gate

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import io.bluetape4k.gradle.applyBluetape4kPomMetadata
 import io.bluetape4k.gradle.centralSnapshotsRepository
 import io.bluetape4k.gradle.configurePublishingSigning
+import io.bluetape4k.gradle.DisabledTestReportTask
 import io.bluetape4k.gradle.resolveCentralPublishingConfig
 import io.bluetape4k.gradle.resolvePublishingSigningConfig
 import io.gitlab.arturbosch.detekt.Detekt
@@ -8,6 +9,7 @@ import io.gitlab.arturbosch.detekt.report.ReportMergeTask
 import nmcp.NmcpAggregationExtension
 import nmcp.NmcpExtension
 import org.gradle.api.Project
+import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import java.io.File
 
@@ -749,4 +751,22 @@ dependencies {
                     !sub.isSampleOrBenchmarkProject()
         }
         .forEach { sub -> kover(project(sub.path)) }
+}
+
+// ── Disabled Test Release Gate ──────────────────────────────────────────────
+val checkDisabledTests by tasks.registering(DisabledTestReportTask::class) {
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    description = "Scans JUnit disabled tests and fails known-bug skips without GitHub issue references."
+    sourceRoot.set(layout.projectDirectory)
+    sourceFiles.from(
+        fileTree(layout.projectDirectory) {
+            include("**/src/test/**/*.kt", "**/src/test/**/*.java")
+            exclude("**/build/**", ".gradle/**", ".git/**", ".worktrees/**", "buildSrc/**")
+        },
+    )
+    reportFile.set(layout.buildDirectory.file("reports/disabled-tests/disabled-tests.md"))
+}
+
+tasks.named("check") {
+    dependsOn(checkDisabledTests)
 }

--- a/buildSrc/src/main/kotlin/DisabledTestReportTask.kt
+++ b/buildSrc/src/main/kotlin/DisabledTestReportTask.kt
@@ -1,0 +1,300 @@
+package io.bluetape4k.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+import java.io.Serializable
+
+/**
+ * Scans test sources for JUnit disabled-test annotations and writes a release
+ * report that keeps skipped tests visible.
+ */
+abstract class DisabledTestReportTask : DefaultTask() {
+
+    @get:Internal
+    abstract val sourceRoot: DirectoryProperty
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    val sourceFiles: ConfigurableFileCollection = project.objects.fileCollection()
+
+    @get:OutputFile
+    abstract val reportFile: RegularFileProperty
+
+    @get:Input
+    abstract val failOnKnownBugWithoutIssue: Property<Boolean>
+
+    init {
+        failOnKnownBugWithoutIssue.convention(true)
+    }
+
+    @TaskAction
+    fun generateReport() {
+        val scanResult = DisabledTestScanner.scan(sourceRoot.get().asFile, sourceFiles.files)
+        val outputFile = reportFile.get().asFile
+        outputFile.parentFile.mkdirs()
+        outputFile.writeText(DisabledTestReportRenderer.render(scanResult))
+
+        if (failOnKnownBugWithoutIssue.get() && scanResult.violations.isNotEmpty()) {
+            val summary = scanResult.violations.joinToString(separator = "\n") { violation ->
+                "- ${violation.entry.relativePath}:${violation.entry.line}: ${violation.message}"
+            }
+            throw GradleException(
+                "Known-bug disabled tests must include a GitHub issue reference.\n" +
+                        "Report: ${outputFile.relativeTo(sourceRoot.get().asFile)}\n" +
+                        summary,
+            )
+        }
+
+        logger.lifecycle("Disabled test report written to {}", outputFile)
+    }
+}
+
+object DisabledTestScanner {
+
+    private val disabledRegex = Regex("""@Disabled(?![A-Za-z])(?:\((.*)\))?""")
+    private val conditionalDisabledRegex = Regex("""@DisabledIf[A-Za-z]*\((.*)\)""")
+    private val stringLiteralRegex = Regex(""""((?:\\.|[^"\\])*)"""")
+    private val issueRegex = Regex("""#\d+""")
+    private val testSourceRegex = Regex("""(^|/)src/test/(kotlin|java)/""")
+
+    fun scan(rootDir: File, sourceFiles: Iterable<File>? = null): DisabledTestScanResult {
+        val candidateFiles = sourceFiles?.asSequence()
+            ?: rootDir.walkTopDown()
+                .onEnter { file -> file.name !in ignoredDirectories }
+
+        val entries = candidateFiles
+            .filter { file -> file.isFile && file.extension in setOf("kt", "java") }
+            .filter { file -> testSourceRegex.containsMatchIn(file.toRelativeString(rootDir).normalizePath()) }
+            .flatMap { file -> scanFile(rootDir, file).asSequence() }
+            .sortedWith(compareBy<DisabledTestEntry> { it.relativePath }.thenBy { it.line })
+            .toList()
+
+        val violations = entries
+            .filter { entry -> entry.category == DisabledTestCategory.KNOWN_BUG.id && entry.trackingIssue == null }
+            .map { entry ->
+                DisabledTestViolation(
+                    entry = entry,
+                    message = "category=${entry.category} requires a tracking issue in the @Disabled reason",
+                )
+            }
+
+        return DisabledTestScanResult(entries = entries, violations = violations)
+    }
+
+    private fun scanFile(rootDir: File, file: File): List<DisabledTestEntry> {
+        val relativePath = file.toRelativeString(rootDir).normalizePath()
+        val lines = file.readLines()
+
+        return lines.mapIndexedNotNull { index, line ->
+            val trimmed = line.trim()
+            if (trimmed.startsWith("//") || trimmed.startsWith("*")) {
+                return@mapIndexedNotNull null
+            }
+
+            val disabledMatch = disabledRegex.find(trimmed)
+            val conditionalMatch = conditionalDisabledRegex.find(trimmed)
+            val annotation = when {
+                disabledMatch != null -> "@Disabled"
+                conditionalMatch != null -> "@DisabledIf"
+                else -> return@mapIndexedNotNull null
+            }
+            val argumentText = disabledMatch?.groupValues?.getOrNull(1)
+                ?: conditionalMatch?.groupValues?.getOrNull(1)
+                ?: ""
+            val reason = extractReason(argumentText)
+            val category = inferCategory(annotation, reason, relativePath)
+            val target = findAnnotatedTarget(lines, index)
+
+            DisabledTestEntry(
+                module = inferModule(relativePath),
+                relativePath = relativePath,
+                line = index + 1,
+                target = target.name,
+                level = target.level,
+                category = category.id,
+                trackingIssue = issueRegex.find(reason)?.value,
+                reason = reason.ifBlank { "(no reason)" },
+                annotation = annotation,
+            )
+        }
+    }
+
+    private fun extractReason(argumentText: String): String {
+        val literal = stringLiteralRegex.find(argumentText)?.groupValues?.getOrNull(1)
+        return literal?.replace("\\\"", "\"")?.replace("\\n", " ") ?: argumentText.trim()
+    }
+
+    private fun inferCategory(annotation: String, reason: String, relativePath: String): DisabledTestCategory {
+        if (annotation == "@DisabledIf") {
+            return DisabledTestCategory.CONDITIONAL_ENVIRONMENT
+        }
+
+        val text = "${reason.lowercase()} ${relativePath.lowercase()}"
+        return when {
+            unsupportedCapabilityRegex.containsMatchIn(text) ->
+                DisabledTestCategory.UNSUPPORTED_CAPABILITY
+
+            listOf("slow", "expensive", "large", "오래", "빈도가 낮", "사이즈").any(text::contains) ->
+                DisabledTestCategory.SLOW_OPTIONAL
+
+            environmentRegex.containsMatchIn(text) ->
+                DisabledTestCategory.ENVIRONMENT_MANUAL
+
+            relativePath.startsWith("examples/") ->
+                DisabledTestCategory.INTENTIONAL_EXAMPLE
+
+            listOf("bug", "failure", "fail", "error", "exception", "regression", "broken", "flaky", "race", "버그", "실패", "오류", "예외", "불안정", "레이스").any(text::contains) ->
+                DisabledTestCategory.KNOWN_BUG
+
+            else -> DisabledTestCategory.UNCATEGORIZED
+        }
+    }
+
+    private fun findAnnotatedTarget(lines: List<String>, annotationIndex: Int): AnnotatedTarget {
+        lines.drop(annotationIndex + 1).take(8).forEach { line ->
+            functionNameRegex.find(line)?.let { match ->
+                return AnnotatedTarget(level = "method", name = match.groupValues[1])
+            }
+            classNameRegex.find(line)?.let { match ->
+                return AnnotatedTarget(level = "class", name = match.groupValues[1])
+            }
+        }
+        return AnnotatedTarget(level = "unknown", name = "(unknown)")
+    }
+
+    private fun inferModule(relativePath: String): String {
+        val sourceStart = relativePath.indexOf("/src/")
+        return when {
+            sourceStart > 0 -> relativePath.substring(0, sourceStart)
+            else -> "(root)"
+        }
+    }
+
+    private fun String.normalizePath(): String = replace(File.separatorChar, '/')
+
+    private val ignoredDirectories = setOf(".git", ".gradle", ".idea", ".worktrees", "build", "buildSrc")
+    private val functionNameRegex = Regex("""\bfun\s+`?([^`(]+)`?\s*\(""")
+    private val classNameRegex = Regex("""\b(?:class|object|interface)\s+([A-Za-z0-9_]+)""")
+    private val unsupportedCapabilityRegex = Regex(
+        """unsupported|does not support|not support|not available|unavailable|미지원|지원하지|불가|사용할 수 없습니다""",
+    )
+    private val environmentRegex = Regex(
+        """\b(api key|proxy|ci|local|docker|macos|port|ryuk)\b|보안|환경|로컬|키|포트|발표용""",
+    )
+}
+
+object DisabledTestReportRenderer {
+
+    fun render(result: DisabledTestScanResult): String {
+        val counts = result.entries
+            .groupingBy { it.category }
+            .eachCount()
+            .toSortedMap()
+
+        return buildString {
+            appendLine("# Disabled Test Report")
+            appendLine()
+            appendLine("Generated by `./gradlew checkDisabledTests`.")
+            appendLine()
+            appendLine("## Summary")
+            appendLine()
+            appendLine("- Disabled annotations: ${result.entries.size}")
+            appendLine("- Known-bug violations without tracking issue: ${result.violations.size}")
+            counts.forEach { (category, count) ->
+                appendLine("- `$category`: $count")
+            }
+            appendLine()
+            appendLine("## Category Legend")
+            appendLine()
+            DisabledTestCategory.entries.forEach { category ->
+                appendLine("- `${category.id}`: ${category.description}")
+            }
+            appendLine()
+            appendLine("## Registry")
+            appendLine()
+            appendLine("| Module | File | Line | Target | Level | Category | Tracking Issue | Reason |")
+            appendLine("|---|---|---:|---|---|---|---|---|")
+            result.entries.forEach { entry ->
+                appendLine(
+                    "| `${entry.module}` | `${entry.relativePath}` | ${entry.line} | `${entry.target.escapeMarkdown()}` | " +
+                            "${entry.level} | `${entry.category}` | ${entry.trackingIssue ?: "-"} | ${entry.reason.escapeMarkdown()} |",
+                )
+            }
+            appendLine()
+            appendLine("## Gate Rule")
+            appendLine()
+            appendLine("Any `known-bug` disabled test must include a GitHub issue reference such as `#497` in the annotation reason.")
+            appendLine("Unsupported capabilities, manual environment requirements, conditional CI skips, and slow optional tests are reported but do not fail the gate.")
+        }
+    }
+
+    private fun String.escapeMarkdown(): String = replace("|", "\\|").replace("\n", " ")
+}
+
+enum class DisabledTestCategory(
+    val id: String,
+    val description: String,
+) {
+    KNOWN_BUG("known-bug", "A product or test bug that must have a tracking issue."),
+    UNSUPPORTED_CAPABILITY("unsupported-capability", "A backend, emulator, protocol, or library capability is intentionally unsupported."),
+    ENVIRONMENT_MANUAL("environment-manual", "The test requires credentials, a local service, a security setup, or another manual environment."),
+    SLOW_OPTIONAL("slow-optional", "The test is intentionally excluded because it is slow, large, or rarely useful in routine builds."),
+    CONDITIONAL_ENVIRONMENT("conditional-environment", "A conditional JUnit disable annotation controls when the test is skipped."),
+    INTENTIONAL_EXAMPLE("intentional-example", "Example code documents a failure mode or behavior that is not a release-blocking bug."),
+    UNCATEGORIZED("uncategorized", "The disabled test does not match a known category and should be reviewed during release."),
+}
+
+data class DisabledTestScanResult(
+    val entries: List<DisabledTestEntry>,
+    val violations: List<DisabledTestViolation>,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+data class DisabledTestEntry(
+    val module: String,
+    val relativePath: String,
+    val line: Int,
+    val target: String,
+    val level: String,
+    val category: String,
+    val trackingIssue: String?,
+    val reason: String,
+    val annotation: String,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+data class DisabledTestViolation(
+    val entry: DisabledTestEntry,
+    val message: String,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+private data class AnnotatedTarget(
+    val level: String,
+    val name: String,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/buildSrc/src/test/kotlin/io/bluetape4k/gradle/DisabledTestScannerTest.kt
+++ b/buildSrc/src/test/kotlin/io/bluetape4k/gradle/DisabledTestScannerTest.kt
@@ -1,0 +1,95 @@
+package io.bluetape4k.gradle
+
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DisabledTestScannerTest {
+
+    @Test
+    fun `known bug disabled test without issue is reported as violation`() {
+        val root = createTempDirectory("disabled-test-scan")
+        val source = root.resolve("io/http/src/test/kotlin/sample/KnownBugTest.kt")
+        source.parent.createDirectories()
+        source.writeText(
+            """
+            import org.junit.jupiter.api.Disabled
+            import org.junit.jupiter.api.Test
+
+            class KnownBugTest {
+                @Test
+                @Disabled("fails until retry race is fixed")
+                fun `retries delayed request`() {
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val result = DisabledTestScanner.scan(root.toFile())
+
+        assertEquals(1, result.entries.size)
+        assertEquals("known-bug", result.entries.single().category)
+        assertEquals(1, result.violations.size)
+    }
+
+    @Test
+    fun `known bug disabled test with issue reference passes gate`() {
+        val root = createTempDirectory("disabled-test-scan")
+        val source = root.resolve("cache/cache-core/src/test/kotlin/sample/CacheTest.kt")
+        source.parent.createDirectories()
+        source.writeText(
+            """
+            import org.junit.jupiter.api.Disabled
+            import org.junit.jupiter.api.Test
+
+            class CacheTest {
+                @Disabled("#497 — flaky refresh failure has a tracking issue")
+                @Test
+                fun `refreshes once`() {
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val result = DisabledTestScanner.scan(root.toFile())
+
+        assertEquals(1, result.entries.size)
+        assertEquals("known-bug", result.entries.single().category)
+        assertEquals("#497", result.entries.single().trackingIssue)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `unsupported and conditional disabled tests are categorized without violations`() {
+        val root = createTempDirectory("disabled-test-scan")
+        val source = root.resolve("testing/testcontainers/src/test/kotlin/sample/ServerTest.kt")
+        source.parent.createDirectories()
+        source.writeText(
+            """
+            import org.junit.jupiter.api.Disabled
+            import org.junit.jupiter.api.Test
+            import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
+
+            class ServerTest {
+                @Disabled("MiniStack does not support CreateGrant")
+                @Test
+                fun `creates grant`() {
+                }
+
+                @DisabledIfEnvironmentVariable(named = "CI", matches = "true")
+                @Test
+                fun `streams with external server`() {
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val result = DisabledTestScanner.scan(root.toFile())
+
+        assertEquals(listOf("conditional-environment", "unsupported-capability"), result.entries.map { it.category }.sorted())
+        assertTrue(result.violations.isEmpty())
+    }
+}

--- a/docs/lessons/2026-05-20-issue-497-disabled-test-gate.md
+++ b/docs/lessons/2026-05-20-issue-497-disabled-test-gate.md
@@ -1,0 +1,38 @@
+# Lessons Learned — Issue #497 Disabled Test Gate
+
+## Context
+
+Disabled tests were scattered across examples, infrastructure tests, and
+conditional environment cases. A release gate needed to expose them without
+changing runtime test behavior.
+
+## Decision
+
+Use a root Gradle task backed by `buildSrc` to scan test sources and generate a
+markdown report. Fail only `known-bug` disabled tests without GitHub issue
+references; keep unsupported, environment, slow, conditional, and intentional
+example skips visible but non-blocking.
+
+## Outcome
+
+The release checklist now points to `./gradlew checkDisabledTests` and the
+generated report under `build/reports/disabled-tests/disabled-tests.md`.
+
+## Verification
+
+- `./gradlew :buildSrc:test --no-configuration-cache` passed.
+- `./gradlew checkDisabledTests --no-configuration-cache` passed and reported
+  37 disabled annotations with 0 known-bug issue-reference violations.
+- `./gradlew help --task checkDisabledTests --no-configuration-cache` confirmed
+  the root verification task registration.
+- `./gradlew build -x test --parallel --no-configuration-cache` passed after
+  narrowing the task input from the whole project directory to explicit
+  `src/test` source files.
+- `git diff --check` passed.
+
+## Future Guidance
+
+When adding `@Disabled` to hide a real defect, include a tracking issue in the
+annotation reason. If the skip is not a bug, phrase the reason so the scanner
+can classify it as unsupported capability, manual environment, slow optional,
+conditional environment, or intentional example behavior.

--- a/docs/release/disabled-test-gate.md
+++ b/docs/release/disabled-test-gate.md
@@ -1,0 +1,25 @@
+# Disabled Test Release Gate
+
+Run the disabled-test gate before release:
+
+```bash
+./gradlew checkDisabledTests
+```
+
+The task writes:
+
+```text
+build/reports/disabled-tests/disabled-tests.md
+```
+
+Release checklist:
+
+1. Open the generated report.
+2. Confirm `Known-bug violations without tracking issue` is `0`.
+3. Review `uncategorized` entries and either add a clearer annotation reason or
+   create a tracking issue when the disabled test hides a real bug.
+4. Keep unsupported capability, manual environment, slow optional, and
+   conditional environment skips visible in the report.
+
+Gate rule: any disabled test categorized as `known-bug` must include a GitHub
+issue reference such as `#497` in the annotation reason.

--- a/docs/superpowers/plans/2026-05-20-issue-497-disabled-test-gate-plan.md
+++ b/docs/superpowers/plans/2026-05-20-issue-497-disabled-test-gate-plan.md
@@ -1,0 +1,11 @@
+# Issue #497 Disabled Test Release Gate Plan
+
+1. Add a `buildSrc` scanner and Gradle task for disabled-test reporting.
+2. Register root `checkDisabledTests` and wire it into `check`.
+3. Add unit tests for known-bug violations, issue references, unsupported
+   capability categorization, and conditional disabled annotations.
+4. Add release documentation pointing maintainers to the generated report and
+   gate rule.
+5. Verify with `:buildSrc:test`, `checkDisabledTests`, and a root task listing
+   or dry run that proves the task is registered.
+6. Add a lessons note for future disabled-test triage.

--- a/docs/superpowers/specs/2026-05-20-issue-497-disabled-test-gate-design.md
+++ b/docs/superpowers/specs/2026-05-20-issue-497-disabled-test-gate-design.md
@@ -1,0 +1,43 @@
+# Issue #497 Disabled Test Release Gate Design
+
+## Context
+
+`@Disabled` tests can hide release-relevant failures when the reason is only
+stored in a test annotation. Issue #497 asks for a lightweight registry and
+release gate that reports disabled tests, categorizes them, and fails when a
+known bug has no GitHub issue reference.
+
+## Decision
+
+Add a root Gradle verification task, `checkDisabledTests`, backed by a
+`buildSrc` scanner. The task scans Kotlin/Java test sources, writes a markdown
+report to `build/reports/disabled-tests/disabled-tests.md`, and fails only when
+a disabled test classified as `known-bug` has no `#NNN` issue reference.
+
+Categories:
+
+- `known-bug`: bug, failure, error, exception, regression, race, or flaky test.
+- `unsupported-capability`: unsupported backend, emulator, protocol, or API.
+- `environment-manual`: local service, credential, Docker, CI, port, or security setup.
+- `slow-optional`: slow, large, expensive, or rarely useful routine test.
+- `conditional-environment`: conditional JUnit disabled annotation.
+- `intentional-example`: example tests documenting intentional failure behavior.
+- `uncategorized`: review during release, but do not fail automatically.
+
+## Constraints
+
+- Runtime test behavior must not change.
+- Existing disabled tests should be visible without forcing a full annotation
+  rewrite in this issue.
+- The release gate must be cheap enough to run as part of root `check`.
+- Generated reports stay under `build/`; durable release instructions live in
+  `docs/release/disabled-test-gate.md`.
+
+## Acceptance Criteria Mapping
+
+- Gradle task reports disabled tests and categories: `checkDisabledTests`.
+- Known bug disabled tests require issue references: task fails `known-bug`
+  entries without `#NNN`.
+- Release checklist references the report: `docs/release/disabled-test-gate.md`.
+- Existing disabled tests are categorized without changing runtime behavior:
+  scanner reads annotations only.


### PR DESCRIPTION
## Summary

Closes #497

- PR 제목: [test] Add disabled-test release gate

- Adds a root `checkDisabledTests` Gradle verification task backed by a buildSrc scanner.
- Generates `build/reports/disabled-tests/disabled-tests.md` with disabled-test categories and a known-bug issue-reference gate.
- Documents the release checklist in `docs/release/disabled-test-gate.md` and records the design, plan, and lesson artifacts.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Issue

Closes #497

### 기존 섹션: Verification

- `./gradlew :buildSrc:test --no-configuration-cache`
- `./gradlew checkDisabledTests --no-configuration-cache`
- `./gradlew help --task checkDisabledTests --no-configuration-cache`
- `git diff --check`

### 기존 섹션: Review Gate

- P0/P1: 0 found in current-session Codex review.
- Claude advisor: attempted twice, but the current tool surface timed out before returning a verdict.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #497, milestone `1.8.1`, assignee `debop`
- PR: #567, head `b79f47413340cd500930d542564e770c46712209`, milestone `1.8.1`, assignee `debop`
- Base: `develop`, head branch `test/issue-497-disabled-test-gate`
- Labels: `enhancement`, `test`, `ci`
- State: `MERGED`, merge commit `d3f31c370963c3d714072afeb16d890bdeb40844`
- CI: - Adds a root `checkDisabledTests` Gradle verification task backed by a buildSrc scanner. / - `./gradlew :buildSrc:test --no-configuration-cache` / - `./gradlew checkDisabledTests --no-configuration-cache`

## DoD Status

- [x] Gradle task reports disabled tests and categories.
- [x] Known-bug disabled tests require a GitHub issue reference.
- [x] Release checklist references the generated report.
- [x] Existing disabled tests are categorized without changing runtime behavior.
- [x] Lessons committed before PR creation.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #567 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `d3f31c370963c3d714072afeb16d890bdeb40844`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
