### PR TITLE
[feat] Add explicit KLoggingChannel lifecycle

### DIFF
--- a/bluetape4k/logging/README.ko.md
+++ b/bluetape4k/logging/README.ko.md
@@ -287,10 +287,12 @@ class AsyncService {
 - 로깅 작업이 별도의 Coroutine에서 처리됨
 - 메인 로직의 성능에 영향 최소화
 
-**3. 자동 리소스 관리**
+**3. 수명주기 관리**
 
-- Shutdown Hook으로 종료 시 자동 정리
-- 모든 버퍼링된 로그 처리 후 종료
+- 기본 채널들은 JVM shutdown hook 하나를 공유
+- `close()`는 해당 채널의 백그라운드 collector를 취소
+- `closeAndJoin()`은 suspend 종료 경계나 테스트에서 collector 취소 완료까지 대기
+- 직접 주입한 `CoroutineScope`는 호출자가 계속 소유하며, 채널 close가 그 scope를 취소하지 않음
 
 #### 실전 예시
 
@@ -385,19 +387,29 @@ class DataImporter {
 - 일반 동기 코드
 - 로그 양이 적은 경우
 - 즉시 로그 출력이 필요한 경우
+- companion object 로거가 장수 객체이고 비동기 전달이 꼭 필요하지 않은 경우
 
-#### 주의사항
+#### 수명주기
 
 ```kotlin
-// ⚠️ 애플리케이션 종료 시 버퍼의 로그가 모두 처리될 때까지 대기
-// Shutdown Hook이 자동으로 처리하지만, 강제 종료 시 일부 로그 유실 가능
+class ManagedProcessor: KLoggingChannel() {
+    suspend fun process() {
+        info { "processing" }
+    }
+}
 
-// ✅ 중요한 로그는 명시적으로 flush
-suspend fun criticalOperation() {
-    log.error { "Critical error occurred!" }
-    delay(100)  // 로그가 처리될 시간 제공
+suspend fun runProcessor() {
+    val processor = ManagedProcessor()
+    try {
+        processor.process()
+    } finally {
+        processor.closeAndJoin()
+    }
 }
 ```
+
+일반 companion object 로거는 coroutine 중심 또는 대량 비동기 로깅이 실제로 필요할 때만
+`KLoggingChannel()`을 사용하고, 그 외에는 `KLogging()`을 우선 사용하세요.
 
 ### 7. Logback 설정
 

--- a/bluetape4k/logging/README.md
+++ b/bluetape4k/logging/README.md
@@ -288,10 +288,12 @@ class AsyncService {
 - Log writes happen in a separate coroutine
 - Minimal impact on main logic performance
 
-**3. Automatic Resource Management**
+**3. Lifecycle Management**
 
-- Shutdown Hook cleans up resources on JVM exit
-- Drains all buffered log events before terminating
+- Default channels share one JVM shutdown hook
+- `close()` cancels this channel's background collector
+- `closeAndJoin()` waits for collector cancellation in suspend shutdown or tests
+- Custom `CoroutineScope` injection is supported, but the caller still owns that scope
 
 #### Real-World Example
 
@@ -386,19 +388,29 @@ class DataImporter {
 - Writing ordinary synchronous code
 - Log volume is low
 - Immediate log output is required
+- The logger belongs to a long-lived companion object and async delivery is not needed
 
-#### Caveats
+#### Lifecycle
 
 ```kotlin
-// ⚠️ On application shutdown, waits until all buffered logs are flushed
-// The Shutdown Hook handles this automatically, but forced termination may lose some logs
+class ManagedProcessor: KLoggingChannel() {
+    suspend fun process() {
+        info { "processing" }
+    }
+}
 
-// ✅ For critical logs, give the buffer time to drain
-suspend fun criticalOperation() {
-    log.error { "Critical error occurred!" }
-    delay(100)  // allow time for the log to be processed
+suspend fun runProcessor() {
+    val processor = ManagedProcessor()
+    try {
+        processor.process()
+    } finally {
+        processor.closeAndJoin()
+    }
 }
 ```
+
+For ordinary companion-object loggers, prefer `KLogging()` unless coroutine-heavy or
+high-volume async logging justifies the lifecycle cost.
 
 ### 7. Logback Configuration
 

--- a/bluetape4k/logging/src/main/kotlin/io/bluetape4k/logging/coroutines/KLoggingChannel.kt
+++ b/bluetape4k/logging/src/main/kotlin/io/bluetape4k/logging/coroutines/KLoggingChannel.kt
@@ -4,11 +4,15 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.WARN_ERROR_PREFIX
 import io.bluetape4k.logging.error
 import io.bluetape4k.logging.logMessageSafe
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.catch
@@ -16,25 +20,34 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.slf4j.event.Level
+import java.io.Serializable
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.concurrent.thread
 
 /**
- * `MutableSharedFlow` 기반 비동기 로깅 채널을 제공하는 베이스 클래스입니다.
+ * Base logger that publishes log events to a background coroutine collector.
  *
- * ## 동작/계약
- * - `send(LogEvent)`로 전달된 이벤트를 백그라운드 코루틴이 순차 소비해 실제 로그로 기록합니다.
- * - 버퍼는 `extraBufferCapacity=64`, `BufferOverflow.SUSPEND` 정책을 사용합니다.
- * - JVM 종료 훅에서 로깅 잡을 취소합니다.
- * - 로그 이벤트 처리 중 예외는 개별적으로 포착되어 Flow 전체가 중단되지 않습니다.
+ * ## Contract
+ * - `send(LogEvent)` publishes to an internal `MutableSharedFlow`.
+ * - The default constructor uses a shared IO coroutine scope and one JVM shutdown hook for all instances.
+ * - `close()` cancels only this channel's collector job and is idempotent.
+ * - `closeAndJoin()` is the suspend shutdown path for tests and lifecycle owners that need deterministic cleanup.
+ * - A custom [CoroutineScope] remains owned by the caller; closing the channel does not cancel the injected scope.
+ * - Events sent after close are dropped.
  *
  * ```kotlin
  * class Service {
  *   companion object : KLoggingChannel()
  * }
- * // suspend fun 안에서 trace/debug/... 호출
+ *
+ * suspend fun Service.load() {
+ *     info { "loading" }
+ * }
  * ```
  */
-open class KLoggingChannel: KLogging() {
+open class KLoggingChannel(
+    private val channelScope: CoroutineScope = KLoggingChannelRuntime.scope,
+): KLogging(), AutoCloseable {
 
     private companion object {
         private const val DEFAULT_BUFFER_CAPACITY = 64
@@ -46,14 +59,17 @@ open class KLoggingChannel: KLogging() {
         onBufferOverflow = BufferOverflow.SUSPEND
     )
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO + CoroutineName("logchannel"))
+    private val closed = AtomicBoolean(false)
 
     /**
-     * 로그 이벤트를 소비하는 백그라운드 Job입니다.
-     * 최초 접근 시 한 번만 thread-safe하게 초기화됩니다.
+     * Whether this channel has been explicitly closed.
      */
+    val isClosed: Boolean get() = closed.get()
+
+    internal val collectorActive: Boolean get() = job.isActive
+
     private val job: Job by lazy {
-        scope.launch {
+        channelScope.launch(start = CoroutineStart.UNDISPATCHED) {
             sharedFlow
                 .onEach { event ->
                     try {
@@ -64,11 +80,16 @@ open class KLoggingChannel: KLogging() {
                             Level.WARN  -> log.warn(WARN_ERROR_PREFIX + event.msg, event.error)
                             Level.ERROR -> log.error(WARN_ERROR_PREFIX + event.msg, event.error)
                         }
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Throwable) {
-                        log.error(e) { "로그 이벤트 처리 중 오류가 발생했습니다." }
+                        log.error(e) { "Failed to process a log event." }
                     }
                 }
                 .catch { error ->
+                    if (error is CancellationException) {
+                        throw error
+                    }
                     log.error(error) { "Error during logging channel." }
                 }
                 .collect()
@@ -76,36 +97,57 @@ open class KLoggingChannel: KLogging() {
     }
 
     init {
-        job // lazy 초기화를 트리거합니다.
-        try {
-            Runtime.getRuntime().addShutdownHook(
-                thread(start = false, isDaemon = true) {
-                    job.cancel()
-                }
-            )
-        } catch (_: IllegalStateException) {
+        job
+    }
+
+    /**
+     * Publishes a log event to the internal channel.
+     *
+     * Events sent after [close] are ignored so callers do not block on a stopped collector.
+     *
+     * ```kotlin
+     * send(LogEvent(Level.INFO, "service started"))
+     * ```
+     *
+     * @param event event to publish.
+     */
+    suspend fun send(event: LogEvent) {
+        if (!isClosed) {
+            sharedFlow.emit(event)
+        }
+    }
+
+    /**
+     * Closes this channel and waits until the collector job has stopped.
+     *
+     * Use this from tests, application shutdown hooks, or lifecycle callbacks when the caller
+     * needs deterministic evidence that the collector no longer runs.
+     */
+    suspend fun closeAndJoin() {
+        if (closed.compareAndSet(false, true)) {
+            job.cancelAndJoin()
+        } else {
+            job.join()
+        }
+    }
+
+    /**
+     * Cancels this channel's collector job.
+     *
+     * This method is idempotent. It does not cancel a custom [CoroutineScope] supplied to the
+     * constructor because the caller owns that scope.
+     */
+    override fun close() {
+        if (closed.compareAndSet(false, true)) {
             job.cancel()
         }
     }
 
     /**
-     * 로그 이벤트를 내부 채널에 발행합니다.
+     * Publishes a TRACE event when TRACE logging is enabled.
      *
      * ```kotlin
-     * send(LogEvent(Level.INFO, "직접 이벤트 발행"))
-     * ```
-     *
-     * @param event 발행할 로그 이벤트입니다.
-     */
-    suspend fun send(event: LogEvent) {
-        sharedFlow.emit(event)
-    }
-
-    /**
-     * TRACE 활성화 시 이벤트를 채널에 발행합니다.
-     *
-     * ```kotlin
-     * trace { "TRACE 이벤트" }
+     * trace { "trace event" }
      * ```
      */
     suspend inline fun trace(error: Throwable? = null, msg: () -> Any?) {
@@ -115,10 +157,10 @@ open class KLoggingChannel: KLogging() {
     }
 
     /**
-     * DEBUG 활성화 시 이벤트를 채널에 발행합니다.
+     * Publishes a DEBUG event when DEBUG logging is enabled.
      *
      * ```kotlin
-     * debug { "DEBUG 이벤트" }
+     * debug { "debug event" }
      * ```
      */
     suspend inline fun debug(error: Throwable? = null, msg: () -> Any?) {
@@ -128,10 +170,10 @@ open class KLoggingChannel: KLogging() {
     }
 
     /**
-     * INFO 활성화 시 이벤트를 채널에 발행합니다.
+     * Publishes an INFO event when INFO logging is enabled.
      *
      * ```kotlin
-     * info { "INFO 이벤트" }
+     * info { "info event" }
      * ```
      */
     suspend inline fun info(error: Throwable? = null, msg: () -> Any?) {
@@ -141,10 +183,10 @@ open class KLoggingChannel: KLogging() {
     }
 
     /**
-     * WARN 활성화 시 이벤트를 채널에 발행합니다.
+     * Publishes a WARN event when WARN logging is enabled.
      *
      * ```kotlin
-     * warn { "WARN 이벤트" }
+     * warn { "warn event" }
      * ```
      */
     suspend inline fun warn(error: Throwable? = null, msg: () -> Any?) {
@@ -154,10 +196,10 @@ open class KLoggingChannel: KLogging() {
     }
 
     /**
-     * ERROR 활성화 시 이벤트를 채널에 발행합니다.
+     * Publishes an ERROR event when ERROR logging is enabled.
      *
      * ```kotlin
-     * error(exception) { "ERROR 이벤트" }
+     * error(exception) { "error event" }
      * ```
      */
     suspend inline fun error(error: Throwable? = null, msg: () -> Any?) {
@@ -167,22 +209,44 @@ open class KLoggingChannel: KLogging() {
     }
 
     /**
-     * 비동기 채널에 전달되는 로그 이벤트 모델입니다.
+     * Log event passed through the asynchronous channel.
      *
      * ```kotlin
-     * val event = LogEvent(Level.INFO, "서버 시작", null)
+     * val event = LogEvent(Level.INFO, "server started", null)
      * // event.level == Level.INFO
-     * // event.msg == "서버 시작"
+     * // event.msg == "server started"
      * ```
      *
-     * @property level 로그 레벨입니다.
-     * @property msg 로그 메시지입니다.
-     * @property error 함께 기록할 예외입니다.
+     * @property level log level.
+     * @property msg log message.
+     * @property error optional error to log with the message.
      */
     @JvmRecord
     data class LogEvent(
         val level: Level = Level.DEBUG,
         val msg: String? = null,
         val error: Throwable? = null,
-    )
+    ): Serializable {
+        companion object {
+            private const val serialVersionUID: Long = -581771429847270896L
+        }
+    }
+}
+
+private object KLoggingChannelRuntime {
+    private val job = SupervisorJob()
+
+    val scope: CoroutineScope = CoroutineScope(job + Dispatchers.IO + CoroutineName("logchannel"))
+
+    init {
+        try {
+            Runtime.getRuntime().addShutdownHook(
+                thread(start = false, isDaemon = true, name = "bluetape4k-logchannel-shutdown") {
+                    job.cancel(CancellationException("JVM shutdown"))
+                }
+            )
+        } catch (_: IllegalStateException) {
+            job.cancel(CancellationException("JVM shutdown already in progress"))
+        }
+    }
 }

--- a/bluetape4k/logging/src/test/kotlin/io/bluetape4k/logging/coroutines/KLoggingChannelTest.kt
+++ b/bluetape4k/logging/src/test/kotlin/io/bluetape4k/logging/coroutines/KLoggingChannelTest.kt
@@ -1,75 +1,168 @@
 package io.bluetape4k.logging.coroutines
 
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.AfterAll
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.time.Instant
+import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.time.Duration.Companion.milliseconds
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class KLoggingChannelTest {
 
-    companion object: KLoggingChannel()
-
     private val error get() = RuntimeException("Boom!")
 
-    @AfterAll
-    fun cleanup() {
-        // 채널에 남은 이벤트가 처리될 시간을 확보합니다.
-        Thread.sleep(100)
-    }
-
     @Test
-    fun `logging trace`() = runTest {
-        trace { "Message at ${Instant.now()}" }
-        trace(error) { "Error at ${Instant.now()}" }
-    }
+    fun `logging events are delivered asynchronously`() = runSuspendIO {
+        val channel = TestLoggingChannel()
+        val appender = channel.attachCapturingAppender()
 
-    @Test
-    fun `logging debug`() = runTest {
-        debug { "Message at ${Instant.now()}" }
-        debug(error) { "Error at ${Instant.now()}" }
-    }
+        try {
+            channel.trace { "trace at ${Instant.now()}" }
+            channel.debug { "debug at ${Instant.now()}" }
+            channel.info { "info at ${Instant.now()}" }
+            channel.warn(error) { "warn at ${Instant.now()}" }
+            channel.error(error) { "error at ${Instant.now()}" }
 
-    @Test
-    fun `logging info`() = runTest {
-        info { "Message at ${Instant.now()}" }
-        info(error) { "Error at ${Instant.now()}" }
-    }
+            val events = appender.awaitEvents(5)
 
-    @Test
-    fun `logging warn`() = runTest {
-        warn { "Message at ${Instant.now()}" }
-        warn(error) { "Error at ${Instant.now()}" }
-    }
-
-    @Test
-    fun `logging error`() = runTest {
-        error { "Message at ${Instant.now()}" }
-        error(error) { "Error at ${Instant.now()}" }
-    }
-
-    @Test
-    fun `logging in coroutines`() = runTest {
-        val jobs = List(10) {
-            launch(Dispatchers.IO) {
-                debug { "Message at $it" }
-            }
+            events.map { it.level } shouldBeEqualTo listOf(
+                ch.qos.logback.classic.Level.TRACE,
+                ch.qos.logback.classic.Level.DEBUG,
+                ch.qos.logback.classic.Level.INFO,
+                ch.qos.logback.classic.Level.WARN,
+                ch.qos.logback.classic.Level.ERROR
+            )
+            events.map { it.formattedMessage.substringBefore(" at ") } shouldBeEqualTo listOf(
+                "trace",
+                "debug",
+                "info",
+                "🔥warn",
+                "🔥error"
+            )
+            events.count { it.throwableProxy != null } shouldBeEqualTo 2
+        } finally {
+            channel.detachCapturingAppender(appender)
+            channel.closeAndJoin()
         }
-        jobs.joinAll()
     }
 
     @Test
-    fun `log message with suspend function`() = runTest {
-        debug { "delay=${runSuspending(100)}" }
+    fun `logging in coroutines`() = runSuspendIO {
+        val channel = TestLoggingChannel()
+        val appender = channel.attachCapturingAppender()
+
+        try {
+            val jobs = List(10) {
+                launch(Dispatchers.IO) {
+                    channel.debug { "Message at $it" }
+                }
+            }
+            jobs.joinAll()
+
+            appender.awaitEvents(10).size shouldBeEqualTo 10
+        } finally {
+            channel.detachCapturingAppender(appender)
+            channel.closeAndJoin()
+        }
+    }
+
+    @Test
+    fun `log message with suspend function`() = runSuspendIO {
+        val channel = TestLoggingChannel()
+        val appender = channel.attachCapturingAppender()
+
+        try {
+            channel.debug { "delay=${runSuspending(100)}" }
+
+            appender.awaitEvents(1).single().formattedMessage shouldBeEqualTo "delay=100"
+        } finally {
+            channel.detachCapturingAppender(appender)
+            channel.closeAndJoin()
+        }
+    }
+
+    @Test
+    fun `closeAndJoin stops collector job`() = runSuspendIO {
+        val channel = TestLoggingChannel()
+
+        channel.isClosed.shouldBeFalse()
+        channel.collectorActive.shouldBeTrue()
+
+        channel.closeAndJoin()
+
+        channel.isClosed.shouldBeTrue()
+        channel.collectorActive.shouldBeFalse()
+    }
+
+    @Test
+    fun `close is idempotent and drops later events`() = runSuspendIO {
+        val channel = TestLoggingChannel()
+        val appender = channel.attachCapturingAppender()
+
+        try {
+            channel.close()
+            channel.close()
+            channel.closeAndJoin()
+
+            channel.isClosed.shouldBeTrue()
+            channel.collectorActive.shouldBeFalse()
+
+            channel.info { "after-close" }
+
+            appender.events.size shouldBeEqualTo 0
+        } finally {
+            channel.detachCapturingAppender(appender)
+            channel.closeAndJoin()
+        }
     }
 
     private suspend fun runSuspending(delayMillis: Long = 100): Long {
         kotlinx.coroutines.delay(delayMillis.milliseconds)
         return delayMillis
+    }
+
+    private class TestLoggingChannel: KLoggingChannel()
+
+    private class CapturingAppender: AppenderBase<ILoggingEvent>() {
+        val events = CopyOnWriteArrayList<ILoggingEvent>()
+
+        override fun append(eventObject: ILoggingEvent) {
+            events += eventObject
+        }
+    }
+
+    private fun KLoggingChannel.attachCapturingAppender(): CapturingAppender {
+        val logger = log as Logger
+        return CapturingAppender().also { appender ->
+            appender.context = logger.loggerContext
+            appender.start()
+            logger.addAppender(appender)
+        }
+    }
+
+    private fun KLoggingChannel.detachCapturingAppender(appender: CapturingAppender) {
+        val logger = log as Logger
+        logger.detachAppender(appender)
+        appender.stop()
+    }
+
+    private suspend fun CapturingAppender.awaitEvents(expectedCount: Int): List<ILoggingEvent> {
+        withTimeout(2_000.milliseconds) {
+            while (events.size < expectedCount) {
+                kotlinx.coroutines.delay(10.milliseconds)
+            }
+        }
+        return events.toList()
     }
 }

--- a/docs/lessons/2026-05-20-issue-498-logging-lifecycle.md
+++ b/docs/lessons/2026-05-20-issue-498-logging-lifecycle.md
@@ -1,0 +1,26 @@
+# Lessons Learned - Issue #498 KLoggingChannel Lifecycle
+
+## Context
+
+`KLoggingChannel` needed explicit lifecycle ownership for tests and reloadable applications. The old test suite only verified no-throw logging calls and did not prove delivery or collector shutdown.
+
+## Decision
+
+`KLoggingChannel` now implements `AutoCloseable`, uses one shared default runtime scope/shutdown hook, and exposes `closeAndJoin()` for suspend cleanup boundaries. Custom scopes remain caller-owned.
+
+## Outcome
+
+Tests now capture Logback events, assert level/message/error delivery, and verify collector cancellation plus post-close event dropping. The collector starts `UNDISPATCHED` to avoid dropping first events before `MutableSharedFlow` subscription is established.
+
+## Verification
+
+- IDE imports optimized for changed Kotlin files.
+- IDE diagnostics: index ready, no build errors; per-file fresh analysis unavailable because files were not open in the IDE.
+- `./gradlew :bluetape4k-logging:compileKotlin :bluetape4k-logging:compileTestKotlin --no-configuration-cache`
+- `./gradlew :bluetape4k-logging:test --tests 'io.bluetape4k.logging.coroutines.KLoggingChannelTest' --no-configuration-cache`
+- `./gradlew :bluetape4k-logging:test --no-configuration-cache`
+- `git diff --check`
+
+## Future Guard
+
+For async logging tests, attach a real appender and assert emitted events. Avoid `Thread.sleep` drain tests; prove lifecycle state through the collector job or observable output.

--- a/docs/superpowers/plans/2026-05-20-issue-498-logging-lifecycle-plan.md
+++ b/docs/superpowers/plans/2026-05-20-issue-498-logging-lifecycle-plan.md
@@ -1,0 +1,32 @@
+# Issue #498 KLoggingChannel Lifecycle Plan
+
+## Tasks
+
+1. Update `KLoggingChannel` lifecycle API.
+   - Implement `AutoCloseable`.
+   - Add shared runtime scope with one shutdown hook.
+   - Add `isClosed` and `closeAndJoin()`.
+   - Drop post-close events.
+
+2. Strengthen tests.
+   - Capture Logback events with an in-memory appender.
+   - Assert emitted levels/messages.
+   - Assert `closeAndJoin()` leaves the collector inactive.
+   - Assert `close()` is idempotent and post-close events are dropped.
+
+3. Update public docs.
+   - English KDoc for changed public API.
+   - `README.md` and `README.ko.md` lifecycle and usage guidance.
+
+4. Verify.
+   - IDE diagnostics/import cleanup when available.
+   - `:bluetape4k-logging:compileKotlin`.
+   - Targeted `KLoggingChannelTest`.
+   - Full `:bluetape4k-logging:test`.
+
+5. Delivery.
+   - Add concise lesson.
+   - Commit with Lore trailers.
+   - Push branch and open PR assigned to `debop`.
+   - Post current-session Codex Review comment and formal review.
+   - Wait for PR CI checks; do not merge.

--- a/docs/superpowers/specs/2026-05-20-issue-498-logging-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-05-20-issue-498-logging-lifecycle-design.md
@@ -1,0 +1,41 @@
+# Issue #498 KLoggingChannel Lifecycle Design
+
+## Context
+
+`KLoggingChannel` currently creates one `CoroutineScope(SupervisorJob() + Dispatchers.IO)` and one JVM shutdown hook per logger instance. This keeps companion-object usage simple, but tests and reloadable applications cannot explicitly stop the collector job.
+
+## Goals
+
+- Preserve existing `companion object : KLoggingChannel()` source compatibility.
+- Add an explicit lifecycle surface that applications and tests can close.
+- Avoid one JVM shutdown hook per logger instance.
+- Document when to use `KLoggingChannel` instead of `KLogging`.
+- Verify collector cancellation and observable log delivery with assertions.
+
+## Design
+
+- Make `KLoggingChannel` implement `AutoCloseable`.
+- Keep the no-arg constructor by adding a default `CoroutineScope` parameter.
+- Use a private `KLoggingChannelRuntime` registry for the default shared `SupervisorJob + Dispatchers.IO` scope and a single shutdown hook.
+- Keep custom scope ownership external: `close()` cancels this channel collector, not the injected scope.
+- Add `closeAndJoin()` for suspend shutdown/test boundaries that need deterministic collector termination.
+- After close, `send()` drops events instead of suspending or restarting the collector.
+
+## Compatibility
+
+- Existing companion-object declarations continue to compile.
+- Existing suspend logging methods keep the same names and signatures.
+- New public API is additive: `isClosed`, `close()`, and `closeAndJoin()`.
+
+## Non-Goals
+
+- Do not replace `MutableSharedFlow` with a new queue implementation in this issue.
+- Do not add a Spring-specific integration hook until a concrete Spring lifecycle adapter issue exists.
+- Do not add dependencies.
+
+## Verification
+
+- Compile `:bluetape4k-logging`.
+- Run `KLoggingChannelTest`.
+- Run full `:bluetape4k-logging:test`.
+- Review diff in the current Codex session per user instruction.


### PR DESCRIPTION
## Summary

Closes #498

- PR 제목: [feat] Add explicit KLoggingChannel lifecycle

- Make `KLoggingChannel` explicitly closeable while preserving no-arg companion-object usage.
- Move default async logging collection onto one shared runtime scope and one JVM shutdown hook.
- Add asserted Logback appender tests for async delivery, collector cancellation, idempotent close, and post-close drop behavior.
- Update English/Korean README lifecycle guidance and record spec/plan/lesson artifacts.

Fixes #498

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary
- Make `KLoggingChannel` explicitly closeable while preserving no-arg companion-object usage.
- Move default async logging collection onto one shared runtime scope and one JVM shutdown hook.
- Add asserted Logback appender tests for async delivery, collector cancellation, idempotent close, and post-close drop behavior.
- Update English/Korean README lifecycle guidance and record spec/plan/lesson artifacts.

Fixes #498

### Validation
- `./gradlew :bluetape4k-logging:compileKotlin :bluetape4k-logging:compileTestKotlin --no-configuration-cache`
- `./gradlew :bluetape4k-logging:test --tests 'io.bluetape4k.logging.coroutines.KLoggingChannelTest' --no-configuration-cache`\n- `./gradlew :bluetape4k-logging:test --no-configuration-cache`\n- `git diff --check`\n- IDE imports optimized for changed Kotlin files.\n- IDE diagnostics: index ready; no build errors. Per-file fresh analysis was unavailable because files were not open in the IDE.\n\n## Current-Session Codex Review\n- Scope: `bluetape4k-logging` Kotlin diff, tests, README docs, spec/plan/lesson.\n- Tier 1 Security: P0=0, P1=0. No credentials, user input parsing, auth boundary, or deserialization surface added.\n- Tier 2 Ops/SRE: P0=0, P1=0. Lifecycle cleanup path added; one shared default shutdown hook replaces per-instance hooks.\n- Tier 3 Structural/API: P0=0, P1=0. Public API is additive (`AutoCloseable`, `isClosed`, `closeAndJoin()`); existing no-arg usage preserved.\n- Tier 4 Kotlin/Coroutine: P0=0, P1=0. `CancellationException` rethrows before broad catch; collector starts `UNDISPATCHED` to avoid first-event drop.\n- Tier 5 Tests/Types: P0=0, P1=0. Former no-assert logging tests now assert emitted levels/messages/errors and collector shutdown.\n- Tier 6 Performance/Stability: P0=0, P1=0. No new blocking production calls or dependencies; test waits are bounded and observation-based.\n- Claude advisor: skipped by user directive; Codex Review was performed in this session.\n\n## DoD\n- [x] Issue acceptance criteria addressed.\n- [x] Public KDoc is English for changed public API.\n- [x] README.md and README.ko.md updated together.\n- [x] Lessons committed before PR creation.\n- [x] CI pending.\n- [ ] Merge: not performed by agent.

## Validation

- `./gradlew :bluetape4k-logging:compileKotlin :bluetape4k-logging:compileTestKotlin --no-configuration-cache`
- `./gradlew :bluetape4k-logging:test --tests 'io.bluetape4k.logging.coroutines.KLoggingChannelTest' --no-configuration-cache`\n- `./gradlew :bluetape4k-logging:test --no-configuration-cache`\n- `git diff --check`\n- IDE imports optimized for changed Kotlin files.\n- IDE diagnostics: index ready; no build errors. Per-file fresh analysis was unavailable because files were not open in the IDE.\n\n## Current-Session Codex Review\n- Scope: `bluetape4k-logging` Kotlin diff, tests, README docs, spec/plan/lesson.\n- Tier 1 Security: P0=0, P1=0. No credentials, user input parsing, auth boundary, or deserialization surface added.\n- Tier 2 Ops/SRE: P0=0, P1=0. Lifecycle cleanup path added; one shared default shutdown hook replaces per-instance hooks.\n- Tier 3 Structural/API: P0=0, P1=0. Public API is additive (`AutoCloseable`, `isClosed`, `closeAndJoin()`); existing no-arg usage preserved.\n- Tier 4 Kotlin/Coroutine: P0=0, P1=0. `CancellationException` rethrows before broad catch; collector starts `UNDISPATCHED` to avoid first-event drop.\n- Tier 5 Tests/Types: P0=0, P1=0. Former no-assert logging tests now assert emitted levels/messages/errors and collector shutdown.\n- Tier 6 Performance/Stability: P0=0, P1=0. No new blocking production calls or dependencies; test waits are bounded and observation-based.\n- Claude advisor: skipped by user directive; Codex Review was performed in this session.\n\n## DoD\n- [x] Issue acceptance criteria addressed.\n- [x] Public KDoc is English for changed public API.\n- [x] README.md and README.ko.md updated together.\n- [x] Lessons committed before PR creation.\n- [x] CI pending.\n- [ ] Merge: not performed by agent.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #498, milestone `1.8.1`, assignee `debop`
- PR: #569, head `359bd7e041c926ce1b7d45582f771a1efcf09dd5`, milestone `1.8.1`, assignee `debop`
- Base: `develop`, head branch `feat/issue-498-logging-lifecycle`
- Labels: `documentation`, `enhancement`, `test`, `1.8.0-after`
- State: `MERGED`, merge commit `94e7879ac5731d06073eba2d3e3613830cf794dd`
- CI: - Make `KLoggingChannel` explicitly closeable while preserving no-arg companion-object usage. / - `./gradlew :bluetape4k-logging:compileKotlin :bluetape4k-logging:compileTestKotlin --no-configuration-cache` / - `./gradlew :bluetape4k-logging:test --tests 'io.bluetape4k.logging.coroutines.KLoggingChannelTest' --no-configuration-cache`\n- `./gradlew :bluetape4k-logging:test --no-configuration-cache`\n- `git diff --check`\n- IDE imports optimized for changed Kotlin files.\n- IDE diagnostics: index ready; no build errors. Per-file fresh analysis was unavailable because files were not open in the IDE.\n\n## Current-Session Codex Review\n- Scope: `bluetape4k-logging` Kotlin diff, tests, README docs, spec/plan/lesson.\n- Tier 1 Security: P0=0, P1=0. No credentials, user input parsing, auth boundary, or deserialization surface added.\n- Tier 2 Ops/SRE: P0=0, P1=0. Lifecycle cleanup path added; one shared default shutdown hook replaces per-instance hooks.\n- Tier 3 Structural/API: P0=0, P1=0. Public API is additive (`AutoCloseable`, `isClosed`, `closeAndJoin()`); existing no-arg usage preserved.\n- Tier 4 Kotlin/Coroutine: P0=0, P1=0. `CancellationException` rethrows before broad catch; collector starts `UNDISPATCHED` to avoid first-event drop.\n- Tier 5 Tests/Types: P0=0, P1=0. Former no-assert logging tests now assert emitted levels/messages/errors and collector shutdown.\n- Tier 6 Performance/Stability: P0=0, P1=0. No new blocking production calls or dependencies; test waits are bo

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #569 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `94e7879ac5731d06073eba2d3e3613830cf794dd`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
