### PR TITLE
[perf] Reduce Future wrapper watcher overhead

### DIFF
--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/FutureSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/FutureSupport.kt
@@ -1,9 +1,12 @@
 package io.bluetape4k.concurrent
 
+import io.bluetape4k.utils.ShutdownQueue
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.ExecutionException
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 import java.util.concurrent.Future
 
 /**
@@ -38,27 +41,42 @@ fun <T> Future<T>.asCompletableFuture(): CompletableFuture<T> = when (this@asCom
 }
 
 /**
- * [Future]를 [CompletableFuture]로 변환하는 래퍼.
- * Virtual thread에서 [Future.get]으로 블로킹 대기하여 폴링 오버헤드를 제거합니다.
- * [cancel]은 래핑된 Future에도 전파되어 불필요한 작업을 중단시킵니다.
+ * Wraps a [Future] as a [CompletableFuture].
+ *
+ * The wrapper waits for [Future.get] on a shared virtual-thread executor so callers do not
+ * allocate a new thread builder and unnamed watcher for every conversion. [cancel] still
+ * propagates to the wrapped [Future] and cancels the watcher task.
  */
 private class FutureToCompletableFutureWrapper<T>(private val wrapped: Future<T>): CompletableFuture<T>() {
-    init {
-        Thread.ofVirtual().name("future-wrapper").start {
-            try {
-                complete(wrapped.get())
-            } catch (e: CancellationException) {
-                cancel(true)
-            } catch (e: ExecutionException) {
-                completeExceptionally(e.cause ?: e)
-            } catch (e: InterruptedException) {
-                completeExceptionally(e)
-            }
+    private val watcher: Future<*> = FutureWrapperExecutor.submit {
+        try {
+            complete(wrapped.get())
+        } catch (e: CancellationException) {
+            super.cancel(true)
+        } catch (e: ExecutionException) {
+            completeExceptionally(e.cause ?: e)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            completeExceptionally(e)
         }
     }
 
     override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
         wrapped.cancel(mayInterruptIfRunning)
+        watcher.cancel(true)
         return super.cancel(mayInterruptIfRunning)
     }
+}
+
+private object FutureWrapperExecutor {
+    private val executor: ExecutorService = Executors.newThreadPerTaskExecutor(
+        Thread.ofVirtual().name("future-wrapper-", 0).factory()
+    )
+
+    init {
+        ShutdownQueue.register(executor)
+    }
+
+    fun submit(task: Runnable): Future<*> =
+        executor.submit(task)
 }

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/FutureSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/FutureSupportTest.kt
@@ -1,5 +1,8 @@
 package io.bluetape4k.concurrent
 
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.concurrent.virtualthread.VirtualFuture
 import io.bluetape4k.concurrent.virtualthread.virtualFuture
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
@@ -12,13 +15,20 @@ import io.bluetape4k.utils.Runtimex
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
-import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Future
 import java.util.concurrent.FutureTask
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -47,6 +57,36 @@ class FutureSupportTest {
         val result2 = future2.asCompletableFuture()
         result1.join() shouldBeEqualTo "value1"
         result2.join() shouldBeEqualTo "value2"
+    }
+
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @Test
+    fun `Future wrapper waits on named virtual executor thread`() {
+        val future = BlockingFuture<String>()
+        val completableFuture = future.asCompletableFuture()
+
+        future.awaitStarted()
+        val watcher = future.getterThread.get()
+
+        watcher.isVirtual.shouldBeTrue()
+        watcher.name.startsWith("future-wrapper-").shouldBeTrue()
+        (watcher.name == "future-wrapper").shouldBeFalse()
+
+        future.complete("value")
+        completableFuture.get(1, TimeUnit.SECONDS) shouldBeEqualTo "value"
+    }
+
+    @Test
+    fun `cancel propagates to wrapped Future and cancels wrapper`() {
+        val future = BlockingFuture<String>()
+        val completableFuture = future.asCompletableFuture()
+
+        future.awaitStarted()
+
+        completableFuture.cancel(true).shouldBeTrue()
+
+        future.isCancelled.shouldBeTrue()
+        completableFuture.isCancelled.shouldBeTrue()
     }
 
     @Test
@@ -120,5 +160,59 @@ class FutureSupportTest {
             .run()
 
         counter.get() shouldBeEqualTo Runtimex.availableProcessors * 2 * ITEM_COUNT / 4
+    }
+
+    private class BlockingFuture<T>: Future<T> {
+        val getterThread: AtomicReference<Thread> = AtomicReference()
+
+        private val started = CountDownLatch(1)
+        private val finished = CountDownLatch(1)
+        private val cancelled = AtomicBoolean(false)
+        private val value = AtomicReference<T>()
+
+        fun awaitStarted() {
+            started.await(1, TimeUnit.SECONDS).shouldBeTrue()
+        }
+
+        fun complete(result: T) {
+            value.set(result)
+            finished.countDown()
+        }
+
+        override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
+            cancelled.set(true)
+            finished.countDown()
+            return true
+        }
+
+        override fun isCancelled(): Boolean =
+            cancelled.get()
+
+        override fun isDone(): Boolean =
+            finished.count == 0L
+
+        override fun get(): T {
+            getterThread.set(Thread.currentThread())
+            started.countDown()
+            finished.await()
+            return completedValue()
+        }
+
+        override fun get(timeout: Long, unit: TimeUnit): T {
+            getterThread.set(Thread.currentThread())
+            started.countDown()
+            if (!finished.await(timeout, unit)) {
+                throw TimeoutException()
+            }
+            return completedValue()
+        }
+
+        private fun completedValue(): T {
+            if (cancelled.get()) {
+                throw CancellationException()
+            }
+            return value.get()
+                ?: throw ExecutionException(IllegalStateException("BlockingFuture completed without a value"))
+        }
     }
 }

--- a/docs/lessons/2026-05-20-issue-541-future-wrapper-executor.md
+++ b/docs/lessons/2026-05-20-issue-541-future-wrapper-executor.md
@@ -1,0 +1,47 @@
+# Lesson: Future Wrapper Executor
+
+**Date:** 2026-05-20
+**Issue:** #541
+**Branch:** `perf/issue-541-future-wrapper`
+
+---
+
+## Context
+
+`FutureToCompletableFutureWrapper` converted plain `Future<T>` instances by creating and
+starting a fresh virtual-thread builder in every wrapper instance. This preserved blocking
+`Future.get()` semantics but added avoidable allocation and made all watcher threads appear
+as the same `future-wrapper` name in diagnostics.
+
+## Decision
+
+Use one shared virtual-thread-per-task executor with a named factory:
+
+- Watcher tasks run through `Executors.newThreadPerTaskExecutor(...)`.
+- Thread names use the `future-wrapper-` prefix with per-thread numbering.
+- The executor is registered with `ShutdownQueue` to follow the existing core lifecycle pattern.
+- `cancel()` still cancels the wrapped `Future` first, then cancels the watcher task and the
+  wrapper `CompletableFuture`.
+
+This still uses one virtual thread per active blocking wait. That is intentional for a plain
+`Future.get()` adapter: without a callback API, avoiding the wait thread would require a
+polling scheduler or a bounded platform-thread pool, both of which are worse tradeoffs here.
+
+## Outcome
+
+The wrapper no longer builds and starts a virtual thread directly for each conversion, while
+existing success, exception, and cancellation behavior remains intact. New tests lock the
+named virtual watcher and wrapped-future cancellation contracts.
+
+## Verification Evidence
+
+- `./gradlew :bluetape4k-core:compileKotlin :bluetape4k-core:compileTestKotlin --no-configuration-cache`
+- `./gradlew :bluetape4k-core:test --tests 'io.bluetape4k.concurrent.FutureSupportTest' --no-configuration-cache`
+- `./gradlew :bluetape4k-core:test --no-configuration-cache`
+
+## Future Guidance
+
+When adapting blocking `Future` APIs into `CompletableFuture`, keep watcher execution behind
+a shared lifecycle-managed executor and preserve cancellation propagation to the wrapped
+resource. Avoid tests that assert wall-clock performance; prefer deterministic contracts such
+as thread naming, virtual-thread usage, completion behavior, and cancellation behavior.


### PR DESCRIPTION
## Summary

Closes #541

- PR 제목: [perf] Reduce Future wrapper watcher overhead

- Replaced direct per-wrapper `Thread.ofVirtual().start { ... }` watcher creation with a shared lifecycle-managed virtual-thread executor.
- Preserved wrapped `Future` cancellation propagation and added watcher-task cancellation.
- Added deterministic tests for named virtual watcher execution and wrapped-future cancellation.
- Added a lessons entry for the blocking Future adapter tradeoff.

Fixes #541

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Codex Review

- Current-session Codex Review completed.
- P0/P1 findings: none.
- Residual note: the shared virtual-thread-per-task executor still uses one virtual waiter per active blocking `Future.get()`; this is intentional because plain `Future` has no callback API.

## Validation

- `./gradlew :bluetape4k-core:compileKotlin :bluetape4k-core:compileTestKotlin --no-configuration-cache`
- `./gradlew :bluetape4k-core:test --tests 'io.bluetape4k.concurrent.FutureSupportTest' --no-configuration-cache`
- `./gradlew :bluetape4k-core:test --no-configuration-cache`
- `git diff --check`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #541, milestone `1.8.1`, assignee `debop`
- PR: #570, head `068a3dca0eacc1a4a7f443d641ed8cec6af31b3a`, milestone `1.8.1`, assignee `debop`
- Base: `develop`, head branch `perf/issue-541-future-wrapper`
- Labels: `enhancement`, `test`, `performance`
- State: `MERGED`, merge commit `bd33e3a09b772becef1d8f99918597fb972dd16a`
- CI: - `./gradlew :bluetape4k-core:compileKotlin :bluetape4k-core:compileTestKotlin --no-configuration-cache` / - `./gradlew :bluetape4k-core:test --tests 'io.bluetape4k.concurrent.FutureSupportTest' --no-configuration-cache` / - `./gradlew :bluetape4k-core:test --no-configuration-cache`

## DoD Status

- [x] Independent worktree and branch.
- [x] Compile and targeted tests pass.
- [x] Full core module test passes.
- [x] Lesson committed before PR.
- [x] No external advisor used; Codex Review handled in this session.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #570 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `bd33e3a09b772becef1d8f99918597fb972dd16a`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
