### PR TITLE
[perf] Keep FlowEvent wrappers source-compatible

### DIFF
--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/FlowEvent.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/FlowEvent.kt
@@ -18,21 +18,23 @@ import io.bluetape4k.coroutines.flow.exceptions.FlowNoElementException
 sealed interface FlowEvent<out T> {
 
     /**
-     * 값을 가진 이벤트입니다.
+     * Event containing a value.
      *
-     * > **성능 개선 TODO**: Kotlin 2.x에서 `@JvmInline value class Value<out T>(val value: T): FlowEvent<T>`로
-     * > 변환하면 hot-path per-event 객체 할당을 제거할 수 있습니다. 단, `componentN()` 소거와
-     * > 구조 분해 호환성을 사전에 확인해야 합니다.
+     * Keep this as a data class. `FlowEvent.Value` is normally emitted as the
+     * `FlowEvent<T>` interface type, where Kotlin/JVM value classes are boxed,
+     * so `@JvmInline` would not remove the hot-path allocation. It would also
+     * remove data-class source conveniences such as destructuring and `copy()`.
      */
     data class Value<out T>(val value: T): FlowEvent<T> {
         override fun toString(): String = "FlowEvent.Value($value)"
     }
 
     /**
-     * 오류를 가진 이벤트입니다.
+     * Event containing an error.
      *
-     * > **성능 개선 TODO**: Kotlin 2.x에서 `@JvmInline value class Error(val error: Throwable): FlowEvent<Nothing>`으로
-     * > 변환하면 per-event 객체 할당을 줄일 수 있습니다.
+     * Keep this as a data class for the same compatibility and boxing reasons
+     * as [Value]. When used as `FlowEvent<Nothing>`, a value-class variant would
+     * still be boxed by the JVM backend.
      */
     data class Error(val error: Throwable): FlowEvent<Nothing> {
         override fun toString(): String = "FlowEvent.Error($error)"

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/FlowEventTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/FlowEventTest.kt
@@ -1,11 +1,11 @@
 package io.bluetape4k.coroutines.flow.extensions
 
-import io.bluetape4k.coroutines.flow.exceptions.FlowNoElementException
-import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.coroutines.flow.exceptions.FlowNoElementException
+import io.bluetape4k.logging.coroutines.KLoggingChannel
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 
 class FlowEventTest: AbstractFlowTest() {
 
@@ -30,6 +30,15 @@ class FlowEventTest: AbstractFlowTest() {
     }
 
     @Test
+    fun `Value keeps data class source conveniences`() {
+        val event = FlowEvent.Value(1)
+        val (value) = event
+
+        value shouldBeEqualTo 1
+        event.copy(value = 2) shouldBeEqualTo FlowEvent.Value(2)
+    }
+
+    @Test
     fun `toString ofFlowEvent Error`() {
         val error = RuntimeException("Boom!")
         FlowEvent.Error(error).toString() shouldBeEqualTo "FlowEvent.Error($error)"
@@ -43,6 +52,16 @@ class FlowEventTest: AbstractFlowTest() {
         FlowEvent.Error(e).hashCode() shouldBeEqualTo FlowEvent.Error(e).hashCode()
 
         e.hashCode() shouldBeEqualTo FlowEvent.Error(e).hashCode()
+    }
+
+    @Test
+    fun `Error keeps data class source conveniences`() {
+        val e = RuntimeException("Boom!")
+        val event = FlowEvent.Error(e)
+        val (error) = event
+
+        error shouldBeEqualTo e
+        event.copy(error = IllegalStateException("next")).error.message shouldBeEqualTo "next"
     }
 
     @Test

--- a/docs/lessons/2026-05-20-issue-544-flowevent-value-class.md
+++ b/docs/lessons/2026-05-20-issue-544-flowevent-value-class.md
@@ -1,0 +1,35 @@
+# Issue 544 FlowEvent Value-Class Evaluation
+
+## Context
+
+Issue #544 asked whether `FlowEvent.Value` and `FlowEvent.Error` should move
+from data classes to Kotlin/JVM value classes to reduce hot-path allocations in
+Flow operators.
+
+## Decision
+
+Keep both wrappers as data classes. Kotlin/JVM value classes can implement
+interfaces, but they are boxed whenever they are used as another type. The
+current API emits and consumes these events as `FlowEvent<T>`, so a value-class
+implementation would still allocate in the important interface-typed path.
+
+## Outcome
+
+The old TODO comments were replaced with explicit KDoc decisions, and tests now
+lock the source conveniences that would disappear with value classes:
+destructuring through `component1()` and `copy()`.
+
+## Verification
+
+- Kotlin official documentation for inline value classes was checked for
+  interface inheritance and boxing rules.
+- `rg` and IDE reference lookup were used to inspect `FlowEvent` call sites;
+  the IDE was partially unavailable due dumb mode, so `rg` was the source of
+  truth for current usage.
+
+## Future Agents
+
+Do not revisit this as a plain `@JvmInline value class ... : FlowEvent<T>`
+change. Reopen only if the public API can avoid the `FlowEvent<T>` interface
+upcast on hot paths, or if Kotlin/JVM changes boxing behavior for interface
+and generic use.


### PR DESCRIPTION
## Summary

Closes #544

- PR 제목: [perf] Keep FlowEvent wrappers source-compatible

- keep `FlowEvent.Value` and `FlowEvent.Error` as data classes after the value-class compatibility review
- replace the old value-class TODOs with KDoc decisions explaining interface boxing and data-class source compatibility
- add tests that lock destructuring and `copy()` compatibility

Closes #544

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- [x] `./gradlew :bluetape4k-coroutines:compileKotlin :bluetape4k-coroutines:compileTestKotlin --no-configuration-cache`
- [x] `./gradlew :bluetape4k-coroutines:test --tests 'io.bluetape4k.coroutines.flow.extensions.*' --no-configuration-cache`
- [x] `./gradlew :bluetape4k-coroutines:test --tests 'io.bluetape4k.coroutines.flow.extensions.FlowEventTest' --no-configuration-cache`
- [x] `git diff --check`

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- Codex Review (current session): P0/P1=0. Value-class migration rejected because `FlowEvent<T>` interface use would still box on Kotlin/JVM and data-class source APIs would be removed.

## Metadata

- Issue: #544, milestone `1.8.1`, assignee `debop`
- PR: #571, head `a28a4e3c81946a044558f39722050f460192efca`, milestone `1.8.1`, assignee `debop`
- Base: `develop`, head branch `perf/issue-544-flowevent-value-class`
- Labels: `documentation`, `enhancement`, `test`, `performance`
- State: `MERGED`, merge commit `06d9c5070a1a82eb443d0fdcef58cf2da099e5a8`
- CI: - replace the old value-class TODOs with KDoc decisions explaining interface boxing and data-class source compatibility / - [x] `./gradlew :bluetape4k-coroutines:compileKotlin :bluetape4k-coroutines:compileTestKotlin --no-configuration-cache` / - [x] `./gradlew :bluetape4k-coroutines:test --tests 'io.bluetape4k.coroutines.flow.extensions.*' --no-configuration-cache`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #571 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `06d9c5070a1a82eb443d0fdcef58cf2da099e5a8`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
