### PR TITLE
[feat] Promote FlociServer to stable

### DIFF
--- a/docs/lessons/2026-05-20-issue-519-floci-stable.md
+++ b/docs/lessons/2026-05-20-issue-519-floci-stable.md
@@ -1,0 +1,41 @@
+# Issue 519 FlociServer Stable Promotion
+
+## Context
+
+Issue #519 asked to remove the circular deprecation between `LocalStackServer`
+and `FlociServer`, update the pinned Floci image, and verify that Floci service
+tests cover the LocalStack replacement path.
+
+## Decision
+
+Promote `FlociServer` to the stable open-source AWS emulator wrapper and keep
+`LocalStackServer` deprecated. The current upstream stable release is Floci
+`1.5.17`, published on 2026-05-18, so the default pinned tag should move past
+the issue's original `1.5.16` target.
+
+Do not use the `-compat` image as the default. Floci documents `x.y.z-compat`
+for images that include AWS CLI and boto3, while the standard pinned image is
+the right default for AWS SDK and Testcontainers usage.
+
+## Outcome
+
+`FlociServer` no longer carries `@Deprecated`, its default tag is pinned to
+`1.5.17`, and the Floci test package no longer suppresses deprecation warnings.
+`LocalStackServer` keeps a clear deprecation message that points open-source
+users to `FlociServer`.
+
+## Verification
+
+- GitHub Releases confirmed `floci-io/floci` `1.5.17` as the latest stable
+  non-draft, non-prerelease release at implementation time.
+- Docker Hub confirmed matching `floci/floci:1.5.17` and
+  `floci/floci:1.5.17-compat` tags.
+- Floci README confirmed standard vs compat image semantics.
+- `rg` confirmed that `FlociSTSTest` already exists, closing the issue's STS
+  coverage question.
+
+## Future Agents
+
+Use pinned stable Floci tags for reproducible testcontainers defaults. Reach for
+`-compat` only when an init-script workflow needs AWS CLI or boto3 inside the
+Floci image.

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/FlociServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/FlociServer.kt
@@ -13,42 +13,37 @@ import org.testcontainers.utility.DockerImageName
 import java.net.URI
 
 /**
- * [Floci](https://github.com/floci-io/floci) AWS 에뮬레이터 서버.
+ * Testcontainers wrapper for the [Floci](https://github.com/floci-io/floci) AWS emulator.
  *
- * GraalVM Native Image로 빌드된 경량 AWS 에뮬레이터입니다.
- * LocalStack Community edition archived(2026-03-23) 이후의 대안으로 활용할 수 있습니다.
+ * Floci is a lightweight AWS emulator built as a GraalVM Native Image. It is
+ * the default open-source replacement for LocalStack Community edition after
+ * the LocalStack Community repository was archived on 2026-03-23.
  *
- * Floci는 Maven 아티팩트를 제공하지 않으므로 Testcontainers의 [GenericContainer]를
- * 직접 래핑하여 사용합니다.
+ * This class wraps the official Docker image directly with [GenericContainer].
+ * Use the pinned [TAG] for reproducible tests. Floci also publishes `-compat`
+ * image tags that include AWS CLI and boto3 for init scripts, but the standard
+ * image is sufficient for AWS SDK/Testcontainers integration tests.
  *
- * > ⚠️ **주의**: Floci는 모든 AWS 서비스를 항상 활성화합니다.
- * > [withServices]를 호출해도 서비스 선택이 적용되지 않습니다 (no-op).
- *
- * > ⚠️ **@Deprecated**: floci는 아직 초기 단계입니다.
- * > 안정 버전이 확인될 때까지 [LocalStackServer]를 사용하는 것을 권장합니다.
+ * Floci enables all AWS services by default. Calling [withServices] is a no-op
+ * kept for [AwsEmulatorServer] and [LocalStackServer] migration compatibility.
  *
  * ```kotlin
- * // 기본 설정으로 Floci 서버 시작
  * val server = FlociServer()
  * server.start()
  *
- * // 에뮬레이터 엔드포인트와 자격 증명 정보를 SDK 타입에 의존하지 않고 사용
  * val endpoint: URI = server.awsEndpoint
  * val accessKey: String = server.awsAccessKey
  * val secretKey: String = server.awsSecretKey
  * val region: String = server.regionName
  * ```
  *
- * 참고: [Floci GitHub](https://github.com/floci-io/floci) · [Docker image](https://hub.docker.com/r/floci/floci/tags)
+ * References: [Floci GitHub](https://github.com/floci-io/floci) ·
+ * [Docker image](https://hub.docker.com/r/floci/floci/tags)
  *
- * @param imageName      Docker 이미지 이름 ([DockerImageName])
- * @param useDefaultPort Default 포트(4566)를 고정 바인딩할지 여부
- * @param reuse          컨테이너 재사용 여부
+ * @param imageName Docker image name.
+ * @param useDefaultPort Whether to bind the default port 4566 directly.
+ * @param reuse Whether to enable Testcontainers reuse.
  */
-@Deprecated(
-    message = "floci는 아직 초기 단계입니다. 안정 버전이 확인될 때까지 LocalStackServer를 사용하는 것을 권장합니다.",
-    level = DeprecationLevel.WARNING
-)
 class FlociServer private constructor(
     imageName: DockerImageName,
     useDefaultPort: Boolean,
@@ -56,40 +51,40 @@ class FlociServer private constructor(
 ): GenericContainer<FlociServer>(imageName), GenericServer, PropertyExportingServer, AwsEmulatorServer {
 
     companion object: KLogging() {
-        /** Floci Docker 이미지 이름 (Repository) */
+        /** Floci Docker image repository. */
         const val IMAGE = "floci/floci"
 
-        /** Floci Docker 이미지 기본 태그 */
-        const val TAG = "1.5.8"
+        /** Default pinned Floci Docker image tag. */
+        const val TAG = "1.5.17"
 
-        /** PropertyExportingServer 네임스페이스 및 컨테이너 식별자 */
+        /** PropertyExportingServer namespace and container identifier. */
         const val NAME = "floci"
 
-        /** Floci가 노출하는 단일 AWS 에뮬레이터 포트 */
+        /** Single AWS emulator port exposed by Floci. */
         const val PORT = 4566
 
-        /** 기본 access key (Floci는 임의의 값을 허용함) */
+        /** Default access key. Floci accepts any non-empty credential value. */
         const val DEFAULT_ACCESS_KEY = "test"
 
-        /** 기본 secret key (Floci는 임의의 값을 허용함) */
+        /** Default secret key. Floci accepts any non-empty credential value. */
         const val DEFAULT_SECRET_KEY = "test"
 
-        /** 기본 region 이름 */
+        /** Default AWS region. */
         const val DEFAULT_REGION = "us-east-1"
 
         /**
-         * 이미지 이름/태그로 [FlociServer] 인스턴스를 생성합니다.
+         * Creates a [FlociServer] from an image repository and tag.
          *
          * ```kotlin
-         * val server = FlociServer(image = "floci/floci", tag = "1.5.7")
+         * val server = FlociServer(image = "floci/floci", tag = FlociServer.TAG)
          * server.start()
          * // server.url.startsWith("http://") == true
          * ```
          *
-         * @param image          Docker 이미지 이름. blank이면 [IllegalArgumentException]이 발생합니다.
-         * @param tag            Docker 이미지 태그. blank이면 [IllegalArgumentException]이 발생합니다.
-         * @param useDefaultPort `true`면 4566 포트를 고정 바인딩합니다.
-         * @param reuse          컨테이너 재사용 여부
+         * @param image Docker image repository. Blank values are rejected.
+         * @param tag Docker image tag. Blank values are rejected.
+         * @param useDefaultPort Whether to bind the default port 4566 directly.
+         * @param reuse Whether to enable Testcontainers reuse.
          */
         @JvmStatic
         operator fun invoke(
@@ -106,17 +101,17 @@ class FlociServer private constructor(
         }
 
         /**
-         * [DockerImageName]으로 [FlociServer] 인스턴스를 생성합니다.
+         * Creates a [FlociServer] from a [DockerImageName].
          *
          * ```kotlin
-         * val image = DockerImageName.parse("floci/floci").withTag("1.5.7")
+         * val image = DockerImageName.parse("floci/floci").withTag(FlociServer.TAG)
          * val server = FlociServer(image)
-         * // server.isRunning == false (아직 start 전)
+         * // server.isRunning == false before start()
          * ```
          *
-         * @param imageName      Docker 이미지 이름
-         * @param useDefaultPort `true`면 4566 포트를 고정 바인딩합니다.
-         * @param reuse          컨테이너 재사용 여부
+         * @param imageName Docker image name.
+         * @param useDefaultPort Whether to bind the default port 4566 directly.
+         * @param reuse Whether to enable Testcontainers reuse.
          */
         @JvmStatic
         operator fun invoke(
@@ -128,44 +123,43 @@ class FlociServer private constructor(
         }
     }
 
-    /** 컨테이너의 매핑된 Floci 포트(4566)를 반환합니다. */
+    /** Mapped Floci port for the running container. */
     override val port: Int get() = getMappedPort(PORT)
 
-    /** Floci 서버의 기본 URL (예: `http://localhost:32768`)을 반환합니다. */
+    /** Base URL of the running Floci server, for example `http://localhost:32768`. */
     override val url: String get() = "http://$host:$port"
 
     /**
-     * AWS 에뮬레이터 엔드포인트 URI.
+     * AWS emulator endpoint URI.
      *
-     * AWS SDK 클라이언트의 `endpointOverride`로 사용합니다.
+     * Use this value as the AWS SDK `endpointOverride`.
      */
     override val awsEndpoint: URI get() = URI.create("http://$host:$port")
 
-    /** 기본 AWS access key (`"test"`). Floci는 임의의 값을 허용합니다. */
+    /** Default AWS access key. Floci accepts any non-empty credential value. */
     override val awsAccessKey: String = DEFAULT_ACCESS_KEY
 
-    /** 기본 AWS secret key (`"test"`). Floci는 임의의 값을 허용합니다. */
+    /** Default AWS secret key. Floci accepts any non-empty credential value. */
     override val awsSecretKey: String = DEFAULT_SECRET_KEY
 
-    /** 기본 AWS region 이름 (`"us-east-1"`). */
+    /** Default AWS region name. */
     override val regionName: String = DEFAULT_REGION
 
-    /** PropertyExportingServer 네임스페이스 ([NAME]). */
+    /** PropertyExportingServer namespace. */
     override val propertyNamespace: String = NAME
 
     /**
-     * 시스템 프로퍼티로 export할 키 목록을 반환합니다.
+     * Returns the keys exported to system properties.
      *
-     * 모든 키는 kebab-case 소문자를 사용합니다.
-     * `host`, `port`, `url`, `aws-endpoint`, `aws-access-key`, `aws-secret-key`, `region`을 노출합니다.
+     * All keys are lower-case kebab-case values.
      */
     override fun propertyKeys(): Set<String> =
         setOf("host", "port", "url", "aws-endpoint", "aws-access-key", "aws-secret-key", "region")
 
     /**
-     * 시스템 프로퍼티로 export할 key/value 맵을 반환합니다.
+     * Returns the key/value map exported to system properties.
      *
-     * 컨테이너가 시작된 이후에 호출되어야 [host], [port]가 유효합니다.
+     * Call this only after the container has started so [host] and [port] are valid.
      */
     override fun properties(): Map<String, String> = mapOf(
         "host" to host,
@@ -181,7 +175,7 @@ class FlociServer private constructor(
         addExposedPorts(PORT)
         withReuse(reuse)
 
-        // Floci는 공식 health endpoint를 제공하지 않으므로 listening port를 대기 전략으로 사용
+        // Floci does not expose a dedicated health endpoint, so wait for the listening port.
         setWaitStrategy(Wait.forListeningPort())
 
         if (useDefaultPort) {
@@ -190,13 +184,13 @@ class FlociServer private constructor(
     }
 
     /**
-     * 활성화할 AWS 서비스 목록을 지정합니다.
+     * Accepts the AWS service list for migration compatibility.
      *
-     * > ⚠️ Floci는 모든 AWS 서비스를 항상 활성화하므로 이 메서드는 **no-op**입니다.
-     * > 호출해도 서비스 선택이 적용되지 않으며, 동일한 [FlociServer] 인스턴스를 그대로 반환합니다.
+     * Floci always enables all services, so this method is a no-op and returns
+     * the same [FlociServer] instance.
      *
-     * @param services (무시됨) 활성화할 서비스 이름 목록
-     * @return 메서드 체이닝을 위한 현재 [FlociServer] 인스턴스
+     * @param services Ignored service names.
+     * @return This [FlociServer] instance for method chaining.
      */
     override fun withServices(vararg services: String): FlociServer {
         log.debug { "Floci enables all services by default. withServices(${services.toList()}) is a no-op." }
@@ -204,7 +198,7 @@ class FlociServer private constructor(
     }
 
     /**
-     * 컨테이너를 시작하고, 시스템 프로퍼티로 [properties]를 export합니다.
+     * Starts the container and exports [properties] to system properties.
      */
     override fun start() {
         super.start()
@@ -212,17 +206,18 @@ class FlociServer private constructor(
     }
 
     /**
-     * 테스트에서 재사용할 [FlociServer] 싱글턴을 제공합니다.
+     * Provides reusable [FlociServer] instances for tests.
      *
-     * 첫 접근 시 컨테이너를 시작하고 JVM 종료 시 자동 정리하도록 [ShutdownQueue]에 등록합니다.
+     * The singleton starts on first access and is registered in [ShutdownQueue]
+     * for JVM shutdown cleanup.
      */
     object Launcher {
         /**
-         * 지연 초기화되는 [FlociServer] 싱글턴.
+         * Lazily initialized [FlociServer] singleton.
          *
          * ```kotlin
          * val floci = FlociServer.Launcher.floci
-         * val endpoint = floci.endpoint
+         * val endpoint = floci.awsEndpoint
          * ```
          */
         val floci: FlociServer by lazy {

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/LocalStackServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/LocalStackServer.kt
@@ -12,24 +12,25 @@ import org.testcontainers.utility.DockerImageName
 import java.net.URI
 
 /**
- * LocalStackServer : 'a fully funcational local AWS cloud stack'
+ * Testcontainers wrapper for LocalStack.
  *
- * ```
- * // Run S3 Server
- * val s3Server = LocalStackServer().start()
- * ```
+ * LocalStack Community edition was archived on 2026-03-23. New open-source AWS
+ * emulator tests should use [FlociServer]. Keep this wrapper only for migration
+ * compatibility or for paid LocalStack Pro deployments that still require the
+ * LocalStack image.
  *
- * ```
+ * ```kotlin
  * val server = LocalStackServer()
  *    .withNetwork(network)
  *    .withNetworkAliases("notthis", "localstack")
- *    .start()
+ * server.start()
  * ```
  *
- * [Locakstack docker image](https://hub.docker.com/r/localstack/localstack/tags)
+ * [LocalStack Docker image](https://hub.docker.com/r/localstack/localstack/tags)
  */
+@Suppress("DEPRECATION")
 @Deprecated(
-    message = "LocalStack Community edition은 2026-03-23에 archived 되었습니다. FlociServer 또는 유료 LocalStack Pro 사용을 검토하세요.",
+    message = "LocalStack Community edition was archived on 2026-03-23. Use FlociServer for open-source AWS emulator tests.",
     replaceWith = ReplaceWith("FlociServer", "io.bluetape4k.testcontainers.aws.FlociServer"),
     level = DeprecationLevel.WARNING
 )
@@ -46,12 +47,12 @@ class LocalStackServer private constructor(
         const val PORT = 4566
 
         /**
-         * [LocalStackServer]를 생성합니다.
+         * Creates a [LocalStackServer].
          *
-         * @param image docker image (기본: `localstack/localstack`)
-         * @param tag docker image tag (기본: `3.6`)
-         * @param useDefaultPort 기본 포트를 사용할지 여부 (기본: `false`)
-         * @param reuse 재사용 여부 (기본: `true`)
+         * @param image Docker image repository.
+         * @param tag Docker image tag.
+         * @param useDefaultPort Whether to bind the default port 4566 directly.
+         * @param reuse Whether to enable Testcontainers reuse.
          */
         @JvmStatic
         operator fun invoke(
@@ -68,11 +69,11 @@ class LocalStackServer private constructor(
         }
 
         /**
-         * [LocalStackServer]를 생성합니다.
+         * Creates a [LocalStackServer] from a [DockerImageName].
          *
-         * @param imageName docker image name
-         * @param useDefaultPort 기본 포트를 사용할지 여부 (기본: `false`)
-         * @param reuse 재사용 여부 (기본: `true`)
+         * @param imageName Docker image name.
+         * @param useDefaultPort Whether to bind the default port 4566 directly.
+         * @param reuse Whether to enable Testcontainers reuse.
          */
         @JvmStatic
         operator fun invoke(
@@ -87,8 +88,8 @@ class LocalStackServer private constructor(
     override val port: Int get() = getMappedPort(PORT)
     override val url: String get() = "http://$host:$port"
 
-    // AwsEmulatorServer 프로퍼티 구현
-    // 프로퍼티 이름에 `aws` 접두어를 붙여 LocalStackContainer 의 Java getter 와의 JVM 시그니처 충돌을 방지한다.
+    // Prefix AwsEmulatorServer properties with `aws` to avoid JVM signature
+    // collisions with LocalStackContainer Java getters.
     override val awsEndpoint: URI get() = this.getEndpoint()
     override val awsAccessKey: String get() = this.getAccessKey()
     override val awsSecretKey: String get() = this.getSecretKey()
@@ -131,7 +132,7 @@ class LocalStackServer private constructor(
     }
 
     /**
-     * [LocalStackServer]용 Launcher
+     * Provides reusable [LocalStackServer] instances for tests.
      */
     object Launcher {
 
@@ -149,14 +150,14 @@ class LocalStackServer private constructor(
         )
 
         /**
-         * [LocalStackServer] 인스턴스를 생성하고 시작합니다.
+         * Creates and starts the default [LocalStackServer] instance.
          */
         val localStack: LocalStackServer by lazy {
             getLocalStack(*services.toTypedArray())
         }
 
         /**
-         * [LocalStackServer] 인스턴스를 생성하고 시작합니다.
+         * Creates and starts a [LocalStackServer] with the requested services.
          */
         fun getLocalStack(vararg services: String): LocalStackServer {
             return LocalStackServer().apply {

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/FlociServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/FlociServerTest.kt
@@ -1,10 +1,11 @@
 package io.bluetape4k.testcontainers.aws
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.testcontainers.AbstractContainerTest
 import io.bluetape4k.utils.ShutdownQueue
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeTrue
 import org.awaitility.kotlin.atMost
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.until
@@ -17,12 +18,10 @@ import software.amazon.awssdk.services.s3.model.CreateBucketRequest
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import java.time.Duration
-import io.bluetape4k.assertions.assertFailsWith
 
 /**
  * [FlociServer] 테스트
  */
-@Suppress("DEPRECATION")
 class FlociServerTest: AbstractContainerTest() {
 
     companion object: KLogging()
@@ -31,6 +30,11 @@ class FlociServerTest: AbstractContainerTest() {
     fun `blank image tag 는 허용하지 않는다`() {
         assertFailsWith<IllegalArgumentException> { FlociServer(image = " ") }
         assertFailsWith<IllegalArgumentException> { FlociServer(tag = " ") }
+    }
+
+    @Test
+    fun `Floci server uses the current stable image tag`() {
+        FlociServer.TAG shouldBeEqualTo "1.5.17"
     }
 
     @Test

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/AbstractFlociServiceTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/AbstractFlociServiceTest.kt
@@ -6,7 +6,6 @@ import io.bluetape4k.testcontainers.aws.FlociServer
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 
-@Suppress("DEPRECATION")
 abstract class AbstractFlociServiceTest: AbstractContainerTest() {
 
     companion object: KLogging()

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociCloudWatchTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociCloudWatchTest.kt
@@ -27,7 +27,6 @@ import java.time.Instant
  *
  * LocalStack 기반 [io.bluetape4k.testcontainers.aws.localstack.services.CloudWatchTest]에 대응합니다.
  */
-@Suppress("DEPRECATION")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class FlociCloudWatchTest : AbstractFlociServiceTest() {
 

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociDynamoDBTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociDynamoDBTest.kt
@@ -37,7 +37,6 @@ import software.amazon.awssdk.services.dynamodb.model.ScanRequest
  * > **알려진 제한사항**: Floci #587 — GSI Query 페이지네이션 무한루프 버그로 인해
  * > GSI 관련 테스트는 포함하지 않습니다.
  */
-@Suppress("DEPRECATION")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class FlociDynamoDBTest : AbstractFlociServiceTest() {
 

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociKMSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociKMSTest.kt
@@ -38,7 +38,6 @@ import software.amazon.awssdk.services.kms.model.KeyUsageType
  * > **알려진 제한사항 2**: `DisableKey`, `EnableKey`, `CreateGrant`, `ListGrants`, `RevokeGrant` 미지원 (Status 400).
  * > 해당 테스트는 `@Disabled`로 표시합니다.
  */
-@Suppress("DEPRECATION")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class FlociKMSTest : AbstractFlociServiceTest() {
 

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociKinesisTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociKinesisTest.kt
@@ -29,7 +29,6 @@ import java.time.Duration
  *
  * LocalStack 기반 [io.bluetape4k.testcontainers.aws.localstack.services.KinesisTest]에 대응합니다.
  */
-@Suppress("DEPRECATION")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class FlociKinesisTest : AbstractFlociServiceTest() {
 

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociS3Test.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociS3Test.kt
@@ -29,7 +29,6 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest
  * LocalStack 기반 [io.bluetape4k.testcontainers.aws.localstack.services.S3Test]에 대응합니다.
  * Floci는 virtual-hosted-style URL을 지원하지 않으므로 path-style access를 사용합니다.
  */
-@Suppress("DEPRECATION")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class FlociS3Test : AbstractFlociServiceTest() {
 

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSNSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSNSTest.kt
@@ -20,7 +20,6 @@ import software.amazon.awssdk.services.sns.SnsClient
  *
  * LocalStack 기반 [io.bluetape4k.testcontainers.aws.localstack.services.SNSTest]에 대응합니다.
  */
-@Suppress("DEPRECATION")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class FlociSNSTest : AbstractFlociServiceTest() {
 

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSQSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSQSTest.kt
@@ -21,7 +21,6 @@ import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry
  *
  * LocalStack 기반 [io.bluetape4k.testcontainers.aws.localstack.services.SQSTest]에 대응합니다.
  */
-@Suppress("DEPRECATION")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class FlociSQSTest : AbstractFlociServiceTest() {
 

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSTSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/floci/services/FlociSTSTest.kt
@@ -19,7 +19,6 @@ import software.amazon.awssdk.services.sts.StsClient
  *
  * LocalStack 기반 [io.bluetape4k.testcontainers.aws.localstack.services.STSTest]에 대응합니다.
  */
-@Suppress("DEPRECATION")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class FlociSTSTest : AbstractFlociServiceTest() {
 


### PR DESCRIPTION
## Summary

Closes #519

- PR 제목: [feat] Promote FlociServer to stable

- promote `FlociServer` by removing its deprecated annotation and pinning the default image to Floci `1.5.17`
- clarify `LocalStackServer` deprecation so open-source users are directed to `FlociServer`
- remove obsolete Floci deprecation suppressions and add a tag lock test
- record the `-compat` image decision in the lesson

Closes #519

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- [x] `./gradlew :bluetape4k-testcontainers:compileKotlin :bluetape4k-testcontainers:compileTestKotlin --no-configuration-cache`
- [x] `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.aws.FlociServerTest' --tests 'io.bluetape4k.testcontainers.aws.floci.*' --tests 'io.bluetape4k.testcontainers.aws.floci.services.*' --no-configuration-cache`\n- [x] `git diff --check`\n\n## Review\n- Codex Review (current session): P0/P1=0. `FlociServer` is no longer deprecated, `LocalStackServer` keeps the intended deprecation, and Floci `1.5.17` standard image is the correct pinned default for AWS SDK/Testcontainers usage.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #519, milestone `1.8.1`, assignee `debop`
- PR: #572, head `24c98ec7ce9fcae4cc7ca6352b08067397410ed0`, milestone `1.8.1`, assignee `debop`
- Base: `develop`, head branch `feat/issue-519-floci-stable`
- Labels: `documentation`, `enhancement`, `test`
- State: `MERGED`, merge commit `a1f006641d41603833f1167e87dc072747d5e877`
- CI: - promote `FlociServer` by removing its deprecated annotation and pinning the default image to Floci `1.5.17` / - clarify `LocalStackServer` deprecation so open-source users are directed to `FlociServer` / - remove obsolete Floci deprecation suppressions and add a tag lock test

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #572 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `a1f006641d41603833f1167e87dc072747d5e877`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
