### PR TITLE
test: cover gRPC server lifecycle contracts

### DIFF
--- a/docs/lessons/2026-05-20-issue-540-grpc-lifecycle.md
+++ b/docs/lessons/2026-05-20-issue-540-grpc-lifecycle.md
@@ -1,0 +1,36 @@
+# Issue 540 gRPC Server Lifecycle Tests
+
+## Context
+
+Issue #540 identified that `GrpcServer`, `AbstractGrpcServer`, and the
+in-process server variant had little direct lifecycle coverage for start, stop,
+shutdown fallback, and binding conflicts.
+
+## Decision
+
+Add a focused `GrpcServerTest` with real Netty and in-process servers for bind
+and replacement behavior, plus fake `io.grpc.Server` implementations for
+deterministic graceful and forced shutdown assertions. Add a protected
+`createServer()` seam to `AbstractGrpcInprocessServer` so its stop semantics can
+be tested without opening real transports.
+
+## Outcome
+
+Port-based servers now have coverage for start, stop, close delegation, port
+conflicts, graceful shutdown, forced `shutdownNow()`, and replacement startup on
+the released port. In-process servers now have coverage for start, stop, name
+conflicts, replacement startup on the released name, and forced shutdown after
+termination timeout.
+
+## Verification
+
+- `./gradlew :bluetape4k-grpc:compileKotlin :bluetape4k-grpc:compileTestKotlin --no-configuration-cache`
+- `./gradlew :bluetape4k-grpc:test --tests 'io.bluetape4k.grpc.GrpcServerTest' --no-configuration-cache --rerun-tasks` (8 passing)
+- `./gradlew :bluetape4k-grpc:test --no-configuration-cache` (61 passing, 4 pending)
+
+## Future Agents
+
+Keep lifecycle behavior in direct `GrpcServerTest` coverage. Use fake
+`io.grpc.Server` implementations for timeout and forced-shutdown branches so
+tests stay deterministic and do not wait for the real five-second shutdown
+timeout.

--- a/io/grpc/src/main/kotlin/io/bluetape4k/grpc/inprocess/AbstractGrpcInprocessServer.kt
+++ b/io/grpc/src/main/kotlin/io/bluetape4k/grpc/inprocess/AbstractGrpcInprocessServer.kt
@@ -5,7 +5,6 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
 import io.bluetape4k.logging.warn
-import io.bluetape4k.support.ifTrue
 import io.bluetape4k.support.requireInRange
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.utils.ShutdownQueue
@@ -22,7 +21,7 @@ import kotlin.concurrent.withLock
  *
  * ## 동작/계약
  * - [start]는 서버를 시작하고 JVM shutdown hook 큐에 종료 작업을 등록합니다.
- * - [stop]은 `shutdown + awaitTermination(5s)`를 수행합니다.
+ * - [stop] performs `shutdown + awaitTermination(5s)`, then calls `shutdownNow()` if termination times out.
  * - 생성 시 전달한 서비스들을 서버 builder에 등록합니다.
  *
  * ```kotlin
@@ -31,8 +30,8 @@ import kotlin.concurrent.withLock
  * ```
  */
 abstract class AbstractGrpcInprocessServer(
-    builder: InProcessServerBuilder,
-    vararg services: BindableService,
+    protected val builder: InProcessServerBuilder,
+    private vararg val services: BindableService,
 ): GrpcServer {
     constructor(name: String, vararg services: BindableService):
             this(InProcessServerBuilder.forName(name.requireNotBlank("name")), *services)
@@ -42,15 +41,23 @@ abstract class AbstractGrpcInprocessServer(
 
     companion object: KLogging()
 
-    private val server: Server by lazy {
-        builder.apply { services.forEach { addService(it) } }.build()
-    }
+    private val server: Server by lazy { createServer() }
 
     private val running = atomic(false)
     private val lock = reentrantLock()
 
     override val isRunning: Boolean by running
     override val isShutdown: Boolean get() = server.isShutdown
+
+    /**
+     * Creates the underlying in-process gRPC [Server].
+     *
+     * Subclasses may override this in tests or specialized servers to customize
+     * lifecycle behavior while keeping [start] and [stop] semantics unchanged.
+     */
+    protected open fun createServer(): Server {
+        return builder.apply { services.forEach { addService(it) } }.build()
+    }
 
     override fun start() {
         lock.withLock {
@@ -74,11 +81,11 @@ abstract class AbstractGrpcInprocessServer(
             if (!isShutdown) {
                 running.value = false
                 runCatching { server.shutdown() }
-                runCatching { server.awaitTermination(5, TimeUnit.SECONDS) }
-                    .isFailure
-                    .ifTrue {
-                        log.warn { "Timed out waiting for server shutdown" }
-                    }
+                val terminated = runCatching { server.awaitTermination(5, TimeUnit.SECONDS) }.getOrDefault(false)
+                if (!terminated) {
+                    log.warn { "InProcess gRPC server did not terminate within 5 seconds. Forcing shutdownNow()." }
+                    runCatching { server.shutdownNow() }
+                }
             }
         }
     }

--- a/io/grpc/src/test/kotlin/io/bluetape4k/grpc/GrpcServerTest.kt
+++ b/io/grpc/src/test/kotlin/io/bluetape4k/grpc/GrpcServerTest.kt
@@ -1,0 +1,251 @@
+package io.bluetape4k.grpc
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.grpc.examples.helloworld.GreeterService
+import io.bluetape4k.grpc.inprocess.AbstractGrpcInprocessServer
+import io.grpc.Server
+import io.grpc.ServerBuilder
+import io.grpc.inprocess.InProcessServerBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.io.IOException
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class GrpcServerTest: AbstractGrpcTest() {
+
+    @Test
+    fun `port server starts stops and lets a replacement reuse the bound port`() {
+        val server = PortLifecycleServer(0)
+        var boundPort = 0
+
+        try {
+            server.start()
+            server.isRunning.shouldBeTrue()
+            server.isShutdown.shouldBeFalse()
+            server.serviceDefinitions.size shouldBeEqualTo 1
+            boundPort = server.port
+            (boundPort > 0).shouldBeTrue()
+        } finally {
+            server.stop()
+        }
+        server.isRunning.shouldBeFalse()
+        server.isShutdown.shouldBeTrue()
+
+        val replacement = PortLifecycleServer(boundPort)
+        try {
+            replacement.start()
+            replacement.isRunning.shouldBeTrue()
+            replacement.port shouldBeEqualTo boundPort
+        } finally {
+            replacement.stop()
+        }
+    }
+
+    @Test
+    fun `port conflict fails during start and leaves the second server stopped`() {
+        val first = PortLifecycleServer(0)
+        try {
+            first.start()
+
+            val second = PortLifecycleServer(first.port)
+            try {
+                assertFailsWith<IOException> {
+                    second.start()
+                }
+                second.isRunning.shouldBeFalse()
+            } finally {
+                second.stop()
+            }
+        } finally {
+            first.stop()
+        }
+    }
+
+    @Test
+    fun `port server stop uses graceful shutdown when termination completes`() {
+        val recordingServer = RecordingServer(terminatesGracefully = true)
+        val server = RecordingPortLifecycleServer(recordingServer)
+
+        server.start()
+        server.stop()
+
+        server.isRunning.shouldBeFalse()
+        server.isShutdown.shouldBeTrue()
+        recordingServer.shutdownCalls shouldBeEqualTo 1
+        recordingServer.awaitTimedCalls shouldBeEqualTo 1
+        recordingServer.shutdownNowCalls shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `port server stop forces shutdown when graceful termination times out`() {
+        val recordingServer = RecordingServer(terminatesGracefully = false)
+        val server = RecordingPortLifecycleServer(recordingServer)
+
+        server.start()
+        server.stop()
+
+        server.isRunning.shouldBeFalse()
+        server.isShutdown.shouldBeTrue()
+        recordingServer.shutdownCalls shouldBeEqualTo 1
+        recordingServer.awaitTimedCalls shouldBeEqualTo 1
+        recordingServer.shutdownNowCalls shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `close delegates to stop for port servers`() {
+        val recordingServer = RecordingServer(terminatesGracefully = true)
+        val server = RecordingPortLifecycleServer(recordingServer)
+
+        server.start()
+        server.close()
+
+        server.isRunning.shouldBeFalse()
+        server.isShutdown.shouldBeTrue()
+        recordingServer.shutdownCalls shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `inprocess server starts stops and lets a replacement reuse the name`() {
+        val name = inprocessName()
+        val server = InprocessLifecycleServer(name)
+
+        try {
+            server.start()
+            server.isRunning.shouldBeTrue()
+            server.isShutdown.shouldBeFalse()
+        } finally {
+            server.stop()
+        }
+        server.isRunning.shouldBeFalse()
+        server.isShutdown.shouldBeTrue()
+
+        val replacement = InprocessLifecycleServer(name)
+        try {
+            replacement.start()
+            replacement.isRunning.shouldBeTrue()
+        } finally {
+            replacement.stop()
+        }
+    }
+
+    @Test
+    fun `inprocess name conflict fails during start and leaves the second server stopped`() {
+        val name = inprocessName()
+        val first = InprocessLifecycleServer(name)
+        try {
+            first.start()
+
+            val second = InprocessLifecycleServer(name)
+            try {
+                assertFailsWith<IOException> {
+                    second.start()
+                }
+                second.isRunning.shouldBeFalse()
+            } finally {
+                second.stop()
+            }
+        } finally {
+            first.stop()
+        }
+    }
+
+    @Test
+    fun `inprocess server stop forces shutdown when graceful termination times out`() {
+        val recordingServer = RecordingServer(terminatesGracefully = false)
+        val server = RecordingInprocessLifecycleServer(recordingServer)
+
+        server.start()
+        server.stop()
+
+        server.isRunning.shouldBeFalse()
+        server.isShutdown.shouldBeTrue()
+        recordingServer.shutdownCalls shouldBeEqualTo 1
+        recordingServer.awaitTimedCalls shouldBeEqualTo 1
+        recordingServer.shutdownNowCalls shouldBeEqualTo 1
+    }
+
+    private fun inprocessName(): String =
+        "grpc-server-test-${UUID.randomUUID()}"
+
+    private class PortLifecycleServer(port: Int): AbstractGrpcServer(port, GreeterService())
+
+    private class RecordingPortLifecycleServer(
+        private val recordingServer: RecordingServer,
+    ): AbstractGrpcServer(ServerBuilder.forPort(1), emptyList()) {
+
+        override fun createServer(): Server =
+            recordingServer
+    }
+
+    private class InprocessLifecycleServer(name: String): AbstractGrpcInprocessServer(name, GreeterService())
+
+    private class RecordingInprocessLifecycleServer(
+        private val recordingServer: RecordingServer,
+    ): AbstractGrpcInprocessServer(InProcessServerBuilder.forName(inprocessName())) {
+
+        override fun createServer(): Server =
+            recordingServer
+
+        private companion object {
+            fun inprocessName(): String =
+                "recording-inprocess-${UUID.randomUUID()}"
+        }
+    }
+
+    private class RecordingServer(
+        private val terminatesGracefully: Boolean,
+    ): Server() {
+        var shutdownCalls = 0
+            private set
+        var shutdownNowCalls = 0
+            private set
+        var awaitTimedCalls = 0
+            private set
+
+        private var started = false
+        private var shutdown = false
+        private var terminated = false
+
+        override fun start(): Server {
+            started = true
+            return this
+        }
+
+        override fun shutdown(): Server {
+            shutdownCalls++
+            shutdown = true
+            terminated = terminatesGracefully
+            return this
+        }
+
+        override fun shutdownNow(): Server {
+            shutdownNowCalls++
+            shutdown = true
+            terminated = true
+            return this
+        }
+
+        override fun isShutdown(): Boolean =
+            shutdown
+
+        override fun isTerminated(): Boolean =
+            terminated
+
+        override fun awaitTermination(timeout: Long, unit: TimeUnit): Boolean {
+            awaitTimedCalls++
+            return terminated
+        }
+
+        override fun awaitTermination() {
+            terminated = true
+        }
+
+        override fun getPort(): Int =
+            if (started) 1 else -1
+    }
+}


### PR DESCRIPTION
## Summary

Closes #540

- PR 제목: test: cover gRPC server lifecycle contracts

- Add `GrpcServerTest` covering port-based start/stop, replacement startup, port conflicts, close delegation, graceful shutdown, and forced shutdown.
- Add in-process lifecycle coverage for start/stop, replacement startup, name conflicts, and forced shutdown.
- Add a protected `createServer()` seam to `AbstractGrpcInprocessServer` and align timeout handling with forced `shutdownNow()`.
- Record the durable lesson for #540.

Closes #540

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- `./gradlew :bluetape4k-grpc:compileKotlin :bluetape4k-grpc:compileTestKotlin --no-configuration-cache`
- `./gradlew :bluetape4k-grpc:test --tests 'io.bluetape4k.grpc.GrpcServerTest' --no-configuration-cache --rerun-tasks` (8 passing)\n- `./gradlew :bluetape4k-grpc:compileKotlin :bluetape4k-grpc:compileTestKotlin :bluetape4k-grpc:test --no-configuration-cache` (61 passing, 4 pending)\n- `git diff --check`\n\n## Review\n- Codex Review, current session: P0/P1=0.\n- External Claude review skipped per user instruction; Codex handled the review in-session.\n\n## Notes\n- Forced-shutdown branches use fake `io.grpc.Server` implementations to avoid sleeping through real five-second timeout windows.\n- Full repository test suite was not run beyond `:bluetape4k-grpc`.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #540, milestone `1.8.1`, assignee `debop`
- PR: #574, head `10e098f703f5dc3826a1ce49b2e81f3913695feb`, milestone `1.8.1`, assignee `debop`
- Base: `develop`, head branch `test/issue-540-grpc-lifecycle`
- Labels: `enhancement`, `test`, `infra/io`, `1.8.0-after`
- State: `MERGED`, merge commit `c1801c0fc8035540d24fcfac800d4ce51608b734`
- CI: - Add a protected `createServer()` seam to `AbstractGrpcInprocessServer` and align timeout handling with forced `shutdownNow()`. / - `./gradlew :bluetape4k-grpc:compileKotlin :bluetape4k-grpc:compileTestKotlin --no-configuration-cache` / - `./gradlew :bluetape4k-grpc:test --tests 'io.bluetape4k.grpc.GrpcServerTest' --no-configuration-cache --rerun-tasks` (8 passing)\n- `./gradlew :bluetape4k-grpc:compileKotlin :bluetape4k-grpc:compileTestKotlin :bluetape4k-grpc:test --no-configuration-cache` (61 passing, 4 pending)\n- `git diff --check`\n\n## Review\n- Codex Review, current session: P0/P1=0.\n- External Claude review skipped per user instruction; Codex handled the review in-session.\n\n## Notes\n- Forced-shutdown branches use fake `io.grpc.Server` implementations to avoid sleeping through real five-second timeout windows.\n- Full repository test suite was not run beyond `:bluetape4k-grpc`.

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #574 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `c1801c0fc8035540d24fcfac800d4ce51608b734`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
