### PR TITLE
chore: remove deprecated Kafka APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 ### Changed
 
+### Breaking Changes
+
+- Removed the deprecated Kafka/Kafka4 JDK-backed codecs (`JdkKafkaCodec`, `LZ4JdkKafkaCodec`, `SnappyJdkKafkaCodec`, `ZstdJdkKafkaCodec`) and the corresponding `KafkaCodecs.*Jdk` registry entries. Use the Fory or Kryo codec variants instead ([#474](https://github.com/bluetape4k/bluetape4k-projects/issues/474)).
+- Removed the deprecated Kafka/Kafka4 Spring send aliases (`sendAndAwait`, `awaitSend`, `awaitSendDefault`, `sendSuspending`) and metrics aliases (`getMetricValue`). Use `suspendSend`, `suspendSendDefault`, and `getMetricValueOrNull` instead ([#474](https://github.com/bluetape4k/bluetape4k-projects/issues/474)).
+
 ### Fixed
 
 ---

--- a/docs/infra-deprecated-inventory.md
+++ b/docs/infra-deprecated-inventory.md
@@ -1,26 +1,27 @@
 # infra Deprecated API Inventory
 
 Snapshot: 2026-05-09 KST
+Updated: 2026-05-20 KST
 Issue: [#110](https://github.com/bluetape4k/bluetape4k-projects/issues/110)
 
-This inventory records every tracked `infra/` source file that currently declares
-`@Deprecated`. It is a planning document only; code removal and replacement
-work should happen in follow-up PRs.
+This inventory records tracked `infra/` and related cache source files that
+still declare `@Deprecated`. Completed cleanup waves are removed from the active
+inventory.
 
 ## Summary
 
 | Decision | Count | Meaning |
 |---|---:|---|
-| Delete | 17 files | Deprecated API has a direct replacement and should not remain in the next cleanup line. |
-| Replace call sites first | 4 files | Repo-local tests or samples still exercise the deprecated API and must move first. |
+| Delete | 7 files | Deprecated API has a direct replacement and should not remain in the next cleanup line. |
+| Replace call sites first | 2 files | Repo-local tests or samples still exercise the deprecated API and must move first. |
 | Keep | 0 files | No deprecated `infra/` API needs long-term retention. |
 
 `infra/kafka4` mirrors several `infra/kafka` deprecated APIs, so the current
 scope is larger than the original 12-file issue comment.
 
-2026-05-20 update: `kafka`/`kafka4` JDK-backed Kafka codecs are now staged as
-`@BluetapeObsoleteApi` + `DeprecationLevel.ERROR`; final API removal remains the
-next breaking cleanup step.
+2026-05-20 update: `kafka`/`kafka4` send aliases, metric aliases, and JDK-backed
+Kafka codecs were removed from the active inventory in the issue #474 PR A
+cleanup wave.
 
 ## Inventory
 
@@ -28,25 +29,19 @@ next breaking cleanup step.
 |---:|---|---|---|---|---|---|
 | 1 | `cache-core` | `cache/core/src/main/kotlin/io/bluetape4k/cache/caffeine/CaffeineSupport.kt` | `AsyncCache.getSuspending(...)` | KDoc sample only | Delete | `AsyncCache.suspendGet(...)` |
 | 2 | `cache-lettuce` | `cache/lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceSuspendNearCache.kt` | `clearFrontCache()` | Definition only | Delete | `clearLocal()` |
-| 3 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt` | `Producer.getMetricValue(...)` | Definition only | Delete | `getMetricValueOrNull(...).asDouble()` |
-| 4 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt` | `JdkKafkaCodec` | Definition only; compile-error gated | Delete in breaking cleanup | `ForyKafkaCodec` or `KryoKafkaCodec` |
-| 5 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/KafkaOperationsExtensions.kt` | `sendAndAwait(...)`, `awaitSendDefault(...)` overloads | Definition only | Delete | `suspendSend(...)` / `suspendSendDefault(...)` |
-| 6 | `kafka` | `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt` | `awaitSend(...)`, `sendSuspending(...)`, `getMetricValue(...)` | KDoc/definition only | Delete | `suspendSend(...)`, `getMetricValueOrNull(...).asDouble()` |
-| 7 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt` | `Producer.getMetricValue(...)` | Definition only | Delete | `getMetricValueOrNull(...).asDouble()` |
-| 8 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt` | `JdkKafkaCodec` | Definition only; compile-error gated | Delete in breaking cleanup | `ForyKafkaCodec` or `KryoKafkaCodec` |
-| 9 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/KafkaOperationsExtensions.kt` | `sendAndAwait(...)`, `awaitSendDefault(...)` overloads | Definition only | Delete | `suspendSend(...)` / `suspendSendDefault(...)` |
-| 10 | `kafka4` | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt` | `awaitSend(...)`, `sendSuspending(...)`, `getMetricValue(...)` | Definition only | Delete | `suspendSend(...)`, `getMetricValueOrNull(...).asDouble()` |
-| 11 | `lettuce` | `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/LettuceConst.kt` | `DEFAULT_DELIMETER` typo | Definition only | Delete | `DEFAULT_DELIMITER` |
-| 12 | `lettuce` | `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/RedisFutureSupport.kt` | `suspendAwait()`, `coAwait()` | `RedisFutureSupportTest` compatibility tests | Replace tests, then delete | `awaitSuspending()` |
-| 13 | `opentelemetry` | `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/SpanCoroutineSupport.kt` | `SpanBuilder.useSuspendSpan(...)` overloads | One compatibility test path | Replace tests, then delete | `useSpanSuspending(...)` |
-| 14 | `opentelemetry` | `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanExporterSupport.kt` | `spanExportOf(...)` | Definition only | Delete | `spanExporterOf(...)` |
-| 15 | `opentelemetry` | `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanProcessorSupport.kt` | `batchSpanProcess(...)` | Definition only | Delete | `batchSpanProcessorOf(...)` |
-| 16 | `redisson` | `infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/RedissonConst.kt` | `DEFAULT_DELIMETER` typo | Definition only | Delete | `DEFAULT_DELIMITER` |
-| 17 | `resilience4j` | `infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/SuspendDecorators.kt` | `decoreate()` typo overloads | Definition only | Delete | `decorate()` |
+| 3 | `lettuce` | `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/LettuceConst.kt` | `DEFAULT_DELIMETER` typo | Definition only | Delete | `DEFAULT_DELIMITER` |
+| 4 | `lettuce` | `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/RedisFutureSupport.kt` | `suspendAwait()`, `coAwait()` | `RedisFutureSupportTest` compatibility tests | Replace tests, then delete | `awaitSuspending()` |
+| 5 | `opentelemetry` | `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/SpanCoroutineSupport.kt` | `SpanBuilder.useSuspendSpan(...)` overloads | One compatibility test path | Replace tests, then delete | `useSpanSuspending(...)` |
+| 6 | `opentelemetry` | `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanExporterSupport.kt` | `spanExportOf(...)` | Definition only | Delete | `spanExporterOf(...)` |
+| 7 | `opentelemetry` | `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanProcessorSupport.kt` | `batchSpanProcess(...)` | Definition only | Delete | `batchSpanProcessorOf(...)` |
+| 8 | `redisson` | `infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/RedissonConst.kt` | `DEFAULT_DELIMETER` typo | Definition only | Delete | `DEFAULT_DELIMITER` |
+| 9 | `resilience4j` | `infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/SuspendDecorators.kt` | `decoreate()` typo overloads | Definition only | Delete | `decorate()` |
 
 ## Follow-Up PR Split
 
 ### PR A: Kafka deprecated surface cleanup
+
+Status: Done in issue #474 PR A.
 
 Scope:
 

--- a/docs/lessons/2026-05-20-issue-474-kafka-deprecated-removal.md
+++ b/docs/lessons/2026-05-20-issue-474-kafka-deprecated-removal.md
@@ -1,0 +1,36 @@
+# Issue 474 Kafka Deprecated Removal
+
+## Context
+
+Issue #474 starts the breaking cleanup for deprecated infra APIs. PR A removes
+the Kafka/Kafka4 deprecated surface that was already staged behind compile-error
+deprecations and compatibility tests.
+
+## Decision
+
+Remove the deprecated Kafka/Kafka4 JDK-backed codecs and registry entries rather
+than keeping compile-error gated compatibility APIs. Remove send and metric
+aliases after confirming repo-local callers only exercised compatibility tests.
+
+## Outcome
+
+`infra/kafka` and `infra/kafka4` now expose only the canonical Fory/Kryo codec
+families, `suspendSend`/`suspendSendDefault`, and `getMetricValueOrNull`.
+README files, CHANGELOG, and the deprecated API inventory now match the active
+API surface.
+
+## Verification
+
+- `rg` found no removed symbols or `@Deprecated` declarations in kafka/kafka4
+  source, tests, or README files.
+- `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka:compileTestKotlin :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka4:compileTestKotlin --no-configuration-cache`
+  passed.
+- `./gradlew :bluetape4k-kafka:test :bluetape4k-kafka4:test --no-configuration-cache`
+  passed: kafka 263 tests, kafka4 274 tests, failures 0, errors 0.
+- `git diff --check` passed.
+
+## Future Guidance
+
+For later #474 PRs, first replace compatibility tests with canonical API tests,
+then delete the deprecated APIs and rerun the affected module tests serially if
+they use Testcontainers or embedded infrastructure.

--- a/infra/kafka/README.ko.md
+++ b/infra/kafka/README.ko.md
@@ -162,16 +162,12 @@ val compressed = lz4ForyCodec.serialize("test-topic", largeObject)
 | `KafkaCodecs.String`    | UTF-8 문자열 직렬화        |
 | `KafkaCodecs.ByteArray` | 바이트 배열 직접 전달         |
 | `KafkaCodecs.Jackson`   | JSON 직렬화             |
-| `KafkaCodecs.Jdk`       | **Obsolete / 컴파일 오류 게이트** — Java 직렬화 (RCE 위험, Fory 사용 권장) |
 | `KafkaCodecs.Kryo`      | Kryo 바이너리 직렬화        |
 | `KafkaCodecs.Fory`      | Fory 바이너리 직렬화 (고성능, 권장) |
-| `KafkaCodecs.LZ4Jdk`    | **Obsolete / 컴파일 오류 게이트** — LZ4 압축 + Java 직렬화 |
 | `KafkaCodecs.Lz4Kryo`   | LZ4 압축 + Kryo 직렬화    |
 | `KafkaCodecs.Lz4Fory`   | LZ4 압축 + Fory 직렬화    |
-| `KafkaCodecs.SnappyJdk` | **Obsolete / 컴파일 오류 게이트** — Snappy 압축 + Java 직렬화 |
 | `KafkaCodecs.SnappyKryo` | Snappy 압축 + Kryo 직렬화 |
 | `KafkaCodecs.SnappyFory` | Snappy 압축 + Fory 직렬화 |
-| `KafkaCodecs.ZstdJdk`   | **Obsolete / 컴파일 오류 게이트** — Zstd 압축 + Java 직렬화 |
 | `KafkaCodecs.ZstdKryo`  | Zstd 압축 + Kryo 직렬화   |
 | `KafkaCodecs.ZstdFory`  | Zstd 압축 + Fory 직렬화   |
 
@@ -432,7 +428,7 @@ io.bluetape4k.kafka
 │   ├── KafkaCodec.kt         # 기본 Codec 인터페이스
 │   ├── KafkaCodecs.kt        # Codec 인스턴스 제공
 │   ├── JacksonKafkaCodec.kt  # JSON 직렬화
-│   ├── BinaryKafkaCodecs.kt  # 바이너리 직렬화 (Kryo, Fory; obsolete JDK 호환)
+│   ├── BinaryKafkaCodecs.kt  # 바이너리 직렬화 (Kryo, Fory)
 │   ├── StringKafkaCodec.kt   # 문자열 직렬화
 │   └── ByteArrayKafkaCodec.kt # 바이트 배열 직렬화
 ├── coroutines/               # Coroutine 지원

--- a/infra/kafka/README.md
+++ b/infra/kafka/README.md
@@ -162,16 +162,12 @@ Available codecs:
 | `KafkaCodecs.String`    | UTF-8 string serialization              |
 | `KafkaCodecs.ByteArray` | Raw byte array passthrough              |
 | `KafkaCodecs.Jackson`   | JSON serialization                      |
-| `KafkaCodecs.Jdk`       | **Obsolete / compile-error gated** — JDK serialization (RCE risk, use Fory) |
 | `KafkaCodecs.Kryo`      | Kryo binary serialization               |
 | `KafkaCodecs.Fory`      | Fory binary serialization               |
-| `KafkaCodecs.LZ4Jdk`    | **Obsolete / compile-error gated** — LZ4 compression + Java serialization |
 | `KafkaCodecs.Lz4Kryo`   | LZ4 compression + Kryo serialization    |
 | `KafkaCodecs.Lz4Fory`   | LZ4 compression + Fory serialization    |
-| `KafkaCodecs.SnappyJdk` | **Obsolete / compile-error gated** — Snappy compression + Java serialization |
 | `KafkaCodecs.SnappyKryo` | Snappy compression + Kryo serialization |
 | `KafkaCodecs.SnappyFory` | Snappy compression + Fory serialization |
-| `KafkaCodecs.ZstdJdk`   | **Obsolete / compile-error gated** — Zstd compression + Java serialization |
 | `KafkaCodecs.ZstdKryo`  | Zstd compression + Kryo serialization   |
 | `KafkaCodecs.ZstdFory`  | Zstd compression + Fory serialization   |
 
@@ -433,7 +429,7 @@ io.bluetape4k.kafka
 │   ├── KafkaCodec.kt         # Base codec interface
 │   ├── KafkaCodecs.kt        # Codec instances
 │   ├── JacksonKafkaCodec.kt  # JSON serialization
-│   ├── BinaryKafkaCodecs.kt  # Binary serialization (Kryo, Fory; obsolete JDK compatibility)
+│   ├── BinaryKafkaCodecs.kt  # Binary serialization (Kryo, Fory)
 │   ├── StringKafkaCodec.kt   # String serialization
 │   └── ByteArrayKafkaCodec.kt # Byte array serialization
 ├── coroutines/               # Coroutine support

--- a/infra/kafka/build.gradle.kts
+++ b/infra/kafka/build.gradle.kts
@@ -14,7 +14,6 @@ configurations {
 }
 
 dependencies {
-    api(project(":bluetape4k-annotations"))
     implementation(platform(libs.spring.boot.dependencies))
     api(project(":bluetape4k-core"))
     api(project(":bluetape4k-io"))

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt
@@ -1,6 +1,5 @@
 package io.bluetape4k.kafka
 
-import io.bluetape4k.support.asDoubleOrNull
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.Producer
 import org.apache.kafka.common.serialization.Serializer
@@ -57,25 +56,6 @@ fun <K, V> producerOf(
     keySerializer: Serializer<K>? = null,
     valueSerializer: Serializer<V>? = null,
 ): Producer<K, V> = KafkaProducer(props, keySerializer, valueSerializer)
-
-/**
- * Producer 의 metrics 측정 값을 조회합니다.
- *
- * **경고**: 메트릭 이름이 없거나 오타인 경우 `0.0`을 반환하여 실제 `0.0` 값과 구별할 수 없습니다.
- * 대신 [getMetricValueOrNull]을 사용하세요.
- *
- * ```
- * val sendCount = producer.getMetricValueOrNull("record-send-total").asDouble()
- * ```
- * @param metricName metric name to retrieve
- * @return metric 값 (메트릭이 없으면 0.0 — 실제 0과 구별 불가)
- */
-@Deprecated(
-    message = "메트릭 이름이 없거나 오타인 경우 0.0을 반환하여 실제 0.0 값과 구별할 수 없습니다. getMetricValueOrNull()을 사용하세요.",
-    replaceWith = ReplaceWith("getMetricValueOrNull(metricName).asDouble()", "io.bluetape4k.support.asDouble")
-)
-fun <K, V> Producer<K, V>.getMetricValue(metricName: String): Double =
-    getMetricValueOrNull(metricName)?.asDoubleOrNull() ?: 0.0
 
 /**
  * Producer 의 metrics 측정 값을 조회합니다. 메트릭이 없으면 `null`을 반환합니다.

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
@@ -1,6 +1,5 @@
 package io.bluetape4k.kafka.codec
 
-import io.bluetape4k.annotations.BluetapeObsoleteApi
 import io.bluetape4k.io.serializer.BinarySerializer
 import io.bluetape4k.io.serializer.BinarySerializers
 import org.apache.kafka.common.header.Headers
@@ -30,30 +29,6 @@ abstract class BinaryKafkaCodec(
 }
 
 /**
- * Kafka codec backed by JDK serialization.
- *
- * ## Security
- *
- * JDK deserialization can execute attacker-controlled object graphs when
- * untrusted bytes are decoded. Use [ForyKafkaCodec] for new code.
- *
- * ```kotlin
- * val codec = ForyKafkaCodec()
- * val bytes = codec.serialize("topic", null, "hello")
- * val result = codec.deserialize("topic", null, bytes)
- * // result == "hello"
- * ```
- */
-@BluetapeObsoleteApi
-@Deprecated(
-    message = "JDK serialization is unsafe for untrusted bytes. Use ForyKafkaCodec instead.",
-    replaceWith = ReplaceWith("ForyKafkaCodec()"),
-    level = DeprecationLevel.ERROR,
-)
-@Suppress("DEPRECATION")
-class JdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.Jdk)
-
-/**
  * Kryo 직렬화를 이용한 Kafka Codec
  *
  * ```kotlin
@@ -76,29 +51,6 @@ class KryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.Kryo)
  * ```
  */
 class ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.Fory)
-
-/**
- * Kafka codec backed by LZ4-compressed JDK serialization.
- *
- * ## Security
- *
- * JDK deserialization can execute attacker-controlled object graphs when
- * untrusted bytes are decoded. Use [LZ4ForyKafkaCodec] for new code.
- *
- * ```kotlin
- * val codec = LZ4ForyKafkaCodec()
- * val bytes = codec.serialize("topic", null, "hello")
- * val result = codec.deserialize("topic", null, bytes)
- * // result == "hello"
- * ```
- */
-@BluetapeObsoleteApi
-@Deprecated(
-    message = "JDK serialization is unsafe for untrusted bytes. Use LZ4ForyKafkaCodec instead.",
-    replaceWith = ReplaceWith("LZ4ForyKafkaCodec()"),
-    level = DeprecationLevel.ERROR,
-)
-class LZ4JdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Jdk)
 
 /**
  * LZ4 압축 + Kryo 직렬화를 이용한 Kafka Codec
@@ -125,29 +77,6 @@ class LZ4KryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Kryo)
 class LZ4ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Fory)
 
 /**
- * Kafka codec backed by Snappy-compressed JDK serialization.
- *
- * ## Security
- *
- * JDK deserialization can execute attacker-controlled object graphs when
- * untrusted bytes are decoded. Use [SnappyForyKafkaCodec] for new code.
- *
- * ```kotlin
- * val codec = SnappyForyKafkaCodec()
- * val bytes = codec.serialize("topic", null, "hello")
- * val result = codec.deserialize("topic", null, bytes)
- * // result == "hello"
- * ```
- */
-@BluetapeObsoleteApi
-@Deprecated(
-    message = "JDK serialization is unsafe for untrusted bytes. Use SnappyForyKafkaCodec instead.",
-    replaceWith = ReplaceWith("SnappyForyKafkaCodec()"),
-    level = DeprecationLevel.ERROR,
-)
-class SnappyJdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyJdk)
-
-/**
  * Snappy 압축 + Kryo 직렬화를 이용한 Kafka Codec
  *
  * ```kotlin
@@ -170,29 +99,6 @@ class SnappyKryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyKryo)
  * ```
  */
 class SnappyForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyFory)
-
-/**
- * Kafka codec backed by Zstd-compressed JDK serialization.
- *
- * ## Security
- *
- * JDK deserialization can execute attacker-controlled object graphs when
- * untrusted bytes are decoded. Use [ZstdForyKafkaCodec] for new code.
- *
- * ```kotlin
- * val codec = ZstdForyKafkaCodec()
- * val bytes = codec.serialize("topic", null, "hello")
- * val result = codec.deserialize("topic", null, bytes)
- * // result == "hello"
- * ```
- */
-@BluetapeObsoleteApi
-@Deprecated(
-    message = "JDK serialization is unsafe for untrusted bytes. Use ZstdForyKafkaCodec instead.",
-    replaceWith = ReplaceWith("ZstdForyKafkaCodec()"),
-    level = DeprecationLevel.ERROR,
-)
-class ZstdJdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.ZstdJdk)
 
 /**
  * Zstd 압축 + Kryo 직렬화를 이용한 Kafka Codec

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodecs.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodecs.kt
@@ -1,7 +1,5 @@
 package io.bluetape4k.kafka.codec
 
-import io.bluetape4k.annotations.BluetapeObsoleteApi
-
 /**
  * 다양한 Kafka Codec 인스턴스를 제공하는 Object입니다.
  *
@@ -31,54 +29,14 @@ object KafkaCodecs {
 
     val Jackson by lazy { JacksonKafkaCodec() }
 
-    @BluetapeObsoleteApi
-    @Deprecated(
-        message = "JDK serialization is unsafe for untrusted bytes. Use KafkaCodecs.Fory instead.",
-        replaceWith = ReplaceWith("KafkaCodecs.Fory"),
-        level = DeprecationLevel.ERROR,
-    )
-    @OptIn(BluetapeObsoleteApi::class)
-    @Suppress("DEPRECATION_ERROR")
-    val Jdk by lazy { JdkKafkaCodec() }
-
     val Kryo by lazy { KryoKafkaCodec() }
     val Fory by lazy { ForyKafkaCodec() }
-
-    @BluetapeObsoleteApi
-    @Deprecated(
-        message = "JDK serialization is unsafe for untrusted bytes. Use KafkaCodecs.Lz4Fory instead.",
-        replaceWith = ReplaceWith("KafkaCodecs.Lz4Fory"),
-        level = DeprecationLevel.ERROR,
-    )
-    @OptIn(BluetapeObsoleteApi::class)
-    @Suppress("DEPRECATION_ERROR")
-    val LZ4Jdk by lazy { LZ4JdkKafkaCodec() }
 
     val Lz4Kryo by lazy { LZ4KryoKafkaCodec() }
     val Lz4Fory by lazy { LZ4ForyKafkaCodec() }
 
-    @BluetapeObsoleteApi
-    @Deprecated(
-        message = "JDK serialization is unsafe for untrusted bytes. Use KafkaCodecs.SnappyFory instead.",
-        replaceWith = ReplaceWith("KafkaCodecs.SnappyFory"),
-        level = DeprecationLevel.ERROR,
-    )
-    @OptIn(BluetapeObsoleteApi::class)
-    @Suppress("DEPRECATION_ERROR")
-    val SnappyJdk by lazy { SnappyJdkKafkaCodec() }
-
     val SnappyKryo by lazy { SnappyKryoKafkaCodec() }
     val SnappyFory by lazy { SnappyForyKafkaCodec() }
-
-    @BluetapeObsoleteApi
-    @Deprecated(
-        message = "JDK serialization is unsafe for untrusted bytes. Use KafkaCodecs.ZstdFory instead.",
-        replaceWith = ReplaceWith("KafkaCodecs.ZstdFory"),
-        level = DeprecationLevel.ERROR,
-    )
-    @OptIn(BluetapeObsoleteApi::class)
-    @Suppress("DEPRECATION_ERROR")
-    val ZstdJdk by lazy { ZstdJdkKafkaCodec() }
 
     val ZstdKryo by lazy { ZstdKryoKafkaCodec() }
     val ZstdFory by lazy { ZstdForyKafkaCodec() }

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/KafkaOperationsExtensions.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/KafkaOperationsExtensions.kt
@@ -20,13 +20,6 @@ import org.springframework.messaging.Message
 suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSend(record: ProducerRecord<K, V>): SendResult<K, V> =
     send(record).await()
 
-@Deprecated(
-    message = "Use `suspendSend` instead.",
-    replaceWith = ReplaceWith("suspendSend(record)")
-)
-suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(record: ProducerRecord<K, V>): SendResult<K, V> =
-    send(record).await()
-
 /**
  * [KafkaOperations] 발송을 suspend 함수로 실행합니다.
  *
@@ -40,13 +33,6 @@ suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(record: Producer
  * @see Message
  */
 suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSend(message: Message<*>): SendResult<K, V> =
-    send(message).await()
-
-@Deprecated(
-    message = "Use `suspendSend` instead.",
-    replaceWith = ReplaceWith("suspendSend(message)")
-)
-suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(message: Message<*>): SendResult<K, V> =
     send(message).await()
 
 /**
@@ -63,13 +49,6 @@ suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(message: Message
  * @return [SendResult] 발송 결과
  */
 suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSend(topic: String, value: V): SendResult<K, V> =
-    send(topic, value).await()
-
-@Deprecated(
-    message = "Use `suspendSend` instead.",
-    replaceWith = ReplaceWith("suspendSend(topic, value)")
-)
-suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(topic: String, value: V): SendResult<K, V> =
     send(topic, value).await()
 
 /**
@@ -89,13 +68,6 @@ suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(topic: String, v
 suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSend(topic: String, key: K, value: V): SendResult<K, V> =
     send(topic, key, value).await()
 
-@Deprecated(
-    message = "Use `suspendSend` instead.",
-    replaceWith = ReplaceWith("suspendSend(topic, key, value)")
-)
-suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(topic: String, key: K, value: V): SendResult<K, V> =
-    send(topic, key, value).await()
-
 /**
  * [KafkaOperations] 발송을 suspend 함수로 실행합니다.
  *
@@ -112,18 +84,6 @@ suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(topic: String, k
  * @return [SendResult] 발송 결과
  */
 suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSend(
-    topic: String,
-    partition: Int,
-    key: K,
-    value: V,
-): SendResult<K, V> =
-    send(topic, partition, key, value).await()
-
-@Deprecated(
-    message = "Use `suspendSend` instead.",
-    replaceWith = ReplaceWith("suspendSend(topic, partition, key, value)")
-)
-suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(
     topic: String,
     partition: Int,
     key: K,
@@ -162,20 +122,6 @@ suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSend(
 ): SendResult<K, V> =
     send(topic, partition, timestamp, key, value).await()
 
-@Deprecated(
-    message = "Use `suspendSend` instead.",
-    replaceWith = ReplaceWith("suspendSend(topic, partition, timestamp, key, value)")
-)
-suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(
-    topic: String,
-    partition: Int,
-    timestamp: Long,
-    key: K,
-    value: V,
-): SendResult<K, V> =
-    send(topic, partition, timestamp, key, value).await()
-
-
 /**
  * [KafkaOperations] 기본 Topic으로 발송하는 작업을 suspend 함수로 실행합니다.
  *
@@ -184,13 +130,6 @@ suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(
  * @see KafkaOperations.sendDefault
  */
 suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSendDefault(value: V): SendResult<K, V> =
-    sendDefault(value).await()
-
-@Deprecated(
-    message = "Use `suspendSendDefault` instead.",
-    replaceWith = ReplaceWith("suspendSendDefault(value)")
-)
-suspend fun <K: Any, V: Any> KafkaOperations<K, V>.awaitSendDefault(value: V): SendResult<K, V> =
     sendDefault(value).await()
 
 /**
@@ -202,11 +141,4 @@ suspend fun <K: Any, V: Any> KafkaOperations<K, V>.awaitSendDefault(value: V): S
  * @see KafkaOperations.sendDefault
  */
 suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSendDefault(key: K, value: V): SendResult<K, V> =
-    sendDefault(key, value).await()
-
-@Deprecated(
-    message = "Use `suspendSendDefault` instead.",
-    replaceWith = ReplaceWith("suspendSendDefault(key, value)")
-)
-suspend fun <K: Any, V: Any> KafkaOperations<K, V>.awaitSendDefault(key: K, value: V): SendResult<K, V> =
     sendDefault(key, value).await()

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt
@@ -1,9 +1,6 @@
-@file:Suppress("removal", "DEPRECATION")
-
 package io.bluetape4k.kafka.spring.core
 
 import io.bluetape4k.coroutines.flow.async
-import io.bluetape4k.support.asDouble
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.last
@@ -23,7 +20,7 @@ import kotlin.coroutines.resumeWithException
  *
  * ```
  * val kafkaOperations: KafkaOperations<String, String> = ...
- * val result = kafkaOperations.sendSuspending(ProducerRecord("topic", "key", "value"))
+ * val result = kafkaOperations.suspendSend(ProducerRecord("topic", "key", "value"))
  * ```
  *
  * @param K Key type   메시지 키 타입
@@ -32,48 +29,6 @@ import kotlin.coroutines.resumeWithException
  * @return 발송 결과 정보 [SendResult]
  */
 suspend inline fun <K, V> KafkaOperations<K, V>.suspendSend(record: ProducerRecord<K, V>): SendResult<K, V> =
-    suspendCancellableCoroutine { cont ->
-        val result: Future<RecordMetadata>? =
-            execute { producer ->
-                producer.send(record) { metadata, exception ->
-                    if (exception != null) {
-                        cont.resumeWithException(exception)
-                    } else {
-                        cont.resume(SendResult(record, metadata))
-                    }
-                }
-            }
-        cont.invokeOnCancellation {
-            result?.cancel(true)
-        }
-    }
-
-@Deprecated(
-    message = "Use `suspendSend` instead.",
-    replaceWith = ReplaceWith("suspendSend(record)")
-)
-suspend inline fun <K, V> KafkaOperations<K, V>.awaitSend(record: ProducerRecord<K, V>): SendResult<K, V> =
-    suspendCancellableCoroutine { cont ->
-        val result: Future<RecordMetadata>? =
-            execute { producer ->
-                producer.send(record) { metadata, exception ->
-                    if (exception != null) {
-                        cont.resumeWithException(exception)
-                    } else {
-                        cont.resume(SendResult(record, metadata))
-                    }
-                }
-            }
-        cont.invokeOnCancellation {
-            result?.cancel(true)
-        }
-    }
-
-@Deprecated(
-    message = "Use `suspendSend` instead.",
-    replaceWith = ReplaceWith("suspendSend(record)")
-)
-suspend inline fun <K, V> KafkaOperations<K, V>.sendSuspending(record: ProducerRecord<K, V>): SendResult<K, V> =
     suspendCancellableCoroutine { cont ->
         val result: Future<RecordMetadata>? =
             execute { producer ->
@@ -154,25 +109,6 @@ suspend inline fun <K, V> KafkaOperations<K, V>.sendAndForget(
  */
 fun <K, V> KafkaOperations<K, V>.getMetric(metricName: String): Metric? =
     metrics().entries.find { it.key.name() == metricName }?.value
-
-/**
- * Producer 의 metrics 측정 값을 조회합니다.
- *
- * **경고**: 메트릭 이름이 없거나 오타인 경우 `0.0`을 반환하여 실제 `0.0` 값과 구별할 수 없습니다.
- * 대신 [getMetricValueOrNull]을 사용하세요.
- *
- * ```
- * val sendCount = producer.getMetricValueOrNull("record-send-total").asDouble()
- * ```
- * @param metricName metric name to retrieve
- * @return metric 값 (메트릭이 없으면 0.0 — 실제 0과 구별 불가)
- */
-@Deprecated(
-    message = "메트릭 이름이 없거나 오타인 경우 0.0을 반환하여 실제 0.0 값과 구별할 수 없습니다. getMetricValueOrNull()을 사용하세요.",
-    replaceWith = ReplaceWith("getMetricValueOrNull(metricName).asDouble()", "io.bluetape4k.support.asDouble")
-)
-fun <K, V> KafkaOperations<K, V>.getMetricValue(metricName: String): Double =
-    getMetric(metricName)?.metricValue().asDouble(0.0)
 
 /**
  * Producer 의 metrics 측정 값을 조회합니다. 메트릭이 없으면 `null`을 반환합니다.

--- a/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/ProducerSupportTest.kt
+++ b/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/ProducerSupportTest.kt
@@ -109,10 +109,4 @@ class ProducerSupportTest: AbstractKafkaTest() {
         customProducer.close()
     }
 
-    @Suppress("DEPRECATION")
-    @Test
-    fun `getMetricValue deprecated - 존재하지 않는 메트릭은 0_0을 반환한다`() {
-        val value = producer.getMetricValue("nonexistent-metric-xyz")
-        assert(value == 0.0) { "Nonexistent metric should return 0.0, got $value" }
-    }
 }

--- a/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensionsTest.kt
+++ b/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensionsTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package io.bluetape4k.kafka.spring.core
 
 import io.bluetape4k.junit5.coroutines.runSuspendIO
@@ -57,26 +55,6 @@ class KafkaOperationExtensionsTest: AbstractKafkaTest() {
     }
 
     @Test
-    fun `awaitSend - deprecated ProducerRecord로 메시지를 발송한다`() = runSuspendIO {
-        val record = ProducerRecord<String, String>(TOPIC, "key-2", "value-${System.currentTimeMillis()}")
-
-        val result = kafkaTemplate.awaitSend(record)
-
-        result.shouldNotBeNull()
-        result.recordMetadata.topic() shouldBeEqualTo TOPIC
-    }
-
-    @Test
-    fun `sendSuspending - deprecated ProducerRecord로 메시지를 발송한다`() = runSuspendIO {
-        val record = ProducerRecord<String, String>(TOPIC, "key-3", "value-${System.currentTimeMillis()}")
-
-        val result = kafkaTemplate.sendSuspending(record)
-
-        result.shouldNotBeNull()
-        result.recordMetadata.topic() shouldBeEqualTo TOPIC
-    }
-
-    @Test
     fun `sendFlowAsParallel - Flow로 여러 메시지를 병렬 발송하고 마지막 결과를 반환한다`() = runSuspendIO {
         val records = flow {
             repeat(3) { i ->
@@ -122,12 +100,6 @@ class KafkaOperationExtensionsTest: AbstractKafkaTest() {
     fun `getMetricValueOrNull - 존재하지 않는 메트릭은 null을 반환한다`() {
         val value = kafkaTemplate.getMetricValueOrNull("nonexistent-metric-xyz-${System.nanoTime()}")
         assert(value == null) { "Nonexistent metric should return null" }
-    }
-
-    @Test
-    fun `getMetricValue - deprecated 존재하지 않는 메트릭은 0_0을 반환한다`() {
-        val value = kafkaTemplate.getMetricValue("nonexistent-metric-xyz-${System.nanoTime()}")
-        assert(value == 0.0) { "Nonexistent metric should return 0.0" }
     }
 
     @Test

--- a/infra/kafka4/README.ko.md
+++ b/infra/kafka4/README.ko.md
@@ -24,7 +24,7 @@ Spring Kafka 4.x, Spring Boot 4, Jackson 3 기준으로 컴파일합니다.
   Spring Kafka 확장 함수.
 - Kafka 4 기준으로 컴파일되는 Kafka Streams helper와 테스트.
 - 문자열, 바이트 배열, Jackson 3 JSON, Kryo, Fory, LZ4/Snappy/Zstd 압축 payload
-  codec. JDK 직렬화 codec은 obsolete 호환 API이며 명시적 opt-in이 필요합니다.
+  codec.
 - Spring Kafka 4의 KRaft 전용 embedded broker 테스트 지원.
 
 ## 의존성
@@ -131,16 +131,12 @@ Jackson codec은 `bluetape4k-jackson3`와 `tools.jackson.*` API를 사용합니�
 | `KafkaCodecs.String` | UTF-8 문자열 직렬화 |
 | `KafkaCodecs.ByteArray` | 바이트 배열 직접 전달 |
 | `KafkaCodecs.Jackson` | Jackson 3 JSON 직렬화 |
-| `KafkaCodecs.Jdk` | **Obsolete / 컴파일 오류 게이트** — Java 직렬화 (RCE 위험, Fory 사용 권장) |
 | `KafkaCodecs.Kryo` | Kryo 바이너리 직렬화 |
 | `KafkaCodecs.Fory` | Fory 바이너리 직렬화 |
-| `KafkaCodecs.LZ4Jdk` | **Obsolete / 컴파일 오류 게이트** — LZ4 압축 + Java 직렬화 |
 | `KafkaCodecs.Lz4Kryo` | LZ4 압축 + Kryo 직렬화 |
 | `KafkaCodecs.Lz4Fory` | LZ4 압축 + Fory 직렬화 |
-| `KafkaCodecs.SnappyJdk` | **Obsolete / 컴파일 오류 게이트** — Snappy 압축 + Java 직렬화 |
 | `KafkaCodecs.SnappyKryo` | Snappy 압축 + Kryo 직렬화 |
 | `KafkaCodecs.SnappyFory` | Snappy 압축 + Fory 직렬화 |
-| `KafkaCodecs.ZstdJdk` | **Obsolete / 컴파일 오류 게이트** — Zstd 압축 + Java 직렬화 |
 | `KafkaCodecs.ZstdKryo` | Zstd 압축 + Kryo 직렬화 |
 | `KafkaCodecs.ZstdFory` | Zstd 압축 + Fory 직렬화 |
 
@@ -217,12 +213,6 @@ class LegacyTrustedJacksonCodec : JacksonKafkaCodec() {
     override val allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
 }
 ```
-
-### 보안: JDK Kafka Codec Obsolete
-
-`JdkKafkaCodec` 과 압축 JDK 기반 codec은 JDK 역직렬화 RCE 위험 때문에 obsolete
-API입니다. `@BluetapeObsoleteApi` 와 `DeprecationLevel.ERROR` 로 표시되며,
-Fory 계열 codec을 사용하세요.
 
 ## Embedded Kafka 테스트
 

--- a/infra/kafka4/README.md
+++ b/infra/kafka4/README.md
@@ -24,8 +24,7 @@ per application.
   containers, and test utilities.
 - Kafka Streams helpers and test coverage compiled against Kafka 4.
 - Codecs for string, byte array, Jackson 3 JSON, Kryo, Fory, and compressed
-  payloads with LZ4, Snappy, or Zstd. JDK serialization codecs are obsolete
-  compatibility APIs and require explicit opt-in.
+  payloads with LZ4, Snappy, or Zstd.
 - Embedded Kafka test support through Spring Kafka 4's KRaft-only broker.
 
 ## Dependency
@@ -133,16 +132,12 @@ Available codecs:
 | `KafkaCodecs.String` | UTF-8 string serialization |
 | `KafkaCodecs.ByteArray` | Raw byte array passthrough |
 | `KafkaCodecs.Jackson` | Jackson 3 JSON serialization |
-| `KafkaCodecs.Jdk` | **Obsolete / compile-error gated** — JDK serialization (RCE risk, use Fory) |
 | `KafkaCodecs.Kryo` | Kryo binary serialization |
 | `KafkaCodecs.Fory` | Fory binary serialization |
-| `KafkaCodecs.LZ4Jdk` | **Obsolete / compile-error gated** — LZ4 compression + Java serialization |
 | `KafkaCodecs.Lz4Kryo` | LZ4 compression + Kryo serialization |
 | `KafkaCodecs.Lz4Fory` | LZ4 compression + Fory serialization |
-| `KafkaCodecs.SnappyJdk` | **Obsolete / compile-error gated** — Snappy compression + Java serialization |
 | `KafkaCodecs.SnappyKryo` | Snappy compression + Kryo serialization |
 | `KafkaCodecs.SnappyFory` | Snappy compression + Fory serialization |
-| `KafkaCodecs.ZstdJdk` | **Obsolete / compile-error gated** — Zstd compression + Java serialization |
 | `KafkaCodecs.ZstdKryo` | Zstd compression + Kryo serialization |
 | `KafkaCodecs.ZstdFory` | Zstd compression + Fory serialization |
 
@@ -220,12 +215,6 @@ class LegacyTrustedJacksonCodec : JacksonKafkaCodec() {
     override val allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
 }
 ```
-
-### Security: JDK Kafka Codecs Obsolete
-
-`JdkKafkaCodec` and compressed JDK-backed codecs are obsolete due to JDK
-deserialization RCE risks. They are marked with `@BluetapeObsoleteApi` and
-`DeprecationLevel.ERROR`; use the Fory variants instead.
 
 ## Embedded Kafka Tests
 

--- a/infra/kafka4/build.gradle.kts
+++ b/infra/kafka4/build.gradle.kts
@@ -21,7 +21,6 @@ configurations {
 }
 
 dependencies {
-    api(project(":bluetape4k-annotations"))
     implementation(platform(libs.spring.boot.dependencies))
     api(project(":bluetape4k-core"))
     api(project(":bluetape4k-io"))

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/ProducerSupport.kt
@@ -1,6 +1,5 @@
 package io.bluetape4k.kafka
 
-import io.bluetape4k.support.asDoubleOrNull
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.Producer
 import org.apache.kafka.common.serialization.Serializer
@@ -57,25 +56,6 @@ fun <K, V> producerOf(
     keySerializer: Serializer<K>? = null,
     valueSerializer: Serializer<V>? = null,
 ): Producer<K, V> = KafkaProducer(props, keySerializer, valueSerializer)
-
-/**
- * Producer 의 metrics 측정 값을 조회합니다.
- *
- * **경고**: 메트릭 이름이 없거나 오타인 경우 `0.0`을 반환하여 실제 `0.0` 값과 구별할 수 없습니다.
- * 대신 [getMetricValueOrNull]을 사용하세요.
- *
- * ```
- * val sendCount = producer.getMetricValueOrNull("record-send-total").asDouble()
- * ```
- * @param metricName metric name to retrieve
- * @return metric 값 (메트릭이 없으면 0.0 — 실제 0과 구별 불가)
- */
-@Deprecated(
-    message = "메트릭 이름이 없거나 오타인 경우 0.0을 반환하여 실제 0.0 값과 구별할 수 없습니다. getMetricValueOrNull()을 사용하세요.",
-    replaceWith = ReplaceWith("getMetricValueOrNull(metricName).asDouble()", "io.bluetape4k.support.asDouble")
-)
-fun <K, V> Producer<K, V>.getMetricValue(metricName: String): Double =
-    getMetricValueOrNull(metricName)?.asDoubleOrNull() ?: 0.0
 
 /**
  * Producer 의 metrics 측정 값을 조회합니다. 메트릭이 없으면 `null`을 반환합니다.

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
@@ -1,6 +1,5 @@
 package io.bluetape4k.kafka.codec
 
-import io.bluetape4k.annotations.BluetapeObsoleteApi
 import io.bluetape4k.io.serializer.BinarySerializer
 import io.bluetape4k.io.serializer.BinarySerializers
 import org.apache.kafka.common.header.Headers
@@ -30,30 +29,6 @@ abstract class BinaryKafkaCodec(
 }
 
 /**
- * Kafka codec backed by JDK serialization.
- *
- * ## Security
- *
- * JDK deserialization can execute attacker-controlled object graphs when
- * untrusted bytes are decoded. Use [ForyKafkaCodec] for new code.
- *
- * ```kotlin
- * val codec = ForyKafkaCodec()
- * val bytes = codec.serialize("topic", null, "hello")
- * val result = codec.deserialize("topic", null, bytes)
- * // result == "hello"
- * ```
- */
-@BluetapeObsoleteApi
-@Deprecated(
-    message = "JDK serialization is unsafe for untrusted bytes. Use ForyKafkaCodec instead.",
-    replaceWith = ReplaceWith("ForyKafkaCodec()"),
-    level = DeprecationLevel.ERROR,
-)
-@Suppress("DEPRECATION")
-class JdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.Jdk)
-
-/**
  * Kryo 직렬화를 이용한 Kafka Codec
  *
  * ```kotlin
@@ -76,29 +51,6 @@ class KryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.Kryo)
  * ```
  */
 class ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.Fory)
-
-/**
- * Kafka codec backed by LZ4-compressed JDK serialization.
- *
- * ## Security
- *
- * JDK deserialization can execute attacker-controlled object graphs when
- * untrusted bytes are decoded. Use [LZ4ForyKafkaCodec] for new code.
- *
- * ```kotlin
- * val codec = LZ4ForyKafkaCodec()
- * val bytes = codec.serialize("topic", null, "hello")
- * val result = codec.deserialize("topic", null, bytes)
- * // result == "hello"
- * ```
- */
-@BluetapeObsoleteApi
-@Deprecated(
-    message = "JDK serialization is unsafe for untrusted bytes. Use LZ4ForyKafkaCodec instead.",
-    replaceWith = ReplaceWith("LZ4ForyKafkaCodec()"),
-    level = DeprecationLevel.ERROR,
-)
-class LZ4JdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Jdk)
 
 /**
  * LZ4 압축 + Kryo 직렬화를 이용한 Kafka Codec
@@ -125,29 +77,6 @@ class LZ4KryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Kryo)
 class LZ4ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Fory)
 
 /**
- * Kafka codec backed by Snappy-compressed JDK serialization.
- *
- * ## Security
- *
- * JDK deserialization can execute attacker-controlled object graphs when
- * untrusted bytes are decoded. Use [SnappyForyKafkaCodec] for new code.
- *
- * ```kotlin
- * val codec = SnappyForyKafkaCodec()
- * val bytes = codec.serialize("topic", null, "hello")
- * val result = codec.deserialize("topic", null, bytes)
- * // result == "hello"
- * ```
- */
-@BluetapeObsoleteApi
-@Deprecated(
-    message = "JDK serialization is unsafe for untrusted bytes. Use SnappyForyKafkaCodec instead.",
-    replaceWith = ReplaceWith("SnappyForyKafkaCodec()"),
-    level = DeprecationLevel.ERROR,
-)
-class SnappyJdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyJdk)
-
-/**
  * Snappy 압축 + Kryo 직렬화를 이용한 Kafka Codec
  *
  * ```kotlin
@@ -170,29 +99,6 @@ class SnappyKryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyKryo)
  * ```
  */
 class SnappyForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyFory)
-
-/**
- * Kafka codec backed by Zstd-compressed JDK serialization.
- *
- * ## Security
- *
- * JDK deserialization can execute attacker-controlled object graphs when
- * untrusted bytes are decoded. Use [ZstdForyKafkaCodec] for new code.
- *
- * ```kotlin
- * val codec = ZstdForyKafkaCodec()
- * val bytes = codec.serialize("topic", null, "hello")
- * val result = codec.deserialize("topic", null, bytes)
- * // result == "hello"
- * ```
- */
-@BluetapeObsoleteApi
-@Deprecated(
-    message = "JDK serialization is unsafe for untrusted bytes. Use ZstdForyKafkaCodec instead.",
-    replaceWith = ReplaceWith("ZstdForyKafkaCodec()"),
-    level = DeprecationLevel.ERROR,
-)
-class ZstdJdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.ZstdJdk)
 
 /**
  * Zstd 압축 + Kryo 직렬화를 이용한 Kafka Codec

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodecs.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodecs.kt
@@ -1,7 +1,5 @@
 package io.bluetape4k.kafka.codec
 
-import io.bluetape4k.annotations.BluetapeObsoleteApi
-
 /**
  * 다양한 Kafka Codec 인스턴스를 제공하는 Object입니다.
  *
@@ -31,54 +29,14 @@ object KafkaCodecs {
 
     val Jackson by lazy { JacksonKafkaCodec() }
 
-    @BluetapeObsoleteApi
-    @Deprecated(
-        message = "JDK serialization is unsafe for untrusted bytes. Use KafkaCodecs.Fory instead.",
-        replaceWith = ReplaceWith("KafkaCodecs.Fory"),
-        level = DeprecationLevel.ERROR,
-    )
-    @OptIn(BluetapeObsoleteApi::class)
-    @Suppress("DEPRECATION_ERROR")
-    val Jdk by lazy { JdkKafkaCodec() }
-
     val Kryo by lazy { KryoKafkaCodec() }
     val Fory by lazy { ForyKafkaCodec() }
-
-    @BluetapeObsoleteApi
-    @Deprecated(
-        message = "JDK serialization is unsafe for untrusted bytes. Use KafkaCodecs.Lz4Fory instead.",
-        replaceWith = ReplaceWith("KafkaCodecs.Lz4Fory"),
-        level = DeprecationLevel.ERROR,
-    )
-    @OptIn(BluetapeObsoleteApi::class)
-    @Suppress("DEPRECATION_ERROR")
-    val LZ4Jdk by lazy { LZ4JdkKafkaCodec() }
 
     val Lz4Kryo by lazy { LZ4KryoKafkaCodec() }
     val Lz4Fory by lazy { LZ4ForyKafkaCodec() }
 
-    @BluetapeObsoleteApi
-    @Deprecated(
-        message = "JDK serialization is unsafe for untrusted bytes. Use KafkaCodecs.SnappyFory instead.",
-        replaceWith = ReplaceWith("KafkaCodecs.SnappyFory"),
-        level = DeprecationLevel.ERROR,
-    )
-    @OptIn(BluetapeObsoleteApi::class)
-    @Suppress("DEPRECATION_ERROR")
-    val SnappyJdk by lazy { SnappyJdkKafkaCodec() }
-
     val SnappyKryo by lazy { SnappyKryoKafkaCodec() }
     val SnappyFory by lazy { SnappyForyKafkaCodec() }
-
-    @BluetapeObsoleteApi
-    @Deprecated(
-        message = "JDK serialization is unsafe for untrusted bytes. Use KafkaCodecs.ZstdFory instead.",
-        replaceWith = ReplaceWith("KafkaCodecs.ZstdFory"),
-        level = DeprecationLevel.ERROR,
-    )
-    @OptIn(BluetapeObsoleteApi::class)
-    @Suppress("DEPRECATION_ERROR")
-    val ZstdJdk by lazy { ZstdJdkKafkaCodec() }
 
     val ZstdKryo by lazy { ZstdKryoKafkaCodec() }
     val ZstdFory by lazy { ZstdForyKafkaCodec() }

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/KafkaOperationsExtensions.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/KafkaOperationsExtensions.kt
@@ -20,13 +20,6 @@ import org.springframework.messaging.Message
 suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSend(record: ProducerRecord<K, V>): SendResult<K, V> =
     send(record).await()
 
-@Deprecated(
-    message = "Use `suspendSend` instead.",
-    replaceWith = ReplaceWith("suspendSend(record)")
-)
-suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(record: ProducerRecord<K, V>): SendResult<K, V> =
-    send(record).await()
-
 /**
  * [KafkaOperations] 발송을 suspend 함수로 실행합니다.
  *
@@ -40,13 +33,6 @@ suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(record: Producer
  * @see Message
  */
 suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSend(message: Message<*>): SendResult<K, V> =
-    send(message).await()
-
-@Deprecated(
-    message = "Use `suspendSend` instead.",
-    replaceWith = ReplaceWith("suspendSend(message)")
-)
-suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(message: Message<*>): SendResult<K, V> =
     send(message).await()
 
 /**
@@ -63,13 +49,6 @@ suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(message: Message
  * @return [SendResult] 발송 결과
  */
 suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSend(topic: String, value: V): SendResult<K, V> =
-    send(topic, value).await()
-
-@Deprecated(
-    message = "Use `suspendSend` instead.",
-    replaceWith = ReplaceWith("suspendSend(topic, value)")
-)
-suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(topic: String, value: V): SendResult<K, V> =
     send(topic, value).await()
 
 /**
@@ -89,13 +68,6 @@ suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(topic: String, v
 suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSend(topic: String, key: K, value: V): SendResult<K, V> =
     send(topic, key, value).await()
 
-@Deprecated(
-    message = "Use `suspendSend` instead.",
-    replaceWith = ReplaceWith("suspendSend(topic, key, value)")
-)
-suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(topic: String, key: K, value: V): SendResult<K, V> =
-    send(topic, key, value).await()
-
 /**
  * [KafkaOperations] 발송을 suspend 함수로 실행합니다.
  *
@@ -112,18 +84,6 @@ suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(topic: String, k
  * @return [SendResult] 발송 결과
  */
 suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSend(
-    topic: String,
-    partition: Int,
-    key: K,
-    value: V,
-): SendResult<K, V> =
-    send(topic, partition, key, value).await()
-
-@Deprecated(
-    message = "Use `suspendSend` instead.",
-    replaceWith = ReplaceWith("suspendSend(topic, partition, key, value)")
-)
-suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(
     topic: String,
     partition: Int,
     key: K,
@@ -162,20 +122,6 @@ suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSend(
 ): SendResult<K, V> =
     send(topic, partition, timestamp, key, value).await()
 
-@Deprecated(
-    message = "Use `suspendSend` instead.",
-    replaceWith = ReplaceWith("suspendSend(topic, partition, timestamp, key, value)")
-)
-suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(
-    topic: String,
-    partition: Int,
-    timestamp: Long,
-    key: K,
-    value: V,
-): SendResult<K, V> =
-    send(topic, partition, timestamp, key, value).await()
-
-
 /**
  * [KafkaOperations] 기본 Topic으로 발송하는 작업을 suspend 함수로 실행합니다.
  *
@@ -184,13 +130,6 @@ suspend fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndAwait(
  * @see KafkaOperations.sendDefault
  */
 suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSendDefault(value: V): SendResult<K, V> =
-    sendDefault(value).await()
-
-@Deprecated(
-    message = "Use `suspendSendDefault` instead.",
-    replaceWith = ReplaceWith("suspendSendDefault(value)")
-)
-suspend fun <K: Any, V: Any> KafkaOperations<K, V>.awaitSendDefault(value: V): SendResult<K, V> =
     sendDefault(value).await()
 
 /**
@@ -202,11 +141,4 @@ suspend fun <K: Any, V: Any> KafkaOperations<K, V>.awaitSendDefault(value: V): S
  * @see KafkaOperations.sendDefault
  */
 suspend fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSendDefault(key: K, value: V): SendResult<K, V> =
-    sendDefault(key, value).await()
-
-@Deprecated(
-    message = "Use `suspendSendDefault` instead.",
-    replaceWith = ReplaceWith("suspendSendDefault(key, value)")
-)
-suspend fun <K: Any, V: Any> KafkaOperations<K, V>.awaitSendDefault(key: K, value: V): SendResult<K, V> =
     sendDefault(key, value).await()

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensions.kt
@@ -1,9 +1,6 @@
-@file:Suppress("removal", "DEPRECATION")
-
 package io.bluetape4k.kafka.spring.core
 
 import io.bluetape4k.coroutines.flow.async
-import io.bluetape4k.support.asDouble
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.last
@@ -32,48 +29,6 @@ import kotlin.coroutines.resumeWithException
  * @return 발송 결과 정보 [SendResult]
  */
 suspend inline fun <K: Any, V: Any> KafkaOperations<K, V>.suspendSend(record: ProducerRecord<K, V>): SendResult<K, V> =
-    suspendCancellableCoroutine { cont ->
-        val result: Future<RecordMetadata>? =
-            execute { producer ->
-                producer.send(record) { metadata, exception ->
-                    if (exception != null) {
-                        cont.resumeWithException(exception)
-                    } else {
-                        cont.resume(SendResult(record, metadata))
-                    }
-                }
-            }
-        cont.invokeOnCancellation {
-            result?.cancel(true)
-        }
-    }
-
-@Deprecated(
-    message = "Use `suspendSend` instead.",
-    replaceWith = ReplaceWith("suspendSend(record)")
-)
-suspend inline fun <K: Any, V: Any> KafkaOperations<K, V>.awaitSend(record: ProducerRecord<K, V>): SendResult<K, V> =
-    suspendCancellableCoroutine { cont ->
-        val result: Future<RecordMetadata>? =
-            execute { producer ->
-                producer.send(record) { metadata, exception ->
-                    if (exception != null) {
-                        cont.resumeWithException(exception)
-                    } else {
-                        cont.resume(SendResult(record, metadata))
-                    }
-                }
-            }
-        cont.invokeOnCancellation {
-            result?.cancel(true)
-        }
-    }
-
-@Deprecated(
-    message = "Use `suspendSend` instead.",
-    replaceWith = ReplaceWith("suspendSend(record)")
-)
-suspend inline fun <K: Any, V: Any> KafkaOperations<K, V>.sendSuspending(record: ProducerRecord<K, V>): SendResult<K, V> =
     suspendCancellableCoroutine { cont ->
         val result: Future<RecordMetadata>? =
             execute { producer ->
@@ -159,25 +114,6 @@ suspend inline fun <K: Any, V: Any> KafkaOperations<K, V>.sendAndForget(
  */
 fun <K: Any, V: Any> KafkaOperations<K, V>.getMetric(metricName: String): Metric? =
     metrics().entries.find { it.key.name() == metricName }?.value
-
-/**
- * Producer 의 metrics 측정 값을 조회합니다.
- *
- * **경고**: 메트릭 이름이 없거나 오타인 경우 `0.0`을 반환하여 실제 `0.0` 값과 구별할 수 없습니다.
- * 대신 [getMetricValueOrNull]을 사용하세요.
- *
- * ```
- * val sendCount = producer.getMetricValueOrNull("record-send-total").asDouble()
- * ```
- * @param metricName metric name to retrieve
- * @return metric 값 (메트릭이 없으면 0.0 — 실제 0과 구별 불가)
- */
-@Deprecated(
-    message = "메트릭 이름이 없거나 오타인 경우 0.0을 반환하여 실제 0.0 값과 구별할 수 없습니다. getMetricValueOrNull()을 사용하세요.",
-    replaceWith = ReplaceWith("getMetricValueOrNull(metricName).asDouble()", "io.bluetape4k.support.asDouble")
-)
-fun <K: Any, V: Any> KafkaOperations<K, V>.getMetricValue(metricName: String): Double =
-    getMetric(metricName)?.metricValue().asDouble(0.0)
 
 /**
  * Producer 의 metrics 측정 값을 조회합니다. 메트릭이 없으면 `null`을 반환합니다.

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensionsIntegrationTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/spring/core/KafkaOperationExtensionsIntegrationTest.kt
@@ -1,9 +1,6 @@
-@file:Suppress("removal", "DEPRECATION")
-
 package io.bluetape4k.kafka.spring.core
 
 import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.kafka.AbstractKafkaTest
@@ -23,7 +20,7 @@ import org.springframework.kafka.core.ProducerFactory
 /**
  * Integration tests for [KafkaOperationExtensions] using a real Kafka broker (Testcontainers).
  *
- * Covers: suspendSend, awaitSend, sendSuspending, sendFlowAsParallel, sendAndForget.
+ * Covers: suspendSend, sendFlowAsParallel, sendAndForget.
  */
 class KafkaOperationExtensionsIntegrationTest: AbstractKafkaTest() {
 
@@ -52,28 +49,6 @@ class KafkaOperationExtensionsIntegrationTest: AbstractKafkaTest() {
         val record = ProducerRecord<String, String>(TOPIC, "key-1", "value-${System.currentTimeMillis()}")
 
         val result = kafkaTemplate.suspendSend(record)
-
-        result.shouldNotBeNull()
-        result.recordMetadata.topic() shouldBeEqualTo TOPIC
-    }
-
-    @RepeatedTest(REPEAT_SIZE)
-    fun `awaitSend deprecated - ProducerRecord 로 메시지 발송`() = runSuspendIO {
-        val record = ProducerRecord<String, String>(TOPIC, "key-await", "value-${System.currentTimeMillis()}")
-
-        @Suppress("DEPRECATION")
-        val result = kafkaTemplate.awaitSend(record)
-
-        result.shouldNotBeNull()
-        result.recordMetadata.topic() shouldBeEqualTo TOPIC
-    }
-
-    @RepeatedTest(REPEAT_SIZE)
-    fun `sendSuspending deprecated - ProducerRecord 로 메시지 발송`() = runSuspendIO {
-        val record = ProducerRecord<String, String>(TOPIC, "key-suspending", "value-${System.currentTimeMillis()}")
-
-        @Suppress("DEPRECATION")
-        val result = kafkaTemplate.sendSuspending(record)
 
         result.shouldNotBeNull()
         result.recordMetadata.topic() shouldBeEqualTo TOPIC
@@ -116,15 +91,4 @@ class KafkaOperationExtensionsIntegrationTest: AbstractKafkaTest() {
         kafkaTemplate.sendAndForget(records, needFlush = true)
     }
 
-    @Test
-    fun `getMetricValue deprecated - 존재하는 메트릭 이름으로 double 값 반환`() = runSuspendIO {
-        // Trigger a send to ensure metrics are populated
-        val record = ProducerRecord<String, String>(TOPIC, "metric-key", "metric-value")
-        kafkaTemplate.suspendSend(record)
-
-        @Suppress("DEPRECATION")
-        val value: Double = kafkaTemplate.getMetricValue("record-send-total")
-
-        value shouldBeGreaterOrEqualTo 0.0
-    }
 }


### PR DESCRIPTION
## Summary

Closes #474

- PR 제목: chore: remove deprecated Kafka APIs

- Removes the deprecated Kafka/Kafka4 JDK-backed codec classes and `KafkaCodecs.*Jdk` registry entries.
- Removes deprecated Kafka/Kafka4 send aliases (`sendAndAwait`, `awaitSend`, `awaitSendDefault`, `sendSuspending`) and metric aliases (`getMetricValue`).
- Updates README pairs, CHANGELOG, deprecated API inventory, and lesson notes for issue #474 PR A.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Issue

Refs #474. This is PR A only; remaining #474 cleanup lanes should stay independent.

### 기존 섹션: Verification

- `rg` confirmed no removed symbols or `@Deprecated` declarations remain in kafka/kafka4 source, tests, or README files.
- `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka:compileTestKotlin :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka4:compileTestKotlin --no-configuration-cache`
- `./gradlew :bluetape4k-kafka:test :bluetape4k-kafka4:test --no-configuration-cache` — kafka 263 tests, kafka4 274 tests, failures 0, errors 0.
- `git diff --check`

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

Current-session Codex Review: P0/P1 findings 0. The remaining risk is intentional external downstream breakage from removing deprecated public APIs.

## Metadata

- Issue: #474, milestone `1.9.0`, assignee debop
- PR: #575, head `4d611382df481cc337c2d0fd6147aedc6aff3161`, milestone `1.9.0`, assignee debop
- Base: `develop`, head branch `chore/issue-474-kafka-deprecated-removal`
- Labels: `documentation`, `test`, `infra/io`, `tech-debt`, `1.8.0-after`
- State: `MERGED`, merge commit `35b735f2b547e0c40363f75af3bf144b22ca7a5f`
- CI: - `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka:compileTestKotlin :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka4:compileTestKotlin --no-configuration-cache` / - `./gradlew :bluetape4k-kafka:test :bluetape4k-kafka4:test --no-configuration-cache` — kafka 263 tests, kafka4 274 tests, failures 0, errors 0.## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #575 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `35b735f2b547e0c40363f75af3bf144b22ca7a5f`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
