### PR TITLE
chore: remove deprecated OpenTelemetry APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Breaking Changes
 
+- Removed deprecated OpenTelemetry aliases `SpanBuilder.useSuspendSpan`, `spanExportOf`, and
+  `batchSpanProcess`; use `useSpanSuspending`, `spanExporterOf`, and `batchSpanProcessorOf`
+  instead ([#474](https://github.com/bluetape4k/bluetape4k-projects/issues/474)).
 - Removed the deprecated Kafka/Kafka4 JDK-backed codecs (`JdkKafkaCodec`, `LZ4JdkKafkaCodec`, `SnappyJdkKafkaCodec`, `ZstdJdkKafkaCodec`) and the corresponding `KafkaCodecs.*Jdk` registry entries. Use the Fory or Kryo codec variants instead ([#474](https://github.com/bluetape4k/bluetape4k-projects/issues/474)).
 - Removed the deprecated Kafka/Kafka4 Spring send aliases (`sendAndAwait`, `awaitSend`, `awaitSendDefault`, `sendSuspending`) and metrics aliases (`getMetricValue`). Use `suspendSend`, `suspendSendDefault`, and `getMetricValueOrNull` instead ([#474](https://github.com/bluetape4k/bluetape4k-projects/issues/474)).
 

--- a/docs/infra-deprecated-inventory.md
+++ b/docs/infra-deprecated-inventory.md
@@ -12,8 +12,8 @@ inventory.
 
 | Decision | Count | Meaning |
 |---|---:|---|
-| Delete | 7 files | Deprecated API has a direct replacement and should not remain in the next cleanup line. |
-| Replace call sites first | 2 files | Repo-local tests or samples still exercise the deprecated API and must move first. |
+| Delete | 5 files | Deprecated API has a direct replacement and should not remain in the next cleanup line. |
+| Replace call sites first | 1 file | Repo-local tests or samples still exercise the deprecated API and must move first. |
 | Keep | 0 files | No deprecated `infra/` API needs long-term retention. |
 
 `infra/kafka4` mirrors several `infra/kafka` deprecated APIs, so the current
@@ -23,6 +23,10 @@ scope is larger than the original 12-file issue comment.
 Kafka codecs were removed from the active inventory in the issue #474 PR A
 cleanup wave.
 
+2026-05-20 update: OpenTelemetry aliases `SpanBuilder.useSuspendSpan`,
+`spanExportOf`, and `batchSpanProcess` were removed; use `useSpanSuspending`,
+`spanExporterOf`, and `batchSpanProcessorOf`.
+
 ## Inventory
 
 | # | Module | File | Deprecated API | Current usage | Decision | Replacement |
@@ -31,11 +35,8 @@ cleanup wave.
 | 2 | `cache-lettuce` | `cache/lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceSuspendNearCache.kt` | `clearFrontCache()` | Definition only | Delete | `clearLocal()` |
 | 3 | `lettuce` | `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/LettuceConst.kt` | `DEFAULT_DELIMETER` typo | Definition only | Delete | `DEFAULT_DELIMITER` |
 | 4 | `lettuce` | `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/RedisFutureSupport.kt` | `suspendAwait()`, `coAwait()` | `RedisFutureSupportTest` compatibility tests | Replace tests, then delete | `awaitSuspending()` |
-| 5 | `opentelemetry` | `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/SpanCoroutineSupport.kt` | `SpanBuilder.useSuspendSpan(...)` overloads | One compatibility test path | Replace tests, then delete | `useSpanSuspending(...)` |
-| 6 | `opentelemetry` | `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanExporterSupport.kt` | `spanExportOf(...)` | Definition only | Delete | `spanExporterOf(...)` |
-| 7 | `opentelemetry` | `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanProcessorSupport.kt` | `batchSpanProcess(...)` | Definition only | Delete | `batchSpanProcessorOf(...)` |
-| 8 | `redisson` | `infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/RedissonConst.kt` | `DEFAULT_DELIMETER` typo | Definition only | Delete | `DEFAULT_DELIMITER` |
-| 9 | `resilience4j` | `infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/SuspendDecorators.kt` | `decoreate()` typo overloads | Definition only | Delete | `decorate()` |
+| 5 | `redisson` | `infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/RedissonConst.kt` | `DEFAULT_DELIMETER` typo | Definition only | Delete | `DEFAULT_DELIMITER` |
+| 6 | `resilience4j` | `infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/SuspendDecorators.kt` | `decoreate()` typo overloads | Definition only | Delete | `decorate()` |
 
 ## Follow-Up PR Split
 
@@ -61,7 +62,25 @@ Validation:
 
 - `./gradlew :bluetape4k-kafka:test :bluetape4k-kafka4:test --no-daemon`
 
-### PR B: Cache, Redis, OpenTelemetry, and Resilience4j aliases
+### PR B: OpenTelemetry aliases
+
+Status: Done in issue #474 PR B.
+
+Scope:
+
+- `infra/opentelemetry`
+
+Tasks:
+
+- Remove coroutine alias APIs: `useSuspendSpan`.
+- Remove naming aliases: `spanExportOf`, `batchSpanProcess`.
+- Rewrite compatibility tests to exercise the canonical APIs only.
+
+Validation:
+
+- `./gradlew :bluetape4k-opentelemetry:test --no-daemon`
+
+### Later PRs: Cache, Redis, and Resilience4j aliases
 
 Scope:
 
@@ -69,20 +88,18 @@ Scope:
 - `cache/lettuce`
 - `infra/lettuce`
 - `infra/redisson`
-- `infra/opentelemetry`
 - `infra/resilience4j`
 
 Tasks:
 
 - Remove typo aliases: `DEFAULT_DELIMETER`, `decoreate()`.
 - Remove coroutine alias APIs: `getSuspending`, `clearFrontCache`,
-  `suspendAwait`, `coAwait`, `useSuspendSpan`.
-- Remove naming aliases: `spanExportOf`, `batchSpanProcess`.
+  `suspendAwait`, `coAwait`.
 - Rewrite compatibility tests to exercise the canonical APIs only.
 
 Validation:
 
-- `./gradlew :bluetape4k-cache-core:test :bluetape4k-cache-lettuce:test :bluetape4k-lettuce:test :bluetape4k-redisson:test :bluetape4k-opentelemetry:test :bluetape4k-resilience4j:test --no-daemon`
+- `./gradlew :bluetape4k-cache-core:test :bluetape4k-cache-lettuce:test :bluetape4k-lettuce:test :bluetape4k-redisson:test :bluetape4k-resilience4j:test --no-daemon`
 
 ## Notes For Follow-Up Work
 

--- a/docs/lessons/2026-05-20-issue-474-opentelemetry-deprecated-removal.md
+++ b/docs/lessons/2026-05-20-issue-474-opentelemetry-deprecated-removal.md
@@ -1,0 +1,30 @@
+# Issue 474 OpenTelemetry Deprecated API Removal
+
+## Context
+
+Issue #474 tracks staged removal of deprecated `infra/` APIs after the compatibility window. This lane only covers the OpenTelemetry module and stays independent from the Kafka cleanup PR.
+
+## Decision
+
+Remove the deprecated OpenTelemetry aliases instead of keeping forwarding shims:
+
+- `SpanBuilder.useSuspendSpan`
+- `spanExportOf`
+- `batchSpanProcess`
+
+The canonical APIs remain `useSpanSuspending`, `spanExporterOf`, and `batchSpanProcessorOf`.
+
+## Outcome
+
+OpenTelemetry no longer exposes deprecated alias APIs in main sources, and README examples now show only canonical names.
+
+## Verification
+
+- `./gradlew :bluetape4k-opentelemetry:compileKotlin :bluetape4k-opentelemetry:compileTestKotlin --no-configuration-cache`
+  passed.
+- `./gradlew :bluetape4k-opentelemetry:test --no-configuration-cache` passed with 73 tests.
+- Removed one existing `!!` in `FlowSpanSupportTest` after compile surfaced an unnecessary non-null assertion warning.
+
+## Future Guidance
+
+Keep future #474 lanes narrow and independent. The shared deprecated inventory may conflict across parallel cleanup PRs; resolve it by preserving each lane's completed rows and keeping remaining work visible.

--- a/infra/opentelemetry/README.ko.md
+++ b/infra/opentelemetry/README.ko.md
@@ -129,7 +129,7 @@ suspend fun withExplicitContext() {
   }
 }
 
-// deprecated 된 useSuspendSpan 대신 useSpanSuspending 사용 권장
+// suspend 작업 주위에 Span을 생성하고 범위를 지정할 때 useSpanSuspending 사용
 tracer.spanBuilder("recommended").useSpanSuspending(Dispatchers.IO) { span ->
   doAsyncWork()
 }

--- a/infra/opentelemetry/README.md
+++ b/infra/opentelemetry/README.md
@@ -130,7 +130,7 @@ suspend fun withExplicitContext() {
   }
 }
 
-// Prefer useSpanSuspending over the deprecated useSuspendSpan
+// Use useSpanSuspending to create and scope a Span around suspend work
 tracer.spanBuilder("recommended").useSpanSuspending(Dispatchers.IO) { span ->
   doAsyncWork()
 }

--- a/infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/SpanCoroutineSupport.kt
+++ b/infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/SpanCoroutineSupport.kt
@@ -81,15 +81,6 @@ suspend inline fun <T> SpanBuilder.useSpanSuspending(
     block(span)
 }
 
-@Deprecated(
-    "use useSpanSuspending instead.",
-    replaceWith = ReplaceWith("useSpanSuspending(coroutineContext, block)")
-)
-suspend inline fun <T> SpanBuilder.useSuspendSpan(
-    coroutineContext: CoroutineContext = EmptyCoroutineContext,
-    crossinline block: suspend (Span) -> T,
-): T = useSpanSuspending(coroutineContext, block)
-
 /**
  * `waitTimeout` 기반 overload 입니다.
  *
@@ -103,38 +94,12 @@ suspend inline fun <T> SpanBuilder.useSpanSuspending(
     block(span)
 }
 
-@Deprecated(
-    "use useSpanSuspending instead.",
-    replaceWith = ReplaceWith("useSpanSuspending(waitTimeout, coroutineContext, block)")
-)
-suspend inline fun <T> SpanBuilder.useSuspendSpan(
-    waitTimeout: Long? = null,
-    coroutineContext: CoroutineContext = EmptyCoroutineContext,
-    crossinline block: suspend (Span) -> T,
-): T = startSpan().useSuspending(waitTimeout, coroutineContext) { span ->
-    block(span)
-}
-
 /**
  * [Duration] 기반 overload 입니다.
  *
  * `waitDuration` 역시 하위 호환용 인자이며 종료 시각을 미래로 밀어 쓰지 않습니다.
  */
 suspend inline fun <T> SpanBuilder.useSpanSuspending(
-    waitDuration: Duration,
-    coroutineContext: CoroutineContext = EmptyCoroutineContext,
-    crossinline block: suspend (Span) -> T,
-): T = useSpanSuspending(
-    waitDuration.toMillis().coerceAtLeast(0L),
-    coroutineContext,
-    block,
-)
-
-@Deprecated(
-    "use useSpanSuspending instead.",
-    replaceWith = ReplaceWith("useSpanSuspending(waitDuration, coroutineContext, block)")
-)
-suspend inline fun <T> SpanBuilder.useSuspendSpan(
     waitDuration: Duration,
     coroutineContext: CoroutineContext = EmptyCoroutineContext,
     crossinline block: suspend (Span) -> T,

--- a/infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanExporterSupport.kt
+++ b/infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanExporterSupport.kt
@@ -32,16 +32,6 @@ fun spanExporterOf(vararg exporters: SpanExporter): SpanExporter =
     SpanExporter.composite(*exporters)
 
 /**
- * [spanExporterOf]의 이전 이름입니다.
- */
-@Deprecated(
-    message = "use spanExporterOf instead.",
-    replaceWith = ReplaceWith("spanExporterOf(*exporters)")
-)
-fun spanExportOf(vararg exporters: SpanExporter): SpanExporter =
-    spanExporterOf(*exporters)
-
-/**
  * 지정된 [SpanData]들을 내보냅니다.
  *
  * @param spanDatas 내보낼 [SpanData] 목록

--- a/infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanProcessorSupport.kt
+++ b/infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanProcessorSupport.kt
@@ -43,16 +43,3 @@ inline fun batchSpanProcessorOf(
 ): BatchSpanProcessor {
     return BatchSpanProcessor.builder(exporter).apply(builder).build()
 }
-
-/**
- * [batchSpanProcessorOf]의 이전 이름입니다.
- */
-@Deprecated(
-    message = "use batchSpanProcessorOf instead.",
-    replaceWith = ReplaceWith("batchSpanProcessorOf(exporter, builder)")
-)
-inline fun batchSpanProcess(
-    exporter: SpanExporter,
-    builder: BatchSpanProcessorBuilder.() -> Unit,
-): BatchSpanProcessor =
-    batchSpanProcessorOf(exporter, builder)

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/coroutines/FlowSpanSupportTest.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/coroutines/FlowSpanSupportTest.kt
@@ -153,11 +153,11 @@ class FlowSpanSupportTest: AbstractOtelTest() {
         }
         flush()
 
-        spanInsideAction.shouldNotBeNull()
+        val collectedSpan = spanInsideAction.shouldNotBeNull()
         // collect 안에서의 Span이 종료된 traced Span과 동일한 traceId
         val finished = spanExporter.finishedSpanItems
         finished shouldHaveSize 1
-        finished[0].traceId shouldBeEqualTo spanInsideAction!!.spanContext.traceId
+        finished[0].traceId shouldBeEqualTo collectedSpan.spanContext.traceId
     }
 
     @Test

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/coroutines/SpanCoroutineSupportTest.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/coroutines/SpanCoroutineSupportTest.kt
@@ -151,12 +151,12 @@ class SpanCoroutineSupportTest: AbstractOtelTest() {
     }
 
     @Test
-    fun `deprecated useSuspendSpan should preserve original exception type`() = runSuspendIO {
+    fun `useSpanSuspending should preserve original exception type`() = runSuspendIO {
         spanExporter.reset()
-        val failure = IllegalStateException("deprecated")
+        val failure = IllegalStateException("canonical")
 
         val ex = kotlin.runCatching {
-            tracer.spanBuilder("deprecated-error-span").useSpanSuspending {
+            tracer.spanBuilder("canonical-error-span").useSpanSuspending {
                 throw failure
             }
         }.exceptionOrNull()
@@ -169,7 +169,7 @@ class SpanCoroutineSupportTest: AbstractOtelTest() {
 
         val finished = spanExporter.finishedSpanItems
         finished shouldHaveSize 1
-        finished[0].name shouldBeEqualTo "deprecated-error-span"
+        finished[0].name shouldBeEqualTo "canonical-error-span"
         finished[0].status.statusCode.name shouldBeEqualTo "ERROR"
         finished[0].events.any { it.name == "exception" }.shouldBeTrue()
     }


### PR DESCRIPTION
## Summary

Closes #474

- PR 제목: chore: remove deprecated OpenTelemetry APIs

- Remove deprecated OpenTelemetry aliases: `SpanBuilder.useSuspendSpan`, `spanExportOf`, and `batchSpanProcess`.
- Keep canonical APIs (`useSpanSuspending`, `spanExporterOf`, `batchSpanProcessorOf`) and update README examples/tests to use them.
- Update the deprecated inventory and add the issue #474 lesson for this independent OpenTelemetry lane.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

- Remove deprecated OpenTelemetry aliases: `SpanBuilder.useSuspendSpan`, `spanExportOf`, and `batchSpanProcess`.
- Keep canonical APIs (`useSpanSuspending`, `spanExporterOf`, `batchSpanProcessorOf`) and update README examples/tests to use them.
- Update the deprecated inventory and add the issue #474 lesson for this independent OpenTelemetry lane.

### Validation

- `./gradlew :bluetape4k-opentelemetry:compileKotlin :bluetape4k-opentelemetry:compileTestKotlin --no-configuration-cache`
- `./gradlew :bluetape4k-opentelemetry:test --no-configuration-cache` (73 passing)
- `git diff --check`
- Current-session Codex Review: no findings.

Refs #474

Co-authored-by: OmX <omx@oh-my-codex.dev>

## Validation

- `./gradlew :bluetape4k-opentelemetry:compileKotlin :bluetape4k-opentelemetry:compileTestKotlin --no-configuration-cache`
- `./gradlew :bluetape4k-opentelemetry:test --no-configuration-cache` (73 passing)
- `git diff --check`
- Current-session Codex Review: no findings.

Refs #474

Co-authored-by: OmX <omx@oh-my-codex.dev>

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #474, milestone `1.9.0`, assignee debop
- PR: #576, head `c7e0912cfd869e47c85466e93113bb480a9c40d8`, milestone `1.9.0`, assignee debop
- Base: `develop`, head branch `chore/issue-474-opentelemetry-deprecated-removal`
- Labels: `documentation`, `test`, `chore`, `infra/io`, `tech-debt`, `1.8.0-after`
- State: `MERGED`, merge commit `511f6775c8893ffbcd111897b57b8bbc6cf7c3c2`
- CI: - `./gradlew :bluetape4k-opentelemetry:compileKotlin :bluetape4k-opentelemetry:compileTestKotlin --no-configuration-cache` / - `./gradlew :bluetape4k-opentelemetry:test --no-configuration-cache` (73 passing)## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #576 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `511f6775c8893ffbcd111897b57b8bbc6cf7c3c2`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
