### PR TITLE
chore: remove cache Redis Resilience4j deprecated APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
   instead ([#474](https://github.com/bluetape4k/bluetape4k-projects/issues/474)).
 - Removed the deprecated Kafka/Kafka4 JDK-backed codecs (`JdkKafkaCodec`, `LZ4JdkKafkaCodec`, `SnappyJdkKafkaCodec`, `ZstdJdkKafkaCodec`) and the corresponding `KafkaCodecs.*Jdk` registry entries. Use the Fory or Kryo codec variants instead ([#474](https://github.com/bluetape4k/bluetape4k-projects/issues/474)).
 - Removed the deprecated Kafka/Kafka4 Spring send aliases (`sendAndAwait`, `awaitSend`, `awaitSendDefault`, `sendSuspending`) and metrics aliases (`getMetricValue`). Use `suspendSend`, `suspendSendDefault`, and `getMetricValueOrNull` instead ([#474](https://github.com/bluetape4k/bluetape4k-projects/issues/474)).
+- Removed deprecated cache, Redis, and Resilience4j aliases (`AsyncCache.getSuspending`,
+  `LettuceSuspendNearCache.clearFrontCache`, Redis `DEFAULT_DELIMETER`, Redisson
+  `DEFAULT_DELIMETER`, `RedisFuture.suspendAwait`, `RedisFuture.coAwait`, and
+  `SuspendDecorators.decoreate`). Use the canonical replacements documented in
+  each module instead ([#474](https://github.com/bluetape4k/bluetape4k-projects/issues/474)).
 
 ### Fixed
 

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/caffeine/CaffeineSupport.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/caffeine/CaffeineSupport.kt
@@ -254,39 +254,3 @@ inline fun <K: Any, V: Any> AsyncCache<K, V>.suspendGet(
         }
     }
 }
-
-/**
- * [AsyncCache]에 값이 없으면 [loader]를 이용하여 값을 채우고, 반환합니다.
- *
- * ```kotlin
- * val cache = caffeine<Any, Any> {
- *   maximumSize(1000)
- *   expireAfterWrite(5, TimeUnit.MINUTES)
- * }
- * val asyncCache: AsyncCache<String, Int> = cache.asyncCache()
- *
- * runBlocking {
- *      val future:CompletableFuture<Int> = asyncCache.getSuspending("hello") { key ->
- *          // suspend function
- *          delay(10)
- *          key.length
- *      }
- *      future.await()  // 5
- * }
- * ```
- *
- * @param key     cache key
- * @param loader  캐시 값을 Coroutines 환경에서 로딩하는 함수
- * @return [CompletableFuture] for cache value
- */
-@Deprecated("use suspendGet instead", ReplaceWith("this.suspendGet(key, loader)"))
-inline fun <K: Any, V: Any> AsyncCache<K, V>.getSuspending(
-    key: K,
-    crossinline loader: suspend (key: K) -> V,
-): CompletableFuture<V> {
-    return this.get(key) { k: K, executor: Executor ->
-        CoroutineScope(executor.asCoroutineDispatcher()).future {
-            loader(k)
-        }
-    }
-}

--- a/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceSuspendNearCache.kt
+++ b/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceSuspendNearCache.kt
@@ -313,11 +313,6 @@ class LettuceSuspendNearCache<V: Any>(
         frontCache.clear()
     }
 
-    @Deprecated("clearLocal()로 통일됨", replaceWith = ReplaceWith("clearLocal()"))
-    fun clearFrontCache() {
-        clearLocal()
-    }
-
     private suspend fun clearBackCache() {
         val pattern = "${config.cacheName}:*"
         var cursor: ScanCursor = ScanCursor.INITIAL

--- a/docs/infra-deprecated-inventory.md
+++ b/docs/infra-deprecated-inventory.md
@@ -2,7 +2,8 @@
 
 Snapshot: 2026-05-09 KST
 Updated: 2026-05-20 KST
-Issue: [#110](https://github.com/bluetape4k/bluetape4k-projects/issues/110)
+Issues: [#110](https://github.com/bluetape4k/bluetape4k-projects/issues/110),
+[#474](https://github.com/bluetape4k/bluetape4k-projects/issues/474)
 
 This inventory records tracked `infra/` and related cache source files that
 still declare `@Deprecated`. Completed cleanup waves are removed from the active
@@ -12,8 +13,8 @@ inventory.
 
 | Decision | Count | Meaning |
 |---|---:|---|
-| Delete | 5 files | Deprecated API has a direct replacement and should not remain in the next cleanup line. |
-| Replace call sites first | 1 file | Repo-local tests or samples still exercise the deprecated API and must move first. |
+| Delete | 0 files | No tracked deprecated API remains in the current cleanup inventory. |
+| Replace call sites first | 0 files | No repo-local compatibility tests or samples remain on tracked deprecated APIs. |
 | Keep | 0 files | No deprecated `infra/` API needs long-term retention. |
 
 `infra/kafka4` mirrors several `infra/kafka` deprecated APIs, so the current
@@ -27,16 +28,16 @@ cleanup wave.
 `spanExportOf`, and `batchSpanProcess` were removed; use `useSpanSuspending`,
 `spanExporterOf`, and `batchSpanProcessorOf`.
 
+2026-05-20 update: cache, Redis, and Resilience4j aliases were removed:
+`AsyncCache.getSuspending`, `LettuceSuspendNearCache.clearFrontCache`,
+`RedisFuture.suspendAwait`, `RedisFuture.coAwait`, Redis/Redisson
+`DEFAULT_DELIMETER`, and `SuspendDecorators.decoreate`.
+
 ## Inventory
 
 | # | Module | File | Deprecated API | Current usage | Decision | Replacement |
 |---:|---|---|---|---|---|---|
-| 1 | `cache-core` | `cache/core/src/main/kotlin/io/bluetape4k/cache/caffeine/CaffeineSupport.kt` | `AsyncCache.getSuspending(...)` | KDoc sample only | Delete | `AsyncCache.suspendGet(...)` |
-| 2 | `cache-lettuce` | `cache/lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceSuspendNearCache.kt` | `clearFrontCache()` | Definition only | Delete | `clearLocal()` |
-| 3 | `lettuce` | `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/LettuceConst.kt` | `DEFAULT_DELIMETER` typo | Definition only | Delete | `DEFAULT_DELIMITER` |
-| 4 | `lettuce` | `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/RedisFutureSupport.kt` | `suspendAwait()`, `coAwait()` | `RedisFutureSupportTest` compatibility tests | Replace tests, then delete | `awaitSuspending()` |
-| 5 | `redisson` | `infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/RedissonConst.kt` | `DEFAULT_DELIMETER` typo | Definition only | Delete | `DEFAULT_DELIMITER` |
-| 6 | `resilience4j` | `infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/SuspendDecorators.kt` | `decoreate()` typo overloads | Definition only | Delete | `decorate()` |
+| - | - | - | - | - | - | - |
 
 ## Follow-Up PR Split
 
@@ -80,12 +81,14 @@ Validation:
 
 - `./gradlew :bluetape4k-opentelemetry:test --no-daemon`
 
-### Later PRs: Cache, Redis, and Resilience4j aliases
+### PR C: Cache, Redis, and Resilience4j aliases
+
+Status: Done in issue #474 PR C.
 
 Scope:
 
-- `cache/core`
-- `cache/lettuce`
+- `cache/cache-core`
+- `cache/cache-lettuce`
 - `infra/lettuce`
 - `infra/redisson`
 - `infra/resilience4j`
@@ -105,7 +108,8 @@ Validation:
 
 - Bucket4j `RateLimitResult(consumedTokens, availableTokens)` cleanup was
   completed by issue #434.
-- This inventory intentionally does not delete the remaining code.
+- This inventory now records the completed cleanup waves; no tracked active
+  rows remain.
 - Keep each cleanup PR small enough to review API removal and test migration
   separately.
 - When a cleanup PR removes public API, add the migration note to

--- a/docs/lessons/2026-05-20-issue-474-cache-redis-resilience4j-deprecated-removal.md
+++ b/docs/lessons/2026-05-20-issue-474-cache-redis-resilience4j-deprecated-removal.md
@@ -1,0 +1,37 @@
+# Issue 474 Cache Redis Resilience4j Deprecated API Removal
+
+## Context
+
+Issue #474 removes deprecated infra/cache aliases after the compatibility window. This lane covers cache-core, cache-lettuce, lettuce, redisson, and resilience4j only.
+
+## Decision
+
+Remove forwarding aliases instead of keeping compatibility shims:
+
+- `AsyncCache.getSuspending`
+- `LettuceSuspendNearCache.clearFrontCache`
+- `RedisFuture.suspendAwait`
+- `RedisFuture.coAwait`
+- Redis and Redisson `DEFAULT_DELIMETER`
+- `SuspendDecorators.decoreate`
+
+Canonical APIs remain `suspendGet`, `clearLocal`, `awaitSuspending`, `DEFAULT_DELIMITER`, and `decorate`.
+
+## Outcome
+
+Compatibility tests now exercise canonical APIs, and the public deprecated alias surface is removed from the touched modules.
+
+## Verification
+
+- `./gradlew :bluetape4k-cache-core:compileKotlin :bluetape4k-cache-core:compileTestKotlin :bluetape4k-cache-lettuce:compileKotlin :bluetape4k-cache-lettuce:compileTestKotlin :bluetape4k-lettuce:compileKotlin :bluetape4k-lettuce:compileTestKotlin :bluetape4k-redisson:compileKotlin :bluetape4k-redisson:compileTestKotlin :bluetape4k-resilience4j:compileKotlin :bluetape4k-resilience4j:compileTestKotlin --no-configuration-cache`
+- `./gradlew :bluetape4k-cache-core:test --no-configuration-cache`: 455 passing.
+- `./gradlew :bluetape4k-cache-lettuce:test --no-configuration-cache`: 427 passing.
+- `./gradlew :bluetape4k-lettuce:test --no-daemon --no-configuration-cache`: 331 passing after one daemon-disappearance retry.
+- `./gradlew :bluetape4k-redisson:test --no-daemon --no-configuration-cache`: 287 passing.
+- `./gradlew :bluetape4k-resilience4j:test --no-daemon --no-configuration-cache`: 280 passing.
+- `git diff --check`
+- `rg -n "@Deprecated|getSuspending|clearFrontCache|suspendAwait\\b|coAwait\\b|DEFAULT_DELIMETER|decoreate" cache/cache-core cache/cache-lettuce infra/lettuce infra/redisson infra/resilience4j`
+
+## Future Guidance
+
+Keep #474 cleanup PRs independent. If `docs/infra-deprecated-inventory.md` conflicts with Kafka or OpenTelemetry cleanup PRs, preserve all completed rows from each lane and keep only truly remaining deprecated APIs in the table.

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/LettuceConst.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/LettuceConst.kt
@@ -30,10 +30,4 @@ object LettuceConst {
     const val DEFAULT_CHARSET = "UTF-8"
     const val DEFAULT_LOGBACK_CHANNEL = "channel:logback:logs"
     const val DEFAULT_DELIMITER = ":"
-
-    @Deprecated(
-        "오타 수정: DEFAULT_DELIMETER → DEFAULT_DELIMITER",
-        replaceWith = ReplaceWith("DEFAULT_DELIMITER")
-    )
-    const val DEFAULT_DELIMETER = DEFAULT_DELIMITER
 }

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/RedisFutureSupport.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/RedisFutureSupport.kt
@@ -20,37 +20,6 @@ import java.util.concurrent.Executor
 suspend inline fun <T> RedisFuture<T>.awaitSuspending(): T = await()
 
 /**
- * [RedisFuture] 완료를 스레드 블로킹 없이 suspend 방식으로 대기합니다.
- *
- * @see awaitSuspending
- *
- * ```kotlin
- * val value: String? = redisAsyncCommands.get("user:1").suspendAwait()
- * ```
- */
-@Deprecated(
-    message = "Use awaitSuspending() instead.",
-    replaceWith = ReplaceWith("awaitSuspending()"),
-)
-suspend inline fun <T> RedisFuture<T>.suspendAwait(): T = await()
-
-
-/**
- * [RedisFuture] 완료를 스레드 블로킹 없이 suspend 방식으로 대기합니다.
- *
- * @see awaitSuspending
- *
- * ```kotlin
- * val value: String? = redisAsyncCommands.get("user:1").coAwait()
- * ```
- */
-@Deprecated(
-    message = "Use awaitSuspending() instead.",
-    replaceWith = ReplaceWith("awaitSuspending()"),
-)
-suspend inline fun <T> RedisFuture<T>.coAwait(): T = await()
-
-/**
  * [RedisFuture] 컬렉션의 모든 요소가 완료될 때까지 스레드 블로킹 없이 대기합니다.
  *
  * 입력 순서대로 결과를 반환합니다. 하나라도 실패하면 반환 [List]를 만들지 않고 해당 예외가 전파됩니다.

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/RedisFutureSupportTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/RedisFutureSupportTest.kt
@@ -28,19 +28,18 @@ class RedisFutureSupportTest: AbstractLettuceTest() {
         asyncCommands.del(keyName).await()
     }
 
-    @Suppress("DEPRECATION")
     @Test
-    fun `suspendAwait - deprecated 버전도 정상 동작`() = runSuspendIO {
+    fun `awaitSuspending should handle set command`() = runSuspendIO {
         val keyName = randomName()
-        asyncCommands.set(keyName, "hello").suspendAwait() shouldBeEqualTo "OK"
+        asyncCommands.set(keyName, "hello").awaitSuspending() shouldBeEqualTo "OK"
         asyncCommands.del(keyName).await()
     }
 
-    @Suppress("DEPRECATION")
     @Test
-    fun `coAwait - deprecated 버전도 정상 동작`() = runSuspendIO {
+    fun `awaitSuspending should handle get command`() = runSuspendIO {
         val keyName = randomName()
-        asyncCommands.set(keyName, "world").coAwait() shouldBeEqualTo "OK"
+        asyncCommands.set(keyName, "world").awaitSuspending() shouldBeEqualTo "OK"
+        asyncCommands.get(keyName).awaitSuspending() shouldBeEqualTo "world"
         asyncCommands.del(keyName).await()
     }
 

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/atomic/LettuceSuspendAtomicLongTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/atomic/LettuceSuspendAtomicLongTest.kt
@@ -37,7 +37,7 @@ class LettuceSuspendAtomicLongTest: AbstractLettuceTest() {
     // =========================================================================
 
     @Test
-    fun `getSuspending and setSuspending`() = runSuspendIO {
+    fun `get and set`() = runSuspendIO {
         val counter = suspendAtomicLong()
         counter.set(42L)
         counter.get() shouldBeEqualTo 42L

--- a/infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/RedissonConst.kt
+++ b/infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/RedissonConst.kt
@@ -32,13 +32,6 @@ object RedissonConst {
     const val DEFAULT_LOGBACK_CHANNEL = "channel:logback:logs"
     const val DEFAULT_DELIMITER = ":"
 
-    @Deprecated(
-        message = "오타 수정: DEFAULT_DELIMETER → DEFAULT_DELIMITER",
-        replaceWith = ReplaceWith("DEFAULT_DELIMITER"),
-        level = DeprecationLevel.WARNING
-    )
-    const val DEFAULT_DELIMETER = DEFAULT_DELIMITER
-
     /**
      * 고동시성 환경용 Connection Pool 크기: CPU × 8 (범위 64~256)
      */

--- a/infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/SuspendDecorators.kt
+++ b/infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/SuspendDecorators.kt
@@ -361,14 +361,6 @@ object SuspendDecorators: KLoggingChannel() {
         fun decorate(): suspend () -> T = supplier
 
         /**
-         * 현재까지 적용된 모든 데코레이터를 조합한 suspend 함수를 반환합니다.
-         *
-         * @deprecated [decorate]를 사용하세요. 이 함수는 오타였습니다.
-         */
-        @Deprecated("오타 수정됨. decorate()를 사용하세요.", ReplaceWith("decorate()"))
-        fun decoreate(): suspend () -> T = supplier
-
-        /**
          * 조합된 suspend 함수를 실행하고 결과를 반환합니다.
          *
          * @return 실행 결과
@@ -480,14 +472,6 @@ object SuspendDecorators: KLoggingChannel() {
         fun decorate(): suspend (T) -> R = func
 
         /**
-         * 현재까지 적용된 모든 데코레이터를 조합한 suspend 함수를 반환합니다.
-         *
-         * @deprecated [decorate]를 사용하세요. 이 함수는 오타였습니다.
-         */
-        @Deprecated("오타 수정됨. decorate()를 사용하세요.", ReplaceWith("decorate()"))
-        fun decoreate(): suspend (T) -> R = func
-
-        /**
          * 조합된 suspend 함수를 [input]과 함께 실행하고 결과를 반환합니다.
          *
          * @param input 함수 입력값
@@ -570,14 +554,6 @@ object SuspendDecorators: KLoggingChannel() {
          * @return 조합된 suspend 함수
          */
         fun decorate(): suspend (T, U) -> R = func
-
-        /**
-         * 현재까지 적용된 모든 데코레이터를 조합한 suspend 함수를 반환합니다.
-         *
-         * @deprecated [decorate]를 사용하세요. 이 함수는 오타였습니다.
-         */
-        @Deprecated("오타 수정됨. decorate()를 사용하세요.", ReplaceWith("decorate()"))
-        fun decoreate(): suspend (T, U) -> R = func
 
         /**
          * 조합된 suspend 함수를 [t], [u]와 함께 실행하고 결과를 반환합니다.

--- a/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/cache/CacheExtensionsTest.kt
+++ b/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/cache/CacheExtensionsTest.kt
@@ -25,7 +25,7 @@ class CacheExtensionsTest {
     companion object: KLogging()
 
     @Test
-    fun `decoreate function1 for Cache`() {
+    fun `decorate function1 for Cache`() {
         val jcache = CaffeineJCacheProvider.getJCache<String, String>("function1")
         val cache = Cache.of(jcache)
 


### PR DESCRIPTION
## Summary

Closes #474

- PR 제목: chore: remove cache Redis Resilience4j deprecated APIs

- Remove deprecated cache, Redis, Redisson, and Resilience4j compatibility aliases from the issue #474 cleanup lane.
- Move compatibility tests to canonical APIs and update the deprecated inventory, changelog, and lesson note.
- Keep this PR independent from the Kafka and OpenTelemetry #474 cleanup PRs.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Codex Review

- Current-session Codex review: no findings.

Refs #474

Co-authored-by: OmX <omx@oh-my-codex.dev>

## Validation

- `./gradlew :bluetape4k-cache-core:compileKotlin :bluetape4k-cache-core:compileTestKotlin :bluetape4k-cache-lettuce:compileKotlin :bluetape4k-cache-lettuce:compileTestKotlin :bluetape4k-lettuce:compileKotlin :bluetape4k-lettuce:compileTestKotlin :bluetape4k-redisson:compileKotlin :bluetape4k-redisson:compileTestKotlin :bluetape4k-resilience4j:compileKotlin :bluetape4k-resilience4j:compileTestKotlin --no-configuration-cache`
- `./gradlew :bluetape4k-cache-core:test --no-configuration-cache` (455 passing)
- `./gradlew :bluetape4k-cache-lettuce:test --no-configuration-cache` (427 passing)
- `./gradlew :bluetape4k-lettuce:test --no-daemon --no-configuration-cache` (331 passing after daemon retry)
- `./gradlew :bluetape4k-redisson:test --no-daemon --no-configuration-cache` (287 passing)
- `./gradlew :bluetape4k-resilience4j:test --no-daemon --no-configuration-cache` (280 passing)
- `git diff --check`
- Deprecated alias search across touched modules returned no matches.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #474, milestone `1.9.0`, assignee debop
- PR: #577, head `70d2ec15070e48c8e7e1e2982aeb8fb9489d31d9`, milestone `1.9.0`, assignee debop
- Base: `develop`, head branch `chore/issue-474-cache-redis-deprecated-removal`
- Labels: `documentation`, `test`, `chore`, `infra/io`, `tech-debt`, `1.8.0-after`
- State: `MERGED`, merge commit `80def7e9d8dec52335fc83d16593d4c3b4fc0a7d`
- CI: - `./gradlew :bluetape4k-cache-core:compileKotlin :bluetape4k-cache-core:compileTestKotlin :bluetape4k-cache-lettuce:compileKotlin :bluetape4k-cache-lettuce:compileTestKotlin :bluetape4k-lettuce:compileKotlin :bluetape4k-lettuce:compileTestKotlin :bluetape4k-redisson:compileKotlin :bluetape4k-redisson:compileTestKotlin :bluetape4k-resilience4j:compileKotlin :bluetape4k-resilience4j:compileTestKotlin --no-configuration-cache` / - `./gradlew :bluetape4k-cache-core:test --no-configuration-cache` (455 passing) / - `./gradlew :bluetape4k-cache-lettuce:test --no-configuration-cache` (427 passing)## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #577 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `80def7e9d8dec52335fc83d16593d4c3b4fc0a7d`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
