### PR TITLE
chore: add @Suppress(DEPRECATION) to LZ4/Snappy/ZstdJdkKafkaCodec

### DIFF
--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
@@ -98,6 +98,7 @@ class ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.Fory)
     replaceWith = ReplaceWith("LZ4ForyKafkaCodec()"),
     level = DeprecationLevel.ERROR,
 )
+@Suppress("DEPRECATION")
 class LZ4JdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Jdk)
 
 /**
@@ -145,6 +146,7 @@ class LZ4ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Fory)
     replaceWith = ReplaceWith("SnappyForyKafkaCodec()"),
     level = DeprecationLevel.ERROR,
 )
+@Suppress("DEPRECATION")
 class SnappyJdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyJdk)
 
 /**
@@ -192,6 +194,7 @@ class SnappyForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyFory)
     replaceWith = ReplaceWith("ZstdForyKafkaCodec()"),
     level = DeprecationLevel.ERROR,
 )
+@Suppress("DEPRECATION")
 class ZstdJdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.ZstdJdk)
 
 /**

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
@@ -98,6 +98,7 @@ class ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.Fory)
     replaceWith = ReplaceWith("LZ4ForyKafkaCodec()"),
     level = DeprecationLevel.ERROR,
 )
+@Suppress("DEPRECATION")
 class LZ4JdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Jdk)
 
 /**
@@ -145,6 +146,7 @@ class LZ4ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Fory)
     replaceWith = ReplaceWith("SnappyForyKafkaCodec()"),
     level = DeprecationLevel.ERROR,
 )
+@Suppress("DEPRECATION")
 class SnappyJdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyJdk)
 
 /**
@@ -192,6 +194,7 @@ class SnappyForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyFory)
     replaceWith = ReplaceWith("ZstdForyKafkaCodec()"),
     level = DeprecationLevel.ERROR,
 )
+@Suppress("DEPRECATION")
 class ZstdJdkKafkaCodec: BinaryKafkaCodec(BinarySerializers.ZstdJdk)
 
 /**


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: chore: add @Suppress(DEPRECATION) to LZ4/Snappy/ZstdJdkKafkaCodec

## Background

`LZ4JdkKafkaCodec`, `SnappyJdkKafkaCodec`, and `ZstdJdkKafkaCodec` each pass a
`@Deprecated(level = WARNING)` `BinarySerializers.*Jdk` property to their
superclass constructor. Without `@Suppress("DEPRECATION")` the compiler emits a
deprecation warning for each of the three classes on every build.

`JdkKafkaCodec` (the plain JDK variant in the same file) already has
`@Suppress("DEPRECATION")`. The three compressed variants were missed when the
`chore: gate unsafe Kafka JDK codecs` commit was applied.

Per CLAUDE.md: "zero errors and no unresolved deprecations in touched code."

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

Added `@Suppress("DEPRECATION")` to the three classes in both
`infra/kafka/` and `infra/kafka4/` modules, matching the pattern already
used by `JdkKafkaCodec`.

### 기존 섹션: Affected files

- `infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt`
- `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt`

Detected by automated daily review job (2026-05-21).

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #579, head `70d8381d8f3fb9702dc1da39e1a8678a819fc513`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/kafka-jdk-codec-suppress-deprecation`
- Labels: 없음
- State: `CLOSED`, merge commit `N/A`
- CI: N/A (역사적 PR; 본문 정규화 과정에서 CI를 재실행하지 않음)

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #579 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: CLOSED (not merged; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
