### PR TITLE
perf(io-http): compare HTTP client benchmark tuning

### DIFF
--- a/docs/benchmarks/2026-05-21-io-http-client-benchmark.md
+++ b/docs/benchmarks/2026-05-21-io-http-client-benchmark.md
@@ -1,0 +1,77 @@
+# io/http HTTP Client Benchmark - 2026-05-21
+
+## Scope
+
+This report records benchmark-driven work for GitHub epic #589 and sub-issue #590.
+Related existing issues included in the epic: #582, #583, #584, #585, #586, and #587.
+
+Target module: `:bluetape4k-http`.
+
+## Commands
+
+```bash
+./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude='HttpClientBenchmark|HttpClientLatencyBenchmark' --no-configuration-cache
+./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude='HttpClientBenchmark.ktorCioCoroutines|HttpClientLatencyBenchmark.ktorCioCoroutines' --no-configuration-cache
+```
+
+Environment: local Colima Docker, `bluetape4k/mock-web-server:latest`, Docker server 29.2.1, 3905 MB Docker memory.
+
+## Changes Tested
+
+- Configured Vert.x `WebClient` with explicit `PoolOptions` in both HTTP client benchmarks.
+- Added Ktor CIO coroutine rows to the benchmark harness.
+- Kept Ktor CIO rows bounded because full class concurrency exhausted local ephemeral ports against the Docker fixture.
+
+## Base Throughput
+
+`HttpClientBenchmark`, `GET /ping`, ops/s.
+
+| Benchmark | Before | After | Change |
+|-----------|-------:|------:|-------:|
+| `hc5AsyncCoroutines` | 11,191.120 | 11,675.259 | +4.3% |
+| `hc5Classic` | 17,115.856 | 18,453.421 | +7.8% |
+| `hc5ClassicCoroutines` | 16,374.041 | 15,799.529 | -3.5% |
+| `hc5ClassicVirtualThread` | 17,425.528 | 18,327.179 | +5.2% |
+| `javaHttpCoroutines` | 14,679.410 | 14,459.907 | -1.5% |
+| `javaHttpH2Coroutines` | 14,288.272 | 13,240.647 | -7.3% |
+| `javaHttpH2Sync` | 19,216.697 | 17,125.597 | -10.9% |
+| `javaHttpH2VirtualThread` | 17,158.663 | 17,328.761 | +1.0% |
+| `javaHttpSync` | 18,589.051 | 17,224.067 | -7.3% |
+| `javaHttpVirtualThread` | 17,736.870 | 18,355.593 | +3.5% |
+| `okhttp3Coroutines` | 14,398.746 | 13,172.953 | -8.5% |
+| `okhttp3Sync` | 17,195.947 | 17,240.102 | +0.3% |
+| `okhttp3VirtualThread` | 17,669.541 | 17,643.375 | -0.1% |
+| `vertxWebClientCoroutines` | 12,278.843 | 13,491.266 | +9.9% |
+| `ktorCioCoroutines` | n/a | 659.071 | bounded |
+
+The `/ping` benchmark showed high local variance. Treat the Vert.x direction as useful, but not as the primary decision signal.
+
+## High-Latency Throughput
+
+`HttpClientLatencyBenchmark`, `GET /httpbin/delay/0.05`, ops/s.
+
+| Benchmark | Before | After | Change |
+|-----------|-------:|------:|-------:|
+| `hc5AsyncCoroutines` | 1,826.352 | 1,789.987 | -2.0% |
+| `hc5Classic` | 1,751.968 | 1,848.171 | +5.5% |
+| `hc5ClassicCoroutines` | 1,161.095 | 1,168.324 | +0.6% |
+| `hc5ClassicVirtualThread` | 1,791.481 | 1,848.070 | +3.2% |
+| `javaHttpCoroutines` | 376.241 | 383.605 | +2.0% |
+| `javaHttpSync` | 376.703 | 383.628 | +1.8% |
+| `javaHttpVirtualThread` | 375.674 | 384.459 | +2.3% |
+| `okhttp3Coroutines` | 1,831.756 | 1,759.273 | -4.0% |
+| `okhttp3Sync` | 1,762.527 | 1,809.275 | +2.7% |
+| `okhttp3VirtualThread` | 1,822.840 | 1,784.900 | -2.1% |
+| `vertxWebClientCoroutines` | 87.844 | 1,818.508 | +1,970.2% |
+| `ktorCioCoroutines` | n/a | 16.501 | bounded |
+
+## Decisions
+
+- Keep the Vert.x pool configuration in the benchmark harness. The previous high-latency row measured the Vert.x 5 default HTTP/1 pool cap instead of comparable client behavior.
+- Include Ktor CIO in the harness, but mark it as a bounded comparison row. Equal-thread CIO runs produced `java.net.BindException: Can't assign requested address` in this local fixture.
+- Do not enable Ktor CIO HTTP/1 pipelining for this benchmark. It produced unexpected EOFs against the mock server.
+
+## Follow-Up
+
+- Issue #587 should refine the Ktor CIO benchmark surface so it can report a fair high-concurrency comparison or a clearly separate fixture.
+- Issue #585 should add CPU, allocation, and GC profiler runs before converting local benchmark rankings into production defaults.

--- a/docs/images/readme-diagrams/io-http-chart-02.svg
+++ b/docs/images/readme-diagrams/io-http-chart-02.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1040" height="390" viewBox="0 0 1040 390" role="img" aria-labelledby="title desc">
+  <title id="title">HTTP client high-latency benchmark throughput</title>
+  <desc id="desc">After tuning, Vert.x WebClient reaches 1818.508 ops/s compared with 87.844 ops/s before tuning.</desc>
+  <rect width="1040" height="390" fill="#ffffff"/>
+  <text x="40" y="42" font-family="Arial, sans-serif" font-size="24" font-weight="700" fill="#172033">HTTP client high-latency throughput</text>
+  <text x="40" y="70" font-family="Arial, sans-serif" font-size="14" fill="#526070">GET /httpbin/delay/0.05, ops/s higher is better. Ktor CIO is a bounded 1-thread row.</text>
+  <line x1="250" y1="320" x2="960" y2="320" stroke="#d6dbe4" stroke-width="1"/>
+  <line x1="250" y1="108" x2="250" y2="320" stroke="#d6dbe4" stroke-width="1"/>
+  <text x="250" y="345" font-family="Arial, sans-serif" font-size="12" fill="#6b7280">0</text>
+  <text x="485" y="345" font-family="Arial, sans-serif" font-size="12" fill="#6b7280">500</text>
+  <text x="724" y="345" font-family="Arial, sans-serif" font-size="12" fill="#6b7280">1,000</text>
+  <text x="940" y="345" font-family="Arial, sans-serif" font-size="12" fill="#6b7280">1,800</text>
+  <text x="40" y="126" font-family="Arial, sans-serif" font-size="14" fill="#172033">Vert.x before</text>
+  <rect x="250" y="110" width="44" height="22" rx="3" fill="#8b95a5"/>
+  <text x="304" y="126" font-family="Arial, sans-serif" font-size="13" fill="#172033">87.844</text>
+  <text x="40" y="166" font-family="Arial, sans-serif" font-size="14" fill="#172033">Vert.x after</text>
+  <rect x="250" y="150" width="710" height="22" rx="3" fill="#2563eb"/>
+  <text x="970" y="166" font-family="Arial, sans-serif" font-size="13" fill="#172033">1,818.508</text>
+  <text x="40" y="206" font-family="Arial, sans-serif" font-size="14" fill="#172033">HC5 Async after</text>
+  <rect x="250" y="190" width="699" height="22" rx="3" fill="#059669"/>
+  <text x="959" y="206" font-family="Arial, sans-serif" font-size="13" fill="#172033">1,789.987</text>
+  <text x="40" y="246" font-family="Arial, sans-serif" font-size="14" fill="#172033">OkHttp Coroutines after</text>
+  <rect x="250" y="230" width="687" height="22" rx="3" fill="#7c3aed"/>
+  <text x="947" y="246" font-family="Arial, sans-serif" font-size="13" fill="#172033">1,759.273</text>
+  <text x="40" y="286" font-family="Arial, sans-serif" font-size="14" fill="#172033">JDK Coroutines after</text>
+  <rect x="250" y="270" width="150" height="22" rx="3" fill="#f59e0b"/>
+  <text x="410" y="286" font-family="Arial, sans-serif" font-size="13" fill="#172033">383.605</text>
+  <text x="40" y="326" font-family="Arial, sans-serif" font-size="14" fill="#172033">Ktor CIO bounded</text>
+  <rect x="250" y="310" width="6" height="22" rx="3" fill="#dc2626"/>
+  <text x="266" y="326" font-family="Arial, sans-serif" font-size="13" fill="#172033">16.501</text>
+</svg>

--- a/docs/lessons/2026-05-21-issue-590-io-http-self-improve.md
+++ b/docs/lessons/2026-05-21-issue-590-io-http-self-improve.md
@@ -1,0 +1,25 @@
+# Issue 590 io/http Self-Improve
+
+## Context
+
+`io/http` needed benchmark-driven comparison across HC5, OkHttp3, Vert.x, JDK, and Ktor CIO.
+
+## Decision
+
+Vert.x WebClient benchmark setup now uses explicit `PoolOptions` so the high-latency benchmark compares client behavior instead of the Vert.x 5 default HTTP/1 pool cap.
+
+Ktor CIO is included as a bounded benchmark row. Full class concurrency exhausted local ephemeral ports, and CIO HTTP/1 pipelining caused unexpected EOFs against the Docker mock server.
+
+## Outcome
+
+High-latency Vert.x throughput moved from 87.844 ops/s to 1,818.508 ops/s in the local JMH run. Ktor CIO has clean bounded rows only: 659.071 ops/s for `/ping`, 16.501 ops/s for the 50 ms delay endpoint.
+
+## Verification
+
+- `./gradlew :bluetape4k-http:compileTestKotlin --no-configuration-cache`
+- `./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude='HttpClientBenchmark|HttpClientLatencyBenchmark' --no-configuration-cache`
+- `./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude='HttpClientBenchmark.ktorCioCoroutines|HttpClientLatencyBenchmark.ktorCioCoroutines' --no-configuration-cache`
+
+## Future Agents
+
+Do not treat bounded Ktor CIO rows as equal-thread comparisons. Rework the fixture or port reuse behavior before using Ktor CIO numbers for production defaults.

--- a/io/http/README.ko.md
+++ b/io/http/README.ko.md
@@ -197,9 +197,9 @@ JMH(Java Microbenchmark Harness) 기반 벤치마크 3종으로 클라이언트�
 ./gradlew :bluetape4k-http:testBenchmark
 
 # 특정 벤치마크만 실행
-./gradlew :bluetape4k-http:testBenchmark -Pbenchmark.include="HttpClientBenchmark"
-./gradlew :bluetape4k-http:testBenchmark -Pbenchmark.include="HttpClientLatencyBenchmark"
-./gradlew :bluetape4k-http:testBenchmark -Pbenchmark.include="HttpClientCompressionCacheBenchmark"
+./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude="HttpClientBenchmark"
+./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude="HttpClientLatencyBenchmark"
+./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude="HttpClientCompressionCacheBenchmark"
 ```
 
 ### 1. HttpClientBenchmark — 기본 처리량 (`GET /ping`)
@@ -221,6 +221,7 @@ JMH(Java Microbenchmark Harness) 기반 벤치마크 3종으로 클라이언트�
 | HC5 Classic Coroutines | 코루틴 | `Dispatchers.IO` |
 | HC5 Async Coroutines | 비동기 | `executeSuspending()` |
 | Vert.x WebClient Coroutines | 비동기 | 이벤트 루프 |
+| Ktor CIO Coroutines | 코루틴 | 제한 행; 이 fixture에서 CIO는 HTTP/1 dedicated request를 생성 |
 
 > **참고**: 지연 없는 경량 응답이므로 동기/비동기 방식 모두 유사한 처리량을 냅니다.
 > 차이는 주로 커넥션 풀 설정과 스레드 모델에서 발생합니다.
@@ -245,6 +246,29 @@ JMH(Java Microbenchmark Harness) 기반 벤치마크 3종으로 클라이언트�
 | HC5 Classic Coroutines | 코루틴 | `Dispatchers.IO` |
 | HC5 Async Coroutines | 비동기 | `executeSuspending()` |
 | Vert.x WebClient Coroutines | 비동기 | — |
+| Ktor CIO Coroutines | 코루틴 | 제한 행; 1 JMH thread로 측정 |
+
+### 2026-05-21 HTTP 클라이언트 벤치마크 스냅샷
+
+환경: 로컬 Colima Docker, `bluetape4k/mock-web-server:latest`, Docker server 29.2.1, JMH via `:bluetape4k-http:testBenchmark`.
+명령, 실패한 접근, 원시 근거는 [벤치마크 리포트](../../docs/benchmarks/2026-05-21-io-http-client-benchmark.md)에 기록했습니다.
+
+| 벤치마크 행 | Before ops/s | After ops/s | 변화 |
+|-------------|-------------:|------------:|-----:|
+| `HttpClientBenchmark.vertxWebClientCoroutines` | 12,278.843 | 13,491.266 | +9.9% |
+| `HttpClientLatencyBenchmark.vertxWebClientCoroutines` | 87.844 | 1,818.508 | +1,970.2% |
+| `HttpClientLatencyBenchmark.hc5AsyncCoroutines` | 1,826.352 | 1,789.987 | -2.0% |
+| `HttpClientLatencyBenchmark.okhttp3Coroutines` | 1,831.756 | 1,759.273 | -4.0% |
+| `HttpClientLatencyBenchmark.javaHttpCoroutines` | 376.241 | 383.605 | +2.0% |
+| `HttpClientBenchmark.ktorCioCoroutines` | n/a | 659.071 | 제한 |
+| `HttpClientLatencyBenchmark.ktorCioCoroutines` | n/a | 16.501 | 제한 |
+
+![HTTP client high-latency benchmark chart](../../docs/images/readme-diagrams/io-http-chart-02.svg)
+
+**메모**:
+- 핵심 개선은 50ms 지연 워크로드의 Vert.x WebClient입니다. Vert.x 5 기본 HTTP/1 풀은 작으므로, 벤치마크에서 `PoolOptions`를 명시해 다른 클라이언트와 같은 조건으로 맞췄습니다.
+- Ktor CIO 행은 1 JMH thread로 제한한 비교입니다. 전체 클래스 동시성에서는 로컬 ephemeral port가 고갈됐고, HTTP/1 pipelining은 unexpected EOF를 만들었습니다.
+- `/ping` 기본 처리량은 로컬 Docker 환경에서 분산이 큽니다. 결정 근거로는 고지연 Vert.x 결과가 더 강합니다.
 
 ### 3. HttpClientCompressionCacheBenchmark — 캐시 + gzip 효과
 

--- a/io/http/README.md
+++ b/io/http/README.md
@@ -183,6 +183,7 @@ val vertxClient = vertxHttpClientOf(options)
 | HC5 Async         | HTTP/1.1, HTTP/2 | Async, Coroutines integration       | High-performance async       |
 | OkHttp3           | HTTP/1.1, HTTP/2 | Lightweight, Virtual Thread default | General-purpose HTTP client  |
 | Vert.x HttpClient | HTTP/1.1, HTTP/2 | Event loop-based                    | Vert.x ecosystem integration |
+| Ktor CIO          | HTTP/1.x         | Suspend-native, lightweight         | Ktor-based apps / coroutine-first calls |
 
 ## Performance Benchmark
 
@@ -194,9 +195,9 @@ All benchmarks target a separate Docker container server, isolating the server J
 ./gradlew :bluetape4k-http:testBenchmark
 
 # Run a specific benchmark
-./gradlew :bluetape4k-http:testBenchmark -Pbenchmark.include="HttpClientBenchmark"
-./gradlew :bluetape4k-http:testBenchmark -Pbenchmark.include="HttpClientLatencyBenchmark"
-./gradlew :bluetape4k-http:testBenchmark -Pbenchmark.include="HttpClientCompressionCacheBenchmark"
+./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude="HttpClientBenchmark"
+./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude="HttpClientLatencyBenchmark"
+./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude="HttpClientCompressionCacheBenchmark"
 ```
 
 ### 1. HttpClientBenchmark — Base Throughput (`GET /ping`)
@@ -218,6 +219,7 @@ Lightweight `/ping` responses to measure pure connection throughput.
 | HC5 Classic Coroutines | coroutine | `Dispatchers.IO` |
 | HC5 Async Coroutines | async | `executeSuspending()` |
 | Vert.x WebClient Coroutines | async | Event loop |
+| Ktor CIO Coroutines | coroutine | Bounded row; CIO opens dedicated HTTP/1 requests in this fixture |
 
 > **Note**: With no simulated latency all modes produce similar throughput.
 > Differences arise mainly from connection pool configuration and thread model.
@@ -228,6 +230,28 @@ Lightweight `/ping` responses to measure pure connection throughput.
 
 **Theoretical sync ceiling**: 100 threads × (1000 ms / 50 ms) = **2,000 ops/s**
 Async / coroutine modes can exceed this ceiling without blocking threads.
+
+### 2026-05-21 HTTP client benchmark snapshot
+
+Environment: local Colima Docker, `bluetape4k/mock-web-server:latest`, Docker server 29.2.1, JMH via `:bluetape4k-http:testBenchmark`.
+See [the benchmark report](../../docs/benchmarks/2026-05-21-io-http-client-benchmark.md) for commands, rejected approaches, and raw evidence notes.
+
+| Benchmark row | Before ops/s | After ops/s | Change |
+|---------------|-------------:|------------:|-------:|
+| `HttpClientBenchmark.vertxWebClientCoroutines` | 12,278.843 | 13,491.266 | +9.9% |
+| `HttpClientLatencyBenchmark.vertxWebClientCoroutines` | 87.844 | 1,818.508 | +1,970.2% |
+| `HttpClientLatencyBenchmark.hc5AsyncCoroutines` | 1,826.352 | 1,789.987 | -2.0% |
+| `HttpClientLatencyBenchmark.okhttp3Coroutines` | 1,831.756 | 1,759.273 | -4.0% |
+| `HttpClientLatencyBenchmark.javaHttpCoroutines` | 376.241 | 383.605 | +2.0% |
+| `HttpClientBenchmark.ktorCioCoroutines` | n/a | 659.071 | bounded |
+| `HttpClientLatencyBenchmark.ktorCioCoroutines` | n/a | 16.501 | bounded |
+
+![HTTP client high-latency benchmark chart](../../docs/images/readme-diagrams/io-http-chart-02.svg)
+
+**Notes**:
+- The main improvement is Vert.x WebClient under the 50 ms delay workload. Vert.x 5 defaults to a small HTTP/1 pool; the benchmark now configures `PoolOptions` to match peer clients.
+- The Ktor CIO rows are intentionally bounded to one JMH thread. Full class concurrency exhausted local ephemeral ports against this Docker fixture, and HTTP/1 pipelining produced unexpected EOFs.
+- Base `/ping` measurements have high variance on this local Docker setup. Treat the high-latency Vert.x result as the strongest decision signal.
 
 ### 3. HttpClientCompressionCacheBenchmark — Cache + gzip Effect
 

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
@@ -1,12 +1,16 @@
 package io.bluetape4k.http.benchmark
 
 import io.bluetape4k.http.hc5.async.executeSuspending
-import io.bluetape4k.http.jdk.sendAwait
-import okhttp3.coroutines.executeAsync
 import io.bluetape4k.http.hc5.classic.virtualThreadHttpClientOf
+import io.bluetape4k.http.jdk.sendAwait
+import io.bluetape4k.http.ktor.ktorCioHttpClientOf
 import io.bluetape4k.http.okhttp3.okhttp3DispatcherWithVirtualThread
 import io.bluetape4k.testcontainers.http.BluetapeHttpServer
+import io.ktor.client.HttpClient as KtorHttpClient
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.bodyAsBytes
 import io.vertx.core.Vertx
+import io.vertx.core.http.PoolOptions
 import io.vertx.ext.web.client.WebClient
 import io.vertx.ext.web.client.WebClientOptions
 import io.vertx.kotlin.coroutines.coAwait
@@ -26,7 +30,7 @@ import okhttp3.ConnectionPool
 import okhttp3.Dispatcher as OkHttpDispatcher
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import org.apache.hc.client5.http.async.methods.SimpleHttpRequest
+import okhttp3.coroutines.executeAsync
 import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder
 import org.apache.hc.client5.http.classic.methods.HttpGet
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients
@@ -55,6 +59,7 @@ import java.util.concurrent.TimeUnit
  * - java.net.http 동기 / Virtual Thread / HTTP2 / Coroutines
  * - Apache HC5 Classic 동기 / Coroutines / Virtual Thread
  * - Apache HC5 Async + Coroutines
+ * - Ktor CIO + Coroutines
  * - Vert.x WebClient + Coroutines
  */
 @State(Scope.Benchmark)
@@ -81,12 +86,14 @@ open class HttpClientBenchmark {
     private lateinit var hc5Classic: org.apache.hc.client5.http.impl.classic.CloseableHttpClient
     private lateinit var hc5ClassicVt: org.apache.hc.client5.http.impl.classic.CloseableHttpClient
     private lateinit var hc5Async: org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient
+    private lateinit var ktorCioClient: KtorHttpClient
     private lateinit var vertx: Vertx
     private lateinit var vertxWebClient: WebClient
 
     @Setup
     fun setup() {
         val n = Runtime.getRuntime().availableProcessors()
+        val maxConnections = n * 50
 
         pingUrl = "${server.url}/ping"
         serverHost = server.host
@@ -145,18 +152,33 @@ open class HttpClientBenchmark {
 
         hc5Async = HttpAsyncClients.createDefault().also { it.start() }
 
+        ktorCioClient = ktorCioHttpClientOf {
+            engine {
+                maxConnectionsCount = n
+                requestTimeout = 5_000
+                endpoint.maxConnectionsPerRoute = n
+                endpoint.connectTimeout = 5_000
+                endpoint.socketTimeout = 5_000
+                endpoint.keepAliveTime = 5_000
+            }
+        }
+
         vertx = Vertx.vertx()
         vertxWebClient = WebClient.create(
             vertx,
             WebClientOptions()
                 .setKeepAlive(true)
                 .setConnectTimeout(5_000)
-                .setIdleTimeout(5)
+                .setIdleTimeout(5),
+            PoolOptions()
+                .setHttp1MaxSize(maxConnections)
+                .setHttp2MaxSize(maxConnections)
         )
     }
 
     @TearDown
     fun teardown() {
+        runCatching { ktorCioClient.close() }
         runCatching { vertxWebClient.close() }
         runCatching { runBlocking { vertx.close().coAwait() } }
         runCatching { hc5Async.close() }
@@ -272,6 +294,19 @@ open class HttpClientBenchmark {
     fun hc5AsyncCoroutines(): Int = runBlocking(Dispatchers.IO) {
         val request = SimpleRequestBuilder.get(pingUrl).build()
         hc5Async.executeSuspending(request).code
+    }
+
+    @Benchmark
+    @Warmup(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+    @Threads(1)
+    fun ktorCioCoroutines(): Int = runBlocking {
+        // CIO makes dedicated HTTP/1 requests for this fixture; keep this row bounded
+        // to avoid local port exhaustion.
+        ktorCioClient.prepareGet(pingUrl).execute { response ->
+            response.bodyAsBytes()
+            response.status.value
+        }
     }
 
     @Benchmark

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientLatencyBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientLatencyBenchmark.kt
@@ -3,9 +3,14 @@ package io.bluetape4k.http.benchmark
 import io.bluetape4k.http.hc5.async.executeSuspending
 import io.bluetape4k.http.hc5.classic.virtualThreadHttpClientOf
 import io.bluetape4k.http.jdk.sendAwait
+import io.bluetape4k.http.ktor.ktorCioHttpClientOf
 import io.bluetape4k.http.okhttp3.okhttp3DispatcherWithVirtualThread
 import io.bluetape4k.testcontainers.http.BluetapeHttpServer
+import io.ktor.client.HttpClient as KtorHttpClient
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.bodyAsBytes
 import io.vertx.core.Vertx
+import io.vertx.core.http.PoolOptions
 import io.vertx.ext.web.client.WebClient
 import io.vertx.ext.web.client.WebClientOptions
 import io.vertx.kotlin.coroutines.coAwait
@@ -49,6 +54,10 @@ import okhttp3.Dispatcher as OkHttpDispatcher
  *
  * 동기 클라이언트 이론 상한: threads × (1000 / 50ms) = 2,000 ops/s
  * 비동기는 스레드 블로킹 없이 더 높은 동시성 확보 가능.
+ *
+ * Vert.x 5 defaults to a 5-connection HTTP/1 pool. This benchmark configures
+ * the pool to match the other clients so the high-latency test compares client
+ * behavior instead of the default connection cap.
  */
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.Throughput)
@@ -70,6 +79,7 @@ open class HttpClientLatencyBenchmark {
     private lateinit var hc5Classic: org.apache.hc.client5.http.impl.classic.CloseableHttpClient
     private lateinit var hc5ClassicVt: org.apache.hc.client5.http.impl.classic.CloseableHttpClient
     private lateinit var hc5Async: org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient
+    private lateinit var ktorCioClient: KtorHttpClient
     private lateinit var vertx: Vertx
     private lateinit var vertxWebClient: WebClient
 
@@ -134,20 +144,36 @@ open class HttpClientLatencyBenchmark {
             .build()
             .also { it.start() }
 
+        ktorCioClient = ktorCioHttpClientOf {
+            engine {
+                val ktorConnections = 1
+
+                maxConnectionsCount = ktorConnections
+                requestTimeout = 10_000
+                endpoint.maxConnectionsPerRoute = ktorConnections
+                endpoint.connectTimeout = 5_000
+                endpoint.socketTimeout = 10_000
+                endpoint.keepAliveTime = 5_000
+            }
+        }
+
         vertx = Vertx.vertx()
         vertxWebClient = WebClient.create(
             vertx,
             WebClientOptions()
-                // .setMaxPoolSize(connPerHost)  // 5.x 에서 없어졌다.
                 .setKeepAlive(true)
                 .setConnectTimeout(5_000)
                 .setIdleTimeout(10)
-                .setDecompressionSupported(true)
+                .setDecompressionSupported(true),
+            PoolOptions()
+                .setHttp1MaxSize(connPerHost)
+                .setHttp2MaxSize(connPerHost)
         )
     }
 
     @TearDown
     fun teardown() {
+        runCatching { ktorCioClient.close() }
         runCatching { vertxWebClient.close() }
         runCatching { runBlocking { vertx.close().coAwait() } }
         runCatching { hc5Async.close() }
@@ -237,6 +263,17 @@ open class HttpClientLatencyBenchmark {
     fun hc5AsyncCoroutines(): Int = runBlocking(Dispatchers.IO) {
         val request = SimpleRequestBuilder.get(delayUrl).build()
         hc5Async.executeSuspending(request).code
+    }
+
+    @Benchmark
+    @Threads(1)
+    fun ktorCioCoroutines(): Int = runBlocking {
+        // CIO is intentionally measured as a bounded row; full class concurrency
+        // exhausts local ephemeral ports.
+        ktorCioClient.prepareGet(delayUrl).execute { response ->
+            response.bodyAsBytes()
+            response.status.value
+        }
     }
 
     @Benchmark


### PR DESCRIPTION
## Summary

Closes #590

- PR 제목: perf(io-http): compare HTTP client benchmark tuning

- add Ktor CIO rows to the io/http HTTP client JMH benchmarks with explicit bounded semantics
- configure Vert.x WebClient PoolOptions so the high-latency benchmark compares client behavior instead of the default HTTP/1 pool cap
- record before/after benchmark results, chart, and lessons in README and docs

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Benchmark Evidence

- Baseline: `./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude='HttpClientBenchmark|HttpClientLatencyBenchmark' --no-configuration-cache`
- Final: `./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude='HttpClientBenchmark|HttpClientLatencyBenchmark' --no-configuration-cache`
- Ktor bounded check: `./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude='HttpClientBenchmark.ktorCioCoroutines|HttpClientLatencyBenchmark.ktorCioCoroutines' --no-configuration-cache`

### 기존 섹션: Results

- Vert.x high-latency throughput: 87.844 -> 1,818.508 ops/s (+1,970.2%)
- Vert.x /ping throughput: 12,278.843 -> 13,491.266 ops/s (+9.9%)
- Ktor CIO bounded rows: 659.071 ops/s for /ping, 16.501 ops/s for the 50 ms delay endpoint

### 기존 섹션: Notes

- Ktor CIO rows are bounded to one JMH thread because full class concurrency exhausted local ephemeral ports in this Docker fixture.
- CPU, allocation, and GC profiler coverage remains tracked by #585.

Closes #590
Part of #589

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #590, milestone 없음, assignee `debop`
- PR: #593, head `a659a4b852c84e65ab79e1106fc76b65c0a9db25`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `perf/issue-590-io-http-self-improve`
- Labels: `documentation`, `test`, `performance`, `infra/io`
- State: `MERGED`, merge commit `1d4c21b5a9d7442027f465dad3d6757dd786abae`
- CI: - add Ktor CIO rows to the io/http HTTP client JMH benchmarks with explicit bounded semantics / - Baseline: `./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude='HttpClientBenchmark|HttpClientLatencyBenchmark' --no-configuration-cache` / - Final: `./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude='HttpClientBenchmark|HttpClientLatencyBenchmark' --no-configuration-cache`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #593 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `1d4c21b5a9d7442027f465dad3d6757dd786abae`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
