### PR TITLE
perf(io-http): make Ktor CIO benchmark comparable

### DIFF
--- a/docs/benchmarks/2026-05-21-io-http-client-benchmark.md
+++ b/docs/benchmarks/2026-05-21-io-http-client-benchmark.md
@@ -2,76 +2,85 @@
 
 ## Scope
 
-This report records benchmark-driven work for GitHub epic #589 and sub-issue #590.
-Related existing issues included in the epic: #582, #583, #584, #585, #586, and #587.
+This report records benchmark-driven work for GitHub epic #589 and sub-issues #590 and #587.
+Related existing issues included in the epic: #582, #583, #584, #585, and #586.
 
 Target module: `:bluetape4k-http`.
 
 ## Commands
 
 ```bash
-./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude='HttpClientBenchmark|HttpClientLatencyBenchmark' --no-configuration-cache
+./gradlew :bluetape4k-mock-webflux-server:jibDockerBuild :bluetape4k-http:compileTestKotlin --no-configuration-cache
 ./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude='HttpClientBenchmark.ktorCioCoroutines|HttpClientLatencyBenchmark.ktorCioCoroutines' --no-configuration-cache
+./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude='HttpClientBenchmark|HttpClientLatencyBenchmark' --no-configuration-cache
 ```
 
-Environment: local Colima Docker, `bluetape4k/mock-web-server:latest`, Docker server 29.2.1, 3905 MB Docker memory.
+Environment: local Colima Docker, `bluetape4k/mock-webflux-server:latest`, Docker server 29.2.1, 3905 MB Docker memory.
 
 ## Changes Tested
 
 - Configured Vert.x `WebClient` with explicit `PoolOptions` in both HTTP client benchmarks.
 - Added Ktor CIO coroutine rows to the benchmark harness.
-- Kept Ktor CIO rows bounded because full class concurrency exhausted local ephemeral ports against the Docker fixture.
+- Switched the benchmark fixture from `BluetapeHttpServer` to `BluetapeWebfluxServer` so every client targets the same WebFlux/Reactor Netty mock server.
+- Removed the one-thread Ktor CIO exception. Every row now uses the class-level JMH thread count.
+- Shortened the class-level benchmark window to 1 warmup second and 1 measurement second. This is the comparable local snapshot that avoids ephemeral-port exhaustion while preserving equal concurrency.
 
 ## Base Throughput
 
-`HttpClientBenchmark`, `GET /ping`, ops/s.
+`HttpClientBenchmark`, `GET /ping`, `@Threads(8)`, warmup 1x1s, measurement 1x1s, ops/s.
 
-| Benchmark | Before | After | Change |
-|-----------|-------:|------:|-------:|
-| `hc5AsyncCoroutines` | 11,191.120 | 11,675.259 | +4.3% |
-| `hc5Classic` | 17,115.856 | 18,453.421 | +7.8% |
-| `hc5ClassicCoroutines` | 16,374.041 | 15,799.529 | -3.5% |
-| `hc5ClassicVirtualThread` | 17,425.528 | 18,327.179 | +5.2% |
-| `javaHttpCoroutines` | 14,679.410 | 14,459.907 | -1.5% |
-| `javaHttpH2Coroutines` | 14,288.272 | 13,240.647 | -7.3% |
-| `javaHttpH2Sync` | 19,216.697 | 17,125.597 | -10.9% |
-| `javaHttpH2VirtualThread` | 17,158.663 | 17,328.761 | +1.0% |
-| `javaHttpSync` | 18,589.051 | 17,224.067 | -7.3% |
-| `javaHttpVirtualThread` | 17,736.870 | 18,355.593 | +3.5% |
-| `okhttp3Coroutines` | 14,398.746 | 13,172.953 | -8.5% |
-| `okhttp3Sync` | 17,195.947 | 17,240.102 | +0.3% |
-| `okhttp3VirtualThread` | 17,669.541 | 17,643.375 | -0.1% |
-| `vertxWebClientCoroutines` | 12,278.843 | 13,491.266 | +9.9% |
-| `ktorCioCoroutines` | n/a | 659.071 | bounded |
+| Benchmark | ops/s |
+|-----------|------:|
+| `javaHttpSync` | 7,276.492 |
+| `hc5ClassicVirtualThread` | 7,246.690 |
+| `okhttp3VirtualThread` | 6,955.796 |
+| `javaHttpVirtualThread` | 6,562.497 |
+| `hc5Classic` | 6,490.422 |
+| `javaHttpH2VirtualThread` | 6,275.262 |
+| `hc5ClassicCoroutines` | 6,230.735 |
+| `vertxWebClientCoroutines` | 6,043.906 |
+| `javaHttpH2Sync` | 6,027.618 |
+| `okhttp3Sync` | 5,771.310 |
+| `okhttp3Coroutines` | 5,752.350 |
+| `hc5AsyncCoroutines` | 5,520.183 |
+| `javaHttpH2Coroutines` | 5,481.592 |
+| `javaHttpCoroutines` | 4,739.894 |
+| `ktorCioCoroutines` | 2,052.281 |
 
-The `/ping` benchmark showed high local variance. Treat the Vert.x direction as useful, but not as the primary decision signal.
+The `/ping` benchmark showed high local variance and is sensitive to connection reuse. Treat it as a same-fixture snapshot, not a production ranking.
 
 ## High-Latency Throughput
 
-`HttpClientLatencyBenchmark`, `GET /httpbin/delay/0.05`, ops/s.
+`HttpClientLatencyBenchmark`, `GET /httpbin/delay/0.05`, `@Threads(100)`, warmup 1x1s, measurement 1x1s, ops/s.
 
-| Benchmark | Before | After | Change |
-|-----------|-------:|------:|-------:|
-| `hc5AsyncCoroutines` | 1,826.352 | 1,789.987 | -2.0% |
-| `hc5Classic` | 1,751.968 | 1,848.171 | +5.5% |
-| `hc5ClassicCoroutines` | 1,161.095 | 1,168.324 | +0.6% |
-| `hc5ClassicVirtualThread` | 1,791.481 | 1,848.070 | +3.2% |
-| `javaHttpCoroutines` | 376.241 | 383.605 | +2.0% |
-| `javaHttpSync` | 376.703 | 383.628 | +1.8% |
-| `javaHttpVirtualThread` | 375.674 | 384.459 | +2.3% |
-| `okhttp3Coroutines` | 1,831.756 | 1,759.273 | -4.0% |
-| `okhttp3Sync` | 1,762.527 | 1,809.275 | +2.7% |
-| `okhttp3VirtualThread` | 1,822.840 | 1,784.900 | -2.1% |
-| `vertxWebClientCoroutines` | 87.844 | 1,818.508 | +1,970.2% |
-| `ktorCioCoroutines` | n/a | 16.501 | bounded |
+| Benchmark | ops/s |
+|-----------|------:|
+| `okhttp3VirtualThread` | 1,902.171 |
+| `hc5ClassicVirtualThread` | 1,888.018 |
+| `javaHttpVirtualThread` | 1,883.634 |
+| `hc5Classic` | 1,880.023 |
+| `okhttp3Sync` | 1,870.124 |
+| `javaHttpSync` | 1,865.997 |
+| `javaHttpCoroutines` | 1,863.948 |
+| `hc5AsyncCoroutines` | 1,860.655 |
+| `vertxWebClientCoroutines` | 1,859.003 |
+| `okhttp3Coroutines` | 1,856.895 |
+| `ktorCioCoroutines` | 1,515.026 |
+| `hc5ClassicCoroutines` | 1,216.306 |
+
+## Rejected Approaches
+
+- Do not keep Ktor CIO as a one-thread row. It avoids the failure but does not compare against the same JMH concurrency as the other clients.
+- Do not force Ktor CIO HTTP/1 pipelining in this fixture. `pipelining=true` with `pipelineMaxSize=1` produced `ClosedReadChannelException: unexpected EOF` or hung against both the MVC and WebFlux mock fixtures.
+- Do not keep the previous MVC fixture for this rerun. Moving every row to `BluetapeWebfluxServer` addresses issue #584 and removes a server-side mismatch from the client comparison.
 
 ## Decisions
 
 - Keep the Vert.x pool configuration in the benchmark harness. The previous high-latency row measured the Vert.x 5 default HTTP/1 pool cap instead of comparable client behavior.
-- Include Ktor CIO in the harness, but mark it as a bounded comparison row. Equal-thread CIO runs produced `java.net.BindException: Can't assign requested address` in this local fixture.
-- Do not enable Ktor CIO HTTP/1 pipelining for this benchmark. It produced unexpected EOFs against the mock server.
+- Include Ktor CIO in the equal-thread tables. Its default CIO path is materially slower in the base `/ping` workload because it opens dedicated HTTP/1 connections when the pipeline path is disabled.
+- Treat this report as a short-window comparable snapshot. It is fairer than per-row thread overrides, but it is not a substitute for profiler-backed long-run capacity testing.
 
 ## Follow-Up
 
-- Issue #587 should refine the Ktor CIO benchmark surface so it can report a fair high-concurrency comparison or a clearly separate fixture.
 - Issue #585 should add CPU, allocation, and GC profiler runs before converting local benchmark rankings into production defaults.
+- If long-run CIO capacity matters, add a dedicated CIO fixture or upstream bug investigation for the pipelining EOF/hang behavior instead of hiding it with per-row JMH settings.

--- a/docs/images/readme-diagrams/io-http-chart-02.svg
+++ b/docs/images/readme-diagrams/io-http-chart-02.svg
@@ -1,31 +1,62 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1040" height="390" viewBox="0 0 1040 390" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1040" height="620" viewBox="0 0 1040 620" role="img" aria-labelledby="title desc">
   <title id="title">HTTP client high-latency benchmark throughput</title>
-  <desc id="desc">After tuning, Vert.x WebClient reaches 1818.508 ops/s compared with 87.844 ops/s before tuning.</desc>
-  <rect width="1040" height="390" fill="#ffffff"/>
+  <desc id="desc">Equal-thread WebFlux fixture snapshot for GET /httpbin/delay/0.05. OkHttp virtual threads lead at 1902.171 ops/s, Ktor CIO records 1515.026 ops/s.</desc>
+  <rect width="1040" height="620" fill="#ffffff"/>
   <text x="40" y="42" font-family="Arial, sans-serif" font-size="24" font-weight="700" fill="#172033">HTTP client high-latency throughput</text>
-  <text x="40" y="70" font-family="Arial, sans-serif" font-size="14" fill="#526070">GET /httpbin/delay/0.05, ops/s higher is better. Ktor CIO is a bounded 1-thread row.</text>
-  <line x1="250" y1="320" x2="960" y2="320" stroke="#d6dbe4" stroke-width="1"/>
-  <line x1="250" y1="108" x2="250" y2="320" stroke="#d6dbe4" stroke-width="1"/>
-  <text x="250" y="345" font-family="Arial, sans-serif" font-size="12" fill="#6b7280">0</text>
-  <text x="485" y="345" font-family="Arial, sans-serif" font-size="12" fill="#6b7280">500</text>
-  <text x="724" y="345" font-family="Arial, sans-serif" font-size="12" fill="#6b7280">1,000</text>
-  <text x="940" y="345" font-family="Arial, sans-serif" font-size="12" fill="#6b7280">1,800</text>
-  <text x="40" y="126" font-family="Arial, sans-serif" font-size="14" fill="#172033">Vert.x before</text>
-  <rect x="250" y="110" width="44" height="22" rx="3" fill="#8b95a5"/>
-  <text x="304" y="126" font-family="Arial, sans-serif" font-size="13" fill="#172033">87.844</text>
-  <text x="40" y="166" font-family="Arial, sans-serif" font-size="14" fill="#172033">Vert.x after</text>
-  <rect x="250" y="150" width="710" height="22" rx="3" fill="#2563eb"/>
-  <text x="970" y="166" font-family="Arial, sans-serif" font-size="13" fill="#172033">1,818.508</text>
-  <text x="40" y="206" font-family="Arial, sans-serif" font-size="14" fill="#172033">HC5 Async after</text>
-  <rect x="250" y="190" width="699" height="22" rx="3" fill="#059669"/>
-  <text x="959" y="206" font-family="Arial, sans-serif" font-size="13" fill="#172033">1,789.987</text>
-  <text x="40" y="246" font-family="Arial, sans-serif" font-size="14" fill="#172033">OkHttp Coroutines after</text>
-  <rect x="250" y="230" width="687" height="22" rx="3" fill="#7c3aed"/>
-  <text x="947" y="246" font-family="Arial, sans-serif" font-size="13" fill="#172033">1,759.273</text>
-  <text x="40" y="286" font-family="Arial, sans-serif" font-size="14" fill="#172033">JDK Coroutines after</text>
-  <rect x="250" y="270" width="150" height="22" rx="3" fill="#f59e0b"/>
-  <text x="410" y="286" font-family="Arial, sans-serif" font-size="13" fill="#172033">383.605</text>
-  <text x="40" y="326" font-family="Arial, sans-serif" font-size="14" fill="#172033">Ktor CIO bounded</text>
-  <rect x="250" y="310" width="6" height="22" rx="3" fill="#dc2626"/>
-  <text x="266" y="326" font-family="Arial, sans-serif" font-size="13" fill="#172033">16.501</text>
+  <text x="40" y="70" font-family="Arial, sans-serif" font-size="14" fill="#526070">WebFlux fixture, @Threads(100), warmup 1x1s, measurement 1x1s, ops/s higher is better</text>
+  <line x1="280" y1="552" x2="980" y2="552" stroke="#d6dbe4" stroke-width="1"/>
+  <line x1="280" y1="105" x2="280" y2="552" stroke="#d6dbe4" stroke-width="1"/>
+  <text x="280" y="578" font-family="Arial, sans-serif" font-size="12" fill="#6b7280">0</text>
+  <text x="449" y="578" font-family="Arial, sans-serif" font-size="12" fill="#6b7280">500</text>
+  <text x="617" y="578" font-family="Arial, sans-serif" font-size="12" fill="#6b7280">1,000</text>
+  <text x="792" y="578" font-family="Arial, sans-serif" font-size="12" fill="#6b7280">1,500</text>
+  <text x="956" y="578" font-family="Arial, sans-serif" font-size="12" fill="#6b7280">2,000</text>
+
+  <text x="40" y="120" font-family="Arial, sans-serif" font-size="13" fill="#172033">OkHttp3 VirtualThread</text>
+  <rect x="280" y="104" width="666" height="20" rx="3" fill="#2563eb"/>
+  <text x="956" y="120" font-family="Arial, sans-serif" font-size="12" fill="#172033">1,902.171</text>
+
+  <text x="40" y="156" font-family="Arial, sans-serif" font-size="13" fill="#172033">HC5 Classic VirtualThread</text>
+  <rect x="280" y="140" width="661" height="20" rx="3" fill="#2563eb"/>
+  <text x="951" y="156" font-family="Arial, sans-serif" font-size="12" fill="#172033">1,888.018</text>
+
+  <text x="40" y="192" font-family="Arial, sans-serif" font-size="13" fill="#172033">JDK VirtualThread</text>
+  <rect x="280" y="176" width="659" height="20" rx="3" fill="#2563eb"/>
+  <text x="949" y="192" font-family="Arial, sans-serif" font-size="12" fill="#172033">1,883.634</text>
+
+  <text x="40" y="228" font-family="Arial, sans-serif" font-size="13" fill="#172033">HC5 Classic</text>
+  <rect x="280" y="212" width="658" height="20" rx="3" fill="#2563eb"/>
+  <text x="948" y="228" font-family="Arial, sans-serif" font-size="12" fill="#172033">1,880.023</text>
+
+  <text x="40" y="264" font-family="Arial, sans-serif" font-size="13" fill="#172033">OkHttp3 Sync</text>
+  <rect x="280" y="248" width="655" height="20" rx="3" fill="#2563eb"/>
+  <text x="945" y="264" font-family="Arial, sans-serif" font-size="12" fill="#172033">1,870.124</text>
+
+  <text x="40" y="300" font-family="Arial, sans-serif" font-size="13" fill="#172033">JDK Sync</text>
+  <rect x="280" y="284" width="653" height="20" rx="3" fill="#2563eb"/>
+  <text x="943" y="300" font-family="Arial, sans-serif" font-size="12" fill="#172033">1,865.997</text>
+
+  <text x="40" y="336" font-family="Arial, sans-serif" font-size="13" fill="#172033">JDK Coroutines</text>
+  <rect x="280" y="320" width="652" height="20" rx="3" fill="#059669"/>
+  <text x="942" y="336" font-family="Arial, sans-serif" font-size="12" fill="#172033">1,863.948</text>
+
+  <text x="40" y="372" font-family="Arial, sans-serif" font-size="13" fill="#172033">HC5 Async Coroutines</text>
+  <rect x="280" y="356" width="651" height="20" rx="3" fill="#059669"/>
+  <text x="941" y="372" font-family="Arial, sans-serif" font-size="12" fill="#172033">1,860.655</text>
+
+  <text x="40" y="408" font-family="Arial, sans-serif" font-size="13" fill="#172033">Vert.x WebClient Coroutines</text>
+  <rect x="280" y="392" width="651" height="20" rx="3" fill="#059669"/>
+  <text x="941" y="408" font-family="Arial, sans-serif" font-size="12" fill="#172033">1,859.003</text>
+
+  <text x="40" y="444" font-family="Arial, sans-serif" font-size="13" fill="#172033">OkHttp3 Coroutines</text>
+  <rect x="280" y="428" width="650" height="20" rx="3" fill="#059669"/>
+  <text x="940" y="444" font-family="Arial, sans-serif" font-size="12" fill="#172033">1,856.895</text>
+
+  <text x="40" y="480" font-family="Arial, sans-serif" font-size="13" fill="#172033">Ktor CIO Coroutines</text>
+  <rect x="280" y="464" width="530" height="20" rx="3" fill="#dc2626"/>
+  <text x="820" y="480" font-family="Arial, sans-serif" font-size="12" fill="#172033">1,515.026</text>
+
+  <text x="40" y="516" font-family="Arial, sans-serif" font-size="13" fill="#172033">HC5 Classic Coroutines</text>
+  <rect x="280" y="500" width="426" height="20" rx="3" fill="#f59e0b"/>
+  <text x="716" y="516" font-family="Arial, sans-serif" font-size="12" fill="#172033">1,216.306</text>
 </svg>

--- a/docs/lessons/2026-05-21-issue-587-ktor-cio-fair-benchmark.md
+++ b/docs/lessons/2026-05-21-issue-587-ktor-cio-fair-benchmark.md
@@ -1,0 +1,36 @@
+# Issue 587 Ktor CIO Fair Benchmark
+
+## Context
+
+The io/http benchmark originally added Ktor CIO as a bounded one-thread row
+because full class concurrency exhausted local ephemeral ports. That made the
+result hard to compare with HC5, OkHttp, JDK, and Vert.x rows.
+
+## Decision
+
+Use `BluetapeWebfluxServer` for both HTTP client benchmark classes and keep the
+same JMH thread count for every row. Shorten the class-level benchmark window to
+1 warmup second and 1 measurement second so Ktor CIO can run with the same
+concurrency without per-row overrides.
+
+## Outcome
+
+The full benchmark now completes with Ktor CIO included in the same tables:
+
+- `HttpClientBenchmark.ktorCioCoroutines`: 2,052.281 ops/s at `@Threads(8)`.
+- `HttpClientLatencyBenchmark.ktorCioCoroutines`: 1,515.026 ops/s at `@Threads(100)`.
+
+Ktor CIO is still slower in the base `/ping` workload because CIO 3.5 opens
+dedicated HTTP/1 connections when its pipeline path is disabled.
+
+## Verification
+
+- `./gradlew :bluetape4k-mock-webflux-server:jibDockerBuild :bluetape4k-http:compileTestKotlin --no-configuration-cache`
+- `./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude='HttpClientBenchmark.ktorCioCoroutines|HttpClientLatencyBenchmark.ktorCioCoroutines' --no-configuration-cache`
+- `./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude='HttpClientBenchmark|HttpClientLatencyBenchmark' --no-configuration-cache`
+
+## Future Guidance
+
+Do not hide Ktor CIO behind per-row thread overrides. If long-run CIO capacity
+matters, add a dedicated CIO fixture or investigate the Ktor CIO pipelining
+EOF/hang behavior directly.

--- a/io/http/README.ko.md
+++ b/io/http/README.ko.md
@@ -204,7 +204,7 @@ JMH(Java Microbenchmark Harness) 기반 벤치마크 3종으로 클라이언트�
 
 ### 1. HttpClientBenchmark — 기본 처리량 (`GET /ping`)
 
-**환경**: `BluetapeHttpServer` (Docker) · `@Threads(8)` · warmup 1×2s · measurement 3×3s
+**환경**: `BluetapeWebfluxServer` (Docker) · `@Threads(8)` · warmup 1×1s · measurement 1×1s
 
 경량 `/ping` 응답으로 순수 연결 처리량을 측정합니다.
 
@@ -221,14 +221,14 @@ JMH(Java Microbenchmark Harness) 기반 벤치마크 3종으로 클라이언트�
 | HC5 Classic Coroutines | 코루틴 | `Dispatchers.IO` |
 | HC5 Async Coroutines | 비동기 | `executeSuspending()` |
 | Vert.x WebClient Coroutines | 비동기 | 이벤트 루프 |
-| Ktor CIO Coroutines | 코루틴 | 제한 행; 이 fixture에서 CIO는 HTTP/1 dedicated request를 생성 |
+| Ktor CIO Coroutines | 코루틴 | CIO 3.5는 pipelining 비활성 시 dedicated HTTP/1 request를 생성 |
 
 > **참고**: 지연 없는 경량 응답이므로 동기/비동기 방식 모두 유사한 처리량을 냅니다.
 > 차이는 주로 커넥션 풀 설정과 스레드 모델에서 발생합니다.
 
 ### 2. HttpClientLatencyBenchmark — 고지연 환경 처리량 (`GET /httpbin/delay/0.05`)
 
-**환경**: `BluetapeHttpServer` (Docker, 50ms 지연) · `@Threads(100)` · warmup 1×3s · measurement 3×5s
+**환경**: `BluetapeWebfluxServer` (Docker, 50ms 지연) · `@Threads(100)` · warmup 1×1s · measurement 1×1s
 
 **이론값**: 100 threads × (1000ms / 50ms) = **2,000 ops/s** (동기 상한)
 비동기/코루틴 방식은 스레드 블로킹 없이 이 상한을 초과합니다.
@@ -246,29 +246,59 @@ JMH(Java Microbenchmark Harness) 기반 벤치마크 3종으로 클라이언트�
 | HC5 Classic Coroutines | 코루틴 | `Dispatchers.IO` |
 | HC5 Async Coroutines | 비동기 | `executeSuspending()` |
 | Vert.x WebClient Coroutines | 비동기 | — |
-| Ktor CIO Coroutines | 코루틴 | 제한 행; 1 JMH thread로 측정 |
+| Ktor CIO Coroutines | 코루틴 | 동일 `@Threads(100)` 조건으로 측정 |
 
 ### 2026-05-21 HTTP 클라이언트 벤치마크 스냅샷
 
-환경: 로컬 Colima Docker, `bluetape4k/mock-web-server:latest`, Docker server 29.2.1, JMH via `:bluetape4k-http:testBenchmark`.
+환경: 로컬 Colima Docker, `bluetape4k/mock-webflux-server:latest`, Docker server 29.2.1, JMH via `:bluetape4k-http:testBenchmark`.
 명령, 실패한 접근, 원시 근거는 [벤치마크 리포트](../../docs/benchmarks/2026-05-21-io-http-client-benchmark.md)에 기록했습니다.
 
-| 벤치마크 행 | Before ops/s | After ops/s | 변화 |
-|-------------|-------------:|------------:|-----:|
-| `HttpClientBenchmark.vertxWebClientCoroutines` | 12,278.843 | 13,491.266 | +9.9% |
-| `HttpClientLatencyBenchmark.vertxWebClientCoroutines` | 87.844 | 1,818.508 | +1,970.2% |
-| `HttpClientLatencyBenchmark.hc5AsyncCoroutines` | 1,826.352 | 1,789.987 | -2.0% |
-| `HttpClientLatencyBenchmark.okhttp3Coroutines` | 1,831.756 | 1,759.273 | -4.0% |
-| `HttpClientLatencyBenchmark.javaHttpCoroutines` | 376.241 | 383.605 | +2.0% |
-| `HttpClientBenchmark.ktorCioCoroutines` | n/a | 659.071 | 제한 |
-| `HttpClientLatencyBenchmark.ktorCioCoroutines` | n/a | 16.501 | 제한 |
+각 벤치마크 안의 모든 행은 같은 JMH thread 수로 측정했습니다.
+Ktor CIO만 1 thread로 낮춘 예외 행이 아니며, CIO 3.5가 pipelining 비활성 시 dedicated HTTP/1 connection을 열기 때문에 전체 행을 짧은 동일 조건 window로 맞췄습니다.
+
+#### 기본 처리량 스냅샷
+
+| 벤치마크 행 | ops/s |
+|-------------|------:|
+| `HttpClientBenchmark.javaHttpSync` | 7,276.492 |
+| `HttpClientBenchmark.hc5ClassicVirtualThread` | 7,246.690 |
+| `HttpClientBenchmark.okhttp3VirtualThread` | 6,955.796 |
+| `HttpClientBenchmark.javaHttpVirtualThread` | 6,562.497 |
+| `HttpClientBenchmark.hc5Classic` | 6,490.422 |
+| `HttpClientBenchmark.javaHttpH2VirtualThread` | 6,275.262 |
+| `HttpClientBenchmark.hc5ClassicCoroutines` | 6,230.735 |
+| `HttpClientBenchmark.vertxWebClientCoroutines` | 6,043.906 |
+| `HttpClientBenchmark.javaHttpH2Sync` | 6,027.618 |
+| `HttpClientBenchmark.okhttp3Sync` | 5,771.310 |
+| `HttpClientBenchmark.okhttp3Coroutines` | 5,752.350 |
+| `HttpClientBenchmark.hc5AsyncCoroutines` | 5,520.183 |
+| `HttpClientBenchmark.javaHttpH2Coroutines` | 5,481.592 |
+| `HttpClientBenchmark.javaHttpCoroutines` | 4,739.894 |
+| `HttpClientBenchmark.ktorCioCoroutines` | 2,052.281 |
+
+#### 고지연 처리량 스냅샷
+
+| 벤치마크 행 | ops/s |
+|-------------|------:|
+| `HttpClientLatencyBenchmark.okhttp3VirtualThread` | 1,902.171 |
+| `HttpClientLatencyBenchmark.hc5ClassicVirtualThread` | 1,888.018 |
+| `HttpClientLatencyBenchmark.javaHttpVirtualThread` | 1,883.634 |
+| `HttpClientLatencyBenchmark.hc5Classic` | 1,880.023 |
+| `HttpClientLatencyBenchmark.okhttp3Sync` | 1,870.124 |
+| `HttpClientLatencyBenchmark.javaHttpSync` | 1,865.997 |
+| `HttpClientLatencyBenchmark.javaHttpCoroutines` | 1,863.948 |
+| `HttpClientLatencyBenchmark.hc5AsyncCoroutines` | 1,860.655 |
+| `HttpClientLatencyBenchmark.vertxWebClientCoroutines` | 1,859.003 |
+| `HttpClientLatencyBenchmark.okhttp3Coroutines` | 1,856.895 |
+| `HttpClientLatencyBenchmark.ktorCioCoroutines` | 1,515.026 |
+| `HttpClientLatencyBenchmark.hc5ClassicCoroutines` | 1,216.306 |
 
 ![HTTP client high-latency benchmark chart](../../docs/images/readme-diagrams/io-http-chart-02.svg)
 
 **메모**:
-- 핵심 개선은 50ms 지연 워크로드의 Vert.x WebClient입니다. Vert.x 5 기본 HTTP/1 풀은 작으므로, 벤치마크에서 `PoolOptions`를 명시해 다른 클라이언트와 같은 조건으로 맞췄습니다.
-- Ktor CIO 행은 1 JMH thread로 제한한 비교입니다. 전체 클래스 동시성에서는 로컬 ephemeral port가 고갈됐고, HTTP/1 pipelining은 unexpected EOF를 만들었습니다.
-- `/ping` 기본 처리량은 로컬 Docker 환경에서 분산이 큽니다. 결정 근거로는 고지연 Vert.x 결과가 더 강합니다.
+- 이전 Vert.x 결과는 주로 Vert.x 5 기본 HTTP/1 pool cap을 측정했습니다. 이제 `PoolOptions`를 명시해 다른 클라이언트와 조건을 맞췄습니다.
+- Ktor CIO 기본 경로는 `/ping`에서 여전히 느립니다. CIO pipelining을 강제하면 mock fixture에서 EOF 또는 hang이 발생했으므로, 비교 가능한 실행은 기본 CIO 동작을 유지하고 모든 행의 측정 window를 동일하게 짧게 둡니다.
+- `/ping` 기본 처리량은 로컬 Docker 환경에서 분산이 큽니다. 결정 근거로는 고지연 표가 더 강합니다.
 
 ### 3. HttpClientCompressionCacheBenchmark — 캐시 + gzip 효과
 

--- a/io/http/README.md
+++ b/io/http/README.md
@@ -202,7 +202,7 @@ All benchmarks target a separate Docker container server, isolating the server J
 
 ### 1. HttpClientBenchmark — Base Throughput (`GET /ping`)
 
-**Setup**: `BluetapeHttpServer` (Docker) · `@Threads(8)` · warmup 1×2s · measurement 3×3s
+**Setup**: `BluetapeWebfluxServer` (Docker) · `@Threads(8)` · warmup 1×1s · measurement 1×1s
 
 Lightweight `/ping` responses to measure pure connection throughput.
 
@@ -219,39 +219,69 @@ Lightweight `/ping` responses to measure pure connection throughput.
 | HC5 Classic Coroutines | coroutine | `Dispatchers.IO` |
 | HC5 Async Coroutines | async | `executeSuspending()` |
 | Vert.x WebClient Coroutines | async | Event loop |
-| Ktor CIO Coroutines | coroutine | Bounded row; CIO opens dedicated HTTP/1 requests in this fixture |
+| Ktor CIO Coroutines | coroutine | CIO 3.5 opens dedicated HTTP/1 requests when pipelining is disabled |
 
 > **Note**: With no simulated latency all modes produce similar throughput.
 > Differences arise mainly from connection pool configuration and thread model.
 
 ### 2. HttpClientLatencyBenchmark — High-Latency Throughput (`GET /httpbin/delay/0.05`)
 
-**Setup**: `BluetapeHttpServer` (Docker, 50 ms delay) · `@Threads(100)` · warmup 1×3s · measurement 3×5s
+**Setup**: `BluetapeWebfluxServer` (Docker, 50 ms delay) · `@Threads(100)` · warmup 1×1s · measurement 1×1s
 
 **Theoretical sync ceiling**: 100 threads × (1000 ms / 50 ms) = **2,000 ops/s**
 Async / coroutine modes can exceed this ceiling without blocking threads.
 
 ### 2026-05-21 HTTP client benchmark snapshot
 
-Environment: local Colima Docker, `bluetape4k/mock-web-server:latest`, Docker server 29.2.1, JMH via `:bluetape4k-http:testBenchmark`.
+Environment: local Colima Docker, `bluetape4k/mock-webflux-server:latest`, Docker server 29.2.1, JMH via `:bluetape4k-http:testBenchmark`.
 See [the benchmark report](../../docs/benchmarks/2026-05-21-io-http-client-benchmark.md) for commands, rejected approaches, and raw evidence notes.
 
-| Benchmark row | Before ops/s | After ops/s | Change |
-|---------------|-------------:|------------:|-------:|
-| `HttpClientBenchmark.vertxWebClientCoroutines` | 12,278.843 | 13,491.266 | +9.9% |
-| `HttpClientLatencyBenchmark.vertxWebClientCoroutines` | 87.844 | 1,818.508 | +1,970.2% |
-| `HttpClientLatencyBenchmark.hc5AsyncCoroutines` | 1,826.352 | 1,789.987 | -2.0% |
-| `HttpClientLatencyBenchmark.okhttp3Coroutines` | 1,831.756 | 1,759.273 | -4.0% |
-| `HttpClientLatencyBenchmark.javaHttpCoroutines` | 376.241 | 383.605 | +2.0% |
-| `HttpClientBenchmark.ktorCioCoroutines` | n/a | 659.071 | bounded |
-| `HttpClientLatencyBenchmark.ktorCioCoroutines` | n/a | 16.501 | bounded |
+The snapshot uses the same JMH thread count for every row in each benchmark.
+Ktor CIO is no longer a one-thread exception, but the whole benchmark uses a short equal-thread window because CIO 3.5 opens dedicated HTTP/1 connections unless its pipeline path is enabled.
+
+#### Base throughput snapshot
+
+| Benchmark row | ops/s |
+|---------------|------:|
+| `HttpClientBenchmark.javaHttpSync` | 7,276.492 |
+| `HttpClientBenchmark.hc5ClassicVirtualThread` | 7,246.690 |
+| `HttpClientBenchmark.okhttp3VirtualThread` | 6,955.796 |
+| `HttpClientBenchmark.javaHttpVirtualThread` | 6,562.497 |
+| `HttpClientBenchmark.hc5Classic` | 6,490.422 |
+| `HttpClientBenchmark.javaHttpH2VirtualThread` | 6,275.262 |
+| `HttpClientBenchmark.hc5ClassicCoroutines` | 6,230.735 |
+| `HttpClientBenchmark.vertxWebClientCoroutines` | 6,043.906 |
+| `HttpClientBenchmark.javaHttpH2Sync` | 6,027.618 |
+| `HttpClientBenchmark.okhttp3Sync` | 5,771.310 |
+| `HttpClientBenchmark.okhttp3Coroutines` | 5,752.350 |
+| `HttpClientBenchmark.hc5AsyncCoroutines` | 5,520.183 |
+| `HttpClientBenchmark.javaHttpH2Coroutines` | 5,481.592 |
+| `HttpClientBenchmark.javaHttpCoroutines` | 4,739.894 |
+| `HttpClientBenchmark.ktorCioCoroutines` | 2,052.281 |
+
+#### High-latency snapshot
+
+| Benchmark row | ops/s |
+|---------------|------:|
+| `HttpClientLatencyBenchmark.okhttp3VirtualThread` | 1,902.171 |
+| `HttpClientLatencyBenchmark.hc5ClassicVirtualThread` | 1,888.018 |
+| `HttpClientLatencyBenchmark.javaHttpVirtualThread` | 1,883.634 |
+| `HttpClientLatencyBenchmark.hc5Classic` | 1,880.023 |
+| `HttpClientLatencyBenchmark.okhttp3Sync` | 1,870.124 |
+| `HttpClientLatencyBenchmark.javaHttpSync` | 1,865.997 |
+| `HttpClientLatencyBenchmark.javaHttpCoroutines` | 1,863.948 |
+| `HttpClientLatencyBenchmark.hc5AsyncCoroutines` | 1,860.655 |
+| `HttpClientLatencyBenchmark.vertxWebClientCoroutines` | 1,859.003 |
+| `HttpClientLatencyBenchmark.okhttp3Coroutines` | 1,856.895 |
+| `HttpClientLatencyBenchmark.ktorCioCoroutines` | 1,515.026 |
+| `HttpClientLatencyBenchmark.hc5ClassicCoroutines` | 1,216.306 |
 
 ![HTTP client high-latency benchmark chart](../../docs/images/readme-diagrams/io-http-chart-02.svg)
 
 **Notes**:
-- The main improvement is Vert.x WebClient under the 50 ms delay workload. Vert.x 5 defaults to a small HTTP/1 pool; the benchmark now configures `PoolOptions` to match peer clients.
-- The Ktor CIO rows are intentionally bounded to one JMH thread. Full class concurrency exhausted local ephemeral ports against this Docker fixture, and HTTP/1 pipelining produced unexpected EOFs.
-- Base `/ping` measurements have high variance on this local Docker setup. Treat the high-latency Vert.x result as the strongest decision signal.
+- The previous Vert.x result mainly measured the Vert.x 5 default HTTP/1 pool cap. The benchmark now configures `PoolOptions` to match peer clients.
+- Ktor CIO's default path remains slower on `/ping` because it uses dedicated HTTP/1 connections. Forcing CIO pipelining produced EOFs or hangs against the mock fixtures, so the comparable run keeps default CIO behavior and shortens the window for every row.
+- Base `/ping` measurements have high variance on this local Docker setup. Treat the high-latency table as the stronger comparison signal.
 
 ### 3. HttpClientCompressionCacheBenchmark — Cache + gzip Effect
 

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
@@ -5,9 +5,9 @@ import io.bluetape4k.http.hc5.classic.virtualThreadHttpClientOf
 import io.bluetape4k.http.jdk.sendAwait
 import io.bluetape4k.http.ktor.ktorCioHttpClientOf
 import io.bluetape4k.http.okhttp3.okhttp3DispatcherWithVirtualThread
-import io.bluetape4k.testcontainers.http.BluetapeHttpServer
+import io.bluetape4k.testcontainers.http.BluetapeWebfluxServer
 import io.ktor.client.HttpClient as KtorHttpClient
-import io.ktor.client.request.prepareGet
+import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsBytes
 import io.vertx.core.Vertx
 import io.vertx.core.http.PoolOptions
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit
 /**
  * 다양한 HTTP Client 의 throughput 을 비교하는 JMH 벤치마크.
  *
- * Docker 기반 [BluetapeHttpServer] 를 외부 프로세스로 사용하므로
+ * Docker 기반 [BluetapeWebfluxServer] 를 외부 프로세스로 사용하므로
  * 서버 JVM 이 벤치마크 JVM 과 분리되어 클라이언트 단독 성능을 측정합니다.
  *
  * 엔드포인트: `GET /ping` → HTTP 200 (경량 응답, 순수 연결 처리량 측정)
@@ -61,16 +61,20 @@ import java.util.concurrent.TimeUnit
  * - Apache HC5 Async + Coroutines
  * - Ktor CIO + Coroutines
  * - Vert.x WebClient + Coroutines
+ *
+ * Ktor CIO 3.5 opens dedicated HTTP/1 connections when its pipeline path is
+ * disabled. The benchmark therefore keeps a short equal-thread measurement
+ * window for every client instead of limiting only the CIO row to one thread.
  */
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.Throughput)
-@Warmup(iterations = 1, time = 2, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
 @Threads(8)
 open class HttpClientBenchmark {
 
     // 별도 Docker 프로세스 — 벤치마크 JVM 과 자원 경쟁 없음
-    private val server = BluetapeHttpServer.Launcher.bluetapeHttpServer
+    private val server = BluetapeWebfluxServer.Launcher.bluetapeWebfluxServer
 
     private lateinit var pingUrl: String
     private lateinit var serverHost: String
@@ -154,9 +158,9 @@ open class HttpClientBenchmark {
 
         ktorCioClient = ktorCioHttpClientOf {
             engine {
-                maxConnectionsCount = n
+                maxConnectionsCount = maxConnections
                 requestTimeout = 5_000
-                endpoint.maxConnectionsPerRoute = n
+                endpoint.maxConnectionsPerRoute = maxConnections
                 endpoint.connectTimeout = 5_000
                 endpoint.socketTimeout = 5_000
                 endpoint.keepAliveTime = 5_000
@@ -297,16 +301,10 @@ open class HttpClientBenchmark {
     }
 
     @Benchmark
-    @Warmup(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
-    @Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
-    @Threads(1)
     fun ktorCioCoroutines(): Int = runBlocking {
-        // CIO makes dedicated HTTP/1 requests for this fixture; keep this row bounded
-        // to avoid local port exhaustion.
-        ktorCioClient.prepareGet(pingUrl).execute { response ->
-            response.bodyAsBytes()
-            response.status.value
-        }
+        val response = ktorCioClient.get(pingUrl)
+        response.bodyAsBytes()
+        response.status.value
     }
 
     @Benchmark

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientLatencyBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientLatencyBenchmark.kt
@@ -5,9 +5,9 @@ import io.bluetape4k.http.hc5.classic.virtualThreadHttpClientOf
 import io.bluetape4k.http.jdk.sendAwait
 import io.bluetape4k.http.ktor.ktorCioHttpClientOf
 import io.bluetape4k.http.okhttp3.okhttp3DispatcherWithVirtualThread
-import io.bluetape4k.testcontainers.http.BluetapeHttpServer
+import io.bluetape4k.testcontainers.http.BluetapeWebfluxServer
 import io.ktor.client.HttpClient as KtorHttpClient
-import io.ktor.client.request.prepareGet
+import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsBytes
 import io.vertx.core.Vertx
 import io.vertx.core.http.PoolOptions
@@ -49,7 +49,7 @@ import okhttp3.Dispatcher as OkHttpDispatcher
 /**
  * 고지연(~50 ms) 환경에서 동기 vs 비동기 HTTP 클라이언트 처리량 비교.
  *
- * Docker 기반 [BluetapeHttpServer] 의 `/httpbin/delay/0.05` 엔드포인트를 사용해
+ * Docker 기반 [BluetapeWebfluxServer] 의 `/httpbin/delay/0.05` 엔드포인트를 사용해
  * 서버 JVM 분리 + 50ms 지연을 시뮬레이션합니다.
  *
  * 동기 클라이언트 이론 상한: threads × (1000 / 50ms) = 2,000 ops/s
@@ -58,15 +58,19 @@ import okhttp3.Dispatcher as OkHttpDispatcher
  * Vert.x 5 defaults to a 5-connection HTTP/1 pool. This benchmark configures
  * the pool to match the other clients so the high-latency test compares client
  * behavior instead of the default connection cap.
+ *
+ * Ktor CIO 3.5 opens dedicated HTTP/1 connections when its pipeline path is
+ * disabled. The benchmark therefore keeps a short equal-thread measurement
+ * window for every client instead of limiting only the CIO row to one thread.
  */
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.Throughput)
-@Warmup(iterations = 1, time = 3, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
 @Threads(100)
 open class HttpClientLatencyBenchmark {
 
-    private val server = BluetapeHttpServer.Launcher.bluetapeHttpServer
+    private val server = BluetapeWebfluxServer.Launcher.bluetapeWebfluxServer
 
     private lateinit var delayUrl: String
     private lateinit var serverHost: String
@@ -146,11 +150,9 @@ open class HttpClientLatencyBenchmark {
 
         ktorCioClient = ktorCioHttpClientOf {
             engine {
-                val ktorConnections = 1
-
-                maxConnectionsCount = ktorConnections
+                maxConnectionsCount = connPerHost
                 requestTimeout = 10_000
-                endpoint.maxConnectionsPerRoute = ktorConnections
+                endpoint.maxConnectionsPerRoute = connPerHost
                 endpoint.connectTimeout = 5_000
                 endpoint.socketTimeout = 10_000
                 endpoint.keepAliveTime = 5_000
@@ -266,14 +268,10 @@ open class HttpClientLatencyBenchmark {
     }
 
     @Benchmark
-    @Threads(1)
     fun ktorCioCoroutines(): Int = runBlocking {
-        // CIO is intentionally measured as a bounded row; full class concurrency
-        // exhausts local ephemeral ports.
-        ktorCioClient.prepareGet(delayUrl).execute { response ->
-            response.bodyAsBytes()
-            response.status.value
-        }
+        val response = ktorCioClient.get(delayUrl)
+        response.bodyAsBytes()
+        response.status.value
     }
 
     @Benchmark


### PR DESCRIPTION
## Summary

Closes #587

- PR 제목: perf(io-http): make Ktor CIO benchmark comparable

- Move the io/http client throughput benchmarks to the WebFlux mock fixture.
- Remove the one-thread Ktor CIO exception so every benchmark row uses the same JMH thread count.
- Re-run the base and high-latency benchmark sets, then update README tables, the high-latency SVG chart, the benchmark report, and lessons.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Results

Base `GET /ping`, `@Threads(8)`, WebFlux fixture, warmup 1x1s, measurement 1x1s:

- `javaHttpSync`: 7,276.492 ops/s
- `hc5ClassicVirtualThread`: 7,246.690 ops/s
- `vertxWebClientCoroutines`: 6,043.906 ops/s
- `ktorCioCoroutines`: 2,052.281 ops/s

High-latency `GET /httpbin/delay/0.05`, `@Threads(100)`, WebFlux fixture, warmup 1x1s, measurement 1x1s:

- `okhttp3VirtualThread`: 1,902.171 ops/s
- `hc5ClassicVirtualThread`: 1,888.018 ops/s
- `vertxWebClientCoroutines`: 1,859.003 ops/s
- `ktorCioCoroutines`: 1,515.026 ops/s

### 기존 섹션: Notes

Ktor CIO 3.5 opens dedicated HTTP/1 connections when its pipeline path is disabled. Forcing CIO pipelining produced EOFs or hangs against the local mock fixtures, so this PR keeps default CIO behavior and uses a short equal-thread measurement window for all rows instead of per-row thread overrides.

Closes #587.
Refs #584, #589, #590.

### 기존 섹션: Verification

- [x] `./gradlew :bluetape4k-mock-webflux-server:jibDockerBuild :bluetape4k-http:compileTestKotlin --no-configuration-cache`
- [x] `./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude='HttpClientBenchmark.ktorCioCoroutines|HttpClientLatencyBenchmark.ktorCioCoroutines' --no-configuration-cache`
- [x] `./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude='HttpClientBenchmark|HttpClientLatencyBenchmark' --no-configuration-cache`
- [x] `./gradlew :bluetape4k-http:compileTestKotlin --no-configuration-cache`
- [x] `git diff --check`
- [x] `xmllint --noout docs/images/readme-diagrams/io-http-chart-02.svg`

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #587, #584, milestone `없음`, assignee debop
- PR: #594, head `110d93f3ed402af07b427fe8a895992bf7fc9e55`, milestone `1.9.2`, assignee debop
- Base: `develop`, head branch `perf/issue-587-ktor-cio-fair-benchmark`
- Labels: `documentation`, `performance`, `infra/io`
- State: `MERGED`, merge commit `1409abaf6cce883af4443410532723b70bc2a905`
- CI: - Remove the one-thread Ktor CIO exception so every benchmark row uses the same JMH thread count. / - `ktorCioCoroutines`: 2,052.281 ops/s / - `ktorCioCoroutines`: 1,515.026 ops/s## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #594 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `1409abaf6cce883af4443410532723b70bc2a905`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
