### PR TITLE
test: add reusable etcd testcontainer

### DIFF
--- a/docs/lessons/2026-05-22-issue-596-etcd-server.md
+++ b/docs/lessons/2026-05-22-issue-596-etcd-server.md
@@ -1,0 +1,36 @@
+# Lesson: #596 EtcdServer Testcontainers fixture
+
+## Context
+
+`bluetape4k-leader` #227 needs real etcd integration tests for `leader-etcd`.
+`bluetape4k-testcontainers` already had `ConsulServer` and `ZooKeeperServer`,
+but no reusable etcd launcher.
+
+## Decision
+
+Add `EtcdServer` as a small `GenericContainer` wrapper in the existing
+`infra` package. Use the official etcd container guide defaults:
+`gcr.io/etcd-development/etcd:v3.6.0`, client port `2379`, peer port `2380`,
+and `/health` readiness.
+
+## Outcome
+
+`EtcdServer.Launcher.etcd` now provides a reusable singleton and exports
+`testcontainers.etcd.*` properties. The primary user-facing helper is
+`endpoint`, which is directly usable by jetcd clients.
+
+## Verification
+
+- PullMD research saved to
+  `~/work/bluetape4k/wiki/research/2026-05-22-issue-596-etcd-container-pullmd.md`
+  and verified with qmd.
+- `./gradlew :bluetape4k-testcontainers:compileKotlin :bluetape4k-testcontainers:compileTestKotlin --no-daemon --console=plain`
+  passed.
+- `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.infra.EtcdServerTest' --no-daemon --console=plain`
+  passed; rerun with `--no-configuration-cache` after the smoke assertion update.
+
+## Future Guidance
+
+For new infrastructure launchers, add direct endpoint smoke coverage in addition
+to `isRunning`. Use official container docs through PullMD, store the research
+in shared wiki research, and qmd-index it before committing the implementation.

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/EtcdServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/EtcdServer.kt
@@ -1,0 +1,163 @@
+package io.bluetape4k.testcontainers.infra
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.testcontainers.GenericServer
+import io.bluetape4k.testcontainers.PropertyExportingServer
+import io.bluetape4k.testcontainers.exposeCustomPorts
+import io.bluetape4k.utils.ShutdownQueue
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * Runs a single-node [etcd](https://etcd.io/) server with Testcontainers.
+ *
+ * ## Behavior / Contract
+ * - Exposes the etcd client API on [CLIENT_PORT] and the peer API on [PEER_PORT].
+ * - [endpoint] is suitable for jetcd `Client.builder().endpoints(...)`.
+ * - The container is reusable by default and can be shared through [Launcher.etcd].
+ * - Starting the server exports connection properties under `testcontainers.etcd.*`.
+ *
+ * ```kotlin
+ * val etcd = EtcdServer.Launcher.etcd
+ * val endpoint = etcd.endpoint
+ * ```
+ */
+class EtcdServer private constructor(
+    imageName: DockerImageName,
+    useDefaultPort: Boolean,
+    reuse: Boolean,
+): GenericContainer<EtcdServer>(imageName), GenericServer, PropertyExportingServer {
+
+    companion object: KLogging() {
+        /** Official etcd container registry recommended by the etcd container guide. */
+        const val IMAGE = "gcr.io/etcd-development/etcd"
+
+        /** Default etcd image tag. */
+        const val TAG = "v3.6.0"
+
+        /** System property namespace. */
+        const val NAME = "etcd"
+
+        /** etcd client API port. */
+        const val CLIENT_PORT = 2379
+
+        /** etcd peer communication port. */
+        const val PEER_PORT = 2380
+
+        /** Ports exported by the container. */
+        val EXPORT_PORTS = intArrayOf(CLIENT_PORT, PEER_PORT)
+
+        /**
+         * Creates an [EtcdServer] from a [DockerImageName].
+         *
+         * @param imageName Docker image name.
+         * @param useDefaultPort binds 2379/2380 to the same host ports when `true`.
+         * @param reuse enables reusable Testcontainers when `true`.
+         */
+        @JvmStatic
+        operator fun invoke(
+            imageName: DockerImageName,
+            useDefaultPort: Boolean = false,
+            reuse: Boolean = true,
+        ): EtcdServer {
+            return EtcdServer(imageName, useDefaultPort, reuse)
+        }
+
+        /**
+         * Creates an [EtcdServer] from an image name and tag.
+         *
+         * @param image Docker image name; blank values are rejected.
+         * @param tag Docker image tag; blank values are rejected.
+         * @param useDefaultPort binds 2379/2380 to the same host ports when `true`.
+         * @param reuse enables reusable Testcontainers when `true`.
+         */
+        @JvmStatic
+        operator fun invoke(
+            image: String = IMAGE,
+            tag: String = TAG,
+            useDefaultPort: Boolean = false,
+            reuse: Boolean = true,
+        ): EtcdServer {
+            image.requireNotBlank("image")
+            tag.requireNotBlank("tag")
+
+            val imageName = DockerImageName.parse(image).withTag(tag)
+            return invoke(imageName, useDefaultPort, reuse)
+        }
+    }
+
+    override val port: Int get() = clientPort
+    override val url: String get() = endpoint
+
+    /** Mapped etcd client API port. */
+    val clientPort: Int get() = getMappedPort(CLIENT_PORT)
+
+    /** Mapped etcd peer port. */
+    val peerPort: Int get() = getMappedPort(PEER_PORT)
+
+    /** HTTP endpoint for etcd v3 clients such as jetcd. */
+    val endpoint: String get() = "http://$host:$clientPort"
+
+    /** Single endpoint list for APIs that accept multiple etcd endpoints. */
+    val endpoints: List<String> get() = listOf(endpoint)
+
+    override val propertyNamespace: String = NAME
+
+    override fun propertyKeys(): Set<String> =
+        setOf("host", "port", "url", "client-port", "peer-port", "endpoint")
+
+    override fun properties(): Map<String, String> = mapOf(
+        "host" to host,
+        "port" to port.toString(),
+        "url" to url,
+        "client-port" to clientPort.toString(),
+        "peer-port" to peerPort.toString(),
+        "endpoint" to endpoint,
+    )
+
+    init {
+        addExposedPorts(*EXPORT_PORTS)
+        withReuse(reuse)
+        waitingFor(Wait.forHttp("/health").forPort(CLIENT_PORT).forStatusCode(200))
+        withCommand(
+            "/usr/local/bin/etcd",
+            "--name",
+            NAME,
+            "--data-dir",
+            "/etcd-data",
+            "--listen-client-urls",
+            "http://0.0.0.0:$CLIENT_PORT",
+            "--advertise-client-urls",
+            "http://127.0.0.1:$CLIENT_PORT",
+            "--listen-peer-urls",
+            "http://0.0.0.0:$PEER_PORT",
+            "--initial-advertise-peer-urls",
+            "http://127.0.0.1:$PEER_PORT",
+            "--initial-cluster",
+            "$NAME=http://127.0.0.1:$PEER_PORT",
+        )
+
+        if (useDefaultPort) {
+            exposeCustomPorts(*EXPORT_PORTS)
+        }
+    }
+
+    override fun start() {
+        super.start()
+        writeToSystemProperties()
+    }
+
+    /**
+     * Shared singleton launcher for tests that need a reusable etcd server.
+     */
+    object Launcher {
+        val etcd: EtcdServer by lazy {
+            EtcdServer().apply {
+                start()
+                ShutdownQueue.register(this)
+            }
+        }
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/EtcdServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/EtcdServerTest.kt
@@ -1,0 +1,57 @@
+package io.bluetape4k.testcontainers.infra
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import org.junit.jupiter.api.Test
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import kotlin.test.assertEquals
+
+class EtcdServerTest: AbstractContainerTest() {
+
+    @Test
+    fun `launch Etcd server`() {
+        EtcdServer().use { etcd ->
+            etcd.start()
+
+            etcd.isRunning.shouldBeTrue()
+            etcd.endpoint.startsWith("http://").shouldBeTrue()
+            etcd.endpoints shouldBeEqualTo listOf(etcd.endpoint)
+            etcd.properties()["endpoint"] shouldBeEqualTo etcd.endpoint
+            System.getProperty("testcontainers.etcd.endpoint") shouldBeEqualTo etcd.endpoint
+
+            val response = httpClient.send(
+                HttpRequest.newBuilder(URI.create("${etcd.endpoint}/health"))
+                    .timeout(Duration.ofSeconds(5))
+                    .GET()
+                    .build(),
+                HttpResponse.BodyHandlers.ofString(),
+            )
+            response.statusCode() shouldBeEqualTo 200
+            response.body().contains("\"health\"").shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `blank image tag is rejected`() {
+        assertFailsWith<IllegalArgumentException> { EtcdServer(image = " ") }
+        assertFailsWith<IllegalArgumentException> { EtcdServer(tag = " ") }
+    }
+
+    @Test
+    fun `uses provided image`() {
+        val server = EtcdServer(image = "gcr.io/etcd-development/etcd", tag = "v3.6.0")
+        assertEquals("gcr.io/etcd-development/etcd:v3.6.0", server.dockerImageName)
+    }
+
+    companion object {
+        private val httpClient: HttpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build()
+    }
+}


### PR DESCRIPTION
## Summary

Closes #596

- PR 제목: test: add reusable etcd testcontainer

- Add `EtcdServer` reusable Testcontainers launcher under `testing/testcontainers`.
- Expose client/peer ports, jetcd-ready `endpoint` helpers, and `testcontainers.etcd.*` properties.
- Add smoke coverage for container startup, exported endpoint, `/health`, image validation, and provided image selection.
- Record the implementation lesson for future infrastructure launchers.

Closes #596.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- `qmd search "Run etcd clusters inside containers" -c bluetape4k-wiki --files --all`
- `./gradlew :bluetape4k-testcontainers:compileKotlin :bluetape4k-testcontainers:compileTestKotlin --no-daemon --console=plain`
- `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.infra.EtcdServerTest' --no-daemon --no-configuration-cache --console=plain`

### 기존 섹션: Notes

This unblocks `bluetape4k-leader` #227 integration tests for `leader-etcd` once the fixture is merged and a snapshot is available.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #596, milestone `1.9.0`, assignee `debop`
- PR: #597, head `5edcbc0859f5b731ff7bcad6afa51cc72bcc8c8a`, milestone `1.9.0`, assignee `debop`
- Base: `develop`, head branch `test/issue-596-etcd-server`
- Labels: `test`
- State: `MERGED`, merge commit `2124b442344016f9f0a0b4652a480c0d200c497b`
- CI: - `./gradlew :bluetape4k-testcontainers:compileKotlin :bluetape4k-testcontainers:compileTestKotlin --no-daemon --console=plain` / - `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.infra.EtcdServerTest' --no-daemon --no-configuration-cache --console=plain`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #597 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `2124b442344016f9f0a0b4652a480c0d200c497b`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
