### PR TITLE
fix: stabilize Nightly external-service test slices

### DIFF
--- a/docs/lessons/2026-05-22-issue-595-nightly-failures.md
+++ b/docs/lessons/2026-05-22-issue-595-nightly-failures.md
@@ -1,0 +1,27 @@
+# Issue 595 Nightly Failures
+
+## Context
+
+Nightly run 26243476594 failed in three slices: IO HTTP, infra search-messaging, and Testcontainers graphdb-memgraph.
+
+## Decision
+
+- Update the MyBatis dynamic-sql join validation test to exercise the current `on`-based Kotlin DSL and expect `InvalidSqlException`.
+- Start the shared Elasticsearch test singleton with `reuse = false` so CI cannot attach to a reused secured container initialized with stale credentials.
+- Bind Memgraph Bolt explicitly to `0.0.0.0` so Testcontainers host port mapping always reaches the Bolt listener.
+
+## Outcome
+
+The failing slices were reduced to deterministic local checks and passed after the fixes.
+
+## Verification
+
+- `./gradlew :bluetape4k-vertx:test --tests '*join with no on condition*' --no-configuration-cache --max-workers=1`
+- `./gradlew :bluetape4k-elasticsearch:test --no-configuration-cache --max-workers=1`
+- `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.graphdb.MemgraphServerTest' --no-configuration-cache --max-workers=1`
+- `./gradlew :bluetape4k-feign:test :bluetape4k-http:test :bluetape4k-retrofit2:test :bluetape4k-vertx:test --parallel --no-configuration-cache`
+- `./gradlew :bluetape4k-elasticsearch:test :bluetape4k-nats:test --max-workers=1 --no-configuration-cache`
+
+## Future Guidance
+
+When Elasticsearch tests fail with 401 in CI, inspect Testcontainers reuse before changing credentials. For Memgraph, keep the Bolt bind address explicit when changing image tags or command-line flags.

--- a/io/vertx/src/test/kotlin/io/bluetape4k/vertx/sqlclient/mybatis/joins/AbstractJoinTest.kt
+++ b/io/vertx/src/test/kotlin/io/bluetape4k/vertx/sqlclient/mybatis/joins/AbstractJoinTest.kt
@@ -32,7 +32,7 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldHaveSize
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.mybatis.dynamic.sql.util.kotlin.KInvalidSQLException
+import org.mybatis.dynamic.sql.exception.InvalidSqlException
 import org.mybatis.dynamic.sql.util.kotlin.elements.invoke
 import org.mybatis.dynamic.sql.util.kotlin.elements.max
 import org.mybatis.dynamic.sql.util.kotlin.model.select
@@ -728,14 +728,15 @@ abstract class AbstractJoinTest: AbstractVertxSqlClientTest() {
         @Test
         fun `join with no on condition`(vertx: Vertx, testContext: VertxTestContext) = runSuspendIO {
             vertx.testWithSuspendRollback(testContext, pool) { conn: SqlConnection ->
-                assertFailsWith<KInvalidSQLException> {
+                assertFailsWith<InvalidSqlException> {
                     val user2 = user.withAlias("other_user")
                     conn.select(
                         listOf(user.userId, user.userName, user.parentId),
                         UserRowMapper
                     ) {
                         from(user, "u1")
-                        join(user2, "u2") { and(user.userId) equalTo user2.parentId }
+                        val join = join(user2, "u2")
+                        join on {}
                         where { user2.userId isEqualTo 4 }
                     }
                 }

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/graphdb/MemgraphServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/graphdb/MemgraphServer.kt
@@ -134,7 +134,7 @@ class MemgraphServer private constructor(
         withReuse(reuse)
         withStartupAttempts(1)
         addEnv("MEMGRAPH", "--telemetry-enabled=false")
-        withCommand("--telemetry-enabled=false")
+        withCommand("--telemetry-enabled=false", "--bolt-address=0.0.0.0")
         waitingFor(
             WaitAllStrategy(WITH_OUTER_TIMEOUT)
                 .withStrategy(Wait.forLogMessage(READY_LOG_REGEX, 1))

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/ElasticsearchServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/ElasticsearchServer.kt
@@ -132,7 +132,7 @@ class ElasticsearchServer private constructor(
          * 기본 [ElasticsearchServer]를 제공합니다.
          */
         val elasticsearch: ElasticsearchServer by lazy {
-            ElasticsearchServer().apply {
+            ElasticsearchServer(reuse = false).apply {
                 start()
                 ShutdownQueue.register(this)
             }


### PR DESCRIPTION
## Summary

Closes #595

- PR 제목: fix: stabilize Nightly external-service test slices

Fixes #595.

- Update the Vert.x MyBatis join validation test for the current Kotlin DSL and exception type.
- Disable reuse for the shared secured Elasticsearch test singleton to avoid stale CI credentials.
- Bind Memgraph Bolt to `0.0.0.0` so Testcontainers host port mapping reaches the service reliably.
- Add a lesson entry for the Nightly failure pattern.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- `./gradlew :bluetape4k-vertx:test --tests '*join with no on condition*' --no-configuration-cache --max-workers=1`\n- `./gradlew :bluetape4k-elasticsearch:test --no-configuration-cache --max-workers=1`\n- `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.graphdb.MemgraphServerTest' --no-configuration-cache --max-workers=1`\n- `./gradlew :bluetape4k-feign:test :bluetape4k-http:test :bluetape4k-retrofit2:test :bluetape4k-vertx:test --parallel --no-configuration-cache`\n- `./gradlew :bluetape4k-elasticsearch:test :bluetape4k-nats:test --max-workers=1 --no-configuration-cache`\n\n## Not Tested\n\n- Full GitHub Nightly rerun.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #595, milestone `1.9.0`, assignee debop
- PR: #598, head `ab2f267484aa7aa108c983fc97491f8c70382510`, milestone `1.9.0`, assignee debop
- Base: `develop`, head branch `fix/issue-595-nightly-failures`
- Labels: `bug`, `test`, `infra/io`, `ci`, `github_actions`
- State: `MERGED`, merge commit `9564316cb0a5c83b151fde59e4216ba08db52270`
- CI: - Disable reuse for the shared secured Elasticsearch test singleton to avoid stale CI credentials. / - `./gradlew :bluetape4k-vertx:test --tests '*join with no on condition*' --no-configuration-cache --max-workers=1`\n- `./gradlew :bluetape4k-elasticsearch:test --no-configuration-cache --max-workers=1`\n- `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.graphdb.MemgraphServerTest' --no-configuration-cache --max-workers=1`\n- `./gradlew :bluetape4k-feign:test :bluetape4k-http:test :bluetape4k-retrofit2:test :bluetape4k-vertx:test --parallel --no-configuration-cache`\n- `./gradlew :bluetape4k-elasticsearch:test :bluetape4k-nats:test --max-workers=1 --no-configuration-cache`\n\n## Not Tested\n\n- Full GitHub Nightly rerun.## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #598 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9564316cb0a5c83b151fde59e4216ba08db52270`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
