### PR TITLE
fix: surface Fory Kafka deserialization trust boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 
 ### Fixed
 
+- Fory-backed Kafka and Kafka4 codecs now carry `@BluetapeDelicateApi` and
+  explicit trust-boundary documentation so callers are warned about the default
+  Fory deserialization risk for shared or external topics ([#580](https://github.com/bluetape4k/bluetape4k-projects/issues/580)).
+
 ---
 
 ## [Unreleased]

--- a/docs/lessons/2026-05-22-issue-580-fory-kafka-delicate.md
+++ b/docs/lessons/2026-05-22-issue-580-fory-kafka-delicate.md
@@ -1,0 +1,31 @@
+# Issue 580 Fory Kafka Trust Boundary
+
+## Context
+
+Issue #580 flagged that the Fory-backed Kafka codecs replaced obsolete JDK codecs
+but still exposed an unregistered-class deserialization trust boundary.
+
+## Decision
+
+Mark `ForyKafkaCodec`, `LZ4ForyKafkaCodec`, `SnappyForyKafkaCodec`, and
+`ZstdForyKafkaCodec` as `@BluetapeDelicateApi` in both Kafka 3 and Kafka 4
+modules. Mark the corresponding `KafkaCodecs` registry properties as delicate
+too, so callers using the registry see the same opt-in warning.
+
+## Outcome
+
+The public API now surfaces the Fory trust boundary without removing source
+compatibility. README files document that Fory-backed codecs are for trusted
+topics and brokers unless callers provide a class-registration-enforced custom
+serializer.
+
+## Verification
+
+- IntelliJ diagnostics: no problems in touched production codec files.
+- `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka:compileTestKotlin :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka4:compileTestKotlin --continue --no-configuration-cache --max-workers=2`
+- `./gradlew :bluetape4k-kafka:test --tests 'io.bluetape4k.kafka.codec.KafkaCodecTest' :bluetape4k-kafka4:test --tests 'io.bluetape4k.kafka.codec.KafkaCodecTest' --no-configuration-cache --max-workers=1`
+
+## Future Guidance
+
+When marking a public API with a Bluetape opt-in annotation, add the annotations
+module as an `api` dependency if consumers must see the marker in signatures.

--- a/infra/kafka/README.ko.md
+++ b/infra/kafka/README.ko.md
@@ -145,6 +145,7 @@ while (true) {
 ### 4. Kafka Codecs 사용
 
 ```kotlin
+import io.bluetape4k.annotations.BluetapeDelicateApi
 import io.bluetape4k.kafka.codec.JacksonKafkaCodec
 import io.bluetape4k.kafka.codec.KafkaCodecs
 
@@ -164,6 +165,7 @@ val jsonBytes = jacksonCodec.serialize("test-topic", data)
 val decoded = jacksonCodec.deserialize("test-topic", jsonBytes)
 
 // LZ4 압축 + Fory 직렬화
+@OptIn(BluetapeDelicateApi::class)
 val lz4ForyCodec = KafkaCodecs.Lz4Fory
 val largeObject = LargeDataObject(/* ... */)
 val compressed = lz4ForyCodec.serialize("test-topic", largeObject)
@@ -177,13 +179,25 @@ val compressed = lz4ForyCodec.serialize("test-topic", largeObject)
 | `KafkaCodecs.ByteArray` | 바이트 배열 직접 전달         |
 | `KafkaCodecs.Jackson`   | JSON 직렬화             |
 | `KafkaCodecs.Kryo`      | Kryo 바이너리 직렬화        |
-| `KafkaCodecs.Fory`      | Fory 바이너리 직렬화 (고성능, 권장) |
+| `KafkaCodecs.Fory`      | 신뢰된 입력용 Fory 바이너리 직렬화 |
 | `KafkaCodecs.Lz4Kryo`   | LZ4 압축 + Kryo 직렬화    |
-| `KafkaCodecs.Lz4Fory`   | LZ4 압축 + Fory 직렬화    |
+| `KafkaCodecs.Lz4Fory`   | 신뢰된 입력용 LZ4 압축 + Fory 직렬화 |
 | `KafkaCodecs.SnappyKryo` | Snappy 압축 + Kryo 직렬화 |
-| `KafkaCodecs.SnappyFory` | Snappy 압축 + Fory 직렬화 |
+| `KafkaCodecs.SnappyFory` | 신뢰된 입력용 Snappy 압축 + Fory 직렬화 |
 | `KafkaCodecs.ZstdKryo`  | Zstd 압축 + Kryo 직렬화   |
-| `KafkaCodecs.ZstdFory`  | Zstd 압축 + Fory 직렬화   |
+| `KafkaCodecs.ZstdFory`  | 신뢰된 입력용 Zstd 압축 + Fory 직렬화 |
+
+#### 보안: Fory 신뢰 경계
+
+Fory 기반 Kafka codec은 `@BluetapeDelicateApi`로 표시됩니다. 이 codec들은 기본
+`ForyBinarySerializer`를 사용하며, 기본 Fory 설정은 역직렬화 시 등록되지 않은 클래스도
+허용합니다. 완전히 신뢰할 수 있는 토픽과 브로커에서만 opt-in 하세요. 공유 토픽이나
+외부 입력에는 `ForyBinarySerializer.secureFory(...)`로 명시적 클래스 등록을 강제한
+커스텀 codec을 사용하세요.
+
+`BinaryKafkaCodec`을 직접 상속하면서 `BinarySerializers.Fory`, `LZ4Fory`,
+`SnappyFory`, `ZstdFory`를 주입하는 경우에도 같은 신뢰 경계가 적용됩니다. 이 하위
+serializer들은 Kafka 전용 opt-in marker를 직접 제공하지 않습니다.
 
 #### 성능: 타입 헤더 쓰기 비활성화
 
@@ -191,7 +205,8 @@ val compressed = lz4ForyCodec.serialize("test-topic", largeObject)
 컨슈머가 타입을 정적으로 이미 알고 있다면 비활성화할 수 있습니다:
 
 ```kotlin
-// Fory/Kryo 기반 코덱은 헤더 없이 안전하게 작동합니다
+// Fory/Kryo 기반 코덱은 value-type 헤더가 필요하지 않습니다
+@OptIn(BluetapeDelicateApi::class)
 class NoHeaderForyCodec : ForyKafkaCodec() {
     override val writeValueTypeHeader = false
 }
@@ -200,7 +215,7 @@ class NoHeaderForyCodec : ForyKafkaCodec() {
 > **`JacksonKafkaCodec` 주의**: Jackson은 역직렬화 시 헤더에서 대상 타입을 결정합니다.
 > `doDeserialize`를 함께 오버라이드하지 않고 `writeValueTypeHeader = false`만 설정하면
 > `LinkedHashMap`으로 역직렬화되어 타입 손상이 발생합니다.
-> 헤더를 안전하게 비활성화하려면 `ForyKafkaCodec` 또는 `KryoKafkaCodec`을 사용하세요.
+> 헤더를 비활성화하려면 `ForyKafkaCodec` 또는 `KryoKafkaCodec`을 사용하세요.
 
 | `writeValueTypeHeader` | 동작 |
 |------------------------|------|

--- a/infra/kafka/README.md
+++ b/infra/kafka/README.md
@@ -145,6 +145,7 @@ while (true) {
 ### 4. Using Kafka Codecs
 
 ```kotlin
+import io.bluetape4k.annotations.BluetapeDelicateApi
 import io.bluetape4k.kafka.codec.JacksonKafkaCodec
 import io.bluetape4k.kafka.codec.KafkaCodecs
 
@@ -164,6 +165,7 @@ val jsonBytes = jacksonCodec.serialize("test-topic", data)
 val decoded = jacksonCodec.deserialize("test-topic", jsonBytes)
 
 // LZ4 compression + Fory serialization
+@OptIn(BluetapeDelicateApi::class)
 val lz4ForyCodec = KafkaCodecs.Lz4Fory
 val largeObject = LargeDataObject(/* ... */)
 val compressed = lz4ForyCodec.serialize("test-topic", largeObject)
@@ -177,13 +179,25 @@ Available codecs:
 | `KafkaCodecs.ByteArray` | Raw byte array passthrough              |
 | `KafkaCodecs.Jackson`   | JSON serialization                      |
 | `KafkaCodecs.Kryo`      | Kryo binary serialization               |
-| `KafkaCodecs.Fory`      | Fory binary serialization               |
+| `KafkaCodecs.Fory`      | Fory binary serialization for trusted inputs |
 | `KafkaCodecs.Lz4Kryo`   | LZ4 compression + Kryo serialization    |
-| `KafkaCodecs.Lz4Fory`   | LZ4 compression + Fory serialization    |
+| `KafkaCodecs.Lz4Fory`   | LZ4 compression + Fory serialization for trusted inputs |
 | `KafkaCodecs.SnappyKryo` | Snappy compression + Kryo serialization |
-| `KafkaCodecs.SnappyFory` | Snappy compression + Fory serialization |
+| `KafkaCodecs.SnappyFory` | Snappy compression + Fory serialization for trusted inputs |
 | `KafkaCodecs.ZstdKryo`  | Zstd compression + Kryo serialization   |
-| `KafkaCodecs.ZstdFory`  | Zstd compression + Fory serialization   |
+| `KafkaCodecs.ZstdFory`  | Zstd compression + Fory serialization for trusted inputs |
+
+#### Security: Fory Trust Boundary
+
+Fory-backed Kafka codecs are marked with `@BluetapeDelicateApi`. They use the
+default `ForyBinarySerializer`, which allows unregistered classes during
+deserialization. Opt in only for trusted topics and brokers. For shared or
+external inputs, prefer a custom codec backed by `ForyBinarySerializer.secureFory(...)`
+with explicit class registration.
+
+The same trust boundary applies if you subclass `BinaryKafkaCodec` directly with
+`BinarySerializers.Fory`, `LZ4Fory`, `SnappyFory`, or `ZstdFory`; those lower-level
+serializers do not add a Kafka-specific opt-in marker by themselves.
 
 #### Performance: Opt-out of Value-Type Header
 
@@ -192,7 +206,8 @@ record header (`bluetape4k.kafka.codec.value.type`). Disable it when the consume
 already knows the type statically:
 
 ```kotlin
-// Fory/Kryo codecs work safely without the header
+// Fory/Kryo codecs do not need the value-type header
+@OptIn(BluetapeDelicateApi::class)
 class NoHeaderForyCodec : ForyKafkaCodec() {
     override val writeValueTypeHeader = false
 }
@@ -201,7 +216,7 @@ class NoHeaderForyCodec : ForyKafkaCodec() {
 > **Note for `JacksonKafkaCodec`:** Jackson uses the header to determine the target type at
 > deserialization time. Setting `writeValueTypeHeader = false` without also overriding
 > `doDeserialize` causes it to fall back to `LinkedHashMap` (silent type corruption).
-> Use `ForyKafkaCodec` or `KryoKafkaCodec` when you want to disable the header safely.
+> Use `ForyKafkaCodec` or `KryoKafkaCodec` when you want to disable the header.
 
 | `writeValueTypeHeader` | Effect |
 |------------------------|--------|

--- a/infra/kafka/build.gradle.kts
+++ b/infra/kafka/build.gradle.kts
@@ -15,6 +15,7 @@ configurations {
 
 dependencies {
     implementation(platform(libs.spring.boot.dependencies))
+    api(project(":bluetape4k-annotations"))
     api(project(":bluetape4k-core"))
     api(project(":bluetape4k-io"))
     compileOnly(project(":bluetape4k-resilience4j"))

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.kafka.codec
 
+import io.bluetape4k.annotations.BluetapeDelicateApi
 import io.bluetape4k.io.serializer.BinarySerializer
 import io.bluetape4k.io.serializer.BinarySerializers
 import org.apache.kafka.common.header.Headers
@@ -41,7 +42,7 @@ abstract class BinaryKafkaCodec(
 class KryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.Kryo)
 
 /**
- * Fory 직렬화를 이용한 Kafka Codec
+ * Kafka codec backed by the default Fory binary serializer.
  *
  * ```kotlin
  * val codec = ForyKafkaCodec()
@@ -49,7 +50,15 @@ class KryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.Kryo)
  * val result = codec.deserialize("topic", null, bytes)
  * // result == "hello"
  * ```
+ *
+ * ## Security
+ *
+ * This codec uses `BinarySerializers.Fory`, whose default Fory configuration
+ * allows unregistered classes during deserialization. Use it only for trusted
+ * topics and brokers, or provide a codec backed by a class-registration-enforced
+ * `ForyBinarySerializer` for shared or external inputs.
  */
+@BluetapeDelicateApi
 class ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.Fory)
 
 /**
@@ -65,7 +74,7 @@ class ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.Fory)
 class LZ4KryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Kryo)
 
 /**
- * LZ4 압축 + Fory 직렬화를 이용한 Kafka Codec
+ * Kafka codec backed by LZ4 compression and the default Fory binary serializer.
  *
  * ```kotlin
  * val codec = LZ4ForyKafkaCodec()
@@ -73,7 +82,14 @@ class LZ4KryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Kryo)
  * val result = codec.deserialize("topic", null, bytes)
  * // result == "hello"
  * ```
+ *
+ * ## Security
+ *
+ * This codec uses `BinarySerializers.LZ4Fory`, which delegates to the default
+ * Fory serializer and allows unregistered classes during deserialization. Use
+ * it only for trusted topics and brokers.
  */
+@BluetapeDelicateApi
 class LZ4ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Fory)
 
 /**
@@ -89,7 +105,7 @@ class LZ4ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Fory)
 class SnappyKryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyKryo)
 
 /**
- * Snappy 압축 + Fory 직렬화를 이용한 Kafka Codec
+ * Kafka codec backed by Snappy compression and the default Fory binary serializer.
  *
  * ```kotlin
  * val codec = SnappyForyKafkaCodec()
@@ -97,7 +113,14 @@ class SnappyKryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyKryo)
  * val result = codec.deserialize("topic", null, bytes)
  * // result == "hello"
  * ```
+ *
+ * ## Security
+ *
+ * This codec uses `BinarySerializers.SnappyFory`, which delegates to the default
+ * Fory serializer and allows unregistered classes during deserialization. Use
+ * it only for trusted topics and brokers.
  */
+@BluetapeDelicateApi
 class SnappyForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyFory)
 
 /**
@@ -113,7 +136,7 @@ class SnappyForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyFory)
 class ZstdKryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.ZstdKryo)
 
 /**
- * Zstd 압축 + Fory 직렬화를 이용한 Kafka Codec
+ * Kafka codec backed by Zstd compression and the default Fory binary serializer.
  *
  * ```kotlin
  * val codec = ZstdForyKafkaCodec()
@@ -121,5 +144,12 @@ class ZstdKryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.ZstdKryo)
  * val result = codec.deserialize("topic", null, bytes)
  * // result == "hello"
  * ```
+ *
+ * ## Security
+ *
+ * This codec uses `BinarySerializers.ZstdFory`, which delegates to the default
+ * Fory serializer and allows unregistered classes during deserialization. Use
+ * it only for trusted topics and brokers.
  */
+@BluetapeDelicateApi
 class ZstdForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.ZstdFory)

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodecs.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodecs.kt
@@ -1,5 +1,7 @@
 package io.bluetape4k.kafka.codec
 
+import io.bluetape4k.annotations.BluetapeDelicateApi
+
 /**
  * 다양한 Kafka Codec 인스턴스를 제공하는 Object입니다.
  *
@@ -15,6 +17,7 @@ package io.bluetape4k.kafka.codec
  * val jacksonCodec = KafkaCodecs.Jackson
  *
  * // LZ4 압축 + Fory 직렬화 Codec 사용
+ * @OptIn(BluetapeDelicateApi::class)
  * val lz4ForyCodec = KafkaCodecs.Lz4Fory
  * ```
  *
@@ -30,14 +33,18 @@ object KafkaCodecs {
     val Jackson by lazy { JacksonKafkaCodec() }
 
     val Kryo by lazy { KryoKafkaCodec() }
+    @BluetapeDelicateApi
     val Fory by lazy { ForyKafkaCodec() }
 
     val Lz4Kryo by lazy { LZ4KryoKafkaCodec() }
+    @BluetapeDelicateApi
     val Lz4Fory by lazy { LZ4ForyKafkaCodec() }
 
     val SnappyKryo by lazy { SnappyKryoKafkaCodec() }
+    @BluetapeDelicateApi
     val SnappyFory by lazy { SnappyForyKafkaCodec() }
 
     val ZstdKryo by lazy { ZstdKryoKafkaCodec() }
+    @BluetapeDelicateApi
     val ZstdFory by lazy { ZstdForyKafkaCodec() }
 }

--- a/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/codec/KafkaCodecTest.kt
+++ b/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/codec/KafkaCodecTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.kafka.codec
 
+import io.bluetape4k.annotations.BluetapeDelicateApi
 import org.junit.jupiter.api.Nested
 
 class KafkaCodecTest {
@@ -17,6 +18,7 @@ class KafkaCodecTest {
     }
 
     @Nested
+    @OptIn(BluetapeDelicateApi::class)
     inner class ForyKafkaCodecTest: AbstractKafkaCodecTest() {
         override val codec: KafkaCodec<Any?> = KafkaCodecs.Fory
     }
@@ -27,6 +29,7 @@ class KafkaCodecTest {
     }
 
     @Nested
+    @OptIn(BluetapeDelicateApi::class)
     inner class Lz4ForyKafkaCodecTest: AbstractKafkaCodecTest() {
         override val codec: KafkaCodec<Any?> = KafkaCodecs.Lz4Fory
     }
@@ -37,6 +40,7 @@ class KafkaCodecTest {
     }
 
     @Nested
+    @OptIn(BluetapeDelicateApi::class)
     inner class SnappyForyKafkaCodecTest: AbstractKafkaCodecTest() {
         override val codec: KafkaCodec<Any?> = KafkaCodecs.SnappyFory
     }
@@ -47,6 +51,7 @@ class KafkaCodecTest {
     }
 
     @Nested
+    @OptIn(BluetapeDelicateApi::class)
     inner class ZstdForyKafkaCodecTest: AbstractKafkaCodecTest() {
         override val codec: KafkaCodec<Any?> = KafkaCodecs.ZstdFory
     }

--- a/infra/kafka4/README.ko.md
+++ b/infra/kafka4/README.ko.md
@@ -132,13 +132,25 @@ Jackson codec은 `bluetape4k-jackson3`와 `tools.jackson.*` API를 사용합니�
 | `KafkaCodecs.ByteArray` | 바이트 배열 직접 전달 |
 | `KafkaCodecs.Jackson` | Jackson 3 JSON 직렬화 |
 | `KafkaCodecs.Kryo` | Kryo 바이너리 직렬화 |
-| `KafkaCodecs.Fory` | Fory 바이너리 직렬화 |
+| `KafkaCodecs.Fory` | 신뢰된 입력용 Fory 바이너리 직렬화 |
 | `KafkaCodecs.Lz4Kryo` | LZ4 압축 + Kryo 직렬화 |
-| `KafkaCodecs.Lz4Fory` | LZ4 압축 + Fory 직렬화 |
+| `KafkaCodecs.Lz4Fory` | 신뢰된 입력용 LZ4 압축 + Fory 직렬화 |
 | `KafkaCodecs.SnappyKryo` | Snappy 압축 + Kryo 직렬화 |
-| `KafkaCodecs.SnappyFory` | Snappy 압축 + Fory 직렬화 |
+| `KafkaCodecs.SnappyFory` | 신뢰된 입력용 Snappy 압축 + Fory 직렬화 |
 | `KafkaCodecs.ZstdKryo` | Zstd 압축 + Kryo 직렬화 |
-| `KafkaCodecs.ZstdFory` | Zstd 압축 + Fory 직렬화 |
+| `KafkaCodecs.ZstdFory` | 신뢰된 입력용 Zstd 압축 + Fory 직렬화 |
+
+### 보안: Fory 신뢰 경계
+
+Fory 기반 Kafka codec은 `@BluetapeDelicateApi`로 표시됩니다. 이 codec들은 기본
+`ForyBinarySerializer`를 사용하며, 기본 Fory 설정은 역직렬화 시 등록되지 않은 클래스도
+허용합니다. 완전히 신뢰할 수 있는 토픽과 브로커에서만 opt-in 하세요. 공유 토픽이나
+외부 입력에는 `ForyBinarySerializer.secureFory(...)`로 명시적 클래스 등록을 강제한
+커스텀 codec을 사용하세요.
+
+`BinaryKafkaCodec`을 직접 상속하면서 `BinarySerializers.Fory`, `LZ4Fory`,
+`SnappyFory`, `ZstdFory`를 주입하는 경우에도 같은 신뢰 경계가 적용됩니다. 이 하위
+serializer들은 Kafka 전용 opt-in marker를 직접 제공하지 않습니다.
 
 ### Poison-pill 정책
 
@@ -164,7 +176,10 @@ Jackson codec은 `bluetape4k-jackson3`와 `tools.jackson.*` API를 사용합니�
 컨슈머가 타입을 정적으로 이미 알고 있다면 헤더 쓰기를 비활성화할 수 있습니다:
 
 ```kotlin
-// Fory/Kryo 기반 코덱은 헤더 없이 안전하게 작동합니다
+import io.bluetape4k.annotations.BluetapeDelicateApi
+
+// Fory/Kryo 기반 코덱은 value-type 헤더가 필요하지 않습니다
+@OptIn(BluetapeDelicateApi::class)
 class NoHeaderForyCodec : ForyKafkaCodec() {
     override val writeValueTypeHeader = false
 }
@@ -173,7 +188,7 @@ class NoHeaderForyCodec : ForyKafkaCodec() {
 > **`JacksonKafkaCodec` 주의**: Jackson은 역직렬화 시 헤더에서 대상 타입을 결정합니다.
 > `doDeserialize`를 함께 오버라이드하지 않고 `writeValueTypeHeader = false`만 설정하면
 > `LinkedHashMap`으로 역직렬화되어 타입 손상이 발생합니다.
-> 헤더를 안전하게 비활성화하려면 `ForyKafkaCodec` 또는 `KryoKafkaCodec`을 사용하세요.
+> 헤더를 비활성화하려면 `ForyKafkaCodec` 또는 `KryoKafkaCodec`을 사용하세요.
 
 | `writeValueTypeHeader` | 동작 |
 |------------------------|------|

--- a/infra/kafka4/README.md
+++ b/infra/kafka4/README.md
@@ -133,13 +133,25 @@ Available codecs:
 | `KafkaCodecs.ByteArray` | Raw byte array passthrough |
 | `KafkaCodecs.Jackson` | Jackson 3 JSON serialization |
 | `KafkaCodecs.Kryo` | Kryo binary serialization |
-| `KafkaCodecs.Fory` | Fory binary serialization |
+| `KafkaCodecs.Fory` | Fory binary serialization for trusted inputs |
 | `KafkaCodecs.Lz4Kryo` | LZ4 compression + Kryo serialization |
-| `KafkaCodecs.Lz4Fory` | LZ4 compression + Fory serialization |
+| `KafkaCodecs.Lz4Fory` | LZ4 compression + Fory serialization for trusted inputs |
 | `KafkaCodecs.SnappyKryo` | Snappy compression + Kryo serialization |
-| `KafkaCodecs.SnappyFory` | Snappy compression + Fory serialization |
+| `KafkaCodecs.SnappyFory` | Snappy compression + Fory serialization for trusted inputs |
 | `KafkaCodecs.ZstdKryo` | Zstd compression + Kryo serialization |
-| `KafkaCodecs.ZstdFory` | Zstd compression + Fory serialization |
+| `KafkaCodecs.ZstdFory` | Zstd compression + Fory serialization for trusted inputs |
+
+### Security: Fory Trust Boundary
+
+Fory-backed Kafka codecs are marked with `@BluetapeDelicateApi`. They use the
+default `ForyBinarySerializer`, which allows unregistered classes during
+deserialization. Opt in only for trusted topics and brokers. For shared or
+external inputs, prefer a custom codec backed by `ForyBinarySerializer.secureFory(...)`
+with explicit class registration.
+
+The same trust boundary applies if you subclass `BinaryKafkaCodec` directly with
+`BinarySerializers.Fory`, `LZ4Fory`, `SnappyFory`, or `ZstdFory`; those lower-level
+serializers do not add a Kafka-specific opt-in marker by themselves.
 
 ### Poison-pill Policy
 
@@ -165,7 +177,10 @@ It also widens the class-loading attack surface described below.
 If your consumer already knows the value type statically, disable the header:
 
 ```kotlin
-// Fory/Kryo codecs work safely without the header
+import io.bluetape4k.annotations.BluetapeDelicateApi
+
+// Fory/Kryo codecs do not need the value-type header
+@OptIn(BluetapeDelicateApi::class)
 class NoHeaderForyCodec : ForyKafkaCodec() {
     override val writeValueTypeHeader = false
 }
@@ -174,7 +189,7 @@ class NoHeaderForyCodec : ForyKafkaCodec() {
 > **Note for `JacksonKafkaCodec`:** Jackson uses the header to determine the target type at
 > deserialization time. Setting `writeValueTypeHeader = false` without also overriding
 > `doDeserialize` causes it to fall back to `LinkedHashMap` (silent type corruption).
-> Use `ForyKafkaCodec` or `KryoKafkaCodec` when you want to disable the header safely.
+> Use `ForyKafkaCodec` or `KryoKafkaCodec` when you want to disable the header.
 
 | `writeValueTypeHeader` | Effect |
 |------------------------|--------|

--- a/infra/kafka4/build.gradle.kts
+++ b/infra/kafka4/build.gradle.kts
@@ -22,6 +22,7 @@ configurations {
 
 dependencies {
     implementation(platform(libs.spring.boot.dependencies))
+    api(project(":bluetape4k-annotations"))
     api(project(":bluetape4k-core"))
     api(project(":bluetape4k-io"))
     compileOnly(project(":bluetape4k-resilience4j"))

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/BinaryKafkaCodecs.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.kafka.codec
 
+import io.bluetape4k.annotations.BluetapeDelicateApi
 import io.bluetape4k.io.serializer.BinarySerializer
 import io.bluetape4k.io.serializer.BinarySerializers
 import org.apache.kafka.common.header.Headers
@@ -41,7 +42,7 @@ abstract class BinaryKafkaCodec(
 class KryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.Kryo)
 
 /**
- * Fory 직렬화를 이용한 Kafka Codec
+ * Kafka codec backed by the default Fory binary serializer.
  *
  * ```kotlin
  * val codec = ForyKafkaCodec()
@@ -49,7 +50,15 @@ class KryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.Kryo)
  * val result = codec.deserialize("topic", null, bytes)
  * // result == "hello"
  * ```
+ *
+ * ## Security
+ *
+ * This codec uses `BinarySerializers.Fory`, whose default Fory configuration
+ * allows unregistered classes during deserialization. Use it only for trusted
+ * topics and brokers, or provide a codec backed by a class-registration-enforced
+ * `ForyBinarySerializer` for shared or external inputs.
  */
+@BluetapeDelicateApi
 class ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.Fory)
 
 /**
@@ -65,7 +74,7 @@ class ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.Fory)
 class LZ4KryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Kryo)
 
 /**
- * LZ4 압축 + Fory 직렬화를 이용한 Kafka Codec
+ * Kafka codec backed by LZ4 compression and the default Fory binary serializer.
  *
  * ```kotlin
  * val codec = LZ4ForyKafkaCodec()
@@ -73,7 +82,14 @@ class LZ4KryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Kryo)
  * val result = codec.deserialize("topic", null, bytes)
  * // result == "hello"
  * ```
+ *
+ * ## Security
+ *
+ * This codec uses `BinarySerializers.LZ4Fory`, which delegates to the default
+ * Fory serializer and allows unregistered classes during deserialization. Use
+ * it only for trusted topics and brokers.
  */
+@BluetapeDelicateApi
 class LZ4ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Fory)
 
 /**
@@ -89,7 +105,7 @@ class LZ4ForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.LZ4Fory)
 class SnappyKryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyKryo)
 
 /**
- * Snappy 압축 + Fory 직렬화를 이용한 Kafka Codec
+ * Kafka codec backed by Snappy compression and the default Fory binary serializer.
  *
  * ```kotlin
  * val codec = SnappyForyKafkaCodec()
@@ -97,7 +113,14 @@ class SnappyKryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyKryo)
  * val result = codec.deserialize("topic", null, bytes)
  * // result == "hello"
  * ```
+ *
+ * ## Security
+ *
+ * This codec uses `BinarySerializers.SnappyFory`, which delegates to the default
+ * Fory serializer and allows unregistered classes during deserialization. Use
+ * it only for trusted topics and brokers.
  */
+@BluetapeDelicateApi
 class SnappyForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyFory)
 
 /**
@@ -113,7 +136,7 @@ class SnappyForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.SnappyFory)
 class ZstdKryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.ZstdKryo)
 
 /**
- * Zstd 압축 + Fory 직렬화를 이용한 Kafka Codec
+ * Kafka codec backed by Zstd compression and the default Fory binary serializer.
  *
  * ```kotlin
  * val codec = ZstdForyKafkaCodec()
@@ -121,5 +144,12 @@ class ZstdKryoKafkaCodec: BinaryKafkaCodec(BinarySerializers.ZstdKryo)
  * val result = codec.deserialize("topic", null, bytes)
  * // result == "hello"
  * ```
+ *
+ * ## Security
+ *
+ * This codec uses `BinarySerializers.ZstdFory`, which delegates to the default
+ * Fory serializer and allows unregistered classes during deserialization. Use
+ * it only for trusted topics and brokers.
  */
+@BluetapeDelicateApi
 class ZstdForyKafkaCodec: BinaryKafkaCodec(BinarySerializers.ZstdFory)

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodecs.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodecs.kt
@@ -1,5 +1,7 @@
 package io.bluetape4k.kafka.codec
 
+import io.bluetape4k.annotations.BluetapeDelicateApi
+
 /**
  * 다양한 Kafka Codec 인스턴스를 제공하는 Object입니다.
  *
@@ -15,6 +17,7 @@ package io.bluetape4k.kafka.codec
  * val jacksonCodec = KafkaCodecs.Jackson
  *
  * // LZ4 압축 + Fory 직렬화 Codec 사용
+ * @OptIn(BluetapeDelicateApi::class)
  * val lz4ForyCodec = KafkaCodecs.Lz4Fory
  * ```
  *
@@ -30,14 +33,18 @@ object KafkaCodecs {
     val Jackson by lazy { JacksonKafkaCodec() }
 
     val Kryo by lazy { KryoKafkaCodec() }
+    @BluetapeDelicateApi
     val Fory by lazy { ForyKafkaCodec() }
 
     val Lz4Kryo by lazy { LZ4KryoKafkaCodec() }
+    @BluetapeDelicateApi
     val Lz4Fory by lazy { LZ4ForyKafkaCodec() }
 
     val SnappyKryo by lazy { SnappyKryoKafkaCodec() }
+    @BluetapeDelicateApi
     val SnappyFory by lazy { SnappyForyKafkaCodec() }
 
     val ZstdKryo by lazy { ZstdKryoKafkaCodec() }
+    @BluetapeDelicateApi
     val ZstdFory by lazy { ZstdForyKafkaCodec() }
 }

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/KafkaCodecTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/KafkaCodecTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.kafka.codec
 
+import io.bluetape4k.annotations.BluetapeDelicateApi
 import org.junit.jupiter.api.Nested
 
 class KafkaCodecTest {
@@ -17,6 +18,7 @@ class KafkaCodecTest {
     }
 
     @Nested
+    @OptIn(BluetapeDelicateApi::class)
     inner class ForyKafkaCodecTest: AbstractKafkaCodecTest() {
         override val codec: KafkaCodec<Any?> = KafkaCodecs.Fory
     }
@@ -27,6 +29,7 @@ class KafkaCodecTest {
     }
 
     @Nested
+    @OptIn(BluetapeDelicateApi::class)
     inner class Lz4ForyKafkaCodecTest: AbstractKafkaCodecTest() {
         override val codec: KafkaCodec<Any?> = KafkaCodecs.Lz4Fory
     }
@@ -37,6 +40,7 @@ class KafkaCodecTest {
     }
 
     @Nested
+    @OptIn(BluetapeDelicateApi::class)
     inner class SnappyForyKafkaCodecTest: AbstractKafkaCodecTest() {
         override val codec: KafkaCodec<Any?> = KafkaCodecs.SnappyFory
     }
@@ -47,6 +51,7 @@ class KafkaCodecTest {
     }
 
     @Nested
+    @OptIn(BluetapeDelicateApi::class)
     inner class ZstdForyKafkaCodecTest: AbstractKafkaCodecTest() {
         override val codec: KafkaCodec<Any?> = KafkaCodecs.ZstdFory
     }


### PR DESCRIPTION
## Summary

Closes #580

- PR 제목: fix: surface Fory Kafka deserialization trust boundaries

Fixes #580.

- Mark Fory-backed Kafka and Kafka4 codec classes with `@BluetapeDelicateApi`.
- Mark the matching `KafkaCodecs` registry properties so registry users see the same opt-in warning.
- Add `bluetape4k-annotations` as an API dependency for both Kafka modules.
- Document the trust boundary in KDoc, README/README.ko, CHANGELOG, and lessons.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- IntelliJ diagnostics: no problems in touched production codec files.
- `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka:compileTestKotlin :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka4:compileTestKotlin --continue --no-configuration-cache --max-workers=2`
- `./gradlew :bluetape4k-kafka:test --tests 'io.bluetape4k.kafka.codec.KafkaCodecTest' :bluetape4k-kafka4:test --tests 'io.bluetape4k.kafka.codec.KafkaCodecTest' --no-configuration-cache --max-workers=1`\n- `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka4:compileKotlin --no-configuration-cache --max-workers=2`\n\n## Not Tested\n\n- Full repository CI locally.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- Claude review artifact: initial P0/P1 review found three documentation issues.
- Claude rereview: P0/P1 = 0 after fixes.
- code-review-graph risk score: 0.30; runtime flow impact low.

## Metadata

- Issue: #580, milestone `1.9.0`, assignee debop
- PR: #599, head `e74ec2cd0c52befaaf6f3604da3828bbaaa8cf70`, milestone `1.9.0`, assignee debop
- Base: `develop`, head branch `fix/issue-580-fory-kafka-delicate`
- Labels: `security`, `infra/io`
- State: `MERGED`, merge commit `bee07112218469c9520c42a4435678043d80dd80`
- CI: - `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka:compileTestKotlin :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka4:compileTestKotlin --continue --no-configuration-cache --max-workers=2` / - `./gradlew :bluetape4k-kafka:test --tests 'io.bluetape4k.kafka.codec.KafkaCodecTest' :bluetape4k-kafka4:test --tests 'io.bluetape4k.kafka.codec.KafkaCodecTest' --no-configuration-cache --max-workers=1`\n- `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka4:compileKotlin --no-configuration-cache --max-workers=2`\n\n## Not Tested\n\n- Full repository CI locally.## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #599 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `bee07112218469c9520c42a4435678043d80dd80`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
