### PR TITLE
fix: bound Memgraph driver shutdown in nightly test

### DIFF
--- a/docs/lessons/2026-05-22-issue-602-memgraph-driver-close-timeout.md
+++ b/docs/lessons/2026-05-22-issue-602-memgraph-driver-close-timeout.md
@@ -1,0 +1,37 @@
+# Lessons Learned - Issue 602 Memgraph Driver Close Timeout (2026-05-22)
+
+**Related issue**: #602
+**Affected module**: `:bluetape4k-testcontainers`
+
+## Context
+
+Full Nightly for the 1.9.0 release candidate repeatedly timed out in
+`MemgraphServerTest` after a successful Bolt query path. The failing stack was
+inside Neo4j Java Driver `Driver.close()`, not container startup.
+
+## Decision
+
+Keep the Memgraph image and Neo4j driver versions pinned because the repository
+already uses the current release line at the time of investigation:
+`memgraph/memgraph:3.9.0`, `neo4j-java-driver:6.1.0`, and
+`neo4j-bolt-connection-netty:11.0.2`.
+
+For Memgraph compatibility tests, constrain the driver to a single connection
+pool/event-loop, disable telemetry and auto-commit retries, and close the driver
+through `closeAsync()` with a bounded timeout. The test's release-gate assertion
+remains the successful Bolt query; cleanup must not hang the nightly runner
+indefinitely.
+
+## Verification
+
+- `./gradlew :bluetape4k-testcontainers:test --tests io.bluetape4k.testcontainers.graphdb.MemgraphServerTest --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1`
+  - Result: `BUILD SUCCESSFUL`, 6 passing.
+- `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.graphdb.*' --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1`
+  - Result: `BUILD SUCCESSFUL`, 27 passing.
+
+## Future Guidance
+
+When a Testcontainers-backed driver test proves connectivity but hangs during
+client cleanup, inspect the close stack before changing container readiness.
+Prefer bounded cleanup around the affected client in tests over widening global
+timeouts.

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/graphdb/MemgraphServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/graphdb/MemgraphServerTest.kt
@@ -1,12 +1,14 @@
 package io.bluetape4k.testcontainers.graphdb
 
-import io.bluetape4k.logging.KLogging
-import io.bluetape4k.logging.debug
-import io.bluetape4k.testcontainers.AbstractContainerTest
 import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
+import io.bluetape4k.testcontainers.AbstractContainerTest
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -16,8 +18,11 @@ import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Config
+import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 @TestInstance(Lifecycle.PER_CLASS)
 @Timeout(value = 5, unit = TimeUnit.MINUTES, threadMode = SEPARATE_THREAD)
@@ -59,22 +64,18 @@ class MemgraphServerTest: AbstractContainerTest() {
     @Test
     @Timeout(value = 3, unit = TimeUnit.MINUTES, threadMode = SEPARATE_THREAD)
     fun `Neo4j Driver로 Bolt 연결 후 쿼리를 실행할 수 있어야 한다`() {
-        val config = Config.builder()
-            .withConnectionTimeout(10, TimeUnit.SECONDS)
-            .withConnectionAcquisitionTimeout(10, TimeUnit.SECONDS)
-            .withConnectionLivenessCheckTimeout(5, TimeUnit.SECONDS)
-            .withMaxTransactionRetryTime(5, TimeUnit.SECONDS)
-            .build()
-
-        GraphDatabase.driver(memgraph.boltUrl, AuthTokens.none(), config).use { driver ->
+        val driver = GraphDatabase.driver(memgraph.boltUrl, AuthTokens.none(), memgraphDriverConfig())
+        try {
             driver.verifyConnectivity()
             driver.session().use { session ->
                 val result = session.run("RETURN 1 AS n")
                 val record = result.single()
                 val value = record["n"].asInt()
                 log.debug { "RETURN 1 AS n => $value" }
-                require(value == 1) { "예상 결과는 1이지만 실제 값은 $value 입니다." }
+                value shouldBeEqualTo 1
             }
+        } finally {
+            driver.closeWithin(10, TimeUnit.SECONDS)
         }
     }
 
@@ -86,5 +87,35 @@ class MemgraphServerTest: AbstractContainerTest() {
     @Test
     fun `blank tag 는 허용하지 않는다`() {
         assertFailsWith<IllegalArgumentException> { MemgraphServer(tag = " ") }
+    }
+
+    private fun memgraphDriverConfig(): Config =
+        Config.builder()
+            .withoutEncryption()
+            .withTelemetryDisabled(true)
+            .withAutoCommitRetriesDisabled(true)
+            // Issue #602: keep Memgraph Bolt test shutdown surface minimal on GitHub Ubuntu runners.
+            .withEventLoopThreads(1)
+            .withMaxConnectionPoolSize(1)
+            .withConnectionTimeout(10, TimeUnit.SECONDS)
+            .withConnectionAcquisitionTimeout(10, TimeUnit.SECONDS)
+            .withConnectionLivenessCheckTimeout(5, TimeUnit.SECONDS)
+            .withMaxTransactionRetryTime(5, TimeUnit.SECONDS)
+            .build()
+
+    private fun Driver.closeWithin(timeout: Long, unit: TimeUnit) {
+        val closeFuture = closeAsync().toCompletableFuture()
+        try {
+            closeFuture.get(timeout, unit)
+        } catch (e: TimeoutException) {
+            // Memgraph compatibility is verified by the query; do not let driver shutdown hang Nightly.
+            closeFuture.cancel(true)
+            log.warn(e) { "Neo4j Driver close timed out after Memgraph query verification." }
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        } catch (e: ExecutionException) {
+            log.warn(e) { "Neo4j Driver close failed after Memgraph query verification." }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #602

- PR 제목: fix: bound Memgraph driver shutdown in nightly test

### 원문 선행 내용

Fixes #602

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Confirmed there is no newer practical upgrade target: the repo already uses Memgraph 3.9.0, Neo4j Java Driver 6.1.0, and Bolt Netty 11.0.2.
- Kept the Memgraph Bolt query assertion strict while minimizing Neo4j driver shutdown work for this compatibility test.
- Replaced blocking `Driver.close()` use with bounded `closeAsync()` cleanup so Full Nightly cannot hang indefinitely after successful query verification.
- Added a lessons entry for the 1.9.0 release-candidate failure mode.

### 기존 섹션: DoD checklist

- [x] Issue assigned to 1.9.0 milestone: #602
- [x] Targeted Memgraph test passed: `./gradlew :bluetape4k-testcontainers:test --tests io.bluetape4k.testcontainers.graphdb.MemgraphServerTest --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1`
- [x] GraphDB Testcontainers slice passed: `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.graphdb.*' --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1`\n- [x] `git diff --check` passed\n- [x] Claude advisor review artifact produced; P0/P1 = 0. A final rerun after P2 cleanup was blocked by Claude session limit, but all P2 code comments were addressed locally.\n- [x] README locale sync: N/A, test-only behavior change\n\n## Release note\nThis should unblock the 1.9.0 Full Nightly release gate that timed out at `MemgraphServerTest` / Neo4j `Driver.close()`.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #602, milestone `1.9.0`, assignee debop
- PR: #604, head `79048c6539a5613d5c17694c4f4fd6afc034e0d5`, milestone `1.9.0`, assignee debop
- Base: `develop`, head branch `fix/issue-602-memgraph-bolt-timeout`
- Labels: `bug`, `test`, `ci`
- State: `MERGED`, merge commit `b54e0732bce64643ea52b789a73c3bd93e9e253f`
- CI: - [x] Targeted Memgraph test passed: `./gradlew :bluetape4k-testcontainers:test --tests io.bluetape4k.testcontainers.graphdb.MemgraphServerTest --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1` / - [x] GraphDB Testcontainers slice passed: `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.graphdb.*' --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1`\n- [x] `git diff --check` passed\n- [x] Claude advisor review artifact produced; P0/P1 = 0. A final rerun after P2 cleanup was blocked by Claude session limit, but all P2 code comments were addressed locally.\n- [x] README locale sync: N/A, test-only behavior change\n\n## Release note\nThis should unblock the 1.9.0 Full Nightly release gate that timed out at `MemgraphServerTest` / Neo4j `Driver.close()`.## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #604 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `b54e0732bce64643ea52b789a73c3bd93e9e253f`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
