### PR TITLE
chore: open 1.10.0 development cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Check `gradle.properties` for the current version:
 
 ```properties
 projectGroup=io.github.bluetape4k
-baseVersion=1.9.0
+baseVersion=1.10.0
 snapshotVersion=
 ```
 

--- a/WIP.md
+++ b/WIP.md
@@ -6,9 +6,9 @@ Open count: 6 issues.
 
 ## Refresh Notes
 
-Verified with `gh issue list --state open --assignee debop` on 2026-05-22 KST.
-All remaining open assigned issues are in the `backlog` milestone. The `1.9.0`
-milestone has no open issues.
+Verified with `gh issue list --state open --assignee debop` on 2026-05-22 KST
+after closing duplicate issue `#603`. All remaining open assigned issues are in
+the `backlog` milestone. The `1.9.0` milestone has no open issues.
 
 ## Recently Completed
 
@@ -16,18 +16,21 @@ milestone has no open issues.
 - `#474` removed deprecated Kafka, OpenTelemetry, cache, Redis, and Resilience4j aliases for the 1.9.0 breaking-change line.
 - `#596` added a reusable `EtcdServer` Testcontainers launcher.
 - `#595` fixed the Nightly failures in IO HTTP, Elasticsearch-backed search messaging, and Memgraph-backed graph tests.
+- `#602` / PR #604 stabilized the Memgraph Bolt nightly test, Full Nightly
+  passed, and the `1.9.0` release workflow completed successfully.
 - `#580` marked Fory-backed Kafka/Kafka4 codecs as `@BluetapeDelicateApi` and documented the deserialization trust boundary.
 - PR #600 prepared the source version for `1.9.0-SNAPSHOT`, and the snapshot publish workflow completed successfully.
 
 ## Current Direction
 
-The repository is in the 1.9.0 release-prep lane. Do not start backlog feature
-work until the release is tagged, Maven Central propagation is verified, and the
-post-release snapshot bump PR is created.
+The repository is in the post-1.9.0 cleanup lane. Open the next development
+cycle by moving the committed base version to `1.10.0`; keep
+`snapshotVersion=` empty in `gradle.properties` and pass
+`-PsnapshotVersion=-SNAPSHOT` only for SNAPSHOT publishing.
 
-After 1.9.0, resume the IO HTTP performance/design backlog. Prioritize API and
-architecture decisions before benchmark polish so later performance work does
-not lock in the wrong client surface.
+After the snapshot bump PR lands, resume the IO HTTP performance/design backlog.
+Prioritize API and architecture decisions before benchmark polish so later
+performance work does not lock in the wrong client surface.
 
 ## Priority Queue
 
@@ -57,7 +60,7 @@ not lock in the wrong client surface.
 
 | Lane | Limit | Current next |
 |---|---:|---|
-| Release prep | 1 | Finish 1.9.0 release, Central verification, and next snapshot bump. |
+| Release prep | 1 | Done; keep only post-release snapshot bump and Central propagation checks. |
 | IO HTTP API/design | 1 | `#586` first. |
 | IO HTTP feature | 1 | `#582`, then `#583`. |
 | IO HTTP performance | 1 | `#589` umbrella; execute `#584/#585` after design decisions. |
@@ -66,6 +69,6 @@ not lock in the wrong client surface.
 
 | Candidate | Action |
 |---|---|
-| `1.9.0` milestone | Keep closed; do not add backlog IO HTTP work to this release. |
+| `1.9.0` milestone | Keep closed; duplicate `#603` was closed after PR #604 and the release workflow succeeded. |
 | `backlog` milestone | Keep `#582/#583/#584/#585/#586/#589` open for the next development lane. |
 | release worktrees | Remove release-prep worktrees after PR merge and final verification. |

--- a/docs/lessons/2026-05-22-1-10-0-post-release-snapshot.md
+++ b/docs/lessons/2026-05-22-1-10-0-post-release-snapshot.md
@@ -1,0 +1,18 @@
+# 2026-05-22 1.10.0 Post-Release Snapshot
+
+Context: The `1.9.0` tag, Full Nightly gate, Publish Release workflow, and
+GitHub release all completed successfully. A duplicate Memgraph nightly issue
+remained open after the release.
+
+Decision: Close the duplicate issue and move the committed base version to
+`1.10.0` for the next development cycle. Keep `snapshotVersion=` empty in
+`gradle.properties`; SNAPSHOT publishing must pass `-PsnapshotVersion=-SNAPSHOT`.
+
+Outcome: `develop` can resume backlog work against the next minor line without
+changing the release/snapshot versioning contract.
+
+Verification: Check Gradle project version with and without
+`-PsnapshotVersion=-SNAPSHOT`, then confirm the post-release PR checks.
+
+Future guard: Do not reopen release work for backlog IO HTTP issues; start from
+`#586` after the snapshot bump reaches `develop`.

--- a/docs/lessons/2026-05-22-1-9-0-snapshot-version.md
+++ b/docs/lessons/2026-05-22-1-9-0-snapshot-version.md
@@ -4,11 +4,12 @@ Context: The 1.9.0 milestone had no remaining open issues, and the next step was
 to publish a Maven Central SNAPSHOT from `develop`.
 
 Decision: Move `baseVersion` from `1.8.1` to `1.9.0` before publishing, keeping
-`snapshotVersion=-SNAPSHOT` as the default.
+`snapshotVersion=` empty in committed properties and passing
+`-PsnapshotVersion=-SNAPSHOT` only for SNAPSHOT publishing.
 
 Outcome: Snapshot publishing can use the normal
 `publishAggregationToCentralSnapshots` workflow and produce `1.9.0-SNAPSHOT`
-artifacts from a reproducible commit.
+artifacts from a reproducible commit when the SNAPSHOT suffix property is set.
 
 Verification: Check Gradle project version and GitHub Publish Snapshot workflow
 after the version bump reaches `develop`.

--- a/gradle.properties
+++ b/gradle.properties
@@ -76,5 +76,5 @@ centralSnapshotsParallelism=8
 # project version
 #
 projectGroup=io.github.bluetape4k
-baseVersion=1.9.0
+baseVersion=1.10.0
 snapshotVersion=


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: chore: open 1.10.0 development cycle

- Move the committed base version from 1.9.0 to 1.10.0 after the successful 1.9.0 release.
- Refresh README/WIP release state and close the duplicate Memgraph nightly issue (#603) as resolved by #604.
- Correct the snapshot version lesson to match the committed empty suffix plus explicit SNAPSHOT publishing override contract.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary
- Move the committed base version from 1.9.0 to 1.10.0 after the successful 1.9.0 release.
- Refresh README/WIP release state and close the duplicate Memgraph nightly issue (#603) as resolved by #604.
- Correct the snapshot version lesson to match the committed empty suffix plus explicit SNAPSHOT publishing override contract.

### Validation
- `./gradlew properties --no-configuration-cache --no-daemon --quiet` => `version: 1.10.0`
- `./gradlew properties -PsnapshotVersion=-SNAPSHOT --no-configuration-cache --no-daemon --quiet` => `version: 1.10.0-SNAPSHOT`
- `git diff --check`
- `gh issue list --state open --assignee debop` shows only six backlog issues (#582, #583, #584, #585, #586, #589)

### DoD
- [x] Version source updated
- [x] README/WIP refreshed
- [x] Lesson captured
- [x] Duplicate release issue closed
- [x] Lightweight verification completed

## Validation

- `./gradlew properties --no-configuration-cache --no-daemon --quiet` => `version: 1.10.0`
- `./gradlew properties -PsnapshotVersion=-SNAPSHOT --no-configuration-cache --no-daemon --quiet` => `version: 1.10.0-SNAPSHOT`
- `git diff --check`
- `gh issue list --state open --assignee debop` shows only six backlog issues (#582, #583, #584, #585, #586, #589)

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #605, head `0b3d79ea25dd8e4677da1331be52103517509af6`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `chore/open-1.10.0-snapshot`
- Labels: `documentation`, `chore`, `release`
- State: `CLOSED`, merge commit `N/A`
- CI: - Correct the snapshot version lesson to match the committed empty suffix plus explicit SNAPSHOT publishing override contract. / - `./gradlew properties --no-configuration-cache --no-daemon --quiet` => `version: 1.10.0` / - `./gradlew properties -PsnapshotVersion=-SNAPSHOT --no-configuration-cache --no-daemon --quiet` => `version: 1.10.0-SNAPSHOT`

## DoD Status

- [x] Version source updated
- [x] README/WIP refreshed
- [x] Lesson captured
- [x] Duplicate release issue closed
- [x] Lightweight verification completed

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #605 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: CLOSED (not merged; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
