### PR TITLE
[feat] Add UTF-8 byte-safe string truncation

### DIFF
--- a/bluetape4k/core/README.ko.md
+++ b/bluetape4k/core/README.ko.md
@@ -26,6 +26,7 @@ Kotlin Backend 개발을 위한 핵심 유틸리티 라이브러리입니다. Bl
 
 - **Validation (RequireSupport)**: 파라미터 검증을 위한 Contract 기반 함수들
 - **Encoding/Decoding (Codec)**: Base58, Base62, Hex, URL62 등 다양한 인코딩
+- **String Support**: UTF-8 바이트 변환과 바이트 경계 안전 `truncateUtf8(maxBytes)`
 - **Type Extensions**: 모든 기본 타입에 대한 Kotlin 스타일 확장 함수
 - **Ranges**: 다양한 Range 타입 (OpenOpen, ClosedOpen, OpenClosed, ClosedClosed)
 - **Collections**: 컬렉션 유틸리티 (BoundedStack, RingBuffer, PaginatedList, Permutation 지연 평가 순열)

--- a/bluetape4k/core/README.md
+++ b/bluetape4k/core/README.md
@@ -26,6 +26,7 @@ A foundational utility library for Kotlin backend development. It provides the c
 
 - **Validation (RequireSupport)**: Contract-based parameter validation functions
 - **Encoding/Decoding (Codec)**: Multiple encoding schemes — Base58, Base62, Hex, URL62
+- **String Support**: UTF-8 byte conversion and byte-safe `truncateUtf8(maxBytes)`
 - **Type Extensions**: Kotlin-style extension functions for all primitive types
 - **Ranges**: Various range types (OpenOpen, ClosedOpen, OpenClosed, ClosedClosed)
 - **Collections**: Collection utilities — BoundedStack, RingBuffer, PaginatedList, lazy Permutation sequences

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/StringSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/StringSupport.kt
@@ -223,6 +223,34 @@ fun String.toUtf8Bytes(): ByteArray = toByteArray(UTF_8)
 fun ByteArray.toUtf8String(): String = toString(UTF_8)
 
 /**
+ * Truncates this string to at most [maxBytes] UTF-8 encoded bytes.
+ *
+ * ## Behavior / Contract
+ * The truncation point is aligned to a valid UTF-8 character boundary, so the
+ * returned value never contains an incomplete multi-byte sequence. Grapheme
+ * cluster boundaries are out of scope: a multi-codepoint grapheme may be split
+ * when it crosses the byte limit.
+ *
+ * [maxBytes] must be greater than or equal to zero.
+ *
+ * ```kotlin
+ * "Hello, 세계".truncateUtf8(8) // "Hello, "
+ * "abc".truncateUtf8(100)      // "abc"
+ * ```
+ */
+fun String.truncateUtf8(maxBytes: Int): String {
+    maxBytes.requireGe(0, "maxBytes")
+    val bytes = toUtf8Bytes()
+    if (bytes.size <= maxBytes) return this
+
+    var cutoff = maxBytes
+    while (cutoff > 0 && (bytes[cutoff].toInt() and 0xC0) == 0x80) {
+        cutoff--
+    }
+    return String(bytes, 0, cutoff, UTF_8)
+}
+
+/**
  * 문자열을 UTF-8 인코딩의 [ByteBuffer]로 변환합니다.
  *
  * ## 동작/계약

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/StringSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/StringSupportTest.kt
@@ -119,6 +119,54 @@ class StringSupportTest: AbstractCoreTest() {
     }
 
     @Test
+    fun `truncate utf8 does not split multi byte characters`() {
+        val input = "Hello, 세계"
+
+        val truncated = input.truncateUtf8(8)
+        val bytes = truncated.toUtf8Bytes()
+
+        bytes.size shouldBeLessOrEqualTo 8
+        truncated shouldBeEqualTo "Hello, "
+        bytes.toUtf8String() shouldBeEqualTo truncated
+    }
+
+    @Test
+    fun `truncate utf8 returns original string when it already fits`() {
+        val input = "abc"
+
+        input.truncateUtf8(100) shouldBeEqualTo input
+    }
+
+    @Test
+    fun `truncate utf8 allows exact byte boundary`() {
+        val input = "세계"
+
+        input.truncateUtf8(3) shouldBeEqualTo "세"
+        input.truncateUtf8(6) shouldBeEqualTo input
+    }
+
+    @Test
+    fun `truncate utf8 handles supplementary plane code points`() {
+        val input = "😀"
+
+        input.truncateUtf8(3) shouldBeEqualTo EMPTY_STRING
+        input.truncateUtf8(4) shouldBeEqualTo input
+    }
+
+    @Test
+    fun `truncate utf8 returns empty string when max bytes is zero`() {
+        "abc".truncateUtf8(0) shouldBeEqualTo EMPTY_STRING
+        "세".truncateUtf8(0) shouldBeEqualTo EMPTY_STRING
+    }
+
+    @Test
+    fun `truncate utf8 rejects negative max bytes`() {
+        assertFailsWith<IllegalArgumentException> {
+            "abc".truncateUtf8(-1)
+        }
+    }
+
+    @Test
     fun `convert string to utf8 byte buffer and back`() {
         emptyValue.toUtf8ByteBuffer().toUtf8String() shouldBeEqualTo emptyValue
         blankValue.toUtf8ByteBuffer().toUtf8String() shouldBeEqualTo blankValue

--- a/docs/lessons/2026-05-23-string-truncate-utf8-support.md
+++ b/docs/lessons/2026-05-23-string-truncate-utf8-support.md
@@ -1,0 +1,24 @@
+# Lesson: Promote byte-safe UTF-8 truncation through bluetape4k-core first
+
+**Date**: 2026-05-23
+**Related**: bluetape4k-leader#270
+
+## Context
+
+`bluetape4k-leader` has an internal `String.truncateUtf8(maxBytes)` helper for
+history error-message truncation. The helper is general-purpose and belongs in
+the shared support package, but downstream repositories cannot safely consume it
+until the public API is present in a published `bluetape4k-core` artifact.
+
+## Decision
+
+Add `io.bluetape4k.support.truncateUtf8(maxBytes)` to `bluetape4k-core` with
+the same byte-boundary contract as the leader-internal implementation. Keep the
+API small: no ellipsis, no grapheme-cluster guarantees, and no nullable receiver
+overload.
+
+## Follow-up
+
+After this API is released in the BOM version consumed by `bluetape4k-leader`,
+the leader repository can remove its internal copy and import the shared support
+function without breaking CI on a missing Maven Central symbol.


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: [feat] Add UTF-8 byte-safe string truncation

Refs bluetape4k/bluetape4k-leader#270.

- Adds `io.bluetape4k.support.truncateUtf8(maxBytes)` to `bluetape4k-core`.
- Preserves UTF-8 character boundaries when truncating by encoded byte length.
- Documents the intentionally byte-oriented contract in KDoc and the core README pair.
- Adds targeted coverage for multi-byte, supplementary-plane, exact-boundary, zero, no-op, and negative limit cases.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Review Gate

- Codex 6-Tier review: P0=0, P1=0
- Claude Code 6-Tier review rerun: P0=0, P1=0, P2=0, P3=0
- Claude artifact: `.omx/artifacts/claude-string-truncate-utf8-review-rerun-20260523030633.md`

### 기존 섹션: Downstream Note

`bluetape4k-leader` can remove its internal `StringTruncateSupport` copy only after this API is available in the BOM version consumed by leader. Until then, changing leader would break CI against the published artifact.

## Validation

- `./gradlew :bluetape4k-core:compileKotlin :bluetape4k-core:compileTestKotlin --no-daemon --console=plain` -> BUILD SUCCESSFUL
- `./gradlew :bluetape4k-core:test --tests 'io.bluetape4k.support.StringSupportTest' --no-daemon --console=plain` -> BUILD SUCCESSFUL, 62 tests passed
- `git diff --check` -> pass

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #606, head `44705011f518513e1a2a6d4f2c57f42594795a8b`, milestone `없음`, assignee debop
- Base: `develop`, head branch `feat/string-truncate-utf8`
- Labels: 없음
- State: `MERGED`, merge commit `66630f6bf475683a89bf2c00b87cea08cfdf2526`
- CI: - `./gradlew :bluetape4k-core:compileKotlin :bluetape4k-core:compileTestKotlin --no-daemon --console=plain` -> BUILD SUCCESSFUL / - `./gradlew :bluetape4k-core:test --tests 'io.bluetape4k.support.StringSupportTest' --no-daemon --console=plain` -> BUILD SUCCESSFUL, 62 tests passed / `bluetape4k-leader` can remove its internal `StringTruncateSupport` copy only after this API is available in the BOM version consumed by leader. Until then, changing leader would break CI against the published artifact.## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #606 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `66630f6bf475683a89bf2c00b87cea08cfdf2526`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
