### PR TITLE
build: consume Fory through the ecosystem catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,6 +81,15 @@ allprojects {
 val rootLibs = libs
 val rootBt4k = bt4k
 
+val bt4kCatalog = extensions.getByType<org.gradle.api.artifacts.VersionCatalogsExtension>().named("bt4k")
+fun bt4kVersion(alias: String): String {
+    val version = bt4kCatalog.findVersion(alias).get()
+    return version.requiredVersion
+        .ifBlank { version.preferredVersion }
+        .ifBlank { version.strictVersion }
+}
+
+
 fun Project.isSampleOrBenchmarkProject(): Boolean {
     val relativeProjectDir = rootDir.toPath()
         .relativize(projectDir.toPath())
@@ -443,7 +452,7 @@ subprojects {
             dependency(rootLibs.guava.get().toString())
 
             dependency(rootLibs.kryo.get().toString())
-            dependency(rootBt4k.fory.kotlin.get().toString())
+            dependency("org.apache.fory:fory-kotlin:${bt4kVersion("fory-kotlin")}")
 
             // HINT: Jackson (이상하게 mavenBom 에 적용이 안되어서 강제로 추가하였다)
             dependency(rootLibs.jackson.bom.get().toString())

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,6 +79,7 @@ allprojects {
 // Capture root-project catalog reference once; used inside subprojects {} closures
 // where `libs` is not in scope (different receiver type in the lambda).
 val rootLibs = libs
+val rootBt4k = bt4k
 
 fun Project.isSampleOrBenchmarkProject(): Boolean {
     val relativeProjectDir = rootDir.toPath()
@@ -442,6 +443,7 @@ subprojects {
             dependency(rootLibs.guava.get().toString())
 
             dependency(rootLibs.kryo.get().toString())
+            dependency(rootBt4k.fory.kotlin.get().toString())
 
             // HINT: Jackson (이상하게 mavenBom 에 적용이 안되어서 강제로 추가하였다)
             dependency(rootLibs.jackson.bom.get().toString())

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,8 +79,6 @@ allprojects {
 // Capture root-project catalog reference once; used inside subprojects {} closures
 // where `libs` is not in scope (different receiver type in the lambda).
 val rootLibs = libs
-val rootBt4k = bt4k
-
 val bt4kCatalog = extensions.getByType<org.gradle.api.artifacts.VersionCatalogsExtension>().named("bt4k")
 fun bt4kVersion(alias: String): String {
     val version = bt4kCatalog.findVersion(alias).get()

--- a/docs/lessons/2026-05-23-bt4k-version-catalog-consumption.md
+++ b/docs/lessons/2026-05-23-bt4k-version-catalog-consumption.md
@@ -1,0 +1,34 @@
+# bt4k Version Catalog Consumption
+
+## Context
+
+`bluetape4k-projects` carried centrally governed versions directly in its local
+catalog. Fory was one example: the approved version already existed in the
+`bluetape4k-dependencies` published catalog, but the projects repository still
+needed a local catalog edit to consume it.
+
+## Decision
+
+Import `io.github.bluetape4k:bluetape4k-version-catalog` as the `bt4k` Gradle
+version catalog and use it as the source for centrally governed dependency
+versions. Keep local `libs` aliases for project-local coordinates, but remove
+the direct Fory version from `libs`.
+
+## Outcome
+
+`libs.fory.kotlin` is now versionless. The managed Fory version is supplied by
+dependency management from `bt4k.fory.kotlin`, so future Fory version changes
+start in `bluetape4k-dependencies`.
+
+## Verification
+
+- `./gradlew help --no-daemon --no-configuration-cache`
+- `./gradlew :bluetape4k-io:dependencyInsight --configuration compileClasspath --dependency org.apache.fory:fory-kotlin --no-daemon --no-configuration-cache`
+- `./gradlew :bluetape4k-io:compileKotlin --no-daemon --no-configuration-cache`
+
+## Future Guidance
+
+When a version is governed by `bluetape4k-dependencies`, prefer reading it from
+the `bt4k` catalog instead of editing `bluetape4k-projects` local versions.
+Avoid importing the full `bluetape4k-dependencies` BOM into this repository
+unless the publishing-cycle implications are reviewed.

--- a/docs/lessons/2026-05-23-bt4k-version-catalog-consumption.md
+++ b/docs/lessons/2026-05-23-bt4k-version-catalog-consumption.md
@@ -17,14 +17,15 @@ the direct Fory version from `libs`.
 ## Outcome
 
 `libs.fory.kotlin` is now versionless. The managed Fory version is supplied by
-dependency management from `bt4k.fory.kotlin`, so future Fory version changes
-start in `bluetape4k-dependencies`.
+dependency management through the `bt4kVersion("fory-kotlin")` catalog lookup,
+so future Fory version changes start in `bluetape4k-dependencies`.
 
 ## Verification
 
 - `./gradlew help --no-daemon --no-configuration-cache`
 - `./gradlew :bluetape4k-io:dependencyInsight --configuration compileClasspath --dependency org.apache.fory:fory-kotlin --no-daemon --no-configuration-cache`
 - `./gradlew :bluetape4k-io:compileKotlin --no-daemon --no-configuration-cache`
+- `./gradlew compileKotlin --no-daemon --no-configuration-cache`
 
 ## Future Guidance
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -69,6 +69,9 @@ kotlinx.atomicfu.jvm.languageLevel=21
 # Publish Signing
 signing.gnupg.executable=/opt/homebrew/bin/gpg
 
+# Shared bluetape4k ecosystem catalog/BOM version
+bluetape4kDependenciesVersion=1.1.1
+
 # Maven Central Snapshots publish parallelism (NMCP default: 8)
 centralSnapshotsParallelism=8
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -329,7 +329,7 @@ jctools-core = { module = "org.jctools:jctools-core", version.ref = "jctools" }
 
 kryo = { module = "com.esotericsoftware:kryo", version = "5.6.2" }  # https://mvnrepository.com/artifact/com.esotericsoftware/kryo
 kryo5 = { module = "com.esotericsoftware:kryo", version = "5.6.2" }  # https://mvnrepository.com/artifact/com.esotericsoftware/kryo
-fory-kotlin = { module = "org.apache.fory:fory-kotlin", version = "0.17.0" }  # https://mvnrepository.com/artifact/org.apache.fory/fory-kotlin
+fory-kotlin = { module = "org.apache.fory:fory-kotlin" }  # version from bt4k catalog
 
 # Spring Boot
 spring-boot-dependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,20 @@ pluginManagement {
     }
 }
 
+val bluetape4kDependenciesVersion = providers.gradleProperty("bluetape4kDependenciesVersion").get()
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
+    }
+    versionCatalogs {
+        create("bt4k") {
+            from("io.github.bluetape4k:bluetape4k-version-catalog:$bluetape4kDependenciesVersion")
+        }
+    }
+}
+
 val projectName = "bluetape4k"
 
 rootProject.name = "$projectName-projects"


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: build: consume Fory through the ecosystem catalog

- Import the shared `bluetape4k-version-catalog` as `bt4k`.
- Resolve the local Fory dependency version from `bt4kVersion("fory-kotlin")` instead of pinning it in `libs.versions.toml`.
- Record the catalog migration boundary and verification evidence in `docs/lessons`.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- `git diff --check`
- `./gradlew help --no-daemon --no-configuration-cache`
- `./gradlew :bluetape4k-io:dependencyInsight --configuration compileClasspath --dependency org.apache.fory:fory-kotlin --no-daemon --no-configuration-cache`
- `./gradlew :bluetape4k-io:compileKotlin --no-daemon --no-configuration-cache`
- `./gradlew compileKotlin --no-daemon --no-configuration-cache`

### 기존 섹션: Notes

- Remaining local duplicate train versions are kept where plugin/BOM resolution still depends on local aliases; migrate those in a dedicated build-script cleanup after central plugin aliases are available.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #621, head `f62b478e17155019179c8daa146460cb8481339c`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `chore/use-bt4k-version-catalog`
- Labels: `build`, `dependencies`, `release`
- State: `MERGED`, merge commit `b33176b8a2734c1213e9d57b1e9f38c278c7c5d8`
- CI: - `./gradlew help --no-daemon --no-configuration-cache` / - `./gradlew :bluetape4k-io:dependencyInsight --configuration compileClasspath --dependency org.apache.fory:fory-kotlin --no-daemon --no-configuration-cache` / - `./gradlew :bluetape4k-io:compileKotlin --no-daemon --no-configuration-cache`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #621 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `b33176b8a2734c1213e9d57b1e9f38c278c7c5d8`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
