### PR TITLE
build: prepare projects 1.9.1 catalog source

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -69,8 +69,7 @@ kotlinx.atomicfu.jvm.languageLevel=21
 # Publish Signing
 signing.gnupg.executable=/opt/homebrew/bin/gpg
 
-# Shared bluetape4k ecosystem catalog/BOM version
-bluetape4kDependenciesVersion=1.1.1
+# Shared bluetape4k ecosystem catalog version
 
 # Maven Central Snapshots publish parallelism (NMCP default: 8)
 centralSnapshotsParallelism=8

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,41 @@ pluginManagement {
     }
 }
 
-val bluetape4kDependenciesVersion = providers.gradleProperty("bluetape4kDependenciesVersion").get()
+val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
+    .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
+    .orElse("develop")
+    .get()
+
+fun resolveBluetape4kDependenciesCatalogFile(): File {
+    providers.gradleProperty("bluetape4kDependenciesCatalogPath")
+        .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_PATH"))
+        .orNull
+        ?.let(::file)
+        ?.let { return it }
+
+    listOf(
+        "../bluetape4k-dependencies/gradle/libs.versions.toml",
+        "bluetape4k-dependencies/gradle/libs.versions.toml",
+    ).map(::file).firstOrNull { it.isFile }?.let { return it }
+
+    val catalogFile = file(".gradle/bluetape4k-dependencies/libs.versions.toml")
+    if (!catalogFile.isFile) {
+        catalogFile.parentFile.mkdirs()
+        val catalogUrl =
+            "https://raw.githubusercontent.com/bluetape4k/bluetape4k-dependencies/$bluetape4kDependenciesCatalogRef/gradle/libs.versions.toml"
+        uri(catalogUrl).toURL().openStream().use { input ->
+            catalogFile.outputStream().use { output -> input.copyTo(output) }
+        }
+    }
+    return catalogFile
+}
+
+val bluetape4kDependenciesCatalogFile = resolveBluetape4kDependenciesCatalogFile()
+
+require(bluetape4kDependenciesCatalogFile.isFile) {
+    "bluetape4k-dependencies catalog not found: $bluetape4kDependenciesCatalogFile. " +
+        "Checkout bluetape4k-dependencies at the release-train tag or set bluetape4kDependenciesCatalogPath."
+}
 
 dependencyResolutionManagement {
     repositories {
@@ -19,7 +53,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("bt4k") {
-            from("io.github.bluetape4k:bluetape4k-version-catalog:$bluetape4kDependenciesVersion")
+            from(files(bluetape4kDependenciesCatalogFile))
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #620

- PR 제목: build: prepare projects 1.9.1 catalog source

- Keep projects at 1.9.1 release settings.
- Resolve shared build aliases from the bluetape4k-dependencies catalog source instead of a published catalog artifact.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Release Notes

- Build metadata preparation for the 1.9.1 release train.

Closes #620

## Validation

- ./gradlew help -Pbluetape4kDependenciesCatalogPath=<dependencies>/gradle/libs.versions.toml
- git diff --check

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #620, milestone `1.9.1`, assignee debop
- PR: #622, head `34ace33a007aa766db2534154ceb59be119e8e46`, milestone `1.9.1`, assignee debop
- Base: `develop`, head branch `build/catalog-version-split-20260523`
- Labels: `build`
- State: `MERGED`, merge commit `e1a9899f0b2807b9eafc4a818e43709e7d191071`
- CI: - Resolve shared build aliases from the bluetape4k-dependencies catalog source instead of a published catalog artifact. / - ./gradlew help -Pbluetape4kDependenciesCatalogPath=<dependencies>/gradle/libs.versions.toml## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #622 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e1a9899f0b2807b9eafc4a818e43709e7d191071`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
