### PR TITLE
feat: provide a reusable DynamoDB Local launcher

### DIFF
--- a/docs/lessons/2026-05-24-dynamodb-local-server.md
+++ b/docs/lessons/2026-05-24-dynamodb-local-server.md
@@ -1,0 +1,17 @@
+# DynamoDB Local Testcontainers Fixture
+
+Context: `bluetape4k-leader` issue #367 needs a reusable DynamoDB Local
+Testcontainers launcher instead of a private test-only `GenericContainer`.
+
+Decision: Add `DynamoDbLocalServer` to `bluetape4k-testcontainers` under the
+AWS emulator package. Keep it SDK-neutral, expose AWS-compatible endpoint and
+credential properties, and provide `Launcher.dynamoDb` for singleton reuse.
+
+Outcome: Downstream leader tests can remove their private container once they
+consume a catalog version containing this fixture.
+
+Verification: `./gradlew :bluetape4k-testcontainers:test --tests
+'io.bluetape4k.testcontainers.aws.DynamoDbLocalServerTest'`.
+
+Future guard: Do not reintroduce DynamoDB Local containers directly in
+downstream test bases; consume `DynamoDbLocalServer.Launcher.dynamoDb` instead.

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/DynamoDbLocalServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/DynamoDbLocalServer.kt
@@ -1,0 +1,168 @@
+package io.bluetape4k.testcontainers.aws
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.testcontainers.GenericServer
+import io.bluetape4k.testcontainers.PropertyExportingServer
+import io.bluetape4k.testcontainers.exposeCustomPorts
+import io.bluetape4k.utils.ShutdownQueue
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import java.net.URI
+
+/**
+ * Runs Amazon DynamoDB Local with Testcontainers.
+ *
+ * ## Behavior / Contract
+ * - Exposes DynamoDB Local on [PORT] and provides [awsEndpoint] for AWS SDK clients.
+ * - Uses in-memory, shared-database mode by default.
+ * - The container is reusable by default and can be shared through [Launcher.dynamoDb].
+ * - Starting the server exports connection properties under `testcontainers.dynamodb-local.*`.
+ *
+ * ```kotlin
+ * val dynamoDb = DynamoDbLocalServer.Launcher.dynamoDb
+ * val endpoint = dynamoDb.awsEndpoint
+ * ```
+ */
+class DynamoDbLocalServer private constructor(
+    imageName: DockerImageName,
+    useDefaultPort: Boolean,
+    reuse: Boolean,
+): GenericContainer<DynamoDbLocalServer>(imageName), GenericServer, PropertyExportingServer, AwsEmulatorServer {
+
+    companion object: KLogging() {
+        /** Official Amazon DynamoDB Local Docker image. */
+        const val IMAGE = "amazon/dynamodb-local"
+
+        /** Default DynamoDB Local image tag. */
+        const val TAG = "2.6.1"
+
+        /** Property namespace for exported connection properties. */
+        const val NAME = "dynamodb-local"
+
+        /** DynamoDB Local service port. */
+        const val PORT = 8000
+
+        /** Default access key accepted by local AWS emulators. */
+        const val DEFAULT_ACCESS_KEY = "test"
+
+        /** Default secret key accepted by local AWS emulators. */
+        const val DEFAULT_SECRET_KEY = "test"
+
+        /** Default region used by tests. */
+        const val DEFAULT_REGION = "us-east-1"
+
+        /**
+         * Creates a [DynamoDbLocalServer] from an image name and tag.
+         *
+         * @param image Docker image name; blank values are rejected.
+         * @param tag Docker image tag; blank values are rejected.
+         * @param useDefaultPort binds [PORT] to the same host port when `true`.
+         * @param reuse enables reusable Testcontainers when `true`.
+         */
+        @JvmStatic
+        operator fun invoke(
+            image: String = IMAGE,
+            tag: String = TAG,
+            useDefaultPort: Boolean = false,
+            reuse: Boolean = true,
+        ): DynamoDbLocalServer {
+            image.requireNotBlank("image")
+            tag.requireNotBlank("tag")
+
+            return invoke(DockerImageName.parse(image).withTag(tag), useDefaultPort, reuse)
+        }
+
+        /**
+         * Creates a [DynamoDbLocalServer] from a [DockerImageName].
+         *
+         * @param imageName Docker image name.
+         * @param useDefaultPort binds [PORT] to the same host port when `true`.
+         * @param reuse enables reusable Testcontainers when `true`.
+         */
+        @JvmStatic
+        operator fun invoke(
+            imageName: DockerImageName,
+            useDefaultPort: Boolean = false,
+            reuse: Boolean = true,
+        ): DynamoDbLocalServer {
+            return DynamoDbLocalServer(imageName, useDefaultPort, reuse)
+        }
+    }
+
+    /** Mapped DynamoDB Local port. */
+    override val port: Int get() = getMappedPort(PORT)
+
+    /** DynamoDB Local base URL. */
+    override val url: String get() = "http://$host:$port"
+
+    /** AWS SDK endpoint override URI. */
+    override val awsEndpoint: URI get() = URI.create(url)
+
+    /** Alias for [awsEndpoint] for DynamoDB-focused tests. */
+    val endpoint: URI get() = awsEndpoint
+
+    /** Default AWS access key. */
+    override val awsAccessKey: String = DEFAULT_ACCESS_KEY
+
+    /** Default AWS secret key. */
+    override val awsSecretKey: String = DEFAULT_SECRET_KEY
+
+    /** Default AWS region name. */
+    override val regionName: String = DEFAULT_REGION
+
+    override val propertyNamespace: String = NAME
+
+    override fun propertyKeys(): Set<String> =
+        setOf("host", "port", "url", "endpoint", "aws-endpoint", "aws-access-key", "aws-secret-key", "region")
+
+    override fun properties(): Map<String, String> = mapOf(
+        "host" to host,
+        "port" to port.toString(),
+        "url" to url,
+        "endpoint" to endpoint.toString(),
+        "aws-endpoint" to awsEndpoint.toString(),
+        "aws-access-key" to awsAccessKey,
+        "aws-secret-key" to awsSecretKey,
+        "region" to regionName,
+    )
+
+    init {
+        addExposedPorts(PORT)
+        withReuse(reuse)
+        withCommand("-jar", "DynamoDBLocal.jar", "-inMemory", "-sharedDb")
+        waitingFor(Wait.forListeningPort())
+
+        if (useDefaultPort) {
+            exposeCustomPorts(PORT)
+        }
+    }
+
+    /**
+     * DynamoDB Local always starts the DynamoDB service, so service selection is a no-op.
+     */
+    override fun withServices(vararg services: String): DynamoDbLocalServer {
+        if (services.isNotEmpty()) {
+            log.warn("withServices(${services.toList()}) is a no-op: DynamoDB Local exposes only DynamoDB.")
+        }
+        return this
+    }
+
+    override fun start() {
+        super.start()
+        writeToSystemProperties()
+    }
+
+    /**
+     * Shared singleton launcher for tests that need a reusable DynamoDB Local server.
+     */
+    object Launcher {
+        val dynamoDb: DynamoDbLocalServer by lazy {
+            DynamoDbLocalServer().apply {
+                start()
+                ShutdownQueue.register(this)
+            }
+        }
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/DynamoDbLocalServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/DynamoDbLocalServerTest.kt
@@ -1,0 +1,57 @@
+package io.bluetape4k.testcontainers.aws
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContainAll
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.assertions.shouldStartWith
+import io.bluetape4k.testcontainers.AbstractContainerTest
+import org.junit.jupiter.api.Test
+
+class DynamoDbLocalServerTest: AbstractContainerTest() {
+
+    @Test
+    fun `blank image tag is rejected`() {
+        assertFailsWith<IllegalArgumentException> { DynamoDbLocalServer(image = " ") }
+        assertFailsWith<IllegalArgumentException> { DynamoDbLocalServer(tag = " ") }
+    }
+
+    @Test
+    fun `property keys are available before start`() {
+        val server = DynamoDbLocalServer(reuse = false)
+
+        server.propertyKeys() shouldContainAll setOf(
+            "host",
+            "port",
+            "url",
+            "endpoint",
+            "aws-endpoint",
+            "aws-access-key",
+            "aws-secret-key",
+            "region",
+        )
+    }
+
+    @Test
+    fun `property namespace is dynamodb local`() {
+        DynamoDbLocalServer(reuse = false).propertyNamespace shouldBeEqualTo DynamoDbLocalServer.NAME
+    }
+
+    @Test
+    fun `DynamoDB Local starts and exports connection properties`() {
+        DynamoDbLocalServer(reuse = false).use { server ->
+            server.start()
+
+            server.isRunning.shouldBeTrue()
+            server.awsEndpoint.shouldNotBeNull()
+            server.awsEndpoint.toString() shouldStartWith "http://"
+            server.endpoint shouldBeEqualTo server.awsEndpoint
+            server.awsAccessKey shouldBeEqualTo DynamoDbLocalServer.DEFAULT_ACCESS_KEY
+            server.awsSecretKey shouldBeEqualTo DynamoDbLocalServer.DEFAULT_SECRET_KEY
+            server.regionName shouldBeEqualTo DynamoDbLocalServer.DEFAULT_REGION
+            System.getProperty("testcontainers.dynamodb-local.endpoint") shouldBeEqualTo server.endpoint.toString()
+            System.getProperty("testcontainers.dynamodb-local.aws-endpoint") shouldBeEqualTo server.awsEndpoint.toString()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #367

- PR 제목: feat: provide a reusable DynamoDB Local launcher

- Add DynamoDbLocalServer to bluetape4k-testcontainers for DynamoDB Local integration tests.
- Expose AWS-compatible endpoint, credentials, region, and PropertyExportingServer keys.
- Add targeted server tests and a lesson for downstream leader issue #367.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- ./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.aws.DynamoDbLocalServerTest'
- git diff --check

Closes bluetape4k/bluetape4k-leader#367 upstream prerequisite.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #367, milestone 없음, assignee 없음
- PR: #625, head `b2eaa3d98343e0ad95b8dde659f76803b983f8ee`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `feat/dynamodb-local-server`
- Labels: `test`, `infra/io`
- State: `MERGED`, merge commit `d3e36cb1005314dd03484135d373ee7f00094870`
- CI: - ./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.aws.DynamoDbLocalServerTest'

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #625 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `d3e36cb1005314dd03484135d373ee7f00094870`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
