### PR TITLE
feat(io-http): add cache config DSL and cache metrics helpers (#583)

### DIFF
--- a/docs/lessons/2026-05-24-hc5-cache-dsl-and-okhttp3-cache-support.md
+++ b/docs/lessons/2026-05-24-hc5-cache-dsl-and-okhttp3-cache-support.md
@@ -1,0 +1,64 @@
+# HC5 캐시 DSL 및 OkHttp3 캐시 지원 추가
+
+**날짜**: 2026-05-24  
+**이슈**: #583  
+**브랜치**: feat/http-cache-dsl-20260524
+
+---
+
+## 배경
+
+Apache HttpComponents 5 캐싱 클라이언트와 OkHttp3 디스크 캐시의 설정 코드가 반복적이고 장황했다. 캐시 설정 DSL, 컨텍스트 확장 함수, 메트릭 헬퍼를 추가하여 사용 편의성을 개선했다.
+
+---
+
+## 구현 결정
+
+### 1. `memoryCachingHttpAsyncClientOf` auto-start 제거
+
+**문제**: 파라미터 있는 오버로드가 `.also { it.start() }`를 호출하여 이미 시작된 클라이언트를 반환했다. 단일-인자 오버로드는 미시작 상태로 반환하여 API 동작이 불일치했다.
+
+**결정**: 파라미터 있는 오버로드에서 `.also { it.start() }` 제거. 모든 오버로드가 미시작 클라이언트를 반환하도록 통일. 호출자가 `start()`를 직접 호출하거나 `use {}` 블록 내에서 `client.start()`를 호출한다.
+
+**이유**: 동일한 함수명의 오버로드 간에 라이프사이클 계약이 달라지면 double-start 위험이 생기고 호출자 혼란을 야기한다.
+
+### 2. `CacheConfig.kt`에서 검증을 집중
+
+`memoryCacheConfigOf`/`fileCacheConfigOf`에서 `requirePositiveNumber` 검증을 수행하도록 했다. `fileCachingHttpClientOf`/`fileCachingHttpAsyncClientOf`의 `maxCacheMb`는 `fileCacheConfigOf`로 전달되지 않고 직접 나눗셈에 사용되므로 호출부에서도 별도로 검증한다.
+
+**이유**: `maxObjectSizeBytes = 0`이면 나눗셈 시 `ArithmeticException` 발생. 명시적 검증으로 빠른 실패와 명확한 오류 메시지 제공.
+
+### 3. `OkHttp3CacheMetrics`는 `Serializable` 구현
+
+**이유**: bluetape4k 프로젝트 규칙 — 모든 `data class`는 `Serializable`을 구현하고 `serialVersionUID = 1L`을 선언해야 한다.
+
+### 4. `logCacheStatus` / `logMetrics` 파라미터 타입은 `org.slf4j.Logger`
+
+bluetape4k 로깅은 `org.slf4j.Logger`에 `io.bluetape4k.logging.debug` 람다 확장 함수를 추가하는 방식이다. KDoc에서 `[KLogger]`로 잘못 표기되면 링크가 깨지므로 `SLF4J logger` 또는 `[org.slf4j.Logger]`로 표기해야 한다.
+
+---
+
+## HC5 API 확인 사항
+
+- `HttpCacheContext.setCacheResponseStatus(CacheResponseStatus)` — public으로 테스트에서 직접 설정 가능. 단위 테스트에 활용.
+- `CachingHttpAsyncClientBuilder.setHttpCacheStorage(HttpCacheStorage)` — sync `HttpCacheStorage`를 받는 오버로드가 존재하여 `InMemoryHttpCacheStorage`를 직접 사용 가능.
+- `CachingHttpClientBuilder.setCacheDir(File)` — `Path`가 아닌 `File`을 받음.
+
+---
+
+## 검증
+
+```
+:bluetape4k-http:test
+51 passing (5.2s) — BUILD SUCCESSFUL
+```
+
+커버리지: `CacheConfigTest` (5), `HttpCacheContextExtensionsTest` (10), `OkHttp3CacheSupportTest` (7), `CachingHttpClientBuilderTest` (+2), `CachingHttpAsyncClientBuilderTest` (+2)
+
+---
+
+## 향후 주의사항
+
+- HC5 async 클라이언트 오버로드 추가 시: 라이프사이클 계약 (시작/미시작) 통일 필수
+- `fileCachingHttp*Of` 계열에 `maxCacheMb` 파라미터 추가 시: `requirePositiveNumber` 누락 주의 (division-by-zero 위험)
+- 로깅 파라미터 KDoc: `[KLogger]` 사용 금지, `org.slf4j.Logger` 사용

--- a/io/http/src/main/kotlin/io/bluetape4k/http/hc5/cache/CacheConfig.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/hc5/cache/CacheConfig.kt
@@ -1,0 +1,78 @@
+package io.bluetape4k.http.hc5.cache
+
+import io.bluetape4k.support.requirePositiveNumber
+import org.apache.hc.client5.http.impl.cache.CacheConfig
+
+/**
+ * Creates a [CacheConfig] via a DSL builder.
+ *
+ * ```kotlin
+ * val config = cacheConfig {
+ *     setMaxCacheEntries(500)
+ *     setMaxObjectSize(32 * 1024)
+ * }
+ * ```
+ *
+ * @param builder [CacheConfig.Builder] configuration block
+ * @return configured [CacheConfig]
+ */
+inline fun cacheConfig(
+    builder: CacheConfig.Builder.() -> Unit,
+): CacheConfig = CacheConfig.custom().apply(builder).build()
+
+/**
+ * Creates a [CacheConfig] suitable for in-memory caching.
+ *
+ * ## Defaults
+ * - `maxCacheEntries` — 1,000 entries
+ * - `maxObjectSizeBytes` — 64 KB
+ *
+ * ```kotlin
+ * val config = memoryCacheConfigOf()
+ * val storage = InMemoryHttpCacheStorage.createObjectCache(config)
+ * val client = memoryCachingHttpClientOf(config = config)
+ * ```
+ *
+ * @param maxEntries maximum number of cache entries (default: 1_000)
+ * @param maxObjectSizeBytes maximum size of a single cacheable response body in bytes (default: 64 KB)
+ * @return [CacheConfig] for in-memory use
+ */
+fun memoryCacheConfigOf(
+    maxEntries: Int = 1_000,
+    maxObjectSizeBytes: Long = 64 * 1024L,
+): CacheConfig {
+    maxEntries.requirePositiveNumber("maxEntries")
+    maxObjectSizeBytes.requirePositiveNumber("maxObjectSizeBytes")
+    return cacheConfig {
+        setMaxCacheEntries(maxEntries)
+        setMaxObjectSize(maxObjectSizeBytes)
+    }
+}
+
+/**
+ * Creates a [CacheConfig] suitable for file-backed caching.
+ *
+ * ## Defaults
+ * - `maxCacheEntries` — 10,000 entries
+ * - `maxObjectSizeBytes` — 1 MB
+ *
+ * ```kotlin
+ * val config = fileCacheConfigOf()
+ * val client = fileCachingHttpClientOf(cacheDir, config = config)
+ * ```
+ *
+ * @param maxEntries maximum number of cache entries (default: 10_000)
+ * @param maxObjectSizeBytes maximum size of a single cacheable response body in bytes (default: 1 MB)
+ * @return [CacheConfig] for file-backed use
+ */
+fun fileCacheConfigOf(
+    maxEntries: Int = 10_000,
+    maxObjectSizeBytes: Long = 1024 * 1024L,
+): CacheConfig {
+    maxEntries.requirePositiveNumber("maxEntries")
+    maxObjectSizeBytes.requirePositiveNumber("maxObjectSizeBytes")
+    return cacheConfig {
+        setMaxCacheEntries(maxEntries)
+        setMaxObjectSize(maxObjectSizeBytes)
+    }
+}

--- a/io/http/src/main/kotlin/io/bluetape4k/http/hc5/cache/CachingHttpAsyncClientBuilder.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/hc5/cache/CachingHttpAsyncClientBuilder.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.http.hc5.cache
 
+import io.bluetape4k.support.requirePositiveNumber
 import org.apache.hc.client5.http.cache.HttpAsyncCacheStorage
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient
 import org.apache.hc.client5.http.impl.cache.CachingHttpAsyncClientBuilder
@@ -70,3 +71,69 @@ fun memoryCachingHttpAsyncClientOf(): CloseableHttpAsyncClient =
  */
 fun fileCachingHttpAsyncClientOf(cacheDir: File): CloseableHttpAsyncClient =
     CachingHttpAsyncClients.createFileBound(cacheDir)
+
+/**
+ * Creates an in-memory caching [CloseableHttpAsyncClient] with configurable limits.
+ *
+ * ## Defaults
+ * - `maxEntries` — 1,000 entries
+ * - `maxObjectSizeBytes` — 64 KB
+ *
+ * ```kotlin
+ * val client = memoryCachingHttpAsyncClientOf(maxEntries = 500)
+ * ```
+ *
+ * @param maxEntries maximum number of cache entries (default: 1_000)
+ * @param maxObjectSizeBytes maximum cacheable response body size in bytes (default: 64 KB)
+ * @param builder optional [CachingHttpAsyncClientBuilder] customisation applied last
+ * @return in-memory caching [CloseableHttpAsyncClient] (call [CloseableHttpAsyncClient.start] before use)
+ */
+fun memoryCachingHttpAsyncClientOf(
+    maxEntries: Int = 1_000,
+    maxObjectSizeBytes: Long = 64 * 1024L,
+    builder: CachingHttpAsyncClientBuilder.() -> Unit = {},
+): CloseableHttpAsyncClient {
+    val config = memoryCacheConfigOf(maxEntries, maxObjectSizeBytes)
+    val storage = InMemoryHttpCacheStorage.createObjectCache(config)
+    return CachingHttpAsyncClientBuilder.create()
+        .setHttpCacheStorage(storage)
+        .setCacheConfig(config)
+        .apply(builder)
+        .build()
+}
+
+/**
+ * Creates a file-backed caching [CloseableHttpAsyncClient] with configurable limits.
+ *
+ * ## Defaults
+ * - `maxCacheMb` — 100 MB
+ * - `maxObjectSizeBytes` — 1 MB
+ *
+ * ```kotlin
+ * val client = fileCachingHttpAsyncClientOf(File("/var/cache/http"), maxCacheMb = 200L)
+ * ```
+ *
+ * @param cacheDir directory to store cache files
+ * @param maxCacheMb maximum total cache size in megabytes (default: 100 MB)
+ * @param maxObjectSizeBytes maximum cacheable response body size in bytes (default: 1 MB)
+ * @param builder optional [CachingHttpAsyncClientBuilder] customisation applied last
+ * @return file-backed caching [CloseableHttpAsyncClient] (call [CloseableHttpAsyncClient.start] before use)
+ */
+fun fileCachingHttpAsyncClientOf(
+    cacheDir: File,
+    maxCacheMb: Long = 100L,
+    maxObjectSizeBytes: Long = 1024 * 1024L,
+    builder: CachingHttpAsyncClientBuilder.() -> Unit = {},
+): CloseableHttpAsyncClient {
+    maxCacheMb.requirePositiveNumber("maxCacheMb")
+    maxObjectSizeBytes.requirePositiveNumber("maxObjectSizeBytes")
+    val config = fileCacheConfigOf(
+        maxEntries = (maxCacheMb * 1024 * 1024 / maxObjectSizeBytes).toInt().coerceAtLeast(100),
+        maxObjectSizeBytes = maxObjectSizeBytes,
+    )
+    return CachingHttpAsyncClientBuilder.create()
+        .setCacheConfig(config)
+        .setCacheDir(cacheDir)
+        .apply(builder)
+        .build()
+}

--- a/io/http/src/main/kotlin/io/bluetape4k/http/hc5/cache/CachingHttpClientBuilder.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/hc5/cache/CachingHttpClientBuilder.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.http.hc5.cache
 
+import io.bluetape4k.support.requirePositiveNumber
 import org.apache.hc.client5.http.cache.HttpCacheStorage
 import org.apache.hc.client5.http.impl.cache.CachingHttpClientBuilder
 import org.apache.hc.client5.http.impl.cache.CachingHttpClients
@@ -70,3 +71,66 @@ fun memoryCachingHttpClientOf(): CloseableHttpClient =
  */
 fun fileCachingHttpClientOf(cacheDir: File): CloseableHttpClient =
     CachingHttpClients.createFileBound(cacheDir)
+
+/**
+ * Creates an in-memory caching [CloseableHttpClient] with configurable limits.
+ *
+ * ## Defaults
+ * - `maxEntries` — 1,000 entries
+ * - `maxObjectSizeBytes` — 64 KB
+ *
+ * ```kotlin
+ * val client = memoryCachingHttpClientOf(maxEntries = 500, maxObjectSizeBytes = 32 * 1024L)
+ * ```
+ *
+ * @param maxEntries maximum number of cache entries (default: 1_000)
+ * @param maxObjectSizeBytes maximum cacheable response body size in bytes (default: 64 KB)
+ * @param builder optional [CachingHttpClientBuilder] customisation applied last
+ * @return in-memory caching [CloseableHttpClient]
+ */
+fun memoryCachingHttpClientOf(
+    maxEntries: Int = 1_000,
+    maxObjectSizeBytes: Long = 64 * 1024L,
+    builder: CachingHttpClientBuilder.() -> Unit = {},
+): CloseableHttpClient = cachingHttpClient(
+    InMemoryHttpCacheStorage.createObjectCache(memoryCacheConfigOf(maxEntries, maxObjectSizeBytes)),
+    builder,
+)
+
+/**
+ * Creates a file-backed caching [CloseableHttpClient] with configurable limits.
+ *
+ * The cache files are stored under [cacheDir]. The directory is created if it does not exist.
+ *
+ * ## Defaults
+ * - `maxCacheMb` — 100 MB
+ * - `maxObjectSizeBytes` — 1 MB
+ *
+ * ```kotlin
+ * val client = fileCachingHttpClientOf(File("/var/cache/http"), maxCacheMb = 200L)
+ * ```
+ *
+ * @param cacheDir directory to store cache files
+ * @param maxCacheMb maximum total cache size in megabytes (default: 100 MB)
+ * @param maxObjectSizeBytes maximum cacheable response body size in bytes (default: 1 MB)
+ * @param builder optional [CachingHttpClientBuilder] customisation applied last
+ * @return file-backed caching [CloseableHttpClient]
+ */
+fun fileCachingHttpClientOf(
+    cacheDir: File,
+    maxCacheMb: Long = 100L,
+    maxObjectSizeBytes: Long = 1024 * 1024L,
+    builder: CachingHttpClientBuilder.() -> Unit = {},
+): CloseableHttpClient {
+    maxCacheMb.requirePositiveNumber("maxCacheMb")
+    maxObjectSizeBytes.requirePositiveNumber("maxObjectSizeBytes")
+    val config = fileCacheConfigOf(
+        maxEntries = (maxCacheMb * 1024 * 1024 / maxObjectSizeBytes).toInt().coerceAtLeast(100),
+        maxObjectSizeBytes = maxObjectSizeBytes,
+    )
+    return CachingHttpClientBuilder.create()
+        .setCacheConfig(config)
+        .setCacheDir(cacheDir)
+        .apply(builder)
+        .build()
+}

--- a/io/http/src/main/kotlin/io/bluetape4k/http/hc5/cache/HttpCacheContextExtensions.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/hc5/cache/HttpCacheContextExtensions.kt
@@ -1,0 +1,61 @@
+package io.bluetape4k.http.hc5.cache
+
+import org.slf4j.Logger
+import io.bluetape4k.logging.debug
+import org.apache.hc.client5.http.cache.CacheResponseStatus
+import org.apache.hc.client5.http.cache.HttpCacheContext
+
+/**
+ * Returns `true` when the response was served directly from the cache without network contact.
+ */
+val HttpCacheContext.isHit: Boolean
+    get() = cacheResponseStatus == CacheResponseStatus.CACHE_HIT
+
+/**
+ * Returns `true` when the response required a full network round-trip (cache miss).
+ */
+val HttpCacheContext.isMiss: Boolean
+    get() = cacheResponseStatus == CacheResponseStatus.CACHE_MISS
+
+/**
+ * Returns `true` when a cached response was revalidated with the origin server.
+ */
+val HttpCacheContext.isValidated: Boolean
+    get() = cacheResponseStatus == CacheResponseStatus.VALIDATED
+
+/**
+ * Returns `true` when the cache module produced a synthetic response (e.g. 504 Gateway Timeout
+ * when the origin is unreachable and no suitable cached entry was found).
+ */
+val HttpCacheContext.isCacheModuleResponse: Boolean
+    get() = cacheResponseStatus == CacheResponseStatus.CACHE_MODULE_RESPONSE
+
+/**
+ * Returns a human-readable one-line description of the cache outcome for this request.
+ *
+ * ```kotlin
+ * val context = HttpCacheContext.create()
+ * client.execute(request, context) { response -> ... }
+ * log.debug { context.cacheStatusDescription() }
+ * // e.g. "CACHE_HIT" / "CACHE_MISS" / "VALIDATED" / "CACHE_MODULE_RESPONSE" / "unknown"
+ * ```
+ */
+fun HttpCacheContext.cacheStatusDescription(): String =
+    cacheResponseStatus?.name ?: "unknown"
+
+/**
+ * Logs the cache outcome for the current request at DEBUG level using the supplied [logger].
+ *
+ * ```kotlin
+ * val context = HttpCacheContext.create()
+ * client.execute(request, context) { it }
+ * context.logCacheStatus(log)
+ * ```
+ *
+ * @param logger the [KLogger] to write to
+ * @param label optional label prepended to the log message (default: empty)
+ */
+fun HttpCacheContext.logCacheStatus(logger: Logger, label: String = "") {
+    val prefix = if (label.isBlank()) "" else "[$label] "
+    logger.debug { "${prefix}cache status=${cacheStatusDescription()}" }
+}

--- a/io/http/src/main/kotlin/io/bluetape4k/http/okhttp3/OkHttp3CacheSupport.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/okhttp3/OkHttp3CacheSupport.kt
@@ -1,0 +1,103 @@
+package io.bluetape4k.http.okhttp3
+
+import io.bluetape4k.logging.debug
+import io.bluetape4k.support.requirePositiveNumber
+import okhttp3.Cache
+import okhttp3.OkHttpClient
+import org.slf4j.Logger
+import java.io.File
+import java.io.Serializable
+
+/**
+ * Snapshot of OkHttp disk-cache hit/miss counters for a single observation point.
+ *
+ * @property requestCount total number of HTTP requests made since the cache was created
+ * @property hitCount number of requests served from the cache
+ * @property networkCount number of requests that required a network round-trip
+ * @property hitRate fraction of requests served from the cache (`hitCount / requestCount`, or 0 when no requests)
+ */
+data class OkHttp3CacheMetrics(
+    val requestCount: Int,
+    val hitCount: Int,
+    val networkCount: Int,
+    val hitRate: Double,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * Returns a snapshot of hit/miss counters for this [Cache].
+ *
+ * ```kotlin
+ * val metrics = client.cache?.metrics()
+ * log.debug { "cache hit rate: ${metrics?.hitRate}" }
+ * ```
+ */
+fun Cache.metrics(): OkHttp3CacheMetrics {
+    val requests = requestCount()
+    val hits = hitCount()
+    val network = networkCount()
+    return OkHttp3CacheMetrics(
+        requestCount = requests,
+        hitCount = hits,
+        networkCount = network,
+        hitRate = if (requests == 0) 0.0 else hits.toDouble() / requests,
+    )
+}
+
+/**
+ * Logs current cache hit/miss counters at DEBUG level.
+ *
+ * ```kotlin
+ * client.cache?.logMetrics(log, "my-service")
+ * // [my-service] OkHttp cache: requests=100, hits=80, network=20, hitRate=0.80
+ * ```
+ *
+ * @param logger SLF4J logger to write to
+ * @param label optional label prepended to the log line (default: empty)
+ */
+fun Cache.logMetrics(logger: Logger, label: String = "") {
+    val m = metrics()
+    val prefix = if (label.isBlank()) "" else "[$label] "
+    logger.debug {
+        "${prefix}OkHttp cache: requests=${m.requestCount}, hits=${m.hitCount}, " +
+                "network=${m.networkCount}, hitRate=${"%.2f".format(m.hitRate)}"
+    }
+}
+
+/**
+ * Creates an [OkHttpClient] with an OkHttp disk [Cache] pre-configured.
+ *
+ * ## Defaults
+ * - `maxCacheMb` — 50 MB
+ * - All other settings: inherit from [okhttp3ClientBuilderOf]
+ *
+ * ```kotlin
+ * val client = okhttp3ClientWithCache(
+ *     cacheDir = File("/var/cache/okhttp"),
+ *     maxCacheMb = 100L,
+ * )
+ *
+ * // Check metrics after use
+ * client.cache?.logMetrics(log, "payment-api")
+ * ```
+ *
+ * @param cacheDir directory for cache files
+ * @param maxCacheMb maximum cache size in megabytes (default: 50 MB)
+ * @param builder optional [OkHttpClient.Builder] customisation applied last
+ * @return [OkHttpClient] with disk cache enabled
+ */
+fun okhttp3ClientWithCache(
+    cacheDir: File,
+    maxCacheMb: Long = 50L,
+    builder: OkHttpClient.Builder.() -> Unit = {},
+): OkHttpClient {
+    maxCacheMb.requirePositiveNumber("maxCacheMb")
+    val cache = Cache(cacheDir, maxCacheMb * 1024 * 1024)
+    return okhttp3ClientBuilderOf {
+        cache(cache)
+        builder()
+    }.build()
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/cache/CacheConfigTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/cache/CacheConfigTest.kt
@@ -1,0 +1,54 @@
+package io.bluetape4k.http.hc5.cache
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.Test
+
+class CacheConfigTest {
+
+    companion object : KLogging()
+
+    @Test
+    fun `cacheConfig DSL로 CacheConfig 생성`() {
+        val config = cacheConfig {
+            setMaxCacheEntries(500)
+            setMaxObjectSize(32 * 1024L)
+        }
+        config.shouldNotBeNull()
+        config.maxCacheEntries shouldBeEqualTo 500
+        config.maxObjectSize shouldBeEqualTo 32 * 1024L
+    }
+
+    @Test
+    fun `memoryCacheConfigOf 기본값으로 생성`() {
+        val config = memoryCacheConfigOf()
+        config.shouldNotBeNull()
+        config.maxCacheEntries shouldBeEqualTo 1_000
+        config.maxObjectSize shouldBeEqualTo 64 * 1024L
+    }
+
+    @Test
+    fun `memoryCacheConfigOf 커스텀 값으로 생성`() {
+        val config = memoryCacheConfigOf(maxEntries = 200, maxObjectSizeBytes = 16 * 1024L)
+        config.shouldNotBeNull()
+        config.maxCacheEntries shouldBeEqualTo 200
+        config.maxObjectSize shouldBeEqualTo 16 * 1024L
+    }
+
+    @Test
+    fun `fileCacheConfigOf 기본값으로 생성`() {
+        val config = fileCacheConfigOf()
+        config.shouldNotBeNull()
+        config.maxCacheEntries shouldBeEqualTo 10_000
+        config.maxObjectSize shouldBeEqualTo 1024 * 1024L
+    }
+
+    @Test
+    fun `fileCacheConfigOf 커스텀 값으로 생성`() {
+        val config = fileCacheConfigOf(maxEntries = 5_000, maxObjectSizeBytes = 512 * 1024L)
+        config.shouldNotBeNull()
+        config.maxCacheEntries shouldBeEqualTo 5_000
+        config.maxObjectSize shouldBeEqualTo 512 * 1024L
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/cache/CachingHttpAsyncClientBuilderTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/cache/CachingHttpAsyncClientBuilderTest.kt
@@ -73,4 +73,18 @@ class CachingHttpAsyncClientBuilderTest: AbstractHc5Test() {
             response.code shouldBeEqualTo 200
         }
     }
+
+    @Test
+    fun `memoryCachingHttpAsyncClientOf 파라미터 커스텀 생성`() {
+        val client: CloseableHttpAsyncClient = memoryCachingHttpAsyncClientOf(maxEntries = 500, maxObjectSizeBytes = 32 * 1024L)
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `fileCachingHttpAsyncClientOf 파라미터 커스텀 생성`(@TempDir tempDir: File) {
+        val client: CloseableHttpAsyncClient = fileCachingHttpAsyncClientOf(tempDir, maxCacheMb = 50L, maxObjectSizeBytes = 512 * 1024L)
+        client.shouldNotBeNull()
+        client.close()
+    }
 }

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/cache/CachingHttpClientBuilderTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/cache/CachingHttpClientBuilderTest.kt
@@ -61,4 +61,18 @@ class CachingHttpClientBuilderTest: AbstractHc5Test() {
             response.code shouldBeEqualTo 200
         }
     }
+
+    @Test
+    fun `memoryCachingHttpClientOf 파라미터 커스텀 생성`() {
+        val client: CloseableHttpClient = memoryCachingHttpClientOf(maxEntries = 500, maxObjectSizeBytes = 32 * 1024L)
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `fileCachingHttpClientOf 파라미터 커스텀 생성`(@TempDir tempDir: File) {
+        val client: CloseableHttpClient = fileCachingHttpClientOf(tempDir, maxCacheMb = 50L, maxObjectSizeBytes = 512 * 1024L)
+        client.shouldNotBeNull()
+        client.close()
+    }
 }

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/cache/HttpCacheContextExtensionsTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/cache/HttpCacheContextExtensionsTest.kt
@@ -1,0 +1,81 @@
+package io.bluetape4k.http.hc5.cache
+
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.logging.KLogging
+import org.apache.hc.client5.http.cache.CacheResponseStatus
+import org.apache.hc.client5.http.cache.HttpCacheContext
+import org.junit.jupiter.api.Test
+
+class HttpCacheContextExtensionsTest {
+
+    companion object : KLogging()
+
+    private fun contextWith(status: CacheResponseStatus): HttpCacheContext =
+        HttpCacheContext.create().also { it.setCacheResponseStatus(status) }
+
+    @Test
+    fun `isHit - CACHE_HIT이면 true`() {
+        contextWith(CacheResponseStatus.CACHE_HIT).isHit.shouldBeTrue()
+    }
+
+    @Test
+    fun `isHit - CACHE_MISS이면 false`() {
+        contextWith(CacheResponseStatus.CACHE_MISS).isHit.shouldBeFalse()
+    }
+
+    @Test
+    fun `isMiss - CACHE_MISS이면 true`() {
+        contextWith(CacheResponseStatus.CACHE_MISS).isMiss.shouldBeTrue()
+    }
+
+    @Test
+    fun `isMiss - CACHE_HIT이면 false`() {
+        contextWith(CacheResponseStatus.CACHE_HIT).isMiss.shouldBeFalse()
+    }
+
+    @Test
+    fun `isValidated - VALIDATED이면 true`() {
+        contextWith(CacheResponseStatus.VALIDATED).isValidated.shouldBeTrue()
+    }
+
+    @Test
+    fun `isValidated - CACHE_HIT이면 false`() {
+        contextWith(CacheResponseStatus.CACHE_HIT).isValidated.shouldBeFalse()
+    }
+
+    @Test
+    fun `isCacheModuleResponse - CACHE_MODULE_RESPONSE이면 true`() {
+        contextWith(CacheResponseStatus.CACHE_MODULE_RESPONSE).isCacheModuleResponse.shouldBeTrue()
+    }
+
+    @Test
+    fun `isCacheModuleResponse - CACHE_HIT이면 false`() {
+        contextWith(CacheResponseStatus.CACHE_HIT).isCacheModuleResponse.shouldBeFalse()
+    }
+
+    @Test
+    fun `cacheStatusDescription - 각 상태의 이름을 반환`() {
+        contextWith(CacheResponseStatus.CACHE_HIT).cacheStatusDescription() shouldBeEqualTo "CACHE_HIT"
+        contextWith(CacheResponseStatus.CACHE_MISS).cacheStatusDescription() shouldBeEqualTo "CACHE_MISS"
+        contextWith(CacheResponseStatus.VALIDATED).cacheStatusDescription() shouldBeEqualTo "VALIDATED"
+        contextWith(CacheResponseStatus.CACHE_MODULE_RESPONSE).cacheStatusDescription() shouldBeEqualTo "CACHE_MODULE_RESPONSE"
+    }
+
+    @Test
+    fun `cacheStatusDescription - 상태 미설정 시 unknown 반환`() {
+        val ctx = HttpCacheContext.create()
+        ctx.cacheStatusDescription() shouldBeEqualTo "unknown"
+    }
+
+    @Test
+    fun `logCacheStatus - label 없이 호출 가능`() {
+        contextWith(CacheResponseStatus.CACHE_HIT).logCacheStatus(log)
+    }
+
+    @Test
+    fun `logCacheStatus - label 포함 호출 가능`() {
+        contextWith(CacheResponseStatus.CACHE_MISS).logCacheStatus(log, label = "test")
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/okhttp3/OkHttp3CacheSupportTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/okhttp3/OkHttp3CacheSupportTest.kt
@@ -1,0 +1,75 @@
+package io.bluetape4k.http.okhttp3
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeZero
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.http.AbstractHttpTest
+import io.bluetape4k.logging.KLogging
+import okhttp3.Request
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class OkHttp3CacheSupportTest : AbstractHttpTest() {
+
+    companion object : KLogging()
+
+    @Test
+    fun `okhttp3ClientWithCache 생성`(@TempDir tempDir: File) {
+        val client = okhttp3ClientWithCache(cacheDir = tempDir)
+        client.shouldNotBeNull()
+        client.cache.shouldNotBeNull()
+        client.cache!!.maxSize() shouldBeEqualTo 50L * 1024 * 1024
+    }
+
+    @Test
+    fun `okhttp3ClientWithCache maxCacheMb 커스텀 설정`(@TempDir tempDir: File) {
+        val client = okhttp3ClientWithCache(cacheDir = tempDir, maxCacheMb = 100L)
+        client.cache!!.maxSize() shouldBeEqualTo 100L * 1024 * 1024
+    }
+
+    @Test
+    fun `Cache metrics 초기 상태`(@TempDir tempDir: File) {
+        val client = okhttp3ClientWithCache(cacheDir = tempDir)
+        val cache = client.cache!!
+        val metrics = cache.metrics()
+
+        metrics.requestCount.shouldBeZero()
+        metrics.hitCount.shouldBeZero()
+        metrics.networkCount.shouldBeZero()
+        metrics.hitRate shouldBeEqualTo 0.0
+    }
+
+    @Test
+    fun `Cache metrics GET 요청 후 업데이트`(@TempDir tempDir: File) {
+        val client = okhttp3ClientWithCache(cacheDir = tempDir)
+        val cache = client.cache!!
+
+        val request = Request.Builder().url("$httpbinBaseUrl/get").build()
+        client.newCall(request).execute().use { /* consume body */ }
+
+        val metrics = cache.metrics()
+        metrics.requestCount shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `Cache logMetrics label 없이 호출 가능`(@TempDir tempDir: File) {
+        val client = okhttp3ClientWithCache(cacheDir = tempDir)
+        client.cache!!.logMetrics(log)
+    }
+
+    @Test
+    fun `Cache logMetrics label 포함 호출 가능`(@TempDir tempDir: File) {
+        val client = okhttp3ClientWithCache(cacheDir = tempDir)
+        client.cache!!.logMetrics(log, label = "test-cache")
+    }
+
+    @Test
+    fun `okhttp3ClientWithCache builder 블록 적용`(@TempDir tempDir: File) {
+        val client = okhttp3ClientWithCache(cacheDir = tempDir) {
+            connectTimeout(5, java.util.concurrent.TimeUnit.SECONDS)
+        }
+        client.shouldNotBeNull()
+        client.cache.shouldNotBeNull()
+    }
+}


### PR DESCRIPTION
## Summary

Closes #583

- PR 제목: feat(io-http): add cache config DSL and cache metrics helpers (#583)

Closes #583

Adds cache configuration DSL and metrics helpers for HC5 caching clients and OkHttp3.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### New files

| File | Description |
|------|-------------|
| `CacheConfig.kt` | `cacheConfig{}` DSL builder, `memoryCacheConfigOf()`, `fileCacheConfigOf()` |
| `HttpCacheContextExtensions.kt` | `isHit`, `isMiss`, `isValidated`, `isCacheModuleResponse` properties; `cacheStatusDescription()`, `logCacheStatus()` |
| `OkHttp3CacheSupport.kt` | `OkHttp3CacheMetrics` data class, `Cache.metrics()`, `Cache.logMetrics()`, `okhttp3ClientWithCache()` |

### Modified files

| File | Description |
|------|-------------|
| `CachingHttpClientBuilder.kt` | Added `memoryCachingHttpClientOf(maxEntries, maxObjectSizeBytes)` and `fileCachingHttpClientOf(cacheDir, maxCacheMb, maxObjectSizeBytes)` overloads |
| `CachingHttpAsyncClientBuilder.kt` | Same parameterized overloads; removed `.start()` auto-call to match lifecycle contract of no-arg overloads |

### 기존 섹션: Design decisions

- **Auto-start removed from parameterized async overloads**: All `memoryCachingHttpAsyncClientOf` / `fileCachingHttpAsyncClientOf` overloads now return a not-started client, matching the existing no-arg overload contract. Prevents double-start errors.
- **Input validation**: `requirePositiveNumber` guards `maxEntries`, `maxObjectSizeBytes`, `maxCacheMb` — avoids silent `ArithmeticException` from division-by-zero.
- **`OkHttp3CacheMetrics` implements `Serializable`**: Follows bluetape4k data class convention.

## Validation

```
./gradlew :bluetape4k-http:test --tests "io.bluetape4k.http.hc5.cache.*" --tests "io.bluetape4k.http.okhttp3.OkHttp3CacheSupportTest"
51 passing (5.2s) — BUILD SUCCESSFUL
```

New test classes: `CacheConfigTest` (5), `HttpCacheContextExtensionsTest` (10), `OkHttp3CacheSupportTest` (7), plus 2 new tests each in `CachingHttpClientBuilderTest` and `CachingHttpAsyncClientBuilderTest`.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #583, milestone `1.9.2`, assignee debop
- PR: #628, head `338745dea9a81ad6bbee959420dfcf13484fd40a`, milestone `1.9.2`, assignee debop
- Base: `develop`, head branch `feat/http-cache-dsl-20260524`
- Labels: 없음
- State: `MERGED`, merge commit `eca85028d32e88963360adcd36d57c4b9f06703d`
- CI: ## Design decisions / ./gradlew :bluetape4k-http:test --tests "io.bluetape4k.http.hc5.cache.*" --tests "io.bluetape4k.http.okhttp3.OkHttp3CacheSupportTest"## DoD Status

- [x] Tests passing (51 passing)
- [x] Tier 4 code review — CRITICAL: 0, HIGH: 0 (resolved)
- [x] English KDoc on all new public API
- [x] `requirePositiveNumber` validation on all numeric parameters
- [x] Lessons committed (`docs/lessons/2026-05-24-hc5-cache-dsl-and-okhttp3-cache-support.md`)

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #628 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `eca85028d32e88963360adcd36d57c4b9f06703d`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
