### PR TITLE
perf(io-http): add CPU/GC profiling to HTTP client benchmarks (#585)

### DIFF
--- a/docs/lessons/2026-05-24-http-benchmark-cpu-gc-profiling.md
+++ b/docs/lessons/2026-05-24-http-benchmark-cpu-gc-profiling.md
@@ -1,0 +1,75 @@
+# Lesson: CPU/GC Profiling for kotlinx-benchmark JMH Benchmarks
+
+**Date**: 2026-05-24  
+**Issue**: #585 — perf(io-http): add CPU and GC profiling to HTTP client benchmarks  
+**Branch**: perf/http-benchmark-profiling-20260524
+
+---
+
+## Root Cause / Background
+
+kotlinx-benchmark 0.4.x does not expose JMH's `OptionsBuilder.addProfiler()` through its
+Gradle DSL. The `BenchmarkConfiguration.advanced()` map is parsed at runtime by
+`JvmBenchmarkRunner`, but only the `jvmForks` key is acted upon — all other keys are
+written to a parameters file and silently ignored by the runner.
+
+Therefore, JMH built-in profilers (`gc`, `jfr`, `stack`) cannot be activated through the
+`advanced()` DSL. The correct approach is to configure JVM args on the generated `JavaExec`
+benchmark exec task via `tasks.withType<JavaExec>().configureEach { ... }`.
+
+---
+
+## Decision
+
+Use JVM-level profiling flags injected via Gradle task configuration:
+
+| Mode | JVM flag |
+|------|----------|
+| `gc` | `-Xlog:gc*,safepoint:file=...` |
+| `jfr` | `-XX:StartFlightRecording=filename=...,dumponexit=true,settings=profile` |
+| `async` | `-agentpath:libasyncProfiler.so=start,event=cpu,file=...,flamegraph` |
+
+Activated by `-PbenchmarkProfile=<gc|jfr|async>` Gradle property.
+
+---
+
+## Critical Pitfall: kotlinx-benchmark task naming
+
+The kotlinx-benchmark plugin generates the benchmark exec task with name:
+
+```
+"${target.name}${config.capitalizedName()}${BENCHMARK_EXEC_SUFFIX}"
+```
+
+where:
+- `capitalizedName()` returns `""` when config name is `"main"` (the default)
+- `BENCHMARK_EXEC_SUFFIX = "Benchmark"`
+
+So for `targets { register("test") }` + default `configurations { named("main") }`:
+- **Task name = `"testBenchmark"`** (NOT `"testMainBenchmarkExec"`)
+
+A filter of `name.endsWith("Exec")` will never match and the profiling block becomes a
+silent no-op. The correct filter is `name.endsWith("Benchmark")` combined with
+`tasks.withType<JavaExec>()` (to exclude lifecycle DefaultTask instances also named
+with "Benchmark").
+
+---
+
+## Verification Evidence
+
+- Build script compiles cleanly with and without `-PbenchmarkProfile=gc`
+- `./gradlew :bluetape4k-http:tasks --all` confirms `testBenchmark` is the JavaExec exec task
+- 8 existing smoke tests pass: `HttpClientBenchmarkTest` — 8 tests, 0 failures
+
+---
+
+## Future Guidance
+
+- Always verify the actual task name via `./gradlew :module:tasks --all` before writing
+  task name filters in `configureEach { }` blocks.
+- If kotlinx-benchmark adds native profiler support in a future release, migrate to that
+  DSL and remove the `tasks.withType<JavaExec>` workaround.
+- For JFR output: open `build/benchmark-profiling/benchmark.jfr` with JDK Mission Control
+  (`jmc`) or IntelliJ IDEA's JFR viewer.
+- async-profiler requires the native agent library; kotlinx-benchmark runtime auto-detects
+  `libasyncProfiler` in JVM args and sets forks=0 (needed for in-process profiling).

--- a/io/http/README.ko.md
+++ b/io/http/README.ko.md
@@ -272,6 +272,42 @@ JMH(Java Microbenchmark Harness) 기반 벤치마크 3종으로 클라이언트�
 ./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude="HttpClientCompressionCacheBenchmark"
 ```
 
+### CPU 및 GC 프로파일링
+
+`-PbenchmarkProfile=<profiler>` 를 추가하면 벤치마크 실행 중 프로파일링이 활성화됩니다.
+출력 파일은 `build/benchmark-profiling/` 에 저장됩니다.
+
+| 속성 값 | 방식 | 출력 파일 | 측정 항목 |
+|--------|------|---------|----------|
+| `gc` | JVM GC 로깅 (`-Xlog:gc*`) | `gc.log` | GC 일시 정지 시간, 할당 이벤트, 세이프포인트 |
+| `jfr` | Java Flight Recorder (`-XX:StartFlightRecording`) | `benchmark.jfr` | CPU 플레임 그래프, GC 이벤트, 락 경합, 메모리 할당 |
+| `async` | async-profiler 에이전트 (`-PasyncProfilerLib=` 필요) | `async-cpu.html` | CPU 플레임 그래프 (저오버헤드 샘플링) |
+
+```bash
+# 전체 벤치마크의 GC 로깅
+./gradlew :bluetape4k-http:testBenchmark -PbenchmarkProfile=gc
+
+# 특정 벤치마크 클래스에 JFR CPU + GC 레코딩 적용
+./gradlew :bluetape4k-http:testBenchmark \
+  -PbenchmarkProfile=jfr \
+  -PbenchmarkInclude="HttpClientBenchmark"
+
+# async-profiler CPU 플레임 그래프 (네이티브 에이전트 라이브러리 필요)
+./gradlew :bluetape4k-http:testBenchmark \
+  -PbenchmarkProfile=async \
+  -PasyncProfilerLib=/path/to/libasyncProfiler.so \
+  -PbenchmarkInclude="HttpClientBenchmark"
+```
+
+> **JFR**: `build/benchmark-profiling/benchmark.jfr` 파일을 JDK Mission Control(`jmc`) 또는
+> IntelliJ IDEA 내장 JFR 뷰어로 열어 CPU 플레임 그래프와 메모리 할당 분석을 확인하세요.
+
+> **async-profiler**: [async-profiler 릴리스](https://github.com/async-profiler/async-profiler/releases)에서
+> 다운로드 후 `-PasyncProfilerLib` 에 네이티브 `libasyncProfiler.so` / `libasyncProfiler.dylib` 경로를 지정하세요.
+> kotlinx-benchmark 런타임이 에이전트를 자동 감지하여 JMH forks를 0으로 설정합니다.
+
+> **요구 사항**: 모든 프로파일러는 프로젝트 툴체인인 JDK 21에서 동작합니다. 추가 Gradle 의존성 불필요.
+
 ### 1. HttpClientBenchmark — 기본 처리량 (`GET /ping`)
 
 **환경**: `BluetapeWebfluxServer` (Docker) · `@Threads(8)` · warmup 1×1s · measurement 1×1s

--- a/io/http/README.md
+++ b/io/http/README.md
@@ -271,6 +271,42 @@ All benchmarks target a separate Docker container server, isolating the server J
 ./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude="HttpClientCompressionCacheBenchmark"
 ```
 
+### CPU and GC Profiling
+
+Add `-PbenchmarkProfile=<profiler>` to enable profiling during the benchmark run.
+Output files are written to `build/benchmark-profiling/`.
+
+| Property value | Mechanism | Output | What it measures |
+|---|---|---|---|
+| `gc` | JVM GC logging (`-Xlog:gc*`) | `gc.log` | GC pause time, allocation events, safepoints |
+| `jfr` | Java Flight Recorder (`-XX:StartFlightRecording`) | `benchmark.jfr` | CPU flame graph, GC events, lock contention, allocations |
+| `async` | async-profiler agent (requires `-PasyncProfilerLib=`) | `async-cpu.html` | CPU flame graph (low-overhead sampling) |
+
+```bash
+# GC logging for all benchmarks
+./gradlew :bluetape4k-http:testBenchmark -PbenchmarkProfile=gc
+
+# JFR CPU + GC recording for a single benchmark class
+./gradlew :bluetape4k-http:testBenchmark \
+  -PbenchmarkProfile=jfr \
+  -PbenchmarkInclude="HttpClientBenchmark"
+
+# async-profiler CPU flame graph (requires the native agent library)
+./gradlew :bluetape4k-http:testBenchmark \
+  -PbenchmarkProfile=async \
+  -PasyncProfilerLib=/path/to/libasyncProfiler.so \
+  -PbenchmarkInclude="HttpClientBenchmark"
+```
+
+> **JFR**: Open `build/benchmark-profiling/benchmark.jfr` with JDK Mission Control (`jmc`)
+> or IntelliJ IDEA's built-in JFR viewer for a CPU flame graph and memory allocation analysis.
+
+> **async-profiler**: Download from [async-profiler releases](https://github.com/async-profiler/async-profiler/releases)
+> and point `-PasyncProfilerLib` at the native `libasyncProfiler.so` / `libasyncProfiler.dylib`.
+> The kotlinx-benchmark runtime detects the agent and automatically sets JMH forks to 0.
+
+> **Requirements**: All profilers run on JDK 21 (the project toolchain). No extra Gradle dependencies needed.
+
 ### 1. HttpClientBenchmark — Base Throughput (`GET /ping`)
 
 **Setup**: `BluetapeWebfluxServer` (Docker) · `@Threads(8)` · warmup 1×1s · measurement 1×1s

--- a/io/http/build.gradle.kts
+++ b/io/http/build.gradle.kts
@@ -28,6 +28,67 @@ benchmark {
     }
 }
 
+// ---------------------------------------------------------------------------
+// CPU / GC profiling support
+//
+// Add -PbenchmarkProfile=<profiler> to the Gradle command to enable profiling.
+//
+//   gc    → JVM GC logging  (-Xlog:gc*)
+//             Output: build/benchmark-profiling/gc.log
+//
+//   jfr   → Java Flight Recorder  (-XX:StartFlightRecording)
+//             Output: build/benchmark-profiling/benchmark.jfr
+//             Open with JDK Mission Control (jmc) or IntelliJ IDEA JFR viewer.
+//
+//   async → async-profiler flame graph  (-agentpath:libasyncProfiler.so)
+//             Also requires: -PasyncProfilerLib=/path/to/libasyncProfiler.so
+//             Output: build/benchmark-profiling/async-cpu.html
+//             kotlinx-benchmark runtime auto-detects the agent and sets forks=0.
+//
+// Examples:
+//   ./gradlew :bluetape4k-http:testBenchmark -PbenchmarkProfile=gc
+//   ./gradlew :bluetape4k-http:testBenchmark -PbenchmarkProfile=jfr \
+//       -PbenchmarkInclude="HttpClientBenchmark"
+//   ./gradlew :bluetape4k-http:testBenchmark -PbenchmarkProfile=async \
+//       -PasyncProfilerLib=/path/to/libasyncProfiler.so \
+//       -PbenchmarkInclude="HttpClientBenchmark"
+// ---------------------------------------------------------------------------
+val benchmarkProfiler = (project.findProperty("benchmarkProfile") as String?)
+if (!benchmarkProfiler.isNullOrBlank()) {
+    tasks.withType<JavaExec>().configureEach {
+        // kotlinx-benchmark generates a JavaExec task named "{target}{capitalizedConfig}Benchmark".
+        // For target="test" + config="main", capitalizedName() returns "" → task is "testBenchmark".
+        if (name.endsWith("Benchmark")) {
+            val profilingDir = layout.buildDirectory.dir("benchmark-profiling").get().asFile
+            doFirst { profilingDir.mkdirs() }
+            when (benchmarkProfiler.lowercase()) {
+                "gc" -> jvmArgs(
+                    "-Xlog:gc*,safepoint:file=${profilingDir}/gc.log:time,uptime,level,tags"
+                )
+                "jfr" -> jvmArgs(
+                    "-XX:StartFlightRecording=" +
+                    "filename=${profilingDir}/benchmark.jfr," +
+                    "dumponexit=true,settings=profile,duration=600s"
+                )
+                "async" -> {
+                    val profilerLib = (project.findProperty("asyncProfilerLib") as String?)
+                        ?: error(
+                            "async-profiler requires -PasyncProfilerLib=/path/to/libasyncProfiler.so"
+                        )
+                    jvmArgs(
+                        "-agentpath:$profilerLib=start,event=cpu," +
+                        "file=${profilingDir}/async-cpu.html,flamegraph,interval=1ms"
+                    )
+                }
+                else -> logger.warn(
+                    "[bluetape4k-http] Unknown benchmarkProfile='$benchmarkProfiler'. " +
+                    "Valid values: gc, jfr, async"
+                )
+            }
+        }
+    }
+}
+
 configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
 }


### PR DESCRIPTION
## Summary

Closes #585

- PR 제목: perf(io-http): add CPU/GC profiling to HTTP client benchmarks (#585)

Closes #585

Adds `-PbenchmarkProfile=<gc|jfr|async>` Gradle property to enable JVM-level
profiling during JMH benchmark runs in the `bluetape4k-http` module.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### `io/http/build.gradle.kts`
- After the `benchmark {}` block, add a `tasks.withType<JavaExec>().configureEach`
  block that injects JVM profiling args into the benchmark exec task (`testBenchmark`)
  when `-PbenchmarkProfile=<value>` is set.
- Three modes: `gc` (JVM GC log), `jfr` (Java Flight Recorder), `async` (async-profiler)
- Output files written to `build/benchmark-profiling/`

### `io/http/README.md` + `README.ko.md`
- Added **CPU and GC Profiling** section with example commands and tool tips.

### 기존 섹션: Implementation Note

kotlinx-benchmark 0.4.x does not expose `OptionsBuilder.addProfiler()` in its Gradle DSL.
Profiling is injected by configuring JVM args on the generated `JavaExec` benchmark exec task.

The exec task for `targets { register("test") }` + default `configurations { named("main") }`
is **`testBenchmark`** — `capitalizedName()` returns `""` for the `"main"` configuration.
Filter: `name.endsWith("Benchmark")` + `withType<JavaExec>()`.

### 기존 섹션: Usage

```bash
# GC logging
./gradlew :bluetape4k-http:testBenchmark -PbenchmarkProfile=gc

# JFR recording (open with jmc or IntelliJ JFR viewer)
./gradlew :bluetape4k-http:testBenchmark -PbenchmarkProfile=jfr -PbenchmarkInclude="HttpClientBenchmark"

# async-profiler flame graph
./gradlew :bluetape4k-http:testBenchmark \
  -PbenchmarkProfile=async \
  -PasyncProfilerLib=/path/to/libasyncProfiler.so \
  -PbenchmarkInclude="HttpClientBenchmark"
```

### 기존 섹션: DoD Checklist

| Item | Status |
|------|--------|
| Tests passing (8/8) | ✅ |
| Code review P0/P1 = 0 | ✅ |
| README.md + README.ko.md updated | ✅ |
| Lessons committed | ✅ |

## Validation

```
Module : :bluetape4k-http
Task   : ./gradlew :bluetape4k-http:test --tests "io.bluetape4k.http.benchmark.HttpClientBenchmarkTest"
Result : 8 tests passing, 0 failures, 0 skipped
```

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #585, milestone `1.9.2`, assignee debop
- PR: #631, head `6ebb781a9db5bcf4e3fe09d2b6c1aec1fd851c13`, milestone `1.9.2`, assignee debop
- Base: `develop`, head branch `perf/http-benchmark-profiling-20260524`
- Labels: 없음
- State: `MERGED`, merge commit `b94f95b4d3317626d46d54d5b70c2452c97503f8`
- CI: Adds `-PbenchmarkProfile=<gc|jfr|async>` Gradle property to enable JVM-level / ### `io/http/build.gradle.kts` / kotlinx-benchmark 0.4.x does not expose `OptionsBuilder.addProfiler()` in its Gradle DSL.## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #631 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `b94f95b4d3317626d46d54d5b70c2452c97503f8`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
