### PR TITLE
build: move default catalog ref to 2026-05-25-01

### DIFF
--- a/data/hibernate-reactive/build.gradle.kts
+++ b/data/hibernate-reactive/build.gradle.kts
@@ -56,6 +56,10 @@ configurations.all {
 // NOTE: implementation 로 지정된 Dependency를 testImplementation 으로도 지정하도록 합니다.
 configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+    kaptTest {
+        exclude(group = "org.hibernate.orm", module = "hibernate-jpamodelgen")
+        exclude(group = "org.hibernate.orm", module = "hibernate-processor")
+    }
 }
 
 dependencies {
@@ -71,7 +75,6 @@ dependencies {
 
     // hibernate-reactive 는 querydsl 을 사용하지 못한다. 대신 jpamodelgen 을 사용합니다.
     kapt(libs.hibernate.jpamodelgen)
-    kaptTest(libs.hibernate.jpamodelgen)
 
     api(libs.jakarta.validation.api)
     implementation(libs.hibernate.validator)

--- a/data/hibernate-reactive/src/test/java/io/bluetape4k/hibernate/reactive/examples/model/Author_.java
+++ b/data/hibernate-reactive/src/test/java/io/bluetape4k/hibernate/reactive/examples/model/Author_.java
@@ -1,0 +1,17 @@
+package io.bluetape4k.hibernate.reactive.examples.model;
+
+import jakarta.persistence.metamodel.ListAttribute;
+import jakarta.persistence.metamodel.SingularAttribute;
+import jakarta.persistence.metamodel.StaticMetamodel;
+
+@StaticMetamodel(Author.class)
+public abstract class Author_ {
+
+    public static volatile SingularAttribute<Author, Long> id;
+    public static volatile SingularAttribute<Author, String> name;
+    public static volatile ListAttribute<Author, Book> books;
+
+    public static final String ID = "id";
+    public static final String NAME = "name";
+    public static final String BOOKS = "books";
+}

--- a/data/hibernate-reactive/src/test/java/io/bluetape4k/hibernate/reactive/examples/model/Book_.java
+++ b/data/hibernate-reactive/src/test/java/io/bluetape4k/hibernate/reactive/examples/model/Book_.java
@@ -1,0 +1,22 @@
+package io.bluetape4k.hibernate.reactive.examples.model;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.metamodel.SingularAttribute;
+import jakarta.persistence.metamodel.StaticMetamodel;
+
+@StaticMetamodel(Book.class)
+public abstract class Book_ {
+
+    public static volatile SingularAttribute<Book, Long> id;
+    public static volatile SingularAttribute<Book, String> isbn;
+    public static volatile SingularAttribute<Book, String> title;
+    public static volatile SingularAttribute<Book, LocalDate> published;
+    public static volatile SingularAttribute<Book, Author> author;
+
+    public static final String ID = "id";
+    public static final String ISBN = "isbn";
+    public static final String TITLE = "title";
+    public static final String PUBLISHED = "published";
+    public static final String AUTHOR = "author";
+}

--- a/docs/lessons/2026-05-25-catalog-ref-2026-05-25-00.md
+++ b/docs/lessons/2026-05-25-catalog-ref-2026-05-25-00.md
@@ -23,10 +23,21 @@ worker loaded an older ANTLR runtime first. Test code only needs the static JPA
 metamodel, so `kaptTest` now excludes the Hibernate processor and keeps
 checked-in test metamodel classes for `Author` and `Book`.
 
+The full Nightly storage-cache job also exposed a Redisson test utility ABI
+issue after Apache Fory moved to 1.0.0. `redisson:4.4.0` still loads its own
+`org.redisson.codec.ForyCodec`, which calls a removed Fory memory helper during
+map serialization. Testcontainers storage tests validate Redis container wiring,
+not Redisson's Fory integration, so the shared Redisson test codec now uses
+`LZ4Codec(Kryo5Codec())`.
+
 ## Verification
 
 - Settings file updated to `catalog/2026-05-25-00`.
 - `./gradlew compileTestKotlin --refresh-dependencies --console=plain -PsnapshotVersion=-SNAPSHOT`
+- `./gradlew :bluetape4k-testcontainers:dependencyInsight --configuration testRuntimeClasspath --dependency org.apache.fory --console=plain -PsnapshotVersion=-SNAPSHOT`
+- `./gradlew :bluetape4k-testcontainers:dependencyInsight --configuration testRuntimeClasspath --dependency redisson --console=plain -PsnapshotVersion=-SNAPSHOT`
+- `./gradlew :bluetape4k-testcontainers:test --tests "io.bluetape4k.testcontainers.storage.RedisClusterServerTest" --console=plain -PsnapshotVersion=-SNAPSHOT`
+- `./gradlew :bluetape4k-redisson:test --console=plain -PsnapshotVersion=-SNAPSHOT`
 
 ## Future Guard
 
@@ -34,3 +45,5 @@ Use dated catalog tags for coordinated dependency train updates.
 When Hibernate processor upgrades break test KAPT through ANTLR runtime drift,
 prefer removing test processor execution from modules that only need stable
 test metamodel symbols.
+Do not use Redisson's built-in Fory codec for generic Testcontainers smoke
+tests unless the Redisson/Fory ABI is explicitly part of the test objective.

--- a/docs/lessons/2026-05-25-catalog-ref-2026-05-25-00.md
+++ b/docs/lessons/2026-05-25-catalog-ref-2026-05-25-00.md
@@ -1,0 +1,36 @@
+# Catalog Ref 2026-05-25-00
+
+## Context
+
+The shared `bluetape4k-dependencies` catalog received dependency updates for
+ASM, AWS Kotlin SDK, and Apache Fory.
+
+## Decision
+
+Pin the default `bluetape4kDependenciesCatalogRef` to
+`catalog/2026-05-25-00` instead of floating on `develop`.
+
+## Outcome
+
+Gradle settings now fetch the release-train catalog by default while still
+allowing overrides through `bluetape4kDependenciesCatalogRef` or
+`BLUETAPE4K_DEPENDENCIES_CATALOG_REF`.
+
+The catalog update exposed a Hibernate 7.3.4 test KAPT incompatibility in
+`bluetape4k-hibernate-reactive`: Hibernate's processor validates test
+`@NamedQuery` declarations with a generated ANTLR 4.13 parser, but the KAPT
+worker loaded an older ANTLR runtime first. Test code only needs the static JPA
+metamodel, so `kaptTest` now excludes the Hibernate processor and keeps
+checked-in test metamodel classes for `Author` and `Book`.
+
+## Verification
+
+- Settings file updated to `catalog/2026-05-25-00`.
+- `./gradlew compileTestKotlin --refresh-dependencies --console=plain -PsnapshotVersion=-SNAPSHOT`
+
+## Future Guard
+
+Use dated catalog tags for coordinated dependency train updates.
+When Hibernate processor upgrades break test KAPT through ANTLR runtime drift,
+prefer removing test processor execution from modules that only need stable
+test metamodel symbols.

--- a/docs/lessons/2026-05-25-catalog-ref-2026-05-25-01.md
+++ b/docs/lessons/2026-05-25-catalog-ref-2026-05-25-01.md
@@ -1,4 +1,4 @@
-# Catalog Ref 2026-05-25-00
+# Catalog Ref 2026-05-25-01
 
 ## Context
 
@@ -8,7 +8,7 @@ ASM, AWS Kotlin SDK, and Apache Fory.
 ## Decision
 
 Pin the default `bluetape4kDependenciesCatalogRef` to
-`catalog/2026-05-25-00` instead of floating on `develop`.
+`catalog/2026-05-25-01` instead of floating on `develop`.
 
 ## Outcome
 
@@ -32,7 +32,7 @@ not Redisson's Fory integration, so the shared Redisson test codec now uses
 
 ## Verification
 
-- Settings file updated to `catalog/2026-05-25-00`.
+- Settings file updated to `catalog/2026-05-25-01`.
 - `./gradlew compileTestKotlin --refresh-dependencies --console=plain -PsnapshotVersion=-SNAPSHOT`
 - `./gradlew :bluetape4k-testcontainers:dependencyInsight --configuration testRuntimeClasspath --dependency org.apache.fory --console=plain -PsnapshotVersion=-SNAPSHOT`
 - `./gradlew :bluetape4k-testcontainers:dependencyInsight --configuration testRuntimeClasspath --dependency redisson --console=plain -PsnapshotVersion=-SNAPSHOT`

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ pluginManagement {
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-    .orElse("develop")
+    .orElse("catalog/2026-05-25-00")
     .get()
 
 fun resolveBluetape4kDependenciesCatalogFile(): File {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ pluginManagement {
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-    .orElse("catalog/2026-05-25-00")
+    .orElse("catalog/2026-05-25-01")
     .get()
 
 fun resolveBluetape4kDependenciesCatalogFile(): File {

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/RedissonTestSupport.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/RedissonTestSupport.kt
@@ -1,7 +1,7 @@
 package io.bluetape4k.testcontainers.storage
 
-import org.redisson.codec.ForyCodec
+import org.redisson.codec.Kryo5Codec
 import org.redisson.codec.LZ4Codec
 
 @JvmField
-internal val TEST_REDISSON_CODEC = LZ4Codec(ForyCodec())
+internal val TEST_REDISSON_CODEC = LZ4Codec(Kryo5Codec())


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: build: move default catalog ref to 2026-05-25-01

- Move the default `bluetape4kDependenciesCatalogRef` to `catalog/2026-05-25-01`.
- Update the catalog-ref lesson to match the corrected immutable ref.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- `git diff --check`
- `./gradlew help -q --no-daemon --console=plain`

### 기존 섹션: Notes

- `catalog/2026-05-25-00` exposes an unreleased `bluetape4k-dependencies:1.1.4` alias.
- `catalog/2026-05-25-01` keeps the downstream BOM alias on released `1.1.3`.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #634, head `43b553c3fa1b5cd6c8a78696cc0eb86f2861184d`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `build/catalog-20260525-00`
- Labels: `build`, `dependencies`
- State: `MERGED`, merge commit `10cc851b7c5ad1604780d251273a14b8580177fe`
- CI: - Move the default `bluetape4kDependenciesCatalogRef` to `catalog/2026-05-25-01`. / - `./gradlew help -q --no-daemon --console=plain` / - `catalog/2026-05-25-00` exposes an unreleased `bluetape4k-dependencies:1.1.4` alias.

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #634 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `10cc851b7c5ad1604780d251273a14b8580177fe`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
