### PR TITLE
docs(io-http): convert cache builder KDoc to English

### DIFF
--- a/docs/lessons/2026-05-26-http-cache-kdoc-language-policy.md
+++ b/docs/lessons/2026-05-26-http-cache-kdoc-language-policy.md
@@ -1,0 +1,29 @@
+# HTTP Cache KDoc Language Policy Cleanup
+
+**Date**: 2026-05-26
+**Issue**: #633
+**Branch**: docs/issue-633-http-cache-kdoc-english
+
+## Problem
+
+`CachingHttpClientBuilder.kt` and `CachingHttpAsyncClientBuilder.kt` had newly added English
+KDoc overloads next to older Korean KDoc on the original no-arg cache builder functions.
+This violated the contributor documentation policy that meaningfully edited KDoc should stay
+in English.
+
+## Solution
+
+Converted the remaining Korean KDoc for the original classic and async HTTP cache builders to
+English, matching the style of the new parameterized overloads.
+
+## Validation
+
+- Confirmed no Korean text remains in the two affected builder files.
+- Ran `./gradlew :bluetape4k-http:compileKotlin`.
+
+## Lessons
+
+1. When adding overloads with English KDoc, scan adjacent overloads in the same file for older
+   localized KDoc before opening the PR.
+2. Use the real Gradle module path from `./gradlew projects`; source path `io/http` maps to
+   `:bluetape4k-http`, not `:io:http`.

--- a/io/http/src/main/kotlin/io/bluetape4k/http/hc5/cache/CachingHttpAsyncClientBuilder.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/hc5/cache/CachingHttpAsyncClientBuilder.kt
@@ -8,7 +8,7 @@ import org.apache.hc.client5.http.impl.cache.CachingHttpAsyncClients
 import java.io.File
 
 /**
- * 캐시를 지원하는 [CloseableHttpAsyncClient]를 생성합니다.
+ * Creates a caching [CloseableHttpAsyncClient] using the supplied builder customisation.
  *
  * ```kotlin
  * val client = cachingHttpAsyncClient {
@@ -24,7 +24,7 @@ inline fun cachingHttpAsyncClient(
 }
 
 /**
- * 캐시를 지원하는 [CloseableHttpAsyncClient]를 생성합니다.
+ * Creates a caching [CloseableHttpAsyncClient] backed by the given [cacheStorage].
  *
  * ```kotlin
  * val client = cachingHttpAsyncClient(cacheStorage) {
@@ -43,31 +43,31 @@ inline fun cachingHttpAsyncClient(
 }
 
 /**
- * 메모리에 캐시하는 [CloseableHttpAsyncClient]를 생성합니다.
+ * Creates an in-memory caching [CloseableHttpAsyncClient].
  *
  * ```kotlin
  * val client = memoryCachingHttpAsyncClientOf()
  * client.start()
- * // HTTP 응답을 메모리에 캐시하는 클라이언트
+ * // Client that caches HTTP responses in memory
  * ```
  *
- * @return [CloseableHttpAsyncClient] 인스턴스
+ * @return in-memory caching [CloseableHttpAsyncClient] (call [CloseableHttpAsyncClient.start] before use)
  */
 fun memoryCachingHttpAsyncClientOf(): CloseableHttpAsyncClient =
     CachingHttpAsyncClients.createMemoryBound()
 
 /**
- * 파일에 캐시하는 [CloseableHttpAsyncClient]를 생성합니다.
+ * Creates a file-backed caching [CloseableHttpAsyncClient].
  *
  * ```kotlin
  * val cacheDir = File("/tmp/http-cache")
  * val client = fileCachingHttpAsyncClientOf(cacheDir)
  * client.start()
- * // HTTP 응답을 파일에 캐시하는 클라이언트
+ * // Client that caches HTTP responses on disk
  * ```
  *
- * @param cacheDir 캐시 파일을 저장할 디렉토리
- * @return [CloseableHttpAsyncClient] 인스턴스
+ * @param cacheDir directory to store cache files
+ * @return file-backed caching [CloseableHttpAsyncClient] (call [CloseableHttpAsyncClient.start] before use)
  */
 fun fileCachingHttpAsyncClientOf(cacheDir: File): CloseableHttpAsyncClient =
     CachingHttpAsyncClients.createFileBound(cacheDir)

--- a/io/http/src/main/kotlin/io/bluetape4k/http/hc5/cache/CachingHttpClientBuilder.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/hc5/cache/CachingHttpClientBuilder.kt
@@ -8,7 +8,7 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
 import java.io.File
 
 /**
- * 캐시를 지원하는 [CloseableHttpClient]를 생성합니다.
+ * Creates a caching [CloseableHttpClient] using the supplied builder customisation.
  *
  * ```kotlin
  * val client = cachingHttpClient {
@@ -25,7 +25,7 @@ inline fun cachingHttpClient(
         .build()
 
 /**
- * 캐시를 지원하는 [CloseableHttpClient]를 생성합니다.
+ * Creates a caching [CloseableHttpClient] backed by the given [cacheStorage].
  *
  * ```kotlin
  * val client = cachingHttpClient(cacheStorage) {
@@ -43,31 +43,31 @@ inline fun cachingHttpClient(
         .build()
 
 /**
- * 메모리에 캐시하는 [CloseableHttpClient]를 생성합니다.
+ * Creates an in-memory caching [CloseableHttpClient].
  *
  * ```kotlin
  * val client = memoryCachingHttpClientOf()
  * val response = client.execute(HttpGet("https://example.com"))
- * // HTTP 응답을 메모리에 캐시하는 클라이언트
+ * // Client that caches HTTP responses in memory
  * ```
  *
- * @return [CloseableHttpClient] 인스턴스
+ * @return in-memory caching [CloseableHttpClient]
  */
 fun memoryCachingHttpClientOf(): CloseableHttpClient =
     cachingHttpClient(InMemoryHttpCacheStorage.createObjectCache())
 
 /**
- * 파일에 캐시하는 [CloseableHttpClient]를 생성합니다.
+ * Creates a file-backed caching [CloseableHttpClient].
  *
  * ```kotlin
  * val cacheDir = File("/tmp/http-cache")
  * val client = fileCachingHttpClientOf(cacheDir)
  * val response = client.execute(HttpGet("https://example.com"))
- * // HTTP 응답을 파일에 캐시하는 클라이언트
+ * // Client that caches HTTP responses on disk
  * ```
  *
- * @param cacheDir 캐시 파일을 저장할 디렉토리
- * @return [CloseableHttpClient] 인스턴스
+ * @param cacheDir directory to store cache files
+ * @return file-backed caching [CloseableHttpClient]
  */
 fun fileCachingHttpClientOf(cacheDir: File): CloseableHttpClient =
     CachingHttpClients.createFileBound(cacheDir)


### PR DESCRIPTION
## Summary

Closes #633

- PR 제목: docs(io-http): convert cache builder KDoc to English

- Convert the remaining Korean KDoc in classic and async HTTP cache builders to English
- Keep wording aligned with the newer parameterized cache builder overloads
- Add a lesson note for the KDoc language-policy cleanup

Closes #633

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Notes

- Earlier attempted module paths :io:http and :http were invalid; the real module path is :bluetape4k-http.

## Validation

- rg -n "[가-힣]" io/http/src/main/kotlin/io/bluetape4k/http/hc5/cache/CachingHttpClientBuilder.kt io/http/src/main/kotlin/io/bluetape4k/http/hc5/cache/CachingHttpAsyncClientBuilder.kt || true
- ./gradlew :bluetape4k-http:compileKotlin
- git diff --check
- code-review-graph update --repo /Users/debop/work/bluetape4k/bluetape4k-projects

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #633, milestone `1.9.2`, assignee `debop`
- PR: #635, head `bfab1578be89f551689cedbef4c9c7720f26885a`, milestone `1.9.2`, assignee `debop`
- Base: `develop`, head branch `docs/issue-633-http-cache-kdoc-english`
- Labels: `documentation`
- State: `MERGED`, merge commit `a62b6c6dc22c667cad64c0563cfdf605108fb0e3`
- CI: - ./gradlew :bluetape4k-http:compileKotlin

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #635 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `a62b6c6dc22c667cad64c0563cfdf605108fb0e3`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
