### PR TITLE
fix: guard release catalog selection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: false
         type: boolean
+      catalogRef:
+        description: 'bluetape4k-dependencies catalog ref to use during release'
+        required: false
+        default: ''
+        type: string
 
 concurrency:
   group: publish-release
@@ -72,6 +77,73 @@ jobs:
         with:
           ref: ${{ needs.resolve-version.outputs.ref }}
           fetch-depth: 0
+
+      - name: Resolve dependencies catalog ref
+        id: catalog
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_CATALOG_REF: ${{ github.event.inputs.catalogRef || '' }}
+          REPOSITORY_CATALOG_REF: ${{ vars.BLUETAPE4K_DEPENDENCIES_CATALOG_REF || '' }}
+        run: |
+          set -euo pipefail
+          DEFAULT_CATALOG_REF=$(sed -nE 's/^[[:space:]]*\.orElse\("([^"]+)"\).*/\1/p' settings.gradle.kts | head -1)
+
+          if [[ -z "$DEFAULT_CATALOG_REF" ]]; then
+            echo "::error::Could not resolve checked-in bluetape4k-dependencies catalog default from settings.gradle.kts"
+            exit 1
+          fi
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" && -n "$INPUT_CATALOG_REF" ]]; then
+            SELECTED_CATALOG_REF="$INPUT_CATALOG_REF"
+            CATALOG_SOURCE="workflow_dispatch input catalogRef"
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" && -n "$REPOSITORY_CATALOG_REF" ]]; then
+            SELECTED_CATALOG_REF="$REPOSITORY_CATALOG_REF"
+            CATALOG_SOURCE="repository variable BLUETAPE4K_DEPENDENCIES_CATALOG_REF"
+          else
+            SELECTED_CATALOG_REF="$DEFAULT_CATALOG_REF"
+            CATALOG_SOURCE="checked-in settings.gradle.kts default"
+          fi
+
+          if [[ "$EVENT_NAME" == "push" && -n "$REPOSITORY_CATALOG_REF" && "$REPOSITORY_CATALOG_REF" != "$DEFAULT_CATALOG_REF" ]]; then
+            echo "::notice::Ignoring repository catalog variable '$REPOSITORY_CATALOG_REF' for tag-triggered release. Using checked-in default '$DEFAULT_CATALOG_REF'."
+          fi
+
+          echo "BLUETAPE4K_DEPENDENCIES_CATALOG_REF=$SELECTED_CATALOG_REF" >> "$GITHUB_ENV"
+          {
+            echo "ref=$SELECTED_CATALOG_REF"
+            echo "source=$CATALOG_SOURCE"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "catalogRef=$SELECTED_CATALOG_REF"
+          echo "catalogSource=$CATALOG_SOURCE"
+          echo "checkedInDefault=$DEFAULT_CATALOG_REF"
+          echo "repositoryVariable=${REPOSITORY_CATALOG_REF:-<unset>}"
+
+      - name: Verify dependencies catalog aliases
+        shell: bash
+        run: |
+          set -euo pipefail
+          catalog_file="$RUNNER_TEMP/bluetape4k-libs.versions.toml"
+          catalog_url="https://raw.githubusercontent.com/bluetape4k/bluetape4k-dependencies/${BLUETAPE4K_DEPENDENCIES_CATALOG_REF}/gradle/libs.versions.toml"
+          required_aliases=(
+            "bluetape4k-bom"
+            "bluetape4k-exposed-bom"
+            "exposed-plugin"
+          )
+
+          echo "Fetching bluetape4k-dependencies catalog: $catalog_url"
+          curl -fsSL "$catalog_url" -o "$catalog_file"
+
+          for alias in "${required_aliases[@]}"; do
+            if ! grep -Eq "^[[:space:]]*${alias}[[:space:]]*=" "$catalog_file"; then
+              echo "::error::Catalog ref '${BLUETAPE4K_DEPENDENCIES_CATALOG_REF}' is missing required alias: ${alias}"
+              exit 1
+            fi
+          done
+
+          echo "Verified catalog aliases from ${BLUETAPE4K_DEPENDENCIES_CATALOG_REF}:"
+          grep -E '^[[:space:]]*(bluetape4k-bom|bluetape4k-exposed-bom|exposed-plugin)[[:space:]]*=' "$catalog_file"
 
       - name: Verify gradle.properties matches tag
         shell: bash

--- a/docs/lessons/2026-05-27-release-catalog-guard.md
+++ b/docs/lessons/2026-05-27-release-catalog-guard.md
@@ -1,0 +1,29 @@
+# Release Catalog Guard
+
+## Context
+
+The AWS 0.3.0 release exposed a shared release workflow risk: an operational
+catalog override can make a stable release use a different
+`bluetape4k-dependencies` catalog than the checked-in `settings.gradle.kts`
+default.
+
+## Decision
+
+Stable tag releases use the checked-in catalog default. Manual dispatch can use
+an explicit `catalogRef` override, then the repository variable as an
+operational fallback.
+
+## Outcome
+
+The release workflow logs the selected catalog source and verifies required
+catalog aliases before Maven Central publish.
+
+## Verification
+
+Run `actionlint`, validate catalog selection branches locally, and check the
+current release catalog contains the required aliases.
+
+## Future Guidance
+
+Treat repository catalog variables as manual release overrides, not as the
+release train source of truth.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1088,7 +1088,7 @@ jna-platform = { module = "net.java.dev.jna:jna-platform", version.ref = "jna" }
 wiremock = { module = "org.wiremock:wiremock", version = "3.13.2" }  # https://mvnrepository.com/artifact/org.wiremock/wiremock
 
 # Kubernetes
-fabric8-kubernetes-client-bom = { module = "io.fabric8:kubernetes-client-bom", version = "7.6.1" }  # https://mvnrepository.com/artifact/io.fabric8/kubernetes-client-bom
+fabric8-kubernetes-client-bom = { module = "io.fabric8:kubernetes-client-bom", version = "7.7.0" }  # https://mvnrepository.com/artifact/io.fabric8/kubernetes-client-bom
 fabric8-kubernetes-client = { module = "io.fabric8:kubernetes-client", version = "7.7.0" }  # https://mvnrepository.com/artifact/io.fabric8/kubernetes-client
 kubernetes-client-java = { module = "io.kubernetes:client-java", version = "24.0.0" }  # https://mvnrepository.com/artifact/io.kubernetes/client-java
 


### PR DESCRIPTION
## Summary

Closes #640

- PR 제목: fix: guard release catalog selection

- keep tag-triggered releases on the checked-in bluetape4k-dependencies catalog default
- allow manual workflow dispatch to use an explicit catalogRef override path
- verify required catalog aliases before Maven Central publish
- document the release catalog override rule in docs/lessons

Closes #640

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- actionlint .github/workflows/release.yml
- git diff --check
- local tag-push catalog selection check with stale repository variable
- required-alias check against catalog/2026-05-26-01

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #640, milestone `1.10.0`, assignee `debop`
- PR: #641, head `a25f9b2241173776c86c873526c7b44a7523575d`, milestone `1.10.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-640-release-catalog-guard`
- Labels: `bug`, `build`, `ci`, `release`
- State: `MERGED`, merge commit `c08fc497c0f565cf3e769310f7717a166bc76e57`
- CI: - keep tag-triggered releases on the checked-in bluetape4k-dependencies catalog default / - allow manual workflow dispatch to use an explicit catalogRef override path

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #641 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `c08fc497c0f565cf3e769310f7717a166bc76e57`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
