### PR TITLE
feat(ktor): implement bluetape4k-ktor-core

### DIFF
--- a/docs/lessons/2026-05-28-issue-612-ktor-core.md
+++ b/docs/lessons/2026-05-28-issue-612-ktor-core.md
@@ -1,0 +1,39 @@
+# Issue 612 - Ktor core baseline helpers
+
+## Context
+
+Issue #612 implements the first reusable Ktor runtime API after the Ktor module
+family was scaffolded in #611. The idgenerator Ktor example showed repeated
+manual JSON, `StatusPages`, health route, and query parameter validation code.
+
+## Decision
+
+Provide a small explicit Ktor-native core surface:
+
+- `installBluetape4kKtorCore()` for opt-in baseline installation.
+- `Bluetape4kKtorJson.defaultJson()` for shared JSON defaults.
+- `ApiErrorResponse`, `HealthResponse`, and health/readiness routes.
+- `StatusPagesConfig.bluetape4kErrorResponses()` with cancellation rethrow.
+- route parameter helpers that throw `IllegalArgumentException` so default
+  status pages map caller input failures to HTTP 400.
+
+The module exposes Ktor and kotlinx serialization dependencies as `api` because
+the public API mentions `Json`, `StatusPagesConfig`, and Ktor application types.
+
+## Outcome
+
+The first core API is intentionally framework-light: no Spring Boot
+auto-configuration, no hidden application routes beyond health/readiness, and no
+client helpers. The example migration stays in #615 after the shared API settles.
+
+## Verification
+
+- `./gradlew :bluetape4k-ktor-core:compileKotlin :bluetape4k-ktor-core:compileTestKotlin`
+- `./gradlew :bluetape4k-ktor-core:test :bluetape4k-ktor-core:koverXmlReport`
+- Kover XML: line coverage 90/98 (91.8%).
+
+## Future Guard
+
+When adding more Ktor shared helpers, keep the installer explicit and avoid
+installing Ktor plugins that applications commonly customize unless they are
+individually switchable in config.

--- a/ktor/core/README.ko.md
+++ b/ktor/core/README.ko.md
@@ -4,12 +4,48 @@
 
 bluetape4k 생태계를 위한 기본 Ktor 서버 helper 모듈입니다.
 
-## 범위
+## 기능
 
-- 공통 JSON/content negotiation 기본값.
-- 명시적 Ktor baseline installer.
-- API error response 및 `StatusPages` helper.
-- Health/readiness route helper.
+- `Bluetape4kKtorJson.defaultJson()` 공통 kotlinx serialization 기본값.
+- `installBluetape4kKtorCore()` 명시적 Ktor 서버 baseline installer.
+- `ApiErrorResponse` 및 `StatusPagesConfig.bluetape4kErrorResponses()` JSON 오류 응답.
+- `HealthResponse`를 반환하는 `/healthz`, `/readyz` helper.
+- 반복되는 Ktor route 검증을 줄이는 query/path parameter helper.
 
-이 scaffold는 아직 production API를 추가하지 않습니다. 구현은 module 등록
-검증 이후 #612에서 진행합니다.
+## 의존성
+
+```kotlin
+dependencies {
+    implementation("io.bluetape4k:bluetape4k-ktor-core")
+}
+```
+
+## 사용 예
+
+```kotlin
+import io.bluetape4k.ktor.core.installBluetape4kKtorCore
+import io.bluetape4k.ktor.core.intQueryParameter
+import io.bluetape4k.ktor.core.requiredPathParameter
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+
+fun Application.module() {
+    installBluetape4kKtorCore()
+
+    routing {
+        get("/items/{type}") {
+            val type = call.requiredPathParameter("type")
+            val size = call.intQueryParameter("size", defaultValue = 10, range = 1..100)
+
+            call.respond(mapOf("type" to type, "size" to size))
+        }
+    }
+}
+```
+
+기본 installer는 content negotiation, JSON 오류 처리, health/readiness route를
+추가합니다. 애플리케이션이 해당 Ktor plugin을 직접 소유해야 한다면
+`Bluetape4kKtorCoreConfig`로 각 기능을 끌 수 있습니다.

--- a/ktor/core/README.md
+++ b/ktor/core/README.md
@@ -4,12 +4,48 @@
 
 Baseline Ktor server helpers for the bluetape4k ecosystem.
 
-## Scope
+## Features
 
-- Shared JSON/content negotiation defaults.
-- Explicit baseline Ktor installer.
-- API error response and `StatusPages` helpers.
-- Health/readiness route helpers.
+- `Bluetape4kKtorJson.defaultJson()` for shared kotlinx serialization defaults.
+- `installBluetape4kKtorCore()` for explicit Ktor server baseline installation.
+- `ApiErrorResponse` and `StatusPagesConfig.bluetape4kErrorResponses()` for JSON error payloads.
+- `/healthz` and `/readyz` helpers returning `HealthResponse`.
+- Query and path parameter helpers for repeated Ktor route validation.
 
-This scaffold intentionally adds no production API yet. Implementation follows
-#612 after the module registration is verified.
+## Dependency
+
+```kotlin
+dependencies {
+    implementation("io.bluetape4k:bluetape4k-ktor-core")
+}
+```
+
+## Usage
+
+```kotlin
+import io.bluetape4k.ktor.core.installBluetape4kKtorCore
+import io.bluetape4k.ktor.core.intQueryParameter
+import io.bluetape4k.ktor.core.requiredPathParameter
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+
+fun Application.module() {
+    installBluetape4kKtorCore()
+
+    routing {
+        get("/items/{type}") {
+            val type = call.requiredPathParameter("type")
+            val size = call.intQueryParameter("size", defaultValue = 10, range = 1..100)
+
+            call.respond(mapOf("type" to type, "size" to size))
+        }
+    }
+}
+```
+
+The default installer adds content negotiation, JSON error handling, and
+health/readiness routes. Disable individual parts through
+`Bluetape4kKtorCoreConfig` when an application already owns that Ktor plugin.

--- a/ktor/core/build.gradle.kts
+++ b/ktor/core/build.gradle.kts
@@ -9,11 +9,10 @@ configurations {
 dependencies {
     api(project(":bluetape4k-core"))
     api(libs.ktor.server.core)
-
-    implementation(libs.ktor.server.content.negotiation)
-    implementation(libs.ktor.server.status.pages)
-    implementation(libs.ktor.serialization.kotlinx.json)
-    implementation(libs.kotlinx.serialization.json)
+    api(libs.ktor.server.content.negotiation)
+    api(libs.ktor.server.status.pages)
+    api(libs.ktor.serialization.kotlinx.json)
+    api(libs.kotlinx.serialization.json)
 
     testImplementation(project(":bluetape4k-junit5"))
     testImplementation(libs.ktor.server.test.host)

--- a/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/ApiErrorResponse.kt
+++ b/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/ApiErrorResponse.kt
@@ -1,0 +1,56 @@
+package io.bluetape4k.ktor.core
+
+import io.bluetape4k.support.requireNotBlank
+import io.ktor.http.HttpStatusCode
+import kotlinx.serialization.Serializable
+import java.io.Serializable as JavaSerializable
+
+/**
+ * Standard JSON error payload for Ktor applications.
+ *
+ * ## Contract
+ * - [error] is a stable machine-readable code.
+ * - [message] is safe to expose to API clients.
+ * - [status] mirrors the HTTP status code sent by Ktor.
+ *
+ * ```kotlin
+ * val response = ApiErrorResponse.of(
+ *     status = HttpStatusCode.BadRequest,
+ *     error = "bad_request",
+ *     message = "Invalid query parameter"
+ * )
+ * ```
+ */
+@Serializable
+data class ApiErrorResponse(
+    val error: String,
+    val message: String,
+    val status: Int,
+    val path: String? = null,
+): JavaSerializable {
+
+    init {
+        error.requireNotBlank("error")
+        message.requireNotBlank("message")
+    }
+
+    companion object {
+        private const val serialVersionUID: Long = 1L
+
+        /**
+         * Creates an [ApiErrorResponse] from a Ktor [HttpStatusCode].
+         */
+        fun of(
+            status: HttpStatusCode,
+            error: String,
+            message: String,
+            path: String? = null,
+        ): ApiErrorResponse =
+            ApiErrorResponse(
+                error = error,
+                message = message,
+                status = status.value,
+                path = path
+            )
+    }
+}

--- a/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/Bluetape4kKtorCore.kt
+++ b/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/Bluetape4kKtorCore.kt
@@ -1,0 +1,47 @@
+package io.bluetape4k.ktor.core
+
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.routing.routing
+
+/**
+ * Installs the bluetape4k baseline Ktor server features.
+ *
+ * ## Contract
+ * - Installation is explicit and application-owned.
+ * - JSON, default error responses, and health routes can be enabled independently.
+ * - The installer does not register any application routes beyond health/readiness.
+ *
+ * ```kotlin
+ * fun Application.module() {
+ *     installBluetape4kKtorCore()
+ * }
+ * ```
+ */
+fun Application.installBluetape4kKtorCore(
+    config: Bluetape4kKtorCoreConfig = Bluetape4kKtorCoreConfig(),
+) {
+    if (config.installContentNegotiation) {
+        install(ContentNegotiation) {
+            json(config.json)
+        }
+    }
+
+    if (config.installStatusPages) {
+        install(StatusPages) {
+            bluetape4kErrorResponses()
+        }
+    }
+
+    if (config.installHealthRoutes) {
+        routing {
+            bluetape4kHealthRoutes(
+                healthPath = config.healthPath,
+                readinessPath = config.readinessPath
+            )
+        }
+    }
+}

--- a/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/Bluetape4kKtorCoreConfig.kt
+++ b/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/Bluetape4kKtorCoreConfig.kt
@@ -1,0 +1,38 @@
+package io.bluetape4k.ktor.core
+
+import io.bluetape4k.support.requireNotBlank
+import kotlinx.serialization.json.Json
+
+/**
+ * Explicit opt-in configuration for [installBluetape4kKtorCore].
+ *
+ * ## Contract
+ * - No Spring Boot auto-configuration is involved.
+ * - Applications can disable each installed Ktor feature independently.
+ * - Health and readiness paths must be absolute Ktor route paths.
+ */
+class Bluetape4kKtorCoreConfig(
+    val json: Json = Bluetape4kKtorJson.defaultJson(),
+    val installContentNegotiation: Boolean = true,
+    val installStatusPages: Boolean = true,
+    val installHealthRoutes: Boolean = true,
+    val healthPath: String = DEFAULT_HEALTH_PATH,
+    val readinessPath: String = DEFAULT_READINESS_PATH,
+) {
+
+    init {
+        healthPath.requireAbsoluteKtorPath("healthPath")
+        readinessPath.requireAbsoluteKtorPath("readinessPath")
+    }
+
+    companion object {
+        const val DEFAULT_HEALTH_PATH: String = "/healthz"
+        const val DEFAULT_READINESS_PATH: String = "/readyz"
+    }
+}
+
+internal fun String.requireAbsoluteKtorPath(parameterName: String): String {
+    requireNotBlank(parameterName)
+    require(startsWith("/")) { "$parameterName[$this] must start with '/'." }
+    return this
+}

--- a/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/Bluetape4kKtorJson.kt
+++ b/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/Bluetape4kKtorJson.kt
@@ -1,0 +1,27 @@
+package io.bluetape4k.ktor.core
+
+import kotlinx.serialization.json.Json
+
+/**
+ * JSON defaults shared by bluetape4k Ktor modules.
+ *
+ * ## Contract
+ * - Unknown fields are ignored to keep clients forward-compatible.
+ * - Default values are encoded so small health/error DTOs remain explicit.
+ * - Null properties are omitted from responses.
+ *
+ * ```kotlin
+ * install(ContentNegotiation) {
+ *     json(Bluetape4kKtorJson.defaultJson())
+ * }
+ * ```
+ */
+object Bluetape4kKtorJson {
+
+    fun defaultJson(): Json =
+        Json {
+            ignoreUnknownKeys = true
+            encodeDefaults = true
+            explicitNulls = false
+        }
+}

--- a/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/Bluetape4kStatusPages.kt
+++ b/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/Bluetape4kStatusPages.kt
@@ -1,0 +1,61 @@
+package io.bluetape4k.ktor.core
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.plugins.statuspages.StatusPagesConfig
+import io.ktor.server.request.path
+import io.ktor.server.response.respond
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Registers default JSON error responses for common application exceptions.
+ *
+ * ## Contract
+ * - [IllegalArgumentException] is mapped to HTTP 400.
+ * - Unhandled exceptions are mapped to HTTP 500.
+ * - [CancellationException] is rethrown so structured concurrency is preserved.
+ *
+ * ```kotlin
+ * install(StatusPages) {
+ *     bluetape4kErrorResponses()
+ * }
+ * ```
+ */
+fun StatusPagesConfig.bluetape4kErrorResponses() {
+    exception<IllegalArgumentException> { call, cause ->
+        call.respondApiError(
+            status = HttpStatusCode.BadRequest,
+            error = "bad_request",
+            message = cause.message ?: "Bad request"
+        )
+    }
+    exception<Throwable> { call, cause ->
+        if (cause is CancellationException) {
+            throw cause
+        }
+        call.respondApiError(
+            status = HttpStatusCode.InternalServerError,
+            error = "internal_server_error",
+            message = "Internal server error"
+        )
+    }
+}
+
+/**
+ * Responds with the standard bluetape4k JSON error payload.
+ */
+suspend fun ApplicationCall.respondApiError(
+    status: HttpStatusCode,
+    error: String,
+    message: String,
+) {
+    respond(
+        status = status,
+        message = ApiErrorResponse.of(
+            status = status,
+            error = error,
+            message = message,
+            path = request.path()
+        )
+    )
+}

--- a/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/HealthResponse.kt
+++ b/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/HealthResponse.kt
@@ -1,0 +1,35 @@
+package io.bluetape4k.ktor.core
+
+import io.bluetape4k.support.requireNotBlank
+import kotlinx.serialization.Serializable
+import java.io.Serializable as JavaSerializable
+
+/**
+ * Standard health/readiness response body.
+ *
+ * ## Contract
+ * - [status] is a compact status token such as `UP` or `DOWN`.
+ * - [details] contains optional string metadata safe to expose to clients.
+ */
+@Serializable
+data class HealthResponse(
+    val status: String = UP,
+    val details: Map<String, String> = emptyMap(),
+): JavaSerializable {
+
+    init {
+        status.requireNotBlank("status")
+    }
+
+    companion object {
+        private const val serialVersionUID: Long = 1L
+        const val UP: String = "UP"
+        const val DOWN: String = "DOWN"
+
+        fun up(details: Map<String, String> = emptyMap()): HealthResponse =
+            HealthResponse(status = UP, details = details)
+
+        fun down(details: Map<String, String> = emptyMap()): HealthResponse =
+            HealthResponse(status = DOWN, details = details)
+    }
+}

--- a/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/KtorHealthRoutes.kt
+++ b/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/KtorHealthRoutes.kt
@@ -1,0 +1,34 @@
+package io.bluetape4k.ktor.core
+
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+
+/**
+ * Adds standard health and readiness endpoints to a Ktor [Route].
+ *
+ * ## Contract
+ * - Both endpoints return [HealthResponse.up] by default.
+ * - Custom paths must be absolute route paths, for example `/healthz`.
+ *
+ * ```kotlin
+ * routing {
+ *     bluetape4kHealthRoutes()
+ * }
+ * ```
+ */
+fun Route.bluetape4kHealthRoutes(
+    healthPath: String = Bluetape4kKtorCoreConfig.DEFAULT_HEALTH_PATH,
+    readinessPath: String = Bluetape4kKtorCoreConfig.DEFAULT_READINESS_PATH,
+) {
+    healthPath.requireAbsoluteKtorPath("healthPath")
+    readinessPath.requireAbsoluteKtorPath("readinessPath")
+
+    get(healthPath) {
+        call.respond(HealthResponse.up())
+    }
+    get(readinessPath) {
+        call.respond(HealthResponse.up())
+    }
+}

--- a/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/KtorRequestParameters.kt
+++ b/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/KtorRequestParameters.kt
@@ -1,0 +1,48 @@
+package io.bluetape4k.ktor.core
+
+import io.bluetape4k.support.requireNotBlank
+import io.ktor.server.application.ApplicationCall
+
+/**
+ * Returns a required path parameter or throws [IllegalArgumentException].
+ */
+fun ApplicationCall.requiredPathParameter(name: String): String {
+    name.requireNotBlank("name")
+    return parameters[name]
+        ?.takeIf { it.isNotBlank() }
+        ?: throw IllegalArgumentException("Required path parameter '$name' is missing.")
+}
+
+/**
+ * Returns a required query parameter or throws [IllegalArgumentException].
+ */
+fun ApplicationCall.requiredQueryParameter(name: String): String {
+    name.requireNotBlank("name")
+    return request.queryParameters[name]
+        ?.takeIf { it.isNotBlank() }
+        ?: throw IllegalArgumentException("Required query parameter '$name' is missing.")
+}
+
+/**
+ * Parses an optional integer query parameter and validates its range.
+ *
+ * ## Contract
+ * - Missing parameters return [defaultValue].
+ * - Non-integer values throw [IllegalArgumentException].
+ * - Values outside [range] throw [IllegalArgumentException].
+ */
+fun ApplicationCall.intQueryParameter(
+    name: String,
+    defaultValue: Int? = null,
+    range: IntRange? = null,
+): Int? {
+    name.requireNotBlank("name")
+    val rawValue = request.queryParameters[name] ?: return defaultValue
+    val value = rawValue.toIntOrNull()
+        ?: throw IllegalArgumentException("Query parameter '$name' must be an integer.")
+
+    if (range != null && value !in range) {
+        throw IllegalArgumentException("Query parameter '$name' must be in $range.")
+    }
+    return value
+}

--- a/ktor/core/src/test/kotlin/io/bluetape4k/ktor/core/Bluetape4kKtorCoreTest.kt
+++ b/ktor/core/src/test/kotlin/io/bluetape4k/ktor/core/Bluetape4kKtorCoreTest.kt
@@ -1,0 +1,148 @@
+package io.bluetape4k.ktor.core
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.io.Serializable as JavaSerializable
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class Bluetape4kKtorCoreTest {
+
+    private val json = Bluetape4kKtorJson.defaultJson()
+
+    @Test
+    fun `installer provides json health and readiness defaults`() = testApplication {
+        application {
+            installBluetape4kKtorCore()
+            routing {
+                get("/echo") {
+                    call.respond(EchoResponse("blue"))
+                }
+            }
+        }
+
+        val health = json.decodeFromString<HealthResponse>(client.get("/healthz").bodyAsText())
+        val readiness = json.decodeFromString<HealthResponse>(client.get("/readyz").bodyAsText())
+        val echo = json.decodeFromString<EchoResponse>(client.get("/echo").bodyAsText())
+
+        health.status shouldBeEqualTo HealthResponse.UP
+        readiness.status shouldBeEqualTo HealthResponse.UP
+        echo.value shouldBeEqualTo "blue"
+    }
+
+    @Test
+    fun `status pages map illegal arguments to bad request payloads`() = testApplication {
+        application {
+            installBluetape4kKtorCore()
+            routing {
+                get("/bad") {
+                    throw IllegalArgumentException("Invalid input")
+                }
+            }
+        }
+
+        val response = client.get("/bad")
+        val body = json.decodeFromString<ApiErrorResponse>(response.bodyAsText())
+
+        response.status shouldBeEqualTo HttpStatusCode.BadRequest
+        body.error shouldBeEqualTo "bad_request"
+        body.message shouldBeEqualTo "Invalid input"
+        body.status shouldBeEqualTo HttpStatusCode.BadRequest.value
+        body.path shouldBeEqualTo "/bad"
+    }
+
+    @Test
+    fun `status pages hide unhandled exception messages`() = testApplication {
+        application {
+            installBluetape4kKtorCore()
+            routing {
+                get("/failure") {
+                    throw IllegalStateException("secret-token")
+                }
+            }
+        }
+
+        val response = client.get("/failure")
+        val body = json.decodeFromString<ApiErrorResponse>(response.bodyAsText())
+
+        response.status shouldBeEqualTo HttpStatusCode.InternalServerError
+        body.error shouldBeEqualTo "internal_server_error"
+        body.message shouldBeEqualTo "Internal server error"
+        body.path shouldBeEqualTo "/failure"
+    }
+
+    @Test
+    fun `query parameter helpers validate missing malformed and ranged values`() = testApplication {
+        application {
+            installBluetape4kKtorCore()
+            routing {
+                get("/items/{type}") {
+                    call.respond(
+                        QueryResponse(
+                            type = call.requiredPathParameter("type"),
+                            filter = call.requiredQueryParameter("filter"),
+                            size = call.intQueryParameter("size", defaultValue = 10, range = 1..100)
+                        )
+                    )
+                }
+            }
+        }
+
+        val ok = json.decodeFromString<QueryResponse>(
+            client.get("/items/book?filter=recent&size=7").bodyAsText()
+        )
+        ok.type shouldBeEqualTo "book"
+        ok.filter shouldBeEqualTo "recent"
+        ok.size shouldBeEqualTo 7
+
+        val defaultSize = json.decodeFromString<QueryResponse>(
+            client.get("/items/book?filter=recent").bodyAsText()
+        )
+        defaultSize.size shouldBeEqualTo 10
+
+        client.get("/items/book?size=7").status shouldBeEqualTo HttpStatusCode.BadRequest
+        client.get("/items/book?filter=recent&size=abc").status shouldBeEqualTo HttpStatusCode.BadRequest
+        client.get("/items/book?filter=recent&size=101").status shouldBeEqualTo HttpStatusCode.BadRequest
+    }
+
+    @Test
+    fun `config rejects non absolute health paths`() {
+        assertFailsWith<IllegalArgumentException> {
+            Bluetape4kKtorCoreConfig(healthPath = "healthz")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            Bluetape4kKtorCoreConfig(readinessPath = "readyz")
+        }
+    }
+
+    @Serializable
+    private data class EchoResponse(
+        val value: String,
+    ): JavaSerializable {
+        companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    @Serializable
+    private data class QueryResponse(
+        val type: String,
+        val filter: String,
+        val size: Int?,
+    ): JavaSerializable {
+        companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #612

- PR 제목: feat(ktor): implement bluetape4k-ktor-core

- Implements the first `bluetape4k-ktor-core` runtime API surface.
- Adds explicit Ktor baseline installation for JSON content negotiation, default JSON error responses, and health/readiness routes.
- Adds request parameter helpers, README locale updates, focused Ktor test-host coverage, and a lesson note.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Stack

- Depends on #663 (`feat/611-ktor-module-scaffold`).
- Resolves #612 after the stack is merged.

### 기존 섹션: Review Gate

Local 7-tier review artifact: `.omx/artifacts/issue-612-code-review.md`

| Tier | P0 | P1 | Notes |
|---|---:|---:|---|
| Security | 0 | 0 | Default 500 payload hides raw exception messages. |
| Ops/SRE Reliability | 0 | 0 | Health/readiness endpoints are explicit and switchable. |
| Structural Impact | 0 | 0 | Public Ktor/kotlinx types are exposed through `api` dependencies. |
| Kotlin/Code Quality | 0 | 0 | bluetape4k validation helpers used; cancellation is rethrown. |
| Tests/Types | 0 | 0 | Ktor test-host coverage for installer, errors, query helpers, config validation. |
| Performance/Stability | 0 | 0 | No blocking, synchronization, sleeps, or resource lifecycle changes. |
| Docs/Release | 0 | 0 | README.md, README.ko.md, KDoc, and lesson updated. |

### 기존 섹션: Verification

- `git diff --check`
- `rg "GlobalScope|runBlocking\\(|Thread\\.sleep|delay\\(|synchronized\\(|@Synchronized|runCatching\\s*\\{" ktor/core/src/main/kotlin` returned no hits.
- `./gradlew :bluetape4k-ktor-core:test :bluetape4k-ktor-core:koverXmlReport`
- Kover XML: instruction 663/727 (91.2%), branch 32/56 (57.1%), line 90/98 (91.8%).

### 기존 섹션: Not Tested

- Downstream idgenerator Ktor example migration; tracked by #615.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #612, milestone `1.10.0`, assignee `debop`
- PR: #664, head `2acc9cf46cd949fc9b61e3af207a3e490bb3bb83`, milestone `1.10.0`, assignee `debop`
- Base: `develop`, head branch `feat/612-ktor-core`
- Labels: `enhancement`
- State: `MERGED`, merge commit `e62724a00b01db478e5b405a3f1fb86e3f527456`
- CI: - Adds explicit Ktor baseline installation for JSON content negotiation, default JSON error responses, and health/readiness routes. / | Ops/SRE Reliability | 0 | 0 | Health/readiness endpoints are explicit and switchable. | / | Structural Impact | 0 | 0 | Public Ktor/kotlinx types are exposed through `api` dependencies. |

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #664 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e62724a00b01db478e5b405a3f1fb86e3f527456`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
