### PR TITLE
feat(ktor): implement bluetape4k-ktor-observability

### DIFF
--- a/docs/lessons/2026-05-28-issue-613-ktor-observability.md
+++ b/docs/lessons/2026-05-28-issue-613-ktor-observability.md
@@ -1,0 +1,41 @@
+# Issue 613 - Ktor observability baseline helpers
+
+## Context
+
+Issue #613 adds reusable observability helpers after `bluetape4k-ktor-core` was
+merged. The target is production diagnostics without hiding application-owned
+policy such as metric registry, exporter, and tracing backend choices.
+
+## Decision
+
+Provide explicit Ktor-native helpers:
+
+- `installBluetape4kKtorObservability()` installs `CallId`, `CallLogging`, and
+  optional `MicrometerMetrics`.
+- `KtorCorrelationId` sanitizes inbound correlation IDs before MDC or response
+  propagation.
+- `prometheusScrapeRoute()` exposes a route only when the application supplies a
+  `PrometheusMeterRegistry`.
+
+Micrometer core is an API dependency because the installer configuration accepts
+`MeterRegistry`. Prometheus registry stays compile-only for main code and is
+documented as application-owned because only the optional scrape helper requires
+it.
+
+## Outcome
+
+The module avoids global mutable registries and does not install tracing by
+default. OpenTelemetry policy remains application-owned or a future narrower
+module decision.
+
+## Verification
+
+- `./gradlew :bluetape4k-ktor-observability:compileKotlin :bluetape4k-ktor-observability:compileTestKotlin`
+- `./gradlew :bluetape4k-ktor-observability:test :bluetape4k-ktor-observability:koverXmlReport`
+- Kover XML: line coverage 88/92 (95.7%).
+
+## Future Guard
+
+Do not echo caller-supplied correlation headers directly. New observability
+helpers should either sanitize inbound values first or leave propagation to the
+application.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -238,7 +238,10 @@ ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
+ktor-server-call-id = { module = "io.ktor:ktor-server-call-id", version.ref = "ktor" }
+ktor-server-call-logging = { module = "io.ktor:ktor-server-call-logging", version.ref = "ktor" }
 ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
+ktor-server-metrics-micrometer = { module = "io.ktor:ktor-server-metrics-micrometer", version.ref = "ktor" }
 ktor-server-status-pages = { module = "io.ktor:ktor-server-status-pages", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }

--- a/ktor/observability/README.ko.md
+++ b/ktor/observability/README.ko.md
@@ -4,12 +4,53 @@
 
 bluetape4k 생태계를 위한 Ktor observability helper 모듈입니다.
 
-## 범위
+## 기능
 
-- CallId 및 CallLogging helper.
-- 정제된 correlation-id 전파.
-- Micrometer metrics 설치.
-- 선택적 Prometheus scrape route helper.
+- `installBluetape4kKtorObservability()` 명시적 Ktor observability 설정.
+- Ktor `CallId` 기반 sanitized correlation ID 전파.
+- query string을 제외한 기본 로그 메시지와 `CallLogging` MDC 연동.
+- 애플리케이션이 `MeterRegistry`를 제공할 때 Micrometer `MicrometerMetrics` 설치.
+- 애플리케이션이 소유한 `PrometheusMeterRegistry` 기반 선택적 scrape route.
 
-이 scaffold는 아직 production API를 추가하지 않습니다. 구현은 module 등록
-검증 이후 #613에서 진행합니다.
+## 의존성
+
+```kotlin
+dependencies {
+    implementation("io.bluetape4k:bluetape4k-ktor-observability")
+
+    // Prometheus scrape route를 사용할 때만 필요합니다.
+    implementation("io.micrometer:micrometer-registry-prometheus")
+}
+```
+
+## 사용 예
+
+```kotlin
+import io.bluetape4k.ktor.observability.Bluetape4kKtorObservabilityConfig
+import io.bluetape4k.ktor.observability.installBluetape4kKtorObservability
+import io.bluetape4k.ktor.observability.prometheusScrapeRoute
+import io.ktor.server.application.Application
+import io.ktor.server.routing.routing
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+
+fun Application.module(registry: PrometheusMeterRegistry) {
+    installBluetape4kKtorObservability(
+        Bluetape4kKtorObservabilityConfig(meterRegistry = registry)
+    )
+
+    routing {
+        prometheusScrapeRoute(registry)
+    }
+}
+```
+
+## 의존성 정책
+
+이 모듈은 Ktor `CallId`, `CallLogging`, `MicrometerMetrics`를 명시적으로
+설치합니다. 실제 `MeterRegistry`, exporter, tracing backend는 애플리케이션이
+소유합니다. OpenTelemetry tracing은 이 모듈에서 기본 설치하지 않습니다.
+exporter 정책이 정해진 애플리케이션 또는 더 좁은 후속 모듈에서 tracing bridge를
+추가하세요.
+
+수신 correlation ID는 그대로 echo하지 않습니다. trim, safe character filtering,
+length cap을 거친 값만 MDC와 응답 헤더에 사용합니다.

--- a/ktor/observability/README.md
+++ b/ktor/observability/README.md
@@ -4,12 +4,53 @@
 
 Ktor observability helpers for the bluetape4k ecosystem.
 
-## Scope
+## Features
 
-- CallId and CallLogging helpers.
-- Sanitized correlation-id propagation.
-- Micrometer metrics installation.
-- Optional Prometheus scrape route helper.
+- `installBluetape4kKtorObservability()` for explicit Ktor observability setup.
+- Sanitized correlation ID propagation through Ktor `CallId`.
+- `CallLogging` MDC integration with query-string-free default log messages.
+- Micrometer `MicrometerMetrics` installation when an application supplies a `MeterRegistry`.
+- Optional Prometheus scrape route backed by an application-owned `PrometheusMeterRegistry`.
 
-This scaffold intentionally adds no production API yet. Implementation follows
-#613 after the module registration is verified.
+## Dependency
+
+```kotlin
+dependencies {
+    implementation("io.bluetape4k:bluetape4k-ktor-observability")
+
+    // Required only when Prometheus scrape routing is used.
+    implementation("io.micrometer:micrometer-registry-prometheus")
+}
+```
+
+## Usage
+
+```kotlin
+import io.bluetape4k.ktor.observability.Bluetape4kKtorObservabilityConfig
+import io.bluetape4k.ktor.observability.installBluetape4kKtorObservability
+import io.bluetape4k.ktor.observability.prometheusScrapeRoute
+import io.ktor.server.application.Application
+import io.ktor.server.routing.routing
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+
+fun Application.module(registry: PrometheusMeterRegistry) {
+    installBluetape4kKtorObservability(
+        Bluetape4kKtorObservabilityConfig(meterRegistry = registry)
+    )
+
+    routing {
+        prometheusScrapeRoute(registry)
+    }
+}
+```
+
+## Dependency Policy
+
+The module installs Ktor `CallId`, `CallLogging`, and `MicrometerMetrics`
+explicitly. Applications still own the actual `MeterRegistry`, exporters, and
+tracing backend. OpenTelemetry tracing is not installed by default in this
+module; add a tracing bridge in the application or a narrower future module when
+the exporter policy is known.
+
+Incoming correlation IDs are never echoed directly. They are trimmed, filtered
+to safe characters, capped, and only then added to MDC or response headers.

--- a/ktor/observability/build.gradle.kts
+++ b/ktor/observability/build.gradle.kts
@@ -5,10 +5,12 @@ configurations {
 dependencies {
     api(project(":bluetape4k-ktor-core"))
     api(libs.ktor.server.core)
+    api(libs.ktor.server.call.id)
+    api(libs.ktor.server.call.logging)
+    api(libs.ktor.server.metrics.micrometer)
+    api(libs.micrometer.core)
 
-    compileOnly(project(":bluetape4k-micrometer"))
-    compileOnly(libs.micrometer.core)
-    testImplementation(libs.micrometer.core)
+    compileOnly(libs.micrometer.registry.prometheus)
     testImplementation(libs.micrometer.registry.prometheus)
 
     testImplementation(project(":bluetape4k-junit5"))

--- a/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservability.kt
+++ b/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservability.kt
@@ -1,0 +1,47 @@
+package io.bluetape4k.ktor.observability
+
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.metrics.micrometer.MicrometerMetrics
+import io.ktor.server.plugins.callid.CallId
+import io.ktor.server.plugins.calllogging.CallLogging
+
+/**
+ * Installs the bluetape4k Ktor observability baseline.
+ *
+ * ## Contract
+ * - Plugin installation is explicit and application-owned.
+ * - Correlation IDs are sanitized before MDC or response propagation.
+ * - Micrometer metrics are installed only when a [Bluetape4kKtorObservabilityConfig.meterRegistry] is provided.
+ *
+ * ```kotlin
+ * fun Application.module(registry: MeterRegistry) {
+ *     installBluetape4kKtorObservability(
+ *         Bluetape4kKtorObservabilityConfig(meterRegistry = registry)
+ *     )
+ * }
+ * ```
+ */
+fun Application.installBluetape4kKtorObservability(
+    config: Bluetape4kKtorObservabilityConfig = Bluetape4kKtorObservabilityConfig(),
+) {
+    if (config.installCorrelationId) {
+        install(CallId) {
+            bluetape4kCorrelationIds(config.correlationId)
+        }
+    }
+
+    if (config.installCallLogging) {
+        install(CallLogging) {
+            bluetape4kCallLogging(config.callLogging)
+        }
+    }
+
+    val registry = config.meterRegistry
+    if (config.installMicrometerMetrics && registry != null) {
+        install(MicrometerMetrics) {
+            this.registry = registry
+            config.configureMicrometer(this)
+        }
+    }
+}

--- a/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservabilityConfig.kt
+++ b/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservabilityConfig.kt
@@ -1,0 +1,28 @@
+package io.bluetape4k.ktor.observability
+
+import io.ktor.server.metrics.micrometer.MicrometerMetricsConfig
+import io.micrometer.core.instrument.MeterRegistry
+
+/**
+ * Explicit opt-in configuration for [installBluetape4kKtorObservability].
+ *
+ * ## Contract
+ * - CallId and CallLogging are enabled by default.
+ * - Micrometer is enabled only when [meterRegistry] is supplied.
+ * - Prometheus export is provided by route helpers, not by this installer.
+ */
+class Bluetape4kKtorObservabilityConfig(
+    val correlationId: CorrelationIdSettings = CorrelationIdSettings(),
+    val callLogging: CallLoggingSettings = CallLoggingSettings(correlationId = correlationId),
+    val meterRegistry: MeterRegistry? = null,
+    val installCorrelationId: Boolean = true,
+    val installCallLogging: Boolean = true,
+    val installMicrometerMetrics: Boolean = meterRegistry != null,
+    val configureMicrometer: MicrometerMetricsConfig.() -> Unit = {},
+) {
+    init {
+        require(!installMicrometerMetrics || meterRegistry != null) {
+            "meterRegistry must be provided when installMicrometerMetrics is true."
+        }
+    }
+}

--- a/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/CallLoggingSettings.kt
+++ b/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/CallLoggingSettings.kt
@@ -1,0 +1,23 @@
+package io.bluetape4k.ktor.observability
+
+import io.bluetape4k.support.requireNotBlank
+import org.slf4j.event.Level
+import java.io.Serializable
+
+/**
+ * Call logging settings for the bluetape4k Ktor observability baseline.
+ */
+data class CallLoggingSettings(
+    val correlationId: CorrelationIdSettings = CorrelationIdSettings(),
+    val level: Level = Level.INFO,
+    val excludedPaths: Set<String> = setOf("/healthz", "/readyz", "/metrics"),
+): Serializable {
+
+    init {
+        excludedPaths.forEach { it.requireNotBlank("excludedPaths") }
+    }
+
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/CorrelationIdSettings.kt
+++ b/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/CorrelationIdSettings.kt
@@ -1,0 +1,36 @@
+package io.bluetape4k.ktor.observability
+
+import io.bluetape4k.support.requireInRange
+import io.bluetape4k.support.requireNotBlank
+import io.ktor.http.HttpHeaders
+import java.io.Serializable
+
+/**
+ * Correlation ID policy used by CallId and CallLogging helpers.
+ *
+ * ## Contract
+ * - Incoming header values are sanitized and capped before use.
+ * - Generated values use bluetape4k Base58 random strings.
+ * - Response propagation uses the sanitized/generated value, never the raw header.
+ */
+data class CorrelationIdSettings(
+    val requestHeaderName: String = HttpHeaders.XRequestId,
+    val responseHeaderName: String = requestHeaderName,
+    val mdcKey: String = "correlation-id",
+    val generatedLength: Int = KtorCorrelationId.DEFAULT_GENERATED_LENGTH,
+    val maxLength: Int = KtorCorrelationId.DEFAULT_MAX_LENGTH,
+    val propagateResponseHeader: Boolean = true,
+): Serializable {
+
+    init {
+        requestHeaderName.requireNotBlank("requestHeaderName")
+        responseHeaderName.requireNotBlank("responseHeaderName")
+        mdcKey.requireNotBlank("mdcKey")
+        generatedLength.requireInRange(8, 128, "generatedLength")
+        maxLength.requireInRange(8, 256, "maxLength")
+    }
+
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/KtorCallIdSupport.kt
+++ b/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/KtorCallIdSupport.kt
@@ -1,0 +1,74 @@
+package io.bluetape4k.ktor.observability
+
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.support.requirePositiveNumber
+import io.ktor.server.plugins.callid.CallIdConfig
+
+/**
+ * Correlation ID utilities for Ktor server calls.
+ */
+object KtorCorrelationId {
+
+    const val DEFAULT_GENERATED_LENGTH: Int = 16
+    const val DEFAULT_MAX_LENGTH: Int = 64
+
+    private val allowedChars: Set<Char> =
+        ('a'..'z').toSet() +
+            ('A'..'Z').toSet() +
+            ('0'..'9').toSet() +
+            setOf('-', '_', '.')
+
+    /**
+     * Sanitizes a caller-supplied correlation ID.
+     *
+     * Returns `null` when the value is blank or has no allowed characters.
+     */
+    fun sanitize(rawValue: String?, maxLength: Int = DEFAULT_MAX_LENGTH): String? {
+        maxLength.requirePositiveNumber("maxLength")
+        val sanitized = rawValue
+            ?.trim()
+            ?.asSequence()
+            ?.filter { it in allowedChars }
+            ?.take(maxLength)
+            ?.joinToString(separator = "")
+            .orEmpty()
+
+        return sanitized.takeIf { it.isNotBlank() }
+    }
+
+    /**
+     * Generates a Base58 correlation ID.
+     */
+    fun generate(length: Int = DEFAULT_GENERATED_LENGTH): String {
+        length.requirePositiveNumber("length")
+        return Base58.randomString(length)
+    }
+
+    fun isValid(value: String, maxLength: Int = DEFAULT_MAX_LENGTH): Boolean =
+        value.length in 1..maxLength && value.all { it in allowedChars }
+}
+
+/**
+ * Configures Ktor CallId with bluetape4k sanitization and response propagation.
+ */
+fun CallIdConfig.bluetape4kCorrelationIds(
+    settings: CorrelationIdSettings = CorrelationIdSettings(),
+) {
+    retrieve { call ->
+        KtorCorrelationId.sanitize(
+            rawValue = call.request.headers[settings.requestHeaderName],
+            maxLength = settings.maxLength
+        )
+    }
+    generate {
+        KtorCorrelationId.generate(settings.generatedLength)
+    }
+    verify { callId ->
+        KtorCorrelationId.isValid(callId, settings.maxLength)
+    }
+    if (settings.propagateResponseHeader) {
+        reply { call, callId ->
+            call.response.headers.append(settings.responseHeaderName, callId)
+        }
+    }
+}

--- a/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/KtorCallLoggingSupport.kt
+++ b/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/KtorCallLoggingSupport.kt
@@ -1,0 +1,32 @@
+package io.bluetape4k.ktor.observability
+
+import io.ktor.server.plugins.callid.callId
+import io.ktor.server.plugins.callid.callIdMdc
+import io.ktor.server.plugins.calllogging.CallLoggingConfig
+import io.ktor.server.plugins.calllogging.processingTimeMillis
+import io.ktor.server.request.httpMethod
+import io.ktor.server.request.path
+
+/**
+ * Configures Ktor CallLogging with sanitized correlation ID MDC.
+ *
+ * ## Contract
+ * - Caller headers are not logged directly.
+ * - Query strings are not included in the default log message.
+ * - Common health/metrics scrape paths can be filtered out.
+ */
+fun CallLoggingConfig.bluetape4kCallLogging(
+    settings: CallLoggingSettings = CallLoggingSettings(),
+) {
+    level = settings.level
+    disableDefaultColors()
+    callIdMdc(settings.correlationId.mdcKey)
+    filter { call ->
+        call.request.path() !in settings.excludedPaths
+    }
+    format { call ->
+        val status = call.response.status()?.value ?: "unhandled"
+        val callId = call.callId ?: "-"
+        "${call.request.httpMethod.value} ${call.request.path()} status=$status elapsed=${call.processingTimeMillis()}ms correlationId=$callId"
+    }
+}

--- a/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/KtorPrometheusRoutes.kt
+++ b/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/KtorPrometheusRoutes.kt
@@ -1,0 +1,36 @@
+package io.bluetape4k.ktor.observability
+
+import io.bluetape4k.support.requireNotBlank
+import io.ktor.http.ContentType
+import io.ktor.server.application.call
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+
+/**
+ * Adds a Prometheus scrape endpoint backed by [PrometheusMeterRegistry].
+ *
+ * ## Contract
+ * - The registry is supplied by the application.
+ * - The helper only exposes the route; it does not create exporters or global registries.
+ */
+fun Route.prometheusScrapeRoute(
+    registry: PrometheusMeterRegistry,
+    path: String = "/metrics",
+) {
+    path.requireAbsoluteKtorPath("path")
+
+    get(path) {
+        call.respondText(
+            text = registry.scrape(),
+            contentType = ContentType.Text.Plain
+        )
+    }
+}
+
+private fun String.requireAbsoluteKtorPath(parameterName: String): String {
+    requireNotBlank(parameterName)
+    require(startsWith("/")) { "$parameterName[$this] must start with '/'." }
+    return this
+}

--- a/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservabilityTest.kt
+++ b/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservabilityTest.kt
@@ -1,0 +1,117 @@
+package io.bluetape4k.ktor.observability
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class Bluetape4kKtorObservabilityTest {
+
+    @Test
+    fun `sanitize correlation id removes unsafe characters and caps length`() {
+        val sanitized = KtorCorrelationId.sanitize(
+            rawValue = "  abcDEF-_.\r\nInjected: 한글 1234567890  ",
+            maxLength = 12
+        )
+
+        sanitized shouldBeEqualTo "abcDEF-_.Inj"
+    }
+
+    @Test
+    fun `observability installer propagates sanitized request correlation id`() = testApplication {
+        application {
+            installBluetape4kKtorObservability()
+            routing {
+                get("/ping") {
+                    call.respondText("pong")
+                }
+            }
+        }
+
+        val response = client.get("/ping") {
+            header(HttpHeaders.XRequestId, "REQ_123-ABC")
+        }
+
+        response.status shouldBeEqualTo HttpStatusCode.OK
+        response.headers[HttpHeaders.XRequestId] shouldBeEqualTo "REQ_123-ABC"
+    }
+
+    @Test
+    fun `observability installer generates correlation id when request header is missing`() = testApplication {
+        application {
+            installBluetape4kKtorObservability()
+            routing {
+                get("/ping") {
+                    call.respondText("pong")
+                }
+            }
+        }
+
+        val response = client.get("/ping")
+        val generated = response.headers[HttpHeaders.XRequestId]
+
+        response.status shouldBeEqualTo HttpStatusCode.OK
+        generated.shouldNotBeNull()
+        generated.length shouldBeEqualTo KtorCorrelationId.DEFAULT_GENERATED_LENGTH
+        KtorCorrelationId.isValid(generated) shouldBeEqualTo true
+    }
+
+    @Test
+    fun `micrometer metrics are installed when registry is provided`() = testApplication {
+        val registry = SimpleMeterRegistry()
+
+        application {
+            installBluetape4kKtorObservability(
+                Bluetape4kKtorObservabilityConfig(meterRegistry = registry)
+            )
+            routing {
+                get("/ping") {
+                    call.respondText("pong")
+                }
+            }
+        }
+
+        client.get("/ping").status shouldBeEqualTo HttpStatusCode.OK
+
+        registry.meters.isNotEmpty() shouldBeEqualTo true
+    }
+
+    @Test
+    fun `observability config rejects micrometer installation without registry`() {
+        assertFailsWith<IllegalArgumentException> {
+            Bluetape4kKtorObservabilityConfig(installMicrometerMetrics = true)
+        }
+    }
+
+    @Test
+    fun `prometheus scrape route exposes registry content`() = testApplication {
+        val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+        registry.counter("demo.requests").increment()
+
+        application {
+            routing {
+                prometheusScrapeRoute(registry)
+            }
+        }
+
+        val response = client.get("/metrics")
+
+        response.status shouldBeEqualTo HttpStatusCode.OK
+        response.bodyAsText().contains("demo_requests_total") shouldBeEqualTo true
+    }
+}


### PR DESCRIPTION
## Summary

Closes #613

- PR 제목: feat(ktor): implement bluetape4k-ktor-observability

- Implements `bluetape4k-ktor-observability` runtime helpers.
- Adds sanitized correlation ID propagation through Ktor `CallId` and MDC-aware `CallLogging` defaults.
- Adds optional Micrometer metrics installation and Prometheus scrape route helper with application-owned registries.
- Updates README/README.ko.md and records a lesson for observability policy boundaries.

Resolves #613.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Dependency Policy

- Ktor `CallId`, `CallLogging`, and `MicrometerMetrics` are explicit module dependencies.
- `MeterRegistry` is supplied by the application.
- `PrometheusMeterRegistry` remains application-owned and is used only by the optional scrape route helper.
- OpenTelemetry tracing is not installed by default; exporter/backend policy stays with the application or a future narrower module.

### 기존 섹션: Review Gate

Local 7-tier review artifact: `.omx/artifacts/issue-613-code-review.md`

| Tier | P0 | P1 | Notes |
|---|---:|---:|---|
| Security | 0 | 0 | Inbound correlation IDs are sanitized and capped before MDC/response propagation. |
| Ops/SRE Reliability | 0 | 0 | Metrics install fails fast when enabled without a registry. |
| Structural Impact | 0 | 0 | Dependency aliases are explicit; optional Prometheus export is route-only. |
| Kotlin/Code Quality | 0 | 0 | bluetape4k validation helpers used; no global registry state. |
| Tests/Types | 0 | 0 | 6 Ktor test-host tests cover sanitizer, propagation, generation, metrics, config failure, scrape route. |
| Performance/Stability | 0 | 0 | No blocking, sleeps, synchronization, or resource lifecycle changes. |
| Docs/Release | 0 | 0 | README locale set, KDoc, and lesson updated. |

### 기존 섹션: Verification

- Context7 was unavailable due quota; official Ktor docs were fetched from `ktor.io` for CallId, CallLogging, and MicrometerMetrics.
- `git diff --check`
- `rg "GlobalScope|runBlocking\\(|Thread\\.sleep|delay\\(|synchronized\\(|@Synchronized|runCatching\\s*\\{" ktor/observability/src/main/kotlin` returned no hits.
- `./gradlew :bluetape4k-ktor-observability:compileKotlin :bluetape4k-ktor-observability:compileTestKotlin`
- `./gradlew :bluetape4k-ktor-observability:test :bluetape4k-ktor-observability:koverXmlReport`
- Kover XML: instruction 661/708 (93.4%), branch 30/44 (68.2%), line 88/92 (95.7%).

### 기존 섹션: Not Tested

- Downstream idgenerator Ktor example adoption; tracked by #615.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #613, milestone `1.10.0`, assignee `debop`
- PR: #665, head `4dcf3440ca28e5cc0924ca10d59da431a78c92f4`, milestone `1.10.0`, assignee `debop`
- Base: `develop`, head branch `feat/613-ktor-observability`
- Labels: `enhancement`
- State: `MERGED`, merge commit `ec8d6b0854aba309a5c5f6a3fe81c4811f8dea5d`
- CI: - Ktor `CallId`, `CallLogging`, and `MicrometerMetrics` are explicit module dependencies. / - OpenTelemetry tracing is not installed by default; exporter/backend policy stays with the application or a future narrower module. / | Structural Impact | 0 | 0 | Dependency aliases are explicit; optional Prometheus export is route-only. |

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #665 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `ec8d6b0854aba309a5c5f6a3fe81c4811f8dea5d`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
