### PR TITLE
feat(ktor): implement bluetape4k-ktor-testing

### DIFF
--- a/docs/lessons/2026-05-28-issue-614-ktor-testing.md
+++ b/docs/lessons/2026-05-28-issue-614-ktor-testing.md
@@ -1,0 +1,36 @@
+# Issue 614 - Ktor testing helpers
+
+## Context
+
+`bluetape4k-ktor-core` and `bluetape4k-ktor-observability` introduced reusable
+Ktor server helpers, but tests still repeated JSON decoding, status assertions,
+and standard API error payload checks.
+
+## Decision
+
+Add a small `bluetape4k-ktor-testing` API surface:
+
+- `installBluetape4kKtorCoreForTest` keeps Ktor `testApplication` ownership in
+  the test while reducing core setup boilerplate.
+- `bluetape4kJsonClient` uses the same JSON defaults as `bluetape4k-ktor-core`.
+- `decodeJsonBody`, `shouldHaveStatus`, `shouldHaveJsonBody`, and
+  `shouldHaveApiError` centralize response assertions.
+- `bluetape4kJsonMockEngine` covers one-response JSON client tests without
+  adding a larger mocking abstraction.
+
+## Outcome
+
+The idgenerator Ktor example now consumes the shared response helpers instead
+of hand-decoding every response with a local `Json` instance.
+
+## Verification
+
+- `./gradlew :bluetape4k-ktor-testing:compileKotlin :bluetape4k-ktor-testing:compileTestKotlin :idgenerator-ktor-demo:compileTestKotlin`
+- `./gradlew :bluetape4k-ktor-testing:test :bluetape4k-ktor-testing:koverXmlReport :idgenerator-ktor-demo:test`
+- `git diff --check`
+
+## Future guard
+
+Keep this module focused on test-scoped helpers. Do not wrap the full Ktor test
+lifecycle unless repeated consumer tests prove a specific lifecycle abstraction
+is worth the loss of explicit setup.

--- a/examples/ktor/idgenerator-ktor-demo/build.gradle.kts
+++ b/examples/ktor/idgenerator-ktor-demo/build.gradle.kts
@@ -24,5 +24,6 @@ dependencies {
     runtimeOnly(libs.logback.classic)
 
     testImplementation(project(":bluetape4k-junit5"))
+    testImplementation(project(":bluetape4k-ktor-testing"))
     testImplementation(libs.ktor.server.test.host)
 }

--- a/examples/ktor/idgenerator-ktor-demo/src/test/kotlin/io/bluetape4k/examples/ktor/idgenerator/IdGeneratorKtorApplicationTest.kt
+++ b/examples/ktor/idgenerator-ktor-demo/src/test/kotlin/io/bluetape4k/examples/ktor/idgenerator/IdGeneratorKtorApplicationTest.kt
@@ -5,13 +5,12 @@ import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import io.bluetape4k.ktor.testing.decodeJsonBody
+import io.bluetape4k.ktor.testing.shouldHaveStatus
 import io.bluetape4k.utils.Runtimex
 import io.ktor.client.request.get
-import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.testApplication
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.util.concurrent.ConcurrentHashMap
@@ -33,10 +32,6 @@ class IdGeneratorKtorApplicationTest {
         private const val CONCURRENCY_COUNT = 512
     }
 
-    private val json = Json {
-        ignoreUnknownKeys = true
-    }
-
     @Test
     fun `all explicit single id endpoints return non blank ids`() = testApplication {
         application {
@@ -45,9 +40,9 @@ class IdGeneratorKtorApplicationTest {
 
         ExplicitTypes.forEach { type ->
             val response = client.get("/ids/$type")
-            response.status shouldBeEqualTo HttpStatusCode.OK
+            response shouldHaveStatus HttpStatusCode.OK
 
-            val body = json.decodeFromString<IdResponse>(response.bodyAsText())
+            val body = response.decodeJsonBody<IdResponse>()
             body.type shouldBeEqualTo type
             body.id.isNotBlank() shouldBeEqualTo true
         }
@@ -61,9 +56,9 @@ class IdGeneratorKtorApplicationTest {
 
         ExplicitTypes.forEach { type ->
             val response = client.get("/ids/$type/batch?size=$BATCH_SIZE")
-            response.status shouldBeEqualTo HttpStatusCode.OK
+            response shouldHaveStatus HttpStatusCode.OK
 
-            val body = json.decodeFromString<IdBatchResponse>(response.bodyAsText())
+            val body = response.decodeJsonBody<IdBatchResponse>()
             body.type shouldBeEqualTo type
             body.size shouldBeEqualTo BATCH_SIZE
             body.ids shouldHaveSize BATCH_SIZE
@@ -82,15 +77,9 @@ class IdGeneratorKtorApplicationTest {
             idGeneratorKtorModule(registry)
         }
 
-        val explicit = json.decodeFromString<IdResponse>(
-            client.get("/ids/uuid-v7").bodyAsText()
-        )
-        val generic = json.decodeFromString<IdResponse>(
-            client.get("/idgen/uuid-v7").bodyAsText()
-        )
-        val genericBatch = json.decodeFromString<IdBatchResponse>(
-            client.get("/idgen/uuid-v7/batch?size=3").bodyAsText()
-        )
+        val explicit = client.get("/ids/uuid-v7").decodeJsonBody<IdResponse>()
+        val generic = client.get("/idgen/uuid-v7").decodeJsonBody<IdResponse>()
+        val genericBatch = client.get("/idgen/uuid-v7/batch?size=3").decodeJsonBody<IdBatchResponse>()
 
         explicit.id shouldBeEqualTo "shared-1"
         generic.id shouldBeEqualTo "shared-2"
@@ -103,14 +92,10 @@ class IdGeneratorKtorApplicationTest {
             idGeneratorKtorModule()
         }
 
-        val health = json.decodeFromString<HealthResponse>(
-            client.get("/health").bodyAsText()
-        )
+        val health = client.get("/health").decodeJsonBody<HealthResponse>()
         health.status shouldBeEqualTo "UP"
 
-        val generators = json.decodeFromString<GeneratorsResponse>(
-            client.get("/generators").bodyAsText()
-        )
+        val generators = client.get("/generators").decodeJsonBody<GeneratorsResponse>()
         generators.generators.map { it.type } shouldBeEqualTo ExplicitTypes
         generators.genericEndpoints shouldBeEqualTo listOf(
             "/idgen/{type}",
@@ -144,9 +129,9 @@ class IdGeneratorKtorApplicationTest {
                 .rounds(CONCURRENCY_COUNT)
                 .add {
                     val response = client.get(endpoint)
-                    response.status shouldBeEqualTo HttpStatusCode.OK
+                    response shouldHaveStatus HttpStatusCode.OK
 
-                    val id = json.decodeFromString<IdResponse>(response.bodyAsText()).id
+                    val id = response.decodeJsonBody<IdResponse>().id
                     id.shouldNotBeNull()
                     idMap.putIfAbsent(id, 1).shouldBeNull()
                 }.run()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -235,6 +235,7 @@ kotlinx-serialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-seria
 # Ktor
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }

--- a/ktor/testing/README.ko.md
+++ b/ktor/testing/README.ko.md
@@ -4,12 +4,63 @@
 
 bluetape4k 생태계를 위한 Ktor 테스트 helper 모듈입니다.
 
-## 범위
+## 기능
 
-- `testApplication` setup helper.
-- JSON test client factory.
-- Response decode helper.
-- Status, body, API error assertion.
+- Ktor `testApplication` 생명주기를 숨기지 않는 `bluetape4k-ktor-core` 설치 helper.
+- `Bluetape4kKtorJson.defaultJson()`을 사용하는 JSON test client factory.
+- kotlinx serialization 응답 decode helper.
+- HTTP status, JSON body, 표준 `ApiErrorResponse` assertion.
+- 단일 JSON 응답 client test를 위한 작은 `MockEngine` helper.
 
-이 scaffold는 아직 production API를 추가하지 않습니다. 구현은 module 등록
-검증 이후 #614에서 진행합니다.
+## 의존성
+
+```kotlin
+testImplementation("io.github.bluetape4k:bluetape4k-ktor-testing")
+```
+
+## 사용 예
+
+```kotlin
+@Test
+fun `endpoint returns json`() = testApplication {
+    installBluetape4kKtorCoreForTest {
+        get("/echo") {
+            call.respond(EchoResponse("blue"))
+        }
+    }
+
+    val response = client.get("/echo")
+
+    response shouldHaveStatus HttpStatusCode.OK
+    response.shouldHaveJsonBody(EchoResponse("blue"))
+}
+```
+
+typed request/response body가 필요한 테스트에서는 JSON-aware Ktor test client를
+만들 수 있습니다.
+
+```kotlin
+val jsonClient = bluetape4kJsonClient()
+val body = jsonClient.get("/echo").body<EchoResponse>()
+```
+
+표준 bluetape4k error payload도 바로 검증할 수 있습니다.
+
+```kotlin
+client.get("/bad").shouldHaveApiError(
+    ExpectedApiError(
+        status = HttpStatusCode.BadRequest,
+        error = "bad_request",
+        message = "Invalid input",
+        path = "/bad"
+    )
+)
+```
+
+단순 client-side test에는 `bluetape4kJsonMockEngine`을 사용합니다.
+
+```kotlin
+val client = HttpClient(
+    bluetape4kJsonMockEngine(EchoResponse("mock"))
+)
+```

--- a/ktor/testing/README.md
+++ b/ktor/testing/README.md
@@ -4,12 +4,63 @@
 
 Ktor testing helpers for the bluetape4k ecosystem.
 
-## Scope
+## Features
 
-- `testApplication` setup helpers.
-- JSON test client factory.
-- Response decode helpers.
-- Status, body, and API error assertions.
+- `testApplication` setup helper that installs `bluetape4k-ktor-core` without hiding the Ktor test lifecycle.
+- JSON test client factory using `Bluetape4kKtorJson.defaultJson()`.
+- Response decode helpers for kotlinx serialization.
+- Status, JSON body, and standard `ApiErrorResponse` assertions.
+- Small JSON `MockEngine` helper for one-response client tests.
 
-This scaffold intentionally adds no production API yet. Implementation follows
-#614 after the module registration is verified.
+## Dependency
+
+```kotlin
+testImplementation("io.github.bluetape4k:bluetape4k-ktor-testing")
+```
+
+## Usage
+
+```kotlin
+@Test
+fun `endpoint returns json`() = testApplication {
+    installBluetape4kKtorCoreForTest {
+        get("/echo") {
+            call.respond(EchoResponse("blue"))
+        }
+    }
+
+    val response = client.get("/echo")
+
+    response shouldHaveStatus HttpStatusCode.OK
+    response.shouldHaveJsonBody(EchoResponse("blue"))
+}
+```
+
+Create a JSON-aware Ktor test client when the test uses typed request or
+response bodies:
+
+```kotlin
+val jsonClient = bluetape4kJsonClient()
+val body = jsonClient.get("/echo").body<EchoResponse>()
+```
+
+Verify the standard bluetape4k error payload:
+
+```kotlin
+client.get("/bad").shouldHaveApiError(
+    ExpectedApiError(
+        status = HttpStatusCode.BadRequest,
+        error = "bad_request",
+        message = "Invalid input",
+        path = "/bad"
+    )
+)
+```
+
+Use `bluetape4kJsonMockEngine` for simple client-side tests:
+
+```kotlin
+val client = HttpClient(
+    bluetape4kJsonMockEngine(EchoResponse("mock"))
+)
+```

--- a/ktor/testing/build.gradle.kts
+++ b/ktor/testing/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     api(project(":bluetape4k-assertions"))
     api(libs.ktor.server.test.host)
     api(libs.ktor.client.core)
+    api(libs.ktor.client.content.negotiation)
     api(libs.ktor.client.mock)
 
     implementation(libs.ktor.serialization.kotlinx.json)

--- a/ktor/testing/src/main/kotlin/io/bluetape4k/ktor/testing/Bluetape4kKtorTesting.kt
+++ b/ktor/testing/src/main/kotlin/io/bluetape4k/ktor/testing/Bluetape4kKtorTesting.kt
@@ -1,0 +1,57 @@
+package io.bluetape4k.ktor.testing
+
+import io.bluetape4k.ktor.core.Bluetape4kKtorCoreConfig
+import io.bluetape4k.ktor.core.Bluetape4kKtorJson
+import io.bluetape4k.ktor.core.installBluetape4kKtorCore
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import kotlinx.serialization.json.Json
+
+/**
+ * Installs the bluetape4k Ktor core module in a `testApplication` block.
+ *
+ * ## Contract
+ * - The caller still owns the surrounding Ktor `testApplication` lifecycle.
+ * - The helper installs the same core defaults used by production modules.
+ * - Additional test routes are registered in the same application setup phase.
+ *
+ * ```kotlin
+ * testApplication {
+ *     installBluetape4kKtorCoreForTest {
+ *         get("/ping") { call.respondText("pong") }
+ *     }
+ * }
+ * ```
+ */
+fun ApplicationTestBuilder.installBluetape4kKtorCoreForTest(
+    config: Bluetape4kKtorCoreConfig = Bluetape4kKtorCoreConfig(),
+    routes: Route.() -> Unit = {},
+) {
+    application {
+        installBluetape4kKtorCore(config)
+        routing(routes)
+    }
+}
+
+/**
+ * Creates a Ktor test client with bluetape4k JSON defaults.
+ *
+ * ## Contract
+ * - Uses [Bluetape4kKtorJson.defaultJson] unless a custom [jsonFormat] is supplied.
+ * - The caller can still install additional client plugins through [configure].
+ */
+fun ApplicationTestBuilder.bluetape4kJsonClient(
+    jsonFormat: Json = Bluetape4kKtorJson.defaultJson(),
+    configure: HttpClientConfig<*>.() -> Unit = {},
+): HttpClient =
+    createClient {
+        install(ContentNegotiation) {
+            json(jsonFormat)
+        }
+        configure()
+    }

--- a/ktor/testing/src/main/kotlin/io/bluetape4k/ktor/testing/ExpectedApiError.kt
+++ b/ktor/testing/src/main/kotlin/io/bluetape4k/ktor/testing/ExpectedApiError.kt
@@ -1,0 +1,31 @@
+package io.bluetape4k.ktor.testing
+
+import io.bluetape4k.support.requireNotBlank
+import io.ktor.http.HttpStatusCode
+import java.io.Serializable
+
+/**
+ * Expected standard bluetape4k API error payload for Ktor response assertions.
+ *
+ * ## Contract
+ * - [status] is matched against both the HTTP response and JSON payload status.
+ * - [error] is the stable machine-readable error code.
+ * - [message] and [path] are verified only when present.
+ */
+data class ExpectedApiError(
+    val status: HttpStatusCode,
+    val error: String,
+    val message: String? = null,
+    val path: String? = null,
+): Serializable {
+
+    init {
+        error.requireNotBlank("error")
+        message?.requireNotBlank("message")
+        path?.requireNotBlank("path")
+    }
+
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/ktor/testing/src/main/kotlin/io/bluetape4k/ktor/testing/KtorJsonMockEngineSupport.kt
+++ b/ktor/testing/src/main/kotlin/io/bluetape4k/ktor/testing/KtorJsonMockEngineSupport.kt
@@ -1,0 +1,40 @@
+package io.bluetape4k.ktor.testing
+
+import io.bluetape4k.ktor.core.Bluetape4kKtorJson
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.Headers
+import io.ktor.http.HeadersBuilder
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Creates a Ktor [MockEngine] that returns one JSON response.
+ *
+ * ## Contract
+ * - Response JSON uses bluetape4k Ktor defaults unless [jsonFormat] is supplied.
+ * - `Content-Type: application/json` is added by default.
+ * - The helper stays intentionally small; use Ktor's [MockEngine] directly for
+ *   request-dependent or multi-step scenarios.
+ */
+inline fun <reified T> bluetape4kJsonMockEngine(
+    body: T,
+    status: HttpStatusCode = HttpStatusCode.OK,
+    headers: Headers = Headers.Empty,
+    jsonFormat: Json = Bluetape4kKtorJson.defaultJson(),
+): MockEngine =
+    MockEngine {
+        respond(
+            content = jsonFormat.encodeToString(body),
+            status = status,
+            headers = HeadersBuilder()
+                .apply {
+                    append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    appendAll(headers)
+                }
+                .build()
+        )
+    }

--- a/ktor/testing/src/main/kotlin/io/bluetape4k/ktor/testing/KtorResponseAssertions.kt
+++ b/ktor/testing/src/main/kotlin/io/bluetape4k/ktor/testing/KtorResponseAssertions.kt
@@ -1,0 +1,70 @@
+package io.bluetape4k.ktor.testing
+
+import io.bluetape4k.assertions.fail
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.ktor.core.ApiErrorResponse
+import io.bluetape4k.ktor.core.Bluetape4kKtorJson
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+
+/**
+ * Verifies the HTTP status and returns the same response for chaining.
+ */
+infix fun HttpResponse.shouldHaveStatus(expected: HttpStatusCode): HttpResponse {
+    status shouldBeEqualTo expected
+    return this
+}
+
+/**
+ * Decodes the response body as JSON using bluetape4k Ktor defaults.
+ *
+ * ## Contract
+ * - Decode failures are converted to assertion failures with the raw body.
+ * - The response body is consumed once, matching Ktor client semantics.
+ */
+suspend inline fun <reified T> HttpResponse.decodeJsonBody(
+    jsonFormat: Json = Bluetape4kKtorJson.defaultJson(),
+): T {
+    val rawBody = bodyAsText()
+    return try {
+        jsonFormat.decodeFromString(rawBody)
+    } catch (e: SerializationException) {
+        fail(
+            message = "Expected response body to decode as ${T::class.qualifiedName}, but body was: $rawBody",
+            cause = e
+        )
+    }
+}
+
+/**
+ * Decodes the response body and verifies structural equality.
+ */
+suspend inline fun <reified T> HttpResponse.shouldHaveJsonBody(
+    expected: T,
+    jsonFormat: Json = Bluetape4kKtorJson.defaultJson(),
+): T {
+    val actual = decodeJsonBody<T>(jsonFormat)
+    actual shouldBeEqualTo expected
+    return actual
+}
+
+/**
+ * Verifies a standard bluetape4k [ApiErrorResponse].
+ */
+suspend fun HttpResponse.shouldHaveApiError(
+    expected: ExpectedApiError,
+    jsonFormat: Json = Bluetape4kKtorJson.defaultJson(),
+): ApiErrorResponse {
+    shouldHaveStatus(expected.status)
+
+    val actual = decodeJsonBody<ApiErrorResponse>(jsonFormat)
+    actual.status shouldBeEqualTo expected.status.value
+    actual.error shouldBeEqualTo expected.error
+    expected.message?.let { actual.message shouldBeEqualTo it }
+    expected.path?.let { actual.path shouldBeEqualTo it }
+    return actual
+}

--- a/ktor/testing/src/test/kotlin/io/bluetape4k/ktor/testing/Bluetape4kKtorTestingTest.kt
+++ b/ktor/testing/src/test/kotlin/io/bluetape4k/ktor/testing/Bluetape4kKtorTestingTest.kt
@@ -1,0 +1,83 @@
+package io.bluetape4k.ktor.testing
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.Serializable
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.io.Serializable as JavaSerializable
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class Bluetape4kKtorTestingTest {
+
+    @Test
+    fun `core setup helper installs json status pages and routes`() = testApplication {
+        installBluetape4kKtorCoreForTest {
+            get("/echo") {
+                call.respond(EchoResponse("blue"))
+            }
+            get("/bad") {
+                throw IllegalArgumentException("Invalid input")
+            }
+        }
+
+        val ok = client.get("/echo")
+        ok shouldHaveStatus HttpStatusCode.OK
+        ok.shouldHaveJsonBody(EchoResponse("blue"))
+
+        client.get("/bad").shouldHaveApiError(
+            ExpectedApiError(
+                status = HttpStatusCode.BadRequest,
+                error = "bad_request",
+                message = "Invalid input",
+                path = "/bad"
+            )
+        )
+    }
+
+    @Test
+    fun `json client installs content negotiation with bluetape4k defaults`() = testApplication {
+        installBluetape4kKtorCoreForTest {
+            get("/echo") {
+                call.respond(EchoResponse("client"))
+            }
+        }
+
+        val jsonClient = bluetape4kJsonClient()
+        val body = jsonClient.get("/echo").body<EchoResponse>()
+
+        body shouldBeEqualTo EchoResponse("client")
+    }
+
+    @Test
+    fun `json mock engine returns encoded body with content type`() {
+        val client = HttpClient(
+            bluetape4kJsonMockEngine(EchoResponse("mock"))
+        )
+
+        testApplication {
+            client.use { mockClient ->
+                val response = mockClient.get("/")
+                response.status shouldBeEqualTo HttpStatusCode.OK
+                response.headers["Content-Type"] shouldBeEqualTo "application/json"
+                response.shouldHaveJsonBody(EchoResponse("mock"))
+            }
+        }
+    }
+
+    @Serializable
+    private data class EchoResponse(
+        val value: String,
+    ): JavaSerializable {
+        companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #614

- PR 제목: feat(ktor): implement bluetape4k-ktor-testing

- Add reusable bluetape4k Ktor testing helpers for core test setup, JSON clients, response decoding, API error assertions, and simple JSON MockEngine responses.
- Document usage in README.md and README.ko.md.
- Migrate the idgenerator Ktor example tests to consume the shared response helpers.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- ./gradlew :bluetape4k-ktor-testing:compileKotlin :bluetape4k-ktor-testing:compileTestKotlin :idgenerator-ktor-demo:compileTestKotlin
- ./gradlew :bluetape4k-ktor-testing:test :bluetape4k-ktor-testing:koverXmlReport :idgenerator-ktor-demo:test
- git diff --check
- Local 7-tier review: .omx/artifacts/issue-614-code-review.md, P0=0, P1=0

Resolves #614

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #614, milestone `1.10.0`, assignee `debop`
- PR: #666, head `330cd9f36bfd1808a51edf6a57db3d2cc4d2a4a7`, milestone `1.10.0`, assignee `debop`
- Base: `develop`, head branch `feat/614-ktor-testing`
- Labels: `enhancement`
- State: `MERGED`, merge commit `4b50ce6e5b79910f1a53f562540952a91dd3a993`
- CI: - ./gradlew :bluetape4k-ktor-testing:compileKotlin :bluetape4k-ktor-testing:compileTestKotlin :idgenerator-ktor-demo:compileTestKotlin / - ./gradlew :bluetape4k-ktor-testing:test :bluetape4k-ktor-testing:koverXmlReport :idgenerator-ktor-demo:test

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #666 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `4b50ce6e5b79910f1a53f562540952a91dd3a993`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
