### PR TITLE
fix(grpc): preserve shutdown interruption status

### DIFF
--- a/docs/lessons/2026-05-28-issue-656-657-grpc-interrupt-lifecycle.md
+++ b/docs/lessons/2026-05-28-issue-656-657-grpc-interrupt-lifecycle.md
@@ -1,0 +1,35 @@
+# Issues 656 and 657 - gRPC shutdown interruption
+
+## Context
+
+The port-based and in-process gRPC server base classes used
+`runCatching { awaitTermination(...) }.getOrDefault(false)` during shutdown.
+That preserved forced shutdown on timeout, but it also collapsed
+`InterruptedException` into a normal timeout and lost the caller thread's
+interrupt status.
+
+## Decision
+
+Use explicit `try/catch` around timed `awaitTermination` in both server base
+classes. On `InterruptedException`, restore the interrupt flag with
+`Thread.currentThread().interrupt()` and return `false` so `shutdownNow()` still
+runs. When graceful termination times out without interruption, force shutdown
+and wait once more with the same bounded timeout.
+
+## Outcome
+
+Both shutdown implementations now keep the existing timeout behavior and
+preserve interrupt status when graceful termination is interrupted. Forced
+shutdown now also gets a bounded termination wait instead of being fire-and-forget.
+
+## Verification
+
+- `./gradlew :bluetape4k-grpc:compileKotlin :bluetape4k-grpc:compileTestKotlin :bluetape4k-grpc:test --tests io.bluetape4k.grpc.GrpcServerTest`
+- `./gradlew :bluetape4k-grpc:koverXmlReport`
+- `git diff --check`
+
+## Future guard
+
+Do not use broad `runCatching` around blocking lifecycle APIs that can throw
+`InterruptedException`. Preserve or propagate interruption explicitly before
+falling back to cleanup.

--- a/io/grpc/src/main/kotlin/io/bluetape4k/grpc/AbstractGrpcServer.kt
+++ b/io/grpc/src/main/kotlin/io/bluetape4k/grpc/AbstractGrpcServer.kt
@@ -14,6 +14,8 @@ import kotlinx.atomicfu.locks.reentrantLock
 import java.util.concurrent.TimeUnit
 import kotlin.concurrent.withLock
 
+private const val SHUTDOWN_TIMEOUT_SECONDS = 5L
+
 /**
  * 포트 기반 gRPC 서버를 관리하는 추상 베이스 클래스입니다.
  *
@@ -94,12 +96,36 @@ abstract class AbstractGrpcServer(
                 // awaitTermination은 타임아웃 시 false를 반환하며, 예외가 아닌 반환값으로 판별해야 합니다.
                 // false(타임아웃) 또는 InterruptedException 발생 시 shutdownNow()를 호출해
                 // 스레드가 무기한 잔류하는 것을 방지합니다.
-                val terminated = runCatching { server.awaitTermination(5, TimeUnit.SECONDS) }.getOrDefault(false)
-                if (!terminated) {
+                if (!awaitTerminationOrRestoreInterrupt()) {
                     log.warn { "gRPC server did not terminate within 5 seconds. Forcing shutdownNow()." }
-                    runCatching { server.shutdownNow() }
+                    forceShutdownNowAndAwaitTermination()
                 }
             }
+        }
+    }
+
+    private fun awaitTerminationOrRestoreInterrupt(): Boolean =
+        try {
+            server.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            false
+        }
+
+    private fun forceShutdownNowAndAwaitTermination() {
+        try {
+            server.shutdownNow()
+        } catch (e: RuntimeException) {
+            log.warn(e) { "Failed to force shutdown gRPC server." }
+            return
+        }
+
+        if (Thread.currentThread().isInterrupted) {
+            return
+        }
+
+        if (!awaitTerminationOrRestoreInterrupt()) {
+            log.warn { "gRPC server did not terminate after forced shutdown within 5 seconds." }
         }
     }
 }

--- a/io/grpc/src/main/kotlin/io/bluetape4k/grpc/inprocess/AbstractGrpcInprocessServer.kt
+++ b/io/grpc/src/main/kotlin/io/bluetape4k/grpc/inprocess/AbstractGrpcInprocessServer.kt
@@ -16,6 +16,8 @@ import kotlinx.atomicfu.locks.reentrantLock
 import java.util.concurrent.TimeUnit
 import kotlin.concurrent.withLock
 
+private const val SHUTDOWN_TIMEOUT_SECONDS = 5L
+
 /**
  * in-process gRPC 서버를 관리하는 테스트용 베이스 클래스입니다.
  *
@@ -81,12 +83,36 @@ abstract class AbstractGrpcInprocessServer(
             if (!isShutdown) {
                 running.value = false
                 runCatching { server.shutdown() }
-                val terminated = runCatching { server.awaitTermination(5, TimeUnit.SECONDS) }.getOrDefault(false)
-                if (!terminated) {
+                if (!awaitTerminationOrRestoreInterrupt()) {
                     log.warn { "InProcess gRPC server did not terminate within 5 seconds. Forcing shutdownNow()." }
-                    runCatching { server.shutdownNow() }
+                    forceShutdownNowAndAwaitTermination()
                 }
             }
+        }
+    }
+
+    private fun awaitTerminationOrRestoreInterrupt(): Boolean =
+        try {
+            server.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            false
+        }
+
+    private fun forceShutdownNowAndAwaitTermination() {
+        try {
+            server.shutdownNow()
+        } catch (e: RuntimeException) {
+            log.warn(e) { "Failed to force shutdown InProcess gRPC server." }
+            return
+        }
+
+        if (Thread.currentThread().isInterrupted) {
+            return
+        }
+
+        if (!awaitTerminationOrRestoreInterrupt()) {
+            log.warn { "InProcess gRPC server did not terminate after forced shutdown within 5 seconds." }
         }
     }
 }

--- a/io/grpc/src/test/kotlin/io/bluetape4k/grpc/GrpcServerTest.kt
+++ b/io/grpc/src/test/kotlin/io/bluetape4k/grpc/GrpcServerTest.kt
@@ -92,8 +92,28 @@ class GrpcServerTest: AbstractGrpcTest() {
         server.isRunning.shouldBeFalse()
         server.isShutdown.shouldBeTrue()
         recordingServer.shutdownCalls shouldBeEqualTo 1
-        recordingServer.awaitTimedCalls shouldBeEqualTo 1
+        recordingServer.awaitTimedCalls shouldBeEqualTo 2
         recordingServer.shutdownNowCalls shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `port server stop restores interrupt status when await termination is interrupted`() {
+        val recordingServer = RecordingServer(terminatesGracefully = false, interruptOnAwait = true)
+        val server = RecordingPortLifecycleServer(recordingServer)
+
+        try {
+            server.start()
+            server.stop()
+
+            server.isRunning.shouldBeFalse()
+            server.isShutdown.shouldBeTrue()
+            recordingServer.shutdownCalls shouldBeEqualTo 1
+            recordingServer.awaitTimedCalls shouldBeEqualTo 1
+            recordingServer.shutdownNowCalls shouldBeEqualTo 1
+            Thread.currentThread().isInterrupted.shouldBeTrue()
+        } finally {
+            Thread.interrupted()
+        }
     }
 
     @Test
@@ -165,8 +185,28 @@ class GrpcServerTest: AbstractGrpcTest() {
         server.isRunning.shouldBeFalse()
         server.isShutdown.shouldBeTrue()
         recordingServer.shutdownCalls shouldBeEqualTo 1
-        recordingServer.awaitTimedCalls shouldBeEqualTo 1
+        recordingServer.awaitTimedCalls shouldBeEqualTo 2
         recordingServer.shutdownNowCalls shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `inprocess server stop restores interrupt status when await termination is interrupted`() {
+        val recordingServer = RecordingServer(terminatesGracefully = false, interruptOnAwait = true)
+        val server = RecordingInprocessLifecycleServer(recordingServer)
+
+        try {
+            server.start()
+            server.stop()
+
+            server.isRunning.shouldBeFalse()
+            server.isShutdown.shouldBeTrue()
+            recordingServer.shutdownCalls shouldBeEqualTo 1
+            recordingServer.awaitTimedCalls shouldBeEqualTo 1
+            recordingServer.shutdownNowCalls shouldBeEqualTo 1
+            Thread.currentThread().isInterrupted.shouldBeTrue()
+        } finally {
+            Thread.interrupted()
+        }
     }
 
     private fun inprocessName(): String =
@@ -199,6 +239,7 @@ class GrpcServerTest: AbstractGrpcTest() {
 
     private class RecordingServer(
         private val terminatesGracefully: Boolean,
+        private val interruptOnAwait: Boolean = false,
     ): Server() {
         var shutdownCalls = 0
             private set
@@ -238,6 +279,9 @@ class GrpcServerTest: AbstractGrpcTest() {
 
         override fun awaitTermination(timeout: Long, unit: TimeUnit): Boolean {
             awaitTimedCalls++
+            if (interruptOnAwait) {
+                throw InterruptedException("interrupted during graceful shutdown")
+            }
             return terminated
         }
 


### PR DESCRIPTION
## Summary

Closes #656, #657

- PR 제목: fix(grpc): preserve shutdown interruption status

- Preserve the caller thread interrupt flag when gRPC timed shutdown is interrupted.
- Keep existing timeout behavior by still forcing `shutdownNow()` when graceful termination returns `false` or is interrupted.
- Apply the same lifecycle contract to port-based and in-process gRPC server base classes.
- Add regression tests for both server variants and capture the shutdown interruption lesson.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

- Preserve the caller thread interrupt flag when gRPC timed shutdown is interrupted.
- Keep existing timeout behavior by still forcing `shutdownNow()` when graceful termination returns `false` or is interrupted.
- Apply the same lifecycle contract to port-based and in-process gRPC server base classes.
- Add regression tests for both server variants and capture the shutdown interruption lesson.

### Validation

- `./gradlew :bluetape4k-grpc:compileKotlin :bluetape4k-grpc:compileTestKotlin :bluetape4k-grpc:test --tests io.bluetape4k.grpc.GrpcServerTest`
- `./gradlew :bluetape4k-grpc:koverXmlReport`
- `git diff --check`

Resolves #656
Resolves #657

## Validation

- `./gradlew :bluetape4k-grpc:compileKotlin :bluetape4k-grpc:compileTestKotlin :bluetape4k-grpc:test --tests io.bluetape4k.grpc.GrpcServerTest`
- `./gradlew :bluetape4k-grpc:koverXmlReport`
- `git diff --check`

Resolves #656
Resolves #657

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #656, #657, milestone `1.10.0`, assignee `debop`
- PR: #669, head `1b119ce4c881154da16061844a9fd2ade979c699`, milestone `1.10.0`, assignee `debop`
- Base: `develop`, head branch `fix/656-657-grpc-interrupt-lifecycle`
- Labels: `bug`
- State: `MERGED`, merge commit `7fef699ed3303c7cb33b5f79ef27fffda0ec71b5`
- CI: - Keep existing timeout behavior by still forcing `shutdownNow()` when graceful termination returns `false` or is interrupted. / - `./gradlew :bluetape4k-grpc:compileKotlin :bluetape4k-grpc:compileTestKotlin :bluetape4k-grpc:test --tests io.bluetape4k.grpc.GrpcServerTest` / - `./gradlew :bluetape4k-grpc:koverXmlReport`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #669 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `7fef699ed3303c7cb33b5f79ef27fffda0ec71b5`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
