### PR TITLE
fix(vertx): preserve route coroutine cancellation

### DIFF
--- a/docs/lessons/2026-05-28-issue-654-vertx-route-cancellation.md
+++ b/docs/lessons/2026-05-28-issue-654-vertx-route-cancellation.md
@@ -1,0 +1,29 @@
+# Issue 654 - Vert.x route coroutine cancellation
+
+## Context
+
+Vert.x route coroutine helpers caught `Throwable` and passed every failure to
+`RoutingContext.fail(...)`. That converted coroutine cancellation into an HTTP
+route failure instead of preserving structured cancellation.
+
+## Decision
+
+Catch `CancellationException` before the broad `Throwable` fallback and rethrow
+it from both `suspendHandler` and `suspendFailureHandler`. Keep normal
+exceptions mapped to `ctx.fail(e)`.
+
+## Outcome
+
+Route handlers now preserve coroutine cancellation semantics while retaining the
+existing error path for ordinary exceptions.
+
+## Verification
+
+- `./gradlew :bluetape4k-vertx:compileKotlin :bluetape4k-vertx:compileTestKotlin :bluetape4k-vertx:test --tests io.bluetape4k.vertx.web.VertxRouteExtensionsTest`
+- `./gradlew :bluetape4k-vertx:koverXmlReport`
+- `git diff --check`
+
+## Future guard
+
+Do not catch `Throwable` around suspend route handlers without rethrowing
+`CancellationException` first.

--- a/io/vertx/src/main/kotlin/io/bluetape4k/vertx/web/VertxRouteExtensions.kt
+++ b/io/vertx/src/main/kotlin/io/bluetape4k/vertx/web/VertxRouteExtensions.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.vertx.web
 import io.bluetape4k.vertx.currentVertxCoroutineScope
 import io.vertx.ext.web.Route
 import io.vertx.ext.web.RoutingContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
 /**
@@ -27,6 +28,8 @@ inline fun Route.suspendHandler(
         currentVertxCoroutineScope().launch {
             try {
                 requestHandler(ctx)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Throwable) {
                 ctx.fail(e)
             }
@@ -55,6 +58,8 @@ inline fun Route.suspendFailureHandler(
         currentVertxCoroutineScope().launch {
             try {
                 requestHandler(ctx)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Throwable) {
                 ctx.fail(e)
             }

--- a/io/vertx/src/test/kotlin/io/bluetape4k/vertx/web/VertxRouteExtensionsTest.kt
+++ b/io/vertx/src/test/kotlin/io/bluetape4k/vertx/web/VertxRouteExtensionsTest.kt
@@ -1,0 +1,153 @@
+package io.bluetape4k.vertx.web
+
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.vertx.AbstractVertxTest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.vertx.core.Handler
+import io.vertx.core.Vertx
+import io.vertx.ext.web.Route
+import io.vertx.ext.web.RoutingContext
+import io.vertx.junit5.VertxTestContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
+
+class VertxRouteExtensionsTest: AbstractVertxTest() {
+
+    @Test
+    fun `suspendHandler propagates cancellation without failing routing context`(
+        vertx: Vertx,
+        testContext: VertxTestContext,
+    ) = runSuspendIO {
+        val handlerCompleted = CompletableDeferred<Unit>()
+        val handler = captureHandler { route ->
+            route.suspendHandler {
+                try {
+                    throw CancellationException("route cancelled")
+                } finally {
+                    handlerCompleted.complete(Unit)
+                }
+            }
+        }
+        val ctx = mockRoutingContext()
+
+        executeHandler(vertx, handler, ctx, handlerCompleted)
+
+        verify(exactly = 0) { ctx.fail(any<Throwable>()) }
+        testContext.completeNow()
+    }
+
+    @Test
+    fun `suspendHandler fails routing context for normal exceptions`(
+        vertx: Vertx,
+        testContext: VertxTestContext,
+    ) = runSuspendIO {
+        val handlerCompleted = CompletableDeferred<Unit>()
+        val failure = IllegalStateException("boom")
+        val handler = captureHandler { route ->
+            route.suspendHandler {
+                try {
+                    throw failure
+                } finally {
+                    handlerCompleted.complete(Unit)
+                }
+            }
+        }
+        val ctx = mockRoutingContext()
+
+        executeHandler(vertx, handler, ctx, handlerCompleted)
+
+        verify(exactly = 1) { ctx.fail(failure) }
+        testContext.completeNow()
+    }
+
+    @Test
+    fun `suspendFailureHandler propagates cancellation without failing routing context`(
+        vertx: Vertx,
+        testContext: VertxTestContext,
+    ) = runSuspendIO {
+        val handlerCompleted = CompletableDeferred<Unit>()
+        val handler = captureFailureHandler { route ->
+            route.suspendFailureHandler {
+                try {
+                    throw CancellationException("failure route cancelled")
+                } finally {
+                    handlerCompleted.complete(Unit)
+                }
+            }
+        }
+        val ctx = mockRoutingContext()
+
+        executeHandler(vertx, handler, ctx, handlerCompleted)
+
+        verify(exactly = 0) { ctx.fail(any<Throwable>()) }
+        testContext.completeNow()
+    }
+
+    @Test
+    fun `suspendFailureHandler fails routing context for normal exceptions`(
+        vertx: Vertx,
+        testContext: VertxTestContext,
+    ) = runSuspendIO {
+        val handlerCompleted = CompletableDeferred<Unit>()
+        val failure = IllegalArgumentException("failure boom")
+        val handler = captureFailureHandler { route ->
+            route.suspendFailureHandler {
+                try {
+                    throw failure
+                } finally {
+                    handlerCompleted.complete(Unit)
+                }
+            }
+        }
+        val ctx = mockRoutingContext()
+
+        executeHandler(vertx, handler, ctx, handlerCompleted)
+
+        verify(exactly = 1) { ctx.fail(failure) }
+        testContext.completeNow()
+    }
+
+    private fun captureHandler(register: (Route) -> Unit): Handler<RoutingContext> {
+        val route = mockk<Route>()
+        val handler = mutableListOf<Handler<RoutingContext>>()
+        every { route.handler(capture(handler)) } returns route
+
+        register(route)
+
+        return handler.single()
+    }
+
+    private fun captureFailureHandler(register: (Route) -> Unit): Handler<RoutingContext> {
+        val route = mockk<Route>()
+        val handler = mutableListOf<Handler<RoutingContext>>()
+        every { route.failureHandler(capture(handler)) } returns route
+
+        register(route)
+
+        return handler.single()
+    }
+
+    private suspend fun executeHandler(
+        vertx: Vertx,
+        handler: Handler<RoutingContext>,
+        ctx: RoutingContext,
+        handlerCompleted: CompletableDeferred<Unit>,
+    ) {
+        vertx.runOnContext {
+            handler.handle(ctx)
+        }
+        withTimeout(3.seconds) {
+            handlerCompleted.await()
+        }
+        delay(100)
+    }
+
+    private fun mockRoutingContext(): RoutingContext =
+        mockk(relaxed = true)
+}


### PR DESCRIPTION
## Summary

Closes #654

- PR 제목: fix(vertx): preserve route coroutine cancellation

- rethrow `CancellationException` from Vert.x `suspendHandler` and `suspendFailureHandler`
- keep ordinary route exceptions flowing through `RoutingContext.fail(e)`
- add focused regression tests for cancellation and normal exception paths
- add a lesson guard for broad `Throwable` catches in suspend route helpers

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary
- rethrow `CancellationException` from Vert.x `suspendHandler` and `suspendFailureHandler`
- keep ordinary route exceptions flowing through `RoutingContext.fail(e)`
- add focused regression tests for cancellation and normal exception paths
- add a lesson guard for broad `Throwable` catches in suspend route helpers

### Validation
- `./gradlew :bluetape4k-vertx:compileKotlin :bluetape4k-vertx:compileTestKotlin :bluetape4k-vertx:test --tests io.bluetape4k.vertx.web.VertxRouteExtensionsTest`
- `./gradlew :bluetape4k-vertx:koverXmlReport`
- `git diff --check`
- local 7-tier review: `.omx/artifacts/local-issue-654-7tier-review.md`, P0=0, P1=0

Resolves #654

## Validation

- `./gradlew :bluetape4k-vertx:compileKotlin :bluetape4k-vertx:compileTestKotlin :bluetape4k-vertx:test --tests io.bluetape4k.vertx.web.VertxRouteExtensionsTest`
- `./gradlew :bluetape4k-vertx:koverXmlReport`
- `git diff --check`
- local 7-tier review: `.omx/artifacts/local-issue-654-7tier-review.md`, P0=0, P1=0

Resolves #654

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #654, milestone `1.10.0`, assignee `debop`
- PR: #670, head `c0804b9ea8d00728e08e2aa96acf51e6886bd08b`, milestone `1.10.0`, assignee `debop`
- Base: `develop`, head branch `fix/654-vertx-cancellation`
- Labels: `bug`
- State: `MERGED`, merge commit `bb7c4d33ff87e69f1308f807dee792fc1fb1dae6`
- CI: - `./gradlew :bluetape4k-vertx:compileKotlin :bluetape4k-vertx:compileTestKotlin :bluetape4k-vertx:test --tests io.bluetape4k.vertx.web.VertxRouteExtensionsTest` / - `./gradlew :bluetape4k-vertx:koverXmlReport`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #670 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `bb7c4d33ff87e69f1308f807dee792fc1fb1dae6`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
