### PR TITLE
perf(csv): scan UTF-8 fields with Okio segments

### DIFF
--- a/docs/lessons/2026-05-29-issue-651-csv-okio-segments.md
+++ b/docs/lessons/2026-05-29-issue-651-csv-okio-segments.md
@@ -1,0 +1,39 @@
+# Issue 651 CSV Okio Segments
+
+## Context
+
+Issue #651 targeted lower allocation and better throughput for large CSV parsing.
+The existing `CsvLexer` decodes through a `Reader` and appends characters into a
+`StringBuilder` per field.
+
+## Decision
+
+Use an internal UTF-8 fast path backed by Okio for supported CSV settings:
+single-byte ASCII delimiter and quote characters with doubled-quote escaping.
+The public `CsvRecordReader` API remains unchanged and falls back to the
+existing reader-based lexer for unsupported charsets or settings.
+
+Okio `Buffer.UnsafeCursor` is used only for read-only structural-byte scanning
+inside the buffered source. Field bytes are moved between Okio buffers and
+decoded once at field completion.
+
+## Outcome
+
+The cursor-backed implementation preserved existing CSV behavior and improved
+throughput for the benchmarked public reader path:
+
+- small: 20,173.731 -> 45,417.110 ops/s
+- medium: 296.944 -> 683.434 ops/s
+- large: 17.312 -> 40.115 ops/s
+
+## Verification
+
+- `./gradlew :bluetape4k-csv:test`
+- `./gradlew :bluetape4k-csv:testBenchmark`
+
+## Future Guidance
+
+When using Okio `UnsafeCursor`, lock behavior with fixture equivalence tests
+before optimizing. A naive byte loop was correct but only modestly faster; a
+read-only cursor scan gave the useful performance gain while keeping memory
+bounded by draining scanned buffer segments.

--- a/io/csv/build.gradle.kts
+++ b/io/csv/build.gradle.kts
@@ -24,6 +24,7 @@ configurations {
 
 dependencies {
     api(project(":bluetape4k-io"))
+    implementation(libs.okio)
     testImplementation(project(":bluetape4k-junit5"))
 
     // Coroutines

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/CsvRecordReader.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/CsvRecordReader.kt
@@ -1,9 +1,13 @@
 package io.bluetape4k.csv
 
 import io.bluetape4k.csv.internal.CsvLexer
+import io.bluetape4k.csv.internal.OkioCsvLexer
 import io.bluetape4k.logging.KLogging
+import okio.buffer
+import okio.source
 import java.io.InputStream
 import java.nio.charset.Charset
+import kotlin.text.Charsets.UTF_8
 
 /**
  * 자체 [CsvLexer]를 사용하는 CSV [RecordReader] 구현체입니다.
@@ -40,6 +44,14 @@ class CsvRecordReader(
         skipHeaders: Boolean,
         transform: (Record) -> T,
     ): Sequence<T> = sequence {
+        if (encoding == UTF_8 && OkioCsvLexer.isSupported(settings)) {
+            OkioCsvLexer(input.source().buffer(), settings, skipHeaders).use { lexer ->
+                while (lexer.hasNext()) {
+                    yield(transform(lexer.next()))
+                }
+            }
+            return@sequence
+        }
         CsvLexer(input.reader(encoding), settings, skipHeaders).use { lexer ->
             while (lexer.hasNext()) {
                 yield(transform(lexer.next()))

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/OkioCsvLexer.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/OkioCsvLexer.kt
@@ -1,0 +1,367 @@
+package io.bluetape4k.csv.internal
+
+import io.bluetape4k.csv.CsvSettings
+import io.bluetape4k.logging.KLogging
+import okio.Buffer
+import okio.BufferedSource
+import okio.ByteString
+import java.io.Closeable
+
+/**
+ * UTF-8 CSV lexer backed by Okio segments.
+ *
+ * This lexer keeps the public CSV semantics of [CsvLexer] for UTF-8 input with
+ * single-byte ASCII delimiter and quote characters. It reads structural bytes
+ * from Okio segments and decodes field payloads only when a field is complete.
+ */
+internal class OkioCsvLexer(
+    private val source: BufferedSource,
+    private val settings: CsvSettings,
+    private val skipHeaders: Boolean = false,
+) : Iterator<ArrayRecord>, Closeable {
+
+    companion object : KLogging() {
+        private const val BOM_1: Byte = 0xEF.toByte()
+        private const val BOM_2: Byte = 0xBB.toByte()
+        private const val BOM_3: Byte = 0xBF.toByte()
+        private const val CR: Byte = '\r'.code.toByte()
+        private const val LF: Byte = '\n'.code.toByte()
+
+        fun isSupported(settings: CsvSettings): Boolean =
+            settings.delimiter.code in 0x00..0x7F &&
+                settings.quote.code in 0x00..0x7F &&
+                settings.delimiter != '\r' &&
+                settings.delimiter != '\n' &&
+                settings.quote != '\r' &&
+                settings.quote != '\n' &&
+                settings.quoteEscape == settings.quote
+    }
+
+    private enum class State {
+        START_FIELD,
+        IN_QUOTED,
+        QUOTE_IN_QUOTED,
+        IN_UNQUOTED,
+    }
+
+    private val delimiter: Byte = settings.delimiter.code.toByte()
+    private val quote: Byte = settings.quote.code.toByte()
+    private val unquotedTerminators: ByteString = ByteString.of(delimiter, CR, LF)
+    private val quoteTerminators: ByteString = ByteString.of(quote)
+    private val trimValues: Boolean = settings.trimValues
+    private val skipEmptyLines: Boolean = settings.skipEmptyLines
+    private val emptyValueAsNull: Boolean = settings.emptyValueAsNull
+    private val emptyQuotedAsNull: Boolean = settings.emptyQuotedAsNull
+    private val maxCharsPerColumn: Int = settings.maxCharsPerColumn
+    private val maxFieldBytes: Long = maxCharsPerColumn.toLong() * 4L
+    private val maxColumns: Int = settings.maxColumns
+    private val fieldBuffer = Buffer()
+
+    private var headers: Array<String>? = null
+    private var headerIndex: HeaderIndex? = null
+    private var rowNumber: Long = 0L
+    private var columnNumber: Int = 0
+    private var nextRecord: ArrayRecord? = null
+    private var exhausted: Boolean = false
+    private var lastFieldWasQuoted: Boolean = false
+    private var state: State = State.START_FIELD
+
+    init {
+        require(isSupported(settings)) {
+            "OkioCsvLexer requires single-byte ASCII delimiter/quote and doubled-quote escaping."
+        }
+        consumeBomIfPresent()
+        if (skipHeaders) {
+            while (true) {
+                val firstRow = parseRow()
+                if (firstRow == null) {
+                    exhausted = true
+                    break
+                }
+                if (firstRow.isEmpty()) continue
+                val arr = Array(firstRow.size) { i -> firstRow[i] ?: "" }
+                headers = arr
+                headerIndex = HeaderIndex.of(arr)
+                break
+            }
+        }
+    }
+
+    override fun hasNext(): Boolean {
+        if (exhausted) return nextRecord != null
+        if (nextRecord != null) return true
+        nextRecord = readNextRecord()
+        return nextRecord != null
+    }
+
+    override fun next(): ArrayRecord {
+        if (!hasNext()) throw NoSuchElementException("더 이상 읽을 레코드가 없습니다")
+        val record = nextRecord!!
+        nextRecord = null
+        return record
+    }
+
+    override fun close() {
+        runCatching { source.close() }
+    }
+
+    private fun consumeBomIfPresent() {
+        if (!settings.detectBom) return
+        if (source.request(3) &&
+            source.buffer[0] == BOM_1 &&
+            source.buffer[1] == BOM_2 &&
+            source.buffer[2] == BOM_3
+        ) {
+            source.skip(3)
+        }
+    }
+
+    private fun readNextRecord(): ArrayRecord? {
+        while (true) {
+            val fields = parseRow()
+            if (fields == null) {
+                exhausted = true
+                return null
+            }
+            if (fields.isEmpty()) {
+                if (skipEmptyLines) continue
+                rowNumber++
+                return ArrayRecord(
+                    rawValues = arrayOfNulls(1),
+                    _headers = headers,
+                    headerIndex = headerIndex,
+                    rowNumber = rowNumber,
+                )
+            }
+            rowNumber++
+            return ArrayRecord(
+                rawValues = fields.toTypedArray(),
+                _headers = headers,
+                headerIndex = headerIndex,
+                rowNumber = rowNumber,
+            )
+        }
+    }
+
+    private fun parseRow(): List<String?>? {
+        val fields = ArrayList<String?>(16)
+        state = State.START_FIELD
+        fieldBuffer.clear()
+        lastFieldWasQuoted = false
+        columnNumber = 0
+
+        while (true) {
+            when (state) {
+                State.START_FIELD -> {
+                    if (source.exhausted()) return handleEof(fields)
+                    when (val b = source.readByte()) {
+                        quote -> {
+                            lastFieldWasQuoted = true
+                            state = State.IN_QUOTED
+                        }
+                        delimiter -> appendField(fields)
+                        CR -> {
+                            consumeLfAfterCr()
+                            return finalizeRowAtStart(fields)
+                        }
+                        LF -> return finalizeRowAtStart(fields)
+                        else -> {
+                            state = State.IN_UNQUOTED
+                            columnNumber++
+                            appendByteToBuffer(b, fields.size)
+                        }
+                    }
+                }
+
+                State.IN_QUOTED -> {
+                    val terminator = transferUntil(fields, quoteTerminators)
+                    if (terminator == null) return handleEof(fields)
+                    state = State.QUOTE_IN_QUOTED
+                }
+
+                State.QUOTE_IN_QUOTED -> {
+                    if (source.exhausted()) {
+                        appendField(fields)
+                        return fields
+                    }
+                    when (val b = source.readByte()) {
+                        quote -> {
+                            appendByteToBuffer(quote, fields.size)
+                            state = State.IN_QUOTED
+                        }
+                        delimiter -> {
+                            appendField(fields)
+                            state = State.START_FIELD
+                        }
+                        CR -> {
+                            consumeLfAfterCr()
+                            appendField(fields)
+                            return fields
+                        }
+                        LF -> {
+                            appendField(fields)
+                            return fields
+                        }
+                        else -> {
+                            state = State.IN_UNQUOTED
+                            appendByteToBuffer(b, fields.size)
+                        }
+                    }
+                }
+
+                State.IN_UNQUOTED -> {
+                    val terminator = transferUntil(fields, unquotedTerminators)
+                    if (terminator == null) return handleEof(fields)
+                    when (terminator) {
+                        delimiter -> {
+                            appendField(fields)
+                            state = State.START_FIELD
+                        }
+                        CR -> {
+                            consumeLfAfterCr()
+                            appendField(fields)
+                            return fields
+                        }
+                        LF -> {
+                            appendField(fields)
+                            return fields
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun transferUntil(fields: List<String?>, terminators: ByteString): Byte? {
+        while (source.request(1)) {
+            val offset = findTerminatorOffset(terminators)
+            if (offset >= 0L) {
+                if (offset > 0L) {
+                    fieldBuffer.write(source.buffer, offset)
+                    checkFieldByteBound(fields.size)
+                }
+                return source.readByte()
+            }
+
+            val bufferedSize = source.buffer.size
+            if (fieldBuffer.size + bufferedSize > maxFieldBytes) {
+                throwColumnTooLarge(fields.size)
+            }
+            fieldBuffer.write(source.buffer, bufferedSize)
+        }
+        return null
+    }
+
+    private fun findTerminatorOffset(terminators: ByteString): Long {
+        source.buffer.readUnsafe().use { cursor ->
+            while (cursor.next() != -1) {
+                val data = cursor.data ?: continue
+                var index = cursor.start
+                while (index < cursor.end) {
+                    if (isTerminator(data[index], terminators)) {
+                        return cursor.offset + index - cursor.start
+                    }
+                    index++
+                }
+            }
+        }
+        return -1L
+    }
+
+    private fun isTerminator(byte: Byte, terminators: ByteString): Boolean =
+        if (terminators == quoteTerminators) {
+            byte == quote
+        } else {
+            byte == delimiter || byte == CR || byte == LF
+        }
+
+    private fun consumeLfAfterCr() {
+        if (source.request(1) && source.buffer[0] == LF) {
+            source.skip(1)
+        }
+    }
+
+    private fun handleEof(fields: MutableList<String?>): List<String?>? {
+        if (fields.isEmpty() && fieldBuffer.size == 0L && state == State.START_FIELD && !lastFieldWasQuoted) {
+            return null
+        }
+        fields.add(finishField(fields.size))
+        checkMaxColumns(fields)
+        return fields
+    }
+
+    private fun finalizeRowAtStart(fields: MutableList<String?>): List<String?> {
+        return if (fields.isEmpty() && fieldBuffer.size == 0L && !lastFieldWasQuoted) {
+            emptyList()
+        } else {
+            fields.add(finishField(fields.size))
+            checkMaxColumns(fields)
+            fields
+        }
+    }
+
+    private fun appendField(fields: MutableList<String?>) {
+        fields.add(finishField(fields.size))
+        checkMaxColumns(fields)
+        fieldBuffer.clear()
+        lastFieldWasQuoted = false
+    }
+
+    private fun appendByteToBuffer(byte: Byte, currentFieldIndex: Int) {
+        fieldBuffer.writeByte(byte.toInt())
+        checkFieldByteBound(currentFieldIndex)
+    }
+
+    private fun checkFieldByteBound(currentFieldIndex: Int) {
+        if (fieldBuffer.size > maxFieldBytes) {
+            throwColumnTooLarge(currentFieldIndex)
+        }
+    }
+
+    private fun checkMaxColumns(fields: List<String?>) {
+        if (fields.size > maxColumns) {
+            throw ParseException(
+                message = "컬럼 수가 maxColumns($maxColumns)를 초과했습니다",
+                rowNumber = rowNumber + 1,
+                columnNumber = columnNumber,
+                fieldIndex = fields.size - 1,
+            )
+        }
+    }
+
+    private fun throwColumnTooLarge(currentFieldIndex: Int): Nothing =
+        throw ParseException(
+            message = "컬럼 크기가 maxCharsPerColumn($maxCharsPerColumn)을 초과했습니다",
+            rowNumber = rowNumber + 1,
+            columnNumber = columnNumber,
+            fieldIndex = currentFieldIndex,
+        )
+
+    private fun finishField(currentFieldIndex: Int): String? {
+        val wasQuoted = lastFieldWasQuoted
+        var raw = fieldBuffer.readString(Charsets.UTF_8)
+        if (raw.length > maxCharsPerColumn) {
+            throwColumnTooLarge(currentFieldIndex)
+        }
+        if (trimValues && !wasQuoted) {
+            raw = raw.trim()
+        }
+
+        return if (wasQuoted) {
+            lastFieldWasQuoted = false
+            when {
+                raw.isEmpty() && emptyQuotedAsNull -> null
+                else -> raw
+            }
+        } else {
+            when {
+                raw.isEmpty() && emptyValueAsNull -> null
+                else -> raw
+            }
+        }
+    }
+
+    fun headerNames(): Array<String>? = headers?.copyOf()
+
+    fun headerIndex(): HeaderIndex? = headerIndex
+}

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/benchmark/CsvParserBenchmark.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/benchmark/CsvParserBenchmark.kt
@@ -3,8 +3,11 @@ package io.bluetape4k.csv.benchmark
 import io.bluetape4k.csv.CsvRecordReader
 import io.bluetape4k.csv.CsvSettings
 import io.bluetape4k.csv.internal.CsvLexer
+import io.bluetape4k.csv.internal.OkioCsvLexer
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.utils.Resourcex
+import okio.buffer
+import okio.source
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
 import org.openjdk.jmh.annotations.Fork
@@ -16,6 +19,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.Setup
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
+import java.io.ByteArrayOutputStream
 import java.util.concurrent.TimeUnit
 import kotlin.text.Charsets.UTF_8
 
@@ -25,6 +29,7 @@ import kotlin.text.Charsets.UTF_8
  * 자체 엔진([CsvLexer], [CsvRecordReader])의 처리량을 측정한다.
  * - 소형: product_type.csv 첫 10KB
  * - 중형: product_type.csv 전체
+ * - 대형: product_type.csv 반복 결합
  */
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.Throughput)
@@ -38,6 +43,7 @@ open class CsvParserBenchmark {
 
     private lateinit var smallCsvBytes: ByteArray
     private lateinit var mediumCsvBytes: ByteArray
+    private lateinit var largeCsvBytes: ByteArray
 
     @Setup(Level.Trial)
     fun setup() {
@@ -46,6 +52,13 @@ open class CsvParserBenchmark {
         }
         mediumCsvBytes = Resourcex.getInputStream("csv/product_type.csv")!!.use {
             it.readBytes()
+        }
+        largeCsvBytes = ByteArrayOutputStream(mediumCsvBytes.size * 16).use { output ->
+            repeat(16) {
+                output.write(mediumCsvBytes)
+                output.write('\n'.code)
+            }
+            output.toByteArray()
         }
     }
 
@@ -69,6 +82,44 @@ open class CsvParserBenchmark {
         return count
     }
 
+    @Benchmark
+    fun nativeLexer_large(): Int {
+        var count = 0
+        CsvLexer(largeCsvBytes.inputStream().reader(), CsvSettings.DEFAULT, skipHeaders = true).use { lexer ->
+            while (lexer.hasNext()) { lexer.next(); count++ }
+        }
+        return count
+    }
+
+    // ── Okio CsvLexer (segment-backed UTF-8 engine)
+
+    @Benchmark
+    fun okioLexer_small(): Int {
+        var count = 0
+        OkioCsvLexer(smallCsvBytes.inputStream().source().buffer(), CsvSettings.DEFAULT, skipHeaders = true).use { lexer ->
+            while (lexer.hasNext()) { lexer.next(); count++ }
+        }
+        return count
+    }
+
+    @Benchmark
+    fun okioLexer_medium(): Int {
+        var count = 0
+        OkioCsvLexer(mediumCsvBytes.inputStream().source().buffer(), CsvSettings.DEFAULT, skipHeaders = true).use { lexer ->
+            while (lexer.hasNext()) { lexer.next(); count++ }
+        }
+        return count
+    }
+
+    @Benchmark
+    fun okioLexer_large(): Int {
+        var count = 0
+        OkioCsvLexer(largeCsvBytes.inputStream().source().buffer(), CsvSettings.DEFAULT, skipHeaders = true).use { lexer ->
+            while (lexer.hasNext()) { lexer.next(); count++ }
+        }
+        return count
+    }
+
     // ── 자체 CsvRecordReader (공개 API 측정)
 
     @Benchmark
@@ -78,5 +129,9 @@ open class CsvParserBenchmark {
     @Benchmark
     fun nativeCsvRead_medium(): Int =
         CsvRecordReader().read(mediumCsvBytes.inputStream(), UTF_8, skipHeaders = true).count()
+
+    @Benchmark
+    fun nativeCsvRead_large(): Int =
+        CsvRecordReader().read(largeCsvBytes.inputStream(), UTF_8, skipHeaders = true).count()
 
 }

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/internal/OkioCsvLexerTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/internal/OkioCsvLexerTest.kt
@@ -1,0 +1,87 @@
+package io.bluetape4k.csv.internal
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.csv.CsvSettings
+import io.bluetape4k.utils.Resourcex
+import okio.buffer
+import okio.source
+import org.junit.jupiter.api.Test
+import kotlin.text.Charsets.UTF_8
+
+class OkioCsvLexerTest {
+
+    @Test
+    fun `Okio lexer matches Reader lexer for RFC4180 records`() {
+        val csv = """
+            name,description,amount
+            apple,"red, fresh",10
+            banana,"multi
+            line",20
+            quote,"a ""quoted"" field",30
+            unicode,한글과 emoji 🚀,40
+        """.trimIndent()
+
+        parseWithOkio(csv) shouldBeEqualTo parseWithReader(csv)
+    }
+
+    @Test
+    fun `Okio lexer preserves BOM stripping and empty value policies`() {
+        val csv = "\uFEFFname,empty,quoted\nalpha,,\"\"\n"
+
+        parseWithOkio(csv) shouldBeEqualTo parseWithReader(csv)
+    }
+
+    @Test
+    fun `Okio lexer supports tab delimiter`() {
+        val settings = CsvSettings.DEFAULT.copy(delimiter = '\t')
+        val tsv = "name\tvalue\nalpha\t1\nbeta\t2\n"
+
+        parseWithOkio(tsv, settings) shouldBeEqualTo parseWithReader(tsv, settings)
+    }
+
+    @Test
+    fun `Okio lexer matches Reader lexer for large fixture`() {
+        val csv = Resourcex.getInputStream("csv/extra_words.csv")!!.readBytes().toString(UTF_8)
+        val okioRecords = parseWithOkio(csv)
+        val readerRecords = parseWithReader(csv)
+
+        okioRecords.zip(readerRecords).indexOfFirst { (okio, reader) -> okio != reader } shouldBeEqualTo -1
+        okioRecords.size shouldBeEqualTo readerRecords.size
+    }
+
+    @Test
+    fun `Okio lexer enforces maxCharsPerColumn without unbounded read ahead`() {
+        val settings = CsvSettings.DEFAULT.copy(maxCharsPerColumn = 5)
+
+        assertFailsWith<ParseException> {
+            OkioCsvLexer("name\nabcdef\n".byteInputStream().source().buffer(), settings, skipHeaders = true).use { lexer ->
+                lexer.next()
+            }
+        }
+    }
+
+    private fun parseWithOkio(
+        text: String,
+        settings: CsvSettings = CsvSettings.DEFAULT,
+    ): List<List<String?>> =
+        OkioCsvLexer(text.byteInputStream().source().buffer(), settings, skipHeaders = true).use { lexer ->
+            buildList {
+                while (lexer.hasNext()) {
+                    add(lexer.next().values.toList())
+                }
+            }
+        }
+
+    private fun parseWithReader(
+        text: String,
+        settings: CsvSettings = CsvSettings.DEFAULT,
+    ): List<List<String?>> =
+        CsvLexer(text.reader(), settings, skipHeaders = true).use { lexer ->
+            buildList {
+                while (lexer.hasNext()) {
+                    add(lexer.next().values.toList())
+                }
+            }
+        }
+}


### PR DESCRIPTION
## Summary

Closes #651

- PR 제목: perf(csv): scan UTF-8 fields with Okio segments

- Add an internal UTF-8 `OkioCsvLexer` fast path for supported CSV settings.
- Scan structural bytes with read-only Okio `Buffer.UnsafeCursor`, then decode field bytes only when the field is complete.
- Keep the existing reader-based lexer as fallback for non-UTF-8 or unsupported delimiter/quote settings.
- Extend CSV benchmarks with small, medium, and large workloads plus native-vs-Okio lexer comparisons.

Fixes #651

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Benchmark

`./gradlew :bluetape4k-csv:testBenchmark`

| Benchmark | Baseline ops/s | PR ops/s | Change |
| --- | ---: | ---: | ---: |
| `nativeCsvRead_small` | 20,173.731 | 45,417.110 | 2.25x |
| `nativeCsvRead_medium` | 296.944 | 683.434 | 2.30x |
| `nativeCsvRead_large` | 17.312 | 40.115 | 2.32x |
| `nativeLexer_small` | 21,043.679 | 21,043.679 | comparison baseline |
| `okioLexer_small` | n/a | 45,062.565 | new |
| `nativeLexer_medium` | 288.105 | 288.105 | comparison baseline |
| `okioLexer_medium` | n/a | 668.457 | new |
| `nativeLexer_large` | 17.996 | 17.996 | comparison baseline |
| `okioLexer_large` | n/a | 41.484 | new |

Notes:
- A simple Okio byte loop was correct but only modestly faster on large input, so the final implementation uses read-only `UnsafeCursor` segment scans.
- The attempted GC profiler run was not used as evidence because kotlinx-benchmark interpreted the selector as a config-file argument.

### 기존 섹션: Verification

- `./gradlew :bluetape4k-csv:test` -> 268 passing
- `./gradlew :bluetape4k-csv:test --tests 'io.bluetape4k.csv.internal.OkioCsvLexerTest'` -> 5 passing
- `./gradlew :bluetape4k-csv:testBenchmark` -> success
- `git diff --check` -> clean

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #651, milestone `1.10.0`, assignee `debop`
- PR: #673, head `e4b78a0f995f69be180d5f330d97fb718634f115`, milestone `1.10.0`, assignee `debop`
- Base: `develop`, head branch `perf/651-csv-okio-segments`
- Labels: `enhancement`, `performance`
- State: `MERGED`, merge commit `c41714946a03c940b9898f3946944c7c97e22b6b`
- CI: `./gradlew :bluetape4k-csv:testBenchmark` / - `./gradlew :bluetape4k-csv:test` -> 268 passing / - `./gradlew :bluetape4k-csv:test --tests 'io.bluetape4k.csv.internal.OkioCsvLexerTest'` -> 5 passing

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #673 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `c41714946a03c940b9898f3946944c7c97e22b6b`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
