### PR TITLE
perf(csv): write UTF-8 files through Okio sink

### DIFF
--- a/docs/lessons/2026-05-29-issue-674-csv-okio-writer.md
+++ b/docs/lessons/2026-05-29-issue-674-csv-okio-writer.md
@@ -1,0 +1,45 @@
+# 2026-05-29 - Issue 674 CSV Okio writer fast path
+
+## Context
+
+Issue #674 followed the CSV reader Okio work by targeting large CSV export
+pipelines. `FlowCsvWriter.writeFile` already accepted a `Flow<Iterable<*>>`, but
+UTF-8 file output still went through `OutputStreamWriter` and many small
+`Writer.write(...)` calls.
+
+## Decision
+
+Keep the public `FlowCsvWriter` contract unchanged and route UTF-8 file output
+through an internal Okio `BufferedSink` writer. Keep non-UTF-8 encodings on the
+existing writer fallback path.
+
+The fast path preserves the existing writer semantics:
+
+- `null` as an unquoted empty field.
+- empty string as quoted `""`.
+- doubled-quote escaping.
+- `quoteAll`.
+- CSV and TSV delimiters and line separators.
+
+## Outcome
+
+The writer benchmark compares the legacy Writer baseline against the public
+Okio-backed `writeFile` path:
+
+| Workload | Writer baseline | Okio writer | Speedup |
+|---|---:|---:|---:|
+| small | 11,741.418 ops/s | 16,355.656 ops/s | 1.39x |
+| medium | 676.110 ops/s | 2,068.696 ops/s | 3.06x |
+| large | 83.802 ops/s | 272.157 ops/s | 3.25x |
+
+## Verification
+
+- `./gradlew :bluetape4k-csv:test --tests 'io.bluetape4k.csv.v2.FlowCsvWriterTest'` - 21 passing.
+- `./gradlew :bluetape4k-csv:test` - 271 passing.
+- `./gradlew :bluetape4k-csv:testBenchmark` - writer benchmark above.
+
+## Future Guard
+
+For CSV writer performance work, benchmark the public `writeFile` path and keep
+a baseline implementation in the benchmark so future agents can compare against
+the previous `Writer` behavior without reintroducing a production fallback flag.

--- a/io/csv/README.ko.md
+++ b/io/csv/README.ko.md
@@ -49,6 +49,26 @@ v1.5.0부터 내부 엔진이 univocity-parsers에서 자체 구현 상태 기�
 - `null` → 쓰기 시 인용 없는 빈 필드; `emptyValueAsNull=true`이면 읽을 때 `null`로 복원
 - `""` (빈 문자열) → 쓰기 시 `""` 인용 출력; 읽을 때 `""` (빈 문자열)로 복원
 
+### UTF-8 Writer Fast Path
+
+`FlowCsvWriter.writeFile(..., encoding = Charsets.UTF_8, ...)`는 파일 출력 시 내부적으로
+Okio `BufferedSink` fast path를 사용합니다. UTF-8이 아닌 인코딩은 기존 `Writer` fallback
+경로를 유지합니다.
+
+벤치마크 명령:
+
+```bash
+./gradlew :bluetape4k-csv:testBenchmark
+```
+
+처리량 단위는 `ops/s`이며, 높을수록 좋습니다.
+
+| Workload | Writer baseline | Okio writer | Speedup |
+|---|---:|---:|---:|
+| small | 11,741.418 ops/s | 16,355.656 ops/s | 1.39x |
+| medium | 676.110 ops/s | 2,068.696 ops/s | 3.06x |
+| large | 83.802 ops/s | 272.157 ops/s | 3.25x |
+
 ## 사용 예제
 
 ### CSV 읽기

--- a/io/csv/README.md
+++ b/io/csv/README.md
@@ -49,6 +49,26 @@ Since v1.5.0 the internal engine has been replaced from univocity-parsers to a s
 - `null` → unquoted empty field on write; read back as `null` when `emptyValueAsNull=true`
 - `""` (empty string) → `""` quoted field on write; read back as `""` (empty string)
 
+### UTF-8 Writer Fast Path
+
+`FlowCsvWriter.writeFile(..., encoding = Charsets.UTF_8, ...)` uses an internal Okio
+`BufferedSink` fast path for file output. Non-UTF-8 encodings keep the existing
+`Writer` fallback path.
+
+Benchmark command:
+
+```bash
+./gradlew :bluetape4k-csv:testBenchmark
+```
+
+Throughput is measured in `ops/s`; higher is better.
+
+| Workload | Writer baseline | Okio writer | Speedup |
+|---|---:|---:|---:|
+| small | 11,741.418 ops/s | 16,355.656 ops/s | 1.39x |
+| medium | 676.110 ops/s | 2,068.696 ops/s | 3.06x |
+| large | 83.802 ops/s | 272.157 ops/s | 3.25x |
+
 ## Usage Examples
 
 ### Reading CSV

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/OkioDelimitedWriter.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/OkioDelimitedWriter.kt
@@ -1,0 +1,100 @@
+package io.bluetape4k.csv.internal
+
+import okio.BufferedSink
+
+/**
+ * Segment-backed CSV/TSV writer for UTF-8 file output.
+ *
+ * This writer preserves [DelimitedWriter] field semantics while avoiding the
+ * `Writer.write(...)` character path for the common UTF-8 export pipeline.
+ */
+internal class OkioDelimitedWriter(
+    private val sink: BufferedSink,
+    private val delimiter: Char,
+    private val quote: Char,
+    private val quoteEscape: Char,
+    private val lineSeparator: String,
+) {
+
+    /**
+     * Writes one row with selective quoting.
+     */
+    fun writeRow(fields: Iterable<*>) {
+        var first = true
+        for (field in fields) {
+            if (!first) sink.writeUtf8Char(delimiter)
+            first = false
+
+            when (field) {
+                null -> { /* unquoted empty field */ }
+                is String -> {
+                    if (field.isEmpty()) {
+                        writeQuoted(field)
+                    } else if (needsQuoting(field)) {
+                        writeQuoted(field)
+                    } else {
+                        sink.writeUtf8(field)
+                    }
+                }
+                else -> {
+                    val str = field.toString()
+                    if (needsQuoting(str)) writeQuoted(str) else sink.writeUtf8(str)
+                }
+            }
+        }
+        sink.writeUtf8(lineSeparator)
+    }
+
+    /**
+     * Writes one row while quoting every non-null field.
+     */
+    fun writeAllQuoted(fields: Iterable<*>) {
+        var first = true
+        for (field in fields) {
+            if (!first) sink.writeUtf8Char(delimiter)
+            first = false
+
+            if (field != null) {
+                val str = if (field is String) field else field.toString()
+                writeQuoted(str)
+            }
+        }
+        sink.writeUtf8(lineSeparator)
+    }
+
+    private fun needsQuoting(s: String): Boolean {
+        if (s.isEmpty()) return false
+        if (s[0] == ' ' || s[s.length - 1] == ' ') return true
+        for (c in s) {
+            if (c == delimiter || c == quote || c == '\r' || c == '\n') return true
+        }
+        return false
+    }
+
+    private fun writeQuoted(s: String) {
+        sink.writeUtf8Char(quote)
+        var start = 0
+        for (index in s.indices) {
+            if (s[index] == quote) {
+                if (start < index) {
+                    sink.writeUtf8(s, start, index)
+                }
+                sink.writeUtf8Char(quoteEscape)
+                sink.writeUtf8Char(quote)
+                start = index + 1
+            }
+        }
+        if (start < s.length) {
+            sink.writeUtf8(s, start, s.length)
+        }
+        sink.writeUtf8Char(quote)
+    }
+
+    private fun BufferedSink.writeUtf8Char(c: Char) {
+        if (c.code <= 0x7F) {
+            writeByte(c.code)
+        } else {
+            writeUtf8CodePoint(c.code)
+        }
+    }
+}

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/v2/FlowCsvWriterImpl.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/v2/FlowCsvWriterImpl.kt
@@ -1,18 +1,24 @@
 package io.bluetape4k.csv.v2
 
 import io.bluetape4k.csv.internal.DelimitedWriter
+import io.bluetape4k.csv.internal.OkioDelimitedWriter
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.warn
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import okio.buffer
+import okio.sink
 import java.io.FileOutputStream
 import java.io.OutputStreamWriter
 import java.io.Writer
 import java.nio.charset.Charset
 import java.nio.file.Path
+import kotlin.text.Charsets.UTF_8
 
 internal class FlowCsvWriterImpl(
     private val writer: Writer,
@@ -60,20 +66,57 @@ internal class FlowCsvWriterImpl(
         rows: Flow<Iterable<*>>,
     ): Long {
         return withContext(Dispatchers.IO) {
-            var count = 0L
-            OutputStreamWriter(FileOutputStream(path.toFile(), append), encoding).use { fw ->
-                // 행마다 DelimitedWriter 재생성을 피하기 위해 파일 전용 인스턴스 1개 생성
-                val fileWriter = DelimitedWriter(fw, delimiter, quote, settings.quoteEscape, lineSeparator)
-                if (!skipHeaders && headers.isNotEmpty()) {
-                    writeRowToDelimited(fileWriter, fw, headers)
-                }
-                rows.collect { row ->
-                    writeRowToDelimited(fileWriter, fw, row)
-                    count++
-                }
+            if (encoding == UTF_8) {
+                return@withContext writeUtf8FileWithOkio(path, append, skipHeaders, headers, rows)
             }
-            count
+            writeFileWithWriter(path, encoding, append, skipHeaders, headers, rows)
         }
+    }
+
+    private suspend fun writeUtf8FileWithOkio(
+        path: Path,
+        append: Boolean,
+        skipHeaders: Boolean,
+        headers: List<String>,
+        rows: Flow<Iterable<*>>,
+    ): Long {
+        var count = 0L
+        FileOutputStream(path.toFile(), append).sink().buffer().use { sink ->
+            val fileWriter = OkioDelimitedWriter(sink, delimiter, quote, settings.quoteEscape, lineSeparator)
+            if (!skipHeaders && headers.isNotEmpty()) {
+                writeRowToOkio(fileWriter, headers)
+            }
+            rows.collect { row ->
+                currentCoroutineContext().ensureActive()
+                writeRowToOkio(fileWriter, row)
+                count++
+            }
+        }
+        return count
+    }
+
+    private suspend fun writeFileWithWriter(
+        path: Path,
+        encoding: Charset,
+        append: Boolean,
+        skipHeaders: Boolean,
+        headers: List<String>,
+        rows: Flow<Iterable<*>>,
+    ): Long {
+        var count = 0L
+        OutputStreamWriter(FileOutputStream(path.toFile(), append), encoding).use { fw ->
+            // 행마다 DelimitedWriter 재생성을 피하기 위해 파일 전용 인스턴스 1개 생성
+            val fileWriter = DelimitedWriter(fw, delimiter, quote, settings.quoteEscape, lineSeparator)
+            if (!skipHeaders && headers.isNotEmpty()) {
+                writeRowToDelimited(fileWriter, fw, headers)
+            }
+            rows.collect { row ->
+                currentCoroutineContext().ensureActive()
+                writeRowToDelimited(fileWriter, fw, row)
+                count++
+            }
+        }
+        return count
     }
 
     override fun close() {
@@ -97,6 +140,14 @@ internal class FlowCsvWriterImpl(
             writeAllQuoted(w, fields)
         } else {
             dw.writeRow(fields)
+        }
+    }
+
+    private fun writeRowToOkio(w: OkioDelimitedWriter, fields: Iterable<*>) {
+        if (config.quoteAll) {
+            w.writeAllQuoted(fields)
+        } else {
+            w.writeRow(fields)
         }
     }
 

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/benchmark/CsvParserBenchmark.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/benchmark/CsvParserBenchmark.kt
@@ -2,10 +2,14 @@ package io.bluetape4k.csv.benchmark
 
 import io.bluetape4k.csv.CsvRecordReader
 import io.bluetape4k.csv.CsvSettings
+import io.bluetape4k.csv.internal.DelimitedWriter
 import io.bluetape4k.csv.internal.CsvLexer
 import io.bluetape4k.csv.internal.OkioCsvLexer
+import io.bluetape4k.csv.v2.csvWriter
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.utils.Resourcex
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.runBlocking
 import okio.buffer
 import okio.source
 import org.openjdk.jmh.annotations.Benchmark
@@ -18,8 +22,14 @@ import org.openjdk.jmh.annotations.OutputTimeUnit
 import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.Setup
 import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
 import org.openjdk.jmh.annotations.Warmup
 import java.io.ByteArrayOutputStream
+import java.io.FileOutputStream
+import java.io.OutputStreamWriter
+import java.io.StringWriter
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 import kotlin.text.Charsets.UTF_8
 
@@ -39,11 +49,18 @@ import kotlin.text.Charsets.UTF_8
 @Fork(1)
 open class CsvParserBenchmark {
 
-    companion object : KLogging()
+    companion object : KLogging() {
+        private val WRITER_HEADERS = listOf("name", "index", "note", "nullable", "empty")
+    }
 
     private lateinit var smallCsvBytes: ByteArray
     private lateinit var mediumCsvBytes: ByteArray
     private lateinit var largeCsvBytes: ByteArray
+    private lateinit var smallRows: List<List<Any?>>
+    private lateinit var mediumRows: List<List<Any?>>
+    private lateinit var largeRows: List<List<Any?>>
+    private lateinit var writerTempDir: Path
+    private lateinit var writerTempFile: Path
 
     @Setup(Level.Trial)
     fun setup() {
@@ -60,6 +77,17 @@ open class CsvParserBenchmark {
             }
             output.toByteArray()
         }
+        smallRows = buildRows(128)
+        mediumRows = buildRows(4_096)
+        largeRows = buildRows(32_768)
+        writerTempDir = Files.createTempDirectory("csv-writer-benchmark")
+        writerTempFile = writerTempDir.resolve("output.csv")
+    }
+
+    @TearDown(Level.Trial)
+    fun tearDown() {
+        runCatching { Files.deleteIfExists(writerTempFile) }
+        runCatching { Files.deleteIfExists(writerTempDir) }
     }
 
     // ── 자체 CsvLexer (내부 엔진 직접 측정)
@@ -133,5 +161,83 @@ open class CsvParserBenchmark {
     @Benchmark
     fun nativeCsvRead_large(): Int =
         CsvRecordReader().read(largeCsvBytes.inputStream(), UTF_8, skipHeaders = true).count()
+
+    // ── Writer path: legacy Writer baseline vs public Okio-backed writeFile
+
+    @Benchmark
+    fun writerBaseline_small(): Long = runBlocking {
+        writeFileWithWriterBaseline(smallRows)
+    }
+
+    @Benchmark
+    fun writerBaseline_medium(): Long = runBlocking {
+        writeFileWithWriterBaseline(mediumRows)
+    }
+
+    @Benchmark
+    fun writerBaseline_large(): Long = runBlocking {
+        writeFileWithWriterBaseline(largeRows)
+    }
+
+    @Benchmark
+    fun okioWriter_small(): Long = runBlocking {
+        writeFileWithPublicWriter(smallRows)
+    }
+
+    @Benchmark
+    fun okioWriter_medium(): Long = runBlocking {
+        writeFileWithPublicWriter(mediumRows)
+    }
+
+    @Benchmark
+    fun okioWriter_large(): Long = runBlocking {
+        writeFileWithPublicWriter(largeRows)
+    }
+
+    private suspend fun writeFileWithPublicWriter(rows: List<List<Any?>>): Long {
+        val writer = csvWriter(StringWriter())
+        return try {
+            writer.writeFile(
+                path = writerTempFile,
+                encoding = UTF_8,
+                append = false,
+                skipHeaders = false,
+                headers = WRITER_HEADERS,
+                rows = rows.asFlow(),
+            )
+        } finally {
+            writer.close()
+        }
+    }
+
+    private fun writeFileWithWriterBaseline(rows: List<List<Any?>>): Long {
+        var count = 0L
+        OutputStreamWriter(FileOutputStream(writerTempFile.toFile(), false), UTF_8).use { fw ->
+            val writer = DelimitedWriter(
+                writer = fw,
+                delimiter = ',',
+                quote = '"',
+                quoteEscape = '"',
+                lineSeparator = "\r\n",
+            )
+            writer.writeRow(WRITER_HEADERS)
+            rows.forEach { row ->
+                writer.writeRow(row)
+                count++
+            }
+        }
+        return count
+    }
+
+    private fun buildRows(size: Int): List<List<Any?>> =
+        List(size) { index ->
+            listOf(
+                "product-$index",
+                index,
+                if (index % 5 == 0) "quoted, value $index" else "plain value $index",
+                if (index % 7 == 0) "say \"hi\" $index" else null,
+                if (index % 11 == 0) "line\nbreak $index" else "",
+            )
+        }
 
 }

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/v2/FlowCsvWriterTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/v2/FlowCsvWriterTest.kt
@@ -218,6 +218,62 @@ class FlowCsvWriterTest {
     }
 
     @Test
+    fun `writeFile UTF-8 fast path preserves CSV edge case semantics`() = runTest {
+        val file = tempDir.resolve("edge.csv")
+        val writer = csvWriter(StringWriter())
+
+        val count = writer.writeFile(
+            path = file,
+            skipHeaders = false,
+            headers = listOf("name", "note", "empty", "nullable"),
+            rows = flowOf(
+                listOf(" Alice ", "hello, world", "", null),
+                listOf("Bob", "say \"hi\"", "line\r\nbreak", 42),
+            ),
+        )
+
+        count shouldBeEqualTo 2L
+        file.toFile().readText(Charsets.UTF_8) shouldBeEqualTo
+                "name,note,empty,nullable\r\n" +
+                "\" Alice \",\"hello, world\",\"\",\r\n" +
+                "Bob,\"say \"\"hi\"\"\",\"line\r\nbreak\",42\r\n"
+    }
+
+    @Test
+    fun `writeFile UTF-8 fast path preserves quoteAll semantics`() = runTest {
+        val file = tempDir.resolve("quote-all.csv")
+        val writer = csvWriter(StringWriter()) { quoteAll = true }
+
+        val count = writer.writeFile(
+            path = file,
+            rows = flowOf(listOf("Alice", 30, null, "say \"hi\"")),
+        )
+
+        count shouldBeEqualTo 1L
+        file.toFile().readText(Charsets.UTF_8) shouldBeEqualTo
+                "\"Alice\",\"30\",,\"say \"\"hi\"\"\"\r\n"
+    }
+
+    @Test
+    fun `writeFile UTF-8 fast path preserves TSV semantics`() = runTest {
+        val file = tempDir.resolve("edge.tsv")
+        val writer = tsvWriter(StringWriter())
+
+        val count = writer.writeFile(
+            path = file,
+            skipHeaders = false,
+            headers = listOf("name", "note"),
+            rows = flowOf(listOf("Alice", "hello\tworld"), listOf("Bob", null)),
+        )
+
+        count shouldBeEqualTo 2L
+        file.toFile().readText(Charsets.UTF_8) shouldBeEqualTo
+                "name\tnote\n" +
+                "Alice\t\"hello\tworld\"\n" +
+                "Bob\t\n"
+    }
+
+    @Test
     fun `writeFile returns zero for empty flow`() = runTest {
         val file = tempDir.resolve("empty.csv")
         val sw = StringWriter()


### PR DESCRIPTION
## Summary

Closes #674

- PR 제목: perf(csv): write UTF-8 files through Okio sink

- Add an internal Okio BufferedSink CSV/TSV writer for UTF-8 FlowCsvWriter.writeFile pipelines.
- Preserve existing DelimitedWriter semantics for null, empty fields, quoting, escaping, quoteAll, delimiters, and line separators.
- Keep non-UTF-8 writes on the existing Writer fallback and document the fast path in both README locales.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Benchmark

Command: `./gradlew :bluetape4k-csv:testBenchmark`

| Dataset | Writer baseline | Okio writer | Speedup |
|---|---:|---:|---:|
| small | 11,741.418 ops/s | 16,355.656 ops/s | 1.39x |
| medium | 676.110 ops/s | 2,068.696 ops/s | 3.06x |
| large | 83.802 ops/s | 272.157 ops/s | 3.25x |

### 기존 섹션: Verification

- `./gradlew :bluetape4k-csv:test --tests 'io.bluetape4k.csv.v2.FlowCsvWriterTest'`
- `./gradlew :bluetape4k-csv:test`
- `./gradlew :bluetape4k-csv:testBenchmark`
- `git diff --check`

Closes #674

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #674, milestone `1.10.0`, assignee `debop`
- PR: #675, head `ee9e1b7fa3ee14ade88bcf70d98c3aec32490413`, milestone `1.10.0`, assignee `debop`
- Base: `develop`, head branch `perf/674-csv-okio-writer`
- Labels: `enhancement`, `performance`
- State: `MERGED`, merge commit `7a642e4c980efaba3cf4f0aaf8db3dd9d20f6f00`
- CI: Command: `./gradlew :bluetape4k-csv:testBenchmark` / - `./gradlew :bluetape4k-csv:test --tests 'io.bluetape4k.csv.v2.FlowCsvWriterTest'` / - `./gradlew :bluetape4k-csv:test`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #675 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `7a642e4c980efaba3cf4f0aaf8db3dd9d20f6f00`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
