### PR TITLE
perf: add web framework benchmark baseline

### DIFF
--- a/benchmark/web-framework-benchmark/build.gradle.kts
+++ b/benchmark/web-framework-benchmark/build.gradle.kts
@@ -1,0 +1,98 @@
+plugins {
+    kotlin("plugin.allopen")
+    kotlin("plugin.serialization")
+    alias(libs.plugins.kotlinx.benchmark)
+}
+
+allOpen {
+    annotation("org.openjdk.jmh.annotations.State")
+}
+
+sourceSets {
+    create("benchmark")
+}
+
+kotlin {
+    target {
+        compilations.getByName("benchmark").associateWith(compilations.getByName("main"))
+    }
+}
+
+configurations {
+    named("benchmarkImplementation") {
+        extendsFrom(
+            configurations.getByName("implementation"),
+            configurations.getByName("compileOnly"),
+            configurations.getByName("testImplementation"),
+        )
+    }
+    named("benchmarkRuntimeOnly") {
+        extendsFrom(
+            configurations.getByName("runtimeOnly"),
+            configurations.getByName("testRuntimeOnly"),
+        )
+    }
+}
+
+benchmark {
+    targets {
+        register("benchmark") {
+            this as kotlinx.benchmark.gradle.JvmBenchmarkTarget
+            jmhVersion = libs.versions.jmh.get()
+        }
+    }
+    configurations {
+        register("throughput") {
+            include("io.bluetape4k.benchmark.webframework.WebFrameworkRequestBenchmark")
+            warmups = 2
+            iterations = 3
+            iterationTime = 1
+            iterationTimeUnit = "s"
+            mode = "thrpt"
+            outputTimeUnit = "s"
+            reportFormat = "json"
+        }
+        register("latency") {
+            include("io.bluetape4k.benchmark.webframework.WebFrameworkLatencyBenchmark")
+            warmups = 2
+            iterations = 3
+            iterationTime = 1
+            iterationTimeUnit = "s"
+            mode = "avgt"
+            outputTimeUnit = "us"
+            reportFormat = "json"
+        }
+        register("startup") {
+            include("io.bluetape4k.benchmark.webframework.WebFrameworkStartupBenchmark")
+            warmups = 1
+            iterations = 3
+            iterationTime = 1
+            iterationTimeUnit = "s"
+            mode = "avgt"
+            outputTimeUnit = "ms"
+            reportFormat = "json"
+        }
+    }
+}
+
+dependencies {
+    add("benchmarkImplementation", project(":bluetape4k-idgenerators"))
+    add("benchmarkImplementation", project(":bluetape4k-ktor-core"))
+
+    add("benchmarkImplementation", libs.kotlinx.benchmark.runtime)
+    add("benchmarkImplementation", libs.kotlinx.benchmark.runtime.jvm)
+    add("benchmarkImplementation", libs.jmh.core)
+
+    add("benchmarkImplementation", libs.kotlinx.serialization.json)
+    add("benchmarkImplementation", libs.ktor.server.core)
+    add("benchmarkImplementation", libs.ktor.server.cio)
+    add("benchmarkImplementation", libs.ktor.server.content.negotiation)
+    add("benchmarkImplementation", libs.ktor.serialization.kotlinx.json)
+
+    add("benchmarkImplementation", platform(libs.spring.boot.dependencies))
+    add("benchmarkImplementation", "org.springframework.boot:spring-boot-starter-webflux")
+    add("benchmarkImplementation", libs.jackson3.module.kotlin)
+    add("benchmarkImplementation", libs.jackson3.module.blackbird)
+
+    add("benchmarkRuntimeOnly", libs.logback.classic)
+}

--- a/benchmark/web-framework-benchmark/src/benchmark/kotlin/io/bluetape4k/benchmark/webframework/WebFrameworkBenchmark.kt
+++ b/benchmark/web-framework-benchmark/src/benchmark/kotlin/io/bluetape4k/benchmark/webframework/WebFrameworkBenchmark.kt
@@ -1,0 +1,420 @@
+package io.bluetape4k.benchmark.webframework
+
+import io.bluetape4k.idgenerators.flake.Flake
+import io.bluetape4k.idgenerators.ksuid.KsuidGenerator
+import io.bluetape4k.idgenerators.snowflake.SnowflakeGenerator
+import io.bluetape4k.idgenerators.ulid.UlidGenerator
+import io.bluetape4k.idgenerators.uuid.Uuid
+import io.bluetape4k.idgenerators.uuid.UuidGenerator
+import io.bluetape4k.ktor.core.installBluetape4kKtorCore
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Routing
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.Serializable
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+import org.springframework.boot.WebApplicationType
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.builder.SpringApplicationBuilder
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import java.io.Serializable as JavaSerializable
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+private const val LOOPBACK = "127.0.0.1"
+private const val DEFAULT_BATCH_SIZE = 10
+private const val MAX_BATCH_SIZE = 100
+
+/**
+ * Throughput benchmark for equivalent Ktor CIO and Spring WebFlux ID endpoints.
+ *
+ * Each operation is one blocking JDK HTTP client round trip to the embedded server.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(1)
+@Warmup(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+open class WebFrameworkRequestBenchmark: WebFrameworkBenchmarkSupport()
+
+/**
+ * Average latency benchmark for equivalent Ktor CIO and Spring WebFlux ID endpoints.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(1)
+@Warmup(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+open class WebFrameworkLatencyBenchmark: WebFrameworkBenchmarkSupport()
+
+/**
+ * Startup and resident-memory snapshot benchmark for the same benchmark apps.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(1)
+@Warmup(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+open class WebFrameworkStartupBenchmark {
+
+    @Benchmark
+    fun ktorStartup(blackhole: Blackhole) {
+        KtorBenchmarkServer().use { server ->
+            blackhole.consume(server.baseUrl)
+            blackhole.consume(usedMemoryBytes())
+        }
+    }
+
+    @Benchmark
+    fun springWebFluxStartup(blackhole: Blackhole) {
+        SpringWebFluxBenchmarkServer().use { server ->
+            blackhole.consume(server.baseUrl)
+            blackhole.consume(usedMemoryBytes())
+        }
+    }
+}
+
+@State(Scope.Benchmark)
+open class WebFrameworkBenchmarkSupport {
+
+    private lateinit var servers: BenchmarkServers
+    private lateinit var client: HttpClient
+
+    @Setup(Level.Trial)
+    fun setup() {
+        servers = BenchmarkServers.start()
+        client = HttpClient
+            .newBuilder()
+            .connectTimeout(Duration.ofSeconds(2))
+            .build()
+    }
+
+    @TearDown(Level.Trial)
+    fun tearDown() {
+        servers.close()
+    }
+
+    @Benchmark
+    fun ktorHealth(blackhole: Blackhole) {
+        blackhole.consume(get(servers.ktor.baseUrl, "/health"))
+    }
+
+    @Benchmark
+    fun springWebFluxHealth(blackhole: Blackhole) {
+        blackhole.consume(get(servers.spring.baseUrl, "/health"))
+    }
+
+    @Benchmark
+    fun ktorSingleId(blackhole: Blackhole) {
+        blackhole.consume(get(servers.ktor.baseUrl, "/idgen/uuid-v7"))
+    }
+
+    @Benchmark
+    fun springWebFluxSingleId(blackhole: Blackhole) {
+        blackhole.consume(get(servers.spring.baseUrl, "/idgen/uuid-v7"))
+    }
+
+    @Benchmark
+    fun ktorBatchIds(blackhole: Blackhole) {
+        blackhole.consume(get(servers.ktor.baseUrl, "/idgen/uuid-v7/batch?size=10"))
+    }
+
+    @Benchmark
+    fun springWebFluxBatchIds(blackhole: Blackhole) {
+        blackhole.consume(get(servers.spring.baseUrl, "/idgen/uuid-v7/batch?size=10"))
+    }
+
+    @Benchmark
+    fun ktorBadRequest(blackhole: Blackhole) {
+        blackhole.consume(get(servers.ktor.baseUrl, "/idgen/unknown"))
+    }
+
+    @Benchmark
+    fun springWebFluxBadRequest(blackhole: Blackhole) {
+        blackhole.consume(get(servers.spring.baseUrl, "/idgen/unknown"))
+    }
+
+    private fun get(baseUrl: String, path: String): BenchmarkHttpResponse {
+        val request = HttpRequest
+            .newBuilder(URI.create("$baseUrl$path"))
+            .timeout(Duration.ofSeconds(3))
+            .GET()
+            .build()
+        val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+        return BenchmarkHttpResponse(
+            statusCode = response.statusCode(),
+            bodyLength = response.body().length,
+        )
+    }
+}
+
+private class BenchmarkServers(
+    val ktor: KtorBenchmarkServer,
+    val spring: SpringWebFluxBenchmarkServer,
+): AutoCloseable {
+
+    override fun close() {
+        runCatching { ktor.close() }
+        runCatching { spring.close() }
+    }
+
+    companion object {
+        fun start(): BenchmarkServers =
+            BenchmarkServers(
+                ktor = KtorBenchmarkServer(),
+                spring = SpringWebFluxBenchmarkServer(),
+            )
+    }
+}
+
+private class KtorBenchmarkServer: AutoCloseable {
+
+    private val server =
+        embeddedServer(CIO, host = LOOPBACK, port = 0) {
+            idGeneratorKtorBenchmarkModule()
+        }.start(wait = false)
+    private val port: Int = runBlocking {
+        server.engine.resolvedConnectors().first().port
+    }
+
+    val baseUrl: String = "http://$LOOPBACK:$port"
+
+    override fun close() {
+        server.stop(gracePeriodMillis = 100, timeoutMillis = 1_000)
+    }
+}
+
+private class SpringWebFluxBenchmarkServer: AutoCloseable {
+
+    private val context: ConfigurableApplicationContext =
+        SpringApplicationBuilder(SpringWebFluxBenchmarkApplication::class.java)
+            .web(WebApplicationType.REACTIVE)
+            .properties(
+                mapOf(
+                    "server.address" to LOOPBACK,
+                    "server.port" to 0,
+                    "spring.main.banner-mode" to "off",
+                    "spring.main.lazy-initialization" to "false",
+                    "logging.level.root" to "ERROR",
+                )
+            )
+            .run()
+    private val port: Int =
+        context.environment.getRequiredProperty("local.server.port", Int::class.java)
+
+    val baseUrl: String = "http://$LOOPBACK:$port"
+
+    override fun close() {
+        context.close()
+    }
+}
+
+private fun Application.idGeneratorKtorBenchmarkModule(
+    registry: BenchmarkIdRegistry = BenchmarkIdRegistry.default(),
+) {
+    installBluetape4kKtorCore()
+    routing {
+        idGeneratorKtorBenchmarkRoutes(registry)
+    }
+}
+
+private fun Routing.idGeneratorKtorBenchmarkRoutes(registry: BenchmarkIdRegistry) {
+    get("/health") {
+        call.respond(HealthResponse(status = "UP", supportedTypes = registry.supportedTypes))
+    }
+    get("/idgen/{type}") {
+        call.respond(registry.nextIdResponse(call.parameters["type"].orEmpty()))
+    }
+    get("/idgen/{type}/batch") {
+        val size = call.request.queryParameters["size"]?.toIntOrNull() ?: DEFAULT_BATCH_SIZE
+        call.respond(registry.nextIdsResponse(call.parameters["type"].orEmpty(), size))
+    }
+}
+
+@Configuration(proxyBeanMethods = false)
+@EnableAutoConfiguration
+@EnableConfigurationProperties
+private class SpringWebFluxBenchmarkApplication {
+
+    @Bean
+    fun benchmarkIdRegistry(): BenchmarkIdRegistry =
+        BenchmarkIdRegistry.default()
+}
+
+@RestController
+private class SpringWebFluxBenchmarkController(
+    private val registry: BenchmarkIdRegistry,
+) {
+
+    @GetMapping("/health")
+    suspend fun health(): HealthResponse =
+        HealthResponse(status = "UP", supportedTypes = registry.supportedTypes)
+
+    @GetMapping("/idgen/{type}")
+    suspend fun generate(
+        @PathVariable type: String,
+    ): IdResponse =
+        registry.nextIdResponse(type)
+
+    @GetMapping("/idgen/{type}/batch")
+    suspend fun generateBatch(
+        @PathVariable type: String,
+        @RequestParam(required = false) size: Int?,
+    ): IdBatchResponse =
+        registry.nextIdsResponse(type, size ?: DEFAULT_BATCH_SIZE)
+}
+
+@RestControllerAdvice
+private class SpringWebFluxBenchmarkExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleBadRequest(ex: IllegalArgumentException): ErrorResponse =
+        ErrorResponse(
+            status = HttpStatus.BAD_REQUEST.value(),
+            error = "bad_request",
+            message = ex.message ?: "Bad request",
+            path = "",
+        )
+}
+
+private class BenchmarkIdRegistry(
+    entries: Map<String, () -> String>,
+) {
+    private val entries: Map<String, () -> String> = entries.toMap()
+
+    val supportedTypes: List<String> = entries.keys.toList()
+
+    fun nextIdResponse(type: String): IdResponse =
+        IdResponse(type = type, id = entry(type).invoke())
+
+    fun nextIdsResponse(type: String, size: Int): IdBatchResponse {
+        require(size in 1..MAX_BATCH_SIZE) {
+            "Batch size must be between 1 and $MAX_BATCH_SIZE: $size"
+        }
+        return IdBatchResponse(
+            type = type,
+            size = size,
+            ids = List(size) { entry(type).invoke() },
+        )
+    }
+
+    private fun entry(type: String): () -> String =
+        entries[type] ?: throw IllegalArgumentException("Unsupported generator type: $type")
+
+    companion object {
+        fun default(): BenchmarkIdRegistry {
+            val uuidV4 = UuidGenerator(Uuid.V4)
+            val uuidV7 = UuidGenerator(Uuid.V7)
+            val ulid = UlidGenerator()
+            val ksuid = KsuidGenerator()
+            val snowflake = SnowflakeGenerator()
+            val flake = Flake()
+
+            return BenchmarkIdRegistry(
+                linkedMapOf(
+                    "uuid-v4" to { uuidV4.nextIdAsString() },
+                    "uuid-v7" to { uuidV7.nextIdAsString() },
+                    "ulid" to { ulid.nextIdAsString() },
+                    "ksuid" to { ksuid.nextIdAsString() },
+                    "snowflake" to { snowflake.nextIdAsString() },
+                    "flake" to { flake.nextIdAsString() },
+                )
+            )
+        }
+    }
+}
+
+@Serializable
+private data class HealthResponse(
+    val status: String,
+    val supportedTypes: List<String>,
+): JavaSerializable {
+    private companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+@Serializable
+private data class IdResponse(
+    val type: String,
+    val id: String,
+): JavaSerializable {
+    private companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+@Serializable
+private data class IdBatchResponse(
+    val type: String,
+    val size: Int,
+    val ids: List<String>,
+): JavaSerializable {
+    private companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+@Serializable
+private data class ErrorResponse(
+    val status: Int,
+    val error: String,
+    val message: String,
+    val path: String,
+    val timestamp: String = Instant.now().toString(),
+): JavaSerializable {
+    private companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+private data class BenchmarkHttpResponse(
+    val statusCode: Int,
+    val bodyLength: Int,
+): JavaSerializable {
+    private companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+private fun usedMemoryBytes(): Long {
+    val runtime = Runtime.getRuntime()
+    return runtime.totalMemory() - runtime.freeMemory()
+}

--- a/benchmark/web-framework-benchmark/src/benchmark/resources/logback.xml
+++ b/benchmark/web-framework-benchmark/src/benchmark/resources/logback.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36}: %msg%n</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.benchmark.webframework" level="WARN"/>
+    <logger name="io.ktor" level="WARN"/>
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="reactor.netty" level="WARN"/>
+
+    <root level="WARN">
+        <appender-ref ref="Console"/>
+    </root>
+</configuration>

--- a/docs/benchmarks/2026-05-29-web-framework-benchmark.md
+++ b/docs/benchmarks/2026-05-29-web-framework-benchmark.md
@@ -1,0 +1,111 @@
+# Ktor CIO vs Spring WebFlux Benchmark - 2026-05-29
+
+## Scope
+
+Issue: #667
+
+Module: `:web-framework-benchmark`
+
+This benchmark compares equivalent in-memory ID generator HTTP APIs implemented
+with Ktor CIO and Spring Boot WebFlux/Netty. The workload intentionally mirrors
+the existing `idgenerator` example domain so the result can guide the Ktor module
+family design in #609 without adding benchmark-only code to production modules.
+
+## Commands
+
+```bash
+./gradlew :web-framework-benchmark:compileBenchmarkKotlin --no-configuration-cache
+./gradlew :web-framework-benchmark:benchmarkStartupBenchmark --no-configuration-cache
+./gradlew :web-framework-benchmark:benchmarkThroughputBenchmark :web-framework-benchmark:benchmarkLatencyBenchmark --no-configuration-cache
+./scripts/web-framework-benchmark.sh
+```
+
+## Run Conditions
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-29 |
+| OS | macOS Darwin 25.5.0 arm64 |
+| CPU | Apple M4 Pro, 12 logical CPUs |
+| Memory | 48 GiB |
+| JDK | Oracle GraalVM 21.0.11 |
+| Kotlin | 2.3.21 |
+| Spring Boot | 4.0.6 |
+| Ktor | 3.5.0 |
+| Serialization | Ktor kotlinx.serialization JSON, Spring Jackson 3 Kotlin module |
+| Client | JDK `HttpClient`, blocking round trip per operation |
+| JMH shape | fork=1, warmup=2x1s, measurement=3x1s for request benchmarks |
+
+Raw artifacts:
+
+- `docs/benchmarks/raw/2026-05-29-web-framework-startup.json`
+- `docs/benchmarks/raw/2026-05-29-web-framework-throughput.json`
+- `docs/benchmarks/raw/2026-05-29-web-framework-latency.json`
+
+## Startup Snapshot
+
+Lower is better.
+
+| Benchmark | ms/op |
+|---|---:|
+| `ktorStartup` | 0.741 |
+| `springWebFluxStartup` | 2,087.926 |
+
+The Ktor startup number measures embedded CIO binding and connector resolution
+only. The Spring number includes Spring Boot reactive application context
+creation and Netty binding. Treat this as a framework bootstrap shape, not an
+end-user cold-start SLA.
+
+## Throughput
+
+Higher is better.
+
+| Benchmark | ops/s |
+|---|---:|
+| `ktorBadRequest` | 4,145.680 |
+| `ktorBatchIds` | 3,726.603 |
+| `ktorHealth` | 3,797.255 |
+| `ktorSingleId` | 3,952.156 |
+| `springWebFluxBadRequest` | 6,045.469 |
+| `springWebFluxBatchIds` | 5,807.421 |
+| `springWebFluxHealth` | 4,418.503 |
+| `springWebFluxSingleId` | 5,625.438 |
+
+## Average Latency
+
+Lower is better.
+
+| Benchmark | us/op |
+|---|---:|
+| `ktorBadRequest` | 245.501 |
+| `ktorBatchIds` | 288.347 |
+| `ktorHealth` | 281.856 |
+| `ktorSingleId` | 256.205 |
+| `springWebFluxBadRequest` | 162.982 |
+| `springWebFluxBatchIds` | 164.854 |
+| `springWebFluxHealth` | 166.158 |
+| `springWebFluxSingleId` | 166.324 |
+
+## Interpretation
+
+- Ktor CIO starts much faster in this embedded benchmark because it avoids Spring
+  Boot context creation.
+- Spring WebFlux is faster for steady-state request throughput and average
+  request latency in this short-window local fixture.
+- The current Ktor library design should stay thin and explicit: keep shared
+  domain behavior in core modules, and add Ktor helpers only where they remove
+  repeated integration code.
+- Do not choose a Ktor server abstraction only because startup is fast. For
+  request-path helpers, compare handler ergonomics, cancellation behavior, and
+  steady-state performance together.
+
+## Follow-Up Issues
+
+- #643 should first decide whether Ktor client support belongs in `io/http`,
+  `ktor/client`, or a thin bridge.
+- #644 should keep Resilience4j helpers coroutine-safe and benchmark timeout /
+  retry overhead after route helpers exist.
+- #645 should remain documentation/metadata focused until route contracts settle.
+- A future benchmark can add p50/p95/p99 histograms with an external load tool
+  such as `wrk`, `oha`, or Gatling. The current JMH fixture records throughput
+  and average latency, not percentile latency.

--- a/docs/benchmarks/raw/2026-05-29-web-framework-latency.json
+++ b/docs/benchmarks/raw/2026-05-29-web-framework-latency.json
@@ -1,0 +1,460 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.benchmark.webframework.WebFrameworkLatencyBenchmark.ktorBadRequest",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-21/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:-UnlockExperimentalVMOptions",
+            "-Dfile.encoding=UTF-8",
+            "-Duser.country=KR",
+            "-Duser.language=ko",
+            "-Duser.variant"
+        ],
+        "jdkVersion" : "21.0.11",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "21.0.11+9-LTS-jvmci-23.1-b92",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 245.50058788131733,
+            "scoreError" : 475.90181277787724,
+            "scoreConfidence" : [
+                -230.4012248965599,
+                721.4024006591945
+            ],
+            "scorePercentiles" : {
+                "0.0" : 222.47658462905375,
+                "50.0" : 240.19326746698678,
+                "90.0" : 273.83191154791155,
+                "95.0" : 273.83191154791155,
+                "99.0" : 273.83191154791155,
+                "99.9" : 273.83191154791155,
+                "99.99" : 273.83191154791155,
+                "99.999" : 273.83191154791155,
+                "99.9999" : 273.83191154791155,
+                "100.0" : 273.83191154791155
+            },
+            "scoreUnit" : "us/op",
+            "rawData" : [
+                [
+                    273.83191154791155,
+                    240.19326746698678,
+                    222.47658462905375
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.benchmark.webframework.WebFrameworkLatencyBenchmark.ktorBatchIds",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-21/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:-UnlockExperimentalVMOptions",
+            "-Dfile.encoding=UTF-8",
+            "-Duser.country=KR",
+            "-Duser.language=ko",
+            "-Duser.variant"
+        ],
+        "jdkVersion" : "21.0.11",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "21.0.11+9-LTS-jvmci-23.1-b92",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 288.3467752029935,
+            "scoreError" : 653.1098479374831,
+            "scoreConfidence" : [
+                -364.7630727344896,
+                941.4566231404766
+            ],
+            "scorePercentiles" : {
+                "0.0" : 248.39876825947016,
+                "50.0" : 299.117680011951,
+                "90.0" : 317.52387733755944,
+                "95.0" : 317.52387733755944,
+                "99.0" : 317.52387733755944,
+                "99.9" : 317.52387733755944,
+                "99.99" : 317.52387733755944,
+                "99.999" : 317.52387733755944,
+                "99.9999" : 317.52387733755944,
+                "100.0" : 317.52387733755944
+            },
+            "scoreUnit" : "us/op",
+            "rawData" : [
+                [
+                    317.52387733755944,
+                    299.117680011951,
+                    248.39876825947016
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.benchmark.webframework.WebFrameworkLatencyBenchmark.ktorHealth",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-21/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:-UnlockExperimentalVMOptions",
+            "-Dfile.encoding=UTF-8",
+            "-Duser.country=KR",
+            "-Duser.language=ko",
+            "-Duser.variant"
+        ],
+        "jdkVersion" : "21.0.11",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "21.0.11+9-LTS-jvmci-23.1-b92",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 281.8560582677976,
+            "scoreError" : 673.2888543729025,
+            "scoreConfidence" : [
+                -391.4327961051049,
+                955.1449126407001
+            ],
+            "scorePercentiles" : {
+                "0.0" : 242.4133339796413,
+                "50.0" : 287.6060237890513,
+                "90.0" : 315.54881703470033,
+                "95.0" : 315.54881703470033,
+                "99.0" : 315.54881703470033,
+                "99.9" : 315.54881703470033,
+                "99.99" : 315.54881703470033,
+                "99.999" : 315.54881703470033,
+                "99.9999" : 315.54881703470033,
+                "100.0" : 315.54881703470033
+            },
+            "scoreUnit" : "us/op",
+            "rawData" : [
+                [
+                    315.54881703470033,
+                    287.6060237890513,
+                    242.4133339796413
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.benchmark.webframework.WebFrameworkLatencyBenchmark.ktorSingleId",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-21/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:-UnlockExperimentalVMOptions",
+            "-Dfile.encoding=UTF-8",
+            "-Duser.country=KR",
+            "-Duser.language=ko",
+            "-Duser.variant"
+        ],
+        "jdkVersion" : "21.0.11",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "21.0.11+9-LTS-jvmci-23.1-b92",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 256.20495585819543,
+            "scoreError" : 573.546211688486,
+            "scoreConfidence" : [
+                -317.34125583029055,
+                829.7511675466815
+            ],
+            "scorePercentiles" : {
+                "0.0" : 228.19778120009127,
+                "50.0" : 250.207376435347,
+                "90.0" : 290.20970993914807,
+                "95.0" : 290.20970993914807,
+                "99.0" : 290.20970993914807,
+                "99.9" : 290.20970993914807,
+                "99.99" : 290.20970993914807,
+                "99.999" : 290.20970993914807,
+                "99.9999" : 290.20970993914807,
+                "100.0" : 290.20970993914807
+            },
+            "scoreUnit" : "us/op",
+            "rawData" : [
+                [
+                    290.20970993914807,
+                    250.207376435347,
+                    228.19778120009127
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.benchmark.webframework.WebFrameworkLatencyBenchmark.springWebFluxBadRequest",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-21/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:-UnlockExperimentalVMOptions",
+            "-Dfile.encoding=UTF-8",
+            "-Duser.country=KR",
+            "-Duser.language=ko",
+            "-Duser.variant"
+        ],
+        "jdkVersion" : "21.0.11",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "21.0.11+9-LTS-jvmci-23.1-b92",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 162.98171377423844,
+            "scoreError" : 220.48611130040132,
+            "scoreConfidence" : [
+                -57.504397526162876,
+                383.4678250746398
+            ],
+            "scorePercentiles" : {
+                "0.0" : 151.6179620444579,
+                "50.0" : 161.64858490566039,
+                "90.0" : 175.678594372597,
+                "95.0" : 175.678594372597,
+                "99.0" : 175.678594372597,
+                "99.9" : 175.678594372597,
+                "99.99" : 175.678594372597,
+                "99.999" : 175.678594372597,
+                "99.9999" : 175.678594372597,
+                "100.0" : 175.678594372597
+            },
+            "scoreUnit" : "us/op",
+            "rawData" : [
+                [
+                    175.678594372597,
+                    161.64858490566039,
+                    151.6179620444579
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.benchmark.webframework.WebFrameworkLatencyBenchmark.springWebFluxBatchIds",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-21/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:-UnlockExperimentalVMOptions",
+            "-Dfile.encoding=UTF-8",
+            "-Duser.country=KR",
+            "-Duser.language=ko",
+            "-Duser.variant"
+        ],
+        "jdkVersion" : "21.0.11",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "21.0.11+9-LTS-jvmci-23.1-b92",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 164.8544755269795,
+            "scoreError" : 311.49340552842494,
+            "scoreConfidence" : [
+                -146.63893000144543,
+                476.34788105540446
+            ],
+            "scorePercentiles" : {
+                "0.0" : 149.42488105857865,
+                "50.0" : 161.94066299773388,
+                "90.0" : 183.19788252462604,
+                "95.0" : 183.19788252462604,
+                "99.0" : 183.19788252462604,
+                "99.9" : 183.19788252462604,
+                "99.99" : 183.19788252462604,
+                "99.999" : 183.19788252462604,
+                "99.9999" : 183.19788252462604,
+                "100.0" : 183.19788252462604
+            },
+            "scoreUnit" : "us/op",
+            "rawData" : [
+                [
+                    183.19788252462604,
+                    161.94066299773388,
+                    149.42488105857865
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.benchmark.webframework.WebFrameworkLatencyBenchmark.springWebFluxHealth",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-21/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:-UnlockExperimentalVMOptions",
+            "-Dfile.encoding=UTF-8",
+            "-Duser.country=KR",
+            "-Duser.language=ko",
+            "-Duser.variant"
+        ],
+        "jdkVersion" : "21.0.11",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "21.0.11+9-LTS-jvmci-23.1-b92",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 166.15801505926586,
+            "scoreError" : 292.4275516510387,
+            "scoreConfidence" : [
+                -126.26953659177283,
+                458.58556671030453
+            ],
+            "scorePercentiles" : {
+                "0.0" : 152.98683407113418,
+                "50.0" : 161.48230284978266,
+                "90.0" : 184.00490825688073,
+                "95.0" : 184.00490825688073,
+                "99.0" : 184.00490825688073,
+                "99.9" : 184.00490825688073,
+                "99.99" : 184.00490825688073,
+                "99.999" : 184.00490825688073,
+                "99.9999" : 184.00490825688073,
+                "100.0" : 184.00490825688073
+            },
+            "scoreUnit" : "us/op",
+            "rawData" : [
+                [
+                    184.00490825688073,
+                    161.48230284978266,
+                    152.98683407113418
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.benchmark.webframework.WebFrameworkLatencyBenchmark.springWebFluxSingleId",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-21/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:-UnlockExperimentalVMOptions",
+            "-Dfile.encoding=UTF-8",
+            "-Duser.country=KR",
+            "-Duser.language=ko",
+            "-Duser.variant"
+        ],
+        "jdkVersion" : "21.0.11",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "21.0.11+9-LTS-jvmci-23.1-b92",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 166.32373811920198,
+            "scoreError" : 280.5195192052871,
+            "scoreConfidence" : [
+                -114.19578108608513,
+                446.84325732448906
+            ],
+            "scorePercentiles" : {
+                "0.0" : 151.56072668276485,
+                "50.0" : 165.1630950970714,
+                "90.0" : 182.2473925777697,
+                "95.0" : 182.2473925777697,
+                "99.0" : 182.2473925777697,
+                "99.9" : 182.2473925777697,
+                "99.99" : 182.2473925777697,
+                "99.999" : 182.2473925777697,
+                "99.9999" : 182.2473925777697,
+                "100.0" : 182.2473925777697
+            },
+            "scoreUnit" : "us/op",
+            "rawData" : [
+                [
+                    182.2473925777697,
+                    165.1630950970714,
+                    151.56072668276485
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/docs/benchmarks/raw/2026-05-29-web-framework-startup.json
+++ b/docs/benchmarks/raw/2026-05-29-web-framework-startup.json
@@ -1,0 +1,118 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.benchmark.webframework.WebFrameworkStartupBenchmark.ktorStartup",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-21/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:-UnlockExperimentalVMOptions",
+            "-Dfile.encoding=UTF-8",
+            "-Duser.country=KR",
+            "-Duser.language=ko",
+            "-Duser.variant"
+        ],
+        "jdkVersion" : "21.0.11",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "21.0.11+9-LTS-jvmci-23.1-b92",
+        "warmupIterations" : 1,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.7410172080584608,
+            "scoreError" : 0.4164092451265921,
+            "scoreConfidence" : [
+                0.3246079629318687,
+                1.1574264531850529
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.7194245103793844,
+                "50.0" : 0.7387258580882353,
+                "90.0" : 0.7649012557077626,
+                "95.0" : 0.7649012557077626,
+                "99.0" : 0.7649012557077626,
+                "99.9" : 0.7649012557077626,
+                "99.99" : 0.7649012557077626,
+                "99.999" : 0.7649012557077626,
+                "99.9999" : 0.7649012557077626,
+                "100.0" : 0.7649012557077626
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.7649012557077626,
+                    0.7387258580882353,
+                    0.7194245103793844
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.benchmark.webframework.WebFrameworkStartupBenchmark.springWebFluxStartup",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-21/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:-UnlockExperimentalVMOptions",
+            "-Dfile.encoding=UTF-8",
+            "-Duser.country=KR",
+            "-Duser.language=ko",
+            "-Duser.variant"
+        ],
+        "jdkVersion" : "21.0.11",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "21.0.11+9-LTS-jvmci-23.1-b92",
+        "warmupIterations" : 1,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2087.9264583333334,
+            "scoreError" : 155.33817100140485,
+            "scoreConfidence" : [
+                1932.5882873319285,
+                2243.2646293347384
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2078.42425,
+                "50.0" : 2090.491333,
+                "90.0" : 2094.863792,
+                "95.0" : 2094.863792,
+                "99.0" : 2094.863792,
+                "99.9" : 2094.863792,
+                "99.99" : 2094.863792,
+                "99.999" : 2094.863792,
+                "99.9999" : 2094.863792,
+                "100.0" : 2094.863792
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2090.491333,
+                    2094.863792,
+                    2078.42425
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/docs/benchmarks/raw/2026-05-29-web-framework-throughput.json
+++ b/docs/benchmarks/raw/2026-05-29-web-framework-throughput.json
@@ -1,0 +1,460 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.benchmark.webframework.WebFrameworkRequestBenchmark.ktorBadRequest",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-21/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:-UnlockExperimentalVMOptions",
+            "-Dfile.encoding=UTF-8",
+            "-Duser.country=KR",
+            "-Duser.language=ko",
+            "-Duser.variant"
+        ],
+        "jdkVersion" : "21.0.11",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "21.0.11+9-LTS-jvmci-23.1-b92",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4145.680453272528,
+            "scoreError" : 8201.747211437963,
+            "scoreConfidence" : [
+                -4056.066758165435,
+                12347.427664710493
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3691.566662838948,
+                "50.0" : 4154.9195713463105,
+                "90.0" : 4590.555125632327,
+                "95.0" : 4590.555125632327,
+                "99.0" : 4590.555125632327,
+                "99.9" : 4590.555125632327,
+                "99.99" : 4590.555125632327,
+                "99.999" : 4590.555125632327,
+                "99.9999" : 4590.555125632327,
+                "100.0" : 4590.555125632327
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3691.566662838948,
+                    4154.9195713463105,
+                    4590.555125632327
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.benchmark.webframework.WebFrameworkRequestBenchmark.ktorBatchIds",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-21/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:-UnlockExperimentalVMOptions",
+            "-Dfile.encoding=UTF-8",
+            "-Duser.country=KR",
+            "-Duser.language=ko",
+            "-Duser.variant"
+        ],
+        "jdkVersion" : "21.0.11",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "21.0.11+9-LTS-jvmci-23.1-b92",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3726.6028776909934,
+            "scoreError" : 6275.201128019958,
+            "scoreConfidence" : [
+                -2548.5982503289642,
+                10001.80400571095
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3391.7738806107013,
+                "50.0" : 3709.006449897234,
+                "90.0" : 4079.0283025650447,
+                "95.0" : 4079.0283025650447,
+                "99.0" : 4079.0283025650447,
+                "99.9" : 4079.0283025650447,
+                "99.99" : 4079.0283025650447,
+                "99.999" : 4079.0283025650447,
+                "99.9999" : 4079.0283025650447,
+                "100.0" : 4079.0283025650447
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3391.7738806107013,
+                    3709.006449897234,
+                    4079.0283025650447
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.benchmark.webframework.WebFrameworkRequestBenchmark.ktorHealth",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-21/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:-UnlockExperimentalVMOptions",
+            "-Dfile.encoding=UTF-8",
+            "-Duser.country=KR",
+            "-Duser.language=ko",
+            "-Duser.variant"
+        ],
+        "jdkVersion" : "21.0.11",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "21.0.11+9-LTS-jvmci-23.1-b92",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3797.2553574234903,
+            "scoreError" : 8480.182014958307,
+            "scoreConfidence" : [
+                -4682.926657534817,
+                12277.437372381797
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3288.5764539850475,
+                "50.0" : 3903.274771284017,
+                "90.0" : 4199.914847001406,
+                "95.0" : 4199.914847001406,
+                "99.0" : 4199.914847001406,
+                "99.9" : 4199.914847001406,
+                "99.99" : 4199.914847001406,
+                "99.999" : 4199.914847001406,
+                "99.9999" : 4199.914847001406,
+                "100.0" : 4199.914847001406
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3288.5764539850475,
+                    3903.274771284017,
+                    4199.914847001406
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.benchmark.webframework.WebFrameworkRequestBenchmark.ktorSingleId",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-21/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:-UnlockExperimentalVMOptions",
+            "-Dfile.encoding=UTF-8",
+            "-Duser.country=KR",
+            "-Duser.language=ko",
+            "-Duser.variant"
+        ],
+        "jdkVersion" : "21.0.11",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "21.0.11+9-LTS-jvmci-23.1-b92",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3952.1555817197773,
+            "scoreError" : 7754.403322717487,
+            "scoreConfidence" : [
+                -3802.2477409977096,
+                11706.558904437265
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3512.309698875752,
+                "50.0" : 3983.491774168976,
+                "90.0" : 4360.665272114604,
+                "95.0" : 4360.665272114604,
+                "99.0" : 4360.665272114604,
+                "99.9" : 4360.665272114604,
+                "99.99" : 4360.665272114604,
+                "99.999" : 4360.665272114604,
+                "99.9999" : 4360.665272114604,
+                "100.0" : 4360.665272114604
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3512.309698875752,
+                    3983.491774168976,
+                    4360.665272114604
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.benchmark.webframework.WebFrameworkRequestBenchmark.springWebFluxBadRequest",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-21/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:-UnlockExperimentalVMOptions",
+            "-Dfile.encoding=UTF-8",
+            "-Duser.country=KR",
+            "-Duser.language=ko",
+            "-Duser.variant"
+        ],
+        "jdkVersion" : "21.0.11",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "21.0.11+9-LTS-jvmci-23.1-b92",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6045.468785931652,
+            "scoreError" : 10649.936097139143,
+            "scoreConfidence" : [
+                -4604.467311207492,
+                16695.404883070794
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5497.133458822691,
+                "50.0" : 5980.120956605323,
+                "90.0" : 6659.15194236694,
+                "95.0" : 6659.15194236694,
+                "99.0" : 6659.15194236694,
+                "99.9" : 6659.15194236694,
+                "99.99" : 6659.15194236694,
+                "99.999" : 6659.15194236694,
+                "99.9999" : 6659.15194236694,
+                "100.0" : 6659.15194236694
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5497.133458822691,
+                    5980.120956605323,
+                    6659.15194236694
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.benchmark.webframework.WebFrameworkRequestBenchmark.springWebFluxBatchIds",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-21/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:-UnlockExperimentalVMOptions",
+            "-Dfile.encoding=UTF-8",
+            "-Duser.country=KR",
+            "-Duser.language=ko",
+            "-Duser.variant"
+        ],
+        "jdkVersion" : "21.0.11",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "21.0.11+9-LTS-jvmci-23.1-b92",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5807.421269073809,
+            "scoreError" : 6583.505620759918,
+            "scoreConfidence" : [
+                -776.0843516861096,
+                12390.926889833727
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5393.330080483627,
+                "50.0" : 5974.226258706398,
+                "90.0" : 6054.707468031402,
+                "95.0" : 6054.707468031402,
+                "99.0" : 6054.707468031402,
+                "99.9" : 6054.707468031402,
+                "99.99" : 6054.707468031402,
+                "99.999" : 6054.707468031402,
+                "99.9999" : 6054.707468031402,
+                "100.0" : 6054.707468031402
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5393.330080483627,
+                    6054.707468031402,
+                    5974.226258706398
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.benchmark.webframework.WebFrameworkRequestBenchmark.springWebFluxHealth",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-21/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:-UnlockExperimentalVMOptions",
+            "-Dfile.encoding=UTF-8",
+            "-Duser.country=KR",
+            "-Duser.language=ko",
+            "-Duser.variant"
+        ],
+        "jdkVersion" : "21.0.11",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "21.0.11+9-LTS-jvmci-23.1-b92",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4418.503455857393,
+            "scoreError" : 32867.46137198696,
+            "scoreConfidence" : [
+                -28448.957916129566,
+                37285.96482784435
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2543.7807502308447,
+                "50.0" : 4575.007050380641,
+                "90.0" : 6136.722566960695,
+                "95.0" : 6136.722566960695,
+                "99.0" : 6136.722566960695,
+                "99.9" : 6136.722566960695,
+                "99.99" : 6136.722566960695,
+                "99.999" : 6136.722566960695,
+                "99.9999" : 6136.722566960695,
+                "100.0" : 6136.722566960695
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2543.7807502308447,
+                    4575.007050380641,
+                    6136.722566960695
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.benchmark.webframework.WebFrameworkRequestBenchmark.springWebFluxSingleId",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-21/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:-UnlockExperimentalVMOptions",
+            "-Dfile.encoding=UTF-8",
+            "-Duser.country=KR",
+            "-Duser.language=ko",
+            "-Duser.variant"
+        ],
+        "jdkVersion" : "21.0.11",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "21.0.11+9-LTS-jvmci-23.1-b92",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5625.43751050039,
+            "scoreError" : 7358.909725517591,
+            "scoreConfidence" : [
+                -1733.472215017201,
+                12984.34723601798
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5159.745491583827,
+                "50.0" : 5851.011587854664,
+                "90.0" : 5865.555452062682,
+                "95.0" : 5865.555452062682,
+                "99.0" : 5865.555452062682,
+                "99.9" : 5865.555452062682,
+                "99.99" : 5865.555452062682,
+                "99.999" : 5865.555452062682,
+                "99.9999" : 5865.555452062682,
+                "100.0" : 5865.555452062682
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5159.745491583827,
+                    5865.555452062682,
+                    5851.011587854664
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/docs/lessons/2026-05-29-issue-667-web-framework-benchmark.md
+++ b/docs/lessons/2026-05-29-issue-667-web-framework-benchmark.md
@@ -1,0 +1,31 @@
+# Lesson: Web Framework Benchmark Baseline
+
+**Date**: 2026-05-29
+**Issue**: #667
+
+## Context
+
+The Ktor module family needed current evidence before broad API work in #609.
+
+## Decision
+
+Add a non-published `benchmark/web-framework-benchmark` module using
+`kotlinx-benchmark`. Keep equivalent Ktor CIO and Spring WebFlux benchmark
+applications inside the benchmark module, not production modules.
+
+## Outcome
+
+The benchmark now covers startup, throughput, and average latency for equivalent
+health, single-ID, batch-ID, and bad-request paths.
+
+## Verification
+
+- `./gradlew :web-framework-benchmark:compileBenchmarkKotlin --no-configuration-cache`
+- `./gradlew :web-framework-benchmark:benchmarkStartupBenchmark --no-configuration-cache`
+- `./gradlew :web-framework-benchmark:benchmarkThroughputBenchmark :web-framework-benchmark:benchmarkLatencyBenchmark --no-configuration-cache`
+
+## Future Guard
+
+Use `server.port=0` and read actual bound ports from the framework runtime.
+Preselecting a local port with `ServerSocket(0)` can race during repeated JMH
+startup iterations.

--- a/scripts/web-framework-benchmark.sh
+++ b/scripts/web-framework-benchmark.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Run Ktor CIO vs Spring WebFlux benchmark tasks and copy the latest JSON
+# reports into docs/benchmarks/raw for issue-backed evidence.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+MODULE=":web-framework-benchmark"
+REPORT_ROOT="benchmark/web-framework-benchmark/build/reports/benchmarks"
+RAW_DIR="docs/benchmarks/raw"
+STAMP="$(date +%F)"
+
+mkdir -p "${RAW_DIR}"
+
+./gradlew \
+    "${MODULE}:benchmarkStartupBenchmark" \
+    "${MODULE}:benchmarkThroughputBenchmark" \
+    "${MODULE}:benchmarkLatencyBenchmark" \
+    --no-configuration-cache
+
+copy_latest() {
+    local config="$1"
+    local target="$2"
+    local latest
+
+    latest="$(ls -1t "${REPORT_ROOT}/${config}"/*/benchmark.json 2>/dev/null | head -n 1 || true)"
+    if [[ -z "${latest}" ]]; then
+        echo "[web-framework-benchmark] missing ${config} benchmark JSON" >&2
+        exit 2
+    fi
+
+    cp "${latest}" "${RAW_DIR}/${STAMP}-web-framework-${target}.json"
+    echo "[web-framework-benchmark] copied ${config}: ${RAW_DIR}/${STAMP}-web-framework-${target}.json" >&2
+}
+
+copy_latest startup startup
+copy_latest throughput throughput
+copy_latest latency latency
+
+jq -r '.[] | [.benchmark, .mode, .primaryMetric.score, .primaryMetric.scoreError, .primaryMetric.scoreUnit] | @tsv' \
+    "${RAW_DIR}/${STAMP}-web-framework-"*.json

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -74,6 +74,9 @@ includeModules("testing", withBaseDir = false)
 includeModules("utils", withBaseDir = false)
 includeModules("virtualthread", withProjectName = true, withBaseDir = true)
 
+// Benchmarks (not published)
+includeModules("benchmark", false, false)
+
 // Examples (library style examples)
 includeModules("examples", withProjectName = true, withBaseDir = true)
 includeModules("examples/spring-boot", false, false)


### PR DESCRIPTION
## Summary

Closes #667

- PR 제목: perf: add web framework benchmark baseline

- Add non-published `:web-framework-benchmark` for Ktor CIO vs Spring WebFlux comparisons.
- Cover startup, throughput, and average latency for equivalent ID generator endpoints.
- Store 2026-05-29 raw JSON artifacts and interpretation under `docs/benchmarks/`.
- Add a repeatable `scripts/web-framework-benchmark.sh` runner.

Closes #667.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- `./gradlew :web-framework-benchmark:compileBenchmarkKotlin --no-configuration-cache`
- `./gradlew :web-framework-benchmark:benchmarkStartupBenchmark --no-configuration-cache`
- `./gradlew :web-framework-benchmark:benchmarkThroughputBenchmark :web-framework-benchmark:benchmarkLatencyBenchmark --no-configuration-cache`
- `bash -n scripts/web-framework-benchmark.sh && git diff --check`

### 기존 섹션: Notes

`kotlinx-benchmark` in this repo accepts throughput and average-time modes through the Gradle DSL, so percentile latency remains a follow-up for an external load tool such as wrk, oha, or Gatling.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #667, milestone `1.10.0`, assignee `debop`
- PR: #676, head `c73de219d27574ada4d81b35a25af9013f401641`, milestone `backlog`, assignee `debop`
- Base: `develop`, head branch `feat/667-web-framework-benchmark`
- Labels: `enhancement`, `performance`
- State: `MERGED`, merge commit `06952815a05005f3889e13af1b5ca044d5339b58`
- CI: - Add non-published `:web-framework-benchmark` for Ktor CIO vs Spring WebFlux comparisons. / - `./gradlew :web-framework-benchmark:compileBenchmarkKotlin --no-configuration-cache` / - `./gradlew :web-framework-benchmark:benchmarkStartupBenchmark --no-configuration-cache`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #676 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `06952815a05005f3889e13af1b5ca044d5339b58`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
