### PR TITLE
feat: keep Ktor client helpers in io-http

### DIFF
--- a/docs/lessons/2026-05-29-issue-643-ktor-client-boundary.md
+++ b/docs/lessons/2026-05-29-issue-643-ktor-client-boundary.md
@@ -1,0 +1,30 @@
+# Issue 643 Ktor Client Boundary
+
+## Context
+
+Issue #643 asked whether `bluetape4k-projects` should introduce a dedicated `bluetape4k-ktor-client` module or keep Ktor client support in an existing module.
+
+## Decision
+
+Keep Ktor client ownership in `bluetape4k-http`. Add only thin helpers for explicit-engine client creation, Kotlinx JSON content negotiation, and timeout defaults.
+
+Avoid a separate Ktor client module until there is a broader API surface that cannot fit the HTTP module without dependency or ownership confusion.
+
+## Outcome
+
+`KtorHttpClientSupport` now exposes:
+
+- `defaultKtorClientJson`
+- `KtorClientTimeouts`
+- `ktorJsonHttpClientOf`
+- `ktorCioJsonHttpClientOf`
+
+The README locale set documents that retry, resilience, authentication, logging, and service-specific plugins remain application-level concerns or belong in existing dedicated modules.
+
+## Verification
+
+- `./gradlew :bluetape4k-http:test --tests 'io.bluetape4k.http.ktor.KtorHttpClientSupportTest' --no-configuration-cache`
+
+## Future Guard
+
+When adding Ktor client helpers, require a clear cross-application pattern first. Prefer explicit engine selection and narrow plugin installation over a broad facade.

--- a/io/http/README.ko.md
+++ b/io/http/README.ko.md
@@ -223,6 +223,35 @@ val options = httpClientOptionsOf(
 val vertxClient = vertxHttpClientOf(options)
 ```
 
+### 4. Ktor Client
+
+Ktor Client 지원은 별도 모듈을 만들지 않고 `bluetape4k-http` 안에 둡니다. 헬퍼는 의도적으로 얇게 유지합니다: 엔진은 명시적으로 선택하고, 공통 JSON 및 timeout 기본값만 선택적으로 적용합니다.
+
+```kotlin
+import io.bluetape4k.http.ktor.*
+import io.ktor.client.call.body
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.get
+import kotlinx.serialization.Serializable
+import java.time.Duration
+
+@Serializable
+data class HealthResponse(val status: String)
+
+val client = ktorJsonHttpClientOf(
+    engineFactory = CIO,
+    timeouts = KtorClientTimeouts(
+        requestTimeout = Duration.ofSeconds(15),
+        connectTimeout = Duration.ofSeconds(5),
+        socketTimeout = Duration.ofSeconds(15),
+    ),
+)
+
+val response: HealthResponse = client.get("https://example.com/health").body()
+```
+
+`ktorJsonHttpClientOf`와 `ktorCioJsonHttpClientOf`는 Kotlinx JSON content negotiation과 `HttpTimeout`만 설치합니다. 재시도, resilience, 인증, 로깅, 서비스별 플러그인은 애플리케이션 계층이나 기존 전용 모듈의 책임으로 둡니다.
+
 ## 주요 권장 클라이언트
 
 > 전체 설계 근거: [`docs/design/2026-05-24-hc5-first-http-client-recommendation.md`](../../docs/design/2026-05-24-hc5-first-http-client-recommendation.md)
@@ -503,6 +532,9 @@ dependencies {
     compileOnly("io.vertx:vertx-core")                           // Vert.x
     compileOnly("io.ktor:ktor-client-core")                      // Ktor Client (엔진 선택)
     compileOnly("io.ktor:ktor-client-cio")                       // Ktor CIO 엔진 (HTTP/1.x)
+    compileOnly("io.ktor:ktor-client-content-negotiation")       // Ktor JSON 헬퍼
+    compileOnly("io.ktor:ktor-serialization-kotlinx-json")       // Kotlinx JSON 연결
+    compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-json")
 }
 ```
 

--- a/io/http/README.md
+++ b/io/http/README.md
@@ -224,6 +224,35 @@ val options = httpClientOptionsOf(
 val vertxClient = vertxHttpClientOf(options)
 ```
 
+### 4. Ktor Client
+
+Ktor client support stays in `bluetape4k-http` rather than a separate module. The helpers are intentionally thin: choose the engine explicitly, then opt into common JSON and timeout defaults.
+
+```kotlin
+import io.bluetape4k.http.ktor.*
+import io.ktor.client.call.body
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.get
+import kotlinx.serialization.Serializable
+import java.time.Duration
+
+@Serializable
+data class HealthResponse(val status: String)
+
+val client = ktorJsonHttpClientOf(
+    engineFactory = CIO,
+    timeouts = KtorClientTimeouts(
+        requestTimeout = Duration.ofSeconds(15),
+        connectTimeout = Duration.ofSeconds(5),
+        socketTimeout = Duration.ofSeconds(15),
+    ),
+)
+
+val response: HealthResponse = client.get("https://example.com/health").body()
+```
+
+`ktorJsonHttpClientOf` and `ktorCioJsonHttpClientOf` install only Kotlinx JSON content negotiation and `HttpTimeout`. Retry, resilience, authentication, logging, and service-specific plugins remain application-level concerns or belong in their existing dedicated modules.
+
 ## Primary Recommendations
 
 > See the full design rationale: [`docs/design/2026-05-24-hc5-first-http-client-recommendation.md`](../../docs/design/2026-05-24-hc5-first-http-client-recommendation.md)
@@ -502,6 +531,9 @@ dependencies {
     compileOnly("io.vertx:vertx-core")                           // Vert.x
     compileOnly("io.ktor:ktor-client-core")                      // Ktor Client (any engine)
     compileOnly("io.ktor:ktor-client-cio")                       // Ktor CIO engine (HTTP/1.x)
+    compileOnly("io.ktor:ktor-client-content-negotiation")       // Ktor JSON helper
+    compileOnly("io.ktor:ktor-serialization-kotlinx-json")       // Kotlinx JSON bridge
+    compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-json")
 }
 ```
 

--- a/io/http/build.gradle.kts
+++ b/io/http/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("plugin.allopen")
+    kotlin("plugin.serialization")
     alias(libs.plugins.kotlinx.benchmark)
 }
 
@@ -140,7 +141,13 @@ dependencies {
     // Ktor Client
     compileOnly(libs.ktor.client.core)
     compileOnly(libs.ktor.client.cio)
+    compileOnly(libs.ktor.client.content.negotiation)
+    compileOnly(libs.ktor.serialization.kotlinx.json)
+    compileOnly(libs.kotlinx.serialization.json)
     testImplementation(libs.ktor.client.mock)
+    testImplementation(libs.ktor.client.content.negotiation)
+    testImplementation(libs.ktor.serialization.kotlinx.json)
+    testImplementation(libs.kotlinx.serialization.json)
 
     // Vertx
     compileOnly(project(":bluetape4k-vertx"))

--- a/io/http/src/main/kotlin/io/bluetape4k/http/ktor/KtorHttpClientSupport.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/ktor/KtorHttpClientSupport.kt
@@ -1,11 +1,57 @@
 package io.bluetape4k.http.ktor
 
+import io.bluetape4k.support.requirePositiveNumber
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngineConfig
 import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.engine.cio.CIOEngineConfig
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+import java.io.Serializable
+import java.time.Duration
+
+/**
+ * Default JSON configuration for Ktor Client helpers.
+ *
+ * ## Behavior / Contract
+ * - Unknown JSON fields are ignored so clients tolerate additive server fields.
+ * - Default values are encoded for stable DTO round trips in tests and examples.
+ * - Explicit `null` values are omitted to match common HTTP API payloads.
+ */
+val defaultKtorClientJson: Json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = true
+    explicitNulls = false
+}
+
+/**
+ * Timeout settings installed by [ktorJsonHttpClientOf].
+ *
+ * ## Behavior / Contract
+ * - All durations must be positive.
+ * - Values are converted to Ktor's millisecond timeout plugin settings.
+ * - Callers that need per-request timeouts should still use Ktor request-level configuration.
+ */
+data class KtorClientTimeouts(
+    val requestTimeout: Duration = Duration.ofSeconds(30),
+    val connectTimeout: Duration = Duration.ofSeconds(10),
+    val socketTimeout: Duration = Duration.ofSeconds(30),
+): Serializable {
+
+    init {
+        requestTimeout.toMillis().requirePositiveNumber("requestTimeoutMillis")
+        connectTimeout.toMillis().requirePositiveNumber("connectTimeoutMillis")
+        socketTimeout.toMillis().requirePositiveNumber("socketTimeoutMillis")
+    }
+
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
 
 /**
  * Creates an [HttpClient] with the given [engineFactory] and optional [block] configuration.
@@ -35,6 +81,47 @@ fun <T : HttpClientEngineConfig> ktorHttpClientOf(
 ): HttpClient = HttpClient(engineFactory, block)
 
 /**
+ * Creates a Ktor [HttpClient] with JSON content negotiation and timeout defaults.
+ *
+ * ## Behavior / Contract
+ * - Engine selection remains explicit through [engineFactory]; this helper does not choose CIO, Java, Apache, or mock.
+ * - Installs only Ktor's `ContentNegotiation` JSON plugin and `HttpTimeout` plugin.
+ * - Does not install retry, resilience, logging, metrics, authentication, or tracing policies.
+ * - The caller owns the returned [HttpClient] and is responsible for calling [HttpClient.close].
+ *
+ * ```kotlin
+ * val client = ktorJsonHttpClientOf(CIO) {
+ *     engine {
+ *         requestTimeout = 10_000
+ *     }
+ * }
+ * ```
+ *
+ * @param engineFactory the Ktor [HttpClientEngineFactory] to use
+ * @param json JSON configuration for request/response serialization
+ * @param timeouts client-level timeout defaults
+ * @param block optional [HttpClientConfig] DSL block applied after shared plugins
+ * @return a new [HttpClient] instance
+ */
+fun <T : HttpClientEngineConfig> ktorJsonHttpClientOf(
+    engineFactory: HttpClientEngineFactory<T>,
+    json: Json = defaultKtorClientJson,
+    timeouts: KtorClientTimeouts = KtorClientTimeouts(),
+    block: HttpClientConfig<T>.() -> Unit = {},
+): HttpClient =
+    HttpClient(engineFactory) {
+        install(ContentNegotiation) {
+            json(json)
+        }
+        install(HttpTimeout) {
+            requestTimeoutMillis = timeouts.requestTimeout.toMillis()
+            connectTimeoutMillis = timeouts.connectTimeout.toMillis()
+            socketTimeoutMillis = timeouts.socketTimeout.toMillis()
+        }
+        block()
+    }
+
+/**
  * Creates an [HttpClient] backed by the Ktor CIO engine.
  *
  * ## Behavior / Contract
@@ -57,3 +144,34 @@ fun <T : HttpClientEngineConfig> ktorHttpClientOf(
 fun ktorCioHttpClientOf(
     block: HttpClientConfig<CIOEngineConfig>.() -> Unit = {},
 ): HttpClient = HttpClient(CIO, block)
+
+/**
+ * Creates a CIO-backed Ktor [HttpClient] with JSON content negotiation and timeout defaults.
+ *
+ * ## Behavior / Contract
+ * - CIO remains HTTP/1.x only; prefer HC5 Async, JDK, or OkHttp engines for HTTP/2 use cases.
+ * - Only JSON and timeout plugins are installed. Retry/resilience policy stays outside this helper.
+ * - The caller owns the returned [HttpClient] and is responsible for calling [HttpClient.close].
+ *
+ * ```kotlin
+ * val client = ktorCioJsonHttpClientOf(
+ *     timeouts = KtorClientTimeouts(requestTimeout = Duration.ofSeconds(5))
+ * )
+ * ```
+ *
+ * @param json JSON configuration for request/response serialization
+ * @param timeouts client-level timeout defaults
+ * @param block optional [HttpClientConfig] DSL block for CIO-specific configuration
+ * @return a new [HttpClient] backed by the CIO engine
+ */
+fun ktorCioJsonHttpClientOf(
+    json: Json = defaultKtorClientJson,
+    timeouts: KtorClientTimeouts = KtorClientTimeouts(),
+    block: HttpClientConfig<CIOEngineConfig>.() -> Unit = {},
+): HttpClient =
+    ktorJsonHttpClientOf(
+        engineFactory = CIO,
+        json = json,
+        timeouts = timeouts,
+        block = block,
+    )

--- a/io/http/src/test/kotlin/io/bluetape4k/http/ktor/KtorHttpClientSupportTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/ktor/KtorHttpClientSupportTest.kt
@@ -1,16 +1,26 @@
 package io.bluetape4k.http.ktor
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeBlank
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.http.AbstractHttpTest
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.KLogging
+import io.ktor.client.call.body
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldNotBeNull
-import io.bluetape4k.assertions.shouldNotBeBlank
+import io.ktor.http.headersOf
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.io.Serializable
+import java.time.Duration
+import kotlinx.serialization.Serializable as KotlinSerializable
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class KtorHttpClientSupportTest : AbstractHttpTest() {
@@ -56,5 +66,64 @@ class KtorHttpClientSupportTest : AbstractHttpTest() {
         } finally {
             client.close()
         }
+    }
+
+    @Test
+    fun `ktorJsonHttpClientOf installs JSON serialization with explicit engine`() = runSuspendIO {
+        val client = ktorJsonHttpClientOf(MockEngine) {
+            engine {
+                addHandler {
+                    respond(
+                        content = """{"status":"UP","ignored":"additive"}""",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+                    )
+                }
+            }
+        }
+
+        try {
+            val response = client.get("https://example.test/health")
+            response.status shouldBeEqualTo HttpStatusCode.OK
+            response.body<ClientHealthResponse>().status shouldBeEqualTo "UP"
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `ktorCioJsonHttpClientOf creates CIO client with shared defaults`() {
+        val client = ktorCioJsonHttpClientOf(
+            timeouts = KtorClientTimeouts(
+                requestTimeout = Duration.ofSeconds(5),
+                connectTimeout = Duration.ofSeconds(2),
+                socketTimeout = Duration.ofSeconds(5),
+            )
+        )
+
+        client.shouldNotBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `KtorClientTimeouts reject non positive durations`() {
+        assertFailsWith<IllegalArgumentException> {
+            KtorClientTimeouts(requestTimeout = Duration.ZERO)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            KtorClientTimeouts(connectTimeout = Duration.ofMillis(-1))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            KtorClientTimeouts(socketTimeout = Duration.ZERO)
+        }
+    }
+}
+
+@KotlinSerializable
+internal data class ClientHealthResponse(
+    val status: String,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
     }
 }


### PR DESCRIPTION
## Summary

Closes #643

- PR 제목: feat: keep Ktor client helpers in io-http

- Keep Ktor client support in `bluetape4k-http` instead of introducing a dedicated module.
- Add thin Ktor JSON helpers with explicit engine selection, Kotlinx JSON content negotiation, and timeout defaults.
- Document the module boundary in the README locale set and capture the lesson for future Ktor helper work.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- `./gradlew :bluetape4k-http:test --tests 'io.bluetape4k.http.ktor.KtorHttpClientSupportTest' --no-configuration-cache`
- `./gradlew :bluetape4k-http:compileKotlin :bluetape4k-http:compileTestKotlin --no-configuration-cache`
- `git diff --check`

Closes #643

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #643, milestone `1.10.0`, assignee `debop`
- PR: #677, head `4591116eb47c68f3f022669a9ed0dd12928a9185`, milestone `backlog`, assignee `debop`
- Base: `develop`, head branch `feat/643-ktor-client-boundary`
- Labels: `enhancement`
- State: `MERGED`, merge commit `78119e4e8f6a953bc3b2a6a4f96a11d6128ffbd3`
- CI: - Keep Ktor client support in `bluetape4k-http` instead of introducing a dedicated module. / - Add thin Ktor JSON helpers with explicit engine selection, Kotlinx JSON content negotiation, and timeout defaults. / - `./gradlew :bluetape4k-http:test --tests 'io.bluetape4k.http.ktor.KtorHttpClientSupportTest' --no-configuration-cache`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #677 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `78119e4e8f6a953bc3b2a6a4f96a11d6128ffbd3`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
