### PR TITLE
perf: reduce Redisson protobuf encode allocation

### DIFF
--- a/benchmark/protobuf-codec-benchmark/build.gradle.kts
+++ b/benchmark/protobuf-codec-benchmark/build.gradle.kts
@@ -1,0 +1,69 @@
+import com.google.protobuf.gradle.id
+
+plugins {
+    kotlin("plugin.allopen")
+    alias(libs.plugins.protobuf.plugin)
+    alias(libs.plugins.kotlinx.benchmark)
+}
+
+allOpen {
+    annotation("org.openjdk.jmh.annotations.State")
+}
+
+sourceSets {
+    create("benchmark")
+}
+
+kotlin {
+    target {
+        compilations.getByName("benchmark").associateWith(compilations.getByName("main"))
+    }
+}
+
+protobuf {
+    protoc {
+        artifact = libs.protobuf.protoc.get().toString()
+    }
+    generateProtoTasks {
+        all().forEach { task ->
+            task.builtins {
+                id("kotlin")
+            }
+        }
+    }
+}
+
+configurations {
+    named("benchmarkImplementation") {
+        extendsFrom(
+            configurations.getByName("implementation"),
+            configurations.getByName("compileOnly"),
+            configurations.getByName("testImplementation"),
+        )
+    }
+    named("benchmarkRuntimeOnly") {
+        extendsFrom(
+            configurations.getByName("runtimeOnly"),
+            configurations.getByName("testRuntimeOnly"),
+        )
+    }
+}
+
+benchmark {
+    targets {
+        register("benchmark") {
+            this as kotlinx.benchmark.gradle.JvmBenchmarkTarget
+            jmhVersion = libs.versions.jmh.get()
+        }
+    }
+}
+
+dependencies {
+    add("benchmarkImplementation", project(":bluetape4k-protobuf"))
+    add("benchmarkImplementation", project(":bluetape4k-redisson"))
+
+    add("benchmarkImplementation", libs.kotlinx.benchmark.runtime)
+    add("benchmarkImplementation", libs.kotlinx.benchmark.runtime.jvm)
+    add("benchmarkImplementation", libs.jmh.core)
+    add("benchmarkRuntimeOnly", libs.logback.classic)
+}

--- a/benchmark/protobuf-codec-benchmark/src/benchmark/kotlin/io/bluetape4k/protobuf/benchmark/ProtobufCodecBenchmark.kt
+++ b/benchmark/protobuf-codec-benchmark/src/benchmark/kotlin/io/bluetape4k/protobuf/benchmark/ProtobufCodecBenchmark.kt
@@ -1,0 +1,92 @@
+package io.bluetape4k.protobuf.benchmark
+
+import io.bluetape4k.protobuf.benchmark.messages.BenchmarkMessage
+import io.bluetape4k.protobuf.benchmark.messages.benchmarkMessage
+import io.bluetape4k.protobuf.serializers.ProtobufSerializer
+import io.bluetape4k.protobuf.serializers.redis.AnyMessage
+import io.bluetape4k.protobuf.serializers.redis.RedissonProtobufCodec
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.BenchmarkMode
+import kotlinx.benchmark.Measurement
+import kotlinx.benchmark.Mode
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.benchmark.Warmup
+import java.io.Serializable
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+class ProtobufCodecBenchmark {
+
+    private val redissonCodec = RedissonProtobufCodec()
+    private val serializer = ProtobufSerializer()
+
+    private lateinit var message: BenchmarkMessage
+    private lateinit var fallbackPayload: FallbackPayload
+    private lateinit var encodedMessage: ByteArray
+
+    @Setup
+    fun setup() {
+        message = benchmarkMessage {
+            id = 42L
+            payload = "protobuf-payload-".repeat(128)
+        }
+        fallbackPayload = FallbackPayload(
+            id = 42L,
+            name = "fallback-payload",
+            values = List(64) { "value-$it" }
+        )
+        redissonCodec.valueEncoder.encode(message).useAndRelease { buffer ->
+            encodedMessage = ByteArray(buffer.readableBytes()).also { buffer.readBytes(it) }
+        }
+    }
+
+    @Benchmark
+    fun redissonProtobufEncode(): Int =
+        redissonCodec.valueEncoder.encode(message).useAndRelease { buffer ->
+            buffer.readableBytes()
+        }
+
+    @Benchmark
+    fun redissonProtobufEncodeByteArrayWrappedBaseline(): Int {
+        val bytes = AnyMessage.pack(message).toByteArray()
+        return io.netty.buffer.Unpooled.wrappedBuffer(bytes).useAndRelease { buffer ->
+            buffer.readableBytes()
+        }
+    }
+
+    @Benchmark
+    fun redissonProtobufDecode(): Any =
+        io.netty.buffer.Unpooled.wrappedBuffer(encodedMessage).useAndRelease { buffer ->
+            redissonCodec.valueDecoder.decode(buffer, null)
+        }
+
+    @Benchmark
+    fun protobufSerializerEncode(): Int =
+        serializer.serialize(message).size
+
+    @Benchmark
+    fun protobufSerializerFallbackEncode(): Int =
+        serializer.serialize(fallbackPayload).size
+
+    data class FallbackPayload(
+        val id: Long,
+        val name: String,
+        val values: List<String>,
+    ): Serializable {
+        companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+}
+
+private inline fun <T> io.netty.buffer.ByteBuf.useAndRelease(block: (io.netty.buffer.ByteBuf) -> T): T =
+    try {
+        block(this)
+    } finally {
+        release()
+    }

--- a/benchmark/protobuf-codec-benchmark/src/benchmark/proto/protobuf/benchmark-message.proto
+++ b/benchmark/protobuf-codec-benchmark/src/benchmark/proto/protobuf/benchmark-message.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package io.bluetape4k.protobuf.benchmark.messages;
+
+option java_multiple_files = true;
+option java_package = "io.bluetape4k.protobuf.benchmark.messages";
+
+message BenchmarkMessage {
+  int64 id = 1;
+  string payload = 2;
+}

--- a/docs/lessons/2026-05-29-issue-649-protobuf-codec-allocation.md
+++ b/docs/lessons/2026-05-29-issue-649-protobuf-codec-allocation.md
@@ -1,0 +1,29 @@
+# Issue 649 Protobuf Codec Allocation
+
+## Context
+
+The Redisson protobuf encoder had a removable allocation: protobuf `Any` was
+serialized to `ByteArray` and then wrapped as a Netty buffer.
+
+## Decision
+
+Use `Any.serializedSize` plus `CodedOutputStream` over a Netty buffer's
+`ByteBuffer` view for the Redisson fast path.
+Keep `ProtobufSerializer` unchanged because its public contract returns
+`ByteArray`.
+
+## Verification
+
+Targeted protobuf codec tests passed. A short local benchmark sample from
+`:protobuf-codec-benchmark:benchmarkBenchmark` showed `redissonProtobufEncode`
+at 3,936,257 ops/s versus the old `toByteArray()`/`wrappedBuffer()` baseline at
+4,056,681 ops/s, within the short-run error interval. Decode and fallback
+benchmarks ran in the same module without weakening the protobuf allowlist.
+
+## Future Guidance
+
+Only optimize encode paths where the owning API returns a buffer or stream. Put
+benchmark harnesses under `benchmark/*-benchmark`, not production modules. Do
+not weaken protobuf decode allowlists for benchmark wins. Keep the old encode
+baseline in benchmark code so future allocation profilers can compare both
+paths directly.

--- a/docs/superpowers/plans/2026-05-29-issue-649-protobuf-codec-allocation-plan.md
+++ b/docs/superpowers/plans/2026-05-29-issue-649-protobuf-codec-allocation-plan.md
@@ -1,0 +1,11 @@
+# Issue 649 Protobuf Codec Allocation Plan
+
+## Steps
+
+1. Add focused protobuf codec benchmarks to `benchmark/protobuf-codec-benchmark`.
+2. Replace the Redisson protobuf encode `ByteArray` wrap with direct `ByteBuf`
+   writing.
+3. Add round-trip and direct buffer-size regression tests.
+4. Run targeted tests, benchmark compile, a short benchmark sample, and diff
+   hygiene.
+5. Post benchmark evidence on #649 before closing.

--- a/docs/superpowers/specs/2026-05-29-issue-649-protobuf-codec-allocation-design.md
+++ b/docs/superpowers/specs/2026-05-29-issue-649-protobuf-codec-allocation-design.md
@@ -1,0 +1,47 @@
+# Issue 649 Protobuf Codec Allocation Design
+
+## Context
+
+`RedissonProtobufCodec` encoded protobuf messages with
+`Any.pack(message).toByteArray()` and then wrapped the byte array into a Netty
+`ByteBuf`. That allocates an intermediate array even though Redisson's encoder
+contract can return a `ByteBuf` directly.
+
+`ProtobufSerializer` still returns `ByteArray` by `BinarySerializer` contract,
+so this change keeps that path unchanged and benchmarked as a comparison point.
+
+## Decision
+
+Encode protobuf messages in `RedissonProtobufCodec` by pre-sizing a Netty buffer
+from `Any.serializedSize` and writing the packed message through
+`CodedOutputStream` over the buffer's `ByteBuffer` view.
+
+## Security
+
+The decode allowlist and class loading behavior are unchanged. This change only
+updates the protobuf encode path and keeps fallback codec delegation intact.
+
+## Measurement
+
+Add `ProtobufCodecBenchmark` under `benchmark/protobuf-codec-benchmark` for:
+
+- Redisson protobuf encode.
+- Redisson protobuf encode baseline using the old `toByteArray()` plus
+  `wrappedBuffer()` path.
+- Redisson protobuf decode.
+- `ProtobufSerializer` protobuf encode.
+- `ProtobufSerializer` fallback encode.
+
+Local sample on 2026-05-29, macOS, Java 21, 2 warmup / 3 measurement
+iterations:
+
+| Benchmark | Score |
+|---|---:|
+| `redissonProtobufEncode` | 3,936,257 ops/s |
+| `redissonProtobufEncodeByteArrayWrappedBaseline` | 4,056,681 ops/s |
+| `redissonProtobufDecode` | 3,294,397 ops/s |
+| `protobufSerializerEncode` | 4,083,259 ops/s |
+| `protobufSerializerFallbackEncode` | 1,472,371 ops/s |
+
+The direct buffer path keeps throughput within the short-run error interval of
+the baseline while removing the explicit `toByteArray()` encode handoff.

--- a/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodec.kt
+++ b/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodec.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.protobuf.serializers.redis
 
+import com.google.protobuf.CodedOutputStream
 import com.google.protobuf.Message
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
@@ -21,7 +22,7 @@ typealias AnyMessage = com.google.protobuf.Any
  * Redisson codec for Protobuf messages.
  *
  * ## Contract
- * - [com.google.protobuf.Message] values are encoded with `Any.pack(message).toByteArray()`.
+ * - [com.google.protobuf.Message] values are encoded directly into a Netty [ByteBuf].
  * - During decoding, the class name from `Any.typeUrl` is validated against [allowedClassPrefixes]
  *   before class loading.
  * - Non-Protobuf payloads are delegated to [fallbackCodec].
@@ -85,8 +86,7 @@ class RedissonProtobufCodec private constructor(
     private val encoder: Encoder =
         Encoder { graph ->
             if (graph is Message) {
-                val bytes = AnyMessage.pack(graph).toByteArray()
-                Unpooled.wrappedBuffer(bytes)
+                encodeProtobufMessage(graph)
             } else {
                 log.debug {
                     "Encoding: Protobuf Message가 아닙니다. fallbackCodec[$fallbackCodec] 사용. graph class=${graph.javaClass}"
@@ -122,6 +122,22 @@ class RedissonProtobufCodec private constructor(
     override fun getValueEncoder(): Encoder = encoder
 
     override fun getValueDecoder(): Decoder<Any> = decoder
+
+    internal fun encodeProtobufMessage(message: Message): ByteBuf {
+        val any = AnyMessage.pack(message)
+        val buffer = Unpooled.buffer(any.serializedSize)
+        return try {
+            val nioBuffer = buffer.nioBuffer(0, any.serializedSize)
+            val output = CodedOutputStream.newInstance(nioBuffer)
+            any.writeTo(output)
+            output.flush()
+            buffer.writerIndex(nioBuffer.position())
+            buffer
+        } catch (e: Throwable) {
+            buffer.release()
+            throw e
+        }
+    }
 
     private fun validateClassName(className: String) {
         if (className.isBlank()) {

--- a/io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodecTest.kt
+++ b/io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodecTest.kt
@@ -122,6 +122,19 @@ class RedissonProtobufCodecTest: AbstractRedissonTest() {
     }
 
     @Test
+    fun `protobuf encoder writes packed message directly to byte buffer`() {
+        val codec = RedissonProtobufCodec()
+        val origin = newSimpleMessage()
+
+        val buf = codec.encodeProtobufMessage(origin)
+        try {
+            buf.readableBytes() shouldBeEqualTo AnyMessage.pack(origin).serializedSize
+        } finally {
+            buf.release()
+        }
+    }
+
+    @Test
     fun `default codec rejects untrusted protobuf typeUrl before class loading`() {
         val bytes = AnyMessage.newBuilder()
             .setTypeUrl("type.googleapis.com/untrusted.payload.UntrustedPayload")


### PR DESCRIPTION
## Summary

Closes #649

- PR 제목: perf: reduce Redisson protobuf encode allocation

- encode Redisson protobuf messages directly into a pre-sized Netty `ByteBuf`
- keep the old `Any.pack(message).toByteArray()` + `wrappedBuffer()` path as a benchmark baseline
- add a dedicated `:protobuf-codec-benchmark` module plus issue spec, plan, and lesson notes

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Benchmark

Short local sample on 2026-05-29, macOS, Java 21, 2 warmup / 3 measurement iterations:

| Benchmark | Score |
|---|---:|
| `redissonProtobufEncode` | 3,936,257 ops/s |
| `redissonProtobufEncodeByteArrayWrappedBaseline` | 4,056,681 ops/s |
| `redissonProtobufDecode` | 3,294,397 ops/s |
| `protobufSerializerEncode` | 4,083,259 ops/s |
| `protobufSerializerFallbackEncode` | 1,472,371 ops/s |

The direct buffer path is throughput-neutral in this short sample and removes the explicit intermediate `toByteArray()` handoff in the Redisson encode path.

### 기존 섹션: Verification

- `./gradlew projects --no-configuration-cache --quiet | rg 'protobuf-codec-benchmark|web-framework-benchmark|bluetape4k-protobuf'`
- `./gradlew :bluetape4k-protobuf:compileKotlin :bluetape4k-protobuf:compileTestKotlin :protobuf-codec-benchmark:compileBenchmarkKotlin --no-configuration-cache`
- `./gradlew :bluetape4k-protobuf:test --tests 'io.bluetape4k.protobuf.serializers.redis.RedissonProtobufCodecTest' --tests 'io.bluetape4k.protobuf.serializers.ProtobufSerializerSecurityTest' --tests 'io.bluetape4k.protobuf.serializers.ProtobufSerializerTest' --no-configuration-cache`
- `./gradlew :protobuf-codec-benchmark:compileBenchmarkKotlin :protobuf-codec-benchmark:benchmarkBenchmark --no-configuration-cache --quiet`
- `git diff --check`

Closes #649

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #649, milestone `1.10.0`, assignee `debop`
- PR: #680, head `8f2675a7f940f3f66dfd97dbce3ca08515bb46f7`, milestone `1.10.0`, assignee `debop`
- Base: `develop`, head branch `perf/649-protobuf-codec-allocation`
- Labels: `performance`
- State: `MERGED`, merge commit `525e7b84ac4a6d9106bb020dfbaa429e71ea24e2`
- CI: The direct buffer path is throughput-neutral in this short sample and removes the explicit intermediate `toByteArray()` handoff in the Redisson encode path. / - `./gradlew projects --no-configuration-cache --quiet | rg 'protobuf-codec-benchmark|web-framework-benchmark|bluetape4k-protobuf'` / - `./gradlew :bluetape4k-protobuf:compileKotlin :bluetape4k-protobuf:compileTestKotlin :protobuf-codec-benchmark:compileBenchmarkKotlin --no-configuration-cache`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #680 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `525e7b84ac4a6d9106bb020dfbaa429e71ea24e2`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
