### PR TITLE
docs: clarify retired Spring Boot 3 references

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -64,7 +64,7 @@ Kotlin 언어를 배우고, 사용하면서, Backend 개발에 자주 사용하�
 
 - **Java**: 21 (JVM Toolchain)
 - **Kotlin**: 2.3 (Language & API Version)
-- **Spring Boot**: 4.x
+- **Spring Boot**: 4.x 전용. 과거 계획서와 리뷰 문서에는 은퇴한 Spring Boot 3 모듈 언급이 남아 있을 수 있지만, 현재 사용자 대상 모듈과 예제는 Spring Boot 4.x를 기준으로 합니다.
 - **JetBrains Exposed**: 1.2.x (외부 `bluetape4k-exposed` artifact는 독립 레포에서 별도 릴리즈됨)
 - **데이터베이스**: H2, PostgreSQL, MySQL
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Feel free to open an Issue if you need something that isn't here yet.
 
 - **Java**: 21 (JVM Toolchain)
 - **Kotlin**: 2.3 (Language & API Version)
-- **Spring Boot**: 4.x
+- **Spring Boot**: 4.x only. Historical planning and review notes may mention retired Spring Boot 3 modules, but current-facing modules and examples target Spring Boot 4.x.
 - **JetBrains Exposed**: 1.2.x (external `bluetape4k-exposed` artifacts are released from the standalone repository)
 - **Databases**: H2, PostgreSQL, MySQL
 

--- a/data/hibernate/README.ko.md
+++ b/data/hibernate/README.ko.md
@@ -44,7 +44,7 @@ dependencies {
 }
 ```
 
-> **Spring Boot 3 통합 주의사항**: Hibernate 7.x와 Spring Boot 3.x를 함께 사용하는 통합 테스트는 현재 비활성화되어 있습니다. Spring Boot 3의 `SpringBeanContainer`가 Hibernate 5 API를 구현하고 있어 호환성 문제가 발생합니다. Hibernate 7.x 완전 호환을 위해 Spring Boot 4 / Spring Framework 7을 사용하세요. 자세한 내용은 테스트 스위트의 `DisabledWithHibernate7AndSpringBoot3`를 참고하세요.
+> **은퇴한 Spring Boot 3 통합 참고**: Hibernate 7.x와 Spring Boot 3.x를 함께 사용하던 과거 통합 테스트는 Spring Boot 3의 `SpringBeanContainer`가 Hibernate 5 API를 구현하기 때문에 계속 비활성화되어 있습니다. 현재 bluetape4k Spring 모듈은 Hibernate 7.x 호환을 위해 Spring Boot 4 / Spring Framework 7을 기준으로 합니다. 자세한 내용은 테스트 스위트의 `DisabledWithHibernate7AndSpringBoot3` 보존 guard를 참고하세요.
 
 ## Spring Boot 4 마이그레이션
 

--- a/data/hibernate/README.md
+++ b/data/hibernate/README.md
@@ -44,7 +44,7 @@ dependencies {
 }
 ```
 
-> **Note on Spring Boot 3 Integration**: Tests combining Hibernate 7.x with Spring Boot 3.x are currently disabled due to incompatibility in Spring Boot 3's `SpringBeanContainer` (which implements the Hibernate 5 API). Use Spring Boot 4 / Spring Framework 7 for full Hibernate 7.x compatibility. See `DisabledWithHibernate7AndSpringBoot3` in the test suite for details.
+> **Retired Spring Boot 3 integration note**: Historical tests combining Hibernate 7.x with Spring Boot 3.x remain disabled because Spring Boot 3's `SpringBeanContainer` implements the Hibernate 5 API. Current bluetape4k Spring modules target Spring Boot 4 / Spring Framework 7 for Hibernate 7.x compatibility. See `DisabledWithHibernate7AndSpringBoot3` in the test suite for the archived guard.
 
 ## Spring Boot 4 Migration
 

--- a/docs/lessons/2026-05-29-issue-660-spring-boot3-doc-retirement.md
+++ b/docs/lessons/2026-05-29-issue-660-spring-boot3-doc-retirement.md
@@ -1,0 +1,33 @@
+# Issue 660: Spring Boot 3 Documentation Retirement
+
+## Context
+
+The repository now presents Spring Boot 4.x as the only current support line.
+Searches still surfaced Spring Boot 3 references in historical plans, specs,
+security reviews, and changelog entries.
+
+## Decision
+
+Keep historical evidence intact, but make the active support boundary explicit
+in current-facing README files and archive entrypoints.
+
+## Outcome
+
+- Root `README.md` and `README.ko.md` now state Spring Boot 4.x only.
+- `docs/superpowers/README.md` marks specs, plans, and research notes as
+  historical internal artifacts.
+- `docs/security-review/README.md` marks security review files as point-in-time
+  evidence.
+
+## Verification
+
+- Confirmed root README files already used Spring Boot 4.x and added the
+  retired-line clarification in both languages.
+- Confirmed repo-local `AGENTS.md` already states Spring Boot 4.x modules and
+  no active `spring-boot3/*` line.
+
+## Future Guidance
+
+Do not rewrite historical Spring Boot 3 references unless the file is being
+republished as current-facing documentation. Prefer a local archive note or
+directory-level context over broad regex replacement.

--- a/docs/security-review/README.md
+++ b/docs/security-review/README.md
@@ -1,0 +1,9 @@
+# Security Review Archive
+
+These reports preserve point-in-time findings. Older reports can refer to
+retired paths such as `spring-boot3/*` because those paths existed when the
+review was written.
+
+Current-facing Spring module documentation is Spring Boot 4.x only. Treat Spring
+Boot 3 references in this directory as historical review evidence unless a newer
+issue, PR, or README explicitly reopens that support line.

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -1,0 +1,13 @@
+# Superpowers Archive
+
+This directory stores internal specs, plans, and research notes from past work.
+Files are preserved as decision history, so older documents can mention retired
+module lines such as `spring-boot3/*` or Spring Boot 3.x compatibility work.
+
+Current-facing project documentation is the repository root `README.md`,
+`README.ko.md`, module READMEs, and repo-local `AGENTS.md`. For Spring modules,
+those current-facing documents define the active support line as Spring Boot
+4.x only.
+
+When updating historical files, do not rewrite old evidence casually. Add local
+archive context only when a note is likely to be mistaken for current support.

--- a/spring-boot/hibernate-lettuce/README.ko.md
+++ b/spring-boot/hibernate-lettuce/README.ko.md
@@ -16,13 +16,14 @@ Hibernate 7 **2nd Level Cache** (Lettuce Near Cache)를 위한 **Spring Boot 4 A
 
 ![Auto-Configuration diagram](../../docs/images/readme-diagrams/spring-boot-hibernate-lettuce-diagram-02.png)
 
-## Spring Boot 4 고유 사항
+## Spring Boot 4 참고 사항
 
 Spring Boot 4에서는 패키지명이 변경되었습니다:
 
-| Spring Boot 3                                                                  | Spring Boot 4                                                                    |
-|--------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-| `org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer` | `org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer` |
+`HibernatePropertiesCustomizer`는 이제
+`org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer`
+패키지에서 제공합니다. 이전 Spring Boot 3 패키지 경로는 Spring Boot 3 모듈
+라인과 함께 은퇴했으며, 과거 문서에만 보존합니다.
 
 또한 Spring Boot 4 BOM을 명시적으로 사용해야 합니다:
 
@@ -306,17 +307,15 @@ bluetape4k:
 
 ## 관련 모듈
 
-- [`bluetape4k-cache-lettuce`](../../infra/cache-lettuce/README.ko.md) — Near Cache 코어 구현
-- [`bluetape4k-hibernate-cache-lettuce`](../../data/hibernate-cache-lettuce/README.ko.md) — Hibernate Region Factory
+- [`bluetape4k-cache-lettuce`](../../cache/cache-lettuce/README.ko.md) — Near Cache 코어 구현
+- [`bluetape4k-hibernate-cache-lettuce`](../../cache/hibernate-cache-lettuce/README.ko.md) — Hibernate Region Factory
 - [`bluetape4k-spring-boot-hibernate-lettuce-demo`](../hibernate-lettuce-demo/README.ko.md) — 실제 사용 예제
 
-## Spring Boot 3과의 차이점
+## 마이그레이션 참고
 
-| 항목                                  | Spring Boot 3                                    | Spring Boot 4                                              |
-|-------------------------------------|--------------------------------------------------|------------------------------------------------------------|
-| `HibernatePropertiesCustomizer` 패키지 | `org.springframework.boot.autoconfigure.orm.jpa` | `org.springframework.boot.hibernate.autoconfigure`         |
-| BOM 설정                              | `dependencyManagement { imports }`               | `implementation(platform(libs.spring.boot.dependencies))` |
-| Hibernate 명시적 추가                    | 불필요                                              | `compileOnly(Libs.springBoot("hibernate"))`                |
+이 모듈은 Spring Boot 4.x 전용입니다.
+`implementation(platform(libs.spring.boot.dependencies))`를 사용하고
+Hibernate는 `compileOnly(Libs.springBoot("hibernate"))`로 명시적으로 선언하세요.
 
 ## 패키지 정보
 

--- a/spring-boot/hibernate-lettuce/README.md
+++ b/spring-boot/hibernate-lettuce/README.md
@@ -16,13 +16,14 @@ Simply add `bluetape4k.cache.lettuce-near.*` settings to your
 
 ![Auto-Configuration Activation Flow diagram](../../docs/images/readme-diagrams/spring-boot-hibernate-lettuce-diagram-02.png)
 
-## Spring Boot 4-Specific Notes
+## Spring Boot 4 Notes
 
 Package names have changed in Spring Boot 4:
 
-| Spring Boot 3                                                                  | Spring Boot 4                                                                    |
-|--------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-| `org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer` | `org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer` |
+`HibernatePropertiesCustomizer` now comes from
+`org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer`.
+The old Spring Boot 3 package path is retired with the Spring Boot 3 module
+line and is kept only in historical docs.
 
 The Spring Boot 4 BOM must also be applied explicitly:
 
@@ -306,17 +307,15 @@ Integration tests automatically manage Redis + H2 via Testcontainers.
 
 ## Related Modules
 
-- [`bluetape4k-cache-lettuce`](../../infra/cache-lettuce/README.md) — Near Cache core implementation
-- [`bluetape4k-hibernate-cache-lettuce`](../../infra/hibernate-cache-lettuce/README.md) — Hibernate Region Factory
+- [`bluetape4k-cache-lettuce`](../../cache/cache-lettuce/README.md) — Near Cache core implementation
+- [`bluetape4k-hibernate-cache-lettuce`](../../cache/hibernate-cache-lettuce/README.md) — Hibernate Region Factory
 - [`bluetape4k-spring-boot-hibernate-lettuce-demo`](../hibernate-lettuce-demo/README.md) — Usage example
 
-## Differences from Spring Boot 3
+## Migration Note
 
-| Aspect                                  | Spring Boot 3                                    | Spring Boot 4                                              |
-|-----------------------------------------|--------------------------------------------------|------------------------------------------------------------|
-| `HibernatePropertiesCustomizer` package | `org.springframework.boot.autoconfigure.orm.jpa` | `org.springframework.boot.hibernate.autoconfigure`         |
-| BOM configuration                       | `dependencyManagement { imports }`               | `implementation(platform(libs.spring.boot.dependencies))` |
-| Explicit Hibernate dependency           | Not required                                     | `compileOnly(Libs.springBoot("hibernate"))`                |
+This module is Spring Boot 4.x only. Use
+`implementation(platform(libs.spring.boot.dependencies))` and declare Hibernate
+explicitly with `compileOnly(Libs.springBoot("hibernate"))`.
 
 ## Package Information
 


### PR DESCRIPTION
## Summary

Closes #660

- PR 제목: docs: clarify retired Spring Boot 3 references

- Clarifies the active Spring support line as Spring Boot 4.x only in root README files.
- Rewrites current-facing Hibernate/Spring module README wording so Spring Boot 3 is presented only as retired/historical context.
- Adds archive entrypoints for `docs/superpowers` and `docs/security-review` so old Spring Boot 3 references are preserved as historical evidence, not active support.
- Fixes stale related-module links in the Spring Boot Hibernate Lettuce README pair while touching that section.

Closes #660

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- `git diff --check`
- Targeted changed README link existence checks for root assets, Hibernate Lettuce diagrams, demo README pairs, and related cache module README pairs.
- Current-facing README scan confirmed remaining Spring Boot 3 mentions are retired, historical, or legacy-constraint notes.

Not run: documentation site render; these are Markdown-only edits and no site build is configured for this repo path.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #660, milestone `1.10.0`, assignee `debop`
- PR: #682, head `9cb63a7b51cb2d8be580717380305b9b492b18bc`, milestone `1.10.0`, assignee `debop`
- Base: `develop`, head branch `docs/660-retire-spring-boot3-docs`
- Labels: `documentation`
- State: `MERGED`, merge commit `802629a3e5fc94b0c6046b682b73ec6777281913`
- CI: - Rewrites current-facing Hibernate/Spring module README wording so Spring Boot 3 is presented only as retired/historical context. / - Current-facing README scan confirmed remaining Spring Boot 3 mentions are retired, historical, or legacy-constraint notes.

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #682 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `802629a3e5fc94b0c6046b682b73ec6777281913`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
