### PR TITLE
docs: add module documentation drift checklist

### DIFF
--- a/.codex/references/module-groups.md
+++ b/.codex/references/module-groups.md
@@ -3,6 +3,8 @@
 Imported from `.claude/references/module-groups.md` for Codex use.
 
 `settings.gradle.kts` auto-registers subdirectories as `bluetape4k-{dirname}`.
+For module additions, moves, removals, or repository splits, follow
+[`docs/process/module-documentation-checklist.md`](../../docs/process/module-documentation-checklist.md).
 
 | Group            | Key Modules                                                                                                                     |
 |------------------|---------------------------------------------------------------------------------------------------------------------------------|
@@ -12,13 +14,15 @@ Imported from `.claude/references/module-groups.md` for Codex use.
 | `aws-kotlin/`    | Kotlin SDK, native suspend                                                                                                      |
 | `data/`          | `exposed-*` (core/dao/jdbc/r2dbc/cache/db-specific), `hibernate`, `mongodb`, `jdbc`, `r2dbc`, `cassandra`                       |
 | `infra/`         | `lettuce`, `redisson`, `kafka`, `pulsar`, `resilience4j`, `bucket4j`, `micrometer`, `opentelemetry`, `cache-*`, `elasticsearch` |
-| `spring-boot3/`  | WebFlux+Coroutines, Exposed JDBC/R2DBC repos, Hibernate Lettuce cache, Spring Batch                                             |
-| `spring-boot4/`  | Same as boot3 - use `implementation(platform(Libs.spring_boot4_dependencies))` (not `dependencyManagement`)                     |
+| `spring-boot/`   | Spring Boot 4.x modules and demos; use `implementation(platform(libs.spring.boot.dependencies))`                                |
 | `texts/`         | `tokenizer-core`, `tokenizer-korean`, `tokenizer-japanese`, `lingua`, `text-search`                                             |
 | `images/`        | `images` (scrimage), `images-vips-api`, `images-vips-java21` (JVips/JNI), `images-vips-java25` (vips-ffm/FFM)                   |
 | `utils/`         | `geo`, `idgenerators`, `javatimes`, `jwt`, `batch`, `states`, `workflow`, `measured`, `money`                                   |
 | `testing/`       | `junit5`, `testcontainers`, `mock-web-server` (SB3 MVC), `mock-webflux-server` (SB4 WebFlux, port 9999)                         |
 | `virtualthread/` | `api`, `jdk21`, `jdk25` - **always update both jdk21 AND jdk25 together**                                                       |
+
+Historical docs may still mention retired `spring-boot3/*` and `spring-boot4/*`
+paths. Current-facing modules use the `spring-boot/` group.
 
 ## Exposed Sub-modules
 

--- a/docs/lessons/2026-05-29-issue-662-module-documentation-checklist.md
+++ b/docs/lessons/2026-05-29-issue-662-module-documentation-checklist.md
@@ -1,0 +1,32 @@
+# Issue 662: Module Documentation Drift Checklist
+
+## Context
+
+Module lifecycle changes can drift across Gradle registration, README locale
+pairs, CI filters, Nightly/examples workflows, BOM/catalog publication, and
+agent references.
+
+## Decision
+
+Create a contributor-facing checklist under `docs/process/` and link it from the
+module group reference. Keep detailed process guidance out of transient agent
+instructions only.
+
+## Outcome
+
+- Added `docs/process/module-documentation-checklist.md`.
+- Linked the checklist from `.codex/references/module-groups.md`.
+- Updated the module group reference to the current Spring Boot 4.x-only
+  `spring-boot/` group and marked old Spring Boot paths as historical.
+
+## Verification
+
+- Checked Markdown whitespace with `git diff --check`.
+- Verified the checklist link target exists.
+- Verified current Spring Boot group wording no longer lists active
+  `spring-boot3/*` or `spring-boot4/*` groups.
+
+## Future Guidance
+
+Every module add, rename, move, removal, split, or repository promotion should
+include checklist evidence in the PR body.

--- a/docs/process/module-documentation-checklist.md
+++ b/docs/process/module-documentation-checklist.md
@@ -1,0 +1,100 @@
+# Module Documentation Drift Checklist
+
+Use this checklist whenever a module is added, renamed, moved, removed, split,
+or promoted to a different repository. The goal is to keep Gradle registration,
+README catalogs, CI coverage, examples, and release metadata synchronized in the
+same change.
+
+## When To Use It
+
+- New module or demo directory.
+- Module rename or path move.
+- Module removal or external repository split.
+- Module family change, such as adding a backend-specific variant.
+- Public README, BOM, or CI behavior changes caused by module registration.
+
+## Required Updates
+
+### Gradle Registration
+
+- Update `settings.gradle.kts` or the relevant include helper when automatic
+  registration does not cover the module.
+- Confirm the Gradle path and published artifact name match the directory.
+- Check BOM/catalog aggregation if the module should be published.
+
+### README Locale Set
+
+- Add or update the module `README.md`.
+- Add or update the matching `README.ko.md` when the module has a Korean README
+  pair, or create both files for new bluetape4k modules.
+- Keep the language switch directly below the title in both files.
+- Keep architecture, features, usage, configuration, dependency, and benchmark
+  sections synchronized when both locales exist.
+- Update root `README.md` and `README.ko.md` module catalogs and diagrams when
+  the module affects the public catalog.
+
+### Repo And Agent References
+
+- Update repo-local `AGENTS.md` if the module group list or workflow rule
+  changes.
+- Update `.codex/references/module-groups.md` when the module group map changes.
+- Add or update `docs/lessons/YYYY-MM-DD-{slug}.md` with context, decision,
+  outcome, verification, and future guidance.
+
+### CI, Nightly, And Examples
+
+- Update `.github/workflows/ci.yml` path filters, changed-module mapping, or test
+  jobs when the module must run in PR CI.
+- Update Nightly or examples workflows when Testcontainers, external services,
+  or long-running examples are involved.
+- Update summary jobs and `needs` lists when new jobs are added.
+- Keep container-backed verification in one sequential lane when required.
+
+### Release And Dependency Metadata
+
+- Check `bluetape4k-bom` or publication aggregation for publishable modules.
+- Check dependency catalog aliases if the module introduces or moves centrally
+  governed dependencies.
+- Update release notes, changelog, or migration notes only when the module
+  change is user-visible.
+
+## Validation Commands
+
+Run the smallest set that proves the checklist for the change:
+
+```bash
+./gradlew projects --no-configuration-cache
+git diff --check
+rg -n "<old-module-name>|<old-artifact-name>|<old-path>"
+rg -n "<new-module-name>|<new-artifact-name>" README.md README.ko.md .codex/references/module-groups.md AGENTS.md
+```
+
+For compile/test evidence, prefer affected module tasks:
+
+```bash
+./gradlew :<module>:compileKotlin :<module>:compileTestKotlin --no-configuration-cache
+./gradlew :<module>:test --no-configuration-cache
+```
+
+For README link/path checks, verify touched relative links directly:
+
+```bash
+test -f <path-from-link-target>
+test -d <module-directory>
+```
+
+## Expected Evidence In PRs
+
+- Gradle project path appears in `./gradlew projects`.
+- Root README locale pair lists or intentionally omits the module.
+- Module README locale pair exists and stays synchronized.
+- CI/Nightly/example workflow impact is listed, even when no change is needed.
+- BOM/catalog impact is listed, even when automatic aggregation covers it.
+- Stale old module names are absent or explicitly marked historical.
+
+## Common Skip Reasons
+
+- Documentation-only wording change with no module lifecycle impact.
+- Historical plan/spec files under `docs/superpowers` that intentionally record
+  old module paths.
+- Archived security review evidence under `docs/security-review`.


### PR DESCRIPTION
## Summary

Closes #662

- PR 제목: docs: add module documentation drift checklist

- Adds `docs/process/module-documentation-checklist.md` for module add/rename/move/remove/split workflows.
- Covers README locale pairs, root catalogs, Gradle registration, CI/Nightly/examples, BOM/catalog metadata, and PR evidence.
- Links the checklist from `.codex/references/module-groups.md`.
- Updates the module group reference to the current Spring Boot 4.x-only `spring-boot/` group and marks old Boot 3/4 paths as historical.

Closes #662

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- `git diff --check`
- Checklist link target exists.
- Module group reference no longer lists active `spring-boot3/` or `spring-boot4/` groups.

Not run: `./gradlew projects`; this is a Markdown-only process change and does not alter Gradle registration.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #662, milestone `1.10.0`, assignee `debop`
- PR: #684, head `661f5054ecbe9ed5607432595ea6f4ac14b052e7`, milestone `1.10.0`, assignee `debop`
- Base: `develop`, head branch `docs/662-module-doc-drift-checklist`
- Labels: `documentation`
- State: `MERGED`, merge commit `8426bb3a47a409799c599b886e3a05ed3ce0bfd8`
- CI: - Covers README locale pairs, root catalogs, Gradle registration, CI/Nightly/examples, BOM/catalog metadata, and PR evidence. / Not run: `./gradlew projects`; this is a Markdown-only process change and does not alter Gradle registration.

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #684 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `8426bb3a47a409799c599b886e3a05ed3ce0bfd8`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
