### PR TITLE
fix: validate zip extraction with canonical paths

### DIFF
--- a/docs/lessons/2026-05-30-zip-slip-canonical-path.md
+++ b/docs/lessons/2026-05-30-zip-slip-canonical-path.md
@@ -1,0 +1,29 @@
+# Zip Slip canonical path validation
+
+## Context
+
+GitHub CodeQL reported `java/zipslip` in `ZipFileSupport.unzip` at the file
+extraction sink.
+
+## Decision
+
+Resolve every ZIP entry through the destination directory's canonical file and
+reject targets whose canonical path escapes that directory before opening the
+output stream.
+
+## Outcome
+
+The extraction path check now guards the exact canonical file passed to
+`FileOutputStream`, including sibling paths that share a textual prefix with
+the destination directory name.
+
+## Verification
+
+- `./gradlew :bluetape4k-io:test --tests "io.bluetape4k.io.compressor.ZipFileSupportTest"`
+- `git diff --check`
+
+## Future guard
+
+For archive extraction code, validate canonical target paths at the same
+abstraction level as the file sink instead of relying only on normalized string
+or path comparisons.

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ZipFileSupport.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ZipFileSupport.kt
@@ -301,7 +301,7 @@ fun unzip(zipFile: File, destDir: File, vararg patterns: String) {
         var entryCount = 0
         var declaredUncompressedSize = 0L
         var extractedUncompressedSize = 0L
-        val destPath = destDir.toPath().toAbsolutePath().normalize()
+        val canonicalDestDir = destDir.canonicalFile
 
         while (entries.hasMoreElements()) {
             val entry = entries.nextElement()
@@ -328,11 +328,7 @@ fun unzip(zipFile: File, destDir: File, vararg patterns: String) {
                 if (!matched) continue
             }
 
-            val targetPath = destPath.resolve(entryName).normalize()
-            require(targetPath.startsWith(destPath)) {
-                "Zip entry is outside of the target dir: $entryName"
-            }
-            val file = targetPath.toFile()
+            val file = resolveZipTarget(canonicalDestDir, entryName)
 
             if (entry.isDirectory) {
                 if (!file.mkdirs() && !file.isDirectory) {
@@ -359,6 +355,14 @@ fun unzip(zipFile: File, destDir: File, vararg patterns: String) {
         runCatching { zip.close() }
             .onFailure { log.warn(it) { "ZipFile 닫기 실패" } }
     }
+}
+
+private fun resolveZipTarget(canonicalDestDir: File, entryName: String): File {
+    val targetFile = File(canonicalDestDir, entryName).canonicalFile
+    require(targetFile.toPath().startsWith(canonicalDestDir.toPath())) {
+        "Zip entry is outside of the target dir: $entryName"
+    }
+    return targetFile
 }
 
 private fun InputStream.copyToLimited(output: OutputStream, remainingLimit: Long): Long {

--- a/io/io/src/test/kotlin/io/bluetape4k/io/compressor/ZipFileSupportTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/compressor/ZipFileSupportTest.kt
@@ -151,6 +151,25 @@ class ZipFileSupportTest {
     }
 
     @Test
+    fun `Zip Slip 방어는 대상 디렉토리와 같은 접두어의 형제 경로를 거부한다`() {
+        val zipBytes = ZipBuilder.ofInMemory()
+            .add("sibling content").path("../safe-output-sibling/evil.txt").save()
+            .toBytes()
+
+        val zipFile = File(tempDir, "sibling.zip")
+        zipFile.writeBytes(zipBytes)
+
+        val destDir = File(tempDir, "safe-output")
+        destDir.mkdirs()
+
+        assertFailsWith<IllegalArgumentException> {
+            unzip(zipFile, destDir)
+        }
+
+        File(tempDir, "safe-output-sibling/evil.txt").exists() shouldBeEqualTo false
+    }
+
+    @Test
     fun `ZipFile closeSafe 는 null 에 대해 안전하다`() {
         val nullZip: java.util.zip.ZipFile? = null
         nullZip?.closeSafe() // 예외 없이 실행


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: validate zip extraction with canonical paths

- Resolve ZIP entries against the destination canonical directory before opening extraction outputs.
- Reject canonical targets that escape the destination directory.
- Add a sibling-prefix Zip Slip regression test.
- Add a short lesson for archive extraction path validation.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Code scanning

Addresses open CodeQL `java/zipslip` alert #46 in `ZipFileSupport.kt`.

### 기존 섹션: Verification

- `./gradlew :bluetape4k-io:test --tests "io.bluetape4k.io.compressor.ZipFileSupportTest" --no-daemon --no-build-cache`
- `git diff --check`

### 기존 섹션: Risk

Low. The change preserves normal extraction behavior and tightens only escaped canonical targets. CodeQL alert closure requires the next code scanning analysis after push or merge.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #686, head `76d250887d1464a154669066bc57d7477624a36c`, milestone `1.10.0`, assignee `debop`
- Base: `develop`, head branch `fix/projects-zip-slip`
- Labels: `bug`, `security`
- State: `MERGED`, merge commit `e8869691c1fa623e1f8e4c233cd52123d793140e`
- CI: - `./gradlew :bluetape4k-io:test --tests "io.bluetape4k.io.compressor.ZipFileSupportTest" --no-daemon --no-build-cache`

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #686 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e8869691c1fa623e1f8e4c233cd52123d793140e`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
