### PR TITLE
docs: prepare projects 1.10.0 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,60 @@
 
 ---
 
+## [1.10.0] — 2026-06-01
+
+### Added
+
+- Added the `bluetape4k-ktor-core`, `bluetape4k-ktor-observability`, and
+  `bluetape4k-ktor-testing` module family, including route helpers,
+  observability integration, testing support, and idgenerator example adoption
+  ([#647](https://github.com/bluetape4k/bluetape4k-projects/pull/647),
+  [#663](https://github.com/bluetape4k/bluetape4k-projects/pull/663),
+  [#664](https://github.com/bluetape4k/bluetape4k-projects/pull/664),
+  [#665](https://github.com/bluetape4k/bluetape4k-projects/pull/665),
+  [#666](https://github.com/bluetape4k/bluetape4k-projects/pull/666),
+  [#668](https://github.com/bluetape4k/bluetape4k-projects/pull/668)).
+- Added route-scoped Ktor Resilience4j helpers and OpenAPI route helpers for
+  the new Ktor integration surface
+  ([#678](https://github.com/bluetape4k/bluetape4k-projects/pull/678),
+  [#679](https://github.com/bluetape4k/bluetape4k-projects/pull/679)).
+
+### Changed
+
+- Kept Ktor client helper APIs in `io-http` after the module-boundary review
+  and benchmark-backed planning pass
+  ([#676](https://github.com/bluetape4k/bluetape4k-projects/pull/676),
+  [#677](https://github.com/bluetape4k/bluetape4k-projects/pull/677)).
+- Improved CSV UTF-8 scanning and writing paths with Okio segment/sink based
+  implementations
+  ([#673](https://github.com/bluetape4k/bluetape4k-projects/pull/673),
+  [#675](https://github.com/bluetape4k/bluetape4k-projects/pull/675)).
+- Reduced Redisson protobuf encoding allocation and clarified R2DBC pool
+  contention guidance
+  ([#680](https://github.com/bluetape4k/bluetape4k-projects/pull/680),
+  [#681](https://github.com/bluetape4k/bluetape4k-projects/pull/681)).
+- Updated release catalog selection, the shared dependencies catalog ref,
+  benchmark report guidance, module documentation drift checks, Spring Boot 3
+  retirement notes, and local work-note preservation for the 1.10.0 release
+  train
+  ([#639](https://github.com/bluetape4k/bluetape4k-projects/pull/639),
+  [#641](https://github.com/bluetape4k/bluetape4k-projects/pull/641),
+  [#682](https://github.com/bluetape4k/bluetape4k-projects/pull/682),
+  [#683](https://github.com/bluetape4k/bluetape4k-projects/pull/683),
+  [#684](https://github.com/bluetape4k/bluetape4k-projects/pull/684),
+  [#687](https://github.com/bluetape4k/bluetape4k-projects/pull/687)).
+
+### Fixed
+
+- Preserved coroutine cancellation and interruption contracts for gRPC shutdown,
+  Vert.x routes, and Lettuce suspended loaded-map close paths
+  ([#669](https://github.com/bluetape4k/bluetape4k-projects/pull/669),
+  [#670](https://github.com/bluetape4k/bluetape4k-projects/pull/670),
+  [#672](https://github.com/bluetape4k/bluetape4k-projects/pull/672)).
+- Hardened archive extraction against Zip Slip by validating canonical paths
+  before writing extracted entries
+  ([#686](https://github.com/bluetape4k/bluetape4k-projects/pull/686)).
+
 ## [1.9.2] — 2026-05-26
 
 ### Added

--- a/docs/lessons/2026-06-01-projects-1-10-0-release-prep.md
+++ b/docs/lessons/2026-06-01-projects-1-10-0-release-prep.md
@@ -1,0 +1,33 @@
+# projects 1.10.0 release prep
+
+## Context
+
+`bluetape4k-projects` needed the 1.10.0 stable release gate prepared after the
+remaining milestone issue was confirmed to be completed and unrelated to the
+repository release scope.
+
+## Decision
+
+Prepare release metadata only: set `baseVersion=1.10.0`, keep
+`snapshotVersion=` empty, and add a curated `CHANGELOG.md` section before
+creating the release-prep PR.
+
+## Outcome
+
+The release-prep branch records the 1.10.0 user-facing changes from the Ktor
+module family, performance work, cancellation fixes, release guards, and Zip
+Slip hardening.
+
+## Verification
+
+- Confirmed the worktree started from clean `origin/develop`.
+- Confirmed `release.yml` requires `version`, optional `diagnoseSigning`, and
+  optional `catalogRef`.
+- Confirmed `snapshotVersion=` remains empty for stable release dispatch.
+
+## Next time
+
+Do not dispatch the stable release until the release-prep PR has passed CI,
+Nightly/snapshot validation is current for the merged release state, and Maven
+Central verification is ready for the exact `1.10.0` BOM and representative
+module POMs.

--- a/gradle.properties
+++ b/gradle.properties
@@ -78,5 +78,5 @@ centralSnapshotsParallelism=8
 # project version
 #
 projectGroup=io.github.bluetape4k
-baseVersion=1.9.2
+baseVersion=1.10.0
 snapshotVersion=


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: docs: prepare projects 1.10.0 release metadata

- set `baseVersion=1.10.0` while keeping `snapshotVersion=` empty for stable release validation
- add a curated `CHANGELOG.md` section for the 1.10.0 release
- capture the release-prep lesson and current dispatch guardrails

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Release gate evidence

- milestone `1.10.0` has `open_issues=0` after closing completed out-of-scope issue #685
- `release.yml` declares `version`, optional `diagnoseSigning`, and optional `catalogRef` inputs
- latest stable artifact check before this PR: 1.9.2 BOM/core HTTP 200; 1.10.0 BOM HTTP 404 as expected before release

### 기존 섹션: Not done

- stable release workflow dispatch
- Maven Central 1.10.0 artifact verification

Release continuation after merge: rerun/confirm current CI, Nightly/full, snapshot validation for the merged release state, then dispatch `release.yml` for `version=1.10.0` only after gates pass.

## Validation

- `git diff --check`
- `./gradlew help --refresh-dependencies --no-daemon --no-configuration-cache --no-build-cache`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #688, head `12fd35b3281b5c5809d353bb6374e03d01f29dca`, milestone `1.10.0`, assignee `debop`
- Base: `develop`, head branch `release/prepare-projects-1.10.0`
- Labels: `documentation`, `release`
- State: `MERGED`, merge commit `c632480fd3385101ab5572c17c615eb442cfa2e3`
- CI: - `./gradlew help --refresh-dependencies --no-daemon --no-configuration-cache --no-build-cache` / Release continuation after merge: rerun/confirm current CI, Nightly/full, snapshot validation for the merged release state, then dispatch `release.yml` for `version=1.10.0` only after gates pass.

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #688 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `c632480fd3385101ab5572c17c615eb442cfa2e3`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
