### PR TITLE
build: prevent stale Nightly Gradle cache

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -301,6 +301,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: false
 
       - name: Build (compile only, excluding examples)
@@ -354,6 +355,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
 
       - name: Detekt static analysis
@@ -384,6 +386,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
 
       - name: Test bluetape4k core modules
@@ -446,6 +449,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
 
       - name: Test io modules
@@ -524,6 +528,7 @@ jobs:
           -   uses: gradle/actions/setup-gradle@v6
               with:
                   gradle-version: wrapper
+                  cache-disabled: true
                   cache-read-only: true
 
           -   name: Build mock-web-server Docker image
@@ -591,6 +596,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
 
       - name: Test Ktor modules
@@ -655,6 +661,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
 
       - name: Test utils modules
@@ -738,6 +745,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
 
       - name: Test misc modules (no Docker)
@@ -857,6 +865,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
 
       - name: Build mock-web-server Docker image
@@ -945,6 +954,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
 
       - name: Test data modules (${{ matrix.group }})
@@ -1030,6 +1040,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
 
       - name: Build mock-web-server Docker image
@@ -1102,6 +1113,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
 
       - name: Build mock-web-server Docker image

--- a/docs/lessons/2026-06-04-issue-707-nightly-gradle-cache.md
+++ b/docs/lessons/2026-06-04-issue-707-nightly-gradle-cache.md
@@ -1,0 +1,22 @@
+# 2026-06-04 Issue 707 Nightly Gradle Cache
+
+## Context
+
+Nightly builds across bluetape4k repositories intermittently resolved managed dependencies as `group:artifact:.` on GitHub runners.
+
+## Decision
+
+Disable `gradle/actions/setup-gradle` cache restore/write for Nightly jobs so scheduled runs do not reuse stale dependency-management state.
+
+## Outcome
+
+Every Nightly `setup-gradle` block now sets `cache-disabled: true` while keeping explicit Gradle dependency refresh.
+
+## Verification
+
+- Audited `.github/workflows/nightly-tests.yml`: setup-gradle blocks match cache-disabled blocks.
+- Planned validation: `actionlint`, `git diff --check`.
+
+## Future Rule
+
+When a Nightly workflow uses snapshot or BOM-managed bluetape4k dependencies, keep Gradle action cache disabled unless a fresh CI proof shows cache restore cannot replay stale metadata.


### PR DESCRIPTION
## Summary

Closes #707

- PR 제목: build: prevent stale Nightly Gradle cache

- Closes #707.
- Disable Gradle action caching for every Nightly setup-gradle step.
- Add a short lesson documenting the stale dependency metadata failure mode.

## Background

Recent bluetape4k Nightly runs resolved managed dependencies as group:artifact:. even with --refresh-dependencies. The common risk is stale Gradle action state being restored into scheduled snapshot/BOM builds.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Added cache-disabled: true to all gradle/actions/setup-gradle@v6 blocks in .github/workflows/nightly-tests.yml.
- Preserved existing --refresh-dependencies and --no-configuration-cache Gradle command behavior.
- Added docs/lessons/2026-06-04-issue-707-nightly-gradle-cache.md.

## Validation

- actionlint .github/workflows/nightly-tests.yml
- git diff --check
- Audited Nightly setup-gradle blocks: every block has cache-disabled: true.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #707, milestone `1.11.0`, assignee `debop`
- PR: #708, head `3b01bcdea31d1a7fc78bf2516ba6bb79b0f2d0f0`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-707-nightly-cache-disabled`
- Labels: `build`, `ci`, `github_actions`
- State: `MERGED`, merge commit `a21b690b5e27528ac7eb20402f546c576c8169e1`
- CI: - Disable Gradle action caching for every Nightly setup-gradle step. / Recent bluetape4k Nightly runs resolved managed dependencies as group:artifact:. even with --refresh-dependencies. The common risk is stale Gradle action state being restored into scheduled snapshot/BOM builds. / - Added cache-disabled: true to all gradle/actions/setup-gradle@v6 blocks in .github/workflows/nightly-tests.yml.

## DoD Status

- Nightly no longer restores or writes Gradle action cache state.
- The recurrence rule is documented for future workflow edits.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #708 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `a21b690b5e27528ac7eb20402f546c576c8169e1`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
