### PR TITLE
build: harden Nightly dependency refresh

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -317,7 +317,7 @@ jobs:
             -x :bluetape4k-examples-virtualthreads-demo:build
           )
 
-          projects="$(./gradlew -q projects)"
+          projects="$(./gradlew -q projects --no-configuration-cache)"
           if grep -q -- "--- Project ':idgenerator-ktor-demo'" <<< "$projects"; then
             excluded_tasks+=(-x :idgenerator-ktor-demo:build)
           fi
@@ -325,13 +325,13 @@ jobs:
             excluded_tasks+=(-x :idgenerator-spring-boot-demo:build)
           fi
 
-          ./gradlew build -x test "${excluded_tasks[@]}" --parallel
+          ./gradlew build -x test "${excluded_tasks[@]}" --parallel --no-configuration-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
       - name: Resolve mock server runtime dependencies (pre-cache for Jib)
         run: >
-          ./gradlew
+          ./gradlew --no-configuration-cache
           :bluetape4k-mock-web-server:dependencies
           :bluetape4k-mock-webflux-server:dependencies
           --configuration runtimeClasspath
@@ -359,7 +359,7 @@ jobs:
           cache-read-only: true
 
       - name: Detekt static analysis
-        run: ./gradlew detekt --parallel
+        run: ./gradlew detekt --parallel --no-configuration-cache
 
       - name: Upload detekt report
         if: always()
@@ -396,7 +396,7 @@ jobs:
           max_attempts: 3
           shell: bash
           command: |
-            ./gradlew \
+            ./gradlew --no-configuration-cache \
               :bluetape4k-annotations:test \
               :bluetape4k-core:test \
               :bluetape4k-coroutines:test \
@@ -408,7 +408,7 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: |
-          ./gradlew \
+          ./gradlew --no-configuration-cache \
             :bluetape4k-annotations:koverXmlReport \
             :bluetape4k-core:koverXmlReport \
             :bluetape4k-coroutines:koverXmlReport \
@@ -459,7 +459,7 @@ jobs:
           max_attempts: 3
           shell: bash
           command: |
-            ./gradlew \
+            ./gradlew --no-configuration-cache \
               :bluetape4k-io:test \
               :bluetape4k-okio:test \
               :bluetape4k-csv:test \
@@ -479,7 +479,7 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: |
-          ./gradlew \
+          ./gradlew --no-configuration-cache \
             :bluetape4k-io:koverXmlReport \
             :bluetape4k-okio:koverXmlReport \
             :bluetape4k-csv:koverXmlReport \
@@ -543,7 +543,7 @@ jobs:
                 max_attempts: 3
                 shell: bash
                 command: |
-                    ./gradlew \
+                    ./gradlew --no-configuration-cache \
                       :bluetape4k-feign:test \
                       :bluetape4k-http:test \
                       :bluetape4k-retrofit2:test \
@@ -555,7 +555,7 @@ jobs:
           -   name: Generate Kover XML report
               if: always()
               run: |
-                  ./gradlew \
+                  ./gradlew --no-configuration-cache \
                     :bluetape4k-feign:koverXmlReport \
                     :bluetape4k-http:koverXmlReport \
                     :bluetape4k-retrofit2:koverXmlReport \
@@ -606,7 +606,7 @@ jobs:
           max_attempts: 3
           shell: bash
           command: |
-            ./gradlew \
+            ./gradlew --no-configuration-cache \
               :bluetape4k-ktor-core:test \
               :bluetape4k-ktor-observability:test \
               :bluetape4k-ktor-openapi:test \
@@ -619,7 +619,7 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: |
-          ./gradlew \
+          ./gradlew --no-configuration-cache \
             :bluetape4k-ktor-core:koverXmlReport \
             :bluetape4k-ktor-observability:koverXmlReport \
             :bluetape4k-ktor-openapi:koverXmlReport \
@@ -671,7 +671,7 @@ jobs:
           max_attempts: 3
           shell: bash
           command: |
-            ./gradlew \
+            ./gradlew --no-configuration-cache \
               :bluetape4k-idgenerators:test \
               :bluetape4k-javatimes:test \
               :bluetape4k-math:test \
@@ -695,7 +695,7 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: |
-          ./gradlew \
+          ./gradlew --no-configuration-cache \
             :bluetape4k-idgenerators:koverXmlReport \
             :bluetape4k-javatimes:koverXmlReport \
             :bluetape4k-math:koverXmlReport \
@@ -755,7 +755,7 @@ jobs:
           max_attempts: 3
           shell: bash
           command: |
-            ./gradlew \
+            ./gradlew --no-configuration-cache \
               :bluetape4k-virtualthread-api:test \
               :bluetape4k-virtualthread-jdk21:test \
               :bluetape4k-virtualthread-jdk25:test \
@@ -771,7 +771,7 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: |
-          ./gradlew \
+          ./gradlew --no-configuration-cache \
             :bluetape4k-virtualthread-api:koverXmlReport \
             :bluetape4k-virtualthread-jdk21:koverXmlReport \
             :bluetape4k-virtualthread-jdk25:koverXmlReport \
@@ -882,7 +882,7 @@ jobs:
           shell: bash
           command: |
             read -ra tasks <<< "$TEST_TASKS"
-            ./gradlew "${tasks[@]}" --max-workers=1
+            ./gradlew "${tasks[@]}" --max-workers=1 --no-configuration-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           TEST_TASKS: ${{ matrix.test_tasks }}
@@ -893,7 +893,7 @@ jobs:
           KOVER_TASKS: ${{ matrix.kover_tasks }}
         run: |
           read -ra tasks <<< "$KOVER_TASKS"
-          ./gradlew "${tasks[@]}" --parallel
+          ./gradlew "${tasks[@]}" --parallel --no-configuration-cache
         continue-on-error: true
 
       - name: Upload test results
@@ -965,7 +965,7 @@ jobs:
           shell: bash
           command: |
             read -ra tasks <<< "$TEST_TASKS"
-            ./gradlew "${tasks[@]}" --max-workers=1
+            ./gradlew "${tasks[@]}" --max-workers=1 --no-configuration-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           TEST_TASKS: ${{ matrix.test_tasks }}
@@ -976,7 +976,7 @@ jobs:
           KOVER_TASKS: ${{ matrix.kover_tasks }}
         run: |
           read -ra tasks <<< "$KOVER_TASKS"
-          ./gradlew "${tasks[@]}" --parallel
+          ./gradlew "${tasks[@]}" --parallel --no-configuration-cache
         continue-on-error: true
 
       - name: Upload test results
@@ -1061,7 +1061,7 @@ jobs:
           shell: bash
           command: |
             read -ra tasks <<< "$TEST_TASKS"
-            ./gradlew "${tasks[@]}" --max-workers=1
+            ./gradlew "${tasks[@]}" --max-workers=1 --no-configuration-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           TEST_TASKS: ${{ matrix.test_tasks }}
@@ -1072,7 +1072,7 @@ jobs:
           KOVER_TASKS: ${{ matrix.kover_tasks }}
         run: |
           read -ra tasks <<< "$KOVER_TASKS"
-          ./gradlew "${tasks[@]}" --parallel
+          ./gradlew "${tasks[@]}" --parallel --no-configuration-cache
         continue-on-error: true
 
       - name: Upload test results
@@ -1151,7 +1151,7 @@ jobs:
               )
             fi
             timeout --kill-after=60s "${TEST_TIMEOUT_MINUTES}m" \
-              ./gradlew :bluetape4k-testcontainers:test "${tests_args[@]}"
+              ./gradlew :bluetape4k-testcontainers:test "${tests_args[@]}" --no-configuration-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           TEST_PATTERNS: ${{ matrix.test_patterns }}
@@ -1161,7 +1161,7 @@ jobs:
       - name: Generate Kover XML report
         if: ${{ always() && needs.plan.outputs.run_testcontainers_coverage == 'true' }}
         timeout-minutes: 10
-        run: ./gradlew :bluetape4k-testcontainers:koverXmlReport -x :bluetape4k-testcontainers:test
+        run: ./gradlew :bluetape4k-testcontainers:koverXmlReport -x :bluetape4k-testcontainers:test --no-configuration-cache
         continue-on-error: true
 
       - name: Upload test results

--- a/docs/lessons/2026-06-04-issue-709-nightly-config-cache-catalog.md
+++ b/docs/lessons/2026-06-04-issue-709-nightly-config-cache-catalog.md
@@ -1,0 +1,21 @@
+# 2026-06-04 Issue 709 Nightly Config Cache And Catalog
+
+## Context
+
+Nightly workflows use snapshot and BOM-managed dependencies, so stale Gradle/configuration state can surface versionless dependency coordinates.
+
+## Decision
+
+Keep Nightly Gradle commands on `--no-configuration-cache` and keep local bluetape4k aliases versioned through their BOM ref.
+
+## Outcome
+
+Nightly commands no longer rely on configuration cache during dependency refresh, and repo-local catalog aliases avoid `group:artifact:.` coordinates.
+
+## Verification
+
+- Planned: `actionlint`, `git diff --check`, command audit, catalog alias audit.
+
+## Future Rule
+
+For Nightly jobs that refresh snapshots, disable both Gradle action cache and configuration cache unless a repo-specific proof says otherwise.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1035,7 +1035,7 @@ junit-platform-suite-api = { module = "org.junit.platform:junit-platform-suite-a
 junit-platform-suite-engine = { module = "org.junit.platform:junit-platform-suite-engine", version.ref = "junit-platform" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit-jupiter" }
 
-bluetape4k-assertions = { module = "io.github.bluetape4k:bluetape4k-assertions" }
+bluetape4k-assertions = { module = "io.github.bluetape4k:bluetape4k-assertions", version.ref = "bluetape4k-bom" }
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj-core" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 springmockk = { module = "com.ninja-squad:springmockk", version.ref = "springmockk" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
+bluetape4k = "1.11.0-SNAPSHOT"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
 kotlin = "2.3.21"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
 kotlinx-coroutines = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-bom
 kotlinx-serialization = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-serialization-bom
@@ -1035,7 +1036,7 @@ junit-platform-suite-api = { module = "org.junit.platform:junit-platform-suite-a
 junit-platform-suite-engine = { module = "org.junit.platform:junit-platform-suite-engine", version.ref = "junit-platform" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit-jupiter" }
 
-bluetape4k-assertions = { module = "io.github.bluetape4k:bluetape4k-assertions", version.ref = "bluetape4k-bom" }
+bluetape4k-assertions = { module = "io.github.bluetape4k:bluetape4k-assertions", version.ref = "bluetape4k" }
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj-core" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 springmockk = { module = "com.ninja-squad:springmockk", version.ref = "springmockk" }


### PR DESCRIPTION
## Summary

Closes #709

- PR 제목: build: harden Nightly dependency refresh

Closes #709.

Harden the Nightly workflow so dependency refresh runs do not reuse stale Gradle setup state and local bluetape4k snapshot aliases always resolve with an explicit governed version key.

## Background

Recent Nightly runs exposed recurring failure modes: configuration-cache serialization or replay during refresh jobs, and local `io.github.bluetape4k:*` catalog aliases resolving with empty or invalid dependency versions in isolated CI jobs. Earlier cache-disabled PRs reduced one layer of stale setup state, but Gradle command lines and local catalog aliases still needed deterministic guards.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Added `--no-configuration-cache` to Nightly Gradle command lines that run dependency refresh, build, detekt, tests, or summaries.
- Added the missing bluetape4k version key and pointed local bluetape4k aliases at that repo-defined version key.
- Added a concise lesson documenting the Nightly hardening rule for future workflow maintenance.

## Validation

- actionlint, git diff --check, version-ref audit, and isolated ./gradlew help --no-configuration-cache --no-daemon passed.
- Nightly audit: `missing_alias=0`, `missing_no_config_cache=0`, `missing_version_refs=0`, and no malformed `--no-configuration-cache` command patterns.

## Review Notes

P0/P1 review gate is clean for this workflow-only change. The branch changes are limited to Nightly workflow hardening, local version catalog alias guards where needed, and the matching lesson note.

## Metadata

- Issue: #709, milestone `1.11.0`, assignee `debop`
- PR: #710, head `114b82dbf701ae7395c0f1e6cede85a69225ad88`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-709-nightly-config-cache-catalog`
- Labels: `build`, `ci`, `github_actions`
- State: `MERGED`, merge commit `56e80210127ccef0fef27254aab03d0332d3ba74`
- CI: Harden the Nightly workflow so dependency refresh runs do not reuse stale Gradle setup state and local bluetape4k snapshot aliases always resolve with an explicit governed version key. / Recent Nightly runs exposed recurring failure modes: configuration-cache serialization or replay during refresh jobs, and local `io.github.bluetape4k:*` catalog aliases resolving with empty or invalid dependency versions in isolated CI jobs. Earlier cache-disabled PRs reduced one layer of stale setup state, but Gradle command lines and local catalog aliases still needed deterministic guards. / - Added `--no-configuration-cache` to Nightly Gradle command lines that run dependency refresh, build, detekt, tests, or summaries.

## DoD Status

| Step | Status | Evidence |
|---|---|---|
| Issue | PASS | Closes #709, milestone `1.11.0`, assignee `debop` |
| Fix | PASS | Nightly Gradle commands and local catalog guards hardened on `fix/issue-709-nightly-config-cache-catalog` |
| Lessons | PASS | `docs/lessons/2026-06-04-issue-709-nightly-config-cache-catalog.md` |
| Local validation | PASS | actionlint, git diff --check, version-ref audit, and isolated ./gradlew help --no-configuration-cache --no-daemon passed.; Nightly audit passed before PR update |
| PR body | PASS | Created and updated with `--body-file`; live body verified after update |
| CI gate | PASS | GitHub checks completed SUCCESS or SKIPPED before merge |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #710 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `56e80210127ccef0fef27254aab03d0332d3ba74`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
