### PR TITLE
docs: refresh 1.11.0 WIP queue

### DIFF
--- a/WIP.md
+++ b/WIP.md
@@ -1,15 +1,20 @@
 # WIP - bluetape4k-projects
 
-Snapshot: 2026-06-02 KST
-Scope: post-1.10.0 release train version alignment.
-Open count: 12 issues.
+Snapshot: 2026-06-06 KST
+Scope: 1.11.0 observability and telemetry lane, plus backlog split.
+Open count: 13 issues.
 
 ## Refresh Notes
 
-The `1.10.0` stable line has been published and consumed by
-`bluetape4k-dependencies` `1.2.0`. Development now moves to the next minor
-line, `1.11.0`, with `snapshotVersion=` kept empty for workflow-injected
-snapshot publication.
+The `1.10.0` stable line has been published and consumed by downstream
+repositories. Development now moves to the `1.11.0` observability and
+event-telemetry lane.
+
+Live GitHub state:
+
+- `1.11.0`: 11 open issues.
+- `backlog`: 2 open issues.
+- Total open issue count: 13.
 
 ## Recently Completed
 
@@ -25,60 +30,69 @@ snapshot publication.
 ## Current Direction
 
 The repository is in the `1.11.0` development lane after the `1.10.0` stable
-release. Keep `snapshotVersion=` empty in `gradle.properties` and pass
-`-PsnapshotVersion=-SNAPSHOT` only for SNAPSHOT publishing.
-
-Work selection should use the next minor line for new feature work unless a
-specific patch milestone is opened for release fallout.
+release. Work selection should prioritize the observability Epic and its
+explicit dependency order, while keeping independent test/docs cleanup small and
+isolated.
 
 ## Priority Queue
 
 | Priority | Issue | Difficulty | Notes |
 |---|---|---:|---|
-| P1 | [#586](https://github.com/bluetape4k/bluetape4k-projects/issues/586) HC5-first HTTP client surface | M | Architecture/API decision with migration risk; settle before adding more tuning helpers. |
-| P1 | [#582](https://github.com/bluetape4k/bluetape4k-projects/issues/582) production HTTP client tuning defaults | M | Feature work that can become the shared default surface for IO HTTP users. |
-| P1 | [#583](https://github.com/bluetape4k/bluetape4k-projects/issues/583) cache configuration DSL and cache metrics helpers | M | User-facing feature that depends on the tuning/defaults shape. |
-| P1 | [#610](https://github.com/bluetape4k/bluetape4k-projects/issues/610) Ktor module family boundaries | L | Architecture/API decision for the `1.10.0` Ktor module family; settle before scaffolding. |
-| P1 | [#611](https://github.com/bluetape4k/bluetape4k-projects/issues/611) Scaffold Ktor module family in Gradle | M | Depends on #610 and sets the build/module shape for later Ktor work. |
-| P2 | [#589](https://github.com/bluetape4k/bluetape4k-projects/issues/589) benchmark-driven HTTP component performance epic | L | Umbrella for the IO HTTP performance lane; split execution through child issues. |
-| P2 | [#584](https://github.com/bluetape4k/bluetape4k-projects/issues/584) HTTP benchmarks against WebFlux mock server | S | Benchmark realism; useful after the target client surface is clear. |
-| P2 | [#585](https://github.com/bluetape4k/bluetape4k-projects/issues/585) CPU and GC profiling for HTTP benchmarks | S | Profiling depth; pair with benchmark scenarios to avoid isolated numbers. |
+| P0 | [#697](https://github.com/bluetape4k/bluetape4k-projects/issues/697) WIP backlog refresh | S | Current task; close after this file reflects live milestone/backlog state. |
+| P1 | [#696](https://github.com/bluetape4k/bluetape4k-projects/issues/696) shared telemetry contract | M | Required design gate before Spring Boot, Ktor, event, and example work. |
+| P1 | [#702](https://github.com/bluetape4k/bluetape4k-projects/issues/702) NearJCache remove semantics | S | Independent regression-test win; safe to run before or after #696. |
+| P1 | [#691](https://github.com/bluetape4k/bluetape4k-projects/issues/691) Ktor opt-in OpenTelemetry tracing | M | First implementation slice after #696; lower blast radius than Spring/event lanes. |
+| P1 | [#694](https://github.com/bluetape4k/bluetape4k-projects/issues/694) Spring Boot 4 observability helpers | M | Follow #696; keep Actuator/Micrometer conventions application-owned. |
+| P2 | [#695](https://github.com/bluetape4k/bluetape4k-projects/issues/695) event publish/consume telemetry helpers | M | Follow #696 and reuse decisions proven by HTTP telemetry work. |
+| P2 | [#692](https://github.com/bluetape4k/bluetape4k-projects/issues/692) observability examples | M | Depends on Spring Boot, Ktor, and event helper issues. |
+| P2 | [#699](https://github.com/bluetape4k/bluetape4k-projects/issues/699) Copilot instruction alignment | S | Independent docs/agent-guidance cleanup. |
+| P2 | [#698](https://github.com/bluetape4k/bluetape4k-projects/issues/698) HC5 interceptor ordering examples | S | Independent test/docs cleanup; verify expected HC5 ordering before editing behavior. |
+| P2 | [#701](https://github.com/bluetape4k/bluetape4k-projects/issues/701) FutureUtils virtual-thread TODO | M | API-boundary cleanup; preserve compatibility and public KDoc. |
+| P3 | [#690](https://github.com/bluetape4k/bluetape4k-projects/issues/690) observability telemetry Epic | L | Umbrella issue; keep open until child issues complete. |
+
+## Backlog Queue
+
+| Issue | Notes |
+|---|---|
+| [#700](https://github.com/bluetape4k/bluetape4k-projects/issues/700) Central snapshot task naming audit | Release-documentation cleanup; keep outside 1.11.0 unless snapshot workflow drift becomes blocking. |
+| [#706](https://github.com/bluetape4k/bluetape4k-projects/issues/706) data-r2dbc pool benchmark validation mode | Performance/benchmark lane; promote only when the benchmark workflow is the active focus. |
 
 ## Dependency Map
 
 ```text
-#586 HC5-first HTTP client surface
-  -> informs #582 production tuning defaults
-  -> informs #583 cache DSL and metrics helper shape
+#690 observability and event telemetry Epic
+  -> #696 shared telemetry contract
+    -> #691 Ktor opt-in OpenTelemetry tracing
+    -> #694 Spring Boot 4 observability helpers
+    -> #695 event publish/consume telemetry helpers
+      -> #692 Prometheus and OTLP examples
 
-#589 IO HTTP performance epic
-  -> #584 WebFlux mock-server benchmark scenarios
-  -> #585 CPU/GC profiling
-  -> should consume decisions from #586/#582/#583 before broad optimization
+#697 WIP refresh
+  -> update this file before choosing the next 1.11.0 execution slice
 
-#609 Ktor module family epic
-  -> #610 design boundaries
-  -> #611 Gradle scaffold
-  -> #612/#613/#614 implementation modules
-  -> #615 example migration
-  -> #616 CI/documentation/release metadata
+#702 NearJCache remove semantics
+#699 Copilot instruction alignment
+#698 HC5 interceptor ordering examples
+#701 FutureUtils virtual-thread TODO
+  -> independent of the observability Epic
 ```
 
 ## WIP Limits
 
 | Lane | Limit | Current next |
 |---|---:|---|
-| Release prep | 1 | Done for 1.9.1; keep only post-release version-line cleanup. |
-| IO HTTP API/design | 1 | `#586` first. |
-| IO HTTP feature | 1 | `#582`, then `#583`. |
-| IO HTTP performance | 1 | `#589` umbrella; execute `#584/#585` after design decisions. |
-| Ktor module family | 1 | `#610` first. |
+| WIP / management | 1 | `#697`; close after this refresh is merged. |
+| Observability design | 1 | `#696` first. |
+| Observability implementation | 1 | `#691`, then `#694`, then `#695`. |
+| Observability examples | 1 | `#692` only after helper APIs exist. |
+| Independent cleanup | 1 | Prefer `#702`; otherwise `#699`, `#698`, or `#701`. |
+| Backlog | 0 | Keep `#700` and `#706` parked until explicitly promoted. |
 
 ## Cleanup Actions
 
 | Candidate | Action |
 |---|---|
-| `1.9.0` and `1.9.1` milestones | Keep closed; do not add backlog work to completed releases. |
-| `1.9.2` milestone | Keep `#582/#583/#584/#585/#586/#589` open for the IO HTTP patch lane. |
-| `1.10.0` milestone | Keep `#609/#610/#611/#612/#613/#614/#615/#616` open for the Ktor module-family lane. |
-| release worktrees | Remove release-prep worktrees after PR merge and final verification. |
+| `#697` | Close only after the WIP refresh is merged or otherwise accepted. |
+| `#690` | Keep open as the 1.11.0 umbrella until child issues are complete. |
+| `backlog` milestone | Keep `#700` and `#706` out of the 1.11.0 lane unless priority changes. |
+| Old 1.9.x / 1.10.0 queue references | Treat as historical context; do not use them for current work ordering. |


### PR DESCRIPTION
## Summary

Closes #697

- PR 제목: docs: refresh 1.11.0 WIP queue

- Refresh WIP.md to match the live 1.11.0 milestone and backlog state.
- Replace stale 1.9.x/1.10.0 work ordering with the current observability and event telemetry lane.
- Document the active dependency order and independent cleanup candidates.

Closes #697.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

- Refresh WIP.md to match the live 1.11.0 milestone and backlog state.
- Replace stale 1.9.x/1.10.0 work ordering with the current observability and event telemetry lane.
- Document the active dependency order and independent cleanup candidates.

Closes #697.

### Validation

- `git diff --check HEAD~1..HEAD`
- `gh issue list --repo bluetape4k/bluetape4k-projects --state open --milestone 1.11.0 --limit 100 --json number | jq length` -> `11`
- `gh issue list --repo bluetape4k/bluetape4k-projects --state open --milestone backlog --limit 100 --json number | jq length` -> `2`
- Targeted stale queue search in `WIP.md` returned no matches for old issue ordering.

### DoD Status

| Gate | Status | Evidence |
|---|---|---|
| Scope | PASS | `WIP.md` only; docs-only change. |
| Milestone sync | PASS | Live GitHub counts: `1.11.0=11`, `backlog=2`. |
| Stale queue cleanup | PASS | Old `#586/#582/#610` style queue references removed from active ordering. |
| Validation | PASS | `git diff --check HEAD~1..HEAD` passed. |
| Not tested | PASS | Gradle build not run because no source/build files changed. |

## Validation

- `git diff --check HEAD~1..HEAD`
- `gh issue list --repo bluetape4k/bluetape4k-projects --state open --milestone 1.11.0 --limit 100 --json number | jq length` -> `11`
- `gh issue list --repo bluetape4k/bluetape4k-projects --state open --milestone backlog --limit 100 --json number | jq length` -> `2`
- Targeted stale queue search in `WIP.md` returned no matches for old issue ordering.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #697, milestone `1.11.0`, assignee `debop`
- PR: #714, head `aba62e75b5d3ef3bcbcb586267e778b2b9d30278`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `docs/wip-1.11.0-refresh`
- Labels: `documentation`, `management`
- State: `MERGED`, merge commit `9600570058d40523a4f52c90416736ff951226ef`
- CI: | Not tested | PASS | Gradle build not run because no source/build files changed. |

## DoD Status

| Gate | Status | Evidence |
|---|---|---|
| Scope | PASS | `WIP.md` only; docs-only change. |
| Milestone sync | PASS | Live GitHub counts: `1.11.0=11`, `backlog=2`. |
| Stale queue cleanup | PASS | Old `#586/#582/#610` style queue references removed from active ordering. |
| Validation | PASS | `git diff --check HEAD~1..HEAD` passed. |
| Not tested | PASS | Gradle build not run because no source/build files changed. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #714 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9600570058d40523a4f52c90416736ff951226ef`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
