### PR TITLE
test: document FutureUtils virtual-thread boundary

### DIFF
--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/FutureUtils.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/FutureUtils.kt
@@ -6,11 +6,16 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
 /**
- * 비동기 작업을 위한 유틸리티 함수들을 제공합니다.
+ * Provides general-purpose [CompletableFuture] aggregation and selection utilities.
+ *
+ * These helpers stay in the core `io.bluetape4k.concurrent` package because they are executor-agnostic
+ * and work with any [CompletableFuture] source. Virtual-thread execution factories live in
+ * `io.bluetape4k.concurrent.virtualthread`, such as
+ * [io.bluetape4k.concurrent.virtualthread.virtualFutureOf] and
+ * [io.bluetape4k.concurrent.virtualthread.virtualFutureOfNullable].
  */
 object FutureUtils {
 
-    // TODO: 이건 VirtualThreadUtils 로 이동
     /**
      * [futures] 중 가장 먼저 terminal state(성공/실패/취소)로 완료되는 것을 반환하고, 나머지 futures 는 취소합니다.
      *

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/CompletableFutureSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/CompletableFutureSupport.kt
@@ -3,7 +3,7 @@ package io.bluetape4k.concurrent.virtualthread
 import java.util.concurrent.CompletableFuture
 
 /**
- * 지정한 block을 Virtual Threads 를 이용하여 비동기로 실행하고, [CompletableFuture]를 반환합니다.
+ * Runs [block] asynchronously on the shared virtual-thread executor and returns a [CompletableFuture].
  *
  * ```kotlin
  * val future: CompletableFuture<Int> = virtualFutureOf {
@@ -13,9 +13,9 @@ import java.util.concurrent.CompletableFuture
  * val result = future.get() // 42
  * ```
  *
- * @param V 작업 결과 타입
- * @param block 비동기로 수행할 작업
- * @return Virtual Thread 위에서 [block]을 실행하는 [CompletableFuture] 인스턴스
+ * @param V result type.
+ * @param block work to run on a virtual thread.
+ * @return a [CompletableFuture] completed with [block]'s result.
  */
 inline fun <V: Any> virtualFutureOf(
     crossinline block: () -> V,
@@ -23,7 +23,7 @@ inline fun <V: Any> virtualFutureOf(
     CompletableFuture.supplyAsync({ block() }, VirtualThreadExecutor)
 
 /**
- * 지정한 block을 Virtual Threads 를 이용하여 비동기로 실행하고, nullable 결과를 허용하는 [CompletableFuture]를 반환합니다.
+ * Runs [block] asynchronously on the shared virtual-thread executor and returns a nullable [CompletableFuture].
  *
  * ```kotlin
  * val future: CompletableFuture<Int?> = virtualFutureOfNullable {
@@ -33,9 +33,9 @@ inline fun <V: Any> virtualFutureOf(
  * val result = future.get() // null 또는 42
  * ```
  *
- * @param V 작업 결과 타입 (nullable 허용)
- * @param block 비동기로 수행할 작업
- * @return Virtual Thread 위에서 [block]을 실행하는 [CompletableFuture] 인스턴스
+ * @param V result type.
+ * @param block work to run on a virtual thread.
+ * @return a [CompletableFuture] completed with [block]'s nullable result.
  */
 inline fun <V> virtualFutureOfNullable(
     crossinline block: () -> V?,

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/CompletableFutureSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/CompletableFutureSupportTest.kt
@@ -27,6 +27,14 @@ class CompletableFutureSupportTest {
     }
 
     @Test
+    fun `virtualFutureOf runs block on virtual thread`() {
+        val future = virtualFutureOf {
+            Thread.currentThread().isVirtual
+        }
+        future.get() shouldBeEqualTo true
+    }
+
+    @Test
     fun `virtualFutureOfNullable returns non-null result`() {
         val future = virtualFutureOfNullable {
             Thread.sleep(100)
@@ -50,6 +58,14 @@ class CompletableFutureSupportTest {
             null
         }
         future.get().shouldBeNull()
+    }
+
+    @Test
+    fun `virtualFutureOfNullable runs block on virtual thread`() {
+        val future = virtualFutureOfNullable {
+            Thread.currentThread().isVirtual
+        }
+        future.get() shouldBeEqualTo true
     }
 
     @Test

--- a/docs/review/2026-06-06-issue-701-future-utils-vt-boundary-review.md
+++ b/docs/review/2026-06-06-issue-701-future-utils-vt-boundary-review.md
@@ -1,0 +1,29 @@
+# Issue #701 FutureUtils virtual-thread boundary review
+
+## Scope
+
+- `FutureUtils`의 stale virtual-thread 이동 TODO를 공개 API 경계 설명으로 대체했다.
+- `virtualFutureOf` / `virtualFutureOfNullable` KDoc을 English public API documentation으로 정리했다.
+- virtual-thread `CompletableFuture` factory가 실제 virtual thread에서 block을 실행하는 테스트를 추가했다.
+
+## Findings
+
+- P0=0
+- P1=0
+- P2=0
+
+## Evidence
+
+- `./gradlew :bluetape4k-core:test --tests "io.bluetape4k.concurrent.FutureUtilsTest" --tests "io.bluetape4k.concurrent.virtualthread.CompletableFutureSupportTest"`: PASS, 24 passing.
+- `./gradlew :bluetape4k-core:test`: first run failed once in existing `FutureSupportTest.cancel propagates to wrapped Future and cancels wrapper`; isolated rerun passed.
+- `./gradlew :bluetape4k-core:test --tests "io.bluetape4k.concurrent.FutureSupportTest.cancel propagates to wrapped Future and cancels wrapper"`: PASS, 1 passing.
+- `./gradlew :bluetape4k-core:test`: retry PASS, 1598 passing.
+- `git diff --check`: PASS.
+- CodeGraph `detect_changes_tool`: risk score 0.00, affected flows 0, test gaps 0.
+- CodeGraph `get_impact_radius_tool`: low risk, additional affected files 0.
+- `rg "TODO:.*VirtualThreadUtils|VirtualThreadUtils"` over changed files: no matches.
+
+## Residual Risk
+
+- IntelliJ diagnostics were not available in this session.
+- The first full core test run exposed a timing-sensitive existing `FutureSupportTest` cancellation assertion, but it passed when isolated and in the full retry.


### PR DESCRIPTION
## Summary

Closes #701

- PR 제목: test: document FutureUtils virtual-thread boundary

- Closes #701.
- Keep `FutureUtils` as the executor-agnostic `CompletableFuture` aggregation and selection utility instead of moving public APIs.
- Document the virtual-thread boundary in public KDoc and point execution factories to `io.bluetape4k.concurrent.virtualthread`.
- Add runtime tests proving `virtualFutureOf` and `virtualFutureOfNullable` execute blocks on virtual threads.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Compatibility

- No public API signatures were moved, removed, or renamed.
- Existing `io.bluetape4k.concurrent.FutureUtils` callers remain source and binary compatible.

## Validation

- `./gradlew :bluetape4k-core:test --tests "io.bluetape4k.concurrent.FutureUtilsTest" --tests "io.bluetape4k.concurrent.virtualthread.CompletableFutureSupportTest"` PASS, 24 passing.
- `./gradlew :bluetape4k-core:test` first run: 1597 passing, 1 existing timing-sensitive `FutureSupportTest` failure.
- `./gradlew :bluetape4k-core:test --tests "io.bluetape4k.concurrent.FutureSupportTest.cancel propagates to wrapped Future and cancels wrapper"` PASS, 1 passing.
- `./gradlew :bluetape4k-core:test` retry PASS, 1598 passing.
- `git diff --check` PASS.
- CodeGraph `detect_changes_tool`: risk score 0.00, affected flows 0, test gaps 0.
- CodeGraph `get_impact_radius_tool`: low risk, additional affected files 0.
- `rg "TODO:.*VirtualThreadUtils|VirtualThreadUtils"` over changed files: no matches.

## Review Notes

- Local review artifact: `docs/review/2026-06-06-issue-701-future-utils-vt-boundary-review.md`.
- Review gate: P0=0, P1=0, P2=0.

## Metadata

- Issue: #701, milestone `1.11.0`, assignee `debop`
- PR: #717, head `7fb8e6bd4294b7a547a67f515ef30af3267824c2`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `refactor/issue-701-future-utils-vt-boundary`
- Labels: `refactor`, `tech-debt`
- State: `MERGED`, merge commit `e8fd1389252a27bc3fc767015eb76c6837912348`
- CI: - `./gradlew :bluetape4k-core:test --tests "io.bluetape4k.concurrent.FutureUtilsTest" --tests "io.bluetape4k.concurrent.virtualthread.CompletableFutureSupportTest"` PASS, 24 passing. / - `./gradlew :bluetape4k-core:test` first run: 1597 passing, 1 existing timing-sensitive `FutureSupportTest` failure. / - `./gradlew :bluetape4k-core:test --tests "io.bluetape4k.concurrent.FutureSupportTest.cancel propagates to wrapped Future and cancels wrapper"` PASS, 1 passing.

## DoD Status

- [x] Stale `FutureUtils` virtual-thread placement TODO resolved.
- [x] Public API compatibility preserved.
- [x] English KDoc added for changed public API documentation.
- [x] Virtual-thread execution factory behavior covered by targeted tests.
- [x] Affected core/virtualthread compile and test evidence collected.
- [x] Local review evidence recorded with P0=0 and P1=0.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #717 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e8fd1389252a27bc3fc767015eb76c6837912348`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
