### PR TITLE
docs: align Copilot instructions with project policy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,17 +1,37 @@
-# Kotlin 백엔드 개발을 위한 레포지토리입니다.
+# bluetape4k-projects Copilot Instructions
 
-- 주석, 설명은 KDoc 형식으로 한국어로 작성한다.
-- Kotlin 2.3.0 이상으로 작성한다
-- 최대한 Kotlin extensions 을 활용한다.
-- 최대한 내부코드를 재활용한다. (예: Any?.requireNotNull() 등)
-- Spring Boot 3.4.0 이상을 사용한다
-- Kotlin Exposed 0.60.0 이상을 사용한다
-- Kotlin DSL 을 적극적으로 활용한다
-- DB 사용은 H2, Postgres, MySQL을 주로 사용한다.
-- 예제는 간결하지만 실제 프로덕션에 사용 가능한 수준으로 작성한다
-- 예제는 실제로 동작하는 예제를 작성한다
-- 테스트 코드는 JUnit 5 기준으로 한다.
-- 테스트 코드는 MockK 를 사용한다
-- 테스트 코드의 Assertions 는 Kluent 를 사용한다.
-- 커밋 메시지는 한국어로 작성한다
-- 커밋 메시지는 머릿말을 둔다 (예: feat, fix, docs, style, refactor, perf, test, chore)
+This repository contains Kotlin/JVM backend libraries for the bluetape4k ecosystem.
+Follow the workspace and repo-local `AGENTS.md` files when they provide stricter or newer guidance.
+
+## Language And Public Artifacts
+
+- Write public API KDoc in English for new or changed public classes, interfaces, objects, and extension functions.
+- Keep contributor-facing artifacts in English, including commit messages, PR titles/bodies, changelog entries, release notes, and GitHub issues.
+- Keep `README.md` in English and update existing localized README files such as `README.ko.md` together when user-facing documentation changes.
+- Keep internal planning, review, and lesson documents concise; Korean is acceptable for internal human-readable docs.
+
+## Kotlin And Module Policy
+
+- Use Kotlin 2.3+ and the repository's Java 21 toolchain.
+- Use Spring Boot 4.x only for this repository's Spring Boot modules.
+- Prefer Kotlin extensions, DSLs, immutable values, and existing bluetape4k helpers before adding new utilities.
+- Reuse established module patterns from the current source tree and `settings.gradle.kts`.
+- Keep examples concise, runnable, and realistic enough for production-style usage.
+
+## Testing
+
+- Use JUnit 5, MockK, and `io.bluetape4k.assertions` helpers.
+- Prefer bluetape4k assertion comparison matchers such as `shouldBeEqualTo` over boolean assertions.
+- Use `assertFailsWith<T> { }` for exception checks unless an existing bluetape4k assertion pattern is clearly more appropriate.
+
+## Spring And Data
+
+- For Spring code, follow Spring Boot 4.x conventions and the current `spring-boot/*` module layout.
+- For Exposed code, follow current Exposed 1.2+ import and receiver-shadowing rules from repo guidance.
+- Prefer existing database/testcontainer launchers and project test infrastructure over ad hoc setup.
+
+## Git And Validation
+
+- Commit messages that will be pushed to GitHub must be in English and use the repository's conventional prefixes when helpful, such as `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `build:`, or `chore:`.
+- Keep changes small, reviewable, and scoped to the requested issue.
+- Run the smallest relevant compile/test/documentation checks and `git diff --check` before claiming completion.

--- a/docs/review/2026-06-06-issue-699-copilot-instructions-review.md
+++ b/docs/review/2026-06-06-issue-699-copilot-instructions-review.md
@@ -1,0 +1,28 @@
+# Issue #699 Copilot instructions policy alignment review
+
+## Scope
+
+- Updated `.github/copilot-instructions.md` to match current bluetape4k-projects policy.
+- Kept the change to agent-facing guidance only; no production code or workflow behavior changed.
+
+## Findings
+
+- P0=0
+- P1=0
+- P2=0
+
+## Evidence
+
+- `gno query "Copilot instructions current bluetape4k project policy" -c bluetape4k-github --fast --no-rerank`: issue #699 evidence found.
+- `gno query "Copilot instructions current bluetape4k project policy" -c bluetape4k-docs --fast --no-rerank`: weak docs match; repo-local `AGENTS.md` and workspace `AGENTS.md` used as current policy sources.
+- `rg -n "Spring Boot 3|3\\.4\\.0|Kluent|한국어로|KDoc.*한국어|Korean KDoc|commit messages.*Korean|커밋 메시지는|Kluent-first" .github/copilot-instructions.md`: no matches.
+- `git diff --check`: PASS.
+
+## Follow-up
+
+- `.github/git-commit-instructions.md` still contains older Korean commit-message guidance, but #699 scope and acceptance criteria target `.github/copilot-instructions.md` only.
+- Follow-up issue created: #718.
+
+## Residual Risk
+
+- No rendered docs or Gradle tests were run because this is a single agent-guidance documentation change.


### PR DESCRIPTION
## Summary

Closes #699

- PR 제목: docs: align Copilot instructions with project policy

- Closes #699.
- Replace stale `.github/copilot-instructions.md` guidance with current bluetape4k-projects policy.
- Align Copilot guidance with Spring Boot 4.x, English contributor-facing artifacts, English public KDoc, and `io.bluetape4k.assertions` testing conventions.
- Record related out-of-scope git commit instruction cleanup as follow-up #718.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- Changed `.github/copilot-instructions.md` only for active Copilot guidance.
- Added local review evidence under `docs/review/2026-06-06-issue-699-copilot-instructions-review.md`.
- No source code, workflow YAML, or rendered documentation behavior changed.

## Work Done

### 기존 섹션: Not Run

- Gradle tests: not run because this is a single agent-guidance documentation change.
- Rendered docs build: not run because no rendered docs or website content changed.

## Validation

- `gno query "Copilot instructions current bluetape4k project policy" -c bluetape4k-github --fast --no-rerank`: issue #699 evidence found.
- `gno query "Copilot instructions current bluetape4k project policy" -c bluetape4k-docs --fast --no-rerank`: weak docs match; repo-local and workspace `AGENTS.md` used as current policy sources.
- `rg -n "Spring Boot 3|3\\.4\\.0|Kluent|한국어로|KDoc.*한국어|Korean KDoc|commit messages.*Korean|커밋 메시지는|Kluent-first" .github/copilot-instructions.md`: no matches.
- `git diff --check`: PASS.
- Local review gate: P0=0, P1=0, P2=0.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #699, milestone `1.11.0`, assignee `debop`
- PR: #719, head `7cf4fa94f9c896b4fffcf69b5c6e93b1a6f63b71`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `docs/issue-699-copilot-instructions`
- Labels: `documentation`, `codex-automation`, `tech-debt`
- State: `MERGED`, merge commit `9617d73111f867bcf29f4f7c3e00df88b8a84180`
- CI: - Align Copilot guidance with Spring Boot 4.x, English contributor-facing artifacts, English public KDoc, and `io.bluetape4k.assertions` testing conventions. / - Gradle tests: not run because this is a single agent-guidance documentation change. / - [x] Contributor-facing language policy is aligned with workspace guidance.

## DoD Status

- [x] `.github/copilot-instructions.md` no longer instructs stale Spring Boot, assertion, public KDoc, or pushed commit-message policy.
- [x] Copilot guidance references Spring Boot 4.x and current bluetape4k testing conventions.
- [x] Contributor-facing language policy is aligned with workspace guidance.
- [x] Targeted stale-term scan and `git diff --check` passed.
- [x] Local review evidence recorded with P0=0 and P1=0.
- [x] Out-of-scope stale git commit instruction guidance tracked in follow-up #718.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #719 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9617d73111f867bcf29f4f7c3e00df88b8a84180`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
