### PR TITLE
docs: align git commit instructions with contributor policy

### DIFF
--- a/.github/git-commit-instructions.md
+++ b/.github/git-commit-instructions.md
@@ -1,2 +1,5 @@
-- 커밋 메시지는 한국어로 작성한다
-- 커밋 메시지는 머릿말을 둔다 (예: feat, fix, docs, style, refactor, perf, test, chore)
+# Git Commit Instructions
+
+- Write pushed commit messages in English because they are contributor-facing artifacts.
+- Use a concise conventional prefix when helpful, such as `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `build:`, or `chore:`.
+- Make the first line describe why the change was made, not just which file changed.

--- a/docs/review/2026-06-06-issue-718-git-commit-instructions-review.md
+++ b/docs/review/2026-06-06-issue-718-git-commit-instructions-review.md
@@ -1,0 +1,24 @@
+# Issue #718 Git commit instructions policy alignment review
+
+## Scope
+
+- Updated `.github/git-commit-instructions.md` to match the current English contributor-facing artifact policy.
+- Kept the change to commit guidance only; no production code, workflow, or Copilot instruction behavior changed.
+
+## Findings
+
+- P0=0
+- P1=0
+- P2=0
+
+## Evidence
+
+- `gh issue view 718 --json body`: issue scope requires English pushed commit messages and conventional prefixes.
+- `gno query "git commit instructions English contributor policy" -c bluetape4k-github --fast --no-rerank`: #699/#718 context found.
+- `.github/copilot-instructions.md`: current policy says contributor-facing artifacts, including commit messages, are English.
+- `rg -n "한국어|Korean|커밋 메시지는 한국어|커밋 메시지는|머릿말" .github/git-commit-instructions.md`: no matches.
+- `git diff --check`: PASS.
+
+## Residual Risk
+
+- No Gradle tests or rendered documentation checks were run because this is a single agent-guidance documentation change.


### PR DESCRIPTION
## Summary

Closes #718

- PR 제목: docs: align git commit instructions with contributor policy

- Closes #718.
- Replace stale `.github/git-commit-instructions.md` Korean commit guidance with the current English contributor-facing artifact policy.
- Preserve concise conventional prefix guidance for generated pushed commits.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- Changed `.github/git-commit-instructions.md` only for commit guidance.
- Added local review evidence under `docs/review/2026-06-06-issue-718-git-commit-instructions-review.md`.
- No source code, workflow YAML, Copilot instruction, or rendered documentation behavior changed.

## Work Done

### 기존 섹션: Not Run

- Gradle tests: not run because this is a single agent-guidance documentation change.
- Rendered docs build: not run because no rendered docs or website content changed.

## Validation

- `gh issue view 718 --json body`: issue scope requires English pushed commit messages and conventional prefixes.
- `gno query "git commit instructions English contributor policy" -c bluetape4k-github --fast --no-rerank`: #699/#718 context found.
- `.github/copilot-instructions.md`: current policy says contributor-facing artifacts, including commit messages, are English.
- `rg -n "한국어|Korean|커밋 메시지는 한국어|커밋 메시지는|머릿말" .github/git-commit-instructions.md`: no matches.
- `git diff --check`: PASS.
- Local review gate: P0=0, P1=0, P2=0.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #718, milestone `1.11.0`, assignee `debop`
- PR: #720, head `a7ce84d408800a50af16a3e5542c6c7002f51ff4`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `docs/issue-718-git-commit-instructions`
- Labels: `documentation`, `codex-automation`, `tech-debt`
- State: `MERGED`, merge commit `2183cd41dda1db000fbe15ecde4dcb0882cfc190`
- CI: - Replace stale `.github/git-commit-instructions.md` Korean commit guidance with the current English contributor-facing artifact policy. / - Preserve concise conventional prefix guidance for generated pushed commits. / - `.github/copilot-instructions.md`: current policy says contributor-facing artifacts, including commit messages, are English.

## DoD Status

- [x] `.github/git-commit-instructions.md` no longer instructs Korean commit messages.
- [x] The file requires English pushed commit messages.
- [x] Conventional prefix guidance is preserved.
- [x] Targeted stale-term scan and `git diff --check` passed.
- [x] Local review evidence recorded with P0=0 and P1=0.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #720 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `2183cd41dda1db000fbe15ecde4dcb0882cfc190`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
