### PR TITLE
test(io-http): lock HC5 interceptor ordering examples

### DIFF
--- a/docs/review/2026-06-06-issue-698-hc5-interceptor-ordering-review.md
+++ b/docs/review/2026-06-06-issue-698-hc5-interceptor-ordering-review.md
@@ -1,0 +1,30 @@
+# Issue #698 HC5 interceptor ordering review
+
+## Scope
+
+- `io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/ClientInterceptors.kt`
+- `io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/AsyncClientInterceptors.kt`
+
+## Findings
+
+- P0: 0
+- P1: 0
+- P2: 0
+
+## Review Notes
+
+- The examples now assert the documented HC5 ordering instead of leaving FIXME comments.
+- The custom exec interceptor records that `request-id` is missing before the request protocol interceptor runs.
+- The request protocol interceptor records `request-id` only after execution reaches the transport path.
+- The 13th request short-circuit is asserted for both classic and async clients.
+- The async example now uses the local httpbin prefix `/httpbin/get`, matching the repository test server contract.
+
+## Verification Evidence
+
+- `./gradlew :bluetape4k-http:test --tests "io.bluetape4k.http.hc5.examples.ClientInterceptors" --tests "io.bluetape4k.http.hc5.examples.AsyncClientInterceptors"`: PASS, 2 tests passing.
+- `git diff --check`: PASS.
+- `rg -n "FIXME|why does this run|ExecInterceptorAfter runs before request interceptor" ...`: PASS, no matches in touched example files.
+
+## Residual Risk
+
+- Full `:bluetape4k-http:test` was not run because the change is limited to two example tests and the targeted test task compiled the module test source and executed both touched classes.

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/AsyncClientInterceptors.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/AsyncClientInterceptors.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.http.hc5.examples
 
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.http.hc5.AbstractHc5Test
 import io.bluetape4k.http.hc5.async.executeSuspending
 import io.bluetape4k.http.hc5.async.httpAsyncClient
@@ -9,8 +10,8 @@ import io.bluetape4k.http.hc5.reactor.ioReactorConfig
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.toUtf8Bytes
-import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.test.runTest
+import org.apache.hc.client5.http.async.AsyncExecCallback
 import org.apache.hc.client5.http.async.AsyncExecChainHandler
 import org.apache.hc.client5.http.impl.ChainElement
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient
@@ -25,17 +26,20 @@ import org.apache.hc.core5.io.CloseMode
 import org.apache.hc.core5.util.Timeout
 import org.junit.jupiter.api.Test
 import java.nio.ByteBuffer
+import java.util.concurrent.CopyOnWriteArrayList
 
 class AsyncClientInterceptors: AbstractHc5Test() {
 
     companion object: KLoggingChannel() {
-        private val counter = atomic(0L)
+        private const val EXECUTION_ID_HEADER = "execution-id"
+        private const val REQUEST_ID_HEADER = "request-id"
     }
 
     @Test
     fun `request interceptor and execution interceptor`() = runTest {
-        val target = HttpHost(httpbinServer.host, httpbinServer.port)
-        val path = "/get"
+        val target = HttpHost("http", httpbinServer.host, httpbinServer.port)
+        val path = "/httpbin/get"
+        val events = CopyOnWriteArrayList<String>()
 
         val ioReactorConfig = ioReactorConfig {
             setSoTimeout(Timeout.ofSeconds(5))
@@ -44,45 +48,54 @@ class AsyncClientInterceptors: AbstractHc5Test() {
         val client: CloseableHttpAsyncClient = httpAsyncClient {
             setIOReactorConfig(ioReactorConfig)
 
-            // 각 요청에 간단한 request-id 헤더를 추가합니다.
-            addRequestInterceptorFirst(requestInterceptor())
+            // Request protocol interceptors run inside HttpAsyncMainClientExec, after custom exec interceptors.
+            addRequestInterceptorFirst(requestInterceptor(events))
 
-            // 일부 요청은 백엔드로 전달하지 않고 404 응답을 시뮬레이션합니다.
-
-            addExecInterceptorAfter(ChainElement.PROTOCOL.name, "custom", asyncExecChainHandler())
+            // Some requests are handled without reaching the backend.
+            addExecInterceptorAfter(ChainElement.PROTOCOL.name, "custom", asyncExecChainHandler(events))
         }
 
         client.start()
 
-        List(20) {
-            val request = simpleHttpRequestOf(Method.GET, target, path)
+        try {
+            val statuses = List(20) {
+                val executionId = (it + 1).toString()
+                val request = simpleHttpRequestOf(Method.GET, target, path)
+                request.setHeader(EXECUTION_ID_HEADER, executionId)
 
-            // FIXME: in coroutine mode, ExecInterceptorAfter runs before request interceptor.
-            val response = client.executeSuspending(request)
-            log.debug { "Response: $request -> ${StatusLine(response)}" }
-            log.debug { "Body: ${response.body}" }
+                val response = client.executeSuspending(request)
+                log.debug { "Response: $request -> ${StatusLine(response)}" }
+                log.debug { "Body: ${response.body}" }
+                response.code
+            }
+
+            statuses shouldBeEqualTo expectedStatuses()
+            events.toList() shouldBeEqualTo expectedEvents()
+        } finally {
+            log.debug { "Shutting down" }
+            client.close(CloseMode.GRACEFUL)
         }
-
-        log.debug { "Shutting down" }
-        client.close(CloseMode.GRACEFUL)
     }
 
-    private fun requestInterceptor(): HttpRequestInterceptor {
-        return HttpRequestInterceptor { request, entity, context ->
-            request.setHeader("request-id", counter.incrementAndGet().toString())
-            log.debug { "request-id = ${request.getFirstHeader("request-id")}" }
+    private fun requestInterceptor(events: MutableList<String>): HttpRequestInterceptor {
+        return HttpRequestInterceptor { request, _, _ ->
+            val executionId = request.getFirstHeader(EXECUTION_ID_HEADER)?.value ?: "missing"
+            events.add("request:$executionId")
+            request.setHeader(REQUEST_ID_HEADER, "request-$executionId")
+            log.debug { "request-id = ${request.getFirstHeader(REQUEST_ID_HEADER)}" }
         }
     }
 
-    // 일부 요청은 백엔드로 전달하지 않고 404 응답을 시뮬레이션합니다.
-    // FIXME: why does this run before request interceptor?
-
-    private fun asyncExecChainHandler(): AsyncExecChainHandler {
+    private fun asyncExecChainHandler(
+        events: MutableList<String>,
+    ): AsyncExecChainHandler {
         return AsyncExecChainHandler { request, entityProducer, scope, chain, asyncExecCallback ->
             log.debug { "AsyncExecChainHandler request=$request" }
-            val idHeader = request.getFirstHeader("request-id")
-            log.debug { "idHeader=${idHeader?.value}" }
-            if (idHeader?.value == "13") {
+            val executionId = request.getFirstHeader(EXECUTION_ID_HEADER)?.value ?: "missing"
+            events.add("exec-before:$executionId:${request.getFirstHeader(REQUEST_ID_HEADER)?.value ?: "missing"}")
+            log.debug { "executionId=$executionId" }
+            if (executionId == "13") {
+                events.add("exec-short-circuit:$executionId")
                 val response = BasicHttpResponse(HttpStatus.SC_NOT_FOUND, "Oppsie")
                 val content = ByteBuffer.wrap("bad luck".toUtf8Bytes())
                 val asyncDataConsumer = asyncExecCallback.handleResponse(
@@ -91,9 +104,43 @@ class AsyncClientInterceptors: AbstractHc5Test() {
                 )
                 asyncDataConsumer.consume(content)
                 asyncDataConsumer.streamEnd(null)
+                asyncExecCallback.completed()
             } else {
-                chain.proceed(request, entityProducer, scope, asyncExecCallback)
+                chain.proceed(
+                    request,
+                    entityProducer,
+                    scope,
+                    object: AsyncExecCallback by asyncExecCallback {
+                        override fun completed() {
+                            events.add(
+                                "exec-after:$executionId:${request.getFirstHeader(REQUEST_ID_HEADER)?.value ?: "missing"}"
+                            )
+                            asyncExecCallback.completed()
+                        }
+                    }
+                )
             }
         }
     }
+
+    private fun expectedStatuses(): List<Int> =
+        (1..20).map { executionId ->
+            if (executionId == 13) HttpStatus.SC_NOT_FOUND else HttpStatus.SC_OK
+        }
+
+    private fun expectedEvents(): List<String> =
+        (1..20).flatMap { executionId ->
+            if (executionId == 13) {
+                listOf(
+                    "exec-before:$executionId:missing",
+                    "exec-short-circuit:$executionId",
+                )
+            } else {
+                listOf(
+                    "exec-before:$executionId:missing",
+                    "request:$executionId",
+                    "exec-after:$executionId:request-$executionId",
+                )
+            }
+        }
 }

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/ClientInterceptors.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/ClientInterceptors.kt
@@ -1,11 +1,11 @@
 package io.bluetape4k.http.hc5.examples
 
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.http.hc5.AbstractHc5Test
 import io.bluetape4k.http.hc5.classic.httpClient
 import io.bluetape4k.http.hc5.entity.consume
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
-import kotlinx.atomicfu.atomic
 import org.apache.hc.client5.http.classic.ExecChain
 import org.apache.hc.client5.http.classic.ExecChainHandler
 import org.apache.hc.client5.http.classic.methods.HttpGet
@@ -22,57 +22,94 @@ import org.junit.jupiter.api.Test
 
 class ClientInterceptors: AbstractHc5Test() {
 
-    companion object: KLogging()
-
-    private val counter = atomic(0L)
+    companion object: KLogging() {
+        private const val EXECUTION_ID_HEADER = "execution-id"
+        private const val REQUEST_ID_HEADER = "request-id"
+    }
 
     @Test
     fun `client interceptors`() {
+        val events = mutableListOf<String>()
+
         val httpclient = httpClient {
 
-            // 각 요청에 간단한 request-id 헤더를 추가합니다.
-            addRequestInterceptorFirst(requestInterceptor())
+            // Request protocol interceptors run inside MainClientExec, after custom exec interceptors.
+            addRequestInterceptorFirst(requestInterceptor(events))
 
-            // FIXME: why does this run first?
-            // 일부 요청은 백엔드로 전달하지 않고 404 응답을 시뮬레이션합니다.
-            addExecInterceptorAfter(ChainElement.PROTOCOL.name, "custom", execChainHandler())
+            // Some requests are handled without reaching the backend.
+            addExecInterceptorAfter(ChainElement.PROTOCOL.name, "custom", execChainHandler(events))
         }
+
+        val statuses = mutableListOf<Int>()
 
         httpclient.use {
             repeat(20) {
+                val executionId = (it + 1).toString()
                 val httpget = HttpGet("$httpbinBaseUrl/get")
+                httpget.setHeader(EXECUTION_ID_HEADER, executionId)
                 log.debug { "Executing request ${httpget.method} ${httpget.uri}" }
 
-                val response = httpclient.execute(httpget) { it }
-                log.debug { "------------------" }
-                log.debug { "$httpget -> ${StatusLine(response)}" }
-                response.entity.consume()
+                val status = httpclient.execute(httpget) { response ->
+                    log.debug { "------------------" }
+                    log.debug { "$httpget -> ${StatusLine(response)}" }
+                    response.entity.consume()
+                    response.code
+                }
+                statuses.add(status)
             }
         }
+
+        statuses shouldBeEqualTo expectedStatuses()
+        events shouldBeEqualTo expectedEvents()
     }
 
-    private fun requestInterceptor(): HttpRequestInterceptor {
+    private fun requestInterceptor(events: MutableList<String>): HttpRequestInterceptor {
 
         return HttpRequestInterceptor { request: HttpRequest, _, _ ->
-            log.debug { "add request-id. ${counter.value}" }
-            request.setHeader("request-id", counter.incrementAndGet().toString())
+            val executionId = request.getFirstHeader(EXECUTION_ID_HEADER)?.value ?: "missing"
+            events.add("request:$executionId")
+            request.setHeader(REQUEST_ID_HEADER, "request-$executionId")
+            log.debug { "request-id = ${request.getFirstHeader(REQUEST_ID_HEADER)}" }
         }
     }
 
-    // 일부 요청은 백엔드로 전달하지 않고 404 응답을 시뮬레이션합니다.
-
-    private fun execChainHandler(): ExecChainHandler {
+    private fun execChainHandler(events: MutableList<String>): ExecChainHandler {
         return ExecChainHandler { request: ClassicHttpRequest, scope: ExecChain.Scope, chain: ExecChain ->
-            val idHeader = request.getFirstHeader("request-id")
-            log.debug { "idHeader=$idHeader" }
+            val executionId = request.getFirstHeader(EXECUTION_ID_HEADER)?.value ?: "missing"
+            events.add("exec-before:$executionId:${request.getFirstHeader(REQUEST_ID_HEADER)?.value ?: "missing"}")
+            log.debug { "executionId=$executionId" }
 
-            if (idHeader?.value.equals("13", ignoreCase = true)) {
+            if (executionId == "13") {
+                events.add("exec-short-circuit:$executionId")
                 BasicClassicHttpResponse(HttpStatus.SC_NOT_FOUND, "Oppsie").apply {
                     entity = StringEntity("bad luck", ContentType.TEXT_PLAIN)
                 }
             } else {
-                chain.proceed(request, scope)
+                chain.proceed(request, scope).also {
+                    events.add("exec-after:$executionId:${request.getFirstHeader(REQUEST_ID_HEADER)?.value ?: "missing"}")
+                }
             }
         }
     }
+
+    private fun expectedStatuses(): List<Int> =
+        (1..20).map { executionId ->
+            if (executionId == 13) HttpStatus.SC_NOT_FOUND else HttpStatus.SC_OK
+        }
+
+    private fun expectedEvents(): List<String> =
+        (1..20).flatMap { executionId ->
+            if (executionId == 13) {
+                listOf(
+                    "exec-before:$executionId:missing",
+                    "exec-short-circuit:$executionId",
+                )
+            } else {
+                listOf(
+                    "exec-before:$executionId:missing",
+                    "request:$executionId",
+                    "exec-after:$executionId:request-$executionId",
+                )
+            }
+        }
 }


### PR DESCRIPTION
## Summary

Closes #698

- PR 제목: test(io-http): lock HC5 interceptor ordering examples

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Why

Closes #698.

The HC5 classic and async interceptor examples had unresolved FIXME comments around request protocol interceptor ordering. Those examples were runnable, but they did not assert the ordering contract or the short-circuit behavior they were meant to demonstrate.

### 기존 섹션: What Changed

- Replaced log-only interceptor examples with explicit status and event-order assertions.
- Documented that HC5 request protocol interceptors run inside the main transport exec stage, after custom exec interceptors placed after `ChainElement.PROTOCOL`.
- Verified the 13th request short-circuit returns 404 while the other requests reach the local httpbin backend.
- Fixed the async example request target to use the local `/httpbin/get` path.
- Added a tracked local review artifact for the pre-PR review gate.

### 기존 섹션: Review Evidence

- `docs/review/2026-06-06-issue-698-hc5-interceptor-ordering-review.md`
- Local review verdict: P0=0, P1=0, P2=0.

## Validation

- PASS: `./gradlew :bluetape4k-http:test --tests "io.bluetape4k.http.hc5.examples.ClientInterceptors" --tests "io.bluetape4k.http.hc5.examples.AsyncClientInterceptors"`
- PASS: `git diff --check`
- PASS: `rg -n "FIXME|why does this run|ExecInterceptorAfter runs before request interceptor" io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/ClientInterceptors.kt io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/AsyncClientInterceptors.kt` returned no matches.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #698, milestone `1.11.0`, assignee `debop`
- PR: #721, head `f2eb06ceb22115c979875a271b59c5b426f05006`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `test/issue-698-hc5-interceptor-ordering`
- Labels: `test`, `infra/io`, `tech-debt`
- State: `MERGED`, merge commit `b023463973699155c8055c02af020ef631ebc860`
- CI: The HC5 classic and async interceptor examples had unresolved FIXME comments around request protocol interceptor ordering. Those examples were runnable, but they did not assert the ordering contract or the short-circuit behavior they were meant to demonstrate. / - Replaced log-only interceptor examples with explicit status and event-order assertions. / - Verified the 13th request short-circuit returns 404 while the other requests reach the local httpbin backend.

## DoD Status

| Step | Status | Evidence |
|---|---|---|
| Worktree setup | PASS | Branch `test/issue-698-hc5-interceptor-ordering` from `origin/develop`. |
| Requirements check | PASS | Issue #698 acceptance criteria mapped to two HC5 example files. |
| Implementation | PASS | Classic and async examples assert statuses and interceptor event order; FIXME comments removed. |
| Targeted tests | PASS | `:bluetape4k-http:test` with both touched test classes: 2 passing. |
| Diff hygiene | PASS | `git diff --check` passed. |
| Local review | PASS | Review artifact committed; P0=0, P1=0, P2=0. |
| CI | PASS | GitHub checks: Build, Test Examples, CI Status, Secret Scan, wrapper validation, coverage, and submit-gradle passed; module shards skipped as expected. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #721 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `b023463973699155c8055c02af020ef631ebc860`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
