### PR TITLE
feat(ktor): add opt-in OpenTelemetry tracing

### DIFF
--- a/docs/lessons/2026-06-06-issue-691-ktor-opentelemetry-tracing.md
+++ b/docs/lessons/2026-06-06-issue-691-ktor-opentelemetry-tracing.md
@@ -1,0 +1,33 @@
+# Issue #691 Ktor OpenTelemetry Tracing
+
+## Context
+
+`ktor/observability` already owned CallId, CallLogging, optional Micrometer, and
+Prometheus route helpers. The observability contract from #696 required Ktor
+tracing to stay explicit, application-owned, and safe around correlation IDs.
+
+## Decision
+
+Add a narrow Ktor OpenTelemetry helper that accepts an application-created
+`OpenTelemetry` instance and wraps OpenTelemetry's Ktor 3 server instrumentation.
+Keep `opentelemetry-ktor-3.0` out of the main runtime dependency graph by using
+`compileOnly`; document it as an application dependency when tracing is enabled.
+
+## Outcome
+
+The baseline installer can opt in through `KtorOpenTelemetryTracingConfig`, while
+existing users without tracing keep the previous behavior. Sanitized
+`correlation.id` is trace-only and opt-in; `correlation.present` is bounded.
+
+## Verification
+
+- `./gradlew :bluetape4k-ktor-observability:compileKotlin`
+- `./gradlew :bluetape4k-ktor-observability:compileTestKotlin`
+- `./gradlew :bluetape4k-ktor-observability:test`
+- `git diff --check`
+
+## Future Guard
+
+When adding framework tracing wrappers, do not create SDKs or exporters inside
+library helpers. Keep alpha instrumentation dependencies optional and test them
+with `InMemorySpanExporter` instead of asserting backend-specific behavior.

--- a/docs/review/2026-06-06-issue-691-ktor-opentelemetry-tracing-review.md
+++ b/docs/review/2026-06-06-issue-691-ktor-opentelemetry-tracing-review.md
@@ -1,0 +1,38 @@
+# Issue #691 Ktor OpenTelemetry Tracing Review
+
+Date: 2026-06-06
+Repo: `bluetape4k-projects`
+Scope: `ktor/observability` OpenTelemetry tracing helper
+
+## Gate
+
+- P0: 0
+- P1: 0
+- Verdict: PASS
+
+## Review Notes
+
+- Public API keeps telemetry backend ownership application-side by accepting an
+  `OpenTelemetry` instance and never constructing or registering a global SDK.
+- `opentelemetry-ktor-3.0` remains `compileOnly` for main code and is documented
+  as a tracing-only application dependency, limiting the alpha instrumentation
+  blast radius.
+- Correlation handling reuses `KtorCorrelationId.sanitize()` and records
+  `correlation.id` only when explicitly enabled. Raw request header values,
+  authorization headers, bodies, and query strings are not captured by the
+  bluetape4k helper.
+- Existing CallId, CallLogging, Micrometer, and Prometheus paths remain covered
+  by the expanded module test.
+
+## Verification Evidence
+
+- `./gradlew :bluetape4k-ktor-observability:compileKotlin`
+- `./gradlew :bluetape4k-ktor-observability:compileTestKotlin`
+- `./gradlew :bluetape4k-ktor-observability:test` - 9 tests passing
+- `git diff --check`
+
+## Residual Risk
+
+- The wrapped OpenTelemetry Ktor instrumentation is alpha-versioned. Future
+  updates may require source-compatible adjustments around `KtorServerTelemetry`
+  builder APIs.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -758,6 +758,7 @@ opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testi
 opentelemetry-sdk-extensions-autoconfigure = { module = "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure" }
 opentelemetry-logback-appender = { module = "io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0" }
 opentelemetry-logback-mdc = { module = "io.opentelemetry.instrumentation:opentelemetry-logback-mdc-1.0" }
+opentelemetry-ktor = { module = "io.opentelemetry.instrumentation:opentelemetry-ktor-3.0" }
 opentelemetry-spring-boot-starter = { module = "io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter" }
 opentelemetry-spring-webflux = { module = "io.opentelemetry.instrumentation:opentelemetry-spring-webflux-5.3" }
 

--- a/ktor/observability/README.ko.md
+++ b/ktor/observability/README.ko.md
@@ -15,6 +15,7 @@ bluetape4k 생태계를 위한 Ktor observability helper 모듈입니다.
 - query string을 제외한 기본 로그 메시지와 `CallLogging` MDC 연동.
 - 애플리케이션이 `MeterRegistry`를 제공할 때 Micrometer `MicrometerMetrics` 설치.
 - 애플리케이션이 소유한 `PrometheusMeterRegistry` 기반 선택적 scrape route.
+- 애플리케이션이 소유한 `OpenTelemetry` 인스턴스 기반 선택적 서버 tracing.
 
 ## 의존성
 
@@ -24,10 +25,13 @@ dependencies {
 
     // Prometheus scrape route를 사용할 때만 필요합니다.
     implementation("io.micrometer:micrometer-registry-prometheus")
+
+    // OpenTelemetry Ktor tracing helper를 사용할 때만 필요합니다.
+    implementation("io.opentelemetry.instrumentation:opentelemetry-ktor-3.0")
 }
 ```
 
-## 사용 예
+## Micrometer와 Prometheus 사용 예
 
 ```kotlin
 import io.bluetape4k.ktor.observability.Bluetape4kKtorObservabilityConfig
@@ -48,13 +52,43 @@ fun Application.module(registry: PrometheusMeterRegistry) {
 }
 ```
 
+## OpenTelemetry Tracing 사용 예
+
+Tracing은 명시적 opt-in입니다. OpenTelemetry SDK, exporter, propagator는
+애플리케이션에서 만들고, helper에는 완성된 `OpenTelemetry` 인스턴스만
+전달합니다.
+
+```kotlin
+import io.bluetape4k.ktor.observability.Bluetape4kKtorObservabilityConfig
+import io.bluetape4k.ktor.observability.KtorOpenTelemetryTracingConfig
+import io.bluetape4k.ktor.observability.installBluetape4kKtorObservability
+import io.ktor.server.application.Application
+import io.opentelemetry.api.OpenTelemetry
+
+fun Application.module(openTelemetry: OpenTelemetry) {
+    installBluetape4kKtorObservability(
+        Bluetape4kKtorObservabilityConfig(
+            tracing = KtorOpenTelemetryTracingConfig(
+                openTelemetry = openTelemetry,
+                captureSanitizedCorrelationId = true
+            )
+        )
+    )
+}
+```
+
+`captureSanitizedCorrelationId`는 sanitized `correlation.id` trace attribute만
+기록합니다. raw request header는 기록하지 않습니다. traced request에는 bounded
+`correlation.present` attribute가 기록됩니다.
+
 ## 의존성 정책
 
 이 모듈은 Ktor `CallId`, `CallLogging`, `MicrometerMetrics`를 명시적으로
 설치합니다. 실제 `MeterRegistry`, exporter, tracing backend는 애플리케이션이
-소유합니다. OpenTelemetry tracing은 이 모듈에서 기본 설치하지 않습니다.
-exporter 정책이 정해진 애플리케이션 또는 더 좁은 후속 모듈에서 tracing bridge를
-추가하세요.
+소유합니다. OpenTelemetry tracing은 기본 설치하지 않습니다.
+`opentelemetry-ktor-3.0` instrumentation dependency는 tracing helper를 사용할 때만
+추가하세요. 해당 instrumentation은 OpenTelemetry alpha BOM에서 versioned되므로,
+애플리케이션 소유 telemetry setup을 쉽게 교체할 수 있게 유지하세요.
 
 수신 correlation ID는 그대로 echo하지 않습니다. trim, safe character filtering,
 length cap을 거친 값만 MDC와 응답 헤더에 사용합니다.

--- a/ktor/observability/README.md
+++ b/ktor/observability/README.md
@@ -15,6 +15,7 @@ Ktor observability helpers for the bluetape4k ecosystem.
 - `CallLogging` MDC integration with query-string-free default log messages.
 - Micrometer `MicrometerMetrics` installation when an application supplies a `MeterRegistry`.
 - Optional Prometheus scrape route backed by an application-owned `PrometheusMeterRegistry`.
+- Optional OpenTelemetry server tracing backed by an application-owned `OpenTelemetry` instance.
 
 ## Dependency
 
@@ -24,10 +25,13 @@ dependencies {
 
     // Required only when Prometheus scrape routing is used.
     implementation("io.micrometer:micrometer-registry-prometheus")
+
+    // Required only when OpenTelemetry Ktor tracing helpers are used.
+    implementation("io.opentelemetry.instrumentation:opentelemetry-ktor-3.0")
 }
 ```
 
-## Usage
+## Micrometer and Prometheus Usage
 
 ```kotlin
 import io.bluetape4k.ktor.observability.Bluetape4kKtorObservabilityConfig
@@ -48,13 +52,43 @@ fun Application.module(registry: PrometheusMeterRegistry) {
 }
 ```
 
+## OpenTelemetry Tracing Usage
+
+Tracing is explicit and opt-in. Create the OpenTelemetry SDK, exporters, and
+propagators in the application, then pass the resulting `OpenTelemetry`
+instance to the helper.
+
+```kotlin
+import io.bluetape4k.ktor.observability.Bluetape4kKtorObservabilityConfig
+import io.bluetape4k.ktor.observability.KtorOpenTelemetryTracingConfig
+import io.bluetape4k.ktor.observability.installBluetape4kKtorObservability
+import io.ktor.server.application.Application
+import io.opentelemetry.api.OpenTelemetry
+
+fun Application.module(openTelemetry: OpenTelemetry) {
+    installBluetape4kKtorObservability(
+        Bluetape4kKtorObservabilityConfig(
+            tracing = KtorOpenTelemetryTracingConfig(
+                openTelemetry = openTelemetry,
+                captureSanitizedCorrelationId = true
+            )
+        )
+    )
+}
+```
+
+`captureSanitizedCorrelationId` records only the sanitized `correlation.id`
+trace attribute. It does not record the raw request header. A bounded
+`correlation.present` attribute is recorded on traced requests.
+
 ## Dependency Policy
 
 The module installs Ktor `CallId`, `CallLogging`, and `MicrometerMetrics`
 explicitly. Applications still own the actual `MeterRegistry`, exporters, and
-tracing backend. OpenTelemetry tracing is not installed by default in this
-module; add a tracing bridge in the application or a narrower future module when
-the exporter policy is known.
+tracing backend. OpenTelemetry tracing is not installed by default; add the
+`opentelemetry-ktor-3.0` instrumentation dependency only when tracing helpers
+are used. That instrumentation is versioned from the OpenTelemetry alpha BOM, so
+keep the application-owned telemetry setup easy to upgrade.
 
 Incoming correlation IDs are never echoed directly. They are trimmed, filtered
 to safe characters, capped, and only then added to MDC or response headers.

--- a/ktor/observability/build.gradle.kts
+++ b/ktor/observability/build.gradle.kts
@@ -9,9 +9,15 @@ dependencies {
     api(libs.ktor.server.call.logging)
     api(libs.ktor.server.metrics.micrometer)
     api(libs.micrometer.core)
+    api(libs.opentelemetry.api)
 
     compileOnly(libs.micrometer.registry.prometheus)
+    compileOnly(libs.opentelemetry.ktor)
     testImplementation(libs.micrometer.registry.prometheus)
+    testImplementation(libs.opentelemetry.ktor)
+    testImplementation(libs.opentelemetry.sdk)
+    testImplementation(libs.opentelemetry.sdk.testing)
+    testImplementation(libs.opentelemetry.sdk.trace)
 
     testImplementation(project(":bluetape4k-junit5"))
     testImplementation(libs.ktor.server.test.host)

--- a/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservability.kt
+++ b/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservability.kt
@@ -13,6 +13,7 @@ import io.ktor.server.plugins.calllogging.CallLogging
  * - Plugin installation is explicit and application-owned.
  * - Correlation IDs are sanitized before MDC or response propagation.
  * - Micrometer metrics are installed only when a [Bluetape4kKtorObservabilityConfig.meterRegistry] is provided.
+ * - OpenTelemetry tracing is installed only when a [Bluetape4kKtorObservabilityConfig.tracing] config is provided.
  *
  * ```kotlin
  * fun Application.module(registry: MeterRegistry) {
@@ -25,6 +26,8 @@ import io.ktor.server.plugins.calllogging.CallLogging
 fun Application.installBluetape4kKtorObservability(
     config: Bluetape4kKtorObservabilityConfig = Bluetape4kKtorObservabilityConfig(),
 ) {
+    config.tracing?.let(::installBluetape4kKtorOpenTelemetryTracing)
+
     if (config.installCorrelationId) {
         install(CallId) {
             bluetape4kCorrelationIds(config.correlationId)

--- a/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservabilityConfig.kt
+++ b/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservabilityConfig.kt
@@ -9,12 +9,14 @@ import io.micrometer.core.instrument.MeterRegistry
  * ## Contract
  * - CallId and CallLogging are enabled by default.
  * - Micrometer is enabled only when [meterRegistry] is supplied.
+ * - OpenTelemetry tracing is installed only when [tracing] is supplied.
  * - Prometheus export is provided by route helpers, not by this installer.
  */
 class Bluetape4kKtorObservabilityConfig(
     val correlationId: CorrelationIdSettings = CorrelationIdSettings(),
     val callLogging: CallLoggingSettings = CallLoggingSettings(correlationId = correlationId),
     val meterRegistry: MeterRegistry? = null,
+    val tracing: KtorOpenTelemetryTracingConfig? = null,
     val installCorrelationId: Boolean = true,
     val installCallLogging: Boolean = true,
     val installMicrometerMetrics: Boolean = meterRegistry != null,

--- a/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/KtorOpenTelemetryTracingConfig.kt
+++ b/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/KtorOpenTelemetryTracingConfig.kt
@@ -1,0 +1,17 @@
+package io.bluetape4k.ktor.observability
+
+import io.opentelemetry.api.OpenTelemetry
+
+/**
+ * Explicit opt-in configuration for Ktor OpenTelemetry server tracing.
+ *
+ * ## Contract
+ * - The application owns the [openTelemetry] instance, SDK, exporters, and backend.
+ * - This module does not register or mutate a global OpenTelemetry SDK.
+ * - Sanitized correlation IDs are captured only when [captureSanitizedCorrelationId] is enabled.
+ */
+class KtorOpenTelemetryTracingConfig(
+    val openTelemetry: OpenTelemetry,
+    val correlationId: CorrelationIdSettings = CorrelationIdSettings(),
+    val captureSanitizedCorrelationId: Boolean = false,
+)

--- a/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/KtorOpenTelemetryTracingSupport.kt
+++ b/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/KtorOpenTelemetryTracingSupport.kt
@@ -1,0 +1,43 @@
+package io.bluetape4k.ktor.observability
+
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.callid.callId
+import io.ktor.server.request.ApplicationRequest
+import io.opentelemetry.instrumentation.ktor.v3_0.KtorServerTelemetry
+
+/**
+ * Installs opt-in OpenTelemetry server tracing for Ktor.
+ *
+ * ## Contract
+ * - Delegates HTTP server span creation to OpenTelemetry's Ktor 3 instrumentation.
+ * - Uses the caller-provided [KtorOpenTelemetryTracingConfig.openTelemetry] instance.
+ * - Records `correlation.present` by default and records `correlation.id` only after sanitization and opt-in.
+ */
+fun Application.installBluetape4kKtorOpenTelemetryTracing(
+    config: KtorOpenTelemetryTracingConfig,
+) {
+    install(KtorServerTelemetry) {
+        setOpenTelemetry(config.openTelemetry)
+        attributesExtractor {
+            onStart {
+                val correlationId = request.sanitizedCorrelationId(config.correlationId)
+                attributes.put(CORRELATION_PRESENT_ATTRIBUTE, correlationId != null)
+                if (config.captureSanitizedCorrelationId && correlationId != null) {
+                    attributes.put(CORRELATION_ID_ATTRIBUTE, correlationId)
+                }
+            }
+        }
+    }
+}
+
+private const val CORRELATION_PRESENT_ATTRIBUTE: String = "correlation.present"
+private const val CORRELATION_ID_ATTRIBUTE: String = "correlation.id"
+
+private fun ApplicationRequest.sanitizedCorrelationId(
+    settings: CorrelationIdSettings,
+): String? =
+    KtorCorrelationId.sanitize(
+        rawValue = call.callId ?: headers[settings.requestHeaderName],
+        maxLength = settings.maxLength
+    )

--- a/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservabilityTest.kt
+++ b/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservabilityTest.kt
@@ -2,13 +2,23 @@ package io.bluetape4k.ktor.observability
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
+import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
@@ -18,6 +28,7 @@ import io.micrometer.prometheusmetrics.PrometheusConfig
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.TimeUnit
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class Bluetape4kKtorObservabilityTest {
@@ -49,6 +60,85 @@ class Bluetape4kKtorObservabilityTest {
 
         response.status shouldBeEqualTo HttpStatusCode.OK
         response.headers[HttpHeaders.XRequestId] shouldBeEqualTo "REQ_123-ABC"
+    }
+
+    @Test
+    fun `observability installer creates server span when tracing is configured`() = testTracing { tracing ->
+        testApplication {
+            application {
+                installBluetape4kKtorObservability(
+                    Bluetape4kKtorObservabilityConfig(
+                        tracing = KtorOpenTelemetryTracingConfig(
+                            openTelemetry = tracing.openTelemetry,
+                            captureSanitizedCorrelationId = true
+                        )
+                    )
+                )
+                routing {
+                    get("/ping") {
+                        call.respondText("pong")
+                    }
+                }
+            }
+
+            val response = client.get("/ping") {
+                header(HttpHeaders.XRequestId, "  REQ_123 Injected: raw  ")
+            }
+
+            response.status shouldBeEqualTo HttpStatusCode.OK
+            tracing.flush()
+
+            val spans = tracing.spanExporter.finishedSpanItems
+            spans shouldHaveSize 1
+            val span = spans[0]
+            span.kind shouldBeEqualTo SpanKind.SERVER
+            span.attributes[CORRELATION_PRESENT_KEY] shouldBeEqualTo true
+            span.attributes[CORRELATION_ID_KEY] shouldBeEqualTo "REQ_123Injectedraw"
+            span.attributes.asMap().keys.none { it.key.equals(HttpHeaders.Authorization, ignoreCase = true) }.shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `observability installer does not create spans when tracing is disabled`() = testTracing { tracing ->
+        testApplication {
+            application {
+                installBluetape4kKtorObservability()
+                routing {
+                    get("/ping") {
+                        call.respondText("pong")
+                    }
+                }
+            }
+
+            client.get("/ping").status shouldBeEqualTo HttpStatusCode.OK
+            tracing.flush()
+
+            tracing.spanExporter.finishedSpanItems shouldHaveSize 0
+        }
+    }
+
+    @Test
+    fun `open telemetry tracing records error request spans`() = testTracing { tracing ->
+        testApplication {
+            application {
+                installBluetape4kKtorOpenTelemetryTracing(
+                    KtorOpenTelemetryTracingConfig(openTelemetry = tracing.openTelemetry)
+                )
+                routing {
+                    get("/failed") {
+                        call.respond(HttpStatusCode.InternalServerError)
+                    }
+                }
+            }
+
+            client.get("/failed").status shouldBeEqualTo HttpStatusCode.InternalServerError
+            tracing.flush()
+
+            val spans = tracing.spanExporter.finishedSpanItems
+            spans shouldHaveSize 1
+            spans[0].kind shouldBeEqualTo SpanKind.SERVER
+            spans[0].status.statusCode shouldBeEqualTo StatusCode.ERROR
+        }
     }
 
     @Test
@@ -113,5 +203,32 @@ class Bluetape4kKtorObservabilityTest {
 
         response.status shouldBeEqualTo HttpStatusCode.OK
         response.bodyAsText().contains("demo_requests_total") shouldBeEqualTo true
+    }
+
+    private class TestTracing: AutoCloseable {
+        val spanExporter: InMemorySpanExporter = InMemorySpanExporter.create()
+        private val tracerProvider: SdkTracerProvider = SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+            .build()
+        val openTelemetry: OpenTelemetrySdk = OpenTelemetrySdk.builder()
+            .setTracerProvider(tracerProvider)
+            .build()
+
+        fun flush() {
+            tracerProvider.forceFlush().join(1, TimeUnit.SECONDS)
+        }
+
+        override fun close() {
+            tracerProvider.close()
+        }
+    }
+
+    private inline fun testTracing(block: (TestTracing) -> Unit) {
+        TestTracing().use(block)
+    }
+
+    companion object {
+        private val CORRELATION_PRESENT_KEY: AttributeKey<Boolean> = AttributeKey.booleanKey("correlation.present")
+        private val CORRELATION_ID_KEY: AttributeKey<String> = AttributeKey.stringKey("correlation.id")
     }
 }


### PR DESCRIPTION
## Summary

Closes #691

- PR 제목: feat(ktor): add opt-in OpenTelemetry tracing

Closes #691.

This PR adds explicit, opt-in OpenTelemetry server tracing support to
`bluetape4k-ktor-observability` while preserving application-owned registry,
SDK, exporter, and backend policy.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Adds `KtorOpenTelemetryTracingConfig` and
  `installBluetape4kKtorOpenTelemetryTracing`.
- Lets `installBluetape4kKtorObservability` install tracing only when a tracing
  config is supplied.
- Reuses `KtorCorrelationId.sanitize()` before adding trace correlation
  attributes.
- Keeps `opentelemetry-ktor-3.0` as a tracing-only optional dependency for
  applications.
- Expands tests with in-memory OpenTelemetry spans for normal, error, disabled,
  and sanitized-correlation cases.
- Updates English and Korean README files and records review/lesson artifacts.

### 기존 섹션: Risk

`opentelemetry-ktor-3.0` is versioned from the OpenTelemetry alpha
instrumentation BOM. The helper keeps it optional and covered by in-memory span
tests to make future API drift visible.

## Validation

- `./gradlew :bluetape4k-ktor-observability:compileKotlin`
- `./gradlew :bluetape4k-ktor-observability:compileTestKotlin`
- `./gradlew :bluetape4k-ktor-observability:test` - 9 tests passing
- `git diff --check`
- Sensitive-header scan: no helper-side header capture API usage found.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #691, milestone `1.11.0`, assignee `debop`
- PR: #722, head `e1650c4793f7a9ef20567c31108358ef42652b68`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `feat/issue-691-ktor-opentelemetry-tracing`
- Labels: `enhancement`, `infra/io`
- State: `MERGED`, merge commit `038a1f37d01104c5e5aa3b05317b7f61f499edc4`
- CI: This PR adds explicit, opt-in OpenTelemetry server tracing support to / - Adds `KtorOpenTelemetryTracingConfig` and / `installBluetape4kKtorOpenTelemetryTracing`.

## DoD Status

| Step | Status | Evidence |
|---|---|---|
| Worktree | PASS | `.worktrees/feat-issue-691-ktor-opentelemetry-tracing` from `origin/develop` |
| Implementation | PASS | Added opt-in Ktor OpenTelemetry tracing helper and baseline installer hook |
| Tests | PASS | `:bluetape4k-ktor-observability:test` - 9 tests passing |
| Docs | PASS | `ktor/observability/README.md` and `README.ko.md` updated |
| Review | PASS | `docs/review/2026-06-06-issue-691-ktor-opentelemetry-tracing-review.md`, P0=0, P1=0 |
| Lessons | PASS | `docs/lessons/2026-06-06-issue-691-ktor-opentelemetry-tracing.md` |
| Diff hygiene | PASS | `git diff --check` |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #722 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `038a1f37d01104c5e5aa3b05317b7f61f499edc4`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
