### PR TITLE
feat: add Spring Boot observability helpers

### DIFF
--- a/docs/lessons/2026-06-06-issue-694-spring-observability-helpers.md
+++ b/docs/lessons/2026-06-06-issue-694-spring-observability-helpers.md
@@ -1,0 +1,31 @@
+# Issue #694 Spring Observability Helpers
+
+## Context
+
+The Spring Boot 4 observability work needed helper APIs for service, HTTP
+handler, and event handler code while preserving Spring Boot Actuator and
+Micrometer ownership of metrics, tracing, exporters, and endpoints.
+
+## Decision
+
+Add narrow `ObservationRegistry` helpers in `spring-boot/core` instead of
+auto-configuring exporters or custom endpoints. Treat Prometheus and OTLP as
+application configuration concerns documented in README examples.
+
+## Outcome
+
+`observeSpring` and `observeSpringSuspending` now manage observation lifecycle,
+exception recording, cancellation propagation, and coroutine scope cleanup.
+README files also now reflect Spring Boot 4's Jackson 3 default.
+
+## Verification
+
+- `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.observability.SpringObservationSupportTest'`
+- `./gradlew :bluetape4k-spring-boot-core:test`
+- `git diff --check`
+
+## Future Guard
+
+For Spring Boot observability helpers, accept framework-owned objects such as
+`ObservationRegistry` and document backend properties. Do not instantiate
+OpenTelemetry SDKs, tracing exporters, or Prometheus endpoints in the library.

--- a/docs/review/2026-06-06-issue-694-spring-observability-helpers-review.md
+++ b/docs/review/2026-06-06-issue-694-spring-observability-helpers-review.md
@@ -1,0 +1,42 @@
+# Issue #694 Spring Observability Helpers Review
+
+Date: 2026-06-06
+Scope: `spring-boot/core`
+
+## Verdict
+
+PASS
+
+- P0: 0
+- P1: 0
+
+## Findings
+
+No blocking findings.
+
+## Evidence
+
+- Added `ObservationRegistry.observeSpring` and
+  `ObservationRegistry.observeSpringSuspending` helpers that use the
+  application-owned `ObservationRegistry`.
+- Key values are grouped with `SpringObservationKeyValues` so bounded
+  low-cardinality labels stay separate from trace-oriented high-cardinality
+  values.
+- The helpers do not register Prometheus endpoints, create exporters, or mutate
+  global OpenTelemetry SDK state.
+- Spring Boot core README files now document Prometheus through Actuator and
+  OTLP tracing through application-owned Spring Boot properties.
+- The stale Spring Boot 4 / Jackson 2 README statements were corrected to
+  Jackson 3 by default.
+
+## Validation
+
+- `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.observability.SpringObservationSupportTest'`
+- `./gradlew :bluetape4k-spring-boot-core:test`
+- `git diff --check`
+
+## Residual Risk
+
+`micrometer-observation` and context propagation remain `compileOnly` in the
+library module. Applications must bring the usual Spring Boot Actuator and
+Micrometer runtime dependencies when using these helpers.

--- a/spring-boot/core/README.ko.md
+++ b/spring-boot/core/README.ko.md
@@ -26,14 +26,21 @@ Spring Boot 4.x 기반 공통 기능 통합 모듈입니다.
 
 - `RestClient` 코루틴 확장 (`suspendGet`, `suspendPost`, `suspendPut`, `suspendPatch`, `suspendDelete`)
 
-### Jackson 2 커스터마이저
+### Spring Boot Observability 헬퍼
+
+- 서비스, HTTP 핸들러, 이벤트 핸들러 코드 경로를 위한 `ObservationRegistry.observeSpring`
+- 코루틴 Observation scope 전파와 정리를 위한 `ObservationRegistry.observeSpringSuspending`
+- `SpringObservationKeyValues`를 통한 Micrometer low-cardinality/high-cardinality key value 그룹화
+- Prometheus와 OpenTelemetry export는 애플리케이션 소유의 Spring Boot Actuator 설정으로 유지
+
+### Jackson 3 커스터마이저
 
 - `jacksonObjectMapperBuilderCustomizer` DSL
 - KotlinModule, JsonUuidModule 자동 등록
 - 직렬화/역직렬화 기본 설정 제공
 
-> **주의**: Spring Boot 4는 내부적으로 Jackson 2(`com.fasterxml.jackson.*`)를 사용합니다.
-> Jackson 3은 지원되지 않습니다.
+> **주의**: Spring Boot 4는 Jackson 3을 기본으로 사용합니다. Jackson 2 지원은 마이그레이션 용도이며,
+> 새로운 Spring Boot 4 코드에서는 사용하지 않는 것을 권장합니다.
 
 ### Retrofit2 통합
 
@@ -168,6 +175,81 @@ class JacksonConfig {
 }
 ```
 
+### 서비스, HTTP 핸들러, 이벤트 코드 관측
+
+Spring Boot가 애플리케이션에 주입한 `ObservationRegistry`를 사용합니다. 이 헬퍼는 Micrometer Observation
+라이프사이클과 코루틴 scope 정리만 담당하며 exporter를 설치하거나 전역 OpenTelemetry SDK 상태를 바꾸지 않습니다.
+
+```kotlin
+import io.bluetape4k.spring.observability.SpringObservationKeyValues
+import io.bluetape4k.spring.observability.observeSpring
+import io.bluetape4k.spring.observability.observeSpringSuspending
+import io.micrometer.common.KeyValue
+import io.micrometer.common.KeyValues
+import io.micrometer.observation.ObservationRegistry
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.bodyValueAndAwait
+
+class OrderService(
+    private val observationRegistry: ObservationRegistry,
+) {
+    fun load(orderId: String): Order =
+        observationRegistry.observeSpring(
+            name = "order.service.load",
+            keyValues = SpringObservationKeyValues(
+                lowCardinality = KeyValues.of(KeyValue.of("component", "order-service")),
+            ),
+        ) { context ->
+            context.addLowCardinalityKeyValue(KeyValue.of("outcome", "success"))
+            repository.find(orderId)
+        }
+
+    suspend fun handleCreated(event: OrderCreated): Unit =
+        observationRegistry.observeSpringSuspending("order.events.consume") { context ->
+            context.addLowCardinalityKeyValue(KeyValue.of("event.name", "order.created"))
+            eventHandler.handle(event)
+        }
+}
+
+class OrderHandler(
+    private val observationRegistry: ObservationRegistry,
+    private val orderService: OrderService,
+) {
+    suspend fun get(request: ServerRequest): ServerResponse =
+        observationRegistry.observeSpringSuspending("order.http.get") { context ->
+            context.addLowCardinalityKeyValue(KeyValue.of("http.route", "/orders/{id}"))
+            val order = orderService.load(request.pathVariable("id"))
+            ServerResponse.ok().bodyValueAndAwait(order)
+        }
+}
+```
+
+Prometheus는 custom endpoint를 만들지 않고 Spring Boot Actuator endpoint로 노출합니다.
+
+```yaml
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    prometheus:
+      access: read_only
+```
+
+Tracing/export backend는 애플리케이션이 소유한 Spring Boot와 Micrometer Tracing 설정으로 연결합니다.
+
+```yaml
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+  otlp:
+    tracing:
+      endpoint: http://localhost:4318/v1/traces
+```
+
 ### WebTestClient 테스트
 
 ```kotlin
@@ -191,7 +273,8 @@ class UserControllerTest(@Autowired val client: WebTestClient) {
 | `spring-boot-starter-webflux` | `api`         | WebFlux + Coroutines 필수 |
 | `bluetape4k-retrofit2`        | `api`         | Retrofit2 통합            |
 | `bluetape4k-coroutines`       | `api`         | Coroutines 지원           |
-| `bluetape4k-jackson2`         | `compileOnly` | Jackson 2 지원            |
+| `bluetape4k-jackson3`         | `compileOnly` | Jackson 3 지원            |
+| `micrometer-observation`      | `compileOnly` | Observation 헬퍼 지원      |
 | `spring-boot-starter-web`     | `compileOnly` | 선택적 서블릿 지원              |
 | `resilience4j-*`              | `compileOnly` | 선택적 Resilience4j        |
 

--- a/spring-boot/core/README.md
+++ b/spring-boot/core/README.md
@@ -26,13 +26,21 @@ A unified module providing common features for Spring Boot 4.x applications.
 
 - `RestClient` coroutine extensions (`suspendGet`, `suspendPost`, `suspendPut`, `suspendPatch`, `suspendDelete`)
 
-### Jackson 2 Customizer
+### Spring Boot Observability Helpers
+
+- `ObservationRegistry.observeSpring` for service, HTTP handler, and event handler code paths
+- `ObservationRegistry.observeSpringSuspending` for coroutine-aware observation scope propagation
+- Low-cardinality and high-cardinality Micrometer key value grouping through `SpringObservationKeyValues`
+- Prometheus and OpenTelemetry export remain application-owned Spring Boot Actuator configuration
+
+### Jackson 3 Customizer
 
 - `jacksonObjectMapperBuilderCustomizer` DSL
 - Auto-registration of KotlinModule and JsonUuidModule
 - Default serialization/deserialization configuration
 
-> **Note**: Spring Boot 4 uses Jackson 2 (`com.fasterxml.jackson.*`) internally. Jackson 3 is not supported.
+> **Note**: Spring Boot 4 uses Jackson 3 by default. Jackson 2 support is for migration only and should not be
+> used for new Spring Boot 4 code.
 
 ### Retrofit2 Integration
 
@@ -167,6 +175,81 @@ class JacksonConfig {
 }
 ```
 
+### Observing Service, HTTP Handler, and Event Code
+
+Use the `ObservationRegistry` that Spring Boot wires for the application. The helpers only manage Micrometer
+Observation lifecycle and coroutine scope cleanup; they do not install exporters or mutate global OpenTelemetry SDK state.
+
+```kotlin
+import io.bluetape4k.spring.observability.SpringObservationKeyValues
+import io.bluetape4k.spring.observability.observeSpring
+import io.bluetape4k.spring.observability.observeSpringSuspending
+import io.micrometer.common.KeyValue
+import io.micrometer.common.KeyValues
+import io.micrometer.observation.ObservationRegistry
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.bodyValueAndAwait
+
+class OrderService(
+    private val observationRegistry: ObservationRegistry,
+) {
+    fun load(orderId: String): Order =
+        observationRegistry.observeSpring(
+            name = "order.service.load",
+            keyValues = SpringObservationKeyValues(
+                lowCardinality = KeyValues.of(KeyValue.of("component", "order-service")),
+            ),
+        ) { context ->
+            context.addLowCardinalityKeyValue(KeyValue.of("outcome", "success"))
+            repository.find(orderId)
+        }
+
+    suspend fun handleCreated(event: OrderCreated): Unit =
+        observationRegistry.observeSpringSuspending("order.events.consume") { context ->
+            context.addLowCardinalityKeyValue(KeyValue.of("event.name", "order.created"))
+            eventHandler.handle(event)
+        }
+}
+
+class OrderHandler(
+    private val observationRegistry: ObservationRegistry,
+    private val orderService: OrderService,
+) {
+    suspend fun get(request: ServerRequest): ServerResponse =
+        observationRegistry.observeSpringSuspending("order.http.get") { context ->
+            context.addLowCardinalityKeyValue(KeyValue.of("http.route", "/orders/{id}"))
+            val order = orderService.load(request.pathVariable("id"))
+            ServerResponse.ok().bodyValueAndAwait(order)
+        }
+}
+```
+
+Expose Prometheus through Spring Boot Actuator instead of registering a custom endpoint:
+
+```yaml
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    prometheus:
+      access: read_only
+```
+
+Configure tracing/export backends with Spring Boot and Micrometer Tracing properties owned by the application:
+
+```yaml
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+  otlp:
+    tracing:
+      endpoint: http://localhost:4318/v1/traces
+```
+
 ### WebTestClient Test
 
 ```kotlin
@@ -190,7 +273,8 @@ class UserControllerTest(@Autowired val client: WebTestClient) {
 | `spring-boot-starter-webflux` | `api`         | Required for WebFlux + Coroutines |
 | `bluetape4k-retrofit2`        | `api`         | Retrofit2 integration             |
 | `bluetape4k-coroutines`       | `api`         | Coroutines support                |
-| `bluetape4k-jackson2`         | `compileOnly` | Jackson 2 support                 |
+| `bluetape4k-jackson3`         | `compileOnly` | Jackson 3 support                 |
+| `micrometer-observation`      | `compileOnly` | Observation helper support        |
 | `spring-boot-starter-web`     | `compileOnly` | Optional servlet support          |
 | `resilience4j-*`              | `compileOnly` | Optional Resilience4j             |
 

--- a/spring-boot/core/build.gradle.kts
+++ b/spring-boot/core/build.gradle.kts
@@ -64,7 +64,11 @@ dependencies {
     compileOnly(libs.resilience4j.reactor)
 
     compileOnly(libs.micrometer.core)
+    compileOnly(libs.micrometer.observation)
+    compileOnly(libs.micrometer.context.propagation)
     testImplementation(libs.micrometer.core)
+    testImplementation(libs.micrometer.observation)
+    testImplementation(libs.micrometer.observation.test)
     testImplementation(libs.micrometer.registry.prometheus)
 
     compileOnly(libs.hibernate.validator)

--- a/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/observability/SpringObservationSupport.kt
+++ b/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/observability/SpringObservationSupport.kt
@@ -1,0 +1,161 @@
+package io.bluetape4k.spring.observability
+
+import io.bluetape4k.support.requireNotBlank
+import io.micrometer.common.KeyValue
+import io.micrometer.common.KeyValues
+import io.micrometer.observation.Observation
+import io.micrometer.observation.ObservationRegistry
+import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ThreadContextElement
+import kotlinx.coroutines.reactor.ReactorContext
+import kotlinx.coroutines.reactor.asCoroutineContext
+import kotlinx.coroutines.withContext
+import reactor.util.context.Context
+import java.io.Serializable
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
+
+/**
+ * Micrometer key values applied when a Spring Boot observation is created.
+ *
+ * ## Contract
+ * - [lowCardinality] is suitable for metrics labels and bounded dimensions such as `component` or `outcome`.
+ * - [highCardinality] is reserved for trace-only dimensions such as sanitized identifiers.
+ * - No exporter, OpenTelemetry SDK, or Prometheus endpoint is configured by this value object.
+ *
+ * ```kotlin
+ * val keyValues = SpringObservationKeyValues(
+ *     lowCardinality = KeyValues.of(KeyValue.of("component", "order-service")),
+ * )
+ * ```
+ */
+class SpringObservationKeyValues(
+    val lowCardinality: KeyValues = KeyValues.empty(),
+    val highCardinality: KeyValues = KeyValues.empty(),
+): Serializable {
+
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * Observe a Spring Boot service block with the application-owned [ObservationRegistry].
+ *
+ * ## Contract
+ * - The observation is created from [registry][ObservationRegistry] and never mutates global OpenTelemetry state.
+ * - The observation starts before [block] and stops after [block], including failure paths.
+ * - [CancellationException] is rethrown without being recorded as an observation error.
+ * - Non-cancellation exceptions are recorded on the observation and rethrown.
+ *
+ * ```kotlin
+ * val result = observationRegistry.observeSpring(
+ *     name = "order.service.load",
+ *     keyValues = SpringObservationKeyValues(
+ *         lowCardinality = KeyValues.of(KeyValue.of("component", "order-service")),
+ *     ),
+ * ) { context ->
+ *     context.addLowCardinalityKeyValue(KeyValue.of("outcome", "success"))
+ *     orderService.load(orderId)
+ * }
+ * ```
+ */
+fun <T> ObservationRegistry.observeSpring(
+    name: String,
+    keyValues: SpringObservationKeyValues = SpringObservationKeyValues(),
+    block: (Observation.Context) -> T,
+): T {
+    name.requireNotBlank("name")
+
+    val observation = Observation
+        .createNotStarted(name, this)
+        .applySpringKeyValues(keyValues)
+
+    observation.start()
+    return try {
+        observation.openScope().use {
+            block(observation.context)
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        observation.error(e)
+        throw e
+    } finally {
+        observation.stop()
+    }
+}
+
+/**
+ * Observe a suspend Spring Boot block with the application-owned [ObservationRegistry].
+ *
+ * ## Contract
+ * - The observation is bound to Reactor and coroutine context so child suspensions can read the current observation.
+ * - [CancellationException] is rethrown without being recorded as an observation error.
+ * - Non-cancellation exceptions are recorded on the observation and rethrown.
+ *
+ * ```kotlin
+ * val result = observationRegistry.observeSpringSuspending("order.handler") { context ->
+ *     context.addLowCardinalityKeyValue(KeyValue.of("handler", "get-order"))
+ *     orderService.load(orderId)
+ * }
+ * ```
+ */
+suspend fun <T> ObservationRegistry.observeSpringSuspending(
+    name: String,
+    keyValues: SpringObservationKeyValues = SpringObservationKeyValues(),
+    block: suspend (Observation.Context) -> T,
+): T {
+    name.requireNotBlank("name")
+
+    val observation = Observation
+        .createNotStarted(name, this)
+        .applySpringKeyValues(keyValues)
+
+    observation.start()
+    return try {
+        withContext(observation.asSpringCoroutineObservationContext()) {
+            block(observation.context)
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        observation.error(e)
+        throw e
+    } finally {
+        observation.stop()
+    }
+}
+
+private fun Observation.applySpringKeyValues(keyValues: SpringObservationKeyValues): Observation =
+    apply {
+        keyValues.lowCardinality.forEach { keyValue: KeyValue ->
+            lowCardinalityKeyValue(keyValue)
+        }
+        keyValues.highCardinality.forEach { keyValue: KeyValue ->
+            highCardinalityKeyValue(keyValue)
+        }
+    }
+
+private class SpringObservationScopeContextElement(
+    private val observation: Observation,
+): ThreadContextElement<Observation.Scope>, AbstractCoroutineContextElement(Key) {
+
+    companion object Key: CoroutineContext.Key<SpringObservationScopeContextElement>
+
+    override fun updateThreadContext(context: CoroutineContext): Observation.Scope =
+        observation.openScope()
+
+    override fun restoreThreadContext(context: CoroutineContext, oldState: Observation.Scope) {
+        oldState.close()
+    }
+}
+
+private suspend fun Observation.asSpringCoroutineObservationContext(): CoroutineContext {
+    val reactorContext = (coroutineContext[ReactorContext]?.context ?: Context.empty())
+        .put(ObservationThreadLocalAccessor.KEY, this)
+
+    return reactorContext.asCoroutineContext() + SpringObservationScopeContextElement(this)
+}

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/observability/SpringObservationSupportTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/observability/SpringObservationSupportTest.kt
@@ -1,0 +1,146 @@
+package io.bluetape4k.spring.observability
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.micrometer.common.KeyValue
+import io.micrometer.common.KeyValues
+import io.micrometer.observation.Observation
+import io.micrometer.observation.ObservationHandler
+import io.micrometer.observation.ObservationRegistry
+import io.micrometer.observation.tck.ObservationRegistryAssert
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.junit.jupiter.api.Test
+
+class SpringObservationSupportTest {
+
+    private fun registry(handler: RecordingObservationHandler): ObservationRegistry =
+        ObservationRegistry.create().apply {
+            observationConfig().observationHandler(handler)
+        }
+
+    private class RecordingObservationHandler: ObservationHandler<Observation.Context> {
+        var started = 0
+        var stopped = 0
+        var errors = 0
+        var lastContext: Observation.Context? = null
+
+        override fun onStart(context: Observation.Context) {
+            started++
+            lastContext = context
+        }
+
+        override fun onStop(context: Observation.Context) {
+            stopped++
+            lastContext = context
+        }
+
+        override fun onError(context: Observation.Context) {
+            errors++
+            lastContext = context
+        }
+
+        override fun supportsContext(context: Observation.Context): Boolean = true
+    }
+
+    @Test
+    fun `observeSpring starts stops and applies key values`() {
+        val handler = RecordingObservationHandler()
+        val registry = registry(handler)
+
+        val result =
+            registry.observeSpring(
+                name = "spring.service.load",
+                keyValues = SpringObservationKeyValues(
+                    lowCardinality = KeyValues.of(KeyValue.of("component", "order-service")),
+                    highCardinality = KeyValues.of(KeyValue.of("correlation.id", "safe-id")),
+                ),
+            ) { context ->
+                context.addLowCardinalityKeyValue(KeyValue.of("outcome", "success"))
+                "ok"
+            }
+
+        result shouldBeEqualTo "ok"
+        handler.started shouldBeEqualTo 1
+        handler.stopped shouldBeEqualTo 1
+        handler.errors shouldBeEqualTo 0
+        handler.lastContext?.getLowCardinalityKeyValue("component")?.value shouldBeEqualTo "order-service"
+        handler.lastContext?.getLowCardinalityKeyValue("outcome")?.value shouldBeEqualTo "success"
+        handler.lastContext?.getHighCardinalityKeyValue("correlation.id")?.value shouldBeEqualTo "safe-id"
+    }
+
+    @Test
+    fun `observeSpring records exception and stops observation`() {
+        val handler = RecordingObservationHandler()
+        val registry = registry(handler)
+
+        assertFailsWith<IllegalStateException> {
+            registry.observeSpring("spring.service.error") {
+                throw IllegalStateException("boom")
+            }
+        }
+
+        handler.started shouldBeEqualTo 1
+        handler.errors shouldBeEqualTo 1
+        handler.stopped shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `observeSpring rethrows cancellation without recording error`() {
+        val handler = RecordingObservationHandler()
+        val registry = registry(handler)
+
+        assertFailsWith<CancellationException> {
+            registry.observeSpring("spring.service.cancel") {
+                throw CancellationException("cancel")
+            }
+        }
+
+        handler.started shouldBeEqualTo 1
+        handler.errors shouldBeEqualTo 0
+        handler.stopped shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `observeSpringSuspending binds and cleans current observation`() = runTest {
+        val handler = RecordingObservationHandler()
+        val registry = registry(handler)
+
+        val result =
+            registry.observeSpringSuspending("spring.handler.suspend") { context ->
+                registry.currentObservation?.context?.name shouldBeEqualTo "spring.handler.suspend"
+                context.name
+            }
+
+        result shouldBeEqualTo "spring.handler.suspend"
+        yield()
+
+        handler.started shouldBeEqualTo 1
+        handler.stopped shouldBeEqualTo 1
+        handler.errors shouldBeEqualTo 0
+        ObservationRegistryAssert.assertThat(registry)
+            .doesNotHaveAnyRemainingCurrentObservation()
+    }
+
+    @Test
+    fun `observeSpringSuspending rethrows cancellation without recording error`() = runTest {
+        val handler = RecordingObservationHandler()
+        val registry = registry(handler)
+        val cancellation = CancellationException("cancel")
+
+        val thrown =
+            assertFailsWith<CancellationException> {
+                registry.observeSpringSuspending("spring.handler.cancel") {
+                    throw cancellation
+                }
+            }
+
+        thrown.message shouldBeEqualTo "cancel"
+        handler.started shouldBeEqualTo 1
+        handler.errors shouldBeEqualTo 0
+        handler.stopped shouldBeEqualTo 1
+        registry.currentObservation.shouldBeNull()
+    }
+}


### PR DESCRIPTION
## Summary

Closes #694

- PR 제목: feat: add Spring Boot observability helpers

Closes #694.

- Add Spring Boot 4 `ObservationRegistry.observeSpring` and `observeSpringSuspending` helpers for service, HTTP handler, and event handler code paths.
- Keep Prometheus and OTLP/tracing backend setup application-owned through Spring Boot Actuator and Micrometer configuration.
- Correct Spring Boot core README guidance to Jackson 3 by default, with Jackson 2 treated as migration-only.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Notes

- `micrometer-observation` and context propagation stay `compileOnly`; applications should bring the normal Spring Boot Actuator/Micrometer runtime dependencies.
- IDE diagnostics were not available in this Codex session; Gradle compile/test verification passed.

## Validation

- `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.observability.SpringObservationSupportTest'`
- `./gradlew :bluetape4k-spring-boot-core:test`
- `git diff --check`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #694, milestone `1.11.0`, assignee `debop`
- PR: #726, head `5e2ea906df4335c0dfc5a3e016eb4e55b6b3e510`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `feat/issue-694-spring-observability-helpers`
- Labels: `documentation`, `enhancement`
- State: `MERGED`, merge commit `c8249433b300f5a094d7ca33533c0e73146f23bb`
- CI: - Keep Prometheus and OTLP/tracing backend setup application-owned through Spring Boot Actuator and Micrometer configuration. / - `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.observability.SpringObservationSupportTest'` / - `./gradlew :bluetape4k-spring-boot-core:test`

## DoD Status

- [x] Helper APIs cover sync and suspend `ObservationRegistry` usage.
- [x] Lifecycle, exception, cancellation, and coroutine cleanup behavior is tested.
- [x] Prometheus is documented through Actuator, not a custom endpoint.
- [x] OTLP tracing is documented as application-owned Spring Boot configuration.
- [x] English and Korean README files are updated.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #726 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `c8249433b300f5a094d7ca33533c0e73146f23bb`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
