### PR TITLE
docs: align Central publish task guidance

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -79,7 +79,7 @@ jobs:
           PY
 
       - name: Publish SNAPSHOT
-        run: ./gradlew publishAggregationToCentralSnapshots -PsnapshotVersion=-SNAPSHOT --no-daemon --no-configuration-cache --no-build-cache
+        run: ./gradlew nmcpPublishAggregationToCentralPortalSnapshots -PsnapshotVersion=-SNAPSHOT --no-daemon --no-configuration-cache --no-build-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,7 +212,7 @@ jobs:
 
       - name: Publish to Central Portal
         run: >
-          ./gradlew publishAggregationToCentralPortal
+          ./gradlew nmcpPublishAggregationToCentralPortal
           --no-daemon
           --no-configuration-cache
           --no-build-cache

--- a/README.ko.md
+++ b/README.ko.md
@@ -316,7 +316,7 @@ Jib으로 Mock Server Docker 이미지를 다시 빌드할 때는 Gradle configu
 
 ```properties
 projectGroup=io.github.bluetape4k
-baseVersion=1.9.1
+baseVersion=1.11.0
 snapshotVersion=
 ```
 
@@ -324,13 +324,13 @@ snapshotVersion=
 
 ```bash
 # 기본 병렬도(centralSnapshotsParallelism=8)로 SNAPSHOT 배포
-./gradlew publishAggregationToCentralSnapshots -PsnapshotVersion=-SNAPSHOT
+./gradlew nmcpPublishAggregationToCentralPortalSnapshots -PsnapshotVersion=-SNAPSHOT
 
 # 병렬도를 낮춰 서버 부담을 줄이고 싶을 때
-./gradlew -PcentralSnapshotsParallelism=4 publishAggregationToCentralSnapshots -PsnapshotVersion=-SNAPSHOT
+./gradlew -PcentralSnapshotsParallelism=4 nmcpPublishAggregationToCentralPortalSnapshots -PsnapshotVersion=-SNAPSHOT
 ```
 
-- 루트 집계 task는 `publishAggregationToCentralSnapshots` 입니다.
+- 루트 집계 task는 `nmcpPublishAggregationToCentralPortalSnapshots` 입니다.
 - SNAPSHOT 배포는 release 와 달리 ZIP 1회 업로드가 아니라 file-by-file 업로드를 수행합니다.
 - 따라서 모듈 수가 많을수록 `PUT` 요청이 많이 발생하는 것이 정상입니다.
 - 업로드 대상은 `workshop/**`, `examples/**`, `-demo` 모듈을 제외한 publishable modules 입니다.
@@ -341,10 +341,10 @@ snapshotVersion=
 
 ```bash
 # snapshotVersion이 비어 있는 커밋에서 RELEASE 배포
-./gradlew publishAggregationToCentralPortal --no-daemon --no-configuration-cache
+./gradlew nmcpPublishAggregationToCentralPortal --no-daemon --no-configuration-cache
 ```
 
-- 루트 집계 task는 `publishAggregationToCentralPortal` 입니다.
+- 루트 집계 task는 `nmcpPublishAggregationToCentralPortal` 입니다.
 - RELEASE 배포는 NMCP aggregation ZIP 을 만들어 Central Portal Publisher API 로 업로드합니다.
 - SNAPSHOT과 달리 artifact 파일들을 개별 `PUT` 하지 않으므로 요청 수가 훨씬 적습니다.
 - 업로드 대상은 `workshop/**`, `examples/**`, `-demo` 모듈을 제외한 publishable modules 입니다.
@@ -373,9 +373,8 @@ centralSnapshotsParallelism=8
 
 ### 참고
 
-- 기존 `publishAggregationToCentralPortalSnapshots` 는 deprecated alias 이며,
-  `publishAggregationToCentralSnapshots` 사용을 권장합니다.
-- `publishAllPublicationsToCentralPortalSnapshots` / `publishAllPublicationsToCentralSnapshots` 같은 개별 task 직접 실행 대신 루트 집계 task 사용을 권장합니다.
+- `publishAggregationToCentralSnapshots`, `publishAggregationToCentralPortal`, `publishAggregationToCentralPortalSnapshots` 같은 하위 호환 task가 `./gradlew tasks`에 남아 있을 수 있지만, 위의 `nmcpPublishAggregation*` 루트 task 사용을 권장합니다.
+- `nmcpPublishAllPublicationsToCentralPortalSnapshots`, `publishAllPublicationsToCentralPortalSnapshots`, `publishAllPublicationsToCentralSnapshots` 같은 개별 task 직접 실행 대신 루트 집계 task 사용을 권장합니다.
 - SNAPSHOT이 느리거나 요청이 과도해 보이면 `centralSnapshotsParallelism` 값을 `4`, `8`, `12` 정도 범위에서 조절해 보세요.
 - RELEASE는 aggregation ZIP 업로드 경로를 사용하므로 SNAPSHOT과 동작 방식이 다릅니다.
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Check `gradle.properties` for the current version:
 
 ```properties
 projectGroup=io.github.bluetape4k
-baseVersion=1.9.2
+baseVersion=1.11.0
 snapshotVersion=
 ```
 
@@ -323,13 +323,13 @@ snapshotVersion=
 
 ```bash
 # Publish a SNAPSHOT with default parallelism (centralSnapshotsParallelism=8)
-./gradlew publishAggregationToCentralSnapshots -PsnapshotVersion=-SNAPSHOT
+./gradlew nmcpPublishAggregationToCentralPortalSnapshots -PsnapshotVersion=-SNAPSHOT
 
 # Reduce parallelism to lower server load
-./gradlew -PcentralSnapshotsParallelism=4 publishAggregationToCentralSnapshots -PsnapshotVersion=-SNAPSHOT
+./gradlew -PcentralSnapshotsParallelism=4 nmcpPublishAggregationToCentralPortalSnapshots -PsnapshotVersion=-SNAPSHOT
 ```
 
-- The root aggregation task is `publishAggregationToCentralSnapshots`.
+- The root aggregation task is `nmcpPublishAggregationToCentralPortalSnapshots`.
 - Unlike a RELEASE, SNAPSHOTs are uploaded file-by-file (not as a single ZIP), so many `PUT` requests are expected for large module counts.
 - Publishable targets exclude `workshop/**`, `examples/**`, and `-demo` modules.
 - Snapshot repository: `https://central.sonatype.com/repository/maven-snapshots/`
@@ -339,10 +339,10 @@ snapshotVersion=
 
 ```bash
 # Publish a RELEASE from a commit where snapshotVersion is empty
-./gradlew publishAggregationToCentralPortal --no-daemon --no-configuration-cache
+./gradlew nmcpPublishAggregationToCentralPortal --no-daemon --no-configuration-cache
 ```
 
-- The root aggregation task is `publishAggregationToCentralPortal`.
+- The root aggregation task is `nmcpPublishAggregationToCentralPortal`.
 - RELEASE publishing creates an NMCP aggregation ZIP and uploads it via the Central Portal Publisher API — far fewer requests than a SNAPSHOT.
 - Publishable targets exclude `workshop/**`, `examples/**`, and `-demo` modules.
 - The same RELEASE version cannot be republished; bump `baseVersion` before retrying after a failure.
@@ -370,8 +370,8 @@ centralSnapshotsParallelism=8
 
 ### Notes
 
-- `publishAggregationToCentralPortalSnapshots` is a deprecated alias — prefer `publishAggregationToCentralSnapshots`.
-- Use the root aggregation task rather than running individual tasks like `publishAllPublicationsToCentralPortalSnapshots` or `publishAllPublicationsToCentralSnapshots` directly.
+- Legacy compatibility tasks such as `publishAggregationToCentralSnapshots`, `publishAggregationToCentralPortal`, and `publishAggregationToCentralPortalSnapshots` may still appear in `./gradlew tasks`; prefer the `nmcpPublishAggregation*` root tasks above.
+- Use the root aggregation task rather than running individual tasks like `nmcpPublishAllPublicationsToCentralPortalSnapshots`, `publishAllPublicationsToCentralPortalSnapshots`, or `publishAllPublicationsToCentralSnapshots` directly.
 - If SNAPSHOTs are slow or generating too many requests, tune `centralSnapshotsParallelism` in the range of `4`–`12`.
 - RELEASE uses an aggregation ZIP upload path, so its behavior differs from SNAPSHOT.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -643,7 +643,7 @@ subprojects {
 
         ```bash
         $ ./gradlew clean build
-        $ ./gradlew publishAggregationToCentralPortal
+        $ ./gradlew nmcpPublishAggregationToCentralPortal
         ```
      */
     publishing {

--- a/docs/lessons/2026-06-07-issue-700-central-snapshot-task-naming.md
+++ b/docs/lessons/2026-06-07-issue-700-central-snapshot-task-naming.md
@@ -1,0 +1,22 @@
+# Issue #700: Central snapshot task naming audit
+
+## Context
+
+The root README files and snapshot workflow still advertised legacy Central
+publish task names while repo-local guidance already used the NMCP task names.
+
+## Decision
+
+Use `nmcpPublishAggregationToCentralPortalSnapshots` for SNAPSHOT publishing and
+`nmcpPublishAggregationToCentralPortal` for release publishing in public
+guidance and GitHub Actions.
+
+## Verification
+
+- `./gradlew tasks --all | rg "publishAggregation|nmcpPublishAggregation|CentralPortal|CentralSnapshots"`
+- `rg "publishAggregationToCentralSnapshots|publishAggregationToCentralPortal|publishAggregationToCentralPortalSnapshots|publishAllPublicationsToCentralPortalSnapshots|publishAllPublicationsToCentralSnapshots" README.md README.ko.md .github/workflows build.gradle.kts`
+
+## Future Guard
+
+When release or snapshot publish tasks change, update README.md, README.ko.md,
+workflow commands, and repo-local contributor guidance together.

--- a/docs/review/2026-06-07-issue-700-central-snapshot-task-naming-review.md
+++ b/docs/review/2026-06-07-issue-700-central-snapshot-task-naming-review.md
@@ -1,0 +1,28 @@
+# Issue #700 Review: Central snapshot task naming audit
+
+## Scope
+
+- README.md / README.ko.md publishing guidance
+- `.github/workflows/publish-snapshot.yml`
+- `.github/workflows/release.yml`
+- `build.gradle.kts` contributor publishing comment
+
+## Findings
+
+- P0: 0
+- P1: 0
+- P2: 0
+
+## Checks
+
+- Confirmed `nmcpPublishAggregationToCentralPortalSnapshots` and
+  `nmcpPublishAggregationToCentralPortal` are present in `./gradlew tasks --all`.
+- Confirmed workflows and README primary commands no longer use legacy
+  `publishAggregation*` task names.
+- Confirmed legacy task names remain documented only as compatibility tasks, not
+  as the recommended command surface.
+
+## Verdict
+
+PASS. The release guidance and workflow commands are aligned with the NMCP task
+surface.


### PR DESCRIPTION
## Summary

Closes #700

- PR 제목: docs: align Central publish task guidance

- Align README.md and README.ko.md Central publish commands with the NMCP aggregation task surface.
- Update `publish-snapshot.yml` and `release.yml` to use the same `nmcpPublishAggregation*` root tasks.
- Record audit evidence in `docs/review` and a short release-guidance lesson in `docs/lessons`.

Closes #700.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- SNAPSHOT primary task: `nmcpPublishAggregationToCentralPortalSnapshots`
- RELEASE primary task: `nmcpPublishAggregationToCentralPortal`
- Legacy `publishAggregation*` task names remain documented only as compatibility tasks.
- No publish workflow was dispatched and no version property was changed.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

- Align README.md and README.ko.md Central publish commands with the NMCP aggregation task surface.
- Update `publish-snapshot.yml` and `release.yml` to use the same `nmcpPublishAggregation*` root tasks.
- Record audit evidence in `docs/review` and a short release-guidance lesson in `docs/lessons`.

Closes #700.

### Scope

- SNAPSHOT primary task: `nmcpPublishAggregationToCentralPortalSnapshots`
- RELEASE primary task: `nmcpPublishAggregationToCentralPortal`
- Legacy `publishAggregation*` task names remain documented only as compatibility tasks.
- No publish workflow was dispatched and no version property was changed.

### Validation

- `./gradlew tasks --all | rg "^(nmcpPublishAggregationToCentralPortal|nmcpPublishAggregationToCentralPortalSnapshots|publishAggregationToCentralSnapshots|publishAggregationToCentralPortal)\\b"`
- `actionlint .github/workflows/publish-snapshot.yml .github/workflows/release.yml`
- `git diff --check`
- `rg` primary legacy publish command search returned no matches.

### DoD Status

- [x] README and workflow task names are corrected to the NMCP root task surface.
- [x] README.md and README.ko.md remain synchronized.
- [x] Actual Gradle task availability is verified.
- [x] Workflow YAML lint passed.
- [x] Review evidence is committed under `docs/review`.
- [x] Lesson evidence is committed under `docs/lessons`.

## Validation

- `./gradlew tasks --all | rg "^(nmcpPublishAggregationToCentralPortal|nmcpPublishAggregationToCentralPortalSnapshots|publishAggregationToCentralSnapshots|publishAggregationToCentralPortal)\\b"`
- `actionlint .github/workflows/publish-snapshot.yml .github/workflows/release.yml`
- `git diff --check`
- `rg` primary legacy publish command search returned no matches.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #700, milestone `1.11.0`, assignee `debop`
- PR: #728, head `919c37fa7099651d520129dc3f92a9ef47041794`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `docs/issue-700-snapshot-task-audit`
- Labels: `documentation`, `release`
- State: `MERGED`, merge commit `6887da13d53ff51d27d7782f40836042e29da2d3`
- CI: - `./gradlew tasks --all | rg "^(nmcpPublishAggregationToCentralPortal|nmcpPublishAggregationToCentralPortalSnapshots|publishAggregationToCentralSnapshots|publishAggregationToCentralPortal)\\b"` / - [x] Actual Gradle task availability is verified.

## DoD Status

- [x] README and workflow task names are corrected to the NMCP root task surface.
- [x] README.md and README.ko.md remain synchronized.
- [x] Actual Gradle task availability is verified.
- [x] Workflow YAML lint passed.
- [x] Review evidence is committed under `docs/review`.
- [x] Lesson evidence is committed under `docs/lessons`.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #728 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `6887da13d53ff51d27d7782f40836042e29da2d3`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
