### PR TITLE
docs(examples): add observability demos

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -68,10 +68,24 @@ jobs:
             )
           fi
 
+          if [[ -f examples/ktor/observability-ktor-demo/build.gradle.kts ]]; then
+            tasks+=(
+              :observability-ktor-demo:compileKotlin
+              :observability-ktor-demo:test
+            )
+          fi
+
           if [[ -f examples/spring-boot/idgenerator-spring-boot-demo/build.gradle.kts ]]; then
             tasks+=(
               :idgenerator-spring-boot-demo:compileKotlin
               :idgenerator-spring-boot-demo:test
+            )
+          fi
+
+          if [[ -f examples/spring-boot/observability-spring-boot-demo/build.gradle.kts ]]; then
+            tasks+=(
+              :observability-spring-boot-demo:compileKotlin
+              :observability-spring-boot-demo:test
             )
           fi
 
@@ -89,5 +103,7 @@ jobs:
             examples/**/build/reports/tests/test/**
             examples/spring-boot/idgenerator-spring-boot-demo/build/test-results/test/**
             examples/spring-boot/idgenerator-spring-boot-demo/build/reports/tests/test/**
+            examples/spring-boot/observability-spring-boot-demo/build/test-results/test/**
+            examples/spring-boot/observability-spring-boot-demo/build/reports/tests/test/**
           if-no-files-found: ignore
           retention-days: 14

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -320,8 +320,14 @@ jobs:
           if grep -q -- "--- Project ':idgenerator-ktor-demo'" <<< "$projects"; then
             excluded_tasks+=(-x :idgenerator-ktor-demo:build)
           fi
+          if grep -q -- "--- Project ':observability-ktor-demo'" <<< "$projects"; then
+            excluded_tasks+=(-x :observability-ktor-demo:build)
+          fi
           if grep -q -- "--- Project ':idgenerator-spring-boot-demo'" <<< "$projects"; then
             excluded_tasks+=(-x :idgenerator-spring-boot-demo:build)
+          fi
+          if grep -q -- "--- Project ':observability-spring-boot-demo'" <<< "$projects"; then
+            excluded_tasks+=(-x :observability-spring-boot-demo:build)
           fi
 
           for attempt in 1 2 3; do

--- a/README.ko.md
+++ b/README.ko.md
@@ -171,6 +171,7 @@ Bluetape4k는 기능별로 분리된 멀티 모듈 Gradle 프로젝트입니다.
 - **[hibernate-lettuce](./spring-boot/hibernate-lettuce/README.ko.md)**: Hibernate 2nd Level Cache + Lettuce NearCache Spring Boot Auto-Configuration
 - **[hibernate-lettuce-demo](./spring-boot/hibernate-lettuce-demo/README.ko.md)**: Hibernate Lettuce NearCache + Spring MVC 통합 데모
 - **[idgenerator-spring-boot-demo](./examples/spring-boot/idgenerator-spring-boot-demo/README.ko.md)**: `bluetape4k-idgenerators` Spring Boot REST 예제
+- **[observability-spring-boot-demo](./examples/spring-boot/observability-spring-boot-demo/README.ko.md)**: Spring Boot 4 Actuator Prometheus와 OTLP observability 예제
 - **[mongodb](./spring-boot/mongodb/README.ko.md)**: Spring Data MongoDB Reactive 코루틴 확장, Criteria/Query/Update infix DSL
 - **[r2dbc](./spring-boot/r2dbc/README.ko.md)**: Spring Data R2DBC 코루틴 확장
 
@@ -254,6 +255,8 @@ Jib으로 Mock Server Docker 이미지를 다시 빌드할 때는 Gradle configu
 - **[jpa-blazepersistence-demo](./examples/jpa-blazepersistence-demo/README.ko.md)**: JPA + Blaze Persistence 사용 예제
 - **[jpa-querydsl-demo](./examples/jpa-querydsl-demo/README.ko.md)**: JPA + QueryDSL 사용 예제
 - **[idgenerator-ktor-demo](./examples/ktor/idgenerator-ktor-demo/README.ko.md)**: `bluetape4k-idgenerators` Ktor HTTP 예제
+- **[observability-ktor-demo](./examples/ktor/observability-ktor-demo/README.ko.md)**: Ktor Prometheus `/metrics`와 opt-in OpenTelemetry tracing 예제
+- **[observability-spring-boot-demo](./examples/spring-boot/observability-spring-boot-demo/README.ko.md)**: Spring Boot 4 Actuator Prometheus와 OTLP observability 예제
 - **[redisson-demo](./examples/redisson-demo/README.ko.md)**: Redisson 사용 예제
 - **[virtualthreads-demo](./examples/virtualthreads-demo/README.ko.md)**: Java Virtual Thread 사용 예제
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ versionless `spring-boot/*` modules publish the current Spring Boot 4 artifacts.
 - **[hibernate-lettuce](./spring-boot/hibernate-lettuce/README.md)**: Hibernate 2nd Level Cache + Lettuce NearCache Spring Boot Auto-Configuration
 - **[hibernate-lettuce-demo](./spring-boot/hibernate-lettuce-demo/README.md)**: Hibernate Lettuce NearCache + Spring MVC integration demo
 - **[idgenerator-spring-boot-demo](./examples/spring-boot/idgenerator-spring-boot-demo/README.md)**: Spring Boot REST demo for `bluetape4k-idgenerators`
+- **[observability-spring-boot-demo](./examples/spring-boot/observability-spring-boot-demo/README.md)**: Spring Boot 4 Actuator Prometheus and OTLP observability demo
 - **[mongodb](./spring-boot/mongodb/README.md)**: Spring Data MongoDB Reactive with Coroutines extensions, Criteria/Query/Update infix DSL
 - **[r2dbc](./spring-boot/r2dbc/README.md)**: Spring Data R2DBC with Coroutines extensions
 
@@ -253,6 +254,8 @@ Demonstration modules showing library usage. Not published to Maven.
 - **[jpa-blazepersistence-demo](./examples/jpa-blazepersistence-demo/README.md)**: JPA + Blaze Persistence usage examples
 - **[jpa-querydsl-demo](./examples/jpa-querydsl-demo/README.md)**: JPA + QueryDSL usage examples
 - **[idgenerator-ktor-demo](./examples/ktor/idgenerator-ktor-demo/README.md)**: Ktor HTTP example for `bluetape4k-idgenerators`
+- **[observability-ktor-demo](./examples/ktor/observability-ktor-demo/README.md)**: Ktor Prometheus `/metrics` and opt-in OpenTelemetry tracing example
+- **[observability-spring-boot-demo](./examples/spring-boot/observability-spring-boot-demo/README.md)**: Spring Boot 4 Actuator Prometheus and OTLP observability example
 - **[redisson-demo](./examples/redisson-demo/README.md)**: Redisson usage examples
 - **[virtualthreads-demo](./examples/virtualthreads-demo/README.md)**: Java Virtual Thread usage examples
 

--- a/examples/ktor/observability-ktor-demo/README.ko.md
+++ b/examples/ktor/observability-ktor-demo/README.ko.md
@@ -1,0 +1,95 @@
+# bluetape4k Ktor observability demo
+
+[English](./README.md) | 한국어
+
+Ktor 3에서 애플리케이션이 소유한 Prometheus metrics route, opt-in OpenTelemetry tracing,
+bluetape4k event telemetry helper를 함께 사용하는 실행 가능한 예제입니다.
+
+## 구조
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Ktor as Ktor Routes
+    participant Obs as bluetape4k Ktor Observability
+    participant EventObs as event telemetry
+    participant Prom as PrometheusMeterRegistry
+    participant OTel as OpenTelemetry SDK
+
+    Client->>Ktor: POST /orders/{orderId}/events
+    Ktor->>Obs: correlation ID, call logging, metrics, tracing
+    Ktor->>EventObs: event.publish 관측
+    Ktor->>EventObs: event.consume 관측
+    EventObs->>Prom: Micrometer timers
+    Obs->>OTel: 설정된 경우 server span
+    Ktor-->>Client: 200 JSON
+    Client->>Ktor: GET /metrics
+    Ktor->>Prom: scrape()
+    Ktor-->>Client: Prometheus text
+```
+
+## 의존성
+
+- `bluetape4k-ktor-core`: JSON, 오류 처리, health/readiness 기본 기능
+- `bluetape4k-ktor-observability`: correlation ID, call logging, Micrometer, Prometheus route, OTel tracing helper
+- `bluetape4k-micrometer`: event publish/consume telemetry helper
+- `micrometer-registry-prometheus`: 애플리케이션 소유 scrape registry
+- `opentelemetry-ktor-3.0`: 선택적 Ktor server span
+
+## 설정
+
+Ktor는 Actuator로 Prometheus를 노출하지 않습니다. 애플리케이션이 registry를 소유하고 scrape route를 명시적으로 mount합니다.
+
+```kotlin
+val meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+
+installBluetape4kKtorObservability(
+    Bluetape4kKtorObservabilityConfig(
+        meterRegistry = meterRegistry,
+        tracing = KtorOpenTelemetryTracingConfig(openTelemetry),
+    )
+)
+
+routing {
+    prometheusScrapeRoute(meterRegistry, path = "/metrics")
+}
+```
+
+`OpenTelemetry` 인스턴스에 `null`을 전달하면 tracing은 비활성화됩니다. 테스트는 in-memory SDK exporter를 사용하므로 외부 collector가 필요하지 않습니다.
+
+## 실행
+
+```bash
+./gradlew :observability-ktor-demo:run
+```
+
+애플리케이션은 `0.0.0.0:8080`에서 실행됩니다.
+
+## 확인
+
+관측 대상 애플리케이션 이벤트를 만듭니다.
+
+```bash
+curl -X POST -H 'X-Request-Id: REQ_123' \
+  http://localhost:8080/orders/order-1/events
+```
+
+애플리케이션 소유 Prometheus metrics를 scrape합니다.
+
+```bash
+curl http://localhost:8080/metrics | grep -E 'ktor_http_server_requests|event_publish|event_consume'
+```
+
+Health route를 확인합니다.
+
+```bash
+curl http://localhost:8080/health
+curl http://localhost:8080/healthz
+curl http://localhost:8080/readyz
+```
+
+## 테스트
+
+```bash
+./gradlew :observability-ktor-demo:compileKotlin :observability-ktor-demo:test
+```

--- a/examples/ktor/observability-ktor-demo/README.ko.md
+++ b/examples/ktor/observability-ktor-demo/README.ko.md
@@ -5,7 +5,49 @@
 Ktor 3에서 애플리케이션이 소유한 Prometheus metrics route, opt-in OpenTelemetry tracing,
 bluetape4k event telemetry helper를 함께 사용하는 실행 가능한 예제입니다.
 
-## 구조
+## 예제 시나리오
+
+이 예제는 observability 구성을 명시적으로 소유하는 Ktor 애플리케이션을 모델링합니다.
+
+1. 애플리케이션이 `PrometheusMeterRegistry`를 생성합니다.
+2. `installBluetape4kKtorObservability`가 correlation ID, call logging, Micrometer metrics, optional tracing을 설치합니다.
+3. 클라이언트가 선택적 `X-Request-Id` header와 함께 주문 이벤트를 전송합니다.
+4. route는 bluetape4k event telemetry helper로 `event.publish`와 `event.consume` observation을 기록합니다.
+5. 애플리케이션이 자체 Prometheus scrape endpoint `/metrics`를 노출합니다.
+6. `OpenTelemetry` SDK 인스턴스를 전달하면 Ktor server span이 활성화되고, `null`을 전달하면 tracing은 비활성화됩니다.
+
+Spring Boot 예제와 달리 Ktor에는 Actuator endpoint가 없습니다. 따라서 애플리케이션이 registry와 route를 직접 소유합니다.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Client[HTTP Client]
+    Routes[Ktor Routes]
+    Core[bluetape4k Ktor Core]
+    Obs[bluetape4k Ktor Observability]
+    Service[OrderEventTelemetryService]
+    EventObs[bluetape4k event telemetry]
+    Registry[PrometheusMeterRegistry]
+    Metrics["/metrics"]
+    OTel[OpenTelemetry SDK optional]
+
+    Client --> Routes
+    Routes --> Core
+    Routes --> Obs
+    Routes --> Service
+    Service --> EventObs
+    Obs --> Registry
+    EventObs --> Registry
+    Routes --> Metrics
+    Metrics --> Registry
+    Obs -. server spans when configured .-> OTel
+```
+
+Scrape route는 애플리케이션이 소유합니다. `prometheusScrapeRoute(registry)`는 registry 내용을
+노출할 뿐, global exporter나 backend 연결을 만들지 않습니다.
+
+## Sequence Diagram
 
 ```mermaid
 sequenceDiagram

--- a/examples/ktor/observability-ktor-demo/README.md
+++ b/examples/ktor/observability-ktor-demo/README.md
@@ -1,0 +1,97 @@
+# bluetape4k Ktor observability demo
+
+English | [한국어](./README.ko.md)
+
+Runnable Ktor 3 application that shows application-owned Prometheus metrics routing, opt-in
+OpenTelemetry tracing, and bluetape4k event telemetry helpers.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Ktor as Ktor Routes
+    participant Obs as bluetape4k Ktor Observability
+    participant EventObs as event telemetry
+    participant Prom as PrometheusMeterRegistry
+    participant OTel as OpenTelemetry SDK
+
+    Client->>Ktor: POST /orders/{orderId}/events
+    Ktor->>Obs: correlation ID, call logging, metrics, tracing
+    Ktor->>EventObs: observe event.publish
+    Ktor->>EventObs: observe event.consume
+    EventObs->>Prom: Micrometer timers
+    Obs->>OTel: server span when configured
+    Ktor-->>Client: 200 JSON
+    Client->>Ktor: GET /metrics
+    Ktor->>Prom: scrape()
+    Ktor-->>Client: Prometheus text
+```
+
+## Dependencies
+
+- `bluetape4k-ktor-core`: JSON, error handling, health/readiness baseline
+- `bluetape4k-ktor-observability`: correlation ID, call logging, Micrometer, Prometheus route, OTel tracing helper
+- `bluetape4k-micrometer`: event publish/consume telemetry helpers
+- `micrometer-registry-prometheus`: application-owned scrape registry
+- `opentelemetry-ktor-3.0`: optional Ktor server spans
+
+## Configuration
+
+Ktor does not expose Prometheus through Actuator. The application owns the registry and explicitly
+mounts the scrape route:
+
+```kotlin
+val meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+
+installBluetape4kKtorObservability(
+    Bluetape4kKtorObservabilityConfig(
+        meterRegistry = meterRegistry,
+        tracing = KtorOpenTelemetryTracingConfig(openTelemetry),
+    )
+)
+
+routing {
+    prometheusScrapeRoute(meterRegistry, path = "/metrics")
+}
+```
+
+Passing `null` for the `OpenTelemetry` instance keeps tracing disabled. Tests use an in-memory SDK
+exporter, so no external collector is required.
+
+## Run
+
+```bash
+./gradlew :observability-ktor-demo:run
+```
+
+The application listens on `0.0.0.0:8080`.
+
+## Verify
+
+Create an observed application event:
+
+```bash
+curl -X POST -H 'X-Request-Id: REQ_123' \
+  http://localhost:8080/orders/order-1/events
+```
+
+Scrape application-owned Prometheus metrics:
+
+```bash
+curl http://localhost:8080/metrics | grep -E 'ktor_http_server_requests|event_publish|event_consume'
+```
+
+Check health routes:
+
+```bash
+curl http://localhost:8080/health
+curl http://localhost:8080/healthz
+curl http://localhost:8080/readyz
+```
+
+## Test
+
+```bash
+./gradlew :observability-ktor-demo:compileKotlin :observability-ktor-demo:test
+```

--- a/examples/ktor/observability-ktor-demo/README.md
+++ b/examples/ktor/observability-ktor-demo/README.md
@@ -5,7 +5,50 @@ English | [한국어](./README.ko.md)
 Runnable Ktor 3 application that shows application-owned Prometheus metrics routing, opt-in
 OpenTelemetry tracing, and bluetape4k event telemetry helpers.
 
+## Example Scenario
+
+The demo models a Ktor application that owns its observability plumbing explicitly:
+
+1. The application creates a `PrometheusMeterRegistry`.
+2. `installBluetape4kKtorObservability` installs correlation IDs, call logging, Micrometer metrics, and optional tracing.
+3. A client posts an order event with an optional `X-Request-Id` header.
+4. The route records `event.publish` and `event.consume` observations through bluetape4k event telemetry helpers.
+5. The application exposes its own Prometheus scrape endpoint at `/metrics`.
+6. Passing an `OpenTelemetry` SDK instance enables Ktor server spans; passing `null` keeps tracing disabled.
+
+This intentionally differs from the Spring Boot demo: Ktor has no Actuator endpoint, so the application
+owns the registry and route.
+
 ## Architecture
+
+```mermaid
+flowchart LR
+    Client[HTTP Client]
+    Routes[Ktor Routes]
+    Core[bluetape4k Ktor Core]
+    Obs[bluetape4k Ktor Observability]
+    Service[OrderEventTelemetryService]
+    EventObs[bluetape4k event telemetry]
+    Registry[PrometheusMeterRegistry]
+    Metrics["/metrics"]
+    OTel[OpenTelemetry SDK optional]
+
+    Client --> Routes
+    Routes --> Core
+    Routes --> Obs
+    Routes --> Service
+    Service --> EventObs
+    Obs --> Registry
+    EventObs --> Registry
+    Routes --> Metrics
+    Metrics --> Registry
+    Obs -. server spans when configured .-> OTel
+```
+
+The scrape route is application-owned. `prometheusScrapeRoute(registry)` only exposes the registry
+content; it does not create global exporters or backend connections.
+
+## Sequence Diagram
 
 ```mermaid
 sequenceDiagram

--- a/examples/ktor/observability-ktor-demo/build.gradle.kts
+++ b/examples/ktor/observability-ktor-demo/build.gradle.kts
@@ -1,0 +1,33 @@
+plugins {
+    application
+    alias(libs.plugins.kotlin.serialization)
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+application {
+    mainClass.set("io.bluetape4k.examples.ktor.observability.ObservabilityKtorApplicationKt")
+}
+
+dependencies {
+    implementation(project(":bluetape4k-ktor-core"))
+    implementation(project(":bluetape4k-ktor-observability"))
+    implementation(project(":bluetape4k-micrometer"))
+
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.cio)
+    implementation(libs.micrometer.registry.prometheus)
+    implementation(libs.opentelemetry.api)
+
+    runtimeOnly(libs.logback.classic)
+    runtimeOnly(libs.opentelemetry.ktor)
+
+    testImplementation(project(":bluetape4k-junit5"))
+    testImplementation(project(":bluetape4k-ktor-testing"))
+    testImplementation(libs.ktor.server.test.host)
+    testImplementation(libs.opentelemetry.sdk)
+    testImplementation(libs.opentelemetry.sdk.testing)
+    testImplementation(libs.opentelemetry.sdk.trace)
+}

--- a/examples/ktor/observability-ktor-demo/src/main/kotlin/io/bluetape4k/examples/ktor/observability/ObservabilityKtorApplication.kt
+++ b/examples/ktor/observability-ktor-demo/src/main/kotlin/io/bluetape4k/examples/ktor/observability/ObservabilityKtorApplication.kt
@@ -1,0 +1,168 @@
+package io.bluetape4k.examples.ktor.observability
+
+import io.bluetape4k.ktor.core.installBluetape4kKtorCore
+import io.bluetape4k.ktor.core.requiredPathParameter
+import io.bluetape4k.ktor.observability.Bluetape4kKtorObservabilityConfig
+import io.bluetape4k.ktor.observability.KtorOpenTelemetryTracingConfig
+import io.bluetape4k.ktor.observability.installBluetape4kKtorObservability
+import io.bluetape4k.ktor.observability.prometheusScrapeRoute
+import io.bluetape4k.micrometer.observation.events.EventCorrelation
+import io.bluetape4k.micrometer.observation.events.EventDestination
+import io.bluetape4k.micrometer.observation.events.EventTelemetry
+import io.bluetape4k.micrometer.observation.events.observeEventConsumeSuspending
+import io.bluetape4k.micrometer.observation.events.observeEventPublishSuspending
+import io.ktor.http.HttpHeaders
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.request.header
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Routing
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler
+import io.micrometer.observation.ObservationRegistry
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import io.opentelemetry.api.OpenTelemetry
+import kotlinx.serialization.Serializable
+import java.io.Serializable as JavaSerializable
+
+/**
+ * Configures the Ktor observability example application.
+ *
+ * ## Contract
+ * - The application owns the Prometheus registry and exposes it at `/metrics`.
+ * - OpenTelemetry tracing is installed only when an [OpenTelemetry] instance is supplied.
+ * - Application event telemetry is recorded with bounded low-cardinality dimensions.
+ */
+internal fun Application.observabilityKtorModule(
+    meterRegistry: PrometheusMeterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT),
+    openTelemetry: OpenTelemetry? = null,
+    service: OrderEventTelemetryService = OrderEventTelemetryService(observationRegistryFor(meterRegistry)),
+) {
+    installBluetape4kKtorCore()
+    installBluetape4kKtorObservability(
+        Bluetape4kKtorObservabilityConfig(
+            meterRegistry = meterRegistry,
+            tracing = openTelemetry?.let {
+                KtorOpenTelemetryTracingConfig(
+                    openTelemetry = it,
+                    captureSanitizedCorrelationId = true,
+                )
+            },
+        )
+    )
+
+    routing {
+        observabilityRoutes(service, meterRegistry)
+    }
+}
+
+fun main() {
+    embeddedServer(CIO, host = "0.0.0.0", port = 8080) {
+        observabilityKtorModule()
+    }.start(wait = true)
+}
+
+internal fun Routing.observabilityRoutes(
+    service: OrderEventTelemetryService,
+    meterRegistry: PrometheusMeterRegistry,
+) {
+    prometheusScrapeRoute(meterRegistry)
+
+    get("/health") {
+        call.respond(HealthResponse())
+    }
+
+    post("/orders/{orderId}/events") {
+        call.respond(
+            service.publishOrderEvent(
+                orderId = call.requiredPathParameter("orderId"),
+                rawCorrelationId = call.request.header(HttpHeaders.XRequestId),
+            )
+        )
+    }
+}
+
+internal class OrderEventTelemetryService(
+    private val observationRegistry: ObservationRegistry,
+) {
+
+    suspend fun publishOrderEvent(
+        orderId: String,
+        rawCorrelationId: String?,
+    ): OrderEventResponse {
+        val correlation = EventCorrelation.sanitized(rawCorrelationId)
+        val telemetry = EventTelemetry(
+            destination = EventDestination("ktor", "order-events"),
+            eventType = EVENT_TYPE,
+            correlation = correlation,
+            batchMessageCount = 1,
+        )
+        val event = OrderEvent(orderId = orderId, type = EVENT_TYPE)
+
+        observationRegistry.observeEventPublishSuspending(telemetry) {
+            publishToLocalChannel(event)
+        }
+        observationRegistry.observeEventConsumeSuspending(telemetry) {
+            consumeFromLocalChannel(event)
+        }
+
+        return OrderEventResponse(
+            orderId = orderId,
+            eventType = event.type,
+            correlationPresent = correlation.present,
+            status = "accepted",
+        )
+    }
+
+    private suspend fun publishToLocalChannel(event: OrderEvent): OrderEvent =
+        event
+
+    private suspend fun consumeFromLocalChannel(event: OrderEvent): OrderEvent =
+        event
+
+    companion object {
+        private const val EVENT_TYPE = "order.accepted"
+    }
+}
+
+internal fun observationRegistryFor(meterRegistry: MeterRegistry): ObservationRegistry =
+    ObservationRegistry.create().apply {
+        observationConfig().observationHandler(DefaultMeterObservationHandler(meterRegistry))
+    }
+
+@Serializable
+internal data class OrderEvent(
+    val orderId: String,
+    val type: String,
+): JavaSerializable {
+    companion object {
+        private const val serialVersionUID: Long = 1155546218142106024L
+    }
+}
+
+@Serializable
+internal data class OrderEventResponse(
+    val orderId: String,
+    val eventType: String,
+    val correlationPresent: Boolean,
+    val status: String,
+): JavaSerializable {
+    companion object {
+        private const val serialVersionUID: Long = 2044338399999869276L
+    }
+}
+
+@Serializable
+internal data class HealthResponse(
+    val status: String = "UP",
+): JavaSerializable {
+    companion object {
+        private const val serialVersionUID: Long = 1624425969250105208L
+    }
+}

--- a/examples/ktor/observability-ktor-demo/src/test/kotlin/io/bluetape4k/examples/ktor/observability/ObservabilityKtorApplicationTest.kt
+++ b/examples/ktor/observability-ktor-demo/src/test/kotlin/io/bluetape4k/examples/ktor/observability/ObservabilityKtorApplicationTest.kt
@@ -1,0 +1,116 @@
+package io.bluetape4k.examples.ktor.observability
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.ktor.testing.decodeJsonBody
+import io.bluetape4k.ktor.testing.shouldHaveStatus
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.TimeUnit
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ObservabilityKtorApplicationTest {
+
+    @Test
+    fun `application publishes event telemetry and propagates request id`() = testApplication {
+        application {
+            observabilityKtorModule()
+        }
+
+        val response = client.post("/orders/order-1/events") {
+            header(HttpHeaders.XRequestId, "REQ_123")
+        }
+
+        response shouldHaveStatus HttpStatusCode.OK
+        response.headers[HttpHeaders.XRequestId] shouldBeEqualTo "REQ_123"
+
+        val body = response.decodeJsonBody<OrderEventResponse>()
+        body.orderId shouldBeEqualTo "order-1"
+        body.eventType shouldBeEqualTo "order.accepted"
+        body.correlationPresent shouldBeEqualTo true
+        body.status shouldBeEqualTo "accepted"
+    }
+
+    @Test
+    fun `metrics route exposes Ktor and event observation metrics`() = testApplication {
+        val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+
+        application {
+            observabilityKtorModule(meterRegistry = registry, openTelemetry = null)
+        }
+
+        client.post("/orders/order-2/events") {
+            header(HttpHeaders.XRequestId, "REQ_456")
+        } shouldHaveStatus HttpStatusCode.OK
+
+        val metrics = client.get("/metrics").bodyAsText()
+
+        metrics.contains("ktor_http_server_requests").shouldBeTrue()
+        metrics.contains("event_publish").shouldBeTrue()
+        metrics.contains("event_consume").shouldBeTrue()
+    }
+
+    @Test
+    fun `optional OpenTelemetry tracing records server span without external collector`() = testTracing { tracing ->
+        testApplication {
+            application {
+                observabilityKtorModule(openTelemetry = tracing.openTelemetry)
+            }
+
+            client.post("/orders/order-3/events") {
+                header(HttpHeaders.XRequestId, "  REQ_789 Injected: raw  ")
+            } shouldHaveStatus HttpStatusCode.OK
+
+            tracing.flush()
+
+            val spans = tracing.spanExporter.finishedSpanItems
+            spans shouldHaveSize 1
+            spans[0].kind shouldBeEqualTo SpanKind.SERVER
+            spans[0].attributes[CORRELATION_PRESENT_KEY] shouldBeEqualTo true
+            spans[0].attributes[CORRELATION_ID_KEY] shouldBeEqualTo "REQ_789Injectedraw"
+        }
+    }
+
+    private class TestTracing: AutoCloseable {
+        val spanExporter: InMemorySpanExporter = InMemorySpanExporter.create()
+        private val tracerProvider: SdkTracerProvider = SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+            .build()
+        val openTelemetry: OpenTelemetrySdk = OpenTelemetrySdk.builder()
+            .setTracerProvider(tracerProvider)
+            .build()
+
+        fun flush() {
+            tracerProvider.forceFlush().join(1, TimeUnit.SECONDS)
+        }
+
+        override fun close() {
+            tracerProvider.close()
+        }
+    }
+
+    private inline fun testTracing(block: (TestTracing) -> Unit) {
+        TestTracing().use(block)
+    }
+
+    companion object {
+        private val CORRELATION_PRESENT_KEY: AttributeKey<Boolean> = AttributeKey.booleanKey("correlation.present")
+        private val CORRELATION_ID_KEY: AttributeKey<String> = AttributeKey.stringKey("correlation.id")
+    }
+}

--- a/examples/ktor/observability-ktor-demo/src/test/resources/junit-platform.properties
+++ b/examples/ktor/observability-ktor-demo/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/examples/ktor/observability-ktor-demo/src/test/resources/logback-test.xml
+++ b/examples/ktor/observability-ktor-demo/src/test/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <!-- @formatter:off -->
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%24.24t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <!-- @formatter:on -->
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.examples.ktor.observability" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+
+</configuration>

--- a/examples/spring-boot/observability-spring-boot-demo/README.ko.md
+++ b/examples/spring-boot/observability-spring-boot-demo/README.ko.md
@@ -1,0 +1,112 @@
+# bluetape4k Spring Boot observability demo
+
+[English](./README.md) | 한국어
+
+Spring Boot 4에서 bluetape4k observation helper를 Spring Boot Actuator Prometheus metrics와
+애플리케이션 소유 OTLP tracing 설정으로 사용하는 실행 가능한 예제입니다.
+
+## 구조
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Controller as Spring MVC Controller
+    participant SpringObs as observeSpring
+    participant EventObs as event telemetry
+    participant Actuator as Actuator /actuator/prometheus
+    participant Otlp as OTLP Collector
+
+    Client->>Controller: POST /orders/{orderId}/events
+    Controller->>SpringObs: HTTP service 작업 관측
+    SpringObs->>EventObs: event.publish 관측
+    SpringObs->>EventObs: event.consume 관측
+    SpringObs-->>Controller: OrderEventResponse
+    Controller-->>Client: 200 JSON
+    Client->>Actuator: GET /actuator/prometheus
+    Actuator-->>Client: Prometheus scrape output
+    SpringObs-->>Otlp: collector/exporter 설정 시 trace 전송
+```
+
+## 의존성
+
+이 예제는 Spring Boot BOM과 기존 bluetape4k helper 모듈을 사용합니다.
+
+- `bluetape4k-spring-boot-core`: `ObservationRegistry.observeSpring`
+- `bluetape4k-micrometer`: event publish/consume telemetry helper
+- `spring-boot-starter-actuator`와 `micrometer-registry-prometheus`: `/actuator/prometheus`
+- `micrometer-tracing-bridge-otel`과 `opentelemetry-exporter-otlp`: 선택적 OTLP trace export
+
+## 설정
+
+Prometheus와 OTLP 설정은 Spring Boot가 소유합니다. 이 애플리케이션은 별도 custom Prometheus endpoint를 만들지 않습니다.
+
+```yaml
+management:
+  defaults:
+    metrics:
+      export:
+        enabled: false
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    prometheus:
+      access: read_only
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+  tracing:
+    sampling:
+      probability: 1.0
+  otlp:
+    tracing:
+      endpoint: ${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:http://localhost:4318/v1/traces}
+```
+
+`management.defaults.metrics.export.enabled=false`는 예제 classpath에 Datadog 같은 registry 구현이
+있더라도 credential 없이 시작되지 않게 막습니다. Prometheus만 명시적으로 활성화합니다.
+
+## 실행
+
+```bash
+./gradlew :observability-spring-boot-demo:bootRun
+```
+
+애플리케이션은 `localhost:8080`에서 실행됩니다.
+
+## 확인
+
+관측 대상 애플리케이션 이벤트를 만듭니다.
+
+```bash
+curl -X POST -H 'X-Request-Id: REQ_123' \
+  http://localhost:8080/orders/order-1/events
+```
+
+Spring Boot Actuator를 통해 metrics를 scrape합니다.
+
+```bash
+curl http://localhost:8080/actuator/prometheus | grep -E 'http_server_requests|event_publish|event_consume'
+```
+
+Health도 Actuator endpoint로 확인합니다.
+
+```bash
+curl http://localhost:8080/actuator/health
+```
+
+Trace를 export하려면 로컬 OTLP collector를 실행하거나 다음 환경 변수를 지정합니다.
+
+```bash
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4318/v1/traces
+```
+
+테스트는 외부 trace export를 비활성화하고, 애플리케이션 기동, event telemetry 실행, Prometheus 출력의 HTTP/event observation metrics를 검증합니다.
+
+## 테스트
+
+```bash
+./gradlew :observability-spring-boot-demo:compileKotlin :observability-spring-boot-demo:test
+```

--- a/examples/spring-boot/observability-spring-boot-demo/README.ko.md
+++ b/examples/spring-boot/observability-spring-boot-demo/README.ko.md
@@ -5,7 +5,48 @@
 Spring Boot 4에서 bluetape4k observation helper를 Spring Boot Actuator Prometheus metrics와
 애플리케이션 소유 OTLP tracing 설정으로 사용하는 실행 가능한 예제입니다.
 
-## 구조
+## 예제 시나리오
+
+이 예제는 작은 주문 이벤트 workflow를 모델링합니다.
+
+1. 클라이언트가 선택적 `X-Request-Id` correlation header와 함께 주문 이벤트를 전송합니다.
+2. Spring MVC controller가 요청을 `OrderEventService`로 전달합니다.
+3. `OrderEventService`는 HTTP/service 경계를 `ObservationRegistry.observeSpring`으로 감쌉니다.
+4. 같은 논리 이벤트에 대해 `event.publish` observation과 `event.consume` observation을 기록합니다.
+5. Spring Boot Actuator가 HTTP 및 event observation metrics를 `/actuator/prometheus`로 노출합니다.
+6. 로컬 collector endpoint를 지정하면 Spring Boot Micrometer tracing exporter가 OTLP trace를 보낼 수 있습니다.
+
+Prometheus server 없이 scrape 결과를 확인할 수 있고, 테스트는 OTLP collector 없이 실행되도록 구성했습니다.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Client[HTTP Client]
+    Controller[Spring MVC Controller]
+    Service[OrderEventService]
+    SpringObs[bluetape4k observeSpring]
+    EventObs[bluetape4k event telemetry]
+    Registry[ObservationRegistry]
+    Actuator[Spring Boot Actuator]
+    Prometheus["/actuator/prometheus"]
+    Otlp[OTLP Collector optional]
+
+    Client --> Controller
+    Controller --> Service
+    Service --> SpringObs
+    Service --> EventObs
+    SpringObs --> Registry
+    EventObs --> Registry
+    Registry --> Actuator
+    Actuator --> Prometheus
+    Registry -. traces when configured .-> Otlp
+```
+
+Spring Boot가 metrics endpoint 등록을 소유합니다. 애플리케이션은 관측 대상 작업을 제공하고,
+Actuator가 Micrometer observation을 Prometheus scrape output으로 변환합니다.
+
+## Sequence Diagram
 
 ```mermaid
 sequenceDiagram

--- a/examples/spring-boot/observability-spring-boot-demo/README.md
+++ b/examples/spring-boot/observability-spring-boot-demo/README.md
@@ -1,0 +1,115 @@
+# bluetape4k Spring Boot observability demo
+
+English | [한국어](./README.ko.md)
+
+Runnable Spring Boot 4 application that shows how to use bluetape4k observation helpers with
+Spring Boot Actuator Prometheus metrics and application-owned OTLP tracing configuration.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Controller as Spring MVC Controller
+    participant SpringObs as observeSpring
+    participant EventObs as event telemetry
+    participant Actuator as Actuator /actuator/prometheus
+    participant Otlp as OTLP Collector
+
+    Client->>Controller: POST /orders/{orderId}/events
+    Controller->>SpringObs: observe HTTP service work
+    SpringObs->>EventObs: observe event.publish
+    SpringObs->>EventObs: observe event.consume
+    SpringObs-->>Controller: OrderEventResponse
+    Controller-->>Client: 200 JSON
+    Client->>Actuator: GET /actuator/prometheus
+    Actuator-->>Client: Prometheus scrape output
+    SpringObs-->>Otlp: traces when collector/exporter is configured
+```
+
+## Dependencies
+
+The demo uses the Spring Boot BOM and the existing bluetape4k helper modules:
+
+- `bluetape4k-spring-boot-core` for `ObservationRegistry.observeSpring`
+- `bluetape4k-micrometer` for event publish/consume telemetry helpers
+- `spring-boot-starter-actuator` plus `micrometer-registry-prometheus` for `/actuator/prometheus`
+- `micrometer-tracing-bridge-otel` and `opentelemetry-exporter-otlp` for optional OTLP trace export
+
+## Configuration
+
+Spring Boot owns Prometheus and OTLP configuration. The application does not register a custom
+Prometheus endpoint.
+
+```yaml
+management:
+  defaults:
+    metrics:
+      export:
+        enabled: false
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    prometheus:
+      access: read_only
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+  tracing:
+    sampling:
+      probability: 1.0
+  otlp:
+    tracing:
+      endpoint: ${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:http://localhost:4318/v1/traces}
+```
+
+`management.defaults.metrics.export.enabled=false` keeps registry implementations that may be present
+on the demo classpath, such as Datadog, from starting without credentials. Prometheus is enabled
+explicitly.
+
+## Run
+
+```bash
+./gradlew :observability-spring-boot-demo:bootRun
+```
+
+The application listens on `localhost:8080`.
+
+## Verify
+
+Create an observed application event:
+
+```bash
+curl -X POST -H 'X-Request-Id: REQ_123' \
+  http://localhost:8080/orders/order-1/events
+```
+
+Scrape metrics through Spring Boot Actuator:
+
+```bash
+curl http://localhost:8080/actuator/prometheus | grep -E 'http_server_requests|event_publish|event_consume'
+```
+
+Health remains an Actuator endpoint:
+
+```bash
+curl http://localhost:8080/actuator/health
+```
+
+To export traces, run an OTLP collector locally or set:
+
+```bash
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4318/v1/traces
+```
+
+The tests disable external trace export and prove the application starts, event telemetry runs, and
+Prometheus output includes HTTP and event observation metrics.
+
+## Test
+
+```bash
+./gradlew :observability-spring-boot-demo:compileKotlin :observability-spring-boot-demo:test
+```

--- a/examples/spring-boot/observability-spring-boot-demo/README.md
+++ b/examples/spring-boot/observability-spring-boot-demo/README.md
@@ -5,7 +5,49 @@ English | [한국어](./README.ko.md)
 Runnable Spring Boot 4 application that shows how to use bluetape4k observation helpers with
 Spring Boot Actuator Prometheus metrics and application-owned OTLP tracing configuration.
 
+## Example Scenario
+
+The demo models a small order-event workflow:
+
+1. A client posts an order event with an optional `X-Request-Id` correlation header.
+2. The Spring MVC controller delegates the request to `OrderEventService`.
+3. `OrderEventService` wraps the HTTP/service boundary with `ObservationRegistry.observeSpring`.
+4. The service records an `event.publish` observation and an `event.consume` observation for the same logical event.
+5. Spring Boot Actuator exposes HTTP and event observation metrics at `/actuator/prometheus`.
+6. OTLP tracing can be enabled by pointing Spring Boot's Micrometer tracing exporter at a local collector.
+
+This keeps the example local-testable: Prometheus scraping works without a Prometheus server, and tests do
+not require an OTLP collector.
+
 ## Architecture
+
+```mermaid
+flowchart LR
+    Client[HTTP Client]
+    Controller[Spring MVC Controller]
+    Service[OrderEventService]
+    SpringObs[bluetape4k observeSpring]
+    EventObs[bluetape4k event telemetry]
+    Registry[ObservationRegistry]
+    Actuator[Spring Boot Actuator]
+    Prometheus["/actuator/prometheus"]
+    Otlp[OTLP Collector optional]
+
+    Client --> Controller
+    Controller --> Service
+    Service --> SpringObs
+    Service --> EventObs
+    SpringObs --> Registry
+    EventObs --> Registry
+    Registry --> Actuator
+    Actuator --> Prometheus
+    Registry -. traces when configured .-> Otlp
+```
+
+Spring Boot owns metrics endpoint registration. The application contributes observed work; Actuator
+turns Micrometer observations into Prometheus scrape output.
+
+## Sequence Diagram
 
 ```mermaid
 sequenceDiagram

--- a/examples/spring-boot/observability-spring-boot-demo/build.gradle.kts
+++ b/examples/spring-boot/observability-spring-boot-demo/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    kotlin("plugin.spring")
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    implementation(platform(libs.spring.boot.dependencies))
+
+    implementation(project(":bluetape4k-micrometer"))
+    implementation(project(":bluetape4k-spring-boot-core"))
+
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    runtimeOnly(libs.micrometer.registry.prometheus)
+    runtimeOnly(libs.micrometer.tracing.bridge.otel)
+    runtimeOnly(libs.opentelemetry.exporter.otlp)
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-webtestclient")
+    testImplementation(project(":bluetape4k-junit5"))
+}

--- a/examples/spring-boot/observability-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/spring/observability/ObservabilitySpringBootDemoApplication.kt
+++ b/examples/spring-boot/observability-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/spring/observability/ObservabilitySpringBootDemoApplication.kt
@@ -1,0 +1,138 @@
+package io.bluetape4k.examples.spring.observability
+
+import io.bluetape4k.micrometer.observation.events.EventCorrelation
+import io.bluetape4k.micrometer.observation.events.EventDestination
+import io.bluetape4k.micrometer.observation.events.EventTelemetry
+import io.bluetape4k.micrometer.observation.events.observeEventConsume
+import io.bluetape4k.micrometer.observation.events.observeEventPublish
+import io.bluetape4k.spring.observability.SpringObservationKeyValues
+import io.bluetape4k.spring.observability.observeSpring
+import io.micrometer.common.KeyValue
+import io.micrometer.common.KeyValues
+import io.micrometer.observation.ObservationRegistry
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.stereotype.Service
+import java.io.Serializable
+
+private const val REQUEST_ID_HEADER = "X-Request-Id"
+
+/**
+ * Spring Boot observability example for Prometheus metrics and OTLP tracing configuration.
+ *
+ * ## Behavior
+ * - Exposes application metrics through Spring Boot Actuator's Prometheus endpoint.
+ * - Wraps HTTP service and application event paths with bluetape4k observation helpers.
+ * - Keeps OTLP exporter configuration application-owned through Spring Boot properties.
+ */
+@SpringBootApplication(proxyBeanMethods = false)
+class ObservabilitySpringBootDemoApplication
+
+fun main(args: Array<String>) {
+    runApplication<ObservabilitySpringBootDemoApplication>(*args)
+}
+
+@RestController
+internal class OrderEventController(
+    private val service: OrderEventService,
+) {
+
+    @GetMapping("/health")
+    fun health(): HealthResponse =
+        HealthResponse()
+
+    @PostMapping("/orders/{orderId}/events")
+    fun publishOrderEvent(
+        @PathVariable orderId: String,
+        @RequestHeader(REQUEST_ID_HEADER, required = false) correlationId: String?,
+    ): OrderEventResponse =
+        service.publishOrderEvent(orderId = orderId, rawCorrelationId = correlationId)
+}
+
+@Service
+internal class OrderEventService(
+    private val observationRegistry: ObservationRegistry,
+) {
+
+    fun publishOrderEvent(
+        orderId: String,
+        rawCorrelationId: String?,
+    ): OrderEventResponse =
+        observationRegistry.observeSpring(
+            name = "orders.http.publish",
+            keyValues = SpringObservationKeyValues(
+                lowCardinality = KeyValues.of(
+                    KeyValue.of("component", "observability-demo"),
+                    KeyValue.of("http.route", "/orders/{orderId}/events"),
+                ),
+            ),
+        ) { context ->
+            context.addLowCardinalityKeyValue(KeyValue.of("order.event", EVENT_TYPE))
+
+            val correlation = EventCorrelation.sanitized(rawCorrelationId)
+            val telemetry = EventTelemetry(
+                destination = EventDestination.spring("order-events"),
+                eventType = EVENT_TYPE,
+                correlation = correlation,
+                batchMessageCount = 1,
+            )
+            val event = OrderEvent(orderId = orderId, type = EVENT_TYPE)
+
+            observationRegistry.observeEventPublish(telemetry) {
+                publishToLocalChannel(event)
+            }
+            observationRegistry.observeEventConsume(telemetry) {
+                consumeFromLocalChannel(event)
+            }
+
+            OrderEventResponse(
+                orderId = orderId,
+                eventType = event.type,
+                correlationPresent = correlation.present,
+                status = "accepted",
+            )
+        }
+
+    private fun publishToLocalChannel(event: OrderEvent): OrderEvent =
+        event
+
+    private fun consumeFromLocalChannel(event: OrderEvent): OrderEvent =
+        event
+
+    companion object {
+        private const val EVENT_TYPE = "order.accepted"
+    }
+}
+
+internal data class OrderEvent(
+    val orderId: String,
+    val type: String,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 7379384661824745069L
+    }
+}
+
+internal data class OrderEventResponse(
+    val orderId: String,
+    val eventType: String,
+    val correlationPresent: Boolean,
+    val status: String,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = -9107738853997178628L
+    }
+}
+
+internal data class HealthResponse(
+    val status: String = "UP",
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 3030398709155074173L
+    }
+}

--- a/examples/spring-boot/observability-spring-boot-demo/src/main/resources/application.yaml
+++ b/examples/spring-boot/observability-spring-boot-demo/src/main/resources/application.yaml
@@ -1,0 +1,26 @@
+management:
+  defaults:
+    metrics:
+      export:
+        enabled: false
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    prometheus:
+      access: read_only
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+  tracing:
+    sampling:
+      probability: 1.0
+  otlp:
+    tracing:
+      endpoint: ${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:http://localhost:4318/v1/traces}
+
+logging:
+  level:
+    io.bluetape4k.examples.spring.observability: INFO

--- a/examples/spring-boot/observability-spring-boot-demo/src/test/kotlin/io/bluetape4k/examples/spring/observability/ObservabilitySpringBootDemoApplicationTest.kt
+++ b/examples/spring-boot/observability-spring-boot-demo/src/test/kotlin/io/bluetape4k/examples/spring/observability/ObservabilitySpringBootDemoApplicationTest.kt
@@ -1,0 +1,86 @@
+package io.bluetape4k.examples.spring.observability
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.http.HttpStatus
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+
+private const val REQUEST_ID_HEADER = "X-Request-Id"
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = [
+        "management.tracing.enabled=false",
+    ],
+)
+class ObservabilitySpringBootDemoApplicationTest {
+
+    @LocalServerPort
+    private val port: Int = 0
+
+    private val client: WebTestClient by lazy {
+        WebTestClient
+            .bindToServer()
+            .baseUrl("http://localhost:$port")
+            .build()
+    }
+
+    @Test
+    fun `application publishes event telemetry and returns correlation state`() {
+        val response = client
+            .post()
+            .uri("/orders/order-1/events")
+            .header(REQUEST_ID_HEADER, "REQ_123")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody<OrderEventResponse>()
+            .returnResult()
+            .responseBody
+            .shouldNotBeNull()
+
+        response.orderId shouldBeEqualTo "order-1"
+        response.eventType shouldBeEqualTo "order.accepted"
+        response.correlationPresent shouldBeEqualTo true
+        response.status shouldBeEqualTo "accepted"
+    }
+
+    @Test
+    fun `actuator prometheus endpoint exposes http and event observation metrics`() {
+        client
+            .post()
+            .uri("/orders/order-2/events")
+            .header(REQUEST_ID_HEADER, "REQ_456")
+            .exchange()
+            .expectStatus().isOk
+
+        val metrics = client
+            .get()
+            .uri("/actuator/prometheus")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody<String>()
+            .returnResult()
+            .responseBody
+            .shouldNotBeNull()
+
+        metrics.contains("http_server_requests").shouldBeTrue()
+        metrics.contains("event_publish").shouldBeTrue()
+        metrics.contains("event_consume").shouldBeTrue()
+    }
+
+    @Test
+    fun `actuator health remains available with observability configuration`() {
+        client
+            .get()
+            .uri("/actuator/health")
+            .exchange()
+            .expectStatus().isEqualTo(HttpStatus.OK)
+    }
+}

--- a/examples/spring-boot/observability-spring-boot-demo/src/test/resources/junit-platform.properties
+++ b/examples/spring-boot/observability-spring-boot-demo/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/examples/spring-boot/observability-spring-boot-demo/src/test/resources/logback-test.xml
+++ b/examples/spring-boot/observability-spring-boot-demo/src/test/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <!-- @formatter:off -->
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%24.24t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <!-- @formatter:on -->
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.examples.spring.observability" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
## Summary

Closes #692

- PR 제목: docs(examples): add observability demos

Closes #692.

Adds runnable observability examples for Spring Boot 4 and Ktor:

- `observability-spring-boot-demo` shows Spring Boot Actuator `/actuator/prometheus`, OTLP-oriented tracing configuration, `observeSpring`, and event publish/consume telemetry helpers.
- `observability-ktor-demo` shows application-owned Prometheus `/metrics`, opt-in OpenTelemetry tracing, Ktor observability helpers, and event publish/consume telemetry helpers.
- Each example README now includes an example scenario, architecture diagram, and sequence diagram.
- Updates root README locale lists and Examples/Nightly workflow coverage for the new modules.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Notes

Spring Boot owns Prometheus exposure through Actuator. Ktor owns a `PrometheusMeterRegistry` and exposes it with the bluetape4k `prometheusScrapeRoute` helper.

The Spring Boot demo disables non-Prometheus metrics exporters by default and explicitly enables Prometheus. This prevents unrelated registry implementations on the classpath, such as Datadog, from starting without credentials.

## Validation

- `./gradlew -q projects --no-configuration-cache | rg --fixed-strings -- "--- Project ':" | rg "observability|idgenerator"`
- `./gradlew :observability-ktor-demo:compileKotlin :observability-ktor-demo:test --no-daemon --console=plain`
- `./gradlew :observability-spring-boot-demo:compileKotlin :observability-spring-boot-demo:test --no-daemon --console=plain`
- `./gradlew :observability-ktor-demo:compileKotlin :observability-ktor-demo:test :observability-spring-boot-demo:compileKotlin :observability-spring-boot-demo:test --no-daemon --console=plain`
- `actionlint .github/workflows/examples.yml .github/workflows/nightly-tests.yml`
- `git diff --check`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #692, milestone `1.11.0`, assignee `debop`
- PR: #729, head `533d8901a3bd916ddd77cd77d6b1e8ffde7994b3`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `feat/issue-692-observability-examples`
- Labels: `documentation`, `examples`
- State: `MERGED`, merge commit `cf9efb348556eec6b46870084c9bdb3f2ea3007d`
- CI: - `observability-spring-boot-demo` shows Spring Boot Actuator `/actuator/prometheus`, OTLP-oriented tracing configuration, `observeSpring`, and event publish/consume telemetry helpers. / - `observability-ktor-demo` shows application-owned Prometheus `/metrics`, opt-in OpenTelemetry tracing, Ktor observability helpers, and event publish/consume telemetry helpers. / The Spring Boot demo disables non-Prometheus metrics exporters by default and explicitly enables Prometheus. This prevents unrelated registry implementations on the classpath, such as Datadog, from starting without credentials.

## DoD Status

- [x] Runnable Spring Boot 4 observability example added.
- [x] Runnable Ktor observability example added.
- [x] Example README scenario sections added.
- [x] Example README architecture diagrams added.
- [x] Example README sequence diagrams added.
- [x] Prometheus scrape paths documented separately for Spring Boot Actuator and Ktor app-owned routing.
- [x] Optional OTLP/OpenTelemetry tracing path documented and smoke-tested without requiring an external collector.
- [x] README.md and README.ko.md updated together.
- [x] Examples and Nightly workflows updated for new modules.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #729 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `cf9efb348556eec6b46870084c9bdb3f2ea3007d`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
