### PR TITLE
security(dependencies): consume patched catalog train

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install gitleaks
         run: |
           GITLEAKS_VERSION=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep '"tag_name"' | sed 's/.*"v\([^"]*\)".*/\1/')
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
             | tar -xz gitleaks
           sudo mv gitleaks /usr/local/bin/
       - name: Run gitleaks

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install gitleaks
         run: |
           GITLEAKS_VERSION=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep '"tag_name"' | sed 's/.*"v\([^"]*\)".*/\1/')
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
             | tar -xz gitleaks
           sudo mv gitleaks /usr/local/bin/
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -442,6 +442,11 @@ subprojects {
             dependency(rootLibs.lz4.java.get().toString())
             dependency(rootLibs.zstd.jni.get().toString())
 
+            // Shared security overrides are sourced from the imported bluetape4k-dependencies catalog.
+            dependency("org.apache.tomcat.embed:tomcat-embed-core:${bt4kVersion("tomcat")}")
+            dependency("io.opentelemetry:opentelemetry-api:${bt4kVersion("opentelemetry")}")
+            dependency("io.opentelemetry:opentelemetry-extension-trace-propagators:${bt4kVersion("opentelemetry")}")
+
             // Java Money
             dependency(rootLibs.javax.money.api.get().toString())
             dependency(rootLibs.javamoney.moneta.get().toString())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,7 +65,7 @@ lz4 = "1.11.0"  # https://mvnrepository.com/artifact/at.yawk.lz4/lz4-java
 hibernate = "7.3.4.Final"  # https://mvnrepository.com/artifact/org.hibernate.orm/hibernate-core
 hibernate-reactive = "4.3.3.Final"  # https://mvnrepository.com/artifact/org.hibernate.reactive/hibernate-reactive-core
 hibernate-validator = "9.1.0.Final"  # https://mvnrepository.com/artifact/org.hibernate.validator/hibernate-validator
-querydsl = "5.1.0"  # https://mvnrepository.com/artifact/com.querydsl/querydsl-apt
+querydsl = "5.6.1"  # https://mvnrepository.com/artifact/io.github.openfeign.querydsl/querydsl-apt
 
 exposed = "1.3.0"  # https://mvnrepository.com/artifact/org.jetbrains.exposed/exposed-bom
 r2dbc = "1.0.0.RELEASE"  # https://mvnrepository.com/artifact/io.r2dbc/r2dbc-spi
@@ -908,12 +908,12 @@ r2dbc-mariadb = { module = "org.mariadb:r2dbc-mariadb", version.ref = "r2dbc-mar
 r2dbc-postgresql = { module = "org.postgresql:r2dbc-postgresql", version.ref = "r2dbc-postgresql" }
 
 # QueryDSL
-querydsl-apt = { module = "com.querydsl:querydsl-apt", version.ref = "querydsl" }
-querydsl-core = { module = "com.querydsl:querydsl-core", version.ref = "querydsl" }
-querydsl-jpa = { module = "com.querydsl:querydsl-jpa", version.ref = "querydsl" }
-querydsl-sql = { module = "com.querydsl:querydsl-sql", version.ref = "querydsl" }
-querydsl-kotlin = { module = "com.querydsl:querydsl-kotlin", version.ref = "querydsl" }
-querydsl-kotlin-codegen = { module = "com.querydsl:querydsl-kotlin-codegen", version.ref = "querydsl" }
+querydsl-apt = { module = "io.github.openfeign.querydsl:querydsl-apt", version.ref = "querydsl" }
+querydsl-core = { module = "io.github.openfeign.querydsl:querydsl-core", version.ref = "querydsl" }
+querydsl-jpa = { module = "io.github.openfeign.querydsl:querydsl-jpa", version.ref = "querydsl" }
+querydsl-sql = { module = "io.github.openfeign.querydsl:querydsl-sql", version.ref = "querydsl" }
+querydsl-kotlin = { module = "io.github.openfeign.querydsl:querydsl-kotlin", version.ref = "querydsl" }
+querydsl-kotlin-codegen = { module = "io.github.openfeign.querydsl:querydsl-kotlin-codegen", version.ref = "querydsl" }
 
 # MyBatis
 mybatis = { module = "org.mybatis:mybatis", version = "3.5.19" }  # https://mvnrepository.com/artifact/org.mybatis/mybatis

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ pluginManagement {
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-    .orElse("catalog/2026-06-02-00")
+    .orElse("catalog/2026-06-07-00")
     .get()
 
 fun resolveBluetape4kDependenciesCatalogFile(): File {


### PR DESCRIPTION
## Summary

Closes #703

- PR 제목: security(dependencies): consume patched catalog train

- Move the default shared catalog ref to `catalog/2026-06-07-00` after the bluetape4k-dependencies security catalog train.
- Add dependency-management overrides for Tomcat and OpenTelemetry from the shared catalog instead of local one-off pins.
- Move Querydsl aliases to the maintained OpenFeign fork at `5.6.1` for the no-patch upstream advisory line.
- Fix the gitleaks install URL so the CI secret scan downloads the resolved release asset instead of a 404 `latest/download` path.

Closes #703.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Notes

- GitHub dependency graph may need a refresh after merge before the live Dependabot alert count drops.
- The root cause catalog work was merged in bluetape4k-dependencies PR #107 and tagged as `catalog/2026-06-07-00`.

## Validation

- `./gradlew :bluetape4k-spring-boot-core:dependencyInsight --dependency org.apache.tomcat.embed:tomcat-embed-core --configuration testRuntimeClasspath --no-configuration-cache` selected `11.0.22`.
- `./gradlew :bluetape4k-spring-boot-core:dependencyInsight --dependency io.opentelemetry:opentelemetry-api --configuration testRuntimeClasspath --no-configuration-cache` selected `1.62.0`.
- `./gradlew :bluetape4k-examples-jpa-querydsl-demo:dependencyInsight --dependency querydsl-jpa --configuration runtimeClasspath --no-configuration-cache` selected `io.github.openfeign.querydsl:querydsl-jpa:5.6.1`.
- `./gradlew :bluetape4k-hibernate:compileKotlin :bluetape4k-spring-boot-core:compileKotlin :bluetape4k-micrometer:compileKotlin :bluetape4k-examples-jpa-querydsl-demo:kaptKotlin :bluetape4k-examples-jpa-querydsl-demo:compileKotlin --no-configuration-cache`.
- `./gradlew projects --no-configuration-cache`.
- `actionlint .github/workflows/ci.yml .github/workflows/security.yml`.
- `curl -sSfI https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz` returned a GitHub release asset redirect.
- `gitleaks detect --source . --redact --no-git --config .gitleaks.toml --verbose` found no leaks locally.
- `git diff --check`.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #703, milestone `1.11.0`, assignee `debop`
- PR: #731, head `7e21a7efba407de660db2bf427a75771f897749e`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/projects-dependabot-catalog-overrides`
- Labels: `build`, `security`, `dependencies`
- State: `MERGED`, merge commit `e377f2ed4f50cc997a3295c6cf2a4b604046d31b`
- CI: - Move the default shared catalog ref to `catalog/2026-06-07-00` after the bluetape4k-dependencies security catalog train. / - Fix the gitleaks install URL so the CI secret scan downloads the resolved release asset instead of a 404 `latest/download` path. / - `./gradlew :bluetape4k-spring-boot-core:dependencyInsight --dependency org.apache.tomcat.embed:tomcat-embed-core --configuration testRuntimeClasspath --no-configuration-cache` selected `11.0.22`.

## DoD Status

- [x] Catalog default points at `catalog/2026-06-07-00`.
- [x] Tomcat and OpenTelemetry security overrides are sourced from the shared catalog.
- [x] Querydsl aliases use the patched OpenFeign fork coordinates.
- [x] Targeted dependency insight confirms patched selected versions.
- [x] Targeted compile/kapt validation passed.
- [x] Gitleaks install workflow URL is fixed and linted.
- [ ] GitHub dependency graph refresh checked after merge.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #731 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e377f2ed4f50cc997a3295c6cf2a4b604046d31b`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
