### PR TITLE
ci: harden gitleaks release asset install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,10 @@ jobs:
           fetch-depth: 0
       - name: Install gitleaks
         run: |
-          GITLEAKS_VERSION=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep '"tag_name"' | sed 's/.*"v\([^"]*\)".*/\1/')
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+          GITLEAKS_ASSET_URL=$(curl -sSfL https://api.github.com/repos/gitleaks/gitleaks/releases/latest \
+            | jq -r '.assets[] | select(.name | test("linux_x64\\.tar\\.gz$")) | .browser_download_url')
+          test -n "${GITLEAKS_ASSET_URL}"
+          curl -sSfL "${GITLEAKS_ASSET_URL}" \
             | tar -xz gitleaks
           sudo mv gitleaks /usr/local/bin/
       - name: Run gitleaks

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,8 +26,10 @@ jobs:
 
       - name: Install gitleaks
         run: |
-          GITLEAKS_VERSION=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep '"tag_name"' | sed 's/.*"v\([^"]*\)".*/\1/')
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+          GITLEAKS_ASSET_URL=$(curl -sSfL https://api.github.com/repos/gitleaks/gitleaks/releases/latest \
+            | jq -r '.assets[] | select(.name | test("linux_x64\\.tar\\.gz$")) | .browser_download_url')
+          test -n "${GITLEAKS_ASSET_URL}"
+          curl -sSfL "${GITLEAKS_ASSET_URL}" \
             | tar -xz gitleaks
           sudo mv gitleaks /usr/local/bin/
 


### PR DESCRIPTION
## Summary

Closes #733

- PR 제목: ci: harden gitleaks release asset install

- Closes #733.
- Updates the CI and Security gitleaks install steps to resolve the Linux x64 release asset from the GitHub release API.
- Removes manual version/path reconstruction so the scan job does not fail before `gitleaks detect` starts when release asset URLs drift.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- `.github/workflows/ci.yml`
- `.github/workflows/security.yml`

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

- Closes #733.
- Updates the CI and Security gitleaks install steps to resolve the Linux x64 release asset from the GitHub release API.
- Removes manual version/path reconstruction so the scan job does not fail before `gitleaks detect` starts when release asset URLs drift.

### Scope

- `.github/workflows/ci.yml`
- `.github/workflows/security.yml`

### Validation

- The latest gitleaks release API resolved a non-empty Linux x64 asset URL locally: `gitleaks_8.30.1_linux_x64.tar.gz`.
- `actionlint .github/workflows/ci.yml .github/workflows/security.yml`: PASS.
- `gitleaks detect --source . --redact --no-git --config .gitleaks.toml`: PASS, no leaks found.
- `git diff --check`: PASS.

### DoD Status

| Step | Evidence | Status |
|---|---|---|
| Issue scope | #733 targets the gitleaks install step in `.github/workflows/ci.yml` and `.github/workflows/security.yml`. | PASS |
| Implementation | Both workflows now select the `linux_x64.tar.gz` asset via the GitHub release API and download that `browser_download_url`. | PASS |
| Release asset lookup | Local lookup returned `https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz`. | PASS |
| Workflow lint | `actionlint .github/workflows/ci.yml .github/workflows/security.yml` completed with no diagnostics. | PASS |
| Secret scan | `gitleaks detect --source . --redact --no-git --config .gitleaks.toml` reported `no leaks found`. | PASS |
| Diff hygiene | `git diff --check` and `git diff --check --cached` passed before commit. | PASS |
| CI | GitHub PR checks passed: Secret Scan, Build, Test suites, Coverage Report, CI Status, Validate Gradle Wrapper, and submit-gradle. | PASS |

## Validation

- The latest gitleaks release API resolved a non-empty Linux x64 asset URL locally: `gitleaks_8.30.1_linux_x64.tar.gz`.
- `actionlint .github/workflows/ci.yml .github/workflows/security.yml`: PASS.
- `gitleaks detect --source . --redact --no-git --config .gitleaks.toml`: PASS, no leaks found.
- `git diff --check`: PASS.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #733, milestone `1.11.0`, assignee `debop`
- PR: #734, head `e18e251fc909cc5198a94c757eff94f658b34124`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-733-gitleaks-install`
- Labels: `ci`, `github_actions`
- State: `MERGED`, merge commit `aa7aa4171e520c90cf8418bfebb885990068021c`
- CI: - Updates the CI and Security gitleaks install steps to resolve the Linux x64 release asset from the GitHub release API. / - `.github/workflows/ci.yml` / - `actionlint .github/workflows/ci.yml .github/workflows/security.yml`: PASS.

## DoD Status

| Step | Evidence | Status |
|---|---|---|
| Issue scope | #733 targets the gitleaks install step in `.github/workflows/ci.yml` and `.github/workflows/security.yml`. | PASS |
| Implementation | Both workflows now select the `linux_x64.tar.gz` asset via the GitHub release API and download that `browser_download_url`. | PASS |
| Release asset lookup | Local lookup returned `https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz`. | PASS |
| Workflow lint | `actionlint .github/workflows/ci.yml .github/workflows/security.yml` completed with no diagnostics. | PASS |
| Secret scan | `gitleaks detect --source . --redact --no-git --config .gitleaks.toml` reported `no leaks found`. | PASS |
| Diff hygiene | `git diff --check` and `git diff --check --cached` passed before commit. | PASS |
| CI | GitHub PR checks passed: Secret Scan, Build, Test suites, Coverage Report, CI Status, Validate Gradle Wrapper, and submit-gradle. | PASS |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #734 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `aa7aa4171e520c90cf8418bfebb885990068021c`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
