### PR TITLE
Prepare coroutine blocking bridges for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
               - 'bluetape4k/logging/**'
               - 'virtualthread/api/**'
               - 'virtualthread/jdk21/**'
+              - 'virtualthread/jdk25/**'
             io:
               - 'io/io/**'
               - 'io/okio/**'
@@ -115,12 +116,12 @@ jobs:
               - 'ktor/**'
             key-utils:
               - 'utils/idgenerators/**'
-              - 'cache/core/**'
+              - 'cache/cache-core/**'
             infra:
               - 'infra/redisson/**'
               - 'infra/lettuce/**'
-              - 'cache/lettuce/**'
-              - 'cache/redisson/**'
+              - 'cache/cache-lettuce/**'
+              - 'cache/cache-redisson/**'
 
   # ── 2. 전체 빌드 (테스트 제외) ──────────────────────────────────────────
   build:
@@ -185,6 +186,7 @@ jobs:
               :bluetape4k-logging:test \
               :bluetape4k-virtualthread-api:test \
               :bluetape4k-virtualthread-jdk21:test \
+              :bluetape4k-virtualthread-jdk25:test \
               --parallel
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
@@ -199,6 +201,7 @@ jobs:
             :bluetape4k-logging:koverXmlReport \
             :bluetape4k-virtualthread-api:koverXmlReport \
             :bluetape4k-virtualthread-jdk21:koverXmlReport \
+            :bluetape4k-virtualthread-jdk25:koverXmlReport \
             --parallel
         continue-on-error: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
             VERSION="$INPUT_VERSION"
           fi
 
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
             echo "::error::Invalid version format: $VERSION"
             exit 1
           fi

--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/onBackpressureDrop.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/onBackpressureDrop.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.coroutines.flow.extensions
 
 import io.bluetape4k.support.uninitialized
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.ensureActive
@@ -41,6 +42,8 @@ internal fun <T> onBackpressureDropInternal(source: Flow<T>): Flow<T> = flow {
                     }
                 }
                 state.done.value = true
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Throwable) {
                 state.error.value = e
             }

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCache.kt
@@ -12,6 +12,7 @@ import io.github.resilience4j.kotlin.retry.executeSuspendFunction
 import io.github.resilience4j.retry.Retry
 import io.github.resilience4j.retry.RetryConfig
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -110,6 +111,8 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
             for (cmd in writeChannel) {
                 try {
                     retry.executeSuspendFunction { applyCommand(cmd) }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     log.error(e) { "Back cache write failed after ${config.retryMaxAttempts} retries, dropping command: $cmd" }
                 }

--- a/io/csv/README.ko.md
+++ b/io/csv/README.ko.md
@@ -196,7 +196,7 @@ v1.5.0부터 `io.bluetape4k.csv.v2` 패키지에 상위 수준 V2 API가 제공�
 | 라이터 타입       | `CsvRecordWriter`             | `FlowCsvWriter` (DSL)            |
 | 레코드 타입       | `Record` (인터페이스)             | `CsvRow` (data class)            |
 | 설정           | `CsvSettings` (data class)    | `CsvReaderConfig` / `CsvWriterConfig` (mutable builder) |
-| 취소 협력        | suspend 내 `ensureActive()`    | `channelFlow + ensureActive()`   |
+| 취소 협력        | `ensureActive()`와 interruptible 행 쓰기 | `channelFlow + ensureActive()`   |
 | quoteAll 지원  | 없음                            | `CsvWriterConfig.quoteAll = true` |
 
 ### V2 읽기

--- a/io/csv/README.md
+++ b/io/csv/README.md
@@ -196,7 +196,7 @@ Since v1.5.0, a higher-level V2 API is available under the `io.bluetape4k.csv.v2
 | Writer type         | `CsvRecordWriter`             | `FlowCsvWriter` (DSL)            |
 | Record type         | `Record` (interface)          | `CsvRow` (data class)            |
 | Settings            | `CsvSettings` (data class)    | `CsvReaderConfig` / `CsvWriterConfig` (mutable builder) |
-| Cancellation        | `ensureActive()` in suspend   | `channelFlow + ensureActive()`   |
+| Cancellation        | `ensureActive()` plus interruptible row writes | `channelFlow + ensureActive()`   |
 | quoteAll support    | No                            | `CsvWriterConfig.quoteAll = true` |
 
 ### Reading with V2

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendCsvRecordWriter.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendCsvRecordWriter.kt
@@ -6,9 +6,9 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.warn
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
 import java.io.Writer
 
 /**
@@ -53,7 +53,7 @@ class SuspendCsvRecordWriter(
      */
     override suspend fun writeHeaders(headers: Iterable<String>) {
         mutex.withLock {
-            withContext(Dispatchers.IO) { lineWriter.writeRow(headers) }
+            runInterruptible(Dispatchers.IO) { lineWriter.writeRow(headers) }
         }
     }
 
@@ -72,7 +72,7 @@ class SuspendCsvRecordWriter(
      */
     override suspend fun writeRow(row: Iterable<*>) {
         mutex.withLock {
-            withContext(Dispatchers.IO) { lineWriter.writeRow(row) }
+            runInterruptible(Dispatchers.IO) { lineWriter.writeRow(row) }
         }
     }
 

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendTsvRecordWriter.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/coroutines/SuspendTsvRecordWriter.kt
@@ -3,7 +3,9 @@ package io.bluetape4k.csv.coroutines
 import io.bluetape4k.csv.TsvSettings
 import io.bluetape4k.csv.internal.TsvLineWriter
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.io.Writer
@@ -48,7 +50,9 @@ class SuspendTsvRecordWriter(
      * ```
      */
     override suspend fun writeHeaders(headers: Iterable<String>) {
-        mutex.withLock { lineWriter.writeRow(headers) }
+        mutex.withLock {
+            runInterruptible(Dispatchers.IO) { lineWriter.writeRow(headers) }
+        }
     }
 
     /**
@@ -64,7 +68,9 @@ class SuspendTsvRecordWriter(
      * ```
      */
     override suspend fun writeRow(row: Iterable<*>) {
-        mutex.withLock { lineWriter.writeRow(row) }
+        mutex.withLock {
+            runInterruptible(Dispatchers.IO) { lineWriter.writeRow(row) }
+        }
     }
 
     /**

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/coroutines/SuspendCsvRecordWriterTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/coroutines/SuspendCsvRecordWriterTest.kt
@@ -1,13 +1,22 @@
 package io.bluetape4k.csv.coroutines
 
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.flow
-import io.bluetape4k.assertions.shouldContain
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.io.StringWriter
+import java.io.Writer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.seconds
 
 class SuspendCsvRecordWriterTest {
 
@@ -101,6 +110,38 @@ class SuspendCsvRecordWriterTest {
                 captured shouldContain """row1,1,2,3"""
                 captured shouldContain """row2,2,3,4"""
             }
+        }
+
+        @Test
+        fun `write row interrupts blocking writer on cancellation`() = runSuspendIO {
+            val started = CountDownLatch(1)
+            val interrupted = AtomicBoolean(false)
+            val blockingWriter = object: Writer() {
+                override fun write(cbuf: CharArray, off: Int, len: Int) {
+                    started.countDown()
+                    try {
+                        Thread.sleep(TimeUnit.SECONDS.toMillis(10))
+                    } catch (e: InterruptedException) {
+                        interrupted.set(true)
+                        throw e
+                    }
+                }
+
+                override fun flush() = Unit
+
+                override fun close() = Unit
+            }
+
+            val writer = SuspendCsvRecordWriter(blockingWriter)
+            val job = launch {
+                writer.writeRow(listOf("slow"))
+            }
+
+            started.await(1, TimeUnit.SECONDS) shouldBeEqualTo true
+            withTimeout(2.seconds) {
+                job.cancelAndJoin()
+            }
+            interrupted.get() shouldBeEqualTo true
         }
     }
 

--- a/io/okio/README.ko.md
+++ b/io/okio/README.ko.md
@@ -92,6 +92,9 @@ read 계약을 줄이기 위한 실용적인 I/O 계층입니다. 핵심 모델�
 - public immutable boundary에는 `ByteString`, 내부 mutable 작업 영역에는 `Buffer`를 사용합니다.
 - coroutine 코드에서는 blocking stream을 직접 감싸기보다 `SuspendedSource`/`SuspendedSink`와
   suspended buffered API를 사용합니다.
+- blocking Okio `Source`/`Sink`를 `asSuspended()`로 변환하면 bridge가 `runInterruptible`과
+  `Dispatchers.IO`로 delegate를 실행하므로, coroutine 취소가 진행 중인 blocking read/write/flush/close를
+  interrupt합니다.
 
 ## Anti-Patterns
 
@@ -324,6 +327,9 @@ val socketSink = SuspendedSocketChannelSink(socketChannel)
 `0L`을 반복 반환하는 상황을 방어합니다. `request`, `skip`, `select`, `indexOf`,
 `readAll`처럼 추가 데이터가 필요한 연산은 무한 루프 대신 반복 no-progress read 이후
 `IOException`을 던집니다.
+파일/소켓 suspended adapter는 `force()`, `flush()`, `close()` 같은 blocking cleanup 경계를
+`runInterruptible(Dispatchers.IO)`로 실행합니다. 따라서 coroutine이 취소되면 해당 리소스 경계의
+blocking 호출도 interrupt되어, 반환될 때까지 무기한 기다리지 않습니다.
 
 **Suspended Pipe (생산자-소비자 패턴):**
 

--- a/io/okio/README.md
+++ b/io/okio/README.md
@@ -103,6 +103,9 @@ Recommended defaults:
   mutable working area.
 - In coroutine code, prefer `SuspendedSource`/`SuspendedSink` and the suspended
   buffered APIs instead of wrapping blocking stream calls directly.
+- When adapting a blocking Okio `Source`/`Sink` with `asSuspended()`, the bridge
+  runs the delegate on `Dispatchers.IO` via `runInterruptible`, so coroutine
+  cancellation interrupts an in-flight blocking read, write, flush, or close.
 
 ## Anti-Patterns
 
@@ -347,6 +350,10 @@ Buffered suspended sources guard against broken or non-blocking delegates that
 repeatedly return `0L` for positive read requests. Operations that need more
 data, such as `request`, `skip`, `select`, `indexOf`, and `readAll`, throw an
 `IOException` after repeated no-progress reads instead of spinning forever.
+File and socket suspended adapters run blocking cleanup operations such as
+`force()`, `flush()`, and `close()` through `runInterruptible(Dispatchers.IO)`,
+so coroutine cancellation interrupts those blocking resource-boundary calls
+instead of only waiting for them to return.
 
 **Suspended Pipe (producer-consumer pattern):**
 

--- a/io/okio/src/main/kotlin/io/bluetape4k/okio/coroutines/SuspendedFileChannelSink.kt
+++ b/io/okio/src/main/kotlin/io/bluetape4k/okio/coroutines/SuspendedFileChannelSink.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.coroutines.support.awaitSuspending
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.runInterruptible
 import okio.Buffer
 import java.io.IOException
 import java.nio.ByteBuffer
@@ -29,7 +29,7 @@ fun AsynchronousFileChannel.asSuspendedSink(): SuspendedFileChannelSink =
  * [AsynchronousFileChannel] 기반의 코루틴 [SuspendedSink] 구현체.
  *
  * 쓰기 경로에서 direct [ByteBuffer]를 재사용해 할당/복사 비용을 줄인다.
- * `force()`와 `close()`는 블로킹 가능 API이므로 `Dispatchers.IO`에서 수행한다.
+ * `force()`와 `close()`는 블로킹 가능 API이므로 interruptible `Dispatchers.IO` 경계에서 수행한다.
  *
  * ```kotlin
  * val file = kotlin.io.path.createTempFile()
@@ -93,7 +93,7 @@ class SuspendedFileChannelSink(
      * Okio 코루틴 버퍼의 데이터를 실제 출력 대상으로 반영합니다.
      */
     override suspend fun flush() {
-        withContext(Dispatchers.IO) {
+        runInterruptible(Dispatchers.IO) {
             // force() is synchronous and may block.
             channel.force(false)
         }
@@ -103,7 +103,7 @@ class SuspendedFileChannelSink(
      * Okio 코루틴 리소스를 정리하고 닫습니다.
      */
     override suspend fun close() {
-        withContext(Dispatchers.IO) {
+        runInterruptible(Dispatchers.IO) {
             // Closing file descriptors may block on underlying OS resources.
             if (channel.isOpen) {
                 log.debug { "Closing AsynchronousFileChannel[$channel]" }

--- a/io/okio/src/main/kotlin/io/bluetape4k/okio/coroutines/SuspendedFileChannelSource.kt
+++ b/io/okio/src/main/kotlin/io/bluetape4k/okio/coroutines/SuspendedFileChannelSource.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.requireZeroOrPositiveNumber
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.runInterruptible
 import okio.Buffer
 import java.nio.ByteBuffer
 import java.nio.channels.AsynchronousFileChannel
@@ -30,7 +30,7 @@ fun AsynchronousFileChannel.asSuspendedSource(): SuspendedFileChannelSource =
  * [AsynchronousFileChannel] 기반의 코루틴 [SuspendedSource] 구현체.
  *
  * 성능을 위해 단일 direct [ByteBuffer]를 재사용하며, EOF는 `read()` 결과로 판별한다.
- * 리소스 해제는 블로킹 가능성이 있어 `Dispatchers.IO`에서 수행한다.
+ * 리소스 해제는 블로킹 가능성이 있어 interruptible `Dispatchers.IO` 경계에서 수행한다.
  *
  * ```kotlin
  * val file = kotlin.io.path.createTempFile()
@@ -94,7 +94,7 @@ class SuspendedFileChannelSource(
      * Okio 코루틴 리소스를 정리하고 닫습니다.
      */
     override suspend fun close() {
-        withContext(Dispatchers.IO) {
+        runInterruptible(Dispatchers.IO) {
             // Closing file descriptors may block on underlying OS resources.
             if (channel.isOpen) {
                 log.debug { "Closing AsynchronousFileChannel[$channel]" }

--- a/io/okio/src/main/kotlin/io/bluetape4k/okio/coroutines/SuspendedSocketChannelSink.kt
+++ b/io/okio/src/main/kotlin/io/bluetape4k/okio/coroutines/SuspendedSocketChannelSink.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.okio.SEGMENT_SIZE
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.runInterruptible
 import okio.Buffer
 import okio.EOFException
 import java.io.IOException
@@ -29,7 +29,7 @@ fun AsynchronousSocketChannel.asSuspendedSink(): SuspendedSocketChannelSink =
  * [AsynchronousSocketChannel] 기반의 코루틴 [SuspendedSink] 구현체.
  *
  * 쓰기 경로에서 direct [ByteBuffer]를 재사용해 chunk 할당을 줄이며,
- * close는 블로킹 가능성을 고려해 `Dispatchers.IO`에서 수행한다.
+ * close는 블로킹 가능성을 고려해 interruptible `Dispatchers.IO` 경계에서 수행한다.
  *
  * ```kotlin
  * val channel = AsynchronousSocketChannel.open()
@@ -90,7 +90,7 @@ class SuspendedSocketChannelSink(
      * Okio 코루틴 리소스를 정리하고 닫습니다.
      */
     override suspend fun close() {
-        withContext(Dispatchers.IO) {
+        runInterruptible(Dispatchers.IO) {
             // Close can block while native resources are released.
             if (channel.isOpen) {
                 log.debug { "Closing socket channel[$channel]" }

--- a/io/okio/src/main/kotlin/io/bluetape4k/okio/coroutines/SuspendedSocketChannelSource.kt
+++ b/io/okio/src/main/kotlin/io/bluetape4k/okio/coroutines/SuspendedSocketChannelSource.kt
@@ -6,7 +6,7 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.okio.SEGMENT_SIZE
 import io.bluetape4k.support.requireZeroOrPositiveNumber
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.runInterruptible
 import okio.Buffer
 import java.nio.ByteBuffer
 import java.nio.channels.AsynchronousSocketChannel
@@ -28,7 +28,7 @@ fun AsynchronousSocketChannel.asSuspendedSource(): SuspendedSocketChannelSource 
  * [AsynchronousSocketChannel] 기반의 코루틴 [SuspendedSource] 구현체.
  *
  * 반복 read에서 direct [ByteBuffer]를 재사용해 할당 비용을 줄이고,
- * close는 블로킹 가능성을 고려해 `Dispatchers.IO`에서 수행한다.
+ * close는 블로킹 가능성을 고려해 interruptible `Dispatchers.IO` 경계에서 수행한다.
  *
  * ```kotlin
  * val channel = AsynchronousSocketChannel.open()
@@ -76,7 +76,7 @@ class SuspendedSocketChannelSource(
      * Okio 코루틴 리소스를 정리하고 닫습니다.
      */
     override suspend fun close() {
-        withContext(Dispatchers.IO) {
+        runInterruptible(Dispatchers.IO) {
             // Close can block while native resources are released.
             if (channel.isOpen) {
                 log.debug { "Closing socket channel[$channel]" }

--- a/io/okio/src/main/kotlin/io/bluetape4k/okio/coroutines/SuspendedSocketSink.kt
+++ b/io/okio/src/main/kotlin/io/bluetape4k/okio/coroutines/SuspendedSocketSink.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.okio.coroutines.internal.await
 import io.bluetape4k.okio.readUnsafeAndClose
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.runInterruptible
 import okio.Buffer
 import java.io.IOException
 import java.net.Socket
@@ -30,7 +30,7 @@ fun Socket.asSuspendedSink(): SuspendedSocketSink = SuspendedSocketSink(this)
 /**
  * non-blocking [SocketChannel]을 이용해 소켓 쓰기를 제공하는 코루틴 [SuspendedSink].
  *
- * Selector 기반으로 쓰기 가능 시점을 기다리며, close는 `Dispatchers.IO`에서 수행한다.
+ * Selector 기반으로 쓰기 가능 시점을 기다리며, close는 interruptible `Dispatchers.IO` 경계에서 수행한다.
  *
  * ```kotlin
  * val socketChannel = SocketChannel.open()
@@ -92,7 +92,7 @@ class SuspendedSocketSink(socket: Socket): SuspendedSink {
      * Okio 코루틴 리소스를 정리하고 닫습니다.
      */
     override suspend fun close() {
-        withContext(Dispatchers.IO) {
+        runInterruptible(Dispatchers.IO) {
             // Close can block while the socket is being torn down.
             if (channel.isOpen) {
                 log.debug { "Closing socket channel[$channel]" }

--- a/io/okio/src/main/kotlin/io/bluetape4k/okio/coroutines/SuspendedSocketSource.kt
+++ b/io/okio/src/main/kotlin/io/bluetape4k/okio/coroutines/SuspendedSocketSource.kt
@@ -6,7 +6,7 @@ import io.bluetape4k.okio.SEGMENT_SIZE
 import io.bluetape4k.okio.coroutines.internal.await
 import io.bluetape4k.support.requireZeroOrPositiveNumber
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.runInterruptible
 import okio.Buffer
 import java.net.Socket
 import java.nio.ByteBuffer
@@ -31,7 +31,7 @@ fun Socket.asSuspendedSource(): SuspendedSocketSource = SuspendedSocketSource(th
  * non-blocking [SocketChannel]을 이용해 소켓 읽기를 제공하는 코루틴 [SuspendedSource].
  *
  * Selector 기반으로 읽기 가능 시점을 기다린 뒤 재사용 direct [ByteBuffer]로 읽는다.
- * 소켓 close는 블로킹 가능성이 있어 `Dispatchers.IO`에서 수행한다.
+ * 소켓 close는 블로킹 가능성이 있어 interruptible `Dispatchers.IO` 경계에서 수행한다.
  *
  * ```kotlin
  * val socketChannel = SocketChannel.open()
@@ -87,7 +87,7 @@ class SuspendedSocketSource(socket: Socket): SuspendedSource {
      * Okio 코루틴 리소스를 정리하고 닫습니다.
      */
     override suspend fun close() {
-        withContext(Dispatchers.IO) {
+        runInterruptible(Dispatchers.IO) {
             // Close can block while the socket is being torn down.
             if (channel.isOpen) {
                 log.debug { "Closing socket channel[$channel]" }

--- a/io/okio/src/main/kotlin/io/bluetape4k/okio/coroutines/internal/ForwardSuspendedSink.kt
+++ b/io/okio/src/main/kotlin/io/bluetape4k/okio/coroutines/internal/ForwardSuspendedSink.kt
@@ -2,35 +2,41 @@ package io.bluetape4k.okio.coroutines.internal
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.okio.coroutines.SuspendedSink
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runInterruptible
 import okio.Buffer
 import okio.Sink
 import okio.Timeout
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Okio 코루틴에서 사용하는 `ForwardSuspendedSink` 타입입니다.
  */
-internal class ForwardSuspendedSink(val delegate: Sink): SuspendedSink {
+internal class ForwardSuspendedSink(
+    val delegate: Sink,
+    private val context: CoroutineContext = Dispatchers.IO,
+): SuspendedSink {
 
     companion object: KLoggingChannel()
 
     /**
      * Okio 코루틴에서 데이터를 기록하는 `write` 함수를 제공합니다.
      */
-    override suspend fun write(source: Buffer, byteCount: Long) {
+    override suspend fun write(source: Buffer, byteCount: Long) = runInterruptible(context) {
         delegate.write(source, byteCount)
     }
 
     /**
      * Okio 코루틴 버퍼의 데이터를 실제 출력 대상으로 반영합니다.
      */
-    override suspend fun flush() {
+    override suspend fun flush() = runInterruptible(context) {
         delegate.flush()
     }
 
     /**
      * Okio 코루틴 리소스를 정리하고 닫습니다.
      */
-    override suspend fun close() {
+    override suspend fun close() = runInterruptible(context) {
         delegate.close()
     }
 

--- a/io/okio/src/main/kotlin/io/bluetape4k/okio/coroutines/internal/ForwardSuspendedSource.kt
+++ b/io/okio/src/main/kotlin/io/bluetape4k/okio/coroutines/internal/ForwardSuspendedSource.kt
@@ -2,28 +2,35 @@ package io.bluetape4k.okio.coroutines.internal
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.okio.coroutines.SuspendedSource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runInterruptible
 import okio.Buffer
 import okio.Source
 import okio.Timeout
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Okio 코루틴에서 사용하는 `ForwardSuspendedSource` 타입입니다.
  */
-internal class ForwardSuspendedSource(val delegate: Source): SuspendedSource {
+internal class ForwardSuspendedSource(
+    val delegate: Source,
+    private val context: CoroutineContext = Dispatchers.IO,
+): SuspendedSource {
 
     companion object: KLoggingChannel()
 
     /**
      * Okio 코루틴에서 데이터를 읽어오는 `read` 함수를 제공합니다.
      */
-    override suspend fun read(sink: Buffer, byteCount: Long): Long {
-        return delegate.read(sink, byteCount)
-    }
+    override suspend fun read(sink: Buffer, byteCount: Long): Long =
+        runInterruptible(context) {
+            delegate.read(sink, byteCount)
+        }
 
     /**
      * Okio 코루틴 리소스를 정리하고 닫습니다.
      */
-    override suspend fun close() {
+    override suspend fun close() = runInterruptible(context) {
         delegate.close()
     }
 

--- a/io/okio/src/test/kotlin/io/bluetape4k/okio/coroutines/BlockingInteropTimeoutTest.kt
+++ b/io/okio/src/test/kotlin/io/bluetape4k/okio/coroutines/BlockingInteropTimeoutTest.kt
@@ -1,14 +1,25 @@
 package io.bluetape4k.okio.coroutines
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.okio.AbstractOkioTest
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.withTimeout
 import okio.Buffer
+import okio.Sink
+import okio.Source
 import okio.Timeout
 import org.junit.jupiter.api.Test
 import java.io.InterruptedIOException
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import io.bluetape4k.assertions.assertFailsWith
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class BlockingInteropTimeoutTest: AbstractOkioTest() {
 
@@ -48,5 +59,73 @@ class BlockingInteropTimeoutTest: AbstractOkioTest() {
         assertFailsWith<InterruptedIOException> {
             sink.write(Buffer().writeUtf8("timeout"), 7L)
         }
+    }
+
+    @Test
+    fun `asSuspended source read cancellation interrupts blocking delegate`() = runSuspendIO {
+        val started = CountDownLatch(1)
+        val interrupted = AtomicBoolean(false)
+        val suspended = object: Source {
+            override fun read(sink: Buffer, byteCount: Long): Long {
+                started.countDown()
+                try {
+                    Thread.sleep(10_000L)
+                    return -1L
+                } catch (e: InterruptedException) {
+                    interrupted.set(true)
+                    throw InterruptedIOException("interrupted")
+                }
+            }
+
+            override fun close() {}
+            override fun timeout(): Timeout = Timeout.NONE
+        }.asSuspended()
+
+        supervisorScope {
+            val job = async {
+                suspended.read(Buffer(), 1L)
+            }
+
+            started.await(1, TimeUnit.SECONDS).shouldBeTrue()
+            withTimeout(1.seconds) {
+                job.cancelAndJoin()
+            }
+        }
+
+        interrupted.get().shouldBeTrue()
+    }
+
+    @Test
+    fun `asSuspended sink write cancellation interrupts blocking delegate`() = runSuspendIO {
+        val started = CountDownLatch(1)
+        val interrupted = AtomicBoolean(false)
+        val suspended = object: Sink {
+            override fun write(source: Buffer, byteCount: Long) {
+                started.countDown()
+                try {
+                    Thread.sleep(10_000L)
+                } catch (e: InterruptedException) {
+                    interrupted.set(true)
+                    throw InterruptedIOException("interrupted")
+                }
+            }
+
+            override fun flush() {}
+            override fun close() {}
+            override fun timeout(): Timeout = Timeout.NONE
+        }.asSuspended()
+
+        supervisorScope {
+            val job = async {
+                suspended.write(Buffer().writeUtf8("cancel"), 6L)
+            }
+
+            started.await(1, TimeUnit.SECONDS).shouldBeTrue()
+            withTimeout(1.seconds) {
+                job.cancelAndJoin()
+            }
+        }
+
+        interrupted.get().shouldBeTrue()
     }
 }

--- a/io/okio/src/test/kotlin/io/bluetape4k/okio/coroutines/SuspendedFileChannelSinkTest.kt
+++ b/io/okio/src/test/kotlin/io/bluetape4k/okio/coroutines/SuspendedFileChannelSinkTest.kt
@@ -1,20 +1,30 @@
 package io.bluetape4k.okio.coroutines
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.junit5.tempfolder.TempFolder
 import io.bluetape4k.junit5.tempfolder.TempFolderTest
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.okio.AbstractOkioTest
 import io.bluetape4k.support.toUtf8String
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 import okio.Buffer
-import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
+import java.io.InterruptedIOException
 import java.nio.ByteBuffer
 import java.nio.channels.AsynchronousFileChannel
+import java.nio.channels.CompletionHandler
+import java.nio.channels.FileLock
 import java.nio.file.StandardOpenOption
-import io.bluetape4k.assertions.assertFailsWith
+import java.util.concurrent.Future
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.seconds
 
 @TempFolderTest
 class SuspendedFileChannelSinkTest: AbstractOkioTest() {
@@ -140,5 +150,105 @@ class SuspendedFileChannelSinkTest: AbstractOkioTest() {
         }
 
         sink.close()
+    }
+
+    @Test
+    fun `flush interrupts blocking force when cancelled`() = runSuspendIO {
+        withTimeout(5.seconds) {
+            val channel = InterruptibleFileChannel()
+            val sink = channel.asSuspendedSink()
+
+            val job = launch {
+                try {
+                    sink.flush()
+                } catch (e: InterruptedIOException) {
+                    // Expected when cancellation interrupts the blocking force() call.
+                }
+            }
+            channel.forceEntered.await()
+            job.cancelAndJoin()
+
+            channel.forceInterrupted.get() shouldBeEqualTo true
+        }
+    }
+
+    private class InterruptibleFileChannel: AsynchronousFileChannel() {
+        val forceEntered = CompletableDeferred<Unit>()
+        val forceInterrupted = AtomicBoolean(false)
+
+        private val open = AtomicBoolean(true)
+
+        override fun isOpen(): Boolean = open.get()
+
+        override fun close() {
+            open.set(false)
+        }
+
+        override fun size(): Long = 0L
+
+        override fun truncate(size: Long): AsynchronousFileChannel = this
+
+        override fun force(metaData: Boolean) {
+            forceEntered.complete(Unit)
+            blockUntilInterrupted(forceInterrupted)
+        }
+
+        override fun <A: Any?> lock(
+            position: Long,
+            size: Long,
+            shared: Boolean,
+            attachment: A,
+            handler: CompletionHandler<FileLock, in A>,
+        ) {
+            throw UnsupportedOperationException()
+        }
+
+        override fun lock(position: Long, size: Long, shared: Boolean): Future<FileLock> {
+            throw UnsupportedOperationException()
+        }
+
+        override fun tryLock(position: Long, size: Long, shared: Boolean): FileLock {
+            throw UnsupportedOperationException()
+        }
+
+        override fun <A: Any?> read(
+            dst: ByteBuffer,
+            position: Long,
+            attachment: A,
+            handler: CompletionHandler<Int, in A>,
+        ) {
+            throw UnsupportedOperationException()
+        }
+
+        override fun read(dst: ByteBuffer, position: Long): Future<Int> {
+            throw UnsupportedOperationException()
+        }
+
+        override fun <A: Any?> write(
+            src: ByteBuffer,
+            position: Long,
+            attachment: A,
+            handler: CompletionHandler<Int, in A>,
+        ) {
+            throw UnsupportedOperationException()
+        }
+
+        override fun write(src: ByteBuffer, position: Long): Future<Int> {
+            throw UnsupportedOperationException()
+        }
+
+        private fun blockUntilInterrupted(interrupted: AtomicBoolean): Nothing {
+            try {
+                while (true) {
+                    Thread.sleep(1_000L)
+                }
+            } catch (e: InterruptedException) {
+                interrupted.set(true)
+                Thread.currentThread().interrupt()
+                throw InterruptedIOException("blocking call interrupted").apply {
+                    initCause(e)
+                }
+            }
+        }
     }
 }

--- a/spring-boot/core/README.ko.md
+++ b/spring-boot/core/README.ko.md
@@ -112,8 +112,12 @@ val hasMapping = method.hasMergedAnnotation<RequestMapping>()
 
 ### RestClient Coroutines DSL
 
+이 DSL은 blocking `RestClient` 호출을 `runInterruptible(Dispatchers.IO)` 로 실행한다.
+따라서 요청 factory가 thread interrupt를 존중하면 coroutine cancellation 이 대기 중인
+client thread 를 interrupt 할 수 있다.
+
 ```kotlin
-import io.bluetape4k.spring4.http.*
+import io.bluetape4k.spring.http.*
 
 val restClient = RestClient.create("https://api.example.com")
 
@@ -127,7 +131,7 @@ restClient.suspendDelete("/users/1")
 ### WebClient 확장
 
 ```kotlin
-import io.bluetape4k.spring4.tests.*
+import io.bluetape4k.spring.tests.*
 
 val webClient = WebClient.create("https://api.example.com")
 

--- a/spring-boot/core/README.md
+++ b/spring-boot/core/README.md
@@ -112,8 +112,12 @@ val hasMapping = method.hasMergedAnnotation<RequestMapping>()
 
 ### RestClient Coroutines DSL
 
+The DSL runs blocking `RestClient` calls with `runInterruptible(Dispatchers.IO)`,
+so coroutine cancellation can interrupt the waiting client thread when the
+underlying request factory honors interruption.
+
 ```kotlin
-import io.bluetape4k.spring4.http.*
+import io.bluetape4k.spring.http.*
 
 val restClient = RestClient.create("https://api.example.com")
 
@@ -127,7 +131,7 @@ restClient.suspendDelete("/users/1")
 ### WebClient Extensions
 
 ```kotlin
-import io.bluetape4k.spring4.tests.*
+import io.bluetape4k.spring.tests.*
 
 val webClient = WebClient.create("https://api.example.com")
 

--- a/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/http/RestClientCoroutinesDsl.kt
+++ b/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/http/RestClientCoroutinesDsl.kt
@@ -1,7 +1,7 @@
 package io.bluetape4k.spring.http
 
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.runInterruptible
 import org.springframework.http.MediaType
 import org.springframework.web.client.RestClient
 
@@ -20,7 +20,7 @@ suspend inline fun <reified T: Any> RestClient.suspendGet(
     uri: String,
     accept: MediaType? = null,
 ): T =
-    withContext(Dispatchers.IO) {
+    runInterruptible(Dispatchers.IO) {
         val spec = get().uri(uri)
         if (accept != null) spec.accept(accept)
         spec.retrieve().body(T::class.java)!!
@@ -45,7 +45,7 @@ suspend inline fun <reified T: Any> RestClient.suspendPost(
     contentType: MediaType? = null,
     accept: MediaType? = null,
 ): T =
-    withContext(Dispatchers.IO) {
+    runInterruptible(Dispatchers.IO) {
         val spec = post().uri(uri)
         if (contentType != null) spec.contentType(contentType)
         if (accept != null) spec.accept(accept)
@@ -72,7 +72,7 @@ suspend inline fun <reified T: Any> RestClient.suspendPut(
     contentType: MediaType? = null,
     accept: MediaType? = null,
 ): T =
-    withContext(Dispatchers.IO) {
+    runInterruptible(Dispatchers.IO) {
         val spec = put().uri(uri)
         if (contentType != null) spec.contentType(contentType)
         if (accept != null) spec.accept(accept)
@@ -99,7 +99,7 @@ suspend inline fun <reified T: Any> RestClient.suspendPatch(
     contentType: MediaType? = null,
     accept: MediaType? = null,
 ): T =
-    withContext(Dispatchers.IO) {
+    runInterruptible(Dispatchers.IO) {
         val spec = patch().uri(uri)
         if (contentType != null) spec.contentType(contentType)
         if (accept != null) spec.accept(accept)
@@ -122,7 +122,7 @@ suspend inline fun <reified T: Any> RestClient.suspendGetOrNull(
     uri: String,
     accept: MediaType? = null,
 ): T? =
-    withContext(Dispatchers.IO) {
+    runInterruptible(Dispatchers.IO) {
         val spec = get().uri(uri)
         if (accept != null) spec.accept(accept)
         spec.retrieve().body(T::class.java)
@@ -147,7 +147,7 @@ suspend inline fun <reified T: Any> RestClient.suspendPostOrNull(
     contentType: MediaType? = null,
     accept: MediaType? = null,
 ): T? =
-    withContext(Dispatchers.IO) {
+    runInterruptible(Dispatchers.IO) {
         val spec = post().uri(uri)
         if (contentType != null) spec.contentType(contentType)
         if (accept != null) spec.accept(accept)
@@ -174,7 +174,7 @@ suspend inline fun <reified T: Any> RestClient.suspendPutOrNull(
     contentType: MediaType? = null,
     accept: MediaType? = null,
 ): T? =
-    withContext(Dispatchers.IO) {
+    runInterruptible(Dispatchers.IO) {
         val spec = put().uri(uri)
         if (contentType != null) spec.contentType(contentType)
         if (accept != null) spec.accept(accept)
@@ -201,7 +201,7 @@ suspend inline fun <reified T: Any> RestClient.suspendPatchOrNull(
     contentType: MediaType? = null,
     accept: MediaType? = null,
 ): T? =
-    withContext(Dispatchers.IO) {
+    runInterruptible(Dispatchers.IO) {
         val spec = patch().uri(uri)
         if (contentType != null) spec.contentType(contentType)
         if (accept != null) spec.accept(accept)
@@ -223,7 +223,7 @@ suspend fun RestClient.suspendDelete(
     uri: String,
     accept: MediaType? = null,
 ): Unit =
-    withContext(Dispatchers.IO) {
+    runInterruptible(Dispatchers.IO) {
         val spec = delete().uri(uri)
         if (accept != null) spec.accept(accept)
         spec.retrieve().toBodilessEntity()

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/http/RestClientCoroutinesDslTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/http/RestClientCoroutinesDslTest.kt
@@ -1,15 +1,35 @@
 package io.bluetape4k.spring.http
 
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.KLogging
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
-import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
+import org.springframework.http.client.AbstractClientHttpRequest
+import org.springframework.http.client.ClientHttpRequest
+import org.springframework.http.client.ClientHttpRequestFactory
+import org.springframework.http.client.ClientHttpResponse
 import org.springframework.web.client.RestClient
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.OutputStream
+import java.net.URI
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration.Companion.seconds
 
 class RestClientCoroutinesDslTest {
     companion object: KLogging()
@@ -88,6 +108,34 @@ class RestClientCoroutinesDslTest {
         }
 
     @Test
+    fun `suspendGet cancels delayed blocking response promptly`() =
+        runSuspendIO {
+            val executeStarted = CountDownLatch(1)
+            val interrupted = AtomicBoolean(false)
+            val interruptibleClient =
+                RestClient
+                    .builder()
+                    .requestFactory(InterruptibleBlockingRequestFactory(executeStarted, interrupted))
+                    .build()
+            val failure = AtomicReference<Throwable?>()
+
+            val job = launch {
+                runCatching {
+                    interruptibleClient.suspendGet<String>("/slow")
+                }.onFailure {
+                    failure.set(it)
+                }
+            }
+
+            executeStarted.await(1, TimeUnit.SECONDS) shouldBeEqualTo true
+            withTimeout(2.seconds) {
+                job.cancelAndJoin()
+            }
+            interrupted.get() shouldBeEqualTo true
+            failure.get()?.cause?.cause?.message shouldBeEqualTo "blocking request interrupted"
+        }
+
+    @Test
     fun `suspendGetOrNull은 응답 본문이 있으면 역직렬화한다`() =
         runTest {
             mockServer.enqueue(
@@ -134,4 +182,53 @@ class RestClientCoroutinesDslTest {
             val result: String? = restClient.suspendPatchOrNull("/test", "payload", MediaType.APPLICATION_JSON)
             result shouldBeEqualTo "patched"
         }
+
+    private class InterruptibleBlockingRequestFactory(
+        private val executeStarted: CountDownLatch,
+        private val interrupted: AtomicBoolean,
+    ): ClientHttpRequestFactory {
+
+        override fun createRequest(
+            uri: URI,
+            httpMethod: HttpMethod,
+        ): ClientHttpRequest =
+            object: AbstractClientHttpRequest() {
+                override fun getMethod(): HttpMethod = httpMethod
+
+                override fun getURI(): URI = uri
+
+                override fun getBodyInternal(headers: HttpHeaders): OutputStream =
+                    ByteArrayOutputStream()
+
+                override fun executeInternal(headers: HttpHeaders): ClientHttpResponse {
+                    executeStarted.countDown()
+                    return try {
+                        Thread.sleep(TimeUnit.SECONDS.toMillis(30))
+                        StringClientHttpResponse("too-late")
+                    } catch (e: InterruptedException) {
+                        interrupted.set(true)
+                        Thread.currentThread().interrupt()
+                        throw IOException("blocking request interrupted", e)
+                    }
+                }
+            }
+    }
+
+    private class StringClientHttpResponse(
+        private val body: String,
+    ): ClientHttpResponse {
+        private val headers = HttpHeaders().apply {
+            contentType = MediaType.TEXT_PLAIN
+        }
+
+        override fun getStatusCode() = org.springframework.http.HttpStatus.OK
+
+        override fun getStatusText(): String = "OK"
+
+        override fun getHeaders(): HttpHeaders = headers
+
+        override fun getBody() = ByteArrayInputStream(body.toByteArray())
+
+        override fun close() = Unit
+    }
 }

--- a/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/api/WorkAdapters.kt
+++ b/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/api/WorkAdapters.kt
@@ -2,12 +2,12 @@ package io.bluetape4k.workflow.api
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.runInterruptible
 
 /**
  * 동기 [Work]를 코루틴 [SuspendWork]로 변환합니다.
  *
- * [Dispatchers.IO]에서 블로킹 실행을 래핑합니다.
+ * [Dispatchers.IO]에서 interruptible 블로킹 실행을 래핑합니다.
  *
  * ```kotlin
  * val suspendWork = blockingWork.asSuspend()
@@ -16,7 +16,7 @@ import kotlinx.coroutines.withContext
  * @return 변환된 [SuspendWork]
  */
 fun Work.asSuspend(): SuspendWork = SuspendWork { ctx ->
-    withContext(Dispatchers.IO) { execute(ctx) }
+    runInterruptible(Dispatchers.IO) { execute(ctx) }
 }
 
 /**

--- a/utils/workflow/src/test/kotlin/io/bluetape4k/workflow/api/WorkAdapterTest.kt
+++ b/utils/workflow/src/test/kotlin/io/bluetape4k/workflow/api/WorkAdapterTest.kt
@@ -1,12 +1,21 @@
 package io.bluetape4k.workflow.api
 
-import kotlinx.coroutines.runBlocking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class WorkAdapterTest: AbstractWorkflowTest() {
 
@@ -53,6 +62,35 @@ class WorkAdapterTest: AbstractWorkflowTest() {
         report.isSuccess.shouldBeTrue()
         val result: String? = report.context["result"]
         result shouldBeEqualTo "processed-value"
+    }
+
+    @Test
+    fun `Work asSuspend 취소 시 blocking Work를 interrupt 한다`() = runSuspendIO {
+        val started = CountDownLatch(1)
+        val interrupted = AtomicBoolean(false)
+        val suspendWork = Work { ctx ->
+            started.countDown()
+            try {
+                Thread.sleep(10_000L)
+            } catch (e: InterruptedException) {
+                interrupted.set(true)
+                throw e
+            }
+            WorkReport.success(ctx)
+        }.asSuspend()
+
+        supervisorScope {
+            val job = async {
+                suspendWork.execute(context)
+            }
+
+            started.await(1, TimeUnit.SECONDS).shouldBeTrue()
+            withTimeout(1.seconds) {
+                job.cancelAndJoin()
+            }
+        }
+
+        interrupted.get().shouldBeTrue()
     }
 
     @Test


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: Prepare coroutine blocking bridges for release

- Replaced blocking coroutine wrappers in RestClient, Okio forwarding adapters, CSV writing, workflow adapters, and selected cache/Flow fallbacks with cancellable interruptible boundaries where the underlying API blocks.
- Added regression tests for interrupt propagation, cancellation, dispatcher usage, and IO cleanup paths across Spring Boot core, Okio, CSV, workflow, coroutines, and cache-core.
- Refreshed related README notes and hardened CI/release workflow coverage for virtualthread JDK25, cache module path filters, and release version validation.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary
- Replaced blocking coroutine wrappers in RestClient, Okio forwarding adapters, CSV writing, workflow adapters, and selected cache/Flow fallbacks with cancellable interruptible boundaries where the underlying API blocks.
- Added regression tests for interrupt propagation, cancellation, dispatcher usage, and IO cleanup paths across Spring Boot core, Okio, CSV, workflow, coroutines, and cache-core.
- Refreshed related README notes and hardened CI/release workflow coverage for virtualthread JDK25, cache module path filters, and release version validation.

### Review Notes
- `bluetape4k-testcontainers` itself was intentionally excluded only from the final full local build, per release-prep build scope.
- Other modules, including Testcontainers-backed modules and examples, remained in the final local build.

### Validation
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `git diff --check`
- Targeted Gradle tests for `spring-boot-core`, `csv`, `okio`, `workflow`, `coroutines`, and `cache-core` changed behavior.
- `./gradlew --no-daemon build -x :bluetape4k-testcontainers:build -x :bluetape4k-testcontainers:check -x :bluetape4k-testcontainers:test -x :bluetape4k-testcontainers:k8sTest -x :bluetape4k-testcontainers:assemble`

### DoD Status
- [x] Interruptible coroutine bridge changes are covered by focused regression tests.
- [x] Documentation updated for changed coroutine/Okio usage.
- [x] Workflow and release YAML syntax validated.
- [x] Local build passed with only `bluetape4k-testcontainers` module self build/check/test/k8sTest/assemble excluded.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `git diff --check`
- Targeted Gradle tests for `spring-boot-core`, `csv`, `okio`, `workflow`, `coroutines`, and `cache-core` changed behavior.
- `./gradlew --no-daemon build -x :bluetape4k-testcontainers:build -x :bluetape4k-testcontainers:check -x :bluetape4k-testcontainers:test -x :bluetape4k-testcontainers:k8sTest -x :bluetape4k-testcontainers:assemble`

## Review Notes

- `bluetape4k-testcontainers` itself was intentionally excluded only from the final full local build, per release-prep build scope.
- Other modules, including Testcontainers-backed modules and examples, remained in the final local build.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #735, head `003d53127f584746f195a0876db00d9f2a9a4458`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/release-prep-coroutine-build-hardening`
- Labels: 없음
- State: `MERGED`, merge commit `2d95c1f9925e41cec1edd4a31fc1c5d7f04d14ab`
- CI: - Refreshed related README notes and hardened CI/release workflow coverage for virtualthread JDK25, cache module path filters, and release version validation. / - `actionlint .github/workflows/ci.yml .github/workflows/release.yml` / - Targeted Gradle tests for `spring-boot-core`, `csv`, `okio`, `workflow`, `coroutines`, and `cache-core` changed behavior.

## DoD Status

- [x] Interruptible coroutine bridge changes are covered by focused regression tests.
- [x] Documentation updated for changed coroutine/Okio usage.
- [x] Workflow and release YAML syntax validated.
- [x] Local build passed with only `bluetape4k-testcontainers` module self build/check/test/k8sTest/assemble excluded.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #735 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `2d95c1f9925e41cec1edd4a31fc1c5d7f04d14ab`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
