### PR TITLE
Apply Kotlin 2.4 catalog train

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 
 [versions]
 bluetape4k = "1.11.0-SNAPSHOT"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
-kotlin = "2.3.21"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
+kotlin = "2.4.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
 kotlinx-coroutines = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-bom
 kotlinx-serialization = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-serialization-bom
 kotlinx-atomicfu = "0.32.1"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/atomicfu

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ pluginManagement {
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-    .orElse("catalog/2026-06-07-00")
+    .orElse("catalog/2026-06-09-01")
     .get()
 
 fun resolveBluetape4kDependenciesCatalogFile(): File {


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: Apply Kotlin 2.4 catalog train

- Apply shared dependencies catalog tag `catalog/2026-06-09-01`.
- Move Kotlin catalog entries to `2.4.0` through the synced version catalog.
- Keep downstream builds pinned to an immutable catalog train.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Notes

- Kotlin language/API levels remain controlled by each repo build configuration; this change advances catalog dependency/plugin versions only.
- detekt 2.0.0-alpha.3 is validated with Kotlin 2.3.21, so graph keeps the detekt runtime Kotlin classpath isolated from the project Kotlin BOM.

## Validation

- ./gradlew --no-daemon build -x test -x k8sTest -x :bluetape4k-testcontainers:build -x :bluetape4k-testcontainers:check --parallel --no-configuration-cache: BUILD SUCCESSFUL in 13s; full build -x test also passed in 1m 18s but included testcontainers custom k8sTest

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #736, head `a066908db4da1729cadba4b24bea08e2f7e4078b`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `codex/kotlin-2-4-catalog`
- Labels: 없음
- State: `MERGED`, merge commit `7b4ba4105e0be74796a44192bf788ccf91e3e365`
- CI: - Apply shared dependencies catalog tag `catalog/2026-06-09-01`. / - detekt 2.0.0-alpha.3 is validated with Kotlin 2.3.21, so graph keeps the detekt runtime Kotlin classpath isolated from the project Kotlin BOM. / - ./gradlew --no-daemon build -x test -x k8sTest -x :bluetape4k-testcontainers:build -x :bluetape4k-testcontainers:check --parallel --no-configuration-cache: BUILD SUCCESSFUL in 13s; full build -x test also passed in 1m 18s but included testcontainers custom k8sTest

## DoD Status

- [x] Catalog ref points to `catalog/2026-06-09-01` where this repo consumes raw catalog refs.
- [x] Kotlin catalog value is `2.4.0`.
- [x] Local build validation completed as listed above.
- [ ] Merge after GitHub checks are green.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #736 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `7b4ba4105e0be74796a44192bf788ccf91e3e365`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
