### PR TITLE
ci: pause CodeQL java-kotlin for Kotlin 2.4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [java-kotlin, python, actions]
+        # TODO(#741, #743): Re-enable java-kotlin after CodeQL supports
+        # Kotlin 2.4.x. Keep actions/python analysis active while the Kotlin
+        # extractor support window catches up.
+        language: [python, actions]
 
     steps:
       - name: Checkout repository
@@ -37,7 +40,9 @@ jobs:
 
       - name: Build with Gradle
         if: matrix.language == 'java-kotlin'
-        run: ./gradlew build -x test --no-daemon
+        # TODO(#745): Keep the re-enabled java-kotlin build compile-only;
+        # `build -x test` still schedules custom Test tasks such as k8sTest.
+        run: ./gradlew assemble --no-daemon
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/docs/lessons/2026-06-11-issue-741-codeql-kotlin24.md
+++ b/docs/lessons/2026-06-11-issue-741-codeql-kotlin24.md
@@ -1,0 +1,27 @@
+# Issue #741 CodeQL Kotlin 2.4
+
+## Context
+
+Kotlin 2.4.0 landed before CodeQL Java/Kotlin extractor support caught up.
+Nightly and Publish Snapshot were green on the same head, but CodeQL failed only
+on the `java-kotlin` axis.
+
+## Lesson
+
+When a security scanner has a language support-window mismatch, keep unaffected
+scanner axes running and disable only the incompatible axis. Do not downgrade
+the project toolchain just to satisfy scanner lag.
+
+## Follow-up Guard
+
+When re-enabling CodeQL `java-kotlin`, use a true compile-only Gradle command
+such as `assemble`. `build -x test` is not enough in this repository because
+custom `Test` tasks can still enter the task graph.
+
+## Evidence
+
+- CodeQL run `27250113912`: `actions` and `python` passed, `java-kotlin`
+  failed.
+- Nightly run `27299345368`: succeeded on the same SHA.
+- Publish Snapshot run `27299715400`: succeeded on the same SHA.
+- Local workflow validation: `actionlint .github/workflows/codeql.yml`.

--- a/docs/review/2026-06-11-issue-741-codeql-kotlin24-review.md
+++ b/docs/review/2026-06-11-issue-741-codeql-kotlin24-review.md
@@ -1,0 +1,37 @@
+# Issue #741 CodeQL Kotlin 2.4 Review
+
+Date: 2026-06-11
+Scope: `.github/workflows/codeql.yml`
+Issue: #741
+
+## Review Result
+
+- P0: 0
+- P1: 0
+- P2/P3: none
+
+## Evidence
+
+- The failing CodeQL run `27250113912` failed only on
+  `Analyze (java-kotlin)`; `Analyze (actions)` and `Analyze (python)` passed.
+- Same-head Nightly run `27299345368` and Publish Snapshot run `27299715400`
+  succeeded, so this is a CodeQL extractor support-window issue rather than a
+  product regression signal.
+- The workflow matrix now keeps `python` and `actions` enabled and removes only
+  `java-kotlin` until CodeQL supports Kotlin 2.4.x.
+- The dormant `java-kotlin` Gradle build command is changed to `assemble` so a
+  future re-enable remains compile-only and does not schedule custom `Test`
+  tasks such as `k8sTest`.
+
+## Validation
+
+- `actionlint .github/workflows/codeql.yml`: PASS
+- `rg -n --fixed-strings "\\'" .github/workflows`: PASS, no escaped single
+  quote hits
+- `git diff --check`: PASS
+
+## Gate Verdict
+
+PASS. The change is limited to the intended CodeQL workflow surface, preserves
+non-Kotlin CodeQL coverage, and records the re-enable conditions in workflow
+comments.


### PR DESCRIPTION
## Summary

Closes #741, #743, #745

- PR 제목: ci: pause CodeQL java-kotlin for Kotlin 2.4

Closes #741
Closes #743
Closes #745
Fixes #745

Pause only the CodeQL `java-kotlin` matrix axis while CodeQL catches up to
Kotlin 2.4.x, keeping the healthy `actions` and `python` analysis axes active.

## Background

CodeQL run `27250113912` failed only on `Analyze (java-kotlin)` with the
extractor support-window error for Kotlin 2.4.0. The same SHA had green Nightly
and Publish Snapshot runs, so this is scanner/tooling lag rather than a product
runtime regression.

Issue #743 reports the same failure mode and acceptance criteria as #741:
disable only `java-kotlin`, keep `actions` and `python`, and leave a clear
re-enable TODO/reference.

Issue #745 covers the dormant `java-kotlin` build command: `build -x test` is
not compile-only because it can still schedule custom `Test` tasks such as
`k8sTest`. The PR changes that dormant command to `assemble` for the eventual
re-enable path.

## What This Solves

- Avoids scheduled CodeQL failures caused solely by Kotlin 2.4 extractor lag.
- Preserves unaffected CodeQL coverage for `actions` and `python`.
- Records the future re-enable guard for `java-kotlin`.
- Keeps the future `java-kotlin` build compile-only with `./gradlew assemble --no-daemon`.

## Work Done

- `.github/workflows/codeql.yml`: removed `java-kotlin` from the active matrix
  and added TODOs for #741/#743 re-enable criteria.
- `.github/workflows/codeql.yml`: changed the dormant Kotlin build command from
  `build -x test` to `assemble` so a future re-enable does not schedule custom
  `Test` tasks.
- `docs/review/2026-06-11-issue-741-codeql-kotlin24-review.md`: recorded the
  pre-PR review verdict and P0/P1 state.
- `docs/lessons/2026-06-11-issue-741-codeql-kotlin24.md`: captured the scanner
  support-window lesson.

## Validation

- `actionlint .github/workflows/codeql.yml`: PASS
- `rg -n --fixed-strings "\\'" .github/workflows`: PASS, no escaped single
  quote hits
- `git diff --check`: PASS
- `gh pr checks 747`: PASS for CI Status, Coverage Report, Build, Detect
  changed modules, Secret Scan, Validate Gradle Wrapper, and submit-gradle.
- PR diff confirms dormant `java-kotlin` build command is `./gradlew assemble --no-daemon`.

## Review Notes

- P0/P1: 0
- P2/P3: none
- Review evidence:
  `docs/review/2026-06-11-issue-741-codeql-kotlin24-review.md`

## Metadata

- Issue: #741, #743, #745, milestone `1.11.0`, assignee `debop`
- PR: #747, head `ccca293ca6e26cdcddef98ff81b10ff0129155c0`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `ci-issue-741-codeql-kotlin24`
- Labels: 없음
- State: `MERGED`, merge commit `deda47298a7c755e67951da8fa108ad6edf88686`
- CI: - Keeps the future `java-kotlin` build compile-only with `./gradlew assemble --no-daemon`. / - `gh pr checks 747`: PASS for CI Status, Coverage Report, Build, Detect / changed modules, Secret Scan, Validate Gradle Wrapper, and submit-gradle.

## DoD Status

| Step | Status | Evidence |
|------|--------|----------|
| Step W - Worktree | PASS | `git worktree add -b ci-issue-741-codeql-kotlin24 .worktrees/ci-issue-741-codeql-kotlin24 origin/develop` |
| Step D - Discovery | PASS | `gh run view 27250113912`: `java-kotlin` failed, `actions`/`python` passed; Nightly `27299345368` and Publish Snapshot `27299715400` succeeded |
| Step C - Change | PASS | `.github/workflows/codeql.yml` keeps `python/actions`, pauses `java-kotlin`, and records re-enable TODOs for #741/#743 |
| Step V - Validation | PASS | `actionlint .github/workflows/codeql.yml`; escaped-quote check; `git diff --check`; PR checks pass |
| Step 6-R - Review | PASS | P0=0/P1=0 in `docs/review/2026-06-11-issue-741-codeql-kotlin24-review.md` |
| Step 7 - Lessons | PASS | `docs/lessons/2026-06-11-issue-741-codeql-kotlin24.md` committed |
| Step 7-P - PR | PASS | PR #747 created with `--body-file`; live body last heading verified as `## DoD Status` |
| Step 7-R - Post-PR review | PASS | P0=0/P1=0; formal PR review/comment recorded after CI evidence |
| Step 8 - CI | PASS | `gh pr checks 747`: all required checks pass or skip; CI run `27352177378` |
| #743 Acceptance | PASS | The same PR disables only `java-kotlin`, keeps `actions`/`python`, and includes TODO issue references for re-enable. |
| #745 Acceptance | PASS | The same PR changes the dormant `java-kotlin` build command to `./gradlew assemble --no-daemon`, avoiding custom `Test` tasks such as `k8sTest` when re-enabled. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #747 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `deda47298a7c755e67951da8fa108ad6edf88686`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
