### PR TITLE
test: stabilize HC5 async interceptor ordering

### DIFF
--- a/docs/lessons/2026-06-11-issue-742-hc5-interceptor-flake.md
+++ b/docs/lessons/2026-06-11-issue-742-hc5-interceptor-flake.md
@@ -1,0 +1,24 @@
+# Issue #742: HC5 async interceptor ordering tests
+
+## Context
+
+`AsyncClientInterceptors` recorded request interceptor and execution interceptor
+events into one shared list while issuing many async requests. The old assertion
+compared the entire list to a serialized expected sequence.
+
+## Decision
+
+Keep the production behavior unchanged and assert interceptor ordering per
+execution id. Cross-request interleaving is valid for async execution and should
+not be part of the test contract.
+
+## Verification
+
+- Focused `AsyncClientInterceptors` test.
+- Full `:bluetape4k-http:test` module test.
+
+## Future Guard
+
+When a test records events from concurrent or async requests, group by the
+request/execution identity first. Assert the per-request invariant unless the
+feature explicitly promises a global ordering contract.

--- a/docs/review/2026-06-11-issue-742-hc5-interceptor-flake-review.md
+++ b/docs/review/2026-06-11-issue-742-hc5-interceptor-flake-review.md
@@ -1,0 +1,27 @@
+# Issue #742 HC5 async interceptor ordering review
+
+## Scope
+
+- `io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/AsyncClientInterceptors.kt`
+
+## Findings
+
+- P0: 0
+- P1: 0
+- P2: 0
+
+## Review Notes
+
+- The production HC5 async client code is unchanged.
+- The flaky global event-list assertion was replaced with per-execution event assertions.
+- Each request still verifies the exec-before, request interceptor, and exec-after ordering for the same execution id.
+- The short-circuited 13th request still verifies exec-before then exec-short-circuit, without requiring unrelated async requests to serialize around it.
+
+## Verification Evidence
+
+- `./gradlew :bluetape4k-http:test --tests 'io.bluetape4k.http.hc5.examples.AsyncClientInterceptors' --no-daemon --no-configuration-cache --no-build-cache`: PASS, 1 test passing.
+- `./gradlew :bluetape4k-http:test --no-daemon --no-configuration-cache --no-build-cache`: PASS, 444 tests passing, 3 pending.
+
+## Residual Risk
+
+- The original CI failure was an async interleaving flake, so local reruns cannot prove every scheduler interleaving. The assertion now removes the invalid cross-request ordering contract while retaining same-request ordering coverage.

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/AsyncClientInterceptors.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/AsyncClientInterceptors.kt
@@ -70,7 +70,7 @@ class AsyncClientInterceptors: AbstractHc5Test() {
             }
 
             statuses shouldBeEqualTo expectedStatuses()
-            events.toList() shouldBeEqualTo expectedEvents()
+            assertEventsByExecution(events.toList())
         } finally {
             log.debug { "Shutting down" }
             client.close(CloseMode.GRACEFUL)
@@ -128,19 +128,29 @@ class AsyncClientInterceptors: AbstractHc5Test() {
             if (executionId == 13) HttpStatus.SC_NOT_FOUND else HttpStatus.SC_OK
         }
 
-    private fun expectedEvents(): List<String> =
-        (1..20).flatMap { executionId ->
-            if (executionId == 13) {
-                listOf(
-                    "exec-before:$executionId:missing",
-                    "exec-short-circuit:$executionId",
-                )
-            } else {
-                listOf(
-                    "exec-before:$executionId:missing",
-                    "request:$executionId",
-                    "exec-after:$executionId:request-$executionId",
-                )
-            }
+    private fun assertEventsByExecution(events: List<String>) {
+        val eventsByExecutionId = events.groupBy { event ->
+            event.substringAfter(':').substringBefore(':')
         }
+
+        eventsByExecutionId.keys shouldBeEqualTo (1..20).map(Int::toString).toSet()
+        eventsByExecutionId.forEach { (executionId, executionEvents) ->
+            executionEvents shouldBeEqualTo expectedEventsFor(executionId)
+        }
+    }
+
+    private fun expectedEventsFor(executionId: String): List<String> {
+        return if (executionId == "13") {
+            listOf(
+                "exec-before:$executionId:missing",
+                "exec-short-circuit:$executionId",
+            )
+        } else {
+            listOf(
+                "exec-before:$executionId:missing",
+                "request:$executionId",
+                "exec-after:$executionId:request-$executionId",
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Closes #742

- PR 제목: test: stabilize HC5 async interceptor ordering

- Fixes #742.
- Keeps the HC5 async interceptor production path unchanged.
- Replaces the flaky global event-list assertion with per-execution interceptor ordering checks.
- Records review and lesson notes for future async/concurrent event-log tests.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- `AsyncClientInterceptors` now groups events by execution id before asserting ordering.
- Non-short-circuited requests still verify `exec-before`, `request`, then `exec-after`.
- The 13th short-circuit request still verifies `exec-before` then `exec-short-circuit`.
- Added tracked review evidence and a reusable lesson under `docs/review` and `docs/lessons`.

### 기존 섹션: Verification

- `./gradlew :bluetape4k-http:test --tests 'io.bluetape4k.http.hc5.examples.AsyncClientInterceptors' --no-daemon --no-configuration-cache --no-build-cache`: PASS, 1 test passing.
- `./gradlew :bluetape4k-http:test --no-daemon --no-configuration-cache --no-build-cache`: PASS, 444 tests passing, 3 pending.
- `git diff --check`: PASS.
- `gno update`: PASS, no collection changes.
- `gno search 'Issue 742 HC5 async interceptor ordering review'`: No result in current GNO collection view because this linked worktree's new docs are not indexed until branch contents are visible to the indexed repo path.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0: 0
- P1: 0
- Review artifact: `docs/review/2026-06-11-issue-742-hc5-interceptor-flake-review.md`
- Lesson artifact: `docs/lessons/2026-06-11-issue-742-hc5-interceptor-flake.md`

## Metadata

- Issue: #742, milestone `1.11.0`, assignee `debop`
- PR: #748, head `e29ad5964f8f4d060aa8e44c64ee5a09a9e329a0`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix-issue-742-hc5-interceptor-flake`
- Labels: 없음
- State: `MERGED`, merge commit `be00cf838be840a64de7a66a8ed539efd9767c54`
- CI: - Non-short-circuited requests still verify `exec-before`, `request`, then `exec-after`. / - The 13th short-circuit request still verifies `exec-before` then `exec-short-circuit`. / - `./gradlew :bluetape4k-http:test --tests 'io.bluetape4k.http.hc5.examples.AsyncClientInterceptors' --no-daemon --no-configuration-cache --no-build-cache`: PASS, 1 test passing.

## DoD Status

| Step | Status | Evidence |
| --- | --- | --- |
| Issue classified and scoped | PASS | #742 is Type C bug fix; scope limited to HC5 async interceptor example test. |
| Production behavior preserved | PASS | No production files changed. |
| Flaky assertion fixed | PASS | Test now asserts per-execution event order instead of global async request order. |
| Regression coverage | PASS | Existing `AsyncClientInterceptors` test now covers the valid invariant. |
| Targeted validation | PASS | Focused test passed. |
| Module validation | PASS | `:bluetape4k-http:test` passed with 444 passing, 3 pending. |
| Review artifact | PASS | `docs/review/2026-06-11-issue-742-hc5-interceptor-flake-review.md`, P0=0/P1=0. |
| Lesson captured | PASS | `docs/lessons/2026-06-11-issue-742-hc5-interceptor-flake.md`. |
| PR CI | PASS | CI Status, Coverage Report, Build, Detect changed modules, Secret Scan, Validate Gradle Wrapper, submit-gradle all passed; unrelated module test jobs skipped by changed-module detection. |
| Merge | PENDING | User approval required before merge. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #748 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `be00cf838be840a64de7a66a8ed539efd9767c54`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
