### PR TITLE
fix: stop suspending observations on success

### DIFF
--- a/docs/lessons/2026-06-11-issue-744-suspending-observation-stop.md
+++ b/docs/lessons/2026-06-11-issue-744-suspending-observation-stop.md
@@ -1,0 +1,27 @@
+# Issue #744: Suspending observation lifecycle
+
+## Context
+
+`Observation.withObservationContextSuspending` bound Micrometer observations to a
+coroutine context but only stopped observations from catch blocks. Successful
+suspend paths could complete without `onStop`.
+
+## Decision
+
+Call `observation.stop()` from `finally` for suspending observation context
+helpers. Keep cancellation separate from non-cancellation errors: cancellation
+rethrows without recording an error, and non-cancellation exceptions still call
+`observation.error(e)` before the final stop.
+
+## Verification
+
+- A pre-fix regression failed with `handler.stopped == 0`.
+- The same focused regression passed after the fix.
+- Related observation coroutine and event telemetry tests passed.
+- Full `:bluetape4k-micrometer:test` passed.
+
+## Future Guard
+
+Any helper that starts or owns an `Observation` must stop it in `finally`.
+Tests should assert handler `onStop` counts for success paths, not only current
+context cleanup.

--- a/docs/review/2026-06-11-issue-744-observation-stop-review.md
+++ b/docs/review/2026-06-11-issue-744-observation-stop-review.md
@@ -1,0 +1,31 @@
+# Issue #744 suspending observation stop review
+
+## Scope
+
+- `infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/observation/coroutines/ObservationCoroutinesSupport.kt`
+- `infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/observation/coroutines/ObservationCoroutinesSupportTest.kt`
+- `infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/observation/events/EventTelemetryObservationSupportTest.kt`
+
+## Findings
+
+- P0: 0
+- P1: 0
+- P2: 0
+
+## Review Notes
+
+- The root bug was reproduced before the fix: successful `observeEventPublishSuspending` started one observation but stopped zero observations.
+- Both suspending observation context overloads now stop in `finally`, so success, cancellation, and error paths all terminate the observation.
+- Cancellation remains distinct from non-cancellation errors: cancellation rethrows without `observation.error(e)`, while other exceptions still record the error before `finally` stops the observation.
+- Regression tests cover both the named suspending helper and the event telemetry suspending publish path.
+
+## Verification Evidence
+
+- Pre-fix focused regression: FAIL, `Expected <0> to equal to <1>` for `handler.stopped`.
+- Post-fix focused regression: PASS, 1 test passing.
+- `./gradlew :bluetape4k-micrometer:test --tests 'io.bluetape4k.micrometer.observation.events.EventTelemetryObservationSupportTest' --tests 'io.bluetape4k.micrometer.observation.coroutines.ObservationCoroutinesSupportTest' --no-daemon --no-configuration-cache --no-build-cache`: PASS, 18 tests passing.
+- `./gradlew :bluetape4k-micrometer:test --no-daemon --no-configuration-cache --no-build-cache`: PASS, 82 tests passing, 1 pending.
+
+## Residual Risk
+
+- The fix intentionally changes observation lifecycle timing only by ensuring `stop()` always runs after the coroutine context exits. No metric names, tags, or exception mapping were changed.

--- a/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/observation/coroutines/ObservationCoroutinesSupport.kt
+++ b/infra/micrometer/src/main/kotlin/io/bluetape4k/micrometer/observation/coroutines/ObservationCoroutinesSupport.kt
@@ -218,12 +218,12 @@ suspend fun <T: Any> withObservationContextSuspending(
             block()
         }
     } catch (e: CancellationException) {
-        observation.stop()
         throw e
     } catch (e: Throwable) {
         observation.error(e)
-        observation.stop()
         throw e
+    } finally {
+        observation.stop()
     }
 }
 
@@ -257,11 +257,11 @@ suspend fun <T: Any> Observation.withObservationContextSuspending(
             block(observation.context)
         }
     } catch (e: CancellationException) {
-        observation.stop()
         throw e
     } catch (e: Throwable) {
         observation.error(e)
-        observation.stop()
         throw e
+    } finally {
+        observation.stop()
     }
 }

--- a/infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/observation/coroutines/ObservationCoroutinesSupportTest.kt
+++ b/infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/observation/coroutines/ObservationCoroutinesSupportTest.kt
@@ -12,6 +12,8 @@ import io.bluetape4k.logging.info
 import io.bluetape4k.micrometer.observation.AbstractObservationTest
 import io.bluetape4k.micrometer.observation.start
 import io.micrometer.observation.Observation
+import io.micrometer.observation.ObservationHandler
+import io.micrometer.observation.ObservationRegistry
 import io.micrometer.observation.tck.ObservationRegistryAssert
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
@@ -70,6 +72,26 @@ class ObservationCoroutinesSupportTest: AbstractObservationTest() {
 
         ObservationRegistryAssert.assertThat(observationRegistry)
             .doesNotHaveAnyRemainingCurrentObservation()
+    }
+
+    @Test
+    fun `withObservationContextSuspending - named observation stops on success`() = runTest {
+        val handler = RecordingObservationHandler()
+        val registry =
+            ObservationRegistry.create().apply {
+                observationConfig().observationHandler(handler)
+            }
+
+        val result =
+            withObservationContextSuspending("observer.stop.${Base58.randomString(8)}", registry) {
+                currentObservationInContext().shouldNotBeNull()
+                "observed"
+            }
+
+        result shouldBeEqualTo "observed"
+        handler.started shouldBeEqualTo 1
+        handler.stopped shouldBeEqualTo 1
+        handler.errors shouldBeEqualTo 0
     }
 
     @Test
@@ -205,5 +227,25 @@ class ObservationCoroutinesSupportTest: AbstractObservationTest() {
         yield()
         ObservationRegistryAssert.assertThat(observationRegistry)
             .doesNotHaveAnyRemainingCurrentObservation()
+    }
+
+    private class RecordingObservationHandler: ObservationHandler<Observation.Context> {
+        var started = 0
+        var stopped = 0
+        var errors = 0
+
+        override fun onStart(context: Observation.Context) {
+            started++
+        }
+
+        override fun onStop(context: Observation.Context) {
+            stopped++
+        }
+
+        override fun onError(context: Observation.Context) {
+            errors++
+        }
+
+        override fun supportsContext(context: Observation.Context): Boolean = true
     }
 }

--- a/infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/observation/events/EventTelemetryObservationSupportTest.kt
+++ b/infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/observation/events/EventTelemetryObservationSupportTest.kt
@@ -126,6 +126,26 @@ class EventTelemetryObservationSupportTest {
     }
 
     @Test
+    fun `observeEventPublishSuspending should stop observation on success`() = runTest {
+        val handler = RecordingObservationHandler()
+        val registry = registry(handler)
+
+        val result =
+            registry.observeEventPublishSuspending(orderTelemetry()) { context ->
+                context.name shouldBeEqualTo EventTelemetryKeys.PUBLISH_OBSERVATION_NAME
+                "published"
+            }
+
+        result shouldBeEqualTo "published"
+        handler.started shouldBeEqualTo 1
+        handler.stopped shouldBeEqualTo 1
+        handler.errors shouldBeEqualTo 0
+
+        val context = handler.stoppedContexts.single()
+        context.low(EventTelemetryKeys.OUTCOME) shouldBeEqualTo EventTelemetryOutcome.SUCCESS.name
+    }
+
+    @Test
     fun `observeEventPublish should not record cancellation as error`() {
         val handler = RecordingObservationHandler()
         val registry = registry(handler)


### PR DESCRIPTION
## Summary

Closes #744

- PR 제목: fix: stop suspending observations on success

Closes #744.

Successful suspending Micrometer observation helpers now always stop their
observation. The fix moves `observation.stop()` into `finally` for both
suspending observation context overloads while preserving cancellation/error
semantics.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Stop suspending observations from `finally` in `ObservationCoroutinesSupport`.
- Keep cancellation propagation separate from non-cancellation error recording.
- Add regression coverage for:
  - named `withObservationContextSuspending` success path,
  - `observeEventPublishSuspending` success path.
- Add tracked review and lesson notes for future observation lifecycle changes.

### 기존 섹션: Verification

- Pre-fix focused regression: FAIL, `Expected <0> to equal to <1>` for `handler.stopped`.
- Post-fix focused regression: PASS, 1 test passing.
- `./gradlew :bluetape4k-micrometer:test --tests 'io.bluetape4k.micrometer.observation.events.EventTelemetryObservationSupportTest' --tests 'io.bluetape4k.micrometer.observation.coroutines.ObservationCoroutinesSupportTest' --no-daemon --no-configuration-cache --no-build-cache`: PASS, 18 tests passing.
- `./gradlew :bluetape4k-micrometer:test --no-daemon --no-configuration-cache --no-build-cache`: PASS, 82 tests passing, 1 pending.
- `git diff --check`: PASS.
- `gno update`: PASS, no collection changes.
- `gno search 'Issue 744 suspending observation stop review'`: no result in current GNO collection view because linked worktree docs are not indexed until branch contents are visible to the indexed repo path.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0: 0
- P1: 0
- Review artifact: `docs/review/2026-06-11-issue-744-observation-stop-review.md`
- Lesson artifact: `docs/lessons/2026-06-11-issue-744-suspending-observation-stop.md`

## Metadata

- Issue: #744, milestone `1.11.0`, assignee `debop`
- PR: #749, head `316d005d5099552faf7fddf8c80e09f6d168370a`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix-issue-744-observation-stop`
- Labels: 없음
- State: `MERGED`, merge commit `44e153e6329742c26c61eeaadb7aa4a434e754c8`
- CI: - `./gradlew :bluetape4k-micrometer:test --tests 'io.bluetape4k.micrometer.observation.events.EventTelemetryObservationSupportTest' --tests 'io.bluetape4k.micrometer.observation.coroutines.ObservationCoroutinesSupportTest' --no-daemon --no-configuration-cache --no-build-cache`: PASS, 18 tests passing. / - `./gradlew :bluetape4k-micrometer:test --no-daemon --no-configuration-cache --no-build-cache`: PASS, 82 tests passing, 1 pending. / | PR CI | PASS | CI Status, Coverage Report, Build, Detect changed modules, Secret Scan, Validate Gradle Wrapper, submit-gradle all passed; unrelated module test jobs skipped by changed-module detection. |

## DoD Status

| Step | Status | Evidence |
| --- | --- | --- |
| Issue classified and scoped | PASS | #744 is Type C bug fix; scope is suspending Micrometer observation lifecycle. |
| Regression reproduced | PASS | Pre-fix focused test failed with `handler.stopped == 0`. |
| Production fix | PASS | Both suspending observation context overloads now call `observation.stop()` from `finally`. |
| Cancellation/error semantics | PASS | Cancellation rethrows without `observation.error(e)`; non-cancellation exceptions still record errors before final stop. |
| Regression coverage | PASS | Named helper and event telemetry suspending publish success paths assert handler `onStop`. |
| Concurrency test gate | PASS | No race/stress concurrency test was needed; this is a deterministic lifecycle regression. Direct handler `onStop` assertions are the correct proof, so `MultithreadingTester`, `SuspendedJobTester`, and `StructuredTaskScopeTester` do not fit this case. |
| Targeted validation | PASS | Related observation coroutine/event tests passed, 18 tests passing. |
| Module validation | PASS | `:bluetape4k-micrometer:test` passed, 82 passing and 1 pending. |
| Review artifact | PASS | `docs/review/2026-06-11-issue-744-observation-stop-review.md`, P0=0/P1=0. |
| Lesson captured | PASS | `docs/lessons/2026-06-11-issue-744-suspending-observation-stop.md`. |
| PR CI | PASS | CI Status, Coverage Report, Build, Detect changed modules, Secret Scan, Validate Gradle Wrapper, submit-gradle all passed; unrelated module test jobs skipped by changed-module detection. |
| Merge | PENDING | User approval required before merge. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #749 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `44e153e6329742c26c61eeaadb7aa4a434e754c8`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
