### PR TITLE
docs: keep AGENTS guidance repo-specific

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,10 @@
 # AGENTS.md - bluetape4k-projects
 
+This repository inherits the workspace guidance from `../AGENTS.md`.
+Read and follow the workspace root guide first. This file only adds
+repo-specific layout, commands, domain rules, and local exceptions.
+
+
 Core bluetape4k Kotlin/JVM backend libraries. This repo improves Java library
 ergonomics and provides coroutine-first, non-blocking infrastructure modules.
 `settings.gradle.kts` auto-registers module directories. Most groups publish as
@@ -41,20 +46,6 @@ repo-test-summary -- ./gradlew :module:test
 
 Full reference may live under `.codex/references/module-groups.md`.
 
-## Knowledge Retrieval
-
-- For prior decisions, lessons, specs, plans, security reviews, follow-up
-  issues, discussions, and historical context, query GNO before broad
-  filesystem search.
-- Use `gno query ... -c wiki --fast --no-rerank` for personal/cross-project knowledge under
-  `~/.codex/wiki`.
-- Use `gno query ... -c bluetape4k-docs --fast --no-rerank` for committed documentation under
-  `~/work/bluetape4k/**/docs/**/*.md`.
-- If GNO is unavailable or stale, fall back to `rg`/filesystem search and note
-  the indexing gap when it affects the answer.
-- For exact code symbols, filenames, current implementation lookup, and local
-  source relationships, use `rg` first.
-
 ## Build Configuration
 
 - Java 21 toolchain.
@@ -79,15 +70,10 @@ Full reference may live under `.codex/references/module-groups.md`.
 - Publishing uses GitHub Packages Maven; `workshop/` and `examples/` are
   excluded.
 - Auditable update paths must use `auditedUpdate*`.
-- Keep top-level `README.md` and `README.ko.md` synchronized with
-  `settings.gradle.kts` when modules are added, moved, removed, or split out.
 
-## Cross-Repo Lesson Guards
+## Repo-Specific Guards
 
-- Before issue, PR, workflow, release, or module-registration work, query GNO
-  for this repo in both `bluetape4k-github` and `bluetape4k-docs`.
-- For module moves, splits, additions, or removals, verify auto-registration,
-  README locale sets, repo-local module lists, CI/Nightly coverage, coverage
-  artifacts, generated catalog/check scripts, and `./gradlew projects`.
-- Keep Kover XML/Codecov visible without hard gates unless explicitly decided.
-  Run Testcontainers-backed verification sequentially across modules/worktrees.
+- For module moves, splits, additions, or removals, verify auto-registration
+  and generated catalog/check scripts in addition to the workspace module
+  registration chain.
+- Keep Testcontainers-backed verification sequential across modules/worktrees.


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: docs: keep AGENTS guidance repo-specific

- Move shared AGENTS guidance to the workspace root contract.
- Keep repo-local AGENTS files focused on inheritance, local layout, commands, domain rules, and exceptions.
- Add thin AGENTS overlays where the repository did not have one.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- `git diff --check`

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #759, head `3758708ee95a247cabe007d9159e3163fb9313a6`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `docs/agents-common-guidance`
- Labels: `documentation`
- State: `MERGED`, merge commit `733f7faffb63e9c52218bc19f89d6730bbaa6604`
- CI: - [x] Repo-local AGENTS keeps only repo-specific narrowing guidance.

## DoD Status

- [x] Workspace/common rules are centralized or referenced from the repo overlay.
- [x] Repo-local AGENTS keeps only repo-specific narrowing guidance.
- [x] Documentation-only validation completed with `git diff --check`.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #759 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `733f7faffb63e9c52218bc19f89d6730bbaa6604`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
