### PR TITLE
docs: use published dependency coordinates

### DIFF
--- a/cache/cache-core/README.ko.md
+++ b/cache/cache-core/README.ko.md
@@ -323,7 +323,7 @@ val result = factorial[10]  // 캐싱되어 반복 계산 방지
 ```kotlin
 // build.gradle.kts
 dependencies {
-    testImplementation(testFixtures(project(":bluetape4k-cache-core")))
+    testImplementation(testFixtures("io.github.bluetape4k:bluetape4k-cache-core:${bluetape4kVersion}"))
 }
 ```
 

--- a/cache/hibernate-cache-lettuce/README.ko.md
+++ b/cache/hibernate-cache-lettuce/README.ko.md
@@ -51,7 +51,7 @@ artifact, Kotlin package는 유지됩니다.
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation(project(":bluetape4k-hibernate-cache-lettuce"))
+    implementation("io.github.bluetape4k:bluetape4k-hibernate-cache-lettuce:${bluetape4kVersion}")
 
     // 런타임 직렬화 (필수 - bluetape4k-io의 optional 의존성이므로 명시 필요)
     implementation(Libs.fory_kotlin)  // Apache Fory

--- a/cache/hibernate-cache-lettuce/README.md
+++ b/cache/hibernate-cache-lettuce/README.md
@@ -52,7 +52,7 @@ No user import migration is required for the reorganization.
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation(project(":bluetape4k-hibernate-cache-lettuce"))
+    implementation("io.github.bluetape4k:bluetape4k-hibernate-cache-lettuce:${bluetape4kVersion}")
 
     // Runtime serialization (required — must be declared explicitly since bluetape4k-io uses optional dependencies)
     implementation(Libs.fory_kotlin)  // Apache Fory

--- a/infra/pulsar/README.ko.md
+++ b/infra/pulsar/README.ko.md
@@ -22,13 +22,13 @@ Kotlin을 위한 Apache Pulsar 클라이언트 확장 — 코루틴 우선, DSL 
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation(project(":bluetape4k-pulsar"))
+    implementation("io.github.bluetape4k:bluetape4k-pulsar:${bluetape4kVersion}")
 
     // 선택: jacksonSchema<T>() 사용 시
-    implementation(project(":bluetape4k-jackson2"))
+    implementation("io.github.bluetape4k:bluetape4k-jackson2:${bluetape4kVersion}")
 
     // 선택: jackson3Schema<T>() 사용 시
-    implementation(project(":bluetape4k-jackson3"))
+    implementation("io.github.bluetape4k:bluetape4k-jackson3:${bluetape4kVersion}")
 }
 ```
 

--- a/infra/pulsar/README.md
+++ b/infra/pulsar/README.md
@@ -22,13 +22,13 @@ Apache Pulsar client extensions for Kotlin — coroutine-first, DSL-friendly, Ja
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation(project(":bluetape4k-pulsar"))
+    implementation("io.github.bluetape4k:bluetape4k-pulsar:${bluetape4kVersion}")
 
     // Optional: for jacksonSchema<T>()
-    implementation(project(":bluetape4k-jackson2"))
+    implementation("io.github.bluetape4k:bluetape4k-jackson2:${bluetape4kVersion}")
 
     // Optional: for jackson3Schema<T>()
-    implementation(project(":bluetape4k-jackson3"))
+    implementation("io.github.bluetape4k:bluetape4k-jackson3:${bluetape4kVersion}")
 }
 ```
 

--- a/io/avro/README.ko.md
+++ b/io/avro/README.ko.md
@@ -135,7 +135,7 @@ val itemV1 = serializer.deserialize<ItemV1>(bytes)
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-avro"))
+    implementation("io.github.bluetape4k:bluetape4k-avro:${bluetape4kVersion}")
 
     // 추가 압축 코덱 (선택)
     runtimeOnly("org.xerial.snappy:snappy-java")

--- a/io/avro/README.md
+++ b/io/avro/README.md
@@ -138,7 +138,7 @@ val itemV1 = serializer.deserialize<ItemV1>(bytes)
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-avro"))
+    implementation("io.github.bluetape4k:bluetape4k-avro:${bluetape4kVersion}")
 
     // Additional compression codecs (optional)
     runtimeOnly("org.xerial.snappy:snappy-java")

--- a/io/csv/README.ko.md
+++ b/io/csv/README.ko.md
@@ -299,7 +299,7 @@ io.bluetape4k.csv
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-csv"))
+    implementation("io.github.bluetape4k:bluetape4k-csv:${bluetape4kVersion}")
 
     // Coroutines 비동기 API 사용 시
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")

--- a/io/csv/README.md
+++ b/io/csv/README.md
@@ -299,7 +299,7 @@ io.bluetape4k.csv
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-csv"))
+    implementation("io.github.bluetape4k:bluetape4k-csv:${bluetape4kVersion}")
 
     // Required for Coroutines async API
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")

--- a/io/fastjson2/README.ko.md
+++ b/io/fastjson2/README.ko.md
@@ -136,7 +136,7 @@ val user = jsonObject.readValueOrNull<User>("key")
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-fastjson2"))
+    implementation("io.github.bluetape4k:bluetape4k-fastjson2:${bluetape4kVersion}")
 
     // 자동 포함됨
     // api("com.alibaba.fastjson2:fastjson2")

--- a/io/fastjson2/README.md
+++ b/io/fastjson2/README.md
@@ -136,7 +136,7 @@ val user = jsonObject.readValueOrNull<User>("key")
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-fastjson2"))
+    implementation("io.github.bluetape4k:bluetape4k-fastjson2:${bluetape4kVersion}")
 
     // Included automatically
     // api("com.alibaba.fastjson2:fastjson2")

--- a/io/feign/README.ko.md
+++ b/io/feign/README.ko.md
@@ -216,7 +216,7 @@ io.bluetape4k.feign
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-feign"))
+    implementation("io.github.bluetape4k:bluetape4k-feign:${bluetape4kVersion}")
 
     // 선택적 의존성
     implementation("io.github.openfeign:feign-jackson")      // Jackson Encoder/Decoder

--- a/io/feign/README.md
+++ b/io/feign/README.md
@@ -216,7 +216,7 @@ io.bluetape4k.feign
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-feign"))
+    implementation("io.github.bluetape4k:bluetape4k-feign:${bluetape4kVersion}")
 
     // Optional dependencies
     implementation("io.github.openfeign:feign-jackson")      // Jackson Encoder/Decoder

--- a/io/http/README.ko.md
+++ b/io/http/README.ko.md
@@ -523,7 +523,7 @@ io.bluetape4k.http
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-http"))
+    implementation("io.github.bluetape4k:bluetape4k-http:${bluetape4kVersion}")
 
     // 사용할 백엔드만 compileOnly로 추가.
     // 애플리케이션 프로젝트에서 런타임에 필요한 경우 implementation으로 변경하세요.

--- a/io/http/README.md
+++ b/io/http/README.md
@@ -522,7 +522,7 @@ io.bluetape4k.http
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-http"))
+    implementation("io.github.bluetape4k:bluetape4k-http:${bluetape4kVersion}")
 
     // Add compileOnly for each backend you use.
     // Change to implementation in application projects where runtime availability is required.

--- a/io/jackson2/README.ko.md
+++ b/io/jackson2/README.ko.md
@@ -317,7 +317,7 @@ val restored = yamlMapper.readValue<User>(yaml)     // 역직렬화
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-jackson2"))
+    implementation("io.github.bluetape4k:bluetape4k-jackson2:${bluetape4kVersion}")
 
     // 바이너리 포맷 (필요한 것만 추가)
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor")
@@ -329,7 +329,7 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-toml")
 
     // 암호화 (선택적)
-    implementation(project(":bluetape4k-tink"))    // @JsonTinkEncrypt (Google Tink) 사용 시
+    implementation("io.github.bluetape4k:bluetape4k-tink:${bluetape4kVersion}")    // @JsonTinkEncrypt (Google Tink) 사용 시
 }
 ```
 

--- a/io/jackson2/README.md
+++ b/io/jackson2/README.md
@@ -293,7 +293,7 @@ io.bluetape4k.jackson
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-jackson2"))
+    implementation("io.github.bluetape4k:bluetape4k-jackson2:${bluetape4kVersion}")
 
     // Binary formats (add only what you need)
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor")
@@ -305,7 +305,7 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-toml")
 
     // Encryption (optional)
-    implementation(project(":bluetape4k-tink"))    // for @JsonTinkEncrypt (Google Tink)
+    implementation("io.github.bluetape4k:bluetape4k-tink:${bluetape4kVersion}")    // for @JsonTinkEncrypt (Google Tink)
 }
 ```
 

--- a/io/jackson3/README.ko.md
+++ b/io/jackson3/README.ko.md
@@ -316,7 +316,7 @@ val restored = yamlMapper.readValue<User>(yaml)     // 역직렬화
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-jackson3"))
+    implementation("io.github.bluetape4k:bluetape4k-jackson3:${bluetape4kVersion}")
 
     // 바이너리 포맷 (필요한 것만 추가)
     implementation("tools.jackson.dataformat:jackson-dataformat-cbor3")
@@ -328,7 +328,7 @@ dependencies {
     implementation("tools.jackson.dataformat:jackson-dataformat-toml3")
 
     // 암호화 (선택적, @JsonTinkEncrypt 사용 시)
-    implementation(project(":bluetape4k-tink"))
+    implementation("io.github.bluetape4k:bluetape4k-tink:${bluetape4kVersion}")
 }
 ```
 

--- a/io/jackson3/README.md
+++ b/io/jackson3/README.md
@@ -321,7 +321,7 @@ val restored = yamlMapper.readValue<User>(yaml)     // deserialization
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-jackson3"))
+    implementation("io.github.bluetape4k:bluetape4k-jackson3:${bluetape4kVersion}")
 
     // Binary formats (add only what you need)
     implementation("tools.jackson.dataformat:jackson-dataformat-cbor3")
@@ -333,7 +333,7 @@ dependencies {
     implementation("tools.jackson.dataformat:jackson-dataformat-toml3")
 
     // Encryption (optional, for @JsonTinkEncrypt)
-    implementation(project(":bluetape4k-tink"))
+    implementation("io.github.bluetape4k:bluetape4k-tink:${bluetape4kVersion}")
 }
 ```
 

--- a/io/json/README.ko.md
+++ b/io/json/README.ko.md
@@ -92,7 +92,7 @@ io.bluetape4k.json
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-json"))
+    implementation("io.github.bluetape4k:bluetape4k-json:${bluetape4kVersion}")
 }
 ```
 

--- a/io/json/README.md
+++ b/io/json/README.md
@@ -96,7 +96,7 @@ io.bluetape4k.json
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-json"))
+    implementation("io.github.bluetape4k:bluetape4k-json:${bluetape4kVersion}")
 }
 ```
 

--- a/io/retrofit2/README.ko.md
+++ b/io/retrofit2/README.ko.md
@@ -226,7 +226,7 @@ io.bluetape4k.retrofit2
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-retrofit2"))
+    implementation("io.github.bluetape4k:bluetape4k-retrofit2:${bluetape4kVersion}")
 
     // 선택적 의존성
     implementation("com.squareup.retrofit2:converter-jackson")       // Jackson 변환

--- a/io/retrofit2/README.md
+++ b/io/retrofit2/README.md
@@ -228,7 +228,7 @@ io.bluetape4k.retrofit2
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-retrofit2"))
+    implementation("io.github.bluetape4k:bluetape4k-retrofit2:${bluetape4kVersion}")
 
     // Optional dependencies
     implementation("com.squareup.retrofit2:converter-jackson")       // Jackson conversion

--- a/spring-boot/hibernate-lettuce-demo/README.ko.md
+++ b/spring-boot/hibernate-lettuce-demo/README.ko.md
@@ -324,7 +324,7 @@ dependencies {
     // Spring Boot 4 BOM
     implementation(platform(libs.spring.boot.dependencies))
 
-    implementation(project(":bluetape4k-spring-boot-hibernate-lettuce"))
+    implementation("io.github.bluetape4k:bluetape4k-spring-boot-hibernate-lettuce:${bluetape4kVersion}")
     implementation(Libs.springBootStarter("web"))
     implementation(Libs.springBootStarter("data-jpa"))
     implementation(Libs.springBootStarter("actuator"))

--- a/spring-boot/hibernate-lettuce-demo/README.md
+++ b/spring-boot/hibernate-lettuce-demo/README.md
@@ -325,7 +325,7 @@ dependencies {
     // Spring Boot 4 BOM
     implementation(platform(libs.spring.boot.dependencies))
 
-    implementation(project(":bluetape4k-spring-boot-hibernate-lettuce"))
+    implementation("io.github.bluetape4k:bluetape4k-spring-boot-hibernate-lettuce:${bluetape4kVersion}")
     implementation(Libs.springBootStarter("web"))
     implementation(Libs.springBootStarter("data-jpa"))
     implementation(Libs.springBootStarter("actuator"))

--- a/spring-boot/hibernate-lettuce/README.ko.md
+++ b/spring-boot/hibernate-lettuce/README.ko.md
@@ -32,7 +32,7 @@ dependencies {
     // Spring Boot 4 BOM (dependencyManagement 대신 platform 사용)
     implementation(platform(libs.spring.boot.dependencies))
 
-    implementation(project(":bluetape4k-spring-boot-hibernate-lettuce"))
+    implementation("io.github.bluetape4k:bluetape4k-spring-boot-hibernate-lettuce:${bluetape4kVersion}")
 
     // Hibernate 명시적 추가 필요
     compileOnly(Libs.springBoot("hibernate"))
@@ -60,7 +60,7 @@ dependencies {
     // Spring Boot 4 BOM (필수)
     implementation(platform(libs.spring.boot.dependencies))
 
-    implementation(project(":bluetape4k-spring-boot-hibernate-lettuce"))
+    implementation("io.github.bluetape4k:bluetape4k-spring-boot-hibernate-lettuce:${bluetape4kVersion}")
 
     // Spring Boot Starters
     implementation(Libs.springBootStarter("data-jpa"))

--- a/spring-boot/hibernate-lettuce/README.md
+++ b/spring-boot/hibernate-lettuce/README.md
@@ -33,7 +33,7 @@ dependencies {
     // Spring Boot 4 BOM (use platform instead of dependencyManagement)
     implementation(platform(libs.spring.boot.dependencies))
 
-    implementation(project(":bluetape4k-spring-boot-hibernate-lettuce"))
+    implementation("io.github.bluetape4k:bluetape4k-spring-boot-hibernate-lettuce:${bluetape4kVersion}")
 
     // Hibernate must be declared explicitly
     compileOnly(Libs.springBoot("hibernate"))
@@ -61,7 +61,7 @@ dependencies {
     // Spring Boot 4 BOM (required)
     implementation(platform(libs.spring.boot.dependencies))
 
-    implementation(project(":bluetape4k-spring-boot-hibernate-lettuce"))
+    implementation("io.github.bluetape4k:bluetape4k-spring-boot-hibernate-lettuce:${bluetape4kVersion}")
 
     // Spring Boot Starters
     implementation(Libs.springBootStarter("data-jpa"))

--- a/testing/assertions/README.ko.md
+++ b/testing/assertions/README.ko.md
@@ -30,9 +30,9 @@ Turbine 연동은 `compileOnly`로 유지합니다.
 
 ```kotlin
 // build.gradle.kts
-testImplementation(project(":bluetape4k-assertions"))
+testImplementation("io.github.bluetape4k:bluetape4k-assertions:${bluetape4kVersion}")
 // 또는 bluetape4k-junit5를 통해 전이적 포함
-testImplementation(project(":bluetape4k-junit5"))
+testImplementation("io.github.bluetape4k:bluetape4k-junit5:${bluetape4kVersion}")
 ```
 
 ### 사용 예시

--- a/testing/assertions/README.md
+++ b/testing/assertions/README.md
@@ -30,9 +30,9 @@ JUnit Jupiter API and Kotlin coroutines are exposed only where the public DSL re
 
 ```kotlin
 // build.gradle.kts
-testImplementation(project(":bluetape4k-assertions"))
+testImplementation("io.github.bluetape4k:bluetape4k-assertions:${bluetape4kVersion}")
 // or via bluetape4k-junit5 (included transitively)
-testImplementation(project(":bluetape4k-junit5"))
+testImplementation("io.github.bluetape4k:bluetape4k-junit5:${bluetape4kVersion}")
 ```
 
 ### Example Usage

--- a/utils/probabilistic/README.ko.md
+++ b/utils/probabilistic/README.ko.md
@@ -8,7 +8,7 @@ JVM 애플리케이션에서 사용할 인메모리 확률적 자료구조 모�
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-probabilistic"))
+    implementation("io.github.bluetape4k:bluetape4k-probabilistic:${bluetape4kVersion}")
 }
 ```
 

--- a/utils/probabilistic/README.md
+++ b/utils/probabilistic/README.md
@@ -8,7 +8,7 @@ This module currently provides a dependency-free Bloom Filter implementation. It
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-probabilistic"))
+    implementation("io.github.bluetape4k:bluetape4k-probabilistic:${bluetape4kVersion}")
 }
 ```
 

--- a/utils/rule-engine/README.ko.md
+++ b/utils/rule-engine/README.ko.md
@@ -228,7 +228,7 @@ val mvelRules = definitions.map { it.toMvelRule() }
 ## 의존성
 
 ```kotlin
-implementation(project(":bluetape4k-rule-engine"))
+implementation("io.github.bluetape4k:bluetape4k-rule-engine:${bluetape4kVersion}")
 
 // optional (compileOnly)
 implementation("org.mvel:mvel2:2.5.2.Final")              // MVEL2 엔진

--- a/utils/rule-engine/README.md
+++ b/utils/rule-engine/README.md
@@ -225,7 +225,7 @@ val mvelRules = definitions.map { it.toMvelRule() }
 ## Dependency
 
 ```kotlin
-implementation(project(":bluetape4k-rule-engine"))
+implementation("io.github.bluetape4k:bluetape4k-rule-engine:${bluetape4kVersion}")
 
 // optional (compileOnly)
 implementation("org.mvel:mvel2:2.5.2.Final")              // MVEL2 engine

--- a/utils/states/README.ko.md
+++ b/utils/states/README.ko.md
@@ -69,7 +69,7 @@ event/effect와 nested-state 아이디어의 참고 자료일 뿐, 이 모듈의
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-states"))
+    implementation("io.github.bluetape4k:bluetape4k-states:${bluetape4kVersion}")
 }
 ```
 

--- a/utils/states/README.md
+++ b/utils/states/README.md
@@ -71,7 +71,7 @@ The comparison work is tracked through #436, #437, and #438.
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-states"))
+    implementation("io.github.bluetape4k:bluetape4k-states:${bluetape4kVersion}")
 }
 ```
 

--- a/utils/workflow/README.ko.md
+++ b/utils/workflow/README.ko.md
@@ -318,6 +318,6 @@ val report = flow.execute(ctx)
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-workflow"))
+    implementation("io.github.bluetape4k:bluetape4k-workflow:${bluetape4kVersion}")
 }
 ```

--- a/utils/workflow/README.md
+++ b/utils/workflow/README.md
@@ -319,6 +319,6 @@ Use this benchmark as a relative comparison for the current examples, not as a u
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-workflow"))
+    implementation("io.github.bluetape4k:bluetape4k-workflow:${bluetape4kVersion}")
 }
 ```

--- a/virtualthread/jdk21/README.ko.md
+++ b/virtualthread/jdk21/README.ko.md
@@ -117,15 +117,15 @@ tasks.withType<JavaCompile>().configureEach {
 
 ## 의존성
 
-### 프로젝트 의존성
+### Gradle 의존성
 
 ```kotlin
 dependencies {
-    api(project(":bluetape4k-virtualthread-api"))
-    implementation(project(":bluetape4k-logging"))
+    api("io.github.bluetape4k:bluetape4k-virtualthread-api:${bluetape4kVersion}")
+    implementation("io.github.bluetape4k:bluetape4k-logging:${bluetape4kVersion}")
     implementation(Libs.kotlinx_coroutines_core)
 
-    testImplementation(project(":bluetape4k-junit5"))
+    testImplementation("io.github.bluetape4k:bluetape4k-junit5:${bluetape4kVersion}")
     testImplementation(Libs.kotlinx_coroutines_test)
 }
 ```

--- a/virtualthread/jdk21/README.md
+++ b/virtualthread/jdk21/README.md
@@ -118,15 +118,15 @@ tasks.withType<JavaCompile>().configureEach {
 
 ## Dependencies
 
-### Project Dependencies
+### Gradle Dependencies
 
 ```kotlin
 dependencies {
-    api(project(":bluetape4k-virtualthread-api"))
-    implementation(project(":bluetape4k-logging"))
+    api("io.github.bluetape4k:bluetape4k-virtualthread-api:${bluetape4kVersion}")
+    implementation("io.github.bluetape4k:bluetape4k-logging:${bluetape4kVersion}")
     implementation(Libs.kotlinx_coroutines_core)
 
-    testImplementation(project(":bluetape4k-junit5"))
+    testImplementation("io.github.bluetape4k:bluetape4k-junit5:${bluetape4kVersion}")
     testImplementation(Libs.kotlinx_coroutines_test)
 }
 ```

--- a/virtualthread/jdk25/README.ko.md
+++ b/virtualthread/jdk25/README.ko.md
@@ -119,15 +119,15 @@ tasks.withType<JavaCompile>().configureEach {
 
 ## 의존성
 
-### 프로젝트 의존성
+### Gradle 의존성
 
 ```kotlin
 dependencies {
-    api(project(":bluetape4k-virtualthread-api"))
-    implementation(project(":bluetape4k-logging"))
+    api("io.github.bluetape4k:bluetape4k-virtualthread-api:${bluetape4kVersion}")
+    implementation("io.github.bluetape4k:bluetape4k-logging:${bluetape4kVersion}")
     implementation(Libs.kotlinx_coroutines_core)
 
-    testImplementation(project(":bluetape4k-junit5"))
+    testImplementation("io.github.bluetape4k:bluetape4k-junit5:${bluetape4kVersion}")
     testImplementation(Libs.kotlinx_coroutines_test)
 }
 ```

--- a/virtualthread/jdk25/README.md
+++ b/virtualthread/jdk25/README.md
@@ -121,15 +121,15 @@ tasks.withType<JavaCompile>().configureEach {
 
 ## Dependencies
 
-### Project Dependencies
+### Gradle Dependencies
 
 ```kotlin
 dependencies {
-    api(project(":bluetape4k-virtualthread-api"))
-    implementation(project(":bluetape4k-logging"))
+    api("io.github.bluetape4k:bluetape4k-virtualthread-api:${bluetape4kVersion}")
+    implementation("io.github.bluetape4k:bluetape4k-logging:${bluetape4kVersion}")
     implementation(Libs.kotlinx_coroutines_core)
 
-    testImplementation(project(":bluetape4k-junit5"))
+    testImplementation("io.github.bluetape4k:bluetape4k-junit5:${bluetape4kVersion}")
     testImplementation(Libs.kotlinx_coroutines_test)
 }
 ```


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: docs: use published dependency coordinates

Replace README dependency snippets that used internal Gradle `project(":...")` references with published Maven coordinates.

## Background

Installation examples in public README files should be copyable from a consumer project. `project(":bluetape4k-avro")` and similar references only work inside this repository's multi-module Gradle build, so they read as contributor-only wiring rather than user-facing dependency instructions.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Updated affected module README files in English and Korean.
- Replaced internal project references with `io.github.bluetape4k:<artifact>:${bluetape4kVersion}` coordinates.
- Renamed virtual thread dependency headings from project-focused wording to Gradle dependency wording.

## Validation

- `rg 'project\\(":' -g 'README*.md' .`: PASS, no matches.
- `rg 'implementation\\(project|api\\(project|testImplementation\\(project|testFixtures\\(project' -g 'README*.md' .`: PASS, no matches.
- `git diff --check HEAD~1..HEAD`: PASS.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #772, head `d2701088fdce8e6b1ef916b49cab8859caad965c`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `docs/readme-user-dependencies`
- Labels: `documentation`
- State: `MERGED`, merge commit `56c3c9c2c5cd99033e4c5cb840680bc291c8fa68`
- CI: Replace README dependency snippets that used internal Gradle `project(":...")` references with published Maven coordinates. / Installation examples in public README files should be copyable from a consumer project. `project(":bluetape4k-avro")` and similar references only work inside this repository's multi-module Gradle build, so they read as contributor-only wiring rather than user-facing dependency instructions. / - Renamed virtual thread dependency headings from project-focused wording to Gradle dependency wording.

## DoD Status

| Step | Status | Evidence |
|------|--------|----------|
| R - Route | PASS | Type E documentation maintenance; README dependency snippets only. |
| D - Discover | PASS | Found internal `project(":...")` references in module README files; root README already had no such snippet. |
| C - Apply | PASS | 41 README files changed from internal Gradle project references to published coordinates. |
| V - Verify | PASS | Targeted `rg` checks returned no README project references; `git diff --check HEAD~1..HEAD` passed. |
| 6-E - Scope | PASS | Documentation-only; no production code or build logic changed. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #772 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `56c3c9c2c5cd99033e4c5cb840680bc291c8fa68`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
