### PR TITLE
fix(coroutines): preserve Flow terminal contracts

### DIFF
--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/bufferingDebounce.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/bufferingDebounce.kt
@@ -2,12 +2,12 @@ package io.bluetape4k.coroutines.flow.extensions
 
 import kotlinx.coroutines.channels.onFailure
 import kotlinx.coroutines.channels.onSuccess
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.produceIn
 import kotlinx.coroutines.selects.onTimeout
 import kotlinx.coroutines.selects.whileSelect
+import kotlinx.coroutines.supervisorScope
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.nanoseconds
 
@@ -30,7 +30,7 @@ private const val DEFAULT_DEBOUNCE_BUFFER_CAPACITY = 16
  * @param timeout 배치를 끊을 디바운스 시간입니다.
  */
 fun <T> Flow<T>.bufferingDebounce(timeout: Duration): Flow<List<T>> = flow {
-    coroutineScope {
+    supervisorScope {
         val itemChannel = this@bufferingDebounce.produceIn(this)
         try {
             var bufferedItems = ArrayList<T>(DEFAULT_DEBOUNCE_BUFFER_CAPACITY)
@@ -52,7 +52,12 @@ fun <T> Flow<T>.bufferingDebounce(timeout: Duration): Flow<List<T>> = flow {
                     prevTimeNs = receiveTimeNs
                     result
                         .onSuccess { item -> bufferedItems.add(item) }
-                        .onFailure { if (bufferedItems.isNotEmpty()) emit(bufferedItems) }
+                        .onFailure { cause ->
+                            if (bufferedItems.isNotEmpty()) {
+                                emit(bufferedItems)
+                            }
+                            cause?.let { throw it }
+                        }
                         .isSuccess
                 }
             }

--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/UnicastSubject.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/UnicastSubject.kt
@@ -196,7 +196,7 @@ class UnicastSubject<T: Any>: AbstractFlow<T>(), SubjectApi<T> {
      * @param ex 종료 원인 예외입니다.
      */
     override suspend fun emitError(ex: Throwable?) {
-        terminal.value = ex
+        terminal.value = ex ?: terminated
         resumable.resume()
     }
 

--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/UnicastWorkSubject.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/UnicastWorkSubject.kt
@@ -140,7 +140,7 @@ class UnicastWorkSubject<T: Any>: AbstractFlow<T>(), SubjectApi<T> {
      * @param ex 종료 시 전파할 예외입니다.
      */
     override suspend fun emitError(ex: Throwable?) {
-        terminal.value = ex
+        terminal.value = ex ?: terminated
         resumable.resume()
     }
 

--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/takeUntil.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/takeUntil.kt
@@ -74,8 +74,6 @@ internal fun <T> takeUntilInternal(source: Flow<T>, notifier: Flow<Any?>): Flow<
                     throw STOP
                 }
             } catch (e: StopFlowException) {
-                // Nothing to do
-            } finally {
                 state.gate.value = true
             }
         }

--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/throttle.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/throttle.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.coroutines.flow.extensions
 import io.bluetape4k.coroutines.flow.exceptions.FlowOperationException
 import io.bluetape4k.coroutines.flow.extensions.utils.DONE_VALUE
 import io.bluetape4k.coroutines.flow.extensions.utils.NULL_VALUE
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.ChannelResult
@@ -374,7 +375,12 @@ fun <T> Flow<T>.throttleTime(
                             }
                         }
                         .onFailure { error ->
-                            error?.let { throw FlowOperationException("Fail to throttling", error) }
+                            error?.let {
+                                if (it is CancellationException) {
+                                    throw it
+                                }
+                                throw FlowOperationException("Fail to throttling", it)
+                            }
 
                             // Once the original flow has completed, there may still be a pending value
                             // waiting to be emitted. If so, wait for the throttling window to end and then

--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/withLatestFrom.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/withLatestFrom.kt
@@ -33,14 +33,18 @@ fun <A, B, R> Flow<A>.withLatestFrom(
 
     try {
         coroutineScope {
-            launch(start = CoroutineStart.UNDISPATCHED) {
+            val otherJob = launch(start = CoroutineStart.UNDISPATCHED) {
                 other.collect { state.otherRef.value = it ?: NULL_VALUE }
             }
 
-            collect { value: A ->
-                emit(
-                    transform(value, NULL_VALUE.unbox(state.otherRef.value ?: return@collect))
-                )
+            try {
+                collect { value: A ->
+                    emit(
+                        transform(value, NULL_VALUE.unbox(state.otherRef.value ?: return@collect))
+                    )
+                }
+            } finally {
+                otherJob.cancel()
             }
         }
     } finally {

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/BufferingDebouncedTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/BufferingDebouncedTest.kt
@@ -1,14 +1,16 @@
 package io.bluetape4k.coroutines.flow.extensions
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldHaveSize
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -62,5 +64,22 @@ class BufferingDebouncedTest: AbstractFlowTest() {
         log.debug { "itemLists=$itemLists" }
 
         itemLists shouldHaveSize 2 shouldBeEqualTo listOf(listOf(1, 2), listOf(3))
+    }
+
+    @Test
+    fun `flow 예외는 버퍼를 발행한 뒤 전파한다`() = runSuspendIO {
+        val source = flow {
+            emit(1)
+            delay(150.milliseconds)
+            emit(2)
+            throw RuntimeException("Boom!")
+        }
+
+        val itemLists = mutableListOf<List<Int>>()
+        assertFailsWith<RuntimeException> {
+            source.bufferingDebounce(200.milliseconds).collect { itemLists += it }
+        }
+
+        itemLists shouldBeEqualTo listOf(listOf(1, 2))
     }
 }

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/RepeatFlowTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/RepeatFlowTest.kt
@@ -1,6 +1,8 @@
 package io.bluetape4k.coroutines.flow.extensions
 
 import app.cash.turbine.test
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.coroutines.tests.assertResult
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import kotlinx.coroutines.delay
@@ -9,8 +11,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.newFixedThreadPoolContext
 import kotlinx.coroutines.test.runTest
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeInstanceOf
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
@@ -20,6 +21,11 @@ class RepeatFlowTest: AbstractFlowTest() {
     companion object: KLoggingChannel()
 
     private val testDispatcher = newFixedThreadPoolContext(8, "flowx")
+
+    @AfterAll
+    fun afterAll() {
+        testDispatcher.close()
+    }
 
     @Test
     fun `repeatFlow operator`() = runTest {

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/TakeUntilTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/TakeUntilTest.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.coroutines.tests.assertError
 import io.bluetape4k.coroutines.tests.assertResult
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onEach
@@ -106,5 +107,12 @@ class TakeUntilTest: AbstractFlowTest() {
             .takeUntil(delayedFlow(100)).log("takeUntil")
             .take(1)
             .assertResult(1)
+    }
+
+    @Test
+    fun `empty notifier does not stop source`() = runTest {
+        flowOf(1, 2, 3).log("source")
+            .takeUntil(emptyFlow()).log("takeUntil")
+            .assertResult(1, 2, 3)
     }
 }

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/ThrottleTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/ThrottleTest.kt
@@ -1,6 +1,9 @@
 package io.bluetape4k.coroutines.flow.extensions
 
 import app.cash.turbine.test
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.coroutines.tests.assertEmpty
 import io.bluetape4k.coroutines.tests.assertResult
 import io.bluetape4k.logging.coroutines.KLoggingChannel
@@ -16,9 +19,6 @@ import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeFalse
-import io.bluetape4k.assertions.shouldBeInstanceOf
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration
@@ -383,6 +383,19 @@ class ThrottleTest: AbstractFlowTest() {
                     awaitItem() shouldBeEqualTo FlowEvent.Value(1)
                     awaitItem().errorOrThrow() shouldBeInstanceOf kotlinx.coroutines.CancellationException::class
                     awaitComplete()
+                }
+        }
+
+        @Test
+        fun `throttle preserves upstream cancellation`() = runTest {
+            flow {
+                emit(1)
+                throw kotlinx.coroutines.CancellationException("source cancelled")
+            }.log("source")
+                .throttleLeading(500.milliseconds).log("leading")
+                .test {
+                    awaitItem() shouldBeEqualTo 1
+                    awaitError() shouldBeInstanceOf kotlinx.coroutines.CancellationException::class
                 }
         }
     }

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/WithLatestFromTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/WithLatestFromTest.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.coroutines.flow.extensions
 
 import app.cash.turbine.test
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.coroutines.tests.assertError
 import io.bluetape4k.coroutines.tests.assertResult
 import io.bluetape4k.logging.coroutines.KLoggingChannel
@@ -9,8 +10,9 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
-import io.bluetape4k.assertions.shouldBeEqualTo
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -86,5 +88,16 @@ class WithLatestFromTest: AbstractFlowTest() {
                 awaitItem() shouldBeEqualTo Pair(1, "a")
                 awaitComplete()
             }
+    }
+
+    @Test
+    fun `withLatestFrom cancels other when source completes first`() = runTest {
+        val result = withTimeout(100.milliseconds) {
+            flowOf(1, 2)
+                .withLatestFrom(neverFlow())
+                .toList()
+        }
+
+        result shouldBeEqualTo emptyList()
     }
 }

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/UnicastSubjectTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/UnicastSubjectTest.kt
@@ -60,6 +60,15 @@ class UnicastSubjectTest {
     }
 
     @Test
+    fun `null error completes subject`() = runSuspendTest {
+        val us = UnicastSubject<Int>()
+        us.emitError(null)
+
+        us.toList().shouldBeEmpty()
+        us.collectorCancelled.shouldBeTrue()
+    }
+
+    @Test
     fun `offline - complete 된 flow 에 대해서 다시 collect 를 수행하면 예외가 발생한다`() = runSuspendTest {
         val us = UnicastSubject<Int>()
         repeat(5) {

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/UnicastWorkSubjectTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/UnicastWorkSubjectTest.kt
@@ -76,6 +76,14 @@ class UnicastWorkSubjectTest {
     }
 
     @Test
+    fun `null error completes subject`() = runTest {
+        val us = UnicastWorkSubject<Int>()
+        us.emitError(null)
+
+        us.toList() shouldBeEqualTo emptyList()
+    }
+
+    @Test
     fun `offline - complete 된 flow 에 대해서 다시 collect 를 수행한다`() = runTest {
         val us = UnicastWorkSubject<Int>()
         repeat(5) {


### PR DESCRIPTION
## Summary

Closes #773

- PR 제목: fix(coroutines): preserve Flow terminal contracts

- Preserve upstream failure propagation in `bufferingDebounce` after flushing the pending buffer.
- Cancel `withLatestFrom`'s auxiliary collector when the source flow completes.
- Keep `takeUntil(emptyFlow())` aligned with its KDoc by not stopping the source on notifier completion alone.
- Preserve `CancellationException` in `throttleTime` and normalize `emitError(null)` in unicast subjects to normal termination.

Fixes #773

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Risk

- Moderate: these operators are shared Flow utilities, but the changes are scoped to terminal and cancellation edge cases covered by regression tests.

## Validation

- `./gradlew :bluetape4k-coroutines:test --tests "io.bluetape4k.coroutines.flow.extensions.BufferingDebouncedTest" --tests "io.bluetape4k.coroutines.flow.extensions.WithLatestFromTest" --tests "io.bluetape4k.coroutines.flow.extensions.TakeUntilTest" --tests "io.bluetape4k.coroutines.flow.extensions.ThrottleTest" --tests "io.bluetape4k.coroutines.flow.extensions.RepeatFlowTest" --tests "io.bluetape4k.coroutines.flow.extensions.subject.UnicastSubjectTest" --tests "io.bluetape4k.coroutines.flow.extensions.subject.UnicastWorkSubjectTest"`: 78 passing
- `./gradlew :bluetape4k-coroutines:test --rerun-tasks`: 573 passing
- `git diff --check`: pass

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #773, milestone `1.11.0`, assignee `debop`
- PR: #774, head `b7d104879b5b23bc339aff5888790a5a4aaaa7ca`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/coroutines-flow-contracts`
- Labels: `bug`, `test`, `tech-debt`
- State: `MERGED`, merge commit `8885451f034734d8f60c99864abdce57eca5376b`
- CI: - `./gradlew :bluetape4k-coroutines:test --tests "io.bluetape4k.coroutines.flow.extensions.BufferingDebouncedTest" --tests "io.bluetape4k.coroutines.flow.extensions.WithLatestFromTest" --tests "io.bluetape4k.coroutines.flow.extensions.TakeUntilTest" --tests "io.bluetape4k.coroutines.flow.extensions.ThrottleTest" --tests "io.bluetape4k.coroutines.flow.extensions.RepeatFlowTest" --tests "io.bluetape4k.coroutines.flow.extensions.subject.UnicastSubjectTest" --tests "io.bluetape4k.coroutines.flow.extensions.subject.UnicastWorkSubjectTest"`: 78 passing / - `./gradlew :bluetape4k-coroutines:test --rerun-tasks`: 573 passing

## DoD Status

- [x] Issue #773 created with milestone `1.11.0`, assignee `debop`, and labels `bug`, `test`, `tech-debt`.
- [x] Flow terminal contracts fixed for the P1/P2 review findings.
- [x] Regression tests added for buffered failure propagation, auxiliary collector cancellation, empty notifier behavior, cancellation preservation, null subject errors, and dispatcher cleanup.
- [x] Targeted and module-level tests pass.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #774 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `8885451f034734d8f60c99864abdce57eca5376b`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
