### PR TITLE
test: run Feign suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
       shared: ${{ steps.filter.outputs.shared }}
       core: ${{ steps.filter.outputs.core }}
       io: ${{ steps.filter.outputs.io }}
+      io-http: ${{ steps.filter.outputs.io-http }}
       ktor: ${{ steps.filter.outputs.ktor }}
       key-utils: ${{ steps.filter.outputs.key-utils }}
       infra: ${{ steps.filter.outputs.infra }}
@@ -112,6 +113,10 @@ jobs:
               - 'io/okio/**'
               - 'io/json/**'
               - 'io/jackson3/**'
+            io-http:
+              - 'io/feign/**'
+              - 'testing/mock-web-server/**'
+              - 'testing/testcontainers/**'
             ktor:
               - 'ktor/**'
             key-utils:
@@ -281,6 +286,62 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: coverage-io
+          path: '**/build/reports/kover/'
+          retention-days: 30
+
+  # ── 4-b. I/O HTTP 클라이언트 테스트 (Testcontainers) ───────────────────────
+  test-io-http:
+    name: Test / IO HTTP
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['io-http'] == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Build mock-web-server Docker image
+        run: ./gradlew :bluetape4k-mock-web-server:jibDockerBuild --no-configuration-cache
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Test Feign module
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          shell: bash
+          command: ./gradlew :bluetape4k-feign:test --no-configuration-cache
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Generate Kover XML report
+        if: always()
+        run: ./gradlew :bluetape4k-feign:koverXmlReport --no-configuration-cache
+        continue-on-error: true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-io-http
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 30
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-io-http
           path: '**/build/reports/kover/'
           retention-days: 30
 
@@ -480,7 +541,7 @@ jobs:
     name: Coverage Report
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [test-core, test-io, test-ktor, test-key-utils, test-infra]
+    needs: [test-core, test-io, test-io-http, test-ktor, test-key-utils, test-infra]
     if: always()
     steps:
       - uses: actions/checkout@v7
@@ -519,7 +580,7 @@ jobs:
     name: CI Status
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [gitleaks, validate-wrapper, changes, build, test-core, test-io, test-ktor, test-key-utils, test-infra, coverage-report]
+    needs: [gitleaks, validate-wrapper, changes, build, test-core, test-io, test-io-http, test-ktor, test-key-utils, test-infra, coverage-report]
     if: always()
     steps:
       - name: Check all jobs

--- a/io/feign/src/test/kotlin/io/bluetape4k/feign/clients/AbstractCoroutineClientTest.kt
+++ b/io/feign/src/test/kotlin/io/bluetape4k/feign/clients/AbstractCoroutineClientTest.kt
@@ -5,6 +5,9 @@ import feign.Param
 import feign.RequestLine
 import feign.codec.DefaultDecoder
 import feign.kotlin.CoroutineFeign
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldContainSame
 import io.bluetape4k.feign.codec.FeignFastjsonDecoder
 import io.bluetape4k.feign.codec.FeignFastjsonEncoder
 import io.bluetape4k.feign.codec.JacksonDecoder2
@@ -15,17 +18,14 @@ import io.bluetape4k.http.okhttp3.mock.enqueueBody
 import io.bluetape4k.http.okhttp3.mock.enqueueBodyWithDelay
 import io.bluetape4k.jackson3.Jackson
 import io.bluetape4k.jackson3.writeAsString
-import tools.jackson.databind.json.JsonMapper
 import io.bluetape4k.junit5.coroutines.runSuspendTest
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.support.closeSafe
 import okhttp3.mockwebserver.MockWebServer
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeNull
-import io.bluetape4k.assertions.shouldContainSame
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import tools.jackson.databind.json.JsonMapper
 import java.io.Serializable
 import java.time.Duration
 
@@ -167,8 +167,9 @@ abstract class AbstractCoroutineClientTest {
 
         val client = newCoroutineBuilder().client<TestInterfaceAsync>(server.baseUrl)
 
-        val result = client.findOrderThatReturningUnit(1)
-        result shouldBeEqualTo Unit
+        client.findOrderThatReturningUnit(1)
+
+        server.takeRequest().path shouldBeEqualTo "/icecream/orders/1"
     }
 
     @Test


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: test: run Feign suite in CI

- Add a push CI `Test / IO HTTP` job for `io/feign` changes.
- Build the mock web server Docker image before running `:bluetape4k-feign:test`.
- Adjust the Unit-return coroutine Feign assertion to verify request arrival, matching Feign's void-return behavior.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary
- Add a push CI `Test / IO HTTP` job for `io/feign` changes.
- Build the mock web server Docker image before running `:bluetape4k-feign:test`.
- Adjust the Unit-return coroutine Feign assertion to verify request arrival, matching Feign's void-return behavior.

### Validation
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- `./gradlew :bluetape4k-mock-web-server:jibDockerBuild --no-configuration-cache`
- `./gradlew :bluetape4k-feign:test --no-configuration-cache`
- `./gradlew :bluetape4k-feign:koverXmlReport --no-configuration-cache`
- GitHub Actions PR checks: all passed, including `Test / IO HTTP`.

### DoD Status
- [x] Feign tests are covered by push CI path filtering.
- [x] Local Feign suite passes: 243 tests.
- [x] Workflow YAML passes actionlint.
- [x] GitHub Actions checks passed on this PR.

## Validation

- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- `./gradlew :bluetape4k-mock-web-server:jibDockerBuild --no-configuration-cache`
- `./gradlew :bluetape4k-feign:test --no-configuration-cache`
- `./gradlew :bluetape4k-feign:koverXmlReport --no-configuration-cache`
- GitHub Actions PR checks: all passed, including `Test / IO HTTP`.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #857, head `111fd102524f491dcda31a47cf06bdbe37fd624d`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `chore/ci-feign-tests`
- Labels: 없음
- State: `MERGED`, merge commit `5c2ed1c6cdf59eb57cfd27ad2c824a39dc585bc5`
- CI: - Add a push CI `Test / IO HTTP` job for `io/feign` changes. / - `actionlint .github/workflows/ci.yml` / - `./gradlew :bluetape4k-mock-web-server:jibDockerBuild --no-configuration-cache`

## DoD Status

- [x] Feign tests are covered by push CI path filtering.
- [x] Local Feign suite passes: 243 tests.
- [x] Workflow YAML passes actionlint.
- [x] GitHub Actions checks passed on this PR.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #857 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `5c2ed1c6cdf59eb57cfd27ad2c824a39dc585bc5`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
