### PR TITLE
Fix workflow ALL fail-fast semantics

### DIFF
--- a/docs/lessons/2026-06-23-issue-856-workflow-all-fail-fast.md
+++ b/docs/lessons/2026-06-23-issue-856-workflow-all-fail-fast.md
@@ -1,0 +1,17 @@
+# Lessons - Issue #856 Workflow ALL Fail-Fast
+
+## Context
+
+Issue #856 fixed `ParallelPolicy.ALL` so blocking and suspend parallel workflows stop remaining siblings when any branch throws or returns a non-success `WorkReport`.
+
+## Lessons
+
+- Fail-fast must cover returned reports as well as thrown exceptions. A child that catches its own exception and returns `WorkReport.Failure` will otherwise look like normal completion to structured concurrency.
+- `WorkReport.Aborted` and `WorkReport.Cancelled` are also non-success outcomes for ALL. They should cancel siblings instead of waiting for every branch and applying a priority table afterward.
+- Cancellation tests need workflow-owned siblings. Stress helpers are useful for repeated independent execution, but they do not prove that a specific sibling received `InterruptedException` or coroutine cancellation from the workflow scope.
+- Suspend implementations must not swallow `CancellationException`. Re-throw it so parent cancellation and child cancellation contracts stay observable.
+- Keep README policy text and `ParallelPolicy` KDoc aligned with implementation semantics. ALL means all branches succeed; any non-success branch fails fast.
+
+## Guard
+
+When changing workflow policies, add thrown-exception plus returned `Failure`/`Aborted`/`Cancelled` regression tests for blocking and suspend implementations, then preserve RED and GREEN evidence in `docs/review`.

--- a/docs/review/2026-06-23-issue-856-workflow-all-fail-fast-review.md
+++ b/docs/review/2026-06-23-issue-856-workflow-all-fail-fast-review.md
@@ -1,0 +1,59 @@
+# Issue #856 Workflow ALL Fail-Fast Review
+
+## Scope
+
+- Branch: `fix/workflow-all-fail-fast-856`
+- Module: `:bluetape4k-workflow`
+- Issue: `#856`
+- Files: blocking and suspend parallel workflow implementations, ALL policy docs, README policy notes, and fail-fast regression tests.
+
+## RED Evidence
+
+Before production code changed, the new fail-fast regression tests failed as expected in an `origin/develop` RED worktree with only the tests applied:
+
+```text
+./gradlew :bluetape4k-workflow:test \
+  --tests "io.bluetape4k.workflow.core.ParallelWorkFlowTest.ALL policy cancels remaining work when one branch throws" \
+  --tests "io.bluetape4k.workflow.core.ParallelWorkFlowTest.ALL policy cancels remaining work when one branch returns Failure" \
+  --tests "io.bluetape4k.workflow.core.ParallelWorkFlowTest.ALL policy cancels remaining work when one branch returns Aborted" \
+  --tests "io.bluetape4k.workflow.core.ParallelWorkFlowTest.ALL policy cancels remaining work when one branch returns Cancelled" \
+  --tests "io.bluetape4k.workflow.coroutines.SuspendParallelFlowTest.ALL policy cancels remaining suspend work when one branch throws" \
+  --tests "io.bluetape4k.workflow.coroutines.SuspendParallelFlowTest.ALL policy cancels remaining suspend work when one branch returns Failure" \
+  --tests "io.bluetape4k.workflow.coroutines.SuspendParallelFlowTest.ALL policy cancels remaining suspend work when one branch returns Aborted" \
+  --tests "io.bluetape4k.workflow.coroutines.SuspendParallelFlowTest.ALL policy cancels remaining suspend work when one branch returns Cancelled"
+```
+
+Result: FAILED, 0 passing and 8 failing.
+
+- Blocking ALL fail-fast tests failed for thrown exception and returned `Failure`/`Aborted`/`Cancelled`: expected sibling interrupt signal, but `slowInterrupted=false`.
+- Suspend ALL fail-fast tests failed for thrown exception and returned `Failure`/`Aborted`/`Cancelled`: expected sibling cancellation signal, but `slowCancelled=false`.
+
+## Review Fixes
+
+| Finding | Resolution |
+|---|---|
+| ALL fail-fast only covered thrown exceptions. | `Failure`, `Aborted`, and `Cancelled` reports are converted to `WorkNotSuccessException` inside each child so structured concurrency cancels siblings. |
+| Blocking tests needed workflow-owned sibling cancellation proof. | Tests now use one workflow-owned slow branch and assert the exact interrupt signal. |
+| Suspend tests needed cancellation semantics proof. | Tests now assert sibling cancellation and add explicit child `CancellationException` propagation coverage. |
+| Concurrency helper choice needed rationale. | Test comments explain why `StructuredTaskScopeTester` and `SuspendedJobTester` do not fit this exact sibling-signal assertion. |
+
+## Findings
+
+| Severity | Count | Notes |
+|---|---:|---|
+| P0 | 0 | No production data-loss, API-breaking, or CI-blocking issue found in the repaired diff. |
+| P1 | 0 | Returned non-success reports and thrown exceptions both trigger ALL fail-fast behavior. |
+| P2 | 0 | No remaining non-blocking review finding after the targeted fixes. |
+
+## Evidence
+
+| Check | Result | Evidence |
+|---|---|---|
+| Targeted workflow tests | PASS | `./gradlew :bluetape4k-workflow:test --tests "io.bluetape4k.workflow.core.ParallelWorkFlowTest" --tests "io.bluetape4k.workflow.coroutines.SuspendParallelFlowTest"` completed with 32 tests. |
+| Module test/build | PASS | `./gradlew :bluetape4k-workflow:test :bluetape4k-workflow:build` completed with 206 tests. |
+| Diff hygiene | PASS | `git diff --check` produced no output. |
+| Policy docs | PASS | `README.md`, `README.ko.md`, and `ParallelPolicy` describe ALL as all-success fail-fast. |
+
+## Verdict
+
+Gate passes with P0=0 and P1=0.

--- a/utils/workflow/README.ko.md
+++ b/utils/workflow/README.ko.md
@@ -141,7 +141,8 @@ val report = flow.execute(WorkContext())
 
 ![Parallel Flow diagram](../../docs/images/readme-diagrams/utils-workflow-diagram-05.png)
 
-`ALL`은 모든 fork 작업을 기다리고 실패 시 fail-fast로 처리합니다. `ANY`는 첫 성공 결과를 반환하고 나머지 작업을 취소합니다.
+`ALL`은 작업 하나가 `Failure`/`Aborted`/`Cancelled`를 반환하거나 예외를 던지면 남은 작업을 취소하는 fail-fast로 처리합니다.
+`ANY`는 첫 성공 결과를 반환하고 나머지 작업을 취소합니다.
 
 ```kotlin
 // 동기 (Virtual Threads)

--- a/utils/workflow/README.md
+++ b/utils/workflow/README.md
@@ -142,7 +142,8 @@ Execute tasks concurrently:
 
 ![Parallel Flow diagram](../../docs/images/readme-diagrams/utils-workflow-diagram-05.png)
 
-`ALL` waits for every forked task and fails fast on failure; `ANY` returns the first successful task and cancels the remaining tasks.
+`ALL` fails fast by cancelling remaining tasks when any task returns `Failure`/`Aborted`/`Cancelled` or throws an exception.
+`ANY` returns the first successful task and cancels the remaining tasks.
 
 ```kotlin
 // Sync (Virtual Threads)

--- a/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/api/ParallelPolicy.kt
+++ b/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/api/ParallelPolicy.kt
@@ -4,13 +4,13 @@ package io.bluetape4k.workflow.api
  * 병렬 워크플로 실행 정책.
  *
  * [java.util.concurrent.StructuredTaskScope] 의 두 가지 정책에 대응합니다:
- * - [ALL]: ShutdownOnFailure — 모든 작업이 완료되어야 하며, 하나라도 실패 시 나머지 취소
+ * - [ALL]: ShutdownOnFailure — 모든 작업이 성공해야 하며, 하나라도 실패 시 나머지 취소
  * - [ANY]: ShutdownOnSuccess — 첫 번째 성공한 작업 결과를 반환하고 나머지 취소
  *
  * ```kotlin
  * val flow = ParallelWorkFlow(
  *     works = listOf(work1, work2),
- *     policy = ParallelPolicy.ALL,   // 모두 완료 대기
+ *     policy = ParallelPolicy.ALL,   // 모두 성공해야 하며 실패 시 나머지 취소
  * )
  *
  * val raceFlow = ParallelWorkFlow(
@@ -20,7 +20,7 @@ package io.bluetape4k.workflow.api
  * ```
  */
 enum class ParallelPolicy {
-    /** 모든 작업이 완료되어야 함. 하나라도 실패 시 나머지 취소. while의 `&&` 조건. */
+    /** 모든 작업이 성공해야 함. 하나라도 실패 시 나머지 취소. while의 `&&` 조건. */
     ALL,
 
     /** 첫 번째 성공한 작업 결과를 반환하고 나머지 취소. while의 `||` 조건. */

--- a/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/core/ParallelWorkFlow.kt
+++ b/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/core/ParallelWorkFlow.kt
@@ -19,11 +19,11 @@ import kotlin.time.Duration.Companion.minutes
  *
  * [StructuredTaskScopes]를 사용하여 구조화된 동시성을 보장합니다.
  * [policy]에 따라 실행 전략이 달라집니다:
- * - [ParallelPolicy.ALL]: 모든 작업 완료를 대기하며, 하나라도 실패 시 나머지를 취소합니다.
+ * - [ParallelPolicy.ALL]: 모든 작업이 성공해야 하며, 성공이 아닌 보고서나 예외가 발생하면 나머지를 취소합니다.
  * - [ParallelPolicy.ANY]: 첫 번째 성공한 작업 결과를 즉시 반환하고 나머지를 취소합니다.
  *
  * ```kotlin
- * // ALL 정책 (기본값)
+ * // ALL 정책 (기본값) — 모두 성공해야 하며, 하나라도 성공이 아니면 fail-fast
  * val allFlow = ParallelWorkFlow(
  *     works = listOf(work1, work2, work3),
  *     policy = ParallelPolicy.ALL,
@@ -63,7 +63,7 @@ class ParallelWorkFlow(
     }
 
     /**
-     * ALL 정책: 모든 작업 완료를 대기합니다. 하나라도 실패 시 나머지를 취소합니다.
+     * ALL 정책: 모든 작업 성공을 대기합니다. 하나라도 성공이 아니거나 예외를 던지면 나머지를 취소합니다.
      *
      * [StructuredTaskScopes.failFast] (ShutdownOnFailure)을 사용합니다.
      */
@@ -77,13 +77,9 @@ class ParallelWorkFlow(
                     val workName = (work as? NamedWork)?.name ?: work.javaClass.simpleName
                     scope.fork {
                         log.debug { "$flowName: '$workName' 병렬 실행 시작 (ALL)" }
-                        val report = runCatching { work.execute(context) }
-                            .getOrElse { e ->
-                                log.debug { "$flowName: '$workName' 예외 발생 - ${e.message}" }
-                                WorkReport.Failure(context, e)
-                            }
+                        val report = work.execute(context)
                         log.debug { "$flowName: '$workName' 실행 완료 - status=${report.status}" }
-                        report
+                        if (report.isSuccess) report else throw WorkNotSuccessException(report)
                     }
                 }
 
@@ -91,23 +87,24 @@ class ParallelWorkFlow(
                     log.debug { "$flowName: throwIfFailed 감지 - ${e.message}" }
                 }
 
-                val reports = tasks.map { task ->
-                    runCatching { task.get() }
-                        .getOrElse { e -> WorkReport.Failure(context, e) }
-                }
+                tasks.forEach { task -> task.get() }
 
-                // 우선순위: ABORTED > CANCELLED > FAILED > SUCCESS
-                reports.firstOrNull { it.isAborted }
-                    ?: reports.firstOrNull { it.isCancelled }
-                    ?: reports.firstOrNull { it.isFailure }
-                    ?: run {
-                        log.debug { "$flowName 완료 - 모두 성공 (ALL)" }
-                        WorkReport.success(context)
-                    }
+                log.debug { "$flowName 완료 - 모두 성공 (ALL)" }
+                WorkReport.success(context)
             }
+        } catch (e: WorkNotSuccessException) {
+            log.debug { "$flowName: fail-fast report 감지 - status=${e.report.status}" }
+            e.report
         } catch (e: TimeoutException) {
             log.debug { "$flowName: timeout 초과 ($timeout) - Cancelled 반환" }
             WorkReport.Cancelled(context)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            log.debug { "$flowName: interrupted - Cancelled 반환" }
+            WorkReport.Cancelled(context)
+        } catch (e: Exception) {
+            log.debug { "$flowName: fail-fast 예외 발생 - ${e.message}" }
+            WorkReport.Failure(context, e)
         }
     }
 
@@ -170,10 +167,9 @@ class ParallelWorkFlow(
 }
 
 /**
- * [ParallelPolicy.ANY] 정책에서 성공이 아닌 [WorkReport]를 예외로 래핑하는 내부 클래스입니다.
+ * [ParallelPolicy.ALL]/[ParallelPolicy.ANY] 정책에서 성공이 아닌 [WorkReport]를 예외로 래핑하는 내부 클래스입니다.
  *
- * [java.util.concurrent.StructuredTaskScope.ShutdownOnSuccess]는 정상 반환만 "성공"으로 간주하므로,
- * 실패/중단/취소 결과를 예외로 전환하여 scope가 계속 다음 성공을 기다리도록 합니다.
+ * 구조화된 동시성 primitive는 정상 반환을 성공으로 간주하므로, 실패/중단/취소 결과를 예외로 전환합니다.
  */
 internal class WorkNotSuccessException(val report: WorkReport): RuntimeException("Work not successful: ${report.status}") {
     // 제어 흐름용 예외 — 스택 캡처 비용 없이 빠른 경로 처리

--- a/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/core/WorkflowDsl.kt
+++ b/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/core/WorkflowDsl.kt
@@ -148,7 +148,7 @@ class SequentialFlowBuilder(private val name: String = "sequential-flow") {
  * [policy]로 실행 전략을 선택할 수 있습니다.
  *
  * ```kotlin
- * // ALL 정책 (기본값) — 모든 작업 완료 대기
+ * // ALL 정책 (기본값) — 모두 성공해야 하며, 하나라도 성공이 아니면 fail-fast
  * val flow = parallelFlow("fetch-all") {
  *     execute("fetch-a") { ctx -> WorkReport.Success(ctx) }
  *     execute("fetch-b") { ctx -> WorkReport.Success(ctx) }
@@ -209,7 +209,7 @@ class ParallelFlowBuilder(private val name: String = "parallel-flow") {
     }
 
     /**
-     * 모든 작업 완료 대기 정책으로 설정합니다. [ParallelPolicy.ALL]과 동일합니다.
+     * 모든 작업이 성공해야 하는 fail-fast 정책으로 설정합니다. [ParallelPolicy.ALL]과 동일합니다.
      */
     fun all() {
         policy = ParallelPolicy.ALL

--- a/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/coroutines/SuspendParallelFlow.kt
+++ b/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/coroutines/SuspendParallelFlow.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.workflow.coroutines
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.workflow.core.WorkNotSuccessException
 import io.bluetape4k.workflow.api.NamedSuspendWork
 import io.bluetape4k.workflow.api.ParallelPolicy
 import io.bluetape4k.workflow.api.SuspendWork
@@ -20,14 +21,11 @@ import kotlinx.coroutines.launch
  *
  * [coroutineScope]를 사용하여 구조화된 동시성을 보장합니다.
  * [policy]에 따라 실행 전략이 달라집니다:
- * - [ParallelPolicy.ALL]: 모든 작업 완료를 대기하며, 하나라도 예외를 발생시키면 나머지가 자동 취소됩니다.
+ * - [ParallelPolicy.ALL]: 모든 작업이 성공해야 하며, 성공이 아닌 보고서나 예외가 발생하면 나머지가 자동 취소됩니다.
  * - [ParallelPolicy.ANY]: 첫 번째 성공한 작업 결과를 즉시 반환하고 나머지를 취소합니다.
  *
- * 결과 우선순위 (ALL): [Aborted][WorkReport.Aborted] > [Cancelled][WorkReport.Cancelled] >
- * [Failure][WorkReport.Failure] > [Success][WorkReport.Success]
- *
  * ```kotlin
- * // ALL 정책 (기본값)
+ * // ALL 정책 (기본값) — 모두 성공해야 하며, 하나라도 성공이 아니면 fail-fast
  * val allFlow = SuspendParallelFlow(
  *     works = listOf(work1, work2, work3),
  *     policy = ParallelPolicy.ALL,
@@ -64,35 +62,36 @@ class SuspendParallelFlow(
     }
 
     /**
-     * ALL 정책: 모든 작업 완료를 대기합니다.
+     * ALL 정책: 모든 작업 성공을 대기합니다.
+     * 하나라도 성공이 아니거나 예외를 던지면 나머지를 취소합니다.
+     *
      * [coroutineScope] + [awaitAll]을 사용하여 구조화된 동시성을 보장합니다.
      */
     private suspend fun executeAll(context: WorkContext): WorkReport {
-        val reports = coroutineScope {
-            works.map { work ->
-                val workName = (work as? NamedSuspendWork)?.name ?: work.javaClass.simpleName
-                async {
-                    log.debug { "$flowName: '$workName' 병렬 실행 시작 (ALL)" }
-                    val report = runCatching { work.execute(context) }
-                        .getOrElse { e ->
-                            if (e is CancellationException) throw e
-                            log.debug { "$flowName: '$workName' 예외 발생 - ${e.message}" }
-                            WorkReport.Failure(context, e)
-                        }
-                    log.debug { "$flowName: '$workName' 실행 완료 - status=${report.status}" }
-                    report
-                }
-            }.awaitAll()
+        try {
+            coroutineScope {
+                works.map { work ->
+                    val workName = (work as? NamedSuspendWork)?.name ?: work.javaClass.simpleName
+                    async {
+                        log.debug { "$flowName: '$workName' 병렬 실행 시작 (ALL)" }
+                        val report = work.execute(context)
+                        log.debug { "$flowName: '$workName' 실행 완료 - status=${report.status}" }
+                        if (report.isSuccess) report else throw WorkNotSuccessException(report)
+                    }
+                }.awaitAll()
+            }
+        } catch (e: WorkNotSuccessException) {
+            log.debug { "$flowName: fail-fast report 감지 - status=${e.report.status}" }
+            return e.report
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.debug { "$flowName: fail-fast 예외 발생 - ${e.message}" }
+            return WorkReport.Failure(context, e)
         }
 
-        // 우선순위: ABORTED > CANCELLED > FAILED > SUCCESS
-        return reports.firstOrNull { it.isAborted }
-            ?: reports.firstOrNull { it.isCancelled }
-            ?: reports.firstOrNull { it.isFailure }
-            ?: run {
-                log.debug { "$flowName 완료 - 모두 성공 (ALL)" }
-                WorkReport.success(context)
-            }
+        log.debug { "$flowName 완료 - 모두 성공 (ALL)" }
+        return WorkReport.success(context)
     }
 
     /**

--- a/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/coroutines/SuspendWorkflowDsl.kt
+++ b/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/coroutines/SuspendWorkflowDsl.kt
@@ -148,7 +148,7 @@ class SuspendSequentialFlowBuilder(private val name: String = "suspend-sequentia
  * [policy]로 실행 전략을 선택할 수 있습니다.
  *
  * ```kotlin
- * // ALL 정책 (기본값) — 모든 작업 완료 대기
+ * // ALL 정책 (기본값) — 모두 성공해야 하며, 하나라도 성공이 아니면 fail-fast
  * val flow = suspendParallelFlow("fetch-all") {
  *     execute("fetch-a") { ctx -> WorkReport.Success(ctx) }
  *     execute("fetch-b") { ctx -> WorkReport.Success(ctx) }
@@ -198,7 +198,7 @@ class SuspendParallelFlowBuilder(private val name: String = "suspend-parallel-fl
     }
 
     /**
-     * 모든 작업 완료 대기 정책으로 설정합니다. [ParallelPolicy.ALL]과 동일합니다.
+     * 모든 작업이 성공해야 하는 fail-fast 정책으로 설정합니다. [ParallelPolicy.ALL]과 동일합니다.
      */
     fun all() {
         policy = ParallelPolicy.ALL

--- a/utils/workflow/src/test/kotlin/io/bluetape4k/workflow/core/ParallelWorkFlowTest.kt
+++ b/utils/workflow/src/test/kotlin/io/bluetape4k/workflow/core/ParallelWorkFlowTest.kt
@@ -7,6 +7,9 @@ import io.bluetape4k.workflow.api.WorkReport
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.milliseconds
 
 class ParallelWorkFlowTest: AbstractWorkflowTest() {
@@ -39,10 +42,83 @@ class ParallelWorkFlowTest: AbstractWorkflowTest() {
     }
 
     @Test
-    fun `하나라도 ABORTED - Aborted 반환, ABORTED가 FAILED보다 우선순위 높음`() {
+    fun `ALL policy cancels remaining work when one branch throws`() {
+        val slowStarted = CountDownLatch(1)
+        val slowInterrupted = AtomicBoolean(false)
+        // StructuredTaskScopeTester stress-runs independent blocks; this assertion needs
+        // one workflow-owned sibling and its exact interrupt signal.
+        val works = listOf(
+            interruptibleSlowWork(slowStarted, slowInterrupted),
+            Work("fast-fail") { ctx ->
+                slowStarted.await(1, TimeUnit.SECONDS).shouldBeTrue()
+                throw IllegalStateException("fail fast")
+            },
+        )
+        val flow = ParallelWorkFlow(works, policy = ParallelPolicy.ALL)
+
+        flow.execute(context) shouldBeInstanceOf WorkReport.Failure::class
+
+        slowInterrupted.get().shouldBeTrue()
+    }
+
+    @Test
+    fun `ALL policy cancels remaining work when one branch returns Failure`() {
+        val slowStarted = CountDownLatch(1)
+        val slowInterrupted = AtomicBoolean(false)
+        val works = listOf(
+            interruptibleSlowWork(slowStarted, slowInterrupted),
+            Work("fast-failure-report") { ctx ->
+                slowStarted.await(1, TimeUnit.SECONDS).shouldBeTrue()
+                WorkReport.failure(ctx, IllegalStateException("failure report"))
+            },
+        )
+        val flow = ParallelWorkFlow(works, policy = ParallelPolicy.ALL)
+
+        flow.execute(context) shouldBeInstanceOf WorkReport.Failure::class
+
+        slowInterrupted.get().shouldBeTrue()
+    }
+
+    @Test
+    fun `ALL policy cancels remaining work when one branch returns Aborted`() {
+        val slowStarted = CountDownLatch(1)
+        val slowInterrupted = AtomicBoolean(false)
+        val works = listOf(
+            interruptibleSlowWork(slowStarted, slowInterrupted),
+            Work("fast-aborted-report") { ctx ->
+                slowStarted.await(1, TimeUnit.SECONDS).shouldBeTrue()
+                WorkReport.aborted(ctx, "aborted report")
+            },
+        )
+        val flow = ParallelWorkFlow(works, policy = ParallelPolicy.ALL)
+
+        flow.execute(context) shouldBeInstanceOf WorkReport.Aborted::class
+
+        slowInterrupted.get().shouldBeTrue()
+    }
+
+    @Test
+    fun `ALL policy cancels remaining work when one branch returns Cancelled`() {
+        val slowStarted = CountDownLatch(1)
+        val slowInterrupted = AtomicBoolean(false)
+        val works = listOf(
+            interruptibleSlowWork(slowStarted, slowInterrupted),
+            Work("fast-cancelled-report") { ctx ->
+                slowStarted.await(1, TimeUnit.SECONDS).shouldBeTrue()
+                WorkReport.cancelled(ctx, "cancelled report")
+            },
+        )
+        val flow = ParallelWorkFlow(works, policy = ParallelPolicy.ALL)
+
+        flow.execute(context) shouldBeInstanceOf WorkReport.Cancelled::class
+
+        slowInterrupted.get().shouldBeTrue()
+    }
+
+    @Test
+    fun `하나라도 ABORTED - Aborted 반환`() {
         val works = listOf(
             successWork("work-1"),
-            failWork("fail-work"),
             abortWork("abort-work"),
             successWork("work-4"),
         )
@@ -171,4 +247,19 @@ class ParallelWorkFlowTest: AbstractWorkflowTest() {
         anyReport.isSuccess.shouldBeTrue()
         anyReport shouldBeInstanceOf WorkReport.Success::class
     }
+
+    private fun interruptibleSlowWork(
+        slowStarted: CountDownLatch,
+        slowInterrupted: AtomicBoolean,
+    ): Work =
+        Work("slow-work") { ctx ->
+            slowStarted.countDown()
+            try {
+                Thread.sleep(5_000)
+                WorkReport.success(ctx)
+            } catch (e: InterruptedException) {
+                slowInterrupted.set(true)
+                throw e
+            }
+        }
 }

--- a/utils/workflow/src/test/kotlin/io/bluetape4k/workflow/coroutines/SuspendParallelFlowTest.kt
+++ b/utils/workflow/src/test/kotlin/io/bluetape4k/workflow/coroutines/SuspendParallelFlowTest.kt
@@ -4,11 +4,18 @@ import io.bluetape4k.workflow.api.AbstractWorkflowTest
 import io.bluetape4k.workflow.api.ParallelPolicy
 import io.bluetape4k.workflow.api.SuspendWork
 import io.bluetape4k.workflow.api.WorkReport
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeTrue
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -40,7 +47,99 @@ class SuspendParallelFlowTest: AbstractWorkflowTest() {
     }
 
     @Test
-    fun `ABORTED 우선순위 - Aborted 반환`() = runTest {
+    fun `ALL policy cancels remaining suspend work when one branch throws`() = runTest {
+        val slowStarted = CompletableDeferred<Unit>()
+        val slowCancelled = AtomicBoolean(false)
+        // SuspendedJobTester stress-runs independent suspend blocks; this assertion needs
+        // one workflow-owned sibling and its exact cancellation signal.
+        val works = listOf(
+            cancellableSlowSuspendWork(slowStarted, slowCancelled),
+            SuspendWork("fast-fail") {
+                slowStarted.await()
+                throw IllegalStateException("fail fast")
+            },
+        )
+        val flow = SuspendParallelFlow(works, policy = ParallelPolicy.ALL)
+
+        flow.execute(context) shouldBeInstanceOf WorkReport.Failure::class
+
+        slowCancelled.get().shouldBeTrue()
+    }
+
+    @Test
+    fun `ALL policy cancels remaining suspend work when one branch returns Failure`() = runTest {
+        val slowStarted = CompletableDeferred<Unit>()
+        val slowCancelled = AtomicBoolean(false)
+        val works = listOf(
+            cancellableSlowSuspendWork(slowStarted, slowCancelled),
+            SuspendWork("fast-failure-report") { ctx ->
+                slowStarted.await()
+                WorkReport.failure(ctx, IllegalStateException("failure report"))
+            },
+        )
+        val flow = SuspendParallelFlow(works, policy = ParallelPolicy.ALL)
+
+        flow.execute(context) shouldBeInstanceOf WorkReport.Failure::class
+
+        slowCancelled.get().shouldBeTrue()
+    }
+
+    @Test
+    fun `ALL policy cancels remaining suspend work when one branch returns Aborted`() = runTest {
+        val slowStarted = CompletableDeferred<Unit>()
+        val slowCancelled = AtomicBoolean(false)
+        val works = listOf(
+            cancellableSlowSuspendWork(slowStarted, slowCancelled),
+            SuspendWork("fast-aborted-report") { ctx ->
+                slowStarted.await()
+                WorkReport.aborted(ctx, "aborted report")
+            },
+        )
+        val flow = SuspendParallelFlow(works, policy = ParallelPolicy.ALL)
+
+        flow.execute(context) shouldBeInstanceOf WorkReport.Aborted::class
+
+        slowCancelled.get().shouldBeTrue()
+    }
+
+    @Test
+    fun `ALL policy cancels remaining suspend work when one branch returns Cancelled`() = runTest {
+        val slowStarted = CompletableDeferred<Unit>()
+        val slowCancelled = AtomicBoolean(false)
+        val works = listOf(
+            cancellableSlowSuspendWork(slowStarted, slowCancelled),
+            SuspendWork("fast-cancelled-report") { ctx ->
+                slowStarted.await()
+                WorkReport.cancelled(ctx, "cancelled report")
+            },
+        )
+        val flow = SuspendParallelFlow(works, policy = ParallelPolicy.ALL)
+
+        flow.execute(context) shouldBeInstanceOf WorkReport.Cancelled::class
+
+        slowCancelled.get().shouldBeTrue()
+    }
+
+    @Test
+    fun `ALL policy propagates child CancellationException`() = runTest {
+        val flow = SuspendParallelFlow(
+            works = listOf(
+                SuspendWork("cancel-work") {
+                    throw CancellationException("cancel")
+                },
+            ),
+            policy = ParallelPolicy.ALL,
+        )
+
+        val error = assertFailsWith<CancellationException> {
+            flow.execute(context)
+        }
+
+        error.message shouldBeEqualTo "cancel"
+    }
+
+    @Test
+    fun `하나라도 ABORTED - Aborted 반환`() = runTest {
         val works = listOf(
             SuspendWork("work-1") { ctx -> WorkReport.success(ctx) },
             SuspendWork("work-abort") { ctx -> WorkReport.aborted(ctx, "중단") },
@@ -52,7 +151,7 @@ class SuspendParallelFlowTest: AbstractWorkflowTest() {
     }
 
     @Test
-    fun `CANCELLED 반환 - Cancelled 우선순위`() = runTest {
+    fun `하나라도 CANCELLED - Cancelled 반환`() = runTest {
         val works = listOf(
             SuspendWork("work-1") { ctx -> WorkReport.success(ctx) },
             SuspendWork("work-cancelled") { ctx -> WorkReport.cancelled(ctx, "취소") },
@@ -166,4 +265,18 @@ class SuspendParallelFlowTest: AbstractWorkflowTest() {
         anyReport.isSuccess.shouldBeTrue()
         anyReport shouldBeInstanceOf WorkReport.Success::class
     }
+
+    private fun cancellableSlowSuspendWork(
+        slowStarted: CompletableDeferred<Unit>,
+        slowCancelled: AtomicBoolean,
+    ): SuspendWork =
+        SuspendWork("slow-work") { ctx ->
+            slowStarted.complete(Unit)
+            try {
+                delay(10_000.milliseconds)
+                WorkReport.success(ctx)
+            } finally {
+                slowCancelled.set(!currentCoroutineContext().isActive)
+            }
+        }
 }


### PR DESCRIPTION
## Summary

Closes #856

- PR 제목: Fix workflow ALL fail-fast semantics

Fixes #856.

`ParallelPolicy.ALL` now cancels remaining blocking and suspend siblings when any branch throws or returns a non-success `WorkReport` (`Failure`, `Aborted`, or `Cancelled`). The original report is preserved at the workflow boundary.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Convert non-success ALL child reports into an internal fail-fast exception, then unwrap it back to the original `WorkReport`.
- Preserve coroutine cancellation by rethrowing `CancellationException`.
- Align `ParallelPolicy`, workflow KDoc, DSL KDoc, and README EN/KO with all-success fail-fast semantics.
- Add blocking and suspend regression tests for thrown exception plus returned `Failure`, `Aborted`, and `Cancelled`.
- Preserve RED/GREEN evidence and lessons in `docs/review` and `docs/lessons`.

### 기존 섹션: Verification

- RED worktree with tests only: 8 ALL fail-fast cases failed on `origin/develop`.
- `./gradlew :bluetape4k-workflow:test --tests "io.bluetape4k.workflow.core.ParallelWorkFlowTest" --tests "io.bluetape4k.workflow.coroutines.SuspendParallelFlowTest"`: 32 passing.
- `./gradlew --no-daemon --no-build-cache :bluetape4k-workflow:test :bluetape4k-workflow:build`: 206 passing; build successful.
- `git diff --check`: PASS.
- Stale ALL contract grep for old “wait for all tasks” wording: no matches.
- Native review gates: code review APPROVE, test review APPROVE, verifier PASS.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #856, milestone `1.11.0`, assignee `debop`
- PR: #858, head `bc7534dde3cd106ac7dd6edb8369179ed8cf2459`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/workflow-all-fail-fast-856`
- Labels: 없음
- State: `MERGED`, merge commit `0879c9bda463eb71d18545a92994e596c45d6d4c`
- CI: - `./gradlew :bluetape4k-workflow:test --tests "io.bluetape4k.workflow.core.ParallelWorkFlowTest" --tests "io.bluetape4k.workflow.coroutines.SuspendParallelFlowTest"`: 32 passing. / - `./gradlew --no-daemon --no-build-cache :bluetape4k-workflow:test :bluetape4k-workflow:build`: 206 passing; build successful.

## DoD Status

- Issue-first: #856 selected from milestone `1.11.0` and scoped before implementation.
- Worktree: `.worktrees/fix-workflow-all-fail-fast-856`.
- Commit: `bc7534dde`.
- Tests: workflow target and module gates passed.
- Review: P0/P1 blockers resolved; final reviewer verdicts approved.
- Merge: not performed; waiting for owner approval after PR checks.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #858 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `0879c9bda463eb71d18545a92994e596c45d6d4c`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
