### PR TITLE
Fix shapefile CRS handling before PostGIS import

### DIFF
--- a/docs/lessons/2026-06-23-issue-854-shapefile-crs.md
+++ b/docs/lessons/2026-06-23-issue-854-shapefile-crs.md
@@ -1,0 +1,27 @@
+# Issue #854 Shapefile CRS Import
+
+Issue #854 found that `ShapefileImportService` stored every shapefile as WGS84
+without reading `.prj` metadata. Projected inputs such as EPSG:3857 therefore
+kept meter coordinates while the layer metadata claimed SRID 4326.
+
+## Decision
+
+Transform shapefile records to EPSG:4326 during import when `.prj` declares a
+different CRS. Store PostGIS geometry as EWKT with `SRID=4326` and recompute
+layer bbox from transformed geometries.
+
+## Lessons
+
+- Layer metadata and geometry SRID must be proven together. A layer-level
+  `srid=4326` is not enough when `PGgeometry` is created from plain WKT.
+- Dynamic shapefile fixtures are better than checked-in projected fixtures for
+  this case. They keep the test small and verify `.prj` generation, CRS parsing,
+  coordinate transformation, SRID storage, and bbox semantics in one path.
+- Missing `.prj` remains a compatibility assumption: treat the input as WGS84,
+  but document that behavior so callers know the boundary.
+
+## Verification
+
+- `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.repository.SpatialFeatureRepositoryTest.Shapefile import transforms projected CRS to WGS84" --no-build-cache`
+- `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.repository.SpatialFeatureRepositoryTest" --no-build-cache`
+- `./gradlew :bluetape4k-science:test --no-build-cache`

--- a/docs/review/2026-06-23-issue-854-shapefile-crs-review.md
+++ b/docs/review/2026-06-23-issue-854-shapefile-crs-review.md
@@ -1,0 +1,33 @@
+# Issue #854 Shapefile CRS Import Review
+
+## Scope
+
+- `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/ShapefileImportService.kt`
+- `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/repository/SpatialFeatureRepositoryTest.kt`
+- `utils/science/README.md`
+- `utils/science/README.ko.md`
+
+## Verdict
+
+Local 7-tier equivalent review: APPROVE.
+
+P0/P1 findings: 0.
+
+## Review Notes
+
+| Lens | Finding | Severity | Resolution |
+|---|---|---:|---|
+| Correctness | Projected shapefiles now read `.prj`, transform to EPSG:4326, recompute bbox, and write EWKT with SRID 4326. | P0/P1 | Covered by projected EPSG:3857 PostGIS test. |
+| Stability | Missing `.prj` keeps the previous WGS84 assumption instead of introducing a new runtime rejection path. | P2 | Documented in both READMEs. |
+| Security | No new external input execution, credentials, SQL string interpolation, or file deletion paths. | P3 | SQL in test uses prepared statements. |
+| Performance | One transform is created per import, then reused for all records. Per-record geometry transform is required for CRS correctness. | P3 | Acceptable for bugfix scope. |
+| API/user | Public import contract now states CRS behavior and SRID storage. | P2 | README and README.ko updated. |
+| Test evidence | RED failed on `ST_SRID=0`; GREEN passed targeted test, class test, and full `:bluetape4k-science:test`. | P0/P1 | Evidence recorded in PR DoD. |
+
+## Verification
+
+- RED: `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.repository.SpatialFeatureRepositoryTest.Shapefile import transforms projected CRS to WGS84" --no-build-cache` failed with `Expected <0> to equal to <4326>`.
+- GREEN targeted: same command passed with 1 passing test.
+- Regression: `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.repository.SpatialFeatureRepositoryTest" --no-build-cache` passed with 7 tests.
+- Module: `./gradlew :bluetape4k-science:test --no-build-cache` passed with 211 tests.
+- Whitespace: `git diff --check` passed.

--- a/utils/science/README.ko.md
+++ b/utils/science/README.ko.md
@@ -221,6 +221,11 @@ val importedCount = service.importShapefile(
 println("임포트 완료: $importedCount 레코드")
 ```
 
+`ShapefileImportService`는 companion `.prj` 파일이 있으면 CRS 정보를 읽습니다.
+Web Mercator, UTM 같은 projected 입력은 저장 전에 EPSG:4326으로 변환하고,
+PostGIS geometry는 SRID 4326으로 기록합니다. `.prj` 메타데이터가 없는
+Shapefile은 이미 WGS84라고 가정합니다.
+
 ### 5.5 NetCDF 메타데이터 카탈로그
 
 DB 스키마와 저장소가 완성되어 있습니다. `NetCdfFileRepository`로 파일 메타데이터를 직접 등록하세요.

--- a/utils/science/README.md
+++ b/utils/science/README.md
@@ -220,6 +220,11 @@ val importedCount = service.importShapefile(
 println("Imported: $importedCount records")
 ```
 
+`ShapefileImportService` reads the companion `.prj` file when present. Projected
+input such as Web Mercator or UTM is transformed to EPSG:4326 before storage, and
+the stored PostGIS geometry is written with SRID 4326. Shapefiles without `.prj`
+metadata are treated as already WGS84.
+
 ### 5.5 NetCDF Metadata Catalog
 
 The DB schema and repository are ready. Register NetCDF file metadata directly using `NetCdfFileRepository`.

--- a/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/ShapefileImportService.kt
+++ b/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/ShapefileImportService.kt
@@ -2,14 +2,22 @@ package io.bluetape4k.science.exposed.service
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.science.coords.BoundingBox
 import io.bluetape4k.science.exposed.model.SpatialLayerRecord
 import io.bluetape4k.science.exposed.repository.SpatialFeatureRepository
 import io.bluetape4k.science.exposed.repository.SpatialLayerRepository
 import io.bluetape4k.science.exposed.schema.SpatialFeatureTable
+import io.bluetape4k.science.shapefile.ShapeRecord
 import io.bluetape4k.science.shapefile.loadShape
 import net.postgis.jdbc.PGgeometry
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem
+import org.geotools.api.referencing.operation.MathTransform
+import org.geotools.data.shapefile.ShapefileDataStore
+import org.geotools.geometry.jts.JTS
+import org.geotools.referencing.CRS
 import org.jetbrains.exposed.v1.jdbc.batchInsert
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.locationtech.jts.geom.Envelope
 import org.locationtech.jts.io.WKTWriter
 import java.io.File
 
@@ -38,7 +46,10 @@ class ShapefileImportService(
     private val layerRepo: SpatialLayerRepository,
     private val featureRepo: SpatialFeatureRepository,
 ) {
-    companion object: KLogging()
+    companion object: KLogging() {
+        private const val TARGET_SRID = 4326
+        private const val TARGET_CRS_CODE = "EPSG:$TARGET_SRID"
+    }
 
     /**
      * Shapefile을 읽어 DB에 임포트합니다.
@@ -65,24 +76,25 @@ class ShapefileImportService(
      */
     fun importShapefile(file: File, layerName: String, batchSize: Int = 1000): Int {
         val shape = loadShape(file)
+        val records = shape.records.toWgs84Records(file)
+        val bbox = records.toBoundingBox()
 
         // 1. 레이어 메타데이터 insert — Virtual Thread 트랜잭션 (중복 검사 포함)
         val layerRecord = transaction {
             require(layerRepo.findByName(layerName) == null) {
                 "동일한 이름의 레이어가 이미 존재합니다: $layerName"
             }
-            val header = shape.header
             layerRepo.save(
                 SpatialLayerRecord(
                     name = layerName,
                     sourceFile = file.absolutePath,
-                    srid = 4326,
-                    geometryType = shape.records.firstOrNull()?.geometry?.geometryType,
-                    bboxMinX = header.bbox.minLon,
-                    bboxMinY = header.bbox.minLat,
-                    bboxMaxX = header.bbox.maxLon,
-                    bboxMaxY = header.bbox.maxLat,
-                    recordCount = shape.records.size,
+                    srid = TARGET_SRID,
+                    geometryType = records.firstOrNull()?.geometry?.geometryType,
+                    bboxMinX = bbox?.minLon,
+                    bboxMinY = bbox?.minLat,
+                    bboxMaxX = bbox?.maxLon,
+                    bboxMaxY = bbox?.maxLat,
+                    recordCount = records.size,
                 )
             )
         }
@@ -91,13 +103,13 @@ class ShapefileImportService(
         val wktWriter = WKTWriter()
         var totalInserted = 0
 
-        for (batch in shape.records.chunked(batchSize)) {
+        for (batch in records.chunked(batchSize)) {
             if (Thread.currentThread().isInterrupted) break
 
             transaction {
                 SpatialFeatureTable.batchInsert(batch) { record ->
                     val wkt = wktWriter.write(record.geometry)
-                    val pgGeom = PGgeometry(wkt)
+                    val pgGeom = PGgeometry("SRID=$TARGET_SRID;$wkt")
 
                     this[SpatialFeatureTable.layerId] = layerRecord.id
                     this[SpatialFeatureTable.featureType] = record.geometry.geometryType
@@ -107,8 +119,61 @@ class ShapefileImportService(
                 }
             }
             totalInserted += batch.size
-            log.debug { "배치 삽입 완료: $totalInserted / ${shape.records.size}" }
+            log.debug { "배치 삽입 완료: $totalInserted / ${records.size}" }
         }
         return totalInserted
     }
+
+    private fun List<ShapeRecord>.toWgs84Records(file: File): List<ShapeRecord> {
+        val sourceCrs = resolveSourceCrs(file)
+        val targetCrs = CRS.decode(TARGET_CRS_CODE, true)
+        val mathTransform = sourceCrs?.toTargetTransform(targetCrs)
+
+        return map { record ->
+            val geometry = if (mathTransform == null) {
+                record.geometry.copy()
+            } else {
+                JTS.transform(record.geometry, mathTransform)
+            }
+            geometry.setSRID(TARGET_SRID)
+            record.copy(
+                geometry = geometry,
+                bbox = geometry.envelopeInternal.toBoundingBox(),
+            )
+        }
+    }
+
+    private fun resolveSourceCrs(file: File): CoordinateReferenceSystem? {
+        val dataStore = ShapefileDataStore(file.toURI().toURL())
+        return try {
+            dataStore.schema?.coordinateReferenceSystem
+        } finally {
+            dataStore.dispose()
+        }
+    }
+
+    private fun CoordinateReferenceSystem.toTargetTransform(
+        targetCrs: CoordinateReferenceSystem,
+    ): MathTransform? =
+        if (CRS.equalsIgnoreMetadata(this, targetCrs)) {
+            null
+        } else {
+            CRS.findMathTransform(this, targetCrs, true)
+        }
+
+    private fun List<ShapeRecord>.toBoundingBox(): BoundingBox? {
+        if (isEmpty()) return null
+
+        val envelope = Envelope()
+        forEach { envelope.expandToInclude(it.geometry.envelopeInternal) }
+        return envelope.toBoundingBox()
+    }
+
+    private fun Envelope.toBoundingBox(): BoundingBox =
+        BoundingBox(
+            minLat = minY,
+            minLon = minX,
+            maxLat = maxY,
+            maxLon = maxX,
+        )
 }

--- a/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/repository/SpatialFeatureRepositoryTest.kt
+++ b/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/repository/SpatialFeatureRepositoryTest.kt
@@ -8,18 +8,29 @@ import io.bluetape4k.science.exposed.model.SpatialLayerRecord
 import io.bluetape4k.science.exposed.schema.SpatialFeatureTable
 import io.bluetape4k.science.exposed.schema.SpatialLayerTable
 import io.bluetape4k.science.exposed.service.ShapefileImportService
+import io.bluetape4k.science.projection.transform
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeLessThan
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeNull
+import org.geotools.api.data.Transaction as GeoToolsTransaction
+import org.geotools.data.shapefile.ShapefileDataStore
+import org.geotools.data.shapefile.ShapefileDataStoreFactory
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder
+import org.geotools.referencing.CRS
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.Point
 import java.io.File
+import java.io.Serializable
+import java.nio.file.Path
+import kotlin.math.abs
 
 /**
  * [SpatialLayerRepository] 및 [SpatialFeatureRepository] 통합 테스트.
@@ -219,6 +230,80 @@ class SpatialFeatureRepositoryTest: AbstractPostgisTest() {
             // cleanup
             features.forEach { featureRepo.deleteById(it.id) }
             layerRepo.deleteById(layer.id)
+        }
+    }
+
+    @Test
+    fun `Shapefile import transforms projected CRS to WGS84`(@TempDir dir: Path) {
+        val expectedLon = 126.9780
+        val expectedLat = 37.5665
+        val shpFile = createWebMercatorPointShapefile(dir, expectedLon, expectedLat)
+        val importService = ShapefileImportService(layerRepo, featureRepo)
+        val layerName = "web-mercator-import-${System.currentTimeMillis()}"
+
+        val count = importService.importShapefile(shpFile, layerName)
+        count shouldBeEqualTo 1
+
+        transaction(db) {
+            val layer = layerRepo.findByName(layerName)
+            layer.shouldNotBeNull()
+            layer.srid shouldBeEqualTo SRID
+
+            val (srid, lon, lat) = queryStoredPoint(layer.id)
+            srid shouldBeEqualTo SRID
+            abs(lon - expectedLon) shouldBeLessThan 1e-5
+            abs(lat - expectedLat) shouldBeLessThan 1e-5
+            abs((layer.bboxMinX ?: Double.NaN) - expectedLon) shouldBeLessThan 1e-5
+            abs((layer.bboxMinY ?: Double.NaN) - expectedLat) shouldBeLessThan 1e-5
+            abs((layer.bboxMaxX ?: Double.NaN) - expectedLon) shouldBeLessThan 1e-5
+            abs((layer.bboxMaxY ?: Double.NaN) - expectedLat) shouldBeLessThan 1e-5
+
+            val features = featureRepo.findAll { SpatialFeatureTable.layerId eq layer.id }
+            features.forEach { featureRepo.deleteById(it.id) }
+            layerRepo.deleteById(layer.id)
+        }
+    }
+
+    private fun createWebMercatorPointShapefile(dir: Path, lon: Double, lat: Double): File {
+        val shpFile = dir.resolve("web-mercator-point.shp").toFile()
+        val sourceCrs = CRS.decode("EPSG:3857", true)
+        val (x, y) = transform("EPSG:4326", "EPSG:3857", lon, lat)
+
+        val typeBuilder = SimpleFeatureTypeBuilder().apply {
+            setName("web_mercator_points")
+            setCRS(sourceCrs)
+            add("the_geom", Point::class.java)
+            add("NAME", String::class.java)
+        }
+        val featureType = typeBuilder.buildFeatureType()
+        val params = mapOf<String, Serializable>("url" to shpFile.toURI().toURL())
+
+        val dataStore = ShapefileDataStoreFactory().createNewDataStore(params) as ShapefileDataStore
+        try {
+            dataStore.createSchema(featureType)
+            dataStore.forceSchemaCRS(sourceCrs)
+            dataStore.getFeatureWriterAppend(GeoToolsTransaction.AUTO_COMMIT).use { writer ->
+                val feature = writer.next()
+                feature.setAttribute("the_geom", point(x, y))
+                feature.setAttribute("NAME", "Seoul")
+                writer.write()
+            }
+        } finally {
+            dataStore.dispose()
+        }
+        return shpFile
+    }
+
+    private fun queryStoredPoint(layerId: Long): Triple<Int, Double, Double> {
+        val sql = "SELECT ST_SRID(geom), ST_X(geom), ST_Y(geom) FROM spatial_features WHERE layer_id=?"
+        val conn = org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager.current().connection.connection
+            as java.sql.Connection
+        return conn.prepareStatement(sql).use { ps ->
+            ps.setLong(1, layerId)
+            ps.executeQuery().use { rs ->
+                rs.next()
+                Triple(rs.getInt(1), rs.getDouble(2), rs.getDouble(3))
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #854

- PR 제목: Fix shapefile CRS handling before PostGIS import

Closes #854

This PR prevents projected shapefiles from being silently stored as mislabeled WGS84 geometries during PostGIS import.

## Background

Milestone `1.11.0` issue #854 reported that `ShapefileImportService` ignored companion `.prj` metadata, always saved layer metadata as SRID 4326, and wrote plain WKT into PostGIS. Projected shapefiles such as Web Mercator or UTM could therefore store meter coordinates while claiming WGS84.

## What This Solves

- Reads shapefile CRS metadata before import and transforms non-WGS84 records into EPSG:4326.
- Writes imported PostGIS geometry with SRID 4326 instead of plain WKT with SRID 0.
- Recomputes layer bbox metadata from transformed geometries so bbox and stored geometry share the same CRS.
- Documents CRS behavior for English and Korean README users.

## Work Done

- `ShapefileImportService`: resolves source CRS from `.prj`, creates a reusable GeoTools transform when needed, transforms records to EPSG:4326, and stores EWKT with `SRID=4326`.
- `SpatialFeatureRepositoryTest`: adds a dynamic EPSG:3857 shapefile fixture and verifies `ST_SRID`, `ST_X`, `ST_Y`, and bbox semantics after import.
- `utils/science/README.md` and `README.ko.md`: document projected CRS transform behavior and the missing `.prj` WGS84 compatibility assumption.
- `docs/review` and `docs/lessons`: capture review verdict and durable maintenance lessons.

## Validation

- `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.repository.SpatialFeatureRepositoryTest.Shapefile import transforms projected CRS to WGS84" --no-build-cache`: PASS (RED first failed on `ST_SRID=0`; GREEN passed with 1 test)
- `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.repository.SpatialFeatureRepositoryTest" --no-build-cache`: PASS (7 tests)
- `./gradlew :bluetape4k-science:test --no-build-cache`: PASS (211 tests)
- `git diff --check`: PASS
- GitHub Actions CI: PASS (`CI Status`, `Coverage Report`, `Build`, scan/wrapper checks, and dependency submission)

## Review Notes

- P0/P1: 0
- P2/P3: no blocking findings; missing `.prj` compatibility assumption documented
- Review evidence: `docs/review/2026-06-23-issue-854-shapefile-crs-review.md`

## Metadata

- Issue: #854, milestone `1.11.0`, assignee `debop`
- PR: #861, head `114070d7ac148510f125ece20ffd8d2f6d55b987`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/shapefile-crs-854`
- Labels: 없음
- State: `MERGED`, merge commit `30ee7ce80fa6523b2dd452fe44d350331d4732fe`
- CI: - `utils/science/README.md` and `README.ko.md`: document projected CRS transform behavior and the missing `.prj` WGS84 compatibility assumption. / - `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.repository.SpatialFeatureRepositoryTest.Shapefile import transforms projected CRS to WGS84" --no-build-cache`: PASS (RED first failed on `ST_SRID=0`; GREEN passed with 1 test) / - `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.repository.SpatialFeatureRepositoryTest" --no-build-cache`: PASS (7 tests)

## DoD Status

| Step | Status | Evidence |
|------|--------|----------|
| Step 1 - Issue | PASS | #854 open under milestone `1.11.0`; defect scope confirmed from issue body |
| Step 2 - RED | PASS | Targeted test failed before fix with `Expected <0> to equal to <4326>` from `ST_SRID(geom)` |
| Step 3 - Fix | PASS | Commit `114070d7a` transforms projected shapefiles to EPSG:4326 and writes EWKT SRID 4326 |
| Step 4 - Tests | PASS | Targeted projected CRS test, full `SpatialFeatureRepositoryTest`, and `:bluetape4k-science:test` all passed |
| Step 5 - Docs | PASS | `utils/science/README.md`, `utils/science/README.ko.md`, and `docs/lessons/2026-06-23-issue-854-shapefile-crs.md` |
| Step 6 - Review | PASS | Local 7-tier equivalent review in `docs/review/2026-06-23-issue-854-shapefile-crs-review.md`, P0/P1=0 |
| Step 7 - PR | PASS | PR #861 created with `--body-file`; live body re-verified after edit |
| Step 8 - CI | PASS | GitHub Actions run `27998004036` PASS; dependency submission run `27997980830` PASS |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #861 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `30ee7ce80fa6523b2dd452fe44d350331d4732fe`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
