### PR TITLE
Fence NetCDF progress writes by lease owner

### DIFF
--- a/docs/lessons/2026-06-23-issue-853-netcdf-progress-lease-owner.md
+++ b/docs/lessons/2026-06-23-issue-853-netcdf-progress-lease-owner.md
@@ -1,0 +1,35 @@
+# Issue #853 NetCDF Progress Lease Owner
+
+Issue #853 found that `NetCdfImportProgressRepository` used the shared progress
+row id as the only write authority. When an `IN_PROGRESS` lease expired and a
+second importer reacquired the same `(fileId, variableName)` row, the stale
+importer still held the same `progressId` and could renew, complete, or fail the
+row owned by the new importer.
+
+## Decision
+
+Use the current `lease_expires_at` value returned by `acquireLease` as the lease
+owner token. `renewLease`, `markCompleted`, and `markFailed` now require that
+expected token in their `WHERE` clause. A mismatched token produces
+`NetCdfException.ImportLeaseLost` and leaves the current owner row unchanged.
+
+No schema migration is needed because the existing lease expiry timestamp is
+already updated on every acquisition and renewal.
+
+## Lessons
+
+- A reusable progress row id is not a lease ownership proof. Reacquiring an
+  expired row must create a new write token even when the primary key stays the
+  same.
+- Heartbeat renewal must return the next token. Completion and failure paths
+  then prove ownership against the latest lease, not the original acquisition.
+- Stale-owner tests should cover every terminal writer, not just heartbeat
+  renewal. Otherwise a stale importer can still corrupt the row by marking it
+  completed or failed.
+
+## Verification
+
+- RED: `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.23a - stale lease owner cannot renew after expired lease is reacquired" --no-build-cache` failed with `Expected <99> to be <null>`.
+- GREEN targeted: `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.23a - stale lease owner cannot renew after expired lease is reacquired" --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.23b - stale lease owner cannot complete after expired lease is reacquired" --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.23c - stale lease owner cannot fail after expired lease is reacquired" --no-build-cache`
+- Regression: `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest" --no-build-cache`
+- Module: `./gradlew :bluetape4k-science:test --no-build-cache` passed with 214 tests.

--- a/docs/review/2026-06-23-issue-853-netcdf-progress-lease-owner-review.md
+++ b/docs/review/2026-06-23-issue-853-netcdf-progress-lease-owner-review.md
@@ -1,0 +1,34 @@
+# Issue #853 NetCDF Progress Lease Owner Review
+
+## Scope
+
+- `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/NetCdfException.kt`
+- `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/repository/NetCdfImportProgressRepository.kt`
+- `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt`
+- `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/schema/NetCdfTables.kt`
+- `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt`
+
+## Verdict
+
+Local 7-tier equivalent review: APPROVE.
+
+P0/P1 findings: 0.
+
+## Review Notes
+
+| Lens | Finding | Severity | Resolution |
+|---|---|---:|---|
+| Correctness | Reacquired expired leases keep the same row id, so row id alone cannot authorize writes. | P1 | `lease_expires_at` is now an owner token checked by all progress writers. |
+| Stale writer safety | Stale renew, complete, and fail calls previously updated the current owner's row. | P1 | All three calls now throw `ImportLeaseLost` on token mismatch and leave the row unchanged. |
+| Service behavior | Renewing a lease changes the owner token needed by later completion or failure handling. | P1 | `NetCdfCatalogService` carries a mutable lease token through import context and catch paths. |
+| API clarity | Callers need a typed stop signal when lease ownership is lost. | P2 | Added `NetCdfException.ImportLeaseLost`. |
+| Schema impact | Adding a separate owner column would require migration for a narrow bugfix. | P3 | Reused existing timestamp token, avoiding schema churn. |
+| Test evidence | RED captured stale renewal mutating `lastSliceIdx`; GREEN covers renew, complete, fail, and class regressions. | P0/P1 | Evidence recorded below and in PR DoD. |
+
+## Verification
+
+- RED: `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.23a - stale lease owner cannot renew after expired lease is reacquired" --no-build-cache` failed with `Expected <99> to be <null>`.
+- GREEN targeted: same module task with tests `23a`, `23b`, and `23c` passed with 3 tests.
+- Regression: `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest" --no-build-cache` passed with 33 tests.
+- Module: `./gradlew :bluetape4k-science:test --no-build-cache` passed with 214 tests.
+- Whitespace: `git diff --check` passed.

--- a/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/NetCdfException.kt
+++ b/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/NetCdfException.kt
@@ -13,6 +13,7 @@ package io.bluetape4k.science.exposed
  * - [MissingCoordinate] : lat/lon/level 좌표축이 누락되었거나 [ucar.nc2.dataset.CoordinateAxis1D] 가 아닐 때
  * - [UnsupportedProjection] : 좌표 참조계가 화이트리스트(EPSG:4326/3857/3031/3413/UTM 32601~32660·32701~32760) 외이거나 proj4j 변환 실패 시
  * - [ImportAlreadyRunning] : 동일 (fileId, variableName) import 가 이미 lease 를 소유 중일 때
+ * - [ImportLeaseLost] : lease 만료 후 다른 importer 가 같은 progress row 를 재획득했을 때
  *
  * @see io.bluetape4k.science.exposed.service.NetCdfCatalogService
  */
@@ -57,4 +58,10 @@ sealed class NetCdfException(message: String, cause: Throwable? = null): Runtime
      */
     class ImportAlreadyRunning(fileId: Long, variableName: String):
         NetCdfException("Import already running: fileId=$fileId var=$variableName")
+
+    /**
+     * 같은 progress row 를 다른 importer 가 재획득하여 현재 importer 가 더 이상 lease owner 가 아닐 때 발생합니다.
+     */
+    class ImportLeaseLost(progressId: Long):
+        NetCdfException("Import lease lost: progressId=$progressId")
 }

--- a/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/repository/NetCdfImportProgressRepository.kt
+++ b/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/repository/NetCdfImportProgressRepository.kt
@@ -28,9 +28,9 @@ import java.time.Instant
  *   - 기존 row 가 `COMPLETED` 면 그대로 반환 (호출자가 no-op 분기)
  *   - `IN_PROGRESS` 이고 lease 유효 → [NetCdfException.ImportAlreadyRunning] throw
  *   - `PENDING` / `FAILED` / 만료된 `IN_PROGRESS` → lease 획득 후 갱신된 row 반환
- * - [renewLease] : 슬라이스 commit 시 호출, `lastSliceIdx` + `leaseExpiresAt` 갱신
- * - [markCompleted] : 정상 완료, `status=COMPLETED` + `leaseExpiresAt=null` + `completedAt=now()`
- * - [markFailed] : 예외 발생, `status=FAILED` + `leaseExpiresAt=null` + `errorMessage` 기록
+ * - [renewLease] : 슬라이스 commit 시 호출, owner token 검증 후 `lastSliceIdx` + `leaseExpiresAt` 갱신
+ * - [markCompleted] : owner token 검증 후 `status=COMPLETED` + `leaseExpiresAt=null` + `completedAt=now()`
+ * - [markFailed] : owner token 검증 후 `status=FAILED` + `leaseExpiresAt=null` + `errorMessage` 기록
  *
  * @see io.bluetape4k.science.exposed.service.NetCdfCatalogService
  */
@@ -171,17 +171,26 @@ class NetCdfImportProgressRepository {
     }
 
     /**
-     * heartbeat — `lastSliceIdx` 와 `leaseExpiresAt` 을 갱신합니다.
+     * heartbeat — owner token 을 검증하고 `lastSliceIdx` 와 `leaseExpiresAt` 을 갱신합니다.
      *
      * 슬라이스 commit tx 안에서 함께 호출하여 원자성 보장.
+     *
+     * @return 갱신된 lease owner token
+     * @throws NetCdfException.ImportLeaseLost 같은 progress row 를 다른 importer 가 재획득했을 때
      */
-    fun renewLease(progressId: Long, lastSliceIdx: Long, leaseTtl: Duration = DEFAULT_LEASE_TTL) {
+    fun renewLease(
+        progressId: Long,
+        expectedLeaseExpiresAt: Instant,
+        lastSliceIdx: Long,
+        leaseTtl: Duration = DEFAULT_LEASE_TTL,
+    ): Instant {
         val now = Instant.now()
         val newExpires = now.plus(leaseTtl)
         val sql = """
             UPDATE netcdf_import_progress
             SET last_slice_idx = ?, lease_expires_at = ?, updated_at = ?
-            WHERE id = ? AND status = 'IN_PROGRESS'
+            WHERE id = ? AND status = 'IN_PROGRESS' AND lease_expires_at = ?
+            RETURNING lease_expires_at
         """.trimIndent()
         val conn = TransactionManager.current().connection.connection as java.sql.Connection
         conn.prepareStatement(sql).use { stmt ->
@@ -189,49 +198,65 @@ class NetCdfImportProgressRepository {
             stmt.setTimestamp(2, Timestamp.from(newExpires))
             stmt.setTimestamp(3, Timestamp.from(now))
             stmt.setLong(4, progressId)
-            stmt.executeUpdate()
+            stmt.setTimestamp(5, Timestamp.from(expectedLeaseExpiresAt))
+            stmt.executeQuery().use { rs ->
+                if (!rs.next()) {
+                    throw NetCdfException.ImportLeaseLost(progressId)
+                }
+                return rs.getTimestamp("lease_expires_at").toInstant()
+            }
         }
     }
 
     /**
-     * 정상 완료 처리 — `status=COMPLETED`, `completedAt=now()`, `leaseExpiresAt=null`.
+     * 정상 완료 처리 — owner token 을 검증하고 `status=COMPLETED`, `completedAt=now()`, `leaseExpiresAt=null`.
+     *
+     * @throws NetCdfException.ImportLeaseLost 같은 progress row 를 다른 importer 가 재획득했을 때
      */
-    fun markCompleted(progressId: Long) {
+    fun markCompleted(progressId: Long, expectedLeaseExpiresAt: Instant) {
         val now = Instant.now()
         val sql = """
             UPDATE netcdf_import_progress
             SET status = 'COMPLETED', completed_at = ?, lease_expires_at = NULL,
                 error_message = NULL, updated_at = ?
-            WHERE id = ?
+            WHERE id = ? AND status = 'IN_PROGRESS' AND lease_expires_at = ?
         """.trimIndent()
         val conn = TransactionManager.current().connection.connection as java.sql.Connection
         conn.prepareStatement(sql).use { stmt ->
             stmt.setTimestamp(1, Timestamp.from(now))
             stmt.setTimestamp(2, Timestamp.from(now))
             stmt.setLong(3, progressId)
-            stmt.executeUpdate()
+            stmt.setTimestamp(4, Timestamp.from(expectedLeaseExpiresAt))
+            if (stmt.executeUpdate() != 1) {
+                throw NetCdfException.ImportLeaseLost(progressId)
+            }
         }
         log.info { "import marked COMPLETED — progressId=$progressId" }
     }
 
     /**
-     * 실패 처리 — `status=FAILED`, `errorMessage` 기록, `leaseExpiresAt=null`.
+     * 실패 처리 — owner token 을 검증하고 `status=FAILED`, `errorMessage` 기록, `leaseExpiresAt=null`.
      *
      * `lastSliceIdx` 는 그대로 유지하여 재호출 시 그 다음부터 재개 가능.
+     *
+     * @throws NetCdfException.ImportLeaseLost 같은 progress row 를 다른 importer 가 재획득했을 때
      */
-    fun markFailed(progressId: Long, errorMessage: String) {
+    fun markFailed(progressId: Long, expectedLeaseExpiresAt: Instant, errorMessage: String) {
         val now = Instant.now()
         val sql = """
             UPDATE netcdf_import_progress
             SET status = 'FAILED', error_message = ?, lease_expires_at = NULL, updated_at = ?
-            WHERE id = ?
+            WHERE id = ? AND status = 'IN_PROGRESS' AND lease_expires_at = ?
         """.trimIndent()
         val conn = TransactionManager.current().connection.connection as java.sql.Connection
         conn.prepareStatement(sql).use { stmt ->
             stmt.setString(1, errorMessage.take(MAX_ERROR_MESSAGE_LENGTH))
             stmt.setTimestamp(2, Timestamp.from(now))
             stmt.setLong(3, progressId)
-            stmt.executeUpdate()
+            stmt.setTimestamp(4, Timestamp.from(expectedLeaseExpiresAt))
+            if (stmt.executeUpdate() != 1) {
+                throw NetCdfException.ImportLeaseLost(progressId)
+            }
         }
         log.warn { "import marked FAILED — progressId=$progressId msg=${errorMessage.take(200)}" }
     }

--- a/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/schema/NetCdfTables.kt
+++ b/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/schema/NetCdfTables.kt
@@ -170,9 +170,9 @@ object NetCdfGridValueIndexes {
  * SchemaUtils.create(NetCdfImportProgressTable)
  *
  * // 진입 시 lease 획득 — Repository.acquireLease() 사용 (raw SQL ON CONFLICT DO UPDATE)
- * // 슬라이스 commit 후 renewLease(progressId, lastSliceIdx, newExpiresAt)
- * // 완료 시 markCompleted(progressId)
- * // 실패 시 markFailed(progressId, errorMessage)
+ * // 슬라이스 commit 후 renewLease(progressId, expectedLeaseExpiresAt, lastSliceIdx)
+ * // 완료 시 markCompleted(progressId, expectedLeaseExpiresAt)
+ * // 실패 시 markFailed(progressId, expectedLeaseExpiresAt, errorMessage)
  * ```
  */
 object NetCdfImportProgressTable: LongIdTable("netcdf_import_progress") {

--- a/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt
+++ b/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt
@@ -160,6 +160,7 @@ class NetCdfCatalogService(
      * @throws NetCdfException.MissingCoordinate lat/lon/level 좌표축이 없거나 1D 가 아닐 때
      * @throws NetCdfException.UnsupportedProjection 화이트리스트 외 CRS 일 때
      * @throws NetCdfException.ImportAlreadyRunning 다른 프로세스가 활성 lease 보유 중일 때
+     * @throws NetCdfException.ImportLeaseLost lease 만료 후 다른 프로세스가 같은 progress row 를 재획득했을 때
      */
     fun importGridValues(fileId: Long, variableName: String) {
         require(variableName.isNotBlank()) { "variableName must not be blank" }
@@ -178,10 +179,16 @@ class NetCdfCatalogService(
             meterRegistry?.counter("netcdf.import.status", "status", "resumed")?.increment()
             log.info { "resuming import — fileId=$fileId var=$variableName startSliceIdx=$startSliceIdx" }
         }
+        val initialLeaseToken = checkNotNull(progress.leaseExpiresAt) {
+            "IN_PROGRESS import progress must have leaseExpiresAt"
+        }
+        val lease = ImportLease(initialLeaseToken)
 
         val dataset = runCatching { NetcdfDatasets.openDataset(record.filePath) }
             .getOrElse {
-                transaction { progressRepo.markFailed(progress.id, it.message.orEmpty()) }
+                transaction {
+                    progressRepo.markFailed(progress.id, lease.expiresAt, it.message.orEmpty())
+                }
                 meterRegistry?.counter("netcdf.import.status", "status", "failure")?.increment()
                 throw NetCdfException.FileOpen(record.filePath, it)
             }
@@ -200,6 +207,7 @@ class NetCdfCatalogService(
                     fileId = fileId,
                     variableName = variableName,
                     progressId = progress.id,
+                    lease = lease,
                     variable = v,
                     axisMap = axisMap,
                     fillValue = v.findAttribute("_FillValue")?.numericValue?.toDouble(),
@@ -212,15 +220,18 @@ class NetCdfCatalogService(
                     4 -> importRank4(ctx, ncd, startSliceIdx)
                 }
 
-                transaction { progressRepo.markCompleted(progress.id) }
+                transaction { progressRepo.markCompleted(ctx.progressId, ctx.lease.expiresAt) }
                 meterRegistry?.counter("netcdf.import.status", "status", "success")?.increment()
                 log.info { "import COMPLETED — fileId=$fileId var=$variableName" }
             }
         } catch (e: NetCdfException.ImportAlreadyRunning) {
             // 다른 프로세스 소유 — progress 변경 없음, failure counter 미증가 (M4)
             throw e
+        } catch (e: NetCdfException.ImportLeaseLost) {
+            // lease 만료 후 다른 프로세스가 재획득 — stale importer 는 progress 를 변경하지 않음.
+            throw e
         } catch (e: Exception) {
-            transaction { progressRepo.markFailed(progress.id, e.message.orEmpty()) }
+            transaction { progressRepo.markFailed(progress.id, lease.expiresAt, e.message.orEmpty()) }
             meterRegistry?.counter("netcdf.import.status", "status", "failure")?.increment()
             throw e
         }
@@ -265,7 +276,12 @@ class NetCdfCatalogService(
                 }
                 ps.executeBatch()
             }
-            progressRepo.renewLease(ctx.progressId, lastSliceIdx = 0L, leaseTtl = LEASE_TTL)
+            ctx.lease.expiresAt = progressRepo.renewLease(
+                progressId = ctx.progressId,
+                expectedLeaseExpiresAt = ctx.lease.expiresAt,
+                lastSliceIdx = 0L,
+                leaseTtl = LEASE_TTL,
+            )
         }
         meterRegistry?.counter("netcdf.import.variable.records", "variable", ctx.variableName)
             ?.increment(inserted.toDouble())
@@ -460,7 +476,12 @@ class NetCdfCatalogService(
                 ps.executeBatch()
             }
             if (renewProgress) {
-                progressRepo.renewLease(ctx.progressId, lastSliceIdx = sliceIdx, leaseTtl = LEASE_TTL)
+                ctx.lease.expiresAt = progressRepo.renewLease(
+                    progressId = ctx.progressId,
+                    expectedLeaseExpiresAt = ctx.lease.expiresAt,
+                    lastSliceIdx = sliceIdx,
+                    leaseTtl = LEASE_TTL,
+                )
             }
         }
 
@@ -507,8 +528,13 @@ class NetCdfCatalogService(
         val fileId: Long,
         val variableName: String,
         val progressId: Long,
+        val lease: ImportLease,
         val variable: Variable,
         val axisMap: VariableAxisMap,
         val fillValue: Double?,
+    )
+
+    private data class ImportLease(
+        var expiresAt: Instant,
     )
 }

--- a/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt
+++ b/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
 import io.bluetape4k.science.exposed.AbstractPostgisTest
 import io.bluetape4k.science.exposed.NetCdfException
+import io.bluetape4k.science.exposed.model.NetCdfImportStatus
 import io.bluetape4k.science.exposed.repository.NetCdfFileRepository
 import io.bluetape4k.science.exposed.repository.NetCdfImportProgressRepository
 import io.bluetape4k.science.exposed.schema.NetCdfFileTable
@@ -400,18 +401,84 @@ class NetCdfCatalogServiceTest: AbstractPostgisTest() {
 
         transaction(db) { progressRepo.acquireLease(fileId, "temperature") }
         // raw SQL 로 lease 강제 만료 (Codex Plan v2.1 Medium#1 — Thread.sleep 금지)
-        transaction(db) {
-            val sql = "UPDATE netcdf_import_progress SET lease_expires_at = now() - interval '10 min' " +
-                "WHERE file_id = ? AND variable_name = 'temperature'"
-            val conn = connection.connection as java.sql.Connection
-            conn.prepareStatement(sql).use { ps ->
-                ps.setLong(1, fileId)
-                ps.executeUpdate()
-            }
-        }
+        forceExpireLease(fileId, "temperature")
         // 만료된 lease 재획득 가능
         val reacquired = transaction(db) { progressRepo.acquireLease(fileId, "temperature") }
         reacquired.shouldNotBeNull()
+    }
+
+    @Test
+    fun `23a - stale lease owner cannot renew after expired lease is reacquired`(@TempDir dir: Path) {
+        val path = NetCdfSampleWriter.writeSample(dir.resolve("stale-renew.nc"), rank = 2)
+        val fileId = service.registerFile(path.absolutePathString())
+        val staleProgress = transaction(db) { progressRepo.acquireLease(fileId, "temperature") }
+        forceExpireLease(fileId, "temperature")
+        val currentProgress = transaction(db) { progressRepo.acquireLease(fileId, "temperature") }
+
+        assertFailsWith<NetCdfException.ImportLeaseLost> {
+            transaction(db) {
+                progressRepo.renewLease(
+                    progressId = staleProgress.id,
+                    expectedLeaseExpiresAt = checkNotNull(staleProgress.leaseExpiresAt),
+                    lastSliceIdx = 99L,
+                )
+            }
+        }
+
+        val progress = transaction(db) { progressRepo.findByFileAndVariable(fileId, "temperature") }
+        progress.shouldNotBeNull()
+        progress.status shouldBeEqualTo NetCdfImportStatus.IN_PROGRESS
+        progress.lastSliceIdx.shouldBeNull()
+        progress.leaseExpiresAt shouldBeEqualTo currentProgress.leaseExpiresAt
+    }
+
+    @Test
+    fun `23b - stale lease owner cannot complete after expired lease is reacquired`(@TempDir dir: Path) {
+        val path = NetCdfSampleWriter.writeSample(dir.resolve("stale-complete.nc"), rank = 2)
+        val fileId = service.registerFile(path.absolutePathString())
+        val staleProgress = transaction(db) { progressRepo.acquireLease(fileId, "temperature") }
+        forceExpireLease(fileId, "temperature")
+        val currentProgress = transaction(db) { progressRepo.acquireLease(fileId, "temperature") }
+
+        assertFailsWith<NetCdfException.ImportLeaseLost> {
+            transaction(db) {
+                progressRepo.markCompleted(
+                    progressId = staleProgress.id,
+                    expectedLeaseExpiresAt = checkNotNull(staleProgress.leaseExpiresAt),
+                )
+            }
+        }
+
+        val progress = transaction(db) { progressRepo.findByFileAndVariable(fileId, "temperature") }
+        progress.shouldNotBeNull()
+        progress.status shouldBeEqualTo NetCdfImportStatus.IN_PROGRESS
+        progress.completedAt.shouldBeNull()
+        progress.leaseExpiresAt shouldBeEqualTo currentProgress.leaseExpiresAt
+    }
+
+    @Test
+    fun `23c - stale lease owner cannot fail after expired lease is reacquired`(@TempDir dir: Path) {
+        val path = NetCdfSampleWriter.writeSample(dir.resolve("stale-fail.nc"), rank = 2)
+        val fileId = service.registerFile(path.absolutePathString())
+        val staleProgress = transaction(db) { progressRepo.acquireLease(fileId, "temperature") }
+        forceExpireLease(fileId, "temperature")
+        val currentProgress = transaction(db) { progressRepo.acquireLease(fileId, "temperature") }
+
+        assertFailsWith<NetCdfException.ImportLeaseLost> {
+            transaction(db) {
+                progressRepo.markFailed(
+                    progressId = staleProgress.id,
+                    expectedLeaseExpiresAt = checkNotNull(staleProgress.leaseExpiresAt),
+                    errorMessage = "stale failure",
+                )
+            }
+        }
+
+        val progress = transaction(db) { progressRepo.findByFileAndVariable(fileId, "temperature") }
+        progress.shouldNotBeNull()
+        progress.status shouldBeEqualTo NetCdfImportStatus.IN_PROGRESS
+        progress.errorMessage.shouldBeNull()
+        progress.leaseExpiresAt shouldBeEqualTo currentProgress.leaseExpiresAt
     }
 
     // -------------------------------------------------------------------------
@@ -560,5 +627,18 @@ class NetCdfCatalogServiceTest: AbstractPostgisTest() {
         service.importGridValues(fileId, "temperature")
         val progress = transaction(db) { progressRepo.findByFileAndVariable(fileId, "temperature") }
         progress.shouldNotBeNull()
+    }
+
+    private fun forceExpireLease(fileId: Long, variableName: String) {
+        transaction(db) {
+            val sql = "UPDATE netcdf_import_progress SET lease_expires_at = now() - interval '10 min' " +
+                "WHERE file_id = ? AND variable_name = ?"
+            val conn = connection.connection as java.sql.Connection
+            conn.prepareStatement(sql).use { ps ->
+                ps.setLong(1, fileId)
+                ps.setString(2, variableName)
+                ps.executeUpdate()
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #853

- PR 제목: Fence NetCDF progress writes by lease owner

- Closes #853.
- Gates NetCDF progress renew, complete, and fail writes with the current `lease_expires_at` owner token instead of progress id alone.
- Adds `NetCdfException.ImportLeaseLost` for stale importers after an expired lease is reacquired.
- Carries the latest lease token through `NetCdfCatalogService` so heartbeat renewal, completion, and failure paths prove the same ownership contract.
- Adds regression tests and local review/lesson notes for the stale renew, complete, and fail cases.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

- Closes #853.
- Gates NetCDF progress renew, complete, and fail writes with the current `lease_expires_at` owner token instead of progress id alone.
- Adds `NetCdfException.ImportLeaseLost` for stale importers after an expired lease is reacquired.
- Carries the latest lease token through `NetCdfCatalogService` so heartbeat renewal, completion, and failure paths prove the same ownership contract.
- Adds regression tests and local review/lesson notes for the stale renew, complete, and fail cases.

### Review Notes

- No schema migration: the existing `lease_expires_at` value changes on acquire/renew and is sufficient as the ownership token for this bugfix.
- Stale writers now fail explicitly and leave the current owner's row unchanged.
- Root `detekt` currently completes as `NO-SOURCE`; there is no `:bluetape4k-science:detekt` task in this build.

### DoD Status

- [x] Issue-first workflow: #853 selected from milestone `1.11.0` and implemented on branch `fix/netcdf-progress-lease-owner-853`.
- [x] RED evidence: targeted stale-renew test failed before implementation with `Expected <99> to be <null>`.
- [x] Targeted regression: `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.23a - stale lease owner cannot renew after expired lease is reacquired" --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.23b - stale lease owner cannot complete after expired lease is reacquired" --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.23c - stale lease owner cannot fail after expired lease is reacquired" --no-build-cache` passed with 3 tests.
- [x] Class regression: `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest" --no-build-cache` passed with 33 tests.
- [x] Module regression: `./gradlew :bluetape4k-science:test --no-build-cache` passed with 214 tests.
- [x] Diff hygiene: `git diff --check` passed.
- [x] Static check attempted: `./gradlew detekt` completed successfully as `NO-SOURCE`; `:bluetape4k-science:detekt` is not registered.
- [x] Documentation: added `docs/lessons/2026-06-23-issue-853-netcdf-progress-lease-owner.md` and `docs/review/2026-06-23-issue-853-netcdf-progress-lease-owner-review.md`.
- [x] GitHub Actions: PR #862 checks passed: Build, CI Status, Coverage Report, Detect changed modules, Secret Scan, Validate Gradle Wrapper, and submit-gradle.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- No schema migration: the existing `lease_expires_at` value changes on acquire/renew and is sufficient as the ownership token for this bugfix.
- Stale writers now fail explicitly and leave the current owner's row unchanged.
- Root `detekt` currently completes as `NO-SOURCE`; there is no `:bluetape4k-science:detekt` task in this build.

## Metadata

- Issue: #853, milestone `1.11.0`, assignee `debop`
- PR: #862, head `bb409ca0a45f862053c29cf08470132daaf63624`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/netcdf-progress-lease-owner-853`
- Labels: 없음
- State: `MERGED`, merge commit `fe12629a748bd11dc933c7a5d626bfe5e88c6586`
- CI: - No schema migration: the existing `lease_expires_at` value changes on acquire/renew and is sufficient as the ownership token for this bugfix. / - Stale writers now fail explicitly and leave the current owner's row unchanged. / - Root `detekt` currently completes as `NO-SOURCE`; there is no `:bluetape4k-science:detekt` task in this build.

## DoD Status

- [x] Issue-first workflow: #853 selected from milestone `1.11.0` and implemented on branch `fix/netcdf-progress-lease-owner-853`.
- [x] RED evidence: targeted stale-renew test failed before implementation with `Expected <99> to be <null>`.
- [x] Targeted regression: `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.23a - stale lease owner cannot renew after expired lease is reacquired" --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.23b - stale lease owner cannot complete after expired lease is reacquired" --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.23c - stale lease owner cannot fail after expired lease is reacquired" --no-build-cache` passed with 3 tests.
- [x] Class regression: `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest" --no-build-cache` passed with 33 tests.
- [x] Module regression: `./gradlew :bluetape4k-science:test --no-build-cache` passed with 214 tests.
- [x] Diff hygiene: `git diff --check` passed.
- [x] Static check attempted: `./gradlew detekt` completed successfully as `NO-SOURCE`; `:bluetape4k-science:detekt` is not registered.
- [x] Documentation: added `docs/lessons/2026-06-23-issue-853-netcdf-progress-lease-owner.md` and `docs/review/2026-06-23-issue-853-netcdf-progress-lease-owner-review.md`.
- [x] GitHub Actions: PR #862 checks passed: Build, CI Status, Coverage Report, Detect changed modules, Secret Scan, Validate Gradle Wrapper, and submit-gradle.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #862 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `fe12629a748bd11dc933c7a5d626bfe5e88c6586`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
