### PR TITLE
Make coroutine-to-Uni bridge subscription-driven

### DIFF
--- a/docs/lessons/2026-06-23-issue-851-mutiny-asuni-cold.md
+++ b/docs/lessons/2026-06-23-issue-851-mutiny-asuni-cold.md
@@ -1,0 +1,30 @@
+# Issue #851 Mutiny Coroutine `asUni` Cold Contract
+
+Issue #851 found that `CoroutineScope.asUni { ... }` created a `Deferred`
+immediately and then converted it to a `Uni`. That made the suspend block hot:
+creating the `Uni` was enough to start side effects even when no subscriber
+existed.
+
+## Decision
+
+Create the coroutine inside `Uni.createFrom().emitter { ... }`, because Mutiny
+invokes the emitter consumer on subscription. The bridge now creates a fresh
+`Deferred` per subscriber, forwards completion/failure from `invokeOnCompletion`,
+and cancels the `Deferred` when the Uni subscription terminates before the
+coroutine completes.
+
+## Lessons
+
+- Reactive bridge helpers must match reactive demand semantics. A `Uni` factory
+  that starts work before subscription is a side-effect leak.
+- `Deferred.asUni()` has useful result and cancellation forwarding, but it is
+  only cold if the `Deferred` itself is created at subscription time.
+- Cancellation tests should prove both directions: cancelling the subscription
+  cancels the coroutine, and coroutine cancellation/failure reaches the Uni.
+
+## Verification
+
+- RED: `./gradlew :bluetape4k-mutiny:test --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni does not start suspend block before subscription" --no-build-cache` failed with `Expected <1> to equal to <0>`.
+- GREEN targeted: `./gradlew :bluetape4k-mutiny:test --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni does not start suspend block before subscription" --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni cancellation cancels running coroutine" --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni propagates failure and cancellation exceptions" --no-build-cache`
+- Module: `./gradlew :bluetape4k-mutiny:compileKotlin :bluetape4k-mutiny:compileTestKotlin :bluetape4k-mutiny:test --no-build-cache` passed with 29 tests.
+- Build: `./gradlew :bluetape4k-mutiny:build --no-build-cache` passed.

--- a/docs/review/2026-06-23-issue-851-mutiny-asuni-cold-review.md
+++ b/docs/review/2026-06-23-issue-851-mutiny-asuni-cold-review.md
@@ -1,0 +1,31 @@
+# Issue #851 Mutiny Coroutine `asUni` Cold Review
+
+## Scope
+
+- `utils/mutiny/src/main/kotlin/io/bluetape4k/mutiny/CoroutineSupport.kt`
+- `utils/mutiny/src/test/kotlin/io/bluetape4k/mutiny/CoroutineSupportTest.kt`
+- `utils/mutiny/README.md`
+- `utils/mutiny/README.ko.md`
+
+## Verdict
+
+Local 7-tier equivalent review: APPROVE.
+
+P0/P1 findings: 0.
+
+## Review Notes
+
+| Lens | Finding | Severity | Resolution |
+|---|---|---:|---|
+| Correctness | `async { ... }.asUni()` started work when the Uni was created, not subscribed. | P1 | Deferred creation now happens inside `Uni.createFrom().emitter`, which Mutiny runs at subscription time. |
+| Cancellation | Subscriber cancellation must stop the coroutine job. | P1 | `emitter.onTermination` cancels the active `Deferred`. |
+| Failure semantics | Coroutine exceptions and cancellation must reach Mutiny subscribers. | P1 | `invokeOnCompletion` forwards item, failure, and cancellation to the emitter. |
+| API documentation | Callers need to know whether `asUni` is cold or hot. | P2 | KDoc and EN/KO README now state that `asUni` is cold and subscription-cancellable. |
+| Test evidence | Existing tests only proved eventual completion. | P1 | Added cold-start, subscription-cancel, and failure/cancellation propagation regressions. |
+
+## Verification
+
+- RED: `./gradlew :bluetape4k-mutiny:test --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni does not start suspend block before subscription" --no-build-cache` failed with `Expected <1> to equal to <0>`.
+- GREEN targeted: same module task with cold-start, cancellation, and failure/cancellation tests passed with 3 tests.
+- Module: `./gradlew :bluetape4k-mutiny:compileKotlin :bluetape4k-mutiny:compileTestKotlin :bluetape4k-mutiny:test --no-build-cache` passed with 29 tests.
+- Build: `./gradlew :bluetape4k-mutiny:build --no-build-cache` passed.

--- a/utils/mutiny/README.ko.md
+++ b/utils/mutiny/README.ko.md
@@ -152,6 +152,9 @@ val uni = scope.fetchData()
 val result = uni.await().indefinitely()
 ```
 
+`asUni`는 cold입니다. 반환된 `Uni`를 구독할 때만 코루틴을 시작하며, 구독을 취소하면 실행 중인
+코루틴도 취소됩니다.
+
 ### Uni와 Multi 변환
 
 ```kotlin

--- a/utils/mutiny/README.md
+++ b/utils/mutiny/README.md
@@ -153,6 +153,9 @@ val uni = scope.fetchData()
 val result = uni.await().indefinitely()
 ```
 
+`asUni` is cold: it starts the coroutine only when the returned `Uni` is subscribed, and cancelling
+the subscription cancels the running coroutine.
+
 ### Convert Between `Uni` and `Multi`
 
 ```kotlin

--- a/utils/mutiny/src/main/kotlin/io/bluetape4k/mutiny/CoroutineSupport.kt
+++ b/utils/mutiny/src/main/kotlin/io/bluetape4k/mutiny/CoroutineSupport.kt
@@ -1,17 +1,19 @@
 package io.bluetape4k.mutiny
 
 import io.smallrye.mutiny.Uni
-import io.smallrye.mutiny.coroutines.asUni
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 
 /**
  * 코루틴 스코프에서 `suspend` 블록을 실행하고 결과를 [Uni]로 감쌉니다.
  *
  * ## 동작/계약
- * - 내부적으로 `async { ... }.asUni()`를 사용하므로 블록은 현재 [CoroutineScope] 컨텍스트에서 비동기 실행됩니다.
+ * - 반환된 [Uni]를 구독할 때 현재 [CoroutineScope] 컨텍스트에서 코루틴 실행을 시작합니다.
+ * - 구독이 취소되면 실행 중인 코루틴도 취소됩니다.
  * - 수신 스코프를 변경하지 않으며 새 [Uni] 인스턴스를 반환합니다.
- * - 블록에서 예외가 발생하면 실패한 `Uni`로 전파됩니다.
+ * - 블록에서 예외 또는 cancellation 이 발생하면 실패한 `Uni`로 전파됩니다.
  *
  * ```kotlin
  * val scope = CoroutineScope(Dispatchers.Default)
@@ -20,10 +22,27 @@ import kotlinx.coroutines.async
  * // result == 42L
  * ```
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 inline fun <T> CoroutineScope.asUni(
     crossinline block: suspend CoroutineScope.() -> T,
 ): Uni<T> {
-    return async {
-        block(this@asUni)
-    }.asUni()
+    return Uni.createFrom().emitter { emitter ->
+        val deferred = async {
+            block(this@asUni)
+        }
+
+        deferred.invokeOnCompletion { cause ->
+            if (cause == null) {
+                emitter.complete(deferred.getCompleted())
+            } else {
+                emitter.fail(cause)
+            }
+        }
+
+        emitter.onTermination {
+            if (deferred.isActive) {
+                deferred.cancel()
+            }
+        }
+    }
 }

--- a/utils/mutiny/src/test/kotlin/io/bluetape4k/mutiny/CoroutineSupportTest.kt
+++ b/utils/mutiny/src/test/kotlin/io/bluetape4k/mutiny/CoroutineSupportTest.kt
@@ -2,14 +2,21 @@ package io.bluetape4k.mutiny
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
-import io.bluetape4k.assertions.shouldBeEqualTo
+import java.util.concurrent.CancellationException
+import java.util.concurrent.atomic.AtomicInteger
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -41,5 +48,65 @@ class CoroutineSupportTest {
         u1.awaitSuspending() shouldBeEqualTo expected1
         u2.awaitSuspending() shouldBeEqualTo expected2
         log.debug { "Done" }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `asUni does not start suspend block before subscription`() = runTest {
+        val executions = AtomicInteger()
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+
+        val uni = scope.asUni {
+            executions.incrementAndGet()
+            42L
+        }
+
+        executions.get() shouldBeEqualTo 0
+        uni.awaitSuspending() shouldBeEqualTo 42L
+        executions.get() shouldBeEqualTo 1
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `asUni cancellation cancels running coroutine`() = runTest {
+        val started = CompletableDeferred<Unit>()
+        val cancelled = CompletableDeferred<Unit>()
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+
+        val cancellable = scope.asUni {
+            started.complete(Unit)
+            try {
+                awaitCancellation()
+            } finally {
+                cancelled.complete(Unit)
+            }
+        }.subscribe().with(
+            { error("Unexpected item: $it") },
+            { error("Unexpected failure: $it") },
+        )
+
+        started.await()
+        cancellable.cancel()
+
+        cancelled.await()
+        cancelled.isCompleted shouldBeEqualTo true
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `asUni propagates failure and cancellation exceptions`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+
+        assertFailsWith<IllegalStateException> {
+            scope.asUni<Long> {
+                throw IllegalStateException("boom")
+            }.awaitSuspending()
+        }
+
+        assertFailsWith<CancellationException> {
+            scope.asUni<Long> {
+                throw CancellationException("cancelled")
+            }.awaitSuspending()
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #851

- PR 제목: Make coroutine-to-Uni bridge subscription-driven

- Closes #851.
- Makes `CoroutineScope.asUni { ... }` cold by creating the coroutine `Deferred` inside Mutiny's subscription-time emitter.
- Wires `Deferred.invokeOnCompletion` to emit item, failure, and cancellation to the `Uni` subscriber.
- Cancels the running coroutine when the Uni subscription terminates before coroutine completion.
- Documents the cold/subscription-cancellable contract in KDoc and EN/KO README files.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

- Closes #851.
- Makes `CoroutineScope.asUni { ... }` cold by creating the coroutine `Deferred` inside Mutiny's subscription-time emitter.
- Wires `Deferred.invokeOnCompletion` to emit item, failure, and cancellation to the `Uni` subscriber.
- Cancels the running coroutine when the Uni subscription terminates before coroutine completion.
- Documents the cold/subscription-cancellable contract in KDoc and EN/KO README files.

### Review Notes

- Mutiny 3.2.0 documentation/source confirms `Uni.createFrom().emitter` and `deferred` creation are subscription-time surfaces; the implementation uses emitter so cancellation can be wired through `onTermination`.
- `Deferred.asUni()` remains useful for result forwarding, but creating the `Deferred` before subscription was the bug. The new implementation creates a fresh `Deferred` per subscriber.
- Root `detekt` currently completes as `NO-SOURCE`.

### DoD Status

- [x] Issue-first workflow: #851 selected from milestone `1.11.0` and implemented on branch `fix/coroutine-uni-subscription-851`.
- [x] RED evidence: `./gradlew :bluetape4k-mutiny:test --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni does not start suspend block before subscription" --no-build-cache` failed before implementation with `Expected <1> to equal to <0>`.
- [x] Targeted regression: `./gradlew :bluetape4k-mutiny:test --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni does not start suspend block before subscription" --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni cancellation cancels running coroutine" --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni propagates failure and cancellation exceptions" --no-build-cache` passed with 3 tests.
- [x] Module regression: `./gradlew :bluetape4k-mutiny:compileKotlin :bluetape4k-mutiny:compileTestKotlin :bluetape4k-mutiny:test --no-build-cache` passed with 29 tests.
- [x] Module build: `./gradlew :bluetape4k-mutiny:build --no-build-cache` passed.
- [x] Diff hygiene: `git diff --check` passed.
- [x] Static check attempted: `./gradlew detekt` completed successfully as `NO-SOURCE`.
- [x] Documentation: added `docs/lessons/2026-06-23-issue-851-mutiny-asuni-cold.md` and `docs/review/2026-06-23-issue-851-mutiny-asuni-cold-review.md`; updated `utils/mutiny/README.md` and `README.ko.md`.
- [x] GitHub Actions: PR #863 checks passed: Build, CI Status, Coverage Report, Detect changed modules, Secret Scan, Validate Gradle Wrapper, and submit-gradle.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- Mutiny 3.2.0 documentation/source confirms `Uni.createFrom().emitter` and `deferred` creation are subscription-time surfaces; the implementation uses emitter so cancellation can be wired through `onTermination`.
- `Deferred.asUni()` remains useful for result forwarding, but creating the `Deferred` before subscription was the bug. The new implementation creates a fresh `Deferred` per subscriber.
- Root `detekt` currently completes as `NO-SOURCE`.

## Metadata

- Issue: #851, milestone `1.11.0`, assignee `debop`
- PR: #863, head `db85bfdaba97fa98d94fc25445ea91fb63f58ce6`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/coroutine-uni-subscription-851`
- Labels: 없음
- State: `MERGED`, merge commit `d03355210a7edb389351bd1a568e8e7dd8acf145`
- CI: - Root `detekt` currently completes as `NO-SOURCE`. / - [x] RED evidence: `./gradlew :bluetape4k-mutiny:test --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni does not start suspend block before subscription" --no-build-cache` failed before implementation with `Expected <1> to equal to <0>`. / - [x] Targeted regression: `./gradlew :bluetape4k-mutiny:test --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni does not start suspend block before subscription" --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni cancellation cancels running coroutine" --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni propagates failure and cancellation exceptions" --no-build-cache` passed with 3 tests.

## DoD Status

- [x] Issue-first workflow: #851 selected from milestone `1.11.0` and implemented on branch `fix/coroutine-uni-subscription-851`.
- [x] RED evidence: `./gradlew :bluetape4k-mutiny:test --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni does not start suspend block before subscription" --no-build-cache` failed before implementation with `Expected <1> to equal to <0>`.
- [x] Targeted regression: `./gradlew :bluetape4k-mutiny:test --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni does not start suspend block before subscription" --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni cancellation cancels running coroutine" --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni propagates failure and cancellation exceptions" --no-build-cache` passed with 3 tests.
- [x] Module regression: `./gradlew :bluetape4k-mutiny:compileKotlin :bluetape4k-mutiny:compileTestKotlin :bluetape4k-mutiny:test --no-build-cache` passed with 29 tests.
- [x] Module build: `./gradlew :bluetape4k-mutiny:build --no-build-cache` passed.
- [x] Diff hygiene: `git diff --check` passed.
- [x] Static check attempted: `./gradlew detekt` completed successfully as `NO-SOURCE`.
- [x] Documentation: added `docs/lessons/2026-06-23-issue-851-mutiny-asuni-cold.md` and `docs/review/2026-06-23-issue-851-mutiny-asuni-cold-review.md`; updated `utils/mutiny/README.md` and `README.ko.md`.
- [x] GitHub Actions: PR #863 checks passed: Build, CI Status, Coverage Report, Detect changed modules, Secret Scan, Validate Gradle Wrapper, and submit-gradle.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #863 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `d03355210a7edb389351bd1a568e8e7dd8acf145`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
