### PR TITLE
Reject non-progressing histogram bin sizes

### DIFF
--- a/docs/lessons/2026-06-23-issue-849-histogram-bin-progress.md
+++ b/docs/lessons/2026-06-23-issue-849-histogram-bin-progress.md
@@ -1,0 +1,33 @@
+# Issue #849 Histogram Bin Progress Guards
+
+Issue #849 found that histogram bin builders trusted the caller-provided bin
+increment. A zero or negative bin size could make the shared comparable bin loop
+append ranges forever, and non-finite `Double` bin sizes had no public guard.
+
+## Decision
+
+Reject invalid typed bin sizes before entering the shared bin loop:
+
+- `Double` bin sizes must be finite and greater than zero.
+- `BigDecimal` bin sizes must be greater than zero.
+- Custom `binByComparable` incrementers must strictly increase the current range
+  end on every loop iteration.
+
+## Lessons
+
+- Public numeric histogram APIs should validate progress at the typed boundary;
+  callers should not be able to create non-terminating bins through a simple
+  zero or negative size.
+- Shared generic loops still need a defensive invariant because callers can
+  provide custom incrementers outside the typed helpers.
+- RED tests for non-progressing loops can exhaust the test JVM. Capture one
+  failing reproduction, then add fail-fast guards before running the full suite.
+
+## Verification
+
+- RED: `./gradlew :bluetape4k-math:test --tests "io.bluetape4k.math.DoubleHistogramTest.binByDouble rejects non progressing bin sizes"` failed with test JVM `Java heap space` after the zero bin size kept growing ranges.
+- GREEN targeted: `./gradlew :bluetape4k-math:test --tests "io.bluetape4k.math.DoubleHistogramTest.binByDouble rejects non progressing bin sizes" --tests "io.bluetape4k.math.BigDecimalHistogramTest.binByBigDecimal rejects non progressing bin sizes" --tests "io.bluetape4k.math.ComparableHistogramTest.binByComparable rejects non progressing incrementers"` passed with 3 tests.
+- Module: `./gradlew :bluetape4k-math:test` passed with 573 tests and 1 pending.
+- Build: `./gradlew :bluetape4k-math:build` passed.
+- Hygiene: `git diff --check` passed.
+- Static analysis: `./gradlew detekt` passed with `:detekt NO-SOURCE`.

--- a/docs/review/2026-06-23-issue-849-histogram-bin-progress-review.md
+++ b/docs/review/2026-06-23-issue-849-histogram-bin-progress-review.md
@@ -1,0 +1,35 @@
+# Issue #849 Histogram Bin Progress Review
+
+## Scope
+
+- `utils/math/src/main/kotlin/io/bluetape4k/math/DoubleHistogram.kt`
+- `utils/math/src/main/kotlin/io/bluetape4k/math/BigDecimalHistogram.kt`
+- `utils/math/src/main/kotlin/io/bluetape4k/math/ComparableHistogram.kt`
+- `utils/math/src/test/kotlin/io/bluetape4k/math/DoubleHistogramTest.kt`
+- `utils/math/src/test/kotlin/io/bluetape4k/math/BigDecimalHistogramTest.kt`
+- `utils/math/src/test/kotlin/io/bluetape4k/math/ComparableHistogramTest.kt`
+
+## Verdict
+
+Local 7-tier equivalent review: APPROVE.
+
+P0/P1 findings: 0.
+
+## Review Notes
+
+| Lens | Finding | Severity | Resolution |
+|---|---|---:|---|
+| Correctness | `binByDouble(0.0)` and negative bin sizes did not advance toward the maximum. | P1 | `Double` bin sizes now require finite positive values. |
+| Correctness | `binByBigDecimal(BigDecimal.ZERO)` and negative bin sizes did not advance. | P1 | `BigDecimal` bin sizes now require values greater than zero. |
+| Defensive API | `binByComparable` could still hang with a custom non-progressing incrementer. | P1 | The loop now requires every incremented range end to be strictly greater than the previous one. |
+| Regression coverage | Existing histogram tests only covered positive bin sizes. | P1 | Added invalid `Double`, invalid `BigDecimal`, and custom comparable incrementer tests. |
+| Compatibility | Existing positive-bin behavior should stay unchanged. | P2 | Existing histogram module tests still pass. |
+
+## Verification
+
+- RED: targeted `DoubleHistogramTest` invalid-bin test failed by exhausting the test JVM heap before the fix.
+- GREEN targeted: invalid `Double`, `BigDecimal`, and comparable incrementer tests passed with 3 tests.
+- Module: `./gradlew :bluetape4k-math:test` passed with 573 tests and 1 pending.
+- Build: `./gradlew :bluetape4k-math:build` passed.
+- Hygiene: `git diff --check` passed.
+- Static analysis: `./gradlew detekt` passed with `:detekt NO-SOURCE`.

--- a/utils/math/src/main/kotlin/io/bluetape4k/math/BigDecimalHistogram.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/BigDecimalHistogram.kt
@@ -52,6 +52,6 @@ inline fun <T: Any, G: Any> Iterable<T>.binByBigDecimal(
     crossinline groupOp: (List<T>) -> G,
     rangeStart: BigDecimal? = null,
 ): BinModel<G, BigDecimal> {
-require(count() > 0) { "Collection must not be empty." }
+    require(binSize > BigDecimal.ZERO) { "binSize must be greater than 0." }
     return binByComparable({ it + binSize }, valueMapper, groupOp, rangeStart)
 }

--- a/utils/math/src/main/kotlin/io/bluetape4k/math/ComparableHistogram.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/ComparableHistogram.kt
@@ -122,7 +122,11 @@ inline fun <T: Any, C: Comparable<C>, G: Any> Iterable<T>.binByComparable(
             var currentRangeStart = minC
             var currentRangeEnd = minC
             while (currentRangeEnd < maxC) {
-                currentRangeEnd = incrementer(currentRangeEnd)
+                val nextRangeEnd = incrementer(currentRangeEnd)
+                require(nextRangeEnd > currentRangeEnd) {
+                    "incrementer must increase the current range end."
+                }
+                currentRangeEnd = nextRangeEnd
                 add(rangeFactory(currentRangeStart, currentRangeEnd))
                 currentRangeStart = currentRangeEnd
             }

--- a/utils/math/src/main/kotlin/io/bluetape4k/math/DoubleHistogram.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/DoubleHistogram.kt
@@ -49,5 +49,7 @@ inline fun <T: Any, G: Any> Iterable<T>.binByDouble(
     valueMapper: (T) -> Double,
     crossinline groupOp: (List<T>) -> G,
     rangeStart: Double? = null,
-): BinModel<G, Double> =
-    binByComparable({ it + binSize }, valueMapper, groupOp, rangeStart)
+): BinModel<G, Double> {
+    require(binSize.isFinite() && binSize > 0.0) { "binSize must be finite and greater than 0." }
+    return binByComparable({ it + binSize }, valueMapper, groupOp, rangeStart)
+}

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/BigDecimalHistogramTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/BigDecimalHistogramTest.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.math
 
 import io.bluetape4k.collections.repeat
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.assertions.shouldBeEqualTo
@@ -50,6 +51,17 @@ class BigDecimalHistogramTest {
         assertTrue {
             histogram[205.0.toBigDecimal()]!!.range.let {
                 it.first == 200.0.toBigDecimal() && it.last == 300.0.toBigDecimal()
+            }
+        }
+    }
+
+    @Test
+    fun `binByBigDecimal rejects non progressing bin sizes`() {
+        val values = listOf(BigDecimal.ZERO, BigDecimal.ONE)
+
+        listOf(BigDecimal.ZERO, BigDecimal("-1.0")).forEach { binSize ->
+            assertFailsWith<IllegalArgumentException> {
+                values.binByBigDecimal(binSize = binSize, valueMapper = { it })
             }
         }
     }

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/ComparableHistogramTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/ComparableHistogramTest.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.math
 
 import io.bluetape4k.collections.repeat
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.trace
@@ -116,5 +117,17 @@ class ComparableHistogramTest {
         )
         binned.forEach { log.trace { it } }
         binned[110.0]!!.value shouldContain sales[2]
+    }
+
+    @Test
+    fun `binByComparable rejects non progressing incrementers`() {
+        val values = listOf(1, 2)
+
+        assertFailsWith<IllegalArgumentException> {
+            values.binByComparable(incrementer = { it }, valueMapper = { it })
+        }
+        assertFailsWith<IllegalArgumentException> {
+            values.binByComparable(incrementer = { it - 1 }, valueMapper = { it })
+        }
     }
 }

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/DoubleHistogramTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/DoubleHistogramTest.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.math
 
 import io.bluetape4k.collections.repeat
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.trace
 import io.bluetape4k.ranges.toClosedClosedRange
@@ -43,5 +44,16 @@ class DoubleHistogramTest {
         histogram[5.0]!!.range shouldBeEqualTo (0.0..100.0).toClosedClosedRange()
         histogram[105.0]!!.range shouldBeEqualTo (100.0..200.0).toClosedClosedRange()
         histogram[205.0]!!.range shouldBeEqualTo (200.0..300.0).toClosedClosedRange()
+    }
+
+    @Test
+    fun `binByDouble rejects non progressing bin sizes`() {
+        val values = listOf(0.0, 1.0)
+
+        listOf(0.0, -1.0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NaN).forEach { binSize ->
+            assertFailsWith<IllegalArgumentException> {
+                values.binByDouble(binSize = binSize, valueMapper = { it })
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #849

- PR 제목: Reject non-progressing histogram bin sizes

- Reject invalid `Double` histogram bin sizes unless they are finite and greater than zero.
- Reject zero/negative `BigDecimal` histogram bin sizes.
- Add a defensive `binByComparable` progress check for custom incrementers.
- Add invalid-bin regression tests and issue lesson/review notes.

Closes #849.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- RED: `./gradlew :bluetape4k-math:test --tests "io.bluetape4k.math.DoubleHistogramTest.binByDouble rejects non progressing bin sizes"` failed by exhausting the test JVM heap before the fix.
- GREEN targeted: invalid `Double`, `BigDecimal`, and comparable incrementer tests passed with 3 tests.
- `./gradlew :bluetape4k-math:test` passed with 573 tests and 1 pending.
- `./gradlew :bluetape4k-math:build` passed.
- `git diff --check` passed.
- `./gradlew detekt` passed with `:detekt NO-SOURCE`.
- GitHub PR checks passed: Build, CI Status, Coverage Report, Detect changed modules, Secret Scan, Validate Gradle Wrapper, submit-gradle.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #849, milestone `1.11.0`, assignee `debop`
- PR: #865, head `cf89b04caf804b0bf08eb5f21cae2e082e97982e`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/histogram-bin-progress-849`
- Labels: 없음
- State: `MERGED`, merge commit `be3d7f78a545139a77f484e374dfc4bb0ee9cc11`
- CI: - Reject zero/negative `BigDecimal` histogram bin sizes. / - RED: `./gradlew :bluetape4k-math:test --tests "io.bluetape4k.math.DoubleHistogramTest.binByDouble rejects non progressing bin sizes"` failed by exhausting the test JVM heap before the fix. / - GREEN targeted: invalid `Double`, `BigDecimal`, and comparable incrementer tests passed with 3 tests.

## DoD Status

- [x] Issue #849 reproduced with a RED non-progressing histogram test.
- [x] Public `Double` and `BigDecimal` bin-size APIs reject non-progressing sizes.
- [x] Shared comparable histogram loop rejects custom non-progressing incrementers.
- [x] Regression tests cover invalid `Double`, `BigDecimal`, and comparable incrementers.
- [x] Lesson and review notes added.
- [x] Local verification completed.
- [x] GitHub PR checks passed.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #865 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `be3d7f78a545139a77f484e374dfc4bb0ee9cc11`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
