### PR TITLE
Make Redis keychain rotation single-winner

### DIFF
--- a/docs/lessons/2026-06-23-issue-848-redis-keychain-single-winner.md
+++ b/docs/lessons/2026-06-23-issue-848-redis-keychain-single-winner.md
@@ -1,0 +1,32 @@
+# Issue #848 Redis Key-Chain Single-Winner Rotation
+
+Issue #848 found that `RedisKeyChainRepository.rotate()` trusted each
+process-local cached current keychain. Two application nodes could cache the
+same expired current keychain and then both insert different replacement keys
+into Redis.
+
+## Decision
+
+Serialize Redis-backed rotation with a Redisson lock derived from the keychain
+queue name. While holding the lock, reload the current keychain from Redis and
+update the local cache before deciding whether to rotate. A node that loses the
+race sees the winner's non-expired keychain and immediately converges its cache
+to that key.
+
+## Lessons
+
+- Distributed repositories cannot make rotation decisions from a per-process
+  cache. The lock-protected section must re-read the shared state.
+- A stale-cache race can be reproduced deterministically without thread timing:
+  two repository instances cache the same expired key, then rotate sequentially.
+- Forced rotation should use the same Redis lock and capacity trimming path so
+  regular and forced writes cannot interleave around deque maintenance.
+
+## Verification
+
+- RED: `./gradlew :bluetape4k-jwt:test --tests "io.bluetape4k.jwt.keychain.redis.RedisKeyChainRepositoryTest.expired cached keychain rotates with single Redis winner"` failed with `Expected <2> to equal to <1>`.
+- GREEN targeted: the same Redis-backed test passed with 1 test.
+- Module: `./gradlew :bluetape4k-jwt:test` passed with 149 tests and 10 pending.
+- Build: `./gradlew :bluetape4k-jwt:build` passed.
+- Hygiene: `git diff --check` passed.
+- Static analysis: `./gradlew detekt` passed with `:detekt NO-SOURCE`.

--- a/docs/review/2026-06-23-issue-848-redis-keychain-single-winner-review.md
+++ b/docs/review/2026-06-23-issue-848-redis-keychain-single-winner-review.md
@@ -1,0 +1,31 @@
+# Issue #848 Redis Key-Chain Single-Winner Review
+
+## Scope
+
+- `utils/jwt/src/main/kotlin/io/bluetape4k/jwt/keychain/repository/redis/RedisKeyChainRepository.kt`
+- `utils/jwt/src/test/kotlin/io/bluetape4k/jwt/keychain/redis/RedisKeyChainRepositoryTest.kt`
+
+## Verdict
+
+Local 7-tier equivalent review: APPROVE.
+
+P0/P1 findings: 0.
+
+## Review Notes
+
+| Lens | Finding | Severity | Resolution |
+|---|---|---:|---|
+| Distributed correctness | `rotate()` made the expired-current decision from a process-local cache. | P1 | Rotation now acquires a Redis lock and reloads current from Redis before deciding. |
+| Consistency | Losing nodes needed to converge immediately to the winning keychain. | P1 | The lock-protected reload updates `cachedCurrent` before returning false for a non-expired winner. |
+| Capacity maintenance | Competing writes could interleave with deque trimming. | P1 | Regular and forced rotation share `changeCurrentAndTrim` under the same lock. |
+| Regression coverage | Existing tests covered sequential single-repository behavior only. | P1 | Added a Redis-backed multi-repository stale-cache regression. |
+| Compatibility | Existing repository contracts should remain unchanged. | P2 | Existing JWT module tests still pass. |
+
+## Verification
+
+- RED: single-winner Redis regression failed because both stale repositories rotated successfully.
+- GREEN targeted: single-winner Redis regression passed.
+- Module: `./gradlew :bluetape4k-jwt:test` passed with 149 tests and 10 pending.
+- Build: `./gradlew :bluetape4k-jwt:build` passed.
+- Hygiene: `git diff --check` passed.
+- Static analysis: `./gradlew detekt` passed with `:detekt NO-SOURCE`.

--- a/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/keychain/repository/redis/RedisKeyChainRepository.kt
+++ b/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/keychain/repository/redis/RedisKeyChainRepository.kt
@@ -14,7 +14,9 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
 import org.redisson.api.RDeque
+import org.redisson.api.RLock
 import org.redisson.api.RedissonClient
+import java.util.concurrent.TimeUnit
 
 /**
  * JWT 토큰 발급에 사용된 [KeyChain]을 Redis에 저장하여, 분산환경에서 [KeyChain]을 공유하고, rotate 시에 전파되도록 합니다.
@@ -34,6 +36,7 @@ import org.redisson.api.RedissonClient
  */
 class RedisKeyChainRepository private constructor(
     private val keyChainStore: RDeque<KeyChainDto>,
+    private val rotationLock: RLock,
     override val capacity: Int,
 ): AbstractKeyChainRepository() {
 
@@ -47,7 +50,8 @@ class RedisKeyChainRepository private constructor(
             capacity: Int = KeyChainRepository.DEFAULT_CAPACITY,
         ): RedisKeyChainRepository {
             val queue = redisson.getDeque<KeyChainDto>(queueName)
-            return RedisKeyChainRepository(queue, capacity.coerceIn(MIN_CAPACITY, MAX_CAPACITY))
+            val lock = redisson.getLock("$queueName:rotation-lock")
+            return RedisKeyChainRepository(queue, lock, capacity.coerceIn(MIN_CAPACITY, MAX_CAPACITY))
         }
     }
 
@@ -66,38 +70,56 @@ class RedisKeyChainRepository private constructor(
 
     override fun rotate(keyChain: KeyChain): Boolean {
         log.debug { "Rotate KeyChain. kid=${keyChain.id}" }
-        if (keyChainStore.isEmpty()) {
-            return changeCurrent(keyChain)
-        }
+        return withRotationLock {
+            val currentKeyChain = doLoadCurrent()
+            cachedCurrent = currentKeyChain
 
-        val currentKeyChain = current()
-
-        // current KeyChain이 유효하다면 굳이 revoke 하지 않습니다 (다른 서버에서도 주기적으로 revoke하게 되면 ping-pong이 되어버립니다.)
-        if (!currentKeyChain.isExpired) {
-            log.debug { "기존 KeyChain의 유효기간이 남아서 rotate 하지 않습니다." }
-            return false
-        }
-
-
-        if (currentKeyChain.id != keyChain.id) {
-            return changeCurrent(keyChain).apply {
-                if (keyChainStore.size > capacity) {
-                    log.debug { "Remove oldest keychain ..." }
-                    keyChainStore.removeLast()
-                }
+            if (currentKeyChain == null) {
+                return@withRotationLock changeCurrentAndTrim(keyChain)
             }
+
+            // current KeyChain이 유효하다면 굳이 revoke 하지 않습니다 (다른 서버에서도 주기적으로 revoke하게 되면 ping-pong이 되어버립니다.)
+            if (!currentKeyChain.isExpired) {
+                log.debug { "기존 KeyChain의 유효기간이 남아서 rotate 하지 않습니다." }
+                return@withRotationLock false
+            }
+
+            if (currentKeyChain.id != keyChain.id) {
+                return@withRotationLock changeCurrentAndTrim(keyChain)
+            }
+
+            false
         }
-        return false
     }
 
     override fun forcedRotate(keyChain: KeyChain): Boolean {
-        if (keyChainStore.isEmpty()) {
-            return changeCurrent(keyChain)
+        return withRotationLock {
+            changeCurrentAndTrim(keyChain)
         }
-        return changeCurrent(keyChain).apply {
-            if (keyChainStore.size > capacity) {
+    }
+
+    private fun changeCurrentAndTrim(keyChain: KeyChain): Boolean {
+        val changed = changeCurrent(keyChain)
+        if (changed) {
+            while (keyChainStore.size > capacity) {
                 log.debug { "Remove oldest keychain ..." }
                 keyChainStore.removeLast()
+            }
+        }
+        return changed
+    }
+
+    private inline fun withRotationLock(action: () -> Boolean): Boolean {
+        check(rotationLock.tryLock(5, 30, TimeUnit.SECONDS)) {
+            "Failed to acquire Redis keychain rotation lock."
+        }
+        return try {
+            action()
+        } finally {
+            runCatching {
+                if (rotationLock.isHeldByCurrentThread) {
+                    rotationLock.unlock()
+                }
             }
         }
     }

--- a/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/keychain/redis/RedisKeyChainRepositoryTest.kt
+++ b/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/keychain/redis/RedisKeyChainRepositoryTest.kt
@@ -1,9 +1,16 @@
 package io.bluetape4k.jwt.keychain.redis
 
+import io.bluetape4k.jwt.keychain.KeyChain
 import io.bluetape4k.jwt.keychain.AbstractKeyChainRepositoryTest
 import io.bluetape4k.jwt.keychain.repository.KeyChainRepository
 import io.bluetape4k.jwt.keychain.repository.redis.RedisKeyChainRepository
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.testcontainers.storage.RedisServer
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.UUID
+import kotlin.test.assertNull
 
 class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
 
@@ -13,5 +20,40 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
 
     override val repository: KeyChainRepository by lazy {
         RedisKeyChainRepository(redisson)
+    }
+
+    @Test
+    fun `expired cached keychain rotates with single Redis winner`() {
+        val queueName = "test:jwt:keychain:${UUID.randomUUID()}"
+        val seedRepository = RedisKeyChainRepository(redisson, queueName = queueName)
+        val firstNode = RedisKeyChainRepository(redisson, queueName = queueName)
+        val secondNode = RedisKeyChainRepository(redisson, queueName = queueName)
+
+        try {
+            val expiredKeyChain = KeyChain(expiredTtl = Duration.ofMillis(1))
+            seedRepository.forcedRotate(expiredKeyChain).shouldBeTrue()
+            Thread.sleep(10)
+
+            firstNode.current() shouldBeEqualTo expiredKeyChain
+            secondNode.current() shouldBeEqualTo expiredKeyChain
+
+            val firstCandidate = KeyChain()
+            val secondCandidate = KeyChain()
+
+            val firstRotated = firstNode.rotate(firstCandidate)
+            val secondRotated = secondNode.rotate(secondCandidate)
+
+            listOf(firstRotated, secondRotated).count { it }.shouldBeEqualTo(1)
+
+            val winner = if (firstRotated) firstCandidate else secondCandidate
+            val loser = if (firstRotated) secondCandidate else firstCandidate
+
+            firstNode.current() shouldBeEqualTo winner
+            secondNode.current() shouldBeEqualTo winner
+            seedRepository.findOrNull(winner.id) shouldBeEqualTo winner
+            assertNull(seedRepository.findOrNull(loser.id))
+        } finally {
+            seedRepository.deleteAll()
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #848

- PR 제목: Make Redis keychain rotation single-winner

- Serialize Redis-backed keychain rotation with a Redisson lock derived from the queue name.
- Re-read Redis current keychain while holding the lock before deciding whether to rotate.
- Share locked capacity trimming between regular and forced rotation.
- Add a Redis-backed stale-cache regression proving only one repository instance wins and all instances converge to the winning key.

Closes #848.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- RED: `./gradlew :bluetape4k-jwt:test --tests "io.bluetape4k.jwt.keychain.redis.RedisKeyChainRepositoryTest.expired cached keychain rotates with single Redis winner"` failed with `Expected <2> to equal to <1>`.
- GREEN targeted: same Redis-backed regression passed with 1 test.
- `./gradlew :bluetape4k-jwt:test` passed with 149 tests and 10 pending.
- `./gradlew :bluetape4k-jwt:build` passed.
- `git diff --check` passed.
- `./gradlew detekt` passed with `:detekt NO-SOURCE`.
- GitHub PR checks passed: Build, CI Status, Coverage Report, Detect changed modules, Secret Scan, Validate Gradle Wrapper, submit-gradle.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #848, milestone `1.11.0`, assignee `debop`
- PR: #866, head `872747858da4c91a76379bd3c4273079b2eaab40`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/redis-keychain-single-winner-848`
- Labels: 없음
- State: `MERGED`, merge commit `b11b786b6b5f111920f2317622e7ba8ab05d255b`
- CI: - Re-read Redis current keychain while holding the lock before deciding whether to rotate. / - Share locked capacity trimming between regular and forced rotation. / - RED: `./gradlew :bluetape4k-jwt:test --tests "io.bluetape4k.jwt.keychain.redis.RedisKeyChainRepositoryTest.expired cached keychain rotates with single Redis winner"` failed with `Expected <2> to equal to <1>`.

## DoD Status

- [x] Issue #848 reproduced with a Redis-backed stale-cache RED test.
- [x] Redis keychain rotation decision is serialized by a Redis lock.
- [x] Losing repository instances refresh/converge to the winning current keychain.
- [x] Regression test verifies a single winner and no loser key persistence.
- [x] Lesson and review notes added.
- [x] Local verification completed.
- [x] GitHub PR checks passed.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #866 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `b11b786b6b5f111920f2317622e7ba8ab05d255b`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
