### PR TITLE
Fix JwtReader remaining TTL semantics

### DIFF
--- a/docs/lessons/2026-06-23-issue-847-jwt-reader-ttl.md
+++ b/docs/lessons/2026-06-23-issue-847-jwt-reader-ttl.md
@@ -1,0 +1,32 @@
+# Issue #847 JwtReader Remaining TTL
+
+Issue #847 found that `JwtReader.expiredTtl` was documented and used as a TTL
+but returned the absolute JWT `exp` timestamp in epoch milliseconds.
+
+## Decision
+
+Split the two concepts explicitly. `expiresAtMillis` now exposes the absolute
+expiration timestamp, `remainingTtlMillis` exposes the remaining TTL in
+milliseconds, and the existing `expiredTtl` property follows the remaining TTL
+contract for compatibility with the documented name. `isExpired` compares the
+absolute expiration timestamp directly instead of reusing the TTL value.
+
+## Lessons
+
+- Public auth APIs should not overload one value as both a TTL and an absolute
+  timestamp. Cache/session callers can retain authorization state for far too
+  long when those units are confused.
+- A one-hour token is an effective regression fixture: the remaining TTL must be
+  near 3,600,000 milliseconds, while an epoch timestamp is orders of magnitude
+  larger.
+- README examples should show both the remaining TTL and absolute expiration
+  accessors so consumers choose the correct value for cache TTLs and audit logs.
+
+## Verification
+
+- RED: `./gradlew :bluetape4k-jwt:test --tests "io.bluetape4k.jwt.reader.JwtReaderExpirationTest.expiredTtl - exp 클레임이 있으면 남은 TTL 밀리초를 반환한다" --no-build-cache` failed with `Expected <1782192683000> to be less than <3600001>`.
+- GREEN targeted: `./gradlew :bluetape4k-jwt:test --tests "io.bluetape4k.jwt.reader.JwtReaderExpirationTest" --no-build-cache` passed.
+- Module: `./gradlew :bluetape4k-jwt:test --no-build-cache` passed with 150 tests and 10 pending.
+- Build: `./gradlew :bluetape4k-jwt:build --no-build-cache` passed.
+- Hygiene: `git diff --check` passed.
+- Static analysis: `./gradlew detekt` passed with `:detekt NO-SOURCE`.

--- a/docs/review/2026-06-23-issue-847-jwt-reader-ttl-review.md
+++ b/docs/review/2026-06-23-issue-847-jwt-reader-ttl-review.md
@@ -1,0 +1,33 @@
+# Issue #847 JwtReader TTL Review
+
+## Scope
+
+- `utils/jwt/src/main/kotlin/io/bluetape4k/jwt/reader/JwtReader.kt`
+- `utils/jwt/src/test/kotlin/io/bluetape4k/jwt/reader/JwtReaderExpirationTest.kt`
+- `utils/jwt/README.md`
+- `utils/jwt/README.ko.md`
+
+## Verdict
+
+Local 7-tier equivalent review: APPROVE.
+
+P0/P1 findings: 0.
+
+## Review Notes
+
+| Lens | Finding | Severity | Resolution |
+|---|---|---:|---|
+| API correctness | `expiredTtl` returned `exp` epoch millis despite TTL documentation. | P1 | Added `expiresAtMillis` for the epoch value and changed `expiredTtl` to remaining TTL semantics. |
+| Expiration logic | `isExpired` reused the mislabeled TTL value as an absolute timestamp. | P1 | `isExpired` now compares `expiresAtMillis` directly with the current clock. |
+| Regression coverage | Existing tests locked the timestamp behavior. | P1 | Updated timestamp coverage to `expiresAtMillis` and added one-hour remaining TTL regression coverage. |
+| Documentation | README examples encouraged assigning `expiredTtl` to a TTL variable without showing the absolute timestamp accessor. | P2 | README and README.ko now show `remainingTtlMillis` and `expiresAtMillis` separately. |
+| Compatibility | Existing callers still have an `expiredTtl` property. | P2 | Kept `expiredTtl` as a remaining TTL alias rather than removing the property. |
+
+## Verification
+
+- RED: remaining-TTL regression failed against the epoch millis implementation.
+- GREEN targeted: `JwtReaderExpirationTest` passed.
+- Module: `./gradlew :bluetape4k-jwt:test --no-build-cache` passed with 150 tests and 10 pending.
+- Build: `./gradlew :bluetape4k-jwt:build --no-build-cache` passed.
+- Hygiene: `git diff --check` passed.
+- Static analysis: `./gradlew detekt` passed with `:detekt NO-SOURCE`.

--- a/utils/jwt/README.ko.md
+++ b/utils/jwt/README.ko.md
@@ -99,6 +99,7 @@ val jwt = jwtProvider.composer()
     .claim("userId", 12345L)
     .claim("email", "user@example.com")
     .claim("roles", listOf("admin", "user"))
+    .expirationAfterMinutes(60)
     .compose()
 
 val reader = jwtProvider.parse(jwt)
@@ -111,8 +112,9 @@ if (reader.isExpired) {
     throw SecurityException("Token expired")
 }
 
-// 만료까지 남은 시간 (TTL)
-val ttl = reader.expiredTtl
+// 만료까지 남은 시간 (TTL)과 절대 만료 시각
+val remainingTtlMillis = reader.remainingTtlMillis
+val expiresAtMillis = reader.expiresAtMillis
 
 // 클레임 조회 (타입 안전)
 val userId: Long? = reader.claim("userId")

--- a/utils/jwt/README.md
+++ b/utils/jwt/README.md
@@ -98,6 +98,7 @@ val jwt = jwtProvider.composer()
     .claim("userId", 12345L)
     .claim("email", "user@example.com")
     .claim("roles", listOf("admin", "user"))
+    .expirationAfterMinutes(60)
     .compose()
 
 val reader = jwtProvider.parse(jwt)
@@ -108,7 +109,8 @@ if (reader.isExpired) {
     throw SecurityException("Token expired")
 }
 
-val ttl = reader.expiredTtl
+val remainingTtlMillis = reader.remainingTtlMillis
+val expiresAtMillis = reader.expiresAtMillis
 
 val userId: Long? = reader.claim("userId")
 val email: String? = reader.claim("email")

--- a/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/reader/JwtReader.kt
+++ b/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/reader/JwtReader.kt
@@ -38,21 +38,39 @@ class JwtReader(
         get() = header<String>("kid")
 
     /**
-     * Expiration TTL (Time To Live) (Milliseconds)
+     * JWT expiration time as epoch milliseconds.
+     *
+     * ## 동작/계약
+     * - `exp` 클레임이 없으면 `null`을 반환합니다.
+     */
+    val expiresAtMillis: Long?
+        get() = expiration?.time
+
+    /**
+     * Expiration TTL (Time To Live) in milliseconds.
      *
      * ## 동작/계약
      * - `exp` 클레임이 없으면 [Long.MAX_VALUE]를 반환합니다.
+     * - 이미 만료된 토큰이면 `0`을 반환합니다.
      *
      * ```kotlin
      * val provider = JwtProviderFactory.default()
      * val jwt = provider.compose { expirationAfterMinutes = 60 }
      * val reader = provider.parse(jwt)
-     * val ttl = reader.expiredTtl
-     * // ttl > System.currentTimeMillis()
+     * val ttl = reader.remainingTtlMillis
+     * // ttl <= 60 * 60 * 1000
      * ```
      */
+    val remainingTtlMillis: Long
+        get() = expiresAtMillis?.let { (it - System.currentTimeMillis()).coerceAtLeast(0L) } ?: Long.MAX_VALUE
+
+    /**
+     * Expiration TTL (Time To Live) in milliseconds.
+     *
+     * @see remainingTtlMillis
+     */
     val expiredTtl: Long
-        get() = expiration?.time ?: Long.MAX_VALUE
+        get() = remainingTtlMillis
 
     /**
      * JWT 정보 만료 여부 (see: [getExpiration] )
@@ -69,7 +87,7 @@ class JwtReader(
      * ```
      */
     val isExpired: Boolean
-        get() = expiredTtl <= System.currentTimeMillis()
+        get() = expiresAtMillis?.let { it <= System.currentTimeMillis() } ?: false
 
     /**
      * 헤더 값을 조회합니다.

--- a/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/reader/JwtReaderExpirationTest.kt
+++ b/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/reader/JwtReaderExpirationTest.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.jwt.provider.JwtProviderFactory
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeLessThan
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
@@ -26,7 +27,8 @@ class JwtReaderExpirationTest: AbstractJwtTest() {
 
         val reader = provider.parse(jwt)
         reader.isExpired.shouldBeFalse()
-        reader.expiredTtl shouldBeGreaterThan System.currentTimeMillis()
+        reader.expiredTtl shouldBeGreaterThan 0L
+        reader.expiredTtl shouldBeLessThan 3_600_001L
     }
 
     @Test
@@ -45,14 +47,29 @@ class JwtReaderExpirationTest: AbstractJwtTest() {
     }
 
     @Test
-    fun `expiredTtl - exp 클레임이 있으면 밀리초 타임스탬프를 반환한다`() {
+    fun `expiresAtMillis - exp 클레임이 있으면 밀리초 타임스탬프를 반환한다`() {
         val jwt = provider.compose {
             subject = "alice"
             expirationAfterSeconds = 3600
         }
 
         val reader = provider.parse(jwt)
-        reader.expiredTtl shouldBeGreaterThan System.currentTimeMillis()
+        reader.expiresAtMillis.shouldNotBeNull()
+        reader.expiresAtMillis!! shouldBeGreaterThan System.currentTimeMillis()
+    }
+
+    @Test
+    fun `expiredTtl - exp 클레임이 있으면 남은 TTL 밀리초를 반환한다`() {
+        val jwt = provider.compose {
+            subject = "alice"
+            expirationAfterSeconds = 3600
+        }
+
+        val reader = provider.parse(jwt)
+        reader.expiredTtl shouldBeGreaterThan 0L
+        reader.expiredTtl shouldBeLessThan 3_600_001L
+        reader.remainingTtlMillis shouldBeGreaterThan 0L
+        reader.remainingTtlMillis shouldBeLessThan 3_600_001L
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #847

- PR 제목: Fix JwtReader remaining TTL semantics

- Split `JwtReader` expiration values into explicit absolute timestamp and remaining TTL accessors.
- Keep `expiredTtl` available but align it with the documented remaining-TTL semantics.
- Update JWT README examples in English and Korean so cache/session TTL usage does not receive epoch millis.
- Add regression coverage and issue lesson/review notes for #847.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Added `JwtReader.expiresAtMillis` for absolute `exp` epoch millis.
- Added `JwtReader.remainingTtlMillis` and made `expiredTtl` delegate to it.
- Updated `isExpired` to compare against `expiresAtMillis` directly.
- Replaced the old timestamp expectation with `expiresAtMillis` coverage and added a one-hour remaining TTL regression.

### 기존 섹션: Verification

- RED: `./gradlew :bluetape4k-jwt:test --tests "io.bluetape4k.jwt.reader.JwtReaderExpirationTest.expiredTtl - exp 클레임이 있으면 남은 TTL 밀리초를 반환한다" --no-build-cache`
  - Failed before the fix with `Expected <1782192683000> to be less than <3600001>`.
- GREEN targeted: `./gradlew :bluetape4k-jwt:test --tests "io.bluetape4k.jwt.reader.JwtReaderExpirationTest" --no-build-cache`
- Module: `./gradlew :bluetape4k-jwt:test --no-build-cache`
  - `150 passing`, `10 pending`, `BUILD SUCCESSFUL`
- Build: `./gradlew :bluetape4k-jwt:build --no-build-cache`
- Static analysis: `./gradlew detekt`
  - `:detekt NO-SOURCE`, `BUILD SUCCESSFUL`
- Hygiene: `git diff --check`

Closes #847

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #847, milestone `1.11.0`, assignee `debop`
- PR: #867, head `bef4a054f39e0bd07e71d72bb8ff58d5f70f708d`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/jwt-reader-expired-ttl-847`
- Labels: 없음
- State: `MERGED`, merge commit `1463bf38946acf6ac8819a206b5ddd0e91acabce`
- CI: - Split `JwtReader` expiration values into explicit absolute timestamp and remaining TTL accessors. / - RED: `./gradlew :bluetape4k-jwt:test --tests "io.bluetape4k.jwt.reader.JwtReaderExpirationTest.expiredTtl - exp 클레임이 있으면 남은 TTL 밀리초를 반환한다" --no-build-cache` / - GREEN targeted: `./gradlew :bluetape4k-jwt:test --tests "io.bluetape4k.jwt.reader.JwtReaderExpirationTest" --no-build-cache`

## DoD Status

- [x] Issue #847 investigated from current source.
- [x] RED regression captured the epoch-millis/TTL mismatch.
- [x] Implementation separates absolute expiration from remaining TTL semantics.
- [x] README and README.ko examples updated.
- [x] Lesson and review notes added.
- [x] Targeted and module verification passed locally.
- [x] PR body created via `--body-file` and verified live with `gh pr view`.
- [x] GitHub checks passed for PR #867.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #867 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `1463bf38946acf6ac8819a206b5ddd0e91acabce`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
