### PR TITLE
Fix DateAdd backward split period seek

### DIFF
--- a/docs/lessons/2026-06-23-issue-846-dateadd-backward-split.md
+++ b/docs/lessons/2026-06-23-issue-846-dateadd-backward-split.md
@@ -1,0 +1,31 @@
+# Issue #846 DateAdd Backward Split Period Seek
+
+Issue #846 found that `DateAdd.findPrevPeriod()` could choose an older
+available period when a backward calculation started after multiple split
+available periods.
+
+## Decision
+
+Compare previous-period distance as `Duration.between(period.end, start)` so
+the nearest prior period has the smallest positive distance. This keeps the
+existing forward seek logic unchanged and fixes backward seek selection for both
+plain `DateAdd` include periods and `CalendarDateAdd` working-hour periods.
+
+## Lessons
+
+- Backward search should compare the distance from a candidate period end to the
+  start moment. Comparing `start` to `period.end` produces negative durations
+  and lets older periods look smaller than closer ones.
+- A zero-offset regression is useful for this bug because it exposes the chosen
+  start period directly before any duration arithmetic happens.
+- `CalendarDateAdd` should be covered when a bug lives in `DateAdd.calculateEnd`
+  because it rebuilds weekly working periods and delegates to the same path.
+
+## Verification
+
+- RED: split backward regressions failed with `2011-04-15T00:00Z` instead of `2011-04-24T00:00Z` and `2011-04-04T12:00Z` instead of `2011-04-04T18:00Z`.
+- GREEN targeted: `./gradlew :bluetape4k-javatimes:test --tests "io.bluetape4k.javatimes.period.calendars.DateAddTest.backward seek after split include periods starts from nearest previous period" --tests "io.bluetape4k.javatimes.period.calendars.CalendarDateAddTest.backward seek after split working hours starts from nearest previous period" --no-build-cache` passed with 2 tests.
+- Module: `./gradlew :bluetape4k-javatimes:test --no-build-cache` passed with 690 tests and 36 pending.
+- Build: `./gradlew :bluetape4k-javatimes:build --no-build-cache` passed.
+- Hygiene: `git diff --check` passed.
+- Static analysis: `./gradlew detekt` passed with `:detekt NO-SOURCE`.

--- a/docs/review/2026-06-23-issue-846-dateadd-backward-split-review.md
+++ b/docs/review/2026-06-23-issue-846-dateadd-backward-split-review.md
@@ -1,0 +1,32 @@
+# Issue #846 DateAdd Backward Split Period Review
+
+## Scope
+
+- `utils/javatimes/src/main/kotlin/io/bluetape4k/javatimes/period/calendars/DateAdd.kt`
+- `utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/calendars/DateAddTest.kt`
+- `utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/calendars/CalendarDateAddTest.kt`
+
+## Verdict
+
+Local 7-tier equivalent review: APPROVE.
+
+P0/P1 findings: 0.
+
+## Review Notes
+
+| Lens | Finding | Severity | Resolution |
+|---|---|---:|---|
+| Backward seek correctness | Previous-period selection compared negative durations from `start` to each period end. | P1 | The comparison now measures positive distance from `period.end` to `start`. |
+| Split include periods | Backward `subtract()` and negative `add()` could start from the first older include period. | P1 | Added split include period regression coverage from after the final period. |
+| Calendar delegation | `CalendarDateAdd` delegates weekly working periods through `DateAdd.calculateEnd`. | P1 | Added split working-hour regression coverage for the same backward path. |
+| Boundary behavior | The wrong period is visible even with zero offset. | P2 | Tests assert zero-offset selection before checking one-day/hour movement. |
+| Scope control | Forward seek behavior should not change. | P2 | The implementation changes only `findPrevPeriod()` distance calculation. |
+
+## Verification
+
+- RED: DateAdd and CalendarDateAdd split backward regressions failed against the old selection logic.
+- GREEN targeted: both new regressions passed.
+- Module: `./gradlew :bluetape4k-javatimes:test --no-build-cache` passed with 690 tests and 36 pending.
+- Build: `./gradlew :bluetape4k-javatimes:build --no-build-cache` passed.
+- Hygiene: `git diff --check` passed.
+- Static analysis: `./gradlew detekt` passed with `:detekt NO-SOURCE`.

--- a/utils/javatimes/src/main/kotlin/io/bluetape4k/javatimes/period/calendars/DateAdd.kt
+++ b/utils/javatimes/src/main/kotlin/io/bluetape4k/javatimes/period/calendars/DateAdd.kt
@@ -381,7 +381,7 @@ open class DateAdd protected constructor() {
                 }
 
                 // 근처 값이 아니라면 포기
-                val periodToMoment = Duration.between(start, period.end)
+                val periodToMoment = Duration.between(period.end, start)
                 if (periodToMoment < diff) {
                     diff = periodToMoment
                     nearest = period

--- a/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/calendars/CalendarDateAddTest.kt
+++ b/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/calendars/CalendarDateAddTest.kt
@@ -194,6 +194,21 @@ class CalendarDateAddTest: AbstractPeriodTest() {
     }
 
     @Test
+    fun `backward seek after split working hours starts from nearest previous period`() = runTest {
+        val dateAdd = CalendarDateAdd().apply {
+            addWorkingWeekdays()
+            workingHours.add(HourRangeInDay(8, 12))
+            workingHours.add(HourRangeInDay(13, 18))
+        }
+
+        val start = zonedDateTimeOf(2011, 4, 4, 20)
+
+        dateAdd.subtract(start, 0.hours()) shouldBeEqualTo zonedDateTimeOf(2011, 4, 4, 18)
+        dateAdd.subtract(start, 1.hours()) shouldBeEqualTo zonedDateTimeOf(2011, 4, 4, 17)
+        dateAdd.add(start, (-1).hours()) shouldBeEqualTo zonedDateTimeOf(2011, 4, 4, 17)
+    }
+
+    @Test
     fun `calendar date add 3`() = runTest {
         val dateAdd = CalendarDateAdd().apply {
             addWorkingWeekdays()

--- a/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/calendars/DateAddTest.kt
+++ b/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/calendars/DateAddTest.kt
@@ -266,6 +266,28 @@ class DateAddTest: AbstractPeriodTest() {
     }
 
     @Test
+    fun `backward seek after split include periods starts from nearest previous period`() = runTest {
+        val start = zonedDateTimeOf(2011, 4, 30)
+        val period1 = TimeRange(
+            zonedDateTimeOf(2011, 4, 1),
+            zonedDateTimeOf(2011, 4, 15)
+        )
+        val period2 = TimeRange(
+            zonedDateTimeOf(2011, 4, 20),
+            zonedDateTimeOf(2011, 4, 24)
+        )
+
+        val dateAdd = DateAdd().apply {
+            includePeriods.add(period1)
+            includePeriods.add(period2)
+        }
+
+        dateAdd.subtract(start, 0.days()) shouldBeEqualTo period2.end
+        dateAdd.subtract(start, 1.days()) shouldBeEqualTo period2.end.minusDays(1)
+        dateAdd.add(start, (-1).days()) shouldBeEqualTo period2.end.minusDays(1)
+    }
+
+    @Test
     fun `start is before exclude period`() = runTest {
         val start = zonedDateTimeOf(2011, 4, 12)
         val period = TimeRange(


### PR DESCRIPTION
## Summary

Closes #846

- PR 제목: Fix DateAdd backward split period seek

- Fix backward `DateAdd` period selection over split available periods.
- Add regressions for plain split include periods and `CalendarDateAdd` split working-hour periods.
- Add issue lesson and review notes for #846.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- `findPrevPeriod()` now compares `Duration.between(period.end, start)` so the nearest previous period wins.
- Added a `DateAdd` regression where a backward seek from `2011-04-30` starts at `2011-04-24`, not `2011-04-15`.
- Added a `CalendarDateAdd` regression where a backward seek after split working hours starts at `18:00`, not `12:00`.

### 기존 섹션: Verification

- RED: split backward regressions failed before the fix:
  - `Expected <2011-04-15T00:00Z> to equal to <2011-04-24T00:00Z>`
  - `Expected <2011-04-04T12:00Z> to equal to <2011-04-04T18:00Z>`
- GREEN targeted: `./gradlew :bluetape4k-javatimes:test --tests "io.bluetape4k.javatimes.period.calendars.DateAddTest.backward seek after split include periods starts from nearest previous period" --tests "io.bluetape4k.javatimes.period.calendars.CalendarDateAddTest.backward seek after split working hours starts from nearest previous period" --no-build-cache`
  - `2 passing`, `BUILD SUCCESSFUL`
- Module: `./gradlew :bluetape4k-javatimes:test --no-build-cache`
  - `690 passing`, `36 pending`, `BUILD SUCCESSFUL`
- Build: `./gradlew :bluetape4k-javatimes:build --no-build-cache`
- Static analysis: `./gradlew detekt`
  - `:detekt NO-SOURCE`, `BUILD SUCCESSFUL`
- Hygiene: `git diff --check`

Closes #846

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #846, milestone `1.11.0`, assignee `debop`
- PR: #868, head `1d31da51b5b2eb42c2d5e307f35d91a32475effe`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/dateadd-backward-split-846`
- Labels: 없음
- State: `MERGED`, merge commit `d046b52b146b2b6abe628be2448fd8d2ce5862d4`
- CI: - GREEN targeted: `./gradlew :bluetape4k-javatimes:test --tests "io.bluetape4k.javatimes.period.calendars.DateAddTest.backward seek after split include periods starts from nearest previous period" --tests "io.bluetape4k.javatimes.period.calendars.CalendarDateAddTest.backward seek after split working hours starts from nearest previous period" --no-build-cache` / - Module: `./gradlew :bluetape4k-javatimes:test --no-build-cache` / - Build: `./gradlew :bluetape4k-javatimes:build --no-build-cache`

## DoD Status

- [x] Issue #846 investigated from current source.
- [x] RED regressions captured wrong previous-period selection for `DateAdd` and `CalendarDateAdd`.
- [x] Backward period distance comparison fixed.
- [x] Targeted regression verification passed.
- [x] Full `bluetape4k-javatimes` module tests passed.
- [x] Build, detekt, and diff hygiene passed locally.
- [x] Lesson and review notes added.
- [x] PR body created via `--body-file` and verified live with `gh pr view`.
- [x] GitHub checks passed for PR #868.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #868 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `d046b52b146b2b6abe628be2448fd8d2ce5862d4`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
