### PR TITLE
Fix Flake component byte layout parsing

### DIFF
--- a/docs/lessons/2026-06-23-issue-845-flake-component-layout.md
+++ b/docs/lessons/2026-06-23-issue-845-flake-component-layout.md
@@ -1,0 +1,29 @@
+# Issue #845 Flake Component Byte Layout
+
+Issue #845 found that `Flake.asComponentString()` parsed generated Flake IDs in
+a different byte order than `Flake.nextId()` writes.
+
+## Decision
+
+Parse component strings in the written layout: timestamp `Long`, six node bytes,
+then sequence `Short`. Also validate the Flake ID length consistently with
+`asBase62String()`.
+
+## Lessons
+
+- Component helpers should be tested against the exact binary layout, not only
+  logged. A fixed clock and fixed node id make the expected string stable.
+- The first generated ID for a fixed-clock `Flake` currently has sequence `1`
+  because the generator initializes `lastTime` from the same clock value and
+  then increments within the same millisecond.
+- Byte layout tests should use distinct timestamp and node values so shifted
+  reads cannot accidentally produce plausible output.
+
+## Verification
+
+- RED: `./gradlew :bluetape4k-idgenerators:test --tests "io.bluetape4k.idgenerators.flake.FlakeTest.component string uses timestamp node and sequence byte layout" --no-build-cache` failed with shifted components: `7528612310232073478-25939941-1`.
+- GREEN targeted: the same Flake component layout test passed.
+- Module: `./gradlew :bluetape4k-idgenerators:test --no-build-cache` passed with 1149 tests.
+- Build: `./gradlew :bluetape4k-idgenerators:build --no-build-cache` passed.
+- Hygiene: `git diff --check` passed.
+- Static analysis: `./gradlew detekt` passed with `:detekt NO-SOURCE`.

--- a/docs/review/2026-06-23-issue-845-flake-component-layout-review.md
+++ b/docs/review/2026-06-23-issue-845-flake-component-layout-review.md
@@ -1,0 +1,30 @@
+# Issue #845 Flake Component Layout Review
+
+## Scope
+
+- `utils/idgenerators/src/main/kotlin/io/bluetape4k/idgenerators/flake/Flake.kt`
+- `utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/flake/FlakeTest.kt`
+
+## Verdict
+
+Local 7-tier equivalent review: APPROVE.
+
+P0/P1 findings: 0.
+
+## Review Notes
+
+| Lens | Finding | Severity | Resolution |
+|---|---|---:|---|
+| Binary layout correctness | `asComponentString()` read node bytes before timestamp bytes. | P1 | It now reads timestamp, node, sequence in the same order `nextId()` writes them. |
+| Public helper contract | KDoc promises `{timestamp}-{nodeId}-{sequence}`. | P1 | Added deterministic assertion for exact component output. |
+| Input validation | `asComponentString()` accepted arbitrary byte array sizes while `asBase62String()` requires 16 bytes. | P2 | Added the same 16-byte size guard. |
+| Regression stability | Existing tests only logged component strings. | P2 | Fixed clock and fixed node id make the expected output deterministic. |
+
+## Verification
+
+- RED: component layout regression failed with shifted timestamp and node values.
+- GREEN targeted: component layout regression passed.
+- Module: `./gradlew :bluetape4k-idgenerators:test --no-build-cache` passed with 1149 tests.
+- Build: `./gradlew :bluetape4k-idgenerators:build --no-build-cache` passed.
+- Hygiene: `git diff --check` passed.
+- Static analysis: `./gradlew detekt` passed with `:detekt NO-SOURCE`.

--- a/utils/idgenerators/src/main/kotlin/io/bluetape4k/idgenerators/flake/Flake.kt
+++ b/utils/idgenerators/src/main/kotlin/io/bluetape4k/idgenerators/flake/Flake.kt
@@ -126,10 +126,13 @@ class Flake private constructor(
          * @return `{timestamp}-{nodeId}-{sequence}` 형식의 문자열
          */
         fun asComponentString(flakeId: ByteArray): String {
+            require(flakeId.size == ID_SIZE_BYTES) { "ByteArray size must be 16" }
             val buffer = ByteBuffer.wrap(flakeId)
+            val timestamp = buffer.long
             val node = ByteArray(NODE_ID_BYTES)
             buffer.get(node)
-            return "${buffer.long}-${BigInteger(node).toLong()}-${buffer.short}"
+            val sequence = buffer.short
+            return "$timestamp-${BigInteger(node).toLong()}-$sequence"
         }
     }
 

--- a/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/flake/FlakeTest.kt
+++ b/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/flake/FlakeTest.kt
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
 import java.time.Clock
 import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
 import java.util.concurrent.ConcurrentHashMap
 
 class FlakeTest {
@@ -65,6 +67,18 @@ class FlakeTest {
         ids shouldHaveSize ID_SIZE
         ids.distinct() shouldHaveSize ID_SIZE
         ids.sorted() shouldBeEqualTo ids
+    }
+
+    @Test
+    fun `component string uses timestamp node and sequence byte layout`() {
+        val timestamp = 1_700_000_000_123L
+        val nodeId = 0x010203040506L
+        val clock = Clock.fixed(Instant.ofEpochMilli(timestamp), ZoneOffset.UTC)
+        val customFlake = Flake({ nodeId }, clock)
+
+        val id = customFlake.nextId()
+
+        Flake.asComponentString(id) shouldBeEqualTo "$timestamp-$nodeId-1"
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #845

- PR 제목: Fix Flake component byte layout parsing

- Fix `Flake.asComponentString()` to parse IDs in the same byte order `Flake.nextId()` writes.
- Add deterministic component-layout regression coverage with fixed clock and node id.
- Add issue lesson and review notes for #845.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Parse Flake components as timestamp `Long`, six node bytes, then sequence `Short`.
- Add a 16-byte input size guard to `asComponentString()`.
- Assert exact `{timestamp}-{nodeId}-{sequence}` output for a generated ID.

### 기존 섹션: Verification

- RED: `./gradlew :bluetape4k-idgenerators:test --tests "io.bluetape4k.idgenerators.flake.FlakeTest.component string uses timestamp node and sequence byte layout" --no-build-cache`
  - Failed before the fix with shifted components: `7528612310232073478-25939941-1`.
- GREEN targeted: same Flake component layout test passed.
- Module: `./gradlew :bluetape4k-idgenerators:test --no-build-cache`
  - `1149 passing`, `BUILD SUCCESSFUL`
- Build: `./gradlew :bluetape4k-idgenerators:build --no-build-cache`
- Static analysis: `./gradlew detekt`
  - `:detekt NO-SOURCE`, `BUILD SUCCESSFUL`
- Hygiene: `git diff --check`

Closes #845

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #845, milestone `1.11.0`, assignee `debop`
- PR: #869, head `119ce6ed22180daf44f51f8dfa3ed6a0222d270b`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/flake-component-parse-845`
- Labels: 없음
- State: `MERGED`, merge commit `c325454867a18f1ec3923716c758cbf5714e04dd`
- CI: - RED: `./gradlew :bluetape4k-idgenerators:test --tests "io.bluetape4k.idgenerators.flake.FlakeTest.component string uses timestamp node and sequence byte layout" --no-build-cache` / - Module: `./gradlew :bluetape4k-idgenerators:test --no-build-cache` / - Build: `./gradlew :bluetape4k-idgenerators:build --no-build-cache`

## DoD Status

- [x] Issue #845 investigated from current source.
- [x] RED regression captured shifted component parsing.
- [x] `asComponentString()` parses timestamp, node id, and sequence in write order.
- [x] Component parser validates 16-byte Flake IDs.
- [x] Targeted and module verification passed locally.
- [x] Build, detekt, and diff hygiene passed locally.
- [x] Lesson and review notes added.
- [x] PR body created via `--body-file` and verified live with `gh pr view`.
- [x] GitHub checks passed for PR #869.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #869 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `c325454867a18f1ec3923716c758cbf5714e04dd`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
