### PR TITLE
ci: make gitleaks install deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ env:
   JAVA_VERSION: '21'
   JAVA_DISTRIBUTION: 'temurin'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  GITLEAKS_VERSION: 'v8.30.1'
 
 jobs:
   # ── 0. 시크릿 스캔 ────────────────────────────────────────────────────────
@@ -55,10 +56,9 @@ jobs:
           fetch-depth: 0
       - name: Install gitleaks
         run: |
-          GITLEAKS_ASSET_URL=$(curl -sSfL https://api.github.com/repos/gitleaks/gitleaks/releases/latest \
-            | jq -r '.assets[] | select(.name | test("linux_x64\\.tar\\.gz$")) | .browser_download_url')
-          test -n "${GITLEAKS_ASSET_URL}"
-          curl -sSfL "${GITLEAKS_ASSET_URL}" \
+          set -euo pipefail
+          gitleaks_version="${GITLEAKS_VERSION#v}"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/${GITLEAKS_VERSION}/gitleaks_${gitleaks_version}_linux_x64.tar.gz" \
             | tar -xz gitleaks
           sudo mv gitleaks /usr/local/bin/
       - name: Run gitleaks

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,6 +13,7 @@ permissions:
 env:
   JAVA_VERSION: '21'
   JAVA_DISTRIBUTION: 'temurin'
+  GITLEAKS_VERSION: 'v8.30.1'
 
 jobs:
   # ── 시크릿 스캔 (전체 히스토리) ───────────────────────────────────────────
@@ -26,10 +27,9 @@ jobs:
 
       - name: Install gitleaks
         run: |
-          GITLEAKS_ASSET_URL=$(curl -sSfL https://api.github.com/repos/gitleaks/gitleaks/releases/latest \
-            | jq -r '.assets[] | select(.name | test("linux_x64\\.tar\\.gz$")) | .browser_download_url')
-          test -n "${GITLEAKS_ASSET_URL}"
-          curl -sSfL "${GITLEAKS_ASSET_URL}" \
+          set -euo pipefail
+          gitleaks_version="${GITLEAKS_VERSION#v}"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/${GITLEAKS_VERSION}/gitleaks_${gitleaks_version}_linux_x64.tar.gz" \
             | tar -xz gitleaks
           sudo mv gitleaks /usr/local/bin/
 

--- a/docs/lessons/2026-06-23-issue-860-gitleaks-install.md
+++ b/docs/lessons/2026-06-23-issue-860-gitleaks-install.md
@@ -1,0 +1,24 @@
+# Issue 860 - deterministic gitleaks install
+
+## Context
+
+The `Secret Scan (gitleaks)` job in `CI` failed before scanning because the
+installer queried `https://api.github.com/repos/gitleaks/gitleaks/releases/latest`
+without authentication. GitHub returned HTTP 403, so the `Run gitleaks` step was
+skipped.
+
+The same latest-release lookup was present in the weekly `Security` workflow.
+Earlier fixes had already moved from hand-built latest URLs to release metadata,
+but that still left the CI path dependent on a rate-limited API call.
+
+## Decision
+
+Pin `GITLEAKS_VERSION` to `v8.30.1` and download the exact Linux x64 release
+asset from the tag URL. This removes the unauthenticated releases API lookup
+from the installer while preserving the existing `gitleaks detect` commands.
+
+## Follow-up Guard
+
+Keep the `CI` and `Security` gitleaks installers aligned. If the pinned scanner
+version changes, update both workflow env blocks and verify the asset URL before
+merging.

--- a/docs/review/2026-06-23-issue-860-gitleaks-install-review.md
+++ b/docs/review/2026-06-23-issue-860-gitleaks-install-review.md
@@ -1,0 +1,22 @@
+# Issue 860 Review - gitleaks installer
+
+## Scope
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/security.yml`
+
+## Review Notes
+
+- The secret scan commands were not weakened or skipped.
+- The installer no longer calls the unauthenticated `releases/latest` API.
+- Both workflows now use the same pinned `GITLEAKS_VERSION`.
+- The pinned release asset name was verified against the upstream GitHub
+  release metadata before editing.
+
+## Verification Plan
+
+- `actionlint .github/workflows/ci.yml .github/workflows/security.yml`
+- `rg -n "\\\\'" .github/workflows`
+- `git diff --check`
+- Local download/extract smoke test for the pinned Linux x64 asset
+- PR `CI` run confirms `Secret Scan (gitleaks)` reaches `Run gitleaks`


### PR DESCRIPTION
## Summary

Closes #860

- PR 제목: ci: make gitleaks install deterministic

Fixes #860.

The CI `Secret Scan (gitleaks)` job failed before scanning because the installer
queried the unauthenticated GitHub Releases `latest` API and received HTTP 403.
This PR removes that runtime API lookup and pins the installer to the exact
`v8.30.1` Linux x64 release asset.

The weekly `Security` workflow had the same installer, so it is updated in the
same way to keep both gitleaks paths aligned.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Add `GITLEAKS_VERSION: 'v8.30.1'` to `CI` and `Security` workflow env blocks.
- Replace `releases/latest` metadata lookup with the deterministic tagged asset
  URL for `gitleaks_8.30.1_linux_x64.tar.gz`.
- Keep existing `gitleaks detect` commands unchanged.
- Add lesson and review notes for the CI failure pattern and future version
  updates.

### 기존 섹션: Verification

- `actionlint .github/workflows/ci.yml .github/workflows/security.yml`
- `rg -n "\\\\'" .github/workflows`
- `rg -n "releases/latest|api.github.com/repos/gitleaks|GITLEAKS_ASSET_URL|jq -r '.assets" .github/workflows/ci.yml .github/workflows/security.yml`
- `git diff --check`
- Downloaded `https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz`, confirmed it contains `gitleaks`, and verified the extracted binary is an ELF 64-bit x86-64 executable.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #860, milestone `1.11.0`, assignee `debop`
- PR: #870, head `156c25928348a64b93460ff69ef6fbdf3468d308`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/ci-gitleaks-auth-860`
- Labels: 없음
- State: `MERGED`, merge commit `c79218d27757db1e5ecf643aa0649ce0c910f0fd`
- CI: The CI `Secret Scan (gitleaks)` job failed before scanning because the installer / - Add `GITLEAKS_VERSION: 'v8.30.1'` to `CI` and `Security` workflow env blocks. / - Add lesson and review notes for the CI failure pattern and future version

## DoD Status

- Issue-first workflow: #860 inspected and fixed directly.
- Secret scan behavior preserved: no `gitleaks detect` flags were weakened or skipped.
- Deterministic install: no gitleaks `releases/latest` or unauthenticated gitleaks API lookup remains in CI/Security installers.
- Local workflow validation: `actionlint`, workflow escape guard, stale lookup guard, and `git diff --check` passed.
- CI validation: PR #870 checks passed, including `Secret Scan (gitleaks)` reaching success in run `28003967741`.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #870 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `c79218d27757db1e5ecf643aa0649ce0c910f0fd`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
