### PR TITLE
docs: make geo README examples consumer-runnable

### DIFF
--- a/docs/lessons/2026-06-23-issue-844-geo-readme-examples.md
+++ b/docs/lessons/2026-06-23-issue-844-geo-readme-examples.md
@@ -1,0 +1,27 @@
+# Issue 844 - geo README examples
+
+## Context
+
+`bluetape4k-geo` consolidated the former geocode, geohash, and geoip2 modules,
+but the English and Korean READMEs still documented the old
+`io.bluetape4k.geo.*` package hierarchy and non-existent helper types.
+
+The installation examples also exposed project-internal Gradle catalog symbols
+such as `Libs.feign_core`, which consumers cannot use in their own builds.
+
+## Decision
+
+Rewrite the README examples against the current public API:
+
+- `io.bluetape4k.geohash` factory and extension functions
+- `io.bluetape4k.geocode.google.GoogleAddressFinder`
+- `io.bluetape4k.geoip2.Geoip` plus `DatabaseReader` extension functions
+
+The installation block now uses Maven coordinates and concrete versions from the
+repository version catalog instead of internal `Libs.*` aliases.
+
+## Follow-up Guard
+
+Keep `README.md` and `README.ko.md` source-equivalent when geocode, geohash, or
+geoip2 public entry points move. The `GeoReadmeContractTest` blocks the stale
+package/API names that caused this issue.

--- a/docs/review/2026-06-23-issue-844-geo-readme-examples-review.md
+++ b/docs/review/2026-06-23-issue-844-geo-readme-examples-review.md
@@ -1,0 +1,27 @@
+# Issue 844 Review - geo README examples
+
+## Scope
+
+- `utils/geo/README.md`
+- `utils/geo/README.ko.md`
+- `utils/geo/src/test/kotlin/io/bluetape4k/geo/GeoReadmeContractTest.kt`
+
+## Review Notes
+
+- README examples now import the implemented public packages:
+  `io.bluetape4k.geohash`, `io.bluetape4k.geocode.*`, and
+  `io.bluetape4k.geoip2.*`.
+- The Google example uses `GoogleAddressFinder`, matching the implemented
+  reverse geocode abstraction.
+- The GeoIP2 example uses `Geoip.cityDatabase.tryFindCity`, matching the current
+  `DatabaseReader` extension API.
+- The installation examples no longer expose `Libs.*` catalog aliases.
+- English and Korean READMEs were updated with equivalent examples.
+
+## Verification
+
+- RED: `GeoReadmeContractTest` failed on stale `io.bluetape4k.geo.geohash`.
+- GREEN: `GeoReadmeContractTest` passed after README updates.
+- `./gradlew :bluetape4k-geo:compileKotlin :bluetape4k-geo:compileTestKotlin :bluetape4k-geo:test --no-build-cache`
+- `rg -n "io\\.bluetape4k\\.geo\\.(geohash|geocode|geoip2)|GoogleGeocoder|GeoIp2Support|Libs\\." utils/geo/README.md utils/geo/README.ko.md`
+- `git diff --check`

--- a/utils/geo/README.ko.md
+++ b/utils/geo/README.ko.md
@@ -47,18 +47,21 @@
 ### GeoHash 인코딩/디코딩
 
 ```kotlin
-import io.bluetape4k.geo.geohash.GeoHash
+import io.bluetape4k.geohash.geoHashOfString
+import io.bluetape4k.geohash.geoHashWithCharacters
+import io.bluetape4k.geohash.getAdjacent
 
 // 좌표 → GeoHash (9자리 정밀도)
-val hash = GeoHash.encode(latitude = 37.5665, longitude = 126.9780, precision = 9)
+val hash = geoHashWithCharacters(latitude = 37.5665, longitude = 126.9780, numberOfChars = 9)
+val base32 = hash.toBase32()
 // 예: "wydm9mufd"
 
 // GeoHash → 좌표
-val point = GeoHash.decode("wydm9mufd")
+val point = geoHashOfString(base32).originatingPoint
 println("lat=${point.latitude}, lon=${point.longitude}")
 
 // 이웃 GeoHash
-val neighbors = GeoHash.neighbors("wydm9mufd")
+val neighbors = hash.getAdjacent().map { it.toBase32() }
 ```
 
 `GeoHashCircleQuery` 제약:
@@ -76,32 +79,31 @@ export BING_GEOCODE_API_KEY="YOUR_BING_API_KEY"
 ```
 
 ```kotlin
-import io.bluetape4k.geo.geocode.google.GoogleGeocoder
+import io.bluetape4k.geocode.Geocode
+import io.bluetape4k.geocode.google.GoogleAddressFinder
 
-val geocoder = GoogleGeocoder(apiKey = "YOUR_API_KEY")
-
-// 주소 → 좌표
-val result = geocoder.geocode("서울특별시 중구 세종대로 110")
-println("lat=${result.latitude}, lon=${result.longitude}")
+val finder = GoogleAddressFinder(apiKey = System.getenv("GOOGLE_GEOCODE_API_KEY"))
 
 // 좌표 → 주소 (역지오코딩)
-val address = geocoder.reverseGeocode(latitude = 37.5665, longitude = 126.9780)
+val address = finder.findAddress(Geocode(37.5665, 126.9780), language = "ko")
+println("국가=${address?.country}, 도시=${address?.city}")
 ```
 
 ### GeoIP2
 
 ```kotlin
-import io.bluetape4k.geo.geoip2.GeoIp2Support
+import io.bluetape4k.geoip2.Geoip
+import io.bluetape4k.geoip2.tryFindCity
 import java.net.InetAddress
 
-// MaxMind GeoIP2 데이터베이스 경로 지정
-val reader = GeoIp2Support.cityReader("/path/to/GeoLite2-City.mmdb")
+// GeoLite2-City.mmdb 파일을 애플리케이션 classpath에 둡니다.
+val ipAddress = InetAddress.getByName("8.8.8.8")
+val cityResponse = Geoip.cityDatabase.tryFindCity(ipAddress).getOrNull()
 
-val cityResponse = reader.city(InetAddress.getByName("8.8.8.8"))
-println("국가: ${cityResponse.country.name}")
-println("도시: ${cityResponse.city.name}")
-println("위도: ${cityResponse.location.latitude}")
-println("경도: ${cityResponse.location.longitude}")
+println("국가: ${cityResponse?.country()?.name()}")
+println("도시: ${cityResponse?.city()?.name()}")
+println("위도: ${cityResponse?.location()?.latitude()}")
+println("경도: ${cityResponse?.location()?.longitude()}")
 ```
 
 ## 설치
@@ -113,10 +115,16 @@ dependencies {
     implementation("io.github.bluetape4k:bluetape4k-geo:${bluetape4kVersion}")
 
     // Geocode (Google Maps) 사용 시
+    implementation("io.github.bluetape4k:bluetape4k-feign:${bluetape4kVersion}")
+    implementation("io.github.bluetape4k:bluetape4k-jackson3:${bluetape4kVersion}")
+    implementation("io.github.bluetape4k:bluetape4k-resilience4j:${bluetape4kVersion}")
     implementation("com.google.maps:google-maps-services:2.2.0")
-    implementation(Libs.feign_core)
-    implementation(Libs.feign_kotlin)
-    implementation(Libs.feign_jackson)
+    implementation("io.github.openfeign:feign-core:13.12")
+    implementation("io.github.openfeign:feign-kotlin:13.12")
+    implementation("io.github.openfeign:feign-slf4j:13.12")
+    implementation("io.github.openfeign:feign-jackson:13.12")
+    implementation("org.apache.httpcomponents.client5:httpclient5:5.6.1")
+    implementation("org.apache.httpcomponents.client5:httpclient5-cache:5.6.1")
 
     // GeoIP2 사용 시
     implementation("com.maxmind.geoip2:geoip2:5.0.2")

--- a/utils/geo/README.md
+++ b/utils/geo/README.md
@@ -48,18 +48,21 @@ A unified module for geographic information processing. Provides Geocode, GeoHas
 ### GeoHash Encoding/Decoding
 
 ```kotlin
-import io.bluetape4k.geo.geohash.GeoHash
+import io.bluetape4k.geohash.geoHashOfString
+import io.bluetape4k.geohash.geoHashWithCharacters
+import io.bluetape4k.geohash.getAdjacent
 
 // Coordinates → GeoHash (precision 9)
-val hash = GeoHash.encode(latitude = 37.5665, longitude = 126.9780, precision = 9)
+val hash = geoHashWithCharacters(latitude = 37.5665, longitude = 126.9780, numberOfChars = 9)
+val base32 = hash.toBase32()
 // e.g. "wydm9mufd"
 
 // GeoHash → coordinates
-val point = GeoHash.decode("wydm9mufd")
+val point = geoHashOfString(base32).originatingPoint
 println("lat=${point.latitude}, lon=${point.longitude}")
 
 // Neighbor GeoHashes
-val neighbors = GeoHash.neighbors("wydm9mufd")
+val neighbors = hash.getAdjacent().map { it.toBase32() }
 ```
 
 `GeoHashCircleQuery` constraints:
@@ -77,32 +80,31 @@ export BING_GEOCODE_API_KEY="YOUR_BING_API_KEY"
 ```
 
 ```kotlin
-import io.bluetape4k.geo.geocode.google.GoogleGeocoder
+import io.bluetape4k.geocode.Geocode
+import io.bluetape4k.geocode.google.GoogleAddressFinder
 
-val geocoder = GoogleGeocoder(apiKey = "YOUR_API_KEY")
-
-// Address → coordinates
-val result = geocoder.geocode("Seoul City Hall, Jung-gu, Seoul")
-println("lat=${result.latitude}, lon=${result.longitude}")
+val finder = GoogleAddressFinder(apiKey = System.getenv("GOOGLE_GEOCODE_API_KEY"))
 
 // Coordinates → address (reverse geocoding)
-val address = geocoder.reverseGeocode(latitude = 37.5665, longitude = 126.9780)
+val address = finder.findAddress(Geocode(37.5665, 126.9780), language = "en")
+println("country=${address?.country}, city=${address?.city}")
 ```
 
 ### GeoIP2
 
 ```kotlin
-import io.bluetape4k.geo.geoip2.GeoIp2Support
+import io.bluetape4k.geoip2.Geoip
+import io.bluetape4k.geoip2.tryFindCity
 import java.net.InetAddress
 
-// Specify the path to the MaxMind GeoIP2 database
-val reader = GeoIp2Support.cityReader("/path/to/GeoLite2-City.mmdb")
+// Place GeoLite2-City.mmdb on the application classpath.
+val ipAddress = InetAddress.getByName("8.8.8.8")
+val cityResponse = Geoip.cityDatabase.tryFindCity(ipAddress).getOrNull()
 
-val cityResponse = reader.city(InetAddress.getByName("8.8.8.8"))
-println("Country: ${cityResponse.country.name}")
-println("City: ${cityResponse.city.name}")
-println("Latitude: ${cityResponse.location.latitude}")
-println("Longitude: ${cityResponse.location.longitude}")
+println("Country: ${cityResponse?.country()?.name()}")
+println("City: ${cityResponse?.city()?.name()}")
+println("Latitude: ${cityResponse?.location()?.latitude()}")
+println("Longitude: ${cityResponse?.location()?.longitude()}")
 ```
 
 ## Installation
@@ -114,10 +116,16 @@ dependencies {
     implementation("io.github.bluetape4k:bluetape4k-geo:${bluetape4kVersion}")
 
     // For Geocode (Google Maps)
+    implementation("io.github.bluetape4k:bluetape4k-feign:${bluetape4kVersion}")
+    implementation("io.github.bluetape4k:bluetape4k-jackson3:${bluetape4kVersion}")
+    implementation("io.github.bluetape4k:bluetape4k-resilience4j:${bluetape4kVersion}")
     implementation("com.google.maps:google-maps-services:2.2.0")
-    implementation(Libs.feign_core)
-    implementation(Libs.feign_kotlin)
-    implementation(Libs.feign_jackson)
+    implementation("io.github.openfeign:feign-core:13.12")
+    implementation("io.github.openfeign:feign-kotlin:13.12")
+    implementation("io.github.openfeign:feign-slf4j:13.12")
+    implementation("io.github.openfeign:feign-jackson:13.12")
+    implementation("org.apache.httpcomponents.client5:httpclient5:5.6.1")
+    implementation("org.apache.httpcomponents.client5:httpclient5-cache:5.6.1")
 
     // For GeoIP2
     implementation("com.maxmind.geoip2:geoip2:5.0.2")

--- a/utils/geo/src/test/kotlin/io/bluetape4k/geo/GeoReadmeContractTest.kt
+++ b/utils/geo/src/test/kotlin/io/bluetape4k/geo/GeoReadmeContractTest.kt
@@ -1,0 +1,51 @@
+package io.bluetape4k.geo
+
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.test.assertFalse
+
+class GeoReadmeContractTest {
+
+    @Test
+    fun `README examples use current public APIs and consumer coordinates`() {
+        readmeTexts().forEach { (filename, text) ->
+            forbiddenFragments.forEach { fragment ->
+                assertFalse(
+                    text.contains(fragment),
+                    "$filename must not contain stale or internal reference: $fragment",
+                )
+            }
+        }
+    }
+
+    private fun readmeTexts(): List<Pair<String, String>> =
+        listOf("README.md", "README.ko.md").map { filename ->
+            filename to findReadme(filename).readText()
+        }
+
+    private fun findReadme(filename: String): Path {
+        val cwd = Path.of("").toAbsolutePath()
+        return generateSequence(cwd) { it.parent }
+            .flatMap { path ->
+                sequenceOf(
+                    path.resolve("utils/geo").resolve(filename),
+                    path.resolve(filename),
+                )
+            }
+            .firstOrNull(Files::isRegularFile)
+            ?: error("Cannot find $filename from $cwd")
+    }
+
+    private companion object {
+        val forbiddenFragments = listOf(
+            "io.bluetape4k.geo.geohash",
+            "io.bluetape4k.geo.geocode",
+            "io.bluetape4k.geo.geoip2",
+            "GoogleGeocoder",
+            "GeoIp2Support",
+            "Libs.",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Closes #844

- PR 제목: docs: make geo README examples consumer-runnable

Fixes #844.

The consolidated `bluetape4k-geo` READMEs still showed old
`io.bluetape4k.geo.*` packages, non-existent helper types, and project-internal
`Libs.*` Gradle catalog aliases. This PR rewrites the English and Korean
examples against the current public APIs and adds a focused README contract test
to keep those stale references from returning.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Rewrite GeoHash examples to use `geoHashWithCharacters`, `geoHashOfString`,
  `toBase32`, and `getAdjacent`.
- Rewrite Google geocode examples to use `GoogleAddressFinder` with `Geocode`.
- Rewrite GeoIP2 examples to use `Geoip.cityDatabase.tryFindCity`.
- Replace `Libs.*` aliases with consumer-facing Maven coordinates.
- Add `GeoReadmeContractTest` to guard both READMEs against stale package names,
  removed helper names, and internal catalog aliases.
- Add lesson and review notes for the consolidated geo README contract.

### 기존 섹션: Verification

- RED: `GeoReadmeContractTest` failed on stale `io.bluetape4k.geo.geohash`.
- GREEN: `GeoReadmeContractTest` passed after README updates.
- `./gradlew :bluetape4k-geo:compileKotlin :bluetape4k-geo:compileTestKotlin :bluetape4k-geo:test --no-build-cache`
- `rg -n "io\\.bluetape4k\\.geo\\.(geohash|geocode|geoip2)|GoogleGeocoder|GeoIp2Support|Libs\\." utils/geo/README.md utils/geo/README.ko.md`
- `git diff --check`

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #844, milestone `1.11.0`, assignee `debop`
- PR: #871, head `2d9c2eadd57436e1ef36a8f09ca16484f1088646`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/geo-readme-examples-844`
- Labels: 없음
- State: `MERGED`, merge commit `6740cb6fbfcf35201be30879e72b3a2d420a28b5`
- CI: `Libs.*` Gradle catalog aliases. This PR rewrites the English and Korean / - Rewrite GeoIP2 examples to use `Geoip.cityDatabase.tryFindCity`. / - Replace `Libs.*` aliases with consumer-facing Maven coordinates.

## DoD Status

- Issue-first workflow: #844 inspected and fixed directly.
- README parity: English and Korean READMEs updated with source-equivalent examples.
- Consumer-runnable API surface: examples now reference implemented public packages and entry points.
- Internal alias cleanup: `Libs.*` removed from consumer-facing installation guidance.
- Regression guard: `GeoReadmeContractTest` added and passing.
- Local verification: targeted RED/GREEN, full `bluetape4k-geo` compile/test, stale-reference guard, and `git diff --check` passed.
- CI validation: PR #871 checks passed in run `28004579921`; module test matrix was skipped by changed-module detection.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #871 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `6740cb6fbfcf35201be30879e72b3a2d420a28b5`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
