### PR TITLE
testcontainers: align HTTP mock property keys

### DIFF
--- a/docs/lessons/2026-06-23-issue-843-http-server-property-keys.md
+++ b/docs/lessons/2026-06-23-issue-843-http-server-property-keys.md
@@ -1,0 +1,26 @@
+# Issue 843 - BluetapeHttpServer property keys
+
+## Context
+
+`PropertyExportingServer` defines exported system property keys as lowercase
+kebab-case under `testcontainers.{propertyNamespace}.{key}`.
+
+`BluetapeWebfluxServer` already followed this contract with `httpbin-url`,
+`jsonplaceholder-url`, and `web-url`, but `BluetapeHttpServer` exposed the
+same values as `httpbinUrl`, `jsonplaceholderUrl`, and `webUrl`.
+
+## Decision
+
+Make `BluetapeHttpServer.propertyKeys()` return only the canonical kebab-case
+keys used by the shared export contract.
+
+`properties()` now writes canonical kebab-case entries and uses
+`withCompatKeys` to keep the previous camelCase keys as compatibility aliases
+for existing downstream tests.
+
+## Follow-up Guard
+
+Keep public README placeholders aligned with `PropertyExportingServer`.
+`PropertyExportingServerContractTest` now includes both mock HTTP server
+wrappers so future divergence between `BluetapeHttpServer` and
+`BluetapeWebfluxServer` fails without starting Docker.

--- a/docs/review/2026-06-23-issue-843-http-server-property-keys-review.md
+++ b/docs/review/2026-06-23-issue-843-http-server-property-keys-review.md
@@ -1,0 +1,30 @@
+# Issue 843 Review - BluetapeHttpServer property keys
+
+## Scope
+
+- `testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeHttpServer.kt`
+- `testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/PropertyExportingServerContractTest.kt`
+- `testing/testcontainers/README.md`
+- `testing/testcontainers/README.ko.md`
+
+## Review Notes
+
+- `BluetapeHttpServer.propertyKeys()` now matches the canonical mock HTTP key
+  set used by `BluetapeWebfluxServer`.
+- `BluetapeHttpServer.properties()` keeps old camelCase keys through
+  `withCompatKeys`, while the documented and contract-tested keys are
+  kebab-case.
+- English and Korean README property tables and Spring Boot placeholders now
+  use `testcontainers.bluetape-http.httpbin-url`,
+  `testcontainers.bluetape-http.jsonplaceholder-url`, and
+  `testcontainers.bluetape-http.web-url`.
+- The regression test constructs the server wrappers without calling `start()`,
+  so it verifies the key contract without depending on Docker image builds.
+
+## Verification
+
+- RED: `PropertyExportingServerContractTest.mock HTTP server propertyKeys expose canonical kebab-case keys` failed on the old camelCase keys.
+- GREEN: `PropertyExportingServerContractTest` passed after the key change.
+- `./gradlew :bluetape4k-testcontainers:compileKotlin :bluetape4k-testcontainers:compileTestKotlin :bluetape4k-testcontainers:test --tests "io.bluetape4k.testcontainers.PropertyExportingServerContractTest" --no-build-cache`
+- `rg -n 'testcontainers\\.bluetape-http\\.(httpbinUrl|jsonplaceholderUrl|webUrl)|\`httpbinUrl\`, \`jsonplaceholderUrl\`, \`webUrl\`' testing/testcontainers/README.md testing/testcontainers/README.ko.md`
+- `git diff --check`

--- a/testing/testcontainers/README.ko.md
+++ b/testing/testcontainers/README.ko.md
@@ -87,7 +87,7 @@ Testcontainers `2.0.3` 기반 통합 테스트를 빠르게 구성하기 위한 
 | NginxServer           | `nginx`            | `host`, `port`, `url`                                                               |
 | ChromaDBServer        | `chromadb`         | `host`, `port`, `url`                                                               |
 | OllamaServer          | `ollama`           | `host`, `port`, `url`                                                               |
-| BluetapeHttpServer    | `bluetape-http`    | `host`, `port`, `url`, `httpbinUrl`, `jsonplaceholderUrl`, `webUrl`, `https-port`, `https-url`, `https-httpbin-url`, `https-jsonplaceholder-url`, `https-web-url` |
+| BluetapeHttpServer    | `bluetape-http`    | `host`, `port`, `url`, `httpbin-url`, `jsonplaceholder-url`, `web-url`, `https-port`, `https-url`, `https-httpbin-url`, `https-jsonplaceholder-url`, `https-web-url` |
 | BluetapeWebfluxServer | `bluetape-webflux` | `host`, `port`, `url`, `httpbin-url`, `jsonplaceholder-url`, `web-url`, `https-port`, `https-url`, `https-httpbin-url`, `https-jsonplaceholder-url`, `https-web-url` |
 
 ## 사용 예
@@ -184,9 +184,9 @@ val webUrl              = server.webUrl             // http://host:<port>/web
 | `testcontainers.bluetape-http.host`               | `localhost`                             |
 | `testcontainers.bluetape-http.port`               | `<동적>`                                  |
 | `testcontainers.bluetape-http.url`                | `http://localhost:<동적>`                 |
-| `testcontainers.bluetape-http.httpbinUrl`         | `http://localhost:<동적>/httpbin`         |
-| `testcontainers.bluetape-http.jsonplaceholderUrl` | `http://localhost:<동적>/jsonplaceholder` |
-| `testcontainers.bluetape-http.webUrl`             | `http://localhost:<동적>/web`             |
+| `testcontainers.bluetape-http.httpbin-url`        | `http://localhost:<동적>/httpbin`         |
+| `testcontainers.bluetape-http.jsonplaceholder-url` | `http://localhost:<동적>/jsonplaceholder` |
+| `testcontainers.bluetape-http.web-url`            | `http://localhost:<동적>/web`             |
 
 #### Spring Boot `application-test.yml`
 
@@ -194,8 +194,8 @@ val webUrl              = server.webUrl             // http://host:<port>/web
 mock:
   server:
     url: ${testcontainers.bluetape-http.url}
-    httpbin-url: ${testcontainers.bluetape-http.httpbinUrl}
-    jsonplaceholder-url: ${testcontainers.bluetape-http.jsonplaceholderUrl}
+    httpbin-url: ${testcontainers.bluetape-http.httpbin-url}
+    jsonplaceholder-url: ${testcontainers.bluetape-http.jsonplaceholder-url}
 ```
 
 #### 수동 인스턴스 (싱글턴 미사용)

--- a/testing/testcontainers/README.md
+++ b/testing/testcontainers/README.md
@@ -82,7 +82,7 @@ Every server implements
 | NginxServer           | `nginx`            | `host`, `port`, `url`                                                               |
 | ChromaDBServer        | `chromadb`         | `host`, `port`, `url`                                                               |
 | OllamaServer          | `ollama`           | `host`, `port`, `url`                                                               |
-| BluetapeHttpServer    | `bluetape-http`    | `host`, `port`, `url`, `httpbinUrl`, `jsonplaceholderUrl`, `webUrl`, `https-port`, `https-url`, `https-httpbin-url`, `https-jsonplaceholder-url`, `https-web-url` |
+| BluetapeHttpServer    | `bluetape-http`    | `host`, `port`, `url`, `httpbin-url`, `jsonplaceholder-url`, `web-url`, `https-port`, `https-url`, `https-httpbin-url`, `https-jsonplaceholder-url`, `https-web-url` |
 | BluetapeWebfluxServer | `bluetape-webflux` | `host`, `port`, `url`, `httpbin-url`, `jsonplaceholder-url`, `web-url`, `https-port`, `https-url`, `https-httpbin-url`, `https-jsonplaceholder-url`, `https-web-url` |
 
 ## Usage Examples
@@ -177,9 +177,9 @@ After `start()`, the following system properties are registered automatically:
 | `testcontainers.bluetape-http.host`               | `localhost`                                  |
 | `testcontainers.bluetape-http.port`               | `<dynamic>`                                  |
 | `testcontainers.bluetape-http.url`                | `http://localhost:<dynamic>`                 |
-| `testcontainers.bluetape-http.httpbinUrl`         | `http://localhost:<dynamic>/httpbin`         |
-| `testcontainers.bluetape-http.jsonplaceholderUrl` | `http://localhost:<dynamic>/jsonplaceholder` |
-| `testcontainers.bluetape-http.webUrl`             | `http://localhost:<dynamic>/web`             |
+| `testcontainers.bluetape-http.httpbin-url`        | `http://localhost:<dynamic>/httpbin`         |
+| `testcontainers.bluetape-http.jsonplaceholder-url` | `http://localhost:<dynamic>/jsonplaceholder` |
+| `testcontainers.bluetape-http.web-url`            | `http://localhost:<dynamic>/web`             |
 
 #### Spring Boot `application-test.yml`
 
@@ -187,8 +187,8 @@ After `start()`, the following system properties are registered automatically:
 mock:
   server:
     url: ${testcontainers.bluetape-http.url}
-    httpbin-url: ${testcontainers.bluetape-http.httpbinUrl}
-    jsonplaceholder-url: ${testcontainers.bluetape-http.jsonplaceholderUrl}
+    httpbin-url: ${testcontainers.bluetape-http.httpbin-url}
+    jsonplaceholder-url: ${testcontainers.bluetape-http.jsonplaceholder-url}
 ```
 
 #### Manual instance (non-singleton)

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeHttpServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeHttpServer.kt
@@ -7,6 +7,7 @@ import io.bluetape4k.testcontainers.GenericServer
 import io.bluetape4k.testcontainers.PropertyExportingServer
 import io.bluetape4k.testcontainers.exposeCustomPorts
 import io.bluetape4k.testcontainers.http.BluetapeHttpServer.Launcher.bluetapeHttpServer
+import io.bluetape4k.testcontainers.withCompatKeys
 import io.bluetape4k.utils.ShutdownQueue
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.wait.strategy.Wait
@@ -151,12 +152,12 @@ class BluetapeHttpServer private constructor(
      *
      * ```kotlin
      * val keys = server.propertyKeys()
-     * // keys == setOf("host", "port", "url", "httpbinUrl", "jsonplaceholderUrl", "webUrl")
+     * // keys == setOf("host", "port", "url", "httpbin-url", "jsonplaceholder-url", "web-url")
      * ```
      */
     override fun propertyKeys(): Set<String> =
         setOf(
-            "host", "port", "url", "httpbinUrl", "jsonplaceholderUrl", "webUrl",
+            "host", "port", "url", "httpbin-url", "jsonplaceholder-url", "web-url",
             "https-port", "https-url", "https-httpbin-url", "https-jsonplaceholder-url", "https-web-url",
         )
 
@@ -165,21 +166,27 @@ class BluetapeHttpServer private constructor(
      *
      * ```kotlin
      * val props = server.properties()
-     * // props["httpbinUrl"] == "http://localhost:80/httpbin"
+     * // props["httpbin-url"] == "http://localhost:80/httpbin"
      * ```
      */
     override fun properties(): Map<String, String> = mapOf(
         "host" to host,
         "port" to port.toString(),
         "url" to url,
-        "httpbinUrl" to httpbinUrl,
-        "jsonplaceholderUrl" to jsonplaceholderUrl,
-        "webUrl" to webUrl,
+        "httpbin-url" to httpbinUrl,
+        "jsonplaceholder-url" to jsonplaceholderUrl,
+        "web-url" to webUrl,
         "https-port" to httpsPort.toString(),
         "https-url" to httpsUrl,
         "https-httpbin-url" to httpsHttpbinUrl,
         "https-jsonplaceholder-url" to httpsJsonplaceholderUrl,
         "https-web-url" to httpsWebUrl,
+    ).withCompatKeys(
+        mapOf(
+            "httpbin-url" to "httpbinUrl",
+            "jsonplaceholder-url" to "jsonplaceholderUrl",
+            "web-url" to "webUrl",
+        )
     )
 
     init {

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/PropertyExportingServerContractTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/PropertyExportingServerContractTest.kt
@@ -7,6 +7,8 @@ import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.testcontainers.http.BluetapeHttpServer
+import io.bluetape4k.testcontainers.http.BluetapeWebfluxServer
 import org.junit.jupiter.api.Test
 
 /**
@@ -105,6 +107,27 @@ class PropertyExportingServerContractTest {
     }
 
     /**
+     * Mock HTTP 서버들은 공통 export 계약과 동일한 canonical kebab-case 키를 노출합니다.
+     */
+    @Test
+    fun `mock HTTP server propertyKeys expose canonical kebab-case keys`() {
+        val expectedKeys = setOf(
+            "host", "port", "url", "httpbin-url", "jsonplaceholder-url", "web-url",
+            "https-port", "https-url", "https-httpbin-url", "https-jsonplaceholder-url", "https-web-url",
+        )
+
+        val servers = listOf(
+            BluetapeHttpServer(),
+            BluetapeWebfluxServer(),
+        )
+
+        servers.forEach { server ->
+            server.propertyKeys() shouldBeEqualTo expectedKeys
+            server.propertyKeys().any { it in setOf("httpbinUrl", "jsonplaceholderUrl", "webUrl") }.shouldBeFalse()
+        }
+    }
+
+    /**
      * [PropertyExportingServer.registerSystemProperties]는 [AutoCloseable]을 반환합니다.
      * close() 호출 시 예외가 발생하지 않아야 합니다.
      */
@@ -187,6 +210,7 @@ class PropertyExportingServerContractTest {
             "io.bluetape4k.testcontainers.mq.RabbitMQServer",
             "io.bluetape4k.testcontainers.database.MySQL8Server",
             "io.bluetape4k.testcontainers.database.MariaDBServer",
+            "io.bluetape4k.testcontainers.http.BluetapeHttpServer",
             "io.bluetape4k.testcontainers.http.BluetapeWebfluxServer",
         )
 


### PR DESCRIPTION
## Summary

Closes #843

- PR 제목: testcontainers: align HTTP mock property keys

- Align `BluetapeHttpServer` exported property keys with the shared kebab-case `PropertyExportingServer` contract.
- Keep the previous camelCase keys as compatibility aliases through `withCompatKeys`.
- Update English and Korean README placeholders and add a Docker-free contract regression test.

Closes #843.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- `BluetapeHttpServer.propertyKeys()` now returns `httpbin-url`, `jsonplaceholder-url`, and `web-url`.
- `BluetapeHttpServer.properties()` writes canonical kebab-case keys plus `httpbinUrl`, `jsonplaceholderUrl`, and `webUrl` compatibility aliases.
- `PropertyExportingServerContractTest` now covers both `BluetapeHttpServer` and `BluetapeWebfluxServer` without starting containers.
- README English/Korean property tables and Spring Boot placeholders now match the canonical system property contract.
- Added issue lesson and review notes under `docs/`.

### 기존 섹션: Verification

- RED: `PropertyExportingServerContractTest.mock HTTP server propertyKeys expose canonical kebab-case keys` failed on the old camelCase keys.
- GREEN: `./gradlew :bluetape4k-testcontainers:compileKotlin :bluetape4k-testcontainers:compileTestKotlin :bluetape4k-testcontainers:test --tests "io.bluetape4k.testcontainers.PropertyExportingServerContractTest" --no-build-cache`
- README stale-key guard:
  ```bash
  rg -n 'testcontainers\\.bluetape-http\\.(httpbinUrl|jsonplaceholderUrl|webUrl)|`httpbinUrl`, `jsonplaceholderUrl`, `webUrl`' testing/testcontainers/README.md testing/testcontainers/README.ko.md
  ```
- `git diff --cached --check`

Full `:bluetape4k-testcontainers:test` was not run because #842 tracks the clean mock-webflux dependency graph path that can affect the full module test task.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #843, milestone `1.11.0`, assignee `debop`
- PR: #872, head `eb5de94685e343f5ac94a826c9c52944b8c98a34`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/http-server-property-keys-843`
- Labels: 없음
- State: `MERGED`, merge commit `b32cc4f7b96721e37ae7576bcdb0744cfaa0bcbf`
- CI: - GREEN: `./gradlew :bluetape4k-testcontainers:compileKotlin :bluetape4k-testcontainers:compileTestKotlin :bluetape4k-testcontainers:test --tests "io.bluetape4k.testcontainers.PropertyExportingServerContractTest" --no-build-cache`

## DoD Status

- [x] Issue #843 implementation complete.
- [x] Regression test added and verified RED/GREEN.
- [x] Compile and targeted contract test passed.
- [x] README English/Korean placeholders updated.
- [x] Lesson and review notes added.
- [x] GitHub Actions passed.
- [x] Merged to `develop`.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #872 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `b32cc4f7b96721e37ae7576bcdb0744cfaa0bcbf`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
