### PR TITLE
docs: align mock-webflux endpoint table

### DIFF
--- a/docs/lessons/2026-06-23-issue-841-mock-webflux-readme-routes.md
+++ b/docs/lessons/2026-06-23-issue-841-mock-webflux-readme-routes.md
@@ -1,0 +1,22 @@
+# Issue 841 - mock-webflux README routes
+
+## Context
+
+`testing/mock-webflux-server` README files listed several httpbin/admin
+endpoints that were not implemented by the WebFlux controllers. Consumers using
+the README as an integration-test contract could call those routes and receive
+404 responses.
+
+## Decision
+
+Keep the implemented route surface unchanged and remove README-only endpoint
+rows from both locales.
+
+The removed rows were `/admin/info`, `/httpbin/stream-bytes/{n}`,
+`/httpbin/drip`, `/httpbin/sse`, `/httpbin/brotli`, `/httpbin/html`,
+`/httpbin/xml`, `/httpbin/json`, `/httpbin/robots.txt`, and `/httpbin/deny`.
+
+## Follow-up Guard
+
+`ReadmeRouteContractTest` now blocks those stale routes from returning to the
+README endpoint tables unless matching WebFlux controller mappings are added.

--- a/docs/review/2026-06-23-issue-841-mock-webflux-readme-routes-review.md
+++ b/docs/review/2026-06-23-issue-841-mock-webflux-readme-routes-review.md
@@ -1,0 +1,24 @@
+# Issue 841 Review - mock-webflux README routes
+
+## Scope
+
+- `testing/mock-webflux-server/README.md`
+- `testing/mock-webflux-server/README.ko.md`
+- `testing/mock-webflux-server/src/test/kotlin/io/bluetape4k/mockwebflux/ReadmeRouteContractTest.kt`
+
+## Review Notes
+
+- README endpoint tables now describe only implemented mock-webflux routes.
+- English and Korean README tables were changed equivalently.
+- `/httpbin/json` was also removed after checking controller annotations; it
+  was README-only even though the issue body did not list it explicitly.
+- The new test is file-based and does not start a Spring context, so it gives a
+  fast regression signal for stale README endpoint rows.
+
+## Verification
+
+- RED: `ReadmeRouteContractTest` failed while README files still listed stale routes.
+- GREEN: `ReadmeRouteContractTest` passed after README cleanup.
+- `./gradlew :bluetape4k-mock-webflux-server:compileKotlin :bluetape4k-mock-webflux-server:compileTestKotlin :bluetape4k-mock-webflux-server:test --no-build-cache`
+- `rg -n '/admin/info|/httpbin/(stream-bytes/\\{n\\}|drip|sse|brotli|html|xml|json|robots\\.txt|deny)' testing/mock-webflux-server/README.md testing/mock-webflux-server/README.ko.md`
+- `git diff --check`

--- a/testing/mock-webflux-server/README.ko.md
+++ b/testing/mock-webflux-server/README.ko.md
@@ -113,7 +113,6 @@ dependencies {
 |--------|----------------|------------------------------------|
 | `GET`  | `/ping`        | 헬스 체크 — `pong` 반환                  |
 | `POST` | `/admin/reset` | 인메모리 Fixture 데이터를 클래스패스 JSON에서 재적재 |
-| `GET`  | `/admin/info`  | 서버 정보 반환                           |
 
 #### `/httpbin/**`
 
@@ -133,18 +132,9 @@ dependencies {
 | `GET`    | `/httpbin/bytes/{n}`        | `n` 바이트의 랜덤 바이너리 반환                  |
 | `GET`    | `/httpbin/delay/{seconds}`  | 지연 후 응답 (`0.5` = 500ms, 범위 0.0–10.0) |
 | `GET`    | `/httpbin/stream/{n}`       | `Flow`로 JSON 라인 `n`개 스트리밍            |
-| `GET`    | `/httpbin/stream-bytes/{n}` | 랜덤 바이트 `n`개 스트리밍                     |
-| `GET`    | `/httpbin/drip`             | 지연 드립 스트리밍                           |
-| `GET`    | `/httpbin/sse`              | Server-Sent Events 스트림               |
 | `GET`    | `/httpbin/image/{format}`   | 샘플 이미지 반환 (png/jpeg/svg/webp)        |
 | `GET`    | `/httpbin/gzip`             | gzip 인코딩 응답                          |
 | `GET`    | `/httpbin/deflate`          | deflate 인코딩 응답                       |
-| `GET`    | `/httpbin/brotli`           | brotli 인코딩 응답                        |
-| `GET`    | `/httpbin/html`             | 샘플 HTML 반환                           |
-| `GET`    | `/httpbin/xml`              | 샘플 XML 반환                            |
-| `GET`    | `/httpbin/json`             | 샘플 JSON 반환                           |
-| `GET`    | `/httpbin/robots.txt`       | robots.txt 반환                        |
-| `GET`    | `/httpbin/deny`             | 403 Forbidden 반환                     |
 
 #### `/jsonplaceholder/**`
 

--- a/testing/mock-webflux-server/README.md
+++ b/testing/mock-webflux-server/README.md
@@ -116,7 +116,6 @@ dependencies {
 |--------|----------------|--------------------------------------------------------------|
 | `GET`  | `/ping`        | Health check — returns `pong`                                |
 | `POST` | `/admin/reset` | Reloads all in-memory fixture data from classpath JSON files |
-| `GET`  | `/admin/info`  | Returns server info                                          |
 
 #### `/httpbin/**`
 
@@ -136,18 +135,9 @@ dependencies {
 | `GET`    | `/httpbin/bytes/{n}`        | Returns `n` random bytes                                |
 | `GET`    | `/httpbin/delay/{seconds}`  | Responds after a delay (`0.5` = 500 ms, range 0.0–10.0) |
 | `GET`    | `/httpbin/stream/{n}`       | Streams `n` JSON lines via `Flow`                       |
-| `GET`    | `/httpbin/stream-bytes/{n}` | Streams `n` random bytes                                |
-| `GET`    | `/httpbin/drip`             | Drip-feeds bytes with configurable delay                |
-| `GET`    | `/httpbin/sse`              | Server-Sent Events stream                               |
 | `GET`    | `/httpbin/image/{format}`   | Returns a sample image (png/jpeg/svg/webp)              |
 | `GET`    | `/httpbin/gzip`             | Returns gzip-encoded response                           |
 | `GET`    | `/httpbin/deflate`          | Returns deflate-encoded response                        |
-| `GET`    | `/httpbin/brotli`           | Returns brotli-encoded response                         |
-| `GET`    | `/httpbin/html`             | Returns sample HTML                                     |
-| `GET`    | `/httpbin/xml`              | Returns sample XML                                      |
-| `GET`    | `/httpbin/json`             | Returns sample JSON                                     |
-| `GET`    | `/httpbin/robots.txt`       | Returns robots.txt                                      |
-| `GET`    | `/httpbin/deny`             | Returns 403 Forbidden                                   |
 
 #### `/jsonplaceholder/**`
 

--- a/testing/mock-webflux-server/src/test/kotlin/io/bluetape4k/mockwebflux/ReadmeRouteContractTest.kt
+++ b/testing/mock-webflux-server/src/test/kotlin/io/bluetape4k/mockwebflux/ReadmeRouteContractTest.kt
@@ -1,0 +1,53 @@
+package io.bluetape4k.mockwebflux
+
+import io.bluetape4k.assertions.shouldBeFalse
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+
+/**
+ * README endpoint rows must describe implemented mock-webflux routes only.
+ */
+class ReadmeRouteContractTest {
+
+    @Test
+    fun `README endpoint tables do not list unimplemented mock-webflux routes`() {
+        val staleRoutes = listOf(
+            "/admin/info",
+            "/httpbin/stream-bytes/{n}",
+            "/httpbin/drip",
+            "/httpbin/sse",
+            "/httpbin/brotli",
+            "/httpbin/html",
+            "/httpbin/xml",
+            "/httpbin/json",
+            "/httpbin/robots.txt",
+            "/httpbin/deny",
+        )
+
+        readmeFiles().forEach { readme ->
+            val content = readme.readText()
+
+            staleRoutes.forEach { route ->
+                content.contains(route).shouldBeFalse()
+            }
+        }
+    }
+
+    private fun readmeFiles(): List<Path> {
+        val candidates = listOf(
+            Path.of("README.md"),
+            Path.of("README.ko.md"),
+            Path.of("testing/mock-webflux-server/README.md"),
+            Path.of("testing/mock-webflux-server/README.ko.md"),
+        ).filter { it.exists() }
+
+        check(candidates.isNotEmpty()) {
+            "mock-webflux README files were not found from ${Path.of("").toAbsolutePath()}"
+        }
+
+        return candidates.filter { Files.isRegularFile(it) }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #841

- PR 제목: docs: align mock-webflux endpoint table

- Remove mock-webflux README endpoint rows that do not have WebFlux controller mappings.
- Keep English and Korean README endpoint tables source-equivalent.
- Add a fast README route contract test so stale README-only routes cannot return silently.

Closes #841.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Removed README-only routes:
  - `/admin/info`
  - `/httpbin/stream-bytes/{n}`
  - `/httpbin/drip`
  - `/httpbin/sse`
  - `/httpbin/brotli`
  - `/httpbin/html`
  - `/httpbin/xml`
  - `/httpbin/json`
  - `/httpbin/robots.txt`
  - `/httpbin/deny`
- Added `ReadmeRouteContractTest`, which reads the README files without starting Spring and blocks those stale rows.
- Added issue lesson and review notes under `docs/`.

### 기존 섹션: Verification

- RED: `ReadmeRouteContractTest` failed while README files still listed stale routes.
- GREEN: `ReadmeRouteContractTest` passed after README cleanup.
- `./gradlew :bluetape4k-mock-webflux-server:compileKotlin :bluetape4k-mock-webflux-server:compileTestKotlin :bluetape4k-mock-webflux-server:test --no-build-cache`
- Stale route guard:
  ```bash
  rg -n '/admin/info|/httpbin/(stream-bytes/\{n\}|drip|sse|brotli|html|xml|json|robots\.txt|deny)' testing/mock-webflux-server/README.md testing/mock-webflux-server/README.ko.md
  ```
- `git diff --cached --check`

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #841, milestone `1.11.0`, assignee `debop`
- PR: #873, head `fddd2940e0d528a233732f00ccd3bdff43fde279`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/mock-webflux-readme-routes-841`
- Labels: 없음
- State: `MERGED`, merge commit `7b6482cefbfcda80a1b6b475c9dabf83893d776b`
- CI: - `./gradlew :bluetape4k-mock-webflux-server:compileKotlin :bluetape4k-mock-webflux-server:compileTestKotlin :bluetape4k-mock-webflux-server:test --no-build-cache`

## DoD Status

- [x] Issue #841 implementation complete.
- [x] README English/Korean endpoint tables updated.
- [x] Regression test added and verified RED/GREEN.
- [x] Mock-webflux compile/test command passed.
- [x] Lesson and review notes added.
- [x] GitHub Actions passed.
- [x] Merged to `develop`.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #873 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `7b6482cefbfcda80a1b6b475c9dabf83893d776b`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
