### PR TITLE
docs: correct mock web HTTPS port

### DIFF
--- a/docs/lessons/2026-06-23-issue-840-mock-web-server-https-port.md
+++ b/docs/lessons/2026-06-23-issue-840-mock-web-server-https-port.md
@@ -1,0 +1,18 @@
+# Issue 840 - mock-web-server HTTPS port
+
+## Context
+
+`testing/mock-web-server` runtime configuration uses HTTPS port `8443` and the
+Jib container metadata exposes ports `80` and `8443`, but both README locales
+still documented HTTPS port `443`.
+
+## Decision
+
+Update the English and Korean READMEs to document `8443` consistently in the
+architecture text, feature list, configuration table, and Docker run command.
+
+## Follow-up Guard
+
+`ReadmeHttpsPortContractTest` now checks that README HTTPS documentation matches
+`application.yml` and the Jib port list, while blocking stale standalone `443`
+documentation patterns.

--- a/docs/review/2026-06-23-issue-840-mock-web-server-https-port-review.md
+++ b/docs/review/2026-06-23-issue-840-mock-web-server-https-port-review.md
@@ -1,0 +1,25 @@
+# Issue 840 Review - mock-web-server HTTPS port
+
+## Scope
+
+- `testing/mock-web-server/README.md`
+- `testing/mock-web-server/README.ko.md`
+- `testing/mock-web-server/src/test/kotlin/io/bluetape4k/mockserver/ReadmeHttpsPortContractTest.kt`
+
+## Review Notes
+
+- README English and Korean now document HTTPS port `8443`, matching
+  `bluetape4k.https.port`.
+- Docker examples now map `8443:8443`, matching the Jib container port list.
+- The regression test reads runtime config, build metadata, and both README
+  files without starting Spring.
+- The test blocks standalone stale `443` documentation while allowing the
+  correct `8443` value.
+
+## Verification
+
+- RED: `ReadmeHttpsPortContractTest` failed while README files documented `443`.
+- GREEN: `ReadmeHttpsPortContractTest` passed after README updates.
+- `./gradlew :bluetape4k-mock-web-server:compileKotlin :bluetape4k-mock-web-server:compileTestKotlin :bluetape4k-mock-web-server:test --no-build-cache`
+- `rg -n '\\*\\*443\\*\\*|(^|[^0-9])443\\s*\\(HTTPS\\)|\`443\`|-p 443:443' testing/mock-web-server/README.md testing/mock-web-server/README.ko.md`
+- `git diff --check`

--- a/testing/mock-web-server/README.ko.md
+++ b/testing/mock-web-server/README.ko.md
@@ -8,7 +8,7 @@
 
 ## 아키텍처
 
-`bluetape4k-mock-web-server`는 포트 **80**(HTTP) / **443**(HTTPS)에서 실행되는 Spring Boot 4 MVC 애플리케이션입니다.
+`bluetape4k-mock-web-server`는 포트 **80**(HTTP) / **8443**(HTTPS)에서 실행되는 Spring Boot 4 MVC 애플리케이션입니다.
 `spring.threads.virtual.enabled=true` 설정으로 JDK 21+ Virtual Threads를 사용해 OS 스레드를 블로킹하지 않고 고동시성 요청을 처리합니다. 모든 Fixture 데이터는 클래스패스 JSON 파일에서 로드되어 인메모리에 저장되며, 제네릭
 `InMemoryRepository<T>`를 통해 `JsonplaceholderService`가 관리합니다. 정적 HTML 콘텐츠는 Caffeine 캐시를 사용하는
 `WebContentLoader`를 통해 제공됩니다.
@@ -38,7 +38,7 @@
 ## 기능
 
 - **Spring Boot 4 + Virtual Threads**: JDK 21+ Virtual Threads(`spring.threads.virtual.enabled=true`)로 고동시성 요청 처리
-- **포트 80(HTTP) / 443(HTTPS)**: 결정론적 테스트 구성을 위한 표준 컨테이너 포트
+- **포트 80(HTTP) / 8443(HTTPS)**: 결정론적 테스트 구성을 위한 표준 컨테이너 포트
 - **httpbin 시뮬레이션**: `/httpbin/**`에서 HTTP 요청 검사 전체 API 제공 — 요청 에코, 헤더/IP/UUID 반환, 스트리밍, 지연, 이미지
 - **jsonplaceholder 시뮬레이션**: `/jsonplaceholder/**`에서 6개 전체 CRUD 리소스 (posts/comments/albums/photos/todos/users)
 - **웹 콘텐츠 Fixture**: Caffeine 캐시를 통한 `/web/{name}` HTML 콘텐츠
@@ -53,7 +53,7 @@
 | 키                                | 값                                               | 설명                          |
 |----------------------------------|-------------------------------------------------|-----------------------------|
 | `server.port`                    | `80`                                            | HTTP 컨테이너 포트                |
-| `bluetape4k.https.port`          | `443`                                           | HTTPS 컨테이너 포트               |
+| `bluetape4k.https.port`          | `8443`                                          | HTTPS 컨테이너 포트               |
 | `server.http2.enabled`           | `true`                                          | HTTP/2 지원                   |
 | `server.tomcat.threads.max`      | `16000`                                         | 최대 플랫폼 스레드 수 (고동시성 벤치마크 지원) |
 | `server.tomcat.max-connections`  | `16000`                                         | 최대 동시 연결 수                  |
@@ -67,7 +67,7 @@
 ### Docker로 실행
 
 ```bash
-docker run --rm -p 80:80 -p 443:443 bluetape4k/mock-web-server:latest
+docker run --rm -p 80:80 -p 8443:8443 bluetape4k/mock-web-server:latest
 ```
 
 ### Jib으로 Docker 이미지 빌드

--- a/testing/mock-web-server/README.md
+++ b/testing/mock-web-server/README.md
@@ -8,7 +8,7 @@ A self-contained Spring Boot 4 + Virtual Threads HTTP mock server that replaces 
 
 ## Architecture
 
-`bluetape4k-mock-web-server` is a Spring Boot 4 MVC application that runs on port **80** (HTTP) / **443** (HTTPS). It uses Virtual Threads
+`bluetape4k-mock-web-server` is a Spring Boot 4 MVC application that runs on port **80** (HTTP) / **8443** (HTTPS). It uses Virtual Threads
 (`spring.threads.virtual.enabled=true`) for high-concurrency handling without blocking OS threads. All fixture data is stored in-memory (loaded from classpath JSON files) and managed by
 `JsonplaceholderService` through a generic `InMemoryRepository<T>`. Static HTML content is served via
 `WebContentLoader` with Caffeine caching.
@@ -39,7 +39,7 @@ A self-contained Spring Boot 4 + Virtual Threads HTTP mock server that replaces 
 
 - **Spring Boot 4 + Virtual Threads**: High-concurrency request handling with JDK 21+ Virtual Threads
   (`spring.threads.virtual.enabled=true`)
-- **Port 80 (HTTP) / 443 (HTTPS)**: Standard container ports for deterministic test configuration
+- **Port 80 (HTTP) / 8443 (HTTPS)**: Standard container ports for deterministic test configuration
 - **httpbin simulation**: Full HTTP inspection API at
   `/httpbin/**` — echoes requests, returns headers/IP/UUID, streams, delays, and images
 - **jsonplaceholder simulation**: 6 full CRUD resources (posts/comments/albums/photos/todos/users) at
@@ -56,7 +56,7 @@ A self-contained Spring Boot 4 + Virtual Threads HTTP mock server that replaces 
 | Key                              | Value                                           | Notes                                                     |
 |----------------------------------|-------------------------------------------------|-----------------------------------------------------------|
 | `server.port`                    | `80`                                            | HTTP container port                                       |
-| `bluetape4k.https.port`          | `443`                                           | HTTPS container port                                      |
+| `bluetape4k.https.port`          | `8443`                                          | HTTPS container port                                      |
 | `server.http2.enabled`           | `true`                                          | HTTP/2 support                                            |
 | `server.tomcat.threads.max`      | `16000`                                         | Max platform threads (high-concurrency benchmark support) |
 | `server.tomcat.max-connections`  | `16000`                                         | Max simultaneous connections                              |
@@ -70,7 +70,7 @@ A self-contained Spring Boot 4 + Virtual Threads HTTP mock server that replaces 
 ### Run via Docker
 
 ```bash
-docker run --rm -p 80:80 -p 443:443 bluetape4k/mock-web-server:latest
+docker run --rm -p 80:80 -p 8443:8443 bluetape4k/mock-web-server:latest
 ```
 
 ### Build Docker image with Jib

--- a/testing/mock-web-server/src/test/kotlin/io/bluetape4k/mockserver/ReadmeHttpsPortContractTest.kt
+++ b/testing/mock-web-server/src/test/kotlin/io/bluetape4k/mockserver/ReadmeHttpsPortContractTest.kt
@@ -1,0 +1,56 @@
+package io.bluetape4k.mockserver
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+
+/**
+ * README HTTPS port documentation must match runtime and container metadata.
+ */
+class ReadmeHttpsPortContractTest {
+
+    @Test
+    fun `README HTTPS port matches application and Jib container ports`() {
+        val projectDir = projectDir()
+        val applicationYaml = projectDir.resolve("src/main/resources/application.yml").readText()
+        val buildGradle = projectDir.resolve("build.gradle.kts").readText()
+        val expectedHttpsPort = Regex("https:\\s*\\n\\s*port:\\s*(\\d+)")
+            .find(applicationYaml)
+            ?.groupValues
+            ?.get(1)
+
+        expectedHttpsPort shouldBeEqualTo "8443"
+        buildGradle.contains("\"$expectedHttpsPort\"").shouldBeTrue()
+
+        val staleHttpsPortDocs = listOf(
+            Regex("""\*\*443\*\*"""),
+            Regex("""(?<!\d)443\s*\(HTTPS\)"""),
+            Regex("""`443`"""),
+            Regex("""-p 443:443"""),
+        )
+
+        listOf("README.md", "README.ko.md").forEach { name ->
+            val readme = projectDir.resolve(name).readText()
+
+            staleHttpsPortDocs.any { it.containsMatchIn(readme) }.shouldBeFalse()
+            readme.contains(expectedHttpsPort!!).shouldBeTrue()
+        }
+    }
+
+    private fun projectDir(): Path {
+        val candidates = listOf(
+            Path.of("."),
+            Path.of("testing/mock-web-server"),
+        ).filter { it.resolve("src/main/resources/application.yml").exists() }
+
+        check(candidates.isNotEmpty()) {
+            "mock-web-server project directory was not found from ${Path.of("").toAbsolutePath()}"
+        }
+
+        return candidates.first()
+    }
+}


### PR DESCRIPTION
## Summary

Closes #840

- PR 제목: docs: correct mock web HTTPS port

- Correct mock-web-server HTTPS documentation from `443` to `8443`.
- Keep README English/Korean, `application.yml`, and Jib container ports aligned.
- Add a README/config consistency test to catch future HTTPS port drift.

Closes #840.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Updated architecture, feature, configuration, and Docker run sections in both README locales.
- Added `ReadmeHttpsPortContractTest` to compare README docs with `application.yml` and `build.gradle.kts`.
- Added issue lesson and review notes under `docs/`.

### 기존 섹션: Verification

- RED: `ReadmeHttpsPortContractTest` failed while README files documented standalone HTTPS `443`.
- GREEN: `ReadmeHttpsPortContractTest` passed after README updates.
- `./gradlew :bluetape4k-mock-web-server:compileKotlin :bluetape4k-mock-web-server:compileTestKotlin :bluetape4k-mock-web-server:test --no-build-cache`
- Stale HTTPS port guard:
  ```bash
  rg -n '\*\*443\*\*|(^|[^0-9])443\s*\(HTTPS\)|`443`|-p 443:443' testing/mock-web-server/README.md testing/mock-web-server/README.ko.md
  ```
- `git diff --cached --check`

Jib Docker image build was not run because runtime configuration was unchanged.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #840, milestone `1.11.0`, assignee `debop`
- PR: #874, head `09c98654c051e68b83cf5de80a40beeec1d1055d`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/mock-web-server-https-docs-840`
- Labels: 없음
- State: `MERGED`, merge commit `283b817cd6e97a570a4e1c0517bdfef6589c51a4`
- CI: - Added `ReadmeHttpsPortContractTest` to compare README docs with `application.yml` and `build.gradle.kts`. / - `./gradlew :bluetape4k-mock-web-server:compileKotlin :bluetape4k-mock-web-server:compileTestKotlin :bluetape4k-mock-web-server:test --no-build-cache`

## DoD Status

- [x] Issue #840 implementation complete.
- [x] README English/Korean HTTPS port docs updated.
- [x] Regression test added and verified RED/GREEN.
- [x] Mock-web-server compile/test command passed.
- [x] Lesson and review notes added.
- [x] GitHub Actions passed.
- [x] Merged to `develop`.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #874 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `283b817cd6e97a570a4e1c0517bdfef6589c51a4`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
