### PR TITLE
Fix hibernate lettuce demo dependency docs

### DIFF
--- a/docs/lessons/2026-06-23-issue-839-hibernate-lettuce-demo-readme-deps.md
+++ b/docs/lessons/2026-06-23-issue-839-hibernate-lettuce-demo-readme-deps.md
@@ -1,0 +1,26 @@
+# Issue 839 - Hibernate Lettuce demo README dependencies
+
+## Context
+
+`spring-boot/hibernate-lettuce-demo` README dependency examples used
+bluetape4k-internal Gradle helpers such as `Libs.springBootStarter(...)`.
+Those helpers are not available in consumer builds, so the copied example would
+fail before users could run the demo.
+
+## Decision
+
+Document the demo dependencies from a consumer perspective:
+
+- import `org.springframework.boot:spring-boot-dependencies` with
+  `platform(...)`;
+- use the published
+  `io.github.bluetape4k:bluetape4k-spring-boot-hibernate-lettuce`
+  coordinate;
+- use standard Spring Boot starter and H2 coordinates;
+- remove the stale explicit `compileOnly` Hibernate helper note because
+  `spring-boot-starter-data-jpa` supplies the demo runtime.
+
+## Follow-up Guard
+
+`ReadmeDependencyContractTest` reads both README locales and fails if internal
+dependency helpers return to the consumer-facing snippets.

--- a/docs/review/2026-06-23-issue-839-hibernate-lettuce-demo-readme-deps-review.md
+++ b/docs/review/2026-06-23-issue-839-hibernate-lettuce-demo-readme-deps-review.md
@@ -1,0 +1,27 @@
+# Issue 839 Review - hibernate-lettuce demo README dependencies
+
+## Scope
+
+- `spring-boot/hibernate-lettuce-demo/README.md`
+- `spring-boot/hibernate-lettuce-demo/README.ko.md`
+- `spring-boot/hibernate-lettuce-demo/src/test/kotlin/io/bluetape4k/examples/cache/lettuce/ReadmeDependencyContractTest.kt`
+
+## Review Notes
+
+- README dependency snippets now use copyable consumer Gradle coordinates
+  instead of bluetape4k-internal version catalog helpers.
+- English and Korean dependency sections were updated equivalently.
+- The Spring Boot 4 note now points to the public BOM coordinate and clarifies
+  that `spring-boot-starter-data-jpa` supplies the demo Hibernate runtime.
+- The new test is file-based and does not start a Spring context, so it gives a
+  fast regression signal for stale dependency snippets.
+
+## Verification
+
+- RED: `ReadmeDependencyContractTest` failed while README files still contained
+  `Libs.` helpers.
+- GREEN: `ReadmeDependencyContractTest` passed after README cleanup.
+- `./gradlew :bluetape4k-spring-boot-hibernate-lettuce-demo:compileKotlin :bluetape4k-spring-boot-hibernate-lettuce-demo:compileTestKotlin :bluetape4k-spring-boot-hibernate-lettuce-demo:test --no-build-cache`
+  passed with 6 demo integration tests plus the README dependency contract.
+- Stale-helper `rg` guard passed with no matches in the README files.
+- `git diff --check` passed.

--- a/spring-boot/hibernate-lettuce-demo/README.ko.md
+++ b/spring-boot/hibernate-lettuce-demo/README.ko.md
@@ -320,29 +320,27 @@ class DemoApplicationTest {
 
 ```kotlin
 // build.gradle.kts
+val springBootVersion = "4.0.6"
+val bluetape4kVersion = "1.11.0"
+
 dependencies {
     // Spring Boot 4 BOM
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion"))
 
     implementation("io.github.bluetape4k:bluetape4k-spring-boot-hibernate-lettuce:${bluetape4kVersion}")
-    implementation(Libs.springBootStarter("web"))
-    implementation(Libs.springBootStarter("data-jpa"))
-    implementation(Libs.springBootStarter("actuator"))
-    runtimeOnly(Libs.h2_database)
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    runtimeOnly("com.h2database:h2")
 
-    // Hibernate (명시적 선언)
-    compileOnly(Libs.springBoot("hibernate"))
-
-    testImplementation(Libs.springBootStarter("test"))
-    testImplementation(Libs.testcontainers)
-    testImplementation(Libs.testcontainers_junit5)
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 ```
 
 ## Spring Boot 4 고유 사항
 
-- **BOM**: `implementation(platform(libs.spring.boot.dependencies))` 필수
-- **Hibernate**: `compileOnly(Libs.springBoot("hibernate"))` 추가 필요
+- **BOM**: `org.springframework.boot:spring-boot-dependencies`를 `platform(...)`으로 import
+- **Hibernate**: 이 demo에 필요한 Hibernate runtime은 `spring-boot-starter-data-jpa`가 제공합니다
 - **패키지명**: `org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer`
 
 ## 패키지 정보

--- a/spring-boot/hibernate-lettuce-demo/README.md
+++ b/spring-boot/hibernate-lettuce-demo/README.md
@@ -321,29 +321,27 @@ class DemoApplicationTest {
 
 ```kotlin
 // build.gradle.kts
+val springBootVersion = "4.0.6"
+val bluetape4kVersion = "1.11.0"
+
 dependencies {
     // Spring Boot 4 BOM
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion"))
 
     implementation("io.github.bluetape4k:bluetape4k-spring-boot-hibernate-lettuce:${bluetape4kVersion}")
-    implementation(Libs.springBootStarter("web"))
-    implementation(Libs.springBootStarter("data-jpa"))
-    implementation(Libs.springBootStarter("actuator"))
-    runtimeOnly(Libs.h2_database)
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    runtimeOnly("com.h2database:h2")
 
-    // Hibernate (explicit declaration)
-    compileOnly(Libs.springBoot("hibernate"))
-
-    testImplementation(Libs.springBootStarter("test"))
-    testImplementation(Libs.testcontainers)
-    testImplementation(Libs.testcontainers_junit5)
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 ```
 
 ## Spring Boot 4-Specific Notes
 
-- **BOM**: `implementation(platform(libs.spring.boot.dependencies))` required
-- **Hibernate**: `compileOnly(Libs.springBoot("hibernate"))` must be added
+- **BOM**: import `org.springframework.boot:spring-boot-dependencies` with `platform(...)`
+- **Hibernate**: `spring-boot-starter-data-jpa` supplies the Hibernate runtime required by this demo
 - **Package name**: `org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer`
 
 ## Package Information

--- a/spring-boot/hibernate-lettuce-demo/src/test/kotlin/io/bluetape4k/examples/cache/lettuce/ReadmeDependencyContractTest.kt
+++ b/spring-boot/hibernate-lettuce-demo/src/test/kotlin/io/bluetape4k/examples/cache/lettuce/ReadmeDependencyContractTest.kt
@@ -1,0 +1,69 @@
+package io.bluetape4k.examples.cache.lettuce
+
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ReadmeDependencyContractTest {
+
+    @Test
+    fun `README dependency examples use consumer Gradle coordinates`() {
+        readmeTexts().forEach { (filename, text) ->
+            forbiddenFragments.forEach { fragment ->
+                assertFalse(
+                    text.contains(fragment),
+                    "$filename must not expose bluetape4k-internal dependency helper: $fragment",
+                )
+            }
+
+            requiredFragments.forEach { fragment ->
+                assertTrue(
+                    text.contains(fragment),
+                    "$filename must document consumer dependency coordinate: $fragment",
+                )
+            }
+        }
+    }
+
+    private fun readmeTexts(): Map<String, String> =
+        listOf("README.md", "README.ko.md").associateWith { filename ->
+            findReadme(filename).readText()
+        }
+
+    private fun findReadme(filename: String): Path {
+        val cwd = Path.of("").toAbsolutePath()
+        return generateSequence(cwd) { it.parent }
+            .flatMap { path ->
+                sequenceOf(
+                    path.resolve("spring-boot/hibernate-lettuce-demo").resolve(filename),
+                    path.resolve(filename),
+                )
+            }
+            .firstOrNull(Files::isRegularFile)
+            ?: error("Cannot find $filename from $cwd")
+    }
+
+    private companion object {
+        val forbiddenFragments = listOf(
+            "Libs.",
+            "libs.",
+            "springBootStarter",
+            "springBoot(\"hibernate\")",
+            "h2_database",
+            "testcontainers_junit5",
+        )
+
+        val requiredFragments = listOf(
+            "org.springframework.boot:spring-boot-dependencies",
+            "io.github.bluetape4k:bluetape4k-spring-boot-hibernate-lettuce",
+            "org.springframework.boot:spring-boot-starter-web",
+            "org.springframework.boot:spring-boot-starter-data-jpa",
+            "org.springframework.boot:spring-boot-starter-actuator",
+            "com.h2database:h2",
+            "org.springframework.boot:spring-boot-starter-test",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Closes #839

- PR 제목: Fix hibernate lettuce demo dependency docs

- Rewrite the Hibernate Lettuce demo README dependency snippets to use consumer Gradle coordinates instead of bluetape4k-internal `Libs.*` helpers.
- Keep English and Korean README dependency guidance equivalent.
- Add a file-based README dependency contract test to block internal helper snippets from returning.
- Record issue lesson and local review notes.

Closes #839.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- RED: `./gradlew :bluetape4k-spring-boot-hibernate-lettuce-demo:test --tests 'io.bluetape4k.examples.cache.lettuce.ReadmeDependencyContractTest' --no-build-cache` failed on `README.md must not expose bluetape4k-internal dependency helper: Libs.`
- GREEN targeted: `./gradlew :bluetape4k-spring-boot-hibernate-lettuce-demo:test --tests 'io.bluetape4k.examples.cache.lettuce.ReadmeDependencyContractTest' --no-build-cache`
- Module: `./gradlew :bluetape4k-spring-boot-hibernate-lettuce-demo:compileKotlin :bluetape4k-spring-boot-hibernate-lettuce-demo:compileTestKotlin :bluetape4k-spring-boot-hibernate-lettuce-demo:test --no-build-cache`
- Stale-helper guard: `rg -n "Libs\\.|libs\\.|springBootStarter|springBoot\\(\"hibernate\"\\)|h2_database|testcontainers_junit5" spring-boot/hibernate-lettuce-demo/README.md spring-boot/hibernate-lettuce-demo/README.ko.md`
- Hygiene: `git diff --check`

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #839, milestone `1.11.0`, assignee `debop`
- PR: #875, head `9f8545321a3ee3dcf0052a538c98b7a0aa12ddb1`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/hibernate-lettuce-demo-readme-deps-839`
- Labels: 없음
- State: `MERGED`, merge commit `76c0d3d5cacc03d9f018680766fcfc6f03feb5bb`
- CI: - Rewrite the Hibernate Lettuce demo README dependency snippets to use consumer Gradle coordinates instead of bluetape4k-internal `Libs.*` helpers. / - RED: `./gradlew :bluetape4k-spring-boot-hibernate-lettuce-demo:test --tests 'io.bluetape4k.examples.cache.lettuce.ReadmeDependencyContractTest' --no-build-cache` failed on `README.md must not expose bluetape4k-internal dependency helper: Libs.` / - GREEN targeted: `./gradlew :bluetape4k-spring-boot-hibernate-lettuce-demo:test --tests 'io.bluetape4k.examples.cache.lettuce.ReadmeDependencyContractTest' --no-build-cache`

## DoD Status

- [x] Issue #839 implementation complete.
- [x] README.md and README.ko.md dependency snippets use public consumer coordinates.
- [x] Regression coverage added for README dependency snippets.
- [x] Local targeted and module verification passed.
- [x] Stale-helper guard passed.
- [x] `git diff --check` passed.
- [x] GitHub Actions passed.
- [x] Merged to `develop`.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #875 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `76c0d3d5cacc03d9f018680766fcfc6f03feb5bb`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
