### PR TITLE
Fix Cassandra demo coroutine README example

### DIFF
--- a/docs/lessons/2026-06-23-issue-838-cassandra-demo-coroutine-readme.md
+++ b/docs/lessons/2026-06-23-issue-838-cassandra-demo-coroutine-readme.md
@@ -1,0 +1,24 @@
+# Issue 838 - Cassandra demo coroutine README example
+
+## Context
+
+`spring-boot/cassandra-demo` README files documented a coroutine repository
+method returning `Flow<Person>` as `suspend fun`. The tested repository uses a
+regular function for `Flow<Person>` queries and reserves `suspend fun` for
+single-result nullable lookups.
+
+## Decision
+
+Mirror the tested repository shape in both README locales:
+
+- `CoroutineCrudRepository<Person, String>`;
+- `fun findByLastname(lastname: String): Flow<Person>`;
+- `suspend fun findByFirstnameAndLastname(...): Person?`.
+
+Add a short note that `Flow<T>` repository queries are regular functions while
+single-result coroutine lookups use `suspend fun`.
+
+## Follow-up Guard
+
+`ReadmeCoroutineRepositoryContractTest` reads both README locales and blocks the
+stale `UUID` / `findByLastName` / `suspend Flow` example from returning.

--- a/docs/review/2026-06-23-issue-838-cassandra-demo-coroutine-readme-review.md
+++ b/docs/review/2026-06-23-issue-838-cassandra-demo-coroutine-readme-review.md
@@ -1,0 +1,25 @@
+# Issue 838 Review - Cassandra demo coroutine README example
+
+## Scope
+
+- `spring-boot/cassandra-demo/README.md`
+- `spring-boot/cassandra-demo/README.ko.md`
+- `spring-boot/cassandra-demo/src/test/kotlin/io/bluetape4k/examples/cassandra/ReadmeCoroutineRepositoryContractTest.kt`
+
+## Review Notes
+
+- README coroutine repository snippets now match the tested
+  `CoroutinePersonRepository` shape.
+- English and Korean README snippets were updated equivalently.
+- The new file-based contract test checks the `Flow<T>` regular-function shape
+  and the single-result `suspend fun` shape without starting a Spring context.
+
+## Verification
+
+- RED: `ReadmeCoroutineRepositoryContractTest` failed while README files still
+  documented `CoroutineCrudRepository<Person, UUID>` and `suspend Flow`.
+- GREEN: `ReadmeCoroutineRepositoryContractTest` passed after README cleanup.
+- `./gradlew :bluetape4k-spring-boot-cassandra-demo:compileTestKotlin :bluetape4k-spring-boot-cassandra-demo:test --no-build-cache`
+  passed, including `CoroutinePersonRepositoryTest` and the README contract.
+- Stale-signature `rg` guard passed with no matches in the README files.
+- `git diff --check` passed.

--- a/spring-boot/cassandra-demo/README.ko.md
+++ b/spring-boot/cassandra-demo/README.ko.md
@@ -62,10 +62,17 @@ interface UserRepository : CassandraRepository<User, UUID> {
 ## Coroutines 지원
 
 ```kotlin
-interface CoroutinePersonRepository : CoroutineCrudRepository<Person, UUID> {
-    suspend fun findByLastName(lastName: String): Flow<Person>
+interface CoroutinePersonRepository : CoroutineCrudRepository<Person, String> {
+
+    fun findByLastname(lastname: String): Flow<Person>
+
+    @Query("SELECT * FROM coroutine_persons WHERE firstname = ?0 AND lastname = ?1")
+    suspend fun findByFirstnameAndLastname(firstname: String, lastname: String): Person?
 }
 ```
+
+`Flow<T>`를 반환하는 Repository query는 일반 함수로 선언합니다. 단일
+결과를 반환하는 nullable `Person?` 조회에는 `suspend fun`을 사용합니다.
 
 ## 실행 방법
 

--- a/spring-boot/cassandra-demo/README.md
+++ b/spring-boot/cassandra-demo/README.md
@@ -62,10 +62,17 @@ interface UserRepository : CassandraRepository<User, UUID> {
 ## Coroutines Support
 
 ```kotlin
-interface CoroutinePersonRepository : CoroutineCrudRepository<Person, UUID> {
-    suspend fun findByLastName(lastName: String): Flow<Person>
+interface CoroutinePersonRepository : CoroutineCrudRepository<Person, String> {
+
+    fun findByLastname(lastname: String): Flow<Person>
+
+    @Query("SELECT * FROM coroutine_persons WHERE firstname = ?0 AND lastname = ?1")
+    suspend fun findByFirstnameAndLastname(firstname: String, lastname: String): Person?
 }
 ```
+
+`Flow<T>` repository queries are regular functions. Use `suspend fun` for
+single-result coroutine queries such as nullable `Person?` lookups.
 
 ## Running the Examples
 

--- a/spring-boot/cassandra-demo/src/test/kotlin/io/bluetape4k/examples/cassandra/ReadmeCoroutineRepositoryContractTest.kt
+++ b/spring-boot/cassandra-demo/src/test/kotlin/io/bluetape4k/examples/cassandra/ReadmeCoroutineRepositoryContractTest.kt
@@ -1,0 +1,62 @@
+package io.bluetape4k.examples.cassandra
+
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ReadmeCoroutineRepositoryContractTest {
+
+    @Test
+    fun `README coroutine repository example matches tested Flow and suspend signatures`() {
+        readmeTexts().forEach { (filename, text) ->
+            forbiddenFragments.forEach { fragment ->
+                assertFalse(
+                    text.contains(fragment),
+                    "$filename must not document stale coroutine repository signature: $fragment",
+                )
+            }
+
+            requiredFragments.forEach { fragment ->
+                assertTrue(
+                    text.contains(fragment),
+                    "$filename must document tested coroutine repository signature: $fragment",
+                )
+            }
+        }
+    }
+
+    private fun readmeTexts(): Map<String, String> =
+        listOf("README.md", "README.ko.md").associateWith { filename ->
+            findReadme(filename).readText()
+        }
+
+    private fun findReadme(filename: String): Path {
+        val cwd = Path.of("").toAbsolutePath()
+        return generateSequence(cwd) { it.parent }
+            .flatMap { path ->
+                sequenceOf(
+                    path.resolve("spring-boot/cassandra-demo").resolve(filename),
+                    path.resolve(filename),
+                )
+            }
+            .firstOrNull(Files::isRegularFile)
+            ?: error("Cannot find $filename from $cwd")
+    }
+
+    private companion object {
+        val forbiddenFragments = listOf(
+            "CoroutineCrudRepository<Person, UUID>",
+            "suspend fun findByLastName(lastName: String): Flow<Person>",
+            "findByLastName",
+        )
+
+        val requiredFragments = listOf(
+            "CoroutineCrudRepository<Person, String>",
+            "fun findByLastname(lastname: String): Flow<Person>",
+            "suspend fun findByFirstnameAndLastname(firstname: String, lastname: String): Person?",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Closes #838

- PR 제목: Fix Cassandra demo coroutine README example

- Correct the Cassandra demo coroutine repository README snippets to match the tested repository shape.
- Document `Flow<T>` repository queries as regular functions and nullable single-result queries as `suspend fun`.
- Keep English and Korean README examples equivalent.
- Add a file-based README contract test plus lesson/review notes.

Closes #838.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- RED: `./gradlew :bluetape4k-spring-boot-cassandra-demo:test --tests 'io.bluetape4k.examples.cassandra.ReadmeCoroutineRepositoryContractTest' --no-build-cache` failed on the stale `CoroutineCrudRepository<Person, UUID>` / `suspend Flow` snippet.
- GREEN targeted: `./gradlew :bluetape4k-spring-boot-cassandra-demo:test --tests 'io.bluetape4k.examples.cassandra.ReadmeCoroutineRepositoryContractTest' --no-build-cache`
- Module: `./gradlew :bluetape4k-spring-boot-cassandra-demo:compileTestKotlin :bluetape4k-spring-boot-cassandra-demo:test --no-build-cache`
- Stale-signature guard: `rg -n "CoroutineCrudRepository<Person, UUID>|suspend fun findByLastName\\(lastName: String\\): Flow<Person>|findByLastName" spring-boot/cassandra-demo/README.md spring-boot/cassandra-demo/README.ko.md`
- Hygiene: `git diff --check`

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #838, milestone `1.11.0`, assignee `debop`
- PR: #876, head `968bbba62a30d1e4083f2823b1254f1e5187cbeb`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/cassandra-demo-readme-coroutine-repository-838`
- Labels: 없음
- State: `MERGED`, merge commit `e133d30e37d63baf5e8f9860690de18eb4ecface`
- CI: - RED: `./gradlew :bluetape4k-spring-boot-cassandra-demo:test --tests 'io.bluetape4k.examples.cassandra.ReadmeCoroutineRepositoryContractTest' --no-build-cache` failed on the stale `CoroutineCrudRepository<Person, UUID>` / `suspend Flow` snippet. / - GREEN targeted: `./gradlew :bluetape4k-spring-boot-cassandra-demo:test --tests 'io.bluetape4k.examples.cassandra.ReadmeCoroutineRepositoryContractTest' --no-build-cache` / - Module: `./gradlew :bluetape4k-spring-boot-cassandra-demo:compileTestKotlin :bluetape4k-spring-boot-cassandra-demo:test --no-build-cache`

## DoD Status

- [x] Issue #838 implementation complete.
- [x] README.md and README.ko.md coroutine repository snippets match the tested code.
- [x] Regression coverage added for README coroutine repository signatures.
- [x] Local targeted and module verification passed.
- [x] Stale-signature guard passed.
- [x] `git diff --check` passed.
- [x] GitHub Actions passed.
- [x] Merged to `develop`.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #876 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e133d30e37d63baf5e8f9860690de18eb4ecface`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
