### PR TITLE
Fix hibernate lettuce dependency docs

### DIFF
--- a/docs/lessons/2026-06-23-issue-837-hibernate-lettuce-readme-deps.md
+++ b/docs/lessons/2026-06-23-issue-837-hibernate-lettuce-readme-deps.md
@@ -1,0 +1,23 @@
+# Issue 837 - Hibernate Lettuce README dependencies
+
+## Context
+
+`spring-boot/hibernate-lettuce` README dependency snippets used repository-local
+Gradle helpers such as `Libs.springBootStarter(...)` and `Libs.micrometer_core`.
+Those examples are not copyable in consumer projects.
+
+## Decision
+
+Document the module dependencies with public Gradle coordinates:
+
+- `org.springframework.boot:spring-boot-dependencies` through `platform(...)`;
+- `io.github.bluetape4k:bluetape4k-spring-boot-hibernate-lettuce`;
+- Spring Boot starter coordinates for Data JPA and Actuator;
+- `io.micrometer:micrometer-core`;
+- `org.springframework.boot:spring-boot-hibernate` for the Spring Boot 4
+  Hibernate integration API used by `HibernatePropertiesCustomizer`.
+
+## Follow-up Guard
+
+`ReadmeDependencyContractTest` reads both README locales and fails if internal
+Gradle helper snippets return to the consumer-facing dependency examples.

--- a/docs/review/2026-06-23-issue-837-hibernate-lettuce-readme-deps-review.md
+++ b/docs/review/2026-06-23-issue-837-hibernate-lettuce-readme-deps-review.md
@@ -1,0 +1,28 @@
+# Issue 837 Review - hibernate-lettuce README dependencies
+
+## Scope
+
+- `spring-boot/hibernate-lettuce/README.md`
+- `spring-boot/hibernate-lettuce/README.ko.md`
+- `spring-boot/hibernate-lettuce/src/test/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/ReadmeDependencyContractTest.kt`
+
+## Review Notes
+
+- README dependency snippets now use copyable consumer Gradle coordinates
+  instead of bluetape4k-internal version catalog helpers.
+- English and Korean dependency sections were updated equivalently.
+- The Spring Boot 4 migration note now points to the public BOM coordinate and
+  the real `org.springframework.boot:spring-boot-hibernate` coordinate.
+- The new file-based contract test uses `bluetape4k-assertions` and does not
+  start a Spring context.
+
+## Verification
+
+- RED: `ReadmeDependencyContractTest` failed while README files still contained
+  internal `Libs.*` helpers.
+- GREEN: `ReadmeDependencyContractTest` passed after README cleanup.
+- `./gradlew :bluetape4k-spring-boot-hibernate-lettuce:compileKotlin :bluetape4k-spring-boot-hibernate-lettuce:compileTestKotlin :bluetape4k-spring-boot-hibernate-lettuce:test --no-build-cache`
+  passed with the existing LettuceNearCache tests plus the README dependency
+  contract.
+- Stale-helper `rg` guard passed with no matches in the README files.
+- `git diff --check` passed.

--- a/spring-boot/hibernate-lettuce/README.ko.md
+++ b/spring-boot/hibernate-lettuce/README.ko.md
@@ -28,19 +28,22 @@ Spring Boot 4에서는 패키지명이 변경되었습니다:
 
 ```kotlin
 // build.gradle.kts
+val springBootVersion = "4.0.6"
+val bluetape4kVersion = "1.11.0"
+
 dependencies {
     // Spring Boot 4 BOM (dependencyManagement 대신 platform 사용)
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion"))
 
     implementation("io.github.bluetape4k:bluetape4k-spring-boot-hibernate-lettuce:${bluetape4kVersion}")
 
-    // Hibernate 명시적 추가 필요
-    compileOnly(Libs.springBoot("hibernate"))
+    // Spring Boot 4 Hibernate 통합
+    implementation("org.springframework.boot:spring-boot-hibernate")
 
     // Spring Boot Starters
-    implementation(Libs.springBootStarter("data-jpa"))
-    implementation(Libs.springBootStarter("actuator"))   // Actuator 엔드포인트 (선택)
-    implementation(Libs.micrometer_core)                 // Micrometer 메트릭 (선택)
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-actuator") // Actuator 엔드포인트 (선택)
+    implementation("io.micrometer:micrometer-core")                         // Micrometer 메트릭 (선택)
 }
 ```
 
@@ -56,19 +59,22 @@ dependencies {
 
 ```kotlin
 // build.gradle.kts
+val springBootVersion = "4.0.6"
+val bluetape4kVersion = "1.11.0"
+
 dependencies {
     // Spring Boot 4 BOM (필수)
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion"))
 
     implementation("io.github.bluetape4k:bluetape4k-spring-boot-hibernate-lettuce:${bluetape4kVersion}")
 
     // Spring Boot Starters
-    implementation(Libs.springBootStarter("data-jpa"))
-    implementation(Libs.springBootStarter("actuator"))   // Actuator 엔드포인트 (선택)
-    implementation(Libs.micrometer_core)                 // Micrometer 메트릭 (선택)
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-actuator") // Actuator 엔드포인트 (선택)
+    implementation("io.micrometer:micrometer-core")                         // Micrometer 메트릭 (선택)
 
-    // Hibernate (명시적 선언)
-    compileOnly(Libs.springBoot("hibernate"))
+    // Spring Boot 4 Hibernate 통합
+    implementation("org.springframework.boot:spring-boot-hibernate")
 }
 ```
 
@@ -313,8 +319,9 @@ bluetape4k:
 ## 마이그레이션 참고
 
 이 모듈은 Spring Boot 4.x 전용입니다.
-`implementation(platform(libs.spring.boot.dependencies))`를 사용하고
-Hibernate는 `compileOnly(Libs.springBoot("hibernate"))`로 명시적으로 선언하세요.
+`implementation(platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion"))`를 사용하고
+`HibernatePropertiesCustomizer`를 사용할 수 있도록
+`org.springframework.boot:spring-boot-hibernate`를 application classpath에 유지하세요.
 
 ## 패키지 정보
 

--- a/spring-boot/hibernate-lettuce/README.md
+++ b/spring-boot/hibernate-lettuce/README.md
@@ -29,19 +29,22 @@ The Spring Boot 4 BOM must also be applied explicitly:
 
 ```kotlin
 // build.gradle.kts
+val springBootVersion = "4.0.6"
+val bluetape4kVersion = "1.11.0"
+
 dependencies {
     // Spring Boot 4 BOM (use platform instead of dependencyManagement)
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion"))
 
     implementation("io.github.bluetape4k:bluetape4k-spring-boot-hibernate-lettuce:${bluetape4kVersion}")
 
-    // Hibernate must be declared explicitly
-    compileOnly(Libs.springBoot("hibernate"))
+    // Spring Boot 4 Hibernate integration
+    implementation("org.springframework.boot:spring-boot-hibernate")
 
     // Spring Boot Starters
-    implementation(Libs.springBootStarter("data-jpa"))
-    implementation(Libs.springBootStarter("actuator"))   // Actuator endpoint (optional)
-    implementation(Libs.micrometer_core)                 // Micrometer metrics (optional)
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-actuator") // Actuator endpoint (optional)
+    implementation("io.micrometer:micrometer-core")                         // Micrometer metrics (optional)
 }
 ```
 
@@ -57,19 +60,22 @@ dependencies {
 
 ```kotlin
 // build.gradle.kts
+val springBootVersion = "4.0.6"
+val bluetape4kVersion = "1.11.0"
+
 dependencies {
     // Spring Boot 4 BOM (required)
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion"))
 
     implementation("io.github.bluetape4k:bluetape4k-spring-boot-hibernate-lettuce:${bluetape4kVersion}")
 
     // Spring Boot Starters
-    implementation(Libs.springBootStarter("data-jpa"))
-    implementation(Libs.springBootStarter("actuator"))   // Actuator endpoint (optional)
-    implementation(Libs.micrometer_core)                 // Micrometer metrics (optional)
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-actuator") // Actuator endpoint (optional)
+    implementation("io.micrometer:micrometer-core")                         // Micrometer metrics (optional)
 
-    // Hibernate (explicit declaration)
-    compileOnly(Libs.springBoot("hibernate"))
+    // Spring Boot 4 Hibernate integration
+    implementation("org.springframework.boot:spring-boot-hibernate")
 }
 ```
 
@@ -314,8 +320,9 @@ Integration tests automatically manage Redis + H2 via Testcontainers.
 ## Migration Note
 
 This module is Spring Boot 4.x only. Use
-`implementation(platform(libs.spring.boot.dependencies))` and declare Hibernate
-explicitly with `compileOnly(Libs.springBoot("hibernate"))`.
+`implementation(platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion"))`
+and keep `org.springframework.boot:spring-boot-hibernate` on the application
+classpath so `HibernatePropertiesCustomizer` is available.
 
 ## Package Information
 

--- a/spring-boot/hibernate-lettuce/src/test/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/ReadmeDependencyContractTest.kt
+++ b/spring-boot/hibernate-lettuce/src/test/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/ReadmeDependencyContractTest.kt
@@ -1,0 +1,61 @@
+package io.bluetape4k.spring.boot.autoconfigure.cache.lettuce
+
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.readText
+
+class ReadmeDependencyContractTest {
+
+    @Test
+    fun `README dependency examples use consumer Gradle coordinates`() {
+        readmeTexts().forEach { (filename, text) ->
+            forbiddenFragments.forEach { fragment ->
+                text.contains(fragment).shouldBeFalse()
+            }
+
+            requiredFragments.forEach { fragment ->
+                text.contains(fragment).shouldBeTrue()
+            }
+        }
+    }
+
+    private fun readmeTexts(): Map<String, String> =
+        listOf("README.md", "README.ko.md").associateWith { filename ->
+            findReadme(filename).readText()
+        }
+
+    private fun findReadme(filename: String): Path {
+        val cwd = Path.of("").toAbsolutePath()
+        return generateSequence(cwd) { it.parent }
+            .flatMap { path ->
+                sequenceOf(
+                    path.resolve("spring-boot/hibernate-lettuce").resolve(filename),
+                    path.resolve(filename),
+                )
+            }
+            .firstOrNull(Files::isRegularFile)
+            ?: error("Cannot find $filename from $cwd")
+    }
+
+    private companion object {
+        val forbiddenFragments = listOf(
+            "Libs.",
+            "libs.",
+            "springBootStarter",
+            "springBoot(\"hibernate\")",
+            "micrometer_core",
+        )
+
+        val requiredFragments = listOf(
+            "org.springframework.boot:spring-boot-dependencies",
+            "io.github.bluetape4k:bluetape4k-spring-boot-hibernate-lettuce",
+            "org.springframework.boot:spring-boot-starter-data-jpa",
+            "org.springframework.boot:spring-boot-starter-actuator",
+            "io.micrometer:micrometer-core",
+            "org.springframework.boot:spring-boot-hibernate",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Closes #837

- PR 제목: Fix hibernate lettuce dependency docs

- Rewrite the Hibernate Lettuce README dependency snippets to use public consumer Gradle coordinates instead of bluetape4k-internal `Libs.*` helpers.
- Keep English and Korean README dependency guidance equivalent.
- Add a file-based README dependency contract test using `bluetape4k-assertions`.
- Record issue lesson and local review notes.

Closes #837.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- RED: `./gradlew :bluetape4k-spring-boot-hibernate-lettuce:test --tests 'io.bluetape4k.spring.boot.autoconfigure.cache.lettuce.ReadmeDependencyContractTest' --no-build-cache` failed while README files still exposed internal helper snippets.
- GREEN targeted: `./gradlew :bluetape4k-spring-boot-hibernate-lettuce:test --tests 'io.bluetape4k.spring.boot.autoconfigure.cache.lettuce.ReadmeDependencyContractTest' --no-build-cache`
- Module: `./gradlew :bluetape4k-spring-boot-hibernate-lettuce:compileKotlin :bluetape4k-spring-boot-hibernate-lettuce:compileTestKotlin :bluetape4k-spring-boot-hibernate-lettuce:test --no-build-cache`
- Stale-helper guard: `rg -n "Libs\\.|libs\\.|springBootStarter|springBoot\\(\"hibernate\"\\)|micrometer_core" spring-boot/hibernate-lettuce/README.md spring-boot/hibernate-lettuce/README.ko.md`
- Hygiene: `git diff --check`

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #837, milestone `1.11.0`, assignee `debop`
- PR: #877, head `132f0f245c197959dcbb6ddebc91ebca605be5f3`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/hibernate-lettuce-readme-deps-837`
- Labels: 없음
- State: `MERGED`, merge commit `6966259cb7bf0759e02018d5ddb9881b14c65b80`
- CI: - Rewrite the Hibernate Lettuce README dependency snippets to use public consumer Gradle coordinates instead of bluetape4k-internal `Libs.*` helpers. / - RED: `./gradlew :bluetape4k-spring-boot-hibernate-lettuce:test --tests 'io.bluetape4k.spring.boot.autoconfigure.cache.lettuce.ReadmeDependencyContractTest' --no-build-cache` failed while README files still exposed internal helper snippets. / - GREEN targeted: `./gradlew :bluetape4k-spring-boot-hibernate-lettuce:test --tests 'io.bluetape4k.spring.boot.autoconfigure.cache.lettuce.ReadmeDependencyContractTest' --no-build-cache`

## DoD Status

- [x] Issue #837 implementation complete.
- [x] README.md and README.ko.md dependency snippets use public consumer coordinates.
- [x] Regression coverage added for README dependency snippets.
- [x] Local targeted and module verification passed.
- [x] Stale-helper guard passed.
- [x] `git diff --check` passed.
- [x] GitHub Actions passed.
- [x] Merged to `develop`.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #877 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `6966259cb7bf0759e02018d5ddb9881b14c65b80`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
