### PR TITLE
fix: make Cassandra queryForMap varargs explicit

### DIFF
--- a/docs/lessons/2026-06-23-issue-836-cassandra-queryformap-varargs.md
+++ b/docs/lessons/2026-06-23-issue-836-cassandra-queryformap-varargs.md
@@ -1,0 +1,24 @@
+# Lessons Learned - Cassandra queryForMap varargs (#836, 2026-06-23)
+
+Related issue: #836
+Affected module: `:bluetape4k-spring-boot-cassandra`
+
+## L1: Vararg bug reports need real bind-marker evidence
+
+The issue suspected that `queryForMap(cql, args)` passed a single array value
+instead of expanding positional bind arguments. A new unit contract and a real
+Cassandra integration test with two bind markers both passed before the
+production change, which means the original runtime failure was not reproduced
+locally.
+
+The fix still made the public helper explicit by calling `queryForMap(cql, *args)`
+and updated the KDoc to match that contract. Future changes to Kotlin wrappers
+around Java varargs should include both MockK vararg verification and at least one
+real bind-marker query when a database binding bug is suspected.
+
+## L2: Do not let mocks encode the misleading shape
+
+The old unit fixture used `any<Array<*>>()`, which reinforced the suspicious
+array-shaped forwarding even though the wrapper behaved correctly in the
+verified paths. Test fixtures for Java vararg APIs should use `*anyVararg()` or
+concrete positional arguments so the test reads like the public contract.

--- a/docs/review/2026-06-23-issue-836-cassandra-queryformap-varargs-review.md
+++ b/docs/review/2026-06-23-issue-836-cassandra-queryformap-varargs-review.md
@@ -1,0 +1,40 @@
+# Review - Cassandra queryForMap varargs (#836, 2026-06-23)
+
+Scope:
+- `spring-boot/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/cql/ReactiveCqlOperationsSupport.kt`
+- `spring-boot/cassandra/src/test/kotlin/io/bluetape4k/spring/cassandra/cql/ReactiveCqlOperationsSupportUnitTest.kt`
+- `spring-boot/cassandra/src/test/kotlin/io/bluetape4k/spring/cassandra/cql/ReactiveCqlOperationsSupportTest.kt`
+
+## Findings
+
+P0: 0
+P1: 0
+P2: 0
+P3: 0 after follow-up
+
+## Review Notes
+
+- The implementation now documents and calls `queryForMap(cql, *args)`.
+- The unit fixture no longer stubs the misleading `Array<*>` shape; it uses `*anyVararg()`.
+- The focused unit contract verifies two concrete positional arguments reach `queryForMap`.
+- The Cassandra integration test was strengthened after review feedback to use two real bind markers:
+  `id = ? AND firstname = ? ALLOW FILTERING`, with `user.id` and `user.firstname`.
+- RED reproduction note: the added unit and integration tests passed before the production change, so
+  the suspected runtime failure was not reproduced locally. The change is still useful because it
+  makes the public vararg contract explicit and removes the misleading test/KDoc shape.
+
+## Validation
+
+- `./gradlew :bluetape4k-spring-boot-cassandra:cleanTest :bluetape4k-spring-boot-cassandra:compileKotlin :bluetape4k-spring-boot-cassandra:compileTestKotlin :bluetape4k-spring-boot-cassandra:test --no-build-cache`
+  - `GRADLE_STATUS=0`
+  - `257 passing`
+  - `BUILD SUCCESSFUL in 23s`
+- `git diff --check`: passed.
+- Stale pattern guard:
+  `rg -n "queryForMap\\(cql, args\\)|queryForMap\\(any<String>\\(\\), any<Array|any<Array<\\*>>\\(\\)" ...`
+  returned no matches.
+
+## Gate Verdict
+
+PASS for PR creation.
+Merge is explicitly out of scope for this branch per user request.

--- a/spring-boot/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/cql/ReactiveCqlOperationsSupport.kt
+++ b/spring-boot/cassandra/src/main/kotlin/io/bluetape4k/spring/cassandra/cql/ReactiveCqlOperationsSupport.kt
@@ -141,7 +141,7 @@ suspend inline fun <reified T: Any> ReactiveCqlOperations.queryForObjectSuspendi
  * CQL 문자열 실행 결과를 단일 행 맵으로 반환합니다.
  *
  * ## 동작/계약
- * - 내부적으로 `queryForMap(cql, args).awaitSingle()`을 호출합니다.
+ * - 내부적으로 `queryForMap(cql, *args).awaitSingle()`을 호출합니다.
  * - 결과가 없거나 다중 행인 경우 예외 여부는 Spring Data Cassandra 규칙을 따릅니다.
  *
  * ```kotlin
@@ -152,7 +152,7 @@ suspend inline fun <reified T: Any> ReactiveCqlOperations.queryForObjectSuspendi
 suspend fun ReactiveCqlOperations.queryForMapSuspending(
     cql: String,
     vararg args: Any,
-): Map<String, Any?> = queryForMap(cql, args).awaitSingle()
+): Map<String, Any?> = queryForMap(cql, *args).awaitSingle()
 
 /**
  * CQL 문자열 실행 결과를 지정 타입 [Flow]로 반환합니다.

--- a/spring-boot/cassandra/src/test/kotlin/io/bluetape4k/spring/cassandra/cql/ReactiveCqlOperationsSupportTest.kt
+++ b/spring-boot/cassandra/src/test/kotlin/io/bluetape4k/spring/cassandra/cql/ReactiveCqlOperationsSupportTest.kt
@@ -89,6 +89,20 @@ class ReactiveCqlOperationsSupportTest(
     }
 
     @Test
+    fun `queryForMapSuspending - CQL bind marker varargs`() = runSuspendIO {
+        val user = insertUser(newUser())
+
+        val row = reactiveCqlOps.queryForMapSuspending(
+            "SELECT * FROM users WHERE id = ? AND firstname = ? ALLOW FILTERING",
+            user.id,
+            user.firstname,
+        )
+
+        row["id"] shouldBeEqualTo user.id
+        row["firstname"] shouldBeEqualTo user.firstname
+    }
+
+    @Test
     fun `queryForResultSetSuspending - ResultSet 반환`() = runSuspendIO {
         val user = insertUser(newUser())
 

--- a/spring-boot/cassandra/src/test/kotlin/io/bluetape4k/spring/cassandra/cql/ReactiveCqlOperationsSupportUnitTest.kt
+++ b/spring-boot/cassandra/src/test/kotlin/io/bluetape4k/spring/cassandra/cql/ReactiveCqlOperationsSupportUnitTest.kt
@@ -9,6 +9,7 @@ import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import io.bluetape4k.junit5.coroutines.runSuspendIO
@@ -46,7 +47,7 @@ class ReactiveCqlOperationsSupportUnitTest {
         every { ops.queryForObject(any<Statement<*>>(), any<Class<*>>()) } answers {
             Mono.just("result") as Mono<Any>
         }
-        every { ops.queryForMap(any<String>(), any<Array<*>>()) } returns Mono.just(testMap)
+        every { ops.queryForMap(any<String>(), *anyVararg()) } returns Mono.just(testMap)
         every { ops.queryForMap(any<Statement<*>>()) } returns Mono.just(testMap)
         every { ops.queryForResultSet(any<String>(), *anyVararg()) } returns Mono.just(mockResultSet)
         every { ops.queryForResultSet(any<Statement<*>>()) } returns Mono.just(mockResultSet)
@@ -114,6 +115,19 @@ class ReactiveCqlOperationsSupportUnitTest {
         val result = mockOps.queryForMapSuspending("SELECT * FROM users WHERE id = ?", "1")
         result.shouldNotBeNull()
         result["id"] shouldBeEqualTo "1"
+    }
+
+    @Test
+    fun `queryForMapSuspending expands CQL vararg arguments`() = runSuspendIO {
+        val localOps = mockk<ReactiveCqlOperations>()
+        val cql = "SELECT * FROM users WHERE id = ? AND firstname = ?"
+
+        every { localOps.queryForMap(cql, "user-1", "Debop") } returns Mono.just(testMap)
+
+        val result = localOps.queryForMapSuspending(cql, "user-1", "Debop")
+
+        result["id"] shouldBeEqualTo "1"
+        verify(exactly = 1) { localOps.queryForMap(cql, "user-1", "Debop") }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #836

- PR 제목: fix: make Cassandra queryForMap varargs explicit

### 원문 선행 내용

Fixes #836

## Background

`ReactiveCqlOperations.queryForMapSuspending(cql, vararg args)` was reported as
potentially forwarding the Kotlin vararg array in an ambiguous shape when calling
Spring Data Cassandra's Java `Object...` API.

Local RED attempts did not reproduce a runtime failure: both a focused MockK
contract and a real Cassandra bind-marker test passed before the production
change. This PR still removes the ambiguity by using the explicit Kotlin spread
operator and by replacing the misleading array-shaped test fixture.

## What This Solves

- Makes `queryForMapSuspending` call `queryForMap(cql, *args)` explicitly.
- Updates the KDoc so the documented implementation contract matches the source.
- Changes the unit fixture from `any<Array<*>>()` to `*anyVararg()`.
- Adds a focused unit contract for two positional CQL arguments.
- Adds a real Cassandra integration test with two bind markers.

## Work Done

### 기존 섹션: Validation And Review

- `./gradlew :bluetape4k-spring-boot-cassandra:cleanTest :bluetape4k-spring-boot-cassandra:compileKotlin :bluetape4k-spring-boot-cassandra:compileTestKotlin :bluetape4k-spring-boot-cassandra:test --no-build-cache`
  - `GRADLE_STATUS=0`
  - `257 passing`
  - `BUILD SUCCESSFUL in 23s`
- `git diff --check` passed.
- Stale pattern guard for production/test source returned no matches:
  `queryForMap(cql, args)`, `queryForMap(any<String>(), any<Array...`, `any<Array<*>>()`.
- Review artifact: `docs/review/2026-06-23-issue-836-cassandra-queryformap-varargs-review.md`.
- Lesson artifact: `docs/lessons/2026-06-23-issue-836-cassandra-queryformap-varargs.md`.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #836, milestone `1.11.0`, assignee `debop`
- PR: #878, head `b573e12a7dc4868ad924937d82f596366a6899fd`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/cassandra-queryformap-varargs-836`
- Labels: `bug`, `test`, `coroutines`
- State: `MERGED`, merge commit `60a3f8a679410efa423cf1236770fbecb1f15ce7`
- CI: change. This PR still removes the ambiguity by using the explicit Kotlin spread / operator and by replacing the misleading array-shaped test fixture. / - Makes `queryForMapSuspending` call `queryForMap(cql, *args)` explicitly.

## DoD Status

| Item | Status | Evidence |
|---|---:|---|
| Issue linked | [x] | Fixes #836 |
| Implementation explicit | [x] | `queryForMap(cql, *args)` |
| Unit contract | [x] | two positional CQL args verified |
| Cassandra integration | [x] | two bind markers with `user.id`, `user.firstname` |
| Module verification | [x] | 257 passing, build successful |
| Diff hygiene | [x] | `git diff --check` passed |
| Review evidence | [x] | P0/P1 = 0 in tracked review artifact |
| Lessons captured | [x] | tracked lesson artifact committed |
| GitHub Actions | [x] | Build, CI Status, Coverage Report, Detect changed modules, gitleaks, wrapper validation, submit-gradle passed |
| Merge | [ ] | intentionally not performed per user request |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #878 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `60a3f8a679410efa423cf1236770fbecb1f15ce7`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
