### PR TITLE
fix: preserve Redis JDK serializer deprecation

### DIFF
--- a/docs/lessons/2026-06-23-issue-835-redis-jdk-serializer-deprecation.md
+++ b/docs/lessons/2026-06-23-issue-835-redis-jdk-serializer-deprecation.md
@@ -1,0 +1,23 @@
+# Lessons Learned - Redis JDK serializer deprecation (#835, 2026-06-23)
+
+Related issue: #835
+Affected module: `:bluetape4k-spring-boot-redis`
+
+## L1: Wrapper constants must preserve lower-level security signals
+
+`BinarySerializers.Jdk` already carried a deprecation warning for JDK
+deserialization RCE risk, but the Redis-facing convenience constants did not
+repeat that warning. Public module boundaries should not hide security guidance
+from the lower-level API they wrap, especially at persistence or network
+boundaries such as Redis.
+
+The Redis constants now carry explicit deprecation annotations and replacement
+guidance, and the reflection contract test checks that future JDK Redis
+constants cannot be reintroduced without the warning.
+
+## L2: README serializer tables need status, not only capability
+
+A serializer matrix that lists JDK, Kryo, and Fory as peers can normalize unsafe
+defaults even when the implementation is technically correct. User-facing tables
+should distinguish recommended serializers from trusted-data-only legacy choices
+when deserialization risk is part of the contract.

--- a/docs/review/2026-06-23-issue-835-redis-jdk-serializer-deprecation-review.md
+++ b/docs/review/2026-06-23-issue-835-redis-jdk-serializer-deprecation-review.md
@@ -1,0 +1,66 @@
+# Code Review - Issue #835 Redis JDK serializer deprecation
+
+Date: 2026-06-23
+Issue: #835
+Module: `:bluetape4k-spring-boot-redis`
+
+## Summary
+
+Redis-facing JDK serializer constants now preserve the lower-level JDK
+deserialization deprecation warning and guide callers toward Kryo or Fory.
+The README serializer matrices now mark JDK variants as deprecated,
+trusted-data-only choices.
+
+## Findings
+
+- P0: 0
+- P1: 0
+- P2: 0
+- P3: 0
+
+## Review Follow-up
+
+- Fixed the review finding that a source-text regex guard could pass when only
+  the first JDK constant carried the warning.
+- Replaced that guard with Kotlin reflection over `RedisBinarySerializers`
+  member properties, checking each expected JDK property for a `Deprecated`
+  annotation and exact `ReplaceWith` expression.
+- Added an unexpected-`*Jdk` property guard so future Redis JDK constants must
+  be explicitly added to the deprecation contract.
+- Suppressed deprecation only at intentional legacy-serializer test call sites.
+
+## Verification
+
+RED:
+
+```text
+./gradlew :bluetape4k-spring-boot-redis:test --tests 'io.bluetape4k.spring.redis.serializer.RedisBinarySerializerTest' --no-build-cache
+GRADLE_STATUS=1
+1 failing
+Redis JDK serializer constants preserve deprecation warning
+```
+
+The first reflection-based RED attempt was discarded because it passed before
+the production annotation existed. The failing source-contract RED established
+the missing-warning behavior before implementation.
+
+GREEN:
+
+```text
+./gradlew :bluetape4k-spring-boot-redis:cleanTest :bluetape4k-spring-boot-redis:compileKotlin :bluetape4k-spring-boot-redis:compileTestKotlin :bluetape4k-spring-boot-redis:test --no-build-cache
+GRADLE_STATUS=0
+83 passing
+BUILD SUCCESSFUL in 8s
+```
+
+Static checks:
+
+```text
+git diff --check
+clean
+```
+
+## Scope Notes
+
+- Full repository build was not run.
+- Merge is intentionally out of scope for this PR per user instruction.

--- a/spring-boot/redis/README.ko.md
+++ b/spring-boot/redis/README.ko.md
@@ -92,23 +92,27 @@ fun redisTemplate(factory: RedisConnectionFactory): RedisTemplate<String, Any> {
 
 ### 직렬화 (객체 → ByteArray)
 
-| 상수                                  | 직렬화 엔진 | 압축     |
-|-------------------------------------|--------|--------|
-| `RedisBinarySerializers.Jdk`        | JDK    | 없음     |
-| `RedisBinarySerializers.Kryo`       | Kryo   | 없음     |
-| `RedisBinarySerializers.Fory`       | Fory   | 없음     |
-| `RedisBinarySerializers.GzipJdk`    | JDK    | GZip   |
-| `RedisBinarySerializers.LZ4Jdk`     | JDK    | LZ4    |
-| `RedisBinarySerializers.SnappyJdk`  | JDK    | Snappy |
-| `RedisBinarySerializers.ZstdJdk`    | JDK    | Zstd   |
-| `RedisBinarySerializers.GzipKryo`   | Kryo   | GZip   |
-| `RedisBinarySerializers.LZ4Kryo`    | Kryo   | LZ4    |
-| `RedisBinarySerializers.SnappyKryo` | Kryo   | Snappy |
-| `RedisBinarySerializers.ZstdKryo`   | Kryo   | Zstd   |
-| `RedisBinarySerializers.GzipFory`   | Fory   | GZip   |
-| `RedisBinarySerializers.LZ4Fory`    | Fory   | LZ4    |
-| `RedisBinarySerializers.SnappyFory` | Fory   | Snappy |
-| `RedisBinarySerializers.ZstdFory`   | Fory   | Zstd   |
+JDK 역직렬화는 Redis에 저장된 값이 gadget chain 기반 RCE 위험에 노출될 수 있습니다. JDK
+serializer 상수는 deprecated 상태이며, 저장된 Redis 데이터가 완전히 신뢰 가능한 경우에만
+사용하세요. 일반 Redis 객체 값에는 Kryo 또는 Fory를 권장합니다.
+
+| 상수                                  | 직렬화 엔진 | 압축     | 상태                 |
+|-------------------------------------|--------|--------|--------------------|
+| `RedisBinarySerializers.Jdk`        | JDK    | 없음     | Deprecated; 신뢰 데이터 전용 |
+| `RedisBinarySerializers.Kryo`       | Kryo   | 없음     | 권장                 |
+| `RedisBinarySerializers.Fory`       | Fory   | 없음     | 권장                 |
+| `RedisBinarySerializers.GzipJdk`    | JDK    | GZip   | Deprecated; 신뢰 데이터 전용 |
+| `RedisBinarySerializers.LZ4Jdk`     | JDK    | LZ4    | Deprecated; 신뢰 데이터 전용 |
+| `RedisBinarySerializers.SnappyJdk`  | JDK    | Snappy | Deprecated; 신뢰 데이터 전용 |
+| `RedisBinarySerializers.ZstdJdk`    | JDK    | Zstd   | Deprecated; 신뢰 데이터 전용 |
+| `RedisBinarySerializers.GzipKryo`   | Kryo   | GZip   | 권장                 |
+| `RedisBinarySerializers.LZ4Kryo`    | Kryo   | LZ4    | 권장                 |
+| `RedisBinarySerializers.SnappyKryo` | Kryo   | Snappy | 권장                 |
+| `RedisBinarySerializers.ZstdKryo`   | Kryo   | Zstd   | 권장                 |
+| `RedisBinarySerializers.GzipFory`   | Fory   | GZip   | 권장                 |
+| `RedisBinarySerializers.LZ4Fory`    | Fory   | LZ4    | 권장                 |
+| `RedisBinarySerializers.SnappyFory` | Fory   | Snappy | 권장                 |
+| `RedisBinarySerializers.ZstdFory`   | Fory   | Zstd   | 권장                 |
 
 ### 압축 전용 (ByteArray → ByteArray)
 

--- a/spring-boot/redis/README.md
+++ b/spring-boot/redis/README.md
@@ -93,23 +93,27 @@ fun redisTemplate(factory: RedisConnectionFactory): RedisTemplate<String, Any> {
 
 ### Object Serializers (Object → ByteArray)
 
-| Constant                            | Serialization Engine | Compression |
-|-------------------------------------|----------------------|-------------|
-| `RedisBinarySerializers.Jdk`        | JDK                  | None        |
-| `RedisBinarySerializers.Kryo`       | Kryo                 | None        |
-| `RedisBinarySerializers.Fory`       | Fory                 | None        |
-| `RedisBinarySerializers.GzipJdk`    | JDK                  | GZip        |
-| `RedisBinarySerializers.LZ4Jdk`     | JDK                  | LZ4         |
-| `RedisBinarySerializers.SnappyJdk`  | JDK                  | Snappy      |
-| `RedisBinarySerializers.ZstdJdk`    | JDK                  | Zstd        |
-| `RedisBinarySerializers.GzipKryo`   | Kryo                 | GZip        |
-| `RedisBinarySerializers.LZ4Kryo`    | Kryo                 | LZ4         |
-| `RedisBinarySerializers.SnappyKryo` | Kryo                 | Snappy      |
-| `RedisBinarySerializers.ZstdKryo`   | Kryo                 | Zstd        |
-| `RedisBinarySerializers.GzipFory`   | Fory                 | GZip        |
-| `RedisBinarySerializers.LZ4Fory`    | Fory                 | LZ4         |
-| `RedisBinarySerializers.SnappyFory` | Fory                 | Snappy      |
-| `RedisBinarySerializers.ZstdFory`   | Fory                 | Zstd        |
+JDK deserialization can expose Redis values to RCE gadget-chain risk. The JDK
+serializer constants are deprecated and should be used only when the stored Redis
+data is fully trusted. Prefer Kryo or Fory for general Redis object values.
+
+| Constant                            | Serialization Engine | Compression | Status |
+|-------------------------------------|----------------------|-------------|--------|
+| `RedisBinarySerializers.Jdk`        | JDK                  | None        | Deprecated; trusted data only |
+| `RedisBinarySerializers.Kryo`       | Kryo                 | None        | Recommended |
+| `RedisBinarySerializers.Fory`       | Fory                 | None        | Recommended |
+| `RedisBinarySerializers.GzipJdk`    | JDK                  | GZip        | Deprecated; trusted data only |
+| `RedisBinarySerializers.LZ4Jdk`     | JDK                  | LZ4         | Deprecated; trusted data only |
+| `RedisBinarySerializers.SnappyJdk`  | JDK                  | Snappy      | Deprecated; trusted data only |
+| `RedisBinarySerializers.ZstdJdk`    | JDK                  | Zstd        | Deprecated; trusted data only |
+| `RedisBinarySerializers.GzipKryo`   | Kryo                 | GZip        | Recommended |
+| `RedisBinarySerializers.LZ4Kryo`    | Kryo                 | LZ4         | Recommended |
+| `RedisBinarySerializers.SnappyKryo` | Kryo                 | Snappy      | Recommended |
+| `RedisBinarySerializers.ZstdKryo`   | Kryo                 | Zstd        | Recommended |
+| `RedisBinarySerializers.GzipFory`   | Fory                 | GZip        | Recommended |
+| `RedisBinarySerializers.LZ4Fory`    | Fory                 | LZ4         | Recommended |
+| `RedisBinarySerializers.SnappyFory` | Fory                 | Snappy      | Recommended |
+| `RedisBinarySerializers.ZstdFory`   | Fory                 | Zstd        | Recommended |
 
 ### Compression-only (ByteArray → ByteArray)
 

--- a/spring-boot/redis/src/main/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializers.kt
+++ b/spring-boot/redis/src/main/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializers.kt
@@ -19,6 +19,15 @@ import io.bluetape4k.io.serializer.BinarySerializers
  */
 object RedisBinarySerializers {
 
+    private const val JDK_SERIALIZATION_DEPRECATION_MESSAGE =
+        "JDK deserialization can expose Redis values to RCE gadget-chain risk. " +
+            "Use RedisBinarySerializers.Kryo or RedisBinarySerializers.Fory unless Redis data is fully trusted."
+
+    @Deprecated(
+        message = JDK_SERIALIZATION_DEPRECATION_MESSAGE,
+        ReplaceWith("RedisBinarySerializers.Kryo")
+    )
+    @Suppress("DEPRECATION")
     val Jdk by lazy { RedisBinarySerializer(BinarySerializers.Jdk) }
     val Kryo by lazy { RedisBinarySerializer(BinarySerializers.Kryo) }
     val Fory by lazy { RedisBinarySerializer(BinarySerializers.Fory) }
@@ -28,9 +37,32 @@ object RedisBinarySerializers {
     val Snappy by lazy { RedisCompressSerializer(Compressors.Snappy) }
     val Zstd by lazy { RedisCompressSerializer(Compressors.Zstd) }
 
+    @Deprecated(
+        message = JDK_SERIALIZATION_DEPRECATION_MESSAGE,
+        ReplaceWith("RedisBinarySerializers.GzipKryo")
+    )
+    @Suppress("DEPRECATION")
     val GzipJdk by lazy { RedisBinarySerializer(BinarySerializers.GZipJdk) }
+
+    @Deprecated(
+        message = JDK_SERIALIZATION_DEPRECATION_MESSAGE,
+        ReplaceWith("RedisBinarySerializers.LZ4Kryo")
+    )
+    @Suppress("DEPRECATION")
     val LZ4Jdk by lazy { RedisBinarySerializer(BinarySerializers.LZ4Jdk) }
+
+    @Deprecated(
+        message = JDK_SERIALIZATION_DEPRECATION_MESSAGE,
+        ReplaceWith("RedisBinarySerializers.SnappyKryo")
+    )
+    @Suppress("DEPRECATION")
     val SnappyJdk by lazy { RedisBinarySerializer(BinarySerializers.SnappyJdk) }
+
+    @Deprecated(
+        message = JDK_SERIALIZATION_DEPRECATION_MESSAGE,
+        ReplaceWith("RedisBinarySerializers.ZstdKryo")
+    )
+    @Suppress("DEPRECATION")
     val ZstdJdk by lazy { RedisBinarySerializer(BinarySerializers.ZstdJdk) }
 
     val GzipKryo by lazy { RedisBinarySerializer(BinarySerializers.GZipKryo) }

--- a/spring-boot/redis/src/test/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializerTest.kt
+++ b/spring-boot/redis/src/test/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializerTest.kt
@@ -1,13 +1,44 @@
 package io.bluetape4k.spring.redis.serializer
 
-import io.bluetape4k.io.serializer.BinarySerializers
-import io.bluetape4k.support.emptyByteArray
+import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.io.serializer.BinarySerializers
+import io.bluetape4k.support.emptyByteArray
 import org.junit.jupiter.api.Test
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.memberProperties
 
 class RedisBinarySerializerTest: AbstractRedisSerializerTest() {
+
+    @Test
+    fun `Redis JDK serializer constants preserve deprecation warning`() {
+        val expectedReplacements = mapOf(
+            "Jdk" to "RedisBinarySerializers.Kryo",
+            "GzipJdk" to "RedisBinarySerializers.GzipKryo",
+            "LZ4Jdk" to "RedisBinarySerializers.LZ4Kryo",
+            "SnappyJdk" to "RedisBinarySerializers.SnappyKryo",
+            "ZstdJdk" to "RedisBinarySerializers.ZstdKryo",
+        )
+        val properties = RedisBinarySerializers::class.memberProperties.associateBy { it.name }
+        val invalidDeprecations = expectedReplacements
+            .filter { (propertyName, replacement) ->
+                val deprecation = properties[propertyName]?.findAnnotation<Deprecated>()
+                deprecation == null ||
+                    !deprecation.message.contains("JDK deserialization can expose Redis values to RCE gadget-chain risk") ||
+                    deprecation.replaceWith.expression != replacement
+            }
+            .keys
+
+        invalidDeprecations.toList().shouldBeEmpty()
+        RedisBinarySerializers::class.memberProperties
+            .filter { it.name.endsWith("Jdk") && it.name !in expectedReplacements.keys }
+            .shouldBeEmpty()
+        expectedReplacements.values shouldContain "RedisBinarySerializers.Kryo"
+        expectedReplacements.values shouldContain "RedisBinarySerializers.ZstdKryo"
+    }
 
     @Test
     fun `null 직렬화는 emptyByteArray 를 반환한다`() {
@@ -70,6 +101,7 @@ class RedisBinarySerializerTest: AbstractRedisSerializerTest() {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `데이터 클래스를 Jdk로 직렬화 후 복원한다`() {
         val serializer = RedisBinarySerializer(BinarySerializers.Jdk)
         val original = TestData(id = 4L, name = "Dave", description = "JDK 직렬화 테스트")

--- a/spring-boot/redis/src/test/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializersTest.kt
+++ b/spring-boot/redis/src/test/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializersTest.kt
@@ -15,6 +15,7 @@ class RedisBinarySerializersTest: AbstractRedisSerializerTest() {
     companion object {
 
         @JvmStatic
+        @Suppress("DEPRECATION")
         fun binarySerializers(): Stream<Arguments> = Stream.of(
             Arguments.of(RedisBinarySerializers.Jdk, "Jdk"),
             Arguments.of(RedisBinarySerializers.Kryo, "Kryo"),


### PR DESCRIPTION
## Summary

Closes #835

- PR 제목: fix: preserve Redis JDK serializer deprecation

Fixes #835.

- Deprecate Redis-facing JDK serializer constants with the same RCE gadget-chain warning as the underlying JDK binary serializers.
- Point each Redis JDK serializer to the closest Kryo replacement through `ReplaceWith`.
- Mark Redis JDK serializers as deprecated/trusted-data-only in English and Korean README serializer matrices.
- Add a reflection contract test that fails if Redis `*Jdk` constants are missing deprecation metadata or exact replacements.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Notes

- This PR is independent from open Cassandra PR #878; it is not stacked.
- Full repository build was not run.

## Validation

- `./gradlew :bluetape4k-spring-boot-redis:cleanTest :bluetape4k-spring-boot-redis:compileKotlin :bluetape4k-spring-boot-redis:compileTestKotlin :bluetape4k-spring-boot-redis:test --no-build-cache` -> `83 passing`, `BUILD SUCCESSFUL in 8s`
- `git diff --check` -> clean
- `repo-status` -> branch `fix/redis-jdk-serializer-deprecation-835`, upstream current with `origin/develop` before commit

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #835, milestone `1.11.0`, assignee `debop`
- PR: #882, head `84f96b9d92628f61b67291481c683ebecc2c17bf`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/redis-jdk-serializer-deprecation-835`
- Labels: `bug`, `documentation`
- State: `MERGED`, merge commit `de8b6f391f88d433debfe38812399a8c703342d5`
- CI: - Deprecate Redis-facing JDK serializer constants with the same RCE gadget-chain warning as the underlying JDK binary serializers. / - `./gradlew :bluetape4k-spring-boot-redis:cleanTest :bluetape4k-spring-boot-redis:compileKotlin :bluetape4k-spring-boot-redis:compileTestKotlin :bluetape4k-spring-boot-redis:test --no-build-cache` -> `83 passing`, `BUILD SUCCESSFUL in 8s`

## DoD Status

- [x] Issue #835 reviewed and scoped.
- [x] Redis JDK serializer constants carry deprecation warning and replacement guidance.
- [x] README.md and README.ko.md document trusted-data-only JDK serializer status.
- [x] Regression/API guard added for Redis JDK deprecation metadata.
- [x] Targeted Redis module verification passed.
- [x] Review and lesson artifacts added.
- [x] GitHub Actions passed.
- [ ] Merge completed.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #882 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `de8b6f391f88d433debfe38812399a8c703342d5`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
