### PR TITLE
refactor: keep MinIO compatibility tests quiet

### DIFF
--- a/docs/lessons/2026-06-23-issue-880-testcontainers-floci-minio.md
+++ b/docs/lessons/2026-06-23-issue-880-testcontainers-floci-minio.md
@@ -1,0 +1,28 @@
+# Lessons Learned - Testcontainers Floci and MinIO policy (#880, 2026-06-23)
+
+Related issue: #880
+Affected module: `:bluetape4k-testcontainers`
+
+## L1: Deprecation policy must not make supported compatibility fixtures noisy
+
+`MinIOServer` is still a supported fixture for direct MinIO compatibility
+tests. Marking the class itself as deprecated made every internal factory,
+launcher, and direct compatibility test look like migration debt even though
+the 1.11.0 policy keeps this fixture available.
+
+The class-level deprecation was removed, and a reflection contract test now
+checks that `MinIOServer` remains non-deprecated while it is supported.
+
+## L2: Default AWS/S3 emulator guidance belongs on the wrapper boundary
+
+New AWS/S3 emulator tests should use the current AWS emulator path instead of
+defaulting to MinIO. The durable guidance now lives in `MinIOServer` KDoc and
+the `testing/testcontainers` README locale set: use `FlociServer` or
+`MiniStackServer` for new AWS/S3 emulator coverage, and use `MinIOServer` only
+for explicit MinIO compatibility behavior.
+
+## L3: Pinned emulator image tags need contract tests
+
+The Docker Hub release tag `1.5.27` was verified on 2026-06-23. `FlociServer`
+keeps a pinned release tag for reproducible Testcontainers runs, and
+`FlociServerTest` guards that value so future tag changes are deliberate.

--- a/docs/review/2026-06-23-issue-880-testcontainers-floci-minio-review.md
+++ b/docs/review/2026-06-23-issue-880-testcontainers-floci-minio-review.md
@@ -1,0 +1,96 @@
+# Code Review - Issue #880 Testcontainers Floci and MinIO policy
+
+Date: 2026-06-23
+Issue: #880
+Module: `:bluetape4k-testcontainers`
+
+## Summary
+
+`MinIOServer` remains available for explicit MinIO compatibility tests without
+class-level deprecation noise. `FlociServer.TAG` is pinned to the verified
+`1.5.27` release tag, and README/KDoc guidance keeps new AWS/S3 emulator tests
+on `FlociServer` or `MiniStackServer`.
+
+## Findings
+
+- P0: 0
+- P1: 0
+- P2: 0
+- P3: 0
+
+## Independent Review Notes
+
+- Code reviewer: PASS, no findings.
+- Verifier: pre-commit readiness FAIL because the worktree was intentionally
+  dirty before commit and the verifier did not independently replay the RED
+  state before interruption. Implementation evidence had no P0 behavior blocker.
+  The dirty-worktree concern is resolved by committing this branch before PR
+  creation.
+
+## RED Evidence
+
+Baseline compile checks:
+
+```text
+./gradlew :bluetape4k-testcontainers:compileKotlin --warning-mode all --rerun-tasks
+No MinIOServer deprecation warning reproduced; only Gradle deprecation warnings were filtered.
+
+./gradlew :bluetape4k-testcontainers:compileTestKotlin --warning-mode all --rerun-tasks
+No MinIOServer deprecation warning reproduced; LocalStack/Gradle deprecation warnings remained.
+```
+
+Contract RED:
+
+```text
+./gradlew :bluetape4k-testcontainers:test \
+  --tests 'io.bluetape4k.testcontainers.aws.FlociServerTest.Floci server uses the current stable image tag' \
+  --tests 'io.bluetape4k.testcontainers.storage.MinIOServerTest.MinIOServer remains available for explicit MinIO compatibility tests' \
+  --no-build-cache
+
+GRADLE_STATUS=1
+FlociServerTest: Expected "1.5.17" to equal to "1.5.27"
+MinIOServerTest: Expected @Deprecated(...) to be null
+```
+
+## GREEN Evidence
+
+```text
+./gradlew :bluetape4k-testcontainers:test \
+  --tests 'io.bluetape4k.testcontainers.aws.FlociServerTest.Floci server uses the current stable image tag' \
+  --tests 'io.bluetape4k.testcontainers.storage.MinIOServerTest.MinIOServer remains available for explicit MinIO compatibility tests' \
+  --no-build-cache
+
+2 passing, 0 failures
+```
+
+```text
+./gradlew :bluetape4k-testcontainers:compileKotlin \
+  :bluetape4k-testcontainers:compileTestKotlin \
+  :bluetape4k-testcontainers:cleanTest \
+  :bluetape4k-testcontainers:test \
+  --tests '*FlociServerTest' \
+  --tests '*MinIOServerTest' \
+  --no-build-cache --warning-mode all
+
+10 passing, 0 failures
+```
+
+```text
+./gradlew :bluetape4k-testcontainers:compileKotlin --warning-mode all --rerun-tasks
+BUILD SUCCESSFUL in 7s
+MinIOServer warning filter: no MinIOServer, MinIO core, or old replacement warning matches
+```
+
+Static checks:
+
+```text
+git diff --check
+clean
+```
+
+## Scope Notes
+
+- Docker Hub `floci/floci` release tags were checked on 2026-06-23; latest plain `1.5.x` release tag was `1.5.27`.
+- Gradle 10 deprecation cleanup remains out of scope.
+- Full repository build was not run.
+- Merge is intentionally out of scope for this PR per user instruction.

--- a/testing/testcontainers/README.ko.md
+++ b/testing/testcontainers/README.ko.md
@@ -23,6 +23,7 @@ Testcontainers `2.0.3` 기반 통합 테스트를 빠르게 구성하기 위한 
 - **DB 서버 지원**: MySQL, MariaDB, PostgreSQL, PostGIS, pgvector, Cockroach, ClickHouse
 - **Graph DB 서버 지원**: Neo4j, Memgraph, FalkorDB, PostgreSQL + Apache AGE
 - **Storage 서버 지원**: Redis/Redis Cluster, MongoDB, Cassandra, Elasticsearch/OSS/OpenSearch, MinIO, InfluxDB
+- `MinIOServer`는 명시적인 MinIO 호환성 테스트용으로 유지하며, 신규 AWS/S3 에뮬레이터 테스트는 `FlociServer` 또는 `MiniStackServer`를 사용하세요.
 - **분산 캐시/그리드**: `HazelcastServer` (5.x slim), `Ignite2Server`, `Ignite3Server` (클러스터 자동 초기화)
 - **MQ 서버 지원**: Kafka, RabbitMQ, Pulsar, Nats, Redpanda
 - **Infra 서버 지원**: Consul, Vault, Prometheus, Jaeger, Zipkin, ZooKeeper, Toxiproxy, Keycloak

--- a/testing/testcontainers/README.md
+++ b/testing/testcontainers/README.md
@@ -21,6 +21,7 @@ A server wrapper and utility library for building integration tests quickly on t
 ## Key Features
 
 - Wrappers for database, graph DB, storage, messaging, infrastructure, distributed SQL, and LLM services
+- `MinIOServer` remains available for explicit MinIO compatibility tests; use `FlociServer` or `MiniStackServer` for new AWS/S3 emulator tests
 - HTTP mocking through WireMock and NginxServer
 - **AWS Emulator support**: `AwsEmulatorServer` common interface; `MiniStackServer` (31+ services, MIT license, recommended), `FlociServer` (open-source LocalStack replacement), `LocalStackServer` (@Deprecated)
 - **Embedded SQS**: `ElasticMqServer` runs an in-process SQS server — no Docker needed

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/FlociServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/FlociServer.kt
@@ -55,7 +55,7 @@ class FlociServer private constructor(
         const val IMAGE = "floci/floci"
 
         /** Default pinned Floci Docker image tag. */
-        const val TAG = "1.5.17"
+        const val TAG = "1.5.27"
 
         /** PropertyExportingServer namespace and container identifier. */
         const val NAME = "floci"

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/MinIOServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/MinIOServer.kt
@@ -11,19 +11,19 @@ import org.testcontainers.containers.MinIOContainer
 import org.testcontainers.utility.DockerImageName
 
 /**
- * [MinIO](https://min.io) Server 를 Docker container 로 실행해주는 클래스입니다.
+ * Testcontainers wrapper for running a [MinIO](https://min.io) server.
  *
- * 참고: [MinIO Docker image](https://hub.docker.com/r/minio/minio/tags)
+ * Keep this server for explicit MinIO compatibility tests. For new AWS or
+ * S3-compatible emulator tests, prefer
+ * [FlociServer][io.bluetape4k.testcontainers.aws.FlociServer] or
+ * [MiniStackServer][io.bluetape4k.testcontainers.aws.MiniStackServer].
  *
- * @param imageName      Docker image name ([DockerImageName])
- * @param useDefaultPort Default port 를 사용할지 여부
- * @param reuse          재사용 여부
+ * Reference: [MinIO Docker image](https://hub.docker.com/r/minio/minio/tags)
+ *
+ * @param imageName Docker image name.
+ * @param useDefaultPort Whether to bind MinIO ports directly.
+ * @param reuse Whether to enable Testcontainers reuse.
  */
-@Deprecated(
-    message = "MinIO core는 2026-04-25에 archived 되었습니다. S3 호환 에뮬레이터가 필요한 경우 FlociServer 또는 LocalStackServer를 사용하세요.",
-    replaceWith = ReplaceWith("FlociServer", "io.bluetape4k.testcontainers.aws.FlociServer"),
-    level = DeprecationLevel.WARNING
-)
 class MinIOServer private constructor(
     imageName: DockerImageName,
     useDefaultPort: Boolean,

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/FlociServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/FlociServerTest.kt
@@ -34,7 +34,7 @@ class FlociServerTest: AbstractContainerTest() {
 
     @Test
     fun `Floci server uses the current stable image tag`() {
-        FlociServer.TAG shouldBeEqualTo "1.5.17"
+        FlociServer.TAG shouldBeEqualTo "1.5.27"
     }
 
     @Test

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/MinIOServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/MinIOServerTest.kt
@@ -1,5 +1,10 @@
 package io.bluetape4k.testcontainers.storage
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNullOrBlank
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.testcontainers.AbstractContainerTest
@@ -7,17 +12,19 @@ import io.minio.BucketExistsArgs
 import io.minio.MakeBucketArgs
 import io.minio.StatObjectArgs
 import io.minio.UploadObjectArgs
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeTrue
-import io.bluetape4k.assertions.shouldNotBeNullOrBlank
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.testcontainers.utility.Base58
-import io.bluetape4k.assertions.assertFailsWith
+import kotlin.reflect.full.findAnnotation
 
 class MinIOServerTest: AbstractContainerTest() {
 
     companion object: KLogging()
+
+    @Test
+    fun `MinIOServer remains available for explicit MinIO compatibility tests`() {
+        MinIOServer::class.findAnnotation<Deprecated>().shouldBeNull()
+    }
 
     @Nested
     inner class UseDockerPort {


### PR DESCRIPTION
## Summary

Closes #880

- PR 제목: refactor: keep MinIO compatibility tests quiet

Fixes #880.

- Remove class-level deprecation from `MinIOServer` so explicit MinIO compatibility tests stay supported and quiet.
- Pin `FlociServer.TAG` to the verified `1.5.27` Docker Hub release tag.
- Add contract coverage for the Floci tag and non-deprecated MinIO fixture policy.
- Update KDoc plus English/Korean README guidance: use `FlociServer` or `MiniStackServer` for new AWS/S3 emulator tests, and `MinIOServer` only for direct MinIO compatibility.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Notes

- This PR is independent from open PRs #878 and #882; it is not stacked.
- Gradle 10 deprecation cleanup remains out of scope.
- Full repository build was not run.

## Validation

- Docker Hub `floci/floci` checked on 2026-06-23: latest plain `1.5.x` release tag is `1.5.27`; `1.5.27` exists alongside `1.5.27-compat`.
- RED contract:
  - `FlociServerTest` failed with `Expected "1.5.17" to equal to "1.5.27"`.
  - `MinIOServerTest` failed because `MinIOServer::class.findAnnotation<Deprecated>()` returned the existing deprecation annotation.
- `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.aws.FlociServerTest.Floci server uses the current stable image tag' --tests 'io.bluetape4k.testcontainers.storage.MinIOServerTest.MinIOServer remains available for explicit MinIO compatibility tests' --no-build-cache` -> `2 passing`
- `./gradlew :bluetape4k-testcontainers:compileKotlin :bluetape4k-testcontainers:compileTestKotlin :bluetape4k-testcontainers:cleanTest :bluetape4k-testcontainers:test --tests '*FlociServerTest' --tests '*MinIOServerTest' --no-build-cache --warning-mode all` -> `10 passing`
- `./gradlew :bluetape4k-testcontainers:compileKotlin --warning-mode all --rerun-tasks` -> `BUILD SUCCESSFUL in 7s`; no `MinIOServer`, `MinIO core`, or old replacement warning matches
- `git diff --check` -> clean
- Code review: PASS, no findings

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #880, milestone `1.11.0`, assignee `debop`
- PR: #883, head `9b5d07412945370ffcdbbf4b36392c6b67ebb932`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `refactor-testcontainers-floci-minio-880`
- Labels: `test`, `dependencies`, `refactor`, `tech-debt`
- State: `MERGED`, merge commit `666506154c28d3b1a436176ab172c7e634cbe22d`
- CI: - Remove class-level deprecation from `MinIOServer` so explicit MinIO compatibility tests stay supported and quiet. / - Pin `FlociServer.TAG` to the verified `1.5.27` Docker Hub release tag. / - Add contract coverage for the Floci tag and non-deprecated MinIO fixture policy.

## DoD Status

- [x] Issue #880 reviewed and scoped.
- [x] Independent branch created from `origin/develop`.
- [x] `MinIOServer` class-level deprecation removed.
- [x] `FlociServer.TAG` pinned to `1.5.27`.
- [x] KDoc and README.md/README.ko.md guidance updated.
- [x] RED contract failures captured.
- [x] Targeted Testcontainers validation passed.
- [x] Review and lesson artifacts added.
- [x] GitHub Actions passed.
- [ ] Merge completed.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #883 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `666506154c28d3b1a436176ab172c7e634cbe22d`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
