### PR TITLE
refactor: migrate NetCDF catalog metadata access

### DIFF
--- a/docs/lessons/2026-06-23-issue-881-science-netcdf-api.md
+++ b/docs/lessons/2026-06-23-issue-881-science-netcdf-api.md
@@ -1,0 +1,43 @@
+# Issue #881 Science NetCDF API Migration
+
+Issue #881 tracked Java deprecation warnings in `NetCdfCatalogService` caused by
+metadata access through deprecated NetCDF-Java bean properties:
+
+- `Variable.getAttributes()`, surfaced in Kotlin as `v.attributes`
+- `NetcdfFile.getDimensions()`, surfaced in Kotlin as `nc.dimensions`
+
+## Decision
+
+Use the NetCDF-Java 5.9.1 replacement API where the current source points:
+
+- variable attributes come from `Variable.attributes()`
+- root-file dimensions come from `nc.rootGroup.getDimensions()`
+
+The service still writes the same bluetape4k domain shape:
+
+- `NetCdfVariableInfo.attributes`
+- `NetCdfFileRecord.dimensions`
+- `NetCdfFileRecord.globalAttrs`
+
+No repository, schema, import, or Gradle 10 cleanup behavior changed.
+
+## Lessons
+
+- Kotlin bean-property syntax can hide deprecated Java getters. When a Java
+  library deprecates a getter, prefer explicit method calls or a local helper
+  that names the intended API.
+- `NetcdfFile.getDimensions()` is a global view that NetCDF-Java discourages.
+  For the current registration behavior, root group dimensions preserve the
+  existing root-file metadata shape without recursing through nested groups.
+- The simple source grep is useful for this issue because it catches accidental
+  reintroduction of the deprecated Kotlin property forms.
+
+## Verification
+
+- `./gradlew :bluetape4k-science:compileKotlin --warning-mode all`
+- `./gradlew :bluetape4k-science:compileTestKotlin --warning-mode all`
+- `./gradlew :bluetape4k-science:test --tests '*NetCdfCatalogServiceTest' --tests '*NetCdfTableTest'`
+  passed with 37 tests.
+- `rg "\.attributes\b|\.dimensions\b" utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt`
+  returned no matches.
+- `git diff --check` passed.

--- a/docs/review/2026-06-23-issue-881-science-netcdf-api-review.md
+++ b/docs/review/2026-06-23-issue-881-science-netcdf-api-review.md
@@ -1,0 +1,31 @@
+# Issue #881 Science NetCDF API Migration Review
+
+## Scope
+
+- `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt`
+
+## Verdict
+
+Local 7-tier equivalent review: APPROVE.
+
+P0/P1 findings: 0.
+
+## Review Notes
+
+| Lens | Finding | Severity | Resolution |
+|---|---|---:|---|
+| API migration | Kotlin `v.attributes` called deprecated `Variable.getAttributes()`. | P1 | Registration now reads variable metadata through the current `Variable.attributes()` API. |
+| API migration | Kotlin `nc.dimensions` called deprecated `NetcdfFile.getDimensions()`. | P1 | Registration now reads root dimensions through `nc.rootGroup.getDimensions()`. |
+| Output compatibility | The migration must keep JSONB domain shapes stable. | P1 | `NetCdfVariableInfo.attributes`, `NetCdfFileRecord.dimensions`, and `globalAttrs` mapping logic is unchanged. |
+| Scope control | Gradle 10 cleanup warnings are out of scope. | P3 | No Gradle build-script cleanup was included. |
+| Regression evidence | Representative registration and persistence paths must stay equivalent. | P1 | `NetCdfCatalogServiceTest` and `NetCdfTableTest` passed with 37 tests. |
+
+## Verification
+
+- `./gradlew :bluetape4k-science:compileKotlin --warning-mode all` passed.
+- `./gradlew :bluetape4k-science:compileTestKotlin --warning-mode all` passed.
+- `./gradlew :bluetape4k-science:test --tests '*NetCdfCatalogServiceTest' --tests '*NetCdfTableTest'` passed:
+  - `NetCdfCatalogServiceTest`: 33 tests, 0 failures, 0 errors, 0 skipped.
+  - `NetCdfTableTest`: 4 tests, 0 failures, 0 errors, 0 skipped.
+- `rg "\.attributes\b|\.dimensions\b" utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt` returned no matches.
+- `git diff --check` passed.

--- a/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt
+++ b/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt
@@ -15,6 +15,7 @@ import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import ucar.ma2.Array as UcarArray
+import ucar.nc2.Attribute
 import ucar.nc2.NetcdfFiles
 import ucar.nc2.Variable
 import ucar.nc2.dataset.NetcdfDataset
@@ -95,12 +96,12 @@ class NetCdfCatalogService(
                             name = v.fullName,
                             dataType = v.dataType.name,
                             shape = v.shape.toList(),
-                            attributes = v.attributes.associate { attr ->
+                            attributes = v.netCdfAttributes().associate { attr ->
                                 attr.shortName to (attr.stringValue ?: attr.numericValue?.toString().orEmpty())
                             },
                         )
                     }
-                    val dimensions = nc.dimensions.associate { it.shortName to it.length }
+                    val dimensions = nc.rootGroup.getDimensions().associate { it.shortName to it.length }
                     val globalAttrs = nc.globalAttributes.associate { attr ->
                         attr.shortName to (attr.stringValue ?: attr.numericValue?.toString().orEmpty())
                     }
@@ -537,4 +538,6 @@ class NetCdfCatalogService(
     private data class ImportLease(
         var expiresAt: Instant,
     )
+
+    private fun Variable.netCdfAttributes(): Iterable<Attribute> = attributes()
 }


### PR DESCRIPTION
## Summary

Closes #881

- PR 제목: refactor: migrate NetCDF catalog metadata access

Fixes #881.

- Migrate `NetCdfCatalogService` variable metadata extraction from deprecated Kotlin bean access to the current NetCDF-Java attribute container API.
- Migrate file dimension extraction from deprecated `NetcdfFile.getDimensions()` to root-group dimensions.
- Preserve the existing `NetCdfVariableInfo.attributes`, `NetCdfFileRecord.dimensions`, and `NetCdfFileRecord.globalAttrs` output shapes.
- Add lesson and local review notes for the API migration.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

Fixes #881.

- Migrate `NetCdfCatalogService` variable metadata extraction from deprecated Kotlin bean access to the current NetCDF-Java attribute container API.
- Migrate file dimension extraction from deprecated `NetcdfFile.getDimensions()` to root-group dimensions.
- Preserve the existing `NetCdfVariableInfo.attributes`, `NetCdfFileRecord.dimensions`, and `NetCdfFileRecord.globalAttrs` output shapes.
- Add lesson and local review notes for the API migration.

### Validation

- `./gradlew :bluetape4k-science:compileKotlin --warning-mode all`
- `./gradlew :bluetape4k-science:compileTestKotlin --warning-mode all`
- `./gradlew :bluetape4k-science:test --tests '*NetCdfCatalogServiceTest' --tests '*NetCdfTableTest'`
  - `NetCdfCatalogServiceTest`: 33 tests, 0 failures, 0 errors, 0 skipped.
  - `NetCdfTableTest`: 4 tests, 0 failures, 0 errors, 0 skipped.
- `rg "\.attributes\b|\.dimensions\b" utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt`
  - no matches.
- `git diff --check`

### Review Notes

- Local 7-tier equivalent review: APPROVE.
- P0/P1 findings: 0.
- Gradle 10 deprecation cleanup was intentionally left out of scope.

### DoD Status

- [x] Issue #881 scope implemented.
- [x] Local compile validation passed.
- [x] Representative NetCDF registration and persistence tests passed.
- [x] Deprecated property-access grep returned no matches.
- [x] Local review and lesson artifacts added.
- [x] GitHub Actions passed.
- [ ] Merged to `develop`.

## Validation

- `./gradlew :bluetape4k-science:compileKotlin --warning-mode all`
- `./gradlew :bluetape4k-science:compileTestKotlin --warning-mode all`
- `./gradlew :bluetape4k-science:test --tests '*NetCdfCatalogServiceTest' --tests '*NetCdfTableTest'`
  - `NetCdfCatalogServiceTest`: 33 tests, 0 failures, 0 errors, 0 skipped.
  - `NetCdfTableTest`: 4 tests, 0 failures, 0 errors, 0 skipped.
- `rg "\.attributes\b|\.dimensions\b" utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt`
  - no matches.
- `git diff --check`

## Review Notes

- Local 7-tier equivalent review: APPROVE.
- P0/P1 findings: 0.
- Gradle 10 deprecation cleanup was intentionally left out of scope.

## Metadata

- Issue: #881, milestone `1.11.0`, assignee `debop`
- PR: #884, head `115d0b7acc4b4f5e0b990fa30b4024565cbdbf74`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `refactor-science-netcdf-api-881`
- Labels: `refactor`, `tech-debt`
- State: `MERGED`, merge commit `c61e38ae6a405658c8e913d0840ef16a79711f83`
- CI: - `./gradlew :bluetape4k-science:compileKotlin --warning-mode all` / - `./gradlew :bluetape4k-science:compileTestKotlin --warning-mode all` / - `./gradlew :bluetape4k-science:test --tests '*NetCdfCatalogServiceTest' --tests '*NetCdfTableTest'`

## DoD Status

- [x] Issue #881 scope implemented.
- [x] Local compile validation passed.
- [x] Representative NetCDF registration and persistence tests passed.
- [x] Deprecated property-access grep returned no matches.
- [x] Local review and lesson artifacts added.
- [x] GitHub Actions passed.
- [ ] Merged to `develop`.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #884 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `c61e38ae6a405658c8e913d0840ef16a79711f83`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
