### PR TITLE
fix: expose Redis serializer runtime dependencies

### DIFF
--- a/docs/lessons/2026-06-23-issue-834-redis-runtime-dependencies.md
+++ b/docs/lessons/2026-06-23-issue-834-redis-runtime-dependencies.md
@@ -1,0 +1,36 @@
+# Issue #834 Redis Serializer Runtime Dependencies
+
+Issue #834 exposed that `bluetape4k-spring-boot-redis` documented
+`RedisBinarySerializers.LZ4Fory` and `LZ4Kryo` as ready-to-use serializer
+choices while the codec and compressor libraries behind those choices were
+only `compileOnly` in the module.
+
+## Decision
+
+- Publish Fory, Kryo, LZ4, Zstd, and Snappy as runtime dependencies of
+  `bluetape4k-spring-boot-redis`.
+- Keep the default module tests unchanged, but add a separate
+  `consumerRuntimeTest` source set that does not inherit the module's
+  `compileOnly` test classpath.
+- Document that consumers do not need separate codec/compressor dependencies
+  for the serializer matrix shown in the README locale set.
+
+## Lessons
+
+- A module test classpath that extends `compileOnly` can hide consumer runtime
+  gaps. For published runtime contracts, add a source set whose runtime
+  classpath is based on `runtimeClasspath`, not `testImplementation`.
+- README examples that use named serializer constants are runtime contracts.
+  Either publish the required runtime dependencies or document each optional
+  dependency explicitly.
+- Stacked PRs are appropriate when a follow-up issue touches the same module
+  files as an already-open PR.
+
+## Verification
+
+- RED: `./gradlew :bluetape4k-spring-boot-redis:consumerRuntimeTest --no-build-cache` failed with missing `org.apache.fory.ThreadSafeFory` and `net.jpountz.lz4.LZ4Factory`.
+- GREEN: the same task passed with 2 consumer-runtime tests after moving the documented codec/compressor libraries to `runtimeOnly`.
+- `./gradlew :bluetape4k-spring-boot-redis:dependencies --configuration runtimeClasspath` showed Fory, Kryo, LZ4, Zstd, and Snappy.
+- `./gradlew :bluetape4k-spring-boot-redis:compileKotlin :bluetape4k-spring-boot-redis:compileTestKotlin :bluetape4k-spring-boot-redis:test :bluetape4k-spring-boot-redis:consumerRuntimeTest --no-build-cache` passed.
+- Test XML totals: default Redis tests 83 tests and consumer runtime tests 2 tests; all failures/errors 0.
+- `git diff --check` passed.

--- a/docs/lessons/2026-06-23-issue-835-redis-jdk-serializer-deprecation.md
+++ b/docs/lessons/2026-06-23-issue-835-redis-jdk-serializer-deprecation.md
@@ -1,0 +1,23 @@
+# Lessons Learned - Redis JDK serializer deprecation (#835, 2026-06-23)
+
+Related issue: #835
+Affected module: `:bluetape4k-spring-boot-redis`
+
+## L1: Wrapper constants must preserve lower-level security signals
+
+`BinarySerializers.Jdk` already carried a deprecation warning for JDK
+deserialization RCE risk, but the Redis-facing convenience constants did not
+repeat that warning. Public module boundaries should not hide security guidance
+from the lower-level API they wrap, especially at persistence or network
+boundaries such as Redis.
+
+The Redis constants now carry explicit deprecation annotations and replacement
+guidance, and the reflection contract test checks that future JDK Redis
+constants cannot be reintroduced without the warning.
+
+## L2: README serializer tables need status, not only capability
+
+A serializer matrix that lists JDK, Kryo, and Fory as peers can normalize unsafe
+defaults even when the implementation is technically correct. User-facing tables
+should distinguish recommended serializers from trusted-data-only legacy choices
+when deserialization risk is part of the contract.

--- a/docs/review/2026-06-23-issue-834-redis-runtime-dependencies-review.md
+++ b/docs/review/2026-06-23-issue-834-redis-runtime-dependencies-review.md
@@ -1,0 +1,33 @@
+# Issue #834 Redis Runtime Dependencies Review
+
+## Scope
+
+- `spring-boot/redis/build.gradle.kts`
+- `spring-boot/redis/README.md`
+- `spring-boot/redis/README.ko.md`
+- `spring-boot/redis/src/consumerRuntimeTest/kotlin/io/bluetape4k/spring/redis/serializer/RedisConsumerRuntimeClasspathTest.kt`
+
+## Verdict
+
+Local 7-tier equivalent review: APPROVE.
+
+P0/P1 findings: 0.
+
+## Review Notes
+
+| Lens | Finding | Severity | Resolution |
+|---|---|---:|---|
+| Runtime contract | Documented `LZ4Fory` and `LZ4Kryo` usage failed on a consumer runtime classpath because Fory/Kryo/LZ4 were compile-only. | P1 | Moved the documented codec and compressor libraries to `runtimeOnly`. |
+| Test adequacy | Default module tests inherited `compileOnly`, hiding missing runtime dependencies. | P1 | Added `consumerRuntimeTest`, which uses the module runtime classpath instead of default test inheritance. |
+| Documentation | README examples implied hidden dependencies were available. | P1 | Updated English and Korean README installation notes to state the runtime dependency contract. |
+| Stack safety | #834 touches the same Redis README area as open #835. | P2 | Kept this work as a stacked branch based on #835. |
+| Concurrency | No shared state, coroutine, or concurrent lifecycle behavior changed. | N/A | Concurrency tester gate is not applicable. |
+
+## Verification
+
+- RED: `./gradlew :bluetape4k-spring-boot-redis:consumerRuntimeTest --no-build-cache` failed with missing Fory and LZ4 classes.
+- GREEN: `./gradlew :bluetape4k-spring-boot-redis:consumerRuntimeTest --no-build-cache` passed with 2 tests.
+- Runtime dependency proof: `./gradlew :bluetape4k-spring-boot-redis:dependencies --configuration runtimeClasspath` lists Fory, Kryo, LZ4, Zstd, and Snappy.
+- Targeted module verification: `./gradlew :bluetape4k-spring-boot-redis:compileKotlin :bluetape4k-spring-boot-redis:compileTestKotlin :bluetape4k-spring-boot-redis:test :bluetape4k-spring-boot-redis:consumerRuntimeTest --no-build-cache` passed.
+- Test XML totals: default Redis tests 83 tests and consumer runtime tests 2 tests; all failures/errors 0.
+- `git diff --check` passed.

--- a/docs/review/2026-06-23-issue-835-redis-jdk-serializer-deprecation-review.md
+++ b/docs/review/2026-06-23-issue-835-redis-jdk-serializer-deprecation-review.md
@@ -1,0 +1,66 @@
+# Code Review - Issue #835 Redis JDK serializer deprecation
+
+Date: 2026-06-23
+Issue: #835
+Module: `:bluetape4k-spring-boot-redis`
+
+## Summary
+
+Redis-facing JDK serializer constants now preserve the lower-level JDK
+deserialization deprecation warning and guide callers toward Kryo or Fory.
+The README serializer matrices now mark JDK variants as deprecated,
+trusted-data-only choices.
+
+## Findings
+
+- P0: 0
+- P1: 0
+- P2: 0
+- P3: 0
+
+## Review Follow-up
+
+- Fixed the review finding that a source-text regex guard could pass when only
+  the first JDK constant carried the warning.
+- Replaced that guard with Kotlin reflection over `RedisBinarySerializers`
+  member properties, checking each expected JDK property for a `Deprecated`
+  annotation and exact `ReplaceWith` expression.
+- Added an unexpected-`*Jdk` property guard so future Redis JDK constants must
+  be explicitly added to the deprecation contract.
+- Suppressed deprecation only at intentional legacy-serializer test call sites.
+
+## Verification
+
+RED:
+
+```text
+./gradlew :bluetape4k-spring-boot-redis:test --tests 'io.bluetape4k.spring.redis.serializer.RedisBinarySerializerTest' --no-build-cache
+GRADLE_STATUS=1
+1 failing
+Redis JDK serializer constants preserve deprecation warning
+```
+
+The first reflection-based RED attempt was discarded because it passed before
+the production annotation existed. The failing source-contract RED established
+the missing-warning behavior before implementation.
+
+GREEN:
+
+```text
+./gradlew :bluetape4k-spring-boot-redis:cleanTest :bluetape4k-spring-boot-redis:compileKotlin :bluetape4k-spring-boot-redis:compileTestKotlin :bluetape4k-spring-boot-redis:test --no-build-cache
+GRADLE_STATUS=0
+83 passing
+BUILD SUCCESSFUL in 8s
+```
+
+Static checks:
+
+```text
+git diff --check
+clean
+```
+
+## Scope Notes
+
+- Full repository build was not run.
+- Merge is intentionally out of scope for this PR per user instruction.

--- a/spring-boot/redis/README.ko.md
+++ b/spring-boot/redis/README.ko.md
@@ -36,6 +36,10 @@ dependencies {
 }
 ```
 
+이 모듈은 아래 `RedisBinarySerializers` 목록에 나온 Kryo/Fory 및
+LZ4/Snappy/Zstd 조합의 런타임 의존성을 함께 게시합니다. 표시된 serializer 조합을
+사용하기 위해 별도 codec 또는 compressor 의존성을 추가할 필요가 없습니다.
+
 ## 사용 예시
 
 ### ReactiveRedisTemplate 설정 (DSL 방식)

--- a/spring-boot/redis/README.ko.md
+++ b/spring-boot/redis/README.ko.md
@@ -92,23 +92,27 @@ fun redisTemplate(factory: RedisConnectionFactory): RedisTemplate<String, Any> {
 
 ### 직렬화 (객체 → ByteArray)
 
-| 상수                                  | 직렬화 엔진 | 압축     |
-|-------------------------------------|--------|--------|
-| `RedisBinarySerializers.Jdk`        | JDK    | 없음     |
-| `RedisBinarySerializers.Kryo`       | Kryo   | 없음     |
-| `RedisBinarySerializers.Fory`       | Fory   | 없음     |
-| `RedisBinarySerializers.GzipJdk`    | JDK    | GZip   |
-| `RedisBinarySerializers.LZ4Jdk`     | JDK    | LZ4    |
-| `RedisBinarySerializers.SnappyJdk`  | JDK    | Snappy |
-| `RedisBinarySerializers.ZstdJdk`    | JDK    | Zstd   |
-| `RedisBinarySerializers.GzipKryo`   | Kryo   | GZip   |
-| `RedisBinarySerializers.LZ4Kryo`    | Kryo   | LZ4    |
-| `RedisBinarySerializers.SnappyKryo` | Kryo   | Snappy |
-| `RedisBinarySerializers.ZstdKryo`   | Kryo   | Zstd   |
-| `RedisBinarySerializers.GzipFory`   | Fory   | GZip   |
-| `RedisBinarySerializers.LZ4Fory`    | Fory   | LZ4    |
-| `RedisBinarySerializers.SnappyFory` | Fory   | Snappy |
-| `RedisBinarySerializers.ZstdFory`   | Fory   | Zstd   |
+JDK 역직렬화는 Redis에 저장된 값이 gadget chain 기반 RCE 위험에 노출될 수 있습니다. JDK
+serializer 상수는 deprecated 상태이며, 저장된 Redis 데이터가 완전히 신뢰 가능한 경우에만
+사용하세요. 일반 Redis 객체 값에는 Kryo 또는 Fory를 권장합니다.
+
+| 상수                                  | 직렬화 엔진 | 압축     | 상태                 |
+|-------------------------------------|--------|--------|--------------------|
+| `RedisBinarySerializers.Jdk`        | JDK    | 없음     | Deprecated; 신뢰 데이터 전용 |
+| `RedisBinarySerializers.Kryo`       | Kryo   | 없음     | 권장                 |
+| `RedisBinarySerializers.Fory`       | Fory   | 없음     | 권장                 |
+| `RedisBinarySerializers.GzipJdk`    | JDK    | GZip   | Deprecated; 신뢰 데이터 전용 |
+| `RedisBinarySerializers.LZ4Jdk`     | JDK    | LZ4    | Deprecated; 신뢰 데이터 전용 |
+| `RedisBinarySerializers.SnappyJdk`  | JDK    | Snappy | Deprecated; 신뢰 데이터 전용 |
+| `RedisBinarySerializers.ZstdJdk`    | JDK    | Zstd   | Deprecated; 신뢰 데이터 전용 |
+| `RedisBinarySerializers.GzipKryo`   | Kryo   | GZip   | 권장                 |
+| `RedisBinarySerializers.LZ4Kryo`    | Kryo   | LZ4    | 권장                 |
+| `RedisBinarySerializers.SnappyKryo` | Kryo   | Snappy | 권장                 |
+| `RedisBinarySerializers.ZstdKryo`   | Kryo   | Zstd   | 권장                 |
+| `RedisBinarySerializers.GzipFory`   | Fory   | GZip   | 권장                 |
+| `RedisBinarySerializers.LZ4Fory`    | Fory   | LZ4    | 권장                 |
+| `RedisBinarySerializers.SnappyFory` | Fory   | Snappy | 권장                 |
+| `RedisBinarySerializers.ZstdFory`   | Fory   | Zstd   | 권장                 |
 
 ### 압축 전용 (ByteArray → ByteArray)
 

--- a/spring-boot/redis/README.md
+++ b/spring-boot/redis/README.md
@@ -93,23 +93,27 @@ fun redisTemplate(factory: RedisConnectionFactory): RedisTemplate<String, Any> {
 
 ### Object Serializers (Object → ByteArray)
 
-| Constant                            | Serialization Engine | Compression |
-|-------------------------------------|----------------------|-------------|
-| `RedisBinarySerializers.Jdk`        | JDK                  | None        |
-| `RedisBinarySerializers.Kryo`       | Kryo                 | None        |
-| `RedisBinarySerializers.Fory`       | Fory                 | None        |
-| `RedisBinarySerializers.GzipJdk`    | JDK                  | GZip        |
-| `RedisBinarySerializers.LZ4Jdk`     | JDK                  | LZ4         |
-| `RedisBinarySerializers.SnappyJdk`  | JDK                  | Snappy      |
-| `RedisBinarySerializers.ZstdJdk`    | JDK                  | Zstd        |
-| `RedisBinarySerializers.GzipKryo`   | Kryo                 | GZip        |
-| `RedisBinarySerializers.LZ4Kryo`    | Kryo                 | LZ4         |
-| `RedisBinarySerializers.SnappyKryo` | Kryo                 | Snappy      |
-| `RedisBinarySerializers.ZstdKryo`   | Kryo                 | Zstd        |
-| `RedisBinarySerializers.GzipFory`   | Fory                 | GZip        |
-| `RedisBinarySerializers.LZ4Fory`    | Fory                 | LZ4         |
-| `RedisBinarySerializers.SnappyFory` | Fory                 | Snappy      |
-| `RedisBinarySerializers.ZstdFory`   | Fory                 | Zstd        |
+JDK deserialization can expose Redis values to RCE gadget-chain risk. The JDK
+serializer constants are deprecated and should be used only when the stored Redis
+data is fully trusted. Prefer Kryo or Fory for general Redis object values.
+
+| Constant                            | Serialization Engine | Compression | Status |
+|-------------------------------------|----------------------|-------------|--------|
+| `RedisBinarySerializers.Jdk`        | JDK                  | None        | Deprecated; trusted data only |
+| `RedisBinarySerializers.Kryo`       | Kryo                 | None        | Recommended |
+| `RedisBinarySerializers.Fory`       | Fory                 | None        | Recommended |
+| `RedisBinarySerializers.GzipJdk`    | JDK                  | GZip        | Deprecated; trusted data only |
+| `RedisBinarySerializers.LZ4Jdk`     | JDK                  | LZ4         | Deprecated; trusted data only |
+| `RedisBinarySerializers.SnappyJdk`  | JDK                  | Snappy      | Deprecated; trusted data only |
+| `RedisBinarySerializers.ZstdJdk`    | JDK                  | Zstd        | Deprecated; trusted data only |
+| `RedisBinarySerializers.GzipKryo`   | Kryo                 | GZip        | Recommended |
+| `RedisBinarySerializers.LZ4Kryo`    | Kryo                 | LZ4         | Recommended |
+| `RedisBinarySerializers.SnappyKryo` | Kryo                 | Snappy      | Recommended |
+| `RedisBinarySerializers.ZstdKryo`   | Kryo                 | Zstd        | Recommended |
+| `RedisBinarySerializers.GzipFory`   | Fory                 | GZip        | Recommended |
+| `RedisBinarySerializers.LZ4Fory`    | Fory                 | LZ4         | Recommended |
+| `RedisBinarySerializers.SnappyFory` | Fory                 | Snappy      | Recommended |
+| `RedisBinarySerializers.ZstdFory`   | Fory                 | Zstd        | Recommended |
 
 ### Compression-only (ByteArray → ByteArray)
 

--- a/spring-boot/redis/README.md
+++ b/spring-boot/redis/README.md
@@ -37,6 +37,11 @@ dependencies {
 }
 ```
 
+The module publishes runtime dependencies for the documented
+`RedisBinarySerializers` Kryo/Fory and LZ4/Snappy/Zstd combinations. Consumers
+do not need to add separate codec or compressor dependencies for the serializer
+matrix shown below.
+
 ## Usage Examples
 
 ### ReactiveRedisTemplate Configuration (DSL approach)

--- a/spring-boot/redis/build.gradle.kts
+++ b/spring-boot/redis/build.gradle.kts
@@ -6,6 +6,26 @@ configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
 }
 
+val consumerRuntimeTest by sourceSets.creating {
+    compileClasspath += sourceSets.main.get().output + configurations.runtimeClasspath.get()
+    runtimeClasspath += output + compileClasspath
+}
+
+val consumerRuntimeTestImplementation by configurations.getting
+
+tasks.register<Test>("consumerRuntimeTest") {
+    description = "Runs Redis serializer smoke tests with the published runtime classpath."
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+
+    testClassesDirs = consumerRuntimeTest.output.classesDirs
+    classpath = consumerRuntimeTest.runtimeClasspath
+    useJUnitPlatform()
+}
+
+tasks.named("check") {
+    dependsOn("consumerRuntimeTest")
+}
+
 dependencies {
     implementation(platform(libs.spring.boot.dependencies))
 
@@ -15,14 +35,14 @@ dependencies {
     // Spring Data Redis (4.x BOM에서 버전 해소)
     api("org.springframework.boot:spring-boot-starter-data-redis")
 
-    // Codecs
-    compileOnly(libs.fory.kotlin)
-    compileOnly(libs.kryo5)
+    // Runtime codecs used by the documented RedisBinarySerializers matrix
+    runtimeOnly(libs.fory.kotlin)
+    runtimeOnly(libs.kryo5)
 
-    // Compressor
-    compileOnly(libs.lz4.java)
-    compileOnly(libs.zstd.jni)
-    compileOnly(libs.snappy.java)
+    // Runtime compressors used by the documented RedisBinarySerializers matrix
+    runtimeOnly(libs.lz4.java)
+    runtimeOnly(libs.zstd.jni)
+    runtimeOnly(libs.snappy.java)
 
     testImplementation(project(":bluetape4k-junit5"))
     testImplementation(project(":bluetape4k-testcontainers"))
@@ -31,4 +51,6 @@ dependencies {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
         exclude(module = "mockito-core")
     }
+
+    consumerRuntimeTestImplementation(project(":bluetape4k-junit5"))
 }

--- a/spring-boot/redis/src/consumerRuntimeTest/kotlin/io/bluetape4k/spring/redis/serializer/RedisConsumerRuntimeClasspathTest.kt
+++ b/spring-boot/redis/src/consumerRuntimeTest/kotlin/io/bluetape4k/spring/redis/serializer/RedisConsumerRuntimeClasspathTest.kt
@@ -1,0 +1,28 @@
+package io.bluetape4k.spring.redis.serializer
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
+import org.junit.jupiter.api.Test
+
+class RedisConsumerRuntimeClasspathTest {
+
+    @Test
+    fun `documented LZ4 Fory serializer works from consumer runtime classpath`() {
+        val original = "Hello, bluetape4k Redis runtime!"
+
+        val bytes = RedisBinarySerializers.LZ4Fory.serialize(original)
+        bytes.shouldNotBeNull()
+
+        RedisBinarySerializers.LZ4Fory.deserialize(bytes) shouldBeEqualTo original
+    }
+
+    @Test
+    fun `documented LZ4 Kryo serializer works from consumer runtime classpath`() {
+        val original = "Hello, bluetape4k Redis Kryo runtime!"
+
+        val bytes = RedisBinarySerializers.LZ4Kryo.serialize(original)
+        bytes.shouldNotBeNull()
+
+        RedisBinarySerializers.LZ4Kryo.deserialize(bytes) shouldBeEqualTo original
+    }
+}

--- a/spring-boot/redis/src/main/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializers.kt
+++ b/spring-boot/redis/src/main/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializers.kt
@@ -19,6 +19,15 @@ import io.bluetape4k.io.serializer.BinarySerializers
  */
 object RedisBinarySerializers {
 
+    private const val JDK_SERIALIZATION_DEPRECATION_MESSAGE =
+        "JDK deserialization can expose Redis values to RCE gadget-chain risk. " +
+            "Use RedisBinarySerializers.Kryo or RedisBinarySerializers.Fory unless Redis data is fully trusted."
+
+    @Deprecated(
+        message = JDK_SERIALIZATION_DEPRECATION_MESSAGE,
+        ReplaceWith("RedisBinarySerializers.Kryo")
+    )
+    @Suppress("DEPRECATION")
     val Jdk by lazy { RedisBinarySerializer(BinarySerializers.Jdk) }
     val Kryo by lazy { RedisBinarySerializer(BinarySerializers.Kryo) }
     val Fory by lazy { RedisBinarySerializer(BinarySerializers.Fory) }
@@ -28,9 +37,32 @@ object RedisBinarySerializers {
     val Snappy by lazy { RedisCompressSerializer(Compressors.Snappy) }
     val Zstd by lazy { RedisCompressSerializer(Compressors.Zstd) }
 
+    @Deprecated(
+        message = JDK_SERIALIZATION_DEPRECATION_MESSAGE,
+        ReplaceWith("RedisBinarySerializers.GzipKryo")
+    )
+    @Suppress("DEPRECATION")
     val GzipJdk by lazy { RedisBinarySerializer(BinarySerializers.GZipJdk) }
+
+    @Deprecated(
+        message = JDK_SERIALIZATION_DEPRECATION_MESSAGE,
+        ReplaceWith("RedisBinarySerializers.LZ4Kryo")
+    )
+    @Suppress("DEPRECATION")
     val LZ4Jdk by lazy { RedisBinarySerializer(BinarySerializers.LZ4Jdk) }
+
+    @Deprecated(
+        message = JDK_SERIALIZATION_DEPRECATION_MESSAGE,
+        ReplaceWith("RedisBinarySerializers.SnappyKryo")
+    )
+    @Suppress("DEPRECATION")
     val SnappyJdk by lazy { RedisBinarySerializer(BinarySerializers.SnappyJdk) }
+
+    @Deprecated(
+        message = JDK_SERIALIZATION_DEPRECATION_MESSAGE,
+        ReplaceWith("RedisBinarySerializers.ZstdKryo")
+    )
+    @Suppress("DEPRECATION")
     val ZstdJdk by lazy { RedisBinarySerializer(BinarySerializers.ZstdJdk) }
 
     val GzipKryo by lazy { RedisBinarySerializer(BinarySerializers.GZipKryo) }

--- a/spring-boot/redis/src/test/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializerTest.kt
+++ b/spring-boot/redis/src/test/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializerTest.kt
@@ -1,13 +1,44 @@
 package io.bluetape4k.spring.redis.serializer
 
-import io.bluetape4k.io.serializer.BinarySerializers
-import io.bluetape4k.support.emptyByteArray
+import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.io.serializer.BinarySerializers
+import io.bluetape4k.support.emptyByteArray
 import org.junit.jupiter.api.Test
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.memberProperties
 
 class RedisBinarySerializerTest: AbstractRedisSerializerTest() {
+
+    @Test
+    fun `Redis JDK serializer constants preserve deprecation warning`() {
+        val expectedReplacements = mapOf(
+            "Jdk" to "RedisBinarySerializers.Kryo",
+            "GzipJdk" to "RedisBinarySerializers.GzipKryo",
+            "LZ4Jdk" to "RedisBinarySerializers.LZ4Kryo",
+            "SnappyJdk" to "RedisBinarySerializers.SnappyKryo",
+            "ZstdJdk" to "RedisBinarySerializers.ZstdKryo",
+        )
+        val properties = RedisBinarySerializers::class.memberProperties.associateBy { it.name }
+        val invalidDeprecations = expectedReplacements
+            .filter { (propertyName, replacement) ->
+                val deprecation = properties[propertyName]?.findAnnotation<Deprecated>()
+                deprecation == null ||
+                    !deprecation.message.contains("JDK deserialization can expose Redis values to RCE gadget-chain risk") ||
+                    deprecation.replaceWith.expression != replacement
+            }
+            .keys
+
+        invalidDeprecations.toList().shouldBeEmpty()
+        RedisBinarySerializers::class.memberProperties
+            .filter { it.name.endsWith("Jdk") && it.name !in expectedReplacements.keys }
+            .shouldBeEmpty()
+        expectedReplacements.values shouldContain "RedisBinarySerializers.Kryo"
+        expectedReplacements.values shouldContain "RedisBinarySerializers.ZstdKryo"
+    }
 
     @Test
     fun `null 직렬화는 emptyByteArray 를 반환한다`() {
@@ -70,6 +101,7 @@ class RedisBinarySerializerTest: AbstractRedisSerializerTest() {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `데이터 클래스를 Jdk로 직렬화 후 복원한다`() {
         val serializer = RedisBinarySerializer(BinarySerializers.Jdk)
         val original = TestData(id = 4L, name = "Dave", description = "JDK 직렬화 테스트")

--- a/spring-boot/redis/src/test/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializersTest.kt
+++ b/spring-boot/redis/src/test/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializersTest.kt
@@ -15,6 +15,7 @@ class RedisBinarySerializersTest: AbstractRedisSerializerTest() {
     companion object {
 
         @JvmStatic
+        @Suppress("DEPRECATION")
         fun binarySerializers(): Stream<Arguments> = Stream.of(
             Arguments.of(RedisBinarySerializers.Jdk, "Jdk"),
             Arguments.of(RedisBinarySerializers.Kryo, "Kryo"),


### PR DESCRIPTION
## Summary

Closes #834

- PR 제목: fix: expose Redis serializer runtime dependencies

Fixes #834.

This is stacked on #882 because #834 and #835 both update the Redis serializer README and tests.

- Publishes Fory, Kryo, LZ4, Zstd, and Snappy as runtime dependencies of `bluetape4k-spring-boot-redis`.
- Adds a `consumerRuntimeTest` source set that exercises documented Redis serializers without inheriting the module `compileOnly` test classpath.
- Documents in both README locales that the listed `RedisBinarySerializers` matrix does not require separate consumer codec/compressor dependencies.
- Records review and lesson evidence for the runtime classpath gap.

## Background

The README documents `RedisBinarySerializers.LZ4Fory` and `LZ4Kryo` as normal usage paths, but the module runtime classpath did not include the codec and compressor libraries behind those constants. The default module tests missed this because `testImplementation` extends `compileOnly`.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

Fixes #834.

This is stacked on #882 because #834 and #835 both update the Redis serializer README and tests.

- Publishes Fory, Kryo, LZ4, Zstd, and Snappy as runtime dependencies of `bluetape4k-spring-boot-redis`.
- Adds a `consumerRuntimeTest` source set that exercises documented Redis serializers without inheriting the module `compileOnly` test classpath.
- Documents in both README locales that the listed `RedisBinarySerializers` matrix does not require separate consumer codec/compressor dependencies.
- Records review and lesson evidence for the runtime classpath gap.

### Background

The README documents `RedisBinarySerializers.LZ4Fory` and `LZ4Kryo` as normal usage paths, but the module runtime classpath did not include the codec and compressor libraries behind those constants. The default module tests missed this because `testImplementation` extends `compileOnly`.

### Validation

- RED: `./gradlew :bluetape4k-spring-boot-redis:consumerRuntimeTest --no-build-cache` failed with missing `org.apache.fory.ThreadSafeFory` and `net.jpountz.lz4.LZ4Factory`.
- GREEN: `./gradlew :bluetape4k-spring-boot-redis:consumerRuntimeTest --no-build-cache` passed with 2 tests.
- `./gradlew :bluetape4k-spring-boot-redis:dependencies --configuration runtimeClasspath` lists Fory, Kryo, LZ4, Zstd, and Snappy.
- `./gradlew :bluetape4k-spring-boot-redis:compileKotlin :bluetape4k-spring-boot-redis:compileTestKotlin :bluetape4k-spring-boot-redis:test :bluetape4k-spring-boot-redis:consumerRuntimeTest --no-build-cache` passed.
- Test XML totals: default Redis tests 83 tests and consumer runtime tests 2 tests; all failures/errors 0.
- `git diff --check` passed.

### Review

- Local 7-tier equivalent review recorded in `docs/review/2026-06-23-issue-834-redis-runtime-dependencies-review.md`.
- Lesson recorded in `docs/lessons/2026-06-23-issue-834-redis-runtime-dependencies.md`.

### DoD Status

- [x] Issue #834 assigned to `debop`, milestone `1.11.0`, labels `bug`, `documentation`, `dependencies`.
- [x] PR assignee, milestone, and labels copied from issue #834.
- [x] Stacked on #882 because #835 touches the same Redis README/test area.
- [x] Consumer-runtime RED/GREEN proof added.
- [x] Redis serializer runtime dependencies made explicit.
- [x] README.md and README.ko.md updated.
- [x] Targeted Redis module validation passed.
- [x] GitHub Actions passed.

## Validation

- RED: `./gradlew :bluetape4k-spring-boot-redis:consumerRuntimeTest --no-build-cache` failed with missing `org.apache.fory.ThreadSafeFory` and `net.jpountz.lz4.LZ4Factory`.
- GREEN: `./gradlew :bluetape4k-spring-boot-redis:consumerRuntimeTest --no-build-cache` passed with 2 tests.
- `./gradlew :bluetape4k-spring-boot-redis:dependencies --configuration runtimeClasspath` lists Fory, Kryo, LZ4, Zstd, and Snappy.
- `./gradlew :bluetape4k-spring-boot-redis:compileKotlin :bluetape4k-spring-boot-redis:compileTestKotlin :bluetape4k-spring-boot-redis:test :bluetape4k-spring-boot-redis:consumerRuntimeTest --no-build-cache` passed.
- Test XML totals: default Redis tests 83 tests and consumer runtime tests 2 tests; all failures/errors 0.
- `git diff --check` passed.

## Review Notes

- Local 7-tier equivalent review recorded in `docs/review/2026-06-23-issue-834-redis-runtime-dependencies-review.md`.
- Lesson recorded in `docs/lessons/2026-06-23-issue-834-redis-runtime-dependencies.md`.

## Metadata

- Issue: #834, milestone `1.11.0`, assignee `debop`
- PR: #886, head `dd14a8a76416307f64765d10d48b023d729e62e2`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/redis-runtime-deps-834`
- Labels: `bug`, `documentation`, `dependencies`
- State: `MERGED`, merge commit `8594aadbc77e73e789ffba70e477b6788b75a4cb`
- CI: - Publishes Fory, Kryo, LZ4, Zstd, and Snappy as runtime dependencies of `bluetape4k-spring-boot-redis`. / - Adds a `consumerRuntimeTest` source set that exercises documented Redis serializers without inheriting the module `compileOnly` test classpath. / - Documents in both README locales that the listed `RedisBinarySerializers` matrix does not require separate consumer codec/compressor dependencies.

## DoD Status

- [x] Issue #834 assigned to `debop`, milestone `1.11.0`, labels `bug`, `documentation`, `dependencies`.
- [x] PR assignee, milestone, and labels copied from issue #834.
- [x] Stacked on #882 because #835 touches the same Redis README/test area.
- [x] Consumer-runtime RED/GREEN proof added.
- [x] Redis serializer runtime dependencies made explicit.
- [x] README.md and README.ko.md updated.
- [x] Targeted Redis module validation passed.
- [x] GitHub Actions passed.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #886 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `8594aadbc77e73e789ffba70e477b6788b75a4cb`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
