### PR TITLE
fix: make Spring WebClient README examples compile

### DIFF
--- a/docs/lessons/2026-06-23-issue-833-spring-webclient-readme-examples.md
+++ b/docs/lessons/2026-06-23-issue-833-spring-webclient-readme-examples.md
@@ -1,0 +1,31 @@
+# Issue 833 - Spring WebClient README examples
+
+## Context
+
+`bluetape4k-spring-boot-core` documents `WebClient.httpGet` and
+`WebClient.httpPost` helpers in both English and Korean READMEs.
+
+Those helpers already call `retrieve()` internally and return
+`WebClient.ResponseSpec`, but the README snippets chained another `retrieve()`.
+The documented examples therefore failed to compile even though the extension
+functions themselves worked.
+
+## Decision
+
+Keep the public helper contract unchanged and fix the examples to consume the
+returned `ResponseSpec` directly:
+
+- `httpGet("/users").bodyToFlux(User::class.java).asFlow()`
+- `httpPost("/users", newUser).bodyToMono(User::class.java).awaitSingle()`
+
+Add `WebClientReadmeExamplesTest` so README drift is caught by tests:
+
+- the README files must not chain `.retrieve()` after `httpGet` or `httpPost`
+- the documented `bodyToFlux` and `bodyToMono` chains compile against the real
+  extension functions
+
+## Follow-up Guard
+
+When WebClient helper return types change, update `README.md`,
+`README.ko.md`, and `WebClientReadmeExamplesTest` together. Public snippets
+should demonstrate the exact next call available on the returned type.

--- a/docs/review/2026-06-23-issue-833-spring-webclient-readme-examples-review.md
+++ b/docs/review/2026-06-23-issue-833-spring-webclient-readme-examples-review.md
@@ -1,0 +1,30 @@
+# Issue 833 Review - Spring WebClient README examples
+
+## Scope
+
+- `spring-boot/core/README.md`
+- `spring-boot/core/README.ko.md`
+- `spring-boot/core/src/test/kotlin/io/bluetape4k/spring/tests/WebClientReadmeExamplesTest.kt`
+
+## Review Notes
+
+- `httpGet` and `httpPost` examples no longer call `.retrieve()` after the
+  project helpers.
+- English and Korean README snippets remain source-equivalent.
+- The new README validation test blocks the exact double-retrieve drift pattern
+  that made the snippets non-compilable.
+- The compile smoke test uses the real `WebClient` extension functions with
+  `bodyToFlux` and `bodyToMono`; it does not perform network I/O.
+
+## Verification
+
+- RED: `WebClientReadmeExamplesTest` failed on
+  `README.md should not chain .retrieve() after httpGet/httpPost`.
+- GREEN: `WebClientReadmeExamplesTest` passed after README updates.
+- Code review: native `code-reviewer` reported 0 critical, 0 high, 0 medium,
+  and 0 low findings. Residual risk is limited to future README drift outside
+  the checked double-`retrieve()` pattern.
+- `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.tests.WebClientReadmeExamplesTest' --no-build-cache`
+- `./gradlew :bluetape4k-spring-boot-core:compileKotlin :bluetape4k-spring-boot-core:compileTestKotlin :bluetape4k-spring-boot-core:test --no-build-cache`
+- `rg -n "http(Get|Post)\\([^)]*\\)\\s*\\.\\s*retrieve\\(\\)" spring-boot/core/README.md spring-boot/core/README.ko.md`
+- `git diff --check`

--- a/spring-boot/core/README.ko.md
+++ b/spring-boot/core/README.ko.md
@@ -122,13 +122,11 @@ val webClient = WebClient.create("https://api.example.com")
 
 // GET 요청
 val response = webClient.httpGet("/users")
-    .retrieve()
     .bodyToFlux(User::class.java)
     .asFlow()
 
 // POST 요청
 val created = webClient.httpPost("/users", newUser)
-    .retrieve()
     .bodyToMono(User::class.java)
     .awaitSingle()
 ```

--- a/spring-boot/core/README.md
+++ b/spring-boot/core/README.md
@@ -122,13 +122,11 @@ val webClient = WebClient.create("https://api.example.com")
 
 // GET request
 val response = webClient.httpGet("/users")
-    .retrieve()
     .bodyToFlux(User::class.java)
     .asFlow()
 
 // POST request
 val created = webClient.httpPost("/users", newUser)
-    .retrieve()
     .bodyToMono(User::class.java)
     .awaitSingle()
 ```

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/tests/WebClientReadmeExamplesTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/tests/WebClientReadmeExamplesTest.kt
@@ -1,0 +1,73 @@
+package io.bluetape4k.spring.tests
+
+import io.bluetape4k.assertions.shouldNotBeNull
+import kotlinx.coroutines.reactive.asFlow
+import org.junit.jupiter.api.Test
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToFlux
+import org.springframework.web.reactive.function.client.bodyToMono
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.test.assertTrue
+
+class WebClientReadmeExamplesTest {
+
+    @Test
+    fun `README WebClient examples do not call retrieve twice`() {
+        readmeTexts().forEach { (fileName, text) ->
+            val matches =
+                DOUBLE_RETRIEVE_PATTERN
+                    .findAll(text)
+                    .map { it.value.replace(Regex("\\s+"), " ") }
+                    .toList()
+
+            assertTrue(
+                actual = matches.isEmpty(),
+                message = "$fileName should not chain .retrieve() after httpGet/httpPost: $matches",
+            )
+        }
+    }
+
+    @Test
+    fun `README WebClient examples compile against ResponseSpec helpers`() {
+        val webClient = WebClient.create("https://api.example.com")
+        val newUser = ReadmeUser("debop")
+
+        val response =
+            webClient
+                .httpGet("/users")
+                .bodyToFlux(ReadmeUser::class.java)
+                .asFlow()
+        val created =
+            webClient
+                .httpPost("/users", newUser)
+                .bodyToMono(ReadmeUser::class.java)
+
+        response.shouldNotBeNull()
+        created.shouldNotBeNull()
+    }
+
+    private fun readmeTexts(): Map<String, String> =
+        listOf("README.md", "README.ko.md").associateWith { fileName ->
+            modulePath(fileName).readText()
+        }
+
+    private fun modulePath(fileName: String): Path {
+        val cwd = Path.of("").toAbsolutePath()
+
+        return generateSequence(cwd) { it.parent }
+            .map { it.resolve("spring-boot/core/$fileName") }
+            .firstOrNull(Files::exists)
+            ?: error("Cannot locate spring-boot/core/$fileName from $cwd")
+    }
+
+    private data class ReadmeUser(
+        val name: String,
+    )
+
+    companion object {
+        private val DOUBLE_RETRIEVE_PATTERN =
+            Regex("""http(?:Get|Post)\([^)]*\)\s*\.\s*retrieve\(\)""")
+    }
+}


### PR DESCRIPTION
## Summary

Closes #833

- PR 제목: fix: make Spring WebClient README examples compile

Fixes #833.

- Remove the extra `.retrieve()` calls from the Spring WebClient README snippets in both English and Korean.
- Add `WebClientReadmeExamplesTest` to block the double-retrieve README drift pattern and compile the documented `ResponseSpec` body extraction chains.
- Capture lesson and review notes for the README/API contract guard.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Root Cause

`WebClient.httpGet` and `WebClient.httpPost` already call `.retrieve()` internally and return `WebClient.ResponseSpec`. The README examples chained `.retrieve()` again before `bodyToFlux` / `bodyToMono`, so copy-pasted snippets did not compile.

## Validation

- RED: `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.tests.WebClientReadmeExamplesTest' --no-build-cache` failed on `README.md should not chain .retrieve() after httpGet/httpPost` before the README fix.
- GREEN: `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.tests.WebClientReadmeExamplesTest' --no-build-cache` passed with 2 tests.
- `./gradlew :bluetape4k-spring-boot-core:compileKotlin :bluetape4k-spring-boot-core:compileTestKotlin :bluetape4k-spring-boot-core:test --no-build-cache` passed with 228 tests.
- `rg -n "http(Get|Post)\\([^)]*\\)\\s*\\.\\s*retrieve\\(\\)" spring-boot/core/README.md spring-boot/core/README.ko.md` found no README double-retrieve patterns.
- `git diff --check` passed.
- Native `code-reviewer` reported 0 critical, 0 high, 0 medium, and 0 low findings.

## Review Notes

- PR metadata should mirror issue #833: assignee `debop`, milestone `1.11.0`, labels `bug`, `documentation`.
- Residual risk: the new test compiles a mirrored smoke snippet rather than extracting and compiling the exact fenced Markdown block. The exact #833 regression pattern is covered.

## Metadata

- Issue: #833, milestone `1.11.0`, assignee `debop`
- PR: #887, head `e92a9cae6fec4f7d080b09f486ebc6ce160e48c5`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/spring-webclient-readme-examples-833`
- Labels: `bug`, `documentation`
- State: `MERGED`, merge commit `f78d3c70a3790bf35dad9f4625e9f2ab557d073a`
- CI: - RED: `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.tests.WebClientReadmeExamplesTest' --no-build-cache` failed on `README.md should not chain .retrieve() after httpGet/httpPost` before the README fix. / - GREEN: `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.tests.WebClientReadmeExamplesTest' --no-build-cache` passed with 2 tests. / - `./gradlew :bluetape4k-spring-boot-core:compileKotlin :bluetape4k-spring-boot-core:compileTestKotlin :bluetape4k-spring-boot-core:test --no-build-cache` passed with 228 tests.

## DoD Status

- [x] Issue #833 is assigned to `debop` and has milestone `1.11.0` with labels `bug`, `documentation`.
- [x] English and Korean README WebClient examples call body extraction directly on `ResponseSpec`.
- [x] README double-retrieve regression is covered by `WebClientReadmeExamplesTest`.
- [x] Targeted Spring Boot core module verification passed locally.
- [x] Lesson and review notes added.
- [x] GitHub Actions passed.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #887 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `f78d3c70a3790bf35dad9f4625e9f2ab557d073a`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
