### PR TITLE
fix: preserve Spring findBean creation failures

### DIFF
--- a/docs/lessons/2026-06-24-issue-832-findbean-failures.md
+++ b/docs/lessons/2026-06-24-issue-832-findbean-failures.md
@@ -1,0 +1,29 @@
+# Issue 832 - findBean failure boundaries
+
+## Context
+
+`BeanFactory.findBean(...)` is an optional lookup helper. It should return
+`null` when the requested bean is absent, but it must not hide Spring
+configuration failures.
+
+The previous implementation wrapped `get(...)` in `runCatching` and returned
+`null` for every exception. That made bean creation failures and duplicate-bean
+ambiguity look the same as an optional missing bean.
+
+## Decision
+
+Keep the optional lookup contract for absent beans only:
+
+- `NoSuchBeanDefinitionException` maps to `null`
+- `NoUniqueBeanDefinitionException` is rethrown even though it is a
+  `NoSuchBeanDefinitionException` subclass
+- bean creation, type, and configuration failures propagate
+
+The shared `findOptionalBean` helper keeps the exception boundary identical
+across class-based, named, and constructor-argument `findBean` overloads.
+
+## Follow-up Guard
+
+When adding optional Spring lookup helpers, do not catch broad `BeansException`
+unless every Spring configuration failure is intentionally optional. Add tests
+for missing-bean, creation-failure, and ambiguity boundaries together.

--- a/docs/review/2026-06-24-issue-832-findbean-failures-review.md
+++ b/docs/review/2026-06-24-issue-832-findbean-failures-review.md
@@ -1,0 +1,30 @@
+# Issue 832 Review - findBean failure boundaries
+
+## Scope
+
+- `spring-boot/core/src/main/kotlin/io/bluetape4k/spring/beans/BeanFactoryExtensions.kt`
+- `spring-boot/core/src/test/kotlin/io/bluetape4k/spring/beans/BeanFactoryExtensionsTest.kt`
+
+## Review Notes
+
+- `findBean` now maps only absent beans to `null`.
+- `NoUniqueBeanDefinitionException` is explicitly rethrown before catching
+  `NoSuchBeanDefinitionException`, preserving duplicate-bean ambiguity.
+- Bean creation failures from class-based, named, and constructor-argument
+  lookups now propagate as Spring failures instead of optional lookup misses.
+- Existing missing-bean tests still cover the intended `null` behavior.
+- Spring 7.0.8 bytecode confirms `NoUniqueBeanDefinitionException extends
+  NoSuchBeanDefinitionException`, so the catch order is required.
+
+## Verification
+
+- RED: `BeanFactoryExtensionsTest` failed because current `findBean` swallowed
+  `BeanCreationException` and `NoUniqueBeanDefinitionException`.
+- GREEN: `BeanFactoryExtensionsTest` passed with 17 tests.
+- Code review: native `code-reviewer` returned APPROVE with 0 blocking
+  findings. Residual gap: no direct `BeanNotOfRequiredTypeException` assertion,
+  but the implementation does not catch that exception family.
+- `javap -classpath spring-beans-7.0.8.jar org.springframework.beans.factory.NoUniqueBeanDefinitionException`
+- `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.beans.BeanFactoryExtensionsTest' --no-build-cache`
+- `./gradlew :bluetape4k-spring-boot-core:compileKotlin :bluetape4k-spring-boot-core:compileTestKotlin :bluetape4k-spring-boot-core:test --no-build-cache`
+- `git diff --check`

--- a/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/beans/BeanFactoryExtensions.kt
+++ b/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/beans/BeanFactoryExtensions.kt
@@ -4,10 +4,25 @@ import io.bluetape4k.logging.KotlinLogging
 import io.bluetape4k.logging.warn
 import org.springframework.beans.BeansException
 import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.NoSuchBeanDefinitionException
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException
 import org.springframework.beans.factory.getBean
 import kotlin.reflect.KClass
 
 private val log by lazy { KotlinLogging.logger {} }
+
+private inline fun <T> findOptionalBean(
+    description: () -> String,
+    block: () -> T,
+): T? =
+    try {
+        block()
+    } catch (e: NoUniqueBeanDefinitionException) {
+        throw e
+    } catch (e: NoSuchBeanDefinitionException) {
+        log.warn(e) { "Bean not found. ${description()}, return null." }
+        null
+    }
 
 /**
  * 제네릭 타입 [T]에 해당하는 빈을 조회합니다.
@@ -109,7 +124,7 @@ operator fun BeanFactory.get(
  *
  * ## 동작/계약
  * - 내부적으로 [Class] 기반 [findBean]으로 위임합니다.
- * - 조회 실패 시 예외 대신 `null`을 반환합니다.
+ * - 빈이 없으면 `null`을 반환하고, 생성/타입/중복 빈 오류는 전파합니다.
  *
  * ```kotlin
  * val service = beanFactory.findBean(MyService::class)
@@ -119,11 +134,11 @@ operator fun BeanFactory.get(
 fun <T: Any> BeanFactory.findBean(requiredType: KClass<T>): T? = findBean(requiredType.java)
 
 /**
- * 타입으로 빈을 조회하고 실패하면 경고 로그 후 `null`을 반환합니다.
+ * 타입으로 빈을 조회하고 없으면 경고 로그 후 `null`을 반환합니다.
  *
  * ## 동작/계약
- * - [get] 호출에서 [BeansException]이 발생하면 예외를 삼키고 `null`을 반환합니다.
- * - 실패 정보는 경고 로그로 기록합니다.
+ * - 빈이 없을 때 발생하는 [NoSuchBeanDefinitionException]만 `null`로 변환합니다.
+ * - [NoUniqueBeanDefinitionException], 빈 생성 실패, 타입 오류 같은 구성 실패는 전파합니다.
  *
  * ```kotlin
  * val service = beanFactory.findBean(MyService::class.java)
@@ -131,18 +146,17 @@ fun <T: Any> BeanFactory.findBean(requiredType: KClass<T>): T? = findBean(requir
  * ```
  */
 fun <T: Any> BeanFactory.findBean(requiredType: Class<T>): T? =
-    runCatching { get(requiredType) }
-        .getOrElse { e ->
-            log.warn(e) { "Fail to find bean. requiredType=$requiredType, return null." }
-            null
-        }
+    findOptionalBean(
+        description = { "requiredType=$requiredType" },
+        block = { get(requiredType) },
+    )
 
 /**
- * 이름과 타입으로 빈을 조회하고 실패하면 `null`을 반환합니다.
+ * 이름과 타입으로 빈을 조회하고 없으면 `null`을 반환합니다.
  *
  * ## 동작/계약
- * - [get] 호출에서 [BeansException]이 발생하면 예외 대신 `null`을 반환합니다.
- * - 실패 정보는 경고 로그로 기록합니다.
+ * - 빈이 없을 때 발생하는 [NoSuchBeanDefinitionException]만 `null`로 변환합니다.
+ * - 빈 생성 실패, 타입 오류 같은 구성 실패는 전파합니다.
  *
  * ```kotlin
  * val service = beanFactory.findBean("myService", MyService::class.java)
@@ -153,18 +167,17 @@ fun <T: Any> BeanFactory.findBean(
     name: String,
     requiredType: Class<T>,
 ): T? =
-    runCatching { get(name, requiredType) }
-        .getOrElse { e ->
-            log.warn(e) { "Fail to find bean. name=$name, requiredType=$requiredType, return null." }
-            null
-        }
+    findOptionalBean(
+        description = { "name=$name, requiredType=$requiredType" },
+        block = { get(name, requiredType) },
+    )
 
 /**
- * 이름과 생성자 인자로 빈을 조회하고 실패하면 `null`을 반환합니다.
+ * 이름과 생성자 인자로 빈을 조회하고 없으면 `null`을 반환합니다.
  *
  * ## 동작/계약
- * - [get] 호출에서 [BeansException]이 발생하면 예외 대신 `null`을 반환합니다.
- * - 실패 정보는 경고 로그로 기록합니다.
+ * - 빈이 없을 때 발생하는 [NoSuchBeanDefinitionException]만 `null`로 변환합니다.
+ * - 빈 생성 실패 같은 구성 실패는 전파합니다.
  *
  * ```kotlin
  * val bean = beanFactory.findBean("myBean", "arg1")
@@ -175,8 +188,7 @@ fun <T: Any> BeanFactory.findBean(
     name: String,
     vararg args: Any?,
 ): Any? =
-    runCatching { get(name, *args) }
-        .getOrElse { e ->
-            log.warn(e) { "Fail to find bean. name=$name, args=$args, return null." }
-            null
-        }
+    findOptionalBean(
+        description = { "name=$name, args=${args.contentToString()}" },
+        block = { get(name, *args) },
+    )

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/beans/BeanFactoryExtensionsTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/beans/BeanFactoryExtensionsTest.kt
@@ -1,16 +1,23 @@
 package io.bluetape4k.spring.beans
 
-import io.bluetape4k.spring.AbstractSpringTest
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.spring.AbstractSpringTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.BeanCreationException
 import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException
+import org.springframework.beans.factory.config.BeanDefinition
+import org.springframework.beans.factory.support.RootBeanDefinition
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.support.GenericApplicationContext
+import java.util.function.Supplier
 
 class BeanFactoryExtensionsTest: AbstractSpringTest() {
 
@@ -22,10 +29,29 @@ class BeanFactoryExtensionsTest: AbstractSpringTest() {
         override fun greet() = "hello"
     }
 
+    class AlternateSampleService: SampleService {
+        override fun greet() = "alternate"
+    }
+
+    class FailingConstructorBean(value: String) {
+        init {
+            error("Cannot create bean for $value")
+        }
+    }
+
     @Configuration
     open class TestConfig {
         @Bean
         open fun sampleService(): SampleService = SampleServiceImpl()
+    }
+
+    @Configuration
+    open class DuplicateBeanConfig {
+        @Bean
+        open fun firstSampleService(): SampleService = SampleServiceImpl()
+
+        @Bean
+        open fun secondSampleService(): SampleService = AlternateSampleService()
     }
 
     private lateinit var context: AnnotationConfigApplicationContext
@@ -98,6 +124,24 @@ class BeanFactoryExtensionsTest: AbstractSpringTest() {
     }
 
     @Test
+    fun `findBean Class bean creation failure is rethrown`() {
+        failingBeanContext().use { failingContext ->
+            assertFailsWith<BeanCreationException> {
+                failingContext.findBean(SampleService::class.java)
+            }
+        }
+    }
+
+    @Test
+    fun `findBean Class duplicate beans are rethrown`() {
+        AnnotationConfigApplicationContext(DuplicateBeanConfig::class.java).use { duplicateContext ->
+            assertFailsWith<NoUniqueBeanDefinitionException> {
+                duplicateContext.findBean(SampleService::class.java)
+            }
+        }
+    }
+
+    @Test
     fun `findBean 이름과 타입으로 성공`() {
         val service = beanFactory.findBean("sampleService", SampleService::class.java)
         service.shouldNotBeNull()
@@ -107,6 +151,15 @@ class BeanFactoryExtensionsTest: AbstractSpringTest() {
     fun `findBean 없는 이름은 null 반환`() {
         val result = beanFactory.findBean("nonExistent", SampleService::class.java)
         result.shouldBeNull()
+    }
+
+    @Test
+    fun `findBean 이름과 타입 bean creation failure is rethrown`() {
+        failingBeanContext().use { failingContext ->
+            assertFailsWith<BeanCreationException> {
+                failingContext.findBean("brokenService", SampleService::class.java)
+            }
+        }
     }
 
     @Test
@@ -120,4 +173,37 @@ class BeanFactoryExtensionsTest: AbstractSpringTest() {
         val result = beanFactory.findBean<Any>("nonExistentBean")
         result.shouldBeNull()
     }
+
+    @Test
+    fun `findBean args 버전 bean creation failure is rethrown`() {
+        failingArgsContext().use { failingContext ->
+            assertFailsWith<BeanCreationException> {
+                failingContext.findBean<Any>("failingConstructorBean", "boom")
+            }
+        }
+    }
+
+    private fun failingBeanContext(): GenericApplicationContext =
+        GenericApplicationContext().apply {
+            val beanDefinition =
+                RootBeanDefinition(SampleService::class.java).apply {
+                    instanceSupplier = Supplier<SampleService> { error("Cannot create sample service") }
+                    isLazyInit = true
+                }
+
+            registerBeanDefinition("brokenService", beanDefinition)
+            refresh()
+        }
+
+    private fun failingArgsContext(): GenericApplicationContext =
+        GenericApplicationContext().apply {
+            val beanDefinition =
+                RootBeanDefinition(FailingConstructorBean::class.java).apply {
+                    scope = BeanDefinition.SCOPE_PROTOTYPE
+                    isLazyInit = true
+                }
+
+            registerBeanDefinition("failingConstructorBean", beanDefinition)
+            refresh()
+        }
 }


### PR DESCRIPTION
## Summary

Closes #832

- PR 제목: fix: preserve Spring findBean creation failures

- Preserve Spring bean creation/configuration failures in `BeanFactory.findBean(...)` helpers instead of converting them to `null`.
- Keep optional lookup behavior for genuinely absent beans by returning `null` only for `NoSuchBeanDefinitionException`.
- Add regression coverage for class, named, duplicate, and constructor-argument lookup boundaries.

### 원문 선행 내용

Fixes #832

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Root Cause

The `findBean` helpers used broad `runCatching { ... }.getOrElse { null }`, which treated every Spring lookup failure as an absent optional bean. That hid bean creation failures and duplicate-bean ambiguity from callers.

## Validation

- RED: targeted `BeanFactoryExtensionsTest` failed before the production change for expected `BeanCreationException` / `NoUniqueBeanDefinitionException` propagation.
- GREEN: `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.beans.BeanFactoryExtensionsTest' --no-build-cache` passed with 17 tests.
- Module: `./gradlew :bluetape4k-spring-boot-core:compileKotlin :bluetape4k-spring-boot-core:compileTestKotlin :bluetape4k-spring-boot-core:test --no-build-cache` passed with 232 tests.
- Static: `git diff --check` passed.
- API check: `javap` against Spring Beans 7.0.8 confirmed `NoUniqueBeanDefinitionException` extends `NoSuchBeanDefinitionException`, so catch order is intentional.
- Review: native code-reviewer reported 0 blocking findings and APPROVE.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #832, milestone `1.11.0`, assignee `debop`
- PR: #888, head `756679b7e1b9b4e7d0d959b3c51b756a4eb63cc6`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/spring-findbean-failures-832`
- Labels: `bug`, `test`
- State: `MERGED`, merge commit `6f57f50c806ce9cdd2b8b2ddf64c397b7db97250`
- CI: - GREEN: `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.beans.BeanFactoryExtensionsTest' --no-build-cache` passed with 17 tests. / - Module: `./gradlew :bluetape4k-spring-boot-core:compileKotlin :bluetape4k-spring-boot-core:compileTestKotlin :bluetape4k-spring-boot-core:test --no-build-cache` passed with 232 tests.

## DoD Status

- [x] Issue #832 is assigned to `debop` and has milestone `1.11.0` with labels `bug`, `test`.
- [x] PR metadata mirrors issue assignee, milestone, and labels.
- [x] Regression tests cover absent optional beans vs propagated creation/ambiguity failures.
- [x] Targeted and module verification passed locally.
- [x] PR body was written via `--body-file` and verified after creation.
- [x] GitHub Actions passed.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #888 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `6f57f50c806ce9cdd2b8b2ddf64c397b7db97250`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
