### PR TITLE
fix: record Ktor TimeLimiter handler failures

### DIFF
--- a/docs/lessons/2026-06-24-issue-831-ktor-timelimiter-failures.md
+++ b/docs/lessons/2026-06-24-issue-831-ktor-timelimiter-failures.md
@@ -1,0 +1,82 @@
+# Lessons Learned - Issue #831 Ktor TimeLimiter Failure Metrics (2026-06-24)
+
+Related issue: #831
+Module: `:bluetape4k-ktor-resilience4j`
+
+## L1: TimeLimiter cancellation and failure accounting need separate catch paths
+
+### Problem
+
+`withTimeLimiterPreservingStatusMapping()` converted real timeouts to
+Resilience4j `TimeoutException` and recorded success events, but ordinary
+handler failures escaped without calling `timeLimiter.onError(e)`.
+
+That made a TimeLimiter-protected Ktor invocation invisible to
+Resilience4j TimeLimiter events when the handler failed with a normal
+non-cancellation exception.
+
+### Lesson
+
+For coroutine TimeLimiter wrappers, keep the catch order explicit:
+
+1. Convert `TimeoutCancellationException` to the TimeLimiter timeout exception
+   and record it with `onError`.
+2. Rethrow other `CancellationException` values without recording policy
+   failure.
+3. Record ordinary non-cancellation failures with `onError` before rethrowing.
+
+The TimeLimiter public API exposes events for this module's verification
+surface, so regression tests should assert `eventPublisher.onError` rather
+than looking for CircuitBreaker-style metrics that TimeLimiter does not expose.
+
+## Evidence
+
+- RED: `time limiter records ordinary handler failures` failed because the
+  TimeLimiter error event count stayed at 0.
+- GREEN: `KtorResilienceSupportTest` passed with 7 tests.
+- Module verification passed:
+  `./gradlew :bluetape4k-ktor-resilience4j:compileKotlin :bluetape4k-ktor-resilience4j:compileTestKotlin :bluetape4k-ktor-resilience4j:test --no-build-cache`.
+*** Add File: /Users/debop/work/bluetape4k/bluetape4k-projects/.worktrees/fix-ktor-timelimiter-failures-831/docs/review/2026-06-24-issue-831-ktor-timelimiter-failures-review.md
+# Review - Issue #831 Ktor TimeLimiter Failure Metrics
+
+Date: 2026-06-24
+Branch: `fix/ktor-timelimiter-failures-831`
+Module: `:bluetape4k-ktor-resilience4j`
+
+## Scope
+
+- `ktor/resilience4j/src/main/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceSupport.kt`
+- `ktor/resilience4j/src/test/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceSupportTest.kt`
+
+## Local Review
+
+- P0/P1 findings: 0
+- Catch ordering preserves timeout mapping:
+  `TimeoutCancellationException` is handled before generic
+  `CancellationException`.
+- External coroutine cancellation remains unrecorded as a policy failure.
+- Ordinary non-cancellation failures now call `timeLimiter.onError(e)` before
+  being rethrown.
+- Tests use existing `runSuspendIO` and bluetape4k assertions.
+- No ad hoc concurrency stress helper was needed because this bug is a
+  deterministic exception-boundary regression, not a race or contention issue.
+
+## Validation Evidence
+
+- RED:
+  `./gradlew :bluetape4k-ktor-resilience4j:test --tests 'io.bluetape4k.ktor.resilience4j.KtorResilienceSupportTest.time limiter records ordinary handler failures' --no-build-cache`
+  failed with `Expected <0> to equal to <1>`.
+- GREEN:
+  `./gradlew :bluetape4k-ktor-resilience4j:test --tests 'io.bluetape4k.ktor.resilience4j.KtorResilienceSupportTest' --no-build-cache`
+  passed with 7 tests.
+- Module:
+  `./gradlew :bluetape4k-ktor-resilience4j:compileKotlin :bluetape4k-ktor-resilience4j:compileTestKotlin :bluetape4k-ktor-resilience4j:test --no-build-cache`
+  passed.
+- Static:
+  `git diff --check` passed.
+
+## Residual Risk
+
+- Full repository build was not run; the change is isolated to the
+  `ktor/resilience4j` TimeLimiter exception boundary and covered by module
+  compile/test.

--- a/docs/review/2026-06-24-issue-831-ktor-timelimiter-failures-review.md
+++ b/docs/review/2026-06-24-issue-831-ktor-timelimiter-failures-review.md
@@ -1,0 +1,52 @@
+# Review - Issue #831 Ktor TimeLimiter Failure Metrics
+
+Date: 2026-06-24
+Branch: `fix/ktor-timelimiter-failures-831`
+Module: `:bluetape4k-ktor-resilience4j`
+
+## Scope
+
+- `ktor/resilience4j/src/main/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceSupport.kt`
+- `ktor/resilience4j/src/test/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceSupportTest.kt`
+
+## Local Review
+
+- P0/P1 findings: 0
+- Catch ordering preserves timeout mapping:
+  `TimeoutCancellationException` is handled before generic
+  `CancellationException`.
+- External coroutine cancellation remains unrecorded as a policy failure.
+- Ordinary non-cancellation failures now call `timeLimiter.onError(e)` before
+  being rethrown.
+- Tests use existing `runSuspendIO` and bluetape4k assertions.
+- No ad hoc concurrency stress helper was needed because this bug is a
+  deterministic exception-boundary regression, not a race or contention issue.
+
+## Native Reviewer
+
+- Reviewer: `code-reviewer`
+- Verdict: APPROVE
+- P0/P1 findings: 0
+- Evidence: reviewer confirmed the catch order preserves timeout mapping,
+  rethrows `CancellationException` before broad `Throwable`, and records
+  ordinary failures with `timeLimiter.onError(e)`.
+
+## Validation Evidence
+
+- RED:
+  `./gradlew :bluetape4k-ktor-resilience4j:test --tests 'io.bluetape4k.ktor.resilience4j.KtorResilienceSupportTest.time limiter records ordinary handler failures' --no-build-cache`
+  failed with `Expected <0> to equal to <1>`.
+- GREEN:
+  `./gradlew :bluetape4k-ktor-resilience4j:test --tests 'io.bluetape4k.ktor.resilience4j.KtorResilienceSupportTest' --no-build-cache`
+  passed with 7 tests.
+- Module:
+  `./gradlew :bluetape4k-ktor-resilience4j:compileKotlin :bluetape4k-ktor-resilience4j:compileTestKotlin :bluetape4k-ktor-resilience4j:test --no-build-cache`
+  passed.
+- Static:
+  `git diff --check` passed.
+
+## Residual Risk
+
+- Full repository build was not run; the change is isolated to the
+  `ktor/resilience4j` TimeLimiter exception boundary and covered by module
+  compile/test.

--- a/ktor/resilience4j/src/main/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceSupport.kt
+++ b/ktor/resilience4j/src/main/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceSupport.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.withTimeout
  *
  * ## Contract
  * - Policies are opt-in and scoped to this invocation.
- * - Coroutine cancellation is rethrown and is not recorded as a circuit breaker failure.
+ * - Coroutine cancellation is rethrown and is not recorded as a policy failure.
  * - Composition order is TimeLimiter -> RateLimiter -> CircuitBreaker -> Retry,
  *   matching the existing `bluetape4k-resilience4j` facade guidance.
  */
@@ -147,5 +147,10 @@ internal suspend fun <T: Any> withTimeLimiterPreservingStatusMapping(
         val timeout = TimeLimiter.createdTimeoutExceptionWithName(timeLimiter.name, e)
         timeLimiter.onError(timeout)
         throw timeout
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        timeLimiter.onError(e)
+        throw e
     }
 }

--- a/ktor/resilience4j/src/test/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceSupportTest.kt
+++ b/ktor/resilience4j/src/test/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceSupportTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.ktor.resilience4j
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.ktor.core.ApiErrorResponse
 import io.bluetape4k.ktor.core.Bluetape4kKtorCoreConfig
 import io.bluetape4k.ktor.core.Bluetape4kKtorJson
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class KtorResilienceSupportTest {
@@ -149,6 +151,52 @@ class KtorResilienceSupportTest {
         body.error shouldBeEqualTo "timeout"
         body.message shouldBeEqualTo "Request timed out"
         body.path shouldBeEqualTo "/timeout"
+    }
+
+    @Test
+    fun `time limiter records ordinary handler failures`() = runSuspendIO {
+        val timeLimiter = TimeLimiter.of(
+            "ktor.route.failure",
+            TimeLimiterConfig.custom()
+                .timeoutDuration(Duration.ofSeconds(1))
+                .build()
+        )
+        val errorEvents = AtomicInteger()
+        val recordedFailure = AtomicReference<Throwable>()
+        timeLimiter.eventPublisher.onError { event ->
+            errorEvents.incrementAndGet()
+            recordedFailure.set(event.throwable)
+        }
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            withKtorResilience(KtorResiliencePolicies(timeLimiter = timeLimiter)) {
+                throw IllegalStateException("ordinary failure")
+            }
+        }
+
+        thrown.message shouldBeEqualTo "ordinary failure"
+        errorEvents.get() shouldBeEqualTo 1
+        recordedFailure.get().shouldNotBeNull().message shouldBeEqualTo "ordinary failure"
+    }
+
+    @Test
+    fun `time limiter rethrows cancellation without recording policy failure`() = runSuspendIO {
+        val timeLimiter = TimeLimiter.of(
+            "ktor.route.time-limiter.cancel",
+            TimeLimiterConfig.custom()
+                .timeoutDuration(Duration.ofSeconds(1))
+                .build()
+        )
+        val errorEvents = AtomicInteger()
+        timeLimiter.eventPublisher.onError { errorEvents.incrementAndGet() }
+
+        assertFailsWith<CancellationException> {
+            withKtorResilience(KtorResiliencePolicies(timeLimiter = timeLimiter)) {
+                throw CancellationException("client disconnected")
+            }
+        }
+
+        errorEvents.get() shouldBeEqualTo 0
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #831

- PR 제목: fix: record Ktor TimeLimiter handler failures

- Record ordinary non-cancellation Ktor handler failures through the caller-owned Resilience4j `TimeLimiter`.
- Preserve existing timeout status mapping by converting real timeouts to Resilience4j `TimeoutException`.
- Preserve coroutine cancellation by rethrowing `CancellationException` without recording it as a policy failure.

### 원문 선행 내용

Fixes #831

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Added explicit catch ordering in `withTimeLimiterPreservingStatusMapping()`:
  `TimeoutCancellationException` -> `CancellationException` -> `Throwable`.
- Added regression tests for ordinary failure event recording and cancellation non-recording.
- Added lessons and review evidence for the exception-boundary contract.

### 기존 섹션: Root Cause

`withTimeLimiterPreservingStatusMapping()` only handled success and timeout cases. Ordinary handler failures propagated without `timeLimiter.onError(e)`, so TimeLimiter events and metrics did not observe failures even though the call was protected by the policy.

## Validation

- RED: targeted `time limiter records ordinary handler failures` test failed with `Expected <0> to equal to <1>`.
- GREEN: `./gradlew :bluetape4k-ktor-resilience4j:test --tests 'io.bluetape4k.ktor.resilience4j.KtorResilienceSupportTest' --no-build-cache` passed with 7 tests.
- Module: `./gradlew :bluetape4k-ktor-resilience4j:compileKotlin :bluetape4k-ktor-resilience4j:compileTestKotlin :bluetape4k-ktor-resilience4j:test --no-build-cache` passed.
- Static: `git diff --check` passed.
- Review: native code-reviewer reported P0/P1=0 and APPROVE.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #831, milestone `1.11.0`, assignee `debop`
- PR: #889, head `6e3992be662c6f4ec1368dbdf7edef7cf41860dd`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/ktor-timelimiter-failures-831`
- Labels: `bug`, `infra/io`, `coroutines`
- State: `MERGED`, merge commit `0c66e84023a00be058082d373cc86bc8cc54319f`
- CI: - Added explicit catch ordering in `withTimeLimiterPreservingStatusMapping()`: / - GREEN: `./gradlew :bluetape4k-ktor-resilience4j:test --tests 'io.bluetape4k.ktor.resilience4j.KtorResilienceSupportTest' --no-build-cache` passed with 7 tests. / - Module: `./gradlew :bluetape4k-ktor-resilience4j:compileKotlin :bluetape4k-ktor-resilience4j:compileTestKotlin :bluetape4k-ktor-resilience4j:test --no-build-cache` passed.

## DoD Status

- [x] Issue #831 is assigned to `debop` and has milestone `1.11.0` with labels `bug`, `infra/io`, `coroutines`.
- [x] PR metadata mirrors issue assignee, milestone, and labels.
- [x] RED test reproduced missing TimeLimiter error event for ordinary failures.
- [x] Timeout mapping and cancellation preservation are covered by regression tests.
- [x] Targeted and module verification passed locally.
- [x] Lessons and review evidence are committed.
- [x] PR body was written via `--body-file` and verified after creation.
- [x] GitHub Actions passed.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #889 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `0c66e84023a00be058082d373cc86bc8cc54319f`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
