### PR TITLE
fix: preserve Ktor OpenAPI metadata sources

### DIFF
--- a/docs/lessons/2026-06-24-issue-829-ktor-openapi-metadata-source.md
+++ b/docs/lessons/2026-06-24-issue-829-ktor-openapi-metadata-source.md
@@ -1,0 +1,31 @@
+# Issue 829 Ktor OpenAPI Metadata Source
+
+## Context
+
+`bluetape4k-ktor-openapi` advertised static files, compiler-generated OpenAPI
+metadata, and runtime `.describe {}` metadata as application-owned document
+sources.
+
+## Lesson
+
+Ktor's `openAPI(path, swaggerFile, block)` and
+`swaggerUI(path, swaggerFile, block)` overloads apply the caller block first and
+then force `source = OpenApiDocSource.File(swaggerFile)`. Wrapper helpers that
+accept a configuration block must delegate through Ktor's `block`-only overload
+when caller-owned `OpenApiDocSource` values need to survive.
+
+## Guard
+
+When README or KDoc claims Ktor routing-tree OpenAPI metadata is supported,
+tests must cover `OpenApiDocSource.Routing` through both the OpenAPI endpoint
+and the Swagger UI specification endpoint. A static YAML happy path is not
+enough because it does not prove the caller-owned `source` contract.
+
+## Evidence
+
+- RED: `KtorOpenApiRoutesTest` added routing metadata source tests; old wrapper
+  failed 2 of 6 tests because the Ktor static-file overload overwrote source.
+- GREEN: `./gradlew :bluetape4k-ktor-openapi:compileKotlin :bluetape4k-ktor-openapi:compileTestKotlin :bluetape4k-ktor-openapi:test --no-build-cache`
+  passed with 6 `KtorOpenApiRoutesTest` cases.
+- Official Ktor docs and local Ktor 3.5.0 sources both show runtime metadata
+  via `OpenApiDocSource.Routing`.

--- a/docs/review/2026-06-24-issue-829-ktor-openapi-metadata-source-review.md
+++ b/docs/review/2026-06-24-issue-829-ktor-openapi-metadata-source-review.md
@@ -1,0 +1,49 @@
+# Issue 829 Ktor OpenAPI Metadata Source Review
+
+## Scope
+
+- `ktor/openapi/src/main/kotlin/io/bluetape4k/ktor/openapi/KtorOpenApiRoutes.kt`
+- `ktor/openapi/src/test/kotlin/io/bluetape4k/ktor/openapi/KtorOpenApiRoutesTest.kt`
+- `ktor/openapi/README.md`
+- `ktor/openapi/README.ko.md`
+
+## Verdict
+
+APPROVE.
+
+- P0: 0
+- P1: 0
+
+## Review Evidence
+
+- Verified issue #829: existing wrappers called Ktor static-file overloads that
+  run caller configuration and then overwrite `source` with
+  `OpenApiDocSource.File(swaggerFile)`.
+- Verified local Ktor 3.5.0 sources:
+  - `Route.openAPI(path, swaggerFile, block)` delegates to `openAPI(path)` and
+    then sets `source = OpenApiDocSource.File(swaggerFile)`.
+  - `Route.swaggerUI(path, swaggerFile, block)` delegates to `swaggerUI(path)`
+    and then sets `source = OpenApiDocSource.File(swaggerFile)` plus
+    `remotePath`.
+- Verified new regression coverage:
+  - `openapi endpoint preserves caller owned document source`
+  - `swagger ui endpoint preserves caller owned document source`
+- Verified static file coverage still exists for both helpers.
+
+## P2 Notes
+
+The implementation detects Ktor's default source shape before applying the
+static `swaggerFile` fallback. This is intentionally narrow for Ktor 3.5.0:
+it preserves the existing default static-file behavior while allowing
+caller-owned `OpenApiDocSource.Routing` or other explicit sources to survive.
+If Ktor changes its default `OpenApiDocSource` shape in a future upgrade, this
+helper should be revisited with that Ktor source change in hand.
+
+## Validation
+
+- RED: old implementation failed the two new source-preservation tests.
+- GREEN: `./gradlew :bluetape4k-ktor-openapi:test --tests 'io.bluetape4k.ktor.openapi.KtorOpenApiRoutesTest' --no-build-cache`
+  passed with 6 tests.
+- Module gate: `./gradlew :bluetape4k-ktor-openapi:compileKotlin :bluetape4k-ktor-openapi:compileTestKotlin :bluetape4k-ktor-openapi:test --no-build-cache`
+  passed with 6 `KtorOpenApiRoutesTest` cases.
+- `git diff --check` passed.

--- a/ktor/openapi/README.ko.md
+++ b/ktor/openapi/README.ko.md
@@ -64,8 +64,29 @@ Ktor OpenAPI HTML renderer가 내부적으로 Swagger Codegen에 위임하고 sc
 ## Runtime Metadata
 
 Ktor 3.5는 Ktor compiler OpenAPI extension, route comment, runtime `.describe {}`
-metadata를 통해 routing tree에서 OpenAPI metadata를 조립할 수 있습니다. Route
-metadata는 해당 동작을 소유하는 route 근처에 둡니다.
+metadata를 통해 routing tree에서 OpenAPI metadata를 조립할 수 있습니다. 정적
+`swaggerFile` 경로가 아니라 route metadata에서 문서를 만들려면 bluetape4k helper에
+`OpenApiDocSource.Routing`을 설정합니다.
+
+```kotlin
+fun Application.module() {
+    installBluetape4kKtorCore()
+
+    routing {
+        widgetRoutes()
+
+        bluetape4kOpenApi {
+            source = OpenApiDocSource.Routing()
+        }
+        bluetape4kSwaggerUi {
+            remotePath = "openapi.json"
+            source = OpenApiDocSource.Routing()
+        }
+    }
+}
+```
+
+Route metadata는 해당 동작을 소유하는 route 근처에 둡니다.
 
 ```kotlin
 @OptIn(ExperimentalKtorApi::class)

--- a/ktor/openapi/README.md
+++ b/ktor/openapi/README.md
@@ -65,8 +65,29 @@ delegates to Swagger Codegen internals that expect the schema map.
 
 Ktor 3.5 can assemble OpenAPI metadata from the routing tree when applications
 enable the Ktor compiler OpenAPI extension, add route comments, or attach
-runtime `.describe {}` metadata. Keep route metadata near the route that owns
-the behavior:
+runtime `.describe {}` metadata. Configure the bluetape4k helpers with
+`OpenApiDocSource.Routing` when the document should come from route metadata
+instead of the static `swaggerFile` path:
+
+```kotlin
+fun Application.module() {
+    installBluetape4kKtorCore()
+
+    routing {
+        widgetRoutes()
+
+        bluetape4kOpenApi {
+            source = OpenApiDocSource.Routing()
+        }
+        bluetape4kSwaggerUi {
+            remotePath = "openapi.json"
+            source = OpenApiDocSource.Routing()
+        }
+    }
+}
+```
+
+Keep route metadata near the route that owns the behavior:
 
 ```kotlin
 @OptIn(ExperimentalKtorApi::class)

--- a/ktor/openapi/src/main/kotlin/io/bluetape4k/ktor/openapi/KtorOpenApiRoutes.kt
+++ b/ktor/openapi/src/main/kotlin/io/bluetape4k/ktor/openapi/KtorOpenApiRoutes.kt
@@ -5,14 +5,17 @@ import io.ktor.server.plugins.openapi.OpenAPIConfig
 import io.ktor.server.plugins.openapi.openAPI
 import io.ktor.server.plugins.swagger.SwaggerConfig
 import io.ktor.server.plugins.swagger.swaggerUI
+import io.ktor.server.routing.openapi.OpenApiDocSource
 import io.ktor.server.routing.Route
+import java.io.File
 
 /**
  * Adds an OpenAPI documentation endpoint backed by Ktor's official OpenAPI plugin.
  *
  * ## Contract
  * - The endpoint is explicit and route-scoped; this function does not install global application plugins.
- * - [swaggerFile] is resolved by Ktor from application resources first and then the file system.
+ * - [swaggerFile] is used when [configure] leaves Ktor's default document source unchanged.
+ * - A caller-owned [OpenAPIConfig.source] from [configure] is preserved for routing-tree or generated metadata.
  * - Applications own the OpenAPI document and route metadata lifecycle.
  *
  * ```kotlin
@@ -28,7 +31,12 @@ fun Route.bluetape4kOpenApi(
 ): Route {
     path.requireNotBlank("path")
     swaggerFile.requireNotBlank("swaggerFile")
-    return openAPI(path = path, swaggerFile = swaggerFile, block = configure)
+    return openAPI(path = path) {
+        configure()
+        if (source.isDefaultDocumentSource()) {
+            source = OpenApiDocSource.File(swaggerFile)
+        }
+    }
 }
 
 /**
@@ -36,7 +44,8 @@ fun Route.bluetape4kOpenApi(
  *
  * ## Contract
  * - The endpoint is explicit and route-scoped.
- * - The OpenAPI document stays caller-owned through [swaggerFile] or [configure].
+ * - [swaggerFile] is used when [configure] leaves Ktor's default document source unchanged.
+ * - A caller-owned [SwaggerConfig.source] from [configure] is preserved for routing-tree or generated metadata.
  * - This helper does not generate route behavior or mutate existing routes.
  *
  * ```kotlin
@@ -52,9 +61,24 @@ fun Route.bluetape4kSwaggerUi(
 ): Route {
     path.requireNotBlank("path")
     swaggerFile.requireNotBlank("swaggerFile")
-    return swaggerUI(path = path, swaggerFile = swaggerFile, block = configure)
+    return swaggerUI(path = path) {
+        configure()
+        if (source.isDefaultDocumentSource()) {
+            source = OpenApiDocSource.File(swaggerFile)
+            remotePath = File(swaggerFile).name
+        }
+    }
 }
 
 const val DEFAULT_OPENAPI_PATH: String = "openapi"
 const val DEFAULT_SWAGGER_UI_PATH: String = "swagger"
 const val DEFAULT_OPENAPI_FILE: String = "openapi/documentation.yaml"
+
+private fun OpenApiDocSource.isDefaultDocumentSource(): Boolean =
+    this is OpenApiDocSource.FirstOf &&
+        options.size == 2 &&
+        options[0].isFileSource(DEFAULT_OPENAPI_FILE) &&
+        options[1] is OpenApiDocSource.Routing
+
+private fun OpenApiDocSource.isFileSource(path: String): Boolean =
+    this is OpenApiDocSource.File && this.path == path

--- a/ktor/openapi/src/test/kotlin/io/bluetape4k/ktor/openapi/KtorOpenApiRoutesTest.kt
+++ b/ktor/openapi/src/test/kotlin/io/bluetape4k/ktor/openapi/KtorOpenApiRoutesTest.kt
@@ -7,8 +7,15 @@ import io.bluetape4k.ktor.core.installBluetape4kKtorCore
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
+import io.ktor.openapi.Components
+import io.ktor.openapi.OpenApiInfo
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.openapi.OpenApiDocSource
+import io.ktor.server.routing.openapi.describe
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import io.ktor.utils.io.ExperimentalKtorApi
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 
@@ -52,6 +59,51 @@ class KtorOpenApiRoutesTest {
     }
 
     @Test
+    fun `openapi endpoint preserves caller owned document source`() = testApplication {
+        application {
+            installOpenApiTestCore()
+            routing {
+                runtimeMetadataRoute()
+                bluetape4kOpenApi {
+                    info = OpenApiInfo("Runtime Owned OpenAPI Test", "1.0.0")
+                    components = Components(schemas = emptyMap())
+                    outputPath = "build/openapi-runtime-docs"
+                    source = OpenApiDocSource.Routing()
+                }
+            }
+        }
+
+        val response = client.get("/openapi")
+        val body = response.bodyAsText()
+
+        response.status shouldBeEqualTo HttpStatusCode.OK
+        body.contains("Runtime Owned OpenAPI Test") shouldBeEqualTo true
+        body.contains("/runtime") shouldBeEqualTo true
+    }
+
+    @Test
+    fun `swagger ui endpoint preserves caller owned document source`() = testApplication {
+        application {
+            installOpenApiTestCore()
+            routing {
+                runtimeMetadataRoute()
+                bluetape4kSwaggerUi {
+                    info = OpenApiInfo("Runtime Owned OpenAPI Test", "1.0.0")
+                    remotePath = "runtime.json"
+                    source = OpenApiDocSource.Routing()
+                }
+            }
+        }
+
+        val response = client.get("/swagger/runtime.json")
+        val body = response.bodyAsText()
+
+        response.status shouldBeEqualTo HttpStatusCode.OK
+        body.contains("Runtime Owned OpenAPI Test") shouldBeEqualTo true
+        body.contains("/runtime") shouldBeEqualTo true
+    }
+
+    @Test
     fun `openapi endpoint rejects blank path`() = testApplication {
         application {
             installOpenApiTestCore()
@@ -82,5 +134,19 @@ class KtorOpenApiRoutesTest {
                 installHealthRoutes = false
             )
         )
+    }
+
+    @OptIn(ExperimentalKtorApi::class)
+    private fun io.ktor.server.routing.Route.runtimeMetadataRoute() {
+        get("/runtime") {
+            call.respondText("runtime")
+        }.describe {
+            summary = "Runtime metadata route"
+            responses {
+                HttpStatusCode.OK {
+                    description = "Runtime metadata response"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #829

- PR 제목: fix: preserve Ktor OpenAPI metadata sources

- Preserve caller-owned OpenAPI document sources in `bluetape4kOpenApi` and `bluetape4kSwaggerUi`.
- Keep the existing static `swaggerFile` fallback when callers leave Ktor's default document source unchanged.
- Add regression coverage for Ktor routing-tree metadata through both the OpenAPI endpoint and Swagger UI specification endpoint.
- Update English and Korean README runtime metadata examples.

### 원문 선행 내용

Fixes #829

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Changed the wrappers to delegate through Ktor's block-only overloads.
- Applied `OpenApiDocSource.File(swaggerFile)` only when Ktor's default document source remains unchanged.
- Preserved Swagger UI `remotePath` behavior for the static-file fallback.
- Added tests that serve routing-tree metadata generated from `.describe {}` through both helpers.
- Documented runtime metadata setup with `OpenApiDocSource.Routing` in `README.md` and `README.ko.md`.
- Added lesson and review evidence for the Ktor source-preservation contract.

### 기존 섹션: Root Cause

Ktor's `openAPI(path, swaggerFile, block)` and `swaggerUI(path, swaggerFile, block)` overloads run the caller configuration block and then overwrite `source` with `OpenApiDocSource.File(swaggerFile)`. The bluetape4k wrappers delegated to those overloads, so applications could not keep `OpenApiDocSource.Routing` or runtime `.describe {}` metadata even though the README advertised that path.

## Validation

- RED: the two new source-preservation tests failed on the old wrapper because `swaggerFile` overloads overwrote the caller source.
- `./gradlew :bluetape4k-ktor-openapi:test --tests 'io.bluetape4k.ktor.openapi.KtorOpenApiRoutesTest' --no-build-cache` passed with 6 tests.
- `./gradlew :bluetape4k-ktor-openapi:compileKotlin :bluetape4k-ktor-openapi:compileTestKotlin :bluetape4k-ktor-openapi:test --no-build-cache` passed.
- `git diff --check` passed.

## Review Notes

- P0/P1 review gate: 0 findings.
- P2 note recorded: the default-source shape check follows Ktor 3.5.0 defaults and should be revisited with future Ktor source changes.

## Metadata

- Issue: #829, milestone `1.11.0`, assignee `debop`
- PR: #891, head `de4fbb6c1c83fe9f9ba436ced4fc87a2a71cfa8d`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/ktor-openapi-metadata-sources-829`
- Labels: `bug`, `documentation`, `infra/io`
- State: `MERGED`, merge commit `06df6c705ac4daf8cd6aa9615aa6e69937d61449`
- CI: - Add regression coverage for Ktor routing-tree metadata through both the OpenAPI endpoint and Swagger UI specification endpoint. / - `./gradlew :bluetape4k-ktor-openapi:test --tests 'io.bluetape4k.ktor.openapi.KtorOpenApiRoutesTest' --no-build-cache` passed with 6 tests. / - `./gradlew :bluetape4k-ktor-openapi:compileKotlin :bluetape4k-ktor-openapi:compileTestKotlin :bluetape4k-ktor-openapi:test --no-build-cache` passed.

## DoD Status

| Step | Status | Evidence |
|------|--------|----------|
| Merge previous PR | PASS | PR #890 merged; local `develop` fast-forwarded to `origin/develop`; merged worktree/branch removed. |
| Issue selection | PASS | Issue #829 selected from open `1.11.0` queue; assignee `debop`, milestone `1.11.0`, labels `bug`, `documentation`, `infra/io`. |
| Worktree | PASS | Branch `fix/ktor-openapi-metadata-sources-829` created from current `origin/develop`. |
| RED test | PASS | New source-preservation tests failed on old wrapper. |
| Fix | PASS | Wrappers now preserve caller-owned `OpenApiDocSource` and retain static-file fallback. |
| Tests | PASS | Targeted class test and module compile/test passed locally. |
| Docs | PASS | `README.md` and `README.ko.md` runtime metadata examples updated. |
| Review | PASS | Review artifact recorded P0/P1=0. |
| Lessons | PASS | `docs/lessons/2026-06-24-issue-829-ktor-openapi-metadata-source.md` committed. |
| PR body | PASS | Body written via `--body-file` and live body verified after PR creation. |
| CI | PASS | GitHub Actions passed: Build, Test / Ktor, Coverage Report, CI Status, gitleaks, wrapper validation, dependency submission. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #891 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `06df6c705ac4daf8cd6aa9615aa6e69937d61449`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
