### PR TITLE
chore: keep test compilation warning-free

### DIFF
--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/ReplayTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/ReplayTest.kt
@@ -18,7 +18,7 @@ class ReplayTest: AbstractFlowTest() {
     @Test
     fun `replay one consumer`() = runTest {
         flowRangeOf(1, 5)
-            .replay { shared ->
+            .replay(5) { shared ->
                 shared.filter { it % 2 == 0 }.log("even", log)
             }
             .assertResult(2, 4)
@@ -27,7 +27,7 @@ class ReplayTest: AbstractFlowTest() {
     @Test
     fun `replay multiple consumers`() = runTest {
         flowRangeOf(1, 5)
-            .replay { shared ->
+            .replay(5) { shared ->
                 merge(
                     shared.filter { it % 2 == 1 }.log("odd", log),
                     shared.filter { it % 2 == 0 }.log("even", log)

--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/SessionSupport.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/SessionSupport.kt
@@ -108,12 +108,10 @@ inline fun <reified T: Any> Session.findByNaturalId(
 ): T? {
     naturalIdValues.requireNotEmpty("naturalIdValues")
 
-    val access = byNaturalId(T::class.java)
-    naturalIdValues.forEach { (attributeName, value) ->
+    naturalIdValues.keys.forEach { attributeName ->
         attributeName.requireNotBlank("naturalIdValues.key")
-        access.using(attributeName, value)
     }
-    return access.load()
+    return find(T::class.java, naturalIdValues, KeyType.NATURAL)
 }
 
 /**

--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/ObjectAsBase64StringConverter.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/ObjectAsBase64StringConverter.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.codec.decodeBase64ByteArray
 import io.bluetape4k.codec.encodeBase64String
 import io.bluetape4k.io.serializer.BinarySerializer
 import io.bluetape4k.io.serializer.BinarySerializers
+import io.bluetape4k.io.serializer.JdkBinarySerializer
 import jakarta.persistence.AttributeConverter
 import jakarta.persistence.Converter
 
@@ -45,7 +46,7 @@ abstract class AbstractObjectAsBase64StringConverter(
  * @see BinarySerializers.Jdk
  */
 @Converter
-class JdkObjectAsBase64StringConverter: AbstractObjectAsBase64StringConverter(BinarySerializers.Jdk)
+class JdkObjectAsBase64StringConverter: AbstractObjectAsBase64StringConverter(JdkBinarySerializer())
 
 /**
  * 객체를 Jdk 직렬화, LZ4로 압축 한 후 Base64 인코딩된 문자열로 변환해서 DB에 저장합니다.

--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/ObjectAsByteArrayConverter.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/ObjectAsByteArrayConverter.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.codec.decodeBase64ByteArray
 import io.bluetape4k.codec.encodeBase64ByteArray
 import io.bluetape4k.io.serializer.BinarySerializer
 import io.bluetape4k.io.serializer.BinarySerializers
+import io.bluetape4k.io.serializer.JdkBinarySerializer
 import jakarta.persistence.AttributeConverter
 import jakarta.persistence.Converter
 
@@ -43,7 +44,7 @@ abstract class AbstractObjectAsByteArrayConverter(
  * 객체를 Jdk 직렬화하여 Base64 인코딩을 거쳐 ByteArray 로 변환해서 DB에 저장합니다.
  */
 @Converter
-class JdkObjectAsByteArrayConverter: AbstractObjectAsByteArrayConverter(BinarySerializers.Jdk)
+class JdkObjectAsByteArrayConverter: AbstractObjectAsByteArrayConverter(JdkBinarySerializer())
 
 /**
  * 객체를 Jdk 직렬화, LZ4로 압축 한 후 Base64 인코딩을 거쳐 ByteArray 로 변환해서 DB에 저장합니다.

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/SessionFactorySupportTest.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/SessionFactorySupportTest.kt
@@ -1,11 +1,11 @@
 package io.bluetape4k.hibernate
 
+import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.hibernate.mapping.simple.SimpleEntity
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeNull
-import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.hibernate.SessionFactory
 import org.hibernate.event.service.spi.EventListenerRegistry
@@ -79,8 +79,7 @@ class SessionFactorySupportTest: AbstractHibernateTest() {
         group.shouldNotBeNull()
 
         // 리스너가 포함되어 있는지 확인
-        val listeners = group.listeners().toList()
-        listeners.shouldNotBeEmpty()
+        group.count() shouldBeGreaterThan 0
     }
 
     @Test

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/mapping/associations/join/models.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/mapping/associations/join/models.kt
@@ -28,7 +28,6 @@ import jakarta.persistence.OneToMany
 import jakarta.persistence.PrimaryKeyJoinColumn
 import jakarta.persistence.SecondaryTable
 import jakarta.validation.constraints.NotBlank
-import org.hibernate.annotations.Cascade
 import org.hibernate.annotations.Fetch
 import org.hibernate.annotations.FetchMode
 import org.springframework.data.annotation.CreatedDate
@@ -112,7 +111,6 @@ class JoinUser private constructor(
         indexes = [Index(name = "ix_join_user_nickname", columnList = "user_id")]
     )
     @ElementCollection(targetClass = String::class, fetch = FetchType.LAZY)
-    @Cascade(org.hibernate.annotations.CascadeType.ALL)
     val nicknames: MutableSet<String> = hashSetOf()
 
     override fun equalProperties(other: Any): Boolean =

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/mapping/inheritance/TablePerClassInheritanceTest.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/mapping/inheritance/TablePerClassInheritanceTest.kt
@@ -14,8 +14,6 @@ import jakarta.persistence.Index
 import jakarta.persistence.Inheritance
 import jakarta.persistence.InheritanceType
 import jakarta.persistence.Table
-import jakarta.persistence.Temporal
-import jakarta.persistence.TemporalType
 import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeEmpty
@@ -25,7 +23,8 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.repository.findByIdOrNull
-import java.util.*
+import java.time.LocalDateTime
+import java.util.UUID
 
 class TablePerClassInheritanceTest: AbstractHibernateTest() {
 
@@ -50,7 +49,7 @@ class TablePerClassInheritanceTest: AbstractHibernateTest() {
             companyName = "KakaoBank"
             expYear = 2024
             expMonth = 12
-            startDate = Date()
+            startDate = LocalDateTime.now()
         }
 
         cardRepo.save(card)
@@ -129,11 +128,9 @@ class UuidCreditCard(owner: String, swift: String? = null): AbstractUuidBilling(
     var expMonth: Int? = null
     var expYear: Int? = null
 
-    @Temporal(TemporalType.TIMESTAMP)
-    var startDate: Date? = null
+    var startDate: LocalDateTime? = null
 
-    @Temporal(TemporalType.TIMESTAMP)
-    var endDate: Date? = null
+    var endDate: LocalDateTime? = null
 
 
     override fun equalProperties(other: Any): Boolean =

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/mapping/localized/TravelContent.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/mapping/localized/TravelContent.kt
@@ -12,7 +12,6 @@ import jakarta.persistence.Embeddable
 import jakarta.persistence.Entity
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.MapKeyColumn
-import org.hibernate.annotations.Cascade
 import java.util.*
 
 @Entity(name = "travel_content")
@@ -26,7 +25,6 @@ class TravelContent(
     @CollectionTable(name = "travel_content_locale_map", joinColumns = [JoinColumn(name = "travel_content_id")])
     @MapKeyColumn(name = "locale_key", length = 256, nullable = false, unique = true)
     @ElementCollection(targetClass = LocalTravelContent::class)
-    @Cascade(org.hibernate.annotations.CascadeType.ALL)
     override val localeMap: MutableMap<Locale, LocalTravelContent> = hashMapOf()
 
     override fun createDefaultLocalizedValue(): LocalTravelContent {

--- a/examples/virtualthreads-demo/src/test/kotlin/io/bluetape4k/examples/virtualthreads/part3/StructuredConcurrencyExamples.kt
+++ b/examples/virtualthreads-demo/src/test/kotlin/io/bluetape4k/examples/virtualthreads/part3/StructuredConcurrencyExamples.kt
@@ -1,8 +1,8 @@
 package io.bluetape4k.examples.virtualthreads.part3
 
 import io.bluetape4k.concurrent.virtualthread.StructuredSubtask
-import io.bluetape4k.concurrent.virtualthread.structuredTaskScopeAll
-import io.bluetape4k.concurrent.virtualthread.structuredTaskScopeAny
+import io.bluetape4k.concurrent.virtualthread.structuredTaskScopeFailFast
+import io.bluetape4k.concurrent.virtualthread.structuredTaskScopeFirstSuccess
 import io.bluetape4k.examples.virtualthreads.AbstractVirtualThreadTest
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.assertions.shouldBeEqualTo
@@ -34,7 +34,7 @@ class StructuredConcurrencyExamples: AbstractVirtualThreadTest() {
     /**
      * 비동기 코드를 병렬로 실행하고, 모든 작업이 성공적으로 완료되면 결과를 반환합니다.
      */
-    fun prepareDish(): Dish = structuredTaskScopeAll { scope ->
+    fun prepareDish(): Dish = structuredTaskScopeFailFast { scope ->
         println("prepare Dish ...")
         val pasta: StructuredSubtask<Pasta> = scope.fork {
             Thread.sleep(100)
@@ -69,7 +69,7 @@ class StructuredConcurrencyExamples: AbstractVirtualThreadTest() {
     fun `structured task scope on success`() {
         // Subtask 들 중 하나라도 성공하면, 나머지 Subtask 들은 취소하고, 결과를 반환합니다.
         // 만약 성공한 것이 없다면 ExecutionException 을 반환합니다.
-        val pasta = structuredTaskScopeAny { scope ->
+        val pasta = structuredTaskScopeFirstSuccess { scope ->
 
             val subtask1 = scope.fork {
                 Thread.sleep(200)

--- a/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplateTest.kt
+++ b/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplateTest.kt
@@ -5,7 +5,9 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.testcontainers.mq.KafkaServer
 import io.mockk.clearMocks
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.Runs
 import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.CompletableDeferred
@@ -127,11 +129,11 @@ class SuspendKafkaConsumerTemplateTest: AbstractKafkaTest() {
         val assignment = linkedSetOf(partition0, partition1)
         val commitSlot = slot<Map<TopicPartition, OffsetAndMetadata>>()
 
-        every { consumer.assign(any<List<TopicPartition>>()) } answers { Unit }
+        every { consumer.assign(any<List<TopicPartition>>()) } just Runs
         every { consumer.assignment() } returns assignment
         every { consumer.position(partition0) } returns 11L
         every { consumer.position(partition1) } returns 29L
-        every { consumer.commitSync(capture(commitSlot)) } answers { Unit }
+        every { consumer.commitSync(capture(commitSlot)) } just Runs
         stubDoOnConsumer(receiver, consumer)
 
         val template = SuspendKafkaConsumerTemplate(receiver)
@@ -152,7 +154,7 @@ class SuspendKafkaConsumerTemplateTest: AbstractKafkaTest() {
 
         every { consumer.offsetsForTimes(mapOf(partition to timestamp)) } returns
                 mapOf(partition to OffsetAndTimestamp(42L, timestamp, Optional.empty()))
-        every { consumer.seek(partition, 42L) } answers { Unit }
+        every { consumer.seek(partition, 42L) } just Runs
         stubDoOnConsumer(receiver, consumer)
 
         val template = SuspendKafkaConsumerTemplate(receiver)

--- a/infra/kafka/src/test/kotlin/org/springframework/kafka/core/KafkaTemplateTests.kt
+++ b/infra/kafka/src/test/kotlin/org/springframework/kafka/core/KafkaTemplateTests.kt
@@ -26,7 +26,6 @@ import org.apache.kafka.common.TopicPartition
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-import org.junit.runner.RunWith
 import org.springframework.aop.framework.ProxyFactory
 import org.springframework.kafka.core.KafkaTemplateTests.Companion.INT_KEY_TOPIC
 import org.springframework.kafka.core.KafkaTemplateTests.Companion.STRING_KEY_TOPIC
@@ -44,14 +43,12 @@ import org.springframework.kafka.test.condition.EmbeddedKafkaCondition
 import org.springframework.kafka.test.context.EmbeddedKafka
 import org.springframework.kafka.test.utils.KafkaTestUtils
 import org.springframework.messaging.Message
-import org.springframework.test.context.junit4.SpringRunner
 import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
-@RunWith(SpringRunner::class)
 @EmbeddedKafka(kraft = true, topics = [INT_KEY_TOPIC, STRING_KEY_TOPIC])
 class KafkaTemplateTests {
 

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
@@ -180,9 +180,6 @@ class SuspendKafkaProducerTemplate<K, V> private constructor(
     @Suppress("UNCHECKED_CAST")
     suspend fun send(topic: String, message: Message<*>): SenderResult<Unit> {
         val producerRecord = messageConverter.fromMessage(message, topic)
-        require(producerRecord is ProducerRecord<*, *>) {
-            "RecordMessageConverter returned ${producerRecord?.javaClass?.name ?: "null"} for topic=$topic"
-        }
         val typedRecord = producerRecord as ProducerRecord<K, V>
 
         val correlationId = message.headers[KafkaHeaders.CORRELATION_ID, ByteArray::class.java]

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/test/utils/KafkaTestUtils.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/test/utils/KafkaTestUtils.kt
@@ -53,7 +53,7 @@ fun EmbeddedKafkaBroker.producerProps(): MutableMap<String, Any> = KafkaTestUtil
 fun EmbeddedKafkaBroker.consumerProps(
     group: String,
     autoCommit: Boolean = false,
-): MutableMap<String, Any> = KafkaTestUtils.consumerProps(this.brokersAsString, group, autoCommit.toString())
+): MutableMap<String, Any> = KafkaTestUtils.consumerProps(this, group, autoCommit)
 
 /**
  * 지정된 토픽과 파티션의 마지막 오프셋을 조회합니다.

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/Consumed.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/streams/kstream/Consumed.kt
@@ -4,7 +4,7 @@
 package io.bluetape4k.kafka.streams.kstream
 
 import org.apache.kafka.common.serialization.Serde
-import org.apache.kafka.streams.Topology
+import org.apache.kafka.streams.AutoOffsetReset
 import org.apache.kafka.streams.kstream.Consumed
 import org.apache.kafka.streams.processor.TimestampExtractor
 
@@ -18,7 +18,7 @@ import org.apache.kafka.streams.processor.TimestampExtractor
  * val consumed = consumedOf(
  *     keySerde = Serdes.String(),
  *     valueSerde = Serdes.String(),
- *     resetPolicy = Topology.AutoOffsetReset.EARLIEST
+ *     resetPolicy = AutoOffsetReset.earliest()
  * )
  * val stream = builder.stream("input-topic", consumed)
  * ```
@@ -35,5 +35,5 @@ fun <K, V> consumedOf(
     keySerde: Serde<K>,
     valueSerde: Serde<V>,
     timestampExtractor: TimestampExtractor? = null,
-    resetPolicy: Topology.AutoOffsetReset? = null,
+    resetPolicy: AutoOffsetReset? = null,
 ): Consumed<K, V> = Consumed.with(keySerde, valueSerde, timestampExtractor, resetPolicy)

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/streams/kstream/KStreamDslTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/streams/kstream/KStreamDslTest.kt
@@ -7,7 +7,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.mockk.mockk
 import org.apache.kafka.common.serialization.Serdes
 import org.apache.kafka.common.utils.Bytes
-import org.apache.kafka.streams.Topology
+import org.apache.kafka.streams.AutoOffsetReset
 import org.apache.kafka.streams.kstream.Branched
 import org.apache.kafka.streams.kstream.Consumed
 import org.apache.kafka.streams.kstream.Grouped
@@ -39,7 +39,7 @@ class KStreamDslTest: AbstractKafkaTest() {
             consumedOf(
                 keySerde = Serdes.String(),
                 valueSerde = Serdes.String(),
-                resetPolicy = Topology.AutoOffsetReset.EARLIEST,
+                resetPolicy = AutoOffsetReset.earliest(),
             )
         consumed.shouldNotBeNull()
     }

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
@@ -181,7 +181,7 @@ class BatchListenerConversionTests {
 
         @Bean
         fun consumerConfigs(embeddedKafka: EmbeddedKafkaBroker): Map<String, Any> {
-            return KafkaTestUtils.consumerProps(DEFAULT_TEST_GROUP_ID, "false", embeddedKafka).apply {
+            return KafkaTestUtils.consumerProps(embeddedKafka, DEFAULT_TEST_GROUP_ID, false).apply {
                 put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer::class.java)
                 put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, 1000)
                 put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, 500)

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/core/KafkaTemplateTests.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/core/KafkaTemplateTests.kt
@@ -26,7 +26,6 @@ import org.apache.kafka.common.TopicPartition
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-import org.junit.runner.RunWith
 import org.springframework.aop.framework.ProxyFactory
 import org.springframework.kafka.core.KafkaTemplateTests.Companion.INT_KEY_TOPIC
 import org.springframework.kafka.core.KafkaTemplateTests.Companion.STRING_KEY_TOPIC
@@ -44,14 +43,12 @@ import org.springframework.kafka.test.condition.EmbeddedKafkaCondition
 import org.springframework.kafka.test.context.EmbeddedKafka
 import org.springframework.kafka.test.utils.KafkaTestUtils
 import org.springframework.messaging.Message
-import org.springframework.test.context.junit4.SpringRunner
 import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
-@RunWith(SpringRunner::class)
 @EmbeddedKafka(topics = [INT_KEY_TOPIC, STRING_KEY_TOPIC])
 class KafkaTemplateTests {
 

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/streams/KafkaStreamsTests.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/streams/KafkaStreamsTests.kt
@@ -229,7 +229,7 @@ class KafkaStreamsTests {
 
         @Bean
         fun consumerConfigs(): Map<String, Any> {
-            return KafkaTestUtils.consumerProps(brokerAddresses, "testGroup", "false")
+            return KafkaTestUtils.consumerProps(brokerAddresses, "testGroup", false)
         }
 
         @Bean

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/streams/WordCountExamples.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/streams/WordCountExamples.kt
@@ -156,7 +156,7 @@ class WordCountExamples {
 
         @Bean
         fun consumerConfigs(): Map<String, Any> {
-            return KafkaTestUtils.consumerProps(brokerAddresses, "testGroup", "false")
+            return KafkaTestUtils.consumerProps(brokerAddresses, "testGroup", false)
         }
 
         @Bean

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/atomic/LettuceSuspendAtomicLong.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/atomic/LettuceSuspendAtomicLong.kt
@@ -115,7 +115,7 @@ end"""
         RedisScriptRunner.runSuspending<String>(
             asyncCommands, GET_AND_SET_SCRIPT, ScriptOutputType.VALUE,
             arrayOf(key), value.toString()
-        )?.toLongOrNull() ?: 0L
+        ).toLongOrNull() ?: 0L
 
     /**
      * 값을 1 증가시키고 증가된 값을 반환합니다.
@@ -171,7 +171,7 @@ end"""
         RedisScriptRunner.runSuspending<String>(
             asyncCommands, GET_AND_ADD_SCRIPT, ScriptOutputType.VALUE,
             arrayOf(key), "1"
-        )?.toLongOrNull() ?: 0L
+        ).toLongOrNull() ?: 0L
 
     /**
      * 현재 값을 반환하고 1 감소시킵니다.
@@ -182,7 +182,7 @@ end"""
         RedisScriptRunner.runSuspending<String>(
             asyncCommands, GET_AND_ADD_SCRIPT, ScriptOutputType.VALUE,
             arrayOf(key), "-1"
-        )?.toLongOrNull() ?: 0L
+        ).toLongOrNull() ?: 0L
 
     /**
      * 현재 값을 반환하고 delta를 더합니다.
@@ -194,7 +194,7 @@ end"""
         RedisScriptRunner.runSuspending<String>(
             asyncCommands, GET_AND_ADD_SCRIPT, ScriptOutputType.VALUE,
             arrayOf(key), delta.toString()
-        )?.toLongOrNull() ?: 0L
+        ).toLongOrNull() ?: 0L
 
     /**
      * 현재 값이 expect와 같으면 update로 변경합니다.

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodecs.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodecs.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.redis.lettuce.codec
 
 import io.bluetape4k.io.serializer.BinarySerializer
 import io.bluetape4k.io.serializer.BinarySerializers
+import io.bluetape4k.io.serializer.JdkBinarySerializer
 
 /**
  * 다양한 Serializer/Compressor 조합의 [LettuceBinaryCodec] 팩토리 모음.
@@ -42,7 +43,7 @@ object LettuceBinaryCodecs {
     /**
      * Jdk Serializer를 사용하는 [LettuceBinaryCodec]를 생성합니다.
      */
-    fun <V: Any> jdk(): LettuceBinaryCodec<V> = codec(BinarySerializers.Jdk)
+    fun <V: Any> jdk(): LettuceBinaryCodec<V> = codec(JdkBinarySerializer())
 
     /**
      * Kryo Serializer를 사용하는 [LettuceBinaryCodec]를 생성합니다.

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodecSizeTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodecSizeTest.kt
@@ -1,13 +1,13 @@
 package io.bluetape4k.redis.lettuce.codec
 
-import io.bluetape4k.io.serializer.BinarySerializers
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.io.serializer.JdkBinarySerializer
 import org.junit.jupiter.api.Test
 import java.nio.ByteBuffer
 
 class LettuceBinaryCodecSizeTest {
 
-    private val codec = LettuceBinaryCodec<Any>(BinarySerializers.Jdk)
+    private val codec = LettuceBinaryCodec<Any>(JdkBinarySerializer())
 
     @Test
     fun `estimateSize should handle string and byte array`() {

--- a/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/codec/Fastjson2CodecTest.kt
+++ b/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/codec/Fastjson2CodecTest.kt
@@ -150,7 +150,7 @@ class Fastjson2CodecTest {
         // Fastjson2Codec encoder: WriteClassName 포함 — 두 포맷은 비호환
         val serializer = FastjsonSerializer()
         val original = Sample(1L, "test", listOf("a"))
-        val bytes = serializer.serialize(original) ?: return  // serializer가 null 반환 시 테스트 스킵
+        val bytes = serializer.serialize(original)
 
         val codec = Fastjson2Codec()
         val buf = Unpooled.wrappedBuffer(bytes)
@@ -178,7 +178,7 @@ class Fastjson2CodecTest {
         val codecBytes = ByteArray(buf.readableBytes()).also { buf.getBytes(buf.readerIndex(), it) }
         buf.release()
 
-        val serializerBytes = serializer.serialize(original) ?: return
+        val serializerBytes = serializer.serialize(original)
 
         codecBytes.contentEquals(serializerBytes) shouldBeEqualTo false
     }

--- a/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/bulkhead/BulkheadExtensionsTest.kt
+++ b/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/bulkhead/BulkheadExtensionsTest.kt
@@ -60,7 +60,7 @@ class BulkheadExtensionsTest {
         }
 
         assertFailsWith<BulkheadFullException> {
-            withBulkhead(bulkhead) { "should not run" }
+            withBulkhead(bulkhead) { error("should not run") }
         }
     }
 

--- a/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/circuitbreaker/CircuitBreakerExtensionsTest.kt
+++ b/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/circuitbreaker/CircuitBreakerExtensionsTest.kt
@@ -47,7 +47,7 @@ class CircuitBreakerExtensionsTest {
         cb.transitionToOpenState()
 
         assertFailsWith<CallNotPermittedException> {
-            withCircuitBreaker(cb) { "should not run" }
+            withCircuitBreaker(cb) { error("should not run") }
         }
 
         cb.metrics.numberOfNotPermittedCalls shouldBeEqualTo 1

--- a/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/ratelimiter/RateLimiterExtensionsTest.kt
+++ b/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/ratelimiter/RateLimiterExtensionsTest.kt
@@ -64,7 +64,7 @@ class RateLimiterExtensionsTest {
 
         // 두 번째 호출은 실패
         assertFailsWith<RequestNotPermitted> {
-            withRateLimiter(rl) { "should fail" }
+            withRateLimiter(rl) { error("should fail") }
         }
     }
 

--- a/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/timelimiter/TimeLimiterExtensionsTest.kt
+++ b/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/timelimiter/TimeLimiterExtensionsTest.kt
@@ -57,7 +57,7 @@ class TimeLimiterExtensionsTest {
         assertFailsWith<TimeoutException> {
             withTimeLimiter(tl) {
                 delay(1000.milliseconds) // 타임아웃보다 오래 실행
-                "should not reach here"
+                error("should not reach here")
             }
         }
     }

--- a/io/http/src/main/kotlin/io/bluetape4k/http/hc5/http/RequestConfig.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/hc5/http/RequestConfig.kt
@@ -33,10 +33,10 @@ fun requestConfigOf(): RequestConfig = requestConfig {}
  *
  * ## Defaults
  * - `connectionRequestTimeout` — 5 s: time to wait for a connection from the pool before failing
- * - `connectTimeout`           — 10 s: TCP connect handshake deadline
+ * - `connectTimeout`           — 10 s: time to establish a TCP connection
  * - `responseTimeout`          — 30 s: time to wait for the first response byte after the request is sent
  *
- * All three timeouts can be overridden via the corresponding parameters.
+ * Request-scoped timeouts can be overridden via the corresponding parameters.
  *
  * ```kotlin
  * // Use defaults
@@ -47,10 +47,11 @@ fun requestConfigOf(): RequestConfig = requestConfig {}
  * ```
  *
  * @param connectionRequestTimeout timeout for acquiring a connection from the pool (default: 5 s)
- * @param connectTimeout TCP connect timeout (default: 10 s)
+ * @param connectTimeout timeout for establishing a TCP connection (default: 10 s)
  * @param responseTimeout timeout for the first response byte (default: 30 s)
  * @return production-tuned [RequestConfig]
  */
+@Suppress("DEPRECATION")
 fun productionRequestConfigOf(
     connectionRequestTimeout: Timeout = Timeout.ofSeconds(5),
     connectTimeout: Timeout = Timeout.ofSeconds(10),

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/MinimalHttpAsyncClientTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/MinimalHttpAsyncClientTest.kt
@@ -54,7 +54,7 @@ class MinimalHttpAsyncClientTest: AbstractHc5Test() {
         val client = minimalHttpAsyncClientOf(connMgr = cm)
         client.start()
         try {
-            val url = java.net.URL(httpbinBaseUrl)
+            val url = java.net.URI.create(httpbinBaseUrl).toURL()
             val host = org.apache.hc.core5.http.HttpHost(url.protocol, url.host, url.port)
             val endpoint = client.leaseSuspending(host)
             log.debug { "Leased endpoint: $endpoint" }

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/auth/CredentialsProviderBuilderTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/auth/CredentialsProviderBuilderTest.kt
@@ -6,8 +6,8 @@ import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.apache.hc.client5.http.auth.AuthScope
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials
+import org.apache.hc.client5.http.protocol.HttpClientContext
 import org.apache.hc.core5.http.HttpHost
-import org.apache.hc.core5.http.protocol.BasicHttpContext
 import org.junit.jupiter.api.Test
 
 class CredentialsProviderBuilderTest {
@@ -16,6 +16,8 @@ class CredentialsProviderBuilderTest {
 
     // HC5 5.x has no AuthScope.ANY — use all-null/wildcard constructor instead
     private val anyScope = AuthScope(null, null, -1, null, null)
+
+    private fun httpContext() = HttpClientContext.create()
 
     @Test
     fun `credentialsProvider DSL creates provider`() {
@@ -31,7 +33,7 @@ class CredentialsProviderBuilderTest {
         val provider = emptyCredentialsProvider()
 
         provider.shouldNotBeNull()
-        val credentials = provider.getCredentials(anyScope, BasicHttpContext())
+        val credentials = provider.getCredentials(anyScope, httpContext())
         credentials.shouldBeNull()
     }
 
@@ -43,7 +45,7 @@ class CredentialsProviderBuilderTest {
         val provider = credentialsProviderOf(authScope, credentials)
 
         provider.shouldNotBeNull()
-        val retrieved = provider.getCredentials(authScope, BasicHttpContext())
+        val retrieved = provider.getCredentials(authScope, httpContext())
         retrieved.shouldNotBeNull()
         val upCreds = retrieved as UsernamePasswordCredentials
         upCreds.userName shouldBeEqualTo "admin"
@@ -58,7 +60,7 @@ class CredentialsProviderBuilderTest {
 
         provider.shouldNotBeNull()
         // Query with same scope should match
-        val retrieved = provider.getCredentials(authScope, BasicHttpContext())
+        val retrieved = provider.getCredentials(authScope, httpContext())
         retrieved.shouldNotBeNull()
         val upCreds = retrieved as UsernamePasswordCredentials
         upCreds.userName shouldBeEqualTo "testuser"
@@ -83,7 +85,7 @@ class CredentialsProviderBuilderTest {
 
         provider.shouldNotBeNull()
         val hostScope = AuthScope(host)
-        val retrieved = provider.getCredentials(hostScope, BasicHttpContext())
+        val retrieved = provider.getCredentials(hostScope, httpContext())
         retrieved.shouldNotBeNull()
         val upCreds = retrieved as UsernamePasswordCredentials
         upCreds.userName shouldBeEqualTo "hostuser"
@@ -98,7 +100,7 @@ class CredentialsProviderBuilderTest {
         val provider = credentialsProviderOf(authScope, username, password)
 
         provider.shouldNotBeNull()
-        val retrieved = provider.getCredentials(authScope, BasicHttpContext())
+        val retrieved = provider.getCredentials(authScope, httpContext())
         retrieved.shouldNotBeNull()
         val upCreds = retrieved as UsernamePasswordCredentials
         upCreds.userName shouldBeEqualTo username
@@ -139,7 +141,7 @@ class CredentialsProviderBuilderTest {
 
         provider.shouldNotBeNull()
         val scope1 = AuthScope(host1)
-        val retrieved = provider.getCredentials(scope1, BasicHttpContext())
+        val retrieved = provider.getCredentials(scope1, httpContext())
         retrieved.shouldNotBeNull()
         (retrieved as UsernamePasswordCredentials).userName shouldBeEqualTo "user1"
     }

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/fluent/FluentResponseHandling.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/fluent/FluentResponseHandling.kt
@@ -52,7 +52,7 @@ class FluentResponseHandling: AbstractHc5Test() {
             }
 
         log.debug { "json node=\n${node.toPrettyString()}" }
-        node["headers"]["Host"].textValue() shouldBeEqualTo "${httpbinServer.host}:${httpbinServer.port}"
+        node["headers"]["Host"].stringValue() shouldBeEqualTo "${httpbinServer.host}:${httpbinServer.port}"
     }
 
     @Test

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/ProductionRequestConfigTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/http/ProductionRequestConfigTest.kt
@@ -11,6 +11,7 @@ class ProductionRequestConfigTest {
     companion object : KLogging()
 
     @Test
+    @Suppress("DEPRECATION")
     fun `productionRequestConfigOf creates config with sensible defaults`() {
         val config = productionRequestConfigOf()
 
@@ -21,15 +22,16 @@ class ProductionRequestConfigTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `productionRequestConfigOf allows overriding individual timeouts`() {
         val config = productionRequestConfigOf(
             connectionRequestTimeout = Timeout.ofSeconds(2),
-            connectTimeout = Timeout.ofSeconds(15),
+            connectTimeout = Timeout.ofSeconds(3),
             responseTimeout = Timeout.ofSeconds(60),
         )
 
         config.connectionRequestTimeout shouldBeEqualTo Timeout.ofSeconds(2)
-        config.connectTimeout shouldBeEqualTo Timeout.ofSeconds(15)
+        config.connectTimeout shouldBeEqualTo Timeout.ofSeconds(3)
         config.responseTimeout shouldBeEqualTo Timeout.ofSeconds(60)
     }
 

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/protocol/HttpClientContextTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/protocol/HttpClientContextTest.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.apache.hc.client5.http.protocol.HttpClientContext
-import org.apache.hc.core5.http.protocol.BasicHttpContext
+import org.apache.hc.core5.http.protocol.HttpCoreContext
 import org.junit.jupiter.api.Test
 
 class HttpClientContextTest {
@@ -19,16 +19,16 @@ class HttpClientContextTest {
     }
 
     @Test
-    fun `httpClientContextOf - 기존 컨텍스트 래핑`() {
-        val baseContext = BasicHttpContext()
+    fun `httpClientContextOf - 기존 코어 컨텍스트 래핑`() {
+        val baseContext = HttpCoreContext.create()
         val context = httpClientContextOf(baseContext)
         context.shouldNotBeNull()
         context.shouldBeInstanceOf<HttpClientContext>()
     }
 
     @Test
-    fun `adapt - BasicHttpContext 를 HttpClientContext 로 변환`() {
-        val baseContext = BasicHttpContext()
+    fun `adapt - HttpCoreContext 를 HttpClientContext 로 변환`() {
+        val baseContext = HttpCoreContext.create()
         val clientContext = baseContext.adapt()
         clientContext.shouldNotBeNull()
         clientContext.shouldBeInstanceOf<HttpClientContext>()

--- a/io/io/src/test/kotlin/io/bluetape4k/io/benchmark/BinarySerializerBenchmark.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/benchmark/BinarySerializerBenchmark.kt
@@ -4,6 +4,7 @@ package io.bluetape4k.io.benchmark
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.bluetape4k.io.serializer.BinarySerializers
+import io.bluetape4k.io.serializer.JdkBinarySerializer
 import io.bluetape4k.junit5.faker.Fakers
 import kotlinx.benchmark.Benchmark
 import kotlinx.benchmark.BenchmarkMode
@@ -27,7 +28,7 @@ import java.util.concurrent.TimeUnit
 @Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
 class BinarySerializerBenchmark {
 
-    private val jdk = BinarySerializers.Jdk
+    private val jdk = JdkBinarySerializer()
     private val kryo = BinarySerializers.Kryo
     private val fory = BinarySerializers.Fory
     private val fastFory = BinarySerializers.FastFory

--- a/io/io/src/test/kotlin/io/bluetape4k/io/serializer/CompressableBinarySerializerTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/serializer/CompressableBinarySerializerTest.kt
@@ -45,6 +45,8 @@ class CompressableBinarySerializerTest {
 
     private fun getSerializers(): Stream<out BinarySerializer> = compressableSerializers.stream()
 
+    private val memorySizeSerializer = JdkBinarySerializer()
+
     @ParameterizedTest
     @MethodSource("getSerializers")
     fun `serialize and compress string`(serializer: BinarySerializer) {
@@ -80,10 +82,10 @@ class CompressableBinarySerializerTest {
     }
 
     private fun SimpleData.memorySize(): Int =
-        BinarySerializers.Jdk.serialize(this).size
+        memorySizeSerializer.serialize(this).size
 
     private fun List<SimpleData>.memorySize(): Int =
-        BinarySerializers.Jdk.serialize(this).size
+        memorySizeSerializer.serialize(this).size
 
 
     data class SimpleData(

--- a/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/binary/JacksonBinary.kt
+++ b/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/binary/JacksonBinary.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.jackson.binary
 
+import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory
@@ -41,12 +42,13 @@ object JacksonBinary: KLogging() {
     private val enabledSerializationFeatures = setOf(
         SerializationFeature.WRITE_DATES_AS_TIMESTAMPS,
         SerializationFeature.WRITE_ENUMS_USING_TO_STRING,
-        SerializationFeature.WRITE_NULL_MAP_VALUES,
         SerializationFeature.WRITE_EMPTY_JSON_ARRAYS
     )
     private val disabledSerializationFeatures = setOf(
         SerializationFeature.FAIL_ON_EMPTY_BEANS,
-        SerializationFeature.WRITE_BIGDECIMAL_AS_PLAIN
+    )
+    private val enabledJsonGeneratorFeatures = setOf(
+        JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN
     )
 
     private val enabledDeserializationFeatures = setOf(
@@ -95,6 +97,7 @@ object JacksonBinary: KLogging() {
                 .enable(
                     CBORGenerator.Feature.WRITE_TYPE_HEADER,
                 )
+                .enable(*enabledJsonGeneratorFeatures.toTypedArray())
                 .enable(*enabledSerializationFeatures.toTypedArray())
                 .disable(*disabledSerializationFeatures.toTypedArray())
                 .enable(*enabledDeserializationFeatures.toTypedArray())
@@ -163,6 +166,7 @@ object JacksonBinary: KLogging() {
                 .enable(
                     IonGenerator.Feature.USE_NATIVE_TYPE_ID,
                 )
+                .enable(*enabledJsonGeneratorFeatures.toTypedArray())
                 .enable(*enabledSerializationFeatures.toTypedArray())
                 .disable(*disabledSerializationFeatures.toTypedArray())
                 .enable(*enabledDeserializationFeatures.toTypedArray())
@@ -232,6 +236,7 @@ object JacksonBinary: KLogging() {
                     SmileGenerator.Feature.WRITE_HEADER,
                     SmileGenerator.Feature.WRITE_END_MARKER,
                 )
+                .enable(*enabledJsonGeneratorFeatures.toTypedArray())
                 .enable(*enabledSerializationFeatures.toTypedArray())
                 .disable(*disabledSerializationFeatures.toTypedArray())
                 .enable(*enabledDeserializationFeatures.toTypedArray())

--- a/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/text/JacksonText.kt
+++ b/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/text/JacksonText.kt
@@ -60,7 +60,6 @@ object JacksonText {
     private val enabledSerializationFeatures = arrayOf(
         SerializationFeature.WRITE_DATES_AS_TIMESTAMPS,
         SerializationFeature.WRITE_ENUMS_USING_TO_STRING,
-        SerializationFeature.WRITE_NULL_MAP_VALUES,
         SerializationFeature.WRITE_EMPTY_JSON_ARRAYS
     )
 

--- a/io/vertx/src/main/kotlin/io/bluetape4k/vertx/sqlclient/SqlResultSupport.kt
+++ b/io/vertx/src/main/kotlin/io/bluetape4k/vertx/sqlclient/SqlResultSupport.kt
@@ -10,7 +10,7 @@ import io.vertx.sqlclient.SqlResult
  * 방금 실행된 Insert 결과에서 자동 증가 식별자 값을 가져옵니다.
  *
  * MySQL은 `last-inserted-id` 속성에서 값을 조회하고, 그 외 구현체(JDBC 등)는
- * `GENERATED_KEYS`에서 [columnName] 키를 조회합니다.
+ * `GENERATED_KEYS_LIST`에서 첫 번째 generated-key row의 [columnName] 키를 조회합니다.
  *
  * ```kotlin
  * val result = sqlClient.preparedQuery("INSERT INTO users (name) VALUES ($1)")
@@ -35,6 +35,6 @@ inline fun <reified ID: Number> SqlResult<*>.getGeneratedId(
         }
 
         else ->
-            this.property(JDBCPool.GENERATED_KEYS).getValue(columnName) as? ID
+            this.property(JDBCPool.GENERATED_KEYS_LIST).rows().firstOrNull()?.getValue(columnName) as? ID
     }
 }

--- a/io/vertx/src/test/kotlin/io/bluetape4k/vertx/examples/SampleVerticleTest.kt
+++ b/io/vertx/src/test/kotlin/io/bluetape4k/vertx/examples/SampleVerticleTest.kt
@@ -40,16 +40,16 @@ class SampleVerticleTest: AbstractVertxTest() {
 
     @Test
     fun `count three ticks with checkpoints`(vertx: Vertx, testContext: VertxTestContext) {
-        val checkpoint = testContext.checkpoint(3)
+        val checkpoint = testContext.checkpoint().asLatch(3)
         vertx.setPeriodic(100) {
-            checkpoint.flag()
+            checkpoint.countDown()
         }
     }
 
     @Test
     fun `use SampleVerticle`(vertx: Vertx, testContext: VertxTestContext) = runSuspendIO {
         val deploymentCheckpoint = testContext.checkpoint()
-        val requestCheckpoint = testContext.checkpoint(REPEAT_SIZE)
+        val requestCheckpoint = testContext.checkpoint().asLatch(REPEAT_SIZE)
 
         val verticle = SampleVerticle()
         vertx
@@ -68,7 +68,7 @@ class SampleVerticleTest: AbstractVertxTest() {
                             testContext.verify {
                                 resp.statusCode() shouldBeEqualTo 200
                                 resp.body() shouldContain "Yo!"
-                                requestCheckpoint.flag()
+                                requestCheckpoint.countDown()
                             }
                         }
                         .onFailure { e ->
@@ -80,9 +80,9 @@ class SampleVerticleTest: AbstractVertxTest() {
 
     @Test
     fun `use SampleVerticle in coroutines`(vertx: Vertx, testContext: VertxTestContext) = runSuspendIO {
-        vertx.withSuspendTestContext(testContext) {
-            val deploymentCheckpoint = testContext.checkpoint()
-            val requestCheckpoint = testContext.checkpoint(REPEAT_SIZE)
+            vertx.withSuspendTestContext(testContext) {
+                val deploymentCheckpoint = testContext.checkpoint()
+                val requestCheckpoint = testContext.checkpoint().asLatch(REPEAT_SIZE)
 
             val verticle = SampleVerticle()
             log.debug { "Deploy SampleVerticle" }
@@ -106,7 +106,7 @@ class SampleVerticleTest: AbstractVertxTest() {
                         resp.body() shouldContain "Yo!"
                         // testContext에 완료되었음을 알린다 (CountDownLatch와 유사)
                         // 모두 차감하면 testContext.completeNow() 와 같이 테스트가 종료된다.
-                        requestCheckpoint.flag()
+                        requestCheckpoint.countDown()
                     }
                 }
             }

--- a/io/vertx/src/test/kotlin/io/bluetape4k/vertx/examples/VertxJunit5Examples.kt
+++ b/io/vertx/src/test/kotlin/io/bluetape4k/vertx/examples/VertxJunit5Examples.kt
@@ -71,15 +71,15 @@ class VertxJunit5Examples: AbstractVertxTest() {
      * [Chekpoint when there are multiple success conditions](https://vertx.io/docs/vertx-junit5/java/#_checkpoint_when_there_are_multiple_success_conditions)
      */
     @Test
-    fun `chekpoint when there are multiple success conditions`(vertx: Vertx, testContext: VertxTestContext) {
-        val serverStarted = testContext.checkpoint()
-        val requestesServed = testContext.checkpoint(10)
-        val responsesReceived = testContext.checkpoint(10)
+        fun `chekpoint when there are multiple success conditions`(vertx: Vertx, testContext: VertxTestContext) {
+            val serverStarted = testContext.checkpoint()
+            val requestesServed = testContext.checkpoint().asLatch(10)
+            val responsesReceived = testContext.checkpoint().asLatch(10)
 
         vertx.createHttpServer()
             .requestHandler { req ->
                 req.response().end("OK")
-                requestesServed.flag()
+                requestesServed.countDown()
             }
             .listen(8888)
             .onSuccess {
@@ -94,7 +94,7 @@ class VertxJunit5Examples: AbstractVertxTest() {
                         .onComplete(testContext.succeeding { buffer ->
                             testContext.verify {
                                 buffer.toString() shouldBeEqualTo "OK"
-                                responsesReceived.flag()
+                                responsesReceived.countDown()
                             }
                         })
                 }

--- a/io/vertx/src/test/kotlin/io/bluetape4k/vertx/sqlclient/mybatis/AbstractSqlClientExtensionsTest.kt
+++ b/io/vertx/src/test/kotlin/io/bluetape4k/vertx/sqlclient/mybatis/AbstractSqlClientExtensionsTest.kt
@@ -837,7 +837,7 @@ abstract class AbstractSqlClientExtensionsTest: AbstractVertxSqlClientTest() {
                     address.state,
                 ) {
                     from(person, "p")
-                    join(address, "a") { on(person.addressId) equalTo address.id }
+                    join(address, "a") on { person.addressId isEqualTo address.id }
                     where { person.id isLessThan 4 }
                     orderBy(person.id)
                     limit(3)

--- a/io/vertx/src/test/kotlin/io/bluetape4k/vertx/sqlclient/mybatis/joins/AbstractJoinTest.kt
+++ b/io/vertx/src/test/kotlin/io/bluetape4k/vertx/sqlclient/mybatis/joins/AbstractJoinTest.kt
@@ -78,7 +78,7 @@ abstract class AbstractJoinTest: AbstractVertxSqlClientTest() {
                     orderDetail.lineNumber, orderDetail.description, orderDetail.quantity
                 ) {
                     from(orderMaster, "om")
-                    join(orderDetail, "od") { on(orderMaster.orderId) equalTo orderDetail.orderId }
+                    join(orderDetail, "od") on { orderMaster.orderId isEqualTo orderDetail.orderId }
                     orderBy(orderMaster.orderId)
                 }
                 rows.size() shouldBeEqualTo 3
@@ -96,9 +96,9 @@ abstract class AbstractJoinTest: AbstractVertxSqlClientTest() {
                     orderDetail.lineNumber, orderDetail.description, orderDetail.quantity
                 ) {
                     from(orderMaster, "om")
-                    join(orderDetail, "od") {
-                        on(orderMaster.orderId) equalTo orderDetail.orderId
-                        and(orderMaster.orderId) equalTo orderDetail.orderId
+                    join(orderDetail, "od") on {
+                        orderMaster.orderId isEqualTo orderDetail.orderId
+                        and { orderMaster.orderId isEqualTo orderDetail.orderId }
                     }
                 }
                 rows.size() shouldBeEqualTo 3
@@ -116,9 +116,9 @@ abstract class AbstractJoinTest: AbstractVertxSqlClientTest() {
                     orderDetail.lineNumber, orderDetail.description, orderDetail.quantity
                 ) {
                     from(orderMaster, "om")
-                    join(orderDetail, "od") {
-                        on(orderMaster.orderId) equalTo orderDetail.orderId
-                        and(orderMaster.orderId) equalTo orderDetail.orderId
+                    join(orderDetail, "od") on {
+                        orderMaster.orderId isEqualTo orderDetail.orderId
+                        and { orderMaster.orderId isEqualTo orderDetail.orderId }
                     }
                     where { orderMaster.orderId isEqualTo 1 }  // where 절 추가
                 }
@@ -137,8 +137,8 @@ abstract class AbstractJoinTest: AbstractVertxSqlClientTest() {
                     orderLine.lineNumber, orderLine.itemId, orderLine.quantity, itemMaster.description
                 ) {
                     from(orderMaster, "om")
-                    join(orderLine, "ol") { on(orderMaster.orderId) equalTo orderLine.orderId }
-                    join(itemMaster, "im") { on(orderLine.itemId) equalTo itemMaster.itemId }
+                    join(orderLine, "ol") on { orderMaster.orderId isEqualTo orderLine.orderId }
+                    join(itemMaster, "im") on { orderLine.itemId isEqualTo itemMaster.itemId }
                     where { orderMaster.orderId isEqualTo 2 }
                 }
 
@@ -204,20 +204,20 @@ abstract class AbstractJoinTest: AbstractVertxSqlClientTest() {
                     OrderRecordRowMapper
                 ) {
                     from(orderMaster, "om")
-                    join(orderLine, "ol") {
-                        on(orderMaster.orderId) equalTo orderLine.orderId
+                    join(orderLine, "ol") on {
+                        orderMaster.orderId isEqualTo orderLine.orderId
                     }
-                    leftJoin(itemMaster, "im") {
-                        on(orderLine.itemId) equalTo itemMaster.itemId
+                    leftJoin(itemMaster, "im") on {
+                        orderLine.itemId isEqualTo itemMaster.itemId
                     }
                     union {
                         select(orderLine.orderId, orderLine.quantity, itemMaster.itemId, itemMaster.description) {
                             from(orderMaster, "om")
-                            join(orderLine, "ol") {
-                                on(orderMaster.orderId) equalTo orderLine.orderId
+                            join(orderLine, "ol") on {
+                                orderMaster.orderId isEqualTo orderLine.orderId
                             }
-                            rightJoin(itemMaster, "im") {
-                                on(orderLine.itemId) equalTo itemMaster.itemId
+                            rightJoin(itemMaster, "im") on {
+                                orderLine.itemId isEqualTo itemMaster.itemId
                             }
                         }
                     }
@@ -269,24 +269,14 @@ abstract class AbstractJoinTest: AbstractVertxSqlClientTest() {
                         select(orderMaster.allColumns()) { from(orderMaster) }
                         +"om"
                     }
-                    join(
-                        subQuery = {
-                            select(orderLine.allColumns()) { from(orderLine) }
-                            +"ol"
-                        },
-                        joinCriteria = {
-                            on("om"(orderMaster.orderId)) equalTo "ol"(orderLine.orderId)
-                        }
-                    )
-                    leftJoin(
-                        subQuery = {
-                            select(itemMaster.allColumns()) { from(itemMaster) }
-                            +"im"
-                        },
-                        joinCriteria = {
-                            on("ol"(orderLine.itemId)) equalTo "im"(itemMaster.itemId)
-                        }
-                    )
+                    join {
+                        select(orderLine.allColumns()) { from(orderLine) }
+                        +"ol"
+                    } on { "om"(orderMaster.orderId) isEqualTo "ol"(orderLine.orderId) }
+                    leftJoin {
+                        select(itemMaster.allColumns()) { from(itemMaster) }
+                        +"im"
+                    } on { "ol"(orderLine.itemId) isEqualTo "im"(itemMaster.itemId) }
                     union {
                         select(
                             "ol"(orderLine.orderId), orderLine.quantity, "im"(itemMaster.itemId), itemMaster.description
@@ -295,24 +285,14 @@ abstract class AbstractJoinTest: AbstractVertxSqlClientTest() {
                                 select(orderMaster.allColumns()) { from(orderMaster) }
                                 +"om"
                             }
-                            join(
-                                subQuery = {
-                                    select(orderLine.allColumns()) { from(orderLine) }
-                                    +"ol"
-                                },
-                                joinCriteria = {
-                                    on("om"(orderMaster.orderId)) equalTo "ol"(orderLine.orderId)
-                                }
-                            )
-                            rightJoin(
-                                subQuery = {
-                                    select(itemMaster.allColumns()) { from(itemMaster) }
-                                    +"im"
-                                },
-                                joinCriteria = {
-                                    on("ol"(orderLine.itemId)) equalTo "im"(itemMaster.itemId)
-                                }
-                            )
+                            join {
+                                select(orderLine.allColumns()) { from(orderLine) }
+                                +"ol"
+                            } on { "om"(orderMaster.orderId) isEqualTo "ol"(orderLine.orderId) }
+                            rightJoin {
+                                select(itemMaster.allColumns()) { from(itemMaster) }
+                                +"im"
+                            } on { "ol"(orderLine.itemId) isEqualTo "im"(itemMaster.itemId) }
                         }
                     }
                     orderBy(orderLine.orderId, itemMaster.itemId)
@@ -355,20 +335,20 @@ abstract class AbstractJoinTest: AbstractVertxSqlClientTest() {
                     OrderRecordRowMapper
                 ) {
                     from(orderMaster, "om")
-                    join(orderLine, "ol") {
-                        on(orderMaster.orderId) equalTo orderLine.orderId
+                    join(orderLine, "ol") on {
+                        orderMaster.orderId isEqualTo orderLine.orderId
                     }
-                    leftJoin(itemMaster) {
-                        on(orderLine.itemId) equalTo itemMaster.itemId
+                    leftJoin(itemMaster) on {
+                        orderLine.itemId isEqualTo itemMaster.itemId
                     }
                     union {
                         select(orderLine.orderId, orderLine.quantity, itemMaster.itemId, itemMaster.description) {
                             from(orderMaster, "om2")
-                            join(orderLine, "ol2") {
-                                on(orderMaster.orderId) equalTo orderLine.orderId
+                            join(orderLine, "ol2") on {
+                                orderMaster.orderId isEqualTo orderLine.orderId
                             }
-                            rightJoin(itemMaster) {
-                                on(orderLine.itemId) equalTo itemMaster.itemId
+                            rightJoin(itemMaster) on {
+                                orderLine.itemId isEqualTo itemMaster.itemId
                             }
                         }
                     }
@@ -400,8 +380,8 @@ abstract class AbstractJoinTest: AbstractVertxSqlClientTest() {
                     OrderRecordRowMapper
                 ) {
                     from(orderMaster, "om")
-                    join(orderLine, "ol") { on(orderMaster.orderId) equalTo orderLine.orderId }
-                    leftJoin(itemMaster, "im") { on(orderLine.itemId) equalTo itemMaster.itemId }
+                    join(orderLine, "ol") on { orderMaster.orderId isEqualTo orderLine.orderId }
+                    leftJoin(itemMaster, "im") on { orderLine.itemId isEqualTo itemMaster.itemId }
                     orderBy(orderLine.orderId, itemMaster.itemId)
                 }
                 // orderRecords shouldHaveSize 5
@@ -425,24 +405,14 @@ abstract class AbstractJoinTest: AbstractVertxSqlClientTest() {
                         select(orderMaster.allColumns()) { from(orderMaster) }
                         +"om"
                     }
-                    join(
-                        subQuery = {
-                            select(orderLine.allColumns()) { from(orderLine) }
-                            +"ol"
-                        },
-                        joinCriteria = {
-                            on("om"(orderMaster.orderId)) equalTo "ol"(orderLine.orderId)
-                        }
-                    )
-                    leftJoin(
-                        subQuery = {
-                            select(itemMaster.allColumns()) { from(itemMaster) }
-                            +"im"
-                        },
-                        joinCriteria = {
-                            on("ol"(orderLine.itemId)) equalTo "im"(itemMaster.itemId)
-                        }
-                    )
+                    join {
+                        select(orderLine.allColumns()) { from(orderLine) }
+                        +"ol"
+                    } on { "om"(orderMaster.orderId) isEqualTo "ol"(orderLine.orderId) }
+                    leftJoin {
+                        select(itemMaster.allColumns()) { from(itemMaster) }
+                        +"im"
+                    } on { "ol"(orderLine.itemId) isEqualTo "im"(itemMaster.itemId) }
                     orderBy(orderLine.orderId, itemMaster.itemId)
                 }
 
@@ -460,11 +430,11 @@ abstract class AbstractJoinTest: AbstractVertxSqlClientTest() {
                     OrderRecordRowMapper
                 ) {
                     from(orderMaster, "om")
-                    join(orderLine, "ol") {
-                        on(orderMaster.orderId) equalTo orderLine.orderId
+                    join(orderLine, "ol") on {
+                        orderMaster.orderId isEqualTo orderLine.orderId
                     }
-                    leftJoin(itemMaster) {
-                        on(orderLine.itemId) equalTo itemMaster.itemId
+                    leftJoin(itemMaster) on {
+                        orderLine.itemId isEqualTo itemMaster.itemId
                     }
                     orderBy(orderLine.orderId, itemMaster.itemId)
                 }
@@ -494,8 +464,8 @@ abstract class AbstractJoinTest: AbstractVertxSqlClientTest() {
                     OrderRecordRowMapper
                 ) {
                     from(orderMaster, "om")
-                    join(orderLine, "ol") { on(orderMaster.orderId) equalTo orderLine.orderId }
-                    rightJoin(itemMaster, "im") { on(orderLine.itemId) equalTo itemMaster.itemId }
+                    join(orderLine, "ol") on { orderMaster.orderId isEqualTo orderLine.orderId }
+                    rightJoin(itemMaster, "im") on { orderLine.itemId isEqualTo itemMaster.itemId }
                     orderBy(orderLine.orderId, itemMaster.itemId)
                 }
                 orderRecords shouldHaveSize 5
@@ -519,24 +489,14 @@ abstract class AbstractJoinTest: AbstractVertxSqlClientTest() {
                         select(orderMaster.allColumns()) { from(orderMaster) }
                         +"om"
                     }
-                    join(
-                        subQuery = {
-                            select(orderLine.allColumns()) { from(orderLine) }
-                            +"ol"
-                        },
-                        joinCriteria = {
-                            on("om"(orderMaster.orderId)) equalTo "ol"(orderLine.orderId)
-                        }
-                    )
-                    rightJoin(
-                        subQuery = {
-                            select(itemMaster.allColumns()) { from(itemMaster) }
-                            +"im"
-                        },
-                        joinCriteria = {
-                            on("ol"(orderLine.itemId)) equalTo "im"(itemMaster.itemId)
-                        }
-                    )
+                    join {
+                        select(orderLine.allColumns()) { from(orderLine) }
+                        +"ol"
+                    } on { "om"(orderMaster.orderId) isEqualTo "ol"(orderLine.orderId) }
+                    rightJoin {
+                        select(itemMaster.allColumns()) { from(itemMaster) }
+                        +"im"
+                    } on { "ol"(orderLine.itemId) isEqualTo "im"(itemMaster.itemId) }
                     orderBy(orderLine.orderId, itemMaster.itemId)
                 }
 
@@ -554,11 +514,11 @@ abstract class AbstractJoinTest: AbstractVertxSqlClientTest() {
                     OrderRecordRowMapper
                 ) {
                     from(orderMaster, "om")
-                    join(orderLine, "ol") {
-                        on(orderMaster.orderId) equalTo orderLine.orderId
+                    join(orderLine, "ol") on {
+                        orderMaster.orderId isEqualTo orderLine.orderId
                     }
-                    rightJoin(itemMaster) {
-                        on(orderLine.itemId) equalTo itemMaster.itemId
+                    rightJoin(itemMaster) on {
+                        orderLine.itemId isEqualTo itemMaster.itemId
                     }
                     orderBy(orderLine.orderId, itemMaster.itemId)
                 }
@@ -593,7 +553,7 @@ abstract class AbstractJoinTest: AbstractVertxSqlClientTest() {
                     UserRowMapper
                 ) {
                     from(user, "u1")
-                    join(user2, "u2") { on(user.userId) equalTo user2.parentId }
+                    join(user2, "u2") on { user.userId isEqualTo user2.parentId }
                     where { user2.userId isEqualTo 4 }
                 }
 
@@ -618,7 +578,7 @@ abstract class AbstractJoinTest: AbstractVertxSqlClientTest() {
                     UserRowMapper
                 ) {
                     from(user)
-                    join(user2) { on(user.userId) equalTo user2.parentId }
+                    join(user2) on { user.userId isEqualTo user2.parentId }
                     where { user2.userId isEqualTo 4 }
                 }
 
@@ -644,7 +604,7 @@ abstract class AbstractJoinTest: AbstractVertxSqlClientTest() {
                     UserRowMapper
                 ) {
                     from(user, "u1")
-                    join(user2, "u2") { on(user.userId) equalTo user2.parentId }
+                    join(user2, "u2") on { user.userId isEqualTo user2.parentId }
                     where { user2.userId isEqualTo 4 }
                 }
 
@@ -677,8 +637,8 @@ abstract class AbstractJoinTest: AbstractVertxSqlClientTest() {
                         }
                         +"p2"
                     }
-                    join(person, "p1") {
-                        on(p2.id) equalTo person.id
+                    join(person, "p1") on {
+                        p2.id isEqualTo person.id
                     }
                     where { person.id isLessThan 5 }
                 }.renderForVertx()
@@ -695,17 +655,14 @@ abstract class AbstractJoinTest: AbstractVertxSqlClientTest() {
                 val p2 = person.withAlias("p2")
                 val selectProvider = select(person.allColumns()) {
                     from(person, "p1")
-                    join({
+                    join {
                         select(p2.id) {
                             from(p2)
                             where { p2.addressId isEqualTo 2 }
                             orderBy(p2.id)
                         }
                         +"p2"
-                    }
-                    ) {
-                        on(person.id).equalTo(p2.id)    // NOTE: PersonTable 이 AliasableSqlTable 이어야 합니다.
-                    }
+                    } on { person.id isEqualTo p2.id }    // NOTE: PersonTable 이 AliasableSqlTable 이어야 합니다.
                     where { person.id isLessThan 5 }
                 }.renderForVertx()
 

--- a/spring-boot/cassandra/src/test/kotlin/io/bluetape4k/spring/cassandra/ReactiveCassandraOperationsCoroutinesUnitTest.kt
+++ b/spring-boot/cassandra/src/test/kotlin/io/bluetape4k/spring/cassandra/ReactiveCassandraOperationsCoroutinesUnitTest.kt
@@ -115,9 +115,8 @@ class ReactiveCassandraOperationsCoroutinesUnitTest {
     @Test
     fun `selectOneOrNullSuspending returns null for empty Mono`() = runSuspendIO {
         val emptyOps = mockk<ReactiveCassandraOperations>()
-        @Suppress("UNCHECKED_CAST")
         every { emptyOps.selectOne(any<com.datastax.oss.driver.api.core.cql.Statement<*>>(), any<Class<*>>()) } returns
-            Mono.empty<Any>() as Mono<Any>
+            Mono.empty<Any>()
         val result = emptyOps.selectOneOrNullSuspending<TestEntity>(testStatement)
         result.shouldBeNull()
     }

--- a/spring-boot/cassandra/src/test/kotlin/io/bluetape4k/spring/cassandra/cql/ReactiveCqlOperationsSupportUnitTest.kt
+++ b/spring-boot/cassandra/src/test/kotlin/io/bluetape4k/spring/cassandra/cql/ReactiveCqlOperationsSupportUnitTest.kt
@@ -39,7 +39,7 @@ class ReactiveCqlOperationsSupportUnitTest {
         every { ops.execute(any<Statement<*>>()) } returns Mono.just(true)
         every { ops.execute(any<ReactivePreparedStatementCreator>()) } returns Mono.just(true)
         every { ops.queryForObject(any<String>(), any<RowMapper<String>>(), *anyVararg()) } answers {
-            Mono.just("result") as Mono<String>
+            Mono.just("result")
         }
         every { ops.queryForObject(any<String>(), any<Class<*>>(), *anyVararg()) } answers {
             Mono.just("result") as Mono<Any>
@@ -54,7 +54,7 @@ class ReactiveCqlOperationsSupportUnitTest {
         every { ops.queryForRows(any<Statement<*>>()) } returns Flux.just(mockRow)
         every { ops.queryForRows(any<String>(), *anyVararg()) } returns Flux.just(mockRow)
         every { ops.query(any<Statement<*>>(), any<RowMapper<String>>()) } answers {
-            Flux.just("mapped") as Flux<String>
+            Flux.just("mapped")
         }
     }
 
@@ -162,10 +162,9 @@ class ReactiveCqlOperationsSupportUnitTest {
 
     @Test
     fun `executeForFlow with Flow of CQL strings`() = runSuspendIO {
-        @Suppress("UNCHECKED_CAST")
         val localOps = mockk<ReactiveCqlOperations>().also { ops ->
             every { ops.execute(any<org.reactivestreams.Publisher<String>>()) } answers {
-                Flux.just(true) as Flux<Boolean>
+                Flux.just(true)
             }
         }
         val cqlFlow = flowOf("TRUNCATE users")

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/beans/BeanUtilsSupportTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/beans/BeanUtilsSupportTest.kt
@@ -48,7 +48,7 @@ class BeanUtilsSupportTest: AbstractSpringTest() {
     fun `findMethod - 이름으로 메서드 찾기`() {
         val method = BaseBean::class.java.findMethod("execute")
         method.shouldNotBeNull()
-        method!!.name shouldBeEqualTo "execute"
+        method.name shouldBeEqualTo "execute"
     }
 
     @Test
@@ -61,14 +61,14 @@ class BeanUtilsSupportTest: AbstractSpringTest() {
     fun `findDeclaredMethod - 선언 메서드 찾기`() {
         val method = BaseBean::class.java.findDeclaredMethod("nonExecute")
         method.shouldNotBeNull()
-        method!!.name shouldBeEqualTo "nonExecute"
+        method.name shouldBeEqualTo "nonExecute"
     }
 
     @Test
     fun `findMethodWithMinimalParameters - 최소 파라미터 메서드 찾기`() {
         val method = BaseBean::class.java.findMethodWithMinimalParameters("execute")
         method.shouldNotBeNull()
-        method!!.name shouldBeEqualTo "execute"
+        method.name shouldBeEqualTo "execute"
     }
 
     @Test

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/util/StopWatchSupportTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/util/StopWatchSupportTest.kt
@@ -91,7 +91,7 @@ class StopWatchSupportTest: AbstractSpringTest() {
         val sw = StopWatch("already running")
         sw.start("first task")
         assertFailsWith<IllegalStateException> {
-            sw.task("second task") { 42 }
+            sw.task("second task") { error("should not run") }
         }
         sw.stop()
     }

--- a/testing/assertions/src/test/kotlin/io/bluetape4k/assertions/ExceptionsTest.kt
+++ b/testing/assertions/src/test/kotlin/io/bluetape4k/assertions/ExceptionsTest.kt
@@ -7,7 +7,6 @@ import org.opentest4j.AssertionFailedError
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.milliseconds
 
-@Suppress("UnusedExpression")
 class ExceptionsTest {
 
     // ── invoking { }.shouldThrow ──────────────────────────────────────────
@@ -33,7 +32,7 @@ class ExceptionsTest {
     @Test
     fun `invoking shouldThrow fails when no exception is thrown`() {
         assertFailsWith<AssertionFailedError> {
-            assertFailsWith<IllegalStateException> { 42 }
+            assertFailsWith<IllegalStateException> { }
         }
     }
 
@@ -184,7 +183,7 @@ class ExceptionsTest {
     @Test
     fun `coInvoking shouldThrow fails when no exception is thrown`() = runTest {
         assertFailsWith<AssertionFailedError> {
-            assertFailsWith<IllegalStateException> { 42 }
+            assertFailsWith<IllegalStateException> { }
         }
     }
 
@@ -327,7 +326,7 @@ class ExceptionsTest {
 
     @Test
     fun `assertNotFailsWith passes when block throws nothing`() {
-        assertNotFailsWith<IllegalArgumentException> { "no exception" }
+        assertNotFailsWith<IllegalArgumentException> { }
     }
 
     @Test
@@ -358,7 +357,7 @@ class ExceptionsTest {
 
     @Test
     fun `assertNotFails passes when no exception thrown`() {
-        assertNotFails { "ok" }
+        assertNotFails { }
     }
 
     @Test

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/localstack/AbstractLocalStackServiceTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/localstack/AbstractLocalStackServiceTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.bluetape4k.testcontainers.aws.localstack
 
 import io.bluetape4k.logging.KLogging

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/localstack/services/CloudWatchTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/localstack/services/CloudWatchTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.bluetape4k.testcontainers.aws.localstack.services
 
 import io.bluetape4k.logging.KLogging

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/localstack/services/DynamoDBTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/localstack/services/DynamoDBTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.bluetape4k.testcontainers.aws.localstack.services
 
 import io.bluetape4k.logging.KLogging

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/localstack/services/KMSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/localstack/services/KMSTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.bluetape4k.testcontainers.aws.localstack.services
 
 import io.bluetape4k.logging.KLogging

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/localstack/services/KinesisTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/localstack/services/KinesisTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.bluetape4k.testcontainers.aws.localstack.services
 
 import io.bluetape4k.logging.KLogging

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/localstack/services/S3Test.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/localstack/services/S3Test.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.bluetape4k.testcontainers.aws.localstack.services
 
 import io.bluetape4k.logging.KotlinLogging

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/localstack/services/SNSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/localstack/services/SNSTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.bluetape4k.testcontainers.aws.localstack.services
 
 import io.bluetape4k.logging.KLogging

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/localstack/services/SQSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/localstack/services/SQSTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.bluetape4k.testcontainers.aws.localstack.services
 
 import io.bluetape4k.logging.KLogging

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/localstack/services/STSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/localstack/services/STSTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.bluetape4k.testcontainers.aws.localstack.services
 
 import io.bluetape4k.logging.KLogging


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: chore: keep test compilation warning-free

- Removes Kotlin compiler warnings from `compileTestKotlin` across affected test and helper modules.
- Replaces deprecated APIs where safe, including MyBatis Dynamic SQL join DSL, Kafka Streams offset reset APIs, Jackson 3 string accessors, and Spring Kafka test utilities.
- Keeps existing public compatibility for request-level HTTP connect timeout and suppresses only legacy LocalStack tests that intentionally exercise the deprecated wrapper.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Impact

This is a maintenance-only cleanup. The final `compileTestKotlin` pass reports zero Kotlin compiler warnings and zero Kotlin compiler errors. QueryDSL/KAPT annotation processor diagnostics remain visible and unchanged because they are outside Kotlin compiler warning cleanup.

## Validation

Final validation log: `/tmp/bluetape4k-projects-compileTestKotlin-warnings-final5.log`

Commit: `4f699b9ce4ffc92b55b643e77e241c5c5776bd03`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #896, head `4f699b9ce4ffc92b55b643e77e241c5c5776bd03`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `chore/compile-test-warning-cleanup`
- Labels: `test`, `chore`, `tech-debt`
- State: `MERGED`, merge commit `967cf52b597e2c34eba7e3f0942103a6c49c0035`
- CI: - Keeps existing public compatibility for request-level HTTP connect timeout and suppresses only legacy LocalStack tests that intentionally exercise the deprecated wrapper. / | Local compile warning cleanup | PASS | `./gradlew compileTestKotlin --warning-mode all --rerun-tasks` completed successfully | / | Remaining non-Kotlin diagnostics | PASS | 4 KAPT unrecognized option warnings and 1 QueryDSL circular Q-class warning remain unchanged and are outside Kotlin compiler warning cleanup |

## DoD Status

| Step | Status | Evidence |
| --- | --- | --- |
| Local compile warning cleanup | PASS | `./gradlew compileTestKotlin --warning-mode all --rerun-tasks` completed successfully |
| Kotlin compiler diagnostics | PASS | Kotlin compiler warnings `0`; Kotlin compiler errors `0` |
| Diff hygiene | PASS | `git diff --check` passed |
| Remaining non-Kotlin diagnostics | PASS | 4 KAPT unrecognized option warnings and 1 QueryDSL circular Q-class warning remain unchanged and are outside Kotlin compiler warning cleanup |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #896 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `967cf52b597e2c34eba7e3f0942103a6c49c0035`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
