### PR TITLE
fix: guard R2DBC SQL DSL interpolation

### DIFF
--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/core/Insert.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/core/Insert.kt
@@ -195,7 +195,7 @@ internal class InsertValuesSpecImpl(
         value: Any,
     ): InsertValuesSpec =
         apply {
-            values[field] = value
+            values[requireValidIdentifier(field)] = value
         }
 
     override fun value(
@@ -204,12 +204,12 @@ internal class InsertValuesSpecImpl(
         type: Class<*>,
     ): InsertValuesSpec =
         apply {
-            values[field] = value.toParameter(type)
+            values[requireValidIdentifier(field)] = value.toParameter(type)
         }
 
     override fun nullValue(field: String): InsertValuesSpec =
         apply {
-            values[field] = null
+            values[requireValidIdentifier(field)] = null
         }
 
     override fun nullValue(
@@ -217,7 +217,7 @@ internal class InsertValuesSpecImpl(
         type: Class<*>,
     ): InsertValuesSpec =
         apply {
-            values[field] = type.toParameter()
+            values[requireValidIdentifier(field)] = type.toParameter()
         }
 
     private fun execute(): DatabaseClient.GenericExecuteSpec {
@@ -356,7 +356,7 @@ internal class InsertValuesKeySpecImpl(
         value: Any,
     ): InsertValuesKeySpec =
         apply {
-            values[field] = value
+            values[requireValidIdentifier(field)] = value
         }
 
     override fun value(
@@ -365,12 +365,12 @@ internal class InsertValuesKeySpecImpl(
         type: Class<*>,
     ): InsertValuesKeySpec =
         apply {
-            values[field] = value.toParameter(type)
+            values[requireValidIdentifier(field)] = value.toParameter(type)
         }
 
     override fun nullValue(field: String): InsertValuesKeySpec =
         apply {
-            values[field] = null
+            values[requireValidIdentifier(field)] = null
         }
 
     override fun nullValue(
@@ -378,7 +378,7 @@ internal class InsertValuesKeySpecImpl(
         type: Class<*>,
     ): InsertValuesKeySpec =
         apply {
-            values[field] = type.toParameter()
+            values[requireValidIdentifier(field)] = type.toParameter()
         }
 
     override fun fetch(): RowsFetchSpec<Int> {

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/core/Update.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/core/Update.kt
@@ -263,7 +263,7 @@ internal class UpdateValuesSpecImpl(
         value: Any,
     ): UpdateValuesSpec =
         apply {
-            values[field] = value
+            values[requireValidIdentifier(field)] = value
         }
 
     override fun set(
@@ -272,7 +272,7 @@ internal class UpdateValuesSpecImpl(
         type: Class<*>,
     ): UpdateValuesSpec =
         apply {
-            values[field] = value.toParameter(type)
+            values[requireValidIdentifier(field)] = value.toParameter(type)
         }
 
     override fun set(parameters: Map<String, Any?>): UpdateValuesSpec =

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/query/QueryBuilder.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/query/QueryBuilder.kt
@@ -176,10 +176,9 @@ class QueryBuilder {
         operator: String = "and",
         block: FilterBuilder.() -> Unit,
     ) {
-        operator.requireNotBlank("operator")
         require(filters.countLeaves() == 0) { "There must be only one root filters group" }
 
-        filters = Filter.Group(operator.trim())
+        filters = Filter.Group(requireLogicalOperator(operator))
         block(FilterBuilder(filters))
     }
 
@@ -205,9 +204,7 @@ class QueryBuilder {
             operator: String = "and",
             block: FilterBuilder.() -> Unit,
         ) {
-            operator.requireNotBlank("operator")
-
-            val inner = Filter.Group(operator.trim())
+            val inner = Filter.Group(requireLogicalOperator(operator))
             group.filters.add(inner)
             block(FilterBuilder(inner))
         }
@@ -294,5 +291,13 @@ class QueryBuilder {
                 if (!root) sb.append(")")
             }
         }
+    }
+
+    private fun requireLogicalOperator(operator: String): String {
+        val normalized = operator.requireNotBlank("operator").trim().lowercase()
+        require(normalized == "and" || normalized == "or") {
+            "Unsupported where group operator: '$operator'. Only 'and' and 'or' are allowed."
+        }
+        return normalized
     }
 }

--- a/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/core/InsertTest.kt
+++ b/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/core/InsertTest.kt
@@ -1,14 +1,15 @@
 package io.bluetape4k.r2dbc.core
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.r2dbc.AbstractR2dbcTest
 import io.bluetape4k.r2dbc.model.User
 import kotlinx.coroutines.reactive.awaitSingle
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeGreaterThan
-import io.bluetape4k.assertions.shouldHaveSize
-import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
 import org.springframework.r2dbc.core.awaitOne
 import java.time.OffsetDateTime
@@ -46,6 +47,26 @@ class InsertTest: AbstractR2dbcTest() {
 
         val count2 = client.execute<Int>("SELECT COUNT(*) FROM users").fetch().awaitOne()
         count2 shouldBeEqualTo count1 + 2
+    }
+
+    @Test
+    fun `insert rejects invalid field identifier before SQL interpolation`() {
+        assertFailsWith<IllegalArgumentException> {
+            client
+                .insert()
+                .into("users")
+                .value("username) VALUES ('mallory'); DROP TABLE users; --", "mallory")
+        }
+    }
+
+    @Test
+    fun `insert with generated key rejects invalid field identifier before SQL interpolation`() {
+        assertFailsWith<IllegalArgumentException> {
+            client
+                .insert()
+                .into("users", "user_id")
+                .nullValue("username) VALUES ('mallory'); DROP TABLE users; --")
+        }
     }
 
     @Test

--- a/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/core/UpdateTest.kt
+++ b/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/core/UpdateTest.kt
@@ -1,11 +1,12 @@
 package io.bluetape4k.r2dbc.core
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.r2dbc.AbstractR2dbcTest
 import io.bluetape4k.r2dbc.model.User
 import kotlinx.coroutines.reactor.awaitSingle
-import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 import org.springframework.r2dbc.core.awaitOne
 import org.springframework.r2dbc.core.awaitRowsUpdated
@@ -51,6 +52,26 @@ class UpdateTest: AbstractR2dbcTest() {
             .fetch()
             .awaitRowsUpdated()
         rowsUpdated3 shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `update rejects invalid field identifier before SQL interpolation`() {
+        assertFailsWith<IllegalArgumentException> {
+            client
+                .update()
+                .table("users")
+                .set("description = 'pwned', active", false)
+        }
+    }
+
+    @Test
+    fun `update rejects invalid map field identifier before SQL interpolation`() {
+        assertFailsWith<IllegalArgumentException> {
+            client
+                .update()
+                .table("users")
+                .set(mapOf("description = 'pwned', active" to false))
+        }
     }
 
     @Test

--- a/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/query/QueryBuilderTest.kt
+++ b/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/query/QueryBuilderTest.kt
@@ -1,12 +1,12 @@
 package io.bluetape4k.r2dbc.query
 
-import io.bluetape4k.logging.KLogging
-import io.r2dbc.spi.Parameter
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.logging.KLogging
+import io.r2dbc.spi.Parameter
 import org.junit.jupiter.api.Test
 import java.io.Serializable
-import io.bluetape4k.assertions.assertFailsWith
 
 class QueryBuilderTest {
 
@@ -322,6 +322,36 @@ class QueryBuilderTest {
                 whereGroup("   ") {
                     where("id = :id")
                     parameter("id", 1)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `root where group rejects unsupported operator before SQL interpolation`() {
+        assertFailsWith<IllegalArgumentException> {
+            query {
+                select("select * from actor")
+                whereGroup("or 1 = 1 --") {
+                    where("id = :id")
+                    parameter("id", 1)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `nested where group rejects unsupported operator before SQL interpolation`() {
+        assertFailsWith<IllegalArgumentException> {
+            query {
+                select("select * from actor")
+                whereGroup {
+                    where("id = :id")
+                    parameter("id", 1)
+                    whereGroup("union select") {
+                        where("name = :name")
+                        parameter("name", "Kate")
+                    }
                 }
             }
         }

--- a/docs/lessons/2026-06-26-issue-822-r2dbc-sql-identifier-guards.md
+++ b/docs/lessons/2026-06-26-issue-822-r2dbc-sql-identifier-guards.md
@@ -1,0 +1,18 @@
+# Lessons Learned — R2DBC SQL Identifier Guards (2026-06-26)
+
+**Issue**: #822
+**Module**: `:bluetape4k-r2dbc`
+
+## L1: Helper coverage is not enough for public DSL safety
+
+### Problem
+
+`requireValidIdentifier(...)` already existed and had unit tests, but the public insert/update builders stored field names before calling that helper. `QueryBuilder.whereGroup(...)` also accepted arbitrary non-blank operators and interpolated them between conditions.
+
+### Lesson
+
+When a SQL DSL has a validation helper, test the public builder paths that interpolate identifiers or operators, not only the helper itself. Helper-level tests prove the predicate, but public-path tests prove the guard is actually wired into the DSL.
+
+### Future Guard
+
+For R2DBC SQL DSL changes, add direct regression tests against the fluent API entrypoint whenever a string argument later becomes SQL syntax instead of a bound value.

--- a/docs/review/2026-06-26-issue-822-r2dbc-sql-identifier-guards-review.md
+++ b/docs/review/2026-06-26-issue-822-r2dbc-sql-identifier-guards-review.md
@@ -1,0 +1,31 @@
+# Review — Issue 822 R2DBC SQL Identifier Guards (2026-06-26)
+
+**Scope**: `:bluetape4k-r2dbc`
+**Issue**: #822
+**Branch**: `fix/r2dbc-sql-identifier-guards`
+
+## Tiers
+
+- Tier 1 Security: PASS
+- Tier 4 Code correctness: PASS
+- Tier 5 Tests: PASS
+- Tier 7 Evidence: PASS
+
+## Findings
+
+- P0: 0
+- P1: 0
+- P2/P3: 0
+
+## Evidence
+
+- `InsertValuesSpecImpl` and `InsertValuesKeySpecImpl` now validate every field key with `requireValidIdentifier(...)` before storing it in the values map.
+- `UpdateValuesSpecImpl.set(...)` validates every field key before storing it; `update(...)`, nullable setters, and `set(parameters)` flow through those setter paths.
+- `QueryBuilder.whereGroup(...)` now normalizes and allow-lists group operators to `and` or `or`.
+- Regression proof before the fix: 6 new tests failed with `Expected IllegalArgumentException but no exception was thrown`.
+- Validation after the fix: `./gradlew :bluetape4k-r2dbc:cleanTest :bluetape4k-r2dbc:compileKotlin :bluetape4k-r2dbc:compileTestKotlin :bluetape4k-r2dbc:test --no-build-cache` passed with 171 tests.
+- `git diff --check` passed.
+
+## Notes
+
+The change keeps raw `where(...)`, `select(...)`, `groupBy(...)`, `having(...)`, and `orderBy(...)` fragments unchanged because those APIs intentionally accept SQL fragments. The hardened paths are only the fluent DSL values that become SQL identifiers or boolean operators before parameter binding can protect values.


### PR DESCRIPTION
## Summary

Closes #822

- PR 제목: fix: guard R2DBC SQL DSL interpolation

### 원문 선행 내용

Fixes #822

## Background

The R2DBC SQL DSL already validates table names and generated-key columns, but insert/update field names and `QueryBuilder.whereGroup` operators were still accepted as raw strings before they were interpolated into SQL. Callers can reasonably treat these fluent builder arguments as safer than raw SQL fragments, so those paths need explicit validation before parameter binding runs.

## What This Solves

- Rejects unsafe insert field identifiers before they are stored and later rendered in `INSERT INTO ... (...)`.
- Rejects unsafe generated-key insert field identifiers through the same public builder path.
- Rejects unsafe update field identifiers for direct setters, nullable setters, update aliases, and map-based setters.
- Restricts `whereGroup` operators to normalized `and` / `or` values instead of interpolating arbitrary non-blank text between conditions.

## Work Done

- Wired `requireValidIdentifier(...)` into `InsertValuesSpecImpl`, `InsertValuesKeySpecImpl`, and `UpdateValuesSpecImpl` field-key storage paths.
- Added a `QueryBuilder` logical-operator guard for root and nested where groups.
- Added public-builder regression tests for insert, generated-key insert, update, map update, root where-group, and nested where-group rejection.
- Added tracked review evidence and lessons for the SQL DSL validation gap.

## Validation

- Regression proof before the fix: the 6 new tests failed with `Expected IllegalArgumentException but no exception was thrown`.
- `./gradlew :bluetape4k-r2dbc:cleanTest :bluetape4k-r2dbc:compileKotlin :bluetape4k-r2dbc:compileTestKotlin :bluetape4k-r2dbc:test --no-build-cache`: PASS, 171 tests.
- `git diff --check`: PASS.

## Review Notes

- Local Tier 1 / Tier 4 / Tier 5 / Tier 7 review completed.
- P0/P1 findings: 0.
- Raw SQL fragment APIs such as `where(...)`, `select(...)`, `groupBy(...)`, `having(...)`, and `orderBy(...)` remain unchanged; this PR only guards fluent arguments that become SQL syntax rather than bound values.

## Metadata

- Issue: #822, milestone `1.11.0`, assignee `debop`
- PR: #899, head `4d246ae6f68a12d44507b41f8176cc344afaed89`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/r2dbc-sql-identifier-guards`
- Labels: `bug`, `security`, `infra/io`
- State: `MERGED`, merge commit `98dc4b40533164bc5037bf820cd5924b0d9fc38e`
- CI: The R2DBC SQL DSL already validates table names and generated-key columns, but insert/update field names and `QueryBuilder.whereGroup` operators were still accepted as raw strings before they were interpolated into SQL. Callers can reasonably treat these fluent builder arguments as safer than raw SQL fragments, so those paths need explicit validation before parameter binding runs. / - Wired `requireValidIdentifier(...)` into `InsertValuesSpecImpl`, `InsertValuesKeySpecImpl`, and `UpdateValuesSpecImpl` field-key storage paths. / - `./gradlew :bluetape4k-r2dbc:cleanTest :bluetape4k-r2dbc:compileKotlin :bluetape4k-r2dbc:compileTestKotlin :bluetape4k-r2dbc:test --no-build-cache`: PASS, 171 tests.

## DoD Status

| Step | Status | Evidence |
|------|--------|----------|
| Step W - Worktree | PASS | `.worktrees/fix-r2dbc-sql-identifier-guards`, branch `fix/r2dbc-sql-identifier-guards` |
| Step A - Issue analysis | PASS | Issue #822 live metadata checked; affected R2DBC insert/update/query builder paths verified |
| Step F - Fix | PASS | Commit `4d246ae6f` validates identifiers/operators before SQL interpolation |
| Step 4-T - Tests | PASS | `:bluetape4k-r2dbc:cleanTest :compileKotlin :compileTestKotlin :test --no-build-cache`, 171 passing |
| Step 6-R - Review | PASS | `docs/review/2026-06-26-issue-822-r2dbc-sql-identifier-guards-review.md`, P0/P1=0 |
| Step 7 - Lessons | PASS | `docs/lessons/2026-06-26-issue-822-r2dbc-sql-identifier-guards.md` committed |
| Step 7-P - PR metadata | PASS | PR #899 verified: assignee `debop`, milestone `1.11.0`, labels `bug`, `security`, `infra/io` |
| Step 7-R - Post-PR review | PASS | PR comment `4801470077` and formal review submitted; P0/P1=0 |
| Step 8 - CI gate | PASS | PR check rollup: CI SUCCESS, submit-gradle SUCCESS, skipped matrix jobs only |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #899 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `98dc4b40533164bc5037bf820cd5924b0d9fc38e`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
