### PR TITLE
fix: fail R2DBC JSON conversion errors

### DIFF
--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/convert/postgresql/JsonToMapConverter.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/convert/postgresql/JsonToMapConverter.kt
@@ -3,6 +3,8 @@ package io.bluetape4k.r2dbc.convert.postgresql
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
 import io.r2dbc.postgresql.codec.Json
+import org.springframework.core.convert.ConversionFailedException
+import org.springframework.core.convert.TypeDescriptor
 import org.springframework.core.convert.converter.Converter
 import org.springframework.data.convert.ReadingConverter
 import tools.jackson.core.JacksonException
@@ -10,21 +12,26 @@ import tools.jackson.databind.ObjectMapper
 import tools.jackson.module.kotlin.readValue
 
 /**
- * PostgreSQL의 Json 타입을 Map\<String, Any?\>로 변환하는 Converter입니다.
+ * Converts a PostgreSQL [Json] value into a `Map<String, Any?>`.
  *
- * @property mapper Jackson ObjectMapper 인스턴스
+ * Invalid JSON is reported as a [ConversionFailedException] with the original Jackson cause.
+ *
+ * @property mapper Jackson object mapper used for deserialization.
  */
 @ReadingConverter
 class JsonToMapConverter(private val mapper: ObjectMapper): Converter<Json, Map<String, Any?>> {
 
-    companion object: KLogging()
+    companion object: KLogging() {
+        private val sourceType = TypeDescriptor.valueOf(Json::class.java)
+        private val targetType = TypeDescriptor.valueOf(Map::class.java)
+    }
 
     override fun convert(source: Json): Map<String, Any?> {
         return try {
             mapper.readValue(source.asString())
         } catch (e: JacksonException) {
             log.error(e) { "Fail to parse Json: $source" }
-            emptyMap()
+            throw ConversionFailedException(sourceType, targetType, source, e)
         }
     }
 }

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/convert/postgresql/MapToJsonConverter.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/convert/postgresql/MapToJsonConverter.kt
@@ -3,33 +3,39 @@ package io.bluetape4k.r2dbc.convert.postgresql
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
 import io.r2dbc.postgresql.codec.Json
+import org.springframework.core.convert.ConversionFailedException
+import org.springframework.core.convert.TypeDescriptor
 import org.springframework.core.convert.converter.Converter
 import org.springframework.data.convert.WritingConverter
 import tools.jackson.core.JacksonException
 import tools.jackson.databind.ObjectMapper
 
 /**
- * Map\<String, Any?\>를 PostgreSQL의 Json 타입으로 변환하는 Converter입니다.
+ * Converts a `Map<String, Any?>` value into a PostgreSQL [Json] value.
  *
- * @property mapper Jackson ObjectMapper 인스턴스
+ * Serialization errors are reported as [ConversionFailedException] with the original Jackson cause.
+ *
+ * @property mapper Jackson object mapper used for serialization.
  */
 @WritingConverter
 class MapToJsonConverter(
     private val mapper: ObjectMapper,
 ): Converter<Map<String, Any?>, Json> {
 
-    companion object: KLogging()
+    companion object: KLogging() {
+        private val sourceType = TypeDescriptor.valueOf(Map::class.java)
+        private val targetType = TypeDescriptor.valueOf(Json::class.java)
+    }
 
     /**
-     * Map을 Json 객체로 변환합니다.
+     * Converts [source] into PostgreSQL [Json].
      *
-     * @param source 변환할 Map
-     * @return Json 객체, 변환 실패 시 빈 Json 객체
+     * @throws ConversionFailedException when Jackson cannot serialize [source].
      */
     override fun convert(source: Map<String, Any?>): Json = try {
         Json.of(mapper.writeValueAsString(source))
     } catch (e: JacksonException) {
         log.error(e) { "Fail to serialize map to Json. source=$source" }
-        Json.of("{}")
+        throw ConversionFailedException(sourceType, targetType, source, e)
     }
 }

--- a/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/convert/postgresql/PostgresJsonConvertersTest.kt
+++ b/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/convert/postgresql/PostgresJsonConvertersTest.kt
@@ -1,0 +1,63 @@
+package io.bluetape4k.r2dbc.convert.postgresql
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.jackson3.Jackson
+import io.mockk.every
+import io.mockk.mockk
+import io.r2dbc.postgresql.codec.Json
+import org.junit.jupiter.api.Test
+import org.springframework.core.convert.ConversionFailedException
+import tools.jackson.core.JacksonException
+import tools.jackson.databind.ObjectMapper
+
+class PostgresJsonConvertersTest {
+
+    private val mapper = Jackson.defaultJsonMapper
+
+    @Test
+    fun `JsonToMapConverter converts valid PostgreSQL Json`() {
+        val converter = JsonToMapConverter(mapper)
+
+        val result = converter.convert(Json.of("""{"name":"debop","active":true}"""))
+
+        result["name"] shouldBeEqualTo "debop"
+        result["active"] shouldBeEqualTo true
+    }
+
+    @Test
+    fun `JsonToMapConverter fails malformed PostgreSQL Json without replacing data`() {
+        val converter = JsonToMapConverter(mapper)
+
+        val error = assertFailsWith<ConversionFailedException> {
+            converter.convert(Json.of("""{"name":"""))
+        }
+
+        error.cause.shouldBeInstanceOf<JacksonException>()
+    }
+
+    @Test
+    fun `MapToJsonConverter converts map to PostgreSQL Json`() {
+        val converter = MapToJsonConverter(mapper)
+
+        val json = converter.convert(mapOf("name" to "debop", "active" to true))
+
+        json.asString() shouldBeEqualTo """{"name":"debop","active":true}"""
+    }
+
+    @Test
+    fun `MapToJsonConverter fails serialization errors without replacing data`() {
+        val jacksonFailure = JacksonException.wrapWithPath(IllegalStateException("boom"), "source", "field")
+        val failingMapper = mockk<ObjectMapper> {
+            every { writeValueAsString(any<Map<String, Any?>>()) } throws jacksonFailure
+        }
+        val converter = MapToJsonConverter(failingMapper)
+
+        val error = assertFailsWith<ConversionFailedException> {
+            converter.convert(mapOf("name" to "debop"))
+        }
+
+        error.cause shouldBeEqualTo jacksonFailure
+    }
+}

--- a/docs/lessons/2026-06-26-issue-824-r2dbc-postgres-json-conversion.md
+++ b/docs/lessons/2026-06-26-issue-824-r2dbc-postgres-json-conversion.md
@@ -1,0 +1,18 @@
+# Lessons Learned — R2DBC PostgreSQL JSON Conversion (2026-06-26)
+
+**Issue**: #824
+**Module**: `:bluetape4k-r2dbc`
+
+## L1: Converter fallbacks can become silent data loss
+
+### Problem
+
+The PostgreSQL JSON converters logged Jackson failures and returned valid empty values. A malformed database value became an empty map, and an unserializable application value became `{}`.
+
+### Lesson
+
+Converters that sit on persistence boundaries should fail with the original cause unless the API explicitly models fallback semantics. A valid empty value is not a safe substitute for invalid stored data or failed serialization.
+
+### Future Guard
+
+For R2DBC converter changes, add regression tests for both the success path and the failure path. Failure-path tests should assert the exception type and cause, not only that logging happened.

--- a/docs/review/2026-06-26-issue-824-r2dbc-postgres-json-conversion-review.md
+++ b/docs/review/2026-06-26-issue-824-r2dbc-postgres-json-conversion-review.md
@@ -1,0 +1,32 @@
+# Review — Issue 824 R2DBC PostgreSQL JSON Conversion (2026-06-26)
+
+**Scope**: `:bluetape4k-r2dbc`
+**Issue**: #824
+**Branch**: `fix/r2dbc-json-conversion-fail-fast`
+
+## Tiers
+
+- Tier 1 Security: PASS
+- Tier 4 Code correctness: PASS
+- Tier 5 Tests: PASS
+- Tier 7 Evidence: PASS
+
+## Findings
+
+- P0: 0
+- P1: 0
+- P2/P3: 0
+
+## Evidence
+
+- `JsonToMapConverter` now throws `ConversionFailedException` for malformed PostgreSQL JSON instead of returning `emptyMap()`.
+- `MapToJsonConverter` now throws `ConversionFailedException` for Jackson serialization failures instead of returning `Json.of("{}")`.
+- Both converters preserve the original Jackson cause on the conversion failure.
+- Regression proof before the fix: 2 new tests failed with `Expected ConversionFailedException but no exception was thrown`.
+- Targeted validation after the fix: `./gradlew :bluetape4k-r2dbc:test --tests 'io.bluetape4k.r2dbc.convert.postgresql.PostgresJsonConvertersTest' --no-build-cache` passed with 4 tests.
+- Module validation after the fix: `./gradlew :bluetape4k-r2dbc:cleanTest :bluetape4k-r2dbc:compileKotlin :bluetape4k-r2dbc:compileTestKotlin :bluetape4k-r2dbc:test --no-build-cache` passed with 175 tests.
+- `git diff --check` passed.
+
+## Notes
+
+The converter still logs the Jackson error, but the persistence/read path now fails explicitly so invalid or unserializable data cannot be silently replaced with a valid empty JSON shape.


### PR DESCRIPTION
## Summary

Closes #824

- PR 제목: fix: fail R2DBC JSON conversion errors

Fixes #824.

`JsonToMapConverter` and `MapToJsonConverter` now fail fast on Jackson conversion errors instead of replacing invalid data with `emptyMap()` or `Json.of("{}")`.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Throw `ConversionFailedException` from PostgreSQL JSON read/write converters while preserving the original Jackson cause.
- Update converter KDoc to describe fail-fast behavior.
- Add regression coverage for malformed PostgreSQL JSON and serialization failure.
- Add issue review and lessons notes for the R2DBC converter boundary.

## Validation

- Regression proof before the fix: 2 new tests failed with `Expected ConversionFailedException but no exception was thrown`.
- `./gradlew :bluetape4k-r2dbc:test --tests 'io.bluetape4k.r2dbc.convert.postgresql.PostgresJsonConvertersTest' --no-build-cache`
- `./gradlew :bluetape4k-r2dbc:cleanTest :bluetape4k-r2dbc:compileKotlin :bluetape4k-r2dbc:compileTestKotlin :bluetape4k-r2dbc:test --no-build-cache` passed with 175 tests.
- `git diff --check`
- GitHub CI passed for PR #901: Build, CI Status, Coverage Report, Secret Scan, Validate Gradle Wrapper, submit-gradle.

## Review Notes

- Local review: P0/P1 = 0.
- Scope risk: narrow, limited to R2DBC PostgreSQL JSON converter failure semantics and tests.

## Metadata

- Issue: #824, milestone `1.11.0`, assignee `debop`
- PR: #901, head `e0f2f2ca35b596a39b5fcedb42816a04426032bd`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/r2dbc-json-conversion-fail-fast`
- Labels: `bug`, `infra/io`, `jackson3`
- State: `MERGED`, merge commit `3ac7bedc77bf347f5d2687ee37dc6c8df1543936`
- CI: `JsonToMapConverter` and `MapToJsonConverter` now fail fast on Jackson conversion errors instead of replacing invalid data with `emptyMap()` or `Json.of("{}")`. / - `./gradlew :bluetape4k-r2dbc:test --tests 'io.bluetape4k.r2dbc.convert.postgresql.PostgresJsonConvertersTest' --no-build-cache` / - `./gradlew :bluetape4k-r2dbc:cleanTest :bluetape4k-r2dbc:compileKotlin :bluetape4k-r2dbc:compileTestKotlin :bluetape4k-r2dbc:test --no-build-cache` passed with 175 tests.

## DoD Status

- [x] Linked issue: #824
- [x] Issue assignee mirrored: `debop`
- [x] Issue milestone mirrored: `1.11.0`
- [x] Issue labels mirrored: `bug`, `infra/io`, `jackson3`
- [x] Regression tests added and verified
- [x] Module compile/test verification passed
- [x] Local review completed with P0/P1 = 0
- [x] GitHub CI passed

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #901 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `3ac7bedc77bf347f5d2687ee37dc6c8df1543936`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
