### PR TITLE
fix: align R2DBC indexed binding contract

### DIFF
--- a/data/r2dbc/README.ko.md
+++ b/data/r2dbc/README.ko.md
@@ -194,10 +194,10 @@ val users = databaseClient
     .fetch()
     .flow { row, _ -> /* mapping */ }
 
-// 인덱스 기반 파라미터 바인딩
+// 인덱스 기반 파라미터 바인딩은 Spring R2DBC의 0-based 인덱스를 사용합니다.
 val indexedParams = mapOf(
-    1 to "john",
-    2 to true
+    0 to "john",
+    1 to true
 )
 
 val users = databaseClient

--- a/data/r2dbc/README.md
+++ b/data/r2dbc/README.md
@@ -199,10 +199,10 @@ val users = databaseClient
     .fetch()
     .flow { row, _ -> /* mapping */ }
 
-// Index-based parameter binding
+// Index-based parameter binding uses Spring R2DBC's zero-based indexes.
 val indexedParams = mapOf(
-    1 to "john",
-    2 to true
+    0 to "john",
+    1 to true
 )
 
 val users = databaseClient

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/support/DatabaseClientSupport.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/support/DatabaseClientSupport.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.r2dbc.support
 
 import io.bluetape4k.logging.KotlinLogging
 import io.bluetape4k.logging.trace
+import io.bluetape4k.support.requireZeroOrPositiveNumber
 import org.springframework.r2dbc.core.DatabaseClient
 
 private val log by lazy { KotlinLogging.logger {} }
@@ -44,16 +45,17 @@ fun DatabaseClient.GenericExecuteSpec.bindMap(parameters: Map<String, Any?>): Da
     }
 
 /**
- * Query의 indexed parameter 정보를 매핑합니다.
+ * Binds indexed query parameters.
  *
- * Indexed parameter는 `?` 형식으로 SQL에 지정하고, Map의 키로 인덱스(1부터 시작)를 지정합니다.
- * null 값은 자동으로 NULL로 바인딩됩니다.
+ * Indexed parameters follow Spring R2DBC's zero-based binding contract. The first
+ * positional parameter is index `0`, the second is index `1`, and so on.
+ * Null values are bound as NULL with this helper's default String type.
  *
  * ```kotlin
  * val sql = "SELECT * FROM users WHERE username = ? AND active = ?"
  * val parameters = mapOf(
- *     1 to "john",
- *     2 to true
+ *     0 to "john",
+ *     1 to true
  * )
  *
  * val users = databaseClient
@@ -68,15 +70,17 @@ fun DatabaseClient.GenericExecuteSpec.bindMap(parameters: Map<String, Any?>): Da
  *     .all()
  * ```
  *
- * @param parameters indexed query parameters (인덱스 -> 값, 인덱스는 1부터 시작)
- * @return 파라미터가 바인딩된 [DatabaseClient.GenericExecuteSpec]
+ * @param parameters indexed query parameters from zero-based index to value.
+ * @return [DatabaseClient.GenericExecuteSpec] with the parameters bound.
+ * @throws IllegalArgumentException when any index is negative.
  */
 fun DatabaseClient.GenericExecuteSpec.bindIndexedMap(parameters: Map<Int, Any?>): DatabaseClient.GenericExecuteSpec =
     parameters.entries.fold(this) { spec, entry ->
-        log.trace { "bind indexed map. index=${entry.key}, value=${entry.value}" }
+        val index = entry.key.requireZeroOrPositiveNumber("index")
+        log.trace { "bind indexed map. index=$index, value=${entry.value}" }
         when (val value = entry.value) {
-            null -> spec.bindNull(entry.key, String::class.java)
-            else -> spec.bind(entry.key, value.toParameter())
+            null -> spec.bindNull(index, String::class.java)
+            else -> spec.bind(index, value.toParameter())
         }
     }
 
@@ -116,26 +120,29 @@ fun DatabaseClient.execute(
 ): DatabaseClient.GenericExecuteSpec = sql(sqlString).bindMap(parameters)
 
 /**
- * Indexed 파라미터에 nullable 값을 바인딩합니다.
- * null 값은 NULL로 바인딩됩니다.
+ * Binds a nullable value to an indexed parameter.
+ *
+ * The [index] follows Spring R2DBC's zero-based binding contract. The first
+ * positional parameter is index `0`. Null values are bound as typed NULL values.
  *
  * ```kotlin
  * databaseClient
  *     .sql("SELECT * FROM users WHERE name = ?")
- *     .bindNullable<String>(1, nullableName)
+ *     .bindNullable<String>(0, nullableName)
  *     .map { row, _ -> /* mapping */ }
  * ```
  *
- * @param V 파라미터의 타입
- * @param index 파라미터 인덱스 (1부터 시작)
- * @param value 바인딩할 값 (null 가능)
- * @return 파라미터가 바인딩된 [DatabaseClient.GenericExecuteSpec]
+ * @param V Parameter type.
+ * @param index Zero-based parameter index.
+ * @param value Value to bind.
+ * @return [DatabaseClient.GenericExecuteSpec] with the parameter bound.
+ * @throws IllegalArgumentException when [index] is negative.
  */
 inline fun <reified V: Any> DatabaseClient.GenericExecuteSpec.bindNullable(
     index: Int,
     value: V? = null,
 ) = apply {
-    bind(index, value.toParameter(V::class.java))
+    bind(index.requireZeroOrPositiveNumber("index"), value.toParameter(V::class.java))
 }
 
 /**

--- a/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/core/ExecuteTest.kt
+++ b/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/core/ExecuteTest.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.r2dbc.AbstractR2dbcTest
 import io.bluetape4k.r2dbc.model.User
 import io.bluetape4k.r2dbc.query.query
+import io.bluetape4k.r2dbc.support.bindIndexedMap
 import io.bluetape4k.support.string
 import io.bluetape4k.support.stringOrNull
 import kotlinx.coroutines.flow.toList
@@ -106,6 +107,18 @@ class ExecuteTest: AbstractR2dbcTest() {
             .fetch()
             .flow().toList()
         smiths3 shouldHaveSize 1
+
+        val smithName = client.databaseClient
+            .sql("SELECT name FROM users WHERE username = ? AND active = ?")
+            .bindIndexedMap(
+                mapOf(
+                    0 to "jsmith",
+                    1 to true,
+                )
+            )
+            .map<String> { row, _ -> row.get("name", String::class.java).shouldNotBeNull() }
+            .awaitOne()
+        smithName shouldBeEqualTo "John Smith"
     }
 
     @Test

--- a/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/support/DatabaseClientSupportTest.kt
+++ b/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/support/DatabaseClientSupportTest.kt
@@ -1,0 +1,27 @@
+package io.bluetape4k.r2dbc.support
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.springframework.r2dbc.core.DatabaseClient
+
+class DatabaseClientSupportTest {
+
+    @Test
+    fun `bindIndexedMap rejects negative indices`() {
+        val spec = mockk<DatabaseClient.GenericExecuteSpec>(relaxed = true)
+
+        assertFailsWith<IllegalArgumentException> {
+            spec.bindIndexedMap(mapOf(-1 to "john"))
+        }
+    }
+
+    @Test
+    fun `bindNullable rejects negative indexed binding`() {
+        val spec = mockk<DatabaseClient.GenericExecuteSpec>(relaxed = true)
+
+        assertFailsWith<IllegalArgumentException> {
+            spec.bindNullable<String>(-1, "john")
+        }
+    }
+}

--- a/docs/lessons/2026-06-26-issue-826-r2dbc-indexed-binding.md
+++ b/docs/lessons/2026-06-26-issue-826-r2dbc-indexed-binding.md
@@ -1,0 +1,18 @@
+# Lessons Learned — R2DBC Indexed Binding (2026-06-26)
+
+**Issue**: #826
+**Module**: `:bluetape4k-r2dbc`
+
+## L1: Documentation examples are API contract tests
+
+### Problem
+
+`bindIndexedMap` forwarded map keys directly to Spring R2DBC's indexed binding API, but KDoc and README examples showed `1` and `2` as the first two indexes.
+
+### Lesson
+
+When a helper mirrors a framework API without translating values, examples must use the framework's exact contract. For Spring R2DBC indexed parameters, that contract is zero-based.
+
+### Future Guard
+
+For parameter binding helpers, add a direct test that executes the README/KDoc-style example. Also validate out-of-contract inputs such as negative indexes before forwarding to the framework layer.

--- a/docs/review/2026-06-26-issue-826-r2dbc-indexed-binding-review.md
+++ b/docs/review/2026-06-26-issue-826-r2dbc-indexed-binding-review.md
@@ -1,0 +1,33 @@
+# Review — Issue 826 R2DBC Indexed Binding (2026-06-26)
+
+**Scope**: `:bluetape4k-r2dbc`
+**Issue**: #826
+**Branch**: `fix/r2dbc-indexed-binding-docs`
+
+## Tiers
+
+- Tier 1 Security: PASS
+- Tier 4 Code correctness: PASS
+- Tier 5 Tests: PASS
+- Tier 7 Evidence: PASS
+
+## Findings
+
+- P0: 0
+- P1: 0
+- P2/P3: 0
+
+## Evidence
+
+- `bindIndexedMap` KDoc now documents Spring R2DBC's zero-based indexed binding contract.
+- `bindIndexedMap` now rejects negative indexes before forwarding to Spring R2DBC.
+- `bindNullable(index, ...)` KDoc and validation now match the same zero-based index contract.
+- English and Korean R2DBC README examples now use `0` and `1` for two positional parameters.
+- Regression coverage now directly exercises `bindIndexedMap` with `?` positional markers through `DatabaseClient.GenericExecuteSpec`.
+- Guard coverage now asserts negative index rejection for `bindIndexedMap` and indexed `bindNullable`.
+- Validation after the fix: `./gradlew :bluetape4k-r2dbc:cleanTest :bluetape4k-r2dbc:compileKotlin :bluetape4k-r2dbc:compileTestKotlin :bluetape4k-r2dbc:test --no-build-cache` passed with 177 tests.
+- `git diff --check` passed.
+
+## Notes
+
+The change does not translate caller indexes. It documents and enforces the existing Spring R2DBC zero-based contract so caller code and documentation stay aligned with the underlying API.


### PR DESCRIPTION
## Summary

Closes #826

- PR 제목: fix: align R2DBC indexed binding contract

Fixes #826.

R2DBC indexed binding documentation and examples now match Spring R2DBC's zero-based index contract. The helper also rejects negative indexes before forwarding to Spring R2DBC.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Update `bindIndexedMap` KDoc to document zero-based indexes and negative-index rejection.
- Update indexed `bindNullable(index, ...)` KDoc and validation to the same zero-based contract.
- Update English and Korean R2DBC README examples from `1, 2` to `0, 1`.
- Add direct `bindIndexedMap` integration coverage using positional `?` markers.
- Add guard tests for negative indexed binding.
- Add review and lesson artifacts for the R2DBC binding contract.

## Validation

- `./gradlew :bluetape4k-r2dbc:test --tests 'io.bluetape4k.r2dbc.core.ExecuteTest.select values with indexed parameters' --tests 'io.bluetape4k.r2dbc.support.DatabaseClientSupportTest' --no-build-cache`
- `./gradlew :bluetape4k-r2dbc:cleanTest :bluetape4k-r2dbc:compileKotlin :bluetape4k-r2dbc:compileTestKotlin :bluetape4k-r2dbc:test --no-build-cache` passed with 177 tests.
- `git diff --check`
- GitHub CI passed for PR #902: Build, CI Status, Coverage Report, Secret Scan, Validate Gradle Wrapper, submit-gradle.

## Review Notes

- Local review: P0/P1 = 0.
- Scope risk: narrow, limited to R2DBC indexed binding documentation, guard validation, and tests.
- IntelliJ diagnostics were unavailable in this session; Gradle compile/test was used as fallback evidence.

## Metadata

- Issue: #826, milestone `1.11.0`, assignee `debop`
- PR: #902, head `fe47a7f1e2352b6b803ae54b46a73d36e8d9f571`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/r2dbc-indexed-binding-docs`
- Labels: `bug`, `documentation`, `infra/io`
- State: `MERGED`, merge commit `3a1d2071369aea407c92458aff6c80e36b526e51`
- CI: - `./gradlew :bluetape4k-r2dbc:test --tests 'io.bluetape4k.r2dbc.core.ExecuteTest.select values with indexed parameters' --tests 'io.bluetape4k.r2dbc.support.DatabaseClientSupportTest' --no-build-cache` / - `./gradlew :bluetape4k-r2dbc:cleanTest :bluetape4k-r2dbc:compileKotlin :bluetape4k-r2dbc:compileTestKotlin :bluetape4k-r2dbc:test --no-build-cache` passed with 177 tests. / - GitHub CI passed for PR #902: Build, CI Status, Coverage Report, Secret Scan, Validate Gradle Wrapper, submit-gradle.

## DoD Status

- [x] Linked issue: #826
- [x] Issue assignee mirrored: `debop`
- [x] Issue milestone mirrored: `1.11.0`
- [x] Issue labels mirrored: `bug`, `documentation`, `infra/io`
- [x] README English/Korean examples updated together
- [x] KDoc contract updated in English
- [x] Regression/guard tests added and verified
- [x] Module compile/test verification passed
- [x] Local review completed with P0/P1 = 0
- [x] GitHub CI passed

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #902 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `3a1d2071369aea407c92458aff6c80e36b526e51`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
