### PR TITLE
fix: make ResultSet empty checks explicit

### DIFF
--- a/data/jdbc/README.ko.md
+++ b/data/jdbc/README.ko.md
@@ -451,10 +451,16 @@ dataSource.runQuery("SELECT * FROM users") { rs ->
 ### 15. 유틸리티 함수
 
 ```kotlin
-// isEmpty / isNotEmpty
+// 커서를 이동시키는 비어 있음 확인
 dataSource.runQuery("SELECT * FROM users WHERE 1=0") { rs ->
-    rs.isEmpty()    // true
-    rs.isNotEmpty() // false
+    rs.isEmptyByMovingCursor() // true; ResultSet.next()를 한 번 호출합니다.
+}
+
+dataSource.runQuery("SELECT * FROM users ORDER BY id") { rs ->
+    if (rs.isNotEmptyByMovingCursor()) {
+        // 커서는 이미 첫 번째 row에 위치합니다.
+        val firstId = rs.getInt("id")
+    }
 }
 
 // count

--- a/data/jdbc/README.md
+++ b/data/jdbc/README.md
@@ -450,10 +450,16 @@ dataSource.runQuery("SELECT * FROM users") { rs ->
 ### 15. Utility Functions
 
 ```kotlin
-// isEmpty / isNotEmpty
+// Cursor-moving emptiness checks
 dataSource.runQuery("SELECT * FROM users WHERE 1=0") { rs ->
-    rs.isEmpty()    // true
-    rs.isNotEmpty() // false
+    rs.isEmptyByMovingCursor() // true; calls ResultSet.next() once
+}
+
+dataSource.runQuery("SELECT * FROM users ORDER BY id") { rs ->
+    if (rs.isNotEmptyByMovingCursor()) {
+        // The cursor is already positioned on the first row.
+        val firstId = rs.getInt("id")
+    }
 }
 
 // count

--- a/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/ResultSetMappingExtensions.kt
+++ b/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/ResultSetMappingExtensions.kt
@@ -393,30 +393,61 @@ inline fun ResultSet.count(crossinline predicate: (ResultSet) -> Boolean = { tru
 }
 
 /**
- * ResultSet이 비어있는지 확인합니다.
+ * Checks whether this [ResultSet] has no rows by moving the cursor once.
+ *
+ * This function calls [ResultSet.next] exactly once. For a non-empty result set
+ * it returns `false` and leaves the cursor positioned on the first row. A normal
+ * iteration helper such as [toList] will therefore continue from the second row
+ * unless the caller maps the current row first.
  *
  * ```kotlin
- * if (rs.isEmpty()) {
+ * if (rs.isEmptyByMovingCursor()) {
  *     println("No results found")
  * }
  * ```
  *
- * @return ResultSet이 비어있으면 true, 그렇지 않으면 false
+ * @return `true` when [ResultSet.next] returns `false`.
  */
-fun ResultSet.isEmpty(): Boolean = !this.next()
+fun ResultSet.isEmptyByMovingCursor(): Boolean = !isNotEmptyByMovingCursor()
 
 /**
- * ResultSet이 비어있지 않은지 확인합니다.
+ * Checks whether this [ResultSet] has at least one row by moving the cursor once.
+ *
+ * This function calls [ResultSet.next] exactly once. When it returns `true`, the
+ * cursor is positioned on the first row and the caller may read that row
+ * immediately.
  *
  * ```kotlin
- * if (rs.isNotEmpty()) {
- *     println("Found results")
+ * if (rs.isNotEmptyByMovingCursor()) {
+ *     val firstId = rs.getInt("id")
  * }
  * ```
  *
- * @return ResultSet에 행이 있으면 true, 그렇지 않으면 false
+ * @return `true` when [ResultSet.next] moves to a row.
  */
-fun ResultSet.isNotEmpty(): Boolean = !isEmpty() // this.next().also { if (it) this.previous() }
+fun ResultSet.isNotEmptyByMovingCursor(): Boolean = this.next()
+
+/**
+ * Checks whether this [ResultSet] has no rows by moving the cursor once.
+ *
+ * @return `true` when [ResultSet.next] returns `false`.
+ */
+@Deprecated(
+    message = "This helper advances the ResultSet cursor. Use isEmptyByMovingCursor() when cursor movement is intended.",
+    replaceWith = ReplaceWith("isEmptyByMovingCursor()"),
+)
+fun ResultSet.isEmpty(): Boolean = isEmptyByMovingCursor()
+
+/**
+ * Checks whether this [ResultSet] has at least one row by moving the cursor once.
+ *
+ * @return `true` when [ResultSet.next] moves to a row.
+ */
+@Deprecated(
+    message = "This helper advances the ResultSet cursor. Use isNotEmptyByMovingCursor() when cursor movement is intended.",
+    replaceWith = ReplaceWith("isNotEmptyByMovingCursor()"),
+)
+fun ResultSet.isNotEmpty(): Boolean = isNotEmptyByMovingCursor()
 
 /**
  * ResultSet의 커서를 이전 위치로 되돌립니다.

--- a/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/sql/ResultSetExtensionsTest.kt
+++ b/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/sql/ResultSetExtensionsTest.kt
@@ -156,7 +156,7 @@ class ResultSetExtensionsTest: AbstractJdbcSqlTest() {
     fun `isEmpty - 결과가 없으면 true 반환`() {
         val empty =
             dataSource.runQuery("SELECT id FROM Actors WHERE 1 = 0") { rs ->
-                rs.isEmpty()
+                rs.isEmptyByMovingCursor()
             }
 
         empty.shouldBeTrue()
@@ -166,10 +166,32 @@ class ResultSetExtensionsTest: AbstractJdbcSqlTest() {
     fun `isNotEmpty - 결과가 있으면 true 반환`() {
         val notEmpty =
             dataSource.runQuery("SELECT id FROM Actors") { rs ->
-                rs.isNotEmpty()
+                rs.isNotEmptyByMovingCursor()
             }
 
         notEmpty.shouldBeTrue()
+    }
+
+    @Test
+    fun `isNotEmptyByMovingCursor positions cursor on first row`() {
+        val firstId =
+            dataSource.runQuery("SELECT id FROM Actors ORDER BY id") { rs ->
+                rs.isNotEmptyByMovingCursor().shouldBeTrue()
+                rs.getInt("id")
+            }
+
+        firstId shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `isNotEmptyByMovingCursor consumes first row before normal iteration`() {
+        val remainingIds =
+            dataSource.runQuery("SELECT id FROM Actors ORDER BY id") { rs ->
+                rs.isNotEmptyByMovingCursor().shouldBeTrue()
+                rs.toList { it.getInt("id") }
+            }
+
+        remainingIds.first() shouldBeEqualTo 2
     }
 
     // ─── count ────────────────────────────────────────────────────────────────

--- a/docs/lessons/2026-06-26-issue-819-jdbc-resultset-empty-cursor.md
+++ b/docs/lessons/2026-06-26-issue-819-jdbc-resultset-empty-cursor.md
@@ -1,0 +1,24 @@
+# Lessons Learned — JDBC ResultSet Empty Cursor Contract (2026-06-26)
+
+**Issue**: #819
+**Module**: `:bluetape4k-jdbc`
+
+## L1: JDBC cursor predicates are consumption APIs
+
+### Problem
+
+`ResultSet.isEmpty()` and `ResultSet.isNotEmpty()` looked like simple
+predicates, but both advanced the JDBC cursor by calling `next()`. A caller that
+checked `isNotEmpty()` and then used `toList` on the same `ResultSet` would miss
+the first row.
+
+### Lesson
+
+Any helper that calls `ResultSet.next()` must make cursor movement explicit in
+its name, KDoc, tests, and README examples. Forward-only cursors cannot be
+treated like reusable collections.
+
+### Future Guard
+
+When reviewing ResultSet helpers, add tests that inspect the cursor position
+after the helper call, not only the returned boolean or mapped value.

--- a/docs/review/2026-06-26-issue-819-jdbc-resultset-empty-cursor-review.md
+++ b/docs/review/2026-06-26-issue-819-jdbc-resultset-empty-cursor-review.md
@@ -1,0 +1,36 @@
+# Review — Issue 819 JDBC ResultSet Empty Cursor Contract (2026-06-26)
+
+**Scope**: `:bluetape4k-jdbc`
+**Issue**: #819
+**Branch**: `fix/jdbc-resultset-empty-cursor-contract`
+
+## Tiers
+
+- Tier 1 Security: PASS
+- Tier 4 Code correctness: PASS
+- Tier 5 Tests: PASS
+- Tier 6 Documentation: PASS
+- Tier 7 Evidence: PASS
+
+## Findings
+
+- P0: 0
+- P1: 0
+- P2/P3: 0
+
+## Evidence
+
+- `ResultSet.isEmptyByMovingCursor()` and `ResultSet.isNotEmptyByMovingCursor()` now make the destructive cursor movement part of the API name.
+- Existing `ResultSet.isEmpty()` and `ResultSet.isNotEmpty()` remain binary-compatible shims but are deprecated with replacement guidance.
+- KDoc now states that the helpers call `ResultSet.next()` exactly once and leave non-empty results positioned on the first row.
+- English and Korean JDBC README examples now use the explicit cursor-moving helper names and document the first-row position.
+- Regression proof before the fix: targeted `:bluetape4k-jdbc:test` failed in `compileTestKotlin` because the explicit cursor-moving helper names did not exist.
+- Validation after the fix: `./gradlew :bluetape4k-jdbc:cleanTest :bluetape4k-jdbc:compileKotlin :bluetape4k-jdbc:compileTestKotlin :bluetape4k-jdbc:test --no-build-cache` passed with 119 tests.
+- `git diff --check` passed.
+
+## Notes
+
+Forward-only JDBC result sets cannot provide a general safe peek without
+buffering or changing the caller's consumption model. This fix keeps the old
+behavior available but makes intentional cursor movement explicit at the API and
+documentation boundary.


### PR DESCRIPTION
## Summary

Closes #819

- PR 제목: fix: make ResultSet empty checks explicit

- Add `ResultSet.isEmptyByMovingCursor()` and `ResultSet.isNotEmptyByMovingCursor()` so cursor movement is explicit in the API name.
- Deprecate ambiguous `ResultSet.isEmpty()` and `ResultSet.isNotEmpty()` while keeping binary-compatible shims with replacement guidance.
- Update KDoc and English/Korean JDBC README examples to explain that the helpers call `ResultSet.next()` and position non-empty results on the first row.
- Add regression coverage for first-row handling after the emptiness check.

### 원문 선행 내용

Closes #819

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

Closes #819

### Summary

- Add `ResultSet.isEmptyByMovingCursor()` and `ResultSet.isNotEmptyByMovingCursor()` so cursor movement is explicit in the API name.
- Deprecate ambiguous `ResultSet.isEmpty()` and `ResultSet.isNotEmpty()` while keeping binary-compatible shims with replacement guidance.
- Update KDoc and English/Korean JDBC README examples to explain that the helpers call `ResultSet.next()` and position non-empty results on the first row.
- Add regression coverage for first-row handling after the emptiness check.

### Validation

- Regression before fix: targeted `:bluetape4k-jdbc:test` failed in `compileTestKotlin` because the explicit cursor-moving helper names did not exist.
- `./gradlew :bluetape4k-jdbc:test --tests 'io.bluetape4k.jdbc.sql.ResultSetExtensionsTest' --no-build-cache` passed.
- `./gradlew :bluetape4k-jdbc:cleanTest :bluetape4k-jdbc:compileKotlin :bluetape4k-jdbc:compileTestKotlin :bluetape4k-jdbc:test --no-build-cache` passed with 119 tests.
- `git diff --check` passed.
- GitHub PR checks passed: Build, CI Status, Coverage Report, Secret Scan, Validate Gradle Wrapper, Detect changed modules, submit-gradle.

### Review

- Local review artifact: `docs/review/2026-06-26-issue-819-jdbc-resultset-empty-cursor-review.md`.
- Findings: P0=0, P1=0.
- Formal PR review comment submitted with P0/P1=0.

### DoD Status

- [x] Issue #819 behavior fixed.
- [x] Cursor-moving ResultSet emptiness helpers added and ambiguous old names deprecated.
- [x] Regression tests cover cursor position and first-row handling after an emptiness check.
- [x] JDBC README and Korean README document the cursor movement contract.
- [x] Local and GitHub validation passed.
- [x] PR metadata mirrors issue #819 assignee, milestone, and labels.

## Validation

- Regression before fix: targeted `:bluetape4k-jdbc:test` failed in `compileTestKotlin` because the explicit cursor-moving helper names did not exist.
- `./gradlew :bluetape4k-jdbc:test --tests 'io.bluetape4k.jdbc.sql.ResultSetExtensionsTest' --no-build-cache` passed.
- `./gradlew :bluetape4k-jdbc:cleanTest :bluetape4k-jdbc:compileKotlin :bluetape4k-jdbc:compileTestKotlin :bluetape4k-jdbc:test --no-build-cache` passed with 119 tests.
- `git diff --check` passed.
- GitHub PR checks passed: Build, CI Status, Coverage Report, Secret Scan, Validate Gradle Wrapper, Detect changed modules, submit-gradle.

## Review Notes

- Local review artifact: `docs/review/2026-06-26-issue-819-jdbc-resultset-empty-cursor-review.md`.
- Findings: P0=0, P1=0.
- Formal PR review comment submitted with P0/P1=0.

## Metadata

- Issue: #819, milestone `1.11.0`, assignee `debop`
- PR: #904, head `5e2412d08dfac2e70ebdf38543e1c322ee43a9bd`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/jdbc-resultset-empty-cursor-contract`
- Labels: `bug`
- State: `MERGED`, merge commit `96c4a56e891880384a31d9db55dfbe63747aa0e8`
- CI: - Add `ResultSet.isEmptyByMovingCursor()` and `ResultSet.isNotEmptyByMovingCursor()` so cursor movement is explicit in the API name. / - Regression before fix: targeted `:bluetape4k-jdbc:test` failed in `compileTestKotlin` because the explicit cursor-moving helper names did not exist. / - `./gradlew :bluetape4k-jdbc:test --tests 'io.bluetape4k.jdbc.sql.ResultSetExtensionsTest' --no-build-cache` passed.

## DoD Status

- [x] Issue #819 behavior fixed.
- [x] Cursor-moving ResultSet emptiness helpers added and ambiguous old names deprecated.
- [x] Regression tests cover cursor position and first-row handling after an emptiness check.
- [x] JDBC README and Korean README document the cursor movement contract.
- [x] Local and GitHub validation passed.
- [x] PR metadata mirrors issue #819 assignee, milestone, and labels.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #904 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `96c4a56e891880384a31d9db55dfbe63747aa0e8`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
