### PR TITLE
fix: reject inconsistent JDBC batch rows

### DIFF
--- a/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/PreparedStatementExtensions.kt
+++ b/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/PreparedStatementExtensions.kt
@@ -97,8 +97,22 @@ inline fun <T> java.sql.Connection.executeUpdateWithGeneratedKeys(
         stmt.generatedKeys.use(keyMapper)
     }
 
+private fun List<List<Any?>>.requireConsistentBatchParameterRows() {
+    val expectedSize = firstOrNull()?.size ?: return
+
+    forEachIndexed { rowIndex, params ->
+        require(params.size == expectedSize) {
+            "Inconsistent batch parameter row size at row $rowIndex: expected $expectedSize parameters but was ${params.size}."
+        }
+    }
+}
+
 /**
- * SQL 업데이트를 PreparedStatement로 배치 실행합니다.
+ * Executes a SQL update as prepared-statement batches.
+ *
+ * All parameter rows must have the same number of values. Inconsistent rows fail
+ * before a statement is prepared, which prevents shorter rows from reusing
+ * values bound by previous rows.
  *
  * ```kotlin
  * val batchSize = 1000
@@ -111,10 +125,10 @@ inline fun <T> java.sql.Connection.executeUpdateWithGeneratedKeys(
  * )
  * ```
  *
- * @param sql 실행할 SQL 쿼리
- * @param paramsList 각 배치 항목의 파라미터 리스트들
- * @param batchSize 배치 크기 (기본값: 1000)
- * @return 각 배치 실행의 결과 배열들의 리스트
+ * @param sql SQL statement to execute.
+ * @param paramsList parameter rows for each batch item.
+ * @param batchSize maximum number of rows to execute per JDBC batch.
+ * @return result arrays for each executed batch.
  */
 fun java.sql.Connection.executeBatch(
     sql: String,
@@ -122,11 +136,13 @@ fun java.sql.Connection.executeBatch(
     batchSize: Int = 1000,
 ): List<IntArray> {
     if (paramsList.isEmpty()) return emptyList()
+    paramsList.requireConsistentBatchParameterRows()
 
     return prepareStatement(sql).use { stmt ->
         val results = mutableListOf<IntArray>()
 
         paramsList.forEachIndexed { index, params ->
+            stmt.clearParameters()
             params.forEachIndexed { paramIndex, param ->
                 stmt.setObject(paramIndex + 1, param)
             }
@@ -149,9 +165,11 @@ fun java.sql.Connection.executeBatch(
 }
 
 /**
- * SQL 업데이트를 PreparedStatement로 대량 실행합니다.
+ * Executes a SQL update as prepared-statement large batches.
  *
- * 이 함수는 executeBatch를 래핑하여 단일 결과 배열을 반환합니다.
+ * All parameter rows must have the same number of values. Inconsistent rows fail
+ * before a statement is prepared, which prevents shorter rows from reusing
+ * values bound by previous rows.
  *
  * ```kotlin
  * val paramsList = listOf(
@@ -166,10 +184,10 @@ fun java.sql.Connection.executeBatch(
  * )
  * ```
  *
- * @param sql 실행할 SQL 쿼리
- * @param paramsList 각 배치 항목의 파라미터 리스트들
- * @param batchSize 배치 크기 (기본값: 1000)
- * @return 모든 배치 실행의 결과를 합친 배열
+ * @param sql SQL statement to execute.
+ * @param paramsList parameter rows for each batch item.
+ * @param batchSize maximum number of rows to execute per JDBC batch.
+ * @return combined result array for all executed batches.
  */
 fun java.sql.Connection.executeLargeBatch(
     sql: String,
@@ -177,11 +195,13 @@ fun java.sql.Connection.executeLargeBatch(
     batchSize: Int = 1000,
 ): LongArray {
     if (paramsList.isEmpty()) return LongArray(0)
+    paramsList.requireConsistentBatchParameterRows()
 
     return prepareStatement(sql).use { stmt ->
         val results = mutableListOf<Long>()
 
         paramsList.forEachIndexed { index, params ->
+            stmt.clearParameters()
             params.forEachIndexed { paramIndex, param ->
                 stmt.setObject(paramIndex + 1, param)
             }

--- a/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/sql/DataSourceTransactionExtensionsTest.kt
+++ b/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/sql/DataSourceTransactionExtensionsTest.kt
@@ -219,6 +219,28 @@ class DataSourceTransactionExtensionsTest: AbstractJdbcSqlTest() {
         results shouldBeEqualTo emptyList()
     }
 
+    @Test
+    fun `DataSource executeBatch - inconsistent parameter rows fail fast`() {
+        assertFailsWith<IllegalArgumentException> {
+            dataSource.executeBatch(
+                "INSERT INTO Actors (firstname, lastname) VALUES (?, ?)",
+                listOf(
+                    listOf("BatchMismatch1", "Actor"),
+                    listOf("BatchMismatch2")
+                )
+            )
+        }
+
+        val count =
+            dataSource.runQuery(
+                "SELECT COUNT(*) FROM Actors WHERE firstname LIKE 'BatchMismatch%'"
+            ) { rs ->
+                rs.next()
+                rs.getInt(1)
+            }
+        count shouldBeEqualTo 0
+    }
+
     // ─── executeLargeBatch ────────────────────────────────────────────────────
 
     @Test
@@ -243,5 +265,27 @@ class DataSourceTransactionExtensionsTest: AbstractJdbcSqlTest() {
                 rs.getInt(1)
             }
         count shouldBeEqualTo 5
+    }
+
+    @Test
+    fun `DataSource executeLargeBatch - inconsistent parameter rows fail fast`() {
+        assertFailsWith<IllegalArgumentException> {
+            dataSource.executeLargeBatch(
+                "INSERT INTO Actors (firstname, lastname) VALUES (?, ?)",
+                listOf(
+                    listOf("LargeBatchMismatch1", "Actor"),
+                    listOf("LargeBatchMismatch2")
+                )
+            )
+        }
+
+        val count =
+            dataSource.runQuery(
+                "SELECT COUNT(*) FROM Actors WHERE firstname LIKE 'LargeBatchMismatch%'"
+            ) { rs ->
+                rs.next()
+                rs.getInt(1)
+            }
+        count shouldBeEqualTo 0
     }
 }

--- a/docs/lessons/2026-06-26-issue-818-jdbc-batch-parameter-rows.md
+++ b/docs/lessons/2026-06-26-issue-818-jdbc-batch-parameter-rows.md
@@ -1,0 +1,25 @@
+# Lessons Learned - JDBC Batch Parameter Rows (2026-06-26)
+
+**Issue**: #818
+**Module**: `:bluetape4k-jdbc`
+
+## L1: Batch row shape must be validated before binding
+
+### Problem
+
+JDBC `PreparedStatement` keeps parameter state across batch additions. When a
+later row had fewer values than an earlier row, the shorter row could reuse a
+stale value and insert corrupted data instead of failing.
+
+### Lesson
+
+List-based batch helpers must validate parameter row shape before preparing or
+executing a statement, then clear statement parameters before binding each row.
+Do not rely on the driver to catch short rows after previous values have already
+been bound.
+
+### Future Guard
+
+When changing JDBC batch helpers, include a regression with a later row that has
+fewer parameters and assert both fail-fast behavior and zero persisted rows for
+the attempted batch.

--- a/docs/review/2026-06-26-issue-818-jdbc-batch-parameter-rows-review.md
+++ b/docs/review/2026-06-26-issue-818-jdbc-batch-parameter-rows-review.md
@@ -1,0 +1,35 @@
+# Review - Issue 818 JDBC Batch Parameter Rows (2026-06-26)
+
+**Scope**: `:bluetape4k-jdbc`
+**Issue**: #818
+**Branch**: `fix/jdbc-batch-parameter-row-validation`
+
+## Tiers
+
+- Tier 1 Security: PASS
+- Tier 4 Code correctness: PASS
+- Tier 5 Tests: PASS
+- Tier 7 Evidence: PASS
+
+## Findings
+
+- P0: 0
+- P1: 0
+- P2/P3: 0
+
+## Evidence
+
+- `Connection.executeBatch` now validates that every parameter row has the same width before preparing a statement.
+- `Connection.executeLargeBatch` applies the same validation path as `executeBatch`.
+- Both batch helpers call `clearParameters()` before binding each row, so driver state from a previous row cannot be reused.
+- Regression proof before the fix: `DataSource executeBatch - inconsistent parameter rows fail fast` and `DataSource executeLargeBatch - inconsistent parameter rows fail fast` failed because no `IllegalArgumentException` was thrown.
+- Stale-binding proof before the fix: the failed `executeBatch` regression inserted corrupted `BatchMismatch%` rows and made the existing batch-count test fail with `Expected <7> to equal to <3>, but was not.`
+- Validation after the fix: `./gradlew :bluetape4k-jdbc:test --tests 'io.bluetape4k.jdbc.sql.DataSourceTransactionExtensionsTest' --no-build-cache` passed with 13 tests.
+- Module validation after the fix: `./gradlew :bluetape4k-jdbc:cleanTest :bluetape4k-jdbc:compileKotlin :bluetape4k-jdbc:compileTestKotlin :bluetape4k-jdbc:test --no-build-cache` passed with 121 tests.
+- `git diff --check` passed.
+
+## Notes
+
+The validation intentionally checks row-to-row consistency instead of parsing SQL
+placeholders. JDBC drivers still own SQL placeholder validation, while these
+helpers prevent stale bound values from being carried into shorter rows.


### PR DESCRIPTION
## Summary

Closes #818

- PR 제목: fix: reject inconsistent JDBC batch rows

- Fixes #818.
- Validate JDBC batch parameter rows before preparing a statement so inconsistent row widths fail fast.
- Clear `PreparedStatement` parameters before binding each batch row for both `executeBatch` and `executeLargeBatch`.
- Add regression coverage for a later row with fewer parameters and verify no attempted rows are persisted.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

- Fixes #818.
- Validate JDBC batch parameter rows before preparing a statement so inconsistent row widths fail fast.
- Clear `PreparedStatement` parameters before binding each batch row for both `executeBatch` and `executeLargeBatch`.
- Add regression coverage for a later row with fewer parameters and verify no attempted rows are persisted.

### Review Notes

- Row consistency is validated at the list API boundary instead of parsing SQL placeholders; JDBC drivers still validate the SQL itself.
- `clearParameters()` is retained even after fail-fast validation to keep driver parameter state isolated per row.
- Public KDoc for the touched batch helpers now documents the row-width contract in English.

### Validation

- Regression before fix: targeted tests failed because no `IllegalArgumentException` was thrown for short later rows; H2 reused stale values and polluted the existing batch-count assertion (`Expected <7> to equal to <3>, but was not.`).
- `./gradlew :bluetape4k-jdbc:test --tests 'io.bluetape4k.jdbc.sql.DataSourceTransactionExtensionsTest' --no-build-cache` passed with 13 tests.
- `./gradlew :bluetape4k-jdbc:cleanTest :bluetape4k-jdbc:compileKotlin :bluetape4k-jdbc:compileTestKotlin :bluetape4k-jdbc:test --no-build-cache` passed with 121 tests.
- `git diff --check` passed.
- GitHub PR checks passed: Build, CI Status, Coverage Report, Detect changed modules, Secret Scan (gitleaks), Validate Gradle Wrapper, and submit-gradle.

### DoD Status

- [x] Issue metadata mirrored: assignee `debop`, milestone `1.11.0`, label `bug`.
- [x] `executeBatch` rejects inconsistent parameter row widths before execution.
- [x] `executeLargeBatch` rejects inconsistent parameter row widths before execution.
- [x] Statement parameters are cleared before each row bind.
- [x] Regression tests cover shorter later rows and assert zero persisted attempted rows.
- [x] Review note and lesson artifact added under `docs/`.
- [x] GitHub PR checks passed.

## Validation

- Regression before fix: targeted tests failed because no `IllegalArgumentException` was thrown for short later rows; H2 reused stale values and polluted the existing batch-count assertion (`Expected <7> to equal to <3>, but was not.`).
- `./gradlew :bluetape4k-jdbc:test --tests 'io.bluetape4k.jdbc.sql.DataSourceTransactionExtensionsTest' --no-build-cache` passed with 13 tests.
- `./gradlew :bluetape4k-jdbc:cleanTest :bluetape4k-jdbc:compileKotlin :bluetape4k-jdbc:compileTestKotlin :bluetape4k-jdbc:test --no-build-cache` passed with 121 tests.
- `git diff --check` passed.
- GitHub PR checks passed: Build, CI Status, Coverage Report, Detect changed modules, Secret Scan (gitleaks), Validate Gradle Wrapper, and submit-gradle.

## Review Notes

- Row consistency is validated at the list API boundary instead of parsing SQL placeholders; JDBC drivers still validate the SQL itself.
- `clearParameters()` is retained even after fail-fast validation to keep driver parameter state isolated per row.
- Public KDoc for the touched batch helpers now documents the row-width contract in English.

## Metadata

- Issue: #818, milestone `1.11.0`, assignee `debop`
- PR: #905, head `d3f64a4d3a9b00ff8ec871f5715e1c205361b2b6`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/jdbc-batch-parameter-row-validation`
- Labels: `bug`
- State: `MERGED`, merge commit `b8b31d565224a07c07c0268f542719bb650f4fcb`
- CI: - `./gradlew :bluetape4k-jdbc:test --tests 'io.bluetape4k.jdbc.sql.DataSourceTransactionExtensionsTest' --no-build-cache` passed with 13 tests. / - `./gradlew :bluetape4k-jdbc:cleanTest :bluetape4k-jdbc:compileKotlin :bluetape4k-jdbc:compileTestKotlin :bluetape4k-jdbc:test --no-build-cache` passed with 121 tests. / - GitHub PR checks passed: Build, CI Status, Coverage Report, Detect changed modules, Secret Scan (gitleaks), Validate Gradle Wrapper, and submit-gradle.

## DoD Status

- [x] Issue metadata mirrored: assignee `debop`, milestone `1.11.0`, label `bug`.
- [x] `executeBatch` rejects inconsistent parameter row widths before execution.
- [x] `executeLargeBatch` rejects inconsistent parameter row widths before execution.
- [x] Statement parameters are cleared before each row bind.
- [x] Regression tests cover shorter later rows and assert zero persisted attempted rows.
- [x] Review note and lesson artifact added under `docs/`.
- [x] GitHub PR checks passed.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #905 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `b8b31d565224a07c07c0268f542719bb650f4fcb`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
