### PR TITLE
fix: preserve JDBC transaction state

### DIFF
--- a/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/TransactionExtensions.kt
+++ b/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/TransactionExtensions.kt
@@ -1,35 +1,32 @@
 package io.bluetape4k.jdbc.sql
 
-import io.bluetape4k.logging.KotlinLogging
-import io.bluetape4k.logging.warn
 import java.sql.Connection
 import java.sql.SQLException
 
-@PublishedApi
-internal val log = KotlinLogging.logger {}
-
 /**
- * 데이터베이스 트랜잭션을 실행합니다.
+ * Executes [block] inside a JDBC transaction.
  *
- * 이 함수는 자동으로 트랜잭션을 시작하고, 블록 실행이 성공하면 커밋하고,
- * 예외가 발생하면 롤백합니다. 마지막에는 Connection을 자동으로 닫습니다.
+ * The connection's `autoCommit`, isolation level, and read-only flag are restored
+ * independently to their original values. Any [Throwable] from the block or
+ * commit path triggers rollback and is rethrown unchanged. Rollback or restore
+ * failures are attached as suppressed exceptions to the primary failure.
  *
- * [CancellationException][kotlinx.coroutines.CancellationException]은 catch 없이 그대로 전파됩니다.
- * rollback/상태복원 실패는 원래 예외에 suppressed로 기록하여 무시하지 않습니다.
+ * If the block and commit succeed but state restoration fails, the restore
+ * failure is thrown instead of returning a successful result.
  *
  * ```kotlin
  * dataSource.withTransaction { conn ->
  *     conn.executeUpdate("INSERT INTO users (name) VALUES ('Alice')")
  *     conn.executeUpdate("INSERT INTO logs (message) VALUES ('User created')")
- *     // 모든 작업이 성공하면 자동으로 커밋됩니다.
+ *     // Commits automatically when all operations succeed.
  * }
  * ```
  *
- * @param T 결과 타입
- * @param isolationLevel 트랜잭션 격리 수준 (기본값: [Connection.TRANSACTION_READ_COMMITTED])
- * @param block 트랜잭션 내에서 실행할 코드 블록
- * @return 블록의 실행 결과
- * @throws SQLException 트랜잭션 실행 중 오류 발생 시
+ * @param T result type.
+ * @param isolationLevel transaction isolation level to use while running [block].
+ * @param block code to execute in the transaction.
+ * @return result returned by [block].
+ * @throws SQLException when JDBC transaction, rollback, or restore operations fail.
  */
 inline fun <T> Connection.withTransaction(
     isolationLevel: Int = Connection.TRANSACTION_READ_COMMITTED,
@@ -37,6 +34,8 @@ inline fun <T> Connection.withTransaction(
 ): T {
     val originalAutoCommit = this.autoCommit
     val originalIsolationLevel = this.transactionIsolation
+    val originalReadOnly = this.isReadOnly
+    var primaryFailure: Throwable? = null
 
     return try {
         this.autoCommit = false
@@ -45,29 +44,34 @@ inline fun <T> Connection.withTransaction(
         val result = block(this)
         this.commit()
         result
-    } catch (e: Exception) {
+    } catch (e: Throwable) {
+        primaryFailure = e
         try {
             this.rollback()
-        } catch (rollbackEx: SQLException) {
-            // 롤백 실패 시 원래 예외에 추가 정보로 기록하여 무시하지 않음
+        } catch (rollbackEx: Throwable) {
             e.addSuppressed(rollbackEx)
         }
         throw e
     } finally {
-        // 원래 상태로 복원 실패 시에도 로그를 남겨 무시하지 않음
-        try {
-            this.autoCommit = originalAutoCommit
-            this.transactionIsolation = originalIsolationLevel
-        } catch (e: SQLException) {
-            log.warn(e) { "트랜잭션 상태 복원 실패 (autoCommit=$originalAutoCommit, isolationLevel=$originalIsolationLevel)" }
+        val restoreFailure =
+            restoreTransactionState(
+                originalAutoCommit = originalAutoCommit,
+                originalIsolationLevel = originalIsolationLevel,
+                originalReadOnly = originalReadOnly,
+            )
+
+        if (restoreFailure != null) {
+            primaryFailure?.addSuppressed(restoreFailure) ?: throw restoreFailure
         }
     }
 }
 
 /**
- * 읽기 전용 트랜잭션을 실행합니다.
+ * Executes [block] inside a read-only JDBC transaction.
  *
- * 이 함수는 읽기 작업에 최적화된 설정으로 트랜잭션을 실행합니다.
+ * The connection's original read-only flag is restored by [withTransaction], so
+ * callers that provide an already read-only connection keep that state after the
+ * transaction finishes.
  *
  * ```kotlin
  * val users = dataSource.withReadOnlyTransaction { conn ->
@@ -77,10 +81,10 @@ inline fun <T> Connection.withTransaction(
  * }
  * ```
  *
- * @param T 결과 타입
- * @param isolationLevel 트랜잭션 격리 수준 (기본값: [Connection.TRANSACTION_READ_COMMITTED])
- * @param block 트랜잭션 내에서 실행할 코드 블록
- * @return 블록의 실행 결과
+ * @param T result type.
+ * @param isolationLevel transaction isolation level to use while running [block].
+ * @param block code to execute in the read-only transaction.
+ * @return result returned by [block].
  */
 inline fun <T> Connection.withReadOnlyTransaction(
     isolationLevel: Int = Connection.TRANSACTION_READ_COMMITTED,
@@ -88,12 +92,46 @@ inline fun <T> Connection.withReadOnlyTransaction(
 ): T =
     withTransaction(isolationLevel) { conn ->
         conn.isReadOnly = true
-        try {
-            block(conn)
-        } finally {
-            conn.isReadOnly = false
+        block(conn)
+    }
+
+@PublishedApi
+internal fun Connection.restoreTransactionState(
+    originalAutoCommit: Boolean,
+    originalIsolationLevel: Int,
+    originalReadOnly: Boolean,
+): Throwable? {
+    var failure: Throwable? = null
+
+    fun recordFailure(restoreFailure: Throwable) {
+        val current = failure
+        if (current == null) {
+            failure = restoreFailure
+        } else {
+            current.addSuppressed(restoreFailure)
         }
     }
+
+    try {
+        this.autoCommit = originalAutoCommit
+    } catch (e: Throwable) {
+        recordFailure(e)
+    }
+
+    try {
+        this.transactionIsolation = originalIsolationLevel
+    } catch (e: Throwable) {
+        recordFailure(e)
+    }
+
+    try {
+        this.isReadOnly = originalReadOnly
+    } catch (e: Throwable) {
+        recordFailure(e)
+    }
+
+    return failure
+}
 
 /**
  * 지정된 격리 수준으로 트랜잭션을 실행합니다.

--- a/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/sql/TransactionExtensionsTest.kt
+++ b/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/sql/TransactionExtensionsTest.kt
@@ -1,13 +1,18 @@
 package io.bluetape4k.jdbc.sql
 
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
 import io.bluetape4k.assertions.assertFailsWith
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
 import java.sql.Connection
+import java.sql.SQLException
 
 /**
  * TransactionExtensions 테스트 클래스
@@ -69,6 +74,91 @@ class TransactionExtensionsTest: AbstractJdbcSqlTest() {
                 }
             count shouldBeGreaterThan 0
         }
+    }
+
+    @Test
+    fun `withReadOnlyTransaction restores pre existing readOnly state`() {
+        val recording = RecordingConnection(readOnly = true)
+
+        val result =
+            recording.connection.withReadOnlyTransaction { conn ->
+                conn.isReadOnly.shouldBeTrue()
+                "read-only"
+            }
+
+        result shouldBeEqualTo "read-only"
+        recording.readOnly.shouldBeTrue()
+    }
+
+    @Test
+    fun `withTransaction rolls back non Exception throwables`() {
+        val recording = RecordingConnection()
+        val failure = AssertionError("boom")
+
+        val thrown =
+            assertFailsWith<AssertionError> {
+                recording.connection.withTransaction {
+                    throw failure
+                }
+            }
+
+        thrown shouldBeEqualTo failure
+        recording.calls shouldContain "rollback"
+    }
+
+    @Test
+    fun `withTransaction restores pre existing autoCommit false and isolation state`() {
+        val recording =
+            RecordingConnection(
+                autoCommit = false,
+                isolation = Connection.TRANSACTION_SERIALIZABLE,
+            )
+
+        recording.connection.withTransaction { conn ->
+            conn.autoCommit.shouldBeFalse()
+            conn.transactionIsolation shouldBeEqualTo Connection.TRANSACTION_READ_COMMITTED
+        }
+
+        recording.autoCommit.shouldBeFalse()
+        recording.isolation shouldBeEqualTo Connection.TRANSACTION_SERIALIZABLE
+    }
+
+    @Test
+    fun `withTransaction suppresses restore failures on primary failure and restores independently`() {
+        val restoreFailure = SQLException("restore autoCommit")
+        val recording =
+            RecordingConnection(
+                isolation = Connection.TRANSACTION_SERIALIZABLE,
+                readOnly = true,
+                failRestoringAutoCommit = restoreFailure,
+            )
+        val primaryFailure = RuntimeException("primary")
+
+        val thrown =
+            assertFailsWith<RuntimeException> {
+                recording.connection.withTransaction { conn ->
+                    conn.isReadOnly = false
+                    throw primaryFailure
+                }
+            }
+
+        thrown shouldBeEqualTo primaryFailure
+        thrown.suppressed.toList() shouldContain restoreFailure
+        recording.calls shouldContain "setTransactionIsolation(${Connection.TRANSACTION_SERIALIZABLE})"
+        recording.calls shouldContain "setReadOnly(true)"
+    }
+
+    @Test
+    fun `withTransaction surfaces restore failure after successful commit`() {
+        val restoreFailure = SQLException("restore autoCommit")
+        val recording = RecordingConnection(failRestoringAutoCommit = restoreFailure)
+
+        val thrown =
+            assertFailsWith<SQLException> {
+                recording.connection.withTransaction {}
+            }
+
+        thrown shouldBeEqualTo restoreFailure
     }
 
     @Test
@@ -171,4 +261,102 @@ class TransactionExtensionsTest: AbstractJdbcSqlTest() {
             }
         count shouldBeEqualTo 0
     }
+}
+
+private class RecordingConnection(
+    autoCommit: Boolean = true,
+    isolation: Int = Connection.TRANSACTION_READ_COMMITTED,
+    readOnly: Boolean = false,
+    private val failRestoringAutoCommit: SQLException? = null,
+    private val failRestoringIsolation: SQLException? = null,
+    private val failRestoringReadOnly: SQLException? = null,
+    private val rollbackFailure: SQLException? = null,
+): InvocationHandler {
+
+    private val originalAutoCommit = autoCommit
+    private val originalIsolation = isolation
+    private val originalReadOnly = readOnly
+
+    var autoCommit: Boolean = autoCommit
+        private set
+    var isolation: Int = isolation
+        private set
+    var readOnly: Boolean = readOnly
+        private set
+
+    val calls = mutableListOf<String>()
+
+    val connection: Connection =
+        Proxy.newProxyInstance(
+            Connection::class.java.classLoader,
+            arrayOf(Connection::class.java),
+            this,
+        ) as Connection
+
+    override fun invoke(proxy: Any, method: Method, args: Array<Any?>?): Any? {
+        val arguments = args ?: emptyArray()
+
+        return when (method.name) {
+            "getAutoCommit" -> autoCommit
+            "setAutoCommit" -> {
+                val value = arguments[0] as Boolean
+                val isRestore = calls.any { it.startsWith("setAutoCommit") } && value == originalAutoCommit
+                calls.add("setAutoCommit($value)")
+                if (isRestore) failRestoringAutoCommit?.let { throw it }
+                autoCommit = value
+                null
+            }
+            "getTransactionIsolation" -> isolation
+            "setTransactionIsolation" -> {
+                val value = arguments[0] as Int
+                val isRestore =
+                    calls.any { it.startsWith("setTransactionIsolation") } && value == originalIsolation
+                calls.add("setTransactionIsolation($value)")
+                if (isRestore) failRestoringIsolation?.let { throw it }
+                isolation = value
+                null
+            }
+            "isReadOnly" -> readOnly
+            "setReadOnly" -> {
+                val value = arguments[0] as Boolean
+                val isRestore = calls.any { it.startsWith("setReadOnly") } && value == originalReadOnly
+                calls.add("setReadOnly($value)")
+                if (isRestore) failRestoringReadOnly?.let { throw it }
+                readOnly = value
+                null
+            }
+            "commit" -> {
+                calls.add("commit")
+                null
+            }
+            "rollback" -> {
+                calls.add("rollback")
+                rollbackFailure?.let { throw it }
+                null
+            }
+            "close" -> {
+                calls.add("close")
+                null
+            }
+            "isClosed" -> false
+            "toString" -> "RecordingConnection"
+            "hashCode" -> System.identityHashCode(proxy)
+            "equals" -> proxy === arguments[0]
+            else -> defaultValue(method.returnType)
+        }
+    }
+
+    private fun defaultValue(returnType: Class<*>): Any? =
+        when (returnType) {
+            Boolean::class.javaPrimitiveType -> false
+            Byte::class.javaPrimitiveType -> 0.toByte()
+            Short::class.javaPrimitiveType -> 0.toShort()
+            Int::class.javaPrimitiveType -> 0
+            Long::class.javaPrimitiveType -> 0L
+            Float::class.javaPrimitiveType -> 0F
+            Double::class.javaPrimitiveType -> 0.0
+            Char::class.javaPrimitiveType -> '\u0000'
+            Void.TYPE -> null
+            else -> null
+        }
 }

--- a/docs/lessons/2026-06-26-issue-817-jdbc-transaction-state.md
+++ b/docs/lessons/2026-06-26-issue-817-jdbc-transaction-state.md
@@ -1,0 +1,27 @@
+# Lessons Learned - JDBC Transaction State (2026-06-26)
+
+**Issue**: #817
+**Module**: `:bluetape4k-jdbc`
+
+## L1: Transaction helpers must not hide restoration failures
+
+### Problem
+
+`withTransaction` restored state in one logged-and-swallowed block and caught
+only `Exception`. That allowed non-`Exception` failures to skip rollback and
+allowed restore failures to be reported as success. `withReadOnlyTransaction`
+also reset read-only mode to `false` instead of restoring the caller's original
+state.
+
+### Lesson
+
+Transaction helpers must treat rollback and state restoration as part of the
+public contract. Capture all caller-owned connection flags, roll back for all
+transaction-aborting `Throwable` paths, restore each state field independently,
+and attach secondary failures as suppressed exceptions.
+
+### Future Guard
+
+When changing JDBC transaction helpers, include deterministic connection-proxy
+tests for `autoCommit=false`, pre-existing read-only state, non-`Exception`
+rollback, primary-failure suppression, and success-path restore failure.

--- a/docs/review/2026-06-26-issue-817-jdbc-transaction-state-review.md
+++ b/docs/review/2026-06-26-issue-817-jdbc-transaction-state-review.md
@@ -1,0 +1,36 @@
+# Review - Issue 817 JDBC Transaction State (2026-06-26)
+
+**Scope**: `:bluetape4k-jdbc`
+**Issue**: #817
+**Branch**: `fix/jdbc-transaction-state-rollback`
+
+## Tiers
+
+- Tier 1 Security: PASS
+- Tier 4 Code correctness: PASS
+- Tier 5 Tests: PASS
+- Tier 7 Evidence: PASS
+
+## Findings
+
+- P0: 0
+- P1: 0
+- P2/P3: 0
+
+## Evidence
+
+- `Connection.withTransaction` now captures and restores `autoCommit`, isolation, and read-only state.
+- Transaction state restoration runs each property independently, so one restore failure does not skip the remaining properties.
+- Non-`Exception` `Throwable` failures now trigger rollback and are rethrown unchanged.
+- Rollback failures and restore failures after a primary failure are attached as suppressed exceptions.
+- Restore failure after a successful block and commit is surfaced instead of returning success.
+- `withReadOnlyTransaction` no longer resets read-only state to `false`; it relies on `withTransaction` to restore the caller's original state.
+- Regression proof before the fix: targeted `TransactionExtensionsTest` failed for read-only restoration, non-`Exception` rollback, suppressed restore failure, and success-path restore failure.
+- Validation after the fix: `./gradlew :bluetape4k-jdbc:cleanTest :bluetape4k-jdbc:compileKotlin :bluetape4k-jdbc:compileTestKotlin :bluetape4k-jdbc:test --no-build-cache` passed with 126 tests and no Kotlin warnings.
+- `git diff --check` passed.
+
+## Notes
+
+The tests use a small `Connection` proxy instead of a driver-specific fake so
+restore failures and `Error` paths are deterministic without introducing a new
+test dependency.


### PR DESCRIPTION
## Summary

Closes #817

- PR 제목: fix: preserve JDBC transaction state

- Fixes #817.
- Restore `autoCommit`, isolation, and read-only state independently after `Connection.withTransaction`.
- Roll back for all transaction-aborting `Throwable` paths, including non-`Exception` failures.
- Attach rollback and restore failures as suppressed exceptions on primary failures, and surface restore failures after successful commit.
- Preserve pre-existing read-only state in `withReadOnlyTransaction` instead of resetting it to `false`.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

- Fixes #817.
- Restore `autoCommit`, isolation, and read-only state independently after `Connection.withTransaction`.
- Roll back for all transaction-aborting `Throwable` paths, including non-`Exception` failures.
- Attach rollback and restore failures as suppressed exceptions on primary failures, and surface restore failures after successful commit.
- Preserve pre-existing read-only state in `withReadOnlyTransaction` instead of resetting it to `false`.

### Review Notes

- State restoration is intentionally independent: one failed property restore does not skip the remaining properties.
- `withReadOnlyTransaction` now delegates read-only restoration to `withTransaction`, which has the original state snapshot.
- Regression tests use a lightweight `Connection` proxy to force restore and rollback paths deterministically without adding dependencies.

### Validation

- Regression before fix: targeted `TransactionExtensionsTest` failed for pre-existing read-only restoration, non-`Exception` rollback, suppressed restore failure, and success-path restore failure.
- `./gradlew :bluetape4k-jdbc:cleanTest :bluetape4k-jdbc:compileKotlin :bluetape4k-jdbc:compileTestKotlin :bluetape4k-jdbc:test --no-build-cache` passed with 126 tests and no Kotlin warnings.
- `git diff --check` passed.
- GitHub PR checks passed: Build, CI Status, Coverage Report, Detect changed modules, Secret Scan (gitleaks), Validate Gradle Wrapper, and submit-gradle.

### DoD Status

- [x] Issue metadata mirrored: assignee `debop`, milestone `1.11.0`, label `bug`.
- [x] Rollback runs for non-`Exception` `Throwable` failures.
- [x] `autoCommit=false` caller state is restored.
- [x] Pre-existing read-only state is restored.
- [x] Isolation state is restored independently.
- [x] Restore failures are suppressed on primary failure and surfaced on success.
- [x] Review note and lesson artifact added under `docs/`.
- [x] GitHub PR checks passed.

## Validation

- Regression before fix: targeted `TransactionExtensionsTest` failed for pre-existing read-only restoration, non-`Exception` rollback, suppressed restore failure, and success-path restore failure.
- `./gradlew :bluetape4k-jdbc:cleanTest :bluetape4k-jdbc:compileKotlin :bluetape4k-jdbc:compileTestKotlin :bluetape4k-jdbc:test --no-build-cache` passed with 126 tests and no Kotlin warnings.
- `git diff --check` passed.
- GitHub PR checks passed: Build, CI Status, Coverage Report, Detect changed modules, Secret Scan (gitleaks), Validate Gradle Wrapper, and submit-gradle.

## Review Notes

- State restoration is intentionally independent: one failed property restore does not skip the remaining properties.
- `withReadOnlyTransaction` now delegates read-only restoration to `withTransaction`, which has the original state snapshot.
- Regression tests use a lightweight `Connection` proxy to force restore and rollback paths deterministically without adding dependencies.

## Metadata

- Issue: #817, milestone `1.11.0`, assignee `debop`
- PR: #906, head `368e86267e04b5995dd2209e5daa0ce5e3a9eabc`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/jdbc-transaction-state-rollback`
- Labels: `bug`
- State: `MERGED`, merge commit `86af69c363c470a7bc1c1604f6276826c74c27dd`
- CI: - Regression tests use a lightweight `Connection` proxy to force restore and rollback paths deterministically without adding dependencies. / - `./gradlew :bluetape4k-jdbc:cleanTest :bluetape4k-jdbc:compileKotlin :bluetape4k-jdbc:compileTestKotlin :bluetape4k-jdbc:test --no-build-cache` passed with 126 tests and no Kotlin warnings. / - GitHub PR checks passed: Build, CI Status, Coverage Report, Detect changed modules, Secret Scan (gitleaks), Validate Gradle Wrapper, and submit-gradle.

## DoD Status

- [x] Issue metadata mirrored: assignee `debop`, milestone `1.11.0`, label `bug`.
- [x] Rollback runs for non-`Exception` `Throwable` failures.
- [x] `autoCommit=false` caller state is restored.
- [x] Pre-existing read-only state is restored.
- [x] Isolation state is restored independently.
- [x] Restore failures are suppressed on primary failure and surfaced on success.
- [x] Review note and lesson artifact added under `docs/`.
- [x] GitHub PR checks passed.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #906 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `86af69c363c470a7bc1c1604f6276826c74c27dd`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
