### PR TITLE
fix: require persisted Hibernate encryption keysets

### DIFF
--- a/data/hibernate/README.ko.md
+++ b/data/hibernate/README.ko.md
@@ -395,9 +395,22 @@ class UserData {
 - `AESStringConverter`: AES-256-GCM (비결정적, 매번 다른 암호문)
 - `DeterministicAESStringConverter`: AES-256-SIV (결정적, 동일 평문 → 동일 암호문, WHERE 절 조회 가능)
 
+암호화된 엔티티 필드는 외부에 보존된 Tink key material이 필요합니다. 기본 컨버터는 애플리케이션
+부트스트랩에서 `EncryptedStringConverterKeysets`를 설정하기 전까지 non-null 값을 처리할 때 즉시 실패합니다.
+영속 컬럼에는 프로세스 안에서 새로 생성한 keyset을 사용하지 마세요. 한 keyset으로 저장한 암호문은 재시작 후
+다른 keyset이나 다른 애플리케이션 인스턴스에서 복호화할 수 없습니다.
+
 ```kotlin
 import io.bluetape4k.hibernate.converters.AESStringConverter
 import io.bluetape4k.hibernate.converters.DeterministicAESStringConverter
+import io.bluetape4k.hibernate.converters.EncryptedStringConverterKeysets
+
+fun configureHibernateEncryption() {
+    // 보호된 외부 secret 저장소에서 JSON keyset을 읽어오세요.
+    // cleartext keyset JSON은 암호화 키 자체이므로 커밋하거나 로그로 남기면 안 됩니다.
+    EncryptedStringConverterKeysets.configureAesKeyset(System.getenv("HIBERNATE_AES_GCM_KEYSET_JSON"))
+    EncryptedStringConverterKeysets.configureDeterministicKeyset(System.getenv("HIBERNATE_AES_SIV_KEYSET_JSON"))
+}
 
 @Entity
 class SecureData {

--- a/data/hibernate/README.md
+++ b/data/hibernate/README.md
@@ -394,13 +394,24 @@ class UserData {
 AES encryption converters based on [Google Tink](https://github.com/google/tink).
 
 - `AESStringConverter`: AES-256-GCM (non-deterministic; ciphertext differs each time)
--
+- `DeterministicAESStringConverter`: AES-256-SIV (deterministic; same plaintext → same ciphertext, supports WHERE clause lookups)
 
-`DeterministicAESStringConverter`: AES-256-SIV (deterministic; same plaintext → same ciphertext, supports WHERE clause lookups)
+Encrypted entity fields require externally persisted Tink key material. The built-in converters fail fast for
+non-null values until `EncryptedStringConverterKeysets` has been configured during application bootstrap. Do not use
+process-local generated keysets for persisted columns: ciphertext written with one generated keyset cannot be read
+after restart or by another application instance.
 
 ```kotlin
 import io.bluetape4k.hibernate.converters.AESStringConverter
 import io.bluetape4k.hibernate.converters.DeterministicAESStringConverter
+import io.bluetape4k.hibernate.converters.EncryptedStringConverterKeysets
+
+fun configureHibernateEncryption() {
+    // Load these JSON keysets from a protected external secret store.
+    // Cleartext keyset JSON is secret key material; do not commit it or log it.
+    EncryptedStringConverterKeysets.configureAesKeyset(System.getenv("HIBERNATE_AES_GCM_KEYSET_JSON"))
+    EncryptedStringConverterKeysets.configureDeterministicKeyset(System.getenv("HIBERNATE_AES_SIV_KEYSET_JSON"))
+}
 
 @Entity
 class SecureData {

--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/EncryptedStringConverters.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/EncryptedStringConverters.kt
@@ -1,12 +1,79 @@
 package io.bluetape4k.hibernate.converters
 
 import io.bluetape4k.tink.encrypt.TinkEncryptor
-import io.bluetape4k.tink.encrypt.TinkEncryptors
+import io.bluetape4k.tink.aead.TinkAead
+import io.bluetape4k.tink.daead.TinkDeterministicAead
+import io.bluetape4k.tink.encrypt.TinkAeadEncryptor
+import io.bluetape4k.tink.encrypt.TinkDaeadEncryptor
+import io.bluetape4k.tink.keyset.keysetHandleOf
 import jakarta.persistence.AttributeConverter
 import jakarta.persistence.Converter
+import java.util.concurrent.atomic.AtomicReference
 
 /**
- * 문자열을 암호화해서 문자열로 저장하는 JPA Converter 입니다.
+ * Registry for persistent key material used by Hibernate encrypted string converters.
+ *
+ * Hibernate creates [AttributeConverter] instances with no dependency injection by default, so the built-in
+ * converters resolve their encryptors from this registry at conversion time. Applications must load key material
+ * from an external protected store, such as a secret manager, KMS envelope-encrypted file, or HSM-backed source,
+ * before encrypted entity fields are read or written.
+ *
+ * The JSON keyset helpers expect cleartext Tink keyset JSON. Protect that JSON as secret key material and avoid
+ * embedding it in source code, logs, or plain configuration files.
+ */
+object EncryptedStringConverterKeysets {
+
+    private val aesEncryptor = AtomicReference<TinkEncryptor?>()
+    private val deterministicEncryptor = AtomicReference<TinkEncryptor?>()
+
+    internal fun configureAes(encryptor: TinkEncryptor) {
+        aesEncryptor.set(encryptor)
+    }
+
+    /**
+     * Configures [AESStringConverter] from externally persisted Tink keyset JSON.
+     */
+    @JvmStatic
+    fun configureAesKeyset(jsonKeyset: String) {
+        configureAes(TinkAeadEncryptor(TinkAead(keysetHandleOf(jsonKeyset))))
+    }
+
+    internal fun configureDeterministic(encryptor: TinkEncryptor) {
+        deterministicEncryptor.set(encryptor)
+    }
+
+    /**
+     * Configures [DeterministicAESStringConverter] from externally persisted Tink keyset JSON.
+     */
+    @JvmStatic
+    fun configureDeterministicKeyset(jsonKeyset: String) {
+        configureDeterministic(TinkDaeadEncryptor(TinkDeterministicAead(keysetHandleOf(jsonKeyset))))
+    }
+
+    internal fun requireAesEncryptor(): TinkEncryptor =
+        aesEncryptor.get() ?: error(
+            "AESStringConverter requires externally persisted key material. " +
+                "Call EncryptedStringConverterKeysets.configureAesKeyset(...) during application bootstrap."
+        )
+
+    internal fun requireDeterministicEncryptor(): TinkEncryptor =
+        deterministicEncryptor.get() ?: error(
+            "DeterministicAESStringConverter requires externally persisted key material. " +
+                "Call EncryptedStringConverterKeysets.configureDeterministicKeyset(...) during application bootstrap."
+        )
+
+    internal fun resetForTesting() {
+        aesEncryptor.set(null)
+        deterministicEncryptor.set(null)
+    }
+}
+
+/**
+ * Base JPA converter that stores encrypted strings in a single database column.
+ *
+ * Built-in subclasses fail fast unless [EncryptedStringConverterKeysets] has been configured with externally
+ * persisted key material. This avoids writing ciphertext with process-local generated keys that cannot be decrypted
+ * after restart or by another application instance.
  *
  * ```kotlin
  * @Entity
@@ -21,27 +88,43 @@ import jakarta.persistence.Converter
  * ```
  */
 @Converter
-abstract class EncryptedStringConverter(
-    private val encryptor: TinkEncryptor = TinkEncryptors.DETERMINISTIC_AES256_SIV,
+abstract class EncryptedStringConverter protected constructor(
+    private val encryptorProvider: () -> TinkEncryptor,
 ): AttributeConverter<String?, String?> {
 
     override fun convertToDatabaseColumn(attribute: String?): String? {
-        return attribute?.run { encryptor.encrypt(this) }
+        return attribute?.run { encryptorProvider().encrypt(this) }
     }
 
     override fun convertToEntityAttribute(dbData: String?): String? {
-        return dbData?.run { encryptor.decrypt(this) }
+        return dbData?.run { encryptorProvider().decrypt(this) }
     }
 }
 
 /**
- * 문자열을 AES 알고리즘으로 암호화해서 저장하는 JPA Converter 입니다.
+ * Encrypts a string column with AES-256-GCM.
+ *
+ * This converter is non-deterministic: the same plaintext produces different ciphertext values. Configure
+ * [EncryptedStringConverterKeysets] with persisted AES key material before converting non-null values.
  */
 @Converter
-class AESStringConverter: EncryptedStringConverter(TinkEncryptors.AES256_GCM)
+class AESStringConverter private constructor(
+    encryptorProvider: () -> TinkEncryptor,
+): EncryptedStringConverter(encryptorProvider) {
+
+    constructor(): this(EncryptedStringConverterKeysets::requireAesEncryptor)
+}
 
 /**
- * 문자열을 결정적 AES 알고리즘으로 암호화해서 저장하는 JPA Converter 입니다.
+ * Encrypts a string column with deterministic AES-256-SIV.
+ *
+ * This converter is deterministic: the same plaintext produces the same ciphertext for lookup support. Configure
+ * [EncryptedStringConverterKeysets] with persisted deterministic key material before converting non-null values.
  */
 @Converter
-class DeterministicAESStringConverter: EncryptedStringConverter(TinkEncryptors.DETERMINISTIC_AES256_SIV)
+class DeterministicAESStringConverter private constructor(
+    encryptorProvider: () -> TinkEncryptor,
+): EncryptedStringConverter(encryptorProvider) {
+
+    constructor(): this(EncryptedStringConverterKeysets::requireDeterministicEncryptor)
+}

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/AbstractHibernateTest.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/AbstractHibernateTest.kt
@@ -1,10 +1,16 @@
 package io.bluetape4k.hibernate
 
+import io.bluetape4k.hibernate.converters.EncryptedStringConverterKeysets
 import io.bluetape4k.junit5.faker.Fakers
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.tink.aeadKeysetHandle
+import io.bluetape4k.tink.daeadKeysetHandle
+import io.bluetape4k.tink.keyset.toJsonKeyset
 import jakarta.persistence.EntityManager
 import jakarta.persistence.EntityManagerFactory
 import net.datafaker.Faker
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
@@ -69,6 +75,17 @@ abstract class AbstractHibernateTest {
 
     protected val em: EntityManager get() = tem.entityManager
     protected val emf: EntityManagerFactory get() = em.entityManagerFactory
+
+    @BeforeEach
+    fun configureEncryptedStringConverters() {
+        EncryptedStringConverterKeysets.configureAesKeyset(aeadKeysetHandle().toJsonKeyset())
+        EncryptedStringConverterKeysets.configureDeterministicKeyset(daeadKeysetHandle().toJsonKeyset())
+    }
+
+    @AfterEach
+    fun resetEncryptedStringConverters() {
+        EncryptedStringConverterKeysets.resetForTesting()
+    }
 
     protected fun clear() {
         tem.clear()

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/converter/EncryptedStringConverterTest.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/converter/EncryptedStringConverterTest.kt
@@ -2,12 +2,20 @@ package io.bluetape4k.hibernate.converter
 
 import io.bluetape4k.hibernate.converters.AESStringConverter
 import io.bluetape4k.hibernate.converters.DeterministicAESStringConverter
+import io.bluetape4k.hibernate.converters.EncryptedStringConverterKeysets
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.tink.aeadKeysetHandle
+import io.bluetape4k.tink.daeadKeysetHandle
+import io.bluetape4k.tink.keyset.toJsonKeyset
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.security.GeneralSecurityException
 
 /**
  * [AESStringConverter]와 [DeterministicAESStringConverter]에 대한 단위 테스트입니다.
@@ -18,6 +26,34 @@ class EncryptedStringConverterTest {
 
     private val aesConverter = AESStringConverter()
     private val deterministicConverter = DeterministicAESStringConverter()
+
+    @BeforeEach
+    fun beforeEach() {
+        configurePersistentKeysets()
+    }
+
+    @AfterEach
+    fun afterEach() {
+        EncryptedStringConverterKeysets.resetForTesting()
+    }
+
+    @Test
+    fun `AESStringConverter는 명시적 key material 없이는 암호화하지 않는다`() {
+        EncryptedStringConverterKeysets.resetForTesting()
+
+        assertFailsWith<IllegalStateException> {
+            AESStringConverter().convertToDatabaseColumn("secret")
+        }
+    }
+
+    @Test
+    fun `DeterministicAESStringConverter는 명시적 key material 없이는 암호화하지 않는다`() {
+        EncryptedStringConverterKeysets.resetForTesting()
+
+        assertFailsWith<IllegalStateException> {
+            DeterministicAESStringConverter().convertToDatabaseColumn("secret")
+        }
+    }
 
     @Test
     fun `AESStringConverter는 문자열을 암호화하고 복호화한다`() {
@@ -114,5 +150,60 @@ class EncryptedStringConverterTest {
 
         val decrypted = deterministicConverter.convertToEntityAttribute(encrypted)
         decrypted shouldBeEqualTo plainText
+    }
+
+    @Test
+    fun `AESStringConverter는 저장된 key material 로 converter instance 사이에서 복호화한다`() {
+        val keysetJson = aeadKeysetHandle().toJsonKeyset()
+        EncryptedStringConverterKeysets.configureAesKeyset(keysetJson)
+        val encrypted = AESStringConverter().convertToDatabaseColumn("restart-safe secret")
+
+        EncryptedStringConverterKeysets.resetForTesting()
+        EncryptedStringConverterKeysets.configureAesKeyset(keysetJson)
+
+        AESStringConverter().convertToEntityAttribute(encrypted) shouldBeEqualTo "restart-safe secret"
+    }
+
+    @Test
+    fun `AESStringConverter는 다른 key material 로 저장된 암호문을 복호화하지 못한다`() {
+        EncryptedStringConverterKeysets.configureAesKeyset(aeadKeysetHandle().toJsonKeyset())
+        val encrypted = AESStringConverter().convertToDatabaseColumn("restart-unsafe secret")
+
+        EncryptedStringConverterKeysets.resetForTesting()
+        EncryptedStringConverterKeysets.configureAesKeyset(aeadKeysetHandle().toJsonKeyset())
+
+        assertFailsWith<GeneralSecurityException> {
+            AESStringConverter().convertToEntityAttribute(encrypted)
+        }
+    }
+
+    @Test
+    fun `DeterministicAESStringConverter는 저장된 key material 로 converter instance 사이에서 복호화한다`() {
+        val keysetJson = daeadKeysetHandle().toJsonKeyset()
+        EncryptedStringConverterKeysets.configureDeterministicKeyset(keysetJson)
+        val encrypted = DeterministicAESStringConverter().convertToDatabaseColumn("lookup-safe secret")
+
+        EncryptedStringConverterKeysets.resetForTesting()
+        EncryptedStringConverterKeysets.configureDeterministicKeyset(keysetJson)
+
+        DeterministicAESStringConverter().convertToEntityAttribute(encrypted) shouldBeEqualTo "lookup-safe secret"
+    }
+
+    @Test
+    fun `DeterministicAESStringConverter는 다른 key material 로 저장된 암호문을 복호화하지 못한다`() {
+        EncryptedStringConverterKeysets.configureDeterministicKeyset(daeadKeysetHandle().toJsonKeyset())
+        val encrypted = DeterministicAESStringConverter().convertToDatabaseColumn("lookup-unsafe secret")
+
+        EncryptedStringConverterKeysets.resetForTesting()
+        EncryptedStringConverterKeysets.configureDeterministicKeyset(daeadKeysetHandle().toJsonKeyset())
+
+        assertFailsWith<GeneralSecurityException> {
+            DeterministicAESStringConverter().convertToEntityAttribute(encrypted)
+        }
+    }
+
+    private fun configurePersistentKeysets() {
+        EncryptedStringConverterKeysets.configureAesKeyset(aeadKeysetHandle().toJsonKeyset())
+        EncryptedStringConverterKeysets.configureDeterministicKeyset(daeadKeysetHandle().toJsonKeyset())
     }
 }

--- a/docs/lessons/2026-06-26-hibernate-encryption-keysets.md
+++ b/docs/lessons/2026-06-26-hibernate-encryption-keysets.md
@@ -1,0 +1,22 @@
+# Lessons Learned - Hibernate Encryption Keysets (2026-06-26)
+
+Related issue: #816
+Affected module: `:bluetape4k-hibernate`
+
+## L1: Persistent converters must not create process-local keys
+
+### Problem
+
+`AESStringConverter` and `DeterministicAESStringConverter` were documented as persistent entity-field converters, but
+their default encryptors used generated in-process Tink keysets. That made same-process tests pass while persisted
+ciphertext could become unreadable after restart or in another application instance.
+
+### Lesson
+
+Persistent encryption converters need explicit externally stored key material. Tests must cover both restart-safe
+positive cases with the same persisted keyset and restart-unsafe negative cases with a different keyset.
+
+### Future guard
+
+When adding a persistent encryption API, do not validate only same-instance round trips. Add a cross-instance or
+cross-keyset regression test and document where key material must live.

--- a/docs/review/2026-06-26-hibernate-encryption-keysets-review.md
+++ b/docs/review/2026-06-26-hibernate-encryption-keysets-review.md
@@ -1,0 +1,43 @@
+# Review - Hibernate Encryption Keysets (2026-06-26)
+
+Issue: #816
+Branch: `fix/hibernate-encryption-keysets`
+Module: `:bluetape4k-hibernate`
+
+## Scope
+
+- `EncryptedStringConverterKeysets` now requires explicit persisted keyset JSON before built-in encrypted converters
+  process non-null values.
+- `AESStringConverter` and `DeterministicAESStringConverter` no longer use generated process-local default
+  `TinkEncryptors`.
+- README files document the external key material requirement.
+- Converter tests cover unconfigured fail-fast, same-key cross-instance success, and different-key failure.
+
+## 7-Tier Review
+
+| Tier | Result | Evidence |
+|---|---:|---|
+| Correctness | PASS | Non-null conversion resolves encryptors lazily from configured keysets; null values still return null. |
+| Security | PASS | Process-local generated keysets are no longer used by built-in persistent converters. |
+| Public API | PASS | New public configuration surface accepts `String` keyset JSON; `TinkEncryptor` helper methods remain internal. |
+| Persistence compatibility | PASS | Existing JPA converter no-arg constructors remain available and targeted Hibernate converter tests pass. |
+| Test coverage | PASS | Added fail-fast, same-key restart-safe, and different-key restart-unsafe tests for AES-GCM and AES-SIV. |
+| Documentation | PASS | `README.md` and `README.ko.md` describe key material storage and bootstrap requirements. |
+| Regression risk | PASS | Targeted module tests pass; full module test has an unrelated pre-existing `org.hibernate.KeyType` blocker on `develop`. |
+
+## Findings
+
+P0: 0
+P1: 0
+
+P2/P3: none requiring code changes before PR.
+
+## Validation Evidence
+
+- `./gradlew :bluetape4k-hibernate:compileKotlin :bluetape4k-hibernate:compileTestKotlin --no-build-cache`
+  - Result: PASS.
+- `./gradlew :bluetape4k-hibernate:test --tests 'io.bluetape4k.hibernate.converter.EncryptedStringConverterTest' --tests 'io.bluetape4k.hibernate.converter.ConverterTest' --tests 'io.bluetape4k.hibernate.mapping.embeddable.EmbeddableTest' --no-build-cache`
+  - Result: PASS.
+- `./gradlew :bluetape4k-hibernate:test --no-build-cache`
+  - Result: FAIL, unrelated existing natural-id tests fail with `NoClassDefFoundError: org/hibernate/KeyType`.
+  - Develop verification: the same two natural-id tests fail on clean `develop` with the same `org.hibernate.KeyType` error.


### PR DESCRIPTION
## Summary

Closes #816

- PR 제목: fix: require persisted Hibernate encryption keysets

### 원문 선행 내용

Fixes #816

## Background

`AESStringConverter` and `DeterministicAESStringConverter` were documented as persistent Hibernate field converters, but their default path used process-local generated Tink keysets. Same-process tests passed while ciphertext could become unreadable after restart, rollout, or multi-instance access.

## What This Solves

This PR makes persistent encrypted fields require explicit externally persisted key material before built-in converters process non-null values. It preserves JPA no-arg converter construction and resolves encryptors lazily at conversion time so application bootstrap can configure keysets before entity reads or writes.

## Work Done

- Added `EncryptedStringConverterKeysets` for AES-GCM and deterministic AES-SIV keyset JSON bootstrap.
- Removed built-in converter defaults that silently used generated `TinkEncryptors` keysets.
- Added regression tests for unconfigured fail-fast behavior, same-key cross-instance decryptability, and different-key decrypt failures.
- Updated Hibernate integration test bootstrap for entities that use deterministic encrypted fields.
- Updated English and Korean README encryption converter docs.
- Added tracked lesson and local review artifacts.

### 기존 섹션: Validation And Review Notes

- PASS: `./gradlew :bluetape4k-hibernate:compileKotlin :bluetape4k-hibernate:compileTestKotlin --no-build-cache`
- PASS: `./gradlew :bluetape4k-hibernate:test --tests 'io.bluetape4k.hibernate.converter.EncryptedStringConverterTest' --tests 'io.bluetape4k.hibernate.converter.ConverterTest' --tests 'io.bluetape4k.hibernate.mapping.embeddable.EmbeddableTest' --no-build-cache`
- PASS: `git diff --check`
- PASS: GitHub Actions checks: Build, CI Status, Coverage Report, Detect changed modules, Secret Scan, Validate Gradle Wrapper, submit-gradle; module matrix jobs skipped by changed-module detection.
- REVIEW: `docs/review/2026-06-26-hibernate-encryption-keysets-review.md`, P0/P1 = 0; GitHub PR review comment posted.
- Known blocker: full `:bluetape4k-hibernate:test --no-build-cache` still fails on two unrelated natural-id tests with `NoClassDefFoundError: org/hibernate/KeyType`; the same two failures reproduce on clean `develop`.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #816, milestone `1.11.0`, assignee `debop`
- PR: #907, head `154a810505c8222786975482c0622c96047e8f50`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/hibernate-encryption-keysets`
- Labels: `bug`, `security`
- State: `MERGED`, merge commit `d5add32582aeff0b9945be5b40fc290bee7534f9`
- CI: `AESStringConverter` and `DeterministicAESStringConverter` were documented as persistent Hibernate field converters, but their default path used process-local generated Tink keysets. Same-process tests passed while ciphertext could become unreadable after restart, rollout, or multi-instance access. / This PR makes persistent encrypted fields require explicit externally persisted key material before built-in converters process non-null values. It preserves JPA no-arg converter construction and resolves encryptors lazily at conversion time so application bootstrap can configure keysets before entity reads or writes. / - PASS: `./gradlew :bluetape4k-hibernate:compileKotlin :bluetape4k-hibernate:compileTestKotlin --no-build-cache`

## DoD Status

| Step | Status | Evidence |
|---|---:|---|
| Step 1 - Review | PASS | #816 evidence confirmed; CodeGraph review context showed contained changed-file scope, direct source search found converter/test/README references. |
| Step 2 - Issue | PASS | Fixes #816, labels `bug/security`, milestone `1.11.0`, assignee `debop`. |
| Step 3 - Fix | PASS | Commit `154a81050` requires persisted keysets and removes generated-key defaults from built-in converters. |
| Step 4 - Test | PASS | Targeted compile and converter/Hibernate tests pass; full module test blocker classified as pre-existing on clean `develop`. |
| Step 5 - Lessons | PASS | `docs/lessons/2026-06-26-hibernate-encryption-keysets.md`. |
| Step 6 - PR | PASS | PR metadata mirrors #816. |
| Step 7 - Review | PASS | Local 7-tier review artifact and GitHub PR review comment report P0/P1 = 0. |
| Step 8 - CI Gate | PASS | GitHub Actions checks pass; changed-module matrix jobs skipped as expected. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #907 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `d5add32582aeff0b9945be5b40fc290bee7534f9`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
