### PR TITLE
fix: restore Hibernate natural-id helpers

### DIFF
--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/SessionSupport.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/SessionSupport.kt
@@ -6,7 +6,6 @@ import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requireNotEmpty
 import io.bluetape4k.support.requirePositiveNumber
-import org.hibernate.KeyType
 import org.hibernate.Session
 import org.hibernate.query.Query
 import org.slf4j.Logger
@@ -86,23 +85,26 @@ inline fun <reified T: Any> Session.findAs(id: Serializable): T? = find(T::class
 inline fun <reified T: Any> Session.getReferenceAs(id: Serializable): T = getReference(T::class.java, id)
 
 /**
- * simple natural id 값으로 엔티티를 조회합니다. 없으면 `null`을 반환합니다.
+ * Finds an entity by its simple natural id, or returns `null` when no row matches.
  *
- * ## 동작/계약
- * - Hibernate `bySimpleNaturalId(...).load(...)`에 위임합니다.
- * - `@NaturalId`가 하나인 엔티티에 사용합니다.
+ * ## Behavior
+ * - Delegates to Hibernate `bySimpleNaturalId(...).load(...)`.
+ * - Use this helper for entities that define exactly one `@NaturalId` attribute.
+ * - Uses the natural-id loader API instead of the `KeyType.NATURAL` path removed from Hibernate 7.2.
  */
+@Suppress("DEPRECATION")
 inline fun <reified T: Any> Session.findBySimpleNaturalId(naturalId: Any): T? =
-    find(T::class.java, naturalId, KeyType.NATURAL)
-// bySimpleNaturalId(T::class.java).load(naturalId)
+    bySimpleNaturalId(T::class.java).load(naturalId)
 
 /**
- * 복합 natural id 속성으로 엔티티를 조회합니다. 없으면 `null`을 반환합니다.
+ * Finds an entity by composite natural-id attributes, or returns `null` when no row matches.
  *
- * ## 동작/계약
- * - [naturalIdValues]는 비어 있을 수 없고, 각 속성명은 blank일 수 없습니다.
- * - Hibernate `byNaturalId(...).using(...).load()`에 위임합니다.
+ * ## Behavior
+ * - [naturalIdValues] must not be empty and each attribute name must not be blank.
+ * - Delegates to Hibernate `byNaturalId(...).using(...).load()`.
+ * - Uses the natural-id loader API instead of the `KeyType.NATURAL` path removed from Hibernate 7.2.
  */
+@Suppress("DEPRECATION")
 inline fun <reified T: Any> Session.findByNaturalId(
     naturalIdValues: Map<String, Any?>,
 ): T? {
@@ -111,7 +113,9 @@ inline fun <reified T: Any> Session.findByNaturalId(
     naturalIdValues.keys.forEach { attributeName ->
         attributeName.requireNotBlank("naturalIdValues.key")
     }
-    return find(T::class.java, naturalIdValues, KeyType.NATURAL)
+    return byNaturalId(T::class.java)
+        .using(naturalIdValues)
+        .load()
 }
 
 /**

--- a/docs/lessons/2026-06-26-hibernate-natural-id-keytype.md
+++ b/docs/lessons/2026-06-26-hibernate-natural-id-keytype.md
@@ -1,0 +1,24 @@
+# Lessons Learned - Hibernate Natural Id KeyType (2026-06-26)
+
+Related issue: #908
+Affected module: `:bluetape4k-hibernate`
+
+## L1: Hibernate natural-id helpers must use loader APIs on Hibernate 7
+
+### Problem
+
+`Session.findBySimpleNaturalId()` and `Session.findByNaturalId()` used `Session.find(..., KeyType.NATURAL)`.
+`org.hibernate.KeyType` is not available in the Hibernate 7.2 runtime used by the module tests, so the helper tests
+failed with `NoClassDefFoundError`.
+
+### Lesson
+
+Use Hibernate's natural-id loader APIs for natural-id lookups:
+
+- `Session.bySimpleNaturalId(entityClass).load(value)` for simple natural ids.
+- `Session.byNaturalId(entityClass).using(values).load()` for composite natural ids.
+
+### Future guard
+
+When a helper wraps Hibernate-specific APIs, verify against the exact `testRuntimeClasspath` Hibernate jar before
+using removed compatibility constants or overloads.

--- a/docs/review/2026-06-26-hibernate-natural-id-keytype-review.md
+++ b/docs/review/2026-06-26-hibernate-natural-id-keytype-review.md
@@ -1,0 +1,42 @@
+# Review - Hibernate Natural Id KeyType (2026-06-26)
+
+Issue: #908
+Branch: `fix/hibernate-natural-id-keytype`
+Module: `:bluetape4k-hibernate`
+
+## Scope
+
+- Removed the runtime dependency on `org.hibernate.KeyType` from natural-id helper methods.
+- Updated simple and composite natural-id lookup helpers to use Hibernate 7 natural-id loader APIs.
+
+## 7-Tier Review
+
+| Tier | Result | Evidence |
+|---|---:|---|
+| Correctness | PASS | `findBySimpleNaturalId` delegates to `bySimpleNaturalId(...).load(...)`; composite lookup delegates to `byNaturalId(...).using(...).load()`. |
+| Compatibility | PASS | Verified Hibernate `7.2.7.Final` test runtime exposes the loader APIs and does not provide `org.hibernate.KeyType`. |
+| Validation | PASS | Empty natural-id map and blank attribute-name guards remain unchanged. |
+| Test coverage | PASS | Targeted EntityManager and Session natural-id tests pass; full `:bluetape4k-hibernate:test` passes. |
+| API surface | PASS | Public extension function signatures are unchanged. |
+| Documentation | PASS | KDoc notes the Hibernate 7 `KeyType.NATURAL` removal path. |
+| Regression risk | PASS | Single production file touched, no unrelated behavior changes. |
+
+## Findings
+
+P0: 0
+P1: 0
+
+P2/P3: none requiring code changes before PR.
+
+## Validation Evidence
+
+- Reproduced before fix:
+  - `./gradlew :bluetape4k-hibernate:test --tests 'io.bluetape4k.hibernate.EntityManagerSupportTest.entity manager natural id helpers 는 simple natural id 조회를 지원한다' --tests 'io.bluetape4k.hibernate.SessionSupportTest.session natural id helpers 는 simple natural id 조회를 지원한다' --no-build-cache`
+  - Result: FAIL with `NoClassDefFoundError: org/hibernate/KeyType`.
+- After fix:
+  - `./gradlew :bluetape4k-hibernate:compileKotlin :bluetape4k-hibernate:compileTestKotlin --no-build-cache`
+  - Result: PASS.
+  - `./gradlew :bluetape4k-hibernate:test --tests 'io.bluetape4k.hibernate.EntityManagerSupportTest.entity manager natural id helpers 는 simple natural id 조회를 지원한다' --tests 'io.bluetape4k.hibernate.SessionSupportTest.session natural id helpers 는 simple natural id 조회를 지원한다' --no-build-cache`
+  - Result: PASS.
+  - `./gradlew :bluetape4k-hibernate:test --no-build-cache`
+  - Result: PASS.


### PR DESCRIPTION
## Summary

Closes #908

- PR 제목: fix: restore Hibernate natural-id helpers

Closes #908.

- Replaced the removed `Session.find(..., KeyType.NATURAL)` natural-id path with Hibernate 7 loader APIs.
- Kept simple and composite natural-id helper signatures unchanged.
- Captured the Hibernate 7.2 `KeyType` runtime removal lesson and review evidence in docs.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- `./gradlew :bluetape4k-hibernate:compileKotlin :bluetape4k-hibernate:compileTestKotlin --no-build-cache`
- `./gradlew :bluetape4k-hibernate:test --tests 'io.bluetape4k.hibernate.EntityManagerSupportTest.entity manager natural id helpers 는 simple natural id 조회를 지원한다' --tests 'io.bluetape4k.hibernate.SessionSupportTest.session natural id helpers 는 simple natural id 조회를 지원한다' --no-build-cache`
- `./gradlew :bluetape4k-hibernate:test --tests 'io.bluetape4k.hibernate.mapping.naturalid.NaturalIdTest' --tests 'io.bluetape4k.hibernate.EntityManagerSupportTest.*natural id*' --tests 'io.bluetape4k.hibernate.SessionSupportTest.*natural id*' --no-build-cache`
- `./gradlew :bluetape4k-hibernate:test --no-build-cache`
- `git diff --check`
- GitHub Actions on PR #909: PASS (`Build`, `CI Status`, `Coverage Report`, `Detect changed modules`, `Secret Scan`, `Validate Gradle Wrapper`, `submit-gradle`)

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1 findings: 0
- Scope reviewed: `SessionSupport.kt`, natural-id regression tests, Hibernate 7.2 runtime API surface, and documentation artifacts.

## Metadata

- Issue: #908, milestone `1.11.0`, assignee `debop`
- PR: #909, head `b499afedef76b1edb351c785bd504ea7696e0349`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/hibernate-natural-id-keytype`
- Labels: `bug`, `test`
- State: `MERGED`, merge commit `1075d2ca63c7219c64ae9fc65d5f902b7a1d519e`
- CI: - `./gradlew :bluetape4k-hibernate:compileKotlin :bluetape4k-hibernate:compileTestKotlin --no-build-cache` / - `./gradlew :bluetape4k-hibernate:test --tests 'io.bluetape4k.hibernate.EntityManagerSupportTest.entity manager natural id helpers 는 simple natural id 조회를 지원한다' --tests 'io.bluetape4k.hibernate.SessionSupportTest.session natural id helpers 는 simple natural id 조회를 지원한다' --no-build-cache` / - `./gradlew :bluetape4k-hibernate:test --tests 'io.bluetape4k.hibernate.mapping.naturalid.NaturalIdTest' --tests 'io.bluetape4k.hibernate.EntityManagerSupportTest.*natural id*' --tests 'io.bluetape4k.hibernate.SessionSupportTest.*natural id*' --no-build-cache`

## DoD Status

- [x] Reproduced the two #908 natural-id helper failures on the pre-fix branch.
- [x] Removed the `org.hibernate.KeyType` runtime dependency from Hibernate natural-id helpers.
- [x] Preserved public helper signatures for simple and composite natural-id lookup.
- [x] Verified targeted regression tests and full `:bluetape4k-hibernate:test` pass locally.
- [x] Added review and lesson artifacts for the Hibernate 7 natural-id API path.
- [x] GitHub Actions pass on this PR.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #909 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `1075d2ca63c7219c64ae9fc65d5f902b7a1d519e`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
