### PR TITLE
fix: reject empty range overlaps

### DIFF
--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/ranges/Range.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/ranges/Range.kt
@@ -139,6 +139,10 @@ fun <T: Comparable<T>> Range<T>.contains(other: Range<T>): Boolean {
  * ```
  */
 fun <T: Comparable<T>> Range<T>.overlaps(other: Range<T>): Boolean {
+    if (isEmpty() || other.isEmpty()) {
+        return false
+    }
+
     // 이 범위의 상한과 other의 하한이 만나는 지점
     val upperVsLower = if (isEndInclusive && other.isStartInclusive) {
         last >= other.first

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/ranges/RangeSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/ranges/RangeSupportTest.kt
@@ -127,4 +127,19 @@ class RangeSupportTest {
         // [0, 5) overlaps (4, 10] -> true (4~5 사이에서 겹침)
         closedOpenRangeOf(0, 5).overlaps(openClosedRangeOf(4, 10)).shouldBeTrue()
     }
+
+    @Test
+    fun `empty ranges never overlap any range`() {
+        val nonEmpty = closedClosedRangeOf(0, 2)
+
+        openOpenRangeOf(1, 1).overlaps(nonEmpty).shouldBeFalse()
+        closedOpenRangeOf(1, 1).overlaps(nonEmpty).shouldBeFalse()
+        openClosedRangeOf(1, 1).overlaps(nonEmpty).shouldBeFalse()
+
+        nonEmpty.overlaps(openOpenRangeOf(1, 1)).shouldBeFalse()
+        nonEmpty.overlaps(closedOpenRangeOf(1, 1)).shouldBeFalse()
+        nonEmpty.overlaps(openClosedRangeOf(1, 1)).shouldBeFalse()
+
+        openOpenRangeOf(1, 1).overlaps(closedOpenRangeOf(1, 1)).shouldBeFalse()
+    }
 }

--- a/docs/lessons/2026-06-26-range-overlaps-empty.md
+++ b/docs/lessons/2026-06-26-range-overlaps-empty.md
@@ -1,0 +1,22 @@
+# Lessons Learned - Range Empty Overlap (2026-06-26)
+
+Related issue: #783
+Affected module: `:bluetape4k-core`
+
+## L1: Empty ranges must short-circuit overlap checks
+
+### Problem
+
+`Range.overlaps()` compared only endpoint ordering and boundary inclusiveness. Empty ranges such as `(1, 1)`,
+`[1, 1)`, and `(1, 1]` could therefore report an overlap with a non-empty range even though no common element
+exists.
+
+### Lesson
+
+When a range operation's contract is element-based, check `isEmpty()` before applying endpoint comparisons.
+Boundary comparisons alone are not enough because empty ranges can still sit inside a non-empty interval.
+
+### Future guard
+
+Range helper changes should include regression coverage for empty operands in both receiver and argument positions,
+plus existing boundary inclusiveness tests for non-empty ranges.

--- a/docs/review/2026-06-26-range-overlaps-empty-review.md
+++ b/docs/review/2026-06-26-range-overlaps-empty-review.md
@@ -1,0 +1,43 @@
+# Review - Range Empty Overlap (2026-06-26)
+
+Issue: #783
+Branch: `fix/range-overlaps-empty`
+Module: `:bluetape4k-core`
+
+## Scope
+
+- Added an empty-operand guard to `Range.overlaps()`.
+- Added regression coverage for empty open/open, closed/open, and open/closed ranges in both receiver and argument
+  positions.
+
+## 7-Tier Review
+
+| Tier | Result | Evidence |
+|---|---:|---|
+| Correctness | PASS | `overlaps()` now returns `false` when either operand is empty before endpoint comparisons run. |
+| Compatibility | PASS | Public API signatures are unchanged. |
+| Boundary behavior | PASS | Existing same-type and cross-type non-empty overlap tests still pass. |
+| Test coverage | PASS | New regression test failed before the fix and passes after the guard. |
+| Simplicity | PASS | One guard added in the shared helper; no new abstraction. |
+| Documentation | PASS | Lesson artifact records the empty-range comparison rule. |
+| Regression risk | PASS | Core module test suite passes and CodeGraph reported low impact for the changed files. |
+
+## Findings
+
+P0: 0
+P1: 0
+
+P2/P3: none requiring code changes before PR.
+
+## Validation Evidence
+
+- Reproduced before fix:
+  - `./gradlew :bluetape4k-core:test --tests 'io.bluetape4k.ranges.RangeSupportTest.empty ranges never overlap any range' --no-build-cache`
+  - Result: FAIL with `Expected <true> to be <false>` at `RangeSupportTest.kt:135`.
+- After fix:
+  - `./gradlew :bluetape4k-core:test --tests 'io.bluetape4k.ranges.RangeSupportTest.empty ranges never overlap any range' --tests 'io.bluetape4k.ranges.RangeSupportTest.overlaps with same type ranges' --tests 'io.bluetape4k.ranges.RangeSupportTest.overlaps with cross-type ranges' --no-build-cache`
+  - Result: PASS.
+  - `./gradlew :bluetape4k-core:compileKotlin :bluetape4k-core:compileTestKotlin :bluetape4k-core:test --no-build-cache`
+  - Result: PASS.
+  - `git diff --check`
+  - Result: PASS.


### PR DESCRIPTION
## Summary

Closes #783

- PR 제목: fix: reject empty range overlaps

Fixes #783.

- Short-circuits `Range.overlaps()` when either operand is empty.
- Adds regression coverage for empty open/open, closed/open, and open/closed ranges in receiver and argument positions.
- Preserves existing boundary inclusiveness behavior for non-empty ranges.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- `./gradlew :bluetape4k-core:test --tests 'io.bluetape4k.ranges.RangeSupportTest.empty ranges never overlap any range' --no-build-cache` (failed before the fix with `Expected <true> to be <false>`)
- `./gradlew :bluetape4k-core:test --tests 'io.bluetape4k.ranges.RangeSupportTest.empty ranges never overlap any range' --tests 'io.bluetape4k.ranges.RangeSupportTest.overlaps with same type ranges' --tests 'io.bluetape4k.ranges.RangeSupportTest.overlaps with cross-type ranges' --no-build-cache`
- `./gradlew :bluetape4k-core:compileKotlin :bluetape4k-core:compileTestKotlin :bluetape4k-core:test --no-build-cache`
- `git diff --check`
- GitHub Actions on PR #910: PASS (`Build`, `Test / Core`, `CI Status`, `Coverage Report`, `Detect changed modules`, `Secret Scan`, `Validate Gradle Wrapper`, `submit-gradle`; unrelated module test lanes skipped by path filter)

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1 findings: 0
- CodeGraph: risk score `0.00`, test gaps `0`
- Scope reviewed: `Range.overlaps()` empty-operand behavior, same-type overlap tests, cross-type overlap tests, lesson/review artifacts.

## Metadata

- Issue: #783, milestone `1.11.0`, assignee `debop`
- PR: #910, head `92335371a24aef728c5ed91c94a36cb352a4a099`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/range-overlaps-empty`
- Labels: `bug`
- State: `MERGED`, merge commit `0f0ab470414ac8e4583f6137e28bc904b4e2bb7a`
- CI: - Short-circuits `Range.overlaps()` when either operand is empty. / - `./gradlew :bluetape4k-core:test --tests 'io.bluetape4k.ranges.RangeSupportTest.empty ranges never overlap any range' --no-build-cache` (failed before the fix with `Expected <true> to be <false>`) / - `./gradlew :bluetape4k-core:test --tests 'io.bluetape4k.ranges.RangeSupportTest.empty ranges never overlap any range' --tests 'io.bluetape4k.ranges.RangeSupportTest.overlaps with same type ranges' --tests 'io.bluetape4k.ranges.RangeSupportTest.overlaps with cross-type ranges' --no-build-cache`

## DoD Status

- [x] Reproduced the #783 empty-range overlap false positive before the fix.
- [x] Added an empty-operand guard to `Range.overlaps()`.
- [x] Added regression coverage for empty range operands in both receiver and argument positions.
- [x] Verified existing non-empty boundary overlap behavior remains unchanged.
- [x] Verified `:bluetape4k-core` compile and test pass locally.
- [x] Added review and lesson artifacts.
- [x] GitHub Actions pass on this PR.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #910 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `0f0ab470414ac8e4583f6137e28bc904b4e2bb7a`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
