### PR TITLE
fix: align Hibernate Reactive runtime stack

### DIFF
--- a/docs/lessons/2026-06-26-issue-912-hibernate-reactive-vertx.md
+++ b/docs/lessons/2026-06-26-issue-912-hibernate-reactive-vertx.md
@@ -1,0 +1,22 @@
+# Lessons Learned - Hibernate Reactive Vert.x Alignment (2026-06-26)
+
+Related issue: #912
+Affected modules: `:bluetape4k-hibernate`, `:bluetape4k-hibernate-reactive`, `:bluetape4k-hibernate-cache-lettuce`
+
+## L1: Hibernate Reactive must track both ORM and Vert.x lines
+
+### Problem
+
+`bluetape4k-hibernate-reactive` used Hibernate Reactive `4.3.3.Final` with the repository-wide Vert.x `5.1.3`.
+The module failed at runtime because Hibernate Reactive called an internal Vert.x SQL client constructor that no longer
+exists in the resolved Vert.x version.
+
+### Lesson
+
+Hibernate Reactive is coupled to both Hibernate ORM and Vert.x SQL client internals. When Vert.x is upgraded globally,
+check the Hibernate Reactive POM line and align Hibernate ORM at the same time instead of bumping only one side.
+
+### Future guard
+
+Run `:bluetape4k-hibernate-reactive:test` after changing Hibernate ORM, Hibernate Reactive, or Vert.x versions. Also
+check `dependencyInsight` for `hibernate-reactive-core`, `hibernate-core`, and Vert.x SQL client artifacts.

--- a/docs/review/2026-06-26-issue-912-hibernate-reactive-vertx-review.md
+++ b/docs/review/2026-06-26-issue-912-hibernate-reactive-vertx-review.md
@@ -1,0 +1,50 @@
+# Review - Hibernate Reactive Vert.x Alignment (2026-06-26)
+
+Issue: #912
+Branch: `fix/hibernate-reactive-vertx`
+Affected modules: `:bluetape4k-hibernate`, `:bluetape4k-hibernate-reactive`, `:bluetape4k-hibernate-cache-lettuce`
+
+## Scope
+
+- Aligned Hibernate ORM from `7.3.4.Final` to `7.4.2.Final`.
+- Aligned Hibernate Reactive from `4.3.3.Final` to `4.5.0.Final`.
+- Kept the repository-wide Vert.x line at `5.1.3`.
+
+## 7-Tier Review
+
+| Tier | Result | Evidence |
+|---|---:|---|
+| Correctness | PASS | `:bluetape4k-hibernate-reactive:test` no longer fails with Vert.x `RowBase` runtime API mismatch. |
+| Compatibility | PASS | Hibernate ORM and Reactive are aligned to the dependency line declared by Hibernate Reactive `4.5.0.Final`. |
+| Boundary behavior | PASS | The change is catalog-only; public APIs and source code are unchanged. |
+| Test coverage | PASS | Hibernate core, Hibernate Reactive, and Hibernate cache Lettuce tests pass locally. |
+| Simplicity | PASS | Two catalog version entries changed; no dependency override or workaround was added. |
+| Documentation | PASS | Lesson artifact records the ORM/Reactive/Vert.x coupling. |
+| Regression risk | PASS | Resolved dependency versions match the intended line: ORM `7.4.2.Final`, Reactive `4.5.0.Final`, Vert.x SQL `5.1.3`. |
+
+## Findings
+
+P0: 0
+P1: 0
+
+P2/P3: none requiring code changes before PR.
+
+## Validation Evidence
+
+- Reproduced before fix:
+  - Data CI candidate command failed at `:bluetape4k-hibernate-reactive:test`.
+  - Root error: `NoSuchMethodError: io.vertx.sqlclient.impl.RowBase.<init>(java.util.Collection)`.
+- Candidate rejected:
+  - `hibernate-reactive = 4.5.0.Final` alone failed with `NoClassDefFoundError: org/hibernate/service/internal/ChangesetCoordinatorInitiator`.
+  - Hibernate Reactive `4.5.0.Final` POM expects Hibernate ORM `7.4.2.Final`.
+- After fix:
+  - `./gradlew :bluetape4k-hibernate-reactive:test --max-workers=1 --no-configuration-cache`
+  - Result: PASS.
+  - `./gradlew :bluetape4k-hibernate:test --max-workers=1 --no-configuration-cache`
+  - Result: PASS.
+  - `./gradlew :bluetape4k-hibernate-cache-lettuce:test --max-workers=1 --no-configuration-cache`
+  - Result: PASS.
+  - `./gradlew :bluetape4k-jdbc:test :bluetape4k-hibernate:test :bluetape4k-hibernate-cache-lettuce:test :bluetape4k-hibernate-reactive:test :bluetape4k-r2dbc:test :bluetape4k-mongodb:test :bluetape4k-cassandra:test --max-workers=1 --no-configuration-cache`
+  - Result: PASS.
+  - `./gradlew :bluetape4k-hibernate-reactive:dependencyInsight --configuration testRuntimeClasspath ...`
+  - Result: resolved `hibernate-reactive-core:4.5.0.Final`, `hibernate-core:7.4.2.Final`, `vertx-sql-client:5.1.3`, and `vertx-mysql-client:5.1.3`.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,8 +62,8 @@ lettuce = "7.6.0.RELEASE"  # https://mvnrepository.com/artifact/io.lettuce/lettu
 redisson = "4.6.1"  # https://mvnrepository.com/artifact/org.redisson/redisson
 lz4 = "1.11.0"  # https://mvnrepository.com/artifact/at.yawk.lz4/lz4-java
 
-hibernate = "7.3.4.Final"  # https://mvnrepository.com/artifact/org.hibernate.orm/hibernate-core
-hibernate-reactive = "4.3.3.Final"  # https://mvnrepository.com/artifact/org.hibernate.reactive/hibernate-reactive-core
+hibernate = "7.4.2.Final"  # https://mvnrepository.com/artifact/org.hibernate.orm/hibernate-core
+hibernate-reactive = "4.5.0.Final"  # https://mvnrepository.com/artifact/org.hibernate.reactive/hibernate-reactive-core
 hibernate-validator = "9.1.0.Final"  # https://mvnrepository.com/artifact/org.hibernate.validator/hibernate-validator
 querydsl = "7.4.0"  # https://mvnrepository.com/artifact/io.github.openfeign.querydsl/querydsl-apt
 


### PR DESCRIPTION
## Summary

Closes #912

- PR 제목: fix: align Hibernate Reactive runtime stack

- Align Hibernate Reactive with the currently resolved Vert.x SQL client runtime line.
- Upgrade Hibernate ORM to the version expected by Hibernate Reactive `4.5.0.Final`.
- Unblock #900 so data-module CI can include Hibernate Reactive tests without a runtime API failure.

Closes #912

## Background

`bluetape4k-hibernate-reactive` failed on current `develop` with:

```text
NoSuchMethodError: io.vertx.sqlclient.impl.RowBase.<init>(java.util.Collection)
```

The repository catalog used Hibernate Reactive `4.3.3.Final` while Vert.x SQL client resolved to `5.1.3`. Upgrading only Hibernate Reactive fixed the Vert.x-side error but failed against the old Hibernate ORM line. Hibernate Reactive `4.5.0.Final` declares the compatible line as Hibernate ORM `7.4.2.Final` and Vert.x `5.1.3`.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- `hibernate`: `7.3.4.Final` -> `7.4.2.Final`
- `hibernate-reactive`: `4.3.3.Final` -> `4.5.0.Final`
- Added lesson and review artifacts for the ORM/Reactive/Vert.x version coupling.

### 기존 섹션: Risk

- Moderate dependency blast radius because Hibernate ORM is shared by Hibernate modules.
- Covered by Hibernate core, Hibernate Reactive, Hibernate cache Lettuce, and full data-module test commands.

## Validation

- Reproduced before fix through the #900 data CI candidate command:
  - `:bluetape4k-hibernate-reactive:test` failed with `NoSuchMethodError: io.vertx.sqlclient.impl.RowBase.<init>(java.util.Collection)`.
- Rejected partial upgrade:
  - `hibernate-reactive = 4.5.0.Final` alone failed with missing `org.hibernate.service.internal.ChangesetCoordinatorInitiator`.
- `./gradlew :bluetape4k-hibernate-reactive:test --max-workers=1 --no-configuration-cache`
- `./gradlew :bluetape4k-hibernate:test --max-workers=1 --no-configuration-cache`
- `./gradlew :bluetape4k-hibernate-cache-lettuce:test --max-workers=1 --no-configuration-cache`
- `./gradlew :bluetape4k-jdbc:test :bluetape4k-hibernate:test :bluetape4k-hibernate-cache-lettuce:test :bluetape4k-hibernate-reactive:test :bluetape4k-r2dbc:test :bluetape4k-mongodb:test :bluetape4k-cassandra:test --max-workers=1 --no-configuration-cache`
- `./gradlew :bluetape4k-hibernate-reactive:dependencyInsight --configuration testRuntimeClasspath ...`
  - Resolved `hibernate-reactive-core:4.5.0.Final`, `hibernate-core:7.4.2.Final`, `vertx-sql-client:5.1.3`, `vertx-mysql-client:5.1.3`.
- `git diff --check`
- CodeGraph change analysis: low risk, no reported test gaps.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #912, milestone `1.11.0`, assignee `debop`
- PR: #913, head `8ad2bd4f240ba995820222e759c7a8399a13a9ad`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/hibernate-reactive-vertx`
- Labels: `bug`, `test`, `dependencies`
- State: `MERGED`, merge commit `e28acfdbda24ef83541db9215f79e4fb1461f99d`
- CI: - Unblock #900 so data-module CI can include Hibernate Reactive tests without a runtime API failure. / - Reproduced before fix through the #900 data CI candidate command: / - `./gradlew :bluetape4k-hibernate-reactive:test --max-workers=1 --no-configuration-cache`

## DoD Status

- [x] Runtime API mismatch reproduced before fix.
- [x] Partial upgrade failure checked and rejected.
- [x] Hibernate ORM and Reactive aligned to compatible versions.
- [x] Hibernate Reactive tests pass.
- [x] Hibernate core and Hibernate cache Lettuce tests pass.
- [x] Full data-module test command passes.
- [x] Lesson and review artifacts added.
- [x] GitHub Actions checks pass.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #913 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e28acfdbda24ef83541db9215f79e4fb1461f99d`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
