### PR TITLE
fix: run data module tests for data changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
       ktor: ${{ steps.filter.outputs.ktor }}
       key-utils: ${{ steps.filter.outputs.key-utils }}
       infra: ${{ steps.filter.outputs.infra }}
+      data: ${{ steps.filter.outputs.data }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
@@ -127,6 +128,9 @@ jobs:
               - 'infra/lettuce/**'
               - 'cache/cache-lettuce/**'
               - 'cache/cache-redisson/**'
+            data:
+              - 'data/**'
+              - 'cache/hibernate-cache-lettuce/**'
 
   # ── 2. 전체 빌드 (테스트 제외) ──────────────────────────────────────────
   build:
@@ -531,8 +535,79 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 30
 
+  # ── 7-b. Data 모듈 테스트 (Testcontainers) ───────────────────────────────
+  test-data:
+    name: Test / Data
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs.data == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Test data modules
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          shell: bash
+          command: |
+            ./gradlew \
+              :bluetape4k-jdbc:test \
+              :bluetape4k-hibernate:test \
+              :bluetape4k-hibernate-cache-lettuce:test \
+              :bluetape4k-hibernate-reactive:test \
+              :bluetape4k-r2dbc:test \
+              :bluetape4k-mongodb:test \
+              :bluetape4k-cassandra:test \
+              --max-workers=1 \
+              --no-configuration-cache
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Generate Kover XML report
+        if: always()
+        run: |
+          ./gradlew \
+            :bluetape4k-jdbc:koverXmlReport \
+            :bluetape4k-hibernate:koverXmlReport \
+            :bluetape4k-hibernate-cache-lettuce:koverXmlReport \
+            :bluetape4k-hibernate-reactive:koverXmlReport \
+            :bluetape4k-r2dbc:koverXmlReport \
+            :bluetape4k-mongodb:koverXmlReport \
+            :bluetape4k-cassandra:koverXmlReport \
+            --parallel \
+            --no-configuration-cache
+        continue-on-error: true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-data
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 30
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-data
+          path: '**/build/reports/kover/'
+          retention-days: 30
+
   # ── 나머지 모듈 → Nightly에서 실행 ─────────────────────────────────
-  # utils 전체, misc, data, spring3-docker, spring4-docker,
+  # utils 전체, misc, spring3-docker, spring4-docker,
   # testcontainers 는 nightly-tests.yml (매일 03:00 KST) 에서 실행
   # exposed 모듈은 bluetape4k-exposed 독립 레포로 분리됨 (#334)
 
@@ -541,7 +616,7 @@ jobs:
     name: Coverage Report
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [test-core, test-io, test-io-http, test-ktor, test-key-utils, test-infra]
+    needs: [test-core, test-io, test-io-http, test-ktor, test-key-utils, test-infra, test-data]
     if: always()
     steps:
       - uses: actions/checkout@v7
@@ -580,7 +655,7 @@ jobs:
     name: CI Status
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [gitleaks, validate-wrapper, changes, build, test-core, test-io, test-io-http, test-ktor, test-key-utils, test-infra, coverage-report]
+    needs: [gitleaks, validate-wrapper, changes, build, test-core, test-io, test-io-http, test-ktor, test-key-utils, test-infra, test-data, coverage-report]
     if: always()
     steps:
       - name: Check all jobs

--- a/docs/lessons/2026-06-26-issue-900-ci-data-tests.md
+++ b/docs/lessons/2026-06-26-issue-900-ci-data-tests.md
@@ -1,0 +1,22 @@
+# Lessons Learned - CI Data Tests (2026-06-26)
+
+Related issue: #900
+Affected workflow: `.github/workflows/ci.yml`
+
+## L1: Path filters need matching test jobs and summary needs
+
+### Problem
+
+The CI workflow compiled data modules during the build job, but it had no `data` path-filter output and no `Test / Data`
+job. Direct `data/**` changes could therefore merge without data-module test coverage in PR CI.
+
+### Lesson
+
+When a CI path group is introduced, wire the whole chain in the same change: `changes.outputs`, the paths-filter entry,
+the test job, coverage aggregation `needs`, and final CI status `needs`. A missing downstream `needs` entry can make a
+new test job invisible to summary gates.
+
+### Future guard
+
+Workflow coverage fixes should validate both syntax and wiring: run `actionlint`, grep for escaped `${{ }}` quotes, and
+check that new jobs appear in coverage and CI status dependencies.

--- a/docs/review/2026-06-26-issue-900-ci-data-tests-review.md
+++ b/docs/review/2026-06-26-issue-900-ci-data-tests-review.md
@@ -1,0 +1,47 @@
+# Review - CI Data Tests (2026-06-26)
+
+Issue: #900
+Branch: `fix/ci-data-tests`
+Workflow: `.github/workflows/ci.yml`
+
+## Scope
+
+- Added a `data` output to the CI `changes` job.
+- Added path filters for `data/**` and `cache/hibernate-cache-lettuce/**`.
+- Added `Test / Data` to run data module tests when data paths, shared CI paths, or manual dispatch trigger CI.
+- Added data coverage/test artifacts to the existing coverage aggregation and CI status dependency chain.
+
+## 7-Tier Review
+
+| Tier | Result | Evidence |
+|---|---:|---|
+| Correctness | PASS | `Test / Data` is gated by `needs.changes.outputs.data`, `shared`, or `workflow_dispatch`. |
+| Compatibility | PASS | Existing jobs and triggers are unchanged; new job only expands data-path test coverage. |
+| CI wiring | PASS | `test-data` is included in both `coverage-report.needs` and `ci-status.needs`. |
+| Test coverage | PASS | Data CI now covers JDBC, Hibernate, Hibernate cache, Hibernate Reactive, R2DBC, MongoDB, and Cassandra modules. |
+| Simplicity | PASS | One workflow file changed; no workflow refactor or new action dependency. |
+| Documentation | PASS | Lesson artifact records the filter/job/summary wiring rule. |
+| Regression risk | PASS | `actionlint` and `git diff --check` pass locally; GitHub Actions PR run remains the final workflow execution proof. |
+
+## Findings
+
+P0: 0
+P1: 0
+
+P2/P3: none requiring code changes before PR.
+
+## Validation Evidence
+
+- `actionlint .github/workflows/ci.yml`
+  - Result: PASS.
+- `rg -n "\\\\'" .github/workflows/ci.yml`
+  - Result: PASS, no escaped single quotes in the workflow.
+- `git diff --check`
+  - Result: PASS.
+- `./gradlew :bluetape4k-jdbc:test :bluetape4k-hibernate:test :bluetape4k-hibernate-cache-lettuce:test :bluetape4k-hibernate-reactive:test :bluetape4k-r2dbc:test :bluetape4k-mongodb:test :bluetape4k-cassandra:test --max-workers=1 --no-configuration-cache --rerun-tasks`
+  - Result: PASS, `BUILD SUCCESSFUL in 1m 49s`, 119 actionable tasks executed.
+
+## Remaining Risk
+
+The local validation proves workflow syntax and static wiring. The PR GitHub Actions run must prove that the new
+`Test / Data` job is scheduled and reported by `CI Status`.


### PR DESCRIPTION
## Summary

Closes #900

- PR 제목: fix: run data module tests for data changes

- Add a data path-filter output to the CI change detector.
- Run the Testcontainers-backed data module test lane for `data/**`, Hibernate cache Lettuce, shared workflow changes, and manual dispatch.
- Include the new data lane in coverage aggregation and final CI status dependencies so it cannot be invisible to the summary gate.

Fixes #900

## Background

The CI workflow compiled data modules during the build job but did not schedule data-module tests for PRs that changed `data/**`. That left JDBC, Hibernate, Hibernate Reactive, R2DBC, MongoDB, Cassandra, and the Hibernate Lettuce cache bridge dependent on Nightly coverage instead of same-PR evidence.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Added `changes.outputs.data` and paths-filter entries for `data/**` and `cache/hibernate-cache-lettuce/**`.
- Added `Test / Data` with the data module test command and `--max-workers=1` for sequential Testcontainers execution.
- Added data test and coverage artifacts.
- Added `test-data` to `coverage-report.needs` and `ci-status.needs`.
- Added lesson and review artifacts for CI filter/job/status wiring.

## Validation

- `actionlint .github/workflows/ci.yml`
- `rg -n -F "\\'" .github/workflows/ci.yml` returned no matches.
- `git diff --check`
- Ruby YAML wiring check: `ci data wiring ok`.
- `./gradlew :bluetape4k-jdbc:test :bluetape4k-hibernate:test :bluetape4k-hibernate-cache-lettuce:test :bluetape4k-hibernate-reactive:test :bluetape4k-r2dbc:test :bluetape4k-mongodb:test :bluetape4k-cassandra:test --max-workers=1 --no-configuration-cache --rerun-tasks`
  - `BUILD SUCCESSFUL in 1m 49s`, 119 actionable tasks executed.

## Review Notes

- Local 7-tier review artifact: `docs/review/2026-06-26-issue-900-ci-data-tests-review.md`.
- P0/P1 findings: 0.
- GitHub Actions proved the new `Test / Data` job was scheduled and included in final `CI Status`.

## Metadata

- Issue: #900, milestone `1.11.0`, assignee `debop`
- PR: #914, head `8dbb73291a8132625e460a988cf988aae744653f`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/ci-data-tests`
- Labels: `bug`, `test`, `ci`, `codex`, `codex-automation`
- State: `MERGED`, merge commit `8c2d785b37ee23a0bfd757773b5e0ba1ad050493`
- CI: - Add a data path-filter output to the CI change detector. / - Include the new data lane in coverage aggregation and final CI status dependencies so it cannot be invisible to the summary gate. / The CI workflow compiled data modules during the build job but did not schedule data-module tests for PRs that changed `data/**`. That left JDBC, Hibernate, Hibernate Reactive, R2DBC, MongoDB, Cassandra, and the Hibernate Lettuce cache bridge dependent on Nightly coverage instead of same-PR evidence.

## DoD Status

- [x] Issue #900 inspected and metadata copied to this PR.
- [x] CI data path filter output added.
- [x] Data module test job added with sequential Testcontainers execution.
- [x] Coverage and CI status dependencies include `test-data`.
- [x] Lesson artifact committed before PR creation.
- [x] Local workflow syntax and wiring validation pass.
- [x] Local data module test lane passes with `--rerun-tasks`.
- [x] GitHub Actions checks pass, including `Test / Data` and `CI Status`.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #914 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `8c2d785b37ee23a0bfd757773b5e0ba1ad050493`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
