### PR TITLE
fix: surface Lettuce near-cache clear failures

### DIFF
--- a/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceNearCache.kt
+++ b/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/nearcache/LettuceNearCache.kt
@@ -339,7 +339,7 @@ class LettuceNearCache<V: Any>(
      */
     override fun clearAll() {
         clearLocal()
-        runCatching { clearBack() }
+        clearBack()
     }
 
     /**

--- a/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/nearcache/LettuceNearCacheTest.kt
+++ b/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/nearcache/LettuceNearCacheTest.kt
@@ -219,6 +219,26 @@ class LettuceNearCacheTest: AbstractLettuceNearCacheTest() {
         }
     }
 
+    @Test
+    fun `clearAll - Redis clear 실패를 호출자에게 전파한다`() {
+        val failingCacheName = "fail-clear-" + Base58.randomString(6)
+        val failingCache =
+            LettuceNearCache(
+                redisClient = resp3Client,
+                codec = failingKeyDecodeCodec(),
+                config = LettuceNearCacheConfig(cacheName = failingCacheName)
+            )
+
+        failingCache.use { c ->
+            directCommands.set("$failingCacheName:k", "v")
+
+            assertFailsWith<Exception> {
+                c.clearAll()
+            }
+            directCommands.get("$failingCacheName:k") shouldBeEqualTo "v"
+        }
+    }
+
     // ---- TTL ----
 
     @Test
@@ -419,6 +439,20 @@ class LettuceNearCacheTest: AbstractLettuceNearCacheTest() {
 
             override fun encodeValue(value: String): ByteBuffer =
                 throw IllegalStateException("encode failure for test")
+        }
+
+    private fun failingKeyDecodeCodec(): RedisCodec<String, String> =
+        object: RedisCodec<String, String> {
+            private val delegate = StringCodec.UTF8
+
+            override fun decodeKey(bytes: ByteBuffer): String =
+                throw IllegalStateException("decode key failure for test")
+
+            override fun decodeValue(bytes: ByteBuffer): String = delegate.decodeValue(bytes)
+
+            override fun encodeKey(key: String): ByteBuffer = delegate.encodeKey(key)
+
+            override fun encodeValue(value: String): ByteBuffer = delegate.encodeValue(value)
         }
 
     private fun assertWriteFailure(block: () -> Unit) {

--- a/docs/lessons/2026-06-26-issue-786-lettuce-clear-failure.md
+++ b/docs/lessons/2026-06-26-issue-786-lettuce-clear-failure.md
@@ -1,0 +1,23 @@
+# Lessons Learned - Lettuce Near Cache Clear Failure (2026-06-26)
+
+Related issue: #786
+Affected module: `:bluetape4k-cache-lettuce`
+
+## L1: Do not hide backend clear failures behind best-effort cleanup
+
+### Problem
+
+`LettuceNearCache.clearAll()` cleared the local Caffeine cache and then wrapped Redis key cleanup in `runCatching`.
+When Redis `SCAN` or `UNLINK` failed, callers saw success even though backend entries could remain and later repopulate
+the local cache.
+
+### Lesson
+
+For cache APIs whose contract says "local + backend", backend deletion failure must be visible to the caller unless the
+API explicitly models partial success. Blocking and suspend near-cache implementations should expose equivalent failure
+semantics.
+
+### Future guard
+
+Failure-path tests should make backend cleanup fail before deletion and assert both that the caller receives an exception
+and that the backend key remains. Avoid `runCatching` around required backend operations when the result is ignored.

--- a/docs/review/2026-06-26-issue-786-lettuce-clear-failure-review.md
+++ b/docs/review/2026-06-26-issue-786-lettuce-clear-failure-review.md
@@ -1,0 +1,43 @@
+# Review - Lettuce Near Cache Clear Failure (2026-06-26)
+
+Issue: #786
+Branch: `fix/lettuce-near-cache-clear-failure`
+Module: `:bluetape4k-cache-lettuce`
+
+## Scope
+
+- Changed blocking `LettuceNearCache.clearAll()` to propagate Redis backend cleanup failures.
+- Added a regression test that makes Redis key decoding fail during `SCAN`, proves `clearAll()` throws, and verifies the
+  backend key remains.
+
+## Review Findings
+
+P0: 0
+P1: 0
+
+P2/P3: none requiring code changes before PR.
+
+## 7-Tier Review
+
+| Tier | Result | Evidence |
+|---|---:|---|
+| Correctness | PASS | Blocking `clearAll()` now matches suspend semantics by letting `clearBack()` failures propagate. |
+| Regression coverage | PASS | `clearAll - Redis clear 실패를 호출자에게 전파한다` covers the hidden failure path. |
+| Data safety | PASS | The regression proves the backend key remains when clear fails, so callers can retry or handle partial clear. |
+| Compatibility | PASS | Successful clear behavior and cache-name isolation tests remain in the same test class. |
+| Simplicity | PASS | Production change removes ignored `runCatching`; no new abstraction or dependency. |
+| Concurrency | PASS | No concurrent behavior changed; existing `MultithreadingTester` and `StructuredTaskScopeTester` tests remain untouched. |
+| Evidence | PASS | Full affected module test passed locally. CodeGraph impact analysis reported low risk / no additional impacted files. |
+
+## Validation Evidence
+
+- `./gradlew :bluetape4k-cache-lettuce:test --tests 'io.bluetape4k.cache.nearcache.LettuceNearCacheTest.clearAll - Redis clear 실패를 호출자에게 전파한다' --no-configuration-cache --rerun-tasks`
+  - Result: PASS, 1 passing, `BUILD SUCCESSFUL in 27s`.
+- `./gradlew :bluetape4k-cache-lettuce:test --max-workers=1 --no-configuration-cache`
+  - Result: PASS, 436 passing, `BUILD SUCCESSFUL in 47s`.
+- CodeGraph impact radius
+  - Result: low risk, no additional impacted files.
+
+## Remaining Risk
+
+CI must rerun the affected module on GitHub Actions before merge.


### PR DESCRIPTION
## Summary

Closes #786

- PR 제목: fix: surface Lettuce near-cache clear failures

- Make blocking `LettuceNearCache.clearAll()` propagate Redis backend clear failures.
- Add a regression test that forces Redis `SCAN` key decode failure during `clearAll()`.
- Record lesson and review artifacts for the hidden partial-clear behavior.

Fixes #786

## Background

`NearCacheOperations.clearAll()` promises to clear both local and backend cache entries. The blocking Lettuce implementation cleared the local cache first, then wrapped Redis cleanup in ignored `runCatching`, so callers could observe success while stale Redis entries remained. The suspend implementation already propagated backend clear failures.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Removed ignored `runCatching` around blocking `clearBack()`.
- Added `clearAll - Redis clear 실패를 호출자에게 전파한다` regression coverage.
- The regression leaves a backend key in Redis, makes `SCAN` fail through a key-decode codec, asserts `clearAll()` throws, and confirms the backend key remains.

## Validation

- `./gradlew :bluetape4k-cache-lettuce:test --tests 'io.bluetape4k.cache.nearcache.LettuceNearCacheTest.clearAll - Redis clear 실패를 호출자에게 전파한다' --no-configuration-cache --rerun-tasks`
  - PASS: 1 passing, `BUILD SUCCESSFUL in 27s`.
- `./gradlew :bluetape4k-cache-lettuce:test --max-workers=1 --no-configuration-cache`
  - PASS: 436 passing, `BUILD SUCCESSFUL in 47s`.
- `git diff --check`
- CodeGraph impact/review context: low risk, no additional impacted files, no test gaps reported.
- GitHub Actions:
  - `Test / Infra (Redis)` PASS in 5m03s.
  - `CI Status` PASS in 5s.

## Review Notes

- Local 7-tier review artifact: `docs/review/2026-06-26-issue-786-lettuce-clear-failure-review.md`.
- P0/P1 findings: 0.
- Concurrency-test rationale: no concurrent behavior changed; existing `MultithreadingTester` and `StructuredTaskScopeTester` tests remain in the affected test class.

## Metadata

- Issue: #786, milestone `1.11.0`, assignee `debop`
- PR: #915, head `4cf2143300830462b361beb5b1f03d17c9d893c1`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/lettuce-near-cache-clear-failure`
- Labels: `bug`
- State: `MERGED`, merge commit `eed4049537ebef1d00073e50437dc2c28d2aa4f5`
- CI: - `./gradlew :bluetape4k-cache-lettuce:test --tests 'io.bluetape4k.cache.nearcache.LettuceNearCacheTest.clearAll - Redis clear 실패를 호출자에게 전파한다' --no-configuration-cache --rerun-tasks` / - `./gradlew :bluetape4k-cache-lettuce:test --max-workers=1 --no-configuration-cache` / - `CI Status` PASS in 5s.

## DoD Status

- [x] Issue #786 inspected and metadata copied to this PR.
- [x] Blocking `clearAll()` now propagates Redis backend clear failures.
- [x] Blocking and suspend clear failure semantics are aligned.
- [x] Regression test proves callers can detect backend clear failure.
- [x] Regression test proves the backend key remains when clear fails before deletion.
- [x] Full affected module test passes locally.
- [x] Lesson and review artifacts committed before PR creation.
- [x] GitHub Actions checks pass.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #915 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `eed4049537ebef1d00073e50437dc2c28d2aa4f5`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
