### PR TITLE
fix: harden Hibernate cache key encoding

### DIFF
--- a/cache/hibernate-cache-lettuce/README.ko.md
+++ b/cache/hibernate-cache-lettuce/README.ko.md
@@ -37,7 +37,8 @@ artifact, Kotlin package는 유지됩니다.
 ![Hibernate Lettuce Cache Layer Structure diagram](../../docs/images/readme-diagrams/cache-hibernate-cache-lettuce-diagram-02.png)
 
 - **Region 격리**: 각 Region은 독립된 `LettuceNearCache` 인스턴스를 가짐
-- **키 prefix**: `{regionName}::{key}` 형식으로 Redis 키 충돌 방지
+- **키 prefix**: Redis key는 `{regionName}:{key}` prefix를 사용해 Region별 key space를 분리
+- **Hibernate key encoding**: Hibernate key는 Region prefix 적용 전에 versioned collision-resistant digest로 정규화
 - **AccessType**: `NONSTRICT_READ_WRITE` 권장 (분산 캐시에서 soft-lock 불필요)
 
 ## 최근 변경

--- a/cache/hibernate-cache-lettuce/README.md
+++ b/cache/hibernate-cache-lettuce/README.md
@@ -38,7 +38,8 @@ No user import migration is required for the reorganization.
 ![Hibernate Lettuce Cache Layer Structure diagram](../../docs/images/readme-diagrams/cache-hibernate-cache-lettuce-diagram-02.png)
 
 - **Region Isolation**: Each region gets its own `LettuceNearCache` instance
-- **Key Prefix**: Redis key collision is prevented using the `{regionName}::{key}` format
+- **Key Prefix**: Redis keys use the `{regionName}:{key}` prefix so regions do not share a key space
+- **Hibernate Key Encoding**: Hibernate keys are normalized to a versioned collision-resistant digest before the region prefix is applied
 - **AccessType**: `NONSTRICT_READ_WRITE` is recommended (soft-locking is unnecessary in a distributed cache)
 
 ## Recent Changes

--- a/cache/hibernate-cache-lettuce/src/main/kotlin/io/bluetape4k/hibernate/cache/lettuce/LettuceNearCacheStorageAccess.kt
+++ b/cache/hibernate-cache-lettuce/src/main/kotlin/io/bluetape4k/hibernate/cache/lettuce/LettuceNearCacheStorageAccess.kt
@@ -8,6 +8,11 @@ import org.hibernate.cache.internal.CacheKeyImplementation
 import org.hibernate.cache.internal.NaturalIdCacheKey
 import org.hibernate.cache.spi.support.DomainDataStorageAccess
 import org.hibernate.engine.spi.SharedSessionContractImplementor
+import java.io.ByteArrayOutputStream
+import java.io.ObjectOutputStream
+import java.io.Serializable
+import java.security.MessageDigest
+import java.util.Base64
 
 /**
  * [DomainDataStorageAccess] 구현체.
@@ -28,47 +33,146 @@ class LettuceNearCacheStorageAccess(
     private val nearCache: LettuceNearCache<Any>,
 ): DomainDataStorageAccess {
 
-    companion object: KLogging()
+    companion object: KLogging() {
+        private const val KEY_VERSION = "hck2"
+    }
 
     // nearCache가 cacheName(=regionName) prefix를 Redis key에 자동으로 추가하므로
-    // 여기서는 key를 stable string으로 정규화만 한다. (이중 prefix 방지)
+    // 여기서는 충돌 방지용 stable digest key로 정규화만 한다. (이중 prefix 방지)
     private fun cacheKey(key: Any): String = when (key) {
-        is BasicCacheKeyImplementation -> "${key.entityOrRoleName}#${canonicalString(key.id)}"
-        is CacheKeyImplementation      -> "${key.entityOrRoleName}#${canonicalString(key.id)}"
-        is NaturalIdCacheKey           -> buildString {
-            append(key.entityName)
-            append("##NaturalId[")
-            append(canonicalNaturalIdValues(key.naturalIdValues))
-            append("]")
+        is BasicCacheKeyImplementation -> digestKey(
+            kind = "basic",
+            entityOrRoleName = key.entityOrRoleName,
+            tenantId = null,
+            value = key.id,
+        )
+
+        is CacheKeyImplementation      -> digestKey(
+            kind = "cache",
+            entityOrRoleName = key.entityOrRoleName,
+            tenantId = key.tenantId,
+            value = key.id,
+        )
+
+        is NaturalIdCacheKey           -> digestKey(
+            kind = "natural-id",
+            entityOrRoleName = key.entityName,
+            tenantId = key.tenantId,
+            value = key.naturalIdValues,
+        )
+
+        else                           -> digestKey(
+            kind = "raw",
+            entityOrRoleName = key.javaClass.name,
+            tenantId = null,
+            value = key,
+        )
+    }
+
+    private fun digestKey(
+        kind: String,
+        entityOrRoleName: String,
+        tenantId: String?,
+        value: Any?,
+    ): String {
+        val canonical = canonicalBytes(kind, entityOrRoleName, tenantId, value)
+        val digest = MessageDigest.getInstance("SHA-256").digest(canonical)
+        val encoded = Base64.getUrlEncoder().withoutPadding().encodeToString(digest)
+        return "$KEY_VERSION:$encoded"
+    }
+
+    private fun canonicalBytes(
+        kind: String,
+        entityOrRoleName: String,
+        tenantId: String?,
+        value: Any?,
+    ): ByteArray =
+        ByteArrayOutputStream().use { bytes ->
+            ObjectOutputStream(bytes).use { out ->
+                out.writeUTF(KEY_VERSION)
+                out.writeUTF(kind)
+                out.writeUTF(entityOrRoleName)
+                out.writeBoolean(tenantId != null)
+                tenantId?.let(out::writeUTF)
+                out.writeCanonicalValue(value)
+            }
+            bytes.toByteArray()
         }
-        else                           -> canonicalString(key)
+
+    private fun ObjectOutputStream.writeCanonicalValue(value: Any?) {
+        when (value) {
+            null            -> writeUTF("null")
+            is Array<*>     -> writeObjectArray(value)
+            is BooleanArray -> writePrimitiveArray("boolean[]", value.toList()) { writeBoolean(it) }
+            is ByteArray    -> writeByteArray(value)
+            is CharArray    -> writePrimitiveArray("char[]", value.toList()) { writeChar(it.code) }
+            is DoubleArray  -> writePrimitiveArray("double[]", value.toList()) { writeDouble(it) }
+            is FloatArray   -> writePrimitiveArray("float[]", value.toList()) { writeFloat(it) }
+            is IntArray     -> writePrimitiveArray("int[]", value.toList()) { writeInt(it) }
+            is LongArray    -> writePrimitiveArray("long[]", value.toList()) { writeLong(it) }
+            is ShortArray   -> writePrimitiveArray("short[]", value.toList()) { writeShort(it.toInt()) }
+            is Serializable -> writeSerializableValue(value)
+            else            -> writeTextFallback(value)
+        }
     }
 
-    private fun canonicalNaturalIdValues(values: Any?): String = when (values) {
-        is Array<*>     -> values.joinToString(", ") { canonicalString(it) }
-        is BooleanArray -> values.joinToString(", ")
-        is ByteArray    -> values.joinToString(", ")
-        is CharArray    -> values.joinToString(", ")
-        is DoubleArray  -> values.joinToString(", ")
-        is FloatArray   -> values.joinToString(", ")
-        is IntArray     -> values.joinToString(", ")
-        is LongArray    -> values.joinToString(", ")
-        is ShortArray   -> values.joinToString(", ")
-        else            -> canonicalString(values)
+    private fun ObjectOutputStream.writeObjectArray(values: Array<*>) {
+        writeUTF("array")
+        writeUTF(values.javaClass.componentType?.name ?: "java.lang.Object")
+        writeInt(values.size)
+        values.forEach { writeCanonicalValue(it) }
     }
 
-    private fun canonicalString(value: Any?): String = when (value) {
-        null            -> "null"
-        is Array<*>     -> value.joinToString(prefix = "[", postfix = "]") { canonicalString(it) }
-        is BooleanArray -> value.joinToString(prefix = "[", postfix = "]")
-        is ByteArray    -> value.joinToString(prefix = "[", postfix = "]")
-        is CharArray    -> value.joinToString(prefix = "[", postfix = "]")
-        is DoubleArray  -> value.joinToString(prefix = "[", postfix = "]")
-        is FloatArray   -> value.joinToString(prefix = "[", postfix = "]")
-        is IntArray     -> value.joinToString(prefix = "[", postfix = "]")
-        is LongArray    -> value.joinToString(prefix = "[", postfix = "]")
-        is ShortArray   -> value.joinToString(prefix = "[", postfix = "]")
-        else            -> value.toString()
+    private inline fun <T> ObjectOutputStream.writePrimitiveArray(
+        typeName: String,
+        values: List<T>,
+        writeElement: ObjectOutputStream.(T) -> Unit,
+    ) {
+        writeUTF("array")
+        writeUTF(typeName)
+        writeInt(values.size)
+        values.forEach { writeElement(it) }
+    }
+
+    private fun ObjectOutputStream.writeByteArray(values: ByteArray) {
+        writeUTF("array")
+        writeUTF("byte[]")
+        writeInt(values.size)
+        write(values)
+    }
+
+    private fun ObjectOutputStream.writeSerializableValue(value: Serializable) {
+        val serialized = serializeValue(value)
+        if (serialized == null) {
+            writeTextFallback(value)
+            return
+        }
+
+        writeUTF("serializable")
+        writeUTF(value.javaClass.name)
+        writeInt(serialized.size)
+        write(serialized)
+    }
+
+    private fun serializeValue(value: Serializable): ByteArray? =
+        runCatching {
+            ByteArrayOutputStream().use { bytes ->
+                ObjectOutputStream(bytes).use { out -> out.writeObject(value) }
+                bytes.toByteArray()
+            }
+        }.getOrNull()
+
+    private fun ObjectOutputStream.writeTextFallback(value: Serializable) {
+        writeUTF("text")
+        writeUTF(value.javaClass.name)
+        writeInt(value.hashCode())
+        writeUTF(value.toString())
+    }
+
+    private fun ObjectOutputStream.writeTextFallback(value: Any) {
+        writeUTF("text")
+        writeUTF(value.javaClass.name)
+        writeUTF(value.toString())
     }
 
     /**

--- a/cache/hibernate-cache-lettuce/src/test/kotlin/io/bluetape4k/hibernate/cache/lettuce/HibernateAdvancedKeyCacheTest.kt
+++ b/cache/hibernate-cache-lettuce/src/test/kotlin/io/bluetape4k/hibernate/cache/lettuce/HibernateAdvancedKeyCacheTest.kt
@@ -4,15 +4,23 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.cache.nearcache.LettuceNearCache
+import io.bluetape4k.cache.nearcache.LettuceNearCacheConfig
 import io.bluetape4k.hibernate.cache.lettuce.model.CompositePerson
 import io.bluetape4k.hibernate.cache.lettuce.model.CompositePersonId
 import io.bluetape4k.hibernate.cache.lettuce.model.NaturalUser
 import io.bluetape4k.hibernate.cache.lettuce.model.Person
+import io.lettuce.core.RedisClient
+import io.lettuce.core.codec.StringCodec
 import org.hibernate.KeyType
+import org.hibernate.cache.internal.BasicCacheKeyImplementation
+import org.hibernate.cache.internal.NaturalIdCacheKey
 import org.hibernate.cache.spi.RegionFactory
+import org.hibernate.engine.spi.SharedSessionContractImplementor
 import org.hibernate.engine.spi.SessionFactoryImplementor
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.io.Serializable
 
 class HibernateAdvancedKeyCacheTest: AbstractHibernateNearCacheTest() {
 
@@ -29,7 +37,7 @@ class HibernateAdvancedKeyCacheTest: AbstractHibernateNearCacheTest() {
     }
 
     @Test
-    fun `composite id entity는 2nd level cache를 사용하고 Redis key는 문자열이다`() {
+    fun `composite id entity는 2nd level cache를 사용하고 Redis key는 digest 문자열이다`() {
         val id = CompositePersonId(companyCode = "ACME", employeeNo = 1001L)
 
         sessionFactory.openSession().use { session ->
@@ -59,11 +67,11 @@ class HibernateAdvancedKeyCacheTest: AbstractHibernateNearCacheTest() {
         val redisKeys = redisKeys("$regionName:*")
 
         redisKeys.size shouldBeGreaterThan 0
-        redisKeys.any { it.contains("[ACME, 1001]") }.shouldBeTrue()
+        redisKeys.any { it.contains("hck2:") }.shouldBeTrue()
     }
 
     @Test
-    fun `natural-id cache는 hit를 만들고 Redis key는 NaturalId 문자열 표현을 사용한다`() {
+    fun `natural-id cache는 hit를 만들고 Redis key는 digest 문자열을 사용한다`() {
         sessionFactory.openSession().use { session ->
             session.beginTransaction()
             session.persist(
@@ -98,12 +106,56 @@ class HibernateAdvancedKeyCacheTest: AbstractHibernateNearCacheTest() {
             regionFactory.getCaches().keys.first { it.contains("##NaturalId") || it.contains("NaturalUser") }
         val redisKeys = redisKeys("$regionName:*")
 
-        redisKeys.any { key -> key.contains("##NaturalId[") }.shouldBeTrue()
-        redisKeys.any { key -> key.contains("natural@example.com") }.shouldBeTrue()
+        redisKeys.any { key -> key.contains("hck2:") }.shouldBeTrue()
     }
 
     @Test
-    fun `update timestamps cache도 문자열 key를 사용한다`() {
+    fun `natural-id delimiter value와 composite arity는 같은 cache key로 충돌하지 않는다`() {
+        withStorageAccess("natural-id-collision-${System.nanoTime()}") { cacheName, storageAccess, session ->
+            val singleValueKey = NaturalIdCacheKey("alpha, beta", "NaturalEntity", null, 1)
+            val compositeValueKey = NaturalIdCacheKey(arrayOf("alpha", "beta"), "NaturalEntity", null, 2)
+
+            storageAccess.putIntoCache(singleValueKey, "single-value", session)
+            storageAccess.putIntoCache(compositeValueKey, "composite-value", session)
+
+            storageAccess.getFromCache(singleValueKey, session) shouldBeEqualTo "single-value"
+            storageAccess.getFromCache(compositeValueKey, session) shouldBeEqualTo "composite-value"
+            redisKeys("$cacheName:*").size shouldBeEqualTo 2
+        }
+    }
+
+    @Test
+    fun `scalar identifier와 object array identifier는 같은 cache key로 충돌하지 않는다`() {
+        withStorageAccess("array-scalar-collision-${System.nanoTime()}") { cacheName, storageAccess, session ->
+            val scalarKey = BasicCacheKeyImplementation("[1, 2]" as Serializable, "ArrayEntity", 1)
+            val arrayKey = BasicCacheKeyImplementation(arrayOf(1, 2) as Serializable, "ArrayEntity", 2)
+
+            storageAccess.putIntoCache(scalarKey, "scalar-id", session)
+            storageAccess.putIntoCache(arrayKey, "array-id", session)
+
+            storageAccess.getFromCache(scalarKey, session) shouldBeEqualTo "scalar-id"
+            storageAccess.getFromCache(arrayKey, session) shouldBeEqualTo "array-id"
+            redisKeys("$cacheName:*").size shouldBeEqualTo 2
+        }
+    }
+
+    @Test
+    fun `same toString custom identifiers는 같은 cache key로 충돌하지 않는다`() {
+        withStorageAccess("custom-id-collision-${System.nanoTime()}") { cacheName, storageAccess, session ->
+            val firstKey = BasicCacheKeyImplementation(OpaqueIdentifier("first"), "OpaqueEntity", 1)
+            val secondKey = BasicCacheKeyImplementation(OpaqueIdentifier("second"), "OpaqueEntity", 2)
+
+            storageAccess.putIntoCache(firstKey, "first-id", session)
+            storageAccess.putIntoCache(secondKey, "second-id", session)
+
+            storageAccess.getFromCache(firstKey, session) shouldBeEqualTo "first-id"
+            storageAccess.getFromCache(secondKey, session) shouldBeEqualTo "second-id"
+            redisKeys("$cacheName:*").size shouldBeEqualTo 2
+        }
+    }
+
+    @Test
+    fun `update timestamps cache도 digest 문자열 key를 사용한다`() {
         sessionFactory.openSession().use { session ->
             session.beginTransaction()
             session.persist(
@@ -133,6 +185,46 @@ class HibernateAdvancedKeyCacheTest: AbstractHibernateNearCacheTest() {
         val redisKeys = redisKeys("${RegionFactory.DEFAULT_UPDATE_TIMESTAMPS_REGION_UNQUALIFIED_NAME}:*")
 
         redisKeys.shouldNotBeNull()
-        redisKeys.any { key -> key.contains("persons") }.shouldBeTrue()
+        redisKeys.any { key -> key.contains("hck2:") }.shouldBeTrue()
+    }
+
+    private fun withStorageAccess(
+        cacheName: String,
+        block: (String, LettuceNearCacheStorageAccess, SharedSessionContractImplementor) -> Unit,
+    ) {
+        val redisClient = RedisClient.create(redisUri)
+        val config = LettuceNearCacheConfig<String, String>(
+            cacheName = cacheName,
+            useRespProtocol3 = false,
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        val nearCache = LettuceNearCache(redisClient, StringCodec.UTF8, config) as LettuceNearCache<Any>
+
+        redisClient.use {
+            nearCache.use { cache ->
+                try {
+                    sessionFactory.openSession().use { session ->
+                        block(
+                            cacheName,
+                            LettuceNearCacheStorageAccess(cacheName, cache),
+                            session as SharedSessionContractImplementor,
+                        )
+                    }
+                } finally {
+                    cache.clearAll()
+                }
+            }
+        }
+    }
+
+    private data class OpaqueIdentifier(
+        private val value: String,
+    ): Serializable {
+        override fun toString(): String = "opaque"
+
+        companion object {
+            private const val serialVersionUID: Long = 1L
+        }
     }
 }

--- a/docs/lessons/2026-06-26-issue-788-hibernate-cache-key-encoding.md
+++ b/docs/lessons/2026-06-26-issue-788-hibernate-cache-key-encoding.md
@@ -1,0 +1,26 @@
+# Lessons Learned - Hibernate Cache Key Encoding (2026-06-26)
+
+Related issue: #788
+Affected module: `:bluetape4k-hibernate-cache-lettuce`
+
+## L1: Cache key collision claims need public-path collision tests
+
+### Problem
+
+`LettuceNearCacheStorageAccess` normalized Hibernate keys with delimiter joins and `toString()`.
+That erased natural-id arity, array/scalar boundaries, and custom identifier state when `toString()` values matched.
+The README claimed Redis key collision prevention, but tests only checked that readable key fragments existed.
+
+### Lesson
+
+When a cache bridge claims key collision resistance, cover the bridge's public storage path with adversarial keys:
+
+- a single delimiter-containing natural-id value versus a composite natural-id array,
+- scalar identifier text versus object-array identifier text,
+- custom identifiers with identical `toString()` output but different serialized state.
+
+### Future guard
+
+Do not use readable delimiter strings as distributed cache keys unless every component is length-prefixed or otherwise
+typed. Prefer a versioned canonical digest key when the raw key can contain user values or Hibernate-disassembled
+objects.

--- a/docs/review/2026-06-26-issue-788-hibernate-cache-key-encoding-review.md
+++ b/docs/review/2026-06-26-issue-788-hibernate-cache-key-encoding-review.md
@@ -1,0 +1,43 @@
+# Review - Hibernate Cache Key Encoding (2026-06-26)
+
+Issue: #788
+Branch: `fix/hibernate-cache-key-encoding`
+Module: `:bluetape4k-hibernate-cache-lettuce`
+
+## Scope
+
+- Replaced delimiter-based Hibernate cache key normalization in `LettuceNearCacheStorageAccess`.
+- Added collision regression tests through the `DomainDataStorageAccess` public path.
+- Updated English and Korean README key-isolation wording.
+
+## 7-Tier Review
+
+| Tier | Result | Evidence |
+|---|---:|---|
+| Tier 1 - Security | PASS | Natural-id delimiter, array/scalar, and same-`toString()` custom identifier collisions are covered by regression tests. |
+| Tier 2 - Architecture | PASS | Region isolation stays in `LettuceNearCache`; storage access only normalizes the Hibernate key before the region prefix is applied. |
+| Tier 3 - Performance | PASS | Redis keys are bounded to `hck2:<sha256-base64url>` instead of unbounded entity/key strings. |
+| Tier 4 - Correctness | PASS | Canonical digest input includes key kind, entity/role name, tenant id, null markers, primitive/object array boundaries, and Serializable object bytes. |
+| Tier 5 - Tests | PASS | Targeted class: 6 passing; full module: 80 passing. |
+| Tier 6 - Documentation | PASS | `README.md` and `README.ko.md` now distinguish region prefix isolation from collision-resistant Hibernate key encoding. |
+| Tier 7 - Evidence | PASS | `git diff --check` clean; CodeGraph change detection reports no additional affected flows or test gaps. |
+
+## Findings
+
+P0: 0
+P1: 0
+
+P2/P3: none requiring code changes before PR.
+
+## Validation Evidence
+
+- `./gradlew :bluetape4k-hibernate-cache-lettuce:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache`
+  - Result: PASS, `BUILD SUCCESSFUL in 12s`.
+- `./gradlew :bluetape4k-hibernate-cache-lettuce:test --tests 'io.bluetape4k.hibernate.cache.lettuce.HibernateAdvancedKeyCacheTest' --no-daemon --no-configuration-cache --rerun-tasks`
+  - Result: PASS, 6 passing.
+- `./gradlew :bluetape4k-hibernate-cache-lettuce:test --no-daemon --no-configuration-cache --rerun-tasks`
+  - Result: PASS, 80 passing.
+- `git diff --check`
+  - Result: PASS.
+- CodeGraph `detect_changes_tool(base=develop)`
+  - Result: risk score 0.00, no test gaps.


### PR DESCRIPTION
## Summary

Closes #788

- PR 제목: fix: harden Hibernate cache key encoding

### 원문 선행 내용

Fixes #788

## Background

`LettuceNearCacheStorageAccess` normalized Hibernate cache keys with delimiter joins and `toString()`. That erased natural-id arity, array/scalar boundaries, tenant separation for generic cache keys, and custom identifier state when `toString()` values matched.

## What This Solves

This PR replaces readable delimiter keys with a versioned bounded digest key. The digest input is a canonical typed payload that includes the Hibernate key kind, entity/role name, tenant id when available, null markers, primitive/object array boundaries, and Serializable object bytes.

## Work Done

- Added `hck2:<sha256-base64url>` key normalization for Hibernate Lettuce storage access.
- Preserved region isolation in `LettuceNearCache` while keeping StorageAccess responsible only for the Hibernate key payload.
- Added public-path collision tests for natural-id delimiter values, array/scalar identifiers, and custom identifiers with the same `toString()`.
- Updated English and Korean README wording to distinguish Redis region prefixing from collision-resistant Hibernate key encoding.
- Added review and lessons artifacts for this security bugfix.

## Validation

- `./gradlew :bluetape4k-hibernate-cache-lettuce:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache`: PASS, `BUILD SUCCESSFUL in 12s`.
- `./gradlew :bluetape4k-hibernate-cache-lettuce:test --tests 'io.bluetape4k.hibernate.cache.lettuce.HibernateAdvancedKeyCacheTest' --no-daemon --no-configuration-cache --rerun-tasks`: PASS, 6 passing.
- `./gradlew :bluetape4k-hibernate-cache-lettuce:test --no-daemon --no-configuration-cache --rerun-tasks`: PASS, 80 passing.
- `git diff --check`: PASS.
- CodeGraph `detect_changes_tool(base=develop)`: risk score 0.00, no test gaps.
- GitHub CI: PASS (`Build`, `Test / Data`, `Coverage Report`, `CI Status`, `Secret Scan`, `Validate Gradle Wrapper`, `submit-gradle`; unrelated lanes skipped by changed-module detection).

## Review Notes

- Review artifact: `docs/review/2026-06-26-issue-788-hibernate-cache-key-encoding-review.md`.
- P0/P1 findings: 0.
- PR review/comment gate completed; P0/P1 findings remained 0.
- IntelliJ diagnostics were not available in this Codex surface; Gradle compile/test and CodeGraph were used as fallback evidence.

## Metadata

- Issue: #788, milestone `1.11.0`, assignee `debop`
- PR: #916, head `cad4559d5c4bef04b8c410af1ef401d3ff1bef1e`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/hibernate-cache-key-encoding`
- Labels: `bug`, `security`
- State: `MERGED`, merge commit `b7ee1c6674b8584b8e0c1550e9b6b53a713ffea6`
- CI: - `./gradlew :bluetape4k-hibernate-cache-lettuce:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache`: PASS, `BUILD SUCCESSFUL in 12s`. / - `./gradlew :bluetape4k-hibernate-cache-lettuce:test --tests 'io.bluetape4k.hibernate.cache.lettuce.HibernateAdvancedKeyCacheTest' --no-daemon --no-configuration-cache --rerun-tasks`: PASS, 6 passing. / - `./gradlew :bluetape4k-hibernate-cache-lettuce:test --no-daemon --no-configuration-cache --rerun-tasks`: PASS, 80 passing.

## DoD Status

| Step | Status | Evidence |
|---|---:|---|
| W - Worktree | PASS | `.worktrees/fix-hibernate-cache-key-encoding` from `develop` at `eed404953`. |
| A - Issue analysis | PASS | #788 inspected; collision vectors reproduced through public `DomainDataStorageAccess` path. |
| F - Fix | PASS | `LettuceNearCacheStorageAccess` uses versioned canonical SHA-256 digest keys. |
| 4-T - Tests | PASS | Targeted class 6 passing; full module 80 passing. |
| 6-R - Review | PASS | `docs/review/2026-06-26-issue-788-hibernate-cache-key-encoding-review.md`; P0/P1=0. |
| 6 partial - README | PASS | `README.md` and `README.ko.md` updated for key encoding behavior. |
| 7 - Lessons | PASS | `docs/lessons/2026-06-26-issue-788-hibernate-cache-key-encoding.md`. |
| 7-P - PR metadata | PASS | Fixes #788; milestone `1.11.0`; assignee `debop`; labels `bug`, `security`. |
| 7-R - Post-PR review | PASS | PR comment and formal review entry posted; P0/P1=0. |
| 8 - CI gate | PASS | GitHub CI all required checks pass; unrelated matrix lanes skipped. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #916 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `b7ee1c6674b8584b8e0c1550e9b6b53a713ffea6`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
