### PR TITLE
fix: align Hibernate converter runtime deps

### DIFF
--- a/data/hibernate/README.ko.md
+++ b/data/hibernate/README.ko.md
@@ -31,18 +31,14 @@ dependencies {
 
     // Querydsl (선택)
     implementation("com.querydsl:querydsl-jpa:5.1.0:jakarta")
-
-    // 암호화 Converter 사용 시 (Google Tink)
-    compileOnly("io.github.bluetape4k:bluetape4k-tink:${version}")
-
-    // JSON Converter 사용 시
-    compileOnly("io.github.bluetape4k:bluetape4k-jackson2:${version}")
-
-    // 직렬화 Converter 사용 시 (Kryo 또는 Apache Fory)
-    compileOnly("com.esotericsoftware:kryo:5.6.2")
-    compileOnly("org.apache.fury:fury-kotlin:0.10.0")
 }
 ```
+
+내장 converter의 런타임 의존성은 `bluetape4k-hibernate` 아티팩트 계약에 포함됩니다. 문서화된
+Tink, Jackson3, Kryo, Apache Fory, LZ4, Snappy, Zstd, Commons Compress converter 경로를
+사용하기 위해 consumer 프로젝트에서 별도의 `compileOnly` 의존성을 추가할 필요는 없습니다. 단, slim
+배포처럼 전이 런타임 의존성을 제외한다면 엔티티 매핑에 사용하는 converter 엔진은 runtime classpath에
+남겨야 합니다.
 
 > **은퇴한 Spring Boot 3 통합 참고**: Hibernate 7.x와 Spring Boot 3.x를 함께 사용하던 과거 통합 테스트는 Spring Boot 3의 `SpringBeanContainer`가 Hibernate 5 API를 구현하기 때문에 계속 비활성화되어 있습니다. 현재 bluetape4k Spring 모듈은 Hibernate 7.x 호환을 위해 Spring Boot 4 / Spring Framework 7을 기준으로 합니다. 자세한 내용은 테스트 스위트의 `DisabledWithHibernate7AndSpringBoot3` 보존 guard를 참고하세요.
 

--- a/data/hibernate/README.md
+++ b/data/hibernate/README.md
@@ -31,18 +31,14 @@ dependencies {
 
     // Querydsl (optional)
     implementation("com.querydsl:querydsl-jpa:5.1.0:jakarta")
-
-    // Encryption converter (Google Tink)
-    compileOnly("io.github.bluetape4k:bluetape4k-tink:${version}")
-
-    // JSON converter
-    compileOnly("io.github.bluetape4k:bluetape4k-jackson2:${version}")
-
-    // Serialization converter (Kryo or Apache Fory)
-    compileOnly("com.esotericsoftware:kryo:5.6.2")
-    compileOnly("org.apache.fury:fury-kotlin:0.10.0")
 }
 ```
+
+Built-in converter runtime dependencies are part of the `bluetape4k-hibernate` artifact contract.
+Consumers do not need separate `compileOnly` declarations for the documented Tink, Jackson3, Kryo,
+Apache Fory, LZ4, Snappy, Zstd, or Commons Compress converter paths. If a slim deployment excludes
+transitive runtime dependencies, keep the converter engine used by your entity mappings on the runtime
+classpath.
 
 > **Retired Spring Boot 3 integration note**: Historical tests combining Hibernate 7.x with Spring Boot 3.x remain disabled because Spring Boot 3's `SpringBeanContainer` implements the Hibernate 5 API. Current bluetape4k Spring modules target Spring Boot 4 / Spring Framework 7 for Hibernate 7.x compatibility. See `DisabledWithHibernate7AndSpringBoot3` in the test suite for the archived guard.
 

--- a/data/hibernate/build.gradle.kts
+++ b/data/hibernate/build.gradle.kts
@@ -70,6 +70,25 @@ configurations {
     create("testJar")
 }
 
+val consumerRuntimeTest by sourceSets.creating {
+    compileClasspath += sourceSets.main.get().output + configurations.runtimeClasspath.get()
+    runtimeClasspath += output + compileClasspath
+}
+
+val consumerRuntimeTestImplementation by configurations.getting
+
+tasks.register<Test>("consumerRuntimeTest") {
+    description = "Runs Hibernate converter smoke tests with the published runtime classpath."
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+
+    testClassesDirs = consumerRuntimeTest.output.classesDirs
+    classpath = consumerRuntimeTest.runtimeClasspath
+    useJUnitPlatform()
+}
+
+tasks.named("check") {
+    dependsOn("consumerRuntimeTest")
+}
 
 // 테스트 코드를 Jar로 만들어서 다른 프로젝트에서 참조할 수 있도록 합니다.
 tasks.register<Jar>("testJar") {
@@ -115,18 +134,16 @@ dependencies {
 
     // Converter
     // compileOnly(project(":bluetape4k-crypto"))
-    compileOnly(project(":bluetape4k-tink"))
-    compileOnly(project(":bluetape4k-jackson3"))
-    compileOnly(libs.jackson3.module.kotlin)
-    compileOnly(libs.jackson3.module.blackbird)
+    api(project(":bluetape4k-tink"))
+    api(project(":bluetape4k-jackson3"))
 
-    compileOnly(libs.kryo)
-    compileOnly(libs.fory.kotlin)  // new Apache Fory
+    runtimeOnly(libs.kryo)
+    runtimeOnly(libs.fory.kotlin)  // new Apache Fory
 
-    testImplementation(libs.commons.compress)
-    testImplementation(libs.snappy.java)
-    testImplementation(libs.lz4.java)
-    testImplementation(libs.zstd.jni)
+    runtimeOnly(libs.commons.compress)
+    runtimeOnly(libs.snappy.java)
+    runtimeOnly(libs.lz4.java)
+    runtimeOnly(libs.zstd.jni)
 
     api(project(":bluetape4k-idgenerators"))
     api(libs.java.uuid.generator)
@@ -160,4 +177,6 @@ dependencies {
 
     // JDBC 와 같이 사용
     testImplementation(project(":bluetape4k-jdbc"))
+
+    consumerRuntimeTestImplementation(project(":bluetape4k-junit5"))
 }

--- a/data/hibernate/src/consumerRuntimeTest/kotlin/io/bluetape4k/hibernate/converter/HibernateConverterConsumerRuntimeClasspathTest.kt
+++ b/data/hibernate/src/consumerRuntimeTest/kotlin/io/bluetape4k/hibernate/converter/HibernateConverterConsumerRuntimeClasspathTest.kt
@@ -1,0 +1,73 @@
+package io.bluetape4k.hibernate.converter
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.hibernate.converters.AESStringConverter
+import io.bluetape4k.hibernate.converters.BZip2StringConverter
+import io.bluetape4k.hibernate.converters.EncryptedStringConverterKeysets
+import io.bluetape4k.hibernate.converters.ForyObjectAsByteArrayConverter
+import io.bluetape4k.hibernate.converters.KryoObjectAsByteArrayConverter
+import io.bluetape4k.hibernate.converters.LZ4KryoObjectAsByteArrayConverter
+import io.bluetape4k.hibernate.converters.LZ4StringConverter
+import io.bluetape4k.hibernate.converters.SnappyKryoObjectAsByteArrayConverter
+import io.bluetape4k.hibernate.converters.SnappyStringConverter
+import io.bluetape4k.hibernate.converters.ZstdForyObjectAsByteArrayConverter
+import io.bluetape4k.hibernate.converters.ZstdStringConverter
+import io.bluetape4k.tink.aeadKeysetHandle
+import io.bluetape4k.tink.keyset.toJsonKeyset
+import org.junit.jupiter.api.Test
+
+class HibernateConverterConsumerRuntimeClasspathTest {
+
+    @Test
+    fun `documented Tink encryption converter works from consumer runtime classpath`() {
+        EncryptedStringConverterKeysets.configureAesKeyset(aeadKeysetHandle().toJsonKeyset())
+        val converter = AESStringConverter()
+        val original = "consumer-runtime-secret"
+
+        val encrypted = converter.convertToDatabaseColumn(original)
+        encrypted.shouldNotBeNull()
+        encrypted shouldNotBeEqualTo original
+
+        converter.convertToEntityAttribute(encrypted) shouldBeEqualTo original
+    }
+
+    @Test
+    fun `documented Kryo and Fory byte-array converters work from consumer runtime classpath`() {
+        val original = "consumer-runtime-payload"
+        val converters = listOf(
+            KryoObjectAsByteArrayConverter(),
+            LZ4KryoObjectAsByteArrayConverter(),
+            SnappyKryoObjectAsByteArrayConverter(),
+            ForyObjectAsByteArrayConverter(),
+            ZstdForyObjectAsByteArrayConverter(),
+        )
+
+        converters.forEach { converter ->
+            val bytes = converter.convertToDatabaseColumn(original)
+            bytes.shouldNotBeNull()
+
+            converter.convertToEntityAttribute(bytes) shouldBeEqualTo original
+        }
+    }
+
+    @Test
+    fun `documented compression converters work from consumer runtime classpath`() {
+        val original = "consumer-runtime-compression".repeat(8)
+        val converters = listOf(
+            BZip2StringConverter(),
+            LZ4StringConverter(),
+            SnappyStringConverter(),
+            ZstdStringConverter(),
+        )
+
+        converters.forEach { converter ->
+            val compressed = converter.convertToDatabaseColumn(original)
+            compressed.shouldNotBeNull()
+            compressed shouldNotBeEqualTo original
+
+            converter.convertToEntityAttribute(compressed) shouldBeEqualTo original
+        }
+    }
+}

--- a/docs/lessons/2026-06-26-issue-814-hibernate-converter-runtime-deps.md
+++ b/docs/lessons/2026-06-26-issue-814-hibernate-converter-runtime-deps.md
@@ -1,0 +1,30 @@
+# Issue 814: Hibernate Converter Runtime Dependencies
+
+## Context
+
+`bluetape4k-hibernate` exposes converter classes for Tink encryption, Jackson3 JSON, Kryo/Fory serialization,
+and LZ4/Snappy/Zstd/Commons Compress compression. These converter engines were declared as `compileOnly` or
+test-only dependencies, while the module's tests extended `compileOnly` into `testImplementation`. That made
+module tests pass even though downstream consumers could miss runtime classes.
+
+## Decision
+
+Treat documented built-in converter engines as part of the `bluetape4k-hibernate` artifact contract:
+
+- Use `api` when the dependency type appears in public converter API (`bluetape4k-tink`, `bluetape4k-jackson3`).
+- Use `runtimeOnly` when the dependency is needed by built-in converter implementations but not exposed in method
+  signatures (Kryo, Fory, LZ4, Snappy, Zstd, Commons Compress).
+- Add a `consumerRuntimeTest` source set that compiles and runs smoke tests against `sourceSets.main.output` plus
+  `runtimeClasspath`, not the regular test classpath.
+
+## Outcome
+
+The new consumer smoke test verifies Tink encryption, Kryo/Fory byte-array converters, and compression converters
+from the published runtime classpath. README dependency snippets no longer tell consumers to add those converter
+engines as `compileOnly`.
+
+## Future Guidance
+
+When a module offers optional-looking concrete implementations in the main artifact, verify the consumer runtime
+classpath separately from unit tests. Do not rely on tests that extend `compileOnly`; they can hide missing
+transitive runtime dependencies.


### PR DESCRIPTION
## Summary

Closes #814

- PR 제목: fix: align Hibernate converter runtime deps

Closes #814.

`bluetape4k-hibernate` now treats the documented built-in converter engines as part of the main artifact runtime contract instead of hiding them behind `compileOnly` or test-only dependencies.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Promote public converter API dependencies to `api` for Tink and Jackson3.
- Add runtime dependencies for Kryo, Apache Fory, Commons Compress, LZ4, Snappy, and Zstd so documented converter implementations can be discovered and used by downstream consumers.
- Add a `consumerRuntimeTest` source set that runs converter smoke tests against `sourceSets.main.output + runtimeClasspath`, avoiding the regular test classpath that extends `compileOnly`.
- Update English and Korean README dependency guidance and add a lesson for future converter/runtime dependency work.

### 기존 섹션: Verification

- `./gradlew :bluetape4k-hibernate:consumerRuntimeTest --no-daemon --no-configuration-cache`
- `./gradlew :bluetape4k-hibernate:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache`
- `./gradlew :bluetape4k-hibernate:test --tests 'io.bluetape4k.hibernate.converter.*' --no-daemon --no-configuration-cache`
- `./gradlew :bluetape4k-hibernate:check --no-daemon --no-configuration-cache`
- `dependencyInsight` on `runtimeClasspath` confirmed `bluetape4k-tink`, Kryo, Fory, LZ4, Snappy, Zstd, and Commons Compress are present.
- `git diff --check`
- CodeGraph `detect_changes`: risk score 0.00, test gaps 0.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #814, milestone `1.11.0`, assignee `debop`
- PR: #917, head `8d6c6430174425bc714f1af9619460155934f87c`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/hibernate-converter-runtime-deps`
- Labels: `bug`, `dependencies`
- State: `MERGED`, merge commit `dff6a8ad215d1731dedc1e2058d11be9304b5f34`
- CI: `bluetape4k-hibernate` now treats the documented built-in converter engines as part of the main artifact runtime contract instead of hiding them behind `compileOnly` or test-only dependencies. / - Promote public converter API dependencies to `api` for Tink and Jackson3. / - Add runtime dependencies for Kryo, Apache Fory, Commons Compress, LZ4, Snappy, and Zstd so documented converter implementations can be discovered and used by downstream consumers.

## DoD Status

- [x] Converter-backed dependencies are transitive for the main `bluetape4k-hibernate` artifact.
- [x] README documents the runtime dependency contract for built-in converters.
- [x] Consumer-style runtime smoke coverage verifies Tink, Kryo/Fory, and compression converter paths from the published runtime classpath.
- [x] Local verification passed.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #917 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `dff6a8ad215d1731dedc1e2058d11be9304b5f34`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
