### PR TITLE
fix: harden Hibernate object converter deserialization

### DIFF
--- a/data/hibernate/README.ko.md
+++ b/data/hibernate/README.ko.md
@@ -357,32 +357,39 @@ val users = queryFactory
 
 #### 직렬화 Converter
 
-객체를 직렬화하여 ByteArray(Base64 인코딩)로 DB에 저장합니다. JDK / Kryo / Apache Fory 직렬화와 LZ4, Snappy, Zstd 압축을 조합할 수 있습니다.
+타입이 정해진 객체를 직렬화하여 ByteArray(Base64 인코딩)나 Base64 문자열로 DB에 저장합니다. 영속 컬럼에는 secure serializer allowlist를 사용하는 typed converter 하위 클래스를 권장합니다. 기존 generic `Any?` object converter는 deprecated 상태이며, DB row 변조, 덜 신뢰할 수 있는 시스템의 import, tenant 간 공유가 없는 trusted storage에서만 사용하세요.
 
 ```kotlin
 import io.bluetape4k.hibernate.converters.*
+import io.bluetape4k.io.serializer.KryoBinarySerializer
+
+data class UserProfile(
+    val displayName: String,
+    val tags: List<String> = emptyList(),
+): java.io.Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+
+class UserProfileAsByteArrayConverter: AbstractTypedObjectAsByteArrayConverter<UserProfile>(
+    targetType = UserProfile::class.java,
+    serializer = KryoBinarySerializer.secure(UserProfile::class.java),
+)
 
 @Entity
 class UserData {
     @Id
     var id: Long? = null
 
-    // JDK 직렬화 → Base64 인코딩 → ByteArray
-    @Convert(converter = JdkObjectAsByteArrayConverter::class)
+    // 명시적 allowlist를 사용하는 typed Kryo 직렬화
+    @Convert(converter = UserProfileAsByteArrayConverter::class)
     @Column(length = 4000)
-    var metadata: Any? = null
-
-    // Kryo 직렬화 + LZ4 압축 → Base64 인코딩 → ByteArray
-    @Convert(converter = LZ4KryoObjectAsByteArrayConverter::class)
-    @Column(length = 4000)
-    var largeData: Any? = null
-
-    // Apache Fory 직렬화 + Zstd 압축 → Base64 인코딩 → ByteArray
-    @Convert(converter = ZstdForyObjectAsByteArrayConverter::class)
-    @Column(length = 4000)
-    var compressedData: Any? = null
+    var profile: UserProfile? = null
 }
 ```
+
+`AbstractTypedObjectAsByteArrayConverter`와 `AbstractTypedObjectAsBase64StringConverter`는 역직렬화된 값의 타입을 Hibernate에 반환하기 전에 확인합니다. Kryo와 Apache Fory를 사용할 때는 `KryoBinarySerializer.secure(...)`, `ForyBinarySerializer.secureFory(...)` 같은 secure serializer와 함께 사용해 converter 경계와 serializer registry가 같은 trust profile을 강제하도록 구성하세요.
 
 #### 암호화 Converter
 

--- a/data/hibernate/README.md
+++ b/data/hibernate/README.md
@@ -358,32 +358,39 @@ A variety of `AttributeConverter` implementations are provided.
 
 #### Serialization Converters
 
-Serialize objects and store them as ByteArray (Base64-encoded) in the database. Supports JDK, Kryo, and Apache Fory serialization combined with LZ4, Snappy, or Zstd compression.
+Serialize typed objects and store them as ByteArray (Base64-encoded) or Base64 strings in the database. For persisted columns, prefer typed converter subclasses with a secure serializer allowlist. The legacy generic `Any?` object converters are deprecated and should be used only for trusted storage where database rows cannot be tampered with, imported from less-trusted systems, or shared across tenants.
 
 ```kotlin
 import io.bluetape4k.hibernate.converters.*
+import io.bluetape4k.io.serializer.KryoBinarySerializer
+
+data class UserProfile(
+    val displayName: String,
+    val tags: List<String> = emptyList(),
+): java.io.Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+
+class UserProfileAsByteArrayConverter: AbstractTypedObjectAsByteArrayConverter<UserProfile>(
+    targetType = UserProfile::class.java,
+    serializer = KryoBinarySerializer.secure(UserProfile::class.java),
+)
 
 @Entity
 class UserData {
     @Id
     var id: Long? = null
 
-    // JDK serialization → Base64 → ByteArray
-    @Convert(converter = JdkObjectAsByteArrayConverter::class)
+    // Typed Kryo serialization with an explicit allowlist.
+    @Convert(converter = UserProfileAsByteArrayConverter::class)
     @Column(length = 4000)
-    var metadata: Any? = null
-
-    // Kryo serialization + LZ4 compression → Base64 → ByteArray
-    @Convert(converter = LZ4KryoObjectAsByteArrayConverter::class)
-    @Column(length = 4000)
-    var largeData: Any? = null
-
-    // Apache Fory serialization + Zstd compression → Base64 → ByteArray
-    @Convert(converter = ZstdForyObjectAsByteArrayConverter::class)
-    @Column(length = 4000)
-    var compressedData: Any? = null
+    var profile: UserProfile? = null
 }
 ```
+
+`AbstractTypedObjectAsByteArrayConverter` and `AbstractTypedObjectAsBase64StringConverter` verify the deserialized value type before returning it to Hibernate. For Kryo and Apache Fory, pair these typed converters with secure serializers such as `KryoBinarySerializer.secure(...)` or `ForyBinarySerializer.secureFory(...)` so the converter boundary and serializer registry enforce the same trust profile.
 
 #### Encryption Converters
 

--- a/data/hibernate/src/consumerRuntimeTest/kotlin/io/bluetape4k/hibernate/converter/HibernateConverterConsumerRuntimeClasspathTest.kt
+++ b/data/hibernate/src/consumerRuntimeTest/kotlin/io/bluetape4k/hibernate/converter/HibernateConverterConsumerRuntimeClasspathTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.bluetape4k.hibernate.converter
 
 import io.bluetape4k.assertions.shouldBeEqualTo

--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/ObjectAsBase64StringConverter.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/ObjectAsBase64StringConverter.kt
@@ -1,12 +1,19 @@
+@file:Suppress("DEPRECATION")
+
 package io.bluetape4k.hibernate.converters
 
 import io.bluetape4k.codec.decodeBase64ByteArray
 import io.bluetape4k.codec.encodeBase64String
 import io.bluetape4k.io.serializer.BinarySerializer
+import io.bluetape4k.io.serializer.BinarySerializationException
 import io.bluetape4k.io.serializer.BinarySerializers
 import io.bluetape4k.io.serializer.JdkBinarySerializer
 import jakarta.persistence.AttributeConverter
 import jakarta.persistence.Converter
+
+private const val TRUSTED_ONLY_BASE64_STRING_CONVERTER =
+    "Generic object converters deserialize arbitrary payloads and are trusted-storage-only. " +
+            "Define an AbstractTypedObjectAsBase64StringConverter subclass with a target type and a secure serializer."
 
 /**
  * 객체를 바이너리 직렬화를 통해 Base64 인코딩된 문자열로 변환해서 DB에 저장합니다.
@@ -26,6 +33,7 @@ import jakarta.persistence.Converter
  *
  * @property serializer 바이너리 직렬화
  */
+@Deprecated(TRUSTED_ONLY_BASE64_STRING_CONVERTER)
 @Converter
 abstract class AbstractObjectAsBase64StringConverter(
     private val serializer: BinarySerializer,
@@ -41,10 +49,50 @@ abstract class AbstractObjectAsBase64StringConverter(
 }
 
 /**
+ * Typed Base64 string converter that rejects deserialized values outside [targetType].
+ *
+ * Use this base class for persistent columns that may cross a trust boundary. The serializer is still
+ * pluggable, so callers can combine the typed converter boundary with secure serializers such as
+ * `KryoBinarySerializer.secure(...)` or `ForyBinarySerializer.secureFory(...)`.
+ *
+ * ```kotlin
+ * class UserProfileAsBase64StringConverter: AbstractTypedObjectAsBase64StringConverter<UserProfile>(
+ *     targetType = UserProfile::class.java,
+ *     serializer = KryoBinarySerializer.secure(UserProfile::class.java),
+ * )
+ * ```
+ */
+@Converter
+abstract class AbstractTypedObjectAsBase64StringConverter<T: Any>(
+    private val targetType: Class<T>,
+    private val serializer: BinarySerializer,
+): AttributeConverter<T?, String?> {
+
+    override fun convertToDatabaseColumn(attribute: T?): String? {
+        return attribute?.run { serializer.serialize(this).encodeBase64String() }
+    }
+
+    override fun convertToEntityAttribute(dbData: String?): T? {
+        return try {
+            val value = dbData?.run { serializer.deserialize<Any>(this.decodeBase64ByteArray()) }
+            requireExpectedType(value, targetType)
+        } catch (e: BinarySerializationException) {
+            throw e
+        } catch (e: Throwable) {
+            throw BinarySerializationException(
+                "Fail to deserialize Hibernate Base64 string converter payload. targetType=${targetType.name}",
+                e,
+            )
+        }
+    }
+}
+
+/**
  * 객체를 Jdk 직렬화를 통해 Base64 인코딩된 문자열로 변환해서 DB에 저장합니다.
  *
  * @see BinarySerializers.Jdk
  */
+@Deprecated(TRUSTED_ONLY_BASE64_STRING_CONVERTER)
 @Converter
 class JdkObjectAsBase64StringConverter: AbstractObjectAsBase64StringConverter(JdkBinarySerializer())
 
@@ -53,6 +101,7 @@ class JdkObjectAsBase64StringConverter: AbstractObjectAsBase64StringConverter(Jd
  *
  * @see BinarySerializers.LZ4Jdk
  */
+@Deprecated(TRUSTED_ONLY_BASE64_STRING_CONVERTER)
 @Converter
 class LZ4JdkObjectAsBase64StringConverter: AbstractObjectAsBase64StringConverter(BinarySerializers.LZ4Jdk)
 
@@ -61,6 +110,7 @@ class LZ4JdkObjectAsBase64StringConverter: AbstractObjectAsBase64StringConverter
  *
  * @see BinarySerializers.SnappyJdk
  */
+@Deprecated(TRUSTED_ONLY_BASE64_STRING_CONVERTER)
 @Converter
 class SnappyJdkObjectAsBase64StringConverter: AbstractObjectAsBase64StringConverter(BinarySerializers.SnappyJdk)
 
@@ -69,6 +119,7 @@ class SnappyJdkObjectAsBase64StringConverter: AbstractObjectAsBase64StringConver
  *
  * @see BinarySerializers.ZstdJdk
  */
+@Deprecated(TRUSTED_ONLY_BASE64_STRING_CONVERTER)
 @Converter
 class ZstdJdkObjectAsBase64StringConverter: AbstractObjectAsBase64StringConverter(BinarySerializers.ZstdJdk)
 
@@ -77,6 +128,7 @@ class ZstdJdkObjectAsBase64StringConverter: AbstractObjectAsBase64StringConverte
  *
  * @see BinarySerializers.Kryo
  */
+@Deprecated(TRUSTED_ONLY_BASE64_STRING_CONVERTER)
 @Converter
 class KryoObjectAsBase64StringConverter: AbstractObjectAsBase64StringConverter(BinarySerializers.Kryo)
 
@@ -85,6 +137,7 @@ class KryoObjectAsBase64StringConverter: AbstractObjectAsBase64StringConverter(B
  *
  * @see BinarySerializers.LZ4Kryo
  */
+@Deprecated(TRUSTED_ONLY_BASE64_STRING_CONVERTER)
 @Converter
 class LZ4KryoObjectAsBase64StringConverter: AbstractObjectAsBase64StringConverter(BinarySerializers.LZ4Kryo)
 
@@ -93,6 +146,7 @@ class LZ4KryoObjectAsBase64StringConverter: AbstractObjectAsBase64StringConverte
  *
  * @see BinarySerializers.SnappyKryo
  */
+@Deprecated(TRUSTED_ONLY_BASE64_STRING_CONVERTER)
 @Converter
 class SnappyKryoObjectAsBase64StringConverter: AbstractObjectAsBase64StringConverter(BinarySerializers.SnappyKryo)
 
@@ -101,5 +155,6 @@ class SnappyKryoObjectAsBase64StringConverter: AbstractObjectAsBase64StringConve
  *
  * @see BinarySerializers.ZstdKryo
  */
+@Deprecated(TRUSTED_ONLY_BASE64_STRING_CONVERTER)
 @Converter
 class ZstdKryoObjectAsBase64StringConverter: AbstractObjectAsBase64StringConverter(BinarySerializers.ZstdKryo)

--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/ObjectAsByteArrayConverter.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/ObjectAsByteArrayConverter.kt
@@ -1,12 +1,19 @@
+@file:Suppress("DEPRECATION")
+
 package io.bluetape4k.hibernate.converters
 
 import io.bluetape4k.codec.decodeBase64ByteArray
 import io.bluetape4k.codec.encodeBase64ByteArray
 import io.bluetape4k.io.serializer.BinarySerializer
+import io.bluetape4k.io.serializer.BinarySerializationException
 import io.bluetape4k.io.serializer.BinarySerializers
 import io.bluetape4k.io.serializer.JdkBinarySerializer
 import jakarta.persistence.AttributeConverter
 import jakarta.persistence.Converter
+
+private const val TRUSTED_ONLY_BYTE_ARRAY_CONVERTER =
+    "Generic object converters deserialize arbitrary payloads and are trusted-storage-only. " +
+            "Define an AbstractTypedObjectAsByteArrayConverter subclass with a target type and a secure serializer."
 
 /**
  * 객체를 직렬화하여 Base64 인코딩을 거쳐 ByteArray 로 변환해서 DB에 저장합니다.
@@ -26,6 +33,7 @@ import jakarta.persistence.Converter
  *
  * @property serializer 바이너리 직렬화
  */
+@Deprecated(TRUSTED_ONLY_BYTE_ARRAY_CONVERTER)
 @Converter
 abstract class AbstractObjectAsByteArrayConverter(
     private val serializer: BinarySerializer,
@@ -41,73 +49,137 @@ abstract class AbstractObjectAsByteArrayConverter(
 }
 
 /**
+ * Typed object converter that rejects deserialized values outside [targetType].
+ *
+ * Use this base class for persistent columns that may cross a trust boundary. The serializer is still
+ * pluggable, so callers can combine the typed converter boundary with secure serializers such as
+ * `KryoBinarySerializer.secure(...)` or `ForyBinarySerializer.secureFory(...)`.
+ *
+ * ```kotlin
+ * class UserProfileAsByteArrayConverter: AbstractTypedObjectAsByteArrayConverter<UserProfile>(
+ *     targetType = UserProfile::class.java,
+ *     serializer = KryoBinarySerializer.secure(UserProfile::class.java),
+ * )
+ * ```
+ */
+@Converter
+abstract class AbstractTypedObjectAsByteArrayConverter<T: Any>(
+    private val targetType: Class<T>,
+    private val serializer: BinarySerializer,
+): AttributeConverter<T?, ByteArray?> {
+
+    override fun convertToDatabaseColumn(attribute: T?): ByteArray? {
+        return attribute?.run { serializer.serialize(this).encodeBase64ByteArray() }
+    }
+
+    override fun convertToEntityAttribute(dbData: ByteArray?): T? {
+        return try {
+            val value = dbData?.run { serializer.deserialize<Any>(this.decodeBase64ByteArray()) }
+            requireExpectedType(value, targetType)
+        } catch (e: BinarySerializationException) {
+            throw e
+        } catch (e: Throwable) {
+            throw BinarySerializationException(
+                "Fail to deserialize Hibernate ByteArray converter payload. targetType=${targetType.name}",
+                e,
+            )
+        }
+    }
+}
+
+internal fun <T: Any> requireExpectedType(value: Any?, targetType: Class<T>): T? {
+    if (value == null) {
+        return null
+    }
+    if (targetType.isInstance(value)) {
+        return targetType.cast(value)
+    }
+
+    throw BinarySerializationException(
+        "Unexpected Hibernate converter payload type. expected=${targetType.name}, actual=${value.javaClass.name}",
+    )
+}
+
+/**
  * 객체를 Jdk 직렬화하여 Base64 인코딩을 거쳐 ByteArray 로 변환해서 DB에 저장합니다.
  */
+@Deprecated(TRUSTED_ONLY_BYTE_ARRAY_CONVERTER)
 @Converter
 class JdkObjectAsByteArrayConverter: AbstractObjectAsByteArrayConverter(JdkBinarySerializer())
 
 /**
  * 객체를 Jdk 직렬화, LZ4로 압축 한 후 Base64 인코딩을 거쳐 ByteArray 로 변환해서 DB에 저장합니다.
  */
+@Deprecated(TRUSTED_ONLY_BYTE_ARRAY_CONVERTER)
 @Converter
 class LZ4JdkObjectAsByteArrayConverter: AbstractObjectAsByteArrayConverter(BinarySerializers.LZ4Jdk)
 
 /**
  * 객체를 Jdk 직렬화, Snappy로 압축 한 후 Base64 인코딩을 거쳐 ByteArray 로 변환해서 DB에 저장합니다.
  */
+@Deprecated(TRUSTED_ONLY_BYTE_ARRAY_CONVERTER)
 @Converter
 class SnappyJdkObjectAsByteArrayConverter: AbstractObjectAsByteArrayConverter(BinarySerializers.SnappyJdk)
 
 /**
  * 객체를 Jdk 직렬화, Zstd로 압축 한 후 Base64 인코딩을 거쳐 ByteArray 로 변환해서 DB에 저장합니다.
  */
+@Deprecated(TRUSTED_ONLY_BYTE_ARRAY_CONVERTER)
 @Converter
 class ZstdJdkObjectAsByteArrayConverter: AbstractObjectAsByteArrayConverter(BinarySerializers.ZstdJdk)
 
 /**
  * 객체를 Kryo 직렬화하여 Base64 인코딩을 거쳐 ByteArray 로 변환해서 DB에 저장합니다.
  */
+@Deprecated(TRUSTED_ONLY_BYTE_ARRAY_CONVERTER)
 @Converter
 class KryoObjectAsByteArrayConverter: AbstractObjectAsByteArrayConverter(BinarySerializers.Kryo)
 
 /**
  * 객체를 Kryo 직렬화, LZ4로 압축 한 후 Base64 인코딩을 거쳐 ByteArray 로 변환해서 DB에 저장합니다.
  */
+@Deprecated(TRUSTED_ONLY_BYTE_ARRAY_CONVERTER)
 @Converter
 class LZ4KryoObjectAsByteArrayConverter: AbstractObjectAsByteArrayConverter(BinarySerializers.LZ4Kryo)
 
 /**
  * 객체를 Kryo 직렬화, Snappy로 압축 한 후 Base64 인코딩을 거쳐 ByteArray 로 변환해서 DB에 저장합니다.
  */
+@Deprecated(TRUSTED_ONLY_BYTE_ARRAY_CONVERTER)
 @Converter
 class SnappyKryoObjectAsByteArrayConverter: AbstractObjectAsByteArrayConverter(BinarySerializers.SnappyKryo)
 
 /**
  * 객체를 Kryo 직렬화, Zstd로 압축 한 후 Base64 인코딩을 거쳐 ByteArray 로 변환해서 DB에 저장합니다.
  */
+@Deprecated(TRUSTED_ONLY_BYTE_ARRAY_CONVERTER)
 @Converter
 class ZstdKryoObjectAsByteArrayConverter: AbstractObjectAsByteArrayConverter(BinarySerializers.ZstdKryo)
 
 /**
  * 객체를 Apache Fory 직렬화하여 Base64 인코딩을 거쳐 ByteArray 로 변환해서 DB에 저장합니다.
  */
+@Deprecated(TRUSTED_ONLY_BYTE_ARRAY_CONVERTER)
 @Converter
 class ForyObjectAsByteArrayConverter: AbstractObjectAsByteArrayConverter(BinarySerializers.Fory)
 
 /**
  * 객체를 Apache Fory 직렬화, LZ4로 압축 한 후 Base64 인코딩을 거쳐 ByteArray 로 변환해서 DB에 저장합니다.
  */
+@Deprecated(TRUSTED_ONLY_BYTE_ARRAY_CONVERTER)
 @Converter
 class LZ4ForyObjectAsByteArrayConverter: AbstractObjectAsByteArrayConverter(BinarySerializers.LZ4Fory)
 
 /**
  * 객체를 Apache Fory 직렬화, Snappy로 압축 한 후 Base64 인코딩을 거쳐 ByteArray 로 변환해서 DB에 저장합니다.
  */
+@Deprecated(TRUSTED_ONLY_BYTE_ARRAY_CONVERTER)
 @Converter
 class SnappyForyObjectAsByteArrayConverter: AbstractObjectAsByteArrayConverter(BinarySerializers.SnappyFory)
 
 /**
  * 객체를 Apache Fory 직렬화, Zstd로 압축 한 후 Base64 인코딩을 거쳐 ByteArray 로 변환해서 DB에 저장합니다.
  */
+@Deprecated(TRUSTED_ONLY_BYTE_ARRAY_CONVERTER)
 @Converter
 class ZstdForyObjectAsByteArrayConverter: AbstractObjectAsByteArrayConverter(BinarySerializers.ZstdFory)

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/converter/ConvertableEntity.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/converter/ConvertableEntity.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.bluetape4k.hibernate.converter
 
 import io.bluetape4k.ToStringBuilder

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/converter/ObjectAsByteArrayConverterTest.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/converter/ObjectAsByteArrayConverterTest.kt
@@ -1,5 +1,12 @@
+@file:Suppress("DEPRECATION")
+
 package io.bluetape4k.hibernate.converter
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.hibernate.converters.AbstractTypedObjectAsByteArrayConverter
 import io.bluetape4k.hibernate.converters.ForyObjectAsByteArrayConverter
 import io.bluetape4k.hibernate.converters.JdkObjectAsByteArrayConverter
 import io.bluetape4k.hibernate.converters.KryoObjectAsByteArrayConverter
@@ -12,11 +19,13 @@ import io.bluetape4k.hibernate.converters.SnappyKryoObjectAsByteArrayConverter
 import io.bluetape4k.hibernate.converters.ZstdForyObjectAsByteArrayConverter
 import io.bluetape4k.hibernate.converters.ZstdJdkObjectAsByteArrayConverter
 import io.bluetape4k.hibernate.converters.ZstdKryoObjectAsByteArrayConverter
+import io.bluetape4k.io.serializer.BinarySerializationException
+import io.bluetape4k.io.serializer.ForyBinarySerializer
+import io.bluetape4k.io.serializer.JdkBinarySerializer
+import io.bluetape4k.io.serializer.KryoBinarySerializer
 import io.bluetape4k.logging.KLogging
 import jakarta.persistence.AttributeConverter
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeNull
-import io.bluetape4k.assertions.shouldNotBeNull
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.io.Serializable
@@ -54,7 +63,36 @@ class ObjectAsByteArrayConverterTest {
         val name: String,
         val value: Int,
         val tags: List<String> = emptyList(),
-    ): Serializable
+    ): Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
+
+    data class UnexpectedData(
+        val payload: String,
+    ): Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
+
+    class TypedSampleAsByteArrayConverter: AbstractTypedObjectAsByteArrayConverter<SampleData>(
+        targetType = SampleData::class.java,
+        serializer = JdkBinarySerializer(),
+    )
+
+    class SecureKryoSampleAsByteArrayConverter: AbstractTypedObjectAsByteArrayConverter<SampleData>(
+        targetType = SampleData::class.java,
+        serializer = KryoBinarySerializer.secure(SampleData::class.java),
+    )
+
+    class SecureForySampleAsByteArrayConverter: AbstractTypedObjectAsByteArrayConverter<SampleData>(
+        targetType = SampleData::class.java,
+        serializer = ForyBinarySerializer(
+            fory = ForyBinarySerializer.secureFory(SampleData::class.java),
+        ),
+    )
 
     @ParameterizedTest(name = "{0} - 객체를 직렬화하고 역직렬화한다")
     @MethodSource("converters")
@@ -110,5 +148,47 @@ class ObjectAsByteArrayConverterTest {
 
         val deserialized = converter.convertToEntityAttribute(serialized)
         deserialized shouldBeEqualTo obj
+    }
+
+    @Test
+    fun `typed byte array converter rejects malformed payload`() {
+        val converter = TypedSampleAsByteArrayConverter()
+
+        assertFailsWith<BinarySerializationException> {
+            converter.convertToEntityAttribute("not-base64".toByteArray())
+        }
+    }
+
+    @Test
+    fun `typed byte array converter rejects unexpected deserialized type`() {
+        val unsafeConverter = JdkObjectAsByteArrayConverter()
+        val typedConverter = TypedSampleAsByteArrayConverter()
+        val payload = unsafeConverter.convertToDatabaseColumn(UnexpectedData("unexpected"))
+
+        assertFailsWith<BinarySerializationException> {
+            typedConverter.convertToEntityAttribute(payload)
+        }
+    }
+
+    @Test
+    fun `secure Kryo typed byte array converter rejects disallowed payload`() {
+        val unsafeConverter = KryoObjectAsByteArrayConverter()
+        val typedConverter = SecureKryoSampleAsByteArrayConverter()
+        val payload = unsafeConverter.convertToDatabaseColumn(UnexpectedData("unexpected"))
+
+        assertFailsWith<BinarySerializationException> {
+            typedConverter.convertToEntityAttribute(payload)
+        }
+    }
+
+    @Test
+    fun `secure Fory typed byte array converter rejects disallowed payload`() {
+        val unsafeConverter = ForyObjectAsByteArrayConverter()
+        val typedConverter = SecureForySampleAsByteArrayConverter()
+        val payload = unsafeConverter.convertToDatabaseColumn(UnexpectedData("unexpected"))
+
+        assertFailsWith<BinarySerializationException> {
+            typedConverter.convertToEntityAttribute(payload)
+        }
     }
 }

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/converters/ObjectAsBase64StringConverterTest.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/converters/ObjectAsBase64StringConverterTest.kt
@@ -1,8 +1,13 @@
+@file:Suppress("DEPRECATION")
+
 package io.bluetape4k.hibernate.converters
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.io.serializer.BinarySerializationException
+import io.bluetape4k.io.serializer.JdkBinarySerializer
 import org.junit.jupiter.api.Test
 import java.io.Serializable
 
@@ -13,6 +18,17 @@ class ObjectAsBase64StringConverterTest {
             private const val serialVersionUID = 1L
         }
     }
+
+    data class UnexpectedData(val payload: String) : Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
+
+    class TypedSampleAsBase64StringConverter: AbstractTypedObjectAsBase64StringConverter<SampleData>(
+        targetType = SampleData::class.java,
+        serializer = JdkBinarySerializer(),
+    )
 
     private val sample = SampleData("hello", 42)
 
@@ -129,5 +145,25 @@ class ObjectAsBase64StringConverterTest {
         val converter = LZ4JdkObjectAsBase64StringConverter()
         converter.convertToDatabaseColumn(null).shouldBeNull()
         converter.convertToEntityAttribute(null).shouldBeNull()
+    }
+
+    @Test
+    fun `typed Base64 string converter rejects malformed payload`() {
+        val converter = TypedSampleAsBase64StringConverter()
+
+        assertFailsWith<BinarySerializationException> {
+            converter.convertToEntityAttribute("not-base64")
+        }
+    }
+
+    @Test
+    fun `typed Base64 string converter rejects unexpected deserialized type`() {
+        val unsafeConverter = JdkObjectAsBase64StringConverter()
+        val typedConverter = TypedSampleAsBase64StringConverter()
+        val payload = unsafeConverter.convertToDatabaseColumn(UnexpectedData("unexpected"))
+
+        assertFailsWith<BinarySerializationException> {
+            typedConverter.convertToEntityAttribute(payload)
+        }
     }
 }

--- a/docs/lessons/2026-06-26-issue-815-hibernate-object-converter-deserialization.md
+++ b/docs/lessons/2026-06-26-issue-815-hibernate-object-converter-deserialization.md
@@ -1,0 +1,17 @@
+# Issue 815 - Hibernate Object Converter Deserialization Boundary
+
+## Context
+
+Generic Hibernate object converters accepted `Any?` and deserialized database payloads without an explicit type boundary. That made persisted object columns a trust boundary whenever rows could be tampered with, imported, or shared across tenants.
+
+## Decision
+
+Keep the legacy converters for compatibility, but deprecate them as trusted-storage-only. Add typed converter bases that require a target class and serializer, then reject deserialized values that do not match the expected type. For Kryo and Fory paths, prefer secure serializer factories such as `KryoBinarySerializer.secure(...)` and `ForyBinarySerializer.secureFory(...)`.
+
+## Outcome
+
+The public API now gives callers a migration path from generic `Any?` converters to typed converter subclasses. Negative tests cover malformed payloads, unexpected JDK payload types, and secure Kryo/Fory disallowed payloads.
+
+## Future Guidance
+
+When adding persistence converters around binary serialization, make the trusted/untrusted boundary explicit in both API shape and README examples. Compatibility wrappers can remain, but they should not be the recommended path for persisted, externally mutable data.

--- a/docs/review/2026-06-26-issue-815-hibernate-object-converter-review.md
+++ b/docs/review/2026-06-26-issue-815-hibernate-object-converter-review.md
@@ -1,0 +1,26 @@
+# Issue 815 - Hibernate Object Converter Review
+
+## Scope
+
+- `ObjectAsByteArrayConverter.kt`
+- `ObjectAsBase64StringConverter.kt`
+- converter unit tests and consumer runtime test fixtures
+- `data/hibernate` README files
+
+## Findings
+
+No P0/P1 findings found in the local review pass.
+
+## Evidence
+
+- `compileTestKotlin --warning-mode all` passed. New generic converter deprecation warnings are suppressed only in legacy converter declarations and legacy test fixtures.
+- Targeted converter tests passed: 77 tests, including malformed payload, unexpected payload type, and secure Kryo/Fory disallowed payload cases.
+- Full `:bluetape4k-hibernate:test --rerun-tasks` passed: 494 tests.
+- `:bluetape4k-hibernate:consumerRuntimeTest` passed: 3 tests.
+- `:bluetape4k-hibernate:check` passed.
+- `git diff --check` passed.
+- CodeGraph `detect_changes` reported risk score 0.00 and 0 test gaps.
+
+## Residual Risk
+
+The legacy generic `Any?` converters remain available for binary compatibility. They are deprecated and documented as trusted-storage-only, but existing downstream consumers must migrate deliberately to the typed converter bases.


### PR DESCRIPTION
## Summary

Closes #815

- PR 제목: fix: harden Hibernate object converter deserialization

Fixes #815.

This PR deprecates the legacy generic Hibernate object converters as trusted-storage-only and adds typed converter bases for persistent object columns. The new typed converters require a target type plus serializer and reject deserialized payloads that do not match the expected type before returning data to Hibernate.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Add `AbstractTypedObjectAsByteArrayConverter<T>` and `AbstractTypedObjectAsBase64StringConverter<T>`.
- Deprecate generic `Any?` object converters with a trusted-storage-only migration message.
- Add negative tests for malformed payloads, unexpected deserialized types, and secure Kryo/Fory disallowed payloads.
- Update English and Korean Hibernate README examples to recommend typed converters with secure serializer allowlists.
- Add issue lesson and local review artifacts.

### 기존 섹션: Verification

- `./gradlew :bluetape4k-hibernate:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache`
- `./gradlew :bluetape4k-hibernate:test --tests 'io.bluetape4k.hibernate.converter.ObjectAsByteArrayConverterTest' --tests 'io.bluetape4k.hibernate.converters.ObjectAsBase64StringConverterTest' --no-daemon --no-configuration-cache` (77 passing)
- `./gradlew :bluetape4k-hibernate:consumerRuntimeTest --no-daemon --no-configuration-cache` (3 passing)
- `./gradlew :bluetape4k-hibernate:test --rerun-tasks --no-daemon --no-configuration-cache` (494 passing)
- `./gradlew :bluetape4k-hibernate:check --no-daemon --no-configuration-cache`
- `git diff --check`
- CodeGraph `detect_changes`: risk score 0.00, 0 test gaps

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

The legacy generic converters remain available for compatibility, but they are no longer the recommended path for persisted object columns. Existing applications should migrate object columns to typed converter subclasses and pair Kryo/Fory paths with secure serializer factories such as `KryoBinarySerializer.secure(...)` or `ForyBinarySerializer.secureFory(...)`.

## Metadata

- Issue: #815, milestone `1.11.0`, assignee `debop`
- PR: #918, head `3ba00c6e1c4732b0cc5b4d29621fe1b31e97854c`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/hibernate-object-converter-safe-deserialization`
- Labels: `bug`, `security`
- State: `MERGED`, merge commit `6af503593088e2a0ece22922b95afe25d139d2ec`
- CI: - `./gradlew :bluetape4k-hibernate:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache` / - `./gradlew :bluetape4k-hibernate:test --tests 'io.bluetape4k.hibernate.converter.ObjectAsByteArrayConverterTest' --tests 'io.bluetape4k.hibernate.converters.ObjectAsBase64StringConverterTest' --no-daemon --no-configuration-cache` (77 passing) / - `./gradlew :bluetape4k-hibernate:consumerRuntimeTest --no-daemon --no-configuration-cache` (3 passing)

## DoD Status

- [x] Issue metadata mirrored: milestone `1.11.0`, labels `bug` and `security`, assignee `debop`.
- [x] Generic object converters are deprecated as trusted-storage-only.
- [x] Typed converter bases enforce the deserialized target type.
- [x] Kryo/Fory trust profile documented through secure serializer factory examples.
- [x] Negative tests cover malformed, unexpected, and disallowed payloads.
- [x] README.md and README.ko.md document the trust boundary and safe migration path.
- [x] Lesson and review artifacts added under `docs/`.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #918 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `6af503593088e2a0ece22922b95afe25d139d2ec`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
