### PR TITLE
fix: prevent Cassandra session cache context collisions

### DIFF
--- a/data/cassandra/README.ko.md
+++ b/data/cassandra/README.ko.md
@@ -62,6 +62,30 @@ val session2 = cqlSessionOf(
 session.use { /* 작업 수행 */ }
 ```
 
+#### 명시적 identity로 Session 캐싱
+
+`CqlSessionProvider.getOrCreateSession`은 keyspace만이 아니라 `CqlSessionIdentity`를 기준으로 캐시합니다. 같은 keyspace를 서로 다른 contact point, datacenter, credential, client id, tenant context에서 사용할 수 있다면 명시적 identity를 지정하세요.
+
+```kotlin
+val sessionIdentity = CqlSessionIdentity.of(
+    keyspace = "tenant_data",
+    contextParts = listOf(
+        "contactPoint=cassandra-a.example.com:9042",
+        "localDatacenter=dc-a",
+        "tenant=tenant-a",
+        "clientId=analytics-worker",
+    ),
+)
+
+val tenantSession = CqlSessionProvider.getOrCreateSession(sessionIdentity) {
+    addContactPoint(InetSocketAddress("cassandra-a.example.com", 9042))
+    withLocalDatacenter("dc-a")
+    withApplicationName("analytics-worker")
+}
+```
+
+`keyspace`만 받는 호환 overload는 builder supplier와 builder lambda에서 보수적인 per-call identity를 만들어 사용합니다. 따라서 서로 다른 builder block이 keyspace만으로 조용히 같은 세션을 재사용하는 문제는 피하지만, 여러 call site에서 같은 context를 안정적으로 재사용하려면 `CqlSessionIdentity`를 명시하세요.
+
 ### 2. 비동기 쿼리 (Coroutines)
 
 ```kotlin

--- a/data/cassandra/README.md
+++ b/data/cassandra/README.md
@@ -62,6 +62,30 @@ val session2 = cqlSessionOf(
 session.use { /* perform operations */ }
 ```
 
+#### Cached sessions with explicit identity
+
+`CqlSessionProvider.getOrCreateSession` caches by `CqlSessionIdentity`, not by keyspace alone. Use an explicit identity when the same keyspace can be reached through different contact points, datacenters, credentials, client ids, or tenant contexts.
+
+```kotlin
+val sessionIdentity = CqlSessionIdentity.of(
+    keyspace = "tenant_data",
+    contextParts = listOf(
+        "contactPoint=cassandra-a.example.com:9042",
+        "localDatacenter=dc-a",
+        "tenant=tenant-a",
+        "clientId=analytics-worker",
+    ),
+)
+
+val tenantSession = CqlSessionProvider.getOrCreateSession(sessionIdentity) {
+    addContactPoint(InetSocketAddress("cassandra-a.example.com", 9042))
+    withLocalDatacenter("dc-a")
+    withApplicationName("analytics-worker")
+}
+```
+
+The compatibility overload that accepts only `keyspace` derives a conservative per-call identity from the builder supplier and builder lambda. That avoids silent keyspace-only reuse across different builder blocks, but stable reuse across call sites should use an explicit `CqlSessionIdentity`.
+
 ### 2. Asynchronous Queries (Coroutines)
 
 ```kotlin

--- a/data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/CqlSessionProvider.kt
+++ b/data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/CqlSessionProvider.kt
@@ -6,12 +6,51 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.info
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.utils.ShutdownQueue
+import java.io.Serializable
 import java.net.InetSocketAddress
 import java.util.concurrent.ConcurrentHashMap
 
+/**
+ * Stable cache identity for a Cassandra session.
+ *
+ * Use this identity to make the session cache boundary explicit when a keyspace can be reached
+ * through multiple contact points, datacenters, credentials, clients, or tenant contexts.
+ */
+data class CqlSessionIdentity(
+    val keyspace: String,
+    val context: String,
+): Serializable {
+    init {
+        keyspace.requireNotBlank("keyspace")
+        context.requireNotBlank("context")
+    }
+
+    companion object {
+        private const val serialVersionUID = 1L
+
+        /**
+         * Builds a deterministic identity from normalized context parts.
+         */
+        fun of(
+            keyspace: String,
+            contextParts: Iterable<String>,
+        ): CqlSessionIdentity {
+            keyspace.requireNotBlank("keyspace")
+            val context = contextParts
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .sorted()
+                .joinToString(separator = "|")
+                .ifBlank { "default" }
+
+            return CqlSessionIdentity(keyspace, context)
+        }
+    }
+}
+
 object CqlSessionProvider: KLogging() {
 
-    private val sessionCache = ConcurrentHashMap<String, CqlSession>()
+    private val sessionCache = ConcurrentHashMap<CqlSessionIdentity, CqlSession>()
 
     val DEFAULT_CONTACT_POINT = InetSocketAddress("localhost", 9042)
     const val DEFAULT_LOCAL_DATACENTER = "datacenter1"
@@ -39,7 +78,12 @@ object CqlSessionProvider: KLogging() {
     }
 
     /**
-     * Keyspace 별로 [CqlSession]을 생성하도록 합니다. 이미 생성된 경우에는 캐시된 [CqlSession]을 반환합니다.
+     * Creates or reuses a [CqlSession] for the resolved connection identity.
+     *
+     * The compatibility overload no longer caches by keyspace alone. It derives a conservative
+     * per-call identity from the keyspace, builder supplier, and builder lambda to avoid silently
+     * reusing a session across different builder blocks. Use the [CqlSessionIdentity] overload when
+     * same-context reuse must remain stable across call sites.
      *
      * ```
      * val session = CqlSessionProvider.getOrCreateSession("keyspace") {
@@ -61,23 +105,47 @@ object CqlSessionProvider: KLogging() {
     ): CqlSession {
         keyspace.requireNotBlank("keyspace")
 
+        val sessionIdentity = toSessionIdentity(keyspace, builderSupplier, builder)
+
+        return resolveSession(sessionIdentity, builderSupplier, builder)
+    }
+
+    /**
+     * Creates or reuses a [CqlSession] with a caller-provided cache [identity].
+     *
+     * Use this overload when the builder is created outside [CqlSessionProvider] or when the caller
+     * needs to include additional tenant, credential, or routing state in the cache boundary.
+     */
+    fun getOrCreateSession(
+        identity: CqlSessionIdentity,
+        builderSupplier: () -> CqlSessionBuilder = { newCqlSessionBuilder() },
+        builder: CqlSessionBuilder.() -> Unit,
+    ): CqlSession {
+        return resolveSession(identity, builderSupplier, builder)
+    }
+
+    private fun resolveSession(
+        identity: CqlSessionIdentity,
+        builderSupplier: () -> CqlSessionBuilder,
+        builder: CqlSessionBuilder.() -> Unit,
+    ): CqlSession {
         // Cache may still contain closed sessions from previous runs.
-        // Drop them before resolving the requested keyspace session.
+        // Drop them before resolving the requested session identity.
         val closedSessions = sessionCache.filterValues { it.isClosed }
         closedSessions.forEach {
             sessionCache.remove(it.key)
         }
 
-        return sessionCache.computeIfAbsent(keyspace) { keyspace ->
-            log.info { "Creating new CqlSession for $keyspace" }
+        return sessionCache.computeIfAbsent(identity) {
+            log.info { "Creating new CqlSession for ${identity.keyspace} (${identity.context})" }
 
             // keyspace가 없을 수 있으므로, adminSession으로 신규 keyspace를 생성하도록 합니다.
             builderSupplier().build().use { adminSession ->
-                CassandraAdmin.createKeyspace(adminSession, keyspace)
+                CassandraAdmin.createKeyspace(adminSession, identity.keyspace)
             }
 
             builderSupplier()
-                .withKeyspace(keyspace)
+                .withKeyspace(identity.keyspace)
                 .apply(builder)
                 .build()
                 .also {
@@ -85,4 +153,23 @@ object CqlSessionProvider: KLogging() {
                 }
         }
     }
+
+}
+
+private fun toSessionIdentity(
+    keyspace: String,
+    builderSupplier: () -> CqlSessionBuilder,
+    builder: CqlSessionBuilder.() -> Unit,
+): CqlSessionIdentity {
+    return CqlSessionIdentity.of(
+        keyspace = keyspace,
+        contextParts = listOf(
+            "builderSupplier=${builderSupplier.cachePart()}",
+            "builder=${builder.cachePart()}",
+        ),
+    )
+}
+
+private fun Any.cachePart(): String {
+    return "${javaClass.name}@${System.identityHashCode(this)}"
 }

--- a/data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/CqlSessionProviderTest.kt
+++ b/data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/CqlSessionProviderTest.kt
@@ -2,12 +2,12 @@ package io.bluetape4k.cassandra
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.support.closeSafe
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeEqualTo
 import org.junit.jupiter.api.Test
 import java.net.InetSocketAddress
 import java.util.*
-import io.bluetape4k.assertions.assertFailsWith
 
 class CqlSessionProviderTest: AbstractCassandraTest() {
 
@@ -17,21 +17,31 @@ class CqlSessionProviderTest: AbstractCassandraTest() {
     }
 
     @Test
-    fun `새로운 CqlSession 을 생성하고 캐싱한다`() {
+    fun `같은 connection context 의 CqlSession 을 재사용한다`() {
         val cqlSessionBuilderSupplier = {
             CqlSessionProvider.newCqlSessionBuilder(
                 InetSocketAddress(cassandra4.host, cassandra4.port),
                 CqlSessionProvider.DEFAULT_LOCAL_DATACENTER
             )
         }
+        val clientId = UUID.randomUUID()
+        val sessionIdentity = CqlSessionIdentity.of(
+            keyspace = TEST_KEYSPACE_1,
+            contextParts = listOf(
+                "contactPoint=${cassandra4.host}:${cassandra4.port}",
+                "localDatacenter=${CqlSessionProvider.DEFAULT_LOCAL_DATACENTER}",
+                "applicationName=provider-test-reuse",
+                "clientId=$clientId",
+            ),
+        )
 
-        val session1 = CqlSessionProvider.getOrCreateSession(TEST_KEYSPACE_1, cqlSessionBuilderSupplier) {
-            withApplicationName("provider-test-1")
-            withClientId(UUID.randomUUID())
+        val session1 = CqlSessionProvider.getOrCreateSession(sessionIdentity, cqlSessionBuilderSupplier) {
+            withApplicationName("provider-test-reuse")
+            withClientId(clientId)
         }
-        val session2 = CqlSessionProvider.getOrCreateSession(TEST_KEYSPACE_1, cqlSessionBuilderSupplier) {
-            withApplicationName("provider-test-2")
-            withClientId(UUID.randomUUID())
+        val session2 = CqlSessionProvider.getOrCreateSession(sessionIdentity, cqlSessionBuilderSupplier) {
+            withApplicationName("provider-test-reuse")
+            withClientId(clientId)
         }
 
         session2 shouldBeEqualTo session1
@@ -46,6 +56,30 @@ class CqlSessionProviderTest: AbstractCassandraTest() {
         session1.closeSafe()
         session2.closeSafe()
         session3.closeSafe()
+    }
+
+    @Test
+    fun `같은 keyspace 라도 다른 connection context 는 재사용하지 않는다`() {
+        val cqlSessionBuilderSupplier = {
+            CqlSessionProvider.newCqlSessionBuilder(
+                InetSocketAddress(cassandra4.host, cassandra4.port),
+                CqlSessionProvider.DEFAULT_LOCAL_DATACENTER
+            )
+        }
+
+        val session1 = CqlSessionProvider.getOrCreateSession(TEST_KEYSPACE_1, cqlSessionBuilderSupplier) {
+            withApplicationName("provider-test-context-1")
+            withClientId(UUID.randomUUID())
+        }
+        val session2 = CqlSessionProvider.getOrCreateSession(TEST_KEYSPACE_1, cqlSessionBuilderSupplier) {
+            withApplicationName("provider-test-context-2")
+            withClientId(UUID.randomUUID())
+        }
+
+        session2 shouldNotBeEqualTo session1
+
+        session1.closeSafe()
+        session2.closeSafe()
     }
 
     @Test

--- a/docs/lessons/2026-06-26-issue-809-cassandra-session-cache-identity.md
+++ b/docs/lessons/2026-06-26-issue-809-cassandra-session-cache-identity.md
@@ -1,0 +1,17 @@
+# Issue 809 - Cassandra Session Cache Identity
+
+## Context
+
+`CqlSessionProvider` cached sessions by keyspace name only. A process using the same keyspace name across tenants, endpoints, credentials, or client settings could silently reuse the first session.
+
+## Decision
+
+Use `CqlSessionIdentity` as the cache key. The compatibility overload derives a conservative per-call identity from the builder supplier and builder lambda so different builder blocks no longer collide by keyspace alone. For stable same-context reuse across call sites, callers should use the explicit `CqlSessionIdentity` overload.
+
+## Outcome
+
+Regression tests now prove that same identity reuses a session while the same keyspace with different connection context does not reuse the earlier session. README examples document when to use explicit identity.
+
+## Future Guidance
+
+Do not cache infrastructure clients by a logical namespace alone when connection, credential, or tenant context can differ. Add an explicit identity object before relying on implicit builder state.

--- a/docs/review/2026-06-26-issue-809-cassandra-session-cache-review.md
+++ b/docs/review/2026-06-26-issue-809-cassandra-session-cache-review.md
@@ -1,0 +1,22 @@
+# Issue 809 - Cassandra Session Cache Review
+
+## Scope
+
+- `data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/CqlSessionProvider.kt`
+- `data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/CqlSessionProviderTest.kt`
+- `data/cassandra/README.md`
+- `data/cassandra/README.ko.md`
+
+## Findings
+
+No P0/P1 findings found in the local review pass.
+
+## Evidence
+
+- TDD red: `CqlSessionProviderTest` failed when the same keyspace with a different builder context reused the same cached session.
+- `compileTestKotlin --warning-mode all` passed. Remaining warnings are existing Gradle Kotlin DSL deprecations outside this change.
+- `:bluetape4k-cassandra:test --rerun-tasks` passed: 178 tests.
+
+## Residual Risk
+
+The compatibility overload cannot inspect arbitrary `CqlSessionBuilder` internals. It prevents keyspace-only collisions by using builder supplier/lambda identity, while the explicit `CqlSessionIdentity` overload is the documented path for stable reuse across call sites.


### PR DESCRIPTION
## Summary

Closes #809

- PR 제목: fix: prevent Cassandra session cache context collisions

Fixes #809.

This PR prevents `CqlSessionProvider` from caching Cassandra sessions by keyspace alone. A keyspace can be reused across endpoints, datacenters, credentials, tenants, or client settings, so the cache boundary now uses `CqlSessionIdentity`.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Add `CqlSessionIdentity` as the stable cache identity for Cassandra sessions.
- Change the internal cache from `keyspace -> CqlSession` to `CqlSessionIdentity -> CqlSession`.
- Keep the existing keyspace overload source-compatible, but make it derive a conservative per-call identity from the builder supplier and builder lambda instead of silently reusing by keyspace alone.
- Add an explicit `CqlSessionIdentity` overload for stable same-context reuse across call sites.
- Add regression tests for same-context reuse and same-keyspace/different-context isolation.
- Update English and Korean README guidance for explicit session cache identity.
- Add lesson and local review artifacts.

### 기존 섹션: Verification

- TDD red: `./gradlew :bluetape4k-cassandra:test --tests 'io.bluetape4k.cassandra.CqlSessionProviderTest' --no-daemon --no-configuration-cache` failed before the fix because the same keyspace with a different connection context reused the same session.
- `./gradlew :bluetape4k-cassandra:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache`
- `./gradlew :bluetape4k-cassandra:compileTestKotlin :bluetape4k-cassandra:test --tests 'io.bluetape4k.cassandra.CqlSessionProviderTest' --no-daemon --no-configuration-cache` (4 passing)
- `./gradlew :bluetape4k-cassandra:test --rerun-tasks :bluetape4k-cassandra:check --no-daemon --no-configuration-cache` (178 passing)
- `git diff --check`
- CodeGraph `detect_changes`: risk score 0.00, 0 test gaps

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

The compatibility overload cannot inspect arbitrary `CqlSessionBuilder` internals safely. It now avoids keyspace-only collisions by separating different builder blocks, while the documented `CqlSessionIdentity` overload is the intended path when callers need stable reuse across call sites.

## Metadata

- Issue: #809, milestone `1.11.0`, assignee `debop`
- PR: #919, head `df08286be91458ad4b8afc54acfb902aec955c79`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/cassandra-session-cache-identity`
- Labels: `bug`, `security`
- State: `MERGED`, merge commit `9ad16dc095b7c73bfbd88f0119c61fdca0b00aee`
- CI: - Add an explicit `CqlSessionIdentity` overload for stable same-context reuse across call sites. / - Update English and Korean README guidance for explicit session cache identity. / - TDD red: `./gradlew :bluetape4k-cassandra:test --tests 'io.bluetape4k.cassandra.CqlSessionProviderTest' --no-daemon --no-configuration-cache` failed before the fix because the same keyspace with a different connection context reused the same session.

## DoD Status

- [x] Issue metadata mirrored: milestone `1.11.0`, labels `bug` and `security`, assignee `debop`.
- [x] Same keyspace plus incompatible connection context no longer reuses the earlier session silently.
- [x] Existing same-context reuse remains supported through explicit `CqlSessionIdentity`.
- [x] Regression tests cover the collision case.
- [x] README.md and README.ko.md document the cache identity boundary.
- [x] Lesson and review artifacts added under `docs/`.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #919 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9ad16dc095b7c73bfbd88f0119c61fdca0b00aee`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
