### PR TITLE
fix: redact OpenTelemetry helper exception telemetry

### DIFF
--- a/docs/lessons/2026-06-27-issue-806-opentelemetry-redacted-exception-telemetry.md
+++ b/docs/lessons/2026-06-27-issue-806-opentelemetry-redacted-exception-telemetry.md
@@ -1,0 +1,22 @@
+# Lessons Learned - Issue 806 OpenTelemetry Redacted Exception Telemetry (2026-06-27)
+
+Issue: #806
+Module: `infra/opentelemetry`
+
+## Context
+
+OpenTelemetry span helpers recorded exception messages into exported span status and exception events by default. Exception messages often contain SQL fragments, URLs, tokens, or user input, so helper-managed failure paths must treat raw messages as sensitive by default.
+
+## Decision
+
+Helper-managed failures now emit a redacted `exception` event and set `StatusCode.ERROR` with `"unspecified error"` as the exported message. The original exception is still rethrown to callers. Full OpenTelemetry `recordException` remains available only as an explicit opt-in at a boundary where exporting the raw exception message is allowed.
+
+## Test Helper Judgment
+
+The change affects coroutine and Flow failure paths, so `SuspendedJobTester` is the fitting bluetape4k helper. It was used for coroutine and Flow redaction stress tests.
+
+`MultithreadingTester` and `StructuredTaskScopeTester` were not used because this fix does not add shared mutable production state, thread contention, virtual-thread behavior, or `StructuredTaskScope` semantics.
+
+## Future Guard
+
+For telemetry helpers, test both status descriptions and event attributes. `recordException(error)` can export `exception.message`, so a status-only assertion is not enough for secret-leak regressions.

--- a/docs/review/2026-06-27-issue-806-opentelemetry-redaction-review.md
+++ b/docs/review/2026-06-27-issue-806-opentelemetry-redaction-review.md
@@ -1,0 +1,29 @@
+# Local Review - Issue 806 OpenTelemetry Redacted Exception Telemetry
+
+Date: 2026-06-27
+Scope: `infra/opentelemetry`
+Issue: #806
+
+## Verdict
+
+No P0/P1 findings found in the current diff.
+
+## Reviewed Risks
+
+- Security/trust boundary: helper-managed OpenTelemetry failure paths no longer export raw exception messages through span status descriptions or `exception.message` event attributes.
+- Coroutine/Flow lifecycle: `CancellationException` branches still rethrow before failure recording, preserving `UNSET` status and structured cancellation behavior.
+- Public API compatibility: existing helper signatures are unchanged. The behavior change is a safer default for exported telemetry.
+- Test helper gate: `SuspendedJobTester` is used for coroutine and Flow redaction stress coverage. `MultithreadingTester` and `StructuredTaskScopeTester` are intentionally not used because the fix does not introduce shared production state, thread contention, virtual-thread behavior, or structured task scope behavior.
+
+## Validation Evidence
+
+- TDD red: targeted redaction tests failed before the fix because exported telemetry still contained secret-bearing exception messages.
+- `./gradlew :bluetape4k-opentelemetry:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache`: PASS. Existing Gradle Kotlin DSL delegated-property deprecation warning remains outside touched source/test code.
+- Targeted redaction tests, including `SuspendedJobTester` stress coverage: PASS.
+- `./gradlew :bluetape4k-opentelemetry:test --rerun-tasks :bluetape4k-opentelemetry:check --no-daemon --no-configuration-cache`: PASS, 78 tests, 0 failures, 0 skipped.
+- `git diff --check`: PASS.
+- CodeGraph `get_affected_flows` against `develop`: 0 affected registered flows for 8 tracked changed files.
+
+## Residual Risk
+
+Callers that explicitly call raw OpenTelemetry `recordException(error)` can still export raw exception messages. README guidance documents that as opt-in behavior, not helper default behavior.

--- a/infra/opentelemetry/README.ko.md
+++ b/infra/opentelemetry/README.ko.md
@@ -98,10 +98,12 @@ tracer.spanBuilder("my-operation").useSpan { span ->
   doWork()
 }
 
-// 일반 예외는 span에 기록한 뒤 원본 예외 타입을 유지한 채 다시 던짐
+// helper가 관리하는 실패는 기본적으로 redacted telemetry로 기록합니다.
+// 원본 예외는 그대로 다시 던집니다.
 tracer.spanBuilder("failing-operation").useSpan { span ->
   runCatching { doWork() }
     .onFailure {
+      // 명시적 opt-in: 이 OpenTelemetry 원시 호출은 예외 메시지를 export할 수 있습니다.
       span.recordException(it)
       throw it
     }
@@ -182,14 +184,15 @@ tracer.withSpan("parent") {
 }
 
 // CancellationException → StatusCode.UNSET (ERROR 미기록)
-// 그 외 Throwable     → StatusCode.ERROR + recordException + 재던짐
+// 그 외 Throwable     → StatusCode.ERROR + redacted exception event + 재던짐
 ```
 
 **Span 생명주기 계약:**
 - 정상 완료 → `StatusCode.OK`, Span 종료
 - `CancellationException` → `StatusCode.UNSET`, Span 종료, 예외 재던짐
-- 그 외 `Throwable` → `StatusCode.ERROR` + `recordException`, Span 종료, 예외 재던짐
-- 예외 메시지 `null` → `"unspecified error"` (내부 클래스명 절대 노출 안 함)
+- 그 외 `Throwable` → `StatusCode.ERROR` + redacted `exception` event, Span 종료, 예외 재던짐
+- status description과 `exception.message`는 기본적으로 `"unspecified error"`를 사용해 원본 예외 메시지를 export하지 않습니다.
+- 전체 예외 이벤트가 꼭 필요하면, 해당 메시지가 외부로 나가도 되는 경계에서 OpenTelemetry `recordException`을 명시적으로 호출하세요.
 
 ### 3-B. Flow 트레이싱 — `traced()` / `tracedCollect()`
 
@@ -223,7 +226,8 @@ flowOf(42).tracedCollect(tracer, "collect-span") { item ->
 **계약:**
 - 정상 완료 → `StatusCode.OK`
 - `CancellationException` (timeout, `take()`, 취소) → `StatusCode.UNSET`
-- 그 외 예외 → `StatusCode.ERROR` + `recordException`, 예외 재던짐
+- 그 외 예외 → `StatusCode.ERROR` + redacted `exception` event, 예외 재던짐
+- 원본 예외 메시지는 기본 export하지 않으며, 명시적 `recordException` 호출만 opt-in입니다.
 - `traced()` vs `tracedCollect()` 선택 기준:
   - `traced()` — 새 Flow 반환. OTel Context는 **producer** 코루틴에만 활성화
   - `tracedCollect()` — 터미널 연산자. OTel Context는 **producer + consumer(action)** 코루틴 양쪽에 활성화

--- a/infra/opentelemetry/README.md
+++ b/infra/opentelemetry/README.md
@@ -98,10 +98,12 @@ tracer.spanBuilder("my-operation").useSpan { span ->
   doWork()
 }
 
-// Exceptions are recorded on the span; the original exception type is rethrown as-is
+// Helper-managed failures are recorded with redacted telemetry by default.
+// The original exception is rethrown as-is.
 tracer.spanBuilder("failing-operation").useSpan { span ->
   runCatching { doWork() }
     .onFailure {
+      // Explicit opt-in: this raw OpenTelemetry call can export the exception message.
       span.recordException(it)
       throw it
     }
@@ -183,14 +185,15 @@ tracer.withSpan("parent") {
 }
 
 // CancellationException → StatusCode.UNSET (not recorded as ERROR)
-// Other Throwable     → StatusCode.ERROR + recordException + rethrown
+// Other Throwable     → StatusCode.ERROR + redacted exception event + rethrown
 ```
 
 **Span lifecycle contracts:**
 - Normal completion → `StatusCode.OK`, span ended
 - `CancellationException` → `StatusCode.UNSET`, span ended, exception rethrown
-- Any other `Throwable` → `StatusCode.ERROR` + `recordException`, span ended, exception rethrown
-- `null` exception message → `"unspecified error"` (internal class names never leaked)
+- Any other `Throwable` → `StatusCode.ERROR` + redacted `exception` event, span ended, exception rethrown
+- Status description and `exception.message` default to `"unspecified error"` so raw exception messages are not exported by helper APIs.
+- Full exception events are explicit opt-in: call OpenTelemetry `recordException` only at boundaries where exporting that message is allowed.
 
 ### 3-B. Flow Tracing — `traced()` / `tracedCollect()`
 
@@ -224,7 +227,8 @@ flowOf(42).tracedCollect(tracer, "collect-span") { item ->
 **Contracts:**
 - Normal completion → `StatusCode.OK`
 - `CancellationException` (timeout, `take()`, cancellation) → `StatusCode.UNSET`
-- Other exception → `StatusCode.ERROR` + `recordException`, exception rethrown
+- Other exception → `StatusCode.ERROR` + redacted `exception` event, exception rethrown
+- Raw exception messages are not exported by default; explicit `recordException` calls are opt-in.
 - `traced()` vs `tracedCollect()`:
   - `traced()` — returns a new Flow; OTel context active in the **producer** coroutine
   - `tracedCollect()` — terminal operator; OTel context active in **both producer and consumer** (action) coroutines

--- a/infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/FlowSpanSupport.kt
+++ b/infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/FlowSpanSupport.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.opentelemetry.coroutines
 
+import io.bluetape4k.opentelemetry.trace.recordFailure
 import io.bluetape4k.support.requireNotBlank
 import io.opentelemetry.api.trace.SpanBuilder
 import io.opentelemetry.api.trace.StatusCode
@@ -11,8 +12,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.withContext
 
-private const val UNSPECIFIED_ERROR = "unspecified error"
-
 /**
  * 이 [Flow]의 collect를 단일 [io.opentelemetry.api.trace.Span]으로 감싸는 새로운 [Flow]를 반환합니다.
  *
@@ -21,8 +20,8 @@ private const val UNSPECIFIED_ERROR = "unspecified error"
  *   emit 횟수와 무관합니다. 아이템별 Span이 필요하면 `onEach { }` 안에서 직접 Span을 관리하세요.
  * - 정상 종료 시 [StatusCode.OK]를 설정하고 Span을 종료합니다.
  * - [CancellationException] (upstream 또는 downstream 취소) 시 상태를 UNSET으로 유지하고 Span을 종료합니다.
- * - 일반 예외 발생 시 `recordException` + [StatusCode.ERROR] 설정 후 Span을 종료하고 예외를 재던집니다.
- *   fallback 메시지는 `"unspecified error"` — 내부 클래스명은 절대 노출하지 않습니다.
+ * - 일반 예외 발생 시 redacted `exception` event와 [StatusCode.ERROR] 설정 후 Span을 종료하고 예외를 재던집니다.
+ *   status description과 event message는 `"unspecified error"`를 사용해 원본 예외 메시지를 기본 노출하지 않습니다.
  *
  * ## 구현 주의
  * - 내부적으로 `channelFlow { }` 를 사용합니다. `flow { }` + `withContext` + `emit()` 조합은
@@ -70,8 +69,7 @@ public fun <T> Flow<T>.traced(
         } catch (ce: CancellationException) {
             throw ce
         } catch (t: Throwable) {
-            span.recordException(t)
-            span.setStatus(StatusCode.ERROR, t.message ?: UNSPECIFIED_ERROR)
+            span.recordFailure(t)
             throw t
         } finally {
             span.end()
@@ -87,7 +85,7 @@ public fun <T> Flow<T>.traced(
  *   따라서 [action] 안에서 `Span.current()`를 호출하면 이 함수가 생성한 Span이 반환됩니다.
  * - 정상 종료 시 [StatusCode.OK]를 설정하고 Span을 종료합니다.
  * - [CancellationException] 시 상태를 UNSET으로 유지하고 Span을 종료합니다.
- * - 일반 예외 발생 시 `recordException` + [StatusCode.ERROR] 설정 후 재던집니다.
+ * - 일반 예외 발생 시 redacted `exception` event와 [StatusCode.ERROR] 설정 후 재던집니다.
  *
  * ## [traced] 와의 차이
  * - `traced()` 는 OTel Context 를 producer(upstream) 코루틴에만 설치합니다.
@@ -122,8 +120,7 @@ public suspend fun <T> Flow<T>.tracedCollect(
     } catch (ce: CancellationException) {
         throw ce
     } catch (t: Throwable) {
-        span.recordException(t)
-        span.setStatus(StatusCode.ERROR, t.message ?: UNSPECIFIED_ERROR)
+        span.recordFailure(t)
         throw t
     } finally {
         span.end()

--- a/infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/SpanCoroutineSupport.kt
+++ b/infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/SpanCoroutineSupport.kt
@@ -20,7 +20,7 @@ import kotlin.coroutines.EmptyCoroutineContext
  *
  * ## 동작/계약
  * - [withSpanContext]를 이용해 현재 span을 코루틴 컨텍스트에 설치합니다.
- * - 일반 예외는 span에 기록하고 `ERROR` 상태로 바꾼 뒤 원본 예외를 그대로 다시 던집니다.
+ * - 일반 예외는 redacted exception event를 기록하고 `ERROR` 상태로 바꾼 뒤 원본 예외를 그대로 다시 던집니다.
  * - [CancellationException]은 취소 의미를 보존하기 위해 span 상태를 바꾸지 않고 그대로 전파합니다.
  * - `waitTimeout`은 하위 호환용 인자이며, 현재 구현은 trace duration 왜곡을 막기 위해 즉시 종료합니다.
  *
@@ -115,7 +115,7 @@ suspend inline fun <T> SpanBuilder.useSpanSuspending(
  * ## 동작/계약
  * - 내부적으로 [SpanBuilder.useSpanSuspending]에 위임합니다.
  * - [CancellationException]은 상태 변경 없이 그대로 전파합니다 (UNSET 유지, 구조적 동시성 보존).
- * - 일반 예외는 span에 기록하고 [io.opentelemetry.api.trace.StatusCode.ERROR] 상태로 바꾼 뒤 재던집니다.
+ * - 일반 예외는 redacted exception event를 기록하고 [io.opentelemetry.api.trace.StatusCode.ERROR] 상태로 바꾼 뒤 재던집니다.
  *
  * ## 보안 경고
  * - [configure] 람다에서 PII, Authorization 토큰, 민감 헤더를 attribute로 설정하지 마세요.
@@ -150,7 +150,7 @@ public suspend fun <T> Tracer.withSpan(
  *
  * ## 동작/계약
  * - `Context.current()`에 [span]을 저장한 뒤 [asContextElement]로 코루틴 컨텍스트에 연결합니다.
- * - 일반 예외는 span에 기록하고 `ERROR` 상태를 남긴 뒤 원본 예외를 다시 던집니다.
+ * - 일반 예외는 redacted exception event와 `ERROR` 상태를 남긴 뒤 원본 예외를 다시 던집니다.
  * - [CancellationException]은 취소 전파를 보존하기 위해 가공하지 않습니다.
  * - `waitTimeout`은 하위 호환용 인자이며, 현재 구현은 trace duration 왜곡을 막기 위해 즉시 종료합니다.
  */

--- a/infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanSupport.kt
+++ b/infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/trace/SpanSupport.kt
@@ -1,6 +1,8 @@
 package io.bluetape4k.opentelemetry.trace
 
 import io.bluetape4k.support.requireNotBlank
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanBuilder
 import io.opentelemetry.api.trace.SpanContext
@@ -10,6 +12,9 @@ import kotlinx.coroutines.CancellationException
 import java.time.Duration
 
 private const val UNSPECIFIED_ERROR = "unspecified error"
+private const val EXCEPTION_EVENT_NAME = "exception"
+private val EXCEPTION_TYPE_ATTRIBUTE = AttributeKey.stringKey("exception.type")
+private val EXCEPTION_MESSAGE_ATTRIBUTE = AttributeKey.stringKey("exception.message")
 
 
 /**
@@ -27,7 +32,7 @@ val InvalidSpanContext: SpanContext = SpanContext.getInvalid()
  * [Span]을 사용하여 코드 블록을 실행하고, 실행이 끝나면 Span을 자동으로 종료합니다.
  *
  * ## 동작/계약
- * - 일반 예외는 span에 `exception` 이벤트와 `ERROR` 상태를 남긴 뒤 원본 예외를 그대로 다시 던집니다.
+ * - 일반 예외는 redacted `exception` 이벤트와 `ERROR` 상태를 남긴 뒤 원본 예외를 그대로 다시 던집니다.
  * - [CancellationException]은 취소 의미를 보존하기 위해 오류로 기록하지 않고 그대로 전파합니다.
  * - `waitTimeout`은 하위 호환을 위해 유지되며, 현재 구현은 trace duration 왜곡을 피하기 위해 span을 즉시 종료합니다.
  *
@@ -76,7 +81,7 @@ inline fun <T> Span.use(waitDuration: Duration, block: (Span) -> T): T =
  *
  * ## 동작/계약
  * - 새 span을 생성한 뒤 [Span.use]에 위임합니다.
- * - 예외 처리와 종료 시맨틱은 [Span.use]와 동일합니다.
+ * - 예외 처리와 종료 시맨틱은 [Span.use]와 동일하며, 원본 예외 메시지는 기본 export하지 않습니다.
  *
  * @param waitTimeout 하위 호환을 위해 남겨둔 종료 대기 시간 인자입니다. 현재 구현은 trace duration 왜곡을 막기 위해 즉시 종료합니다.
  * @param block 실행할 코드 블록
@@ -105,8 +110,14 @@ internal fun Span.recordFailure(error: Throwable) {
         return
     }
 
-    recordException(error)
-    setStatus(StatusCode.ERROR, error.message ?: UNSPECIFIED_ERROR)
+    addEvent(
+        EXCEPTION_EVENT_NAME,
+        Attributes.builder()
+            .put(EXCEPTION_TYPE_ATTRIBUTE, error::class.java.name)
+            .put(EXCEPTION_MESSAGE_ATTRIBUTE, UNSPECIFIED_ERROR)
+            .build(),
+    )
+    setStatus(StatusCode.ERROR, UNSPECIFIED_ERROR)
 }
 
 /**
@@ -114,8 +125,8 @@ internal fun Span.recordFailure(error: Throwable) {
  *
  * ## 동작/계약
  * - 정상 종료 시 [StatusCode.OK]를 설정하고 Span을 종료합니다.
- * - 일반 예외 발생 시 `recordException` + [StatusCode.ERROR] 설정 후 재던집니다.
- *   fallback 메시지는 `"unspecified error"` — 내부 클래스명은 절대 노출하지 않습니다.
+ * - 일반 예외 발생 시 redacted `exception` event와 [StatusCode.ERROR] 설정 후 재던집니다.
+ *   status description과 event message는 `"unspecified error"`를 사용해 원본 예외 메시지를 기본 노출하지 않습니다.
  * - [CancellationException]은 상태 변경 없이 그대로 전파합니다 (UNSET 유지).
  *
  * ## 보안 경고

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/RedactionAssertions.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/RedactionAssertions.kt
@@ -1,0 +1,21 @@
+package io.bluetape4k.opentelemetry
+
+import io.bluetape4k.assertions.shouldBeFalse
+import io.opentelemetry.sdk.trace.data.SpanData
+
+internal fun SpanData.shouldNotExpose(secret: String) {
+    val exported = buildString {
+        append(status.description)
+        attributes.asMap().forEach { (key, value) ->
+            append('|').append(key.key).append('=').append(value)
+        }
+        events.forEach { event ->
+            append('|').append(event.name)
+            event.attributes.asMap().forEach { (key, value) ->
+                append('|').append(key.key).append('=').append(value)
+            }
+        }
+    }
+
+    exported.contains(secret).shouldBeFalse()
+}

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/coroutines/FlowSpanSupportTest.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/coroutines/FlowSpanSupportTest.kt
@@ -6,9 +6,11 @@ import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.opentelemetry.AbstractOtelTest
+import io.bluetape4k.opentelemetry.shouldNotExpose
 import io.bluetape4k.opentelemetry.trace.sdkTracerProvider
 import io.bluetape4k.opentelemetry.trace.simpleSpanProcessorOf
 import io.opentelemetry.api.common.AttributeKey
@@ -24,6 +26,8 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -94,6 +98,68 @@ class FlowSpanSupportTest: AbstractOtelTest() {
         finished shouldHaveSize 1
         finished[0].status.statusCode shouldBeEqualTo StatusCode.ERROR
         finished[0].events.any { it.name == "exception" }.shouldBeTrue()
+    }
+
+    @Test
+    fun `traced upstream exception should not export raw exception message by default`() = runSuspendIO {
+        val secret = "password=hunter2"
+        val failure = IllegalStateException("query failed with $secret")
+        val upstream = flow<Int> { throw failure }
+
+        val ex = kotlin.runCatching {
+            upstream.traced(tracer, "redacted-flow").collect { }
+        }.exceptionOrNull()
+
+        ex.shouldNotBeNull()
+        (ex is IllegalStateException).shouldBeTrue()
+        ex.message shouldBeEqualTo failure.message
+        flush()
+
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 1
+
+        val span = finished[0]
+        span.status.statusCode shouldBeEqualTo StatusCode.ERROR
+        span.events.any { it.name == "exception" }.shouldBeTrue()
+        span.shouldNotExpose(secret)
+    }
+
+    @Test
+    fun `traced upstream exception should keep redaction stable under SuspendedJobTester`() = runSuspendIO {
+        val sequence = AtomicInteger()
+        val secrets = ConcurrentLinkedQueue<String>()
+
+        SuspendedJobTester()
+            .workers(4)
+            .rounds(24)
+            .add {
+                val id = sequence.incrementAndGet()
+                val secret = "password=flow-token-$id"
+                secrets.add(secret)
+
+                val failure = IllegalStateException("query failed with $secret")
+                val upstream = flow<Int> { throw failure }
+
+                val ex = kotlin.runCatching {
+                    upstream.traced(tracer, "redacted-flow-stress-$id").collect { }
+                }.exceptionOrNull()
+
+                ex.shouldNotBeNull()
+                (ex is IllegalStateException).shouldBeTrue()
+            }
+            .run()
+
+        flush()
+
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 24
+        finished.forEach { span ->
+            span.status.statusCode shouldBeEqualTo StatusCode.ERROR
+            span.events.any { it.name == "exception" }.shouldBeTrue()
+            secrets.forEach { secret ->
+                span.shouldNotExpose(secret)
+            }
+        }
     }
 
     @Test

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/coroutines/SpanCoroutineSupportTest.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/coroutines/SpanCoroutineSupportTest.kt
@@ -6,9 +6,11 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.opentelemetry.AbstractOtelTest
+import io.bluetape4k.opentelemetry.shouldNotExpose
 import io.bluetape4k.opentelemetry.trace.export
 import io.bluetape4k.opentelemetry.trace.loggingSpanExporterOf
 import io.bluetape4k.opentelemetry.trace.sdkTracerProvider
@@ -24,6 +26,7 @@ import io.opentelemetry.sdk.trace.export.SpanExporter
 import kotlinx.coroutines.CancellationException
 import org.junit.jupiter.api.Test
 import java.time.Duration
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -124,6 +127,73 @@ class SpanCoroutineSupportTest: AbstractOtelTest() {
         span.name shouldBeEqualTo "error-span"
         span.status.statusCode.name shouldBeEqualTo "ERROR"
         span.events.any { it.name == "exception" }.shouldBeTrue()
+    }
+
+    @Test
+    fun `useSuspending should not export raw exception message by default`() = runSuspendIO {
+        spanExporter.reset()
+
+        val secret = "authorization=Bearer abc.def.ghi"
+        val failure = IllegalArgumentException("request failed with $secret")
+
+        val ex = kotlin.runCatching {
+            tracer.spanBuilder("redacted-coroutine-span").startSpan().useSuspending {
+                throw failure
+            }
+        }.exceptionOrNull()
+
+        ex.shouldNotBeNull()
+        (ex is IllegalArgumentException).shouldBeTrue()
+        ex.message shouldBeEqualTo failure.message
+
+        flush()
+
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 1
+
+        val span = finished[0]
+        span.status.statusCode.name shouldBeEqualTo "ERROR"
+        span.events.any { it.name == "exception" }.shouldBeTrue()
+        span.shouldNotExpose(secret)
+    }
+
+    @Test
+    fun `useSuspending should keep redaction stable under SuspendedJobTester`() = runSuspendIO {
+        spanExporter.reset()
+
+        val sequence = AtomicInteger()
+        val secrets = ConcurrentLinkedQueue<String>()
+
+        SuspendedJobTester()
+            .workers(4)
+            .rounds(24)
+            .add {
+                val id = sequence.incrementAndGet()
+                val secret = "authorization=Bearer coroutine-token-$id"
+                secrets.add(secret)
+
+                val ex = kotlin.runCatching {
+                    tracer.spanBuilder("redacted-coroutine-stress-$id").startSpan().useSuspending {
+                        throw IllegalArgumentException("request failed with $secret")
+                    }
+                }.exceptionOrNull()
+
+                ex.shouldNotBeNull()
+                (ex is IllegalArgumentException).shouldBeTrue()
+            }
+            .run()
+
+        flush()
+
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 24
+        finished.forEach { span ->
+            span.status.statusCode.name shouldBeEqualTo "ERROR"
+            span.events.any { it.name == "exception" }.shouldBeTrue()
+            secrets.forEach { secret ->
+                span.shouldNotExpose(secret)
+            }
+        }
     }
 
     @Test

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/trace/SpanSupportTest.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/trace/SpanSupportTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.opentelemetry.trace
 
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.opentelemetry.AbstractOtelTest
+import io.bluetape4k.opentelemetry.shouldNotExpose
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
@@ -78,6 +79,33 @@ class SpanSupportTest: AbstractOtelTest() {
         s.name shouldBeEqualTo "error-span"
         s.status.statusCode shouldBeEqualTo StatusCode.ERROR
         s.events.any { it.name == "exception" }.shouldBeTrue()
+    }
+
+    @Test
+    fun `Span use should not export raw exception message by default`() = runSuspendIO {
+        spanExporter.reset()
+
+        val secret = "token=abc123&password=super-secret"
+        val failure = IllegalStateException("database rejected $secret")
+
+        val ex = kotlin.runCatching {
+            tracer.spanBuilder("redacted-error-span").startSpan().use {
+                throw failure
+            }
+        }.exceptionOrNull()
+
+        ex.shouldNotBeNull()
+        (ex === failure).shouldBeTrue()
+
+        flush()
+
+        val finished = spanExporter.finishedSpanItems
+        finished shouldHaveSize 1
+
+        val span = finished[0]
+        span.status.statusCode shouldBeEqualTo StatusCode.ERROR
+        span.events.any { it.name == "exception" }.shouldBeTrue()
+        span.shouldNotExpose(secret)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #806

- PR 제목: fix: redact OpenTelemetry helper exception telemetry

Fixes #806.

OpenTelemetry helper-managed failure paths now redact exported exception telemetry by default. The helpers still rethrow the original exception, but span status descriptions and helper-created `exception.message` attributes use the bounded sentinel `unspecified error` instead of raw exception messages.

## Background

Exception messages often include user input, SQL fragments, URLs, tokens, credentials, or other sensitive values. The previous helper implementation called raw OpenTelemetry `recordException(error)` and set status descriptions from `error.message`, which could leak those values to observability backends by default.

## What This Solves

- Stops `Span.use`, `SpanBuilder.useSpan`, blocking/suspend `Tracer.withSpan`, `Span.useSuspending`, `withSpanContext`, `Flow.traced`, and `Flow.tracedCollect` helper paths from exporting raw exception messages by default.
- Preserves cancellation behavior: `CancellationException` remains unrecorded as an error and is rethrown.
- Preserves API compatibility: public helper signatures are unchanged.
- Documents raw OpenTelemetry `recordException(error)` as an explicit opt-in at allowed trust boundaries.

## Work Done

- Replaced helper default failure recording with a redacted `exception` event and `StatusCode.ERROR` description.
- Reused the common `Span.recordFailure` path from Flow helpers to avoid drift.
- Added exported-span assertions that inspect status descriptions, attributes, event names, and event attributes for secret-bearing text.
- Added redaction regression tests for blocking Span, coroutine Span, and Flow helper paths.
- Added `SuspendedJobTester` coroutine/Flow stress coverage because #806 touches suspend/Flow failure boundaries.
- Did not add `MultithreadingTester` or `StructuredTaskScopeTester`: this fix does not add shared mutable production state, thread contention, virtual-thread behavior, or structured task scope semantics.
- Updated `README.md` and `README.ko.md` with default redaction and explicit opt-in guidance.
- Added lesson and local review artifacts under `docs/`.

## Validation

- TDD red: targeted redaction tests failed before the fix because exported telemetry still contained secret-bearing exception messages.
- `./gradlew :bluetape4k-opentelemetry:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache`
  - PASS. Existing Gradle Kotlin DSL delegated-property deprecation warning remains outside touched source/test code.
- Targeted redaction and stress tests:
  - `SpanSupportTest.Span use should not export raw exception message by default`
  - `SpanCoroutineSupportTest.useSuspending should not export raw exception message by default`
  - `SpanCoroutineSupportTest.useSuspending should keep redaction stable under SuspendedJobTester`
  - `FlowSpanSupportTest.traced upstream exception should not export raw exception message by default`
  - `FlowSpanSupportTest.traced upstream exception should keep redaction stable under SuspendedJobTester`
  - PASS.
- `./gradlew :bluetape4k-opentelemetry:test --rerun-tasks :bluetape4k-opentelemetry:check --no-daemon --no-configuration-cache`
  - PASS, 78 tests, 0 failures, 0 skipped.
- `git diff --check`: PASS.
- CodeGraph `get_affected_flows` against `develop`: 0 affected registered flows for 8 tracked changed source/doc/test files.

## Review Notes

Local review found no P0/P1 findings. Residual risk is intentionally documented: callers that explicitly invoke raw OpenTelemetry `recordException(error)` can still export raw exception messages, and that remains opt-in behavior.

## Metadata

- Issue: #806, milestone `1.11.0`, assignee `debop`
- PR: #920, head `83e43e5c7853910ce9c08551b2d303aa48d309a8`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/opentelemetry-redacted-exception-status`
- Labels: `bug`, `test`, `security`, `infra/io`
- State: `MERGED`, merge commit `d517ca091e0222a87acb87c26f9db03b753b18b4`
- CI: OpenTelemetry helper-managed failure paths now redact exported exception telemetry by default. The helpers still rethrow the original exception, but span status descriptions and helper-created `exception.message` attributes use the bounded sentinel `unspecified error` instead of raw exception messages. / - Documents raw OpenTelemetry `recordException(error)` as an explicit opt-in at allowed trust boundaries. / - Updated `README.md` and `README.ko.md` with default redaction and explicit opt-in guidance.

## DoD Status

| Step | Status | Evidence |
|---|---|---|
| Issue metadata | PASS | #806 is open, milestone `1.11.0`, labels `bug`, `test`, `security`, `infra/io`, assignee `debop`. |
| Fix | PASS | Helper-managed failures now export redacted `exception.message` and status description while preserving original exception propagation. |
| Concurrency helper gate | PASS | `SuspendedJobTester` used for coroutine/Flow redaction stress; `MultithreadingTester` and `StructuredTaskScopeTester` excluded with rationale. |
| Tests | PASS | Targeted redaction/stress tests pass; full `:bluetape4k-opentelemetry:test --rerun-tasks :bluetape4k-opentelemetry:check` passes with 78 tests. |
| Docs | PASS | `infra/opentelemetry/README.md` and `README.ko.md` document default redaction and explicit `recordException` opt-in. |
| Review | PASS | `docs/review/2026-06-27-issue-806-opentelemetry-redaction-review.md`, P0/P1 = 0. |
| Lessons | PASS | `docs/lessons/2026-06-27-issue-806-opentelemetry-redacted-exception-telemetry.md` committed before PR creation. |
| CI | PASS | GitHub Actions: 7 successful, 7 skipped, 0 failing, 0 pending. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #920 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `d517ca091e0222a87acb87c26f9db03b753b18b4`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
