### PR TITLE
fix: bound Redisson GZip decompression output

### DIFF
--- a/docs/lessons/2026-06-27-issue-803-redisson-gzip-decompression-bound.md
+++ b/docs/lessons/2026-06-27-issue-803-redisson-gzip-decompression-bound.md
@@ -1,0 +1,43 @@
+# Lessons Learned - Issue #803 Redisson GZip Decompression Bound (2026-06-27)
+
+## Context
+
+Issue #803 identified that `GzipCodec` decompressed Redis payloads through
+`Compressors.GZip.decompress(bytes)`, and `GZipCompressor` used
+`GZIPInputStream.readBytes()` with no decompressed-size bound.
+
+## Decision
+
+- Put the defensive size limit in `GZipCompressor`, not only in Redisson, so
+  every JDK GZip caller gets the same default protection.
+- Keep the default limit at 256 MiB, matching the existing Snappy/Zstd defensive
+  limits in `bluetape4k-io`.
+- Let `GzipCodec` expose `maxDecompressedSize` so Redis trust boundaries can use
+  a smaller deployment-specific maximum.
+
+## Outcome
+
+- `GZipCompressor` now rejects decompressed output larger than
+  `maxDecompressedSize` before writing the chunk into the output buffer.
+- `GzipCodec` preserves `maxDecompressedSize` through the Redisson copy
+  constructor path.
+- README pairs document the default limit and custom limit examples.
+
+## Verification
+
+- Red test: new tests failed before implementation because `maxDecompressedSize`
+  constructor parameters did not exist.
+- `./gradlew :bluetape4k-io:compileTestKotlin :bluetape4k-redisson:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache`: PASS.
+- `./gradlew :bluetape4k-redisson:test --tests "*Gzip*" :bluetape4k-io:test --tests "*Compressor*" --no-build-cache --no-daemon --no-configuration-cache`: PASS.
+- `./gradlew :bluetape4k-io:test :bluetape4k-redisson:test --no-daemon --no-configuration-cache`: PASS, `io/io` 1005 tests and `infra/redisson` 290 tests with 0 failures/errors/skips.
+- `git diff --check`: PASS.
+
+## Future Guard
+
+- Any compressor that cannot know the decompressed size from a trusted header
+  must copy streams through a bounded loop, not `readBytes()`.
+- For concurrency helper selection: this change adds no shared mutable state,
+  coroutine lifecycle, or structured task scope behavior. `MultithreadingTester`,
+  `SuspendedJobTester`, and `StructuredTaskScopeTester` are not applicable for
+  the new regression tests; existing compressor concurrency coverage remains in
+  `CompressorEdgeCaseTest`.

--- a/docs/review/2026-06-27-issue-803-redisson-gzip-review.md
+++ b/docs/review/2026-06-27-issue-803-redisson-gzip-review.md
@@ -1,0 +1,48 @@
+# Review - Issue #803 Redisson GZip Decompression Bound (2026-06-27)
+
+## Scope
+
+- Issue: #803 `P1: Bound Redisson GZip decompression output`
+- Modules: `:bluetape4k-io`, `:bluetape4k-redisson`
+- Changed runtime paths:
+  - `GZipCompressor.doDecompress`
+  - `GzipCodec.valueDecoder`
+
+## Findings
+
+No P0/P1 findings remain.
+
+## Review Notes
+
+- Security/trust boundary: `GZipCompressor` now enforces a positive
+  `maxDecompressedSize` and checks each decompressed chunk before appending it
+  to the `ByteArrayOutputStream`. This blocks gzip expansion beyond the
+  configured bound.
+- Redisson integration: `GzipCodec` uses the bounded `GZipCompressor` instance
+  and preserves the configured limit through the Redisson `(ClassLoader,
+  GzipCodec)` copy constructor.
+- API compatibility: the original `GZipCompressor(bufferSize)` and
+  `GzipCodec(innerCodec)` call shapes remain valid through default parameters
+  and Java overloads.
+- Documentation: `README.md` and `README.ko.md` pairs document the default
+  256 MiB limit and custom limit examples.
+- Tests/evidence: new tests cover invalid limits, oversized decompression,
+  corrupt gzip payloads, and successful bounded roundtrip.
+- Concurrency helper gate: no new shared mutable state, coroutine lifecycle, or
+  structured concurrency behavior was introduced. `MultithreadingTester`,
+  `SuspendedJobTester`, and `StructuredTaskScopeTester` are not applicable to
+  the new regression tests; existing compressor multithread coverage remains
+  unchanged in `CompressorEdgeCaseTest`.
+
+## Validation Evidence
+
+- Red test before implementation: compile failed on missing
+  `maxDecompressedSize` constructor parameters.
+- Compile: `./gradlew :bluetape4k-io:compileTestKotlin :bluetape4k-redisson:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache` PASS.
+- Targeted tests: `./gradlew :bluetape4k-redisson:test --tests "*Gzip*" :bluetape4k-io:test --tests "*Compressor*" --no-build-cache --no-daemon --no-configuration-cache` PASS.
+- Full affected module tests: `./gradlew :bluetape4k-io:test :bluetape4k-redisson:test --no-daemon --no-configuration-cache` PASS; `io/io` 1005 tests and `infra/redisson` 290 tests with 0 failures/errors/skips.
+- Whitespace: `git diff --check` PASS.
+
+## Gate Verdict
+
+P0/P1 = 0. Proceed to PR after final diff and metadata verification.

--- a/infra/redisson/README.ko.md
+++ b/infra/redisson/README.ko.md
@@ -160,7 +160,14 @@ Codec 클래스:
 - `Fastjson2Codec` — Fastjson2 JSONB 바이너리 포맷. 클래스 이름 헤더 + JSONB 바이트로 저장. `allowedPackagePrefixes`로 pre-instantiation 보안 검증 지원
 - `Lz4Codec` — LZ4 압축 래퍼. `innerCodec`으로 감쌈
 - `ZstdCodec` — Zstd 압축 래퍼
-- `GzipCodec` — GZip 압축 래퍼
+- `GzipCodec` — 압축 해제 크기를 제한하는 GZip 압축 래퍼 (`maxDecompressedSize`, 기본 256 MiB)
+
+```kotlin
+val codec = GzipCodec(
+    innerCodec = RedissonCodecs.Fory,
+    maxDecompressedSize = 64 * 1024 * 1024,
+)
+```
 
 #### Codec 신뢰 프로필
 
@@ -170,6 +177,7 @@ Codec 클래스:
 | Codec 계열 | 기본 프로필 | 공유 경계에서 더 안전한 선택 |
 |---|---|---|
 | `ForyCodec`, `Kryo5Codec`, 압축 변형 | `TrustedInternal` | 하나의 배포 경계가 제어하는 private Redis 데이터에만 사용하거나, 가능한 경우 secure serializer/factory를 선택합니다. |
+| `GzipCodec` 압축 payload | 확장 크기 제한이 있는 `TrustedInternal` | 배포 환경에서 정상 Redis 값의 최대 크기에 맞춰 `maxDecompressedSize`를 조정합니다. |
 | `allowedPackagePrefixes = null`인 `Jackson3Codec` / `Fastjson2Codec` | `TrustedInternal` | `allowedPackagePrefixes`를 지정해 `AllowListedTypes`로 사용합니다. |
 | `Fastjson2Codec(allowedPackagePrefixes = setOf(...))` | `AllowListedTypes` | 저장 DTO 패키지 범위만큼만 좁게 접두사를 유지합니다. |
 

--- a/infra/redisson/README.md
+++ b/infra/redisson/README.md
@@ -161,7 +161,14 @@ Codec classes:
 - `Fastjson2Codec` — Fastjson2 JSONB binary format. Stores class name header + JSONB bytes. Supports `allowedPackagePrefixes` for pre-instantiation security validation.
 - `Lz4Codec` — LZ4 compression wrapper around an `innerCodec`.
 - `ZstdCodec` — Zstd compression wrapper.
-- `GzipCodec` — GZip compression wrapper.
+- `GzipCodec` — GZip compression wrapper with bounded decompression (`maxDecompressedSize`, default 256 MiB).
+
+```kotlin
+val codec = GzipCodec(
+    innerCodec = RedissonCodecs.Fory,
+    maxDecompressedSize = 64 * 1024 * 1024,
+)
+```
 
 #### Codec Trust Profiles
 
@@ -171,6 +178,7 @@ for the shared profile vocabulary.
 | Codec family | Default profile | Safer shared-boundary option |
 |---|---|---|
 | `ForyCodec`, `Kryo5Codec`, and compressed variants | `TrustedInternal` | Use only for private Redis data controlled by one deployment boundary, or choose a secure serializer/factory where available. |
+| `GzipCodec` compressed payloads | `TrustedInternal` with bounded expansion | Tune `maxDecompressedSize` to the largest legitimate Redis value for the deployment. |
 | `Jackson3Codec` / `Fastjson2Codec` with `allowedPackagePrefixes = null` | `TrustedInternal` | Set `allowedPackagePrefixes` for `AllowListedTypes`. |
 | `Fastjson2Codec(allowedPackagePrefixes = setOf(...))` | `AllowListedTypes` | Keep prefixes as narrow as the stored DTO packages allow. |
 

--- a/infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/codec/GzipCodec.kt
+++ b/infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/codec/GzipCodec.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.redis.redisson.codec
 
-import io.bluetape4k.io.compressor.Compressors
+import io.bluetape4k.io.compressor.GZipCompressor
 import io.bluetape4k.logging.KLogging
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.ByteBufUtil
@@ -12,37 +12,43 @@ import org.redisson.client.protocol.Decoder
 import org.redisson.client.protocol.Encoder
 
 /**
- * Gzip 알고리즘으로 값을 압축/복원하는 래퍼 Codec입니다.
+ * Wraps another Redisson [Codec] with GZip compression.
  *
- * ## 동작 방식
- * - 인코딩: [innerCodec]으로 직렬화한 바이트를 Gzip으로 압축하여 Redis에 저장합니다.
- * - 디코딩: Redis에서 읽은 Gzip 압축 데이터를 해제한 후 [innerCodec]으로 역직렬화합니다.
+ * ## Behavior
+ * - Encoding: serializes with [innerCodec], then stores the GZip-compressed bytes in Redis.
+ * - Decoding: decompresses Redis bytes with a [maxDecompressedSize] bound, then delegates to [innerCodec].
  *
- * ## 특징
- * - 압축률이 높아 저장 공간을 효율적으로 절감할 수 있습니다.
- * - 단, Gzip은 압축/해제 속도가 LZ4나 Zstd에 비해 느립니다. 고속 처리가 필요한 경우 [Lz4Codec]이나 [ZstdCodec]을 권장합니다.
+ * GZip provides strong compression but is slower than LZ4 or Zstd. Prefer [Lz4Codec] or [ZstdCodec]
+ * for high-throughput cache paths.
  *
- * ## 사용 예
  * ```kotlin
- * val codec = GzipCodec(RedissonCodecs.Kryo5) // Kryo5 직렬화 + Gzip 압축
+ * val codec = GzipCodec(
+ *     innerCodec = RedissonCodecs.Kryo5,
+ *     maxDecompressedSize = 64 * 1024 * 1024,
+ * )
  * val config = Config()
  * config.codec = codec
  * ```
  *
- * @property innerCodec 직렬화/역직렬화에 사용할 내부 Codec (기본값: [RedissonCodecs.Default])
+ * @property innerCodec delegate codec used for serialization and deserialization.
+ * @property maxDecompressedSize maximum decompressed Redis value size in bytes.
  */
-class GzipCodec(
+class GzipCodec @JvmOverloads constructor(
     private val innerCodec: Codec = RedissonCodecs.Default,
+    val maxDecompressedSize: Int = GZipCompressor.DEFAULT_MAX_DECOMPRESSED_SIZE,
 ): BaseCodec() {
 
     // classLoader를 인자로 받는 보조 생성자는 Redisson에서 환경설정 정보를 바탕으로 동적으로 Codec 생성 시에 필요합니다.
     @Suppress("UNUSED_PARAMETER")
     constructor(classLoader: ClassLoader): this()
-    constructor(classLoader: ClassLoader, codec: GzipCodec): this(copy(classLoader, codec.innerCodec))
+    constructor(classLoader: ClassLoader, codec: GzipCodec): this(
+        innerCodec = copy(classLoader, codec.innerCodec),
+        maxDecompressedSize = codec.maxDecompressedSize,
+    )
 
     companion object: KLogging()
 
-    private val gzip = Compressors.GZip
+    private val gzip = GZipCompressor(maxDecompressedSize = maxDecompressedSize)
 
     private val encoder: Encoder = Encoder { graph ->
         val encoded = innerCodec.valueEncoder.encode(graph)

--- a/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/codec/GzipCodecTest.kt
+++ b/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/codec/GzipCodecTest.kt
@@ -1,0 +1,53 @@
+package io.bluetape4k.redis.redisson.codec
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.io.compressor.Compressors
+import io.netty.buffer.Unpooled
+import org.junit.jupiter.api.Test
+import org.redisson.client.handler.State
+import java.util.zip.ZipException
+
+class GzipCodecTest {
+
+    @Test
+    fun `GzipCodec rejects decompressed output larger than configured limit`() {
+        val compressed = Compressors.GZip.compress(ByteArray(128) { 'A'.code.toByte() })
+        val buf = Unpooled.wrappedBuffer(compressed)
+
+        try {
+            assertFailsWith<IllegalArgumentException> {
+                GzipCodec(RedissonCodecs.String, maxDecompressedSize = 64)
+                    .valueDecoder
+                    .decode(buf, State())
+            }
+        } finally {
+            buf.release()
+        }
+    }
+
+    @Test
+    fun `GzipCodec propagates corrupt gzip payload failures`() {
+        val buf = Unpooled.wrappedBuffer(byteArrayOf(1, 2, 3, 4))
+
+        try {
+            assertFailsWith<ZipException> {
+                GzipCodec(RedissonCodecs.String).valueDecoder.decode(buf, State())
+            }
+        } finally {
+            buf.release()
+        }
+    }
+
+    @Test
+    fun `GzipCodec roundtrips values within configured decompression limit`() {
+        val codec = GzipCodec(RedissonCodecs.String, maxDecompressedSize = 1024)
+        val buf = codec.valueEncoder.encode("bounded gzip")
+
+        try {
+            codec.valueDecoder.decode(buf, State()) shouldBeEqualTo "bounded gzip"
+        } finally {
+            buf.release()
+        }
+    }
+}

--- a/io/io/README.ko.md
+++ b/io/io/README.ko.md
@@ -52,6 +52,10 @@
 - **저장 공간 최적화**: BZip2, Zstd (압축률 > 속도)
 - **파일 아카이브**: Zip (디렉토리 구조 보존)
 
+`Compressors.GZip`은 gzip 확장으로 인한 메모리 과다 사용을 막기 위해
+기본적으로 256 MiB를 초과하는 압축 해제 출력을 거부합니다. 신뢰 경계에 맞는
+다른 한도가 필요하면 `GZipCompressor(maxDecompressedSize = bytes)`를 직접 생성하세요.
+
 ### 2. 직렬화 (BinarySerializer)
 
 객체를 바이너리로 직렬화/역직렬화하는 다양한 구현체를 제공합니다.
@@ -202,6 +206,7 @@ val restored = compressor.decompressOrNull(compressed) // 손상/null/empty 시 
 
 ```kotlin
 import io.bluetape4k.io.compressor.Compressors
+import io.bluetape4k.io.compressor.GZipCompressor
 
 // 기본 사용
 val plainData = "Hello, World!".toByteArray()
@@ -219,6 +224,10 @@ val compressedBuffer = Compressors.Snappy.compress(buffer)
 // InputStream 지원
 val inputStream = File("large-file.txt").inputStream()
 val compressedStream = Compressors.GZip.compress(inputStream)
+
+// 더 작은 신뢰 경계에 맞춘 GZip 압축 해제 한도
+val boundedGzip = GZipCompressor(maxDecompressedSize = 64 * 1024 * 1024)
+val restored = boundedGzip.decompress(compressed)
 ```
 
 **StreamingCompressor (대용량 스트리밍 처리):**

--- a/io/io/README.md
+++ b/io/io/README.md
@@ -52,6 +52,10 @@ A unified interface for multiple compression algorithms.
 - **Storage optimization**: BZip2, Zstd (ratio over speed)
 - **File archives**: Zip (preserves directory structure)
 
+`Compressors.GZip` rejects decompressed output above 256 MiB by default to avoid
+unbounded gzip expansion. Create `GZipCompressor(maxDecompressedSize = bytes)`
+directly when a trusted boundary needs a different limit.
+
 ### 2. Serialization (BinarySerializer)
 
 Multiple implementations for serializing and deserializing objects to/from binary.
@@ -201,6 +205,7 @@ This allows callers to distinguish "corrupt input" (returns `null`) from "empty 
 
 ```kotlin
 import io.bluetape4k.io.compressor.Compressors
+import io.bluetape4k.io.compressor.GZipCompressor
 
 // Basic usage
 val plainData = "Hello, World!".toByteArray()
@@ -218,6 +223,10 @@ val compressedBuffer = Compressors.Snappy.compress(buffer)
 // InputStream support
 val inputStream = File("large-file.txt").inputStream()
 val compressedStream = Compressors.GZip.compress(inputStream)
+
+// Bound GZip decompression for a smaller trust boundary
+val boundedGzip = GZipCompressor(maxDecompressedSize = 64 * 1024 * 1024)
+val restored = boundedGzip.decompress(compressed)
 ```
 
 **StreamingCompressor (for large-scale streaming):**

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/Compressors.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/Compressors.kt
@@ -89,10 +89,11 @@ object Compressors {
     val ApacheGZip: ApacheGZipCompressor by lazy { ApacheGZipCompressor() }
 
     /**
-     * JDK 표준 `GZIPOutputStream` 기반 GZip 압축기입니다.
-     * 표준 gzip 형식과 호환되어 외부 시스템과의 파일 교환에 적합합니다.
+     * GZip compressor backed by the JDK `GZIPOutputStream` / `GZIPInputStream` APIs.
      *
-     * 예제:
+     * Decompression is bounded by [GZipCompressor.DEFAULT_MAX_DECOMPRESSED_SIZE] by default.
+     * Create [GZipCompressor] directly when a smaller or larger trusted-boundary limit is required.
+     *
      * ```kotlin
      * val data = "compress me".toByteArray()
      * val compressed = Compressors.GZip.compress(data)

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/GZipCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/GZipCompressor.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.io.compressor
 
+import io.bluetape4k.support.requirePositiveNumber
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.util.zip.GZIPInputStream
@@ -7,9 +8,11 @@ import java.util.zip.GZIPOutputStream
 import java.util.zip.ZipException
 
 /**
- * JDK GZip 알고리즘을 이용한 압축/복원
+ * Compresses and decompresses byte arrays with the JDK GZip implementation.
  *
- * 팩토리를 통한 사용을 권장합니다:
+ * Decompression is bounded by [maxDecompressedSize] so compressed payloads
+ * cannot expand indefinitely in memory. The default limit is 256 MiB.
+ *
  * ```kotlin
  * val data = "Hello, GZip!".toByteArray()
  * val compressed = Compressors.GZip.compress(data)
@@ -17,21 +20,30 @@ import java.util.zip.ZipException
  * // restored contentEquals data == true
  * ```
  *
+ * @property bufferSize GZip stream buffer size.
+ * @property maxDecompressedSize Maximum decompressed output size in bytes.
  * @see [GZIPOutputStream]
  * @see [GZIPInputStream]
  * @throws java.io.IOException when GZip stream processing fails.
+ * @throws IllegalArgumentException when decompressed output exceeds [maxDecompressedSize].
  * @throws ZipException when the payload is corrupt or not valid GZip data.
  */
-class GZipCompressor(
+class GZipCompressor @JvmOverloads constructor(
     private val bufferSize: Int = DEFAULT_BUFFER_SIZE,
+    val maxDecompressedSize: Int = DEFAULT_MAX_DECOMPRESSED_SIZE,
 ): AbstractCompressor() {
 
+    companion object {
+        const val DEFAULT_MAX_DECOMPRESSED_SIZE: Int = 256 * 1024 * 1024
+    }
+
     init {
-        require(bufferSize > 0) { "bufferSize must be greater than 0." }
+        bufferSize.requirePositiveNumber("bufferSize")
+        maxDecompressedSize.requirePositiveNumber("maxDecompressedSize")
     }
 
     /**
-     * I/O 압축에서 `doCompress` 함수를 제공합니다.
+     * Compresses [plain] bytes with GZip.
      */
     override fun doCompress(plain: ByteArray): ByteArray {
         val output = ByteArrayOutputStream(plain.size)
@@ -43,13 +55,36 @@ class GZipCompressor(
     }
 
     /**
-     * I/O 압축에서 `doDecompress` 함수를 제공합니다.
+     * Decompresses [compressed] bytes and rejects output above [maxDecompressedSize].
      */
     override fun doDecompress(compressed: ByteArray): ByteArray {
         return ByteArrayInputStream(compressed).use { input ->
             GZIPInputStream(input, bufferSize).use { gzip ->
-                gzip.readBytes()
+                gzip.readBoundedBytes()
             }
         }
     }
+
+    private fun GZIPInputStream.readBoundedBytes(): ByteArray {
+        val output = ByteArrayOutputStream(compressedOutputBufferSize())
+        val buffer = ByteArray(bufferSize)
+
+        while (true) {
+            val read = read(buffer)
+            if (read < 0) {
+                return output.toByteArray()
+            }
+            if (read == 0) {
+                continue
+            }
+
+            require(read <= maxDecompressedSize - output.size()) {
+                "GZip decompressed output exceeds maxDecompressedSize=$maxDecompressedSize bytes."
+            }
+            output.write(buffer, 0, read)
+        }
+    }
+
+    private fun compressedOutputBufferSize(): Int =
+        minOf(bufferSize, maxDecompressedSize)
 }

--- a/io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorsTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorsTest.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.io.compressor
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.logging.KLogging
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 
 class CompressorsTest {
     companion object: KLogging()
@@ -94,6 +94,26 @@ class CompressorsTest {
         }
         assertFailsWith<IllegalArgumentException> {
             GZipCompressor(-1)
+        }
+    }
+
+    @Test
+    fun `GZipCompressor 는 0 이하 maxDecompressedSize 를 허용하지 않는다`() {
+        assertFailsWith<IllegalArgumentException> {
+            GZipCompressor(maxDecompressedSize = 0)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            GZipCompressor(maxDecompressedSize = -1)
+        }
+    }
+
+    @Test
+    fun `GZipCompressor 는 maxDecompressedSize 보다 큰 압축 해제 출력을 거부한다`() {
+        val plain = ByteArray(128) { 'A'.code.toByte() }
+        val compressed = GZipCompressor().compress(plain)
+
+        assertFailsWith<IllegalArgumentException> {
+            GZipCompressor(maxDecompressedSize = 64).decompress(compressed)
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #803

- PR 제목: fix: bound Redisson GZip decompression output

### 원문 선행 내용

Fixes #803

## Background

`GzipCodec` decoded Redis bytes through `Compressors.GZip.decompress(bytes)`, and the JDK GZip implementation used `GZIPInputStream.readBytes()` without a decompressed-size limit. A small gzip payload could expand until heap pressure or OOM at a Redis trust boundary.

## What This Solves

This PR adds a bounded GZip decompression path in `bluetape4k-io` and carries the same limit into Redisson `GzipCodec`. The default limit is 256 MiB, and `GzipCodec` callers can tune `maxDecompressedSize` for smaller deployment boundaries.

## Work Done

- Added `GZipCompressor.maxDecompressedSize` with a 256 MiB default and positive validation through bluetape4k validation helpers.
- Replaced unbounded `GZIPInputStream.readBytes()` with a bounded chunk-copy loop that checks the limit before appending bytes to the output buffer.
- Added `GzipCodec.maxDecompressedSize` and preserved it through the Redisson copy-constructor path.
- Added oversized, corrupt-payload, invalid-limit, and bounded-roundtrip tests.
- Updated `io/io` and `infra/redisson` README locale pairs with the limit and configuration examples.
- Added lessons and local review artifacts.

### 기존 섹션: Validation And Review Notes

- Red test before implementation: new tests failed because `maxDecompressedSize` constructor parameters did not exist.
- Compile: `./gradlew :bluetape4k-io:compileTestKotlin :bluetape4k-redisson:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache` passed.
- Targeted suggested verification: `./gradlew :bluetape4k-redisson:test --tests "*Gzip*" :bluetape4k-io:test --tests "*Compressor*" --no-build-cache --no-daemon --no-configuration-cache` passed.
- Full affected module tests: `./gradlew :bluetape4k-io:test :bluetape4k-redisson:test --no-daemon --no-configuration-cache` passed; `io/io` 1005 tests and `infra/redisson` 290 tests, 0 failures/errors/skips.
- Final compile plus GZip/Gzip regression tests passed after import/doc cleanup.
- `git diff --check` passed.
- Local 6-R review: P0/P1 = 0, recorded in `docs/review/2026-06-27-issue-803-redisson-gzip-review.md`.
- Concurrency helper gate: no new shared mutable state, coroutine lifecycle, or structured task scope behavior was introduced. `MultithreadingTester`, `SuspendedJobTester`, and `StructuredTaskScopeTester` are not applicable to the new regression tests; existing compressor multithread coverage remains in `CompressorEdgeCaseTest`.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #803, milestone `1.11.0`, assignee `debop`
- PR: #921, head `7920f90912d5e143a721d5a3725ea7431774df5d`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/redisson-gzip-decompression-bound`
- Labels: `bug`, `test`, `performance`, `security`, `infra/io`
- State: `MERGED`, merge commit `7a1560a1b5875a51206bb85f269487e6c96c9786`
- CI: - Compile: `./gradlew :bluetape4k-io:compileTestKotlin :bluetape4k-redisson:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache` passed. / - Targeted suggested verification: `./gradlew :bluetape4k-redisson:test --tests "*Gzip*" :bluetape4k-io:test --tests "*Compressor*" --no-build-cache --no-daemon --no-configuration-cache` passed. / - Full affected module tests: `./gradlew :bluetape4k-io:test :bluetape4k-redisson:test --no-daemon --no-configuration-cache` passed; `io/io` 1005 tests and `infra/redisson` 290 tests, 0 failures/errors/skips.

## DoD Status

| Step | Status | Evidence |
|---|---|---|
| W - Worktree | PASS | `.worktrees/fix-redisson-gzip-decompression-bound`, branch `fix/redisson-gzip-decompression-bound`. |
| A - Issue analysis | PASS | #803 live body verified; unbounded path identified in `GzipCodec` and `GZipCompressor`. |
| F - Fix | PASS | Commit `7920f9091` bounds GZip decompression and exposes Redisson limit configuration. |
| 4-T - Tests | PASS | Compile, targeted suggested verification, full affected module tests, and final GZip/Gzip regression tests passed. |
| 6-R - Review | PASS | `docs/review/2026-06-27-issue-803-redisson-gzip-review.md`; P0/P1 = 0. |
| README | PASS | `io/io` and `infra/redisson` README locale pairs updated. |
| Lessons | PASS | `docs/lessons/2026-06-27-issue-803-redisson-gzip-decompression-bound.md`. |
| PR metadata | PASS | Live PR metadata verified: assignee `debop`, labels `bug`, `test`, `performance`, `security`, `infra/io`, milestone `1.11.0`. |
| 7-R - Post-PR review | PASS | PR comment https://github.com/bluetape4k/bluetape4k-projects/pull/921#issuecomment-4811335820 and formal review submitted; P0/P1 = 0. |
| CI | PASS | GitHub Actions passed: 9 successful, 5 skipped, 0 failing, 0 pending. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #921 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `7a1560a1b5875a51206bb85f269487e6c96c9786`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
