### PR TITLE
fix: enforce JSON codec allow-list fallback boundaries

### DIFF
--- a/docs/lessons/2026-06-27-issue-802-redisson-json-allowlist-fallback.md
+++ b/docs/lessons/2026-06-27-issue-802-redisson-json-allowlist-fallback.md
@@ -1,0 +1,31 @@
+# Issue 802: Redisson JSON allow-list fallback boundary
+
+## Context
+
+`Jackson3Codec` and `Fastjson2Codec` advertised `allowedPackagePrefixes` as a Redis trust-boundary control, but malformed or non-JSON payloads could still fall through to the Fory fallback decoder. That made the documented allow-list weaker than the public API contract.
+
+## Decision
+
+When `allowedPackagePrefixes` is configured, JSON codec decode fallback is disabled by default. Existing trusted-internal behavior remains unchanged for `allowedPackagePrefixes = null`, and a caller must explicitly set `allowFallbackDecode = true` for a trusted migration window.
+
+## Outcome
+
+- Allow-listed `Jackson3Codec` and `Fastjson2Codec` now reject fallback-format binary payloads with `SecurityException`.
+- `RedissonCodecs.jackson3(...)` and `RedissonCodecs.fastjson2(...)` inherit the safe default.
+- README trust-profile guidance now documents the default rejection and explicit migration escape hatch.
+
+## Verification
+
+- Red test before implementation: allow-listed Jackson3/Fastjson2 binary fallback payload tests failed because no exception was thrown.
+- `./gradlew :bluetape4k-redisson:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache`
+- `./gradlew :bluetape4k-redisson:test --tests "io.bluetape4k.redis.redisson.codec.*CodecTest" --no-build-cache --no-daemon --no-configuration-cache`
+- `./gradlew :bluetape4k-redisson:test --no-daemon --no-configuration-cache`
+- `git diff --check`
+
+## Future Guard
+
+Do not describe a codec factory as `AllowListedTypes` unless all decode fallback paths either validate the same type boundary or are disabled by default. If a legacy migration path is needed, make it explicit in the API and in README trust-profile text.
+
+## Concurrency Helper Gate
+
+`MultithreadingTester`, `SuspendedJobTester`, and `StructuredTaskScopeTester` were not applicable here. The change does not add shared mutable state, coroutine lifecycle behavior, or structured task scope behavior; it only narrows synchronous decode fallback behavior at a Redis codec trust boundary.

--- a/docs/review/2026-06-27-issue-802-redisson-json-allowlist-fallback-review.md
+++ b/docs/review/2026-06-27-issue-802-redisson-json-allowlist-fallback-review.md
@@ -1,0 +1,37 @@
+# Issue 802 Review: Redisson JSON allow-list fallback boundary
+
+## Scope
+
+- `Jackson3Codec`
+- `Fastjson2Codec`
+- `RedissonCodecs` safe factories
+- Redisson codec regression tests
+- Redisson README locale pair
+
+## Findings
+
+No P0/P1 findings.
+
+## Checks
+
+- The default behavior for `allowedPackagePrefixes = null` still permits fallback decode for trusted-internal compatibility.
+- The allow-listed constructor path rejects Fory fallback-format binary payloads by default.
+- The explicit migration path requires `allowFallbackDecode = true`.
+- `RedissonCodecs.jackson3(...)` and `RedissonCodecs.fastjson2(...)` reject fallback binary payloads.
+- README English/Korean trust-profile text describes the safer default and migration exception.
+
+## Verification Evidence
+
+- Red test before implementation failed with `Expected SecurityException but no exception was thrown` for both JSON codecs.
+- `:bluetape4k-redisson:compileTestKotlin --warning-mode all`: passed; only existing Gradle Kotlin DSL deprecation warnings were reported.
+- Suggested codec tests: passed.
+- Full `:bluetape4k-redisson:test`: 295 tests, 0 failures, 0 errors, 0 skipped.
+- `git diff --check`: passed.
+
+## Residual Risk
+
+This patch does not introduce tagged/versioned JSON envelopes. The explicit `allowFallbackDecode = true` migration option remains broad and should only be used for trusted one-time migration reads.
+
+## Concurrency Helper Gate
+
+No multithreading, coroutine, or structured-task helper was added because the behavior is a synchronous decoder trust-boundary check without shared mutable state or async lifecycle changes.

--- a/infra/redisson/README.ko.md
+++ b/infra/redisson/README.ko.md
@@ -149,6 +149,12 @@ val secureCodec = Fastjson2Codec(
     allowedPackagePrefixes = setOf("com.example.", "io.bluetape4k.")
 )
 
+// 신뢰된 일회성 마이그레이션에서만 기존 Fory 바이트 fallback 허용
+val migrationCodec = Jackson3Codec(
+    allowedPackagePrefixes = setOf("com.example."),
+    allowFallbackDecode = true,
+)
+
 // 직접 조합도 가능
 val customCodec = Lz4Codec(innerCodec = ForyCodec())
 ```
@@ -156,8 +162,8 @@ val customCodec = Lz4Codec(innerCodec = ForyCodec())
 Codec 클래스:
 
 - `ForyCodec` — Apache Fory 직렬화. 직렬화 실패 시 fallback Codec(Kryo5)으로 자동 전환
-- `Jackson3Codec` — Jackson 3.x JSON 직렬화. 사람이 읽을 수 있는 JSON 텍스트로 저장
-- `Fastjson2Codec` — Fastjson2 JSONB 바이너리 포맷. 클래스 이름 헤더 + JSONB 바이트로 저장. `allowedPackagePrefixes`로 pre-instantiation 보안 검증 지원
+- `Jackson3Codec` — Jackson 3.x JSON 직렬화. 사람이 읽을 수 있는 JSON 텍스트로 저장하며, `allowedPackagePrefixes`가 있으면 binary fallback decode를 차단
+- `Fastjson2Codec` — Fastjson2 JSONB 바이너리 포맷. 클래스 이름 헤더 + JSONB 바이트로 저장. `allowedPackagePrefixes`로 pre-instantiation 보안 검증을 수행하고 allow-list 사용 시 binary fallback decode를 차단
 - `Lz4Codec` — LZ4 압축 래퍼. `innerCodec`으로 감쌈
 - `ZstdCodec` — Zstd 압축 래퍼
 - `GzipCodec` — 압축 해제 크기를 제한하는 GZip 압축 래퍼 (`maxDecompressedSize`, 기본 256 MiB)
@@ -179,7 +185,7 @@ val codec = GzipCodec(
 | `ForyCodec`, `Kryo5Codec`, 압축 변형 | `TrustedInternal` | 하나의 배포 경계가 제어하는 private Redis 데이터에만 사용하거나, 가능한 경우 secure serializer/factory를 선택합니다. |
 | `GzipCodec` 압축 payload | 확장 크기 제한이 있는 `TrustedInternal` | 배포 환경에서 정상 Redis 값의 최대 크기에 맞춰 `maxDecompressedSize`를 조정합니다. |
 | `allowedPackagePrefixes = null`인 `Jackson3Codec` / `Fastjson2Codec` | `TrustedInternal` | `allowedPackagePrefixes`를 지정해 `AllowListedTypes`로 사용합니다. |
-| `Fastjson2Codec(allowedPackagePrefixes = setOf(...))` | `AllowListedTypes` | 저장 DTO 패키지 범위만큼만 좁게 접두사를 유지합니다. |
+| `allowedPackagePrefixes = setOf(...)`인 `Jackson3Codec` / `Fastjson2Codec` | `AllowListedTypes` | 접두사를 좁게 유지합니다. binary fallback decode는 거부되며, 신뢰된 마이그레이션 구간에서만 `allowFallbackDecode = true`를 명시합니다. |
 
 #### 사용 목적별 팩토리 함수
 

--- a/infra/redisson/README.md
+++ b/infra/redisson/README.md
@@ -150,6 +150,12 @@ val secureCodec = Fastjson2Codec(
     allowedPackagePrefixes = setOf("com.example.", "io.bluetape4k.")
 )
 
+// Trusted one-time migration from legacy Fory bytes into an allow-listed JSON codec
+val migrationCodec = Jackson3Codec(
+    allowedPackagePrefixes = setOf("com.example."),
+    allowFallbackDecode = true,
+)
+
 // You can also compose codecs manually
 val customCodec = Lz4Codec(innerCodec = ForyCodec())
 ```
@@ -157,8 +163,8 @@ val customCodec = Lz4Codec(innerCodec = ForyCodec())
 Codec classes:
 
 - `ForyCodec` — Apache Fory serialization. Automatically falls back to Kryo5 on serialization failure.
-- `Jackson3Codec` — Jackson 3.x JSON serialization. Stores values as human-readable JSON text.
-- `Fastjson2Codec` — Fastjson2 JSONB binary format. Stores class name header + JSONB bytes. Supports `allowedPackagePrefixes` for pre-instantiation security validation.
+- `Jackson3Codec` — Jackson 3.x JSON serialization. Stores values as human-readable JSON text and disables fallback binary decode when `allowedPackagePrefixes` is set.
+- `Fastjson2Codec` — Fastjson2 JSONB binary format. Stores class name header + JSONB bytes. Supports `allowedPackagePrefixes` for pre-instantiation security validation and disables fallback binary decode when the allow-list is set.
 - `Lz4Codec` — LZ4 compression wrapper around an `innerCodec`.
 - `ZstdCodec` — Zstd compression wrapper.
 - `GzipCodec` — GZip compression wrapper with bounded decompression (`maxDecompressedSize`, default 256 MiB).
@@ -180,7 +186,7 @@ for the shared profile vocabulary.
 | `ForyCodec`, `Kryo5Codec`, and compressed variants | `TrustedInternal` | Use only for private Redis data controlled by one deployment boundary, or choose a secure serializer/factory where available. |
 | `GzipCodec` compressed payloads | `TrustedInternal` with bounded expansion | Tune `maxDecompressedSize` to the largest legitimate Redis value for the deployment. |
 | `Jackson3Codec` / `Fastjson2Codec` with `allowedPackagePrefixes = null` | `TrustedInternal` | Set `allowedPackagePrefixes` for `AllowListedTypes`. |
-| `Fastjson2Codec(allowedPackagePrefixes = setOf(...))` | `AllowListedTypes` | Keep prefixes as narrow as the stored DTO packages allow. |
+| `Jackson3Codec` / `Fastjson2Codec` with `allowedPackagePrefixes = setOf(...)` | `AllowListedTypes` | Keep prefixes narrow. Fallback binary decode is rejected unless `allowFallbackDecode = true` is selected for a trusted migration window. |
 
 #### Use-Case Factory Functions
 

--- a/infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/codec/Fastjson2Codec.kt
+++ b/infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/codec/Fastjson2Codec.kt
@@ -13,43 +13,46 @@ import org.redisson.client.protocol.Decoder
 import org.redisson.client.protocol.Encoder
 
 /**
- * Fastjson2 JSONB 포맷으로 직렬화/역직렬화를 수행하는 Redisson [Codec] 구현체입니다.
+ * Redisson [Codec] implementation for Fastjson2 JSONB values.
  *
- * ## 직렬화 포맷
- * 다음 구조의 바이트 배열로 인코딩합니다:
+ * ## Wire format
+ *
+ * Encodes values as:
  * ```
- * [4바이트 big-endian: className 길이] + [className UTF-8 바이트] + [JSONB 바이트]
+ * [4-byte big-endian className length] + [className UTF-8 bytes] + [JSONB bytes]
  * ```
- * 클래스 이름을 헤더에 저장하고, JSONB는 명시적 타입(`JSONB.parseObject(bytes, clazz)`)으로 디코딩합니다.
- * `WriteClassName`/`SupportAutoType`의 TYPED_ANY 제한을 우회하며 모든 중첩 타입을 올바르게 복원합니다.
  *
- * 이 포맷은 [io.bluetape4k.fastjson2.FastjsonSerializer]와 **비호환**입니다. 혼용 시 역직렬화 오류가 발생합니다.
+ * The class name is validated before class loading, then JSONB is decoded with an explicit target type.
+ * This wire format is not compatible with [io.bluetape4k.fastjson2.FastjsonSerializer].
  *
- * ## 역직렬화 보안 (Pre-instantiation 검증)
- * 역직렬화는 헤더에서 읽은 클래스 이름을 [validateClassName]으로 검사한 뒤 클래스를 로드합니다.
- * [allowedPackagePrefixes]에 포함되지 않은 클래스는 로드 전에 [SecurityException]을 던집니다.
+ * ## Trust boundary
  *
- * ## 보안 경고
- * - `allowedPackagePrefixes = null`이면 모든 클래스를 허용합니다 (**신뢰된 내부 Redis 환경에서만 사용**).
- * - 외부에 노출된 Redis 또는 다중 테넌트 환경에서는 [allowedPackagePrefixes]를 반드시 지정하십시오:
+ * - `allowedPackagePrefixes = null` allows all class names and keeps fallback decode enabled.
+ * - Set [allowedPackagePrefixes] for exposed or multi-tenant Redis boundaries.
+ * - When [allowedPackagePrefixes] is set, fallback decode is disabled by default so non-JSONB binary
+ *   payloads cannot bypass the allow-list. Set [allowFallbackDecode] only for trusted migration reads.
+ *
+ * Example:
  *   ```kotlin
  *   val codec = Fastjson2Codec(allowedPackagePrefixes = setOf("com.mycompany.", "io.bluetape4k."))
- *   // 또는 factory 사용:
  *   val codec = RedissonCodecs.fastjson2(setOf("com.mycompany.", "io.bluetape4k."))
  *   ```
  *
- * ## 제한사항
- * - 루트 타입이 `List`, `Map` 등 컬렉션인 경우 원소 타입 정보가 소실됩니다. DTO 래퍼로 감싸서 사용하십시오.
- * - 직렬화/역직렬화 실패 시 [fallbackCodec]으로 자동 전환합니다.
+ * ## Limitations
  *
- * @property fallbackCodec 직렬화/역직렬화 실패 시 사용할 대체 Codec (기본값: [RedissonCodecs.Fory])
- * @property classLoader 역직렬화 시 사용할 [ClassLoader] (Redisson 동적 생성용)
- * @property allowedPackagePrefixes 허용할 패키지 prefix 목록. null이면 모든 클래스 허용 (보안 주의)
+ * Root collection element types are not preserved. Wrap collections in DTOs when element type fidelity
+ * matters.
+ *
+ * @property fallbackCodec fallback codec used for encode failures and trusted decode migrations.
+ * @property classLoader class loader used by Redisson dynamic codec copies.
+ * @property allowedPackagePrefixes package prefixes allowed before class loading, or null for trusted internal use.
+ * @property allowFallbackDecode whether decode can fall back to [fallbackCodec] after JSONB envelope failure.
  */
 class Fastjson2Codec(
     private val fallbackCodec: Codec = RedissonCodecs.Fory,
     private val classLoader: ClassLoader? = null,
     private val allowedPackagePrefixes: Set<String>? = null,
+    private val allowFallbackDecode: Boolean = allowedPackagePrefixes == null,
 ): BaseCodec() {
 
     @Suppress("UNUSED_PARAMETER")
@@ -59,6 +62,7 @@ class Fastjson2Codec(
         copy(classLoader, codec.fallbackCodec),
         classLoader,
         codec.allowedPackagePrefixes,
+        codec.allowFallbackDecode,
     )
 
     companion object: KLogging()
@@ -115,6 +119,13 @@ class Fastjson2Codec(
         } catch (e: SecurityException) {
             throw e
         } catch (e: Exception) {
+            if (!allowFallbackDecode) {
+                throw SecurityException(
+                    "Fastjson2Codec fallback decode is disabled for allow-listed JSONB payloads. " +
+                        "Rejecting non-Fastjson2 binary payload.",
+                    e,
+                )
+            }
             log.info(e) { "Decoding failed for Fastjson2Codec. Using fallbackCodec[$fallbackCodec]" }
             val fallbackBuf = Unpooled.wrappedBuffer(bytes)
             try {
@@ -129,5 +140,9 @@ class Fastjson2Codec(
     override fun getValueDecoder(): Decoder<Any> = decoder
 
     override fun toString(): String =
-        "Fastjson2Codec(fallback=${fallbackCodec.javaClass.simpleName}, allowedPrefixes=$allowedPackagePrefixes)"
+        "Fastjson2Codec(" +
+            "fallback=${fallbackCodec.javaClass.simpleName}, " +
+            "allowedPrefixes=$allowedPackagePrefixes, " +
+            "allowFallbackDecode=$allowFallbackDecode" +
+            ")"
 }

--- a/infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/codec/Jackson3Codec.kt
+++ b/infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/codec/Jackson3Codec.kt
@@ -13,40 +13,46 @@ import org.redisson.client.protocol.Encoder
 import tools.jackson.databind.json.JsonMapper
 
 /**
- * Jackson 3 커스텀 JSON 엔벨로프 방식으로 직렬화/역직렬화를 수행하는 Redisson [Codec] 구현체입니다.
+ * Redisson [Codec] implementation for Jackson 3 JSON envelope values.
  *
- * ## 직렬화 포맷
- * 객체를 `{"_type": "com.example.Foo", "_data": {...}}` 형태의 JSON 엔벨로프로 감싸 저장합니다.
- * `_type` 필드에 FQCN을 기록하여 역직렬화 시 타입 정보를 복원합니다.
+ * ## Wire format
  *
- * ## Jackson 3.x 보안 설계
- * Jackson 3.x에서는 `activateDefaultTyping`이 제거되었습니다. 이 Codec은 자체 엔벨로프 포맷을 사용하여
- * 동일한 다형 타입 지원을 구현하면서, 역직렬화 전에 `validateClassName`으로 클래스 이름을 검사합니다.
- * 이는 pre-materialization 보안 제어에 해당합니다.
+ * Encodes values as a JSON envelope:
+ * ```json
+ * {"_type": "com.example.Foo", "_data": {...}}
+ * ```
+ * The `_type` field stores the FQCN and is validated before class loading.
  *
- * ## 보안 경고
- * - `allowedPackagePrefixes = null`이면 모든 클래스 이름을 허용합니다 (**신뢰된 내부 Redis 환경에서만 사용**).
- * - 외부에 노출된 Redis 또는 다중 테넌트 환경에서는 [allowedPackagePrefixes]를 반드시 지정하십시오:
+ * ## Trust boundary
+ *
+ * - `allowedPackagePrefixes = null` allows all class names and keeps fallback decode enabled.
+ * - Set [allowedPackagePrefixes] for exposed or multi-tenant Redis boundaries.
+ * - When [allowedPackagePrefixes] is set, fallback decode is disabled by default so non-JSON binary
+ *   payloads cannot bypass the allow-list. Set [allowFallbackDecode] only for trusted migration reads.
+ *
+ * Example:
  *   ```kotlin
  *   val codec = Jackson3Codec(allowedPackagePrefixes = setOf("com.mycompany.", "io.bluetape4k."))
- *   // 또는 factory 사용:
  *   val codec = RedissonCodecs.jackson3(setOf("com.mycompany.", "io.bluetape4k."))
  *   ```
  *
- * ## 제한사항
- * - 루트 타입이 `List`, `Map` 등 컬렉션인 경우 원소 타입 정보가 소실됩니다. DTO 래퍼로 감싸서 사용하십시오.
- * - 직렬화 실패 시 [fallbackCodec]으로 자동 전환합니다.
+ * ## Limitations
  *
- * @property mapper Jackson 3 [JsonMapper] 인스턴스 (기본값: [io.bluetape4k.jackson3.Jackson.defaultJsonMapper])
- * @property fallbackCodec 직렬화/역직렬화 실패 시 사용할 대체 Codec (기본값: [RedissonCodecs.Fory])
- * @property classLoader 역직렬화 시 클래스 로드에 사용할 [ClassLoader]
- * @property allowedPackagePrefixes 허용할 패키지 prefix 목록. null이면 모든 클래스 허용 (보안 주의)
+ * Root collection element types are not preserved. Wrap collections in DTOs when element type fidelity
+ * matters.
+ *
+ * @property mapper Jackson 3 mapper.
+ * @property fallbackCodec fallback codec used for encode failures and trusted decode migrations.
+ * @property classLoader class loader used by Redisson dynamic codec copies.
+ * @property allowedPackagePrefixes package prefixes allowed before class loading, or null for trusted internal use.
+ * @property allowFallbackDecode whether decode can fall back to [fallbackCodec] after JSON envelope failure.
  */
 class Jackson3Codec(
     private val mapper: JsonMapper = io.bluetape4k.jackson3.Jackson.defaultJsonMapper,
     private val fallbackCodec: Codec = RedissonCodecs.Fory,
     private val classLoader: ClassLoader? = null,
     private val allowedPackagePrefixes: Set<String>? = null,
+    private val allowFallbackDecode: Boolean = allowedPackagePrefixes == null,
 ): BaseCodec() {
 
     @Suppress("UNUSED_PARAMETER")
@@ -61,6 +67,7 @@ class Jackson3Codec(
         copy(classLoader, codec.fallbackCodec),
         classLoader,
         codec.allowedPackagePrefixes,
+        codec.allowFallbackDecode,
     )
 
     companion object: KLogging() {
@@ -110,6 +117,13 @@ class Jackson3Codec(
         } catch (e: SecurityException) {
             throw e
         } catch (e: Exception) {
+            if (!allowFallbackDecode) {
+                throw SecurityException(
+                    "Jackson3Codec fallback decode is disabled for allow-listed JSON payloads. " +
+                        "Rejecting non-Jackson3 binary payload.",
+                    e,
+                )
+            }
             log.info(e) { "Decoding failed for Jackson3Codec. Using fallbackCodec[$fallbackCodec]" }
             val fallbackBuf = Unpooled.wrappedBuffer(bytes)
             try {
@@ -124,5 +138,9 @@ class Jackson3Codec(
     override fun getValueDecoder(): Decoder<Any> = decoder
 
     override fun toString(): String =
-        "Jackson3Codec(fallback=${fallbackCodec.javaClass.simpleName}, allowedPrefixes=$allowedPackagePrefixes)"
+        "Jackson3Codec(" +
+            "fallback=${fallbackCodec.javaClass.simpleName}, " +
+            "allowedPrefixes=$allowedPackagePrefixes, " +
+            "allowFallbackDecode=$allowFallbackDecode" +
+            ")"
 }

--- a/infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/codec/RedissonCodecs.kt
+++ b/infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/codec/RedissonCodecs.kt
@@ -375,34 +375,38 @@ object RedissonCodecs: KLogging() {
     // -------------------------------------------------------------------------
 
     /**
-     * `allowedPackagePrefixes`를 지정한 안전한 Jackson 3 JSON Codec을 생성합니다.
+     * Creates an allow-listed Jackson 3 JSON codec.
      *
-     * 외부에 노출된 Redis 또는 보안 요구사항이 있는 환경에서 [Jackson3] 싱글턴 대신 사용하십시오.
-     * 지정한 prefix에 속하지 않는 클래스 이름이 역직렬화 요청되면 [SecurityException]이 발생합니다.
+     * Use this factory instead of [Jackson3] for exposed Redis boundaries or multi-tenant data.
+     * Decode rejects class names outside [allowedPackagePrefixes], and fallback binary decode is
+     * disabled so non-JSON payloads cannot bypass the allow-list.
      *
      * ```kotlin
      * val codec = RedissonCodecs.jackson3(setOf("com.mycompany.", "io.bluetape4k."))
      * config.codec = codec
      * ```
      *
-     * @param allowedPackagePrefixes 허용할 패키지 prefix 집합 (예: `setOf("com.mycompany.", "io.bluetape4k.")`)
+     * @param allowedPackagePrefixes allowed package prefixes, for example
+     * `setOf("com.mycompany.", "io.bluetape4k.")`.
      */
     @JvmStatic
     fun jackson3(allowedPackagePrefixes: Set<String>): Codec =
         Jackson3Codec(allowedPackagePrefixes = allowedPackagePrefixes)
 
     /**
-     * `allowedPackagePrefixes`를 지정한 안전한 Fastjson2 JSONB Codec을 생성합니다.
+     * Creates an allow-listed Fastjson2 JSONB codec.
      *
-     * 외부에 노출된 Redis 또는 보안 요구사항이 있는 환경에서 [Fastjson2] 싱글턴 대신 사용하십시오.
-     * 지정한 prefix에 속하지 않는 AutoType 클래스 역직렬화 요청 시 [SecurityException]이 발생합니다.
+     * Use this factory instead of [Fastjson2] for exposed Redis boundaries or multi-tenant data.
+     * Decode rejects class names outside [allowedPackagePrefixes], and fallback binary decode is
+     * disabled so non-JSONB payloads cannot bypass the allow-list.
      *
      * ```kotlin
      * val codec = RedissonCodecs.fastjson2(setOf("com.mycompany.", "io.bluetape4k."))
      * config.codec = codec
      * ```
      *
-     * @param allowedPackagePrefixes 허용할 패키지 prefix 집합 (예: `setOf("com.mycompany.", "io.bluetape4k.")`)
+     * @param allowedPackagePrefixes allowed package prefixes, for example
+     * `setOf("com.mycompany.", "io.bluetape4k.")`.
      */
     @JvmStatic
     fun fastjson2(allowedPackagePrefixes: Set<String>): Codec =

--- a/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/codec/Fastjson2CodecTest.kt
+++ b/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/codec/Fastjson2CodecTest.kt
@@ -3,12 +3,12 @@ package io.bluetape4k.redis.redisson.codec
 import io.bluetape4k.fastjson2.FastjsonSerializer
 import io.bluetape4k.logging.KLogging
 import io.netty.buffer.Unpooled
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeInstanceOf
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 
 @DisplayName("Fastjson2Codec encode/decode & security")
 class Fastjson2CodecTest {
@@ -91,6 +91,59 @@ class Fastjson2CodecTest {
                 // Fory 바이트는 JSONB WriteClassName 포맷이 아니므로 Fastjson2Codec이 fallback으로 전환한다.
                 runCatching { fastjson2Codec.valueDecoder.decode(wrapped, null) }
                     .isSuccess.shouldNotBeNull()
+            } finally {
+                wrapped.release()
+            }
+        } finally {
+            foryEncodedBuf.release()
+        }
+    }
+
+    @Test
+    fun `allowedPackagePrefixes 가 지정된 Fastjson2Codec 은 binary fallback payload 를 거부한다`() {
+        val fallbackCodec = RedissonCodecs.Fory
+        val fastjson2Codec = Fastjson2Codec(
+            fallbackCodec = fallbackCodec,
+            allowedPackagePrefixes = setOf("io.bluetape4k."),
+        )
+
+        val original = Sample(99L, "blocked-fallback", listOf("x", "y"))
+        val foryEncodedBuf = fallbackCodec.valueEncoder.encode(original)
+        try {
+            val foryBytes = ByteArray(foryEncodedBuf.readableBytes())
+            foryEncodedBuf.getBytes(foryEncodedBuf.readerIndex(), foryBytes)
+
+            val wrapped = Unpooled.wrappedBuffer(foryBytes)
+            try {
+                assertFailsWith<SecurityException> {
+                    fastjson2Codec.valueDecoder.decode(wrapped, null)
+                }
+            } finally {
+                wrapped.release()
+            }
+        } finally {
+            foryEncodedBuf.release()
+        }
+    }
+
+    @Test
+    fun `trusted migration mode 의 Fastjson2Codec 은 allowlist 와 함께 binary fallback payload 를 허용한다`() {
+        val fallbackCodec = RedissonCodecs.Fory
+        val fastjson2Codec = Fastjson2Codec(
+            fallbackCodec = fallbackCodec,
+            allowedPackagePrefixes = setOf("io.bluetape4k."),
+            allowFallbackDecode = true,
+        )
+
+        val original = Sample(100L, "migration", listOf("legacy"))
+        val foryEncodedBuf = fallbackCodec.valueEncoder.encode(original)
+        try {
+            val foryBytes = ByteArray(foryEncodedBuf.readableBytes())
+            foryEncodedBuf.getBytes(foryEncodedBuf.readerIndex(), foryBytes)
+
+            val wrapped = Unpooled.wrappedBuffer(foryBytes)
+            try {
+                fastjson2Codec.valueDecoder.decode(wrapped, null) shouldBeEqualTo original
             } finally {
                 wrapped.release()
             }

--- a/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/codec/Jackson3CodecTest.kt
+++ b/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/codec/Jackson3CodecTest.kt
@@ -2,11 +2,11 @@ package io.bluetape4k.redis.redisson.codec
 
 import io.bluetape4k.logging.KLogging
 import io.netty.buffer.Unpooled
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 
 @DisplayName("Jackson3Codec encode/decode & security")
 class Jackson3CodecTest {
@@ -90,6 +90,59 @@ class Jackson3CodecTest {
                 // fallback(Fory)이 원본을 복원하거나 실패해도 프로세스 예외가 전파되지 않아야 한다.
                 runCatching { jackson3Codec.valueDecoder.decode(wrapped, null) }
                     .isSuccess.shouldNotBeNull()
+            } finally {
+                wrapped.release()
+            }
+        } finally {
+            foryEncodedBuf.release()
+        }
+    }
+
+    @Test
+    fun `allowedPackagePrefixes 가 지정된 Jackson3Codec 은 binary fallback payload 를 거부한다`() {
+        val fallbackCodec = RedissonCodecs.Fory
+        val jackson3Codec = Jackson3Codec(
+            fallbackCodec = fallbackCodec,
+            allowedPackagePrefixes = setOf("io.bluetape4k."),
+        )
+
+        val original = Sample(99L, "blocked-fallback", listOf("x", "y"))
+        val foryEncodedBuf = fallbackCodec.valueEncoder.encode(original)
+        try {
+            val foryBytes = ByteArray(foryEncodedBuf.readableBytes())
+            foryEncodedBuf.getBytes(foryEncodedBuf.readerIndex(), foryBytes)
+
+            val wrapped = Unpooled.wrappedBuffer(foryBytes)
+            try {
+                assertFailsWith<SecurityException> {
+                    jackson3Codec.valueDecoder.decode(wrapped, null)
+                }
+            } finally {
+                wrapped.release()
+            }
+        } finally {
+            foryEncodedBuf.release()
+        }
+    }
+
+    @Test
+    fun `trusted migration mode 의 Jackson3Codec 은 allowlist 와 함께 binary fallback payload 를 허용한다`() {
+        val fallbackCodec = RedissonCodecs.Fory
+        val jackson3Codec = Jackson3Codec(
+            fallbackCodec = fallbackCodec,
+            allowedPackagePrefixes = setOf("io.bluetape4k."),
+            allowFallbackDecode = true,
+        )
+
+        val original = Sample(100L, "migration", listOf("legacy"))
+        val foryEncodedBuf = fallbackCodec.valueEncoder.encode(original)
+        try {
+            val foryBytes = ByteArray(foryEncodedBuf.readableBytes())
+            foryEncodedBuf.getBytes(foryEncodedBuf.readerIndex(), foryBytes)
+
+            val wrapped = Unpooled.wrappedBuffer(foryBytes)
+            try {
+                jackson3Codec.valueDecoder.decode(wrapped, null) shouldBeEqualTo original
             } finally {
                 wrapped.release()
             }

--- a/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/codec/RedissonCodecsTest.kt
+++ b/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/codec/RedissonCodecsTest.kt
@@ -1,11 +1,14 @@
 package io.bluetape4k.redis.redisson.codec
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.junit5.faker.Fakers
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.redis.redisson.AbstractRedissonTest
 import io.bluetape4k.redis.redisson.RedissonTestUtils.faker
-import io.bluetape4k.assertions.shouldBeEqualTo
+import io.netty.buffer.Unpooled
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.redisson.client.codec.Codec
@@ -105,6 +108,33 @@ class RedissonCodecsTest: AbstractRedissonTest() {
     fun `codec for kotlin data class with fallback codec`(codec: Codec) {
         repeat(REPEAT_SIZE) {
             codec.verifyCodec(newCustomData())
+        }
+    }
+
+    @Test
+    fun `allow-listed JSON factories reject fallback binary payloads`() {
+        val origin = newCustomData()
+        val fallbackBuf = RedissonCodecs.Fory.valueEncoder.encode(origin)
+        val fallbackBytes = try {
+            ByteArray(fallbackBuf.readableBytes()).also {
+                fallbackBuf.getBytes(fallbackBuf.readerIndex(), it)
+            }
+        } finally {
+            fallbackBuf.release()
+        }
+
+        listOf(
+            RedissonCodecs.jackson3(setOf("io.bluetape4k.")),
+            RedissonCodecs.fastjson2(setOf("io.bluetape4k.")),
+        ).forEach { codec ->
+            val buf = Unpooled.wrappedBuffer(fallbackBytes)
+            try {
+                assertFailsWith<SecurityException> {
+                    codec.valueDecoder.decode(buf, State())
+                }
+            } finally {
+                buf.release()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #802

- PR 제목: fix: enforce JSON codec allow-list fallback boundaries

### 원문 선행 내용

Fixes #802

## Background

`Jackson3Codec` and `Fastjson2Codec` exposed allow-listed type loading through `allowedPackagePrefixes`, but malformed or non-JSON payloads could still fall back to Fory binary decode. That let Redis payloads bypass the documented allow-listed JSON trust boundary.

## What This Solves

This PR disables fallback binary decode by default whenever `allowedPackagePrefixes` is configured. Trusted-internal compatibility remains unchanged for `allowedPackagePrefixes = null`, and one-time trusted migrations can explicitly opt in with `allowFallbackDecode = true`.

## Work Done

- Added `allowFallbackDecode` to `Jackson3Codec` and `Fastjson2Codec`, defaulting to fallback only when no allow-list is configured.
- Preserved Redisson dynamic copy-constructor behavior for the fallback decode setting.
- Updated `RedissonCodecs.jackson3(...)` and `RedissonCodecs.fastjson2(...)` KDoc to state that factory-created allow-listed codecs reject fallback binary payloads.
- Added regression tests for allow-listed binary fallback rejection, explicit trusted migration fallback, and factory-path rejection.
- Updated `infra/redisson` README English/Korean trust-profile guidance.
- Added lessons and local review artifacts.

### 기존 섹션: Validation And Review Notes

- Red test before implementation: allow-listed Jackson3/Fastjson2 fallback payload tests failed with `Expected SecurityException but no exception was thrown`.
- Compile: `./gradlew :bluetape4k-redisson:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache` passed; only existing Gradle Kotlin DSL deprecation warnings were reported.
- Suggested codec tests: `./gradlew :bluetape4k-redisson:test --tests "io.bluetape4k.redis.redisson.codec.*CodecTest" --no-build-cache --no-daemon --no-configuration-cache` passed.
- Full affected module tests: `./gradlew :bluetape4k-redisson:test --no-daemon --no-configuration-cache` passed; 295 tests, 0 failures, 0 errors, 0 skipped.
- `git diff --check` passed.
- Local 6-R review: P0/P1 = 0, recorded in `docs/review/2026-06-27-issue-802-redisson-json-allowlist-fallback-review.md`.
- Concurrency helper gate: no shared mutable state, coroutine lifecycle, or structured task scope behavior was introduced. `MultithreadingTester`, `SuspendedJobTester`, and `StructuredTaskScopeTester` are not applicable to this synchronous codec trust-boundary fix.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #802, milestone `1.11.0`, assignee `debop`
- PR: #922, head `528bea2d33fa107341d8e6c7e840b5abea9bdae2`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/redisson-json-allowlist-fallback`
- Labels: `bug`, `test`, `security`, `infra/io`, `jackson3`
- State: `MERGED`, merge commit `0d98c039fe3a7ac551244e0e2304c8266760de79`
- CI: This PR disables fallback binary decode by default whenever `allowedPackagePrefixes` is configured. Trusted-internal compatibility remains unchanged for `allowedPackagePrefixes = null`, and one-time trusted migrations can explicitly opt in with `allowFallbackDecode = true`. / - Added regression tests for allow-listed binary fallback rejection, explicit trusted migration fallback, and factory-path rejection. / - Compile: `./gradlew :bluetape4k-redisson:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache` passed; only existing Gradle Kotlin DSL deprecation warnings were reported.

## DoD Status

| Step | Status | Evidence |
|---|---|---|
| W - Worktree | PASS | `.worktrees/fix-redisson-json-allowlist-fallback`, branch `fix/redisson-json-allowlist-fallback`. |
| A - Issue analysis | PASS | #802 live body verified; unsafe fallback path identified in Jackson3/Fastjson2 decode. |
| T - Red test | PASS | New allow-listed fallback payload tests failed before implementation. |
| F - Fix | PASS | Commit `528bea2d3` disables fallback binary decode by default for allow-listed JSON codecs and keeps explicit migration mode. |
| 4-T - Tests | PASS | Compile, suggested codec tests, full `:bluetape4k-redisson:test`, and `git diff --check` passed. |
| README | PASS | `infra/redisson` README locale pair updated with trust-profile and migration guidance. |
| Lessons | PASS | `docs/lessons/2026-06-27-issue-802-redisson-json-allowlist-fallback.md`. |
| 6-R - Review | PASS | `docs/review/2026-06-27-issue-802-redisson-json-allowlist-fallback-review.md`; P0/P1 = 0. |
| PR metadata | PASS | Live PR metadata verified: assignee `debop`, labels `bug`, `test`, `security`, `infra/io`, `jackson3`, milestone `1.11.0`. |
| 7-R - Post-PR review | PASS | PR comment https://github.com/bluetape4k/bluetape4k-projects/pull/922#issuecomment-4811521619 and formal review submitted; P0/P1 = 0. |
| CI | PASS | GitHub Actions passed: 8 successful, 6 skipped, 0 failing, 0 pending. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #922 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `0d98c039fe3a7ac551244e0e2304c8266760de79`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
