### PR TITLE
fix: expose Cassandra mapper runtime dependency

### DIFF
--- a/data/cassandra/README.ko.md
+++ b/data/cassandra/README.ko.md
@@ -11,6 +11,7 @@
 - **Row/Gettable/Settable 확장**: 타입 안전한 값 조회/설정
 - **QueryBuilder 확장**: CQL 빌더 작성 편의 함수
 - **Statement 지원**: SimpleStatement, BoundStatement, BatchStatement 생성 DSL
+- **Mapper 헬퍼**: DataStax mapper `EntityHelper` 기반 PreparedStatement 생성과 entity binding 확장
 - **Admin 유틸**: Keyspace 생성/삭제, 버전 확인 등 관리 작업 지원
 
 ## 아키텍처 다이어그램
@@ -34,6 +35,10 @@ dependencies {
     implementation("io.github.bluetape4k:bluetape4k-cassandra:${bluetape4kVersion}")
 }
 ```
+
+이 단일 artifact에는 `io.bluetape4k.cassandra.mapper` API가 필요로 하는
+DataStax mapper runtime이 포함됩니다. Mapper helper 확장을 사용할 때
+소비자 프로젝트에서 `java-driver-mapper-runtime`을 별도로 선언할 필요가 없습니다.
 
 ## 주요 기능
 
@@ -262,7 +267,29 @@ val delete = deleteFrom("users")
     .build()
 ```
 
-### 7. Cassandra 관리 (Admin)
+### 7. DataStax Mapper 헬퍼
+
+```kotlin
+import io.bluetape4k.cassandra.mapper.*
+
+val insert = userEntityHelper.prepareInsert(session)
+val insertIfAbsent = userEntityHelper.prepareInsertIfNotExists(session)
+
+val bound = userEntityHelper.bind(
+    preparedStatement = insert,
+    entity = user,
+)
+
+val selected = session.prepare(userEntityHelper) {
+    select().all().from(keyspaceId, tableId).asCql()
+}
+```
+
+Mapper helper API는 DataStax `EntityHelper`와 `NullSavingStrategy` 타입을
+공개 시그니처에 직접 노출하므로, `bluetape4k-cassandra`는 mapper runtime을
+public dependency contract로 제공합니다.
+
+### 8. Cassandra 관리 (Admin)
 
 ```kotlin
 import io.bluetape4k.cassandra.CassandraAdmin
@@ -282,7 +309,7 @@ val version = CassandraAdmin.getReleaseVersion(session)
 println("Cassandra version: $version")
 ```
 
-### 8. 문자열 처리 유틸리티
+### 9. 문자열 처리 유틸리티
 
 ```kotlin
 import io.bluetape4k.cassandra.*
@@ -301,7 +328,7 @@ val isDoubleQuoted = """"test"""".isDoubleQuoted()  // true
 val needsQuotes = "test column".needsDoubleQuotes()  // true
 ```
 
-### 9. CqlIdentifier 지원
+### 10. CqlIdentifier 지원
 
 ```kotlin
 import io.bluetape4k.cassandra.CqlIdentifierSupport
@@ -314,7 +341,7 @@ val id2 = CqlIdentifier.fromCql("my_column")
 val idWithSpace = "my column".toCqlIdentifier()  // "my column"
 ```
 
-### 10. 비동기 ResultSet 처리
+### 11. 비동기 ResultSet 처리
 
 ```kotlin
 import io.bluetape4k.cassandra.cql.*

--- a/data/cassandra/README.md
+++ b/data/cassandra/README.md
@@ -11,6 +11,7 @@ A Kotlin extension library that makes it easier to use the [Apache Cassandra](ht
 - **Row/Gettable/Settable Extensions**: Type-safe value access and mutation
 - **QueryBuilder Extensions**: Convenience functions for building CQL queries
 - **Statement Support**: DSL for creating SimpleStatement, BoundStatement, and BatchStatement
+- **Mapper Helpers**: DataStax mapper `EntityHelper` extensions for prepared statements and entity binding
 - **Admin Utilities**: Keyspace creation/deletion, version checks, and other administrative tasks
 
 ## Architecture Diagrams
@@ -34,6 +35,10 @@ dependencies {
     implementation("io.github.bluetape4k:bluetape4k-cassandra:${bluetape4kVersion}")
 }
 ```
+
+This single artifact includes the DataStax mapper runtime required by
+`io.bluetape4k.cassandra.mapper` APIs. Consumers do not need to declare
+`java-driver-mapper-runtime` separately when using the mapper helper extensions.
 
 ## Core Features
 
@@ -262,7 +267,29 @@ val delete = deleteFrom("users")
     .build()
 ```
 
-### 7. Cassandra Administration
+### 7. DataStax Mapper Helpers
+
+```kotlin
+import io.bluetape4k.cassandra.mapper.*
+
+val insert = userEntityHelper.prepareInsert(session)
+val insertIfAbsent = userEntityHelper.prepareInsertIfNotExists(session)
+
+val bound = userEntityHelper.bind(
+    preparedStatement = insert,
+    entity = user,
+)
+
+val selected = session.prepare(userEntityHelper) {
+    select().all().from(keyspaceId, tableId).asCql()
+}
+```
+
+The mapper helper APIs expose DataStax `EntityHelper` and `NullSavingStrategy`
+types directly, so `bluetape4k-cassandra` exports the mapper runtime as part of
+its public dependency contract.
+
+### 8. Cassandra Administration
 
 ```kotlin
 import io.bluetape4k.cassandra.CassandraAdmin
@@ -282,7 +309,7 @@ val version = CassandraAdmin.getReleaseVersion(session)
 println("Cassandra version: $version")
 ```
 
-### 8. String Utilities
+### 9. String Utilities
 
 ```kotlin
 import io.bluetape4k.cassandra.*
@@ -301,7 +328,7 @@ val isDoubleQuoted = """"test"""".isDoubleQuoted()  // true
 val needsQuotes = "test column".needsDoubleQuotes()  // true
 ```
 
-### 9. CqlIdentifier Support
+### 10. CqlIdentifier Support
 
 ```kotlin
 import io.bluetape4k.cassandra.CqlIdentifierSupport
@@ -314,7 +341,7 @@ val id2 = CqlIdentifier.fromCql("my_column")
 val idWithSpace = "my column".toCqlIdentifier()  // "my column"
 ```
 
-### 10. Asynchronous ResultSet Processing
+### 11. Asynchronous ResultSet Processing
 
 ```kotlin
 import io.bluetape4k.cassandra.cql.*

--- a/data/cassandra/build.gradle.kts
+++ b/data/cassandra/build.gradle.kts
@@ -21,6 +21,24 @@ configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
 }
 
+val consumerRuntimeTest = sourceSets.create("consumerRuntimeTest") {
+    compileClasspath += sourceSets.main.get().output + configurations.runtimeClasspath.get()
+    runtimeClasspath += output + compileClasspath
+}
+
+tasks.register<Test>("consumerRuntimeTest") {
+    description = "Runs Cassandra mapper API smoke tests with the published runtime classpath."
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+
+    testClassesDirs = consumerRuntimeTest.output.classesDirs
+    classpath = consumerRuntimeTest.runtimeClasspath
+    useJUnitPlatform()
+}
+
+tasks.named("check") {
+    dependsOn("consumerRuntimeTest")
+}
+
 dependencies {
     api(project(":bluetape4k-io"))
     api(project(":bluetape4k-coroutines"))
@@ -31,7 +49,7 @@ dependencies {
     // NOTE: Cassandra 4 oss 버전을 사용합니다.
     api(libs.cassandra.java.driver.core)
     api(libs.cassandra.java.driver.query.builder)
-    compileOnly(libs.cassandra.java.driver.mapper.runtime)
+    api(libs.cassandra.java.driver.mapper.runtime)
     compileOnly(libs.cassandra.java.driver.metrics.micrometer)
     testImplementation(libs.cassandra.java.driver.test.infra)
 
@@ -43,4 +61,6 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.reactor)
     testImplementation(libs.kotlinx.coroutines.test)
+
+    add("consumerRuntimeTestImplementation", project(":bluetape4k-junit5"))
 }

--- a/data/cassandra/src/consumerRuntimeTest/kotlin/io/bluetape4k/cassandra/mapper/CassandraMapperConsumerRuntimeClasspathTest.kt
+++ b/data/cassandra/src/consumerRuntimeTest/kotlin/io/bluetape4k/cassandra/mapper/CassandraMapperConsumerRuntimeClasspathTest.kt
@@ -1,0 +1,36 @@
+package io.bluetape4k.cassandra.mapper
+
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.cql.PreparedStatement
+import com.datastax.oss.driver.api.mapper.entity.EntityHelper
+import com.datastax.oss.driver.api.mapper.entity.saving.NullSavingStrategy
+import org.junit.jupiter.api.Test
+
+class CassandraMapperConsumerRuntimeClasspathTest {
+
+    class ConsumerEntity(val id: Int)
+
+    @Test
+    fun `mapper helper APIs compile from consumer runtime classpath`() {
+        // The source-set classpath intentionally excludes module compileOnly dependencies.
+    }
+
+    @Suppress("unused")
+    private fun assertMapperApiCompiles(
+        session: CqlSession,
+        entityHelper: EntityHelper<ConsumerEntity>,
+        preparedStatement: PreparedStatement,
+        entity: ConsumerEntity,
+    ) {
+        entityHelper.prepareInsert(session)
+        entityHelper.prepareInsertIfNotExists(session)
+        entityHelper.bind(
+            preparedStatement = preparedStatement,
+            entity = entity,
+            nullSavingStrategy = NullSavingStrategy.DO_NOT_SET,
+        )
+        session.prepare(entityHelper) {
+            insert().asCql()
+        }
+    }
+}

--- a/data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/mapper/EntitySupport.kt
+++ b/data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/mapper/EntitySupport.kt
@@ -8,7 +8,7 @@ import com.datastax.oss.driver.api.mapper.entity.EntityHelper
 import com.datastax.oss.driver.api.mapper.entity.saving.NullSavingStrategy
 
 /**
- * [EntityHelper] 를 이용하여 Insert 용 [PreparedStatement] 를 빌드합니다.
+ * Builds an insert [PreparedStatement] from this DataStax [EntityHelper].
  *
  * ```
  * val session: CqlSession = ...
@@ -16,15 +16,15 @@ import com.datastax.oss.driver.api.mapper.entity.saving.NullSavingStrategy
  * val preparedStatement: PreparedStatement = entityHelper.prepareInsert(session)
  * ```
  *
- * @param session [CqlSession] 세션
- * @return [PreparedStatement] 인스턴스
+ * @param session Cassandra [CqlSession] used to prepare the generated CQL.
+ * @return Prepared insert statement for the entity table.
  */
 fun <T: Any> EntityHelper<T>.prepareInsert(session: CqlSession): PreparedStatement {
     return session.prepare(insert().asCql())
 }
 
 /**
- * [EntityHelper] 를 이용하여 신규 Insert 용 [PreparedStatement] 를 빌드합니다.
+ * Builds an insert-if-not-exists [PreparedStatement] from this DataStax [EntityHelper].
  *
  * ```
  * val session: CqlSession = ...
@@ -32,15 +32,15 @@ fun <T: Any> EntityHelper<T>.prepareInsert(session: CqlSession): PreparedStateme
  * val preparedStatement: PreparedStatement = entityHelper.prepareInsertIfNotExists(session)
  * ```
  *
- * @param session [CqlSession] 세션
- * @return [PreparedStatement] 인스턴스
+ * @param session Cassandra [CqlSession] used to prepare the generated CQL.
+ * @return Prepared conditional insert statement for the entity table.
  */
 fun <T: Any> EntityHelper<T>.prepareInsertIfNotExists(session: CqlSession): PreparedStatement {
     return session.prepare(insert().ifNotExists().asCql())
 }
 
 /**
- * [preparedStatement]에 변수를 바인딩합니다.
+ * Creates a [BoundStatement] by applying [builder] to [preparedStatement].
  *
  * ```
  * val preparedStatement: PreparedStatement = ...
@@ -51,8 +51,9 @@ fun <T: Any> EntityHelper<T>.prepareInsertIfNotExists(session: CqlSession): Prep
  * }
  * ```
  *
- * @param preparedStatement [PreparedStatement] 인스턴스
- * @param builder [BoundStatementBuilder] 초기화 람다
+ * @param preparedStatement Prepared statement to bind.
+ * @param builder Bound statement builder customizer.
+ * @return Bound statement produced by the customized builder.
  */
 inline fun <T: Any> bindEntity(
     preparedStatement: PreparedStatement,
@@ -64,7 +65,7 @@ inline fun <T: Any> bindEntity(
 }
 
 /**
- * [EntityHelper] 를 이용하여 [PreparedStatement] 를 빌드하고, [BoundStatement] 를 생성합니다.
+ * Binds [entity] to [preparedStatement] through this DataStax [EntityHelper].
  *
  * ```
  * val session: CqlSession = ...
@@ -74,11 +75,11 @@ inline fun <T: Any> bindEntity(
  * val boundStatement: BoundStatement = entityHelper.bind(preparedStatement, user)
  * ```
  *
- * @param preparedStatement [PreparedStatement] 인스턴스
- * @param entity [T] 엔티티 인스턴스
- * @param nullSavingStrategy [NullSavingStrategy] Null 저장 전략 (기본값: [NullSavingStrategy.DO_NOT_SET])
- * @param lenient [Boolean] 느슨한 바인딩 여부 (기본값: `true`)
- * @return [BoundStatement] 인스턴스
+ * @param preparedStatement Prepared statement to bind.
+ * @param entity Entity instance used as the binding source.
+ * @param nullSavingStrategy Strategy used when entity properties are null.
+ * @param lenient Whether missing columns should be tolerated by the mapper.
+ * @return Bound statement containing values extracted from [entity].
  */
 fun <T: Any> EntityHelper<T>.bind(
     preparedStatement: PreparedStatement,
@@ -94,7 +95,7 @@ fun <T: Any> EntityHelper<T>.bind(
 }
 
 /**
- * [entityHelper]를 이용하여 [PreparedStatement]를 빌드합니다.
+ * Prepares CQL generated from [entityHelper].
  *
  * ```
  * val session: CqlSession = ...
@@ -108,9 +109,9 @@ fun <T: Any> EntityHelper<T>.bind(
  * }
  * ```
  *
- * @param entityHelper [EntityHelper] 인스턴스
- * @param builder [EntityHelper] 를 이용하여 CQL을 생성하는 람다
- * @return [PreparedStatement] 인스턴스
+ * @param entityHelper DataStax mapper helper used to build CQL.
+ * @param builder Lambda that creates CQL from [entityHelper].
+ * @return Prepared statement for the generated CQL.
  */
 inline fun <T: Any> CqlSession.prepare(
     entityHelper: EntityHelper<T>,

--- a/docs/lessons/2026-06-27-issue-811-cassandra-mapper-runtime-dependency.md
+++ b/docs/lessons/2026-06-27-issue-811-cassandra-mapper-runtime-dependency.md
@@ -1,0 +1,53 @@
+# Issue #811: Cassandra Mapper Runtime Dependency
+
+## Context
+
+`bluetape4k-cassandra` exposes DataStax mapper runtime types in public mapper
+extension signatures:
+
+- `EntityHelper<T>` receiver and parameters
+- `NullSavingStrategy` parameter default
+
+The module declared `java-driver-mapper-runtime` as `compileOnly`, while the
+regular test classpath extended `compileOnly`. That made module tests pass even
+though consumers using only the documented `bluetape4k-cassandra` dependency
+could not compile mapper helper APIs.
+
+## Decision
+
+Treat mapper helpers as part of the `bluetape4k-cassandra` public API contract:
+
+- Promote `libs.cassandra.java.driver.mapper.runtime` from `compileOnly` to
+  `api`.
+- Add a `consumerRuntimeTest` source set whose compile/runtime classpath uses
+  `main.output + runtimeClasspath`, not the regular test classpath.
+- Document that the single `bluetape4k-cassandra` artifact includes the mapper
+  runtime required by `io.bluetape4k.cassandra.mapper`.
+
+## Verification
+
+- RED: `./gradlew :bluetape4k-cassandra:compileConsumerRuntimeTestKotlin --no-build-cache --no-daemon --no-configuration-cache`
+  failed with unresolved `com.datastax.oss.driver.api.mapper.*` and
+  `Cannot access class 'EntityHelper'`.
+- GREEN: the same compile task passed after promoting mapper runtime to `api`.
+- `./gradlew :bluetape4k-cassandra:dependencies --configuration runtimeClasspath --no-daemon --no-configuration-cache`
+  showed `org.apache.cassandra:java-driver-mapper-runtime:4.19.2`.
+- `./gradlew :bluetape4k-cassandra:compileKotlin :bluetape4k-cassandra:compileTestKotlin :bluetape4k-cassandra:compileConsumerRuntimeTestKotlin --warning-mode all --no-daemon --no-configuration-cache`
+  passed.
+- `./gradlew :bluetape4k-cassandra:test :bluetape4k-cassandra:consumerRuntimeTest --no-build-cache --no-daemon --no-configuration-cache`
+  passed with 178 module tests and 1 consumer runtime test.
+- `git diff --check` passed.
+
+## Future Guidance
+
+When a bluetape4k module exposes third-party types in public signatures, the
+dependency must be exported (`api`) or the API must move behind an optional
+artifact. Regular tests that inherit `compileOnly` are not sufficient evidence;
+add a consumer-style source set for compile/runtime contracts.
+
+## Concurrency Helper Gate
+
+No shared mutable state, coroutine lifecycle, structured concurrency, or virtual
+thread behavior changed. `MultithreadingTester`, `SuspendedJobTester`, and
+`StructuredTaskScopeTester` are not applicable to this dependency metadata and
+consumer compile-contract fix.

--- a/docs/review/2026-06-27-issue-811-cassandra-mapper-runtime-dependency-review.md
+++ b/docs/review/2026-06-27-issue-811-cassandra-mapper-runtime-dependency-review.md
@@ -1,0 +1,50 @@
+# Review: Issue #811 Cassandra Mapper Runtime Dependency
+
+## Scope
+
+- `data/cassandra/build.gradle.kts`
+- `data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/mapper/EntitySupport.kt`
+- `data/cassandra/src/consumerRuntimeTest/kotlin/io/bluetape4k/cassandra/mapper/CassandraMapperConsumerRuntimeClasspathTest.kt`
+- `data/cassandra/README.md`
+- `data/cassandra/README.ko.md`
+
+## Findings
+
+P0/P1: none.
+
+## Review Notes
+
+- The issue is reproduced at the consumer classpath boundary. The new
+  `consumerRuntimeTest` source set excludes module `compileOnly` dependencies,
+  so it catches missing published dependency metadata.
+- Promoting `java-driver-mapper-runtime` to `api` matches the public extension
+  signatures because `EntityHelper` and `NullSavingStrategy` are directly
+  exposed.
+- README and Korean README now describe the selected single-artifact dependency
+  contract.
+- Public KDoc touched in `EntitySupport.kt` is now English.
+- CodeGraph impact lookup returned `0 nodes` for the worktree diff, so this
+  review used direct source, diff, dependency, and Gradle verification evidence.
+
+## Verification Evidence
+
+- RED: `:bluetape4k-cassandra:compileConsumerRuntimeTestKotlin` failed before
+  the dependency fix with unresolved `mapper` imports and missing
+  `EntityHelper` classpath.
+- GREEN: `:bluetape4k-cassandra:compileConsumerRuntimeTestKotlin` passed.
+- Runtime metadata: `runtimeClasspath` includes
+  `org.apache.cassandra:java-driver-mapper-runtime:4.19.2`.
+- Compile: `:bluetape4k-cassandra:compileKotlin`,
+  `:bluetape4k-cassandra:compileTestKotlin`, and
+  `:bluetape4k-cassandra:compileConsumerRuntimeTestKotlin` passed with
+  `--warning-mode all`; remaining warnings are existing repo Gradle Kotlin DSL
+  deprecations outside the new source-set declaration.
+- Tests: `:bluetape4k-cassandra:test` passed with 178 tests, 0 failures,
+  0 errors, 0 skipped; `:bluetape4k-cassandra:consumerRuntimeTest` passed with
+  1 test, 0 failures, 0 errors, 0 skipped.
+- `git diff --check` passed.
+
+## Concurrency Helper Gate
+
+Not applicable. The change does not modify thread safety, coroutine
+cancellation, structured task scope behavior, or virtual-thread execution.


### PR DESCRIPTION
## Summary

Closes #811

- PR 제목: fix: expose Cassandra mapper runtime dependency

### 원문 선행 내용

Fixes #811

## Background

`bluetape4k-cassandra` exposes DataStax mapper runtime types in public mapper helper APIs, but `java-driver-mapper-runtime` was declared as `compileOnly`. Regular module tests inherited `compileOnly`, so the missing consumer classpath contract was not visible.

## What This Solves

This PR makes the published dependency metadata match the public API surface. Consumers that follow the documented single `bluetape4k-cassandra` dependency can compile and use `io.bluetape4k.cassandra.mapper` helpers without declaring DataStax mapper runtime separately.

## Work Done

- Promoted `libs.cassandra.java.driver.mapper.runtime` from `compileOnly` to `api`.
- Added `consumerRuntimeTest`, whose classpath uses `main.output + runtimeClasspath` instead of the regular test classpath.
- Added a consumer compile fixture for `EntityHelper`, `NullSavingStrategy`, and the mapper helper extensions.
- Updated `README.md` and `README.ko.md` with the mapper runtime dependency contract.
- Rewrote touched public KDoc in `EntitySupport.kt` in English.
- Added lessons and local review artifacts.

### 기존 섹션: Validation And Review Notes

- Red test before implementation: `./gradlew :bluetape4k-cassandra:compileConsumerRuntimeTestKotlin --no-build-cache --no-daemon --no-configuration-cache` failed with unresolved `com.datastax.oss.driver.api.mapper.*` imports and missing `EntityHelper` classpath.
- Green consumer compile: the same task passed after promoting mapper runtime to `api`.
- Runtime metadata: `./gradlew :bluetape4k-cassandra:dependencies --configuration runtimeClasspath --no-daemon --no-configuration-cache` includes `org.apache.cassandra:java-driver-mapper-runtime:4.19.2`.
- Compile: `./gradlew :bluetape4k-cassandra:compileKotlin :bluetape4k-cassandra:compileTestKotlin :bluetape4k-cassandra:compileConsumerRuntimeTestKotlin --warning-mode all --no-daemon --no-configuration-cache` passed. Remaining warnings are existing repo Gradle Kotlin DSL deprecations outside the new source-set declaration.
- Tests: `./gradlew :bluetape4k-cassandra:test :bluetape4k-cassandra:consumerRuntimeTest --no-build-cache --no-daemon --no-configuration-cache` passed; 178 module tests and 1 consumer runtime test, 0 failures/errors/skipped.
- `git diff --check` passed.
- Local 6-R review: P0/P1 = 0, recorded in `docs/review/2026-06-27-issue-811-cassandra-mapper-runtime-dependency-review.md`.
- Concurrency helper gate: no shared mutable state, coroutine lifecycle, structured task scope, or virtual-thread behavior changed. `MultithreadingTester`, `SuspendedJobTester`, and `StructuredTaskScopeTester` are not applicable to this dependency metadata and consumer compile-contract fix.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #811, milestone `1.11.0`, assignee `debop`
- PR: #923, head `a9b3e5c1d769a4089b667e4768e71e3691e30f34`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/cassandra-mapper-runtime-dependency`
- Labels: `bug`, `dependencies`
- State: `MERGED`, merge commit `6f695d63ba2e29728e1def40fe6e3ec39ff25e19`
- CI: - Red test before implementation: `./gradlew :bluetape4k-cassandra:compileConsumerRuntimeTestKotlin --no-build-cache --no-daemon --no-configuration-cache` failed with unresolved `com.datastax.oss.driver.api.mapper.*` imports and missing `EntityHelper` classpath. / - Runtime metadata: `./gradlew :bluetape4k-cassandra:dependencies --configuration runtimeClasspath --no-daemon --no-configuration-cache` includes `org.apache.cassandra:java-driver-mapper-runtime:4.19.2`. / - Compile: `./gradlew :bluetape4k-cassandra:compileKotlin :bluetape4k-cassandra:compileTestKotlin :bluetape4k-cassandra:compileConsumerRuntimeTestKotlin --warning-mode all --no-daemon --no-configuration-cache` passed. Remaining warnings are existing repo Gradle Kotlin DSL deprecations outside the new source-set declaration.

## DoD Status

| Step | Status | Evidence |
|---|---|---|
| W - Worktree | PASS | `.worktrees/fix-cassandra-mapper-runtime-dependency`, branch `fix/cassandra-mapper-runtime-dependency`. |
| A - Issue analysis | PASS | #811 live body verified; mapper public API exposes `EntityHelper` and `NullSavingStrategy` while mapper runtime was `compileOnly`. |
| T - Red test | PASS | Consumer source-set compile failed before the fix with unresolved mapper imports and missing `EntityHelper` classpath. |
| F - Fix | PASS | Commit `a9b3e5c1d` promotes mapper runtime to `api`, adds consumer runtime fixture, and updates docs/KDoc. |
| 4-T - Tests | PASS | Consumer compile, runtimeClasspath dependency report, compile lanes, default test, consumerRuntimeTest, and `git diff --check` passed. |
| README | PASS | `data/cassandra` README locale pair documents the mapper runtime single-artifact contract. |
| Lessons | PASS | `docs/lessons/2026-06-27-issue-811-cassandra-mapper-runtime-dependency.md`. |
| 6-R - Review | PASS | `docs/review/2026-06-27-issue-811-cassandra-mapper-runtime-dependency-review.md`; P0/P1 = 0. |
| PR metadata | PASS | Live PR metadata verified: assignee `debop`, labels `bug`, `dependencies`, milestone `1.11.0`. |
| 7-R - Post-PR review | PASS | PR comment https://github.com/bluetape4k/bluetape4k-projects/pull/923#issuecomment-4811694246 and formal review submitted; P0/P1 = 0. |
| CI | PASS | GitHub Actions passed: 8 successful, 6 skipped, 0 failing, 0 pending. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #923 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `6f695d63ba2e29728e1def40fe6e3ec39ff25e19`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
