### PR TITLE
fix: redact Kafka Logback producer config status

### DIFF
--- a/docs/lessons/2026-06-27-issue-799-kafka-logback-producer-config-redaction.md
+++ b/docs/lessons/2026-06-27-issue-799-kafka-logback-producer-config-redaction.md
@@ -1,0 +1,52 @@
+# Issue #799: Kafka Logback Producer Config Redaction
+
+## Context
+
+`bluetape4k-kafka-logback` accepted arbitrary Kafka producer configuration and
+emitted Logback status messages for added config entries, malformed config
+strings, and producer creation failures. Raw status messages can be collected by
+operations tooling, so values from keys such as `sasl.jaas.config` and
+`*.password` must be treated as sensitive even when they are not ordinary
+application logs.
+
+## Decision
+
+Route all Kafka producer config status formatting through one internal helper:
+
+- redact credential-bearing values by sensitive key fragments;
+- keep non-sensitive keys and values visible for diagnostics;
+- report malformed `key=value` input by payload length only;
+- reuse the same formatter for add-config, producer creation success, and
+  producer creation failure status messages.
+
+## Verification
+
+- RED: new `KafkaAppenderTest` redaction tests failed before the fix because
+  added producer config and malformed config status messages contained raw
+  secret values.
+- GREEN: `./gradlew :bluetape4k-kafka-logback:test --tests "io.bluetape4k.kafka.logback.KafkaAppenderTest" --no-build-cache --no-daemon --no-configuration-cache`
+  passed with 11 tests.
+- `./gradlew :bluetape4k-kafka-logback:test --tests "*KafkaAppender*" --no-build-cache --no-daemon --no-configuration-cache`
+  passed with 12 tests, including the Testcontainers-backed `KafkaAppenderIT`.
+- `./gradlew :bluetape4k-kafka-logback:test --no-build-cache --no-daemon --no-configuration-cache`
+  passed with 22 tests, 0 failures, 0 errors, 0 skipped.
+- `./gradlew :bluetape4k-kafka-logback:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache`
+  passed. Remaining warnings are existing Gradle Kotlin DSL deprecations outside
+  the touched source/test code.
+- Source scan found no remaining raw `$producerConfig`, `$keyValue`, or
+  `value=$value` status formatting in `infra/kafka-logback`.
+- `git diff --check` passed.
+
+## Future Guidance
+
+Status output is still an operational export surface. When logging dynamic
+configuration or parse failures, redact by key before formatting and avoid
+echoing the original malformed payload. Tests should assert both the absence of
+secret substrings and the presence of useful non-sensitive diagnostics.
+
+## Concurrency Helper Gate
+
+No shared mutable state, coroutine lifecycle, thread contention, virtual-thread,
+or `StructuredTaskScope` behavior changed. `MultithreadingTester`,
+`SuspendedJobTester`, and `StructuredTaskScopeTester` are not applicable to this
+status-formatting redaction fix.

--- a/docs/review/2026-06-27-issue-799-kafka-logback-producer-config-redaction-review.md
+++ b/docs/review/2026-06-27-issue-799-kafka-logback-producer-config-redaction-review.md
@@ -1,0 +1,50 @@
+# Local Review - Issue #799 Kafka Logback Producer Config Redaction
+
+Date: 2026-06-27
+Scope: `infra/kafka-logback`
+Issue: #799
+
+## Verdict
+
+No P0/P1 findings found in the current diff.
+
+## Reviewed Risks
+
+- Security/trust boundary: producer config values are redacted before Logback
+  status output on add-config, malformed config, producer creation success, and
+  producer creation failure paths.
+- Diagnostic quality: non-sensitive entries such as `client.id` remain visible,
+  while malformed input reports payload length without echoing the original
+  payload.
+- Compatibility: public appender APIs and Kafka producer construction semantics
+  are unchanged; only status-message formatting and stricter malformed string
+  parsing changed.
+- Test helper gate: concurrency helpers are intentionally not used because this
+  diff does not add shared state, coroutine behavior, virtual threads, or
+  structured task scope behavior.
+
+## Validation Evidence
+
+- TDD red: `KafkaAppenderTest` redaction tests failed before the fix because
+  status messages contained `kafka-jaas-secret`, `truststore-secret`, and raw
+  malformed payload text.
+- `./gradlew :bluetape4k-kafka-logback:test --tests "io.bluetape4k.kafka.logback.KafkaAppenderTest" --no-build-cache --no-daemon --no-configuration-cache`:
+  PASS, 11 tests.
+- `./gradlew :bluetape4k-kafka-logback:test --tests "*KafkaAppender*" --no-build-cache --no-daemon --no-configuration-cache`:
+  PASS, 12 tests including `KafkaAppenderIT`.
+- `./gradlew :bluetape4k-kafka-logback:test --no-build-cache --no-daemon --no-configuration-cache`:
+  PASS, 22 tests, 0 failures, 0 errors, 0 skipped.
+- `./gradlew :bluetape4k-kafka-logback:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache`:
+  PASS. Remaining warnings are existing Gradle Kotlin DSL deprecations outside
+  touched source/test code.
+- `rg -n '\$producerConfig|\$keyValue|value=\$value|Add producer config|Fail to add producer config value|Create Kafka Producer|Fail to create Kafka Producer|KafkaProducerConfigDiagnostics' infra/kafka-logback/src/main/kotlin infra/kafka-logback/src/test/kotlin`:
+  PASS; remaining status messages route through `KafkaProducerConfigDiagnostics`.
+- CodeGraph review context against `develop`: low risk, 0 impacted nodes for
+  the changed files.
+- `git diff --check`: PASS.
+
+## Residual Risk
+
+Sensitive key detection is intentionally conservative and based on lowercased
+key fragments. Future Kafka config keys that carry secrets should be added to
+`KafkaProducerConfigDiagnostics` with matching redaction tests.

--- a/infra/kafka-logback/src/main/kotlin/io/bluetape4k/kafka/logback/AbstractKafkaAppender.kt
+++ b/infra/kafka-logback/src/main/kotlin/io/bluetape4k/kafka/logback/AbstractKafkaAppender.kt
@@ -61,7 +61,7 @@ abstract class AbstractKafkaAppender<E: Any>: UnsynchronizedAppenderBase<E>(), A
      */
     open fun addProducerConfigValue(key: String, value: Any?) {
         producerConfig[key] = value
-        addInfo("Add producer config: key=$key, value=$value")
+        addInfo("Add producer config: ${KafkaProducerConfigDiagnostics.formatEntry(key, value)}")
     }
 
     /**
@@ -72,12 +72,21 @@ abstract class AbstractKafkaAppender<E: Any>: UnsynchronizedAppenderBase<E>(), A
      */
     open fun addProducerConfigValue(keyValue: String) {
         runCatching {
-            val (key, value) = keyValue.split("=", limit = 2)
-            addProducerConfigValue(key, value).apply {
-                addInfo("Add producer config: key=$key, value=$value")
+            val separatorIndex = keyValue.indexOf("=")
+            require(separatorIndex > 0) {
+                "Producer config value must use key=value format."
             }
+            val key = keyValue.substring(0, separatorIndex)
+            require(key.isNotBlank() && key.none { it.isWhitespace() }) {
+                "Producer config key must be non-blank and contain no whitespace."
+            }
+            val value = keyValue.substring(separatorIndex + 1)
+            addProducerConfigValue(key, value)
         }.onFailure {
-            addError("Fail to add producer config value: $keyValue", it)
+            addError(
+                "Fail to add producer config value: ${KafkaProducerConfigDiagnostics.formatMalformedPayload(keyValue)}",
+                it
+            )
         }
     }
 

--- a/infra/kafka-logback/src/main/kotlin/io/bluetape4k/kafka/logback/KafkaAppender.kt
+++ b/infra/kafka-logback/src/main/kotlin/io/bluetape4k/kafka/logback/KafkaAppender.kt
@@ -142,10 +142,17 @@ class KafkaAppender<E: Any>: io.bluetape4k.kafka.logback.AbstractKafkaAppender<E
 
         return try {
             return KafkaProducer(producerConfig, ByteArraySerializer(), ByteArraySerializer()).apply {
-                addInfo("Create Kafka Producer for Logging with config: $producerConfig")
+                addInfo(
+                    "Create Kafka Producer for Logging with config: " +
+                        KafkaProducerConfigDiagnostics.formatConfig(producerConfig)
+                )
             }
         } catch (e: Exception) {
-            addError("Fail to create Kafka Producer for Logging with config: $producerConfig", e)
+            addError(
+                "Fail to create Kafka Producer for Logging with config: " +
+                    KafkaProducerConfigDiagnostics.formatConfig(producerConfig),
+                e
+            )
             null
         }
     }

--- a/infra/kafka-logback/src/main/kotlin/io/bluetape4k/kafka/logback/KafkaProducerConfigDiagnostics.kt
+++ b/infra/kafka-logback/src/main/kotlin/io/bluetape4k/kafka/logback/KafkaProducerConfigDiagnostics.kt
@@ -1,0 +1,50 @@
+package io.bluetape4k.kafka.logback
+
+/**
+ * Formats Kafka producer configuration for Logback status output without
+ * exposing credential-bearing values.
+ */
+internal object KafkaProducerConfigDiagnostics {
+
+    private const val REDACTED = "[REDACTED]"
+
+    private val sensitiveKeyFragments = listOf(
+        "password",
+        "secret",
+        "token",
+        "credential",
+        "sasl.jaas.config",
+        "keytab",
+        "private.key",
+        "access.key",
+        "secret.key",
+        "ssl.key",
+        "oauthbearer",
+        "basic.auth.user.info",
+    )
+
+    fun formatEntry(key: String, value: Any?): String =
+        "key=$key, value=${redactValue(key, value)}"
+
+    fun formatConfig(config: Map<String, Any?>): String =
+        config.toSortedMap()
+            .entries
+            .joinToString(prefix = "{", postfix = "}") { (key, value) ->
+                "$key=${redactValue(key, value)}"
+            }
+
+    fun formatMalformedPayload(keyValue: String): String =
+        "payloadLength=${keyValue.length}"
+
+    private fun redactValue(key: String, value: Any?): String =
+        if (isSensitiveKey(key)) {
+            REDACTED
+        } else {
+            value.toString()
+        }
+
+    private fun isSensitiveKey(key: String): Boolean {
+        val normalized = key.lowercase()
+        return sensitiveKeyFragments.any { fragment -> normalized.contains(fragment) }
+    }
+}

--- a/infra/kafka-logback/src/test/kotlin/io/bluetape4k/kafka/logback/KafkaAppenderTest.kt
+++ b/infra/kafka-logback/src/test/kotlin/io/bluetape4k/kafka/logback/KafkaAppenderTest.kt
@@ -9,7 +9,9 @@ import ch.qos.logback.core.encoder.Encoder
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.assertions.shouldNotContain
 import io.bluetape4k.kafka.logback.exporter.KafkaExporter
 import io.bluetape4k.kafka.logback.keyprovider.KafkaKeyProvider
 import io.bluetape4k.logging.coroutines.KLoggingChannel
@@ -86,7 +88,7 @@ class KafkaAppenderTest {
         statusList.forEach {
             log.debug { "status=$it" }
         }
-        statusList shouldHaveSize 2
+        statusList.any { it.message == "Kafka Producer closed." }.shouldBeTrue()
 
         confirmVerified(encoder, keyProvider, exporter)
     }
@@ -116,6 +118,59 @@ class KafkaAppenderTest {
         appender.isStarted.shouldBeFalse()
         ctx.statusManager.copyOfStatusList shouldHaveSize 1
         ctx.statusManager.copyOfStatusList.first().message shouldBeEqualTo "encoder is not set"
+    }
+
+    @Test
+    fun `producer config status messages redact sensitive values`() {
+        val jaasSecret = "kafka-jaas-secret"
+        val truststoreSecret = "truststore-secret"
+
+        appender.addProducerConfigValue(
+            "sasl.jaas.config",
+            "org.apache.kafka.common.security.plain.PlainLoginModule required password=\"$jaasSecret\";"
+        )
+        appender.addProducerConfigValue("ssl.truststore.password", truststoreSecret)
+        appender.addProducerConfigValue("client.id", "visible-client-id")
+
+        val statusMessages = statusMessages()
+
+        statusMessages shouldNotContain jaasSecret
+        statusMessages shouldNotContain truststoreSecret
+        statusMessages shouldContain "key=sasl.jaas.config, value=[REDACTED]"
+        statusMessages shouldContain "key=ssl.truststore.password, value=[REDACTED]"
+        statusMessages shouldContain "key=client.id, value=visible-client-id"
+    }
+
+    @Test
+    fun `malformed producer config status message does not expose raw payload`() {
+        val secret = "malformed-secret"
+
+        appender.addProducerConfigValue("sasl.jaas.config password=$secret")
+
+        val statusMessages = statusMessages()
+
+        statusMessages shouldNotContain secret
+        statusMessages shouldNotContain "sasl.jaas.config password=$secret"
+        statusMessages shouldContain "Fail to add producer config value"
+        statusMessages shouldContain "payloadLength="
+    }
+
+    @Test
+    fun `producer creation failure status message redacts sensitive config values`() {
+        val secret = "creation-secret"
+
+        appender.acks = "invalid-acks"
+        appender.addProducerConfigValue("sasl.jaas.config", "password=\"$secret\"")
+        appender.addProducerConfigValue("client.id", "visible-client-id")
+
+        appender.createProducer()
+
+        val statusMessages = statusMessages()
+
+        statusMessages shouldNotContain secret
+        statusMessages shouldContain "Fail to create Kafka Producer for Logging with config:"
+        statusMessages shouldContain "sasl.jaas.config=[REDACTED]"
+        statusMessages shouldContain "client.id=visible-client-id"
     }
 
     @Test
@@ -181,4 +236,7 @@ class KafkaAppenderTest {
         verify { exporter.export(any<Producer<ByteArray, ByteArray>>(), any(), kafkaClientEvent, any()) }
         verify { exporter.export(any<Producer<ByteArray, ByteArray>>(), any(), sampleEvent, any()) }
     }
+
+    private fun statusMessages(): String =
+        ctx.statusManager.copyOfStatusList.joinToString(separator = "\n") { it.message }
 }


### PR DESCRIPTION
## Summary

Closes #799

- PR 제목: fix: redact Kafka Logback producer config status

### 원문 선행 내용

Fixes #799

## Background

Kafka Logback producer configuration is user-provided operational data, and
Logback status events can be collected outside normal application logs. Before
this change, `AbstractKafkaAppender` and `KafkaAppender` could include raw
producer config values in add-config, malformed-config, and producer creation
status messages.

## What This Solves

- Redacts credential-bearing Kafka producer config values before status output.
- Keeps non-sensitive diagnostics such as `client.id` visible.
- Avoids echoing malformed `key=value` payloads that may contain secrets.
- Adds regression tests for add-config, malformed-config, and producer creation
  failure status messages.

## Work Done

- Added `KafkaProducerConfigDiagnostics` as the single formatter for producer
  config status output.
- Updated `AbstractKafkaAppender.addProducerConfigValue(...)` to format added
  config entries through the redaction helper and to report malformed payload
  length instead of raw input.
- Updated `KafkaAppender.createProducer()` success and failure diagnostics to
  use redacted full-config formatting.
- Added focused regression tests in `KafkaAppenderTest`.
- Added lesson and local review artifacts under `docs/`.

## Validation

- TDD RED: redaction tests failed before the fix because status messages
  contained `kafka-jaas-secret`, `truststore-secret`, and malformed secret text.
- `./gradlew :bluetape4k-kafka-logback:test --tests "io.bluetape4k.kafka.logback.KafkaAppenderTest" --no-build-cache --no-daemon --no-configuration-cache`: PASS, 11 tests.
- `./gradlew :bluetape4k-kafka-logback:test --tests "*KafkaAppender*" --no-build-cache --no-daemon --no-configuration-cache`: PASS, 12 tests including `KafkaAppenderIT`.
- `./gradlew :bluetape4k-kafka-logback:test --no-build-cache --no-daemon --no-configuration-cache`: PASS, 22 tests, 0 failures, 0 errors, 0 skipped.
- `./gradlew :bluetape4k-kafka-logback:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache`: PASS. Remaining warnings are existing Gradle Kotlin DSL deprecations outside touched source/test code.
- Source scan: remaining producer-config status messages route through `KafkaProducerConfigDiagnostics`; no raw `$producerConfig`, `$keyValue`, or `value=$value` formatting remains in `infra/kafka-logback`.
- `git diff --check`: PASS.

## Review Notes

- Local review artifact: `docs/review/2026-06-27-issue-799-kafka-logback-producer-config-redaction-review.md`
- P0/P1: 0.
- CodeGraph review context against `develop`: low risk, 0 impacted nodes.
- Concurrency helper gate: not applicable. This change only formats Logback
  status output and does not change shared-state, coroutine, virtual-thread, or
  structured-task-scope behavior.

## Metadata

- Issue: #799, milestone `1.11.0`, assignee `debop`
- PR: #924, head `23ef52ef3113873bd7caa11759e0dbe4f1694547`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/kafka-logback-redact-producer-config`
- Labels: `bug`, `security`, `infra/io`
- State: `MERGED`, merge commit `be019d4934a36f428ae2af0f9f22bfe27e28593b`
- CI: - `./gradlew :bluetape4k-kafka-logback:test --tests "io.bluetape4k.kafka.logback.KafkaAppenderTest" --no-build-cache --no-daemon --no-configuration-cache`: PASS, 11 tests. / - `./gradlew :bluetape4k-kafka-logback:test --tests "*KafkaAppender*" --no-build-cache --no-daemon --no-configuration-cache`: PASS, 12 tests including `KafkaAppenderIT`. / - `./gradlew :bluetape4k-kafka-logback:test --no-build-cache --no-daemon --no-configuration-cache`: PASS, 22 tests, 0 failures, 0 errors, 0 skipped.

## DoD Status

| Step | Status | Evidence |
|------|--------|----------|
| W - Worktree | PASS | `fix/kafka-logback-redact-producer-config`, clean before push |
| A - Issue analysis | PASS | Issue #799 metadata: milestone `1.11.0`, labels `bug`, `security`, `infra/io`, assignee `debop` |
| F - Fix | PASS | `KafkaProducerConfigDiagnostics`; appender status formatting routed through redaction helper |
| 4-T - Tests | PASS | `KafkaAppenderTest` 11 passing; `*KafkaAppender*` 12 passing; module test 22 passing |
| 6-R - Review | PASS | Local review artifact, CodeGraph low risk/0 impacted nodes, P0/P1=0 |
| README check | N/A | No public API or README-facing usage behavior changed |
| 7 - Lessons | PASS | `docs/lessons/2026-06-27-issue-799-kafka-logback-producer-config-redaction.md` |
| 7-P - PR metadata | PASS | PR #924 live metadata verified: milestone `1.11.0`, assignee `debop`, labels `bug`, `security`, `infra/io` |
| 7-R - Post-PR review | PASS | PR comment `4812659322` and formal review `4582074881`; P0/P1=0 |
| 8 - CI gate | PASS | PR checks PASS: Build, Coverage Report, Secret Scan, Validate Gradle Wrapper, CI Status, submit-gradle; module-test jobs skipped by path filter |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #924 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `be019d4934a36f428ae2af0f9f22bfe27e28593b`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
