### PR TITLE
fix: make Protobuf codecs strict by default

### DIFF
--- a/docs/lessons/2026-06-27-issue-798-protobuf-strict-default-codecs.md
+++ b/docs/lessons/2026-06-27-issue-798-protobuf-strict-default-codecs.md
@@ -1,0 +1,37 @@
+# Issue 798: Protobuf strict default codecs
+
+## Context
+
+`ProtobufSerializer` and Redis Protobuf codecs were documented as allow-listed Protobuf codecs, but their default behavior still delegated non-Protobuf values and non-Protobuf bytes to Kryo/Kryo5 fallback serializers. That made the advertised shared-boundary trust profile too broad.
+
+## Decision
+
+Make the default Protobuf profile strict. Non-Protobuf payloads are rejected unless the caller chooses an explicit trusted-internal API:
+
+- `ProtobufSerializer.trustedInternalProtobuf()`
+- `LettuceProtobufCodecs.trustedInternal*Protobuf()`
+- `RedissonProtobufCodec.trustedInternal()`
+- `RedissonProtobufCodecs.TrustedInternal*Protobuf`
+
+## Outcome
+
+- Default Protobuf serializer and Redis codecs reject fallback-format payloads.
+- Legacy mixed Protobuf + Kryo fallback remains available for trusted internal Redis stores.
+- Tests now separate strict shared-boundary behavior from trusted-internal compatibility behavior.
+- `docs/security/serialization-trust-profiles.md` documents the distinction.
+
+## Verification
+
+- Red test before implementation: new trusted-internal API references failed compilation.
+- `./gradlew :bluetape4k-protobuf:compileTestKotlin --warning-mode all --rerun-tasks --no-daemon --no-configuration-cache`
+- `./gradlew :bluetape4k-protobuf:test --tests "io.bluetape4k.protobuf.serializers.ProtobufSerializerTest" --tests "io.bluetape4k.protobuf.serializers.redis.LettuceProtobufCodecsTest" --tests "io.bluetape4k.protobuf.serializers.redis.RedissonProtobufCodecTest" --rerun-tasks --no-daemon --no-configuration-cache`
+- `./gradlew :bluetape4k-protobuf:test --no-daemon --no-configuration-cache`: 209 tests, 0 failures, 0 errors, 0 skipped.
+- `git diff --check`
+
+## Future Guard
+
+Do not label a codec as `AllowListedTypes` if default decode paths silently fall back to a serializer that can load arbitrary application object graphs. Keep legacy fallback paths explicit and name them as trusted-internal APIs.
+
+## Concurrency Helper Gate
+
+`MultithreadingTester`, `SuspendedJobTester`, and `StructuredTaskScopeTester` were not applicable. This is a synchronous encode/decode trust-boundary change with no concurrent state, coroutine lifecycle, or structured task-scope behavior.

--- a/docs/review/2026-06-27-issue-798-protobuf-strict-default-codecs-review.md
+++ b/docs/review/2026-06-27-issue-798-protobuf-strict-default-codecs-review.md
@@ -1,0 +1,40 @@
+# Issue 798 Review: Protobuf strict default codecs
+
+## Scope
+
+- `ProtobufSerializer`
+- Lettuce Protobuf codec factories
+- Redisson Protobuf codec constructors and registry factories
+- Protobuf Redis codec regression tests
+- Serialization trust-profile documentation
+
+## Findings
+
+No P0/P1 findings.
+
+## Checks
+
+- `ProtobufSerializer()` rejects non-Protobuf values and fallback-format bytes by default.
+- `ProtobufSerializer.trustedInternalProtobuf()` preserves legacy Kryo fallback compatibility.
+- `LettuceProtobufCodecs.*Protobuf()` factories are strict by default.
+- `LettuceProtobufCodecs.trustedInternal*Protobuf()` factories preserve trusted-internal fallback compatibility.
+- `RedissonProtobufCodec()` and `RedissonProtobufCodecs.*Protobuf` values are strict by default.
+- `RedissonProtobufCodec.trustedInternal()` and `RedissonProtobufCodecs.TrustedInternal*Protobuf` values preserve trusted-internal fallback compatibility.
+- Trust-profile documentation distinguishes strict shared-boundary Protobuf codecs from trusted-internal fallback codecs.
+
+## Verification Evidence
+
+- Red test before implementation failed in `:bluetape4k-protobuf:compileTestKotlin` because the new trusted-internal APIs did not exist.
+- `:bluetape4k-protobuf:compileTestKotlin --warning-mode all --rerun-tasks`: passed; remaining warnings are existing Gradle Kotlin DSL deprecations outside the touched Protobuf source/test code.
+- Targeted Protobuf serializer, Lettuce codec, and Redisson codec tests with `--rerun-tasks`: passed.
+- Full `:bluetape4k-protobuf:test`: 209 tests, 0 failures, 0 errors, 0 skipped.
+- `git diff --check`: passed.
+- CodeGraph review context: 8 changed files, low risk, 0 impacted nodes reported.
+
+## Residual Risk
+
+Existing callers that used default Protobuf codecs for mixed Kotlin object storage must switch to the explicit trusted-internal APIs. This is the intended security tightening for shared-boundary defaults.
+
+## Concurrency Helper Gate
+
+No `MultithreadingTester`, `SuspendedJobTester`, or `StructuredTaskScopeTester` coverage was added. The change narrows synchronous codec encode/decode trust boundaries and does not add shared mutable state, coroutine lifecycle behavior, or structured task scope behavior.

--- a/docs/security/serialization-trust-profiles.md
+++ b/docs/security/serialization-trust-profiles.md
@@ -5,8 +5,8 @@ can influence deserialization.
 
 | Profile | Dynamic type loading | Default safety boundary | Examples |
 |---|---|---|---|
-| `TrustedInternal` | May load classes chosen by data written inside the same trusted deployment. | Use only for private caches or queues controlled by one application boundary. | Redisson Fory/Kryo defaults, Redisson Jackson/Fastjson when `allowedPackagePrefixes = null`. |
-| `AllowListedTypes` | Loads only classes allowed by package prefixes, class names, or object input filters. | Suitable for shared infrastructure and mixed producer/consumer deployments. | Kafka Jackson codecs with `allowedTypePackages`, `ProtobufSerializer`, `RedissonProtobufCodec`, secure Kryo/Fory factories, JDK object input filter. |
+| `TrustedInternal` | May load classes chosen by data written inside the same trusted deployment. | Use only for private caches or queues controlled by one application boundary. | Redisson Fory/Kryo defaults, Redisson Jackson/Fastjson when `allowedPackagePrefixes = null`, `trustedInternal*Protobuf` fallback codecs. |
+| `AllowListedTypes` | Loads only classes allowed by package prefixes, class names, or object input filters. | Suitable for shared infrastructure and mixed producer/consumer deployments. | Kafka Jackson codecs with `allowedTypePackages`, strict `ProtobufSerializer`, strict `RedissonProtobufCodec`, secure Kryo/Fory factories, JDK object input filter. |
 | `NoDynamicTypeLoading` | Serialized data does not choose a class. | Safest shape when the caller already knows the value type. | Static value-type JSON serializers and non-polymorphic decode APIs. |
 | `UnsafeLegacyCompatibility` | Restores allow-all legacy behavior through an explicit unsafe name. | Temporary migration only in fully trusted internal deployments. | `AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE`, `RedissonProtobufCodec.ALLOW_ALL_CLASSES_UNSAFE`. |
 
@@ -15,8 +15,9 @@ can influence deserialization.
 | Area | Default profile | Notes |
 |---|---|---|
 | Kafka 3/4 Jackson codecs | `AllowListedTypes` | `emptySet()` denies all dynamic class loading; configure package prefixes for production or use `ALLOW_ALL_TYPES_UNSAFE` only for trusted legacy migration. |
-| ProtobufSerializer | `AllowListedTypes` | Defaults to `io.bluetape4k.` and `com.google.protobuf.`. |
-| RedissonProtobufCodec | `AllowListedTypes` | Uses the same default prefixes as `ProtobufSerializer` and Kryo5 fallback for non-Protobuf values; legacy allow-all requires `ALLOW_ALL_CLASSES_UNSAFE`. |
+| ProtobufSerializer | `AllowListedTypes` | Defaults to `io.bluetape4k.` and `com.google.protobuf.` and rejects non-Protobuf values or bytes unless `ProtobufSerializer.trustedInternalProtobuf()` is selected. |
+| LettuceProtobufCodecs | `AllowListedTypes` | Default `*Protobuf()` factories are strict. Use `trustedInternal*Protobuf()` only for internal Redis stores that must read legacy Kryo fallback payloads. |
+| RedissonProtobufCodec | `AllowListedTypes` | Default constructors and `RedissonProtobufCodecs.*Protobuf` values are strict. Use `RedissonProtobufCodec.trustedInternal()` or `RedissonProtobufCodecs.TrustedInternal*Protobuf` only for legacy fallback payloads; legacy allow-all requires `ALLOW_ALL_CLASSES_UNSAFE`. |
 | Redisson Jackson3/Fastjson2 | `TrustedInternal` by default | Set `allowedPackagePrefixes` to move JSONB/polymorphic JSON use into `AllowListedTypes`. |
 | Kryo/Fory binary serializers | `TrustedInternal` by default | Use secure factories when data crosses a shared or untrusted boundary. |
 | JDK binary serializer | `AllowListedTypes` | Applies the default JDK object input filter and remains deprecated for new general use. |
@@ -34,9 +35,12 @@ Use unsafe legacy constants only as an intentional migration bridge:
 override val allowedTypePackages = AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE
 
 // Redisson Protobuf legacy compatibility: trusted internal deployments only.
-val codec = RedissonProtobufCodec(
+val codec = RedissonProtobufCodec.trustedInternal(
     allowedClassPrefixes = RedissonProtobufCodec.ALLOW_ALL_CLASSES_UNSAFE,
 )
+
+// Lettuce Protobuf legacy fallback bytes: trusted internal deployments only.
+val lettuceCodec = LettuceProtobufCodecs.trustedInternalProtobuf<MyTrustedValue>()
 ```
 
 Replace unsafe settings with narrow package prefixes once all stored payloads and

--- a/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializer.kt
+++ b/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializer.kt
@@ -10,32 +10,32 @@ import io.bluetape4k.support.isNullOrEmpty
 import java.util.concurrent.ConcurrentHashMap
 
 /**
- * Protobuf 메시지는 `Any`로 직렬화하고, 그 외 타입은 fallback serializer로 처리하는 바이너리 직렬화기입니다.
+ * Binary serializer for Protobuf messages packed as `Any`.
  *
- * ## 동작/계약
- * - [ProtoMessage] 입력은 `ProtoAny.pack(message).toByteArray()`로 직렬화합니다.
- * - 역직렬화 시 `typeUrl`의 클래스명을 [allowedClassPrefixes] 허용 목록으로 검증한 후 로딩합니다.
- * - 허용 목록에 없는 클래스명은 [SecurityException]을 발생시킵니다.
- * - Protobuf 경로 실패 시 [fallback]으로 자동 위임합니다.
+ * ## Contract
+ * - [ProtoMessage] inputs are encoded as `ProtoAny.pack(message).toByteArray()`.
+ * - Decoding validates the class name from `Any.typeUrl` against [allowedClassPrefixes] before loading it.
+ * - The default profile is strict: non-Protobuf values and non-Protobuf bytes are rejected.
+ * - A non-null [fallback] enables the trusted-internal mixed Protobuf + fallback profile.
  *
- * ## 보안 주의
- * - `typeUrl`에서 추출한 클래스명은 [allowedClassPrefixes]에 해당하는 것만 로딩합니다.
- * - `Class.forName` 호출 시 static initializer를 실행하지 않아 gadget chain 실행을 방지합니다.
- * - 사용자 정의 Protobuf 클래스가 허용 목록 외 패키지에 있으면 [allowedClassPrefixes]에 추가하세요.
+ * ## Security notes
+ * - Only class names matching [allowedClassPrefixes] are loaded from `Any.typeUrl`.
+ * - `Class.forName` uses `initialize=false` to avoid running static initializers.
+ * - Use [trustedInternalProtobuf] only when all producers and stored bytes are trusted.
  *
  * ```kotlin
- * // 기본 사용 — io.bluetape4k.** 과 com.google.protobuf.** 클래스만 허용
+ * // Strict shared-boundary profile.
  * val serializer = ProtobufSerializer()
  * val bytes = serializer.serialize(message)
  *
- * // 사용자 패키지 추가
+ * // Add an application Protobuf package.
  * val serializer = ProtobufSerializer(
  *     allowedClassPrefixes = setOf("io.bluetape4k.", "com.google.protobuf.", "com.example.proto.")
  * )
  * ```
  */
 class ProtobufSerializer(
-    private val fallback: BinarySerializer = BinarySerializers.Kryo,
+    private val fallback: BinarySerializer? = null,
     private val allowedClassPrefixes: Set<String> = DEFAULT_ALLOWED_PREFIXES,
 ): AbstractBinarySerializer() {
     init {
@@ -48,20 +48,34 @@ class ProtobufSerializer(
         private val messageTypes = ConcurrentHashMap<String, Class<out ProtoMessage>>()
 
         /**
-         * 기본 허용 클래스 패키지 접두사 목록.
-         * Protobuf 역직렬화 시 `typeUrl`에서 추출된 클래스명은 이 목록 중 하나로 시작해야 합니다.
+         * Package prefixes allowed for class names extracted from Protobuf `Any.typeUrl`.
          */
         val DEFAULT_ALLOWED_PREFIXES: Set<String> = setOf(
             "io.bluetape4k.",
             "com.google.protobuf."
         )
+
+        /**
+         * Creates the trusted-internal mixed Protobuf + fallback serializer.
+         *
+         * Use this profile only for internal stores whose historical bytes may contain fallback-encoded payloads.
+         */
+        fun trustedInternalProtobuf(
+            fallback: BinarySerializer = BinarySerializers.Kryo,
+            allowedClassPrefixes: Set<String> = DEFAULT_ALLOWED_PREFIXES,
+        ): ProtobufSerializer =
+            ProtobufSerializer(fallback = fallback, allowedClassPrefixes = allowedClassPrefixes)
     }
 
     override fun doSerialize(graph: Any): ByteArray =
         if (graph is ProtoMessage) {
             ProtoAny.pack(graph).toByteArray()
         } else {
-            fallback.serialize(graph)
+            fallback?.serialize(graph)
+                ?: throw IllegalArgumentException(
+                    "Strict Protobuf serializer can encode only Protobuf messages. " +
+                        "Use ProtobufSerializer.trustedInternalProtobuf() for trusted fallback payloads."
+                )
         }
 
     @Suppress("UNCHECKED_CAST")
@@ -74,23 +88,28 @@ class ProtobufSerializer(
             val protoAny = ProtoAny.parseFrom(bytes)
             val className = protoAny.typeUrl.substringAfterLast("/")
 
-            // 보안: 허용 목록에 없는 클래스는 로딩 거부
+            // Reject class names outside the configured allowlist before class loading.
             require(allowedClassPrefixes.any { className.matchesAllowedPrefix(it) }) {
-                "신뢰할 수 없는 Protobuf 클래스: $className. allowedClassPrefixes에 추가하세요."
+                "Untrusted Protobuf class: $className. Add the package to allowedClassPrefixes."
             }
 
             val clazz =
                 messageTypes.getOrPut(className) {
-                    // initialize=false: static initializer 실행 방지 (gadget chain RCE 예방)
+                    // initialize=false prevents static initializer execution while resolving the message class.
                     @Suppress("UNCHECKED_CAST")
                     Class.forName(className, false, Thread.currentThread().contextClassLoader) as Class<ProtoMessage>
                 }
             protoAny.unpack(clazz) as? T
         } catch (e: IllegalArgumentException) {
-            throw SecurityException("Protobuf 역직렬화 차단: ${e.message}", e)
+            throw SecurityException("Blocked Protobuf deserialization: ${e.message}", e)
         } catch (e: Throwable) {
-            log.debug(e) { "Protobuf 역직렬화 실패, fallback serializer로 대체합니다." }
-            fallback.deserialize(bytes)
+            val trustedFallback = fallback
+                ?: throw SecurityException(
+                    "Payload is not Protobuf Any and no trusted fallback serializer is configured.",
+                    e
+                )
+            log.debug(e) { "Protobuf deserialization failed; delegating to the trusted fallback serializer." }
+            trustedFallback.deserialize(bytes)
         }
     }
 

--- a/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/redis/LettuceProtobufCodecs.kt
+++ b/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/redis/LettuceProtobufCodecs.kt
@@ -14,7 +14,8 @@ import io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodec
  */
 object LettuceProtobufCodecs {
 
-    private val serializer: BinarySerializer by lazy { ProtobufSerializer() }
+    private val strictSerializer: BinarySerializer by lazy { ProtobufSerializer() }
+    private val trustedInternalSerializer: BinarySerializer by lazy { ProtobufSerializer.trustedInternalProtobuf() }
 
     /**
      * Protobuf Serializer를 사용하는 [io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodec]를 생성합니다.
@@ -25,7 +26,7 @@ object LettuceProtobufCodecs {
      * ```
      */
     fun <V: Any> protobuf(): LettuceBinaryCodec<V> =
-        LettuceBinaryCodec(serializer)
+        LettuceBinaryCodec(strictSerializer)
 
     /**
      * Protobuf Serializer와 Gzip Compressor를 사용하는 [io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodec]를 생성합니다.
@@ -36,7 +37,7 @@ object LettuceProtobufCodecs {
      * ```
      */
     fun <V: Any> gzipProtobuf(): LettuceBinaryCodec<V> =
-        LettuceBinaryCodec(CompressableBinarySerializer(serializer, Compressors.GZip))
+        LettuceBinaryCodec(CompressableBinarySerializer(strictSerializer, Compressors.GZip))
 
     /**
      * Protobuf Serializer와 Deflate Compressor를 사용하는 [io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodec]를 생성합니다.
@@ -47,7 +48,7 @@ object LettuceProtobufCodecs {
      * ```
      */
     fun <V: Any> deflateProtobuf(): LettuceBinaryCodec<V> =
-        LettuceBinaryCodec(CompressableBinarySerializer(serializer, Compressors.Deflate))
+        LettuceBinaryCodec(CompressableBinarySerializer(strictSerializer, Compressors.Deflate))
 
     /**
      * Protobuf Serializer와 LZ4 Compressor를 사용하는 [io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodec]를 생성합니다.
@@ -58,7 +59,7 @@ object LettuceProtobufCodecs {
      * ```
      */
     fun <V: Any> lz4Protobuf(): LettuceBinaryCodec<V> =
-        LettuceBinaryCodec(CompressableBinarySerializer(serializer, Compressors.LZ4))
+        LettuceBinaryCodec(CompressableBinarySerializer(strictSerializer, Compressors.LZ4))
 
     /**
      * Protobuf Serializer와 Snappy Compressor를 사용하는 [io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodec]를 생성합니다.
@@ -69,7 +70,7 @@ object LettuceProtobufCodecs {
      * ```
      */
     fun <V: Any> snappyProtobuf(): LettuceBinaryCodec<V> =
-        LettuceBinaryCodec(CompressableBinarySerializer(serializer, Compressors.Snappy))
+        LettuceBinaryCodec(CompressableBinarySerializer(strictSerializer, Compressors.Snappy))
 
     /**
      * Protobuf Serializer와 Zstd Compressor를 사용하는 [io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodec]를 생성합니다.
@@ -80,5 +81,43 @@ object LettuceProtobufCodecs {
      * ```
      */
     fun <V: Any> zstdProtobuf(): LettuceBinaryCodec<V> =
-        LettuceBinaryCodec(CompressableBinarySerializer(serializer, Compressors.Zstd))
+        LettuceBinaryCodec(CompressableBinarySerializer(strictSerializer, Compressors.Zstd))
+
+    /**
+     * Creates a trusted-internal mixed Protobuf + Kryo fallback codec.
+     *
+     * Use only for internal Redis stores that already contain legacy fallback-encoded values.
+     */
+    fun <V: Any> trustedInternalProtobuf(): LettuceBinaryCodec<V> =
+        LettuceBinaryCodec(trustedInternalSerializer)
+
+    /**
+     * Creates a trusted-internal mixed Protobuf + Kryo fallback codec with Gzip compression.
+     */
+    fun <V: Any> trustedInternalGzipProtobuf(): LettuceBinaryCodec<V> =
+        LettuceBinaryCodec(CompressableBinarySerializer(trustedInternalSerializer, Compressors.GZip))
+
+    /**
+     * Creates a trusted-internal mixed Protobuf + Kryo fallback codec with Deflate compression.
+     */
+    fun <V: Any> trustedInternalDeflateProtobuf(): LettuceBinaryCodec<V> =
+        LettuceBinaryCodec(CompressableBinarySerializer(trustedInternalSerializer, Compressors.Deflate))
+
+    /**
+     * Creates a trusted-internal mixed Protobuf + Kryo fallback codec with LZ4 compression.
+     */
+    fun <V: Any> trustedInternalLz4Protobuf(): LettuceBinaryCodec<V> =
+        LettuceBinaryCodec(CompressableBinarySerializer(trustedInternalSerializer, Compressors.LZ4))
+
+    /**
+     * Creates a trusted-internal mixed Protobuf + Kryo fallback codec with Snappy compression.
+     */
+    fun <V: Any> trustedInternalSnappyProtobuf(): LettuceBinaryCodec<V> =
+        LettuceBinaryCodec(CompressableBinarySerializer(trustedInternalSerializer, Compressors.Snappy))
+
+    /**
+     * Creates a trusted-internal mixed Protobuf + Kryo fallback codec with Zstd compression.
+     */
+    fun <V: Any> trustedInternalZstdProtobuf(): LettuceBinaryCodec<V> =
+        LettuceBinaryCodec(CompressableBinarySerializer(trustedInternalSerializer, Compressors.Zstd))
 }

--- a/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodec.kt
+++ b/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodec.kt
@@ -25,7 +25,8 @@ typealias AnyMessage = com.google.protobuf.Any
  * - [com.google.protobuf.Message] values are encoded directly into a Netty [ByteBuf].
  * - During decoding, the class name from `Any.typeUrl` is validated against [allowedClassPrefixes]
  *   before class loading.
- * - Non-Protobuf payloads are delegated to [fallbackCodec].
+ * - The default profile is strict: non-Protobuf values and bytes are rejected.
+ * - A non-null [fallbackCodec] enables the trusted-internal mixed Protobuf + fallback profile.
  * - A trust-boundary violation throws [SecurityException] instead of falling back silently.
  *
  * ```kotlin
@@ -33,11 +34,11 @@ typealias AnyMessage = com.google.protobuf.Any
  * // Register the codec in Redisson Config to store Protobuf messages.
  * ```
  *
- * @property fallbackCodec fallback codec for non-Protobuf payloads.
+ * @property fallbackCodec trusted fallback codec for non-Protobuf payloads, or `null` for strict mode.
  * @property allowedClassPrefixes package prefixes allowed for Protobuf `Any.typeUrl` class names.
  */
 class RedissonProtobufCodec private constructor(
-    private val fallbackCodec: Codec = RedissonCodecs.Kryo5,
+    private val fallbackCodec: Codec? = null,
     private val allowedClassPrefixes: Set<String> = ProtobufSerializer.DEFAULT_ALLOWED_PREFIXES,
     private val classLoader: ClassLoader? = null,
 ): BaseCodec() {
@@ -49,7 +50,7 @@ class RedissonProtobufCodec private constructor(
         }
     }
 
-    constructor(): this(RedissonCodecs.Kryo5, ProtobufSerializer.DEFAULT_ALLOWED_PREFIXES, null)
+    constructor(): this(null, ProtobufSerializer.DEFAULT_ALLOWED_PREFIXES, null)
 
     constructor(
         fallbackCodec: Codec,
@@ -57,7 +58,7 @@ class RedissonProtobufCodec private constructor(
 
     constructor(
         allowedClassPrefixes: Set<String>,
-    ): this(RedissonCodecs.Kryo5, allowedClassPrefixes, null)
+    ): this(null, allowedClassPrefixes, null)
 
     constructor(
         fallbackCodec: Codec,
@@ -65,9 +66,9 @@ class RedissonProtobufCodec private constructor(
     ): this(fallbackCodec, allowedClassPrefixes, null)
 
     // Redisson requires class-loader constructors for dynamic codec creation from configuration.
-    constructor(classLoader: ClassLoader): this(RedissonCodecs.Kryo5, ProtobufSerializer.DEFAULT_ALLOWED_PREFIXES, classLoader)
+    constructor(classLoader: ClassLoader): this(null, ProtobufSerializer.DEFAULT_ALLOWED_PREFIXES, classLoader)
     constructor(classLoader: ClassLoader, codec: RedissonProtobufCodec): this(
-        fallbackCodec = copy(classLoader, codec.fallbackCodec),
+        fallbackCodec = codec.fallbackCodec?.let { copy(classLoader, it) },
         allowedClassPrefixes = codec.allowedClassPrefixes,
         classLoader = classLoader,
     )
@@ -79,6 +80,17 @@ class RedissonProtobufCodec private constructor(
          * Use only for fully trusted internal Redis deployments while migrating to an allowlist.
          */
         val ALLOW_ALL_CLASSES_UNSAFE: Set<String> = setOf("*")
+
+        /**
+         * Creates a trusted-internal mixed Protobuf + fallback codec.
+         *
+         * Use this profile only for internal Redis stores whose historical bytes may contain fallback-encoded payloads.
+         */
+        fun trustedInternal(
+            fallbackCodec: Codec = RedissonCodecs.Kryo5,
+            allowedClassPrefixes: Set<String> = ProtobufSerializer.DEFAULT_ALLOWED_PREFIXES,
+        ): RedissonProtobufCodec =
+            RedissonProtobufCodec(fallbackCodec, allowedClassPrefixes, null)
     }
 
     private val classCache = ConcurrentHashMap<String, Class<Message>>()
@@ -88,10 +100,15 @@ class RedissonProtobufCodec private constructor(
             if (graph is Message) {
                 encodeProtobufMessage(graph)
             } else {
+                val trustedFallback = fallbackCodec
+                    ?: throw IllegalArgumentException(
+                        "Strict Protobuf codec can encode only Protobuf messages. " +
+                            "Use RedissonProtobufCodec.trustedInternal() for trusted fallback payloads."
+                    )
                 log.debug {
                     "Encoding: Protobuf Message가 아닙니다. fallbackCodec[$fallbackCodec] 사용. graph class=${graph.javaClass}"
                 }
-                fallbackCodec.valueEncoder.encode(graph)
+                trustedFallback.valueEncoder.encode(graph)
             }
         }
 
@@ -99,7 +116,7 @@ class RedissonProtobufCodec private constructor(
     private val decoder: Decoder<Any> =
         Decoder { buf: ByteBuf, state: State? ->
             try {
-                val bytes = buf.getBytes(copy = false)
+                val bytes = buf.getBytes(copy = true)
                 val any = AnyMessage.parseFrom(bytes)
                 val className = any.typeUrl.substringAfterLast("/")
                 validateClassName(className)
@@ -112,10 +129,15 @@ class RedissonProtobufCodec private constructor(
             } catch (e: SecurityException) {
                 throw e
             } catch (e: Throwable) {
+                val trustedFallback = fallbackCodec
+                    ?: throw SecurityException(
+                        "Payload is not Protobuf Any and no trusted fallback codec is configured.",
+                        e
+                    )
                 log.debug(e) {
                     "Decoding: Protobuf 메시지가 아닙니다. fallbackCodec[$fallbackCodec] 사용."
                 }
-                fallbackCodec.valueDecoder.decode(Unpooled.wrappedBuffer(buf.resetReaderIndex()), state)
+                trustedFallback.valueDecoder.decode(Unpooled.wrappedBuffer(buf.getBytes(copy = true)), state)
             }
         }
 

--- a/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodecs.kt
+++ b/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodecs.kt
@@ -37,6 +37,13 @@ object RedissonProtobufCodecs: KLogging() {
     val Protobuf: Codec by lazy { RedissonProtobufCodec() }
 
     /**
+     * Trusted-internal mixed Protobuf + Kryo fallback codec.
+     *
+     * Use only for internal Redis stores that already contain legacy fallback-encoded values.
+     */
+    val TrustedInternalProtobuf: Codec by lazy { RedissonProtobufCodec.trustedInternal() }
+
+    /**
      * Gzip 압축 + Protobuf 직렬화 Codec입니다.
      *
      * ```kotlin
@@ -45,6 +52,11 @@ object RedissonProtobufCodecs: KLogging() {
      * ```
      */
     val GzipProtobuf: Codec by lazy { GzipCodec(Protobuf) }
+
+    /**
+     * Trusted-internal mixed Protobuf + Kryo fallback codec with Gzip compression.
+     */
+    val TrustedInternalGzipProtobuf: Codec by lazy { GzipCodec(TrustedInternalProtobuf) }
 
     /**
      * 키는 String, 값은 Gzip+Protobuf를 사용하는 CompositeCodec입니다.
@@ -57,6 +69,13 @@ object RedissonProtobufCodecs: KLogging() {
     val GzipProtobufComposite: Codec by lazy { CompositeCodec(String, GzipProtobuf, GzipProtobuf) }
 
     /**
+     * Composite codec whose values use trusted-internal Gzip+Protobuf fallback.
+     */
+    val TrustedInternalGzipProtobufComposite: Codec by lazy {
+        CompositeCodec(String, TrustedInternalGzipProtobuf, TrustedInternalGzipProtobuf)
+    }
+
+    /**
      * LZ4 압축 + Protobuf 직렬화 Codec입니다.
      *
      * ```kotlin
@@ -65,6 +84,11 @@ object RedissonProtobufCodecs: KLogging() {
      * ```
      */
     val LZ4Protobuf: Codec by lazy { Lz4Codec(Protobuf) }
+
+    /**
+     * Trusted-internal mixed Protobuf + Kryo fallback codec with LZ4 compression.
+     */
+    val TrustedInternalLZ4Protobuf: Codec by lazy { Lz4Codec(TrustedInternalProtobuf) }
 
     /**
      * 키는 String, 값은 LZ4+Protobuf를 사용하는 CompositeCodec입니다.
@@ -77,6 +101,13 @@ object RedissonProtobufCodecs: KLogging() {
     val LZ4ProtobufComposite: Codec by lazy { CompositeCodec(String, LZ4Protobuf, LZ4Protobuf) }
 
     /**
+     * Composite codec whose values use trusted-internal LZ4+Protobuf fallback.
+     */
+    val TrustedInternalLZ4ProtobufComposite: Codec by lazy {
+        CompositeCodec(String, TrustedInternalLZ4Protobuf, TrustedInternalLZ4Protobuf)
+    }
+
+    /**
      * Snappy 압축 + Protobuf 직렬화 Codec입니다.
      *
      * ```kotlin
@@ -85,6 +116,11 @@ object RedissonProtobufCodecs: KLogging() {
      * ```
      */
     val SnappyProtobuf: Codec by lazy { SnappyCodecV2(Protobuf) }
+
+    /**
+     * Trusted-internal mixed Protobuf + Kryo fallback codec with Snappy compression.
+     */
+    val TrustedInternalSnappyProtobuf: Codec by lazy { SnappyCodecV2(TrustedInternalProtobuf) }
 
     /**
      * 키는 String, 값은 Snappy+Protobuf를 사용하는 CompositeCodec입니다.
@@ -97,6 +133,13 @@ object RedissonProtobufCodecs: KLogging() {
     val SnappyProtobufComposite: Codec by lazy { CompositeCodec(String, SnappyProtobuf, SnappyProtobuf) }
 
     /**
+     * Composite codec whose values use trusted-internal Snappy+Protobuf fallback.
+     */
+    val TrustedInternalSnappyProtobufComposite: Codec by lazy {
+        CompositeCodec(String, TrustedInternalSnappyProtobuf, TrustedInternalSnappyProtobuf)
+    }
+
+    /**
      * Zstandard 압축 + Protobuf 직렬화 Codec입니다.
      *
      * ```kotlin
@@ -107,6 +150,11 @@ object RedissonProtobufCodecs: KLogging() {
     val ZstdProtobuf: Codec by lazy { ZstdCodec(Protobuf) }
 
     /**
+     * Trusted-internal mixed Protobuf + Kryo fallback codec with Zstd compression.
+     */
+    val TrustedInternalZstdProtobuf: Codec by lazy { ZstdCodec(TrustedInternalProtobuf) }
+
+    /**
      * 키는 String, 값은 Zstd+Protobuf를 사용하는 CompositeCodec입니다.
      *
      * ```kotlin
@@ -115,5 +163,12 @@ object RedissonProtobufCodecs: KLogging() {
      * ```
      */
     val ZstdProtobufComposite: Codec by lazy { CompositeCodec(String, ZstdProtobuf, ZstdProtobuf) }
+
+    /**
+     * Composite codec whose values use trusted-internal Zstd+Protobuf fallback.
+     */
+    val TrustedInternalZstdProtobufComposite: Codec by lazy {
+        CompositeCodec(String, TrustedInternalZstdProtobuf, TrustedInternalZstdProtobuf)
+    }
 
 }

--- a/io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializerTest.kt
+++ b/io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializerTest.kt
@@ -1,6 +1,9 @@
 package io.bluetape4k.protobuf.serializers
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.junit5.faker.Fakers
+import io.bluetape4k.io.serializer.BinarySerializationException
+import io.bluetape4k.io.serializer.BinarySerializers
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.protobuf.messages.NestedMessage
@@ -20,6 +23,15 @@ class ProtobufSerializerTest {
     }
 
     private val serializer = ProtobufSerializer()
+
+    data class SimpleData(
+        val id: Int,
+        val name: String,
+    ): java.io.Serializable {
+        companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
 
     @RepeatedTest(REPEAT_SIZE)
     fun `serialize proto message`() {
@@ -65,18 +77,34 @@ class ProtobufSerializerTest {
     }
 
     @Test
-    fun `non-protobuf 타입은 fallback serializer로 직렬화 및 역직렬화된다`() {
-        data class SimpleData(
-            val id: Int,
-            val name: String,
-        ): java.io.Serializable
-
+    fun `strict serializer rejects non-protobuf values by default`() {
         val origin = SimpleData(1, "hello")
-        val bytes = serializer.serialize(origin)
+
+        assertFailsWith<BinarySerializationException> {
+            serializer.serialize(origin)
+        }
+    }
+
+    @Test
+    fun `strict serializer rejects non-protobuf bytes by default`() {
+        val origin = SimpleData(1, "hello")
+        val bytes = BinarySerializers.Kryo.serialize(origin)
+
+        assertFailsWith<BinarySerializationException> {
+            serializer.deserialize<SimpleData>(bytes)
+        }
+    }
+
+    @Test
+    fun `trusted internal serializer keeps fallback compatibility`() {
+        val origin = SimpleData(1, "hello")
+        val trustedInternalSerializer = ProtobufSerializer.trustedInternalProtobuf()
+
+        val bytes = trustedInternalSerializer.serialize(origin)
         bytes.shouldNotBeNull()
         (bytes.isNotEmpty()).shouldBeTrue()
 
-        val actual = serializer.deserialize<SimpleData>(bytes)
+        val actual = trustedInternalSerializer.deserialize<SimpleData>(bytes)
         actual shouldBeEqualTo origin
     }
 

--- a/io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/serializers/redis/LettuceProtobufCodecsTest.kt
+++ b/io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/serializers/redis/LettuceProtobufCodecsTest.kt
@@ -2,16 +2,20 @@ package io.bluetape4k.protobuf.serializers.redis
 
 import com.google.protobuf.Timestamp
 import com.google.protobuf.timestamp
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContainSame
+import io.bluetape4k.io.serializer.BinarySerializationException
 import io.bluetape4k.junit5.faker.Fakers
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.protobuf.redis.messages.RedisSimpleMessage
 import io.bluetape4k.protobuf.redis.messages.redisSimpleMessage
 import io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodec
 import io.lettuce.core.codec.RedisCodec
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldContainSame
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import java.nio.ByteBuffer
 import java.time.Instant
 import kotlin.random.Random
 
@@ -19,7 +23,7 @@ class LettuceProtobufCodecsTest: AbstractLettuceTest() {
 
     companion object: KLogging()
 
-    private fun getRedisCodecs(): List<LettuceBinaryCodec<out Any>> = listOf(
+    private fun getStrictRedisCodecs(): List<LettuceBinaryCodec<out Any>> = listOf(
         LettuceProtobufCodecs.protobuf(),
         LettuceProtobufCodecs.deflateProtobuf(),
         LettuceProtobufCodecs.gzipProtobuf(),
@@ -28,8 +32,56 @@ class LettuceProtobufCodecsTest: AbstractLettuceTest() {
         LettuceProtobufCodecs.zstdProtobuf(),
     )
 
+    private fun getTrustedInternalRedisCodecs(): List<LettuceBinaryCodec<out Any>> = listOf(
+        LettuceProtobufCodecs.trustedInternalProtobuf(),
+        LettuceProtobufCodecs.trustedInternalDeflateProtobuf(),
+        LettuceProtobufCodecs.trustedInternalGzipProtobuf(),
+        LettuceProtobufCodecs.trustedInternalLz4Protobuf(),
+        LettuceProtobufCodecs.trustedInternalSnappyProtobuf(),
+        LettuceProtobufCodecs.trustedInternalZstdProtobuf(),
+    )
+
+    private fun getStrictAndTrustedInternalRedisCodecs(): List<Arguments> = listOf(
+        Arguments.of(LettuceProtobufCodecs.protobuf<Any>(), LettuceProtobufCodecs.trustedInternalProtobuf<Any>()),
+        Arguments.of(
+            LettuceProtobufCodecs.deflateProtobuf<Any>(),
+            LettuceProtobufCodecs.trustedInternalDeflateProtobuf<Any>(),
+        ),
+        Arguments.of(LettuceProtobufCodecs.gzipProtobuf<Any>(), LettuceProtobufCodecs.trustedInternalGzipProtobuf<Any>()),
+        Arguments.of(LettuceProtobufCodecs.lz4Protobuf<Any>(), LettuceProtobufCodecs.trustedInternalLz4Protobuf<Any>()),
+        Arguments.of(
+            LettuceProtobufCodecs.snappyProtobuf<Any>(),
+            LettuceProtobufCodecs.trustedInternalSnappyProtobuf<Any>(),
+        ),
+        Arguments.of(LettuceProtobufCodecs.zstdProtobuf<Any>(), LettuceProtobufCodecs.trustedInternalZstdProtobuf<Any>()),
+    )
+
     @ParameterizedTest(name = "codec={0}")
-    @MethodSource("getRedisCodecs")
+    @MethodSource("getStrictRedisCodecs")
+    fun `strict codec rejects kotlin data class by default`(codec: RedisCodec<String, Any>) {
+        val origin = CustomData(Random.nextInt(), Fakers.randomString(1024, 4096))
+
+        assertFailsWith<BinarySerializationException> {
+            codec.encodeValue(origin)
+        }
+    }
+
+    @ParameterizedTest(name = "codec={0}")
+    @MethodSource("getStrictAndTrustedInternalRedisCodecs")
+    fun `strict codec rejects non-protobuf fallback bytes by default`(
+        codec: LettuceBinaryCodec<Any>,
+        trustedInternalCodec: LettuceBinaryCodec<Any>,
+    ) {
+        val origin = CustomData(Random.nextInt(), Fakers.randomString(1024, 4096))
+        val bytes = trustedInternalCodec.serializer.serialize(origin)
+
+        assertFailsWith<BinarySerializationException> {
+            codec.decodeValue(ByteBuffer.wrap(bytes))
+        }
+    }
+
+    @ParameterizedTest(name = "codec={0}")
+    @MethodSource("getTrustedInternalRedisCodecs")
     fun `codec for kotlin data class`(codec: RedisCodec<String, Any>) {
         client.connect(codec).use { connection ->
             // client.connect(codec).use { connection ->
@@ -46,7 +98,7 @@ class LettuceProtobufCodecsTest: AbstractLettuceTest() {
     }
 
     @ParameterizedTest(name = "codec={0}")
-    @MethodSource("getRedisCodecs")
+    @MethodSource("getTrustedInternalRedisCodecs")
     fun `codec for collection of kotlin data class`(codec: RedisCodec<String, Any>) {
         client.connect(codec).use { connection ->
             // client.connect(codec).use { connection ->
@@ -65,7 +117,7 @@ class LettuceProtobufCodecsTest: AbstractLettuceTest() {
     }
 
     @ParameterizedTest(name = "codec={0}")
-    @MethodSource("getRedisCodecs")
+    @MethodSource("getStrictRedisCodecs")
     fun `codec for protobuf message`(codec: RedisCodec<String, Any>) {
         client.connect(codec).use { connection ->
             val commands = connection.sync()
@@ -81,7 +133,7 @@ class LettuceProtobufCodecsTest: AbstractLettuceTest() {
     }
 
     @ParameterizedTest(name = "codec={0}")
-    @MethodSource("getRedisCodecs")
+    @MethodSource("getTrustedInternalRedisCodecs")
     fun `codec for collection of protobuf message`(codec: RedisCodec<String, Any>) {
         client.connect(codec).use { connection ->
             val commands = connection.sync()
@@ -97,7 +149,7 @@ class LettuceProtobufCodecsTest: AbstractLettuceTest() {
     }
 
     @ParameterizedTest(name = "codec={0}")
-    @MethodSource("getRedisCodecs")
+    @MethodSource("getTrustedInternalRedisCodecs")
     fun `codec for hset with data class`(codec: RedisCodec<String, Any>) {
         client.connect(codec).use { connection ->
             val commands = connection.sync()
@@ -113,7 +165,7 @@ class LettuceProtobufCodecsTest: AbstractLettuceTest() {
     }
 
     @ParameterizedTest(name = "codec={0}")
-    @MethodSource("getRedisCodecs")
+    @MethodSource("getStrictRedisCodecs")
     fun `codec for hset with protobuf message`(codec: RedisCodec<String, Any>) {
         client.connect(codec).use { connection ->
             val commands = connection.sync()
@@ -131,7 +183,11 @@ class LettuceProtobufCodecsTest: AbstractLettuceTest() {
     data class CustomData(
         val id: Int,
         val name: String,
-    ): java.io.Serializable
+    ): java.io.Serializable {
+        companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
 
     private fun getRedisSimpleMessage() = redisSimpleMessage {
         id = Random.nextLong()

--- a/io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodecTest.kt
+++ b/io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodecTest.kt
@@ -27,7 +27,7 @@ class RedissonProtobufCodecTest: AbstractRedissonTest() {
         private const val REPEAT_SIZE = 10
     }
 
-    private fun getTestCodecs() = listOf(
+    private fun getStrictTestCodecs() = listOf(
         Arguments.of(RedissonProtobufCodecs.Protobuf),
         Arguments.of(RedissonProtobufCodecs.GzipProtobuf),
         Arguments.of(RedissonProtobufCodecs.GzipProtobufComposite),
@@ -37,6 +37,18 @@ class RedissonProtobufCodecTest: AbstractRedissonTest() {
         Arguments.of(RedissonProtobufCodecs.SnappyProtobufComposite),
         Arguments.of(RedissonProtobufCodecs.ZstdProtobuf),
         Arguments.of(RedissonProtobufCodecs.ZstdProtobufComposite),
+    )
+
+    private fun getTrustedInternalTestCodecs() = listOf(
+        Arguments.of(RedissonProtobufCodecs.TrustedInternalProtobuf),
+        Arguments.of(RedissonProtobufCodecs.TrustedInternalGzipProtobuf),
+        Arguments.of(RedissonProtobufCodecs.TrustedInternalGzipProtobufComposite),
+        Arguments.of(RedissonProtobufCodecs.TrustedInternalLZ4Protobuf),
+        Arguments.of(RedissonProtobufCodecs.TrustedInternalLZ4ProtobufComposite),
+        Arguments.of(RedissonProtobufCodecs.TrustedInternalSnappyProtobuf),
+        Arguments.of(RedissonProtobufCodecs.TrustedInternalSnappyProtobufComposite),
+        Arguments.of(RedissonProtobufCodecs.TrustedInternalZstdProtobuf),
+        Arguments.of(RedissonProtobufCodecs.TrustedInternalZstdProtobufComposite),
     )
 
     data class CustomData(
@@ -90,14 +102,14 @@ class RedissonProtobufCodecTest: AbstractRedissonTest() {
     }
 
     @ParameterizedTest(name = "codec for simple string with {0}")
-    @MethodSource("getTestCodecs")
+    @MethodSource("getTrustedInternalTestCodecs")
     fun `codec for simple string with fallback codec`(codec: Codec) {
         val origin = "Hello world! 동해물과 백두산이"
         codec.verifyCodec(origin)
     }
 
     @ParameterizedTest(name = "codec for kotlin data class with {0}")
-    @MethodSource("getTestCodecs")
+    @MethodSource("getTrustedInternalTestCodecs")
     fun `codec for kotlin data class with fallback codec`(codec: Codec) {
         repeat(REPEAT_SIZE) {
             val origin = CustomData(faker.random().nextInt(), faker.name().fullName())
@@ -106,7 +118,7 @@ class RedissonProtobufCodecTest: AbstractRedissonTest() {
     }
 
     @ParameterizedTest(name = "codec for protobuf simple message with {0}")
-    @MethodSource("getTestCodecs")
+    @MethodSource("getStrictTestCodecs")
     fun `codec for protobuf simple message`(codec: Codec) {
         repeat(REPEAT_SIZE) {
             codec.verifyCodec(newSimpleMessage())
@@ -114,10 +126,34 @@ class RedissonProtobufCodecTest: AbstractRedissonTest() {
     }
 
     @ParameterizedTest(name = "codec for protobuf nested message with {0}")
-    @MethodSource("getTestCodecs")
+    @MethodSource("getStrictTestCodecs")
     fun `codec for protobuf nested message`(codec: Codec) {
         repeat(REPEAT_SIZE) {
             codec.verifyCodec(newNestedMessage())
+        }
+    }
+
+    @Test
+    fun `default codec rejects non-protobuf values by default`() {
+        val codec = RedissonProtobufCodec()
+
+        assertFailsWith<IllegalArgumentException> {
+            codec.valueEncoder.encode("Hello world! 동해물과 백두산이")
+        }
+    }
+
+    @Test
+    fun `default codec rejects non-protobuf bytes by default`() {
+        val trustedInternalCodec = RedissonProtobufCodec.trustedInternal()
+        val fallbackBytes = trustedInternalCodec.valueEncoder.encode("fallback-bytes")
+        val strictCodec = RedissonProtobufCodec()
+
+        try {
+            assertFailsWith<SecurityException> {
+                strictCodec.valueDecoder.decode(fallbackBytes, State())
+            }
+        } finally {
+            fallbackBytes.release()
         }
     }
 
@@ -156,7 +192,7 @@ class RedissonProtobufCodecTest: AbstractRedissonTest() {
             .build()
             .toByteArray()
 
-        val codec = RedissonProtobufCodec(
+        val codec = RedissonProtobufCodec.trustedInternal(
             fallbackCodec = SentinelFallbackCodec(fallbackValue),
             allowedClassPrefixes = RedissonProtobufCodec.ALLOW_ALL_CLASSES_UNSAFE,
         )


### PR DESCRIPTION
## Summary

Closes #798

- PR 제목: fix: make Protobuf codecs strict by default

Resolves #798.

- Make `ProtobufSerializer()` strict by default so non-Protobuf values and fallback-format bytes are rejected unless a trusted fallback is configured.
- Keep legacy mixed Protobuf + Kryo/Kryo5 compatibility behind explicit trusted-internal APIs for serializer, Lettuce, and Redisson codecs.
- Update Redis codec tests and serialization trust-profile documentation to separate shared-boundary strict defaults from trusted-internal fallback migration paths.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Risk

Existing callers that relied on default Protobuf codecs for mixed Kotlin object storage must switch to the new trusted-internal APIs. That is the intended shared-boundary hardening for this bug.

## Validation

- `./gradlew :bluetape4k-protobuf:compileTestKotlin --warning-mode all --rerun-tasks --no-daemon --no-configuration-cache`
- `./gradlew :bluetape4k-protobuf:test --tests "io.bluetape4k.protobuf.serializers.ProtobufSerializerTest" --tests "io.bluetape4k.protobuf.serializers.redis.LettuceProtobufCodecsTest" --tests "io.bluetape4k.protobuf.serializers.redis.RedissonProtobufCodecTest" --rerun-tasks --no-daemon --no-configuration-cache`
- `./gradlew :bluetape4k-protobuf:test --no-daemon --no-configuration-cache` (`209 tests, 0 failures, 0 errors, 0 skipped`)
- `git diff --check`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #798, milestone `1.11.0`, assignee `debop`
- PR: #925, head `9507ee2d4c01822b2d39cf5e361d9904c7da4ce6`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/protobuf-strict-default-codecs`
- Labels: `bug`, `documentation`, `test`, `security`
- State: `MERGED`, merge commit `20ed85bf9c6bdf4fb099e7f9a678b7c8e3cd4ab9`
- CI: - Keep legacy mixed Protobuf + Kryo/Kryo5 compatibility behind explicit trusted-internal APIs for serializer, Lettuce, and Redisson codecs. / - `./gradlew :bluetape4k-protobuf:compileTestKotlin --warning-mode all --rerun-tasks --no-daemon --no-configuration-cache` / - `./gradlew :bluetape4k-protobuf:test --tests "io.bluetape4k.protobuf.serializers.ProtobufSerializerTest" --tests "io.bluetape4k.protobuf.serializers.redis.LettuceProtobufCodecsTest" --tests "io.bluetape4k.protobuf.serializers.redis.RedissonProtobufCodecTest" --rerun-tasks --no-daemon --no-configuration-cache`

## DoD Status

- [x] Strict Protobuf serializer and Redis codec defaults reject non-Protobuf values or bytes.
- [x] Mixed Protobuf + fallback compatibility remains available through explicit trusted-internal API names.
- [x] Security documentation distinguishes strict Protobuf defaults from trusted-internal fallback profiles.
- [x] Regression tests cover strict rejection and explicit fallback compatibility.
- [x] Concurrency helper gate evaluated: `MultithreadingTester`, `SuspendedJobTester`, and `StructuredTaskScopeTester` are not applicable because this is synchronous codec encode/decode trust-boundary behavior.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #925 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `20ed85bf9c6bdf4fb099e7f9a678b7c8e3cd4ab9`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
