### PR TITLE
fix: require explicit gRPC plaintext opt-in

### DIFF
--- a/docs/lessons/2026-06-27-issue-797-grpc-client-plaintext.md
+++ b/docs/lessons/2026-06-27-issue-797-grpc-client-plaintext.md
@@ -1,0 +1,35 @@
+# Issue 797: gRPC client plaintext opt-in
+
+## Context
+
+`AbstractGrpcClient(host, port)` silently built a plaintext channel for arbitrary hosts. Subclasses using the convenience constructor for remote services could therefore send RPC traffic and metadata without TLS even though the insecure choice was not visible at the call site.
+
+## Decision
+
+Make the convenience constructor secure by default and require explicit local/test opt-in for plaintext:
+
+- Default: `GrpcChannelSecurity.TRANSPORT_SECURITY`
+- Local/test escape hatch: `GrpcChannelSecurity.LOCAL_PLAINTEXT`
+- Plaintext opt-in is restricted to loopback hosts.
+
+## Outcome
+
+- Host/port `AbstractGrpcClient` construction no longer silently chooses plaintext.
+- Remote plaintext opt-in is rejected before channel construction.
+- README English/Korean examples now show production transport security and local/test plaintext separately.
+
+## Verification
+
+- Red test before implementation: new channel security API references failed compilation.
+- `./gradlew :bluetape4k-grpc:compileTestKotlin --warning-mode all --rerun-tasks --no-daemon --no-configuration-cache`
+- `./gradlew :bluetape4k-grpc:test --tests "io.bluetape4k.grpc.GrpcChannelSecurityTest" --tests "io.bluetape4k.grpc.GrpcSupportValidationTest" --tests "io.bluetape4k.grpc.ManagedChannelSupportTest" --rerun-tasks --no-daemon --no-configuration-cache`
+- `./gradlew :bluetape4k-grpc:test --no-daemon --no-configuration-cache`: 72 tests, 0 failures, 0 errors, 4 skipped.
+- `git diff --check`
+
+## Future Guard
+
+Do not add host/port convenience constructors that silently select insecure transports for arbitrary remote targets. If plaintext is needed for local tests, make the API name or enum value explicit and document that it is loopback-only.
+
+## Concurrency Helper Gate
+
+`MultithreadingTester`, `SuspendedJobTester`, and `StructuredTaskScopeTester` were not applicable. This is a synchronous channel-construction security choice with no concurrent state, coroutine lifecycle, or structured task-scope behavior.

--- a/docs/review/2026-06-27-issue-797-grpc-client-plaintext-review.md
+++ b/docs/review/2026-06-27-issue-797-grpc-client-plaintext-review.md
@@ -1,0 +1,37 @@
+# Issue 797 Review: gRPC client plaintext opt-in
+
+## Scope
+
+- `AbstractGrpcClient`
+- gRPC channel security selection helper
+- gRPC README locale pair
+- gRPC channel security regression tests
+
+## Findings
+
+No P0/P1 findings.
+
+## Checks
+
+- `AbstractGrpcClient(host, port)` now uses transport security by default.
+- Plaintext requires explicit `GrpcChannelSecurity.LOCAL_PLAINTEXT`.
+- Local plaintext is restricted to loopback hosts.
+- Remote plaintext opt-in fails before channel construction.
+- README English/Korean examples separate production transport security from local/test plaintext.
+
+## Verification Evidence
+
+- Red test before implementation failed in `:bluetape4k-grpc:compileTestKotlin` because `GrpcChannelSecurity` and `applyGrpcChannelSecurity` did not exist.
+- `:bluetape4k-grpc:compileTestKotlin --warning-mode all --rerun-tasks`: passed; remaining warnings are existing Gradle Kotlin DSL deprecations outside the touched gRPC source/test code.
+- Targeted gRPC channel security, support validation, and managed channel tests with `--rerun-tasks`: passed.
+- Full `:bluetape4k-grpc:test`: 72 tests, 0 failures, 0 errors, 4 skipped.
+- `git diff --check`: passed.
+- CodeGraph review context: 5 changed files, low risk, 0 impacted nodes reported.
+
+## Residual Risk
+
+Existing local clients that relied on the no-arg or host/port constructor to talk to plaintext local services must pass `GrpcChannelSecurity.LOCAL_PLAINTEXT`. This is the intended security hardening for production-facing defaults.
+
+## Concurrency Helper Gate
+
+No `MultithreadingTester`, `SuspendedJobTester`, or `StructuredTaskScopeTester` coverage was added. The change selects channel transport security during synchronous channel construction and does not add shared mutable state, coroutine lifecycle behavior, or structured task scope behavior.

--- a/io/grpc/README.ko.md
+++ b/io/grpc/README.ko.md
@@ -33,6 +33,7 @@ gRPC 서버/클라이언트 구현을 위한 Kotlin 확장 라이브러리입니
 - **gRPC 클라이언트 추상화**: 채널 관리 및 호출
 - **In-process 서버/클라이언트**: 테스트용 인메모리 통신
 - **인터셉터 지원**: 서버 인터셉터 보조
+- **안전한 클라이언트 기본값**: host/port 클라이언트 생성자는 기본적으로 transport security를 사용하고, plaintext는 local/test 용도로 명시적으로만 선택
 - **입력 검증**: host/target/name 은 blank를 허용하지 않고 port 는 `1..65535` 범위를 즉시 검증
 
 ## 사용 예시
@@ -73,30 +74,30 @@ server.blockUntilShutdown()
 
 ```kotlin
 import io.bluetape4k.grpc.AbstractGrpcClient
+import io.bluetape4k.grpc.GrpcChannelSecurity
 
 class MyGrpcClient(
-    private val host: String = "localhost",
-    private val port: Int = 50051
-): AbstractGrpcClient() {
+    host: String,
+    port: Int,
+    channelSecurity: GrpcChannelSecurity = GrpcChannelSecurity.TRANSPORT_SECURITY,
+): AbstractGrpcClient(host, port, channelSecurity) {
 
-    private lateinit var channel: ManagedChannel
-    private lateinit var stub: MyServiceGrpc.MyServiceBlockingStub
-
-    override fun connect() {
-        channel = ManagedChannelBuilder.forAddress(host, port)
-            .usePlaintext()
-            .build()
-        stub = MyServiceGrpc.newBlockingStub(channel)
-    }
-
-    override fun close() {
-        channel.shutdown()
-    }
+    private val stub = MyServiceGrpc.newBlockingStub(channel)
 
     fun doSomething(request: Request): Response {
         return stub.doSomething(request)
     }
 }
+
+// 운영 또는 공유 인프라: transport security가 기본값입니다.
+val productionClient = MyGrpcClient("api.example.com", 443)
+
+// local/test plaintext는 명시적으로 선택해야 하며 loopback host로 제한됩니다.
+val localTestClient = MyGrpcClient(
+    host = "localhost",
+    port = 50051,
+    channelSecurity = GrpcChannelSecurity.LOCAL_PLAINTEXT,
+)
 ```
 
 ### 3. In-process 서버/클라이언트 (테스트용)

--- a/io/grpc/README.md
+++ b/io/grpc/README.md
@@ -33,6 +33,7 @@ A Kotlin extension library for implementing gRPC servers and clients.
 - **gRPC client abstraction**: Channel management and calls
 - **In-process server/client**: In-memory communication for testing
 - **Interceptor support**: Server interceptor helpers
+- **Secure client defaults**: Host/port client constructors use transport security by default; plaintext requires explicit local/test opt-in
 - **Input validation**: host/target/name must be non-blank; port must be in the `1..65535` range — validated immediately
 
 ## Usage Examples
@@ -73,30 +74,30 @@ server.blockUntilShutdown()
 
 ```kotlin
 import io.bluetape4k.grpc.AbstractGrpcClient
+import io.bluetape4k.grpc.GrpcChannelSecurity
 
 class MyGrpcClient(
-    private val host: String = "localhost",
-    private val port: Int = 50051
-): AbstractGrpcClient() {
+    host: String,
+    port: Int,
+    channelSecurity: GrpcChannelSecurity = GrpcChannelSecurity.TRANSPORT_SECURITY,
+): AbstractGrpcClient(host, port, channelSecurity) {
 
-    private lateinit var channel: ManagedChannel
-    private lateinit var stub: MyServiceGrpc.MyServiceBlockingStub
-
-    override fun connect() {
-        channel = ManagedChannelBuilder.forAddress(host, port)
-            .usePlaintext()
-            .build()
-        stub = MyServiceGrpc.newBlockingStub(channel)
-    }
-
-    override fun close() {
-        channel.shutdown()
-    }
+    private val stub = MyServiceGrpc.newBlockingStub(channel)
 
     fun doSomething(request: Request): Response {
         return stub.doSomething(request)
     }
 }
+
+// Production or shared infrastructure: transport security is the default.
+val productionClient = MyGrpcClient("api.example.com", 443)
+
+// Local/test plaintext must be explicit and is restricted to loopback hosts.
+val localTestClient = MyGrpcClient(
+    host = "localhost",
+    port = 50051,
+    channelSecurity = GrpcChannelSecurity.LOCAL_PLAINTEXT,
+)
 ```
 
 ### 3. In-process Server/Client (for Testing)

--- a/io/grpc/src/main/kotlin/io/bluetape4k/grpc/AbstractGrpcClient.kt
+++ b/io/grpc/src/main/kotlin/io/bluetape4k/grpc/AbstractGrpcClient.kt
@@ -10,31 +10,42 @@ import java.io.Closeable
 import java.util.concurrent.TimeUnit
 
 /**
- * [ManagedChannel] 수명주기를 관리하는 gRPC 클라이언트 베이스 클래스입니다.
+ * Base gRPC client that owns a [ManagedChannel] lifecycle.
  *
- * ## 동작/계약
- * - 기본 생성자는 `localhost:50051` 채널을 생성합니다.
- * - [close]는 채널이 살아 있으면 `shutdown + awaitTermination(5s)`를 수행합니다.
- * - 종료 실패 예외는 내부에서 무시됩니다.
+ * ## Contract
+ * - The host/port constructor uses [GrpcChannelSecurity.TRANSPORT_SECURITY] by default.
+ * - Plaintext channels require explicit [GrpcChannelSecurity.LOCAL_PLAINTEXT] opt-in and are limited to loopback hosts.
+ * - [close] calls `shutdown + awaitTermination(5s)` while the channel is alive.
+ * - Shutdown failures are swallowed after logging the shutdown attempt.
  *
  * ```kotlin
- * client.close()
- * // channel.isShutdown == true
+ * val channel = ManagedChannelBuilder.forAddress("api.example.com", 443)
+ *     .useTransportSecurity()
+ *     .build()
+ * val client = object: AbstractGrpcClient(channel) {}
  * ```
  */
 abstract class AbstractGrpcClient(
     protected val channel: ManagedChannel,
 ): Closeable {
 
-    constructor(host: String = DEFAULT_HOST, port: Int = DEFAULT_PORT): this(buildForAddress(host, port))
+    constructor(
+        host: String = DEFAULT_HOST,
+        port: Int = DEFAULT_PORT,
+        channelSecurity: GrpcChannelSecurity = GrpcChannelSecurity.TRANSPORT_SECURITY,
+    ): this(buildForAddress(host, port, channelSecurity))
 
     companion object: KLogging() {
         const val DEFAULT_HOST = "localhost"
         const val DEFAULT_PORT = 50051
 
-        private fun buildForAddress(host: String, port: Int): ManagedChannel =
+        private fun buildForAddress(
+            host: String,
+            port: Int,
+            channelSecurity: GrpcChannelSecurity,
+        ): ManagedChannel =
             managedChannel(host, port) {
-                usePlaintext()
+                applyGrpcChannelSecurity(channelSecurity, host)
                 executor(Dispatchers.IO.asExecutor())
             }
     }

--- a/io/grpc/src/main/kotlin/io/bluetape4k/grpc/GrpcChannelSecurity.kt
+++ b/io/grpc/src/main/kotlin/io/bluetape4k/grpc/GrpcChannelSecurity.kt
@@ -1,0 +1,39 @@
+package io.bluetape4k.grpc
+
+import io.grpc.ManagedChannelBuilder
+import java.util.Locale
+
+/**
+ * Security profile for gRPC client channels created by bluetape4k helpers.
+ */
+enum class GrpcChannelSecurity {
+    /**
+     * Uses transport security for production-facing channels.
+     */
+    TRANSPORT_SECURITY,
+
+    /**
+     * Uses plaintext only for local or test loopback channels.
+     */
+    LOCAL_PLAINTEXT,
+}
+
+private val LOCAL_PLAINTEXT_HOSTS = setOf("localhost", "127.0.0.1", "::1", "[::1]")
+
+internal fun ManagedChannelBuilder<*>.applyGrpcChannelSecurity(
+    security: GrpcChannelSecurity,
+    host: String,
+): ManagedChannelBuilder<*> = apply {
+    when (security) {
+        GrpcChannelSecurity.TRANSPORT_SECURITY -> useTransportSecurity()
+        GrpcChannelSecurity.LOCAL_PLAINTEXT   -> {
+            require(host.isLocalPlaintextHost()) {
+                "LOCAL_PLAINTEXT is allowed only for loopback hosts. Use a ManagedChannel for custom test targets."
+            }
+            usePlaintext()
+        }
+    }
+}
+
+private fun String.isLocalPlaintextHost(): Boolean =
+    trim().lowercase(Locale.ROOT) in LOCAL_PLAINTEXT_HOSTS

--- a/io/grpc/src/test/kotlin/io/bluetape4k/grpc/GrpcChannelSecurityTest.kt
+++ b/io/grpc/src/test/kotlin/io/bluetape4k/grpc/GrpcChannelSecurityTest.kt
@@ -1,0 +1,73 @@
+package io.bluetape4k.grpc
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.grpc.ManagedChannelBuilder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GrpcChannelSecurityTest {
+
+    private val builder = mockk<ManagedChannelBuilder<*>>(relaxed = true)
+
+    private class TestClient(
+        host: String = AbstractGrpcClient.DEFAULT_HOST,
+        port: Int = AbstractGrpcClient.DEFAULT_PORT,
+        channelSecurity: GrpcChannelSecurity = GrpcChannelSecurity.TRANSPORT_SECURITY,
+    ): AbstractGrpcClient(host, port, channelSecurity)
+
+    @BeforeEach
+    fun setUp() {
+        clearMocks(builder)
+        every { builder.useTransportSecurity() } returns builder
+        every { builder.usePlaintext() } returns builder
+    }
+
+    @Test
+    fun `transport security is the default channel security`() {
+        builder.applyGrpcChannelSecurity(GrpcChannelSecurity.TRANSPORT_SECURITY, "api.example.com")
+
+        verify(exactly = 1) { builder.useTransportSecurity() }
+        verify(exactly = 0) { builder.usePlaintext() }
+    }
+
+    @Test
+    fun `local plaintext opt-in applies plaintext only for loopback hosts`() {
+        listOf("localhost", "127.0.0.1", "::1", "[::1]").forEach { host ->
+            clearMocks(builder)
+            every { builder.usePlaintext() } returns builder
+
+            builder.applyGrpcChannelSecurity(GrpcChannelSecurity.LOCAL_PLAINTEXT, host)
+
+            verify(exactly = 1) { builder.usePlaintext() }
+            verify(exactly = 0) { builder.useTransportSecurity() }
+        }
+    }
+
+    @Test
+    fun `local plaintext opt-in rejects remote hosts`() {
+        assertFailsWith<IllegalArgumentException> {
+            builder.applyGrpcChannelSecurity(GrpcChannelSecurity.LOCAL_PLAINTEXT, "api.example.com")
+        }
+
+        verify(exactly = 0) { builder.usePlaintext() }
+        verify(exactly = 0) { builder.useTransportSecurity() }
+    }
+
+    @Test
+    fun `abstract client host port constructor rejects remote plaintext opt-in`() {
+        assertFailsWith<IllegalArgumentException> {
+            TestClient("api.example.com", 50051, GrpcChannelSecurity.LOCAL_PLAINTEXT)
+        }
+    }
+
+    @Test
+    fun `abstract client host port constructor allows local plaintext opt-in`() {
+        val client = TestClient("localhost", 50051, GrpcChannelSecurity.LOCAL_PLAINTEXT)
+
+        client.close()
+    }
+}


### PR DESCRIPTION
## Summary

Closes #797

- PR 제목: fix: require explicit gRPC plaintext opt-in

- Make `AbstractGrpcClient(host, port)` use transport security by default instead of silently selecting plaintext.
- Add `GrpcChannelSecurity.LOCAL_PLAINTEXT` as an explicit loopback-only local/test opt-in.
- Update English and Korean gRPC README examples to separate production TLS from local plaintext testing.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Issue

Resolves #797

### 기존 섹션: Verification

- `./gradlew :bluetape4k-grpc:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache` failed first as RED coverage before `GrpcChannelSecurity` existed.
- `./gradlew :bluetape4k-grpc:compileTestKotlin --warning-mode all --rerun-tasks --no-daemon --no-configuration-cache`
- `./gradlew :bluetape4k-grpc:test --tests "io.bluetape4k.grpc.GrpcChannelSecurityTest" --tests "io.bluetape4k.grpc.GrpcSupportValidationTest" --tests "io.bluetape4k.grpc.ManagedChannelSupportTest" --rerun-tasks --no-daemon --no-configuration-cache`
- `./gradlew :bluetape4k-grpc:test --no-daemon --no-configuration-cache` (`72 tests`, `0 failures`, `0 errors`, `4 skipped`)
- `git diff --check`

### 기존 섹션: Review Evidence

- Added `docs/review/2026-06-27-issue-797-grpc-client-plaintext-review.md` with no P0/P1 findings.
- Added `docs/lessons/2026-06-27-issue-797-grpc-client-plaintext.md` for the durable security/defaults lesson.
- CodeGraph review context after source changes reported 5 changed source/doc files, low overall risk, and no impacted graph nodes.

### 기존 섹션: Risk

Existing local clients that relied on `AbstractGrpcClient()` or `AbstractGrpcClient("localhost", port)` creating plaintext channels must now pass `GrpcChannelSecurity.LOCAL_PLAINTEXT`. This is intentional for issue #797 and is documented in the README examples.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #797, milestone `1.11.0`, assignee `debop`
- PR: #928, head `0ba3063c9275ed208d592f64c1d0a1097dca9804`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/grpc-client-explicit-plaintext`
- Labels: `bug`, `documentation`, `security`
- State: `MERGED`, merge commit `e145dc765c0243f4244e571950a5f63860ac447e`
- CI: - Add `GrpcChannelSecurity.LOCAL_PLAINTEXT` as an explicit loopback-only local/test opt-in. / - `./gradlew :bluetape4k-grpc:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache` failed first as RED coverage before `GrpcChannelSecurity` existed. / - `./gradlew :bluetape4k-grpc:compileTestKotlin --warning-mode all --rerun-tasks --no-daemon --no-configuration-cache`

## DoD Status

- [x] Production-facing host/port convenience construction no longer silently enables plaintext.
- [x] Plaintext is an explicit local/test opt-in and is limited to loopback hosts.
- [x] README and README.ko document production TLS and local plaintext separately.
- [x] Regression tests cover secure default, explicit loopback plaintext, remote plaintext rejection, and the `AbstractGrpcClient` constructor path.
- [x] Concurrency helper gate evaluated: `MultithreadingTester`, `SuspendedJobTester`, and `StructuredTaskScopeTester` are not applicable because this is channel-construction policy with no multi-threaded, coroutine, or structured-concurrency behavior change.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #928 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e145dc765c0243f4244e571950a5f63860ac447e`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
