### PR TITLE
fix: redact sensitive HTTP header logs

### DIFF
--- a/docs/lessons/2026-06-27-issue-792-http-logging-redaction.md
+++ b/docs/lessons/2026-06-27-issue-792-http-logging-redaction.md
@@ -1,0 +1,27 @@
+# Lessons Learned - Issue #792 HTTP logging header redaction (2026-06-27)
+
+## Context
+
+Issue #792 showed that HTTP diagnostic logs could expose credential-bearing headers. The affected paths were OkHttp request/response logging and Retrofit HC5 request conversion trace logging.
+
+## Decision
+
+Use one shared HTTP header redaction helper before formatting diagnostic log values. The helper redacts well-known credential headers, API-key names, token-like names, and caller-provided project-specific header names.
+
+## Outcome
+
+- `LoggingInterceptor` now logs redacted request and response headers.
+- `Hc5OkHttp3Support.toSimpleHttpRequest()` now redacts sensitive header values only in trace logs while preserving the real outgoing request headers.
+- `io/http` README locale pair documents the default redaction policy and custom extension path.
+
+## Verification
+
+- RED tests first reproduced raw sensitive header leakage in `LoggingInterceptor` and `Hc5OkHttp3Support`.
+- Targeted tests passed for `LoggingInterceptorTest` and `Hc5OkHttp3SupportTest`.
+- Full module tests passed for `:bluetape4k-http:test` and `:bluetape4k-retrofit2:test`.
+- `:bluetape4k-http:compileTestKotlin` and `:bluetape4k-retrofit2:compileTestKotlin` passed with `--warning-mode all --rerun-tasks`; remaining warnings were existing Gradle Kotlin DSL deprecations outside the touched code.
+- `git diff --check` passed.
+
+## Future Guard
+
+Do not log HTTP header values directly. New HTTP diagnostic paths should call `redactHttpHeaderValue` for individual name/value logs or `Headers.toRedactedString` for OkHttp header blocks. If the change introduces concurrency, coroutine, virtual-thread, or structured-concurrency behavior, use the matching bluetape4k concurrency helper and record the helper evidence in the PR DoD.

--- a/docs/review/2026-06-27-issue-792-http-logging-redaction-review.md
+++ b/docs/review/2026-06-27-issue-792-http-logging-redaction-review.md
@@ -1,0 +1,44 @@
+# Review - Issue #792 HTTP logging header redaction (2026-06-27)
+
+## Scope
+
+- Issue: #792, `P1: HTTP logging can expose sensitive headers`
+- Modules: `:bluetape4k-http`, `:bluetape4k-retrofit2`
+- Changed paths:
+  - `io/http/src/main/kotlin/io/bluetape4k/http/okhttp3/HttpHeaderRedaction.kt`
+  - `io/http/src/main/kotlin/io/bluetape4k/http/okhttp3/LoggingInterceptor.kt`
+  - `io/http/src/test/kotlin/io/bluetape4k/http/okhttp3/LoggingInterceptorTest.kt`
+  - `io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/clients/hc5/Hc5OkHttp3Support.kt`
+  - `io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/clients/hc5/Hc5OkHttp3SupportTest.kt`
+  - `io/http/README.md`
+  - `io/http/README.ko.md`
+
+## Findings
+
+- P0: 0
+- P1: 0
+- P2: 0
+- P3: 1
+
+### P3 - Redaction helper normalizes custom header names per lookup
+
+`isSensitiveHttpHeaderName` normalizes `additionalSensitiveHeaderNames` for each call. The current call sites pass small sets and HTTP header counts are small, so this is not a release blocker. If future logging paths apply large policy sets or hot-path structured logging, pre-normalize the policy once at the call boundary.
+
+## Review Notes
+
+- `LoggingInterceptor` no longer delegates header formatting to OkHttp `Headers.toString()`. That OkHttp path redacts some built-in sensitive names but does not cover project/API-key headers required by #792.
+- `Hc5OkHttp3Support.toSimpleHttpRequest()` redacts only the trace log value. The generated `SimpleHttpRequest` still receives the original raw header values.
+- The public factory `LoggingInterceptor(logger)` remains available, and the new `LoggingInterceptor(logger, additionalSensitiveHeaderNames)` overload gives callers a source-compatible way to add project-specific sensitive names.
+- README locale pair was updated because the public logging behavior changed.
+- Concurrency helper gate: not applicable. The change formats immutable request/response header snapshots and does not add shared mutable state, coroutines, virtual threads, structured concurrency, or stress-sensitive lifecycle behavior. No `MultithreadingTester`, `SuspendedJobTester`, or `StructuredTaskScopeTester` was needed.
+
+## Verification Evidence
+
+- RED: `./gradlew :bluetape4k-http:test --tests "io.bluetape4k.http.okhttp3.LoggingInterceptorTest.LoggingInterceptor - sensitive request and response headers are redacted" --no-daemon --no-configuration-cache` failed before the fix because sensitive response `X-Api-Key` remained visible and OkHttp built-in redaction used a different marker.
+- RED: `./gradlew :bluetape4k-retrofit2:test --tests "io.bluetape4k.retrofit2.clients.hc5.Hc5OkHttp3SupportTest" --no-daemon --no-configuration-cache` failed before the fix because HC5 trace logs contained raw `Authorization` and `X-Api-Key` values.
+- GREEN targeted: `./gradlew :bluetape4k-http:test --tests "io.bluetape4k.http.okhttp3.LoggingInterceptorTest" :bluetape4k-retrofit2:test --tests "io.bluetape4k.retrofit2.clients.hc5.Hc5OkHttp3SupportTest" --no-daemon --no-configuration-cache` passed.
+- GREEN compile: `./gradlew :bluetape4k-http:compileTestKotlin :bluetape4k-retrofit2:compileTestKotlin --warning-mode all --rerun-tasks --no-daemon --no-configuration-cache` passed. Remaining warnings were existing Gradle Kotlin DSL deprecations outside the touched files.
+- GREEN module tests: `./gradlew :bluetape4k-http:test --no-daemon --no-configuration-cache` passed with 446 passing and 3 pending tests.
+- GREEN module tests: `./gradlew :bluetape4k-retrofit2:test --no-daemon --no-configuration-cache` passed with 293 passing and 1 pending test.
+- Static diff check: `git diff --check` passed with no output.
+- Source scan: searched HTTP and Retrofit production/test sources for raw header diagnostic paths; changed paths route sensitive diagnostic values through `toRedactedString` or `redactHttpHeaderValue`.

--- a/io/http/README.ko.md
+++ b/io/http/README.ko.md
@@ -188,6 +188,12 @@ val client = okhttp3Client(
     addNetworkInterceptor(CachingResponseInterceptor())
 }
 
+// LoggingInterceptor는 Authorization, Cookie, Set-Cookie,
+// API key, token 계열 헤더를 기본으로 마스킹합니다.
+val clientWithCustomRedaction = okhttp3Client {
+    addInterceptor(LoggingInterceptor(log, setOf("X-Internal-Secret")))
+}
+
 // Request DSL
 val request = okhttp3RequestOf("https://httpbin.org/get") {
     get()

--- a/io/http/README.md
+++ b/io/http/README.md
@@ -189,6 +189,12 @@ val client = okhttp3Client(
     addNetworkInterceptor(CachingResponseInterceptor())
 }
 
+// LoggingInterceptor redacts Authorization, Cookie, Set-Cookie,
+// API-key, and token-like headers by default.
+val clientWithCustomRedaction = okhttp3Client {
+    addInterceptor(LoggingInterceptor(log, setOf("X-Internal-Secret")))
+}
+
 // Request DSL
 val request = okhttp3RequestOf("https://httpbin.org/get") {
     get()

--- a/io/http/src/main/kotlin/io/bluetape4k/http/okhttp3/HttpHeaderRedaction.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/okhttp3/HttpHeaderRedaction.kt
@@ -1,0 +1,61 @@
+package io.bluetape4k.http.okhttp3
+
+import okhttp3.Headers
+import java.util.Locale
+
+/** Redacted marker used for sensitive HTTP header values in diagnostic logs. */
+const val REDACTED_HTTP_HEADER_VALUE: String = "<redacted>"
+
+private val DEFAULT_SENSITIVE_HEADER_NAMES = setOf(
+    "authorization",
+    "proxy-authorization",
+    "cookie",
+    "set-cookie",
+    "x-api-key",
+    "api-key",
+)
+
+/**
+ * Returns true when [headerName] should have its value redacted in logs.
+ *
+ * ## Contract
+ * - Matches well-known credential headers such as `Authorization`, `Cookie`, and `Set-Cookie`.
+ * - Matches API-key and token-like header names by normalized fragments.
+ * - [additionalSensitiveHeaderNames] lets callers extend the policy for project-specific headers.
+ */
+fun isSensitiveHttpHeaderName(
+    headerName: String,
+    additionalSensitiveHeaderNames: Set<String> = emptySet(),
+): Boolean {
+    val normalized = headerName.normalizedHeaderName()
+    return normalized in DEFAULT_SENSITIVE_HEADER_NAMES ||
+            normalized in additionalSensitiveHeaderNames.mapTo(HashSet()) { it.normalizedHeaderName() } ||
+            "api-key" in normalized ||
+            "apikey" in normalized ||
+            "token" in normalized
+}
+
+/**
+ * Returns [REDACTED_HTTP_HEADER_VALUE] for sensitive headers and the original [headerValue] otherwise.
+ */
+fun redactHttpHeaderValue(
+    headerName: String,
+    headerValue: String,
+    additionalSensitiveHeaderNames: Set<String> = emptySet(),
+): String =
+    if (isSensitiveHttpHeaderName(headerName, additionalSensitiveHeaderNames)) {
+        REDACTED_HTTP_HEADER_VALUE
+    } else {
+        headerValue
+    }
+
+/**
+ * Formats OkHttp [Headers] for logs while redacting sensitive values.
+ */
+fun Headers.toRedactedString(additionalSensitiveHeaderNames: Set<String> = emptySet()): String =
+    joinToString(separator = "") { (name, value) ->
+        "$name: ${redactHttpHeaderValue(name, value, additionalSensitiveHeaderNames)}\n"
+    }
+
+private fun String.normalizedHeaderName(): String =
+    trim().lowercase(Locale.ROOT)

--- a/io/http/src/main/kotlin/io/bluetape4k/http/okhttp3/LoggingInterceptor.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/okhttp3/LoggingInterceptor.kt
@@ -5,7 +5,12 @@ import okhttp3.Interceptor
 import okhttp3.Response
 
 /**
- * [okhttp3.OkHttpClient] 실행 시, 요청과 응답 정보를 [logger]에 출력하는 [Interceptor]입니다.
+ * OkHttp interceptor that logs request and response diagnostics.
+ *
+ * ## Contract
+ * - Logs request URL, connection, and redacted request headers before execution.
+ * - Logs response URL, elapsed time, and redacted response headers after execution.
+ * - Redacts credential-bearing headers by default and supports additional project-specific names.
  *
  * ```kotlin
  * val client = OkHttpClient.Builder()
@@ -13,35 +18,50 @@ import okhttp3.Response
  *    .build()
  * ```
  *
- * @property logger 로그를 출력할 [org.slf4j.Logger]
+ * @property logger Logger that receives diagnostics.
  */
 class LoggingInterceptor private constructor(
     private val logger: org.slf4j.Logger,
+    private val additionalSensitiveHeaderNames: Set<String> = emptySet(),
 ): Interceptor {
 
     companion object {
         /**
-         * [okhttp3.OkHttpClient] 실행 시, 요청과 응답 정보를 [logger]에 출력하는 [Interceptor]입니다.
+         * Creates a logging interceptor with the default sensitive header redaction policy.
          *
-         * @param logger 로그를 출력할 [org.slf4j.Logger]
+         * @param logger Logger that receives request and response diagnostics.
          */
         @JvmStatic
         operator fun invoke(logger: org.slf4j.Logger): LoggingInterceptor {
             return LoggingInterceptor(logger)
         }
+
+        /**
+         * Creates a logging interceptor with project-specific sensitive headers.
+         *
+         * @param logger Logger that receives request and response diagnostics.
+         * @param additionalSensitiveHeaderNames Extra header names whose values must be redacted.
+         */
+        @JvmStatic
+        operator fun invoke(
+            logger: org.slf4j.Logger,
+            additionalSensitiveHeaderNames: Set<String>,
+        ): LoggingInterceptor {
+            return LoggingInterceptor(logger, additionalSensitiveHeaderNames)
+        }
     }
 
     /**
-     * HTTP 요청 전송 전 URL·연결 정보·헤더를 DEBUG 로그로 출력하고,
-     * 응답 수신 후 URL·소요 시간·헤더를 DEBUG 로그로 출력합니다.
+     * Logs redacted request/response diagnostics around [chain] execution.
      *
-     * @param chain [Interceptor.Chain] 인스턴스
-     * @return [Response]
+     * @param chain OkHttp interceptor chain.
+     * @return The response returned by the next interceptor or network call.
      */
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
         logger.debug {
-            "Sending request. url=${request.url}, connection=${chain.connection()}, headers=${request.headers}"
+            "Sending request. url=${request.url}, connection=${chain.connection()}, " +
+                    "headers=${request.headers.toRedactedString(additionalSensitiveHeaderNames)}"
         }
         val startMillis = System.currentTimeMillis()
 
@@ -50,7 +70,8 @@ class LoggingInterceptor private constructor(
 
         val elapsedMillis = System.currentTimeMillis() - startMillis
         logger.debug {
-            "Receive response. url=${response.request.url}, elapsed=${elapsedMillis} msec. headers=${response.headers}"
+            "Receive response. url=${response.request.url}, elapsed=${elapsedMillis} msec. " +
+                    "headers=${response.headers.toRedactedString(additionalSensitiveHeaderNames)}"
         }
 
         return response

--- a/io/http/src/test/kotlin/io/bluetape4k/http/okhttp3/LoggingInterceptorTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/okhttp3/LoggingInterceptorTest.kt
@@ -1,12 +1,15 @@
 package io.bluetape4k.http.okhttp3
 
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotContain
+import io.bluetape4k.junit5.output.InMemoryLogbackAppender
 import io.bluetape4k.logging.KLogging
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -17,11 +20,14 @@ class LoggingInterceptorTest {
 
     private lateinit var server: MockWebServer
     private lateinit var client: OkHttpClient
+    private lateinit var appender: InMemoryLogbackAppender
 
     @BeforeEach
     fun beforeEach() {
         server = MockWebServer().apply { start() }
-        val logger = LoggerFactory.getLogger(LoggingInterceptorTest::class.java)
+        val loggerName = LoggingInterceptorTest::class.java.name
+        appender = InMemoryLogbackAppender(loggerName)
+        val logger = LoggerFactory.getLogger(loggerName)
         client =
             OkHttpClient
                 .Builder()
@@ -31,6 +37,7 @@ class LoggingInterceptorTest {
 
     @AfterEach
     fun afterEach() {
+        runCatching { appender.close() }
         runCatching { server.shutdown() }
     }
 
@@ -68,5 +75,79 @@ class LoggingInterceptorTest {
                 response.isSuccessful.shouldBeTrue()
             }
         }
+    }
+
+    @Test
+    fun `LoggingInterceptor - sensitive request and response headers are redacted`() {
+        val secretToken = "Bearer request-secret"
+        val cookie = "session=request-cookie"
+        val responseCookie = "session=response-cookie"
+        val apiKey = "response-api-key"
+
+        server.enqueue(
+            MockResponse()
+                .setBody("ok")
+                .setResponseCode(200)
+                .setHeader("Set-Cookie", responseCookie)
+                .setHeader("X-Api-Key", apiKey)
+                .setHeader("X-Trace-Id", "trace-123")
+        )
+
+        val request =
+            Request
+                .Builder()
+                .url(server.url("/redaction"))
+                .get()
+                .header("Authorization", secretToken)
+                .header("Cookie", cookie)
+                .header("X-Request-Id", "request-123")
+                .build()
+
+        client.newCall(request).execute().use { response ->
+            response.isSuccessful.shouldBeTrue()
+        }
+
+        val messages = appender.messages.joinToString("\n")
+        messages shouldContain "Authorization: <redacted>"
+        messages shouldContain "Cookie: <redacted>"
+        messages shouldContain "Set-Cookie: <redacted>"
+        messages shouldContain "X-Api-Key: <redacted>"
+        messages shouldContain "X-Request-Id: request-123"
+        messages shouldContain "X-Trace-Id: trace-123"
+        messages shouldNotContain secretToken
+        messages shouldNotContain cookie
+        messages shouldNotContain responseCookie
+        messages shouldNotContain apiKey
+    }
+
+    @Test
+    fun `LoggingInterceptor - additional sensitive headers are redacted`() {
+        val internalSecret = "internal-secret"
+        val loggerName = LoggingInterceptorTest::class.java.name
+        val customClient =
+            OkHttpClient
+                .Builder()
+                .addInterceptor(LoggingInterceptor(LoggerFactory.getLogger(loggerName), setOf("X-Internal-Secret")))
+                .build()
+
+        server.enqueue(MockResponse().setBody("ok").setResponseCode(200))
+
+        val request =
+            Request
+                .Builder()
+                .url(server.url("/custom-redaction"))
+                .get()
+                .header("X-Internal-Secret", internalSecret)
+                .header("X-Request-Id", "request-123")
+                .build()
+
+        customClient.newCall(request).execute().use { response ->
+            response.isSuccessful.shouldBeTrue()
+        }
+
+        val messages = appender.messages.joinToString("\n")
+        messages shouldContain "X-Internal-Secret: <redacted>"
+        messages shouldContain "X-Request-Id: request-123"
+        messages shouldNotContain internalSecret
     }
 }

--- a/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/clients/hc5/Hc5OkHttp3Support.kt
+++ b/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/clients/hc5/Hc5OkHttp3Support.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.retrofit2.clients.hc5
 
 import io.bluetape4k.http.hc5.async.methods.simpleHttpRequest
 import io.bluetape4k.http.okhttp3.okhttp3Response
+import io.bluetape4k.http.okhttp3.redactHttpHeaderValue
 import io.bluetape4k.http.okhttp3.toTypeString
 import io.bluetape4k.io.compressor.Compressors
 import io.bluetape4k.logging.KotlinLogging
@@ -46,7 +47,7 @@ internal fun okhttp3.Request.toSimpleHttpRequest(): SimpleHttpRequest {
     simpleRequest.setHeader(HttpHeaders.ACCEPT_ENCODING, "gzip,deflate")
 
     self.headers.forEach { (name, value) ->
-        log.trace { "Add header. $name=$value" }
+        log.trace { "Add header. $name=${redactHttpHeaderValue(name, value)}" }
         simpleRequest.setHeader(name, value)
     }
 

--- a/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/clients/hc5/Hc5OkHttp3SupportTest.kt
+++ b/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/clients/hc5/Hc5OkHttp3SupportTest.kt
@@ -1,0 +1,52 @@
+package io.bluetape4k.retrofit2.clients.hc5
+
+import ch.qos.logback.classic.Level
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotContain
+import io.bluetape4k.junit5.output.InMemoryLogbackAppender
+import okhttp3.Request
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+
+class Hc5OkHttp3SupportTest {
+
+    @Test
+    fun `toSimpleHttpRequest redacts sensitive headers in trace logs`() {
+        val loggerName = "io.bluetape4k.retrofit2.clients.hc5.Hc5OkHttp3Support"
+        val logger = LoggerFactory.getLogger(loggerName) as ch.qos.logback.classic.Logger
+        val previousLevel = logger.level
+        val secretToken = "Bearer hc5-secret"
+        val apiKey = "hc5-api-key"
+
+        InMemoryLogbackAppender(loggerName).use { appender ->
+            try {
+                logger.level = Level.TRACE
+
+                val request =
+                    Request
+                        .Builder()
+                        .url("https://example.com/redaction")
+                        .get()
+                        .header("Authorization", secretToken)
+                        .header("X-Api-Key", apiKey)
+                        .header("X-Request-Id", "request-123")
+                        .build()
+
+                val simpleRequest = request.toSimpleHttpRequest()
+
+                simpleRequest.getFirstHeader("Authorization").value shouldBeEqualTo secretToken
+                simpleRequest.getFirstHeader("X-Api-Key").value shouldBeEqualTo apiKey
+
+                val messages = appender.messages.joinToString("\n")
+                messages shouldContain "Authorization=<redacted>"
+                messages shouldContain "X-Api-Key=<redacted>"
+                messages shouldContain "X-Request-Id=request-123"
+                messages shouldNotContain secretToken
+                messages shouldNotContain apiKey
+            } finally {
+                logger.level = previousLevel
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #792

- PR 제목: fix: redact sensitive HTTP header logs

Redact sensitive HTTP header values before they enter OkHttp and Retrofit HC5 diagnostic logs.

### 원문 선행 내용

Resolves #792

## Background

HTTP diagnostics are useful for request tracing, but the previous logging paths could expose credentials:

- `LoggingInterceptor` formatted OkHttp request and response headers directly.
- `Hc5OkHttp3Support.toSimpleHttpRequest()` traced copied headers as raw name/value pairs.

Issue #792 requires default redaction for authorization, cookie, API-key, and token-like headers while keeping ordinary header diagnostics visible.

## What This Solves

- Prevents credential-bearing headers from being written to application logs.
- Keeps outbound request behavior unchanged; only diagnostic formatting is redacted.
- Gives callers a custom extension point for project-specific sensitive header names.

## Work Done

- Added `HttpHeaderRedaction` helpers for sensitive header detection, value redaction, and OkHttp `Headers` formatting.
- Updated `LoggingInterceptor` to log redacted request and response headers.
- Updated Retrofit HC5 header trace logging to redact sensitive values while preserving raw outgoing headers.
- Added RED/GREEN tests for OkHttp request/response header redaction, custom sensitive headers, and HC5 trace logs.
- Updated `io/http` README locale pair with the default redaction policy and custom extension example.
- Added review and lesson artifacts for the security logging guard.

### 기존 섹션: Validation And Review Notes

- RED evidence: `LoggingInterceptorTest.LoggingInterceptor - sensitive request and response headers are redacted` failed before the fix because `X-Api-Key` was visible in logs.
- RED evidence: `Hc5OkHttp3SupportTest` failed before the fix because HC5 trace logs contained raw `Authorization` and `X-Api-Key` values.
- GREEN targeted tests passed for `LoggingInterceptorTest` and `Hc5OkHttp3SupportTest`.
- GREEN full module tests passed for `:bluetape4k-http:test` and `:bluetape4k-retrofit2:test`.
- GREEN compile passed for `:bluetape4k-http:compileTestKotlin` and `:bluetape4k-retrofit2:compileTestKotlin` with `--warning-mode all --rerun-tasks`; remaining warnings are existing Gradle Kotlin DSL deprecations outside touched code.
- `git diff --check origin/develop...HEAD` passed.
- Review artifact: `docs/review/2026-06-27-issue-792-http-logging-redaction-review.md`
- Lessons artifact: `docs/lessons/2026-06-27-issue-792-http-logging-redaction.md`
- Concurrency helper gate: not applicable. This change formats immutable header snapshots for logging and does not introduce shared mutable state, coroutines, virtual threads, structured concurrency, or stress-sensitive lifecycle behavior.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #792, milestone `1.11.0`, assignee `debop`
- PR: #929, head `472c42f4c71eb67ba9ddff28a9bdc21aa337eaa6`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/http-logging-header-redaction`
- Labels: `bug`, `test`, `security`
- State: `MERGED`, merge commit `f086c467071ee5520bd8ccef2943c05354480abd`
- CI: HTTP diagnostics are useful for request tracing, but the previous logging paths could expose credentials: / - Gives callers a custom extension point for project-specific sensitive header names. / - GREEN compile passed for `:bluetape4k-http:compileTestKotlin` and `:bluetape4k-retrofit2:compileTestKotlin` with `--warning-mode all --rerun-tasks`; remaining warnings are existing Gradle Kotlin DSL deprecations outside touched code.

## DoD Status

| Step | Status | Evidence |
|---|---|---|
| W - Worktree | PASS | `.worktrees/fix-http-logging-header-redaction` on `fix/http-logging-header-redaction`, based on current `origin/develop`. |
| A - Issue analysis | PASS | #792 is open, assigned to `debop`, milestone `1.11.0`, labels `bug`, `test`, `security`; affected paths confirmed in OkHttp logging and Retrofit HC5 header tracing. |
| F - Fix | PASS | Shared `HttpHeaderRedaction` helper added; `LoggingInterceptor` and `Hc5OkHttp3Support` route diagnostic header values through redaction. |
| 4-T - Tests | PASS | Targeted tests passed; full `:bluetape4k-http:test` passed with 446 passing/3 pending; full `:bluetape4k-retrofit2:test` passed with 293 passing/1 pending. |
| 6-R - Review | PASS | `docs/review/2026-06-27-issue-792-http-logging-redaction-review.md`; P0/P1 = 0; concurrency helper rationale recorded. |
| 6 partial - README | PASS | `io/http/README.md` and `io/http/README.ko.md` updated in sync. |
| 7 - Lessons | PASS | `docs/lessons/2026-06-27-issue-792-http-logging-redaction.md` committed before PR creation. |
| 7-P - PR | PASS | PR #929 created against `develop`; live metadata verified with assignee `debop`, milestone `1.11.0`, labels `bug`, `test`, `security`, and final `## DoD Status` heading. |
| 7-R - PR review | PASS | PR comment `4813468681` and formal review `COMMENTED` review `4582788797`; P0/P1 = 0. |
| 8 - CI Gate | PASS | GitHub checks pass/skip: Build, CI Status, Coverage Report, Detect changed modules, Secret Scan, Validate Gradle Wrapper, submit-gradle passed; scoped test jobs skipped by path/module filter. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #929 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `f086c467071ee5520bd8ccef2943c05354480abd`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
