### PR TITLE
fix: preserve Jackson2 typed mapper allowlist

### DIFF
--- a/docs/lessons/2026-06-27-issue-790-jackson2-typed-mapper-allowlist.md
+++ b/docs/lessons/2026-06-27-issue-790-jackson2-typed-mapper-allowlist.md
@@ -1,0 +1,32 @@
+# Issue 790: Jackson2 typed mapper allowlist preservation
+
+## Context
+
+`Jackson.createTypedJsonMapper(...)` built a `BasicPolymorphicTypeValidator`, then replaced Jackson's configured default typing resolver with a raw `StdTypeResolverBuilder`. That removed the validator from the actual polymorphic deserialization path and allowed a root `Any` payload with an external `@class` id.
+
+## Decision
+
+Use Jackson's `activateDefaultTypingAsProperty(...)` so the configured validator stays attached to property-based `@class` type ids. For the safe factory, validate package prefixes with `allowIfSubType(...)` instead of `allowIfBaseType(...)`, because allowing a base type can approve every legal subtype once the nominal base type matches.
+
+## Outcome
+
+- Disallowed root `Any` polymorphic payloads now fail with `InvalidTypeIdException`.
+- Disallowed nested payloads still fail, and allowed package payloads still round-trip with `@class` type ids.
+- `typedJsonMapper` remains only a deprecated legacy compatibility mapper and is no longer promoted in examples for untrusted JSON.
+
+## Verification
+
+- Red test before implementation: root `Any` payload with `com.example.disallowed.DisallowedTypedPayload` did not throw.
+- `./gradlew :bluetape4k-jackson2:test --tests "io.bluetape4k.jackson.JacksonTest.createTypedJsonMapper*" --no-daemon --no-configuration-cache`
+- `./gradlew :bluetape4k-jackson2:test --tests "io.bluetape4k.jackson.JacksonTest" --no-daemon --no-configuration-cache`
+- `./gradlew :bluetape4k-jackson2:test --no-daemon --no-configuration-cache`
+- `./gradlew :bluetape4k-jackson2:compileTestKotlin --warning-mode all --rerun-tasks --no-daemon --no-configuration-cache`
+- `git diff --check`
+
+## Future Guard
+
+Do not call `setDefaultTyping(...)` with a raw `StdTypeResolverBuilder` after installing a `PolymorphicTypeValidator`; it can silently bypass the validator. For package allowlists, include a root `Any` payload regression test, not only an envelope or nested-property test.
+
+## Concurrency Helper Gate
+
+`MultithreadingTester`, `SuspendedJobTester`, and `StructuredTaskScopeTester` were not applicable here. This fix does not add concurrency, coroutine, virtual-thread, or structured-task behavior; it narrows synchronous Jackson default typing validation.

--- a/docs/review/2026-06-27-issue-790-jackson2-typed-mapper-allowlist-review.md
+++ b/docs/review/2026-06-27-issue-790-jackson2-typed-mapper-allowlist-review.md
@@ -1,0 +1,38 @@
+# Issue 790 Review: Jackson2 typed mapper allowlist preservation
+
+## Scope
+
+- `Jackson.createTypedJsonMapper(...)`
+- Legacy `Jackson.typedJsonMapper` default typing compatibility path
+- Jackson2 typed mapper regression tests
+- Jackson2 README locale pair
+
+## Findings
+
+No P0/P1 findings.
+
+## Checks
+
+- `createTypedJsonMapper(...)` now installs Jackson's property-based default typing with the configured `PolymorphicTypeValidator` intact.
+- The trusted package list is enforced as subtype package prefixes with `allowIfSubType(...)`.
+- Disallowed root `Any` polymorphic payloads are rejected instead of bypassing the allowlist.
+- Disallowed nested payloads are rejected, and allowed payloads still round-trip with `@class` property type ids.
+- Deprecated `typedJsonMapper` remains a legacy compatibility path and is no longer promoted in the class KDoc or README examples.
+
+## Verification Evidence
+
+- Red test before implementation: `createTypedJsonMapper - denied root payload is rejected` failed with `Expected InvalidTypeIdException but no exception was thrown`.
+- Initial nested denied-package test passed before the fix; it was retained for nested-property coverage but was not the root reproducer.
+- Targeted `createTypedJsonMapper*` Jackson tests: passed.
+- Full `JacksonTest`: passed.
+- Full `:bluetape4k-jackson2:test`: 433 tests passed.
+- `:bluetape4k-jackson2:compileTestKotlin --warning-mode all --rerun-tasks`: passed; only existing root Gradle Kotlin DSL deprecation warnings were reported.
+- `git diff --check`: passed.
+
+## Residual Risk
+
+The public parameter name `allowedBasePackages` is historical. The safe factory now treats it as trusted subtype package prefixes to satisfy the security contract, and the KDoc clarifies that behavior. Downstream callers that relied on the safe factory accepting arbitrary external root `Any` subtype ids must migrate those payloads to trusted packages or use an explicit legacy compatibility mapper only for trusted JSON.
+
+## Concurrency Helper Gate
+
+No `MultithreadingTester`, `SuspendedJobTester`, or `StructuredTaskScopeTester` was added. The change is a synchronous Jackson mapper construction and deserialization trust-boundary fix with no shared mutable state, coroutine lifecycle, virtual-thread behavior, or structured task scope behavior.

--- a/io/jackson2/README.ko.md
+++ b/io/jackson2/README.ko.md
@@ -67,6 +67,20 @@ val defaultMapper = Jackson.defaultJsonMapper
 val prettyJson = Jackson.prettyJsonWriter.writeValueAsString(data)
 ```
 
+### 안전한 다형성 Mapper
+
+Jackson default type information이 필요한 JSON에는 `Jackson.createTypedJsonMapper(...)`를 사용하세요.
+allowlist는 다형 subtype class name에 적용되며, type id는 `@class` property로 기록됩니다.
+
+```kotlin
+val mapper = Jackson.createTypedJsonMapper("com.example.model.")
+val json = mapper.writeValueAsString(value)
+val restored = mapper.readValue(json, ModelEnvelope::class.java)
+```
+
+신뢰할 수 없는 JSON에는 deprecated된 `Jackson.typedJsonMapper`를 사용하지 마세요. 이 mapper는
+호환성을 위해 기존 `Any` base default typing 동작을 유지하므로 외부 payload에 안전하지 않습니다.
+
 ### 2. JacksonSerializer
 
 `JsonSerializer` 인터페이스를 구현하며, Jackson ObjectMapper를 사용합니다.

--- a/io/jackson2/README.md
+++ b/io/jackson2/README.md
@@ -135,6 +135,21 @@ val defaultMapper = Jackson.defaultJsonMapper
 val prettyJson = Jackson.prettyJsonWriter.writeValueAsString(data)
 ```
 
+### Safe Polymorphic Mapper
+
+Use `Jackson.createTypedJsonMapper(...)` when JSON must carry Jackson default type information.
+The allowlist is enforced against polymorphic subtype class names, and type ids are written as the
+`@class` property.
+
+```kotlin
+val mapper = Jackson.createTypedJsonMapper("com.example.model.")
+val json = mapper.writeValueAsString(value)
+val restored = mapper.readValue(json, ModelEnvelope::class.java)
+```
+
+Do not use the deprecated `Jackson.typedJsonMapper` with untrusted JSON. It keeps the legacy
+`Any`-base default typing behavior for compatibility and is unsafe for external payloads.
+
 ### JacksonSerializer
 
 ```kotlin

--- a/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/Jackson.kt
+++ b/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/Jackson.kt
@@ -1,6 +1,5 @@
 package io.bluetape4k.jackson
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.core.json.JsonReadFeature
 import com.fasterxml.jackson.databind.DeserializationFeature
@@ -9,7 +8,6 @@ import com.fasterxml.jackson.databind.ObjectWriter
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator
-import com.fasterxml.jackson.databind.jsontype.impl.StdTypeResolverBuilder
 import com.fasterxml.jackson.module.kotlin.KotlinFeature
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import io.bluetape4k.jackson.Jackson.defaultJsonMapper
@@ -22,17 +20,19 @@ import java.io.IOException
  * Bluetape4k 기본 Jackson 매퍼 구성을 제공하는 싱글턴입니다.
  *
  * ## 동작/계약
- * - [defaultJsonMapper], [typedJsonMapper]는 lazy 초기화 후 동일 인스턴스를 재사용합니다.
- * - `typed` 계열은 default typing 정보를 포함해 다형 타입 직렬화를 지원합니다.
+ * - [defaultJsonMapper] is lazily initialized and reused.
+ * - Use [createTypedJsonMapper] for allowlisted default typing.
+ * - [typedJsonMapper] is legacy compatibility API and must not be used for untrusted JSON.
  * - 매퍼 생성 중 I/O/설정 오류가 발생하면 [IllegalStateException]으로 전파됩니다.
  *
  * ```kotlin
  * val mapper = Jackson.defaultJsonMapper
- * val typedMapper = Jackson.typedJsonMapper
- * // mapper !== typedMapper
+ * val typedMapper = Jackson.createTypedJsonMapper("com.example.model.")
  * ```
  */
 object Jackson: KLogging() {
+
+    private const val DEFAULT_TYPE_PROPERTY_NAME = "@class"
 
     /** 기본 JsonMapper 인스턴스입니다. */
     val defaultJsonMapper: JsonMapper by lazy { createDefaultJsonMapper() }
@@ -69,19 +69,21 @@ object Jackson: KLogging() {
     }
 
     /**
-     * 사용자가 지정한 패키지만 허용하는 다형 타입 지원 [JsonMapper]를 생성합니다.
+     * Creates a [JsonMapper] that writes property-based type information and allows only trusted
+     * subtype packages.
      *
-     * ## 보안 주의
-     * - [allowedBasePackages]에 신뢰할 수 있는 패키지만 지정하세요.
-     * - 빈 목록은 허용되지 않으며 [IllegalArgumentException]을 발생시킵니다.
+     * ## Security contract
+     * - [allowedBasePackages] must contain trusted subtype package prefixes.
+     * - Empty allowlists are rejected with [IllegalArgumentException].
+     * - Type ids are written as the `@class` property and validated during polymorphic deserialization.
      *
      * ```kotlin
      * val mapper = Jackson.createTypedJsonMapper("com.example.", "io.myapp.")
-     * // 지정된 패키지의 타입만 다형 역직렬화 허용
+     * // Only subtypes under the supplied package prefixes are accepted.
      * ```
      *
-     * @param allowedBasePackages 허용할 기본 타입 패키지 접두사 목록 (예: `"com.example."`)
-     * @param typing 다형 타입 처리 전략 (기본값: [ObjectMapper.DefaultTyping.NON_FINAL_AND_ENUMS])
+     * @param allowedBasePackages Trusted subtype package prefixes, for example `"com.example."`.
+     * @param typing Default typing strategy. Defaults to [ObjectMapper.DefaultTyping.NON_FINAL_AND_ENUMS].
      */
     fun createTypedJsonMapper(
         vararg allowedBasePackages: String,
@@ -92,12 +94,12 @@ object Jackson: KLogging() {
         }
         log.info { "Create TypedJsonMapper ... allowedBasePackages=${allowedBasePackages.toList()}" }
         val validator = BasicPolymorphicTypeValidator.builder().apply {
-            allowedBasePackages.forEach { allowIfBaseType(it) }
+            allowedBasePackages.forEach { allowIfSubType(it) }
             allowIfSubTypeIsArray()
         }.build()
         return createDefaultJsonMapper().apply {
-            activateDefaultTyping(validator, typing)
-            initTypeInclusion(this)
+            activateDefaultTypingAsProperty(validator, typing, DEFAULT_TYPE_PROPERTY_NAME)
+            verifyTypeInclusion(this)
         }
     }
 
@@ -165,25 +167,20 @@ object Jackson: KLogging() {
                 // (CVE-2019-12384 계열 취약점 참고)
                 // 보안이 중요한 환경에서는 allowIfBaseType() 에 신뢰할 패키지만 명시적으로 지정하세요.
                 // 예: .allowIfBaseType("com.example.model")
-                activateDefaultTyping(
+                activateDefaultTypingAsProperty(
                     BasicPolymorphicTypeValidator.builder()
                         .allowIfBaseType(Any::class.java)
                         .allowIfSubTypeIsArray()
                         .build(),
-                    ObjectMapper.DefaultTyping.NON_FINAL_AND_ENUMS
+                    ObjectMapper.DefaultTyping.NON_FINAL_AND_ENUMS,
+                    DEFAULT_TYPE_PROPERTY_NAME
                 )
-                initTypeInclusion(this)
+                verifyTypeInclusion(this)
             }
         }
     }
 
-    private fun initTypeInclusion(mapper: JsonMapper) {
-        val mapTypers = StdTypeResolverBuilder().apply {
-            init(JsonTypeInfo.Id.CLASS, null)
-            inclusion(JsonTypeInfo.As.PROPERTY)
-        }
-        mapper.setDefaultTyping(mapTypers)
-
+    private fun verifyTypeInclusion(mapper: JsonMapper) {
         try {
             val s = mapper.writeValueAsBytes(1)
             mapper.readValue(s, Any::class.java)

--- a/io/jackson2/src/test/kotlin/com/example/disallowed/DisallowedTypedPayload.kt
+++ b/io/jackson2/src/test/kotlin/com/example/disallowed/DisallowedTypedPayload.kt
@@ -1,0 +1,11 @@
+package com.example.disallowed
+
+import java.io.Serializable
+
+internal data class DisallowedTypedPayload(
+    val value: String,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = -4314960917682563259L
+    }
+}

--- a/io/jackson2/src/test/kotlin/io/bluetape4k/jackson/JacksonTest.kt
+++ b/io/jackson2/src/test/kotlin/io/bluetape4k/jackson/JacksonTest.kt
@@ -1,15 +1,20 @@
 package io.bluetape4k.jackson
 
+import com.example.disallowed.DisallowedTypedPayload
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.bluetape4k.jackson.uuid.JsonUuidModule
-import io.bluetape4k.logging.KLogging
+import com.fasterxml.jackson.databind.exc.InvalidTypeIdException
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterThan
-import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldContainAll
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.jackson.uuid.JsonUuidModule
+import io.bluetape4k.logging.KLogging
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
+import java.io.Serializable
 
 class JacksonTest {
 
@@ -69,9 +74,70 @@ class JacksonTest {
     }
 
     @Test
+    fun `createTypedJsonMapper - allowed package payload round trips with property type info`() {
+        val mapper = Jackson.createTypedJsonMapper("io.bluetape4k.jackson.")
+        val original = TypedPayloadEnvelope(AllowedTypedPayload("safe"))
+
+        val json = mapper.writeValueAsString(original)
+        val restored = mapper.readValue(json, TypedPayloadEnvelope::class.java)
+
+        json shouldContain "\"@class\""
+        val payload = restored.payload.shouldBeInstanceOf<AllowedTypedPayload>()
+        payload.value shouldBeEqualTo "safe"
+    }
+
+    @Test
+    fun `createTypedJsonMapper - denied package payload is rejected`() {
+        val mapper = Jackson.createTypedJsonMapper("io.bluetape4k.jackson.")
+        val json = """
+            {
+              "payload": {
+                "@class": "${DisallowedTypedPayload::class.qualifiedName}",
+                "value": "blocked"
+              }
+            }
+        """.trimIndent()
+
+        assertFailsWith<InvalidTypeIdException> {
+            mapper.readValue(json, TypedPayloadEnvelope::class.java)
+        }
+    }
+
+    @Test
+    fun `createTypedJsonMapper - denied root payload is rejected`() {
+        val mapper = Jackson.createTypedJsonMapper("io.bluetape4k.jackson.")
+        val json = """
+            {
+              "@class": "${DisallowedTypedPayload::class.qualifiedName}",
+              "value": "blocked"
+            }
+        """.trimIndent()
+
+        assertFailsWith<InvalidTypeIdException> {
+            mapper.readValue(json, Any::class.java)
+        }
+    }
+
+    @Test
     fun `registeredModuleIdList - 등록된 모듈 ID를 List로 반환`() {
         val ids = Jackson.defaultJsonMapper.registeredModuleIdList()
         ids.shouldNotBeNull()
         (ids.isNotEmpty()).shouldBeTrue()
+    }
+}
+
+internal data class TypedPayloadEnvelope(
+    val payload: Any,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 8658783199380213352L
+    }
+}
+
+internal data class AllowedTypedPayload(
+    val value: String,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = -6573928863435706361L
     }
 }


### PR DESCRIPTION
## Summary

Closes #790

- PR 제목: fix: preserve Jackson2 typed mapper allowlist

- Preserve the `BasicPolymorphicTypeValidator` installed by `Jackson.createTypedJsonMapper(...)` by switching to `activateDefaultTypingAsProperty(...)` instead of replacing default typing with a raw resolver.
- Enforce the safe factory allowlist against subtype package prefixes with `allowIfSubType(...)`.
- Add root and nested disallowed-payload regression tests plus allowed-package round-trip coverage.
- Update Jackson2 README locale pair and durable review/lesson notes so deprecated `typedJsonMapper` is not promoted for untrusted JSON.

### 원문 선행 내용

Resolves #790

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- RED before fix: `createTypedJsonMapper - denied root payload is rejected` failed with `Expected InvalidTypeIdException but no exception was thrown`.
- `./gradlew :bluetape4k-jackson2:test --tests "io.bluetape4k.jackson.JacksonTest.createTypedJsonMapper*" --rerun-tasks --no-build-cache --no-daemon --no-configuration-cache`: 6 passing.
- `./gradlew :bluetape4k-jackson2:test --no-daemon --no-configuration-cache`: `BUILD SUCCESSFUL`.
- `./gradlew :bluetape4k-jackson2:compileTestKotlin --warning-mode all --rerun-tasks --no-daemon --no-configuration-cache`: `BUILD SUCCESSFUL`; only existing Gradle Kotlin DSL deprecation warnings from build scripts were reported.
- `git diff --check`: passed.
- GitHub PR checks: Build, CI Status, Coverage Report, Detect changed modules, Secret Scan, Validate Gradle Wrapper, and submit-gradle passed; unrelated module test jobs were skipped by the changed-module gate.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- No P0/P1 findings in `docs/review/2026-06-27-issue-790-jackson2-typed-mapper-allowlist-review.md`.
- Concurrency helper gate: not applicable. This is synchronous mapper construction/deserialization trust-boundary work with no shared mutable state, coroutine lifecycle, virtual-thread behavior, or structured task scope behavior.

## Metadata

- Issue: #790, milestone `1.11.0`, assignee `debop`
- PR: #930, head `04f444debcccb9195ad1ff678ee10b6919c719d9`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/jackson2-typed-mapper-allowlist`
- Labels: `bug`, `test`, `security`
- State: `MERGED`, merge commit `6ace3cc2a6109bcccd4a94e693efb33b6336aff4`
- CI: - Preserve the `BasicPolymorphicTypeValidator` installed by `Jackson.createTypedJsonMapper(...)` by switching to `activateDefaultTypingAsProperty(...)` instead of replacing default typing with a raw resolver. / - `./gradlew :bluetape4k-jackson2:test --tests "io.bluetape4k.jackson.JacksonTest.createTypedJsonMapper*" --rerun-tasks --no-build-cache --no-daemon --no-configuration-cache`: 6 passing. / - `./gradlew :bluetape4k-jackson2:test --no-daemon --no-configuration-cache`: `BUILD SUCCESSFUL`.

## DoD Status

| Step | Status | Evidence |
| --- | --- | --- |
| Workflow classification | PASS | Type C bug fix for issue #790. |
| W. Worktree and metadata | PASS | Branch `fix/jackson2-typed-mapper-allowlist`; issue assignee/milestone/labels mirrored to PR. |
| A. Acceptance | PASS | Disallowed root and nested polymorphic payloads rejected; allowed package payload round-trips with `@class`. |
| F. RED first | PASS | Root `Any` disallowed payload test failed before implementation. |
| 4-T. Implementation | PASS | Safe factory preserves Jackson PTV and uses subtype package allowlist. |
| 6-R. Regression tests | PASS | Targeted cache-free `createTypedJsonMapper*` tests: 6 passing. |
| README/docs | PASS | `io/jackson2/README.md` and `README.ko.md` updated. |
| Lessons | PASS | `docs/lessons/2026-06-27-issue-790-jackson2-typed-mapper-allowlist.md` added. |
| Review | PASS | Review doc records no P0/P1 findings and residual compatibility risk. |
| Verification | PASS | Full module test, `compileTestKotlin --warning-mode all --rerun-tasks`, GitHub PR checks, and `git diff --check` passed. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #930 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `6ace3cc2a6109bcccd4a94e693efb33b6336aff4`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
