### PR TITLE
docs: clarify Jackson Tink keyset durability

### DIFF
--- a/docs/lessons/2026-06-27-issue-791-jackson-tink-persistent-keyset-docs.md
+++ b/docs/lessons/2026-06-27-issue-791-jackson-tink-persistent-keyset-docs.md
@@ -1,0 +1,31 @@
+# Issue 791: Jackson Tink durable-search guidance
+
+## Context
+
+Jackson2 and Jackson3 field-encryption docs described `DETERMINISTIC_AES256_SIV` as suitable for DB search, but `@JsonTinkEncrypt` resolves algorithms through `TinkEncryptors` singleton instances. Those singleton keysets are generated in memory for the current JVM process, so persisted ciphertext can become unreadable or search-incompatible after restart, rollout, or multi-instance access.
+
+## Decision
+
+Use the documentation-safe fix path for this milestone issue: remove durable DB-search claims from Jackson field-encryption README/KDoc, keep the API behavior unchanged, and point durable searchable storage guidance to `bluetape4k-tink` versioned keyset APIs.
+
+## Outcome
+
+- Jackson2 and Jackson3 no longer promote `@JsonTinkEncrypt(DETERMINISTIC_AES256_SIV)` for durable DB search.
+- `JsonTinkEncrypt`, `TinkEncryptAlgorithm`, and `TinkEncryptors` KDoc now describe the process-local singleton-keyset boundary.
+- Tink README guidance now recommends `TinkDaeads.versioned(store)` with persisted AES-SIV keysets for durable searchable DB columns.
+
+## Verification
+
+- Red evidence: pre-change `rg` showed Jackson README/KDoc DB-search claims.
+- `rg -n "DB search|DB 검색|searchable in DB|DB 검색 가능" io/jackson2 io/jackson3 -g '*.md' -g '*.kt'` produced no matches after the fix.
+- `./gradlew :bluetape4k-jackson2:compileTestKotlin :bluetape4k-jackson3:compileTestKotlin :bluetape4k-tink:compileTestKotlin --warning-mode all --rerun-tasks --no-daemon --no-configuration-cache`
+- `./gradlew :bluetape4k-jackson2:test --tests "io.bluetape4k.jackson.crypto.JsonTinkEncryptTest" :bluetape4k-jackson3:test --tests "io.bluetape4k.jackson3.crypto.JsonTinkEncryptTest" :bluetape4k-tink:test --tests "io.bluetape4k.tink.encrypt.TinkEncryptorTest" --no-daemon --no-configuration-cache`
+- `git diff --check`
+
+## Future Guard
+
+Do not document process-local singleton encryptors as durable database storage helpers. If Jackson field encryption needs durable searchable storage later, add an explicit keyset/provider-backed API and tests that prove ciphertext survives keyset reload and remains searchable for deterministic fields.
+
+## Concurrency Helper Gate
+
+No new concurrency helper was needed because the change is documentation/KDoc only. Existing Jackson field-encryption tests already cover multithreading, coroutine suspend job, and virtual-thread execution and passed during this work.

--- a/docs/review/2026-06-27-issue-791-jackson-tink-persistent-keyset-docs-review.md
+++ b/docs/review/2026-06-27-issue-791-jackson-tink-persistent-keyset-docs-review.md
@@ -1,0 +1,36 @@
+# Issue 791 Review: Jackson Tink durable-search guidance
+
+## Scope
+
+- Jackson2 `@JsonTinkEncrypt` README and KDoc
+- Jackson3 `@JsonTinkEncrypt` README and KDoc
+- `TinkEncryptors` README and KDoc wording for singleton keysets
+- Durable storage guidance toward `TinkDaeads.versioned(store)` and `VersionedKeysetStore`
+
+## Findings
+
+No P0/P1 findings.
+
+## Checks
+
+- Jackson2 and Jackson3 no longer describe `@JsonTinkEncrypt(DETERMINISTIC_AES256_SIV)` as DB-search-capable durable storage.
+- `TinkEncryptAlgorithm` KDoc now explains that enum values resolve to process-local singleton encryptors.
+- `JsonTinkEncrypt` KDoc warns against using the annotation for durable encrypted database columns or searchable indexes.
+- Tink README guidance distinguishes durable searchable DB columns from process-local singleton deterministic equality.
+- `rg` over Jackson2/Jackson3 found no remaining `DB search`, `DB 검색`, or `searchable in DB` claims.
+
+## Verification Evidence
+
+- Red evidence before implementation: `rg` found Jackson2/Jackson3 README and KDoc claims that deterministic field encryption was suitable for DB search.
+- `:bluetape4k-jackson2:compileTestKotlin :bluetape4k-jackson3:compileTestKotlin :bluetape4k-tink:compileTestKotlin --warning-mode all --rerun-tasks`: passed; only existing root Gradle Kotlin DSL deprecation warnings were reported.
+- Targeted field-encryption tests passed: Jackson2 `JsonTinkEncryptTest` 14 passing, Jackson3 `JsonTinkEncryptTest` 14 passing, Tink `TinkEncryptorTest` 22 passing.
+- `git diff --check`: passed.
+- CodeGraph `detect_changes`: 11 changed files, 0 changed functions/classes, 0 affected flows, 0 test gaps, risk score 0.00.
+
+## Residual Risk
+
+This patch does not add keyset/provider-backed Jackson field encryption. That keeps the behavioral surface stable and satisfies the issue's documentation-safe acceptance path, but callers that need durable searchable JSON-field encryption still need a dedicated persisted-keyset integration rather than `@JsonTinkEncrypt`.
+
+## Concurrency Helper Gate
+
+No new `MultithreadingTester`, `SuspendedJobTester`, or `StructuredTaskScopeTester` coverage was added because this patch changes documentation and KDoc only. Existing Jackson2/Jackson3 `JsonTinkEncryptTest` coverage already exercises multithreaded, coroutine suspend job, and virtual-thread paths and passed unchanged.

--- a/io/jackson2/README.ko.md
+++ b/io/jackson2/README.ko.md
@@ -225,13 +225,18 @@ data class User(
     val username: String,
     @get:JsonTinkEncrypt                                               // AES256-GCM (기본값)
     val password: String,
-    @get:JsonTinkEncrypt(TinkEncryptAlgorithm.DETERMINISTIC_AES256_SIV) // DB 검색 가능한 결정적 암호화
+    @get:JsonTinkEncrypt(TinkEncryptAlgorithm.DETERMINISTIC_AES256_SIV) // 현재 JVM keyset 안에서만 결정적
     val mobile: String,
 )
 
 // 직렬화: { "username": "debop", "password": "AXYzK1...", "mobile": "BVp0..." }
 // 역직렬화 시 자동 복호화
 ```
+
+`@JsonTinkEncrypt`는 현재 JVM process에서 메모리로 생성되는 `TinkEncryptors` singleton keyset을 사용합니다.
+재시작, rollout, multi-instance 접근 이후에도 유지되어야 하는 DB 컬럼 암호화나 검색 index에는 이 annotation을
+사용하지 마세요. durable searchable storage가 필요하다면 보호된 `VersionedKeysetStore`와
+`TinkDaeads.versioned(store)` 같은 `bluetape4k-tink` versioned keyset API를 사용하세요.
 
 지원 알고리즘:
 
@@ -241,7 +246,7 @@ data class User(
 | `AES128_GCM`               | AES128-GCM 비결정적 암호화 — 성능 우선          |
 | `CHACHA20_POLY1305`        | ChaCha20-Poly1305 — HW AES 가속 없는 환경  |
 | `XCHACHA20_POLY1305`       | XChaCha20-Poly1305 — 큰 nonce(192bit) |
-| `DETERMINISTIC_AES256_SIV` | AES256-SIV 결정적 암호화 — DB 검색 가능        |
+| `DETERMINISTIC_AES256_SIV` | AES256-SIV 결정적 암호화 — 현재 process 안의 equality 확인용 |
 
 ### 7. 필드 마스킹 (@JsonMasker)
 

--- a/io/jackson2/README.md
+++ b/io/jackson2/README.md
@@ -94,7 +94,7 @@ Supported algorithms for `@JsonTinkEncrypt`:
 | `AES128_GCM`               | AES128-GCM non-deterministic — performance-focused                     |
 | `CHACHA20_POLY1305`        | ChaCha20-Poly1305 — for environments without hardware AES acceleration |
 | `XCHACHA20_POLY1305`       | XChaCha20-Poly1305 — large nonce (192-bit)                             |
-| `DETERMINISTIC_AES256_SIV` | AES256-SIV deterministic — searchable in DB                            |
+| `DETERMINISTIC_AES256_SIV` | AES256-SIV deterministic — process-local equality only                 |
 
 ### 7. Field Masking (@JsonMasker)
 
@@ -227,13 +227,18 @@ data class User(
     val username: String,
     @get:JsonTinkEncrypt                                               // AES256-GCM (default)
     val password: String,
-    @get:JsonTinkEncrypt(TinkEncryptAlgorithm.DETERMINISTIC_AES256_SIV) // deterministic encryption for DB search
+    @get:JsonTinkEncrypt(TinkEncryptAlgorithm.DETERMINISTIC_AES256_SIV) // deterministic within this JVM keyset
     val mobile: String,
 )
 
 // Serialized: { "username": "debop", "password": "AXYzK1...", "mobile": "BVp0..." }
 // Automatically decrypted on deserialization
 ```
+
+`@JsonTinkEncrypt` uses `TinkEncryptors` singleton instances, whose keysets are generated in memory for the
+current JVM process. Do not use this annotation for durable encrypted database columns or searchable indexes that must
+survive restart, rollout, or multi-instance access. For durable searchable storage, use `bluetape4k-tink` versioned
+keyset APIs such as `TinkDaeads.versioned(store)` with a protected `VersionedKeysetStore`.
 
 ### Field Masking
 

--- a/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/crypto/JsonTinkEncrypt.kt
+++ b/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/crypto/JsonTinkEncrypt.kt
@@ -5,12 +5,17 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 
 /**
- * 문자열 필드를 JSON 직렬화 시 Google Tink로 암호화하고 역직렬화 시 복호화하도록 지정하는 애너테이션입니다.
+ * Marks a string field for Google Tink encryption during JSON serialization and
+ * decryption during JSON deserialization.
  *
- * ## 동작/계약
- * - 직렬화는 [JsonTinkEncryptSerializer], 역직렬화는 [JsonTinkEncryptDeserializer]가 처리합니다.
- * - [algorithm]으로 지정한 [TinkEncryptAlgorithm]의 [TinkEncryptors] 인스턴스를 사용합니다.
- * - 필드 값 자체는 객체 메모리에서 변경하지 않고 JSON 표현만 암복호화합니다.
+ * ## Contract
+ * - Serialization is handled by [JsonTinkEncryptSerializer], and deserialization
+ *   is handled by [JsonTinkEncryptDeserializer].
+ * - The selected [algorithm] resolves to a [TinkEncryptors] singleton.
+ * - Singleton encryptors use process-local in-memory keysets; do not use this
+ *   annotation for durable encrypted database columns or searchable indexes.
+ * - The in-memory object value is unchanged; only the JSON representation is
+ *   encrypted or decrypted.
  *
  * ```kotlin
  * data class User(
@@ -18,11 +23,11 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize
  *     @get:JsonTinkEncrypt val password: String,
  *     @get:JsonTinkEncrypt(algorithm = TinkEncryptAlgorithm.DETERMINISTIC_AES256_SIV) val mobile: String,
  * )
- * // password 필드는 AES256-GCM 암호문 문자열로 직렬화됨
- * // mobile 필드는 결정적 AES256-SIV 암호문 문자열로 직렬화됨
+ * // password is serialized as an AES256-GCM ciphertext string.
+ * // mobile is serialized as a deterministic AES256-SIV ciphertext string for this JVM keyset.
  * ```
  *
- * @property algorithm 사용할 Tink 암호화 알고리즘 (기본값: [TinkEncryptAlgorithm.AES256_GCM])
+ * @property algorithm Tink encryption algorithm. Defaults to [TinkEncryptAlgorithm.AES256_GCM].
  */
 @JacksonAnnotationsInside
 @JsonSerialize(using = JsonTinkEncryptSerializer::class)

--- a/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/crypto/TinkEncryptAlgorithm.kt
+++ b/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/crypto/TinkEncryptAlgorithm.kt
@@ -4,9 +4,12 @@ import io.bluetape4k.tink.encrypt.TinkEncryptor
 import io.bluetape4k.tink.encrypt.TinkEncryptors
 
 /**
- * [JsonTinkEncrypt] 어노테이션에서 사용할 Tink 기반 암호화 알고리즘을 열거합니다.
+ * Tink-backed encryption algorithms used by [JsonTinkEncrypt].
  *
- * 각 값은 [TinkEncryptors] 싱글턴의 미리 구성된 [TinkEncryptor] 인스턴스에 매핑됩니다.
+ * Each enum value resolves to a preconfigured [TinkEncryptors] singleton. Those
+ * singleton encryptors use in-memory keysets generated for the current JVM
+ * process, so ciphertext is not durable across restart, rollout, or
+ * multi-instance access unless the caller uses a separate persisted keyset API.
  *
  * ```kotlin
  * val encryptor = TinkEncryptAlgorithm.AES256_GCM.getEncryptor()
@@ -15,25 +18,25 @@ import io.bluetape4k.tink.encrypt.TinkEncryptors
  */
 enum class TinkEncryptAlgorithm {
 
-    /** AES256-GCM 비결정적 암호화 — 범용 AEAD, 권장 기본값 */
+    /** AES256-GCM non-deterministic encryption for general-purpose AEAD use. */
     AES256_GCM,
 
-    /** AES128-GCM 비결정적 암호화 — 성능 우선 환경 */
+    /** AES128-GCM non-deterministic encryption for performance-focused use. */
     AES128_GCM,
 
-    /** ChaCha20-Poly1305 비결정적 암호화 — 하드웨어 AES 가속이 없는 환경 */
+    /** ChaCha20-Poly1305 non-deterministic encryption for environments without hardware AES acceleration. */
     CHACHA20_POLY1305,
 
-    /** XChaCha20-Poly1305 비결정적 암호화 — 큰 nonce(192bit)로 재사용 위험 감소 */
+    /** XChaCha20-Poly1305 non-deterministic encryption with a 192-bit nonce. */
     XCHACHA20_POLY1305,
 
-    /** AES256-SIV 결정적 암호화 — 동일 평문에 동일 암호문, DB 검색 가능 */
+    /** AES256-SIV deterministic encryption for process-local equality checks only. */
     DETERMINISTIC_AES256_SIV;
 
     /**
-     * 이 알고리즘에 대응하는 [TinkEncryptor] 인스턴스를 반환합니다.
+     * Returns the singleton [TinkEncryptor] mapped to this algorithm.
      *
-     * @return 미리 구성된 [TinkEncryptor] 인스턴스
+     * @return preconfigured singleton [TinkEncryptor].
      */
     fun getEncryptor(): TinkEncryptor = when (this) {
         AES256_GCM         -> TinkEncryptors.AES256_GCM

--- a/io/jackson3/README.ko.md
+++ b/io/jackson3/README.ko.md
@@ -223,7 +223,7 @@ data class User(
     val username: String,
     @get:JsonTinkEncrypt                                               // AES256-GCM (기본값)
     val password: String,
-    @get:JsonTinkEncrypt(TinkEncryptAlgorithm.DETERMINISTIC_AES256_SIV) // DB 검색 가능한 결정적 암호화
+    @get:JsonTinkEncrypt(TinkEncryptAlgorithm.DETERMINISTIC_AES256_SIV) // 현재 JVM keyset 안에서만 결정적
     val mobile: String,
 )
 
@@ -236,6 +236,11 @@ val mapper = Jackson.createDefaultJsonMapper().rebuild()
 // 역직렬화 시 자동 복호화
 ```
 
+`@JsonTinkEncrypt`는 현재 JVM process에서 메모리로 생성되는 `TinkEncryptors` singleton keyset을 사용합니다.
+재시작, rollout, multi-instance 접근 이후에도 유지되어야 하는 DB 컬럼 암호화나 검색 index에는 이 annotation을
+사용하지 마세요. durable searchable storage가 필요하다면 보호된 `VersionedKeysetStore`와
+`TinkDaeads.versioned(store)` 같은 `bluetape4k-tink` versioned keyset API를 사용하세요.
+
 지원 알고리즘:
 
 | `TinkEncryptAlgorithm`     | 설명                                   |
@@ -244,7 +249,7 @@ val mapper = Jackson.createDefaultJsonMapper().rebuild()
 | `AES128_GCM`               | AES128-GCM 비결정적 암호화 — 성능 우선          |
 | `CHACHA20_POLY1305`        | ChaCha20-Poly1305 — HW AES 가속 없는 환경  |
 | `XCHACHA20_POLY1305`       | XChaCha20-Poly1305 — 큰 nonce(192bit) |
-| `DETERMINISTIC_AES256_SIV` | AES256-SIV 결정적 암호화 — DB 검색 가능        |
+| `DETERMINISTIC_AES256_SIV` | AES256-SIV 결정적 암호화 — 현재 process 안의 equality 확인용 |
 
 ### 7. 필드 마스킹 (@JsonMasker)
 

--- a/io/jackson3/README.md
+++ b/io/jackson3/README.md
@@ -227,7 +227,7 @@ data class User(
     val username: String,
     @get:JsonTinkEncrypt                                               // AES256-GCM (default)
     val password: String,
-    @get:JsonTinkEncrypt(TinkEncryptAlgorithm.DETERMINISTIC_AES256_SIV) // deterministic encryption for DB search
+    @get:JsonTinkEncrypt(TinkEncryptAlgorithm.DETERMINISTIC_AES256_SIV) // deterministic within this JVM keyset
     val mobile: String,
 )
 
@@ -240,6 +240,11 @@ val mapper = Jackson.createDefaultJsonMapper().rebuild()
 // Automatically decrypted on deserialization
 ```
 
+`@JsonTinkEncrypt` uses `TinkEncryptors` singleton instances, whose keysets are generated in memory for the
+current JVM process. Do not use this annotation for durable encrypted database columns or searchable indexes that must
+survive restart, rollout, or multi-instance access. For durable searchable storage, use `bluetape4k-tink` versioned
+keyset APIs such as `TinkDaeads.versioned(store)` with a protected `VersionedKeysetStore`.
+
 Supported algorithms:
 
 | `TinkEncryptAlgorithm`     | Description                                                            |
@@ -248,7 +253,7 @@ Supported algorithms:
 | `AES128_GCM`               | AES128-GCM non-deterministic — performance-focused                     |
 | `CHACHA20_POLY1305`        | ChaCha20-Poly1305 — for environments without hardware AES acceleration |
 | `XCHACHA20_POLY1305`       | XChaCha20-Poly1305 — large nonce (192-bit)                             |
-| `DETERMINISTIC_AES256_SIV` | AES256-SIV deterministic — searchable in DB                            |
+| `DETERMINISTIC_AES256_SIV` | AES256-SIV deterministic — process-local equality only                 |
 
 ### 7. Field Masking (@JsonMasker)
 

--- a/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/crypto/JsonTinkEncrypt.kt
+++ b/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/crypto/JsonTinkEncrypt.kt
@@ -3,12 +3,17 @@ package io.bluetape4k.jackson3.crypto
 import com.fasterxml.jackson.annotation.JacksonAnnotationsInside
 
 /**
- * 문자열 필드를 JSON 직렬화 시 Google Tink로 암호화하고 역직렬화 시 복호화하도록 지정하는 애너테이션입니다.
+ * Marks a string field for Google Tink encryption during JSON serialization and
+ * decryption during JSON deserialization.
  *
- * ## 동작/계약
- * - [JsonTinkEncryptModule] 등록 시 [JsonTinkEncryptAnnotationIntrospector]가 serializer/deserializer를 선택합니다.
- * - [algorithm]으로 지정한 [TinkEncryptAlgorithm]의 [TinkEncryptors] 인스턴스를 사용합니다.
- * - 객체 내부 값은 변경하지 않고 JSON 표현만 암복호화합니다.
+ * ## Contract
+ * - [JsonTinkEncryptModule] registers [JsonTinkEncryptAnnotationIntrospector] to
+ *   select the serializer and deserializer.
+ * - The selected [algorithm] resolves to a [TinkEncryptors] singleton.
+ * - Singleton encryptors use process-local in-memory keysets; do not use this
+ *   annotation for durable encrypted database columns or searchable indexes.
+ * - The in-memory object value is unchanged; only the JSON representation is
+ *   encrypted or decrypted.
  *
  * ```kotlin
  * data class User(
@@ -16,11 +21,11 @@ import com.fasterxml.jackson.annotation.JacksonAnnotationsInside
  *     @get:JsonTinkEncrypt val password: String,
  *     @get:JsonTinkEncrypt(algorithm = TinkEncryptAlgorithm.DETERMINISTIC_AES256_SIV) val mobile: String,
  * )
- * // password 필드는 AES256-GCM 암호문 문자열로 직렬화됨
- * // mobile 필드는 결정적 AES256-SIV 암호문 문자열로 직렬화됨
+ * // password is serialized as an AES256-GCM ciphertext string.
+ * // mobile is serialized as a deterministic AES256-SIV ciphertext string for this JVM keyset.
  * ```
  *
- * @property algorithm 사용할 Tink 암호화 알고리즘 (기본값: [TinkEncryptAlgorithm.AES256_GCM])
+ * @property algorithm Tink encryption algorithm. Defaults to [TinkEncryptAlgorithm.AES256_GCM].
  */
 @JacksonAnnotationsInside
 @Retention(AnnotationRetention.RUNTIME)

--- a/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/crypto/TinkEncryptAlgorithm.kt
+++ b/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/crypto/TinkEncryptAlgorithm.kt
@@ -4,9 +4,12 @@ import io.bluetape4k.tink.encrypt.TinkEncryptor
 import io.bluetape4k.tink.encrypt.TinkEncryptors
 
 /**
- * [JsonTinkEncrypt] 어노테이션에서 사용할 Tink 기반 암호화 알고리즘을 열거합니다.
+ * Tink-backed encryption algorithms used by [JsonTinkEncrypt].
  *
- * 각 값은 [TinkEncryptors] 싱글턴의 미리 구성된 [TinkEncryptor] 인스턴스에 매핑됩니다.
+ * Each enum value resolves to a preconfigured [TinkEncryptors] singleton. Those
+ * singleton encryptors use in-memory keysets generated for the current JVM
+ * process, so ciphertext is not durable across restart, rollout, or
+ * multi-instance access unless the caller uses a separate persisted keyset API.
  *
  * ```kotlin
  * val encryptor = TinkEncryptAlgorithm.AES256_GCM.getEncryptor()
@@ -15,25 +18,25 @@ import io.bluetape4k.tink.encrypt.TinkEncryptors
  */
 enum class TinkEncryptAlgorithm {
 
-    /** AES256-GCM 비결정적 암호화 — 범용 AEAD, 권장 기본값 */
+    /** AES256-GCM non-deterministic encryption for general-purpose AEAD use. */
     AES256_GCM,
 
-    /** AES128-GCM 비결정적 암호화 — 성능 우선 환경 */
+    /** AES128-GCM non-deterministic encryption for performance-focused use. */
     AES128_GCM,
 
-    /** ChaCha20-Poly1305 비결정적 암호화 — 하드웨어 AES 가속이 없는 환경 */
+    /** ChaCha20-Poly1305 non-deterministic encryption for environments without hardware AES acceleration. */
     CHACHA20_POLY1305,
 
-    /** XChaCha20-Poly1305 비결정적 암호화 — 큰 nonce(192bit)로 재사용 위험 감소 */
+    /** XChaCha20-Poly1305 non-deterministic encryption with a 192-bit nonce. */
     XCHACHA20_POLY1305,
 
-    /** AES256-SIV 결정적 암호화 — 동일 평문에 동일 암호문, DB 검색 가능 */
+    /** AES256-SIV deterministic encryption for process-local equality checks only. */
     DETERMINISTIC_AES256_SIV;
 
     /**
-     * 이 알고리즘에 대응하는 [TinkEncryptor] 인스턴스를 반환합니다.
+     * Returns the singleton [TinkEncryptor] mapped to this algorithm.
      *
-     * @return 미리 구성된 [TinkEncryptor] 인스턴스
+     * @return preconfigured singleton [TinkEncryptor].
      */
     fun getEncryptor(): TinkEncryptor = when (this) {
         AES256_GCM         -> TinkEncryptors.AES256_GCM

--- a/io/tink/README.ko.md
+++ b/io/tink/README.ko.md
@@ -43,8 +43,8 @@ raw JCA/JCE API를 직접 사용할 때 실수하기 쉬운 nonce 처리, cipher
 
 - **Context binding이 필요한 애플리케이션 데이터 암호화**: `TinkAeads.AES256_GCM`을 사용하고 tenant ID,
   entity ID, column name 같은 associated data를 전달합니다.
-- **검색 가능한 DB 컬럼 암호화**: `TinkDaeads.AES256_SIV` 또는
-  `TinkEncryptors.DETERMINISTIC_AES256_SIV`를 사용합니다. 같은 평문은 같은 암호문이 된다는 점을 수용해야 합니다.
+- **검색 가능하면서 durable한 DB 컬럼 암호화**: persisted AES-SIV keyset store와
+  `TinkDaeads.versioned(store)`를 사용합니다. 같은 평문은 같은 암호문이 된다는 점을 수용해야 합니다.
 - **Key rotation 이후에도 기존 ciphertext 복호화가 필요할 때**: `TinkAeads.versioned(store)` 또는
   `TinkDaeads.versioned(store)`를 사용해 ciphertext에 keyset version을 포함합니다.
 - **여러 서비스가 active keyset을 공유해야 할 때**: Redis 기반 `VersionedKeysetStore`를 사용하되 Redis를
@@ -233,7 +233,7 @@ import io.bluetape4k.tink.encrypt.tinkDecrypt
 val encrypted = TinkEncryptors.AES256_GCM.encrypt("비밀 메시지")
 val decrypted = TinkEncryptors.AES256_GCM.decrypt(encrypted)
 
-// 결정적 암호화 (DB 검색용)
+// 현재 process 안의 결정적 암호화. durable DB 검색에는 singleton key를 사용하지 마세요.
 val ct = TinkEncryptors.DETERMINISTIC_AES256_SIV.encrypt("검색 가능한 필드")
 val ct2 = TinkEncryptors.DETERMINISTIC_AES256_SIV.encrypt("검색 가능한 필드")
 // ct == ct2 (결정적)
@@ -249,7 +249,7 @@ val dec = enc.tinkDecrypt(TinkEncryptors.CHACHA20_POLY1305)
 |-----------------|------------------------|----------------------------------------------------------------------|
 | 범용 암호화          | AES-256-GCM            | `TinkAeads.AES256_GCM` / `TinkEncryptors.AES256_GCM`                 |
 | 하드웨어 AES 없는 환경  | XChaCha20-Poly1305     | `TinkAeads.XCHACHA20_POLY1305` / `TinkEncryptors.XCHACHA20_POLY1305` |
-| DB 컬럼 검색 가능 암호화 | AES-256-SIV            | `TinkDaeads.AES256_SIV` / `TinkEncryptors.DETERMINISTIC_AES256_SIV`  |
+| durable DB 컬럼 검색 암호화 | AES-256-SIV            | persisted AES-SIV keyset store를 사용하는 `TinkDaeads.versioned(store)` |
 | 데이터 무결성 검증      | HMAC-SHA256            | `TinkMacs.HMAC_SHA256`                                               |
 | 고보안 무결성 검증      | HMAC-SHA512 (512비트 태그) | `TinkMacs.HMAC_SHA512_512BITTAG`                                     |
 | 범용 해시           | SHA-256                | `TinkDigesters.SHA256`                                               |

--- a/io/tink/README.md
+++ b/io/tink/README.md
@@ -47,8 +47,8 @@ Use this module when:
 - **Application data must be encrypted with context binding**: use
   `TinkAeads.AES256_GCM` and pass associated data such as tenant ID, entity ID,
   or column name.
-- **A database column must remain searchable**: use
-  `TinkDaeads.AES256_SIV` or `TinkEncryptors.DETERMINISTIC_AES256_SIV`, and
+- **A database column must remain searchable and durable**: use
+  `TinkDaeads.versioned(store)` with a persisted AES-SIV keyset store, and
   accept that repeated plaintext values produce repeated ciphertext values.
 - **Ciphertexts must survive key rotation**: use `TinkAeads.versioned(store)` or
   `TinkDaeads.versioned(store)` so ciphertext includes the keyset version.
@@ -248,7 +248,7 @@ import io.bluetape4k.tink.encrypt.tinkDecrypt
 val encrypted = TinkEncryptors.AES256_GCM.encrypt("secret message")
 val decrypted = TinkEncryptors.AES256_GCM.decrypt(encrypted)
 
-// Deterministic encryption (for DB search)
+// Process-local deterministic encryption. Do not use singleton keys for durable DB search.
 val ct = TinkEncryptors.DETERMINISTIC_AES256_SIV.encrypt("searchable field")
 val ct2 = TinkEncryptors.DETERMINISTIC_AES256_SIV.encrypt("searchable field")
 // ct == ct2 (deterministic)
@@ -264,7 +264,7 @@ val dec = enc.tinkDecrypt(TinkEncryptors.CHACHA20_POLY1305)
 |--------------------------------------|---------------------------|----------------------------------------------------------------------|
 | General encryption                   | AES-256-GCM               | `TinkAeads.AES256_GCM` / `TinkEncryptors.AES256_GCM`                 |
 | No hardware AES acceleration         | XChaCha20-Poly1305        | `TinkAeads.XCHACHA20_POLY1305` / `TinkEncryptors.XCHACHA20_POLY1305` |
-| Searchable DB column encryption      | AES-256-SIV               | `TinkDaeads.AES256_SIV` / `TinkEncryptors.DETERMINISTIC_AES256_SIV`  |
+| Durable searchable DB column         | AES-256-SIV               | `TinkDaeads.versioned(store)` with a persisted AES-SIV keyset store  |
 | Data integrity verification          | HMAC-SHA256               | `TinkMacs.HMAC_SHA256`                                               |
 | High-security integrity verification | HMAC-SHA512 (512-bit tag) | `TinkMacs.HMAC_SHA512_512BITTAG`                                     |
 | General-purpose hash                 | SHA-256                   | `TinkDigesters.SHA256`                                               |

--- a/io/tink/src/main/kotlin/io/bluetape4k/tink/encrypt/TinkEncryptors.kt
+++ b/io/tink/src/main/kotlin/io/bluetape4k/tink/encrypt/TinkEncryptors.kt
@@ -13,19 +13,21 @@ import io.bluetape4k.tink.daeadKeysetHandle
 import io.bluetape4k.tink.registerTink
 
 /**
- * 미리 구성된 [TinkEncryptor] 인스턴스를 제공하는 팩토리 싱글턴입니다.
+ * Factory singleton for preconfigured [TinkEncryptor] instances.
  *
- * AEAD(비결정적)와 Deterministic AEAD(결정적) 암호화 구현체를 모두 제공합니다.
- * 각 인스턴스는 lazy 초기화되며, 서로 다른 키를 사용하므로
- * 같은 알고리즘이라도 교차 복호화가 불가능합니다.
+ * The singleton encryptors are lazily initialized with process-local in-memory
+ * keysets. They are useful for ephemeral JSON/document protection, examples,
+ * and tests, but must not be used for durable ciphertext that must survive JVM
+ * restart, rollout, or multi-instance access. Use versioned keyset APIs when
+ * ciphertext is persisted.
  *
  * ```kotlin
- * // 비결정적 암호화 (범용)
+ * // Non-deterministic encryption for ephemeral data.
  * val encrypted = TinkEncryptors.AES256_GCM.encrypt("Hello, World!")
  * val decrypted = TinkEncryptors.AES256_GCM.decrypt(encrypted)
  *
- * // 결정적 암호화 (DB 검색용)
- * val ct = TinkEncryptors.DETERMINISTIC_AES256_SIV.encrypt("검색 가능한 필드")
+ * // Deterministic equality within this singleton keyset only.
+ * val ct = TinkEncryptors.DETERMINISTIC_AES256_SIV.encrypt("searchable field")
  * ```
  */
 object TinkEncryptors: KLogging() {
@@ -34,27 +36,27 @@ object TinkEncryptors: KLogging() {
         registerTink()
     }
 
-    /** AES256-GCM 기반 비결정적 암호화. 범용 인증 암호화에 권장됩니다. */
+    /** AES256-GCM non-deterministic encryption for general authenticated encryption. */
     val AES256_GCM: TinkEncryptor by publicLazy {
         TinkAeadEncryptor(TinkAead(aeadKeysetHandle(AesGcmKeyManager.aes256GcmTemplate())))
     }
 
-    /** AES128-GCM 기반 비결정적 암호화. 성능이 중요한 경우 사용합니다. */
+    /** AES128-GCM non-deterministic encryption for performance-focused use. */
     val AES128_GCM: TinkEncryptor by publicLazy {
         TinkAeadEncryptor(TinkAead(aeadKeysetHandle(AesGcmKeyManager.aes128GcmTemplate())))
     }
 
-    /** ChaCha20-Poly1305 기반 비결정적 암호화. 하드웨어 AES 가속이 없는 환경에 적합합니다. */
+    /** ChaCha20-Poly1305 non-deterministic encryption for environments without hardware AES acceleration. */
     val CHACHA20_POLY1305: TinkEncryptor by publicLazy {
         TinkAeadEncryptor(TinkAead(aeadKeysetHandle(ChaCha20Poly1305KeyManager.chaCha20Poly1305Template())))
     }
 
-    /** XChaCha20-Poly1305 기반 비결정적 암호화. 더 큰 nonce(192bit)로 nonce 재사용 위험을 줄입니다. */
+    /** XChaCha20-Poly1305 non-deterministic encryption with a 192-bit nonce. */
     val XCHACHA20_POLY1305: TinkEncryptor by publicLazy {
         TinkAeadEncryptor(TinkAead(aeadKeysetHandle(XChaCha20Poly1305KeyManager.xChaCha20Poly1305Template())))
     }
 
-    /** AES256-SIV 기반 결정적 암호화. 동일 평문에 동일 암호문을 생성하여 DB 검색이 가능합니다. */
+    /** AES256-SIV deterministic encryption for process-local equality checks only. */
     val DETERMINISTIC_AES256_SIV: TinkEncryptor by publicLazy {
         TinkDaeadEncryptor(TinkDeterministicAead(daeadKeysetHandle(AesSivKeyManager.aes256SivTemplate())))
     }


### PR DESCRIPTION
## Summary

Closes #791

- PR 제목: docs: clarify Jackson Tink keyset durability

- Remove Jackson2/Jackson3 field-encryption README and KDoc claims that `DETERMINISTIC_AES256_SIV` is suitable for durable DB search through `@JsonTinkEncrypt`.
- Document that `@JsonTinkEncrypt` resolves to `TinkEncryptors` singleton instances with process-local in-memory keysets.
- Point durable searchable storage guidance to `bluetape4k-tink` versioned keyset APIs such as `TinkDaeads.versioned(store)` with a protected `VersionedKeysetStore`.
- Record review and lesson notes for the singleton-keyset documentation boundary.

### 원문 선행 내용

Resolves #791

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- RED evidence before fix: `rg` found Jackson2/Jackson3 README and KDoc DB-search claims for deterministic field encryption.
- `rg -n "DB search|DB 검색|searchable in DB|DB 검색 가능" io/jackson2 io/jackson3 -g '*.md' -g '*.kt'`: no matches after the fix.
- `./gradlew :bluetape4k-jackson2:compileTestKotlin :bluetape4k-jackson3:compileTestKotlin :bluetape4k-tink:compileTestKotlin --warning-mode all --rerun-tasks --no-daemon --no-configuration-cache`: `BUILD SUCCESSFUL`; only existing root Gradle Kotlin DSL deprecation warnings were reported.
- `./gradlew :bluetape4k-jackson2:test --tests "io.bluetape4k.jackson.crypto.JsonTinkEncryptTest" :bluetape4k-jackson3:test --tests "io.bluetape4k.jackson3.crypto.JsonTinkEncryptTest" :bluetape4k-tink:test --tests "io.bluetape4k.tink.encrypt.TinkEncryptorTest" --no-daemon --no-configuration-cache`: Jackson2 14 passing, Jackson3 14 passing, Tink 22 passing.
- `git diff --check`: passed.
- CodeGraph `detect_changes`: 11 changed files, 0 changed functions/classes, 0 affected flows, 0 test gaps, risk score 0.00.
- GitHub PR checks: Build, CI Status, Coverage Report, Detect changed modules, Secret Scan, Test / IO, Validate Gradle Wrapper, and submit-gradle passed; unrelated module test jobs were skipped by the changed-module gate.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- No P0/P1 findings in `docs/review/2026-06-27-issue-791-jackson-tink-persistent-keyset-docs-review.md`.
- Concurrency helper gate: no new helper was needed because this is documentation/KDoc only. Existing Jackson field-encryption tests already cover multithreading, coroutine suspend job, and virtual-thread execution and passed unchanged.
- This PR intentionally does not add a keyset/provider-backed Jackson field-encryption API; that is a broader API design and test-scope decision.

## Metadata

- Issue: #791, milestone `1.11.0`, assignee `debop`
- PR: #931, head `e3edc16109e50fc76c04fbd8991c8fed67fa2a2b`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/jackson-tink-docs-persistent-keysets`
- Labels: `bug`, `documentation`, `security`
- State: `MERGED`, merge commit `f3a21dfe387034c1e9e8ddd82698e0347b607ff6`
- CI: - `./gradlew :bluetape4k-jackson2:compileTestKotlin :bluetape4k-jackson3:compileTestKotlin :bluetape4k-tink:compileTestKotlin --warning-mode all --rerun-tasks --no-daemon --no-configuration-cache`: `BUILD SUCCESSFUL`; only existing root Gradle Kotlin DSL deprecation warnings were reported. / - `./gradlew :bluetape4k-jackson2:test --tests "io.bluetape4k.jackson.crypto.JsonTinkEncryptTest" :bluetape4k-jackson3:test --tests "io.bluetape4k.jackson3.crypto.JsonTinkEncryptTest" :bluetape4k-tink:test --tests "io.bluetape4k.tink.encrypt.TinkEncryptorTest" --no-daemon --no-configuration-cache`: Jackson2 14 passing, Jackson3 14 passing, Tink 22 passing. / - GitHub PR checks: Build, CI Status, Coverage Report, Detect changed modules, Secret Scan, Test / IO, Validate Gradle Wrapper, and submit-gradle passed; unrelated module test jobs were skipped by the changed-module gate.

## DoD Status

| Step | Status | Evidence |
| --- | --- | --- |
| Workflow classification | PASS | Type C bug/documentation fix for issue #791. |
| W. Worktree and metadata | PASS | Branch `fix/jackson-tink-docs-persistent-keysets`; issue assignee/milestone/labels mirrored to PR. |
| A. Acceptance | PASS | Jackson docs/KDoc no longer imply durable DB-search support; README points durable searchable storage to versioned keysets. |
| F. RED first | PASS | Pre-change `rg` found the DB-search claims listed in #791 evidence. |
| 4-T. Implementation | PASS | README/KDoc wording corrected without changing runtime API behavior. |
| 6-R. Regression tests | PASS | Jackson2/Jackson3 `JsonTinkEncryptTest` and Tink `TinkEncryptorTest` passed. |
| Documentation | PASS | Jackson2/Jackson3 and Tink README locale pairs updated. |
| Lessons | PASS | `docs/lessons/2026-06-27-issue-791-jackson-tink-persistent-keyset-docs.md` added. |
| Review | PASS | Review doc records no P0/P1 findings and residual API-design risk. |
| Verification | PASS | Claim-removal `rg`, compileTestKotlin, targeted tests, CodeGraph, GitHub PR checks, and `git diff --check` passed. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #931 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `f3a21dfe387034c1e9e8ddd82698e0347b607ff6`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
