### PR TITLE
fix: align Kafka 4 test runtime with Spring Kafka

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -110,7 +110,7 @@ elasticsearch = "9.4.0"  # https://mvnrepository.com/artifact/org.elasticsearch.
 elasticsearch-java = "9.4.0"  # https://mvnrepository.com/artifact/co.elastic.clients/elasticsearch-java
 
 kafka3 = "3.9.2"  # https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients; Server-side: spring-kafka 3.x embedded test (EmbeddedKafkaKraftBroker)
-kafka4 = "4.3.1"  # https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients; Client-side: kafka-clients, kafka-streams (production)
+kafka4 = "4.2.1"  # https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients; Spring Kafka 4.1 embedded-test ABI
 spring-kafka = "3.3.16"  # https://mvnrepository.com/artifact/org.springframework.kafka/spring-kafka
 spring-kafka4 = "4.1.0"  # https://mvnrepository.com/artifact/org.springframework.kafka/spring-kafka
 


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: align Kafka 4 test runtime with Spring Kafka

- Align `kafka4` to Kafka 4.2.1 so Spring Kafka 4.1.0 embedded KRaft tests keep the required `KafkaClusterTestKit.clientProperties()` ABI.
- Unblock the Projects 1.11.0 Nightly(full) `kafka-resilience` matrix before stable release.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary
- Align `kafka4` to Kafka 4.2.1 so Spring Kafka 4.1.0 embedded KRaft tests keep the required `KafkaClusterTestKit.clientProperties()` ABI.
- Unblock the Projects 1.11.0 Nightly(full) `kafka-resilience` matrix before stable release.

### Validation
- `./gradlew :bluetape4k-kafka4:dependencyInsight --configuration testRuntimeClasspath --dependency org.apache.kafka:kafka-clients --no-daemon --no-configuration-cache --no-build-cache`
- `./gradlew :bluetape4k-kafka:test :bluetape4k-kafka4:test :bluetape4k-resilience4j:test :bluetape4k-bucket4j:test --no-daemon --no-configuration-cache --no-build-cache`
- `./gradlew :bluetape4k-kafka:koverXmlReport :bluetape4k-kafka4:koverXmlReport :bluetape4k-resilience4j:koverXmlReport :bluetape4k-bucket4j:koverXmlReport --no-daemon --no-configuration-cache --no-build-cache`
- `git diff --check`
- GitHub PR CI: all checks passed on runs `28291105084` and `28291096461`.

### DoD Status
- [x] Root cause identified from Nightly(full) run `28290549379`: Kafka 4.3.1 removed the embedded-test ABI required by `spring-kafka-test` 4.1.0.
- [x] Local kafka-resilience test and Kover matrix tasks pass after the fix.
- [x] GitHub CI is green.
- [ ] PR is merged and Nightly(full) is rerun on `develop`.

## Validation

- `./gradlew :bluetape4k-kafka4:dependencyInsight --configuration testRuntimeClasspath --dependency org.apache.kafka:kafka-clients --no-daemon --no-configuration-cache --no-build-cache`
- `./gradlew :bluetape4k-kafka:test :bluetape4k-kafka4:test :bluetape4k-resilience4j:test :bluetape4k-bucket4j:test --no-daemon --no-configuration-cache --no-build-cache`
- `./gradlew :bluetape4k-kafka:koverXmlReport :bluetape4k-kafka4:koverXmlReport :bluetape4k-resilience4j:koverXmlReport :bluetape4k-bucket4j:koverXmlReport --no-daemon --no-configuration-cache --no-build-cache`
- `git diff --check`
- GitHub PR CI: all checks passed on runs `28291105084` and `28291096461`.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #933, head `4ffad5e88b72b7bbd5afe8ec778527715fec6182`, milestone `1.11.0`, assignee `debop`
- Base: `develop`, head branch `fix/projects-kafka4-nightly`
- Labels: `bug`, `ci`, `release`
- State: `MERGED`, merge commit `6187173b58e8b4c5c435c145e00e94708f31ef75`
- CI: - `./gradlew :bluetape4k-kafka4:dependencyInsight --configuration testRuntimeClasspath --dependency org.apache.kafka:kafka-clients --no-daemon --no-configuration-cache --no-build-cache` / - `./gradlew :bluetape4k-kafka:test :bluetape4k-kafka4:test :bluetape4k-resilience4j:test :bluetape4k-bucket4j:test --no-daemon --no-configuration-cache --no-build-cache` / - `./gradlew :bluetape4k-kafka:koverXmlReport :bluetape4k-kafka4:koverXmlReport :bluetape4k-resilience4j:koverXmlReport :bluetape4k-bucket4j:koverXmlReport --no-daemon --no-configuration-cache --no-build-cache`

## DoD Status

- [x] Root cause identified from Nightly(full) run `28290549379`: Kafka 4.3.1 removed the embedded-test ABI required by `spring-kafka-test` 4.1.0.
- [x] Local kafka-resilience test and Kover matrix tasks pass after the fix.
- [x] GitHub CI is green.
- [ ] PR is merged and Nightly(full) is rerun on `develop`.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #933 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `6187173b58e8b4c5c435c145e00e94708f31ef75`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
