### PR TITLE
feat: add refreshing JDBC password DataSource

### DIFF
--- a/data/jdbc/README.ko.md
+++ b/data/jdbc/README.ko.md
@@ -58,6 +58,69 @@ dataSource.withConnect { conn ->
 }
 ```
 
+#### 갱신형 비밀번호 DataSource
+
+`RefreshingJdbcPasswordDataSource`는 물리 JDBC 연결마다 비밀번호가 달라질
+수 있는 환경을 위한 작은 `DriverManager` 기반 `DataSource`입니다. 예를
+들어 클라우드에서 생성하는 데이터베이스 토큰을 사용할 때, 인자 없는
+`getConnection()` 호출마다 비밀번호 provider를 호출한 뒤
+`DriverManager.getConnection(url, properties)`에 위임합니다.
+
+```kotlin
+import io.bluetape4k.jdbc.datasource.JdbcPasswordProvider
+import io.bluetape4k.jdbc.datasource.RefreshingJdbcPasswordDataSource
+import io.bluetape4k.jdbc.datasource.RefreshingJdbcPasswordDataSourceConfig
+
+val refreshingDataSource = RefreshingJdbcPasswordDataSource(
+    config = RefreshingJdbcPasswordDataSourceConfig(
+        url = "jdbc:postgresql://localhost:5432/app",
+        driverClassName = "org.postgresql.Driver",
+        username = "app_user",
+        dataSourceProperties = mapOf("sslmode" to "require"),
+    ),
+    passwordProvider = JdbcPasswordProvider {
+        currentDatabaseToken()
+    },
+)
+
+refreshingDataSource.connection.use { connection ->
+    connection.prepareStatement("SELECT 1").use { statement ->
+        statement.executeQuery().use { rs ->
+            rs.next()
+        }
+    }
+}
+```
+
+Hikari로 감쌀 때는 내부 `dataSource`만 설정합니다. 이 갱신 경로에서는
+Hikari의 `jdbcUrl`, `username`, `password`, `credentialsProvider`,
+`dataSourceClassName`을 함께 설정하지 마세요. 이런 설정은 인자 없는
+`getConnection()` 계약을 우회할 수 있습니다.
+
+```kotlin
+import com.zaxxer.hikari.HikariDataSource
+
+val pooled = HikariDataSource().apply {
+    dataSource = refreshingDataSource
+    maximumPoolSize = 10
+}
+```
+
+중요 동작:
+
+- `getConnection(username, password)`는 거부됩니다. 호출자가 넘긴 인증
+  정보는 갱신 계약을 우회하기 때문입니다.
+- `getLogWriter`, `setLogWriter`, `getLoginTimeout`, `setLoginTimeout`은
+  인스턴스별 상태가 아니라 프로세스 전역 `DriverManager` 상태를
+  사용합니다.
+- 이 helper는 connection pool, 예약 refresh 서비스, async password
+  provider, 범용 정적 credential helper, 호출자 credential override
+  경로가 아닙니다.
+- `dataSourceProperties`에는 벤더 driver 옵션을 넣을 수 있지만, 비밀
+  값이 들어간 항목은 진단 메시지에 안전하지 않습니다. `user`와
+  `password` 항목은 항상 설정된 username과 현재 provider password로
+  덮어씁니다.
+
 ### 2. Statement 실행
 
 간편한 Statement 생성과 실행:

--- a/data/jdbc/README.md
+++ b/data/jdbc/README.md
@@ -57,6 +57,67 @@ dataSource.withConnect { conn ->
 }
 ```
 
+#### Refreshing Password DataSource
+
+`RefreshingJdbcPasswordDataSource` is a small `DriverManager`-backed `DataSource`
+for passwords that can change between physical JDBC connections, such as
+cloud-generated database tokens. It calls the password provider for every
+no-argument `getConnection()` call and then delegates to
+`DriverManager.getConnection(url, properties)`.
+
+```kotlin
+import io.bluetape4k.jdbc.datasource.JdbcPasswordProvider
+import io.bluetape4k.jdbc.datasource.RefreshingJdbcPasswordDataSource
+import io.bluetape4k.jdbc.datasource.RefreshingJdbcPasswordDataSourceConfig
+
+val refreshingDataSource = RefreshingJdbcPasswordDataSource(
+    config = RefreshingJdbcPasswordDataSourceConfig(
+        url = "jdbc:postgresql://localhost:5432/app",
+        driverClassName = "org.postgresql.Driver",
+        username = "app_user",
+        dataSourceProperties = mapOf("sslmode" to "require"),
+    ),
+    passwordProvider = JdbcPasswordProvider {
+        currentDatabaseToken()
+    },
+)
+
+refreshingDataSource.connection.use { connection ->
+    connection.prepareStatement("SELECT 1").use { statement ->
+        statement.executeQuery().use { rs ->
+            rs.next()
+        }
+    }
+}
+```
+
+Wrap it with Hikari by setting the nested `dataSource`. Do not also set
+Hikari `jdbcUrl`, `username`, `password`, `credentialsProvider`, or
+`dataSourceClassName` for this refresh path, because those settings can bypass
+the no-argument `getConnection()` contract.
+
+```kotlin
+import com.zaxxer.hikari.HikariDataSource
+
+val pooled = HikariDataSource().apply {
+    dataSource = refreshingDataSource
+    maximumPoolSize = 10
+}
+```
+
+Important behavior:
+
+- `getConnection(username, password)` is rejected because caller-supplied
+  credentials would bypass the refresh contract.
+- `getLogWriter`, `setLogWriter`, `getLoginTimeout`, and `setLoginTimeout`
+  use process-wide `DriverManager` state, not per-instance state.
+- This helper is not a connection pool, scheduled refresh service, async
+  password provider, generic static credential helper, or caller-supplied
+  credential override path.
+- `dataSourceProperties` may contain vendor driver options, but secret-bearing
+  entries are not diagnostic-safe. `user` and `password` entries are always
+  overwritten by the configured username and the current provider password.
+
 ### 2. Executing Statements
 
 Simple statement creation and execution:

--- a/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/datasource/RefreshingJdbcPasswordDataSource.kt
+++ b/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/datasource/RefreshingJdbcPasswordDataSource.kt
@@ -1,0 +1,182 @@
+package io.bluetape4k.jdbc.datasource
+
+import io.bluetape4k.support.requireNotBlank
+import java.io.PrintWriter
+import java.io.Serializable
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.SQLException
+import java.util.Properties
+import java.util.logging.Logger
+import javax.sql.DataSource
+
+/**
+ * Provides the current JDBC password for a physical connection attempt.
+ *
+ * ## Contract
+ *
+ * [RefreshingJdbcPasswordDataSource] calls [currentPassword] synchronously for
+ * every no-arg [DataSource.getConnection] invocation. Implementations must be
+ * thread-safe because connection pools may open multiple physical connections
+ * concurrently. Expensive token generation, caching, and coalescing belong in
+ * the provider implementation, not in the generic DataSource.
+ *
+ * Implementations must not log or expose secrets. Exceptions thrown by the
+ * provider are reported as secret-free [SQLException] failures by the
+ * DataSource.
+ */
+fun interface JdbcPasswordProvider {
+
+    /**
+     * Returns the current JDBC password or null when no password is available.
+     */
+    fun currentPassword(): String?
+}
+
+/**
+ * Configuration for [RefreshingJdbcPasswordDataSource].
+ *
+ * @property url JDBC URL used with [DriverManager.getConnection].
+ * @property driverClassName optional driver class to load during construction.
+ * @property username JDBC user name written to each per-call [Properties].
+ * @property dataSourceProperties vendor-specific JDBC properties copied into
+ * each per-call [Properties] before `user` and `password` are written.
+ * @property nullPasswordMessage secret-free [SQLException] message used when
+ * [JdbcPasswordProvider.currentPassword] returns null.
+ */
+data class RefreshingJdbcPasswordDataSourceConfig(
+    val url: String,
+    val driverClassName: String? = null,
+    val username: String,
+    val dataSourceProperties: Map<String, String> = emptyMap(),
+    val nullPasswordMessage: String = "JDBC password provider returned null.",
+): Serializable {
+
+    init {
+        url.requireNotBlank("url")
+        username.requireNotBlank("username")
+        driverClassName?.requireNotBlank("driverClassName")
+        nullPasswordMessage.requireNotBlank("nullPasswordMessage")
+        dataSourceProperties.keys.forEach { key ->
+            key.requireNotBlank("dataSourceProperties key")
+        }
+    }
+
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * A [DataSource] that obtains a fresh password for each physical connection.
+ *
+ * ## Behavior
+ *
+ * This DataSource builds a fresh JDBC [Properties] object for every no-arg
+ * [getConnection] call, copies configured vendor properties, writes `user`,
+ * obtains the current password, writes `password`, and delegates to
+ * [DriverManager.getConnection].
+ *
+ * Caller-supplied credentials are rejected because they would bypass the
+ * refresh contract. This class is not a connection pool, does not schedule
+ * refreshes, and does not own returned [Connection] instances or provider
+ * lifecycle.
+ *
+ * [logWriter] and [loginTimeout] delegate to process-wide [DriverManager]
+ * state. They are not per-instance settings.
+ *
+ * ```kotlin
+ * val dataSource = RefreshingJdbcPasswordDataSource(
+ *     config = RefreshingJdbcPasswordDataSourceConfig(
+ *         url = "jdbc:postgresql://localhost:5432/app",
+ *         username = "app",
+ *     ),
+ *     passwordProvider = JdbcPasswordProvider { currentToken() },
+ * )
+ * ```
+ */
+class RefreshingJdbcPasswordDataSource(
+    config: RefreshingJdbcPasswordDataSourceConfig,
+    private val passwordProvider: JdbcPasswordProvider,
+): DataSource {
+
+    private val url: String = config.url
+    private val username: String = config.username
+    private val dataSourceProperties: Map<String, String> = config.dataSourceProperties.toMap()
+    private val nullPasswordMessage: String = config.nullPasswordMessage
+    private val urlSummary: String = sanitizeUrl(config.url)
+
+    init {
+        config.driverClassName?.let { driverClassName ->
+            try {
+                Class.forName(driverClassName)
+            } catch (e: ClassNotFoundException) {
+                throw IllegalArgumentException("JDBC driver class not found: $driverClassName", e)
+            }
+        }
+    }
+
+    override fun getConnection(): Connection {
+        val properties = Properties(dataSourceProperties.size + 2)
+        properties.putAll(dataSourceProperties)
+        properties.setProperty("user", username)
+
+        val password = currentPassword()
+        properties.setProperty("password", password)
+
+        return DriverManager.getConnection(url, properties)
+    }
+
+    override fun getConnection(username: String?, password: String?): Connection =
+        throw SQLException(REJECT_CALLER_CREDENTIALS_MESSAGE)
+
+    override fun getLogWriter(): PrintWriter? =
+        DriverManager.getLogWriter()
+
+    override fun setLogWriter(out: PrintWriter?) {
+        DriverManager.setLogWriter(out)
+    }
+
+    override fun setLoginTimeout(seconds: Int) {
+        DriverManager.setLoginTimeout(seconds)
+    }
+
+    override fun getLoginTimeout(): Int =
+        DriverManager.getLoginTimeout()
+
+    override fun getParentLogger(): Logger =
+        Logger.getGlobal()
+
+    override fun <T: Any?> unwrap(iface: Class<T>): T {
+        if (iface.isInstance(this)) {
+            return iface.cast(this)
+        }
+        throw SQLException("Not a wrapper for ${iface.name}.")
+    }
+
+    override fun isWrapperFor(iface: Class<*>): Boolean =
+        iface.isInstance(this)
+
+    override fun toString(): String =
+        "RefreshingJdbcPasswordDataSource(url=$urlSummary, username=<redacted>)"
+
+    private fun currentPassword(): String =
+        try {
+            passwordProvider.currentPassword()
+                ?: throw SQLException(nullPasswordMessage)
+        } catch (e: SQLException) {
+            throw e
+        } catch (e: Exception) {
+            throw SQLException("JDBC password provider failed.", e)
+        }
+
+    private companion object {
+        private const val REJECT_CALLER_CREDENTIALS_MESSAGE =
+            "Refreshing JDBC password data source does not accept caller-supplied credentials."
+
+        private fun sanitizeUrl(url: String): String {
+            val withoutQuery = url.substringBefore('?').substringBefore(';')
+            return withoutQuery.replace(Regex("//[^/@]+@"), "//")
+        }
+    }
+}

--- a/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/datasource/RefreshingJdbcPasswordDataSourceTest.kt
+++ b/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/datasource/RefreshingJdbcPasswordDataSourceTest.kt
@@ -1,0 +1,391 @@
+package io.bluetape4k.jdbc.datasource
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotContain
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import org.junit.jupiter.api.Test
+import java.io.PrintWriter
+import java.lang.reflect.Proxy
+import java.sql.Connection
+import java.sql.Driver
+import java.sql.DriverManager
+import java.sql.DriverPropertyInfo
+import java.sql.SQLException
+import java.sql.SQLFeatureNotSupportedException
+import java.util.Properties
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.logging.Logger
+
+class RefreshingJdbcPasswordDataSourceTest {
+
+    @Test
+    fun `getConnection opens H2 connection and calls password provider`() {
+        val calls = AtomicInteger()
+        val dataSource = RefreshingJdbcPasswordDataSource(
+            config = RefreshingJdbcPasswordDataSourceConfig(
+                url = "jdbc:h2:mem:refreshing_${System.nanoTime()};DB_CLOSE_DELAY=-1",
+                driverClassName = "org.h2.Driver",
+                username = "sa",
+            ),
+            passwordProvider = JdbcPasswordProvider {
+                calls.incrementAndGet()
+                ""
+            },
+        )
+
+        dataSource.connection.use { connection ->
+            connection.createStatement().use { statement ->
+                statement.executeQuery("SELECT 1").use { rs ->
+                    rs.next().shouldBeTrue()
+                    rs.getInt(1) shouldBeEqualTo 1
+                }
+            }
+        }
+
+        calls.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `getConnection invokes provider for each physical connection`() {
+        val driver = RecordingDriver()
+
+        withRegisteredDriver(driver) {
+            val calls = AtomicInteger()
+            val dataSource = dataSourceFor(driver.url) {
+                "token-${calls.incrementAndGet()}"
+            }
+
+            dataSource.connection.close()
+            dataSource.connection.close()
+
+            calls.get() shouldBeEqualTo 2
+            driver.captures.map { it.properties.getProperty("password") } shouldBeEqualTo listOf("token-1", "token-2")
+        }
+    }
+
+    @Test
+    fun `caller supplied credential overload is rejected without invoking provider`() {
+        val calls = AtomicInteger()
+        val dataSource = dataSourceFor("jdbc:bluetape4k-refresh-test:rejected") {
+            calls.incrementAndGet()
+            "provider-secret"
+        }
+
+        val ex = assertFailsWith<SQLException> {
+            dataSource.getConnection("caller-user", "caller-password")
+        }
+
+        ex.message shouldBeEqualTo "Refreshing JDBC password data source does not accept caller-supplied credentials."
+        ex.message shouldNotContain "caller-user"
+        ex.message shouldNotContain "caller-password"
+        calls.get() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `null password throws configured secret free SQLException`() {
+        val dataSource = RefreshingJdbcPasswordDataSource(
+            config = RefreshingJdbcPasswordDataSourceConfig(
+                url = "jdbc:bluetape4k-refresh-test:null?password=url-secret&token=url-token",
+                username = "db-user",
+                dataSourceProperties = mapOf("sslpassword" to "property-secret"),
+                nullPasswordMessage = "Password provider returned no value.",
+            ),
+            passwordProvider = JdbcPasswordProvider { null },
+        )
+
+        val ex = assertFailsWith<SQLException> {
+            dataSource.connection
+        }
+
+        ex.message shouldBeEqualTo "Password provider returned no value."
+        ex.message shouldNotContain "url-secret"
+        ex.message shouldNotContain "url-token"
+        ex.message shouldNotContain "property-secret"
+    }
+
+    @Test
+    fun `config validation rejects blank values`() {
+        assertFailsWith<IllegalArgumentException> {
+            RefreshingJdbcPasswordDataSourceConfig(url = " ", username = "user")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            RefreshingJdbcPasswordDataSourceConfig(url = "jdbc:test", username = " ")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            RefreshingJdbcPasswordDataSourceConfig(url = "jdbc:test", username = "user", driverClassName = " ")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            RefreshingJdbcPasswordDataSourceConfig(url = "jdbc:test", username = "user", nullPasswordMessage = " ")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            RefreshingJdbcPasswordDataSourceConfig(
+                url = "jdbc:test",
+                username = "user",
+                dataSourceProperties = mapOf(" " to "value"),
+            )
+        }
+    }
+
+    @Test
+    fun `properties are fresh per call and generated credentials override base entries`() {
+        val driver = RecordingDriver()
+
+        withRegisteredDriver(driver) {
+            val calls = AtomicInteger()
+            val dataSource = RefreshingJdbcPasswordDataSource(
+                config = RefreshingJdbcPasswordDataSourceConfig(
+                    url = driver.url,
+                    username = "constructor-user",
+                    dataSourceProperties = mapOf(
+                        "user" to "stale-user",
+                        "password" to "stale-password",
+                        "vendorOption" to "vendor-value",
+                    ),
+                ),
+                passwordProvider = JdbcPasswordProvider {
+                    "provider-password-${calls.incrementAndGet()}"
+                },
+            )
+
+            dataSource.connection.close()
+            dataSource.connection.close()
+
+            val captures = driver.captures.toList()
+            captures.size shouldBeEqualTo 2
+            captures.map { it.identityHash }.toSet().size shouldBeEqualTo 2
+            captures[0].properties.getProperty("user") shouldBeEqualTo "constructor-user"
+            captures[0].properties.getProperty("password") shouldBeEqualTo "provider-password-1"
+            captures[0].properties.getProperty("vendorOption") shouldBeEqualTo "vendor-value"
+            captures[1].properties.getProperty("user") shouldBeEqualTo "constructor-user"
+            captures[1].properties.getProperty("password") shouldBeEqualTo "provider-password-2"
+            captures[1].properties.getProperty("driverMutation") shouldBeEqualTo null
+        }
+    }
+
+    @Test
+    fun `concurrent getConnection calls use isolated properties and provider invocations`() {
+        val driver = RecordingDriver()
+
+        withRegisteredDriver(driver) {
+            val calls = AtomicInteger()
+            val dataSource = dataSourceFor(driver.url) {
+                "token-${calls.incrementAndGet()}"
+            }
+
+            MultithreadingTester()
+                .workers(8)
+                .rounds(4)
+                .add { dataSource.connection.close() }
+                .run()
+
+            val expectedCalls = 32
+            calls.get() shouldBeEqualTo expectedCalls
+            driver.captures.size shouldBeEqualTo expectedCalls
+            driver.captures.map { it.identityHash }.toSet().size shouldBeEqualTo expectedCalls
+        }
+    }
+
+    @Test
+    fun `wrapper methods only unwrap the helper instance`() {
+        val dataSource = dataSourceFor("jdbc:bluetape4k-refresh-test:wrapper") { "token" }
+
+        dataSource.isWrapperFor(RefreshingJdbcPasswordDataSource::class.java).shouldBeTrue()
+        dataSource.unwrap(RefreshingJdbcPasswordDataSource::class.java) shouldBeEqualTo dataSource
+
+        val ex = assertFailsWith<SQLException> {
+            dataSource.unwrap(Connection::class.java)
+        }
+
+        ex.message shouldContain "Not a wrapper for java.sql.Connection."
+    }
+
+    @Test
+    fun `toString is sanitized and does not call provider`() {
+        val calls = AtomicInteger()
+        val dataSource = RefreshingJdbcPasswordDataSource(
+            config = RefreshingJdbcPasswordDataSourceConfig(
+                url = "jdbc:postgresql://url-user:url-password@localhost:5432/app?password=query-secret&token=query-token&sslpassword=ssl-secret",
+                username = "db-user",
+            ),
+            passwordProvider = JdbcPasswordProvider {
+                calls.incrementAndGet()
+                "provider-secret"
+            },
+        )
+
+        val value = dataSource.toString()
+
+        value shouldContain "RefreshingJdbcPasswordDataSource"
+        value shouldContain "username=<redacted>"
+        value shouldNotContain "db-user"
+        value shouldNotContain "url-password"
+        value shouldNotContain "query-secret"
+        value shouldNotContain "query-token"
+        value shouldNotContain "ssl-secret"
+        value shouldNotContain "provider-secret"
+        value shouldNotContain "password="
+        value shouldNotContain "token="
+        calls.get() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `provider failure is wrapped in secret free SQLException`() {
+        val failure = IllegalStateException("provider exploded with provider-secret")
+        val dataSource = dataSourceFor("jdbc:bluetape4k-refresh-test:provider-failure") {
+            throw failure
+        }
+
+        val ex = assertFailsWith<SQLException> {
+            dataSource.connection
+        }
+
+        ex.cause shouldBeEqualTo failure
+        ex.message shouldNotContain "provider-secret"
+    }
+
+    @Test
+    fun `driver class load failure does not include credentials`() {
+        val ex = assertFailsWith<IllegalArgumentException> {
+            RefreshingJdbcPasswordDataSource(
+                config = RefreshingJdbcPasswordDataSourceConfig(
+                    url = "jdbc:bluetape4k-refresh-test:driver?password=url-secret",
+                    driverClassName = "missing.DriverClass",
+                    username = "user",
+                    dataSourceProperties = mapOf("password" to "property-secret"),
+                ),
+                passwordProvider = JdbcPasswordProvider { "provider-secret" },
+            )
+        }
+
+        ex.message shouldContain "missing.DriverClass"
+        ex.message shouldNotContain "url-secret"
+        ex.message shouldNotContain "property-secret"
+        ex.message shouldNotContain "provider-secret"
+    }
+
+    @Test
+    fun `DriverManager global log writer and login timeout are delegated and restored`() {
+        val dataSource = dataSourceFor("jdbc:bluetape4k-refresh-test:globals") { "token" }
+        val originalWriter = DriverManager.getLogWriter()
+        val originalTimeout = DriverManager.getLoginTimeout()
+        val writer = PrintWriter(System.err)
+
+        try {
+            dataSource.logWriter = writer
+            dataSource.loginTimeout = 7
+
+            DriverManager.getLogWriter() shouldBeEqualTo writer
+            dataSource.logWriter shouldBeEqualTo writer
+            DriverManager.getLoginTimeout() shouldBeEqualTo 7
+            dataSource.loginTimeout shouldBeEqualTo 7
+        } finally {
+            DriverManager.setLogWriter(originalWriter)
+            DriverManager.setLoginTimeout(originalTimeout)
+        }
+    }
+
+    private fun dataSourceFor(
+        url: String,
+        passwordProvider: () -> String?,
+    ): RefreshingJdbcPasswordDataSource =
+        RefreshingJdbcPasswordDataSource(
+            config = RefreshingJdbcPasswordDataSourceConfig(
+                url = url,
+                username = "db-user",
+            ),
+            passwordProvider = JdbcPasswordProvider(passwordProvider),
+        )
+
+    private fun withRegisteredDriver(
+        driver: Driver,
+        block: () -> Unit,
+    ) {
+        DriverManager.registerDriver(driver)
+        try {
+            block()
+        } finally {
+            DriverManager.deregisterDriver(driver)
+        }
+    }
+
+    private class RecordingDriver(
+        val url: String = "jdbc:bluetape4k-refresh-test:${System.nanoTime()}",
+    ): Driver {
+
+        val captures = ConcurrentLinkedQueue<CapturedProperties>()
+
+        override fun acceptsURL(url: String?): Boolean =
+            url == this.url
+
+        override fun connect(url: String?, info: Properties?): Connection? {
+            if (!acceptsURL(url)) {
+                return null
+            }
+
+            requireNotNull(info)
+            val copy = Properties()
+            copy.putAll(info)
+            captures.add(CapturedProperties(System.identityHashCode(info), copy))
+            info["driverMutation"] = "mutated-by-driver"
+
+            return connectionProxy()
+        }
+
+        override fun getMajorVersion(): Int = 1
+
+        override fun getMinorVersion(): Int = 0
+
+        override fun getPropertyInfo(url: String?, info: Properties?): Array<DriverPropertyInfo> = emptyArray()
+
+        override fun jdbcCompliant(): Boolean = false
+
+        override fun getParentLogger(): Logger =
+            throw SQLFeatureNotSupportedException("parent logger")
+
+        private fun connectionProxy(): Connection =
+            Proxy.newProxyInstance(
+                Connection::class.java.classLoader,
+                arrayOf(Connection::class.java),
+            ) { proxy, method, _ ->
+                when (method.name) {
+                    "close" -> Unit
+                    "isClosed" -> false
+                    "toString" -> "RecordingConnection"
+                    "unwrap" -> unwrap(proxy, method)
+                    "isWrapperFor" -> method.parameterTypes.single().isInstance(proxy)
+                    else -> defaultValue(method)
+                }
+            } as Connection
+
+        private fun unwrap(proxy: Any, method: java.lang.reflect.Method): Any {
+            val iface = method.parameterTypes.single()
+            if (iface.isInstance(proxy)) {
+                return proxy
+            }
+            throw SQLException("Not a wrapper for ${iface.name}.")
+        }
+
+        private fun defaultValue(method: java.lang.reflect.Method): Any? =
+            when (method.returnType) {
+                java.lang.Boolean.TYPE -> false
+                java.lang.Byte.TYPE -> 0.toByte()
+                java.lang.Short.TYPE -> 0.toShort()
+                java.lang.Integer.TYPE -> 0
+                java.lang.Long.TYPE -> 0L
+                java.lang.Float.TYPE -> 0.0f
+                java.lang.Double.TYPE -> 0.0
+                java.lang.Character.TYPE -> '\u0000'
+                java.lang.Void.TYPE -> Unit
+                else -> null
+            }
+    }
+
+    private data class CapturedProperties(
+        val identityHash: Int,
+        val properties: Properties,
+    )
+}

--- a/docs/superpowers/plans/2026-06-30-refreshing-jdbc-datasource-plan.md
+++ b/docs/superpowers/plans/2026-06-30-refreshing-jdbc-datasource-plan.md
@@ -1,0 +1,159 @@
+# Refreshing JDBC DataSource Implementation Plan
+
+Date: 2026-06-30
+Repository: `bluetape4k-projects`
+Branch: `feat/projects-refreshing-jdbc-datasource`
+Spec: `docs/superpowers/specs/2026-06-30-refreshing-jdbc-datasource-design.md`
+
+## Goal
+
+Add a reusable `bluetape4k-jdbc` `DataSource` that obtains the current JDBC
+password for every physical connection and delegates to `DriverManager`, so
+`bluetape4k-aws` can later remove its internal RDS IAM JDBC wrapper after a
+published helper artifact exists.
+
+## Stop Conditions
+
+- Stop the upstream PR after `bluetape4k-projects` tests, docs, and CI are
+  green.
+- Do not edit `bluetape4k-aws` source to consume the helper until a snapshot or
+  stable `bluetape4k-jdbc` artifact containing it is published and dependency
+  resolution is proven.
+- If the helper API shape needs to change after tests start, update the spec
+  before continuing implementation.
+
+## Implementation Sequence
+
+### 1. Add Failing Tests First
+
+File:
+`data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/datasource/RefreshingJdbcPasswordDataSourceTest.kt`
+
+Test cases:
+
+- H2 smoke: `getConnection()` opens a connection and calls
+  `JdbcPasswordProvider.currentPassword()`.
+- Repeated physical connections: two direct `getConnection()` calls invoke the
+  provider twice.
+- Rejected overload: `getConnection(username, password)` throws `SQLException`
+  with the stable secret-free message.
+- Null password: provider returns null and `SQLException(config.nullPasswordMessage)`
+  is thrown without leaking URL, properties, or sentinel secrets.
+- Validation: blank URL, blank username, blank null message, blank driver class
+  name, and blank property keys fail with `IllegalArgumentException`.
+- Fake Driver capture:
+  - register a local `Driver` for a sentinel JDBC URL;
+  - capture each received `Properties` instance;
+  - prove base `user` and `password` entries are overwritten;
+  - prove each call receives a distinct `Properties` instance;
+  - mutate the first captured properties and prove the mutation does not leak
+    into later calls;
+  - deregister the driver in teardown.
+- Concurrent fake Driver calls: use `MultithreadingTester` and assert provider
+  calls equal physical connection attempts and every call receives a distinct
+  `Properties` instance.
+- Wrapper methods: `isWrapperFor`, successful `unwrap`, and failed `unwrap`
+  with stable `SQLException("Not a wrapper for <fqcn>.")`.
+- Secret-free `toString()`: provider is not called and output excludes full URL
+  query strings, URL userinfo, `password`, `token`, and `sslpassword` sentinel
+  values.
+- Provider failure: provider exception is wrapped in a secret-free `SQLException`
+  with the cause preserved.
+- Driver class load failure: failure includes the class name but not URL,
+  properties, or credentials.
+- DriverManager global methods: log writer and login timeout delegate to
+  process-wide `DriverManager`; save and restore original state.
+
+Expected first result: tests fail to compile because the new public API does
+not exist.
+
+### 2. Implement The Generic Helper
+
+File:
+`data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/datasource/RefreshingJdbcPasswordDataSource.kt`
+
+Public API:
+
+- `fun interface JdbcPasswordProvider`
+- `data class RefreshingJdbcPasswordDataSourceConfig : Serializable`
+- `class RefreshingJdbcPasswordDataSource : DataSource`
+
+Implementation rules:
+
+- Validate config with existing bluetape4k validation helpers.
+- Copy `dataSourceProperties` in the constructor.
+- Load optional `driverClassName` in the constructor.
+- Build a fresh per-call `Properties` object and write base properties first,
+  then `user`, then `password`.
+- Reject caller-supplied credentials before invoking the provider.
+- Wrap provider failures as secret-free `SQLException` with cause.
+- Propagate `DriverManager.getConnection` `SQLException` unchanged.
+- Delegate log writer/login timeout to `DriverManager`.
+- Implement wrapper methods only for the helper instance.
+- Keep `toString()` sanitized and provider-free.
+- Do not implement `Closeable`, `AutoCloseable`, or `Serializable` on the
+  `DataSource` class or provider interface.
+
+### 3. Update Documentation
+
+Files:
+
+- `data/jdbc/README.md`
+- `data/jdbc/README.ko.md`
+
+Required content:
+
+- Source-equivalent sections for `RefreshingJdbcPasswordDataSource`.
+- Imports from `io.bluetape4k.jdbc.datasource`.
+- Runnable-style Kotlin snippet using
+  `RefreshingJdbcPasswordDataSourceConfig`.
+- Hikari wrapping example using
+  `dataSource = RefreshingJdbcPasswordDataSource(...)`.
+- Warning that `getConnection(username, password)` is rejected.
+- Warning that log writer/login timeout methods use process-wide
+  `DriverManager` state.
+- Unsupported cases: no pooling, no scheduled refresh, no async provider, no
+  generic static credential helper, no caller-supplied credential override.
+- Note that `dataSourceProperties` can contain vendor driver options, but
+  secret-bearing entries are not diagnostic-safe; `user` and `password` are
+  overwritten.
+
+### 4. Local Verification
+
+Run in `bluetape4k-projects` worktree:
+
+```bash
+./gradlew :bluetape4k-jdbc:test --no-daemon --stacktrace
+./gradlew :bluetape4k-jdbc:koverXmlReport --no-daemon --stacktrace
+git diff --check
+```
+
+If tests fail:
+
+- fix implementation or tests;
+- rerun the smallest failing command first;
+- then rerun the full verification set above.
+
+### 5. PR Preparation
+
+- Commit spec, review artifact, plan, implementation, tests, and README updates
+  with Lore-protocol commit messages.
+- Create a `bluetape4k-projects` PR against `develop`.
+- Set assignee `debop`.
+- Reference `bluetape4k-aws#295` and explain that AWS consumption is blocked
+  until publication.
+- Keep the final PR body section as `## DoD Status`.
+- Verify PR body via `gh pr view --json body` before reporting the PR ready.
+- Verify PR checks include the `test-data` lane that runs
+  `:bluetape4k-jdbc:test` and `:bluetape4k-jdbc:koverXmlReport`.
+
+## Downstream AWS Follow-Up
+
+After a consumable helper artifact exists:
+
+- update `bluetape4k-aws` catalog to the selected snapshot or stable version;
+- prove dependency resolution from the expected repository;
+- replace the internal `RdsIamRefreshingDataSource`;
+- keep RDS IAM Hikari configuration on the `dataSource` path only;
+- run `:bluetape4k-aws-exposed:test`;
+- open the AWS PR for issue #295.

--- a/docs/superpowers/specs/2026-06-30-refreshing-jdbc-datasource-design.md
+++ b/docs/superpowers/specs/2026-06-30-refreshing-jdbc-datasource-design.md
@@ -136,9 +136,10 @@ Package: `io.bluetape4k.jdbc.datasource`
   - `getLogWriter`, `setLogWriter`, `getLoginTimeout`, and `setLoginTimeout`
     delegate to `DriverManager`; KDoc and README must say these methods read
     or mutate process-wide `DriverManager` state, not per-instance state.
-  - `toString()` reports only class name, sanitized URL summary, and username.
-    It must not include full JDBC URLs, URL query strings, URL userinfo, the
-    current password, or any password-like values.
+  - `toString()` reports only class name, sanitized URL summary, and a redacted
+    username marker. It must not include username values, full JDBC URLs, URL
+    query strings, URL userinfo, the current password, or any password-like
+    values.
   - `getParentLogger()` returns `Logger.getGlobal()` as the current AWS class
     does.
   - `unwrap` and `isWrapperFor` support unwrapping to the helper instance only.
@@ -247,9 +248,9 @@ AWS migration after the helper is released:
   `DriverManager` global state after execution.
 - wrapper methods report `isWrapperFor` and `unwrap` behavior.
 - `toString()` does not invoke the provider and does not expose password
-  values, full URL query strings, URL userinfo, or credential-bearing JDBC URL
-  parts. Sentinel tests include URL query parameters such as `password`,
-  `token`, and `sslpassword`.
+  values, username values, full URL query strings, URL userinfo, or
+  credential-bearing JDBC URL parts. Sentinel tests include URL query
+  parameters such as `password`, `token`, and `sslpassword`.
 - failure messages for null password, rejected caller credentials, unwrap
   failure, and driver loading do not expose password values.
 - null-password tests use sentinel URL parameters and secret-bearing

--- a/docs/superpowers/specs/2026-06-30-refreshing-jdbc-datasource-design.md
+++ b/docs/superpowers/specs/2026-06-30-refreshing-jdbc-datasource-design.md
@@ -1,0 +1,371 @@
+# Refreshing JDBC DataSource Design
+
+Date: 2026-06-30
+Repositories: `bluetape4k-projects`, `bluetape4k-aws`
+Primary issue: bluetape4k-aws #295
+Primary branch: `feat/projects-refreshing-jdbc-datasource`
+
+## Problem
+
+`bluetape4k-aws` issue #295 tracks the remaining ecosystem-reuse gap in the
+RDS IAM JDBC path. `aws-exposed` currently owns an internal
+`RdsIamRefreshingDataSource` that builds a fresh `Properties` object for every
+physical JDBC connection, asks `AwsDatabasePasswordProvider.currentPassword()`
+for the current token, injects that token as the JDBC password, and delegates
+to `DriverManager.getConnection(url, properties)`.
+
+The behavior is correct, but the low-level JDBC connection creation wrapper is
+not AWS-specific. The reusable boundary belongs in `bluetape4k-jdbc`, while AWS
+should only supply the username, base properties, token-producing function, and
+AWS-specific error message for null tokens.
+
+## Current Evidence
+
+- `bluetape4k-aws/aws-exposed/src/main/kotlin/io/bluetape4k/aws/exposed/AwsJdbcDataSourceFactory.kt`
+  contains the only production `DriverManager` use in the AWS worktree.
+- `RdsIamRefreshingDataSource.getConnection()` creates per-call JDBC
+  properties, sets `user`, sets a token-derived `password`, and calls
+  `DriverManager.getConnection(url, connectionProperties)`.
+- `RdsIamRefreshingDataSource.getConnection(username, password)` rejects
+  caller-supplied credentials with `SQLException`.
+- `data/jdbc` currently provides `hikariDataSourceOf`, `DataSource` execution
+  extensions, transaction helpers, and JDBC driver constants, but no
+  refresh-aware `DataSource` or `DriverManager` wrapper.
+- `javap javax.sql.DataSource java.sql.DriverManager` confirms the needed
+  public surface: `DataSource` has `getConnection()` and
+  `getConnection(String, String)`, while `DriverManager` exposes
+  `getConnection(String, Properties)`, log writer, and login timeout methods.
+- `bluetape4k-aws` consumes `io.github.bluetape4k:bluetape4k-jdbc` through
+  catalog version `1.11.0`. A new helper in `bluetape4k-projects` cannot be
+  used by AWS remote CI until the helper is published in a version AWS can
+  consume.
+- Prior AWS docs for #269 explicitly kept JDBC password refresh,
+  Hikari, and `DriverManager` behavior in `aws-exposed` and marked #295 as
+  out of scope. Prior #294 review states the remaining direct `DriverManager`
+  usage is intentionally isolated for this follow-up.
+
+## Constraints
+
+- Keep `bluetape4k-jdbc` generic. It must not depend on AWS, Exposed, Hikari,
+  or token-specific types.
+- Preserve per-physical-connection refresh semantics. The password supplier
+  must run for every no-arg `getConnection()` call.
+- Preserve caller-supplied credential rejection for this helper. Accepting
+  `getConnection(username, password)` would bypass the refresh contract.
+- Preserve existing `DriverManager` log writer and login timeout behavior.
+- Keep connection properties per call so one connection cannot mutate state
+  visible to later connections.
+- Public API and KDoc must be English.
+- `README.md` and `README.ko.md` for `data/jdbc` must remain source-equivalent.
+- `bluetape4k-aws` cannot consume the helper from a normal PR until a new
+  `bluetape4k-jdbc` version or snapshot containing the helper is available.
+
+## Design Options
+
+### Option A: Move `RdsIamRefreshingDataSource` Into `bluetape4k-jdbc`
+
+Move the class almost verbatim and make it public.
+
+Rejected. The class name and null-password error are RDS IAM specific, and a
+move would leak AWS vocabulary into a generic JDBC module.
+
+### Option B: Add A Generic `DriverManagerDataSource` With Optional Credentials
+
+Expose a reusable `DataSource` that accepts optional static or dynamic
+credentials and delegates to `DriverManager`.
+
+Rejected. A broad credential model expands the contract beyond #295 and makes
+the dangerous overload behavior ambiguous. For RDS IAM, caller-supplied
+credentials must be rejected, not optionally merged.
+
+### Option C: Add A Focused Refreshing Password `DataSource`
+
+Add a generic `RefreshingJdbcPasswordDataSource` to
+`io.bluetape4k.jdbc.datasource`
+that accepts:
+
+- `config: RefreshingJdbcPasswordDataSourceConfig`
+- `passwordProvider: JdbcPasswordProvider`
+
+The helper loads the optional JDBC driver class in `init`, builds a new
+`Properties` object on each no-arg `getConnection()`, copies base properties,
+sets `user`, obtains the current password, fails with `SQLException` when the
+provider returns null, sets `password`, and delegates to
+`DriverManager.getConnection(url, properties)`. It rejects
+`getConnection(username, password)`.
+
+Selected. This keeps the reusable behavior generic, preserves AWS semantics,
+and keeps token redaction responsibility outside `bluetape4k-jdbc`.
+
+## API Shape
+
+Package: `io.bluetape4k.jdbc.datasource`
+
+- `fun interface JdbcPasswordProvider`
+  - `fun currentPassword(): String?`
+  - Public-facing contract says the function is called for every physical
+    connection opened through `RefreshingJdbcPasswordDataSource`.
+  - It is called synchronously during `getConnection()`. Provider exceptions
+    propagate as connection acquisition failures, and providers must not log
+    secrets.
+  - Providers must be thread-safe. Connection pools may open multiple physical
+    connections concurrently during warm-up or scale-out, and expensive token
+    generation should be cached or coalesced outside the generic DataSource.
+- `data class RefreshingJdbcPasswordDataSourceConfig`
+  - `url: String`
+  - `driverClassName: String? = null`
+  - `username: String`
+  - `dataSourceProperties: Map<String, String> = emptyMap()`
+  - `nullPasswordMessage: String = "JDBC password provider returned null."`
+  - The constructor validates `url`, `username`, and `nullPasswordMessage` as
+    nonblank values using bluetape4k validation helpers.
+  - `driverClassName`, when present, is validated as nonblank.
+  - `dataSourceProperties` keys are validated as nonblank. Values are copied
+    without semantic validation because JDBC drivers own vendor-specific
+    option interpretation.
+  - The config implements `Serializable` and defines `serialVersionUID`.
+- `class RefreshingJdbcPasswordDataSource : DataSource`
+  - Public construction uses a config object plus `passwordProvider` to avoid
+    same-type positional mistakes.
+  - Constructor copies `config.dataSourceProperties` to an immutable `Map`.
+  - `getConnection()` obtains the latest password and delegates to
+    `DriverManager.getConnection(url, properties)`.
+  - `getConnection(username, password)` throws `SQLException` with
+    `"Refreshing JDBC password data source does not accept caller-supplied credentials."`
+    and never includes supplied username, supplied password, URL, or properties.
+  - `getLogWriter`, `setLogWriter`, `getLoginTimeout`, and `setLoginTimeout`
+    delegate to `DriverManager`; KDoc and README must say these methods read
+    or mutate process-wide `DriverManager` state, not per-instance state.
+  - `toString()` reports only class name, sanitized URL summary, and username.
+    It must not include full JDBC URLs, URL query strings, URL userinfo, the
+    current password, or any password-like values.
+  - `getParentLogger()` returns `Logger.getGlobal()` as the current AWS class
+    does.
+  - `unwrap` and `isWrapperFor` support unwrapping to the helper instance only.
+  - The DataSource and provider do not implement `Serializable`; only the
+    immutable config value object does.
+
+AWS migration after the helper is released:
+
+- Remove the internal `RdsIamRefreshingDataSource` class from
+  `AwsJdbcDataSourceFactory.kt`.
+- Replace it with `RefreshingJdbcPasswordDataSource`, adapting
+  `AwsDatabasePasswordProvider.currentPassword()?.reveal()` to the generic
+  `String?` provider.
+- Keep the AWS-specific null-token message:
+  `"RDS IAM password provider returned null."`
+- AWS users see no configuration or public API change after the
+  `aws-exposed` upgrade. RDS IAM mode must keep the Hikari `dataSource` path
+  and must not set Hikari `jdbcUrl`, `username`, or `password` directly for
+  RDS IAM.
+- RDS IAM mode must not set `HikariConfig.username`,
+  `HikariConfig.password`, `HikariConfig.credentialsProvider`,
+  `HikariConfig.jdbcUrl`, or `HikariConfig.dataSourceClassName`; setting any of
+  these can make Hikari call `DataSource.getConnection(username, password)` or
+  bypass the refresh-aware DataSource path. The only allowed Hikari connection
+  source for RDS IAM is `dataSource = RefreshingJdbcPasswordDataSource(...)`.
+- Keep `AwsDatabasePasswordProvider` and `AwsDatabasePasswordProviders` in
+  `aws-exposed`; only the JDBC connection wrapper moves.
+
+## Behavior
+
+- `passwordProvider.currentPassword()` is called once per no-arg
+  `getConnection()` invocation.
+- Connection pools call the helper only when they open a physical connection.
+  Reusing an already-open physical connection from a pool must not trigger a
+  password lookup.
+- `passwordProvider.currentPassword()` is never called from `toString()`,
+  wrapper inspection, log-writer methods, or the rejected credential overload.
+- The AWS adapter reveals `AwsSecretString` before calling the generic helper.
+  `bluetape4k-jdbc` may hold the resulting raw password string only long
+  enough to construct the per-call JDBC `Properties` passed to
+  `DriverManager`; it must not log, cache, store, expose, or include that
+  password in diagnostics.
+- A fresh `Properties(dataSourceProperties.size + 2)` instance, or an
+  equivalent pre-sized fresh instance, is created for each call. The helper
+  must not pass a shared or defaults-backed `Properties` object to JDBC drivers.
+- Base `dataSourceProperties` are copied before setting `user` and `password`.
+  The generated `user` and `password` values intentionally override same-named
+  base entries to keep the constructor's `username` and current password
+  authoritative.
+- The provider may return a cached token, a newly generated token, or null.
+  Null results in `SQLException` with the configured `nullPasswordMessage`.
+- The helper does not cache passwords, schedule refreshes, manage pools, or
+  close connections. Hikari remains the pool owner in `aws-exposed`.
+- The helper does not implement `Closeable` or `AutoCloseable` and owns no
+  resources. Returned `Connection` lifecycle belongs to the caller or pool;
+  `JdbcPasswordProvider`, JDBC driver, and AWS SDK/RDS utilities lifecycle
+  remain caller-owned.
+- Failure messages must not include password values or caller-supplied
+  credentials. Null password uses `config.nullPasswordMessage`; rejected
+  caller credentials use the stable message above; unwrap failures use
+  `"Not a wrapper for <fqcn>."`; driver class loading failures may include the
+  driver class name but not credentials.
+- `nullPasswordMessage` must be a static, secret-free diagnostic message. It
+  must not interpolate provider return values, URL query values,
+  `dataSourceProperties`, or caller-supplied credential values.
+- Null password changing from the current AWS internal `requireNotNull` path to
+  `SQLException` is an intentional JDBC API correction, not strict exception
+  preservation. AWS migration tests must pin the new behavior.
+- Exception contract:
+  - Config validation failures throw `IllegalArgumentException`.
+  - Optional driver class loading uses `Class.forName(driverClassName)` in the
+    constructor. `ClassNotFoundException` may propagate directly or be wrapped
+    in `IllegalArgumentException` with the driver class name and cause, but the
+    message must not include URL, properties, or credentials.
+  - Null password throws `SQLException(config.nullPasswordMessage)`.
+  - Provider failure is wrapped as a secret-free `SQLException` with cause, so
+    `DataSource.getConnection()` consistently exposes connection acquisition
+    failure as `SQLException`.
+  - `DriverManager.getConnection(...)` `SQLException` is propagated unchanged.
+  - Rejected caller credentials throw the stable `SQLException` message above.
+  - `unwrap` failure throws `SQLException("Not a wrapper for <fqcn>.")`.
+- `DriverManager` log writer and login timeout methods are process-global.
+  Tests that touch these methods must save and restore previous values, and
+  provider/property hot-path tests must not use these global methods as part of
+  their measurement or assertions.
+
+## Tests
+
+`bluetape4k-projects:data/jdbc` tests:
+
+- `getConnection()` opens an H2 connection and calls the password provider.
+- repeated `getConnection()` calls invoke the provider for each physical
+  connection.
+- caller-supplied credential overload throws `SQLException`.
+- null password throws `SQLException` with the configured message.
+- base properties are copied per call and cannot leak mutations across
+  invocations.
+- concurrent `getConnection()` calls are covered with
+  `MultithreadingTester` and a fake registered `Driver`; the test asserts the
+  provider count equals physical connection attempts, every call receives a
+  distinct `Properties`, and driver-side mutations do not leak between calls.
+- a fake registered `Driver` captures received `Properties`; tests assert base
+  properties containing stale `user` and `password` are overridden by the
+  constructor username and provider password.
+- fake-driver tests deregister the driver and restore any touched
+  `DriverManager` global state after execution.
+- wrapper methods report `isWrapperFor` and `unwrap` behavior.
+- `toString()` does not invoke the provider and does not expose password
+  values, full URL query strings, URL userinfo, or credential-bearing JDBC URL
+  parts. Sentinel tests include URL query parameters such as `password`,
+  `token`, and `sslpassword`.
+- failure messages for null password, rejected caller credentials, unwrap
+  failure, and driver loading do not expose password values.
+- null-password tests use sentinel URL parameters and secret-bearing
+  `dataSourceProperties` to prove `nullPasswordMessage` remains static and
+  secret-free.
+
+`bluetape4k-aws` tests after consumption:
+
+- existing RDS IAM DataSource test still opens H2 with provider token.
+- add a Hikari boundary test that proves per-physical-connection refresh by
+  holding connection #1 while opening connection #2 with `maximumPoolSize = 2`,
+  then asserting the provider count reaches 2. Do not treat two sequential
+  logical borrows as evidence because Hikari may reuse one physical connection.
+- add a logical-borrow reuse assertion when practical: returning and borrowing
+  the same pooled physical connection should not force another token lookup.
+- assert RDS IAM mode still configures Hikari through `dataSource` and does not
+  set Hikari `jdbcUrl`, `username`, `password`, `credentialsProvider`,
+  or `dataSourceClassName` directly.
+- run the AWS Hikari boundary test through `HikariAwsJdbcDataSourceFactory`,
+  not only by instantiating the generic DataSource directly.
+- add an explicit caller-supplied credential rejection assertion if it is not
+  already covered by the generic helper tests.
+- existing redaction tests remain in AWS because `bluetape4k-jdbc` only sees
+  revealed JDBC password strings at the driver boundary.
+
+## Documentation Requirements
+
+- `data/jdbc/README.md` and `data/jdbc/README.ko.md` must include
+  source-equivalent sections for the refresh-aware `DataSource` helper.
+- README examples must include imports, a runnable-style Kotlin snippet using
+  `RefreshingJdbcPasswordDataSourceConfig`, and a Hikari wrapping example that
+  sets `dataSource = RefreshingJdbcPasswordDataSource(...)`.
+- README/KDoc must warn that `getConnection(username, password)` is rejected,
+  and that `getLogWriter` / `setLogWriter` / `getLoginTimeout` /
+  `setLoginTimeout` use process-wide `DriverManager` state.
+- README/KDoc must list unsupported cases: this helper is not a connection
+  pool, scheduled refresh service, async password provider, generic static
+  credential helper, or caller-supplied credential override path.
+- README/KDoc must say `dataSourceProperties` may contain vendor driver
+  options, but secret-bearing entries are not diagnostic-safe; `user` and
+  `password` entries are overwritten by the constructor username and current
+  provider password.
+- README/KDoc examples must import from `io.bluetape4k.jdbc.datasource`.
+- New public KDoc for this helper must be English. Existing Korean KDoc in
+  unrelated `data/jdbc` files is not part of this cleanup.
+
+## Publication Gate
+
+AWS consumption is a separate downstream step and remains blocked until one of
+these artifact paths is available and verified:
+
+- Snapshot validation path: publish `io.github.bluetape4k:bluetape4k-jdbc:1.11.0-SNAPSHOT`
+  from the upstream PR/ref, update AWS `gradle/libs.versions.toml` to
+  `bluetape4k = "1.11.0-SNAPSHOT"` only for the pre-release validation PR, and
+  prove dependency resolution from
+  `https://central.sonatype.com/repository/maven-snapshots/`.
+- Stable release path: publish a forward version such as `1.11.1` or the next
+  explicitly approved release train, update AWS to that stable version, and
+  verify resolution from Maven Central release repositories.
+
+Do not edit AWS to consume an unreleased helper unless the selected snapshot or
+stable artifact path has already been published and resolved in a clean build.
+AWS `0.5.0` migration must update the catalog coordinate first, keep the
+Central snapshots repository only for the snapshot path, run dependency
+resolution evidence, run clean AWS CI, and only then remove the internal
+wrapper.
+
+## Rollback
+
+- If AWS snapshot validation fails, revert the AWS catalog coordinate and keep
+  the internal `RdsIamRefreshingDataSource` until a corrected snapshot is
+  published and resolved.
+- If a published stable helper is wrong, use a forward-only patch release and,
+  when needed, deprecate the flawed API. Do not delete or rewrite stable
+  artifacts.
+- If the upstream `bluetape4k-projects` PR fails CI or review, no AWS change is
+  attempted.
+
+## Risks And Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| AWS cannot consume the helper until publication. | Split delivery into upstream `bluetape4k-projects` PR first, then AWS consumption after a published version or snapshot exists. |
+| Generic helper leaks secret values through diagnostics. | Do not include password values in exception messages or `toString()`. Keep redaction tests in AWS value objects. |
+| Existing AWS behavior changes around property precedence. | Pin precedence in tests: base properties copied first, `user` and `password` written last. |
+| `getConnection(username, password)` ambiguity creates unsafe bypass. | Reject the overload consistently in the generic helper and keep AWS tests for the rejection. |
+| Hikari integration changes lifecycle semantics. | Keep Hikari configuration unchanged; only the nested `dataSource` implementation changes after AWS consumes the helper. |
+
+## Acceptance Criteria
+
+- `data/jdbc` exposes a generic refresh-aware `DataSource` API with English
+  KDoc.
+- `data/jdbc` tests prove per-call password lookup, caller-supplied credential
+  rejection, null-password failure, wrapper behavior, and no per-call property
+  leakage.
+- `data/jdbc/README.md` and `data/jdbc/README.ko.md` mention the new
+  refresh-aware `DataSource` helper with runnable-style examples, imports,
+  unsupported cases, Hikari wrapping, and process-global `DriverManager`
+  method warnings.
+- `bluetape4k-projects` targeted compile/tests for `:bluetape4k-jdbc` pass:
+  `:bluetape4k-jdbc:test`, `:bluetape4k-jdbc:koverXmlReport`, and
+  `git diff --check`.
+- `bluetape4k-projects` PR CI includes the `test-data` path that runs
+  `:bluetape4k-jdbc:test` and `:bluetape4k-jdbc:koverXmlReport`.
+- AWS consumption is explicitly blocked until a consumable `bluetape4k-jdbc`
+  version exists; once available, AWS replaces the internal DataSource wrapper
+  without changing RDS IAM token provider/redaction semantics.
+- AWS consumption verification includes dependency-resolution evidence for the
+  selected artifact coordinate and `:bluetape4k-aws-exposed:test`.
+
+## Out Of Scope
+
+- Publishing a stable `bluetape4k-projects` release without an explicit release
+  request.
+- Changing `AwsDatabasePasswordProvider` caching semantics.
+- Adding Hikari-specific token refresh APIs.
+- Adding Spring Boot auto-configuration for this helper.
+- Changing `bluetape4k-aws` catalog versions before the helper is actually
+  available from a repository CI can resolve.


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: feat: add refreshing JDBC password DataSource

- Add `RefreshingJdbcPasswordDataSource` to `bluetape4k-jdbc` for per-physical-connection password refresh through `DriverManager`.
- Add `JdbcPasswordProvider` and `RefreshingJdbcPasswordDataSourceConfig` with validation, secret-free diagnostics, and wrapper behavior.
- Document the helper in both `data/jdbc/README.md` and `data/jdbc/README.ko.md`.
- Add design and implementation plan artifacts for the cross-repo handoff.

Refs bluetape4k/bluetape4k-aws#295.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Notes

This PR is the upstream prerequisite for AWS issue #295. It does not update
`bluetape4k-aws` because AWS cannot consume the helper until a snapshot or
stable `bluetape4k-jdbc` artifact containing this API is published and resolved
in a clean build.

The helper intentionally rejects `getConnection(username, password)` so callers
and pools cannot bypass the refresh-aware no-arg `getConnection()` path.
`toString()` redacts username and credential-bearing URL parts.

### 기존 섹션: Verification

- `./gradlew :bluetape4k-jdbc:test --no-daemon --stacktrace --rerun-tasks`
- `./gradlew :bluetape4k-jdbc:koverXmlReport --no-daemon --stacktrace`
- `git diff --check`

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #938, head `273f7868dbcf1f4e00b4bedf4157a8a12f3fe137`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `feat/projects-refreshing-jdbc-datasource`
- Labels: `documentation`, `test`, `refactoring`
- State: `MERGED`, merge commit `632b76a920fd8cfdfd820623e535e6623d0cdcaf`
- CI: - `./gradlew :bluetape4k-jdbc:test --no-daemon --stacktrace --rerun-tasks` / - `./gradlew :bluetape4k-jdbc:koverXmlReport --no-daemon --stacktrace`

## DoD Status

- [x] Generic refresh-aware JDBC `DataSource` added under `io.bluetape4k.jdbc.datasource`.
- [x] Tests cover provider invocation, property isolation, caller credential rejection, null password failure, wrapper behavior, `toString()` redaction, provider failure wrapping, driver class loading failure, and DriverManager global delegation.
- [x] English and Korean README sections added with imports, runnable-style usage, Hikari wrapping, unsupported cases, and DriverManager global-state warning.
- [x] AWS consumption remains blocked until a consumable `bluetape4k-jdbc` artifact is available.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #938 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `632b76a920fd8cfdfd820623e535e6623d0cdcaf`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
