### PR TITLE
fix: preserve API helper caller contracts

### DIFF
--- a/data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/CassandraAdmin.kt
+++ b/data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/CassandraAdmin.kt
@@ -11,6 +11,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
 import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
 
 /**
  * Cassandra keyspace 관리 및 버전 조회 유틸리티 객체입니다.
@@ -47,15 +48,16 @@ object CassandraAdmin: KLogging() {
         keyspace: String = DEFAULT_KEYSPACE,
         replicationFactor: Int = DEFAULT_REPLICATION_FACTOR,
     ): Boolean {
-        keyspace.requireNotBlank("keyspace")
+        val checkedKeyspace = keyspace.requireNotBlank("keyspace")
+        val checkedReplicationFactor = replicationFactor.requirePositiveNumber("replicationFactor")
 
-        val stmt = SchemaBuilder.createKeyspace(keyspace)
+        val stmt = SchemaBuilder.createKeyspace(checkedKeyspace)
             .ifNotExists()
-            .withSimpleStrategy(replicationFactor)
+            .withSimpleStrategy(checkedReplicationFactor)
             .build()
 
         return session.execute(stmt).wasApplied().apply {
-            log.info { "Create Keyspace[$keyspace], replicationFactor[$replicationFactor] wasApplied [$this]" }
+            log.info { "Create Keyspace[$checkedKeyspace], replicationFactor[$checkedReplicationFactor] wasApplied [$this]" }
         }
     }
 

--- a/data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/CassandraAdminTest.kt
+++ b/data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/CassandraAdminTest.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.cassandra
 
-import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.coroutines.KLoggingChannel
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 
 /**
  * [CassandraAdmin]의 keyspace 생성/삭제 및 버전 조회 기능을 검증합니다.
@@ -57,6 +57,13 @@ class CassandraAdminTest : AbstractCassandraTest() {
     fun `createKeyspace 는 blank keyspace 를 허용하지 않는다`() {
         assertFailsWith<IllegalArgumentException> {
             CassandraAdmin.createKeyspace(session, " ")
+        }
+    }
+
+    @Test
+    fun `createKeyspace 는 양수가 아닌 replicationFactor 를 허용하지 않는다`() {
+        assertFailsWith<IllegalArgumentException> {
+            CassandraAdmin.createKeyspace(session, TEST_KEYSPACE, replicationFactor = 0)
         }
     }
 

--- a/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/PreparedStatementExtensions.kt
+++ b/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/PreparedStatementExtensions.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.jdbc.sql
 
+import io.bluetape4k.support.requirePositiveNumber
 import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.sql.Statement
@@ -135,6 +136,7 @@ fun java.sql.Connection.executeBatch(
     paramsList: List<List<Any?>>,
     batchSize: Int = 1000,
 ): List<IntArray> {
+    val checkedBatchSize = batchSize.requirePositiveNumber("batchSize")
     if (paramsList.isEmpty()) return emptyList()
     paramsList.requireConsistentBatchParameterRows()
 
@@ -149,14 +151,14 @@ fun java.sql.Connection.executeBatch(
             stmt.addBatch()
 
             // 배치 크기에 도달하면 실행
-            if ((index + 1) % batchSize == 0) {
+            if ((index + 1) % checkedBatchSize == 0) {
                 results.add(stmt.executeBatch())
                 stmt.clearBatch()
             }
         }
 
         // 남은 배치 실행
-        if (paramsList.size % batchSize != 0) {
+        if (paramsList.size % checkedBatchSize != 0) {
             results.add(stmt.executeBatch())
         }
 
@@ -194,6 +196,7 @@ fun java.sql.Connection.executeLargeBatch(
     paramsList: List<List<Any?>>,
     batchSize: Int = 1000,
 ): LongArray {
+    val checkedBatchSize = batchSize.requirePositiveNumber("batchSize")
     if (paramsList.isEmpty()) return LongArray(0)
     paramsList.requireConsistentBatchParameterRows()
 
@@ -207,13 +210,13 @@ fun java.sql.Connection.executeLargeBatch(
             }
             stmt.addBatch()
 
-            if ((index + 1) % batchSize == 0) {
+            if ((index + 1) % checkedBatchSize == 0) {
                 stmt.executeLargeBatch().forEach { results.add(it) }
                 stmt.clearBatch()
             }
         }
 
-        if (paramsList.size % batchSize != 0) {
+        if (paramsList.size % checkedBatchSize != 0) {
             stmt.executeLargeBatch().forEach { results.add(it) }
         }
 

--- a/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/sql/DataSourceTransactionExtensionsTest.kt
+++ b/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/sql/DataSourceTransactionExtensionsTest.kt
@@ -1,13 +1,13 @@
 package io.bluetape4k.jdbc.sql
 
-import io.bluetape4k.jdbc.model.Actor
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.jdbc.model.Actor
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 
 /**
  * DataSourceTransactionExtensions 테스트 클래스
@@ -220,6 +220,17 @@ class DataSourceTransactionExtensionsTest: AbstractJdbcSqlTest() {
     }
 
     @Test
+    fun `DataSource executeBatch - batchSize 는 양수여야 한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            dataSource.executeBatch(
+                "INSERT INTO Actors (firstname, lastname) VALUES (?, ?)",
+                listOf(listOf("InvalidBatch", "Actor")),
+                batchSize = 0
+            )
+        }
+    }
+
+    @Test
     fun `DataSource executeBatch - inconsistent parameter rows fail fast`() {
         assertFailsWith<IllegalArgumentException> {
             dataSource.executeBatch(
@@ -285,7 +296,18 @@ class DataSourceTransactionExtensionsTest: AbstractJdbcSqlTest() {
             ) { rs ->
                 rs.next()
                 rs.getInt(1)
-            }
+        }
         count shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `DataSource executeLargeBatch - batchSize 는 양수여야 한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            dataSource.executeLargeBatch(
+                "INSERT INTO Actors (firstname, lastname) VALUES (?, ?)",
+                listOf(listOf("InvalidLargeBatch", "Actor")),
+                batchSize = -1
+            )
+        }
     }
 }

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/query/QueryBuilder.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/query/QueryBuilder.kt
@@ -4,6 +4,8 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.r2dbc.support.toParameter
 import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
+import io.bluetape4k.support.requireZeroOrPositiveNumber
 import io.bluetape4k.utils.Systemx
 import io.r2dbc.spi.Parameters
 import kotlin.reflect.KProperty
@@ -155,7 +157,7 @@ class QueryBuilder {
      */
     fun limit(limit: Int) =
         apply {
-            this.limit = limit
+            this.limit = limit.requirePositiveNumber("limit")
         }
 
     /**
@@ -163,7 +165,7 @@ class QueryBuilder {
      */
     fun offset(offset: Int) =
         apply {
-            this.offset = offset
+            this.offset = offset.requireZeroOrPositiveNumber("offset")
         }
 
     /**

--- a/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/query/QueryBuilderTest.kt
+++ b/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/query/QueryBuilderTest.kt
@@ -193,6 +193,26 @@ class QueryBuilderTest {
     }
 
     @Test
+    fun `limit 은 양수여야 한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            query {
+                select("select * from actor")
+                limit(0)
+            }
+        }
+    }
+
+    @Test
+    fun `offset 은 0 이상이어야 한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            query {
+                select("select * from actor")
+                offset(-1)
+            }
+        }
+    }
+
+    @Test
     fun `select with group by and having`() {
         val query = query {
             select("select actor_id, count(*) as cnt from actor")

--- a/docs/lessons/2026-07-04-api-contract-failures.md
+++ b/docs/lessons/2026-07-04-api-contract-failures.md
@@ -1,0 +1,29 @@
+# API contract failures should preserve caller context
+
+## Context
+
+Issues #951 and #954 found helper APIs where public contracts drifted from
+caller expectations:
+
+- Ktor Swagger UI collapsed nested specification paths to a basename.
+- RestClient coroutine helpers used `!!`, turning empty bodies into raw
+  `NullPointerException` failures.
+
+## Decision
+
+- Preserve caller-provided relative Swagger specification paths for both the
+  file source and Swagger UI remote path.
+- Replace RestClient coroutine `!!` assertions with an explicit non-null body
+  contract error that includes HTTP method, URI, and target type.
+
+## Verification
+
+- `./gradlew :bluetape4k-ktor-openapi:test --tests 'io.bluetape4k.ktor.openapi.KtorOpenApiRoutesTest'`
+- `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.http.RestClientCoroutinesDslTest'`
+- `git diff --check`
+
+## Future guidance
+
+Route helper defaults must keep documented path contracts source-verified.
+Coroutine wrappers around blocking clients should expose explicit caller-facing
+contract errors instead of relying on Kotlin null assertions.

--- a/docs/lessons/2026-07-04-data-validation-fail-fast.md
+++ b/docs/lessons/2026-07-04-data-validation-fail-fast.md
@@ -1,0 +1,31 @@
+# Data validation fail-fast for public numeric parameters
+
+## Context
+
+Issues #947 and #955 found public data APIs that accepted invalid numeric
+parameters and let downstream JDBC modulo operations or SQL/CQL builders expose
+late, low-signal failures.
+
+## Decision
+
+Validate numeric inputs at the public entrypoint with bluetape4k `require*`
+helpers:
+
+- JDBC batch size must be positive before any batch loop or modulo operation.
+- R2DBC query limit must be positive.
+- R2DBC query offset must be zero or positive.
+- Cassandra keyspace replication factor must be positive.
+
+## Verification
+
+- `./gradlew :bluetape4k-jdbc:test --tests 'io.bluetape4k.jdbc.sql.DataSourceTransactionExtensionsTest'`
+- `./gradlew :bluetape4k-r2dbc:test --tests 'io.bluetape4k.r2dbc.query.QueryBuilderTest'`
+- `./gradlew :bluetape4k-cassandra:test --tests 'io.bluetape4k.cassandra.CassandraAdminTest'`
+- `git diff --check`
+
+## Future guidance
+
+For public data API parameters that shape generated SQL/CQL or loop arithmetic,
+validate before delegating to driver builders or iteration logic. Prefer
+`requirePositiveNumber` and `requireZeroOrPositiveNumber` over raw `require`
+when the parameter is numeric.

--- a/ktor/openapi/src/main/kotlin/io/bluetape4k/ktor/openapi/KtorOpenApiRoutes.kt
+++ b/ktor/openapi/src/main/kotlin/io/bluetape4k/ktor/openapi/KtorOpenApiRoutes.kt
@@ -7,7 +7,6 @@ import io.ktor.server.plugins.swagger.SwaggerConfig
 import io.ktor.server.plugins.swagger.swaggerUI
 import io.ktor.server.routing.openapi.OpenApiDocSource
 import io.ktor.server.routing.Route
-import java.io.File
 
 /**
  * Adds an OpenAPI documentation endpoint backed by Ktor's official OpenAPI plugin.
@@ -30,11 +29,11 @@ fun Route.bluetape4kOpenApi(
     configure: OpenAPIConfig.() -> Unit = {},
 ): Route {
     path.requireNotBlank("path")
-    swaggerFile.requireNotBlank("swaggerFile")
+    val checkedSwaggerFile = swaggerFile.requireNotBlank("swaggerFile")
     return openAPI(path = path) {
         configure()
         if (source.isDefaultDocumentSource()) {
-            source = OpenApiDocSource.File(swaggerFile)
+            source = OpenApiDocSource.File(checkedSwaggerFile)
         }
     }
 }
@@ -44,7 +43,9 @@ fun Route.bluetape4kOpenApi(
  *
  * ## Contract
  * - The endpoint is explicit and route-scoped.
- * - [swaggerFile] is used when [configure] leaves Ktor's default document source unchanged.
+ * - [swaggerFile] is used as both the document source and Swagger UI remote path when [configure] leaves
+ *   Ktor's default document source unchanged.
+ * - Nested relative specification paths, such as `openapi/documentation.yaml`, are preserved.
  * - A caller-owned [SwaggerConfig.source] from [configure] is preserved for routing-tree or generated metadata.
  * - This helper does not generate route behavior or mutate existing routes.
  *
@@ -60,12 +61,12 @@ fun Route.bluetape4kSwaggerUi(
     configure: SwaggerConfig.() -> Unit = {},
 ): Route {
     path.requireNotBlank("path")
-    swaggerFile.requireNotBlank("swaggerFile")
+    val checkedSwaggerFile = swaggerFile.requireNotBlank("swaggerFile")
     return swaggerUI(path = path) {
         configure()
         if (source.isDefaultDocumentSource()) {
-            source = OpenApiDocSource.File(swaggerFile)
-            remotePath = File(swaggerFile).name
+            source = OpenApiDocSource.File(checkedSwaggerFile)
+            remotePath = checkedSwaggerFile
         }
     }
 }

--- a/ktor/openapi/src/test/kotlin/io/bluetape4k/ktor/openapi/KtorOpenApiRoutesTest.kt
+++ b/ktor/openapi/src/test/kotlin/io/bluetape4k/ktor/openapi/KtorOpenApiRoutesTest.kt
@@ -59,6 +59,23 @@ class KtorOpenApiRoutesTest {
     }
 
     @Test
+    fun `swagger ui endpoint preserves nested specification remote path`() = testApplication {
+        application {
+            installOpenApiTestCore()
+            routing {
+                bluetape4kSwaggerUi(swaggerFile = "openapi/documentation.yaml")
+            }
+        }
+
+        val response = client.get("/swagger/openapi/documentation.yaml")
+        val body = response.bodyAsText()
+
+        response.status shouldBeEqualTo HttpStatusCode.OK
+        body.contains("Bluetape4k Ktor OpenAPI Test") shouldBeEqualTo true
+        body.contains("/healthz") shouldBeEqualTo true
+    }
+
+    @Test
     fun `openapi endpoint preserves caller owned document source`() = testApplication {
         application {
             installOpenApiTestCore()

--- a/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/http/RestClientCoroutinesDsl.kt
+++ b/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/http/RestClientCoroutinesDsl.kt
@@ -6,7 +6,12 @@ import org.springframework.http.MediaType
 import org.springframework.web.client.RestClient
 
 /**
- * [RestClient]를 사용하여 suspend GET 요청을 수행하고 응답을 역직렬화합니다.
+ * Performs a suspend GET request with [RestClient] and deserializes a non-null response body.
+ *
+ * ## Contract
+ * - Blocking RestClient I/O runs on [Dispatchers.IO].
+ * - Empty response bodies fail with [IllegalStateException] that includes the method, URI, and target type.
+ * - Use [suspendGetOrNull] when an empty body is a valid response.
  *
  * ```kotlin
  * val user = client.suspendGet<User>("/users/1")
@@ -23,11 +28,16 @@ suspend inline fun <reified T: Any> RestClient.suspendGet(
     runInterruptible(Dispatchers.IO) {
         val spec = get().uri(uri)
         if (accept != null) spec.accept(accept)
-        spec.retrieve().body(T::class.java)!!
+        requireRestClientBody(spec.retrieve().body(T::class.java), "GET", uri)
     }
 
 /**
- * [RestClient]를 사용하여 suspend POST 요청을 수행하고 응답을 역직렬화합니다.
+ * Performs a suspend POST request with [RestClient] and deserializes a non-null response body.
+ *
+ * ## Contract
+ * - Blocking RestClient I/O runs on [Dispatchers.IO].
+ * - Empty response bodies fail with [IllegalStateException] that includes the method, URI, and target type.
+ * - Use [suspendPostOrNull] when an empty body is a valid response.
  *
  * ```kotlin
  * val created = client.suspendPost<User>("/users", newUser, MediaType.APPLICATION_JSON)
@@ -50,11 +60,16 @@ suspend inline fun <reified T: Any> RestClient.suspendPost(
         if (contentType != null) spec.contentType(contentType)
         if (accept != null) spec.accept(accept)
         if (body != null) spec.body(body)
-        spec.retrieve().body(T::class.java)!!
+        requireRestClientBody(spec.retrieve().body(T::class.java), "POST", uri)
     }
 
 /**
- * [RestClient]를 사용하여 suspend PUT 요청을 수행하고 응답을 역직렬화합니다.
+ * Performs a suspend PUT request with [RestClient] and deserializes a non-null response body.
+ *
+ * ## Contract
+ * - Blocking RestClient I/O runs on [Dispatchers.IO].
+ * - Empty response bodies fail with [IllegalStateException] that includes the method, URI, and target type.
+ * - Use [suspendPutOrNull] when an empty body is a valid response.
  *
  * ```kotlin
  * val updated = client.suspendPut<User>("/users/1", updatedUser, MediaType.APPLICATION_JSON)
@@ -77,11 +92,16 @@ suspend inline fun <reified T: Any> RestClient.suspendPut(
         if (contentType != null) spec.contentType(contentType)
         if (accept != null) spec.accept(accept)
         if (body != null) spec.body(body)
-        spec.retrieve().body(T::class.java)!!
+        requireRestClientBody(spec.retrieve().body(T::class.java), "PUT", uri)
     }
 
 /**
- * [RestClient]를 사용하여 suspend PATCH 요청을 수행하고 응답을 역직렬화합니다.
+ * Performs a suspend PATCH request with [RestClient] and deserializes a non-null response body.
+ *
+ * ## Contract
+ * - Blocking RestClient I/O runs on [Dispatchers.IO].
+ * - Empty response bodies fail with [IllegalStateException] that includes the method, URI, and target type.
+ * - Use [suspendPatchOrNull] when an empty body is a valid response.
  *
  * ```kotlin
  * val patched = client.suspendPatch<User>("/users/1", patchData, MediaType.APPLICATION_JSON)
@@ -104,7 +124,7 @@ suspend inline fun <reified T: Any> RestClient.suspendPatch(
         if (contentType != null) spec.contentType(contentType)
         if (accept != null) spec.accept(accept)
         if (body != null) spec.body(body)
-        spec.retrieve().body(T::class.java)!!
+        requireRestClientBody(spec.retrieve().body(T::class.java), "PATCH", uri)
     }
 
 /**
@@ -228,3 +248,14 @@ suspend fun RestClient.suspendDelete(
         if (accept != null) spec.accept(accept)
         spec.retrieve().toBodilessEntity()
     }
+
+@PublishedApi
+internal inline fun <reified T: Any> requireRestClientBody(
+    body: T?,
+    method: String,
+    uri: String,
+): T =
+    body ?: throw IllegalStateException(
+        "RestClient $method $uri returned an empty response body for ${T::class.java.name}. " +
+            "Use the corresponding OrNull coroutine helper when an empty body is valid."
+    )

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/http/RestClientCoroutinesDslTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/http/RestClientCoroutinesDslTest.kt
@@ -1,6 +1,9 @@
 package io.bluetape4k.spring.http
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.KLogging
 import kotlinx.coroutines.cancelAndJoin
@@ -95,6 +98,62 @@ class RestClientCoroutinesDslTest {
             )
             val result: String = restClient.suspendPatch("/test", "payload", MediaType.APPLICATION_JSON)
             result shouldBeEqualTo "patched"
+        }
+
+    @Test
+    fun `suspendGet rejects empty body with contextual contract error`() =
+        runTest {
+            mockServer.enqueue(MockResponse().setResponseCode(204))
+
+            val error = assertFailsWith<IllegalStateException> {
+                restClient.suspendGet<String>("/empty-get")
+            }
+
+            val message = error.message.shouldNotBeNull()
+            message shouldContain "GET /empty-get"
+            message shouldContain "java.lang.String"
+        }
+
+    @Test
+    fun `suspendPost rejects empty body with contextual contract error`() =
+        runTest {
+            mockServer.enqueue(MockResponse().setResponseCode(204))
+
+            val error = assertFailsWith<IllegalStateException> {
+                restClient.suspendPost<String>("/empty-post", "payload", MediaType.APPLICATION_JSON)
+            }
+
+            val message = error.message.shouldNotBeNull()
+            message shouldContain "POST /empty-post"
+            message shouldContain "java.lang.String"
+        }
+
+    @Test
+    fun `suspendPut rejects empty body with contextual contract error`() =
+        runTest {
+            mockServer.enqueue(MockResponse().setResponseCode(204))
+
+            val error = assertFailsWith<IllegalStateException> {
+                restClient.suspendPut<String>("/empty-put", "payload", MediaType.APPLICATION_JSON)
+            }
+
+            val message = error.message.shouldNotBeNull()
+            message shouldContain "PUT /empty-put"
+            message shouldContain "java.lang.String"
+        }
+
+    @Test
+    fun `suspendPatch rejects empty body with contextual contract error`() =
+        runTest {
+            mockServer.enqueue(MockResponse().setResponseCode(204))
+
+            val error = assertFailsWith<IllegalStateException> {
+                restClient.suspendPatch<String>("/empty-patch", "payload", MediaType.APPLICATION_JSON)
+            }
+
+            val message = error.message.shouldNotBeNull()
+            message shouldContain "PATCH /empty-patch"
+            message shouldContain "java.lang.String"
         }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #951, #954

- PR 제목: fix: preserve API helper caller contracts

- Preserve nested Swagger UI specification paths such as `openapi/documentation.yaml` instead of collapsing them to a basename.
- Replace RestClient coroutine `!!` body assertions with explicit non-null body contract errors that include HTTP method, URI, and target type.
- Add targeted regression tests and a short lesson for API helper caller contracts.

Fixes #951.
Fixes #954.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Stacked PR

- Stack position: 2 / N
- Base: `fix/issue-947-955-data-validation` (#957)
- Head: `fix/issue-951-954-api-contracts`
- Next planned base: this branch

## Validation

- `./gradlew :bluetape4k-ktor-openapi:test --tests 'io.bluetape4k.ktor.openapi.KtorOpenApiRoutesTest'` -> BUILD SUCCESSFUL in 8s
- `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.http.RestClientCoroutinesDslTest'` -> BUILD SUCCESSFUL in 14s
- `git diff --check`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #951, #954, milestone `1.12.0`, assignee `debop`
- PR: #958, head `26e4f30c8bb22fdcf36c1d5e0a570455b5e7d5f6`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-951-954-api-contracts`
- Labels: `bug`, `documentation`, `java`, `tech-debt`
- State: `MERGED`, merge commit `fc39e9e2dd57f70222656d03a73bb6496a5df063`
- CI: - Preserve nested Swagger UI specification paths such as `openapi/documentation.yaml` instead of collapsing them to a basename. / - Replace RestClient coroutine `!!` body assertions with explicit non-null body contract errors that include HTTP method, URI, and target type. / - `./gradlew :bluetape4k-ktor-openapi:test --tests 'io.bluetape4k.ktor.openapi.KtorOpenApiRoutesTest'` -> BUILD SUCCESSFUL in 8s

## DoD Status

- [x] Issue #951 metadata verified: milestone `1.12.0`, assignee `debop`, labels `bug,documentation`.
- [x] Issue #954 metadata verified: milestone `1.12.0`, assignee `debop`, labels `bug,java,tech-debt`.
- [x] PR metadata mirrors issue milestone, assignee, and labels.
- [x] Targeted module tests passed.
- [x] Diff hygiene passed.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #958 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `fc39e9e2dd57f70222656d03a73bb6496a5df063`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
