### PR TITLE
fix: preserve Lettuce lock release tokens

### DIFF
--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCache.kt
@@ -154,9 +154,7 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
 
         return when (config.getFailureStrategy) {
             GetFailureStrategy.RETURN_FRONT_OR_NULL ->
-                runCatching { backCache.get(key) }
-                    .onFailure { e -> log.warn(e) { "Back cache GET failed for key=$key, returning null" } }
-                    .getOrNull()
+                getBackOrNull(key, "Back cache GET failed for key=$key, returning null")
                     ?.also { value -> frontCache.put(key, value) }
 
             GetFailureStrategy.PROPAGATE_EXCEPTION ->
@@ -173,9 +171,7 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
         val missedKeys = (keys - result.keys).filter { !tombstones.contains(it) }
 
         missedKeys.forEach { key ->
-            runCatching { backCache.get(key) }
-                .onFailure { e -> log.warn(e) { "Back cache GET failed for key=$key during getAll" } }
-                .getOrNull()
+            getBackOrNull(key, "Back cache GET failed for key=$key during getAll")
                 ?.let { value ->
                     result[key] = value
                     frontCache.put(key, value)
@@ -237,7 +233,7 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
         if (tombstones.contains(key) || clearPending.value) return false
 
         if (!frontCache.containsKey(key)) {
-            if (!runCatching { backCache.containsKey(key) }.getOrDefault(false)) return false
+            if (!containsBackOrFalse(key, null)) return false
         }
         val replaced = backCache.replace(key, value)
         if (replaced) {
@@ -279,9 +275,7 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
     suspend fun containsKey(key: K): Boolean {
         if (tombstones.contains(key) || clearPending.value) return false
         if (frontCache.containsKey(key)) return true
-        return runCatching { backCache.containsKey(key) }
-            .onFailure { e -> log.warn(e) { "Back cache containsKey failed for key=$key" } }
-            .getOrDefault(false)
+        return containsBackOrFalse(key, "Back cache containsKey failed for key=$key")
     }
 
     /**
@@ -332,6 +326,34 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
      * 로컬 캐시의 추정 크기.
      */
     fun localCacheSize(): Long = frontCache.estimatedSize()
+
+    private suspend fun getBackOrNull(
+        key: K,
+        failureMessage: String,
+    ): V? =
+        try {
+            backCache.get(key)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { failureMessage }
+            null
+        }
+
+    private suspend fun containsBackOrFalse(
+        key: K,
+        failureMessage: String?,
+    ): Boolean =
+        try {
+            backCache.containsKey(key)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            if (failureMessage != null) {
+                log.warn(e) { failureMessage }
+            }
+            false
+        }
 
     /**
      * 모든 리소스를 정리한다.

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCacheTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCacheTest.kt
@@ -1,14 +1,19 @@
 package io.bluetape4k.cache.nearcache.jcache
 
 import io.bluetape4k.cache.jcache.CaffeineSuspendJCache
-import io.bluetape4k.idgenerators.uuid.Uuid
-import io.bluetape4k.junit5.awaitility.untilSuspending
-import io.bluetape4k.junit5.coroutines.runSuspendIO
-import io.bluetape4k.logging.KLogging
+import io.bluetape4k.cache.jcache.SuspendJCache
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.idgenerators.uuid.Uuid
+import io.bluetape4k.junit5.awaitility.untilSuspending
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.KLogging
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import org.awaitility.kotlin.atMost
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.AfterEach
@@ -88,6 +93,23 @@ class ResilientSuspendNearJCacheTest {
         }
 
     @Test
+    fun `get - CancellationException은 fallback하지 않고 재전파한다`() =
+        runSuspendIO {
+            val failingCache = resilientCacheWithFailingBackCache { backCache ->
+                coEvery { backCache.get("cancel-key") } throws CancellationException("cancel get")
+            }
+
+            try {
+                val error = assertFailsWith<CancellationException> {
+                    failingCache.get("cancel-key")
+                }
+                error.message shouldBeEqualTo "cancel get"
+            } finally {
+                failingCache.close()
+            }
+        }
+
+    @Test
     fun `putAll and getAll`() =
         runSuspendIO {
             val data = mapOf("a" to "1", "b" to "2", "c" to "3")
@@ -97,6 +119,23 @@ class ResilientSuspendNearJCacheTest {
             result["b"] shouldBeEqualTo "2"
             result["c"] shouldBeEqualTo "3"
             result["x"].shouldBeNull()
+        }
+
+    @Test
+    fun `getAll - CancellationException은 fallback하지 않고 재전파한다`() =
+        runSuspendIO {
+            val failingCache = resilientCacheWithFailingBackCache { backCache ->
+                coEvery { backCache.get("cancel-key") } throws CancellationException("cancel getAll")
+            }
+
+            try {
+                val error = assertFailsWith<CancellationException> {
+                    failingCache.getAll(setOf("cancel-key"))
+                }
+                error.message shouldBeEqualTo "cancel getAll"
+            } finally {
+                failingCache.close()
+            }
         }
 
     @Test
@@ -133,6 +172,23 @@ class ResilientSuspendNearJCacheTest {
         }
 
     @Test
+    fun `containsKey - CancellationException은 false fallback하지 않고 재전파한다`() =
+        runSuspendIO {
+            val failingCache = resilientCacheWithFailingBackCache { backCache ->
+                coEvery { backCache.containsKey("cancel-key") } throws CancellationException("cancel contains")
+            }
+
+            try {
+                val error = assertFailsWith<CancellationException> {
+                    failingCache.containsKey("cancel-key")
+                }
+                error.message shouldBeEqualTo "cancel contains"
+            } finally {
+                failingCache.close()
+            }
+        }
+
+    @Test
     fun `putIfAbsent - 캐시 값 없으면 추가, 있으면 기존 값 반환`() =
         runSuspendIO {
             cache.putIfAbsent("key", "first").shouldBeNull()
@@ -152,6 +208,23 @@ class ResilientSuspendNearJCacheTest {
 
             cache.replace("key", "new").shouldBeTrue()
             cache.get("key") shouldBeEqualTo "new"
+        }
+
+    @Test
+    fun `replace - containsKey CancellationException은 false fallback하지 않고 재전파한다`() =
+        runSuspendIO {
+            val failingCache = resilientCacheWithFailingBackCache { backCache ->
+                coEvery { backCache.containsKey("cancel-key") } throws CancellationException("cancel replace")
+            }
+
+            try {
+                val error = assertFailsWith<CancellationException> {
+                    failingCache.replace("cancel-key", "value")
+                }
+                error.message shouldBeEqualTo "cancel replace"
+            } finally {
+                failingCache.close()
+            }
         }
 
     @Test
@@ -217,5 +290,19 @@ class ResilientSuspendNearJCacheTest {
         c.close()
         c.close() // 중복 호출 시에도 예외 없음
         c.isClosed.shouldBeTrue()
+    }
+
+    private fun resilientCacheWithFailingBackCache(
+        configure: (SuspendJCache<String, String>) -> Unit,
+    ): ResilientSuspendNearJCache<String, String> {
+        val failingBackCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        configure(failingBackCache)
+        return ResilientSuspendNearJCache(
+            backCache = failingBackCache,
+            config = ResilientNearJCacheConfig(
+                retryMaxAttempts = 1,
+                retryWaitDuration = Duration.ofMillis(10),
+            )
+        )
     }
 }

--- a/data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/CassandraAdmin.kt
+++ b/data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/CassandraAdmin.kt
@@ -11,6 +11,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
 import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
 
 /**
  * Cassandra keyspace 관리 및 버전 조회 유틸리티 객체입니다.
@@ -47,15 +48,16 @@ object CassandraAdmin: KLogging() {
         keyspace: String = DEFAULT_KEYSPACE,
         replicationFactor: Int = DEFAULT_REPLICATION_FACTOR,
     ): Boolean {
-        keyspace.requireNotBlank("keyspace")
+        val checkedKeyspace = keyspace.requireNotBlank("keyspace")
+        val checkedReplicationFactor = replicationFactor.requirePositiveNumber("replicationFactor")
 
-        val stmt = SchemaBuilder.createKeyspace(keyspace)
+        val stmt = SchemaBuilder.createKeyspace(checkedKeyspace)
             .ifNotExists()
-            .withSimpleStrategy(replicationFactor)
+            .withSimpleStrategy(checkedReplicationFactor)
             .build()
 
         return session.execute(stmt).wasApplied().apply {
-            log.info { "Create Keyspace[$keyspace], replicationFactor[$replicationFactor] wasApplied [$this]" }
+            log.info { "Create Keyspace[$checkedKeyspace], replicationFactor[$checkedReplicationFactor] wasApplied [$this]" }
         }
     }
 

--- a/data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/CassandraAdminTest.kt
+++ b/data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/CassandraAdminTest.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.cassandra
 
-import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.coroutines.KLoggingChannel
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 
 /**
  * [CassandraAdmin]의 keyspace 생성/삭제 및 버전 조회 기능을 검증합니다.
@@ -57,6 +57,13 @@ class CassandraAdminTest : AbstractCassandraTest() {
     fun `createKeyspace 는 blank keyspace 를 허용하지 않는다`() {
         assertFailsWith<IllegalArgumentException> {
             CassandraAdmin.createKeyspace(session, " ")
+        }
+    }
+
+    @Test
+    fun `createKeyspace 는 양수가 아닌 replicationFactor 를 허용하지 않는다`() {
+        assertFailsWith<IllegalArgumentException> {
+            CassandraAdmin.createKeyspace(session, TEST_KEYSPACE, replicationFactor = 0)
         }
     }
 

--- a/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/PreparedStatementExtensions.kt
+++ b/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/PreparedStatementExtensions.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.jdbc.sql
 
+import io.bluetape4k.support.requirePositiveNumber
 import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.sql.Statement
@@ -135,6 +136,7 @@ fun java.sql.Connection.executeBatch(
     paramsList: List<List<Any?>>,
     batchSize: Int = 1000,
 ): List<IntArray> {
+    val checkedBatchSize = batchSize.requirePositiveNumber("batchSize")
     if (paramsList.isEmpty()) return emptyList()
     paramsList.requireConsistentBatchParameterRows()
 
@@ -149,14 +151,14 @@ fun java.sql.Connection.executeBatch(
             stmt.addBatch()
 
             // 배치 크기에 도달하면 실행
-            if ((index + 1) % batchSize == 0) {
+            if ((index + 1) % checkedBatchSize == 0) {
                 results.add(stmt.executeBatch())
                 stmt.clearBatch()
             }
         }
 
         // 남은 배치 실행
-        if (paramsList.size % batchSize != 0) {
+        if (paramsList.size % checkedBatchSize != 0) {
             results.add(stmt.executeBatch())
         }
 
@@ -194,6 +196,7 @@ fun java.sql.Connection.executeLargeBatch(
     paramsList: List<List<Any?>>,
     batchSize: Int = 1000,
 ): LongArray {
+    val checkedBatchSize = batchSize.requirePositiveNumber("batchSize")
     if (paramsList.isEmpty()) return LongArray(0)
     paramsList.requireConsistentBatchParameterRows()
 
@@ -207,13 +210,13 @@ fun java.sql.Connection.executeLargeBatch(
             }
             stmt.addBatch()
 
-            if ((index + 1) % batchSize == 0) {
+            if ((index + 1) % checkedBatchSize == 0) {
                 stmt.executeLargeBatch().forEach { results.add(it) }
                 stmt.clearBatch()
             }
         }
 
-        if (paramsList.size % batchSize != 0) {
+        if (paramsList.size % checkedBatchSize != 0) {
             stmt.executeLargeBatch().forEach { results.add(it) }
         }
 

--- a/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/TransactionExtensions.kt
+++ b/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/TransactionExtensions.kt
@@ -155,11 +155,17 @@ inline fun <T> Connection.withIsolationLevel(
     block: (Connection) -> T,
 ): T {
     val originalLevel = this.transactionIsolation
+    var primaryFailure: Throwable? = null
     return try {
         this.transactionIsolation = level
         block(this)
+    } catch (e: Throwable) {
+        primaryFailure = e
+        throw e
     } finally {
-        this.transactionIsolation = originalLevel
+        restoreConnectionState(primaryFailure) {
+            this.transactionIsolation = originalLevel
+        }
     }
 }
 
@@ -183,11 +189,17 @@ inline fun <T> Connection.withAutoCommit(
     block: (Connection) -> T,
 ): T {
     val originalAutoCommit = this.autoCommit
+    var primaryFailure: Throwable? = null
     return try {
         this.autoCommit = autoCommit
         block(this)
+    } catch (e: Throwable) {
+        primaryFailure = e
+        throw e
     } finally {
-        this.autoCommit = originalAutoCommit
+        restoreConnectionState(primaryFailure) {
+            this.autoCommit = originalAutoCommit
+        }
     }
 }
 
@@ -209,11 +221,17 @@ inline fun <T> Connection.withAutoCommit(
  */
 inline fun <T> Connection.withReadOnly(block: (Connection) -> T): T {
     val originalReadOnly = this.isReadOnly
+    var primaryFailure: Throwable? = null
     return try {
         this.isReadOnly = true
         block(this)
+    } catch (e: Throwable) {
+        primaryFailure = e
+        throw e
     } finally {
-        this.isReadOnly = originalReadOnly
+        restoreConnectionState(primaryFailure) {
+            this.isReadOnly = originalReadOnly
+        }
     }
 }
 
@@ -236,10 +254,28 @@ inline fun <T> Connection.withHoldability(
     block: (Connection) -> T,
 ): T {
     val originalHoldability = this.holdability
+    var primaryFailure: Throwable? = null
     return try {
         this.holdability = holdability
         block(this)
+    } catch (e: Throwable) {
+        primaryFailure = e
+        throw e
     } finally {
-        this.holdability = originalHoldability
+        restoreConnectionState(primaryFailure) {
+            this.holdability = originalHoldability
+        }
+    }
+}
+
+@PublishedApi
+internal inline fun restoreConnectionState(
+    primaryFailure: Throwable?,
+    restore: () -> Unit,
+) {
+    try {
+        restore()
+    } catch (restoreFailure: Throwable) {
+        primaryFailure?.addSuppressed(restoreFailure) ?: throw restoreFailure
     }
 }

--- a/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/sql/DataSourceTransactionExtensionsTest.kt
+++ b/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/sql/DataSourceTransactionExtensionsTest.kt
@@ -1,13 +1,13 @@
 package io.bluetape4k.jdbc.sql
 
-import io.bluetape4k.jdbc.model.Actor
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.jdbc.model.Actor
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 
 /**
  * DataSourceTransactionExtensions 테스트 클래스
@@ -220,6 +220,17 @@ class DataSourceTransactionExtensionsTest: AbstractJdbcSqlTest() {
     }
 
     @Test
+    fun `DataSource executeBatch - batchSize 는 양수여야 한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            dataSource.executeBatch(
+                "INSERT INTO Actors (firstname, lastname) VALUES (?, ?)",
+                listOf(listOf("InvalidBatch", "Actor")),
+                batchSize = 0
+            )
+        }
+    }
+
+    @Test
     fun `DataSource executeBatch - inconsistent parameter rows fail fast`() {
         assertFailsWith<IllegalArgumentException> {
             dataSource.executeBatch(
@@ -285,7 +296,18 @@ class DataSourceTransactionExtensionsTest: AbstractJdbcSqlTest() {
             ) { rs ->
                 rs.next()
                 rs.getInt(1)
-            }
+        }
         count shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `DataSource executeLargeBatch - batchSize 는 양수여야 한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            dataSource.executeLargeBatch(
+                "INSERT INTO Actors (firstname, lastname) VALUES (?, ?)",
+                listOf(listOf("InvalidLargeBatch", "Actor")),
+                batchSize = -1
+            )
+        }
     }
 }

--- a/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/sql/TransactionExtensionsTest.kt
+++ b/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/sql/TransactionExtensionsTest.kt
@@ -1,17 +1,18 @@
 package io.bluetape4k.jdbc.sql
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
 import java.sql.Connection
+import java.sql.ResultSet
 import java.sql.SQLException
 
 /**
@@ -208,6 +209,74 @@ class TransactionExtensionsTest: AbstractJdbcSqlTest() {
     }
 
     @Test
+    fun `withIsolationLevel suppresses restore failure on primary failure`() {
+        val restoreFailure = SQLException("restore isolation")
+        val primaryFailure = RuntimeException("primary")
+        val recording = RecordingConnection(failRestoringIsolation = restoreFailure)
+
+        val thrown =
+            assertFailsWith<RuntimeException> {
+                recording.connection.withIsolationLevel(Connection.TRANSACTION_SERIALIZABLE) {
+                    throw primaryFailure
+                }
+            }
+
+        thrown shouldBeEqualTo primaryFailure
+        thrown.suppressed.toList() shouldContain restoreFailure
+    }
+
+    @Test
+    fun `withAutoCommit suppresses restore failure on primary failure`() {
+        val restoreFailure = SQLException("restore autoCommit")
+        val primaryFailure = RuntimeException("primary")
+        val recording = RecordingConnection(failRestoringAutoCommit = restoreFailure)
+
+        val thrown =
+            assertFailsWith<RuntimeException> {
+                recording.connection.withAutoCommit(false) {
+                    throw primaryFailure
+                }
+            }
+
+        thrown shouldBeEqualTo primaryFailure
+        thrown.suppressed.toList() shouldContain restoreFailure
+    }
+
+    @Test
+    fun `withReadOnly suppresses restore failure on primary failure`() {
+        val restoreFailure = SQLException("restore readOnly")
+        val primaryFailure = RuntimeException("primary")
+        val recording = RecordingConnection(failRestoringReadOnly = restoreFailure)
+
+        val thrown =
+            assertFailsWith<RuntimeException> {
+                recording.connection.withReadOnly {
+                    throw primaryFailure
+                }
+            }
+
+        thrown shouldBeEqualTo primaryFailure
+        thrown.suppressed.toList() shouldContain restoreFailure
+    }
+
+    @Test
+    fun `withHoldability suppresses restore failure on primary failure`() {
+        val restoreFailure = SQLException("restore holdability")
+        val primaryFailure = RuntimeException("primary")
+        val recording = RecordingConnection(failRestoringHoldability = restoreFailure)
+
+        val thrown =
+            assertFailsWith<RuntimeException> {
+                recording.connection.withHoldability(ResultSet.CLOSE_CURSORS_AT_COMMIT) {
+                    throw primaryFailure
+                }
+            }
+
+        thrown shouldBeEqualTo primaryFailure
+        thrown.suppressed.toList() shouldContain restoreFailure
+    }
+
+    @Test
     fun `복합 트랜잭션 작업`() {
         val actorId =
             dataSource.withTransaction { conn ->
@@ -267,21 +336,26 @@ private class RecordingConnection(
     autoCommit: Boolean = true,
     isolation: Int = Connection.TRANSACTION_READ_COMMITTED,
     readOnly: Boolean = false,
+    holdability: Int = ResultSet.HOLD_CURSORS_OVER_COMMIT,
     private val failRestoringAutoCommit: SQLException? = null,
     private val failRestoringIsolation: SQLException? = null,
     private val failRestoringReadOnly: SQLException? = null,
+    private val failRestoringHoldability: SQLException? = null,
     private val rollbackFailure: SQLException? = null,
 ): InvocationHandler {
 
     private val originalAutoCommit = autoCommit
     private val originalIsolation = isolation
     private val originalReadOnly = readOnly
+    private val originalHoldability = holdability
 
     var autoCommit: Boolean = autoCommit
         private set
     var isolation: Int = isolation
         private set
     var readOnly: Boolean = readOnly
+        private set
+    var holdability: Int = holdability
         private set
 
     val calls = mutableListOf<String>()
@@ -323,6 +397,15 @@ private class RecordingConnection(
                 calls.add("setReadOnly($value)")
                 if (isRestore) failRestoringReadOnly?.let { throw it }
                 readOnly = value
+                null
+            }
+            "getHoldability" -> holdability
+            "setHoldability" -> {
+                val value = arguments[0] as Int
+                val isRestore = calls.any { it.startsWith("setHoldability") } && value == originalHoldability
+                calls.add("setHoldability($value)")
+                if (isRestore) failRestoringHoldability?.let { throw it }
+                holdability = value
                 null
             }
             "commit" -> {

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/query/QueryBuilder.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/query/QueryBuilder.kt
@@ -4,6 +4,8 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.r2dbc.support.toParameter
 import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
+import io.bluetape4k.support.requireZeroOrPositiveNumber
 import io.bluetape4k.utils.Systemx
 import io.r2dbc.spi.Parameters
 import kotlin.reflect.KProperty
@@ -155,7 +157,7 @@ class QueryBuilder {
      */
     fun limit(limit: Int) =
         apply {
-            this.limit = limit
+            this.limit = limit.requirePositiveNumber("limit")
         }
 
     /**
@@ -163,7 +165,7 @@ class QueryBuilder {
      */
     fun offset(offset: Int) =
         apply {
-            this.offset = offset
+            this.offset = offset.requireZeroOrPositiveNumber("offset")
         }
 
     /**

--- a/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/query/QueryBuilderTest.kt
+++ b/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/query/QueryBuilderTest.kt
@@ -193,6 +193,26 @@ class QueryBuilderTest {
     }
 
     @Test
+    fun `limit 은 양수여야 한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            query {
+                select("select * from actor")
+                limit(0)
+            }
+        }
+    }
+
+    @Test
+    fun `offset 은 0 이상이어야 한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            query {
+                select("select * from actor")
+                offset(-1)
+            }
+        }
+    }
+
+    @Test
     fun `select with group by and having`() {
         val query = query {
             select("select actor_id, count(*) as cnt from actor")

--- a/docs/lessons/2026-07-04-api-contract-failures.md
+++ b/docs/lessons/2026-07-04-api-contract-failures.md
@@ -1,0 +1,29 @@
+# API contract failures should preserve caller context
+
+## Context
+
+Issues #951 and #954 found helper APIs where public contracts drifted from
+caller expectations:
+
+- Ktor Swagger UI collapsed nested specification paths to a basename.
+- RestClient coroutine helpers used `!!`, turning empty bodies into raw
+  `NullPointerException` failures.
+
+## Decision
+
+- Preserve caller-provided relative Swagger specification paths for both the
+  file source and Swagger UI remote path.
+- Replace RestClient coroutine `!!` assertions with an explicit non-null body
+  contract error that includes HTTP method, URI, and target type.
+
+## Verification
+
+- `./gradlew :bluetape4k-ktor-openapi:test --tests 'io.bluetape4k.ktor.openapi.KtorOpenApiRoutesTest'`
+- `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.http.RestClientCoroutinesDslTest'`
+- `git diff --check`
+
+## Future guidance
+
+Route helper defaults must keep documented path contracts source-verified.
+Coroutine wrappers around blocking clients should expose explicit caller-facing
+contract errors instead of relying on Kotlin null assertions.

--- a/docs/lessons/2026-07-04-data-validation-fail-fast.md
+++ b/docs/lessons/2026-07-04-data-validation-fail-fast.md
@@ -1,0 +1,31 @@
+# Data validation fail-fast for public numeric parameters
+
+## Context
+
+Issues #947 and #955 found public data APIs that accepted invalid numeric
+parameters and let downstream JDBC modulo operations or SQL/CQL builders expose
+late, low-signal failures.
+
+## Decision
+
+Validate numeric inputs at the public entrypoint with bluetape4k `require*`
+helpers:
+
+- JDBC batch size must be positive before any batch loop or modulo operation.
+- R2DBC query limit must be positive.
+- R2DBC query offset must be zero or positive.
+- Cassandra keyspace replication factor must be positive.
+
+## Verification
+
+- `./gradlew :bluetape4k-jdbc:test --tests 'io.bluetape4k.jdbc.sql.DataSourceTransactionExtensionsTest'`
+- `./gradlew :bluetape4k-r2dbc:test --tests 'io.bluetape4k.r2dbc.query.QueryBuilderTest'`
+- `./gradlew :bluetape4k-cassandra:test --tests 'io.bluetape4k.cassandra.CassandraAdminTest'`
+- `git diff --check`
+
+## Future guidance
+
+For public data API parameters that shape generated SQL/CQL or loop arithmetic,
+validate before delegating to driver builders or iteration logic. Prefer
+`requirePositiveNumber` and `requireZeroOrPositiveNumber` over raw `require`
+when the parameter is numeric.

--- a/docs/lessons/2026-07-04-hibernate-lettuce-classpath-guards.md
+++ b/docs/lessons/2026-07-04-hibernate-lettuce-classpath-guards.md
@@ -1,0 +1,31 @@
+# Hibernate Lettuce Classpath Guards
+
+## Context
+
+Issue #945 found that the Hibernate Lettuce Spring Boot auto-configurations used
+direct class references for optional compile-only Hibernate, Actuator, and
+Micrometer integrations.
+
+## Decision
+
+Keep optional integration metadata string-based:
+
+- use `@ConditionalOnClass(name = [...])` for optional classpath probes
+- use `@ConditionalOnBean(type = [...])` for optional bean types
+- use `@AutoConfiguration(afterName = [...])` for optional ordering targets
+
+## Outcome
+
+`FilteredClassLoader` slice tests now prove the configuration backs off cleanly
+when Hibernate customizer, Actuator endpoint annotations, or Micrometer registry
+types are unavailable.
+
+## Verification
+
+- `./gradlew :bluetape4k-spring-boot-hibernate-lettuce:test --tests 'io.bluetape4k.spring.boot.autoconfigure.cache.lettuce.LettuceNearCacheAutoConfigurationTest'`
+
+## Future Guidance
+
+When an auto-configuration imports a `compileOnly` integration, avoid class
+literals in annotation metadata and add a missing-class `ApplicationContextRunner`
+test before marking the integration classpath-safe.

--- a/docs/lessons/2026-07-04-jdbc-state-restore-failures.md
+++ b/docs/lessons/2026-07-04-jdbc-state-restore-failures.md
@@ -1,0 +1,23 @@
+# JDBC state restore failures must not replace primary failures
+
+## Context
+
+Issue #946 found JDBC helper functions that restored connection state in
+`finally` without preserving a primary block failure when restore also failed.
+
+## Decision
+
+Record the primary failure from the caller block or state-change path, then add
+restore failures as suppressed exceptions. If the caller block succeeds and only
+restore fails, surface the restore failure.
+
+## Verification
+
+- `./gradlew :bluetape4k-jdbc:test --tests 'io.bluetape4k.jdbc.sql.TransactionExtensionsTest'`
+- `git diff --check`
+
+## Future guidance
+
+Any lifecycle helper that temporarily mutates JDBC connection state should use
+the same primary-failure preservation pattern as transaction rollback/restore
+logic.

--- a/docs/lessons/2026-07-04-jdk25-joinuntil-interrupt-semantics.md
+++ b/docs/lessons/2026-07-04-jdk25-joinuntil-interrupt-semantics.md
@@ -1,0 +1,27 @@
+# JDK25 JoinUntil Interrupt Semantics
+
+## Context
+
+Issue #953 found that the JDK25 structured-scope `joinUntil` fallback converted
+every `InterruptedException` into `TimeoutException` and cleared the caller's
+interrupt status.
+
+## Decision
+
+Track only the scheduled timeout interrupt as timeout evidence. Preserve
+pre-existing and external interrupts by rethrowing `InterruptedException` and
+restoring the caller thread interrupt flag.
+
+## Outcome
+
+Timeout joins still throw `TimeoutException`, while cancellation or interrupt
+signals from outside the timeout scheduler remain diagnosable.
+
+## Verification
+
+- `./gradlew :bluetape4k-virtualthread-jdk25:test --tests 'io.bluetape4k.concurrent.virtualthread.jdk25.Jdk25StructuredTaskScopeProviderTest' --tests 'io.bluetape4k.concurrent.virtualthread.jdk25.Jdk25StructuredTaskScopeProviderExtTest'`
+
+## Future Guidance
+
+Do not clear interrupt status in structured-concurrency helpers unless the code
+can prove it created the interrupt signal being consumed.

--- a/docs/lessons/2026-07-04-kafka3-close-evidence.md
+++ b/docs/lessons/2026-07-04-kafka3-close-evidence.md
@@ -1,0 +1,26 @@
+# Kafka receiver close evidence should stay visible
+
+## Context
+
+Issue #950 found that Kafka3 suspend consumer shutdown did not expose receiver
+close failures or non-`AutoCloseable` receiver evidence, while Kafka4 already
+logged both paths.
+
+## Decision
+
+Port the Kafka4 close pattern to Kafka3:
+
+- Warn when `KafkaReceiver` does not implement `AutoCloseable`.
+- Wrap receiver close with `runCatching` and log failures instead of throwing
+  them from `close()`/`destroy()`.
+
+## Verification
+
+- `./gradlew :bluetape4k-kafka:test --tests 'io.bluetape4k.kafka.spring.core.SuspendKafkaConsumerTemplateTest'`
+- `git diff --check`
+
+## Future guidance
+
+Kafka3 and Kafka4 suspend templates should keep lifecycle diagnostics in parity.
+Resource close paths should preserve shutdown progress while logging close
+failure evidence with the receiver class.

--- a/docs/lessons/2026-07-04-lettuce-lock-duration-token.md
+++ b/docs/lessons/2026-07-04-lettuce-lock-duration-token.md
@@ -1,0 +1,27 @@
+# Lettuce Lock Duration And Token Preservation
+
+## Context
+
+Issue #949 found that Lettuce lock APIs converted invalid durations to Redis PX
+values and cleared the local owner token before Redis release success was known.
+
+## Decision
+
+Validate lock durations at the API boundary and clear the local token only after
+the Redis Lua release script confirms success.
+
+## Outcome
+
+Invalid lease/wait durations fail before Redis commands are issued. If a release
+fails because the Redis key expired or no longer matches, the local token remains
+available so callers can retry when release evidence becomes available.
+
+## Verification
+
+- `./gradlew :bluetape4k-lettuce:test --tests 'io.bluetape4k.redis.lettuce.lock.LettuceLockTest' --tests 'io.bluetape4k.redis.lettuce.lock.LettuceSuspendLockTest'`
+
+## Future Guidance
+
+Distributed lock implementations must validate Redis TTL inputs before command
+construction and must not discard local ownership evidence until remote release
+success is confirmed.

--- a/docs/lessons/2026-07-04-resilient-suspend-cache-cancellation.md
+++ b/docs/lessons/2026-07-04-resilient-suspend-cache-cancellation.md
@@ -1,0 +1,28 @@
+# Resilient Suspend Cache Cancellation
+
+## Context
+
+Issue #942 found `runCatching` around suspend back-cache reads in
+`ResilientSuspendNearJCache`. That converted coroutine cancellation into
+configured fallback behavior.
+
+## Decision
+
+Replace suspend `runCatching` fallback paths with explicit `try/catch` blocks
+that rethrow `CancellationException` before applying non-cancellation fallback
+behavior.
+
+## Outcome
+
+`get`, `getAll`, `replace`, and `containsKey` now preserve structured
+concurrency cancellation while still returning null/false for ordinary back
+cache failures where the existing contract expects graceful degradation.
+
+## Verification
+
+- `./gradlew :bluetape4k-cache-core:test --tests 'io.bluetape4k.cache.nearcache.jcache.ResilientSuspendNearJCacheTest'`
+
+## Future Guidance
+
+Do not use `runCatching` around suspend cache calls unless cancellation is
+handled and rethrown before fallback behavior is applied.

--- a/docs/lessons/2026-07-04-retrofit-cancellation-cleanup.md
+++ b/docs/lessons/2026-07-04-retrofit-cancellation-cleanup.md
@@ -1,0 +1,24 @@
+# Retrofit cancellation races must close delivered response bodies
+
+## Context
+
+Issue #948 found a Retrofit coroutine bridge race where a response could arrive
+after coroutine cancellation without explicit response-body cleanup evidence.
+
+## Decision
+
+When cancellation wins before `onResponse`, close the Retrofit response body
+before cancelling the continuation. Also close the delivered response from the
+`resume` cancellation handler if cancellation wins after resume but before
+dispatch.
+
+## Verification
+
+- `./gradlew :bluetape4k-retrofit2:test --tests 'io.bluetape4k.retrofit2.SuspendRetrofitCallSupportTest'`
+- `git diff --check`
+
+## Future guidance
+
+Coroutine HTTP bridges should close response resources on every cancellation
+race path. Prefer `resume(value) { ... }` cleanup handlers plus an explicit
+`!cont.isActive` check before delivery.

--- a/docs/lessons/2026-07-04-vertx-transaction-cancellation-cleanup.md
+++ b/docs/lessons/2026-07-04-vertx-transaction-cancellation-cleanup.md
@@ -1,0 +1,30 @@
+# Vert.x Transaction Cancellation Cleanup
+
+## Context
+
+Issue #940 found that Vert.x SQL transaction helpers performed rollback and
+connection close in the caller coroutine context, so caller cancellation could
+abort transaction cleanup.
+
+## Decision
+
+Run rollback and close operations inside `NonCancellable` cleanup boundaries.
+Preserve the primary cancellation or failure and attach rollback or close
+failures as suppressed exceptions.
+
+## Outcome
+
+`withSuspendTransaction` and `withSuspendRollback` now complete cleanup even
+when the action cancels its coroutine context, while still rethrowing the
+original `CancellationException`.
+
+## Verification
+
+- `./gradlew :bluetape4k-vertx:test --tests 'io.bluetape4k.vertx.sqlclient.PoolSupportTest'`
+
+## Future Guidance
+
+Coroutine-based database lifecycle cleanup should not use `runCatching` around
+suspending rollback or close calls. Use explicit `try/catch` in a
+`NonCancellable` boundary and preserve secondary cleanup failures as suppressed
+evidence.

--- a/docs/lessons/2026-07-04-virtual-thread-controller-lifecycle.md
+++ b/docs/lessons/2026-07-04-virtual-thread-controller-lifecycle.md
@@ -1,0 +1,27 @@
+# Virtual Thread Controller Lifecycle
+
+## Context
+
+Issue #952 found that `AbstractVirtualThreadController` exposed a shared
+virtual-thread executor without a Spring bean destruction path.
+
+## Decision
+
+Keep the public `virtualThreadExecutor` accessor for compatibility, but make the
+controller close the current executor through `@PreDestroy`. The accessor
+recreates the executor when a later Spring context accesses it after shutdown.
+
+## Outcome
+
+Controller bean shutdown now closes the executor while repeated test or
+application context creation does not reuse a closed executor.
+
+## Verification
+
+- `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.virtualthread.AbstractVirtualThreadControllerTest'`
+
+## Future Guidance
+
+Public controller base classes that expose executor or coroutine resources must
+own a Spring destruction callback and tests should cover both direct destroy and
+context shutdown paths.

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplate.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplate.kt
@@ -1,6 +1,8 @@
 package io.bluetape4k.kafka.spring.core
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.error
+import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requireNotEmpty
 import kotlinx.coroutines.CoroutineScope
@@ -495,7 +497,14 @@ class SuspendKafkaConsumerTemplate<K, V> private constructor(
     private fun doClose() {
         if (closed.compareAndSet(false, true)) {
             scope.cancel("SuspendKafkaConsumerTemplate closed")
-            (receiver as? AutoCloseable)?.close()
+            val closeable = receiver as? AutoCloseable
+            if (closeable == null) {
+                // reactor-kafka 의 KafkaReceiver 가 AutoCloseable 을 구현하지 않은 경우 — 자원 누수 가능성을 명시적으로 노출한다.
+                log.warn { "KafkaReceiver does not implement AutoCloseable; underlying Kafka consumer connection may leak. receiverClass=${receiver.javaClass.name}" }
+            } else {
+                runCatching { closeable.close() }
+                    .onFailure { e -> log.error(e) { "Failed to close KafkaReceiver. receiverClass=${receiver.javaClass.name}" } }
+            }
         }
     }
 }

--- a/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplateTest.kt
+++ b/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplateTest.kt
@@ -1,5 +1,10 @@
 package io.bluetape4k.kafka.spring.core
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.kafka.AbstractKafkaTest
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.testcontainers.mq.KafkaServer
@@ -15,10 +20,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeTrue
-import io.bluetape4k.assertions.shouldContain
-import io.bluetape4k.assertions.shouldNotBeNull
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp
@@ -32,7 +33,6 @@ import reactor.kafka.receiver.ReceiverOptions
 import java.util.*
 import java.util.function.Function
 import java.util.regex.Pattern
-import io.bluetape4k.assertions.assertFailsWith
 
 /**
  * [SuspendKafkaConsumerTemplate]에 대한 테스트 클래스입니다.
@@ -186,9 +186,8 @@ class SuspendKafkaConsumerTemplateTest: AbstractKafkaTest() {
         stubDoOnConsumer(closableReceiver, consumer)
         val template = SuspendKafkaConsumerTemplate(closableReceiver)
         val blocker = CompletableDeferred<Unit>()
-        lateinit var launchedJob: Job
 
-        launchedJob = template.launch {
+        val launchedJob: Job = template.launch {
             blocker.await()
         }
 
@@ -197,6 +196,32 @@ class SuspendKafkaConsumerTemplateTest: AbstractKafkaTest() {
 
         (template.coroutineContext[Job]?.isCancelled ?: false).shouldBeTrue()
         verify(exactly = 1) { (closableReceiver as AutoCloseable).close() }
+    }
+
+    @Test
+    fun `템플릿 종료 시 receiver close 실패를 전파하지 않는다`() = runTest {
+        val closeFailure = IllegalStateException("receiver close failed")
+        every { (closableReceiver as AutoCloseable).close() } throws closeFailure
+        val template = SuspendKafkaConsumerTemplate(closableReceiver)
+
+        template.close()
+
+        (template.coroutineContext[Job]?.isCancelled ?: false).shouldBeTrue()
+        verify(exactly = 1) { (closableReceiver as AutoCloseable).close() }
+    }
+
+    @Test
+    fun `템플릿 종료 시 AutoCloseable 이 아닌 receiver 도 scope 를 취소한다`() = runTest {
+        val template = SuspendKafkaConsumerTemplate(receiver)
+        val blocker = CompletableDeferred<Unit>()
+        val launchedJob: Job = template.launch {
+            blocker.await()
+        }
+
+        template.close()
+        launchedJob.cancelAndJoin()
+
+        (template.coroutineContext[Job]?.isCancelled ?: false).shouldBeTrue()
     }
 
     private fun stubDoOnConsumer(

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceLock.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceLock.kt
@@ -98,6 +98,9 @@ class LettuceLock(
         waitTime: Duration = Duration.ZERO,
         leaseTime: Duration = defaultLeaseTime,
     ): Boolean {
+        waitTime.requireZeroOrPositiveDuration("waitTime")
+        leaseTime.requirePositiveMillisDuration("leaseTime")
+
         val token = UUID.randomUUID().toString()
         val leaseMs = leaseTime.toMillis()
         val deadline = System.currentTimeMillis() + waitTime.toMillis()
@@ -134,6 +137,9 @@ class LettuceLock(
      * @throws IllegalStateException maxWaitTime 초과 시
      */
     fun lock(leaseTime: Duration = defaultLeaseTime, maxWaitTime: Duration = Duration.ofMinutes(5)) {
+        leaseTime.requirePositiveMillisDuration("leaseTime")
+        maxWaitTime.requirePositiveMillisDuration("maxWaitTime")
+
         val token = UUID.randomUUID().toString()
         val leaseMs = leaseTime.toMillis()
         val args = SetArgs().nx().px(leaseMs)
@@ -166,7 +172,7 @@ class LettuceLock(
      * @throws IllegalStateException 락을 보유하지 않은 경우
      */
     fun unlock() {
-        val token = tokenRef.getAndSet(null)
+        val token = tokenRef.value
             ?: throw IllegalStateException("현재 인스턴스가 락을 보유하지 않습니다: lockKey=$lockKey")
 
         val released = RedisScriptRunner.run<Long>(
@@ -175,6 +181,7 @@ class LettuceLock(
         if (released == 0L) {
             throw IllegalStateException("Lock 해제 실패 (토큰 불일치 또는 만료): lockKey=$lockKey")
         }
+        tokenRef.compareAndSet(token, null)
         log.debug { "Lock 해제 성공: lockKey=$lockKey" }
     }
 
@@ -201,6 +208,9 @@ class LettuceLock(
         waitTime: Duration = Duration.ZERO,
         leaseTime: Duration = defaultLeaseTime,
     ): CompletableFuture<Boolean> {
+        waitTime.requireZeroOrPositiveDuration("waitTime")
+        leaseTime.requirePositiveMillisDuration("leaseTime")
+
         val token = UUID.randomUUID().toString()
         val leaseMs = leaseTime.toMillis()
         val deadline = System.currentTimeMillis() + waitTime.toMillis()
@@ -245,6 +255,9 @@ class LettuceLock(
         leaseTime: Duration = defaultLeaseTime,
         maxWaitTime: Duration = Duration.ofMinutes(5),
     ): CompletableFuture<Unit> {
+        leaseTime.requirePositiveMillisDuration("leaseTime")
+        maxWaitTime.requirePositiveMillisDuration("maxWaitTime")
+
         val token = UUID.randomUUID().toString()
         val leaseMs = leaseTime.toMillis()
         val deadline = System.currentTimeMillis() + maxWaitTime.toMillis()
@@ -283,7 +296,7 @@ class LettuceLock(
      * @return 완료를 나타내는 CompletableFuture
      */
     fun unlockAsync(): CompletableFuture<Unit> {
-        val token = tokenRef.getAndSet(null)
+        val token = tokenRef.value
             ?: return CompletableFuture.failedFuture(
                 IllegalStateException("현재 인스턴스가 락을 보유하지 않습니다: lockKey=$lockKey")
             )
@@ -294,6 +307,7 @@ class LettuceLock(
             if (released == 0L) {
                 throw IllegalStateException("Lock 해제 실패 (토큰 불일치 또는 만료, async): lockKey=$lockKey")
             }
+            tokenRef.compareAndSet(token, null)
             log.debug { "Lock 해제 성공 (async): lockKey=$lockKey" }
         }
     }

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceLockValidation.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceLockValidation.kt
@@ -1,0 +1,15 @@
+package io.bluetape4k.redis.lettuce.lock
+
+import java.time.Duration
+
+internal fun Duration.requirePositiveMillisDuration(parameterName: String): Duration = apply {
+    require(!isNegative && !isZero && toMillis() > 0L) {
+        "$parameterName must be at least 1ms. $parameterName=$this"
+    }
+}
+
+internal fun Duration.requireZeroOrPositiveDuration(parameterName: String): Duration = apply {
+    require(!isNegative) {
+        "$parameterName must be zero or positive. $parameterName=$this"
+    }
+}

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSuspendLock.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSuspendLock.kt
@@ -88,6 +88,9 @@ class LettuceSuspendLock(
         waitTime: Duration = Duration.ZERO,
         leaseTime: Duration = defaultLeaseTime,
     ): Boolean {
+        waitTime.requireZeroOrPositiveDuration("waitTime")
+        leaseTime.requirePositiveMillisDuration("leaseTime")
+
         val token = UUID.randomUUID().toString()
         val leaseMs = leaseTime.toMillis()
         val deadline = System.currentTimeMillis() + waitTime.toMillis()
@@ -126,6 +129,9 @@ class LettuceSuspendLock(
         leaseTime: Duration = defaultLeaseTime,
         maxWaitTime: Duration = Duration.ofMinutes(DEFAULT_MAX_WAIT_MINUTES),
     ) {
+        leaseTime.requirePositiveMillisDuration("leaseTime")
+        maxWaitTime.requirePositiveMillisDuration("maxWaitTime")
+
         val token = UUID.randomUUID().toString()
         val leaseMs = leaseTime.toMillis()
         val deadline = System.currentTimeMillis() + maxWaitTime.toMillis()
@@ -163,7 +169,7 @@ class LettuceSuspendLock(
      */
     suspend fun unlock() {
         val token =
-            tokenRef.getAndSet(null)
+            tokenRef.value
                 ?: throw IllegalStateException("현재 인스턴스가 락을 보유하지 않습니다: lockKey=$lockKey")
 
         // 개선: EVALSHA 우선 실행, NOSCRIPT 발생 시 원문 전송으로 자동 fallback.
@@ -174,6 +180,7 @@ class LettuceSuspendLock(
         if (released == 0L) {
             throw IllegalStateException("Lock 해제 실패 (토큰 불일치 또는 만료, suspend): lockKey=$lockKey")
         }
+        tokenRef.compareAndSet(token, null)
         log.debug { "Lock 해제 성공 (suspend): lockKey=$lockKey" }
     }
 }

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceLockTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceLockTest.kt
@@ -8,14 +8,16 @@ import io.bluetape4k.redis.lettuce.LettuceClients
 import io.bluetape4k.redis.lettuce.LettuceTestUtils
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
 import io.lettuce.core.codec.StringCodec
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 import java.time.Duration
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.atomic.AtomicInteger
 
 @OptIn(ExperimentalLettuceCoroutinesApi::class)
@@ -60,6 +62,44 @@ class LettuceLockTest: AbstractLettuceTest() {
         assertFailsWith<IllegalStateException> {
             lock.unlock()
         }
+    }
+
+    @Test
+    fun `tryLock - 잘못된 duration은 즉시 거부한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            lock.tryLock(waitTime = Duration.ofMillis(-1))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            lock.tryLock(leaseTime = Duration.ZERO)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            lock.tryLock(leaseTime = Duration.ofNanos(1))
+        }
+    }
+
+    @Test
+    fun `lock - 잘못된 duration은 즉시 거부한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            lock.lock(leaseTime = Duration.ZERO)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            lock.lock(maxWaitTime = Duration.ZERO)
+        }
+    }
+
+    @Test
+    fun `unlock - 만료된 lock 해제 실패 시 token을 보존해 재시도할 수 있다`() {
+        lock.lock(leaseTime = Duration.ofSeconds(5))
+        val token = connection.sync().get(lock.lockKey)
+        connection.sync().del(lock.lockKey)
+
+        assertFailsWith<IllegalStateException> {
+            lock.unlock()
+        }
+
+        connection.sync().set(lock.lockKey, token)
+        lock.unlock()
+        lock.isHeldByCurrentInstance().shouldBeFalse()
     }
 
     @Test
@@ -113,6 +153,35 @@ class LettuceLockTest: AbstractLettuceTest() {
         } finally {
             lock.unlockAsync().get()
         }
+    }
+
+    @Test
+    fun `tryLockAsync - 잘못된 duration은 즉시 거부한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            lock.tryLockAsync(waitTime = Duration.ofMillis(-1))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            lock.tryLockAsync(leaseTime = Duration.ZERO)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            lock.lockAsync(maxWaitTime = Duration.ZERO)
+        }
+    }
+
+    @Test
+    fun `unlockAsync - 만료된 lock 해제 실패 시 token을 보존해 재시도할 수 있다`() {
+        lock.lockAsync(leaseTime = Duration.ofSeconds(5)).get()
+        val token = connection.sync().get(lock.lockKey)
+        connection.sync().del(lock.lockKey)
+
+        val failure = assertFailsWith<ExecutionException> {
+            lock.unlockAsync().get()
+        }
+        failure.cause.shouldBeInstanceOf<IllegalStateException>()
+
+        connection.sync().set(lock.lockKey, token)
+        lock.unlockAsync().get()
+        lock.isHeldByCurrentInstance().shouldBeFalse()
     }
 
     // =========================================================================

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSuspendLockTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSuspendLockTest.kt
@@ -8,10 +8,12 @@ import io.bluetape4k.redis.lettuce.LettuceClients
 import io.bluetape4k.redis.lettuce.LettuceTestUtils
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
 import io.lettuce.core.codec.StringCodec
+import io.bluetape4k.assertions.assertFailsWith
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.BeforeEach
@@ -57,6 +59,40 @@ class LettuceSuspendLockTest: AbstractLettuceTest() {
         lock.isHeldByCurrentInstance().shouldBeTrue()
         lock.unlock()
         lock.isHeldByCurrentInstance()
+    }
+
+    @Test
+    fun `tryLock and lock - 잘못된 duration은 즉시 거부한다`() = runSuspendIO {
+        val lock = suspendLock()
+
+        assertFailsWith<IllegalArgumentException> {
+            lock.tryLock(waitTime = Duration.ofMillis(-1))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            lock.tryLock(leaseTime = Duration.ZERO)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            lock.tryLock(leaseTime = Duration.ofNanos(1))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            lock.lock(maxWaitTime = Duration.ZERO)
+        }
+    }
+
+    @Test
+    fun `unlock - 만료된 lock 해제 실패 시 token을 보존해 재시도할 수 있다`() = runSuspendIO {
+        val lock = suspendLock()
+        lock.lock(leaseTime = Duration.ofSeconds(5))
+        val token = connection.sync().get(lock.lockKey)
+        connection.sync().del(lock.lockKey)
+
+        assertFailsWith<IllegalStateException> {
+            lock.unlock()
+        }
+
+        connection.sync().set(lock.lockKey, token)
+        lock.unlock()
+        lock.isHeldByCurrentInstance().shouldBeFalse()
     }
 
     @Test

--- a/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/SuspendRetrofitCallSupport.kt
+++ b/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/SuspendRetrofitCallSupport.kt
@@ -14,6 +14,7 @@ import kotlin.coroutines.resumeWithException
  *
  * ## 동작/계약
  * - 코루틴 취소 시 `Call.cancel()`을 호출합니다.
+ * - 취소가 응답 전달보다 먼저 완료되면 응답 바디를 닫아 연결 누수를 방지합니다.
  * - 호출이 이미 취소된 상태에서 응답/실패가 도착하면 [cancelHandler]를 호출하고 코루틴을 취소합니다.
  * - 네트워크 실패는 예외로 재개(`resumeWithException`)됩니다.
  *
@@ -33,12 +34,16 @@ suspend inline fun <T> Call<T>.suspendExecute(
 
     val callback = object: Callback<T> {
         override fun onResponse(call: Call<T>, response: Response<T>) {
-            if (call.isCanceled) {
+            if (!cont.isActive || call.isCanceled) {
+                response.closeBodyQuietly()
                 val ex = HttpException(response)
                 cancelHandler(ex)
                 cont.cancel(ex)
             } else {
-                cont.resume(response) { _, _, _ -> call.cancel() }
+                cont.resume(response) { _, deliveredResponse, _ ->
+                    deliveredResponse.closeBodyQuietly()
+                    call.cancel()
+                }
             }
         }
 
@@ -53,6 +58,12 @@ suspend inline fun <T> Call<T>.suspendExecute(
     }
 
     enqueue(callback)
+}
+
+@PublishedApi
+internal fun Response<*>.closeBodyQuietly() {
+    runCatching { raw().close() }
+    runCatching { errorBody()?.close() }
 }
 
 /**

--- a/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/SuspendRetrofitCallSupportTest.kt
+++ b/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/SuspendRetrofitCallSupportTest.kt
@@ -9,15 +9,30 @@ import io.bluetape4k.junit5.coroutines.runCatchingNonCancellation
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.retrofit2.services.TestService
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.ResponseBody
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy
+import okio.Buffer
+import okio.BufferedSource
+import okio.Source
+import okio.Timeout
+import okio.buffer
+import retrofit2.Callback
 import retrofit2.Call
+import retrofit2.Response
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import retrofit2.converter.scalars.ScalarsConverterFactory
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * [suspendExecute] 확장 함수 단위 테스트입니다.
@@ -109,5 +124,123 @@ class SuspendRetrofitCallSupportTest {
             call = api.get()
             call.suspendExecute()
         }
+    }
+
+    @Test
+    fun `suspendExecute closes successful response body when cancellation wins response race`() = runTest {
+        val call = ControlledCall<String>()
+        val cancelCause = AtomicReference<Throwable?>()
+        val body = CloseTrackingResponseBody()
+
+        val job = launch {
+            runCatching {
+                call.suspendExecute { cancelCause.set(it) }
+            }
+        }
+
+        call.awaitEnqueued()
+        job.cancel("cancel before response")
+        call.callback.onResponse(call, successResponse("hello", body))
+        job.join()
+
+        call.isCanceled.shouldBeTrue()
+        body.closed.shouldBeTrue()
+        cancelCause.get().shouldNotBeNull()
+    }
+
+    @Test
+    fun `suspendExecute closes error response body when cancellation wins response race`() = runTest {
+        val call = ControlledCall<String>()
+        val cancelCause = AtomicReference<Throwable?>()
+        val body = CloseTrackingResponseBody()
+
+        val job = launch {
+            runCatching {
+                call.suspendExecute { cancelCause.set(it) }
+            }
+        }
+
+        call.awaitEnqueued()
+        job.cancel("cancel before response")
+        call.callback.onResponse(call, Response.error(500, body))
+        job.join()
+
+        call.isCanceled.shouldBeTrue()
+        body.closed.shouldBeTrue()
+        cancelCause.get().shouldNotBeNull()
+    }
+
+    private fun successResponse(
+        body: String,
+        rawBody: ResponseBody,
+    ): Response<String> {
+        val raw =
+            okhttp3.Response
+                .Builder()
+                .request(Request.Builder().url("https://example.test/").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(rawBody)
+                .build()
+
+        return Response.success(body, raw)
+    }
+
+    private class ControlledCall<T>: Call<T> {
+        private val callbackReady = CompletableDeferred<Callback<T>>()
+        private var canceled = false
+
+        val callback: Callback<T>
+            get() = callbackReady.getCompleted()
+
+        suspend fun awaitEnqueued() {
+            callbackReady.await()
+        }
+
+        override fun enqueue(callback: Callback<T>) {
+            callbackReady.complete(callback)
+        }
+
+        override fun cancel() {
+            canceled = true
+        }
+
+        override fun isCanceled(): Boolean = canceled
+
+        override fun isExecuted(): Boolean = callbackReady.isCompleted
+
+        override fun clone(): Call<T> = ControlledCall()
+
+        override fun execute(): Response<T> = error("Synchronous execution is not used by this test.")
+
+        override fun request(): Request =
+            Request.Builder().url("https://example.test/").build()
+
+        override fun timeout(): Timeout = Timeout.NONE
+    }
+
+    private class CloseTrackingResponseBody: ResponseBody() {
+        private val source = CloseTrackingSource()
+        val closed: Boolean get() = source.closed
+
+        override fun contentType() = null
+
+        override fun contentLength(): Long = 0L
+
+        override fun source(): BufferedSource = source.buffer()
+    }
+
+    private class CloseTrackingSource: Source {
+        var closed: Boolean = false
+            private set
+
+        override fun close() {
+            closed = true
+        }
+
+        override fun read(sink: Buffer, byteCount: Long): Long = -1L
+
+        override fun timeout(): Timeout = Timeout.NONE
     }
 }

--- a/io/vertx/src/main/kotlin/io/bluetape4k/vertx/sqlclient/PoolSupport.kt
+++ b/io/vertx/src/main/kotlin/io/bluetape4k/vertx/sqlclient/PoolSupport.kt
@@ -3,8 +3,11 @@ package io.bluetape4k.vertx.sqlclient
 import io.vertx.kotlin.coroutines.coAwait
 import io.vertx.sqlclient.Pool
 import io.vertx.sqlclient.SqlConnection
+import io.vertx.sqlclient.Transaction
 import io.vertx.sqlclient.TransactionRollbackException
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import java.sql.SQLException
 
 /**
@@ -31,21 +34,26 @@ suspend inline fun <T> Pool.withSuspendTransaction(
 ): T {
     val conn = connection.coAwait()
     val tx = conn.begin().coAwait()
+    var primaryFailure: Throwable? = null
 
     return try {
         val result = action(conn)
         tx.commit().coAwait()
         result
     } catch (e: TransactionRollbackException) {
+        primaryFailure = e
         throw (e)
     } catch (e: CancellationException) {
-        runCatching { tx.rollback().coAwait() }
+        primaryFailure = e
+        rollbackSuppressing(tx, e)
         throw e
     } catch (e: Throwable) {
-        runCatching { tx.rollback().coAwait() }
-        throw SQLException(e)
+        val sqlException = SQLException(e)
+        primaryFailure = sqlException
+        rollbackSuppressing(tx, sqlException)
+        throw sqlException
     } finally {
-        conn.close().coAwait()
+        closeConnection(conn, primaryFailure)
     }
 }
 
@@ -72,19 +80,55 @@ suspend inline fun <T> Pool.withSuspendRollback(
 ): T {
     val conn = connection.coAwait()
     val tx = conn.begin().coAwait()
+    var primaryFailure: Throwable? = null
     return try {
         val result = action(conn)
         tx.rollback().coAwait()
         result
     } catch (e: TransactionRollbackException) {
+        primaryFailure = e
         throw (e)
     } catch (e: CancellationException) {
-        runCatching { tx.rollback().coAwait() }
+        primaryFailure = e
+        rollbackSuppressing(tx, e)
         throw e
     } catch (e: Throwable) {
-        runCatching { tx.rollback().coAwait() }
-        throw SQLException(e)
+        val sqlException = SQLException(e)
+        primaryFailure = sqlException
+        rollbackSuppressing(tx, sqlException)
+        throw sqlException
     } finally {
-        conn.close().coAwait()
+        closeConnection(conn, primaryFailure)
+    }
+}
+
+@PublishedApi
+internal suspend fun rollbackSuppressing(
+    tx: Transaction,
+    primaryFailure: Throwable,
+) {
+    try {
+        withContext(NonCancellable) {
+            tx.rollback().coAwait()
+        }
+    } catch (rollbackFailure: Throwable) {
+        primaryFailure.addSuppressed(rollbackFailure)
+    }
+}
+
+@PublishedApi
+internal suspend fun closeConnection(
+    conn: SqlConnection,
+    primaryFailure: Throwable?,
+) {
+    try {
+        withContext(NonCancellable) {
+            conn.close().coAwait()
+        }
+    } catch (closeFailure: Throwable) {
+        if (primaryFailure == null) {
+            throw closeFailure
+        }
+        primaryFailure.addSuppressed(closeFailure)
     }
 }

--- a/io/vertx/src/test/kotlin/io/bluetape4k/vertx/sqlclient/PoolSupportTest.kt
+++ b/io/vertx/src/test/kotlin/io/bluetape4k/vertx/sqlclient/PoolSupportTest.kt
@@ -1,14 +1,30 @@
 package io.bluetape4k.vertx.sqlclient
 
-import io.bluetape4k.junit5.coroutines.runSuspendIO
-import io.vertx.core.Vertx
-import io.vertx.junit5.VertxTestContext
-import kotlinx.coroutines.CancellationException
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.mockk.every
+import io.mockk.mockk
+import io.vertx.core.Future
+import io.vertx.core.Promise
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
+import io.vertx.sqlclient.Pool
+import io.vertx.sqlclient.SqlConnection
+import io.vertx.sqlclient.Transaction
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
 import org.junit.jupiter.api.Test
 import java.sql.SQLException
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
 
 class PoolSupportTest: AbstractVertxSqlClientTest() {
 
@@ -34,6 +50,30 @@ class PoolSupportTest: AbstractVertxSqlClientTest() {
     }
 
     @Test
+    fun `withSuspendTransaction은 취소된 컨텍스트에서도 rollback과 close 완료를 보장한다`() = runSuspendIO {
+        val rollbackCompleted = AtomicBoolean(false)
+        val closeCompleted = AtomicBoolean(false)
+        val pool = poolWithCleanupFutures(
+            rollbackFuture = { delayedSucceededFuture { rollbackCompleted.set(true) } },
+            closeFuture = { delayedSucceededFuture { closeCompleted.set(true) } },
+        )
+
+        val error = assertFailsWith<CancellationException> {
+            runInCancelledChild {
+                pool.withSuspendTransaction {
+                    val cancellation = CancellationException("cancel requested")
+                    currentCoroutineContext().cancel(cancellation)
+                    throw cancellation
+                }
+            }
+        }
+
+        error.message shouldBeEqualTo "cancel requested"
+        rollbackCompleted.get().shouldBeTrue()
+        closeCompleted.get().shouldBeTrue()
+    }
+
+    @Test
     fun `withSuspendRollback은 CancellationException을 그대로 전파한다`(
         @Suppress("UNUSED_PARAMETER") unusedVertx: Vertx,
         testContext: VertxTestContext,
@@ -53,6 +93,50 @@ class PoolSupportTest: AbstractVertxSqlClientTest() {
     }
 
     @Test
+    fun `withSuspendRollback은 취소된 컨텍스트에서도 rollback과 close 완료를 보장한다`() = runSuspendIO {
+        val rollbackCompleted = AtomicBoolean(false)
+        val closeCompleted = AtomicBoolean(false)
+        val pool = poolWithCleanupFutures(
+            rollbackFuture = { delayedSucceededFuture { rollbackCompleted.set(true) } },
+            closeFuture = { delayedSucceededFuture { closeCompleted.set(true) } },
+        )
+
+        val error = assertFailsWith<CancellationException> {
+            runInCancelledChild {
+                pool.withSuspendRollback {
+                    val cancellation = CancellationException("cancel requested")
+                    currentCoroutineContext().cancel(cancellation)
+                    throw cancellation
+                }
+            }
+        }
+
+        error.message shouldBeEqualTo "cancel requested"
+        rollbackCompleted.get().shouldBeTrue()
+        closeCompleted.get().shouldBeTrue()
+    }
+
+    @Test
+    fun `cleanup 실패는 CancellationException의 suppressed 예외로 보존한다`() = runSuspendIO {
+        val rollbackFailure = IllegalStateException("rollback failed")
+        val closeFailure = IllegalArgumentException("close failed")
+        val pool = poolWithCleanupFutures(
+            rollbackFuture = { Future.failedFuture(rollbackFailure) },
+            closeFuture = { Future.failedFuture(closeFailure) },
+        )
+
+        val error = assertFailsWith<CancellationException> {
+            pool.withSuspendTransaction {
+                throw CancellationException("cancel requested")
+            }
+        }
+
+        error.message shouldBeEqualTo "cancel requested"
+        error.suppressed.any { it is IllegalStateException && it.message == rollbackFailure.message }.shouldBeTrue()
+        error.suppressed.any { it is IllegalArgumentException && it.message == closeFailure.message }.shouldBeTrue()
+    }
+
+    @Test
     fun `withSuspendTransaction은 일반 예외를 SQLException으로 래핑한다`(
         @Suppress("UNUSED_PARAMETER") unusedVertx: Vertx,
         testContext: VertxTestContext,
@@ -69,5 +153,41 @@ class PoolSupportTest: AbstractVertxSqlClientTest() {
         } catch (t: Throwable) {
             testContext.failNow(t)
         }
+    }
+
+    private suspend fun runInCancelledChild(block: suspend () -> Unit) {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            val deferred = scope.async { block() }
+            deferred.await()
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    private fun poolWithCleanupFutures(
+        rollbackFuture: () -> Future<Void>,
+        closeFuture: () -> Future<Void>,
+    ): Pool {
+        val pool = mockk<Pool>()
+        val conn = mockk<SqlConnection>()
+        val tx = mockk<Transaction>()
+
+        every { pool.connection } returns Future.succeededFuture(conn)
+        every { conn.begin() } returns Future.succeededFuture(tx)
+        every { tx.rollback() } answers { rollbackFuture() }
+        every { conn.close() } answers { closeFuture() }
+
+        return pool
+    }
+
+    private fun delayedSucceededFuture(onComplete: () -> Unit): Future<Void> {
+        val promise = Promise.promise<Void>()
+        thread(start = true, isDaemon = true, name = "vertx-cleanup-test") {
+            Thread.sleep(50)
+            onComplete()
+            promise.complete()
+        }
+        return promise.future()
     }
 }

--- a/ktor/openapi/src/main/kotlin/io/bluetape4k/ktor/openapi/KtorOpenApiRoutes.kt
+++ b/ktor/openapi/src/main/kotlin/io/bluetape4k/ktor/openapi/KtorOpenApiRoutes.kt
@@ -7,7 +7,6 @@ import io.ktor.server.plugins.swagger.SwaggerConfig
 import io.ktor.server.plugins.swagger.swaggerUI
 import io.ktor.server.routing.openapi.OpenApiDocSource
 import io.ktor.server.routing.Route
-import java.io.File
 
 /**
  * Adds an OpenAPI documentation endpoint backed by Ktor's official OpenAPI plugin.
@@ -30,11 +29,11 @@ fun Route.bluetape4kOpenApi(
     configure: OpenAPIConfig.() -> Unit = {},
 ): Route {
     path.requireNotBlank("path")
-    swaggerFile.requireNotBlank("swaggerFile")
+    val checkedSwaggerFile = swaggerFile.requireNotBlank("swaggerFile")
     return openAPI(path = path) {
         configure()
         if (source.isDefaultDocumentSource()) {
-            source = OpenApiDocSource.File(swaggerFile)
+            source = OpenApiDocSource.File(checkedSwaggerFile)
         }
     }
 }
@@ -44,7 +43,9 @@ fun Route.bluetape4kOpenApi(
  *
  * ## Contract
  * - The endpoint is explicit and route-scoped.
- * - [swaggerFile] is used when [configure] leaves Ktor's default document source unchanged.
+ * - [swaggerFile] is used as both the document source and Swagger UI remote path when [configure] leaves
+ *   Ktor's default document source unchanged.
+ * - Nested relative specification paths, such as `openapi/documentation.yaml`, are preserved.
  * - A caller-owned [SwaggerConfig.source] from [configure] is preserved for routing-tree or generated metadata.
  * - This helper does not generate route behavior or mutate existing routes.
  *
@@ -60,12 +61,12 @@ fun Route.bluetape4kSwaggerUi(
     configure: SwaggerConfig.() -> Unit = {},
 ): Route {
     path.requireNotBlank("path")
-    swaggerFile.requireNotBlank("swaggerFile")
+    val checkedSwaggerFile = swaggerFile.requireNotBlank("swaggerFile")
     return swaggerUI(path = path) {
         configure()
         if (source.isDefaultDocumentSource()) {
-            source = OpenApiDocSource.File(swaggerFile)
-            remotePath = File(swaggerFile).name
+            source = OpenApiDocSource.File(checkedSwaggerFile)
+            remotePath = checkedSwaggerFile
         }
     }
 }

--- a/ktor/openapi/src/test/kotlin/io/bluetape4k/ktor/openapi/KtorOpenApiRoutesTest.kt
+++ b/ktor/openapi/src/test/kotlin/io/bluetape4k/ktor/openapi/KtorOpenApiRoutesTest.kt
@@ -59,6 +59,23 @@ class KtorOpenApiRoutesTest {
     }
 
     @Test
+    fun `swagger ui endpoint preserves nested specification remote path`() = testApplication {
+        application {
+            installOpenApiTestCore()
+            routing {
+                bluetape4kSwaggerUi(swaggerFile = "openapi/documentation.yaml")
+            }
+        }
+
+        val response = client.get("/swagger/openapi/documentation.yaml")
+        val body = response.bodyAsText()
+
+        response.status shouldBeEqualTo HttpStatusCode.OK
+        body.contains("Bluetape4k Ktor OpenAPI Test") shouldBeEqualTo true
+        body.contains("/healthz") shouldBeEqualTo true
+    }
+
+    @Test
     fun `openapi endpoint preserves caller owned document source`() = testApplication {
         application {
             installOpenApiTestCore()

--- a/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/http/RestClientCoroutinesDsl.kt
+++ b/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/http/RestClientCoroutinesDsl.kt
@@ -6,7 +6,12 @@ import org.springframework.http.MediaType
 import org.springframework.web.client.RestClient
 
 /**
- * [RestClient]를 사용하여 suspend GET 요청을 수행하고 응답을 역직렬화합니다.
+ * Performs a suspend GET request with [RestClient] and deserializes a non-null response body.
+ *
+ * ## Contract
+ * - Blocking RestClient I/O runs on [Dispatchers.IO].
+ * - Empty response bodies fail with [IllegalStateException] that includes the method, URI, and target type.
+ * - Use [suspendGetOrNull] when an empty body is a valid response.
  *
  * ```kotlin
  * val user = client.suspendGet<User>("/users/1")
@@ -23,11 +28,16 @@ suspend inline fun <reified T: Any> RestClient.suspendGet(
     runInterruptible(Dispatchers.IO) {
         val spec = get().uri(uri)
         if (accept != null) spec.accept(accept)
-        spec.retrieve().body(T::class.java)!!
+        requireRestClientBody(spec.retrieve().body(T::class.java), "GET", uri)
     }
 
 /**
- * [RestClient]를 사용하여 suspend POST 요청을 수행하고 응답을 역직렬화합니다.
+ * Performs a suspend POST request with [RestClient] and deserializes a non-null response body.
+ *
+ * ## Contract
+ * - Blocking RestClient I/O runs on [Dispatchers.IO].
+ * - Empty response bodies fail with [IllegalStateException] that includes the method, URI, and target type.
+ * - Use [suspendPostOrNull] when an empty body is a valid response.
  *
  * ```kotlin
  * val created = client.suspendPost<User>("/users", newUser, MediaType.APPLICATION_JSON)
@@ -50,11 +60,16 @@ suspend inline fun <reified T: Any> RestClient.suspendPost(
         if (contentType != null) spec.contentType(contentType)
         if (accept != null) spec.accept(accept)
         if (body != null) spec.body(body)
-        spec.retrieve().body(T::class.java)!!
+        requireRestClientBody(spec.retrieve().body(T::class.java), "POST", uri)
     }
 
 /**
- * [RestClient]를 사용하여 suspend PUT 요청을 수행하고 응답을 역직렬화합니다.
+ * Performs a suspend PUT request with [RestClient] and deserializes a non-null response body.
+ *
+ * ## Contract
+ * - Blocking RestClient I/O runs on [Dispatchers.IO].
+ * - Empty response bodies fail with [IllegalStateException] that includes the method, URI, and target type.
+ * - Use [suspendPutOrNull] when an empty body is a valid response.
  *
  * ```kotlin
  * val updated = client.suspendPut<User>("/users/1", updatedUser, MediaType.APPLICATION_JSON)
@@ -77,11 +92,16 @@ suspend inline fun <reified T: Any> RestClient.suspendPut(
         if (contentType != null) spec.contentType(contentType)
         if (accept != null) spec.accept(accept)
         if (body != null) spec.body(body)
-        spec.retrieve().body(T::class.java)!!
+        requireRestClientBody(spec.retrieve().body(T::class.java), "PUT", uri)
     }
 
 /**
- * [RestClient]를 사용하여 suspend PATCH 요청을 수행하고 응답을 역직렬화합니다.
+ * Performs a suspend PATCH request with [RestClient] and deserializes a non-null response body.
+ *
+ * ## Contract
+ * - Blocking RestClient I/O runs on [Dispatchers.IO].
+ * - Empty response bodies fail with [IllegalStateException] that includes the method, URI, and target type.
+ * - Use [suspendPatchOrNull] when an empty body is a valid response.
  *
  * ```kotlin
  * val patched = client.suspendPatch<User>("/users/1", patchData, MediaType.APPLICATION_JSON)
@@ -104,7 +124,7 @@ suspend inline fun <reified T: Any> RestClient.suspendPatch(
         if (contentType != null) spec.contentType(contentType)
         if (accept != null) spec.accept(accept)
         if (body != null) spec.body(body)
-        spec.retrieve().body(T::class.java)!!
+        requireRestClientBody(spec.retrieve().body(T::class.java), "PATCH", uri)
     }
 
 /**
@@ -228,3 +248,14 @@ suspend fun RestClient.suspendDelete(
         if (accept != null) spec.accept(accept)
         spec.retrieve().toBodilessEntity()
     }
+
+@PublishedApi
+internal inline fun <reified T: Any> requireRestClientBody(
+    body: T?,
+    method: String,
+    uri: String,
+): T =
+    body ?: throw IllegalStateException(
+        "RestClient $method $uri returned an empty response body for ${T::class.java.name}. " +
+            "Use the corresponding OrNull coroutine helper when an empty body is valid."
+    )

--- a/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/virtualthread/AbstractVirtualThreadController.kt
+++ b/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/virtualthread/AbstractVirtualThreadController.kt
@@ -1,13 +1,17 @@
 package io.bluetape4k.spring.virtualthread
 
+import jakarta.annotation.PreDestroy
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicReference
 
 /**
- * Virtual Thread Executor를 제공하는 컨트롤러 베이스 클래스입니다.
+ * Base controller that exposes a virtual-thread-per-task executor.
  *
- * Spring Boot 4에서는 기본으로 VT가 활성화되므로,
- * 명시적 VT Executor가 필요한 경우에만 이 클래스를 상속합니다.
+ * Use this base class only when a controller needs an explicit
+ * [ExecutorService] for virtual-thread task submission. Spring calls
+ * [closeVirtualThreadExecutor] when the controller bean is destroyed, and the
+ * shared executor is recreated on the next access if a later context needs it.
  *
  * ```kotlin
  * @RestController
@@ -19,20 +23,52 @@ import java.util.concurrent.Executors
  * ```
  */
 abstract class AbstractVirtualThreadController {
+
+    @PreDestroy
+    fun closeVirtualThreadExecutor() {
+        shutdownVirtualThreadExecutor()
+    }
+
     companion object {
+        private val executorRef = AtomicReference(newVirtualThreadExecutor())
+
         /**
-         * Virtual Thread Per Task Executor.
+         * Virtual-thread-per-task executor.
          *
-         * ## 동작/계약
-         * - `Executors.newVirtualThreadPerTaskExecutor()`로 생성됩니다.
-         * - 각 작업마다 새 가상 스레드를 할당합니다.
+         * ## Contract
+         * - Created by [Executors.newVirtualThreadPerTaskExecutor].
+         * - Allocates a new virtual thread for each submitted task.
+         * - If a Spring context shutdown closed the previous executor, the next
+         *   access returns a fresh executor instead of a closed instance.
          *
          * ```kotlin
          * val future = AbstractVirtualThreadController.virtualThreadExecutor.submit { "done" }
          * // future.get() == "done"
          * ```
          */
-        val virtualThreadExecutor: ExecutorService =
+        val virtualThreadExecutor: ExecutorService
+            get() = getOrCreateVirtualThreadExecutor()
+
+        private fun newVirtualThreadExecutor(): ExecutorService =
             Executors.newVirtualThreadPerTaskExecutor()
+
+        private fun getOrCreateVirtualThreadExecutor(): ExecutorService {
+            while (true) {
+                val current = executorRef.get()
+                if (!current.isShutdown && !current.isTerminated) {
+                    return current
+                }
+
+                val replacement = newVirtualThreadExecutor()
+                if (executorRef.compareAndSet(current, replacement)) {
+                    return replacement
+                }
+                replacement.shutdown()
+            }
+        }
+
+        internal fun shutdownVirtualThreadExecutor() {
+            executorRef.get().shutdown()
+        }
     }
 }

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/http/RestClientCoroutinesDslTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/http/RestClientCoroutinesDslTest.kt
@@ -1,6 +1,9 @@
 package io.bluetape4k.spring.http
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.KLogging
 import kotlinx.coroutines.cancelAndJoin
@@ -95,6 +98,62 @@ class RestClientCoroutinesDslTest {
             )
             val result: String = restClient.suspendPatch("/test", "payload", MediaType.APPLICATION_JSON)
             result shouldBeEqualTo "patched"
+        }
+
+    @Test
+    fun `suspendGet rejects empty body with contextual contract error`() =
+        runTest {
+            mockServer.enqueue(MockResponse().setResponseCode(204))
+
+            val error = assertFailsWith<IllegalStateException> {
+                restClient.suspendGet<String>("/empty-get")
+            }
+
+            val message = error.message.shouldNotBeNull()
+            message shouldContain "GET /empty-get"
+            message shouldContain "java.lang.String"
+        }
+
+    @Test
+    fun `suspendPost rejects empty body with contextual contract error`() =
+        runTest {
+            mockServer.enqueue(MockResponse().setResponseCode(204))
+
+            val error = assertFailsWith<IllegalStateException> {
+                restClient.suspendPost<String>("/empty-post", "payload", MediaType.APPLICATION_JSON)
+            }
+
+            val message = error.message.shouldNotBeNull()
+            message shouldContain "POST /empty-post"
+            message shouldContain "java.lang.String"
+        }
+
+    @Test
+    fun `suspendPut rejects empty body with contextual contract error`() =
+        runTest {
+            mockServer.enqueue(MockResponse().setResponseCode(204))
+
+            val error = assertFailsWith<IllegalStateException> {
+                restClient.suspendPut<String>("/empty-put", "payload", MediaType.APPLICATION_JSON)
+            }
+
+            val message = error.message.shouldNotBeNull()
+            message shouldContain "PUT /empty-put"
+            message shouldContain "java.lang.String"
+        }
+
+    @Test
+    fun `suspendPatch rejects empty body with contextual contract error`() =
+        runTest {
+            mockServer.enqueue(MockResponse().setResponseCode(204))
+
+            val error = assertFailsWith<IllegalStateException> {
+                restClient.suspendPatch<String>("/empty-patch", "payload", MediaType.APPLICATION_JSON)
+            }
+
+            val message = error.message.shouldNotBeNull()
+            message shouldContain "PATCH /empty-patch"
+            message shouldContain "java.lang.String"
         }
 
     @Test

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/virtualthread/AbstractVirtualThreadControllerTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/virtualthread/AbstractVirtualThreadControllerTest.kt
@@ -1,0 +1,66 @@
+package io.bluetape4k.spring.virtualthread
+
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+class AbstractVirtualThreadControllerTest {
+
+    @AfterEach
+    fun tearDown() {
+        AbstractVirtualThreadController.shutdownVirtualThreadExecutor()
+    }
+
+    @Test
+    fun `controller destroy shuts down current virtual thread executor`() {
+        val executor = AbstractVirtualThreadController.virtualThreadExecutor
+        executor.isShutdown.shouldBeFalse()
+
+        TestVirtualThreadController().closeVirtualThreadExecutor()
+
+        executor.isShutdown.shouldBeTrue()
+    }
+
+    @Test
+    fun `executor accessor recreates executor after shutdown`() {
+        val closedExecutor = AbstractVirtualThreadController.virtualThreadExecutor
+        TestVirtualThreadController().closeVirtualThreadExecutor()
+        closedExecutor.isShutdown.shouldBeTrue()
+
+        val replacementExecutor = AbstractVirtualThreadController.virtualThreadExecutor
+
+        replacementExecutor.isShutdown.shouldBeFalse()
+        (replacementExecutor === closedExecutor).shouldBeFalse()
+    }
+
+    @Test
+    fun `spring context shutdown closes controller executor`() {
+        val executor = AbstractVirtualThreadController.virtualThreadExecutor
+
+        contextRunner.run { context ->
+            context.getBean(TestVirtualThreadController::class.java)
+            executor.isShutdown.shouldBeFalse()
+        }
+
+        executor.isShutdown.shouldBeTrue()
+    }
+
+    private class TestVirtualThreadController: AbstractVirtualThreadController()
+
+    @Configuration(proxyBeanMethods = false)
+    private class TestConfiguration {
+
+        @Bean
+        fun testVirtualThreadController(): TestVirtualThreadController =
+            TestVirtualThreadController()
+    }
+
+    private companion object {
+        val contextRunner = ApplicationContextRunner()
+            .withUserConfiguration(TestConfiguration::class.java)
+    }
+}

--- a/spring-boot/hibernate-lettuce/src/main/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheActuatorAutoConfiguration.kt
+++ b/spring-boot/hibernate-lettuce/src/main/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheActuatorAutoConfiguration.kt
@@ -2,12 +2,10 @@ package io.bluetape4k.spring.boot.autoconfigure.cache.lettuce
 
 import io.bluetape4k.hibernate.cache.lettuce.LettuceNearCacheRegionFactory
 import jakarta.persistence.EntityManagerFactory
-import org.springframework.boot.actuate.endpoint.annotation.Endpoint
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration
 import org.springframework.context.annotation.Bean
 
 /**
@@ -35,9 +33,18 @@ import org.springframework.context.annotation.Bean
  * // GET /actuator/nearcache/{region}  → 특정 region 통계
  * ```
  */
-@AutoConfiguration(after = [LettuceNearCacheHibernateAutoConfiguration::class, HibernateJpaAutoConfiguration::class])
-@ConditionalOnClass(Endpoint::class, LettuceNearCacheRegionFactory::class, EntityManagerFactory::class)
-@ConditionalOnBean(EntityManagerFactory::class)
+@AutoConfiguration(
+    after = [LettuceNearCacheHibernateAutoConfiguration::class],
+    afterName = ["org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration"],
+)
+@ConditionalOnClass(
+    name = [
+        "org.springframework.boot.actuate.endpoint.annotation.Endpoint",
+        "io.bluetape4k.hibernate.cache.lettuce.LettuceNearCacheRegionFactory",
+        "jakarta.persistence.EntityManagerFactory",
+    ]
+)
+@ConditionalOnBean(type = ["jakarta.persistence.EntityManagerFactory"])
 @ConditionalOnProperty(
     prefix = "bluetape4k.cache.lettuce-near",
     name = ["enabled"],

--- a/spring-boot/hibernate-lettuce/src/main/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheHibernateAutoConfiguration.kt
+++ b/spring-boot/hibernate-lettuce/src/main/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheHibernateAutoConfiguration.kt
@@ -1,7 +1,6 @@
 package io.bluetape4k.spring.boot.autoconfigure.cache.lettuce
 
 import io.bluetape4k.hibernate.cache.lettuce.LettuceNearCacheRegionFactory
-import jakarta.persistence.EntityManagerFactory
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -37,7 +36,13 @@ import org.springframework.context.annotation.Bean
  * ```
  */
 @AutoConfiguration
-@ConditionalOnClass(LettuceNearCacheRegionFactory::class, EntityManagerFactory::class)
+@ConditionalOnClass(
+    name = [
+        "io.bluetape4k.hibernate.cache.lettuce.LettuceNearCacheRegionFactory",
+        "jakarta.persistence.EntityManagerFactory",
+        "org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer",
+    ]
+)
 @ConditionalOnProperty(
     prefix = "bluetape4k.cache.lettuce-near",
     name = ["enabled"],

--- a/spring-boot/hibernate-lettuce/src/main/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheMetricsAutoConfiguration.kt
+++ b/spring-boot/hibernate-lettuce/src/main/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheMetricsAutoConfiguration.kt
@@ -8,9 +8,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
-import org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration
-import org.springframework.boot.micrometer.metrics.autoconfigure.CompositeMeterRegistryAutoConfiguration
-import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration
 import org.springframework.context.annotation.Bean
 
 /**
@@ -37,15 +34,21 @@ import org.springframework.context.annotation.Bean
  * ```
  */
 @AutoConfiguration(
-    after = [
-        LettuceNearCacheHibernateAutoConfiguration::class,
-        HibernateJpaAutoConfiguration::class,
-        MetricsAutoConfiguration::class,
-        CompositeMeterRegistryAutoConfiguration::class,
+    after = [LettuceNearCacheHibernateAutoConfiguration::class],
+    afterName = [
+        "org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration",
+        "org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration",
+        "org.springframework.boot.micrometer.metrics.autoconfigure.CompositeMeterRegistryAutoConfiguration",
     ]
 )
-@ConditionalOnClass(LettuceNearCacheRegionFactory::class, EntityManagerFactory::class, MeterRegistry::class)
-@ConditionalOnBean(EntityManagerFactory::class, MeterRegistry::class)
+@ConditionalOnClass(
+    name = [
+        "io.bluetape4k.hibernate.cache.lettuce.LettuceNearCacheRegionFactory",
+        "jakarta.persistence.EntityManagerFactory",
+        "io.micrometer.core.instrument.MeterRegistry",
+    ]
+)
+@ConditionalOnBean(type = ["jakarta.persistence.EntityManagerFactory", "io.micrometer.core.instrument.MeterRegistry"])
 @ConditionalOnProperty(
     prefix = "bluetape4k.cache.lettuce-near.metrics",
     name = ["enabled"],

--- a/spring-boot/hibernate-lettuce/src/test/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheAutoConfigurationTest.kt
+++ b/spring-boot/hibernate-lettuce/src/test/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheAutoConfigurationTest.kt
@@ -1,16 +1,17 @@
 package io.bluetape4k.spring.boot.autoconfigure.cache.lettuce
 
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import jakarta.persistence.EntityManagerFactory
 import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldHaveSize
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import jakarta.persistence.EntityManagerFactory
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.getBean
 import org.springframework.beans.factory.getBeansOfType
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer
+import org.springframework.boot.test.context.FilteredClassLoader
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import java.util.function.Supplier
 
@@ -45,6 +46,18 @@ class LettuceNearCacheAutoConfigurationTest {
         contextRunner
             .withPropertyValues("bluetape4k.cache.lettuce-near.enabled=false")
             .run { context ->
+                context.getBeansOfType<HibernatePropertiesCustomizer>().shouldBeEmpty()
+            }
+    }
+
+    @Test
+    fun `Hibernate customizer가 classpath에 없으면 auto configuration이 안전하게 비활성화된다`() {
+        contextRunner
+            .withClassLoader(
+                FilteredClassLoader("org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer")
+            )
+            .run { context ->
+                context.getStartupFailure() shouldBeEqualTo null
                 context.getBeansOfType<HibernatePropertiesCustomizer>().shouldBeEmpty()
             }
     }
@@ -143,7 +156,17 @@ class LettuceNearCacheAutoConfigurationTest {
     fun `actuator auto configuration registers endpoint when entity manager exists`() {
         metricsContextRunner.run { context ->
             context.getBeansOfType<LettuceNearCacheActuatorEndpoint>().shouldHaveSize(1)
-        }
+            }
+    }
+
+    @Test
+    fun `actuator가 classpath에 없으면 endpoint auto configuration이 안전하게 비활성화된다`() {
+        metricsContextRunner
+            .withClassLoader(FilteredClassLoader("org.springframework.boot.actuate.endpoint.annotation.Endpoint"))
+            .run { context ->
+                context.getStartupFailure() shouldBeEqualTo null
+                context.getBeansOfType<LettuceNearCacheActuatorEndpoint>().shouldBeEmpty()
+            }
     }
 
     @Test
@@ -152,6 +175,16 @@ class LettuceNearCacheAutoConfigurationTest {
             .withBean(SimpleMeterRegistry::class.java, Supplier { SimpleMeterRegistry() })
             .withPropertyValues("bluetape4k.cache.lettuce-near.metrics.enabled=false")
             .run { context ->
+                context.getBeansOfType<LettuceNearCacheMetricsBinder>().shouldBeEmpty()
+            }
+    }
+
+    @Test
+    fun `micrometer가 classpath에 없으면 metrics auto configuration이 안전하게 비활성화된다`() {
+        metricsContextRunner
+            .withClassLoader(FilteredClassLoader("io.micrometer.core.instrument.MeterRegistry"))
+            .run { context ->
+                context.getStartupFailure() shouldBeEqualTo null
                 context.getBeansOfType<LettuceNearCacheMetricsBinder>().shouldBeEmpty()
             }
     }

--- a/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
+++ b/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
@@ -17,6 +17,7 @@ import java.util.concurrent.StructuredTaskScope
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Function
 
 /**
@@ -55,6 +56,8 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
          *
          * [joinAction]이 실행되는 동안 [deadline]이 초과되면 owner thread를 interrupt하여
          * [InterruptedException]을 발생시키고, 이를 [TimeoutException]으로 변환합니다.
+         * timeout interrupt가 아닌 기존/외부 interrupt는 [InterruptedException]으로 보존하고
+         * caller thread의 interrupt 상태를 복구합니다.
          *
          * ## 계약
          * - [joinAction]은 [InterruptedException]을 catch하지 않고 전파해야 합니다.
@@ -75,21 +78,31 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
             val scheduler = ScheduledThreadPoolExecutor(1) { r ->
                 Thread(r, threadName).apply { isDaemon = true }
             }
+            val timeoutTriggered = AtomicBoolean(false)
             val timeoutFuture = scheduler.schedule(
-                { ownerThread.interrupt() },
+                {
+                    timeoutTriggered.set(true)
+                    ownerThread.interrupt()
+                },
                 remaining.toNanos(),
                 TimeUnit.NANOSECONDS
             )
+            var preserveInterrupt = false
             try {
                 joinAction()
             } catch (e: InterruptedException) {
-                throw TimeoutException("joinUntil deadline exceeded")
+                if (timeoutTriggered.get()) {
+                    throw TimeoutException("joinUntil deadline exceeded")
+                }
+                preserveInterrupt = true
+                ownerThread.interrupt()
+                throw e
             } finally {
                 timeoutFuture.cancel(false)
                 scheduler.shutdownNow()
-                // finally 이후 scheduled interrupt가 늦게 발화하더라도 interrupt 상태가
-                // caller thread로 누출되지 않도록 항상 clear
-                Thread.interrupted()
+                if (timeoutTriggered.get() && !preserveInterrupt) {
+                    Thread.interrupted()
+                }
             }
         }
     }

--- a/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderExtTest.kt
+++ b/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderExtTest.kt
@@ -13,7 +13,10 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
 import java.time.Instant
+import java.util.concurrent.Executors
 import java.util.concurrent.StructuredTaskScope
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import io.bluetape4k.assertions.assertFailsWith
 
 /**
@@ -80,12 +83,88 @@ class Jdk25StructuredTaskScopeProviderExtTest {
 
     @Test
     fun `withAll joinUntil 이미 지난 데드라인에서 TimeoutException 이 발생해야 한다`() {
-        assertFailsWith<java.util.concurrent.TimeoutException> {
+        assertFailsWith<TimeoutException> {
             provider.withAll { scope ->
                 scope.fork { Thread.sleep(500); 1 }
                 scope.joinUntil(Instant.now().minusSeconds(1))
                 scope.throwIfFailed()
             }
+        }
+    }
+
+    @Test
+    fun `interruptJoinUntil timeout interrupt는 TimeoutException 으로 변환하고 interrupt 상태를 clear 해야 한다`() {
+        try {
+            assertFailsWith<TimeoutException> {
+                Jdk25StructuredTaskScopeProvider.interruptJoinUntil(
+                    deadline = Instant.now().plusMillis(100),
+                    threadName = "jdk25-test-timeout",
+                ) {
+                    Thread.sleep(5_000)
+                }
+            }
+
+            Thread.currentThread().isInterrupted.shouldBeFalse()
+        } finally {
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `interruptJoinUntil 기존 interrupt는 InterruptedException 으로 보존해야 한다`() {
+        try {
+            Thread.currentThread().interrupt()
+
+            assertFailsWith<InterruptedException> {
+                Jdk25StructuredTaskScopeProvider.interruptJoinUntil(
+                    deadline = Instant.now().plusSeconds(5),
+                    threadName = "jdk25-test-pre-interrupted",
+                ) {
+                    Thread.sleep(10)
+                }
+            }
+
+            Thread.currentThread().isInterrupted.shouldBeTrue()
+        } finally {
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `interruptJoinUntil 외부 interrupt는 InterruptedException 으로 보존해야 한다`() {
+        val ownerThread = Thread.currentThread()
+        val interrupter = Executors.newSingleThreadScheduledExecutor()
+        try {
+            assertFailsWith<InterruptedException> {
+                interrupter.schedule({ ownerThread.interrupt() }, 100, TimeUnit.MILLISECONDS)
+                Jdk25StructuredTaskScopeProvider.interruptJoinUntil(
+                    deadline = Instant.now().plusSeconds(5),
+                    threadName = "jdk25-test-external-interrupt",
+                ) {
+                    Thread.sleep(5_000)
+                }
+            }
+
+            Thread.currentThread().isInterrupted.shouldBeTrue()
+        } finally {
+            interrupter.shutdownNow()
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `interruptJoinUntil 정상 완료는 interrupt 상태를 변경하지 않아야 한다`() {
+        try {
+            Jdk25StructuredTaskScopeProvider.interruptJoinUntil(
+                deadline = Instant.now().plusSeconds(5),
+                threadName = "jdk25-test-normal-completion",
+            ) {
+                Thread.sleep(10)
+            }
+
+            Thread.currentThread().isInterrupted.shouldBeFalse()
+        } finally {
+            Thread.interrupted()
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #949

- PR 제목: fix: preserve Lettuce lock release tokens

- Validate Lettuce lock wait/lease/max-wait durations before constructing Redis `PX` commands.
- Keep local owner tokens until the Redis unlock script confirms release success.
- Add sync/async/suspend regression tests for invalid durations and retryable failed release.

Fixes #949

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- `./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lock.LettuceLockTest" --tests "io.bluetape4k.redis.lettuce.lock.LettuceSuspendLockTest"`
- `git diff --check`

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- Stacked on #966 (`fix/issue-942-cache-cancellation-fallback`).
- Scope is limited to Lettuce lock APIs; semaphore ownership issue #944 remains separate because it changes the semaphore data model.

## Metadata

- Issue: #949, milestone `1.12.0`, assignee `debop`
- PR: #967, head `e7ef54443aabe87419998e94544c2427386ac872`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-944-949-lettuce-lock-ownership`
- Labels: `bug`, `test`, `tech-debt`
- State: `MERGED`, merge commit `f1875585d88c12e3300f19abb90d0aa464fade9c`
- CI: - `./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lock.LettuceLockTest" --tests "io.bluetape4k.redis.lettuce.lock.LettuceSuspendLockTest"`

## DoD Status

- [x] Issue #949 is addressed by validating Redis lock durations at the API boundary.
- [x] Local lock tokens are preserved after failed release and cleared only after confirmed release.
- [x] Sync, async, and suspend lock tests passed locally.
- [ ] Full repository test will run after the stacked PR set is complete.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #967 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `f1875585d88c12e3300f19abb90d0aa464fade9c`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
