### PR TITLE
test: migrate residual assertion and coroutine patterns

### DIFF
--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientNearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientNearJCache.kt
@@ -59,6 +59,8 @@ class ResilientNearJCache<K: Any, V: Any>(
 
     companion object: KLogging()
 
+    private val closeDrainTimeoutMillis: Long = 5_000L
+
     private val closed = atomic(false)
     val isClosed by closed
 
@@ -85,17 +87,25 @@ class ResilientNearJCache<K: Any, V: Any>(
     private val consumerThread: Thread = virtualThread(
         name = "resilient-near-cache-writer-${config.cacheName}",
     ) {
-        while (!closed.value) {
+        while (true) {
             try {
-                val cmd = queue.take()
+                val cmd = if (closed.value) {
+                    queue.poll() ?: break
+                } else {
+                    queue.take()
+                }
                 try {
                     retry.executeRunnable { applyCommand(cmd) }
                 } catch (e: Exception) {
                     log.error(e) { "Back cache write failed after ${config.retryMaxAttempts} retries, dropping command: $cmd" }
                 }
             } catch (e: InterruptedException) {
-                Thread.currentThread().interrupt()
-                break
+                if (closed.value) {
+                    continue
+                } else {
+                    Thread.currentThread().interrupt()
+                    break
+                }
             }
         }
     }
@@ -186,22 +196,18 @@ class ResilientNearJCache<K: Any, V: Any>(
      */
     fun put(key: K, value: V) {
         key.requireNotNull("key")
+        enqueueWrite(BackJCacheCommand.Put(key, value), "Write queue full for Put key=$key")
         tombstones.remove(key)
         frontCache.put(key, value)
-        if (!queue.offer(BackJCacheCommand.Put(key, value))) {
-            log.warn { "Write queue full, dropping Put for key=$key" }
-        }
     }
 
     /**
      * 여러 키-값 쌍을 저장한다.
      */
     fun putAll(entries: Map<K, V>) {
+        enqueueWrite(BackJCacheCommand.PutAll(entries), "Write queue full for PutAll entries=${entries.size}")
         tombstones.removeAll(entries.keys)
         frontCache.putAll(entries)
-        if (!queue.offer(BackJCacheCommand.PutAll(entries))) {
-            log.warn { "Write queue full, dropping PutAll for ${entries.size} entries" }
-        }
     }
 
     /**
@@ -286,22 +292,18 @@ class ResilientNearJCache<K: Any, V: Any>(
      */
     fun remove(key: K) {
         key.requireNotNull("key")
+        enqueueWrite(BackJCacheCommand.Remove(key), "Write queue full for Remove key=$key")
         frontCache.remove(key)
         tombstones.add(key)
-        if (!queue.offer(BackJCacheCommand.Remove(key))) {
-            log.warn { "Write queue full, dropping Remove for key=$key" }
-        }
     }
 
     /**
      * 여러 키에 해당하는 캐시 항목을 제거한다.
      */
     fun removeAll(keys: Set<K>) {
+        enqueueWrite(BackJCacheCommand.RemoveAll(keys), "Write queue full for RemoveAll keys=${keys.size}")
         frontCache.removeAll(keys)
         tombstones.addAll(keys)
-        if (!queue.offer(BackJCacheCommand.RemoveAll(keys))) {
-            log.warn { "Write queue full, dropping RemoveAll for ${keys.size} keys" }
-        }
     }
 
     /**
@@ -316,10 +318,13 @@ class ResilientNearJCache<K: Any, V: Any>(
      * 로컬 캐시와 back cache를 모두 비운다 (write-behind).
      */
     fun clearAll() {
-        clearLocal()
         clearPending.value = true
-        if (!queue.offer(BackJCacheCommand.ClearBack())) {
-            log.warn { "Write queue full, dropping ClearBack" }
+        try {
+            enqueueWrite(BackJCacheCommand.ClearBack(), "Write queue full for ClearBack")
+            clearLocal()
+        } catch (e: Exception) {
+            clearPending.value = false
+            throw e
         }
     }
 
@@ -334,9 +339,21 @@ class ResilientNearJCache<K: Any, V: Any>(
     override fun close() {
         if (closed.compareAndSet(false, true)) {
             runCatching { consumerThread.interrupt() }
-            runCatching { queue.clear() }
+            runCatching {
+                if (Thread.currentThread() != consumerThread) {
+                    consumerThread.join(closeDrainTimeoutMillis)
+                    if (consumerThread.isAlive) {
+                        log.warn { "Timed out draining back cache write queue. remaining=${queue.size}" }
+                    }
+                }
+            }
             runCatching { frontCache.close() }
             log.debug { "ResilientNearCache closed" }
         }
+    }
+
+    private fun enqueueWrite(command: BackJCacheCommand<K, V>, failureMessage: String) {
+        check(!closed.value) { "ResilientNearCache is closed" }
+        check(queue.offer(command)) { failureMessage }
     }
 }

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCache.kt
@@ -15,10 +15,13 @@ import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -64,6 +67,8 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
 
     companion object: KLogging()
 
+    private val closeDrainTimeoutMillis: Long = 5_000L
+
     private val closed = atomic(false)
     val isClosed by closed
 
@@ -89,9 +94,7 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
      */
     private val clearPending = atomic(false)
 
-    init {
-        launchWriteConsumer()
-    }
+    private val writeConsumerJob: Job = launchWriteConsumer()
 
     private fun buildRetry(): Retry {
         val intervalFn = if (config.retryExponentialBackoff) {
@@ -106,7 +109,7 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
         return Retry.of("resilient-suspend-near-cache-write-retry", retryConfig)
     }
 
-    private fun launchWriteConsumer() {
+    private fun launchWriteConsumer(): Job =
         scope.launch {
             for (cmd in writeChannel) {
                 try {
@@ -118,7 +121,6 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
                 }
             }
         }
-    }
 
     private suspend fun applyCommand(cmd: BackJCacheCommand<K, V>) {
         when (cmd) {
@@ -187,22 +189,18 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
      */
     suspend fun put(key: K, value: V) {
         key.requireNotNull("key")
+        enqueueWrite(BackJCacheCommand.Put(key, value), "Write channel full for Put key=$key")
         tombstones.remove(key)
         frontCache.put(key, value)
-        writeChannel.trySend(BackJCacheCommand.Put(key, value)).also { result ->
-            if (result.isFailure) log.warn { "Write channel full, dropping Put for key=$key" }
-        }
     }
 
     /**
      * 여러 키-값 쌍을 저장한다.
      */
     suspend fun putAll(entries: Map<K, V>) {
+        enqueueWrite(BackJCacheCommand.PutAll(entries), "Write channel full for PutAll entries=${entries.size}")
         tombstones.removeAll(entries.keys)
         frontCache.putAll(entries)
-        writeChannel.trySend(BackJCacheCommand.PutAll(entries)).also { result ->
-            if (result.isFailure) log.warn { "Write channel full, dropping PutAll for ${entries.size} entries" }
-        }
     }
 
     /**
@@ -285,22 +283,18 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
      */
     suspend fun remove(key: K) {
         key.requireNotNull("key")
+        enqueueWrite(BackJCacheCommand.Remove(key), "Write channel full for Remove key=$key")
         frontCache.remove(key)
         tombstones.add(key)
-        writeChannel.trySend(BackJCacheCommand.Remove(key)).also { result ->
-            if (result.isFailure) log.warn { "Write channel full, dropping Remove for key=$key" }
-        }
     }
 
     /**
      * 여러 키에 해당하는 캐시 항목을 제거한다.
      */
     suspend fun removeAll(keys: Set<K>) {
+        enqueueWrite(BackJCacheCommand.RemoveAll(keys), "Write channel full for RemoveAll keys=${keys.size}")
         frontCache.removeAll(keys)
         tombstones.addAll(keys)
-        writeChannel.trySend(BackJCacheCommand.RemoveAll(keys)).also { result ->
-            if (result.isFailure) log.warn { "Write channel full, dropping RemoveAll for ${keys.size} keys" }
-        }
     }
 
     /**
@@ -315,10 +309,13 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
      * 로컬 캐시와 back cache를 모두 비운다 (write-behind).
      */
     suspend fun clearAll() {
-        clearLocal()
         clearPending.value = true
-        writeChannel.trySend(BackJCacheCommand.ClearBack()).also { result ->
-            if (result.isFailure) log.warn { "Write channel full, dropping ClearBack" }
+        try {
+            enqueueWrite(BackJCacheCommand.ClearBack(), "Write channel full for ClearBack")
+            clearLocal()
+        } catch (e: Exception) {
+            clearPending.value = false
+            throw e
         }
     }
 
@@ -360,10 +357,26 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
      */
     override fun close() {
         if (closed.compareAndSet(false, true)) {
-            runCatching { scope.cancel() }
             runCatching { writeChannel.close() }
+            runCatching {
+                runBlocking {
+                    val drained = withTimeoutOrNull(closeDrainTimeoutMillis) {
+                        writeConsumerJob.join()
+                        true
+                    } ?: false
+                    if (!drained) {
+                        log.warn { "Timed out draining back cache write channel." }
+                    }
+                }
+            }
+            runCatching { scope.cancel() }
             runCatching { frontCache.close() }
             log.debug { "ResilientSuspendNearCache closed" }
         }
+    }
+
+    private fun enqueueWrite(command: BackJCacheCommand<K, V>, failureMessage: String) {
+        check(!closed.value) { "ResilientSuspendNearCache is closed" }
+        check(writeChannel.trySend(command).isSuccess) { failureMessage }
     }
 }

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCache.kt
@@ -154,9 +154,7 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
 
         return when (config.getFailureStrategy) {
             GetFailureStrategy.RETURN_FRONT_OR_NULL ->
-                runCatching { backCache.get(key) }
-                    .onFailure { e -> log.warn(e) { "Back cache GET failed for key=$key, returning null" } }
-                    .getOrNull()
+                getBackOrNull(key, "Back cache GET failed for key=$key, returning null")
                     ?.also { value -> frontCache.put(key, value) }
 
             GetFailureStrategy.PROPAGATE_EXCEPTION ->
@@ -173,9 +171,7 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
         val missedKeys = (keys - result.keys).filter { !tombstones.contains(it) }
 
         missedKeys.forEach { key ->
-            runCatching { backCache.get(key) }
-                .onFailure { e -> log.warn(e) { "Back cache GET failed for key=$key during getAll" } }
-                .getOrNull()
+            getBackOrNull(key, "Back cache GET failed for key=$key during getAll")
                 ?.let { value ->
                     result[key] = value
                     frontCache.put(key, value)
@@ -237,7 +233,7 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
         if (tombstones.contains(key) || clearPending.value) return false
 
         if (!frontCache.containsKey(key)) {
-            if (!runCatching { backCache.containsKey(key) }.getOrDefault(false)) return false
+            if (!containsBackOrFalse(key, null)) return false
         }
         val replaced = backCache.replace(key, value)
         if (replaced) {
@@ -279,9 +275,7 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
     suspend fun containsKey(key: K): Boolean {
         if (tombstones.contains(key) || clearPending.value) return false
         if (frontCache.containsKey(key)) return true
-        return runCatching { backCache.containsKey(key) }
-            .onFailure { e -> log.warn(e) { "Back cache containsKey failed for key=$key" } }
-            .getOrDefault(false)
+        return containsBackOrFalse(key, "Back cache containsKey failed for key=$key")
     }
 
     /**
@@ -332,6 +326,34 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
      * 로컬 캐시의 추정 크기.
      */
     fun localCacheSize(): Long = frontCache.estimatedSize()
+
+    private suspend fun getBackOrNull(
+        key: K,
+        failureMessage: String,
+    ): V? =
+        try {
+            backCache.get(key)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { failureMessage }
+            null
+        }
+
+    private suspend fun containsBackOrFalse(
+        key: K,
+        failureMessage: String?,
+    ): Boolean =
+        try {
+            backCache.containsKey(key)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            if (failureMessage != null) {
+                log.warn(e) { failureMessage }
+            }
+            false
+        }
 
     /**
      * 모든 리소스를 정리한다.

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/NearCacheResilienceConfigBuilderTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/NearCacheResilienceConfigBuilderTest.kt
@@ -1,12 +1,12 @@
 package io.bluetape4k.cache.nearcache
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.logging.KLogging
 import org.junit.jupiter.api.Test
 import java.time.Duration
-import kotlin.test.assertFailsWith
 
 class NearCacheResilienceConfigBuilderTest {
 

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientNearJCacheTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientNearJCacheTest.kt
@@ -2,12 +2,15 @@ package io.bluetape4k.cache.nearcache.jcache
 
 import io.bluetape4k.cache.jcache.JCaching
 import io.bluetape4k.cache.jcache.jcacheConfiguration
-import io.bluetape4k.idgenerators.uuid.Uuid
-import io.bluetape4k.logging.KLogging
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.idgenerators.uuid.Uuid
+import io.bluetape4k.logging.KLogging
+import io.mockk.every
+import io.mockk.mockk
 import org.awaitility.kotlin.atMost
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.until
@@ -15,6 +18,10 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.cache.Cache
 import javax.cache.expiry.EternalExpiryPolicy
 import kotlin.time.Duration.Companion.seconds
 
@@ -79,6 +86,40 @@ class ResilientNearJCacheTest {
         // back cache는 write-behind로 비동기 반영 → awaitility 폴링
         await atMost 5.seconds until { backCache.get("wb-key") != null }
         backCache.get("wb-key") shouldBeEqualTo "wb-val"
+    }
+
+    @Test
+    fun `put - full write queue fails before front update`() {
+        val putStarted = CountDownLatch(1)
+        val releasePut = CountDownLatch(1)
+        val blockingBackCache = mockk<Cache<String, String>>(relaxed = true)
+        every { blockingBackCache.put(any(), any()) } answers {
+            putStarted.countDown()
+            releasePut.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        }
+        every { blockingBackCache.get("third") } returns null
+        val smallQueueCache = ResilientNearJCache(
+            backCache = blockingBackCache,
+            config = ResilientNearJCacheConfig(
+                writeQueueCapacity = 1,
+                retryMaxAttempts = 1,
+                retryWaitDuration = Duration.ofMillis(10),
+            )
+        )
+
+        try {
+            smallQueueCache.put("first", "1")
+            putStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            smallQueueCache.put("second", "2")
+
+            assertFailsWith<IllegalStateException> {
+                smallQueueCache.put("third", "3")
+            }
+            smallQueueCache.get("third").shouldBeNull()
+        } finally {
+            releasePut.countDown()
+            smallQueueCache.close()
+        }
     }
 
     @Test
@@ -201,6 +242,36 @@ class ResilientNearJCacheTest {
         cache.localCacheSize() shouldBeEqualTo 0L
 
         await atMost 5.seconds until { backCache.get("k1") == null }
+    }
+
+    @Test
+    fun `close drains queued write-behind commands`() {
+        val closeDrainBackCache =
+            JCaching.Caffeine.getOrCreate<String, String>(
+                name = "resilient-near-close-drain-" + randomKey(),
+                configuration =
+                    jcacheConfiguration {
+                        setExpiryPolicyFactory(EternalExpiryPolicy.factoryOf())
+                    }
+            )
+        val closeDrainCache = ResilientNearJCache(
+            backCache = closeDrainBackCache,
+            config = ResilientNearJCacheConfig(
+                writeQueueCapacity = 512,
+                retryMaxAttempts = 1,
+                retryWaitDuration = Duration.ofMillis(10),
+            )
+        )
+
+        repeat(200) { index ->
+            closeDrainCache.put("close-$index", "value-$index")
+        }
+
+        closeDrainCache.close()
+
+        repeat(200) { index ->
+            closeDrainBackCache.get("close-$index") shouldBeEqualTo "value-$index"
+        }
     }
 
     @Test

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCacheTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCacheTest.kt
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -83,6 +85,41 @@ class ResilientSuspendNearJCacheTest {
 
             await atMost 5.seconds untilSuspending { backCache.get("wb-key") == "wb-val" }
             backCache.get("wb-key") shouldBeEqualTo "wb-val"
+        }
+
+    @Test
+    fun `put - full write channel fails before front update`() =
+        runSuspendIO {
+            val putStarted = CountDownLatch(1)
+            val releasePut = CountDownLatch(1)
+            val blockingBackCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+            coEvery { blockingBackCache.put(any(), any()) } coAnswers {
+                putStarted.countDown()
+                releasePut.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            }
+            coEvery { blockingBackCache.get("third") } returns null
+            val smallQueueCache = ResilientSuspendNearJCache(
+                backCache = blockingBackCache,
+                config = ResilientNearJCacheConfig(
+                    writeQueueCapacity = 1,
+                    retryMaxAttempts = 1,
+                    retryWaitDuration = Duration.ofMillis(10),
+                )
+            )
+
+            try {
+                smallQueueCache.put("first", "1")
+                putStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                smallQueueCache.put("second", "2")
+
+                assertFailsWith<IllegalStateException> {
+                    smallQueueCache.put("third", "3")
+                }
+                smallQueueCache.get("third").shouldBeNull()
+            } finally {
+                releasePut.countDown()
+                smallQueueCache.close()
+            }
         }
 
     @Test
@@ -282,6 +319,34 @@ class ResilientSuspendNearJCacheTest {
 
             await atMost 5.seconds untilSuspending { backCache.get("k1") == null }
             backCache.get("k1").shouldBeNull()
+        }
+
+    @Test
+    fun `close drains queued write-behind commands`() =
+        runSuspendIO {
+            val closeDrainBackCache =
+                CaffeineSuspendJCache<String, String> {
+                    maximumSize(10_000)
+                    expireAfterWrite(Duration.ofMinutes(30))
+                }
+            val closeDrainCache = ResilientSuspendNearJCache(
+                backCache = closeDrainBackCache,
+                config = ResilientNearJCacheConfig(
+                    writeQueueCapacity = 512,
+                    retryMaxAttempts = 1,
+                    retryWaitDuration = Duration.ofMillis(10),
+                )
+            )
+
+            repeat(200) { index ->
+                closeDrainCache.put("close-$index", "value-$index")
+            }
+
+            closeDrainCache.close()
+
+            repeat(200) { index ->
+                closeDrainBackCache.get("close-$index") shouldBeEqualTo "value-$index"
+            }
         }
 
     @Test

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCacheTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCacheTest.kt
@@ -1,14 +1,19 @@
 package io.bluetape4k.cache.nearcache.jcache
 
 import io.bluetape4k.cache.jcache.CaffeineSuspendJCache
-import io.bluetape4k.idgenerators.uuid.Uuid
-import io.bluetape4k.junit5.awaitility.untilSuspending
-import io.bluetape4k.junit5.coroutines.runSuspendIO
-import io.bluetape4k.logging.KLogging
+import io.bluetape4k.cache.jcache.SuspendJCache
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.idgenerators.uuid.Uuid
+import io.bluetape4k.junit5.awaitility.untilSuspending
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.KLogging
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import org.awaitility.kotlin.atMost
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.AfterEach
@@ -88,6 +93,23 @@ class ResilientSuspendNearJCacheTest {
         }
 
     @Test
+    fun `get - CancellationException은 fallback하지 않고 재전파한다`() =
+        runSuspendIO {
+            val failingCache = resilientCacheWithFailingBackCache { backCache ->
+                coEvery { backCache.get("cancel-key") } throws CancellationException("cancel get")
+            }
+
+            try {
+                val error = assertFailsWith<CancellationException> {
+                    failingCache.get("cancel-key")
+                }
+                error.message shouldBeEqualTo "cancel get"
+            } finally {
+                failingCache.close()
+            }
+        }
+
+    @Test
     fun `putAll and getAll`() =
         runSuspendIO {
             val data = mapOf("a" to "1", "b" to "2", "c" to "3")
@@ -97,6 +119,23 @@ class ResilientSuspendNearJCacheTest {
             result["b"] shouldBeEqualTo "2"
             result["c"] shouldBeEqualTo "3"
             result["x"].shouldBeNull()
+        }
+
+    @Test
+    fun `getAll - CancellationException은 fallback하지 않고 재전파한다`() =
+        runSuspendIO {
+            val failingCache = resilientCacheWithFailingBackCache { backCache ->
+                coEvery { backCache.get("cancel-key") } throws CancellationException("cancel getAll")
+            }
+
+            try {
+                val error = assertFailsWith<CancellationException> {
+                    failingCache.getAll(setOf("cancel-key"))
+                }
+                error.message shouldBeEqualTo "cancel getAll"
+            } finally {
+                failingCache.close()
+            }
         }
 
     @Test
@@ -133,6 +172,23 @@ class ResilientSuspendNearJCacheTest {
         }
 
     @Test
+    fun `containsKey - CancellationException은 false fallback하지 않고 재전파한다`() =
+        runSuspendIO {
+            val failingCache = resilientCacheWithFailingBackCache { backCache ->
+                coEvery { backCache.containsKey("cancel-key") } throws CancellationException("cancel contains")
+            }
+
+            try {
+                val error = assertFailsWith<CancellationException> {
+                    failingCache.containsKey("cancel-key")
+                }
+                error.message shouldBeEqualTo "cancel contains"
+            } finally {
+                failingCache.close()
+            }
+        }
+
+    @Test
     fun `putIfAbsent - 캐시 값 없으면 추가, 있으면 기존 값 반환`() =
         runSuspendIO {
             cache.putIfAbsent("key", "first").shouldBeNull()
@@ -152,6 +208,23 @@ class ResilientSuspendNearJCacheTest {
 
             cache.replace("key", "new").shouldBeTrue()
             cache.get("key") shouldBeEqualTo "new"
+        }
+
+    @Test
+    fun `replace - containsKey CancellationException은 false fallback하지 않고 재전파한다`() =
+        runSuspendIO {
+            val failingCache = resilientCacheWithFailingBackCache { backCache ->
+                coEvery { backCache.containsKey("cancel-key") } throws CancellationException("cancel replace")
+            }
+
+            try {
+                val error = assertFailsWith<CancellationException> {
+                    failingCache.replace("cancel-key", "value")
+                }
+                error.message shouldBeEqualTo "cancel replace"
+            } finally {
+                failingCache.close()
+            }
         }
 
     @Test
@@ -217,5 +290,19 @@ class ResilientSuspendNearJCacheTest {
         c.close()
         c.close() // 중복 호출 시에도 예외 없음
         c.isClosed.shouldBeTrue()
+    }
+
+    private fun resilientCacheWithFailingBackCache(
+        configure: (SuspendJCache<String, String>) -> Unit,
+    ): ResilientSuspendNearJCache<String, String> {
+        val failingBackCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        configure(failingBackCache)
+        return ResilientSuspendNearJCache(
+            backCache = failingBackCache,
+            config = ResilientNearJCacheConfig(
+                retryMaxAttempts = 1,
+                retryWaitDuration = Duration.ofMillis(10),
+            )
+        )
     }
 }

--- a/data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/CassandraAdmin.kt
+++ b/data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/CassandraAdmin.kt
@@ -11,6 +11,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
 import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
 
 /**
  * Cassandra keyspace 관리 및 버전 조회 유틸리티 객체입니다.
@@ -47,15 +48,16 @@ object CassandraAdmin: KLogging() {
         keyspace: String = DEFAULT_KEYSPACE,
         replicationFactor: Int = DEFAULT_REPLICATION_FACTOR,
     ): Boolean {
-        keyspace.requireNotBlank("keyspace")
+        val checkedKeyspace = keyspace.requireNotBlank("keyspace")
+        val checkedReplicationFactor = replicationFactor.requirePositiveNumber("replicationFactor")
 
-        val stmt = SchemaBuilder.createKeyspace(keyspace)
+        val stmt = SchemaBuilder.createKeyspace(checkedKeyspace)
             .ifNotExists()
-            .withSimpleStrategy(replicationFactor)
+            .withSimpleStrategy(checkedReplicationFactor)
             .build()
 
         return session.execute(stmt).wasApplied().apply {
-            log.info { "Create Keyspace[$keyspace], replicationFactor[$replicationFactor] wasApplied [$this]" }
+            log.info { "Create Keyspace[$checkedKeyspace], replicationFactor[$checkedReplicationFactor] wasApplied [$this]" }
         }
     }
 

--- a/data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/CassandraAdminTest.kt
+++ b/data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/CassandraAdminTest.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.cassandra
 
-import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.coroutines.KLoggingChannel
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 
 /**
  * [CassandraAdmin]의 keyspace 생성/삭제 및 버전 조회 기능을 검증합니다.
@@ -57,6 +57,13 @@ class CassandraAdminTest : AbstractCassandraTest() {
     fun `createKeyspace 는 blank keyspace 를 허용하지 않는다`() {
         assertFailsWith<IllegalArgumentException> {
             CassandraAdmin.createKeyspace(session, " ")
+        }
+    }
+
+    @Test
+    fun `createKeyspace 는 양수가 아닌 replicationFactor 를 허용하지 않는다`() {
+        assertFailsWith<IllegalArgumentException> {
+            CassandraAdmin.createKeyspace(session, TEST_KEYSPACE, replicationFactor = 0)
         }
     }
 

--- a/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/PreparedStatementExtensions.kt
+++ b/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/PreparedStatementExtensions.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.jdbc.sql
 
+import io.bluetape4k.support.requirePositiveNumber
 import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.sql.Statement
@@ -135,6 +136,7 @@ fun java.sql.Connection.executeBatch(
     paramsList: List<List<Any?>>,
     batchSize: Int = 1000,
 ): List<IntArray> {
+    val checkedBatchSize = batchSize.requirePositiveNumber("batchSize")
     if (paramsList.isEmpty()) return emptyList()
     paramsList.requireConsistentBatchParameterRows()
 
@@ -149,14 +151,14 @@ fun java.sql.Connection.executeBatch(
             stmt.addBatch()
 
             // 배치 크기에 도달하면 실행
-            if ((index + 1) % batchSize == 0) {
+            if ((index + 1) % checkedBatchSize == 0) {
                 results.add(stmt.executeBatch())
                 stmt.clearBatch()
             }
         }
 
         // 남은 배치 실행
-        if (paramsList.size % batchSize != 0) {
+        if (paramsList.size % checkedBatchSize != 0) {
             results.add(stmt.executeBatch())
         }
 
@@ -194,6 +196,7 @@ fun java.sql.Connection.executeLargeBatch(
     paramsList: List<List<Any?>>,
     batchSize: Int = 1000,
 ): LongArray {
+    val checkedBatchSize = batchSize.requirePositiveNumber("batchSize")
     if (paramsList.isEmpty()) return LongArray(0)
     paramsList.requireConsistentBatchParameterRows()
 
@@ -207,13 +210,13 @@ fun java.sql.Connection.executeLargeBatch(
             }
             stmt.addBatch()
 
-            if ((index + 1) % batchSize == 0) {
+            if ((index + 1) % checkedBatchSize == 0) {
                 stmt.executeLargeBatch().forEach { results.add(it) }
                 stmt.clearBatch()
             }
         }
 
-        if (paramsList.size % batchSize != 0) {
+        if (paramsList.size % checkedBatchSize != 0) {
             stmt.executeLargeBatch().forEach { results.add(it) }
         }
 

--- a/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/TransactionExtensions.kt
+++ b/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/TransactionExtensions.kt
@@ -155,11 +155,17 @@ inline fun <T> Connection.withIsolationLevel(
     block: (Connection) -> T,
 ): T {
     val originalLevel = this.transactionIsolation
+    var primaryFailure: Throwable? = null
     return try {
         this.transactionIsolation = level
         block(this)
+    } catch (e: Throwable) {
+        primaryFailure = e
+        throw e
     } finally {
-        this.transactionIsolation = originalLevel
+        restoreConnectionState(primaryFailure) {
+            this.transactionIsolation = originalLevel
+        }
     }
 }
 
@@ -183,11 +189,17 @@ inline fun <T> Connection.withAutoCommit(
     block: (Connection) -> T,
 ): T {
     val originalAutoCommit = this.autoCommit
+    var primaryFailure: Throwable? = null
     return try {
         this.autoCommit = autoCommit
         block(this)
+    } catch (e: Throwable) {
+        primaryFailure = e
+        throw e
     } finally {
-        this.autoCommit = originalAutoCommit
+        restoreConnectionState(primaryFailure) {
+            this.autoCommit = originalAutoCommit
+        }
     }
 }
 
@@ -209,11 +221,17 @@ inline fun <T> Connection.withAutoCommit(
  */
 inline fun <T> Connection.withReadOnly(block: (Connection) -> T): T {
     val originalReadOnly = this.isReadOnly
+    var primaryFailure: Throwable? = null
     return try {
         this.isReadOnly = true
         block(this)
+    } catch (e: Throwable) {
+        primaryFailure = e
+        throw e
     } finally {
-        this.isReadOnly = originalReadOnly
+        restoreConnectionState(primaryFailure) {
+            this.isReadOnly = originalReadOnly
+        }
     }
 }
 
@@ -236,10 +254,28 @@ inline fun <T> Connection.withHoldability(
     block: (Connection) -> T,
 ): T {
     val originalHoldability = this.holdability
+    var primaryFailure: Throwable? = null
     return try {
         this.holdability = holdability
         block(this)
+    } catch (e: Throwable) {
+        primaryFailure = e
+        throw e
     } finally {
-        this.holdability = originalHoldability
+        restoreConnectionState(primaryFailure) {
+            this.holdability = originalHoldability
+        }
+    }
+}
+
+@PublishedApi
+internal inline fun restoreConnectionState(
+    primaryFailure: Throwable?,
+    restore: () -> Unit,
+) {
+    try {
+        restore()
+    } catch (restoreFailure: Throwable) {
+        primaryFailure?.addSuppressed(restoreFailure) ?: throw restoreFailure
     }
 }

--- a/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/sql/DataSourceTransactionExtensionsTest.kt
+++ b/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/sql/DataSourceTransactionExtensionsTest.kt
@@ -1,13 +1,13 @@
 package io.bluetape4k.jdbc.sql
 
-import io.bluetape4k.jdbc.model.Actor
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.jdbc.model.Actor
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 
 /**
  * DataSourceTransactionExtensions 테스트 클래스
@@ -220,6 +220,17 @@ class DataSourceTransactionExtensionsTest: AbstractJdbcSqlTest() {
     }
 
     @Test
+    fun `DataSource executeBatch - batchSize 는 양수여야 한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            dataSource.executeBatch(
+                "INSERT INTO Actors (firstname, lastname) VALUES (?, ?)",
+                listOf(listOf("InvalidBatch", "Actor")),
+                batchSize = 0
+            )
+        }
+    }
+
+    @Test
     fun `DataSource executeBatch - inconsistent parameter rows fail fast`() {
         assertFailsWith<IllegalArgumentException> {
             dataSource.executeBatch(
@@ -285,7 +296,18 @@ class DataSourceTransactionExtensionsTest: AbstractJdbcSqlTest() {
             ) { rs ->
                 rs.next()
                 rs.getInt(1)
-            }
+        }
         count shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `DataSource executeLargeBatch - batchSize 는 양수여야 한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            dataSource.executeLargeBatch(
+                "INSERT INTO Actors (firstname, lastname) VALUES (?, ?)",
+                listOf(listOf("InvalidLargeBatch", "Actor")),
+                batchSize = -1
+            )
+        }
     }
 }

--- a/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/sql/TransactionExtensionsTest.kt
+++ b/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/sql/TransactionExtensionsTest.kt
@@ -1,17 +1,18 @@
 package io.bluetape4k.jdbc.sql
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
 import java.sql.Connection
+import java.sql.ResultSet
 import java.sql.SQLException
 
 /**
@@ -208,6 +209,74 @@ class TransactionExtensionsTest: AbstractJdbcSqlTest() {
     }
 
     @Test
+    fun `withIsolationLevel suppresses restore failure on primary failure`() {
+        val restoreFailure = SQLException("restore isolation")
+        val primaryFailure = RuntimeException("primary")
+        val recording = RecordingConnection(failRestoringIsolation = restoreFailure)
+
+        val thrown =
+            assertFailsWith<RuntimeException> {
+                recording.connection.withIsolationLevel(Connection.TRANSACTION_SERIALIZABLE) {
+                    throw primaryFailure
+                }
+            }
+
+        thrown shouldBeEqualTo primaryFailure
+        thrown.suppressed.toList() shouldContain restoreFailure
+    }
+
+    @Test
+    fun `withAutoCommit suppresses restore failure on primary failure`() {
+        val restoreFailure = SQLException("restore autoCommit")
+        val primaryFailure = RuntimeException("primary")
+        val recording = RecordingConnection(failRestoringAutoCommit = restoreFailure)
+
+        val thrown =
+            assertFailsWith<RuntimeException> {
+                recording.connection.withAutoCommit(false) {
+                    throw primaryFailure
+                }
+            }
+
+        thrown shouldBeEqualTo primaryFailure
+        thrown.suppressed.toList() shouldContain restoreFailure
+    }
+
+    @Test
+    fun `withReadOnly suppresses restore failure on primary failure`() {
+        val restoreFailure = SQLException("restore readOnly")
+        val primaryFailure = RuntimeException("primary")
+        val recording = RecordingConnection(failRestoringReadOnly = restoreFailure)
+
+        val thrown =
+            assertFailsWith<RuntimeException> {
+                recording.connection.withReadOnly {
+                    throw primaryFailure
+                }
+            }
+
+        thrown shouldBeEqualTo primaryFailure
+        thrown.suppressed.toList() shouldContain restoreFailure
+    }
+
+    @Test
+    fun `withHoldability suppresses restore failure on primary failure`() {
+        val restoreFailure = SQLException("restore holdability")
+        val primaryFailure = RuntimeException("primary")
+        val recording = RecordingConnection(failRestoringHoldability = restoreFailure)
+
+        val thrown =
+            assertFailsWith<RuntimeException> {
+                recording.connection.withHoldability(ResultSet.CLOSE_CURSORS_AT_COMMIT) {
+                    throw primaryFailure
+                }
+            }
+
+        thrown shouldBeEqualTo primaryFailure
+        thrown.suppressed.toList() shouldContain restoreFailure
+    }
+
+    @Test
     fun `복합 트랜잭션 작업`() {
         val actorId =
             dataSource.withTransaction { conn ->
@@ -267,21 +336,26 @@ private class RecordingConnection(
     autoCommit: Boolean = true,
     isolation: Int = Connection.TRANSACTION_READ_COMMITTED,
     readOnly: Boolean = false,
+    holdability: Int = ResultSet.HOLD_CURSORS_OVER_COMMIT,
     private val failRestoringAutoCommit: SQLException? = null,
     private val failRestoringIsolation: SQLException? = null,
     private val failRestoringReadOnly: SQLException? = null,
+    private val failRestoringHoldability: SQLException? = null,
     private val rollbackFailure: SQLException? = null,
 ): InvocationHandler {
 
     private val originalAutoCommit = autoCommit
     private val originalIsolation = isolation
     private val originalReadOnly = readOnly
+    private val originalHoldability = holdability
 
     var autoCommit: Boolean = autoCommit
         private set
     var isolation: Int = isolation
         private set
     var readOnly: Boolean = readOnly
+        private set
+    var holdability: Int = holdability
         private set
 
     val calls = mutableListOf<String>()
@@ -323,6 +397,15 @@ private class RecordingConnection(
                 calls.add("setReadOnly($value)")
                 if (isRestore) failRestoringReadOnly?.let { throw it }
                 readOnly = value
+                null
+            }
+            "getHoldability" -> holdability
+            "setHoldability" -> {
+                val value = arguments[0] as Int
+                val isRestore = calls.any { it.startsWith("setHoldability") } && value == originalHoldability
+                calls.add("setHoldability($value)")
+                if (isRestore) failRestoringHoldability?.let { throw it }
+                holdability = value
                 null
             }
             "commit" -> {

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/query/QueryBuilder.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/query/QueryBuilder.kt
@@ -4,6 +4,8 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.r2dbc.support.toParameter
 import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
+import io.bluetape4k.support.requireZeroOrPositiveNumber
 import io.bluetape4k.utils.Systemx
 import io.r2dbc.spi.Parameters
 import kotlin.reflect.KProperty
@@ -155,7 +157,7 @@ class QueryBuilder {
      */
     fun limit(limit: Int) =
         apply {
-            this.limit = limit
+            this.limit = limit.requirePositiveNumber("limit")
         }
 
     /**
@@ -163,7 +165,7 @@ class QueryBuilder {
      */
     fun offset(offset: Int) =
         apply {
-            this.offset = offset
+            this.offset = offset.requireZeroOrPositiveNumber("offset")
         }
 
     /**

--- a/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/query/QueryBuilderTest.kt
+++ b/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/query/QueryBuilderTest.kt
@@ -193,6 +193,26 @@ class QueryBuilderTest {
     }
 
     @Test
+    fun `limit 은 양수여야 한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            query {
+                select("select * from actor")
+                limit(0)
+            }
+        }
+    }
+
+    @Test
+    fun `offset 은 0 이상이어야 한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            query {
+                select("select * from actor")
+                offset(-1)
+            }
+        }
+    }
+
+    @Test
     fun `select with group by and having`() {
         val query = query {
             select("select actor_id, count(*) as cnt from actor")

--- a/docs/lessons/2026-07-04-api-contract-failures.md
+++ b/docs/lessons/2026-07-04-api-contract-failures.md
@@ -1,0 +1,29 @@
+# API contract failures should preserve caller context
+
+## Context
+
+Issues #951 and #954 found helper APIs where public contracts drifted from
+caller expectations:
+
+- Ktor Swagger UI collapsed nested specification paths to a basename.
+- RestClient coroutine helpers used `!!`, turning empty bodies into raw
+  `NullPointerException` failures.
+
+## Decision
+
+- Preserve caller-provided relative Swagger specification paths for both the
+  file source and Swagger UI remote path.
+- Replace RestClient coroutine `!!` assertions with an explicit non-null body
+  contract error that includes HTTP method, URI, and target type.
+
+## Verification
+
+- `./gradlew :bluetape4k-ktor-openapi:test --tests 'io.bluetape4k.ktor.openapi.KtorOpenApiRoutesTest'`
+- `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.http.RestClientCoroutinesDslTest'`
+- `git diff --check`
+
+## Future guidance
+
+Route helper defaults must keep documented path contracts source-verified.
+Coroutine wrappers around blocking clients should expose explicit caller-facing
+contract errors instead of relying on Kotlin null assertions.

--- a/docs/lessons/2026-07-04-data-validation-fail-fast.md
+++ b/docs/lessons/2026-07-04-data-validation-fail-fast.md
@@ -1,0 +1,31 @@
+# Data validation fail-fast for public numeric parameters
+
+## Context
+
+Issues #947 and #955 found public data APIs that accepted invalid numeric
+parameters and let downstream JDBC modulo operations or SQL/CQL builders expose
+late, low-signal failures.
+
+## Decision
+
+Validate numeric inputs at the public entrypoint with bluetape4k `require*`
+helpers:
+
+- JDBC batch size must be positive before any batch loop or modulo operation.
+- R2DBC query limit must be positive.
+- R2DBC query offset must be zero or positive.
+- Cassandra keyspace replication factor must be positive.
+
+## Verification
+
+- `./gradlew :bluetape4k-jdbc:test --tests 'io.bluetape4k.jdbc.sql.DataSourceTransactionExtensionsTest'`
+- `./gradlew :bluetape4k-r2dbc:test --tests 'io.bluetape4k.r2dbc.query.QueryBuilderTest'`
+- `./gradlew :bluetape4k-cassandra:test --tests 'io.bluetape4k.cassandra.CassandraAdminTest'`
+- `git diff --check`
+
+## Future guidance
+
+For public data API parameters that shape generated SQL/CQL or loop arithmetic,
+validate before delegating to driver builders or iteration logic. Prefer
+`requirePositiveNumber` and `requireZeroOrPositiveNumber` over raw `require`
+when the parameter is numeric.

--- a/docs/lessons/2026-07-04-hibernate-lettuce-classpath-guards.md
+++ b/docs/lessons/2026-07-04-hibernate-lettuce-classpath-guards.md
@@ -1,0 +1,31 @@
+# Hibernate Lettuce Classpath Guards
+
+## Context
+
+Issue #945 found that the Hibernate Lettuce Spring Boot auto-configurations used
+direct class references for optional compile-only Hibernate, Actuator, and
+Micrometer integrations.
+
+## Decision
+
+Keep optional integration metadata string-based:
+
+- use `@ConditionalOnClass(name = [...])` for optional classpath probes
+- use `@ConditionalOnBean(type = [...])` for optional bean types
+- use `@AutoConfiguration(afterName = [...])` for optional ordering targets
+
+## Outcome
+
+`FilteredClassLoader` slice tests now prove the configuration backs off cleanly
+when Hibernate customizer, Actuator endpoint annotations, or Micrometer registry
+types are unavailable.
+
+## Verification
+
+- `./gradlew :bluetape4k-spring-boot-hibernate-lettuce:test --tests 'io.bluetape4k.spring.boot.autoconfigure.cache.lettuce.LettuceNearCacheAutoConfigurationTest'`
+
+## Future Guidance
+
+When an auto-configuration imports a `compileOnly` integration, avoid class
+literals in annotation metadata and add a missing-class `ApplicationContextRunner`
+test before marking the integration classpath-safe.

--- a/docs/lessons/2026-07-04-jdbc-state-restore-failures.md
+++ b/docs/lessons/2026-07-04-jdbc-state-restore-failures.md
@@ -1,0 +1,23 @@
+# JDBC state restore failures must not replace primary failures
+
+## Context
+
+Issue #946 found JDBC helper functions that restored connection state in
+`finally` without preserving a primary block failure when restore also failed.
+
+## Decision
+
+Record the primary failure from the caller block or state-change path, then add
+restore failures as suppressed exceptions. If the caller block succeeds and only
+restore fails, surface the restore failure.
+
+## Verification
+
+- `./gradlew :bluetape4k-jdbc:test --tests 'io.bluetape4k.jdbc.sql.TransactionExtensionsTest'`
+- `git diff --check`
+
+## Future guidance
+
+Any lifecycle helper that temporarily mutates JDBC connection state should use
+the same primary-failure preservation pattern as transaction rollback/restore
+logic.

--- a/docs/lessons/2026-07-04-jdk25-joinuntil-interrupt-semantics.md
+++ b/docs/lessons/2026-07-04-jdk25-joinuntil-interrupt-semantics.md
@@ -1,0 +1,27 @@
+# JDK25 JoinUntil Interrupt Semantics
+
+## Context
+
+Issue #953 found that the JDK25 structured-scope `joinUntil` fallback converted
+every `InterruptedException` into `TimeoutException` and cleared the caller's
+interrupt status.
+
+## Decision
+
+Track only the scheduled timeout interrupt as timeout evidence. Preserve
+pre-existing and external interrupts by rethrowing `InterruptedException` and
+restoring the caller thread interrupt flag.
+
+## Outcome
+
+Timeout joins still throw `TimeoutException`, while cancellation or interrupt
+signals from outside the timeout scheduler remain diagnosable.
+
+## Verification
+
+- `./gradlew :bluetape4k-virtualthread-jdk25:test --tests 'io.bluetape4k.concurrent.virtualthread.jdk25.Jdk25StructuredTaskScopeProviderTest' --tests 'io.bluetape4k.concurrent.virtualthread.jdk25.Jdk25StructuredTaskScopeProviderExtTest'`
+
+## Future Guidance
+
+Do not clear interrupt status in structured-concurrency helpers unless the code
+can prove it created the interrupt signal being consumed.

--- a/docs/lessons/2026-07-04-kafka3-close-evidence.md
+++ b/docs/lessons/2026-07-04-kafka3-close-evidence.md
@@ -1,0 +1,26 @@
+# Kafka receiver close evidence should stay visible
+
+## Context
+
+Issue #950 found that Kafka3 suspend consumer shutdown did not expose receiver
+close failures or non-`AutoCloseable` receiver evidence, while Kafka4 already
+logged both paths.
+
+## Decision
+
+Port the Kafka4 close pattern to Kafka3:
+
+- Warn when `KafkaReceiver` does not implement `AutoCloseable`.
+- Wrap receiver close with `runCatching` and log failures instead of throwing
+  them from `close()`/`destroy()`.
+
+## Verification
+
+- `./gradlew :bluetape4k-kafka:test --tests 'io.bluetape4k.kafka.spring.core.SuspendKafkaConsumerTemplateTest'`
+- `git diff --check`
+
+## Future guidance
+
+Kafka3 and Kafka4 suspend templates should keep lifecycle diagnostics in parity.
+Resource close paths should preserve shutdown progress while logging close
+failure evidence with the receiver class.

--- a/docs/lessons/2026-07-04-lettuce-lock-duration-token.md
+++ b/docs/lessons/2026-07-04-lettuce-lock-duration-token.md
@@ -1,0 +1,27 @@
+# Lettuce Lock Duration And Token Preservation
+
+## Context
+
+Issue #949 found that Lettuce lock APIs converted invalid durations to Redis PX
+values and cleared the local owner token before Redis release success was known.
+
+## Decision
+
+Validate lock durations at the API boundary and clear the local token only after
+the Redis Lua release script confirms success.
+
+## Outcome
+
+Invalid lease/wait durations fail before Redis commands are issued. If a release
+fails because the Redis key expired or no longer matches, the local token remains
+available so callers can retry when release evidence becomes available.
+
+## Verification
+
+- `./gradlew :bluetape4k-lettuce:test --tests 'io.bluetape4k.redis.lettuce.lock.LettuceLockTest' --tests 'io.bluetape4k.redis.lettuce.lock.LettuceSuspendLockTest'`
+
+## Future Guidance
+
+Distributed lock implementations must validate Redis TTL inputs before command
+construction and must not discard local ownership evidence until remote release
+success is confirmed.

--- a/docs/lessons/2026-07-04-resilient-suspend-cache-cancellation.md
+++ b/docs/lessons/2026-07-04-resilient-suspend-cache-cancellation.md
@@ -1,0 +1,28 @@
+# Resilient Suspend Cache Cancellation
+
+## Context
+
+Issue #942 found `runCatching` around suspend back-cache reads in
+`ResilientSuspendNearJCache`. That converted coroutine cancellation into
+configured fallback behavior.
+
+## Decision
+
+Replace suspend `runCatching` fallback paths with explicit `try/catch` blocks
+that rethrow `CancellationException` before applying non-cancellation fallback
+behavior.
+
+## Outcome
+
+`get`, `getAll`, `replace`, and `containsKey` now preserve structured
+concurrency cancellation while still returning null/false for ordinary back
+cache failures where the existing contract expects graceful degradation.
+
+## Verification
+
+- `./gradlew :bluetape4k-cache-core:test --tests 'io.bluetape4k.cache.nearcache.jcache.ResilientSuspendNearJCacheTest'`
+
+## Future Guidance
+
+Do not use `runCatching` around suspend cache calls unless cancellation is
+handled and rethrown before fallback behavior is applied.

--- a/docs/lessons/2026-07-04-retrofit-cancellation-cleanup.md
+++ b/docs/lessons/2026-07-04-retrofit-cancellation-cleanup.md
@@ -1,0 +1,24 @@
+# Retrofit cancellation races must close delivered response bodies
+
+## Context
+
+Issue #948 found a Retrofit coroutine bridge race where a response could arrive
+after coroutine cancellation without explicit response-body cleanup evidence.
+
+## Decision
+
+When cancellation wins before `onResponse`, close the Retrofit response body
+before cancelling the continuation. Also close the delivered response from the
+`resume` cancellation handler if cancellation wins after resume but before
+dispatch.
+
+## Verification
+
+- `./gradlew :bluetape4k-retrofit2:test --tests 'io.bluetape4k.retrofit2.SuspendRetrofitCallSupportTest'`
+- `git diff --check`
+
+## Future guidance
+
+Coroutine HTTP bridges should close response resources on every cancellation
+race path. Prefer `resume(value) { ... }` cleanup handlers plus an explicit
+`!cont.isActive` check before delivery.

--- a/docs/lessons/2026-07-04-vertx-transaction-cancellation-cleanup.md
+++ b/docs/lessons/2026-07-04-vertx-transaction-cancellation-cleanup.md
@@ -1,0 +1,30 @@
+# Vert.x Transaction Cancellation Cleanup
+
+## Context
+
+Issue #940 found that Vert.x SQL transaction helpers performed rollback and
+connection close in the caller coroutine context, so caller cancellation could
+abort transaction cleanup.
+
+## Decision
+
+Run rollback and close operations inside `NonCancellable` cleanup boundaries.
+Preserve the primary cancellation or failure and attach rollback or close
+failures as suppressed exceptions.
+
+## Outcome
+
+`withSuspendTransaction` and `withSuspendRollback` now complete cleanup even
+when the action cancels its coroutine context, while still rethrowing the
+original `CancellationException`.
+
+## Verification
+
+- `./gradlew :bluetape4k-vertx:test --tests 'io.bluetape4k.vertx.sqlclient.PoolSupportTest'`
+
+## Future Guidance
+
+Coroutine-based database lifecycle cleanup should not use `runCatching` around
+suspending rollback or close calls. Use explicit `try/catch` in a
+`NonCancellable` boundary and preserve secondary cleanup failures as suppressed
+evidence.

--- a/docs/lessons/2026-07-04-virtual-thread-controller-lifecycle.md
+++ b/docs/lessons/2026-07-04-virtual-thread-controller-lifecycle.md
@@ -1,0 +1,27 @@
+# Virtual Thread Controller Lifecycle
+
+## Context
+
+Issue #952 found that `AbstractVirtualThreadController` exposed a shared
+virtual-thread executor without a Spring bean destruction path.
+
+## Decision
+
+Keep the public `virtualThreadExecutor` accessor for compatibility, but make the
+controller close the current executor through `@PreDestroy`. The accessor
+recreates the executor when a later Spring context accesses it after shutdown.
+
+## Outcome
+
+Controller bean shutdown now closes the executor while repeated test or
+application context creation does not reuse a closed executor.
+
+## Verification
+
+- `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.virtualthread.AbstractVirtualThreadControllerTest'`
+
+## Future Guidance
+
+Public controller base classes that expose executor or coroutine resources must
+own a Spring destruction callback and tests should cover both direct destroy and
+context shutdown paths.

--- a/examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/cachestrategy/CacheReadThroughExample.kt
+++ b/examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/cachestrategy/CacheReadThroughExample.kt
@@ -35,6 +35,11 @@ class CacheReadThroughExample: AbstractCacheExample() {
 
     companion object: KLogging() {
         const val ACTOR_SIZE = 500
+        private const val REDIS_COMMAND_RETRY_ATTEMPTS = 6
+        private val REDIS_COMMAND_TIMEOUT: Duration = Duration.ofSeconds(30)
+
+        private fun redisCommandRetryDelay(attempt: Int): Duration =
+            Duration.ofMillis((attempt + 1) * 100L)
     }
 
     @BeforeEach
@@ -63,12 +68,12 @@ class CacheReadThroughExample: AbstractCacheExample() {
             val name = randomName()
             val options = MapCacheOptions.name<Long, ActorRecord>(name)
                 .loader(actorRecordLoader)
-                .retryAttempts(3)
+                .retryAttempts(REDIS_COMMAND_RETRY_ATTEMPTS)
                 .retryDelay { attempt ->
                     log.trace { "Retry attempt=$attempt" }
-                    Duration.ofMillis(attempt * 10L + 10L)
+                    redisCommandRetryDelay(attempt)
                 }
-                .timeout(Duration.ofSeconds(10))
+                .timeout(REDIS_COMMAND_TIMEOUT)
                 .codec(defaultCodec)
 
             val cache: RMapCache<Long, ActorRecord?> = redisson.getMapCache(options)
@@ -85,13 +90,13 @@ class CacheReadThroughExample: AbstractCacheExample() {
             val name = randomName()
             val options = LocalCachedMapOptions.name<Long, ActorRecord>(name)
                 .loader(actorRecordLoader)
-                .retryAttempts(3)
+                .retryAttempts(REDIS_COMMAND_RETRY_ATTEMPTS)
                 .retryDelay { attempt ->
                     log.trace { "Retry attempt=$attempt" }
-                    Duration.ofMillis(attempt * 10L + 10L)
+                    redisCommandRetryDelay(attempt)
                 }
                 .timeToLive(Duration.ofSeconds(10))   // 로컬 캐시의 TTL
-                .timeout(Duration.ofSeconds(10))
+                .timeout(REDIS_COMMAND_TIMEOUT)
                 .codec(defaultCodec)
 
             val cache: RLocalCachedMap<Long, ActorRecord?> = redisson.getLocalCachedMap(options)
@@ -154,12 +159,12 @@ class CacheReadThroughExample: AbstractCacheExample() {
             val name = randomName()
             val options = MapCacheOptions.name<Long, ActorRecord>(name)
                 .loaderAsync(actorRecordLoaderAsync)
-                .retryAttempts(3)
+                .retryAttempts(REDIS_COMMAND_RETRY_ATTEMPTS)
                 .retryDelay { attempt ->
                     log.trace { "Retry attempt=$attempt" }
-                    Duration.ofMillis(attempt * 10L + 10L)
+                    redisCommandRetryDelay(attempt)
                 }
-                .timeout(Duration.ofSeconds(10))
+                .timeout(REDIS_COMMAND_TIMEOUT)
                 .codec(defaultCodec)
 
             val cache: RMapCache<Long, ActorRecord?> = redisson.getMapCache(options)
@@ -175,13 +180,13 @@ class CacheReadThroughExample: AbstractCacheExample() {
             val name = randomName()
             val options = LocalCachedMapOptions.name<Long, ActorRecord>(name)
                 .loaderAsync(actorRecordLoaderAsync)
-                .retryAttempts(3)
+                .retryAttempts(REDIS_COMMAND_RETRY_ATTEMPTS)
                 .retryDelay { attempt ->
                     log.trace { "Retry attempt=$attempt" }
-                    Duration.ofMillis(attempt * 10L + 10L)
+                    redisCommandRetryDelay(attempt)
                 }
                 .timeToLive(Duration.ofSeconds(10))   // 로컬 캐시의 TTL
-                .timeout(Duration.ofSeconds(10))
+                .timeout(REDIS_COMMAND_TIMEOUT)
                 .codec(defaultCodec)
 
             val cache: RLocalCachedMap<Long, ActorRecord?> = redisson.getLocalCachedMap(options)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -110,7 +110,7 @@ elasticsearch = "9.4.0"  # https://mvnrepository.com/artifact/org.elasticsearch.
 elasticsearch-java = "9.4.0"  # https://mvnrepository.com/artifact/co.elastic.clients/elasticsearch-java
 
 kafka3 = "3.9.2"  # https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients; Server-side: spring-kafka 3.x embedded test (EmbeddedKafkaKraftBroker)
-kafka4 = "4.3.1"  # https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients; Spring Kafka 4.1 embedded-test ABI
+kafka4 = "4.2.1"  # https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients; Spring Kafka 4.1 embedded-test ABI
 spring-kafka = "3.3.16"  # https://mvnrepository.com/artifact/org.springframework.kafka/spring-kafka
 spring-kafka4 = "4.1.0"  # https://mvnrepository.com/artifact/org.springframework.kafka/spring-kafka
 

--- a/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/ratelimit/local/LocalSuspendRateLimiterTest.kt
+++ b/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/ratelimit/local/LocalSuspendRateLimiterTest.kt
@@ -4,16 +4,16 @@ import io.bluetape4k.bucket4j.local.LocalSuspendBucketProvider
 import io.bluetape4k.bucket4j.ratelimit.AbstractSuspendRateLimiterTest
 import io.bluetape4k.bucket4j.ratelimit.RateLimitStatus
 import io.bluetape4k.bucket4j.ratelimit.SuspendRateLimiter
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.KLogging
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.runBlocking
-import io.bluetape4k.assertions.shouldBeEqualTo
-import org.junit.jupiter.api.Assertions.assertTimeoutPreemptively
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
-import java.time.Duration
-import io.bluetape4k.assertions.assertFailsWith
+import kotlin.time.Duration.Companion.seconds
 
 class LocalSuspendRateLimiterTest: AbstractSuspendRateLimiterTest() {
 
@@ -24,24 +24,20 @@ class LocalSuspendRateLimiterTest: AbstractSuspendRateLimiterTest() {
     override val rateLimiter: SuspendRateLimiter<String> = LocalSuspendRateLimiter(bucketProvider)
 
     @Test
-    fun `토큰 부족 시 즉시 거절해야 한다`() {
+    fun `토큰 부족 시 즉시 거절해야 한다`() = runSuspendIO {
         val key = randomKey()
 
-        runBlocking {
-            rateLimiter.consume(key, INITIAL_CAPACITY)
-        }
+        rateLimiter.consume(key, INITIAL_CAPACITY)
 
-        assertTimeoutPreemptively(Duration.ofSeconds(1)) {
-            runBlocking {
-                val result = rateLimiter.consume(key, 1)
-                result.status shouldBeEqualTo RateLimitStatus.REJECTED
-                result.consumedTokens shouldBeEqualTo 0L
-            }
+        withTimeout(1.seconds) {
+            val result = rateLimiter.consume(key, 1)
+            result.status shouldBeEqualTo RateLimitStatus.REJECTED
+            result.consumedTokens shouldBeEqualTo 0L
         }
     }
 
     @Test
-    fun `취소 예외는 전파해야 한다`() = runBlocking {
+    fun `취소 예외는 전파해야 한다`() = runSuspendIO {
         val brokenProvider = mockk<LocalSuspendBucketProvider>()
         every { brokenProvider.resolveBucket(any()) } throws CancellationException("simulated cancellation")
 

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplate.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplate.kt
@@ -1,6 +1,8 @@
 package io.bluetape4k.kafka.spring.core
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.error
+import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requireNotEmpty
 import kotlinx.coroutines.CoroutineScope
@@ -495,7 +497,14 @@ class SuspendKafkaConsumerTemplate<K, V> private constructor(
     private fun doClose() {
         if (closed.compareAndSet(false, true)) {
             scope.cancel("SuspendKafkaConsumerTemplate closed")
-            (receiver as? AutoCloseable)?.close()
+            val closeable = receiver as? AutoCloseable
+            if (closeable == null) {
+                // reactor-kafka 의 KafkaReceiver 가 AutoCloseable 을 구현하지 않은 경우 — 자원 누수 가능성을 명시적으로 노출한다.
+                log.warn { "KafkaReceiver does not implement AutoCloseable; underlying Kafka consumer connection may leak. receiverClass=${receiver.javaClass.name}" }
+            } else {
+                runCatching { closeable.close() }
+                    .onFailure { e -> log.error(e) { "Failed to close KafkaReceiver. receiverClass=${receiver.javaClass.name}" } }
+            }
         }
     }
 }

--- a/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplateTest.kt
+++ b/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplateTest.kt
@@ -1,5 +1,10 @@
 package io.bluetape4k.kafka.spring.core
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.kafka.AbstractKafkaTest
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.testcontainers.mq.KafkaServer
@@ -15,10 +20,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeTrue
-import io.bluetape4k.assertions.shouldContain
-import io.bluetape4k.assertions.shouldNotBeNull
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp
@@ -32,7 +33,6 @@ import reactor.kafka.receiver.ReceiverOptions
 import java.util.*
 import java.util.function.Function
 import java.util.regex.Pattern
-import io.bluetape4k.assertions.assertFailsWith
 
 /**
  * [SuspendKafkaConsumerTemplate]에 대한 테스트 클래스입니다.
@@ -186,9 +186,8 @@ class SuspendKafkaConsumerTemplateTest: AbstractKafkaTest() {
         stubDoOnConsumer(closableReceiver, consumer)
         val template = SuspendKafkaConsumerTemplate(closableReceiver)
         val blocker = CompletableDeferred<Unit>()
-        lateinit var launchedJob: Job
 
-        launchedJob = template.launch {
+        val launchedJob: Job = template.launch {
             blocker.await()
         }
 
@@ -197,6 +196,32 @@ class SuspendKafkaConsumerTemplateTest: AbstractKafkaTest() {
 
         (template.coroutineContext[Job]?.isCancelled ?: false).shouldBeTrue()
         verify(exactly = 1) { (closableReceiver as AutoCloseable).close() }
+    }
+
+    @Test
+    fun `템플릿 종료 시 receiver close 실패를 전파하지 않는다`() = runTest {
+        val closeFailure = IllegalStateException("receiver close failed")
+        every { (closableReceiver as AutoCloseable).close() } throws closeFailure
+        val template = SuspendKafkaConsumerTemplate(closableReceiver)
+
+        template.close()
+
+        (template.coroutineContext[Job]?.isCancelled ?: false).shouldBeTrue()
+        verify(exactly = 1) { (closableReceiver as AutoCloseable).close() }
+    }
+
+    @Test
+    fun `템플릿 종료 시 AutoCloseable 이 아닌 receiver 도 scope 를 취소한다`() = runTest {
+        val template = SuspendKafkaConsumerTemplate(receiver)
+        val blocker = CompletableDeferred<Unit>()
+        val launchedJob: Job = template.launch {
+            blocker.await()
+        }
+
+        template.close()
+        launchedJob.cancelAndJoin()
+
+        (template.coroutineContext[Job]?.isCancelled ?: false).shouldBeTrue()
     }
 
     private fun stubDoOnConsumer(

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversion2Tests.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversion2Tests.kt
@@ -32,7 +32,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 @SpringBootTest
-@EmbeddedKafka(topics = ["blc.2.1"], partitions = 1)
+@EmbeddedKafka(topics = ["blc.2.1"], partitions = 1, adminTimeout = 120)
 class BatchListenerConversion2Tests {
 
     companion object: KLoggingChannel() {

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
@@ -56,7 +56,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 @SpringBootTest
-@EmbeddedKafka(partitions = 1, topics = ["blc1", "blc2", "blc3", "blc4", "blc5", "blc6", "blc6-dlt"])
+@EmbeddedKafka(partitions = 1, topics = ["blc1", "blc2", "blc3", "blc4", "blc5", "blc6", "blc6-dlt"], adminTimeout = 120)
 @TestMethodOrder(MethodOrderer.MethodName::class)
 class BatchListenerConversionTests {
 

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/core/KafkaTemplateTests.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/core/KafkaTemplateTests.kt
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
-@EmbeddedKafka(topics = [INT_KEY_TOPIC, STRING_KEY_TOPIC])
+@EmbeddedKafka(topics = [INT_KEY_TOPIC, STRING_KEY_TOPIC], adminTimeout = 120)
 class KafkaTemplateTests {
 
     companion object: KLoggingChannel() {

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/streams/KafkaStreamsBranchTests.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/streams/KafkaStreamsBranchTests.kt
@@ -40,7 +40,8 @@ import org.springframework.kafka.test.utils.KafkaTestUtils
 @SpringBootTest
 @EmbeddedKafka(
     partitions = 1,
-    topics = [TRUE_TOPIC, FALSE_TOPIC, TRUE_FALSE_INPUT_TOPIC]
+    topics = [TRUE_TOPIC, FALSE_TOPIC, TRUE_FALSE_INPUT_TOPIC],
+    adminTimeout = 120
 )
 class KafkaStreamsBranchTests {
 

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/streams/KafkaStreamsTests.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/streams/KafkaStreamsTests.kt
@@ -72,7 +72,8 @@ import java.util.concurrent.atomic.AtomicBoolean
         $$"auto.create.topics.enable=${topics.authCreate:false}",
         $$"delete.topic.enable=${topic.delete:true}"
     ],
-    brokerPropertiesLocation = $$"classpath:/${broker.filename:broker}.properties"
+    brokerPropertiesLocation = $$"classpath:/${broker.filename:broker}.properties",
+    adminTimeout = 120
 )
 class KafkaStreamsTests {
 

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/streams/WordCountExamples.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/streams/WordCountExamples.kt
@@ -56,7 +56,8 @@ import java.util.*
         $$"auto.create.topics.enable=${topics.autoCreate:false}",
         $$"delete.topic.enable=${topic.delete:true}"
     ],
-    brokerPropertiesLocation = $$"classpath:/${broker.filename:broker}.properties"
+    brokerPropertiesLocation = $$"classpath:/${broker.filename:broker}.properties",
+    adminTimeout = 120
 )
 class WordCountExamples {
 

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceLock.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceLock.kt
@@ -98,6 +98,9 @@ class LettuceLock(
         waitTime: Duration = Duration.ZERO,
         leaseTime: Duration = defaultLeaseTime,
     ): Boolean {
+        waitTime.requireZeroOrPositiveDuration("waitTime")
+        leaseTime.requirePositiveMillisDuration("leaseTime")
+
         val token = UUID.randomUUID().toString()
         val leaseMs = leaseTime.toMillis()
         val deadline = System.currentTimeMillis() + waitTime.toMillis()
@@ -134,6 +137,9 @@ class LettuceLock(
      * @throws IllegalStateException maxWaitTime 초과 시
      */
     fun lock(leaseTime: Duration = defaultLeaseTime, maxWaitTime: Duration = Duration.ofMinutes(5)) {
+        leaseTime.requirePositiveMillisDuration("leaseTime")
+        maxWaitTime.requirePositiveMillisDuration("maxWaitTime")
+
         val token = UUID.randomUUID().toString()
         val leaseMs = leaseTime.toMillis()
         val args = SetArgs().nx().px(leaseMs)
@@ -166,7 +172,7 @@ class LettuceLock(
      * @throws IllegalStateException 락을 보유하지 않은 경우
      */
     fun unlock() {
-        val token = tokenRef.getAndSet(null)
+        val token = tokenRef.value
             ?: throw IllegalStateException("현재 인스턴스가 락을 보유하지 않습니다: lockKey=$lockKey")
 
         val released = RedisScriptRunner.run<Long>(
@@ -175,6 +181,7 @@ class LettuceLock(
         if (released == 0L) {
             throw IllegalStateException("Lock 해제 실패 (토큰 불일치 또는 만료): lockKey=$lockKey")
         }
+        tokenRef.compareAndSet(token, null)
         log.debug { "Lock 해제 성공: lockKey=$lockKey" }
     }
 
@@ -201,6 +208,9 @@ class LettuceLock(
         waitTime: Duration = Duration.ZERO,
         leaseTime: Duration = defaultLeaseTime,
     ): CompletableFuture<Boolean> {
+        waitTime.requireZeroOrPositiveDuration("waitTime")
+        leaseTime.requirePositiveMillisDuration("leaseTime")
+
         val token = UUID.randomUUID().toString()
         val leaseMs = leaseTime.toMillis()
         val deadline = System.currentTimeMillis() + waitTime.toMillis()
@@ -245,6 +255,9 @@ class LettuceLock(
         leaseTime: Duration = defaultLeaseTime,
         maxWaitTime: Duration = Duration.ofMinutes(5),
     ): CompletableFuture<Unit> {
+        leaseTime.requirePositiveMillisDuration("leaseTime")
+        maxWaitTime.requirePositiveMillisDuration("maxWaitTime")
+
         val token = UUID.randomUUID().toString()
         val leaseMs = leaseTime.toMillis()
         val deadline = System.currentTimeMillis() + maxWaitTime.toMillis()
@@ -283,7 +296,7 @@ class LettuceLock(
      * @return 완료를 나타내는 CompletableFuture
      */
     fun unlockAsync(): CompletableFuture<Unit> {
-        val token = tokenRef.getAndSet(null)
+        val token = tokenRef.value
             ?: return CompletableFuture.failedFuture(
                 IllegalStateException("현재 인스턴스가 락을 보유하지 않습니다: lockKey=$lockKey")
             )
@@ -294,6 +307,7 @@ class LettuceLock(
             if (released == 0L) {
                 throw IllegalStateException("Lock 해제 실패 (토큰 불일치 또는 만료, async): lockKey=$lockKey")
             }
+            tokenRef.compareAndSet(token, null)
             log.debug { "Lock 해제 성공 (async): lockKey=$lockKey" }
         }
     }

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceLockValidation.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceLockValidation.kt
@@ -1,0 +1,15 @@
+package io.bluetape4k.redis.lettuce.lock
+
+import java.time.Duration
+
+internal fun Duration.requirePositiveMillisDuration(parameterName: String): Duration = apply {
+    require(!isNegative && !isZero && toMillis() > 0L) {
+        "$parameterName must be at least 1ms. $parameterName=$this"
+    }
+}
+
+internal fun Duration.requireZeroOrPositiveDuration(parameterName: String): Duration = apply {
+    require(!isNegative) {
+        "$parameterName must be zero or positive. $parameterName=$this"
+    }
+}

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSuspendLock.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSuspendLock.kt
@@ -88,6 +88,9 @@ class LettuceSuspendLock(
         waitTime: Duration = Duration.ZERO,
         leaseTime: Duration = defaultLeaseTime,
     ): Boolean {
+        waitTime.requireZeroOrPositiveDuration("waitTime")
+        leaseTime.requirePositiveMillisDuration("leaseTime")
+
         val token = UUID.randomUUID().toString()
         val leaseMs = leaseTime.toMillis()
         val deadline = System.currentTimeMillis() + waitTime.toMillis()
@@ -126,6 +129,9 @@ class LettuceSuspendLock(
         leaseTime: Duration = defaultLeaseTime,
         maxWaitTime: Duration = Duration.ofMinutes(DEFAULT_MAX_WAIT_MINUTES),
     ) {
+        leaseTime.requirePositiveMillisDuration("leaseTime")
+        maxWaitTime.requirePositiveMillisDuration("maxWaitTime")
+
         val token = UUID.randomUUID().toString()
         val leaseMs = leaseTime.toMillis()
         val deadline = System.currentTimeMillis() + maxWaitTime.toMillis()
@@ -163,7 +169,7 @@ class LettuceSuspendLock(
      */
     suspend fun unlock() {
         val token =
-            tokenRef.getAndSet(null)
+            tokenRef.value
                 ?: throw IllegalStateException("현재 인스턴스가 락을 보유하지 않습니다: lockKey=$lockKey")
 
         // 개선: EVALSHA 우선 실행, NOSCRIPT 발생 시 원문 전송으로 자동 fallback.
@@ -174,6 +180,7 @@ class LettuceSuspendLock(
         if (released == 0L) {
             throw IllegalStateException("Lock 해제 실패 (토큰 불일치 또는 만료, suspend): lockKey=$lockKey")
         }
+        tokenRef.compareAndSet(token, null)
         log.debug { "Lock 해제 성공 (suspend): lockKey=$lockKey" }
     }
 }

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/semaphore/LettuceSemaphore.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/semaphore/LettuceSemaphore.kt
@@ -2,7 +2,6 @@ package io.bluetape4k.redis.lettuce.semaphore
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
-import io.bluetape4k.redis.lettuce.script.RedisScript
 import io.bluetape4k.redis.lettuce.script.RedisScriptRunner
 import io.bluetape4k.support.requirePositiveNumber
 import io.lettuce.core.ScriptOutputType
@@ -11,6 +10,7 @@ import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.api.async.RedisAsyncCommands
 import io.lettuce.core.api.sync.RedisCommands
 import java.time.Duration
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.LockSupport
@@ -18,8 +18,8 @@ import java.util.concurrent.locks.LockSupport
 /**
  * Lettuce Redis 클라이언트를 이용한 분산 세마포어(Distributed Semaphore) 구현체입니다.
  *
- * Redis의 카운터(잔여 허가 수)를 사용하여 세마포어를 구현합니다.
- * Lua 스크립트를 통해 acquire/release를 원자적으로 처리합니다.
+ * Redis의 카운터(잔여 허가 수), owner token hash, expiry sorted set을 사용하여 세마포어를 구현합니다.
+ * Lua 스크립트를 통해 acquire/release/expired-owner cleanup을 원자적으로 처리합니다.
  *
  * 동기, 비동기(CompletableFuture) 2가지 방식을 지원합니다.
  * 코루틴(suspend) 방식은 [LettuceSuspendSemaphore]를 사용하세요.
@@ -37,52 +37,26 @@ import java.util.concurrent.locks.LockSupport
  * @param connection Lettuce StatefulRedisConnection (StringCodec 기반)
  * @param semaphoreKey Redis에 저장될 세마포어 키
  * @param totalPermits 전체 허가 수
+ * @param leaseTime 획득한 permit owner token의 lease time
  */
 class LettuceSemaphore(
     private val connection: StatefulRedisConnection<String, String>,
     val semaphoreKey: String,
     val totalPermits: Int,
+    private val leaseTime: Duration = Duration.ofSeconds(30),
 ) {
     companion object: KLogging() {
         private const val RETRY_DELAY_MS = 50L
         private const val RETRY_DELAY_NANOS = RETRY_DELAY_MS * 1_000_000L
-
-        // 개선: 상수 String → RedisScript 로 승격해 SHA1 을 1 회만 계산하고 EVALSHA 호출을 재사용합니다.
-
-        /**
-         * Lua: 원자적 acquire
-         * KEYS[1]=semaphoreKey, ARGV[1]=permits
-         * 반환: 남은 허가 수 (허가 수 부족 시 -1)
-         */
-        private val ACQUIRE_SCRIPT = RedisScript(
-            """
-local v = tonumber(redis.call('get', KEYS[1]))
-if v and v >= tonumber(ARGV[1]) then
-  return redis.call('decrby', KEYS[1], ARGV[1])
-else
-  return -1
-end"""
-        )
-
-        /**
-         * Lua: 원자적 release (최대값 초과 방지)
-         * KEYS[1]=semaphoreKey, ARGV[1]=permits, ARGV[2]=maxPermits
-         * 반환: 현재 남은 허가 수
-         */
-        private val RELEASE_SCRIPT = RedisScript(
-            """
-local v = tonumber(redis.call('incrby', KEYS[1], ARGV[1]))
-if v > tonumber(ARGV[2]) then
-  redis.call('set', KEYS[1], ARGV[2])
-  return tonumber(ARGV[2])
-end
-return v"""
-        )
     }
 
     // 개선: getter → final field 로 변경 (매 호출 connection.sync()/async() 호출 제거).
     private val syncCommands: RedisCommands<String, String> = connection.sync()
     private val asyncCommands: RedisAsyncCommands<String, String> = connection.async()
+    private val ownersKey = "$semaphoreKey:owners"
+    private val expirationsKey = "$semaphoreKey:expirations"
+    private val localPermits = LocalSemaphorePermits()
+    private val leaseMillis = leaseTime.requirePositiveMillis("leaseTime").toMillis()
 
     init {
         totalPermits.requirePositiveNumber("totalPermits")
@@ -107,6 +81,8 @@ return v"""
     fun trySetPermits(permits: Int) {
         permits.requirePositiveNumber("permits")
         syncCommands.set(semaphoreKey, permits.toString())
+        syncCommands.del(ownersKey, expirationsKey)
+        localPermits.clear()
         log.debug { "세마포어 허가 수 설정: semaphoreKey=$semaphoreKey, permits=$permits" }
     }
 
@@ -116,7 +92,10 @@ return v"""
      * @return 잔여 허가 수 (초기화 안 된 경우 0)
      */
     fun availablePermits(): Int =
-        syncCommands.get(semaphoreKey)?.toIntOrNull() ?: 0
+        RedisScriptRunner.run<Long>(
+            syncCommands, LettuceSemaphoreScripts.AVAILABLE_SCRIPT, ScriptOutputType.INTEGER,
+            semaphoreKeys(), nowMillis().toString(), totalPermits.toString()
+        ).toInt()
 
     // =========================================================================
     // 동기 API
@@ -137,12 +116,22 @@ return v"""
      */
     fun tryAcquire(permits: Int = 1): Boolean {
         permits.requirePositiveNumber("permits")
+        val token = UUID.randomUUID().toString()
+        val now = nowMillis()
 
         val result = RedisScriptRunner.run<Long>(
-            syncCommands, ACQUIRE_SCRIPT, ScriptOutputType.INTEGER,
-            arrayOf(semaphoreKey), permits.toString()
+            syncCommands, LettuceSemaphoreScripts.ACQUIRE_SCRIPT, ScriptOutputType.INTEGER,
+            semaphoreKeys(),
+            now.toString(),
+            totalPermits.toString(),
+            permits.toString(),
+            token,
+            (now + leaseMillis).toString(),
         )
         val acquired = result >= 0
+        if (acquired) {
+            localPermits.record(token, permits)
+        }
         log.debug { "Semaphore tryAcquire: key=$semaphoreKey, permits=$permits, acquired=$acquired" }
         return acquired
     }
@@ -196,11 +185,11 @@ return v"""
     fun release(permits: Int = 1) {
         permits.requirePositiveNumber("permits")
 
-        val remaining = RedisScriptRunner.run<Long>(
-            syncCommands, RELEASE_SCRIPT, ScriptOutputType.INTEGER,
-            arrayOf(semaphoreKey), permits.toString(), totalPermits.toString()
-        )
-        log.debug { "Semaphore release: key=$semaphoreKey, permits=$permits, remaining=$remaining" }
+        val releases = localPermits.select(permits)
+        releases.forEach { release ->
+            val remaining = releaseOwnedPermitsSync(release)
+            log.debug { "Semaphore release: key=$semaphoreKey, permits=${release.permits}, remaining=$remaining" }
+        }
     }
 
     // =========================================================================
@@ -215,12 +204,22 @@ return v"""
      */
     fun tryAcquireAsync(permits: Int = 1): CompletableFuture<Boolean> {
         permits.requirePositiveNumber("permits")
+        val token = UUID.randomUUID().toString()
+        val now = nowMillis()
 
         return RedisScriptRunner.runAsync<Long>(
-            asyncCommands, ACQUIRE_SCRIPT, ScriptOutputType.INTEGER,
-            arrayOf(semaphoreKey), permits.toString()
+            asyncCommands, LettuceSemaphoreScripts.ACQUIRE_SCRIPT, ScriptOutputType.INTEGER,
+            semaphoreKeys(),
+            now.toString(),
+            totalPermits.toString(),
+            permits.toString(),
+            token,
+            (now + leaseMillis).toString(),
         ).thenApply { result ->
             val acquired = result >= 0
+            if (acquired) {
+                localPermits.record(token, permits)
+            }
             log.debug { "Semaphore tryAcquireAsync: key=$semaphoreKey, permits=$permits, acquired=$acquired" }
             acquired
         }
@@ -264,11 +263,51 @@ return v"""
     fun releaseAsync(permits: Int = 1): CompletableFuture<Unit> {
         permits.requirePositiveNumber("permits")
 
-        return RedisScriptRunner.runAsync<Long>(
-            asyncCommands, RELEASE_SCRIPT, ScriptOutputType.INTEGER,
-            arrayOf(semaphoreKey), permits.toString(), totalPermits.toString()
-        ).thenApply { remaining ->
-            log.debug { "Semaphore releaseAsync: key=$semaphoreKey, permits=$permits, remaining=$remaining" }
+        val releases = localPermits.select(permits)
+        var future = CompletableFuture.completedFuture(Unit)
+        releases.forEach { release ->
+            future = future.thenCompose {
+                RedisScriptRunner.runAsync<Long>(
+                    asyncCommands, LettuceSemaphoreScripts.RELEASE_SCRIPT, ScriptOutputType.INTEGER,
+                    semaphoreKeys(),
+                    nowMillis().toString(),
+                    totalPermits.toString(),
+                    release.permits.toString(),
+                    release.token,
+                ).thenApply { remaining ->
+                    handleReleaseResult(release, remaining)
+                    log.debug { "Semaphore releaseAsync: key=$semaphoreKey, permits=${release.permits}, remaining=$remaining" }
+                }
+            }
+        }
+        return future
+    }
+
+    private fun releaseOwnedPermitsSync(release: PermitRelease): Long {
+        val remaining = RedisScriptRunner.run<Long>(
+            syncCommands, LettuceSemaphoreScripts.RELEASE_SCRIPT, ScriptOutputType.INTEGER,
+            semaphoreKeys(),
+            nowMillis().toString(),
+            totalPermits.toString(),
+            release.permits.toString(),
+            release.token,
+        )
+        handleReleaseResult(release, remaining)
+        return remaining
+    }
+
+    private fun handleReleaseResult(release: PermitRelease, remaining: Long) {
+        when {
+            remaining >= 0L -> localPermits.markReleased(release)
+            remaining == -1L -> {
+                localPermits.markLost(release)
+                error("Semaphore permits are no longer owned or already expired: semaphoreKey=$semaphoreKey")
+            }
+            else -> error("Semaphore release exceeds owned permits: semaphoreKey=$semaphoreKey")
         }
     }
+
+    private fun semaphoreKeys(): Array<String> = arrayOf(semaphoreKey, ownersKey, expirationsKey)
+
+    private fun nowMillis(): Long = System.currentTimeMillis()
 }

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/semaphore/LettuceSemaphoreSupport.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/semaphore/LettuceSemaphoreSupport.kt
@@ -1,0 +1,169 @@
+package io.bluetape4k.redis.lettuce.semaphore
+
+import io.bluetape4k.redis.lettuce.script.RedisScript
+import java.time.Duration
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+internal object LettuceSemaphoreScripts {
+
+    val AVAILABLE_SCRIPT = RedisScript(
+        """
+local function cleanup(now, total)
+  local expired = redis.call('zrangebyscore', KEYS[3], '-inf', now)
+  for _, token in ipairs(expired) do
+    local held = tonumber(redis.call('hget', KEYS[2], token) or '0')
+    if held > 0 then
+      redis.call('incrby', KEYS[1], held)
+    end
+    redis.call('hdel', KEYS[2], token)
+    redis.call('zrem', KEYS[3], token)
+  end
+  local current = tonumber(redis.call('get', KEYS[1]) or '0')
+  if current > total then
+    redis.call('set', KEYS[1], total)
+    current = total
+  end
+  return current
+end
+return cleanup(tonumber(ARGV[1]), tonumber(ARGV[2]))
+"""
+    )
+
+    val ACQUIRE_SCRIPT = RedisScript(
+        """
+local function cleanup(now, total)
+  local expired = redis.call('zrangebyscore', KEYS[3], '-inf', now)
+  for _, token in ipairs(expired) do
+    local held = tonumber(redis.call('hget', KEYS[2], token) or '0')
+    if held > 0 then
+      redis.call('incrby', KEYS[1], held)
+    end
+    redis.call('hdel', KEYS[2], token)
+    redis.call('zrem', KEYS[3], token)
+  end
+  local current = tonumber(redis.call('get', KEYS[1]) or '0')
+  if current > total then
+    redis.call('set', KEYS[1], total)
+    current = total
+  end
+  return current
+end
+local now = tonumber(ARGV[1])
+local total = tonumber(ARGV[2])
+local permits = tonumber(ARGV[3])
+local token = ARGV[4]
+local expiresAt = tonumber(ARGV[5])
+local current = cleanup(now, total)
+if current >= permits then
+  redis.call('decrby', KEYS[1], permits)
+  redis.call('hset', KEYS[2], token, permits)
+  redis.call('zadd', KEYS[3], expiresAt, token)
+  return current - permits
+end
+return -1
+"""
+    )
+
+    val RELEASE_SCRIPT = RedisScript(
+        """
+local function cleanup(now, total)
+  local expired = redis.call('zrangebyscore', KEYS[3], '-inf', now)
+  for _, token in ipairs(expired) do
+    local held = tonumber(redis.call('hget', KEYS[2], token) or '0')
+    if held > 0 then
+      redis.call('incrby', KEYS[1], held)
+    end
+    redis.call('hdel', KEYS[2], token)
+    redis.call('zrem', KEYS[3], token)
+  end
+  local current = tonumber(redis.call('get', KEYS[1]) or '0')
+  if current > total then
+    redis.call('set', KEYS[1], total)
+    current = total
+  end
+  return current
+end
+local now = tonumber(ARGV[1])
+local total = tonumber(ARGV[2])
+local permits = tonumber(ARGV[3])
+local token = ARGV[4]
+cleanup(now, total)
+local held = tonumber(redis.call('hget', KEYS[2], token) or '-1')
+if held < 0 then
+  return -1
+end
+if held < permits then
+  return -2
+end
+local current = tonumber(redis.call('incrby', KEYS[1], permits))
+if current > total then
+  redis.call('set', KEYS[1], total)
+  current = total
+end
+if held == permits then
+  redis.call('hdel', KEYS[2], token)
+  redis.call('zrem', KEYS[3], token)
+else
+  redis.call('hincrby', KEYS[2], token, -permits)
+end
+return current
+"""
+    )
+}
+
+internal class LocalSemaphorePermits {
+    private val leases = mutableListOf<Lease>()
+    private val lock = ReentrantLock()
+
+    fun record(token: String, permits: Int): Unit = lock.withLock {
+        leases += Lease(token, permits)
+    }
+
+    fun select(permits: Int): List<PermitRelease> = lock.withLock {
+        var remaining = permits
+        val selected = mutableListOf<PermitRelease>()
+        for (lease in leases) {
+            if (remaining == 0) break
+            val releasePermits = minOf(lease.permits, remaining)
+            selected += PermitRelease(lease.token, releasePermits)
+            remaining -= releasePermits
+        }
+        check(remaining == 0) { "Cannot release permits that are not owned by this semaphore instance: permits=$permits" }
+        selected
+    }
+
+    fun markReleased(release: PermitRelease): Unit = lock.withLock {
+        val lease = leases.firstOrNull { it.token == release.token } ?: return
+        if (lease.permits <= release.permits) {
+            leases.remove(lease)
+        } else {
+            lease.permits -= release.permits
+        }
+    }
+
+    fun markLost(release: PermitRelease): Unit = lock.withLock {
+        leases.removeAll { it.token == release.token }
+    }
+
+    fun clear(): Unit = lock.withLock {
+        leases.clear()
+    }
+
+    private class Lease(
+        val token: String,
+        var permits: Int,
+    )
+}
+
+internal class PermitRelease(
+    val token: String,
+    val permits: Int,
+)
+
+internal fun Duration.requirePositiveMillis(parameterName: String): Duration {
+    require(!isNegative && !isZero && toMillis() > 0L) {
+        "$parameterName must be positive and at least 1 millisecond."
+    }
+    return this
+}

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/semaphore/LettuceSuspendSemaphore.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/semaphore/LettuceSuspendSemaphore.kt
@@ -2,23 +2,24 @@ package io.bluetape4k.redis.lettuce.semaphore
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
-import io.bluetape4k.redis.lettuce.script.RedisScript
 import io.bluetape4k.redis.lettuce.script.RedisScriptRunner
 import io.bluetape4k.support.requirePositiveNumber
+import io.lettuce.core.ScriptOutputType
 import io.lettuce.core.SetArgs
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.api.async.RedisAsyncCommands
-import io.lettuce.core.ScriptOutputType
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.future.await
 import java.time.Duration
+import java.util.UUID
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Lettuce Redis 클라이언트를 이용한 분산 세마포어의 코루틴(suspend) 구현체입니다.
  *
- * [LettuceSemaphore]의 코루틴 버전으로, Redis의 카운터(잔여 허가 수)를 사용하여 세마포어를 구현합니다.
- * Lua 스크립트를 통해 acquire/release를 원자적으로 처리합니다.
+ * [LettuceSemaphore]의 코루틴 버전으로, Redis의 카운터(잔여 허가 수), owner token hash,
+ * expiry sorted set을 사용하여 세마포어를 구현합니다.
+ * Lua 스크립트를 통해 acquire/release/expired-owner cleanup을 원자적으로 처리합니다.
  *
  * ```kotlin
  * val semaphore = LettuceSuspendSemaphore(connection, "my-semaphore", totalPermits = 3)
@@ -32,50 +33,24 @@ import kotlin.time.Duration.Companion.milliseconds
  * @param connection Lettuce StatefulRedisConnection (StringCodec 기반)
  * @param semaphoreKey Redis에 저장될 세마포어 키
  * @param totalPermits 전체 허가 수
+ * @param leaseTime 획득한 permit owner token의 lease time
  */
 class LettuceSuspendSemaphore(
     private val connection: StatefulRedisConnection<String, String>,
     val semaphoreKey: String,
     val totalPermits: Int,
+    private val leaseTime: Duration = Duration.ofSeconds(30),
 ) {
     companion object: KLogging() {
         private const val RETRY_DELAY_MS = 50L
-
-        // 개선: 상수 String → RedisScript 로 승격해 SHA1 을 1 회만 계산하고 EVALSHA 호출을 재사용합니다.
-
-        /**
-         * Lua: 원자적 acquire
-         * KEYS[1]=semaphoreKey, ARGV[1]=permits
-         * 반환: 남은 허가 수 (허가 수 부족 시 -1)
-         */
-        private val ACQUIRE_SCRIPT = RedisScript(
-            """
-local v = tonumber(redis.call('get', KEYS[1]))
-if v and v >= tonumber(ARGV[1]) then
-  return redis.call('decrby', KEYS[1], ARGV[1])
-else
-  return -1
-end"""
-        )
-
-        /**
-         * Lua: 원자적 release (최대값 초과 방지)
-         * KEYS[1]=semaphoreKey, ARGV[1]=permits, ARGV[2]=maxPermits
-         * 반환: 현재 남은 허가 수
-         */
-        private val RELEASE_SCRIPT = RedisScript(
-            """
-local v = tonumber(redis.call('incrby', KEYS[1], ARGV[1]))
-if v > tonumber(ARGV[2]) then
-  redis.call('set', KEYS[1], ARGV[2])
-  return tonumber(ARGV[2])
-end
-return v"""
-        )
     }
 
     // 개선: getter → final field 로 변경 (매 호출 connection.async() 호출 제거).
     private val asyncCommands: RedisAsyncCommands<String, String> = connection.async()
+    private val ownersKey = "$semaphoreKey:owners"
+    private val expirationsKey = "$semaphoreKey:expirations"
+    private val localPermits = LocalSemaphorePermits()
+    private val leaseMillis = leaseTime.requirePositiveMillis("leaseTime").toMillis()
 
     init {
         totalPermits.requirePositiveNumber("totalPermits")
@@ -99,6 +74,8 @@ return v"""
     suspend fun trySetPermits(permits: Int) {
         permits.requirePositiveNumber("permits")
         asyncCommands.set(semaphoreKey, permits.toString()).await()
+        asyncCommands.del(ownersKey, expirationsKey).await()
+        localPermits.clear()
         log.debug { "세마포어 허가 수 설정: semaphoreKey=$semaphoreKey, permits=$permits" }
     }
 
@@ -108,7 +85,10 @@ return v"""
      * @return 잔여 허가 수 (초기화 안 된 경우 0)
      */
     suspend fun availablePermits(): Int =
-        asyncCommands.get(semaphoreKey).await()?.toIntOrNull() ?: 0
+        RedisScriptRunner.runSuspending<Long>(
+            asyncCommands, LettuceSemaphoreScripts.AVAILABLE_SCRIPT, ScriptOutputType.INTEGER,
+            semaphoreKeys(), nowMillis().toString(), totalPermits.toString()
+        ).toInt()
 
     // =========================================================================
     // 코루틴 API (suspend)
@@ -129,12 +109,22 @@ return v"""
      */
     suspend fun tryAcquire(permits: Int = 1): Boolean {
         permits.requirePositiveNumber("permits")
+        val token = UUID.randomUUID().toString()
+        val now = nowMillis()
 
         val result = RedisScriptRunner.runSuspending<Long>(
-            asyncCommands, ACQUIRE_SCRIPT, ScriptOutputType.INTEGER,
-            arrayOf(semaphoreKey), permits.toString()
+            asyncCommands, LettuceSemaphoreScripts.ACQUIRE_SCRIPT, ScriptOutputType.INTEGER,
+            semaphoreKeys(),
+            now.toString(),
+            totalPermits.toString(),
+            permits.toString(),
+            token,
+            (now + leaseMillis).toString(),
         )
         val acquired = result >= 0
+        if (acquired) {
+            localPermits.record(token, permits)
+        }
         log.debug { "Semaphore tryAcquire: key=$semaphoreKey, permits=$permits, acquired=$acquired" }
         return acquired
     }
@@ -187,10 +177,33 @@ return v"""
     suspend fun release(permits: Int = 1) {
         permits.requirePositiveNumber("permits")
 
-        val remaining = RedisScriptRunner.runSuspending<Long>(
-            asyncCommands, RELEASE_SCRIPT, ScriptOutputType.INTEGER,
-            arrayOf(semaphoreKey), permits.toString(), totalPermits.toString()
-        )
-        log.debug { "Semaphore release: key=$semaphoreKey, permits=$permits, remaining=$remaining" }
+        val releases = localPermits.select(permits)
+        releases.forEach { release ->
+            val remaining = RedisScriptRunner.runSuspending<Long>(
+                asyncCommands, LettuceSemaphoreScripts.RELEASE_SCRIPT, ScriptOutputType.INTEGER,
+                semaphoreKeys(),
+                nowMillis().toString(),
+                totalPermits.toString(),
+                release.permits.toString(),
+                release.token,
+            )
+            handleReleaseResult(release, remaining)
+            log.debug { "Semaphore release: key=$semaphoreKey, permits=${release.permits}, remaining=$remaining" }
+        }
     }
+
+    private fun handleReleaseResult(release: PermitRelease, remaining: Long) {
+        when {
+            remaining >= 0L -> localPermits.markReleased(release)
+            remaining == -1L -> {
+                localPermits.markLost(release)
+                error("Semaphore permits are no longer owned or already expired: semaphoreKey=$semaphoreKey")
+            }
+            else -> error("Semaphore release exceeds owned permits: semaphoreKey=$semaphoreKey")
+        }
+    }
+
+    private fun semaphoreKeys(): Array<String> = arrayOf(semaphoreKey, ownersKey, expirationsKey)
+
+    private fun nowMillis(): Long = System.currentTimeMillis()
 }

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceLockTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceLockTest.kt
@@ -8,14 +8,16 @@ import io.bluetape4k.redis.lettuce.LettuceClients
 import io.bluetape4k.redis.lettuce.LettuceTestUtils
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
 import io.lettuce.core.codec.StringCodec
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 import java.time.Duration
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.atomic.AtomicInteger
 
 @OptIn(ExperimentalLettuceCoroutinesApi::class)
@@ -60,6 +62,44 @@ class LettuceLockTest: AbstractLettuceTest() {
         assertFailsWith<IllegalStateException> {
             lock.unlock()
         }
+    }
+
+    @Test
+    fun `tryLock - 잘못된 duration은 즉시 거부한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            lock.tryLock(waitTime = Duration.ofMillis(-1))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            lock.tryLock(leaseTime = Duration.ZERO)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            lock.tryLock(leaseTime = Duration.ofNanos(1))
+        }
+    }
+
+    @Test
+    fun `lock - 잘못된 duration은 즉시 거부한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            lock.lock(leaseTime = Duration.ZERO)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            lock.lock(maxWaitTime = Duration.ZERO)
+        }
+    }
+
+    @Test
+    fun `unlock - 만료된 lock 해제 실패 시 token을 보존해 재시도할 수 있다`() {
+        lock.lock(leaseTime = Duration.ofSeconds(5))
+        val token = connection.sync().get(lock.lockKey)
+        connection.sync().del(lock.lockKey)
+
+        assertFailsWith<IllegalStateException> {
+            lock.unlock()
+        }
+
+        connection.sync().set(lock.lockKey, token)
+        lock.unlock()
+        lock.isHeldByCurrentInstance().shouldBeFalse()
     }
 
     @Test
@@ -113,6 +153,35 @@ class LettuceLockTest: AbstractLettuceTest() {
         } finally {
             lock.unlockAsync().get()
         }
+    }
+
+    @Test
+    fun `tryLockAsync - 잘못된 duration은 즉시 거부한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            lock.tryLockAsync(waitTime = Duration.ofMillis(-1))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            lock.tryLockAsync(leaseTime = Duration.ZERO)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            lock.lockAsync(maxWaitTime = Duration.ZERO)
+        }
+    }
+
+    @Test
+    fun `unlockAsync - 만료된 lock 해제 실패 시 token을 보존해 재시도할 수 있다`() {
+        lock.lockAsync(leaseTime = Duration.ofSeconds(5)).get()
+        val token = connection.sync().get(lock.lockKey)
+        connection.sync().del(lock.lockKey)
+
+        val failure = assertFailsWith<ExecutionException> {
+            lock.unlockAsync().get()
+        }
+        failure.cause.shouldBeInstanceOf<IllegalStateException>()
+
+        connection.sync().set(lock.lockKey, token)
+        lock.unlockAsync().get()
+        lock.isHeldByCurrentInstance().shouldBeFalse()
     }
 
     // =========================================================================

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSuspendLockTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSuspendLockTest.kt
@@ -8,10 +8,12 @@ import io.bluetape4k.redis.lettuce.LettuceClients
 import io.bluetape4k.redis.lettuce.LettuceTestUtils
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
 import io.lettuce.core.codec.StringCodec
+import io.bluetape4k.assertions.assertFailsWith
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.BeforeEach
@@ -57,6 +59,40 @@ class LettuceSuspendLockTest: AbstractLettuceTest() {
         lock.isHeldByCurrentInstance().shouldBeTrue()
         lock.unlock()
         lock.isHeldByCurrentInstance()
+    }
+
+    @Test
+    fun `tryLock and lock - 잘못된 duration은 즉시 거부한다`() = runSuspendIO {
+        val lock = suspendLock()
+
+        assertFailsWith<IllegalArgumentException> {
+            lock.tryLock(waitTime = Duration.ofMillis(-1))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            lock.tryLock(leaseTime = Duration.ZERO)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            lock.tryLock(leaseTime = Duration.ofNanos(1))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            lock.lock(maxWaitTime = Duration.ZERO)
+        }
+    }
+
+    @Test
+    fun `unlock - 만료된 lock 해제 실패 시 token을 보존해 재시도할 수 있다`() = runSuspendIO {
+        val lock = suspendLock()
+        lock.lock(leaseTime = Duration.ofSeconds(5))
+        val token = connection.sync().get(lock.lockKey)
+        connection.sync().del(lock.lockKey)
+
+        assertFailsWith<IllegalStateException> {
+            lock.unlock()
+        }
+
+        connection.sync().set(lock.lockKey, token)
+        lock.unlock()
+        lock.isHeldByCurrentInstance().shouldBeFalse()
     }
 
     @Test

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/semaphore/LettuceSemaphoreTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/semaphore/LettuceSemaphoreTest.kt
@@ -70,9 +70,44 @@ class LettuceSemaphoreTest: AbstractLettuceTest() {
     }
 
     @Test
-    fun `release - 최대값 초과하지 않음`() {
-        semaphore.release(10)
+    fun `release - owned permit 없이 반납하면 실패`() {
+        assertFailsWith<IllegalStateException> {
+            semaphore.release()
+        }
         semaphore.availablePermits() shouldBeEqualTo TOTAL_PERMITS
+    }
+
+    @Test
+    fun `release - double release does not restore extra permits`() {
+        semaphore.tryAcquire().shouldBeTrue()
+        semaphore.release()
+
+        assertFailsWith<IllegalStateException> {
+            semaphore.release()
+        }
+        semaphore.availablePermits() shouldBeEqualTo TOTAL_PERMITS
+    }
+
+    @Test
+    fun `expired owner lease restores permits and rejects stale release`() {
+        val expiringSemaphore = LettuceSemaphore(
+            connection = connection,
+            semaphoreKey = randomName(),
+            totalPermits = TOTAL_PERMITS,
+            leaseTime = Duration.ofMillis(20),
+        )
+        expiringSemaphore.initialize()
+
+        expiringSemaphore.tryAcquire(TOTAL_PERMITS).shouldBeTrue()
+        expiringSemaphore.availablePermits() shouldBeEqualTo 0
+
+        Thread.sleep(50)
+
+        expiringSemaphore.availablePermits() shouldBeEqualTo TOTAL_PERMITS
+        assertFailsWith<IllegalStateException> {
+            expiringSemaphore.release(TOTAL_PERMITS)
+        }
+        expiringSemaphore.availablePermits() shouldBeEqualTo TOTAL_PERMITS
     }
 
     @Test
@@ -129,6 +164,17 @@ class LettuceSemaphoreTest: AbstractLettuceTest() {
     fun `tryAcquireAsync - 허가 소진 시 false`() {
         repeat(TOTAL_PERMITS) { semaphore.tryAcquireAsync().get().shouldBeTrue() }
         semaphore.tryAcquireAsync().get().shouldBeFalse()
+    }
+
+    @Test
+    fun `releaseAsync - double release does not restore extra permits`() {
+        semaphore.tryAcquireAsync().get().shouldBeTrue()
+        semaphore.releaseAsync().get()
+
+        assertFailsWith<IllegalStateException> {
+            semaphore.releaseAsync().get()
+        }
+        semaphore.availablePermits() shouldBeEqualTo TOTAL_PERMITS
     }
 
     // =========================================================================

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/semaphore/LettuceSuspendSemaphoreTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/semaphore/LettuceSuspendSemaphoreTest.kt
@@ -65,6 +65,53 @@ class LettuceSuspendSemaphoreTest: AbstractLettuceTest() {
     }
 
     @Test
+    fun `releaseSuspending - owned permit 없이 반납하면 실패`() = runSuspendIO {
+        val suspendSemaphore =
+            LettuceSuspendSemaphore(connection, semaphore.semaphoreKey, TOTAL_PERMITS)
+
+        assertFailsWith<IllegalStateException> {
+            suspendSemaphore.release()
+        }
+        semaphore.availablePermits() shouldBeEqualTo TOTAL_PERMITS
+    }
+
+    @Test
+    fun `releaseSuspending - double release does not restore extra permits`() = runSuspendIO {
+        val suspendSemaphore =
+            LettuceSuspendSemaphore(connection, semaphore.semaphoreKey, TOTAL_PERMITS)
+
+        suspendSemaphore.tryAcquire().shouldBeTrue()
+        suspendSemaphore.release()
+
+        assertFailsWith<IllegalStateException> {
+            suspendSemaphore.release()
+        }
+        semaphore.availablePermits() shouldBeEqualTo TOTAL_PERMITS
+    }
+
+    @Test
+    fun `expired suspend owner lease restores permits and rejects stale release`() = runSuspendIO {
+        val suspendSemaphore = LettuceSuspendSemaphore(
+            connection = connection,
+            semaphoreKey = randomName(),
+            totalPermits = TOTAL_PERMITS,
+            leaseTime = Duration.ofMillis(20),
+        )
+        suspendSemaphore.initialize()
+
+        suspendSemaphore.tryAcquire(TOTAL_PERMITS).shouldBeTrue()
+        suspendSemaphore.availablePermits() shouldBeEqualTo 0
+
+        delay(50.milliseconds)
+
+        suspendSemaphore.availablePermits() shouldBeEqualTo TOTAL_PERMITS
+        assertFailsWith<IllegalStateException> {
+            suspendSemaphore.release(TOTAL_PERMITS)
+        }
+        suspendSemaphore.availablePermits() shouldBeEqualTo TOTAL_PERMITS
+    }
+
+    @Test
     fun `코루틴 동시성 - 최대 TOTAL_PERMITS개만 허가`() = runSuspendIO {
         val acquired = AtomicInteger(0)
 

--- a/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/SuspendRetrofitCallSupport.kt
+++ b/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/SuspendRetrofitCallSupport.kt
@@ -14,6 +14,7 @@ import kotlin.coroutines.resumeWithException
  *
  * ## 동작/계약
  * - 코루틴 취소 시 `Call.cancel()`을 호출합니다.
+ * - 취소가 응답 전달보다 먼저 완료되면 응답 바디를 닫아 연결 누수를 방지합니다.
  * - 호출이 이미 취소된 상태에서 응답/실패가 도착하면 [cancelHandler]를 호출하고 코루틴을 취소합니다.
  * - 네트워크 실패는 예외로 재개(`resumeWithException`)됩니다.
  *
@@ -33,12 +34,16 @@ suspend inline fun <T> Call<T>.suspendExecute(
 
     val callback = object: Callback<T> {
         override fun onResponse(call: Call<T>, response: Response<T>) {
-            if (call.isCanceled) {
+            if (!cont.isActive || call.isCanceled) {
+                response.closeBodyQuietly()
                 val ex = HttpException(response)
                 cancelHandler(ex)
                 cont.cancel(ex)
             } else {
-                cont.resume(response) { _, _, _ -> call.cancel() }
+                cont.resume(response) { _, deliveredResponse, _ ->
+                    deliveredResponse.closeBodyQuietly()
+                    call.cancel()
+                }
             }
         }
 
@@ -53,6 +58,12 @@ suspend inline fun <T> Call<T>.suspendExecute(
     }
 
     enqueue(callback)
+}
+
+@PublishedApi
+internal fun Response<*>.closeBodyQuietly() {
+    runCatching { raw().close() }
+    runCatching { errorBody()?.close() }
 }
 
 /**

--- a/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/SuspendRetrofitCallSupportTest.kt
+++ b/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/SuspendRetrofitCallSupportTest.kt
@@ -9,15 +9,30 @@ import io.bluetape4k.junit5.coroutines.runCatchingNonCancellation
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.retrofit2.services.TestService
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.ResponseBody
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy
+import okio.Buffer
+import okio.BufferedSource
+import okio.Source
+import okio.Timeout
+import okio.buffer
+import retrofit2.Callback
 import retrofit2.Call
+import retrofit2.Response
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import retrofit2.converter.scalars.ScalarsConverterFactory
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * [suspendExecute] 확장 함수 단위 테스트입니다.
@@ -109,5 +124,123 @@ class SuspendRetrofitCallSupportTest {
             call = api.get()
             call.suspendExecute()
         }
+    }
+
+    @Test
+    fun `suspendExecute closes successful response body when cancellation wins response race`() = runTest {
+        val call = ControlledCall<String>()
+        val cancelCause = AtomicReference<Throwable?>()
+        val body = CloseTrackingResponseBody()
+
+        val job = launch {
+            runCatching {
+                call.suspendExecute { cancelCause.set(it) }
+            }
+        }
+
+        call.awaitEnqueued()
+        job.cancel("cancel before response")
+        call.callback.onResponse(call, successResponse("hello", body))
+        job.join()
+
+        call.isCanceled.shouldBeTrue()
+        body.closed.shouldBeTrue()
+        cancelCause.get().shouldNotBeNull()
+    }
+
+    @Test
+    fun `suspendExecute closes error response body when cancellation wins response race`() = runTest {
+        val call = ControlledCall<String>()
+        val cancelCause = AtomicReference<Throwable?>()
+        val body = CloseTrackingResponseBody()
+
+        val job = launch {
+            runCatching {
+                call.suspendExecute { cancelCause.set(it) }
+            }
+        }
+
+        call.awaitEnqueued()
+        job.cancel("cancel before response")
+        call.callback.onResponse(call, Response.error(500, body))
+        job.join()
+
+        call.isCanceled.shouldBeTrue()
+        body.closed.shouldBeTrue()
+        cancelCause.get().shouldNotBeNull()
+    }
+
+    private fun successResponse(
+        body: String,
+        rawBody: ResponseBody,
+    ): Response<String> {
+        val raw =
+            okhttp3.Response
+                .Builder()
+                .request(Request.Builder().url("https://example.test/").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(rawBody)
+                .build()
+
+        return Response.success(body, raw)
+    }
+
+    private class ControlledCall<T>: Call<T> {
+        private val callbackReady = CompletableDeferred<Callback<T>>()
+        private var canceled = false
+
+        val callback: Callback<T>
+            get() = callbackReady.getCompleted()
+
+        suspend fun awaitEnqueued() {
+            callbackReady.await()
+        }
+
+        override fun enqueue(callback: Callback<T>) {
+            callbackReady.complete(callback)
+        }
+
+        override fun cancel() {
+            canceled = true
+        }
+
+        override fun isCanceled(): Boolean = canceled
+
+        override fun isExecuted(): Boolean = callbackReady.isCompleted
+
+        override fun clone(): Call<T> = ControlledCall()
+
+        override fun execute(): Response<T> = error("Synchronous execution is not used by this test.")
+
+        override fun request(): Request =
+            Request.Builder().url("https://example.test/").build()
+
+        override fun timeout(): Timeout = Timeout.NONE
+    }
+
+    private class CloseTrackingResponseBody: ResponseBody() {
+        private val source = CloseTrackingSource()
+        val closed: Boolean get() = source.closed
+
+        override fun contentType() = null
+
+        override fun contentLength(): Long = 0L
+
+        override fun source(): BufferedSource = source.buffer()
+    }
+
+    private class CloseTrackingSource: Source {
+        var closed: Boolean = false
+            private set
+
+        override fun close() {
+            closed = true
+        }
+
+        override fun read(sink: Buffer, byteCount: Long): Long = -1L
+
+        override fun timeout(): Timeout = Timeout.NONE
     }
 }

--- a/io/tink/src/main/kotlin/io/bluetape4k/tink/keyset/redis/LettuceVersionedKeysetStore.kt
+++ b/io/tink/src/main/kotlin/io/bluetape4k/tink/keyset/redis/LettuceVersionedKeysetStore.kt
@@ -50,13 +50,13 @@ class LettuceVersionedKeysetStore(
             return requireNotNull(find(activeVersion)) { "Missing keyset for activeVersion=$activeVersion" }
         }
 
-        return withLock {
+        return withLock { token ->
             val reloadedVersion = commands.get(activeVersionKey)?.toLongOrNull()
             if (reloadedVersion != null) {
                 requireNotNull(find(reloadedVersion)) { "Missing keyset for activeVersion=$reloadedVersion" }
             } else {
                 val initial = newVersionedKeyset(1L)
-                persist(initial, activate = true)
+                persist(initial, activate = true, lockToken = token)
                 initial
             }
         }
@@ -73,16 +73,16 @@ class LettuceVersionedKeysetStore(
     }
 
     override fun rotate(): VersionedKeysetHandle =
-        withLock {
+        withLock { token ->
             val nextVersion = (commands.get(activeVersionKey)?.toLongOrNull() ?: 0L) + 1L
             val rotated = newVersionedKeyset(nextVersion)
-            persist(rotated, activate = true)
+            persist(rotated, activate = true, lockToken = token)
             rotated
         }
 
     override fun rotateIfDue(rotationPeriod: Duration): VersionedKeysetHandle {
         require(rotationPeriod > Duration.ZERO) { "rotationPeriod must be positive." }
-        return withLock {
+        return withLock { token ->
             // Due 판단은 lock 안에서 다시 읽는다. 여러 caller가 같은 stale active keyset을 보고
             // 순차적으로 rotate하는 것을 막아 "한 due window당 한 번"만 회전하게 한다.
             val activeVersion = commands.get(activeVersionKey)?.toLongOrNull()
@@ -90,13 +90,13 @@ class LettuceVersionedKeysetStore(
                 requireNotNull(find(activeVersion)) { "Missing keyset for activeVersion=$activeVersion" }
             } else {
                 val initial = newVersionedKeyset(1L)
-                persist(initial, activate = true)
+                persist(initial, activate = true, lockToken = token)
                 initial
             }
             val elapsed = Duration.between(current.createdAt, Instant.now(clock))
             if (elapsed >= rotationPeriod) {
                 val rotated = newVersionedKeyset(current.version + 1L)
-                persist(rotated, activate = true)
+                persist(rotated, activate = true, lockToken = token)
                 rotated
             } else {
                 current
@@ -111,21 +111,35 @@ class LettuceVersionedKeysetStore(
             keysetHandle = KeysetHandle.generateNew(keyTemplate),
         )
 
-    private fun persist(keyset: VersionedKeysetHandle, activate: Boolean) {
+    private fun persist(keyset: VersionedKeysetHandle, activate: Boolean, lockToken: String?) {
         // active version은 마지막에 갱신한다. reader가 active=N을 봤다면 keyset/createdAt도 이미 기록된 상태여야 한다.
-        commands.hset(keysetsKey, keyset.version.toString(), keyset.keysetHandle.toJsonKeyset())
-        commands.hset(createdAtKey, keyset.version.toString(), keyset.createdAt.toEpochMilli().toString())
         if (activate) {
-            commands.set(activeVersionKey, keyset.version.toString())
+            val token = requireNotNull(lockToken) { "lockToken is required to activate a keyset" }
+            val persisted = persistActivatedIfOwned(
+                commands = commands,
+                lockKey = lockKey,
+                keysetsKey = keysetsKey,
+                createdAtKey = createdAtKey,
+                activeVersionKey = activeVersionKey,
+                token = token,
+                lockTtlMillis = LOCK_TTL_MILLIS,
+                version = keyset.version.toString(),
+                keysetJson = keyset.keysetHandle.toJsonKeyset(),
+                createdAtEpochMillis = keyset.createdAt.toEpochMilli().toString(),
+            )
+            check(persisted) { "Lost lock ownership for keyring=$keyringName" }
+        } else {
+            commands.hset(keysetsKey, keyset.version.toString(), keyset.keysetHandle.toJsonKeyset())
+            commands.hset(createdAtKey, keyset.version.toString(), keyset.createdAt.toEpochMilli().toString())
         }
     }
 
-    private fun <T> withLock(action: () -> T): T {
+    private fun <T> withLock(action: (String) -> T): T {
         val token = UUID.randomUUID().toString()
         val acquired = acquireLock(token)
         check(acquired) { "Failed to acquire lock for keyring=$keyringName" }
         return try {
-            action()
+            action(token)
         } finally {
             runCatching {
                 releaseLockIfOwned(commands, lockKey, token)
@@ -157,6 +171,15 @@ class LettuceVersionedKeysetStore(
                 "return redis.call('del', KEYS[1]) " +
                 "else return 0 end"
 
+        private const val PERSIST_ACTIVATED_IF_OWNED_SCRIPT: String =
+            "if redis.call('get', KEYS[1]) == ARGV[1] then " +
+                "redis.call('pexpire', KEYS[1], ARGV[2]) " +
+                "redis.call('hset', KEYS[2], ARGV[3], ARGV[4]) " +
+                "redis.call('hset', KEYS[3], ARGV[3], ARGV[5]) " +
+                "redis.call('set', KEYS[4], ARGV[3]) " +
+                "return 1 " +
+                "else return 0 end"
+
         internal fun releaseLockIfOwned(
             commands: io.lettuce.core.api.sync.RedisCommands<String, String>,
             lockKey: String,
@@ -171,6 +194,31 @@ class LettuceVersionedKeysetStore(
                 token
             )
             return deleted == 1L
+        }
+
+        internal fun persistActivatedIfOwned(
+            commands: io.lettuce.core.api.sync.RedisCommands<String, String>,
+            lockKey: String,
+            keysetsKey: String,
+            createdAtKey: String,
+            activeVersionKey: String,
+            token: String,
+            lockTtlMillis: Long,
+            version: String,
+            keysetJson: String,
+            createdAtEpochMillis: String,
+        ): Boolean {
+            val persisted = commands.eval<Long>(
+                PERSIST_ACTIVATED_IF_OWNED_SCRIPT,
+                ScriptOutputType.INTEGER,
+                arrayOf(lockKey, keysetsKey, createdAtKey, activeVersionKey),
+                token,
+                lockTtlMillis.toString(),
+                version,
+                keysetJson,
+                createdAtEpochMillis,
+            )
+            return persisted == 1L
         }
     }
 }

--- a/io/tink/src/main/kotlin/io/bluetape4k/tink/keyset/redis/RedissonVersionedKeysetStore.kt
+++ b/io/tink/src/main/kotlin/io/bluetape4k/tink/keyset/redis/RedissonVersionedKeysetStore.kt
@@ -106,6 +106,9 @@ class RedissonVersionedKeysetStore(
 
     private fun persist(keyset: VersionedKeysetHandle, activate: Boolean) {
         // active version은 마지막에 갱신한다. reader가 active=N을 봤다면 keyset/createdAt도 이미 기록된 상태여야 한다.
+        if (activate) {
+            check(lock.isHeldByCurrentThread) { "Lost lock ownership for keyring=$keyringName" }
+        }
         keysetsMap[keyset.version.toString()] = keyset.keysetHandle.toJsonKeyset()
         createdAtMap[keyset.version.toString()] = keyset.createdAt.toEpochMilli().toString()
         if (activate) {
@@ -114,7 +117,7 @@ class RedissonVersionedKeysetStore(
     }
 
     private fun <T> withLock(action: () -> T): T {
-        check(lock.tryLock(5, 30, TimeUnit.SECONDS)) { "Failed to acquire lock for keyring=$keyringName" }
+        check(lock.tryLock(5, TimeUnit.SECONDS)) { "Failed to acquire lock for keyring=$keyringName" }
         return try {
             action()
         } finally {

--- a/io/tink/src/test/kotlin/io/bluetape4k/tink/keyset/redis/LettuceVersionedKeysetStoreTest.kt
+++ b/io/tink/src/test/kotlin/io/bluetape4k/tink/keyset/redis/LettuceVersionedKeysetStoreTest.kt
@@ -11,6 +11,7 @@ import io.bluetape4k.testcontainers.storage.RedisServer
 import io.bluetape4k.tink.aead.TinkAeads
 import io.bluetape4k.tink.keyset.VersionedTinkDaead
 import io.lettuce.core.RedisClient
+import io.lettuce.core.SetArgs
 import io.lettuce.core.codec.StringCodec
 import org.junit.jupiter.api.Test
 import java.time.Clock
@@ -96,6 +97,55 @@ class LettuceVersionedKeysetStoreTest {
         commands.set(lockKey, "owner-2")
         LettuceVersionedKeysetStore.releaseLockIfOwned(commands, lockKey, "stale-owner").shouldBeFalse()
         commands.get(lockKey) shouldBeEqualTo "owner-2"
+    }
+
+    @Test
+    fun `activation write requires live lock token`() {
+        val connection = client.connect(StringCodec.UTF8)
+        val commands = connection.sync()
+        val keyring = randomName()
+        val lockKey = "$keyring:lock"
+        val keysetsKey = "$keyring:keysets"
+        val createdAtKey = "$keyring:created-at"
+        val activeVersionKey = "$keyring:active"
+
+        commands.set(lockKey, "owner-1", SetArgs().px(1))
+        Thread.sleep(10)
+
+        LettuceVersionedKeysetStore.persistActivatedIfOwned(
+            commands = commands,
+            lockKey = lockKey,
+            keysetsKey = keysetsKey,
+            createdAtKey = createdAtKey,
+            activeVersionKey = activeVersionKey,
+            token = "owner-1",
+            lockTtlMillis = 30_000L,
+            version = "2",
+            keysetJson = "stale-keyset",
+            createdAtEpochMillis = "123",
+        ).shouldBeFalse()
+
+        commands.hget(keysetsKey, "2").shouldBeNull()
+        commands.hget(createdAtKey, "2").shouldBeNull()
+        commands.get(activeVersionKey).shouldBeNull()
+
+        commands.set(lockKey, "owner-2", SetArgs().px(30_000))
+        LettuceVersionedKeysetStore.persistActivatedIfOwned(
+            commands = commands,
+            lockKey = lockKey,
+            keysetsKey = keysetsKey,
+            createdAtKey = createdAtKey,
+            activeVersionKey = activeVersionKey,
+            token = "owner-2",
+            lockTtlMillis = 30_000L,
+            version = "2",
+            keysetJson = "live-keyset",
+            createdAtEpochMillis = "456",
+        ).shouldBeTrue()
+
+        commands.hget(keysetsKey, "2") shouldBeEqualTo "live-keyset"
+        commands.hget(createdAtKey, "2") shouldBeEqualTo "456"
+        commands.get(activeVersionKey) shouldBeEqualTo "2"
     }
 
     @Test

--- a/io/vertx/src/main/kotlin/io/bluetape4k/vertx/sqlclient/PoolSupport.kt
+++ b/io/vertx/src/main/kotlin/io/bluetape4k/vertx/sqlclient/PoolSupport.kt
@@ -3,8 +3,11 @@ package io.bluetape4k.vertx.sqlclient
 import io.vertx.kotlin.coroutines.coAwait
 import io.vertx.sqlclient.Pool
 import io.vertx.sqlclient.SqlConnection
+import io.vertx.sqlclient.Transaction
 import io.vertx.sqlclient.TransactionRollbackException
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import java.sql.SQLException
 
 /**
@@ -31,21 +34,26 @@ suspend inline fun <T> Pool.withSuspendTransaction(
 ): T {
     val conn = connection.coAwait()
     val tx = conn.begin().coAwait()
+    var primaryFailure: Throwable? = null
 
     return try {
         val result = action(conn)
         tx.commit().coAwait()
         result
     } catch (e: TransactionRollbackException) {
+        primaryFailure = e
         throw (e)
     } catch (e: CancellationException) {
-        runCatching { tx.rollback().coAwait() }
+        primaryFailure = e
+        rollbackSuppressing(tx, e)
         throw e
     } catch (e: Throwable) {
-        runCatching { tx.rollback().coAwait() }
-        throw SQLException(e)
+        val sqlException = SQLException(e)
+        primaryFailure = sqlException
+        rollbackSuppressing(tx, sqlException)
+        throw sqlException
     } finally {
-        conn.close().coAwait()
+        closeConnection(conn, primaryFailure)
     }
 }
 
@@ -72,19 +80,55 @@ suspend inline fun <T> Pool.withSuspendRollback(
 ): T {
     val conn = connection.coAwait()
     val tx = conn.begin().coAwait()
+    var primaryFailure: Throwable? = null
     return try {
         val result = action(conn)
         tx.rollback().coAwait()
         result
     } catch (e: TransactionRollbackException) {
+        primaryFailure = e
         throw (e)
     } catch (e: CancellationException) {
-        runCatching { tx.rollback().coAwait() }
+        primaryFailure = e
+        rollbackSuppressing(tx, e)
         throw e
     } catch (e: Throwable) {
-        runCatching { tx.rollback().coAwait() }
-        throw SQLException(e)
+        val sqlException = SQLException(e)
+        primaryFailure = sqlException
+        rollbackSuppressing(tx, sqlException)
+        throw sqlException
     } finally {
-        conn.close().coAwait()
+        closeConnection(conn, primaryFailure)
+    }
+}
+
+@PublishedApi
+internal suspend fun rollbackSuppressing(
+    tx: Transaction,
+    primaryFailure: Throwable,
+) {
+    try {
+        withContext(NonCancellable) {
+            tx.rollback().coAwait()
+        }
+    } catch (rollbackFailure: Throwable) {
+        primaryFailure.addSuppressed(rollbackFailure)
+    }
+}
+
+@PublishedApi
+internal suspend fun closeConnection(
+    conn: SqlConnection,
+    primaryFailure: Throwable?,
+) {
+    try {
+        withContext(NonCancellable) {
+            conn.close().coAwait()
+        }
+    } catch (closeFailure: Throwable) {
+        if (primaryFailure == null) {
+            throw closeFailure
+        }
+        primaryFailure.addSuppressed(closeFailure)
     }
 }

--- a/io/vertx/src/test/kotlin/io/bluetape4k/vertx/sqlclient/PoolSupportTest.kt
+++ b/io/vertx/src/test/kotlin/io/bluetape4k/vertx/sqlclient/PoolSupportTest.kt
@@ -1,14 +1,30 @@
 package io.bluetape4k.vertx.sqlclient
 
-import io.bluetape4k.junit5.coroutines.runSuspendIO
-import io.vertx.core.Vertx
-import io.vertx.junit5.VertxTestContext
-import kotlinx.coroutines.CancellationException
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.mockk.every
+import io.mockk.mockk
+import io.vertx.core.Future
+import io.vertx.core.Promise
+import io.vertx.core.Vertx
+import io.vertx.junit5.VertxTestContext
+import io.vertx.sqlclient.Pool
+import io.vertx.sqlclient.SqlConnection
+import io.vertx.sqlclient.Transaction
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
 import org.junit.jupiter.api.Test
 import java.sql.SQLException
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
 
 class PoolSupportTest: AbstractVertxSqlClientTest() {
 
@@ -34,6 +50,30 @@ class PoolSupportTest: AbstractVertxSqlClientTest() {
     }
 
     @Test
+    fun `withSuspendTransaction은 취소된 컨텍스트에서도 rollback과 close 완료를 보장한다`() = runSuspendIO {
+        val rollbackCompleted = AtomicBoolean(false)
+        val closeCompleted = AtomicBoolean(false)
+        val pool = poolWithCleanupFutures(
+            rollbackFuture = { delayedSucceededFuture { rollbackCompleted.set(true) } },
+            closeFuture = { delayedSucceededFuture { closeCompleted.set(true) } },
+        )
+
+        val error = assertFailsWith<CancellationException> {
+            runInCancelledChild {
+                pool.withSuspendTransaction {
+                    val cancellation = CancellationException("cancel requested")
+                    currentCoroutineContext().cancel(cancellation)
+                    throw cancellation
+                }
+            }
+        }
+
+        error.message shouldBeEqualTo "cancel requested"
+        rollbackCompleted.get().shouldBeTrue()
+        closeCompleted.get().shouldBeTrue()
+    }
+
+    @Test
     fun `withSuspendRollback은 CancellationException을 그대로 전파한다`(
         @Suppress("UNUSED_PARAMETER") unusedVertx: Vertx,
         testContext: VertxTestContext,
@@ -53,6 +93,50 @@ class PoolSupportTest: AbstractVertxSqlClientTest() {
     }
 
     @Test
+    fun `withSuspendRollback은 취소된 컨텍스트에서도 rollback과 close 완료를 보장한다`() = runSuspendIO {
+        val rollbackCompleted = AtomicBoolean(false)
+        val closeCompleted = AtomicBoolean(false)
+        val pool = poolWithCleanupFutures(
+            rollbackFuture = { delayedSucceededFuture { rollbackCompleted.set(true) } },
+            closeFuture = { delayedSucceededFuture { closeCompleted.set(true) } },
+        )
+
+        val error = assertFailsWith<CancellationException> {
+            runInCancelledChild {
+                pool.withSuspendRollback {
+                    val cancellation = CancellationException("cancel requested")
+                    currentCoroutineContext().cancel(cancellation)
+                    throw cancellation
+                }
+            }
+        }
+
+        error.message shouldBeEqualTo "cancel requested"
+        rollbackCompleted.get().shouldBeTrue()
+        closeCompleted.get().shouldBeTrue()
+    }
+
+    @Test
+    fun `cleanup 실패는 CancellationException의 suppressed 예외로 보존한다`() = runSuspendIO {
+        val rollbackFailure = IllegalStateException("rollback failed")
+        val closeFailure = IllegalArgumentException("close failed")
+        val pool = poolWithCleanupFutures(
+            rollbackFuture = { Future.failedFuture(rollbackFailure) },
+            closeFuture = { Future.failedFuture(closeFailure) },
+        )
+
+        val error = assertFailsWith<CancellationException> {
+            pool.withSuspendTransaction {
+                throw CancellationException("cancel requested")
+            }
+        }
+
+        error.message shouldBeEqualTo "cancel requested"
+        error.suppressed.any { it is IllegalStateException && it.message == rollbackFailure.message }.shouldBeTrue()
+        error.suppressed.any { it is IllegalArgumentException && it.message == closeFailure.message }.shouldBeTrue()
+    }
+
+    @Test
     fun `withSuspendTransaction은 일반 예외를 SQLException으로 래핑한다`(
         @Suppress("UNUSED_PARAMETER") unusedVertx: Vertx,
         testContext: VertxTestContext,
@@ -69,5 +153,41 @@ class PoolSupportTest: AbstractVertxSqlClientTest() {
         } catch (t: Throwable) {
             testContext.failNow(t)
         }
+    }
+
+    private suspend fun runInCancelledChild(block: suspend () -> Unit) {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            val deferred = scope.async { block() }
+            deferred.await()
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    private fun poolWithCleanupFutures(
+        rollbackFuture: () -> Future<Void>,
+        closeFuture: () -> Future<Void>,
+    ): Pool {
+        val pool = mockk<Pool>()
+        val conn = mockk<SqlConnection>()
+        val tx = mockk<Transaction>()
+
+        every { pool.connection } returns Future.succeededFuture(conn)
+        every { conn.begin() } returns Future.succeededFuture(tx)
+        every { tx.rollback() } answers { rollbackFuture() }
+        every { conn.close() } answers { closeFuture() }
+
+        return pool
+    }
+
+    private fun delayedSucceededFuture(onComplete: () -> Unit): Future<Void> {
+        val promise = Promise.promise<Void>()
+        thread(start = true, isDaemon = true, name = "vertx-cleanup-test") {
+            Thread.sleep(50)
+            onComplete()
+            promise.complete()
+        }
+        return promise.future()
     }
 }

--- a/ktor/openapi/src/main/kotlin/io/bluetape4k/ktor/openapi/KtorOpenApiRoutes.kt
+++ b/ktor/openapi/src/main/kotlin/io/bluetape4k/ktor/openapi/KtorOpenApiRoutes.kt
@@ -7,7 +7,6 @@ import io.ktor.server.plugins.swagger.SwaggerConfig
 import io.ktor.server.plugins.swagger.swaggerUI
 import io.ktor.server.routing.openapi.OpenApiDocSource
 import io.ktor.server.routing.Route
-import java.io.File
 
 /**
  * Adds an OpenAPI documentation endpoint backed by Ktor's official OpenAPI plugin.
@@ -30,11 +29,11 @@ fun Route.bluetape4kOpenApi(
     configure: OpenAPIConfig.() -> Unit = {},
 ): Route {
     path.requireNotBlank("path")
-    swaggerFile.requireNotBlank("swaggerFile")
+    val checkedSwaggerFile = swaggerFile.requireNotBlank("swaggerFile")
     return openAPI(path = path) {
         configure()
         if (source.isDefaultDocumentSource()) {
-            source = OpenApiDocSource.File(swaggerFile)
+            source = OpenApiDocSource.File(checkedSwaggerFile)
         }
     }
 }
@@ -44,7 +43,9 @@ fun Route.bluetape4kOpenApi(
  *
  * ## Contract
  * - The endpoint is explicit and route-scoped.
- * - [swaggerFile] is used when [configure] leaves Ktor's default document source unchanged.
+ * - [swaggerFile] is used as both the document source and Swagger UI remote path when [configure] leaves
+ *   Ktor's default document source unchanged.
+ * - Nested relative specification paths, such as `openapi/documentation.yaml`, are preserved.
  * - A caller-owned [SwaggerConfig.source] from [configure] is preserved for routing-tree or generated metadata.
  * - This helper does not generate route behavior or mutate existing routes.
  *
@@ -60,12 +61,12 @@ fun Route.bluetape4kSwaggerUi(
     configure: SwaggerConfig.() -> Unit = {},
 ): Route {
     path.requireNotBlank("path")
-    swaggerFile.requireNotBlank("swaggerFile")
+    val checkedSwaggerFile = swaggerFile.requireNotBlank("swaggerFile")
     return swaggerUI(path = path) {
         configure()
         if (source.isDefaultDocumentSource()) {
-            source = OpenApiDocSource.File(swaggerFile)
-            remotePath = File(swaggerFile).name
+            source = OpenApiDocSource.File(checkedSwaggerFile)
+            remotePath = checkedSwaggerFile
         }
     }
 }

--- a/ktor/openapi/src/test/kotlin/io/bluetape4k/ktor/openapi/KtorOpenApiRoutesTest.kt
+++ b/ktor/openapi/src/test/kotlin/io/bluetape4k/ktor/openapi/KtorOpenApiRoutesTest.kt
@@ -59,6 +59,23 @@ class KtorOpenApiRoutesTest {
     }
 
     @Test
+    fun `swagger ui endpoint preserves nested specification remote path`() = testApplication {
+        application {
+            installOpenApiTestCore()
+            routing {
+                bluetape4kSwaggerUi(swaggerFile = "openapi/documentation.yaml")
+            }
+        }
+
+        val response = client.get("/swagger/openapi/documentation.yaml")
+        val body = response.bodyAsText()
+
+        response.status shouldBeEqualTo HttpStatusCode.OK
+        body.contains("Bluetape4k Ktor OpenAPI Test") shouldBeEqualTo true
+        body.contains("/healthz") shouldBeEqualTo true
+    }
+
+    @Test
     fun `openapi endpoint preserves caller owned document source`() = testApplication {
         application {
             installOpenApiTestCore()

--- a/spring-boot/cassandra/src/test/kotlin/io/bluetape4k/spring/cassandra/cql/AsyncCqlOperationsCoroutinesTest.kt
+++ b/spring-boot/cassandra/src/test/kotlin/io/bluetape4k/spring/cassandra/cql/AsyncCqlOperationsCoroutinesTest.kt
@@ -8,7 +8,6 @@ import io.bluetape4k.spring.cassandra.AbstractCassandraCoroutineTest
 import io.bluetape4k.spring.cassandra.domain.DomainTestConfiguration
 import io.bluetape4k.spring.cassandra.domain.model.User
 import kotlinx.coroutines.future.await
-import kotlinx.coroutines.runBlocking
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeEmpty
 import org.junit.jupiter.api.BeforeEach
@@ -40,10 +39,8 @@ class AsyncCqlOperationsCoroutinesTest(
         User(Uuids.timeBased().toString(), faker.name().firstName(), faker.name().lastName())
 
     @BeforeEach
-    fun beforeEach() {
-        runBlocking {
-            cassandraTemplate.truncate(User::class.java).await()
-        }
+    fun beforeEach() = runSuspendIO {
+        cassandraTemplate.truncate(User::class.java).await()
     }
 
     private suspend fun insertUser(user: User): User {

--- a/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/http/RestClientCoroutinesDsl.kt
+++ b/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/http/RestClientCoroutinesDsl.kt
@@ -6,7 +6,12 @@ import org.springframework.http.MediaType
 import org.springframework.web.client.RestClient
 
 /**
- * [RestClient]를 사용하여 suspend GET 요청을 수행하고 응답을 역직렬화합니다.
+ * Performs a suspend GET request with [RestClient] and deserializes a non-null response body.
+ *
+ * ## Contract
+ * - Blocking RestClient I/O runs on [Dispatchers.IO].
+ * - Empty response bodies fail with [IllegalStateException] that includes the method, URI, and target type.
+ * - Use [suspendGetOrNull] when an empty body is a valid response.
  *
  * ```kotlin
  * val user = client.suspendGet<User>("/users/1")
@@ -23,11 +28,16 @@ suspend inline fun <reified T: Any> RestClient.suspendGet(
     runInterruptible(Dispatchers.IO) {
         val spec = get().uri(uri)
         if (accept != null) spec.accept(accept)
-        spec.retrieve().body(T::class.java)!!
+        requireRestClientBody(spec.retrieve().body(T::class.java), "GET", uri)
     }
 
 /**
- * [RestClient]를 사용하여 suspend POST 요청을 수행하고 응답을 역직렬화합니다.
+ * Performs a suspend POST request with [RestClient] and deserializes a non-null response body.
+ *
+ * ## Contract
+ * - Blocking RestClient I/O runs on [Dispatchers.IO].
+ * - Empty response bodies fail with [IllegalStateException] that includes the method, URI, and target type.
+ * - Use [suspendPostOrNull] when an empty body is a valid response.
  *
  * ```kotlin
  * val created = client.suspendPost<User>("/users", newUser, MediaType.APPLICATION_JSON)
@@ -50,11 +60,16 @@ suspend inline fun <reified T: Any> RestClient.suspendPost(
         if (contentType != null) spec.contentType(contentType)
         if (accept != null) spec.accept(accept)
         if (body != null) spec.body(body)
-        spec.retrieve().body(T::class.java)!!
+        requireRestClientBody(spec.retrieve().body(T::class.java), "POST", uri)
     }
 
 /**
- * [RestClient]를 사용하여 suspend PUT 요청을 수행하고 응답을 역직렬화합니다.
+ * Performs a suspend PUT request with [RestClient] and deserializes a non-null response body.
+ *
+ * ## Contract
+ * - Blocking RestClient I/O runs on [Dispatchers.IO].
+ * - Empty response bodies fail with [IllegalStateException] that includes the method, URI, and target type.
+ * - Use [suspendPutOrNull] when an empty body is a valid response.
  *
  * ```kotlin
  * val updated = client.suspendPut<User>("/users/1", updatedUser, MediaType.APPLICATION_JSON)
@@ -77,11 +92,16 @@ suspend inline fun <reified T: Any> RestClient.suspendPut(
         if (contentType != null) spec.contentType(contentType)
         if (accept != null) spec.accept(accept)
         if (body != null) spec.body(body)
-        spec.retrieve().body(T::class.java)!!
+        requireRestClientBody(spec.retrieve().body(T::class.java), "PUT", uri)
     }
 
 /**
- * [RestClient]를 사용하여 suspend PATCH 요청을 수행하고 응답을 역직렬화합니다.
+ * Performs a suspend PATCH request with [RestClient] and deserializes a non-null response body.
+ *
+ * ## Contract
+ * - Blocking RestClient I/O runs on [Dispatchers.IO].
+ * - Empty response bodies fail with [IllegalStateException] that includes the method, URI, and target type.
+ * - Use [suspendPatchOrNull] when an empty body is a valid response.
  *
  * ```kotlin
  * val patched = client.suspendPatch<User>("/users/1", patchData, MediaType.APPLICATION_JSON)
@@ -104,7 +124,7 @@ suspend inline fun <reified T: Any> RestClient.suspendPatch(
         if (contentType != null) spec.contentType(contentType)
         if (accept != null) spec.accept(accept)
         if (body != null) spec.body(body)
-        spec.retrieve().body(T::class.java)!!
+        requireRestClientBody(spec.retrieve().body(T::class.java), "PATCH", uri)
     }
 
 /**
@@ -228,3 +248,14 @@ suspend fun RestClient.suspendDelete(
         if (accept != null) spec.accept(accept)
         spec.retrieve().toBodilessEntity()
     }
+
+@PublishedApi
+internal inline fun <reified T: Any> requireRestClientBody(
+    body: T?,
+    method: String,
+    uri: String,
+): T =
+    body ?: throw IllegalStateException(
+        "RestClient $method $uri returned an empty response body for ${T::class.java.name}. " +
+            "Use the corresponding OrNull coroutine helper when an empty body is valid."
+    )

--- a/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/virtualthread/AbstractVirtualThreadController.kt
+++ b/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/virtualthread/AbstractVirtualThreadController.kt
@@ -1,13 +1,17 @@
 package io.bluetape4k.spring.virtualthread
 
+import jakarta.annotation.PreDestroy
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicReference
 
 /**
- * Virtual Thread Executor를 제공하는 컨트롤러 베이스 클래스입니다.
+ * Base controller that exposes a virtual-thread-per-task executor.
  *
- * Spring Boot 4에서는 기본으로 VT가 활성화되므로,
- * 명시적 VT Executor가 필요한 경우에만 이 클래스를 상속합니다.
+ * Use this base class only when a controller needs an explicit
+ * [ExecutorService] for virtual-thread task submission. Spring calls
+ * [closeVirtualThreadExecutor] when the controller bean is destroyed, and the
+ * shared executor is recreated on the next access if a later context needs it.
  *
  * ```kotlin
  * @RestController
@@ -19,20 +23,52 @@ import java.util.concurrent.Executors
  * ```
  */
 abstract class AbstractVirtualThreadController {
+
+    @PreDestroy
+    fun closeVirtualThreadExecutor() {
+        shutdownVirtualThreadExecutor()
+    }
+
     companion object {
+        private val executorRef = AtomicReference(newVirtualThreadExecutor())
+
         /**
-         * Virtual Thread Per Task Executor.
+         * Virtual-thread-per-task executor.
          *
-         * ## 동작/계약
-         * - `Executors.newVirtualThreadPerTaskExecutor()`로 생성됩니다.
-         * - 각 작업마다 새 가상 스레드를 할당합니다.
+         * ## Contract
+         * - Created by [Executors.newVirtualThreadPerTaskExecutor].
+         * - Allocates a new virtual thread for each submitted task.
+         * - If a Spring context shutdown closed the previous executor, the next
+         *   access returns a fresh executor instead of a closed instance.
          *
          * ```kotlin
          * val future = AbstractVirtualThreadController.virtualThreadExecutor.submit { "done" }
          * // future.get() == "done"
          * ```
          */
-        val virtualThreadExecutor: ExecutorService =
+        val virtualThreadExecutor: ExecutorService
+            get() = getOrCreateVirtualThreadExecutor()
+
+        private fun newVirtualThreadExecutor(): ExecutorService =
             Executors.newVirtualThreadPerTaskExecutor()
+
+        private fun getOrCreateVirtualThreadExecutor(): ExecutorService {
+            while (true) {
+                val current = executorRef.get()
+                if (!current.isShutdown && !current.isTerminated) {
+                    return current
+                }
+
+                val replacement = newVirtualThreadExecutor()
+                if (executorRef.compareAndSet(current, replacement)) {
+                    return replacement
+                }
+                replacement.shutdown()
+            }
+        }
+
+        internal fun shutdownVirtualThreadExecutor() {
+            executorRef.get().shutdown()
+        }
     }
 }

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/http/RestClientCoroutinesDslTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/http/RestClientCoroutinesDslTest.kt
@@ -1,6 +1,9 @@
 package io.bluetape4k.spring.http
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.KLogging
 import kotlinx.coroutines.cancelAndJoin
@@ -95,6 +98,62 @@ class RestClientCoroutinesDslTest {
             )
             val result: String = restClient.suspendPatch("/test", "payload", MediaType.APPLICATION_JSON)
             result shouldBeEqualTo "patched"
+        }
+
+    @Test
+    fun `suspendGet rejects empty body with contextual contract error`() =
+        runTest {
+            mockServer.enqueue(MockResponse().setResponseCode(204))
+
+            val error = assertFailsWith<IllegalStateException> {
+                restClient.suspendGet<String>("/empty-get")
+            }
+
+            val message = error.message.shouldNotBeNull()
+            message shouldContain "GET /empty-get"
+            message shouldContain "java.lang.String"
+        }
+
+    @Test
+    fun `suspendPost rejects empty body with contextual contract error`() =
+        runTest {
+            mockServer.enqueue(MockResponse().setResponseCode(204))
+
+            val error = assertFailsWith<IllegalStateException> {
+                restClient.suspendPost<String>("/empty-post", "payload", MediaType.APPLICATION_JSON)
+            }
+
+            val message = error.message.shouldNotBeNull()
+            message shouldContain "POST /empty-post"
+            message shouldContain "java.lang.String"
+        }
+
+    @Test
+    fun `suspendPut rejects empty body with contextual contract error`() =
+        runTest {
+            mockServer.enqueue(MockResponse().setResponseCode(204))
+
+            val error = assertFailsWith<IllegalStateException> {
+                restClient.suspendPut<String>("/empty-put", "payload", MediaType.APPLICATION_JSON)
+            }
+
+            val message = error.message.shouldNotBeNull()
+            message shouldContain "PUT /empty-put"
+            message shouldContain "java.lang.String"
+        }
+
+    @Test
+    fun `suspendPatch rejects empty body with contextual contract error`() =
+        runTest {
+            mockServer.enqueue(MockResponse().setResponseCode(204))
+
+            val error = assertFailsWith<IllegalStateException> {
+                restClient.suspendPatch<String>("/empty-patch", "payload", MediaType.APPLICATION_JSON)
+            }
+
+            val message = error.message.shouldNotBeNull()
+            message shouldContain "PATCH /empty-patch"
+            message shouldContain "java.lang.String"
         }
 
     @Test

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/virtualthread/AbstractVirtualThreadControllerTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/virtualthread/AbstractVirtualThreadControllerTest.kt
@@ -1,0 +1,66 @@
+package io.bluetape4k.spring.virtualthread
+
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+class AbstractVirtualThreadControllerTest {
+
+    @AfterEach
+    fun tearDown() {
+        AbstractVirtualThreadController.shutdownVirtualThreadExecutor()
+    }
+
+    @Test
+    fun `controller destroy shuts down current virtual thread executor`() {
+        val executor = AbstractVirtualThreadController.virtualThreadExecutor
+        executor.isShutdown.shouldBeFalse()
+
+        TestVirtualThreadController().closeVirtualThreadExecutor()
+
+        executor.isShutdown.shouldBeTrue()
+    }
+
+    @Test
+    fun `executor accessor recreates executor after shutdown`() {
+        val closedExecutor = AbstractVirtualThreadController.virtualThreadExecutor
+        TestVirtualThreadController().closeVirtualThreadExecutor()
+        closedExecutor.isShutdown.shouldBeTrue()
+
+        val replacementExecutor = AbstractVirtualThreadController.virtualThreadExecutor
+
+        replacementExecutor.isShutdown.shouldBeFalse()
+        (replacementExecutor === closedExecutor).shouldBeFalse()
+    }
+
+    @Test
+    fun `spring context shutdown closes controller executor`() {
+        val executor = AbstractVirtualThreadController.virtualThreadExecutor
+
+        contextRunner.run { context ->
+            context.getBean(TestVirtualThreadController::class.java)
+            executor.isShutdown.shouldBeFalse()
+        }
+
+        executor.isShutdown.shouldBeTrue()
+    }
+
+    private class TestVirtualThreadController: AbstractVirtualThreadController()
+
+    @Configuration(proxyBeanMethods = false)
+    private class TestConfiguration {
+
+        @Bean
+        fun testVirtualThreadController(): TestVirtualThreadController =
+            TestVirtualThreadController()
+    }
+
+    private companion object {
+        val contextRunner = ApplicationContextRunner()
+            .withUserConfiguration(TestConfiguration::class.java)
+    }
+}

--- a/spring-boot/hibernate-lettuce/src/main/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheActuatorAutoConfiguration.kt
+++ b/spring-boot/hibernate-lettuce/src/main/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheActuatorAutoConfiguration.kt
@@ -2,12 +2,10 @@ package io.bluetape4k.spring.boot.autoconfigure.cache.lettuce
 
 import io.bluetape4k.hibernate.cache.lettuce.LettuceNearCacheRegionFactory
 import jakarta.persistence.EntityManagerFactory
-import org.springframework.boot.actuate.endpoint.annotation.Endpoint
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration
 import org.springframework.context.annotation.Bean
 
 /**
@@ -35,9 +33,18 @@ import org.springframework.context.annotation.Bean
  * // GET /actuator/nearcache/{region}  → 특정 region 통계
  * ```
  */
-@AutoConfiguration(after = [LettuceNearCacheHibernateAutoConfiguration::class, HibernateJpaAutoConfiguration::class])
-@ConditionalOnClass(Endpoint::class, LettuceNearCacheRegionFactory::class, EntityManagerFactory::class)
-@ConditionalOnBean(EntityManagerFactory::class)
+@AutoConfiguration(
+    after = [LettuceNearCacheHibernateAutoConfiguration::class],
+    afterName = ["org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration"],
+)
+@ConditionalOnClass(
+    name = [
+        "org.springframework.boot.actuate.endpoint.annotation.Endpoint",
+        "io.bluetape4k.hibernate.cache.lettuce.LettuceNearCacheRegionFactory",
+        "jakarta.persistence.EntityManagerFactory",
+    ]
+)
+@ConditionalOnBean(type = ["jakarta.persistence.EntityManagerFactory"])
 @ConditionalOnProperty(
     prefix = "bluetape4k.cache.lettuce-near",
     name = ["enabled"],

--- a/spring-boot/hibernate-lettuce/src/main/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheHibernateAutoConfiguration.kt
+++ b/spring-boot/hibernate-lettuce/src/main/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheHibernateAutoConfiguration.kt
@@ -1,7 +1,6 @@
 package io.bluetape4k.spring.boot.autoconfigure.cache.lettuce
 
 import io.bluetape4k.hibernate.cache.lettuce.LettuceNearCacheRegionFactory
-import jakarta.persistence.EntityManagerFactory
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -37,7 +36,13 @@ import org.springframework.context.annotation.Bean
  * ```
  */
 @AutoConfiguration
-@ConditionalOnClass(LettuceNearCacheRegionFactory::class, EntityManagerFactory::class)
+@ConditionalOnClass(
+    name = [
+        "io.bluetape4k.hibernate.cache.lettuce.LettuceNearCacheRegionFactory",
+        "jakarta.persistence.EntityManagerFactory",
+        "org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer",
+    ]
+)
 @ConditionalOnProperty(
     prefix = "bluetape4k.cache.lettuce-near",
     name = ["enabled"],

--- a/spring-boot/hibernate-lettuce/src/main/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheMetricsAutoConfiguration.kt
+++ b/spring-boot/hibernate-lettuce/src/main/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheMetricsAutoConfiguration.kt
@@ -8,9 +8,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
-import org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration
-import org.springframework.boot.micrometer.metrics.autoconfigure.CompositeMeterRegistryAutoConfiguration
-import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration
 import org.springframework.context.annotation.Bean
 
 /**
@@ -37,15 +34,21 @@ import org.springframework.context.annotation.Bean
  * ```
  */
 @AutoConfiguration(
-    after = [
-        LettuceNearCacheHibernateAutoConfiguration::class,
-        HibernateJpaAutoConfiguration::class,
-        MetricsAutoConfiguration::class,
-        CompositeMeterRegistryAutoConfiguration::class,
+    after = [LettuceNearCacheHibernateAutoConfiguration::class],
+    afterName = [
+        "org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration",
+        "org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration",
+        "org.springframework.boot.micrometer.metrics.autoconfigure.CompositeMeterRegistryAutoConfiguration",
     ]
 )
-@ConditionalOnClass(LettuceNearCacheRegionFactory::class, EntityManagerFactory::class, MeterRegistry::class)
-@ConditionalOnBean(EntityManagerFactory::class, MeterRegistry::class)
+@ConditionalOnClass(
+    name = [
+        "io.bluetape4k.hibernate.cache.lettuce.LettuceNearCacheRegionFactory",
+        "jakarta.persistence.EntityManagerFactory",
+        "io.micrometer.core.instrument.MeterRegistry",
+    ]
+)
+@ConditionalOnBean(type = ["jakarta.persistence.EntityManagerFactory", "io.micrometer.core.instrument.MeterRegistry"])
 @ConditionalOnProperty(
     prefix = "bluetape4k.cache.lettuce-near.metrics",
     name = ["enabled"],

--- a/spring-boot/hibernate-lettuce/src/test/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheAutoConfigurationTest.kt
+++ b/spring-boot/hibernate-lettuce/src/test/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheAutoConfigurationTest.kt
@@ -1,16 +1,17 @@
 package io.bluetape4k.spring.boot.autoconfigure.cache.lettuce
 
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import jakarta.persistence.EntityManagerFactory
 import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldHaveSize
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import jakarta.persistence.EntityManagerFactory
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.getBean
 import org.springframework.beans.factory.getBeansOfType
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer
+import org.springframework.boot.test.context.FilteredClassLoader
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import java.util.function.Supplier
 
@@ -45,6 +46,18 @@ class LettuceNearCacheAutoConfigurationTest {
         contextRunner
             .withPropertyValues("bluetape4k.cache.lettuce-near.enabled=false")
             .run { context ->
+                context.getBeansOfType<HibernatePropertiesCustomizer>().shouldBeEmpty()
+            }
+    }
+
+    @Test
+    fun `Hibernate customizer가 classpath에 없으면 auto configuration이 안전하게 비활성화된다`() {
+        contextRunner
+            .withClassLoader(
+                FilteredClassLoader("org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer")
+            )
+            .run { context ->
+                context.getStartupFailure() shouldBeEqualTo null
                 context.getBeansOfType<HibernatePropertiesCustomizer>().shouldBeEmpty()
             }
     }
@@ -143,7 +156,17 @@ class LettuceNearCacheAutoConfigurationTest {
     fun `actuator auto configuration registers endpoint when entity manager exists`() {
         metricsContextRunner.run { context ->
             context.getBeansOfType<LettuceNearCacheActuatorEndpoint>().shouldHaveSize(1)
-        }
+            }
+    }
+
+    @Test
+    fun `actuator가 classpath에 없으면 endpoint auto configuration이 안전하게 비활성화된다`() {
+        metricsContextRunner
+            .withClassLoader(FilteredClassLoader("org.springframework.boot.actuate.endpoint.annotation.Endpoint"))
+            .run { context ->
+                context.getStartupFailure() shouldBeEqualTo null
+                context.getBeansOfType<LettuceNearCacheActuatorEndpoint>().shouldBeEmpty()
+            }
     }
 
     @Test
@@ -152,6 +175,16 @@ class LettuceNearCacheAutoConfigurationTest {
             .withBean(SimpleMeterRegistry::class.java, Supplier { SimpleMeterRegistry() })
             .withPropertyValues("bluetape4k.cache.lettuce-near.metrics.enabled=false")
             .run { context ->
+                context.getBeansOfType<LettuceNearCacheMetricsBinder>().shouldBeEmpty()
+            }
+    }
+
+    @Test
+    fun `micrometer가 classpath에 없으면 metrics auto configuration이 안전하게 비활성화된다`() {
+        metricsContextRunner
+            .withClassLoader(FilteredClassLoader("io.micrometer.core.instrument.MeterRegistry"))
+            .run { context ->
+                context.getStartupFailure() shouldBeEqualTo null
                 context.getBeansOfType<LettuceNearCacheMetricsBinder>().shouldBeEmpty()
             }
     }

--- a/spring-boot/redis/src/test/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializersTest.kt
+++ b/spring-boot/redis/src/test/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializersTest.kt
@@ -3,7 +3,7 @@ package io.bluetape4k.spring.redis.serializer
 import io.bluetape4k.support.emptyByteArray
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
-import org.junit.jupiter.api.Assertions.assertArrayEquals
+import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -70,7 +70,9 @@ class RedisBinarySerializersTest: AbstractRedisSerializerTest() {
         val bytes = newSampleBytes()
         val compressed = serializer.serialize(bytes)
         compressed.shouldNotBeNull()
-        assertArrayEquals(bytes, serializer.deserialize(compressed))
+        val restored = serializer.deserialize(compressed)
+        restored.shouldNotBeNull()
+        restored.contentEquals(bytes).shouldBeTrue()
     }
 
     @ParameterizedTest(name = "[{1}] null 직렬화 → emptyByteArray 반환")

--- a/spring-boot/redis/src/test/kotlin/io/bluetape4k/spring/redis/serializer/RedisCompressSerializerTest.kt
+++ b/spring-boot/redis/src/test/kotlin/io/bluetape4k/spring/redis/serializer/RedisCompressSerializerTest.kt
@@ -6,7 +6,7 @@ import io.bluetape4k.support.emptyByteArray
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeNull
-import org.junit.jupiter.api.Assertions.assertArrayEquals
+import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -49,6 +49,7 @@ class RedisCompressSerializerTest: AbstractRedisSerializerTest() {
         compressed.shouldNotBeNull()
 
         val restored = serializer.deserialize(compressed)
-        assertArrayEquals(bytes, restored)
+        restored.shouldNotBeNull()
+        restored.contentEquals(bytes).shouldBeTrue()
     }
 }

--- a/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/TimeBlockTest.kt
+++ b/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/TimeBlockTest.kt
@@ -22,8 +22,6 @@ import io.bluetape4k.assertions.shouldNotBeEqualTo
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import io.bluetape4k.assertions.assertFailsWith
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class TimeBlockTest: AbstractPeriodTest() {
 
@@ -402,20 +400,20 @@ class TimeBlockTest: AbstractPeriodTest() {
     @Test
     fun `hasInsideWith with all ZonedDateTime`() {
         with(testData) {
-            assertFalse { reference hasInsideWith before }
-            assertFalse { reference hasInsideWith startTouching }
-            assertFalse { reference hasInsideWith startInside }
-            assertFalse { reference hasInsideWith insideStartTouching }
+            (reference hasInsideWith before).shouldBeFalse()
+            (reference hasInsideWith startTouching).shouldBeFalse()
+            (reference hasInsideWith startInside).shouldBeFalse()
+            (reference hasInsideWith insideStartTouching).shouldBeFalse()
 
-            assertTrue { reference hasInsideWith enclosingStartTouching }
-            assertTrue { reference hasInsideWith enclosing }
-            assertTrue { reference hasInsideWith enclosingEndTouching }
-            assertTrue { reference hasInsideWith exactMatch }
+            (reference hasInsideWith enclosingStartTouching).shouldBeTrue()
+            (reference hasInsideWith enclosing).shouldBeTrue()
+            (reference hasInsideWith enclosingEndTouching).shouldBeTrue()
+            (reference hasInsideWith exactMatch).shouldBeTrue()
 
-            assertFalse { reference hasInsideWith inside }
-            assertFalse { reference hasInsideWith insideEndTouching }
-            assertFalse { reference hasInsideWith endTouching }
-            assertFalse { reference hasInsideWith after }
+            (reference hasInsideWith inside).shouldBeFalse()
+            (reference hasInsideWith insideEndTouching).shouldBeFalse()
+            (reference hasInsideWith endTouching).shouldBeFalse()
+            (reference hasInsideWith after).shouldBeFalse()
         }
     }
 
@@ -423,20 +421,20 @@ class TimeBlockTest: AbstractPeriodTest() {
     fun `intersectWith with ZonedDateTime`() {
 
         with(testData) {
-            assertFalse { reference intersectWith before }
-            assertTrue { reference intersectWith startTouching }
-            assertTrue { reference intersectWith startInside }
-            assertTrue { reference intersectWith insideStartTouching }
+            (reference intersectWith before).shouldBeFalse()
+            (reference intersectWith startTouching).shouldBeTrue()
+            (reference intersectWith startInside).shouldBeTrue()
+            (reference intersectWith insideStartTouching).shouldBeTrue()
 
-            assertTrue { reference intersectWith enclosingStartTouching }
-            assertTrue { reference intersectWith enclosing }
-            assertTrue { reference intersectWith enclosingEndTouching }
-            assertTrue { reference intersectWith exactMatch }
+            (reference intersectWith enclosingStartTouching).shouldBeTrue()
+            (reference intersectWith enclosing).shouldBeTrue()
+            (reference intersectWith enclosingEndTouching).shouldBeTrue()
+            (reference intersectWith exactMatch).shouldBeTrue()
 
-            assertTrue { reference intersectWith inside }
-            assertTrue { reference intersectWith insideEndTouching }
-            assertTrue { reference intersectWith endTouching }
-            assertFalse { reference intersectWith after }
+            (reference intersectWith inside).shouldBeTrue()
+            (reference intersectWith insideEndTouching).shouldBeTrue()
+            (reference intersectWith endTouching).shouldBeTrue()
+            (reference intersectWith after).shouldBeFalse()
         }
     }
 
@@ -444,20 +442,20 @@ class TimeBlockTest: AbstractPeriodTest() {
     fun `overlapWith with ZonedDateTime`() {
 
         with(testData) {
-            assertFalse { reference overlapWith before }
-            assertFalse { reference overlapWith startTouching }
-            assertTrue { reference overlapWith startInside }
-            assertTrue { reference overlapWith insideStartTouching }
+            (reference overlapWith before).shouldBeFalse()
+            (reference overlapWith startTouching).shouldBeFalse()
+            (reference overlapWith startInside).shouldBeTrue()
+            (reference overlapWith insideStartTouching).shouldBeTrue()
 
-            assertTrue { reference overlapWith enclosingStartTouching }
-            assertTrue { reference overlapWith enclosing }
-            assertTrue { reference overlapWith enclosingEndTouching }
-            assertTrue { reference overlapWith exactMatch }
+            (reference overlapWith enclosingStartTouching).shouldBeTrue()
+            (reference overlapWith enclosing).shouldBeTrue()
+            (reference overlapWith enclosingEndTouching).shouldBeTrue()
+            (reference overlapWith exactMatch).shouldBeTrue()
 
-            assertTrue { reference overlapWith inside }
-            assertTrue { reference overlapWith insideEndTouching }
-            assertFalse { reference overlapWith endTouching }
-            assertFalse { reference overlapWith after }
+            (reference overlapWith inside).shouldBeTrue()
+            (reference overlapWith insideEndTouching).shouldBeTrue()
+            (reference overlapWith endTouching).shouldBeFalse()
+            (reference overlapWith after).shouldBeFalse()
         }
     }
 
@@ -466,20 +464,20 @@ class TimeBlockTest: AbstractPeriodTest() {
         val block = TimeBlock(start, end)
 
         // before
-        assertFalse { block intersectWith TimeBlock(start - 2.hours(), start - 1.hours()) }
-        assertTrue { block intersectWith TimeBlock(start - 1.hours(), start) }
-        assertTrue { block intersectWith TimeBlock(start - 1.hours(), start + 1.nanos()) }
+        (block intersectWith TimeBlock(start - 2.hours(), start - 1.hours())).shouldBeFalse()
+        (block intersectWith TimeBlock(start - 1.hours(), start)).shouldBeTrue()
+        (block intersectWith TimeBlock(start - 1.hours(), start + 1.nanos())).shouldBeTrue()
 
         // after
-        assertFalse { block intersectWith TimeBlock(end + 1.hours(), end + 2.hours()) }
-        assertTrue { block intersectWith TimeBlock(end, end + 1.nanos()) }
-        assertTrue { block intersectWith TimeBlock(end - 1.nanos(), end + 1.nanos()) }
+        (block intersectWith TimeBlock(end + 1.hours(), end + 2.hours())).shouldBeFalse()
+        (block intersectWith TimeBlock(end, end + 1.nanos())).shouldBeTrue()
+        (block intersectWith TimeBlock(end - 1.nanos(), end + 1.nanos())).shouldBeTrue()
 
         // intersection
-        assertTrue { block intersectWith block }
-        assertTrue { block intersectWith TimeBlock(start + 1.nanos(), end + 1.nanos()) }
-        assertTrue { block intersectWith TimeBlock(start - 1.nanos(), start + 1.nanos()) }
-        assertTrue { block intersectWith TimeBlock(end - 1.nanos(), end + 1.nanos()) }
+        (block intersectWith block).shouldBeTrue()
+        (block intersectWith TimeBlock(start + 1.nanos(), end + 1.nanos())).shouldBeTrue()
+        (block intersectWith TimeBlock(start - 1.nanos(), start + 1.nanos())).shouldBeTrue()
+        (block intersectWith TimeBlock(end - 1.nanos(), end + 1.nanos())).shouldBeTrue()
     }
 
     @Test
@@ -553,112 +551,112 @@ class TimeBlockTest: AbstractPeriodTest() {
             // reference
             reference.start shouldBeEqualTo start
             reference.end shouldBeEqualTo end
-            assertTrue { reference.readonly }
+            (reference.readonly).shouldBeTrue()
 
             // after
-            assertTrue { after.readonly }
-            assertTrue { after.start < start }
-            assertTrue { after.end < start }
+            (after.readonly).shouldBeTrue()
+            (after.start < start).shouldBeTrue()
+            (after.end < start).shouldBeTrue()
 
-            assertFalse { reference.hasInsideWith(after.start) }
-            assertFalse { reference.hasInsideWith(after.end) }
+            (reference.hasInsideWith(after.start)).shouldBeFalse()
+            (reference.hasInsideWith(after.end)).shouldBeFalse()
 
             // start touching
-            assertTrue { startTouching.readonly }
-            assertTrue { startTouching.start < start }
-            assertTrue { startTouching.end == start }
+            (startTouching.readonly).shouldBeTrue()
+            (startTouching.start < start).shouldBeTrue()
+            (startTouching.end == start).shouldBeTrue()
 
-            assertFalse { reference.hasInsideWith(startTouching.start) }
-            assertTrue { reference.hasInsideWith(startTouching.end) }
+            (reference.hasInsideWith(startTouching.start)).shouldBeFalse()
+            (reference.hasInsideWith(startTouching.end)).shouldBeTrue()
 
             // start inside
-            assertTrue { startInside.readonly }
-            assertTrue { startInside.start < start }
-            assertTrue { startInside.end < end }
+            (startInside.readonly).shouldBeTrue()
+            (startInside.start < start).shouldBeTrue()
+            (startInside.end < end).shouldBeTrue()
 
-            assertFalse { reference.hasInsideWith(startInside.start) }
-            assertTrue { reference.hasInsideWith(startInside.end) }
+            (reference.hasInsideWith(startInside.start)).shouldBeFalse()
+            (reference.hasInsideWith(startInside.end)).shouldBeTrue()
 
 
             // inside start touching
-            assertTrue { insideStartTouching.readonly }
-            assertTrue { insideStartTouching.start == start }
-            assertTrue { insideStartTouching.end > end }
+            (insideStartTouching.readonly).shouldBeTrue()
+            (insideStartTouching.start == start).shouldBeTrue()
+            (insideStartTouching.end > end).shouldBeTrue()
 
-            assertTrue { reference.hasInsideWith(insideStartTouching.start) }
-            assertFalse { reference.hasInsideWith(insideStartTouching.end) }
+            (reference.hasInsideWith(insideStartTouching.start)).shouldBeTrue()
+            (reference.hasInsideWith(insideStartTouching.end)).shouldBeFalse()
 
             // enclosing start touching
-            assertTrue { enclosingStartTouching.readonly }
-            assertTrue { enclosingStartTouching.start == start }
-            assertTrue { enclosingStartTouching.end < end }
+            (enclosingStartTouching.readonly).shouldBeTrue()
+            (enclosingStartTouching.start == start).shouldBeTrue()
+            (enclosingStartTouching.end < end).shouldBeTrue()
 
-            assertTrue { reference.hasInsideWith(enclosingStartTouching.start) }
-            assertTrue { reference.hasInsideWith(enclosingStartTouching.end) }
+            (reference.hasInsideWith(enclosingStartTouching.start)).shouldBeTrue()
+            (reference.hasInsideWith(enclosingStartTouching.end)).shouldBeTrue()
 
             // enclosing
-            assertTrue { enclosing.readonly }
-            assertTrue { enclosing.start > start }
-            assertTrue { enclosing.end < end }
+            (enclosing.readonly).shouldBeTrue()
+            (enclosing.start > start).shouldBeTrue()
+            (enclosing.end < end).shouldBeTrue()
 
-            assertTrue { reference.hasInsideWith(enclosing.start) }
-            assertTrue { reference.hasInsideWith(enclosing.end) }
+            (reference.hasInsideWith(enclosing.start)).shouldBeTrue()
+            (reference.hasInsideWith(enclosing.end)).shouldBeTrue()
 
             // enclosing end touching
-            assertTrue { enclosingEndTouching.readonly }
-            assertTrue { enclosingEndTouching.start > start }
-            assertTrue { enclosingEndTouching.end == end }
+            (enclosingEndTouching.readonly).shouldBeTrue()
+            (enclosingEndTouching.start > start).shouldBeTrue()
+            (enclosingEndTouching.end == end).shouldBeTrue()
 
-            assertTrue { reference.hasInsideWith(enclosingEndTouching.start) }
-            assertTrue { reference.hasInsideWith(enclosingEndTouching.end) }
+            (reference.hasInsideWith(enclosingEndTouching.start)).shouldBeTrue()
+            (reference.hasInsideWith(enclosingEndTouching.end)).shouldBeTrue()
 
             // exact match
-            assertTrue { exactMatch.readonly }
-            assertTrue { exactMatch.start == start }
-            assertTrue { exactMatch.end == end }
+            (exactMatch.readonly).shouldBeTrue()
+            (exactMatch.start == start).shouldBeTrue()
+            (exactMatch.end == end).shouldBeTrue()
 
-            assertTrue { reference.hasInsideWith(exactMatch.start) }
-            assertTrue { reference.hasInsideWith(exactMatch.end) }
+            (reference.hasInsideWith(exactMatch.start)).shouldBeTrue()
+            (reference.hasInsideWith(exactMatch.end)).shouldBeTrue()
 
             // inside
-            assertTrue { inside.readonly }
-            assertTrue { inside.start < start }
-            assertTrue { inside.end > end }
+            (inside.readonly).shouldBeTrue()
+            (inside.start < start).shouldBeTrue()
+            (inside.end > end).shouldBeTrue()
 
-            assertFalse { reference.hasInsideWith(inside.start) }
-            assertFalse { reference.hasInsideWith(inside.end) }
+            (reference.hasInsideWith(inside.start)).shouldBeFalse()
+            (reference.hasInsideWith(inside.end)).shouldBeFalse()
 
             // inside end touching
-            assertTrue { insideEndTouching.readonly }
-            assertTrue { insideEndTouching.start < start }
-            assertTrue { insideEndTouching.end == end }
+            (insideEndTouching.readonly).shouldBeTrue()
+            (insideEndTouching.start < start).shouldBeTrue()
+            (insideEndTouching.end == end).shouldBeTrue()
 
-            assertFalse { reference.hasInsideWith(insideEndTouching.start) }
-            assertTrue { reference.hasInsideWith(insideEndTouching.end) }
+            (reference.hasInsideWith(insideEndTouching.start)).shouldBeFalse()
+            (reference.hasInsideWith(insideEndTouching.end)).shouldBeTrue()
 
             // end inside
-            assertTrue { endInside.readonly }
-            assertTrue { endInside.start in start..end }
-            assertTrue { endInside.end > end }
+            (endInside.readonly).shouldBeTrue()
+            (endInside.start in start..end).shouldBeTrue()
+            (endInside.end > end).shouldBeTrue()
 
-            assertTrue { reference.hasInsideWith(endInside.start) }
-            assertFalse { reference.hasInsideWith(endInside.end) }
+            (reference.hasInsideWith(endInside.start)).shouldBeTrue()
+            (reference.hasInsideWith(endInside.end)).shouldBeFalse()
 
             // end Touching
-            assertTrue { endTouching.readonly }
-            assertTrue { endTouching.start == end }
-            assertTrue { endTouching.end > end }
+            (endTouching.readonly).shouldBeTrue()
+            (endTouching.start == end).shouldBeTrue()
+            (endTouching.end > end).shouldBeTrue()
 
-            assertTrue { reference.hasInsideWith(endTouching.start) }
-            assertFalse { reference.hasInsideWith(endTouching.end) }
+            (reference.hasInsideWith(endTouching.start)).shouldBeTrue()
+            (reference.hasInsideWith(endTouching.end)).shouldBeFalse()
 
             // before
-            assertTrue { before.readonly }
-            assertTrue { before.start > end }
-            assertTrue { before.end > end }
+            (before.readonly).shouldBeTrue()
+            (before.start > end).shouldBeTrue()
+            (before.end > end).shouldBeTrue()
 
-            assertFalse { reference.hasInsideWith(before.start) }
-            assertFalse { reference.hasInsideWith(before.end) }
+            (reference.hasInsideWith(before.start)).shouldBeFalse()
+            (reference.hasInsideWith(before.end)).shouldBeFalse()
         }
     }
 

--- a/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
+++ b/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
@@ -17,6 +17,7 @@ import java.util.concurrent.StructuredTaskScope
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Function
 
 /**
@@ -55,6 +56,8 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
          *
          * [joinAction]이 실행되는 동안 [deadline]이 초과되면 owner thread를 interrupt하여
          * [InterruptedException]을 발생시키고, 이를 [TimeoutException]으로 변환합니다.
+         * timeout interrupt가 아닌 기존/외부 interrupt는 [InterruptedException]으로 보존하고
+         * caller thread의 interrupt 상태를 복구합니다.
          *
          * ## 계약
          * - [joinAction]은 [InterruptedException]을 catch하지 않고 전파해야 합니다.
@@ -75,21 +78,31 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
             val scheduler = ScheduledThreadPoolExecutor(1) { r ->
                 Thread(r, threadName).apply { isDaemon = true }
             }
+            val timeoutTriggered = AtomicBoolean(false)
             val timeoutFuture = scheduler.schedule(
-                { ownerThread.interrupt() },
+                {
+                    timeoutTriggered.set(true)
+                    ownerThread.interrupt()
+                },
                 remaining.toNanos(),
                 TimeUnit.NANOSECONDS
             )
+            var preserveInterrupt = false
             try {
                 joinAction()
             } catch (e: InterruptedException) {
-                throw TimeoutException("joinUntil deadline exceeded")
+                if (timeoutTriggered.get()) {
+                    throw TimeoutException("joinUntil deadline exceeded")
+                }
+                preserveInterrupt = true
+                ownerThread.interrupt()
+                throw e
             } finally {
                 timeoutFuture.cancel(false)
                 scheduler.shutdownNow()
-                // finally 이후 scheduled interrupt가 늦게 발화하더라도 interrupt 상태가
-                // caller thread로 누출되지 않도록 항상 clear
-                Thread.interrupted()
+                if (timeoutTriggered.get() && !preserveInterrupt) {
+                    Thread.interrupted()
+                }
             }
         }
     }

--- a/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderExtTest.kt
+++ b/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderExtTest.kt
@@ -13,7 +13,10 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
 import java.time.Instant
+import java.util.concurrent.Executors
 import java.util.concurrent.StructuredTaskScope
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import io.bluetape4k.assertions.assertFailsWith
 
 /**
@@ -80,12 +83,88 @@ class Jdk25StructuredTaskScopeProviderExtTest {
 
     @Test
     fun `withAll joinUntil 이미 지난 데드라인에서 TimeoutException 이 발생해야 한다`() {
-        assertFailsWith<java.util.concurrent.TimeoutException> {
+        assertFailsWith<TimeoutException> {
             provider.withAll { scope ->
                 scope.fork { Thread.sleep(500); 1 }
                 scope.joinUntil(Instant.now().minusSeconds(1))
                 scope.throwIfFailed()
             }
+        }
+    }
+
+    @Test
+    fun `interruptJoinUntil timeout interrupt는 TimeoutException 으로 변환하고 interrupt 상태를 clear 해야 한다`() {
+        try {
+            assertFailsWith<TimeoutException> {
+                Jdk25StructuredTaskScopeProvider.interruptJoinUntil(
+                    deadline = Instant.now().plusMillis(100),
+                    threadName = "jdk25-test-timeout",
+                ) {
+                    Thread.sleep(5_000)
+                }
+            }
+
+            Thread.currentThread().isInterrupted.shouldBeFalse()
+        } finally {
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `interruptJoinUntil 기존 interrupt는 InterruptedException 으로 보존해야 한다`() {
+        try {
+            Thread.currentThread().interrupt()
+
+            assertFailsWith<InterruptedException> {
+                Jdk25StructuredTaskScopeProvider.interruptJoinUntil(
+                    deadline = Instant.now().plusSeconds(5),
+                    threadName = "jdk25-test-pre-interrupted",
+                ) {
+                    Thread.sleep(10)
+                }
+            }
+
+            Thread.currentThread().isInterrupted.shouldBeTrue()
+        } finally {
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `interruptJoinUntil 외부 interrupt는 InterruptedException 으로 보존해야 한다`() {
+        val ownerThread = Thread.currentThread()
+        val interrupter = Executors.newSingleThreadScheduledExecutor()
+        try {
+            assertFailsWith<InterruptedException> {
+                interrupter.schedule({ ownerThread.interrupt() }, 100, TimeUnit.MILLISECONDS)
+                Jdk25StructuredTaskScopeProvider.interruptJoinUntil(
+                    deadline = Instant.now().plusSeconds(5),
+                    threadName = "jdk25-test-external-interrupt",
+                ) {
+                    Thread.sleep(5_000)
+                }
+            }
+
+            Thread.currentThread().isInterrupted.shouldBeTrue()
+        } finally {
+            interrupter.shutdownNow()
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `interruptJoinUntil 정상 완료는 interrupt 상태를 변경하지 않아야 한다`() {
+        try {
+            Jdk25StructuredTaskScopeProvider.interruptJoinUntil(
+                deadline = Instant.now().plusSeconds(5),
+                threadName = "jdk25-test-normal-completion",
+            ) {
+                Thread.sleep(10)
+            }
+
+            Thread.currentThread().isInterrupted.shouldBeFalse()
+        } finally {
+            Thread.interrupted()
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #956

- PR 제목: test: migrate residual assertion and coroutine patterns

- Replace raw JUnit/kotlin.test assertions in issue #956 hotspot tests with bluetape4k assertion helpers.
- Move blocking coroutine test wrappers to repo-native `runSuspendIO` plus coroutine timeout where needed.
- Keep ByteArray compression round-trip checks content-based without reintroducing `assertArrayEquals`.
- Harden the Redisson read-through demo retry/timeout budget after full-suite `test` exposed a LocalCachedMap command write timeout under suite load.
- Align the Kafka4 catalog line with Spring Kafka 4.1 embedded-test ABI after full-suite `test` exposed `KafkaClusterTestKit.clientProperties()` drift.
- Extend Kafka4 embedded KRaft admin timeouts after full-suite `test` exposed slower topic creation during `WordCountExamples` context startup.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- `:bluetape4k-javatimes:test --tests "io.bluetape4k.javatimes.period.TimeBlockTest"`
- `:bluetape4k-cache-core:test --tests "io.bluetape4k.cache.nearcache.NearCacheResilienceConfigBuilderTest"`
- `:bluetape4k-bucket4j:test --tests "io.bluetape4k.bucket4j.ratelimit.local.LocalSuspendRateLimiterTest"`
- `:bluetape4k-spring-boot-redis:test --tests "io.bluetape4k.spring.redis.serializer.RedisBinarySerializersTest" --tests "io.bluetape4k.spring.redis.serializer.RedisCompressSerializerTest"`
- `:bluetape4k-spring-boot-cassandra:test --tests "io.bluetape4k.spring.cassandra.cql.AsyncCqlOperationsCoroutinesTest"`
- `:bluetape4k-examples-redisson-demo:test --tests "io.bluetape4k.examples.redisson.coroutines.cachestrategy.CacheReadThroughExample*"`
- `:bluetape4k-kafka4:test --tests "org.springframework.kafka.core.KafkaTemplateTests" --tests "org.springframework.kafka.annotation.BatchListenerConversionTests" --tests "org.springframework.kafka.annotation.BatchListenerConversion2Tests" --tests "org.springframework.kafka.streams.KafkaStreamsTests" --tests "org.springframework.kafka.streams.KafkaStreamsBranchTests" --tests "org.springframework.kafka.streams.WordCountExamples"`
- `:bluetape4k-kafka4:test --tests "org.springframework.kafka.streams.WordCountExamples"`
- `:bluetape4k-kafka4:test`
- `:bluetape4k-testcontainers:test --tests "io.bluetape4k.testcontainers.database.CockroachServerTest*"`
- `repo-test-summary -- ./gradlew --no-parallel test` (`BUILD SUCCESSFUL in 8m 27s`)
- Issue #956 violation scan for the touched hotspot files
- `git diff --check`

Fixes #956

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #956, milestone `1.12.0`, assignee `debop`
- PR: #971, head `3ff22caf146821191c615ecf7aa71feb5ae372f3`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `test/issue-956-assertion-coroutine-cleanup`
- Labels: `test`, `tech-debt`
- State: `MERGED`, merge commit `9a9c065e1ea7091a2f2c9a7aa38b107321f9bcb8`
- CI: - Keep ByteArray compression round-trip checks content-based without reintroducing `assertArrayEquals`. / - `repo-test-summary -- ./gradlew --no-parallel test` (`BUILD SUCCESSFUL in 8m 27s`) / - [x] Full-suite Kafka4 KRaft topic-admin timeout is diagnosed; embedded Kafka admin timeouts are explicit and Kafka4 full module test passes.

## DoD Status

- [x] Touched raw JUnit/kotlin.test assertions use bluetape4k assertion helpers.
- [x] Touched blocking coroutine test wrappers use repo-native coroutine test runners.
- [x] Targeted tests for each affected module pass.
- [x] Full-suite Redisson failure is diagnosed and Redisson read-through targeted test passes after hardening.
- [x] Full-suite Kafka4 ABI failure is diagnosed; Kafka4 classpath is aligned to Spring Kafka 4.1 embedded-test ABI and Kafka4 full module test passes.
- [x] Full-suite Kafka4 KRaft topic-admin timeout is diagnosed; embedded Kafka admin timeouts are explicit and Kafka4 full module test passes.
- [x] Full-suite CockroachDB clock-skew failure is isolated as transient resource/clock skew; targeted rerun passes and full repository test passes after external Gradle contention ended.
- [x] Full repository `test` passes with `repo-test-summary -- ./gradlew --no-parallel test`.
- [x] PR metadata mirrors issue #956: assignee `debop`, milestone `1.12.0`, labels `test` and `tech-debt`.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #971 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9a9c065e1ea7091a2f2c9a7aa38b107321f9bcb8`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
