### PR TITLE
ci: cover telemetry infra test lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
       ktor: ${{ steps.filter.outputs.ktor }}
       key-utils: ${{ steps.filter.outputs.key-utils }}
       infra: ${{ steps.filter.outputs.infra }}
+      telemetry-infra: ${{ steps.filter.outputs.telemetry-infra }}
       data: ${{ steps.filter.outputs.data }}
     steps:
       - uses: actions/checkout@v7
@@ -134,6 +135,9 @@ jobs:
               - 'infra/lettuce/**'
               - 'cache/cache-lettuce/**'
               - 'cache/cache-redisson/**'
+            telemetry-infra:
+              - 'infra/opentelemetry/**'
+              - 'infra/kafka-logback/**'
             data:
               - 'data/**'
               - 'cache/hibernate-cache-lettuce/**'
@@ -559,6 +563,67 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 30
 
+  # ── 7-a. Telemetry Infra 테스트 (Kafka / OpenTelemetry) ─────────────────
+  test-telemetry-infra:
+    name: Test / Telemetry Infra
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['telemetry-infra'] == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Test telemetry infra modules
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          shell: bash
+          command: |
+            ./gradlew \
+              :bluetape4k-opentelemetry:test \
+              :bluetape4k-kafka-logback:test \
+              --max-workers=1 \
+              --no-configuration-cache
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Generate Kover XML report
+        if: always()
+        run: |
+          ./gradlew \
+            :bluetape4k-opentelemetry:koverXmlReport \
+            :bluetape4k-kafka-logback:koverXmlReport \
+            --max-workers=1 \
+            --no-configuration-cache
+        continue-on-error: true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-telemetry-infra
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 30
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-telemetry-infra
+          path: '**/build/reports/kover/'
+          retention-days: 30
+
   # ── 7-b. Data 모듈 테스트 (Testcontainers) ───────────────────────────────
   test-data:
     name: Test / Data
@@ -640,7 +705,7 @@ jobs:
     name: Coverage Report
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [test-core, test-io, test-io-http, test-ktor, test-key-utils, test-infra, test-data]
+    needs: [test-core, test-io, test-io-http, test-ktor, test-key-utils, test-infra, test-telemetry-infra, test-data]
     if: always()
     steps:
       - uses: actions/checkout@v7
@@ -679,7 +744,7 @@ jobs:
     name: CI Status
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [gitleaks, validate-wrapper, changes, build, test-core, test-io, test-io-http, test-ktor, test-key-utils, test-infra, test-data, coverage-report]
+    needs: [gitleaks, validate-wrapper, changes, build, test-core, test-io, test-io-http, test-ktor, test-key-utils, test-infra, test-telemetry-infra, test-data, coverage-report]
     if: always()
     steps:
       - name: Check all jobs

--- a/docs/lessons/2026-07-04-issue-927-telemetry-ci.md
+++ b/docs/lessons/2026-07-04-issue-927-telemetry-ci.md
@@ -1,0 +1,30 @@
+# Issue #927 Telemetry CI Coverage
+
+## Context
+
+Push CI skipped module tests for changes under `infra/opentelemetry/**` and `infra/kafka-logback/**`. Nightly already covered OpenTelemetry, but push CI still allowed telemetry and logging changes to pass without targeted module tests.
+
+## Decision
+
+Add a dedicated `telemetry-infra` path-filter output and `Test / Telemetry Infra` job instead of adding these modules to the Redis-focused infra lane.
+
+## Rationale
+
+- `infra/kafka-logback` uses Kafka Testcontainers and should run serially with `--max-workers=1`.
+- `infra/opentelemetry` is observability-focused and already has a Nightly shape, but needs push CI coverage when its own files change.
+- A separate job keeps Redis/cache infra results distinct from telemetry/logback failures.
+
+## Verification
+
+- `actionlint .github/workflows/ci.yml`
+- Backslash-single-quote guard for GitHub Actions expressions
+- `git diff --check`
+- Gradle project/task wiring dry-run
+- `:bluetape4k-opentelemetry:test`
+- `:bluetape4k-kafka-logback:test`
+- Matching Kover XML tasks
+
+## Future Guard
+
+When adding CI path filters for a module family, update all four surfaces together: path-filter output, test job, `coverage-report.needs`, and `ci-status.needs`.
+

--- a/docs/review/2026-07-04-issue-927-telemetry-ci-review.md
+++ b/docs/review/2026-07-04-issue-927-telemetry-ci-review.md
@@ -1,0 +1,37 @@
+# Issue #927 Telemetry CI Coverage Review
+
+## Scope
+
+- Issue: #927 `ci: Run telemetry infra tests for kafka-logback and opentelemetry changes`
+- Changed file: `.github/workflows/ci.yml`
+- Modules covered by the new CI lane:
+  - `:bluetape4k-opentelemetry`
+  - `:bluetape4k-kafka-logback`
+
+## 7-Tier Review
+
+| Tier | Verdict | Evidence |
+|------|---------|----------|
+| 1. Security | PASS | The change adds CI execution only. No secrets, permissions, credentials, or production runtime paths changed. |
+| 2. Architecture | PASS | Telemetry infra gets a dedicated `telemetry-infra` filter/job instead of being mixed into the Redis-specific infra lane. |
+| 3. Reliability | PASS | `kafka-logback` uses Testcontainers, so the job runs with `--max-workers=1` and `--no-configuration-cache`. |
+| 4. Code quality | PASS | Workflow wiring is narrow: filter output, job, coverage needs, and status needs are synchronized. |
+| 5. Testing | PASS | Actual telemetry test command passed locally: OpenTelemetry 78 tests and Kafka Logback 22 tests. |
+| 6. Performance | PASS | The lane is path-filtered and does not expand unrelated CI jobs for non-telemetry changes. |
+| 7. Documentation / Evidence | PASS | This review plus the lesson document record the issue boundary, commands, and future guard. |
+
+## Validation
+
+- `actionlint .github/workflows/ci.yml`: PASS.
+- Backslash-single-quote guard for `.github/workflows/ci.yml`: PASS, no escaped expression quotes.
+- `git diff --check`: PASS.
+- Gradle project/task wiring dry-run for `:bluetape4k-opentelemetry` and `:bluetape4k-kafka-logback`: PASS.
+- `./gradlew :bluetape4k-opentelemetry:test :bluetape4k-kafka-logback:test --max-workers=1 --no-configuration-cache`: PASS.
+- `./gradlew :bluetape4k-opentelemetry:koverXmlReport :bluetape4k-kafka-logback:koverXmlReport --max-workers=1 --no-configuration-cache`: PASS.
+
+## Findings
+
+- P0: 0
+- P1: 0
+- P2/P3: 0 open
+


### PR DESCRIPTION
## Summary

Closes #927

- PR 제목: ci: cover telemetry infra test lanes

- Add a dedicated `telemetry-infra` path-filter output for `infra/opentelemetry/**` and `infra/kafka-logback/**`.
- Add `Test / Telemetry Infra` to run `:bluetape4k-opentelemetry:test` and `:bluetape4k-kafka-logback:test` on push/PR changes.
- Include matching Kover XML tasks and wire the new job into `coverage-report` and `CI Status` needs.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

- Add a dedicated `telemetry-infra` path-filter output for `infra/opentelemetry/**` and `infra/kafka-logback/**`.
- Add `Test / Telemetry Infra` to run `:bluetape4k-opentelemetry:test` and `:bluetape4k-kafka-logback:test` on push/PR changes.
- Include matching Kover XML tasks and wire the new job into `coverage-report` and `CI Status` needs.

### Validation

- `actionlint .github/workflows/ci.yml`: PASS.
- Backslash-single-quote workflow guard: PASS.
- `git diff --check`: PASS.
- Gradle project/task wiring dry-run: PASS.
- `./gradlew :bluetape4k-opentelemetry:test :bluetape4k-kafka-logback:test --max-workers=1 --no-configuration-cache`: PASS, OpenTelemetry 78 tests and Kafka Logback 22 tests.
- `./gradlew :bluetape4k-opentelemetry:koverXmlReport :bluetape4k-kafka-logback:koverXmlReport --max-workers=1 --no-configuration-cache`: PASS.

### Review Notes

- P0/P1: 0 open findings in `docs/review/2026-07-04-issue-927-telemetry-ci-review.md`.
- `infra/kafka-logback` uses Kafka Testcontainers, so the CI lane runs with `--max-workers=1` and `--no-configuration-cache`.
- Live GitHub PR CI remains the final proof that the path-filtered job executes in the shared workflow.

Fixes #927

### DoD Status

| Step | Status | Evidence |
|------|--------|----------|
| Issue metadata | PASS | #927 milestone `1.11.1`, assignee `debop`, labels mirrored to PR. |
| Workflow coverage | PASS | `telemetry-infra` filter added for `infra/opentelemetry/**` and `infra/kafka-logback/**` with a dedicated test/Kover job. |
| Local validation | PASS | `actionlint`, quote guard, `git diff --check`, Gradle wiring dry-run, telemetry tests, and Kover XML generation passed. |
| Review evidence | PASS | 7-Tier review and lesson committed under `docs/review` and `docs/lessons`. |
| CI | PASS | GitHub PR checks passed, including `Test / Telemetry Infra`, `Coverage Report`, `CI Status`, and `submit-gradle`. |

## Validation

- `actionlint .github/workflows/ci.yml`: PASS.
- Backslash-single-quote workflow guard: PASS.
- `git diff --check`: PASS.
- Gradle project/task wiring dry-run: PASS.
- `./gradlew :bluetape4k-opentelemetry:test :bluetape4k-kafka-logback:test --max-workers=1 --no-configuration-cache`: PASS, OpenTelemetry 78 tests and Kafka Logback 22 tests.
- `./gradlew :bluetape4k-opentelemetry:koverXmlReport :bluetape4k-kafka-logback:koverXmlReport --max-workers=1 --no-configuration-cache`: PASS.

## Review Notes

- P0/P1: 0 open findings in `docs/review/2026-07-04-issue-927-telemetry-ci-review.md`.
- `infra/kafka-logback` uses Kafka Testcontainers, so the CI lane runs with `--max-workers=1` and `--no-configuration-cache`.
- Live GitHub PR CI remains the final proof that the path-filtered job executes in the shared workflow.

Fixes #927

## Metadata

- Issue: #927, milestone `1.12.0`, assignee `debop`
- PR: #974, head `9fa11290c95b72234895386f3d1b7e1d856372d2`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-927-telemetry-ci`
- Labels: `bug`, `test`, `infra/io`, `ci`, `codex`, `codex-automation`
- State: `MERGED`, merge commit `aa5dd9f378e83d00174014ed0b1d9e405b96201e`
- CI: - Include matching Kover XML tasks and wire the new job into `coverage-report` and `CI Status` needs. / - `actionlint .github/workflows/ci.yml`: PASS. / - Gradle project/task wiring dry-run: PASS.

## DoD Status

| Step | Status | Evidence |
|------|--------|----------|
| Issue metadata | PASS | #927 milestone `1.11.1`, assignee `debop`, labels mirrored to PR. |
| Workflow coverage | PASS | `telemetry-infra` filter added for `infra/opentelemetry/**` and `infra/kafka-logback/**` with a dedicated test/Kover job. |
| Local validation | PASS | `actionlint`, quote guard, `git diff --check`, Gradle wiring dry-run, telemetry tests, and Kover XML generation passed. |
| Review evidence | PASS | 7-Tier review and lesson committed under `docs/review` and `docs/lessons`. |
| CI | PASS | GitHub PR checks passed, including `Test / Telemetry Infra`, `Coverage Report`, `CI Status`, and `submit-gradle`. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #974 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `aa5dd9f378e83d00174014ed0b1d9e405b96201e`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
