### PR TITLE
test: guard Ktor cancellation span status

### DIFF
--- a/docs/lessons/2026-07-04-issue-828-ktor-cancellation-spans.md
+++ b/docs/lessons/2026-07-04-issue-828-ktor-cancellation-spans.md
@@ -1,0 +1,23 @@
+# Issue #828 Ktor Cancellation Spans
+
+## Context
+
+The observability contract says intentional coroutine cancellation must not become an error metric or an `ERROR` span status. `ktor/observability` delegated Ktor server span lifecycle to OpenTelemetry's Ktor instrumentation, but had no regression test for a route that throws `CancellationException`.
+
+## Decision
+
+Add a focused Ktor OpenTelemetry regression test that throws `CancellationException` from a route and asserts exported spans never use `StatusCode.ERROR`. If the instrumentation exports a cancellation span in the future, the test requires the status to remain `UNSET`.
+
+## Outcome
+
+The current OpenTelemetry Ktor behavior does not export a span for the canceled route in the Ktor test host. That already satisfies "no ERROR span" for cancellation, and the new test locks the contract while preserving existing coverage that real 500 responses still record `ERROR`.
+
+## Verification
+
+- Targeted cancellation and real-error tracing tests
+- Full `:bluetape4k-ktor-observability` compile/test command
+- `git diff --check`
+
+## Future Guard
+
+When wrapping framework instrumentation, test cancellation separately from ordinary handler failures. Do not assume a framework's error response shape is the same as the tracing status contract.

--- a/docs/review/2026-07-04-issue-828-ktor-cancellation-spans-review.md
+++ b/docs/review/2026-07-04-issue-828-ktor-cancellation-spans-review.md
@@ -1,0 +1,35 @@
+# Issue 828 Ktor Cancellation Span Review
+
+## Scope
+
+- Issue: #828 `P1: Keep Ktor cancellation spans out of ERROR status`
+- Milestone: 1.11.1
+- Branch: `fix/issue-828-ktor-cancellation-spans`
+- Target: `ktor/observability`
+
+## 7-Tier Review
+
+| Tier | Result | Evidence |
+|---|---|---|
+| P0 Correctness | PASS | A cancellation route regression test now asserts exported Ktor OpenTelemetry spans never use `StatusCode.ERROR`; if spans are exported, their status must remain `UNSET`. |
+| P1 Coroutine Semantics | PASS | The test uses real `CancellationException` from a Ktor route and preserves the existing Ktor test-host response behavior instead of wrapping cancellation as an application error. |
+| P2 Error Boundary | PASS | Existing real 500 request span coverage still asserts `StatusCode.ERROR`, so cancellation and application failure remain distinct. |
+| P3 Test Quality | PASS | The regression uses the module's existing `InMemorySpanExporter` helper and bluetape4k assertions. No ad hoc coroutine stress helper is needed because this is single-request instrumentation behavior. |
+| P4 Scope Control | PASS | No production code changed. The current OpenTelemetry Ktor behavior already avoids exporting an ERROR span for cancellation; this PR locks that contract with a focused test. |
+| P5 Build Hygiene | PASS | Targeted test and full module verification passed. CodeGraph was attempted first but the worktree graph was empty, so review fell back to current source/tests and GNO evidence. |
+| P6 Process | PASS | PR metadata must mirror issue #828: milestone `1.11.1`, assignee `debop`, and labels `bug`, `infra/io`, `coroutines`, `codex`, `codex-automation`. |
+
+## Verification
+
+- `./gradlew :bluetape4k-ktor-observability:test --tests "io.bluetape4k.ktor.observability.Bluetape4kKtorObservabilityTest.open telemetry tracing does not record error status for cancellation" --tests "io.bluetape4k.ktor.observability.Bluetape4kKtorObservabilityTest.open telemetry tracing records error request spans" --no-build-cache --no-configuration-cache`
+  - PASS: 2 tests.
+- `./gradlew :bluetape4k-ktor-observability:compileKotlin :bluetape4k-ktor-observability:compileTestKotlin :bluetape4k-ktor-observability:test --no-build-cache --no-configuration-cache`
+  - PASS.
+- `./gradlew :bluetape4k-ktor-observability:koverXmlReport --no-configuration-cache`
+  - PASS.
+- `git diff --check`
+  - PASS.
+
+## Residual Risk
+
+- The wrapped OpenTelemetry Ktor instrumentation remains alpha-versioned. If a future version starts exporting a cancellation server span, this test permits it only when the status remains `UNSET`.

--- a/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservabilityTest.kt
+++ b/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservabilityTest.kt
@@ -29,6 +29,7 @@ import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.util.concurrent.TimeUnit
+import kotlin.coroutines.cancellation.CancellationException
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class Bluetape4kKtorObservabilityTest {
@@ -138,6 +139,33 @@ class Bluetape4kKtorObservabilityTest {
             spans shouldHaveSize 1
             spans[0].kind shouldBeEqualTo SpanKind.SERVER
             spans[0].status.statusCode shouldBeEqualTo StatusCode.ERROR
+        }
+    }
+
+    @Test
+    fun `open telemetry tracing does not record error status for cancellation`() = testTracing { tracing ->
+        testApplication {
+            application {
+                installBluetape4kKtorOpenTelemetryTracing(
+                    KtorOpenTelemetryTracingConfig(openTelemetry = tracing.openTelemetry)
+                )
+                routing {
+                    get("/cancelled") {
+                        throw CancellationException("client disconnected")
+                    }
+                }
+            }
+
+            val response = client.get("/cancelled")
+            response.status shouldBeEqualTo HttpStatusCode.InternalServerError
+            tracing.flush()
+
+            val spans = tracing.spanExporter.finishedSpanItems
+            spans.none { it.status.statusCode == StatusCode.ERROR }.shouldBeTrue()
+            spans.forEach { span ->
+                span.kind shouldBeEqualTo SpanKind.SERVER
+                span.status.statusCode shouldBeEqualTo StatusCode.UNSET
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #828

- PR 제목: test: guard Ktor cancellation span status

- Add a Ktor OpenTelemetry regression test for a route that throws `CancellationException`.
- Assert cancellation tracing never exports `StatusCode.ERROR`; if a cancellation span is exported, its status must remain `UNSET`.
- Keep the existing real HTTP 500 span test as the positive error boundary.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

- Add a Ktor OpenTelemetry regression test for a route that throws `CancellationException`.
- Assert cancellation tracing never exports `StatusCode.ERROR`; if a cancellation span is exported, its status must remain `UNSET`.
- Keep the existing real HTTP 500 span test as the positive error boundary.

### Validation

- Targeted cancellation and real-error tracing tests: PASS, 2 tests.
- `./gradlew :bluetape4k-ktor-observability:compileKotlin :bluetape4k-ktor-observability:compileTestKotlin :bluetape4k-ktor-observability:test --no-build-cache --no-configuration-cache`: PASS, 10 tests.
- `./gradlew :bluetape4k-ktor-observability:koverXmlReport --no-configuration-cache`: PASS.
- `git diff --check`: PASS.
- GitHub PR CI: PASS (`Test / Ktor`, `Coverage Report`, `CI Status`, `Build`, wrapper validation, gitleaks).

### Review Notes

- P0/P1: 0 open findings in `docs/review/2026-07-04-issue-828-ktor-cancellation-spans-review.md`.
- CodeGraph was attempted first, but the worktree graph was empty; review used current source/tests plus GNO issue/spec evidence as fallback.
- The current OpenTelemetry Ktor behavior exports no span for this cancellation path in the Ktor test host, which satisfies the no-ERROR-span contract. The test also remains future-safe if upstream starts exporting an UNSET cancellation span.

Fixes #828

### DoD Status

| Step | Status | Evidence |
|------|--------|----------|
| Issue metadata | PASS | #828 milestone `1.11.1`, assignee `debop`, labels mirrored to PR. |
| Contract coverage | PASS | Cancellation route test asserts no exported span has `StatusCode.ERROR`; exported cancellation spans must remain `UNSET`. |
| Error boundary | PASS | Existing HTTP 500 tracing test still asserts `StatusCode.ERROR`. |
| Local validation | PASS | Targeted tests, full module compile/test, Kover XML, and `git diff --check` passed. |
| Review evidence | PASS | 7-Tier review and lesson committed under `docs/review` and `docs/lessons`. |
| CI | PASS | GitHub checks passed: `Test / Ktor`, `Coverage Report`, `CI Status`, `Build`, wrapper validation, gitleaks. |

## Validation

- Targeted cancellation and real-error tracing tests: PASS, 2 tests.
- `./gradlew :bluetape4k-ktor-observability:compileKotlin :bluetape4k-ktor-observability:compileTestKotlin :bluetape4k-ktor-observability:test --no-build-cache --no-configuration-cache`: PASS, 10 tests.
- `./gradlew :bluetape4k-ktor-observability:koverXmlReport --no-configuration-cache`: PASS.
- `git diff --check`: PASS.
- GitHub PR CI: PASS (`Test / Ktor`, `Coverage Report`, `CI Status`, `Build`, wrapper validation, gitleaks).

## Review Notes

- P0/P1: 0 open findings in `docs/review/2026-07-04-issue-828-ktor-cancellation-spans-review.md`.
- CodeGraph was attempted first, but the worktree graph was empty; review used current source/tests plus GNO issue/spec evidence as fallback.
- The current OpenTelemetry Ktor behavior exports no span for this cancellation path in the Ktor test host, which satisfies the no-ERROR-span contract. The test also remains future-safe if upstream starts exporting an UNSET cancellation span.

Fixes #828

## Metadata

- Issue: #828, milestone `1.12.0`, assignee `debop`
- PR: #977, head `096928376c04a2207767b98276728103ec8d470c`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-828-ktor-cancellation-spans`
- Labels: `bug`, `infra/io`, `codex`, `codex-automation`, `coroutines`
- State: `MERGED`, merge commit `5f18ac9bf19b513d34f2286b009f2119a3291b34`
- CI: - Assert cancellation tracing never exports `StatusCode.ERROR`; if a cancellation span is exported, its status must remain `UNSET`. / - Targeted cancellation and real-error tracing tests: PASS, 2 tests. / - `./gradlew :bluetape4k-ktor-observability:compileKotlin :bluetape4k-ktor-observability:compileTestKotlin :bluetape4k-ktor-observability:test --no-build-cache --no-configuration-cache`: PASS, 10 tests.

## DoD Status

| Step | Status | Evidence |
|------|--------|----------|
| Issue metadata | PASS | #828 milestone `1.11.1`, assignee `debop`, labels mirrored to PR. |
| Contract coverage | PASS | Cancellation route test asserts no exported span has `StatusCode.ERROR`; exported cancellation spans must remain `UNSET`. |
| Error boundary | PASS | Existing HTTP 500 tracing test still asserts `StatusCode.ERROR`. |
| Local validation | PASS | Targeted tests, full module compile/test, Kover XML, and `git diff --check` passed. |
| Review evidence | PASS | 7-Tier review and lesson committed under `docs/review` and `docs/lessons`. |
| CI | PASS | GitHub checks passed: `Test / Ktor`, `Coverage Report`, `CI Status`, `Build`, wrapper validation, gitleaks. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #977 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `5f18ac9bf19b513d34f2286b009f2119a3291b34`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
