### PR TITLE
ci: cover Kafka infra test lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
       ktor: ${{ steps.filter.outputs.ktor }}
       key-utils: ${{ steps.filter.outputs.key-utils }}
       infra: ${{ steps.filter.outputs.infra }}
+      kafka-infra: ${{ steps.filter.outputs.kafka-infra }}
       telemetry-infra: ${{ steps.filter.outputs.telemetry-infra }}
       data: ${{ steps.filter.outputs.data }}
     steps:
@@ -136,6 +137,8 @@ jobs:
               - 'infra/lettuce/**'
               - 'cache/cache-lettuce/**'
               - 'cache/cache-redisson/**'
+            kafka-infra:
+              - 'infra/kafka/**'
             telemetry-infra:
               - 'infra/opentelemetry/**'
               - 'infra/kafka-logback/**'
@@ -566,7 +569,66 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 30
 
-  # ── 7-a. Telemetry Infra 테스트 (Kafka / OpenTelemetry) ─────────────────
+  # ── 7-a. Kafka Infra 테스트 (Testcontainers) ────────────────────────────
+  test-kafka-infra:
+    name: Test / Kafka Infra
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['kafka-infra'] == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Test Kafka infra modules
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          shell: bash
+          command: |
+            ./gradlew \
+              :bluetape4k-kafka:test \
+              --max-workers=1 \
+              --no-configuration-cache
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Generate Kover XML report
+        if: always()
+        run: |
+          ./gradlew \
+            :bluetape4k-kafka:koverXmlReport \
+            --max-workers=1 \
+            --no-configuration-cache
+        continue-on-error: true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-kafka-infra
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 30
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-kafka-infra
+          path: '**/build/reports/kover/'
+          retention-days: 30
+
+  # ── 7-b. Telemetry Infra 테스트 (Kafka / OpenTelemetry) ─────────────────
   test-telemetry-infra:
     name: Test / Telemetry Infra
     runs-on: ubuntu-latest
@@ -627,7 +689,7 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 30
 
-  # ── 7-b. Data 모듈 테스트 (Testcontainers) ───────────────────────────────
+  # ── 7-c. Data 모듈 테스트 (Testcontainers) ───────────────────────────────
   test-data:
     name: Test / Data
     runs-on: ubuntu-latest
@@ -708,7 +770,7 @@ jobs:
     name: Coverage Report
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [test-core, test-io, test-io-http, test-ktor, test-key-utils, test-infra, test-telemetry-infra, test-data]
+    needs: [test-core, test-io, test-io-http, test-ktor, test-key-utils, test-infra, test-kafka-infra, test-telemetry-infra, test-data]
     if: always()
     steps:
       - uses: actions/checkout@v7
@@ -747,7 +809,7 @@ jobs:
     name: CI Status
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [gitleaks, validate-wrapper, changes, build, test-core, test-io, test-io-http, test-ktor, test-key-utils, test-infra, test-telemetry-infra, test-data, coverage-report]
+    needs: [gitleaks, validate-wrapper, changes, build, test-core, test-io, test-io-http, test-ktor, test-key-utils, test-infra, test-kafka-infra, test-telemetry-infra, test-data, coverage-report]
     if: always()
     steps:
       - name: Check all jobs

--- a/docs/lessons/2026-07-04-issue-975-kafka-ci.md
+++ b/docs/lessons/2026-07-04-issue-975-kafka-ci.md
@@ -1,0 +1,31 @@
+# Issue #975 Kafka CI Coverage
+
+## Context
+
+Push CI did not run `:bluetape4k-kafka:test` for changes under `infra/kafka/**`.
+The existing `infra` lane was Redis/cache-specific, while `telemetry-infra`
+covered `infra/opentelemetry/**` and `infra/kafka-logback/**`.
+
+## Decision
+
+Add a dedicated `kafka-infra` path-filter output and `Test / Kafka Infra` job
+instead of mixing Kafka into the Redis-focused infra lane.
+
+## Rationale
+
+- `infra/kafka` tests use embedded Kafka/Testcontainers-style infrastructure and should run serially with `--max-workers=1`.
+- A dedicated job keeps Kafka failures distinct from Redis/cache and telemetry/logback failures.
+- CI aggregation must list the new job in both `coverage-report.needs` and `ci-status.needs` so skipped/failed Kafka coverage is visible.
+
+## Verification
+
+- `actionlint .github/workflows/ci.yml`
+- Backslash-single-quote guard for GitHub Actions expressions
+- `git diff --check`
+- `./gradlew :bluetape4k-kafka:cleanTest :bluetape4k-kafka:test --max-workers=1 --no-build-cache --no-configuration-cache`
+- `./gradlew :bluetape4k-kafka:koverXmlReport --max-workers=1 --no-configuration-cache`
+
+## Future Guard
+
+When adding CI coverage for a module family, update all four surfaces together:
+path-filter output, test job, `coverage-report.needs`, and `ci-status.needs`.

--- a/docs/review/2026-07-04-issue-975-kafka-ci-review.md
+++ b/docs/review/2026-07-04-issue-975-kafka-ci-review.md
@@ -1,0 +1,34 @@
+# Issue #975 Kafka CI Coverage Review
+
+## Scope
+
+- Issue: #975 `ci: Run Kafka infra tests for infra/kafka changes`
+- Changed file: `.github/workflows/ci.yml`
+- Module covered by the new CI lane:
+  - `:bluetape4k-kafka`
+
+## 7-Tier Review
+
+| Tier | Verdict | Evidence |
+|------|---------|----------|
+| 1. Security | PASS | The change adds CI execution only. No secrets, permissions, credentials, or production runtime paths changed. |
+| 2. Architecture | PASS | Kafka infra gets a dedicated `kafka-infra` filter/job instead of being mixed into the Redis/cache infra lane. |
+| 3. Reliability | PASS | The Kafka job runs serially with `--max-workers=1` and disables the configuration cache, matching the module's infrastructure-test profile. |
+| 4. Code quality | PASS | Workflow wiring is narrow: filter output, job, coverage needs, and status needs are synchronized. |
+| 5. Testing | PASS | `:bluetape4k-kafka:cleanTest :bluetape4k-kafka:test` passed with 265 tests, and Kover XML generation passed. |
+| 6. Performance | PASS | The lane is path-filtered to `infra/kafka/**` and does not expand unrelated Redis/cache or telemetry jobs for Kafka-only changes. |
+| 7. Documentation / Evidence | PASS | This review plus the lesson document record the issue boundary, commands, and future guard. |
+
+## Validation
+
+- `actionlint .github/workflows/ci.yml`: PASS.
+- Backslash-single-quote guard for `.github/workflows`: PASS.
+- `git diff --check`: PASS.
+- `./gradlew :bluetape4k-kafka:cleanTest :bluetape4k-kafka:test --max-workers=1 --no-build-cache --no-configuration-cache`: PASS, 265 tests.
+- `./gradlew :bluetape4k-kafka:koverXmlReport --max-workers=1 --no-configuration-cache`: PASS.
+
+## Findings
+
+- P0: 0
+- P1: 0
+- P2/P3: 0 open


### PR DESCRIPTION
## Summary

Closes #975

- PR 제목: ci: cover Kafka infra test lane

- Add a dedicated `kafka-infra` path-filter output for `infra/kafka/**` changes.
- Add `Test / Kafka Infra` to run `:bluetape4k-kafka:test` serially with `--max-workers=1` and `--no-configuration-cache`.
- Wire the new job into `coverage-report.needs` and `ci-status.needs` so Kafka CI results are aggregated.

## Background

#975 found that push CI covered Redis/cache infra and telemetry/logback infra, but not the `infra/kafka` module. A production/test change under `infra/kafka/**` could pass without running `:bluetape4k-kafka:test`.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

- Add a dedicated `kafka-infra` path-filter output for `infra/kafka/**` changes.
- Add `Test / Kafka Infra` to run `:bluetape4k-kafka:test` serially with `--max-workers=1` and `--no-configuration-cache`.
- Wire the new job into `coverage-report.needs` and `ci-status.needs` so Kafka CI results are aggregated.

### Background

#975 found that push CI covered Redis/cache infra and telemetry/logback infra, but not the `infra/kafka` module. A production/test change under `infra/kafka/**` could pass without running `:bluetape4k-kafka:test`.

### Validation

- `actionlint .github/workflows/ci.yml`: PASS.
- Backslash-single-quote guard for `.github/workflows`: PASS.
- `git diff --check`: PASS.
- `./gradlew :bluetape4k-kafka:cleanTest :bluetape4k-kafka:test --max-workers=1 --no-build-cache --no-configuration-cache`: PASS, 265 tests.
- `./gradlew :bluetape4k-kafka:koverXmlReport --max-workers=1 --no-configuration-cache`: PASS.
- GitHub PR CI: PASS (`Test / Kafka Infra`, `Coverage Report`, `CI Status`, and full workflow-change smoke matrix).

### Review Notes

- P0/P1: 0 open findings in `docs/review/2026-07-04-issue-975-kafka-ci-review.md`.
- The new lane follows the issue #927 telemetry CI pattern: path-filter output, dedicated job, coverage aggregation, and final CI status aggregation are updated together.
- The PR changes CI wiring only; no production runtime code or permissions changed.

Fixes #975

### DoD Status

| Step | Status | Evidence |
|------|--------|----------|
| Issue metadata | PASS | #975 milestone `1.11.1`, assignee `debop`, labels mirrored to PR. |
| CI path filter | PASS | Added `kafka-infra` output and `infra/kafka/**` filter. |
| Kafka test lane | PASS | Added `Test / Kafka Infra` running `:bluetape4k-kafka:test` serially with `--max-workers=1`. |
| Aggregation wiring | PASS | Added `test-kafka-infra` to `coverage-report.needs` and `ci-status.needs`. |
| Local validation | PASS | actionlint, quote guard, `git diff --check`, Kafka cleanTest/test, and Kover XML passed. |
| Review evidence | PASS | 7-Tier review and lesson committed under `docs/review` and `docs/lessons`. |
| CI | PASS | GitHub checks passed: `Test / Kafka Infra`, full workflow-change smoke matrix, `Coverage Report`, and `CI Status`. |

## Validation

- `actionlint .github/workflows/ci.yml`: PASS.
- Backslash-single-quote guard for `.github/workflows`: PASS.
- `git diff --check`: PASS.
- `./gradlew :bluetape4k-kafka:cleanTest :bluetape4k-kafka:test --max-workers=1 --no-build-cache --no-configuration-cache`: PASS, 265 tests.
- `./gradlew :bluetape4k-kafka:koverXmlReport --max-workers=1 --no-configuration-cache`: PASS.
- GitHub PR CI: PASS (`Test / Kafka Infra`, `Coverage Report`, `CI Status`, and full workflow-change smoke matrix).

## Review Notes

- P0/P1: 0 open findings in `docs/review/2026-07-04-issue-975-kafka-ci-review.md`.
- The new lane follows the issue #927 telemetry CI pattern: path-filter output, dedicated job, coverage aggregation, and final CI status aggregation are updated together.
- The PR changes CI wiring only; no production runtime code or permissions changed.

Fixes #975

## Metadata

- Issue: #975, milestone `1.12.0`, assignee `debop`
- PR: #978, head `2ba01df2ddb102b263acfc9a322930499bed079c`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-975-kafka-ci`
- Labels: `bug`, `test`, `ci`, `codex`, `codex-automation`
- State: `MERGED`, merge commit `e79d980e8e199d0ddc26f79ff3cdd65cf7c0f60a`
- CI: - Wire the new job into `coverage-report.needs` and `ci-status.needs` so Kafka CI results are aggregated. / #975 found that push CI covered Redis/cache infra and telemetry/logback infra, but not the `infra/kafka` module. A production/test change under `infra/kafka/**` could pass without running `:bluetape4k-kafka:test`. / - `actionlint .github/workflows/ci.yml`: PASS.

## DoD Status

| Step | Status | Evidence |
|------|--------|----------|
| Issue metadata | PASS | #975 milestone `1.11.1`, assignee `debop`, labels mirrored to PR. |
| CI path filter | PASS | Added `kafka-infra` output and `infra/kafka/**` filter. |
| Kafka test lane | PASS | Added `Test / Kafka Infra` running `:bluetape4k-kafka:test` serially with `--max-workers=1`. |
| Aggregation wiring | PASS | Added `test-kafka-infra` to `coverage-report.needs` and `ci-status.needs`. |
| Local validation | PASS | actionlint, quote guard, `git diff --check`, Kafka cleanTest/test, and Kover XML passed. |
| Review evidence | PASS | 7-Tier review and lesson committed under `docs/review` and `docs/lessons`. |
| CI | PASS | GitHub checks passed: `Test / Kafka Infra`, full workflow-change smoke matrix, `Coverage Report`, and `CI Status`. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #978 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e79d980e8e199d0ddc26f79ff3cdd65cf7c0f60a`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
