### PR TITLE
fix: capture generated Ktor correlation ids in spans

### DIFF
--- a/docs/lessons/2026-07-04-issue-827-ktor-correlation-tracing.md
+++ b/docs/lessons/2026-07-04-issue-827-ktor-correlation-tracing.md
@@ -1,0 +1,34 @@
+# Lessons Learned - Issue #827 Ktor Correlation Tracing
+
+## Context
+
+`bluetape4k-ktor-observability` recorded `correlation.present` and optional
+`correlation.id` in the OpenTelemetry Ktor extractor `onStart` callback. The
+OpenTelemetry plugin starts before Ktor `ApplicationCallPipeline.Setup`, while
+Ktor `CallId` sanitizes or generates the call id during `Setup`.
+
+## Lesson
+
+When tracing attributes depend on framework plugins that run later in the call
+pipeline, capture them at span end unless the value must participate in sampler
+decisions. For Ktor server spans, generated `CallId` values are available by
+the OpenTelemetry extractor `onEnd` callback.
+
+## Outcome
+
+The tracing helper now records correlation attributes from `onEnd`, so
+headerless requests produce the same generated `X-Request-Id` in both the HTTP
+response and the server span.
+
+## Future Guard
+
+Keep generated correlation ID regression coverage whenever changing Ktor
+OpenTelemetry extractor timing, CallId installation order, or correlation
+header policy.
+
+## Verification
+
+- Regression test failed before the fix with `correlation.present=false`.
+- Targeted regression test passed after the fix.
+- Full `:bluetape4k-ktor-observability` compile/test/Kover validation passed.
+- `git diff --check` passed.

--- a/docs/review/2026-07-04-issue-827-ktor-correlation-tracing-review.md
+++ b/docs/review/2026-07-04-issue-827-ktor-correlation-tracing-review.md
@@ -1,0 +1,75 @@
+# Issue #827 Ktor Correlation Tracing Review
+
+Date: 2026-07-04
+Repo: `bluetape4k-projects`
+Scope: `ktor/observability` OpenTelemetry correlation attributes
+
+## Gate
+
+- P0: 0
+- P1: 0
+- Verdict: PASS
+
+## 7-Tier Review
+
+### Tier 1 - Correctness
+
+- PASS. `KtorOpenTelemetryTracingSupport` now records correlation attributes in
+  the OpenTelemetry extractor `onEnd` callback, after Ktor `CallId` has had a
+  chance to sanitize or generate `call.callId`.
+- PASS. The fallback still sanitizes request headers for applications that call
+  `installBluetape4kKtorOpenTelemetryTracing` directly without installing
+  bluetape4k `CallId`.
+
+### Tier 2 - API and Compatibility
+
+- PASS. No new public API or dependency is introduced.
+- PASS. Existing `KtorOpenTelemetryTracingConfig.captureSanitizedCorrelationId`
+  opt-in semantics are preserved.
+
+### Tier 3 - Security and Privacy
+
+- PASS. Raw request headers are not copied to span attributes. Values continue
+  through `KtorCorrelationId.sanitize()` before `correlation.id` is recorded.
+- PASS. `correlation.id` remains opt-in high-cardinality data.
+
+### Tier 4 - Kotlin and bluetape4k Patterns
+
+- PASS. The change reuses existing `KtorCorrelationId`, `CorrelationIdSettings`,
+  and `CallId` integration instead of adding a parallel ID generator.
+- PASS. Touched boolean assertions use `shouldBeTrue()` and infix comparison
+  assertions from `bluetape4k-assertions`.
+
+### Tier 5 - Tests
+
+- PASS. Added a regression test for headerless requests with generated
+  `X-Request-Id` and tracing capture enabled.
+- PASS. The test verifies that the response header and span `correlation.id`
+  contain the same generated value.
+
+### Tier 6 - Operations
+
+- PASS. No workflow, module registration, exporter, global OpenTelemetry SDK,
+  or runtime configuration changes were made.
+
+### Tier 7 - Documentation and Evidence
+
+- PASS. KDoc contract now states that correlation attributes are recorded before
+  span end and after CallId sanitization/generation.
+- PASS. This review and the issue lesson are committed with the implementation.
+
+## Verification Evidence
+
+- Regression baseline before fix:
+  `:bluetape4k-ktor-observability:test --tests "...observability installer records generated correlation id on server span"` failed with `correlation.present=false`.
+- Targeted regression after fix:
+  `:bluetape4k-ktor-observability:test --tests "...observability installer records generated correlation id on server span"` passed.
+- Full module validation:
+  `./gradlew :bluetape4k-ktor-observability:compileKotlin :bluetape4k-ktor-observability:compileTestKotlin :bluetape4k-ktor-observability:test :bluetape4k-ktor-observability:koverXmlReport --no-build-cache --no-configuration-cache` passed.
+- Test result XML: 11 tests, 0 failures, 0 errors, 0 skipped.
+- `git diff --check` passed.
+
+## Residual Risk
+
+- OpenTelemetry Ktor instrumentation is still alpha-versioned. Future upstream
+  changes to extractor timing should be checked with this regression test.

--- a/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/KtorOpenTelemetryTracingSupport.kt
+++ b/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/KtorOpenTelemetryTracingSupport.kt
@@ -12,7 +12,8 @@ import io.opentelemetry.instrumentation.ktor.v3_0.KtorServerTelemetry
  * ## Contract
  * - Delegates HTTP server span creation to OpenTelemetry's Ktor 3 instrumentation.
  * - Uses the caller-provided [KtorOpenTelemetryTracingConfig.openTelemetry] instance.
- * - Records `correlation.present` by default and records `correlation.id` only after sanitization and opt-in.
+ * - Records `correlation.present` by default before the span ends.
+ * - Records `correlation.id` only after CallId sanitization/generation and explicit opt-in.
  */
 fun Application.installBluetape4kKtorOpenTelemetryTracing(
     config: KtorOpenTelemetryTracingConfig,
@@ -20,7 +21,7 @@ fun Application.installBluetape4kKtorOpenTelemetryTracing(
     install(KtorServerTelemetry) {
         setOpenTelemetry(config.openTelemetry)
         attributesExtractor {
-            onStart {
+            onEnd {
                 val correlationId = request.sanitizedCorrelationId(config.correlationId)
                 attributes.put(CORRELATION_PRESENT_ATTRIBUTE, correlationId != null)
                 if (config.captureSanitizedCorrelationId && correlationId != null) {

--- a/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservabilityTest.kt
+++ b/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservabilityTest.kt
@@ -93,9 +93,45 @@ class Bluetape4kKtorObservabilityTest {
             spans shouldHaveSize 1
             val span = spans[0]
             span.kind shouldBeEqualTo SpanKind.SERVER
-            span.attributes[CORRELATION_PRESENT_KEY] shouldBeEqualTo true
+            span.attributes[CORRELATION_PRESENT_KEY].shouldBeTrue()
             span.attributes[CORRELATION_ID_KEY] shouldBeEqualTo "REQ_123Injectedraw"
             span.attributes.asMap().keys.none { it.key.equals(HttpHeaders.Authorization, ignoreCase = true) }.shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `observability installer records generated correlation id on server span`() = testTracing { tracing ->
+        testApplication {
+            application {
+                installBluetape4kKtorObservability(
+                    Bluetape4kKtorObservabilityConfig(
+                        tracing = KtorOpenTelemetryTracingConfig(
+                            openTelemetry = tracing.openTelemetry,
+                            captureSanitizedCorrelationId = true
+                        )
+                    )
+                )
+                routing {
+                    get("/ping") {
+                        call.respondText("pong")
+                    }
+                }
+            }
+
+            val response = client.get("/ping")
+            val generated = response.headers[HttpHeaders.XRequestId].shouldNotBeNull()
+
+            response.status shouldBeEqualTo HttpStatusCode.OK
+            generated.length shouldBeEqualTo KtorCorrelationId.DEFAULT_GENERATED_LENGTH
+            KtorCorrelationId.isValid(generated).shouldBeTrue()
+            tracing.flush()
+
+            val spans = tracing.spanExporter.finishedSpanItems
+            spans shouldHaveSize 1
+            val span = spans[0]
+            span.kind shouldBeEqualTo SpanKind.SERVER
+            span.attributes[CORRELATION_PRESENT_KEY].shouldBeTrue()
+            span.attributes[CORRELATION_ID_KEY] shouldBeEqualTo generated
         }
     }
 
@@ -186,7 +222,7 @@ class Bluetape4kKtorObservabilityTest {
         response.status shouldBeEqualTo HttpStatusCode.OK
         generated.shouldNotBeNull()
         generated.length shouldBeEqualTo KtorCorrelationId.DEFAULT_GENERATED_LENGTH
-        KtorCorrelationId.isValid(generated) shouldBeEqualTo true
+        KtorCorrelationId.isValid(generated).shouldBeTrue()
     }
 
     @Test
@@ -206,7 +242,7 @@ class Bluetape4kKtorObservabilityTest {
 
         client.get("/ping").status shouldBeEqualTo HttpStatusCode.OK
 
-        registry.meters.isNotEmpty() shouldBeEqualTo true
+        registry.meters.isNotEmpty().shouldBeTrue()
     }
 
     @Test
@@ -230,7 +266,7 @@ class Bluetape4kKtorObservabilityTest {
         val response = client.get("/metrics")
 
         response.status shouldBeEqualTo HttpStatusCode.OK
-        response.bodyAsText().contains("demo_requests_total") shouldBeEqualTo true
+        response.bodyAsText().contains("demo_requests_total").shouldBeTrue()
     }
 
     private class TestTracing: AutoCloseable {


### PR DESCRIPTION
## Summary

Closes #827

- PR 제목: fix: capture generated Ktor correlation ids in spans

- Record Ktor OpenTelemetry correlation attributes in the extractor `onEnd` callback, after Ktor `CallId` has sanitized or generated `call.callId`.
- Add a regression test for headerless requests that verifies the generated `X-Request-Id` response header matches the server span `correlation.id`.
- Clean up touched boolean assertions to use `bluetape4k-assertions` boolean matchers.

## Background

#827 found that OpenTelemetry Ktor starts spans before `ApplicationCallPipeline.Setup`, while Ktor `CallId` generates and stores missing correlation IDs during `Setup`. Headerless requests could therefore return an `X-Request-Id` response header while the server span still recorded `correlation.present=false` and omitted `correlation.id`.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Moved bluetape4k correlation attribute capture from `onStart` to `onEnd` in `KtorOpenTelemetryTracingSupport`.
- Kept the existing `KtorCorrelationId.sanitize()` and `CorrelationIdSettings` policy as the only source of correlation ID validation.
- Added review evidence under `docs/review/2026-07-04-issue-827-ktor-correlation-tracing-review.md`.
- Added the issue lesson under `docs/lessons/2026-07-04-issue-827-ktor-correlation-tracing.md`.

## Validation

- Baseline regression before fix: targeted generated-correlation span test failed with `correlation.present=false`.
- Targeted regression after fix: `./gradlew :bluetape4k-ktor-observability:test --tests "io.bluetape4k.ktor.observability.Bluetape4kKtorObservabilityTest.observability installer records generated correlation id on server span" --no-build-cache --no-configuration-cache`: PASS.
- Full module validation: `./gradlew :bluetape4k-ktor-observability:compileKotlin :bluetape4k-ktor-observability:compileTestKotlin :bluetape4k-ktor-observability:test :bluetape4k-ktor-observability:koverXmlReport --no-build-cache --no-configuration-cache`: PASS.
- Test result XML: 11 tests, 0 failures, 0 errors, 0 skipped.
- `git diff --check`: PASS.
- CodeGraph diff review: risk score 0.00, test gaps 0 for tracked source/test diff.

Fixes #827

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #827, milestone `1.12.0`, assignee `debop`
- PR: #979, head `1cbd2ecf6ba797d6efc140928f59a17dcb2833c3`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-827-ktor-correlation-tracing`
- Labels: `bug`, `performance`, `infra/io`, `codex`, `codex-automation`
- State: `MERGED`, merge commit `e6e778caed3802a07438fc49fb66c8846d1a9b43`
- CI: - Moved bluetape4k correlation attribute capture from `onStart` to `onEnd` in `KtorOpenTelemetryTracingSupport`. / - Added review evidence under `docs/review/2026-07-04-issue-827-ktor-correlation-tracing-review.md`. / - Added the issue lesson under `docs/lessons/2026-07-04-issue-827-ktor-correlation-tracing.md`.

## DoD Status

| Step | Status | Evidence |
|------|--------|----------|
| Issue metadata | PASS | #827 milestone `1.12.0`, assignee `debop`, labels mirrored to PR. |
| Regression reproduction | PASS | New generated-correlation span test failed before fix with `correlation.present=false`. |
| Fix | PASS | Correlation attributes now record in OTel extractor `onEnd`, after Ktor `CallId` generation/sanitization. |
| Pattern compliance | PASS | Existing bluetape4k correlation helpers reused; touched boolean assertions use `shouldBeTrue()`. |
| Local validation | PASS | Targeted regression, full module compile/test/Kover, 11-test XML, and `git diff --check` passed. |
| Review evidence | PASS | 7-Tier review committed under `docs/review`; P0/P1=0. |
| Lessons | PASS | Issue lesson committed under `docs/lessons`. |
| CI | PASS | GitHub Actions passed: `Build`, `Test / Ktor`, `Coverage Report`, `CI Status`, security checks, and non-matching module lanes skipped. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #979 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e6e778caed3802a07438fc49fb66c8846d1a9b43`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
