### PR TITLE
fix: harden R2DBC auto-configuration activation

### DIFF
--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/config/R2dbcClientAutoConfiguration.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/config/R2dbcClientAutoConfiguration.kt
@@ -3,26 +3,38 @@ package io.bluetape4k.r2dbc.config
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.info
 import io.bluetape4k.r2dbc.R2dbcClient
+import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
 import org.springframework.data.r2dbc.convert.MappingR2dbcConverter
 import org.springframework.data.r2dbc.core.R2dbcEntityTemplate
 import org.springframework.r2dbc.core.DatabaseClient
 
 /**
- * [R2dbcClient] 를 Bean으로 자동 등록해주는 Configuration
+ * Auto-configuration that registers the default [R2dbcClient] bean.
+ *
+ * ## Contract
+ * - Activates only when all Spring R2DBC types used by the bean signature are present.
+ * - Backs off when the application already provides an [R2dbcClient] bean.
  */
-@Configuration
-@ConditionalOnClass(DatabaseClient::class)
+@AutoConfiguration
+@ConditionalOnClass(
+    name = [
+        "org.springframework.r2dbc.core.DatabaseClient",
+        "org.springframework.data.r2dbc.core.R2dbcEntityTemplate",
+        "org.springframework.data.r2dbc.convert.MappingR2dbcConverter",
+    ]
+)
 class R2dbcClientAutoConfiguration {
 
     companion object: KLogging()
 
     /**
-     * [R2dbcClient] Bean을 생성한다.
+     * Creates the default [R2dbcClient] bean from Spring R2DBC infrastructure beans.
      */
     @Bean
+    @ConditionalOnMissingBean(R2dbcClient::class)
     fun r2dbcClient(
         databaseClient: DatabaseClient,
         r2dbcEntityTemplate: R2dbcEntityTemplate,

--- a/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/config/R2dbcClientAutoConfigurationTest.kt
+++ b/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/config/R2dbcClientAutoConfigurationTest.kt
@@ -1,0 +1,78 @@
+package io.bluetape4k.r2dbc.config
+
+import io.bluetape4k.assertions.shouldBeEmpty
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.r2dbc.R2dbcClient
+import io.r2dbc.spi.ConnectionFactories
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.getBeansOfType
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.FilteredClassLoader
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.data.r2dbc.convert.MappingR2dbcConverter
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate
+import org.springframework.r2dbc.core.DatabaseClient
+import java.util.function.Supplier
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class R2dbcClientAutoConfigurationTest {
+
+    private val entityTemplate = R2dbcEntityTemplate(
+        ConnectionFactories.get("r2dbc:h2:mem:///r2dbc_auto_config_${System.nanoTime()}")
+    )
+
+    private val databaseClient = entityTemplate.databaseClient
+
+    private val mappingR2dbcConverter = entityTemplate.converter as MappingR2dbcConverter
+
+    private val autoConfigurationRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(R2dbcClientAutoConfiguration::class.java)
+        )
+
+    private val r2dbcClientRunner = autoConfigurationRunner
+        .withBean(R2dbcEntityTemplate::class.java, Supplier { entityTemplate })
+        .withBean(MappingR2dbcConverter::class.java, Supplier { mappingR2dbcConverter })
+        .withBean(DatabaseClient::class.java, Supplier { databaseClient })
+
+    @Test
+    fun `registers R2dbcClient when required Spring R2DBC infrastructure beans exist`() {
+        r2dbcClientRunner.run { context ->
+            context.getStartupFailure() shouldBeEqualTo null
+            context.getBeansOfType<R2dbcClient>().shouldHaveSize(1)
+        }
+    }
+
+    @Test
+    fun `backs off when application provides custom R2dbcClient bean`() {
+        val customClient = R2dbcClient(databaseClient, entityTemplate, mappingR2dbcConverter)
+
+        r2dbcClientRunner
+            .withBean(R2dbcClient::class.java, Supplier { customClient })
+            .run { context ->
+                context.getStartupFailure() shouldBeEqualTo null
+                val clients = context.getBeansOfType<R2dbcClient>()
+
+                clients.shouldHaveSize(1)
+                clients.values.single() shouldBeSameInstanceAs customClient
+            }
+    }
+
+    @Test
+    fun `does not activate when Spring Data R2DBC signature types are absent`() {
+        autoConfigurationRunner
+            .withClassLoader(
+                FilteredClassLoader(
+                    "org.springframework.data.r2dbc.core.R2dbcEntityTemplate",
+                    "org.springframework.data.r2dbc.convert.MappingR2dbcConverter",
+                )
+            )
+            .run { context ->
+                context.getStartupFailure() shouldBeEqualTo null
+                context.beanFactory.getBeanNamesForType(R2dbcClient::class.java).asList().shouldBeEmpty()
+            }
+    }
+}

--- a/docs/lessons/2026-07-04-issue-825-r2dbc-autoconfig-guards.md
+++ b/docs/lessons/2026-07-04-issue-825-r2dbc-autoconfig-guards.md
@@ -1,0 +1,34 @@
+# Lessons Learned - Issue #825 R2DBC Auto-Configuration Guards
+
+## Context
+
+`R2dbcClientAutoConfiguration` was guarded only by `DatabaseClient`, but the
+auto-configured bean method also used `R2dbcEntityTemplate` and
+`MappingR2dbcConverter`. Those Spring Data R2DBC types are compile-only for the
+published module.
+
+## Lesson
+
+Spring Boot auto-configuration classes should guard every compile-only type that
+appears in bean method signatures. Use string-based `@ConditionalOnClass` names
+when the guard exists to prevent class-loading failures before the condition can
+short-circuit.
+
+## Outcome
+
+The R2DBC auto-configuration now checks all Spring R2DBC signature types and
+backs off when a user-defined `R2dbcClient` bean exists.
+
+## Future Guard
+
+When adding auto-configured beans with compile-only parameters, add
+`ApplicationContextRunner` tests for both missing classpath behavior and custom
+bean backoff.
+
+## Verification
+
+- `:bluetape4k-r2dbc:compileKotlin` and `:bluetape4k-r2dbc:compileTestKotlin`
+  passed.
+- `:bluetape4k-r2dbc:test` passed with 188 tests.
+- `:bluetape4k-r2dbc:koverXmlReport` generated the XML coverage report.
+- `git diff --check` passed.

--- a/docs/review/2026-07-04-issue-825-r2dbc-autoconfig-review.md
+++ b/docs/review/2026-07-04-issue-825-r2dbc-autoconfig-review.md
@@ -1,0 +1,72 @@
+# Issue #825 R2DBC Auto-Configuration Review
+
+Date: 2026-07-04
+Repo: `bluetape4k-projects`
+Scope: `data/r2dbc` auto-configuration classpath guards and bean backoff
+
+## Gate
+
+- P0: 0
+- P1: 0
+- Verdict: PASS
+
+## 7-Tier Review
+
+### Tier 1 - Correctness
+
+- PASS. `R2dbcClientAutoConfiguration` now requires every Spring R2DBC type used
+  by the bean signature before activation.
+- PASS. `R2dbcClient` auto-registration now backs off when an application
+  provides its own `R2dbcClient` bean.
+
+### Tier 2 - API and Compatibility
+
+- PASS. No public `R2dbcClient` API was changed.
+- PASS. The auto-configuration remains registered through the existing
+  `AutoConfiguration.imports` and legacy `spring.factories` entries.
+
+### Tier 3 - Security and Privacy
+
+- PASS. No credential, SQL, logging, or user-data handling changed.
+
+### Tier 4 - Kotlin and bluetape4k Patterns
+
+- PASS. The fix uses Spring Boot conditional annotations directly and keeps the
+  implementation narrowly scoped.
+- PASS. Tests use `bluetape4k-assertions` and infix identity assertion style.
+- PASS. No MockK operation mocking was introduced.
+
+### Tier 5 - Tests
+
+- PASS. Added `ApplicationContextRunner` coverage for successful default bean
+  registration, custom bean backoff, and missing Spring Data R2DBC classpath
+  behavior.
+- PASS. The partial-classpath test validates startup without failure and no
+  accidental `R2dbcClient` bean registration.
+
+### Tier 6 - Operations
+
+- PASS. No workflow, CI, module registration, or dependency catalog changes were
+  needed.
+
+### Tier 7 - Documentation and Evidence
+
+- PASS. Public KDoc for the auto-configuration now states activation and backoff
+  contracts in English.
+- PASS. This review and the issue lesson are committed with the implementation.
+
+## Verification Evidence
+
+- Compile validation:
+  `./gradlew :bluetape4k-r2dbc:compileKotlin :bluetape4k-r2dbc:compileTestKotlin --no-build-cache --no-configuration-cache` passed.
+- Module validation:
+  `./gradlew :bluetape4k-r2dbc:test --no-build-cache --no-configuration-cache` passed with 188 tests.
+- Coverage report:
+  `./gradlew :bluetape4k-r2dbc:koverXmlReport --no-build-cache --no-configuration-cache` passed and generated `data/r2dbc/build/reports/kover/report.xml`.
+- `git diff --check` passed.
+
+## Residual Risk
+
+- Consumers that still rely on legacy `spring.factories` auto-configuration are
+  preserved, but future Spring Boot cleanup should re-evaluate whether the
+  legacy entry is still needed.


### PR DESCRIPTION
## Summary

Closes #825

- PR 제목: fix: harden R2DBC auto-configuration activation

Resolves #825.

- Converts `R2dbcClientAutoConfiguration` to Spring Boot auto-configuration style.
- Guards every compile-only Spring R2DBC type used by the `R2dbcClient` bean signature.
- Adds `@ConditionalOnMissingBean(R2dbcClient::class)` so applications can provide their own client bean.
- Adds `ApplicationContextRunner` coverage for default registration, custom bean backoff, and missing Spring Data R2DBC classpath behavior.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- `./gradlew :bluetape4k-r2dbc:compileKotlin :bluetape4k-r2dbc:compileTestKotlin --no-build-cache --no-configuration-cache`
- `./gradlew :bluetape4k-r2dbc:test --no-build-cache --no-configuration-cache`
- `./gradlew :bluetape4k-r2dbc:koverXmlReport --no-build-cache --no-configuration-cache`
- `git diff --check`

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- 7-Tier review: `docs/review/2026-07-04-issue-825-r2dbc-autoconfig-review.md`
- Lesson: `docs/lessons/2026-07-04-issue-825-r2dbc-autoconfig-guards.md`

## Metadata

- Issue: #825, milestone `1.12.0`, assignee `debop`
- PR: #980, head `9581be5829a67a96c6dd6c1ed6d9175bdebb2273`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-825-r2dbc-autoconfig-guards`
- Labels: `bug`, `dependencies`, `infra/io`, `codex`, `codex-automation`
- State: `MERGED`, merge commit `e19a4822365c1c707d496a6dd44dce7e985c334b`
- CI: - `./gradlew :bluetape4k-r2dbc:compileKotlin :bluetape4k-r2dbc:compileTestKotlin --no-build-cache --no-configuration-cache` / - `./gradlew :bluetape4k-r2dbc:test --no-build-cache --no-configuration-cache` / - `./gradlew :bluetape4k-r2dbc:koverXmlReport --no-build-cache --no-configuration-cache`

## DoD Status

| Gate | Status | Evidence |
| --- | --- | --- |
| Issue metadata | PASS | #825 is assigned to `debop`, milestone `1.12.0`, labels `bug`, `dependencies`, `infra/io`. |
| Classpath guard | PASS | `@ConditionalOnClass(name = [...])` covers `DatabaseClient`, `R2dbcEntityTemplate`, and `MappingR2dbcConverter`. |
| Bean backoff | PASS | `@ConditionalOnMissingBean(R2dbcClient::class)` added and tested. |
| Regression tests | PASS | `R2dbcClientAutoConfigurationTest` covers default registration, custom bean backoff, and missing Spring Data R2DBC classes. |
| Module validation | PASS | `:bluetape4k-r2dbc:test` passed with 188 tests, 0 failures, 0 errors, 0 skipped. |
| Coverage artifact | PASS | `data/r2dbc/build/reports/kover/report.xml` generated. |
| CI | PASS | PR #980 checks passed: Build, Test / Data, Coverage Report, CI Status, Secret Scan, Validate Gradle Wrapper, submit-gradle. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #980 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e19a4822365c1c707d496a6dd44dce7e985c334b`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
