### PR TITLE
fix: preserve MongoDB transaction abort on cancellation

### DIFF
--- a/data/mongodb/src/main/kotlin/io/bluetape4k/mongodb/MongoClientExtensions.kt
+++ b/data/mongodb/src/main/kotlin/io/bluetape4k/mongodb/MongoClientExtensions.kt
@@ -6,7 +6,9 @@ import com.mongodb.kotlin.client.coroutine.MongoClient
 import io.bluetape4k.logging.KotlinLogging
 import io.bluetape4k.logging.error
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.withContext
 import org.slf4j.Logger
 
 private val log: Logger by lazy { KotlinLogging.logger { } }
@@ -100,23 +102,30 @@ suspend fun <T> MongoClient.inTransaction(
         //   순서가 바뀌면 일반 catch(Exception) 블록이 먼저 처리해 버린다.
         //   코루틴 취소 신호를 삼키면 해당 코루틴이 종료되지 않고 구조적 동시성(structured
         //   concurrency)이 깨지기 때문에, 반드시 abort 후 즉시 재전파(rethrow)해야 한다.
-        try {
-            session.abortTransaction()
-        } catch (abortEx: Exception) {
-            e.addSuppressed(abortEx)
-            log.error(abortEx) { "Transaction abort failed after CancellationException" }
-        }
+        session.abortTransactionSafely(e, "Transaction abort failed after CancellationException")
         throw e
     } catch (e: Exception) {
         // [WHY] 비즈니스 예외 발생 시 트랜잭션을 명시적으로 abort해야 하는 이유:
         //   MongoDB Kotlin Coroutine Driver는 세션이 닫혀도 미완료 트랜잭션을 자동 rollback하지
         //   않으므로, 예외 경로에서 직접 abortTransaction()을 호출해 서버 측 리소스를 즉시 해제한다.
-        try {
-            session.abortTransaction()
-        } catch (abortEx: Exception) {
-            e.addSuppressed(abortEx)
-            log.error(abortEx) { "Transaction abort failed" }
-        }
+        session.abortTransactionSafely(e, "Transaction abort failed")
         throw e
+    }
+}
+
+private suspend fun ClientSession.abortTransactionSafely(owner: Throwable, message: String) {
+    try {
+        withContext(NonCancellable) {
+            abortTransaction()
+        }
+    } catch (abortEx: CancellationException) {
+        owner.addSuppressed(abortEx)
+        log.error(abortEx) { message }
+        if (owner !is CancellationException) {
+            throw abortEx
+        }
+    } catch (abortEx: Exception) {
+        owner.addSuppressed(abortEx)
+        log.error(abortEx) { message }
     }
 }

--- a/data/mongodb/src/test/kotlin/io/bluetape4k/mongodb/MongoClientSupportTest.kt
+++ b/data/mongodb/src/test/kotlin/io/bluetape4k/mongodb/MongoClientSupportTest.kt
@@ -2,21 +2,50 @@ package io.bluetape4k.mongodb
 
 import com.mongodb.ConnectionString
 import com.mongodb.MongoClientSettings
+import com.mongodb.kotlin.client.coroutine.ClientSession
+import com.mongodb.kotlin.client.coroutine.MongoClient
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.mongodb.bson.documentOf
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
+import kotlinx.coroutines.yield
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Assertions.assertNotSame
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.seconds
 
 class MongoClientSupportTest: AbstractMongoTest() {
 
     companion object: KLoggingChannel()
+
+    private val mockClient = mockk<MongoClient>()
+    private val mockSession = mockk<ClientSession>()
+
+    @BeforeEach
+    fun clearMock() {
+        clearMocks(mockClient, mockSession)
+        coEvery { mockClient.startSession() } returns mockSession
+        justRun { mockSession.startTransaction() }
+        justRun { mockSession.close() }
+    }
 
     @Test
     fun `mongoClient DSL 빌더로 MongoClient 생성`() = runTest(timeout = 30.seconds) {
@@ -100,6 +129,60 @@ class MongoClientSupportTest: AbstractMongoTest() {
         }
         // 예외가 재전파되어야 합니다
         exceptionCaught shouldBeEqualTo true
+    }
+
+    @Test
+    fun `inTransaction cancellation abort cleanup runs from NonCancellable context`() = runTest(timeout = 30.seconds) {
+        val abortCompleted = AtomicBoolean(false)
+        val cancellation = CancellationException("cancel transaction")
+
+        coEvery { mockSession.abortTransaction() } coAnswers {
+            yield()
+            abortCompleted.set(true)
+        }
+
+        val deferred = async {
+            mockClient.inTransaction {
+                currentCoroutineContext().cancel(cancellation)
+                throw cancellation
+            }
+        }
+
+        val thrown = assertFailsWith<CancellationException> {
+            deferred.await()
+        }
+
+        thrown.message shouldBeEqualTo cancellation.message
+        abortCompleted.get().shouldBeTrue()
+        cancellation.suppressed.asList().shouldBeEmpty()
+        coVerify(exactly = 1) { mockSession.abortTransaction() }
+        verify(exactly = 1) { mockSession.close() }
+    }
+
+    @Test
+    fun `inTransaction preserves abort failure as suppressed on cancellation`() = runTest(timeout = 30.seconds) {
+        val cancellation = CancellationException("cancel transaction")
+        val abortFailure = RuntimeException("abort failed")
+
+        coEvery { mockSession.abortTransaction() } throws abortFailure
+
+        val deferred = async {
+            mockClient.inTransaction {
+                currentCoroutineContext().cancel(cancellation)
+                throw cancellation
+            }
+        }
+
+        val thrown = assertFailsWith<CancellationException> {
+            deferred.await()
+        }
+
+        val suppressed = cancellation.suppressed.asList()
+        thrown.message shouldBeEqualTo cancellation.message
+        suppressed.size shouldBeEqualTo 1
+        suppressed.single().message shouldBeEqualTo abortFailure.message
+        coVerify(exactly = 1) { mockSession.abortTransaction() }
+        verify(exactly = 1) { mockSession.close() }
     }
 
     @Test

--- a/docs/lessons/2026-07-04-issue-821-mongodb-transaction-abort.md
+++ b/docs/lessons/2026-07-04-issue-821-mongodb-transaction-abort.md
@@ -1,0 +1,37 @@
+# Lessons Learned - Issue #821 MongoDB Transaction Abort
+
+## Context
+
+`MongoClient.inTransaction` handled `CancellationException` correctly by
+rethrowing it, but called the suspend `ClientSession.abortTransaction()` from
+the already-cancelled coroutine context. That could skip the abort cleanup
+before MongoDB released the transaction.
+
+## Lesson
+
+Suspend cleanup that must run after coroutine cancellation needs an explicit
+`withContext(NonCancellable)` boundary. Keep that boundary as small as possible:
+only the cleanup call should run non-cancellable, and the original cancellation
+must still be rethrown.
+
+## Outcome
+
+MongoDB transaction abort now runs from `NonCancellable` for both cancellation
+and non-cancellation exception paths. Abort failures are preserved as suppressed
+exceptions on the owner throwable.
+
+## Future Guard
+
+When a suspend cleanup call runs from a `catch (e: CancellationException)` path,
+add a regression test that cancels the current coroutine context before cleanup
+and proves a suspension point inside cleanup still completes.
+
+## Verification
+
+- `:bluetape4k-mongodb:compileKotlin` and
+  `:bluetape4k-mongodb:compileTestKotlin` passed.
+- `:bluetape4k-mongodb:test --tests "io.bluetape4k.mongodb.MongoClientSupportTest"`
+  passed with 12 tests.
+- `:bluetape4k-mongodb:test` passed with 50 tests.
+- `:bluetape4k-mongodb:koverXmlReport` generated the XML coverage report.
+- `git diff --check` passed.

--- a/docs/review/2026-07-04-issue-821-mongodb-transaction-abort-review.md
+++ b/docs/review/2026-07-04-issue-821-mongodb-transaction-abort-review.md
@@ -1,0 +1,76 @@
+# Issue #821 MongoDB Transaction Abort Review
+
+Date: 2026-07-04
+Repo: `bluetape4k-projects`
+Scope: `data/mongodb` coroutine transaction cancellation cleanup
+
+## Gate
+
+- P0: 0
+- P1: 0
+- Verdict: PASS
+
+## 7-Tier Review
+
+### Tier 1 - Correctness
+
+- PASS. `MongoClient.inTransaction` now aborts the MongoDB transaction from a
+  `NonCancellable` context when the transaction block is cancelled.
+- PASS. Abort failures are added as suppressed exceptions to the owner throwable
+  and the original cancellation path is still rethrown.
+
+### Tier 2 - API and Compatibility
+
+- PASS. No public API signature or behavior was changed for successful
+  transactions.
+- PASS. The helper is private to the extension file and does not introduce a new
+  user-facing contract.
+
+### Tier 3 - Security and Privacy
+
+- PASS. No credential, query, document, or logging data handling changed.
+- PASS. Abort failure logging continues to log only the failure object and a
+  fixed message.
+
+### Tier 4 - Kotlin and bluetape4k Patterns
+
+- PASS. The implementation rethrows `CancellationException` after cleanup and
+  uses `NonCancellable` only for the suspend cleanup call.
+- PASS. Tests use class-level MockK fields and reset them in `@BeforeEach` with
+  `clearMocks(...)`.
+- PASS. Assertions use bluetape4k assertion helpers and infix comparison style.
+
+### Tier 5 - Tests
+
+- PASS. Added regression coverage proving cancelled-context abort cleanup still
+  reaches code after `yield()`.
+- PASS. Added cancellation-path coverage for preserving abort failure details as
+  suppressed exceptions.
+
+### Tier 6 - Operations
+
+- PASS. No dependency catalog, workflow, module registration, or CI path changes
+  were required.
+
+### Tier 7 - Documentation and Evidence
+
+- PASS. This review and the issue lesson record the cancellation cleanup rule
+  and verification evidence.
+
+## Verification Evidence
+
+- Compile validation:
+  `./gradlew :bluetape4k-mongodb:compileKotlin :bluetape4k-mongodb:compileTestKotlin --no-build-cache --no-configuration-cache` passed.
+- Targeted regression validation:
+  `./gradlew :bluetape4k-mongodb:test --tests "io.bluetape4k.mongodb.MongoClientSupportTest" --no-build-cache --no-configuration-cache` passed with 12 tests.
+- Module validation:
+  `./gradlew :bluetape4k-mongodb:test --no-build-cache --no-configuration-cache` passed with 50 tests.
+- Coverage report:
+  `./gradlew :bluetape4k-mongodb:koverXmlReport --no-build-cache --no-configuration-cache` passed and generated `data/mongodb/build/reports/kover/report.xml`.
+- `git diff --check` passed.
+
+## Residual Risk
+
+- The regression uses MockK to force a cancelled coroutine context at the
+  transaction boundary. Real-driver transaction success and failure paths remain
+  covered by the existing MongoDB module tests.


### PR DESCRIPTION
## Summary

Closes #821

- PR 제목: fix: preserve MongoDB transaction abort on cancellation

- Run `ClientSession.abortTransaction()` from a minimal `NonCancellable` cleanup boundary in `MongoClient.inTransaction`.
- Preserve abort cleanup failures as suppressed details while keeping cancellation propagation intact.
- Add focused cancellation-path regression tests using class-level MockK fields reset from `@BeforeEach`.
- Record 7-Tier review and lesson evidence for the MongoDB transaction cleanup rule.

### 원문 선행 내용

Closes #821.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

Closes #821.

### Summary

- Run `ClientSession.abortTransaction()` from a minimal `NonCancellable` cleanup boundary in `MongoClient.inTransaction`.
- Preserve abort cleanup failures as suppressed details while keeping cancellation propagation intact.
- Add focused cancellation-path regression tests using class-level MockK fields reset from `@BeforeEach`.
- Record 7-Tier review and lesson evidence for the MongoDB transaction cleanup rule.

### Validation

- `./gradlew :bluetape4k-mongodb:compileKotlin :bluetape4k-mongodb:compileTestKotlin :bluetape4k-mongodb:test :bluetape4k-mongodb:koverXmlReport --no-build-cache --no-configuration-cache`
- `git diff --check`
- GitHub CI for PR #981 passed: Build, Test / Data, Coverage Report, CI Status, Secret Scan, Validate Gradle Wrapper, Detect changed modules, and submit-gradle.

### Review Notes

- Existing real MongoDB module tests still cover driver-backed happy paths.
- The new regression tests isolate the cancelled-context cleanup behavior so the abort call must survive a suspension point after cancellation.

### DoD Status

- [x] Issue #821 cancellation bug fixed.
- [x] bluetape4k coroutine cancellation rule followed: cleanup uses `NonCancellable`, cancellation remains propagated.
- [x] MockK operations are class-level fields and reset in `@BeforeEach` with `clearMocks(...)`.
- [x] Targeted and module-level MongoDB tests pass.
- [x] Kover XML report generated for the changed module.
- [x] 7-Tier review and lesson docs added.
- [x] Live PR CI passed for PR #981.

## Validation

- `./gradlew :bluetape4k-mongodb:compileKotlin :bluetape4k-mongodb:compileTestKotlin :bluetape4k-mongodb:test :bluetape4k-mongodb:koverXmlReport --no-build-cache --no-configuration-cache`
- `git diff --check`
- GitHub CI for PR #981 passed: Build, Test / Data, Coverage Report, CI Status, Secret Scan, Validate Gradle Wrapper, Detect changed modules, and submit-gradle.

## Review Notes

- Existing real MongoDB module tests still cover driver-backed happy paths.
- The new regression tests isolate the cancelled-context cleanup behavior so the abort call must survive a suspension point after cancellation.

## Metadata

- Issue: #821, milestone `1.12.0`, assignee `debop`
- PR: #981, head `5942437234d13bd70fd9851231aadc31986fd70f`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-821-mongodb-abort-noncancellable`
- Labels: `bug`, `codex`, `codex-automation`, `coroutines`
- State: `MERGED`, merge commit `f1eda143f8497cccfc5d8a53f03fa76e80046540`
- CI: - `./gradlew :bluetape4k-mongodb:compileKotlin :bluetape4k-mongodb:compileTestKotlin :bluetape4k-mongodb:test :bluetape4k-mongodb:koverXmlReport --no-build-cache --no-configuration-cache` / - GitHub CI for PR #981 passed: Build, Test / Data, Coverage Report, CI Status, Secret Scan, Validate Gradle Wrapper, Detect changed modules, and submit-gradle. / - [x] Live PR CI passed for PR #981.

## DoD Status

- [x] Issue #821 cancellation bug fixed.
- [x] bluetape4k coroutine cancellation rule followed: cleanup uses `NonCancellable`, cancellation remains propagated.
- [x] MockK operations are class-level fields and reset in `@BeforeEach` with `clearMocks(...)`.
- [x] Targeted and module-level MongoDB tests pass.
- [x] Kover XML report generated for the changed module.
- [x] 7-Tier review and lesson docs added.
- [x] Live PR CI passed for PR #981.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #981 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `f1eda143f8497cccfc5d8a53f03fa76e80046540`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
