### PR TITLE
ci: pin Kotlin for CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,10 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO(#741, #743): Re-enable java-kotlin after CodeQL supports
-        # Kotlin 2.4.x. Keep actions/python analysis active while the Kotlin
-        # extractor support window catches up.
-        language: [python, actions]
+        language: [java-kotlin, python, actions]
 
     steps:
       - name: Checkout repository
@@ -30,6 +27,12 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+
+      - name: Pin Kotlin for CodeQL extractor
+        if: matrix.language == 'java-kotlin'
+        run: |
+          perl -0pi -e 's/kotlin = "2\.4\.0"/kotlin = "2.3.21"/' gradle/libs.versions.toml
+          grep -n 'kotlin = "2.3.21"' gradle/libs.versions.toml
 
       - name: Setup JDK 21
         if: matrix.language == 'java-kotlin'


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: ci: pin Kotlin for CodeQL analysis

- Pin Kotlin to 2.3.21 only inside the CodeQL java-kotlin analysis job.
- Keep the repository Gradle version catalog on Kotlin 2.4.0 for normal builds.
- Verify the temporary runner-side catalog rewrite before the CodeQL Gradle build starts.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Rationale

CodeQL Java/Kotlin extractor support can lag Kotlin 2.4.x. This keeps project builds on Kotlin 2.4.0 while allowing CodeQL analysis to build with the latest known supported Kotlin line.

## Validation

- `actionlint .github/workflows/codeql.yml`
- `git diff --check`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #982, head `16a867b60f1e5d3a23edac34a9048f6865c3acaf`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `fix/codeql-kotlin-extractor-pin`
- Labels: `ci`
- State: `MERGED`, merge commit `d4849c14e6bc0103b169ba1d13b44e11860b81b6`
- CI: - Keep the repository Gradle version catalog on Kotlin 2.4.0 for normal builds. / - Verify the temporary runner-side catalog rewrite before the CodeQL Gradle build starts.

## DoD Status

| Step | Status | Evidence |
|---|---:|---|
| Scope | PASS | Changed only `.github/workflows/codeql.yml` |
| CodeQL Kotlin pin | PASS | `java-kotlin` job rewrites `kotlin = "2.4.0"` to `2.3.21` in the runner workspace |
| Repository Kotlin version | PASS | Source catalog remains Kotlin 2.4.0 outside the workflow job |
| Workflow lint | PASS | `actionlint .github/workflows/codeql.yml` |
| Whitespace check | PASS | `git diff --check` |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #982 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `d4849c14e6bc0103b169ba1d13b44e11860b81b6`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
