### PR TITLE
fix: make MongoDB provider cache settings-aware

### DIFF
--- a/data/mongodb/README.ko.md
+++ b/data/mongodb/README.ko.md
@@ -9,7 +9,7 @@ MongoDB Kotlin Coroutine Driver(v5.x)는 이미 네이티브 `suspend` 함수와
 ## 특징
 
 - **MongoClient DSL**: `mongoClient {}` 빌더, `mongoClientOf()` 편의 팩토리
-- **MongoClient 캐싱**: `MongoClientProvider` — 연결 문자열 기반 인스턴스 캐싱
+- **MongoClient 캐싱**: `MongoClientProvider` — 최종 `MongoClientSettings` 기반 공유 client 캐싱
 - **Database 확장**: reified 타입 `getCollectionOf<T>()`, `listCollectionNamesList()`
 - **Collection 확장**: `findFirst`, `exists`, `upsert`, `findAsFlow` (skip/limit/sort 통합)
 - **BSON Document DSL**: `documentOf {}` 빌더, `getAs<T>()` 타입 안전 조회
@@ -54,7 +54,25 @@ val client2 = mongoClientOf("mongodb://localhost:27017")
 
 // 연결 문자열 기반 캐싱 (동일 URL → 동일 인스턴스)
 val client3 = MongoClientProvider.getOrCreate("mongodb://localhost:27017")
+
+// 커스텀 설정은 최종 MongoClientSettings를 cache key로 사용합니다.
+// URL이 같아도 설정이 다르면 서로 다른 공유 client를 반환합니다.
+val analyticsClient = MongoClientProvider.getOrCreate("mongodb://localhost:27017") {
+    applicationName("analytics-reader")
+}
+
+// Provider가 관리하는 client는 공유됩니다. 반환된 client를 직접 닫지 마세요.
+// 명시적인 lifecycle 경계에서는 provider를 통해 cache에서 제거하고 닫습니다.
+MongoClientProvider.close("mongodb://localhost:27017") {
+    applicationName("analytics-reader")
+}
+MongoClientProvider.closeAll()
 ```
+
+`MongoClientProvider`는 provider-managed shared client를 반환합니다. 동일한
+cached instance를 다른 caller가 사용할 수 있으므로 반환된 client에 직접
+`close()`를 호출하지 마세요. 단일 cache entry는 `MongoClientProvider.close(...)`,
+테스트나 애플리케이션 종료 경계에서는 `MongoClientProvider.closeAll()`로 정리합니다.
 
 ### 2. Database & Collection 확장
 

--- a/data/mongodb/README.md
+++ b/data/mongodb/README.md
@@ -10,7 +10,7 @@ Since the MongoDB Kotlin Coroutine Driver (v5.x) already provides native `suspen
 ## Features
 
 - **MongoClient DSL**: `mongoClient {}` builder and `mongoClientOf()` factory function
-- **MongoClient Caching**: `MongoClientProvider` — instance caching based on connection string
+- **MongoClient Caching**: `MongoClientProvider` — shared-client caching based on final `MongoClientSettings`
 - **Database Extensions**: Reified `getCollectionOf<T>()`, `listCollectionNamesList()`
 - **Collection Extensions**: `findFirst`, `exists`, `upsert`, `findAsFlow` (skip/limit/sort in one call)
 - **BSON Document DSL**: `documentOf {}` builder, type-safe `getAs<T>()` accessor
@@ -55,7 +55,25 @@ val client2 = mongoClientOf("mongodb://localhost:27017")
 
 // Connection-string-based caching (same URL → same instance)
 val client3 = MongoClientProvider.getOrCreate("mongodb://localhost:27017")
+
+// Custom settings use the final MongoClientSettings as the cache key.
+// Same URL + different settings returns different shared clients.
+val analyticsClient = MongoClientProvider.getOrCreate("mongodb://localhost:27017") {
+    applicationName("analytics-reader")
+}
+
+// Provider-managed clients are shared. Do not close the returned client directly.
+// Remove and close it through the provider when an explicit lifecycle boundary is needed.
+MongoClientProvider.close("mongodb://localhost:27017") {
+    applicationName("analytics-reader")
+}
+MongoClientProvider.closeAll()
 ```
+
+`MongoClientProvider` returns provider-managed shared clients. Callers should not
+call `close()` on the returned client because another caller may be using the
+same cached instance. Use `MongoClientProvider.close(...)` for one cache entry or
+`MongoClientProvider.closeAll()` for test/application shutdown boundaries.
 
 ### 2. Database & Collection Extensions
 

--- a/data/mongodb/src/main/kotlin/io/bluetape4k/mongodb/MongoClientProvider.kt
+++ b/data/mongodb/src/main/kotlin/io/bluetape4k/mongodb/MongoClientProvider.kt
@@ -6,59 +6,61 @@ import com.mongodb.kotlin.client.coroutine.MongoClient
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.info
 import io.bluetape4k.mongodb.MongoClientProvider.DEFAULT_CONNECTION_STRING
+import io.bluetape4k.support.closeSafe
+import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.utils.ShutdownQueue
 import java.util.concurrent.ConcurrentHashMap
 
 /**
- * [MongoClient] 인스턴스를 연결 문자열 또는 설정 기반으로 캐싱하고 관리합니다.
+ * Caches and manages coroutine [MongoClient] instances by [MongoClientSettings].
  *
- * 동일한 키(연결 문자열 또는 [MongoClientSettings])에 대해서는 동일한 [MongoClient]
- * 인스턴스를 반환하며, JVM 종료 시 등록된 클라이언트가 자동으로 닫힙니다.
+ * Calls that resolve to equal [MongoClientSettings] share the same provider-managed
+ * [MongoClient]. Callers must not close returned clients directly because the same
+ * cached instance may be used elsewhere. Use [close] or [closeAll] to remove and
+ * close provider-managed entries. Registered clients are also closed from the JVM
+ * shutdown queue.
  *
  * ```kotlin
  * val client = MongoClientProvider.getOrCreate("mongodb://localhost:27017")
+ * MongoClientProvider.close("mongodb://localhost:27017")
  * ```
  */
 object MongoClientProvider: KLogging() {
 
-    /** 기본 MongoDB 연결 문자열입니다. */
+    /** Default MongoDB connection string. */
     const val DEFAULT_CONNECTION_STRING = "mongodb://localhost:27017"
 
-    /** 기본 데이터베이스 이름입니다. */
+    /** Default database name. */
     const val DEFAULT_DATABASE_NAME = "test"
 
-    private val clientCache = ConcurrentHashMap<String, MongoClient>()
     private val settingsClientCache = ConcurrentHashMap<MongoClientSettings, MongoClient>()
 
     /**
-     * 연결 문자열에 해당하는 코루틴 [MongoClient]를 반환합니다.
+     * Returns a coroutine [MongoClient] for [connectionString].
      *
-     * 캐시에 해당 연결 문자열의 클라이언트가 없으면 새로 생성하고
-     * [ShutdownQueue]에 종료 훅을 등록합니다.
+     * The connection string is first converted to [MongoClientSettings], then the
+     * settings-based cache is used. The returned client is provider-managed and
+     * must be closed through [close] or [closeAll].
      *
      * ```kotlin
      * val client1 = MongoClientProvider.getOrCreate("mongodb://localhost:27017")
      * val client2 = MongoClientProvider.getOrCreate("mongodb://localhost:27017")
-     * // client1 === client2 (동일 인스턴스)
+     * // client1 === client2
      * ```
      *
-     * @param connectionString MongoDB 연결 문자열 (기본값: [DEFAULT_CONNECTION_STRING])
-     * @return 캐시된 또는 새로 생성된 코루틴 [MongoClient] 인스턴스
+     * @param connectionString MongoDB connection string. Defaults to [DEFAULT_CONNECTION_STRING].
+     * @return cached or newly created coroutine [MongoClient]
      */
     fun getOrCreate(connectionString: String = DEFAULT_CONNECTION_STRING): MongoClient {
-        return clientCache.computeIfAbsent(connectionString) { url ->
-            log.info { "Creating new MongoClient for $url" }
-            MongoClient.create(url).also {
-                ShutdownQueue.register(it)
-            }
-        }
+        return getOrCreate(mongoClientSettingsOf(connectionString))
     }
 
     /**
-     * 연결 문자열과 추가 설정으로 코루틴 [MongoClient]를 반환합니다.
+     * Returns a coroutine [MongoClient] for [connectionString] plus custom settings.
      *
-     * 연결 문자열을 캐시 키로 사용합니다. 동일한 연결 문자열로 처음 호출될 때
-     * [builder]를 적용하여 클라이언트를 생성합니다.
+     * The final [MongoClientSettings] produced after applying [builder] is the cache
+     * key. Therefore the same URL can return different clients when timeout, TLS,
+     * application name, credentials, or other effective settings differ.
      *
      * ```kotlin
      * val client = MongoClientProvider.getOrCreate("mongodb://localhost:27017") {
@@ -66,31 +68,22 @@ object MongoClientProvider: KLogging() {
      * }
      * ```
      *
-     * @param connectionString MongoDB 연결 문자열 (기본값: [DEFAULT_CONNECTION_STRING])
-     * @param builder [MongoClientSettings.Builder] 추가 설정 람다
-     * @return 캐시된 또는 새로 생성된 코루틴 [MongoClient] 인스턴스
+     * @param connectionString MongoDB connection string. Defaults to [DEFAULT_CONNECTION_STRING].
+     * @param builder additional [MongoClientSettings.Builder] configuration
+     * @return cached or newly created coroutine [MongoClient]
      */
     fun getOrCreate(
         connectionString: String = DEFAULT_CONNECTION_STRING,
         builder: MongoClientSettings.Builder.() -> Unit,
     ): MongoClient {
-        return clientCache.computeIfAbsent(connectionString) { url ->
-            log.info { "Creating new MongoClient for $url with custom settings" }
-            val settings = MongoClientSettings.builder()
-                .applyConnectionString(ConnectionString(url))
-                .apply(builder)
-                .build()
-            MongoClient.create(settings).also {
-                ShutdownQueue.register(it)
-            }
-        }
+        return getOrCreate(mongoClientSettingsOf(connectionString, builder))
     }
 
     /**
-     * [MongoClientSettings]에 해당하는 코루틴 [MongoClient]를 반환합니다.
+     * Returns a coroutine [MongoClient] for [settings].
      *
-     * [MongoClientSettings]를 캐시 키로 사용합니다.
-     * `MongoClientSettings`는 `equals()`/`hashCode()`를 올바르게 구현합니다.
+     * [MongoClientSettings] is used directly as the cache key. The returned client is
+     * provider-managed and must be closed through [close] or [closeAll].
      *
      * ```kotlin
      * val settings = MongoClientSettings.builder()
@@ -99,8 +92,8 @@ object MongoClientProvider: KLogging() {
      * val client = MongoClientProvider.getOrCreate(settings)
      * ```
      *
-     * @param settings [MongoClientSettings] 인스턴스
-     * @return 캐시된 또는 새로 생성된 코루틴 [MongoClient] 인스턴스
+     * @param settings effective MongoDB client settings
+     * @return cached or newly created coroutine [MongoClient]
      */
     fun getOrCreate(settings: MongoClientSettings): MongoClient {
         return settingsClientCache.computeIfAbsent(settings) {
@@ -109,6 +102,66 @@ object MongoClientProvider: KLogging() {
                 ShutdownQueue.register(it)
             }
         }
+    }
+
+    /**
+     * Removes and closes the provider-managed [MongoClient] for [connectionString].
+     *
+     * @return `true` when a cached client was found and closed; otherwise `false`
+     */
+    fun close(connectionString: String = DEFAULT_CONNECTION_STRING): Boolean {
+        return close(mongoClientSettingsOf(connectionString))
+    }
+
+    /**
+     * Removes and closes the provider-managed [MongoClient] for [connectionString]
+     * plus custom settings.
+     *
+     * This computes the same settings key as [getOrCreate], so it can explicitly
+     * manage a shared client created by the builder overload.
+     *
+     * @return `true` when a cached client was found and closed; otherwise `false`
+     */
+    fun close(
+        connectionString: String = DEFAULT_CONNECTION_STRING,
+        builder: MongoClientSettings.Builder.() -> Unit,
+    ): Boolean {
+        return close(mongoClientSettingsOf(connectionString, builder))
+    }
+
+    /**
+     * Removes and closes the provider-managed [MongoClient] for [settings].
+     *
+     * @return `true` when a cached client was found and closed; otherwise `false`
+     */
+    fun close(settings: MongoClientSettings): Boolean {
+        return settingsClientCache.remove(settings)
+            ?.also { it.closeSafe() }
+            ?.let { true }
+            ?: false
+    }
+
+    /**
+     * Closes every provider-managed [MongoClient] and clears the cache.
+     */
+    fun closeAll() {
+        settingsClientCache.forEach { (settings, client) ->
+            if (settingsClientCache.remove(settings, client)) {
+                client.closeSafe()
+            }
+        }
+    }
+
+    private fun mongoClientSettingsOf(
+        connectionString: String,
+        builder: MongoClientSettings.Builder.() -> Unit = {},
+    ): MongoClientSettings {
+        val url = connectionString.requireNotBlank("connectionString")
+
+        return MongoClientSettings.builder()
+            .applyConnectionString(ConnectionString(url))
+            .apply(builder)
+            .build()
     }
 
 }

--- a/data/mongodb/src/test/kotlin/io/bluetape4k/mongodb/MongoClientSupportTest.kt
+++ b/data/mongodb/src/test/kotlin/io/bluetape4k/mongodb/MongoClientSupportTest.kt
@@ -6,6 +6,13 @@ import com.mongodb.kotlin.client.coroutine.ClientSession
 import com.mongodb.kotlin.client.coroutine.MongoClient
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEmpty
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.assertions.shouldNotBeSameInstanceAs
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.mongodb.bson.documentOf
 import io.mockk.clearMocks
@@ -20,14 +27,9 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldContain
-import io.bluetape4k.assertions.shouldBeTrue
-import io.bluetape4k.assertions.shouldNotBeNull
 import kotlinx.coroutines.yield
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Assertions.assertNotSame
-import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Test
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.seconds
@@ -42,9 +44,15 @@ class MongoClientSupportTest: AbstractMongoTest() {
     @BeforeEach
     fun clearMock() {
         clearMocks(mockClient, mockSession)
+        MongoClientProvider.closeAll()
         coEvery { mockClient.startSession() } returns mockSession
         justRun { mockSession.startTransaction() }
         justRun { mockSession.close() }
+    }
+
+    @AfterEach
+    fun closeProviderClients() {
+        MongoClientProvider.closeAll()
     }
 
     @Test
@@ -69,17 +77,16 @@ class MongoClientSupportTest: AbstractMongoTest() {
     fun `MongoClientProvider getOrCreate 동일 URL에 동일 인스턴스 반환`() {
         val client1 = MongoClientProvider.getOrCreate(mongoServer.url)
         val client2 = MongoClientProvider.getOrCreate(mongoServer.url)
-        assertSame(client1, client2)
+
+        client1 shouldBeSameInstanceAs client2
     }
 
     @Test
     fun `MongoClientProvider getOrCreate 다른 URL에 다른 인스턴스 반환`() {
         val client1 = MongoClientProvider.getOrCreate(mongoServer.url)
-        val client2 = MongoClientProvider.getOrCreate(
-            mongoServer.url.replace("test", "other")
-        )
-        // 다른 URL이므로 다른 인스턴스
-        assertNotSame(client1, client2)
+        val client2 = MongoClientProvider.getOrCreate("${mongoServer.url}/other")
+
+        client1 shouldNotBeSameInstanceAs client2
     }
 
     @Test
@@ -89,8 +96,8 @@ class MongoClientSupportTest: AbstractMongoTest() {
             .build()
         val client1 = MongoClientProvider.getOrCreate(settings)
         val client2 = MongoClientProvider.getOrCreate(settings)
-        // 동일 설정이면 동일 인스턴스
-        assertSame(client1, client2)
+
+        client1 shouldBeSameInstanceAs client2
     }
 
     @Test
@@ -186,15 +193,50 @@ class MongoClientSupportTest: AbstractMongoTest() {
     }
 
     @Test
-    fun `MongoClientProvider getOrCreate 빌더 적용 동일 URL에 동일 인스턴스 반환`() {
+    fun `MongoClientProvider getOrCreate 빌더 적용 동일 설정에 동일 인스턴스 반환`() {
         val url = mongoServer.url
         val c1 = MongoClientProvider.getOrCreate(url) {
-            // 추가 설정 없음
+            applicationName("bt4k-provider-cache")
         }
         val c2 = MongoClientProvider.getOrCreate(url) {
-            // 동일 URL → 이미 캐시된 인스턴스 반환
+            applicationName("bt4k-provider-cache")
         }
-        assertSame(c1, c2)
+
+        c1 shouldBeSameInstanceAs c2
+    }
+
+    @Test
+    fun `MongoClientProvider getOrCreate 빌더 적용 동일 URL 다른 설정에 다른 인스턴스 반환`() {
+        val url = mongoServer.url
+        val c1 = MongoClientProvider.getOrCreate(url) {
+            applicationName("bt4k-provider-cache-first")
+        }
+        val c2 = MongoClientProvider.getOrCreate(url) {
+            applicationName("bt4k-provider-cache-second")
+        }
+
+        c1 shouldNotBeSameInstanceAs c2
+    }
+
+    @Test
+    fun `MongoClientProvider close removes provider managed cached client`() {
+        val url = mongoServer.url
+        val client1 = MongoClientProvider.getOrCreate(url) {
+            applicationName("bt4k-provider-close")
+        }
+
+        MongoClientProvider.close(url) {
+            applicationName("bt4k-provider-close")
+        }.shouldBeTrue()
+        MongoClientProvider.close(url) {
+            applicationName("bt4k-provider-close")
+        }.shouldBeFalse()
+
+        val client2 = MongoClientProvider.getOrCreate(url) {
+            applicationName("bt4k-provider-close")
+        }
+
+        client1 shouldNotBeSameInstanceAs client2
     }
 
     @Test

--- a/docs/lessons/2026-07-04-issue-820-mongodb-provider-cache.md
+++ b/docs/lessons/2026-07-04-issue-820-mongodb-provider-cache.md
@@ -1,0 +1,28 @@
+# Issue #820 MongoDB Provider Cache Semantics
+
+## Context
+
+`MongoClientProvider.getOrCreate(connectionString, builder)` cached by URL only.
+The first caller for a URL decided the effective settings for all later callers
+with the same URL, even when those later callers supplied different builder
+settings.
+
+## Decision
+
+Cache provider-managed clients by the final immutable `MongoClientSettings`
+instead of the raw connection string. Keep the existing overloads source
+compatible, but route every overload through the settings cache.
+
+## Outcome
+
+- Same URL plus equal settings returns the same shared client.
+- Same URL plus different settings returns different shared clients.
+- Provider-owned shared clients now have explicit `close(...)` and `closeAll()`
+  lifecycle APIs, and README/KDoc warns callers not to directly close returned
+  shared instances.
+
+## Future Rule
+
+When a provider overload accepts a builder or custom options, the cache key must
+represent the final effective configuration. Do not cache by only the "base"
+identifier when caller-provided settings can change runtime behavior.

--- a/docs/review/2026-07-04-issue-820-mongodb-provider-cache-review.md
+++ b/docs/review/2026-07-04-issue-820-mongodb-provider-cache-review.md
@@ -1,0 +1,37 @@
+# Issue #820 MongoDB Provider Cache Review
+
+## Scope
+
+- Issue: #820 `P1: Make MongoClientProvider custom-settings cache semantics safe`
+- Module: `:bluetape4k-mongodb`
+- Files reviewed:
+  - `data/mongodb/src/main/kotlin/io/bluetape4k/mongodb/MongoClientProvider.kt`
+  - `data/mongodb/src/test/kotlin/io/bluetape4k/mongodb/MongoClientSupportTest.kt`
+  - `data/mongodb/README.md`
+  - `data/mongodb/README.ko.md`
+
+## 7-Tier Review
+
+| Tier | Result | Evidence |
+|---|---|---|
+| API contract | PASS | `MongoClientProvider` now caches all overloads by final immutable `MongoClientSettings`; provider-managed ownership is explicit through `close(...)` and `closeAll()`. |
+| Correctness | PASS | Same URL plus equal settings returns the same client; same URL plus different settings returns different clients. |
+| Resource lifecycle | PASS | Provider-managed clients are removed before `closeSafe()`; `closeAll()` removes by `(key, value)` to avoid clearing entries created concurrently after iteration starts. |
+| Kotlin style | PASS | Uses package-level helper style already present in the module, `requireNotBlank`, `val`, and bluetape4k assertion extensions in touched tests. |
+| Test quality | PASS | Regression tests cover equal settings, different settings with the same URL, and explicit provider close semantics. MockK operations remain field-level with `clearMocks` in `@BeforeEach`. |
+| Documentation | PASS | English and Korean READMEs describe settings-based cache keys and provider-managed shared-client ownership. Public KDoc is English. |
+| Compatibility | PASS | `getOrCreate(connectionString)` and builder overloads remain source-compatible; only cache semantics become settings-aware. |
+
+## Verification
+
+- `./gradlew :bluetape4k-mongodb:compileKotlin :bluetape4k-mongodb:compileTestKotlin :bluetape4k-mongodb:test :bluetape4k-mongodb:koverXmlReport --no-build-cache --no-configuration-cache`
+  - Result: PASS
+  - Tests: 52 passing
+  - Coverage XML: `data/mongodb/build/reports/kover/report.xml`
+- `git diff --check`
+  - Result: PASS
+
+## Residual Risk
+
+- Shutdown hooks may still see already-closed clients when a provider entry is closed explicitly before JVM shutdown. This is acceptable because provider close paths use `closeSafe()` and MongoDB clients tolerate repeated close calls.
+- `closeAll()` is intended for lifecycle and test boundaries, not as a hot-path cache eviction policy.


### PR DESCRIPTION
## Summary

Closes #820

- PR 제목: fix: make MongoDB provider cache settings-aware

- Route all `MongoClientProvider.getOrCreate(...)` overloads through the final immutable `MongoClientSettings` cache key.
- Add provider-managed `close(...)` and `closeAll()` APIs so shared-client ownership is explicit.
- Add MongoDB regression tests for same URL with equal settings, same URL with different custom settings, and provider close semantics.
- Update `README.md`, `README.ko.md`, and public KDoc with settings-aware cache and shared-client lifecycle guidance.

Closes #820

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Review Evidence

- 7-Tier review artifact: `docs/review/2026-07-04-issue-820-mongodb-provider-cache-review.md`
- Lesson artifact: `docs/lessons/2026-07-04-issue-820-mongodb-provider-cache.md`

### 기존 섹션: Verification

- PASS: `./gradlew :bluetape4k-mongodb:compileKotlin :bluetape4k-mongodb:compileTestKotlin :bluetape4k-mongodb:test :bluetape4k-mongodb:koverXmlReport --no-build-cache --no-configuration-cache`
  - 52 tests passing
  - Kover XML generated at `data/mongodb/build/reports/kover/report.xml`
- PASS: `git diff --check`
- PASS: GitHub Actions for PR #983
  - Build
  - Test / Data
  - Coverage Report
  - CI Status
  - Secret Scan (gitleaks)
  - Validate Gradle Wrapper
  - Detect changed modules
  - submit-gradle

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #820, milestone `1.12.0`, assignee `debop`
- PR: #983, head `5d0e0932d28ef1207f3539676095dd21131b7a01`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-820-mongodb-provider-cache`
- Labels: `bug`, `codex`, `codex-automation`
- State: `MERGED`, merge commit `b8a5b2d6d24d23fc8c5cccabd5e11aeb3f6f4970`
- CI: - Add provider-managed `close(...)` and `closeAll()` APIs so shared-client ownership is explicit. / - PASS: `./gradlew :bluetape4k-mongodb:compileKotlin :bluetape4k-mongodb:compileTestKotlin :bluetape4k-mongodb:test :bluetape4k-mongodb:koverXmlReport --no-build-cache --no-configuration-cache` / - CI Status

## DoD Status

| Requirement | Status | Evidence |
|---|---|---|
| Safe custom-settings cache semantics | PASS | Cache key is now the final `MongoClientSettings`, so same URL with different effective settings gets distinct clients. |
| Provider-managed ownership explicit | PASS | Added `MongoClientProvider.close(...)` and `closeAll()` plus README/KDoc guidance that returned clients are shared and should not be directly closed. |
| Regression tests | PASS | Added tests for equal settings sharing, same URL with different settings, and close/recreate behavior. |
| Documentation parity | PASS | Updated `data/mongodb/README.md` and `data/mongodb/README.ko.md`. |
| Local verification | PASS | Module compile/test/kover and `git diff --check` passed. |
| CI verification | PASS | GitHub Actions run `28710153716` completed successfully; `Test / Data` passed in 6m19s. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #983 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `b8a5b2d6d24d23fc8c5cccabd5e11aeb3f6f4970`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
