### PR TITLE
fix: isolate stateless session transaction resource

### DIFF
--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/spring/StatelessSessionFactoryBean.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/spring/StatelessSessionFactoryBean.kt
@@ -18,29 +18,20 @@ import org.springframework.util.ReflectionUtils
 import java.sql.Connection
 
 /**
- * Spring 트랜잭션에 바인딩된 Hibernate [StatelessSession] 프록시를 제공하는 FactoryBean입니다.
+ * Provides a Hibernate [StatelessSession] proxy bound to the current Spring transaction.
  *
- * ## 동작/계약
- * - `getObject()`는 매 호출마다 프록시를 반환하고, 실제 세션은 메서드 호출 시 트랜잭션 컨텍스트에서 조회/생성됩니다.
- * - 활성 트랜잭션이 없으면 인터셉터의 `check(...)`에 의해 `IllegalStateException`이 발생합니다.
- * - 현재 트랜잭션 리소스에 세션이 없으면 JDBC 연결 기반으로 새 `StatelessSession`을 열고 트랜잭션 종료 시 close 합니다.
- * - 수신 객체를 직접 변경하지 않으며, 트랜잭션 리소스 바인딩으로 동작을 연결합니다.
+ * ## Contract
+ * - [getObject] returns a proxy; the real session is resolved lazily for each method call.
+ * - Calls require an active Spring transaction and fail with [IllegalStateException] outside one.
+ * - The stateless session is stored under a dedicated transaction resource key, so it cannot
+ *   collide with Spring's `SessionFactory` or `EntityManager` resource binding.
+ * - The session created by this factory is unbound and closed when the transaction completes.
  *
  * ```kotlin
- * entityManager.withStateless { stateless ->
- *     repeat(COUNT) {
- *         val master = createMaster("master-$it")
- *         stateless.insert(master)
- *         master.details.forEach { detail ->
- *             stateless.insert(detail)
- *         }
- *     }
- * }
+ * statelessSession.insert(entity)
  * ```
  *
- * 참고 : https://gist.github.com/jelies/5181262
- *
- * @param sf 트랜잭션 리소스 키와 세션 생성을 위한 Hibernate [SessionFactory]
+ * @param sf Hibernate [SessionFactory] used to create stateless sessions.
  */
 class StatelessSessionFactoryBean(
     @field:Autowired val sf: SessionFactory,
@@ -59,9 +50,11 @@ class StatelessSessionFactoryBean(
 
     class StatelessSessionInterceptor(private val sf: SessionFactory): org.aopalliance.intercept.MethodInterceptor {
 
+        private val resourceKey = StatelessSessionResourceKey(sf)
+
         override fun invoke(invocation: MethodInvocation): Any? {
             val stateless = getCurrentStatelessSession()
-            return ReflectionUtils.invokeMethod(invocation.method, stateless, invocation.arguments)
+            return ReflectionUtils.invokeMethod(invocation.method, stateless, *invocation.arguments)
         }
 
         private fun getCurrentStatelessSession(): StatelessSession {
@@ -69,7 +62,7 @@ class StatelessSessionFactoryBean(
                 "현 스레드에 활성화된 Transaction이 없습니다. StatelessSession은 Transaction하에서만 작동됩니다."
             }
 
-            return TransactionSynchronizationManager.getResource(sf) as? StatelessSession
+            return TransactionSynchronizationManager.getResource(resourceKey) as? StatelessSession
                 ?: run {
                     log.info { "현 스레드에 새로운 StatelessSession 인스턴스를 생성합니다." }
                     newStatelessSession().apply {
@@ -91,13 +84,31 @@ class StatelessSessionFactoryBean(
 
         private fun bindWithTransaction(stateless: StatelessSession) {
             log.debug { "bind stateless session with transaction. statelessSession=$stateless" }
-            TransactionSynchronizationManager.registerSynchronization(StatelessSessionSynchronization(sf, stateless))
-            TransactionSynchronizationManager.bindResource(sf, stateless)
+            TransactionSynchronizationManager.registerSynchronization(
+                StatelessSessionSynchronization(resourceKey, stateless)
+            )
+            TransactionSynchronizationManager.bindResource(resourceKey, stateless)
+        }
+    }
+
+    private class StatelessSessionResourceKey(
+        private val sessionFactory: SessionFactory,
+    ) {
+        override fun equals(other: Any?): Boolean {
+            return other is StatelessSessionResourceKey && sessionFactory === other.sessionFactory
+        }
+
+        override fun hashCode(): Int {
+            return System.identityHashCode(sessionFactory)
+        }
+
+        override fun toString(): String {
+            return "StatelessSessionResourceKey(sessionFactory=$sessionFactory)"
         }
     }
 
     private class StatelessSessionSynchronization(
-        private val sf: SessionFactory,
+        private val resourceKey: StatelessSessionResourceKey,
         private val stateless: StatelessSession,
     ): TransactionSynchronization {
 
@@ -112,8 +123,13 @@ class StatelessSessionFactoryBean(
         }
 
         override fun beforeCompletion() {
-            TransactionSynchronizationManager.unbindResource(sf)
-            stateless.close()
+            try {
+                if (TransactionSynchronizationManager.getResource(resourceKey) === stateless) {
+                    TransactionSynchronizationManager.unbindResource(resourceKey)
+                }
+            } finally {
+                stateless.close()
+            }
         }
     }
 }

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/spring/stateless/StatelessSessionTest.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/spring/stateless/StatelessSessionTest.kt
@@ -1,5 +1,12 @@
 package io.bluetape4k.hibernate.spring.stateless
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.assertions.shouldNotBeEmpty
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.hibernate.spring.AbstractJpaTest
 import io.bluetape4k.hibernate.stateless.withStateless
 import io.bluetape4k.idgenerators.uuid.Uuid
@@ -8,19 +15,29 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.asInt
 import io.bluetape4k.support.asString
-import io.bluetape4k.assertions.shouldNotBeEmpty
+import org.hibernate.SessionFactory
+import org.hibernate.StatelessSession
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.transaction.AfterTransaction
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronizationManager
+import org.springframework.transaction.support.TransactionTemplate
 import kotlin.system.measureTimeMillis
 
 /**
  * 대량의 데이터 삽입 시에는 Stateless 가 Stateful 보다 최소 3배 정도 빠르다
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+@Import(StatelessSessionTestConfiguration::class)
 class StatelessSessionTest: AbstractJpaTest() {
     companion object: KLogging() {
         private const val COUNT = 10 // 1_000
@@ -40,6 +57,20 @@ class StatelessSessionTest: AbstractJpaTest() {
             }
     }
 
+    @Autowired
+    private lateinit var statelessSession: StatelessSession
+
+    @Autowired
+    private lateinit var sessionFactory: SessionFactory
+
+    @Autowired
+    private lateinit var transactionManager: PlatformTransactionManager
+
+    @AfterTransaction
+    fun assertNoStatelessSessionResourceLeak() {
+        currentStatelessResources().shouldHaveSize(0)
+    }
+
     @Order(0)
     @Test
     fun `warm up`() {
@@ -55,6 +86,41 @@ class StatelessSessionTest: AbstractJpaTest() {
             tem.persist(getStatelessEntity(it))
         }
         flushAndClear()
+    }
+
+    @Test
+    fun `injected StatelessSession proxy reuses dedicated transaction resource`() {
+        statelessSession.isOpen.shouldBeTrue()
+        val first = currentStatelessResource()
+        (TransactionSynchronizationManager.getResource(sessionFactory) is StatelessSession).shouldBeFalse()
+
+        statelessSession.isOpen.shouldBeTrue()
+        val second = currentStatelessResource()
+
+        second shouldBeSameInstanceAs first
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    fun `injected StatelessSession proxy unbinds and closes after transaction completion`() {
+        var opened: StatelessSession? = null
+
+        TransactionTemplate(transactionManager).executeWithoutResult {
+            statelessSession.isOpen.shouldBeTrue()
+            opened = currentStatelessResource()
+            opened.shouldNotBeNull().isOpen.shouldBeTrue()
+        }
+
+        currentStatelessResources().shouldHaveSize(0)
+        opened.shouldNotBeNull().isOpen.shouldBeFalse()
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    fun `injected StatelessSession proxy rejects calls outside transaction`() {
+        assertFailsWith<IllegalStateException> {
+            statelessSession.isOpen
+        }
     }
 
     @Nested
@@ -164,5 +230,17 @@ class StatelessSessionTest: AbstractJpaTest() {
             detail.master = master
         }
         return master
+    }
+
+    private fun currentStatelessResource(): StatelessSession {
+        val resources = currentStatelessResources()
+        resources.shouldHaveSize(1)
+        return resources.single()
+    }
+
+    private fun currentStatelessResources(): List<StatelessSession> {
+        return TransactionSynchronizationManager.getResourceMap()
+            .values
+            .filterIsInstance<StatelessSession>()
     }
 }

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/spring/stateless/StatelessSessionTestConfiguration.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/spring/stateless/StatelessSessionTestConfiguration.kt
@@ -1,6 +1,14 @@
 package io.bluetape4k.hibernate.spring.stateless
 
+import org.hibernate.SessionFactory
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+
+@TestConfiguration(proxyBeanMethods = false)
 class StatelessSessionTestConfiguration {
 
-    // TODO: [StatelessSessionFactoryBean] 을 사용하여 작업하는 것을 테스트해야 한다.
+    @Bean
+    fun statelessSession(sf: SessionFactory): StatelessSessionFactoryBean {
+        return StatelessSessionFactoryBean(sf)
+    }
 }

--- a/docs/lessons/2026-07-05-issue-813-stateless-session-resource.md
+++ b/docs/lessons/2026-07-05-issue-813-stateless-session-resource.md
@@ -1,0 +1,32 @@
+# Issue #813 Stateless Session Resource Binding
+
+## Context
+
+`StatelessSessionFactoryBean` stored provider-created `StatelessSession`
+instances in Spring's transaction resource map using the `SessionFactory` itself
+as the key. Spring JPA transaction infrastructure also uses the factory key for
+its own resource binding, so the stateless proxy path could collide with the
+active `EntityManager` lifecycle.
+
+## Decision
+
+Use a dedicated transaction resource key for stateless sessions. The key is tied
+to the exact `SessionFactory` identity but has a separate key type, so it cannot
+collide with Spring's ordinary `SessionFactory` or `EntityManager` resources.
+
+## Outcome
+
+- The injected `StatelessSession` proxy reuses the same stateless session inside
+  one transaction.
+- The proxy no longer binds a `StatelessSession` under the raw `SessionFactory`
+  key.
+- The exact resource created by the factory is unbound and closed when the
+  transaction completes.
+- Calls outside an active transaction still fail fast.
+
+## Future Rule
+
+When integrating custom resources with Spring's
+`TransactionSynchronizationManager`, never reuse a framework-owned resource key
+for a different lifecycle participant. Use a dedicated key type and test both
+same-transaction reuse and after-completion cleanup.

--- a/docs/review/2026-07-05-issue-813-stateless-session-resource-review.md
+++ b/docs/review/2026-07-05-issue-813-stateless-session-resource-review.md
@@ -1,0 +1,50 @@
+# Issue #813 Stateless Session Resource Review
+
+## Scope
+
+- Issue: #813 `P1: Isolate Spring stateless session resource binding`
+- Module: `:bluetape4k-hibernate`
+- Files reviewed:
+  - `data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/spring/StatelessSessionFactoryBean.kt`
+  - `data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/spring/stateless/StatelessSessionTest.kt`
+  - `data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/spring/stateless/StatelessSessionTestConfiguration.kt`
+
+## 7-Tier Review
+
+| Tier | Result | Evidence |
+|---|---|---|
+| API contract | PASS | Existing `StatelessSession` proxy bean contract is preserved; the backing transaction resource key is now dedicated to stateless sessions. |
+| Correctness | PASS | `SessionFactory` resource binding is no longer reused for stateless sessions, preventing collisions with Spring's `EntityManager` resource. |
+| Lifecycle | PASS | The exact stateless session resource created by the factory is unbound and closed in transaction completion. |
+| Kotlin style | PASS | Touched tests use bluetape4k assertions, infix identity assertions, and no JUnit assertion APIs. |
+| Test quality | PASS | Regression tests cover same-transaction reuse, close/unbind after completion, and outside-transaction failure. |
+| Documentation | PASS | Public KDoc for the touched FactoryBean is English and describes the dedicated resource-key contract. |
+| Evidence integrity | PASS | CodeGraph incremental build re-parsed 3 changed files; its test-gap hints are covered by integration tests that exercise the proxy bean through Spring transactions. |
+
+## Verification
+
+- `./gradlew :bluetape4k-hibernate:compileKotlin :bluetape4k-hibernate:compileTestKotlin :bluetape4k-hibernate:test --tests 'io.bluetape4k.hibernate.spring.stateless.StatelessSessionTest' --no-build-cache --no-configuration-cache`
+  - Result: PASS
+  - Tests: 17 passing
+- `./gradlew :bluetape4k-hibernate:compileKotlin :bluetape4k-hibernate:compileTestKotlin :bluetape4k-hibernate:test :bluetape4k-hibernate:koverXmlReport --no-build-cache --no-configuration-cache`
+  - Result: PASS
+  - Main tests: 497 passing
+  - Consumer runtime tests: 3 passing
+  - Coverage XML: `data/hibernate/build/reports/kover/report.xml`
+- CodeGraph incremental update
+  - Result: PASS
+  - Files re-parsed: 3
+  - Changed functions/classes: 20
+  - Risk score: 0.60
+
+## Findings
+
+- P0/P1: 0
+- P2/P3: 0
+
+## Notes
+
+The new tests also exposed an existing proxy invocation bug: the interceptor passed
+`invocation.arguments` as one array argument instead of spreading it. The fix now
+uses `*invocation.arguments`, which allows no-arg methods such as `isOpen()` to
+delegate correctly.


### PR DESCRIPTION
## Summary

Closes #813

- PR 제목: fix: isolate stateless session transaction resource

- Use a dedicated Spring transaction resource key for `StatelessSessionFactoryBean` instead of binding stateless sessions under the raw `SessionFactory` key.
- Unbind only the exact stateless-session resource created by the factory and close it during transaction completion.
- Fix proxy delegation to spread `MethodInvocation.arguments`, which the new proxy-path tests exposed for no-arg methods such as `isOpen()`.
- Add Spring transactional tests for same-transaction reuse, after-completion cleanup, and outside-transaction failure.

Closes #813

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Review Evidence

- 7-Tier review artifact: `docs/review/2026-07-05-issue-813-stateless-session-resource-review.md`
- Lesson artifact: `docs/lessons/2026-07-05-issue-813-stateless-session-resource.md`
- CodeGraph incremental update: 3 changed files re-parsed, no dependent files.

### 기존 섹션: Verification

- PASS: `./gradlew :bluetape4k-hibernate:compileKotlin :bluetape4k-hibernate:compileTestKotlin :bluetape4k-hibernate:test --tests 'io.bluetape4k.hibernate.spring.stateless.StatelessSessionTest' --no-build-cache --no-configuration-cache`
  - 17 tests passing
- PASS: `./gradlew :bluetape4k-hibernate:compileKotlin :bluetape4k-hibernate:compileTestKotlin :bluetape4k-hibernate:test :bluetape4k-hibernate:koverXmlReport --no-build-cache --no-configuration-cache`
  - 497 main tests passing
  - 3 consumer runtime tests passing
  - Kover XML generated at `data/hibernate/build/reports/kover/report.xml`
- PASS: `git diff --check`
- PASS: GitHub Actions run `28710897814`
  - Build, Test / Data, Coverage Report, CI Status, Secret Scan, Gradle Wrapper, Detect changed modules, and submit-gradle passed.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #813, milestone `1.12.0`, assignee `debop`
- PR: #984, head `a05ca36f005d39370a847ba695e439aba003e65a`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-813-stateless-session-resource`
- Labels: `bug`, `codex`, `codex-automation`
- State: `MERGED`, merge commit `391c749142c3611d6a6b5d2407dae3472635a580`
- CI: - PASS: `./gradlew :bluetape4k-hibernate:compileKotlin :bluetape4k-hibernate:compileTestKotlin :bluetape4k-hibernate:test --tests 'io.bluetape4k.hibernate.spring.stateless.StatelessSessionTest' --no-build-cache --no-configuration-cache` / - PASS: `./gradlew :bluetape4k-hibernate:compileKotlin :bluetape4k-hibernate:compileTestKotlin :bluetape4k-hibernate:test :bluetape4k-hibernate:koverXmlReport --no-build-cache --no-configuration-cache` / - Build, Test / Data, Coverage Report, CI Status, Secret Scan, Gradle Wrapper, Detect changed modules, and submit-gradle passed.

## DoD Status

| Requirement | Status | Evidence |
|---|---|---|
| Dedicated stateless-session resource key | PASS | `StatelessSessionFactoryBean` now binds under a private key type tied to `SessionFactory` identity, not the raw `SessionFactory` key. |
| Exact resource cleanup | PASS | `beforeCompletion()` unbinds only when the currently bound resource is the stateless session created by the factory, then closes it. |
| Transactional proxy regression tests | PASS | Tests cover same-transaction reuse, after-completion unbind/close, and outside-transaction failure. |
| Kotlin/bluetape4k patterns | PASS | Touched tests use bluetape4k assertions and no method-local MockK setup. |
| Review gate | PASS | 7-Tier review recorded P0/P1 = 0 in `docs/review/2026-07-05-issue-813-stateless-session-resource-review.md`. |
| Local verification | PASS | Targeted test, full module test/kover, CodeGraph incremental update, and `git diff --check` passed. |
| CI verification | PASS | GitHub Actions run `28710897814` passed; `Test / Data` passed in 6m30s and `Coverage Report` passed in 20s. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #984 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `391c749142c3611d6a6b5d2407dae3472635a580`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
