### PR TITLE
fix: align transient entity hash contract

### DIFF
--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/model/AbstractJpaEntity.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/model/AbstractJpaEntity.kt
@@ -7,46 +7,41 @@ import org.hibernate.Hibernate
 import java.io.Serializable
 
 /**
- * [JpaEntity]의 최상위 추상화 클래스입니다.
+ * Base abstraction for JPA entities.
+ *
+ * Equality uses the assigned identifier only when both entities are persisted.
+ * Transient entities fall back to [equalProperties], so their default
+ * [hashCode] must stay stable for hash-based collections before persistence.
  */
 abstract class AbstractJpaEntity<ID: Serializable>: AbstractPersistenceObject(), JpaEntity<ID> {
 
     companion object: KLogging() {
         /**
-         * 엔티티가 저장되었다고 한다면, identifier 값이 할당되어 있을 것이고, identifier만으로 두 엔티티가 같은지 검사합니다.
-         * @param id     현 엔티티의 identifer의 값
-         * @param target 비교 대상 엔티티
-         * @param <TId>  엔티티의 identifer의 수형
-         * @return 두 엔티티의 identifer 가 같은지 여부
+         * Returns whether the persisted [target] has the same non-null identifier.
          */
         private fun <TId> hasSameNonDefaultId(id: TId, target: JpaEntity<*>): Boolean =
             id == target.id
 
         /**
-         * transient object 는 아직 identifier 의 값이 없으므로, business logic 상 엔티티를 구분할 수 있는 값으로 비교해야 합니다.
-         * 업무로직 상 구분 상 같은지 여부를 판단하는 메소드입니다.
-         * @param target 비교할 대상 객체
-         * @param <TId> 엔티티의 고유 값을 나타내는 identifier의 수형
-         * @return 업무로직 상 두 값이 같은 값을 나타내는지 여부
+         * Returns whether two transient entities share the same business signature.
          */
         private fun <TId> hasSameBusinessSignature(self: AbstractJpaEntity<*>, target: JpaEntity<*>): Boolean =
             self.equalProperties(target)
     }
 
     /**
-     * 엔티티가 Persistent Object 인지 여부를 반환합니다.
+     * Returns whether this entity already has an assigned identifier.
      */
     @get:Transient
     override val isPersisted: Boolean get() = id != null
 
     /**
-     * 엔티티가 같은 지 비교합니다.
-     * 일반적인 Language 차원의 비교가 아닌,
-     * 엔티티의 Identifier를 비교하던가, 저장 전 객체 (transient object) 인 경우에는 Business identifier 를 구해 비교합니다.
+     * Compares entities by identifier once both are persisted.
      *
-     * 두 엔티티 모두 Persist 인 경우에만 Id 로 비교하고, 나머지 경우에는 business signature를 비교합니다.
+     * Transient entities are compared by their business signature. A persisted
+     * entity and a transient entity are never considered equal.
      *
-     * @param other 비교할 엔티티
+     * @param other the candidate entity to compare
      */
     override fun equals(other: Any?): Boolean {
         val target = other?.let { Hibernate.unproxy(it) } as? JpaEntity<*> ?: return false
@@ -58,16 +53,18 @@ abstract class AbstractJpaEntity<ID: Serializable>: AbstractPersistenceObject(),
     }
 
     /**
-     * 엔티티의 고유 값을 제공합니다.
-     * persistent object 인 경우에는 identifier의 hash code를 반환하고,
-     * transient object 인 경우에는 business logic 에 의한 고유 값을 반환합니다.
+     * Returns the entity hash code.
+     *
+     * Persisted entities use the identifier hash. Transient entities use the
+     * Hibernate-resolved entity class hash so equal transient instances land in
+     * the same hash bucket even before an identifier is assigned.
      */
     override fun hashCode(): Int {
-        return id?.hashCode() ?: System.identityHashCode(this)
+        return id?.hashCode() ?: Hibernate.getClass(this).hashCode()
     }
 
     /**
-     * 로그 출력도 비용이 많이 드는 작업입니다. 꼭 필요한 정보만 출력하게 하면 성능 저하를 최소화할 수 있습니다.
+     * Builds a concise string representation for logging.
      */
     override fun buildStringHelper(): ToStringBuilder {
         return super.buildStringHelper()

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/model/AbstractJpaEntityUnitTest.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/model/AbstractJpaEntityUnitTest.kt
@@ -1,11 +1,12 @@
 package io.bluetape4k.hibernate.model
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
-import java.io.Serializable
 
 class AbstractJpaEntityUnitTest {
 
@@ -92,16 +93,29 @@ class AbstractJpaEntityUnitTest {
     }
 
     @Test
-    fun `hashCode는 transient 엔티티에서 identityHashCode를 반환한다`() {
-        val entity = TestEntity("test")
-        val hash = entity.hashCode()
-        hash.shouldNotBeNull()
+    fun `동일한 transient 엔티티는 같은 hashCode를 반환한다`() {
+        val e1 = TestEntity("alice")
+        val e2 = TestEntity("alice")
+
+        e1.hashCode() shouldBeEqualTo e2.hashCode()
+    }
+
+    @Test
+    fun `동일한 transient 엔티티는 hash set에서 하나의 논리 요소로 처리된다`() {
+        val e1 = TestEntity("alice")
+        val e2 = TestEntity("alice")
+        val entities = hashSetOf(e1)
+
+        entities.add(e2).shouldBeFalse()
+
+        entities shouldHaveSize 1
+        entities.contains(e2).shouldBeTrue()
     }
 
     @Test
     fun `hashCode는 persisted 엔티티에서 id hashCode를 반환한다`() {
         val entity = TestEntity("test", id = 42L)
-        entity.hashCode().shouldNotBeNull()
+        entity.hashCode() shouldBeEqualTo 42L.hashCode()
     }
 
     @Test

--- a/docs/lessons/2026-07-05-issue-812-jpa-entity-hashcode.md
+++ b/docs/lessons/2026-07-05-issue-812-jpa-entity-hashcode.md
@@ -1,0 +1,17 @@
+# Issue #812 Lesson
+
+## Context
+
+`AbstractJpaEntity` compared transient entities through `equalProperties`, but returned `System.identityHashCode(this)` when `id == null`.
+
+## Decision
+
+Use the Hibernate-resolved entity class hash for transient entities and keep identifier-based hashing for persisted entities.
+
+## Outcome
+
+Equal transient entities now land in the same hash bucket, so hash-based collections treat them as one logical element before persistence assigns an identifier.
+
+## Future Guidance
+
+When entity equality has a transient business-signature path, add a hash-based collection regression test. Do not use identity hash for objects that can compare equal by business fields.

--- a/docs/review/2026-07-05-issue-812-jpa-entity-hashcode-review.md
+++ b/docs/review/2026-07-05-issue-812-jpa-entity-hashcode-review.md
@@ -1,0 +1,32 @@
+# Issue #812 7-Tier Review
+
+## Scope
+
+- Issue: #812, `P1: Fix transient equals/hashCode contract in Hibernate entity base`
+- Files:
+  - `data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/model/AbstractJpaEntity.kt`
+  - `data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/model/AbstractJpaEntityUnitTest.kt`
+
+## Findings
+
+- P0/P1 findings: 0
+- Contract: PASS. Equal transient entities now share the Hibernate entity class hash instead of identity hash.
+- Persisted behavior: PASS. Persisted entities still hash by assigned identifier.
+- Regression coverage: PASS. Unit tests cover equal transient hash equality, `HashSet` single logical element behavior, and persisted ID hash behavior.
+- Kotlin/bluetape4k style: PASS. Tests use bluetape4k assertions with infix matchers where applicable and no method-local MockK setup.
+- Public API documentation: PASS. Touched public KDoc is English and documents the transient hash contract.
+
+## Tool Evidence
+
+- CodeGraph incremental update: 2 files re-parsed, 26 nodes and 144 edges updated, no dependent files.
+- CodeGraph change detection: 2 changed files, risk score 0.55, 0 affected flows.
+- CodeGraph reported test gaps for `AbstractJpaEntity` and `hashCode`; reviewed as covered by the new direct unit tests in `AbstractJpaEntityUnitTest`.
+
+## Verification
+
+- PASS: `./gradlew :bluetape4k-hibernate:compileKotlin :bluetape4k-hibernate:compileTestKotlin :bluetape4k-hibernate:test --tests 'io.bluetape4k.hibernate.model.AbstractJpaEntityUnitTest' --no-build-cache --no-configuration-cache`
+  - 15 tests passing.
+- PASS: `./gradlew :bluetape4k-hibernate:compileKotlin :bluetape4k-hibernate:compileTestKotlin :bluetape4k-hibernate:test :bluetape4k-hibernate:koverXmlReport --no-build-cache --no-configuration-cache`
+  - 498 main tests passing.
+  - 3 consumer runtime tests passing.
+  - Kover XML report generated.


### PR DESCRIPTION
## Summary

Closes #812

- PR 제목: fix: align transient entity hash contract

- Change `AbstractJpaEntity` transient `hashCode()` from identity hash to the Hibernate-resolved entity class hash.
- Keep persisted entity hashing based on the assigned identifier.
- Add regression tests proving equal transient entities have equal hash codes and collapse to one logical element in a `HashSet`.
- Refresh touched public KDoc to document the transient hash contract.

Closes #812

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Review Evidence

- 7-Tier review artifact: `docs/review/2026-07-05-issue-812-jpa-entity-hashcode-review.md`
- Lesson artifact: `docs/lessons/2026-07-05-issue-812-jpa-entity-hashcode.md`
- CodeGraph incremental update: 2 files re-parsed, no dependent files.
- CodeGraph change detection: risk score 0.55, 0 affected flows; direct unit tests cover the reported `hashCode` gap.

### 기존 섹션: Verification

- PASS: `./gradlew :bluetape4k-hibernate:compileKotlin :bluetape4k-hibernate:compileTestKotlin :bluetape4k-hibernate:test --tests 'io.bluetape4k.hibernate.model.AbstractJpaEntityUnitTest' --no-build-cache --no-configuration-cache`
  - 15 tests passing
- PASS: `./gradlew :bluetape4k-hibernate:compileKotlin :bluetape4k-hibernate:compileTestKotlin :bluetape4k-hibernate:test :bluetape4k-hibernate:koverXmlReport --no-build-cache --no-configuration-cache`
  - 498 main tests passing
  - 3 consumer runtime tests passing
  - Kover XML generated
- PASS: `git diff --check`
- PASS: GitHub Actions run `28711435027`
  - Build, Test / Data, Coverage Report, CI Status, Secret Scan, Gradle Wrapper, Detect changed modules, and submit-gradle passed.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #812, milestone `1.12.0`, assignee `debop`
- PR: #985, head `92e4ed5a1d89eceb16217ed53d4e452417c26608`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-812-jpa-entity-hashcode`
- Labels: `bug`, `codex`, `codex-automation`
- State: `MERGED`, merge commit `39f5e8351398a10f8fdc81269b5eb819293c6d34`
- CI: - PASS: `./gradlew :bluetape4k-hibernate:compileKotlin :bluetape4k-hibernate:compileTestKotlin :bluetape4k-hibernate:test --tests 'io.bluetape4k.hibernate.model.AbstractJpaEntityUnitTest' --no-build-cache --no-configuration-cache` / - PASS: `./gradlew :bluetape4k-hibernate:compileKotlin :bluetape4k-hibernate:compileTestKotlin :bluetape4k-hibernate:test :bluetape4k-hibernate:koverXmlReport --no-build-cache --no-configuration-cache` / - Build, Test / Data, Coverage Report, CI Status, Secret Scan, Gradle Wrapper, Detect changed modules, and submit-gradle passed.

## DoD Status

| Requirement | Status | Evidence |
|---|---|---|
| Transient equals/hashCode contract | PASS | Equal transient entities now share the Hibernate entity class hash. |
| Persisted entity behavior | PASS | Persisted entities still hash by assigned identifier. |
| Hash collection regression | PASS | `AbstractJpaEntityUnitTest` verifies equal transient entities produce equal hashes and a `HashSet` keeps one logical element. |
| Kotlin/bluetape4k patterns | PASS | Tests use bluetape4k assertions and infix matchers where applicable; no method-local MockK setup. |
| Review gate | PASS | 7-Tier review recorded P0/P1 = 0 in `docs/review/2026-07-05-issue-812-jpa-entity-hashcode-review.md`. |
| Local verification | PASS | Targeted test, full module test/kover, CodeGraph incremental update, and `git diff --check` passed. |
| CI verification | PASS | GitHub Actions run `28711435027` passed; `Test / Data` passed in 6m2s and `Coverage Report` passed in 10s. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #985 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `39f5e8351398a10f8fdc81269b5eb819293c6d34`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
