### PR TITLE
fix: honor Cassandra bootstrap builder options

### DIFF
--- a/data/cassandra/README.ko.md
+++ b/data/cassandra/README.ko.md
@@ -69,10 +69,10 @@ session.use { /* 작업 수행 */ }
 
 #### 명시적 identity로 Session 캐싱
 
-`CqlSessionProvider.getOrCreateSession`은 keyspace만이 아니라 `CqlSessionIdentity`를 기준으로 캐시합니다. 같은 keyspace를 서로 다른 contact point, datacenter, credential, client id, tenant context에서 사용할 수 있다면 명시적 identity를 지정하세요.
+`CqlSessionProvider.getOrCreateSession`은 keyspace만이 아니라 `CqlSessionIdentity`를 기준으로 캐시합니다. 같은 keyspace를 서로 다른 contact point, datacenter, credential, client id, tenant context에서 사용할 수 있다면 명시적 identity를 지정하세요. Provider는 최종 keyspace-bound session을 열기 전에 bootstrap admin session으로 keyspace를 먼저 생성합니다. 따라서 builder block에는 contact point, local datacenter, credential, TLS, application 설정처럼 bootstrap과 최종 session에 공통으로 필요한 옵션을 넣고, `withKeyspace(...)`는 넣지 마세요. 대상 keyspace는 bootstrap 이후 provider가 직접 바인딩합니다.
 
 ```kotlin
-val sessionIdentity = CqlSessionIdentity.of(
+val sessionIdentity = cqlSessionIdentityOf(
     keyspace = "tenant_data",
     contextParts = listOf(
         "contactPoint=cassandra-a.example.com:9042",
@@ -85,11 +85,12 @@ val sessionIdentity = CqlSessionIdentity.of(
 val tenantSession = CqlSessionProvider.getOrCreateSession(sessionIdentity) {
     addContactPoint(InetSocketAddress("cassandra-a.example.com", 9042))
     withLocalDatacenter("dc-a")
+    withAuthCredentials("username", "password")
     withApplicationName("analytics-worker")
 }
 ```
 
-`keyspace`만 받는 호환 overload는 builder supplier와 builder lambda에서 보수적인 per-call identity를 만들어 사용합니다. 따라서 서로 다른 builder block이 keyspace만으로 조용히 같은 세션을 재사용하는 문제는 피하지만, 여러 call site에서 같은 context를 안정적으로 재사용하려면 `CqlSessionIdentity`를 명시하세요.
+`keyspace`만 받는 호환 overload는 builder supplier와 builder lambda에서 보수적인 per-call identity를 만들어 사용합니다. 따라서 서로 다른 builder block이 keyspace만으로 조용히 같은 세션을 재사용하는 문제는 피하지만, 여러 call site에서 같은 context를 안정적으로 재사용하려면 `CqlSessionIdentity`를 명시하세요. 최종 session에만 유효한 옵션이 필요하다면 `bootstrapBuilder`와 `sessionBuilder`를 분리하는 overload를 사용하세요.
 
 ### 2. 비동기 쿼리 (Coroutines)
 

--- a/data/cassandra/README.md
+++ b/data/cassandra/README.md
@@ -69,10 +69,10 @@ session.use { /* perform operations */ }
 
 #### Cached sessions with explicit identity
 
-`CqlSessionProvider.getOrCreateSession` caches by `CqlSessionIdentity`, not by keyspace alone. Use an explicit identity when the same keyspace can be reached through different contact points, datacenters, credentials, client ids, or tenant contexts.
+`CqlSessionProvider.getOrCreateSession` caches by `CqlSessionIdentity`, not by keyspace alone. Use an explicit identity when the same keyspace can be reached through different contact points, datacenters, credentials, client ids, or tenant contexts. The provider creates the keyspace with a bootstrap admin session before opening the final keyspace-bound session, so the builder block must contain shared connection options such as contact points, local datacenter, credentials, TLS, and application settings. Do not set `withKeyspace(...)` inside the shared builder block; the provider binds the target keyspace after bootstrap.
 
 ```kotlin
-val sessionIdentity = CqlSessionIdentity.of(
+val sessionIdentity = cqlSessionIdentityOf(
     keyspace = "tenant_data",
     contextParts = listOf(
         "contactPoint=cassandra-a.example.com:9042",
@@ -85,11 +85,12 @@ val sessionIdentity = CqlSessionIdentity.of(
 val tenantSession = CqlSessionProvider.getOrCreateSession(sessionIdentity) {
     addContactPoint(InetSocketAddress("cassandra-a.example.com", 9042))
     withLocalDatacenter("dc-a")
+    withAuthCredentials("username", "password")
     withApplicationName("analytics-worker")
 }
 ```
 
-The compatibility overload that accepts only `keyspace` derives a conservative per-call identity from the builder supplier and builder lambda. That avoids silent keyspace-only reuse across different builder blocks, but stable reuse across call sites should use an explicit `CqlSessionIdentity`.
+The compatibility overload that accepts only `keyspace` derives a conservative per-call identity from the builder supplier and builder lambda. That avoids silent keyspace-only reuse across different builder blocks, but stable reuse across call sites should use an explicit `CqlSessionIdentity`. If the final session needs options that are not valid for bootstrap, call the overload with separate `bootstrapBuilder` and `sessionBuilder` lambdas.
 
 ### 2. Asynchronous Queries (Coroutines)
 

--- a/data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/CqlSessionProvider.kt
+++ b/data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/CqlSessionProvider.kt
@@ -31,21 +31,33 @@ data class CqlSessionIdentity(
         /**
          * Builds a deterministic identity from normalized context parts.
          */
+        @Deprecated(
+            message = "Use the Kotlin package function cqlSessionIdentityOf().",
+            replaceWith = ReplaceWith("cqlSessionIdentityOf(keyspace, contextParts)")
+        )
         fun of(
             keyspace: String,
             contextParts: Iterable<String>,
-        ): CqlSessionIdentity {
-            keyspace.requireNotBlank("keyspace")
-            val context = contextParts
-                .map { it.trim() }
-                .filter { it.isNotEmpty() }
-                .sorted()
-                .joinToString(separator = "|")
-                .ifBlank { "default" }
-
-            return CqlSessionIdentity(keyspace, context)
-        }
+        ): CqlSessionIdentity = cqlSessionIdentityOf(keyspace, contextParts)
     }
+}
+
+/**
+ * Builds a deterministic Cassandra session cache identity from normalized context parts.
+ */
+fun cqlSessionIdentityOf(
+    keyspace: String,
+    contextParts: Iterable<String>,
+): CqlSessionIdentity {
+    keyspace.requireNotBlank("keyspace")
+    val context = contextParts
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .sorted()
+        .joinToString(separator = "|")
+        .ifBlank { "default" }
+
+    return CqlSessionIdentity(keyspace, context)
 }
 
 object CqlSessionProvider: KLogging() {
@@ -57,15 +69,15 @@ object CqlSessionProvider: KLogging() {
     const val DEFAULT_KEYSPACE = "general"
 
     /**
-     * 새로운 [CqlSessionBuilder] 를 생성합니다.
+     * Creates a new [CqlSessionBuilder] with the provided contact point and local datacenter.
      *
      * ```
      * val builder = CqlSessionProvider.newCqlSessionBuilder(InetSocketAddress("localhost", 9042), "datacenter1")
      * ```
      *
-     * @param contactPoint    Cassandra 서버 주소
-     * @param localDatacenter LocalDataCenter 이름
-     * @return [CqlSessionBuilder] 인스턴스
+     * @param contactPoint Cassandra server address.
+     * @param localDatacenter Local datacenter name.
+     * @return A configured [CqlSessionBuilder].
      */
     fun newCqlSessionBuilder(
         contactPoint: InetSocketAddress = DEFAULT_CONTACT_POINT,
@@ -88,15 +100,20 @@ object CqlSessionProvider: KLogging() {
      * ```
      * val session = CqlSessionProvider.getOrCreateSession("keyspace") {
      *   withLocalDatacenter("datacenter1")
-     *   withKeyspace("keyspace")
      *   withAuthCredentials("username", "password")
      * }
      * ```
      *
-     * @param keyspace  keyspace 명, null 이면 cql 에 keyspace 를 지정해주어야 합니다.
-     * @param builderSupplier [CqlSessionBuilder]를 제공하는 Supplier
-     * @param builder [CqlSessionBuilder]를 이용하여 설정하는 함수
-     * @return `keyspace` 전용의 [CqlSession] 인스턴스
+     * [builder] is applied to both the bootstrap admin session and the final keyspace-bound
+     * session, so secured or custom driver options are honored while creating the keyspace.
+     * Do not set the keyspace inside [builder]; this provider binds [keyspace] only after
+     * bootstrap. Use the overload with explicit `bootstrapBuilder` and `sessionBuilder` when
+     * the final session needs additional keyspace-specific settings.
+     *
+     * @param keyspace Keyspace name to bootstrap and bind.
+     * @param builderSupplier Supplier that creates a fresh [CqlSessionBuilder].
+     * @param builder Shared builder customization for bootstrap and final sessions.
+     * @return A cached [CqlSession] bound to [keyspace].
      */
     fun getOrCreateSession(
         keyspace: String = DEFAULT_KEYSPACE,
@@ -107,7 +124,12 @@ object CqlSessionProvider: KLogging() {
 
         val sessionIdentity = toSessionIdentity(keyspace, builderSupplier, builder)
 
-        return resolveSession(sessionIdentity, builderSupplier, builder)
+        return resolveSession(
+            identity = sessionIdentity,
+            builderSupplier = builderSupplier,
+            bootstrapBuilder = builder,
+            sessionBuilder = builder,
+        )
     }
 
     /**
@@ -115,19 +137,76 @@ object CqlSessionProvider: KLogging() {
      *
      * Use this overload when the builder is created outside [CqlSessionProvider] or when the caller
      * needs to include additional tenant, credential, or routing state in the cache boundary.
+     *
+     * [builder] is applied to both the bootstrap admin session and the final keyspace-bound session.
+     * Do not set the keyspace inside [builder]; this provider binds [identity.keyspace] only after
+     * bootstrap. Use the overload with explicit `bootstrapBuilder` and `sessionBuilder` when the
+     * final session needs additional keyspace-specific settings.
      */
     fun getOrCreateSession(
         identity: CqlSessionIdentity,
         builderSupplier: () -> CqlSessionBuilder = { newCqlSessionBuilder() },
         builder: CqlSessionBuilder.() -> Unit,
     ): CqlSession {
-        return resolveSession(identity, builderSupplier, builder)
+        return resolveSession(
+            identity = identity,
+            builderSupplier = builderSupplier,
+            bootstrapBuilder = builder,
+            sessionBuilder = builder,
+        )
+    }
+
+    /**
+     * Creates or reuses a [CqlSession] with separate bootstrap and final-session configuration.
+     *
+     * Use [bootstrapBuilder] for connection, credential, TLS, driver, and application settings
+     * required to create [identity.keyspace]. Use [sessionBuilder] for the same shared options plus
+     * any settings that are valid only after the keyspace exists.
+     */
+    fun getOrCreateSession(
+        identity: CqlSessionIdentity,
+        builderSupplier: () -> CqlSessionBuilder = { newCqlSessionBuilder() },
+        bootstrapBuilder: CqlSessionBuilder.() -> Unit,
+        sessionBuilder: CqlSessionBuilder.() -> Unit,
+    ): CqlSession {
+        return resolveSession(
+            identity = identity,
+            builderSupplier = builderSupplier,
+            bootstrapBuilder = bootstrapBuilder,
+            sessionBuilder = sessionBuilder,
+        )
+    }
+
+    /**
+     * Creates or reuses a [CqlSession] with separate bootstrap and final-session configuration.
+     *
+     * This overload derives a conservative cache identity from [keyspace], [builderSupplier], and
+     * [sessionBuilder]. Prefer the [CqlSessionIdentity] overload when stable cache reuse across call
+     * sites is required.
+     */
+    fun getOrCreateSession(
+        keyspace: String = DEFAULT_KEYSPACE,
+        builderSupplier: () -> CqlSessionBuilder = { newCqlSessionBuilder() },
+        bootstrapBuilder: CqlSessionBuilder.() -> Unit,
+        sessionBuilder: CqlSessionBuilder.() -> Unit,
+    ): CqlSession {
+        keyspace.requireNotBlank("keyspace")
+
+        val sessionIdentity = toSessionIdentity(keyspace, builderSupplier, sessionBuilder)
+
+        return resolveSession(
+            identity = sessionIdentity,
+            builderSupplier = builderSupplier,
+            bootstrapBuilder = bootstrapBuilder,
+            sessionBuilder = sessionBuilder,
+        )
     }
 
     private fun resolveSession(
         identity: CqlSessionIdentity,
         builderSupplier: () -> CqlSessionBuilder,
-        builder: CqlSessionBuilder.() -> Unit,
+        bootstrapBuilder: CqlSessionBuilder.() -> Unit,
+        sessionBuilder: CqlSessionBuilder.() -> Unit,
     ): CqlSession {
         // Cache may still contain closed sessions from previous runs.
         // Drop them before resolving the requested session identity.
@@ -139,14 +218,17 @@ object CqlSessionProvider: KLogging() {
         return sessionCache.computeIfAbsent(identity) {
             log.info { "Creating new CqlSession for ${identity.keyspace} (${identity.context})" }
 
-            // keyspace가 없을 수 있으므로, adminSession으로 신규 keyspace를 생성하도록 합니다.
-            builderSupplier().build().use { adminSession ->
-                CassandraAdmin.createKeyspace(adminSession, identity.keyspace)
-            }
+            // The keyspace may not exist yet, so bootstrap with an admin session before binding it.
+            builderSupplier()
+                .apply(bootstrapBuilder)
+                .build()
+                .use { adminSession ->
+                    CassandraAdmin.createKeyspace(adminSession, identity.keyspace)
+                }
 
             builderSupplier()
+                .apply(sessionBuilder)
                 .withKeyspace(identity.keyspace)
-                .apply(builder)
                 .build()
                 .also {
                     ShutdownQueue.register(it)
@@ -161,7 +243,7 @@ private fun toSessionIdentity(
     builderSupplier: () -> CqlSessionBuilder,
     builder: CqlSessionBuilder.() -> Unit,
 ): CqlSessionIdentity {
-    return CqlSessionIdentity.of(
+    return cqlSessionIdentityOf(
         keyspace = keyspace,
         contextParts = listOf(
             "builderSupplier=${builderSupplier.cachePart()}",

--- a/data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/CqlSessionProviderTest.kt
+++ b/data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/CqlSessionProviderTest.kt
@@ -1,10 +1,11 @@
 package io.bluetape4k.cassandra
 
-import io.bluetape4k.logging.coroutines.KLoggingChannel
-import io.bluetape4k.support.closeSafe
+import com.datastax.oss.driver.api.core.CqlSessionBuilder
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeEqualTo
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.support.closeSafe
 import org.junit.jupiter.api.Test
 import java.net.InetSocketAddress
 import java.util.*
@@ -25,7 +26,7 @@ class CqlSessionProviderTest: AbstractCassandraTest() {
             )
         }
         val clientId = UUID.randomUUID()
-        val sessionIdentity = CqlSessionIdentity.of(
+        val sessionIdentity = cqlSessionIdentityOf(
             keyspace = TEST_KEYSPACE_1,
             contextParts = listOf(
                 "contactPoint=${cassandra4.host}:${cassandra4.port}",
@@ -56,6 +57,29 @@ class CqlSessionProviderTest: AbstractCassandraTest() {
         session1.closeSafe()
         session2.closeSafe()
         session3.closeSafe()
+    }
+
+    @Test
+    fun `keyspace bootstrap 에 caller builder 설정을 적용한다`() {
+        val sessionIdentity = cqlSessionIdentityOf(
+            keyspace = "provider_bootstrap_${UUID.randomUUID().toString().take(8)}",
+            contextParts = listOf(
+                "contactPoint=${cassandra4.host}:${cassandra4.port}",
+                "localDatacenter=${CqlSessionProvider.DEFAULT_LOCAL_DATACENTER}",
+                "applicationName=provider-test-bootstrap",
+            ),
+        )
+        val bareBuilderSupplier = { CqlSessionBuilder() }
+
+        val session = CqlSessionProvider.getOrCreateSession(sessionIdentity, bareBuilderSupplier) {
+            addContactPoint(InetSocketAddress(cassandra4.host, cassandra4.port))
+            withLocalDatacenter(CqlSessionProvider.DEFAULT_LOCAL_DATACENTER)
+            withApplicationName("provider-test-bootstrap")
+        }
+
+        session.keyspace.orElseThrow().asInternal() shouldBeEqualTo sessionIdentity.keyspace
+
+        session.closeSafe()
     }
 
     @Test

--- a/docs/lessons/2026-07-05-issue-810-cassandra-bootstrap-builder.md
+++ b/docs/lessons/2026-07-05-issue-810-cassandra-bootstrap-builder.md
@@ -1,0 +1,18 @@
+# Issue 810 - Cassandra Bootstrap Builder
+
+## Context
+
+`CqlSessionProvider` created an admin session to bootstrap the keyspace before it applied the caller builder block. Secured clusters could fail even when the final session builder contained valid credentials, TLS, contact point, or driver options.
+
+## Decision
+
+Apply the shared builder block to both bootstrap and final sessions. Bind the provider-managed keyspace after bootstrap, and expose explicit bootstrap/session builder overloads for callers whose final session needs settings that are invalid before the keyspace exists.
+
+## Outcome
+
+The regression test uses a bare `CqlSessionBuilder` supplier and relies on the caller builder block for contact point and datacenter. It fails without bootstrap builder application and passes with the new behavior.
+
+## Future Guidance
+
+Do not hide administrative side effects behind a final-session-only builder. When a helper performs DDL before returning a client/session, document which builder settings apply to the admin path and provide separate hooks when some settings are phase-specific.
+

--- a/docs/review/2026-07-05-issue-810-cassandra-bootstrap-review.md
+++ b/docs/review/2026-07-05-issue-810-cassandra-bootstrap-review.md
@@ -1,0 +1,35 @@
+# Issue 810 - Cassandra Bootstrap Builder Review
+
+## Scope
+
+- `data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/CqlSessionProvider.kt`
+- `data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/CqlSessionProviderTest.kt`
+- `data/cassandra/README.md`
+- `data/cassandra/README.ko.md`
+
+## 7-Tier Review
+
+| Tier | Result | Evidence |
+|------|--------|----------|
+| API contract | PASS | Shared builder settings now apply to bootstrap and final sessions; explicit bootstrap/session builder overloads cover keyspace-specific settings. |
+| Correctness | PASS | The final session binds `identity.keyspace` after bootstrap, preserving keyspace creation order. |
+| Regression coverage | PASS | `CqlSessionProviderTest` proves a bare supplier only succeeds when caller builder contact point and datacenter are applied during bootstrap. |
+| Kotlin style | PASS | New identity creation uses the package function `cqlSessionIdentityOf`; existing `of()` is retained only as deprecated compatibility. |
+| Resource lifecycle | PASS | Admin session still closes with `use`; final session remains registered in `ShutdownQueue`. |
+| Documentation | PASS | README and README.ko document bootstrap side effects and keyspace binding rules. |
+| Blast radius | PASS | CodeGraph review context and impact radius report low risk and no impacted nodes. |
+
+## Findings
+
+- P0: none.
+- P1: none.
+
+## Verification
+
+- PASS: `./gradlew :bluetape4k-cassandra:compileKotlin :bluetape4k-cassandra:compileTestKotlin --no-build-cache --no-configuration-cache`
+- PASS: `./gradlew :bluetape4k-cassandra:test --tests 'io.bluetape4k.cassandra.CqlSessionProviderTest' --no-build-cache --no-configuration-cache`
+- PASS: `./gradlew :bluetape4k-cassandra:compileKotlin :bluetape4k-cassandra:compileTestKotlin :bluetape4k-cassandra:test :bluetape4k-cassandra:consumerRuntimeTest :bluetape4k-cassandra:koverXmlReport --no-build-cache --no-configuration-cache`
+  - 180 main tests passing
+  - 1 consumer runtime test passing
+  - Kover XML generated
+- PASS: `git diff --check`


### PR DESCRIPTION
## Summary

Closes #810

- PR 제목: fix: honor Cassandra bootstrap builder options

- Apply caller-provided Cassandra builder settings to the keyspace bootstrap admin session.
- Keep final session keyspace binding provider-managed after bootstrap, and add explicit bootstrap/session builder overloads for phase-specific settings.
- Add `cqlSessionIdentityOf(...)` as the Kotlin package-function identity factory while retaining `CqlSessionIdentity.of(...)` as deprecated compatibility.
- Document bootstrap side effects and keyspace binding rules in `README.md` and `README.ko.md`.

Closes #810

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Review Evidence

- 7-Tier review artifact: `docs/review/2026-07-05-issue-810-cassandra-bootstrap-review.md`
- Lesson artifact: `docs/lessons/2026-07-05-issue-810-cassandra-bootstrap-builder.md`
- CodeGraph review context: risk low, 0 impacted nodes.
- CodeGraph impact radius: risk low, 0 impacted files.

### 기존 섹션: Verification

- PASS: GitHub Actions run `28713611735`
  - Build, Test / Data, Coverage Report, CI Status, Secret Scan, Gradle Wrapper, Detect changed modules, and submit-gradle passed.
- PASS: `./gradlew :bluetape4k-cassandra:compileKotlin :bluetape4k-cassandra:compileTestKotlin --no-build-cache --no-configuration-cache`
- PASS: `./gradlew :bluetape4k-cassandra:test --tests 'io.bluetape4k.cassandra.CqlSessionProviderTest' --no-build-cache --no-configuration-cache`
  - 5 `CqlSessionProviderTest` tests passing
- PASS: `./gradlew :bluetape4k-cassandra:compileKotlin :bluetape4k-cassandra:compileTestKotlin :bluetape4k-cassandra:test :bluetape4k-cassandra:consumerRuntimeTest :bluetape4k-cassandra:koverXmlReport --no-build-cache --no-configuration-cache`
  - 180 main tests passing
  - 1 consumer runtime test passing
  - Kover XML generated
- PASS: `git diff --check`

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #810, milestone `1.12.0`, assignee `debop`
- PR: #986, head `31e8e1cb3b03c9bb20e5fbe3c0d5a931fd09de5c`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-810-cassandra-keyspace-options`
- Labels: `bug`, `codex`, `codex-automation`
- State: `MERGED`, merge commit `0ad15119db8bcccc6d9a3448919b6de903723cd5`
- CI: - Keep final session keyspace binding provider-managed after bootstrap, and add explicit bootstrap/session builder overloads for phase-specific settings. / - Build, Test / Data, Coverage Report, CI Status, Secret Scan, Gradle Wrapper, Detect changed modules, and submit-gradle passed. / - PASS: `./gradlew :bluetape4k-cassandra:compileKotlin :bluetape4k-cassandra:compileTestKotlin --no-build-cache --no-configuration-cache`

## DoD Status

| Requirement | Status | Evidence |
|---|---|---|
| Bootstrap builder options | PASS | `resolveSession` applies `bootstrapBuilder` before building the admin session used by `CassandraAdmin.createKeyspace`. |
| Final session keyspace binding | PASS | Final session applies session settings, then binds `identity.keyspace` after bootstrap. |
| Explicit admin/session split | PASS | New overloads accept separate `bootstrapBuilder` and `sessionBuilder` lambdas for phase-specific settings. |
| Kotlin/bluetape4k patterns | PASS | New identity factory uses package function `cqlSessionIdentityOf`; assertions use bluetape4k infix matchers. |
| Regression coverage | PASS | `CqlSessionProviderTest` uses a bare supplier and proves caller builder contact point/datacenter are required for bootstrap success. |
| Documentation | PASS | `README.md`, `README.ko.md`, and public KDoc document bootstrap behavior and `withKeyspace` placement. |
| Local and CI verification | PASS | Targeted test, full Cassandra module test/consumerRuntimeTest/kover, CodeGraph checks, `git diff --check`, and GitHub Actions run `28713611735` passed. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #986 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `0ad15119db8bcccc6d9a3448919b6de903723cd5`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
