### PR TITLE
fix: close Elasticsearch PIT after cancellation

### DIFF
--- a/docs/lessons/2026-07-05-issue-807-elasticsearch-pit-cleanup.md
+++ b/docs/lessons/2026-07-05-issue-807-elasticsearch-pit-cleanup.md
@@ -1,0 +1,18 @@
+# Issue 807 - Elasticsearch PIT Cleanup
+
+## Context
+
+`searchAsFlow` opened a Point-in-Time context and closed it from the collector coroutine's `finally` block. During cancellation, a suspend close call can be cancelled before it reaches Elasticsearch.
+
+## Decision
+
+Move PIT close into a small `NonCancellable` best-effort cleanup helper. Log cleanup failures without replacing the original collector cancellation or upstream failure.
+
+## Outcome
+
+A new unit test proves suspend cleanup completes after the parent coroutine is cancelled, and the existing Elasticsearch integration test continues to pass.
+
+## Future Guidance
+
+When a coroutine Flow opens a remote resource and closes it with a suspend call, put the close path behind a `NonCancellable` cleanup boundary and test the helper independently from heavy infrastructure tests.
+

--- a/docs/review/2026-07-05-issue-807-elasticsearch-pit-cleanup-review.md
+++ b/docs/review/2026-07-05-issue-807-elasticsearch-pit-cleanup-review.md
@@ -1,0 +1,35 @@
+# Issue 807 - Elasticsearch PIT Cleanup Review
+
+## Scope
+
+- `infra/elasticsearch/src/main/kotlin/io/bluetape4k/elasticsearch/coroutines/SearchApiCoroutines.kt`
+- `infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/SearchApiCoroutinesUnitTest.kt`
+- `infra/elasticsearch/README.md`
+- `infra/elasticsearch/README.ko.md`
+
+## 7-Tier Review
+
+| Tier | Result | Evidence |
+|------|--------|----------|
+| Correctness | PASS | `searchAsFlow` now closes PIT through `closePointInTimeBestEffort` from `finally`. |
+| Cancellation safety | PASS | PIT close runs inside `withContext(NonCancellable)` so collector cancellation does not skip suspend cleanup. |
+| Failure propagation | PASS | Cleanup failures are logged and swallowed so the original collector cancellation or upstream error can continue. |
+| Regression coverage | PASS | Unit test cancels a running coroutine and proves the suspend cleanup block still completes. |
+| Integration coverage | PASS | Full `bluetape4k-elasticsearch` Testcontainers suite passes with 33 tests. |
+| Documentation | PASS | README and README.ko document non-cancellable PIT cleanup behavior. |
+| Kotlin style | PASS | Validation uses `requireNotBlank`; tests use `runTest` and bluetape4k boolean assertion. |
+| Impact radius | PASS | CodeGraph review context reports low risk, 0 impacted files, and 0 test gaps for changed Kotlin files. |
+
+## Findings
+
+- P0: none.
+- P1: none.
+
+## Verification
+
+- PASS: `./gradlew :bluetape4k-elasticsearch:compileKotlin :bluetape4k-elasticsearch:compileTestKotlin :bluetape4k-elasticsearch:test --tests 'io.bluetape4k.elasticsearch.coroutines.SearchApiCoroutinesUnitTest' --no-build-cache --no-configuration-cache`
+- PASS: `./gradlew :bluetape4k-elasticsearch:test --tests 'io.bluetape4k.elasticsearch.coroutines.SearchApiCoroutinesTest' --no-build-cache --no-configuration-cache`
+- PASS: `./gradlew :bluetape4k-elasticsearch:compileKotlin :bluetape4k-elasticsearch:compileTestKotlin :bluetape4k-elasticsearch:test :bluetape4k-elasticsearch:koverXmlReport --no-build-cache --no-configuration-cache`
+- PASS: `infra/elasticsearch` test result XML summary: 7 suites, 33 tests, 0 failures, 0 errors, 0 skipped.
+- PASS: `git diff --check`
+- PASS: CodeGraph `get_review_context` for changed Kotlin files: low risk, 0 impacted files, 0 test gaps.

--- a/infra/elasticsearch/README.ko.md
+++ b/infra/elasticsearch/README.ko.md
@@ -151,7 +151,7 @@ suspend fun scrollAllDocuments() {
 }
 ```
 
-**중요**: search_after 가 올바르게 작동하려면 정렬 절에 tie-breaker (예: `_shard_doc`)를 반드시 포함해야 합니다.
+**중요**: search_after 가 올바르게 작동하려면 정렬 절에 tie-breaker (예: `_shard_doc`)를 반드시 포함해야 합니다. `searchAsFlow`는 PIT close를 non-cancellable cleanup boundary에서 수행하므로 timeout이나 collector cancellation이 발생해도 원래 cancellation을 전파하기 전에 PIT cleanup을 시도합니다.
 
 ### 4. Flow를 사용한 일괄 인덱싱
 
@@ -365,7 +365,7 @@ val client = elasticsearchAsyncClient {
 
 ### Flow 기반 페이징 (searchAsFlow)
 
-Kotlin Flow를 사용한 지연(lazy), 백프레셔 인식 페이징. PIT 생명주기를 자동으로 관리합니다.
+Kotlin Flow를 사용한 지연(lazy), 백프레셔 인식 페이징. Cancellation 중에도 best-effort non-cancellable PIT close를 수행해 PIT 생명주기를 자동으로 관리합니다.
 
 ### Coroutine 래퍼 (suspendBulk)
 

--- a/infra/elasticsearch/README.md
+++ b/infra/elasticsearch/README.md
@@ -151,7 +151,7 @@ suspend fun scrollAllDocuments() {
 }
 ```
 
-**Important**: You must include a tie-breaker in sort clause (e.g., `_shard_doc`) for search_after to work correctly.
+**Important**: You must include a tie-breaker in sort clause (e.g., `_shard_doc`) for search_after to work correctly. `searchAsFlow` closes the PIT from a non-cancellable cleanup boundary, so timeout or collector cancellation still attempts PIT cleanup before the original cancellation is propagated.
 
 ### 4. Bulk Indexing with Flow
 
@@ -365,7 +365,7 @@ val client = elasticsearchAsyncClient {
 
 ### Flow-based Pagination (searchAsFlow)
 
-Lazy, backpressure-aware pagination using Kotlin Flow. Automatically manages PIT lifecycle.
+Lazy, backpressure-aware pagination using Kotlin Flow. Automatically manages PIT lifecycle, including best-effort non-cancellable PIT close during cancellation.
 
 ### Coroutine Wrappers (suspendBulk)
 

--- a/infra/elasticsearch/src/main/kotlin/io/bluetape4k/elasticsearch/coroutines/SearchApiCoroutines.kt
+++ b/infra/elasticsearch/src/main/kotlin/io/bluetape4k/elasticsearch/coroutines/SearchApiCoroutines.kt
@@ -11,9 +11,11 @@ import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requirePositiveNumber
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.future.await
+import kotlinx.coroutines.withContext
 
 @PublishedApi
 internal val log = KotlinLogging.logger {}
@@ -82,28 +84,50 @@ suspend fun ElasticsearchAsyncClient.closePointInTimeSuspending(
     return this.closePointInTime(request).await().succeeded()
 }
 
+@PublishedApi
+internal suspend fun closePointInTimeBestEffort(
+    pitId: String,
+    close: suspend (String) -> Boolean,
+) {
+    pitId.requireNotBlank("pitId")
+
+    withContext(NonCancellable) {
+        try {
+            close(pitId)
+        } catch (e: CancellationException) {
+            log.warn(e) { "Cancelled while closing ES PIT: pitId=$pitId" }
+        } catch (e: Exception) {
+            log.warn(e) { "Failed to close ES PIT: pitId=$pitId" }
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // search_after + PIT 기반 무한 스크롤 Flow
 // ---------------------------------------------------------------------------
 
 /**
- * `search_after` + PIT(point-in-time) 페이징을 [Flow] 로 노출하는 무한 스크롤 검색입니다.
+ * Exposes `search_after` + PIT(point-in-time) pagination as a lazy [Flow].
  *
- * Elasticsearch 의 scroll API 는 deprecated 되었으므로 본 함수는 PIT + `search_after` 조합을 사용합니다.
+ * Elasticsearch deprecated the scroll API, so this helper uses PIT with `search_after`
+ * for consistent cursor-based paging.
  *
- * ## 동작
- * 1. 함수 시작 시 [openPointInTimeSuspending] 으로 PIT 를 열어 일관된 스냅샷을 확보합니다.
- * 2. `batchSize` 만큼 search 를 반복 호출하며 `searchAfter` 커서를 다음 페이지로 갱신합니다.
- * 3. 빈 페이지가 반환되면 종료되며, 정상 종료 / 예외 / `CancellationException` 어느 경로에서도
- *    `finally` 블록에서 PIT 를 닫아 자원 누수를 막습니다.
+ * ## Behavior
+ * 1. Opens a PIT through [openPointInTimeSuspending] before the first page.
+ * 2. Repeats search requests in `batchSize` chunks and advances the `searchAfter` cursor.
+ * 3. Stops when Elasticsearch returns an empty page and closes the PIT from `finally`
+ *    for normal completion, failures, and collector cancellation.
  *
- * ## 사용 시 주의
- * - `queryBlock` 안에서 **반드시 tie-breaker 를 포함한 `sort` 를 지정**해야 합니다 (예: 정렬 기준 + `_shard_doc`).
- *   sort 가 없으면 `searchAfter` 가 동작하지 않습니다.
- * - `index`, `pit`, `size`, `searchAfter` 는 본 함수가 자동으로 채우므로 [queryBlock] 에서 다시 지정하지 마세요.
- * - PIT close 가 실패해도 leak 만 막으면 충분하므로 `runCatching` 으로 swallow 합니다.
+ * ## Usage notes
+ * - [queryBlock] must set a stable sort that includes a tie-breaker such as `_shard_doc`.
+ *   Without sorting, `searchAfter` cannot advance safely.
+ * - Do not set `index`, `pit`, `size`, or `searchAfter` inside [queryBlock]; this helper
+ *   owns those fields.
+ * - PIT close runs from a non-cancellable cleanup boundary. Close failures are logged
+ *   and swallowed so the original collector cancellation or upstream failure can continue
+ *   to propagate.
  *
- * ## 사용 예시
+ * ## Example
  * ```kotlin
  * asyncClient.searchAsFlow<MyDoc>(
  *     indexName = "my-index",
@@ -160,14 +184,9 @@ inline fun <reified T : Any> ElasticsearchAsyncClient.searchAsFlow(
                 searchAfter = lastSort
             }
         } finally {
-            // 정상/예외/취소 모든 종료 경로에서 PIT close 보장.
-            // CancellationException 은 재던짐, 그 외 close 실패는 warn 로그 후 swallow — leak 방지가 목적.
-            try {
-                client.closePointInTimeSuspending(pitId)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Throwable) {
-                log.warn(e) { "Failed to close ES PIT: pitId=$pitId" }
+            // Close PIT from a cleanup boundary that survives collector cancellation.
+            closePointInTimeBestEffort(pitId) { id ->
+                client.closePointInTimeSuspending(id)
             }
         }
     }

--- a/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/SearchApiCoroutinesUnitTest.kt
+++ b/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/SearchApiCoroutinesUnitTest.kt
@@ -1,0 +1,37 @@
+package io.bluetape4k.elasticsearch.coroutines
+
+import io.bluetape4k.assertions.shouldBeTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
+
+class SearchApiCoroutinesUnitTest {
+
+    @Test
+    fun `PIT cleanup completes from cancelled coroutine context`() = runTest(timeout = 10.seconds) {
+        val jobStarted = CompletableDeferred<Unit>()
+        var cleanupCompleted = false
+
+        val job = launch {
+            try {
+                jobStarted.complete(Unit)
+                delay(1.seconds)
+            } finally {
+                closePointInTimeBestEffort("pit-id") {
+                    delay(10)
+                    cleanupCompleted = true
+                    true
+                }
+            }
+        }
+
+        jobStarted.await()
+        job.cancelAndJoin()
+
+        cleanupCompleted.shouldBeTrue()
+    }
+}


### PR DESCRIPTION
## Summary

Closes #807

- PR 제목: fix: close Elasticsearch PIT after cancellation

Closes #807.

This PR makes `searchAsFlow` close Elasticsearch point-in-time handles from a `NonCancellable` cleanup boundary so collector cancellation cannot skip the suspend close request.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Adds `closePointInTimeBestEffort` for best-effort PIT cleanup that preserves the original collector cancellation or upstream failure.
- Adds a coroutine cancellation regression test for suspend PIT cleanup.
- Updates `infra/elasticsearch` README and Korean README lifecycle notes.
- Adds issue review and lesson notes for the #807 lifecycle fix.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- Scope is limited to `infra/elasticsearch` search PIT cleanup and documentation.
- CodeGraph review context for changed Kotlin files reported low risk, 0 impacted files, and 0 test gaps.
- Full affected module verification passed with 7 suites and 33 tests.

## Metadata

- Issue: #807, milestone `1.12.0`, assignee `debop`
- PR: #987, head `21ea7a63982dc89d6f2962bcc132def25065dfa5`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-807-elasticsearch-pit-cleanup`
- Labels: `bug`, `test`, `infra/io`, `codex`, `codex-automation`, `coroutines`
- State: `MERGED`, merge commit `7d52df795d6381a36dab1b5ca0bf2e8eb88921ed`
- CI: - [x] Local verification passed: `./gradlew :bluetape4k-elasticsearch:compileKotlin :bluetape4k-elasticsearch:compileTestKotlin :bluetape4k-elasticsearch:test :bluetape4k-elasticsearch:koverXmlReport --no-build-cache --no-configuration-cache`.

## DoD Status

- [x] Issue #807 metadata checked: assignee `debop`, milestone `1.12.0`, labels `bug`, `test`, `infra/io`, `coroutines`.
- [x] Cancellation-safe PIT cleanup implemented with `withContext(NonCancellable)`.
- [x] Regression test added: `SearchApiCoroutinesUnitTest`.
- [x] README and README.ko updated for PIT lifecycle behavior.
- [x] 7-Tier review recorded in `docs/review/2026-07-05-issue-807-elasticsearch-pit-cleanup-review.md`.
- [x] Local verification passed: `./gradlew :bluetape4k-elasticsearch:compileKotlin :bluetape4k-elasticsearch:compileTestKotlin :bluetape4k-elasticsearch:test :bluetape4k-elasticsearch:koverXmlReport --no-build-cache --no-configuration-cache`.
- [x] Local verification passed: `git diff --check`.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #987 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `7d52df795d6381a36dab1b5ca0bf2e8eb88921ed`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
