### PR TITLE
fix: bound Elasticsearch bulk progress events

### DIFF
--- a/docs/lessons/2026-07-05-issue-808-elasticsearch-bulk-progress-buffering.md
+++ b/docs/lessons/2026-07-05-issue-808-elasticsearch-bulk-progress-buffering.md
@@ -1,0 +1,17 @@
+# Issue 808 - Elasticsearch Bulk Progress Buffering
+
+## Context
+
+`bulkProgressListener` used `Channel.UNLIMITED`, so slow or absent collectors could retain bulk requests, responses, failures, and caller contexts without a hard bound.
+
+## Decision
+
+Use a bounded `Channel` with default capacity 256 and `BufferOverflow.SUSPEND`. Keep listener callbacks non-blocking by using `trySend`, and log failed sends so overflow is visible.
+
+## Outcome
+
+The progress listener retains a finite number of events by default, exposes capacity and overflow tuning, and has a regression test for overflow behavior without requiring Elasticsearch I/O.
+
+## Future Guidance
+
+Listener-to-Flow adapters should avoid unbounded channels unless the caller explicitly opts in. Prefer bounded buffers, non-blocking callback paths, and visible drop/overflow behavior.

--- a/docs/review/2026-07-05-issue-808-elasticsearch-bulk-progress-buffering-review.md
+++ b/docs/review/2026-07-05-issue-808-elasticsearch-bulk-progress-buffering-review.md
@@ -1,0 +1,35 @@
+# Issue 808 - Elasticsearch Bulk Progress Buffering Review
+
+## Scope
+
+- `infra/elasticsearch/src/main/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkIngesterCoroutines.kt`
+- `infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkIngesterCoroutinesTest.kt`
+- `infra/elasticsearch/README.md`
+- `infra/elasticsearch/README.ko.md`
+
+## 7-Tier Review
+
+| Tier | Result | Evidence |
+|------|--------|----------|
+| Correctness | PASS | `bulkProgressListener` now uses a bounded channel instead of `Channel.UNLIMITED`. |
+| Resource safety | PASS | Default buffer capacity is 256 and slow or absent collectors cannot retain progress events without bound. |
+| Callback safety | PASS | Listener callbacks still use `trySend`; they do not suspend or block Elasticsearch client threads. |
+| Overflow visibility | PASS | Failed `trySend` attempts are logged with the event type. |
+| API behavior | PASS | Callers can tune `bufferCapacity` and `onBufferOverflow`; defaults are conservative. |
+| Regression coverage | PASS | Unit path verifies bounded buffer overflow drops the second event and keeps the first buffered event observable. |
+| Documentation | PASS | README and README.ko document the default bounded buffer and overflow behavior. |
+| Impact radius | PASS | CodeGraph review context reports low risk, 0 impacted files, and 0 test gaps for changed Kotlin files. |
+
+## Findings
+
+- P0: none.
+- P1: none.
+
+## Verification
+
+- PASS: `./gradlew :bluetape4k-elasticsearch:compileKotlin :bluetape4k-elasticsearch:compileTestKotlin --no-build-cache --no-configuration-cache`
+- PASS: `./gradlew :bluetape4k-elasticsearch:test --tests 'io.bluetape4k.elasticsearch.coroutines.BulkIngesterCoroutinesTest' --no-build-cache --no-configuration-cache`
+- PASS: `./gradlew :bluetape4k-elasticsearch:compileKotlin :bluetape4k-elasticsearch:compileTestKotlin :bluetape4k-elasticsearch:test :bluetape4k-elasticsearch:koverXmlReport --no-build-cache --no-configuration-cache`
+- PASS: `infra/elasticsearch` test result XML summary: 7 suites, 34 tests, 0 failures, 0 errors, 0 skipped.
+- PASS: `git diff --check`
+- PASS: CodeGraph `get_review_context` for changed Kotlin files: low risk, 0 impacted files, 0 test gaps.

--- a/infra/elasticsearch/README.ko.md
+++ b/infra/elasticsearch/README.ko.md
@@ -192,6 +192,12 @@ suspend fun bulkIndexDocuments() {
 }
 ```
 
+`bulkProgressListener()`는 기본적으로 bounded progress-event buffer를 사용합니다
+(`bufferCapacity = 256`, `onBufferOverflow = BufferOverflow.SUSPEND`). Listener callback은
+Elasticsearch client thread를 블로킹하지 않으며, collector가 느리거나 없어서 `trySend`가 실패하면
+warn 로그를 남기고 overflow된 progress event를 드롭합니다. 워크로드에 다른 보존 정책이 필요하면
+`bufferCapacity`와 `onBufferOverflow`를 조정하세요.
+
 ### 5. 직접 일괄 작업
 
 ```kotlin

--- a/infra/elasticsearch/README.md
+++ b/infra/elasticsearch/README.md
@@ -192,6 +192,12 @@ suspend fun bulkIndexDocuments() {
 }
 ```
 
+`bulkProgressListener()` uses a bounded progress-event buffer by default
+(`bufferCapacity = 256`, `onBufferOverflow = BufferOverflow.SUSPEND`). Listener callbacks never
+block Elasticsearch client threads; if collectors are too slow or absent, failed `trySend` attempts
+are logged and overflowed progress events are dropped. Tune `bufferCapacity` and
+`onBufferOverflow` when a workload needs a different retention policy.
+
 ### 5. Direct Bulk Operation
 
 ```kotlin

--- a/infra/elasticsearch/src/main/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkIngesterCoroutines.kt
+++ b/infra/elasticsearch/src/main/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkIngesterCoroutines.kt
@@ -9,8 +9,11 @@ import co.elastic.clients.elasticsearch.core.BulkResponse
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation
 import co.elastic.clients.util.ObjectBuilder
 import io.bluetape4k.elasticsearch.ElasticsearchDefaults
+import io.bluetape4k.logging.KotlinLogging
+import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requirePositiveNumber
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -23,6 +26,10 @@ import java.util.function.Function
 // ---------------------------------------------------------------------------
 // BulkIngester 팩토리 함수
 // ---------------------------------------------------------------------------
+
+private const val DEFAULT_BULK_PROGRESS_BUFFER_CAPACITY = 256
+
+private val bulkIngesterLog = KotlinLogging.logger {}
 
 /**
  * [ElasticsearchAsyncClient] 기반의 [BulkIngester] 를 생성합니다.
@@ -234,42 +241,55 @@ data class BulkListenerHandle<Context>(
 }
 
 /**
- * [BulkListener] 콜백 이벤트를 [Flow] 로 변환하는 리스너-Flow 쌍을 생성합니다.
+ * Creates a [BulkListener] and [Flow] pair for bulk progress callbacks.
  *
- * 반환된 [BulkListener] 를 [BulkIngester] 에 등록하면,
- * `beforeBulk`, `afterBulk(성공)`, `afterBulk(실패)` 이벤트가
- * [Flow] 로 스트리밍됩니다.
+ * Register the returned [BulkListener] with a [BulkIngester] to stream `beforeBulk`,
+ * successful `afterBulk`, and failed `afterBulk` callbacks as [BulkProgressEvent] values.
  *
- * Channel 은 `UNLIMITED` 버퍼를 사용하여 리스너 콜백이 블로킹되지 않도록 합니다.
- * Flow 를 소비하지 않으면 이벤트가 채널에 쌓이므로, 반드시 collect 하거나 `close()` 를 호출해야 합니다.
+ * The callback path never suspends or blocks Elasticsearch client threads. Events are
+ * offered to a bounded [Channel] with [bufferCapacity] and [onBufferOverflow]. With the
+ * default [BufferOverflow.SUSPEND] policy, `trySend` failures are logged and the event is
+ * dropped when collectors are too slow or absent.
  *
- * ## 사용 예시
+ * Always collect [BulkListenerHandle.events] or call [BulkListenerHandle.close] when the
+ * listener is no longer needed.
+ *
+ * ## Example
  * ```kotlin
  * val (listener, events) = bulkProgressListener<Void>()
  * val ingester = bulkIngesterOf<Void>(asyncClient, listener = listener)
  *
- * // 이벤트 소비
  * val job = launch {
  *     events.collect { event ->
  *         when (event) {
- *             is BulkProgressEvent.Before -> println("요청 전송 전: ${event.executionId}")
- *             is BulkProgressEvent.After  -> println("요청 완료: ${event.response.took()} ms")
- *             is BulkProgressEvent.Error  -> println("오류 발생: ${event.exception.message}")
+ *             is BulkProgressEvent.Before -> println("before: ${event.executionId}")
+ *             is BulkProgressEvent.After  -> println("after: ${event.response.took()} ms")
+ *             is BulkProgressEvent.Error  -> println("error: ${event.exception.message}")
  *         }
  *     }
  * }
  *
  * ingester.use {
- *     // ... 작업 추가 ...
+ *     // add bulk operations
  * }
  * job.cancelAndJoin()
  * ```
  *
- * @param Context 각 Bulk 작업에 연결할 애플리케이션 컨텍스트 타입
- * @return [BulkListenerHandle] — listener, events Flow, 그리고 close() 를 포함합니다
+ * @param Context application context type attached to each bulk operation
+ * @param bufferCapacity maximum progress events retained when collectors lag
+ * @param onBufferOverflow channel overflow policy for progress events
+ * @return [BulkListenerHandle] containing the listener, events Flow, and close hook
  */
-fun <Context> bulkProgressListener(): BulkListenerHandle<Context> {
-    val channel = Channel<BulkProgressEvent<Context>>(Channel.UNLIMITED)
+fun <Context> bulkProgressListener(
+    bufferCapacity: Int = DEFAULT_BULK_PROGRESS_BUFFER_CAPACITY,
+    onBufferOverflow: BufferOverflow = BufferOverflow.SUSPEND,
+): BulkListenerHandle<Context> {
+    bufferCapacity.requirePositiveNumber("bufferCapacity")
+
+    val channel = Channel<BulkProgressEvent<Context>>(
+        capacity = bufferCapacity,
+        onBufferOverflow = onBufferOverflow,
+    )
 
     val listener = object : BulkListener<Context> {
         override fun beforeBulk(
@@ -277,12 +297,13 @@ fun <Context> bulkProgressListener(): BulkListenerHandle<Context> {
             request: BulkRequest,
             contexts: List<Context>,
         ) {
-            channel.trySend(
+            channel.trySendOrLog(
                 BulkProgressEvent.Before(
                     executionId = executionId,
                     request = request,
                     contexts = contexts,
-                )
+                ),
+                eventName = "Before",
             )
         }
 
@@ -292,13 +313,14 @@ fun <Context> bulkProgressListener(): BulkListenerHandle<Context> {
             contexts: List<Context>,
             response: BulkResponse,
         ) {
-            channel.trySend(
+            channel.trySendOrLog(
                 BulkProgressEvent.After(
                     executionId = executionId,
                     request = request,
                     response = response,
                     contexts = contexts,
-                )
+                ),
+                eventName = "After",
             )
         }
 
@@ -308,13 +330,14 @@ fun <Context> bulkProgressListener(): BulkListenerHandle<Context> {
             contexts: List<Context>,
             failure: Throwable,
         ) {
-            channel.trySend(
+            channel.trySendOrLog(
                 BulkProgressEvent.Error(
                     executionId = executionId,
                     request = request,
                     exception = failure,
                     contexts = contexts,
-                )
+                ),
+                eventName = "Error",
             )
         }
     }
@@ -324,4 +347,16 @@ fun <Context> bulkProgressListener(): BulkListenerHandle<Context> {
         events = channel.receiveAsFlow(),
         closeAction = channel::close,
     )
+}
+
+private fun <Context> Channel<BulkProgressEvent<Context>>.trySendOrLog(
+    event: BulkProgressEvent<Context>,
+    eventName: String,
+) {
+    val result = trySend(event)
+    if (result.isFailure) {
+        bulkIngesterLog.warn(result.exceptionOrNull()) {
+            "Dropped Elasticsearch bulk progress event because the listener buffer is full or closed: event=$eventName"
+        }
+    }
 }

--- a/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkIngesterCoroutinesTest.kt
+++ b/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkIngesterCoroutinesTest.kt
@@ -1,6 +1,13 @@
 package io.bluetape4k.elasticsearch.coroutines
 
+import co.elastic.clients.elasticsearch.core.BulkRequest
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.elasticsearch.AbstractElasticsearchTest
 import io.bluetape4k.elasticsearch.ElasticsearchTestFixtures.createTestIndex
 import io.bluetape4k.elasticsearch.ElasticsearchTestFixtures.deleteTestIndex
@@ -11,12 +18,11 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
-import io.bluetape4k.assertions.shouldBeFalse
-import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
-import io.bluetape4k.assertions.shouldNotBeNull
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -121,4 +127,42 @@ class BulkIngesterCoroutinesTest : AbstractElasticsearchTest() {
         // 채널 정리 — 메모리 누수 방지
         handle.close()
     }
+
+    @Test
+    fun `bulkProgressListener drops overflowed events from bounded buffer`() = runTest {
+        val handle = bulkProgressListener<Void>(bufferCapacity = 1)
+        val (listener, events) = handle
+
+        try {
+            val request = bulkRequestOf("overflow")
+
+            listener.beforeBulk(1L, request, emptyList<Void>())
+            listener.beforeBulk(2L, request, emptyList<Void>())
+
+            val event = events.first()
+            event shouldBeInstanceOf BulkProgressEvent.Before::class
+            (event as BulkProgressEvent.Before<Void>).executionId shouldBeEqualTo 1L
+
+            withTimeoutOrNull(100.milliseconds) {
+                events.first()
+            }.shouldBeNull()
+        } finally {
+            handle.close()
+        }
+    }
+
+    private fun bulkRequestOf(id: String): BulkRequest =
+        BulkRequest.of { request ->
+            request.operations(
+                listOf(
+                    BulkOperation.of { operation ->
+                        operation.index<Map<String, String>> { index ->
+                            index.index("bulk-progress-test")
+                                .id(id)
+                                .document(mapOf("id" to id))
+                        }
+                    }
+                )
+            )
+        }
 }


### PR DESCRIPTION
## Summary

Closes #808

- PR 제목: fix: bound Elasticsearch bulk progress events

Closes #808.

This is a stacked PR on top of #987. It bounds `bulkProgressListener` buffering so slow or absent collectors cannot retain unlimited bulk requests, responses, failures, and caller contexts.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Replaces `Channel.UNLIMITED` with a bounded progress-event channel.
- Adds `bufferCapacity` and `onBufferOverflow` options with conservative defaults: `256` and `BufferOverflow.SUSPEND`.
- Logs failed `trySend` attempts so default overflow is visible while listener callbacks remain non-blocking.
- Adds an overflow regression test for a slow or absent collector path.
- Updates `infra/elasticsearch` README and Korean README lifecycle notes.

### 기존 섹션: Stack

- Base PR: #987
- This PR base branch: `fix/issue-807-elasticsearch-pit-cleanup`
- This PR head branch: `fix/issue-808-elasticsearch-bulk-progress-buffering`

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- Scope is limited to `infra/elasticsearch` bulk progress listener buffering and documentation.
- CodeGraph review context for changed Kotlin files reported low risk, 0 impacted files, and 0 test gaps.
- Full affected module verification passed with 7 suites and 34 tests.

## Metadata

- Issue: #808, milestone `1.12.0`, assignee `debop`
- PR: #988, head `30b0308f7d3a5ba9e9bc2b1a92d65a008626da55`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-808-elasticsearch-bulk-progress-buffering`
- Labels: `bug`, `test`, `performance`, `infra/io`, `codex`, `codex-automation`
- State: `MERGED`, merge commit `a7dcf538e624709fa8d46fc7ea0647f30068578a`
- CI: - Adds `bufferCapacity` and `onBufferOverflow` options with conservative defaults: `256` and `BufferOverflow.SUSPEND`. / - [x] Capacity and overflow options are exposed for callers that need tuning. / - [x] Local verification passed: `./gradlew :bluetape4k-elasticsearch:compileKotlin :bluetape4k-elasticsearch:compileTestKotlin :bluetape4k-elasticsearch:test :bluetape4k-elasticsearch:koverXmlReport --no-build-cache --no-configuration-cache`.

## DoD Status

- [x] Issue #808 metadata checked: assignee `debop`, milestone `1.12.0`, labels `bug`, `test`, `performance`, `infra/io`.
- [x] Progress listener buffer is bounded by default.
- [x] Capacity and overflow options are exposed for callers that need tuning.
- [x] Failed `trySend` attempts are logged so default overflow is visible.
- [x] Regression test added: `bulkProgressListener drops overflowed events from bounded buffer`.
- [x] README and README.ko updated for bounded buffering behavior.
- [x] 7-Tier review recorded in `docs/review/2026-07-05-issue-808-elasticsearch-bulk-progress-buffering-review.md`.
- [x] Local verification passed: `./gradlew :bluetape4k-elasticsearch:compileKotlin :bluetape4k-elasticsearch:compileTestKotlin :bluetape4k-elasticsearch:test :bluetape4k-elasticsearch:koverXmlReport --no-build-cache --no-configuration-cache`.
- [x] Local verification passed: `git diff --check`.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #988 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `a7dcf538e624709fa8d46fc7ea0647f30068578a`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
