### PR TITLE
fix: close ResultCall error bodies

### DIFF
--- a/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/clients/hc5/Hc5CallFactory.kt
+++ b/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/clients/hc5/Hc5CallFactory.kt
@@ -19,41 +19,46 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import kotlin.reflect.KClass
 
 /**
- * Apache HC5 비동기 클라이언트를 사용하는 Retrofit용 OkHttp `Call.Factory`를 생성합니다.
+ * Creates a Retrofit-compatible OkHttp `Call.Factory` backed by Apache HC5 async client.
  *
- * ## 동작/계약
- * - [asyncClient]를 래핑한 [Hc5CallFactory]를 반환합니다.
- * - [asyncClient] 기본값은 시스템 설정 기반 `httpAsyncClientSystemOf()`입니다.
+ * ## Contract
+ * - Wraps [asyncClient] without taking ownership beyond [Hc5CallFactory.close].
+ * - Uses [callTimeout] for blocking `execute()` waits and the advertised Okio timeout.
+ * - A blocking timeout or interruption cancels the underlying HC5 request.
  *
  * ```kotlin
- * val callFactory = hc5CallFactoryOf()
- * // callFactory != null
+ * val callFactory = hc5CallFactoryOf(callTimeout = Duration.ofSeconds(10))
+ * // callFactory can be passed to Retrofit.Builder.callFactory(...)
  * ```
  */
 fun hc5CallFactoryOf(
     asyncClient: CloseableHttpAsyncClient = httpAsyncClientSystemOf(),
+    callTimeout: Duration = Hc5CallFactory.CallTimeout,
 ): Hc5CallFactory {
-    return Hc5CallFactory(asyncClient)
+    return Hc5CallFactory(asyncClient, callTimeout)
 }
 
 /**
- * Apache HC5 비동기 클라이언트를 OkHttp [okhttp3.Call.Factory]로 어댑트합니다.
+ * Adapts an Apache HC5 async client to OkHttp [okhttp3.Call.Factory].
  *
- * ## 동작/계약
- * - 생성 시 [asyncClient] 상태가 비활성(`!= ACTIVE`)이면 `start()`를 호출합니다.
- * - [newCall]은 요청마다 독립 Call 인스턴스를 생성합니다.
- * - `execute()`는 내부 async 처리 결과를 timeout까지 대기하는 blocking 호출입니다.
+ * ## Contract
+ * - Starts [asyncClient] when it is not already active.
+ * - [newCall] creates an independent call instance per request.
+ * - `execute()` blocks up to [callTimeout], cancels the HC5 future on timeout/interruption,
+ *   and restores the thread interrupt flag for interruptions.
  *
  * ```kotlin
- * val retrofit = retrofitOf(baseUrl, hc5CallFactoryOf())
- * // retrofit.callFactory()가 HC5 기반으로 동작
+ * val retrofit = retrofitOf(baseUrl, hc5CallFactoryOf(callTimeout = Duration.ofSeconds(10)))
+ * // retrofit.callFactory() uses the HC5 transport adapter
  * ```
  */
 class Hc5CallFactory private constructor(
     private val asyncClient: CloseableHttpAsyncClient,
+    private val callTimeout: Duration,
 ): okhttp3.Call.Factory, java.io.Closeable {
 
     companion object: KLogging() {
@@ -62,19 +67,23 @@ class Hc5CallFactory private constructor(
         val CallTimeout: Duration = Duration.ofSeconds(30)
 
         /**
-         * [Hc5CallFactory] 인스턴스를 생성합니다.
+         * Creates an [Hc5CallFactory] from an existing HC5 async client.
          *
-         * ## 동작/계약
-         * - 전달한 [asyncClient]를 그대로 사용합니다.
+         * ## Contract
+         * - Keeps using the caller-provided [asyncClient].
+         * - Applies [callTimeout] to each new call.
          *
          * ```kotlin
-         * val factory = Hc5CallFactory(httpAsyncClientSystemOf())
+         * val factory = Hc5CallFactory(httpAsyncClientSystemOf(), Duration.ofSeconds(10))
          * // factory != null
          * ```
          */
         @JvmStatic
-        operator fun invoke(asyncClient: CloseableHttpAsyncClient): Hc5CallFactory {
-            return Hc5CallFactory(asyncClient)
+        operator fun invoke(
+            asyncClient: CloseableHttpAsyncClient,
+            callTimeout: Duration = CallTimeout,
+        ): Hc5CallFactory {
+            return Hc5CallFactory(asyncClient, callTimeout)
         }
     }
 
@@ -95,7 +104,7 @@ class Hc5CallFactory private constructor(
      * ```
      */
     override fun newCall(request: okhttp3.Request): okhttp3.Call {
-        return AsyncClientCall(request)
+        return AsyncClientCall(request, callTimeout)
     }
 
     /**
@@ -133,7 +142,18 @@ class Hc5CallFactory private constructor(
             return try {
                 executeAsync().get(callTimeout.toMillis(), TimeUnit.MILLISECONDS)
             } catch (e: ExecutionException) {
-                throw (e.cause ?: e).toIOException()
+                val cause = e.cause ?: e
+                if (cause.isTimeoutLikeFailure()) {
+                    cancel()
+                }
+                throw cause.toIOException()
+            } catch (e: TimeoutException) {
+                cancel()
+                throw IOException("Call timed out after $callTimeout. request=$okRequest", e)
+            } catch (e: InterruptedException) {
+                cancel()
+                Thread.currentThread().interrupt()
+                throw IOException("Call interrupted. request=$okRequest", e)
             } catch (e: Throwable) {
                 throw e.toIOException()
             }
@@ -235,5 +255,10 @@ class Hc5CallFactory private constructor(
         private fun throwAlreadyExecuted() {
             error("Already executed. request=$okRequest")
         }
+
+        private fun Throwable.isTimeoutLikeFailure(): Boolean =
+            this is TimeoutException ||
+                message?.contains("timeout", ignoreCase = true) == true ||
+                message?.contains("timed out", ignoreCase = true) == true
     }
 }

--- a/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/clients/vertx/VertxCallFactory.kt
+++ b/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/clients/vertx/VertxCallFactory.kt
@@ -11,64 +11,76 @@ import io.vertx.core.http.HttpClient
 import io.vertx.core.http.HttpClientRequest
 import io.vertx.kotlin.core.http.requestOptionsOf
 import kotlinx.atomicfu.atomic
+import java.io.IOException
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import kotlin.reflect.KClass
 
 /**
- * Vert.x [HttpClient] 기반 Retrofit용 OkHttp `Call.Factory`를 생성합니다.
+ * Creates a Retrofit-compatible OkHttp `Call.Factory` backed by a Vert.x [HttpClient].
  *
- * ## 동작/계약
- * - [client]를 래핑한 [VertxCallFactory]를 반환합니다.
- * - [client] 기본값은 [defaultVertxHttpClient]입니다.
+ * ## Contract
+ * - Wraps [client] without taking ownership beyond [VertxCallFactory.close].
+ * - Uses [callTimeout] for blocking `execute()` waits, Vert.x request timeout, and the advertised Okio timeout.
+ * - A blocking timeout or interruption resets the underlying Vert.x request when one exists.
  *
  * ```kotlin
- * val callFactory = vertxCallFactoryOf()
- * // callFactory != null
+ * val callFactory = vertxCallFactoryOf(callTimeout = Duration.ofSeconds(10))
+ * // callFactory can be passed to Retrofit.Builder.callFactory(...)
  * ```
  */
-fun vertxCallFactoryOf(client: HttpClient = defaultVertxHttpClient): VertxCallFactory {
-    return VertxCallFactory(client)
+fun vertxCallFactoryOf(
+    client: HttpClient = defaultVertxHttpClient,
+    callTimeout: Duration = VertxCallFactory.callTimeout,
+): VertxCallFactory {
+    return VertxCallFactory(client, callTimeout)
 }
 
 /**
- * Vert.x HTTP 요청을 OkHttp [okhttp3.Call.Factory] 인터페이스로 어댑트한 구현입니다.
+ * Adapts Vert.x HTTP requests to OkHttp [okhttp3.Call.Factory].
  *
- * ## 동작/계약
- * - [newCall]은 요청마다 독립 Call 인스턴스를 생성합니다.
- * - `execute()`는 내부 async 처리 결과를 timeout까지 대기하는 blocking 호출입니다.
- * - 네트워크/변환 오류는 [io.bluetape4k.retrofit2.toIOException]으로 변환됩니다.
+ * ## Contract
+ * - [newCall] creates an independent call instance per request.
+ * - `execute()` blocks up to [callTimeout], resets the Vert.x request on timeout/interruption,
+ *   and restores the thread interrupt flag for interruptions.
+ * - Network and conversion failures are normalized with [io.bluetape4k.retrofit2.toIOException].
  *
  * ```kotlin
- * val retrofit = retrofitOf(baseUrl, vertxCallFactoryOf())
- * // retrofit.callFactory()가 Vert.x 기반으로 동작
+ * val retrofit = retrofitOf(baseUrl, vertxCallFactoryOf(callTimeout = Duration.ofSeconds(10)))
+ * // retrofit.callFactory() uses the Vert.x transport adapter
  * ```
  */
 class VertxCallFactory private constructor(
     private val client: HttpClient,
+    private val defaultCallTimeout: Duration,
 ): okhttp3.Call.Factory, java.io.Closeable {
 
     companion object: KLogging() {
-        /** 기본 호출 타임아웃입니다. */
+        /** Default call timeout. */
         val callTimeout: Duration = Duration.ofSeconds(30L)
 
         /**
-         * [VertxCallFactory] 인스턴스를 생성합니다.
+         * Creates a [VertxCallFactory] from an existing Vert.x [HttpClient].
          *
-         * ## 동작/계약
-         * - 전달한 [client] 인스턴스를 그대로 사용합니다.
+         * ## Contract
+         * - Keeps using the caller-provided [client].
+         * - Applies [callTimeout] to each new call.
          *
          * ```kotlin
-         * val factory = VertxCallFactory(defaultVertxHttpClient)
+         * val factory = VertxCallFactory(defaultVertxHttpClient, Duration.ofSeconds(10))
          * // factory != null
          * ```
          */
         @JvmStatic
-        operator fun invoke(client: HttpClient): VertxCallFactory {
-            return VertxCallFactory(client)
+        operator fun invoke(
+            client: HttpClient,
+            callTimeout: Duration = VertxCallFactory.callTimeout,
+        ): VertxCallFactory {
+            return VertxCallFactory(client, callTimeout)
         }
     }
 
@@ -83,7 +95,7 @@ class VertxCallFactory private constructor(
      * ```
      */
     override fun newCall(request: okhttp3.Request): okhttp3.Call {
-        return VertxCall(request)
+        return VertxCall(request, defaultCallTimeout)
     }
 
     /**
@@ -101,6 +113,7 @@ class VertxCallFactory private constructor(
 
     private inner class VertxCall(
         private val okRequest: okhttp3.Request,
+        private val callTimeout: Duration,
     ): okhttp3.Call {
 
         private val promiseRef = atomic<CompletableFuture<okhttp3.Response>?>(null)
@@ -120,7 +133,18 @@ class VertxCallFactory private constructor(
             return try {
                 executeAsync().get(callTimeout.toMillis(), TimeUnit.MILLISECONDS)
             } catch (e: ExecutionException) {
-                throw (e.cause ?: e).toIOException()
+                val cause = e.cause ?: e
+                if (cause.isTimeoutLikeFailure()) {
+                    cancel()
+                }
+                throw cause.toIOException()
+            } catch (e: TimeoutException) {
+                cancel()
+                throw IOException("Call timed out after $callTimeout. request=$okRequest", e)
+            } catch (e: InterruptedException) {
+                cancel()
+                Thread.currentThread().interrupt()
+                throw IOException("Call interrupted. request=$okRequest", e)
             } catch (e: Throwable) {
                 throw e.toIOException()
             }
@@ -200,7 +224,7 @@ class VertxCallFactory private constructor(
         }
 
         override fun clone(): okhttp3.Call {
-            return VertxCall(okRequest)
+            return VertxCall(okRequest, callTimeout)
         }
 
         override fun request(): okhttp3.Request {
@@ -230,5 +254,10 @@ class VertxCallFactory private constructor(
         private fun throwAlreadyExecuted() {
             error("Already executed. request=$okRequest")
         }
+
+        private fun Throwable.isTimeoutLikeFailure(): Boolean =
+            this is TimeoutException ||
+                message?.contains("timeout", ignoreCase = true) == true ||
+                message?.contains("timed out", ignoreCase = true) == true
     }
 }

--- a/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/result/ResultCall.kt
+++ b/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/result/ResultCall.kt
@@ -13,13 +13,14 @@ import retrofit2.Response
 import java.io.IOException
 
 /**
- * `Call<T>`를 `Call<Result<T>>`로 래핑해 HTTP/네트워크 실패를 `Result.failure`로 전달하는 구현체입니다.
+ * Wraps `Call<T>` as `Call<Result<T>>` so HTTP and network failures are returned as [Result.failure].
  *
- * ## 동작/계약
- * - 성공 응답(`2xx`)은 `Result.success(body)`로 변환합니다.
- * - 비성공 응답(`4xx/5xx`)은 [HttpException]을 담은 `Result.failure`로 변환합니다.
- * - 예외/실패 경로에서도 `Callback.onResponse`를 호출하며 `Response.success(Result.failure(...))` 형태를 사용합니다.
- * - 응답 본문이 `null`이면 [IOException] 실패로 처리합니다.
+ * ## Contract
+ * - Successful HTTP responses (`2xx`) become `Result.success(body)`.
+ * - Unsuccessful HTTP responses (`4xx/5xx`) become `Result.failure(HttpException(response))`.
+ * - Unsuccessful response error bodies are closed before the failure result is returned.
+ * - Delegate callback failures are delivered through `Callback.onResponse` as `Response.success(Result.failure(...))`.
+ * - A successful HTTP response with a `null` body becomes an [IOException] failure.
  *
  * ```kotlin
  * val resultCall = ResultCall(delegateCall)
@@ -33,10 +34,10 @@ class ResultCall<T> private constructor(
 
     companion object: KLogging() {
         /**
-         * [ResultCall] 인스턴스를 생성합니다.
+         * Creates a [ResultCall] wrapper for [delegate].
          *
-         * ## 동작/계약
-         * - [delegate]가 이미 취소된 상태면 [IllegalStateException]을 발생시킵니다.
+         * ## Contract
+         * - Throws [IllegalStateException] when [delegate] is already cancelled.
          *
          * ```kotlin
          * val wrapped = ResultCall(delegate)
@@ -53,11 +54,12 @@ class ResultCall<T> private constructor(
     }
 
     /**
-     * 동기 호출을 실행하고 [Result] 형태로 반환합니다.
+     * Executes the delegate synchronously and returns a [Result] response.
      *
-     * ## 동작/계약
-     * - 원본 [delegate.execute] 예외는 `IOException(cause)`를 담은 실패 결과로 변환됩니다.
-     * - HTTP 실패도 예외를 던지지 않고 `Result.failure`로 감쌉니다.
+     * ## Contract
+     * - Exceptions from [delegate.execute] become failure results with `IOException(cause)`.
+     * - HTTP failures are wrapped as `Result.failure` instead of being thrown.
+     * - HTTP failure error bodies are closed after [HttpException] creation.
      *
      * ```kotlin
      * val result = ResultCall(delegate).execute().body()!!
@@ -80,7 +82,7 @@ class ResultCall<T> private constructor(
                 }
 
                 else                  -> {
-                    val result = Result.failure<T>(HttpException(response))
+                    val result = response.toHttpFailureResult<T>()
                     Response.success(result)
                 }
             }
@@ -91,15 +93,16 @@ class ResultCall<T> private constructor(
     }
 
     /**
-     * 비동기 호출을 실행하고 [Callback]에 `Result` 형태로 전달합니다.
+     * Executes the delegate asynchronously and delivers a [Result] response to [callback].
      *
-     * ## 동작/계약
-     * - 원본 콜백의 `onFailure`도 최종적으로 `callback.onResponse(...Result.failure...)`로 전달됩니다.
-     * - 호출자는 Retrofit `onFailure` 대신 `Result.isFailure`를 확인해 분기할 수 있습니다.
+     * ## Contract
+     * - Delegate `onFailure` is converted to `callback.onResponse(...Result.failure...)`.
+     * - HTTP failures are wrapped as `Result.failure` and close their error bodies before callback delivery.
+     * - Callers branch on `Result.isFailure` instead of Retrofit `onFailure`.
      *
      * ```kotlin
      * resultCall.enqueue(callback)
-     * // callback.onResponse에서 Result 성공/실패를 처리
+     * // callback.onResponse receives either Result.success or Result.failure
      * ```
      */
     override fun enqueue(callback: Callback<Result<T>>) {
@@ -124,7 +127,7 @@ class ResultCall<T> private constructor(
 
                     else                  -> {
                         log.warn { "Failed to execute call. response=$response" }
-                        val result = Result.failure<T>(HttpException(response))
+                        val result = response.toHttpFailureResult<T>()
                         callback.onResponse(this@ResultCall, Response.success(result))
                     }
                 }
@@ -155,4 +158,18 @@ class ResultCall<T> private constructor(
     override fun timeout(): Timeout = delegate.timeout()
 
     override fun clone(): Call<Result<T>> = ResultCall(delegate.clone())
+
+    private fun <R> Response<*>.toHttpFailureResult(): Result<R> {
+        val exception = HttpException(this)
+        closeErrorBodySuppressing(exception)
+        return Result.failure(exception)
+    }
+
+    private fun Response<*>.closeErrorBodySuppressing(primaryFailure: Throwable) {
+        try {
+            errorBody()?.close()
+        } catch (closeFailure: Throwable) {
+            primaryFailure.addSuppressed(closeFailure)
+        }
+    }
 }

--- a/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/client/CallFactoryConformanceTest.kt
+++ b/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/client/CallFactoryConformanceTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.retrofit2.client
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
@@ -15,8 +16,11 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.io.IOException
+import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
 
 /**
  * Shared OkHttp [Call.Factory] conformance tests for Retrofit transport adapters.
@@ -24,6 +28,8 @@ import java.util.concurrent.TimeUnit
 abstract class CallFactoryConformanceTest: AbstractClientTest() {
 
     private lateinit var conformanceServer: MockWebServer
+
+    protected abstract fun callFactory(callTimeout: Duration): Call.Factory
 
     @BeforeEach
     fun startConformanceServer() {
@@ -93,6 +99,51 @@ abstract class CallFactoryConformanceTest: AbstractClientTest() {
         val call = callFactory.newCall(request())
 
         call.timeout().timeoutNanos() shouldBeEqualTo TimeUnit.SECONDS.toNanos(30)
+    }
+
+    @Test
+    fun `execute timeout aborts underlying request`() {
+        conformanceServer.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE))
+
+        val call = callFactory(Duration.ofMillis(100)).newCall(request())
+
+        val error = assertFailsWith<IOException> {
+            call.execute()
+        }
+
+        val errorMessage = error.message.shouldNotBeNull()
+        (errorMessage.contains("timeout", ignoreCase = true) ||
+            errorMessage.contains("timed out", ignoreCase = true)).shouldBeTrue()
+        call.isCanceled().shouldBeTrue()
+    }
+
+    @Test
+    fun `execute interruption aborts underlying request and restores interrupt status`() {
+        conformanceServer.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE))
+
+        val call = callFactory(Duration.ofSeconds(5)).newCall(request())
+        val started = CountDownLatch(1)
+        val completed = CountDownLatch(1)
+        val interruptedStatusRestored = AtomicBoolean(false)
+
+        val worker = thread(start = true, isDaemon = true, name = "retrofit-call-interrupt-test") {
+            try {
+                started.countDown()
+                call.execute()
+            } catch (e: IOException) {
+                interruptedStatusRestored.set(Thread.currentThread().isInterrupted)
+            } finally {
+                completed.countDown()
+            }
+        }
+
+        started.await(1, TimeUnit.SECONDS).shouldBeTrue()
+        Thread.sleep(100)
+        worker.interrupt()
+
+        completed.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        interruptedStatusRestored.get().shouldBeTrue()
+        call.isCanceled().shouldBeTrue()
     }
 
     @Test

--- a/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/client/hc5/Hc5HttpClientTest.kt
+++ b/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/client/hc5/Hc5HttpClientTest.kt
@@ -4,10 +4,14 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.retrofit2.client.CallFactoryConformanceTest
 import io.bluetape4k.retrofit2.clients.hc5.hc5CallFactoryOf
 import okhttp3.Call
+import java.time.Duration
 
 class Hc5HttpClientTest: CallFactoryConformanceTest() {
 
     companion object: KLogging()
 
     override val callFactory: Call.Factory = hc5CallFactoryOf()
+
+    override fun callFactory(callTimeout: Duration): Call.Factory =
+        hc5CallFactoryOf(callTimeout = callTimeout)
 }

--- a/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/client/vertx/VertxHttpClientTest.kt
+++ b/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/client/vertx/VertxHttpClientTest.kt
@@ -4,10 +4,14 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.retrofit2.client.CallFactoryConformanceTest
 import io.bluetape4k.retrofit2.clients.vertx.vertxCallFactoryOf
 import okhttp3.Call
+import java.time.Duration
 
 class VertxHttpClientTest: CallFactoryConformanceTest() {
 
     companion object: KLogging()
 
     override val callFactory: Call.Factory = vertxCallFactoryOf()
+
+    override fun callFactory(callTimeout: Duration): Call.Factory =
+        vertxCallFactoryOf(callTimeout = callTimeout)
 }

--- a/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/result/ResultCallTest.kt
+++ b/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/result/ResultCallTest.kt
@@ -1,5 +1,10 @@
 package io.bluetape4k.retrofit2.result
 
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.retrofit2.AbstractRetrofitTest
@@ -11,15 +16,22 @@ import io.bluetape4k.retrofit2.service
 import io.bluetape4k.retrofit2.services.HttpbinAnythingResponse
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.test.runTest
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeFalse
-import io.bluetape4k.assertions.shouldBeInstanceOf
-import io.bluetape4k.assertions.shouldBeTrue
-import io.bluetape4k.assertions.shouldNotBeNull
+import okhttp3.Request
+import okhttp3.ResponseBody
+import okio.Buffer
+import okio.BufferedSource
+import okio.Source
+import okio.Timeout
+import okio.buffer
 import org.junit.jupiter.api.Test
+import retrofit2.Call
+import retrofit2.Callback
 import retrofit2.HttpException
+import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Path
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
 
 class ResultCallTest: AbstractRetrofitTest() {
     companion object: KLoggingChannel()
@@ -136,4 +148,112 @@ class ResultCallTest: AbstractRetrofitTest() {
             result.isSuccess.shouldBeTrue()
             result.isFailure.shouldBeFalse()
         }
+
+    @Test
+    fun `execute closes error response body before returning Result failure`() {
+        val errorBody = CloseTrackingResponseBody()
+        val delegate = ControlledCall<String>(syncResponse = Response.error(404, errorBody))
+
+        val response = ResultCall(delegate).execute()
+        val result = response.body().shouldNotBeNull()
+
+        result.isFailure.shouldBeTrue()
+        val exception = result.exceptionOrNull().shouldNotBeNull()
+        exception shouldBeInstanceOf HttpException::class
+        (exception as HttpException).code() shouldBeEqualTo 404
+        errorBody.closed.shouldBeTrue()
+    }
+
+    @Test
+    fun `enqueue closes error response body before returning Result failure`() {
+        val errorBody = CloseTrackingResponseBody()
+        val delegate = ControlledCall<String>()
+        val completed = CompletableFuture<Response<Result<String>>>()
+
+        ResultCall(delegate).enqueue(
+            object: Callback<Result<String>> {
+                override fun onResponse(
+                    call: Call<Result<String>>,
+                    response: Response<Result<String>>,
+                ) {
+                    completed.complete(response)
+                }
+
+                override fun onFailure(
+                    call: Call<Result<String>>,
+                    t: Throwable,
+                ) {
+                    completed.completeExceptionally(t)
+                }
+            }
+        )
+
+        delegate.callback.onResponse(delegate, Response.error(500, errorBody))
+
+        val result = completed.get(1, TimeUnit.SECONDS).body().shouldNotBeNull()
+        result.isFailure.shouldBeTrue()
+        val exception = result.exceptionOrNull().shouldNotBeNull()
+        exception shouldBeInstanceOf HttpException::class
+        (exception as HttpException).code() shouldBeEqualTo 500
+        errorBody.closed.shouldBeTrue()
+    }
+
+    private class ControlledCall<T>(
+        private val syncResponse: Response<T>? = null,
+    ): Call<T> {
+        lateinit var callback: Callback<T>
+            private set
+
+        private var executed = false
+        private var canceled = false
+
+        override fun enqueue(callback: Callback<T>) {
+            this.callback = callback
+            executed = true
+        }
+
+        override fun execute(): Response<T> {
+            executed = true
+            return syncResponse.shouldNotBeNull()
+        }
+
+        override fun clone(): Call<T> = ControlledCall(syncResponse)
+
+        override fun isExecuted(): Boolean = executed
+
+        override fun cancel() {
+            canceled = true
+        }
+
+        override fun isCanceled(): Boolean = canceled
+
+        override fun request(): Request =
+            Request.Builder().url("https://example.test/").build()
+
+        override fun timeout(): Timeout = Timeout.NONE
+    }
+
+    private class CloseTrackingResponseBody: ResponseBody() {
+        private val source = CloseTrackingSource()
+        val closed: Boolean get() = source.closed
+
+        override fun contentType() = null
+
+        override fun contentLength(): Long = 0L
+
+        override fun source(): BufferedSource = source.buffer()
+    }
+
+    private class CloseTrackingSource: Source {
+        var closed: Boolean = false
+            private set
+
+        override fun close() {
+            closed = true
+        }
+
+        override fun read(sink: Buffer, byteCount: Long): Long = -1L
+
+        override fun timeout(): Timeout = Timeout.NONE
+    }
 }


### PR DESCRIPTION
## Summary

Closes #794

- PR 제목: fix: close ResultCall error bodies

- Close Retrofit error bodies when `ResultCall` converts unsuccessful HTTP responses into `Result.failure(HttpException)`.
- Preserve `HttpException` status diagnostics while preventing hidden response-body leaks in sync and async paths.
- Add close-tracking regression coverage for both `execute()` and `enqueue()` failure wrapping.

Stacked on #989.
Closes #794.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- `./gradlew :bluetape4k-retrofit2:test --tests "io.bluetape4k.retrofit2.result.ResultCallTest" --no-build-cache`
- `git diff --check`

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #794, milestone `1.12.0`, assignee `debop`
- PR: #990, head `d50707b698ab5283539482cdf2387e6d9a2ab319`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-794-resultcall-error-body`
- Labels: `bug`, `test`
- State: `MERGED`, merge commit `e201fcf077c1f9276a05b3720050295842461ce3`
- CI: - `./gradlew :bluetape4k-retrofit2:test --tests "io.bluetape4k.retrofit2.result.ResultCallTest" --no-build-cache`

## DoD Status

| Gate | Status | Evidence |
| --- | --- | --- |
| Issue scope | PASS | Addresses #794 sync and async `ResultCall` unsuccessful-response error-body cleanup. |
| Stacked base | PASS | PR targets `fix/issue-793-retrofit-timeout-abort` / #989 so the #794 diff remains isolated. |
| Code patterns | PASS | Keeps failure wrapping small, preserves `HttpException.code()`, and uses bluetape4k assertions in tests. |
| Tests | PASS | `ResultCallTest` passed: 10 tests, `BUILD SUCCESSFUL in 10s`. |
| Static diff | PASS | `git diff --check` passed. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #990 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e201fcf077c1f9276a05b3720050295842461ce3`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
