### PR TITLE
build: sync managed catalog versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,8 +19,8 @@ chaos-monkey = "4.0.0"  # https://mvnrepository.com/artifact/de.codecentric/chao
 blockhound = "1.0.16.RELEASE"  # https://mvnrepository.com/artifact/io.projectreactor.tools/blockhound
 
 mutiny = "3.2.0"  # https://mvnrepository.com/artifact/io.smallrye.reactive/mutiny
-vertx = "5.1.3"  # https://mvnrepository.com/artifact/io.vertx/vertx-dependencies
-ktor = "3.5.0"  # https://mvnrepository.com/artifact/io.ktor/ktor-server-core
+vertx = "5.1.4"  # https://mvnrepository.com/artifact/io.vertx/vertx-dependencies
+ktor = "3.5.1"  # https://mvnrepository.com/artifact/io.ktor/ktor-server-core
 
 swagger = "2.2.49"  # https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-core
 springdoc-openapi = "3.0.3"  # https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-api
@@ -28,12 +28,12 @@ problem = "0.29.1"  # https://mvnrepository.com/artifact/org.zalando/problem
 
 bucket4j = "8.18.0"  # https://mvnrepository.com/artifact/com.bucket4j/bucket4j_jdk17-core
 resilience4j = "2.4.0"  # https://mvnrepository.com/artifact/io.github.resilience4j/resilience4j-bom
-netty = "4.2.15.Final"  # https://mvnrepository.com/artifact/io.netty/netty-bom
+netty = "4.2.16.Final"  # https://mvnrepository.com/artifact/io.netty/netty-bom
 netty-tcnative = "2.0.77.Final"  # https://mvnrepository.com/artifact/io.netty/netty-tcnative-classes
 
-aws2 = "2.46.17"  # https://mvnrepository.com/artifact/software.amazon.awssdk/bom
+aws2 = "2.47.1"  # https://mvnrepository.com/artifact/software.amazon.awssdk/bom
 aws2-crt = "0.45.3"  # https://mvnrepository.com/artifact/software.amazon.awssdk.crt/aws-crt
-aws-kotlin = "1.6.102"  # https://mvnrepository.com/artifact/aws.sdk.kotlin/aws-core
+aws-kotlin = "1.8.0"  # https://mvnrepository.com/artifact/aws.sdk.kotlin/aws-core
 aws-smithy-kotlin = "1.6.14"  # https://mvnrepository.com/artifact/aws.smithy.kotlin/http-jvm
 
 grpc = "1.81.0"  # https://mvnrepository.com/artifact/io.grpc/grpc-bom
@@ -43,13 +43,13 @@ grpc-google-common-protos = "2.71.0"  # https://mvnrepository.com/artifact/com.g
 avro = "1.12.1"  # https://mvnrepository.com/artifact/org.apache.avro/avro
 
 feign = "13.12"  # https://mvnrepository.com/artifact/io.github.openfeign/feign-bom
-httpclient5 = "5.6.1"  # https://mvnrepository.com/artifact/org.apache.httpcomponents.client5/httpclient5
-httpcore5 = "5.4.2"  # https://mvnrepository.com/artifact/org.apache.httpcomponents.core5/httpcore5
+httpclient5 = "5.6.2"  # https://mvnrepository.com/artifact/org.apache.httpcomponents.client5/httpclient5
+httpcore5 = "5.4.3"  # https://mvnrepository.com/artifact/org.apache.httpcomponents.core5/httpcore5
 retrofit2 = "3.0.0"  # https://mvnrepository.com/artifact/com.squareup.retrofit2/retrofit
 okhttp3 = "5.3.2"  # https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp-bom
 okio = "3.17.0"  # https://mvnrepository.com/artifact/com.squareup.okio/okio
 
-jackson = "2.22.0"  # https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom
+jackson = "2.22.1"  # https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom
 jackson3 = "3.2.0"  # https://mvnrepository.com/artifact/tools.jackson/jackson-bom
 fastjson2 = "2.0.62"  # https://mvnrepository.com/artifact/com.alibaba.fastjson2/fastjson2
 jjwt = "0.13.0"  # https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api
@@ -62,12 +62,12 @@ lettuce = "7.6.0.RELEASE"  # https://mvnrepository.com/artifact/io.lettuce/lettu
 redisson = "4.6.1"  # https://mvnrepository.com/artifact/org.redisson/redisson
 lz4 = "1.11.0"  # https://mvnrepository.com/artifact/at.yawk.lz4/lz4-java
 
-hibernate = "7.4.2.Final"  # https://mvnrepository.com/artifact/org.hibernate.orm/hibernate-core
+hibernate = "7.4.4.Final"  # https://mvnrepository.com/artifact/org.hibernate.orm/hibernate-core
 hibernate-reactive = "4.5.0.Final"  # https://mvnrepository.com/artifact/org.hibernate.reactive/hibernate-reactive-core
 hibernate-validator = "9.1.0.Final"  # https://mvnrepository.com/artifact/org.hibernate.validator/hibernate-validator
 querydsl = "7.4.0"  # https://mvnrepository.com/artifact/io.github.openfeign.querydsl/querydsl-apt
 
-exposed = "1.3.0"  # https://mvnrepository.com/artifact/org.jetbrains.exposed/exposed-bom
+exposed = "1.3.1"  # https://mvnrepository.com/artifact/org.jetbrains.exposed/exposed-bom
 r2dbc = "1.0.0.RELEASE"  # https://mvnrepository.com/artifact/io.r2dbc/r2dbc-spi
 r2dbc-h2 = "1.1.0.RELEASE"  # https://mvnrepository.com/artifact/io.r2dbc/r2dbc-h2
 r2dbc-pool = "1.0.2.RELEASE"  # https://mvnrepository.com/artifact/io.r2dbc/r2dbc-pool
@@ -77,9 +77,9 @@ r2dbc-mariadb = "1.4.0"  # https://mvnrepository.com/artifact/org.mariadb/r2dbc-
 r2dbc-postgresql = "1.1.1.RELEASE"  # https://mvnrepository.com/artifact/org.postgresql/r2dbc-postgresql
 mysql-connector-j = "9.7.0"  # https://mvnrepository.com/artifact/com.mysql/mysql-connector-j
 mariadb-java-client = "3.5.8"  # https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client
-postgresql = "42.7.11"  # https://mvnrepository.com/artifact/org.postgresql/postgresql
+postgresql = "42.7.13"  # https://mvnrepository.com/artifact/org.postgresql/postgresql
 h2-v2 = "2.4.240"  # https://mvnrepository.com/artifact/com.h2database/h2
-agroal = "3.2"  # https://mvnrepository.com/artifact/io.agroal/agroal-api
+agroal = "3.2.1"  # https://mvnrepository.com/artifact/io.agroal/agroal-api
 
 blaze-persistence = "3.34.6"  # https://mvnrepository.com/artifact/com.blazebit/blaze-persistence-core-api
 blaze-persistence-jakarta = "1.6.16"  # https://repo1.maven.org/maven2/com/blazebit/blaze-persistence-integration-hibernate-7.0/
@@ -110,7 +110,7 @@ elasticsearch = "9.4.0"  # https://mvnrepository.com/artifact/org.elasticsearch.
 elasticsearch-java = "9.4.0"  # https://mvnrepository.com/artifact/co.elastic.clients/elasticsearch-java
 
 kafka3 = "3.9.2"  # https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients; Server-side: spring-kafka 3.x embedded test (EmbeddedKafkaKraftBroker)
-kafka4 = "4.2.1"  # https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients; Spring Kafka 4.1 embedded-test ABI
+kafka4 = "4.3.1"  # https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients; Spring Kafka 4.1 embedded-test ABI
 spring-kafka = "3.3.16"  # https://mvnrepository.com/artifact/org.springframework.kafka/spring-kafka
 spring-kafka4 = "4.1.0"  # https://mvnrepository.com/artifact/org.springframework.kafka/spring-kafka
 
@@ -157,11 +157,11 @@ dependency-management = "1.1.7"  # https://mvnrepository.com/artifact/io.spring.
 dokka = "2.2.0"  # https://mvnrepository.com/artifact/org.jetbrains.dokka/dokka-gradle-plugin
 kover = "0.9.8"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kover-gradle-plugin
 test-logger = "4.0.0"  # https://mvnrepository.com/artifact/com.adarshr/gradle-test-logger-plugin
-shadow = "9.4.2"  # https://mvnrepository.com/artifact/com.gradleup.shadow/shadow-gradle-plugin
+shadow = "9.5.1"  # https://mvnrepository.com/artifact/com.gradleup.shadow/shadow-gradle-plugin
 protobuf-plugin = "0.10.0"  # https://mvnrepository.com/artifact/com.google.protobuf/protobuf-gradle-plugin
 avro-plugin = "1.9.1"  # https://mvnrepository.com/artifact/com.github.davidmc24.gradle.plugin/gradle-avro-plugin
 graalvm-native = "1.1.0"  # https://mvnrepository.com/artifact/org.graalvm.buildtools/native-gradle-plugin
-nmcp = "1.6.0"  # https://mvnrepository.com/artifact/com.gradleup.nmcp/nmcp
+nmcp = "1.6.1"  # https://mvnrepository.com/artifact/com.gradleup.nmcp/nmcp
 dependency-check = "12.2.2"  # https://mvnrepository.com/artifact/org.owasp/dependency-check-gradle
 
 [plugins]
@@ -928,7 +928,7 @@ agroal-narayana = { module = "io.agroal:agroal-narayana", version.ref = "agroal"
 agroal-spring-boot-starter = { module = "io.agroal:agroal-spring-boot-starter", version.ref = "agroal" }
 
 # JDBC / Connection Pool
-hikaricp = { module = "com.zaxxer:HikariCP", version = "7.0.2" }  # https://mvnrepository.com/artifact/com.zaxxer/HikariCP
+hikaricp = { module = "com.zaxxer:HikariCP", version = "7.1.0" }  # https://mvnrepository.com/artifact/com.zaxxer/HikariCP
 tomcat-jdbc = { module = "org.apache.tomcat:tomcat-jdbc", version = "11.0.18" }  # https://mvnrepository.com/artifact/org.apache.tomcat/tomcat-jdbc
 mysql-connector-j = { module = "com.mysql:mysql-connector-j", version.ref = "mysql-connector-j" }
 mariadb-java-client = { module = "org.mariadb.jdbc:mariadb-java-client", version.ref = "mariadb-java-client" }
@@ -1020,7 +1020,7 @@ ow2-asm-tree = { module = "org.ow2.asm:asm-tree", version.ref = "ow2-asm" }
 objenesis = { module = "org.objenesis:objenesis", version = "3.5" }  # https://mvnrepository.com/artifact/org.objenesis/objenesis
 
 # ByteBuddy
-byte-buddy = { module = "net.bytebuddy:byte-buddy", version = "1.18.4" }  # https://mvnrepository.com/artifact/net.bytebuddy/byte-buddy
+byte-buddy = { module = "net.bytebuddy:byte-buddy", version = "1.18.11" }  # https://mvnrepository.com/artifact/net.bytebuddy/byte-buddy
 byte-buddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version = "1.18.4" }  # https://mvnrepository.com/artifact/net.bytebuddy/byte-buddy-agent
 
 # JUnit 5
@@ -1099,7 +1099,7 @@ wiremock = { module = "org.wiremock:wiremock", version = "3.13.2" }  # https://m
 
 # Kubernetes
 fabric8-kubernetes-client-bom = { module = "io.fabric8:kubernetes-client-bom", version = "7.7.0" }  # https://mvnrepository.com/artifact/io.fabric8/kubernetes-client-bom
-fabric8-kubernetes-client = { module = "io.fabric8:kubernetes-client", version = "7.7.0" }  # https://mvnrepository.com/artifact/io.fabric8/kubernetes-client
+fabric8-kubernetes-client = { module = "io.fabric8:kubernetes-client", version = "7.8.0" }  # https://mvnrepository.com/artifact/io.fabric8/kubernetes-client
 kubernetes-client-java = { module = "io.kubernetes:client-java", version = "24.0.0" }  # https://mvnrepository.com/artifact/io.kubernetes/client-java
 
 # Rest Assured

--- a/io/http/build.gradle.kts
+++ b/io/http/build.gradle.kts
@@ -126,13 +126,17 @@ dependencies {
     compileOnly(libs.httpclient5)
     compileOnly(libs.httpclient5.cache)
     compileOnly(libs.httpclient5.fluent)
-    testImplementation(libs.httpclient5.testing)
+    testImplementation(libs.httpclient5.testing) {
+        exclude(group = "org.apache.httpcomponents.core5", module = "httpcore5-testing")
+    }
 
     // Apache HttpComponent Core 5
     compileOnly(libs.httpcore5)
     compileOnly(libs.httpcore5.h2)
     compileOnly(libs.httpcore5.reactive)
-    testImplementation(libs.httpcore5.testing)
+    testImplementation(libs.httpcore5.testing) {
+        exclude(group = "org.apache.httpcomponents.core5", module = "httpcore5")
+    }
 
     compileOnly(project(":bluetape4k-cache-core"))
     compileOnly(libs.caffeine)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ pluginManagement {
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-    .orElse("catalog/2026-06-25-05")
+    .orElse("catalog/2026-07-08-00")
     .get()
 val bluetape4kDependenciesCatalogCacheKey = bluetape4kDependenciesCatalogRef.replace(Regex("[^A-Za-z0-9._-]"), "_")
 

--- a/spring-boot/core/build.gradle.kts
+++ b/spring-boot/core/build.gradle.kts
@@ -48,7 +48,9 @@ dependencies {
     compileOnly(libs.httpclient5)
     compileOnly(libs.httpclient5.cache)
     compileOnly(libs.httpclient5.fluent)
-    testImplementation(libs.httpclient5.testing)
+    testImplementation(libs.httpclient5.testing) {
+        exclude(group = "org.apache.httpcomponents.core5", module = "httpcore5-testing")
+    }
 
     // Jackson 3 (Spring Boot 4는 Jackson 3 사용)
     compileOnly(project(":bluetape4k-jackson3"))


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: build: sync managed catalog versions

- Materializes the refreshed `bluetape4k-dependencies` shared version catalog into this repository.
- Updates the default `bluetape4kDependenciesCatalogRef` to `catalog/2026-07-08-00`.
- `bluetape4k-experimental` is intentionally excluded from this propagation wave.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary
- Materializes the refreshed `bluetape4k-dependencies` shared version catalog into this repository.
- Updates the default `bluetape4kDependenciesCatalogRef` to `catalog/2026-07-08-00`.
- `bluetape4k-experimental` is intentionally excluded from this propagation wave.

### Validation
- `git diff --check`
- `./gradlew help --no-configuration-cache --console=plain`

### DoD Status

- [x] Synced catalog-managed versions from `bluetape4k-dependencies`.
- [x] Updated default `bluetape4kDependenciesCatalogRef` to `catalog/2026-07-08-00`.
- [x] Fixed `:bluetape4k-http:test` executor startup by excluding the broken `httpcore5` tests classifier from Apache HttpComponents testing dependencies.
- [x] Verified locally with `git diff --check`.
- [x] Verified locally with `./gradlew help --no-configuration-cache --console=plain`.
- [x] Verified locally with `./gradlew :bluetape4k-http:test --no-configuration-cache --console=plain`.
- [x] Verified locally with `./gradlew :bluetape4k-spring-boot-core:test --no-configuration-cache --console=plain`.
- [ ] GitHub Actions rerun is pending after commit `494cfc6af`.

## Validation

- `git diff --check`
- `./gradlew help --no-configuration-cache --console=plain`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #992, head `494cfc6af275fbfddc41b28ef151c6460b3ef9e6`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `build/refresh-catalog-managed-versions`
- Labels: `dependencies`
- State: `MERGED`, merge commit `309eec181935c981ccebe10ba99f99637d453555`
- CI: - Materializes the refreshed `bluetape4k-dependencies` shared version catalog into this repository. / - Updates the default `bluetape4kDependenciesCatalogRef` to `catalog/2026-07-08-00`. / - `./gradlew help --no-configuration-cache --console=plain`

## DoD Status

- [x] Synced catalog-managed versions from `bluetape4k-dependencies`.
- [x] Updated default `bluetape4kDependenciesCatalogRef` to `catalog/2026-07-08-00`.
- [x] Fixed `:bluetape4k-http:test` executor startup by excluding the broken `httpcore5` tests classifier from Apache HttpComponents testing dependencies.
- [x] Verified locally with `git diff --check`.
- [x] Verified locally with `./gradlew help --no-configuration-cache --console=plain`.
- [x] Verified locally with `./gradlew :bluetape4k-http:test --no-configuration-cache --console=plain`.
- [x] Verified locally with `./gradlew :bluetape4k-spring-boot-core:test --no-configuration-cache --console=plain`.
- [ ] GitHub Actions rerun is pending after commit `494cfc6af`.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #992 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `309eec181935c981ccebe10ba99f99637d453555`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
