### PR TITLE
fix: preserve distributed rate limiter cancellation

### DIFF
--- a/docs/lessons/2026-07-08-issue-805-rate-limiter-cancellation.md
+++ b/docs/lessons/2026-07-08-issue-805-rate-limiter-cancellation.md
@@ -1,0 +1,29 @@
+# Issue 805 - Distributed Rate Limiter Cancellation
+
+## Context
+
+`DistributedSuspendRateLimiter` used `withTimeout` and then caught
+`TimeoutCancellationException` before `CancellationException`. That made the
+limiter-owned timeout path clear, but it also allowed timeout-shaped
+cancellation from an async bucket boundary to be converted into
+`RateLimitResult.ERROR`.
+
+## Decision
+
+Model limiter-owned timeout explicitly with `withTimeoutOrNull`, convert only
+that `null` result into `RateLimitResult.ERROR`, and rethrow every
+`CancellationException` before general error handling.
+
+## Outcome
+
+The distributed suspend tests now cover three cancellation boundaries: cancelled
+await, async timeout cancellation, and caller `withTimeout` with and without
+`defaultTimeout`. The existing limiter-owned timeout test still returns
+`RateLimitStatus.ERROR`.
+
+## Future Guidance
+
+Do not catch `TimeoutCancellationException` as an ordinary error around suspend
+boundaries. Use an explicit timeout result boundary when a component owns the
+timeout, then let coroutine cancellation propagate through the normal
+`CancellationException` path.

--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/distributed/DistributedSuspendRateLimiter.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/distributed/DistributedSuspendRateLimiter.kt
@@ -9,9 +9,9 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.future.await
-import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.TimeoutException
 import kotlin.time.Duration
 
 /**
@@ -75,19 +75,22 @@ class DistributedSuspendRateLimiter @JvmOverloads constructor(
             val probe = if (timeout == null) {
                 bucketProxy.tryConsumeAndReturnRemaining(numToken).await()
             } else {
-                withTimeout(timeout) {
+                withTimeoutOrNull(timeout) {
                     bucketProxy.tryConsumeAndReturnRemaining(numToken).await()
-                }
+                } ?: return timeoutResult(key, timeout)
             }
             toRateLimitResult(probe, numToken)
-        } catch (e: TimeoutCancellationException) {
-            log.warn(e) { "Rate Limiter timed out. key=$key" }
-            RateLimitResult.error(e)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             log.warn(e) { "Rate Limiter 적용에 실패했습니다. key=$key" }
             RateLimitResult.error(e)
         }
+    }
+
+    private fun timeoutResult(key: String, timeout: Duration): RateLimitResult {
+        val cause = TimeoutException("Rate Limiter timed out. key=$key, timeout=$timeout")
+        log.warn(cause) { "Rate Limiter timed out. key=$key, timeout=$timeout" }
+        return RateLimitResult.error(cause)
     }
 }

--- a/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/ratelimit/distributed/LettuceSuspendRateLimiterTest.kt
+++ b/infra/bucket4j/src/test/kotlin/io/bluetape4k/bucket4j/ratelimit/distributed/LettuceSuspendRateLimiterTest.kt
@@ -17,9 +17,13 @@ import io.github.bucket4j.distributed.proxy.ExecutionStrategy
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
@@ -94,6 +98,23 @@ class LettuceSuspendRateLimiterTest: AbstractSuspendRateLimiterTest() {
     }
 
     @Test
+    fun `distributed await 이 timeout cancellation 으로 실패하면 전파해야 한다`() = runTest {
+        val bucket = mockk<AsyncBucketProxy>()
+        val failed = CompletableFuture<ConsumptionProbe>()
+        failed.completeExceptionally(callerTimeoutCancellation())
+        every { bucket.tryConsumeAndReturnRemaining(any()) } returns failed
+
+        val provider = mockk<AsyncBucketProxyProvider>()
+        every { provider.resolveBucket(any()) } returns bucket
+
+        val limiter = DistributedSuspendRateLimiter(provider)
+
+        assertFailsWith<TimeoutCancellationException> {
+            limiter.consume(randomKey(), 1)
+        }
+    }
+
+    @Test
     fun `distributed await timeout 은 error 결과로 반환한다`() = runTest {
         val bucket = mockk<AsyncBucketProxy>()
         val pending = CompletableFuture<ConsumptionProbe>()
@@ -111,5 +132,64 @@ class LettuceSuspendRateLimiterTest: AbstractSuspendRateLimiterTest() {
 
         val result = deferred.await()
         result.status shouldBeEqualTo RateLimitStatus.ERROR
+    }
+
+    @Test
+    fun `caller timeout 은 per-call timeout 없이도 전파해야 한다`() = runTest {
+        val bucket = mockk<AsyncBucketProxy>()
+        val pending = CompletableFuture<ConsumptionProbe>()
+        every { bucket.tryConsumeAndReturnRemaining(any()) } returns pending
+
+        val provider = mockk<AsyncBucketProxyProvider>()
+        every { provider.resolveBucket(any()) } returns bucket
+
+        val limiter = DistributedSuspendRateLimiter(provider)
+        val task = async {
+            withTimeout(10.milliseconds) {
+                limiter.consume(randomKey(), 1, timeout = null)
+            }
+        }
+
+        advanceTimeBy(10.milliseconds)
+        runCurrent()
+
+        assertFailsWith<TimeoutCancellationException> {
+            task.await()
+        }
+    }
+
+    @Test
+    fun `caller timeout 은 default timeout 보다 먼저 발생하면 전파해야 한다`() = runTest {
+        val bucket = mockk<AsyncBucketProxy>()
+        val pending = CompletableFuture<ConsumptionProbe>()
+        every { bucket.tryConsumeAndReturnRemaining(any()) } returns pending
+
+        val provider = mockk<AsyncBucketProxyProvider>()
+        every { provider.resolveBucket(any()) } returns bucket
+
+        val limiter = DistributedSuspendRateLimiter(provider, defaultTimeout = 1.seconds)
+        val task = async {
+            withTimeout(10.milliseconds) {
+                limiter.consume(randomKey(), 1)
+            }
+        }
+
+        advanceTimeBy(10.milliseconds)
+        runCurrent()
+
+        assertFailsWith<TimeoutCancellationException> {
+            task.await()
+        }
+    }
+
+    private suspend fun callerTimeoutCancellation(): TimeoutCancellationException {
+        try {
+            withTimeout(1.milliseconds) {
+                delay(2.milliseconds)
+            }
+        } catch (e: TimeoutCancellationException) {
+            return e
+        }
+        error("withTimeout must throw TimeoutCancellationException")
     }
 }


### PR DESCRIPTION
## Summary

Closes #805

- PR 제목: fix: preserve distributed rate limiter cancellation

Fixes #805.

- Separates limiter-owned distributed async timeouts from coroutine cancellation by using `withTimeoutOrNull`.
- Converts only the limiter-owned timeout boundary into `RateLimitResult.ERROR`.
- Adds regression coverage for async timeout cancellation and caller `withTimeout` with and without `defaultTimeout`.
- Records the cancellation-boundary lesson for future coroutine fixes.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

Fixes #805.

- Separates limiter-owned distributed async timeouts from coroutine cancellation by using `withTimeoutOrNull`.
- Converts only the limiter-owned timeout boundary into `RateLimitResult.ERROR`.
- Adds regression coverage for async timeout cancellation and caller `withTimeout` with and without `defaultTimeout`.
- Records the cancellation-boundary lesson for future coroutine fixes.

### Review Notes

- README already states the intended contract: timeout returns `RateLimitStatus.ERROR`, coroutine cancellation throws `CancellationException`. No README change was needed.
- The red test failed before the production fix with: `Expected TimeoutCancellationException but no exception was thrown`.

### DoD Status

| Check | Status | Evidence |
|---|---:|---|
| Issue metadata | PASS | Issue #805 is assigned to `debop`, milestone `1.12.0`, labels `bug`, `test`, `infra/io`, `coroutines`. |
| TDD red | PASS | Targeted test failed before implementation: async `TimeoutCancellationException` was swallowed as no thrown exception. |
| Targeted tests | PASS | `./gradlew :bluetape4k-bucket4j:test --tests "io.bluetape4k.bucket4j.ratelimit.distributed.*SuspendRateLimiterTest" --no-build-cache` |
| Diff hygiene | PASS | `git diff --check HEAD~1..HEAD` |
| GitHub checks | PASS | `Build`, `Coverage Report`, `CI Status`, `Detect changed modules`, `Secret Scan (gitleaks)`, `Validate Gradle Wrapper`, and `submit-gradle` passed. Test matrix jobs were skipped by changed-module detection. |
| Post-PR review | PASS | PR comment and COMMENTED review posted after CI. |
| Worktree status | PASS | Feature worktree clean after push. |

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- README already states the intended contract: timeout returns `RateLimitStatus.ERROR`, coroutine cancellation throws `CancellationException`. No README change was needed.
- The red test failed before the production fix with: `Expected TimeoutCancellationException but no exception was thrown`.

## Metadata

- Issue: #805, milestone `1.12.0`, assignee `debop`
- PR: #994, head `02f09a4c4b0bede2ee3a96ecc75861c4ea9fb836`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-805-rate-limiter-cancellation`
- Labels: `bug`, `test`, `infra/io`, `coroutines`
- State: `MERGED`, merge commit `9c9b88cf720ccd2c9c5f270b68d37d5b5132262e`
- CI: | Targeted tests | PASS | `./gradlew :bluetape4k-bucket4j:test --tests "io.bluetape4k.bucket4j.ratelimit.distributed.*SuspendRateLimiterTest" --no-build-cache` | / | GitHub checks | PASS | `Build`, `Coverage Report`, `CI Status`, `Detect changed modules`, `Secret Scan (gitleaks)`, `Validate Gradle Wrapper`, and `submit-gradle` passed. Test matrix jobs were skipped by changed-module detection. | / | Post-PR review | PASS | PR comment and COMMENTED review posted after CI. |

## DoD Status

| Check | Status | Evidence |
|---|---:|---|
| Issue metadata | PASS | Issue #805 is assigned to `debop`, milestone `1.12.0`, labels `bug`, `test`, `infra/io`, `coroutines`. |
| TDD red | PASS | Targeted test failed before implementation: async `TimeoutCancellationException` was swallowed as no thrown exception. |
| Targeted tests | PASS | `./gradlew :bluetape4k-bucket4j:test --tests "io.bluetape4k.bucket4j.ratelimit.distributed.*SuspendRateLimiterTest" --no-build-cache` |
| Diff hygiene | PASS | `git diff --check HEAD~1..HEAD` |
| GitHub checks | PASS | `Build`, `Coverage Report`, `CI Status`, `Detect changed modules`, `Secret Scan (gitleaks)`, `Validate Gradle Wrapper`, and `submit-gradle` passed. Test matrix jobs were skipped by changed-module detection. |
| Post-PR review | PASS | PR comment and COMMENTED review posted after CI. |
| Worktree status | PASS | Feature worktree clean after push. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #994 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9c9b88cf720ccd2c9c5f270b68d37d5b5132262e`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
