### PR TITLE
fix: cancel leaf futures on aggregate cancellation

### DIFF
--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/CompletionStageSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/CompletionStageSupport.kt
@@ -70,6 +70,23 @@ fun <T> CompletionStage<T>.getExceptionOrNull(): Throwable? {
     }
 }
 
+private fun <T> sequenceFutures(
+    futures: List<CompletableFuture<out T>>,
+    executor: Executor,
+): CompletableFuture<List<T>> {
+    if (futures.isEmpty()) return completableFutureOf(emptyList())
+
+    val aggregate = CompletableFuture.allOf(*futures.toTypedArray())
+    val sequenced = aggregate.thenApplyAsync({ futures.map { it.join() } }, executor)
+    sequenced.whenComplete { _, _ ->
+        if (sequenced.isCancelled) {
+            futures.forEach { it.cancel(true) }
+            aggregate.cancel(true)
+        }
+    }
+    return sequenced
+}
+
 /**
  * [CompletionStage]의 컬렉션을 `CompletableFuture<List<*>>` 로 변환합니다.
  *
@@ -78,15 +95,14 @@ fun <T> CompletionStage<T>.getExceptionOrNull(): Throwable? {
  * val results: CompletableFuture<List<Int>> = futures.sequence()
  * ```
  *
+ * Cancelling the returned future also cancels every source future.
+ *
  * @receiver Iterable<CompletionStage<out Any>>
  * @param executor Executor (default: ForkJoinExecutor)
  * @return CompletableFuture<List<*>>
  */
 fun Iterable<CompletionStage<out Any>>.sequence(executor: Executor = ForkJoinExecutor): CompletableFuture<List<*>> {
-    val futures = map { it.toCompletableFuture() }
-    if (futures.isEmpty()) return completableFutureOf(emptyList<Any>())
-    return CompletableFuture.allOf(*futures.toTypedArray())
-        .thenApplyAsync({ futures.map { it.join() } }, executor)
+    return sequenceFutures(map { it.toCompletableFuture() }, executor)
 }
 
 /**
@@ -97,14 +113,13 @@ fun Iterable<CompletionStage<out Any>>.sequence(executor: Executor = ForkJoinExe
  * val results: CompletableFuture<List<Int>> = futures.sequence()
  * ```
  *
+ * Cancelling the returned future also cancels every source future.
+ *
  * @param executor Executor (default: ForkJoinExecutor)
  * @return `CompletableFuture<List<T>>`
  */
 fun <T> Collection<CompletionStage<out T>>.sequence(executor: Executor = ForkJoinExecutor): CompletableFuture<List<T>> {
-    if (isEmpty()) return completableFutureOf(emptyList())
-    val futures = map { it.toCompletableFuture() }
-    return CompletableFuture.allOf(*futures.toTypedArray())
-        .thenApplyAsync({ futures.map { it.join() } }, executor)
+    return sequenceFutures(map { it.toCompletableFuture() }, executor)
 }
 
 /**

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/CompletionStageSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/CompletionStageSupportTest.kt
@@ -50,6 +50,22 @@ class CompletionStageSupportTest {
     }
 
     @Test
+    fun `sequence - 결과 future 가 취소되면 source stage 를 취소한다`() {
+        val stages = listOf(
+            CompletableFuture<Int>(),
+            CompletableFuture<Int>(),
+            CompletableFuture<Int>(),
+        )
+
+        val sequenced = stages.sequence()
+
+        sequenced.cancel(true).shouldBeTrue()
+        stages.forEach { stage ->
+            stage.isCancelled.shouldBeTrue()
+        }
+    }
+
+    @Test
     fun `firstCompleted 와 firstSucceeded`() {
         val failedFirst = failedCompletableFutureOf<Int>(IllegalStateException("boom"))
         val pending = CompletableFuture<Int>()

--- a/docs/lessons/2026-07-09-issue-804-cancel-leaf-redis-futures.md
+++ b/docs/lessons/2026-07-09-issue-804-cancel-leaf-redis-futures.md
@@ -1,0 +1,28 @@
+# Issue 804 - Cancel Leaf Redis Futures
+
+## Context
+
+Redis bulk await helpers waited on one aggregate `CompletableFuture` created by
+`CompletionStage.sequence`. Cancelling the caller coroutine cancelled that
+aggregate await, but it did not cancel the original Lettuce `RedisFuture` or
+Redisson `RFuture` leaves.
+
+## Decision
+
+Put leaf cancellation in the shared `CompletionStage.sequence` boundary. When
+the returned aggregate future is cancelled, each source future receives
+`cancel(true)`. Redis-specific helpers keep their existing API and inherit the
+shared all-or-nothing cancellation behavior.
+
+## Outcome
+
+Core, Lettuce, and Redisson tests now prove that aggregate/coroutine
+cancellation cancels pending source futures while preserving input-order success
+results and existing failure propagation.
+
+## Future Guidance
+
+When wrapping many external futures behind one coroutine await, cancellation
+must be propagated to the source futures, not only to the aggregate future.
+Cover both the shared aggregate helper and one representative adapter boundary
+when the behavior is reused across modules.

--- a/docs/review/2026-07-09-issue-804-cancel-leaf-redis-futures-review.md
+++ b/docs/review/2026-07-09-issue-804-cancel-leaf-redis-futures-review.md
@@ -1,0 +1,28 @@
+# Issue 804 Review - Cancel Leaf Redis Futures
+
+## Scope
+
+- `bluetape4k/core`: `CompletionStage.sequence` aggregate cancellation behavior.
+- `infra/lettuce`: `RedisFuture.awaitAll` and `sequence` cancellation contract.
+- `infra/redisson`: `RFuture.awaitAll` and `sequence` cancellation contract.
+
+## Findings
+
+- P0/P1: 0 after fix.
+- The red test reproduced the issue through Redisson `awaitAll`: cancelling the coroutine left pending `RFuture` leaves uncancelled.
+- The fix centralizes leaf cancellation in `CompletionStage.sequence`, so Lettuce and Redisson keep one shared aggregate behavior.
+- Existing exception propagation and input-order result construction remain unchanged because result collection still waits for `CompletableFuture.allOf` and maps `join()` in source order.
+
+## Concurrency Test Gate
+
+The new tests are deterministic cancellation-boundary tests, not stress tests. Existing `SuspendedJobTester` coverage remains in both Redis helper test classes for repeated concurrent await stability.
+
+## Verification
+
+- RED: `RFutureSupportTest > awaitAll cancels pending RFuture leaves when coroutine is cancelled` failed with `Expected <false> to be <true>`.
+- GREEN: `./gradlew :bluetape4k-core:test --tests "io.bluetape4k.concurrent.CompletionStageSupportTest" :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.RedisFutureSupportTest" :bluetape4k-redisson:test --tests "io.bluetape4k.redis.redisson.coroutines.RFutureSupportTest" --no-build-cache`
+- Hygiene: `git diff --check`
+
+## Residual Risk
+
+Changing `CompletionStage.sequence` broadens cancellation propagation for all callers that cancel the returned aggregate future. That is intentional for all-or-nothing bulk waits, but callers that previously expected aggregate cancellation to leave leaves running should avoid cancelling the aggregate or build an explicit detached future boundary.

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/RedisFutureSupport.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/RedisFutureSupport.kt
@@ -23,7 +23,8 @@ suspend inline fun <T> RedisFuture<T>.awaitSuspending(): T = await()
  * [RedisFuture] 컬렉션의 모든 요소가 완료될 때까지 스레드 블로킹 없이 대기합니다.
  *
  * 입력 순서대로 결과를 반환합니다. 하나라도 실패하면 반환 [List]를 만들지 않고 해당 예외가 전파됩니다.
- * 빈 컬렉션은 즉시 빈 리스트를 반환합니다.
+ * 빈 컬렉션은 즉시 빈 리스트를 반환합니다. Cancelling the caller coroutine cancels every pending source
+ * [RedisFuture].
  *
  * ```kotlin
  * val results = listOf(
@@ -41,7 +42,8 @@ suspend inline fun <T> Collection<RedisFuture<out T>>.awaitAll(): List<T> = when
  * [RedisFuture] 컬렉션을 입력 순서를 보존하는 [CompletableFuture]`<List<T>>`로 변환합니다.
  *
  * 모든 future가 완료된 뒤 단일 continuation에서 결과 리스트를 만듭니다. 대량 명령에서는 future마다
- * 별도 코루틴을 만들기보다 [awaitAll] 또는 이 함수를 사용하는 편이 가볍습니다.
+ * 별도 코루틴을 만들기보다 [awaitAll] 또는 이 함수를 사용하는 편이 가볍습니다. Cancelling the returned
+ * [CompletableFuture] cancels every source [RedisFuture].
  *
  * ```kotlin
  * val future: CompletableFuture<List<T>> = listOf(

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/RedisFutureSupportTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/RedisFutureSupportTest.kt
@@ -2,17 +2,23 @@ package io.bluetape4k.redis.lettuce
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.redis.lettuce.LettuceTestUtils.asyncCommands
 import io.lettuce.core.RedisFuture
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
 import kotlinx.coroutines.future.await
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import kotlin.time.Duration.Companion.seconds
 
 class RedisFutureSupportTest: AbstractLettuceTest() {
 
@@ -69,6 +75,28 @@ class RedisFutureSupportTest: AbstractLettuceTest() {
             listOf(failed).awaitAll()
         }
         error.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `awaitAll - 취소되면 대기 중인 RedisFuture 들을 취소한다`() = runSuspendIO {
+        val futures = List(3) { TestRedisFuture<String>() }
+        val task = async {
+            futures.awaitAll()
+        }
+
+        withTimeout(1.seconds) {
+            while (futures.any { it.numberOfDependents == 0 }) {
+                yield()
+            }
+        }
+        task.cancel(CancellationException("cancel Redis bulk await"))
+
+        assertFailsWith<CancellationException> {
+            task.await()
+        }
+        futures.forEach { future ->
+            future.isCancelled.shouldBeTrue()
+        }
     }
 
     @Test

--- a/infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/coroutines/RFutureSupport.kt
+++ b/infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/coroutines/RFutureSupport.kt
@@ -17,6 +17,7 @@ import kotlin.coroutines.ContinuationInterceptor
  *
  * 모든 [RFuture]가 완료될 때까지 기다린 후 입력 순서대로 결과를 담은 [List]를 반환하는
  * [CompletableFuture]를 생성합니다. 하나라도 실패하면 결과 [List]를 만들지 않고 해당 예외가 전파됩니다.
+ * Cancelling the returned [CompletableFuture] cancels every source [RFuture].
  *
  * ## 사용 예
  * ```kotlin
@@ -39,7 +40,8 @@ fun <V> Iterable<RFuture<out V>>.sequence(
  *
  * 현재 코루틴 디스패처를 Executor로 활용하며, 디스패처가 없으면 [Dispatchers.Default]를 사용합니다.
  * 컬렉션이 비어 있으면 빈 리스트를 즉시 반환합니다. 결과 순서는 입력 순서를 보존하고,
- * 실패한 [RFuture]가 있으면 해당 예외를 전파합니다.
+ * 실패한 [RFuture]가 있으면 해당 예외를 전파합니다. Cancelling the caller coroutine cancels every
+ * pending source [RFuture].
  *
  * ## 사용 예
  * ```kotlin

--- a/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/coroutines/RFutureSupportTest.kt
+++ b/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/coroutines/RFutureSupportTest.kt
@@ -2,21 +2,26 @@ package io.bluetape4k.redis.redisson.coroutines
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.coroutines.support.awaitSuspending
 import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.redis.redisson.RedissonTestUtils.randomName
 import io.bluetape4k.redis.redisson.RedissonTestUtils.redisson
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.redisson.api.RFuture
 import java.util.concurrent.CompletableFuture
+import kotlin.time.Duration.Companion.seconds
 
 class RFutureSupportTest: AbstractRedissonCoroutineTest() {
 
@@ -39,6 +44,28 @@ class RFutureSupportTest: AbstractRedissonCoroutineTest() {
             listOf(failed).awaitAll()
         }
         error.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `awaitAll cancels pending RFuture leaves when coroutine is cancelled`() = runSuspendIO {
+        val futures = List(3) { TestRFuture<String>() }
+        val task = async {
+            futures.awaitAll()
+        }
+
+        withTimeout(1.seconds) {
+            while (futures.any { it.numberOfDependents == 0 }) {
+                yield()
+            }
+        }
+        task.cancel(CancellationException("cancel Redisson bulk await"))
+
+        assertFailsWith<CancellationException> {
+            task.await()
+        }
+        futures.forEach { future ->
+            future.isCancelled.shouldBeTrue()
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #804

- PR 제목: fix: cancel leaf futures on aggregate cancellation

Fixes #804.

- Propagates cancellation from `CompletionStage.sequence` aggregate futures to every source future.
- Preserves input-order successful results and existing failure propagation.
- Updates Lettuce `RedisFuture` and Redisson `RFuture` cancellation contract KDoc.
- Adds regression coverage for core sequence, Lettuce awaitAll, and Redisson awaitAll.
- Adds review and lesson artifacts for the cancellation-boundary decision.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

Fixes #804.

- Propagates cancellation from `CompletionStage.sequence` aggregate futures to every source future.
- Preserves input-order successful results and existing failure propagation.
- Updates Lettuce `RedisFuture` and Redisson `RFuture` cancellation contract KDoc.
- Adds regression coverage for core sequence, Lettuce awaitAll, and Redisson awaitAll.
- Adds review and lesson artifacts for the cancellation-boundary decision.

### Review Notes

- The red test failed before the production fix with `Expected <false> to be <true>` for pending Redisson leaves.
- The implementation is centralized in `CompletionStage.sequence` to avoid duplicating Redis-only cancellation wrappers.
- Concurrency test gate: new tests are deterministic cancellation-boundary tests; existing `SuspendedJobTester` stress coverage remains in both Redis helper test classes.

### DoD Status

| Check | Status | Evidence |
|---|---:|---|
| Issue metadata | PASS | Issue #804 is assigned to `debop`, milestone `1.12.0`, labels `bug`, `test`, `infra/io`, `coroutines`. |
| TDD red | PASS | Redisson awaitAll cancellation test failed before implementation: `Expected <false> to be <true>`. |
| Implementation | PASS | Shared `CompletionStage.sequence` now cancels source futures when returned aggregate is cancelled. |
| Targeted tests | PASS | `./gradlew :bluetape4k-core:test --tests "io.bluetape4k.concurrent.CompletionStageSupportTest" :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.RedisFutureSupportTest" :bluetape4k-redisson:test --tests "io.bluetape4k.redis.redisson.coroutines.RFutureSupportTest" --no-build-cache` |
| Diff hygiene | PASS | `git diff --check HEAD~1..HEAD` |
| GitHub checks | PASS | CI run `28955701867`: Build, Test / Core, Test / Infra (Redis), Coverage Report, CI Status, Detect changed modules, gitleaks, Gradle wrapper all passed; unrelated module test jobs skipped by changed-module detection. Automatic Dependency Submission `submit-gradle` also passed. |
| Review artifact | PASS | `docs/review/2026-07-09-issue-804-cancel-leaf-redis-futures-review.md`, P0/P1 = 0. |
| Post-PR review | PASS | Self-review comment and formal review posted on PR #995. |
| Lessons | PASS | `docs/lessons/2026-07-09-issue-804-cancel-leaf-redis-futures.md` |
| Worktree status | PASS | Feature worktree clean after push; branch is ahead 0 / behind 0 with origin. |

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- The red test failed before the production fix with `Expected <false> to be <true>` for pending Redisson leaves.
- The implementation is centralized in `CompletionStage.sequence` to avoid duplicating Redis-only cancellation wrappers.
- Concurrency test gate: new tests are deterministic cancellation-boundary tests; existing `SuspendedJobTester` stress coverage remains in both Redis helper test classes.

## Metadata

- Issue: #804, milestone `1.12.0`, assignee `debop`
- PR: #995, head `7a0d8f7662cad213efa8f09b19a450ff63be0000`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-804-cancel-leaf-redis-futures`
- Labels: `bug`, `test`, `infra/io`, `coroutines`
- State: `MERGED`, merge commit `376001f2d45e58fad85573e1785ef6f7a666d3bf`
- CI: - Adds review and lesson artifacts for the cancellation-boundary decision. / | Targeted tests | PASS | `./gradlew :bluetape4k-core:test --tests "io.bluetape4k.concurrent.CompletionStageSupportTest" :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.RedisFutureSupportTest" :bluetape4k-redisson:test --tests "io.bluetape4k.redis.redisson.coroutines.RFutureSupportTest" --no-build-cache` | / | GitHub checks | PASS | CI run `28955701867`: Build, Test / Core, Test / Infra (Redis), Coverage Report, CI Status, Detect changed modules, gitleaks, Gradle wrapper all passed; unrelated module test jobs skipped by changed-module detection. Automatic Dependency Submission `submit-gradle` also passed. |

## DoD Status

| Check | Status | Evidence |
|---|---:|---|
| Issue metadata | PASS | Issue #804 is assigned to `debop`, milestone `1.12.0`, labels `bug`, `test`, `infra/io`, `coroutines`. |
| TDD red | PASS | Redisson awaitAll cancellation test failed before implementation: `Expected <false> to be <true>`. |
| Implementation | PASS | Shared `CompletionStage.sequence` now cancels source futures when returned aggregate is cancelled. |
| Targeted tests | PASS | `./gradlew :bluetape4k-core:test --tests "io.bluetape4k.concurrent.CompletionStageSupportTest" :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.RedisFutureSupportTest" :bluetape4k-redisson:test --tests "io.bluetape4k.redis.redisson.coroutines.RFutureSupportTest" --no-build-cache` |
| Diff hygiene | PASS | `git diff --check HEAD~1..HEAD` |
| GitHub checks | PASS | CI run `28955701867`: Build, Test / Core, Test / Infra (Redis), Coverage Report, CI Status, Detect changed modules, gitleaks, Gradle wrapper all passed; unrelated module test jobs skipped by changed-module detection. Automatic Dependency Submission `submit-gradle` also passed. |
| Review artifact | PASS | `docs/review/2026-07-09-issue-804-cancel-leaf-redis-futures-review.md`, P0/P1 = 0. |
| Post-PR review | PASS | Self-review comment and formal review posted on PR #995. |
| Lessons | PASS | `docs/lessons/2026-07-09-issue-804-cancel-leaf-redis-futures.md` |
| Worktree status | PASS | Feature worktree clean after push; branch is ahead 0 / behind 0 with origin. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #995 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `376001f2d45e58fad85573e1785ef6f7a666d3bf`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
