### PR TITLE
ci: narrow CodeQL Kotlin build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
+    name: Analyze (${{ matrix.language }} / ${{ matrix.scope }})
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -17,7 +17,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [java-kotlin, python, actions]
+        include:
+          - language: actions
+            scope: workflows
+            roots: ''
+          - language: python
+            scope: python
+            roots: ''
+          - language: java-kotlin
+            scope: foundation
+            roots: bluetape4k:cache:utils
+          - language: java-kotlin
+            scope: data-io
+            roots: data:io
+          - language: java-kotlin
+            scope: infra
+            roots: infra
+          - language: java-kotlin
+            scope: frameworks
+            roots: ktor:spring-boot:virtualthread
+          # Exclude testing/testcontainers from scheduled CodeQL for now: even
+          # the single compileKotlin task stayed in Build with Gradle for more
+          # than 30 minutes under CodeQL tracing.
+          - language: java-kotlin
+            scope: testing-core
+            roots: testing/assertions:testing/junit5:testing/mock-web-server:testing/mock-webflux-server
 
     steps:
       - name: Checkout repository
@@ -43,11 +67,46 @@ jobs:
 
       - name: Build with Gradle
         if: matrix.language == 'java-kotlin'
-        # TODO(#745): Keep the re-enabled java-kotlin build compile-only;
-        # `build -x test` still schedules custom Test tasks such as k8sTest.
-        run: ./gradlew assemble --no-daemon
+        timeout-minutes: 120
+        env:
+          CODEQL_JAVA_ROOTS: ${{ matrix.roots }}
+        # Keep each CodeQL Kotlin job scoped and compiler-only. Avoid examples,
+        # demos, resources, benchmarks, archives, and distributions under
+        # CodeQL tracing.
+        run: |
+          codeql_tasks_file="$(mktemp)"
+          printf '%s\n' "$CODEQL_JAVA_ROOTS" | tr ':' '\n' | while IFS= read -r root; do
+            [ -d "$root" ] || continue
+            if [ -f "$root/build.gradle.kts" ]; then
+              printf '%s\n' "$root/build.gradle.kts"
+            else
+              find "$root" -mindepth 2 -maxdepth 2 -name build.gradle.kts -print
+            fi
+          done |
+            sed 's#/build.gradle.kts$##' |
+            grep -Ev '(^|/)([^/]*-)?demo$' |
+            while IFS= read -r module_dir; do
+              [ -d "$module_dir/src/main" ] || continue
+              base="${module_dir%%/*}"
+              name="${module_dir#*/}"
+              case "$base" in
+                bluetape4k|cache|data|infra|io|testing|utils)
+                  printf ':bluetape4k-%s:compileKotlin\n' "$name"
+                  [ -d "$module_dir/src/main/java" ] && printf ':bluetape4k-%s:compileJava\n' "$name"
+                  ;;
+                ktor|spring-boot|virtualthread)
+                  printf ':bluetape4k-%s-%s:compileKotlin\n' "$base" "$name"
+                  [ -d "$module_dir/src/main/java" ] && printf ':bluetape4k-%s-%s:compileJava\n' "$base" "$name"
+                  ;;
+              esac
+            done |
+            sort > "$codeql_tasks_file"
+
+          printf 'CodeQL Gradle tasks (%s):\n' "$(wc -l < "$codeql_tasks_file")"
+          sed 's/^/  /' "$codeql_tasks_file"
+          xargs ./gradlew --no-daemon < "$codeql_tasks_file"
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
-          category: '/language:${{ matrix.language }}'
+          category: '/language:${{ matrix.language }}/${{ matrix.scope }}'

--- a/docs/lessons/2026-07-09-codeql-java-kotlin-timeout.md
+++ b/docs/lessons/2026-07-09-codeql-java-kotlin-timeout.md
@@ -1,0 +1,31 @@
+# CodeQL Java/Kotlin Timeout
+
+## Context
+
+After re-enabling the CodeQL `java-kotlin` matrix with a workflow-local Kotlin
+`2.3.21` pin, scheduled CodeQL runs were cancelled after about six hours.
+
+## Decision
+
+Keep the repository catalog on Kotlin `2.4.0` and keep the CodeQL-only
+`2.3.21` rewrite, but narrow the manual Java/Kotlin build from full
+`assemble` to scoped generated library compiler tasks.
+
+## Outcome
+
+The workflow now asks CodeQL to trace library production source compilation in
+separate Java/Kotlin scopes instead of examples, demos, benchmarks, archive
+tasks, distribution tasks, resource processing, and aggregate assembly. Testing
+helpers are kept in a `testing-core` scope. The `bluetape4k-testcontainers`
+module is temporarily excluded because its single `compileKotlin` task stayed
+in `Build with Gradle` after about 31 minutes under CodeQL tracing; issue #999
+tracks restoring that coverage. The Gradle build step also has an explicit
+120-minute timeout so future regressions do not consume the default 360-minute
+GitHub Actions timeout.
+
+## Future Guidance
+
+For CodeQL Kotlin analysis, do not assume a successful normal Gradle build means
+the same command is appropriate under CodeQL tracing. Build only the source set
+needed for extraction, keep the workflow-local Kotlin pin isolated, and verify
+with a live CodeQL workflow dispatch.

--- a/docs/review/2026-07-09-codeql-java-kotlin-timeout-review.md
+++ b/docs/review/2026-07-09-codeql-java-kotlin-timeout-review.md
@@ -1,0 +1,57 @@
+# CodeQL Java/Kotlin Timeout Review
+
+Date: 2026-07-09
+Scope: `.github/workflows/codeql.yml`
+
+## Review Result
+
+- P0: 0
+- P1: 0
+- P2/P3: none
+
+## Evidence
+
+- CodeQL scheduled runs `28731149402`, `28771654658`, `28844864852`, and
+  `28918464140` were cancelled only on the `Analyze (java-kotlin)` matrix job.
+- Run `28918464140` completed `Analyze (actions)` and `Analyze (python)`, then
+  cancelled `Analyze (java-kotlin)` while `Build with Gradle` was running.
+- The Kotlin CodeQL pin step succeeded before the cancellation, so the failure
+  is not a missing `2.3.21` pin.
+- Local dry-run comparison shows root `classes` still includes demo and
+  benchmark modules.
+- A generated library task list targets scoped compiler tasks and excludes
+  examples, demos, resources, and benchmarks.
+- A live dispatch of the single Java/Kotlin task-list build still spent more
+  than one hour in `Build with Gradle`.
+- A live dispatch of scoped `classes` jobs completed `foundation`, `data-io`,
+  `infra`, and `frameworks` in about 11-13 minutes, but `testing` remained in
+  `Build with Gradle` after about 20 minutes.
+- The workflow now splits Java/Kotlin analysis into scoped compiler-only jobs:
+  `foundation`, `data-io`, `infra`, `frameworks`, and `testing-core`.
+- A live dispatch of the single `testing-containers` compiler task remained in
+  `Build with Gradle` after about 31 minutes, so `bluetape4k-testcontainers`
+  is temporarily excluded from scheduled CodeQL and tracked by issue #999.
+
+## Decision
+
+Generate scoped library compiler tasks for the CodeQL Java/Kotlin manual build.
+This compiles production Kotlin sources, plus Java sources where present, for
+CodeQL extraction while avoiding examples, demos, resources, benchmarks, archive
+tasks, distribution tasks, and aggregate assemble tasks that are not needed for
+library analysis.
+
+Split Java/Kotlin analysis into multiple CodeQL categories so no single
+GitHub-hosted runner traces the whole Kotlin library set in one Gradle build.
+Temporarily exclude the Testcontainers support module because it is the slowest
+observed testing scope under CodeQL tracing and prevents the scheduled CodeQL
+workflow from completing. Re-enable it through issue #999 after the module has
+a CodeQL-compatible build path.
+
+Add `timeout-minutes: 120` to the Gradle build step so future regressions fail
+well before the GitHub Actions default 360-minute job timeout.
+
+## Residual Risk
+
+GitHub-hosted CodeQL tracing can still be slower than a normal Gradle build.
+The PR must be validated by a live `CodeQL Analysis` workflow dispatch before
+merge evidence is considered complete.


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: ci: narrow CodeQL Kotlin build

Fixes the recurring scheduled CodeQL Java/Kotlin cancellation after the workflow-local Kotlin `2.3.21` pin re-enabled the `java-kotlin` matrix.

## Background

The cancelled scheduled runs were not caused by a missing Kotlin pin. The `Pin Kotlin for CodeQL extractor` step succeeded, but the `Analyze (java-kotlin)` job spent about six hours in `Build with Gradle` and was cancelled by the GitHub Actions default timeout before `Perform CodeQL Analysis` could run.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Keeps the repository catalog on Kotlin `2.4.0`.
- Keeps the CodeQL-only rewrite from Kotlin `2.4.0` to `2.3.21` for the checked-out runner copy.
- Splits Java/Kotlin CodeQL analysis into scoped categories: `foundation`, `data-io`, `infra`, `frameworks`, and `testing-core`.
- Generates scoped compiler-only Gradle tasks (`compileKotlin`, plus `compileJava` only when production Java sources exist) for each Java/Kotlin CodeQL manual build.
- Excludes examples, demos, benchmarks, BOM/non-code modules, resources, archives, distributions, and aggregate assemble/classes tasks from CodeQL tracing.
- Temporarily excludes `bluetape4k-testcontainers` from scheduled CodeQL because its isolated `compileKotlin` task stayed in `Build with Gradle` after about 31 minutes under CodeQL tracing; follow-up issue #999 tracks restoring that coverage.
- Adds `timeout-minutes: 120` to each Java/Kotlin Gradle build step so future regressions fail before the 360-minute default job timeout.
- Adds review and lesson artifacts for the CodeQL timeout decision.

## Validation

- `actionlint .github/workflows/codeql.yml`
- `rg -n -F "\\'" .github/workflows`
- Generated scoped CodeQL task dry-run: `foundation=22`, `data-io=22`, `infra=13`, `frameworks=16`, `testing-core=4`; total 77 compiler tasks; no `example`, `benchmark`, `demo`, `bom`, `processResources`, or aggregate `classes` tasks.
- Root task comparison from the first pass: `classes` had 483 tasks; `assemble` had 665 tasks.
- `git diff --check`
- `git diff --cached --check`
- `git diff --check HEAD~1..HEAD`
- Live `CodeQL Analysis` dispatch `28972091872` succeeded on commit `ddb5ea1fc`.

## Review Notes

- Run `28958675755` was intentionally cancelled after the root `classes` command was still too broad.
- Run `28960279908` was intentionally cancelled after the single 75-task Java/Kotlin build spent more than one hour in `Build with Gradle`.
- Run `28964861660` showed scoped `classes` jobs could finish for most scopes, but `testing` remained a bottleneck.
- Run `28970095586` showed `testing-core` passed in 8m39s and all non-Testcontainers scopes passed, but the isolated `testing-containers` job remained in `Build with Gradle` after about 31 minutes.
- Run `28972091872` is the final validation run and succeeded with the Testcontainers follow-up split to issue #999.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #996, head `ddb5ea1fc6ff9c4c001d3a3f4a31c7d85bf49d75`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/codeql-java-kotlin-timeout`
- Labels: `build`, `security`, `ci`
- State: `MERGED`, merge commit `060ae9b75f35939264ddf492994b4f7b3027d80c`
- CI: The cancelled scheduled runs were not caused by a missing Kotlin pin. The `Pin Kotlin for CodeQL extractor` step succeeded, but the `Analyze (java-kotlin)` job spent about six hours in `Build with Gradle` and was cancelled by the GitHub Actions default timeout before `Perform CodeQL Analysis` could run. / - Generates scoped compiler-only Gradle tasks (`compileKotlin`, plus `compileJava` only when production Java sources exist) for each Java/Kotlin CodeQL manual build. / - Excludes examples, demos, benchmarks, BOM/non-code modules, resources, archives, distributions, and aggregate assemble/classes tasks from CodeQL tracing.

## DoD Status

| Check | Status | Evidence |
|---|---:|---|
| Root cause | PASS | CodeQL run `28918464140`: `Analyze (actions)` and `Analyze (python)` succeeded; `Analyze (java-kotlin)` cancelled in `Build with Gradle` after about 6 hours. |
| Kotlin pin boundary | PASS | Repo catalog remains Kotlin `2.4.0`; CodeQL java-kotlin jobs still rewrite the checked-out catalog to `2.3.21`. |
| Workflow change | PASS | Java/Kotlin CodeQL now runs scoped compiler-only categories `foundation`, `data-io`, `infra`, `frameworks`, and `testing-core`, with `timeout-minutes: 120`. |
| Testcontainers follow-up | PASS | `bluetape4k-testcontainers` isolated compile remained in `Build with Gradle` after about 31 minutes; issue #999 tracks restoring that coverage. |
| YAML lint | PASS | `actionlint .github/workflows/codeql.yml` |
| Quote guard | PASS | `rg -n -F "\\'" .github/workflows` returned no escaped single-quote hits. |
| Gradle task generation | PASS | Scoped task counts: `22 + 22 + 13 + 16 + 4 = 77`; all included scopes generated compiler-only tasks and excluded examples/demos/benchmarks/BOM/resource/classes tasks. |
| Diff hygiene | PASS | `git diff --check`; `git diff --cached --check`; `git diff --check HEAD~1..HEAD` |
| Review artifact | PASS | `docs/review/2026-07-09-codeql-java-kotlin-timeout-review.md`, P0/P1 = 0. |
| Lessons | PASS | `docs/lessons/2026-07-09-codeql-java-kotlin-timeout.md` |
| Live CodeQL dispatch | PASS | Run `28972091872` succeeded on commit `ddb5ea1fc`: actions 55s, python 57s, testing-core 8m10s, infra 10m59s, foundation 11m28s, data-io 11m56s, frameworks 15m04s. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #996 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `060ae9b75f35939264ddf492994b4f7b3027d80c`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
