### PR TITLE
fix: report non-fatal Kafka export failures

### DIFF
--- a/docs/lessons/2026-07-09-issue-800-kafka-exporter.md
+++ b/docs/lessons/2026-07-09-issue-800-kafka-exporter.md
@@ -1,0 +1,21 @@
+# Lessons Learned — Issue #800 DefaultKafkaExporter failures (2026-07-09)
+
+## Context
+
+`DefaultKafkaExporter` reports Kafka producer send failures through an `ExportExceptionHandler`. The old synchronous failure path caught `Throwable`, reported only timeout/buffer exceptions, and silently returned `false` for other failures.
+
+## Lesson
+
+Exporter boundaries should catch non-fatal `Exception`, not `Throwable`. Fatal `Error` values must propagate, while every synchronous non-fatal send failure should use the same handler path as callback failures.
+
+## Outcome
+
+- Added regression coverage for generic synchronous `Exception` handling.
+- Added regression coverage for fatal `Error` propagation.
+- Preserved callback exception handling and timeout handling.
+
+## Verification
+
+- RED targeted test: 5 tests completed, 2 expected failures.
+- GREEN targeted test: 5 passing.
+- Module test: `:bluetape4k-kafka-logback:test`, 24 passing.

--- a/docs/review/2026-07-09-issue-800-kafka-exporter-review.md
+++ b/docs/review/2026-07-09-issue-800-kafka-exporter-review.md
@@ -1,0 +1,65 @@
+# Issue #800 Review — DefaultKafkaExporter send failure handling (2026-07-09)
+
+## Scope
+
+- Module: `infra/kafka-logback`
+- Issue: #800 `P1: Report all non-fatal DefaultKafkaExporter send failures`
+- Files:
+  - `infra/kafka-logback/src/main/kotlin/io/bluetape4k/kafka/logback/exporter/DefaultKafkaExporter.kt`
+  - `infra/kafka-logback/src/test/kotlin/io/bluetape4k/kafka/logback/exporter/DefaultKafkaExporterTest.kt`
+
+## Finding
+
+`DefaultKafkaExporter.export` caught `Throwable`, called the export exception handler only for `BufferExhaustedException` and `TimeoutException`, and returned `false` for all other synchronous send failures. This hid ordinary non-fatal producer failures and also swallowed fatal `Error` values.
+
+## Fix Review
+
+- Changed the synchronous send failure boundary from `Throwable` to `Exception`.
+- All synchronous non-fatal `Exception` failures now call `exceptionHandler.handle(event, e)` and return `false`.
+- Fatal `Error` values are no longer caught and propagate to the caller.
+- Callback exception handling remains unchanged.
+- Public KDoc now states the non-fatal `Exception` and fatal `Error` contract in English.
+
+## TDD Evidence
+
+- Baseline targeted test before changes:
+  - `repo-test-summary -- ./gradlew :bluetape4k-kafka-logback:test --tests "io.bluetape4k.kafka.logback.exporter.DefaultKafkaExporterTest"`
+  - Result: PASS, 3 passing.
+- RED after adding regression tests:
+  - Same command.
+  - Result: FAIL, 5 tests completed, 2 failed.
+  - Expected failures:
+    - Generic `IllegalStateException` did not call `exceptionHandler.handle(...)`.
+    - `OutOfMemoryError` was swallowed instead of propagated.
+- GREEN targeted test:
+  - Same command.
+  - Result: PASS, 5 passing.
+- Module verification:
+  - `repo-test-summary -- ./gradlew :bluetape4k-kafka-logback:test`
+  - Result: PASS, 24 passing.
+- Whitespace verification:
+  - `git diff --check`
+  - Result: PASS.
+- IDE diagnostics:
+  - IntelliJ diagnostics were not available in this session; the exposed LSP diagnostics transport was closed.
+  - Fallback evidence is Gradle `compileKotlin` through module test plus `git diff --check`.
+
+## Review Verdict
+
+- Local 7-tier equivalent review: PASS
+- Impact evidence: CodeGraph reports `DefaultKafkaExporter` affects the exporter, `KafkaAppender`, and kafka-logback tests; no cross-module production callers beyond the appender path require a wider API change.
+- P0/P1 findings: 0
+- P2/P3 findings: 0
+- Remaining risk: low; behavior change is limited to synchronous `Producer.send` exception handling and covered by direct regression tests.
+
+## 7-Tier Notes
+
+| Tier | Result | Evidence |
+|---|---|---|
+| Correctness/API | PASS | `DefaultKafkaExporter.kt:34-36` catches `Exception`, reports it, and returns `false`; fatal `Error` is outside the catch boundary. |
+| Stability/lifecycle | PASS | Callback exception handling remains at `DefaultKafkaExporter.kt:28-31`; synchronous and callback paths both use `exceptionHandler.handle(...)`. |
+| Tests/evidence | PASS | `DefaultKafkaExporterTest.kt:87-108` covers generic `Exception` handling and fatal `Error` propagation; targeted and module tests pass. |
+| Security | PASS | No new inputs, serialization, networking credentials, or logging of sensitive data. |
+| Performance | PASS | Handler call is only on exceptional synchronous send failure; no hot-path allocation or blocking added. |
+| Maintainability | PASS | Removes special-case imports and documents one explicit exception boundary. |
+| Docs/KDoc | PASS | Public KDoc is English and describes callback, non-fatal, and fatal behavior. |

--- a/infra/kafka-logback/src/main/kotlin/io/bluetape4k/kafka/logback/exporter/DefaultKafkaExporter.kt
+++ b/infra/kafka-logback/src/main/kotlin/io/bluetape4k/kafka/logback/exporter/DefaultKafkaExporter.kt
@@ -1,16 +1,15 @@
 package io.bluetape4k.kafka.logback.exporter
 
-import org.apache.kafka.clients.producer.BufferExhaustedException
 import org.apache.kafka.clients.producer.Producer
 import org.apache.kafka.clients.producer.ProducerRecord
-import org.apache.kafka.common.errors.TimeoutException
 
 /**
- * 기본 Kafka 전송 구현체입니다.
+ * Default Kafka exporter implementation.
  *
- * ## 동작/계약
- * - [Producer.send] 비동기 전송을 사용하고 콜백 예외를 [exceptionHandler]로 전달합니다.
- * - 즉시 발생한 [BufferExhaustedException], [TimeoutException]은 handler 호출 후 `false`를 반환합니다.
+ * ## Contract
+ * - Uses asynchronous [Producer.send] and forwards callback exceptions to [exceptionHandler].
+ * - Handles synchronous non-fatal [Exception] failures with [exceptionHandler] and returns `false`.
+ * - Does not catch [Error]; fatal errors propagate to the caller.
  *
  * ```kotlin
  * val exported = DefaultKafkaExporter().export(producer, record, event, handler)
@@ -32,10 +31,8 @@ class DefaultKafkaExporter: io.bluetape4k.kafka.logback.exporter.KafkaExporter {
                 }
             }
             return true
-        } catch (e: Throwable) {
-            if (e is BufferExhaustedException || e is TimeoutException) {
-                exceptionHandler.handle(event, e)
-            }
+        } catch (e: Exception) {
+            exceptionHandler.handle(event, e)
             false
         }
     }

--- a/infra/kafka-logback/src/test/kotlin/io/bluetape4k/kafka/logback/exporter/DefaultKafkaExporterTest.kt
+++ b/infra/kafka-logback/src/test/kotlin/io/bluetape4k/kafka/logback/exporter/DefaultKafkaExporterTest.kt
@@ -1,5 +1,7 @@
 package io.bluetape4k.kafka.logback.exporter
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.mockk.Called
 import io.mockk.clearAllMocks
@@ -80,5 +82,29 @@ class DefaultKafkaExporterTest {
         exporter.export(producer, record, "msg", exceptionHandler)
 
         verify { exceptionHandler.handle("msg", exception) }
+    }
+
+    @Test
+    fun `kafka producer에서 일반 Exception이 발생하면 exception handler 가 호출된다`() {
+        val exception = IllegalStateException("Kafka producer is closed")
+
+        every { producer.send(record, any<Callback>()) } throws exception
+
+        val exported = exporter.export(producer, record, "msg", exceptionHandler)
+
+        exported.shouldBeFalse()
+        verify { exceptionHandler.handle("msg", exception) }
+    }
+
+    @Test
+    fun `kafka producer에서 fatal Error가 발생하면 전파한다`() {
+        val error = OutOfMemoryError("fatal")
+
+        every { producer.send(record, any<Callback>()) } throws error
+
+        assertFailsWith<OutOfMemoryError> {
+            exporter.export(producer, record, "msg", exceptionHandler)
+        }
+        verify { exceptionHandler wasNot Called }
     }
 }


### PR DESCRIPTION
## Summary

Closes #800

- PR 제목: fix: report non-fatal Kafka export failures

### 원문 선행 내용

Fixes #800

## Background

`DefaultKafkaExporter` caught `Throwable` for synchronous `producer.send(...)` failures but only reported `BufferExhaustedException` and `TimeoutException` through the configured `ExportExceptionHandler`. Other non-fatal producer failures returned `false` silently, and fatal `Error` values were swallowed.

## What This Solves

- Reports every synchronous non-fatal `Exception` from `Producer.send` to `exceptionHandler.handle(event, e)`.
- Preserves existing callback exception handling.
- Lets fatal `Error` values propagate instead of catching them.
- Documents the exporter exception boundary in public KDoc.

## Work Done

- Changed `DefaultKafkaExporter.export` to catch `Exception` instead of `Throwable`.
- Removed timeout/buffer-only special casing from the synchronous failure path.
- Added regression coverage for generic producer send failures.
- Added regression coverage for fatal `Error` propagation.
- Added review and lessons artifacts for the issue.

### 기존 섹션: Validation And Review Notes

- Baseline targeted test before changes: `DefaultKafkaExporterTest`, 3 passing.
- RED targeted test after adding regression tests: 5 tests completed, 2 expected failures.
- GREEN targeted test: `DefaultKafkaExporterTest`, 5 passing.
- Module test: `:bluetape4k-kafka-logback:test`, 24 passing.
- Whitespace: `git diff --check`, PASS.
- Review artifact: `docs/review/2026-07-09-issue-800-kafka-exporter-review.md`, P0/P1 = 0.
- Lessons artifact: `docs/lessons/2026-07-09-issue-800-kafka-exporter.md`.
- IDE diagnostics: unavailable in this session; exposed LSP diagnostics transport was closed. Gradle compile/test was used as fallback.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #800, milestone `1.12.0`, assignee `debop`
- PR: #998, head `40318547bbdee75e2b92909bef8de9ded5f3385f`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-800-kafka-exporter-failures`
- Labels: `bug`, `test`, `infra/io`
- State: `MERGED`, merge commit `f5d0512f1b91de6e9300c7a45ccfd665996b21d1`
- CI: - Removed timeout/buffer-only special casing from the synchronous failure path. / - IDE diagnostics: unavailable in this session; exposed LSP diagnostics transport was closed. Gradle compile/test was used as fallback. / | Step 8 - CI Gate | PASS | GitHub checks PASS: Build, Test / Telemetry Infra, Coverage Report, CI Status, Secret Scan, Validate Gradle Wrapper, submit-gradle; unrelated module lanes SKIPPED. |

## DoD Status

| Step | Status | Evidence |
|---|---|---|
| Step 1 - Review | PASS | Issue #800 live metadata verified; CodeGraph impact checked for `DefaultKafkaExporter`; local 7-tier equivalent review P0/P1 = 0. |
| Step 2 - Issue | PASS | Fixes #800; assignee `debop`, milestone `1.12.0`, labels `bug`, `test`, `infra/io`. |
| Step 3 - Fix | PASS | Commit `40318547b` changes synchronous catch boundary to `Exception` and reports all non-fatal send failures. |
| Step 4 - Test | PASS | Targeted RED: 5 tests, 2 expected failures; targeted GREEN: 5 passing; module test: 24 passing. |
| Step 5 - Lessons | PASS | `docs/lessons/2026-07-09-issue-800-kafka-exporter.md`. |
| Step 6 - PR | PASS | PR metadata mirrors issue metadata. |
| Step 7 - Review | PASS | `docs/review/2026-07-09-issue-800-kafka-exporter-review.md`, P0/P1 = 0. |
| Step 8 - CI Gate | PASS | GitHub checks PASS: Build, Test / Telemetry Infra, Coverage Report, CI Status, Secret Scan, Validate Gradle Wrapper, submit-gradle; unrelated module lanes SKIPPED. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #998 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `f5d0512f1b91de6e9300c7a45ccfd665996b21d1`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
