### PR TITLE
fix: align Kafka4 test runtime with catalog

### DIFF
--- a/docs/lessons/2026-07-09-issue-1000-kafka4-catalog-regression.md
+++ b/docs/lessons/2026-07-09-issue-1000-kafka4-catalog-regression.md
@@ -1,0 +1,17 @@
+# Lessons Learned - Issue 1000 Kafka4 Catalog Regression (2026-07-09)
+
+## Context
+
+Nightly(full) run `28964461250` failed in `Test / Infra (kafka-resilience)` after the catalog set `kafka4` back to `4.3.1`.
+
+## Decision
+
+Materialize the source-of-truth `kafka4 = "4.2.1"` compatibility line in `bluetape4k-projects` until Spring Kafka 4.1 embedded-test support is compatible with Kafka 4.3.x.
+
+## Outcome
+
+The failing local equivalent passed after aligning Kafka runtime artifacts to `4.2.1`.
+
+## Future Guard
+
+When `kafka4` changes, check both dependency insight and `:bluetape4k-kafka4:test`. A green dependency sync alone is not sufficient because the failure is an embedded-test ABI mismatch.

--- a/docs/review/2026-07-09-issue-1000-kafka4-compat-review.md
+++ b/docs/review/2026-07-09-issue-1000-kafka4-compat-review.md
@@ -1,0 +1,20 @@
+# Review - Issue 1000 Kafka4 Compatibility
+
+## Scope
+
+- `gradle/libs.versions.toml`
+
+## Findings
+
+- P0: none.
+- P1: none.
+
+## Evidence
+
+- `gh issue view 1000`: issue is open, assigned to `debop`, milestone `1.12.0`, labels include `bug`, `test`, and `dependencies`.
+- `./gradlew :bluetape4k-kafka4:dependencyInsight --configuration testRuntimeClasspath --dependency org.apache.kafka:kafka-clients --no-daemon --no-configuration-cache --no-build-cache`: PASS, selected `org.apache.kafka:kafka-clients:4.2.1`.
+- `./gradlew :bluetape4k-kafka:test :bluetape4k-kafka4:test :bluetape4k-resilience4j:test :bluetape4k-bucket4j:test --max-workers=1 --no-daemon --no-configuration-cache --no-build-cache`: PASS, `BUILD SUCCESSFUL in 2m 51s`.
+
+## Verdict
+
+Approved for PR. The previous `KafkaClusterTestKit.clientProperties()` failure path is covered by the passing `:bluetape4k-kafka4:test` run.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -110,7 +110,7 @@ elasticsearch = "9.4.0"  # https://mvnrepository.com/artifact/org.elasticsearch.
 elasticsearch-java = "9.4.0"  # https://mvnrepository.com/artifact/co.elastic.clients/elasticsearch-java
 
 kafka3 = "3.9.2"  # https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients; Server-side: spring-kafka 3.x embedded test (EmbeddedKafkaKraftBroker)
-kafka4 = "4.3.1"  # https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients; Spring Kafka 4.1 embedded-test ABI
+kafka4 = "4.2.1"  # https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients; Spring Kafka 4.1 embedded-test ABI
 spring-kafka = "3.3.16"  # https://mvnrepository.com/artifact/org.springframework.kafka/spring-kafka
 spring-kafka4 = "4.1.0"  # https://mvnrepository.com/artifact/org.springframework.kafka/spring-kafka
 


### PR DESCRIPTION
## Summary

Closes #1000

- PR 제목: fix: align Kafka4 test runtime with catalog

Fixes #1000.

Align the local `kafka4` catalog alias with the shared compatibility line so the `kafka-resilience` Nightly(full) group can run Spring Kafka embedded KRaft tests.

## Background

Nightly(full) run `28964461250` failed in `Test / Infra (kafka-resilience)` after `kafka4` was restored to `4.3.1`. The failing test XMLs all converged on `NoSuchMethodError: KafkaClusterTestKit.clientProperties()`, which is the Spring Kafka 4.1 embedded-test ABI boundary already seen in PR #933 and issue #936.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Set `kafka4 = "4.2.1"` in `gradle/libs.versions.toml`.
- Kept the line comment tied to the Spring Kafka 4.1 embedded-test ABI reason.
- Added lesson and review evidence for the regression.

## Validation

- `./gradlew :bluetape4k-kafka4:dependencyInsight --configuration testRuntimeClasspath --dependency org.apache.kafka:kafka-clients --no-daemon --no-configuration-cache --no-build-cache`
- `./gradlew :bluetape4k-kafka:test :bluetape4k-kafka4:test :bluetape4k-resilience4j:test :bluetape4k-bucket4j:test --max-workers=1 --no-daemon --no-configuration-cache --no-build-cache`
- `git diff --check`
- GitHub PR CI: all checks passed.

## Review Notes

P0/P1 findings: 0.

## Metadata

- Issue: #1000, milestone `1.12.0`, assignee `debop`
- PR: #1002, head `d01803521879307b99669c01063dc464dc8758f5`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1000-kafka4-compat`
- Labels: `bug`, `test`, `dependencies`
- State: `MERGED`, merge commit `d08407c3211093acb2d03a8a6096eff8b0d5b820`
- CI: - Set `kafka4 = "4.2.1"` in `gradle/libs.versions.toml`. / - `./gradlew :bluetape4k-kafka4:dependencyInsight --configuration testRuntimeClasspath --dependency org.apache.kafka:kafka-clients --no-daemon --no-configuration-cache --no-build-cache` / - `./gradlew :bluetape4k-kafka:test :bluetape4k-kafka4:test :bluetape4k-resilience4j:test :bluetape4k-bucket4j:test --max-workers=1 --no-daemon --no-configuration-cache --no-build-cache`

## DoD Status

| Step | Status | Evidence |
|---|---|---|
| Issue | PASS | Fixes #1000; issue assigned to `debop`, milestone `1.12.0`, labels include `bug`, `test`, `dependencies` |
| Root cause | PASS | Nightly `28964461250`, `KafkaClusterTestKit.clientProperties()` `NoSuchMethodError` with `kafka4=4.3.1` |
| Fix | PASS | `gradle/libs.versions.toml` sets `kafka4 = "4.2.1"` |
| Dependency proof | PASS | dependencyInsight selected `org.apache.kafka:kafka-clients:4.2.1` |
| Test | PASS | kafka-resilience local equivalent: `BUILD SUCCESSFUL in 2m 51s` |
| Review | PASS | `docs/review/2026-07-09-issue-1000-kafka4-compat-review.md`, P0/P1=0 |
| Lessons | PASS | `docs/lessons/2026-07-09-issue-1000-kafka4-catalog-regression.md` |
| CI | PASS | GitHub PR checks passed; merge state `CLEAN` |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1002 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `d08407c3211093acb2d03a8a6096eff8b0d5b820`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
