### PR TITLE
fix: keep Pulsar cleanup non-cancellable

### DIFF
--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/PulsarClientSupport.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/PulsarClientSupport.kt
@@ -1,8 +1,6 @@
 package io.bluetape4k.pulsar
 
-import io.bluetape4k.coroutines.support.awaitSuspending
 import io.bluetape4k.logging.KotlinLogging
-import io.bluetape4k.logging.warn
 import org.apache.pulsar.client.api.ClientBuilder
 import org.apache.pulsar.client.api.PulsarClient
 
@@ -67,8 +65,7 @@ suspend inline fun <T> withPulsarClient(
     try {
         return block(client)
     } finally {
-        runCatching { client.closeAsync().awaitSuspending() }
-            .onFailure { log.warn(it) { "PulsarClient close 실패" } }
+        closeAsyncNonCancellable("PulsarClient") { client.closeAsync() }
     }
 }
 

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/PulsarCloseSupport.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/PulsarCloseSupport.kt
@@ -1,0 +1,24 @@
+package io.bluetape4k.pulsar
+
+import io.bluetape4k.coroutines.support.awaitSuspending
+import io.bluetape4k.logging.warn
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+import java.util.concurrent.CompletableFuture
+import kotlin.coroutines.cancellation.CancellationException
+
+@PublishedApi
+internal suspend fun closeAsyncNonCancellable(
+    resourceName: String,
+    closeAsync: () -> CompletableFuture<Void>,
+) {
+    withContext(NonCancellable) {
+        try {
+            closeAsync().awaitSuspending()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "$resourceName close 실패" }
+        }
+    }
+}

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/consumer/ConsumerSupport.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/consumer/ConsumerSupport.kt
@@ -1,15 +1,10 @@
 package io.bluetape4k.pulsar.consumer
 
-import io.bluetape4k.coroutines.support.awaitSuspending
-import io.bluetape4k.logging.KotlinLogging
-import io.bluetape4k.logging.warn
+import io.bluetape4k.pulsar.closeAsyncNonCancellable
 import org.apache.pulsar.client.api.Consumer
 import org.apache.pulsar.client.api.ConsumerBuilder
 import org.apache.pulsar.client.api.PulsarClient
 import org.apache.pulsar.client.api.Schema
-
-@PublishedApi
-internal val log = KotlinLogging.logger {}
 
 /**
  * [Consumer] DSL 빌더 ([PulsarClient] 확장).
@@ -59,7 +54,6 @@ suspend inline fun <T, R> PulsarClient.withConsumer(
     try {
         return block(consumer)
     } finally {
-        runCatching { consumer.closeAsync().awaitSuspending() }
-            .onFailure { log.warn(it) { "Consumer close 실패" } }
+        closeAsyncNonCancellable("Consumer") { consumer.closeAsync() }
     }
 }

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/producer/ProducerSupport.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/producer/ProducerSupport.kt
@@ -1,15 +1,10 @@
 package io.bluetape4k.pulsar.producer
 
-import io.bluetape4k.coroutines.support.awaitSuspending
-import io.bluetape4k.logging.KotlinLogging
-import io.bluetape4k.logging.warn
+import io.bluetape4k.pulsar.closeAsyncNonCancellable
 import org.apache.pulsar.client.api.Producer
 import org.apache.pulsar.client.api.ProducerBuilder
 import org.apache.pulsar.client.api.PulsarClient
 import org.apache.pulsar.client.api.Schema
-
-@PublishedApi
-internal val log = KotlinLogging.logger {}
 
 /**
  * [Producer] DSL 빌더 ([PulsarClient] 확장).
@@ -56,7 +51,6 @@ suspend inline fun <T, R> PulsarClient.withProducer(
     try {
         return block(producer)
     } finally {
-        runCatching { producer.closeAsync().awaitSuspending() }
-            .onFailure { log.warn(it) { "Producer close 실패" } }
+        closeAsyncNonCancellable("Producer") { producer.closeAsync() }
     }
 }

--- a/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/reader/ReaderSupport.kt
+++ b/infra/pulsar/src/main/kotlin/io/bluetape4k/pulsar/reader/ReaderSupport.kt
@@ -1,15 +1,10 @@
 package io.bluetape4k.pulsar.reader
 
-import io.bluetape4k.coroutines.support.awaitSuspending
-import io.bluetape4k.logging.KotlinLogging
-import io.bluetape4k.logging.warn
+import io.bluetape4k.pulsar.closeAsyncNonCancellable
 import org.apache.pulsar.client.api.PulsarClient
 import org.apache.pulsar.client.api.Reader
 import org.apache.pulsar.client.api.ReaderBuilder
 import org.apache.pulsar.client.api.Schema
-
-@PublishedApi
-internal val log = KotlinLogging.logger {}
 
 /**
  * [Reader] DSL 빌더 ([PulsarClient] 확장).
@@ -60,7 +55,6 @@ suspend inline fun <T, R> PulsarClient.withReader(
     try {
         return block(reader)
     } finally {
-        runCatching { reader.closeAsync().awaitSuspending() }
-            .onFailure { log.warn(it) { "Reader close 실패" } }
+        closeAsyncNonCancellable("Reader") { reader.closeAsync() }
     }
 }

--- a/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/PulsarCleanupCancellationTestSupport.kt
+++ b/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/PulsarCleanupCancellationTestSupport.kt
@@ -1,0 +1,32 @@
+package io.bluetape4k.pulsar
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import java.util.concurrent.CompletableFuture
+
+internal suspend fun TestScope.assertCleanupWaitsAfterCancellation(
+    closeFuture: CompletableFuture<Void>,
+    block: suspend (CompletableDeferred<Unit>) -> Unit,
+) {
+    val entered = CompletableDeferred<Unit>()
+    val job = launch {
+        block(entered)
+    }
+
+    entered.await()
+    job.cancel()
+    runCurrent()
+
+    try {
+        job.isCompleted shouldBeEqualTo false
+    } finally {
+        closeFuture.complete(null)
+    }
+
+    job.join()
+    job.isCompleted shouldBeEqualTo true
+}

--- a/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/PulsarClientSupportTest.kt
+++ b/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/PulsarClientSupportTest.kt
@@ -3,9 +3,18 @@ package io.bluetape4k.pulsar
 import io.bluetape4k.logging.KLogging
 import kotlinx.coroutines.test.runTest
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.awaitCancellation
+import org.apache.pulsar.client.api.ClientBuilder
+import org.apache.pulsar.client.api.PulsarClient
 import org.apache.pulsar.client.api.Schema
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.CompletableFuture
 import kotlin.time.Duration.Companion.seconds
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -49,6 +58,32 @@ class PulsarClientSupportTest : AbstractPulsarTest() {
             val producer = newProducer(Schema.STRING).topic(newTopic()).create()
             producer.shouldNotBeNull()
             producer.close()
+        }
+    }
+
+    @Test
+    fun `withPulsarClient - 취소되어도 closeAsync 완료를 기다린다`() = runTest {
+        val builder = mockk<ClientBuilder>()
+        val client = mockk<PulsarClient>()
+        val closeFuture = CompletableFuture<Void>()
+
+        mockkStatic(PulsarClient::class)
+        try {
+            every { PulsarClient.builder() } returns builder
+            every { builder.serviceUrl(any()) } returns builder
+            every { builder.build() } returns client
+            every { client.closeAsync() } returns closeFuture
+
+            assertCleanupWaitsAfterCancellation(closeFuture) { entered ->
+                withPulsarClient("pulsar://localhost:6650") {
+                    entered.complete(Unit)
+                    awaitCancellation()
+                }
+            }
+
+            verify(exactly = 1) { client.closeAsync() }
+        } finally {
+            unmockkStatic(PulsarClient::class)
         }
     }
 }

--- a/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/consumer/ConsumerSupportTest.kt
+++ b/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/consumer/ConsumerSupportTest.kt
@@ -2,15 +2,24 @@ package io.bluetape4k.pulsar.consumer
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.pulsar.AbstractPulsarTest
+import io.bluetape4k.pulsar.assertCleanupWaitsAfterCancellation
 import io.bluetape4k.pulsar.producer.sendSuspend
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
+import org.apache.pulsar.client.api.Consumer
+import org.apache.pulsar.client.api.ConsumerBuilder
+import org.apache.pulsar.client.api.PulsarClient
 import org.apache.pulsar.client.api.Schema
 import org.apache.pulsar.client.api.SubscriptionType
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.CompletableFuture
 import kotlin.time.Duration.Companion.seconds
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -87,5 +96,26 @@ class ConsumerSupportTest : AbstractPulsarTest() {
         client.close()
 
         received.forEachIndexed { i, v -> v shouldBeEqualTo "msg-$i" }
+    }
+
+    @Test
+    fun `withConsumer - 취소되어도 closeAsync 완료를 기다린다`() = runTest {
+        val client = mockk<PulsarClient>()
+        val builder = mockk<ConsumerBuilder<String>>()
+        val consumer = mockk<Consumer<String>>()
+        val closeFuture = CompletableFuture<Void>()
+
+        every { client.newConsumer(Schema.STRING) } returns builder
+        every { builder.subscribe() } returns consumer
+        every { consumer.closeAsync() } returns closeFuture
+
+        assertCleanupWaitsAfterCancellation(closeFuture) { entered ->
+            client.withConsumer(Schema.STRING) {
+                entered.complete(Unit)
+                awaitCancellation()
+            }
+        }
+
+        verify(exactly = 1) { consumer.closeAsync() }
     }
 }

--- a/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/producer/ProducerSupportTest.kt
+++ b/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/producer/ProducerSupportTest.kt
@@ -2,15 +2,24 @@ package io.bluetape4k.pulsar.producer
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.pulsar.AbstractPulsarTest
+import io.bluetape4k.pulsar.assertCleanupWaitsAfterCancellation
 import io.bluetape4k.pulsar.consumer.receiveSuspend
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.test.runTest
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.apache.pulsar.client.api.CompressionType
+import org.apache.pulsar.client.api.Producer
+import org.apache.pulsar.client.api.ProducerBuilder
+import org.apache.pulsar.client.api.PulsarClient
 import org.apache.pulsar.client.api.Schema
 import org.apache.pulsar.client.api.SubscriptionType
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.CompletableFuture
 import kotlin.time.Duration.Companion.seconds
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -81,5 +90,26 @@ class ProducerSupportTest : AbstractPulsarTest() {
             consumer.close()
             client.close()
         }
+    }
+
+    @Test
+    fun `withProducer - 취소되어도 closeAsync 완료를 기다린다`() = runTest {
+        val client = mockk<PulsarClient>()
+        val builder = mockk<ProducerBuilder<String>>()
+        val producer = mockk<Producer<String>>()
+        val closeFuture = CompletableFuture<Void>()
+
+        every { client.newProducer(Schema.STRING) } returns builder
+        every { builder.create() } returns producer
+        every { producer.closeAsync() } returns closeFuture
+
+        assertCleanupWaitsAfterCancellation(closeFuture) { entered ->
+            client.withProducer(Schema.STRING) {
+                entered.complete(Unit)
+                awaitCancellation()
+            }
+        }
+
+        verify(exactly = 1) { producer.closeAsync() }
     }
 }

--- a/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/reader/ReaderSupportTest.kt
+++ b/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/reader/ReaderSupportTest.kt
@@ -2,14 +2,23 @@ package io.bluetape4k.pulsar.reader
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.pulsar.AbstractPulsarTest
+import io.bluetape4k.pulsar.assertCleanupWaitsAfterCancellation
 import io.bluetape4k.pulsar.producer.sendSuspend
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.test.runTest
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.apache.pulsar.client.api.MessageId
+import org.apache.pulsar.client.api.PulsarClient
+import org.apache.pulsar.client.api.Reader
+import org.apache.pulsar.client.api.ReaderBuilder
 import org.apache.pulsar.client.api.Schema
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.CompletableFuture
 import kotlin.time.Duration.Companion.seconds
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -55,6 +64,27 @@ class ReaderSupportTest : AbstractPulsarTest() {
             msg.value shouldBeEqualTo "withReader test"
         }
         client.close()
+    }
+
+    @Test
+    fun `withReader - 취소되어도 closeAsync 완료를 기다린다`() = runTest {
+        val client = mockk<PulsarClient>()
+        val builder = mockk<ReaderBuilder<String>>()
+        val reader = mockk<Reader<String>>()
+        val closeFuture = CompletableFuture<Void>()
+
+        every { client.newReader(Schema.STRING) } returns builder
+        every { builder.create() } returns reader
+        every { reader.closeAsync() } returns closeFuture
+
+        assertCleanupWaitsAfterCancellation(closeFuture) { entered ->
+            client.withReader(Schema.STRING) {
+                entered.complete(Unit)
+                awaitCancellation()
+            }
+        }
+
+        verify(exactly = 1) { reader.closeAsync() }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #801

- PR 제목: fix: keep Pulsar cleanup non-cancellable

- Add a shared Pulsar async close helper that waits in `NonCancellable`.
- Use it from `withPulsarClient`, `withProducer`, `withConsumer`, and `withReader`.
- Add deterministic cancellation regression tests for each helper using controlled `CompletableFuture` close completion.

Closes #801

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Risk

- Narrow infra/pulsar lifecycle cleanup change.
- Close failures other than cancellation are still logged and swallowed, while close cancellation is propagated.

## Validation

- `repo-test-summary -- ./gradlew :bluetape4k-pulsar:test --tests "io.bluetape4k.pulsar.*취소되어도*"`
- `repo-test-summary -- ./gradlew :bluetape4k-pulsar:test --tests "io.bluetape4k.pulsar.*SupportTest"`
- `repo-test-summary -- ./gradlew :bluetape4k-pulsar:test`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #801, milestone `1.12.0`, assignee `debop`
- PR: #1003, head `ed02e301f0cfdd3d8a6ecd2a1a3176d74babf43b`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-801-pulsar-noncancellable-cleanup`
- Labels: `bug`, `test`, `infra/io`, `coroutines`
- State: `MERGED`, merge commit `9bc169ec4aab24d50d600221b4d55d83ffee325c`
- CI: - `repo-test-summary -- ./gradlew :bluetape4k-pulsar:test --tests "io.bluetape4k.pulsar.*취소되어도*"` / - `repo-test-summary -- ./gradlew :bluetape4k-pulsar:test --tests "io.bluetape4k.pulsar.*SupportTest"` / - `repo-test-summary -- ./gradlew :bluetape4k-pulsar:test`

## DoD Status

- [x] Issue #801 cancellation cleanup contract covered by RED/GREEN regression tests.
- [x] Pulsar `with*` cleanup waits for async close completion under caller cancellation.
- [x] Targeted support tests and full `:bluetape4k-pulsar:test` passed locally.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1003 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9bc169ec4aab24d50d600221b4d55d83ffee325c`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
