### PR TITLE
fix: manage default Vertx lifecycle

### DIFF
--- a/docs/lessons/2026-07-09-issue-796-current-vertx-lifecycle.md
+++ b/docs/lessons/2026-07-09-issue-796-current-vertx-lifecycle.md
@@ -1,0 +1,23 @@
+# Lessons Learned - currentVertx Lifecycle (2026-07-09)
+
+**Related issue**: #796
+**Affected modules**: `bluetape4k-vertx`, `bluetape4k-http`
+
+## L1: Context fallback helpers must define ownership
+
+### Problem
+
+`currentVertx()` created a new `Vertx.vertx()` instance whenever no Vert.x context existed. Helpers such as
+`vertxHttpClientOf()` inherited that hidden ownership and could leave event-loop resources unmanaged.
+
+### Lesson
+
+Fallback resource creation must either require an explicit owner or use a managed singleton with a documented close path.
+For Vert.x helpers, prefer explicit `Vertx` parameters in lifecycle-sensitive APIs and keep default fallbacks reusable and
+closable.
+
+### Verification
+
+- RED: lifecycle tests failed before `closeDefaultVertx`, explicit `Vertx` overload, and default client close API existed.
+- GREEN: `:bluetape4k-vertx:test`
+- GREEN: `:bluetape4k-http:test`

--- a/io/http/README.ko.md
+++ b/io/http/README.ko.md
@@ -220,13 +220,26 @@ Eclipse Vert.x의 비동기 HttpClient를 Kotlin Coroutines와 통합합니다.
 
 ```kotlin
 import io.bluetape4k.http.vertx.*
+import io.vertx.core.Vertx
 import io.vertx.kotlin.core.http.httpClientOptionsOf
 
+val vertx = Vertx.vertx()
 val options = httpClientOptionsOf(
     maxPoolSize = 20,
     keepAlive = true,
 )
-val vertxClient = vertxHttpClientOf(options)
+val vertxClient = vertxHttpClientOf(vertx, options)
+```
+
+`defaultVertxHttpClient`는 `bluetape4k-vertx`의 관리되는 기본 Vert.x 인스턴스를 사용합니다. 애플리케이션 종료
+또는 테스트 정리 시에는 기본 Vert.x를 닫기 전에 관리되는 기본 클라이언트를 닫으세요.
+
+```kotlin
+import io.bluetape4k.http.vertx.closeDefaultVertxHttpClient
+import io.bluetape4k.vertx.closeDefaultVertx
+
+closeDefaultVertxHttpClient()
+closeDefaultVertx()
 ```
 
 ### 4. Ktor Client

--- a/io/http/README.md
+++ b/io/http/README.md
@@ -221,13 +221,26 @@ Integrates Eclipse Vert.x's async HttpClient with Kotlin Coroutines.
 
 ```kotlin
 import io.bluetape4k.http.vertx.*
+import io.vertx.core.Vertx
 import io.vertx.kotlin.core.http.httpClientOptionsOf
 
+val vertx = Vertx.vertx()
 val options = httpClientOptionsOf(
     maxPoolSize = 20,
     keepAlive = true,
 )
-val vertxClient = vertxHttpClientOf(options)
+val vertxClient = vertxHttpClientOf(vertx, options)
+```
+
+The `defaultVertxHttpClient` uses the managed default Vert.x instance from `bluetape4k-vertx`. Close the managed client
+before closing the default Vert.x instance during application shutdown or test cleanup.
+
+```kotlin
+import io.bluetape4k.http.vertx.closeDefaultVertxHttpClient
+import io.bluetape4k.vertx.closeDefaultVertx
+
+closeDefaultVertxHttpClient()
+closeDefaultVertx()
 ```
 
 ### 4. Ktor Client

--- a/io/http/src/main/kotlin/io/bluetape4k/http/vertx/VertxHttpClientSupport.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/vertx/VertxHttpClientSupport.kt
@@ -1,15 +1,24 @@
 package io.bluetape4k.http.vertx
 
+import io.bluetape4k.vertx.defaultVertx
 import io.bluetape4k.vertx.currentVertx
+import io.vertx.core.Future
+import io.vertx.core.Vertx
 import io.vertx.core.http.HttpClient
 import io.vertx.core.http.HttpClientOptions
 import io.vertx.kotlin.core.http.httpClientOptionsOf
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+private val defaultVertxHttpClientLock = ReentrantLock()
+@Volatile
+private var defaultVertxHttpClientRef: HttpClient? = null
 
 /**
- * 기본 Vert.x [HttpClientOptions] 입니다.
+ * Default Vert.x [HttpClientOptions].
  *
- * 보안 참고: `trustAll = false`(기본값)로 설정되어 있어 TLS 인증서 검증이 활성화됩니다.
- * 테스트 환경에서 자체 서명 인증서를 사용하는 경우 `trustAll = true`로 별도 설정하세요.
+ * Security note: `trustAll = false` keeps TLS certificate verification enabled.
+ * Use custom options with `trustAll = true` only for controlled test environments.
  */
 @JvmField
 val defaultVertxHttpClientOptions: HttpClientOptions = httpClientOptionsOf(
@@ -21,19 +30,39 @@ val defaultVertxHttpClientOptions: HttpClientOptions = httpClientOptionsOf(
 )
 
 /**
- * 기본 Vert.x [HttpClient] 입니다.
+ * Managed default Vert.x [HttpClient].
+ *
+ * ## Behaviour / Contract
+ * - The client is created lazily from `bluetape4k-vertx`'s managed [defaultVertx].
+ * - The client is reused across calls to this property.
+ * - Call [closeDefaultVertxHttpClient] before closing the managed default Vert.x during shutdown.
  *
  * ```kotlin
  * val client = defaultVertxHttpClient
- * // keep-alive, ALPN, TLS 인증서 검증이 활성화된 기본 클라이언트
+ * // Reused managed client with keep-alive, ALPN, and TLS verification enabled.
  * ```
  */
-val defaultVertxHttpClient: HttpClient by lazy {
-    vertxHttpClientOf(defaultVertxHttpClientOptions)
+val defaultVertxHttpClient: HttpClient
+    get() = defaultVertxHttpClientLock.withLock {
+        defaultVertxHttpClientRef ?: vertxHttpClientOf(defaultVertx(), defaultVertxHttpClientOptions)
+            .also { defaultVertxHttpClientRef = it }
+    }
+
+/**
+ * Closes and clears the managed default Vert.x [HttpClient], if it was created.
+ */
+fun closeDefaultVertxHttpClient(): Future<Void> {
+    val client = defaultVertxHttpClientLock.withLock {
+        defaultVertxHttpClientRef.also { defaultVertxHttpClientRef = null }
+    }
+
+    return client?.close() ?: Future.succeededFuture()
 }
 
 /**
- * 주어진 [options]으로 새 Vert.x [HttpClient]를 생성합니다.
+ * Creates a Vert.x [HttpClient] from the current Vert.x context owner or managed default Vert.x.
+ *
+ * For lifecycle-sensitive code, prefer [vertxHttpClientOf] with an explicit [Vertx] owner.
  *
  * ```kotlin
  * val options = httpClientOptionsOf(
@@ -48,5 +77,17 @@ val defaultVertxHttpClient: HttpClient by lazy {
  * @return [HttpClient]
  */
 fun vertxHttpClientOf(options: HttpClientOptions = defaultVertxHttpClientOptions): HttpClient {
-    return currentVertx().createHttpClient(options)
+    return vertxHttpClientOf(currentVertx(), options)
+}
+
+/**
+ * Creates a Vert.x [HttpClient] owned by the supplied [vertx] instance.
+ *
+ * Use this overload when the caller owns the Vert.x lifecycle explicitly.
+ */
+fun vertxHttpClientOf(
+    vertx: Vertx,
+    options: HttpClientOptions = defaultVertxHttpClientOptions,
+): HttpClient {
+    return vertx.createHttpClient(options)
 }

--- a/io/http/src/test/kotlin/io/bluetape4k/http/vertx/VertxHttpClientSupportTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/vertx/VertxHttpClientSupportTest.kt
@@ -1,0 +1,60 @@
+package io.bluetape4k.http.vertx
+
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldNotBeSameInstanceAs
+import io.bluetape4k.http.AbstractHttpTest
+import io.bluetape4k.vertx.asCompletableFuture
+import io.bluetape4k.vertx.closeDefaultVertx
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.vertx.core.Vertx
+import io.vertx.core.http.HttpClientAgent
+import io.vertx.core.http.HttpClientOptions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
+
+class VertxHttpClientSupportTest : AbstractHttpTest() {
+
+    private val vertx = mockk<Vertx>()
+    private val client = mockk<HttpClientAgent>()
+
+    @BeforeEach
+    fun beforeEach() {
+        clearMocks(vertx, client)
+    }
+
+    @AfterEach
+    fun closeManagedResources() {
+        closeDefaultVertxHttpClient().asCompletableFuture().get(5, TimeUnit.SECONDS)
+        closeDefaultVertx().asCompletableFuture().get(5, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun `vertxHttpClientOf uses explicit Vertx owner`() {
+        val options = HttpClientOptions()
+        every { vertx.createHttpClient(options) } returns client
+
+        val actual = vertxHttpClientOf(vertx, options)
+
+        actual shouldBeSameInstanceAs client
+        verify(exactly = 1) { vertx.createHttpClient(options) }
+    }
+
+    @Test
+    fun `defaultVertxHttpClient is managed until explicitly closed`() {
+        val first = defaultVertxHttpClient
+        val second = defaultVertxHttpClient
+
+        second shouldBeSameInstanceAs first
+
+        closeDefaultVertxHttpClient().asCompletableFuture().get(5, TimeUnit.SECONDS)
+
+        val recreated = defaultVertxHttpClient
+        recreated shouldNotBeSameInstanceAs first
+        recreated shouldBeSameInstanceAs defaultVertxHttpClient
+    }
+}

--- a/io/vertx/README.ko.md
+++ b/io/vertx/README.ko.md
@@ -84,6 +84,23 @@ dependencies {
 
 ## 사용 예시
 
+### 현재 및 기본 Vert.x 생명주기
+
+`currentVertx()`는 현재 Vert.x 컨텍스트가 있으면 그 owner를 반환합니다. 컨텍스트 밖에서는 호출할 때마다 숨은
+미소유 인스턴스를 만들지 않고, 관리되는 기본 Vert.x 인스턴스를 재사용합니다.
+
+```kotlin
+import io.bluetape4k.vertx.closeDefaultVertx
+import io.bluetape4k.vertx.currentVertx
+import io.bluetape4k.vertx.defaultVertx
+
+val vertx = currentVertx()
+val fallback = defaultVertx()
+
+// 애플리케이션 종료 또는 테스트 정리 시점
+closeDefaultVertx()
+```
+
 ### Verticle (Coroutines)
 
 ```kotlin

--- a/io/vertx/README.md
+++ b/io/vertx/README.md
@@ -84,6 +84,23 @@ dependencies {
 
 ## Usage Examples
 
+### Current and Default Vert.x Lifecycle
+
+`currentVertx()` returns the current Vert.x context owner when one exists. Outside a Vert.x context it reuses a managed
+default Vert.x instance instead of creating a hidden unowned instance per call.
+
+```kotlin
+import io.bluetape4k.vertx.closeDefaultVertx
+import io.bluetape4k.vertx.currentVertx
+import io.bluetape4k.vertx.defaultVertx
+
+val vertx = currentVertx()
+val fallback = defaultVertx()
+
+// Application shutdown or test cleanup
+closeDefaultVertx()
+```
+
 ### Verticle (Coroutines)
 
 ```kotlin

--- a/io/vertx/src/main/kotlin/io/bluetape4k/vertx/VertxSupport.kt
+++ b/io/vertx/src/main/kotlin/io/bluetape4k/vertx/VertxSupport.kt
@@ -1,20 +1,61 @@
 package io.bluetape4k.vertx
 
 import io.vertx.core.Vertx
+import io.vertx.core.Future
 import io.vertx.kotlin.coroutines.dispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withContext
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+private val defaultVertxLock = ReentrantLock()
+@Volatile
+private var defaultVertxRef: Vertx? = null
 
 /**
- * 현재 실행 중인 [Vertx] 인스턴스를 반환합니다.
- * 현재 컨텍스트가 없으면 새 [Vertx] 인스턴스를 생성합니다.
+ * Returns the Vert.x instance that owns the current context, or the managed default Vert.x instance.
+ *
+ * ## Behaviour / Contract
+ * - Inside a Vert.x context, returns `Vertx.currentContext().owner()`.
+ * - Outside a Vert.x context, returns [defaultVertx] instead of creating an unowned Vert.x instance.
+ * - Close the managed fallback with [closeDefaultVertx] during application shutdown or test cleanup.
  *
  * ```kotlin
  * val vertx = currentVertx()
- * // vertx != null  (기존 컨텍스트 또는 새로 생성된 인스턴스)
+ * // Uses the current context owner when present; otherwise uses the managed default Vert.x.
  * ```
  */
-fun currentVertx(): Vertx = Vertx.currentContext()?.owner() ?: Vertx.vertx()
+fun currentVertx(): Vertx = Vertx.currentContext()?.owner() ?: defaultVertx()
+
+/**
+ * Returns the process-local managed default [Vertx] instance.
+ *
+ * ## Behaviour / Contract
+ * - The instance is created lazily and reused across calls.
+ * - The lifecycle is owned by this module only when callers use this function or [currentVertx]
+ *   outside a Vert.x context.
+ * - Call [closeDefaultVertx] to close and clear the managed instance.
+ */
+fun defaultVertx(): Vertx {
+    defaultVertxRef?.let { return it }
+
+    return defaultVertxLock.withLock {
+        defaultVertxRef ?: Vertx.vertx().also { defaultVertxRef = it }
+    }
+}
+
+/**
+ * Closes the managed default [Vertx] instance, if one has been created.
+ *
+ * Returns a succeeded future when no managed default instance exists.
+ */
+fun closeDefaultVertx(): Future<Void> {
+    val vertx = defaultVertxLock.withLock {
+        defaultVertxRef.also { defaultVertxRef = null }
+    }
+
+    return vertx?.close() ?: Future.succeededFuture()
+}
 
 /**
  * 현재 [Vertx] 인스턴스의 dispatcher 내에서 [block]을 실행합니다.

--- a/io/vertx/src/test/kotlin/io/bluetape4k/vertx/VertxSupportTest.kt
+++ b/io/vertx/src/test/kotlin/io/bluetape4k/vertx/VertxSupportTest.kt
@@ -10,13 +10,22 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeSameInstanceAs
 import io.bluetape4k.assertions.shouldNotBeNull
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
 
 class VertxSupportTest : AbstractVertxTest() {
 
     companion object : KLoggingChannel()
+
+    @AfterEach
+    fun closeManagedDefaultVertx() {
+        closeDefaultVertx().asCompletableFuture().get(5, TimeUnit.SECONDS)
+    }
 
     @Test
     fun `currentVertx 는 null이 아닌 Vertx 인스턴스를 반환한다`(vertx: Vertx, testContext: VertxTestContext) =
@@ -24,6 +33,24 @@ class VertxSupportTest : AbstractVertxTest() {
             val current = currentVertx()
             current.shouldNotBeNull()
         }
+
+    @Test
+    fun `currentVertx reuses managed fallback outside Vertx context`() {
+        val first = currentVertx()
+        val second = currentVertx()
+
+        second shouldBeSameInstanceAs first
+    }
+
+    @Test
+    fun `closeDefaultVertx closes managed fallback and allows recreation`() {
+        val first = currentVertx()
+
+        closeDefaultVertx().asCompletableFuture().get(5, TimeUnit.SECONDS)
+
+        val second = currentVertx()
+        second shouldNotBeSameInstanceAs first
+    }
 
     @Test
     fun `withVertxDispatcher 는 블록을 실행하고 결과를 반환한다`(vertx: Vertx, testContext: VertxTestContext) =


### PR DESCRIPTION
## Summary

Closes #796

- PR 제목: fix: manage default Vertx lifecycle

- Make `currentVertx()` reuse a managed default Vert.x instance outside Vert.x contexts instead of creating unowned instances per call.
- Add `defaultVertx()` / `closeDefaultVertx()` and managed default Vert.x HttpClient close support.
- Add explicit `vertxHttpClientOf(vertx, options)` for caller-owned lifecycle paths.
- Document the lifecycle contract in `io/vertx` and `io/http` English/Korean READMEs.

Closes #796

## Background

`currentVertx()` previously used `Vertx.vertx()` as a hidden fallback. APIs such as `vertxHttpClientOf()` inherited that fallback, making lifecycle ownership unclear outside an active Vert.x context.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Risk

- Moderate API behavior change: context-less `currentVertx()` now returns a reusable managed fallback.
- New close APIs make fallback ownership explicit. Existing explicit Vert.x usage is unchanged.
- Concurrency tester exception: this is a deterministic lifecycle ownership contract, not a race/stress scenario.

## Validation

- RED: lifecycle tests failed before `closeDefaultVertx`, explicit `Vertx` overload, and default client close API existed.
- `repo-test-summary -- ./gradlew :bluetape4k-vertx:test --tests "io.bluetape4k.vertx.VertxSupportTest" :bluetape4k-http:test --tests "io.bluetape4k.http.vertx.VertxHttpClientSupportTest"`
- `repo-test-summary -- ./gradlew :bluetape4k-vertx:test`
- `repo-test-summary -- ./gradlew :bluetape4k-http:test`
- `git diff --check`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #796, milestone `1.12.0`, assignee `debop`
- PR: #1004, head `062c7331b24cb64d3a3727cc1b284e63ecbbe638`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-796-current-vertx-lifecycle`
- Labels: `bug`, `test`, `tech-debt`
- State: `MERGED`, merge commit `e22166ab592d265d4920e0e11e7177c51eb500a5`
- CI: - Add explicit `vertxHttpClientOf(vertx, options)` for caller-owned lifecycle paths. / - RED: lifecycle tests failed before `closeDefaultVertx`, explicit `Vertx` overload, and default client close API existed. / - `repo-test-summary -- ./gradlew :bluetape4k-vertx:test --tests "io.bluetape4k.vertx.VertxSupportTest" :bluetape4k-http:test --tests "io.bluetape4k.http.vertx.VertxHttpClientSupportTest"`

## DoD Status

| Step | Status | Evidence |
|---|---|---|
| Issue scope | PASS | #796 live issue verified: assignee `debop`, milestone `1.12.0`, labels `bug`, `test`, `tech-debt`. |
| RED test | PASS | New lifecycle tests failed before the managed fallback APIs and explicit owner overload existed. |
| Fix | PASS | `currentVertx()` now uses managed `defaultVertx()`; HTTP helper has explicit `Vertx` overload and managed default client close API. |
| Documentation | PASS | Updated `io/vertx` and `io/http` README locale pairs. |
| Lessons | PASS | Added `docs/lessons/2026-07-09-issue-796-current-vertx-lifecycle.md`. |
| Local tests | PASS | Targeted tests, `:bluetape4k-vertx:test`, `:bluetape4k-http:test`, and `git diff --check` passed. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1004 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e22166ab592d265d4920e0e11e7177c51eb500a5`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
