### PR TITLE
fix: compensate resilient near-cache retry failures

### DIFF
--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientNearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientNearJCache.kt
@@ -14,6 +14,8 @@ import io.github.resilience4j.retry.RetryConfig
 import kotlinx.atomicfu.atomic
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 import javax.cache.Cache
 
 /**
@@ -72,7 +74,12 @@ class ResilientNearJCache<K: Any, V: Any>(
     )
 
     private val retry: Retry = buildRetry()
-    private val queue = LinkedBlockingQueue<BackJCacheCommand<K, V>>(config.writeQueueCapacity)
+    private val queue = LinkedBlockingQueue<QueuedCommand<K, V>>(config.writeQueueCapacity)
+    private val writeStateLock = ReentrantLock()
+    private val pendingMutationTokens = ConcurrentHashMap<K, MutationToken<V>>()
+    private val pendingClearToken = atomic<ClearToken?>(null)
+    private val stateVersion = atomic(0L)
+    private var nextCommandSequence = 0L
 
     /**
      * write-behind로 삭제 요청된 키 집합 (tombstone).
@@ -94,10 +101,19 @@ class ResilientNearJCache<K: Any, V: Any>(
                 } else {
                     queue.take()
                 }
+                writeStateLock.withLock { }
                 try {
-                    retry.executeRunnable { applyCommand(cmd) }
+                    retry.executeRunnable { applyCommand(cmd.command) }
+                    writeStateLock.withLock {
+                        completeCommand(cmd, failed = false)
+                    }
                 } catch (e: Exception) {
-                    log.error(e) { "Back cache write failed after ${config.retryMaxAttempts} retries, dropping command: $cmd" }
+                    log.error(e) {
+                        "Back cache write failed after ${config.retryMaxAttempts} retries, compensating command: ${cmd.command}"
+                    }
+                    writeStateLock.withLock {
+                        completeCommand(cmd, failed = true)
+                    }
                 }
             } catch (e: InterruptedException) {
                 if (closed.value) {
@@ -127,18 +143,43 @@ class ResilientNearJCache<K: Any, V: Any>(
         when (cmd) {
             is BackJCacheCommand.Put       -> backCache.put(cmd.key, cmd.value)
             is BackJCacheCommand.PutAll    -> backCache.putAll(cmd.entries)
-            is BackJCacheCommand.Remove    -> {
-                backCache.remove(cmd.key)
-                tombstones.remove(cmd.key)
+            is BackJCacheCommand.Remove    -> backCache.remove(cmd.key)
+            is BackJCacheCommand.RemoveAll -> cmd.keys.forEach { backCache.remove(it) }
+            is BackJCacheCommand.ClearBack -> backCache.clear()
+        }
+    }
+
+    private fun completeCommand(queued: QueuedCommand<K, V>, failed: Boolean) {
+        when (val command = queued.command) {
+            is BackJCacheCommand.Put       -> completePut(queued, setOf(command.key), failed)
+            is BackJCacheCommand.PutAll    -> completePut(queued, command.entries.keys, failed)
+            is BackJCacheCommand.Remove    -> completeRemove(queued, setOf(command.key))
+            is BackJCacheCommand.RemoveAll -> completeRemove(queued, command.keys)
+            is BackJCacheCommand.ClearBack -> queued.clearToken?.let { token ->
+                if (pendingClearToken.compareAndSet(token, null)) {
+                    stateVersion.incrementAndGet()
+                    clearPending.value = false
+                }
             }
-            is BackJCacheCommand.RemoveAll -> {
-                cmd.keys.forEach { backCache.remove(it) }
-                tombstones.removeAll(cmd.keys)
+        }
+    }
+
+    private fun completePut(queued: QueuedCommand<K, V>, keys: Set<K>, failed: Boolean) {
+        keys.forEach { key ->
+            val token = queued.mutationTokens.getValue(key)
+            if (pendingMutationTokens.remove(key, token) && failed) {
+                stateVersion.incrementAndGet()
+                frontCache.remove(key)
             }
-            is BackJCacheCommand.ClearBack -> {
-                backCache.clear()
-                tombstones.clear()
-                clearPending.value = false
+        }
+    }
+
+    private fun completeRemove(queued: QueuedCommand<K, V>, keys: Set<K>) {
+        keys.forEach { key ->
+            val token = queued.mutationTokens.getValue(key)
+            if (pendingMutationTokens.remove(key, token)) {
+                stateVersion.incrementAndGet()
+                tombstones.remove(key)
             }
         }
     }
@@ -152,18 +193,21 @@ class ResilientNearJCache<K: Any, V: Any>(
     fun get(key: K): V? {
         key.requireNotNull("key")
 
-        if (tombstones.contains(key) || clearPending.value) return null
-        frontCache.get(key)?.let { return it }
+        val observedVersion = writeStateLock.withLock {
+            if (tombstones.contains(key) || clearPending.value) return null
+            frontCache.get(key)?.let { return it }
+            stateVersion.value
+        }
 
         return when (config.getFailureStrategy) {
             GetFailureStrategy.RETURN_FRONT_OR_NULL ->
                 runCatching { backCache.get(key) }
                     .onFailure { e -> log.warn(e) { "Back cache GET failed for key=$key, returning null" } }
                     .getOrNull()
-                    ?.also { value -> frontCache.put(key, value) }
+                    ?.also { value -> populateFrontIfUnchanged(key, value, observedVersion) }
 
             GetFailureStrategy.PROPAGATE_EXCEPTION ->
-                backCache.get(key)?.also { value -> frontCache.put(key, value) }
+                backCache.get(key)?.also { value -> populateFrontIfUnchanged(key, value, observedVersion) }
         }
     }
 
@@ -171,9 +215,15 @@ class ResilientNearJCache<K: Any, V: Any>(
      * 여러 키에 대한 값을 한 번에 조회한다.
      */
     fun getAll(keys: Set<K>): Map<K, V> {
-        if (clearPending.value) return emptyMap()
-        val result = frontCache.getAll(keys).toMutableMap()
-        val missedKeys = (keys - result.keys).filter { !tombstones.contains(it) }
+        val (result, missedKeys, observedVersion) = writeStateLock.withLock {
+            if (clearPending.value) return emptyMap()
+            val frontResult = frontCache.getAll(keys).toMutableMap()
+            Triple(
+                frontResult,
+                (keys - frontResult.keys).filter { !tombstones.contains(it) },
+                stateVersion.value,
+            )
+        }
 
         if (missedKeys.isNotEmpty()) {
             missedKeys.forEach { key ->
@@ -182,11 +232,19 @@ class ResilientNearJCache<K: Any, V: Any>(
                     .getOrNull()
                     ?.let { value ->
                         result[key] = value
-                        frontCache.put(key, value)
+                        populateFrontIfUnchanged(key, value, observedVersion)
                     }
             }
         }
         return result
+    }
+
+    private fun populateFrontIfUnchanged(key: K, value: V, observedVersion: Long) {
+        writeStateLock.withLock {
+            if (stateVersion.value == observedVersion && !tombstones.contains(key) && !clearPending.value) {
+                frontCache.put(key, value)
+            }
+        }
     }
 
     /**
@@ -196,18 +254,21 @@ class ResilientNearJCache<K: Any, V: Any>(
      */
     fun put(key: K, value: V) {
         key.requireNotNull("key")
-        enqueueWrite(BackJCacheCommand.Put(key, value), "Write queue full for Put key=$key")
-        tombstones.remove(key)
-        frontCache.put(key, value)
+        enqueueWrite(BackJCacheCommand.Put(key, value), "Write queue full for Put key=$key") {
+            tombstones.remove(key)
+            frontCache.put(key, value)
+        }
     }
 
     /**
      * 여러 키-값 쌍을 저장한다.
      */
     fun putAll(entries: Map<K, V>) {
-        enqueueWrite(BackJCacheCommand.PutAll(entries), "Write queue full for PutAll entries=${entries.size}")
-        tombstones.removeAll(entries.keys)
-        frontCache.putAll(entries)
+        val entriesSnapshot = entries.toMap()
+        enqueueWrite(BackJCacheCommand.PutAll(entriesSnapshot), "Write queue full for PutAll entries=${entries.size}") {
+            tombstones.removeAll(entriesSnapshot.keys)
+            frontCache.putAll(entriesSnapshot)
+        }
     }
 
     /**
@@ -216,16 +277,28 @@ class ResilientNearJCache<K: Any, V: Any>(
      */
     fun putIfAbsent(key: K, value: V): V? {
         key.requireNotNull("key")
+        return writeStateLock.withLock {
+            frontCache.get(key)?.let { return it }
+            val pendingMutation = pendingMutationTokens[key]
+            val pendingClear = pendingClearToken.value
+            if (pendingMutation?.value != null && (pendingClear == null || pendingMutation.sequence > pendingClear.sequence)) {
+                return pendingMutation.value
+            }
 
-        val existing = get(key)
-        if (existing != null) return existing
+            if (pendingMutation != null || pendingClear != null) {
+                enqueueWriteLocked(BackJCacheCommand.Put(key, value), "Write queue full for Put key=$key") {
+                    tombstones.remove(key)
+                    frontCache.put(key, value)
+                }
+                return null
+            }
 
-        val prev = backCache.getAndPut(key, value)
-        return if (prev == null) {
-            frontCache.put(key, value)
-            null
-        } else {
-            prev
+            backCache.getAndPut(key, value).also { previous ->
+                if (previous == null) {
+                    stateVersion.incrementAndGet()
+                    frontCache.put(key, value)
+                }
+            }
         }
     }
 
@@ -235,16 +308,19 @@ class ResilientNearJCache<K: Any, V: Any>(
      */
     fun replace(key: K, value: V): Boolean {
         key.requireNotNull("key")
-        if (tombstones.contains(key) || clearPending.value) return false
+        return writeStateLock.withLock {
+            if (pendingMutationTokens.containsKey(key) || tombstones.contains(key) || clearPending.value) return false
 
-        if (!frontCache.containsKey(key)) {
-            if (!runCatching { backCache.containsKey(key) }.getOrDefault(false)) return false
+            if (!frontCache.containsKey(key)) {
+                if (!runCatching { backCache.containsKey(key) }.getOrDefault(false)) return false
+            }
+            backCache.replace(key, value).also { replaced ->
+                if (replaced) {
+                    stateVersion.incrementAndGet()
+                    frontCache.put(key, value)
+                }
+            }
         }
-        val replaced = backCache.replace(key, value)
-        if (replaced) {
-            frontCache.put(key, value)
-        }
-        return replaced
     }
 
     /**
@@ -292,18 +368,21 @@ class ResilientNearJCache<K: Any, V: Any>(
      */
     fun remove(key: K) {
         key.requireNotNull("key")
-        enqueueWrite(BackJCacheCommand.Remove(key), "Write queue full for Remove key=$key")
-        frontCache.remove(key)
-        tombstones.add(key)
+        enqueueWrite(BackJCacheCommand.Remove(key), "Write queue full for Remove key=$key") {
+            frontCache.remove(key)
+            tombstones.add(key)
+        }
     }
 
     /**
      * 여러 키에 해당하는 캐시 항목을 제거한다.
      */
     fun removeAll(keys: Set<K>) {
-        enqueueWrite(BackJCacheCommand.RemoveAll(keys), "Write queue full for RemoveAll keys=${keys.size}")
-        frontCache.removeAll(keys)
-        tombstones.addAll(keys)
+        val keysSnapshot = keys.toSet()
+        enqueueWrite(BackJCacheCommand.RemoveAll(keysSnapshot), "Write queue full for RemoveAll keys=${keys.size}") {
+            frontCache.removeAll(keysSnapshot)
+            tombstones.addAll(keysSnapshot)
+        }
     }
 
     /**
@@ -318,13 +397,9 @@ class ResilientNearJCache<K: Any, V: Any>(
      * 로컬 캐시와 back cache를 모두 비운다 (write-behind).
      */
     fun clearAll() {
-        clearPending.value = true
-        try {
-            enqueueWrite(BackJCacheCommand.ClearBack(), "Write queue full for ClearBack")
+        enqueueWrite(BackJCacheCommand.ClearBack(), "Write queue full for ClearBack") {
+            clearPending.value = true
             clearLocal()
-        } catch (e: Exception) {
-            clearPending.value = false
-            throw e
         }
     }
 
@@ -337,8 +412,14 @@ class ResilientNearJCache<K: Any, V: Any>(
      * 모든 리소스를 정리한다.
      */
     override fun close() {
-        if (closed.compareAndSet(false, true)) {
-            runCatching { consumerThread.interrupt() }
+        val shouldClose = writeStateLock.withLock {
+            closed.compareAndSet(false, true).also { changed ->
+                if (changed) {
+                    runCatching { consumerThread.interrupt() }
+                }
+            }
+        }
+        if (shouldClose) {
             runCatching {
                 if (Thread.currentThread() != consumerThread) {
                     consumerThread.join(closeDrainTimeoutMillis)
@@ -352,8 +433,49 @@ class ResilientNearJCache<K: Any, V: Any>(
         }
     }
 
-    private fun enqueueWrite(command: BackJCacheCommand<K, V>, failureMessage: String) {
+    private fun enqueueWrite(
+        command: BackJCacheCommand<K, V>,
+        failureMessage: String,
+        updateFrontState: () -> Unit,
+    ) {
+        writeStateLock.withLock {
+            enqueueWriteLocked(command, failureMessage, updateFrontState)
+        }
+    }
+
+    private fun enqueueWriteLocked(
+        command: BackJCacheCommand<K, V>,
+        failureMessage: String,
+        updateFrontState: () -> Unit,
+    ) {
+        val queued = QueuedCommand(command, ++nextCommandSequence)
         check(!closed.value) { "ResilientNearCache is closed" }
-        check(queue.offer(command)) { failureMessage }
+        check(queue.offer(queued)) { failureMessage }
+        queued.mutationTokens.forEach(pendingMutationTokens::put)
+        queued.clearToken?.let { pendingClearToken.value = it }
+        stateVersion.incrementAndGet()
+        updateFrontState()
+    }
+
+    private class MutationToken<V: Any>(
+        val value: V?,
+        val sequence: Long,
+    )
+
+    private class ClearToken(val sequence: Long)
+
+    private class QueuedCommand<K: Any, V: Any>(
+        val command: BackJCacheCommand<K, V>,
+        sequence: Long,
+    ) {
+        val mutationTokens: Map<K, MutationToken<V>> = when (command) {
+            is BackJCacheCommand.Put       -> mapOf(command.key to MutationToken(command.value, sequence))
+            is BackJCacheCommand.PutAll    -> command.entries.mapValues { MutationToken(it.value, sequence) }
+            is BackJCacheCommand.Remove    -> mapOf(command.key to MutationToken(null, sequence))
+            is BackJCacheCommand.RemoveAll -> command.keys.associateWith { MutationToken(null, sequence) }
+            is BackJCacheCommand.ClearBack -> emptyMap()
+        }
+
+        val clearToken: ClearToken? = if (command is BackJCacheCommand.ClearBack) ClearToken(sequence) else null
     }
 }

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCache.kt
@@ -21,6 +21,8 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.ConcurrentHashMap
 
@@ -80,7 +82,12 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
     )
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val writeChannel = Channel<BackJCacheCommand<K, V>>(capacity = config.writeQueueCapacity)
+    private val writeChannel = Channel<QueuedCommand<K, V>>(capacity = config.writeQueueCapacity)
+    private val writeStateMutex = Mutex()
+    private val pendingMutationTokens = ConcurrentHashMap<K, MutationToken<V>>()
+    private val pendingClearToken = atomic<ClearToken?>(null)
+    private val stateVersion = atomic(0L)
+    private var nextCommandSequence = 0L
 
     private val retry: Retry = buildRetry()
 
@@ -112,12 +119,21 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
     private fun launchWriteConsumer(): Job =
         scope.launch {
             for (cmd in writeChannel) {
+                writeStateMutex.withLock { }
                 try {
-                    retry.executeSuspendFunction { applyCommand(cmd) }
+                    retry.executeSuspendFunction { applyCommand(cmd.command) }
+                    writeStateMutex.withLock {
+                        completeCommand(cmd, failed = false)
+                    }
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
-                    log.error(e) { "Back cache write failed after ${config.retryMaxAttempts} retries, dropping command: $cmd" }
+                    log.error(e) {
+                        "Back cache write failed after ${config.retryMaxAttempts} retries, compensating command: ${cmd.command}"
+                    }
+                    writeStateMutex.withLock {
+                        completeCommand(cmd, failed = true)
+                    }
                 }
             }
         }
@@ -126,18 +142,43 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
         when (cmd) {
             is BackJCacheCommand.Put       -> backCache.put(cmd.key, cmd.value)
             is BackJCacheCommand.PutAll    -> backCache.putAll(cmd.entries)
-            is BackJCacheCommand.Remove    -> {
-                backCache.remove(cmd.key)
-                tombstones.remove(cmd.key)
+            is BackJCacheCommand.Remove    -> backCache.remove(cmd.key)
+            is BackJCacheCommand.RemoveAll -> backCache.removeAll(cmd.keys)
+            is BackJCacheCommand.ClearBack -> backCache.clear()
+        }
+    }
+
+    private fun completeCommand(queued: QueuedCommand<K, V>, failed: Boolean) {
+        when (val command = queued.command) {
+            is BackJCacheCommand.Put       -> completePut(queued, setOf(command.key), failed)
+            is BackJCacheCommand.PutAll    -> completePut(queued, command.entries.keys, failed)
+            is BackJCacheCommand.Remove    -> completeRemove(queued, setOf(command.key))
+            is BackJCacheCommand.RemoveAll -> completeRemove(queued, command.keys)
+            is BackJCacheCommand.ClearBack -> queued.clearToken?.let { token ->
+                if (pendingClearToken.compareAndSet(token, null)) {
+                    stateVersion.incrementAndGet()
+                    clearPending.value = false
+                }
             }
-            is BackJCacheCommand.RemoveAll -> {
-                backCache.removeAll(cmd.keys)
-                tombstones.removeAll(cmd.keys)
+        }
+    }
+
+    private fun completePut(queued: QueuedCommand<K, V>, keys: Set<K>, failed: Boolean) {
+        keys.forEach { key ->
+            val token = queued.mutationTokens.getValue(key)
+            if (pendingMutationTokens.remove(key, token) && failed) {
+                stateVersion.incrementAndGet()
+                frontCache.remove(key)
             }
-            is BackJCacheCommand.ClearBack -> {
-                backCache.clear()
-                tombstones.clear()
-                clearPending.value = false
+        }
+    }
+
+    private fun completeRemove(queued: QueuedCommand<K, V>, keys: Set<K>) {
+        keys.forEach { key ->
+            val token = queued.mutationTokens.getValue(key)
+            if (pendingMutationTokens.remove(key, token)) {
+                stateVersion.incrementAndGet()
+                tombstones.remove(key)
             }
         }
     }
@@ -151,16 +192,26 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
     suspend fun get(key: K): V? {
         key.requireNotNull("key")
 
-        if (tombstones.contains(key) || clearPending.value) return null
-        frontCache.get(key)?.let { return it }
+        var frontValue: V? = null
+        val observedVersion = writeStateMutex.withLock {
+            if (tombstones.contains(key) || clearPending.value) return null
+            frontValue = frontCache.get(key)
+            stateVersion.value
+        }
+        frontValue?.let { return it }
 
         return when (config.getFailureStrategy) {
-            GetFailureStrategy.RETURN_FRONT_OR_NULL ->
-                getBackOrNull(key, "Back cache GET failed for key=$key, returning null")
-                    ?.also { value -> frontCache.put(key, value) }
+            GetFailureStrategy.RETURN_FRONT_OR_NULL -> {
+                val value = getBackOrNull(key, "Back cache GET failed for key=$key, returning null")
+                value?.let { populateFrontIfUnchanged(key, it, observedVersion) }
+                value
+            }
 
-            GetFailureStrategy.PROPAGATE_EXCEPTION ->
-                backCache.get(key)?.also { value -> frontCache.put(key, value) }
+            GetFailureStrategy.PROPAGATE_EXCEPTION -> {
+                val value = backCache.get(key)
+                value?.let { populateFrontIfUnchanged(key, it, observedVersion) }
+                value
+            }
         }
     }
 
@@ -168,18 +219,32 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
      * 여러 키에 대한 값을 한 번에 조회한다.
      */
     suspend fun getAll(keys: Set<K>): Map<K, V> {
-        if (clearPending.value) return emptyMap()
-        val result = frontCache.getAll(keys).toMutableMap()
-        val missedKeys = (keys - result.keys).filter { !tombstones.contains(it) }
+        val (result, missedKeys, observedVersion) = writeStateMutex.withLock {
+            if (clearPending.value) return emptyMap()
+            val frontResult = frontCache.getAll(keys).toMutableMap()
+            Triple(
+                frontResult,
+                (keys - frontResult.keys).filter { !tombstones.contains(it) },
+                stateVersion.value,
+            )
+        }
 
         missedKeys.forEach { key ->
             getBackOrNull(key, "Back cache GET failed for key=$key during getAll")
                 ?.let { value ->
                     result[key] = value
-                    frontCache.put(key, value)
+                    populateFrontIfUnchanged(key, value, observedVersion)
                 }
         }
         return result
+    }
+
+    private suspend fun populateFrontIfUnchanged(key: K, value: V, observedVersion: Long) {
+        writeStateMutex.withLock {
+            if (stateVersion.value == observedVersion && !tombstones.contains(key) && !clearPending.value) {
+                frontCache.put(key, value)
+            }
+        }
     }
 
     /**
@@ -189,18 +254,21 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
      */
     suspend fun put(key: K, value: V) {
         key.requireNotNull("key")
-        enqueueWrite(BackJCacheCommand.Put(key, value), "Write channel full for Put key=$key")
-        tombstones.remove(key)
-        frontCache.put(key, value)
+        enqueueWrite(BackJCacheCommand.Put(key, value), "Write channel full for Put key=$key") {
+            tombstones.remove(key)
+            frontCache.put(key, value)
+        }
     }
 
     /**
      * 여러 키-값 쌍을 저장한다.
      */
     suspend fun putAll(entries: Map<K, V>) {
-        enqueueWrite(BackJCacheCommand.PutAll(entries), "Write channel full for PutAll entries=${entries.size}")
-        tombstones.removeAll(entries.keys)
-        frontCache.putAll(entries)
+        val entriesSnapshot = entries.toMap()
+        enqueueWrite(BackJCacheCommand.PutAll(entriesSnapshot), "Write channel full for PutAll entries=${entries.size}") {
+            tombstones.removeAll(entriesSnapshot.keys)
+            frontCache.putAll(entriesSnapshot)
+        }
     }
 
     /**
@@ -209,16 +277,29 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
      */
     suspend fun putIfAbsent(key: K, value: V): V? {
         key.requireNotNull("key")
+        return writeStateMutex.withLock {
+            frontCache.get(key)?.let { return it }
+            val pendingMutation = pendingMutationTokens[key]
+            val pendingClear = pendingClearToken.value
+            if (pendingMutation?.value != null && (pendingClear == null || pendingMutation.sequence > pendingClear.sequence)) {
+                return pendingMutation.value
+            }
 
-        val existing = get(key)
-        if (existing != null) return existing
+            if (pendingMutation != null || pendingClear != null) {
+                enqueueWriteLocked(BackJCacheCommand.Put(key, value), "Write channel full for Put key=$key") {
+                    tombstones.remove(key)
+                    frontCache.put(key, value)
+                }
+                return null
+            }
 
-        val setted = backCache.putIfAbsent(key, value)
-        return if (setted) {
-            frontCache.put(key, value)
-            null
-        } else {
-            backCache.get(key)
+            if (backCache.putIfAbsent(key, value)) {
+                stateVersion.incrementAndGet()
+                frontCache.put(key, value)
+                null
+            } else {
+                backCache.get(key)
+            }
         }
     }
 
@@ -228,16 +309,19 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
      */
     suspend fun replace(key: K, value: V): Boolean {
         key.requireNotNull("key")
-        if (tombstones.contains(key) || clearPending.value) return false
+        return writeStateMutex.withLock {
+            if (pendingMutationTokens.containsKey(key) || tombstones.contains(key) || clearPending.value) return false
 
-        if (!frontCache.containsKey(key)) {
-            if (!containsBackOrFalse(key, null)) return false
+            if (!frontCache.containsKey(key)) {
+                if (!containsBackOrFalse(key, null)) return false
+            }
+            backCache.replace(key, value).also { replaced ->
+                if (replaced) {
+                    stateVersion.incrementAndGet()
+                    frontCache.put(key, value)
+                }
+            }
         }
-        val replaced = backCache.replace(key, value)
-        if (replaced) {
-            frontCache.put(key, value)
-        }
-        return replaced
     }
 
     /**
@@ -283,18 +367,21 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
      */
     suspend fun remove(key: K) {
         key.requireNotNull("key")
-        enqueueWrite(BackJCacheCommand.Remove(key), "Write channel full for Remove key=$key")
-        frontCache.remove(key)
-        tombstones.add(key)
+        enqueueWrite(BackJCacheCommand.Remove(key), "Write channel full for Remove key=$key") {
+            frontCache.remove(key)
+            tombstones.add(key)
+        }
     }
 
     /**
      * 여러 키에 해당하는 캐시 항목을 제거한다.
      */
     suspend fun removeAll(keys: Set<K>) {
-        enqueueWrite(BackJCacheCommand.RemoveAll(keys), "Write channel full for RemoveAll keys=${keys.size}")
-        frontCache.removeAll(keys)
-        tombstones.addAll(keys)
+        val keysSnapshot = keys.toSet()
+        enqueueWrite(BackJCacheCommand.RemoveAll(keysSnapshot), "Write channel full for RemoveAll keys=${keys.size}") {
+            frontCache.removeAll(keysSnapshot)
+            tombstones.addAll(keysSnapshot)
+        }
     }
 
     /**
@@ -309,13 +396,9 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
      * 로컬 캐시와 back cache를 모두 비운다 (write-behind).
      */
     suspend fun clearAll() {
-        clearPending.value = true
-        try {
-            enqueueWrite(BackJCacheCommand.ClearBack(), "Write channel full for ClearBack")
+        enqueueWrite(BackJCacheCommand.ClearBack(), "Write channel full for ClearBack") {
+            clearPending.value = true
             clearLocal()
-        } catch (e: Exception) {
-            clearPending.value = false
-            throw e
         }
     }
 
@@ -375,8 +458,49 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
         }
     }
 
-    private fun enqueueWrite(command: BackJCacheCommand<K, V>, failureMessage: String) {
+    private suspend fun enqueueWrite(
+        command: BackJCacheCommand<K, V>,
+        failureMessage: String,
+        updateFrontState: () -> Unit,
+    ) {
+        writeStateMutex.withLock {
+            enqueueWriteLocked(command, failureMessage, updateFrontState)
+        }
+    }
+
+    private fun enqueueWriteLocked(
+        command: BackJCacheCommand<K, V>,
+        failureMessage: String,
+        updateFrontState: () -> Unit,
+    ) {
+        val queued = QueuedCommand(command, ++nextCommandSequence)
         check(!closed.value) { "ResilientSuspendNearCache is closed" }
-        check(writeChannel.trySend(command).isSuccess) { failureMessage }
+        check(writeChannel.trySend(queued).isSuccess) { failureMessage }
+        queued.mutationTokens.forEach(pendingMutationTokens::put)
+        queued.clearToken?.let { pendingClearToken.value = it }
+        stateVersion.incrementAndGet()
+        updateFrontState()
+    }
+
+    private class MutationToken<V: Any>(
+        val value: V?,
+        val sequence: Long,
+    )
+
+    private class ClearToken(val sequence: Long)
+
+    private class QueuedCommand<K: Any, V: Any>(
+        val command: BackJCacheCommand<K, V>,
+        sequence: Long,
+    ) {
+        val mutationTokens: Map<K, MutationToken<V>> = when (command) {
+            is BackJCacheCommand.Put       -> mapOf(command.key to MutationToken(command.value, sequence))
+            is BackJCacheCommand.PutAll    -> command.entries.mapValues { MutationToken(it.value, sequence) }
+            is BackJCacheCommand.Remove    -> mapOf(command.key to MutationToken(null, sequence))
+            is BackJCacheCommand.RemoveAll -> command.keys.associateWith { MutationToken(null, sequence) }
+            is BackJCacheCommand.ClearBack -> emptyMap()
+        }
+
+        val clearToken: ClearToken? = if (command is BackJCacheCommand.ClearBack) ClearToken(sequence) else null
     }
 }

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientNearJCacheTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientNearJCacheTest.kt
@@ -2,15 +2,18 @@ package io.bluetape4k.cache.nearcache.jcache
 
 import io.bluetape4k.cache.jcache.JCaching
 import io.bluetape4k.cache.jcache.jcacheConfiguration
+import io.bluetape4k.concurrent.virtualthread.virtualThread
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.idgenerators.uuid.Uuid
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.logging.KLogging
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import org.awaitility.kotlin.atMost
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.until
@@ -19,8 +22,11 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import javax.cache.Cache
 import javax.cache.expiry.EternalExpiryPolicy
 import kotlin.time.Duration.Companion.seconds
@@ -123,9 +129,100 @@ class ResilientNearJCacheTest {
     }
 
     @Test
+    fun `put - retry exhaustion invalidates uncommitted front value`() {
+        val failingCache = resilientCacheWithFailingBackCache { backCache ->
+            every { backCache.get("put-key") } returns "back-value"
+            every { backCache.put("put-key", "front-value") } throws IllegalStateException("put failed")
+        }
+
+        try {
+            failingCache.get("put-key") shouldBeEqualTo "back-value"
+            failingCache.put("put-key", "front-value")
+
+            await atMost 5.seconds until { failingCache.get("put-key") == "back-value" }
+        } finally {
+            failingCache.close()
+        }
+    }
+
+    @Test
     fun `get - front miss 시 back cache에서 읽어 front populate`() {
         backCache.put("remote-key", "remote-val")
         cache.get("remote-key") shouldBeEqualTo "remote-val"
+    }
+
+    @Test
+    fun `get - concurrent put prevents stale read-through population`() {
+        val readStarted = CountDownLatch(1)
+        val releaseRead = CountDownLatch(1)
+        val staleBackCache = mockk<Cache<String, String>>(relaxed = true)
+        every { staleBackCache.get("shared") } answers {
+            readStarted.countDown()
+            releaseRead.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            "stale"
+        }
+        val staleReadCache = ResilientNearJCache(
+            backCache = staleBackCache,
+            config = ResilientNearJCacheConfig(
+                retryMaxAttempts = 1,
+                retryWaitDuration = Duration.ofMillis(10),
+            )
+        )
+        val readResult = AtomicReference<String?>()
+
+        try {
+            val reader = virtualThread(name = "near-cache-stale-read") {
+                readResult.set(staleReadCache.get("shared"))
+            }
+            readStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            staleReadCache.put("shared", "latest")
+            releaseRead.countDown()
+            reader.join(5_000)
+
+            readResult.get() shouldBeEqualTo "stale"
+            staleReadCache.get("shared") shouldBeEqualTo "latest"
+        } finally {
+            releaseRead.countDown()
+            staleReadCache.close()
+        }
+    }
+
+    @Test
+    fun `get - concurrent replace prevents stale read-through population`() {
+        val readStarted = CountDownLatch(1)
+        val releaseRead = CountDownLatch(1)
+        val staleBackCache = mockk<Cache<String, String>>(relaxed = true)
+        every { staleBackCache.get("shared") } answers {
+            readStarted.countDown()
+            releaseRead.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            "stale"
+        }
+        every { staleBackCache.containsKey("shared") } returns true
+        every { staleBackCache.replace("shared", "latest") } returns true
+        val staleReadCache = ResilientNearJCache(
+            backCache = staleBackCache,
+            config = ResilientNearJCacheConfig(
+                retryMaxAttempts = 1,
+                retryWaitDuration = Duration.ofMillis(10),
+            )
+        )
+        val readResult = AtomicReference<String?>()
+
+        try {
+            val reader = virtualThread(name = "near-cache-stale-replace-read") {
+                readResult.set(staleReadCache.get("shared"))
+            }
+            readStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            staleReadCache.replace("shared", "latest").shouldBeTrue()
+            releaseRead.countDown()
+            reader.join(5_000)
+
+            readResult.get() shouldBeEqualTo "stale"
+            staleReadCache.get("shared") shouldBeEqualTo "latest"
+        } finally {
+            releaseRead.countDown()
+            staleReadCache.close()
+        }
     }
 
     @Test
@@ -140,6 +237,133 @@ class ResilientNearJCacheTest {
     }
 
     @Test
+    fun `putAll - snapshots mutable entries before enqueue`() {
+        val firstPutStarted = CountDownLatch(1)
+        val releaseFirstPut = CountDownLatch(1)
+        val nextPutStored = CountDownLatch(1)
+        val capturedEntries = slot<Map<String, String>>()
+        val mutableBackCache = mockk<Cache<String, String>>(relaxed = true)
+        every { mutableBackCache.put("block", "value") } answers {
+            firstPutStarted.countDown()
+            releaseFirstPut.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        }
+        every { mutableBackCache.putAll(capture(capturedEntries)) } answers { }
+        every { mutableBackCache.put("next", "value") } answers { nextPutStored.countDown() }
+        val mutableEntriesCache = ResilientNearJCache(
+            backCache = mutableBackCache,
+            config = ResilientNearJCacheConfig(
+                retryMaxAttempts = 1,
+                retryWaitDuration = Duration.ofMillis(10),
+            )
+        )
+
+        try {
+            mutableEntriesCache.put("block", "value")
+            firstPutStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            val entries = mutableMapOf("initial" to "value")
+            mutableEntriesCache.putAll(entries)
+            entries["late"] = "value"
+            releaseFirstPut.countDown()
+
+            mutableEntriesCache.put("next", "value")
+            nextPutStored.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            capturedEntries.captured shouldBeEqualTo mapOf("initial" to "value")
+        } finally {
+            releaseFirstPut.countDown()
+            mutableEntriesCache.close()
+        }
+    }
+
+    @Test
+    fun `removeAll - snapshots mutable keys before enqueue`() {
+        val firstPutStarted = CountDownLatch(1)
+        val releaseFirstPut = CountDownLatch(1)
+        val drainCompleted = CountDownLatch(1)
+        val removedKeys = ConcurrentHashMap.newKeySet<String>()
+        val mutableBackCache = mockk<Cache<String, String>>(relaxed = true)
+        every { mutableBackCache.put("block", "value") } answers {
+            firstPutStarted.countDown()
+            releaseFirstPut.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        }
+        every { mutableBackCache.put("marker", "done") } answers { drainCompleted.countDown() }
+        every { mutableBackCache.remove(any()) } answers {
+            removedKeys.add(firstArg())
+            true
+        }
+        val mutableKeysCache = ResilientNearJCache(
+            backCache = mutableBackCache,
+            config = ResilientNearJCacheConfig(
+                retryMaxAttempts = 1,
+                retryWaitDuration = Duration.ofMillis(10),
+            )
+        )
+
+        try {
+            mutableKeysCache.put("block", "value")
+            firstPutStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            val keys = mutableSetOf("initial")
+            mutableKeysCache.removeAll(keys)
+            keys.add("late")
+            releaseFirstPut.countDown()
+
+            mutableKeysCache.put("marker", "done")
+            drainCompleted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            removedKeys shouldBeEqualTo setOf("initial")
+        } finally {
+            releaseFirstPut.countDown()
+            mutableKeysCache.close()
+        }
+    }
+
+    @Test
+    fun `MultithreadingTester - stale completions preserve latest accepted state`() {
+        val backValue = AtomicReference<String?>(null)
+        val valueSequence = AtomicInteger()
+        val operationSequence = AtomicInteger()
+        val drainCompleted = CountDownLatch(1)
+        val concurrentBackCache = mockk<Cache<String, String>>(relaxed = true)
+        every { concurrentBackCache.get("shared") } answers { backValue.get() }
+        every { concurrentBackCache.put("marker", "done") } answers { drainCompleted.countDown() }
+        every { concurrentBackCache.put("shared", any()) } answers {
+            if (operationSequence.incrementAndGet() % 4 == 0) throw IllegalStateException("put failed")
+            backValue.set(secondArg())
+        }
+        every { concurrentBackCache.remove("shared") } answers {
+            if (operationSequence.incrementAndGet() % 4 == 0) throw IllegalStateException("remove failed")
+            backValue.set(null)
+            true
+        }
+        every { concurrentBackCache.clear() } answers {
+            if (operationSequence.incrementAndGet() % 4 == 0) throw IllegalStateException("clear failed")
+            backValue.set(null)
+        }
+        val concurrentCache = ResilientNearJCache(
+            backCache = concurrentBackCache,
+            config = ResilientNearJCacheConfig(
+                writeQueueCapacity = 2_048,
+                retryMaxAttempts = 1,
+                retryWaitDuration = Duration.ofMillis(1),
+            )
+        )
+
+        try {
+            MultithreadingTester()
+                .workers(8)
+                .rounds(32)
+                .add { concurrentCache.put("shared", "value-${valueSequence.incrementAndGet()}") }
+                .add { concurrentCache.remove("shared") }
+                .add { concurrentCache.clearAll() }
+                .run()
+
+            concurrentCache.put("marker", "done")
+            drainCompleted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            concurrentCache.get("shared") shouldBeEqualTo backValue.get()
+        } finally {
+            concurrentCache.close()
+        }
+    }
+
+    @Test
     fun `remove - front 즉시 삭제, back write-behind`() {
         backCache.put("rm-key", "rm-val")
         cache.get("rm-key") shouldBeEqualTo "rm-val"
@@ -149,6 +373,23 @@ class ResilientNearJCacheTest {
 
         // back cache에서도 삭제되길 대기
         await atMost 5.seconds until { backCache.get("rm-key") == null }
+    }
+
+    @Test
+    fun `remove - retry exhaustion releases tombstone`() {
+        val failingCache = resilientCacheWithFailingBackCache { backCache ->
+            every { backCache.get("remove-key") } returns "back-value"
+            every { backCache.remove("remove-key") } throws IllegalStateException("remove failed")
+        }
+
+        try {
+            failingCache.get("remove-key") shouldBeEqualTo "back-value"
+            failingCache.remove("remove-key")
+
+            await atMost 5.seconds until { failingCache.get("remove-key") == "back-value" }
+        } finally {
+            failingCache.close()
+        }
     }
 
     @Test
@@ -178,6 +419,96 @@ class ResilientNearJCacheTest {
     }
 
     @Test
+    fun `putIfAbsent - queued remove preserves mutation order`() {
+        val removeStarted = CountDownLatch(1)
+        val releaseRemove = CountDownLatch(1)
+        val putApplied = CountDownLatch(1)
+        val orderedBackCache = mockk<Cache<String, String>>(relaxed = true)
+        every { orderedBackCache.get("key") } returns "old"
+        every { orderedBackCache.remove("key") } answers {
+            removeStarted.countDown()
+            releaseRemove.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            true
+        }
+        every { orderedBackCache.put("key", "new") } answers { putApplied.countDown() }
+        val orderedCache = ResilientNearJCache(orderedBackCache)
+
+        try {
+            orderedCache.get("key") shouldBeEqualTo "old"
+            orderedCache.remove("key")
+            removeStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+
+            orderedCache.putIfAbsent("key", "new").shouldBeNull()
+            orderedCache.get("key") shouldBeEqualTo "new"
+            releaseRemove.countDown()
+            putApplied.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            orderedCache.get("key") shouldBeEqualTo "new"
+        } finally {
+            releaseRemove.countDown()
+            orderedCache.close()
+        }
+    }
+
+    @Test
+    fun `putIfAbsent - queued clear preserves mutation order`() {
+        val clearStarted = CountDownLatch(1)
+        val releaseClear = CountDownLatch(1)
+        val putApplied = CountDownLatch(1)
+        val orderedBackCache = mockk<Cache<String, String>>(relaxed = true)
+        every { orderedBackCache.clear() } answers {
+            clearStarted.countDown()
+            releaseClear.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        }
+        every { orderedBackCache.put("key", "new") } answers { putApplied.countDown() }
+        val orderedCache = ResilientNearJCache(orderedBackCache)
+
+        try {
+            orderedCache.clearAll()
+            clearStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+
+            orderedCache.putIfAbsent("key", "new").shouldBeNull()
+            orderedCache.get("key").shouldBeNull()
+            releaseClear.countDown()
+            putApplied.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            await atMost 5.seconds until { orderedCache.get("key") == "new" }
+        } finally {
+            releaseClear.countDown()
+            orderedCache.close()
+        }
+    }
+
+    @Test
+    fun `putIfAbsent - newer clear supersedes pending put`() {
+        val oldPutStarted = CountDownLatch(1)
+        val releaseOldPut = CountDownLatch(1)
+        val clearApplied = CountDownLatch(1)
+        val newPutApplied = CountDownLatch(1)
+        val orderedBackCache = mockk<Cache<String, String>>(relaxed = true)
+        every { orderedBackCache.put("key", "old") } answers {
+            oldPutStarted.countDown()
+            releaseOldPut.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        }
+        every { orderedBackCache.clear() } answers { clearApplied.countDown() }
+        every { orderedBackCache.put("key", "new") } answers { newPutApplied.countDown() }
+        val orderedCache = ResilientNearJCache(orderedBackCache)
+
+        try {
+            orderedCache.put("key", "old")
+            oldPutStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            orderedCache.clearAll()
+
+            orderedCache.putIfAbsent("key", "new").shouldBeNull()
+            releaseOldPut.countDown()
+            clearApplied.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            newPutApplied.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            await atMost 5.seconds until { orderedCache.get("key") == "new" }
+        } finally {
+            releaseOldPut.countDown()
+            orderedCache.close()
+        }
+    }
+
+    @Test
     fun `replace - 키가 존재할 때만 교체`() {
         cache.replace("noKey", "val").shouldBeFalse()
         cache.put("key", "old")
@@ -187,6 +518,18 @@ class ResilientNearJCacheTest {
 
         cache.replace("key", "new").shouldBeTrue()
         cache.get("key") shouldBeEqualTo "new"
+    }
+
+    @Test
+    fun `replace - queued remove prevents replacement`() {
+        cache.put("key", "old")
+        await atMost 5.seconds until { backCache.get("key") == "old" }
+
+        cache.remove("key")
+
+        cache.replace("key", "new").shouldBeFalse()
+        await atMost 5.seconds until { backCache.get("key") == null }
+        cache.get("key").shouldBeNull()
     }
 
     @Test
@@ -245,6 +588,23 @@ class ResilientNearJCacheTest {
     }
 
     @Test
+    fun `clearAll - retry exhaustion restores back reads`() {
+        val failingCache = resilientCacheWithFailingBackCache { backCache ->
+            every { backCache.get("clear-key") } returns "back-value"
+            every { backCache.clear() } throws IllegalStateException("clear failed")
+        }
+
+        try {
+            failingCache.get("clear-key") shouldBeEqualTo "back-value"
+            failingCache.clearAll()
+
+            await atMost 5.seconds until { failingCache.get("clear-key") == "back-value" }
+        } finally {
+            failingCache.close()
+        }
+    }
+
+    @Test
     fun `close drains queued write-behind commands`() {
         val closeDrainBackCache =
             JCaching.Caffeine.getOrCreate<String, String>(
@@ -280,5 +640,19 @@ class ResilientNearJCacheTest {
         c.close()
         c.close() // 중복 호출 시에도 예외 없음
         c.isClosed.shouldBeTrue()
+    }
+
+    private fun resilientCacheWithFailingBackCache(
+        configure: (Cache<String, String>) -> Unit,
+    ): ResilientNearJCache<String, String> {
+        val failingBackCache = mockk<Cache<String, String>>(relaxed = true)
+        configure(failingBackCache)
+        return ResilientNearJCache(
+            backCache = failingBackCache,
+            config = ResilientNearJCacheConfig(
+                retryMaxAttempts = 1,
+                retryWaitDuration = Duration.ofMillis(10),
+            )
+        )
     }
 }

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCacheTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCacheTest.kt
@@ -9,11 +9,14 @@ import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.idgenerators.uuid.Uuid
 import io.bluetape4k.junit5.awaitility.untilSuspending
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.KLogging
 import io.mockk.coEvery
 import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
 import org.awaitility.kotlin.atMost
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.AfterEach
@@ -23,6 +26,8 @@ import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -123,10 +128,96 @@ class ResilientSuspendNearJCacheTest {
         }
 
     @Test
+    fun `put - retry exhaustion invalidates uncommitted front value`() =
+        runSuspendIO {
+            val failingCache = resilientCacheWithFailingBackCache { backCache ->
+                coEvery { backCache.get("put-key") } returns "back-value"
+                coEvery { backCache.put("put-key", "front-value") } throws IllegalStateException("put failed")
+            }
+
+            try {
+                failingCache.get("put-key") shouldBeEqualTo "back-value"
+                failingCache.put("put-key", "front-value")
+
+                await atMost 5.seconds untilSuspending { failingCache.get("put-key") == "back-value" }
+            } finally {
+                failingCache.close()
+            }
+        }
+
+    @Test
     fun `get - front miss 시 back cache에서 읽어 front populate`() =
         runSuspendIO {
             backCache.put("remote-key", "remote-val")
             cache.get("remote-key") shouldBeEqualTo "remote-val"
+        }
+
+    @Test
+    fun `get - concurrent put prevents stale read-through population`() =
+        runSuspendIO {
+            val readStarted = CountDownLatch(1)
+            val releaseRead = CountDownLatch(1)
+            val staleBackCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+            coEvery { staleBackCache.get("shared") } coAnswers {
+                readStarted.countDown()
+                releaseRead.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                "stale"
+            }
+            val staleReadCache = ResilientSuspendNearJCache(
+                backCache = staleBackCache,
+                config = ResilientNearJCacheConfig(
+                    retryMaxAttempts = 1,
+                    retryWaitDuration = Duration.ofMillis(10),
+                )
+            )
+
+            try {
+                val reader = async { staleReadCache.get("shared") }
+                readStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                staleReadCache.put("shared", "latest")
+                releaseRead.countDown()
+
+                reader.await() shouldBeEqualTo "stale"
+                staleReadCache.get("shared") shouldBeEqualTo "latest"
+            } finally {
+                releaseRead.countDown()
+                staleReadCache.close()
+            }
+        }
+
+    @Test
+    fun `get - concurrent replace prevents stale read-through population`() =
+        runSuspendIO {
+            val readStarted = CountDownLatch(1)
+            val releaseRead = CountDownLatch(1)
+            val staleBackCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+            coEvery { staleBackCache.get("shared") } coAnswers {
+                readStarted.countDown()
+                releaseRead.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                "stale"
+            }
+            coEvery { staleBackCache.containsKey("shared") } returns true
+            coEvery { staleBackCache.replace("shared", "latest") } returns true
+            val staleReadCache = ResilientSuspendNearJCache(
+                backCache = staleBackCache,
+                config = ResilientNearJCacheConfig(
+                    retryMaxAttempts = 1,
+                    retryWaitDuration = Duration.ofMillis(10),
+                )
+            )
+
+            try {
+                val reader = async { staleReadCache.get("shared") }
+                readStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                staleReadCache.replace("shared", "latest").shouldBeTrue()
+                releaseRead.countDown()
+
+                reader.await() shouldBeEqualTo "stale"
+                staleReadCache.get("shared") shouldBeEqualTo "latest"
+            } finally {
+                releaseRead.countDown()
+                staleReadCache.close()
+            }
         }
 
     @Test
@@ -159,6 +250,133 @@ class ResilientSuspendNearJCacheTest {
         }
 
     @Test
+    fun `putAll - snapshots mutable entries before enqueue`() =
+        runSuspendIO {
+            val firstPutStarted = CountDownLatch(1)
+            val releaseFirstPut = CountDownLatch(1)
+            val nextPutStored = CountDownLatch(1)
+            val capturedEntries = slot<Map<String, String>>()
+            val mutableBackCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+            coEvery { mutableBackCache.put("block", "value") } coAnswers {
+                firstPutStarted.countDown()
+                releaseFirstPut.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            }
+            coEvery { mutableBackCache.putAll(capture(capturedEntries)) } coAnswers { }
+            coEvery { mutableBackCache.put("next", "value") } coAnswers { nextPutStored.countDown() }
+            val mutableEntriesCache = ResilientSuspendNearJCache(
+                backCache = mutableBackCache,
+                config = ResilientNearJCacheConfig(
+                    retryMaxAttempts = 1,
+                    retryWaitDuration = Duration.ofMillis(10),
+                )
+            )
+
+            try {
+                mutableEntriesCache.put("block", "value")
+                firstPutStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                val entries = mutableMapOf("initial" to "value")
+                mutableEntriesCache.putAll(entries)
+                entries["late"] = "value"
+                releaseFirstPut.countDown()
+
+                mutableEntriesCache.put("next", "value")
+                nextPutStored.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                capturedEntries.captured shouldBeEqualTo mapOf("initial" to "value")
+            } finally {
+                releaseFirstPut.countDown()
+                mutableEntriesCache.close()
+            }
+        }
+
+    @Test
+    fun `removeAll - snapshots mutable keys before enqueue`() =
+        runSuspendIO {
+            val firstPutStarted = CountDownLatch(1)
+            val releaseFirstPut = CountDownLatch(1)
+            val drainCompleted = CountDownLatch(1)
+            val capturedKeys = slot<Set<String>>()
+            val mutableBackCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+            coEvery { mutableBackCache.put("block", "value") } coAnswers {
+                firstPutStarted.countDown()
+                releaseFirstPut.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            }
+            coEvery { mutableBackCache.put("marker", "done") } coAnswers { drainCompleted.countDown() }
+            coEvery { mutableBackCache.removeAll(capture(capturedKeys)) } coAnswers { }
+            val mutableKeysCache = ResilientSuspendNearJCache(
+                backCache = mutableBackCache,
+                config = ResilientNearJCacheConfig(
+                    retryMaxAttempts = 1,
+                    retryWaitDuration = Duration.ofMillis(10),
+                )
+            )
+
+            try {
+                mutableKeysCache.put("block", "value")
+                firstPutStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                val keys = mutableSetOf("initial")
+                mutableKeysCache.removeAll(keys)
+                keys.add("late")
+                releaseFirstPut.countDown()
+
+                mutableKeysCache.put("marker", "done")
+                drainCompleted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                capturedKeys.captured shouldBeEqualTo setOf("initial")
+            } finally {
+                releaseFirstPut.countDown()
+                mutableKeysCache.close()
+            }
+        }
+
+    @Test
+    fun `SuspendedJobTester - stale completions preserve latest accepted state`() =
+        runSuspendIO {
+            val backValue = AtomicReference<String?>(null)
+            val valueSequence = AtomicInteger()
+            val operationSequence = AtomicInteger()
+            val drainCompleted = CountDownLatch(1)
+            val concurrentBackCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+            coEvery { concurrentBackCache.get("shared") } coAnswers { backValue.get() }
+            coEvery { concurrentBackCache.put("marker", "done") } coAnswers { drainCompleted.countDown() }
+            coEvery { concurrentBackCache.put("shared", any()) } coAnswers {
+                if (operationSequence.incrementAndGet() % 4 == 0) throw IllegalStateException("put failed")
+                backValue.set(secondArg())
+            }
+            coEvery { concurrentBackCache.remove("shared") } coAnswers {
+                if (operationSequence.incrementAndGet() % 4 == 0) throw IllegalStateException("remove failed")
+                backValue.set(null)
+                true
+            }
+            coEvery { concurrentBackCache.clear() } coAnswers {
+                if (operationSequence.incrementAndGet() % 4 == 0) throw IllegalStateException("clear failed")
+                backValue.set(null)
+            }
+            val concurrentCache = ResilientSuspendNearJCache(
+                backCache = concurrentBackCache,
+                config = ResilientNearJCacheConfig(
+                    writeQueueCapacity = 2_048,
+                    retryMaxAttempts = 1,
+                    retryWaitDuration = Duration.ofMillis(1),
+                )
+            )
+
+            try {
+                SuspendedJobTester()
+                    .workers(8)
+                    .rounds(32)
+                    .add { concurrentCache.put("shared", "value-${valueSequence.incrementAndGet()}") }
+                    .add { concurrentCache.remove("shared") }
+                    .add { concurrentCache.clearAll() }
+                    .run()
+
+                concurrentCache.put("marker", "done")
+                drainCompleted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                concurrentCache.get("shared") shouldBeEqualTo backValue.get()
+            } finally {
+                concurrentCache.close()
+            }
+        }
+
+    @Test
     fun `getAll - CancellationException은 fallback하지 않고 재전파한다`() =
         runSuspendIO {
             val failingCache = resilientCacheWithFailingBackCache { backCache ->
@@ -186,6 +404,24 @@ class ResilientSuspendNearJCacheTest {
 
             await atMost 5.seconds untilSuspending { backCache.get("rm-key") == null }
             backCache.get("rm-key").shouldBeNull()
+        }
+
+    @Test
+    fun `remove - retry exhaustion releases tombstone`() =
+        runSuspendIO {
+            val failingCache = resilientCacheWithFailingBackCache { backCache ->
+                coEvery { backCache.get("remove-key") } returns "back-value"
+                coEvery { backCache.remove("remove-key") } throws IllegalStateException("remove failed")
+            }
+
+            try {
+                failingCache.get("remove-key") shouldBeEqualTo "back-value"
+                failingCache.remove("remove-key")
+
+                await atMost 5.seconds untilSuspending { failingCache.get("remove-key") == "back-value" }
+            } finally {
+                failingCache.close()
+            }
         }
 
     @Test
@@ -235,6 +471,99 @@ class ResilientSuspendNearJCacheTest {
         }
 
     @Test
+    fun `putIfAbsent - queued remove preserves mutation order`() =
+        runSuspendIO {
+            val removeStarted = CountDownLatch(1)
+            val releaseRemove = CountDownLatch(1)
+            val putApplied = CountDownLatch(1)
+            val orderedBackCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+            coEvery { orderedBackCache.get("key") } returns "old"
+            coEvery { orderedBackCache.remove("key") } coAnswers {
+                removeStarted.countDown()
+                releaseRemove.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                true
+            }
+            coEvery { orderedBackCache.put("key", "new") } coAnswers { putApplied.countDown() }
+            val orderedCache = ResilientSuspendNearJCache(orderedBackCache)
+
+            try {
+                orderedCache.get("key") shouldBeEqualTo "old"
+                orderedCache.remove("key")
+                removeStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+
+                orderedCache.putIfAbsent("key", "new").shouldBeNull()
+                orderedCache.get("key") shouldBeEqualTo "new"
+                releaseRemove.countDown()
+                putApplied.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                orderedCache.get("key") shouldBeEqualTo "new"
+            } finally {
+                releaseRemove.countDown()
+                orderedCache.close()
+            }
+        }
+
+    @Test
+    fun `putIfAbsent - queued clear preserves mutation order`() =
+        runSuspendIO {
+            val clearStarted = CountDownLatch(1)
+            val releaseClear = CountDownLatch(1)
+            val putApplied = CountDownLatch(1)
+            val orderedBackCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+            coEvery { orderedBackCache.clear() } coAnswers {
+                clearStarted.countDown()
+                releaseClear.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            }
+            coEvery { orderedBackCache.put("key", "new") } coAnswers { putApplied.countDown() }
+            val orderedCache = ResilientSuspendNearJCache(orderedBackCache)
+
+            try {
+                orderedCache.clearAll()
+                clearStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+
+                orderedCache.putIfAbsent("key", "new").shouldBeNull()
+                orderedCache.get("key").shouldBeNull()
+                releaseClear.countDown()
+                putApplied.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                await atMost 5.seconds untilSuspending { orderedCache.get("key") == "new" }
+            } finally {
+                releaseClear.countDown()
+                orderedCache.close()
+            }
+        }
+
+    @Test
+    fun `putIfAbsent - newer clear supersedes pending put`() =
+        runSuspendIO {
+            val oldPutStarted = CountDownLatch(1)
+            val releaseOldPut = CountDownLatch(1)
+            val clearApplied = CountDownLatch(1)
+            val newPutApplied = CountDownLatch(1)
+            val orderedBackCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+            coEvery { orderedBackCache.put("key", "old") } coAnswers {
+                oldPutStarted.countDown()
+                releaseOldPut.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            }
+            coEvery { orderedBackCache.clear() } coAnswers { clearApplied.countDown() }
+            coEvery { orderedBackCache.put("key", "new") } coAnswers { newPutApplied.countDown() }
+            val orderedCache = ResilientSuspendNearJCache(orderedBackCache)
+
+            try {
+                orderedCache.put("key", "old")
+                oldPutStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                orderedCache.clearAll()
+
+                orderedCache.putIfAbsent("key", "new").shouldBeNull()
+                releaseOldPut.countDown()
+                clearApplied.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                newPutApplied.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                await atMost 5.seconds untilSuspending { orderedCache.get("key") == "new" }
+            } finally {
+                releaseOldPut.countDown()
+                orderedCache.close()
+            }
+        }
+
+    @Test
     fun `replace - 키가 존재할 때만 교체`() =
         runSuspendIO {
             cache.replace("noKey", "val").shouldBeFalse()
@@ -245,6 +574,19 @@ class ResilientSuspendNearJCacheTest {
 
             cache.replace("key", "new").shouldBeTrue()
             cache.get("key") shouldBeEqualTo "new"
+        }
+
+    @Test
+    fun `replace - queued remove prevents replacement`() =
+        runSuspendIO {
+            cache.put("key", "old")
+            await atMost 5.seconds untilSuspending { backCache.get("key") == "old" }
+
+            cache.remove("key")
+
+            cache.replace("key", "new").shouldBeFalse()
+            await atMost 5.seconds untilSuspending { backCache.get("key") == null }
+            cache.get("key").shouldBeNull()
         }
 
     @Test
@@ -319,6 +661,24 @@ class ResilientSuspendNearJCacheTest {
 
             await atMost 5.seconds untilSuspending { backCache.get("k1") == null }
             backCache.get("k1").shouldBeNull()
+        }
+
+    @Test
+    fun `clearAll - retry exhaustion restores back reads`() =
+        runSuspendIO {
+            val failingCache = resilientCacheWithFailingBackCache { backCache ->
+                coEvery { backCache.get("clear-key") } returns "back-value"
+                coEvery { backCache.clear() } throws IllegalStateException("clear failed")
+            }
+
+            try {
+                failingCache.get("clear-key") shouldBeEqualTo "back-value"
+                failingCache.clearAll()
+
+                await atMost 5.seconds untilSuspending { failingCache.get("clear-key") == "back-value" }
+            } finally {
+                failingCache.close()
+            }
         }
 
     @Test

--- a/docs/lessons/2026-07-10-issue-785-near-cache-retry-compensation.md
+++ b/docs/lessons/2026-07-10-issue-785-near-cache-retry-compensation.md
@@ -1,0 +1,56 @@
+# Issue #785: Near-cache retry failure compensation
+
+## Context
+
+Bounded queue overflow and close draining were already handled, but a backend
+write could still exhaust all retries after the public write-behind operation
+had updated the front cache. This left uncommitted front values, permanent
+tombstones, or a permanently enabled `clearPending` flag.
+
+## Decision
+
+- Keep the existing write-behind API and compensate terminal backend failures.
+- Invalidate failed `Put` front entries so later reads repopulate from the back cache.
+- Release failed `Remove` tombstones and failed `ClearBack` read blocking.
+- Serialize queue acceptance with optimistic front-state mutation so the consumer
+  cannot complete a command before its local state is installed.
+- Associate each accepted command with ownership tokens. A stale completion must
+  not compensate state installed by a newer command for the same key or clear.
+- Apply token completion and compensation under the same lock or mutex used by
+  enqueue state installation, and snapshot caller-owned bulk collections.
+- Guard read-through population with a monotonic state version so a backend read
+  started before a newer mutation cannot overwrite the newer front state.
+- Serialize synchronous replace with pending write state and advance the same
+  version so delayed reads cannot restore the replaced value.
+- Preserve the logical value in mutation tokens so `putIfAbsent` can return an
+  in-flight Put value or enqueue after an in-flight remove/clear without reordering.
+- Compare mutation and clear command sequences so a newer clear supersedes an
+  older pending Put when evaluating `putIfAbsent`.
+
+## Outcome
+
+Blocking and suspend implementations now converge to observable backend state
+after retry exhaustion instead of retaining a permanently divergent local view.
+Terminal failures remain logged because an asynchronous write-behind call cannot
+retroactively fail after it has returned.
+
+## Verification
+
+- RED: six retry-exhaustion tests failed with `ConditionTimeoutException` before the fix.
+- GREEN: the same six tests passed after compensation was implemented.
+- RED: mutable `PutAll` inputs terminated both consumers before snapshotting was added.
+- `MultithreadingTester` and `SuspendedJobTester` verified mixed same-key
+  put/remove/clear completion against the final backend state.
+- Deterministic blocked-read tests verified stale read-through results are not
+  repopulated after a concurrent put or replace.
+- Queued-remove tests verified replace cannot bypass a pending tombstone.
+- Queued remove/clear tests verified `putIfAbsent` preserves mutation order.
+- Pending Put then Clear tests verified the newer clear wins before `putIfAbsent`.
+- Both resilient near-cache test classes: 68 tests passed.
+- `:bluetape4k-cache-core:test`: 502 tests passed.
+
+## Future Guard
+
+When optimistic state is associated with queued asynchronous work, completion
+and compensation must be conditional on command ownership. Do not use an
+unversioned `remove` or boolean reset that can overwrite a newer accepted state.

--- a/docs/review/2026-07-10-issue-785-near-cache-retry-compensation-review.md
+++ b/docs/review/2026-07-10-issue-785-near-cache-retry-compensation-review.md
@@ -1,0 +1,33 @@
+# Issue 785 Near-Cache Retry Compensation Review
+
+## Scope
+
+- Compensate optimistic front state when write-behind retries are exhausted.
+- Preserve command ownership across stale completions, clear, replace, and
+  `putIfAbsent` ordering in blocking and suspend implementations.
+- Snapshot caller-owned bulk command inputs before enqueue.
+
+## Review Result
+
+- Code review: APPROVE, P0=0, P1=0.
+- Architecture and concurrency review: CLEAR.
+- Resolved findings included atomic enqueue/compensation, clear ownership,
+  stale read-through population, close/enqueue ordering, synchronous replace,
+  and `putIfAbsent` ordering across pending mutations and clear.
+
+## Verification
+
+- Retry-exhaustion RED tests failed before compensation and passed after it.
+- Deterministic blocked-read and command-order tests cover stale Put, Replace,
+  Remove, Clear, and `putIfAbsent` paths.
+- `MultithreadingTester` and `SuspendedJobTester` cover mixed stale completions.
+- Both resilient near-cache test classes: 68 passing.
+- `./gradlew :bluetape4k-cache-core:test`: 502 passing.
+- `git diff --check`: passing.
+- IntelliJ diagnostics were unavailable; successful Kotlin compilation and the
+  full module test suite were used as fallback evidence.
+
+## Documentation
+
+No README or diagram change is required. The public API shape is unchanged and
+the fix is an internal write-behind consistency contract.


### PR DESCRIPTION
## Summary

Closes #785

- PR 제목: fix: compensate resilient near-cache retry failures

- compensate optimistic front-cache state when write-behind retries are exhausted
- preserve command ownership and accepted ordering across Put, Remove, Clear, Replace, and `putIfAbsent`
- snapshot mutable bulk inputs and prevent stale read-through results from overwriting newer state
- cover blocking and suspend implementations with deterministic concurrency and stress tests

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Behavior

Write-behind calls still acknowledge successful enqueue rather than backend completion. If all retries later fail, the consumer logs the terminal failure and compensates the local optimistic state so subsequent reads converge on observable backend state. A completed asynchronous call cannot retroactively throw to its caller.

### 기존 섹션: Verification

- `./gradlew :bluetape4k-cache-core:test`: 502 passing
- resilient near-cache test classes: 68 passing
- code review: APPROVE, P0=0, P1=0
- architecture/concurrency review: CLEAR
- `git diff --check`: passing

Fixes #785

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #785, milestone `1.12.0`, assignee `debop`
- PR: #1005, head `61164e9805f02559f84df3322b946e72e6846666`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-785-near-cache-retry-compensation`
- Labels: `bug`, `tech-debt`
- State: `MERGED`, merge commit `707a6c0d02a9032b4460322bd00ae2173484a71f`
- CI: - `./gradlew :bluetape4k-cache-core:test`: 502 passing

## DoD Status

- [x] Blocking and suspend retry exhaustion compensation implemented
- [x] Stale completion, read-through, Replace, and `putIfAbsent` ordering covered
- [x] Mutable PutAll and RemoveAll inputs snapshotted
- [x] Full affected module test suite passing
- [x] Independent code and architecture reviews passing
- [x] Lesson and review evidence recorded
- [x] README/diagram impact assessed as not applicable because the public API and documentation model are unchanged

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1005 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `707a6c0d02a9032b4460322bd00ae2173484a71f`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
