### PR TITLE
Fix Redis module diagram validation evidence

### DIFF
--- a/docs/images/readme-diagrams/infra-redis-diagram-01.svg
+++ b/docs/images/readme-diagrams/infra-redis-diagram-01.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1680" height="1160" viewBox="0 0 1680 1160" role="img" aria-labelledby="title desc">
+<svg data-intent="Explain that the Redis umbrella exports Lettuce and Redisson while Spring Data Redis serializers remain an explicit separate module choice." data-evidence="infra/redis/README.md; infra/redis/build.gradle.kts; spring-boot/redis/src/main/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializers.kt; spring-boot/redis/src/main/kotlin/io/bluetape4k/spring/redis/serializer/RedisSerializationContextSupport.kt" data-source-read="infra/redis/README.md; infra/redis/build.gradle.kts; spring-boot/redis/src/main/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializers.kt; spring-boot/redis/src/main/kotlin/io/bluetape4k/spring/redis/serializer/RedisSerializationContextSupport.kt" xmlns="http://www.w3.org/2000/svg" width="1680" height="1160" viewBox="0 0 1680 1160" role="img" aria-labelledby="title desc">
 <title id="title">Redis umbrella module dependency structure</title>
 <desc id="desc">bluetape4k-redis exports Lettuce and Redisson; Spring Data Redis serializers remain a separate dependency choice.</desc>
 <defs><style>
@@ -8,72 +8,70 @@
   .layerSub{font-size:14px}.cardTitle{font-family:"Architects Daughter";font-size:24px;fill:#1F2937}
   .sub{font-size:15px}.note{font-size:14px}.code{font-family:"Comic Mono";font-size:16px;fill:#334155}
 </style></defs>
-<marker id="arrowBlue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="13" markerHeight="13" orient="auto" markerUnits="userSpaceOnUse"><path d="M 1 1 L 9 5 L 1 9" fill="#356FEA" stroke="#356FEA" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none"  style="stroke-dasharray:none"/></marker>
-<marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="13" markerHeight="13" orient="auto" markerUnits="userSpaceOnUse"><path d="M 1 1 L 9 5 L 1 9" fill="#229E5D" stroke="#229E5D" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none"  style="stroke-dasharray:none"/></marker>
-<marker id="arrowTeal" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="13" markerHeight="13" orient="auto" markerUnits="userSpaceOnUse"><path d="M 1 1 L 9 5 L 1 9" fill="#0F9B8E" stroke="#0F9B8E" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none"  style="stroke-dasharray:none"/></marker>
-<marker id="arrowOrange" viewBox="0 0 18 18" refX="16" refY="9" markerWidth="18" markerHeight="18" orient="auto" markerUnits="userSpaceOnUse" overflow="visible"><path d="M 3 3 L 16 9 L 3 15" fill="none" stroke="#EA580C" stroke-width="2.4" stroke-linecap="butt" stroke-linejoin="round" stroke-dasharray="none" style="stroke-dasharray:none" /></marker>
-<marker id="arrowPink" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="13" markerHeight="13" orient="auto" markerUnits="userSpaceOnUse"><path d="M 1 1 L 9 5 L 1 9" fill="none" stroke="#DB2777" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none"  style="stroke-dasharray:none"/></marker>
-<rect width="1680" height="1160" fill="#F7FAFC" />
-<rect x="30" y="28" width="1620" height="1104" rx="24" fill="#FFFFFF" stroke="#D5E1EC" stroke-width="2.4" />
+<marker id="arrowBlue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="13" markerHeight="13" orient="auto" markerUnits="userSpaceOnUse"><path d="M 1 1 L 9 5 L 1 9" fill="#356FEA" stroke="#356FEA" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none"/></marker>
+<marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="13" markerHeight="13" orient="auto" markerUnits="userSpaceOnUse"><path d="M 1 1 L 9 5 L 1 9" fill="#229E5D" stroke="#229E5D" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none"/></marker>
+<marker id="arrowTeal" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="13" markerHeight="13" orient="auto" markerUnits="userSpaceOnUse"><path d="M 1 1 L 9 5 L 1 9" fill="#0F9B8E" stroke="#0F9B8E" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none"/></marker>
+<marker id="arrowOrange" viewBox="0 0 18 18" refX="16" refY="9" markerWidth="18" markerHeight="18" orient="auto" markerUnits="userSpaceOnUse" overflow="visible"><path d="M 3 3 L 16 9 L 3 15" fill="none" stroke="#EA580C" stroke-width="2.4" stroke-linecap="butt" stroke-linejoin="round" stroke-dasharray="none" style="stroke-dasharray:none"/></marker>
+<marker id="arrowPink" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="13" markerHeight="13" orient="auto" markerUnits="userSpaceOnUse"><path d="M 1 1 L 9 5 L 1 9" fill="none" stroke="#DB2777" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none"/></marker>
+<rect width="1680" height="1160" fill="#F7FAFC"/>
+<rect x="30" y="28" width="1620" height="1104" rx="24" fill="#FFFFFF" stroke="#D5E1EC" stroke-width="2.4"/>
 <text x="840" y="82" text-anchor="middle" class="title">Redis Umbrella Module Dependency Structure</text>
 <text x="840" y="116" text-anchor="middle" class="subtitle">The umbrella artifact exports Lettuce and Redisson only; Spring Data Redis serializers are selected separately.</text>
-<rect x="72" y="160" width="1536" height="250" rx="20" fill="#FFFFFF" stroke="#D5E1EC" stroke-width="2.2" />
+<rect x="72" y="160" width="1536" height="250" rx="20" fill="#FFFFFF" stroke="#D5E1EC" stroke-width="2.2"/>
 <text x="100" y="202" class="layerTitle">Dependency chosen by an application</text>
 <text x="100" y="228" class="layerSub">Use the full bundle for migration compatibility, or depend on only one client module.</text>
-<rect x="130" y="270" width="360" height="110" rx="16" fill="#EBF2FF" stroke="#356FEA" stroke-width="2.8" />
+<rect x="130" y="270" width="360" height="110" rx="16" fill="#EBF2FF" stroke="#356FEA" stroke-width="2.8"/>
 <text x="310" y="312" text-anchor="middle" class="cardTitle">bluetape4k-redis</text>
 <text x="310" y="342" text-anchor="middle" class="sub">umbrella artifact</text>
 <text x="310" y="364" text-anchor="middle" class="sub">api(project(:lettuce, :redisson))</text>
-<rect x="595" y="270" width="360" height="110" rx="16" fill="#F0FDF4" stroke="#229E5D" stroke-width="2.8" />
+<rect x="595" y="270" width="360" height="110" rx="16" fill="#F0FDF4" stroke="#229E5D" stroke-width="2.8"/>
 <text x="775" y="312" text-anchor="middle" class="cardTitle">client-only choice</text>
 <text x="775" y="342" text-anchor="middle" class="sub">depend on lettuce or redisson</text>
 <text x="775" y="364" text-anchor="middle" class="sub">when the other client is unused</text>
-<rect x="1060" y="270" width="400" height="110" rx="16" fill="#FFF7ED" stroke="#EA580C" stroke-width="2.8" stroke-dasharray="10 8" />
+<rect x="1060" y="270" width="400" height="110" rx="16" fill="#FFF7ED" stroke="#EA580C" stroke-width="2.8" stroke-dasharray="10 8"/>
 <text x="1260" y="312" text-anchor="middle" class="cardTitle">Spring Redis serializers</text>
 <text x="1260" y="342" text-anchor="middle" class="sub">separate module</text>
 <text x="1260" y="364" text-anchor="middle" class="sub">not exported by the umbrella</text>
-<rect x="72" y="440" width="1536" height="350" rx="20" fill="#FFFFFF" stroke="#D5E1EC" stroke-width="2.2" />
+<rect x="72" y="440" width="1536" height="350" rx="20" fill="#FFFFFF" stroke="#D5E1EC" stroke-width="2.2"/>
 <text x="100" y="482" class="layerTitle">Exported Redis client modules</text>
 <text x="100" y="508" class="layerSub">Both included modules talk to the same Redis backend but expose different client models.</text>
-<rect x="160" y="570" width="440" height="164" rx="16" fill="#ECFDF5" stroke="#229E5D" stroke-width="2.8" />
+<rect x="160" y="570" width="440" height="164" rx="16" fill="#ECFDF5" stroke="#229E5D" stroke-width="2.8"/>
 <text x="380" y="612" text-anchor="middle" class="cardTitle">bluetape4k-lettuce</text>
 <text x="380" y="642" text-anchor="middle" class="sub">RedisClient and cached connections</text>
 <text x="380" y="664" text-anchor="middle" class="sub">sync / async / coroutine commands</text>
 <text x="380" y="686" text-anchor="middle" class="sub">RedisFuture.awaitSuspending()</text>
 <text x="380" y="708" text-anchor="middle" class="sub">binary, JSON, and Protobuf codecs</text>
-<rect x="650" y="570" width="440" height="164" rx="16" fill="#F3E8FF" stroke="#8B5CF6" stroke-width="2.8" />
+<rect x="650" y="570" width="440" height="164" rx="16" fill="#F3E8FF" stroke="#8B5CF6" stroke-width="2.8"/>
 <text x="870" y="612" text-anchor="middle" class="cardTitle">bluetape4k-redisson</text>
 <text x="870" y="642" text-anchor="middle" class="sub">redissonClient DSL</text>
 <text x="870" y="664" text-anchor="middle" class="sub">RFuture coroutine adapters</text>
 <text x="870" y="686" text-anchor="middle" class="sub">map/cache helpers</text>
 <text x="870" y="708" text-anchor="middle" class="sub">RedissonNearCache</text>
-<rect x="1140" y="570" width="370" height="142" rx="16" fill="#FFF7ED" stroke="#EA580C" stroke-width="2.8" stroke-dasharray="10 8" />
+<rect x="1140" y="570" width="370" height="142" rx="16" fill="#FFF7ED" stroke="#EA580C" stroke-width="2.8" stroke-dasharray="10 8"/>
 <text x="1325" y="612" text-anchor="middle" class="cardTitle">spring-boot/redis</text>
 <text x="1325" y="642" text-anchor="middle" class="sub">RedisBinarySerializers</text>
 <text x="1325" y="664" text-anchor="middle" class="sub">redisSerializationContext()</text>
 <text x="1325" y="686" text-anchor="middle" class="sub">use explicitly with templates</text>
-<rect x="72" y="850" width="1536" height="190" rx="20" fill="#FFFFFF" stroke="#D5E1EC" stroke-width="2.2" />
+<rect x="72" y="850" width="1536" height="190" rx="20" fill="#FFFFFF" stroke="#D5E1EC" stroke-width="2.2"/>
 <text x="100" y="892" class="layerTitle">Runtime backend boundary</text>
 <text x="100" y="918" class="layerSub">The dependency choice changes client APIs, not the Redis server contract.</text>
-<rect x="445" y="922" width="790" height="100" rx="16" fill="#FFF1F2" stroke="#DB2777" stroke-width="2.8" />
-<image data-bluetape4k-icon="redis/redis-icon.svg" x="473" y="950" width="48" height="48" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiBoZWlnaHQ9IjY0IiB2aWV3Qm94PSIwIDAgMzIgMzIiIHdpZHRoPSI2NCI+PGcgdHJhbnNmb3JtPSJtYXRyaXgoLjg0ODMyNyAwIDAgLjg0ODMyNyAtNy44ODM1NzMgLTkuNDQ5NjkxKSI+PHVzZSB4bGluazpocmVmPSIjQiIgZmlsbD0iI2E0MWUxMSIvPjxwYXRoIGQ9Ik00NS41MzYgMzQuOTVjLTIuMDEzIDEuMDUtMTIuNDQgNS4zMzctMTQuNjYgNi40OTRzLTMuNDUzIDEuMTQ2LTUuMjA3LjMwOC0xMi44NS01LjMyLTE0Ljg1LTYuMjc2LTIuMDQtMS42MTMtLjA3Ny0yLjM4MmwxNS4zMzItNS45MzZjMi4zMzItLjgzNiAzLjE0LS44NjcgNS4xMjYtLjE0UzQzLjU1IDMxLjg3IDQ1LjUxIDMyLjZzMi4wMzcgMS4zMS4wMjQgMi4zNnoiIGZpbGw9IiNkODJjMjAiLz48dXNlIHhsaW5rOmhyZWY9IiNCIiB5PSItNi4yMTgiIGZpbGw9IiNhNDFlMTEiLz48dXNlIHhsaW5rOmhyZWY9IiNDIiBmaWxsPSIjZDgyYzIwIi8+PHBhdGggZD0iTTQ1LjUzNiAyNi4wOThjLTIuMDEzIDEuMDUtMTIuNDQgNS4zMzctMTQuNjYgNi40OTVzLTMuNDUzIDEuMTQ2LTUuMjA3LjMwOC0xMi44NS01LjMyLTE0Ljg1LTYuMjc2Yy0xLS40NzgtMS41MjQtLjg4LTEuNTI0LTEuMjZWMjEuNTVzMTQuNDQ3LTMuMTQ1IDE2Ljc4LTMuOTgyIDMuMTQtLjg2NyA1LjEyNi0uMTQgMTMuODUzIDIuODY4IDE1LjgxNCAzLjU4N3YzLjc2YzAgLjM3Ny0uNDUyLjgtMS40NzcgMS4zMjR6IiBmaWxsPSIjYTQxZTExIi8+PHVzZSB4bGluazpocmVmPSIjQyIgeT0iLTYuNDQ5IiBmaWxsPSIjZDgyYzIwIi8+PGcgZmlsbD0iI2ZmZiI+PHBhdGggZD0iTTI5LjA5NiAyMC43MTJsLTEuMTgyLTEuOTY1LTMuNzc0LS4zNCAyLjgxNi0xLjAxNi0uODQ1LTEuNTYgMi42MzYgMS4wMyAyLjQ4Ni0uODE0LS42NzIgMS42MTIgMi41MzQuOTUtMy4yNjguMzR6TTIyLjggMjQuNjI0bDguNzQtMS4zNDItMi42NCAzLjg3MnoiLz48ZWxsaXBzZSBjeD0iMjAuNDQ0IiByeD0iNC42NzIiIHJ5PSIxLjgxMSIgY3k9IjIxLjQwMiIvPjwvZz48cGF0aCBkPSJNNDIuMTMyIDIxLjEzOGwtNS4xNyAyLjA0Mi0uMDA0LTQuMDg3eiIgZmlsbD0iIzdhMGMwMCIvPjxwYXRoIGQ9Ik0zNi45NjMgMjMuMThsLS41Ni4yMi01LjE2Ni0yLjA0MiA1LjcyMy0yLjI2NHoiIGZpbGw9IiNhZDIxMTUiLz48L2c+PGRlZnMgPjxwYXRoIGlkPSJCIiBkPSJNNDUuNTM2IDM4Ljc2NGMtMi4wMTMgMS4wNS0xMi40NCA1LjMzNy0xNC42NiA2LjQ5NHMtMy40NTMgMS4xNDYtNS4yMDcuMzA4LTEyLjg1LTUuMzItMTQuODUtNi4yNzZjLTEtLjQ3OC0xLjUyNC0uODgtMS41MjQtMS4yNnYtMy44MTNzMTQuNDQ3LTMuMTQ1IDE2Ljc4LTMuOTgyIDMuMTQtLjg2NyA1LjEyNi0uMTQgMTMuODUzIDIuODY4IDE1LjgxNCAzLjU4N3YzLjc2YzAgLjM3Ny0uNDUyLjgtMS40NzcgMS4zMjR6Ii8+PHBhdGggaWQ9IkMiIGQ9Ik00NS41MzYgMjguNzMzYy0yLjAxMyAxLjA1LTEyLjQ0IDUuMzM3LTE0LjY2IDYuNDk0cy0zLjQ1MyAxLjE0Ni01LjIwNy4zMDgtMTIuODUtNS4zMi0xNC44NS02LjI3Ni0yLjA0LTEuNjEzLS4wNzctMi4zODJsMTUuMzMyLTUuOTM1YzIuMzMyLS44MzcgMy4xNC0uODY3IDUuMTI2LS4xNHMxMi4zNSA0Ljg1MyAxNC4zMTIgNS41NyAyLjAzNyAxLjMxLjAyNCAyLjM2eiIvPjwvZGVmcz48L3N2Zz4=" preserveAspectRatio="xMidYMid meet" />
+<rect x="445" y="922" width="790" height="100" rx="16" fill="#FFF1F2" stroke="#DB2777" stroke-width="2.8"/>
+<image data-bluetape4k-icon="redis/redis-icon.svg" x="473" y="950" width="48" height="48" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiBoZWlnaHQ9IjY0IiB2aWV3Qm94PSIwIDAgMzIgMzIiIHdpZHRoPSI2NCI+PGcgdHJhbnNmb3JtPSJtYXRyaXgoLjg0ODMyNyAwIDAgLjg0ODMyNyAtNy44ODM1NzMgLTkuNDQ5NjkxKSI+PHVzZSB4bGluazpocmVmPSIjQiIgZmlsbD0iI2E0MWUxMSIvPjxwYXRoIGQ9Ik00NS41MzYgMzQuOTVjLTIuMDEzIDEuMDUtMTIuNDQgNS4zMzctMTQuNjYgNi40OTRzLTMuNDUzIDEuMTQ2LTUuMjA3LjMwOC0xMi44NS01LjMyLTE0Ljg1LTYuMjc2LTIuMDQtMS42MTMtLjA3Ny0yLjM4MmwxNS4zMzItNS45MzZjMi4zMzItLjgzNiAzLjE0LS44NjcgNS4xMjYtLjE0UzQzLjU1IDMxLjg3IDQ1LjUxIDMyLjZzMi4wMzcgMS4zMS4wMjQgMi4zNnoiIGZpbGw9IiNkODJjMjAiLz48dXNlIHhsaW5rOmhyZWY9IiNCIiB5PSItNi4yMTgiIGZpbGw9IiNhNDFlMTEiLz48dXNlIHhsaW5rOmhyZWY9IiNDIiBmaWxsPSIjZDgyYzIwIi8+PHBhdGggZD0iTTQ1LjUzNiAyNi4wOThjLTIuMDEzIDEuMDUtMTIuNDQgNS4zMzctMTQuNjYgNi40OTVzLTMuNDUzIDEuMTQ2LTUuMjA3LjMwOC0xMi44NS01LjMyLTE0Ljg1LTYuMjc2Yy0xLS40NzgtMS41MjQtLjg4LTEuNTI0LTEuMjZWMjEuNTVzMTQuNDQ3LTMuMTQ1IDE2Ljc4LTMuOTgyIDMuMTQtLjg2NyA1LjEyNi0uMTQgMTMuODUzIDIuODY4IDE1LjgxNCAzLjU4N3YzLjc2YzAgLjM3Ny0uNDUyLjgtMS40NzcgMS4zMjR6IiBmaWxsPSIjYTQxZTExIi8+PHVzZSB4bGluazpocmVmPSIjQyIgeT0iLTYuNDQ5IiBmaWxsPSIjZDgyYzIwIi8+PGcgZmlsbD0iI2ZmZiI+PHBhdGggZD0iTTI5LjA5NiAyMC43MTJsLTEuMTgyLTEuOTY1LTMuNzc0LS4zNCAyLjgxNi0xLjAxNi0uODQ1LTEuNTYgMi42MzYgMS4wMyAyLjQ4Ni0uODE0LS42NzIgMS42MTIgMi41MzQuOTUtMy4yNjguMzR6TTIyLjggMjQuNjI0bDguNzQtMS4zNDItMi42NCAzLjg3MnoiLz48ZWxsaXBzZSBjeD0iMjAuNDQ0IiByeD0iNC42NzIiIHJ5PSIxLjgxMSIgY3k9IjIxLjQwMiIvPjwvZz48cGF0aCBkPSJNNDIuMTMyIDIxLjEzOGwtNS4xNyAyLjA0Mi0uMDA0LTQuMDg3eiIgZmlsbD0iIzdhMGMwMCIvPjxwYXRoIGQ9Ik0zNi45NjMgMjMuMThsLS41Ni4yMi01LjE2Ni0yLjA0MiA1LjcyMy0yLjI2NHoiIGZpbGw9IiNhZDIxMTUiLz48L2c+PGRlZnMgPjxwYXRoIGlkPSJCIiBkPSJNNDUuNTM2IDM4Ljc2NGMtMi4wMTMgMS4wNS0xMi40NCA1LjMzNy0xNC42NiA2LjQ5NHMtMy40NTMgMS4xNDYtNS4yMDcuMzA4LTEyLjg1LTUuMzItMTQuODUtNi4yNzZjLTEtLjQ3OC0xLjUyNC0uODgtMS41MjQtMS4yNnYtMy44MTNzMTQuNDQ3LTMuMTQ1IDE2Ljc4LTMuOTgyIDMuMTQtLjg2NyA1LjEyNi0uMTQgMTMuODUzIDIuODY4IDE1LjgxNCAzLjU4N3YzLjc2YzAgLjM3Ny0uNDUyLjgtMS40NzcgMS4zMjR6Ii8+PHBhdGggaWQ9IkMiIGQ9Ik00NS41MzYgMjguNzMzYy0yLjAxMyAxLjA1LTEyLjQ0IDUuMzM3LTE0LjY2IDYuNDk0cy0zLjQ1MyAxLjE0Ni01LjIwNy4zMDgtMTIuODUtNS4zMi0xNC44NS02LjI3Ni0yLjA0LTEuNjEzLS4wNzctMi4zODJsMTUuMzMyLTUuOTM1YzIuMzMyLS44MzcgMy4xNC0uODY3IDUuMTI2LS4xNHMxMi4zNSA0Ljg1MyAxNC4zMTIgNS41NyAyLjAzNyAxLjMxLjAyNCAyLjM2eiIvPjwvZGVmcz48L3N2Zz4=" preserveAspectRatio="xMidYMid meet"/>
 <text x="533" y="964" text-anchor="start" class="cardTitle">Redis server / cache backend</text>
 <text x="533" y="994" text-anchor="start" class="sub">keys, maps, streams, locks, and cached values</text>
 <text x="533" y="1016" text-anchor="start" class="sub">template data shares the same Redis runtime</text>
-<path d="M 310 380 L 310 416 Q 310 430 324 430 L 366 430 Q 380 430 380 444 L 380 566" fill="none" stroke="#356FEA" stroke-width="4.2" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowBlue)" />
-<path d="M 310 380 L 310 408 Q 310 422 324 422 L 856 422 Q 870 422 870 436 L 870 566" fill="none" stroke="#356FEA" stroke-width="4.2" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowBlue)" />
-<path d="M 775 380 L 775 512 Q 775 526 761 526 L 519 526 Q 505 526 505 540 L 505 566" fill="none" stroke="#229E5D" stroke-width="3.4" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="10 8" />
+<path d="M 310 380 L 310 416 Q 310 430 324 430 L 366 430 Q 380 430 380 444 L 380 566" fill="none" stroke="#356FEA" stroke-width="4.2" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowBlue)"/>
+<path d="M 310 380 L 310 408 Q 310 422 324 422 L 856 422 Q 870 422 870 436 L 870 566" fill="none" stroke="#356FEA" stroke-width="4.2" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowBlue)"/>
+<path d="M 775 380 L 775 512 Q 775 526 761 526 L 519 526 Q 505 526 505 540 L 505 566" fill="none" stroke="#229E5D" stroke-width="3.4" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="10 8"/>
 <polygon points="499,554 505,566 511,554" fill="#229E5D" stroke="#229E5D" stroke-width="1" stroke-linejoin="round" stroke-dasharray="none" style="stroke-dasharray:none!important" data-direct-solid-head="true"/>
-<path d="M 775 380 L 775 566" fill="none" stroke="#229E5D" stroke-width="3.4" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="10 8" />
+<path d="M 775 380 L 775 566" fill="none" stroke="#229E5D" stroke-width="3.4" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="10 8"/>
 <polygon points="769,554 775,566 781,554" fill="#229E5D" stroke="#229E5D" stroke-width="1" stroke-linejoin="round" stroke-dasharray="none" style="stroke-dasharray:none!important" data-direct-solid-head="true"/>
-<path d="M 1260 380 L 1260 566" fill="none" stroke="#EA580C" stroke-width="3.4" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="10 8" />
-
+<path d="M 1260 380 L 1260 566" fill="none" stroke="#EA580C" stroke-width="3.4" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="10 8"/>
 <polyline points="1252,548 1260,566 1268,548" fill="none" stroke="#EA580C" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" style="stroke-dasharray:none!important"/>
-<path d="M 380 734 L 380 800 Q 380 814 394 814 L 686 814 Q 700 814 700 828 L 700 918" fill="none" stroke="#229E5D" stroke-width="4.2" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowGreen)" />
-<path d="M 870 734 L 870 804 Q 870 814 860 814 L 870 814 Q 860 814 860 824 L 860 918" fill="none" stroke="#0F9B8E" stroke-width="4.2" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowTeal)" />
-<path d="M 1325 712 L 1325 806 Q 1325 820 1311 820 L 994 820 Q 980 820 980 834 L 980 918" fill="none" stroke="#EA580C" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="10 8" />
-
+<path d="M 380 734 L 380 800 Q 380 814 394 814 L 686 814 Q 700 814 700 828 L 700 918" fill="none" stroke="#229E5D" stroke-width="4.2" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowGreen)"/>
+<path d="M 870 734 L 870 804 Q 870 814 860 814 L 870 814 Q 860 814 860 824 L 860 918" fill="none" stroke="#0F9B8E" stroke-width="4.2" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowTeal)"/>
+<path d="M 1325 712 L 1325 806 Q 1325 820 1311 820 L 994 820 Q 980 820 980 834 L 980 918" fill="none" stroke="#EA580C" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="10 8"/>
 <polyline points="972,900 980,918 988,900" fill="none" stroke="#EA580C" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" style="stroke-dasharray:none!important"/>
-<rect x="350" y="1076" width="980" height="42" rx="15" fill="#FFFFFF" stroke="#D5E1EC" stroke-width="1.8" />
+<rect x="350" y="1076" width="980" height="42" rx="15" fill="#FFFFFF" stroke="#D5E1EC" stroke-width="1.8"/>
 <text x="840" y="1103" text-anchor="middle" class="note">Rule of thumb: use the umbrella for compatibility; use direct modules for leaner dependency graphs.</text>
 </svg>

--- a/docs/lessons/2026-07-10-issue-768-module-generator-parity.md
+++ b/docs/lessons/2026-07-10-issue-768-module-generator-parity.md
@@ -1,0 +1,37 @@
+# Issue #768 Module Diagram Generator Parity
+
+## Context
+
+The Redis umbrella diagram had correct visible content but lacked source-backed
+validation metadata. Running its generator exposed a second defect: the
+generator no longer reproduced the approved rounded connectors, direct heads
+for dashed routes, or icon provenance stored in the committed SVG.
+
+## Decision
+
+- Derive diagram intent from the umbrella Gradle dependency declaration, README,
+  and the separate Spring Redis serializer source.
+- Store the evidence in the generated SVG root.
+- Encode rounded routes and Cairo-safe direct arrowheads in the owning generator
+  before accepting regenerated output.
+- Keep the PNG unchanged when metadata and generator parity do not alter pixels.
+
+## Outcome
+
+The module diagram validator failure was removed without changing the rendered
+image. The generator now reproduces the committed SVG and PNG idempotently.
+
+## Verification
+
+- README diagram validator: `total=268 failed=136`
+- Target row: `failures=[]`
+- Generator and PNG render SHA checks: idempotent
+- Connector audit: `connectors=4`, `intrusions=0`, `crossings=0`
+- Geometry and endpoint audits: PASS
+- Mixed-corner audit: `q_bends=12`, `failures=0`
+
+## Future Guidance
+
+When adding validation metadata to a generated asset, regenerate before editing
+the SVG manually. If the output differs beyond metadata, repair generator parity
+first and verify that the PNG remains visually equivalent.

--- a/scripts/generate-infra-redis-diagram-01.mjs
+++ b/scripts/generate-infra-redis-diagram-01.mjs
@@ -3,6 +3,13 @@ import { readFileSync, writeFileSync } from "node:fs";
 const out = "docs/images/readme-diagrams/infra-redis-diagram-01.svg";
 const W = 1680;
 const H = 1160;
+const intent = "Explain that the Redis umbrella exports Lettuce and Redisson while Spring Data Redis serializers remain an explicit separate module choice.";
+const sources = [
+  "infra/redis/README.md",
+  "infra/redis/build.gradle.kts",
+  "spring-boot/redis/src/main/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializers.kt",
+  "spring-boot/redis/src/main/kotlin/io/bluetape4k/spring/redis/serializer/RedisSerializationContextSupport.kt",
+];
 
 const redisIcon = Buffer.from(
   readFileSync("/Users/debop/work/bluetape4k/bluetape4k-wiki/docs/icons/redis/redis-logo.svg", "utf8"),
@@ -26,6 +33,12 @@ const lines = [];
 const esc = (s) => s.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 
 function marker(id, color, open = false) {
+  if (id === "arrowOrange") {
+    lines.push(
+      `<marker id="${id}" viewBox="0 0 18 18" refX="16" refY="9" markerWidth="18" markerHeight="18" orient="auto" markerUnits="userSpaceOnUse" overflow="visible"><path d="M 3 3 L 16 9 L 3 15" fill="none" stroke="${color}" stroke-width="2.4" stroke-linecap="butt" stroke-linejoin="round" stroke-dasharray="none" style="stroke-dasharray:none"/></marker>`,
+    );
+    return;
+  }
   const fill = open ? "none" : color;
   lines.push(
     `<marker id="${id}" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="13" markerHeight="13" orient="auto" markerUnits="userSpaceOnUse"><path d="M 1 1 L 9 5 L 1 9" fill="${fill}" stroke="${color}" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none"/></marker>`,
@@ -42,7 +55,7 @@ function card({ x, y, w, h, fill, stroke, title, sub = [], icon = false, dashed 
   lines.push(`<rect x="${x}" y="${y}" width="${w}" height="${h}" rx="16" fill="${fill}" stroke="${stroke}" stroke-width="2.8"${dashed ? ' stroke-dasharray="10 8"' : ""}/>`);
   const tx = icon ? x + 88 : x + w / 2;
   if (icon) {
-    lines.push(`<image x="${x + 28}" y="${y + 28}" width="48" height="48" href="data:image/svg+xml;base64,${redisIcon}"/>`);
+    lines.push(`<image data-bluetape4k-icon="redis/redis-icon.svg" x="${x + 28}" y="${y + 28}" width="48" height="48" href="data:image/svg+xml;base64,${redisIcon}" preserveAspectRatio="xMidYMid meet"/>`);
   }
   lines.push(`<text x="${tx}" y="${y + 42}" text-anchor="${icon ? "start" : "middle"}" class="cardTitle">${esc(title)}</text>`);
   textLines(tx, y + 72, sub, "sub", icon ? "start" : "middle", 22);
@@ -54,12 +67,18 @@ function layer(x, y, w, h, title, sub) {
   if (sub) lines.push(`<text x="${x + 28}" y="${y + 68}" class="layerSub">${esc(sub)}</text>`);
 }
 
-function path(id, d, color, dashed = false, width = 4.2) {
+function path(id, d, color, dashed = false, width = 4.2, directHead = null) {
   const dash = dashed ? ' stroke-dasharray="10 8"' : "";
-  lines.push(`<path d="${d}" fill="none" stroke="${color}" stroke-width="${width}" stroke-linecap="round" stroke-linejoin="round"${dash} marker-end="url(#${id})"/>`);
+  const markerEnd = directHead ? "" : ` marker-end="url(#${id})"`;
+  lines.push(`<path d="${d}" fill="none" stroke="${color}" stroke-width="${width}" stroke-linecap="round" stroke-linejoin="round"${dash}${markerEnd}/>`);
+  if (directHead?.open) {
+    lines.push(`<polyline points="${directHead.points}" fill="none" stroke="${color}" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="none" style="stroke-dasharray:none!important"/>`);
+  } else if (directHead) {
+    lines.push(`<polygon points="${directHead.points}" fill="${color}" stroke="${color}" stroke-width="1" stroke-linejoin="round" stroke-dasharray="none" style="stroke-dasharray:none!important" data-direct-solid-head="true"/>`);
+  }
 }
 
-lines.push(`<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" role="img" aria-labelledby="title desc">`);
+lines.push(`<svg data-intent="${esc(intent)}" data-evidence="${esc(sources.join("; "))}" data-source-read="${esc(sources.join("; "))}" xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" role="img" aria-labelledby="title desc">`);
 lines.push(`<title id="title">Redis umbrella module dependency structure</title>`);
 lines.push(`<desc id="desc">bluetape4k-redis exports Lettuce and Redisson; Spring Data Redis serializers remain a separate dependency choice.</desc>`);
 lines.push(`<defs><style>
@@ -159,14 +178,14 @@ card({
   icon: true,
 });
 
-path("arrowBlue", "M 310 380 L 310 430 L 380 430 L 380 566", c.blue);
-path("arrowBlue", "M 310 380 L 310 422 L 870 422 L 870 566", c.blue);
-path("arrowGreen", "M 775 380 L 775 526 L 505 526 L 505 566", c.green, true, 3.4);
-path("arrowGreen", "M 775 380 L 775 566", c.green, true, 3.4);
-path("arrowOrange", "M 1260 380 L 1260 566", c.orange, true, 3.4);
-path("arrowGreen", "M 380 734 L 380 814 L 700 814 L 700 918", c.green);
-path("arrowTeal", "M 870 734 L 870 814 L 860 814 L 860 918", c.teal);
-path("arrowOrange", "M 1325 712 L 1325 820 L 980 820 L 980 918", c.orange, true, 3.2);
+path("arrowBlue", "M 310 380 L 310 416 Q 310 430 324 430 L 366 430 Q 380 430 380 444 L 380 566", c.blue);
+path("arrowBlue", "M 310 380 L 310 408 Q 310 422 324 422 L 856 422 Q 870 422 870 436 L 870 566", c.blue);
+path("arrowGreen", "M 775 380 L 775 512 Q 775 526 761 526 L 519 526 Q 505 526 505 540 L 505 566", c.green, true, 3.4, { points: "499,554 505,566 511,554" });
+path("arrowGreen", "M 775 380 L 775 566", c.green, true, 3.4, { points: "769,554 775,566 781,554" });
+path("arrowOrange", "M 1260 380 L 1260 566", c.orange, true, 3.4, { points: "1252,548 1260,566 1268,548", open: true });
+path("arrowGreen", "M 380 734 L 380 800 Q 380 814 394 814 L 686 814 Q 700 814 700 828 L 700 918", c.green);
+path("arrowTeal", "M 870 734 L 870 804 Q 870 814 860 814 L 870 814 Q 860 814 860 824 L 860 918", c.teal);
+path("arrowOrange", "M 1325 712 L 1325 806 Q 1325 820 1311 820 L 994 820 Q 980 820 980 834 L 980 918", c.orange, true, 3.2, { points: "972,900 980,918 988,900", open: true });
 
 lines.push(`<rect x="350" y="1076" width="980" height="42" rx="15" fill="#FFFFFF" stroke="${c.border}" stroke-width="1.8"/>`);
 lines.push(`<text x="${W / 2}" y="1103" text-anchor="middle" class="note">Rule of thumb: use the umbrella for compatibility; use direct modules for leaner dependency graphs.</text>`);


### PR DESCRIPTION
## Summary

Closes #768

- PR 제목: Fix Redis module diagram validation evidence

- attach source-backed intent and evidence to the Redis umbrella module diagram
- bring the owning generator back into parity with the committed rounded routes and Cairo-safe direct arrowheads
- preserve the rendered PNG while making repeated generation idempotent

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

This removes the only module-family failure. The remaining 136 findings belong to architecture, class, flow-state, and unclassified diagrams.

Related to #768.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

- attach source-backed intent and evidence to the Redis umbrella module diagram
- bring the owning generator back into parity with the committed rounded routes and Cairo-safe direct arrowheads
- preserve the rendered PNG while making repeated generation idempotent

### Validation

- README diagram validator: `total=268 failed=136`, target failures `0`
- generator and Cairo PNG SHA checks: idempotent
- connector audit: `markers=5 connectors=4 intrusions=0 crossings=0`
- geometry and endpoint audits: PASS
- mixed-corner audit: `q_bends=12 failures=0`
- `node --check`, `xmllint --noout`, and `git diff --check`
- rendered PNG visually inspected and byte-identical to `develop`

### Scope

This removes the only module-family failure. The remaining 136 findings belong to architecture, class, flow-state, and unclassified diagrams.

Related to #768.

### DoD Status

- [x] Redis module intent verified from README, Gradle, and serializer source
- [x] Generator and committed SVG are reproducible
- [x] Rendered PNG is unchanged
- [x] Target validator failures reduced to zero
- [x] P0/P1 6-R review findings: zero

## Validation

- README diagram validator: `total=268 failed=136`, target failures `0`
- generator and Cairo PNG SHA checks: idempotent
- connector audit: `markers=5 connectors=4 intrusions=0 crossings=0`
- geometry and endpoint audits: PASS
- mixed-corner audit: `q_bends=12 failures=0`
- `node --check`, `xmllint --noout`, and `git diff --check`
- rendered PNG visually inspected and byte-identical to `develop`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #768, milestone `1.12.0`, assignee `debop`
- PR: #1007, head `c6a2679def1fbe43055b6ff730762da0db3e4eb7`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-768-module-validation`
- Labels: `bug`, `test`, `codex`, `codex-automation`
- State: `MERGED`, merge commit `b765307f8125159155cf9b4e330cc7199c9aee8c`
- CI: - [x] Redis module intent verified from README, Gradle, and serializer source / - [x] Generator and committed SVG are reproducible

## DoD Status

- [x] Redis module intent verified from README, Gradle, and serializer source
- [x] Generator and committed SVG are reproducible
- [x] Rendered PNG is unchanged
- [x] Target validator failures reduced to zero
- [x] P0/P1 6-R review findings: zero

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1007 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `b765307f8125159155cf9b4e330cc7199c9aee8c`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
