### PR TITLE
build: allow independent module tests to run concurrently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,7 +598,6 @@ jobs:
           command: |
             ./gradlew \
               :bluetape4k-kafka:test \
-              --max-workers=1 \
               --no-configuration-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
@@ -608,7 +607,6 @@ jobs:
         run: |
           ./gradlew \
             :bluetape4k-kafka:koverXmlReport \
-            --max-workers=1 \
             --no-configuration-cache
         continue-on-error: true
 
@@ -658,7 +656,6 @@ jobs:
             ./gradlew \
               :bluetape4k-opentelemetry:test \
               :bluetape4k-kafka-logback:test \
-              --max-workers=1 \
               --no-configuration-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
@@ -669,7 +666,6 @@ jobs:
           ./gradlew \
             :bluetape4k-opentelemetry:koverXmlReport \
             :bluetape4k-kafka-logback:koverXmlReport \
-            --max-workers=1 \
             --no-configuration-cache
         continue-on-error: true
 
@@ -724,7 +720,6 @@ jobs:
               :bluetape4k-r2dbc:test \
               :bluetape4k-mongodb:test \
               :bluetape4k-cassandra:test \
-              --max-workers=1 \
               --no-configuration-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,6 +598,7 @@ jobs:
           command: |
             ./gradlew \
               :bluetape4k-kafka:test \
+              --max-workers=2 \
               --no-configuration-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
@@ -607,6 +608,7 @@ jobs:
         run: |
           ./gradlew \
             :bluetape4k-kafka:koverXmlReport \
+            --max-workers=2 \
             --no-configuration-cache
         continue-on-error: true
 
@@ -656,6 +658,7 @@ jobs:
             ./gradlew \
               :bluetape4k-opentelemetry:test \
               :bluetape4k-kafka-logback:test \
+              --max-workers=2 \
               --no-configuration-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
@@ -666,6 +669,7 @@ jobs:
           ./gradlew \
             :bluetape4k-opentelemetry:koverXmlReport \
             :bluetape4k-kafka-logback:koverXmlReport \
+            --max-workers=2 \
             --no-configuration-cache
         continue-on-error: true
 
@@ -720,6 +724,7 @@ jobs:
               :bluetape4k-r2dbc:test \
               :bluetape4k-mongodb:test \
               :bluetape4k-cassandra:test \
+              --max-workers=2 \
               --no-configuration-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -888,7 +888,7 @@ jobs:
           shell: bash
           command: |
             read -ra tasks <<< "$TEST_TASKS"
-            ./gradlew "${tasks[@]}" --max-workers=1 --no-configuration-cache
+            ./gradlew "${tasks[@]}" --no-configuration-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           TEST_TASKS: ${{ matrix.test_tasks }}
@@ -970,7 +970,7 @@ jobs:
           shell: bash
           command: |
             read -ra tasks <<< "$TEST_TASKS"
-            ./gradlew "${tasks[@]}" --max-workers=1 --no-configuration-cache
+            ./gradlew "${tasks[@]}" --no-configuration-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           TEST_TASKS: ${{ matrix.test_tasks }}
@@ -1065,7 +1065,7 @@ jobs:
           shell: bash
           command: |
             read -ra tasks <<< "$TEST_TASKS"
-            ./gradlew "${tasks[@]}" --max-workers=1 --no-configuration-cache
+            ./gradlew "${tasks[@]}" --no-configuration-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           TEST_TASKS: ${{ matrix.test_tasks }}

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -769,9 +769,10 @@ jobs:
               :bluetape4k-cache-core:test \
               :bluetape4k-opentelemetry:test \
               :bluetape4k-mock-web-server:test \
-              :bluetape4k-mock-webflux-server:test \
               :bluetape4k-r2dbc:test \
               --parallel
+            ./gradlew --no-configuration-cache \
+              :bluetape4k-mock-webflux-server:test
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -888,7 +888,7 @@ jobs:
           shell: bash
           command: |
             read -ra tasks <<< "$TEST_TASKS"
-            ./gradlew "${tasks[@]}" --no-configuration-cache
+            ./gradlew "${tasks[@]}" --max-workers=2 --no-configuration-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           TEST_TASKS: ${{ matrix.test_tasks }}
@@ -970,7 +970,7 @@ jobs:
           shell: bash
           command: |
             read -ra tasks <<< "$TEST_TASKS"
-            ./gradlew "${tasks[@]}" --no-configuration-cache
+            ./gradlew "${tasks[@]}" --max-workers=2 --no-configuration-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           TEST_TASKS: ${{ matrix.test_tasks }}
@@ -1065,7 +1065,7 @@ jobs:
           shell: bash
           command: |
             read -ra tasks <<< "$TEST_TASKS"
-            ./gradlew "${tasks[@]}" --no-configuration-cache
+            ./gradlew "${tasks[@]}" --max-workers=2 --no-configuration-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           TEST_TASKS: ${{ matrix.test_tasks }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -237,17 +237,9 @@ subprojects {
             }
         }
 
-        // 멀티 모듈들을 테스트 시에 동시에 실행되지 않게 하기 위해 Mutex 를 활용합니다.
-        abstract class TestMutexService: BuildService<BuildServiceParameters.None>
         abstract class SigningMutexService: BuildService<BuildServiceParameters.None>
         abstract class NmcpPublishMutexService: BuildService<BuildServiceParameters.None>
 
-        val testMutex = gradle.sharedServices.registerIfAbsent(
-            "test-mutex",
-            TestMutexService::class
-        ) {
-            maxParallelUsages.set(1)
-        }
         val signingMutex = gradle.sharedServices.registerIfAbsent(
             "signing-mutex",
             SigningMutexService::class
@@ -262,8 +254,6 @@ subprojects {
         }
 
         test {
-            usesService(testMutex)
-
             useJUnitPlatform()
 
             // bluetape4k.* 시스템 프로퍼티를 테스트 JVM에 전달 (골든 이미지 갱신 모드 등)

--- a/infra/kafka/build.gradle.kts
+++ b/infra/kafka/build.gradle.kts
@@ -3,6 +3,11 @@ plugins {
     kotlin("plugin.noarg")
 }
 
+tasks.withType<Test> {
+    systemProperty("java.io.tmpdir", temporaryDir)
+    systemProperty("spring.kafka.streams.state-dir", temporaryDir.resolve("kafka-streams"))
+}
+
 configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
     all {

--- a/infra/kafka4/build.gradle.kts
+++ b/infra/kafka4/build.gradle.kts
@@ -3,6 +3,11 @@ plugins {
     kotlin("plugin.noarg")
 }
 
+tasks.withType<Test> {
+    systemProperty("java.io.tmpdir", temporaryDir)
+    systemProperty("spring.kafka.streams.state-dir", temporaryDir.resolve("kafka-streams"))
+}
+
 configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
     all {


### PR DESCRIPTION
## Summary

Closes #1012

- PR 제목: build: allow independent module tests to run concurrently

- remove root TestMutexService and test-mutex
- stop binding every Test task to a global single-use service
- replace CI and Nightly single-worker limits with bounded two-worker concurrency
- isolate the two fixed-port mock application suites in Full Nightly
- isolate Kafka and Kafka4 test filesystem state per Gradle Test task
- preserve signing and NMCP publication serialization

Closes #1012

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

- remove root TestMutexService and test-mutex
- stop binding every Test task to a global single-use service
- replace CI and Nightly single-worker limits with bounded two-worker concurrency
- isolate the two fixed-port mock application suites in Full Nightly
- isolate Kafka and Kafka4 test filesystem state per Gradle Test task
- preserve signing and NMCP publication serialization

Closes #1012

### Validation

- `actionlint .github/workflows/ci.yml .github/workflows/nightly-tests.yml`
- `git diff --check`
- Default Gradle worker settings with parallel container-backed modules
  - `:bluetape4k-redisson:test`: 296 tests, 0 failures
  - `:bluetape4k-mongodb:test`: 52 tests, 0 failures
  - observed maximum concurrent Gradle test executors: 2
  - `BUILD SUCCESSFUL in 41s`
- All seven Data modules with `--max-workers=2 --no-build-cache`
  - observed maximum concurrent Gradle test executors: 2
  - `BUILD SUCCESSFUL in 1m 13s`
- Fixed-port mock applications executed sequentially with `--rerun-tasks`
  - MVC mock server: `BUILD SUCCESSFUL in 21s`
  - WebFlux mock server: `BUILD SUCCESSFUL in 16s`
- Kafka and Kafka4 executed together with `--parallel --max-workers=2 --rerun-tasks`
  - `BUILD SUCCESSFUL in 1m 8s`
- CI run 29139542112: all checks passed
  - retry attempts: 0
  - HTTPS port conflicts: 0
  - Kafka Streams state-directory conflicts: 0
- Full Nightly run 29139545468: 40/40 jobs passed
  - retry attempts: 0
  - HTTPS port conflicts: 0
  - Kafka Streams state-directory conflicts: 0
- Data CI duration: 5m 39s, down from 6m 23s in the single-worker baseline run

### DoD Status

- [x] Root test mutex removed.
- [x] CI and Nightly single-worker overrides replaced with two-worker concurrency.
- [x] Fixed-port and filesystem-backed test resources are isolated where concurrency exposed conflicts.
- [x] Signing and publication mutexes preserved.
- [x] Container-backed modules pass with overlapping test executors.
- [x] Latest PR CI passes without retry-only failures.
- [x] Full Nightly passes all jobs without retry-only failures.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/nightly-tests.yml`
- `git diff --check`
- Default Gradle worker settings with parallel container-backed modules
  - `:bluetape4k-redisson:test`: 296 tests, 0 failures
  - `:bluetape4k-mongodb:test`: 52 tests, 0 failures
  - observed maximum concurrent Gradle test executors: 2
  - `BUILD SUCCESSFUL in 41s`
- All seven Data modules with `--max-workers=2 --no-build-cache`
  - observed maximum concurrent Gradle test executors: 2
  - `BUILD SUCCESSFUL in 1m 13s`
- Fixed-port mock applications executed sequentially with `--rerun-tasks`
  - MVC mock server: `BUILD SUCCESSFUL in 21s`
  - WebFlux mock server: `BUILD SUCCESSFUL in 16s`
- Kafka and Kafka4 executed together with `--parallel --max-workers=2 --rerun-tasks`
  - `BUILD SUCCESSFUL in 1m 8s`
- CI run 29139542112: all checks passed
  - retry attempts: 0
  - HTTPS port conflicts: 0
  - Kafka Streams state-directory conflicts: 0
- Full Nightly run 29139545468: 40/40 jobs passed
  - retry attempts: 0
  - HTTPS port conflicts: 0
  - Kafka Streams state-directory conflicts: 0
- Data CI duration: 5m 39s, down from 6m 23s in the single-worker baseline run

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1012, milestone `1.12.0`, assignee `debop`
- PR: #1013, head `7e8e649a627fc77c6fe0f0f815040ada7968a23b`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `build/issue-1012-parallel-module-tests`
- Labels: `test`, `build`
- State: `MERGED`, merge commit `6d8a4067ebc6549f39fabde1c7a1604e6a74b88e`
- CI: - replace CI and Nightly single-worker limits with bounded two-worker concurrency / - isolate Kafka and Kafka4 test filesystem state per Gradle Test task / - `actionlint .github/workflows/ci.yml .github/workflows/nightly-tests.yml`

## DoD Status

- [x] Root test mutex removed.
- [x] CI and Nightly single-worker overrides replaced with two-worker concurrency.
- [x] Fixed-port and filesystem-backed test resources are isolated where concurrency exposed conflicts.
- [x] Signing and publication mutexes preserved.
- [x] Container-backed modules pass with overlapping test executors.
- [x] Latest PR CI passes without retry-only failures.
- [x] Full Nightly passes all jobs without retry-only failures.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1013 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `6d8a4067ebc6549f39fabde1c7a1604e6a74b88e`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
