### PR TITLE
Fix ResilientNearJCache putIfAbsent back-cache overwrite

### DIFF
--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientNearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientNearJCache.kt
@@ -293,11 +293,12 @@ class ResilientNearJCache<K: Any, V: Any>(
                 return null
             }
 
-            backCache.getAndPut(key, value).also { previous ->
-                if (previous == null) {
-                    stateVersion.incrementAndGet()
-                    frontCache.put(key, value)
-                }
+            if (backCache.putIfAbsent(key, value)) {
+                stateVersion.incrementAndGet()
+                frontCache.put(key, value)
+                null
+            } else {
+                backCache.get(key)
             }
         }
     }

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientNearJCacheTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientNearJCacheTest.kt
@@ -419,6 +419,15 @@ class ResilientNearJCacheTest {
     }
 
     @Test
+    fun `putIfAbsent - back cache 기존 값은 overwrite 하지 않는다`() {
+        backCache.put("cold-key", "existing")
+
+        cache.putIfAbsent("cold-key", "new") shouldBeEqualTo "existing"
+
+        backCache.get("cold-key") shouldBeEqualTo "existing"
+    }
+
+    @Test
     fun `putIfAbsent - queued remove preserves mutation order`() {
         val removeStarted = CountDownLatch(1)
         val releaseRemove = CountDownLatch(1)


### PR DESCRIPTION
## Summary

Closes #1011

- PR 제목: Fix ResilientNearJCache putIfAbsent back-cache overwrite

Fixes #1011.

`ResilientNearJCache.putIfAbsent` now preserves existing back-cache values when the front cache is cold. The blocking implementation now follows the same semantic shape as `ResilientSuspendNearJCache`: write with `putIfAbsent` first, populate the front cache only on success, and read the existing value on failure.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Root Cause

The blocking implementation used `backCache.getAndPut(key, value)` after a front-cache miss. That returned the previous back-cache value but had already overwritten the back cache with the new value, violating put-if-absent semantics and diverging from the suspend implementation.

### 기존 섹션: Risk

Narrow cache-core behavior change in one blocking put-if-absent path. No public API shape changes.

## Validation

- RED: `./gradlew :bluetape4k-cache-core:cleanTest :bluetape4k-cache-core:test --tests "io.bluetape4k.cache.nearcache.jcache.ResilientNearJCacheTest" --rerun-tasks` failed on the new back-cache overwrite regression: expected existing value, observed overwritten `new` value.
- GREEN: same targeted command passed with 33 tests.
- Module: `./gradlew :bluetape4k-cache-core:test` passed with 503 tests.
- Hygiene: `git diff --check` passed.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1011, milestone `1.12.0`, assignee `debop`
- PR: #1016, head `0b4f720c3dfbee29b4f80724f02165f3619922dd`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1011-resilient-near-jcache-put-if-absent`
- Labels: `bug`, `codex`, `cache`
- State: `MERGED`, merge commit `6695c13ca05faace7c86e08373a8ca5f51e4dcc1`
- CI: - RED: `./gradlew :bluetape4k-cache-core:cleanTest :bluetape4k-cache-core:test --tests "io.bluetape4k.cache.nearcache.jcache.ResilientNearJCacheTest" --rerun-tasks` failed on the new back-cache overwrite regression: expected existing value, observed overwritten `new` value. / - Module: `./gradlew :bluetape4k-cache-core:test` passed with 503 tests.

## DoD Status

| Gate | Status | Evidence |
| --- | --- | --- |
| Issue scope | PASS | #1011, bug/cache, milestone 1.12.0 |
| Regression RED | PASS | New `ResilientNearJCacheTest` back-cache-only putIfAbsent case failed before fix |
| Fix | PASS | Blocking implementation changed from `getAndPut` to `putIfAbsent` + `get` |
| Targeted tests | PASS | `ResilientNearJCacheTest` 33 passing |
| Module tests | PASS | `:bluetape4k-cache-core:test` 503 passing |
| Diff hygiene | PASS | `git diff --check` |
| Lesson | N/A | Single-method semantic divergence already captured by regression and issue; no new reusable workflow rule |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1016 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `6695c13ca05faace7c86e08373a8ca5f51e4dcc1`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
