### PR TITLE
test(coroutines): stress BufferedResumableCollector with SuspendedJobTester

### DIFF
--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/BufferedResumableCollector.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/BufferedResumableCollector.kt
@@ -5,12 +5,15 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /**
- * 단일 생산자/단일 소비자 버퍼를 이용해 값을 비동기 전달하는 재개 가능한 collector입니다.
+ * 복수 생산자/단일 소비자 버퍼를 이용해 값을 비동기 전달하는 재개 가능한 collector입니다.
  *
  * ## 동작/계약
- * - 내부적으로 `SpscArrayQueue`를 사용해 값을 버퍼링하고, 소비 속도가 느리면 생산자가 suspend 대기합니다.
+ * - 내부적으로 `SpscArrayQueue`를 사용하고 생산자 진입을 직렬화해 값을 버퍼링합니다.
+ * - 소비 속도가 느리면 생산자가 suspend 대기합니다.
  * - `drain` 중 collector 예외가 발생하면 `cancelled`를 설정하고 이후 `next`는 `CancellationException`으로 종료됩니다.
  * - `error` 또는 `complete` 호출 후 버퍼가 비면 drain 루프가 종료되며, `error`가 있으면 해당 예외를 전파합니다.
  * - 용량(`capacity`) 기반 고정 버퍼를 사용하며 추가 컬렉션 할당 없이 슬롯 재사용 중심으로 동작합니다.
@@ -52,6 +55,7 @@ class BufferedResumableCollector<T> private constructor(capacity: Int): Resumabl
     private val available = atomic(0L)
 
     private val valueReady = Resumable()
+    private val producerMutex = Mutex()
 
     private val output: Array<Any?> = Array(1) { null }
     private val limit: Int = capacity - (capacity shr 2)
@@ -66,7 +70,7 @@ class BufferedResumableCollector<T> private constructor(capacity: Int): Resumabl
      *
      * @param value 버퍼에 추가할 값입니다.
      */
-    suspend fun next(value: T) {
+    suspend fun next(value: T) = producerMutex.withLock {
         while (!cancelled.value) {
             if (queue.offer(value)) {
                 if (available.getAndIncrement() == 0L) {

--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/BufferedResumableCollector.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/BufferedResumableCollector.kt
@@ -9,14 +9,16 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 /**
- * 복수 생산자/단일 소비자 버퍼를 이용해 값을 비동기 전달하는 재개 가능한 collector입니다.
+ * A resumable collector that transfers values asynchronously through a multi-producer, single-consumer buffer.
  *
- * ## 동작/계약
- * - 내부적으로 `SpscArrayQueue`를 사용하고 생산자 진입을 직렬화해 값을 버퍼링합니다.
- * - 소비 속도가 느리면 생산자가 suspend 대기합니다.
- * - `drain` 중 collector 예외가 발생하면 `cancelled`를 설정하고 이후 `next`는 `CancellationException`으로 종료됩니다.
- * - `error` 또는 `complete` 호출 후 버퍼가 비면 drain 루프가 종료되며, `error`가 있으면 해당 예외를 전파합니다.
- * - 용량(`capacity`) 기반 고정 버퍼를 사용하며 추가 컬렉션 할당 없이 슬롯 재사용 중심으로 동작합니다.
+ * ## Contract
+ * - Producer admission is serialized so the internal `SpscArrayQueue` remains single-producer.
+ * - A producer suspends while the consumer cannot free buffer capacity.
+ * - All producer calls must finish before `error` or `complete` is invoked; concurrent termination is unsupported.
+ * - A collector failure during `drain` marks the collector as cancelled, and later `next` calls fail with
+ *   `CancellationException`.
+ * - After `error` or `complete`, the drain loop terminates when the buffer is empty and propagates a stored error.
+ * - The fixed-size buffer reuses its slots without allocating an additional collection.
  *
  * ```kotlin
  * val rc = BufferedResumableCollector<Int>(4)

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/BufferedResumableCollectorTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/BufferedResumableCollectorTest.kt
@@ -119,9 +119,10 @@ class BufferedResumableCollectorTest {
         val bc = BufferedResumableCollector<Int>(1)
         val producerWorkers = 8
         val rounds = 512
-        val expectedCount = rounds
+        val expectedValues = (1..rounds).toList()
+        val expectedCount = expectedValues.size
         val produced = AtomicInteger(0)
-        val consumed = AtomicInteger(0)
+        val received = mutableListOf<Int>()
 
         val producerJob = launch {
             SuspendedJobTester()
@@ -137,13 +138,13 @@ class BufferedResumableCollectorTest {
         yield()
 
         val collector = FlowCollector<Int> {
-            consumed.incrementAndGet()
+            received += it
         }
         bc.drain(collector)
         producerJob.join()
 
         produced.get() shouldBeEqualTo expectedCount
-        consumed.get() shouldBeEqualTo expectedCount
+        received.sorted() shouldBeEqualTo expectedValues
     }
 
     @Test
@@ -151,9 +152,10 @@ class BufferedResumableCollectorTest {
         val bc = BufferedResumableCollector<Int>(64)
         val producerWorkers = 8
         val rounds = 1024
-        val expectedCount = rounds
+        val expectedValues = (1..rounds).toList()
+        val expectedCount = expectedValues.size
         val produced = AtomicInteger(0)
-        val consumed = AtomicInteger(0)
+        val received = mutableListOf<Int>()
 
         val producerJob = launch {
             SuspendedJobTester()
@@ -169,12 +171,12 @@ class BufferedResumableCollectorTest {
         yield()
 
         val collector = FlowCollector<Int> {
-            consumed.incrementAndGet()
+            received += it
         }
         bc.drain(collector)
         producerJob.join()
 
         produced.get() shouldBeEqualTo expectedCount
-        consumed.get() shouldBeEqualTo expectedCount
+        received.sorted() shouldBeEqualTo expectedValues
     }
 }

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/BufferedResumableCollectorTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/BufferedResumableCollectorTest.kt
@@ -1,6 +1,8 @@
 package io.bluetape4k.coroutines.flow.extensions.subject
 
 import io.bluetape4k.coroutines.support.log
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import io.bluetape4k.junit5.coroutines.runSuspendDefault
 import io.bluetape4k.junit5.coroutines.withSingleThread
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import kotlinx.coroutines.flow.FlowCollector
@@ -10,6 +12,7 @@ import kotlinx.coroutines.yield
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.seconds
 
 class BufferedResumableCollectorTest {
 
@@ -109,5 +112,69 @@ class BufferedResumableCollectorTest {
             job.join()
         }
         counter.get() shouldBeEqualTo n
+    }
+
+    @Test
+    fun `suspended concurrent producers drain all values with small capacity`() = runSuspendDefault(timeout = 10.seconds) {
+        val bc = BufferedResumableCollector<Int>(1)
+        val producerWorkers = 8
+        val rounds = 512
+        val expectedCount = rounds
+        val produced = AtomicInteger(0)
+        val consumed = AtomicInteger(0)
+
+        val producerJob = launch {
+            SuspendedJobTester()
+                .workers(producerWorkers)
+                .rounds(rounds)
+                .add {
+                    bc.next(produced.incrementAndGet())
+                }
+                .run()
+            bc.complete()
+        }.log("producerJob")
+
+        yield()
+
+        val collector = FlowCollector<Int> {
+            consumed.incrementAndGet()
+        }
+        bc.drain(collector)
+        producerJob.join()
+
+        produced.get() shouldBeEqualTo expectedCount
+        consumed.get() shouldBeEqualTo expectedCount
+    }
+
+    @Test
+    fun `suspended concurrent producers drain all values with buffered capacity`() = runSuspendDefault(timeout = 10.seconds) {
+        val bc = BufferedResumableCollector<Int>(64)
+        val producerWorkers = 8
+        val rounds = 1024
+        val expectedCount = rounds
+        val produced = AtomicInteger(0)
+        val consumed = AtomicInteger(0)
+
+        val producerJob = launch {
+            SuspendedJobTester()
+                .workers(producerWorkers)
+                .rounds(rounds)
+                .add {
+                    bc.next(produced.incrementAndGet())
+                }
+                .run()
+            bc.complete()
+        }.log("producerJob")
+
+        yield()
+
+        val collector = FlowCollector<Int> {
+            consumed.incrementAndGet()
+        }
+        bc.drain(collector)
+        producerJob.join()
+
+        produced.get() shouldBeEqualTo expectedCount
+        consumed.get() shouldBeEqualTo expectedCount
     }
 }


### PR DESCRIPTION
## Summary

Closes #775

- PR 제목: test(coroutines): stress BufferedResumableCollector with SuspendedJobTester

Closes #775

Stress concurrent suspended producers against `BufferedResumableCollector` and preserve every emitted value at small and buffered capacities.

## Background

Milestone `1.12.0` issue #775 identified that existing tests exercised only one producer, leaving the collector's suspended multi-producer behavior unproved.

## What This Solves

- Keeps the internal `SpscArrayQueue` within its single-producer contract by serializing producer admission.
- Proves that capacities `1` and `64` preserve the complete set of values emitted by eight suspended producer workers.
- Documents that terminal signals follow all producer calls.

## Work Done

- Added a producer `Mutex` around `next()` without replacing the existing queue or consumer drain path.
- Added two `SuspendedJobTester` stress tests with exact produced-value verification.
- Added English public KDoc for the multi-producer and terminal-ordering contract.

## Validation

- `./gradlew :bluetape4k-coroutines:test --tests "io.bluetape4k.coroutines.flow.extensions.subject.BufferedResumableCollectorTest" --rerun-tasks`: PASS (6/6)
- `./gradlew :bluetape4k-coroutines:test --rerun-tasks`: PASS (568/568)
- `./gradlew detekt`: PASS (`NO-SOURCE`; compile/test tasks are the diagnostics fallback)
- `git diff --check origin/develop...HEAD`: PASS

## Review Notes

- P0/P1: 0 after repairing the terminal-ordering contract found by the independent concurrency review.
- P2/P3: exact-value assertions and English KDoc fixed before publication.
- Review evidence: workflow run `20260714T153615Z-d313fb64`, exact head `a4d9f46adcc7d48b9d3995a7d6433bd1435fce5c`.

## Metadata

- Issue: #775, milestone `1.12.0`, assignee `debop`
- PR: #1017, head `a4d9f46adcc7d48b9d3995a7d6433bd1435fce5c`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-775-buffered-resumable-collector-stress`
- Labels: `test`, `coroutines`
- State: `MERGED`, merge commit `35663ef6faee8f21522584cc7e1897426d3602dc`
- CI: Stress concurrent suspended producers against `BufferedResumableCollector` and preserve every emitted value at small and buffered capacities. / Milestone `1.12.0` issue #775 identified that existing tests exercised only one producer, leaving the collector's suspended multi-producer behavior unproved. / - Proves that capacities `1` and `64` preserve the complete set of values emitted by eight suspended producer workers.

## DoD Status

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CL-01 | Checklist reconstructed before further mutation after guidance refresh | PASS | Router/common/leaf rows instantiated | none |
| CL-02 | Classified every row | PASS | Required and N/A rows below | none |
| CL-03 | Preserved dependency order | PASS | Pre-PR proof completed before push | none |
| CL-04 | Recorded fresh evidence | PASS | Commands and workflow receipts | none |
| CL-05 | Failed closed on review P1 | PASS | PR blocked until repair and rerun | none |
| CL-06 | Repaired late machine-evidence initialization | PASS | Run `20260714T153615Z-d313fb64` completed | none |
| CL-07 | Refreshed external-action holds | PASS | Exact repo/base/head verified before push and PR | refresh again before merge |
| CL-08 | Reconciled counts | PASS | 53/57, N/A 6, Blocked 0 | refresh after merge |
| WF-01 | Classified work | PASS | Type B, one module, two files, no dependency | none |
| WF-02 | Wrote concrete plan | PASS | issue #775 plan shown in active thread | none |
| WF-03 | Obtained plan approval | PASS | user: `진행해` | none |
| WF-04 | Loaded execution contracts | PASS | fast-track, common gates, Kotlin/testing/coroutines | none |
| WF-04A | Initialized machine evidence | PASS | completed workflow run `20260714T153615Z-d313fb64` | none |
| WF-05 | Executed dependent gates | PASS | review P1 repaired before publication | none |
| WF-06 | Repaired weak gates | PASS | tests and review rerun on `a4d9f46ad` | none |
| B-01 | Confirmed Type B boundary | PASS | existing coroutines module; two coupled files | none |
| B-02 | Inspected existing patterns | PASS | `SuspendedJobTester`, `Resumable`, SPSC queue anchors | none |
| B-03 | Reviewed lightweight design | PASS | serialize producer admission; preserve drain path | none |
| B-04 | Implemented narrowly | PASS | 2 files, 82 additions, 7 deletions | none |
| B-05 | Proved changed behavior | PASS | targeted 6/6; module 568/568 | none |
| B-06 | Reviewed final blast radius | PASS | P0=0, P1=0 on exact head | none |
| B-07 | Evaluate durable lesson | N/A | local contract captured in KDoc/tests; no cross-module recovery or ops guidance | none |
| B-08 | Complete PR delivery and CI | PASS | PR #1017 checks successful on exact head; reviews 0; threads 0 | none |
| B-09 | Report merge readiness | PASS | exact PR/head and gate counts reconciled | wait at CG-16 |
| B-10 | Close out after merge approval | PENDING | depends on fresh CG-16 approval | stop after CG-15 |
| CG-01 | Re-read authority | PASS | current AGENTS, skills, status, diff, request | none |
| CG-02 | Queried current evidence | PASS | context-mode plus live issue #775 | none |
| CG-03 | Protected user work | PASS | clean isolated worktree; clean develop checkout | none |
| CG-04 | Applied policy boundaries | PASS | Kotlin/KDoc/permissions scoped to two files | none |
| CG-05 | Reused ecosystem patterns | PASS | `SuspendedJobTester`, `Mutex`, existing SPSC queue | none |
| CG-06 | Proved public/docs contracts | PASS | English class KDoc with terminal ordering | none |
| CG-07 | Ran targeted proof | PASS | 6/6 targeted and 568/568 module tests | none |
| CG-08 | Serialize heavyweight checks | N/A | no container, DB, native, JNI, emulator, or benchmark work | none |
| CG-09 | Evaluate lesson gate | N/A | behavior-specific learning is fully represented by committed KDoc/tests; no separate ops artifact | none |
| CG-10 | Converged pre-PR proof | PASS | clean exact head `a4d9f46ad` with P0/P1 zero | none |
| CG-11 | Verified PR authority | PASS | repo `bluetape4k/bluetape4k-projects`, base `develop`, authorized head | none |
| CG-12 | Published exact head | PASS | local/remote `a4d9f46adcc7d48b9d3995a7d6433bd1435fce5c` | none |
| CG-13 | Created and verified PR | PASS | PR #1017; live metadata/body verification follows update | none |
| CG-14 | Pass CI and live review | PASS | required checks success; reviews 0; threads 0; P0/P1 0 | none |
| CG-15 | Report merge-ready | PASS | PR #1017 at exact head; 53/57 checks PASS | wait at CG-16 |
| CG-16 | Obtain fresh merge approval | PENDING | must follow CG-15 report | wait for user |
| CG-17 | Execute and verify merge | PENDING | depends on CG-16 | merge only after fresh approval |
| CG-18 | Synchronize and clean up | PENDING | depends on CG-17 | sync develop and remove merged worktree |
| KT-01 | Loaded triggered Kotlin guidance | PASS | testing and coroutine references loaded | none |
| KT-02 | Inspected impact and reuse | PASS | collector, tests, helper, queue contract | none |
| KT-03 | Enforced Kotlin contracts | PASS | no unsafe constructs; terminal order documented | none |
| KT-04 | Ran Kotlin validation | PASS | targeted/module compile and tests; diff check | none |
| KT-05 | Rendered Kotlin checklist | PASS | KT-FIN rows below; P0/P1 zero | none |
| KT-TEST-01 | Used project test idioms | PASS | JUnit 5, bluetape assertions, descriptive names | none |
| KT-TEST-02 | Proved concurrency | PASS | `SuspendedJobTester`, capacities 1 and 64 | none |
| KT-TEST-03 | Reuse infrastructure fixtures | N/A | no infrastructure fixture or Testcontainers usage | none |
| KT-TEST-04 | Cover HTTP lifecycle | N/A | no HTTP/HC5 surface | none |
| KT-TEST-05 | Ran targeted then module tests | PASS | 6/6 then 568/568 with rerun tasks | none |
| KT-FIN-01 | Inspected current surface | PASS | source, tests, helper, KDoc | none |
| KT-FIN-02 | Preserved validation contracts | PASS | no caller validation change | none |
| KT-FIN-03 | Excluded unsafe constructs | PASS | no new `!!`, runCatching, GlobalScope, monitors | none |
| KT-FIN-04 | Proved lifecycle ownership | PASS | producer completion precedes terminal signal | none |
| KT-FIN-05 | Verify Exposed boundaries | N/A | no Exposed code touched | none |
| KT-FIN-06 | Applied triggered references | PASS | coroutine/testing checks completed | none |
| KT-FIN-07 | Proved named test behavior | PASS | exact sorted value set asserted | none |
| KT-FIN-08 | Synchronized public docs | PASS | English class KDoc matches behavior | none |
| KT-FIN-09 | Cleared diagnostics | PASS | compile/test clean; root Detekt NO-SOURCE | none |
| KT-FIN-10 | Ran fresh validation | PASS | targeted 6/6, module 568/568, diff check | none |
| KT-FIN-11 | Converged final scope | PASS | two intended files; P0=0/P1=0 | none |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1017 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `35663ef6faee8f21522584cc7e1897426d3602dc`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
