### PR TITLE
fix(coroutines): serialize PublishSubject signals under concurrent emit

### DIFF
--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/PublishSubject.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/PublishSubject.kt
@@ -9,13 +9,15 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.AbstractFlow
 import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /**
  * 구독 시점 이후에 emit된 값만 전달하는 Publish Subject 구현입니다.
  *
  * ## 동작/계약
  * - 과거 값은 재생(replay)하지 않고, 현재 등록된 collector에게만 값을 전달합니다.
- * - `emit`/`complete`/`emitError`는 collector 배열을 원자적으로 교체하며, 수신 객체 내부 상태를 변경합니다.
+ * - `emit`/`complete`/`emitError`는 신호 전달을 직렬화하고 collector 배열을 원자적으로 교체합니다.
  * - `emitError`는 최초 1회만 적용되며 이후 신규 collector의 collect 시 저장된 예외가 다시 전파될 수 있습니다.
  * - collector 추가/삭제 시 배열 복사가 발생하므로 collector 변경 비용은 collector 수에 비례합니다.
  *
@@ -39,6 +41,8 @@ class PublishSubject<T>: AbstractFlow<T>(), SubjectApi<T> {
 
     private val collectors: AtomicRef<Array<ResumableCollector<T>>> =
         atomic(EMPTY as Array<ResumableCollector<T>>)
+
+    private val signalMutex = Mutex()
 
     @Volatile
     private var error: Throwable? = null
@@ -96,6 +100,7 @@ class PublishSubject<T>: AbstractFlow<T>(), SubjectApi<T> {
      * 현재 등록된 모든 collector에게 값을 전파합니다.
      *
      * ## 동작/계약
+     * - 동시 호출은 Subject 단위로 직렬화해 각 collector의 단일 producer 계약을 보존합니다.
      * - 호출 시점 collector 스냅샷에 대해 순회하며 `next(value)`를 호출합니다.
      * - 전달 중 `CancellationException`이 발생한 collector는 목록에서 제거합니다.
      * - 구독자가 없으면 아무 동작 없이 반환하며 값을 버퍼링하지 않습니다.
@@ -112,7 +117,7 @@ class PublishSubject<T>: AbstractFlow<T>(), SubjectApi<T> {
      *
      * @param value 전파할 값입니다.
      */
-    override suspend fun emit(value: T) {
+    override suspend fun emit(value: T) = signalMutex.withLock {
         collectors.value.forEach { collector ->
             try {
                 collector.next(value)
@@ -127,6 +132,7 @@ class PublishSubject<T>: AbstractFlow<T>(), SubjectApi<T> {
      * Subject를 오류 종료하고 현재 collector들에게 오류를 전파합니다.
      *
      * ## 동작/계약
+     * - 진행 중인 값 전파와 다른 종료 신호가 끝날 때까지 Subject 단위로 대기합니다.
      * - 최초 1회 호출에서만 `error`를 저장하고 collector 배열을 종료 상태로 교체합니다.
      * - 이미 종료된 이후 재호출하면 추가 동작 없이 반환합니다.
      * - 이후 신규 collect는 저장된 오류를 다시 전파할 수 있습니다.
@@ -139,9 +145,9 @@ class PublishSubject<T>: AbstractFlow<T>(), SubjectApi<T> {
      *
      * @param ex 전파할 종료 원인 예외입니다.
      */
-    override suspend fun emitError(ex: Throwable?) {
+    override suspend fun emitError(ex: Throwable?) = signalMutex.withLock {
         if (areEqualAsAny(collectors.value, TERMINATED)) {
-            return
+            return@withLock
         }
 
         this.error = ex
@@ -159,11 +165,12 @@ class PublishSubject<T>: AbstractFlow<T>(), SubjectApi<T> {
      * Subject를 정상 종료하고 현재 collector에게 완료 신호를 보냅니다.
      *
      * ## 동작/계약
+     * - 진행 중인 값 전파와 다른 종료 신호가 끝날 때까지 Subject 단위로 대기합니다.
      * - collector 배열을 종료 상태로 교체한 뒤 각 collector에 `complete()`를 호출합니다.
      * - 완료 이후 신규 collect는 즉시 반환될 수 있으며 과거 값은 재생되지 않습니다.
      * - 종료 전 등록된 collector가 없으면 상태 전환만 수행하고 반환합니다.
      */
-    override suspend fun complete() {
+    override suspend fun complete() = signalMutex.withLock {
         val colls = collectors.getAndSet(TERMINATED as Array<ResumableCollector<T>>)
         colls.forEach { collector ->
             try {

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/PublishSubjectTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/PublishSubjectTest.kt
@@ -1,11 +1,21 @@
 package io.bluetape4k.coroutines.flow.extensions.subject
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.coroutines.flow.extensions.log
 import io.bluetape4k.coroutines.support.log
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import io.bluetape4k.junit5.coroutines.runSuspendDefault
 import io.bluetape4k.junit5.coroutines.withSingleThread
 import io.bluetape4k.junit5.awaitility.untilSuspending
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.trace
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.onEach
@@ -13,18 +23,14 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeFalse
-import io.bluetape4k.assertions.shouldBeInstanceOf
-import io.bluetape4k.assertions.shouldBeTrue
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.Test
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.cancellation.CancellationException
-import io.bluetape4k.assertions.assertFailsWith
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class PublishSubjectTest {
 
@@ -107,28 +113,32 @@ class PublishSubjectTest {
     }
 
     @Test
-    fun `emit and collect many items`() = runTest {
-        withSingleThread { dispatcher ->
-            val subject = PublishSubject<Int>()
-            val n = 10_000
-            val counter = AtomicInteger(0)
+    fun `concurrent producers emit all items to one collector`() = runSuspendDefault(timeout = 10.seconds) {
+        val subject = PublishSubject<Int>()
+        val producerWorkers = 8
+        val rounds = 1024
+        val expectedValues = (1..rounds).toList()
+        val produced = AtomicInteger(0)
+        val received = ConcurrentLinkedQueue<Int>()
 
-            val job = launch(dispatcher) {
-                subject.collect {
-                    counter.incrementAndGet()
-                }
-            }
-
-            subject.awaitCollectors(1)
-
-            repeat(n) { i ->
-                subject.emit(i)
-            }
-            subject.complete()
-            job.join()
-
-            counter.get() shouldBeEqualTo n
+        val collectorJob = launch {
+            subject.collect(received::add)
         }
+
+        subject.awaitCollectors(1)
+
+        SuspendedJobTester()
+            .workers(producerWorkers)
+            .rounds(rounds)
+            .add { subject.emit(produced.incrementAndGet()) }
+            .run()
+        subject.complete()
+        collectorJob.join()
+
+        produced.get() shouldBeEqualTo rounds
+        received.sorted() shouldBeEqualTo expectedValues
+        subject.collectorCount shouldBeEqualTo 0
+        subject.hasCollectors.shouldBeFalse()
     }
 
     @Test
@@ -161,37 +171,77 @@ class PublishSubjectTest {
     }
 
     @Test
-    fun `multiple collectors`() = runTest {
+    fun `concurrent producers broadcast all items to multiple collectors`() = runSuspendDefault(timeout = 10.seconds) {
         val subject = PublishSubject<Int>()
-        val n = 10_000
-        val counter1 = AtomicInteger(0)
-        val counter2 = AtomicInteger(0)
+        val producerWorkers = 8
+        val rounds = 1024
+        val expectedValues = (1..rounds).toList()
+        val produced = AtomicInteger(0)
+        val received1 = ConcurrentLinkedQueue<Int>()
+        val received2 = ConcurrentLinkedQueue<Int>()
 
-        withSingleThread { dispatcher ->
-            val job1 = launch(dispatcher) {
-                subject.collect {
-                    counter1.incrementAndGet()
+        val collectorJob1 = launch {
+            subject.collect(received1::add)
+        }.log("collectorJob1")
+        val collectorJob2 = launch {
+            subject.collect(received2::add)
+        }.log("collectorJob2")
+
+        subject.awaitCollectors(2)
+
+        SuspendedJobTester()
+            .workers(producerWorkers)
+            .rounds(rounds)
+            .add { subject.emit(produced.incrementAndGet()) }
+            .run()
+        subject.complete()
+        collectorJob1.join()
+        collectorJob2.join()
+
+        produced.get() shouldBeEqualTo rounds
+        received1.sorted() shouldBeEqualTo expectedValues
+        received2.sorted() shouldBeEqualTo expectedValues
+        received1.toList() shouldBeEqualTo received2.toList()
+        subject.collectorCount shouldBeEqualTo 0
+        subject.hasCollectors.shouldBeFalse()
+    }
+
+    @Test
+    fun `terminal signal waits for in-flight concurrent emit`() = runSuspendDefault(timeout = 10.seconds) {
+        val subject = PublishSubject<Int>()
+        val received = ConcurrentLinkedQueue<Int>()
+        val firstValueStarted = CompletableDeferred<Unit>()
+        val releaseFirstValue = CompletableDeferred<Unit>()
+
+        val collectorJob = launch {
+            subject.collect { value ->
+                received.add(value)
+                if (value == 1) {
+                    firstValueStarted.complete(Unit)
+                    releaseFirstValue.await()
                 }
-            }.log("job1")
-
-            val job2 = launch(dispatcher) {
-                subject.collect {
-                    counter2.incrementAndGet()
-                }
-            }.log("job2")
-
-            subject.awaitCollectors(2)
-
-            repeat(n) {
-                subject.emit(it)
             }
-            subject.complete()
-
-            job1.join()
-            job2.join()
         }
-        counter1.get() shouldBeEqualTo n
-        counter2.get() shouldBeEqualTo n
+
+        subject.awaitCollectors(1)
+        subject.emit(1)
+        firstValueStarted.await()
+
+        val pendingEmit = async(start = CoroutineStart.UNDISPATCHED) {
+            subject.emit(2)
+        }
+        val terminal = async(start = CoroutineStart.UNDISPATCHED) {
+            subject.complete()
+        }
+
+        releaseFirstValue.complete(Unit)
+        pendingEmit.await()
+        terminal.await()
+        collectorJob.join()
+
+        received.toList() shouldBeEqualTo listOf(1, 2)
+        subject.collectorCount shouldBeEqualTo 0
+        subject.hasCollectors.shouldBeFalse()
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #776

- PR 제목: fix(coroutines): serialize PublishSubject signals under concurrent emit

- Stress `PublishSubject` with eight concurrent `SuspendedJobTester` producers for one and two collectors.
- Serialize value and terminal signals so the single-producer `ResumableCollector` handshake cannot be entered concurrently.
- Verify exact value preservation, identical broadcast order, collector cleanup, and terminal ordering behind an in-flight emit.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Root Cause

`PublishSubject.emit()` forwarded concurrent callers directly into `ResumableCollector`, whose handshake permits only one producer waiter. Overlapping producers timed out, and a terminal signal racing a queued emit raised `IllegalStateException`.

### 기존 섹션: Verification

- RED: both concurrent producer scenarios timed out after 10 seconds before serialization.
- RED: the terminal race failed with `Only one thread can await a Resumable`.
- `./gradlew detekt :bluetape4k-coroutines:test --tests 'io.bluetape4k.coroutines.flow.extensions.subject.PublishSubjectTest' --rerun-tasks`
- `./gradlew :bluetape4k-coroutines:test --rerun-tasks` (569 tests)
- Concurrent producer tests repeated three times successfully.
- `git diff --check`

Fixes #776

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #776, milestone `1.12.0`, assignee `debop`
- PR: #1018, head `f0e87ecd5f4a0c2e3f947679435806ce0c7cf4c8`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-776-publish-subject-stress`
- Labels: `test`, `coroutines`
- State: `MERGED`, merge commit `f93c286d7652028e7061cee06fb9c66c2b718b11`
- CI: `PublishSubject.emit()` forwarded concurrent callers directly into `ResumableCollector`, whose handshake permits only one producer waiter. Overlapping producers timed out, and a terminal signal racing a queued emit raised `IllegalStateException`. / - `./gradlew detekt :bluetape4k-coroutines:test --tests 'io.bluetape4k.coroutines.flow.extensions.subject.PublishSubjectTest' --rerun-tasks` / - `./gradlew :bluetape4k-coroutines:test --rerun-tasks` (569 tests)

## DoD Status

- [x] Concurrent one-collector producer stress
- [x] Concurrent two-collector broadcast stress
- [x] Exact values, broadcast order, and collector cleanup verified
- [x] Terminal race regression covered
- [x] Targeted and module tests passing
- [x] Independent review: P0=0, P1=0
- [x] Required GitHub CI checks passing

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1018 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `f93c286d7652028e7061cee06fb9c66c2b718b11`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
