### PR TITLE
fix(coroutines): preserve MulticastSubject concurrent fanout

### DIFF
--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/MulticastSubject.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/MulticastSubject.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.AbstractFlow
 import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /**
  * 지정한 collector 수가 준비될 때까지 producer를 대기시키는 multicast Subject입니다.
@@ -18,6 +20,7 @@ import kotlinx.coroutines.flow.FlowCollector
  * ## 동작/계약
  * - 생성 시 지정한 collector 수(`expectedCollectorSize`)가 모두 등록되기 전까지 `emit`은 suspend 대기합니다.
  * - 기준 수를 한 번 충족한 이후에는 이후 `emit` 호출에서 추가 대기를 하지 않습니다.
+ * - collector 등록 대기 이후 `emit`/`complete`/`emitError` 신호는 Subject 단위로 직렬화됩니다.
  * - `emit`된 값은 현재 등록된 collector 전원에게 전달되며, 취소된 collector는 제거됩니다.
  * - collector 추가/제거는 배열 복사 기반(CAS)으로 처리되어 collector 변동 비용은 collector 수에 비례합니다.
  *
@@ -55,6 +58,8 @@ class MulticastSubject<T> private constructor(
 
     private val producer = Resumable()
 
+    private val signalMutex = Mutex()
+
     private val remainingCollectors = atomic(expectedCollectorSize)
 
     @Volatile
@@ -85,6 +90,7 @@ class MulticastSubject<T> private constructor(
      *
      * ## 동작/계약
      * - `remainingCollectors > 0`이면 최소 구독자 수가 채워질 때까지 suspend 대기합니다.
+     * - collector 등록 대기 이후 동시 호출은 Subject 단위로 직렬화해 각 collector의 단일 producer 계약을 보존합니다.
      * - 대기 조건이 풀리면 호출 시점 collector 전원에게 `next(value)`를 호출합니다.
      * - 전달 중 `CancellationException`이 난 collector는 목록에서 제거됩니다.
      *
@@ -92,12 +98,14 @@ class MulticastSubject<T> private constructor(
      */
     override suspend fun emit(value: T) {
         awaitCollectors()
-        collectors.value.forEach { collector ->
-            try {
-                collector.next(value)
-            } catch (e: CancellationException) {
-                currentCoroutineContext().ensureActive() // 부모 취소 시 rethrow
-                remove(collector) // 이 collector만 개별 취소됨
+        signalMutex.withLock {
+            collectors.value.forEach { collector ->
+                try {
+                    collector.next(value)
+                } catch (e: CancellationException) {
+                    currentCoroutineContext().ensureActive() // 부모 취소 시 rethrow
+                    remove(collector) // 이 collector만 개별 취소됨
+                }
             }
         }
     }
@@ -106,6 +114,8 @@ class MulticastSubject<T> private constructor(
      * Subject를 오류 종료하고 현재 collector에게 예외를 전달합니다.
      *
      * ## 동작/계약
+     * - 진행 중인 값 전파와 다른 종료 신호가 끝날 때까지 Subject 단위로 대기합니다.
+     * - 최초 terminal 신호만 적용하며 이미 종료된 이후 재호출하면 추가 동작 없이 반환합니다.
      * - `terminated`에 예외를 저장한 뒤 collector 배열을 종료 상태로 교체합니다.
      * - 교체 시점의 collector 각각에 `error(ex)`를 호출합니다.
      * - 종료 이후 신규 collect는 등록에 실패하고 저장된 예외가 재전파될 수 있습니다.
@@ -113,7 +123,11 @@ class MulticastSubject<T> private constructor(
      * @param ex 종료 원인 예외입니다.
      */
     @Suppress("UNCHECKED_CAST")
-    override suspend fun emitError(ex: Throwable?) {
+    override suspend fun emitError(ex: Throwable?) = signalMutex.withLock {
+        if (areEqualAsAny(collectors.value, TERMINATED)) {
+            return@withLock
+        }
+
         terminated = ex
         collectors.getAndSet(TERMINATED as Array<ResumableCollector<T>>)
             .forEach { collector ->
@@ -130,11 +144,17 @@ class MulticastSubject<T> private constructor(
      * Subject를 정상 종료하고 현재 collector에게 완료를 전달합니다.
      *
      * ## 동작/계약
+     * - 진행 중인 값 전파와 다른 종료 신호가 끝날 때까지 Subject 단위로 대기합니다.
+     * - 최초 terminal 신호만 적용하며 이미 종료된 이후 재호출하면 추가 동작 없이 반환합니다.
      * - 내부 종료 원인을 `DONE`으로 기록하고 collector 배열을 종료 상태로 교체합니다.
      * - 교체 시점의 collector 각각에 `complete()`를 호출합니다.
      */
     @Suppress("UNCHECKED_CAST")
-    override suspend fun complete() {
+    override suspend fun complete() = signalMutex.withLock {
+        if (areEqualAsAny(collectors.value, TERMINATED)) {
+            return@withLock
+        }
+
         terminated = DONE
         collectors.getAndSet(TERMINATED as Array<ResumableCollector<T>>)
             .forEach { collector ->

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/MulticastSubjectTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/MulticastSubjectTest.kt
@@ -1,18 +1,26 @@
 package io.bluetape4k.coroutines.flow.extensions.subject
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.coroutines.flow.extensions.log
 import io.bluetape4k.coroutines.support.log
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import io.bluetape4k.junit5.coroutines.runSuspendDefault
 import io.bluetape4k.junit5.coroutines.withSingleThread
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
-import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class MulticastSubjectTest {
 
@@ -65,6 +73,105 @@ class MulticastSubjectTest {
             job.join()
         }
         counter.get() shouldBeEqualTo n
+    }
+
+    @Test
+    fun `concurrent producers broadcast all items to two collectors`() = runSuspendDefault(timeout = 10.seconds) {
+        val subject = MulticastSubject<Int>(2)
+        val producerWorkers = 8
+        val rounds = 1024
+        val expectedValues = (1..rounds).toList()
+        val produced = AtomicInteger(0)
+        val received1 = ConcurrentLinkedQueue<Int>()
+        val received2 = ConcurrentLinkedQueue<Int>()
+
+        val collectorJob1 = launch {
+            subject.collect(received1::add)
+        }.log("collectorJob1")
+        val collectorJob2 = launch {
+            subject.collect(received2::add)
+        }.log("collectorJob2")
+
+        subject.awaitCollectors(2)
+
+        SuspendedJobTester()
+            .workers(producerWorkers)
+            .rounds(rounds)
+            .add { subject.emit(produced.incrementAndGet()) }
+            .run()
+        subject.complete()
+        collectorJob1.join()
+        collectorJob2.join()
+
+        produced.get() shouldBeEqualTo rounds
+        received1.sorted() shouldBeEqualTo expectedValues
+        received2.sorted() shouldBeEqualTo expectedValues
+        received1.toList() shouldBeEqualTo received2.toList()
+        subject.collectorCount shouldBeEqualTo 0
+        subject.hasCollectors.shouldBeFalse()
+    }
+
+    @Test
+    fun `terminal signal waits for in-flight multicast emit`() = runSuspendDefault(timeout = 10.seconds) {
+        val subject = MulticastSubject<Int>(2)
+        val received1 = ConcurrentLinkedQueue<Int>()
+        val received2 = ConcurrentLinkedQueue<Int>()
+        val firstValueStarted = CompletableDeferred<Unit>()
+        val releaseFirstValue = CompletableDeferred<Unit>()
+
+        val collectorJob1 = launch {
+            subject.collect { value ->
+                received1.add(value)
+                if (value == 1) {
+                    firstValueStarted.complete(Unit)
+                    releaseFirstValue.await()
+                }
+            }
+        }
+        val collectorJob2 = launch {
+            subject.collect(received2::add)
+        }
+
+        subject.awaitCollectors(2)
+        subject.emit(1)
+        firstValueStarted.await()
+
+        val pendingEmit = async(start = CoroutineStart.UNDISPATCHED) {
+            subject.emit(2)
+        }
+        val terminal = async(start = CoroutineStart.UNDISPATCHED) {
+            subject.complete()
+        }
+
+        releaseFirstValue.complete(Unit)
+        pendingEmit.await()
+        terminal.await()
+        collectorJob1.join()
+        collectorJob2.join()
+
+        received1.toList() shouldBeEqualTo listOf(1, 2)
+        received2.toList() shouldBeEqualTo listOf(1, 2)
+        subject.collectorCount shouldBeEqualTo 0
+        subject.hasCollectors.shouldBeFalse()
+    }
+
+    @Test
+    fun `first terminal signal wins`() = runTest {
+        val failure = IllegalStateException("boom")
+        val errorSubject = MulticastSubject<Int>(1)
+
+        errorSubject.emitError(failure)
+        errorSubject.complete()
+
+        assertFailsWith<IllegalStateException> {
+            errorSubject.collect {}
+        } shouldBeEqualTo failure
+
+        val completedSubject = MulticastSubject<Int>(1)
+        completedSubject.complete()
+        completedSubject.emitError(failure)
+
+        completedSubject.collect {}
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #777

- PR 제목: fix(coroutines): preserve MulticastSubject concurrent fanout

- serialize `MulticastSubject` value and terminal signals after the collector gate
- preserve the first terminal outcome across repeated `complete` and `emitError` calls
- add two-collector `SuspendedJobTester` fanout stress and deterministic terminal-order regression coverage
- keep the existing one- and two-collector gating tests intact

Fixes #777

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- targeted stress test: reproduced 10-second timeout before the fix, then passed
- `MulticastSubjectTest`: 6 passing
- `:bluetape4k-coroutines:cleanTest :bluetape4k-coroutines:test --rerun-tasks`: 572 passing
- concurrent fanout stress: 3 consecutive passes
- `detekt` plus target test class: passed
- `git diff --check`: passed

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- independent delta review: P0=0, P1=0
- residual risk: an emit waiting before the collector gate can still remain suspended if termination occurs first; this predates the post-gate fanout scope of #777

## Metadata

- Issue: #777, milestone `1.12.0`, assignee `debop`
- PR: #1019, head `cc463ee8205947ffdb4ce8212b91df12cbb33622`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-777-multicast-subject-stress`
- Labels: `test`, `coroutines`
- State: `MERGED`, merge commit `0a9c43b4c6ab7a75d226d1c638c7513729e6570c`
- CI: - `detekt` plus target test class: passed

## DoD Status

- [x] Two collector fanout stress uses `SuspendedJobTester`
- [x] Each collector receives the exact expected values in identical broadcast order
- [x] Existing collector-gating tests are preserved
- [x] Signal and terminal ordering regressions are covered
- [x] Targeted, module, repeated stress, static analysis, and independent review gates pass

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1019 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `0a9c43b4c6ab7a75d226d1c638c7513729e6570c`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
