### PR TITLE
fix(coroutines): preserve BehaviorSubject concurrent signals

### DIFF
--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/BehaviorSubject.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/BehaviorSubject.kt
@@ -2,15 +2,15 @@ package io.bluetape4k.coroutines.flow.extensions.subject
 
 import io.bluetape4k.coroutines.flow.extensions.Resumable
 import io.bluetape4k.logging.coroutines.KLoggingChannel
-import io.bluetape4k.logging.error
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.AbstractFlow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.coroutines.coroutineContext
 
 /**
@@ -19,6 +19,7 @@ import kotlin.coroutines.coroutineContext
  * ## 동작/계약
  * - 새 collector는 구독 즉시 최신 값(있다면)을 먼저 받고 이후 실시간 값을 받습니다.
  * - 기본 생성 시 초기값이 없고, `invoke(initialValue)`로 초기값을 줄 수 있습니다.
+ * - `emit`/`complete`/`emitError`는 Subject 단위로 직렬화됩니다.
  * - `complete()`/`emitError()` 이후에는 종료 상태가 되며 이후 emit은 무시됩니다.
  * - 다중 collector를 허용하며 collector별 동기화 객체를 유지하므로 collector 수에 비례한 할당이 발생합니다.
  *
@@ -61,6 +62,8 @@ class BehaviorSubject<T> private constructor(
     }
 
     private val collectors = atomic<Array<InnerCollector>>(EMPTY)
+
+    private val signalMutex = Mutex()
 
     @Volatile
     private var error: Throwable? = null
@@ -134,7 +137,9 @@ class BehaviorSubject<T> private constructor(
      *
      * ## 동작/계약
      * - 종료 상태(`DONE`)면 호출을 무시합니다.
+     * - 동시 호출은 Subject 단위로 직렬화해 linked node와 collector 알림 순서를 보존합니다.
      * - 최신 노드를 교체한 뒤 collector들을 깨워 새 값을 전달합니다.
+     * - 상태 반영 후 producer가 취소되더라도 아직 알리지 못한 collector에는 wake-up을 남깁니다.
      * - collector가 취소되면 내부 목록에서 제거합니다.
      *
      * ```kotlin
@@ -144,31 +149,26 @@ class BehaviorSubject<T> private constructor(
      * ```
      * @param value 방출할 값입니다.
      */
-    override suspend fun emit(value: T) {
-        if (current == DONE)
-            return
+    override suspend fun emit(value: T) = signalMutex.withLock {
+        if (current == DONE) {
+            return@withLock
+        }
 
         val next = Node(value)
         current.set(next)
         current = next
 
-        collectors.value.forEach { innerCollector ->
-            try {
-                innerCollector.consumeReady.await()
-                innerCollector.resume()
-            } catch (e: CancellationException) {
-                currentCoroutineContext().ensureActive() // 부모 취소 시 rethrow
-                remove(innerCollector) // 이 collector만 개별 취소됨
-            }
-        }
+        notifyCollectors(collectors.value)
     }
 
     /**
      * 오류 종료 상태로 전환합니다.
      *
      * ## 동작/계약
+     * - 진행 중인 값 전파와 다른 종료 신호가 끝날 때까지 Subject 단위로 대기합니다.
      * - 최초 종료 전환 시 error를 저장하고 `DONE` 노드로 마킹합니다.
      * - 활성 collector를 모두 깨워 종료 경로로 진행시킵니다.
+     * - 종료 상태 반영 후 호출자가 취소돼도 아직 알리지 못한 collector에는 wake-up을 남깁니다.
      * - 이후 emit/complete/emitError 호출은 무시됩니다.
      *
      * ```kotlin
@@ -181,32 +181,26 @@ class BehaviorSubject<T> private constructor(
     // 안전: DONE은 Node<Any> 타입 sentinel이며, 실제 값을 가리키지 않으므로
     // Node<T>로 캐스팅해도 런타임에서 값에 접근하지 않는 한 ClassCastException이 발생하지 않음.
     @Suppress("UNCHECKED_CAST")
-    override suspend fun emitError(ex: Throwable?) {
-        if (current == DONE)
-            return
+    override suspend fun emitError(ex: Throwable?) = signalMutex.withLock {
+        if (current == DONE) {
+            return@withLock
+        }
 
         error = ex
         current.set(DONE as Node<T>)
         current = DONE
 
-        collectors.getAndSet(TERMINATED).forEach { innerCollector ->
-            try {
-                innerCollector.consumeReady.await()
-                innerCollector.resume()
-            } catch (e: CancellationException) {
-                currentCoroutineContext().ensureActive()
-            } catch (e: Throwable) {
-                log.error(e) { "BehaviorSubject.emitError notification failed. innerCollector=$innerCollector" }
-            }
-        }
+        notifyCollectors(collectors.getAndSet(TERMINATED))
     }
 
     /**
      * 정상 완료 상태로 전환합니다.
      *
      * ## 동작/계약
+     * - 진행 중인 값 전파와 다른 종료 신호가 끝날 때까지 Subject 단위로 대기합니다.
      * - 최초 종료 전환 시 `DONE` 노드로 마킹하고 collector를 모두 깨웁니다.
      * - collector는 남은 값을 처리한 뒤 정상 종료합니다.
+     * - 종료 상태 반영 후 호출자가 취소돼도 아직 알리지 못한 collector에는 wake-up을 남깁니다.
      * - 이후 emit/complete/emitError 호출은 무시됩니다.
      *
      * ```kotlin
@@ -217,23 +211,15 @@ class BehaviorSubject<T> private constructor(
      */
     // 안전: DONE sentinel을 Node<T>로 캐스팅. sentinel의 value에 접근하지 않으므로 ClassCastException 없음.
     @Suppress("UNCHECKED_CAST")
-    override suspend fun complete() {
-        if (current == DONE)
-            return
+    override suspend fun complete() = signalMutex.withLock {
+        if (current == DONE) {
+            return@withLock
+        }
 
         current.set(DONE as Node<T>)
         current = DONE
 
-        collectors.getAndSet(TERMINATED).forEach { innerCollector ->
-            try {
-                innerCollector.consumeReady.await()
-                innerCollector.resume()
-            } catch (e: CancellationException) {
-                currentCoroutineContext().ensureActive()
-            } catch (e: Throwable) {
-                log.error(e) { "Fail to complete. innerCollector=$innerCollector" }
-            }
-        }
+        notifyCollectors(collectors.getAndSet(TERMINATED))
     }
 
 
@@ -299,6 +285,23 @@ class BehaviorSubject<T> private constructor(
         }
 
         error?.let { throw it }
+    }
+
+    private suspend fun notifyCollectors(snapshot: Array<InnerCollector>) {
+        var notified = 0
+        try {
+            while (notified < snapshot.size) {
+                val inner = snapshot[notified]
+                inner.consumeReady.await()
+                inner.resume()
+                notified++
+            }
+        } finally {
+            while (notified < snapshot.size) {
+                snapshot[notified].resume()
+                notified++
+            }
+        }
     }
 
     // 안전: TERMINATED sentinel(Array<InnerCollector>)과 실제 배열은 동일 타입이므로

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/BehaviorSubjectTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/BehaviorSubjectTest.kt
@@ -1,10 +1,21 @@
 package io.bluetape4k.coroutines.flow.extensions.subject
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.coroutines.flow.extensions.log
 import io.bluetape4k.coroutines.support.log
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import io.bluetape4k.junit5.coroutines.runSuspendDefault
 import io.bluetape4k.junit5.coroutines.withSingleThread
 import io.bluetape4k.junit5.awaitility.untilSuspending
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.onEach
@@ -12,15 +23,13 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeInstanceOf
-import io.bluetape4k.assertions.shouldBeTrue
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.Test
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class BehaviorSubjectTest {
 
@@ -120,6 +129,200 @@ class BehaviorSubjectTest {
         job.join()
 
         counter.get() shouldBeEqualTo n
+    }
+
+    @Test
+    fun `concurrent emitters retain active collectors and latest value`() = runSuspendDefault(timeout = 10.seconds) {
+        val subject = BehaviorSubject<Int>()
+        val producerWorkers = 8
+        val rounds = 1024
+        val expectedValues = (1..rounds).toList()
+        val produced = AtomicInteger(0)
+        val received1 = ConcurrentLinkedQueue<Int>()
+        val received2 = ConcurrentLinkedQueue<Int>()
+
+        val collectorJob1 = launch {
+            subject.collect(received1::add)
+        }.log("collectorJob1")
+        val collectorJob2 = launch {
+            subject.collect(received2::add)
+        }.log("collectorJob2")
+
+        subject.awaitCollectors(2)
+
+        SuspendedJobTester()
+            .workers(producerWorkers)
+            .rounds(rounds)
+            .add { subject.emit(produced.incrementAndGet()) }
+            .run()
+
+        val retainedValue = subject.value
+        val lateCollectorValues = ConcurrentLinkedQueue<Int>()
+        val lateCollectorJob = launch {
+            subject.take(1).collect(lateCollectorValues::add)
+        }
+        lateCollectorJob.join()
+
+        subject.collectorCount shouldBeEqualTo 2
+        subject.hasCollectors.shouldBeTrue()
+
+        subject.complete()
+        collectorJob1.join()
+        collectorJob2.join()
+
+        produced.get() shouldBeEqualTo rounds
+        received1.sorted() shouldBeEqualTo expectedValues
+        received2.sorted() shouldBeEqualTo expectedValues
+        received1.toList() shouldBeEqualTo received2.toList()
+        received1.last() shouldBeEqualTo retainedValue
+        received2.last() shouldBeEqualTo retainedValue
+        lateCollectorValues.toList() shouldBeEqualTo listOf(retainedValue)
+        subject.collectorCount shouldBeEqualTo 0
+        subject.hasCollectors.shouldBeFalse()
+    }
+
+    @Test
+    fun `terminal signal waits for in-flight behavior emit`() = runSuspendDefault(timeout = 10.seconds) {
+        val subject = BehaviorSubject<Int>()
+        val received1 = ConcurrentLinkedQueue<Int>()
+        val received2 = ConcurrentLinkedQueue<Int>()
+        val firstValueStarted = CompletableDeferred<Unit>()
+        val releaseFirstValue = CompletableDeferred<Unit>()
+
+        val collectorJob1 = launch {
+            subject.collect { value ->
+                received1.add(value)
+                if (value == 1) {
+                    firstValueStarted.complete(Unit)
+                    releaseFirstValue.await()
+                }
+            }
+        }
+        val collectorJob2 = launch {
+            subject.collect(received2::add)
+        }
+
+        subject.awaitCollectors(2)
+        subject.emit(1)
+        firstValueStarted.await()
+
+        val pendingEmit = async(start = CoroutineStart.UNDISPATCHED) {
+            subject.emit(2)
+        }
+        val terminal = async(start = CoroutineStart.UNDISPATCHED) {
+            subject.complete()
+        }
+
+        releaseFirstValue.complete(Unit)
+        pendingEmit.await()
+        terminal.await()
+        collectorJob1.join()
+        collectorJob2.join()
+
+        received1.toList() shouldBeEqualTo listOf(1, 2)
+        received2.toList() shouldBeEqualTo listOf(1, 2)
+        subject.collectorCount shouldBeEqualTo 0
+        subject.hasCollectors.shouldBeFalse()
+    }
+
+    @Test
+    fun `cancelled emit wakes every collector after state commit`() = runSuspendDefault(timeout = 10.seconds) {
+        val subject = BehaviorSubject<Int>()
+        val received1 = ConcurrentLinkedQueue<Int>()
+        val received2 = ConcurrentLinkedQueue<Int>()
+        val firstValueStarted = CompletableDeferred<Unit>()
+        val releaseFirstValue = CompletableDeferred<Unit>()
+
+        val collectorJob1 = launch {
+            subject.collect(received1::add)
+        }
+        val collectorJob2 = launch {
+            subject.collect { value ->
+                received2.add(value)
+                if (value == 1) {
+                    firstValueStarted.complete(Unit)
+                    releaseFirstValue.await()
+                }
+            }
+        }
+
+        subject.awaitCollectors(2)
+        subject.emit(1)
+        firstValueStarted.await()
+
+        val pendingEmit = launch(start = CoroutineStart.UNDISPATCHED) {
+            subject.emit(2)
+        }
+        pendingEmit.cancelAndJoin()
+
+        releaseFirstValue.complete(Unit)
+        subject.complete()
+        collectorJob1.join()
+        collectorJob2.join()
+
+        received1.toList() shouldBeEqualTo listOf(1, 2)
+        received2.toList() shouldBeEqualTo listOf(1, 2)
+        subject.collectorCount shouldBeEqualTo 0
+        subject.hasCollectors.shouldBeFalse()
+    }
+
+    @Test
+    fun `cancelled terminal signal still wakes every collector`() = runSuspendDefault(timeout = 10.seconds) {
+        val subject = BehaviorSubject<Int>()
+        val received1 = ConcurrentLinkedQueue<Int>()
+        val received2 = ConcurrentLinkedQueue<Int>()
+        val firstValueStarted = CompletableDeferred<Unit>()
+        val releaseFirstValue = CompletableDeferred<Unit>()
+
+        val collectorJob1 = launch {
+            subject.collect(received1::add)
+        }
+        val collectorJob2 = launch {
+            subject.collect { value ->
+                received2.add(value)
+                if (value == 1) {
+                    firstValueStarted.complete(Unit)
+                    releaseFirstValue.await()
+                }
+            }
+        }
+
+        subject.awaitCollectors(2)
+        subject.emit(1)
+        firstValueStarted.await()
+
+        val terminal = launch(start = CoroutineStart.UNDISPATCHED) {
+            subject.complete()
+        }
+        terminal.cancelAndJoin()
+
+        releaseFirstValue.complete(Unit)
+        collectorJob1.join()
+        collectorJob2.join()
+
+        received1.toList() shouldBeEqualTo listOf(1)
+        received2.toList() shouldBeEqualTo listOf(1)
+        subject.collectorCount shouldBeEqualTo 0
+        subject.hasCollectors.shouldBeFalse()
+    }
+
+    @Test
+    fun `first terminal signal wins`() = runTest {
+        val failure = IllegalStateException("boom")
+        val errorSubject = BehaviorSubject<Int>()
+
+        errorSubject.emitError(failure)
+        errorSubject.complete()
+
+        assertFailsWith<IllegalStateException> {
+            errorSubject.collect {}
+        }.message shouldBeEqualTo failure.message
+
+        val completedSubject = BehaviorSubject<Int>()
+        completedSubject.complete()
+        completedSubject.emitError(failure)
+
+        completedSubject.collect {}
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #778

- PR 제목: fix(coroutines): preserve BehaviorSubject concurrent signals

- serialize `BehaviorSubject` signal mutation and collector notification across concurrent producers
- preserve committed fanout when an emitting or terminal coroutine is cancelled
- add deterministic multi-collector stress, terminal-race, retention, cleanup, and cancellation coverage

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

- serialize `BehaviorSubject` signal mutation and collector notification across concurrent producers
- preserve committed fanout when an emitting or terminal coroutine is cancelled
- add deterministic multi-collector stress, terminal-race, retention, cleanup, and cancellation coverage

### Validation

- `BehaviorSubjectTest`: 14 passing
- `:bluetape4k-coroutines:cleanTest :bluetape4k-coroutines:test --rerun-tasks`: 577 passing
- concurrent-emitter stress repeated 3 times
- `detekt`: passing
- `git diff --check`: passing
- independent review: P0=0, P1=0

Fixes #778

### DoD Status

- [x] Concurrent producer signals are serialized without orphaning collector nodes
- [x] Active collectors receive the same signal order and the latest value is retained
- [x] Committed emit and terminal fanout survives caller cancellation
- [x] Collector cleanup and first-terminal-wins behavior are covered
- [x] Targeted, module, stress, static-analysis, and independent-review gates pass

## Validation

- `BehaviorSubjectTest`: 14 passing
- `:bluetape4k-coroutines:cleanTest :bluetape4k-coroutines:test --rerun-tasks`: 577 passing
- concurrent-emitter stress repeated 3 times
- `detekt`: passing
- `git diff --check`: passing
- independent review: P0=0, P1=0

Fixes #778

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #778, milestone `1.12.0`, assignee `debop`
- PR: #1020, head `c076c6c05d45936a20290c5f29c1dcdf4fb53502`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-778-behavior-subject-stress`
- Labels: `test`, `coroutines`
- State: `MERGED`, merge commit `690f5f4086e45256c0db771617cc121bca19c9cf`
- CI: - `detekt`: passing

## DoD Status

- [x] Concurrent producer signals are serialized without orphaning collector nodes
- [x] Active collectors receive the same signal order and the latest value is retained
- [x] Committed emit and terminal fanout survives caller cancellation
- [x] Collector cleanup and first-terminal-wins behavior are covered
- [x] Targeted, module, stress, static-analysis, and independent-review gates pass

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1020 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `690f5f4086e45256c0db771617cc121bca19c9cf`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
