### PR TITLE
test(coroutines): stress UnicastWorkSubject producers and chunked consumers

### DIFF
--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/UnicastWorkSubjectTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/UnicastWorkSubjectTest.kt
@@ -3,6 +3,8 @@ package io.bluetape4k.coroutines.flow.extensions.subject
 import io.bluetape4k.coroutines.flow.extensions.flowRangeOf
 import io.bluetape4k.coroutines.flow.extensions.log
 import io.bluetape4k.coroutines.support.log
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import io.bluetape4k.junit5.coroutines.runSuspendDefault
 import io.bluetape4k.junit5.coroutines.withSingleThread
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import kotlinx.coroutines.coroutineScope
@@ -13,8 +15,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import org.junit.jupiter.api.Test
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.seconds
 
 class UnicastWorkSubjectTest {
 
@@ -108,6 +114,72 @@ class UnicastWorkSubjectTest {
 
         val result = us.take(3).log("#1").toList()
         result shouldBeEqualTo listOf(0, 1, 2)
+    }
+
+    @Test
+    fun `concurrent producers emit every work item exactly once`() = runSuspendDefault(timeout = 10.seconds) {
+        val subject = UnicastWorkSubject<Int>()
+        val producerWorkers = 8
+        val rounds = 1024
+        val expectedValues = (1..rounds).toList()
+        val produced = AtomicInteger(0)
+        val received = ConcurrentLinkedQueue<Int>()
+
+        val collectorJob = launch {
+            subject.collect(received::add)
+        }
+
+        subject.awaitCollector()
+
+        SuspendedJobTester()
+            .workers(producerWorkers)
+            .rounds(rounds)
+            .add { subject.emit(produced.incrementAndGet()) }
+            .run()
+        subject.complete()
+        collectorJob.join()
+
+        produced.get() shouldBeEqualTo rounds
+        received.sorted() shouldBeEqualTo expectedValues
+        subject.collectorCount shouldBeEqualTo 0
+        subject.hasCollectors.shouldBeFalse()
+    }
+
+    @Test
+    fun `chunked collector drains concurrent producer work without loss`() = runSuspendDefault(timeout = 10.seconds) {
+        val subject = UnicastWorkSubject<Int>()
+        val producerWorkers = 8
+        val rounds = 1024
+        val chunkSize = 64
+        val expectedValues = (1..rounds).toList()
+        val produced = AtomicInteger(0)
+        val received = ConcurrentLinkedQueue<Int>()
+        val chunkSizes = mutableListOf<Int>()
+
+        val collectorJob = launch {
+            while (received.size < rounds) {
+                val chunk = subject.take(chunkSize).toList()
+                chunkSizes += chunk.size
+                received.addAll(chunk)
+            }
+        }
+
+        subject.awaitCollector()
+
+        SuspendedJobTester()
+            .workers(producerWorkers)
+            .rounds(rounds)
+            .add { subject.emit(produced.incrementAndGet()) }
+            .run()
+        subject.complete()
+        collectorJob.join()
+
+        produced.get() shouldBeEqualTo rounds
+        received.sorted() shouldBeEqualTo expectedValues
+        chunkSizes shouldBeEqualTo List(rounds / chunkSize) { chunkSize }
+        subject.toList() shouldBeEqualTo emptyList()
+        subject.collectorCount shouldBeEqualTo 0
+        subject.hasCollectors.shouldBeFalse()
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #779

- PR 제목: test(coroutines): stress UnicastWorkSubject producers and chunked consumers

- add concurrent `SuspendedJobTester` producers with unique work IDs
- verify full collection has no lost, duplicated, or unexpected work
- verify deterministic 64-item chunk transitions, terminal draining, and collector cleanup

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

- add concurrent `SuspendedJobTester` producers with unique work IDs
- verify full collection has no lost, duplicated, or unexpected work
- verify deterministic 64-item chunk transitions, terminal draining, and collector cleanup

### Validation

- `UnicastWorkSubjectTest`: 12 passing
- `UnicastWorkSubjectTest` repeated 3 times: 12 passing in every round
- `:bluetape4k-coroutines:cleanTest :bluetape4k-coroutines:test --rerun-tasks`: 579 passing
- `detekt`: passing
- `git diff --check`: passing
- independent review: APPROVE, P0=0, P1=0

### Review Notes

- producer overlap remains scheduler-dependent because `SuspendedJobTester` has no start barrier
- a lost-work regression fails through the bounded 10-second test timeout rather than an immediate chunk-loop assertion
- concurrent second-collector rejection remains covered outside this issue's producer/chunk scope

Fixes #779

### DoD Status

- [x] Concurrent producers emit unique work through `SuspendedJobTester`
- [x] Full collection proves exact set equality with all emitted work
- [x] Chunked collection proves sixteen deterministic 64-item chunks
- [x] `complete()` runs once after all producers finish
- [x] Terminal draining and collector cleanup are verified
- [x] Targeted, repeated stress, module, detekt, diff, and independent-review gates pass

## Validation

- `UnicastWorkSubjectTest`: 12 passing
- `UnicastWorkSubjectTest` repeated 3 times: 12 passing in every round
- `:bluetape4k-coroutines:cleanTest :bluetape4k-coroutines:test --rerun-tasks`: 579 passing
- `detekt`: passing
- `git diff --check`: passing
- independent review: APPROVE, P0=0, P1=0

## Review Notes

- producer overlap remains scheduler-dependent because `SuspendedJobTester` has no start barrier
- a lost-work regression fails through the bounded 10-second test timeout rather than an immediate chunk-loop assertion
- concurrent second-collector rejection remains covered outside this issue's producer/chunk scope

Fixes #779

## Metadata

- Issue: #779, milestone `1.12.0`, assignee `debop`
- PR: #1021, head `c707f2b21432b3931f9a063e20e90a95fbbd1f04`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `test/issue-779-unicast-work-subject-stress`
- Labels: `test`, `coroutines`
- State: `MERGED`, merge commit `ad22da92976693001d3a426926f538372d0fc390`
- CI: - `detekt`: passing / - [x] Targeted, repeated stress, module, detekt, diff, and independent-review gates pass

## DoD Status

- [x] Concurrent producers emit unique work through `SuspendedJobTester`
- [x] Full collection proves exact set equality with all emitted work
- [x] Chunked collection proves sixteen deterministic 64-item chunks
- [x] `complete()` runs once after all producers finish
- [x] Terminal draining and collector cleanup are verified
- [x] Targeted, repeated stress, module, detekt, diff, and independent-review gates pass

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1021 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `ad22da92976693001d3a426926f538372d0fc390`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
