### PR TITLE
test(coroutines): stress UnicastSubject concurrent producers

### DIFF
--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/UnicastSubjectTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/UnicastSubjectTest.kt
@@ -1,24 +1,29 @@
 package io.bluetape4k.coroutines.flow.extensions.subject
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEmpty
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.coroutines.flow.extensions.log
 import io.bluetape4k.coroutines.support.log
-import io.bluetape4k.junit5.coroutines.withSingleThread
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import io.bluetape4k.junit5.coroutines.runSuspendDefault
 import io.bluetape4k.junit5.coroutines.runSuspendTest
+import io.bluetape4k.junit5.coroutines.withSingleThread
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.trace
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
-import io.bluetape4k.assertions.shouldBeEmpty
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeInstanceOf
-import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
-import io.bluetape4k.assertions.assertFailsWith
+import kotlin.time.Duration.Companion.seconds
 
 class UnicastSubjectTest {
 
@@ -101,6 +106,43 @@ class UnicastSubjectTest {
         assertFailsWith<IllegalStateException> {
             us.take(3).log("#2").toList().shouldBeEmpty()
         }
+    }
+
+    @Test
+    fun `concurrent producers emit every item to the single collector`() = runSuspendDefault(timeout = 10.seconds) {
+        val subject = UnicastSubject<Int>()
+        val producerWorkers = 8
+        val rounds = 1024
+        val expectedValues = (1..rounds).toList()
+        val produced = AtomicInteger(0)
+        val received = ConcurrentLinkedQueue<Int>()
+        val readyProducers = AtomicInteger(0)
+        val startGate = CompletableDeferred<Unit>()
+
+        val collectorJob = launch {
+            subject.collect(received::add)
+        }
+
+        subject.awaitCollector()
+
+        SuspendedJobTester()
+            .workers(producerWorkers)
+            .rounds(rounds)
+            .add {
+                if (readyProducers.incrementAndGet() == producerWorkers) {
+                    startGate.complete(Unit)
+                }
+                startGate.await()
+                subject.emit(produced.incrementAndGet())
+            }
+            .run()
+        subject.complete()
+        collectorJob.join()
+
+        produced.get() shouldBeEqualTo rounds
+        received.sorted() shouldBeEqualTo expectedValues
+        subject.collectorCount shouldBeEqualTo 0
+        subject.collectorCancelled.shouldBeTrue()
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #780

- PR 제목: test(coroutines): stress UnicastSubject concurrent producers

- Add a bounded concurrent-producer stress test for `UnicastSubject`.
- Keep exactly one collector and verify every produced value is delivered before normal completion.
- Coordinate all producer workers at a start gate so the test exercises genuine concurrent producer entry.

### 원문 선행 내용

Closes #780

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- Test-only change in `UnicastSubjectTest.kt`.
- No production API, dependency, module, documentation, or publication changes.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

Closes #780

### Summary

- Add a bounded concurrent-producer stress test for `UnicastSubject`.
- Keep exactly one collector and verify every produced value is delivered before normal completion.
- Coordinate all producer workers at a start gate so the test exercises genuine concurrent producer entry.

### Validation

- Gated stress test repeated three times: 1/1 passing each run.
- `UnicastSubjectTest`: 10/10 passing.
- `:bluetape4k-coroutines:check`: 580/580 passing.
- `git diff --check`.
- Independent Kotlin coroutine review: P0=0, P1=0, P2=0.

### Scope

- Test-only change in `UnicastSubjectTest.kt`.
- No production API, dependency, module, documentation, or publication changes.

### DoD Status

- [x] Uses `SuspendedJobTester` with eight coordinated producer workers.
- [x] Keeps exactly one collector active.
- [x] Verifies the exact produced value set without relying on concurrent ordering.
- [x] Sends the terminal signal only after every producer operation completes.
- [x] Verifies collector termination and zero active collectors.
- [x] Targeted and full coroutines module checks pass.
- [x] Exact-head PR CI and live review gates pass.
- [x] Fresh merge approval was obtained after the merge-ready report.

## Validation

- Gated stress test repeated three times: 1/1 passing each run.
- `UnicastSubjectTest`: 10/10 passing.
- `:bluetape4k-coroutines:check`: 580/580 passing.
- `git diff --check`.
- Independent Kotlin coroutine review: P0=0, P1=0, P2=0.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #780, milestone `1.12.0`, assignee `debop`
- PR: #1023, head `e5e2748ea232a7420ab8f42c9f4eb90c83da7488`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `test/issue-780-unicast-subject-stress`
- Labels: `test`, `coroutines`
- State: `MERGED`, merge commit `66607608065293eb46a54a2a0d4172de23517a9d`
- CI: - Coordinate all producer workers at a start gate so the test exercises genuine concurrent producer entry. / - [x] Exact-head PR CI and live review gates pass.

## DoD Status

- [x] Uses `SuspendedJobTester` with eight coordinated producer workers.
- [x] Keeps exactly one collector active.
- [x] Verifies the exact produced value set without relying on concurrent ordering.
- [x] Sends the terminal signal only after every producer operation completes.
- [x] Verifies collector termination and zero active collectors.
- [x] Targeted and full coroutines module checks pass.
- [x] Exact-head PR CI and live review gates pass.
- [x] Fresh merge approval was obtained after the merge-ready report.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1023 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `66607608065293eb46a54a2a0d4172de23517a9d`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
