### PR TITLE
test(coroutines): stress AsyncFlow concurrent collectors

### DIFF
--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/AsyncFlowTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/AsyncFlowTest.kt
@@ -1,25 +1,31 @@
 package io.bluetape4k.coroutines.flow
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.concurrent.virtualthread.VT
 import io.bluetape4k.coroutines.flow.extensions.log
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import io.bluetape4k.junit5.coroutines.runSuspendDefault
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.utils.Runtimex
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.newFixedThreadPoolContext
 import kotlinx.coroutines.test.runTest
-import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.random.Random
-import io.bluetape4k.assertions.assertFailsWith
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class AsyncFlowTest {
 
@@ -57,6 +63,43 @@ class AsyncFlowTest {
     @RepeatedTest(REPEAT_SIZE)
     fun `asyncFlow with virtual thread dispatcher`() = runTest {
         runAsyncFlow(Dispatchers.VT)
+    }
+
+    @Test
+    fun `concurrent collectors preserve per-collector order`() = runSuspendDefault(timeout = 15.seconds) {
+        val workerCount = 8
+        val collectionCount = 32
+        val stressItems = expectedItems.take(128)
+        val readyCollectors = AtomicInteger(0)
+        val completedCollectors = AtomicInteger(0)
+        val startGate = CompletableDeferred<Unit>()
+
+        SuspendedJobTester()
+            .workers(workerCount)
+            .rounds(collectionCount)
+            .add {
+                val enteredOperator = AtomicBoolean(false)
+                val results = stressItems
+                    .asFlow()
+                    .async(Dispatchers.Default) { item ->
+                        if (enteredOperator.compareAndSet(false, true)) {
+                            if (readyCollectors.incrementAndGet() == workerCount) {
+                                startGate.complete(Unit)
+                            }
+                            startGate.await()
+                        }
+                        delay((item % 3 + 1).milliseconds)
+                        item
+                    }
+                    .toList()
+
+                results shouldBeEqualTo stressItems
+                completedCollectors.incrementAndGet()
+            }
+            .run()
+
+        readyCollectors.get() shouldBeEqualTo collectionCount
+        completedCollectors.get() shouldBeEqualTo collectionCount
     }
 
     private suspend inline fun runAsyncFlow(dispatcher: CoroutineDispatcher) {


### PR DESCRIPTION
## Summary

Closes #781

- PR 제목: test(coroutines): stress AsyncFlow concurrent collectors

- Add a bounded concurrent-collector stress test for `AsyncFlow`.
- Rendezvous eight distinct collections from inside each collection's first transform invocation.
- Keep every cold flow and result list isolated while verifying exact per-collector ordering across 32 collections.

### 원문 선행 내용

Closes #781

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- Test-only change in `AsyncFlowTest.kt`.
- No production API, dependency, module, documentation, or publication changes.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

Closes #781

### Summary

- Add a bounded concurrent-collector stress test for `AsyncFlow`.
- Rendezvous eight distinct collections from inside each collection's first transform invocation.
- Keep every cold flow and result list isolated while verifying exact per-collector ordering across 32 collections.

### Validation

- Baseline `AsyncFlowTest`: 15/15 passing.
- New stress test repeated three times with cache bypass: 1/1 passing each run.
- Updated `AsyncFlowTest`: 16/16 passing.
- `:bluetape4k-coroutines:test` and `:bluetape4k-coroutines:check`: 581/581 passing.
- `git diff --check`.
- Independent Kotlin coroutine review: P0=0, P1=0, P2=0, P3=0.

### Scope

- Test-only change in `AsyncFlowTest.kt`.
- No production API, dependency, module, documentation, or publication changes.

### DoD Status

- [x] Uses `SuspendedJobTester` with eight concurrent workers and 32 independent collections.
- [x] Gates eight distinct collections from inside the `AsyncFlow` transform path.
- [x] Uses a separate cold flow and local result list for every collection.
- [x] Verifies exact per-collector order across a deterministic suspended transform.
- [x] Verifies all 32 collections entered and completed.
- [x] Targeted, class, and full coroutines module checks pass.
- [x] Exact-head PR CI and live review gates pass.
- [x] Fresh merge approval is obtained after the merge-ready report.

## Validation

- Baseline `AsyncFlowTest`: 15/15 passing.
- New stress test repeated three times with cache bypass: 1/1 passing each run.
- Updated `AsyncFlowTest`: 16/16 passing.
- `:bluetape4k-coroutines:test` and `:bluetape4k-coroutines:check`: 581/581 passing.
- `git diff --check`.
- Independent Kotlin coroutine review: P0=0, P1=0, P2=0, P3=0.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #781, milestone `1.12.0`, assignee `debop`
- PR: #1024, head `a57bf3e232ebe32729caa9ceb750e737226a26e4`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `test/issue-781-async-flow-stress`
- Labels: `test`, `coroutines`
- State: `MERGED`, merge commit `36971526b5d9a7ba8cd40103892e74743896e24a`
- CI: - [x] Exact-head PR CI and live review gates pass.

## DoD Status

- [x] Uses `SuspendedJobTester` with eight concurrent workers and 32 independent collections.
- [x] Gates eight distinct collections from inside the `AsyncFlow` transform path.
- [x] Uses a separate cold flow and local result list for every collection.
- [x] Verifies exact per-collector order across a deterministic suspended transform.
- [x] Verifies all 32 collections entered and completed.
- [x] Targeted, class, and full coroutines module checks pass.
- [x] Exact-head PR CI and live review gates pass.
- [x] Fresh merge approval is obtained after the merge-ready report.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1024 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `36971526b5d9a7ba8cd40103892e74743896e24a`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
