### PR TITLE
Interrupt timed virtualFutureAll child tasks

### DIFF
--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/VirtualFutureExtensions.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/VirtualFutureExtensions.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.concurrent.virtualthread
 
+import io.bluetape4k.concurrent.asCompletableFuture
 import io.bluetape4k.concurrent.sequence
 import io.bluetape4k.utils.ShutdownQueue
 import java.time.Duration
@@ -77,8 +78,13 @@ fun <T> virtualFutureAll(
 }
 
 /**
- * 복수의 작업들을 Virtual thread 를 이용하여 비동기로 제한시간 [timeout] 동안 수행합니다. 결과는 [List]로 반환됩니다.
- * 모든 작업이 제한시간 내에 완료되지 않으면 [java.util.concurrent.TimeoutException]을 던집니다.
+ * Runs multiple tasks asynchronously on virtual threads and returns their results in input order.
+ * The aggregate future fails with [java.util.concurrent.TimeoutException] unless every task completes within [timeout].
+ *
+ * On timeout, cancellation with interruption is requested for every unfinished task.
+ * Cancellation is cooperative, so task code that ignores interruption may continue after the aggregate future completes.
+ * Awaiting a timed-out result throws [java.util.concurrent.ExecutionException] with
+ * [java.util.concurrent.TimeoutException] as its cause.
  *
  * ```kotlin
  * val tasks = listOf(
@@ -90,12 +96,11 @@ fun <T> virtualFutureAll(
  * val result = future.await() // [1, 2, 3]
  * ```
  *
- * @param T 작업 결과 타입
- * @param tasks 병렬로 실행할 작업 목록
- * @param executor 작업을 실행할 [ExecutorService] (기본값: [VirtualThreadExecutor])
- * @param timeout 각 작업의 최대 대기 시간
- * @return 모든 작업의 결과를 담은 [VirtualFuture] 인스턴스
- * @throws java.util.concurrent.TimeoutException 제한 시간 초과 시
+ * @param T task result type
+ * @param tasks tasks to execute in parallel
+ * @param executor executor used to run tasks (defaults to [VirtualThreadExecutor])
+ * @param timeout maximum duration for the aggregate operation
+ * @return a [VirtualFuture] containing every task result in input order
  */
 fun <T> virtualFutureAll(
     tasks: Collection<() -> T>,
@@ -106,7 +111,7 @@ fun <T> virtualFutureAll(
         return VirtualFuture(CompletableFuture.completedFuture(emptyList()))
     }
     val futures = tasks.map { task ->
-        CompletableFuture.supplyAsync({ task() }, executor)
+        executor.submit<T>(task).asCompletableFuture()
     }
     val combined = CompletableFuture.allOf(*futures.toTypedArray())
         .thenApply { futures.map { it.join() } }

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/VirtualFutureTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/VirtualFutureTest.kt
@@ -1,16 +1,21 @@
 package io.bluetape4k.concurrent.virtualthread
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.junit5.concurrency.StructuredTaskScopeTester
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.trace
-import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
-import io.bluetape4k.assertions.assertFailsWith
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
@@ -60,6 +65,37 @@ class VirtualFutureTest {
 
         val virtualFutures = virtualFutureAll(tasks = tasks)
         virtualFutures.await() shouldBeEqualTo (0 until taskSize).toList()
+    }
+
+    @Test
+    fun `timed virtualFutureAll interrupts running tasks after timeout`() {
+        val started = CountDownLatch(1)
+        val interrupted = CountDownLatch(1)
+        val release = CountDownLatch(1)
+
+        val result = virtualFutureAll(
+            tasks = listOf {
+                started.countDown()
+                try {
+                    release.await()
+                    1
+                } catch (e: InterruptedException) {
+                    interrupted.countDown()
+                    throw e
+                }
+            },
+            timeout = 2.seconds.toJavaDuration(),
+        )
+
+        try {
+            started.await(1, TimeUnit.SECONDS).shouldBeTrue()
+            assertFailsWith<ExecutionException> {
+                result.await()
+            }.cause shouldBeInstanceOf TimeoutException::class
+            interrupted.await(1, TimeUnit.SECONDS).shouldBeTrue()
+        } finally {
+            release.countDown()
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #784

- PR 제목: Interrupt timed virtualFutureAll child tasks

Closes #784

Ensure timed `virtualFutureAll` operations request interruption of running child tasks instead of timing out only the aggregate wrapper.

## Background

Milestone 1.12.0 issue #784 identified that `CompletableFuture.supplyAsync` cancellation did not retain an executor-owned task handle, allowing interruptible virtual-thread work to continue after the caller observed timeout.

## What This Solves

- Propagates timeout cancellation to the actual executor-owned child `Future` instances.
- Makes aggregate timeout, wrapped exception exposure, and cooperative interruption limits explicit in KDoc.

## Work Done

- Submit timed child tasks through `ExecutorService.submit` and reuse the existing cancellation-forwarding `Future.asCompletableFuture` wrapper.
- Add a deterministic started/interrupted/release latch regression proving that an already-running child is interrupted after aggregate timeout.
- Document that `VirtualFuture.await()` exposes timeout as `ExecutionException` with `TimeoutException` as its cause.

## Validation

- Focused regression before implementation: FAIL as expected (`0 passing, 1 failing` on missing interruption).
- Focused regression after implementation: PASS, followed by three uncached PASS repetitions.
- `./gradlew :bluetape4k-core:test --tests 'io.bluetape4k.concurrent.virtualthread.VirtualFutureTest'`: PASS (`7 passing`).
- `./gradlew :bluetape4k-core:test`: PASS (`1601 passing`).
- `./gradlew :bluetape4k-core:check`: PASS.
- `./gradlew detekt`: PASS.
- `git diff --check`: PASS.

## Review Notes

- P0/P1: 0/0.
- P2/P3: both P2 findings fixed; one P3 timeout-boundary observation-latency risk remains documented in the Lore commit as not tested.
- Review evidence: independent exact-diff re-review returned APPROVE with P0=0, P1=0, P2=0.

## Metadata

- Issue: #784, milestone `1.12.0`, assignee `debop`
- PR: #1027, head `2825b71936b38b7af7790f91f4e9d7bb90fc8dc5`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-784-virtual-future-timeout-cancellation`
- Labels: `bug`, `java`
- State: `MERGED`, merge commit `ba00854ad1a261724cc9d270b0ae82082ab52651`
- CI: - Makes aggregate timeout, wrapped exception exposure, and cooperative interruption limits explicit in KDoc. / - `./gradlew :bluetape4k-core:test --tests 'io.bluetape4k.concurrent.virtualthread.VirtualFutureTest'`: PASS (`7 passing`). / - `./gradlew :bluetape4k-core:test`: PASS (`1601 passing`).

## DoD Status

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| C-01 - Root cause | Reproduced timeout without child interruption | PASS | Focused test failed at the interruption assertion | None |
| C-03 - Regression RED | Locked started/interrupted/release lifecycle | PASS | `0 passing, 1 failing` before implementation | None |
| C-04 - Surgical fix | Retained owner `Future` handles | PASS | Commit `2825b71936b38b7af7790f91f4e9d7bb90fc8dc5` | None |
| C-05 - GREEN and blast radius | Ran focused, repeated, class, module, check, and detekt validation | PASS | 3 uncached repetitions; 7/7 class; 1601/1601 module | None |
| CG-10 - Pre-PR convergence | Repaired review findings and committed exact scope | PASS | Independent APPROVE; P0=0/P1=0/P2=0 | None |
| CG-12 - Exact head publication | Pushed authorized branch | PASS | Local/remote SHA match | None |
| CG-13 - PR metadata | Create and verify live PR | PASS | PR #1027; exact head, base, assignee, labels, milestone verified | None |
| CG-14 - CI and live review | Verify exact-head checks and reread reviews/threads | PASS | CI #29420998495 and dependency #29420897665 succeeded; `MERGEABLE/CLEAN`; 0 reviews; 0 unresolved threads | None |
| CG-15 - Merge readiness | Reconcile exact PR/head delivery evidence | PASS | PR #1027 at `2825b71936b38b7af7790f91f4e9d7bb90fc8dc5`; 53/57 applicable checks pass | Stop for fresh merge approval |
| CG-16 - Fresh merge approval | Obtain approval after merge-ready report | PASS | User explicitly approved merging PR #1027 after the exact-head report | None |
| CG-17 - Merge | Merge and verify the exact approved PR/head | PASS | Live PR is `MERGED`; merge commit `ba00854ad1a261724cc9d270b0ae82082ab52651`; issue #784 closed | None |
| CG-18 - Sync and cleanup | Sync develop and remove proven-merged worktree | PASS | Local/remote develop match merge commit; worktree removed and pruned; local branch preserved | None |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1027 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `ba00854ad1a261724cc9d270b0ae82082ab52651`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
