### PR TITLE
Isolate nightly mock server Kover tasks

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -745,6 +745,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Validate mock server Kover isolation
+        id: validate-kover-isolation
+        run: ruby scripts/validate-nightly-kover-isolation.rb
+
       - uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
@@ -777,7 +781,7 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
       - name: Generate Kover XML report
-        if: always()
+        if: ${{ always() && steps.validate-kover-isolation.outcome == 'success' }}
         run: |
           ./gradlew --no-configuration-cache \
             :bluetape4k-virtualthread-api:koverXmlReport \
@@ -786,9 +790,15 @@ jobs:
             :bluetape4k-cache-core:koverXmlReport \
             :bluetape4k-opentelemetry:koverXmlReport \
             :bluetape4k-mock-web-server:koverXmlReport \
-            :bluetape4k-mock-webflux-server:koverXmlReport \
             :bluetape4k-r2dbc:koverXmlReport \
             --parallel
+        continue-on-error: true
+
+      - name: Generate mock webflux Kover XML report
+        if: ${{ always() && steps.validate-kover-isolation.outcome == 'success' }}
+        run: >-
+          ./gradlew --no-configuration-cache
+          :bluetape4k-mock-webflux-server:koverXmlReport
         continue-on-error: true
 
       - name: Upload test results

--- a/scripts/validate-nightly-kover-isolation.rb
+++ b/scripts/validate-nightly-kover-isolation.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "shellwords"
+require "yaml"
+
+SERVER_TASK = ":bluetape4k-mock-web-server:koverXmlReport"
+WEBFLUX_TASK = ":bluetape4k-mock-webflux-server:koverXmlReport"
+KOVER_TASKS = [SERVER_TASK, WEBFLUX_TASK].freeze
+
+def fail_validation(message)
+  warn message
+  exit 1
+end
+
+def gradle_tokens(command)
+  normalized = command.gsub(/\\\r?\n/, " ").strip
+  fail_validation("mock server Kover tasks require one simple Gradle invocation") if normalized.match?(/[\r\n#;&|<>$`]/)
+
+  tokens = Shellwords.shellsplit(normalized)
+  fail_validation("mock server Kover tasks must run through ./gradlew") unless tokens.first == "./gradlew"
+  tokens
+rescue ArgumentError => error
+  fail_validation("invalid mock server Kover command: #{error.message}")
+end
+
+workflow_path = ARGV.fetch(0, ".github/workflows/nightly-tests.yml")
+workflow = YAML.safe_load(File.read(workflow_path), aliases: true)
+steps = workflow.fetch("jobs").fetch("test-misc").fetch("steps")
+commands = steps.map { |step| step["run"] }.compact
+task_commands = commands.select { |command| KOVER_TASKS.any? { |task| command.include?(task) } }
+invocations = task_commands.map { |command| gradle_tokens(command) }
+
+task_counts = KOVER_TASKS.to_h do |task|
+  [task, invocations.sum { |tokens| tokens.count(task) }]
+end
+
+invalid_counts = task_counts.reject { |_task, count| count == 1 }
+fail_validation("expected each mock server Kover task exactly once: #{invalid_counts}") unless invalid_counts.empty?
+
+if invocations.any? { |tokens| KOVER_TASKS.all? { |task| tokens.include?(task) } }
+  fail_validation("mock server Kover tasks must use separate Gradle invocations")
+end
+
+puts "nightly mock server Kover isolation is valid"


### PR DESCRIPTION
## Summary

Closes #1014

- PR 제목: Isolate nightly mock server Kover tasks

Closes #1014

Prevent the Nightly misc coverage phase from rebuilding both fixed-port mock server test graphs in one parallel Gradle process.

## Background

The Nightly test step already isolated `mock-web-server` and `mock-webflux-server`, but the following Kover step regrouped both report tasks under one `--parallel` invocation. Because each Kover report depends on its module test task, the workflow could reintroduce the HTTPS port collision.

## What This Solves

- Keeps the two mock server Kover task graphs in separate Gradle invocations.
- Adds an executable fail-closed workflow validator so the unsafe grouping cannot silently return.
- Prevents the Kover steps from bypassing a failed validator while preserving report-only coverage behavior.

## Work Done

- Added `scripts/validate-nightly-kover-isolation.rb` using Ruby stdlib YAML and Shellwords with a narrow simple-Gradle-command contract.
- Moved `:bluetape4k-mock-webflux-server:koverXmlReport` into a dedicated workflow step.
- Guarded both Kover report steps on the validator outcome while retaining `always()` and `continue-on-error: true`.

## Validation

- `ruby scripts/validate-nightly-kover-isolation.rb`: PASS.
- `ruby -wc scripts/validate-nightly-kover-isolation.rb`: PASS on Ruby 2.6.10.
- Adversarial fixtures: PASS for combined invocation, missing/duplicate tasks, comments, wrappers, pipelines, substitutions, redirections, and shell metacharacters.
- `actionlint .github/workflows/nightly-tests.yml`: PASS.
- Outcome-guard YAML assertion: PASS for both Kover report steps.
- Shared Kover Gradle `--dry-run`: PASS; contains only `mock-web-server` test/report tasks.
- Mock webflux Kover Gradle `--dry-run`: PASS; contains only `mock-webflux-server` test/report tasks.
- `git diff origin/develop...HEAD --check`: PASS.

## Review Notes

- P0/P1: 0.
- P2/P3: 0 after repairing parser bypasses, task occurrence counting, fail-closed metacharacters, and validator outcome guards.
- Review evidence: independent local final-diff review approved the rebased two-file change.
- Remaining risk: the full GitHub-hosted scheduled Nightly workflow was not executed locally.

## Metadata

- Issue: #1014, milestone `1.12.0`, assignee `debop`
- PR: #1028, head `76436898135028119b87645ec0d6a3e81ed5f26a`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1014-nightly-kover-isolation`
- Labels: `bug`
- State: `MERGED`, merge commit `1b81cbdb2afde481f31f324bf8168306dbc8786f`
- CI: Prevent the Nightly misc coverage phase from rebuilding both fixed-port mock server test graphs in one parallel Gradle process. / - Keeps the two mock server Kover task graphs in separate Gradle invocations. / - Added `scripts/validate-nightly-kover-isolation.rb` using Ruby stdlib YAML and Shellwords with a narrow simple-Gradle-command contract.

## DoD Status

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| WF-01 through WF-04A | Classified, planned, approved, and initialized Type C plus Type E support | PASS | Approved plan and run `20260715T141658Z-4170ea38` | None |
| WF-05 | Execute all gates through the merge hold | PASS | Exact-head delivery reached the CG-16 merge hold | None |
| WF-06 | Repair weak or stale proof | PASS | Reviewer findings repaired and downstream proof refreshed | None |
| CL-01 through CL-06 | Instantiate, classify, order, record, fail closed, and repair | PASS | Issue checklist and coordinator sequence 10 | None |
| CL-07 through CL-08 | Refresh external holds and reconcile merge-ready counts | PASS | Exact PR/head hold and 41/46 counts reconciled; CG-16 remains separate | None |
| CG-01 through CG-05 | Re-read authority, history, boundaries, policy, and patterns | PASS | AGENTS, skills, GNO, issue, worktrees, workflow, and repo state | None |
| CG-06 | Public API and documentation parity | N/A | Internal workflow/script only; no API, README, KDoc, or registration surface | None |
| CG-07 through CG-08 | Lock RED/GREEN and serialize task-graph proof | PASS | Validator RED/GREEN, fixtures, actionlint, and sequential dry-runs | None |
| CG-09 | Evaluate lesson gate | N/A | Executable validator captures the reused rule; no novel failure, recovery, design, or operational guidance | None |
| CG-10 through CG-12 | Converge, commit, authorize, and publish exact head | PASS | Commit and remote head `76436898135028119b87645ec0d6a3e81ed5f26a` | None |
| CG-13 | Create and verify the live PR | PASS | PR #1028 at exact head `76436898135028119b87645ec0d6a3e81ed5f26a` with mirrored issue metadata | None |
| CG-14 | Pass exact-head CI and current review | PASS | 8 success, 0 failure/pending; conditional module jobs N/A via CI Status; MERGEABLE/CLEAN; reviews 0; threads 0 | None |
| CG-15 | Report exact-head merge readiness | PASS | PR #1028 at `76436898135028119b87645ec0d6a3e81ed5f26a`, counts 41/46, N/A 5, blocked 0 | None |
| CG-16 through CG-18 | Obtain fresh approval, merge, synchronize, and clean | PASS | Fresh approval; squash commit `1b81cbdb2afde481f31f324bf8168306dbc8786f`; synced develop; bounded worktree cleanup | None |
| CG-X01 | Non-PR irreversible action | N/A | No tag, publish, release, dispatch, or deletion in this lane | None |
| C-01 through C-05 | Diagnose, scope, RED, surgical fix, and GREEN | PASS | Root-cause task graph, two-file diff, fixtures, and verification | None |
| C-06 | Capture a durable lesson | N/A | Regression rule is executable in the validator; no broader lesson needed | None |
| C-07 through C-08 | Deliver and report merge readiness | PASS | PR #1028 exact-head CI/review and Type C report complete | None |
| C-09 | Close out after fresh approval | PASS | Exact PR merged, issue closed, develop synchronized, task worktree removed, local branch retained | None |
| E-01 through E-03 | Route, discover, and preserve ownership | PASS | Maintenance route, GNO/current workflow, exact two-file scope | None |
| E-04 | Chezmoi source/live parity | N/A | Repository workflow files are not user-scope chezmoi surfaces | None |
| E-05 through E-06 | Verify maintenance and durable pre-PR proof | PASS | Validator, actionlint, references, dry-runs, diff check, and review | None |
| E-07 | Deliver through merge-ready | PASS | CG-11 through CG-15 complete for PR #1028 | None |
| E-08 | Close out after fresh approval | PASS | CG-16 through CG-18 completed with verified merge and cleanup | None |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1028 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `1b81cbdb2afde481f31f324bf8168306dbc8786f`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
