### PR TITLE
Run CSV tests for CSV changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
       data: ${{ steps.filter.outputs.data }}
     steps:
       - uses: actions/checkout@v7
+      - name: Validate CSV CI coverage
+        run: ruby scripts/validate-ci-csv-coverage.rb
       - uses: dorny/paths-filter@v4
         id: filter
         with:
@@ -114,6 +116,7 @@ jobs:
               - 'virtualthread/jdk25/**'
             io:
               - 'io/io/**'
+              - 'io/csv/**'
               - 'io/okio/**'
               - 'io/json/**'
               - 'io/jackson2/**'
@@ -310,6 +313,7 @@ jobs:
           command: |
             ./gradlew \
               :bluetape4k-io:test \
+              :bluetape4k-csv:test \
               :bluetape4k-okio:test \
               :bluetape4k-json:test \
               :bluetape4k-jackson2:test \
@@ -326,6 +330,7 @@ jobs:
         run: |
           ./gradlew \
             :bluetape4k-io:koverXmlReport \
+            :bluetape4k-csv:koverXmlReport \
             :bluetape4k-okio:koverXmlReport \
             :bluetape4k-json:koverXmlReport \
             :bluetape4k-jackson2:koverXmlReport \

--- a/scripts/validate-ci-csv-coverage.rb
+++ b/scripts/validate-ci-csv-coverage.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "shellwords"
+require "yaml"
+
+CSV_PATH = "io/csv/**"
+CSV_TEST_TASK = ":bluetape4k-csv:test"
+CSV_KOVER_TASK = ":bluetape4k-csv:koverXmlReport"
+VALIDATOR_COMMAND = ["ruby", "scripts/validate-ci-csv-coverage.rb"].freeze
+IO_OUTPUT = "${{ steps.filter.outputs.io }}"
+TEST_IO_CONDITION = "${{ needs.changes.outputs.io == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}"
+FORBIDDEN_GRADLE_OPTIONS = ["-x", "--exclude-task", "-m", "--dry-run"].freeze
+
+def fail_validation(message)
+  warn message
+  exit 1
+end
+
+def gradle_tokens(command, label)
+  normalized = command.gsub(/\\\r?\n/, " ").strip
+  fail_validation("#{label} must use one simple Gradle invocation") if normalized.match?(/[\r\n#;&|<>$`]/)
+
+  tokens = Shellwords.shellsplit(normalized)
+  fail_validation("#{label} must run through ./gradlew") unless tokens.first == "./gradlew"
+
+  forbidden = tokens.find do |token|
+    FORBIDDEN_GRADLE_OPTIONS.include?(token) ||
+      token.start_with?("-x=", "-x:", "--exclude-task=", "--dry-run=")
+  end
+  fail_validation("#{label} must execute its tasks; forbidden option #{forbidden}") if forbidden
+  tokens
+rescue ArgumentError => error
+  fail_validation("invalid #{label}: #{error.message}")
+end
+
+def require_once(values, expected, label)
+  count = values.count(expected)
+  fail_validation("expected #{expected} exactly once in #{label}, found #{count}") unless count == 1
+end
+
+workflow_path = ARGV.fetch(0, ".github/workflows/ci.yml")
+workflow = YAML.safe_load(File.read(workflow_path), aliases: true)
+jobs = workflow.fetch("jobs")
+
+changes_job = jobs.fetch("changes")
+change_steps = changes_job.fetch("steps")
+validator_steps = change_steps.select do |step|
+  command = step["run"]
+  command && Shellwords.shellsplit(command) == VALIDATOR_COMMAND
+end
+fail_validation("expected the CSV CI validator exactly once in changes job, found #{validator_steps.size}") unless validator_steps.one?
+
+validator_step = validator_steps.first
+fail_validation("CSV CI validator must run unconditionally") if validator_step.key?("if")
+fail_validation("CSV CI validator must fail the changes job") if validator_step.key?("continue-on-error")
+
+io_output = changes_job.fetch("outputs").fetch("io")
+fail_validation("changes.io output must use steps.filter.outputs.io") unless io_output == IO_OUTPUT
+
+filter_step = change_steps.find { |step| step["id"] == "filter" }
+fail_validation("changes job must define the paths-filter step") unless filter_step
+
+filters = YAML.safe_load(filter_step.fetch("with").fetch("filters"), aliases: true)
+io_paths = filters.fetch("io")
+require_once(io_paths, CSV_PATH, "changes.io paths")
+
+test_io_job = jobs.fetch("test-io")
+fail_validation("test-io job must depend on changes") unless Array(test_io_job.fetch("needs")).include?("changes")
+fail_validation("test-io job must use the io scheduling condition") unless test_io_job.fetch("if") == TEST_IO_CONDITION
+
+io_steps = test_io_job.fetch("steps")
+test_step = io_steps.find { |step| step["name"] == "Test io modules" }
+kover_step = io_steps.find { |step| step["name"] == "Generate Kover XML report" }
+fail_validation("test-io job must define Test io modules") unless test_step
+fail_validation("test-io job must define Generate Kover XML report") unless kover_step
+fail_validation("Test io modules must run unconditionally within test-io") if test_step.key?("if")
+fail_validation("Test io modules must fail the test-io job") if test_step.key?("continue-on-error")
+
+test_tokens = gradle_tokens(test_step.fetch("with").fetch("command"), "CSV test command")
+kover_tokens = gradle_tokens(kover_step.fetch("run"), "CSV Kover command")
+fail_validation("Test io modules must include #{CSV_TEST_TASK}") unless test_tokens.include?(CSV_TEST_TASK)
+fail_validation("Generate Kover XML report must include #{CSV_KOVER_TASK}") unless kover_tokens.include?(CSV_KOVER_TASK)
+
+task_tokens = io_steps.flat_map do |step|
+  commands = [step["run"], step.dig("with", "command")].compact
+  commands.select { |command| [CSV_TEST_TASK, CSV_KOVER_TASK].any? { |task| command.include?(task) } }
+          .map { |command| gradle_tokens(command, "test-io CSV command") }
+end.flatten
+require_once(task_tokens, CSV_TEST_TASK, "all test-io commands")
+require_once(task_tokens, CSV_KOVER_TASK, "all test-io commands")
+
+puts "CI CSV coverage is valid"


### PR DESCRIPTION
## Summary

Closes #1001

- PR 제목: Run CSV tests for CSV changes

Closes #1001

Ensure CSV-only pull requests run the existing IO test and coverage gate instead of bypassing CI validation.

## Background

Milestone 1.12.0 issue #1001 identified that `io/csv/**` was absent from the pull-request path filter and that the IO lane omitted the CSV test and Kover tasks.

## What This Solves

- Routes CSV source changes into the existing `Test / IO` job.
- Prevents future drift between the CSV path filter, test task, coverage task, and scheduling chain.

## Work Done

- Updated `.github/workflows/ci.yml` to include the CSV path, test task, Kover task, and an always-running validator step.
- Added `scripts/validate-ci-csv-coverage.rb` to fail closed on missing, duplicate, conditional, disconnected, excluded, or dry-run CSV CI contracts.

## Validation

- `ruby -wc scripts/validate-ci-csv-coverage.rb`: PASS
- `ruby scripts/validate-ci-csv-coverage.rb`: PASS
- `actionlint .github/workflows/ci.yml`: PASS
- `./gradlew :bluetape4k-csv:test --no-configuration-cache`: PASS (275 tests)
- CSV Kover plus IO test/Kover dry-runs: PASS
- 21 adversarial workflow fixtures and `git diff --check`: PASS
- Exact-head GitHub Actions: PASS (17/17 checks)
- `Test / IO` log: PASS (`:bluetape4k-csv:test` and `:bluetape4k-csv:koverXmlReport` executed successfully)

## Review Notes

- P0/P1: 0 remaining
- P2/P3: 0 remaining; independent P1=3/P2=1 validator bypass findings were reproduced and repaired
- Review evidence: completed independent review plus post-repair main-session review; a second post-repair reviewer was stopped after bounded waits produced no result

## Metadata

- Issue: #1001, milestone `1.12.0`, assignee `debop`
- PR: #1029, head `d89f47d231b56523b597face6d3180f02030b5f2`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1001-csv-ci`
- Labels: `bug`, `test`, `ci`, `codex`, `codex-automation`
- State: `MERGED`, merge commit `cf077afa99ca1d4e6a026147e85c134862c03dca`
- CI: Ensure CSV-only pull requests run the existing IO test and coverage gate instead of bypassing CI validation. / - Updated `.github/workflows/ci.yml` to include the CSV path, test task, Kover task, and an always-running validator step. / - Added `scripts/validate-ci-csv-coverage.rb` to fail closed on missing, duplicate, conditional, disconnected, excluded, or dry-run CSV CI contracts.

## DoD Status

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-10 - Pre-PR proof | Converged implementation, validation, and review | PASS | `d89f47d23`; validator/actionlint/Gradle/review evidence | none |
| CG-12 - Publish exact head | Pushed without force and read back remote | PASS | local=remote=`d89f47d23` | none |
| CG-13 - Create PR | Created and verified metadata | PASS | PR #1029; exact base/head/SHA/labels/milestone/assignee | none |
| CG-14 - CI and live review | Verified exact-head checks, mergeability, and threads | PASS | 17/17 SUCCESS; `MERGEABLE/CLEAN`; review threads 0 | none |
| CG-16 - Fresh merge approval | Stop after merge-ready report | PENDING | no post-report approval yet | wait for explicit approval |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1029 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `cf077afa99ca1d4e6a026147e85c134862c03dca`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
