### PR TITLE
Make the issue #754 release-settings gate observable

### DIFF
--- a/.github/release-holds/1.12.0-github-settings.json
+++ b/.github/release-holds/1.12.0-github-settings.json
@@ -1,0 +1,89 @@
+{
+  "apps": {
+    "settings": {
+      "appIdSource": "RELEASE_SETTINGS_APP_ID",
+      "installationIdSource": "RELEASE_SETTINGS_INSTALLATION_ID",
+      "permissions": {
+        "administration": "write",
+        "contents": "read",
+        "metadata": "read"
+      },
+      "privateKeySource": "RELEASE_SETTINGS_APP_PRIVATE_KEY",
+      "slug": "bluetape4k-release-settings-bot"
+    },
+    "tag": {
+      "appIdSource": "RELEASE_TAG_APP_ID",
+      "installationIdSource": "RELEASE_TAG_INSTALLATION_ID",
+      "permissions": {
+        "administration": "none",
+        "contents": "write",
+        "metadata": "read"
+      },
+      "privateKeySource": "RELEASE_TAG_APP_PRIVATE_KEY",
+      "slug": "bluetape4k-release-tag-bot"
+    }
+  },
+  "environments": {
+    "release-tag-1.12.0": {
+      "deploymentBranches": [
+        "develop"
+      ],
+      "requiredReviewerSource": "RELEASE_REVIEWER_ID",
+      "requiredReviewerType": "User",
+      "secretNames": [
+        "CENTRAL_PASSWORD",
+        "CENTRAL_USERNAME",
+        "RELEASE_SETTINGS_APP_PRIVATE_KEY",
+        "RELEASE_TAG_APP_PRIVATE_KEY",
+        "SIGNING_KEY",
+        "SIGNING_KEY_ID",
+        "SIGNING_PASSWORD"
+      ],
+      "variableNames": [
+        "RELEASE_SETTINGS_APP_ID",
+        "RELEASE_TAG_APP_ID"
+      ]
+    },
+    "snapshot-publish-1.12.0": {
+      "deploymentBranches": [
+        "develop"
+      ],
+      "requiredReviewerSource": "RELEASE_REVIEWER_ID",
+      "requiredReviewerType": "User",
+      "secretNames": [
+        "CENTRAL_PASSWORD",
+        "CENTRAL_USERNAME",
+        "SIGNING_KEY",
+        "SIGNING_KEY_ID",
+        "SIGNING_PASSWORD"
+      ],
+      "variableNames": []
+    }
+  },
+  "legacyEnvironmentSecretNames": [
+    "CENTRAL_PASSWORD",
+    "CENTRAL_USERNAME",
+    "SIGNING_KEY",
+    "SIGNING_KEY_ID",
+    "SIGNING_PASSWORD"
+  ],
+  "repository": "bluetape4k/bluetape4k-projects",
+  "repositorySecretNames": [],
+  "repositoryVariableNames": [],
+  "ruleset": {
+    "bypassApp": "tag",
+    "enforcement": "active",
+    "name": "release-tags-1.12.0",
+    "patterns": [
+      "1.12.0",
+      "release-gate-probe/issue-754/*"
+    ],
+    "rules": [
+      "creation",
+      "update",
+      "deletion"
+    ],
+    "target": "tag"
+  },
+  "schemaVersion": 1
+}

--- a/scripts/issue-754-github-settings.py
+++ b/scripts/issue-754-github-settings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import copy
 import hashlib
 import json
@@ -98,7 +99,7 @@ def expected_state(repository: str) -> dict[str, Any]:
             "patterns": list(RULESET_PATTERNS),
             "rules": list(RULESET_RULE_TYPES),
             "bypassActors": [
-                {"actorType": "Integration", "actorId": 7541}
+                {"actorType": "Integration", "actorId": 7541, "bypassMode": "always"}
             ],
         },
         "environments": {
@@ -193,7 +194,7 @@ def validate_settings(state: dict[str, Any]) -> list[str]:
             errors.append("settings App permissions must be exactly Administration write, Contents read, Metadata read")
 
         expected_bypass = [
-            {"actorType": "Integration", "actorId": tag_app.get("appId")}
+            {"actorType": "Integration", "actorId": tag_app.get("appId"), "bypassMode": "always"}
         ]
         if ruleset.get("bypassActors") != expected_bypass:
             errors.append("only tag App may be the ruleset bypass actor")
@@ -230,6 +231,114 @@ def validate_settings(state: dict[str, Any]) -> list[str]:
         errors.append(
             "legacy maven-central-release environment must retain exactly five Maven/signing secret names"
         )
+    return errors
+
+
+def validate_settings_config(config: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    expected_top = {
+        "schemaVersion",
+        "repository",
+        "ruleset",
+        "environments",
+        "apps",
+        "repositorySecretNames",
+        "repositoryVariableNames",
+        "legacyEnvironmentSecretNames",
+    }
+    if set(config) != expected_top:
+        errors.append("settings config fields are missing or unknown")
+        return errors
+    if config.get("schemaVersion") != SCHEMA_VERSION:
+        errors.append(f"settings config schemaVersion must be {SCHEMA_VERSION}")
+    if not isinstance(config.get("repository"), str) or "/" not in config["repository"]:
+        errors.append("settings config repository must be OWNER/REPO")
+
+    ruleset = config.get("ruleset")
+    expected_ruleset = {
+        "name": "release-tags-1.12.0",
+        "target": "tag",
+        "enforcement": "active",
+        "patterns": RULESET_PATTERNS,
+        "rules": RULESET_RULE_TYPES,
+        "bypassApp": "tag",
+    }
+    if ruleset != expected_ruleset:
+        errors.append("settings config ruleset contract is stale or incomplete")
+
+    apps = config.get("apps")
+    expected_app_sources = {
+        "tag": {
+            "appIdSource": "RELEASE_TAG_APP_ID",
+            "installationIdSource": "RELEASE_TAG_INSTALLATION_ID",
+            "privateKeySource": "RELEASE_TAG_APP_PRIVATE_KEY",
+            "permissions": {"administration": "none", "contents": "write", "metadata": "read"},
+        },
+        "settings": {
+            "appIdSource": "RELEASE_SETTINGS_APP_ID",
+            "installationIdSource": "RELEASE_SETTINGS_INSTALLATION_ID",
+            "privateKeySource": "RELEASE_SETTINGS_APP_PRIVATE_KEY",
+            "permissions": {"administration": "write", "contents": "read", "metadata": "read"},
+        },
+    }
+    if not isinstance(apps, dict) or set(apps) != set(expected_app_sources):
+        errors.append("settings config requires distinct tag and settings Apps")
+    else:
+        for role, expected in expected_app_sources.items():
+            app = apps.get(role)
+            expected_fields = set(expected) | {"slug"}
+            if isinstance(app, dict) and any(
+                field in app for field in ("appId", "installationId", "privateKey")
+            ):
+                errors.append(f"{role} App config must not contain a literal App identity or private key")
+            if not isinstance(app, dict) or set(app) != expected_fields:
+                errors.append(f"{role} App config fields are missing or unknown")
+                continue
+            if not isinstance(app.get("slug"), str) or not app["slug"]:
+                errors.append(f"{role} App slug must be non-empty")
+            for field, value in expected.items():
+                if app.get(field) != value:
+                    errors.append(f"{role} App {field} source or permissions are invalid")
+
+    environments = config.get("environments")
+    if not isinstance(environments, dict) or set(environments) != {
+        "snapshot-publish-1.12.0",
+        "release-tag-1.12.0",
+    }:
+        errors.append("settings config requires the exact 1.12.0 environments")
+    else:
+        for name, secret_names, variable_names in (
+            ("snapshot-publish-1.12.0", MAVEN_SECRET_NAMES, []),
+            ("release-tag-1.12.0", RELEASE_SECRET_NAMES, RELEASE_VARIABLE_NAMES),
+        ):
+            environment = environments.get(name)
+            expected_fields = {
+                "deploymentBranches",
+                "requiredReviewerSource",
+                "requiredReviewerType",
+                "secretNames",
+                "variableNames",
+            }
+            if not isinstance(environment, dict) or set(environment) != expected_fields:
+                errors.append(f"{name} config fields are missing or unknown")
+                continue
+            if environment.get("deploymentBranches") != ["develop"]:
+                errors.append(f"{name} must allow only develop")
+            if environment.get("requiredReviewerSource") != "RELEASE_REVIEWER_ID":
+                errors.append(f"{name} reviewer must come from RELEASE_REVIEWER_ID")
+            if environment.get("requiredReviewerType") != "User":
+                errors.append(f"{name} reviewer type must be User")
+            if sorted(environment.get("secretNames") or []) != secret_names:
+                errors.append(f"{name} secret-name ownership is invalid")
+            if sorted(environment.get("variableNames") or []) != variable_names:
+                errors.append(f"{name} variable-name ownership is invalid")
+
+    if config.get("repositorySecretNames") != []:
+        errors.append("settings config must not retain repository secrets")
+    if config.get("repositoryVariableNames") != []:
+        errors.append("settings config must not retain repository variables")
+    if sorted(config.get("legacyEnvironmentSecretNames") or []) != MAVEN_SECRET_NAMES:
+        errors.append("settings config must retain the five generic-release environment secrets")
     return errors
 
 
@@ -632,6 +741,300 @@ def gh_api(
     if paginate and isinstance(body, list) and all(isinstance(page, list) for page in body):
         body = [item for page in body for item in page]
     return result.returncode, body
+
+
+def require_live_token() -> str:
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        return token
+    result = subprocess.run(
+        ["gh", "auth", "token"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        raise SettingsError("GitHub authentication is required for live read-only snapshot")
+    return result.stdout.strip()
+
+
+def named_items(payload: Any, field: str) -> list[str]:
+    pages = payload if isinstance(payload, list) else [payload]
+    names: list[str] = []
+    for page in pages:
+        if not isinstance(page, dict):
+            raise SettingsError(f"GitHub {field} listing returned an invalid payload")
+        items = page.get(field)
+        if not isinstance(items, list):
+            raise SettingsError(f"GitHub {field} listing returned an invalid payload")
+        total_count = page.get("total_count")
+        if isinstance(total_count, int) and total_count != len(items):
+            raise SettingsError(f"GitHub {field} listing is incomplete")
+        for item in items:
+            if not isinstance(item, dict) or not isinstance(item.get("name"), str):
+                raise SettingsError(f"GitHub {field} listing contains an invalid {field} entry")
+            names.append(item["name"])
+    return sorted(set(names))
+
+
+def normalize_ruleset(ruleset: dict[str, Any]) -> dict[str, Any]:
+    ref_name = (ruleset.get("conditions") or {}).get("ref_name") or {}
+    patterns = []
+    for pattern in ref_name.get("include") or []:
+        patterns.append(pattern.removeprefix("refs/tags/") if isinstance(pattern, str) else pattern)
+    bypass_actors = []
+    for actor in ruleset.get("bypass_actors") or []:
+        if isinstance(actor, dict):
+            bypass_actors.append({
+                "actorType": actor.get("actor_type"),
+                "actorId": actor.get("actor_id"),
+                "bypassMode": actor.get("bypass_mode"),
+            })
+    rule_types = [
+        rule.get("type") if isinstance(rule, dict) else rule
+        for rule in ruleset.get("rules") or []
+    ]
+    return {
+        "id": ruleset.get("id"),
+        "name": ruleset.get("name"),
+        "target": ruleset.get("target"),
+        "enforcement": ruleset.get("enforcement"),
+        "patterns": patterns,
+        "rules": rule_types,
+        "bypassActors": bypass_actors,
+    }
+
+
+def reviewer_names(environment: dict[str, Any]) -> list[dict[str, Any]]:
+    reviewers: list[dict[str, Any]] = []
+    for rule in environment.get("protection_rules") or []:
+        if not isinstance(rule, dict) or rule.get("type") != "required_reviewers":
+            continue
+        for entry in rule.get("reviewers") or []:
+            if not isinstance(entry, dict):
+                continue
+            reviewer = entry.get("reviewer") or {}
+            reviewer_type = entry.get("type")
+            reviewer_id = reviewer.get("id")
+            name = reviewer.get("login") or reviewer.get("slug") or reviewer.get("name")
+            if not isinstance(reviewer_type, str) or not isinstance(reviewer_id, int) or not isinstance(name, str):
+                raise SettingsError("GitHub required reviewer entry is invalid")
+            reviewers.append({"type": reviewer_type, "id": reviewer_id, "name": name})
+    return sorted(reviewers, key=lambda item: (item["type"], item["id"], item["name"]))
+
+
+def deployment_branch_names(payload: Any) -> list[str]:
+    pages = payload if isinstance(payload, list) else [payload]
+    for page in pages:
+        if not isinstance(page, dict):
+            raise SettingsError("GitHub branch_policies listing returned an invalid payload")
+        policies = page.get("branch_policies")
+        if not isinstance(policies, list):
+            raise SettingsError("GitHub branch_policies listing returned an invalid payload")
+        for policy in policies:
+            if not isinstance(policy, dict) or policy.get("type") != "branch":
+                raise SettingsError("GitHub deployment policy is not an explicit branch policy")
+    return named_items(payload, "branch_policies")
+
+
+def snapshot_environment(repository: str, name: str, token: str) -> dict[str, Any] | None:
+    base = f"repos/{repository}/environments/{name}"
+    code, environment = gh_api(base, token, check=False)
+    if code != 0:
+        if isinstance(environment, dict) and str(environment.get("status")) == "404":
+            return None
+        raise SettingsError(f"GitHub environment read failed: {name}")
+    if not isinstance(environment, dict):
+        raise SettingsError(f"GitHub environment read returned an invalid payload: {name}")
+
+    deployment_branches: list[str] = []
+    branch_policy = environment.get("deployment_branch_policy")
+    if isinstance(branch_policy, dict) and branch_policy.get("custom_branch_policies") is True:
+        _, policies = gh_api(f"{base}/deployment-branch-policies?per_page=100", token)
+        deployment_branches = deployment_branch_names(policies)
+    _, secrets = gh_api(f"{base}/secrets?per_page=100", token)
+    _, variables = gh_api(f"{base}/variables?per_page=100", token)
+    return {
+        "deploymentBranches": deployment_branches,
+        "requiredReviewers": reviewer_names(environment),
+        "secretNames": named_items(secrets, "secrets"),
+        "variableNames": named_items(variables, "variables"),
+    }
+
+
+def snapshot_live(repository: str, token: str) -> dict[str, Any]:
+    state = empty_state(repository)
+    rulesets = list_rulesets(repository, token)
+    matches = [ruleset for ruleset in rulesets if ruleset.get("name") == "release-tags-1.12.0"]
+    if len(matches) > 1:
+        raise SettingsError("multiple release-tags-1.12.0 rulesets found")
+    if matches:
+        ruleset_id = matches[0].get("id")
+        _, ruleset = gh_api(f"repos/{repository}/rulesets/{ruleset_id}", token)
+        if not isinstance(ruleset, dict):
+            raise SettingsError("GitHub ruleset read returned an invalid payload")
+        state["ruleset"] = normalize_ruleset(ruleset)
+
+    for name in ("snapshot-publish-1.12.0", "release-tag-1.12.0"):
+        environment = snapshot_environment(repository, name, token)
+        if environment is not None:
+            state["environments"][name] = environment
+
+    legacy = snapshot_environment(repository, "maven-central-release", token)
+    if legacy is not None:
+        state["legacyEnvironmentSecretNames"] = legacy["secretNames"]
+    _, repository_secrets = gh_api(f"repos/{repository}/actions/secrets?per_page=100", token)
+    _, repository_variables = gh_api(f"repos/{repository}/actions/variables?per_page=100", token)
+    state["repositorySecretNames"] = named_items(repository_secrets, "secrets")
+    state["repositoryVariableNames"] = named_items(repository_variables, "variables")
+    return state
+
+
+def base64url(payload: bytes) -> str:
+    return base64.urlsafe_b64encode(payload).rstrip(b"=").decode("ascii")
+
+
+def mint_app_jwt(app_id: int, private_key: str, *, now: int | None = None) -> str:
+    timestamp = int(time.time()) if now is None else now
+    header = base64url(json.dumps(
+        {"alg": "RS256", "typ": "JWT"},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8"))
+    claims = base64url(json.dumps(
+        {"exp": timestamp + 540, "iat": timestamp - 60, "iss": app_id},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8"))
+    signing_input = f"{header}.{claims}".encode("ascii")
+    with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8") as key_file:
+        os.chmod(key_file.name, 0o600)
+        key_file.write(private_key)
+        key_file.flush()
+        result = subprocess.run(
+            ["openssl", "dgst", "-sha256", "-sign", key_file.name],
+            input=signing_input,
+            capture_output=True,
+            check=False,
+        )
+    if result.returncode != 0:
+        raise SettingsError("GitHub App JWT signing failed")
+    return f"{header}.{claims}.{base64url(result.stdout)}"
+
+
+def source_integer(name: str) -> int:
+    try:
+        value = int(require_token(name))
+    except ValueError as error:
+        raise SettingsError(f"{name} must contain a positive integer") from error
+    if value <= 0:
+        raise SettingsError(f"{name} must contain a positive integer")
+    return value
+
+
+def snapshot_configured_apps(repository: str, config: dict[str, Any]) -> dict[str, Any]:
+    apps: dict[str, Any] = {}
+    for role in ("tag", "settings"):
+        app_config = config["apps"][role]
+        app_id = source_integer(app_config["appIdSource"])
+        private_key = require_token(app_config["privateKeySource"])
+        app_jwt = mint_app_jwt(app_id, private_key)
+        _, installation = gh_api(f"repos/{repository}/installation", app_jwt)
+        if not isinstance(installation, dict):
+            raise SettingsError(f"{role} App installation read returned an invalid payload")
+        observed = {
+            "slug": installation.get("app_slug"),
+            "appId": installation.get("app_id"),
+            "installationId": installation.get("id"),
+            "permissions": installation.get("permissions"),
+        }
+        if (
+            not isinstance(observed["slug"], str)
+            or not isinstance(observed["appId"], int)
+            or not isinstance(observed["installationId"], int)
+            or not isinstance(observed["permissions"], dict)
+        ):
+            raise SettingsError(f"{role} App installation payload is incomplete")
+        apps[role] = observed
+    return apps
+
+
+def credential_source_names(config: dict[str, Any]) -> list[str]:
+    names = set(MAVEN_SECRET_NAMES)
+    for app in (config.get("apps") or {}).values():
+        if not isinstance(app, dict):
+            continue
+        for field in ("appIdSource", "installationIdSource", "privateKeySource"):
+            source = app.get(field)
+            if isinstance(source, str):
+                names.add(source)
+    for environment in (config.get("environments") or {}).values():
+        if not isinstance(environment, dict):
+            continue
+        reviewer_source = environment.get("requiredReviewerSource")
+        if isinstance(reviewer_source, str):
+            names.add(reviewer_source)
+    return sorted(names)
+
+
+def live_authority_errors(config: dict[str, Any], current: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    apps = current.get("apps") or {}
+    for role in ("tag", "settings"):
+        app_config = config["apps"][role]
+        observed = apps.get(role) or {}
+        expected = {
+            "slug": app_config["slug"],
+            "appId": source_integer(app_config["appIdSource"]),
+            "installationId": source_integer(app_config["installationIdSource"]),
+            "permissions": app_config["permissions"],
+        }
+        if observed != expected:
+            errors.append(f"{role} App installation identity or permissions do not match configured authority")
+
+    for name, environment_config in config["environments"].items():
+        environment = (current.get("environments") or {}).get(name) or {}
+        reviewers = environment.get("requiredReviewers") or []
+        expected_type = environment_config["requiredReviewerType"]
+        expected_id = source_integer(environment_config["requiredReviewerSource"])
+        identities = [
+            (reviewer.get("type"), reviewer.get("id"))
+            for reviewer in reviewers
+            if isinstance(reviewer, dict)
+        ]
+        if identities != [(expected_type, expected_id)]:
+            errors.append(f"{name} reviewer does not match configured authority")
+    return errors
+
+
+def verify_live_config(repository: str, config: dict[str, Any], token: str) -> dict[str, Any]:
+    config_errors = validate_settings_config(config)
+    if config.get("repository") != repository:
+        config_errors.append("settings config repository does not match --repository")
+    current = snapshot_live(repository, token)
+    source_names = credential_source_names(config)
+    source_presence = {name: bool(os.environ.get(name)) for name in source_names}
+    missing_sources = [name for name, present in source_presence.items() if not present]
+    authority_errors: list[str] = []
+    if not config_errors and not missing_sources:
+        current["apps"] = snapshot_configured_apps(repository, config)
+        authority_errors = live_authority_errors(config, current)
+    state_errors = validate_settings(current)
+    decision = (
+        "PASS"
+        if not config_errors and not state_errors and not authority_errors and not missing_sources
+        else "HOLD"
+    )
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "decision": decision,
+        "configErrors": config_errors,
+        "stateErrors": state_errors,
+        "authorityErrors": authority_errors,
+        "currentStateSha256": stable_hash(current),
+        "credentialSourcePresence": source_presence,
+        "missingCredentialSources": missing_sources,
+    }
 
 
 def require_token(name: str) -> str:
@@ -1461,11 +1864,13 @@ def add_common(parser: argparse.ArgumentParser, *, output: bool = True) -> None:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Issue #754 GitHub release-setting state machine (fixture-safe in Task 4)"
+        description="Issue #754 GitHub release-setting state machine"
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
-    for command in ("snapshot", "verify"):
-        add_common(subparsers.add_parser(command))
+    add_common(subparsers.add_parser("snapshot"))
+    verify_settings_parser = subparsers.add_parser("verify")
+    add_common(verify_settings_parser)
+    verify_settings_parser.add_argument("--config", type=Path)
 
     probe_parser = subparsers.add_parser("probe")
     add_common(probe_parser)
@@ -1631,6 +2036,16 @@ def main(argv: list[str] | None = None) -> int:
             report = {"schemaVersion": SCHEMA_VERSION, "decision": "PASS" if not errors else "HOLD", "errors": errors}
             write_json(args.output, report)
             return 0 if not errors else 3
+
+        if args.command == "snapshot" and args.fixture_state is None:
+            write_json(args.output, snapshot_live(args.repository, require_live_token()))
+            return 0
+        if args.command == "verify" and args.fixture_state is None:
+            if args.config is None:
+                raise SettingsError("live verify requires --config")
+            report = verify_live_config(args.repository, read_json(args.config), require_live_token())
+            write_json(args.output, report)
+            return 0 if report["decision"] == "PASS" else 3
 
         current = require_fixture(args)
         if current.get("repository") != args.repository:

--- a/scripts/test_issue_754_github_settings.py
+++ b/scripts/test_issue_754_github_settings.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 
+import base64
 import copy
 import importlib.util
 import json
+import os
+import stat
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -48,7 +52,11 @@ class GitHubSettingsStateMachineTest(unittest.TestCase):
         state["apps"]["tag"]["permissions"]["administration"] = "write"
         state["apps"]["settings"]["permissions"]["contents"] = "write"
         state["ruleset"]["bypassActors"] = [
-            {"actorType": "Integration", "actorId": state["apps"]["settings"]["installationId"]}
+            {
+                "actorType": "Integration",
+                "actorId": state["apps"]["settings"]["installationId"],
+                "bypassMode": "always",
+            }
         ]
         errors = self.settings.validate_settings(state)
         self.assertTrue(any("distinct" in error for error in errors), errors)
@@ -68,6 +76,334 @@ class GitHubSettingsStateMachineTest(unittest.TestCase):
         state["legacyEnvironmentSecretNames"] = ["SIGNING_KEY"]
         errors = self.settings.validate_settings(state)
         self.assertTrue(any("maven-central-release environment" in error for error in errors), errors)
+
+    def test_checked_config_uses_named_sources_without_literal_credentials(self):
+        config_path = REPOSITORY / ".github" / "release-holds" / "1.12.0-github-settings.json"
+        config = self.settings.read_json(config_path)
+
+        self.assertEqual([], self.settings.validate_settings_config(config))
+        serialized = json.dumps(config, sort_keys=True)
+        self.assertNotIn('"appId"', serialized)
+        self.assertNotIn('"installationId"', serialized)
+        self.assertNotIn('"privateKey"', serialized)
+        self.assertEqual(
+            "RELEASE_TAG_APP_ID",
+            config["apps"]["tag"]["appIdSource"],
+        )
+        self.assertEqual(
+            "RELEASE_SETTINGS_APP_PRIVATE_KEY",
+            config["apps"]["settings"]["privateKeySource"],
+        )
+
+    def test_checked_config_rejects_literal_or_placeholder_app_identity(self):
+        config = self.settings.read_json(
+            REPOSITORY / ".github" / "release-holds" / "1.12.0-github-settings.json"
+        )
+        config["apps"]["tag"]["appId"] = 7541
+        config["apps"]["settings"]["installationId"] = 75402
+
+        errors = self.settings.validate_settings_config(config)
+
+        self.assertTrue(any("literal App identity" in error for error in errors), errors)
+
+    def test_live_snapshot_normalizes_rulesets_environments_and_name_only_scopes(self):
+        repository = "bluetape4k/bluetape4k-projects"
+        responses = {
+            f"repos/{repository}/rulesets?per_page=100": (0, [{
+                "id": 9001,
+                "name": "release-tags-1.12.0",
+            }]),
+            f"repos/{repository}/rulesets/9001": (0, {
+                "id": 9001,
+                "name": "release-tags-1.12.0",
+                "target": "tag",
+                "enforcement": "active",
+                "conditions": {"ref_name": {"include": [
+                    "refs/tags/1.12.0",
+                    "refs/tags/release-gate-probe/issue-754/*",
+                ]}},
+                "rules": [{"type": "creation"}, {"type": "update"}, {"type": "deletion"}],
+                "bypass_actors": [{
+                    "actor_type": "Integration",
+                    "actor_id": 42001,
+                    "bypass_mode": "always",
+                }],
+            }),
+            f"repos/{repository}/environments/snapshot-publish-1.12.0": (0, {
+                "name": "snapshot-publish-1.12.0",
+                "deployment_branch_policy": {
+                    "protected_branches": False,
+                    "custom_branch_policies": True,
+                },
+                "protection_rules": [{
+                    "type": "required_reviewers",
+                    "reviewers": [{"type": "User", "reviewer": {"login": "debop", "id": 17}}],
+                }],
+            }),
+            f"repos/{repository}/environments/snapshot-publish-1.12.0/deployment-branch-policies?per_page=100": (
+                0,
+                {"branch_policies": [{"name": "develop", "type": "branch"}]},
+            ),
+            f"repos/{repository}/environments/snapshot-publish-1.12.0/secrets?per_page=100": (
+                0,
+                {"secrets": [{"name": name, "value": "must-not-be-copied"} for name in self.settings.MAVEN_SECRET_NAMES]},
+            ),
+            f"repos/{repository}/environments/snapshot-publish-1.12.0/variables?per_page=100": (0, {"variables": []}),
+            f"repos/{repository}/environments/release-tag-1.12.0": (1, {"message": "Not Found", "status": "404"}),
+            f"repos/{repository}/environments/maven-central-release": (0, {
+                "name": "maven-central-release",
+                "deployment_branch_policy": None,
+                "protection_rules": [],
+            }),
+            f"repos/{repository}/environments/maven-central-release/secrets?per_page=100": (
+                0,
+                {"secrets": [{"name": "CENTRAL_USERNAME"}]},
+            ),
+            f"repos/{repository}/environments/maven-central-release/variables?per_page=100": (0, {"variables": []}),
+            f"repos/{repository}/actions/secrets?per_page=100": (0, {"secrets": [{"name": "REPO_ONLY"}]}),
+            f"repos/{repository}/actions/variables?per_page=100": (0, {"variables": [{"name": "REPO_VAR"}]}),
+        }
+
+        def fake_api(endpoint, token, **kwargs):
+            return responses[endpoint]
+
+        with mock.patch.object(self.settings, "gh_api", side_effect=fake_api):
+            state = self.settings.snapshot_live(repository, "read-token")
+
+        self.assertEqual(self.settings.RULESET_PATTERNS, state["ruleset"]["patterns"])
+        self.assertEqual(
+            [{"actorType": "Integration", "actorId": 42001, "bypassMode": "always"}],
+            state["ruleset"]["bypassActors"],
+        )
+        self.assertEqual(
+            ["develop"],
+            state["environments"]["snapshot-publish-1.12.0"]["deploymentBranches"],
+        )
+        self.assertEqual(
+            [{"type": "User", "id": 17, "name": "debop"}],
+            state["environments"]["snapshot-publish-1.12.0"]["requiredReviewers"],
+        )
+        self.assertEqual(self.settings.MAVEN_SECRET_NAMES, state["environments"]["snapshot-publish-1.12.0"]["secretNames"])
+        self.assertNotIn("release-tag-1.12.0", state["environments"])
+        self.assertEqual(["CENTRAL_USERNAME"], state["legacyEnvironmentSecretNames"])
+        self.assertEqual(["REPO_ONLY"], state["repositorySecretNames"])
+        self.assertEqual(["REPO_VAR"], state["repositoryVariableNames"])
+        self.assertNotIn("must-not-be-copied", json.dumps(state))
+
+    def test_snapshot_cli_uses_live_read_only_path_without_fixture(self):
+        repository = "bluetape4k/bluetape4k-projects"
+        state = self.settings.empty_state(repository)
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "pre-state.json"
+            with mock.patch.object(self.settings, "require_live_token", return_value="read-token"), mock.patch.object(
+                self.settings,
+                "snapshot_live",
+                return_value=state,
+            ) as snapshot:
+                exit_code = self.settings.main([
+                    "snapshot",
+                    "--repository",
+                    repository,
+                    "--output",
+                    str(output),
+                ])
+
+            self.assertEqual(0, exit_code)
+            snapshot.assert_called_once_with(repository, "read-token")
+            self.assertEqual(state, json.loads(output.read_text(encoding="utf-8")))
+
+    def test_live_verify_reports_credential_presence_without_values(self):
+        repository = "bluetape4k/bluetape4k-projects"
+        config = REPOSITORY / ".github" / "release-holds" / "1.12.0-github-settings.json"
+        state = self.settings.empty_state(repository)
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "verify.json"
+            environment = {
+                "RELEASE_TAG_APP_ID": "42001",
+                "RELEASE_TAG_APP_PRIVATE_KEY": "super-secret-private-key",
+            }
+            with mock.patch.object(self.settings, "require_live_token", return_value="read-token"), mock.patch.object(
+                self.settings,
+                "snapshot_live",
+                return_value=state,
+            ), mock.patch.dict(self.settings.os.environ, environment, clear=True):
+                exit_code = self.settings.main([
+                    "verify",
+                    "--repository",
+                    repository,
+                    "--config",
+                    str(config),
+                    "--output",
+                    str(output),
+                ])
+
+            report = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(3, exit_code)
+            self.assertEqual("HOLD", report["decision"])
+            self.assertTrue(report["credentialSourcePresence"]["RELEASE_TAG_APP_ID"])
+            self.assertFalse(report["credentialSourcePresence"]["RELEASE_SETTINGS_APP_ID"])
+            self.assertIn("RELEASE_SETTINGS_APP_ID", report["missingCredentialSources"])
+            self.assertNotIn("super-secret-private-key", output.read_text(encoding="utf-8"))
+
+    def test_name_inventory_rejects_malformed_entries(self):
+        with self.assertRaisesRegex(self.settings.SettingsError, "invalid secrets entry"):
+            self.settings.named_items({"secrets": [{"name": 123}]}, "secrets")
+        with self.assertRaisesRegex(self.settings.SettingsError, "incomplete"):
+            self.settings.named_items(
+                {"total_count": 2, "secrets": [{"name": "ONLY_ONE"}]},
+                "secrets",
+            )
+
+    def test_deployment_policy_requires_branch_type(self):
+        with self.assertRaisesRegex(self.settings.SettingsError, "explicit branch policy"):
+            self.settings.deployment_branch_names({
+                "branch_policies": [{"name": "develop", "type": "tag"}],
+            })
+
+    def test_configured_apps_use_separate_jwts_and_observed_installation_permissions(self):
+        config = self.settings.read_json(
+            REPOSITORY / ".github" / "release-holds" / "1.12.0-github-settings.json"
+        )
+        environment = {
+            "RELEASE_TAG_APP_ID": "42001",
+            "RELEASE_TAG_INSTALLATION_ID": "43001",
+            "RELEASE_TAG_APP_PRIVATE_KEY": "tag-private-key",
+            "RELEASE_SETTINGS_APP_ID": "42002",
+            "RELEASE_SETTINGS_INSTALLATION_ID": "43002",
+            "RELEASE_SETTINGS_APP_PRIVATE_KEY": "settings-private-key",
+        }
+        installations = {
+            "tag-jwt": {
+                "id": 43001,
+                "app_id": 42001,
+                "app_slug": "bluetape4k-release-tag-bot",
+                "permissions": {"administration": "none", "contents": "write", "metadata": "read"},
+            },
+            "settings-jwt": {
+                "id": 43002,
+                "app_id": 42002,
+                "app_slug": "bluetape4k-release-settings-bot",
+                "permissions": {"administration": "write", "contents": "read", "metadata": "read"},
+            },
+        }
+
+        def fake_jwt(app_id, private_key):
+            self.assertNotEqual("", private_key)
+            return "tag-jwt" if app_id == 42001 else "settings-jwt"
+
+        def fake_api(endpoint, token, **kwargs):
+            self.assertEqual("repos/bluetape4k/bluetape4k-projects/installation", endpoint)
+            return 0, installations[token]
+
+        with mock.patch.dict(self.settings.os.environ, environment, clear=True), mock.patch.object(
+            self.settings,
+            "mint_app_jwt",
+            side_effect=fake_jwt,
+        ), mock.patch.object(self.settings, "gh_api", side_effect=fake_api):
+            apps = self.settings.snapshot_configured_apps(
+                "bluetape4k/bluetape4k-projects",
+                config,
+            )
+
+        self.assertEqual(42001, apps["tag"]["appId"])
+        self.assertEqual(43002, apps["settings"]["installationId"])
+        self.assertEqual("write", apps["settings"]["permissions"]["administration"])
+
+    def test_app_jwt_keeps_private_key_out_of_arguments_and_uses_private_temp_file(self):
+        private_key = "private-key-material"
+
+        def fake_run(command, **kwargs):
+            self.assertNotIn(private_key, " ".join(command))
+            key_path = Path(command[-1])
+            self.assertEqual(private_key, key_path.read_text(encoding="utf-8"))
+            self.assertEqual(0o600, stat.S_IMODE(os.stat(key_path).st_mode))
+            self.assertNotIn(private_key.encode("utf-8"), kwargs["input"])
+            return subprocess.CompletedProcess(command, 0, stdout=b"signature", stderr=b"")
+
+        with mock.patch.object(self.settings.subprocess, "run", side_effect=fake_run):
+            token = self.settings.mint_app_jwt(42001, private_key, now=1_000)
+
+        header, claims, signature = token.split(".")
+
+        def decode(segment):
+            return json.loads(base64.urlsafe_b64decode(segment + "=" * (-len(segment) % 4)))
+
+        self.assertEqual({"alg": "RS256", "typ": "JWT"}, decode(header))
+        self.assertEqual({"exp": 1540, "iat": 940, "iss": 42001}, decode(claims))
+        self.assertEqual(self.settings.base64url(b"signature"), signature)
+
+    def test_live_verify_passes_only_for_exact_apps_reviewer_and_sources(self):
+        repository = "bluetape4k/bluetape4k-projects"
+        config = self.settings.read_json(
+            REPOSITORY / ".github" / "release-holds" / "1.12.0-github-settings.json"
+        )
+        state = self.settings.expected_state(repository)
+        state["apps"] = {
+            "tag": {
+                "slug": "bluetape4k-release-tag-bot",
+                "appId": 42001,
+                "installationId": 43001,
+                "permissions": {"administration": "none", "contents": "write", "metadata": "read"},
+            },
+            "settings": {
+                "slug": "bluetape4k-release-settings-bot",
+                "appId": 42002,
+                "installationId": 43002,
+                "permissions": {"administration": "write", "contents": "read", "metadata": "read"},
+            },
+        }
+        state["ruleset"]["bypassActors"] = [{
+            "actorType": "Integration",
+            "actorId": 42001,
+            "bypassMode": "always",
+        }]
+        reviewer = {"type": "User", "id": 17, "name": "debop"}
+        for environment in state["environments"].values():
+            environment["requiredReviewers"] = [reviewer]
+        source_environment = {name: "present" for name in self.settings.MAVEN_SECRET_NAMES}
+        source_environment.update({
+            "RELEASE_REVIEWER_ID": "17",
+            "RELEASE_TAG_APP_ID": "42001",
+            "RELEASE_TAG_INSTALLATION_ID": "43001",
+            "RELEASE_TAG_APP_PRIVATE_KEY": "tag-private-key",
+            "RELEASE_SETTINGS_APP_ID": "42002",
+            "RELEASE_SETTINGS_INSTALLATION_ID": "43002",
+            "RELEASE_SETTINGS_APP_PRIVATE_KEY": "settings-private-key",
+        })
+
+        snapshot_without_apps = copy.deepcopy(state)
+        snapshot_without_apps["apps"] = {}
+        with mock.patch.dict(self.settings.os.environ, source_environment, clear=True), mock.patch.object(
+            self.settings,
+            "snapshot_live",
+            return_value=snapshot_without_apps,
+        ), mock.patch.object(
+            self.settings,
+            "snapshot_configured_apps",
+            return_value=state["apps"],
+        ):
+            report = self.settings.verify_live_config(repository, config, "read-token")
+
+        self.assertEqual("PASS", report["decision"], report)
+        self.assertEqual([], report["stateErrors"])
+        self.assertEqual([], report["authorityErrors"])
+
+        wrong_reviewer = copy.deepcopy(snapshot_without_apps)
+        for environment in wrong_reviewer["environments"].values():
+            environment["requiredReviewers"] = [{"type": "User", "id": 99, "name": "other"}]
+        with mock.patch.dict(self.settings.os.environ, source_environment, clear=True), mock.patch.object(
+            self.settings,
+            "snapshot_live",
+            return_value=wrong_reviewer,
+        ), mock.patch.object(
+            self.settings,
+            "snapshot_configured_apps",
+            return_value=state["apps"],
+        ):
+            report = self.settings.verify_live_config(repository, config, "read-token")
+
+        self.assertEqual("HOLD", report["decision"])
+        self.assertTrue(any("reviewer" in error for error in report["authorityErrors"]), report)
 
     def test_accepted_response_loss_reconciles_from_readback(self):
         current = self.settings.empty_state("bluetape4k/bluetape4k-projects")


### PR DESCRIPTION
## Summary

Closes #754

- PR 제목: Make the issue #754 release-settings gate observable

Related to #754.

Repairs the post-PR1 Task 5 precondition that blocked the stacked ByteBuffer serializer work. The merged CLI only supported fixture state, while the approved plan requires a real read-only GitHub settings snapshot and an authority-bound live verification report before any repository-setting mutation.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: What Changed

- Adds a checked, value-free desired-state contract for the 1.12.0 ruleset, protected environments, App identities, reviewer source, and credential scopes.
- Adds live read-only `snapshot` support for rulesets, environments, deployment branch policies, reviewer identities, and repository/environment secret and variable names.
- Adds live `verify --config` reporting with credential-source presence only; values are never persisted.
- Binds the two configured GitHub Apps to separate JWT-authenticated repository installation readbacks and exact observed permissions.
- Fails closed on malformed or incomplete REST inventories, wrong reviewer identity, wrong bypass mode, and non-branch deployment policies.
- Preserves all existing fixture CLI behavior and immutable-closeout commands.

### 기존 섹션: Current Hold

No GitHub settings, secrets, Apps, tags, probes, workflows, or publications were mutated. Task 6 / PR2 remains blocked until the required credential sources exist and Task 5 receives a separate fresh settings-mutation approval followed by green apply, readback, isolation, probe, and rollback evidence.

Required source groups:

- Maven/signing: `CENTRAL_USERNAME`, `CENTRAL_PASSWORD`, `SIGNING_KEY`, `SIGNING_KEY_ID`, `SIGNING_PASSWORD`
- Reviewer: `RELEASE_REVIEWER_ID`
- Tag App: `RELEASE_TAG_APP_ID`, `RELEASE_TAG_INSTALLATION_ID`, `RELEASE_TAG_APP_PRIVATE_KEY`
- Settings App: `RELEASE_SETTINGS_APP_ID`, `RELEASE_SETTINGS_INSTALLATION_ID`, `RELEASE_SETTINGS_APP_PRIVATE_KEY`

### 기존 섹션: Stack Metadata

- Issue: #754
- Milestone: `1.12.0`
- Base: `develop@fe6cf6ac76b1a90c613642a44b106c3c4a4f3d73`
- Head: `99ba931384ada9e425c84fe502a9a5b0602c1177`
- Role: Task 5 tooling repair before PR2 core serializers
- Does not close #754

## Validation

- `python3 -m unittest scripts/test_issue_754_github_settings.py -v`: PASS, 47 tests
- `python3 -m unittest scripts/test_check_release_holds.py -v`: PASS, 27 tests
- `python3 -m py_compile scripts/issue-754-github-settings.py scripts/test_issue_754_github_settings.py`: PASS
- `ruff check scripts/issue-754-github-settings.py scripts/test_issue_754_github_settings.py`: PASS
- `git diff --check`: PASS
- Live read-only snapshot: PASS, checksum `77bd1718eeb30da097f6c61b9663aeac0154a4eb15ae3af8ea1f06d1d03f4e07`
- Live `verify --config`: expected `HOLD(3)`, config errors 0, missing credential sources 12, current-state errors 13

## Review Notes

The initial independent security/Ops review found three P1 issues: permanently-HOLD App state, reviewer ID not bound, and malformed list entries being ignored. All three were repaired with regression coverage. Additional fail-closed checks cover bypass mode, deployment policy type, inventory completeness, and private-key argument/temp-file handling.

## Metadata

- Issue: #754, milestone `1.12.0`, assignee `debop`
- PR: #1032, head `99ba931384ada9e425c84fe502a9a5b0602c1177`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-754-live-settings-gate`
- Labels: `enhancement`, `performance`, `infra/io`
- State: `MERGED`, merge commit `889a398b3cde8aefb3e8ad520b01a62e54c0567a`
- CI: - Adds live read-only `snapshot` support for rulesets, environments, deployment branch policies, reviewer identities, and repository/environment secret and variable names. / - Fails closed on malformed or incomplete REST inventories, wrong reviewer identity, wrong bypass mode, and non-branch deployment policies.

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1032 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `889a398b3cde8aefb3e8ad520b01a62e54c0567a`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
