### PR TITLE
perf(io): add lower-copy ByteBuffer paths to core serializers

### DIFF
--- a/docs/evidence/issue-754/contract/abi-report.json
+++ b/docs/evidence/issue-754/contract/abi-report.json
@@ -8,7 +8,7 @@
     {
       "module": "io",
       "path": "io/io/build/libs/bluetape4k-io-1.12.0.jar",
-      "sha256": "ab7c38e76022f1e57c09b3a26cae08bdc0a1e0ee7e48c79b02d333cbe3bc9c19"
+      "sha256": "a89f9aa75d40b2addc58475109493dad5004e1904e4abc4cce5b909efb7308d6"
     },
     {
       "module": "json",
@@ -33,13 +33,13 @@
     "legacy-java-compilation": "PASS",
     "legacy-kotlin-compilation": "PASS"
   },
-  "command": "bash scripts/check-serializer-buffer-abi.sh --build-current --expected-head e661a6ab32770f0fa594be077dff98362ec253d5",
+  "command": "bash scripts/check-serializer-buffer-abi.sh --build-current --expected-head 43f51bcfa176f50e7dfbed677c32f2306a4d01c2",
   "issue": 754,
-  "producerCommit": "e661a6ab32770f0fa594be077dff98362ec253d5",
-  "producerTree": "119c6c3a2057feb3907501c5617e18aad6f17ae4",
+  "producerCommit": "43f51bcfa176f50e7dfbed677c32f2306a4d01c2",
+  "producerTree": "2f7d61cc4a1f0a2a0758b840f02862b3ca4144bb",
   "schemaVersion": 1,
   "slice": "contract",
   "status": "GREEN",
-  "testedCodeTreeSha256": "fd29f912544dd39799eb1dd52dbc9fa9bad766f0ba721edac2f2349774ea7248",
+  "testedCodeTreeSha256": "a3dbf3040e1eaff0e6a499e6a7c26417fe6991ab2cef36f0e8ce48c5e4a82d77",
   "textReport": ".codex/compat/issue-754/90b267871e9154f242e6de7ee9fd0539f83e509e/abi-report.txt"
 }

--- a/docs/evidence/issue-754/contract/abi-report.json
+++ b/docs/evidence/issue-754/contract/abi-report.json
@@ -8,7 +8,7 @@
     {
       "module": "io",
       "path": "io/io/build/libs/bluetape4k-io-1.12.0.jar",
-      "sha256": "0bad944286f78fff44039c62a53328c3cfe4527f9d25289933c5a7728973c1f7"
+      "sha256": "ab7c38e76022f1e57c09b3a26cae08bdc0a1e0ee7e48c79b02d333cbe3bc9c19"
     },
     {
       "module": "json",
@@ -33,13 +33,13 @@
     "legacy-java-compilation": "PASS",
     "legacy-kotlin-compilation": "PASS"
   },
-  "command": "bash scripts/check-serializer-buffer-abi.sh --build-current --expected-head c1f6ce0f08cdb8452d0ae3692077e94b96e97bb5",
+  "command": "bash scripts/check-serializer-buffer-abi.sh --build-current --expected-head e661a6ab32770f0fa594be077dff98362ec253d5",
   "issue": 754,
-  "producerCommit": "c1f6ce0f08cdb8452d0ae3692077e94b96e97bb5",
-  "producerTree": "18ca88aefbca05e2a0939f84400c6bf8931d3a49",
+  "producerCommit": "e661a6ab32770f0fa594be077dff98362ec253d5",
+  "producerTree": "119c6c3a2057feb3907501c5617e18aad6f17ae4",
   "schemaVersion": 1,
   "slice": "contract",
   "status": "GREEN",
-  "testedCodeTreeSha256": "b9b8d2c14d5a44c00269cc506fbe6b191247d9e64731ed90392243a6412b15af",
+  "testedCodeTreeSha256": "fd29f912544dd39799eb1dd52dbc9fa9bad766f0ba721edac2f2349774ea7248",
   "textReport": ".codex/compat/issue-754/90b267871e9154f242e6de7ee9fd0539f83e509e/abi-report.txt"
 }

--- a/docs/lessons/2026-07-17-issue-1036-core-serializer-bytebuffer.md
+++ b/docs/lessons/2026-07-17-issue-1036-core-serializer-bytebuffer.md
@@ -1,0 +1,53 @@
+# Issue #1036: Core serializer ByteBuffer paths
+
+## Context
+
+`BinarySerializer` already exposed compatible ByteBuffer defaults, but those
+defaults staged every operation through a newly allocated ByteArray. JDK, Kryo,
+and Fory have different buffer capabilities and lifecycle constraints, so one
+shared optimization strategy could not preserve every existing contract.
+
+## Decision
+
+- Use fixed ByteBuffer-backed streams for JDK input and output and apply the same
+  configured or global `ObjectInputFilter` as the ByteArray path.
+- Bind Kryo `ByteBufferInput` and `ByteBufferOutput` to the caller's bounded slice,
+  but expose them only through scoped provider methods that detach caller storage
+  before returning adapters to the global pool.
+- Use Fory's native ByteBuffer input overload and retain the compatibility
+  ByteArray output path because the backend may grow or detach output storage.
+- Keep new failure and cleanup helpers internal instead of extending the
+  protected surface of the externally extensible `AbstractBinarySerializer`.
+- Preserve raw overflow, fatal errors, configured registration, wire bytes, and
+  caller position/limit/order behavior.
+
+## Surprise / Failure
+
+Adding protected convenience methods to an open base class looked source-local
+but could create JVM signature conflicts for external subclasses. Direct pooled
+adapter obtain/release methods also allowed future callers to return adapters
+without detaching caller buffers. Finally, logging a failed graph invoked
+arbitrary `toString()` implementations and could expose payload contents.
+
+## Outcome
+
+JDK and Kryo now bypass the compatibility ByteArray staging path where their
+backends safely support fixed caller-owned buffers. Fory avoids the input copy
+without claiming unsupported output behavior. Existing ByteArray entry points
+and serializer configuration remain unchanged.
+
+## Verification
+
+- Core serializer ByteBuffer suite: 18 tests passed.
+- Full `:bluetape4k-io:test` suite: 1055 tests passed.
+- Wire parity, exact capacity, overflow, cursor rollback, source-state
+  preservation, security filters, registration, pooling, retry, and mixed
+  concurrency paths are covered.
+- ABI verification is run from the clean committed head before PR publication.
+
+## Future Guard
+
+Do not add convenience members to a public extensible base class without ABI
+analysis. Treat pooled adapters as scoped resources and detach caller-owned
+storage before reuse. Verify backend capabilities against the resolved dependency
+version, and defer allocation claims until #1039 records repeated measurements.

--- a/docs/lessons/2026-07-17-issue-1036-core-serializer-bytebuffer.md
+++ b/docs/lessons/2026-07-17-issue-1036-core-serializer-bytebuffer.md
@@ -13,7 +13,10 @@ shared optimization strategy could not preserve every existing contract.
   configured or global `ObjectInputFilter` as the ByteArray path.
 - Bind Kryo `ByteBufferInput` and `ByteBufferOutput` to the caller's bounded slice,
   but expose them only through scoped provider methods that detach caller storage
-  before returning adapters to the global pool.
+  before returning adapters to the global pool. Apply this path only to the default,
+  secure, and fast pools owned by the serializer.
+- Keep externally supplied Kryo pools on the ByteArray compatibility path because
+  their custom serializers may depend on array-backed `Input` and `Output` access.
 - Use Fory's native ByteBuffer input overload and retain the compatibility
   ByteArray output path because the backend may grow or detach output storage.
 - Keep new failure and cleanup helpers internal instead of extending the
@@ -28,13 +31,16 @@ but could create JVM signature conflicts for external subclasses. Direct pooled
 adapter obtain/release methods also allowed future callers to return adapters
 without detaching caller buffers. Finally, logging a failed graph invoked
 arbitrary `toString()` implementations and could expose payload contents.
+Kryo's ByteBuffer adapters also override `getBuffer()` to throw, so applying them
+to an external pool could break an otherwise valid custom serializer.
 
 ## Outcome
 
 JDK and Kryo now bypass the compatibility ByteArray staging path where their
-backends safely support fixed caller-owned buffers. Fory avoids the input copy
-without claiming unsupported output behavior. Existing ByteArray entry points
-and serializer configuration remain unchanged.
+owned configurations safely support fixed caller-owned buffers. External Kryo
+pools retain their prior array-backed behavior. Fory avoids the input copy without
+claiming unsupported output behavior. Existing ByteArray entry points and serializer
+configuration remain unchanged.
 
 ## Verification
 
@@ -49,5 +55,7 @@ and serializer configuration remain unchanged.
 
 Do not add convenience members to a public extensible base class without ABI
 analysis. Treat pooled adapters as scoped resources and detach caller-owned
-storage before reuse. Verify backend capabilities against the resolved dependency
-version, and defer allocation claims until #1039 records repeated measurements.
+storage before reuse. Do not pass a backend-specific adapter to externally supplied
+serializer implementations unless they explicitly declare that capability. Verify
+backend behavior against the resolved dependency version, and defer allocation
+claims until #1039 records repeated measurements.

--- a/docs/review/2026-07-17-issue-1036-core-serializer-bytebuffer-review.md
+++ b/docs/review/2026-07-17-issue-1036-core-serializer-bytebuffer-review.md
@@ -1,0 +1,64 @@
+# Issue 1036 Core Serializer ByteBuffer Review
+
+## Scope
+
+- Route JDK serialization through fixed ByteBuffer-backed object streams.
+- Route Kryo serialization through scoped pooled ByteBuffer adapters.
+- Use Fory's supported ByteBuffer input while retaining its ByteArray output fallback.
+- Preserve ByteArray APIs, wire bytes, security and registration configuration,
+  exception policy, and caller-owned buffer state.
+
+## Review Result
+
+- Final integrated review: APPROVE, P0=0, P1=0.
+- Performance: the JDK and Kryo paths avoid the compatibility ByteArray staging
+  path; measured allocation and pool-contention claims remain assigned to #1039.
+- Stability: Kryo adapters detach caller buffers before returning to the pool,
+  and mixed concurrent success, overflow, and malformed-input calls remain isolated.
+- Security: JDK applies the configured or global `ObjectInputFilter`; Kryo and
+  Fory retain configured registration behavior. Failure logging records only
+  `graphType`, never the caller graph.
+- Ops: no module registration, Gradle configuration, release, or workflow surface changed.
+- Developer/API: no new public or protected JVM method was added in this slice;
+  scoped internal adapters avoid exposing pool release ordering to callers.
+- User/caller: heap, direct, sliced, and read-only inputs preserve caller state.
+  Output failure restores position only; overwritten bytes remain unspecified as
+  documented by `BinarySerializer`.
+
+## Resolved Findings
+
+- Removed convenience methods from `AbstractBinarySerializer`; adding protected
+  final JVM methods could conflict with external subclasses.
+- Replaced direct Kryo adapter obtain/release calls with scoped provider methods
+  that always detach caller buffers before pool return.
+- Changed ByteBuffer failure logs from `graph=$graph` to bounded type metadata and
+  added a regression test whose caller `toString()` throws.
+- Verified the resolved Fory dependency is `1.3.0` and that its ByteBuffer input
+  overload accepts all supported source shapes.
+
+## Dispositions
+
+- Read-only output rejects before null handling and failure rolls back only the
+  position. Both behaviors are existing executable `BinarySerializer` contracts.
+- JEP 290 quantitative limits would change the existing ByteArray and ByteBuffer
+  security acceptance boundary, so that baseline hardening is outside #1036.
+- Allocation rate, throughput, and Kryo pool-contention evidence are deferred to #1039.
+- Fory output remains on the compatibility ByteArray fallback because its output
+  buffer may grow or detach caller storage.
+
+## Verification
+
+- RED: the initial tests did not compile before the backend ByteBuffer paths existed.
+- Core serializer ByteBuffer suite: 18 passing.
+- `./gradlew :bluetape4k-io:test --no-configuration-cache --rerun-tasks`:
+  1055 passing.
+- `git diff --check`: passing.
+- Production unsafe-pattern scan: no new matches.
+- The module has no `detekt` task; root `detekt` is `NO-SOURCE`, so Kotlin
+  compilation and the complete module test suite provide the static fallback.
+
+## Documentation
+
+Public method contracts were established in #1031. Backend capability tables,
+measured allocation claims, representative README updates, and CHANGELOG updates
+remain assigned to #1039.

--- a/docs/review/2026-07-17-issue-1036-core-serializer-bytebuffer-review.md
+++ b/docs/review/2026-07-17-issue-1036-core-serializer-bytebuffer-review.md
@@ -11,8 +11,8 @@
 ## Review Result
 
 - Final integrated review: APPROVE, P0=0, P1=0.
-- Performance: the JDK and Kryo paths avoid the compatibility ByteArray staging
-  path; measured allocation and pool-contention claims remain assigned to #1039.
+- Performance: the JDK and built-in Kryo paths avoid the compatibility ByteArray
+  staging path; measured allocation and pool-contention claims remain assigned to #1039.
 - Stability: Kryo adapters detach caller buffers before returning to the pool,
   and mixed concurrent success, overflow, and malformed-input calls remain isolated.
 - Security: JDK applies the configured or global `ObjectInputFilter`; Kryo and
@@ -33,6 +33,9 @@
   that always detach caller buffers before pool return.
 - Changed ByteBuffer failure logs from `graph=$graph` to bounded type metadata and
   added a regression test whose caller `toString()` throws.
+- Limited native Kryo ByteBuffer adapters to the default, secure, and fast pools.
+  Externally supplied pools retain array-backed compatibility for custom serializers
+  that call `Input.getBuffer()` or `Output.getBuffer()`.
 - Verified the resolved Fory dependency is `1.3.0` and that its ByteBuffer input
   overload accepts all supported source shapes.
 
@@ -45,6 +48,8 @@
 - Allocation rate, throughput, and Kryo pool-contention evidence are deferred to #1039.
 - Fory output remains on the compatibility ByteArray fallback because its output
   buffer may grow or detach caller storage.
+- External Kryo pools remain on the compatibility fallback because Kryo 5.6.2
+  ByteBuffer adapters reject array-buffer access used by valid custom serializers.
 
 ## Verification
 

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/BufferSerializationDefaults.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/BufferSerializationDefaults.kt
@@ -1,5 +1,8 @@
 package io.bluetape4k.io.serializer
 
+import io.bluetape4k.io.BufferFailurePolicy
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.error
 import java.nio.BufferOverflowException
 import java.nio.ByteBuffer
 import java.nio.ReadOnlyBufferException
@@ -32,3 +35,63 @@ internal inline fun serializeNullableTo(
 
 internal fun copyRemaining(source: ByteBuffer): ByteArray =
     ByteArray(source.remaining()).also { source.duplicate().get(it) }
+
+internal fun throwBufferSerializationFailure(
+    graph: Any,
+    failure: Throwable,
+): Nothing = BufferSerializationFailureSupport.throwSerialization(graph, failure)
+
+internal fun throwBufferDeserializationFailure(
+    sourceSize: Int,
+    failure: Throwable,
+): Nothing = BufferSerializationFailureSupport.throwDeserialization(sourceSize, failure)
+
+internal inline fun <R, T> useWithCleanup(
+    resource: R,
+    cleanup: (R) -> Unit,
+    block: (R) -> T,
+): T {
+    var operationFailure: Throwable? = null
+    try {
+        return block(resource)
+    } catch (failure: Throwable) {
+        operationFailure = failure
+        throw failure
+    } finally {
+        var cleanupFailure: Throwable? = null
+        try {
+            cleanup(resource)
+        } catch (failure: Throwable) {
+            cleanupFailure = failure
+        }
+        if (cleanupFailure != null) {
+            throw checkNotNull(BufferFailurePolicy.classify(operationFailure, cleanupFailure))
+        }
+    }
+}
+
+private object BufferSerializationFailureSupport: KLogging() {
+
+    fun throwSerialization(
+        graph: Any,
+        failure: Throwable,
+    ): Nothing {
+        val classified = BufferFailurePolicy.classify(failure, null) ?: failure
+        if (classified is Error || classified is BufferOverflowException) throw classified
+
+        val graphType = graph.javaClass.name
+        log.error(classified) { "Fail to serialize to ByteBuffer. graphType=$graphType" }
+        throw BinarySerializationException("Fail to serialize. graphType=$graphType", classified)
+    }
+
+    fun throwDeserialization(
+        sourceSize: Int,
+        failure: Throwable,
+    ): Nothing {
+        val classified = BufferFailurePolicy.classify(failure, null) ?: failure
+        if (classified is Error) throw classified
+
+        log.error(classified) { "Fail to deserialize from ByteBuffer." }
+        throw BinarySerializationException("Fail to deserialize. bytesSize=$sourceSize", classified)
+    }
+}

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/ForyBinarySerializer.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/ForyBinarySerializer.kt
@@ -5,6 +5,7 @@ import org.apache.fory.Fory
 import org.apache.fory.ThreadSafeFory
 import org.apache.fory.config.CompatibleMode
 import org.apache.fory.config.Language
+import java.nio.ByteBuffer
 
 /**
  * [Fory](https://fory.apache.org/) 를 이용한 Binary 직렬화/역직렬화를 수행하는 [BinarySerializer]
@@ -18,6 +19,10 @@ import org.apache.fory.config.Language
  * val bytes = serializer.serialize("Hello, World!")
  * val text = serializer.deserialize<String>(bytes)  // text="Hello, World!"
  * ```
+ *
+ * [deserializeFrom] delegates a duplicate of the caller's bounded range to Fory's ByteBuffer API.
+ * [serializeTo] intentionally keeps the BinarySerializer ByteArray compatibility fallback because
+ * Fory's MemoryBuffer output may grow by replacing caller-provided storage.
  */
 class ForyBinarySerializer(
     private val fory: ThreadSafeFory = DefaultFory,
@@ -142,5 +147,17 @@ class ForyBinarySerializer(
     @Suppress("UNCHECKED_CAST")
     override fun <T: Any> doDeserialize(bytes: ByteArray): T? {
         return fory.deserialize(bytes) as? T
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T: Any> deserializeFrom(source: ByteBuffer): T? {
+        val sourceSize = source.remaining()
+        if (sourceSize == 0) return null
+
+        return try {
+            fory.deserialize(source.duplicate()) as? T
+        } catch (failure: Throwable) {
+            throwBufferDeserializationFailure(sourceSize, failure)
+        }
     }
 }

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/JdkBinarySerializer.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/JdkBinarySerializer.kt
@@ -1,11 +1,15 @@
 package io.bluetape4k.io.serializer
 
+import io.bluetape4k.io.ByteBufferInputStream
+import io.bluetape4k.io.ByteBufferOutputStream
 import io.bluetape4k.logging.KLogging
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.ObjectInputFilter
 import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
+import java.nio.ByteBuffer
+import java.nio.ReadOnlyBufferException
 
 /**
  * 기본 [ObjectInputFilter]. `io.bluetape4k.**`, `java.lang.**`, `java.util.**`,
@@ -41,6 +45,9 @@ val JDK_DEFAULT_OBJECT_INPUT_FILTER: ObjectInputFilter = ObjectInputFilter.Confi
  * val safeSerializer = JdkBinarySerializer(objectInputFilter = customFilter)
  * ```
  *
+ * [serializeTo] and [deserializeFrom] use fixed ByteBuffer-backed streams. The configured
+ * [objectInputFilter] is applied to both ByteArray and ByteBuffer deserialization paths.
+ *
  * @param bufferSize 버퍼 크기 (기본값: [DEFAULT_BUFFER_SIZE])
  * @param objectInputFilter 역직렬화 시 적용할 [ObjectInputFilter]. 기본값: [JDK_DEFAULT_OBJECT_INPUT_FILTER]
  */
@@ -75,6 +82,27 @@ class JdkBinarySerializer(
         return output.toByteArray()
     }
 
+    override fun serializeTo(graph: Any?, target: ByteBuffer): Int {
+        if (target.isReadOnly) throw ReadOnlyBufferException()
+        val source = graph ?: return 0
+        val start = target.position()
+        val view = target.duplicate()
+
+        return try {
+            ByteBufferOutputStream.fixed(view).use { output ->
+                ObjectOutputStream(output).use { oos ->
+                    oos.writeObject(source)
+                }
+            }
+            val written = view.position() - start
+            target.position(start + written)
+            written
+        } catch (failure: Throwable) {
+            target.position(start)
+            throwBufferSerializationFailure(source, failure)
+        }
+    }
+
     /**
      * [ObjectInputStream]을 사용하여 [bytes]를 역직렬화하고 객체를 반환합니다.
      * [objectInputFilter]가 설정된 경우 역직렬화 전에 필터를 적용합니다.
@@ -100,6 +128,26 @@ class JdkBinarySerializer(
             }.use { ois ->
                 ois.readObject() as? T
             }
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T: Any> deserializeFrom(source: ByteBuffer): T? {
+        val sourceSize = source.remaining()
+        if (sourceSize == 0) return null
+
+        return try {
+            ByteBufferInputStream(source.duplicate()).use { input ->
+                ObjectInputStream(input).apply {
+                    val filter = this@JdkBinarySerializer.objectInputFilter
+                        ?: ObjectInputFilter.Config.getSerialFilter()
+                    filter?.let { setObjectInputFilter(it) }
+                }.use { ois ->
+                    ois.readObject() as? T
+                }
+            }
+        } catch (failure: Throwable) {
+            throwBufferDeserializationFailure(sourceSize, failure)
         }
     }
 }

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/KryoBinarySerializer.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/KryoBinarySerializer.kt
@@ -7,6 +7,8 @@ import io.bluetape4k.logging.KLogging
 import java.nio.ByteBuffer
 import java.nio.ReadOnlyBufferException
 
+private abstract class NativeByteBufferKryoPool: Pool<Kryo>(true, false, 1024)
+
 /**
  *  [Kryo](https://github.com/EsotericSoftware/kryo) 라이브러리를 이용하는 [BinarySerializer]
  *
@@ -24,8 +26,9 @@ import java.nio.ReadOnlyBufferException
  *  val secureSerializer = KryoBinarySerializer.secure(MyData::class.java)
  *  ```
  *
- * [serializeTo] and [deserializeFrom] bind pooled Kryo ByteBuffer adapters to the caller's bounded range.
- * The adapters detach caller storage before returning to the pool, including failure paths.
+ * [serializeTo] and [deserializeFrom] bind pooled Kryo ByteBuffer adapters to the caller's bounded range for the
+ * default, [fast], and [secure] configurations. An externally supplied [kryoPool] retains the ByteArray compatibility
+ * path because its custom serializers may require array-backed [Input] and `Output` instances.
  *
  * @param bufferSize 내부 버퍼 크기 (기본값: [DEFAULT_BUFFER_SIZE])
  * @param kryoPool 커스텀 Kryo 풀. null이면 기본 [KryoProvider] 풀을 사용합니다.
@@ -90,7 +93,7 @@ class KryoBinarySerializer(
          */
         @JvmStatic
         fun fast(): KryoBinarySerializer {
-            val pool = object: Pool<Kryo>(true, false, 1024) {
+            val pool = object: NativeByteBufferKryoPool() {
                 override fun create(): Kryo = KryoProvider.createFastKryo()
             }
             return KryoBinarySerializer(kryoPool = pool)
@@ -98,7 +101,7 @@ class KryoBinarySerializer(
 
         @JvmStatic
         fun secure(vararg classes: Class<*>): KryoBinarySerializer {
-            val pool = object: Pool<Kryo>(true, false, 1024) {
+            val pool = object: NativeByteBufferKryoPool() {
                 override fun create(): Kryo = KryoProvider.createKryo().apply {
                     isRegistrationRequired = true
                     classes.forEach { register(it) }
@@ -143,6 +146,9 @@ class KryoBinarySerializer(
         }
     }
 
+    private fun supportsNativeByteBufferAdapters(): Boolean =
+        kryoPool == null || kryoPool is NativeByteBufferKryoPool
+
     /**
      * I/O 직렬화에서 `doSerialize` 함수를 제공합니다.
      */
@@ -160,6 +166,9 @@ class KryoBinarySerializer(
     }
 
     override fun serializeTo(graph: Any?, target: ByteBuffer): Int {
+        if (!supportsNativeByteBufferAdapters()) {
+            return serializeNullableTo(target) { serialize(graph) }
+        }
         if (target.isReadOnly) throw ReadOnlyBufferException()
         val source = graph ?: return 0
         val start = target.position()
@@ -194,6 +203,9 @@ class KryoBinarySerializer(
 
     @Suppress("UNCHECKED_CAST")
     override fun <T: Any> deserializeFrom(source: ByteBuffer): T? {
+        if (!supportsNativeByteBufferAdapters()) {
+            return deserialize(copyRemaining(source))
+        }
         val sourceSize = source.remaining()
         if (sourceSize == 0) return null
         val view = source.slice()

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/KryoBinarySerializer.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/KryoBinarySerializer.kt
@@ -4,6 +4,8 @@ import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.util.Pool
 import io.bluetape4k.logging.KLogging
+import java.nio.ByteBuffer
+import java.nio.ReadOnlyBufferException
 
 /**
  *  [Kryo](https://github.com/EsotericSoftware/kryo) 라이브러리를 이용하는 [BinarySerializer]
@@ -21,6 +23,9 @@ import io.bluetape4k.logging.KLogging
  *  // 보안 사용 (등록된 클래스만 허용)
  *  val secureSerializer = KryoBinarySerializer.secure(MyData::class.java)
  *  ```
+ *
+ * [serializeTo] and [deserializeFrom] bind pooled Kryo ByteBuffer adapters to the caller's bounded range.
+ * The adapters detach caller storage before returning to the pool, including failure paths.
  *
  * @param bufferSize 내부 버퍼 크기 (기본값: [DEFAULT_BUFFER_SIZE])
  * @param kryoPool 커스텀 Kryo 풀. null이면 기본 [KryoProvider] 풀을 사용합니다.
@@ -129,6 +134,15 @@ class KryoBinarySerializer(
         }
     }
 
+    private fun <T> useKryoForBuffer(block: Kryo.() -> T): T {
+        val pool = kryoPool
+        return if (pool != null) {
+            useWithCleanup(pool.obtain(), pool::free) { kryo -> block(kryo) }
+        } else {
+            useWithCleanup(KryoProvider.obtainKryo(), KryoProvider::releaseKryo) { kryo -> block(kryo) }
+        }
+    }
+
     /**
      * I/O 직렬화에서 `doSerialize` 함수를 제공합니다.
      */
@@ -145,6 +159,27 @@ class KryoBinarySerializer(
         }
     }
 
+    override fun serializeTo(graph: Any?, target: ByteBuffer): Int {
+        if (target.isReadOnly) throw ReadOnlyBufferException()
+        val source = graph ?: return 0
+        val start = target.position()
+        val view = target.slice()
+
+        return try {
+            val written = KryoProvider.useByteBufferOutput(view) { output ->
+                useKryoForBuffer {
+                    writeClassAndObject(output, source)
+                }
+                output.position()
+            }
+            target.position(start + written)
+            written
+        } catch (failure: Throwable) {
+            target.position(start)
+            throwBufferSerializationFailure(source, failure)
+        }
+    }
+
     /**
      * I/O 직렬화에서 `doDeserialize` 함수를 제공합니다.
      */
@@ -154,6 +189,23 @@ class KryoBinarySerializer(
             useKryo {
                 readClassAndObject(input) as? T
             }
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T: Any> deserializeFrom(source: ByteBuffer): T? {
+        val sourceSize = source.remaining()
+        if (sourceSize == 0) return null
+        val view = source.slice()
+
+        return try {
+            KryoProvider.useByteBufferInput(view) { input ->
+                useKryoForBuffer {
+                    readClassAndObject(input) as? T
+                }
+            }
+        } catch (failure: Throwable) {
+            throwBufferDeserializationFailure(sourceSize, failure)
         }
     }
 }

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/KryoProvider.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/KryoProvider.kt
@@ -1,6 +1,8 @@
 package io.bluetape4k.io.serializer
 
 import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.io.ByteBufferInput
+import com.esotericsoftware.kryo.io.ByteBufferOutput
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import com.esotericsoftware.kryo.serializers.CompatibleFieldSerializer
@@ -15,6 +17,7 @@ import io.bluetape4k.io.serializer.KryoProvider.releaseOutput
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import org.objenesis.strategy.StdInstantiatorStrategy
+import java.nio.ByteBuffer
 
 /**
  * Kryo 인스턴스를 Pool 방식으로 관리하는 싱글톤 유틸리티입니다.
@@ -88,6 +91,18 @@ object KryoProvider: KLogging() {
         }
     }
 
+    private val byteBufferInputPool: Pool<PooledByteBufferInput> by lazy {
+        object: Pool<PooledByteBufferInput>(true, false, MAX_POOL_SIZE) {
+            override fun create(): PooledByteBufferInput = PooledByteBufferInput()
+        }
+    }
+
+    private val byteBufferOutputPool: Pool<PooledByteBufferOutput> by lazy {
+        object: Pool<PooledByteBufferOutput>(true, false, MAX_POOL_SIZE) {
+            override fun create(): PooledByteBufferOutput = PooledByteBufferOutput()
+        }
+    }
+
     /**
      * Pool에서 [Kryo] 인스턴스를 대여합니다.
      *
@@ -115,6 +130,22 @@ object KryoProvider: KLogging() {
      */
     fun obtainOutput(): Output = outputPool.obtain()
 
+    internal fun <T> useByteBufferInput(
+        buffer: ByteBuffer,
+        block: (ByteBufferInput) -> T,
+    ): T {
+        val input = byteBufferInputPool.obtain().apply { attach(buffer) }
+        return useWithCleanup(input, ::releaseByteBufferInput, block)
+    }
+
+    internal fun <T> useByteBufferOutput(
+        buffer: ByteBuffer,
+        block: (ByteBufferOutput) -> T,
+    ): T {
+        val output = byteBufferOutputPool.obtain().apply { attach(buffer) }
+        return useWithCleanup(output, ::releaseByteBufferOutput, block)
+    }
+
     /**
      * 사용이 끝난 [Kryo] 인스턴스를 Pool에 반납합니다.
      *
@@ -140,6 +171,16 @@ object KryoProvider: KLogging() {
      */
     fun releaseOutput(output: Output) {
         outputPool.free(output)
+    }
+
+    private fun releaseByteBufferInput(input: PooledByteBufferInput) {
+        input.detach()
+        byteBufferInputPool.free(input)
+    }
+
+    private fun releaseByteBufferOutput(output: PooledByteBufferOutput) {
+        output.detach()
+        byteBufferOutputPool.free(output)
     }
 
     /**
@@ -221,5 +262,31 @@ object KryoProvider: KLogging() {
             register(java.time.ZonedDateTime::class.java)
             register(java.math.BigDecimal::class.java)
         }
+    }
+}
+
+private class PooledByteBufferInput: ByteBufferInput(ByteBuffer.allocate(0)) {
+
+    private val detachedBuffer: ByteBuffer = byteBuffer
+
+    fun attach(buffer: ByteBuffer) {
+        setBuffer(buffer)
+    }
+
+    fun detach() {
+        setBuffer(detachedBuffer)
+    }
+}
+
+private class PooledByteBufferOutput: ByteBufferOutput(ByteBuffer.allocate(0), 0) {
+
+    private val detachedBuffer: ByteBuffer = byteBuffer
+
+    fun attach(buffer: ByteBuffer) {
+        setBuffer(buffer, buffer.capacity())
+    }
+
+    fun detach() {
+        setBuffer(detachedBuffer, 0)
     }
 }

--- a/io/io/src/test/kotlin/io/bluetape4k/io/serializer/CoreBinarySerializerByteBufferTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/serializer/CoreBinarySerializerByteBufferTest.kt
@@ -1,0 +1,582 @@
+package io.bluetape4k.io.serializer
+
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.io.ByteBufferInput
+import com.esotericsoftware.kryo.io.ByteBufferOutput
+import com.esotericsoftware.kryo.io.Input
+import com.esotericsoftware.kryo.io.Output
+import com.esotericsoftware.kryo.util.Pool
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeLessThan
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import org.apache.fory.ThreadSafeFory
+import org.junit.jupiter.api.Test
+import untrusted.payload.UntrustedPayload
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import java.io.Serializable
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.ReadOnlyBufferException
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+class JdkBinarySerializerByteBufferTest {
+
+    @Test
+    fun `serializeTo preserves JDK wire bytes in the bounded target range`() {
+        val serializer = JdkBinarySerializer()
+        val expected = "jdk-byte-buffer"
+        val wire = serializer.serialize(expected)
+
+        writableTargets(wire.size).forEach { target ->
+            val start = target.position()
+            val limit = target.limit()
+            val capacity = target.capacity()
+            val before = target.fullBytes()
+            val written = serializer.serializeTo(expected, target)
+
+            written shouldBeEqualTo wire.size
+            target.rangeBytes(start, written) shouldBeEqualTo wire
+            target.position() shouldBeEqualTo start + written
+            target.limit() shouldBeEqualTo limit
+            target.capacity() shouldBeEqualTo capacity
+            target.order() shouldBeEqualTo ByteOrder.LITTLE_ENDIAN
+            target.fullBytes().copyOfRange(0, start) shouldBeEqualTo before.copyOfRange(0, start)
+            target.fullBytes().copyOfRange(limit, capacity) shouldBeEqualTo before.copyOfRange(limit, capacity)
+            target.reset()
+            target.position() shouldBeEqualTo start
+        }
+    }
+
+    @Test
+    fun `deserializeFrom reads every JDK source shape without changing caller state`() {
+        val serializer = JdkBinarySerializer()
+        val expected = "jdk-source-shapes"
+        val wire = serializer.serialize(expected)
+
+        sourceBuffers(wire).forEach { source ->
+            val start = source.position()
+            val limit = source.limit()
+            val order = source.order()
+
+            serializer.deserializeFrom<String>(source) shouldBeEqualTo expected
+
+            source.position() shouldBeEqualTo start
+            source.limit() shouldBeEqualTo limit
+            source.order() shouldBeEqualTo order
+            source.reset()
+            source.position() shouldBeEqualTo start
+        }
+    }
+
+    @Test
+    fun `fixed JDK output overflows before a large custom write completes and remains reusable`() {
+        val serializer = JdkBinarySerializer()
+        val payload = JdkOverflowProbe()
+        val target = configuredTarget(32)
+        val start = target.position()
+
+        JdkOverflowProbe.writes.set(0)
+        assertFailsWith<BufferOverflowException> {
+            serializer.serializeTo(payload, target)
+        }
+
+        JdkOverflowProbe.writes.get() shouldBeLessThan JdkOverflowProbe.WRITE_COUNT
+        target.position() shouldBeEqualTo start
+
+        val required = serializer.serialize(payload).size
+        JdkOverflowProbe.writes.set(0)
+        serializer.serializeTo(payload, configuredTarget(required)) shouldBeEqualTo required
+        JdkOverflowProbe.writes.get() shouldBeEqualTo JdkOverflowProbe.WRITE_COUNT
+    }
+
+    @Test
+    fun `deserializeFrom applies the configured JDK object input filter`() {
+        val unfiltered = JdkBinarySerializer(objectInputFilter = null)
+        val filtered = JdkBinarySerializer()
+        val wire = unfiltered.serialize(UntrustedPayload("blocked"))
+        val source = configuredSource(wire, direct = true)
+        val start = source.position()
+
+        val failure = assertFailsWith<BinarySerializationException> {
+            filtered.deserializeFrom<UntrustedPayload>(source)
+        }
+
+        (failure.cause is java.io.InvalidClassException).shouldBeTrue()
+        source.position() shouldBeEqualTo start
+        source.order() shouldBeEqualTo ByteOrder.LITTLE_ENDIAN
+    }
+
+    @Test
+    fun `serialization failure does not render the caller graph in diagnostics`() {
+        val failure = assertFailsWith<BinarySerializationException> {
+            JdkBinarySerializer().serializeTo(ThrowingToStringPayload(), configuredTarget(4 * 1024))
+        }
+
+        (failure.cause is IllegalStateException).shouldBeTrue()
+    }
+}
+
+class KryoBinarySerializerByteBufferTest {
+
+    @Test
+    fun `serializeTo preserves Kryo wire bytes in every writable target shape`() {
+        val serializer = KryoBinarySerializer()
+        val expected = "kryo-byte-buffer"
+        val wire = serializer.serialize(expected)
+
+        writableTargets(wire.size).forEach { target ->
+            val start = target.position()
+            val limit = target.limit()
+            val capacity = target.capacity()
+            val before = target.fullBytes()
+            val written = serializer.serializeTo(expected, target)
+
+            target.rangeBytes(start, written) shouldBeEqualTo wire
+            target.position() shouldBeEqualTo start + written
+            target.limit() shouldBeEqualTo limit
+            target.capacity() shouldBeEqualTo capacity
+            target.order() shouldBeEqualTo ByteOrder.LITTLE_ENDIAN
+            target.fullBytes().copyOfRange(0, start) shouldBeEqualTo before.copyOfRange(0, start)
+            target.fullBytes().copyOfRange(limit, capacity) shouldBeEqualTo before.copyOfRange(limit, capacity)
+            target.reset()
+            target.position() shouldBeEqualTo start
+        }
+    }
+
+    @Test
+    fun `deserializeFrom reads every Kryo source shape without changing caller state`() {
+        val serializer = KryoBinarySerializer()
+        val expected = "kryo-source-shapes"
+        val wire = serializer.serialize(expected)
+
+        sourceBuffers(wire).forEach { source ->
+            val start = source.position()
+            val limit = source.limit()
+            val order = source.order()
+
+            serializer.deserializeFrom<String>(source) shouldBeEqualTo expected
+
+            source.position() shouldBeEqualTo start
+            source.limit() shouldBeEqualTo limit
+            source.order() shouldBeEqualTo order
+            source.reset()
+            source.position() shouldBeEqualTo start
+        }
+    }
+
+    @Test
+    fun `Kryo overflow is public and a failed call does not poison the next call`() {
+        val serializer = KryoBinarySerializer()
+        val expected = "kryo-overflow-retry"
+        val wire = serializer.serialize(expected)
+        val tooSmall = configuredTarget(wire.size - 1)
+        val start = tooSmall.position()
+
+        assertFailsWith<BufferOverflowException> {
+            serializer.serializeTo(expected, tooSmall)
+        }
+
+        tooSmall.position() shouldBeEqualTo start
+        val retry = configuredTarget(wire.size)
+        serializer.serializeTo(expected, retry) shouldBeEqualTo wire.size
+    }
+
+    @Test
+    fun `Kryo serializer passes ByteBuffer adapters to its configured Kryo`() {
+        val created = AtomicInteger()
+        val observedInput = AtomicReference<Class<*>>()
+        val observedOutput = AtomicReference<Class<*>>()
+        val pool = object: Pool<Kryo>(true, false, 1) {
+            override fun create(): Kryo {
+                created.incrementAndGet()
+                return RecordingKryo(observedInput, observedOutput)
+            }
+        }
+        val serializer = KryoBinarySerializer(kryoPool = pool)
+        val target = configuredTarget(256)
+        val start = target.position()
+
+        val written = serializer.serializeTo("record-adapters", target)
+        val restored = serializer.deserializeFrom<String>(
+            configuredSource(target.rangeBytes(start, written), direct = true)
+        )
+
+        restored shouldBeEqualTo "record-adapters"
+        ByteBufferOutput::class.java.isAssignableFrom(observedOutput.get()).shouldBeTrue()
+        ByteBufferInput::class.java.isAssignableFrom(observedInput.get()).shouldBeTrue()
+        created.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `scoped Kryo ByteBuffer adapters detach caller buffers on return`() {
+        val inputBuffer = configuredSource(byteArrayOf(1, 2, 3), direct = true)
+        lateinit var input: ByteBufferInput
+        KryoProvider.useByteBufferInput(inputBuffer) { adapter ->
+            input = adapter
+            (adapter.byteBuffer === inputBuffer).shouldBeTrue()
+        }
+        (input.byteBuffer !== inputBuffer).shouldBeTrue()
+        input.byteBuffer.capacity() shouldBeEqualTo 0
+
+        val outputBuffer = ByteBuffer.allocateDirect(16)
+        lateinit var output: ByteBufferOutput
+        KryoProvider.useByteBufferOutput(outputBuffer) { adapter ->
+            output = adapter
+            (adapter.byteBuffer === outputBuffer).shouldBeTrue()
+        }
+        (output.byteBuffer !== outputBuffer).shouldBeTrue()
+        output.byteBuffer.capacity() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `secure and fast Kryo configurations remain active on ByteBuffer paths`() {
+        val secure = KryoBinarySerializer.secure(KryoRegisteredPayload::class.java)
+        val expected = KryoRegisteredPayload(7, "registered")
+        val wire = secure.serialize(expected)
+        val target = configuredTarget(wire.size)
+        val start = target.position()
+
+        val written = secure.serializeTo(expected, target)
+        val source = configuredSource(target.rangeBytes(start, written), direct = true)
+
+        secure.deserializeFrom<KryoRegisteredPayload>(source) shouldBeEqualTo expected
+        assertFailsWith<BinarySerializationException> {
+            secure.serializeTo(KryoUnregisteredPayload("blocked"), configuredTarget(256))
+        }
+        val unregisteredWire = KryoBinarySerializer().serialize(KryoUnregisteredPayload("blocked"))
+        assertFailsWith<BinarySerializationException> {
+            secure.deserializeFrom<KryoUnregisteredPayload>(configuredSource(unregisteredWire, direct = true))
+        }
+
+        val fast = KryoBinarySerializer.fast()
+        val fastWire = fast.serialize("fast-kryo")
+        val fastTarget = configuredTarget(fastWire.size)
+        val fastStart = fastTarget.position()
+        val fastWritten = fast.serializeTo("fast-kryo", fastTarget)
+        fast.deserializeFrom<String>(
+            configuredSource(fastTarget.rangeBytes(fastStart, fastWritten), direct = true)
+        ) shouldBeEqualTo "fast-kryo"
+    }
+
+    @Test
+    fun `custom Kryo reference configuration remains active on ByteBuffer paths`() {
+        val pool = object: Pool<Kryo>(true, false, 4) {
+            override fun create(): Kryo = KryoProvider.createKryo().apply {
+                references = true
+            }
+        }
+        val serializer = KryoBinarySerializer(kryoPool = pool)
+        val shared = KryoReferencePayload(11)
+        val expected = listOf(shared, shared)
+        val wire = serializer.serialize(expected)
+        val target = configuredTarget(wire.size)
+        val start = target.position()
+
+        val written = serializer.serializeTo(expected, target)
+        val actual = serializer.deserializeFrom<List<KryoReferencePayload>>(
+            configuredSource(target.rangeBytes(start, written), direct = true)
+        )
+
+        actual.shouldNotBeNull()
+        actual shouldBeEqualTo expected
+        (actual[0] === actual[1]).shouldBeTrue()
+    }
+
+    @Test
+    fun `shared Kryo serializer isolates concurrent success overflow and malformed input calls`() {
+        val serializer = KryoBinarySerializer()
+
+        verifySerializerBufferConcurrency { worker, repetition ->
+            val value = "$worker:$repetition"
+            val wire = serializer.serialize(value)
+            when (repetition % 3) {
+                0 -> {
+                    val target = configuredTarget(wire.size, direct = repetition % 2 == 0)
+                    val start = target.position()
+                    val written = serializer.serializeTo(value, target)
+                    serializer.deserializeFrom<String>(
+                        configuredSource(target.rangeBytes(start, written), direct = true)
+                    ) shouldBeEqualTo value
+                }
+                1 -> assertFailsWith<BufferOverflowException> {
+                    serializer.serializeTo(value, configuredTarget(wire.size - 1))
+                }
+                else -> assertFailsWith<BinarySerializationException> {
+                    serializer.deserializeFrom<String>(configuredSource(byteArrayOf(1, 2, 3), direct = true))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `optimized serializers reject read-only targets before null handling`() {
+        listOf<BinarySerializer>(JdkBinarySerializer(), KryoBinarySerializer()).forEach { serializer ->
+            val target = ByteBuffer.allocate(16).asReadOnlyBuffer()
+
+            assertFailsWith<ReadOnlyBufferException> {
+                serializer.serializeTo(null, target)
+            }
+        }
+    }
+}
+
+class ForyBinarySerializerByteBufferTest {
+
+    @Test
+    fun `deserializeFrom delegates the caller range to the Fory ByteBuffer overload`() {
+        val handler = RecordingForyHandler(decoded = "decoded")
+        val serializer = ForyBinarySerializer(handler.proxy())
+        val source = configuredSource(byteArrayOf(1, 2, 3, 4), direct = true)
+        val start = source.position()
+
+        serializer.deserializeFrom<String>(source) shouldBeEqualTo "decoded"
+
+        handler.byteBufferDeserializeCalls shouldBeEqualTo 1
+        handler.byteArrayDeserializeCalls shouldBeEqualTo 0
+        handler.receivedBuffer?.position() shouldBeEqualTo start
+        handler.receivedBuffer?.limit() shouldBeEqualTo source.limit()
+        (handler.receivedBuffer !== source).shouldBeTrue()
+        source.position() shouldBeEqualTo start
+        source.order() shouldBeEqualTo ByteOrder.LITTLE_ENDIAN
+    }
+
+    @Test
+    fun `serializeTo keeps the Fory ByteArray compatibility fallback`() {
+        val wire = byteArrayOf(4, 3, 2, 1)
+        val handler = RecordingForyHandler(encoded = wire)
+        val serializer = ForyBinarySerializer(handler.proxy())
+        val target = configuredTarget(wire.size)
+        val start = target.position()
+
+        serializer.serializeTo("value", target) shouldBeEqualTo wire.size
+
+        handler.byteArraySerializeCalls shouldBeEqualTo 1
+        target.rangeBytes(start, wire.size) shouldBeEqualTo wire
+    }
+
+    @Test
+    fun `fast Fory configuration remains active on the ByteBuffer input path`() {
+        val serializer = ForyBinarySerializer.fast()
+        val expected = "fast-fory"
+        val wire = serializer.serialize(expected)
+
+        serializer.deserializeFrom<String>(configuredSource(wire, direct = true)) shouldBeEqualTo expected
+    }
+
+    @Test
+    fun `deserializeFrom reads every Fory source shape without changing caller state`() {
+        val serializer = ForyBinarySerializer()
+        val expected = "fory-source-shapes"
+        val wire = serializer.serialize(expected)
+
+        sourceBuffers(wire).forEach { source ->
+            val start = source.position()
+            val limit = source.limit()
+            val order = source.order()
+
+            serializer.deserializeFrom<String>(source) shouldBeEqualTo expected
+
+            source.position() shouldBeEqualTo start
+            source.limit() shouldBeEqualTo limit
+            source.order() shouldBeEqualTo order
+            source.reset()
+            source.position() shouldBeEqualTo start
+        }
+    }
+}
+
+private class JdkOverflowProbe: Serializable {
+
+    private fun writeObject(output: ObjectOutputStream) {
+        repeat(WRITE_COUNT) { index ->
+            writes.incrementAndGet()
+            output.writeInt(index)
+        }
+    }
+
+    @Suppress("unused")
+    private fun readObject(input: ObjectInputStream) {
+        repeat(WRITE_COUNT) { input.readInt() }
+    }
+
+    companion object {
+        const val WRITE_COUNT = 10_000
+        val writes = AtomicInteger()
+    }
+}
+
+private class ThrowingToStringPayload: Serializable {
+
+    @Suppress("unused")
+    private fun writeObject(output: ObjectOutputStream) {
+        error("expected serialization failure")
+    }
+
+    override fun toString(): String = error("caller graph must not be rendered")
+}
+
+data class KryoRegisteredPayload(
+    val id: Int = 0,
+    val text: String = "",
+)
+
+data class KryoUnregisteredPayload(
+    val text: String = "",
+)
+
+data class KryoReferencePayload(
+    val id: Int = 0,
+)
+
+private class RecordingKryo(
+    private val observedInput: AtomicReference<Class<*>>,
+    private val observedOutput: AtomicReference<Class<*>>,
+): Kryo() {
+
+    override fun writeClassAndObject(output: Output, objectValue: Any?) {
+        observedOutput.set(output.javaClass)
+        super.writeClassAndObject(output, objectValue)
+    }
+
+    override fun readClassAndObject(input: Input): Any? {
+        observedInput.set(input.javaClass)
+        return super.readClassAndObject(input)
+    }
+}
+
+private class RecordingForyHandler(
+    private val decoded: Any? = null,
+    private val encoded: ByteArray = byteArrayOf(),
+): InvocationHandler {
+
+    var byteBufferDeserializeCalls: Int = 0
+    var byteArrayDeserializeCalls: Int = 0
+    var byteArraySerializeCalls: Int = 0
+    var receivedBuffer: ByteBuffer? = null
+
+    fun proxy(): ThreadSafeFory = Proxy.newProxyInstance(
+        ThreadSafeFory::class.java.classLoader,
+        arrayOf(ThreadSafeFory::class.java),
+        this,
+    ) as ThreadSafeFory
+
+    override fun invoke(proxy: Any, method: Method, args: Array<out Any?>?): Any? {
+        if (method.declaringClass == Any::class.java) {
+            return when (method.name) {
+                "toString" -> "RecordingThreadSafeFory"
+                "hashCode" -> System.identityHashCode(proxy)
+                "equals" -> proxy === args?.firstOrNull()
+                else -> null
+            }
+        }
+
+        val argument = args?.singleOrNull()
+        return when {
+            method.name == "deserialize" && argument is ByteBuffer -> {
+                byteBufferDeserializeCalls++
+                receivedBuffer = argument
+                decoded
+            }
+            method.name == "deserialize" && argument is ByteArray -> {
+                byteArrayDeserializeCalls++
+                decoded
+            }
+            method.name == "serialize" && args?.size == 1 -> {
+                byteArraySerializeCalls++
+                encoded
+            }
+            else -> error("Unexpected ThreadSafeFory call: ${method.name}")
+        }
+    }
+}
+
+private fun configuredTarget(
+    remaining: Int,
+    direct: Boolean = false,
+): ByteBuffer {
+    val target = if (direct) ByteBuffer.allocateDirect(remaining + 8) else ByteBuffer.allocate(remaining + 8)
+    repeat(target.capacity()) { target.put(0x55) }
+    target.clear()
+    target.order(ByteOrder.LITTLE_ENDIAN)
+    target.position(3)
+    target.mark()
+    target.limit(3 + remaining)
+    return target
+}
+
+private fun configuredSource(
+    payload: ByteArray,
+    direct: Boolean,
+): ByteBuffer {
+    val source = if (direct) ByteBuffer.allocateDirect(payload.size + 5) else ByteBuffer.allocate(payload.size + 5)
+    source.put(byteArrayOf(9, 8, 7))
+    source.put(payload)
+    source.put(byteArrayOf(6, 5))
+    source.position(3)
+    source.limit(3 + payload.size)
+    source.order(ByteOrder.LITTLE_ENDIAN)
+    source.mark()
+    return source
+}
+
+private fun writableTargets(remaining: Int): List<ByteBuffer> = listOf(
+    configuredTarget(remaining),
+    configuredTarget(remaining, direct = true),
+    configuredSliceTarget(remaining),
+)
+
+private fun configuredSliceTarget(remaining: Int): ByteBuffer {
+    val parent = ByteBuffer.allocate(remaining + 12)
+    repeat(parent.capacity()) { parent.put(0x55) }
+    parent.position(2)
+    parent.limit(parent.capacity() - 2)
+    return parent.slice().apply {
+        order(ByteOrder.LITTLE_ENDIAN)
+        position(3)
+        mark()
+        limit(3 + remaining)
+    }
+}
+
+private fun sourceBuffers(payload: ByteArray): List<ByteBuffer> = listOf(
+    configuredSource(payload, direct = false),
+    configuredSource(payload, direct = true),
+    configuredSliceSource(payload),
+    configuredSource(payload, direct = false).asReadOnlyBuffer().apply {
+        order(ByteOrder.LITTLE_ENDIAN)
+        mark()
+    },
+)
+
+private fun configuredSliceSource(payload: ByteArray): ByteBuffer {
+    val parent = ByteBuffer.allocate(payload.size + 7)
+    parent.put(byteArrayOf(1, 2))
+    parent.put(byteArrayOf(9, 8, 7))
+    parent.put(payload)
+    parent.put(byteArrayOf(6, 5))
+    parent.flip()
+    parent.position(2)
+    return parent.slice().apply {
+        position(3)
+        limit(3 + payload.size)
+        order(ByteOrder.LITTLE_ENDIAN)
+        mark()
+    }
+}
+
+private fun ByteBuffer.rangeBytes(start: Int, count: Int): ByteArray =
+    duplicate().apply {
+        position(start)
+        limit(start + count)
+    }.let { view -> ByteArray(count).also(view::get) }
+
+private fun ByteBuffer.fullBytes(): ByteArray =
+    duplicate().clear().let { view -> ByteArray(view.remaining()).also(view::get) }

--- a/io/io/src/test/kotlin/io/bluetape4k/io/serializer/CoreBinarySerializerByteBufferTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/serializer/CoreBinarySerializerByteBufferTest.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.io.serializer
 
 import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.Serializer
 import com.esotericsoftware.kryo.io.ByteBufferInput
 import com.esotericsoftware.kryo.io.ByteBufferOutput
 import com.esotericsoftware.kryo.io.Input
@@ -25,7 +26,6 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.nio.ReadOnlyBufferException
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicReference
 
 class JdkBinarySerializerByteBufferTest {
 
@@ -190,28 +190,27 @@ class KryoBinarySerializerByteBufferTest {
     }
 
     @Test
-    fun `Kryo serializer passes ByteBuffer adapters to its configured Kryo`() {
+    fun `external Kryo pools keep array backed compatibility adapters`() {
         val created = AtomicInteger()
-        val observedInput = AtomicReference<Class<*>>()
-        val observedOutput = AtomicReference<Class<*>>()
         val pool = object: Pool<Kryo>(true, false, 1) {
-            override fun create(): Kryo {
+            override fun create(): Kryo = KryoProvider.createKryo().apply {
                 created.incrementAndGet()
-                return RecordingKryo(observedInput, observedOutput)
+                register(KryoArrayBackedPayload::class.java, KryoArrayBackedPayloadSerializer())
             }
         }
         val serializer = KryoBinarySerializer(kryoPool = pool)
-        val target = configuredTarget(256)
+        val expected = KryoArrayBackedPayload("array-backed")
+        val wire = serializer.serialize(expected)
+        val target = configuredTarget(wire.size)
         val start = target.position()
 
-        val written = serializer.serializeTo("record-adapters", target)
-        val restored = serializer.deserializeFrom<String>(
+        val written = serializer.serializeTo(expected, target)
+        val restored = serializer.deserializeFrom<KryoArrayBackedPayload>(
             configuredSource(target.rangeBytes(start, written), direct = true)
         )
 
-        restored shouldBeEqualTo "record-adapters"
-        ByteBufferOutput::class.java.isAssignableFrom(observedOutput.get()).shouldBeTrue()
-        ByteBufferInput::class.java.isAssignableFrom(observedInput.get()).shouldBeTrue()
+        target.rangeBytes(start, written) shouldBeEqualTo wire
+        restored shouldBeEqualTo expected
         created.get() shouldBeEqualTo 1
     }
 
@@ -267,7 +266,7 @@ class KryoBinarySerializerByteBufferTest {
     }
 
     @Test
-    fun `custom Kryo reference configuration remains active on ByteBuffer paths`() {
+    fun `custom Kryo reference configuration remains active on compatibility buffer paths`() {
         val pool = object: Pool<Kryo>(true, false, 4) {
             override fun create(): Kryo = KryoProvider.createKryo().apply {
                 references = true
@@ -436,19 +435,24 @@ data class KryoReferencePayload(
     val id: Int = 0,
 )
 
-private class RecordingKryo(
-    private val observedInput: AtomicReference<Class<*>>,
-    private val observedOutput: AtomicReference<Class<*>>,
-): Kryo() {
+data class KryoArrayBackedPayload(
+    val text: String = "",
+)
 
-    override fun writeClassAndObject(output: Output, objectValue: Any?) {
-        observedOutput.set(output.javaClass)
-        super.writeClassAndObject(output, objectValue)
+private class KryoArrayBackedPayloadSerializer: Serializer<KryoArrayBackedPayload>() {
+
+    override fun write(kryo: Kryo, output: Output, value: KryoArrayBackedPayload) {
+        check(output.buffer.isNotEmpty())
+        output.writeString(value.text)
     }
 
-    override fun readClassAndObject(input: Input): Any? {
-        observedInput.set(input.javaClass)
-        return super.readClassAndObject(input)
+    override fun read(
+        kryo: Kryo,
+        input: Input,
+        type: Class<out KryoArrayBackedPayload>,
+    ): KryoArrayBackedPayload {
+        check(input.buffer.isNotEmpty())
+        return KryoArrayBackedPayload(input.readString())
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #1036

- PR 제목: perf(io): add lower-copy ByteBuffer paths to core serializers

- Add fixed ByteBuffer-backed JDK object stream paths while preserving the configured/global `ObjectInputFilter`.
- Add scoped pooled Kryo ByteBuffer adapters for default/fast/secure configurations and retain the array-backed compatibility path for external pools.
- Use Fory's native ByteBuffer input path and retain the ByteArray output fallback where caller-owned output cannot be guaranteed.
- Preserve ByteArray APIs, wire bytes, registration/security configuration, exception behavior, and caller buffer state.

Closes #1036. Part of #754.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Change Type

- [x] `perf` - lower-copy backend paths
- [x] `test` - buffer, failure, security, pool, and concurrency coverage
- [x] `docs` - review, lesson, KDoc, and generated ABI evidence

### 기존 섹션: Code Review

- [x] Six-lens performance, stability, security, Ops, developer/API, and caller review completed.
- [x] Final integrated result: P0=0, P1=0, P2=0, P3=0.
- [x] Removed caller graph rendering from failure logs and added a regression test.
- [x] Reproduced and repaired external Kryo pool custom serializer compatibility.
- [x] Allocation and Kryo pool-contention measurements remain explicitly deferred to #1039.

## Validation

- [x] `./gradlew :bluetape4k-io:test --tests '*JdkBinarySerializerByteBufferTest' --tests '*KryoBinarySerializerByteBufferTest' --tests '*ForyBinarySerializerByteBufferTest' --no-configuration-cache --rerun-tasks` -> 18 passing in 9s
- [x] `./gradlew :bluetape4k-io:test --no-configuration-cache --rerun-tasks` -> 1055 passing in 16s
- [x] `bash scripts/check-serializer-buffer-abi.sh --build-current --expected-head 43f51bcfa176f50e7dfbed677c32f2306a4d01c2` -> legacy/new callers, default dispatch, and buffer ABI PASS
- [x] `git diff --check`
- [x] Test log captured in the tracked review and ABI evidence; `docs/testlogs/YYYY-MM.md` is N/A because that path does not exist in this repository.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1036, milestone `1.12.0`, assignee `debop`
- PR: #1040, head `f06bf2db37633ac0a44093df3536936a3ef20853`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `feat/issue-754-core-serializers`
- Labels: `enhancement`, `performance`, `infra/io`
- State: `MERGED`, merge commit `7459b84cb976a349e1bbc03fefb36d4ca50d02ee`
- CI: - [x] `./gradlew :bluetape4k-io:test --tests '*JdkBinarySerializerByteBufferTest' --tests '*KryoBinarySerializerByteBufferTest' --tests '*ForyBinarySerializerByteBufferTest' --no-configuration-cache --rerun-tasks` -> 18 passing in 9s / - [x] `./gradlew :bluetape4k-io:test --no-configuration-cache --rerun-tasks` -> 1055 passing in 16s / - [x] Allocation and Kryo pool-contention measurements remain explicitly deferred to #1039.

## DoD Status

- [x] Public backend behavior documented in KDoc; representative README and CHANGELOG updates remain assigned to #1039 with measured evidence.
- [x] Work completed in an isolated worktree.
- [x] Generated ABI evidence records the clean implementation producer commit.
- [x] Durable review and lesson artifacts committed.
- [x] `docs/superpowers/index/YYYY-MM.md` is N/A because this repository has no superpowers index path; the approved #754 spec and plan remain tracked under `docs/superpowers`.
- [x] Spring Boot, virtual thread, mock web server, module registration, release, and workflow checks are N/A for this serializer-only change.

- [x] Add RED tests for heap/direct/sliced/read-only inputs, fixed outputs, exact capacity, overflow, rollback, and caller-state preservation.
- [x] Route JDK object streams through caller-owned ByteBuffer adapters without weakening `ObjectInputFilter` or cleanup behavior.
- [x] Implement Kryo buffer paths and prove failed calls release pooled state without poisoning later calls.
- [x] Optimize only Fory cells whose resolved backend API preserves registration, security, and caller-state contracts; document fallback cells.
- [x] Preserve legacy/new caller ABI and existing wire compatibility.
- [x] Pass targeted tests, ABI verification, and correctness/API/security/resource/performance-boundary review with P0=0 and P1=0.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1040 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `7459b84cb976a349e1bbc03fefb36d4ca50d02ee`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
