### PR TITLE
Prevent invalid Maven publication models from catalog aliases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,14 @@ jobs:
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
+      - name: Validate publication POMs
+        run: |
+          ruby scripts/publication/publication_pom_audit_test.rb
+          ruby scripts/publication/publication_pom_integration_test.rb
+          ./gradlew generatePomFileForBluetape4kPublication -PsnapshotVersion=-SNAPSHOT \
+            --no-daemon --no-configuration-cache --no-build-cache
+          ruby scripts/publication/validate_poms.rb
+
   # ── 3. Core 모듈 테스트 ───────────────────────────────────────────────────
   test-core:
     name: Test / Core

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -63,6 +63,12 @@ jobs:
               print(f"{name} set={bool(value)} length={len(value)}")
           PY
 
+      - name: Validate publication POMs
+        run: |
+          ./gradlew generatePomFileForBluetape4kPublication -PsnapshotVersion=-SNAPSHOT \
+            --no-daemon --no-configuration-cache --no-build-cache
+          ruby scripts/publication/validate_poms.rb
+
       - name: Publish SNAPSHOT
         run: >-
           ./gradlew nmcpPublishAggregationToCentralPortalSnapshots

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
           catalog_url="https://raw.githubusercontent.com/bluetape4k/bluetape4k-dependencies/${BLUETAPE4K_DEPENDENCIES_CATALOG_REF}/gradle/libs.versions.toml"
           curl -fsSL "$catalog_url" -o "$catalog_file"
 
-          for alias in bluetape4k-bom bluetape4k-exposed-bom exposed-plugin; do
+          for alias in bluetape4k-bom bluetape4k-exposed-bom exposed-plugin spring-boot4-dependencies jackson jackson3; do
             if ! grep -Eq "^[[:space:]]*${alias}[[:space:]]*=" "$catalog_file"; then
               echo "::error::Catalog ref '${BLUETAPE4K_DEPENDENCIES_CATALOG_REF}' is missing alias: ${alias}"
               exit 1
@@ -158,6 +158,12 @@ jobs:
               value = os.environ.get(name, "")
               print(f"{name} set={bool(value)} length={len(value)}")
           PY
+
+      - name: Validate publication POMs
+        run: |
+          ./gradlew generatePomFileForBluetape4kPublication \
+            --no-daemon --no-configuration-cache --no-build-cache
+          ruby scripts/publication/validate_poms.rb
 
       - name: Publish to Central Portal
         run: >-

--- a/benchmark/web-framework-benchmark/build.gradle.kts
+++ b/benchmark/web-framework-benchmark/build.gradle.kts
@@ -89,7 +89,7 @@ dependencies {
     add("benchmarkImplementation", libs.ktor.server.content.negotiation)
     add("benchmarkImplementation", libs.ktor.serialization.kotlinx.json)
 
-    add("benchmarkImplementation", platform(libs.spring.boot.dependencies))
+    add("benchmarkImplementation", platform(bt4k.spring.boot4.dependencies))
     add("benchmarkImplementation", "org.springframework.boot:spring-boot-starter-webflux")
     add("benchmarkImplementation", libs.jackson3.module.kotlin)
     add("benchmarkImplementation", libs.jackson3.module.blackbird)

--- a/cache/cache-redisson/build.gradle.kts
+++ b/cache/cache-redisson/build.gradle.kts
@@ -4,7 +4,7 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
     api(project(":bluetape4k-cache-core"))
 
     // Redisson JCache provider

--- a/data/hibernate-reactive/build.gradle.kts
+++ b/data/hibernate-reactive/build.gradle.kts
@@ -63,7 +63,7 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
     constraints {
         // netty-tcnative is published on the 2.0.x line; Spring Boot 4.1 currently constrains it to Netty core 4.2.x.
         implementation("io.netty:netty-tcnative-classes") {

--- a/data/hibernate/build.gradle.kts
+++ b/data/hibernate/build.gradle.kts
@@ -102,7 +102,7 @@ artifacts {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
     testImplementation(platform(libs.junit.bom))
 
     api(project(":bluetape4k-core"))

--- a/data/jdbc/build.gradle.kts
+++ b/data/jdbc/build.gradle.kts
@@ -8,7 +8,7 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
     api(project(":bluetape4k-core"))
     testImplementation(project(":bluetape4k-junit5"))
     testImplementation(project(":bluetape4k-testcontainers"))

--- a/data/r2dbc/build.gradle.kts
+++ b/data/r2dbc/build.gradle.kts
@@ -99,7 +99,7 @@ benchmark {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
     api(project(":bluetape4k-core"))
     testImplementation(project(":bluetape4k-junit5"))
 

--- a/docs/lessons/2026-07-17-snapshot-publication-pom-model-validation.md
+++ b/docs/lessons/2026-07-17-snapshot-publication-pom-model-validation.md
@@ -1,0 +1,31 @@
+# Snapshot Publication POM Model Validation
+
+## Context
+
+Generated publication POMs contained versionless Spring Boot and Jackson BOM
+imports. Maven therefore rejected 25 module POMs, including regular Spring
+dependencies whose versions could not be resolved without those imports.
+
+## Decision
+
+Use the central `bt4k` catalog as the version source for every published BOM
+import. Validate all generated POMs structurally and then build their effective
+Maven models before CI, snapshot publishing, and release publishing.
+
+## Outcome
+
+The 77 generated publication POMs have versioned dependency-management imports,
+while regular versionless dependencies remain valid when a versioned BOM or the
+same POM manages them.
+
+## Verification
+
+- `ruby scripts/publication/publication_pom_audit_test.rb`
+- `./gradlew generatePomFileForBluetape4kPublication -PsnapshotVersion=-SNAPSHOT --no-daemon --no-configuration-cache --no-build-cache`
+- `ruby scripts/publication/validate_poms.rb`
+
+## Future Guidance
+
+Do not require a direct version on every regular dependency. Require versions
+on BOM imports, then let Maven effective-model validation prove that each
+versionless regular dependency is actually managed.

--- a/examples/jpa-blazepersistence-demo/build.gradle.kts
+++ b/examples/jpa-blazepersistence-demo/build.gradle.kts
@@ -35,7 +35,7 @@ configurations.configureEach {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
     implementation(project(":bluetape4k-hibernate"))
     testImplementation(project(":bluetape4k-junit5"))
 

--- a/examples/jpa-querydsl-demo/build.gradle.kts
+++ b/examples/jpa-querydsl-demo/build.gradle.kts
@@ -59,7 +59,7 @@ configurations.matching { it.name.startsWith("test") }.configureEach {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
     implementation(project(":bluetape4k-hibernate"))
     testImplementation(project(":bluetape4k-junit5"))
 

--- a/examples/redisson-demo/build.gradle.kts
+++ b/examples/redisson-demo/build.gradle.kts
@@ -8,7 +8,7 @@ configurations {
 }
 
 dependencies {
-    implementation(enforcedPlatform(libs.spring.boot.dependencies))
+    implementation(enforcedPlatform(bt4k.spring.boot4.dependencies))
     
     // Redisson
     testImplementation(project(":bluetape4k-redisson"))

--- a/examples/spring-boot/idgenerator-spring-boot-demo/build.gradle.kts
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/build.gradle.kts
@@ -7,7 +7,7 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
 
     implementation(project(":bluetape4k-idgenerators"))
     implementation("org.springframework.boot:spring-boot-starter-web")

--- a/examples/spring-boot/observability-spring-boot-demo/build.gradle.kts
+++ b/examples/spring-boot/observability-spring-boot-demo/build.gradle.kts
@@ -7,7 +7,7 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
 
     implementation(project(":bluetape4k-micrometer"))
     implementation(project(":bluetape4k-spring-boot-core"))

--- a/infra/bucket4j/build.gradle.kts
+++ b/infra/bucket4j/build.gradle.kts
@@ -7,7 +7,7 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
     api(project(":bluetape4k-core"))
     compileOnly(project(":bluetape4k-cache-core"))
     testImplementation(project(":bluetape4k-junit5"))

--- a/infra/kafka/build.gradle.kts
+++ b/infra/kafka/build.gradle.kts
@@ -19,7 +19,7 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
     api(project(":bluetape4k-annotations"))
     api(project(":bluetape4k-core"))
     api(project(":bluetape4k-io"))

--- a/infra/kafka4/build.gradle.kts
+++ b/infra/kafka4/build.gradle.kts
@@ -26,7 +26,7 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
     api(project(":bluetape4k-annotations"))
     api(project(":bluetape4k-core"))
     api(project(":bluetape4k-io"))

--- a/infra/micrometer/build.gradle.kts
+++ b/infra/micrometer/build.gradle.kts
@@ -8,7 +8,7 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
 
     api(project(":bluetape4k-core"))
     implementation(project(":bluetape4k-cache-core"))

--- a/infra/opentelemetry/build.gradle.kts
+++ b/infra/opentelemetry/build.gradle.kts
@@ -40,7 +40,7 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
     api(project(":bluetape4k-io"))
     implementation(project(":bluetape4k-netty"))
     testImplementation(project(":bluetape4k-junit5"))

--- a/infra/redisson/build.gradle.kts
+++ b/infra/redisson/build.gradle.kts
@@ -46,7 +46,7 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
     api(project(":bluetape4k-core"))
     api(project(":bluetape4k-io"))
     api(project(":bluetape4k-netty"))

--- a/io/feign/build.gradle.kts
+++ b/io/feign/build.gradle.kts
@@ -13,7 +13,7 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
     testImplementation(platform(libs.spring.cloud.dependencies))
 
     api(project(":bluetape4k-http"))

--- a/io/jackson2/build.gradle.kts
+++ b/io/jackson2/build.gradle.kts
@@ -3,8 +3,8 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jackson.bom))
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform("com.fasterxml.jackson:jackson-bom:${bt4k.versions.jackson.asProvider().get()}"))
+    implementation(platform(bt4k.spring.boot4.dependencies))
 
     api(libs.jackson.core)
     api(libs.jackson.databind)

--- a/io/jackson3/build.gradle.kts
+++ b/io/jackson3/build.gradle.kts
@@ -3,8 +3,8 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jackson3.bom))
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform("tools.jackson:jackson-bom:${bt4k.versions.jackson3.get()}"))
+    implementation(platform(bt4k.spring.boot4.dependencies))
 
     api(libs.jackson3.core)
     api(libs.jackson3.databind)

--- a/io/retrofit2/build.gradle.kts
+++ b/io/retrofit2/build.gradle.kts
@@ -3,7 +3,7 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
 
     api(project(":bluetape4k-http"))
     api(project(":bluetape4k-okio"))

--- a/scripts/publication/maven-settings.xml
+++ b/scripts/publication/maven-settings.xml
@@ -1,0 +1,24 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+  <profiles>
+    <profile>
+      <id>publication-pom-audit</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>https://repo.maven.apache.org/maven2</url>
+          <releases><enabled>true</enabled></releases>
+          <snapshots><enabled>false</enabled></snapshots>
+        </repository>
+        <repository>
+          <id>central-snapshots</id>
+          <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+          <releases><enabled>false</enabled></releases>
+          <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>publication-pom-audit</activeProfile>
+  </activeProfiles>
+</settings>

--- a/scripts/publication/publication_pom_audit.rb
+++ b/scripts/publication/publication_pom_audit.rb
@@ -1,0 +1,67 @@
+require "rexml/document"
+require "set"
+
+module Publication
+  class PomAudit
+    Result = Struct.new(:errors, :file_count, :dependency_count, keyword_init: true)
+
+    def initialize(paths)
+      @paths = Array(paths).map { |path| File.expand_path(path) }.sort
+    end
+
+    def validate
+      return Result.new(errors: ["no publication POM files found"], file_count: 0, dependency_count: 0) if @paths.empty?
+
+      errors = []
+      dependency_count = 0
+
+      @paths.each do |path|
+        document = REXML::Document.new(File.read(path))
+        managed_dependencies = REXML::XPath.match(
+          document,
+          "/project/dependencyManagement/dependencies/dependency",
+        )
+        managed_versions = managed_dependencies.each_with_object(Set.new) do |dependency, result|
+          version = dependency.elements["version"]&.text.to_s.strip
+          result << coordinate(dependency) unless version.empty?
+        end
+        has_versioned_bom_import = managed_dependencies.any? do |dependency|
+          version = dependency.elements["version"]&.text.to_s.strip
+          type = dependency.elements["type"]&.text.to_s.strip
+          scope = dependency.elements["scope"]&.text.to_s.strip
+          !version.empty? && type == "pom" && scope == "import"
+        end
+
+        managed_dependencies.each do |dependency|
+          dependency_count += 1
+          next unless dependency.elements["version"]&.text.to_s.strip.empty?
+
+          errors << "#{path}: missing dependency version: #{coordinate(dependency)}"
+        end
+
+        REXML::XPath.each(document, "/project/dependencies/dependency") do |dependency|
+          dependency_count += 1
+          version = dependency.elements["version"]&.text.to_s.strip
+          dependency_coordinate = coordinate(dependency)
+          next unless version.empty?
+          next if managed_versions.include?(dependency_coordinate)
+          next if has_versioned_bom_import
+
+          errors << "#{path}: missing dependency version: #{dependency_coordinate}"
+        end
+      rescue REXML::ParseException => error
+        errors << "#{path}: invalid XML: #{error.message.lines.first.to_s.strip}"
+      end
+
+      Result.new(errors: errors.sort, file_count: @paths.length, dependency_count: dependency_count)
+    end
+
+    private
+
+    def coordinate(dependency)
+      group = dependency.elements["groupId"]&.text.to_s.strip
+      artifact = dependency.elements["artifactId"]&.text.to_s.strip
+      "#{group}:#{artifact}"
+    end
+  end
+end

--- a/scripts/publication/publication_pom_audit_test.rb
+++ b/scripts/publication/publication_pom_audit_test.rb
@@ -1,0 +1,85 @@
+require "fileutils"
+require "minitest/autorun"
+require "tmpdir"
+
+require_relative "publication_pom_audit"
+
+class PublicationPomAuditTest < Minitest::Test
+  def test_accepts_dependencies_with_explicit_versions
+    with_pom(<<~XML) do |path|
+      <project><dependencies><dependency>
+        <groupId>org.example</groupId><artifactId>example-core</artifactId><version>1.2.3</version>
+      </dependency></dependencies></project>
+    XML
+      result = Publication::PomAudit.new([path]).validate
+      assert_empty result.errors
+      assert_equal 1, result.file_count
+      assert_equal 1, result.dependency_count
+    end
+  end
+
+  def test_rejects_versionless_regular_and_managed_dependencies
+    with_pom(<<~XML) do |path|
+      <project>
+        <dependencyManagement><dependencies><dependency>
+          <groupId>org.example</groupId><artifactId>example-bom</artifactId>
+          <type>pom</type><scope>import</scope>
+        </dependency></dependencies></dependencyManagement>
+        <dependencies><dependency>
+          <groupId>org.example</groupId><artifactId>example-core</artifactId>
+        </dependency></dependencies>
+      </project>
+    XML
+      errors = Publication::PomAudit.new([path]).validate.errors
+      assert_equal 2, errors.length
+      assert errors.any? { |error| error.end_with?("missing dependency version: org.example:example-bom") }
+      assert errors.any? { |error| error.end_with?("missing dependency version: org.example:example-core") }
+    end
+  end
+
+  def test_accepts_a_versionless_dependency_managed_by_the_same_pom
+    with_pom(<<~XML) do |path|
+      <project>
+        <dependencyManagement><dependencies><dependency>
+          <groupId>org.example</groupId><artifactId>example-core</artifactId><version>1.2.3</version>
+        </dependency></dependencies></dependencyManagement>
+        <dependencies><dependency>
+          <groupId>org.example</groupId><artifactId>example-core</artifactId>
+        </dependency></dependencies>
+      </project>
+    XML
+      assert_empty Publication::PomAudit.new([path]).validate.errors
+    end
+  end
+
+  def test_accepts_a_versionless_dependency_when_a_versioned_bom_is_imported
+    with_pom(<<~XML) do |path|
+      <project>
+        <dependencyManagement><dependencies><dependency>
+          <groupId>org.example</groupId><artifactId>example-bom</artifactId><version>1.2.3</version>
+          <type>pom</type><scope>import</scope>
+        </dependency></dependencies></dependencyManagement>
+        <dependencies><dependency>
+          <groupId>org.example</groupId><artifactId>example-core</artifactId>
+        </dependency></dependencies>
+      </project>
+    XML
+      assert_empty Publication::PomAudit.new([path]).validate.errors
+    end
+  end
+
+  def test_fails_closed_when_no_publication_poms_exist
+    result = Publication::PomAudit.new([]).validate
+    assert_equal ["no publication POM files found"], result.errors
+  end
+
+  private
+
+  def with_pom(content)
+    Dir.mktmpdir("publication-pom-audit") do |root|
+      path = File.join(root, "pom-default.xml")
+      File.write(path, content)
+      yield path
+    end
+  end
+end

--- a/scripts/publication/publication_pom_integration_test.rb
+++ b/scripts/publication/publication_pom_integration_test.rb
@@ -1,0 +1,69 @@
+require "minitest/autorun"
+require "open3"
+require "rbconfig"
+require "tmpdir"
+
+class PublicationPomIntegrationTest < Minitest::Test
+  def test_maven_rejects_a_dependency_not_managed_by_the_imported_bom
+    with_pom(<<~XML) do |path|
+      <project>
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>org.example</groupId>
+        <artifactId>unmanaged-dependency</artifactId>
+        <version>1</version>
+        <dependencyManagement><dependencies><dependency>
+          <groupId>org.junit</groupId><artifactId>junit-bom</artifactId><version>5.10.2</version>
+          <type>pom</type><scope>import</scope>
+        </dependency></dependencies></dependencyManagement>
+        <dependencies><dependency>
+          <groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId>
+        </dependency></dependencies>
+      </project>
+    XML
+      output, status = validate(path)
+      refute status.success?
+      assert_includes output, "'dependencies.dependency.version' for org.slf4j:slf4j-api:jar is missing"
+    end
+  end
+
+  def test_maven_accepts_a_dependency_managed_by_the_imported_bom
+    with_pom(<<~XML) do |path|
+      <project>
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>org.example</groupId>
+        <artifactId>managed-dependency</artifactId>
+        <version>1</version>
+        <dependencyManagement><dependencies><dependency>
+          <groupId>org.junit</groupId><artifactId>junit-bom</artifactId><version>5.10.2</version>
+          <type>pom</type><scope>import</scope>
+        </dependency></dependencies></dependencyManagement>
+        <dependencies><dependency>
+          <groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter-api</artifactId>
+        </dependency></dependencies>
+      </project>
+    XML
+      output, status = validate(path)
+      assert status.success?, output
+      assert_includes output, "maven_models=1"
+    end
+  end
+
+  private
+
+  def validate(path)
+    stdout, stderr, status = Open3.capture3(
+      RbConfig.ruby,
+      File.expand_path("validate_poms.rb", __dir__),
+      path,
+    )
+    [stdout + stderr, status]
+  end
+
+  def with_pom(content)
+    Dir.mktmpdir("publication-pom-integration") do |root|
+      path = File.join(root, "pom.xml")
+      File.write(path, content)
+      yield path
+    end
+  end
+end

--- a/scripts/publication/validate_poms.rb
+++ b/scripts/publication/validate_poms.rb
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+
+require "fileutils"
+require "open3"
+require "tmpdir"
+
+require_relative "publication_pom_audit"
+
+paths = if ARGV.empty?
+          Dir.glob("**/build/publications/*/pom-default.xml")
+            .reject { |path| path.start_with?(".worktrees/") }
+        else
+          ARGV
+        end
+
+result = Publication::PomAudit.new(paths).validate
+unless result.errors.empty?
+  warn(result.errors.join("\n"))
+  abort("publication-poms: failures=#{result.errors.length} files=#{result.file_count} dependencies=#{result.dependency_count}")
+end
+
+settings = File.expand_path("maven-settings.xml", __dir__)
+
+Dir.mktmpdir("publication-pom-reactor") do |reactor|
+  modules = paths.sort.each_with_index.map do |path, index|
+    module_name = format("module-%03d", index + 1)
+    module_dir = File.join(reactor, module_name)
+    FileUtils.mkdir_p(module_dir)
+    FileUtils.cp(File.expand_path(path), File.join(module_dir, "pom.xml"))
+    module_name
+  end
+
+  File.write(
+    File.join(reactor, "pom.xml"),
+    <<~XML,
+      <project xmlns="http://maven.apache.org/POM/4.0.0">
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>io.github.bluetape4k.validation</groupId>
+        <artifactId>publication-pom-reactor</artifactId>
+        <version>1</version>
+        <packaging>pom</packaging>
+        <modules>
+      #{modules.map { |name| "    <module>#{name}</module>" }.join("\n")}
+        </modules>
+      </project>
+    XML
+  )
+
+  command = [
+    ENV.fetch("MAVEN_COMMAND", "mvn"),
+    "-U", "-q", "-s", settings,
+    "-f", File.join(reactor, "pom.xml"),
+    "validate",
+  ]
+  stdout, stderr, status = Open3.capture3(*command)
+  unless status.success?
+    diagnostics = (stdout + stderr).lines.grep(/\[ERROR\]/).first(40)
+    warn(diagnostics.empty? ? stdout + stderr : diagnostics.join)
+    abort("publication-poms: Maven effective-model validation failed")
+  end
+rescue Errno::ENOENT => error
+  abort("publication-poms: Maven executable not found: #{error.message}")
+end
+
+puts "publication-poms: failures=0 files=#{result.file_count} dependencies=#{result.dependency_count} maven_models=#{result.file_count}"

--- a/spring-boot/cassandra-demo/build.gradle.kts
+++ b/spring-boot/cassandra-demo/build.gradle.kts
@@ -19,7 +19,7 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
 
     implementation(project(":bluetape4k-cassandra"))
     implementation(project(":bluetape4k-spring-boot-cassandra"))

--- a/spring-boot/cassandra/build.gradle.kts
+++ b/spring-boot/cassandra/build.gradle.kts
@@ -23,7 +23,7 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
     api(project(":bluetape4k-cassandra"))
     api(project(":bluetape4k-spring-boot-core"))
     testImplementation(project(":bluetape4k-jackson3"))
@@ -61,4 +61,3 @@ dependencies {
     implementation(libs.reactor.kotlin.extensions)
     testImplementation(libs.reactor.test)
 }
-

--- a/spring-boot/core/build.gradle.kts
+++ b/spring-boot/core/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     // Spring Boot 4 BOM: platform()을 사용하면 compileClasspath/runtimeClasspath에만 적용되고
     // kotlinBuildToolsApiClasspath 같은 내부 Gradle 설정에는 영향을 주지 않음
     // (dependencyManagement 플러그인은 ALL configurations에 적용되어 kotlin-stdlib 버전 충돌 유발)
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
     // Spring Boot Starters
     compileOnly("org.springframework.boot:spring-boot-starter-webflux")
     compileOnly("org.springframework.boot:spring-boot-starter-web")

--- a/spring-boot/hibernate-lettuce-demo/build.gradle.kts
+++ b/spring-boot/hibernate-lettuce-demo/build.gradle.kts
@@ -40,7 +40,7 @@ configurations.matching { it.name.startsWith("test") }.configureEach {
 
 dependencies {
     // Spring Boot 4 BOM: platform() 방식 필수 (dependencyManagement 사용 금지 - KGP 2.3 충돌)
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
 
     implementation(project(":bluetape4k-spring-boot-hibernate-lettuce"))
     implementation("org.springframework.boot:spring-boot-starter-web")

--- a/spring-boot/hibernate-lettuce/build.gradle.kts
+++ b/spring-boot/hibernate-lettuce/build.gradle.kts
@@ -38,7 +38,7 @@ configurations.matching { it.name.startsWith("test") }.configureEach {
 
 dependencies {
     // Spring Boot 4 BOM: platform() 방식 필수 (dependencyManagement 사용 금지 - KGP 2.3 충돌)
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
 
     // 핵심: Hibernate 2nd Level Cache Lettuce 구현체
     api(project(":bluetape4k-hibernate-cache-lettuce"))

--- a/spring-boot/mongodb/build.gradle.kts
+++ b/spring-boot/mongodb/build.gradle.kts
@@ -13,7 +13,7 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
 
     api(project(":bluetape4k-spring-boot-core"))
 

--- a/spring-boot/r2dbc/build.gradle.kts
+++ b/spring-boot/r2dbc/build.gradle.kts
@@ -7,7 +7,7 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
 
     api(project(":bluetape4k-r2dbc"))
     testImplementation(project(":bluetape4k-junit5"))

--- a/spring-boot/redis/build.gradle.kts
+++ b/spring-boot/redis/build.gradle.kts
@@ -27,7 +27,7 @@ tasks.named("check") {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
 
     api(project(":bluetape4k-core"))
     api(project(":bluetape4k-io"))

--- a/testing/mock-web-server/build.gradle.kts
+++ b/testing/mock-web-server/build.gradle.kts
@@ -20,9 +20,9 @@ tasks.withType<AbstractPublishToMaven>().configureEach { enabled = false }
 
 dependencies {
     // Spring Boot 4 BOM: platform() 방식 필수 (dependencyManagement 사용 금지 - KGP 2.3 충돌)
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
     // Jackson 3 BOM: Spring Boot 4는 tools.jackson.* (Jackson 3) 사용
-    implementation(platform(libs.jackson3.bom))
+    implementation(platform("tools.jackson:jackson-bom:${bt4k.versions.jackson3.get()}"))
 
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-cache")

--- a/testing/mock-webflux-server/build.gradle.kts
+++ b/testing/mock-webflux-server/build.gradle.kts
@@ -18,9 +18,9 @@ tasks.withType<AbstractPublishToMaven>().configureEach { enabled = false }
 
 dependencies {
     // Spring Boot 4 BOM via platform() — KGP 2.3 compatible
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
     // Jackson 3 BOM — Spring Boot 4 does not auto-opt-in
-    implementation(platform(libs.jackson3.bom))
+    implementation(platform("tools.jackson:jackson-bom:${bt4k.versions.jackson3.get()}"))
 
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.boot:spring-boot-starter-cache")

--- a/testing/testcontainers/build.gradle.kts
+++ b/testing/testcontainers/build.gradle.kts
@@ -63,7 +63,7 @@ tasks.register<Test>("k8sTest") {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
     api(project(":bluetape4k-core"))
     testImplementation(project(":bluetape4k-junit5"))
 

--- a/utils/rule-engine/build.gradle.kts
+++ b/utils/rule-engine/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
 
     // Spring BOM (SpEL 버전 관리)
-    implementation(platform(libs.spring.boot.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
     compileOnly("org.springframework:spring-expression")
 
     // MVEL2


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: Prevent invalid Maven publication models from catalog aliases

This PR prevents catalog aliases from producing incomplete Maven publication metadata.

## Background

Central catalog aliases could resolve correctly in Gradle while generating Maven POM entries without usable versions.

## What This Solves

- Publication POM correctness is verified as a Maven consumer contract, not inferred from Gradle resolution.
- Snapshot, release, and CI paths fail closed when generated metadata is incomplete.

## Work Done

- Use central catalog versions for Spring Boot 4 and Jackson BOM imports across affected publications.
- Add structural POM auditing, Maven model validation, and CI/snapshot/release gates for every generated publication.

## Validation

- Ruby audit: 5 tests / 12 assertions: PASS
- Maven integration: 2 tests / 6 assertions: PASS
- Publication contract: 77 POMs, 32,031 dependency entries, 77 Maven models: PASS
- ./gradlew build -x test: PASS (564 tasks): PASS
- actionlint on changed workflows: PASS: PASS

## Review Notes

- P0/P1: 0
- P2/P3: fixed during local review; no open findings
- Review evidence: independent local review plus the complete cross-repository publication gate

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #1041, head `407431a77b35922ae37c0036b17cff30b1691c7d`, milestone `없음`, assignee `debop`
- Base: `develop`, head branch `agent/publication-pom-model-validation`
- Labels: `bug`, `build`, `ci`
- State: `MERGED`, merge commit `7a2f998433862e8e6ca8759d07ac64efe03a9f54`
- CI: This PR prevents catalog aliases from producing incomplete Maven publication metadata. / Central catalog aliases could resolve correctly in Gradle while generating Maven POM entries without usable versions. / - Publication POM correctness is verified as a Maven consumer contract, not inferred from Gradle resolution.

## DoD Status

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01 to CG-10 | Scope, implement, review, and verify the branch | PASS | Clean Lore commit `407431a77b35922ae37c0036b17cff30b1691c7d`; local validation above | none |
| CG-11 | Confirm PR authority and exact base/head | PASS | User requested PR delivery for every changed repo; base `develop` | none |
| CG-12 | Push and read back exact head | PASS | Local and remote head `407431a77b35922ae37c0036b17cff30b1691c7d` | none |
| CG-13 | Create and verify PR metadata | PASS | https://github.com/bluetape4k/bluetape4k-projects/pull/1041; head `407431a77b35922ae37c0036b17cff30b1691c7d`; assignee `debop` | none |
| CG-14 | Pass CI and live review | PASS | 19 successful checks; mergeable; unresolved review threads 0 | none |
| CG-15 | Report exact-head merge readiness | PASS | PR #1041 at `407431a77b35922ae37c0036b17cff30b1691c7d`; checks/review evidence reported to user | none |
| CG-16 | Obtain fresh merge approval | PASS | User replied `승인` after the exact-head merge-ready report | none |
| CG-17 | Execute and verify squash merge | PASS | PR #1041 merged as `7a2f998433862e8e6ca8759d07ac64efe03a9f54`; tested head `407431a77b35922ae37c0036b17cff30b1691c7d` | none |
| CG-18 | Synchronize local develop | PASS | Local and `origin/develop` at `7a2f998433862e8e6ca8759d07ac64efe03a9f54`; merge tree equals tested head tree | Local feature branch preserved; no unrelated worktree cleanup |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1041 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `7a2f998433862e8e6ca8759d07ac64efe03a9f54`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
