### PR TITLE
Implement lower-copy ByteBuffer paths for JSON serializers

### DIFF
--- a/docs/evidence/issue-754/contract/abi-report.json
+++ b/docs/evidence/issue-754/contract/abi-report.json
@@ -33,10 +33,10 @@
     "legacy-java-compilation": "PASS",
     "legacy-kotlin-compilation": "PASS"
   },
-  "command": "bash scripts/check-serializer-buffer-abi.sh --build-current --expected-head 43f51bcfa176f50e7dfbed677c32f2306a4d01c2",
+  "command": "bash scripts/check-serializer-buffer-abi.sh --build-current --expected-head 3198fa3c8648033b2ae36bfd3fcecec42db23cdf",
   "issue": 754,
-  "producerCommit": "43f51bcfa176f50e7dfbed677c32f2306a4d01c2",
-  "producerTree": "2f7d61cc4a1f0a2a0758b840f02862b3ca4144bb",
+  "producerCommit": "3198fa3c8648033b2ae36bfd3fcecec42db23cdf",
+  "producerTree": "c63492950369da2376453cf15ebab0c89a5192ea",
   "schemaVersion": 1,
   "slice": "contract",
   "status": "GREEN",

--- a/docs/evidence/issue-754/json/abi-report.json
+++ b/docs/evidence/issue-754/json/abi-report.json
@@ -1,0 +1,60 @@
+{
+  "schemaVersion": 1,
+  "issue": 1037,
+  "slice": "json-serializers",
+  "status": "GREEN",
+  "producerCommit": "3198fa3c8648033b2ae36bfd3fcecec42db23cdf",
+  "producerTree": "c63492950369da2376453cf15ebab0c89a5192ea",
+  "artifacts": [
+    {
+      "module": "jackson2",
+      "path": "io/jackson2/build/libs/bluetape4k-jackson2-1.12.0.jar",
+      "sha256": "76bf40eb7d355d6dee2a070cae274ea223ef2f3ea42d497753fac722c4db740d"
+    },
+    {
+      "module": "jackson3",
+      "path": "io/jackson3/build/libs/bluetape4k-jackson3-1.12.0.jar",
+      "sha256": "fb3c1c15689846e4540e7e4ff792c7075aa965ca8538b57202678ad8fe633c32"
+    },
+    {
+      "module": "fastjson2",
+      "path": "io/fastjson2/build/libs/bluetape4k-fastjson2-1.12.0.jar",
+      "sha256": "4c897818bee3b62f0a763ffb4db76abfdd26937a0a310733054025237c433aca"
+    }
+  ],
+  "checks": {
+    "aggregate-serializer-abi": "PASS",
+    "jackson2-open-class-has-no-bytebuffer-reified-member": "PASS",
+    "jackson2-top-level-bytebuffer-extension": "PASS",
+    "jackson3-open-class-has-no-bytebuffer-reified-member": "PASS",
+    "jackson3-top-level-bytebuffer-extension": "PASS",
+    "fastjson2-final-class-bytebuffer-member": "PASS",
+    "jackson2-external-consumer-compilation": "PASS",
+    "jackson3-external-consumer-compilation": "PASS",
+    "jackson2-complete-module-tests-455": "PASS",
+    "jackson3-complete-module-tests-456": "PASS",
+    "fastjson2-complete-module-tests-180": "PASS"
+  },
+  "publicSymbols": {
+    "jackson2Class": [
+      "public int serializeTo(java.lang.Object, java.nio.ByteBuffer)",
+      "public <T> T deserializeFrom(java.nio.ByteBuffer, java.lang.Class<T>)"
+    ],
+    "jackson2Extension": "public static final <T> T deserialize(io.bluetape4k.jackson.JacksonSerializer, java.nio.ByteBuffer)",
+    "jackson3Class": [
+      "public int serializeTo(java.lang.Object, java.nio.ByteBuffer)",
+      "public <T> T deserializeFrom(java.nio.ByteBuffer, java.lang.Class<T>)"
+    ],
+    "jackson3Extension": "public static final <T> T deserialize(io.bluetape4k.jackson3.JacksonSerializer, java.nio.ByteBuffer)",
+    "fastjson2Class": [
+      "public int serializeTo(java.lang.Object, java.nio.ByteBuffer)",
+      "public <T> T deserializeFrom(java.nio.ByteBuffer, java.lang.Class<T>)",
+      "public final <T> T deserialize(java.nio.ByteBuffer)"
+    ]
+  },
+  "commands": [
+    "bash scripts/check-serializer-buffer-abi.sh --build-current --expected-head 3198fa3c8648033b2ae36bfd3fcecec42db23cdf",
+    "./gradlew :bluetape4k-jackson2:jar :bluetape4k-jackson3:jar :bluetape4k-fastjson2:jar --no-daemon",
+    "javap -public -classpath <module-jar> <serializer-class-or-file-facade>"
+  ]
+}

--- a/docs/evidence/issue-754/json/fastjson2-2.0.62-capability.md
+++ b/docs/evidence/issue-754/json/fastjson2-2.0.62-capability.md
@@ -1,0 +1,58 @@
+# Fastjson2 2.0.62 ByteBuffer Capability Evidence
+
+## Resolved Artifact
+
+- Coordinate: `com.alibaba.fastjson2:fastjson2:2.0.62`
+- Sources JAR SHA-256: `712dba017b892c2e878614b38c94316ebdaab2a0f3104eb055a6ec9bb6b18619`
+- Inspected source root: `.codex/lib-sources/fastjson2-2.0.62`
+- Inspection date: 2026-07-17
+
+The extraction directory is temporary review input and is removed before the PR. This document is the durable evidence.
+
+## Source Findings
+
+1. `com/alibaba/fastjson2/JSONB.java:1653-1670` implements `toBytes(Object)` with an internal
+   `JSONWriterJSONB` and returns `writer.getBytes()`.
+2. `com/alibaba/fastjson2/JSONWriterJSONB.java:1837-1839` implements `getBytes()` as
+   `Arrays.copyOf(bytes, off)`. Public JSONB output therefore materializes a library-owned `byte[]`.
+3. `com/alibaba/fastjson2/JSONReaderJSONB.java:106-137` implements the `InputStream` constructor by
+   obtaining or allocating an internal `byte[]`, reading the stream into it, and growing it with
+   `Arrays.copyOf` when required. Adapting a `ByteBuffer` to this constructor does not remove the input copy.
+4. `com/alibaba/fastjson2/JSONB.java:1267-1323` exposes `byte[]`, offset, and length overloads for both
+   `Class<T>` and `Type`. They construct `JSONReaderJSONB` over the supplied array range without first
+   copying that range.
+5. `com/alibaba/fastjson2/JSONReaderJSONB.java:752-791` handles JSONB typed-any metadata and checks
+   `Feature.SupportAutoType`; without that feature it reads object/array payloads as data instead of
+   resolving and instantiating the encoded class.
+
+## Decision
+
+Use the offset/length parser only when `ByteBuffer.hasArray()` is true. Pass
+`array()`, `arrayOffset() + position()`, and `remaining()` with either the class token or
+`reference<T>().type`. Use a bounded copy from `source.duplicate()` for direct or read-only input.
+
+Keep `serializeTo` as an explicitly allocating compatibility path: call `JSONB.toBytes`, validate target
+capacity, write through a duplicate, and commit the caller position only after success. No lower-copy or
+zero-copy output claim is made.
+
+All paths use Fastjson2's feature-free overloads. They do not enable `SupportAutoType`, install an AutoType
+filter, or broaden the default reader context.
+
+## Capability Matrix
+
+| Operation / buffer kind | Path | Allocation statement |
+|---|---|---|
+| Deserialize writable heap buffer | backing `byte[]` + offset/length | Optimized: avoids the adapter-level range copy |
+| Deserialize writable heap slice | backing `byte[]` + `arrayOffset()` + position | Optimized: avoids the adapter-level range copy |
+| Deserialize direct buffer | duplicate into bounded `byte[]` | Compatibility fallback: one adapter-level copy |
+| Deserialize read-only buffer | duplicate into bounded `byte[]` | Compatibility fallback: one adapter-level copy |
+| Deserialize concrete reified generic | same cells with `reference<T>().type` | Preserves `List<Model>` and `Map<String, Model>` typing |
+| Deserialize through `JsonSerializer` receiver | class-token path | Preserves existing raw generic limitation |
+| Serialize to any writable target | `JSONB.toBytes` then duplicate `put` | Allocating compatibility fallback; no allocation reduction claim |
+
+## Rejected Paths
+
+- `JSONReaderJSONB(Context, InputStream)`: rejected because it reads into and may grow an internal array.
+- Reflection into `JSONWriterJSONB` storage: rejected because it is not a stable public API and would weaken
+  compatibility and security reviewability.
+- Enabling AutoType to improve generic reconstruction: rejected because it changes the established security contract.

--- a/docs/lessons/2026-07-17-issue-1037-json-serializer-bytebuffer.md
+++ b/docs/lessons/2026-07-17-issue-1037-json-serializer-bytebuffer.md
@@ -1,0 +1,79 @@
+# Issue #1037: JSON serializer ByteBuffer paths
+
+## Context
+
+The shared `JsonSerializer` contract already exposed ByteBuffer defaults, but the
+compatibility implementation staged data through a complete ByteArray. Jackson 2,
+Jackson 3, and Fastjson2 expose materially different stream and array-range APIs,
+so the JSON slice needed backend-specific paths without changing wire formats,
+mapper/security configuration, exception policy, or caller-owned buffer state.
+
+## Decision
+
+- Stream Jackson 2 and Jackson 3 output through a fixed duplicate-backed
+  `ByteBufferOutputStream`, and read input through a duplicate-backed
+  `ByteBufferInputStream`.
+- Create and close the Jackson generator explicitly through the configured
+  `ObjectWriter`; mapper convenience methods catch `Exception`, not every fatal
+  `Error`, so caller-owned stream cleanup cannot rely on them.
+- Keep the generic Jackson ByteBuffer API as a top-level concrete-receiver
+  extension. Adding a final member to the public open serializer classes could
+  conflict with an existing subclass that already owns the same JVM signature.
+- Use Fastjson2's array/offset/length JSONB parser only for writable array-backed
+  input. Copy direct and read-only input, and retain `JSONB.toBytes` as the
+  explicitly allocating output compatibility path.
+- Traverse at most 64 cause links when preserving nested fatal errors or buffer
+  overflow. Suppressed cleanup failures never replace the primary backend failure.
+- Keep all JSONB readers feature-free and do not enable AutoType.
+
+## Surprise / Failure
+
+The first Jackson reified API was a member on an open class. It worked in local
+callers but introduced a final JVM method that could break a legacy subclass with
+the same erased signature. Moving it to an extension fixed the class ABI, but the
+README and tests also had to distinguish that extension from the existing
+`JsonSerializer.deserialize` extension through explicit imports and an alias.
+
+Jackson's mapper-owned write path closes its generator for ordinary exceptions,
+but the resolved Jackson 2 and Jackson 3 sources catch `Exception` rather than
+`Error`. An explicit generator scope was required to guarantee cleanup on fatal
+serialization failures.
+
+Fastjson2 may replace a setter-thrown `Error` with a `ClassCastException`, so that
+fixture could not prove adapter behavior. A registered JSONB `ObjectReader` that
+throws an ordinary wrapper with the fatal error as its cause provided the valid
+identity test. The same investigation exposed that scanning suppressed failures
+would incorrectly promote cleanup errors over the primary parse failure.
+
+## Outcome
+
+Jackson 2 and Jackson 3 bypass the ByteArray compatibility path for fixed output
+and bounded input while retaining mapper configuration and inherited data formats.
+Fastjson2 avoids an input copy only where its public API supports an existing
+array range; unsupported input and all output stay on documented compatibility
+paths. Existing ByteArray entry points, JSON/JSONB wire bytes, raw interface
+dispatch, and caller position/limit/mark/order contracts remain intact.
+
+## Verification
+
+- Jackson 2 ByteBuffer suite: 14 tests passed; external consumer import test:
+  1 test passed; full module: 455 tests passed.
+- Jackson 3 ByteBuffer suite: 16 tests passed; external consumer import test:
+  1 test passed; full module: 456 tests passed.
+- Fastjson2 ByteBuffer suite: 14 tests passed; full module: 180 tests passed.
+- Legacy same-signature Jackson subclasses compile, while the reified extension
+  still retains generic collection element types.
+- Fastjson2 resolved-source evidence records version `2.0.62`, source locations,
+  source JAR SHA-256, and the optimized/fallback matrix.
+- Root `detekt` is `NO-SOURCE`; module compilation, complete module tests,
+  README contract checks, unsafe-pattern scanning, and `git diff --check` provide
+  the available static fallback.
+
+## Future Guard
+
+Do not add a convenience member to a public open class without checking erased
+subclass signatures. When a backend owns a stream wrapper, inspect the resolved
+source for fatal-error cleanup rather than assuming `use` at the outer stream is
+sufficient. Preserve only fatal failures reachable through the primary cause
+chain, never through suppressed cleanup failures. Make optimization claims per
+backend cell and defer allocation claims until repeated benchmark evidence exists.

--- a/docs/review/2026-07-17-issue-1037-json-serializer-bytebuffer-review.md
+++ b/docs/review/2026-07-17-issue-1037-json-serializer-bytebuffer-review.md
@@ -1,0 +1,80 @@
+# Issue 1037 JSON Serializer ByteBuffer Review
+
+## Scope
+
+- Route Jackson 2 and Jackson 3 through duplicate-backed ByteBuffer streams.
+- Use Fastjson2 JSONB array-range input where supported while retaining its
+  allocating output compatibility path.
+- Preserve ByteArray APIs, wire formats, mapper and AutoType security settings,
+  exception policy, and caller-owned buffer state.
+- Document the backend capability matrix and verify external Kotlin import use.
+
+## Review Result
+
+- Final integrated review: APPROVE, P0=0, P1=0.
+- Performance: Jackson bypasses complete ByteArray staging for fixed output and
+  bounded input. Fastjson2 bypasses input copying only for writable array-backed
+  buffers; unsupported input and all output retain the documented fallback.
+- Stability: output commits caller position only after success, failures restore
+  position, explicit Jackson generator scopes close on fatal failures, and cause
+  traversal is bounded to 64 links without promoting suppressed cleanup failures.
+- Security: configured Jackson readers and writers remain authoritative;
+  Fastjson2 JSONB readers remain feature-free and never enable AutoType.
+- Ops: no module registration, Gradle configuration, publishing, release, or
+  workflow surface changed. Resource ownership and fallback behavior are local
+  to the three serializers.
+- Developer/API: the open Jackson serializer classes gain no final public JVM
+  method; concrete reified ByteBuffer decoding is a top-level extension. The
+  final Fastjson2 serializer retains its concrete convenience member.
+- User/caller: heap, direct, sliced, and read-only input behavior is covered.
+  External-package tests prove that concrete and generic ByteBuffer extensions
+  can be imported together through an explicit alias.
+
+## Resolved Findings
+
+- Moved the Jackson reified ByteBuffer method from the public open classes to
+  top-level concrete-receiver extensions, preserving legacy subclass ABI.
+- Replaced Jackson mapper-owned output calls with explicit configured-writer
+  generator scopes so fatal serialization failures still close resources.
+- Limited fatal and overflow classification to the primary cause chain and a
+  maximum of 64 links; suppressed failures cannot replace the primary failure.
+- Replaced a Fastjson2 setter fixture that rewrote the fatal cause with a
+  registered JSONB `ObjectReader` fixture that preserves fatal-error identity.
+- Updated all six READMEs with executable fixed-buffer examples, explicit
+  imports, fallback wording, and caller-state guarantees.
+- Added external consumer-package compile tests for the two Jackson extension
+  import combinations.
+
+## Dispositions
+
+- Failed output restores position but may overwrite bytes in the writable range;
+  this remains the documented shared serializer contract.
+- Fastjson2 output remains allocating because its supported JSONB API returns a
+  ByteArray; this slice does not claim a native fixed-buffer output path.
+- The pre-existing Jackson 2 blank-prefix and array-validator behavior in
+  `createTypedJsonMapper` is outside #1037 because this change does not alter the
+  mapper or its AutoType acceptance boundary.
+- Allocation rate and throughput measurements remain assigned to #1039; this
+  slice reports only verified staging-path behavior.
+
+## Verification
+
+- Jackson 2 ByteBuffer suite: 14 passing; external consumer import test: 1
+  passing; complete module: 455 passing.
+- Jackson 3 ByteBuffer suite: 16 passing; external consumer import test: 1
+  passing; complete module: 456 passing.
+- Fastjson2 ByteBuffer suite: 14 passing; complete module: 180 passing.
+- README contract and import parity, production unsafe-pattern scan, extracted
+  source cleanup, and `git diff --check`: passing.
+- Public-symbol inspection confirms that Jackson exposes the concrete reified
+  decoder through `JacksonSerializerKt`, not as a class member, while Fastjson2
+  retains the member on its final class.
+- Root `detekt` is `NO-SOURCE`; complete module compilation and tests provide
+  the available static fallback.
+
+## Evidence
+
+- Fastjson2 resolved-source evidence records version `2.0.62`, source locations,
+  source JAR SHA-256, and the optimized/fallback matrix.
+- Exact-head aggregate and JSON-module ABI reports are generated after the main
+  implementation commit so their producer commit and JAR hashes are auditable.

--- a/docs/superpowers/plans/2026-07-16-issue-754-bytebuffer-serializer-stack-plan.md
+++ b/docs/superpowers/plans/2026-07-16-issue-754-bytebuffer-serializer-stack-plan.md
@@ -24,10 +24,10 @@ PR head after CI and review pass.
 
 | Slice | Branch | Scope | Status |
 |---|---|---|---|
-| 1 | `feat/issue-754-buffer-contract` | API defaults, fixed-buffer contract, ABI fixtures | Merged; preserve through corrective PR |
-| corrective | `fix/issue-754-remove-release-scope` | Remove unauthorized release/settings coupling | Current |
-| 2 | `feat/issue-754-core-serializers` | JDK, Kryo, Fory lower-copy paths | Pending |
-| 3 | `feat/issue-754-json-serializers` | Jackson 2/3 and Fastjson2 | Pending |
+| 1 | `feat/issue-754-buffer-contract` | API defaults, fixed-buffer contract, ABI fixtures | Merged via PR #1031 |
+| corrective | `fix/issue-754-remove-release-scope` | Remove unauthorized release/settings coupling | Merged via PR #1034 |
+| 2 | `feat/issue-754-core-serializers` | JDK, Kryo, Fory lower-copy paths | Merged via PR #1040 |
+| 3 | `feat/issue-754-json-serializers` | Jackson 2/3 and Fastjson2 | Current; base `7459b84cb976a349e1bbc03fefb36d4ca50d02ee` |
 | 4 | `feat/issue-754-avro-serializers` | Reflect, generic, specific/list | Pending |
 | 5 | `feat/issue-754-allocation-proof` | Benchmarks, allocation evidence, docs | Pending |
 
@@ -99,20 +99,171 @@ performance claim boundaries. Repair P0/P1 before PR creation.
 
 ## Slice 3: JSON Serializers
 
-### Task 1: Jackson 2 and Jackson 3
+### Task 1: Jackson 2 RED contract
 
-1. Add RED tests for fixed output, direct/read-only input, overflow, rollback,
-   mapper configuration, polymorphic typing, and wire compatibility.
-2. Connect mapper stream APIs to the fixed ByteBuffer adapters.
-3. Preserve exception types and caller state on all paths.
-4. Run each module's targeted tests and inherited contract proof.
+1. Add `JacksonSerializerByteBufferTest` under
+   `io/jackson2/src/test/kotlin/io/bluetape4k/jackson/`.
+2. Cover heap/direct/sliced/read-only input, non-zero position, reduced limit,
+   order/mark preservation, empty and malformed input, exact-capacity output,
+   read-only target prevalidation, raw overflow, rollback, fatal-error identity,
+   failed-call reuse, mapper configuration, old/new cross-reading, and
+   `serializeTo(null)` returning `0` without changing target position or invoking
+   the mapper.
+3. Prove `serializeTo` and `deserializeFrom` bypass the allocating `ByteArray`
+   methods with throwing/counting overrides.
+4. Prove concrete reified `List<User>` and `Map<String, User>` input retain
+   Jackson `TypeReference` semantics. Also prove a receiver statically typed as
+   `JsonSerializer` retains the existing raw class-based collection behavior and
+   that an invalid target class keeps the established failure wrapper.
+5. Exercise allowed and denied root/nested class identifiers through a typed
+   mapper and preserve the existing allowlist rejection wrapper/cause.
+6. Run the focused test and observe the expected RED failures before production
+   edits.
 
-### Task 2: Fastjson2
+   ```bash
+   ./gradlew :bluetape4k-jackson2:test \
+     --tests "io.bluetape4k.jackson.JacksonSerializerByteBufferTest" \
+     --no-configuration-cache
+   ```
 
-1. Add JSONB compatibility, direct-input, and fallback-output tests.
-2. Use a lower-copy path only if the resolved API demonstrably avoids a full
-   internal array.
-3. Otherwise retain the default and document it as ergonomic only.
+### Task 2: Jackson 2 implementation and inherited formats
+
+1. Override buffer methods in
+   `io/jackson2/src/main/kotlin/io/bluetape4k/jackson/JacksonSerializer.kt` using
+   `ByteBufferOutputStream.fixed(target.duplicate())` and
+   `ByteBufferInputStream(source.duplicate())` with mapper stream APIs.
+2. Add the concrete reified ByteBuffer API as a top-level concrete-receiver extension using
+   `jacksonTypeRef<T>()`; do not add a final JVM method to the open serializer class or a new public `Type`
+   overload to `JsonSerializer`.
+3. Return `0` before mapper work when the graph is null. Classify output
+   failures as raw read-only/overflow, identical fatal `Error`,
+   or the established `JsonSerializationException`; commit target position only
+   after successful completion.
+4. Add old/new cross-reading buffer coverage for YAML, Properties, CSV, TOML,
+   CBOR, Ion, and Smile in
+   `io/jackson2/src/test/kotlin/io/bluetape4k/jackson/JacksonFormatSerializerByteBufferTest.kt`
+   because they inherit the base override.
+5. Run focused ByteBuffer and inherited-format tests, then the full module test.
+
+   ```bash
+   ./gradlew :bluetape4k-jackson2:test \
+     --tests "io.bluetape4k.jackson.JacksonSerializerByteBufferTest" \
+     --tests "io.bluetape4k.jackson.JacksonFormatSerializerByteBufferTest" \
+     --no-configuration-cache
+   ./gradlew :bluetape4k-jackson2:test --no-configuration-cache
+   ```
+
+### Task 3: Jackson 3 RED and implementation
+
+1. Mirror Tasks 1-2 in `io/jackson3`, using Jackson 3 mapper/type-reference APIs.
+2. Add a negative ByteBuffer test proving unsolicited class-id properties do not
+   introduce default typing or instantiate arbitrary subtypes.
+3. Preserve annotation-driven polymorphism, mapper factories, failure policy,
+   caller state, reuse, and all inherited format wire semantics.
+4. Put inherited-format coverage in
+   `io/jackson3/src/test/kotlin/io/bluetape4k/jackson3/JacksonFormatSerializerByteBufferTest.kt`.
+5. Run focused ByteBuffer and inherited-format tests, then the full module test.
+
+   ```bash
+   ./gradlew :bluetape4k-jackson3:test \
+     --tests "io.bluetape4k.jackson3.JacksonSerializerByteBufferTest" \
+     --tests "io.bluetape4k.jackson3.JacksonFormatSerializerByteBufferTest" \
+     --no-configuration-cache
+   ./gradlew :bluetape4k-jackson3:test --no-configuration-cache
+   ```
+
+### Task 4: Fastjson2 capability decision and bounded optimization
+
+1. Extract the resolved Fastjson2 `2.0.62` sources into the required inspection
+   directory and inspect `JSONB.toBytes`, the `JSONReaderJSONB(InputStream)`
+   constructor, and the `byte[]` offset/length `parseObject` overloads:
+
+   ```bash
+   set -euo pipefail
+   sources_jar="$(find "$HOME/.gradle/caches/modules-2/files-2.1/com.alibaba.fastjson2/fastjson2/2.0.62" \
+     -name 'fastjson2-2.0.62-sources.jar' -print -quit)"
+   test -n "$sources_jar"
+   rm -rf .codex/lib-sources/fastjson2-2.0.62
+   mkdir -p .codex/lib-sources/fastjson2-2.0.62
+   unzip -q -o "$sources_jar" -d .codex/lib-sources/fastjson2-2.0.62
+   shasum -a 256 "$sources_jar"
+   rg -n "toBytes\(Object|JSONReaderJSONB\(Context ctx, InputStream|parseObject\(" \
+     .codex/lib-sources/fastjson2-2.0.62/com/alibaba/fastjson2/JSONB.java \
+     .codex/lib-sources/fastjson2-2.0.62/com/alibaba/fastjson2/JSONReaderJSONB.java
+   ```
+
+   Record that JSONB output and stream input allocate or grow internal arrays,
+   while the `byte[]` offset/length parser aliases an existing heap array. Store
+   the resolved sources-JAR SHA-256, exact matched source locations, conclusions,
+   and optimized/fallback matrix in
+   `docs/evidence/issue-754/json/fastjson2-2.0.62-capability.md`. Remove the
+   extracted inspection directory before preparing the PR; the evidence document
+   is the durable review artifact.
+2. Add `FastjsonSerializerByteBufferTest` covering JSONB old/new cross-reading,
+   heap/direct/sliced/read-only input, caller state, concrete reified
+   `List<User>` and `Map<String, User>`, interface-typed raw collections, invalid
+   target classes, malformed/fatal failures, retry, output overflow/rollback,
+   `serializeTo(null)` returning `0` without changing target position, and a
+   negative type-metadata/AutoType case.
+3. Override class-token `deserializeFrom` and add the concrete reified
+   `deserialize(ByteBuffer)` overload. For writable array-backed input, pass the
+   backing array, `arrayOffset() + position()`, remaining length, and respectively
+   `clazz` or `reference<T>().type` to JSONB. For direct/read-only input, copy the
+   duplicate's remaining range and call the same class/type-token parser.
+4. Override `serializeTo` as an explicitly allocating compatibility path using
+   `JSONB.toBytes`, capacity validation, a duplicate target, and commit-on-success;
+   return `0` before JSONB work for null input and do not describe it as
+   lower-copy.
+5. In class-token, reified, and output buffer paths, catch in this order: rethrow
+   the identical fatal `Error`; expose raw `ReadOnlyBufferException` and
+   `BufferOverflowException`; wrap other failures in the existing
+   `JsonSerializationException` message/cause contract; restore output position
+   on every failure. Preserve the feature-free reader context and do not enable
+   AutoType.
+6. Run the focused test, then the full Fastjson2 module test.
+
+   ```bash
+   ./gradlew :bluetape4k-fastjson2:test \
+     --tests "io.bluetape4k.fastjson2.FastjsonSerializerByteBufferTest" \
+     --no-configuration-cache
+   ./gradlew :bluetape4k-fastjson2:test --no-configuration-cache
+   ```
+
+### Task 5: Slice documentation and inherited proof
+
+1. Update the class and buffer-overload KDoc in
+   `io/jackson2/src/main/kotlin/io/bluetape4k/jackson/JacksonSerializer.kt`,
+   `io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/JacksonSerializer.kt`, and
+   `io/fastjson2/src/main/kotlin/io/bluetape4k/fastjson2/FastjsonSerializer.kt`.
+2. Update `io/jackson2/README.md`, `io/jackson2/README.ko.md`,
+   `io/jackson3/README.md`, `io/jackson3/README.ko.md`,
+   `io/fastjson2/README.md`, and `io/fastjson2/README.ko.md` with buffer state
+   rules, optimized/fallback cells, the allocation-claim exclusion, a Kotlin
+   concrete `deserialize<List<User>>(buffer)` example, a Java
+   `deserializeFrom(buffer, User.class)` example, and the interface receiver's
+   raw-generic limitation.
+3. Run `git diff --check` and verify every language variant contains the
+   required contract and examples with:
+
+   ```bash
+   set -euo pipefail
+   for readme in \
+     io/jackson2/README.md io/jackson2/README.ko.md \
+     io/jackson3/README.md io/jackson3/README.ko.md \
+     io/fastjson2/README.md io/fastjson2/README.ko.md
+   do
+     rg -q "ByteBuffer" "$readme"
+     rg -q "optimized|optimization|최적화" "$readme"
+     rg -q "fallback|compatibility|호환" "$readme"
+     rg -q "allocation|할당" "$readme"
+     rg -q "JsonSerializer" "$readme"
+     rg -q 'deserialize<List<User>>\(buffer\)' "$readme"
+     rg -q 'deserialize<Map<String, User>>\(buffer\)' "$readme"
+     rg -q 'deserializeFrom\(buffer, User\.class\)' "$readme"
+   done
+   ```
+
+4. Run all three module tests and the inherited ABI script.
 
 ### Slice 3 gate
 

--- a/docs/superpowers/specs/2026-07-16-issue-754-bytebuffer-serializer-stack-design.md
+++ b/docs/superpowers/specs/2026-07-16-issue-754-bytebuffer-serializer-stack-design.md
@@ -85,6 +85,20 @@ Java input methods use `deserializeFrom` to avoid making existing null-literal
 calls ambiguous. Existing Kotlin `deserialize(ByteBuffer)` extensions delegate
 to the new polymorphic member.
 
+Concrete JSON serializers that already expose reified `ByteArray` overloads
+retain equivalent parameterized-type behavior for `ByteBuffer` input. In
+particular, `List<T>` and `Map<K, V>` calls must continue to use the backend's
+type-token mechanism instead of erasing the request to the raw JVM class.
+
+That parameterized behavior is available when the receiver retains its concrete
+Jackson or Fastjson serializer type, matching the existing backend-specific
+reified `ByteArray` overloads. A receiver statically typed as `JsonSerializer`
+continues to expose the class-based interface contract: Kotlin's interface
+extension and Java's `deserializeFrom(source, clazz)` cannot represent nested
+generic arguments and therefore return backend raw collection shapes for raw
+`List` or `Map` requests. Slice 3 does not add a new public `Type` API. Callers
+that need typed nested collections must retain the concrete serializer type.
+
 Avro serializers add corresponding methods for reflect, generic-record,
 specific-record, and specific-record list operations. They retain the existing
 Object Container File/DataFile wire format.
@@ -111,10 +125,21 @@ not an allocation claim.
 
 - Jackson 2 and Jackson 3 can use stream-shaped mapper APIs backed by the fixed
   ByteBuffer adapters.
-- Fastjson2 JSONB remains on the compatibility fallback unless measurement shows
-  that the resolved implementation avoids a full internal array.
-- Mapper configuration, polymorphic typing, filters, and wire bytes remain
-  authoritative.
+- The Jackson overrides live in the open base serializers and therefore apply
+  to their YAML, Properties, CSV, TOML, CBOR, Ion, and Smile subclasses. The
+  configured mapper factory remains authoritative, and every inherited format
+  must preserve old/new cross-reading compatibility.
+- Jackson 2 retains its configured allowlisted default-typing behavior. Jackson
+  3 must not gain default typing; annotation-driven polymorphism and its current
+  safe defaults remain unchanged.
+- Resolved Fastjson2 `2.0.62` JSONB output and stream input stage through an
+  internal `byte[]`, so caller-owned output, direct input, and read-only input
+  retain the compatibility fallback. An array-backed heap input may use the
+  `byte[]` offset/length parser only when it directly aliases the caller's
+  remaining range and preserves caller state.
+- Fastjson2 must not enable AutoType, class loading, or a broader reader context.
+- Mapper configuration, polymorphic typing, filters, exception policy, and wire
+  bytes remain authoritative.
 
 ### 4.4 Avro serializers
 
@@ -136,6 +161,10 @@ metadata is nondeterministic.
 - A failed call must not poison the next call or retain caller buffers.
 - No optimized path may weaken JDK filtering, Kryo/Fory registration, Jackson
   typing, Fastjson2 JSONB semantics, or Avro schema/codec handling.
+- JSON buffer paths expose raw `ReadOnlyBufferException` and
+  `BufferOverflowException`, preserve the identity of fatal `Error` instances,
+  restore the caller position on failure, and retain each backend's established
+  `JsonSerializationException` message/cause policy for ordinary failures.
 
 ## 6. Evidence
 
@@ -153,6 +182,16 @@ metadata is nondeterministic.
 Each backend PR reruns inherited contract tests and adds wire/security/resource
 tests for its own optimized path. A backend that cannot safely optimize keeps
 the default and records that limitation.
+
+The JSON slice additionally proves that Jackson does not delegate buffer calls
+through its allocating `ByteArray` methods, covers every mapper-backed Jackson
+format affected by the base override, and records the resolved Fastjson2 source
+evidence for optimized versus fallback cells. Backend KDoc and English/Korean
+README pairs describe those cells without making allocation-improvement claims.
+The concrete Jackson reified ByteBuffer API remains a top-level extension so the open serializer classes do not
+gain a final JVM method that can conflict with a legacy subclass signature. The caller matrix covers concrete reified `List<Model>` and
+`Map<String, Model>`, interface-typed raw collection calls, invalid target
+classes, and the documented Kotlin/Java migration boundary.
 
 ### Allocation slice
 
@@ -186,6 +225,8 @@ outside this design and follow their own workflows and authority gates.
 - Position, limit, order, mark, overflow, and failure contracts are tested.
 - Lower-copy claims are made only for measured backend overrides.
 - Wire, security, registration, and resource-lifecycle behavior is preserved.
+- Parameterized JSON types retain the concrete serializers' existing reified
+  behavior, and mapper-backed Jackson subformats retain their wire semantics.
 - Allocation evidence reports allocation/GC metrics rather than throughput alone.
 - English/Korean docs explain optimized versus fallback behavior.
 - No issue-specific release, credential, settings, tag, or publication machinery

--- a/io/fastjson2/README.ko.md
+++ b/io/fastjson2/README.ko.md
@@ -50,7 +50,50 @@ try {
 
 - `serialize(null)`은 빈 `ByteArray`, `serializeAsString(null)`은 빈 문자열을 반환합니다.
 - `deserialize(null)` / `deserializeFromString(null)`은 `null`을 반환합니다.
-- 그 외 직렬화/역직렬화 실패는 `JsonSerializationException` 예외를 던집니다.
+- 일반적인 backend 직렬화/역직렬화 실패는 `JsonSerializationException` 예외를 던집니다.
+
+#### ByteBuffer 계약
+
+writable array-backed heap buffer와 slice의 `deserializeFrom`은 backing array, offset, remaining length를
+JSONB에 직접 전달하도록 최적화되어 있습니다. direct 및 read-only 입력은 bounded-copy 호환 fallback을
+사용합니다. 모든 입력 경로는 position, limit, mark, byte order를 보존합니다. feature-free reader를
+사용하며 AutoType을 활성화하지 않습니다.
+신뢰할 수 없는 입력은 호출 전에 limit를 설정해 범위를 제한해야 하며 serializer는 remaining 범위 밖을 읽지 않습니다.
+
+`serializeTo`는 할당이 있는 호환 fallback입니다. Fastjson2 2.0.62의 공개 출력 API가
+`JSONB.toBytes`이므로 결과를 caller target으로 복사합니다. 출력 position은 성공 시에만 반영되고
+read-only/overflow 실패는 raw buffer 예외로 유지됩니다. 이 API는 lower-copy 출력이라고 주장하지 않습니다.
+치명적인 `Error` 인스턴스는 wrapping하지 않고 동일 identity를 유지합니다.
+
+```kotlin
+import io.bluetape4k.fastjson2.FastjsonSerializer
+import io.bluetape4k.json.JsonSerializer
+import io.bluetape4k.json.deserialize
+import java.nio.ByteBuffer
+
+run {
+    val buffer = ByteBuffer.allocate(4096)
+    serializer.serializeTo(users, buffer)
+    buffer.flip()
+    val restored = serializer.deserialize<List<User>>(buffer)
+}
+run {
+    val buffer = ByteBuffer.wrap(serializer.serialize(usersByName))
+    val restored = serializer.deserialize<Map<String, User>>(buffer)
+}
+
+val contract: JsonSerializer = serializer
+val buffer = ByteBuffer.wrap(serializer.serialize(users))
+val rawUsers: List<*>? = contract.deserialize<List<User>>(buffer)
+```
+
+concrete overload는 generic `Type` 정보를 유지합니다. 정적 타입이 `JsonSerializer`인 receiver는 기존
+class-token 호환 동작을 유지하므로 collection element가 raw map으로 남습니다.
+
+```java
+ByteBuffer buffer = ByteBuffer.wrap(bytes);
+User restored = serializer.deserializeFrom(buffer, User.class);
+```
 
 ### 2. JSON 문자열 확장 함수
 

--- a/io/fastjson2/README.md
+++ b/io/fastjson2/README.md
@@ -50,7 +50,51 @@ try {
 
 - `serialize(null)` returns an empty `ByteArray`; `serializeAsString(null)` returns an empty string.
 - `deserialize(null)` / `deserializeFromString(null)` returns `null`.
-- All other serialization/deserialization failures throw `JsonSerializationException`.
+- Ordinary backend serialization/deserialization failures throw `JsonSerializationException`.
+
+#### ByteBuffer contract
+
+For writable array-backed heap buffers and slices, `deserializeFrom` is optimized to pass the backing array,
+offset, and remaining length directly to JSONB. Direct and read-only input use a bounded-copy compatibility
+fallback. All input paths preserve position, limit, mark, and byte order. Feature-free readers are used and
+AutoType is not enabled.
+Set a bounded limit before passing untrusted input; the serializer cannot read outside the remaining range.
+
+`serializeTo` is an allocating compatibility fallback: Fastjson2 2.0.62 exposes output through
+`JSONB.toBytes`, so the result is copied into the caller target. Output position is committed only on success;
+read-only and overflow failures remain raw buffer exceptions. The output allocation remains, and this API makes
+no lower-copy output claim.
+Fatal `Error` instances retain their identity instead of being wrapped.
+
+```kotlin
+import io.bluetape4k.fastjson2.FastjsonSerializer
+import io.bluetape4k.json.JsonSerializer
+import io.bluetape4k.json.deserialize
+import java.nio.ByteBuffer
+
+run {
+    val buffer = ByteBuffer.allocate(4096)
+    serializer.serializeTo(users, buffer)
+    buffer.flip()
+    val restored = serializer.deserialize<List<User>>(buffer)
+}
+run {
+    val buffer = ByteBuffer.wrap(serializer.serialize(usersByName))
+    val restored = serializer.deserialize<Map<String, User>>(buffer)
+}
+
+val contract: JsonSerializer = serializer
+val buffer = ByteBuffer.wrap(serializer.serialize(users))
+val rawUsers: List<*>? = contract.deserialize<List<User>>(buffer)
+```
+
+The concrete overload retains generic `Type` information. A receiver statically typed as `JsonSerializer`
+keeps the compatibility class-token behavior, so collection elements remain raw maps.
+
+```java
+ByteBuffer buffer = ByteBuffer.wrap(bytes);
+User restored = serializer.deserializeFrom(buffer, User.class);
+```
 
 ### 2. JSON String Extension Functions
 

--- a/io/fastjson2/src/main/kotlin/io/bluetape4k/fastjson2/FastjsonSerializer.kt
+++ b/io/fastjson2/src/main/kotlin/io/bluetape4k/fastjson2/FastjsonSerializer.kt
@@ -9,6 +9,9 @@ import io.bluetape4k.json.JsonSerializer
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.emptyByteArray
 import io.bluetape4k.support.isNullOrEmpty
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+import java.nio.ReadOnlyBufferException
 
 /**
  * Fastjson2 기반으로 JSON 문자열/JSONB 바이트 직렬화를 제공하는 [JsonSerializer] 구현체입니다.
@@ -18,6 +21,10 @@ import io.bluetape4k.support.isNullOrEmpty
  * - `serialize(null)`은 빈 바이트 배열을, `serializeAsString(null)`은 빈 문자열을 반환합니다.
  * - 역직렬화 입력이 `null`이면 `null`을 반환합니다.
  * - fastjson2 처리 실패는 [JsonSerializationException]으로 감싸서 던집니다.
+ * - Writable array-backed [ByteBuffer] input is parsed from its backing-array range without an intermediate copy.
+ *   Direct and read-only input use a bounded compatibility copy because Fastjson2 has no public zero-copy buffer API.
+ * - [serializeTo] remains an allocating compatibility path because `JSONB.toBytes` owns its output array.
+ * - Buffer parsing uses feature-free JSONB readers and never enables AutoType.
  *
  * ```kotlin
  * val serializer = FastjsonSerializer()
@@ -71,6 +78,34 @@ class FastjsonSerializer: JsonSerializer {
     }
 
     /**
+     * Serializes through `JSONB.toBytes` and copies the result into [target].
+     * This compatibility path commits the target position only on success and does not claim allocation reduction.
+     */
+    override fun serializeTo(graph: Any?, target: ByteBuffer): Int {
+        if (target.isReadOnly) throw ReadOnlyBufferException()
+        if (graph == null) return 0
+
+        val start = target.position()
+        val view = target.duplicate()
+        return try {
+            val bytes = JSONB.toBytes(graph)
+            if (bytes.size > view.remaining()) throw BufferOverflowException()
+            view.put(bytes)
+            target.position(start + bytes.size)
+            bytes.size
+        } catch (e: Error) {
+            target.position(start)
+            throw e
+        } catch (e: BufferOverflowException) {
+            target.position(start)
+            throw e
+        } catch (e: Throwable) {
+            target.position(start)
+            throw fastjsonWriteFailure(e, graph)
+        }
+    }
+
+    /**
      * JSONB 바이트 배열을 지정 클래스 타입으로 역직렬화합니다.
      *
      * ## 동작/계약
@@ -95,6 +130,32 @@ class FastjsonSerializer: JsonSerializer {
         return try {
             JSONB.parseObject(bytes, clazz)
         } catch (e: Throwable) {
+            throw JsonSerializationException("Fail to deserialize by Fastjson2. targetType=${clazz.name}", e)
+        }
+    }
+
+    /**
+     * Parses an array-backed remaining range in place; direct and read-only sources use a bounded copy.
+     * Caller position, limit, mark, and byte order remain unchanged.
+     */
+    override fun <T: Any> deserializeFrom(source: ByteBuffer, clazz: Class<T>): T? {
+        if (!source.hasRemaining()) return null
+        return try {
+            if (source.hasArray()) {
+                JSONB.parseObject(
+                    source.array(),
+                    source.arrayOffset() + source.position(),
+                    source.remaining(),
+                    clazz,
+                )
+            } else {
+                val bytes = ByteArray(source.remaining()).also { source.duplicate().get(it) }
+                JSONB.parseObject(bytes, clazz)
+            }
+        } catch (e: Error) {
+            throw e
+        } catch (e: Throwable) {
+            findCauseError(e)?.let { throw it }
             throw JsonSerializationException("Fail to deserialize by Fastjson2. targetType=${clazz.name}", e)
         }
     }
@@ -190,6 +251,47 @@ class FastjsonSerializer: JsonSerializer {
         }
 
     /**
+     * Parses the remaining JSONB range while retaining reified parameterized type information.
+     */
+    inline fun <reified T: Any> deserialize(source: ByteBuffer): T? {
+        if (!source.hasRemaining()) return null
+        return try {
+            val clazz = T::class.java
+            if (source.hasArray()) {
+                val bytes = source.array()
+                val offset = source.arrayOffset() + source.position()
+                val length = source.remaining()
+                if (clazz.typeParameters.isEmpty()) {
+                    JSONB.parseObject(bytes, offset, length, clazz)
+                } else {
+                    JSONB.parseObject(bytes, offset, length, reference<T>().type)
+                }
+            } else {
+                val bytes = ByteArray(source.remaining()).also { source.duplicate().get(it) }
+                if (clazz.typeParameters.isEmpty()) {
+                    JSONB.parseObject(bytes, clazz)
+                } else {
+                    JSONB.parseObject(bytes, reference<T>().type)
+                }
+            }
+        } catch (e: Error) {
+            throw e
+        } catch (e: Throwable) {
+            var current: Throwable? = e
+            var depth = 0
+            while (current != null && depth < 64) {
+                if (current is Error) throw current
+                current = current.cause
+                depth++
+            }
+            throw JsonSerializationException(
+                "Fail to deserialize by Fastjson2. targetType=${T::class.java.name}",
+                e
+            )
+        }
+    }
+
+    /**
      * JSON 문자열을 reified 타입 [T]로 역직렬화합니다.
      *
      * ## 동작/계약
@@ -221,4 +323,35 @@ class FastjsonSerializer: JsonSerializer {
                 )
             }
         }
+}
+
+private fun fastjsonWriteFailure(failure: Throwable, graph: Any): Throwable {
+    findCauseFailure(failure)?.let { return it }
+    return JsonSerializationException("Fail to serialize by Fastjson2. graphType=${graph.javaClass.name}", failure)
+}
+
+private fun findCauseFailure(root: Throwable): Throwable? {
+    var current: Throwable? = root
+    var depth = 0
+    while (current != null && depth < 64) {
+        when (current) {
+            is Error -> return current
+            is BufferOverflowException ->
+                return if (current === root) current else BufferOverflowException().apply { initCause(root) }
+        }
+        current = current.cause
+        depth++
+    }
+    return null
+}
+
+private fun findCauseError(root: Throwable): Error? {
+    var current: Throwable? = root
+    var depth = 0
+    while (current != null && depth < 64) {
+        if (current is Error) return current
+        current = current.cause
+        depth++
+    }
+    return null
 }

--- a/io/fastjson2/src/test/kotlin/io/bluetape4k/fastjson2/FastjsonSerializerByteBufferTest.kt
+++ b/io/fastjson2/src/test/kotlin/io/bluetape4k/fastjson2/FastjsonSerializerByteBufferTest.kt
@@ -1,0 +1,333 @@
+package io.bluetape4k.fastjson2
+
+import com.alibaba.fastjson2.JSONB
+import com.alibaba.fastjson2.JSONFactory
+import com.alibaba.fastjson2.JSONReader
+import com.alibaba.fastjson2.JSONWriter
+import com.alibaba.fastjson2.reader.ObjectReader
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.fastjson2.model.User
+import io.bluetape4k.json.JsonSerializationException
+import io.bluetape4k.json.JsonSerializer
+import io.bluetape4k.json.deserialize
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Type
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.ReadOnlyBufferException
+
+class FastjsonSerializerByteBufferTest {
+
+    @Test
+    fun `concrete ByteBuffer overload preserves parameterized collection types`() {
+        val serializer = FastjsonSerializer()
+        val users = listOf(User(1, "alpha"), User(2, "beta"))
+        val usersByName = users.associateBy { it.name }
+
+        serializer.deserialize<List<User>>(ByteBuffer.wrap(serializer.serialize(users))) shouldBeEqualTo users
+        serializer.deserialize<Map<String, User>>(ByteBuffer.wrap(serializer.serialize(usersByName))) shouldBeEqualTo usersByName
+    }
+
+    @Test
+    fun `old and new JSONB paths cross read`() {
+        val serializer = FastjsonSerializer()
+        val expected = User(7, "cross-read")
+        val target = ByteBuffer.allocate(256)
+
+        val written = serializer.serializeTo(expected, target)
+        val newWire = target.writtenBytes(0, written)
+        serializer.deserialize(newWire, User::class.java) shouldBeEqualTo expected
+        serializer.deserializeFrom(ByteBuffer.wrap(serializer.serialize(expected)), User::class.java) shouldBeEqualTo expected
+    }
+
+    @Test
+    fun `heap direct sliced and read-only sources preserve caller state`() {
+        val serializer = FastjsonSerializer()
+        val expected = User(8, "stateful")
+        val wire = serializer.serialize(expected)
+
+        sourceVariants(wire).forEach { source ->
+            val position = source.position()
+            val limit = source.limit()
+            val order = source.order()
+            source.mark()
+
+            serializer.deserializeFrom(source, User::class.java) shouldBeEqualTo expected
+            source.position() shouldBeEqualTo position
+            source.limit() shouldBeEqualTo limit
+            source.order() shouldBeEqualTo order
+            source.reset()
+            source.position() shouldBeEqualTo position
+        }
+    }
+
+    @Test
+    fun `bounded compatibility output commits exact JSONB range`() {
+        val serializer = FastjsonSerializer()
+        val expected = User(9, "bounded")
+        val wire = serializer.serialize(expected)
+        val target = ByteBuffer.allocate(wire.size + 6).order(ByteOrder.LITTLE_ENDIAN)
+        target.position(3)
+        target.limit(3 + wire.size)
+
+        serializer.serializeTo(expected, target) shouldBeEqualTo wire.size
+        target.position() shouldBeEqualTo 3 + wire.size
+        target.limit() shouldBeEqualTo 3 + wire.size
+        target.order() shouldBeEqualTo ByteOrder.LITTLE_ENDIAN
+        target.writtenBytes(3, wire.size).contentEquals(wire).shouldBeTrue()
+    }
+
+    @Test
+    fun `read-only target rejects null and null output is otherwise a no-op`() {
+        val serializer = FastjsonSerializer()
+        val readOnly = ByteBuffer.allocate(8).asReadOnlyBuffer()
+        assertFailsWith<ReadOnlyBufferException> {
+            serializer.serializeTo(null, readOnly)
+        }
+
+        val target = ByteBuffer.allocate(8)
+        target.position(4)
+        serializer.serializeTo(null, target) shouldBeEqualTo 0
+        target.position() shouldBeEqualTo 4
+    }
+
+    @Test
+    fun `overflow rolls back and target is reusable`() {
+        val serializer = FastjsonSerializer()
+        val expected = User(10, "retry")
+        val wire = serializer.serialize(expected)
+        val target = ByteBuffer.allocate(wire.size + 2)
+        target.position(2)
+        target.limit(target.capacity() - 1)
+
+        assertFailsWith<BufferOverflowException> {
+            serializer.serializeTo(expected, target)
+        }
+        target.position() shouldBeEqualTo 2
+
+        target.limit(target.capacity())
+        serializer.serializeTo(expected, target) shouldBeEqualTo wire.size
+    }
+
+    @Test
+    fun `malformed and empty input preserve state and serializer remains reusable`() {
+        val serializer = FastjsonSerializer()
+        val malformed = ByteBuffer.wrap(byteArrayOf(0x7F, 0x00, 0x01)).order(ByteOrder.LITTLE_ENDIAN)
+        malformed.mark()
+
+        assertFailsWith<JsonSerializationException> {
+            serializer.deserializeFrom(malformed, User::class.java)
+        }
+        malformed.position() shouldBeEqualTo 0
+        malformed.limit() shouldBeEqualTo 3
+        malformed.order() shouldBeEqualTo ByteOrder.LITTLE_ENDIAN
+        malformed.reset()
+        serializer.deserializeFrom(ByteBuffer.allocate(0), User::class.java).shouldBeNull()
+
+        val expected = User(11, "reused")
+        serializer.deserializeFrom(ByteBuffer.wrap(serializer.serialize(expected)), User::class.java) shouldBeEqualTo expected
+    }
+
+    @Test
+    fun `fatal serialization error keeps identity and output position`() {
+        val serializer = FastjsonSerializer()
+        val fatal = SerializerFatalError()
+        val target = ByteBuffer.allocate(64)
+        target.position(5)
+
+        val thrown = assertFailsWith<SerializerFatalError> {
+            serializer.serializeTo(FatalGraph(fatal), target)
+        }
+
+        (thrown === fatal).shouldBeTrue()
+        target.position() shouldBeEqualTo 5
+    }
+
+    @Test
+    fun `fatal deserialization error keeps identity for class token and reified paths`() {
+        val serializer = FastjsonSerializer()
+        val fatal = SerializerFatalError()
+        val payload = serializer.serialize(emptyMap<String, String>())
+        val provider = JSONFactory.getDefaultObjectReaderProvider()
+        val reader = throwingObjectReader<FatalReadGraph>(IllegalStateException("wrapper", fatal))
+        val previous = provider.register(FatalReadGraph::class.java, reader)
+
+        try {
+            val classTokenFailure = assertFailsWith<SerializerFatalError> {
+                serializer.deserializeFrom(ByteBuffer.wrap(payload), FatalReadGraph::class.java)
+            }
+            (classTokenFailure === fatal).shouldBeTrue()
+
+            val reifiedFailure = assertFailsWith<SerializerFatalError> {
+                serializer.deserialize<FatalReadGraph>(ByteBuffer.wrap(payload))
+            }
+            (reifiedFailure === fatal).shouldBeTrue()
+        } finally {
+            if (previous == null) {
+                provider.unregisterObjectReader(FatalReadGraph::class.java)
+            } else {
+                provider.register(FatalReadGraph::class.java, previous)
+            }
+        }
+    }
+
+    @Test
+    fun `suppressed fatal error does not replace the primary deserialization failure`() {
+        val serializer = FastjsonSerializer()
+        val fatal = SerializerFatalError()
+        val primary = IllegalStateException("primary").apply { addSuppressed(fatal) }
+        val payload = serializer.serialize(emptyMap<String, String>())
+        val provider = JSONFactory.getDefaultObjectReaderProvider()
+        val reader = throwingObjectReader<SuppressedFailureReadGraph>(primary)
+        val previous = provider.register(SuppressedFailureReadGraph::class.java, reader)
+
+        try {
+            val classTokenFailure = assertFailsWith<JsonSerializationException> {
+                serializer.deserializeFrom(ByteBuffer.wrap(payload), SuppressedFailureReadGraph::class.java)
+            }
+            (classTokenFailure.cause === primary).shouldBeTrue()
+
+            val reifiedFailure = assertFailsWith<JsonSerializationException> {
+                serializer.deserialize<SuppressedFailureReadGraph>(ByteBuffer.wrap(payload))
+            }
+            (reifiedFailure.cause === primary).shouldBeTrue()
+        } finally {
+            if (previous == null) {
+                provider.unregisterObjectReader(SuppressedFailureReadGraph::class.java)
+            } else {
+                provider.register(SuppressedFailureReadGraph::class.java, previous)
+            }
+        }
+    }
+
+    @Test
+    fun `suppressed overflow does not replace the primary serialization failure`() {
+        val serializer = FastjsonSerializer()
+        val primary = IllegalStateException("primary").apply {
+            addSuppressed(BufferOverflowException())
+        }
+        val target = ByteBuffer.allocate(64)
+        target.position(4)
+
+        assertFailsWith<JsonSerializationException> {
+            serializer.serializeTo(FailureGraph(primary), target)
+        }
+        target.position() shouldBeEqualTo 4
+    }
+
+    @Test
+    fun `interface receiver stays raw and invalid class is wrapped`() {
+        val concrete = FastjsonSerializer()
+        val serializer: JsonSerializer = concrete
+        val users = listOf(User(1, "raw"))
+
+        val restored: Any? = serializer.deserialize<List<User>>(ByteBuffer.wrap(concrete.serialize(users)))
+        (restored as List<*>).first().shouldBeInstanceOf<Map<*, *>>()
+
+        assertFailsWith<JsonSerializationException> {
+            serializer.deserialize(ByteBuffer.wrap(concrete.serialize(users)), User::class.java)
+        }
+    }
+
+    @Test
+    fun `type metadata stays data without AutoType`() {
+        val serializer = FastjsonSerializer()
+        val metadata = mapOf("@type" to "java.lang.ProcessBuilder", "value" to "blocked")
+        val restored = serializer.deserializeFrom(ByteBuffer.wrap(serializer.serialize(metadata)), Any::class.java)
+
+        restored.shouldBeInstanceOf<Map<*, *>>()["@type"] shouldBeEqualTo "java.lang.ProcessBuilder"
+    }
+
+    @Test
+    fun `JSONB typed any metadata stays data without AutoType`() {
+        val serializer = FastjsonSerializer()
+        val payload = JSONB.toBytes(AutoTypePayload("blocked"), JSONWriter.Feature.WriteClassName)
+        val heap = ByteBuffer.wrap(payload)
+        val direct = ByteBuffer.allocateDirect(payload.size).apply {
+            put(payload)
+            flip()
+        }
+
+        listOf(heap, direct).forEach { source ->
+            serializer.deserializeFrom(source, Any::class.java)
+                .shouldBeInstanceOf<Map<*, *>>()["value"] shouldBeEqualTo "blocked"
+            serializer.deserialize<Any>(source)
+                .shouldBeInstanceOf<Map<*, *>>()["value"] shouldBeEqualTo "blocked"
+        }
+    }
+}
+
+private data class AutoTypePayload(
+    val value: String,
+)
+
+private class FatalGraph(private val failure: Error) {
+    val value: String
+        get() = throw failure
+}
+
+private class FailureGraph(private val failure: RuntimeException) {
+    val value: String
+        get() = throw failure
+}
+
+private class SerializerFatalError: Error()
+
+private class FatalReadGraph
+
+private class SuppressedFailureReadGraph
+
+private fun <T: Any> throwingObjectReader(failure: Throwable): ObjectReader<T> = object: ObjectReader<T> {
+    override fun readObject(
+        jsonReader: JSONReader,
+        fieldType: Type?,
+        fieldName: Any?,
+        features: Long,
+    ): T = throw failure
+
+    override fun readJSONBObject(
+        jsonReader: JSONReader,
+        fieldType: Type?,
+        fieldName: Any?,
+        features: Long,
+    ): T = throw failure
+}
+
+private fun sourceVariants(bytes: ByteArray): List<ByteBuffer> {
+    fun filled(buffer: ByteBuffer): ByteBuffer = buffer.apply {
+        position(2)
+        put(bytes)
+        limit(2 + bytes.size)
+        position(2)
+        order(ByteOrder.LITTLE_ENDIAN)
+    }
+
+    val heap = filled(ByteBuffer.allocate(bytes.size + 4))
+    val direct = filled(ByteBuffer.allocateDirect(bytes.size + 4))
+    val parent = ByteBuffer.allocate(bytes.size + 8).apply {
+        position(3)
+        put(bytes)
+        limit(3 + bytes.size)
+        position(3)
+    }
+    val sliced = parent.slice().apply {
+        limit(bytes.size)
+        order(ByteOrder.LITTLE_ENDIAN)
+    }
+    val readOnly = filled(ByteBuffer.allocate(bytes.size + 4)).asReadOnlyBuffer().order(ByteOrder.LITTLE_ENDIAN)
+    return listOf(heap, direct, sliced, readOnly)
+}
+
+private fun ByteBuffer.writtenBytes(start: Int, size: Int): ByteArray =
+    ByteArray(size).also { bytes ->
+        duplicate().apply {
+            position(start)
+            limit(start + size)
+            get(bytes)
+        }
+    }

--- a/io/jackson2/README.ko.md
+++ b/io/jackson2/README.ko.md
@@ -110,7 +110,51 @@ try {
 
 - `serialize(null)`은 빈 `ByteArray`를 반환합니다.
 - `deserialize(null)` / `deserializeFromString(null)`은 `null`을 반환합니다.
-- 그 외 직렬화/역직렬화 실패는 `JsonSerializationException` 예외를 던집니다.
+- 일반적인 backend 직렬화/역직렬화 실패는 `JsonSerializationException` 예외를 던집니다.
+
+#### ByteBuffer 계약
+
+`serializeTo`는 설정된 mapper의 stream API로 caller-owned buffer에 직접 쓰고, `deserializeFrom`은
+duplicate view를 읽습니다. 이 Jackson 전용 override는 호환 `serialize(): ByteArray`와
+`deserialize(ByteArray)` 메서드를 우회합니다. optimized dispatch cell이라는 의미만 가지며, 측정 전에는
+할당 개선을 주장하지 않습니다. heap, direct, slice, read-only 입력을 지원하며 입력 상태를 보존합니다. 출력 position은 성공
+시에만 이동하고, read-only target과 용량 부족은 각각 raw `ReadOnlyBufferException`,
+`BufferOverflowException`을 노출합니다. 실패한 출력 호출은 원래 position으로 rollback하지만 이미 기록된
+바이트는 불특정 상태이므로 주변 프로토콜이 요구하면 재시도 전에 지우거나 덮어써야 합니다.
+치명적인 `Error` 인스턴스는 wrapping하지 않고 동일 identity를 유지합니다.
+신뢰할 수 없는 입력은 호출 전에 limit를 설정해 범위를 제한해야 하며 serializer는 remaining 범위 밖을 읽지 않습니다.
+
+```kotlin
+import io.bluetape4k.jackson.*
+import io.bluetape4k.json.JsonSerializer
+import io.bluetape4k.json.deserialize as deserializeRaw
+import java.nio.ByteBuffer
+
+run {
+    val buffer = ByteBuffer.allocate(4096)
+    serializer.serializeTo(users, buffer)
+    buffer.flip()
+    val restored = serializer.deserialize<List<User>>(buffer)
+}
+run {
+    val buffer = ByteBuffer.wrap(serializer.serialize(usersByName))
+    val restored = serializer.deserialize<Map<String, User>>(buffer)
+}
+
+val contract: JsonSerializer = serializer
+val buffer = ByteBuffer.wrap(serializer.serialize(users))
+val rawUsers: List<*>? = contract.deserializeRaw<List<User>>(buffer)
+```
+
+concrete `JacksonSerializer` extension은 generic `TypeReference` 정보를 유지합니다. 정적 타입이
+`JsonSerializer`인 receiver는 기존 class-token 호환 fallback 계약을 사용하므로 collection element가
+raw map으로 남습니다. YAML, Properties, CSV, TOML, CBOR, Ion, Smile도 같은 buffer override를 상속합니다.
+Jackson 내부 전체에 대한 zero-allocation 주장은 하지 않습니다.
+
+```java
+ByteBuffer buffer = ByteBuffer.wrap(bytes);
+User restored = serializer.deserializeFrom(buffer, User.class);
+```
 
 ### 3. ObjectMapper 확장 함수
 

--- a/io/jackson2/README.md
+++ b/io/jackson2/README.md
@@ -59,7 +59,52 @@ Implements the `JsonSerializer` interface backed by Jackson's `ObjectMapper`.
 
 - `serialize(null)` returns an empty `ByteArray`.
 - `deserialize(null)` / `deserializeFromString(null)` returns `null`.
-- All other serialization / deserialization failures throw `JsonSerializationException`.
+- Ordinary backend serialization / deserialization failures throw `JsonSerializationException`.
+
+#### ByteBuffer contract
+
+`serializeTo` streams through the configured mapper into the caller-owned buffer, and `deserializeFrom`
+reads a duplicate view. These Jackson-specific overrides bypass the compatibility `serialize(): ByteArray`
+and `deserialize(ByteArray)` methods. They are optimized dispatch cells only; allocation improvement remains
+unclaimed until it is measured.
+Heap, direct, sliced, and read-only input are supported. Input state is preserved; output position advances
+only on success. A read-only target and insufficient capacity expose raw `ReadOnlyBufferException` and
+`BufferOverflowException`, and a failed output call restores its original position. Bytes written before failure
+are unspecified; clear or overwrite them before retry when the surrounding protocol requires it.
+Fatal `Error` instances retain their identity instead of being wrapped.
+Set a bounded limit before passing untrusted input; the serializer cannot read outside the remaining range.
+
+```kotlin
+import io.bluetape4k.jackson.*
+import io.bluetape4k.json.JsonSerializer
+import io.bluetape4k.json.deserialize as deserializeRaw
+import java.nio.ByteBuffer
+
+run {
+    val buffer = ByteBuffer.allocate(4096)
+    serializer.serializeTo(users, buffer)
+    buffer.flip()
+    val restored = serializer.deserialize<List<User>>(buffer)
+}
+run {
+    val buffer = ByteBuffer.wrap(serializer.serialize(usersByName))
+    val restored = serializer.deserialize<Map<String, User>>(buffer)
+}
+
+val contract: JsonSerializer = serializer
+val buffer = ByteBuffer.wrap(serializer.serialize(users))
+val rawUsers: List<*>? = contract.deserializeRaw<List<User>>(buffer)
+```
+
+The concrete `JacksonSerializer` extension retains generic `TypeReference` information. A receiver statically
+typed as `JsonSerializer` uses the compatibility class-token contract, so collection elements remain raw maps.
+The same buffer override is inherited by YAML, Properties, CSV, TOML, CBOR, Ion, and Smile.
+No broader zero-allocation claim is made for Jackson internals.
+
+```java
+ByteBuffer buffer = ByteBuffer.wrap(bytes);
+User restored = serializer.deserializeFrom(buffer, User.class);
+```
 
 ### 3. ObjectMapper Extension Functions
 

--- a/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/JacksonSerializer.kt
+++ b/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/JacksonSerializer.kt
@@ -1,10 +1,15 @@
 package io.bluetape4k.jackson
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.bluetape4k.io.ByteBufferInputStream
+import io.bluetape4k.io.ByteBufferOutputStream
 import io.bluetape4k.json.JsonSerializationException
 import io.bluetape4k.json.JsonSerializer
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.emptyByteArray
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+import java.nio.ReadOnlyBufferException
 
 /**
  * Jackson 라이브러리를 사용하는 [JsonSerializer] 구현체입니다.
@@ -14,6 +19,10 @@ import io.bluetape4k.support.emptyByteArray
  * - [serialize]는 입력이 null이면 빈 바이트 배열을 반환합니다.
  * - 역직렬화 계열은 입력이 null이면 null을 반환하고, 파싱 실패 시 [JsonSerializationException]을 던집니다.
  * - 입력 객체/바이트 배열은 mutate하지 않고 직렬화 결과를 새로 생성합니다.
+ * - [ByteBuffer] 출력은 mapper의 stream API로 caller-owned storage에 직접 쓰고, 입력은 duplicate view로 읽어
+ *   caller의 position, limit, mark, byte order를 보존합니다.
+ * - concrete reified [deserialize]는 parameterized type을 보존하지만 [JsonSerializer] receiver는 기존 raw class
+ *   token 동작을 유지합니다.
  *
  * ```kotlin
  * val serializer = JacksonSerializer()
@@ -55,6 +64,32 @@ open class JacksonSerializer(
     }
 
     /**
+     * Serializes into [target] through the configured mapper instead of the compatibility [serialize] method.
+     * The target position is committed only on success; read-only and overflow failures remain raw buffer exceptions.
+     */
+    override fun serializeTo(graph: Any?, target: ByteBuffer): Int {
+        if (target.isReadOnly) throw ReadOnlyBufferException()
+        if (graph == null) return 0
+
+        val start = target.position()
+        val view = target.duplicate()
+        return try {
+            ByteBufferOutputStream.fixed(view).use { output ->
+                val writer = mapper.writer()
+                writer.createGenerator(output).use { generator ->
+                    writer.writeValue(generator, graph)
+                }
+            }
+            val written = view.position() - start
+            target.position(start + written)
+            written
+        } catch (failure: Throwable) {
+            target.position(start)
+            throw jacksonWriteFailure(failure, graph)
+        }
+    }
+
+    /**
      * JSON [ByteArray]를 읽어 지정된 타입의 객체로 역직렬화합니다.
      *
      * ## 동작/계약
@@ -78,6 +113,20 @@ open class JacksonSerializer(
             throw JsonSerializationException("Fail to deserialize by Jackson. targetType=${clazz.name}", e)
         }
     }
+
+    /**
+     * Deserializes the remaining [source] range through a duplicate-backed stream and preserves caller state.
+     */
+    override fun <T: Any> deserializeFrom(source: ByteBuffer, clazz: Class<T>): T? =
+        try {
+            ByteBufferInputStream(source.duplicate()).use { input ->
+                mapper.readValue(input, clazz)
+            }
+        } catch (e: Error) {
+            throw e
+        } catch (e: Throwable) {
+            throw JsonSerializationException("Fail to deserialize by Jackson. targetType=${clazz.name}", e)
+        }
 
     /**
      * JSON [ByteArray]를 읽어 reified 타입 [T]의 객체로 역직렬화합니다.
@@ -122,4 +171,40 @@ open class JacksonSerializer(
                 throw JsonSerializationException("Fail to deserialize by Jackson. targetType=${T::class.java.name}", e)
             }
         }
+}
+
+/**
+ * Deserializes the remaining [source] range with a Jackson type reference, preserving generic type arguments.
+ *
+ * This stays an extension so adding it does not introduce a final JVM method on the open [JacksonSerializer] class.
+ */
+inline fun <reified T: Any> JacksonSerializer.deserialize(source: ByteBuffer): T? =
+    try {
+        ByteBufferInputStream(source.duplicate()).use { input ->
+            mapper.readValue(input, jacksonTypeRef<T>())
+        }
+    } catch (e: Error) {
+        throw e
+    } catch (e: Throwable) {
+        throw JsonSerializationException("Fail to deserialize by Jackson. targetType=${T::class.java.name}", e)
+    }
+
+private fun jacksonWriteFailure(failure: Throwable, graph: Any): Throwable {
+    findCauseFailure(failure)?.let { return it }
+    return JsonSerializationException("Fail to serialize by Jackson. graphType=${graph.javaClass.name}", failure)
+}
+
+private fun findCauseFailure(root: Throwable): Throwable? {
+    var current: Throwable? = root
+    var depth = 0
+    while (current != null && depth < 64) {
+        when (current) {
+            is Error -> return current
+            is BufferOverflowException ->
+                return if (current === root) current else BufferOverflowException().apply { initCause(root) }
+        }
+        current = current.cause
+        depth++
+    }
+    return null
 }

--- a/io/jackson2/src/test/kotlin/io/bluetape4k/jackson/JacksonFormatSerializerByteBufferTest.kt
+++ b/io/jackson2/src/test/kotlin/io/bluetape4k/jackson/JacksonFormatSerializerByteBufferTest.kt
@@ -1,0 +1,58 @@
+package io.bluetape4k.jackson
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.jackson.binary.CborJacksonSerializer
+import io.bluetape4k.jackson.binary.IonJacksonSerializer
+import io.bluetape4k.jackson.binary.SmileJacksonSerializer
+import io.bluetape4k.jackson.text.CsvJacksonSerializer
+import io.bluetape4k.jackson.text.PropsJacksonSerializer
+import io.bluetape4k.jackson.text.TomlJacksonSerializer
+import io.bluetape4k.jackson.text.YamlJacksonSerializer
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.nio.ByteBuffer
+
+class JacksonFormatSerializerByteBufferTest {
+
+    @TestFactory
+    fun `inherited formats preserve ByteArray wire and cross-read ByteBuffer paths`() =
+        formatCases().map { case ->
+            dynamicTest(case.name) {
+                val oldWire = case.serializer.serialize(case.value)
+                val target = ByteBuffer.allocate(oldWire.size)
+
+                case.serializer.serializeTo(case.value, target) shouldBeEqualTo oldWire.size
+                val newWire = target.array()
+                newWire.contentEquals(oldWire).shouldBeTrue()
+
+                @Suppress("UNCHECKED_CAST")
+                val targetClass = case.targetClass as Class<Any>
+                case.serializer.deserializeFrom(ByteBuffer.wrap(oldWire), targetClass) shouldBeEqualTo
+                    case.serializer.deserialize(oldWire, targetClass)
+                case.serializer.deserialize(newWire, targetClass) shouldBeEqualTo case.value
+            }
+        }
+
+    private fun formatCases(): List<FormatCase> = listOf(
+        FormatCase("YAML", YamlJacksonSerializer()),
+        FormatCase("Properties", PropsJacksonSerializer()),
+        FormatCase("CSV", CsvJacksonSerializer(), listOf("format"), List::class.java),
+        FormatCase("TOML", TomlJacksonSerializer()),
+        FormatCase("CBOR", CborJacksonSerializer()),
+        FormatCase("Ion", IonJacksonSerializer()),
+        FormatCase("Smile", SmileJacksonSerializer()),
+    )
+}
+
+private data class FormatCase(
+    val name: String,
+    val serializer: JacksonSerializer,
+    val value: Any = FormatItem(17, "format"),
+    val targetClass: Class<*> = FormatItem::class.java,
+)
+
+private data class FormatItem(
+    val id: Int = 0,
+    val name: String = "",
+)

--- a/io/jackson2/src/test/kotlin/io/bluetape4k/jackson/JacksonSerializerByteBufferTest.kt
+++ b/io/jackson2/src/test/kotlin/io/bluetape4k/jackson/JacksonSerializerByteBufferTest.kt
@@ -1,0 +1,337 @@
+package io.bluetape4k.jackson
+
+import com.example.disallowed.DisallowedTypedPayload
+import com.fasterxml.jackson.databind.SerializationFeature
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.json.JsonSerializationException
+import io.bluetape4k.json.JsonSerializer
+import io.bluetape4k.json.deserialize as deserializeRaw
+import org.junit.jupiter.api.Test
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.ReadOnlyBufferException
+
+class JacksonSerializerByteBufferTest {
+
+    @Test
+    fun `ByteBuffer paths bypass allocating ByteArray overrides`() {
+        val baseline = JacksonSerializer()
+        val expected = CollectionItem(7, "buffer-user")
+        val wire = baseline.serialize(expected)
+        val serializer = NoByteArrayJacksonSerializer()
+        val target = ByteBuffer.allocate(wire.size)
+
+        serializer.serializeTo(expected, target) shouldBeEqualTo wire.size
+        target.flip()
+        serializer.deserializeFrom(target, CollectionItem::class.java) shouldBeEqualTo expected
+    }
+
+    @Test
+    fun `ByteArray and ByteBuffer paths remain wire compatible`() {
+        val serializer = JacksonSerializer()
+        val expected = CollectionItem(8, "wire-compatible")
+
+        serializer.deserializeFrom(
+            ByteBuffer.wrap(serializer.serialize(expected)),
+            CollectionItem::class.java,
+        ) shouldBeEqualTo expected
+
+        val target = ByteBuffer.allocate(256)
+        serializer.serializeTo(expected, target)
+        val wire = target.writtenBytes(0, target.position())
+        serializer.deserialize(wire, CollectionItem::class.java) shouldBeEqualTo expected
+    }
+
+    @Test
+    fun `concrete ByteBuffer overload preserves parameterized collection types`() {
+        val serializer = JacksonSerializer()
+        val users = listOf(CollectionItem(1, "alpha"), CollectionItem(2, "beta"))
+        val usersByName = users.associateBy { it.name }
+
+        serializer.deserialize<List<CollectionItem>>(ByteBuffer.wrap(serializer.serialize(users))) shouldBeEqualTo users
+        serializer.deserialize<Map<String, CollectionItem>>(ByteBuffer.wrap(serializer.serialize(usersByName))) shouldBeEqualTo usersByName
+    }
+
+    @Test
+    fun `legacy subclass may retain the ByteBuffer deserialize JVM signature`() {
+        val legacy = LegacySignatureJacksonSerializer()
+        legacy.deserialize<CollectionItem>(ByteBuffer.allocate(0)).shouldBeNull()
+
+        val serializer: JacksonSerializer = legacy
+        val expected = CollectionItem(3, "extension-dispatch")
+        serializer.deserialize<CollectionItem>(ByteBuffer.wrap(serializer.serialize(expected))) shouldBeEqualTo expected
+    }
+
+    @Test
+    fun `heap direct sliced and read-only sources preserve caller state`() {
+        val serializer = JacksonSerializer()
+        val expected = CollectionItem(9, "stateful")
+        val wire = serializer.serialize(expected)
+
+        sourceVariants(wire).forEach { source ->
+            val position = source.position()
+            val limit = source.limit()
+            val order = source.order()
+            source.mark()
+
+            serializer.deserializeFrom(source, CollectionItem::class.java) shouldBeEqualTo expected
+            source.position() shouldBeEqualTo position
+            source.limit() shouldBeEqualTo limit
+            source.order() shouldBeEqualTo order
+            source.reset()
+            source.position() shouldBeEqualTo position
+        }
+    }
+
+    @Test
+    fun `bounded output commits only the written range`() {
+        val serializer = JacksonSerializer()
+        val value = CollectionItem(11, "bounded")
+        val wire = serializer.serialize(value)
+        val target = ByteBuffer.allocate(wire.size + 6).order(ByteOrder.LITTLE_ENDIAN)
+        target.position(3)
+        target.limit(3 + wire.size)
+
+        serializer.serializeTo(value, target) shouldBeEqualTo wire.size
+        target.position() shouldBeEqualTo 3 + wire.size
+        target.limit() shouldBeEqualTo 3 + wire.size
+        target.order() shouldBeEqualTo ByteOrder.LITTLE_ENDIAN
+        target.writtenBytes(3, wire.size).contentEquals(wire).shouldBeTrue()
+    }
+
+    @Test
+    fun `read-only null target is rejected before mapper work`() {
+        val serializer = NoByteArrayJacksonSerializer()
+        val target = ByteBuffer.allocate(8).asReadOnlyBuffer()
+
+        assertFailsWith<ReadOnlyBufferException> {
+            serializer.serializeTo(null, target)
+        }
+        target.position() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `null output is a no-op and overflow rolls back for retry`() {
+        val serializer = JacksonSerializer()
+        val value = CollectionItem(12, "retry")
+        val wire = serializer.serialize(value)
+        val target = ByteBuffer.allocate(wire.size + 2)
+        target.position(2)
+        target.limit(2)
+
+        serializer.serializeTo(null, target) shouldBeEqualTo 0
+        target.position() shouldBeEqualTo 2
+
+        target.limit(target.capacity())
+        target.limit(target.capacity() - 1)
+        assertFailsWith<BufferOverflowException> {
+            serializer.serializeTo(value, target)
+        }
+        target.position() shouldBeEqualTo 2
+
+        target.limit(target.capacity())
+        serializer.serializeTo(value, target) shouldBeEqualTo wire.size
+    }
+
+    @Test
+    fun `malformed and empty input keep wrapper state and serializer remains reusable`() {
+        val serializer = JacksonSerializer()
+        val malformed = ByteBuffer.wrap("{not-json".toByteArray()).order(ByteOrder.LITTLE_ENDIAN)
+        malformed.position(1)
+        malformed.mark()
+        val position = malformed.position()
+        val limit = malformed.limit()
+
+        assertFailsWith<JsonSerializationException> {
+            serializer.deserializeFrom(malformed, CollectionItem::class.java)
+        }
+        malformed.position() shouldBeEqualTo position
+        malformed.limit() shouldBeEqualTo limit
+        malformed.order() shouldBeEqualTo ByteOrder.LITTLE_ENDIAN
+        malformed.reset()
+
+        assertFailsWith<JsonSerializationException> {
+            serializer.deserializeFrom(ByteBuffer.allocate(0), CollectionItem::class.java)
+        }
+
+        val expected = CollectionItem(13, "reused")
+        serializer.deserializeFrom(ByteBuffer.wrap(serializer.serialize(expected)), CollectionItem::class.java) shouldBeEqualTo expected
+    }
+
+    @Test
+    fun `fatal serialization error keeps identity and output position`() {
+        val serializer = JacksonSerializer()
+        val fatal = SerializerFatalError()
+        val target = ByteBuffer.allocate(64)
+        target.position(5)
+
+        val thrown = assertFailsWith<SerializerFatalError> {
+            serializer.serializeTo(FatalGraph(fatal), target)
+        }
+
+        (thrown === fatal).shouldBeTrue()
+        target.position() shouldBeEqualTo 5
+    }
+
+    @Test
+    fun `fatal deserialization error keeps identity for class token and reified paths`() {
+        val serializer = JacksonSerializer()
+        val fatal = SerializerFatalError()
+        fatalReadFailure = fatal
+
+        try {
+            val classTokenFailure = assertFailsWith<SerializerFatalError> {
+                serializer.deserializeFrom(
+                    ByteBuffer.wrap("""{"value":"boom"}""".toByteArray()),
+                    FatalReadGraph::class.java,
+                )
+            }
+            (classTokenFailure === fatal).shouldBeTrue()
+
+            val reifiedFailure = assertFailsWith<SerializerFatalError> {
+                serializer.deserialize<FatalReadGraph>(ByteBuffer.wrap("""{"value":"boom"}""".toByteArray()))
+            }
+            (reifiedFailure === fatal).shouldBeTrue()
+        } finally {
+            fatalReadFailure = null
+        }
+    }
+
+    @Test
+    fun `suppressed overflow does not replace the primary serialization failure`() {
+        val serializer = JacksonSerializer()
+        val primary = IllegalStateException("primary").apply {
+            addSuppressed(BufferOverflowException())
+        }
+        val target = ByteBuffer.allocate(64)
+        target.position(4)
+
+        assertFailsWith<JsonSerializationException> {
+            serializer.serializeTo(FailureGraph(primary), target)
+        }
+        target.position() shouldBeEqualTo 4
+    }
+
+    @Test
+    fun `configured mapper and typed allowlist apply to ByteBuffer paths`() {
+        val indentedMapper = Jackson.createDefaultJsonMapper().enable(SerializationFeature.INDENT_OUTPUT)
+        val serializer = JacksonSerializer(indentedMapper)
+        val value = CollectionItem(14, "configured")
+        val target = ByteBuffer.allocate(256)
+        serializer.serializeTo(value, target)
+        target.writtenBytes(0, target.position()).decodeToString() shouldContain "\n"
+
+        val typedSerializer = JacksonSerializer(Jackson.createTypedJsonMapper("io.bluetape4k.jackson."))
+        val envelope = TypedPayloadEnvelope(AllowedTypedPayload("safe"))
+        val typedTarget = ByteBuffer.allocate(512)
+        typedSerializer.serializeTo(envelope, typedTarget)
+        typedTarget.flip()
+        val restored = typedSerializer.deserializeFrom(typedTarget, TypedPayloadEnvelope::class.java)
+        restored?.payload.shouldBeInstanceOf<AllowedTypedPayload>().value shouldBeEqualTo "safe"
+
+        val allowedRoot = """{"@class":"${AllowedTypedPayload::class.qualifiedName}","value":"root-safe"}"""
+        typedSerializer.deserializeFrom(ByteBuffer.wrap(allowedRoot.toByteArray()), Any::class.java)
+            .shouldBeInstanceOf<AllowedTypedPayload>()
+            .value shouldBeEqualTo "root-safe"
+
+        val denied = """{"payload":{"@class":"${DisallowedTypedPayload::class.qualifiedName}","value":"blocked"}}"""
+        assertFailsWith<JsonSerializationException> {
+            typedSerializer.deserializeFrom(ByteBuffer.wrap(denied.toByteArray()), TypedPayloadEnvelope::class.java)
+        }
+
+        val deniedRoot = """{"@class":"${DisallowedTypedPayload::class.qualifiedName}","value":"blocked"}"""
+        assertFailsWith<JsonSerializationException> {
+            typedSerializer.deserializeFrom(ByteBuffer.wrap(deniedRoot.toByteArray()), Any::class.java)
+        }
+    }
+
+    @Test
+    fun `interface receiver retains raw collection behavior and invalid class is wrapped`() {
+        val concrete = JacksonSerializer()
+        val serializer: JsonSerializer = concrete
+        val values = listOf(CollectionItem(1, "raw"))
+
+        val restored: Any? = serializer.deserializeRaw<List<CollectionItem>>(ByteBuffer.wrap(concrete.serialize(values)))
+        (restored as List<*>).first().shouldBeInstanceOf<Map<*, *>>()
+
+        assertFailsWith<JsonSerializationException> {
+            serializer.deserializeRaw(ByteBuffer.wrap(concrete.serialize(values)), CollectionItem::class.java)
+        }
+    }
+}
+
+private class NoByteArrayJacksonSerializer: JacksonSerializer() {
+    override fun serialize(graph: Any?): ByteArray = error("ByteArray serialization fallback must not run")
+
+    override fun <T: Any> deserialize(bytes: ByteArray?, clazz: Class<T>): T? =
+        error("ByteArray deserialization fallback must not run")
+}
+
+private class LegacySignatureJacksonSerializer: JacksonSerializer() {
+    fun <T: Any> deserialize(source: ByteBuffer): T? {
+        source.remaining()
+        return null
+    }
+}
+
+private class FatalGraph(private val failure: Error) {
+    val value: String
+        get() = throw failure
+}
+
+private class FailureGraph(private val failure: RuntimeException) {
+    val value: String
+        get() = throw failure
+}
+
+private class SerializerFatalError: Error()
+
+private var fatalReadFailure: Error? = null
+
+private class FatalReadGraph {
+    var value: String? = null
+        set(value) {
+            field = value
+            fatalReadFailure?.let { throw it }
+        }
+}
+
+private fun sourceVariants(bytes: ByteArray): List<ByteBuffer> {
+    fun filled(buffer: ByteBuffer): ByteBuffer = buffer.apply {
+        position(2)
+        put(bytes)
+        limit(2 + bytes.size)
+        position(2)
+        order(ByteOrder.LITTLE_ENDIAN)
+    }
+
+    val heap = filled(ByteBuffer.allocate(bytes.size + 4))
+    val direct = filled(ByteBuffer.allocateDirect(bytes.size + 4))
+    val parent = ByteBuffer.allocate(bytes.size + 8).apply {
+        position(3)
+        put(bytes)
+        limit(3 + bytes.size)
+        position(3)
+    }
+    val sliced = parent.slice().apply {
+        limit(bytes.size)
+        order(ByteOrder.LITTLE_ENDIAN)
+    }
+    val readOnly = filled(ByteBuffer.allocate(bytes.size + 4)).asReadOnlyBuffer().order(ByteOrder.LITTLE_ENDIAN)
+    return listOf(heap, direct, sliced, readOnly)
+}
+
+private fun ByteBuffer.writtenBytes(start: Int, size: Int): ByteArray =
+    ByteArray(size).also { bytes ->
+        duplicate().apply {
+            position(start)
+            limit(start + size)
+            get(bytes)
+        }
+    }

--- a/io/jackson2/src/test/kotlin/io/bluetape4k/jackson/consumer/JacksonSerializerExtensionImportTest.kt
+++ b/io/jackson2/src/test/kotlin/io/bluetape4k/jackson/consumer/JacksonSerializerExtensionImportTest.kt
@@ -1,0 +1,31 @@
+package io.bluetape4k.jackson.consumer
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.jackson.JacksonSerializer
+import io.bluetape4k.jackson.deserialize
+import io.bluetape4k.json.JsonSerializer
+import io.bluetape4k.json.deserialize as deserializeRaw
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+
+class JacksonSerializerExtensionImportTest {
+
+    @Test
+    fun `external caller can import concrete and raw ByteBuffer extensions together`() {
+        val serializer = JacksonSerializer()
+        val expected = listOf(ConsumerItem(1, "external"))
+        val wire = serializer.serialize(expected)
+
+        serializer.deserialize<List<ConsumerItem>>(ByteBuffer.wrap(wire)) shouldBeEqualTo expected
+
+        val contract: JsonSerializer = serializer
+        val raw: Any? = contract.deserializeRaw<List<ConsumerItem>>(ByteBuffer.wrap(wire))
+        (raw as List<*>).first().shouldBeInstanceOf<Map<*, *>>()
+    }
+}
+
+private data class ConsumerItem(
+    val id: Int,
+    val name: String,
+)

--- a/io/jackson3/README.ko.md
+++ b/io/jackson3/README.ko.md
@@ -105,7 +105,52 @@ try {
 
 - `serialize(null)`은 빈 `ByteArray`를 반환합니다.
 - `deserialize(null)` / `deserializeFromString(null)`은 `null`을 반환합니다.
-- 그 외 직렬화/역직렬화 실패는 `JsonSerializationException` 예외를 던집니다.
+- 일반적인 backend 직렬화/역직렬화 실패는 `JsonSerializationException` 예외를 던집니다.
+
+#### ByteBuffer 계약
+
+`serializeTo`는 설정된 mapper의 stream API로 caller-owned buffer에 직접 쓰고, `deserializeFrom`은
+duplicate view를 읽습니다. 이 Jackson 전용 override는 호환 `serialize(): ByteArray`와
+`deserialize(ByteArray)` 메서드를 우회합니다. optimized dispatch cell이라는 의미만 가지며, 측정 전에는
+할당 개선을 주장하지 않습니다. heap, direct, slice, read-only 입력을 지원하며 입력 상태를 보존합니다. 출력 position은 성공
+시에만 이동하고, read-only target과 용량 부족은 각각 raw `ReadOnlyBufferException`,
+`BufferOverflowException`을 노출합니다. 실패한 출력 호출은 원래 position으로 rollback하지만 이미 기록된
+바이트는 불특정 상태이므로 주변 프로토콜이 요구하면 재시도 전에 지우거나 덮어써야 합니다.
+치명적인 `Error` 인스턴스는 wrapping하지 않고 동일 identity를 유지합니다.
+신뢰할 수 없는 입력은 호출 전에 limit를 설정해 범위를 제한해야 하며 serializer는 remaining 범위 밖을 읽지 않습니다.
+
+```kotlin
+import io.bluetape4k.jackson3.*
+import io.bluetape4k.json.JsonSerializer
+import io.bluetape4k.json.deserialize as deserializeRaw
+import java.nio.ByteBuffer
+
+run {
+    val buffer = ByteBuffer.allocate(4096)
+    serializer.serializeTo(users, buffer)
+    buffer.flip()
+    val restored = serializer.deserialize<List<User>>(buffer)
+}
+run {
+    val buffer = ByteBuffer.wrap(serializer.serialize(usersByName))
+    val restored = serializer.deserialize<Map<String, User>>(buffer)
+}
+
+val contract: JsonSerializer = serializer
+val buffer = ByteBuffer.wrap(serializer.serialize(users))
+val rawUsers: List<*>? = contract.deserializeRaw<List<User>>(buffer)
+```
+
+concrete `JacksonSerializer` extension은 generic type-reference 정보를 유지합니다. 정적 타입이
+`JsonSerializer`인 receiver는 기존 class-token 호환 fallback 계약을 사용하므로 collection element가
+raw map으로 남습니다. YAML, Properties, CSV, TOML, CBOR, Ion, Smile도 같은 buffer override를 상속합니다.
+Jackson 3에서 제거된 default typing은 활성화하지 않으며 내부 전체에 대한 zero-allocation 주장은 하지 않습니다.
+신뢰할 수 없는 다형성 입력에는 class-name ID 대신 명시적 subtype 목록과 `JsonTypeInfo.Id.NAME`을 권장합니다.
+
+```java
+ByteBuffer buffer = ByteBuffer.wrap(bytes);
+User restored = serializer.deserializeFrom(buffer, User.class);
+```
 
 ### 3. ObjectMapper 확장 함수
 

--- a/io/jackson3/README.md
+++ b/io/jackson3/README.md
@@ -106,7 +106,53 @@ try {
 
 - `serialize(null)` returns an empty `ByteArray`.
 - `deserialize(null)` / `deserializeFromString(null)` returns `null`.
-- All other serialization / deserialization failures throw `JsonSerializationException`.
+- Ordinary backend serialization / deserialization failures throw `JsonSerializationException`.
+
+#### ByteBuffer contract
+
+`serializeTo` streams through the configured mapper into the caller-owned buffer, and `deserializeFrom`
+reads a duplicate view. These Jackson-specific overrides bypass the compatibility `serialize(): ByteArray`
+and `deserialize(ByteArray)` methods. They are optimized dispatch cells only; allocation improvement remains
+unclaimed until it is measured.
+Heap, direct, sliced, and read-only input are supported. Input state is preserved; output position advances
+only on success. A read-only target and insufficient capacity expose raw `ReadOnlyBufferException` and
+`BufferOverflowException`, and a failed output call restores its original position. Bytes written before failure
+are unspecified; clear or overwrite them before retry when the surrounding protocol requires it.
+Fatal `Error` instances retain their identity instead of being wrapped.
+Set a bounded limit before passing untrusted input; the serializer cannot read outside the remaining range.
+
+```kotlin
+import io.bluetape4k.jackson3.*
+import io.bluetape4k.json.JsonSerializer
+import io.bluetape4k.json.deserialize as deserializeRaw
+import java.nio.ByteBuffer
+
+run {
+    val buffer = ByteBuffer.allocate(4096)
+    serializer.serializeTo(users, buffer)
+    buffer.flip()
+    val restored = serializer.deserialize<List<User>>(buffer)
+}
+run {
+    val buffer = ByteBuffer.wrap(serializer.serialize(usersByName))
+    val restored = serializer.deserialize<Map<String, User>>(buffer)
+}
+
+val contract: JsonSerializer = serializer
+val buffer = ByteBuffer.wrap(serializer.serialize(users))
+val rawUsers: List<*>? = contract.deserializeRaw<List<User>>(buffer)
+```
+
+The concrete `JacksonSerializer` extension retains generic type-reference information. A receiver statically
+typed as `JsonSerializer` uses the compatibility class-token contract, so collection elements remain raw maps.
+The same buffer override is inherited by YAML, Properties, CSV, TOML, CBOR, Ion, and Smile.
+Jackson 3 does not enable removed default typing, and no broader zero-allocation claim is made for internals.
+For untrusted polymorphic input, prefer `JsonTypeInfo.Id.NAME` with an explicit subtype list instead of class-name IDs.
+
+```java
+ByteBuffer buffer = ByteBuffer.wrap(bytes);
+User restored = serializer.deserializeFrom(buffer, User.class);
+```
 
 ### 3. ObjectMapper Extension Functions
 

--- a/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/JacksonSerializer.kt
+++ b/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/JacksonSerializer.kt
@@ -1,10 +1,15 @@
 package io.bluetape4k.jackson3
 
+import io.bluetape4k.io.ByteBufferInputStream
+import io.bluetape4k.io.ByteBufferOutputStream
 import io.bluetape4k.json.JsonSerializationException
 import io.bluetape4k.json.JsonSerializer
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.emptyByteArray
 import tools.jackson.databind.ObjectMapper
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+import java.nio.ReadOnlyBufferException
 
 /**
  * Jackson 3 기반 [JsonSerializer] 구현체입니다.
@@ -13,6 +18,10 @@ import tools.jackson.databind.ObjectMapper
  * - [serialize]는 입력이 null이면 빈 바이트 배열을 반환합니다.
  * - 역직렬화 계열은 입력이 null이면 null을 반환하고 실패 시 [JsonSerializationException]을 던집니다.
  * - 기본 매퍼는 [Jackson.defaultJsonMapper]입니다.
+ * - [ByteBuffer] 출력은 mapper의 stream API로 caller-owned storage에 직접 쓰고, 입력은 duplicate view로 읽어
+ *   caller의 position, limit, mark, byte order를 보존합니다.
+ * - concrete reified [deserialize]는 parameterized type을 보존하지만 [JsonSerializer] receiver는 기존 raw class
+ *   token 동작을 유지합니다.
  *
  * ```kotlin
  * val serializer = JacksonSerializer()
@@ -54,6 +63,32 @@ open class JacksonSerializer(
     }
 
     /**
+     * Serializes into [target] through the configured mapper instead of the compatibility [serialize] method.
+     * The target position is committed only on success; read-only and overflow failures remain raw buffer exceptions.
+     */
+    override fun serializeTo(graph: Any?, target: ByteBuffer): Int {
+        if (target.isReadOnly) throw ReadOnlyBufferException()
+        if (graph == null) return 0
+
+        val start = target.position()
+        val view = target.duplicate()
+        return try {
+            ByteBufferOutputStream.fixed(view).use { output ->
+                val writer = mapper.writer()
+                writer.createGenerator(output).use { generator ->
+                    writer.writeValue(generator, graph)
+                }
+            }
+            val written = view.position() - start
+            target.position(start + written)
+            written
+        } catch (failure: Throwable) {
+            target.position(start)
+            throw jackson3WriteFailure(failure, graph)
+        }
+    }
+
+    /**
      * JSON [ByteArray]를 읽어 지정된 타입의 객체로 역직렬화합니다.
      *
      * ## 동작/계약
@@ -77,6 +112,20 @@ open class JacksonSerializer(
             throw JsonSerializationException("Fail to deserialize by Jackson3. targetType=${clazz.name}", e)
         }
     }
+
+    /**
+     * Deserializes the remaining [source] range through a duplicate-backed stream and preserves caller state.
+     */
+    override fun <T: Any> deserializeFrom(source: ByteBuffer, clazz: Class<T>): T? =
+        try {
+            ByteBufferInputStream(source.duplicate()).use { input ->
+                mapper.readValue(input, clazz)
+            }
+        } catch (e: Error) {
+            throw e
+        } catch (e: Throwable) {
+            throw JsonSerializationException("Fail to deserialize by Jackson3. targetType=${clazz.name}", e)
+        }
 
     /**
      * JSON [ByteArray]를 읽어 reified 타입 [T]의 객체로 역직렬화합니다.
@@ -123,4 +172,40 @@ open class JacksonSerializer(
                 throw JsonSerializationException("Fail to deserialize by Jackson3. targetType=${T::class.java.name}", e)
             }
         }
+}
+
+/**
+ * Deserializes the remaining [source] range with a Jackson type reference, preserving generic type arguments.
+ *
+ * This stays an extension so adding it does not introduce a final JVM method on the open [JacksonSerializer] class.
+ */
+inline fun <reified T: Any> JacksonSerializer.deserialize(source: ByteBuffer): T? =
+    try {
+        ByteBufferInputStream(source.duplicate()).use { input ->
+            mapper.readValue(input, jacksonTypeRef<T>())
+        }
+    } catch (e: Error) {
+        throw e
+    } catch (e: Throwable) {
+        throw JsonSerializationException("Fail to deserialize by Jackson3. targetType=${T::class.java.name}", e)
+    }
+
+private fun jackson3WriteFailure(failure: Throwable, graph: Any): Throwable {
+    findCauseFailure(failure)?.let { return it }
+    return JsonSerializationException("Fail to serialize by Jackson3. graphType=${graph.javaClass.name}", failure)
+}
+
+private fun findCauseFailure(root: Throwable): Throwable? {
+    var current: Throwable? = root
+    var depth = 0
+    while (current != null && depth < 64) {
+        when (current) {
+            is Error -> return current
+            is BufferOverflowException ->
+                return if (current === root) current else BufferOverflowException().apply { initCause(root) }
+        }
+        current = current.cause
+        depth++
+    }
+    return null
 }

--- a/io/jackson3/src/test/kotlin/io/bluetape4k/jackson3/JacksonFormatSerializerByteBufferTest.kt
+++ b/io/jackson3/src/test/kotlin/io/bluetape4k/jackson3/JacksonFormatSerializerByteBufferTest.kt
@@ -1,0 +1,58 @@
+package io.bluetape4k.jackson3
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.jackson3.binary.CborJacksonSerializer
+import io.bluetape4k.jackson3.binary.IonJacksonSerializer
+import io.bluetape4k.jackson3.binary.SmileJacksonSerializer
+import io.bluetape4k.jackson3.text.CsvJacksonSerializer
+import io.bluetape4k.jackson3.text.PropsJacksonSerializer
+import io.bluetape4k.jackson3.text.TomlJacksonSerializer
+import io.bluetape4k.jackson3.text.YamlJacksonSerializer
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.nio.ByteBuffer
+
+class JacksonFormatSerializerByteBufferTest {
+
+    @TestFactory
+    fun `inherited formats preserve ByteArray wire and cross-read ByteBuffer paths`() =
+        formatCases().map { case ->
+            dynamicTest(case.name) {
+                val oldWire = case.serializer.serialize(case.value)
+                val target = ByteBuffer.allocate(oldWire.size)
+
+                case.serializer.serializeTo(case.value, target) shouldBeEqualTo oldWire.size
+                val newWire = target.array()
+                newWire.contentEquals(oldWire).shouldBeTrue()
+
+                @Suppress("UNCHECKED_CAST")
+                val targetClass = case.targetClass as Class<Any>
+                case.serializer.deserializeFrom(ByteBuffer.wrap(oldWire), targetClass) shouldBeEqualTo
+                    case.serializer.deserialize(oldWire, targetClass)
+                case.serializer.deserialize(newWire, targetClass) shouldBeEqualTo case.value
+            }
+        }
+
+    private fun formatCases(): List<FormatCase> = listOf(
+        FormatCase("YAML", YamlJacksonSerializer()),
+        FormatCase("Properties", PropsJacksonSerializer()),
+        FormatCase("CSV", CsvJacksonSerializer(), listOf("format"), List::class.java),
+        FormatCase("TOML", TomlJacksonSerializer()),
+        FormatCase("CBOR", CborJacksonSerializer()),
+        FormatCase("Ion", IonJacksonSerializer()),
+        FormatCase("Smile", SmileJacksonSerializer()),
+    )
+}
+
+private data class FormatCase(
+    val name: String,
+    val serializer: JacksonSerializer,
+    val value: Any = FormatItem(17, "format"),
+    val targetClass: Class<*> = FormatItem::class.java,
+)
+
+private data class FormatItem(
+    val id: Int = 0,
+    val name: String = "",
+)

--- a/io/jackson3/src/test/kotlin/io/bluetape4k/jackson3/JacksonSerializerByteBufferTest.kt
+++ b/io/jackson3/src/test/kotlin/io/bluetape4k/jackson3/JacksonSerializerByteBufferTest.kt
@@ -1,0 +1,341 @@
+package io.bluetape4k.jackson3
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.json.JsonSerializationException
+import io.bluetape4k.json.JsonSerializer
+import io.bluetape4k.json.deserialize as deserializeRaw
+import org.junit.jupiter.api.Test
+import tools.jackson.databind.SerializationFeature
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.ReadOnlyBufferException
+
+class JacksonSerializerByteBufferTest {
+
+    @Test
+    fun `ByteBuffer paths bypass allocating ByteArray overrides`() {
+        val baseline = JacksonSerializer()
+        val expected = CollectionItem(7, "buffer-user")
+        val wire = baseline.serialize(expected)
+        val serializer = NoByteArrayJacksonSerializer()
+        val target = ByteBuffer.allocate(wire.size)
+
+        serializer.serializeTo(expected, target) shouldBeEqualTo wire.size
+        target.flip()
+        serializer.deserializeFrom(target, CollectionItem::class.java) shouldBeEqualTo expected
+    }
+
+    @Test
+    fun `ByteArray and ByteBuffer paths remain wire compatible`() {
+        val serializer = JacksonSerializer()
+        val expected = CollectionItem(8, "wire-compatible")
+
+        serializer.deserializeFrom(
+            ByteBuffer.wrap(serializer.serialize(expected)),
+            CollectionItem::class.java,
+        ) shouldBeEqualTo expected
+
+        val target = ByteBuffer.allocate(256)
+        serializer.serializeTo(expected, target)
+        val wire = target.writtenBytes(0, target.position())
+        serializer.deserialize(wire, CollectionItem::class.java) shouldBeEqualTo expected
+    }
+
+    @Test
+    fun `concrete ByteBuffer overload preserves parameterized collection types`() {
+        val serializer = JacksonSerializer()
+        val users = listOf(CollectionItem(1, "alpha"), CollectionItem(2, "beta"))
+        val usersByName = users.associateBy { it.name }
+
+        serializer.deserialize<List<CollectionItem>>(ByteBuffer.wrap(serializer.serialize(users))) shouldBeEqualTo users
+        serializer.deserialize<Map<String, CollectionItem>>(ByteBuffer.wrap(serializer.serialize(usersByName))) shouldBeEqualTo usersByName
+    }
+
+    @Test
+    fun `legacy subclass may retain the ByteBuffer deserialize JVM signature`() {
+        val legacy = LegacySignatureJacksonSerializer()
+        legacy.deserialize<CollectionItem>(ByteBuffer.allocate(0)).shouldBeNull()
+
+        val serializer: JacksonSerializer = legacy
+        val expected = CollectionItem(3, "extension-dispatch")
+        serializer.deserialize<CollectionItem>(ByteBuffer.wrap(serializer.serialize(expected))) shouldBeEqualTo expected
+    }
+
+    @Test
+    fun `heap direct sliced and read-only sources preserve caller state`() {
+        val serializer = JacksonSerializer()
+        val expected = CollectionItem(9, "stateful")
+        val wire = serializer.serialize(expected)
+
+        sourceVariants(wire).forEach { source ->
+            val position = source.position()
+            val limit = source.limit()
+            val order = source.order()
+            source.mark()
+
+            serializer.deserializeFrom(source, CollectionItem::class.java) shouldBeEqualTo expected
+            source.position() shouldBeEqualTo position
+            source.limit() shouldBeEqualTo limit
+            source.order() shouldBeEqualTo order
+            source.reset()
+            source.position() shouldBeEqualTo position
+        }
+    }
+
+    @Test
+    fun `bounded output commits only the written range`() {
+        val serializer = JacksonSerializer()
+        val value = CollectionItem(11, "bounded")
+        val wire = serializer.serialize(value)
+        val target = ByteBuffer.allocate(wire.size + 6).order(ByteOrder.LITTLE_ENDIAN)
+        target.position(3)
+        target.limit(3 + wire.size)
+
+        serializer.serializeTo(value, target) shouldBeEqualTo wire.size
+        target.position() shouldBeEqualTo 3 + wire.size
+        target.limit() shouldBeEqualTo 3 + wire.size
+        target.order() shouldBeEqualTo ByteOrder.LITTLE_ENDIAN
+        target.writtenBytes(3, wire.size).contentEquals(wire).shouldBeTrue()
+    }
+
+    @Test
+    fun `read-only null target is rejected before mapper work`() {
+        val serializer = NoByteArrayJacksonSerializer()
+        val target = ByteBuffer.allocate(8).asReadOnlyBuffer()
+
+        assertFailsWith<ReadOnlyBufferException> {
+            serializer.serializeTo(null, target)
+        }
+        target.position() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `null output is a no-op and overflow rolls back for retry`() {
+        val serializer = JacksonSerializer()
+        val value = CollectionItem(12, "retry")
+        val wire = serializer.serialize(value)
+        val target = ByteBuffer.allocate(wire.size + 2)
+        target.position(2)
+        target.limit(2)
+
+        serializer.serializeTo(null, target) shouldBeEqualTo 0
+        target.position() shouldBeEqualTo 2
+
+        target.limit(target.capacity() - 1)
+        assertFailsWith<BufferOverflowException> {
+            serializer.serializeTo(value, target)
+        }
+        target.position() shouldBeEqualTo 2
+
+        target.limit(target.capacity())
+        serializer.serializeTo(value, target) shouldBeEqualTo wire.size
+    }
+
+    @Test
+    fun `malformed and empty input keep wrapper state and serializer remains reusable`() {
+        val serializer = JacksonSerializer()
+        val malformed = ByteBuffer.wrap("{not-json".toByteArray()).order(ByteOrder.LITTLE_ENDIAN)
+        malformed.position(1)
+        malformed.mark()
+        val position = malformed.position()
+        val limit = malformed.limit()
+
+        assertFailsWith<JsonSerializationException> {
+            serializer.deserializeFrom(malformed, CollectionItem::class.java)
+        }
+        malformed.position() shouldBeEqualTo position
+        malformed.limit() shouldBeEqualTo limit
+        malformed.order() shouldBeEqualTo ByteOrder.LITTLE_ENDIAN
+        malformed.reset()
+
+        assertFailsWith<JsonSerializationException> {
+            serializer.deserializeFrom(ByteBuffer.allocate(0), CollectionItem::class.java)
+        }
+
+        val expected = CollectionItem(13, "reused")
+        serializer.deserializeFrom(ByteBuffer.wrap(serializer.serialize(expected)), CollectionItem::class.java) shouldBeEqualTo expected
+    }
+
+    @Test
+    fun `fatal serialization error keeps identity and output position`() {
+        val serializer = JacksonSerializer()
+        val fatal = SerializerFatalError()
+        val target = ByteBuffer.allocate(64)
+        target.position(5)
+
+        val thrown = assertFailsWith<SerializerFatalError> {
+            serializer.serializeTo(FatalGraph(fatal), target)
+        }
+
+        (thrown === fatal).shouldBeTrue()
+        target.position() shouldBeEqualTo 5
+    }
+
+    @Test
+    fun `fatal deserialization error keeps identity for class token and reified paths`() {
+        val serializer = JacksonSerializer()
+        val fatal = SerializerFatalError()
+        fatalReadFailure = fatal
+
+        try {
+            val classTokenFailure = assertFailsWith<SerializerFatalError> {
+                serializer.deserializeFrom(
+                    ByteBuffer.wrap("""{"value":"boom"}""".toByteArray()),
+                    FatalReadGraph::class.java,
+                )
+            }
+            (classTokenFailure === fatal).shouldBeTrue()
+
+            val reifiedFailure = assertFailsWith<SerializerFatalError> {
+                serializer.deserialize<FatalReadGraph>(ByteBuffer.wrap("""{"value":"boom"}""".toByteArray()))
+            }
+            (reifiedFailure === fatal).shouldBeTrue()
+        } finally {
+            fatalReadFailure = null
+        }
+    }
+
+    @Test
+    fun `suppressed overflow does not replace the primary serialization failure`() {
+        val serializer = JacksonSerializer()
+        val primary = IllegalStateException("primary").apply {
+            addSuppressed(BufferOverflowException())
+        }
+        val target = ByteBuffer.allocate(64)
+        target.position(4)
+
+        assertFailsWith<JsonSerializationException> {
+            serializer.serializeTo(FailureGraph(primary), target)
+        }
+        target.position() shouldBeEqualTo 4
+    }
+
+    @Test
+    fun `configured mapper applies and unsolicited type metadata stays data`() {
+        val indentedMapper = Jackson.createDefaultJsonMapper()
+            .rebuild()
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .build()
+        val serializer = JacksonSerializer(indentedMapper)
+        val value = CollectionItem(14, "configured")
+        val target = ByteBuffer.allocate(256)
+        serializer.serializeTo(value, target)
+        target.writtenBytes(0, target.position()).decodeToString() shouldContain "\n"
+
+        val metadata = """{"@class":"java.lang.ProcessBuilder","value":"blocked"}"""
+        val restored = serializer.deserializeFrom(ByteBuffer.wrap(metadata.toByteArray()), Any::class.java)
+        restored.shouldBeInstanceOf<Map<*, *>>()["@class"] shouldBeEqualTo "java.lang.ProcessBuilder"
+    }
+
+    @Test
+    fun `annotation driven polymorphism is preserved on ByteBuffer paths`() {
+        val serializer = JacksonSerializer()
+        val expected: Person = Professor("buffer-professor", 42, "coroutines")
+        val target = ByteBuffer.allocate(512)
+
+        serializer.serializeTo(expected, target)
+        target.flip()
+
+        serializer.deserializeFrom(target, Person::class.java) shouldBeEqualTo expected
+    }
+
+    @Test
+    fun `annotation driven polymorphism rejects an unrelated class id`() {
+        val serializer = JacksonSerializer()
+        val payload = """{"@class":"java.lang.ProcessBuilder","name":"blocked","age":1}"""
+
+        assertFailsWith<JsonSerializationException> {
+            serializer.deserializeFrom(ByteBuffer.wrap(payload.toByteArray()), Person::class.java)
+        }
+    }
+
+    @Test
+    fun `interface receiver retains raw collection behavior and invalid class is wrapped`() {
+        val concrete = JacksonSerializer()
+        val serializer: JsonSerializer = concrete
+        val values = listOf(CollectionItem(1, "raw"))
+
+        val restored: Any? = serializer.deserializeRaw<List<CollectionItem>>(ByteBuffer.wrap(concrete.serialize(values)))
+        (restored as List<*>).first().shouldBeInstanceOf<Map<*, *>>()
+
+        assertFailsWith<JsonSerializationException> {
+            serializer.deserializeRaw(ByteBuffer.wrap(concrete.serialize(values)), CollectionItem::class.java)
+        }
+    }
+}
+
+private class NoByteArrayJacksonSerializer: JacksonSerializer() {
+    override fun serialize(graph: Any?): ByteArray = error("ByteArray serialization fallback must not run")
+
+    override fun <T: Any> deserialize(bytes: ByteArray?, clazz: Class<T>): T? =
+        error("ByteArray deserialization fallback must not run")
+}
+
+private class LegacySignatureJacksonSerializer: JacksonSerializer() {
+    fun <T: Any> deserialize(source: ByteBuffer): T? {
+        source.remaining()
+        return null
+    }
+}
+
+private class FatalGraph(private val failure: Error) {
+    val value: String
+        get() = throw failure
+}
+
+private class FailureGraph(private val failure: RuntimeException) {
+    val value: String
+        get() = throw failure
+}
+
+private class SerializerFatalError: Error()
+
+private var fatalReadFailure: Error? = null
+
+private class FatalReadGraph {
+    var value: String? = null
+        set(value) {
+            field = value
+            fatalReadFailure?.let { throw it }
+        }
+}
+
+private fun sourceVariants(bytes: ByteArray): List<ByteBuffer> {
+    fun filled(buffer: ByteBuffer): ByteBuffer = buffer.apply {
+        position(2)
+        put(bytes)
+        limit(2 + bytes.size)
+        position(2)
+        order(ByteOrder.LITTLE_ENDIAN)
+    }
+
+    val heap = filled(ByteBuffer.allocate(bytes.size + 4))
+    val direct = filled(ByteBuffer.allocateDirect(bytes.size + 4))
+    val parent = ByteBuffer.allocate(bytes.size + 8).apply {
+        position(3)
+        put(bytes)
+        limit(3 + bytes.size)
+        position(3)
+    }
+    val sliced = parent.slice().apply {
+        limit(bytes.size)
+        order(ByteOrder.LITTLE_ENDIAN)
+    }
+    val readOnly = filled(ByteBuffer.allocate(bytes.size + 4)).asReadOnlyBuffer().order(ByteOrder.LITTLE_ENDIAN)
+    return listOf(heap, direct, sliced, readOnly)
+}
+
+private fun ByteBuffer.writtenBytes(start: Int, size: Int): ByteArray =
+    ByteArray(size).also { bytes ->
+        duplicate().apply {
+            position(start)
+            limit(start + size)
+            get(bytes)
+        }
+    }

--- a/io/jackson3/src/test/kotlin/io/bluetape4k/jackson3/consumer/JacksonSerializerExtensionImportTest.kt
+++ b/io/jackson3/src/test/kotlin/io/bluetape4k/jackson3/consumer/JacksonSerializerExtensionImportTest.kt
@@ -1,0 +1,31 @@
+package io.bluetape4k.jackson3.consumer
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.jackson3.JacksonSerializer
+import io.bluetape4k.jackson3.deserialize
+import io.bluetape4k.json.JsonSerializer
+import io.bluetape4k.json.deserialize as deserializeRaw
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+
+class JacksonSerializerExtensionImportTest {
+
+    @Test
+    fun `external caller can import concrete and raw ByteBuffer extensions together`() {
+        val serializer = JacksonSerializer()
+        val expected = listOf(ConsumerItem(1, "external"))
+        val wire = serializer.serialize(expected)
+
+        serializer.deserialize<List<ConsumerItem>>(ByteBuffer.wrap(wire)) shouldBeEqualTo expected
+
+        val contract: JsonSerializer = serializer
+        val raw: Any? = contract.deserializeRaw<List<ConsumerItem>>(ByteBuffer.wrap(wire))
+        (raw as List<*>).first().shouldBeInstanceOf<Map<*, *>>()
+    }
+}
+
+private data class ConsumerItem(
+    val id: Int,
+    val name: String,
+)


### PR DESCRIPTION
## Summary

Closes #1037

- PR 제목: Implement lower-copy ByteBuffer paths for JSON serializers

Closes #1037

Provide backend-specific ByteBuffer paths for Jackson 2, Jackson 3, and Fastjson2 while preserving wire formats, security configuration, exceptions, and caller-owned buffer state.

## Background

Issue #1037 is Slice 3 of Epic #754 for milestone `1.12.0`. The shared `JsonSerializer` ByteBuffer defaults staged through a complete ByteArray, but the resolved backends expose different stream and array-range capabilities.

## What This Solves

- Jackson 2 and Jackson 3 can use fixed caller-owned output storage and bounded input without complete adapter-level ByteArray staging.
- Fastjson2 uses its supported JSONB array-range parser where safe, while unsupported input and all output retain an explicit compatibility fallback.
- Public open Jackson class ABI, configured mapper behavior, AutoType boundaries, and caller buffer state remain stable.

## Work Done

- Jackson 2/3: added duplicate-backed stream input, fixed-buffer output, explicit generator cleanup, bounded failure classification, and concrete reified top-level extensions.
- Fastjson2: added writable array-backed range parsing, bounded fallback copies, allocating output compatibility, and feature-free JSONB readers.
- Tests and docs: covered heap/direct/sliced/read-only buffers, overflow rollback, fatal and suppressed failures, inherited Jackson formats, JSONB AutoType metadata, legacy subclasses, external imports, and six bilingual README examples.
- Evidence: recorded Fastjson2 `2.0.62` source capability findings and exact implementation-head aggregate and JSON ABI reports.

## Validation

- `./gradlew :bluetape4k-jackson2:test --no-daemon`: PASS (455 tests)
- `./gradlew :bluetape4k-jackson3:test --no-daemon`: PASS (456 tests)
- `./gradlew :bluetape4k-fastjson2:test --rerun-tasks --no-daemon`: PASS (180 tests)
- `bash scripts/check-serializer-buffer-abi.sh --build-current --expected-head 3198fa3c8648033b2ae36bfd3fcecec42db23cdf`: PASS (all compatibility checks GREEN)
- `./gradlew detekt --no-daemon`: PASS (`detekt NO-SOURCE`; compilation, complete module tests, README/static scans, and `git diff --check` provide the available fallback)

## Review Notes

- P0/P1: 0
- P2/P3: all issue-scoped findings fixed; allocation benchmarks remain in #1039; unchanged Jackson 2 typed-mapper validator hardening remains outside #1037.
- Review evidence: `docs/review/2026-07-17-issue-1037-json-serializer-bytebuffer-review.md`

## Metadata

- Issue: #1037, milestone `1.12.0`, assignee `debop`
- PR: #1042, head `4bf42d5cecb48f69ab3a75e07ccd4c01e1700983`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `feat/issue-754-json-serializers`
- Labels: `enhancement`, `performance`, `infra/io`
- State: `MERGED`, merge commit `0b8162a227acc0e50eb111526066269e47f200f5`
- CI: Provide backend-specific ByteBuffer paths for Jackson 2, Jackson 3, and Fastjson2 while preserving wire formats, security configuration, exceptions, and caller-owned buffer state. / - Fastjson2 uses its supported JSONB array-range parser where safe, while unsupported input and all output retain an explicit compatibility fallback. / - Jackson 2/3: added duplicate-backed stream input, fixed-buffer output, explicit generator cleanup, bounded failure classification, and concrete reified top-level extensions.

## DoD Status

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| DOD-1 - RED coverage | Added backend-focused ByteBuffer regression suites | PASS | 14 Jackson2, 16 Jackson3, and 14 Fastjson2 focused tests | none |
| DOD-2 - Jackson fixed buffers | Connected configured stream APIs to duplicate-backed adapters | PASS | Complete Jackson2 and Jackson3 module suites | none |
| DOD-3 - compatibility contracts | Preserved exceptions, caller state, and old/new cross-reading | PASS | Focused suites and bilingual README contract tables | none |
| DOD-4 - Fastjson capability | Used only proven array-range input and documented all fallbacks | PASS | `docs/evidence/issue-754/json/fastjson2-2.0.62-capability.md` | none |
| DOD-5 - ABI and wire compatibility | Verified legacy/new callers, class symbols, JAR hashes, and JSON/JSONB cross-read | PASS | Both tracked ABI reports are GREEN | none |
| DOD-6 - tests and review | Ran complete module tests and six independent review lenses | PASS | 455/456/180 passing; P0=0, P1=0 | none |
| CG-14 - GitHub CI/review | Ran exact-head GitHub checks and reread review surfaces | PASS | [CI run 29557675834](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/29557675834) succeeded; dependency submission passed; no reviews, comments, or unresolved threads | none |
| CG-16 - fresh merge approval | Obtained approval after exact-head CI and review readiness | PASS | User approved PR #1042 at `4bf42d5cecb48f69ab3a75e07ccd4c01e1700983`; rebase merge produced `0b8162a227acc0e50eb111526066269e47f200f5`; local `develop` synchronized | none |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1042 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `0b8162a227acc0e50eb111526066269e47f200f5`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
