### PR TITLE
Implement lower-copy ByteBuffer paths for Avro serializers

### DIFF
--- a/docs/evidence/issue-754/contract/abi-report.json
+++ b/docs/evidence/issue-754/contract/abi-report.json
@@ -3,7 +3,7 @@
     {
       "module": "avro",
       "path": "io/avro/build/libs/bluetape4k-avro-1.12.0.jar",
-      "sha256": "715b6fef2fc9f73801e6efd7b9828b26a3bb002daf1ebb6a260164844d71a123"
+      "sha256": "ab36e2302aa48f79a52657289b614a90bb5b6a76dbc59d0ec43e646765c7f175"
     },
     {
       "module": "io",
@@ -33,13 +33,13 @@
     "legacy-java-compilation": "PASS",
     "legacy-kotlin-compilation": "PASS"
   },
-  "command": "bash scripts/check-serializer-buffer-abi.sh --build-current --expected-head 40fc6e6c8c499456ed9190f25796a2c21bb194d6",
+  "command": "bash scripts/check-serializer-buffer-abi.sh --build-current --expected-head 02abab67ea2e2627e7adce251160588432b20d69",
   "issue": 754,
-  "producerCommit": "40fc6e6c8c499456ed9190f25796a2c21bb194d6",
-  "producerTree": "48336cc22b099abaa610b02c8ac8f988a07ec445",
+  "producerCommit": "02abab67ea2e2627e7adce251160588432b20d69",
+  "producerTree": "ce24d517558d86a589ff4f6ea2cf19bbe0cf361c",
   "schemaVersion": 1,
   "slice": "contract",
   "status": "GREEN",
-  "testedCodeTreeSha256": "17b5b788e3e36ef25f923d4e86c0fff18d74e81f466be47823d96f03fa08c6fb",
+  "testedCodeTreeSha256": "e68b6cef451dac745009407eab61157997331f73575d9347b2748a6211cdddf6",
   "textReport": ".codex/compat/issue-754/90b267871e9154f242e6de7ee9fd0539f83e509e/abi-report.txt"
 }

--- a/docs/evidence/issue-754/contract/abi-report.json
+++ b/docs/evidence/issue-754/contract/abi-report.json
@@ -3,7 +3,7 @@
     {
       "module": "avro",
       "path": "io/avro/build/libs/bluetape4k-avro-1.12.0.jar",
-      "sha256": "cbe8615478f60859f06d0b770043535c28febf0e56fc3184cb5d6d0dfd6f7c27"
+      "sha256": "715b6fef2fc9f73801e6efd7b9828b26a3bb002daf1ebb6a260164844d71a123"
     },
     {
       "module": "io",
@@ -33,13 +33,13 @@
     "legacy-java-compilation": "PASS",
     "legacy-kotlin-compilation": "PASS"
   },
-  "command": "bash scripts/check-serializer-buffer-abi.sh --build-current --expected-head 3198fa3c8648033b2ae36bfd3fcecec42db23cdf",
+  "command": "bash scripts/check-serializer-buffer-abi.sh --build-current --expected-head 40fc6e6c8c499456ed9190f25796a2c21bb194d6",
   "issue": 754,
-  "producerCommit": "3198fa3c8648033b2ae36bfd3fcecec42db23cdf",
-  "producerTree": "c63492950369da2376453cf15ebab0c89a5192ea",
+  "producerCommit": "40fc6e6c8c499456ed9190f25796a2c21bb194d6",
+  "producerTree": "48336cc22b099abaa610b02c8ac8f988a07ec445",
   "schemaVersion": 1,
   "slice": "contract",
   "status": "GREEN",
-  "testedCodeTreeSha256": "a3dbf3040e1eaff0e6a499e6a7c26417fe6991ab2cef36f0e8ce48c5e4a82d77",
+  "testedCodeTreeSha256": "17b5b788e3e36ef25f923d4e86c0fff18d74e81f466be47823d96f03fa08c6fb",
   "textReport": ".codex/compat/issue-754/90b267871e9154f242e6de7ee9fd0539f83e509e/abi-report.txt"
 }

--- a/docs/lessons/2026-07-17-issue-1038-avro-serializer-bytebuffer.md
+++ b/docs/lessons/2026-07-17-issue-1038-avro-serializer-bytebuffer.md
@@ -1,0 +1,68 @@
+# Issue #1038: Avro serializer ByteBuffer paths
+
+## Context
+
+The Avro interfaces already exposed compatible `ByteBuffer` defaults, but those
+defaults copied through complete ByteArrays before reading or writing OCF data.
+Reflect, generic-record, specific-record, and list implementations needed direct
+stream routing without changing schema, codec, sync-marker, framing, null/empty,
+or caller-state behavior.
+
+## Decision
+
+- Write OCF data through a non-growing `ByteBufferOutputStream` over a duplicate
+  of the caller target, then commit the caller position only after writer close
+  succeeds.
+- Read OCF data with `DataFileStream` over a duplicate-backed
+  `ByteBufferInputStream`, preserving every caller-visible source property.
+- Tag overflow only when it originates in the fixed target stream. A datum
+  accessor may itself throw `BufferOverflowException`; that remains an ordinary
+  handled backend failure rather than a false target-capacity signal.
+- Preserve fatal errors found on the primary cause chain. Do not promote
+  suppressed cleanup failures over the primary backend failure.
+- Keep new handled-failure logs metadata-only so caller records are never
+  rendered.
+
+## Surprise / Failure
+
+The first overflow classifier searched the full primary cause chain for any
+`BufferOverflowException`. An independent Developer/API review showed that Avro
+wraps datum-writer failures, so a record accessor could be misreported as a full
+target buffer. A stream-bound signal separated target capacity from backend
+behavior and a RED regression test locked the distinction.
+
+The first SpecificRecord log copied the legacy `graph=$graph` diagnostic. That
+could evaluate caller `toString()` and expose record data. The regression test
+had to force both a real codec-close failure and ERROR-level lazy message
+evaluation; a throwing `toString()` alone was insufficient because the logging
+helper safely replaces message-render exceptions.
+
+The ABI script also intentionally refuses dirty serializer paths. The reliable
+sequence is implementation commit, clean-head ABI generation, evidence commit,
+and regeneration after every review-driven source fix.
+
+## Outcome
+
+All four Avro families now bypass the allocating ByteArray sibling methods for
+bounded buffer input and fixed output. OCF data cross-reads with legacy methods,
+configured codecs remain authoritative, caller state is preserved, failed calls
+remain reusable, and the compatibility report is bound to the reviewed code.
+
+## Verification
+
+- The focused contract suite covers direct/heap/sliced/read-only input,
+  exact-capacity output, overflow provenance, rollback, fatal identity, cleanup
+  failure, retry, schema mismatch, codecs, null/empty lists, malformed input,
+  sibling bypass, and caller-safe logging.
+- The complete Avro module reports 221 passing tests.
+- Legacy Java/Kotlin callers, implementation loading, JVM default dispatch,
+  public symbols, and frozen fixtures pass the exact-head ABI gate.
+- Root detekt is `NO-SOURCE`; Kotlin compilation, full tests, unsafe-pattern
+  scanning, and `git diff --check` provide the available static proof.
+
+## Future Guard
+
+Do not infer target capacity failure from an unqualified nested exception; mark
+the resource boundary that produced it. Do not log a serializer datum to explain
+a handled failure. Keep OCF comparisons semantic, and defer allocation or
+throughput claims until #1039 supplies repeatable benchmark evidence.

--- a/docs/review/2026-07-17-issue-1038-avro-serializer-bytebuffer-review.md
+++ b/docs/review/2026-07-17-issue-1038-avro-serializer-bytebuffer-review.md
@@ -1,0 +1,83 @@
+# Issue 1038 Avro Serializer ByteBuffer Review
+
+## Scope
+
+- Route reflect, generic-record, specific-record, and specific-list OCF paths
+  through caller-owned `ByteBuffer` streams.
+- Preserve existing ByteArray APIs, schemas, codecs, OCF framing, null/empty
+  policy, and caller buffer state.
+- Keep benchmark and measured allocation claims assigned to issue #1039.
+
+## Verifier Result
+
+`PASS`: the implementation matches the approved issue #754 design and Slice 4
+plan without expanding module, dependency, workflow, or release scope.
+
+| Requirement | Implementation or evidence |
+|---|---|
+| Bypass complete ByteArray sibling staging | Concrete overrides use fixed output and duplicate-backed input streams; MockK verifies zero sibling calls. |
+| Preserve OCF schema and codec behavior | Old/new cross-reading covers reflect, generic, specific, list, and null/deflate/snappy/zstd codecs. |
+| Preserve caller-owned state | Heap/direct/sliced/read-only input and non-zero output positions retain position, limit, order, and mark contracts. |
+| Preserve failure and cleanup policy | Raw target overflow, backend overflow, fatal identity, close/flush failure, rollback, retry, null, empty, and malformed paths are covered. |
+| Preserve compatibility | The tracked ABI report passes legacy Java/Kotlin compilation, implementation loading, default dispatch, public-symbol, and fixture checks. |
+| Exclude measured allocation claims | Only ByteArray sibling bypass and lower-copy routing are claimed; benchmarks remain in #1039. |
+
+## Perspective Review
+
+- Performance: explicit pre-close `flush()` calls were removed. Complete
+  ByteArray sibling staging is bypassed, but measured allocation improvement is
+  deliberately not claimed before #1039.
+- Stability: fixed-target overflow is tagged only at the target stream boundary;
+  backend `BufferOverflowException` retains the handled failure policy. Primary
+  backend failures remain primary and suppressed cleanup failures are not
+  promoted, as required by the approved design.
+- Security: deserialization keeps caller-bounded views and caller-supplied
+  schemas/classes. New SpecificRecord failure logging records only graph and
+  failure types and never renders the caller datum.
+- Ops: resources are owned by nested `use` scopes, caller position commits only
+  after success, and failed calls remain reusable. The final tracked ABI report
+  is bound to the reviewed implementation commit.
+- Developer/API: no public signature changed in this slice. English override
+  KDoc documents handled backend failures versus escaping target overflow and
+  fatal errors.
+- User/caller: null/empty behavior, exact-capacity output, heap/direct/sliced/
+  read-only input, schema mismatch, codecs, and old/new cross-reading match the
+  existing contract.
+
+## Resolved Findings
+
+- P1: stopped classifying every nested `BufferOverflowException` as target
+  capacity failure; only fixed-target stream overflow now escapes raw.
+- P1: removed caller datum rendering and full backend exception logging from the
+  new SpecificRecord handled-failure path.
+- P2: documented concrete handled-failure return policy in English KDoc.
+- P3: removed redundant explicit writer flushes before `DataFileWriter.close()`.
+
+## Dispositions
+
+- Two stability/Ops lanes proposed promoting suppressed cleanup errors over a
+  normal primary backend failure. This was rejected because the approved design
+  requires retaining the primary failure and attaching cleanup failures as
+  suppressed; the JSON predecessor records the same rule.
+- Failed output content is unspecified even though position is restored. This is
+  the inherited serializer contract.
+- Avro still owns internal OCF block buffers. This slice proves routing and
+  compatibility, not allocation counts or throughput.
+- README, CHANGELOG, benchmark tables, and public migration recommendations are
+  deferred to the approved Slice 5 issue #1039.
+
+## Verification
+
+- Targeted ByteBuffer contract suite: passing, including review regressions.
+- Complete `:bluetape4k-avro:test`: 221 passing.
+- `check-serializer-buffer-abi.sh --build-current`: passing at implementation
+  commit `02abab67e` with refreshed tracked evidence.
+- Root `detekt`: successful `NO-SOURCE`; the module has no separate detekt task.
+- Kotlin compilation and complete tests are the static-analysis fallback because
+  the available LSP diagnostic backend is TypeScript-only.
+- Production unsafe-concurrency diff scan and `git diff --check`: passing.
+
+## Final Gate
+
+Final integrated result: `APPROVE`, P0=0, P1=0. Remaining P2 allocation evidence
+is assigned to #1039 and does not block Slice 4 delivery.

--- a/docs/superpowers/plans/2026-07-16-issue-754-bytebuffer-serializer-stack-plan.md
+++ b/docs/superpowers/plans/2026-07-16-issue-754-bytebuffer-serializer-stack-plan.md
@@ -28,7 +28,7 @@ PR head after CI and review pass.
 | corrective | `fix/issue-754-remove-release-scope` | Remove unauthorized release/settings coupling | Merged via PR #1034 |
 | 2 | `feat/issue-754-core-serializers` | JDK, Kryo, Fory lower-copy paths | Merged via PR #1040 |
 | 3 | `feat/issue-754-json-serializers` | Jackson 2/3 and Fastjson2 | Merged via PR #1042 |
-| 4 | `feat/issue-754-avro-serializers` | Reflect, generic, specific/list | Current; base `e89bf724fd018af8c2ab4564a5c9a007fe27b46a` |
+| 4 | `feat/issue-754-avro-serializers` | Reflect, generic, specific/list | Implemented and verified; PR pending; base `e89bf724fd018af8c2ab4564a5c9a007fe27b46a` |
 | 5 | `feat/issue-754-allocation-proof` | Benchmarks, allocation evidence, docs | Pending |
 
 ## Slice 1: Contract And Compatibility

--- a/docs/superpowers/plans/2026-07-16-issue-754-bytebuffer-serializer-stack-plan.md
+++ b/docs/superpowers/plans/2026-07-16-issue-754-bytebuffer-serializer-stack-plan.md
@@ -27,8 +27,8 @@ PR head after CI and review pass.
 | 1 | `feat/issue-754-buffer-contract` | API defaults, fixed-buffer contract, ABI fixtures | Merged via PR #1031 |
 | corrective | `fix/issue-754-remove-release-scope` | Remove unauthorized release/settings coupling | Merged via PR #1034 |
 | 2 | `feat/issue-754-core-serializers` | JDK, Kryo, Fory lower-copy paths | Merged via PR #1040 |
-| 3 | `feat/issue-754-json-serializers` | Jackson 2/3 and Fastjson2 | Current; base `7459b84cb976a349e1bbc03fefb36d4ca50d02ee` |
-| 4 | `feat/issue-754-avro-serializers` | Reflect, generic, specific/list | Pending |
+| 3 | `feat/issue-754-json-serializers` | Jackson 2/3 and Fastjson2 | Merged via PR #1042 |
+| 4 | `feat/issue-754-avro-serializers` | Reflect, generic, specific/list | Current; base `e89bf724fd018af8c2ab4564a5c9a007fe27b46a` |
 | 5 | `feat/issue-754-allocation-proof` | Benchmarks, allocation evidence, docs | Pending |
 
 ## Slice 1: Contract And Compatibility

--- a/io/avro/src/main/kotlin/io/bluetape4k/avro/BufferSerializationDefaults.kt
+++ b/io/avro/src/main/kotlin/io/bluetape4k/avro/BufferSerializationDefaults.kt
@@ -1,5 +1,7 @@
 package io.bluetape4k.avro
 
+import io.bluetape4k.io.ByteBufferOutputStream
+import java.io.OutputStream
 import java.nio.BufferOverflowException
 import java.nio.ByteBuffer
 import java.nio.ReadOnlyBufferException
@@ -32,3 +34,37 @@ internal inline fun serializeNullableTo(
 
 internal fun copyRemaining(source: ByteBuffer): ByteArray =
     ByteArray(source.remaining()).also { source.duplicate().get(it) }
+
+internal inline fun writeToFixedBuffer(
+    target: ByteBuffer,
+    write: (OutputStream) -> Unit,
+): Int {
+    if (target.isReadOnly) throw ReadOnlyBufferException()
+
+    val start = target.position()
+    val view = target.duplicate()
+    return try {
+        ByteBufferOutputStream.fixed(view).use(write)
+        val written = view.position() - start
+        target.position(start + written)
+        written
+    } catch (failure: Throwable) {
+        target.position(start)
+        throw failure.forBufferPath()
+    }
+}
+
+internal fun Throwable.forBufferPath(): Throwable {
+    var current: Throwable? = this
+    var overflow: BufferOverflowException? = null
+    var depth = 0
+    while (current != null && depth++ < 64) {
+        if (current is Error) return current
+        if (overflow == null && current is BufferOverflowException) overflow = current
+        current = current.cause?.takeUnless { it === current }
+    }
+    return overflow?.let {
+        if (it === this) it
+        else BufferOverflowException().apply { initCause(this@forBufferPath) }
+    } ?: this
+}

--- a/io/avro/src/main/kotlin/io/bluetape4k/avro/BufferSerializationDefaults.kt
+++ b/io/avro/src/main/kotlin/io/bluetape4k/avro/BufferSerializationDefaults.kt
@@ -1,6 +1,8 @@
 package io.bluetape4k.avro
 
 import io.bluetape4k.io.ByteBufferOutputStream
+import java.io.FilterOutputStream
+import java.io.IOException
 import java.io.OutputStream
 import java.nio.BufferOverflowException
 import java.nio.ByteBuffer
@@ -44,27 +46,48 @@ internal inline fun writeToFixedBuffer(
     val start = target.position()
     val view = target.duplicate()
     return try {
-        ByteBufferOutputStream.fixed(view).use(write)
+        FixedTargetOutputStream(ByteBufferOutputStream.fixed(view)).use(write)
         val written = view.position() - start
         target.position(start + written)
         written
     } catch (failure: Throwable) {
         target.position(start)
-        throw failure.forBufferPath()
+        throw failure
     }
 }
 
-internal fun Throwable.forBufferPath(): Throwable {
+internal fun Throwable.escapingBufferFailure(): Throwable? {
     var current: Throwable? = this
-    var overflow: BufferOverflowException? = null
+    var targetOverflow = false
     var depth = 0
     while (current != null && depth++ < 64) {
         if (current is Error) return current
-        if (overflow == null && current is BufferOverflowException) overflow = current
+        if (current is FixedTargetOverflowSignal) targetOverflow = true
         current = current.cause?.takeUnless { it === current }
     }
-    return overflow?.let {
-        if (it === this) it
-        else BufferOverflowException().apply { initCause(this@forBufferPath) }
-    } ?: this
+    return if (targetOverflow) {
+        BufferOverflowException().apply { initCause(this@escapingBufferFailure) }
+    } else {
+        null
+    }
 }
+
+internal class FixedTargetOutputStream(
+    output: OutputStream,
+): FilterOutputStream(output) {
+
+    override fun write(b: Int) = translateOverflow { super.write(b) }
+
+    override fun write(b: ByteArray, off: Int, len: Int) =
+        translateOverflow { super.write(b, off, len) }
+
+    private inline fun translateOverflow(write: () -> Unit) {
+        try {
+            write()
+        } catch (failure: BufferOverflowException) {
+            throw FixedTargetOverflowSignal(failure)
+        }
+    }
+}
+
+private class FixedTargetOverflowSignal(cause: BufferOverflowException): IOException(cause)

--- a/io/avro/src/main/kotlin/io/bluetape4k/avro/impl/DefaultAvroGenericRecordSerializer.kt
+++ b/io/avro/src/main/kotlin/io/bluetape4k/avro/impl/DefaultAvroGenericRecordSerializer.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.avro.impl
 
 import io.bluetape4k.avro.AvroGenericRecordSerializer
 import io.bluetape4k.avro.DEFAULT_CODEC_FACTORY
+import io.bluetape4k.avro.escapingBufferFailure
 import io.bluetape4k.avro.writeToFixedBuffer
 import io.bluetape4k.io.ByteBufferInputStream
 import io.bluetape4k.logging.KLogging
@@ -17,7 +18,6 @@ import org.apache.avro.generic.GenericDatumReader
 import org.apache.avro.generic.GenericDatumWriter
 import org.apache.avro.generic.GenericRecord
 import java.io.ByteArrayOutputStream
-import java.nio.BufferOverflowException
 import java.nio.ByteBuffer
 import java.nio.ReadOnlyBufferException
 
@@ -99,6 +99,10 @@ class DefaultAvroGenericRecordSerializer private constructor(
         }
     }
 
+    /**
+     * Writes an Avro OCF record directly into [target]. Handled backend failures are logged and return `0`, matching
+     * this implementation's nullable ByteArray policy. Fixed-target overflow and fatal JVM errors escape to callers.
+     */
     override fun serializeTo(schema: Schema, graph: GenericRecord?, target: ByteBuffer): Int {
         if (target.isReadOnly) throw ReadOnlyBufferException()
         if (graph == null) return 0
@@ -109,20 +113,12 @@ class DefaultAvroGenericRecordSerializer private constructor(
                 DataFileWriter(datumWriter).setCodec(codecFactory).use { writer ->
                     writer.create(schema, output)
                     writer.append(graph)
-                    writer.flush()
                 }
             }
         } catch (failure: Throwable) {
-            when (failure) {
-                is Error,
-                is BufferOverflowException,
-                is ReadOnlyBufferException,
-                -> throw failure
-                else -> {
-                    log.error(failure) { "GenericRecord ByteBuffer 직렬화에 실패했습니다. schema=${schema.name}" }
-                    0
-                }
-            }
+            failure.escapingBufferFailure()?.let { throw it }
+            log.error(failure) { "GenericRecord ByteBuffer 직렬화에 실패했습니다. schema=${schema.name}" }
+            0
         }
     }
 

--- a/io/avro/src/main/kotlin/io/bluetape4k/avro/impl/DefaultAvroGenericRecordSerializer.kt
+++ b/io/avro/src/main/kotlin/io/bluetape4k/avro/impl/DefaultAvroGenericRecordSerializer.kt
@@ -2,11 +2,14 @@ package io.bluetape4k.avro.impl
 
 import io.bluetape4k.avro.AvroGenericRecordSerializer
 import io.bluetape4k.avro.DEFAULT_CODEC_FACTORY
+import io.bluetape4k.avro.writeToFixedBuffer
+import io.bluetape4k.io.ByteBufferInputStream
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
 import org.apache.avro.Schema
 import org.apache.avro.file.CodecFactory
 import org.apache.avro.file.DataFileReader
+import org.apache.avro.file.DataFileStream
 import org.apache.avro.file.DataFileWriter
 import org.apache.avro.file.SeekableByteArrayInput
 import org.apache.avro.generic.GenericData
@@ -14,6 +17,9 @@ import org.apache.avro.generic.GenericDatumReader
 import org.apache.avro.generic.GenericDatumWriter
 import org.apache.avro.generic.GenericRecord
 import java.io.ByteArrayOutputStream
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+import java.nio.ReadOnlyBufferException
 
 /**
  * [AvroGenericRecordSerializer]의 기본 구현체입니다.
@@ -93,6 +99,33 @@ class DefaultAvroGenericRecordSerializer private constructor(
         }
     }
 
+    override fun serializeTo(schema: Schema, graph: GenericRecord?, target: ByteBuffer): Int {
+        if (target.isReadOnly) throw ReadOnlyBufferException()
+        if (graph == null) return 0
+
+        return try {
+            val datumWriter = GenericDatumWriter<GenericRecord>(schema)
+            writeToFixedBuffer(target) { output ->
+                DataFileWriter(datumWriter).setCodec(codecFactory).use { writer ->
+                    writer.create(schema, output)
+                    writer.append(graph)
+                    writer.flush()
+                }
+            }
+        } catch (failure: Throwable) {
+            when (failure) {
+                is Error,
+                is BufferOverflowException,
+                is ReadOnlyBufferException,
+                -> throw failure
+                else -> {
+                    log.error(failure) { "GenericRecord ByteBuffer 직렬화에 실패했습니다. schema=${schema.name}" }
+                    0
+                }
+            }
+        }
+    }
+
     /**
      * Avro 바이트 배열을 [GenericData.Record]로 역직렬화합니다.
      *
@@ -125,6 +158,20 @@ class DefaultAvroGenericRecordSerializer private constructor(
             }
         } catch (e: Throwable) {
             log.error(e) { "GenericRecord 역직렬화에 실패했습니다. schema=${schema.name}" }
+            null
+        }
+    }
+
+    override fun deserializeFrom(schema: Schema, source: ByteBuffer): GenericData.Record? {
+        return try {
+            val datumReader = GenericDatumReader<GenericData.Record>(schema)
+            DataFileStream(ByteBufferInputStream(source.duplicate()), datumReader).use { reader ->
+                if (reader.hasNext()) reader.next()
+                else null
+            }
+        } catch (failure: Throwable) {
+            if (failure is Error) throw failure
+            log.error(failure) { "GenericRecord ByteBuffer 역직렬화에 실패했습니다. schema=${schema.name}, size=${source.remaining()}" }
             null
         }
     }

--- a/io/avro/src/main/kotlin/io/bluetape4k/avro/impl/DefaultAvroReflectSerializer.kt
+++ b/io/avro/src/main/kotlin/io/bluetape4k/avro/impl/DefaultAvroReflectSerializer.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.avro.impl
 
 import io.bluetape4k.avro.AvroReflectSerializer
 import io.bluetape4k.avro.DEFAULT_CODEC_FACTORY
+import io.bluetape4k.avro.escapingBufferFailure
 import io.bluetape4k.avro.writeToFixedBuffer
 import io.bluetape4k.io.ByteBufferInputStream
 import io.bluetape4k.logging.KLogging
@@ -15,7 +16,6 @@ import org.apache.avro.reflect.ReflectData
 import org.apache.avro.reflect.ReflectDatumReader
 import org.apache.avro.reflect.ReflectDatumWriter
 import java.io.ByteArrayOutputStream
-import java.nio.BufferOverflowException
 import java.nio.ByteBuffer
 import java.nio.ReadOnlyBufferException
 import java.util.concurrent.ConcurrentHashMap
@@ -104,6 +104,10 @@ class DefaultAvroReflectSerializer private constructor(
         }
     }
 
+    /**
+     * Writes an Avro OCF record directly into [target]. Handled backend failures are logged and return `0`, matching
+     * this implementation's nullable ByteArray policy. Fixed-target overflow and fatal JVM errors escape to callers.
+     */
     override fun <T> serializeTo(graph: T?, target: ByteBuffer): Int {
         if (target.isReadOnly) throw ReadOnlyBufferException()
         if (graph == null) return 0
@@ -115,20 +119,12 @@ class DefaultAvroReflectSerializer private constructor(
                 DataFileWriter(datumWriter).setCodec(codecFactory).use { writer ->
                     writer.create(schema, output)
                     writer.append(graph)
-                    writer.flush()
                 }
             }
         } catch (failure: Throwable) {
-            when (failure) {
-                is Error,
-                is BufferOverflowException,
-                is ReadOnlyBufferException,
-                -> throw failure
-                else -> {
-                    log.error(failure) { "Reflect 기반 ByteBuffer 직렬화에 실패했습니다. clazz=${graph.javaClass.name}" }
-                    0
-                }
-            }
+            failure.escapingBufferFailure()?.let { throw it }
+            log.error(failure) { "Reflect 기반 ByteBuffer 직렬화에 실패했습니다. clazz=${graph.javaClass.name}" }
+            0
         }
     }
 

--- a/io/avro/src/main/kotlin/io/bluetape4k/avro/impl/DefaultAvroReflectSerializer.kt
+++ b/io/avro/src/main/kotlin/io/bluetape4k/avro/impl/DefaultAvroReflectSerializer.kt
@@ -2,16 +2,22 @@ package io.bluetape4k.avro.impl
 
 import io.bluetape4k.avro.AvroReflectSerializer
 import io.bluetape4k.avro.DEFAULT_CODEC_FACTORY
+import io.bluetape4k.avro.writeToFixedBuffer
+import io.bluetape4k.io.ByteBufferInputStream
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
 import org.apache.avro.file.CodecFactory
 import org.apache.avro.file.DataFileReader
+import org.apache.avro.file.DataFileStream
 import org.apache.avro.file.DataFileWriter
 import org.apache.avro.file.SeekableByteArrayInput
 import org.apache.avro.reflect.ReflectData
 import org.apache.avro.reflect.ReflectDatumReader
 import org.apache.avro.reflect.ReflectDatumWriter
 import java.io.ByteArrayOutputStream
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+import java.nio.ReadOnlyBufferException
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -98,6 +104,34 @@ class DefaultAvroReflectSerializer private constructor(
         }
     }
 
+    override fun <T> serializeTo(graph: T?, target: ByteBuffer): Int {
+        if (target.isReadOnly) throw ReadOnlyBufferException()
+        if (graph == null) return 0
+
+        return try {
+            val schema = schemaOf(graph.javaClass)
+            val datumWriter = ReflectDatumWriter<T>(schema)
+            writeToFixedBuffer(target) { output ->
+                DataFileWriter(datumWriter).setCodec(codecFactory).use { writer ->
+                    writer.create(schema, output)
+                    writer.append(graph)
+                    writer.flush()
+                }
+            }
+        } catch (failure: Throwable) {
+            when (failure) {
+                is Error,
+                is BufferOverflowException,
+                is ReadOnlyBufferException,
+                -> throw failure
+                else -> {
+                    log.error(failure) { "Reflect 기반 ByteBuffer 직렬화에 실패했습니다. clazz=${graph.javaClass.name}" }
+                    0
+                }
+            }
+        }
+    }
+
     /**
      * Avro 바이트 배열을 지정 타입으로 역직렬화합니다.
      *
@@ -130,6 +164,21 @@ class DefaultAvroReflectSerializer private constructor(
             }
         } catch (e: Throwable) {
             log.error(e) { "Reflect 기반 역직렬화에 실패했습니다. clazz=${clazz.name}, size=${avroBytes.size}" }
+            null
+        }
+    }
+
+    override fun <T> deserializeFrom(source: ByteBuffer, clazz: Class<T>): T? {
+        return try {
+            val schema = schemaOf(clazz)
+            val datumReader = ReflectDatumReader<T>(schema, schema)
+            DataFileStream(ByteBufferInputStream(source.duplicate()), datumReader).use { reader ->
+                if (reader.hasNext()) reader.next()
+                else null
+            }
+        } catch (failure: Throwable) {
+            if (failure is Error) throw failure
+            log.error(failure) { "Reflect 기반 ByteBuffer 역직렬화에 실패했습니다. clazz=${clazz.name}, size=${source.remaining()}" }
             null
         }
     }

--- a/io/avro/src/main/kotlin/io/bluetape4k/avro/impl/DefaultAvroSpecificRecordSerializer.kt
+++ b/io/avro/src/main/kotlin/io/bluetape4k/avro/impl/DefaultAvroSpecificRecordSerializer.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.avro.impl
 
 import io.bluetape4k.avro.AvroSpecificRecordSerializer
 import io.bluetape4k.avro.DEFAULT_CODEC_FACTORY
+import io.bluetape4k.avro.escapingBufferFailure
 import io.bluetape4k.avro.writeToFixedBuffer
 import io.bluetape4k.io.ByteBufferInputStream
 import io.bluetape4k.logging.KLogging
@@ -16,7 +17,6 @@ import org.apache.avro.specific.SpecificDatumReader
 import org.apache.avro.specific.SpecificDatumWriter
 import org.apache.avro.specific.SpecificRecord
 import java.io.ByteArrayOutputStream
-import java.nio.BufferOverflowException
 import java.nio.ByteBuffer
 import java.nio.ReadOnlyBufferException
 
@@ -98,6 +98,10 @@ class DefaultAvroSpecificRecordSerializer private constructor(
         }
     }
 
+    /**
+     * Writes one Avro OCF record directly into [target]. Handled backend failures are logged and return `0`, matching
+     * this implementation's nullable ByteArray policy. Fixed-target overflow and fatal JVM errors escape to callers.
+     */
     override fun <T: SpecificRecord> serializeTo(graph: T?, target: ByteBuffer): Int {
         if (target.isReadOnly) throw ReadOnlyBufferException()
         if (graph == null) return 0
@@ -108,20 +112,12 @@ class DefaultAvroSpecificRecordSerializer private constructor(
                 DataFileWriter(datumWriter).setCodec(codecFactory).use { writer ->
                     writer.create(graph.schema, output)
                     writer.append(graph)
-                    writer.flush()
                 }
             }
         } catch (failure: Throwable) {
-            when (failure) {
-                is Error,
-                is BufferOverflowException,
-                is ReadOnlyBufferException,
-                -> throw failure
-                else -> {
-                    log.error(failure) { "SpecificRecord ByteBuffer 직렬화에 실패했습니다. graph=$graph" }
-                    0
-                }
-            }
+            failure.escapingBufferFailure()?.let { throw it }
+            log.error(failure) { "SpecificRecord ByteBuffer 직렬화에 실패했습니다. graph=$graph" }
+            0
         }
     }
 
@@ -162,6 +158,10 @@ class DefaultAvroSpecificRecordSerializer private constructor(
         }
     }
 
+    /**
+     * Writes an Avro OCF record list directly into [target]. Handled backend failures are logged and return `0`,
+     * matching this implementation's nullable ByteArray policy. Fixed-target overflow and fatal JVM errors escape.
+     */
     override fun <T: SpecificRecord> serializeListTo(collection: List<T>?, target: ByteBuffer): Int {
         if (target.isReadOnly) throw ReadOnlyBufferException()
         if (collection.isNullOrEmpty()) return 0
@@ -173,20 +173,12 @@ class DefaultAvroSpecificRecordSerializer private constructor(
                 DataFileWriter(datumWriter).setCodec(codecFactory).use { writer ->
                     writer.create(schema, output)
                     collection.forEach(writer::append)
-                    writer.flush()
                 }
             }
         } catch (failure: Throwable) {
-            when (failure) {
-                is Error,
-                is BufferOverflowException,
-                is ReadOnlyBufferException,
-                -> throw failure
-                else -> {
-                    log.error(failure) { "SpecificRecord 리스트 ByteBuffer 직렬화에 실패했습니다. size=${collection.size}" }
-                    0
-                }
-            }
+            failure.escapingBufferFailure()?.let { throw it }
+            log.error(failure) { "SpecificRecord 리스트 ByteBuffer 직렬화에 실패했습니다. size=${collection.size}" }
+            0
         }
     }
 

--- a/io/avro/src/main/kotlin/io/bluetape4k/avro/impl/DefaultAvroSpecificRecordSerializer.kt
+++ b/io/avro/src/main/kotlin/io/bluetape4k/avro/impl/DefaultAvroSpecificRecordSerializer.kt
@@ -116,7 +116,9 @@ class DefaultAvroSpecificRecordSerializer private constructor(
             }
         } catch (failure: Throwable) {
             failure.escapingBufferFailure()?.let { throw it }
-            log.error(failure) { "SpecificRecord ByteBuffer 직렬화에 실패했습니다. graph=$graph" }
+            val graphType = graph.javaClass.name
+            val failureType = failure.javaClass.name
+            log.error { "SpecificRecord ByteBuffer 직렬화에 실패했습니다. graphType=$graphType, failureType=$failureType" }
             0
         }
     }

--- a/io/avro/src/main/kotlin/io/bluetape4k/avro/impl/DefaultAvroSpecificRecordSerializer.kt
+++ b/io/avro/src/main/kotlin/io/bluetape4k/avro/impl/DefaultAvroSpecificRecordSerializer.kt
@@ -2,17 +2,23 @@ package io.bluetape4k.avro.impl
 
 import io.bluetape4k.avro.AvroSpecificRecordSerializer
 import io.bluetape4k.avro.DEFAULT_CODEC_FACTORY
+import io.bluetape4k.avro.writeToFixedBuffer
+import io.bluetape4k.io.ByteBufferInputStream
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
 import io.bluetape4k.support.isNullOrEmpty
 import org.apache.avro.file.CodecFactory
 import org.apache.avro.file.DataFileReader
+import org.apache.avro.file.DataFileStream
 import org.apache.avro.file.DataFileWriter
 import org.apache.avro.file.SeekableByteArrayInput
 import org.apache.avro.specific.SpecificDatumReader
 import org.apache.avro.specific.SpecificDatumWriter
 import org.apache.avro.specific.SpecificRecord
 import java.io.ByteArrayOutputStream
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+import java.nio.ReadOnlyBufferException
 
 /**
  * [AvroSpecificRecordSerializer]의 기본 구현체입니다.
@@ -92,6 +98,33 @@ class DefaultAvroSpecificRecordSerializer private constructor(
         }
     }
 
+    override fun <T: SpecificRecord> serializeTo(graph: T?, target: ByteBuffer): Int {
+        if (target.isReadOnly) throw ReadOnlyBufferException()
+        if (graph == null) return 0
+
+        return try {
+            val datumWriter = SpecificDatumWriter<T>(graph.schema)
+            writeToFixedBuffer(target) { output ->
+                DataFileWriter(datumWriter).setCodec(codecFactory).use { writer ->
+                    writer.create(graph.schema, output)
+                    writer.append(graph)
+                    writer.flush()
+                }
+            }
+        } catch (failure: Throwable) {
+            when (failure) {
+                is Error,
+                is BufferOverflowException,
+                is ReadOnlyBufferException,
+                -> throw failure
+                else -> {
+                    log.error(failure) { "SpecificRecord ByteBuffer 직렬화에 실패했습니다. graph=$graph" }
+                    0
+                }
+            }
+        }
+    }
+
     /**
      * `SpecificRecord` 리스트를 Avro 바이트 배열로 직렬화합니다.
      *
@@ -126,6 +159,34 @@ class DefaultAvroSpecificRecordSerializer private constructor(
         } catch (e: Throwable) {
             log.error(e) { "SpecificRecord 리스트 직렬화에 실패했습니다. size=${collection.size}" }
             null
+        }
+    }
+
+    override fun <T: SpecificRecord> serializeListTo(collection: List<T>?, target: ByteBuffer): Int {
+        if (target.isReadOnly) throw ReadOnlyBufferException()
+        if (collection.isNullOrEmpty()) return 0
+
+        return try {
+            val schema = collection.first().schema
+            val datumWriter = SpecificDatumWriter<T>(schema)
+            writeToFixedBuffer(target) { output ->
+                DataFileWriter(datumWriter).setCodec(codecFactory).use { writer ->
+                    writer.create(schema, output)
+                    collection.forEach(writer::append)
+                    writer.flush()
+                }
+            }
+        } catch (failure: Throwable) {
+            when (failure) {
+                is Error,
+                is BufferOverflowException,
+                is ReadOnlyBufferException,
+                -> throw failure
+                else -> {
+                    log.error(failure) { "SpecificRecord 리스트 ByteBuffer 직렬화에 실패했습니다. size=${collection.size}" }
+                    0
+                }
+            }
         }
     }
 
@@ -165,6 +226,20 @@ class DefaultAvroSpecificRecordSerializer private constructor(
         }
     }
 
+    override fun <T: SpecificRecord> deserializeFrom(source: ByteBuffer, clazz: Class<T>): T? {
+        return try {
+            val datumReader = SpecificDatumReader<T>(clazz)
+            DataFileStream(ByteBufferInputStream(source.duplicate()), datumReader).use { reader ->
+                if (reader.hasNext()) reader.next()
+                else null
+            }
+        } catch (failure: Throwable) {
+            if (failure is Error) throw failure
+            log.error(failure) { "SpecificRecord ByteBuffer 역직렬화에 실패했습니다. clazz=${clazz.name}" }
+            null
+        }
+    }
+
     /**
      * Avro 바이트 배열을 `SpecificRecord` 리스트로 역직렬화합니다.
      *
@@ -199,6 +274,25 @@ class DefaultAvroSpecificRecordSerializer private constructor(
             result
         } catch (e: Throwable) {
             log.error(e) { "SpecificRecord 리스트 역직렬화에 실패했습니다. clazz=${clazz.name}" }
+            emptyList()
+        }
+    }
+
+    override fun <T: SpecificRecord> deserializeListFrom(source: ByteBuffer, clazz: Class<T>): List<T> {
+        if (!source.hasRemaining()) return emptyList()
+
+        return try {
+            val result = mutableListOf<T>()
+            val datumReader = SpecificDatumReader<T>(clazz)
+            DataFileStream(ByteBufferInputStream(source.duplicate()), datumReader).use { reader ->
+                while (reader.hasNext()) {
+                    result.add(reader.next())
+                }
+            }
+            result
+        } catch (failure: Throwable) {
+            if (failure is Error) throw failure
+            log.error(failure) { "SpecificRecord 리스트 ByteBuffer 역직렬화에 실패했습니다. clazz=${clazz.name}" }
             emptyList()
         }
     }

--- a/io/avro/src/test/kotlin/io/bluetape4k/avro/impl/DefaultAvroSerializerByteBufferTest.kt
+++ b/io/avro/src/test/kotlin/io/bluetape4k/avro/impl/DefaultAvroSerializerByteBufferTest.kt
@@ -7,6 +7,7 @@ import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.avro.TestMessageProvider
 import io.bluetape4k.avro.message.examples.Employee
+import io.mockk.every
 import io.mockk.spyk
 import io.mockk.verify
 import org.apache.avro.Schema
@@ -132,6 +133,18 @@ class DefaultAvroSerializerByteBufferTest {
         target.limit(target.capacity())
         serializer.serializeTo(employee, target) shouldBeEqualTo legacyWire.size
         verify(exactly = 0) { serializer.serialize(any<Employee>()) }
+    }
+
+    @Test
+    fun `backend buffer overflow keeps the established handled failure policy`() {
+        val record = spyk(TestMessageProvider.createEmployee())
+        every { record.get(any<Int>()) } throws BufferOverflowException()
+        val serializer = DefaultAvroGenericRecordSerializer()
+        val target = ByteBuffer.allocate(4096).apply { position(7) }
+
+        serializer.serializeTo(Employee.getClassSchema(), record, target) shouldBeEqualTo 0
+
+        target.position() shouldBeEqualTo 7
     }
 
     @Test

--- a/io/avro/src/test/kotlin/io/bluetape4k/avro/impl/DefaultAvroSerializerByteBufferTest.kt
+++ b/io/avro/src/test/kotlin/io/bluetape4k/avro/impl/DefaultAvroSerializerByteBufferTest.kt
@@ -1,5 +1,7 @@
 package io.bluetape4k.avro.impl
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeEqualTo
@@ -15,6 +17,7 @@ import org.apache.avro.file.Codec
 import org.apache.avro.file.CodecFactory
 import org.apache.avro.generic.GenericRecord
 import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
 import java.io.IOException
 import java.nio.BufferOverflowException
 import java.nio.ByteBuffer
@@ -145,6 +148,30 @@ class DefaultAvroSerializerByteBufferTest {
         serializer.serializeTo(Employee.getClassSchema(), record, target) shouldBeEqualTo 0
 
         target.position() shouldBeEqualTo 7
+    }
+
+    @Test
+    fun `handled failure logging does not render the caller record`() {
+        val record = spyk(TestMessageProvider.createEmployee())
+        val rendered = AtomicBoolean(false)
+        every { record.toString() } answers {
+            rendered.set(true)
+            "secret caller record"
+        }
+        val codec = codecFactory { passThroughCodec { throw IOException("backend failed") } }
+        val target = ByteBuffer.allocate(4096).apply { position(9) }
+        val logger = LoggerFactory.getLogger(DefaultAvroSpecificRecordSerializer.Companion::class.java) as Logger
+        val originalLevel = logger.level
+
+        try {
+            logger.level = Level.ERROR
+            DefaultAvroSpecificRecordSerializer(codec).serializeTo(record, target) shouldBeEqualTo 0
+        } finally {
+            logger.level = originalLevel
+        }
+
+        target.position() shouldBeEqualTo 9
+        rendered.get() shouldBeEqualTo false
     }
 
     @Test

--- a/io/avro/src/test/kotlin/io/bluetape4k/avro/impl/DefaultAvroSerializerByteBufferTest.kt
+++ b/io/avro/src/test/kotlin/io/bluetape4k/avro/impl/DefaultAvroSerializerByteBufferTest.kt
@@ -1,0 +1,291 @@
+package io.bluetape4k.avro.impl
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEmpty
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.avro.TestMessageProvider
+import io.bluetape4k.avro.message.examples.Employee
+import io.mockk.spyk
+import io.mockk.verify
+import org.apache.avro.Schema
+import org.apache.avro.file.Codec
+import org.apache.avro.file.CodecFactory
+import org.apache.avro.generic.GenericRecord
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.ReadOnlyBufferException
+import java.util.concurrent.atomic.AtomicBoolean
+
+class DefaultAvroSerializerByteBufferTest {
+
+    @Test
+    fun `reflect ByteBuffer paths bypass ByteArray siblings and preserve caller state`() {
+        val employee = TestMessageProvider.createEmployee()
+        val baseline = DefaultAvroReflectSerializer()
+        val legacyWire = baseline.serialize(employee)!!
+        val serializer = spyk(DefaultAvroReflectSerializer())
+        val target = boundedTarget(legacyWire.size, direct = true)
+
+        val written = serializer.serializeTo(employee, target)
+
+        written shouldBeEqualTo legacyWire.size
+        target.position() shouldBeEqualTo 2 + written
+        target.limit() shouldBeEqualTo 2 + legacyWire.size
+        target.order() shouldBeEqualTo ByteOrder.LITTLE_ENDIAN
+        verify(exactly = 0) { serializer.serialize(any<Employee>()) }
+
+        sourceVariants(legacyWire).forEach { source ->
+            val position = source.position()
+            val limit = source.limit()
+            val order = source.order()
+            source.mark()
+
+            serializer.deserializeFrom(source, Employee::class.java) shouldBeEqualTo employee
+
+            source.position() shouldBeEqualTo position
+            source.limit() shouldBeEqualTo limit
+            source.order() shouldBeEqualTo order
+            source.reset()
+        }
+        verify(exactly = 0) { serializer.deserialize(any<ByteArray>(), Employee::class.java) }
+
+        baseline.deserialize(target.writtenBytes(2, written), Employee::class.java) shouldBeEqualTo employee
+    }
+
+    @Test
+    fun `generic ByteBuffer paths bypass ByteArray siblings and retain schema policy`() {
+        val employee = TestMessageProvider.createEmployee()
+        val schema = Employee.getClassSchema()
+        val baseline = DefaultAvroGenericRecordSerializer()
+        val legacyWire = baseline.serialize(schema, employee)!!
+        val serializer = spyk(DefaultAvroGenericRecordSerializer())
+        val target = boundedTarget(legacyWire.size, direct = false)
+
+        val written = serializer.serializeTo(schema, employee, target)
+
+        written shouldBeEqualTo legacyWire.size
+        verify(exactly = 0) { serializer.serialize(schema, any<GenericRecord>()) }
+        serializer.deserializeFrom(schema, ByteBuffer.wrap(target.writtenBytes(2, written))).toString() shouldBeEqualTo
+                employee.toString()
+        verify(exactly = 0) { serializer.deserialize(schema, any<ByteArray>()) }
+
+        val mismatched = Schema.create(Schema.Type.STRING)
+        val source = ByteBuffer.wrap(legacyWire).order(ByteOrder.LITTLE_ENDIAN)
+        source.mark()
+        serializer.deserializeFrom(mismatched, source).shouldBeNull()
+        source.position() shouldBeEqualTo 0
+        source.limit() shouldBeEqualTo legacyWire.size
+        source.order() shouldBeEqualTo ByteOrder.LITTLE_ENDIAN
+        source.reset()
+        verify(exactly = 0) { serializer.deserialize(mismatched, any<ByteArray>()) }
+    }
+
+    @Test
+    fun `specific record and list ByteBuffer paths bypass ByteArray siblings`() {
+        val employees = List(3) { TestMessageProvider.createEmployee() }
+        val employee = employees.first()
+        val baseline = DefaultAvroSpecificRecordSerializer()
+        val singleWire = baseline.serialize(employee)!!
+        val listWire = baseline.serializeList(employees)!!
+        val serializer = spyk(DefaultAvroSpecificRecordSerializer())
+
+        val singleTarget = boundedTarget(singleWire.size, direct = true)
+        val singleWritten = serializer.serializeTo(employee, singleTarget)
+        serializer.deserializeFrom(
+            ByteBuffer.wrap(singleTarget.writtenBytes(2, singleWritten)),
+            Employee::class.java,
+        ) shouldBeEqualTo employee
+
+        val listTarget = boundedTarget(listWire.size, direct = false)
+        val listWritten = serializer.serializeListTo(employees, listTarget)
+        serializer.deserializeListFrom(
+            ByteBuffer.wrap(listTarget.writtenBytes(2, listWritten)),
+            Employee::class.java,
+        ) shouldBeEqualTo employees
+
+        verify(exactly = 0) { serializer.serialize(any<Employee>()) }
+        verify(exactly = 0) { serializer.deserialize(any<ByteArray>(), Employee::class.java) }
+        verify(exactly = 0) { serializer.serializeList(any<List<Employee>>()) }
+        verify(exactly = 0) { serializer.deserializeList(any<ByteArray>(), Employee::class.java) }
+    }
+
+    @Test
+    fun `fixed output overflow restores position and remains reusable`() {
+        val employee = TestMessageProvider.createEmployee()
+        val baseline = DefaultAvroSpecificRecordSerializer()
+        val legacyWire = baseline.serialize(employee)!!
+        val serializer = spyk(DefaultAvroSpecificRecordSerializer())
+        val target = ByteBuffer.allocate(legacyWire.size + 2)
+        target.position(2)
+        target.limit(target.capacity() - 1)
+
+        assertFailsWith<BufferOverflowException> {
+            serializer.serializeTo(employee, target)
+        }
+        target.position() shouldBeEqualTo 2
+
+        target.limit(target.capacity())
+        serializer.serializeTo(employee, target) shouldBeEqualTo legacyWire.size
+        verify(exactly = 0) { serializer.serialize(any<Employee>()) }
+    }
+
+    @Test
+    fun `specific list null empty and malformed policies remain unchanged without ByteArray fallback`() {
+        val serializer = spyk(DefaultAvroSpecificRecordSerializer())
+        val target = ByteBuffer.allocate(8)
+        target.position(3)
+
+        serializer.serializeListTo<Employee>(null, target) shouldBeEqualTo 0
+        serializer.serializeListTo(emptyList<Employee>(), target) shouldBeEqualTo 0
+        target.position() shouldBeEqualTo 3
+        serializer.deserializeListFrom(ByteBuffer.allocate(0), Employee::class.java).shouldBeEmpty()
+        serializer.deserializeListFrom(
+            ByteBuffer.wrap(byteArrayOf(0x00, 0x01, 0x02)),
+            Employee::class.java,
+        ).shouldBeEmpty()
+
+        verify(exactly = 0) { serializer.serializeList(any<List<Employee>>()) }
+        verify(exactly = 0) { serializer.deserializeList(any<ByteArray>(), Employee::class.java) }
+    }
+
+    @Test
+    fun `ByteBuffer paths preserve configured Avro codecs`() {
+        val employee = TestMessageProvider.createEmployee()
+        codecFactories().forEach { codecFactory ->
+            val baseline = DefaultAvroSpecificRecordSerializer(codecFactory)
+            val legacyWire = baseline.serialize(employee)!!
+            val serializer = spyk(DefaultAvroSpecificRecordSerializer(codecFactory))
+            val target = boundedTarget(legacyWire.size, direct = true)
+
+            val written = serializer.serializeTo(employee, target)
+            val optimizedWire = target.writtenBytes(2, written)
+
+            baseline.deserialize(optimizedWire, Employee::class.java) shouldBeEqualTo employee
+            serializer.deserializeFrom(ByteBuffer.wrap(legacyWire), Employee::class.java) shouldBeEqualTo employee
+            verify(exactly = 0) { serializer.serialize(any<Employee>()) }
+            verify(exactly = 0) { serializer.deserialize(any<ByteArray>(), Employee::class.java) }
+        }
+    }
+
+    @Test
+    fun `read only targets fail before null and empty policies run`() {
+        val target = ByteBuffer.allocate(16).asReadOnlyBuffer()
+
+        assertFailsWith<ReadOnlyBufferException> {
+            DefaultAvroReflectSerializer().serializeTo<Employee>(null, target)
+        }
+        assertFailsWith<ReadOnlyBufferException> {
+            DefaultAvroGenericRecordSerializer().serializeTo(Employee.getClassSchema(), null, target)
+        }
+        assertFailsWith<ReadOnlyBufferException> {
+            DefaultAvroSpecificRecordSerializer().serializeTo<Employee>(null, target)
+        }
+        assertFailsWith<ReadOnlyBufferException> {
+            DefaultAvroSpecificRecordSerializer().serializeListTo<Employee>(emptyList(), target)
+        }
+    }
+
+    @Test
+    fun `flush failure rolls back position and does not poison the next call`() {
+        val failed = AtomicBoolean(false)
+        val codec = codecFactory {
+            passThroughCodec { data ->
+                if (failed.compareAndSet(false, true)) throw IOException("flush failed")
+                data
+            }
+        }
+        val employee = TestMessageProvider.createEmployee()
+        val serializer = DefaultAvroSpecificRecordSerializer(codec)
+        val target = ByteBuffer.allocate(4096).apply { position(3) }
+
+        serializer.serializeTo(employee, target) shouldBeEqualTo 0
+        target.position() shouldBeEqualTo 3
+
+        val written = serializer.serializeTo(employee, target)
+        (written > 0).shouldBeTrue()
+        DefaultAvroSpecificRecordSerializer().deserialize(
+            target.writtenBytes(3, written),
+            Employee::class.java,
+        ) shouldBeEqualTo employee
+    }
+
+    @Test
+    fun `fatal codec failure preserves Error identity and rolls back position`() {
+        val fatal = OutOfMemoryError("fatal codec failure")
+        val codec = codecFactory { passThroughCodec { throw fatal } }
+        val target = ByteBuffer.allocate(4096).apply { position(5) }
+
+        val thrown = assertFailsWith<OutOfMemoryError> {
+            DefaultAvroSpecificRecordSerializer(codec).serializeTo(TestMessageProvider.createEmployee(), target)
+        }
+
+        (thrown === fatal).shouldBeTrue()
+        target.position() shouldBeEqualTo 5
+    }
+
+    private fun boundedTarget(size: Int, direct: Boolean): ByteBuffer {
+        val target = if (direct) ByteBuffer.allocateDirect(size + 4) else ByteBuffer.allocate(size + 4)
+        return target.order(ByteOrder.LITTLE_ENDIAN).apply {
+            position(2)
+            limit(2 + size)
+        }
+    }
+
+    private fun sourceVariants(bytes: ByteArray): List<ByteBuffer> {
+        val heap = ByteBuffer.wrap(byteArrayOf(9, 8) + bytes + byteArrayOf(7)).apply {
+            position(2)
+            limit(2 + bytes.size)
+        }
+        val direct = ByteBuffer.allocateDirect(bytes.size + 3).apply {
+            put(9)
+            put(8)
+            put(bytes)
+            put(7)
+            position(2)
+            limit(2 + bytes.size)
+        }
+        val sliced = ByteBuffer.wrap(byteArrayOf(9, 8) + bytes + byteArrayOf(7)).apply {
+            position(2)
+            limit(2 + bytes.size)
+        }.slice()
+        val readOnly = heap.asReadOnlyBuffer()
+        return listOf(heap, direct, sliced, readOnly)
+    }
+
+    private fun ByteBuffer.writtenBytes(start: Int, count: Int): ByteArray =
+        duplicate().apply {
+            position(start)
+            limit(start + count)
+        }.let { view -> ByteArray(view.remaining()).also(view::get) }
+
+    private fun codecFactories(): List<CodecFactory> =
+        listOf(
+            CodecFactory.nullCodec(),
+            CodecFactory.deflateCodec(6),
+            CodecFactory.snappyCodec(),
+            CodecFactory.zstandardCodec(3),
+        )
+
+    private fun codecFactory(create: () -> Codec): CodecFactory =
+        object: CodecFactory() {
+            override fun createInstance(): Codec = create()
+        }
+
+    private fun passThroughCodec(compress: (ByteBuffer) -> ByteBuffer): Codec =
+        object: Codec() {
+            override fun getName(): String = "null"
+
+            override fun compress(uncompressedData: ByteBuffer): ByteBuffer = compress(uncompressedData)
+
+            override fun decompress(compressedData: ByteBuffer): ByteBuffer = compressedData
+
+            override fun equals(other: Any?): Boolean = this === other
+
+            override fun hashCode(): Int = System.identityHashCode(this)
+        }
+}


### PR DESCRIPTION
## Summary

Closes #1038

- PR 제목: Implement lower-copy ByteBuffer paths for Avro serializers

- route Avro reflect, generic-record, specific-record, and specific-list OCF serialization directly through caller-owned `ByteBuffer` streams
- preserve schemas, codecs, OCF framing, null/empty behavior, caller position/limit/order/mark, and legacy ByteArray compatibility
- distinguish fixed-target capacity overflow from backend-originated `BufferOverflowException`
- keep handled-failure logging metadata-only so caller records are not rendered

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Scope and non-goals

- no public API signature, dependency, module, workflow, publishing, README, or CHANGELOG change
- no benchmark or measured allocation claim; those remain assigned to #1039
- failed output bytes remain unspecified while the caller position is rolled back, matching the existing serializer contract

### 기존 섹션: Verification

- `repo-test-summary -- ./gradlew :bluetape4k-avro:test --rerun-tasks --no-configuration-cache`: 221 passing, 31 tasks executed
- `bash scripts/check-serializer-buffer-abi.sh --build-current --expected-head 02abab67e`: legacy Java/Kotlin compilation, implementation loading, JVM default dispatch, public symbols, and frozen fixtures passed
- `./gradlew detekt --no-configuration-cache`: successful (`:detekt NO-SOURCE`)
- `git diff --check`: passed
- six-perspective review: final `APPROVE`, P0=0, P1=0

### 기존 섹션: Risk and review dispositions

- target overflow is marked at the fixed output-stream boundary; backend overflow keeps the ordinary handled-failure policy
- primary backend failures remain authoritative; suppressed cleanup failures are not promoted
- Avro may still allocate internal OCF block buffers, so allocation/throughput evidence is deferred to #1039
- review and lesson artifacts are recorded under `docs/review` and `docs/lessons`

Closes #1038

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1038, milestone `1.12.0`, assignee `debop`
- PR: #1044, head `8c9189abdfb2419432bc128f702541d711863342`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `feat/issue-754-avro-serializers`
- Labels: `enhancement`, `performance`, `infra/io`
- State: `MERGED`, merge commit `8957eb9cdca1d8897b3d7def654720b28a3392b5`
- CI: - route Avro reflect, generic-record, specific-record, and specific-list OCF serialization directly through caller-owned `ByteBuffer` streams / - distinguish fixed-target capacity overflow from backend-originated `BufferOverflowException` / - failed output bytes remain unspecified while the caller position is rolled back, matching the existing serializer contract

## DoD Status

- [x] approved Slice 4 scope implemented without expansion
- [x] TDD regressions cover sibling bypass, buffer state, overflow provenance, cleanup, retry, codecs, malformed data, and safe logging
- [x] complete Avro module test suite passes from an actual rerun
- [x] serializer ABI compatibility evidence is refreshed and tracked
- [x] independent review converged with no P0/P1 findings
- [x] exact PR head GitHub checks complete

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1044 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `8957eb9cdca1d8897b3d7def654720b28a3392b5`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
