### PR TITLE
fix: publish resolvable Gradle module metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,13 +227,16 @@ jobs:
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
-      - name: Validate publication POMs
+      - name: Validate publication metadata
         run: |
           ruby scripts/publication/publication_pom_audit_test.rb
           ruby scripts/publication/publication_pom_integration_test.rb
-          ./gradlew generatePomFileForBluetape4kPublication -PsnapshotVersion=-SNAPSHOT \
+          ruby scripts/publication/publication_module_metadata_audit_test.rb
+          ./gradlew generatePomFileForBluetape4kPublication generateMetadataFileForBluetape4kPublication \
+            -PsnapshotVersion=-SNAPSHOT \
             --no-daemon --no-configuration-cache --no-build-cache
           ruby scripts/publication/validate_poms.rb
+          ruby scripts/publication/validate_module_metadata.rb
 
   # ── 3. Core 모듈 테스트 ───────────────────────────────────────────────────
   test-core:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -63,11 +63,13 @@ jobs:
               print(f"{name} set={bool(value)} length={len(value)}")
           PY
 
-      - name: Validate publication POMs
+      - name: Validate publication metadata
         run: |
-          ./gradlew generatePomFileForBluetape4kPublication -PsnapshotVersion=-SNAPSHOT \
+          ./gradlew generatePomFileForBluetape4kPublication generateMetadataFileForBluetape4kPublication \
+            -PsnapshotVersion=-SNAPSHOT \
             --no-daemon --no-configuration-cache --no-build-cache
           ruby scripts/publication/validate_poms.rb
+          ruby scripts/publication/validate_module_metadata.rb
 
       - name: Publish SNAPSHOT
         run: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,11 +159,12 @@ jobs:
               print(f"{name} set={bool(value)} length={len(value)}")
           PY
 
-      - name: Validate publication POMs
+      - name: Validate publication metadata
         run: |
-          ./gradlew generatePomFileForBluetape4kPublication \
+          ./gradlew generatePomFileForBluetape4kPublication generateMetadataFileForBluetape4kPublication \
             --no-daemon --no-configuration-cache --no-build-cache
           ruby scripts/publication/validate_poms.rb
+          ruby scripts/publication/validate_module_metadata.rb
 
       - name: Publish to Central Portal
         run: >-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -950,6 +950,15 @@ subprojects {
                     artifact(sourcesJar)
                     artifact(javadocJar)
 
+                    versionMapping {
+                        usage("java-api") {
+                            fromResolutionOf("runtimeClasspath")
+                        }
+                        usage("java-runtime") {
+                            fromResolutionResult()
+                        }
+                    }
+
                     pom {
                         applyBluetape4kPomMetadata(
                             artifactDisplayName = project.name,

--- a/cache/cache-core/build.gradle.kts
+++ b/cache/cache-core/build.gradle.kts
@@ -51,7 +51,9 @@ dependencies {
     compileOnly(libs.kotlinx.coroutines.core)
 
     testFixturesApi(project(":bluetape4k-junit5"))
-    testFixturesApi(libs.awaitility.kotlin)
+    testFixturesApi(
+        "org.awaitility:awaitility-kotlin:${bt4k.versions.awaitility.get()}",
+    )
     testFixturesImplementation(libs.kotlinx.coroutines.core)
     testFixturesImplementation(libs.kotlinx.coroutines.test)
 

--- a/infra/elasticsearch/build.gradle.kts
+++ b/infra/elasticsearch/build.gradle.kts
@@ -30,6 +30,12 @@ dependencies {
     // Test Fixtures
     testFixturesApi(project(":bluetape4k-junit5"))
     testFixturesApi(project(":bluetape4k-testcontainers"))
+    testFixturesApi(
+        platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:${bt4k.versions.kotlinx.coroutines.get()}"),
+    )
+    testFixturesApi(
+        platform("org.testcontainers:testcontainers-bom:${bt4k.versions.testcontainers.get()}"),
+    )
     testFixturesApi(libs.elasticsearch.java)
     testFixturesApi(libs.kotlinx.coroutines.core)
     testFixturesApi(libs.kotlinx.coroutines.test)

--- a/scripts/publication/publication_module_metadata_audit.rb
+++ b/scripts/publication/publication_module_metadata_audit.rb
@@ -1,0 +1,79 @@
+require "json"
+require "set"
+
+module Publication
+  class ModuleMetadataAudit
+    Result = Struct.new(:errors, :file_count, :variant_count, :dependency_count, keyword_init: true)
+
+    def initialize(paths)
+      @paths = Array(paths).map { |path| File.expand_path(path) }.sort
+    end
+
+    def validate
+      if @paths.empty?
+        return Result.new(
+          errors: ["no publication module metadata files found"],
+          file_count: 0,
+          variant_count: 0,
+          dependency_count: 0,
+        )
+      end
+
+      errors = []
+      variant_count = 0
+      dependency_count = 0
+
+      @paths.each do |path|
+        metadata = JSON.parse(File.read(path))
+        Array(metadata["variants"]).each do |variant|
+          variant_count += 1
+          dependencies = Array(variant["dependencies"])
+          dependency_count += dependencies.length
+          constrained_coordinates = versioned_coordinates(variant["dependencyConstraints"])
+          has_versioned_platform = dependencies.any? do |dependency|
+            platform?(dependency) && versioned?(dependency)
+          end
+
+          dependencies.each do |dependency|
+            next if versioned?(dependency)
+            next if constrained_coordinates.include?(coordinate(dependency))
+            next if has_versioned_platform && !platform?(dependency)
+
+            errors << "#{path}: #{variant.fetch("name", "<unnamed>")}: " \
+                      "missing dependency version: #{coordinate(dependency)}"
+          end
+        end
+      rescue JSON::ParserError => error
+        errors << "#{path}: invalid JSON: #{error.message.lines.first.to_s.strip}"
+      end
+
+      Result.new(
+        errors: errors.sort,
+        file_count: @paths.length,
+        variant_count: variant_count,
+        dependency_count: dependency_count,
+      )
+    end
+
+    private
+
+    def coordinate(dependency)
+      "#{dependency.fetch("group", "")}:#{dependency.fetch("module", "")}"
+    end
+
+    def platform?(dependency)
+      category = dependency.fetch("attributes", {}).fetch("org.gradle.category", "")
+      category == "platform" || category == "enforced-platform"
+    end
+
+    def versioned?(dependency)
+      dependency.fetch("version", {}).values.any? { |value| !value.to_s.strip.empty? }
+    end
+
+    def versioned_coordinates(dependencies)
+      Array(dependencies).each_with_object(Set.new) do |dependency, coordinates|
+        coordinates << coordinate(dependency) if versioned?(dependency)
+      end
+    end
+  end
+end

--- a/scripts/publication/publication_module_metadata_audit_test.rb
+++ b/scripts/publication/publication_module_metadata_audit_test.rb
@@ -1,0 +1,139 @@
+require "fileutils"
+require "json"
+require "minitest/autorun"
+require "tmpdir"
+
+require_relative "publication_module_metadata_audit"
+
+class PublicationModuleMetadataAuditTest < Minitest::Test
+  def test_accepts_dependencies_with_explicit_versions
+    with_metadata(
+      variants: [
+        variant(
+          "apiElements",
+          dependencies: [dependency("org.example", "example-core", "1.2.3")],
+        ),
+      ],
+    ) do |path|
+      result = Publication::ModuleMetadataAudit.new([path]).validate
+
+      assert_empty result.errors
+      assert_equal 1, result.file_count
+      assert_equal 1, result.variant_count
+      assert_equal 1, result.dependency_count
+    end
+  end
+
+  def test_rejects_a_versionless_dependency_when_only_another_variant_has_a_platform
+    with_metadata(
+      variants: [
+        variant(
+          "apiElements",
+          dependencies: [dependency("tools.jackson.core", "jackson-databind")],
+        ),
+        variant(
+          "runtimeElements",
+          dependencies: [
+            platform_dependency("tools.jackson", "jackson-bom", "3.2.0"),
+            dependency("tools.jackson.core", "jackson-databind"),
+          ],
+        ),
+      ],
+    ) do |path|
+      errors = Publication::ModuleMetadataAudit.new([path]).validate.errors
+
+      assert_equal 1, errors.length
+      assert_includes errors.first, "apiElements: missing dependency version: tools.jackson.core:jackson-databind"
+    end
+  end
+
+  def test_accepts_a_versionless_dependency_with_a_versioned_platform_in_the_same_variant
+    with_metadata(
+      variants: [
+        variant(
+          "apiElements",
+          dependencies: [
+            platform_dependency("tools.jackson", "jackson-bom", "3.2.0"),
+            dependency("tools.jackson.core", "jackson-databind"),
+          ],
+        ),
+      ],
+    ) do |path|
+      assert_empty Publication::ModuleMetadataAudit.new([path]).validate.errors
+    end
+  end
+
+  def test_accepts_a_versionless_dependency_with_a_matching_constraint
+    constrained = dependency("org.example", "example-core", "1.2.3")
+    with_metadata(
+      variants: [
+        variant(
+          "apiElements",
+          dependencies: [dependency("org.example", "example-core")],
+          dependency_constraints: [constrained],
+        ),
+      ],
+    ) do |path|
+      assert_empty Publication::ModuleMetadataAudit.new([path]).validate.errors
+    end
+  end
+
+  def test_rejects_a_versionless_platform_even_when_another_platform_is_versioned
+    with_metadata(
+      variants: [
+        variant(
+          "apiElements",
+          dependencies: [
+            platform_dependency("tools.jackson", "jackson-bom", "3.2.0"),
+            dependency("org.springframework.boot", "spring-boot-dependencies").merge(
+              "attributes" => { "org.gradle.category" => "platform" },
+            ),
+          ],
+        ),
+      ],
+    ) do |path|
+      errors = Publication::ModuleMetadataAudit.new([path]).validate.errors
+
+      assert_equal 1, errors.length
+      assert_includes errors.first,
+                      "apiElements: missing dependency version: org.springframework.boot:spring-boot-dependencies"
+    end
+  end
+
+  def test_fails_closed_when_no_module_metadata_files_exist
+    result = Publication::ModuleMetadataAudit.new([]).validate
+
+    assert_equal ["no publication module metadata files found"], result.errors
+  end
+
+  private
+
+  def dependency(group, module_name, version = nil)
+    value = { "group" => group, "module" => module_name }
+    value["version"] = { "requires" => version } if version
+    value
+  end
+
+  def platform_dependency(group, module_name, version)
+    dependency(group, module_name, version).merge(
+      "attributes" => { "org.gradle.category" => "platform" },
+    )
+  end
+
+  def variant(name, dependencies:, dependency_constraints: [])
+    {
+      "name" => name,
+      "attributes" => { "org.gradle.usage" => name == "apiElements" ? "java-api" : "java-runtime" },
+      "dependencies" => dependencies,
+      "dependencyConstraints" => dependency_constraints,
+    }
+  end
+
+  def with_metadata(variants:)
+    Dir.mktmpdir("publication-module-metadata-audit") do |root|
+      path = File.join(root, "module.json")
+      File.write(path, JSON.pretty_generate("formatVersion" => "1.1", "variants" => variants))
+      yield path
+    end
+  end
+end

--- a/scripts/publication/validate_module_metadata.rb
+++ b/scripts/publication/validate_module_metadata.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+require_relative "publication_module_metadata_audit"
+
+paths = if ARGV.empty?
+          Dir.glob("**/build/publications/*/module.json")
+            .reject { |path| path.start_with?(".worktrees/") }
+        else
+          ARGV
+        end
+
+result = Publication::ModuleMetadataAudit.new(paths).validate
+unless result.errors.empty?
+  warn(result.errors.join("\n"))
+  abort(
+    "publication-module-metadata: failures=#{result.errors.length} " \
+    "files=#{result.file_count} variants=#{result.variant_count} dependencies=#{result.dependency_count}",
+  )
+end
+
+puts(
+  "publication-module-metadata: failures=0 files=#{result.file_count} " \
+  "variants=#{result.variant_count} dependencies=#{result.dependency_count}",
+)


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: fix: publish resolvable Gradle module metadata

- publish resolved dependency versions for Java API and runtime variants
- keep test-fixture variants independently resolvable through central catalog versions and BOMs
- add a fail-closed Gradle Module Metadata audit to CI, snapshot publishing, and stable release workflows

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Root cause

The existing gate validated Maven POM files only. Public snapshot build 5 had valid POMs but its Gradle apiElements variant still exposed versionless Jackson dependencies, so Gradle consumers failed before compilation.

### 기존 섹션: Remaining release gate

Do not converge downstream catalog consumers until a newer public 1.12.0-SNAPSHOT is published from the merged exact head and all consumer builds pass.

## Validation

- publication audit tests: 13 tests, 35 assertions, 0 failures
- publication POMs: 77 files, 32033 dependencies, 77 Maven models, 0 failures
- Gradle Module Metadata: 77 files, 159 variants, 1509 dependencies, 0 failures
- full Gradle build excluding standard test tasks: 564 tasks, successful
- isolated local publication consumed by bluetape4k-aws Kotlin compile: successful
- actionlint and git diff check: successful

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: N/A (라이브 PR 메타데이터와 본문에 closing issue 참조 없음), milestone 없음, assignee 없음
- PR: #1046, head `d60851ecad4868c10c72d821b94e71a1cb85695b`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/gradle-module-metadata-versions`
- Labels: `bug`, `dependencies`
- State: `MERGED`, merge commit `9d9f36635e082b38be147b11f4bb50b24efb5f17`
- CI: - add a fail-closed Gradle Module Metadata audit to CI, snapshot publishing, and stable release workflows / The existing gate validated Maven POM files only. Public snapshot build 5 had valid POMs but its Gradle apiElements variant still exposed versionless Jackson dependencies, so Gradle consumers failed before compilation. / - publication POMs: 77 files, 32033 dependencies, 77 Maven models, 0 failures

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1046 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9d9f36635e082b38be147b11f4bb50b24efb5f17`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
