### PR TITLE
Fix CodeQL catalog pin and document testcontainers exclusion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,18 @@ jobs:
       - name: Verify Maven-only release policy
         run: python3 -m unittest scripts/test_release_workflow_policy.py -v
 
+  codeql-policy:
+    name: CodeQL Workflow Policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Verify CodeQL catalog and build policy
+        run: python3 -m unittest scripts/test_codeql_workflow_policy.py -v
+
   # ── 0. 시크릿 스캔 ────────────────────────────────────────────────────────
   gitleaks:
     name: Secret Scan (gitleaks)
@@ -874,7 +886,7 @@ jobs:
     name: CI Status
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [release-policy, catalog-governance, gitleaks, validate-wrapper, changes, build, test-core, test-io, test-io-http, test-ktor, test-key-utils, test-infra, test-kafka-infra, test-telemetry-infra, test-data, coverage-report]
+    needs: [release-policy, codeql-policy, catalog-governance, gitleaks, validate-wrapper, changes, build, test-core, test-io, test-io-http, test-ktor, test-key-utils, test-infra, test-kafka-infra, test-telemetry-infra, test-data, coverage-report]
     if: always()
     steps:
       - name: Check all jobs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,8 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }} / ${{ matrix.scope }})
     runs-on: ubuntu-latest
+    env:
+      BLUETAPE4K_DEPENDENCIES_CATALOG_PATH: ${{ github.workspace }}/.catalog/bluetape4k-dependencies/gradle/libs.versions.toml
     permissions:
       security-events: write
       actions: read
@@ -21,31 +23,60 @@ jobs:
           - language: actions
             scope: workflows
             roots: ''
+            build_timeout_minutes: 120
           - language: python
             scope: python
             roots: ''
+            build_timeout_minutes: 120
           - language: java-kotlin
             scope: foundation
             roots: bluetape4k:cache:utils
+            build_timeout_minutes: 120
           - language: java-kotlin
             scope: data-io
             roots: data:io
+            build_timeout_minutes: 120
           - language: java-kotlin
             scope: infra
             roots: infra
+            build_timeout_minutes: 120
           - language: java-kotlin
             scope: frameworks
             roots: ktor:spring-boot:virtualthread
-          # Exclude testing/testcontainers from scheduled CodeQL for now: even
-          # the single compileKotlin task stayed in Build with Gradle for more
-          # than 30 minutes under CodeQL tracing.
+            build_timeout_minutes: 120
           - language: java-kotlin
             scope: testing-core
             roots: testing/assertions:testing/junit5:testing/mock-web-server:testing/mock-webflux-server
+            build_timeout_minutes: 120
+          - language: java-kotlin
+            scope: testing-containers
+            roots: testing/testcontainers
+            build_timeout_minutes: 20
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+
+      - name: Resolve dependencies catalog ref
+        id: catalog-ref
+        if: matrix.language == 'java-kotlin'
+        shell: bash
+        run: |
+          set -euo pipefail
+          catalog_ref="$(sed -nE 's/^[[:space:]]*\.orElse\("([^"]+)"\).*/\1/p' settings.gradle.kts | head -1)"
+          if [[ ! "$catalog_ref" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Could not resolve an immutable bluetape4k-dependencies catalog ref"
+            exit 1
+          fi
+          echo "ref=$catalog_ref" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout dependencies catalog
+        if: matrix.language == 'java-kotlin'
+        uses: actions/checkout@v7
+        with:
+          repository: bluetape4k/bluetape4k-dependencies
+          ref: ${{ steps.catalog-ref.outputs.ref }}
+          path: .catalog/bluetape4k-dependencies
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
@@ -55,8 +86,11 @@ jobs:
       - name: Pin Kotlin for CodeQL extractor
         if: matrix.language == 'java-kotlin'
         run: |
-          perl -0pi -e 's/kotlin = "2\.4\.0"/kotlin = "2.3.21"/' gradle/libs.versions.toml
-          grep -n 'kotlin = "2.3.21"' gradle/libs.versions.toml
+          set -euo pipefail
+          catalog_file="$BLUETAPE4K_DEPENDENCIES_CATALOG_PATH"
+          test "$(git -C .catalog/bluetape4k-dependencies rev-parse HEAD)" = "${{ steps.catalog-ref.outputs.ref }}"
+          perl -0pi -e 's/kotlin = "2\.4\.0"/kotlin = "2.3.21"/' "$catalog_file"
+          grep -n 'kotlin = "2.3.21"' "$catalog_file"
 
       - name: Setup JDK 21
         if: matrix.language == 'java-kotlin'
@@ -67,7 +101,7 @@ jobs:
 
       - name: Build with Gradle
         if: matrix.language == 'java-kotlin'
-        timeout-minutes: 120
+        timeout-minutes: ${{ matrix.build_timeout_minutes }}
         env:
           CODEQL_JAVA_ROOTS: ${{ matrix.roots }}
         # Keep each CodeQL Kotlin job scoped and compiler-only. Avoid examples,

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -89,8 +89,9 @@ jobs:
           set -euo pipefail
           catalog_file="$BLUETAPE4K_DEPENDENCIES_CATALOG_PATH"
           test "$(git -C .catalog/bluetape4k-dependencies rev-parse HEAD)" = "${{ steps.catalog-ref.outputs.ref }}"
-          perl -0pi -e 's/kotlin = "2\.4\.0"/kotlin = "2.3.21"/' "$catalog_file"
-          grep -n 'kotlin = "2.3.21"' "$catalog_file"
+          grep -Eq '^kotlin[[:space:]]*=[[:space:]]*"2\.4\.0"' "$catalog_file"
+          perl -0pi -e 's/^kotlin\h*=\h*"2\.4\.0"/kotlin = "2.3.21"/m' "$catalog_file"
+          grep -En '^kotlin[[:space:]]*=[[:space:]]*"2\.3\.21"' "$catalog_file"
 
       - name: Setup JDK 21
         if: matrix.language == 'java-kotlin'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,35 +23,29 @@ jobs:
           - language: actions
             scope: workflows
             roots: ''
-            build_timeout_minutes: 120
           - language: python
             scope: python
             roots: ''
-            build_timeout_minutes: 120
           - language: java-kotlin
             scope: foundation
             roots: bluetape4k:cache:utils
-            build_timeout_minutes: 120
           - language: java-kotlin
             scope: data-io
             roots: data:io
-            build_timeout_minutes: 120
           - language: java-kotlin
             scope: infra
             roots: infra
-            build_timeout_minutes: 120
           - language: java-kotlin
             scope: frameworks
             roots: ktor:spring-boot:virtualthread
-            build_timeout_minutes: 120
+          # testing/testcontainers remains excluded: its single compileKotlin
+          # task timed out after 20 minutes while every other scope passed:
+          # https://github.com/bluetape4k/bluetape4k-projects/actions/runs/29648755583
+          # See the durable lesson for measurements and reconsideration gates:
+          # docs/lessons/2026-07-18-codeql-testcontainers-exclusion.md
           - language: java-kotlin
             scope: testing-core
             roots: testing/assertions:testing/junit5:testing/mock-web-server:testing/mock-webflux-server
-            build_timeout_minutes: 120
-          - language: java-kotlin
-            scope: testing-containers
-            roots: testing/testcontainers
-            build_timeout_minutes: 20
 
     steps:
       - name: Checkout repository
@@ -102,7 +96,7 @@ jobs:
 
       - name: Build with Gradle
         if: matrix.language == 'java-kotlin'
-        timeout-minutes: ${{ matrix.build_timeout_minutes }}
+        timeout-minutes: 120
         env:
           CODEQL_JAVA_ROOTS: ${{ matrix.roots }}
         # Keep each CodeQL Kotlin job scoped and compiler-only. Avoid examples,

--- a/docs/lessons/2026-07-18-codeql-testcontainers-exclusion.md
+++ b/docs/lessons/2026-07-18-codeql-testcontainers-exclusion.md
@@ -1,0 +1,58 @@
+# CodeQL에서 `bluetape4k-testcontainers`를 제외하는 이유
+
+## 배경
+
+Issue #999는 `:bluetape4k-testcontainers:compileKotlin`을 CodeQL Java/Kotlin
+수동 build에 다시 포함할 수 있는지 검증했다. 일반 Gradle 환경에서는 이
+모듈이 정상적으로 컴파일되지만, CodeQL의 compiler tracing 환경에서는 단일
+task도 scheduled analysis의 실용적인 시간 안에 끝나지 않았다.
+
+## 근거
+
+- 과거 run
+  [28970095586](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/28970095586)은
+  단일 `:bluetape4k-testcontainers:compileKotlin` task가 31분 넘게 build 단계에
+  머문 뒤 취소됐다.
+- 중앙 catalog pin을 수정한 통제 run
+  [29648755583](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/29648755583)은
+  같은 task에 20분 step timeout을 적용했다. task는 2026-07-18 14:54:00 UTC에
+  시작했지만 15:09:29 UTC까지 완료되지 않아 build가 timeout됐다.
+- 같은 exact source에서 `--rerun-tasks --no-configuration-cache`로 실행한 로컬
+  compile은 cache 없이 19초에 성공했다. 따라서 일반 Gradle 성능 문제가 아니라
+  CodeQL tracing 환경에서만 나타나는 증폭이다.
+- 같은 run의 다른 scope는 모두 성공했다. Java/Kotlin scope의 전체 job 시간은
+  `testing-core` 6분 44초, `infra` 9분 13초, `data-io` 11분 28초,
+  `foundation` 11분 33초, `frameworks` 12분 6초였다.
+- `testing/testcontainers` main source는 68개 파일, 10,993줄이며
+  `build.gradle.kts`에 107개의 dependency declaration이 있다. 여러 DB,
+  메시징, 검색, cloud SDK를 하나의 optional integration module에 모은 넓은
+  compile classpath가 Kotlin extractor tracing 비용을 크게 증폭한다.
+
+## 판단
+
+CodeQL은 [compiled language의 manual build](https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/manage-your-configuration/codeql-for-compiled-languages)에서
+실제 compiler invocation을 추적한다. 이 모듈은 소스 크기 자체보다 넓은 optional integration classpath와
+Kotlin extractor tracing의 결합 때문에 일반 Gradle compile과 전혀 다른
+시간 특성을 보인다. 특정 library 하나가 원인이라는 증거는 없으므로 dependency를
+임의로 제거하거나 분석 시간을 무제한으로 늘리지 않는다.
+
+따라서 `testing/testcontainers`는 scheduled CodeQL matrix에서 계속 제외한다.
+나머지 production scope의 분석을 안정적으로 완료하는 것이 우선이며, 이 결정은
+소스/의존성 구조나 CodeQL Kotlin extractor 성능이 유의미하게 바뀔 때만 다시
+검토한다.
+
+## 재검토 조건
+
+다음 조건을 모두 충족할 때 별도 issue와 단 한 번의 bounded dispatch로 재검증한다.
+
+1. `testing/testcontainers`가 backend별 module로 분리되거나 compile classpath가
+   의미 있게 축소됐다.
+2. CodeQL release note에 Kotlin extractor의 Gradle tracing 성능 개선이 명시됐다.
+3. 비교 run은 모듈 단일 `compileKotlin` task와 20분 이하 timeout을 유지한다.
+4. 다른 matrix scope의 성공 여부와 exact head SHA를 함께 기록한다.
+
+## 검증 규칙
+
+`scripts/test_codeql_workflow_policy.py`는 이 exclusion의 run 링크와 lesson 경로를
+workflow에 남기고, `testing-containers` scope가 실수로 다시 추가되지 않도록
+검사한다.

--- a/scripts/test_codeql_workflow_policy.py
+++ b/scripts/test_codeql_workflow_policy.py
@@ -32,6 +32,7 @@ class CodeqlWorkflowPolicyTest(unittest.TestCase):
         self.assertIn("path: .catalog/bluetape4k-dependencies", checkout)
         self.assertIn("BLUETAPE4K_DEPENDENCIES_CATALOG_PATH", CODEQL)
         self.assertIn('catalog_file="$BLUETAPE4K_DEPENDENCIES_CATALOG_PATH"', pin)
+        self.assertIn(r's/^kotlin\h*=\h*"2\.4\.0"', pin)
         self.assertNotIn("gradle/libs.versions.toml", pin.replace("$catalog_file", ""))
 
     def test_catalog_ref_is_resolved_from_the_checked_in_settings(self) -> None:

--- a/scripts/test_codeql_workflow_policy.py
+++ b/scripts/test_codeql_workflow_policy.py
@@ -42,15 +42,16 @@ class CodeqlWorkflowPolicyTest(unittest.TestCase):
         self.assertIn("settings.gradle.kts", resolve)
         self.assertIn('echo "ref=$catalog_ref" >> "$GITHUB_OUTPUT"', resolve)
 
-    def test_testcontainers_scope_is_isolated_and_bounded(self) -> None:
-        self.assertRegex(
+    def test_testcontainers_exclusion_has_durable_evidence(self) -> None:
+        self.assertNotIn("scope: testing-containers", CODEQL)
+        self.assertNotIn("roots: testing/testcontainers", CODEQL)
+        self.assertIn("actions/runs/29648755583", CODEQL)
+        self.assertIn(
+            "docs/lessons/2026-07-18-codeql-testcontainers-exclusion.md",
             CODEQL,
-            r"scope: testing-containers\n"
-            r"\s+roots: testing/testcontainers\n"
-            r"\s+build_timeout_minutes: 20",
         )
         build = named_step(CODEQL, "Build with Gradle")
-        self.assertIn("timeout-minutes: ${{ matrix.build_timeout_minutes }}", build)
+        self.assertIn("timeout-minutes: 120", build)
 
     def test_pull_request_ci_runs_this_policy(self) -> None:
         workflow = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")

--- a/scripts/test_codeql_workflow_policy.py
+++ b/scripts/test_codeql_workflow_policy.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+import re
+import unittest
+from pathlib import Path
+
+
+REPOSITORY = Path(__file__).resolve().parents[1]
+WORKFLOWS = REPOSITORY / ".github" / "workflows"
+CODEQL = (WORKFLOWS / "codeql.yml").read_text(encoding="utf-8")
+
+
+def named_step(workflow: str, name: str) -> str:
+    match = re.search(
+        rf"^      - name: {re.escape(name)}\n(?P<body>.*?)(?=^      - (?:name:|uses:)|\Z)",
+        workflow,
+        re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        return ""
+    return match.group("body")
+
+
+class CodeqlWorkflowPolicyTest(unittest.TestCase):
+
+    def test_java_kotlin_uses_the_checked_out_central_catalog(self) -> None:
+        checkout = named_step(CODEQL, "Checkout dependencies catalog")
+        pin = named_step(CODEQL, "Pin Kotlin for CodeQL extractor")
+
+        self.assertIn("repository: bluetape4k/bluetape4k-dependencies", checkout)
+        self.assertIn("ref: ${{ steps.catalog-ref.outputs.ref }}", checkout)
+        self.assertIn("path: .catalog/bluetape4k-dependencies", checkout)
+        self.assertIn("BLUETAPE4K_DEPENDENCIES_CATALOG_PATH", CODEQL)
+        self.assertIn('catalog_file="$BLUETAPE4K_DEPENDENCIES_CATALOG_PATH"', pin)
+        self.assertNotIn("gradle/libs.versions.toml", pin.replace("$catalog_file", ""))
+
+    def test_catalog_ref_is_resolved_from_the_checked_in_settings(self) -> None:
+        resolve = named_step(CODEQL, "Resolve dependencies catalog ref")
+
+        self.assertIn('id: catalog-ref', resolve)
+        self.assertIn("settings.gradle.kts", resolve)
+        self.assertIn('echo "ref=$catalog_ref" >> "$GITHUB_OUTPUT"', resolve)
+
+    def test_testcontainers_scope_is_isolated_and_bounded(self) -> None:
+        self.assertRegex(
+            CODEQL,
+            r"scope: testing-containers\n"
+            r"\s+roots: testing/testcontainers\n"
+            r"\s+build_timeout_minutes: 20",
+        )
+        build = named_step(CODEQL, "Build with Gradle")
+        self.assertIn("timeout-minutes: ${{ matrix.build_timeout_minutes }}", build)
+
+    def test_pull_request_ci_runs_this_policy(self) -> None:
+        workflow = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
+
+        self.assertIn("name: CodeQL Workflow Policy", workflow)
+        self.assertIn(
+            "python3 -m unittest scripts/test_codeql_workflow_policy.py -v",
+            workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #999

- PR 제목: Fix CodeQL catalog pin and document testcontainers exclusion

- Resolve the immutable `bluetape4k-dependencies` catalog ref from `settings.gradle.kts` and pin Kotlin in the checked-out central catalog before CodeQL builds.
- Add a CI-enforced workflow policy regression for the catalog boundary and the testcontainers exclusion.
- Record why `bluetape4k-testcontainers` remains excluded from scheduled CodeQL and when to reconsider the decision.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Check out the exact central catalog commit declared by the repository and point Gradle at that file.
- Make the Kotlin extractor pin tolerant of the catalog's aligned whitespace and fail closed if the expected version is absent.
- Add `scripts/test_codeql_workflow_policy.py` and run it as a required CI job.
- Preserve the scheduled exclusion with live-run evidence and a durable Korean lesson.

### 기존 섹션: Root Cause

The CodeQL workflow still patched `gradle/libs.versions.toml` after Kotlin version ownership moved to the central catalog, so every Java/Kotlin job failed before Gradle started. Once that prerequisite was repaired, the isolated `:bluetape4k-testcontainers:compileKotlin` task still exceeded a 20-minute traced build limit while every comparison scope completed successfully. The module's unusually broad optional-integration compile classpath amplifies Kotlin extractor tracing cost.

## Validation

- `python3 -m unittest scripts/test_codeql_workflow_policy.py scripts/test_release_workflow_policy.py -v`: PASS (11/11)
- `python3 -m py_compile scripts/test_codeql_workflow_policy.py`: PASS
- `actionlint .github/workflows/codeql.yml .github/workflows/ci.yml`: PASS
- `./gradlew :bluetape4k-testcontainers:compileKotlin --rerun-tasks --no-configuration-cache`: PASS in 19 seconds locally
- Controlled CodeQL run [29648755583](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/29648755583): seven comparison jobs passed; the isolated testcontainers build timed out after 20 minutes
- Review findings: P0 `0`, P1 `0`

Fixes #999

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #999, milestone `1.12.0`, assignee `debop`
- PR: #1057, head `e9a0e76729f4693ecbbd1898dd96d7a08753b93d`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-999-codeql-testcontainers`
- Labels: `build`, `security`, `ci`
- State: `MERGED`, merge commit `8063f99aaad7e8edc3a90664ff4e5229542a1b05`
- CI: - Resolve the immutable `bluetape4k-dependencies` catalog ref from `settings.gradle.kts` and pin Kotlin in the checked-out central catalog before CodeQL builds. / - Add a CI-enforced workflow policy regression for the catalog boundary and the testcontainers exclusion. / - Record why `bluetape4k-testcontainers` remains excluded from scheduled CodeQL and when to reconsider the decision.

## DoD Status

| Check | Status | Evidence |
|---|---|---|
| C-01 Root cause identified | PASS | The stale local-catalog pin blocked Java/Kotlin jobs; the repaired run isolated the remaining traced compile limit. |
| C-03 RED reproduced | PASS | The policy test failed before central checkout/pin/CI enforcement existed and before the durable exclusion was recorded. |
| C-05 GREEN verified | PASS | 11 workflow policy tests, actionlint, Python compilation, and module compilation pass. |
| C-06 Lesson artifact | PASS | `docs/lessons/2026-07-18-codeql-testcontainers-exclusion.md` records measurements and reconsideration gates. |
| CG-10 Pre-PR verification | PASS | Final four-file diff has P0=0/P1=0 and all scoped local checks pass. |
| CG-12 Exact-head gate | PASS | Local and remote head are `e9a0e76729f4693ecbbd1898dd96d7a08753b93d`. |
| CG-13 PR metadata | PASS | PR #1057 targets `develop` from the exact approved head with assignee `debop`, milestone `1.12.0`, labels `build`, `security`, and `ci`, and this final DoD heading. |
| CG-14 CI and review | PASS | Exact-head CI run 29649817903 passed 18/18 jobs; current reviews and review threads are empty. |
| CG-15 Merge-ready | PASS | PR #1057 is open, non-draft, `MERGEABLE`, and `CLEAN` at the approved exact head. |
| CG-16 Fresh merge approval | PASS | User approved the exact-head merge after the merge-ready report on 2026-07-19. |
| CG-17 Exact-head merge | PASS | Exact head `e9a0e76729f4693ecbbd1898dd96d7a08753b93d` was rebase-merged as `8063f99aaad7e8edc3a90664ff4e5229542a1b05`; PR #1057 is `MERGED`. |
| CG-18 Post-merge verification | PASS | Local and remote `develop` match `8063f99aaad7e8edc3a90664ff4e5229542a1b05`; 11 policy tests, actionlint, module compilation, and GNO lesson indexing pass; checkout is clean. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1057 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `8063f99aaad7e8edc3a90664ff4e5229542a1b05`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
