### PR TITLE
test: Add HTTP observability conformance fixtures

### DIFF
--- a/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservabilityTest.kt
+++ b/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservabilityTest.kt
@@ -5,6 +5,13 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.observability.HttpOperationClassification
+import io.bluetape4k.junit5.observability.HttpOperationCorrelation
+import io.bluetape4k.junit5.observability.HttpOperationCorrelationMode
+import io.bluetape4k.junit5.observability.HttpOperationExpectation
+import io.bluetape4k.junit5.observability.HttpOperationObservation
+import io.bluetape4k.junit5.observability.HttpOperationSensitiveValues
+import io.bluetape4k.junit5.observability.assertHttpOperationObservability
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.StatusCode
@@ -14,13 +21,18 @@ import io.opentelemetry.sdk.trace.SdkTracerProvider
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
 import io.ktor.client.request.get
 import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
 import io.ktor.server.application.call
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
+import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
@@ -246,6 +258,83 @@ class Bluetape4kKtorObservabilityTest {
     }
 
     @Test
+    fun `Ktor telemetry satisfies the shared HTTP observability conformance fixture`() = testTracing { tracing ->
+        testApplication {
+            val registry = SimpleMeterRegistry()
+            val correlationId = "request-123"
+            try {
+                application {
+                    installBluetape4kKtorObservability(
+                        Bluetape4kKtorObservabilityConfig(
+                            meterRegistry = registry,
+                            tracing = KtorOpenTelemetryTracingConfig(
+                                openTelemetry = tracing.openTelemetry,
+                                captureSanitizedCorrelationId = true,
+                            ),
+                        )
+                    )
+                    routing {
+                        post("/sales/{saleId}") {
+                            call.respondText("ok")
+                        }
+                    }
+                }
+
+                val response = client.post("/sales/sale-123?user=user-456") {
+                    header(HttpHeaders.XRequestId, correlationId)
+                    header(HttpHeaders.XForwardedFor, "203.0.113.7")
+                    contentType(ContentType.Application.Json)
+                    setBody("payload-secret")
+                }
+                tracing.flush()
+
+                val span = tracing.spanExporter.finishedSpanItems.single()
+                val timer = registry.find("ktor.http.server.requests").timers().single()
+                val metricAttributes = timer.id.tags.associate { tag ->
+                    val key = when (tag.key) {
+                        "method"      -> "http.request.method"
+                        "route"       -> "http.route"
+                        "status"      -> "http.response.status_code"
+                        else          -> tag.key
+                    }
+                    key to tag.value
+                } + ("correlation.present" to span.attributes[CORRELATION_PRESENT_KEY].toString())
+
+                assertHttpOperationObservability(
+                    observation = HttpOperationObservation(
+                        operationName = timer.id.name,
+                        routeTemplate = metricAttributes.getValue("http.route"),
+                        statusCode = response.status.value,
+                        classification = response.status.value.toHttpOperationClassification(),
+                        correlation = HttpOperationCorrelation(
+                            inbound = correlationId,
+                            outbound = response.headers[HttpHeaders.XRequestId],
+                            mode = HttpOperationCorrelationMode.PROPAGATED,
+                        ),
+                        metricAttributes = metricAttributes,
+                    ),
+                    expectation = HttpOperationExpectation(
+                        operationName = "ktor.http.server.requests",
+                        routeTemplate = "/sales/{saleId}",
+                        statusCode = 200,
+                        classification = HttpOperationClassification.SUCCESS,
+                        sensitiveValues = HttpOperationSensitiveValues(
+                            rawUrl = "http://localhost/sales/sale-123?user=user-456",
+                            query = "user=user-456",
+                            clientIp = "203.0.113.7",
+                            userId = "user-456",
+                            saleId = "sale-123",
+                            requestPayload = "payload-secret",
+                        ),
+                    ),
+                )
+            } finally {
+                registry.close()
+            }
+        }
+    }
+
+    @Test
     fun `observability config rejects micrometer installation without registry`() {
         assertFailsWith<IllegalArgumentException> {
             Bluetape4kKtorObservabilityConfig(installMicrometerMetrics = true)
@@ -283,13 +372,20 @@ class Bluetape4kKtorObservabilityTest {
         }
 
         override fun close() {
-            tracerProvider.close()
+            openTelemetry.close()
         }
     }
 
     private inline fun testTracing(block: (TestTracing) -> Unit) {
         TestTracing().use(block)
     }
+
+    private fun Int.toHttpOperationClassification(): HttpOperationClassification =
+        when (this) {
+            in 100..399 -> HttpOperationClassification.SUCCESS
+            in 400..499 -> HttpOperationClassification.CLIENT_ERROR
+            else        -> HttpOperationClassification.DEPENDENCY_FAILURE
+        }
 
     companion object {
         private val CORRELATION_PRESENT_KEY: AttributeKey<Boolean> = AttributeKey.booleanKey("correlation.present")

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/observability/SpringObservationSupportTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/observability/SpringObservationSupportTest.kt
@@ -3,16 +3,40 @@ package io.bluetape4k.spring.observability
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.observability.HttpOperationClassification
+import io.bluetape4k.junit5.observability.HttpOperationCorrelation
+import io.bluetape4k.junit5.observability.HttpOperationCorrelationMode
+import io.bluetape4k.junit5.observability.HttpOperationExpectation
+import io.bluetape4k.junit5.observability.HttpOperationObservation
+import io.bluetape4k.junit5.observability.HttpOperationSensitiveValues
+import io.bluetape4k.junit5.observability.assertHttpOperationObservability
 import io.micrometer.common.KeyValue
 import io.micrometer.common.KeyValues
 import io.micrometer.observation.Observation
 import io.micrometer.observation.ObservationHandler
 import io.micrometer.observation.ObservationRegistry
 import io.micrometer.observation.tck.ObservationRegistryAssert
+import io.micrometer.observation.tck.TestObservationRegistry
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.web.filter.ServerHttpObservationFilter
 
 class SpringObservationSupportTest {
 
@@ -143,4 +167,107 @@ class SpringObservationSupportTest {
         handler.stopped shouldBeEqualTo 1
         registry.currentObservation.shouldBeNull()
     }
+
+    @Test
+    fun `Spring HTTP observation satisfies the shared HTTP observability conformance fixture`() {
+        val handler = RecordingObservationHandler()
+        val registry = TestObservationRegistry.create().apply {
+            observationConfig().observationHandler(handler)
+        }
+        val correlationId = "request-123"
+        val mockMvcBuilder = MockMvcBuilders.standaloneSetup(HttpConformanceController())
+        mockMvcBuilder.addFilters<StandaloneMockMvcBuilder>(
+            ServerHttpObservationFilter(registry),
+            CorrelationObservationFilter(registry),
+        )
+        val mockMvc = mockMvcBuilder.build()
+
+        val result = mockMvc
+            .perform(
+                post("/sales/sale-123")
+                    .queryParam("user", "user-456")
+                    .header("X-Request-Id", correlationId)
+                    .header("X-Forwarded-For", "203.0.113.7")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("payload-secret")
+            )
+            .andExpect(status().isOk)
+            .andReturn()
+
+        val context = handler.lastContext.shouldNotBeNull()
+        val metricAttributes = context.lowCardinalityKeyValues.associate { keyValue ->
+            val key = when (keyValue.key) {
+                "method" -> "http.request.method"
+                "uri"    -> "http.route"
+                "status" -> "http.response.status_code"
+                else     -> keyValue.key
+            }
+            key to keyValue.value
+        }
+        val statusCode = result.response.status
+
+        assertHttpOperationObservability(
+            observation = HttpOperationObservation(
+                operationName = context.name.shouldNotBeNull(),
+                routeTemplate = metricAttributes.getValue("http.route"),
+                statusCode = statusCode,
+                classification = statusCode.toHttpOperationClassification(),
+                correlation = HttpOperationCorrelation(
+                    inbound = correlationId,
+                    outbound = result.response.getHeader("X-Request-Id"),
+                    mode = HttpOperationCorrelationMode.PROPAGATED,
+                ),
+                metricAttributes = metricAttributes,
+            ),
+            expectation = HttpOperationExpectation(
+                operationName = "http.server.requests",
+                routeTemplate = "/sales/{saleId}",
+                statusCode = 200,
+                classification = HttpOperationClassification.SUCCESS,
+                sensitiveValues = HttpOperationSensitiveValues(
+                    rawUrl = "http://localhost/sales/sale-123?user=user-456",
+                    query = "user=user-456",
+                    clientIp = "203.0.113.7",
+                    userId = "user-456",
+                    saleId = "sale-123",
+                    requestPayload = "payload-secret",
+                ),
+            ),
+        )
+    }
+
+    private class CorrelationObservationFilter(
+        private val registry: ObservationRegistry,
+    ): OncePerRequestFilter() {
+        override fun doFilterInternal(
+            request: HttpServletRequest,
+            response: HttpServletResponse,
+            filterChain: FilterChain,
+        ) {
+            val correlationId = request.getHeader("X-Request-Id")
+            registry.currentObservation?.lowCardinalityKeyValue(
+                "correlation.present",
+                (correlationId != null).toString(),
+            )
+            correlationId?.let { response.setHeader("X-Request-Id", it) }
+            filterChain.doFilter(request, response)
+        }
+    }
+
+    @RestController
+    private class HttpConformanceController {
+        @PostMapping("/sales/{saleId}")
+        fun createSale(
+            @PathVariable saleId: String,
+            @RequestBody payload: String,
+        ): ResponseEntity<String> =
+            ResponseEntity.ok("$saleId:${payload.length}")
+    }
+
+    private fun Int.toHttpOperationClassification(): HttpOperationClassification =
+        when (this) {
+            in 100..399 -> HttpOperationClassification.SUCCESS
+            in 400..499 -> HttpOperationClassification.CLIENT_ERROR
+            else        -> HttpOperationClassification.DEPENDENCY_FAILURE
+        }
 }

--- a/testing/junit5/README.ko.md
+++ b/testing/junit5/README.ko.md
@@ -23,6 +23,7 @@ JUnit 5 테스트 작성 시 반복 코드를 줄여주는 확장 라이브러�
 - **System Property 확장**: 테스트 중 시스템 속성 설정/복원
 - **Awaitility + Coroutines**: suspend 조건 대기 유틸
 - **Coroutine Cancellation Contracts**: cancellation 전파, waiter 정리, resource cancellation 검증
+- **HTTP Observability Conformance**: 안정적인 route, 결과 분류, correlation, 민감 정보 제외 검증
 - **Stress Tester**: 멀티스레드/가상스레드/코루틴 기반 스트레스 테스트
 - **Parameter Source 확장**: FieldSource 기반 인자 제공
 - **Mermaid 리포트**: 테스트 실행 결과를 Mermaid Gantt 타임라인으로 출력
@@ -257,6 +258,51 @@ suspend API에서 cancellation 전파가 필요하다면 plain `runCatching`으�
 `CancellationException`은 structured concurrency의 cancellation 신호이므로 반드시 다시 던져야 합니다.
 non-cancellation 실패만 `Result`로 반환하려면 `runCatchingNonCancellation` 또는
 `resultOfNonCancellation`을 사용하세요.
+
+### HTTP Observability Conformance
+
+Spring Boot, Ktor 같은 서버 통합 테스트에서 registry 또는 tracer 결과를 `HttpOperationObservation`으로
+변환한 뒤 같은 계약으로 검증할 수 있습니다.
+
+```kotlin
+assertHttpOperationObservability(
+    observation = HttpOperationObservation(
+        operationName = "http.server.requests",
+        routeTemplate = "/sales/{saleId}",
+        statusCode = 200,
+        classification = HttpOperationClassification.SUCCESS,
+        correlation = HttpOperationCorrelation(
+            inbound = requestId,
+            outbound = responseRequestId,
+            mode = HttpOperationCorrelationMode.PROPAGATED,
+        ),
+        metricAttributes = metricTags,
+    ),
+    expectation = HttpOperationExpectation(
+        operationName = "http.server.requests",
+        routeTemplate = "/sales/{saleId}",
+        statusCode = 200,
+        classification = HttpOperationClassification.SUCCESS,
+        sensitiveValues = HttpOperationSensitiveValues(
+            rawUrl = rawUrl,
+            query = query,
+            clientIp = clientIp,
+            userId = userId,
+            saleId = saleId,
+            requestPayload = payload,
+        ),
+    ),
+)
+```
+
+fixture는 operation과 route의 안정성, status와 일치하는
+success/client-error/timeout-or-cancellation/dependency-failure 분류, propagated/generated/absent correlation
+의미, 민감한 metric 값 제외 여부를 확인합니다. 여섯 종류의 대표 민감 입력은 모두 필수입니다. 검증에
+성공하면 classification, status code, metric attribute 개수만 로그에 남기고, assertion 실패 메시지에서는
+비교값을 redaction하여 raw telemetry 값을 기록하지 않습니다.
+
+registry, tracer, exporter, OpenTelemetry SDK의 lifecycle은 테스트가 직접 소유합니다. 이 fixture는
+framework-neutral snapshot만 검증하며 telemetry 인프라를 설치하거나 종료하지 않습니다.
 
 ### 9. Stress Tester
 

--- a/testing/junit5/README.md
+++ b/testing/junit5/README.md
@@ -23,6 +23,7 @@ An extension library that reduces repetitive boilerplate in JUnit 5 tests.
 - System property helpers — set properties before a test and restore them after
 - Awaitility + coroutine helpers — `suspendUntil` / `awaitSuspending`
 - Coroutine cancellation contracts — verify propagation, waiter cleanup, and resource cancellation
+- HTTP observability conformance — verify stable routes, classifications, correlation, and sensitive-data exclusion
 - Stress-testing utilities — `MultithreadingTester`, `SuspendedJobTester`, `StructuredTaskScopeTester`
 - Parameter-source extensions — `FieldSource` for parameterized tests
 - Mermaid-based reporting — Gantt timeline of test execution
@@ -187,6 +188,52 @@ fun `cancellation cancels the underlying call`() = runSuspendIO {
 Do not wrap suspend APIs in plain `runCatching` when cancellation must propagate. `CancellationException` is the
 structured concurrency signal and must be rethrown. Use `runCatchingNonCancellation` or `resultOfNonCancellation`
 when an API intentionally returns `Result` for non-cancellation failures.
+
+### HTTP Observability Conformance
+
+Adapt a framework-owned test registry or tracer result into `HttpOperationObservation`, then verify the same contract
+from Spring Boot, Ktor, or another server integration.
+
+```kotlin
+assertHttpOperationObservability(
+    observation = HttpOperationObservation(
+        operationName = "http.server.requests",
+        routeTemplate = "/sales/{saleId}",
+        statusCode = 200,
+        classification = HttpOperationClassification.SUCCESS,
+        correlation = HttpOperationCorrelation(
+            inbound = requestId,
+            outbound = responseRequestId,
+            mode = HttpOperationCorrelationMode.PROPAGATED,
+        ),
+        metricAttributes = metricTags,
+    ),
+    expectation = HttpOperationExpectation(
+        operationName = "http.server.requests",
+        routeTemplate = "/sales/{saleId}",
+        statusCode = 200,
+        classification = HttpOperationClassification.SUCCESS,
+        sensitiveValues = HttpOperationSensitiveValues(
+            rawUrl = rawUrl,
+            query = query,
+            clientIp = clientIp,
+            userId = userId,
+            saleId = saleId,
+            requestPayload = payload,
+        ),
+    ),
+)
+```
+
+The fixture checks operation and route stability, status-compatible
+success/client-error/timeout-or-cancellation/dependency-failure classification, explicit propagated/generated/absent
+correlation semantics, and sensitive metric exclusion. All six representative sensitive inputs are required. A
+successful check logs only the bounded classification, status code, and metric-attribute count; assertion failures
+redact compared values and never log raw telemetry values.
+
+The test remains the lifecycle owner. Create and close the fake registry, tracer, exporter, and OpenTelemetry SDK in
+the Spring Boot or Ktor test; this fixture only validates the framework-neutral snapshot and does not install or close
+telemetry infrastructure.
 
 ### SystemProperty
 

--- a/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/observability/HttpOperationObservabilityConformance.kt
+++ b/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/observability/HttpOperationObservabilityConformance.kt
@@ -1,0 +1,249 @@
+package io.bluetape4k.junit5.observability
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import java.io.Serializable
+
+/** Logger name used by the HTTP operation observability conformance fixture. */
+const val HTTP_OPERATION_OBSERVABILITY_LOGGER_NAME: String =
+    "io.bluetape4k.junit5.observability.HttpOperationObservabilityConformance"
+
+/**
+ * Stable classifications shared by HTTP operation observability tests.
+ */
+enum class HttpOperationClassification {
+    SUCCESS,
+    CLIENT_ERROR,
+    TIMEOUT_OR_CANCELLATION,
+    DEPENDENCY_FAILURE,
+}
+
+/**
+ * Describes how the outbound correlation value relates to the inbound request.
+ */
+enum class HttpOperationCorrelationMode {
+    PROPAGATED,
+    GENERATED,
+    ABSENT,
+}
+
+/**
+ * Captures inbound and outbound correlation values for propagation assertions.
+ *
+ * The fixture compares these values but never writes them to its log.
+ */
+data class HttpOperationCorrelation(
+    val inbound: String?,
+    val outbound: String?,
+    val mode: HttpOperationCorrelationMode,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * Representative sensitive inputs that must be absent from metric attributes,
+ * operation names, route templates, and fixture logs.
+ */
+data class HttpOperationSensitiveValues(
+    val rawUrl: String,
+    val query: String,
+    val clientIp: String,
+    val userId: String,
+    val saleId: String,
+    val requestPayload: String,
+): Serializable {
+    internal fun asList(): List<String> =
+        listOf(rawUrl, query, clientIp, userId, saleId, requestPayload)
+
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * Framework-neutral snapshot of an observed HTTP operation.
+ *
+ * Spring Boot and Ktor tests adapt their fake registry or tracer output into
+ * this value without introducing a shared production routing API.
+ */
+data class HttpOperationObservation(
+    val operationName: String,
+    val routeTemplate: String,
+    val statusCode: Int?,
+    val classification: HttpOperationClassification,
+    val correlation: HttpOperationCorrelation,
+    val metricAttributes: Map<String, String>,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * Expected stable values and known sensitive inputs for one HTTP operation.
+ *
+ * [sensitiveValues] contains representative raw identifiers, addresses, query
+ * values, and payload fragments supplied to the framework integration.
+ */
+data class HttpOperationExpectation(
+    val operationName: String,
+    val routeTemplate: String,
+    val statusCode: Int?,
+    val classification: HttpOperationClassification,
+    val sensitiveValues: HttpOperationSensitiveValues,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * Verifies the shared HTTP operation observability contract.
+ *
+ * The assertion checks stable operation and route names, status/failure
+ * classification, correlation propagation, and low-cardinality metric
+ * attributes. It rejects common raw URL, query, address, identity, and payload
+ * attribute keys as well as caller-supplied sensitive values.
+ *
+ * A successful check emits one bounded summary log containing only the
+ * classification, status code, and attribute count. Raw telemetry values are
+ * never logged by this fixture. The caller owns and closes every registry,
+ * tracer, exporter, and SDK; this function only inspects the supplied snapshot.
+ */
+fun assertHttpOperationObservability(
+    observation: HttpOperationObservation,
+    expectation: HttpOperationExpectation,
+) {
+    assertRedacted(observation.operationName == expectation.operationName, "operation name")
+    assertRedacted(observation.routeTemplate == expectation.routeTemplate, "route template")
+    assertRedacted(observation.statusCode == expectation.statusCode, "status code")
+    assertRedacted(observation.classification == expectation.classification, "classification")
+    assertRedacted(isClassificationCompatible(observation), "classification semantics")
+
+    assertRedacted(!observation.routeTemplate.contains('?'), "route cardinality")
+    assertRedacted(!observation.routeTemplate.contains("://"), "route cardinality")
+    assertRedacted(
+        observation.metricAttributes["http.route"] == expectation.routeTemplate,
+        "metric route template",
+    )
+    assertRedacted(
+        observation.metricAttributes["http.response.status_code"] == observation.statusCode?.toString(),
+        "metric status code",
+    )
+
+    assertCorrelation(observation.correlation)
+    val correlationPresent = observation.correlation.inbound != null || observation.correlation.outbound != null
+    assertRedacted(
+        observation.metricAttributes["correlation.present"] == correlationPresent.toString(),
+        "metric correlation presence",
+    )
+
+    assertRedacted(
+        observation.metricAttributes.keys.none(::isForbiddenMetricAttributeKey),
+        "metric attribute key safety",
+    )
+    assertRedacted(
+        expectation.sensitiveValues.asList().all(String::isNotBlank),
+        "sensitive input coverage",
+    )
+
+    val telemetryText = buildString {
+        appendLine(observation.operationName)
+        appendLine(observation.routeTemplate)
+        observation.metricAttributes.forEach { (key, value) ->
+            appendLine("$key=$value")
+        }
+    }
+    assertRedacted(
+        expectation.sensitiveValues.asList().none(telemetryText::contains),
+        "sensitive telemetry exclusion",
+    )
+
+    HttpOperationObservabilityConformance.logVerified(observation)
+}
+
+private fun assertCorrelation(correlation: HttpOperationCorrelation) {
+    val matchesMode = when (correlation.mode) {
+        HttpOperationCorrelationMode.PROPAGATED ->
+            correlation.inbound != null && correlation.outbound == correlation.inbound
+
+        HttpOperationCorrelationMode.GENERATED ->
+            correlation.inbound == null && correlation.outbound != null
+
+        HttpOperationCorrelationMode.ABSENT ->
+            correlation.inbound == null && correlation.outbound == null
+    }
+    assertRedacted(matchesMode, "correlation contract")
+}
+
+private fun isClassificationCompatible(observation: HttpOperationObservation): Boolean =
+    when (observation.classification) {
+        HttpOperationClassification.SUCCESS ->
+            observation.statusCode != null && observation.statusCode in 100..399
+
+        HttpOperationClassification.CLIENT_ERROR ->
+            observation.statusCode != null && observation.statusCode in 400..499
+
+        HttpOperationClassification.TIMEOUT_OR_CANCELLATION ->
+            observation.statusCode == null || observation.statusCode in setOf(408, 499, 504)
+
+        HttpOperationClassification.DEPENDENCY_FAILURE ->
+            observation.statusCode == null || observation.statusCode >= 500
+    }
+
+private fun assertRedacted(condition: Boolean, field: String) {
+    if (!condition) {
+        throw AssertionError("HTTP observability conformance failed for $field; values redacted")
+    }
+}
+
+private object HttpOperationObservabilityConformance: KLogging() {
+    fun logVerified(observation: HttpOperationObservation) {
+        log.info {
+            "HTTP observability conformance verified: " +
+                    "classification=${observation.classification}, " +
+                    "statusCode=${observation.statusCode}, " +
+                    "metricAttributeCount=${observation.metricAttributes.size}"
+        }
+    }
+}
+
+private fun isForbiddenMetricAttributeKey(key: String): Boolean {
+    val normalized = key.lowercase().replace('_', '.').replace('-', '.')
+    val compact = normalized.replace(".", "")
+    return normalized in FORBIDDEN_METRIC_ATTRIBUTE_KEYS ||
+            FORBIDDEN_METRIC_ATTRIBUTE_FRAGMENTS.any(normalized::contains) ||
+            FORBIDDEN_METRIC_ATTRIBUTE_COMPACT_FRAGMENTS.any(compact::contains)
+}
+
+private val FORBIDDEN_METRIC_ATTRIBUTE_KEYS = setOf(
+    "url.full",
+    "url.query",
+    "http.url",
+    "http.query",
+    "client.address",
+    "network.peer.address",
+    "remote.address",
+    "ip.address",
+    "request.body",
+    "response.body",
+    "http.request.body",
+    "http.response.body",
+)
+
+private val FORBIDDEN_METRIC_ATTRIBUTE_FRAGMENTS = setOf(
+    "user.id",
+    "sale.id",
+    "request.payload",
+    "response.payload",
+)
+
+private val FORBIDDEN_METRIC_ATTRIBUTE_COMPACT_FRAGMENTS = setOf(
+    "clientip",
+    "userid",
+    "saleid",
+    "requestpayload",
+    "responsepayload",
+)

--- a/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/observability/HttpOperationObservabilityConformanceTest.kt
+++ b/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/observability/HttpOperationObservabilityConformanceTest.kt
@@ -1,0 +1,273 @@
+package io.bluetape4k.junit5.observability
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotContain
+import io.bluetape4k.junit5.output.InMemoryLogbackAppender
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HttpOperationObservabilityConformanceTest {
+
+    @Test
+    fun `safe HTTP observation satisfies the conformance contract and logs only bounded metadata`() {
+        val observation = successObservation()
+        val expectation = successExpectation()
+
+        InMemoryLogbackAppender(HTTP_OPERATION_OBSERVABILITY_LOGGER_NAME).use { appender ->
+            assertHttpOperationObservability(observation, expectation)
+
+            appender.size shouldBeEqualTo 1
+            appender.lastMessage shouldBeEqualTo
+                    "HTTP observability conformance verified: " +
+                    "classification=SUCCESS, statusCode=200, metricAttributeCount=4"
+            appender.messages.forEach { message ->
+                message shouldNotContain observation.operationName
+                message shouldNotContain observation.routeTemplate
+                message shouldNotContain observation.correlation.inbound.orEmpty()
+                sensitiveValueSet.forEach { sensitiveValue ->
+                    message shouldNotContain sensitiveValue
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `all required HTTP result classifications satisfy the same contract`() {
+        val cases = listOf(
+            HttpOperationClassification.SUCCESS to 200,
+            HttpOperationClassification.CLIENT_ERROR to 404,
+            HttpOperationClassification.TIMEOUT_OR_CANCELLATION to null,
+            HttpOperationClassification.DEPENDENCY_FAILURE to 503,
+        )
+
+        cases.forEach { (classification, statusCode) ->
+            val observation = successObservation().copy(
+                statusCode = statusCode,
+                classification = classification,
+                metricAttributes = successObservation().metricAttributes.withStatusCode(statusCode),
+            )
+            val expectation = successExpectation().copy(
+                statusCode = statusCode,
+                classification = classification,
+            )
+
+            assertHttpOperationObservability(observation, expectation)
+        }
+    }
+
+    @Test
+    fun `semantically invalid status and classification pairs fail the conformance contract`() {
+        val invalidCases = listOf(
+            HttpOperationClassification.SUCCESS to 503,
+            HttpOperationClassification.CLIENT_ERROR to 200,
+            HttpOperationClassification.TIMEOUT_OR_CANCELLATION to 200,
+            HttpOperationClassification.DEPENDENCY_FAILURE to 404,
+        )
+
+        invalidCases.forEach { (classification, statusCode) ->
+            val observation = successObservation().copy(
+                statusCode = statusCode,
+                classification = classification,
+                metricAttributes = successObservation().metricAttributes.withStatusCode(statusCode),
+            )
+            val expectation = successExpectation().copy(
+                statusCode = statusCode,
+                classification = classification,
+            )
+
+            assertFailsWith<AssertionError> {
+                assertHttpOperationObservability(observation, expectation)
+            }
+        }
+    }
+
+    @Test
+    fun `metric status must match the observed HTTP status`() {
+        val mismatchedStatus = successObservation().copy(
+            metricAttributes = successObservation().metricAttributes + ("http.response.status_code" to "503"),
+        )
+
+        assertFailsWith<AssertionError> {
+            assertHttpOperationObservability(mismatchedStatus, successExpectation())
+        }
+    }
+
+    @Test
+    fun `standard body size metric keys remain low-cardinality safe`() {
+        val bodySizes = successObservation().copy(
+            metricAttributes = successObservation().metricAttributes + mapOf(
+                "http.request.body.size" to "14",
+                "http.response.body.size" to "2",
+            ),
+        )
+
+        assertHttpOperationObservability(bodySizes, successExpectation())
+    }
+
+    @Test
+    fun `raw route fails the conformance contract`() {
+        val rawRoute = "/sales/sale-123"
+        val rawRouteObservation = successObservation().copy(
+            routeTemplate = rawRoute,
+            metricAttributes = successObservation().metricAttributes + ("http.route" to rawRoute),
+        )
+        val rawRouteExpectation = successExpectation().copy(routeTemplate = rawRoute)
+
+        val failure = assertFailsWith<AssertionError> {
+            assertHttpOperationObservability(rawRouteObservation, rawRouteExpectation)
+        }
+        failure.message.orEmpty() shouldContain "values redacted"
+        sensitiveValueSet.forEach { sensitiveValue ->
+            failure.message.orEmpty() shouldNotContain sensitiveValue
+        }
+    }
+
+    @Test
+    fun `sensitive metric keys independently fail the conformance contract`() {
+        val unsafeAttributes = mapOf(
+            "url.full" to "https://example.test/sales/sale-123",
+            "url.query" to "user=user-456",
+            "client.address" to "203.0.113.7",
+            "user.id" to "user-456",
+            "sale.id" to "sale-123",
+            "request.payload" to "payload-secret",
+            "client_ip" to "203.0.113.7",
+            "userId" to "user-456",
+            "sale-id" to "sale-123",
+            "requestPayload" to "payload-secret",
+        )
+
+        unsafeAttributes.forEach { (key, value) ->
+            val unsafeObservation = successObservation().copy(
+                metricAttributes = successObservation().metricAttributes + (key to value),
+            )
+
+            assertFailsWith<AssertionError> {
+                assertHttpOperationObservability(unsafeObservation, successExpectation())
+            }
+        }
+    }
+
+    @Test
+    fun `sensitive metric value under an unrecognized key fails the conformance contract`() {
+        val unsafeObservation = successObservation().copy(
+            metricAttributes = successObservation().metricAttributes + ("custom.label" to "sale-123"),
+        )
+
+        assertFailsWith<AssertionError> {
+            assertHttpOperationObservability(unsafeObservation, successExpectation())
+        }
+    }
+
+    @Test
+    fun `blank sensitive input coverage fails the conformance contract`() {
+        val incompleteExpectation = successExpectation().copy(
+            sensitiveValues = sensitiveValues().copy(requestPayload = ""),
+        )
+
+        assertFailsWith<AssertionError> {
+            assertHttpOperationObservability(successObservation(), incompleteExpectation)
+        }
+    }
+
+    @Test
+    fun `correlation mismatch fails the conformance contract`() {
+        val mismatched = successObservation().copy(
+            correlation = HttpOperationCorrelation(
+                inbound = "request-123",
+                outbound = "different-456",
+                mode = HttpOperationCorrelationMode.PROPAGATED,
+            ),
+        )
+
+        assertFailsWith<AssertionError> {
+            assertHttpOperationObservability(mismatched, successExpectation())
+        }
+    }
+
+    @Test
+    fun `generated correlation satisfies the explicit generated contract`() {
+        val generated = successObservation().copy(
+            correlation = HttpOperationCorrelation(
+                inbound = null,
+                outbound = "generated-123",
+                mode = HttpOperationCorrelationMode.GENERATED,
+            ),
+        )
+
+        assertHttpOperationObservability(generated, successExpectation())
+    }
+
+    @Test
+    fun `absent correlation satisfies the explicit absent contract`() {
+        val absent = successObservation().copy(
+            correlation = HttpOperationCorrelation(
+                inbound = null,
+                outbound = null,
+                mode = HttpOperationCorrelationMode.ABSENT,
+            ),
+            metricAttributes = successObservation().metricAttributes + ("correlation.present" to "false"),
+        )
+
+        assertHttpOperationObservability(absent, successExpectation())
+    }
+
+    private fun successObservation(): HttpOperationObservation =
+        HttpOperationObservation(
+            operationName = "http.server.requests",
+            routeTemplate = "/sales/{saleId}",
+            statusCode = 200,
+            classification = HttpOperationClassification.SUCCESS,
+            correlation = HttpOperationCorrelation(
+                inbound = "request-123",
+                outbound = "request-123",
+                mode = HttpOperationCorrelationMode.PROPAGATED,
+            ),
+            metricAttributes = mapOf(
+                "http.request.method" to "GET",
+                "http.route" to "/sales/{saleId}",
+                "http.response.status_code" to "200",
+                "correlation.present" to "true",
+            ),
+        )
+
+    private fun successExpectation(): HttpOperationExpectation =
+        HttpOperationExpectation(
+            operationName = "http.server.requests",
+            routeTemplate = "/sales/{saleId}",
+            statusCode = 200,
+            classification = HttpOperationClassification.SUCCESS,
+            sensitiveValues = sensitiveValues(),
+        )
+
+    private companion object {
+        fun Map<String, String>.withStatusCode(statusCode: Int?): Map<String, String> =
+            if (statusCode == null) {
+                this - "http.response.status_code"
+            } else {
+                this + ("http.response.status_code" to statusCode.toString())
+            }
+
+        val sensitiveValueSet = setOf(
+            "https://example.test/sales/sale-123?user=user-456",
+            "user=user-456",
+            "203.0.113.7",
+            "user-456",
+            "sale-123",
+            "payload-secret",
+        )
+
+        fun sensitiveValues(): HttpOperationSensitiveValues =
+            HttpOperationSensitiveValues(
+                rawUrl = "https://example.test/sales/sale-123?user=user-456",
+                query = "user=user-456",
+                clientIp = "203.0.113.7",
+                userId = "user-456",
+                saleId = "sale-123",
+                requestPayload = "payload-secret",
+            )
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1050

- PR 제목: test: Add HTTP observability conformance fixtures

- add a framework-neutral JUnit 5 conformance fixture for stable HTTP operation names, route templates, status/failure classification, and correlation modes
- require representative raw URL, query, IP, user, sale, and payload inputs and reject them from metric attributes with redacted assertion failures
- emit exactly one bounded success log containing only classification, status, and metric attribute count
- adapt actual Spring MockMvc observations and Ktor Micrometer/OpenTelemetry output without adding a shared production routing API
- keep registry, exporter, tracer provider, and OpenTelemetry SDK lifecycle caller-owned

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: References

- [OpenTelemetry HTTP metrics semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/)
- [Micrometer observation testing](https://docs.micrometer.io/micrometer/reference/observation/testing.html)

Closes #1050

## Validation

- `:bluetape4k-junit5:test` — 281 passing
- `:bluetape4k-ktor-observability:test` — 12 passing
- `:bluetape4k-spring-boot-core:test` — 240 passing
- `git diff --check` — passing
- root `detekt` — successful, `NO-SOURCE`
- independent code review — APPROVE, P0/P1/P2 = 0
- independent architecture review — PASS, P0/P1/P2 = 0

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1050, milestone `1.12.0`, assignee `debop`
- PR: #1058, head `6dfa4ac8a0425a63c1bf7733923ca237a2fcc3dc`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `test/issue-1050-http-observability-conformance`
- Labels: `enhancement`, `test`, `security`
- State: `MERGED`, merge commit `06c6d0bc823f504c47536fce6b1e07f2b3e3698b`
- CI: - root `detekt` — successful, `NO-SOURCE` / - [x] Caller-owned telemetry lifecycle is documented and exercised

## DoD Status

- [x] Shared test-only fixture covers success, client error, timeout/cancellation, and dependency failure semantics
- [x] Spring Boot and Ktor consume actual framework telemetry
- [x] Low-cardinality route and metric status contracts are enforced
- [x] Sensitive metric dimensions and log leakage are regression-tested
- [x] Caller-owned telemetry lifecycle is documented and exercised
- [x] Targeted module suites and independent reviews pass

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1058 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `06c6d0bc823f504c47536fce6b1e07f2b3e3698b`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
