### PR TITLE
perf(data-r2dbc): split pool benchmark validation modes

### DIFF
--- a/data/r2dbc/README.ko.md
+++ b/data/r2dbc/README.ko.md
@@ -75,31 +75,43 @@ val pool = r2dbcConnectionPool("r2dbc:postgresql://user:secret@localhost:5432/ap
 풀 benchmark는 다음 task로 실행합니다.
 
 ```bash
-./gradlew :bluetape4k-r2dbc:benchmarkPoolConfig
-./gradlew :bluetape4k-r2dbc:benchmarkH2PoolAcquire
-./gradlew :bluetape4k-r2dbc:benchmarkPostgresPoolAcquire
-./gradlew :bluetape4k-r2dbc:benchmarkMysql8PoolAcquire
-./gradlew :bluetape4k-r2dbc:benchmarkH2PoolContention
+./gradlew :bluetape4k-r2dbc:benchmarkPoolConfigBenchmark
+./gradlew :bluetape4k-r2dbc:benchmarkH2PoolAcquireBenchmark
+./gradlew :bluetape4k-r2dbc:benchmarkPostgresPoolAcquireBenchmark
+./gradlew :bluetape4k-r2dbc:benchmarkMysql8PoolAcquireBenchmark
+./gradlew :bluetape4k-r2dbc:benchmarkH2PoolContentionBenchmark
 ```
 
-PostgreSQL과 MySQL benchmark는 Testcontainers 기반 DB를 사용하므로 순차로 실행하세요.
+PostgreSQL과 MySQL benchmark는 Testcontainers 기반 DB를 사용하므로 순차로 실행하세요. 각 acquire task는 다음 validation mode를 명시적으로 측정합니다.
 
-최근 로컬 acquire benchmark(`8` JMH threads, `3` measurement iterations,
-`validationQuery = "SELECT 1"`)에서는 순수 acquire/close 처리량은 드라이버마다 달랐고, 실제 커넥션 점유 시간이 들어가면 기본/고처리량 profile이 수렴했습니다.
+- `local`: `ValidationDepth.LOCAL`, validation query 없음.
+- `sql`: `ValidationDepth.LOCAL`, `validationQuery = "SELECT 1"`.
 
-| DB                          | 점유 시간 | 기본 설정         | 고처리량 프리셋      |
-|-----------------------------|-------|---------------|---------------|
-| H2                          | 0 ms  | 100,200 ops/s | 95,423 ops/s  |
-| H2                          | 1 ms  | 6,921 ops/s   | 6,906 ops/s   |
-| H2                          | 5 ms  | 1,430 ops/s   | 1,439 ops/s   |
-| PostgreSQL 18 Testcontainer | 0 ms  | 16,571 ops/s  | 16,960 ops/s  |
-| PostgreSQL 18 Testcontainer | 1 ms  | 4,271 ops/s   | 4,695 ops/s   |
-| PostgreSQL 18 Testcontainer | 5 ms  | 1,050 ops/s   | 1,066 ops/s   |
-| MySQL 8.4 Testcontainer     | 0 ms  | 9,007 ops/s   | 8,251 ops/s   |
-| MySQL 8.4 Testcontainer     | 1 ms  | 4,266 ops/s   | 4,279 ops/s   |
-| MySQL 8.4 Testcontainer     | 5 ms  | 918 ops/s     | 960 ops/s     |
+모든 acquire benchmark method에는 `30s` JMH iteration timeout이 적용됩니다. 생성된 Gradle task에도 `5m` task timeout을 적용하므로 interrupt를 무시하는 JMH worker가 automation을 무기한 막을 수 없습니다. Trial lifecycle log에는 validation mode, pool 설정, acquired/failed count가 기록됩니다.
 
-![R2DBC Pool Acquire Throughput chart](../../docs/images/readme-charts/data-r2dbc-pool-acquire-throughput-chart-01.png)
+아래 로컬 snapshot은 2026-07-19에 `8` JMH threads, `1` warmup iteration,
+`3` measurement iterations로 측정했습니다. 처리량은 높을수록 좋습니다. 짧은 `1s` 측정 구간 때문에 특히 `0 ms` 결과의 오차 구간이 넓으므로, 이 수치는 관측된 validation 비용을 설명하는 기준선이며 profile 순위가 아닙니다.
+
+| DB                          | 점유 시간 | Validation | 기본 ops/s | 고처리량 ops/s |
+|-----------------------------|----------:|------------|-----------:|----------------:|
+| H2                          | 0 ms      | local      | 110,992    | 93,080          |
+| H2                          | 0 ms      | sql        | 101,184    | 86,400          |
+| H2                          | 1 ms      | local      | 6,899      | 6,962           |
+| H2                          | 1 ms      | sql        | 6,911      | 6,895           |
+| H2                          | 5 ms      | local      | 1,417      | 1,442           |
+| H2                          | 5 ms      | sql        | 1,430      | 1,428           |
+| PostgreSQL 18 Testcontainer | 0 ms      | local      | 113,743    | 114,217         |
+| PostgreSQL 18 Testcontainer | 0 ms      | sql        | 16,970     | 16,780          |
+| PostgreSQL 18 Testcontainer | 1 ms      | local      | 6,312      | 6,875           |
+| PostgreSQL 18 Testcontainer | 1 ms      | sql        | 3,981      | 4,229           |
+| PostgreSQL 18 Testcontainer | 5 ms      | local      | 1,438      | 1,426           |
+| PostgreSQL 18 Testcontainer | 5 ms      | sql        | 1,048      | 1,052           |
+| MySQL 8.4 Testcontainer     | 0 ms      | local      | 17,132     | 16,176          |
+| MySQL 8.4 Testcontainer     | 0 ms      | sql        | 8,385      | 8,010           |
+| MySQL 8.4 Testcontainer     | 1 ms      | local      | 3,952      | 3,470           |
+| MySQL 8.4 Testcontainer     | 1 ms      | sql        | 4,075      | 3,899           |
+| MySQL 8.4 Testcontainer     | 5 ms      | local      | 1,084      | 1,044           |
+| MySQL 8.4 Testcontainer     | 5 ms      | sql        | 913        | 925             |
 
 contention benchmark는 `64` JMH threads에서 동시성보다 작은 `maxSize`를 사용합니다.
 기본 profile은 이 benchmark에서 무제한 pending queue를 사용하고, high-throughput profile은 제한된 pending acquire와
@@ -118,10 +130,8 @@ contention benchmark는 `64` JMH threads에서 동시성보다 작은 `maxSize`�
 
 #### 실측 기반 튜닝 가이드
 
-- 순수 acquire/close 경로(
-  `0 ms` 점유)는 실제 사용하는 드라이버 기준으로 비교하세요. 이번 실행에서는 H2/PostgreSQL은 고처리량 프리셋이 약간 높았고, MySQL 8은 기본 profile이 높았습니다. 이 경로는 대부분 드라이버/풀 오버헤드 microbenchmark이므로 서버 기본값을 이것만으로 결정하지 마세요.
-- 요청이 SQL 또는 트랜잭션 실행 동안 커넥션을 점유하는 서버 워크로드라면 `R2dbcPoolConfig.highThroughput()`을 사용하세요. `1 ms`,
-  `5 ms` 점유 시간에서는 H2, PostgreSQL, MySQL 8 모두 점유 시간이 처리량을 지배해 두 profile이 사실상 수렴했고, 이때는 high-throughput 프리셋의 bounded queue와 warmup 동작이 더 중요한 운영 속성이 됩니다.
+- 순수 acquire/close 경로(`0 ms` 점유)는 같은 드라이버 안에서 `local`과 `sql`을 비교하세요. 이번 snapshot에서는 PostgreSQL과 MySQL에서 SQL validation 비용이 분명했지만, H2는 오차 구간이 넓어 순위를 판단할 수 없습니다.
+- 요청이 SQL 또는 트랜잭션 실행 동안 커넥션을 점유하는 서버 워크로드라면 `R2dbcPoolConfig.highThroughput()`을 사용하세요. 점유 시간이 늘수록 connection occupancy가 validation과 profile 차이를 지배할 수 있으므로, 노이즈가 큰 microbenchmark 순위보다 bounded queue와 warmup 동작이 더 중요합니다.
 - 동시 요청 수가 풀 크기를 넘고 DB가 추가 세션을 감당할 수 있을 때만 `maxSize`를 늘리세요. `64`개 경쟁 thread에서는 커넥션 슬롯이 병목이라 처리량이
   기본 profile의 무제한 queue 경로에서 `maxSize`에 거의 선형으로 반응했습니다.
 - failure count가 큰 high-throughput contention 행은 성공 SQL 처리량이 아니라 과부하 신호로 해석하세요. 제한된 pending queue는 backpressure를 빠르게 드러냅니다. DB가 추가 작업을 감당할 수 있을 때만 `maxSize`, pending queue, acquire timeout 예산을 늘리고, 그렇지 않으면 traffic shed나 hold time 감소를 우선하세요.
@@ -135,8 +145,7 @@ contention benchmark는 `64` JMH threads에서 동시성보다 작은 `maxSize`�
   `maxSize * 4`를 사용해 짧은 burst는 흡수하되, 과부하를 숨기고 tail latency를 키우는 무제한 backlog를 피합니다.
 - `maxPendingAcquire`가 너무 작으면 풀과 pending queue가 찼을 때 r2dbc-pool이 추가 획득을 거부합니다. 이는 fail-fast 과부하 제어에 유용하지만, 애플리케이션 acquire 실패/timeout 지표와 함께 운영해야 합니다.
 - `maxAcquireTime`은 유한한 값으로 두세요. API 서비스는 `2-3s`를 시작점으로 삼고, 실패보다 대기가 나은 배치 작업은 더 길게 둘 수 있습니다.
-- 운영 드라이버가 로컬 검증을 지원한다면 `ValidationDepth.LOCAL`과 `validationQuery = null`을 우선하세요. benchmark에서
-  `SELECT 1`을 사용한 것은 H2/PostgreSQL/MySQL 검증 경로를 일관되게 만들기 위한 것이며, SQL 검증 쿼리는 커넥션 획득마다 DB 왕복을 추가합니다.
+- 운영 드라이버가 로컬 검증을 지원한다면 `ValidationDepth.LOCAL`과 `validationQuery = null`을 우선하세요. 배포 환경에서 `SELECT 1`이 명시적으로 필요할 때는 benchmark의 `sql` mode를 사용하세요. SQL 검증은 커넥션 획득마다 DB 왕복을 추가합니다.
 - 위 수치는 로컬 기준선이지 보편적 한계값이 아닙니다. 쿼리 latency, 트랜잭션 시간, 인스턴스 수, DB 커넥션 한도가 바뀌면 DB별 pool acquire benchmark를 다시 실행하세요.
 
 ### 2. DatabaseClient SQL 실행

--- a/data/r2dbc/README.md
+++ b/data/r2dbc/README.md
@@ -77,32 +77,49 @@ building an unbounded queue.
 Run the pool benchmarks with:
 
 ```bash
-./gradlew :bluetape4k-r2dbc:benchmarkPoolConfig
-./gradlew :bluetape4k-r2dbc:benchmarkH2PoolAcquire
-./gradlew :bluetape4k-r2dbc:benchmarkPostgresPoolAcquire
-./gradlew :bluetape4k-r2dbc:benchmarkMysql8PoolAcquire
-./gradlew :bluetape4k-r2dbc:benchmarkH2PoolContention
+./gradlew :bluetape4k-r2dbc:benchmarkPoolConfigBenchmark
+./gradlew :bluetape4k-r2dbc:benchmarkH2PoolAcquireBenchmark
+./gradlew :bluetape4k-r2dbc:benchmarkPostgresPoolAcquireBenchmark
+./gradlew :bluetape4k-r2dbc:benchmarkMysql8PoolAcquireBenchmark
+./gradlew :bluetape4k-r2dbc:benchmarkH2PoolContentionBenchmark
 ```
 
 Run PostgreSQL and MySQL benchmark tasks sequentially because they use
-Testcontainers-backed databases.
+Testcontainers-backed databases. Each acquire task measures two explicit validation modes:
 
-Recent local acquire benchmark (`8` JMH threads, `3` measurement iterations,
-`validationQuery = "SELECT 1"`) showed that pure acquire/close throughput varies by driver, while realistic connection hold time makes default and high-throughput profiles converge:
+- `local`: `ValidationDepth.LOCAL` with no validation query.
+- `sql`: `ValidationDepth.LOCAL` with `validationQuery = "SELECT 1"`.
 
-| Database                    | Hold time | Default       | High-throughput |
-|-----------------------------|-----------|---------------|-----------------|
-| H2                          | 0 ms      | 100,200 ops/s | 95,423 ops/s    |
-| H2                          | 1 ms      | 6,921 ops/s   | 6,906 ops/s     |
-| H2                          | 5 ms      | 1,430 ops/s   | 1,439 ops/s     |
-| PostgreSQL 18 Testcontainer | 0 ms      | 16,571 ops/s  | 16,960 ops/s    |
-| PostgreSQL 18 Testcontainer | 1 ms      | 4,271 ops/s   | 4,695 ops/s     |
-| PostgreSQL 18 Testcontainer | 5 ms      | 1,050 ops/s   | 1,066 ops/s     |
-| MySQL 8.4 Testcontainer     | 0 ms      | 9,007 ops/s   | 8,251 ops/s     |
-| MySQL 8.4 Testcontainer     | 1 ms      | 4,266 ops/s   | 4,279 ops/s     |
-| MySQL 8.4 Testcontainer     | 5 ms      | 918 ops/s     | 960 ops/s       |
+Every acquire benchmark method has a `30s` JMH iteration timeout. The generated Gradle
+tasks also have a `5m` task timeout so an interrupt-resistant JMH worker cannot block
+automation indefinitely. Trial lifecycle logs include the validation mode, pool
+configuration, and acquired/failed counts.
 
-![R2DBC Pool Acquire Throughput chart](../../docs/images/readme-charts/data-r2dbc-pool-acquire-throughput-chart-01.png)
+The following local snapshot was recorded on 2026-07-19 with `8` JMH threads,
+`1` warmup iteration, and `3` measurement iterations. Throughput is higher-is-better.
+The short `1s` windows produced wide error intervals, especially for `0 ms`, so these
+scores describe the observed validation cost and are not profile rankings.
+
+| Database                    | Hold time | Validation | Default ops/s | High-throughput ops/s |
+|-----------------------------|----------:|------------|--------------:|----------------------:|
+| H2                          | 0 ms      | local      | 110,992       | 93,080                |
+| H2                          | 0 ms      | sql        | 101,184       | 86,400                |
+| H2                          | 1 ms      | local      | 6,899         | 6,962                 |
+| H2                          | 1 ms      | sql        | 6,911         | 6,895                 |
+| H2                          | 5 ms      | local      | 1,417         | 1,442                 |
+| H2                          | 5 ms      | sql        | 1,430         | 1,428                 |
+| PostgreSQL 18 Testcontainer | 0 ms      | local      | 113,743       | 114,217               |
+| PostgreSQL 18 Testcontainer | 0 ms      | sql        | 16,970        | 16,780                |
+| PostgreSQL 18 Testcontainer | 1 ms      | local      | 6,312         | 6,875                 |
+| PostgreSQL 18 Testcontainer | 1 ms      | sql        | 3,981         | 4,229                 |
+| PostgreSQL 18 Testcontainer | 5 ms      | local      | 1,438         | 1,426                 |
+| PostgreSQL 18 Testcontainer | 5 ms      | sql        | 1,048         | 1,052                 |
+| MySQL 8.4 Testcontainer     | 0 ms      | local      | 17,132        | 16,176                |
+| MySQL 8.4 Testcontainer     | 0 ms      | sql        | 8,385         | 8,010                 |
+| MySQL 8.4 Testcontainer     | 1 ms      | local      | 3,952         | 3,470                 |
+| MySQL 8.4 Testcontainer     | 1 ms      | sql        | 4,075         | 3,899                 |
+| MySQL 8.4 Testcontainer     | 5 ms      | local      | 1,084         | 1,044                 |
+| MySQL 8.4 Testcontainer     | 5 ms      | sql        | 913           | 925                   |
 
 The contention benchmark uses `64` JMH threads with `maxSize` below concurrency.
 Default uses an unbounded pending queue in this benchmark; high-throughput uses
@@ -123,8 +140,8 @@ the acquired/failed trial counts.
 
 #### Tuning guide from the measurement
 
-- For pure acquire/close paths (`0 ms` hold), compare with your actual driver. H2/PostgreSQL slightly favored the high-throughput preset in this run, while MySQL 8 favored the default profile. This path is mostly a driver/pool overhead microbenchmark and should not drive server defaults by itself.
-- Use `R2dbcPoolConfig.highThroughput()` for server workloads where each request holds a connection while running SQL or a transaction. At `1 ms` and `5 ms` hold time, throughput was dominated by the hold time and the two profiles were effectively equivalent across H2, PostgreSQL, and MySQL 8, so the high-throughput preset's bounded queue and warmup behavior become the more important operational property.
+- For pure acquire/close paths (`0 ms` hold), compare `local` and `sql` within the same driver. PostgreSQL and MySQL showed a visible SQL validation cost in this snapshot, while the H2 error intervals were too wide for a ranking claim.
+- Use `R2dbcPoolConfig.highThroughput()` for server workloads where each request holds a connection while running SQL or a transaction. As hold time increases, connection occupancy can dominate validation and profile differences, so bounded queues and warmup behavior become more important than a noisy microbenchmark ranking.
 - Increase `maxSize` only when concurrent requests exceed the pool size and the database can handle the additional sessions. Under `64` contending threads, throughput scaled almost linearly with `maxSize` on the default unbounded queue path because the benchmark was connection-slot limited.
 - Treat high-throughput contention rows with large failure counts as overload evidence, not as successful SQL throughput. A bounded pending queue exposes backpressure quickly; raise `maxSize`, reduce hold time, shed traffic, or increase the pending/acquire timeout budget only when the database can absorb the extra work.
 - Long-running queries and transactions reduce the useful throughput ceiling to roughly
@@ -139,9 +156,9 @@ the acquired/failed trial counts.
 - If `maxPendingAcquire` is too low, r2dbc-pool rejects extra acquire attempts once the pool and pending queue are full. This is useful for fail-fast overload control, but it should be paired with application metrics for acquire failures/timeouts.
 - Keep `maxAcquireTime` finite.
   `2-3s` is a reasonable starting point for API services; batch jobs can use a longer timeout if waiting is preferable to failing.
-- Prefer `ValidationDepth.LOCAL` and no
-  `validationQuery` in production drivers that support local validation. The benchmark used
-  `SELECT 1` to keep H2/PostgreSQL/MySQL validation behavior consistent; a SQL validation query adds one database round trip to every connection acquisition.
+- Prefer `ValidationDepth.LOCAL` and no `validationQuery` in production drivers that support
+  local validation. Use the benchmark's `sql` mode when the deployment deliberately requires
+  `SELECT 1`; it adds one database round trip to every connection acquisition.
 - Treat benchmark numbers as local baselines, not universal limits. Re-run the DB-specific pool acquire benchmark against your driver/database shape when query latency, transaction duration, instance count, or DB connection limits change.
 
 ### 2. Executing SQL with DatabaseClient

--- a/data/r2dbc/build.gradle.kts
+++ b/data/r2dbc/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.time.Duration
+
 plugins {
     kotlin("plugin.allopen")
     kotlin("plugin.spring")
@@ -96,6 +98,20 @@ benchmark {
             reportFormat = "json"
         }
     }
+}
+
+val poolAcquireBenchmarkTaskNames = setOf(
+    "benchmarkH2PoolAcquireBenchmark",
+    "benchmarkPostgresPoolAcquireBenchmark",
+    "benchmarkMysql8PoolAcquireBenchmark",
+)
+val poolAcquireBenchmarkTaskTimeout = providers
+    .gradleProperty("r2dbcPoolAcquireBenchmarkTaskTimeoutSeconds")
+    .map { Duration.ofSeconds(it.toLong()) }
+    .orElse(Duration.ofMinutes(5))
+
+tasks.matching { it.name in poolAcquireBenchmarkTaskNames }.configureEach {
+    timeout.set(poolAcquireBenchmarkTaskTimeout)
 }
 
 dependencies {

--- a/data/r2dbc/src/benchmark/kotlin/io/bluetape4k/r2dbc/benchmark/R2dbcPoolAcquireBenchmark.kt
+++ b/data/r2dbc/src/benchmark/kotlin/io/bluetape4k/r2dbc/benchmark/R2dbcPoolAcquireBenchmark.kt
@@ -1,5 +1,7 @@
 package io.bluetape4k.r2dbc.benchmark
 
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
 import io.bluetape4k.r2dbc.pool.R2dbcPoolConfig
 import io.bluetape4k.r2dbc.pool.connectionFactoryOptionsOf
 import io.bluetape4k.r2dbc.pool.connectionPoolOf
@@ -25,6 +27,7 @@ import org.openjdk.jmh.annotations.Setup
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.TearDown
 import org.openjdk.jmh.annotations.Threads
+import org.openjdk.jmh.annotations.Timeout
 import org.openjdk.jmh.annotations.Warmup
 import org.openjdk.jmh.infra.Blackhole
 import java.time.Duration
@@ -37,7 +40,8 @@ import java.util.concurrent.atomic.LongAdder
  * 측정 경로는 `Publisher`를 코루틴으로 브리지하는 실제 사용 패턴에 맞춰
  * `kotlinx-coroutines-reactor`의 `awaitSingle`과 `kotlinx-coroutines-reactive`의
  * `awaitFirstOrNull`을 사용합니다. [holdMillis]는 쿼리/트랜잭션이 커넥션을 점유하는 시간을
- * 단순 지연으로 모델링합니다.
+ * 단순 지연으로 모델링합니다. `validationMode`는 SQL 왕복이 없는 `local`과 `SELECT 1`을
+ * 실행하는 `sql`을 구분합니다.
  */
 @State(Scope.Benchmark)
 abstract class AbstractR2dbcPoolAcquireBenchmark {
@@ -47,6 +51,9 @@ abstract class AbstractR2dbcPoolAcquireBenchmark {
 
     @Param("0", "1", "5")
     var holdMillis: Long = 0
+
+    @Param("local", "sql")
+    lateinit var validationMode: String
 
     private lateinit var pool: ConnectionPool
     private lateinit var poolConfig: R2dbcPoolConfig
@@ -59,8 +66,13 @@ abstract class AbstractR2dbcPoolAcquireBenchmark {
 
     @Setup(Level.Trial)
     fun setup() {
-        poolConfig = acquireBenchmarkPoolConfig(profile)
+        poolConfig = acquireBenchmarkPoolConfig(profile, validationMode)
         pool = connectionPoolOf(connectionFactoryOptions(), poolConfig)
+        log.info {
+            "Started R2DBC pool acquire benchmark: database=$databaseName, profile=$profile, " +
+                    "holdMillis=$holdMillis, validationMode=$validationMode, " +
+                    poolConfig.describeBenchmarkPoolConfig()
+        }
     }
 
     @TearDown(Level.Trial)
@@ -68,11 +80,12 @@ abstract class AbstractR2dbcPoolAcquireBenchmark {
         if (::pool.isInitialized) {
             pool.close()
         }
-        println(
-            "pool-acquire result: database=$databaseName, profile=$profile, holdMillis=$holdMillis, " +
+        log.info {
+            "Completed R2DBC pool acquire benchmark: database=$databaseName, profile=$profile, " +
+                    "holdMillis=$holdMillis, validationMode=$validationMode, " +
                     poolConfig.describeBenchmarkPoolConfig() + ", threads=8, " +
                     "acquired=${acquired.sum()}, failed=${failed.sum()}"
-        )
+        }
     }
 
     protected fun acquireAndClose(blackhole: Blackhole) {
@@ -95,6 +108,8 @@ abstract class AbstractR2dbcPoolAcquireBenchmark {
             }
         }
     }
+
+    companion object: KLogging()
 }
 
 /**
@@ -102,7 +117,7 @@ abstract class AbstractR2dbcPoolAcquireBenchmark {
  *
  * ## 실행 방법
  * ```bash
- * ./gradlew :bluetape4k-r2dbc:benchmarkH2PoolAcquire
+ * ./gradlew :bluetape4k-r2dbc:benchmarkH2PoolAcquireBenchmark
  * ```
  */
 @State(Scope.Benchmark)
@@ -120,6 +135,7 @@ open class H2R2dbcPoolAcquireBenchmark: AbstractR2dbcPoolAcquireBenchmark() {
 
     @Benchmark
     @Threads(8)
+    @Timeout(time = 30, timeUnit = TimeUnit.SECONDS)
     fun acquireAndCloseConnection(blackhole: Blackhole) {
         acquireAndClose(blackhole)
     }
@@ -130,7 +146,7 @@ open class H2R2dbcPoolAcquireBenchmark: AbstractR2dbcPoolAcquireBenchmark() {
  *
  * ## 실행 방법
  * ```bash
- * ./gradlew :bluetape4k-r2dbc:benchmarkPostgresPoolAcquire
+ * ./gradlew :bluetape4k-r2dbc:benchmarkPostgresPoolAcquireBenchmark
  * ```
  */
 @State(Scope.Benchmark)
@@ -148,6 +164,7 @@ open class PostgreSqlR2dbcPoolAcquireBenchmark: AbstractR2dbcPoolAcquireBenchmar
 
     @Benchmark
     @Threads(8)
+    @Timeout(time = 30, timeUnit = TimeUnit.SECONDS)
     fun acquireAndCloseConnection(blackhole: Blackhole) {
         acquireAndClose(blackhole)
     }
@@ -158,7 +175,7 @@ open class PostgreSqlR2dbcPoolAcquireBenchmark: AbstractR2dbcPoolAcquireBenchmar
  *
  * ## 실행 방법
  * ```bash
- * ./gradlew :bluetape4k-r2dbc:benchmarkMysql8PoolAcquire
+ * ./gradlew :bluetape4k-r2dbc:benchmarkMysql8PoolAcquireBenchmark
  * ```
  */
 @State(Scope.Benchmark)
@@ -176,6 +193,7 @@ open class MySql8R2dbcPoolAcquireBenchmark: AbstractR2dbcPoolAcquireBenchmark() 
 
     @Benchmark
     @Threads(8)
+    @Timeout(time = 30, timeUnit = TimeUnit.SECONDS)
     fun acquireAndCloseConnection(blackhole: Blackhole) {
         acquireAndClose(blackhole)
     }
@@ -195,11 +213,13 @@ private object MySql8 {
 
 internal const val R2DBC_BENCHMARK_VALIDATION_QUERY: String = "SELECT 1"
 
-internal fun acquireBenchmarkPoolConfig(profile: String): R2dbcPoolConfig =
-    when (profile) {
+internal fun acquireBenchmarkPoolConfig(
+    profile: String,
+    validationMode: String,
+): R2dbcPoolConfig {
+    val profileConfig = when (profile) {
         "default"        -> R2dbcPoolConfig(
             maxValidationTime = Duration.ofSeconds(1),
-            validationQuery = R2DBC_BENCHMARK_VALIDATION_QUERY,
         )
         "highThroughput" -> R2dbcPoolConfig.highThroughput(
             maxSize = 64,
@@ -207,10 +227,17 @@ internal fun acquireBenchmarkPoolConfig(profile: String): R2dbcPoolConfig =
             poolName = "benchmark-r2dbc",
         ).copy(
             maxAcquireTime = Duration.ofSeconds(2),
-            validationQuery = R2DBC_BENCHMARK_VALIDATION_QUERY,
         )
         else             -> error("Unknown profile: $profile")
     }
+
+    val validationQuery = when (validationMode) {
+        "local" -> null
+        "sql"   -> R2DBC_BENCHMARK_VALIDATION_QUERY
+        else    -> error("Unknown validation mode: $validationMode")
+    }
+    return profileConfig.copy(validationQuery = validationQuery)
+}
 
 internal fun contentionBenchmarkPoolConfig(
     profile: String,


### PR DESCRIPTION
## Summary

Closes #706

- PR 제목: perf(data-r2dbc): split pool benchmark validation modes

- split the R2DBC pool acquire benchmark into explicit `local` and `sql` validation modes
- retain acquired/failed trial counters and report lifecycle state through `KLogging`
- apply a 30-second JMH iteration timeout and a 5-minute Gradle task timeout
- refresh the English and Korean benchmark guidance with mode-labeled local results

### 원문 선행 내용

Closes #706

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Timeout contract

JMH 1.37 keeps interrupting timed-out workers until they return, so `@Timeout` alone is not a hard process bound for an interrupt-resistant reactive close. The generated H2, PostgreSQL, and MySQL acquire tasks therefore also use Gradle `Task.timeout`. A one-second override was verified to terminate the JMH child process with `Timeout has been exceeded` and a non-zero exit.

### 기존 섹션: Verification

- `./gradlew :bluetape4k-r2dbc:cleanTest :bluetape4k-r2dbc:test :bluetape4k-r2dbc:compileBenchmarkKotlin detekt --no-configuration-cache --no-build-cache` — 188 tests passed
- H2, PostgreSQL, and MySQL acquire benchmarks — 12/12 parameter combinations each, run sequentially
- `-Pr2dbcPoolAcquireBenchmarkTaskTimeoutSeconds=1` — expected timeout failure and process termination
- compiled JMH timeout annotations — 3/3
- README English/Korean result-table parity — 36/36 scores matched the pinned local JSON artifacts
- `git diff --check` — passed
- independent final review — P0=0, P1=0, P2=0, P3=0

Raw local benchmark artifacts used for the documented 2026-07-19 snapshot:

- `data/r2dbc/build/reports/benchmarks/h2PoolAcquire/2026-07-19T02.25.33.541629/benchmark.json`
- `data/r2dbc/build/reports/benchmarks/postgresPoolAcquire/2026-07-19T02.27.23.440243/benchmark.json`
- `data/r2dbc/build/reports/benchmarks/mysql8PoolAcquire/2026-07-19T02.29.31.445434/benchmark.json`

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #706, milestone `1.12.0`, assignee `debop`
- PR: #1059, head `c98784b8c6fe0e2a0ee78b36b283ad7b6b113676`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `perf/issue-706-r2dbc-validation-mode`
- Labels: `enhancement`, `performance`
- State: `MERGED`, merge commit `784e74c182ae97a6f2b89991bdf068832ecdbb4d`
- CI: - split the R2DBC pool acquire benchmark into explicit `local` and `sql` validation modes / - apply a 30-second JMH iteration timeout and a 5-minute Gradle task timeout / JMH 1.37 keeps interrupting timed-out workers until they return, so `@Timeout` alone is not a hard process bound for an interrupt-resistant reactive close. The generated H2, PostgreSQL, and MySQL acquire tasks therefore also use Gradle `Task.timeout`. A one-second override was verified to terminate the JMH child process with `Timeout has been exceeded` and a non-zero exit.

## DoD Status

- [x] Explicit local and SQL validation modes
- [x] JMH and outer Gradle task timeouts
- [x] Lifecycle logging with acquired/failed counters
- [x] H2, PostgreSQL, and MySQL sequential benchmark proof
- [x] English/Korean README parity
- [x] Local tests, compilation, static checks, and independent review
- [x] Required GitHub checks complete on the exact PR head
- [ ] Fresh merge approval after the merge-ready report

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1059 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `784e74c182ae97a6f2b89991bdf068832ecdbb4d`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
