### PR TITLE
feat(infra-lettuce): add monotonic fencing lease tokens

### DIFF
--- a/docs/superpowers/plans/2026-07-22-issue-1068-fencing-lease-plan.md
+++ b/docs/superpowers/plans/2026-07-22-issue-1068-fencing-lease-plan.md
@@ -1,0 +1,1297 @@
+# Redis Fencing Lease Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `bluetape4k-lettuce`에 `(epoch, sequence)`로 정렬 가능한 fencing lease를 추가하고, Redis history loss·모호한 완료·취소·Cluster routing·외부 resilience 조합의 경계를 실행 가능한 test와 영문/한글 문서로 고정한다.
+
+**Architecture:** 한 instance가 `LettuceFencingLeaseConfig(namespace, resourceName, epoch)` 하나를 소유하고, 파생된 lease/counter 두 key만 동일 slot에서 Lua로 다룬다. public model과 result는 Java serialization invariant를 지키며, sync/`CompletableFuture`/suspend facade는 같은 validation·script·wire decoder·backend classifier를 공유한다. primitive 내부에는 retry/CB/bulkhead를 넣지 않고, 테스트와 README에서 `bluetape4k-resilience4j` decorator 및 downstream tuple CAS를 보여준다.
+
+**Tech Stack:** Kotlin 2.3, Java 21, Lettuce, Redis Lua/EVALSHA/EVAL/EVAL_RO, Kotlin Coroutines, JUnit 5, bluetape4k-assertions, bluetape4k-junit5, bluetape4k-testcontainers, bluetape4k-resilience4j, Resilience4j 2.4.0.
+
+---
+
+## 1. 실행 계약
+
+### 1.1 승인된 입력과 범위
+
+- 설계 기준: `docs/superpowers/specs/2026-07-22-issue-1068-fencing-lease-design.md`
+- 구현 범위: `infra/lettuce`의 기존 `io.bluetape4k.redis.lettuce.lease` package와 공용 `RedisScriptRunner`의 async cancellation 보강.
+- 보존 범위: 기존 `LettuceLock`, `LettuceSemaphore`, `LettuceMultiKeyLease` API와 동작, module registration, publication topology, dependency catalog.
+- 새 dependency/module/benchmark framework/production PostgreSQL adapter는 추가하지 않는다.
+- Testcontainers 기반 standalone과 Cluster 검증은 다른 module/worktree와 병렬 실행하지 않는다.
+- 모든 새 public API KDoc은 English, `README.md`는 English, `README.ko.md`는 자연스러운 Korean으로 작성한다.
+
+### 1.2 구현 그래프와 write scope
+
+| Task | 복잡도 | 선행 작업 | 주 write scope | 병렬 가능성 |
+|---|---:|---|---|---|
+| 1. Public value/result contract | M | 없음 | `FencingLeaseValue.kt`, `FencingLeaseResult.kt`, 대응 unit test | Task 2와 파일 비중첩 |
+| 2. Async script cancellation | M | 없음 | `RedisScript.kt`, `RedisScriptTest.kt` | Task 1과 병렬 가능 |
+| 3. Internal protocol/validation | H | 1, 2 | `LettuceFencingLeaseSupport.kt`, support test | 이후 모든 task의 직렬 선행 |
+| 4. Lua state machine/standalone hostile state | H | 3 | support와 script integration test | 단일 owner로 직렬 수행 |
+| 5. Sync/future/suspend facade parity | H | 4 | facade 2개, contract와 facade test | 단일 owner로 직렬 수행 |
+| 6. Cancellation/ambiguous completion | H | 5 | cancellation/fault-injection test | Task 7과 test file 비중첩이나 Redis 실행은 직렬 |
+| 7. Concurrency/Cluster | H | 5 | concurrency/Cluster test | Task 6과 작성 병렬 가능, 실행 직렬 |
+| 8. Resilience/downstream/recovery examples | H | 5 | resilience/recovery test | Task 6·7과 작성 병렬 가능, 실행 직렬 |
+| 9. KDoc/README parity | M | 1–8 public contract 확정 | production KDoc, README locale, docs test | 코드 계약 확정 후 수행 |
+| 10. Full regression/DoD | M | 1–9 | 변경 없음 | 반드시 마지막 |
+
+### 1.3 위험 예측과 중단 조건
+
+| 위험 | 사전 방어 | 실패 시 중단/복구 |
+|---|---|---|
+| Lua가 큰 sequence를 `number`로 바꿔 정밀도를 잃음 | canonical decimal string 길이/사전식 비교, mutation 뒤 `GET` 반환 | numeric conversion이 hot path에 보이면 Task 4를 중단하고 script unit test부터 수정 |
+| `INCR` 이후 runtime error를 rollback으로 오해 | 모든 expected error를 write 전 preflight, gap 허용, TTL 없는 partial lease fail-closed | partial mutation test가 분류표와 다르면 facade 작업 중단 |
+| chained future 취소가 현재 upstream으로 전파되지 않음 | EVALSHA→EVAL target 교체를 `AtomicReference`로 보존, 전환 race test | Task 2가 통과하기 전 future facade 구현 금지 |
+| broad catch가 cancellation/decoder bug를 `BackendFailure`로 평탄화 | bounded cause normalizer + cancellation 우선 rethrow + allowlist classifier | unknown exception이 result가 되면 Task 3부터 수정 |
+| Serializable 누락 또는 singleton identity 손실 | reflection + `ObjectStreamClass` + canonical reference identity round-trip | public variant 하나라도 누락되면 Task 1 완료 금지 |
+| assertion style 퇴행 | `bluetape4k.assertions.assertFailsWith`, intent matcher, `shouldNotBeEqualTo` 사용 | boolean assertion이나 JUnit/kotlin raw assertion 발견 시 해당 test 수정 |
+| 동일 resource의 mixed epoch activation | deterministic control-plane harness와 lower-epoch rollback 거절 | harness가 mixed epoch를 허용하면 문서 작업 중단 |
+| Cluster codec routing을 String으로 추정 | `codec.encodeKey(key)` wire bytes로 `SlotHash.getSlot` 검증 | custom codec fixture dispatch가 관찰되면 constructor validation 수정 |
+| README 예제와 실제 decorator 동작 불일치 | 동일 helper를 실제 Redis test와 documentation test에서 실행 | docs test 실패 시 README를 구현에 맞춰 수정, test 완화 금지 |
+
+### 1.4 공통 TDD/검증 규칙
+
+- 각 task는 RED test를 먼저 추가하고 예상 원인으로 실패하는 것을 확인한 뒤 최소 production code로 GREEN을 만든다.
+- `.kt` 변경 후 IDE diagnostics가 가능하면 먼저 확인하고, targeted test → `:bluetape4k-lettuce:test` → detekt 순서로 넓힌다.
+- Testcontainers test는 반드시 순차 실행한다. 첫 실패 후 재실행 성공은 바로 flaky로 치부하지 않고 lifecycle/timing 원인을 기록한다.
+- 새 test는 JUnit 5와 `bluetape4k-assertions`를 사용한다. 예외는 `io.bluetape4k.assertions.assertFailsWith`, suspend 전용이면 `coInvoking { } shouldThrow`를 사용한다.
+- equality/ordering은 intent matcher를 사용한다. 예: `first shouldNotBeEqualTo second`; `(first == second).shouldBeFalse()` 형태를 만들지 않는다.
+- 매 commit 전 `git diff --check`를 통과시키고 아래 Lore 형식을 사용한다.
+
+```text
+<intent line describing why>
+
+Constraint: <external constraint>
+Rejected: <alternative> | <reason>
+Confidence: high
+Scope-risk: <narrow|moderate>
+Directive: <future modifier warning>
+Tested: <fresh evidence>
+Not-tested: <known gap>
+```
+
+## 2. Task 1 — Public value와 sealed result를 먼저 고정
+
+**Files:**
+
+- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseValue.kt`
+- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseResult.kt`
+- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseValueTest.kt`
+- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseResultTest.kt`
+
+### 2.1 RED — invariant, ordering, serialization test
+
+- [ ] `FencingLeaseValueTest`에 다음 실패 contract를 작성한다.
+  - config의 name은 1..128자 `[A-Za-z0-9._-]+`, epoch는 positive.
+  - `FencingOwnerId.from`은 UTF-8 1..256 bytes, `random()`은 `Base58.randomString(22)` alphabet/length.
+  - owner ID equality/hashCode는 raw value 기준이지만 `toString()`은 항상 `FencingOwnerId(<redacted>)`.
+  - `FencingToken`은 epoch 우선, sequence 차순, equality와 natural ordering 일치, redacted `toString()`.
+  - config/owner/token Java round-trip, `serialVersionUID == 1L`, crafted invalid payload의 `InvalidObjectException`.
+  - config의 `namespace`/`resourceName`과 owner의 raw value를 crafted `null`로 만든 payload도 cause 없는 stable `InvalidObjectException`.
+- [ ] `FencingLeaseResultTest`에 모든 enum, sealed interface, nested data class/data object sample table을 만든다.
+  - 모든 non-enum public sample은 `Serializable`, `ObjectStreamClass.lookup(...).serialVersionUID == 1L`.
+  - sealed interface 자체도 declared `serialVersionUID == 1L`을 가지는지 reflection으로 검증.
+  - 모든 `data object` round-trip은 `restored shouldBeSameInstanceAs original`.
+  - TTL variant는 negative value와 crafted serialized negative payload를 거절.
+  - nested failure property를 `null`로 조작한 crafted payload도 canonical constructor 재검증에서 `InvalidObjectException`으로 거절.
+  - invalid payload exception은 stable message, `cause == null`, sentinel value 비노출을 검증.
+  - public property에 key/owner/raw reply/`Throwable`/message가 없음을 reflection으로 검증.
+- [ ] RED 명령을 실행하고 unresolved type 때문에 실패하는지 확인한다.
+
+```bash
+./gradlew :bluetape4k-lettuce:test --tests '*FencingLeaseValueTest' --tests '*FencingLeaseResultTest'
+```
+
+Expected: 새 type이 없어 Kotlin test compilation이 실패한다.
+
+### 2.2 GREEN — public model 구현
+
+- [ ] `FencingLeaseValue.kt`에 English KDoc과 함께 다음 shape를 구현한다. constructor invariant가 있는 type의 `readResolve()`는 raw invalid value나 원래 exception을 노출하지 않는다.
+
+```kotlin
+data class LettuceFencingLeaseConfig(
+    val namespace: String,
+    val resourceName: String,
+    val epoch: Long,
+) : Serializable {
+    init {
+        require(NAME_PATTERN.matches(namespace)) { "namespace must be 1..128 safe ASCII characters." }
+        require(NAME_PATTERN.matches(resourceName)) { "resourceName must be 1..128 safe ASCII characters." }
+        epoch.requirePositiveNumber("epoch")
+    }
+
+    @Throws(ObjectStreamException::class)
+    private fun readResolve(): Any = try {
+        LettuceFencingLeaseConfig(namespace, resourceName, epoch)
+    } catch (_: IllegalArgumentException) {
+        throw InvalidObjectException("Invalid fencing lease config.")
+    } catch (_: NullPointerException) {
+        throw InvalidObjectException("Invalid fencing lease config.")
+    }
+
+    private companion object {
+        val NAME_PATTERN: Regex = Regex("[A-Za-z0-9._-]{1,128}")
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+class FencingOwnerId private constructor(
+    internal val value: String,
+) : Serializable {
+    init {
+        require(value.isNotBlank() && value.toByteArray(Charsets.UTF_8).size in 1..256) {
+            "ownerId must contain 1..256 UTF-8 bytes."
+        }
+    }
+
+    override fun equals(other: Any?): Boolean = other is FencingOwnerId && value == other.value
+    override fun hashCode(): Int = value.hashCode()
+    override fun toString(): String = "FencingOwnerId(<redacted>)"
+
+    @Throws(ObjectStreamException::class)
+    private fun readResolve(): Any = try {
+        from(value)
+    } catch (_: IllegalArgumentException) {
+        throw InvalidObjectException("Invalid fencing owner ID.")
+    } catch (_: NullPointerException) {
+        throw InvalidObjectException("Invalid fencing owner ID.")
+    }
+
+    companion object {
+        private const val serialVersionUID: Long = 1L
+        fun random(): FencingOwnerId = from(Base58.randomString(22))
+        fun from(value: String): FencingOwnerId = FencingOwnerId(value)
+    }
+}
+
+data class FencingToken(
+    val epoch: Long,
+    val sequence: Long,
+) : Comparable<FencingToken>, Serializable {
+    init {
+        epoch.requirePositiveNumber("epoch")
+        sequence.requirePositiveNumber("sequence")
+    }
+
+    override fun compareTo(other: FencingToken): Int =
+        compareValuesBy(this, other, FencingToken::epoch, FencingToken::sequence)
+
+    override fun toString(): String = "FencingToken(<redacted>)"
+
+    @Throws(ObjectStreamException::class)
+    private fun readResolve(): Any = try {
+        FencingToken(epoch, sequence)
+    } catch (_: IllegalArgumentException) {
+        throw InvalidObjectException("Invalid fencing token.")
+    } catch (_: NullPointerException) {
+        throw InvalidObjectException("Invalid fencing token.")
+    }
+
+    private companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+```
+
+- [ ] `FencingLeaseResult.kt`에 설계의 enum과 다섯 sealed result를 이름 그대로 구현한다.
+  - `FencingBackendFailureKind`는 `CONNECTION`, `TIMEOUT`, `COMMAND`; `FencingIntegrityFailureKind`는 `MALFORMED_LEASE`, `INVALID_COUNTER`, `COUNTER_BEHIND_LEASE`다. enum serialization은 Java 기본 계약을 그대로 사용한다.
+  - `FencingLeaseBackendFailure`, `FencingLeaseIntegrityFailure`, token/TTL/failure property를 가진 모든 variant는 `readResolve()`에서 canonical constructor를 다시 호출한다. `IllegalArgumentException`, `NullPointerException` 등 invariant failure는 raw cause 없이 stable `InvalidObjectException`으로 바꾼다.
+  - 모든 nested `data class`는 `Serializable` 상속과 private companion `serialVersionUID = 1L`을 가진다.
+  - 모든 nested `data object`는 아래 canonical singleton 패턴을 빠짐없이 사용한다.
+
+| Result | Exact variants |
+|---|---|
+| `FencingBootstrapResult` | `Initialized`, `AlreadyInitialized`, `IntegrityFailure`, `BackendFailure` |
+| `FencingAcquireResult` | `Acquired`, `AlreadyOwned`, `Contended`, `CounterUnavailable`, `SequenceExhausted`, `IntegrityFailure`, `BackendFailure` |
+| `FencingInspectResult` | `Owned`, `Lost`, `Contended`, `IntegrityFailure`, `BackendFailure` |
+| `FencingRenewResult` | `Renewed`, `Lost`, `OwnershipMismatch`, `IntegrityFailure`, `BackendFailure` |
+| `FencingReleaseResult` | `Released`, `Lost`, `OwnershipMismatch`, `IntegrityFailure`, `BackendFailure` |
+
+```kotlin
+sealed interface FencingBootstrapResult : Serializable {
+    private companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+
+    data object Initialized : FencingBootstrapResult {
+        @Suppress("unused")
+        private fun readResolve(): Any = Initialized
+        private const val serialVersionUID: Long = 1L
+    }
+
+    data object AlreadyInitialized : FencingBootstrapResult {
+        @Suppress("unused")
+        private fun readResolve(): Any = AlreadyInitialized
+        private const val serialVersionUID: Long = 1L
+    }
+
+    data class IntegrityFailure(
+        val failure: FencingLeaseIntegrityFailure,
+    ) : FencingBootstrapResult {
+        @Throws(ObjectStreamException::class)
+        private fun readResolve(): Any = try {
+            IntegrityFailure(failure)
+        } catch (_: IllegalArgumentException) {
+            throw InvalidObjectException("Invalid fencing integrity failure.")
+        } catch (_: NullPointerException) {
+            throw InvalidObjectException("Invalid fencing integrity failure.")
+        }
+
+        private companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    data class BackendFailure(
+        val failure: FencingLeaseBackendFailure,
+    ) : FencingBootstrapResult {
+        @Throws(ObjectStreamException::class)
+        private fun readResolve(): Any = try {
+            BackendFailure(failure)
+        } catch (_: IllegalArgumentException) {
+            throw InvalidObjectException("Invalid fencing backend failure.")
+        } catch (_: NullPointerException) {
+            throw InvalidObjectException("Invalid fencing backend failure.")
+        }
+
+        private companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+}
+```
+
+- [ ] GREEN 명령을 실행한다.
+
+```bash
+./gradlew :bluetape4k-lettuce:test --tests '*FencingLeaseValueTest' --tests '*FencingLeaseResultTest'
+```
+
+Expected: 모든 ordering/invariant/serialization/redaction test가 통과한다.
+
+### 2.3 Commit
+
+- [ ] `git diff --check` 후 다음 Lore commit을 만든다.
+
+```text
+Define a serialization-safe fencing lease vocabulary
+
+Constraint: Every public non-enum value and nested result variant must be Serializable with stable invariants.
+Rejected: primitive Long and String API | it would permit domain confusion and leak owner values through default rendering
+Confidence: high
+Scope-risk: narrow
+Directive: Preserve canonical readResolve behavior for every serialized data object and validated value.
+Tested: FencingLeaseValueTest; FencingLeaseResultTest; git diff --check
+Not-tested: Redis execution is introduced in later tasks
+```
+
+## 3. Task 2 — `RedisScriptRunner`의 현재 upstream future 취소 전파
+
+**Files:**
+
+- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/script/RedisScript.kt`
+- Modify: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/script/RedisScriptTest.kt`
+
+### 3.1 RED — EVALSHA/NOSCRIPT race contract
+
+- [ ] controllable `TestRedisFuture`와 mocked `RedisScriptingAsyncCommands`로 다음 test를 먼저 추가한다.
+  - EVALSHA pending 중 returned future cancel → EVALSHA future cancelled.
+  - EVALSHA가 `RedisNoScriptException`으로 끝난 뒤 EVAL pending 중 cancel → EVAL future cancelled.
+  - EVALSHA failure와 returned cancel이 경쟁해도 fallback이 시작됐다면 그 current future가 cancelled.
+  - caller cancellation은 `CompletionException`이나 failed future로 바뀌지 않고 returned future의 `isCancelled`를 유지.
+  - 초기 `evalsha(...)`가 동기 throw해도 returned future가 terminal exceptional 상태가 되고 pending으로 남지 않음.
+  - NOSCRIPT fallback의 `eval(...)`가 동기 throw해도 같은 terminal exceptional 상태가 되고 pending으로 남지 않음.
+  - 정상 result와 non-NOSCRIPT failure의 기존 동작 유지.
+- [ ] RED 명령으로 현재 `exceptionallyCompose` chain이 upstream cancellation contract를 만족하지 못함을 확인한다.
+
+```bash
+./gradlew :bluetape4k-lettuce:test --tests 'io.bluetape4k.redis.lettuce.script.RedisScriptTest'
+```
+
+Expected: 새 cancellation assertion이 실패한다.
+
+### 3.2 GREEN — cancellable bridge 구현
+
+- [ ] `runAsyncScripting`을 `exceptionallyCompose` 반환에서 명시적 bridge로 교체한다. `AtomicReference`는 class property가 아니라 method-local이므로 atomicfu가 아니라 JDK `AtomicReference`를 사용한다.
+
+```kotlin
+private fun <T> runAsyncScripting(
+    commands: RedisScriptingAsyncCommands<String, String>,
+    script: RedisScript,
+    outputType: ScriptOutputType,
+    keys: Array<String>,
+    vararg args: String,
+): CompletableFuture<T> {
+    val current = AtomicReference<CompletableFuture<T>>()
+    val result = object : CompletableFuture<T>() {
+        override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
+            val cancelled = super.cancel(mayInterruptIfRunning)
+            if (cancelled) current.get()?.cancel(mayInterruptIfRunning)
+            return cancelled
+        }
+    }
+
+    lateinit var attach: (CompletableFuture<T>) -> Unit
+    val dispatch: (() -> CompletableFuture<T>) -> Unit = { command ->
+        if (!result.isDone) {
+            val upstream = try {
+                command()
+            } catch (error: Exception) {
+                result.completeExceptionally(error)
+                null
+            }
+            if (upstream != null) attach(upstream)
+        }
+    }
+
+    attach = { upstream ->
+        current.set(upstream)
+        if (result.isCancelled) {
+            upstream.cancel(true)
+        } else {
+            upstream.whenComplete { value, error ->
+                val cause = error?.unwrapCompletionCause()
+                if (cause is RedisNoScriptException && !result.isCancelled) {
+                    log.debug { "NOSCRIPT(async) fallback (sha1=${script.sha1})" }
+                    dispatch { commands.eval<T>(script.source, outputType, keys, *args).toCompletableFuture() }
+                } else if (cause != null) {
+                    result.completeExceptionally(cause)
+                } else {
+                    result.complete(value)
+                }
+            }
+        }
+    }
+
+    dispatch { commands.evalsha<T>(script.sha1, outputType, keys, *args).toCompletableFuture() }
+    return result
+}
+
+private fun Throwable.unwrapCompletionCause(): Throwable =
+    if (this is CompletionException) cause ?: this else this
+```
+
+- [ ] race에서 cancelled result에 fallback이 붙은 직후 `isCancelled` 재확인으로 current future가 남지 않는지 test를 반복 실행한다.
+
+```bash
+./gradlew :bluetape4k-lettuce:test --tests 'io.bluetape4k.redis.lettuce.script.RedisScriptTest' --rerun-tasks
+```
+
+Expected: 기존 sync/async/suspend/NOSCRIPT test와 새 cancellation test가 모두 통과한다.
+
+### 3.3 Commit
+
+- [ ] `git diff --check` 후 commit한다.
+
+```text
+Keep script cancellation attached to the active Redis command
+
+Constraint: EVALSHA may hand execution to an EVAL fallback after NOSCRIPT.
+Rejected: chained CompletableFuture cancellation | it loses a stable reference to the active Lettuce future
+Confidence: high
+Scope-risk: moderate
+Directive: Any future fallback stage must replace the cancellation target before it becomes observable.
+Tested: RedisScriptTest including EVALSHA and EVAL cancellation races; git diff --check
+Not-tested: fencing lease integration is introduced later
+```
+
+## 4. Task 3 — Key derivation, validation, wire protocol, backend classifier
+
+**Files:**
+
+- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupport.kt`
+- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupportTest.kt`
+
+### 4.1 RED — pure support contract
+
+- [ ] 다음 pure unit test를 작성한다.
+  - derived key가 정확히 `fence:{namespace:resourceName}:<epoch>:lease|counter`.
+  - default/custom codec 모두 `SlotHash.getSlot(codec.encodeKey(key))`를 사용하고, wire bytes가 다른 slot이면 stable `IllegalArgumentException`이며 command mock interaction은 0.
+  - decimal parser는 `0`, positive canonical decimal, `Long.MAX_VALUE`를 허용하고 sign, leading zero, whitespace, empty, non-digit, 20+ byte를 거절.
+  - TTL은 positive whole millisecond만 허용하며 nanos-only, zero, negative, `toMillis()` overflow를 모두 `IllegalArgumentException`으로 정규화.
+  - token epoch mismatch는 renew/release dispatch 전에 거절.
+  - `CompletionException`/`ExecutionException` 최대 8단계 unwrap, identity cycle 방지, chain 어디의 `CancellationException`도 rethrow.
+  - `RedisConnectionException`→`CONNECTION`, `RedisCommandTimeoutException`/`TimeoutException`→`TIMEOUT`, 다른 `RedisException`→`COMMAND`.
+  - validation, internal wire exception, unknown non-Lettuce exception은 classifier가 다시 던지고 result로 만들지 않음.
+  - log capture에 sentinel namespace/resource/key/owner/token/raw reply/exception message가 없고 allowlisted operation/kind/class name만 존재.
+- [ ] RED 명령을 실행한다.
+
+```bash
+./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseSupportTest'
+```
+
+Expected: support symbol이 없어 test compilation이 실패한다.
+
+### 4.2 GREEN — 고정 내부 계약 구현
+
+- [ ] 다음 internal type을 구현한다. script reply는 Lua number가 아니라 fixed-size bulk string vector로 decode한다.
+
+```kotlin
+internal data class FencingLeaseKeys(
+    val lease: String,
+    val counter: String,
+)
+
+internal enum class FencingLeaseOperation {
+    BOOTSTRAP,
+    ACQUIRE,
+    INSPECT,
+    RENEW,
+    RELEASE,
+}
+
+internal class FencingLeaseProtocolException : IllegalStateException(
+    "Malformed fencing lease response.",
+)
+
+internal fun deriveFencingLeaseKeys(
+    config: LettuceFencingLeaseConfig,
+    codec: RedisCodec<String, String>,
+): FencingLeaseKeys {
+    val tag = "${config.namespace}:${config.resourceName}"
+    val prefix = "fence:{$tag}:${config.epoch}"
+    val keys = FencingLeaseKeys("$prefix:lease", "$prefix:counter")
+    require(SlotHash.getSlot(codec.encodeKey(keys.lease)) == SlotHash.getSlot(codec.encodeKey(keys.counter))) {
+        "Derived fencing lease keys must share one Redis Cluster slot."
+    }
+    return keys
+}
+```
+
+- [ ] decimal comparison은 `Long`/`Double` 변환 전에 canonical string 자체를 검증한다.
+
+```kotlin
+internal fun compareCanonicalDecimals(left: String, right: String): Int {
+    requireCanonicalDecimal(left)
+    requireCanonicalDecimal(right)
+    val lengthComparison = left.length.compareTo(right.length)
+    return if (lengthComparison != 0) lengthComparison else left.compareTo(right)
+}
+
+internal fun requireCanonicalDecimal(value: String): String {
+    require(value == "0" || value.firstOrNull() in '1'..'9' && value.all(Char::isDigit)) {
+        "Invalid decimal value."
+    }
+    require(value.length <= Long.MAX_VALUE.toString().length) { "Decimal value is out of range." }
+    require(compareCanonicalDecimalsWithoutValidation(value, Long.MAX_VALUE.toString()) <= 0) {
+        "Decimal value is out of range."
+    }
+    return value
+}
+
+private fun compareCanonicalDecimalsWithoutValidation(left: String, right: String): Int {
+    val lengthComparison = left.length.compareTo(right.length)
+    return if (lengthComparison != 0) lengthComparison else left.compareTo(right)
+}
+```
+
+- [ ] duration conversion은 overflow 원인을 public message/cause에 보존하지 않는다.
+
+```kotlin
+internal fun Duration.requireFencingLeaseMillis(): Long {
+    val millis = try {
+        toMillis()
+    } catch (_: ArithmeticException) {
+        throw IllegalArgumentException("leaseTime must fit positive whole milliseconds.")
+    }
+    require(millis > 0 && this == Duration.ofMillis(millis)) {
+        "leaseTime must fit positive whole milliseconds."
+    }
+    return millis
+}
+```
+
+- [ ] operation별 decoder와 result factory를 분리하되 unknown status/field count/malformed success payload는 `FencingLeaseProtocolException`으로만 실패하게 한다.
+- [ ] backend classifier는 public result를 받는 operation wrapper 하나에서 공유하고 raw `Throwable`을 public value나 log message에 넣지 않는다.
+- [ ] `domainFingerprint`가 필요할 때만 `namespace + NUL + resourceName + NUL + epoch` SHA-256 앞 12 bytes를 24 lowercase hex로 계산하며 metric label API는 추가하지 않는다.
+- [ ] GREEN 명령을 실행한다.
+
+```bash
+./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseSupportTest'
+```
+
+Expected: key/codec/decimal/TTL/classifier/protocol/redaction unit test가 모두 통과한다.
+
+### 4.3 Commit
+
+- [ ] `git diff --check` 후 commit한다.
+
+```text
+Fail closed before fencing lease scripts can mutate Redis
+
+Constraint: Key routing, exact decimals, TTL conversion, and backend classification must agree across three APIs.
+Rejected: Lua number decoding and broad Throwable flattening | they lose integer precision and hide programmer failures
+Confidence: high
+Scope-risk: moderate
+Directive: Keep protocol failures distinct from Redis state integrity and backend failures.
+Tested: LettuceFencingLeaseSupportTest; git diff --check
+Not-tested: real Redis state transitions are introduced next
+```
+
+## 5. Task 4 — Lua state machine와 hostile standalone Redis
+
+**Files:**
+
+- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupport.kt`
+- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseScriptTest.kt`
+
+### 5.1 RED — operation matrix와 hostile state
+
+- [ ] 실제 singleton Redis fixture로 bootstrap/acquire/inspect/renew/release의 정상·경합·lost·mismatch contract를 먼저 작성한다.
+- [ ] 다음 hostile state를 raw Redis command로 만든 뒤 expected public integrity category와 no-mutation을 검증한다.
+  - lease/counter wrong type, missing/extra hash field, oversized owner/epoch/sequence/counter.
+  - signed/leading-zero/whitespace/non-digit/out-of-range decimal.
+  - counter TTL, lease no TTL, counter missing while lease active, counter behind lease.
+  - lease absent + counter absent는 acquire `CounterUnavailable`; inspect/renew/release `Lost`.
+  - counter `Long.MAX_VALUE`는 `SequenceExhausted`이고 lease를 만들지 않음.
+- [ ] `SCRIPT FLUSH` 뒤 EVALSHA→EVAL fallback 결과가 동일함을 검증한다.
+- [ ] test-only Lua 두 개를 exact fixture key로 실행해 Redis runtime error의 non-rollback을 실제로 증명한다.
+  - `INCR` 직후 deliberate wrong-type command로 실패시켜 counter 증가가 남고 다음 acquire가 그 sequence를 재사용하지 않음을 검증.
+  - `HSET` 직후 `PEXPIRE` 전에 deliberate wrong-type command로 실패시켜 TTL 없는 partial lease가 남고 다음 production operation이 `MALFORMED_LEASE`를 반환함을 검증.
+- [ ] structural assertion으로 script source에 `KEYS`, `SCAN`, `HGETALL`, stored cardinality loop가 없고, `HLEN == 3`, fixed `HSTRLEN`/`HMGET`, write 전 preflight, `INCR`→`GET`→`HSET`→`PEXPIRE` 순서가 있음을 검증한다. test-only non-rollback script는 production script inventory에서 제외한다.
+- [ ] command spy로 정상 경로는 `EVALSHA=1, EVAL=0`, `NOSCRIPT` 경로만 `EVALSHA=1, EVAL=1`, validation/constructor rejection은 Redis dispatch 0임을 검증한다. facade가 script 앞에 `GET`/`TYPE` 같은 client-side preflight를 보내면 실패한다.
+- [ ] RED 명령을 실행한다.
+
+```bash
+./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseScriptTest'
+```
+
+Expected: script runner/decoder operation이 없어 test compilation 또는 assertion이 실패한다.
+
+### 5.2 GREEN — fixed O(1) Lua protocol
+
+- [ ] script 공통 preflight는 두 exact key만 사용하고 mutation 전에 다음을 모두 판정한다.
+  - counter `TYPE`, `PTTL`, `STRLEN`, canonical decimal과 범위.
+  - lease `TYPE`, `PTTL`, `HLEN`, fixed field `HSTRLEN`, fixed `HMGET`, stored epoch와 counter relation.
+  - lease `PTTL == -2`는 absent로 재분류하고 `-1`은 `MALFORMED_LEASE`.
+- [ ] bootstrap은 lease가 없고 counter도 없을 때만 counter `0`을 생성한다. active lease + missing counter와 existing malformed counter는 initialize하지 않는다.
+- [ ] acquire는 같은 owner에게 stored token을 그대로 반환하고, 다른 owner에게 TTL만 반환한다. absent lease에서는 missing counter/overflow를 write 없이 반환하고, 정상일 때만 아래 mutation order를 사용한다.
+
+```lua
+local nextSequence = redis.call('INCR', KEYS[2])
+local nextSequenceText = redis.call('GET', KEYS[2])
+redis.call('HSET', KEYS[1],
+  'owner', ARGV[1],
+  'epoch', ARGV[2],
+  'sequence', nextSequenceText)
+redis.call('PEXPIRE', KEYS[1], ARGV[3])
+return {'ACQUIRED', ARGV[2], nextSequenceText, '-1'}
+```
+
+- [ ] renew/release는 stored owner와 exact `(epoch, sequence)`를 모두 비교한다. renew는 `PEXPIRE`만, release는 lease key `DEL`만 수행하며 counter를 변경하지 않는다.
+- [ ] 모든 정상/분류 reply는 fixed field count의 string vector다. expected validation branch 이후 write가 없어야 하며 script source에 raw secret을 포함한 `error(...)`를 만들지 않는다.
+- [ ] 모든 operation은 exact 4-field reply `[status, value1, value2, ttl]`을 사용한다. unused token field는 `0`, unused TTL은 `-1` sentinel로 고정한다.
+
+| Status family | `value1` | `value2` | `ttl` | Arity |
+|---|---|---|---:|---:|
+| `INITIALIZED`, `ALREADY_INITIALIZED`, `COUNTER_UNAVAILABLE`, `SEQUENCE_EXHAUSTED`, `RENEWED`, `RELEASED`, `LOST`, `OWNERSHIP_MISMATCH` | `0` | `0` | `-1` | 4 |
+| `ACQUIRED` | epoch decimal | sequence decimal | `-1` | 4 |
+| `ALREADY_OWNED`, `OWNED` | epoch decimal | sequence decimal | non-negative PTTL | 4 |
+| `CONTENDED` | `0` | `0` | non-negative PTTL | 4 |
+| `INTEGRITY_FAILURE` | enum wire code | `0` | `-1` | 4 |
+
+- [ ] production script의 최대 Redis command inventory를 source-level structural test로 고정한다. common lease preflight는 `TYPE`, `PTTL`, `HLEN`, `HSTRLEN` ×3, fixed `HMGET` 최대 7회; counter preflight는 `TYPE`, `PTTL`, `STRLEN`, `GET` 최대 4회다. mutation 상한은 bootstrap `SET` 1회, acquire `INCR`/`GET`/`HSET`/`PEXPIRE` 4회, renew `PEXPIRE` 1회, release `DEL` 1회, inspect 0회다. 따라서 operation당 최대 internal command는 acquire 15, bootstrap/renew/release 12, inspect 11이며 stored cardinality에 따라 증가하지 않는다.
+- [ ] standalone test를 실행한다.
+
+```bash
+./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseScriptTest'
+```
+
+Expected: 정상 state machine, hostile state fail-closed, overflow, NOSCRIPT, structural O(1) test가 통과한다.
+
+### 5.3 Commit
+
+- [ ] `git diff --check` 후 commit한다.
+
+```text
+Issue ordered lease generations only from validated Redis state
+
+Constraint: Redis scripts do not roll back writes after every runtime error and Lua numbers cannot represent all Long values exactly.
+Rejected: implicit counter bootstrap and numeric token replies | they hide history loss and precision boundaries
+Confidence: high
+Scope-risk: moderate
+Directive: Keep all expected failures before the first write and never reduce or delete the counter.
+Tested: LettuceFencingLeaseScriptTest against standalone Redis; git diff --check
+Not-tested: facade parity, Cluster routing, and cancellation follow
+```
+
+## 6. Task 5 — Sync, future, suspend facade와 shared contract
+
+**Files:**
+
+- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLease.kt`
+- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLease.kt`
+- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseContract.kt`
+- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseTest.kt`
+- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLeaseTest.kt`
+
+### 6.1 RED — 공통 adapter contract
+
+- [ ] `FencingLeaseAdapter`를 test internal interface로 만들고 sync, future, suspend adapter가 동일 scenario table을 실행하게 한다.
+
+```kotlin
+internal interface FencingLeaseAdapter {
+    val name: String
+    suspend fun bootstrap(): FencingBootstrapResult
+    suspend fun acquire(ownerId: FencingOwnerId, leaseTime: Duration): FencingAcquireResult
+    suspend fun inspect(ownerId: FencingOwnerId): FencingInspectResult
+    suspend fun renew(ownerId: FencingOwnerId, token: FencingToken, leaseTime: Duration): FencingRenewResult
+    suspend fun release(ownerId: FencingOwnerId, token: FencingToken): FencingReleaseResult
+}
+```
+
+- [ ] scenario table에 다음을 넣는다.
+  - bootstrap initialized/replay.
+  - strictly increasing acquire→release generations.
+  - same-owner acquire replay가 같은 token이며 TTL을 연장하지 않음.
+  - inspect owned/contended/lost, renew token 유지, release counter 보존.
+  - wrong owner와 stale token renew/release가 newer lease를 변경하지 않음.
+  - expiry 뒤 takeover가 더 큰 token.
+  - 다른 epoch token renew/release가 dispatch 전에 `IllegalArgumentException`.
+  - invalid TTL/config/owner가 세 API에서 dispatch 전에 동일 exception type.
+  - connection/timeout/command failure가 세 API에서 같은 backend kind.
+  - cancellation/decoder/unknown exception은 backend result가 아님.
+- [ ] public facade shape가 설계 9절과 정확히 일치하는 compile-time usage test를 작성한다. public constructor, bootstrap, 모든 sync/future/suspend operation을 빠짐없이 호출한다.
+- [ ] RED 명령을 실행한다.
+
+```bash
+./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseTest' --tests '*LettuceSuspendFencingLeaseTest'
+```
+
+Expected: facade type이 없어 compilation이 실패한다.
+
+### 6.2 GREEN — facade는 validation과 support에만 위임
+
+- [ ] `LettuceFencingLease` primary constructor는 private이고 standalone/Cluster public secondary constructor가 config를 필수로 받는다. constructor에서 config invariant, derived key wire slot invariant를 완료한다.
+- [ ] sync method와 async method는 같은 validated input을 만들며 async validation failure도 future 생성 전에 동기 throw한다.
+- [ ] future method는 Task 2의 cancellation-propagating `RedisScriptRunner.runAsync()`를 통해 얻은 future를 operation decoder/classifier와 연결하되 caller cancellation을 failed result로 바꾸지 않는다.
+- [ ] public `CompletableFuture<Fencing*Result>`를 만드는 decode/classifier mapping도 source runner future의 cancellation target을 잃지 않는 `decodeCancellable` shared helper를 사용한다. `thenApply`, `handle`, `exceptionally` chain을 public future로 직접 반환하지 않는다. helper는 success frame과 failure를 모두 mapping하고, allowlisted Redis failure만 operation-specific `BackendFailure` result factory에 전달한다. decoder/protocol/unknown exception은 exceptional completion이다.
+
+```kotlin
+internal fun <R> CompletableFuture<List<String>>.decodeCancellable(
+    operation: FencingLeaseOperation,
+    decode: (List<String>) -> R,
+    backendFailure: (FencingLeaseBackendFailure) -> R,
+): CompletableFuture<R> {
+    val source = this
+    val mapped = object : CompletableFuture<R>() {
+        override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
+            val cancelled = super.cancel(mayInterruptIfRunning)
+            if (cancelled) source.cancel(mayInterruptIfRunning)
+            return cancelled
+        }
+    }
+    source.whenComplete { frame, error ->
+        when {
+            source.isCancelled -> mapped.cancel(false)
+            error != null -> try {
+                val failure = classifyFencingBackendFailure(operation, error.unwrapCompletionCause())
+                mapped.complete(backendFailure(failure))
+            } catch (_: CancellationException) {
+                mapped.cancel(false)
+            } catch (failure: Throwable) {
+                mapped.completeExceptionally(failure)
+            }
+            else -> try {
+                mapped.complete(decode(frame))
+            } catch (failure: Throwable) {
+                mapped.completeExceptionally(failure)
+            }
+        }
+    }
+    return mapped
+}
+```
+
+- [ ] public future cancel test는 decode/classifier가 연결된 뒤 EVALSHA pending과 NOSCRIPT EVAL pending 각각에서 현재 upstream future까지 취소되는지 검증한다.
+- [ ] connection/timeout/command exception은 public future가 exceptional completion이 아니라 matching `BackendFailure` result로 정상 완료되는지 sync/suspend와 parity assertion을 둔다. decoder/unknown exception은 exceptional completion을 유지한다.
+- [ ] `LettuceSuspendFencingLease`는 같은 async commands/codec/config/support를 사용하고 `RedisFuture.awaitSuspending()` cancellation을 그대로 보존한다.
+- [ ] 두 execution class는 Redis connection을 보유하므로 `Serializable`을 구현하지 않는다.
+- [ ] facade public signature는 다음 complete contract를 그대로 유지한다.
+
+```kotlin
+class LettuceFencingLease private constructor(
+    syncCommands: RedisScriptingCommands<String, String>,
+    asyncCommands: RedisScriptingAsyncCommands<String, String>,
+    codec: RedisCodec<String, String>,
+    config: LettuceFencingLeaseConfig,
+) {
+    constructor(
+        connection: StatefulRedisConnection<String, String>,
+        config: LettuceFencingLeaseConfig,
+    ) : this(connection.sync(), connection.async(), connection.codec, config)
+
+    constructor(
+        connection: StatefulRedisClusterConnection<String, String>,
+        config: LettuceFencingLeaseConfig,
+    ) : this(connection.sync(), connection.async(), connection.codec, config)
+
+    fun bootstrap(): FencingBootstrapResult
+    fun bootstrapAsync(): CompletableFuture<FencingBootstrapResult>
+    fun acquire(ownerId: FencingOwnerId, leaseTime: Duration): FencingAcquireResult
+    fun acquireAsync(ownerId: FencingOwnerId, leaseTime: Duration): CompletableFuture<FencingAcquireResult>
+    fun inspect(ownerId: FencingOwnerId): FencingInspectResult
+    fun inspectAsync(ownerId: FencingOwnerId): CompletableFuture<FencingInspectResult>
+    fun renew(ownerId: FencingOwnerId, token: FencingToken, leaseTime: Duration): FencingRenewResult
+    fun renewAsync(
+        ownerId: FencingOwnerId,
+        token: FencingToken,
+        leaseTime: Duration,
+    ): CompletableFuture<FencingRenewResult>
+    fun release(ownerId: FencingOwnerId, token: FencingToken): FencingReleaseResult
+    fun releaseAsync(ownerId: FencingOwnerId, token: FencingToken): CompletableFuture<FencingReleaseResult>
+}
+
+class LettuceSuspendFencingLease private constructor(
+    asyncCommands: RedisScriptingAsyncCommands<String, String>,
+    codec: RedisCodec<String, String>,
+    config: LettuceFencingLeaseConfig,
+) {
+    constructor(
+        connection: StatefulRedisConnection<String, String>,
+        config: LettuceFencingLeaseConfig,
+    ) : this(connection.async(), connection.codec, config)
+
+    constructor(
+        connection: StatefulRedisClusterConnection<String, String>,
+        config: LettuceFencingLeaseConfig,
+    ) : this(connection.async(), connection.codec, config)
+
+    suspend fun bootstrap(): FencingBootstrapResult
+    suspend fun acquire(ownerId: FencingOwnerId, leaseTime: Duration): FencingAcquireResult
+    suspend fun inspect(ownerId: FencingOwnerId): FencingInspectResult
+    suspend fun renew(
+        ownerId: FencingOwnerId,
+        token: FencingToken,
+        leaseTime: Duration,
+    ): FencingRenewResult
+    suspend fun release(ownerId: FencingOwnerId, token: FencingToken): FencingReleaseResult
+}
+```
+
+- [ ] targeted contract를 실행한다.
+
+```bash
+./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseTest' --tests '*LettuceSuspendFencingLeaseTest'
+```
+
+Expected: sync/future/suspend가 동일 result와 validation/backend failure boundary를 보인다.
+
+### 6.3 Commit
+
+- [ ] `git diff --check` 후 commit한다.
+
+```text
+Expose one fencing contract across blocking, future, and suspend callers
+
+Constraint: All execution styles must share validation, scripts, decoding, and failure classification.
+Rejected: separate per-facade implementations | they would drift on cancellation and hostile Redis state
+Confidence: high
+Scope-risk: moderate
+Directive: Keep new behavior in shared support and prove every public result through FencingLeaseContract.
+Tested: LettuceFencingLeaseTest; LettuceSuspendFencingLeaseTest; shared contract; git diff --check
+Not-tested: bounded contention and Cluster stress follow
+```
+
+## 7. Task 6 — Cancellation과 모호한 완료를 결정적으로 재현
+
+**Files:**
+
+- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupport.kt`
+- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLease.kt`
+- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLease.kt`
+- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseCancellationTest.kt`
+
+### 7.1 RED — apply 전/후 fault injection
+
+- [ ] public API를 늘리지 않는 internal executor seam을 support에 정의하고, test fake가 operation별로 `BEFORE_APPLY`와 `AFTER_APPLY_BEFORE_REPLY`를 inject하게 한다.
+
+```kotlin
+internal interface FencingScriptExecutor {
+    fun run(
+        operation: FencingLeaseOperation,
+        keys: FencingLeaseKeys,
+        args: List<String>,
+    ): List<String>
+
+    fun runAsync(
+        operation: FencingLeaseOperation,
+        keys: FencingLeaseKeys,
+        args: List<String>,
+    ): CompletableFuture<List<String>>
+
+    suspend fun runSuspending(
+        operation: FencingLeaseOperation,
+        keys: FencingLeaseKeys,
+        args: List<String>,
+    ): List<String>
+}
+```
+
+- [ ] bootstrap/acquire/renew/release 각각에 apply 전 failure와 apply 후 reply loss를 inject하고 operation-specific reconciliation을 검증한다.
+  - bootstrap: 승인된 fresh epoch에서 replay는 initialized/already initialized.
+  - acquire: 같은 owner replay가 같은 token.
+  - renew: inspect same token 후 재시도 가능.
+  - release: `Lost`를 ownership 폐기로만 해석.
+- [ ] release ambiguity는 두 branch를 모두 검증한다.
+  - BEFORE_APPLY 뒤 `inspect(ownerId)`가 exact same token의 `Owned`면 같은 owner/token으로 release를 한 번 다시 시도할 수 있다.
+  - AFTER_APPLY 뒤 `Lost`면 local ownership을 폐기하고 성공/expiry를 구분하지 않는다.
+  - inspect가 `Contended`, 다른/newer token, integrity/backend failure를 보이면 release retry와 local success 처리를 모두 금지한다.
+- [ ] returned `CompletableFuture.cancel(true)`의 cancelled 상태, EVALSHA/fallback current upstream cancellation, server apply 전/후 state를 검증한다.
+- [ ] 실제 coroutine job cancel이 `CancellationException`으로 끝나고 backend result/retry로 변하지 않음을 `runSuspendIO`로 검증한다.
+- [ ] sleep/network timing 없이 latch/fake로 아래 operation × phase × signal matrix를 모두 실행한다. 모든 BEFORE cell은 Redis mutation 0, 모든 AFTER cell은 적용된 ambiguous state와 operation-specific reconcile을 확인한다.
+
+| Operation | BEFORE_APPLY backend failure | AFTER_APPLY reply loss | Future cancel | Coroutine cancel | Reconcile |
+|---|---:|---:|---:|---:|---|
+| bootstrap | required | required | required | required | fresh higher epoch replay |
+| acquire | required | required | required | required | same owner replay, same token |
+| renew | required | required | required | required | inspect same token, optional renew retry |
+| release | required | required | required | required | `Lost` means local ownership discarded |
+- [ ] RED 명령을 실행한다.
+
+```bash
+./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseCancellationTest'
+```
+
+Expected: fault seam과 cancellation reconciliation이 없어 실패한다.
+
+### 7.2 GREEN — cancellation 우선 전파
+
+- [ ] default executor는 기존 runner에만 위임하고 test seam은 internal test access로 제한한다.
+- [ ] 두 facade의 public constructor는 default executor를 private primary constructor로 전달한다. `internal companion object createForTesting(...)`만 controllable executor를 같은 private constructor에 주입하며 public test constructor나 public executor type은 만들지 않는다.
+- [ ] suspend wrapper의 catch ordering은 반드시 아래 형태를 유지한다.
+
+```kotlin
+try {
+    return decode(executor.runSuspending(operation, keys, args))
+} catch (e: CancellationException) {
+    throw e
+} catch (e: Exception) {
+    return backendFailureOrThrow(operation, e)
+}
+```
+
+- [ ] future completion도 `CancellationException`/cancelled 상태를 먼저 보존하고 backend classifier는 실제 Redis exception만 받는다.
+- [ ] cancellation test를 실행한다.
+
+```bash
+./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseCancellationTest' --rerun-tasks
+```
+
+Expected: before/after apply와 EVALSHA/EVAL 전환 모든 case가 deterministic하게 통과한다.
+
+### 7.3 Commit
+
+- [ ] `git diff --check` 후 commit한다.
+
+```text
+Make ambiguous fencing outcomes recoverable without hiding cancellation
+
+Constraint: Client cancellation and transport loss cannot prove whether a Redis script executed.
+Rejected: cancellation as BackendFailure | it breaks structured concurrency and caller ownership recovery
+Confidence: high
+Scope-risk: moderate
+Directive: Reconcile mutations with the same owner and token after any post-dispatch ambiguity.
+Tested: LettuceFencingLeaseCancellationTest before and after apply; git diff --check
+Not-tested: external topology promotion remains opt-in
+```
+
+## 8. Task 7 — Bounded contention과 Redis Cluster routing
+
+**Files:**
+
+- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseConcurrencyTest.kt`
+- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseClusterTest.kt`
+
+### 8.1 RED — duplicate generation과 wrong-slot 방어
+
+- [ ] `@Timeout(30)`을 붙인 standalone `MultithreadingTester`/`SuspendedJobTester` fixture로 16 caller × 25 generation을 수행한다.
+  - 각 round마다 16개의 distinct owner를 barrier에서 동시에 시작한다.
+  - 정확히 1 `Acquired`, 나머지 15 `Contended` → winner same-owner replay가 동일 token → winner release → 다음 round 순서를 강제한다.
+  - 발급 token 중복 0, natural ordering regression 0, unexpected failure 0.
+  - 같은-owner retry는 generation을 증가시키지 않음.
+- [ ] `@Timeout(30)` Cluster fixture도 round마다 8 distinct owner를 barrier에서 동시에 시작해 정확히 1 `Acquired`, 7 `Contended`, same-owner replay, release 후 다음 round로 진행한다. standalone은 25개, Cluster는 10개의 중복 없는 strictly increasing winner token을 검증하고 sync/future/suspend result parity와 script routing을 함께 고정한다.
+- [ ] custom codec이 두 logical key를 다른 wire slot으로 encode하는 fixture에서 constructor가 node dispatch 전에 stable `IllegalArgumentException`을 던짐을 command spy로 검증한다.
+- [ ] RED 명령을 Testcontainers 순차로 실행한다.
+
+```bash
+./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseConcurrencyTest'
+./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseClusterTest'
+```
+
+Expected: contention/Cluster contract 중 누락된 동작이 실패한다.
+
+### 8.2 GREEN — 발견된 race/routing만 최소 수정
+
+- [ ] 실패가 있다면 shared support/Lua에만 최소 수정하고 facade별 workaround를 만들지 않는다.
+- [ ] hot resource는 한 slot/event loop에서 직렬화된다는 경계를 test 이름과 KDoc evidence에 남기고 latency SLA나 새 benchmark dependency는 추가하지 않는다.
+- [ ] 두 test를 다시 순차 실행한다.
+
+```bash
+./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseConcurrencyTest' --rerun-tasks
+./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseClusterTest' --rerun-tasks
+```
+
+Expected: bounded contention과 Cluster test가 각각 30초 안에 통과한다.
+
+### 8.3 Commit
+
+- [ ] `git diff --check` 후 commit한다.
+
+```text
+Prove fencing generations stay unique under bounded contention
+
+Constraint: One logical resource is serialized by one Redis slot and custom codecs define routing bytes.
+Rejected: string-only slot checks and latency SLA gates | they ignore wire encoding and add unstable environment coupling
+Confidence: high
+Scope-risk: narrow
+Directive: Keep contention bounded and run standalone and Cluster Testcontainers checks sequentially.
+Tested: LettuceFencingLeaseConcurrencyTest; LettuceFencingLeaseClusterTest; git diff --check
+Not-tested: production-scale latency is intentionally outside this issue
+```
+
+## 9. Task 8 — 외부 resilience, downstream CAS, epoch recovery 예제
+
+**Files:**
+
+- Modify: `infra/lettuce/build.gradle.kts`
+- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseResilience4jTest.kt`
+- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseRecoveryTest.kt`
+- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseTopologyRecoveryTest.kt`
+
+### 9.1 RED — caller-layer policy contract
+
+- [ ] 실제 Redis acquire를 `SuspendDecorators`로 감싸고 다음 exact order를 검증한다.
+
+```kotlin
+SuspendDecorators.ofSupplier {
+    lease.acquire(ownerId, leaseTime)
+}
+    .withRetry(retry)
+    .withCircuitBreaker(circuitBreaker)
+    .withBulkhead(bulkhead)
+    .invoke()
+```
+
+- [ ] `RetryConfig.retryOnResult`와 `CircuitBreakerConfig.recordResult`는 `FencingAcquireResult.BackendFailure`만 failure로 센다.
+- [ ] Retry의 exception predicate는 항상 false여서 exception을 재시도하지 않는다. CircuitBreaker는 exception을 모두 ignore해 caller/validation/cancellation/internal exception을 success나 failure로 기록하지 않는다. exception은 decorator 밖으로 그대로 전파한다.
+
+```kotlin
+val retry = Retry.of(
+    name,
+    RetryConfig.custom<FencingAcquireResult>()
+        .maxAttempts(2)
+        .waitDuration(Duration.ZERO)
+        .retryOnResult(::isBackendFailure)
+        .retryOnException { false }
+        .build(),
+)
+val circuitBreaker = CircuitBreaker.of(
+    name,
+    CircuitBreakerConfig.custom()
+        .slidingWindowSize(2)
+        .minimumNumberOfCalls(2)
+        .failureRateThreshold(50.0F)
+        .recordResult { result -> result is FencingAcquireResult.BackendFailure }
+        .ignoreException { true }
+        .build(),
+)
+```
+- [ ] 한 bulkhead permit이 전체 retry를 감싸고 circuit breaker가 retry 종료 후 final result 하나만 관찰함을 metrics와 controlled attempts로 검증한다.
+- [ ] `IntegrityFailure`, `CounterUnavailable`, `SequenceExhausted`, `OwnershipMismatch`, validation은 retry하지 않는다.
+- [ ] `CallNotPermittedException`, `BulkheadFullException`, `CancellationException`은 primitive result로 변환하지 않는다.
+- [ ] supplier 내부 `IllegalArgumentException`, `CancellationException`, internal protocol exception은 supplier attempt=1, retry attempt=0, Retry `failedWithoutRetryAttempt=1`, CircuitBreaker success/failure=0인지 각각 독립 instance로 검증한다.
+- [ ] open CircuitBreaker의 `CallNotPermittedException`과 포화 Bulkhead의 `BulkheadFullException`은 supplier attempt=0이며 inner Retry metric이 변하지 않는다. CircuitBreaker는 open rejection을 recorded success/failure로 세지 않고, Bulkhead rejection은 CircuitBreaker와 Retry 모두에 도달하지 않는다.
+- [ ] same owner를 decorator 밖에서 capture해 ambiguous acquire replay가 같은 token을 반환함을 실제 Redis로 검증한다.
+- [ ] PostgreSQL-style in-memory fixture는 `(resourceId, epoch, sequence)`를 저장하고 `affectedRows == 1`만 accepted로 처리한다. same/stale token replay는 0이며 business idempotency key는 별도 field/fixture로 둔다.
+- [ ] deterministic control-plane harness가 다음 exact transition을 검증한다.
+
+```text
+pause -> block old acquire -> drain lease and downstream writer -> CAS bump epoch ->
+bootstrap -> verify readiness and tuple guard -> rollout -> confirm old absence -> resume
+```
+
+- [ ] mixed epoch 탐지 시 abort, lower-epoch rollback 거절, higher epoch 유지, Redis-only rollback detection 한계와 downstream stale rejection을 검증한다.
+- [ ] concurrent durable epoch allocator 두 개 이상을 barrier에서 시작해 CAS 성공이 정확히 1개이고 한 higher epoch만 활성화됨을 검증한다. application-local config와 Redis counter를 authority로 넣는 fake는 allocation 권한이 없어야 한다.
+- [ ] bootstrap 후 readiness PASS는 exact counter `TYPE=string`, `PTTL=-1`, canonical non-negative decimal, downstream strict tuple guard enabled를 모두 만족할 때만 발생한다.
+- [ ] event trace로 mixed epoch 발견 뒤 `ROLLOUT`과 `RESUME` event가 0임을 검증한다. lower-epoch binary rollback 요청은 rejected event를 남기고 current higher epoch를 유지한다.
+- [ ] README의 marker-delimited diagnostic Lua를 실제 standalone Redis에서 `evalReadOnly`/`EVAL_RO`로 실행한다.
+  - input은 derived lease/counter exact 2 keys만 허용하고 output은 bounded stable classification code와 boolean뿐이다.
+  - clean, missing counter, malformed lease, TTL 없는 partial lease를 각각 분류한다.
+  - lease-only delete eligibility 4조건을 각 하나씩 false로 만드는 table과 all-true case를 검증한다. 하나라도 false면 delete 금지다.
+  - repair 전후 counter value와 `PTTL=-1`은 같아야 하며 counter delete/decrement/TTL 설정/same-epoch bootstrap command가 없어야 한다.
+- [ ] `LettuceFencingLeaseTopologyRecoveryTest`는 `@Tag("fencing-topology")`를 사용하고 기본 `test` task에서는 제외한다. 전용 `fencingLeaseTopologyRecoveryTest` task만 해당 tag를 include하며 Testcontainers primary/replica와 Toxiproxy를 순차 실행한다.
+  - primary/replica가 같은 baseline offset에 도달한 뒤 Toxiproxy로 replication path를 차단하고 old epoch write를 primary에만 acknowledge시킨다.
+  - primary를 중지하고 stale replica를 실제 `REPLICAOF NO ONE`으로 승격한 뒤 external incident signal을 발생시킨다.
+  - signal 이전 old acquire 1회가 존재하고, signal 뒤 traffic gate가 닫혀 old acquire/downstream write가 0인지 event trace와 barrier로 검증한다.
+  - durable CAS allocator가 higher epoch를 정확히 한 번 발급하고, promoted Redis에 bootstrap/readiness를 통과한 뒤 새 token의 epoch가 높으며 downstream strict tuple guard가 old token을 거절하는지 검증한다.
+  - restore branch는 known-old RDB fixture로 Redis를 재기동한 뒤 동일 pause→CAS bump→bootstrap→readiness→resume contract를 반복하고 same/lower epoch bootstrap이 없음을 검증한다.
+  - `finally`에서 traffic gate, Toxiproxy toxic/proxy, Lettuce connection/client, primary/replica/restore container, network를 역순으로 정리하고 thread/future가 남지 않는지 검증한다.
+- [ ] RED 명령을 순차 실행한다.
+
+```bash
+./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseResilience4jTest'
+./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseRecoveryTest'
+./gradlew :bluetape4k-lettuce:fencingLeaseTopologyRecoveryTest
+```
+
+Expected: caller policy/recovery fixture와 tagged topology task가 없어 실패한다.
+
+### 9.2 GREEN — test/example layer에서만 policy 구현
+
+- [ ] resilience/testcontainers dependency는 이미 있으므로 dependency를 추가하지 않는다. `build.gradle.kts`는 기본 `test`의 `excludeTags("performance", "fencing-topology")`와 `fencingLeaseTopologyRecoveryTest` 전용 task만 추가한다.
+- [ ] result predicate는 acquire result에 대해 다음 exact shape를 사용하고, 다른 operation 예제도 각 `BackendFailure` variant만 failure로 센다.
+
+```kotlin
+private fun isBackendFailure(result: FencingAcquireResult): Boolean =
+    result is FencingAcquireResult.BackendFailure
+```
+
+- [ ] production primitive에 Retry/CircuitBreaker/Bulkhead type, 설정, retry loop를 추가하지 않는다.
+- [ ] recovery harness는 test-only durable authority/CAS로 유지하고 production PostgreSQL adapter를 만들지 않는다.
+- [ ] test를 다시 순차 실행한다.
+
+```bash
+./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseResilience4jTest' --rerun-tasks
+./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseRecoveryTest' --rerun-tasks
+./gradlew :bluetape4k-lettuce:fencingLeaseTopologyRecoveryTest --rerun-tasks
+```
+
+Expected: decorator topology, exception boundary, strict tuple acceptance, simulated recovery와 실제 tagged promotion/restore contract가 통과한다.
+
+### 9.3 Commit
+
+- [ ] `git diff --check` 후 commit한다.
+
+```text
+Demonstrate caller-owned resilience and durable fencing rejection
+
+Constraint: Retry policy and durable epoch authority belong outside the Redis primitive.
+Rejected: internal retry and PostgreSQL adapter | they would couple service policy and persistence to the lease API
+Confidence: high
+Scope-risk: narrow
+Directive: Retry only BackendFailure with the same owner and keep business idempotency separate from fencing order.
+Tested: LettuceFencingLeaseResilience4jTest; LettuceFencingLeaseRecoveryTest; fencingLeaseTopologyRecoveryTest; git diff --check
+Not-tested: production-managed Redis topology remains outside the Testcontainers contract
+```
+
+## 10. Task 9 — English KDoc, bilingual README, executable documentation
+
+**Files:**
+
+- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseValue.kt`
+- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseResult.kt`
+- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLease.kt`
+- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLease.kt`
+- Modify: `infra/lettuce/README.md`
+- Modify: `infra/lettuce/README.ko.md`
+- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseDocumentationTest.kt`
+
+### 10.1 RED — KDoc와 locale parity contract
+
+- [ ] public class/interface/object/function/property에 English KDoc이 있는지 source/reflection contract로 검증한다.
+- [ ] README locale 양쪽에 같은 marker 순서와 다음 decision fragment를 요구한다.
+  - opaque lease와 fencing lease 선택 기준.
+  - config instance가 namespace/resource/epoch를 고정.
+  - explicit bootstrap, counter loss 시 same-epoch bootstrap 금지.
+  - `(epoch, sequence)` ordering과 resource-bound storage.
+  - PostgreSQL `NOT NULL DEFAULT 0` tuple 및 `affectedRows == 1` strict acceptance.
+  - retry/CB/bulkhead exact chain, BackendFailure-only result predicate, caller-layer exceptions.
+  - pause/drain/CAS bump/bootstrap/readiness/rollout/resume, lower epoch rollback 금지.
+  - O(1) `EVAL_RO` fixed-key diagnostic과 lease-only manual repair 4조건.
+  - metric 허용 dimension은 operation/result/backend-or-integrity kind뿐이고 namespace/resource/owner/token/fingerprint는 label 금지.
+  - `CounterUnavailable`/integrity/overflow/backend/external restore signal별 pause→diagnose→cutover action mapping.
+  - exactly-once/business idempotency/durable correctness 비보장.
+- [ ] documentation test에서 README 양 locale의 marker-delimited Kotlin/SQL/Lua snippet을 추출·정규화해 같은 helper/config/source와 비교하고 Kotlin resilience 예제, downstream CAS helper, diagnostic Lua를 실제 호출한다. SQL contract는 `affectedRows == 1` acceptance, `0` stale/same-token rejection, 별도 business idempotency key를 함께 검증한다.
+- [ ] 양 README와 table-driven docs test에 아래 exhaustive caller action 표를 동일하게 넣는다. token을 저장하는 정상 경로는 stable resource/domain identity와 tuple을 함께 저장해야 한다.
+
+| Result | Required caller action |
+|---|---|
+| `Initialized`, `AlreadyInitialized` | readiness 확인 후 승인된 epoch rollout 계속 |
+| `Acquired`, `AlreadyOwned`, `Owned`, `Renewed` | ownership 정상 경로 계속; token을 resource/domain identity와 함께 저장 |
+| `Released` | local ownership 폐기, downstream write 금지 |
+| acquire `Contended` | TTL 이후 새 owner attempt 또는 bounded backoff; backend retry로 취급 금지 |
+| inspect `Contended` | local ownership 폐기, downstream write 금지 |
+| `Lost`, `OwnershipMismatch` | local ownership 폐기, downstream write 금지 |
+| `CounterUnavailable` | acquire 중지, 최초 배포/history-loss 운영 판정; 결과만 보고 bootstrap 금지 |
+| `SequenceExhausted` | retry 금지, higher-epoch cutover alert; max epoch면 domain freeze/migration |
+| `IntegrityFailure` | retry/mutation 중지, read-only diagnosis와 runbook 실행 |
+| `BackendFailure` | ambiguous completion으로 operation-specific reconcile; 정책 retry면 same owner/token |
+- [ ] RED 명령을 실행한다.
+
+```bash
+./gradlew :bluetape4k-lettuce:test --tests '*FencingLeaseDocumentationTest'
+```
+
+Expected: README section/marker가 없어 실패한다.
+
+### 10.2 GREEN — 문서와 KDoc를 구현에 맞춤
+
+- [ ] public KDoc에 owner capability, token domain identity 부재, cross-epoch pre-dispatch rejection, same-owner recovery, ambiguous completion, same-slot codec validation, hot resource serialization, overflow/terminal epoch, downstream strict tuple guard를 설명한다.
+- [ ] `README.md`에 English `<!-- fencing-lease:* -->` marker section을 추가하고 `README.ko.md`에 같은 marker/heading 구조의 자연스러운 Korean section을 추가한다.
+- [ ] PostgreSQL 예제는 다음 exact SQL과 `affectedRows == 1` 판단을 포함한다.
+
+```sql
+ALTER TABLE guarded_resource
+    ADD COLUMN fence_epoch BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN fence_sequence BIGINT NOT NULL DEFAULT 0;
+
+UPDATE guarded_resource
+SET fence_epoch = :epoch,
+    fence_sequence = :sequence,
+    payload = :payload
+WHERE id = :id
+  AND (fence_epoch, fence_sequence) < (:epoch, :sequence);
+```
+
+- [ ] EVAL_RO 진단은 파생된 exact lease/counter key만 입력하고 stable code/boolean만 출력한다. raw owner/token/value, `HGETALL`, `KEYS`, `SCAN` 예제를 문서에 넣지 않는다.
+- [ ] README 양쪽에서 existing multi-key lease 설명을 유지하고 fencing이 이를 자동 대체한다고 쓰지 않는다.
+- [ ] docs test와 diff check를 실행한다.
+
+```bash
+./gradlew :bluetape4k-lettuce:test --tests '*FencingLeaseDocumentationTest'
+git diff --check
+```
+
+Expected: bilingual marker/source parity와 executable example이 통과한다.
+
+### 10.3 Commit
+
+- [ ] commit한다.
+
+```text
+Document the operational boundary required for fencing safety
+
+Constraint: Redis ordering is safe only when callers persist and compare the resource-bound tuple durably.
+Rejected: API-only documentation | it would omit recovery, rollback, and resilience responsibilities
+Confidence: high
+Scope-risk: narrow
+Directive: Keep English and Korean README contracts source-equivalent whenever fencing behavior changes.
+Tested: FencingLeaseDocumentationTest; KDoc contract; git diff --check
+Not-tested: rendered website is outside this module README change
+```
+
+## 11. Task 10 — Regression, static analysis, acceptance 추적
+
+**Files:**
+
+- Verify only; source 변경은 실패 수정에 한정한다.
+
+### 11.1 Targeted suite
+
+- [ ] pure unit부터 Redis integration 순으로 실행한다.
+
+```bash
+./gradlew :bluetape4k-lettuce:test \
+  --tests '*FencingLeaseValueTest' \
+  --tests '*FencingLeaseResultTest' \
+  --tests '*LettuceFencingLeaseSupportTest'
+
+./gradlew :bluetape4k-lettuce:test \
+  --tests '*LettuceFencingLeaseScriptTest' \
+  --tests '*LettuceFencingLeaseTest' \
+  --tests '*LettuceSuspendFencingLeaseTest' \
+  --tests '*LettuceFencingLeaseCancellationTest' \
+  --tests '*LettuceFencingLeaseConcurrencyTest' \
+  --tests '*LettuceFencingLeaseResilience4jTest' \
+  --tests '*LettuceFencingLeaseRecoveryTest' \
+  --tests '*FencingLeaseDocumentationTest'
+
+./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseClusterTest'
+./gradlew :bluetape4k-lettuce:fencingLeaseTopologyRecoveryTest
+```
+
+Expected: 모든 targeted test가 통과하고 Testcontainers test가 서로 겹치지 않는다.
+
+### 11.2 기존 API 회귀
+
+- [ ] 기존 script와 lease test를 명시적으로 실행한다.
+
+```bash
+./gradlew :bluetape4k-lettuce:test \
+  --tests 'io.bluetape4k.redis.lettuce.script.RedisScriptTest' \
+  --tests '*LettuceMultiKeyLease*' \
+  --tests '*MultiKeyLease*'
+```
+
+Expected: 기존 RedisScriptRunner와 multi-key lease contract가 그대로 통과한다.
+
+### 11.3 Module gate와 static analysis
+
+- [ ] full module test와 detekt를 실행한다.
+
+```bash
+repo-test-summary -- ./gradlew :bluetape4k-lettuce:test
+./gradlew :bluetape4k-lettuce:detekt :bluetape4k-lettuce:detektTest
+git diff --check
+```
+
+Expected: `:bluetape4k-lettuce:test` 0 failures, detekt 0 findings, whitespace error 0.
+
+- [ ] changed Kotlin test 전체를 검색해 assertion/style invariant를 확인한다.
+
+```bash
+rg -n 'assertThrows|kotlin\.test\.assertFailsWith|\)\.shouldBeFalse\(\)|TO''DO|FIX''ME|T''BD' \
+  infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease \
+  infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease \
+  infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/script/RedisScriptTest.kt
+```
+
+Expected: 허용되지 않은 assertion/작업 marker 0. 의도적 `shouldBeFalse()`가 있다면 boolean 상태 자체를 검증하는 경우인지 수동 확인하고 equality 대체가 가능하면 intent matcher로 바꾼다.
+
+### 11.4 Acceptance traceability
+
+- [ ] 아래 matrix의 각 행을 fresh test 이름/파일/명령 결과에 연결한다.
+
+| 설계/issue acceptance | 구현 evidence | Test evidence |
+|---|---|---|
+| config-bound domain, wire-byte same slot | `FencingLeaseValue.kt`, support key derivation | value/support/Cluster test |
+| orderable token, serialization, redaction | `FencingToken`, owner/result model | value/result round-trip, identity, crafted payload test |
+| explicit bootstrap, missing counter fail-closed | bootstrap/acquire Lua | script hostile-state test |
+| atomic generation and same-owner replay | acquire Lua | contract/concurrency/ambiguous completion test |
+| owner+token renew/release | renew/release Lua | shared contract stale holder test |
+| backend/integrity/protocol boundary | shared decoder/classifier | support + three-adapter parity test |
+| future/coroutine cancellation | runner bridge + suspend wrapper | RedisScript/cancellation test |
+| fixed O(1) preflight/reply | Lua source and decoder | script structural/hostile test |
+| standalone/Cluster parity | two facades + shared support | standalone/Cluster test |
+| external Retry/CB/Bulkhead only | test/example code | resilience + docs test |
+| downstream strict tuple guard | no production adapter | recovery/docs CAS fixture |
+| epoch recovery/lower rollback prohibition | docs + test harness | recovery/docs test |
+| tagged topology promotion/restore recovery | opt-in Testcontainers task | `fencingLeaseTopologyRecoveryTest` |
+| bilingual docs/KDoc | README locale + public source | documentation test |
+| existing API unchanged | no old API edits except shared runner behavior fix | RedisScript + MultiKeyLease regression |
+
+- [ ] review 결과 P0=0/P1=0인지 확인하고 P2/P3는 수정하거나 근거와 함께 PR review note에 남긴다.
+
+### 11.5 Final implementation commit
+
+- [ ] verification 중 필요한 수정이 있었다면 하나의 bounded commit으로 마무리한다. 수정이 없으면 빈 commit을 만들지 않는다.
+
+```text
+Close the fencing lease verification gaps before review
+
+Constraint: Issue 1068 requires fresh module, static-analysis, serialization, cancellation, Cluster, and documentation evidence.
+Rejected: targeted tests alone | they cannot prove existing Lettuce lease compatibility
+Confidence: high
+Scope-risk: narrow
+Directive: Re-run the exact affected gate after any review fix before updating the PR head.
+Tested: targeted fencing suite; opt-in topology recovery; existing RedisScript and MultiKeyLease suite; module test; detekt; git diff --check
+Not-tested: production-managed Redis topology
+```
+
+## 12. 구현 완료 후 delivery gate
+
+- [ ] branch가 `feature/issue-1068-fencing-lease`, base가 latest `origin/develop`인지 확인한다.
+- [ ] exact local HEAD를 push하고 public PR title/body는 English로 작성한다. PR은 issue #1068을 연결하고 issue milestone/assignee/labels를 미러링한다.
+- [ ] PR body에 acceptance traceability, exact commands/results, tagged topology task 결과, production-managed topology boundary, no new dependency/module을 기록한다.
+- [ ] CI, current review, unresolved thread, human-review artifact를 exact head에서 확인한다.
+- [ ] merge-ready 상태를 보고한 뒤 별도의 사용자 merge 승인을 기다린다. plan/spec 승인은 merge 승인으로 간주하지 않는다.
+- [ ] merge 승인 뒤에만 rebase merge하고 local `develop` fast-forward, merged worktree/branch cleanup을 수행한다.
+
+## 13. Plan 완료 조건
+
+- implementation 시작 전 plan 자체를 performance, stability, security, Ops, API, caller 관점에서 독립 검토한다.
+- P0=0, P1=0이 아니면 plan을 수정하고 해당 관점을 새 review lane에서 재검토한다.
+- spec 17절 acceptance criteria가 Task 1–10과 traceability matrix에 모두 연결돼야 한다.
+- plan file만 commit하고 Kotlin/README 구현은 다음 명시적 승인 전 시작하지 않는다.

--- a/docs/superpowers/plans/2026-07-22-issue-1068-fencing-lease-plan.md
+++ b/docs/superpowers/plans/2026-07-22-issue-1068-fencing-lease-plan.md
@@ -409,7 +409,7 @@ Not-tested: fencing lease integration is introduced later
   - derived key가 정확히 `fence:{namespace:resourceName}:<epoch>:lease|counter`.
   - default/custom codec 모두 `SlotHash.getSlot(codec.encodeKey(key))`를 사용하고, wire bytes가 다른 slot이면 stable `IllegalArgumentException`이며 command mock interaction은 0.
   - decimal parser는 `0`, positive canonical decimal, `Long.MAX_VALUE`를 허용하고 sign, leading zero, whitespace, empty, non-digit, 20+ byte를 거절.
-  - TTL은 positive whole millisecond만 허용하며 nanos-only, zero, negative, `toMillis()` overflow를 모두 `IllegalArgumentException`으로 정규화.
+  - TTL은 positive whole millisecond로 변환하고 nanos-only, zero, negative, `toMillis()` overflow를 모두 `IllegalArgumentException`으로 정규화. operation wrapper는 exact Lua integer/TTL reply를 위해 `2^53 - 1` milliseconds 상한도 dispatch 전에 검증.
   - token epoch mismatch는 renew/release dispatch 전에 거절.
   - `CompletionException`/`ExecutionException` 최대 8단계 unwrap, identity cycle 방지, chain 어디의 `CancellationException`도 rethrow.
   - `RedisConnectionException`→`CONNECTION`, `RedisCommandTimeoutException`/`TimeoutException`→`TIMEOUT`, 다른 `RedisException`→`COMMAND`.
@@ -502,6 +502,8 @@ internal fun Duration.requireFencingLeaseMillis(): Long {
 }
 ```
 
+- [ ] Redis operation TTL은 `2^53 - 1` milliseconds 이하로 제한해 `PEXPIRE` absolute timestamp overflow와 Lua `PTTL` precision loss를 write 전에 차단한다. `PTTL` wire field는 `string.format('%.0f', ttl)`로 canonical decimal을 유지한다.
+
 - [ ] operation별 decoder와 result factory를 분리하되 unknown status/field count/malformed success payload는 `FencingLeaseProtocolException`으로만 실패하게 한다.
 - [ ] backend classifier는 public result를 받는 operation wrapper 하나에서 공유하고 raw `Throwable`을 public value나 log message에 넣지 않는다.
 - [ ] `domainFingerprint`가 필요할 때만 `namespace + NUL + resourceName + NUL + epoch` SHA-256 앞 12 bytes를 24 lowercase hex로 계산하며 metric label API는 추가하지 않는다.
@@ -562,6 +564,7 @@ Expected: script runner/decoder operation이 없어 test compilation 또는 asse
 ### 5.2 GREEN — fixed O(1) Lua protocol
 
 - [ ] script 공통 preflight는 두 exact key만 사용하고 mutation 전에 다음을 모두 판정한다.
+  - acquire/renew TTL argument의 canonical positive decimal과 `2^53 - 1` 상한.
   - counter `TYPE`, `PTTL`, `STRLEN`, canonical decimal과 범위.
   - lease `TYPE`, `PTTL`, `HLEN`, fixed field `HSTRLEN`, fixed `HMGET`, stored epoch와 counter relation.
   - lease `PTTL == -2`는 absent로 재분류하고 `-1`은 `MALFORMED_LEASE`.

--- a/docs/superpowers/specs/2026-07-22-issue-1068-fencing-lease-design.md
+++ b/docs/superpowers/specs/2026-07-22-issue-1068-fencing-lease-design.md
@@ -414,7 +414,9 @@ class LettuceSuspendFencingLease private constructor(
 모든 operation은 caller가 준 argument를 dispatch 전에 검증한다. 특히 TTL은 positive
 millisecond로 정확히 변환 가능해야 하며 0, negative, sub-millisecond, overflow
 duration을 거절한다. `Duration.toMillis()`의 `ArithmeticException`을 포함한 변환 실패는
-raw exception을 노출하지 않고 `IllegalArgumentException`으로 정규화한다.
+raw exception을 노출하지 않고 `IllegalArgumentException`으로 정규화한다. 변환된 TTL은
+Lua가 integer와 `PTTL` reply를 정확히 다룰 수 있도록 `2^53 - 1` milliseconds 이하여야 하며,
+이 상한 초과도 Redis dispatch 전에 `IllegalArgumentException`으로 거절한다.
 `renew`와 `release`는 `token.epoch == config.epoch`를 dispatch 전에 검증하며 다른 epoch는
 `IllegalArgumentException`이다. 같은 tuple을 가진 다른 resource의 token은 token 자체에
 domain identity가 없어 검출할 수 없으므로, caller가 resource-bound handle/storage로
@@ -810,6 +812,8 @@ counter는 어떤 repair에서도 삭제, 감소, TTL 설정, 같은 epoch boots
   backend kind가 되고 cancellation/decoder/non-Lettuce exception은 분류되지 않는 test.
 - sub-millisecond와 `Duration.toMillis()` overflow가 세 API 모두 dispatch 전에
   `IllegalArgumentException`이 되는 parity test.
+- `2^53 - 1` milliseconds TTL은 실제 Redis acquire/replay/inspect에서 canonical decimal
+  reply를 유지하고, 그보다 큰 TTL은 세 API 모두 dispatch 전에 거절하는 test.
 - 다른 epoch token의 renew/release가 dispatch 전에 거절되고, 같은 tuple의 다른 resource
   token은 primitive가 식별할 수 없어 resource-bound caller handle이 필요한 misuse test.
 - 모든 public config/value/failure/result variant의 Java serialization round-trip과

--- a/docs/superpowers/specs/2026-07-22-issue-1068-fencing-lease-design.md
+++ b/docs/superpowers/specs/2026-07-22-issue-1068-fencing-lease-design.md
@@ -1,0 +1,1008 @@
+# Issue #1068 Redis fencing lease 설계
+
+## 1. 배경
+
+`infra/lettuce`의 기존 `LettuceLock`, `LettuceSemaphore`,
+`LettuceMultiKeyLease`는 opaque owner token과 TTL로 Redis 안의 소유권 변경을
+보호한다. 하지만 opaque token은 순서를 비교할 수 없으므로, 만료된 lease holder가
+긴 pause 뒤에 깨어나 PostgreSQL이나 outbox 같은 외부 시스템에 늦은 write를 보내는
+문제를 막지 못한다.
+
+Issue #1068은 한 logical resource에 대해 ownership generation마다 증가하는
+`FencingToken(epoch, sequence)`을 발급하는 Redis primitive를 `bluetape4k-lettuce`에
+추가한다. downstream authority는 마지막으로 수락한 token을 저장하고 다음 조건을
+원자적으로 적용해야 한다.
+
+```text
+accept only when incomingFence > lastAcceptedFence
+```
+
+이 primitive가 제공하는 것은 orderable ownership generation이다. exactly-once 실행,
+분산 transaction, business idempotency를 대신하지 않는다.
+
+## 2. 목표
+
+- 한 resource의 lease 획득과 fencing sequence 증가를 하나의 Lua 실행으로 처리한다.
+- 같은 counter history 안에서 새 ownership generation마다 더 큰 token을 발급한다.
+- token을 `(epoch, sequence)` 사전식 순서로 비교해 Redis history recovery 뒤에도 새
+  namespace generation이 이전 generation보다 크게 정렬되게 한다.
+- active owner가 같은 `FencingOwnerId`로 acquire를 재시도하면 새 sequence를 만들지 않고
+  기존 token을 돌려준다.
+- renew는 기존 token을 유지하고 release와 함께 owner와 token을 모두 비교한다.
+- bootstrap, acquire, inspect, renew, release가 모호한 boolean 대신 명시적인 sealed
+  result를 반환한다.
+- sync, `CompletableFuture`, suspend API가 같은 validation, Lua, decoder, result 의미를
+  공유한다.
+- Redis Cluster same-slot, sequence overflow, counter loss, script cache loss,
+  cancellation, ambiguous completion의 경계를 문서와 test로 고정한다.
+- 모든 public data class, sealed result, nested data object에 `Serializable`과 명시적인
+  `serialVersionUID = 1L`을 적용한다. enum은 Java의 고정 enum serialization을 따른다.
+
+## 3. 비목표
+
+- PostgreSQL adapter, repository, outbox, scheduler, domain workflow를 구현하지 않는다.
+- `bluetape4k-leader` API나 module dependency를 변경하지 않는다.
+- 여러 resource를 한 transaction으로 묶거나 cross-slot fencing을 흉내 내지 않는다.
+- Redis 내부 retry, `Retry`, `CircuitBreaker`, `Bulkhead` 정책을 포함하지 않는다.
+- Redis counter history 손실 뒤 같은 epoch의 monotonicity를 복구했다고 주장하지 않는다.
+- downstream conditional write나 마지막 accepted token 저장을 대신하지 않는다.
+- 기존 opaque lock/lease를 fencing token으로 재해석하지 않는다.
+- 새 module, 새 dependency, diagram을 추가하지 않는다.
+
+## 4. 현재 근거와 제약
+
+### 4.1 재사용할 저장소 구현
+
+- `RedisScript`와 `RedisScriptRunner`: sync/async/suspend EVALSHA 우선 실행 및
+  `NOSCRIPT` 발생 시 EVAL fallback.
+- `RedisScriptRunner.runAsync()`가 만드는 chained future만으로는 upstream Lettuce future의
+  cancellation 전파를 보장할 수 없다. 구현 plan은 upstream future를 보존하는 internal
+  cancellation-propagating wrapper 또는 runner 확장을 먼저 추가하고, EVALSHA와
+  `NOSCRIPT` EVAL fallback 양쪽에 취소를 best-effort로 전달한다.
+- `LettuceMultiKeyLeaseSupport`: Lua 상태 코드, dispatch 전 validation, 공통 decoder,
+  standalone/Cluster scripting command 추상화.
+- `RedisFuture.awaitSuspending()`: suspend API cancellation 전파.
+- `RedisServer.Launcher`와 `RedisClusterServer.Launcher`: 실제 standalone Redis와
+  Cluster 검증 fixture.
+- `MultithreadingTester`, `SuspendedJobTester`: 결정적인 동시성 test harness.
+- `bluetape4k-assertions`: JUnit 5 test의 matcher와 failure assertion.
+
+### 4.2 Redis가 제공하는 범위
+
+- Redis `INCR`는 signed 64-bit integer 범위에서 동작하며 overflow를 error로 거절한다.
+  다만 Lua number로 반환된 큰 정수를 Kotlin `Long`으로 직접 decode하면 IEEE-754 정밀도
+  경계를 건드릴 수 있으므로, script는 counter를 decimal string으로 검증하고 mutation
+  뒤 `GET` 결과를 반환한다.
+- Redis script는 한 번 실행되는 동안 atomic하지만, 네트워크 timeout이나 connection
+  failure가 caller에게 command 적용 여부를 알려주지는 않는다.
+- Redis Cluster의 multi-key script는 모든 key가 같은 hash slot에 있어야 한다.
+- Redis replication은 기본적으로 asynchronous이므로 acknowledged write loss, replica
+  promotion, snapshot rollback, disaster restore 뒤에는 이전 counter history가 보존됐다고
+  가정할 수 없다.
+
+공식 근거:
+
+- [Redis INCR](https://redis.io/docs/latest/commands/incr/)
+- [Redis scripting](https://redis.io/docs/latest/develop/programmability/eval-intro/)
+- [Redis EVAL_RO](https://redis.io/docs/latest/commands/eval_ro/) — Redis 7.0 이상 read-only script
+- [Redis Cluster specification](https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/)
+- [Redis replication](https://redis.io/docs/latest/operate/oss_and_stack/management/replication/)
+
+### 4.3 채택과 거절
+
+| 선택지 | 결정 | 이유 |
+|---|---|---|
+| `FencingToken(sequence)`만 사용 | 거절 | counter history loss 뒤 새 sequence를 이전 값보다 크게 보장할 수 없다. |
+| `FencingToken(epoch, sequence)` 사전식 비교 | 채택 | application-controlled epoch를 올리면 새 history 전체를 이전 history 뒤에 정렬할 수 있다. |
+| acquire가 없는 counter를 자동 생성 | 거절 | 삭제·rollback 뒤 같은 epoch에서 더 작은 sequence를 조용히 발급할 수 있다. |
+| 명시적인 `bootstrap()` | 채택 | 최초 생성과 recovery를 operation boundary로 드러내고 acquire는 counter가 없으면 fail closed한다. |
+| 외부 durable database가 sequence 발급 | 거절 | Redis primitive 범위를 벗어나며 새 persistence adapter가 필요하다. |
+| instance마다 resource/epoch를 config로 고정 | 채택 | key derivation과 ordering domain을 constructor에서 검증하고 operation별 cross-slot 입력을 없앤다. |
+| `FencingLeaseHandle(ownerId, token)` 반환 | 거절 | caller가 이미 가진 owner ID를 result에 중복해 노출하고 log/toString 유출 표면을 늘린다. |
+| raw `Throwable`을 result에 포함 | 거절 | serialization, 정보 노출, backend coupling을 public API에 전파한다. |
+| backend failure category만 반환 | 채택 | caller policy에 필요한 범위만 안정적으로 제공하고 실제 exception은 내부 log에 남긴다. |
+| primitive 내부 resilience 정책 | 거절 | Redis operation과 서비스별 retry/CB/bulkhead 설정을 결합한다. |
+
+## 5. Ordering domain과 config
+
+새 public API의 canonical package는 기존 lease 배치와 같은
+`io.bluetape4k.redis.lettuce.lease`다. 한 `LettuceFencingLease` instance는 정확히 하나의
+`(namespace, resourceName, epoch)`를 담당한다.
+
+```kotlin
+data class LettuceFencingLeaseConfig(
+    val namespace: String,
+    val resourceName: String,
+    val epoch: Long,
+) : Serializable
+```
+
+- `namespace`와 `resourceName`은 각각 1..128자의
+  `[A-Za-z0-9._-]+`만 허용한다. `{`, `}`, `:`와 whitespace를 금지해 key/hash-tag
+  ambiguity를 제거한다.
+- `epoch`는 1 이상이어야 한다. 최초 운영 epoch도 1부터 시작한다.
+- Java deserialization은 constructor와 `init`을 우회하므로, config는 private
+  `readResolve()`에서 public constructor로 새 instance를 만들어 모든 invariant를 다시
+  검증한다. invalid payload는 raw value를 message에 포함하지 않은
+  `InvalidObjectException`으로 거절한다.
+- config는 application-owned trusted configuration이다. untrusted Java serialization
+  payload를 입력으로 받는 것은 지원하지 않는다.
+- token 비교는 같은 `namespace`와 `resourceName`에서만 의미가 있다. token 자체에는
+  namespace/resource를 포함하지 않으므로 caller는 서로 다른 ordering domain의 token을
+  비교하지 않아야 한다.
+- config는 `Serializable`을 구현하고 private companion object에
+  `serialVersionUID: Long = 1L`을 둔다.
+
+`FencingOwnerId`는 acquire attempt를 식별하는 opaque capability value다.
+
+```kotlin
+class FencingOwnerId private constructor(
+    internal val value: String,
+) : Serializable {
+    companion object {
+        fun random(): FencingOwnerId
+        fun from(value: String): FencingOwnerId
+    }
+
+    override fun toString(): String = "FencingOwnerId(<redacted>)"
+}
+```
+
+- `value`는 blank일 수 없고 UTF-8 기준 1..256 byte여야 한다.
+- `random()`은 새 encoder를 만들지 않고 기존 `Base58.randomString(22)`를 사용한다.
+  이 helper는 `SecureRandom.getInstanceStrong()`과 58-symbol alphabet을 사용하며 22자는
+  약 129-bit의 선택 공간을 제공한다.
+- `from(value)`는 외부 attempt ID 연동용이다. caller가 전역 collision/guessing 방지와
+  안전한 저장을 책임진다.
+- caller는 logical acquisition attempt마다 새 owner ID를 만들고, ambiguous response를
+  복구할 때만 같은 값을 재사용한다.
+- owner ID를 아는 caller는 active token을 조회하고 같은-owner recovery를 수행할 수
+  있으므로 신뢰되지 않은 입력으로 사용하면 안 된다. Redis authentication이나 application
+  authorization을 대신하지 않는다.
+- owner ID는 orderable token이 아니며 downstream fence로 저장하면 안 된다.
+- public result에는 owner ID를 넣지 않는다.
+- equality와 hash code는 raw value만 사용하고 `toString()`은 항상 redacted한다.
+- `FencingOwnerId`도 `serialVersionUID: Long = 1L`과 constructor 재검증
+  `readResolve()`를 정의한다.
+
+## 6. Fencing token
+
+```kotlin
+data class FencingToken(
+    val epoch: Long,
+    val sequence: Long,
+) : Comparable<FencingToken>, Serializable {
+    override fun compareTo(other: FencingToken): Int {
+        val epochComparison = epoch.compareTo(other.epoch)
+        return if (epochComparison != 0) epochComparison else sequence.compareTo(other.sequence)
+    }
+
+    override fun toString(): String = "FencingToken(<redacted>)"
+}
+```
+
+- `epoch >= 1`, `sequence >= 1`을 생성 시 검증한다.
+- natural ordering은 `(epoch, sequence)`의 lexicographic ordering이다.
+- `equals`, `hashCode`, `compareTo`가 같은 두 property만 사용한다.
+- library 내부와 기본 operational log가 token 숫자를 우발적으로 기록하지 않도록
+  `toString()`을 redacted한다. downstream이 명시적으로 property를 저장·비교하는 것은
+  이 제한과 별개다.
+- `serialVersionUID: Long = 1L`과 constructor 재검증 `readResolve()`를 정의한다.
+- counter는 0으로 bootstrap되고 첫 acquire가 sequence 1을 발급한다.
+- sequence가 `Long.MAX_VALUE`이면 새 generation을 만들지 않고
+  `SequenceExhausted`를 반환한다. wraparound는 허용하지 않는다. `epoch < Long.MAX_VALUE`
+  일 때만 더 높은 epoch로 rollover할 수 있다. 최대 epoch가 소진되면 현재 ordering
+  domain은 terminal 상태이며 external schema를 포함한 별도 domain migration이 필요하다.
+
+예를 들어 epoch 7의 마지막 token보다 epoch 8의 첫 token이 항상 크다.
+
+```text
+(7, 9223372036854775807) < (8, 1)
+```
+
+## 7. Redis key와 저장 상태
+
+config로부터 두 key를 내부에서만 생성한다.
+
+```text
+fence:{namespace:resourceName}:<epoch>:lease
+fence:{namespace:resourceName}:<epoch>:counter
+```
+
+실제 `epoch` 숫자가 `epoch` 자리에 들어간다. 예:
+
+```text
+fence:{orders:rebuild}:7:lease
+fence:{orders:rebuild}:7:counter
+```
+
+- 두 key는 같은 `{namespace:resourceName}` hash tag를 사용하므로 같은 Cluster slot에
+  배치된다.
+- 모든 epoch가 같은 resource slot을 공유하지만 keyspace는 epoch별로 분리된다.
+- 같은 resource의 서로 다른 epoch lease는 Redis key 수준에서는 동시에 존재할 수 있다.
+  epoch rollover는 old epoch acquire 중지와 새 config 배포를 포함한 control-plane cutover다.
+  동시 활성화가 발생해도 downstream tuple 비교는 낮은 epoch의 stale write를 거절하지만,
+  Redis mutual exclusion 자체가 epoch 사이에 유지된다고 주장하지 않는다.
+- key는 public API 입력으로 받지 않는다. 따라서 cross-slot validation은 생성된 두
+  key의 실제 wire byte slot이 같은지 constructor에서 확인하는 invariant check다.
+- connection의 `RedisCodec<String, String>`을 private constructor까지 보존하고
+  `SlotHash.getSlot(codec.encodeKey(key))`로 두 key를 검증한다. Kotlin `String` 자체나
+  기본 charset으로 slot을 추정하지 않는다.
+- 이 keyspace는 fencing lease 전용이다. 다른 command나 application이 직접 수정하면
+  integrity가 깨진 것으로 취급한다.
+
+counter key:
+
+- Redis type은 string이어야 하고 canonical non-negative decimal string을 저장한다.
+- `STRLEN <= 19`를 `GET`보다 먼저 확인한다.
+- TTL을 두지 않는다.
+- `PTTL == -1`만 정상이다. `-2`는 missing, 0 이상은 expiring counter integrity
+  failure다.
+- 정상 operation에서 감소하거나 삭제하지 않는다.
+
+lease key:
+
+- Redis type은 hash여야 하며 `owner`, `epoch`, `sequence` field를 저장한다.
+- `HLEN == 3`과 fixed-field `HMGET`만 사용한다. `HGETALL`, `KEYS`, `SCAN`, stored
+  cardinality loop를 사용하지 않는다.
+- `HSTRLEN`으로 owner 256 byte, epoch/sequence 19 byte 상한을 materialization 전에
+  검증한다.
+- lease TTL만 millisecond 단위로 둔다.
+- `epoch`와 `sequence`는 canonical decimal string으로 저장한다.
+- field 누락, 예상하지 않은 field, 잘못된 숫자, config와 다른 epoch, lease sequence보다
+  작은 counter는 integrity failure다.
+- lease `PTTL == -2`는 absent/expired로 다시 분류하고, `-1`은 TTL 없는 malformed
+  lease다. `PTTL >= 0`만 active이며 public TTL은 negative가 될 수 없다.
+- 모든 script와 reply는 fixed command count와 fixed field count를 유지한다. steady-state
+  operation은 한 번의 EVALSHA network round trip이고 `NOSCRIPT` fallback만 EVAL dispatch를
+  한 번 더 추가한다.
+
+한 logical resource의 command는 한 Redis slot/event loop에서 직렬화된다. caller 수를
+늘려도 하나의 hot resource가 수평 확장되지는 않는다. 독립 resource는 서로 다른
+ordering domain을 사용해 Cluster slot에 분산할 수 있다.
+
+## 8. Bootstrap과 recovery
+
+### 8.1 `bootstrap()`
+
+`bootstrap()`은 새 `(namespace, resourceName, epoch)` counter를 0으로 초기화하는
+명시적 operation이다.
+
+1. lease key가 있으면 구조를 검증한다.
+2. lease가 있는데 counter가 없으면 초기화하지 않고 integrity failure를 반환한다.
+3. counter가 있으면 canonical decimal과 범위를 검증하고 `AlreadyInitialized`를 반환한다.
+4. lease가 없고 counter도 없을 때만 `SET counter 0 NX`와 동등한 원자적 초기화를 한다.
+5. concurrent bootstrap 중 다른 caller가 먼저 초기화하면 다시 검증하고
+   `AlreadyInitialized`를 반환한다.
+
+`bootstrap()`의 존재는 same-epoch recovery가 안전하다는 뜻이 아니다. 최초 배포나 아직
+사용되지 않은 더 높은 epoch의 초기화에만 사용한다.
+
+### 8.2 History loss recovery
+
+counter missing, rollback, restore가 의심되면 다음 절차를 따른다.
+
+1. external incident detector가 replica promotion, acknowledged-write loss, snapshot restore,
+   disaster restore, counter missing/reset 같은 신호를 감지하면 해당 ordering domain의 acquire와
+   downstream write를 즉시 중지한다. Redis primitive가 이 사건을 완전히 탐지한다고 주장하지
+   않는다.
+2. downstream에 저장된 마지막 `(epoch, sequence)`와 Redis recovery 사건을 확인한다.
+3. 기존 epoch에 `bootstrap()`하지 않는다. `CounterUnavailable` 결과만으로 bootstrap을
+   허가하지 않는다.
+4. old epoch acquire가 실제로 차단됐고 active lease가 없어졌음을 read-only inspection과
+   downstream writer drain으로 확인한다. mixed-epoch writer가 발견되면 cutover를 중단한다.
+5. drain이 확인된 뒤 durable epoch authority에서 single-writer transaction 또는
+   compare-and-set으로 현재보다 큰 epoch를 정확히 한 번 할당한다. application instance의
+   local config나 Redis counter를 epoch authority로 사용하지 않는다.
+6. 새 config로 instance를 만들고 새 epoch를 `bootstrap()`한 뒤 counter type, non-expiring
+   TTL, readiness와 downstream tuple guard를 검증한다.
+7. 새 writer를 점진 배포하고 old epoch write 부재를 확인한 뒤 acquire와 downstream write를
+   재개한다.
+
+Redis만 보고 기존 counter가 과거보다 작아졌는지는 완전히 감지할 수 없다. lease와
+counter가 함께 일관된 과거 snapshot으로 돌아가면 구조는 정상처럼 보일 수 있다.
+최종 stale rejection은 downstream이 마지막 accepted token을 durable하게 저장하고 더
+작거나 같은 token을 거절해야 성립한다.
+
+### 8.3 Epoch cutover와 rollback
+
+정상 rollover도 8.2와 같은 durable single-writer/CAS epoch authority를 사용한다. 두 배포가
+서로 다른 higher epoch를 동시에 활성화하면 mutual exclusion이 깨질 수 있으므로
+`stop old acquire -> drain active lease/writer -> allocate higher epoch -> bootstrap -> readiness
+verify -> roll out -> confirm old absence -> resume` 순서를 runbook invariant로 둔다.
+
+cutover 뒤 application binary를 rollback하더라도 epoch를 낮추지 않는다. rollback binary가
+현재 higher epoch config와 tuple guard를 지원하면 그 epoch를 유지하고, 지원하지 않으면
+traffic을 중지한 채 호환 binary로 roll-forward하거나 다시 더 높은 epoch로 새 cutover를
+수행한다. lower epoch 재활성화와 같은-epoch counter 재초기화는 금지한다. deterministic
+rollback simulation은 old writer 차단, mixed-epoch 탐지, higher-epoch 유지, stale write
+거절을 검증한다. Redis topology promotion 자체는 환경 의존적이므로 별도 opt-in tagged
+integration test로 두고 기본 CI에서는 runbook/fault-injection simulation으로 대체한다.
+
+## 9. Public API
+
+### 9.1 Sync와 `CompletableFuture`
+
+```kotlin
+class LettuceFencingLease private constructor(
+    syncCommands: RedisScriptingCommands<String, String>,
+    asyncCommands: RedisScriptingAsyncCommands<String, String>,
+    codec: RedisCodec<String, String>,
+    config: LettuceFencingLeaseConfig,
+) {
+    constructor(
+        connection: StatefulRedisConnection<String, String>,
+        config: LettuceFencingLeaseConfig,
+    ) : this(connection.sync(), connection.async(), connection.codec, config)
+
+    constructor(
+        connection: StatefulRedisClusterConnection<String, String>,
+        config: LettuceFencingLeaseConfig,
+    ) : this(connection.sync(), connection.async(), connection.codec, config)
+
+    fun bootstrap(): FencingBootstrapResult
+    fun bootstrapAsync(): CompletableFuture<FencingBootstrapResult>
+
+    fun acquire(
+        ownerId: FencingOwnerId,
+        leaseTime: Duration,
+    ): FencingAcquireResult
+
+    fun acquireAsync(
+        ownerId: FencingOwnerId,
+        leaseTime: Duration,
+    ): CompletableFuture<FencingAcquireResult>
+
+    fun inspect(ownerId: FencingOwnerId): FencingInspectResult
+    fun inspectAsync(ownerId: FencingOwnerId): CompletableFuture<FencingInspectResult>
+
+    fun renew(
+        ownerId: FencingOwnerId,
+        token: FencingToken,
+        leaseTime: Duration,
+    ): FencingRenewResult
+
+    fun renewAsync(
+        ownerId: FencingOwnerId,
+        token: FencingToken,
+        leaseTime: Duration,
+    ): CompletableFuture<FencingRenewResult>
+
+    fun release(
+        ownerId: FencingOwnerId,
+        token: FencingToken,
+    ): FencingReleaseResult
+
+    fun releaseAsync(
+        ownerId: FencingOwnerId,
+        token: FencingToken,
+    ): CompletableFuture<FencingReleaseResult>
+}
+```
+
+### 9.2 Suspend
+
+```kotlin
+class LettuceSuspendFencingLease private constructor(
+    asyncCommands: RedisScriptingAsyncCommands<String, String>,
+    codec: RedisCodec<String, String>,
+    config: LettuceFencingLeaseConfig,
+) {
+    constructor(
+        connection: StatefulRedisConnection<String, String>,
+        config: LettuceFencingLeaseConfig,
+    ) : this(connection.async(), connection.codec, config)
+
+    constructor(
+        connection: StatefulRedisClusterConnection<String, String>,
+        config: LettuceFencingLeaseConfig,
+    ) : this(connection.async(), connection.codec, config)
+
+    suspend fun bootstrap(): FencingBootstrapResult
+    suspend fun acquire(ownerId: FencingOwnerId, leaseTime: Duration): FencingAcquireResult
+    suspend fun inspect(ownerId: FencingOwnerId): FencingInspectResult
+    suspend fun renew(
+        ownerId: FencingOwnerId,
+        token: FencingToken,
+        leaseTime: Duration,
+    ): FencingRenewResult
+    suspend fun release(ownerId: FencingOwnerId, token: FencingToken): FencingReleaseResult
+}
+```
+
+두 execution class는 Redis connection을 보유하므로 `Serializable`을 구현하지 않는다.
+모든 operation은 caller가 준 argument를 dispatch 전에 검증한다. 특히 TTL은 positive
+millisecond로 정확히 변환 가능해야 하며 0, negative, sub-millisecond, overflow
+duration을 거절한다. `Duration.toMillis()`의 `ArithmeticException`을 포함한 변환 실패는
+raw exception을 노출하지 않고 `IllegalArgumentException`으로 정규화한다.
+`renew`와 `release`는 `token.epoch == config.epoch`를 dispatch 전에 검증하며 다른 epoch는
+`IllegalArgumentException`이다. 같은 tuple을 가진 다른 resource의 token은 token 자체에
+domain identity가 없어 검출할 수 없으므로, caller가 resource-bound handle/storage로
+혼용을 막아야 하며 이 한계를 KDoc에 명시한다.
+
+## 10. Result model
+
+### 10.1 공통 failure value
+
+```kotlin
+enum class FencingBackendFailureKind {
+    CONNECTION,
+    TIMEOUT,
+    COMMAND,
+}
+
+data class FencingLeaseBackendFailure(
+    val kind: FencingBackendFailureKind,
+) : Serializable
+
+enum class FencingIntegrityFailureKind {
+    MALFORMED_LEASE,
+    INVALID_COUNTER,
+    COUNTER_BEHIND_LEASE,
+}
+
+data class FencingLeaseIntegrityFailure(
+    val kind: FencingIntegrityFailureKind,
+) : Serializable
+```
+
+- public failure value는 message, Redis key, owner ID, fencing token, raw reply,
+  `Throwable`을 포함하지 않는다.
+- actual `Throwable`, message, cause, Redis command text는 log에 전달하지 않는다. allowlist된
+  exception class name, operation, failure kind만 structured field로 남기고
+  key/owner/token/raw argument는 기록하지 않는다.
+- decoder invariant 또는 programmer bug는 `BackendFailure`로 평탄화하지 않는다.
+- `CancellationException`은 broad catch보다 먼저 다시 던진다.
+- sync/future/suspend는 하나의 internal backend classifier를 공유한다. classifier는
+  `CompletionException`과 `ExecutionException`의 cause chain만 순환 방지와 bounded depth로
+  정규화하고, chain 어디에 있든 `CancellationException`은 다시 던진다. internal decoder
+  exception과 validation exception도 분류 대상에서 제외한다. 정규화한 원인이
+  `RedisConnectionException`이면 `CONNECTION`, `RedisCommandTimeoutException` 또는 command
+  timeout `TimeoutException`이면 `TIMEOUT`, 그 밖의 Lettuce `RedisException`이면 fallback
+  `COMMAND`다. 알려지지 않은 non-Lettuce exception은 programmer/internal failure로 다시
+  던지며 raw message나 cause를 public result에 넣지 않는다.
+- enum을 포함한 public failure type과 모든 nested result는 Java serialization round-trip
+  test를 가진다. enum은 Java가 본래 제공하는 serialization을 사용하고, 나머지 sealed
+  result/data variant는 `serialVersionUID = 1L`을 명시한다. constructor invariant가 있는
+  config/value/result data class는 private
+  `readResolve()`에서 canonical constructor를 다시 호출하고 invalid serialized payload를
+  `InvalidObjectException`으로 거절한다.
+
+### 10.2 Bootstrap
+
+```kotlin
+sealed interface FencingBootstrapResult : Serializable {
+    data object Initialized : FencingBootstrapResult
+    data object AlreadyInitialized : FencingBootstrapResult
+    data class IntegrityFailure(
+        val failure: FencingLeaseIntegrityFailure,
+    ) : FencingBootstrapResult
+    data class BackendFailure(
+        val failure: FencingLeaseBackendFailure,
+    ) : FencingBootstrapResult
+}
+```
+
+### 10.3 Acquire
+
+```kotlin
+sealed interface FencingAcquireResult : Serializable {
+    data class Acquired(val token: FencingToken) : FencingAcquireResult
+    data class AlreadyOwned(
+        val token: FencingToken,
+        val remainingTtlMillis: Long,
+    ) : FencingAcquireResult
+    data class Contended(val remainingTtlMillis: Long) : FencingAcquireResult
+    data object CounterUnavailable : FencingAcquireResult
+    data object SequenceExhausted : FencingAcquireResult
+    data class IntegrityFailure(
+        val failure: FencingLeaseIntegrityFailure,
+    ) : FencingAcquireResult
+    data class BackendFailure(
+        val failure: FencingLeaseBackendFailure,
+    ) : FencingAcquireResult
+}
+```
+
+### 10.4 Inspect
+
+```kotlin
+sealed interface FencingInspectResult : Serializable {
+    data class Owned(
+        val token: FencingToken,
+        val remainingTtlMillis: Long,
+    ) : FencingInspectResult
+    data object Lost : FencingInspectResult
+    data class Contended(val remainingTtlMillis: Long) : FencingInspectResult
+    data class IntegrityFailure(
+        val failure: FencingLeaseIntegrityFailure,
+    ) : FencingInspectResult
+    data class BackendFailure(
+        val failure: FencingLeaseBackendFailure,
+    ) : FencingInspectResult
+}
+```
+
+### 10.5 Renew와 release
+
+```kotlin
+sealed interface FencingRenewResult : Serializable {
+    data object Renewed : FencingRenewResult
+    data object Lost : FencingRenewResult
+    data object OwnershipMismatch : FencingRenewResult
+    data class IntegrityFailure(
+        val failure: FencingLeaseIntegrityFailure,
+    ) : FencingRenewResult
+    data class BackendFailure(
+        val failure: FencingLeaseBackendFailure,
+    ) : FencingRenewResult
+}
+
+sealed interface FencingReleaseResult : Serializable {
+    data object Released : FencingReleaseResult
+    data object Lost : FencingReleaseResult
+    data object OwnershipMismatch : FencingReleaseResult
+    data class IntegrityFailure(
+        val failure: FencingLeaseIntegrityFailure,
+    ) : FencingReleaseResult
+    data class BackendFailure(
+        val failure: FencingLeaseBackendFailure,
+    ) : FencingReleaseResult
+}
+```
+
+각 sealed interface, nested data class, `data object`에
+`serialVersionUID: Long = 1L`을 명시한다. nested value까지 빠짐없이 적용하고
+reflection/round-trip test로 누락을 막는다. TTL을 담는 result는
+`remainingTtlMillis >= 0`을 constructor와 `readResolve()`에서 검증한다.
+serialized `data object`는 각각 private `readResolve()`가 canonical singleton instance를
+반환하게 해 Java deserialization 뒤 reference identity까지 보존한다.
+
+### 10.6 Caller action 결정표
+
+| 결과 | caller action |
+|---|---|
+| `Initialized`, `AlreadyInitialized` | readiness를 확인하고 승인된 epoch rollout을 계속한다. |
+| `Acquired`, `AlreadyOwned`, `Owned`, `Renewed` | ownership이 유효한 정상 경로를 계속한다. token은 resource identity와 함께 저장한다. |
+| `Released` | local ownership을 즉시 폐기하고 downstream write를 금지한다. |
+| acquire `Contended` | TTL 이후 새 owner attempt를 시작하거나 bounded backoff한다. 같은 호출을 backend retry로 취급하지 않는다. |
+| inspect `Contended` | 다른 owner가 active하므로 local ownership을 즉시 폐기하고 downstream write를 금지한다. |
+| `Lost`, `OwnershipMismatch` | local ownership을 폐기하고 downstream write를 금지한다. |
+| `CounterUnavailable` | acquire를 중지하고 최초 배포인지 history-loss incident인지 운영 절차로 판별한다. 이 결과만으로 bootstrap하지 않는다. |
+| `SequenceExhausted` | retry하지 않고 acquire를 중지하며 higher-epoch cutover를 alert한다. epoch도 최대면 ordering domain/schema migration 전까지 domain을 freeze한다. |
+| `IntegrityFailure` | retry와 mutation을 중지하고 read-only 진단 및 runbook을 수행한다. |
+| `BackendFailure` | ambiguous completion으로 보고 operation별 reconcile을 수행한다. 정책상 retry할 때만 같은 owner/token을 사용한다. |
+
+token tuple만으로 ordering domain을 식별할 수 없으므로 downstream record와 in-memory handle은
+항상 stable resource/domain identity와 `(epoch, sequence)`를 함께 보관한다.
+
+## 11. Lua operation semantics
+
+모든 script는 반환 field 수와 decimal string을 고정한 internal wire protocol을 사용한다.
+Kotlin decoder는 예상하지 않은 status, field 수 또는 정상 status에 딸린 malformed
+TTL/token/numeric payload를 stable internal protocol exception으로 처리하며 raw reply를
+exception message나 log에 넣지 않는다. Redis key에서 script가 직접 관찰한 malformed
+state만 public `IntegrityFailure`로 분류한다.
+
+lease가 존재하는 모든 operation은 lease field뿐 아니라 counter가 존재하고 canonical하며
+`counter >= lease.sequence`인지 mutation 전에 확인한다. active lease에서 counter가
+없거나 뒤처졌다면 inspect를 포함해 integrity failure로 fail closed한다. 64-bit 값을
+Lua `tonumber`로 변환해 비교하지 않고 decimal string의 길이와 lexicographic ordering을
+사용한다.
+
+Redis scripting의 atomicity는 다른 command와 interleave되지 않는다는 뜻이며 runtime
+error 이전 write를 rollback한다는 뜻이 아니다. 모든 type, field count, value length,
+decimal, TTL, argument를 첫 write 전에 O(1) command로 preflight한다. acquire mutation은
+`INCR -> HSET -> PEXPIRE` 순서다.
+
+- `INCR` 뒤 lease write 전에 중단되면 sequence gap은 허용한다. token은 증가만 하므로
+  safety를 약화하지 않는다.
+- `HSET` 뒤 `PEXPIRE` 전에 예상하지 못한 runtime failure가 나면 TTL 없는 partial lease가
+  남을 수 있다. 다음 operation은 `PTTL == -1`을 `MALFORMED_LEASE`로 fail closed한다.
+- operator는 incident 확인 뒤 partial lease만 제거할 수 있지만 counter를 감소·삭제하거나
+  같은 epoch를 bootstrap하면 안 된다.
+- script는 expected validation/error branch에서 write를 시작하지 않으며 모든 정상 reply는
+  fixed-size다.
+
+### 11.1 Integrity/result 결정표
+
+| Redis/wire 상태 | Public/internal 분류 |
+|---|---|
+| lease wrong type, `HLEN != 3`, field 누락/초과, oversized owner/epoch/sequence, invalid lease decimal, config와 다른 epoch, lease `PTTL == -1` | `MALFORMED_LEASE` |
+| active lease의 counter missing/wrong type/oversized/invalid/expiring | `INVALID_COUNTER` |
+| lease 없음 + counter missing | acquire `CounterUnavailable`; inspect/renew/release는 각 operation의 `Lost` |
+| valid counter < valid lease sequence | `COUNTER_BEHIND_LEASE` |
+| lease `PTTL == -2` | absent/expired branch로 재분류 |
+| lease `PTTL >= 0` | active; non-negative TTL만 public result에 포함 |
+| unknown script status, 정상 status의 잘못된 reply field count 또는 malformed TTL/token/numeric payload | stable internal protocol exception; `BackendFailure`나 `IntegrityFailure`로 평탄화하지 않음 |
+
+### 11.2 Acquire
+
+1. lease가 있으면 `owner`, `epoch`, `sequence`, TTL과 counter integrity를 검증한다.
+2. 같은 owner면 sequence를 증가시키지 않고 `AlreadyOwned(existingToken, pttl)`을
+   반환한다.
+3. 다른 owner면 mutation 없이 `Contended(pttl)`을 반환한다.
+4. lease가 없으면 counter 존재와 canonical decimal을 검증한다.
+5. counter가 없으면 `CounterUnavailable`, 값이 `Long.MAX_VALUE`면
+   `SequenceExhausted`를 반환한다.
+6. string length와 lexicographic 비교로 counter 범위를 검사한 뒤 `INCR`한다.
+7. 증가된 값을 다시 `GET`해 exact decimal string으로 받고 lease hash와 TTL을 설정한다.
+8. `Acquired(FencingToken(config.epoch, newSequence))`을 반환한다.
+
+lease 생성과 counter 증가는 한 script 안에서 처리한다. script가 정상 status를 반환하기
+전후로 connection이 끊기면 caller는 적용 여부를 확정할 수 없다.
+
+### 11.3 Inspect
+
+- lease가 없으면 `Lost`다.
+- owner가 같으면 stored token과 TTL을 검증해 `Owned`를 반환한다.
+- owner가 다르면 token이나 owner를 노출하지 않고 `Contended`를 반환한다.
+- inspect는 TTL을 연장하거나 state를 수정하지 않는다.
+
+### 11.4 Renew
+
+- lease가 없으면 `Lost`다.
+- stored owner 또는 `(epoch, sequence)`가 argument와 다르면
+  `OwnershipMismatch`다.
+- 둘 다 같을 때만 TTL을 갱신하고 `Renewed`를 반환한다.
+- renew는 counter를 변경하거나 새 token을 만들지 않는다.
+
+### 11.5 Release
+
+- lease가 없으면 `Lost`다.
+- stored owner 또는 token이 다르면 `OwnershipMismatch`다.
+- 둘 다 같을 때만 lease key를 삭제하고 `Released`를 반환한다.
+- counter는 삭제하거나 감소시키지 않는다.
+
+## 12. Failure, retry, cancellation
+
+### 12.1 Ambiguous completion
+
+command dispatch 뒤 timeout, connection loss, future cancellation, coroutine cancellation은
+Redis mutation이 적용됐는지 확정하지 못하는 ambiguous completion이다.
+
+- acquire: 같은 owner ID로 다시 acquire한다. active ownership이면
+  `AlreadyOwned`와 같은 token을 받는다.
+- bootstrap: 최초 배포 또는 아직 사용되지 않은 higher epoch라는 전제가 유지될 때 같은
+  config로 다시 호출한다. 첫 command가 적용됐다면 `AlreadyInitialized`, 아니면
+  `Initialized`다. history loss가 의심되는 old epoch에는 이 규칙을 적용하지 않는다.
+- renew: `inspect(ownerId)`로 현재 ownership과 token을 확인한다. 같은 token이면 새 TTL로
+  renew를 다시 시도할 수 있다.
+- release: `Lost`는 이전 release 성공과 자연 만료를 구분하지 않는다. 두 경우 모두
+  caller가 더는 ownership을 갖지 않는다는 사실만 사용한다.
+- backend failure result를 받았다고 local 성공/실패를 단정하지 않는다.
+
+implementation은 public API를 늘리지 않는 internal script-executor seam으로 mutating
+command의 다음 두 지점을 결정적으로 fault-inject한다.
+
+- server apply 전 failure/cancellation;
+- apply 완료 뒤 reply decode 전 failure/cancellation.
+
+bootstrap, acquire, renew, release 각각에 대해 network timing이나 sleep에 기대지 않고 위
+두 지점과 operation-specific reconciliation 결과를 검증한다.
+
+### 12.2 `CompletableFuture` cancellation
+
+- returned future의 `cancel(...)`은 future를 cancelled 상태로 끝내며
+  `FencingLeaseBackendFailure`로 변환하지 않는다.
+- cancellation은 underlying Lettuce future에 best-effort로 전파하지만, 이미 dispatch된
+  Redis command의 중단이나 rollback을 보장하지 않는다.
+- 기존 `RedisScriptRunner.runAsync()`의 chained future를 그대로 반환하지 않는다. internal
+  wrapper가 현재 upstream Lettuce future를 보존하고 returned future의 cancellation을
+  EVALSHA에 전달하며, `NOSCRIPT` 뒤 EVAL로 교체된 경우에는 새 upstream future로 전달
+  대상을 원자적으로 바꾼다. fallback 전/후 cancellation race를 contract test로 고정한다.
+- caller는 acquire에는 같은 owner ID, renew/release에는 inspect와 같은 token을 사용해
+  server state를 reconcile한다.
+- controllable internal executor로 server apply 전 cancel과 apply 후 reply 전 cancel을
+  각각 검증한다.
+
+### 12.3 외부 resilience decorator
+
+primitive 내부에는 retry를 넣지 않는다. caller는 같은 owner ID와 token을 캡처한
+operation을 `bluetape4k-resilience4j`의 `Retry`, `CircuitBreaker`, `Bulkhead` decorator로
+감쌀 수 있다. 문서 예제와 실제 Redis integration test에서 조합 가능성을 보여주되,
+다음 원칙을 지킨다.
+
+- validation failure와 `IntegrityFailure`, `CounterUnavailable`,
+  `SequenceExhausted`, `OwnershipMismatch`는 retry하지 않는다.
+- operation이 exception 대신 classified result를 반환하므로 `Retry`와
+  `CircuitBreaker`는 `BackendFailure`만 실패로 보는 result predicate를 명시적으로
+  구성한다.
+- 권장 `SuspendDecorators` chain은
+  `.withRetry(retry).withCircuitBreaker(circuitBreaker).withBulkhead(bulkhead)`다. 이 builder는
+  호출 순서대로 기존 supplier를 감싸므로 마지막 `Bulkhead`가 최외곽, 그 안이
+  `CircuitBreaker`, 가장 안쪽이 `Retry`와 supplier다. 한 bulkhead permit이 전체 retry
+  attempt를 감싸고 circuit breaker는 retry가 끝난 최종 result를 관찰한다.
+- `Retry`와 `CircuitBreaker`의 result predicate는 `BackendFailure`만 failure로 센다.
+  `CallNotPermittedException`과 `BulkheadFullException`은 primitive의 sealed result로
+  변환하지 않는 caller-layer exception이다. `CancellationException`도 decorator를
+  통과해 그대로 전파한다.
+- acquire retry는 반드시 같은 owner ID를 사용한다.
+- cancellation은 retry 대상이 아니다.
+- decorator가 ambiguous completion을 exactly-once로 바꾸지는 않는다.
+
+### 12.4 Exception/result boundary
+
+- dispatch 전 argument/config validation은 existing Bluetape validation helper로
+  `IllegalArgumentException`을 던진다.
+- `Duration.toMillis()` overflow의 `ArithmeticException`도 dispatch 전에
+  `IllegalArgumentException`으로 정규화한다.
+- Redis connection, timeout, command failure는 classified result로 반환한다.
+- async method의 dispatch 전 validation failure는 method 호출 시 동기적으로 throw한다.
+- suspend method는 `CancellationException`을 result로 바꾸지 않고 그대로 전파한다.
+- public result를 만들 수 없는 decoder invariant는 stable internal exception으로 fail
+  fast한다.
+- sync/future/suspend는 10.1의 같은 cause normalizer와 classifier를 사용하므로 wrapper
+  형태가 달라도 같은 backend failure kind를 반환한다.
+
+## 13. 주요 failure mode
+
+| Failure mode | 탐지 | 결과/복구 |
+|---|---|---|
+| 최초 bootstrap 누락 | lease 없음 + counter 없음 | acquire `CounterUnavailable`; 승인된 새 epoch만 bootstrap |
+| active lease 중 counter 삭제 | lease 존재 + counter 없음 | integrity failure; old epoch 자동 복구 금지 |
+| counter가 lease sequence보다 작음 | 두 decimal string 비교 | `COUNTER_BEHIND_LEASE`; acquire/renew/release mutation 금지 |
+| counter `Long.MAX_VALUE` | exact string 비교 | `SequenceExhausted`; epoch 여유가 있을 때만 더 높은 epoch로 rollover |
+| epoch와 sequence 모두 `Long.MAX_VALUE` | config/counter exact 비교 | ordering domain terminal; external schema/domain migration |
+| lease hash 손상/oversized field | O(1) type/HLEN/HSTRLEN/fixed HMGET 검증 | `MALFORMED_LEASE`; fail closed |
+| counter에 TTL 존재 | `PTTL >= 0` | `INVALID_COUNTER`; mutation 금지 |
+| lease에 TTL 없음 | `PTTL == -1` | `MALFORMED_LEASE`; incident 확인 뒤 lease만 제거 가능 |
+| `INCR` 뒤 script runtime failure | counter 증가, lease 없거나 partial | gap 허용; TTL 없는 partial lease는 다음 operation에서 fail closed |
+| `SCRIPT FLUSH` | EVALSHA가 `NOSCRIPT` 반환 | `RedisScriptRunner`가 EVAL fallback 후 같은 contract 유지 |
+| command 적용 뒤 response loss | client/backend failure | same-owner acquire 또는 inspect 기반 reconciliation |
+| coroutine cancellation | `CancellationException` | 즉시 전파; same-owner reconciliation 가능 |
+| future cancellation | cancelled future | backend result로 변환하지 않음; dispatch 중단은 보장하지 않음 |
+| replica promotion/write loss | Redis만으로 완전 탐지 불가 | 중지, durable epoch 증가, downstream tuple 비교 |
+| snapshot rollback | 구조가 정상처럼 보일 수 있음 | downstream이 이전 accepted token을 거절; 더 높은 epoch로 복구 |
+| stale holder renew/release | owner+token mismatch | `OwnershipMismatch`; newer lease 불변 |
+
+### 13.1 Observability와 repair runbook
+
+library structured log는 raw key, namespace, resource, owner, token, reply, exception message를
+기록하지 않는다. correlation이 필요할 때만 canonical
+`namespace + "\u0000" + resourceName + "\u0000" + epoch`의 SHA-256 앞 12 byte를 24자리
+lowercase hex `domainFingerprint`로 계산한다. 이 fingerprint는 bounded stable log correlation
+field일 뿐 metric label로 사용하지 않는다.
+
+새 Micrometer dependency를 추가하지 않는다. caller가 classified result를 관찰해 operation,
+result variant, backend/integrity failure kind처럼 bounded low-cardinality dimension만 기존
+metrics에 기록한다. namespace, resource, owner, token, fingerprint는 metric label에서
+금지한다. alert와 runbook mapping은 다음과 같다.
+
+| signal | alert/action |
+|---|---|
+| `CounterUnavailable`, `INVALID_COUNTER`, `COUNTER_BEHIND_LEASE` | domain traffic pause, read-only diagnosis, history-loss 여부 판정; 자동 bootstrap 금지 |
+| `MALFORMED_LEASE` | mutation pause, fixed key inspection, lease-only repair 조건 검토 |
+| `SequenceExhausted` | non-retry alert, higher-epoch cutover; max epoch면 domain freeze와 schema/domain migration |
+| backend failure rate 또는 circuit open | operation별 reconcile, dependency incident runbook; lower epoch 전환 금지 |
+| external promotion/restore/rollback signal | 즉시 pause, durable epoch CAS bump, 8.2/8.3 절차 후 resume |
+
+operator diagnosis는 파생된 정확한 두 key만 받는 bounded read-only diagnostic Lua를
+`EVAL_RO`로 실행한다. script 내부는 `TYPE`, `PTTL`, `STRLEN`, `HLEN`, fixed-field
+`HSTRLEN`, `GET`, fixed-field `HMGET`만 O(1)로 사용해 canonical decimal, counter TTL,
+lease structure, `counter >= lease.sequence`를 판정하고, raw key/owner/token/value 대신 stable
+classification code와 boolean만 반환한다. recorded classification output이 repair evidence다.
+`HGETALL`, `KEYS`, `SCAN`, raw owner/token 출력은 사용하지 않는다.
+TTL 없는 partial lease는 다음 조건을 모두 만족할 때만 lease key 하나를 수동 삭제할 수 있다.
+
+1. ordering domain의 acquire와 downstream writer가 중지됐다.
+2. downstream tuple guard와 마지막 accepted token이 확인됐다.
+3. 보안 경계를 지킨 incident evidence와 정확한 진단 `lease PTTL == -1`이 기록됐다.
+4. diagnostic script의 기록된 결과가 counter를 valid canonical non-expiring string,
+   `counter >= lease.sequence`, lease `PTTL == -1`로 판정한다.
+
+counter는 어떤 repair에서도 삭제, 감소, TTL 설정, 같은 epoch bootstrap 대상이 아니다.
+
+## 14. Test 전략
+
+### 14.1 Unit test
+
+- `FencingToken`의 epoch 우선/sequence 차순/동일 token ordering과 equality.
+- config, owner ID, TTL, token 경계 validation.
+- `Base58.randomString(22)` 기반 owner ID factory 형식과 최소 128-bit 선택 공간, custom owner ID 재사용 시 같은-owner
+  capability가 공유됨을 보여주는 misuse fixture.
+- connection codec의 `encodeKey` 결과를 사용한 key derivation과 `SlotHash.getSlot` same-slot
+  invariant. non-default codec fixture로 String 기반 추정이 아님을 고정한다.
+- decimal string validator: leading zero, sign, whitespace, non-digit, 범위 초과,
+  `Long.MAX_VALUE`.
+- wire decoder의 unknown status, field count, malformed TTL/token과 public/internal 분류표.
+- wrapped/unwrapped Lettuce connection, timeout, command exception이 sync/future/suspend에서 같은
+  backend kind가 되고 cancellation/decoder/non-Lettuce exception은 분류되지 않는 test.
+- sub-millisecond와 `Duration.toMillis()` overflow가 세 API 모두 dispatch 전에
+  `IllegalArgumentException`이 되는 parity test.
+- 다른 epoch token의 renew/release가 dispatch 전에 거절되고, 같은 tuple의 다른 resource
+  token은 primitive가 식별할 수 없어 resource-bound caller handle이 필요한 misuse test.
+- 모든 public config/value/failure/result variant의 Java serialization round-trip과
+  non-enum serializable type의 `serialVersionUID` 존재 검증.
+- 모든 serialized `data object` round-trip이 equality뿐 아니라 canonical singleton과
+  reference identity를 유지함.
+- constructor를 우회한 crafted serialized payload가 invalid config/token/TTL/oversized
+  owner를 만들지 못하고 `InvalidObjectException`으로 거절되는 test.
+- sentinel key/owner/token과 raw command가 backend/integrity log에 포함되지 않는
+  redaction capture test.
+- test는 JUnit 5, `bluetape4k-assertions`,
+  `io.bluetape4k.assertions.assertFailsWith`, intent-specific matcher를 사용한다.
+
+### 14.2 Shared behavior contract
+
+`FencingLeaseContract`를 만들고 sync, future, suspend adapter가 같은 fixture를 실행한다.
+
+- sequential acquire/release의 strictly increasing token.
+- concurrent acquire에서 한 owner와 한 fencing generation만 생성.
+- 같은 owner acquire retry가 같은 token을 반환.
+- renew가 token을 유지.
+- wrong owner와 stale token renew/release가 newer lease를 바꾸지 않음.
+- caller action 표의 terminal/non-retry/reconcile 분기가 sealed result별로 빠짐없이 대응됨.
+- expiry 뒤 takeover가 더 큰 token을 발급.
+- backend failure category parity.
+- `MultithreadingTester`, `SuspendedJobTester`를 적합한 concurrency case에 사용.
+- standalone은 16 caller × 25 generation, Cluster는 8 caller × 10 generation의 bounded
+  contention fixture를 30초 test timeout 안에서 실행한다. duplicate generation,
+  ordering regression, unexpected failure, hang이 없어야 한다.
+
+### 14.3 실제 standalone Redis
+
+기존 singleton launcher를 사용하고 module 간/작업 간 Testcontainers 실행은
+sequential하게 유지한다.
+
+- lease key만 유실되고 counter가 남으면 다음 acquire가 더 큰 token을 발급.
+- counter 삭제 시 acquire가 fail closed.
+- active lease 상태에서 counter를 0으로 reset하면 integrity failure.
+- wrong Redis type, oversized counter/owner/field, unexpected extra hash field, counter TTL,
+  TTL 없는 partial lease가 O(1) preflight에서 fail closed.
+- lease와 counter rollback을 Redis만으로 탐지할 수 없는 case와 downstream
+  `incoming > lastAccepted` fixture의 stale rejection.
+- resource identity와 last accepted tuple을 저장하는 PostgreSQL-style in-memory CAS fixture가
+  `affectedRows == 1`만 수락하고 stale/same-token replay를 거절함.
+- `Long.MAX_VALUE`에서 `SequenceExhausted`.
+- `SCRIPT FLUSH` 뒤 EVALSHA/NOSCRIPT fallback.
+- same-owner ambiguous acquire reconciliation.
+- internal executor fault injection으로 bootstrap/acquire/renew/release의 apply 전과 apply 후
+  reply 유실을 결정적으로 재현하고 각 recovery 결과를 검증.
+- control-plane harness가 `pause -> old acquire 차단 -> active lease/downstream writer drain ->
+  durable CAS epoch bump -> bootstrap -> readiness/tuple guard 확인 -> rollout -> old writer 부재
+  확인 -> resume` 순서를 결정적으로 검증하고, mixed-epoch 탐지 시 abort 및 lower-epoch
+  rollback을 거절함.
+- tagged opt-in topology promotion/restore test는 external incident signal 뒤 traffic pause와
+  higher-epoch recovery를 검증한다. 기본 CI는 동일 상태 전이를 fault-injection simulation으로
+  검증한다.
+- `Retry`, `CircuitBreaker`, `Bulkhead`를 외부 decorator로 적용한 실제 Redis 예제 test.
+- decorator 순서가 Bulkhead 최외곽, CircuitBreaker, Retry, supplier이고 한 permit이 전체 retry를
+  감싸며 circuit breaker가 최종 retry result만 관찰함을 검증한다. backend result만
+  retry/CB failure로 세고 circuit-open/bulkhead-full exception과 cancellation이 library
+  result로 변환되지 않음을 검증한다.
+
+### 14.4 Redis Cluster
+
+- derived lease/counter key가 같은 slot에 배치됨.
+- test codec이 두 derived key를 다른 wire slot으로 encode하는 fixture는 constructor에서
+  stable `IllegalArgumentException`으로 실패하고 어떤 node에도 dispatch하지 않음.
+- standalone과 Cluster에서 sync/future/suspend result parity.
+- invalid config/argument가 node dispatch 전에 실패함.
+- script가 검증된 key 쌍으로 정상 routing됨.
+- structural test/review로 hot path가 fixed command/reply와 steady-state one-script dispatch를
+  유지함을 확인. 새 benchmark dependency나 CI latency SLA는 추가하지 않음.
+
+### 14.5 Cancellation
+
+- 실제 coroutine job을 cancel해 `CancellationException`이 다시 던져짐.
+- cancellation을 backend failure result로 바꾸거나 retry하지 않음.
+- local ownership cache가 없으므로 cancellation 뒤 client-side state가 오염되지 않음.
+- 같은 owner acquire와 inspect를 이용해 server state를 복구 가능함.
+- controllable executor에서 future를 server apply 전과 apply 후 reply 전 각각 cancel하고,
+  cancelled 상태 유지와 operation-specific reconciliation을 검증.
+- EVALSHA 단계와 `NOSCRIPT` EVAL fallback 전환 race 각각에서 returned future cancellation이
+  현재 upstream future에 best-effort로 전달됨.
+- 실제 async/suspend IO는 `runSuspendIO`를 사용한다.
+
+## 15. Documentation과 KDoc
+
+모든 public class, function, result, property에 English KDoc을 작성한다.
+
+- ownership과 orderable fencing의 차이.
+- token ordering domain과 `(epoch, sequence)` 비교.
+- token이 domain identity를 포함하지 않아 resource-bound storage/handle이 필요한 점과
+  renew/release의 cross-epoch pre-dispatch rejection.
+- owner ID 재사용 범위와 ambiguous acquire retry.
+- `FencingOwnerId.random()` 기본값, custom ID의 capability/collision 책임, redacted
+  `toString()`과 serialization 재검증.
+- expiry, renew, release, overflow, Cluster same-slot.
+- 서로 다른 epoch의 동시 activation 금지와 control-plane cutover.
+- 한 hot resource가 한 slot/event loop에서 직렬화되는 성능 경계.
+- Redis history loss와 higher-epoch recovery.
+- timeout/cancellation 뒤 ambiguous completion.
+- downstream conditional write 책임.
+- 내부 retry가 없고 외부 decorator를 사용할 수 있다는 점.
+- 권장 Retry/CB/Bulkhead 순서, result predicate와 caller-layer exception 경계.
+- public API의 canonical package `io.bluetape4k.redis.lettuce.lease`.
+
+`infra/lettuce/README.md`와 `README.ko.md`는 같은 기술 내용을 각각 자연스럽게 제공한다.
+
+- opaque multi-key lease가 충분한 경우와 fencing lease가 필요한 경우 비교.
+- bootstrap과 epoch 운영 절차.
+- 최대 epoch terminal 상태와 ordering-domain migration 경계.
+- PostgreSQL-style tuple conditional update 예제.
+- stale writer rejection 예제.
+- `Retry`, `CircuitBreaker`, `Bulkhead` 외부 조합 예제.
+- Redis가 exactly-once나 durable business correctness를 제공하지 않는다는 제한.
+
+PostgreSQL 예제는 adapter를 만들지 않고 다음 의미만 보여준다.
+
+`fence_epoch`와 `fence_sequence`는 `NOT NULL DEFAULT 0`으로 추가해 기존 row를 `(0, 0)`에서
+시작하고, resource/domain identity와 함께 저장한다.
+
+```sql
+UPDATE guarded_resource
+SET fence_epoch = :epoch,
+    fence_sequence = :sequence,
+    payload = :payload
+WHERE id = :id
+  AND (fence_epoch, fence_sequence) < (:epoch, :sequence);
+```
+
+caller는 `affectedRows == 1`일 때만 fencing guard가 write를 수락했다고 본다.
+`affectedRows == 0`은 stale token 또는 같은-token replay이며 성공으로 간주하지 않는다.
+business command의 idempotency key와 duplicate 처리 정책은 fencing tuple과 별도다.
+
+## 16. Compatibility와 migration
+
+- 기존 `LettuceLock`, `LettuceSuspendLock`, `LettuceSemaphore`,
+  `LettuceMultiKeyLease` public API와 behavior를 변경하지 않는다.
+- 기존 caller가 fencing lease로 자동 이동하지 않는다. orderable downstream guard가 필요한
+  consumer만 새 primitive를 명시적으로 선택한다.
+- opaque owner token을 `FencingToken`으로 cast/parse하는 migration은 제공하지 않는다.
+- 안전한 migration은 먼저 downstream table에 resource-bound `NOT NULL` tuple column과
+  strict `incoming > stored` guard를 배포한 뒤, old opaque lease writer의 신규 acquire를
+  중지하고 active holder와 in-flight write를 drain한다. 그 다음 durable authority에서 새
+  higher epoch를 할당·bootstrap하고 fencing writer를 활성화한다. old binary/opaque writer가
+  다시 들어오지 못하도록 deployment/version gate를 유지하며, 재진입 가능성이 있으면
+  migration을 완료로 보지 않는다.
+- 새 API는 `bluetape4k-lettuce` 안에 추가되며 module registration, dependency catalog,
+  publication topology를 바꾸지 않는다. public type은
+  `io.bluetape4k.redis.lettuce.lease`에 둔다.
+- `bluetape4k-leader` integration은 별도 issue에서 public leader contract와 함께 검토한다.
+
+## 17. Acceptance criteria
+
+- config가 namespace, resource, epoch를 instance 생성 시 고정하고 두 Redis key를 같은
+  Cluster slot에 생성한다. slot은 connection codec이 encode한 실제 key byte로 검증한다.
+- owner ID는 CSPRNG 기본 factory, custom capability 경계, redacted logging contract를
+  제공한다.
+- `FencingToken`이 `(epoch, sequence)` natural ordering과 serialization contract를
+  제공한다.
+- explicit bootstrap만 새 counter를 만들고 acquire는 missing counter에서 fail closed한다.
+- acquire와 counter increment, lease 저장이 한 Lua execution에서 원자적이다.
+- same-owner acquire retry가 active ownership의 같은 token을 돌려준다.
+- renew는 token을 유지하고 renew/release는 owner와 token을 모두 비교한다.
+- overflow, malformed state, counter loss/behind, backend failure를 명시적인 outcome으로
+  구분한다.
+- sync/future/suspend shared contract와 standalone/Cluster fixture가 같은 semantics를
+  증명한다.
+- 공통 cause classifier가 wrapper 차이와 무관하게 backend kind parity를 보장하고 validation,
+  cancellation, decoder/internal exception을 public backend result로 평탄화하지 않는다.
+- cancellation이 보존되고 ambiguous completion recovery가 test와 KDoc에 드러난다.
+- upstream future cancellation이 EVALSHA와 NOSCRIPT fallback 양쪽에 best-effort로 전파된다.
+- script preflight와 reply가 O(1)/fixed-size이고 runtime error의 non-rollback 및 safe gap,
+  TTL 없는 partial lease 처리가 문서와 hostile-state test에 고정된다.
+- 모든 public non-enum value/result 및 nested variant가 `Serializable`과
+  `serialVersionUID = 1L`을 가지며 invalid deserialization을 canonical constructor
+  재검증으로 거절한다. enum은 Java enum serialization round-trip을 검증한다.
+- English KDoc과 영문/한글 README가 ordering, recovery, downstream responsibility를
+  동등하게 설명한다.
+- durable CAS epoch authority, pause/drain/bump/bootstrap/verify/resume cutover, lower-epoch
+  rollback 금지, bounded observability와 lease-only repair 조건이 runbook에 고정된다.
+- PostgreSQL 예제가 resource-bound `NOT NULL DEFAULT 0` tuple과 `affectedRows == 1` strict
+  acceptance를 사용하고 business idempotency를 별도 책임으로 둔다.
+- 기존 Lettuce lock/semaphore/multi-key lease test가 그대로 통과한다.
+
+## 18. Definition of Done
+
+- 설계와 구현 plan의 독립 관점 review에서 P0=0, P1=0이다.
+- production code보다 먼저 failing test가 public contract와 hostile state를 고정한다.
+- targeted unit/contract/standalone/Cluster/cancellation/resilience tests가 통과한다.
+- `:bluetape4k-lettuce:test`, 관련 static analysis, `git diff --check`가 통과한다.
+- public KDoc, `README.md`, `README.ko.md`가 구현과 일치한다.
+- issue #1068 acceptance criteria가 PR DoD에 추적된다.
+- PR은 `feature/issue-1068-fencing-lease`에서 `develop`으로 생성한다.
+- CI와 최신 review/thread를 확인한 뒤 별도의 merge 승인을 받는다.
+- merge 뒤 local `develop`을 fast-forward하고 merged worktree/branch를 정리한다.

--- a/infra/lettuce/README.ko.md
+++ b/infra/lettuce/README.ko.md
@@ -28,6 +28,8 @@ Lettuce Redis 클라이언트를 Kotlin에서 편리하게 사용할 수 있도�
 | `LettuceSuspendLock`                | 분산 뮤텍스 락 (suspend 전용)                                                                    |
 | `LettuceMultiKeyLease`              | 제한된 same-slot 키 집합의 원자적 소유권 lease (sync + async)                                      |
 | `LettuceSuspendMultiKeyLease`       | 제한된 same-slot 키 집합의 원자적 소유권 lease (suspend 전용)                                        |
+| `LettuceFencingLease`               | 정렬 가능한 `(epoch, sequence)` token을 발급하는 config-bound Redis fencing lease (sync + async)       |
+| `LettuceSuspendFencingLease`        | 정렬 가능한 `(epoch, sequence)` token을 발급하는 config-bound Redis fencing lease (suspend 전용)         |
 | `LettuceHyperLogLog<V>`             | Redis HyperLogLog 근사 카디널리티 추정 (sync). 코루틴 버전: `LettuceSuspendHyperLogLog<V>`             |
 | `LettuceSuspendHyperLogLog<V>`      | Redis HyperLogLog 근사 카디널리티 추정 (suspend 전용)                                               |
 | `LettuceBloomFilter`                | Redis BitSet 기반 Bloom Filter (sync). 코루틴 버전: `LettuceSuspendBloomFilter`                 |
@@ -537,6 +539,195 @@ owner token을 plaintext로 저장하므로 Redis ACL과 TLS가 실제 보안 �
 예상 owner token을 가진 persistent key는 `MultiKeyLeaseIntegrityException`을 발생시킵니다. 운영 승인을 받아
 exact namespace/key 집합을 확인한 뒤 그 집합만 수동 삭제하거나 namespace를 교체하고, writer를 활성화하기
 전에 Redis 상태와 durable authority를 다시 검증합니다.
+
+<!-- fencing-lease:basic -->
+### Downstream Stale Writer 차단을 위한 Fencing Lease
+
+불투명한 advisory ownership guard만 필요하면 `LettuceMultiKeyLease`를 사용합니다. 보호 대상 downstream
+resource가 정렬 token을 영속 저장하고 strict compare할 때만 `LettuceFencingLease` 또는
+`LettuceSuspendFencingLease`를 사용합니다. `LettuceFencingLeaseConfig(namespace, resourceName, epoch)`는 인스턴스
+생성 시 하나의 ordering domain을 고정합니다. 파생된 lease/counter key는 동일한 Redis Cluster slot을 사용합니다.
+
+`epoch`은 durable external authority가 발급합니다. 새로 승인된 epoch에만 `bootstrap`을 명시적으로 호출합니다.
+Acquire가 `CounterUnavailable`을 반환해도 bootstrap 권한이 생기지 않습니다. acquire를 중지하고 최초 배포인지
+history loss인지 판정해야 합니다. Counter 유실 뒤 같은 epoch를 bootstrap하거나 binary rollback/restore recovery에서
+epoch를 낮추면 안 됩니다. Token은 `(epoch, sequence)`만 가지며 resource identity를 포함하지 않습니다.
+
+<!-- fencing-lease:downstream-guard -->
+#### Durable Downstream Tuple Guard
+
+Stable resource identity와 token의 두 field를 함께 저장합니다. PostgreSQL-style migration과 strict update 예시:
+
+```sql
+ALTER TABLE guarded_resource
+    ADD COLUMN fence_epoch BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN fence_sequence BIGINT NOT NULL DEFAULT 0;
+
+UPDATE guarded_resource
+SET fence_epoch = :epoch,
+    fence_sequence = :sequence,
+    payload = :payload
+WHERE id = :id
+  AND (fence_epoch, fence_sequence) < (:epoch, :sequence);
+```
+
+`affectedRows == 1`일 때만 write를 승인합니다. `0`은 같은 token 또는 stale token을 거절한 것입니다. Business
+idempotency key는 별도 column과 policy로 관리합니다. Fencing order와 business idempotency는 서로 다른 문제입니다.
+
+<!-- fencing-lease:resilience -->
+#### Caller-Owned Retry, Circuit Breaker, Bulkhead
+
+Primitive는 backend failure를 result value로 반환합니다. `FencingAcquireResult.BackendFailure`만 retry하고, 모호하게
+성공한 acquire가 새 token 발급 대신 `AlreadyOwned`가 되도록 같은 owner ID를 재사용합니다. Validation,
+cancellation, protocol exception은 caller layer에서 retry나 circuit breaker 기록 없이 빠져나가야 합니다. 다음
+decorator chain은 의도된 순서입니다. Retry가 가장 안쪽이고 CircuitBreaker는 최종 result 한 번만 보며 Bulkhead가
+가장 바깥쪽입니다.
+
+```kotlin
+val retry = Retry.of(
+    "fencing-acquire",
+    RetryConfig.custom<FencingAcquireResult>()
+        .maxAttempts(2)
+        .waitDuration(Duration.ofMillis(50))
+        .retryOnResult { it is FencingAcquireResult.BackendFailure }
+        .retryOnException { false }
+        .build(),
+)
+val circuitBreaker = CircuitBreaker.of(
+    "fencing-acquire",
+    CircuitBreakerConfig.custom()
+        .slidingWindowSize(20)
+        .minimumNumberOfCalls(10)
+        .failureRateThreshold(50.0F)
+        .recordResult { it is FencingAcquireResult.BackendFailure }
+        .ignoreException { true }
+        .build(),
+)
+val bulkhead = Bulkhead.of(
+    "fencing-acquire",
+    BulkheadConfig.custom()
+        .maxConcurrentCalls(32)
+        .maxWaitDuration(Duration.ofMillis(100))
+        .build(),
+)
+
+val result = SuspendDecorators.ofSupplier {
+    lease.acquire(ownerId, leaseTime)
+}
+    .withRetry(retry)
+    .withCircuitBreaker(circuitBreaker)
+    .withBulkhead(bulkhead)
+    .invoke()
+```
+
+Production backoff는 bounded non-zero 값이어야 합니다. Bootstrap, inspect, renew, release에도 operation별
+`BackendFailure` predicate만 적용하고 Redis primitive 내부에 retry loop를 추가하지 않습니다.
+
+<!-- fencing-lease:recovery -->
+#### Epoch Recovery와 Rollback
+
+Promotion, known-old backup restore 같은 external history-loss signal은 다음 control-plane 순서를 요구합니다.
+
+```text
+pause -> block old acquire -> drain lease and downstream writer -> CAS bump epoch ->
+bootstrap -> verify readiness and tuple guard -> rollout -> confirm old absence -> resume
+```
+
+CAS allocator는 durable해야 하며 정확히 하나의 higher epoch만 허용해야 합니다. Readiness는 counter가 string이고
+`PTTL=-1`이며 canonical non-negative decimal이고 downstream strict tuple guard가 활성화된 경우에만 통과합니다.
+Mixed epoch이면 abort합니다. 이전 binary나 lower epoch를 resume하지 않습니다. Downstream에 higher epoch가 이미
+저장됐다면 sequence가 더 크더라도 restore된 lower-epoch token을 모두 거절해야 합니다.
+
+<!-- fencing-lease:diagnostics -->
+#### Bounded Read-Only 진단과 수동 복구
+
+다음 fixed-two-key Lua를 `EVAL_RO`로 실행하고 exact derived lease key, counter key, expected epoch만 전달합니다.
+결과는 stable classification과 bounded lease-only repair-candidate boolean입니다. Owner, token, key, stored value를
+반환하지 않으며 `KEYS`, `SCAN`, `HGETALL`도 사용하지 않습니다.
+
+```lua
+local counter_type = redis.call('TYPE', KEYS[2])['ok']
+if counter_type == 'none' then return {'COUNTER_MISSING', '0'} end
+if counter_type ~= 'string' then return {'COUNTER_INVALID', '0'} end
+if redis.call('PTTL', KEYS[2]) ~= -1 then return {'COUNTER_INVALID', '0'} end
+local counter_length = redis.call('STRLEN', KEYS[2])
+if counter_length < 1 or counter_length > 19 then return {'COUNTER_INVALID', '0'} end
+local counter = redis.call('GET', KEYS[2])
+local counter_valid = counter == '0' or string.match(counter, '^[1-9][0-9]*$')
+counter_valid = counter_valid and (#counter < 19 or counter <= '9223372036854775807')
+if not counter_valid then return {'COUNTER_INVALID', '0'} end
+
+local lease_type = redis.call('TYPE', KEYS[1])['ok']
+if lease_type == 'none' then return {'CLEAN', '0'} end
+if lease_type ~= 'hash' then return {'LEASE_MALFORMED', '0'} end
+if redis.call('HLEN', KEYS[1]) ~= 3 then return {'LEASE_MALFORMED', '0'} end
+local owner_length = redis.call('HSTRLEN', KEYS[1], 'owner')
+local epoch_length = redis.call('HSTRLEN', KEYS[1], 'epoch')
+local sequence_length = redis.call('HSTRLEN', KEYS[1], 'sequence')
+if owner_length < 1 or owner_length > 256 or epoch_length < 1 or epoch_length > 19 or
+   sequence_length < 1 or sequence_length > 19 then
+    return {'LEASE_MALFORMED', '0'}
+end
+local fields = redis.call('HMGET', KEYS[1], 'owner', 'epoch', 'sequence')
+local epoch = fields[2]
+local sequence = fields[3]
+if not string.match(epoch, '^[1-9][0-9]*$') then return {'LEASE_MALFORMED', '0'} end
+if not string.match(sequence, '^[1-9][0-9]*$') then return {'LEASE_MALFORMED', '0'} end
+if epoch ~= ARGV[1] then return {'LEASE_MALFORMED', '0'} end
+if #epoch > 19 or (#epoch == 19 and epoch > '9223372036854775807') then
+    return {'LEASE_MALFORMED', '0'}
+end
+if #sequence > 19 or (#sequence == 19 and sequence > '9223372036854775807') then
+    return {'LEASE_MALFORMED', '0'}
+end
+if #counter < #sequence or (#counter == #sequence and counter < sequence) then
+    return {'COUNTER_BEHIND_LEASE', '0'}
+end
+if redis.call('PTTL', KEYS[1]) == -1 then return {'LEASE_NO_TTL', '1'} end
+return {'ACTIVE', '0'}
+```
+
+수동 delete는 네 조건을 모두 만족할 때만 허용합니다. Incident가 pause되고 old acquire가 차단돼야 합니다. Lease와
+downstream writer가 모두 drain돼야 합니다. Counter는 valid, persistent이며 lease보다 뒤처지면 안 됩니다. 마지막으로
+exact classification이 `LEASE_NO_TTL`이어야 합니다. Lease key만 삭제합니다. Counter를 delete, decrement, expire,
+recreate하면 안 됩니다.
+
+운영 mapping: `CounterUnavailable`은 acquire를 pause하고 history를 진단합니다. `IntegrityFailure`는 모든 mutation을
+pause하고 이 read-only diagnostic과 runbook을 실행합니다. `SequenceExhausted`는 higher-epoch cutover를 시작합니다.
+`BackendFailure`는 operation별 ambiguous completion을 reconcile합니다. External restore/promotion signal은 즉시 전체
+pause-to-cutover 순서를 시작합니다.
+
+<!-- fencing-lease:caller-actions -->
+#### 전체 Result별 Caller 조치
+
+| Result | Required caller action |
+|---|---|
+| `Initialized`, `AlreadyInitialized` | Readiness를 확인한 뒤 승인된 epoch rollout만 계속합니다. |
+| `Acquired`, `AlreadyOwned`, `Owned`, `Renewed` | 정상 ownership 경로를 계속하고 token을 stable resource/domain identity와 함께 저장합니다. |
+| `Released` | Local ownership을 폐기하고 downstream write를 금지합니다. |
+| acquire `Contended` | TTL 또는 bounded backoff 뒤 새 owner로 시도하며 backend retry로 취급하지 않습니다. |
+| inspect `Contended` | Local ownership을 폐기하고 downstream write를 금지합니다. |
+| `Lost`, `OwnershipMismatch` | Local ownership을 폐기하고 downstream write를 금지합니다. |
+| `CounterUnavailable` | Acquire를 중지하고 최초 배포인지 history loss인지 판정하며 result만 보고 bootstrap하지 않습니다. |
+| `SequenceExhausted` | Retry하지 않고 higher-epoch cutover를 alert하며 max epoch이면 domain을 freeze/migrate합니다. |
+| `IntegrityFailure` | Retry와 mutation을 중지하고 read-only diagnosis와 승인된 runbook을 실행합니다. |
+| `BackendFailure` | Operation별 ambiguous completion을 reconcile하며 policy retry는 같은 owner/token을 사용합니다. |
+
+<!-- fencing-lease:security-telemetry -->
+#### 보안과 Telemetry
+
+Owner ID는 Redis에 저장되는 capability material입니다. High-entropy 값을 만들고 credential, JWT, session token,
+사용자 식별자, PII를 재사용하지 않습니다. Redis ACL과 TLS를 사용합니다. Log에는 allowlisted operation, result,
+backend-or-integrity kind, bounded domain fingerprint만 허용합니다. Metric label은 `operation`, `result`, `kind`만
+사용하며 `namespace/resource/owner/token/fingerprint`는 금지된 metric-label dimension입니다.
+
+<!-- fencing-lease:limitations -->
+#### 보장 범위와 비보장 범위
+
+Primitive는 config-bound domain 안에서 atomic Redis lease mutation과 monotonically ordered token을 제공합니다.
+exactly-once 실행, business idempotency, durable correctness, 자동 database fencing, durable epoch allocation,
+topology failure detection, 자동 recovery는 제공하지 않습니다. 이는 caller와 operator 책임입니다. Fencing lease는
+multi-key ownership lease를 보완하며 자동 대체하지 않습니다.
 
 ## Memoizer (함수 결과 Redis 캐싱)
 

--- a/infra/lettuce/README.md
+++ b/infra/lettuce/README.md
@@ -29,6 +29,8 @@ A Kotlin extension module for the Lettuce Redis client, providing high-performan
 | `LettuceSuspendLock`                | Distributed mutex lock (suspend-only)                                                                                                        |
 | `LettuceMultiKeyLease`              | Same-slot atomic ownership lease across bounded keys (sync + async)                                                                           |
 | `LettuceSuspendMultiKeyLease`       | Same-slot atomic ownership lease across bounded keys (suspend-only)                                                                           |
+| `LettuceFencingLease`               | Config-bound Redis fencing lease with ordered `(epoch, sequence)` tokens (sync + async)                                                       |
+| `LettuceSuspendFencingLease`        | Config-bound Redis fencing lease with ordered `(epoch, sequence)` tokens (suspend-only)                                                       |
 | `LettuceHyperLogLog<V>`             | Redis HyperLogLog approximate cardinality estimation (sync). Coroutine variant: `LettuceSuspendHyperLogLog<V>`                               |
 | `LettuceSuspendHyperLogLog<V>`      | Redis HyperLogLog approximate cardinality estimation (suspend-only)                                                                          |
 | `LettuceBloomFilter`                | Redis BitSet-based Bloom Filter (sync). Coroutine variant: `LettuceSuspendBloomFilter`                                                       |
@@ -542,6 +544,194 @@ tokens in plaintext, so Redis ACLs and TLS are the actual security boundary. Met
 A persistent key with the expected owner token raises `MultiKeyLeaseIntegrityException`. With operator approval,
 confirm the exact namespace/key set, then manually delete only that set or replace the namespace, and reverify both
 Redis state and the durable authority before enabling a writer.
+
+<!-- fencing-lease:basic -->
+### Fencing Lease for Downstream Stale-Writer Rejection
+
+Use `LettuceMultiKeyLease` when an opaque advisory ownership guard is sufficient. Use `LettuceFencingLease` or
+`LettuceSuspendFencingLease` only when every protected downstream resource durably stores and strictly compares an
+ordered token. `LettuceFencingLeaseConfig(namespace, resourceName, epoch)` fixes one ordering domain at instance
+creation. The derived lease and counter keys share one Redis Cluster slot.
+
+`epoch` comes from a durable external authority. Call `bootstrap` explicitly only for a newly approved epoch. An
+acquire returning `CounterUnavailable` is not permission to bootstrap: stop acquisition and determine whether this is
+first deployment or history loss. Never bootstrap the same epoch after counter loss, and never lower an epoch during
+binary rollback or restore recovery. A token contains only `(epoch, sequence)`; it does not contain resource identity.
+
+<!-- fencing-lease:downstream-guard -->
+#### Durable Downstream Tuple Guard
+
+Store stable resource identity and both token fields together. PostgreSQL-style schema migration and strict update:
+
+```sql
+ALTER TABLE guarded_resource
+    ADD COLUMN fence_epoch BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN fence_sequence BIGINT NOT NULL DEFAULT 0;
+
+UPDATE guarded_resource
+SET fence_epoch = :epoch,
+    fence_sequence = :sequence,
+    payload = :payload
+WHERE id = :id
+  AND (fence_epoch, fence_sequence) < (:epoch, :sequence);
+```
+
+Accept the write only when `affectedRows == 1`. A result of `0` rejects a same or stale token. Keep the business
+idempotency key in a separate column and policy; fencing order and business idempotency solve different problems.
+
+<!-- fencing-lease:resilience -->
+#### Caller-Owned Retry, Circuit Breaker, and Bulkhead
+
+The primitive returns backend failures as result values. Retry only `FencingAcquireResult.BackendFailure`, and reuse
+the same owner ID so an ambiguous successful acquire returns `AlreadyOwned` instead of allocating another token.
+Validation, cancellation, and protocol exceptions stay in the caller layer and must escape without retry or circuit
+breaker recording. The exact decorator chain is intentional: Retry is innermost, CircuitBreaker sees one final result,
+and Bulkhead is outermost.
+
+```kotlin
+val retry = Retry.of(
+    "fencing-acquire",
+    RetryConfig.custom<FencingAcquireResult>()
+        .maxAttempts(2)
+        .waitDuration(Duration.ofMillis(50))
+        .retryOnResult { it is FencingAcquireResult.BackendFailure }
+        .retryOnException { false }
+        .build(),
+)
+val circuitBreaker = CircuitBreaker.of(
+    "fencing-acquire",
+    CircuitBreakerConfig.custom()
+        .slidingWindowSize(20)
+        .minimumNumberOfCalls(10)
+        .failureRateThreshold(50.0F)
+        .recordResult { it is FencingAcquireResult.BackendFailure }
+        .ignoreException { true }
+        .build(),
+)
+val bulkhead = Bulkhead.of(
+    "fencing-acquire",
+    BulkheadConfig.custom()
+        .maxConcurrentCalls(32)
+        .maxWaitDuration(Duration.ofMillis(100))
+        .build(),
+)
+
+val result = SuspendDecorators.ofSupplier {
+    lease.acquire(ownerId, leaseTime)
+}
+    .withRetry(retry)
+    .withCircuitBreaker(circuitBreaker)
+    .withBulkhead(bulkhead)
+    .invoke()
+```
+
+Use bounded, non-zero production backoff. Apply an operation-specific `BackendFailure` predicate for bootstrap,
+inspect, renew, and release; do not add retry loops to the Redis primitive.
+
+<!-- fencing-lease:recovery -->
+#### Epoch Recovery and Rollback
+
+Promotion, known-old backup restore, or other external history-loss signals require this control-plane order:
+
+```text
+pause -> block old acquire -> drain lease and downstream writer -> CAS bump epoch ->
+bootstrap -> verify readiness and tuple guard -> rollout -> confirm old absence -> resume
+```
+
+The CAS allocator must be durable and permit exactly one higher epoch. Readiness requires a string counter with
+`PTTL=-1`, canonical non-negative decimal content, and the downstream strict tuple guard enabled. Abort on mixed
+epochs. Never resume an old binary or lower epoch; downstream state at a higher epoch must reject all restored
+lower-epoch tokens even when their sequence is larger.
+
+<!-- fencing-lease:diagnostics -->
+#### Bounded Read-Only Diagnosis and Manual Repair
+
+Run the following fixed-two-key Lua with `EVAL_RO`, passing only the exact derived lease key, counter key, and expected
+epoch. It returns a stable classification and a bounded lease-only repair-candidate boolean. It never returns owner,
+token, key, or stored values and never uses `KEYS`, `SCAN`, or `HGETALL`.
+
+```lua
+local counter_type = redis.call('TYPE', KEYS[2])['ok']
+if counter_type == 'none' then return {'COUNTER_MISSING', '0'} end
+if counter_type ~= 'string' then return {'COUNTER_INVALID', '0'} end
+if redis.call('PTTL', KEYS[2]) ~= -1 then return {'COUNTER_INVALID', '0'} end
+local counter_length = redis.call('STRLEN', KEYS[2])
+if counter_length < 1 or counter_length > 19 then return {'COUNTER_INVALID', '0'} end
+local counter = redis.call('GET', KEYS[2])
+local counter_valid = counter == '0' or string.match(counter, '^[1-9][0-9]*$')
+counter_valid = counter_valid and (#counter < 19 or counter <= '9223372036854775807')
+if not counter_valid then return {'COUNTER_INVALID', '0'} end
+
+local lease_type = redis.call('TYPE', KEYS[1])['ok']
+if lease_type == 'none' then return {'CLEAN', '0'} end
+if lease_type ~= 'hash' then return {'LEASE_MALFORMED', '0'} end
+if redis.call('HLEN', KEYS[1]) ~= 3 then return {'LEASE_MALFORMED', '0'} end
+local owner_length = redis.call('HSTRLEN', KEYS[1], 'owner')
+local epoch_length = redis.call('HSTRLEN', KEYS[1], 'epoch')
+local sequence_length = redis.call('HSTRLEN', KEYS[1], 'sequence')
+if owner_length < 1 or owner_length > 256 or epoch_length < 1 or epoch_length > 19 or
+   sequence_length < 1 or sequence_length > 19 then
+    return {'LEASE_MALFORMED', '0'}
+end
+local fields = redis.call('HMGET', KEYS[1], 'owner', 'epoch', 'sequence')
+local epoch = fields[2]
+local sequence = fields[3]
+if not string.match(epoch, '^[1-9][0-9]*$') then return {'LEASE_MALFORMED', '0'} end
+if not string.match(sequence, '^[1-9][0-9]*$') then return {'LEASE_MALFORMED', '0'} end
+if epoch ~= ARGV[1] then return {'LEASE_MALFORMED', '0'} end
+if #epoch > 19 or (#epoch == 19 and epoch > '9223372036854775807') then
+    return {'LEASE_MALFORMED', '0'}
+end
+if #sequence > 19 or (#sequence == 19 and sequence > '9223372036854775807') then
+    return {'LEASE_MALFORMED', '0'}
+end
+if #counter < #sequence or (#counter == #sequence and counter < sequence) then
+    return {'COUNTER_BEHIND_LEASE', '0'}
+end
+if redis.call('PTTL', KEYS[1]) == -1 then return {'LEASE_NO_TTL', '1'} end
+return {'ACTIVE', '0'}
+```
+
+Manual deletion is allowed only when all four conditions hold: the incident is paused and old acquire is blocked; all
+lease and downstream writers are drained; the counter is valid, persistent, and not behind the lease; and the exact
+classification is `LEASE_NO_TTL`. Delete only the lease key. Never delete, decrement, expire, or recreate the counter.
+
+Operational mapping: `CounterUnavailable` pauses acquire and triggers history diagnosis; `IntegrityFailure` pauses all
+mutation and uses this read-only diagnostic; `SequenceExhausted` triggers a higher-epoch cutover; `BackendFailure`
+triggers operation-specific ambiguous-completion reconciliation; an external restore/promotion signal immediately
+starts the full pause-to-cutover sequence.
+
+<!-- fencing-lease:caller-actions -->
+#### Exhaustive Result Actions
+
+| Result | Required caller action |
+|---|---|
+| `Initialized`, `AlreadyInitialized` | Verify readiness, then continue only the approved epoch rollout. |
+| `Acquired`, `AlreadyOwned`, `Owned`, `Renewed` | Continue the ownership path; store the token with stable resource/domain identity. |
+| `Released` | Discard local ownership and prohibit downstream writes. |
+| acquire `Contended` | Retry with a new owner only after TTL or bounded backoff; never treat it as a backend retry. |
+| inspect `Contended` | Discard local ownership and prohibit downstream writes. |
+| `Lost`, `OwnershipMismatch` | Discard local ownership and prohibit downstream writes. |
+| `CounterUnavailable` | Stop acquire and determine first deployment versus history loss; never bootstrap from this result alone. |
+| `SequenceExhausted` | Do not retry; alert for higher-epoch cutover, or freeze/migrate the domain at maximum epoch. |
+| `IntegrityFailure` | Stop retry and mutation; run read-only diagnosis and the approved runbook. |
+| `BackendFailure` | Reconcile operation-specific ambiguous completion; policy retry must reuse the same owner/token. |
+
+<!-- fencing-lease:security-telemetry -->
+#### Security and Telemetry
+
+Owner IDs are capability material stored in Redis. Generate high-entropy values and never reuse credentials, JWTs,
+session tokens, user identifiers, or PII. Use Redis ACLs and TLS. Logs may include only an allowlisted operation,
+result, backend-or-integrity kind, and bounded domain fingerprint. Metrics may label only `operation`, `result`, and
+`kind`; `namespace/resource/owner/token/fingerprint` are forbidden metric-label dimensions.
+
+<!-- fencing-lease:limitations -->
+#### Guarantees and Non-Guarantees
+
+The primitive provides atomic Redis lease mutation and monotonically ordered tokens within a config-bound domain. It
+does not provide exactly-once execution, business idempotency, durable correctness, automatic database fencing,
+durable epoch allocation, topology failure detection, or automatic recovery. Those remain caller and operator
+responsibilities. This fencing lease complements rather than automatically replaces the multi-key ownership lease.
 
 ## Memoizer (Caching Function Results in Redis)
 

--- a/infra/lettuce/build.gradle.kts
+++ b/infra/lettuce/build.gradle.kts
@@ -103,8 +103,21 @@ dependencies {
 
 tasks.named<Test>("test") {
     useJUnitPlatform {
-        excludeTags("performance")
+        excludeTags("performance", "fencing-topology")
     }
+}
+
+tasks.register<Test>("fencingLeaseTopologyRecoveryTest") {
+    description = "Runs fencing lease Redis promotion and restore recovery tests."
+    group = "verification"
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
+    useJUnitPlatform {
+        includeTags("fencing-topology")
+    }
+    outputs.upToDateWhen { false }
+    outputs.cacheIf { false }
+    shouldRunAfter(tasks.test)
 }
 
 tasks.register<Test>("multiKeyLeasePerformanceTest") {

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseResult.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseResult.kt
@@ -51,7 +51,12 @@ data class FencingLeaseIntegrityFailure(
     }
 }
 
-/** Represents every outcome of explicitly initializing a new fencing counter. */
+/**
+ * Represents every outcome of explicitly initializing a new fencing counter.
+ *
+ * Bootstrap is a control-plane operation for an externally approved epoch. [AlreadyInitialized] is not proof that
+ * downstream tuple guards or rollout readiness are complete, and a missing counter must never be repaired implicitly.
+ */
 sealed interface FencingBootstrapResult: Serializable {
 
     /** Indicates that the previously absent counter was initialized to zero. */
@@ -66,7 +71,11 @@ sealed interface FencingBootstrapResult: Serializable {
         private fun readResolve(): Any = AlreadyInitialized
     }
 
-    /** Indicates that stored lease or counter state violated an integrity invariant. */
+    /**
+     * Indicates that stored lease or counter state violated an integrity invariant.
+     *
+     * @property failure sanitized integrity category
+     */
     data class IntegrityFailure(
         val failure: FencingLeaseIntegrityFailure,
     ): FencingBootstrapResult {
@@ -79,7 +88,11 @@ sealed interface FencingBootstrapResult: Serializable {
         }
     }
 
-    /** Indicates an allowlisted Redis backend failure with ambiguous completion. */
+    /**
+     * Indicates an allowlisted Redis backend failure with ambiguous completion.
+     *
+     * @property failure sanitized backend category
+     */
     data class BackendFailure(
         val failure: FencingLeaseBackendFailure,
     ): FencingBootstrapResult {
@@ -97,10 +110,19 @@ sealed interface FencingBootstrapResult: Serializable {
     }
 }
 
-/** Represents every outcome of acquiring a fencing lease. */
+/**
+ * Represents every outcome of acquiring a fencing lease.
+ *
+ * [AlreadyOwned] is deterministic same-owner recovery after ambiguous completion. [CounterUnavailable],
+ * [SequenceExhausted], and [IntegrityFailure] are fail-closed outcomes and must not be treated as backend retries.
+ */
 sealed interface FencingAcquireResult: Serializable {
 
-    /** Indicates that a new lease and token were created for the owner. */
+    /**
+     * Indicates that a new lease and token were created for the owner.
+     *
+     * @property token newly allocated fencing token
+     */
     data class Acquired(
         val token: FencingToken,
     ): FencingAcquireResult {
@@ -113,7 +135,12 @@ sealed interface FencingAcquireResult: Serializable {
         }
     }
 
-    /** Indicates deterministic recovery of the same owner's active lease without allocating a new token. */
+    /**
+     * Indicates deterministic recovery of the same owner's active lease without allocating a new token.
+     *
+     * @property token previously allocated fencing token
+     * @property remainingTtlMillis remaining lease TTL in milliseconds
+     */
     data class AlreadyOwned(
         val token: FencingToken,
         val remainingTtlMillis: Long,
@@ -131,7 +158,11 @@ sealed interface FencingAcquireResult: Serializable {
         }
     }
 
-    /** Indicates that another owner currently holds the lease. */
+    /**
+     * Indicates that another owner currently holds the lease.
+     *
+     * @property remainingTtlMillis remaining competing lease TTL in milliseconds
+     */
     data class Contended(
         val remainingTtlMillis: Long,
     ): FencingAcquireResult {
@@ -154,13 +185,17 @@ sealed interface FencingAcquireResult: Serializable {
         private fun readResolve(): Any = CounterUnavailable
     }
 
-    /** Indicates that the current epoch has allocated its final sequence. */
+    /** Indicates terminal sequence overflow for the current epoch; callers must cut over to a higher durable epoch. */
     data object SequenceExhausted: FencingAcquireResult {
         private const val serialVersionUID: Long = 1L
         private fun readResolve(): Any = SequenceExhausted
     }
 
-    /** Indicates that stored lease or counter state violated an integrity invariant. */
+    /**
+     * Indicates that stored lease or counter state violated an integrity invariant.
+     *
+     * @property failure sanitized integrity category
+     */
     data class IntegrityFailure(
         val failure: FencingLeaseIntegrityFailure,
     ): FencingAcquireResult {
@@ -173,7 +208,11 @@ sealed interface FencingAcquireResult: Serializable {
         }
     }
 
-    /** Indicates an allowlisted Redis backend failure with ambiguous completion. */
+    /**
+     * Indicates an allowlisted Redis backend failure with ambiguous completion.
+     *
+     * @property failure sanitized backend category
+     */
     data class BackendFailure(
         val failure: FencingLeaseBackendFailure,
     ): FencingAcquireResult {
@@ -191,10 +230,20 @@ sealed interface FencingAcquireResult: Serializable {
     }
 }
 
-/** Represents every outcome of inspecting a fencing lease without mutation. */
+/**
+ * Represents every outcome of inspecting a fencing lease without mutation.
+ *
+ * Inspection supports operation-specific reconciliation but cannot prove whether an expired lease was released or
+ * merely timed out. Callers must stop downstream writes for [Lost] or [Contended].
+ */
 sealed interface FencingInspectResult: Serializable {
 
-    /** Indicates that the requested owner still holds the active lease. */
+    /**
+     * Indicates that the requested owner still holds the active lease.
+     *
+     * @property token active fencing token
+     * @property remainingTtlMillis remaining lease TTL in milliseconds
+     */
     data class Owned(
         val token: FencingToken,
         val remainingTtlMillis: Long,
@@ -218,7 +267,11 @@ sealed interface FencingInspectResult: Serializable {
         private fun readResolve(): Any = Lost
     }
 
-    /** Indicates that another owner currently holds the active lease. */
+    /**
+     * Indicates that another owner currently holds the active lease.
+     *
+     * @property remainingTtlMillis remaining competing lease TTL in milliseconds
+     */
     data class Contended(
         val remainingTtlMillis: Long,
     ): FencingInspectResult {
@@ -235,7 +288,11 @@ sealed interface FencingInspectResult: Serializable {
         }
     }
 
-    /** Indicates that stored lease or counter state violated an integrity invariant. */
+    /**
+     * Indicates that stored lease or counter state violated an integrity invariant.
+     *
+     * @property failure sanitized integrity category
+     */
     data class IntegrityFailure(
         val failure: FencingLeaseIntegrityFailure,
     ): FencingInspectResult {
@@ -248,7 +305,11 @@ sealed interface FencingInspectResult: Serializable {
         }
     }
 
-    /** Indicates an allowlisted Redis backend failure. */
+    /**
+     * Indicates an allowlisted Redis backend failure.
+     *
+     * @property failure sanitized backend category
+     */
     data class BackendFailure(
         val failure: FencingLeaseBackendFailure,
     ): FencingInspectResult {
@@ -266,7 +327,12 @@ sealed interface FencingInspectResult: Serializable {
     }
 }
 
-/** Represents every outcome of renewing an existing fencing lease. */
+/**
+ * Represents every outcome of renewing an existing fencing lease.
+ *
+ * Renew requires the same owner capability and token. A [BackendFailure] is an ambiguous completion; reconcile with
+ * the same owner and token instead of issuing a new acquisition identity.
+ */
 sealed interface FencingRenewResult: Serializable {
 
     /** Indicates that the matching lease TTL was renewed. */
@@ -287,7 +353,11 @@ sealed interface FencingRenewResult: Serializable {
         private fun readResolve(): Any = OwnershipMismatch
     }
 
-    /** Indicates that stored lease or counter state violated an integrity invariant. */
+    /**
+     * Indicates that stored lease or counter state violated an integrity invariant.
+     *
+     * @property failure sanitized integrity category
+     */
     data class IntegrityFailure(
         val failure: FencingLeaseIntegrityFailure,
     ): FencingRenewResult {
@@ -300,7 +370,11 @@ sealed interface FencingRenewResult: Serializable {
         }
     }
 
-    /** Indicates an allowlisted Redis backend failure with ambiguous completion. */
+    /**
+     * Indicates an allowlisted Redis backend failure with ambiguous completion.
+     *
+     * @property failure sanitized backend category
+     */
     data class BackendFailure(
         val failure: FencingLeaseBackendFailure,
     ): FencingRenewResult {
@@ -318,7 +392,12 @@ sealed interface FencingRenewResult: Serializable {
     }
 }
 
-/** Represents every outcome of releasing an existing fencing lease. */
+/**
+ * Represents every outcome of releasing an existing fencing lease.
+ *
+ * Release requires the same owner capability and token. A [BackendFailure] is an ambiguous completion; reconcile
+ * before discarding durable ownership state.
+ */
 sealed interface FencingReleaseResult: Serializable {
 
     /** Indicates that the matching active lease was removed. */
@@ -339,7 +418,11 @@ sealed interface FencingReleaseResult: Serializable {
         private fun readResolve(): Any = OwnershipMismatch
     }
 
-    /** Indicates that stored lease or counter state violated an integrity invariant. */
+    /**
+     * Indicates that stored lease or counter state violated an integrity invariant.
+     *
+     * @property failure sanitized integrity category
+     */
     data class IntegrityFailure(
         val failure: FencingLeaseIntegrityFailure,
     ): FencingReleaseResult {
@@ -352,7 +435,11 @@ sealed interface FencingReleaseResult: Serializable {
         }
     }
 
-    /** Indicates an allowlisted Redis backend failure with ambiguous completion. */
+    /**
+     * Indicates an allowlisted Redis backend failure with ambiguous completion.
+     *
+     * @property failure sanitized backend category
+     */
     data class BackendFailure(
         val failure: FencingLeaseBackendFailure,
     ): FencingReleaseResult {

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseResult.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseResult.kt
@@ -1,0 +1,375 @@
+package io.bluetape4k.redis.lettuce.lease
+
+import io.bluetape4k.support.requireZeroOrPositiveNumber
+import java.io.Serializable
+
+/** Classifies allowlisted Redis backend failures without exposing exception details. */
+enum class FencingBackendFailureKind {
+    CONNECTION,
+    TIMEOUT,
+    COMMAND,
+}
+
+/**
+ * Describes a Redis backend failure without retaining a cause, message, command, key, owner ID, or raw reply.
+ *
+ * @property kind allowlisted backend failure category
+ */
+data class FencingLeaseBackendFailure(
+    val kind: FencingBackendFailureKind,
+): Serializable {
+    private fun readResolve(): Any = restoreFencingSerializedValue("FencingLeaseBackendFailure") {
+        FencingLeaseBackendFailure(kind)
+    }
+
+    private companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/** Classifies fencing-lease state that violates a durable Redis invariant. */
+enum class FencingIntegrityFailureKind {
+    MALFORMED_LEASE,
+    INVALID_COUNTER,
+    COUNTER_BEHIND_LEASE,
+}
+
+/**
+ * Describes a fencing-lease integrity failure without exposing stored values or Redis keys.
+ *
+ * @property kind violated integrity category
+ */
+data class FencingLeaseIntegrityFailure(
+    val kind: FencingIntegrityFailureKind,
+): Serializable {
+    private fun readResolve(): Any = restoreFencingSerializedValue("FencingLeaseIntegrityFailure") {
+        FencingLeaseIntegrityFailure(kind)
+    }
+
+    private companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/** Represents every outcome of explicitly initializing a new fencing counter. */
+sealed interface FencingBootstrapResult: Serializable {
+
+    /** Indicates that the previously absent counter was initialized to zero. */
+    data object Initialized: FencingBootstrapResult {
+        private const val serialVersionUID: Long = 1L
+        private fun readResolve(): Any = Initialized
+    }
+
+    /** Indicates that a valid counter already existed. */
+    data object AlreadyInitialized: FencingBootstrapResult {
+        private const val serialVersionUID: Long = 1L
+        private fun readResolve(): Any = AlreadyInitialized
+    }
+
+    /** Indicates that stored lease or counter state violated an integrity invariant. */
+    data class IntegrityFailure(
+        val failure: FencingLeaseIntegrityFailure,
+    ): FencingBootstrapResult {
+        private fun readResolve(): Any = restoreFencingSerializedValue("FencingBootstrapResult.IntegrityFailure") {
+            IntegrityFailure(failure)
+        }
+
+        private companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    /** Indicates an allowlisted Redis backend failure with ambiguous completion. */
+    data class BackendFailure(
+        val failure: FencingLeaseBackendFailure,
+    ): FencingBootstrapResult {
+        private fun readResolve(): Any = restoreFencingSerializedValue("FencingBootstrapResult.BackendFailure") {
+            BackendFailure(failure)
+        }
+
+        private companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    private companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/** Represents every outcome of acquiring a fencing lease. */
+sealed interface FencingAcquireResult: Serializable {
+
+    /** Indicates that a new lease and token were created for the owner. */
+    data class Acquired(
+        val token: FencingToken,
+    ): FencingAcquireResult {
+        private fun readResolve(): Any = restoreFencingSerializedValue("FencingAcquireResult.Acquired") {
+            Acquired(token)
+        }
+
+        private companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    /** Indicates deterministic recovery of the same owner's active lease without allocating a new token. */
+    data class AlreadyOwned(
+        val token: FencingToken,
+        val remainingTtlMillis: Long,
+    ): FencingAcquireResult {
+        init {
+            requireRemainingTtl(remainingTtlMillis)
+        }
+
+        private fun readResolve(): Any = restoreFencingSerializedValue("FencingAcquireResult.AlreadyOwned") {
+            AlreadyOwned(token, remainingTtlMillis)
+        }
+
+        private companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    /** Indicates that another owner currently holds the lease. */
+    data class Contended(
+        val remainingTtlMillis: Long,
+    ): FencingAcquireResult {
+        init {
+            requireRemainingTtl(remainingTtlMillis)
+        }
+
+        private fun readResolve(): Any = restoreFencingSerializedValue("FencingAcquireResult.Contended") {
+            Contended(remainingTtlMillis)
+        }
+
+        private companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    /** Indicates that acquisition cannot proceed because the fencing counter is absent. */
+    data object CounterUnavailable: FencingAcquireResult {
+        private const val serialVersionUID: Long = 1L
+        private fun readResolve(): Any = CounterUnavailable
+    }
+
+    /** Indicates that the current epoch has allocated its final sequence. */
+    data object SequenceExhausted: FencingAcquireResult {
+        private const val serialVersionUID: Long = 1L
+        private fun readResolve(): Any = SequenceExhausted
+    }
+
+    /** Indicates that stored lease or counter state violated an integrity invariant. */
+    data class IntegrityFailure(
+        val failure: FencingLeaseIntegrityFailure,
+    ): FencingAcquireResult {
+        private fun readResolve(): Any = restoreFencingSerializedValue("FencingAcquireResult.IntegrityFailure") {
+            IntegrityFailure(failure)
+        }
+
+        private companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    /** Indicates an allowlisted Redis backend failure with ambiguous completion. */
+    data class BackendFailure(
+        val failure: FencingLeaseBackendFailure,
+    ): FencingAcquireResult {
+        private fun readResolve(): Any = restoreFencingSerializedValue("FencingAcquireResult.BackendFailure") {
+            BackendFailure(failure)
+        }
+
+        private companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    private companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/** Represents every outcome of inspecting a fencing lease without mutation. */
+sealed interface FencingInspectResult: Serializable {
+
+    /** Indicates that the requested owner still holds the active lease. */
+    data class Owned(
+        val token: FencingToken,
+        val remainingTtlMillis: Long,
+    ): FencingInspectResult {
+        init {
+            requireRemainingTtl(remainingTtlMillis)
+        }
+
+        private fun readResolve(): Any = restoreFencingSerializedValue("FencingInspectResult.Owned") {
+            Owned(token, remainingTtlMillis)
+        }
+
+        private companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    /** Indicates that no active lease exists. */
+    data object Lost: FencingInspectResult {
+        private const val serialVersionUID: Long = 1L
+        private fun readResolve(): Any = Lost
+    }
+
+    /** Indicates that another owner currently holds the active lease. */
+    data class Contended(
+        val remainingTtlMillis: Long,
+    ): FencingInspectResult {
+        init {
+            requireRemainingTtl(remainingTtlMillis)
+        }
+
+        private fun readResolve(): Any = restoreFencingSerializedValue("FencingInspectResult.Contended") {
+            Contended(remainingTtlMillis)
+        }
+
+        private companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    /** Indicates that stored lease or counter state violated an integrity invariant. */
+    data class IntegrityFailure(
+        val failure: FencingLeaseIntegrityFailure,
+    ): FencingInspectResult {
+        private fun readResolve(): Any = restoreFencingSerializedValue("FencingInspectResult.IntegrityFailure") {
+            IntegrityFailure(failure)
+        }
+
+        private companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    /** Indicates an allowlisted Redis backend failure. */
+    data class BackendFailure(
+        val failure: FencingLeaseBackendFailure,
+    ): FencingInspectResult {
+        private fun readResolve(): Any = restoreFencingSerializedValue("FencingInspectResult.BackendFailure") {
+            BackendFailure(failure)
+        }
+
+        private companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    private companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/** Represents every outcome of renewing an existing fencing lease. */
+sealed interface FencingRenewResult: Serializable {
+
+    /** Indicates that the matching lease TTL was renewed. */
+    data object Renewed: FencingRenewResult {
+        private const val serialVersionUID: Long = 1L
+        private fun readResolve(): Any = Renewed
+    }
+
+    /** Indicates that no active lease exists. */
+    data object Lost: FencingRenewResult {
+        private const val serialVersionUID: Long = 1L
+        private fun readResolve(): Any = Lost
+    }
+
+    /** Indicates that the owner or token did not match the active lease. */
+    data object OwnershipMismatch: FencingRenewResult {
+        private const val serialVersionUID: Long = 1L
+        private fun readResolve(): Any = OwnershipMismatch
+    }
+
+    /** Indicates that stored lease or counter state violated an integrity invariant. */
+    data class IntegrityFailure(
+        val failure: FencingLeaseIntegrityFailure,
+    ): FencingRenewResult {
+        private fun readResolve(): Any = restoreFencingSerializedValue("FencingRenewResult.IntegrityFailure") {
+            IntegrityFailure(failure)
+        }
+
+        private companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    /** Indicates an allowlisted Redis backend failure with ambiguous completion. */
+    data class BackendFailure(
+        val failure: FencingLeaseBackendFailure,
+    ): FencingRenewResult {
+        private fun readResolve(): Any = restoreFencingSerializedValue("FencingRenewResult.BackendFailure") {
+            BackendFailure(failure)
+        }
+
+        private companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    private companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/** Represents every outcome of releasing an existing fencing lease. */
+sealed interface FencingReleaseResult: Serializable {
+
+    /** Indicates that the matching active lease was removed. */
+    data object Released: FencingReleaseResult {
+        private const val serialVersionUID: Long = 1L
+        private fun readResolve(): Any = Released
+    }
+
+    /** Indicates that no active lease exists. */
+    data object Lost: FencingReleaseResult {
+        private const val serialVersionUID: Long = 1L
+        private fun readResolve(): Any = Lost
+    }
+
+    /** Indicates that the owner or token did not match the active lease. */
+    data object OwnershipMismatch: FencingReleaseResult {
+        private const val serialVersionUID: Long = 1L
+        private fun readResolve(): Any = OwnershipMismatch
+    }
+
+    /** Indicates that stored lease or counter state violated an integrity invariant. */
+    data class IntegrityFailure(
+        val failure: FencingLeaseIntegrityFailure,
+    ): FencingReleaseResult {
+        private fun readResolve(): Any = restoreFencingSerializedValue("FencingReleaseResult.IntegrityFailure") {
+            IntegrityFailure(failure)
+        }
+
+        private companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    /** Indicates an allowlisted Redis backend failure with ambiguous completion. */
+    data class BackendFailure(
+        val failure: FencingLeaseBackendFailure,
+    ): FencingReleaseResult {
+        private fun readResolve(): Any = restoreFencingSerializedValue("FencingReleaseResult.BackendFailure") {
+            BackendFailure(failure)
+        }
+
+        private companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    private companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+private fun requireRemainingTtl(remainingTtlMillis: Long) {
+    remainingTtlMillis.requireZeroOrPositiveNumber("remainingTtlMillis")
+}

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseValue.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseValue.kt
@@ -1,0 +1,133 @@
+package io.bluetape4k.redis.lettuce.lease
+
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.support.requirePositiveNumber
+import java.io.InvalidObjectException
+import java.io.Serializable
+import java.nio.charset.StandardCharsets
+
+/**
+ * Identifies one Redis fencing-token ordering domain.
+ *
+ * Tokens are comparable only within the same [namespace] and [resourceName]. The [epoch] must be allocated by a
+ * durable external authority and must never be lowered during rollback or recovery.
+ *
+ * @property namespace stable namespace used to derive the Redis Cluster hash tag
+ * @property resourceName stable logical resource name used to derive the Redis Cluster hash tag
+ * @property epoch positive generation allocated for this ordering domain
+ */
+data class LettuceFencingLeaseConfig(
+    val namespace: String,
+    val resourceName: String,
+    val epoch: Long,
+): Serializable {
+    init {
+        require(SAFE_COMPONENT.matches(namespace)) {
+            "namespace must contain 1..128 ASCII letters, digits, dots, underscores, or hyphens."
+        }
+        require(SAFE_COMPONENT.matches(resourceName)) {
+            "resourceName must contain 1..128 ASCII letters, digits, dots, underscores, or hyphens."
+        }
+        epoch.requirePositiveNumber("epoch")
+    }
+
+    private fun readResolve(): Any = restoreFencingSerializedValue("LettuceFencingLeaseConfig") {
+        LettuceFencingLeaseConfig(namespace, resourceName, epoch)
+    }
+
+    private companion object {
+        private const val serialVersionUID: Long = 1L
+        private val SAFE_COMPONENT = Regex("[A-Za-z0-9._-]{1,128}")
+    }
+}
+
+/**
+ * Opaque identifier for one logical fencing-lease acquisition attempt.
+ *
+ * Reuse an owner ID only when reconciling an ambiguous response from the same logical attempt. The raw value is
+ * intentionally excluded from [toString].
+ */
+class FencingOwnerId private constructor(
+    internal val value: String,
+): Serializable {
+    init {
+        val byteCount = value.toByteArray(StandardCharsets.UTF_8).size
+        require(value.isNotBlank() && byteCount in 1..MAX_UTF8_BYTES) {
+            "Fencing owner ID must be non-blank and contain 1..256 UTF-8 bytes."
+        }
+    }
+
+    override fun equals(other: Any?): Boolean = other is FencingOwnerId && value == other.value
+
+    override fun hashCode(): Int = value.hashCode()
+
+    override fun toString(): String = "FencingOwnerId(<redacted>)"
+
+    private fun readResolve(): Any = restoreFencingSerializedValue("FencingOwnerId") {
+        FencingOwnerId(value)
+    }
+
+    companion object {
+        private const val serialVersionUID: Long = 1L
+        private const val MAX_UTF8_BYTES = 256
+        private const val RANDOM_LENGTH = 22
+
+        /** Creates a cryptographically strong random owner ID for a new logical acquisition attempt. */
+        fun random(): FencingOwnerId = FencingOwnerId(Base58.randomString(RANDOM_LENGTH))
+
+        /**
+         * Creates an owner ID from an externally managed acquisition-attempt identifier.
+         *
+         * The caller remains responsible for global collision resistance, secrecy, and safe persistence.
+         */
+        fun from(value: String): FencingOwnerId = FencingOwnerId(value)
+    }
+}
+
+/**
+ * Monotonic fencing token ordered lexicographically by [epoch] and then [sequence].
+ *
+ * The numeric tuple is intentionally excluded from [toString]. Downstream systems must persist the tuple together
+ * with stable resource identity and reject tokens that are not strictly greater than the last accepted token.
+ *
+ * @property epoch positive ordering-domain generation
+ * @property sequence positive sequence allocated within [epoch]
+ */
+data class FencingToken(
+    val epoch: Long,
+    val sequence: Long,
+): Comparable<FencingToken>, Serializable {
+    init {
+        epoch.requirePositiveNumber("epoch")
+        sequence.requirePositiveNumber("sequence")
+    }
+
+    override fun compareTo(other: FencingToken): Int {
+        val epochComparison = epoch.compareTo(other.epoch)
+        return if (epochComparison != 0) epochComparison else sequence.compareTo(other.sequence)
+    }
+
+    override fun toString(): String = "FencingToken(<redacted>)"
+
+    private fun readResolve(): Any = restoreFencingSerializedValue("FencingToken") {
+        FencingToken(epoch, sequence)
+    }
+
+    private companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal fun <T> restoreFencingSerializedValue(
+    typeName: String,
+    factory: () -> T,
+): T = try {
+    factory()
+} catch (_: IllegalArgumentException) {
+    invalidSerializedFencingValue(typeName)
+} catch (_: NullPointerException) {
+    invalidSerializedFencingValue(typeName)
+}
+
+private fun invalidSerializedFencingValue(typeName: String): Nothing =
+    throw InvalidObjectException("Invalid serialized $typeName.")

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseValue.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseValue.kt
@@ -10,7 +10,8 @@ import java.nio.charset.StandardCharsets
  * Identifies one Redis fencing-token ordering domain.
  *
  * Tokens are comparable only within the same [namespace] and [resourceName]. The [epoch] must be allocated by a
- * durable external authority and must never be lowered during rollback or recovery.
+ * durable external authority and must not be lowered during rollback or recovery. One config instance binds every
+ * operation to the same derived lease/counter keys; the encoded keys are validated to share one Redis Cluster slot.
  *
  * @property namespace stable namespace used to derive the Redis Cluster hash tag
  * @property resourceName stable logical resource name used to derive the Redis Cluster hash tag
@@ -44,8 +45,9 @@ data class LettuceFencingLeaseConfig(
 /**
  * Opaque identifier for one logical fencing-lease acquisition attempt.
  *
- * Reuse an owner ID only when reconciling an ambiguous response from the same logical attempt. The raw value is
- * intentionally excluded from [toString].
+ * The identifier is an ownership capability, not a fencing token. Reuse the same owner ID only when reconciling an
+ * ambiguous response from the same logical acquisition attempt; a new owner ID cannot recover that active lease.
+ * The raw value is intentionally excluded from [toString].
  */
 class FencingOwnerId private constructor(
     internal val value: String,
@@ -57,16 +59,20 @@ class FencingOwnerId private constructor(
         }
     }
 
+    /** Compares owner IDs by their opaque value. */
     override fun equals(other: Any?): Boolean = other is FencingOwnerId && value == other.value
 
+    /** Returns a hash derived from the opaque owner-ID value. */
     override fun hashCode(): Int = value.hashCode()
 
+    /** Returns a redacted representation that never exposes the owner-ID value. */
     override fun toString(): String = "FencingOwnerId(<redacted>)"
 
     private fun readResolve(): Any = restoreFencingSerializedValue("FencingOwnerId") {
         FencingOwnerId(value)
     }
 
+    /** Creates owner IDs for new or externally identified logical acquisition attempts. */
     companion object {
         private const val serialVersionUID: Long = 1L
         private const val MAX_UTF8_BYTES = 256
@@ -87,8 +93,9 @@ class FencingOwnerId private constructor(
 /**
  * Monotonic fencing token ordered lexicographically by [epoch] and then [sequence].
  *
- * The numeric tuple is intentionally excluded from [toString]. Downstream systems must persist the tuple together
- * with stable resource identity and reject tokens that are not strictly greater than the last accepted token.
+ * The token deliberately carries no namespace, resource name, or other domain identity. The numeric tuple is
+ * intentionally excluded from [toString]. Downstream systems must persist it together with stable resource identity
+ * and use a strict tuple guard that rejects tokens that are not strictly greater than the last accepted token.
  *
  * @property epoch positive ordering-domain generation
  * @property sequence positive sequence allocated within [epoch]
@@ -102,11 +109,13 @@ data class FencingToken(
         sequence.requirePositiveNumber("sequence")
     }
 
+    /** Compares tokens lexicographically by epoch and then sequence. */
     override fun compareTo(other: FencingToken): Int {
         val epochComparison = epoch.compareTo(other.epoch)
         return if (epochComparison != 0) epochComparison else sequence.compareTo(other.sequence)
     }
 
+    /** Returns a redacted representation that never exposes the token tuple. */
     override fun toString(): String = "FencingToken(<redacted>)"
 
     private fun readResolve(): Any = restoreFencingSerializedValue("FencingToken") {

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLease.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLease.kt
@@ -10,7 +10,9 @@ import java.util.concurrent.CompletableFuture
  * Provides blocking and [CompletableFuture]-based access to one Redis fencing-lease ordering domain.
  *
  * A fencing token proves ordering, not durable business correctness. Persist every accepted token together with the
- * resource identity and reject downstream writes whose token is not strictly greater than the stored token.
+ * resource identity and reject downstream writes whose token is not strictly greater than the stored token. Redis Lua
+ * serializes acquisition for a hot resource, but exactly-once work and business idempotency remain caller concerns.
+ * The supplied config binds the instance to one namespace, resource, and durable epoch.
  */
 class LettuceFencingLease private constructor(
     private val executor: FencingScriptExecutor,
@@ -19,19 +21,19 @@ class LettuceFencingLease private constructor(
 ) {
     private val keys: FencingLeaseKeys = deriveFencingLeaseKeys(config, codec)
 
-    /** Creates a fencing lease over a standalone Redis connection. */
+    /** Creates a config-bound fencing lease after validating that encoded lease/counter keys share one slot. */
     constructor(
         connection: StatefulRedisConnection<String, String>,
         config: LettuceFencingLeaseConfig,
     ): this(DefaultFencingScriptExecutor(connection.sync(), connection.async()), connection.codec, config)
 
-    /** Creates a fencing lease over a Redis Cluster connection after validating the encoded key slot. */
+    /** Creates a Redis Cluster fencing lease after validating the codec-produced lease/counter key slot. */
     constructor(
         connection: StatefulRedisClusterConnection<String, String>,
         config: LettuceFencingLeaseConfig,
     ): this(DefaultFencingScriptExecutor(connection.sync(), connection.async()), connection.codec, config)
 
-    /** Initializes the counter for a new, externally approved epoch without repairing old history. */
+    /** Initializes a new externally approved epoch; this never reconstructs or repairs lost same-epoch history. */
     fun bootstrap(): FencingBootstrapResult = classified(
         FencingLeaseOperation.BOOTSTRAP,
         FencingBootstrapResult::BackendFailure,
@@ -39,7 +41,7 @@ class LettuceFencingLease private constructor(
         decodeFencingBootstrap(executor.run(FencingLeaseOperation.BOOTSTRAP, keys, fencingBootstrapArgs(config)))
     }
 
-    /** Asynchronously initializes the counter for a new, externally approved epoch. */
+    /** Asynchronously initializes a new externally approved epoch without repairing lost history. */
     fun bootstrapAsync(): CompletableFuture<FencingBootstrapResult> =
         executor.runAsync(FencingLeaseOperation.BOOTSTRAP, keys, fencingBootstrapArgs(config))
             .decodeCancellable(
@@ -49,7 +51,7 @@ class LettuceFencingLease private constructor(
                 FencingBootstrapResult::BackendFailure,
             )
 
-    /** Acquires the lease or reports the active competing owner without exposing its identity. */
+    /** Acquires the lease; retry ambiguous completion only with the same [ownerId]. */
     fun acquire(ownerId: FencingOwnerId, leaseTime: Duration): FencingAcquireResult {
         val leaseTimeMillis = leaseTime.validatedFencingLeaseTimeMillis()
         return classified(FencingLeaseOperation.ACQUIRE, FencingAcquireResult::BackendFailure) {
@@ -59,7 +61,11 @@ class LettuceFencingLease private constructor(
         }
     }
 
-    /** Asynchronously acquires the lease while preserving cancellation of the active Redis command. */
+    /**
+     * Asynchronously acquires the lease while preserving cancellation of the active Redis command.
+     *
+     * Cancellation does not prove that Redis skipped the mutation; reconcile with the same [ownerId].
+     */
     fun acquireAsync(
         ownerId: FencingOwnerId,
         leaseTime: Duration,
@@ -77,7 +83,7 @@ class LettuceFencingLease private constructor(
         )
     }
 
-    /** Inspects current ownership without extending the lease TTL. */
+    /** Inspects current ownership without extending TTL or mutating the counter. */
     fun inspect(ownerId: FencingOwnerId): FencingInspectResult = classified(
         FencingLeaseOperation.INSPECT,
         FencingInspectResult::BackendFailure,
@@ -85,7 +91,7 @@ class LettuceFencingLease private constructor(
         decodeFencingInspect(executor.run(FencingLeaseOperation.INSPECT, keys, fencingInspectArgs(config, ownerId)))
     }
 
-    /** Asynchronously inspects current ownership without extending the lease TTL. */
+    /** Asynchronously inspects current ownership without extending TTL or mutating the counter. */
     fun inspectAsync(ownerId: FencingOwnerId): CompletableFuture<FencingInspectResult> =
         executor.runAsync(
             FencingLeaseOperation.INSPECT,
@@ -98,7 +104,7 @@ class LettuceFencingLease private constructor(
             FencingInspectResult::BackendFailure,
         )
 
-    /** Renews the lease only when both owner ID and fencing token still match. */
+    /** Renews only the matching owner/token; a cross-epoch token is rejected before Redis dispatch. */
     fun renew(
         ownerId: FencingOwnerId,
         token: FencingToken,
@@ -113,7 +119,7 @@ class LettuceFencingLease private constructor(
         }
     }
 
-    /** Asynchronously renews the lease only when both owner ID and fencing token still match. */
+    /** Asynchronously renews the matching owner/token and rejects a cross-epoch token before dispatch. */
     fun renewAsync(
         ownerId: FencingOwnerId,
         token: FencingToken,
@@ -133,7 +139,7 @@ class LettuceFencingLease private constructor(
         )
     }
 
-    /** Releases the lease only when both owner ID and fencing token still match. */
+    /** Releases only the matching owner/token; a cross-epoch token is rejected before Redis dispatch. */
     fun release(ownerId: FencingOwnerId, token: FencingToken): FencingReleaseResult {
         requireFencingTokenEpoch(config, token)
         return classified(FencingLeaseOperation.RELEASE, FencingReleaseResult::BackendFailure) {
@@ -141,7 +147,7 @@ class LettuceFencingLease private constructor(
         }
     }
 
-    /** Asynchronously releases the lease only when both owner ID and fencing token still match. */
+    /** Asynchronously releases the matching owner/token and rejects a cross-epoch token before dispatch. */
     fun releaseAsync(
         ownerId: FencingOwnerId,
         token: FencingToken,
@@ -170,7 +176,7 @@ class LettuceFencingLease private constructor(
     }
 
     internal companion object {
-        fun createForTesting(
+        internal fun createForTesting(
             executor: FencingScriptExecutor,
             codec: RedisCodec<String, String>,
             config: LettuceFencingLeaseConfig,

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLease.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLease.kt
@@ -1,0 +1,194 @@
+package io.bluetape4k.redis.lettuce.lease
+
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.async.RedisScriptingAsyncCommands
+import io.lettuce.core.api.sync.RedisScriptingCommands
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
+import io.lettuce.core.codec.RedisCodec
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Provides blocking and [CompletableFuture]-based access to one Redis fencing-lease ordering domain.
+ *
+ * A fencing token proves ordering, not durable business correctness. Persist every accepted token together with the
+ * resource identity and reject downstream writes whose token is not strictly greater than the stored token.
+ */
+class LettuceFencingLease private constructor(
+    private val syncCommands: RedisScriptingCommands<String, String>,
+    private val asyncCommands: RedisScriptingAsyncCommands<String, String>,
+    codec: RedisCodec<String, String>,
+    private val config: LettuceFencingLeaseConfig,
+) {
+    private val keys: FencingLeaseKeys = deriveFencingLeaseKeys(config, codec)
+
+    /** Creates a fencing lease over a standalone Redis connection. */
+    constructor(
+        connection: StatefulRedisConnection<String, String>,
+        config: LettuceFencingLeaseConfig,
+    ): this(connection.sync(), connection.async(), connection.codec, config)
+
+    /** Creates a fencing lease over a Redis Cluster connection after validating the encoded key slot. */
+    constructor(
+        connection: StatefulRedisClusterConnection<String, String>,
+        config: LettuceFencingLeaseConfig,
+    ): this(connection.sync(), connection.async(), connection.codec, config)
+
+    /** Initializes the counter for a new, externally approved epoch without repairing old history. */
+    fun bootstrap(): FencingBootstrapResult = classified(
+        FencingLeaseOperation.BOOTSTRAP,
+        FencingBootstrapResult::BackendFailure,
+    ) {
+        runFencingBootstrap(syncCommands, keys, config)
+    }
+
+    /** Asynchronously initializes the counter for a new, externally approved epoch. */
+    fun bootstrapAsync(): CompletableFuture<FencingBootstrapResult> =
+        runFencingScriptAsync(asyncCommands, FencingLeaseScripts.BOOTSTRAP, keys, config.epoch.toString())
+            .decodeCancellable(
+                FencingLeaseOperation.BOOTSTRAP,
+                config::domainFingerprint,
+                ::decodeFencingBootstrap,
+                FencingBootstrapResult::BackendFailure,
+            )
+
+    /** Acquires the lease or reports the active competing owner without exposing its identity. */
+    fun acquire(ownerId: FencingOwnerId, leaseTime: Duration): FencingAcquireResult {
+        val leaseTimeMillis = leaseTime.validatedFencingLeaseTimeMillis()
+        return classified(FencingLeaseOperation.ACQUIRE, FencingAcquireResult::BackendFailure) {
+            runFencingAcquire(syncCommands, keys, config, ownerId, leaseTimeMillis)
+        }
+    }
+
+    /** Asynchronously acquires the lease while preserving cancellation of the active Redis command. */
+    fun acquireAsync(
+        ownerId: FencingOwnerId,
+        leaseTime: Duration,
+    ): CompletableFuture<FencingAcquireResult> {
+        val leaseTimeMillis = leaseTime.validatedFencingLeaseTimeMillis()
+        return runFencingScriptAsync(
+            asyncCommands,
+            FencingLeaseScripts.ACQUIRE,
+            keys,
+            ownerId.value,
+            config.epoch.toString(),
+            leaseTimeMillis.toString(),
+        ).decodeCancellable(
+            FencingLeaseOperation.ACQUIRE,
+            config::domainFingerprint,
+            ::decodeFencingAcquire,
+            FencingAcquireResult::BackendFailure,
+        )
+    }
+
+    /** Inspects current ownership without extending the lease TTL. */
+    fun inspect(ownerId: FencingOwnerId): FencingInspectResult = classified(
+        FencingLeaseOperation.INSPECT,
+        FencingInspectResult::BackendFailure,
+    ) {
+        runFencingInspect(syncCommands, keys, config, ownerId)
+    }
+
+    /** Asynchronously inspects current ownership without extending the lease TTL. */
+    fun inspectAsync(ownerId: FencingOwnerId): CompletableFuture<FencingInspectResult> =
+        runFencingScriptAsync(
+            asyncCommands,
+            FencingLeaseScripts.INSPECT,
+            keys,
+            ownerId.value,
+            config.epoch.toString(),
+        ).decodeCancellable(
+            FencingLeaseOperation.INSPECT,
+            config::domainFingerprint,
+            ::decodeFencingInspect,
+            FencingInspectResult::BackendFailure,
+        )
+
+    /** Renews the lease only when both owner ID and fencing token still match. */
+    fun renew(
+        ownerId: FencingOwnerId,
+        token: FencingToken,
+        leaseTime: Duration,
+    ): FencingRenewResult {
+        requireFencingTokenEpoch(config, token)
+        val leaseTimeMillis = leaseTime.validatedFencingLeaseTimeMillis()
+        return classified(FencingLeaseOperation.RENEW, FencingRenewResult::BackendFailure) {
+            runFencingRenew(syncCommands, keys, config, ownerId, token, leaseTimeMillis)
+        }
+    }
+
+    /** Asynchronously renews the lease only when both owner ID and fencing token still match. */
+    fun renewAsync(
+        ownerId: FencingOwnerId,
+        token: FencingToken,
+        leaseTime: Duration,
+    ): CompletableFuture<FencingRenewResult> {
+        requireFencingTokenEpoch(config, token)
+        val leaseTimeMillis = leaseTime.validatedFencingLeaseTimeMillis()
+        return runFencingScriptAsync(
+            asyncCommands,
+            FencingLeaseScripts.RENEW,
+            keys,
+            ownerId.value,
+            token.epoch.toString(),
+            token.sequence.toString(),
+            leaseTimeMillis.toString(),
+        ).decodeCancellable(
+            FencingLeaseOperation.RENEW,
+            config::domainFingerprint,
+            ::decodeFencingRenew,
+            FencingRenewResult::BackendFailure,
+        )
+    }
+
+    /** Releases the lease only when both owner ID and fencing token still match. */
+    fun release(ownerId: FencingOwnerId, token: FencingToken): FencingReleaseResult {
+        requireFencingTokenEpoch(config, token)
+        return classified(FencingLeaseOperation.RELEASE, FencingReleaseResult::BackendFailure) {
+            runFencingRelease(syncCommands, keys, config, ownerId, token)
+        }
+    }
+
+    /** Asynchronously releases the lease only when both owner ID and fencing token still match. */
+    fun releaseAsync(
+        ownerId: FencingOwnerId,
+        token: FencingToken,
+    ): CompletableFuture<FencingReleaseResult> {
+        requireFencingTokenEpoch(config, token)
+        return runFencingScriptAsync(
+            asyncCommands,
+            FencingLeaseScripts.RELEASE,
+            keys,
+            ownerId.value,
+            token.epoch.toString(),
+            token.sequence.toString(),
+        ).decodeCancellable(
+            FencingLeaseOperation.RELEASE,
+            config::domainFingerprint,
+            ::decodeFencingRelease,
+            FencingReleaseResult::BackendFailure,
+        )
+    }
+
+    private inline fun <R> classified(
+        operation: FencingLeaseOperation,
+        backendFailure: (FencingLeaseBackendFailure) -> R,
+        block: () -> R,
+    ): R = try {
+        block()
+    } catch (error: Exception) {
+        backendFailure(classifyFencingBackendFailure(operation, error, config::domainFingerprint))
+    }
+
+    internal companion object {
+        fun fromCommands(
+            syncCommands: RedisScriptingCommands<String, String>,
+            asyncCommands: RedisScriptingAsyncCommands<String, String>,
+            codec: RedisCodec<String, String>,
+            config: LettuceFencingLeaseConfig,
+        ): LettuceFencingLease = LettuceFencingLease(syncCommands, asyncCommands, codec, config)
+    }
+}
+
+internal fun Duration.validatedFencingLeaseTimeMillis(): Long =
+    requireFencingLeaseMillis().requireRedisFencingLeaseTimeMillis()

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLease.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLease.kt
@@ -1,8 +1,6 @@
 package io.bluetape4k.redis.lettuce.lease
 
 import io.lettuce.core.api.StatefulRedisConnection
-import io.lettuce.core.api.async.RedisScriptingAsyncCommands
-import io.lettuce.core.api.sync.RedisScriptingCommands
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
 import io.lettuce.core.codec.RedisCodec
 import java.time.Duration
@@ -15,8 +13,7 @@ import java.util.concurrent.CompletableFuture
  * resource identity and reject downstream writes whose token is not strictly greater than the stored token.
  */
 class LettuceFencingLease private constructor(
-    private val syncCommands: RedisScriptingCommands<String, String>,
-    private val asyncCommands: RedisScriptingAsyncCommands<String, String>,
+    private val executor: FencingScriptExecutor,
     codec: RedisCodec<String, String>,
     private val config: LettuceFencingLeaseConfig,
 ) {
@@ -26,25 +23,25 @@ class LettuceFencingLease private constructor(
     constructor(
         connection: StatefulRedisConnection<String, String>,
         config: LettuceFencingLeaseConfig,
-    ): this(connection.sync(), connection.async(), connection.codec, config)
+    ): this(DefaultFencingScriptExecutor(connection.sync(), connection.async()), connection.codec, config)
 
     /** Creates a fencing lease over a Redis Cluster connection after validating the encoded key slot. */
     constructor(
         connection: StatefulRedisClusterConnection<String, String>,
         config: LettuceFencingLeaseConfig,
-    ): this(connection.sync(), connection.async(), connection.codec, config)
+    ): this(DefaultFencingScriptExecutor(connection.sync(), connection.async()), connection.codec, config)
 
     /** Initializes the counter for a new, externally approved epoch without repairing old history. */
     fun bootstrap(): FencingBootstrapResult = classified(
         FencingLeaseOperation.BOOTSTRAP,
         FencingBootstrapResult::BackendFailure,
     ) {
-        runFencingBootstrap(syncCommands, keys, config)
+        decodeFencingBootstrap(executor.run(FencingLeaseOperation.BOOTSTRAP, keys, fencingBootstrapArgs(config)))
     }
 
     /** Asynchronously initializes the counter for a new, externally approved epoch. */
     fun bootstrapAsync(): CompletableFuture<FencingBootstrapResult> =
-        runFencingScriptAsync(asyncCommands, FencingLeaseScripts.BOOTSTRAP, keys, config.epoch.toString())
+        executor.runAsync(FencingLeaseOperation.BOOTSTRAP, keys, fencingBootstrapArgs(config))
             .decodeCancellable(
                 FencingLeaseOperation.BOOTSTRAP,
                 config::domainFingerprint,
@@ -56,7 +53,9 @@ class LettuceFencingLease private constructor(
     fun acquire(ownerId: FencingOwnerId, leaseTime: Duration): FencingAcquireResult {
         val leaseTimeMillis = leaseTime.validatedFencingLeaseTimeMillis()
         return classified(FencingLeaseOperation.ACQUIRE, FencingAcquireResult::BackendFailure) {
-            runFencingAcquire(syncCommands, keys, config, ownerId, leaseTimeMillis)
+            decodeFencingAcquire(
+                executor.run(FencingLeaseOperation.ACQUIRE, keys, fencingAcquireArgs(config, ownerId, leaseTimeMillis)),
+            )
         }
     }
 
@@ -66,13 +65,10 @@ class LettuceFencingLease private constructor(
         leaseTime: Duration,
     ): CompletableFuture<FencingAcquireResult> {
         val leaseTimeMillis = leaseTime.validatedFencingLeaseTimeMillis()
-        return runFencingScriptAsync(
-            asyncCommands,
-            FencingLeaseScripts.ACQUIRE,
+        return executor.runAsync(
+            FencingLeaseOperation.ACQUIRE,
             keys,
-            ownerId.value,
-            config.epoch.toString(),
-            leaseTimeMillis.toString(),
+            fencingAcquireArgs(config, ownerId, leaseTimeMillis),
         ).decodeCancellable(
             FencingLeaseOperation.ACQUIRE,
             config::domainFingerprint,
@@ -86,17 +82,15 @@ class LettuceFencingLease private constructor(
         FencingLeaseOperation.INSPECT,
         FencingInspectResult::BackendFailure,
     ) {
-        runFencingInspect(syncCommands, keys, config, ownerId)
+        decodeFencingInspect(executor.run(FencingLeaseOperation.INSPECT, keys, fencingInspectArgs(config, ownerId)))
     }
 
     /** Asynchronously inspects current ownership without extending the lease TTL. */
     fun inspectAsync(ownerId: FencingOwnerId): CompletableFuture<FencingInspectResult> =
-        runFencingScriptAsync(
-            asyncCommands,
-            FencingLeaseScripts.INSPECT,
+        executor.runAsync(
+            FencingLeaseOperation.INSPECT,
             keys,
-            ownerId.value,
-            config.epoch.toString(),
+            fencingInspectArgs(config, ownerId),
         ).decodeCancellable(
             FencingLeaseOperation.INSPECT,
             config::domainFingerprint,
@@ -113,7 +107,9 @@ class LettuceFencingLease private constructor(
         requireFencingTokenEpoch(config, token)
         val leaseTimeMillis = leaseTime.validatedFencingLeaseTimeMillis()
         return classified(FencingLeaseOperation.RENEW, FencingRenewResult::BackendFailure) {
-            runFencingRenew(syncCommands, keys, config, ownerId, token, leaseTimeMillis)
+            decodeFencingRenew(
+                executor.run(FencingLeaseOperation.RENEW, keys, fencingRenewArgs(ownerId, token, leaseTimeMillis)),
+            )
         }
     }
 
@@ -125,14 +121,10 @@ class LettuceFencingLease private constructor(
     ): CompletableFuture<FencingRenewResult> {
         requireFencingTokenEpoch(config, token)
         val leaseTimeMillis = leaseTime.validatedFencingLeaseTimeMillis()
-        return runFencingScriptAsync(
-            asyncCommands,
-            FencingLeaseScripts.RENEW,
+        return executor.runAsync(
+            FencingLeaseOperation.RENEW,
             keys,
-            ownerId.value,
-            token.epoch.toString(),
-            token.sequence.toString(),
-            leaseTimeMillis.toString(),
+            fencingRenewArgs(ownerId, token, leaseTimeMillis),
         ).decodeCancellable(
             FencingLeaseOperation.RENEW,
             config::domainFingerprint,
@@ -145,7 +137,7 @@ class LettuceFencingLease private constructor(
     fun release(ownerId: FencingOwnerId, token: FencingToken): FencingReleaseResult {
         requireFencingTokenEpoch(config, token)
         return classified(FencingLeaseOperation.RELEASE, FencingReleaseResult::BackendFailure) {
-            runFencingRelease(syncCommands, keys, config, ownerId, token)
+            decodeFencingRelease(executor.run(FencingLeaseOperation.RELEASE, keys, fencingReleaseArgs(ownerId, token)))
         }
     }
 
@@ -155,13 +147,10 @@ class LettuceFencingLease private constructor(
         token: FencingToken,
     ): CompletableFuture<FencingReleaseResult> {
         requireFencingTokenEpoch(config, token)
-        return runFencingScriptAsync(
-            asyncCommands,
-            FencingLeaseScripts.RELEASE,
+        return executor.runAsync(
+            FencingLeaseOperation.RELEASE,
             keys,
-            ownerId.value,
-            token.epoch.toString(),
-            token.sequence.toString(),
+            fencingReleaseArgs(ownerId, token),
         ).decodeCancellable(
             FencingLeaseOperation.RELEASE,
             config::domainFingerprint,
@@ -181,12 +170,11 @@ class LettuceFencingLease private constructor(
     }
 
     internal companion object {
-        fun fromCommands(
-            syncCommands: RedisScriptingCommands<String, String>,
-            asyncCommands: RedisScriptingAsyncCommands<String, String>,
+        fun createForTesting(
+            executor: FencingScriptExecutor,
             codec: RedisCodec<String, String>,
             config: LettuceFencingLeaseConfig,
-        ): LettuceFencingLease = LettuceFencingLease(syncCommands, asyncCommands, codec, config)
+        ): LettuceFencingLease = LettuceFencingLease(executor, codec, config)
     }
 }
 

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupport.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupport.kt
@@ -2,9 +2,14 @@ package io.bluetape4k.redis.lettuce.lease
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.warn
+import io.bluetape4k.redis.lettuce.script.RedisScript
+import io.bluetape4k.redis.lettuce.script.RedisScriptRunner
+import io.bluetape4k.support.requirePositiveNumber
 import io.lettuce.core.RedisCommandTimeoutException
 import io.lettuce.core.RedisConnectionException
 import io.lettuce.core.RedisException
+import io.lettuce.core.ScriptOutputType
+import io.lettuce.core.api.sync.RedisScriptingCommands
 import io.lettuce.core.cluster.SlotHash
 import io.lettuce.core.codec.RedisCodec
 import java.security.MessageDigest
@@ -93,6 +98,14 @@ internal fun Duration.requireFencingLeaseMillis(): Long {
     }
     require(millis > 0 && this == Duration.ofMillis(millis)) { INVALID_LEASE_TIME_MESSAGE }
     return millis
+}
+
+internal fun Long.requireRedisFencingLeaseTimeMillis(): Long {
+    requirePositiveNumber("leaseTimeMillis")
+    require(this <= MAX_EXACT_REDIS_LEASE_TIME_MILLIS) {
+        "leaseTimeMillis exceeds the exact Redis Lua integer range."
+    }
+    return this
 }
 
 internal fun requireFencingTokenEpoch(
@@ -240,6 +253,105 @@ internal fun decodeFencingRelease(frame: List<String>): FencingReleaseResult {
     }
 }
 
+internal fun runFencingBootstrap(
+    commands: RedisScriptingCommands<String, String>,
+    keys: FencingLeaseKeys,
+    config: LettuceFencingLeaseConfig,
+): FencingBootstrapResult = decodeFencingBootstrap(
+    runFencingScript(commands, FencingLeaseScripts.BOOTSTRAP, keys, config.epoch.toString()),
+)
+
+internal fun runFencingAcquire(
+    commands: RedisScriptingCommands<String, String>,
+    keys: FencingLeaseKeys,
+    config: LettuceFencingLeaseConfig,
+    ownerId: FencingOwnerId,
+    leaseTimeMillis: Long,
+): FencingAcquireResult {
+    leaseTimeMillis.requireRedisFencingLeaseTimeMillis()
+    return decodeFencingAcquire(
+        runFencingScript(
+            commands,
+            FencingLeaseScripts.ACQUIRE,
+            keys,
+            ownerId.value,
+            config.epoch.toString(),
+            leaseTimeMillis.toString(),
+        ),
+    )
+}
+
+internal fun runFencingInspect(
+    commands: RedisScriptingCommands<String, String>,
+    keys: FencingLeaseKeys,
+    config: LettuceFencingLeaseConfig,
+    ownerId: FencingOwnerId,
+): FencingInspectResult = decodeFencingInspect(
+    runFencingScript(
+        commands,
+        FencingLeaseScripts.INSPECT,
+        keys,
+        ownerId.value,
+        config.epoch.toString(),
+    ),
+)
+
+internal fun runFencingRenew(
+    commands: RedisScriptingCommands<String, String>,
+    keys: FencingLeaseKeys,
+    config: LettuceFencingLeaseConfig,
+    ownerId: FencingOwnerId,
+    token: FencingToken,
+    leaseTimeMillis: Long,
+): FencingRenewResult {
+    requireFencingTokenEpoch(config, token)
+    leaseTimeMillis.requireRedisFencingLeaseTimeMillis()
+    return decodeFencingRenew(
+        runFencingScript(
+            commands,
+            FencingLeaseScripts.RENEW,
+            keys,
+            ownerId.value,
+            token.epoch.toString(),
+            token.sequence.toString(),
+            leaseTimeMillis.toString(),
+        ),
+    )
+}
+
+internal fun runFencingRelease(
+    commands: RedisScriptingCommands<String, String>,
+    keys: FencingLeaseKeys,
+    config: LettuceFencingLeaseConfig,
+    ownerId: FencingOwnerId,
+    token: FencingToken,
+): FencingReleaseResult {
+    requireFencingTokenEpoch(config, token)
+    return decodeFencingRelease(
+        runFencingScript(
+            commands,
+            FencingLeaseScripts.RELEASE,
+            keys,
+            ownerId.value,
+            token.epoch.toString(),
+            token.sequence.toString(),
+        ),
+    )
+}
+
+private fun runFencingScript(
+    commands: RedisScriptingCommands<String, String>,
+    script: RedisScript,
+    keys: FencingLeaseKeys,
+    vararg arguments: String,
+): List<String> = RedisScriptRunner.run(
+    commands,
+    script,
+    ScriptOutputType.MULTI,
+    arrayOf(keys.lease, keys.counter),
+    *arguments,
+)
+
 private data class DecodedFencingFrame(
     val status: String,
     val value1: String,
@@ -320,4 +432,258 @@ private const val UNUSED_TTL = "-1"
 private const val MAX_COMPLETION_DEPTH = 8
 private const val DOMAIN_FINGERPRINT_BYTES = 12
 private const val INVALID_LEASE_TIME_MESSAGE = "leaseTime must fit positive whole milliseconds."
+internal const val MAX_EXACT_REDIS_LEASE_TIME_MILLIS = 9_007_199_254_740_991L
 private val MAX_LONG_DECIMAL = Long.MAX_VALUE.toString()
+
+internal object FencingLeaseScripts {
+    val BOOTSTRAP = RedisScript(
+        COMMON_FENCING_PREFLIGHT +
+            """
+
+            local lease = readLease(ARGV[1])
+            if lease.failure then
+              return integrityFailure(lease.failure)
+            end
+            if lease.present then
+              return {'ALREADY_INITIALIZED', '0', '0', '-1'}
+            end
+
+            local counter = readCounter()
+            if counter.failure then
+              return integrityFailure(counter.failure)
+            end
+            if counter.present then
+              return {'ALREADY_INITIALIZED', '0', '0', '-1'}
+            end
+
+            redis.call('SET', counterKey, '0')
+            return {'INITIALIZED', '0', '0', '-1'}
+            """.trimIndent(),
+    )
+
+    val ACQUIRE = RedisScript(
+        COMMON_FENCING_PREFLIGHT +
+            """
+
+            if not isValidLeaseTime(ARGV[3]) then
+              return {'INVALID_ARGUMENT', '0', '0', '-1'}
+            end
+            local lease = readLease(ARGV[2])
+            if lease.failure then
+              return integrityFailure(lease.failure)
+            end
+            if lease.present then
+              if lease.owner == ARGV[1] then
+                return {'ALREADY_OWNED', lease.epoch, lease.sequence, formatInteger(lease.ttl)}
+              end
+              return {'CONTENDED', '0', '0', formatInteger(lease.ttl)}
+            end
+
+            local counter = readCounter()
+            if counter.failure then
+              return integrityFailure(counter.failure)
+            end
+            if not counter.present then
+              return {'COUNTER_UNAVAILABLE', '0', '0', '-1'}
+            end
+            if counter.text == MAX_LONG_DECIMAL then
+              return {'SEQUENCE_EXHAUSTED', '0', '0', '-1'}
+            end
+
+            local nextSequence = redis.call('INCR', counterKey)
+            local nextSequenceText = redis.call('GET', counterKey)
+            redis.call('HSET', leaseKey,
+              'owner', ARGV[1],
+              'epoch', ARGV[2],
+              'sequence', nextSequenceText)
+            redis.call('PEXPIRE', leaseKey, ARGV[3])
+            return {'ACQUIRED', ARGV[2], nextSequenceText, '-1'}
+            """.trimIndent(),
+    )
+
+    val INSPECT = RedisScript(
+        COMMON_FENCING_PREFLIGHT +
+            """
+
+            local lease = readLease(ARGV[2])
+            if lease.failure then
+              return integrityFailure(lease.failure)
+            end
+            if not lease.present then
+              return {'LOST', '0', '0', '-1'}
+            end
+            if lease.owner == ARGV[1] then
+              return {'OWNED', lease.epoch, lease.sequence, formatInteger(lease.ttl)}
+            end
+            return {'CONTENDED', '0', '0', formatInteger(lease.ttl)}
+            """.trimIndent(),
+    )
+
+    val RENEW = RedisScript(
+        COMMON_FENCING_PREFLIGHT +
+            """
+
+            if not isValidLeaseTime(ARGV[4]) then
+              return {'INVALID_ARGUMENT', '0', '0', '-1'}
+            end
+            local lease = readLease(ARGV[2])
+            if lease.failure then
+              return integrityFailure(lease.failure)
+            end
+            if not lease.present then
+              return {'LOST', '0', '0', '-1'}
+            end
+            if lease.owner ~= ARGV[1] or lease.epoch ~= ARGV[2] or lease.sequence ~= ARGV[3] then
+              return {'OWNERSHIP_MISMATCH', '0', '0', '-1'}
+            end
+
+            redis.call('PEXPIRE', leaseKey, ARGV[4])
+            return {'RENEWED', '0', '0', '-1'}
+            """.trimIndent(),
+    )
+
+    val RELEASE = RedisScript(
+        COMMON_FENCING_PREFLIGHT +
+            """
+
+            local lease = readLease(ARGV[2])
+            if lease.failure then
+              return integrityFailure(lease.failure)
+            end
+            if not lease.present then
+              return {'LOST', '0', '0', '-1'}
+            end
+            if lease.owner ~= ARGV[1] or lease.epoch ~= ARGV[2] or lease.sequence ~= ARGV[3] then
+              return {'OWNERSHIP_MISMATCH', '0', '0', '-1'}
+            end
+
+            redis.call('DEL', leaseKey)
+            return {'RELEASED', '0', '0', '-1'}
+            """.trimIndent(),
+    )
+}
+
+private const val COMMON_FENCING_PREFLIGHT = """
+local leaseKey = KEYS[1]
+local counterKey = KEYS[2]
+local MAX_LONG_DECIMAL = '9223372036854775807'
+local MAX_EXACT_LEASE_TIME = '9007199254740991'
+
+local function integrityFailure(kind)
+  return {'INTEGRITY_FAILURE', kind, '0', '-1'}
+end
+
+local function isCanonicalDecimal(value)
+  if value == '0' then
+    return true
+  end
+  if #value == 0 or #value > #MAX_LONG_DECIMAL then
+    return false
+  end
+  if string.match(value, '^[1-9][0-9]*$') == nil then
+    return false
+  end
+  return #value < #MAX_LONG_DECIMAL or value <= MAX_LONG_DECIMAL
+end
+
+local function compareCanonicalDecimals(left, right)
+  if #left ~= #right then
+    return #left < #right and -1 or 1
+  end
+  if left == right then
+    return 0
+  end
+  return left < right and -1 or 1
+end
+
+local function isValidLeaseTime(value)
+  return isCanonicalDecimal(value) and value ~= '0' and
+    compareCanonicalDecimals(value, MAX_EXACT_LEASE_TIME) <= 0
+end
+
+local function formatInteger(value)
+  return string.format('%.0f', value)
+end
+
+local function readCounter()
+  local counterType = redis.call('TYPE', counterKey).ok
+  if counterType == 'none' then
+    return {present = false}
+  end
+  if counterType ~= 'string' then
+    return {failure = 'INVALID_COUNTER'}
+  end
+
+  local counterTtl = redis.call('PTTL', counterKey)
+  if counterTtl ~= -1 then
+    return {failure = 'INVALID_COUNTER'}
+  end
+  if redis.call('STRLEN', counterKey) > #MAX_LONG_DECIMAL then
+    return {failure = 'INVALID_COUNTER'}
+  end
+
+  local counterText = redis.call('GET', counterKey)
+  if not isCanonicalDecimal(counterText) then
+    return {failure = 'INVALID_COUNTER'}
+  end
+  return {present = true, text = counterText}
+end
+
+local function readLease(expectedEpoch)
+  local leaseType = redis.call('TYPE', leaseKey).ok
+  if leaseType == 'none' then
+    return {present = false}
+  end
+  if leaseType ~= 'hash' then
+    return {failure = 'MALFORMED_LEASE'}
+  end
+
+  local leaseTtl = redis.call('PTTL', leaseKey)
+  if leaseTtl == -2 then
+    return {present = false}
+  end
+  if leaseTtl < 0 then
+    return {failure = 'MALFORMED_LEASE'}
+  end
+  if redis.call('HLEN', leaseKey) ~= 3 then
+    return {failure = 'MALFORMED_LEASE'}
+  end
+
+  local ownerLength = redis.call('HSTRLEN', leaseKey, 'owner')
+  local epochLength = redis.call('HSTRLEN', leaseKey, 'epoch')
+  local sequenceLength = redis.call('HSTRLEN', leaseKey, 'sequence')
+  if ownerLength < 1 or ownerLength > 256 or
+     epochLength < 1 or epochLength > #MAX_LONG_DECIMAL or
+     sequenceLength < 1 or sequenceLength > #MAX_LONG_DECIMAL then
+    return {failure = 'MALFORMED_LEASE'}
+  end
+
+  local fields = redis.call('HMGET', leaseKey, 'owner', 'epoch', 'sequence')
+  local owner = fields[1]
+  local epoch = fields[2]
+  local sequence = fields[3]
+  if not isCanonicalDecimal(epoch) or not isCanonicalDecimal(sequence) or
+     epoch == '0' or sequence == '0' or epoch ~= expectedEpoch then
+    return {failure = 'MALFORMED_LEASE'}
+  end
+
+  local counter = readCounter()
+  if counter.failure then
+    return {failure = counter.failure}
+  end
+  if not counter.present then
+    return {failure = 'INVALID_COUNTER'}
+  end
+  if compareCanonicalDecimals(counter.text, sequence) < 0 then
+    return {failure = 'COUNTER_BEHIND_LEASE'}
+  end
+
+  return {
+    present = true,
+    owner = owner,
+    epoch = epoch,
+    sequence = sequence,
+    ttl = leaseTtl
+  }
+end
+"""

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupport.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupport.kt
@@ -9,6 +9,7 @@ import io.lettuce.core.RedisCommandTimeoutException
 import io.lettuce.core.RedisConnectionException
 import io.lettuce.core.RedisException
 import io.lettuce.core.ScriptOutputType
+import io.lettuce.core.api.async.RedisScriptingAsyncCommands
 import io.lettuce.core.api.sync.RedisScriptingCommands
 import io.lettuce.core.cluster.SlotHash
 import io.lettuce.core.codec.RedisCodec
@@ -18,6 +19,7 @@ import java.util.Collections
 import java.util.HexFormat
 import java.util.IdentityHashMap
 import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeoutException
@@ -148,7 +150,7 @@ internal fun Throwable.unwrapFencingCompletionCause(): Throwable {
 internal fun classifyFencingBackendFailure(
     operation: FencingLeaseOperation,
     error: Throwable,
-    domainFingerprint: String? = null,
+    domainFingerprint: (() -> String)? = null,
 ): FencingLeaseBackendFailure {
     val cause = error.unwrapFencingCompletionCause()
     val kind = when (cause) {
@@ -164,7 +166,7 @@ internal fun classifyFencingBackendFailure(
             operation,
             failure,
             cause.javaClass.name,
-            domainFingerprint,
+            domainFingerprint?.invoke(),
         )
     }
 }
@@ -351,6 +353,69 @@ private fun runFencingScript(
     arrayOf(keys.lease, keys.counter),
     *arguments,
 )
+
+internal fun runFencingScriptAsync(
+    commands: RedisScriptingAsyncCommands<String, String>,
+    script: RedisScript,
+    keys: FencingLeaseKeys,
+    vararg arguments: String,
+): CompletableFuture<List<String>> = RedisScriptRunner.runAsync(
+    commands,
+    script,
+    ScriptOutputType.MULTI,
+    arrayOf(keys.lease, keys.counter),
+    *arguments,
+)
+
+internal suspend fun runFencingScriptSuspending(
+    commands: RedisScriptingAsyncCommands<String, String>,
+    script: RedisScript,
+    keys: FencingLeaseKeys,
+    vararg arguments: String,
+): List<String> = RedisScriptRunner.runSuspending(
+    commands,
+    script,
+    ScriptOutputType.MULTI,
+    arrayOf(keys.lease, keys.counter),
+    *arguments,
+)
+
+internal fun <R> CompletableFuture<List<String>>.decodeCancellable(
+    operation: FencingLeaseOperation,
+    domainFingerprint: () -> String,
+    decode: (List<String>) -> R,
+    backendFailure: (FencingLeaseBackendFailure) -> R,
+): CompletableFuture<R> {
+    val source = this
+    val mapped = object: CompletableFuture<R>() {
+        override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
+            val cancelled = super.cancel(mayInterruptIfRunning)
+            if (cancelled) {
+                source.cancel(mayInterruptIfRunning)
+            }
+            return cancelled
+        }
+    }
+    source.whenComplete { frame, error ->
+        when {
+            source.isCancelled -> mapped.cancel(false)
+            error != null -> try {
+                val failure = classifyFencingBackendFailure(operation, error, domainFingerprint)
+                mapped.complete(backendFailure(failure))
+            } catch (_: CancellationException) {
+                mapped.cancel(false)
+            } catch (failure: Throwable) {
+                mapped.completeExceptionally(failure)
+            }
+            else -> try {
+                mapped.complete(decode(frame))
+            } catch (failure: Throwable) {
+                mapped.completeExceptionally(failure)
+            }
+        }
+    }
+    return mapped
+}
 
 private data class DecodedFencingFrame(
     val status: String,

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupport.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupport.kt
@@ -37,6 +37,50 @@ internal enum class FencingLeaseOperation {
     RELEASE,
 }
 
+internal interface FencingScriptExecutor {
+    fun run(
+        operation: FencingLeaseOperation,
+        keys: FencingLeaseKeys,
+        args: List<String>,
+    ): List<String>
+
+    fun runAsync(
+        operation: FencingLeaseOperation,
+        keys: FencingLeaseKeys,
+        args: List<String>,
+    ): CompletableFuture<List<String>>
+
+    suspend fun runSuspending(
+        operation: FencingLeaseOperation,
+        keys: FencingLeaseKeys,
+        args: List<String>,
+    ): List<String>
+}
+
+internal class DefaultFencingScriptExecutor(
+    private val syncCommands: RedisScriptingCommands<String, String>,
+    private val asyncCommands: RedisScriptingAsyncCommands<String, String>,
+): FencingScriptExecutor {
+    override fun run(
+        operation: FencingLeaseOperation,
+        keys: FencingLeaseKeys,
+        args: List<String>,
+    ): List<String> = runFencingScript(syncCommands, operation.script, keys, *args.toTypedArray())
+
+    override fun runAsync(
+        operation: FencingLeaseOperation,
+        keys: FencingLeaseKeys,
+        args: List<String>,
+    ): CompletableFuture<List<String>> =
+        runFencingScriptAsync(asyncCommands, operation.script, keys, *args.toTypedArray())
+
+    override suspend fun runSuspending(
+        operation: FencingLeaseOperation,
+        keys: FencingLeaseKeys,
+        args: List<String>,
+    ): List<String> = runFencingScriptSuspending(asyncCommands, operation.script, keys, *args.toTypedArray())
+}
+
 internal class FencingLeaseProtocolException: IllegalStateException(
     "Malformed fencing lease response.",
 ) {
@@ -119,6 +163,29 @@ internal fun requireFencingTokenEpoch(
     }
     return token
 }
+
+internal fun fencingBootstrapArgs(config: LettuceFencingLeaseConfig): List<String> =
+    listOf(config.epoch.toString())
+
+internal fun fencingAcquireArgs(
+    config: LettuceFencingLeaseConfig,
+    ownerId: FencingOwnerId,
+    leaseTimeMillis: Long,
+): List<String> = listOf(ownerId.value, config.epoch.toString(), leaseTimeMillis.toString())
+
+internal fun fencingInspectArgs(
+    config: LettuceFencingLeaseConfig,
+    ownerId: FencingOwnerId,
+): List<String> = listOf(ownerId.value, config.epoch.toString())
+
+internal fun fencingRenewArgs(
+    ownerId: FencingOwnerId,
+    token: FencingToken,
+    leaseTimeMillis: Long,
+): List<String> = listOf(ownerId.value, token.epoch.toString(), token.sequence.toString(), leaseTimeMillis.toString())
+
+internal fun fencingReleaseArgs(ownerId: FencingOwnerId, token: FencingToken): List<String> =
+    listOf(ownerId.value, token.epoch.toString(), token.sequence.toString())
 
 internal fun Throwable.unwrapFencingCompletionCause(): Throwable {
     val seen = Collections.newSetFromMap(IdentityHashMap<Throwable, Boolean>())
@@ -260,7 +327,12 @@ internal fun runFencingBootstrap(
     keys: FencingLeaseKeys,
     config: LettuceFencingLeaseConfig,
 ): FencingBootstrapResult = decodeFencingBootstrap(
-    runFencingScript(commands, FencingLeaseScripts.BOOTSTRAP, keys, config.epoch.toString()),
+    runFencingScript(
+        commands,
+        FencingLeaseOperation.BOOTSTRAP.script,
+        keys,
+        *fencingBootstrapArgs(config).toTypedArray(),
+    ),
 )
 
 internal fun runFencingAcquire(
@@ -274,11 +346,9 @@ internal fun runFencingAcquire(
     return decodeFencingAcquire(
         runFencingScript(
             commands,
-            FencingLeaseScripts.ACQUIRE,
+            FencingLeaseOperation.ACQUIRE.script,
             keys,
-            ownerId.value,
-            config.epoch.toString(),
-            leaseTimeMillis.toString(),
+            *fencingAcquireArgs(config, ownerId, leaseTimeMillis).toTypedArray(),
         ),
     )
 }
@@ -291,10 +361,9 @@ internal fun runFencingInspect(
 ): FencingInspectResult = decodeFencingInspect(
     runFencingScript(
         commands,
-        FencingLeaseScripts.INSPECT,
+        FencingLeaseOperation.INSPECT.script,
         keys,
-        ownerId.value,
-        config.epoch.toString(),
+        *fencingInspectArgs(config, ownerId).toTypedArray(),
     ),
 )
 
@@ -311,12 +380,9 @@ internal fun runFencingRenew(
     return decodeFencingRenew(
         runFencingScript(
             commands,
-            FencingLeaseScripts.RENEW,
+            FencingLeaseOperation.RENEW.script,
             keys,
-            ownerId.value,
-            token.epoch.toString(),
-            token.sequence.toString(),
-            leaseTimeMillis.toString(),
+            *fencingRenewArgs(ownerId, token, leaseTimeMillis).toTypedArray(),
         ),
     )
 }
@@ -332,14 +398,21 @@ internal fun runFencingRelease(
     return decodeFencingRelease(
         runFencingScript(
             commands,
-            FencingLeaseScripts.RELEASE,
+            FencingLeaseOperation.RELEASE.script,
             keys,
-            ownerId.value,
-            token.epoch.toString(),
-            token.sequence.toString(),
+            *fencingReleaseArgs(ownerId, token).toTypedArray(),
         ),
     )
 }
+
+private val FencingLeaseOperation.script: RedisScript
+    get() = when (this) {
+        FencingLeaseOperation.BOOTSTRAP -> FencingLeaseScripts.BOOTSTRAP
+        FencingLeaseOperation.ACQUIRE -> FencingLeaseScripts.ACQUIRE
+        FencingLeaseOperation.INSPECT -> FencingLeaseScripts.INSPECT
+        FencingLeaseOperation.RENEW -> FencingLeaseScripts.RENEW
+        FencingLeaseOperation.RELEASE -> FencingLeaseScripts.RELEASE
+    }
 
 private fun runFencingScript(
     commands: RedisScriptingCommands<String, String>,

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupport.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupport.kt
@@ -1,0 +1,323 @@
+package io.bluetape4k.redis.lettuce.lease
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import io.lettuce.core.RedisCommandTimeoutException
+import io.lettuce.core.RedisConnectionException
+import io.lettuce.core.RedisException
+import io.lettuce.core.cluster.SlotHash
+import io.lettuce.core.codec.RedisCodec
+import java.security.MessageDigest
+import java.time.Duration
+import java.util.Collections
+import java.util.HexFormat
+import java.util.IdentityHashMap
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletionException
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeoutException
+
+internal data class FencingLeaseKeys(
+    val lease: String,
+    val counter: String,
+)
+
+internal enum class FencingLeaseOperation {
+    BOOTSTRAP,
+    ACQUIRE,
+    INSPECT,
+    RENEW,
+    RELEASE,
+}
+
+internal class FencingLeaseProtocolException: IllegalStateException(
+    "Malformed fencing lease response.",
+) {
+    private companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal object FencingLeaseSupportLogger: KLogging() {
+    fun backendFailure(
+        operation: FencingLeaseOperation,
+        failure: FencingLeaseBackendFailure,
+        exceptionClassName: String,
+        domainFingerprint: String?,
+    ) {
+        val domain = domainFingerprint ?: "unavailable"
+        log.warn {
+            "Fencing lease backend failure operation=$operation kind=${failure.kind} " +
+                "exception=$exceptionClassName domain=$domain"
+        }
+    }
+}
+
+internal fun deriveFencingLeaseKeys(
+    config: LettuceFencingLeaseConfig,
+    codec: RedisCodec<String, String>,
+): FencingLeaseKeys {
+    val tag = "${config.namespace}:${config.resourceName}"
+    val prefix = "fence:{$tag}:${config.epoch}"
+    val keys = FencingLeaseKeys("$prefix:lease", "$prefix:counter")
+    require(SlotHash.getSlot(codec.encodeKey(keys.lease)) == SlotHash.getSlot(codec.encodeKey(keys.counter))) {
+        "Derived fencing lease keys must share one Redis Cluster slot."
+    }
+    return keys
+}
+
+internal fun requireCanonicalFencingDecimal(value: String): String {
+    val canonical = value == "0" ||
+        value.firstOrNull() in '1'..'9' && value.all { character -> character in '0'..'9' }
+    require(canonical) { "Invalid decimal value." }
+    require(value.length <= MAX_LONG_DECIMAL.length) { "Decimal value is out of range." }
+    require(compareCanonicalFencingDecimalsWithoutValidation(value, MAX_LONG_DECIMAL) <= 0) {
+        "Decimal value is out of range."
+    }
+    return value
+}
+
+internal fun compareCanonicalFencingDecimals(left: String, right: String): Int {
+    requireCanonicalFencingDecimal(left)
+    requireCanonicalFencingDecimal(right)
+    return compareCanonicalFencingDecimalsWithoutValidation(left, right)
+}
+
+internal fun parseCanonicalFencingLong(value: String): Long = requireCanonicalFencingDecimal(value).toLong()
+
+internal fun Duration.requireFencingLeaseMillis(): Long {
+    val millis = try {
+        toMillis()
+    } catch (_: ArithmeticException) {
+        throw IllegalArgumentException(INVALID_LEASE_TIME_MESSAGE)
+    }
+    require(millis > 0 && this == Duration.ofMillis(millis)) { INVALID_LEASE_TIME_MESSAGE }
+    return millis
+}
+
+internal fun requireFencingTokenEpoch(
+    config: LettuceFencingLeaseConfig,
+    token: FencingToken,
+): FencingToken {
+    require(token.epoch == config.epoch) {
+        "Fencing token epoch must match the configured ordering domain."
+    }
+    return token
+}
+
+internal fun Throwable.unwrapFencingCompletionCause(): Throwable {
+    val seen = Collections.newSetFromMap(IdentityHashMap<Throwable, Boolean>())
+    var current = this
+    repeat(MAX_COMPLETION_DEPTH) {
+        if (current is CancellationException) {
+            throw current
+        }
+        if (!seen.add(current)) {
+            return current
+        }
+        val next = when (current) {
+            is CompletionException,
+            is ExecutionException,
+            -> current.cause
+            else -> null
+        }
+        if (next == null || next === current) {
+            return current
+        }
+        current = next
+    }
+    if (current is CancellationException) {
+        throw current
+    }
+    return current
+}
+
+internal fun classifyFencingBackendFailure(
+    operation: FencingLeaseOperation,
+    error: Throwable,
+    domainFingerprint: String? = null,
+): FencingLeaseBackendFailure {
+    val cause = error.unwrapFencingCompletionCause()
+    val kind = when (cause) {
+        is RedisConnectionException -> FencingBackendFailureKind.CONNECTION
+        is RedisCommandTimeoutException,
+        is TimeoutException,
+        -> FencingBackendFailureKind.TIMEOUT
+        is RedisException -> FencingBackendFailureKind.COMMAND
+        else -> throw cause
+    }
+    return FencingLeaseBackendFailure(kind).also { failure ->
+        FencingLeaseSupportLogger.backendFailure(
+            operation,
+            failure,
+            cause.javaClass.name,
+            domainFingerprint,
+        )
+    }
+}
+
+internal fun LettuceFencingLeaseConfig.domainFingerprint(): String {
+    val source = "$namespace\u0000$resourceName\u0000$epoch".toByteArray(Charsets.UTF_8)
+    val digest = MessageDigest.getInstance("SHA-256").digest(source)
+    return HexFormat.of().formatHex(digest, 0, DOMAIN_FINGERPRINT_BYTES)
+}
+
+internal fun decodeFencingBootstrap(frame: List<String>): FencingBootstrapResult {
+    val decoded = decodeFencingFrame(frame)
+    decoded.integrityFailureOrNull()?.let { failure ->
+        return FencingBootstrapResult.IntegrityFailure(failure)
+    }
+    decoded.requireUnusedValues()
+    return when (decoded.status) {
+        "INITIALIZED" -> FencingBootstrapResult.Initialized
+        "ALREADY_INITIALIZED" -> FencingBootstrapResult.AlreadyInitialized
+        else -> malformedFencingReply()
+    }
+}
+
+internal fun decodeFencingAcquire(frame: List<String>): FencingAcquireResult {
+    val decoded = decodeFencingFrame(frame)
+    decoded.integrityFailureOrNull()?.let { failure ->
+        return FencingAcquireResult.IntegrityFailure(failure)
+    }
+    return when (decoded.status) {
+        "ACQUIRED" -> {
+            decoded.requireTtlSentinel()
+            FencingAcquireResult.Acquired(decoded.token())
+        }
+        "ALREADY_OWNED" -> FencingAcquireResult.AlreadyOwned(decoded.token(), decoded.ttl())
+        "CONTENDED" -> {
+            decoded.requireUnusedToken()
+            FencingAcquireResult.Contended(decoded.ttl())
+        }
+        "COUNTER_UNAVAILABLE" -> decoded.withUnusedValues { FencingAcquireResult.CounterUnavailable }
+        "SEQUENCE_EXHAUSTED" -> decoded.withUnusedValues { FencingAcquireResult.SequenceExhausted }
+        else -> malformedFencingReply()
+    }
+}
+
+internal fun decodeFencingInspect(frame: List<String>): FencingInspectResult {
+    val decoded = decodeFencingFrame(frame)
+    decoded.integrityFailureOrNull()?.let { failure ->
+        return FencingInspectResult.IntegrityFailure(failure)
+    }
+    return when (decoded.status) {
+        "OWNED" -> FencingInspectResult.Owned(decoded.token(), decoded.ttl())
+        "LOST" -> decoded.withUnusedValues { FencingInspectResult.Lost }
+        "CONTENDED" -> {
+            decoded.requireUnusedToken()
+            FencingInspectResult.Contended(decoded.ttl())
+        }
+        else -> malformedFencingReply()
+    }
+}
+
+internal fun decodeFencingRenew(frame: List<String>): FencingRenewResult {
+    val decoded = decodeFencingFrame(frame)
+    decoded.integrityFailureOrNull()?.let { failure ->
+        return FencingRenewResult.IntegrityFailure(failure)
+    }
+    decoded.requireUnusedValues()
+    return when (decoded.status) {
+        "RENEWED" -> FencingRenewResult.Renewed
+        "LOST" -> FencingRenewResult.Lost
+        "OWNERSHIP_MISMATCH" -> FencingRenewResult.OwnershipMismatch
+        else -> malformedFencingReply()
+    }
+}
+
+internal fun decodeFencingRelease(frame: List<String>): FencingReleaseResult {
+    val decoded = decodeFencingFrame(frame)
+    decoded.integrityFailureOrNull()?.let { failure ->
+        return FencingReleaseResult.IntegrityFailure(failure)
+    }
+    decoded.requireUnusedValues()
+    return when (decoded.status) {
+        "RELEASED" -> FencingReleaseResult.Released
+        "LOST" -> FencingReleaseResult.Lost
+        "OWNERSHIP_MISMATCH" -> FencingReleaseResult.OwnershipMismatch
+        else -> malformedFencingReply()
+    }
+}
+
+private data class DecodedFencingFrame(
+    val status: String,
+    val value1: String,
+    val value2: String,
+    val ttl: String,
+) {
+    fun token(): FencingToken = decodeFencingField {
+        FencingToken(
+            parseCanonicalFencingLong(value1),
+            parseCanonicalFencingLong(value2),
+        )
+    }
+
+    fun ttl(): Long = decodeFencingField { parseCanonicalFencingLong(ttl) }
+
+    fun integrityFailureOrNull(): FencingLeaseIntegrityFailure? {
+        if (status != "INTEGRITY_FAILURE") {
+            return null
+        }
+        if (value2 != UNUSED_VALUE || ttl != UNUSED_TTL) {
+            malformedFencingReply()
+        }
+        val kind = when (value1) {
+            "MALFORMED_LEASE" -> FencingIntegrityFailureKind.MALFORMED_LEASE
+            "INVALID_COUNTER" -> FencingIntegrityFailureKind.INVALID_COUNTER
+            "COUNTER_BEHIND_LEASE" -> FencingIntegrityFailureKind.COUNTER_BEHIND_LEASE
+            else -> malformedFencingReply()
+        }
+        return FencingLeaseIntegrityFailure(kind)
+    }
+
+    fun requireUnusedToken() {
+        if (value1 != UNUSED_VALUE || value2 != UNUSED_VALUE) {
+            malformedFencingReply()
+        }
+    }
+
+    fun requireTtlSentinel() {
+        if (ttl != UNUSED_TTL) {
+            malformedFencingReply()
+        }
+    }
+
+    fun requireUnusedValues() {
+        requireUnusedToken()
+        requireTtlSentinel()
+    }
+
+    inline fun <T> withUnusedValues(result: () -> T): T {
+        requireUnusedValues()
+        return result()
+    }
+}
+
+private fun decodeFencingFrame(frame: List<String>): DecodedFencingFrame {
+    if (frame.size != FENCING_FRAME_SIZE) {
+        malformedFencingReply()
+    }
+    return DecodedFencingFrame(frame[0], frame[1], frame[2], frame[3])
+}
+
+private inline fun <T> decodeFencingField(block: () -> T): T = try {
+    block()
+} catch (_: IllegalArgumentException) {
+    malformedFencingReply()
+}
+
+private fun compareCanonicalFencingDecimalsWithoutValidation(left: String, right: String): Int {
+    val lengthComparison = left.length.compareTo(right.length)
+    return if (lengthComparison != 0) lengthComparison else left.compareTo(right)
+}
+
+private fun malformedFencingReply(): Nothing = throw FencingLeaseProtocolException()
+
+private const val FENCING_FRAME_SIZE = 4
+private const val UNUSED_VALUE = "0"
+private const val UNUSED_TTL = "-1"
+private const val MAX_COMPLETION_DEPTH = 8
+private const val DOMAIN_FINGERPRINT_BYTES = 12
+private const val INVALID_LEASE_TIME_MESSAGE = "leaseTime must fit positive whole milliseconds."
+private val MAX_LONG_DECIMAL = Long.MAX_VALUE.toString()

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLease.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLease.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.redis.lettuce.lease
 
 import io.lettuce.core.api.StatefulRedisConnection
-import io.lettuce.core.api.async.RedisScriptingAsyncCommands
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
 import io.lettuce.core.codec.RedisCodec
 import java.time.Duration
+import java.util.concurrent.CancellationException
 
 /**
  * Provides suspending access to one Redis fencing-lease ordering domain.
@@ -13,7 +13,7 @@ import java.time.Duration
  * reached Redis, so callers must reconcile ambiguous completion with the same owner ID or token.
  */
 class LettuceSuspendFencingLease private constructor(
-    private val asyncCommands: RedisScriptingAsyncCommands<String, String>,
+    private val executor: FencingScriptExecutor,
     codec: RedisCodec<String, String>,
     private val config: LettuceFencingLeaseConfig,
 ) {
@@ -23,13 +23,13 @@ class LettuceSuspendFencingLease private constructor(
     constructor(
         connection: StatefulRedisConnection<String, String>,
         config: LettuceFencingLeaseConfig,
-    ): this(connection.async(), connection.codec, config)
+    ): this(DefaultFencingScriptExecutor(connection.sync(), connection.async()), connection.codec, config)
 
     /** Creates a suspending fencing lease over a Redis Cluster connection after validating the encoded key slot. */
     constructor(
         connection: StatefulRedisClusterConnection<String, String>,
         config: LettuceFencingLeaseConfig,
-    ): this(connection.async(), connection.codec, config)
+    ): this(DefaultFencingScriptExecutor(connection.sync(), connection.async()), connection.codec, config)
 
     /** Initializes the counter for a new, externally approved epoch without repairing old history. */
     suspend fun bootstrap(): FencingBootstrapResult = classified(
@@ -37,12 +37,7 @@ class LettuceSuspendFencingLease private constructor(
         FencingBootstrapResult::BackendFailure,
     ) {
         decodeFencingBootstrap(
-            runFencingScriptSuspending(
-                asyncCommands,
-                FencingLeaseScripts.BOOTSTRAP,
-                keys,
-                config.epoch.toString(),
-            ),
+            executor.runSuspending(FencingLeaseOperation.BOOTSTRAP, keys, fencingBootstrapArgs(config)),
         )
     }
 
@@ -51,13 +46,10 @@ class LettuceSuspendFencingLease private constructor(
         val leaseTimeMillis = leaseTime.validatedFencingLeaseTimeMillis()
         return classified(FencingLeaseOperation.ACQUIRE, FencingAcquireResult::BackendFailure) {
             decodeFencingAcquire(
-                runFencingScriptSuspending(
-                    asyncCommands,
-                    FencingLeaseScripts.ACQUIRE,
+                executor.runSuspending(
+                    FencingLeaseOperation.ACQUIRE,
                     keys,
-                    ownerId.value,
-                    config.epoch.toString(),
-                    leaseTimeMillis.toString(),
+                    fencingAcquireArgs(config, ownerId, leaseTimeMillis),
                 ),
             )
         }
@@ -69,13 +61,7 @@ class LettuceSuspendFencingLease private constructor(
         FencingInspectResult::BackendFailure,
     ) {
         decodeFencingInspect(
-            runFencingScriptSuspending(
-                asyncCommands,
-                FencingLeaseScripts.INSPECT,
-                keys,
-                ownerId.value,
-                config.epoch.toString(),
-            ),
+            executor.runSuspending(FencingLeaseOperation.INSPECT, keys, fencingInspectArgs(config, ownerId)),
         )
     }
 
@@ -89,14 +75,10 @@ class LettuceSuspendFencingLease private constructor(
         val leaseTimeMillis = leaseTime.validatedFencingLeaseTimeMillis()
         return classified(FencingLeaseOperation.RENEW, FencingRenewResult::BackendFailure) {
             decodeFencingRenew(
-                runFencingScriptSuspending(
-                    asyncCommands,
-                    FencingLeaseScripts.RENEW,
+                executor.runSuspending(
+                    FencingLeaseOperation.RENEW,
                     keys,
-                    ownerId.value,
-                    token.epoch.toString(),
-                    token.sequence.toString(),
-                    leaseTimeMillis.toString(),
+                    fencingRenewArgs(ownerId, token, leaseTimeMillis),
                 ),
             )
         }
@@ -107,14 +89,7 @@ class LettuceSuspendFencingLease private constructor(
         requireFencingTokenEpoch(config, token)
         return classified(FencingLeaseOperation.RELEASE, FencingReleaseResult::BackendFailure) {
             decodeFencingRelease(
-                runFencingScriptSuspending(
-                    asyncCommands,
-                    FencingLeaseScripts.RELEASE,
-                    keys,
-                    ownerId.value,
-                    token.epoch.toString(),
-                    token.sequence.toString(),
-                ),
+                executor.runSuspending(FencingLeaseOperation.RELEASE, keys, fencingReleaseArgs(ownerId, token)),
             )
         }
     }
@@ -125,15 +100,17 @@ class LettuceSuspendFencingLease private constructor(
         crossinline block: suspend () -> R,
     ): R = try {
         block()
+    } catch (error: CancellationException) {
+        throw error
     } catch (error: Exception) {
         backendFailure(classifyFencingBackendFailure(operation, error, config::domainFingerprint))
     }
 
     internal companion object {
-        fun fromCommands(
-            asyncCommands: RedisScriptingAsyncCommands<String, String>,
+        fun createForTesting(
+            executor: FencingScriptExecutor,
             codec: RedisCodec<String, String>,
             config: LettuceFencingLeaseConfig,
-        ): LettuceSuspendFencingLease = LettuceSuspendFencingLease(asyncCommands, codec, config)
+        ): LettuceSuspendFencingLease = LettuceSuspendFencingLease(executor, codec, config)
     }
 }

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLease.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLease.kt
@@ -10,7 +10,9 @@ import java.util.concurrent.CancellationException
  * Provides suspending access to one Redis fencing-lease ordering domain.
  *
  * Coroutine cancellation is propagated and never converted into a lease result. A cancelled mutation can still have
- * reached Redis, so callers must reconcile ambiguous completion with the same owner ID or token.
+ * reached Redis, so callers must reconcile ambiguous completion with the same owner ID or token. The supplied config
+ * binds the instance to one namespace, resource, and durable epoch; downstream strict tuple comparison remains a
+ * caller-owned durability boundary.
  */
 class LettuceSuspendFencingLease private constructor(
     private val executor: FencingScriptExecutor,
@@ -19,19 +21,19 @@ class LettuceSuspendFencingLease private constructor(
 ) {
     private val keys: FencingLeaseKeys = deriveFencingLeaseKeys(config, codec)
 
-    /** Creates a suspending fencing lease over a standalone Redis connection. */
+    /** Creates a config-bound suspending lease after validating the encoded lease/counter key slot. */
     constructor(
         connection: StatefulRedisConnection<String, String>,
         config: LettuceFencingLeaseConfig,
     ): this(DefaultFencingScriptExecutor(connection.sync(), connection.async()), connection.codec, config)
 
-    /** Creates a suspending fencing lease over a Redis Cluster connection after validating the encoded key slot. */
+    /** Creates a Redis Cluster suspending lease after validating the codec-produced lease/counter key slot. */
     constructor(
         connection: StatefulRedisClusterConnection<String, String>,
         config: LettuceFencingLeaseConfig,
     ): this(DefaultFencingScriptExecutor(connection.sync(), connection.async()), connection.codec, config)
 
-    /** Initializes the counter for a new, externally approved epoch without repairing old history. */
+    /** Initializes a new externally approved epoch; this never reconstructs or repairs lost same-epoch history. */
     suspend fun bootstrap(): FencingBootstrapResult = classified(
         FencingLeaseOperation.BOOTSTRAP,
         FencingBootstrapResult::BackendFailure,
@@ -41,7 +43,7 @@ class LettuceSuspendFencingLease private constructor(
         )
     }
 
-    /** Acquires the lease or reports the active competing owner without exposing its identity. */
+    /** Acquires the lease; reconcile cancellation or backend ambiguity only with the same [ownerId]. */
     suspend fun acquire(ownerId: FencingOwnerId, leaseTime: Duration): FencingAcquireResult {
         val leaseTimeMillis = leaseTime.validatedFencingLeaseTimeMillis()
         return classified(FencingLeaseOperation.ACQUIRE, FencingAcquireResult::BackendFailure) {
@@ -55,7 +57,7 @@ class LettuceSuspendFencingLease private constructor(
         }
     }
 
-    /** Inspects current ownership without extending the lease TTL. */
+    /** Inspects current ownership without extending TTL or mutating the counter. */
     suspend fun inspect(ownerId: FencingOwnerId): FencingInspectResult = classified(
         FencingLeaseOperation.INSPECT,
         FencingInspectResult::BackendFailure,
@@ -65,7 +67,7 @@ class LettuceSuspendFencingLease private constructor(
         )
     }
 
-    /** Renews the lease only when both owner ID and fencing token still match. */
+    /** Renews only the matching owner/token and rejects a cross-epoch token before Redis dispatch. */
     suspend fun renew(
         ownerId: FencingOwnerId,
         token: FencingToken,
@@ -84,7 +86,7 @@ class LettuceSuspendFencingLease private constructor(
         }
     }
 
-    /** Releases the lease only when both owner ID and fencing token still match. */
+    /** Releases only the matching owner/token and rejects a cross-epoch token before Redis dispatch. */
     suspend fun release(ownerId: FencingOwnerId, token: FencingToken): FencingReleaseResult {
         requireFencingTokenEpoch(config, token)
         return classified(FencingLeaseOperation.RELEASE, FencingReleaseResult::BackendFailure) {
@@ -107,7 +109,7 @@ class LettuceSuspendFencingLease private constructor(
     }
 
     internal companion object {
-        fun createForTesting(
+        internal fun createForTesting(
             executor: FencingScriptExecutor,
             codec: RedisCodec<String, String>,
             config: LettuceFencingLeaseConfig,

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLease.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLease.kt
@@ -1,0 +1,139 @@
+package io.bluetape4k.redis.lettuce.lease
+
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.async.RedisScriptingAsyncCommands
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
+import io.lettuce.core.codec.RedisCodec
+import java.time.Duration
+
+/**
+ * Provides suspending access to one Redis fencing-lease ordering domain.
+ *
+ * Coroutine cancellation is propagated and never converted into a lease result. A cancelled mutation can still have
+ * reached Redis, so callers must reconcile ambiguous completion with the same owner ID or token.
+ */
+class LettuceSuspendFencingLease private constructor(
+    private val asyncCommands: RedisScriptingAsyncCommands<String, String>,
+    codec: RedisCodec<String, String>,
+    private val config: LettuceFencingLeaseConfig,
+) {
+    private val keys: FencingLeaseKeys = deriveFencingLeaseKeys(config, codec)
+
+    /** Creates a suspending fencing lease over a standalone Redis connection. */
+    constructor(
+        connection: StatefulRedisConnection<String, String>,
+        config: LettuceFencingLeaseConfig,
+    ): this(connection.async(), connection.codec, config)
+
+    /** Creates a suspending fencing lease over a Redis Cluster connection after validating the encoded key slot. */
+    constructor(
+        connection: StatefulRedisClusterConnection<String, String>,
+        config: LettuceFencingLeaseConfig,
+    ): this(connection.async(), connection.codec, config)
+
+    /** Initializes the counter for a new, externally approved epoch without repairing old history. */
+    suspend fun bootstrap(): FencingBootstrapResult = classified(
+        FencingLeaseOperation.BOOTSTRAP,
+        FencingBootstrapResult::BackendFailure,
+    ) {
+        decodeFencingBootstrap(
+            runFencingScriptSuspending(
+                asyncCommands,
+                FencingLeaseScripts.BOOTSTRAP,
+                keys,
+                config.epoch.toString(),
+            ),
+        )
+    }
+
+    /** Acquires the lease or reports the active competing owner without exposing its identity. */
+    suspend fun acquire(ownerId: FencingOwnerId, leaseTime: Duration): FencingAcquireResult {
+        val leaseTimeMillis = leaseTime.validatedFencingLeaseTimeMillis()
+        return classified(FencingLeaseOperation.ACQUIRE, FencingAcquireResult::BackendFailure) {
+            decodeFencingAcquire(
+                runFencingScriptSuspending(
+                    asyncCommands,
+                    FencingLeaseScripts.ACQUIRE,
+                    keys,
+                    ownerId.value,
+                    config.epoch.toString(),
+                    leaseTimeMillis.toString(),
+                ),
+            )
+        }
+    }
+
+    /** Inspects current ownership without extending the lease TTL. */
+    suspend fun inspect(ownerId: FencingOwnerId): FencingInspectResult = classified(
+        FencingLeaseOperation.INSPECT,
+        FencingInspectResult::BackendFailure,
+    ) {
+        decodeFencingInspect(
+            runFencingScriptSuspending(
+                asyncCommands,
+                FencingLeaseScripts.INSPECT,
+                keys,
+                ownerId.value,
+                config.epoch.toString(),
+            ),
+        )
+    }
+
+    /** Renews the lease only when both owner ID and fencing token still match. */
+    suspend fun renew(
+        ownerId: FencingOwnerId,
+        token: FencingToken,
+        leaseTime: Duration,
+    ): FencingRenewResult {
+        requireFencingTokenEpoch(config, token)
+        val leaseTimeMillis = leaseTime.validatedFencingLeaseTimeMillis()
+        return classified(FencingLeaseOperation.RENEW, FencingRenewResult::BackendFailure) {
+            decodeFencingRenew(
+                runFencingScriptSuspending(
+                    asyncCommands,
+                    FencingLeaseScripts.RENEW,
+                    keys,
+                    ownerId.value,
+                    token.epoch.toString(),
+                    token.sequence.toString(),
+                    leaseTimeMillis.toString(),
+                ),
+            )
+        }
+    }
+
+    /** Releases the lease only when both owner ID and fencing token still match. */
+    suspend fun release(ownerId: FencingOwnerId, token: FencingToken): FencingReleaseResult {
+        requireFencingTokenEpoch(config, token)
+        return classified(FencingLeaseOperation.RELEASE, FencingReleaseResult::BackendFailure) {
+            decodeFencingRelease(
+                runFencingScriptSuspending(
+                    asyncCommands,
+                    FencingLeaseScripts.RELEASE,
+                    keys,
+                    ownerId.value,
+                    token.epoch.toString(),
+                    token.sequence.toString(),
+                ),
+            )
+        }
+    }
+
+    private suspend inline fun <R> classified(
+        operation: FencingLeaseOperation,
+        backendFailure: (FencingLeaseBackendFailure) -> R,
+        crossinline block: suspend () -> R,
+    ): R = try {
+        block()
+    } catch (error: Exception) {
+        backendFailure(classifyFencingBackendFailure(operation, error, config::domainFingerprint))
+    }
+
+    internal companion object {
+        fun fromCommands(
+            asyncCommands: RedisScriptingAsyncCommands<String, String>,
+            codec: RedisCodec<String, String>,
+            config: LettuceFencingLeaseConfig,
+        ): LettuceSuspendFencingLease = LettuceSuspendFencingLease(asyncCommands, codec, config)
+    }
+}

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/script/RedisScript.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/script/RedisScript.kt
@@ -10,8 +10,10 @@ import io.lettuce.core.api.async.RedisScriptingAsyncCommands
 import io.lettuce.core.api.sync.RedisCommands
 import io.lettuce.core.api.sync.RedisScriptingCommands
 import java.security.MessageDigest
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * 재사용되는 Redis Lua 스크립트를 표현합니다.
@@ -110,16 +112,68 @@ object RedisScriptRunner: KLogging() {
         keys: Array<String>,
         vararg args: String,
     ): CompletableFuture<T> {
-        val future = commands.evalsha<T>(script.sha1, outputType, keys, *args).toCompletableFuture()
-        return future.exceptionallyCompose { error ->
-            val cause = if (error is CompletionException) error.cause ?: error else error
-            if (cause is RedisNoScriptException) {
-                log.debug { "NOSCRIPT(async) → 원문 전송 fallback (sha1=${script.sha1})" }
-                commands.eval<T>(script.source, outputType, keys, *args).toCompletableFuture()
-            } else {
-                CompletableFuture.failedFuture(cause)
+        val current = AtomicReference<CompletableFuture<T>>()
+        val result = object: CompletableFuture<T>() {
+            override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
+                val cancelled = super.cancel(mayInterruptIfRunning)
+                if (cancelled) {
+                    current.get()?.cancel(mayInterruptIfRunning)
+                }
+                return cancelled
             }
         }
+
+        lateinit var attach: (CompletableFuture<T>, Boolean) -> Unit
+        val dispatch: ((() -> CompletableFuture<T>), Boolean) -> Unit = { command, fallbackOnNoScript ->
+            if (!result.isDone) {
+                val upstream = try {
+                    command()
+                } catch (_: CancellationException) {
+                    result.cancel(false)
+                    null
+                } catch (error: Exception) {
+                    result.completeExceptionally(error)
+                    null
+                }
+                if (upstream != null) {
+                    attach(upstream, fallbackOnNoScript)
+                }
+            }
+        }
+
+        attach = { upstream, fallbackOnNoScript ->
+            current.set(upstream)
+            if (result.isCancelled) {
+                upstream.cancel(true)
+            } else {
+                upstream.whenComplete { value, error ->
+                    when (val cause = error?.unwrapCompletionCause()) {
+                        null -> result.complete(value)
+                        is CancellationException -> result.cancel(false)
+                        is RedisNoScriptException -> {
+                            if (fallbackOnNoScript && !result.isCancelled) {
+                                log.debug { "NOSCRIPT(async) → 원문 전송 fallback (sha1=${script.sha1})" }
+                                dispatch(
+                                    {
+                                        commands.eval<T>(script.source, outputType, keys, *args).toCompletableFuture()
+                                    },
+                                    false,
+                                )
+                            } else if (!result.isDone) {
+                                result.completeExceptionally(cause)
+                            }
+                        }
+                        else -> result.completeExceptionally(cause)
+                    }
+                }
+            }
+        }
+
+        dispatch(
+            { commands.evalsha<T>(script.sha1, outputType, keys, *args).toCompletableFuture() },
+            true,
+        )
+        return result
     }
 
     /** 코루틴: `EVALSHA` 우선, NOSCRIPT 시 원문 전송 fallback. */
@@ -155,3 +209,6 @@ object RedisScriptRunner: KLogging() {
         }
     }
 }
+
+private fun Throwable.unwrapCompletionCause(): Throwable =
+    if (this is CompletionException) cause ?: this else this

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseContract.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseContract.kt
@@ -8,9 +8,9 @@ import io.bluetape4k.assertions.shouldBeLessOrEqualTo
 import io.bluetape4k.assertions.shouldBePositive
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.redis.lettuce.AbstractLettuceTest
-import io.bluetape4k.redis.lettuce.LettuceClients
 import io.bluetape4k.redis.lettuce.LettuceTestUtils
 import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.sync.RedisCommands
 import io.lettuce.core.codec.StringCodec
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
@@ -32,6 +32,8 @@ internal abstract class FencingLeaseContract : AbstractLettuceTest() {
     private lateinit var config: LettuceFencingLeaseConfig
     private lateinit var keys: FencingLeaseKeys
     private lateinit var adapter: FencingLeaseAdapter
+    private lateinit var connection: StatefulRedisConnection<String, String>
+    private lateinit var commands: RedisCommands<String, String>
 
     private val owner = FencingOwnerId.from("contract-owner")
     private val contender = FencingOwnerId.from("contract-contender")
@@ -43,6 +45,8 @@ internal abstract class FencingLeaseContract : AbstractLettuceTest() {
 
     @BeforeEach
     fun setUpContract() {
+        connection = LettuceTestUtils.client.connect(StringCodec.UTF8)
+        commands = connection.sync()
         config = LettuceFencingLeaseConfig("contract", "lease-${randomName().substringAfter(':')}", 11)
         keys = deriveFencingLeaseKeys(config, StringCodec.UTF8)
         commands.del(keys.lease, keys.counter)
@@ -51,7 +55,11 @@ internal abstract class FencingLeaseContract : AbstractLettuceTest() {
 
     @AfterEach
     fun tearDownContract() {
-        commands.del(keys.lease, keys.counter)
+        try {
+            commands.del(keys.lease, keys.counter)
+        } finally {
+            connection.close()
+        }
     }
 
     @Test
@@ -151,8 +159,5 @@ internal abstract class FencingLeaseContract : AbstractLettuceTest() {
     private companion object {
         val DEFAULT_LEASE: Duration = Duration.ofSeconds(5)
         val LONGER_LEASE: Duration = Duration.ofSeconds(30)
-
-        val connection by lazy { LettuceClients.connect(LettuceTestUtils.client, StringCodec.UTF8) }
-        val commands by lazy { connection.sync() }
     }
 }

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseContract.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseContract.kt
@@ -1,0 +1,158 @@
+package io.bluetape4k.redis.lettuce.lease
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeLessOrEqualTo
+import io.bluetape4k.assertions.shouldBePositive
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.redis.lettuce.AbstractLettuceTest
+import io.bluetape4k.redis.lettuce.LettuceClients
+import io.bluetape4k.redis.lettuce.LettuceTestUtils
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.codec.StringCodec
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+internal interface FencingLeaseAdapter {
+    suspend fun bootstrap(): FencingBootstrapResult
+    suspend fun acquire(ownerId: FencingOwnerId, leaseTime: Duration): FencingAcquireResult
+    suspend fun inspect(ownerId: FencingOwnerId): FencingInspectResult
+    suspend fun renew(ownerId: FencingOwnerId, token: FencingToken, leaseTime: Duration): FencingRenewResult
+    suspend fun release(ownerId: FencingOwnerId, token: FencingToken): FencingReleaseResult
+}
+
+internal abstract class FencingLeaseContract : AbstractLettuceTest() {
+
+    private lateinit var config: LettuceFencingLeaseConfig
+    private lateinit var keys: FencingLeaseKeys
+    private lateinit var adapter: FencingLeaseAdapter
+
+    private val owner = FencingOwnerId.from("contract-owner")
+    private val contender = FencingOwnerId.from("contract-contender")
+
+    protected abstract fun createAdapter(
+        connection: StatefulRedisConnection<String, String>,
+        config: LettuceFencingLeaseConfig,
+    ): FencingLeaseAdapter
+
+    @BeforeEach
+    fun setUpContract() {
+        config = LettuceFencingLeaseConfig("contract", "lease-${randomName().substringAfter(':')}", 11)
+        keys = deriveFencingLeaseKeys(config, StringCodec.UTF8)
+        commands.del(keys.lease, keys.counter)
+        adapter = createAdapter(connection, config)
+    }
+
+    @AfterEach
+    fun tearDownContract() {
+        commands.del(keys.lease, keys.counter)
+    }
+
+    @Test
+    fun `bootstrap replay and sequential generations are consistent`() = runSuspendIO {
+        adapter.bootstrap() shouldBeEqualTo FencingBootstrapResult.Initialized
+        adapter.bootstrap() shouldBeEqualTo FencingBootstrapResult.AlreadyInitialized
+
+        val first = adapter.acquire(owner, DEFAULT_LEASE).shouldBeInstanceOf<FencingAcquireResult.Acquired>().token
+        adapter.release(owner, first) shouldBeEqualTo FencingReleaseResult.Released
+        val second = adapter.acquire(contender, DEFAULT_LEASE)
+            .shouldBeInstanceOf<FencingAcquireResult.Acquired>().token
+
+        second shouldBeGreaterThan first
+        commands.get(keys.counter) shouldBeEqualTo second.sequence.toString()
+    }
+
+    @Test
+    fun `same owner replay keeps token and does not extend ttl`() = runSuspendIO {
+        adapter.bootstrap()
+        val acquired = adapter.acquire(owner, DEFAULT_LEASE).shouldBeInstanceOf<FencingAcquireResult.Acquired>()
+        val before = commands.pttl(keys.lease)
+
+        val replay = adapter.acquire(owner, LONGER_LEASE).shouldBeInstanceOf<FencingAcquireResult.AlreadyOwned>()
+        val after = commands.pttl(keys.lease)
+
+        replay.token shouldBeEqualTo acquired.token
+        replay.remainingTtlMillis.shouldBePositive()
+        replay.remainingTtlMillis shouldBeLessOrEqualTo before
+        after shouldBeLessOrEqualTo before
+    }
+
+    @Test
+    fun `inspect renew and release reject stale ownership without changing newer lease`() = runSuspendIO {
+        adapter.bootstrap()
+        val token = adapter.acquire(owner, DEFAULT_LEASE).shouldBeInstanceOf<FencingAcquireResult.Acquired>().token
+
+        adapter.inspect(owner).shouldBeInstanceOf<FencingInspectResult.Owned>().token shouldBeEqualTo token
+        adapter.inspect(contender).shouldBeInstanceOf<FencingInspectResult.Contended>()
+        adapter.renew(contender, token, LONGER_LEASE) shouldBeEqualTo FencingRenewResult.OwnershipMismatch
+        adapter.renew(owner, FencingToken(token.epoch, token.sequence + 1), LONGER_LEASE) shouldBeEqualTo
+            FencingRenewResult.OwnershipMismatch
+        adapter.release(contender, token) shouldBeEqualTo FencingReleaseResult.OwnershipMismatch
+        adapter.release(owner, FencingToken(token.epoch, token.sequence + 1)) shouldBeEqualTo
+            FencingReleaseResult.OwnershipMismatch
+
+        adapter.inspect(owner).shouldBeInstanceOf<FencingInspectResult.Owned>().token shouldBeEqualTo token
+        adapter.renew(owner, token, LONGER_LEASE) shouldBeEqualTo FencingRenewResult.Renewed
+        commands.get(keys.counter) shouldBeEqualTo token.sequence.toString()
+        adapter.release(owner, token) shouldBeEqualTo FencingReleaseResult.Released
+        commands.get(keys.counter) shouldBeEqualTo token.sequence.toString()
+        adapter.inspect(owner) shouldBeEqualTo FencingInspectResult.Lost
+    }
+
+    @Test
+    fun `expiry permits takeover only with a greater token`() = runSuspendIO {
+        adapter.bootstrap()
+        val first = adapter.acquire(owner, Duration.ofMillis(100))
+            .shouldBeInstanceOf<FencingAcquireResult.Acquired>().token
+
+        withTimeout(Duration.ofSeconds(5).toMillis()) {
+            while (adapter.inspect(owner) != FencingInspectResult.Lost) {
+                delay(20)
+            }
+        }
+        val second = adapter.acquire(contender, DEFAULT_LEASE)
+            .shouldBeInstanceOf<FencingAcquireResult.Acquired>().token
+
+        second shouldBeGreaterThan first
+    }
+
+    @Test
+    fun `cross epoch and invalid ttl fail before Redis dispatch`() = runSuspendIO {
+        adapter.bootstrap()
+        val before = commands.get(keys.counter)
+        val otherEpoch = FencingToken(12, 1)
+
+        assertFailsWith<IllegalArgumentException> {
+            adapter.acquire(owner, Duration.ZERO)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            adapter.acquire(owner, Duration.ofNanos(1))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            adapter.acquire(owner, Duration.ofMillis(MAX_EXACT_REDIS_LEASE_TIME_MILLIS + 1))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            adapter.renew(owner, otherEpoch, DEFAULT_LEASE)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            adapter.release(owner, otherEpoch)
+        }
+
+        commands.get(keys.counter) shouldBeEqualTo before
+        commands.exists(keys.lease) shouldBeEqualTo 0L
+    }
+
+    private companion object {
+        val DEFAULT_LEASE: Duration = Duration.ofSeconds(5)
+        val LONGER_LEASE: Duration = Duration.ofSeconds(30)
+
+        val connection by lazy { LettuceClients.connect(LettuceTestUtils.client, StringCodec.UTF8) }
+        val commands by lazy { connection.sync() }
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseDocumentationTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseDocumentationTest.kt
@@ -1,0 +1,389 @@
+package io.bluetape4k.redis.lettuce.lease
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeLessThan
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldContentEqual
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.redis.lettuce.LettuceClients
+import io.bluetape4k.redis.lettuce.LettuceTestUtils
+import io.bluetape4k.resilience4j.SuspendDecorators
+import io.github.resilience4j.bulkhead.Bulkhead
+import io.github.resilience4j.bulkhead.BulkheadConfig
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
+import io.github.resilience4j.retry.Retry
+import io.github.resilience4j.retry.RetryConfig
+import io.lettuce.core.ScriptOutputType
+import io.lettuce.core.codec.StringCodec
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+
+internal class FencingLeaseDocumentationTest {
+
+    @Test
+    fun `README locales preserve the fencing safety contract and executable examples`() = runSuspendIO {
+        val english = readModuleFile("README.md")
+        val korean = readModuleFile("README.ko.md")
+
+        markerOrder(english) shouldContentEqual REQUIRED_MARKERS
+        markerOrder(korean) shouldContentEqual REQUIRED_MARKERS
+        headingLevels(english) shouldContentEqual REQUIRED_HEADING_LEVELS
+        headingLevels(korean) shouldContentEqual REQUIRED_HEADING_LEVELS
+        REQUIRED_POLICY_FRAGMENTS.forEach { fragment ->
+            english shouldContain fragment
+            korean shouldContain fragment
+        }
+        REQUIRED_SECTION_CONTRACTS.forEach { (marker, orderedTerms) ->
+            assertOrderedTerms(section(english, marker), orderedTerms)
+            assertOrderedTerms(section(korean, marker), orderedTerms)
+        }
+
+        val resilienceSource = codeBlock(section(english, "resilience"), "kotlin")
+        resilienceSource shouldBeEqualTo codeBlock(section(korean, "resilience"), "kotlin")
+        val sqlSource = codeBlock(section(english, "downstream-guard"), "sql")
+        sqlSource shouldBeEqualTo codeBlock(section(korean, "downstream-guard"), "sql")
+        val diagnosticSource = codeBlock(section(english, "diagnostics"), "lua")
+        diagnosticSource shouldBeEqualTo codeBlock(section(korean, "diagnostics"), "lua")
+        diagnosticSource shouldBeEqualTo LettuceFencingLeaseRecoveryTest.FENCING_DIAGNOSTIC_LUA
+
+        assertExecutableResilienceExample(resilienceSource)
+        assertDownstreamGuardExample(sqlSource)
+        assertDiagnosticExample(diagnosticSource)
+    }
+
+    @Test
+    fun `public fencing API has English KDoc for caller owned safety boundaries`() {
+        val sourceByFile = KDocSource.entries.associateWith { readModuleFile(it.relativePath) }
+        sourceByFile.values.forEach { source ->
+            val declarations = PUBLIC_DECLARATION_PATTERN.findAll(source).toList()
+            declarations.isNotEmpty().shouldBeTrue()
+            declarations.forEach { declaration ->
+                assertKDocImmediatelyBefore(source, declaration.range.first)
+            }
+            declarations.asSequence()
+                .filter { it.value.trimStart().removePrefix("public ").startsWith("data class") }
+                .forEach { declaration ->
+                    assertDataClassPropertiesDocumented(source, declaration.range.first)
+                }
+        }
+
+        val combined = sourceByFile.values.joinToString("\n")
+        REQUIRED_KDOC_FRAGMENTS.forEach(combined::shouldContain)
+    }
+
+    private suspend fun assertExecutableResilienceExample(resilienceSource: String) {
+        val documentedConfig = documentedResilienceConfig(resilienceSource)
+        val attempts = AtomicInteger()
+        val retry = Retry.of(
+            "fencing-documentation",
+            RetryConfig.custom<FencingAcquireResult>()
+                .maxAttempts(documentedConfig.maxAttempts)
+                .waitDuration(Duration.ofMillis(documentedConfig.retryWaitMillis))
+                .retryOnResult { it is FencingAcquireResult.BackendFailure }
+                .retryOnException { false }
+                .build(),
+        )
+        val circuitBreaker = CircuitBreaker.of(
+            "fencing-documentation",
+            CircuitBreakerConfig.custom()
+                .slidingWindowSize(documentedConfig.slidingWindowSize)
+                .minimumNumberOfCalls(documentedConfig.minimumNumberOfCalls)
+                .failureRateThreshold(documentedConfig.failureRateThreshold)
+                .recordResult { it is FencingAcquireResult.BackendFailure }
+                .ignoreException { true }
+                .build(),
+        )
+        val bulkhead = Bulkhead.of(
+            "fencing-documentation",
+            BulkheadConfig.custom()
+                .maxConcurrentCalls(documentedConfig.maxConcurrentCalls)
+                .maxWaitDuration(Duration.ofMillis(documentedConfig.maxWaitMillis))
+                .build(),
+        )
+
+        val result = SuspendDecorators.ofSupplier {
+            if (attempts.incrementAndGet() == 1) BACKEND_FAILURE else ACQUIRED
+        }
+            .withRetry(retry)
+            .withCircuitBreaker(circuitBreaker)
+            .withBulkhead(bulkhead)
+            .invoke()
+
+        result shouldBeEqualTo ACQUIRED
+        attempts.get() shouldBeEqualTo 2
+    }
+
+    private fun documentedResilienceConfig(source: String): DocumentedResilienceConfig =
+        DocumentedResilienceConfig(
+            maxAttempts = source.intArgument(".maxAttempts("),
+            retryWaitMillis = source.longArgument(".waitDuration(Duration.ofMillis("),
+            slidingWindowSize = source.intArgument(".slidingWindowSize("),
+            minimumNumberOfCalls = source.intArgument(".minimumNumberOfCalls("),
+            failureRateThreshold = source.floatArgument(".failureRateThreshold("),
+            maxConcurrentCalls = source.intArgument(".maxConcurrentCalls("),
+            maxWaitMillis = source.longArgument(".maxWaitDuration(Duration.ofMillis("),
+        )
+
+    private fun String.intArgument(prefix: String): Int = argument(prefix, "[0-9]+").toInt()
+
+    private fun String.longArgument(prefix: String): Long = argument(prefix, "[0-9]+").toLong()
+
+    private fun String.floatArgument(prefix: String): Float =
+        argument(prefix, "[0-9]+(?:\\.[0-9]+)?F").removeSuffix("F").toFloat()
+
+    private fun String.argument(prefix: String, valuePattern: String): String =
+        requireNotNull(Regex("${Regex.escape(prefix)}($valuePattern)").find(this)) {
+            "Missing documented resilience call: $prefix"
+        }.groupValues[1]
+
+    private fun assertDownstreamGuardExample(sqlSource: String) {
+        sqlSource shouldContain "NOT NULL DEFAULT 0"
+        sqlSource shouldContain "(fence_epoch, fence_sequence) < (:epoch, :sequence)"
+
+        val store = GuardedStore()
+        store.update("invoice-42", FencingToken(9, 1), "payment-1") shouldBeEqualTo 1
+        store.update("invoice-42", FencingToken(9, 1), "payment-2") shouldBeEqualTo 0
+        store.update("invoice-42", FencingToken(8, Long.MAX_VALUE), "payment-3") shouldBeEqualTo 0
+        store.update("invoice-42", FencingToken(9, 2), "payment-1") shouldBeEqualTo 1
+        store.row("invoice-42") shouldBeEqualTo GuardedRow(FencingToken(9, 2), "payment-1")
+    }
+
+    private fun assertDiagnosticExample(diagnosticSource: String) {
+        diagnosticSource.indexOf("redis.call('STRLEN', KEYS[2])") shouldBeLessThan
+            diagnosticSource.indexOf("redis.call('GET', KEYS[2])")
+        LettuceClients.connect(LettuceTestUtils.client, StringCodec.UTF8).use { connection ->
+            val tag = LettuceTestUtils.randomName().substringAfter(':')
+            val config = LettuceFencingLeaseConfig("documentation", tag, 81)
+            val keys = deriveFencingLeaseKeys(config, StringCodec.UTF8)
+            val commands = connection.sync()
+            try {
+                commands.set(keys.counter, "9".repeat(20))
+                commands.evalReadOnly<String>(
+                    diagnosticSource,
+                    ScriptOutputType.MULTI,
+                    arrayOf(keys.lease, keys.counter),
+                    config.epoch.toString(),
+                ) shouldBeEqualTo listOf("COUNTER_INVALID", "0")
+
+                commands.set(keys.counter, "1")
+                commands.hset(
+                    keys.lease,
+                    mapOf("owner" to "owner", "epoch" to "81", "sequence" to "1"),
+                )
+                commands.evalReadOnly<String>(
+                    diagnosticSource,
+                    ScriptOutputType.MULTI,
+                    arrayOf(keys.lease, keys.counter),
+                    config.epoch.toString(),
+                ) shouldBeEqualTo listOf("LEASE_NO_TTL", "1")
+            } finally {
+                commands.del(keys.lease, keys.counter)
+            }
+        }
+    }
+
+    private fun markerOrder(readme: String): List<String> = MARKER_PATTERN.findAll(readme)
+        .map { it.groupValues[1] }
+        .toList()
+
+    private fun headingLevels(readme: String): List<Int> = MARKER_WITH_HEADING_PATTERN.findAll(readme)
+        .map { it.groupValues[2].length }
+        .toList()
+
+    private fun section(readme: String, marker: String): String {
+        val start = readme.indexOf("<!-- fencing-lease:$marker -->").shouldBeGreaterOrEqualTo(0)
+        val next = readme.indexOf("<!-- fencing-lease:", start + 1)
+        return readme.substring(start, if (next >= 0) next else readme.length)
+    }
+
+    private fun codeBlock(section: String, language: String): String {
+        val opening = "```$language"
+        val start = section.indexOf(opening).shouldBeGreaterOrEqualTo(0) + opening.length
+        val end = section.indexOf("```", start).shouldBeGreaterOrEqualTo(start)
+        return section.substring(start, end).trim()
+    }
+
+    private fun assertOrderedTerms(section: String, orderedTerms: List<String>) {
+        var cursor = 0
+        orderedTerms.forEach { term ->
+            val next = section.indexOf(term, cursor, ignoreCase = true)
+            next shouldBeGreaterOrEqualTo cursor
+            cursor = next + term.length
+        }
+    }
+
+    private fun assertKDocImmediatelyBefore(source: String, declarationIndex: Int) {
+        val prefix = source.substring(0, declarationIndex).trimEnd()
+        prefix.endsWith("*/").shouldBeTrue()
+        val kdocStart = prefix.lastIndexOf("/**").shouldBeGreaterOrEqualTo(0)
+        prefix.lastIndexOf("/*") shouldBeEqualTo kdocStart
+    }
+
+    private fun assertDataClassPropertiesDocumented(source: String, declarationIndex: Int) {
+        val openingParenthesis = source.indexOf('(', declarationIndex).shouldBeGreaterOrEqualTo(declarationIndex)
+        val closingParenthesis = matchingParenthesis(source, openingParenthesis)
+        val declarationHeader = source.substring(openingParenthesis + 1, closingParenthesis)
+        val kdoc = kdocImmediatelyBefore(source, declarationIndex)
+        PROPERTY_PATTERN.findAll(declarationHeader).forEach { property ->
+            kdoc shouldContain "@property ${property.groupValues[1]}"
+        }
+    }
+
+    private fun matchingParenthesis(source: String, openingIndex: Int): Int {
+        var depth = 0
+        source.forEachIndexed { index, character ->
+            if (index < openingIndex) return@forEachIndexed
+            when (character) {
+                '(' -> depth++
+                ')' -> {
+                    depth--
+                    if (depth == 0) return index
+                }
+            }
+        }
+        error("Unclosed data-class primary constructor at offset $openingIndex")
+    }
+
+    private fun kdocImmediatelyBefore(source: String, declarationIndex: Int): String {
+        val prefix = source.substring(0, declarationIndex).trimEnd()
+        val start = prefix.lastIndexOf("/**").shouldBeGreaterOrEqualTo(0)
+        return prefix.substring(start)
+    }
+
+    private fun readModuleFile(name: String): String {
+        val workingDirectory = Path.of(System.getProperty("user.dir"))
+        val moduleDirectory = if (workingDirectory.endsWith(Path.of("infra", "lettuce"))) {
+            workingDirectory
+        } else {
+            workingDirectory.resolve("infra/lettuce")
+        }
+        return Files.readString(moduleDirectory.resolve(name))
+    }
+
+    private data class GuardedRow(
+        val token: FencingToken,
+        val businessIdempotencyKey: String,
+    )
+
+    private class GuardedStore {
+        private val rows = mutableMapOf<String, GuardedRow>()
+
+        fun update(resourceId: String, token: FencingToken, businessIdempotencyKey: String): Int {
+            val current = rows[resourceId]
+            if (current != null && token <= current.token) return 0
+            rows[resourceId] = GuardedRow(token, businessIdempotencyKey)
+            return 1
+        }
+
+        fun row(resourceId: String): GuardedRow? = rows[resourceId]
+    }
+
+    private data class DocumentedResilienceConfig(
+        val maxAttempts: Int,
+        val retryWaitMillis: Long,
+        val slidingWindowSize: Int,
+        val minimumNumberOfCalls: Int,
+        val failureRateThreshold: Float,
+        val maxConcurrentCalls: Int,
+        val maxWaitMillis: Long,
+    )
+
+    private enum class KDocSource(val relativePath: String) {
+        VALUE("src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseValue.kt"),
+        RESULT("src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseResult.kt"),
+        BLOCKING("src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLease.kt"),
+        SUSPENDING("src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLease.kt"),
+    }
+
+    private companion object {
+        val REQUIRED_MARKERS = listOf(
+            "basic",
+            "downstream-guard",
+            "resilience",
+            "recovery",
+            "diagnostics",
+            "caller-actions",
+            "security-telemetry",
+            "limitations",
+        )
+        val REQUIRED_HEADING_LEVELS = listOf(3, 4, 4, 4, 4, 4, 4, 4)
+        val REQUIRED_POLICY_FRAGMENTS = listOf(
+            "LettuceFencingLeaseConfig",
+            "namespace",
+            "resourceName",
+            "epoch",
+            "bootstrap",
+            "CounterUnavailable",
+            "(epoch, sequence)",
+            "affectedRows == 1",
+            ".withRetry(retry)",
+            ".withCircuitBreaker(circuitBreaker)",
+            ".withBulkhead(bulkhead)",
+            "BackendFailure",
+            "pause",
+            "drain",
+            "CAS",
+            "readiness",
+            "rollout",
+            "resume",
+            "EVAL_RO",
+            "LEASE_NO_TTL",
+            "operation",
+            "result",
+            "kind",
+            "namespace/resource/owner/token/fingerprint",
+            "exactly-once",
+            "business idempotency",
+            "durable correctness",
+        )
+        val REQUIRED_SECTION_CONTRACTS = mapOf(
+            "resilience" to listOf(
+                ".maxAttempts(", ".waitDuration(", ".retryOnResult", ".retryOnException",
+                ".slidingWindowSize(", ".minimumNumberOfCalls(", ".failureRateThreshold(",
+                ".recordResult", ".ignoreException", ".maxConcurrentCalls(", ".maxWaitDuration(",
+                ".withRetry(retry)", ".withCircuitBreaker(circuitBreaker)", ".withBulkhead(bulkhead)",
+            ),
+            "caller-actions" to listOf(
+                "Initialized", "AlreadyInitialized", "Acquired", "AlreadyOwned", "Owned", "Renewed", "Released",
+                "acquire", "Contended", "inspect", "Contended", "Lost", "OwnershipMismatch", "CounterUnavailable",
+                "SequenceExhausted", "IntegrityFailure", "BackendFailure",
+            ),
+            "recovery" to listOf(
+                "pause", "block old acquire", "drain", "CAS", "bootstrap", "readiness", "rollout",
+                "confirm old absence", "resume",
+            ),
+        )
+        val REQUIRED_KDOC_FRAGMENTS = listOf(
+            "durable external authority",
+            "ambiguous",
+            "same owner ID",
+            "stable resource identity",
+            "not strictly greater",
+            "Redis Cluster",
+            "ordering, not durable business correctness",
+            "must not be lowered",
+        )
+        val MARKER_PATTERN = Regex("<!-- fencing-lease:([a-z-]+) -->")
+        val MARKER_WITH_HEADING_PATTERN = Regex(
+            "<!-- fencing-lease:([a-z-]+) -->\\s*\\n(#{3,4}) [^\\n]+",
+        )
+        val PUBLIC_DECLARATION_PATTERN = Regex(
+            """(?m)^[ \t]*(?!(?:private|internal|protected)\b)""" +
+                """(?:public\s+)?(?:(?:data\s+)?(?:class|object)\s+\w+|enum\s+class\s+\w+|""" +
+                """sealed\s+interface\s+\w+|companion\s+object|constructor\s*\(|""" +
+                """(?:override\s+)?(?:suspend\s+)?fun\s+\w+\s*\()""",
+        )
+        val PROPERTY_PATTERN = Regex("""\bval\s+(\w+)\s*:""")
+        val ACQUIRED = FencingAcquireResult.Acquired(FencingToken(1, 1))
+        val BACKEND_FAILURE = FencingAcquireResult.BackendFailure(
+            FencingLeaseBackendFailure(FencingBackendFailureKind.CONNECTION),
+        )
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseDocumentationTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseDocumentationTest.kt
@@ -8,7 +8,6 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldContentEqual
 import io.bluetape4k.junit5.coroutines.runSuspendIO
-import io.bluetape4k.redis.lettuce.LettuceClients
 import io.bluetape4k.redis.lettuce.LettuceTestUtils
 import io.bluetape4k.resilience4j.SuspendDecorators
 import io.github.resilience4j.bulkhead.Bulkhead
@@ -158,7 +157,7 @@ internal class FencingLeaseDocumentationTest {
     private fun assertDiagnosticExample(diagnosticSource: String) {
         diagnosticSource.indexOf("redis.call('STRLEN', KEYS[2])") shouldBeLessThan
             diagnosticSource.indexOf("redis.call('GET', KEYS[2])")
-        LettuceClients.connect(LettuceTestUtils.client, StringCodec.UTF8).use { connection ->
+        LettuceTestUtils.client.connect(StringCodec.UTF8).use { connection ->
             val tag = LettuceTestUtils.randomName().substringAfter(':')
             val config = LettuceFencingLeaseConfig("documentation", tag, 81)
             val keys = deriveFencingLeaseKeys(config, StringCodec.UTF8)

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseResultTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseResultTest.kt
@@ -1,0 +1,260 @@
+package io.bluetape4k.redis.lettuce.lease
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEmpty
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InvalidObjectException
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import java.io.ObjectStreamClass
+import java.io.Serializable
+import kotlin.reflect.KClass
+import kotlin.reflect.KVisibility
+import kotlin.reflect.full.memberProperties
+
+class FencingLeaseResultTest {
+
+    @Test
+    fun `all public results expose the documented values`() {
+        FencingBootstrapResult.Initialized shouldBeSameInstanceAs FencingBootstrapResult.Initialized
+        FencingBootstrapResult.AlreadyInitialized shouldBeSameInstanceAs FencingBootstrapResult.AlreadyInitialized
+
+        FencingAcquireResult.Acquired(token).token shouldBeEqualTo token
+        FencingAcquireResult.AlreadyOwned(token, 10).remainingTtlMillis shouldBeEqualTo 10L
+        FencingAcquireResult.Contended(9).remainingTtlMillis shouldBeEqualTo 9L
+        FencingAcquireResult.CounterUnavailable shouldBeSameInstanceAs FencingAcquireResult.CounterUnavailable
+        FencingAcquireResult.SequenceExhausted shouldBeSameInstanceAs FencingAcquireResult.SequenceExhausted
+
+        FencingInspectResult.Owned(token, 8).token shouldBeEqualTo token
+        FencingInspectResult.Lost shouldBeSameInstanceAs FencingInspectResult.Lost
+        FencingInspectResult.Contended(7).remainingTtlMillis shouldBeEqualTo 7L
+
+        FencingRenewResult.Renewed shouldBeSameInstanceAs FencingRenewResult.Renewed
+        FencingRenewResult.Lost shouldBeSameInstanceAs FencingRenewResult.Lost
+        FencingRenewResult.OwnershipMismatch shouldBeSameInstanceAs FencingRenewResult.OwnershipMismatch
+
+        FencingReleaseResult.Released shouldBeSameInstanceAs FencingReleaseResult.Released
+        FencingReleaseResult.Lost shouldBeSameInstanceAs FencingReleaseResult.Lost
+        FencingReleaseResult.OwnershipMismatch shouldBeSameInstanceAs FencingReleaseResult.OwnershipMismatch
+    }
+
+    @Test
+    fun `ttl results reject negative values`() {
+        assertFailsWith<IllegalArgumentException> { FencingAcquireResult.AlreadyOwned(token, -1) }
+        assertFailsWith<IllegalArgumentException> { FencingAcquireResult.Contended(-1) }
+        assertFailsWith<IllegalArgumentException> { FencingInspectResult.Owned(token, -1) }
+        assertFailsWith<IllegalArgumentException> { FencingInspectResult.Contended(-1) }
+    }
+
+    @Test
+    fun `all non-enum values and result variants have stable serialization contracts`() {
+        serializableSamples.forEach { original ->
+            val restored = javaRoundTrip(original)
+
+            restored shouldBeEqualTo original
+            restored.javaClass shouldBeSameInstanceAs original.javaClass
+            ObjectStreamClass.lookup(original.javaClass).serialVersionUID shouldBeEqualTo 1L
+        }
+    }
+
+    @Test
+    fun `all sealed result contracts declare serial version uid`() {
+        resultContracts.forEach { contract ->
+            val companionClass = contract.java.declaredClasses.single { nested -> nested.simpleName == "Companion" }
+            val serialVersionUid = companionClass.getDeclaredField("serialVersionUID").also { field ->
+                field.isAccessible = true
+            }
+
+            serialVersionUid.getLong(null) shouldBeEqualTo 1L
+        }
+    }
+
+    @Test
+    fun `all result singleton variants preserve identity after serialization`() {
+        singletonSamples.forEach { original ->
+            javaRoundTrip(original) shouldBeSameInstanceAs original
+        }
+    }
+
+    @Test
+    fun `failure enums preserve identity after serialization`() {
+        enumSamples.forEach { original ->
+            javaRoundTrip(original) shouldBeSameInstanceAs original
+        }
+    }
+
+    @Test
+    fun `deserialization revalidates ttl result variants`() {
+        val invalidSamples = listOf(
+            FencingAcquireResult.AlreadyOwned(token, 1).withField("remainingTtlMillis", -1L) to
+                "Invalid serialized FencingAcquireResult.AlreadyOwned.",
+            FencingAcquireResult.Contended(1).withField("remainingTtlMillis", -1L) to
+                "Invalid serialized FencingAcquireResult.Contended.",
+            FencingInspectResult.Owned(token, 1).withField("remainingTtlMillis", -1L) to
+                "Invalid serialized FencingInspectResult.Owned.",
+            FencingInspectResult.Contended(1).withField("remainingTtlMillis", -1L) to
+                "Invalid serialized FencingInspectResult.Contended.",
+        )
+
+        invalidSamples.forEach { (invalid, expectedMessage) ->
+            val error = assertFailsWith<InvalidObjectException> { javaRoundTrip(invalid) }
+            error.cause shouldBeEqualTo null
+            error.message shouldBeEqualTo expectedMessage
+        }
+    }
+
+    @Test
+    fun `deserialization rejects null nested failure without leaking a sentinel`() {
+        val invalidSamples = listOf(
+            FencingBootstrapResult.IntegrityFailure(integrityFailure).withField("failure", null) to
+                "Invalid serialized FencingBootstrapResult.IntegrityFailure.",
+            FencingAcquireResult.BackendFailure(backendFailure).withField("failure", null) to
+                "Invalid serialized FencingAcquireResult.BackendFailure.",
+            FencingInspectResult.IntegrityFailure(integrityFailure).withField("failure", null) to
+                "Invalid serialized FencingInspectResult.IntegrityFailure.",
+            FencingRenewResult.BackendFailure(backendFailure).withField("failure", null) to
+                "Invalid serialized FencingRenewResult.BackendFailure.",
+            FencingReleaseResult.IntegrityFailure(integrityFailure).withField("failure", null) to
+                "Invalid serialized FencingReleaseResult.IntegrityFailure.",
+        )
+
+        invalidSamples.forEach { (invalid, expectedMessage) ->
+            val error = assertFailsWith<InvalidObjectException> { javaRoundTrip(invalid) }
+            error.cause shouldBeEqualTo null
+            error.message shouldBeEqualTo expectedMessage
+        }
+    }
+
+    @Test
+    fun `deserialization rejects null failure kind with a stable cause-free message`() {
+        val invalidSamples = listOf(
+            FencingLeaseBackendFailure(FencingBackendFailureKind.COMMAND).withField("kind", null) to
+                "Invalid serialized FencingLeaseBackendFailure.",
+            FencingLeaseIntegrityFailure(FencingIntegrityFailureKind.MALFORMED_LEASE).withField("kind", null) to
+                "Invalid serialized FencingLeaseIntegrityFailure.",
+        )
+
+        invalidSamples.forEach { (invalid, expectedMessage) ->
+            val error = assertFailsWith<InvalidObjectException> { javaRoundTrip(invalid) }
+            error.cause shouldBeEqualTo null
+            error.message shouldBeEqualTo expectedMessage
+        }
+    }
+
+    @Test
+    fun `failure values expose no raw backend details`() {
+        val forbiddenProperties = failureTypes
+            .flatMap { type -> type.memberProperties }
+            .filter { property ->
+                property.visibility == KVisibility.PUBLIC && (
+                    property.name.contains("key", ignoreCase = true) ||
+                        property.name.contains("owner", ignoreCase = true) ||
+                        property.name.contains("token", ignoreCase = true) ||
+                        property.name.contains("raw", ignoreCase = true) ||
+                        property.name.contains("message", ignoreCase = true) ||
+                        Throwable::class.java.isAssignableFrom(property.returnType.classifier.let { it as? KClass<*> }?.java)
+                    )
+            }
+
+        forbiddenProperties.shouldBeEmpty()
+    }
+
+    @Test
+    fun `sealed result variants never expose key owner raw reply throwable or message properties`() {
+        val forbiddenProperties = resultContracts
+            .flatMap { contract -> contract.sealedSubclasses }
+            .flatMap { subtype -> subtype.memberProperties }
+            .filter { property ->
+                property.visibility == KVisibility.PUBLIC && (
+                    property.name.contains("key", ignoreCase = true) ||
+                        property.name.contains("owner", ignoreCase = true) ||
+                        property.name.contains("raw", ignoreCase = true) ||
+                        property.name.contains("reply", ignoreCase = true) ||
+                        property.name.contains("message", ignoreCase = true) ||
+                        Throwable::class.java.isAssignableFrom(property.returnType.classifier.let { it as? KClass<*> }?.java)
+                    )
+            }
+
+        forbiddenProperties.shouldBeEmpty()
+    }
+
+    private fun <T: Serializable> T.withField(name: String, value: Any?): T = apply {
+        javaClass.getDeclaredField(name).also { field ->
+            field.isAccessible = true
+            field.set(this, value)
+        }
+    }
+
+    private fun javaRoundTrip(original: Serializable): Any =
+        ByteArrayOutputStream().use { bytes ->
+            ObjectOutputStream(bytes).use { output -> output.writeObject(original) }
+            ObjectInputStream(ByteArrayInputStream(bytes.toByteArray())).use { input -> input.readObject() }
+        }
+
+    private companion object {
+        val token = FencingToken(7, 42)
+        val backendFailure = FencingLeaseBackendFailure(FencingBackendFailureKind.TIMEOUT)
+        val integrityFailure = FencingLeaseIntegrityFailure(FencingIntegrityFailureKind.INVALID_COUNTER)
+
+        val singletonSamples: List<Serializable> = listOf(
+            FencingBootstrapResult.Initialized,
+            FencingBootstrapResult.AlreadyInitialized,
+            FencingAcquireResult.CounterUnavailable,
+            FencingAcquireResult.SequenceExhausted,
+            FencingInspectResult.Lost,
+            FencingRenewResult.Renewed,
+            FencingRenewResult.Lost,
+            FencingRenewResult.OwnershipMismatch,
+            FencingReleaseResult.Released,
+            FencingReleaseResult.Lost,
+            FencingReleaseResult.OwnershipMismatch,
+        )
+
+        val serializableSamples: List<Serializable> = listOf(
+            backendFailure,
+            integrityFailure,
+            *singletonSamples.toTypedArray(),
+            FencingBootstrapResult.IntegrityFailure(integrityFailure),
+            FencingBootstrapResult.BackendFailure(backendFailure),
+            FencingAcquireResult.Acquired(token),
+            FencingAcquireResult.AlreadyOwned(token, 10),
+            FencingAcquireResult.Contended(9),
+            FencingAcquireResult.IntegrityFailure(integrityFailure),
+            FencingAcquireResult.BackendFailure(backendFailure),
+            FencingInspectResult.Owned(token, 8),
+            FencingInspectResult.Contended(7),
+            FencingInspectResult.IntegrityFailure(integrityFailure),
+            FencingInspectResult.BackendFailure(backendFailure),
+            FencingRenewResult.IntegrityFailure(integrityFailure),
+            FencingRenewResult.BackendFailure(backendFailure),
+            FencingReleaseResult.IntegrityFailure(integrityFailure),
+            FencingReleaseResult.BackendFailure(backendFailure),
+        )
+
+        val enumSamples: List<Serializable> = listOf(
+            FencingBackendFailureKind.CONNECTION,
+            FencingBackendFailureKind.TIMEOUT,
+            FencingBackendFailureKind.COMMAND,
+            FencingIntegrityFailureKind.MALFORMED_LEASE,
+            FencingIntegrityFailureKind.INVALID_COUNTER,
+            FencingIntegrityFailureKind.COUNTER_BEHIND_LEASE,
+        )
+
+        val failureTypes = listOf(
+            FencingLeaseBackendFailure::class,
+            FencingLeaseIntegrityFailure::class,
+        )
+
+        val resultContracts = listOf(
+            FencingBootstrapResult::class,
+            FencingAcquireResult::class,
+            FencingInspectResult::class,
+            FencingRenewResult::class,
+            FencingReleaseResult::class,
+        )
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseValueTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseValueTest.kt
@@ -1,0 +1,151 @@
+package io.bluetape4k.redis.lettuce.lease
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeLessThan
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeEqualTo
+import io.bluetape4k.assertions.shouldNotContain
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InvalidObjectException
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import java.io.ObjectStreamClass
+import java.io.Serializable
+
+class FencingLeaseValueTest {
+
+    @Test
+    fun `config accepts safe ordering domain values`() {
+        val config = LettuceFencingLeaseConfig(
+            namespace = "n".repeat(128),
+            resourceName = "resource-1._safe",
+            epoch = 1,
+        )
+
+        config.namespace shouldBeEqualTo "n".repeat(128)
+        config.resourceName shouldBeEqualTo "resource-1._safe"
+        config.epoch shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `config rejects unsafe ordering domain values`() {
+        listOf("", "n".repeat(129), "white space", "hash{tag}", "colon:value", "line\nbreak").forEach { value ->
+            assertFailsWith<IllegalArgumentException> {
+                LettuceFencingLeaseConfig(value, "resource", 1)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                LettuceFencingLeaseConfig("namespace", value, 1)
+            }
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LettuceFencingLeaseConfig("namespace", "resource", 0)
+        }
+    }
+
+    @Test
+    fun `owner id validates UTF-8 byte length and redacts text`() {
+        val ascii = "a".repeat(256)
+        val utf8 = "한".repeat(85)
+
+        FencingOwnerId.from(ascii).toString() shouldBeEqualTo "FencingOwnerId(<redacted>)"
+        FencingOwnerId.from(utf8).toString() shouldBeEqualTo "FencingOwnerId(<redacted>)"
+        FencingOwnerId.from("secret-owner").toString() shouldNotContain "secret-owner"
+
+        listOf("", "   ", "a".repeat(257), "한".repeat(86)).forEach { value ->
+            assertFailsWith<IllegalArgumentException> { FencingOwnerId.from(value) }
+        }
+    }
+
+    @Test
+    fun `owner id equality uses the raw opaque value`() {
+        val first = FencingOwnerId.from("attempt-1")
+        val same = FencingOwnerId.from("attempt-1")
+        val other = FencingOwnerId.from("attempt-2")
+
+        first shouldBeEqualTo same
+        first.hashCode() shouldBeEqualTo same.hashCode()
+        first shouldNotBeEqualTo other
+    }
+
+    @Test
+    fun `random owner id uses a fresh 22 character value`() {
+        val first = FencingOwnerId.random()
+        val second = FencingOwnerId.random()
+
+        first.value.length shouldBeEqualTo 22
+        second.value.length shouldBeEqualTo 22
+        first.value.all { character -> character in BASE58_ALPHABET }.shouldBeTrue()
+        second.value.all { character -> character in BASE58_ALPHABET }.shouldBeTrue()
+        first shouldNotBeEqualTo second
+    }
+
+    @Test
+    fun `token validates positive components and orders epoch before sequence`() {
+        val epochOneLast = FencingToken(1, Long.MAX_VALUE)
+        val epochTwoFirst = FencingToken(2, 1)
+
+        FencingToken(1, 1).compareTo(FencingToken(1, 2)) shouldBeLessThan 0
+        FencingToken(1, 2).compareTo(FencingToken(1, 2)) shouldBeEqualTo 0
+        epochOneLast.compareTo(epochTwoFirst) shouldBeLessThan 0
+        epochTwoFirst.toString() shouldBeEqualTo "FencingToken(<redacted>)"
+        epochTwoFirst.toString() shouldNotContain "2"
+
+        assertFailsWith<IllegalArgumentException> { FencingToken(0, 1) }
+        assertFailsWith<IllegalArgumentException> { FencingToken(1, 0) }
+    }
+
+    @Test
+    fun `value objects have stable Java serialization contracts`() {
+        val samples = listOf<Serializable>(
+            LettuceFencingLeaseConfig("orders", "rebuild", 7),
+            FencingOwnerId.from("attempt-1"),
+            FencingToken(7, 42),
+        )
+
+        samples.forEach { original ->
+            javaRoundTrip(original) shouldBeEqualTo original
+            ObjectStreamClass.lookup(original.javaClass).serialVersionUID shouldBeEqualTo 1L
+        }
+    }
+
+    @Test
+    fun `deserialization revalidates config owner and token without leaking raw values`() {
+        val invalidConfigs = listOf(
+            LettuceFencingLeaseConfig("orders", "rebuild", 7).withField("namespace", "secret namespace"),
+            LettuceFencingLeaseConfig("orders", "rebuild", 7).withField("namespace", null),
+            LettuceFencingLeaseConfig("orders", "rebuild", 7).withField("resourceName", null),
+        )
+        val invalidOwner = FencingOwnerId.from("attempt-1")
+            .withField("value", null)
+        val invalidToken = FencingToken(7, 42)
+            .withField("sequence", 0L)
+
+        (invalidConfigs + listOf(invalidOwner, invalidToken)).forEach { invalid ->
+            val error = assertFailsWith<InvalidObjectException> { javaRoundTrip(invalid) }
+            error.cause shouldBeEqualTo null
+            error.message shouldBeEqualTo "Invalid serialized ${invalid.javaClass.simpleName}."
+            error.message shouldNotContain "secret namespace"
+            error.message shouldNotContain "attempt-1"
+        }
+    }
+
+    private fun <T: Serializable> T.withField(name: String, value: Any?): T = apply {
+        javaClass.getDeclaredField(name).also { field ->
+            field.isAccessible = true
+            field.set(this, value)
+        }
+    }
+
+    private fun javaRoundTrip(original: Serializable): Any =
+        ByteArrayOutputStream().use { bytes ->
+            ObjectOutputStream(bytes).use { output -> output.writeObject(original) }
+            ObjectInputStream(ByteArrayInputStream(bytes.toByteArray())).use { input -> input.readObject() }
+        }
+
+    private companion object {
+        const val BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseCancellationTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseCancellationTest.kt
@@ -1,0 +1,402 @@
+package io.bluetape4k.redis.lettuce.lease
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeLessOrEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.redis.lettuce.AbstractLettuceTest
+import io.bluetape4k.redis.lettuce.LettuceClients
+import io.bluetape4k.redis.lettuce.LettuceTestUtils
+import io.lettuce.core.RedisConnectionException
+import io.lettuce.core.codec.StringCodec
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal class LettuceFencingLeaseCancellationTest : AbstractLettuceTest() {
+
+    @Test
+    fun `backend failure before and after apply has operation specific reconciliation`() {
+        mutationOperations.forEach { operation ->
+            FaultPhase.entries.forEach { phase ->
+                withFixture(operation, phase) { fixture ->
+                    val context = prepare(operation, fixture.healthy)
+                    val executor = OneShotFaultExecutor(fixture.defaultExecutor, operation, phase)
+                    val lease = LettuceFencingLease.createForTesting(executor, StringCodec.UTF8, fixture.config)
+
+                    assertBackendFailure(operation, invokeSync(operation, lease, context))
+                    reconcile(operation, phase, fixture.healthy, context)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `future cancellation preserves cancelled state before and after every mutation`() {
+        mutationOperations.forEach { operation ->
+            FaultPhase.entries.forEach { phase ->
+                withFixture(operation, phase) { fixture ->
+                    val context = prepare(operation, fixture.healthy)
+                    val executor = ControlledCancellationExecutor(fixture.defaultExecutor, operation, phase)
+                    val lease = LettuceFencingLease.createForTesting(executor, StringCodec.UTF8, fixture.config)
+
+                    val result = invokeFuture(operation, lease, context)
+                    result.cancel(true).shouldBeTrue()
+                    result.isCancelled.shouldBeTrue()
+                    executor.pending.isCancelled.shouldBeTrue()
+                    reconcile(operation, phase, fixture.healthy, context)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `coroutine cancellation remains cancellation before and after every mutation`() = runSuspendIO {
+        mutationOperations.forEach { operation ->
+            FaultPhase.entries.forEach { phase ->
+                withFixture(operation, phase) { fixture ->
+                    val context = prepare(operation, fixture.healthy)
+                    val executor = ControlledCancellationExecutor(fixture.defaultExecutor, operation, phase)
+                    val lease = LettuceSuspendFencingLease.createForTesting(executor, StringCodec.UTF8, fixture.config)
+                    val observed = CompletableDeferred<Throwable>()
+
+                    val job = launch {
+                        try {
+                            invokeSuspending(operation, lease, context)
+                        } catch (failure: Throwable) {
+                            observed.complete(failure)
+                            throw failure
+                        }
+                    }
+                    executor.started.await()
+                    job.cancelAndJoin()
+
+                    observed.await().shouldBeInstanceOf<CancellationException>()
+                    reconcile(operation, phase, fixture.healthy, context)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `release ambiguity does not authorize retry for unsafe inspection results`() {
+        withFixture(FencingLeaseOperation.RELEASE, FaultPhase.BEFORE_APPLY) { fixture ->
+            fixture.healthy.bootstrap()
+            val original = fixture.healthy.acquire(OWNER, INITIAL_LEASE)
+                .shouldBeInstanceOf<FencingAcquireResult.Acquired>().token
+
+            fixture.healthy.release(OWNER, original) shouldBeEqualTo FencingReleaseResult.Released
+            val contenderToken = fixture.healthy.acquire(CONTENDER, INITIAL_LEASE)
+                .shouldBeInstanceOf<FencingAcquireResult.Acquired>().token
+            fixture.healthy.inspect(OWNER).shouldBeInstanceOf<FencingInspectResult.Contended>()
+            fixture.healthy.release(OWNER, original) shouldBeEqualTo FencingReleaseResult.OwnershipMismatch
+            fixture.healthy.inspect(CONTENDER)
+                .shouldBeInstanceOf<FencingInspectResult.Owned>().token shouldBeEqualTo contenderToken
+
+            fixture.healthy.release(CONTENDER, contenderToken) shouldBeEqualTo FencingReleaseResult.Released
+            val newer = fixture.healthy.acquire(OWNER, INITIAL_LEASE)
+                .shouldBeInstanceOf<FencingAcquireResult.Acquired>().token
+            newer shouldBeGreaterThan original
+            fixture.healthy.inspect(OWNER)
+                .shouldBeInstanceOf<FencingInspectResult.Owned>().token shouldBeEqualTo newer
+            fixture.healthy.release(OWNER, original) shouldBeEqualTo FencingReleaseResult.OwnershipMismatch
+            fixture.healthy.inspect(OWNER)
+                .shouldBeInstanceOf<FencingInspectResult.Owned>().token shouldBeEqualTo newer
+
+            commands.set(fixture.keys.lease, "corrupted")
+            fixture.healthy.inspect(OWNER).shouldBeInstanceOf<FencingInspectResult.IntegrityFailure>()
+            fixture.healthy.release(OWNER, original).shouldBeInstanceOf<FencingReleaseResult.IntegrityFailure>()
+            commands.get(fixture.keys.lease) shouldBeEqualTo "corrupted"
+
+            val backendExecutor = OneShotFaultExecutor(
+                fixture.defaultExecutor,
+                FencingLeaseOperation.INSPECT,
+                FaultPhase.BEFORE_APPLY,
+            )
+            val backendLease = LettuceFencingLease.createForTesting(
+                backendExecutor,
+                StringCodec.UTF8,
+                fixture.config,
+            )
+            backendLease.inspect(OWNER).shouldBeInstanceOf<FencingInspectResult.BackendFailure>()
+            backendExecutor.calls shouldBeEqualTo listOf(FencingLeaseOperation.INSPECT)
+        }
+    }
+
+    private fun prepare(
+        operation: FencingLeaseOperation,
+        healthy: LettuceFencingLease,
+    ): OperationContext = when (operation) {
+        FencingLeaseOperation.BOOTSTRAP -> OperationContext()
+        FencingLeaseOperation.ACQUIRE -> {
+            healthy.bootstrap() shouldBeEqualTo FencingBootstrapResult.Initialized
+            OperationContext()
+        }
+        FencingLeaseOperation.RENEW,
+        FencingLeaseOperation.RELEASE,
+        -> {
+            healthy.bootstrap() shouldBeEqualTo FencingBootstrapResult.Initialized
+            val token = healthy.acquire(OWNER, INITIAL_LEASE)
+                .shouldBeInstanceOf<FencingAcquireResult.Acquired>().token
+            OperationContext(token)
+        }
+        FencingLeaseOperation.INSPECT -> error("Inspect is not a mutation operation.")
+    }
+
+    private fun invokeSync(
+        operation: FencingLeaseOperation,
+        lease: LettuceFencingLease,
+        context: OperationContext,
+    ): Any = when (operation) {
+        FencingLeaseOperation.BOOTSTRAP -> lease.bootstrap()
+        FencingLeaseOperation.ACQUIRE -> lease.acquire(OWNER, INITIAL_LEASE)
+        FencingLeaseOperation.RENEW -> lease.renew(OWNER, context.requiredToken(), RENEWED_LEASE)
+        FencingLeaseOperation.RELEASE -> lease.release(OWNER, context.requiredToken())
+        FencingLeaseOperation.INSPECT -> error("Inspect is not a mutation operation.")
+    }
+
+    private fun invokeFuture(
+        operation: FencingLeaseOperation,
+        lease: LettuceFencingLease,
+        context: OperationContext,
+    ): CompletableFuture<*> = when (operation) {
+        FencingLeaseOperation.BOOTSTRAP -> lease.bootstrapAsync()
+        FencingLeaseOperation.ACQUIRE -> lease.acquireAsync(OWNER, INITIAL_LEASE)
+        FencingLeaseOperation.RENEW -> lease.renewAsync(OWNER, context.requiredToken(), RENEWED_LEASE)
+        FencingLeaseOperation.RELEASE -> lease.releaseAsync(OWNER, context.requiredToken())
+        FencingLeaseOperation.INSPECT -> error("Inspect is not a mutation operation.")
+    }
+
+    private suspend fun invokeSuspending(
+        operation: FencingLeaseOperation,
+        lease: LettuceSuspendFencingLease,
+        context: OperationContext,
+    ): Any = when (operation) {
+        FencingLeaseOperation.BOOTSTRAP -> lease.bootstrap()
+        FencingLeaseOperation.ACQUIRE -> lease.acquire(OWNER, INITIAL_LEASE)
+        FencingLeaseOperation.RENEW -> lease.renew(OWNER, context.requiredToken(), RENEWED_LEASE)
+        FencingLeaseOperation.RELEASE -> lease.release(OWNER, context.requiredToken())
+        FencingLeaseOperation.INSPECT -> error("Inspect is not a mutation operation.")
+    }
+
+    private fun assertBackendFailure(operation: FencingLeaseOperation, result: Any) {
+        val failure = when (operation) {
+            FencingLeaseOperation.BOOTSTRAP ->
+                result.shouldBeInstanceOf<FencingBootstrapResult.BackendFailure>().failure
+            FencingLeaseOperation.ACQUIRE ->
+                result.shouldBeInstanceOf<FencingAcquireResult.BackendFailure>().failure
+            FencingLeaseOperation.RENEW ->
+                result.shouldBeInstanceOf<FencingRenewResult.BackendFailure>().failure
+            FencingLeaseOperation.RELEASE ->
+                result.shouldBeInstanceOf<FencingReleaseResult.BackendFailure>().failure
+            FencingLeaseOperation.INSPECT -> error("Inspect is not a mutation operation.")
+        }
+        failure.kind shouldBeEqualTo FencingBackendFailureKind.CONNECTION
+    }
+
+    private fun reconcile(
+        operation: FencingLeaseOperation,
+        phase: FaultPhase,
+        healthy: LettuceFencingLease,
+        context: OperationContext,
+    ) {
+        when (operation) {
+            FencingLeaseOperation.BOOTSTRAP -> {
+                val expected = if (phase == FaultPhase.BEFORE_APPLY) {
+                    FencingBootstrapResult.Initialized
+                } else {
+                    FencingBootstrapResult.AlreadyInitialized
+                }
+                healthy.bootstrap() shouldBeEqualTo expected
+            }
+            FencingLeaseOperation.ACQUIRE -> {
+                val result = healthy.acquire(OWNER, INITIAL_LEASE)
+                val token = if (phase == FaultPhase.BEFORE_APPLY) {
+                    result.shouldBeInstanceOf<FencingAcquireResult.Acquired>().token
+                } else {
+                    result.shouldBeInstanceOf<FencingAcquireResult.AlreadyOwned>().token
+                }
+                token shouldBeEqualTo FencingToken(CONFIG_EPOCH, 1)
+            }
+            FencingLeaseOperation.RENEW -> {
+                val owned = healthy.inspect(OWNER).shouldBeInstanceOf<FencingInspectResult.Owned>()
+                owned.token shouldBeEqualTo context.requiredToken()
+                if (phase == FaultPhase.BEFORE_APPLY) {
+                    owned.remainingTtlMillis shouldBeLessOrEqualTo INITIAL_LEASE.toMillis()
+                } else {
+                    owned.remainingTtlMillis shouldBeGreaterThan RENEWED_LEASE.toMillis() - TTL_TOLERANCE_MILLIS
+                }
+                healthy.renew(OWNER, context.requiredToken(), RENEWED_LEASE) shouldBeEqualTo
+                    FencingRenewResult.Renewed
+            }
+            FencingLeaseOperation.RELEASE -> {
+                if (phase == FaultPhase.BEFORE_APPLY) {
+                    val owned = healthy.inspect(OWNER).shouldBeInstanceOf<FencingInspectResult.Owned>()
+                    owned.token shouldBeEqualTo context.requiredToken()
+                    healthy.release(OWNER, context.requiredToken()) shouldBeEqualTo FencingReleaseResult.Released
+                } else {
+                    healthy.inspect(OWNER) shouldBeSameInstanceAs FencingInspectResult.Lost
+                }
+            }
+            FencingLeaseOperation.INSPECT -> error("Inspect is not a mutation operation.")
+        }
+    }
+
+    private inline fun withFixture(
+        operation: FencingLeaseOperation,
+        phase: FaultPhase,
+        block: (Fixture) -> Unit,
+    ) {
+        val suffix = randomName().substringAfter(':')
+        val config = LettuceFencingLeaseConfig(
+            "cancellation",
+            "${operation.name.lowercase()}-${phase.name.lowercase()}-$suffix",
+            CONFIG_EPOCH,
+        )
+        val keys = deriveFencingLeaseKeys(config, StringCodec.UTF8)
+        val defaultExecutor = DefaultFencingScriptExecutor(connection.sync(), connection.async())
+        val fixture = Fixture(
+            config,
+            keys,
+            defaultExecutor,
+            LettuceFencingLease.createForTesting(defaultExecutor, StringCodec.UTF8, config),
+        )
+        try {
+            block(fixture)
+        } finally {
+            commands.del(keys.lease, keys.counter)
+        }
+    }
+
+    private data class Fixture(
+        val config: LettuceFencingLeaseConfig,
+        val keys: FencingLeaseKeys,
+        val defaultExecutor: DefaultFencingScriptExecutor,
+        val healthy: LettuceFencingLease,
+    )
+
+    private data class OperationContext(
+        val token: FencingToken? = null,
+    ) {
+        fun requiredToken(): FencingToken = requireNotNull(token)
+    }
+
+    private enum class FaultPhase {
+        BEFORE_APPLY,
+        AFTER_APPLY_BEFORE_REPLY,
+    }
+
+    private class OneShotFaultExecutor(
+        private val delegate: FencingScriptExecutor,
+        private val target: FencingLeaseOperation,
+        private val phase: FaultPhase,
+    ): FencingScriptExecutor {
+        private val armed = AtomicBoolean(true)
+        val calls = mutableListOf<FencingLeaseOperation>()
+
+        override fun run(
+            operation: FencingLeaseOperation,
+            keys: FencingLeaseKeys,
+            args: List<String>,
+        ): List<String> {
+            calls += operation
+            if (operation != target || !armed.compareAndSet(true, false)) {
+                return delegate.run(operation, keys, args)
+            }
+            if (phase == FaultPhase.BEFORE_APPLY) {
+                throw backendFailure()
+            }
+            delegate.run(operation, keys, args)
+            throw backendFailure()
+        }
+
+        override fun runAsync(
+            operation: FencingLeaseOperation,
+            keys: FencingLeaseKeys,
+            args: List<String>,
+        ): CompletableFuture<List<String>> = delegate.runAsync(operation, keys, args)
+
+        override suspend fun runSuspending(
+            operation: FencingLeaseOperation,
+            keys: FencingLeaseKeys,
+            args: List<String>,
+        ): List<String> = delegate.runSuspending(operation, keys, args)
+
+        private fun backendFailure(): RedisConnectionException =
+            RedisConnectionException("fault injection sentinel")
+    }
+
+    private class ControlledCancellationExecutor(
+        private val delegate: FencingScriptExecutor,
+        private val target: FencingLeaseOperation,
+        private val phase: FaultPhase,
+    ): FencingScriptExecutor {
+        val pending = CompletableFuture<List<String>>()
+        val started = CompletableDeferred<Unit>()
+
+        override fun run(
+            operation: FencingLeaseOperation,
+            keys: FencingLeaseKeys,
+            args: List<String>,
+        ): List<String> = delegate.run(operation, keys, args)
+
+        override fun runAsync(
+            operation: FencingLeaseOperation,
+            keys: FencingLeaseKeys,
+            args: List<String>,
+        ): CompletableFuture<List<String>> {
+            require(operation == target)
+            applyIfRequired(operation, keys, args)
+            started.complete(Unit)
+            return pending
+        }
+
+        override suspend fun runSuspending(
+            operation: FencingLeaseOperation,
+            keys: FencingLeaseKeys,
+            args: List<String>,
+        ): List<String> {
+            require(operation == target)
+            applyIfRequired(operation, keys, args)
+            started.complete(Unit)
+            return suspendCancellableCoroutine { }
+        }
+
+        private fun applyIfRequired(
+            operation: FencingLeaseOperation,
+            keys: FencingLeaseKeys,
+            args: List<String>,
+        ) {
+            if (phase == FaultPhase.AFTER_APPLY_BEFORE_REPLY) {
+                delegate.run(operation, keys, args)
+            }
+        }
+    }
+
+    private companion object {
+        const val CONFIG_EPOCH: Long = 17
+        const val TTL_TOLERANCE_MILLIS: Long = 5_000
+        val INITIAL_LEASE: Duration = Duration.ofSeconds(30)
+        val RENEWED_LEASE: Duration = Duration.ofMinutes(5)
+        val OWNER: FencingOwnerId = FencingOwnerId.from("cancellation-owner")
+        val CONTENDER: FencingOwnerId = FencingOwnerId.from("cancellation-contender")
+        val mutationOperations = listOf(
+            FencingLeaseOperation.BOOTSTRAP,
+            FencingLeaseOperation.ACQUIRE,
+            FencingLeaseOperation.RENEW,
+            FencingLeaseOperation.RELEASE,
+        )
+
+        val connection by lazy { LettuceClients.connect(LettuceTestUtils.client, StringCodec.UTF8) }
+        val commands by lazy { connection.sync() }
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseClusterTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseClusterTest.kt
@@ -1,0 +1,266 @@
+package io.bluetape4k.redis.lettuce.lease
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeEqualTo
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.redis.lettuce.LettuceTestUtils
+import io.bluetape4k.testcontainers.storage.RedisClusterServer
+import io.lettuce.core.cluster.SlotHash
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
+import io.lettuce.core.cluster.api.async.RedisAdvancedClusterAsyncCommands
+import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands
+import io.lettuce.core.codec.RedisCodec
+import io.mockk.Called
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.future.await
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CyclicBarrier
+
+/** Verifies that one fencing domain remains on one Redis Cluster slot across every execution style. */
+internal class LettuceFencingLeaseClusterTest {
+
+    @Test
+    @Timeout(30)
+    fun `cluster issues unique generations under mixed sync future and suspend contention`() = runSuspendIO {
+        val server = RedisClusterServer.Launcher.redisCluster
+        RedisClusterServer.Launcher.LettuceLib.getClusterClient(server).use { client ->
+            client.connect().use { connection ->
+                val config = newConfig("contention")
+                val keys = deriveFencingLeaseKeys(config, connection.codec)
+                val adapters = clusterAdapters(connection, config)
+                val commands = connection.sync()
+                val tokens = mutableListOf<FencingToken>()
+                try {
+                    adapters.first().bootstrap() shouldBeEqualTo FencingBootstrapResult.Initialized
+
+                    repeat(CLUSTER_ROUNDS) { round ->
+                        val barrier = CyclicBarrier(CLUSTER_CALLERS)
+                        val attempts = ConcurrentLinkedQueue<ClusterAttempt>()
+                        val tasks = List<suspend () -> Unit>(CLUSTER_CALLERS) { caller ->
+                            val ownerId = FencingOwnerId.from("cluster-owner-$round-$caller")
+                            val adapterIndex = caller % adapters.size
+                            val task: suspend () -> Unit = {
+                                barrier.await()
+                                attempts += ClusterAttempt(
+                                    ownerId,
+                                    adapterIndex,
+                                    adapters[adapterIndex].acquire(ownerId, LEASE_TIME),
+                                )
+                            }
+                            task
+                        }
+
+                        SuspendedJobTester()
+                            .workers(CLUSTER_CALLERS)
+                            .rounds(1)
+                            .addAll(tasks)
+                            .run()
+
+                        val winner = verifyClusterRound(attempts)
+                        val winnerAdapter = adapters[winner.adapterIndex]
+                        val replay = winnerAdapter.acquire(winner.ownerId, LONGER_LEASE)
+                            .shouldBeInstanceOf<FencingAcquireResult.AlreadyOwned>()
+                        replay.token shouldBeEqualTo winner.token
+                        commands.get(keys.counter) shouldBeEqualTo winner.token.sequence.toString()
+                        winnerAdapter.release(winner.ownerId, winner.token) shouldBeEqualTo
+                            FencingReleaseResult.Released
+                        tokens += winner.token
+                    }
+
+                    tokens.size shouldBeEqualTo CLUSTER_ROUNDS
+                    tokens.toSet().size shouldBeEqualTo CLUSTER_ROUNDS
+                    tokens.zipWithNext().forEach { (previous, next) -> next shouldBeGreaterThan previous }
+                } finally {
+                    commands.del(keys.lease, keys.counter)
+                }
+            }
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    fun `cluster preserves complete result parity for every execution style`() = runSuspendIO {
+        val server = RedisClusterServer.Launcher.redisCluster
+        RedisClusterServer.Launcher.LettuceLib.getClusterClient(server).use { client ->
+            client.connect().use { connection ->
+                val commands = connection.sync()
+                clusterAdapterFactories(connection).forEachIndexed { index, factory ->
+                    val config = newConfig("parity-$index")
+                    val keys = deriveFencingLeaseKeys(config, connection.codec)
+                    val adapter = factory(config)
+                    val ownerId = FencingOwnerId.from("cluster-parity-owner-$index")
+                    try {
+                        adapter.bootstrap() shouldBeEqualTo FencingBootstrapResult.Initialized
+                        val acquired = adapter.acquire(ownerId, LEASE_TIME)
+                            .shouldBeInstanceOf<FencingAcquireResult.Acquired>()
+                        val replay = adapter.acquire(ownerId, LONGER_LEASE)
+                            .shouldBeInstanceOf<FencingAcquireResult.AlreadyOwned>()
+                        replay.token shouldBeEqualTo acquired.token
+                        adapter.inspect(ownerId)
+                            .shouldBeInstanceOf<FencingInspectResult.Owned>().token shouldBeEqualTo acquired.token
+                        adapter.renew(ownerId, acquired.token, LONGER_LEASE) shouldBeEqualTo FencingRenewResult.Renewed
+                        adapter.release(ownerId, acquired.token) shouldBeEqualTo FencingReleaseResult.Released
+                        adapter.inspect(ownerId) shouldBeEqualTo FencingInspectResult.Lost
+                    } finally {
+                        commands.del(keys.lease, keys.counter)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `wire split codec rejects public cluster facades before Redis dispatch`() {
+        val syncCommands = mockk<RedisAdvancedClusterCommands<String, String>>(relaxed = true)
+        val asyncCommands = mockk<RedisAdvancedClusterAsyncCommands<String, String>>(relaxed = true)
+        val connection = mockk<StatefulRedisClusterConnection<String, String>>()
+        every { connection.sync() } returns syncCommands
+        every { connection.async() } returns asyncCommands
+        every { connection.codec } returns SplitSlotWireCodec
+        val config = LettuceFencingLeaseConfig("cluster", "wire-split", 29)
+        val keys = FencingLeaseKeys(
+            "fence:{cluster:wire-split}:29:lease",
+            "fence:{cluster:wire-split}:29:counter",
+        )
+        SlotHash.getSlot(SplitSlotWireCodec.encodeKey(keys.lease)) shouldNotBeEqualTo
+            SlotHash.getSlot(SplitSlotWireCodec.encodeKey(keys.counter))
+        assertFailsWith<IllegalArgumentException> { LettuceFencingLease(connection, config) }
+        assertFailsWith<IllegalArgumentException> { LettuceSuspendFencingLease(connection, config) }
+
+        verify { syncCommands wasNot Called }
+        verify { asyncCommands wasNot Called }
+    }
+
+    private fun clusterAdapters(
+        connection: StatefulRedisClusterConnection<String, String>,
+        config: LettuceFencingLeaseConfig,
+    ): List<FencingLeaseAdapter> = clusterAdapterFactories(connection).map { factory -> factory(config) }
+
+    private fun clusterAdapterFactories(
+        connection: StatefulRedisClusterConnection<String, String>,
+    ): List<(LettuceFencingLeaseConfig) -> FencingLeaseAdapter> = listOf(
+        { config ->
+            val lease = LettuceFencingLease(connection, config)
+            object: FencingLeaseAdapter {
+                override suspend fun bootstrap(): FencingBootstrapResult = lease.bootstrap()
+                override suspend fun acquire(ownerId: FencingOwnerId, leaseTime: Duration): FencingAcquireResult =
+                    lease.acquire(ownerId, leaseTime)
+                override suspend fun inspect(ownerId: FencingOwnerId): FencingInspectResult = lease.inspect(ownerId)
+                override suspend fun renew(
+                    ownerId: FencingOwnerId,
+                    token: FencingToken,
+                    leaseTime: Duration,
+                ): FencingRenewResult = lease.renew(ownerId, token, leaseTime)
+                override suspend fun release(ownerId: FencingOwnerId, token: FencingToken): FencingReleaseResult =
+                    lease.release(ownerId, token)
+            }
+        },
+        { config ->
+            val lease = LettuceFencingLease(connection, config)
+            object: FencingLeaseAdapter {
+                override suspend fun bootstrap(): FencingBootstrapResult = lease.bootstrapAsync().await()
+                override suspend fun acquire(ownerId: FencingOwnerId, leaseTime: Duration): FencingAcquireResult =
+                    lease.acquireAsync(ownerId, leaseTime).await()
+                override suspend fun inspect(ownerId: FencingOwnerId): FencingInspectResult =
+                    lease.inspectAsync(ownerId).await()
+                override suspend fun renew(
+                    ownerId: FencingOwnerId,
+                    token: FencingToken,
+                    leaseTime: Duration,
+                ): FencingRenewResult = lease.renewAsync(ownerId, token, leaseTime).await()
+                override suspend fun release(ownerId: FencingOwnerId, token: FencingToken): FencingReleaseResult =
+                    lease.releaseAsync(ownerId, token).await()
+            }
+        },
+        { config ->
+            val lease = LettuceSuspendFencingLease(connection, config)
+            object: FencingLeaseAdapter {
+                override suspend fun bootstrap(): FencingBootstrapResult = lease.bootstrap()
+                override suspend fun acquire(ownerId: FencingOwnerId, leaseTime: Duration): FencingAcquireResult =
+                    lease.acquire(ownerId, leaseTime)
+                override suspend fun inspect(ownerId: FencingOwnerId): FencingInspectResult = lease.inspect(ownerId)
+                override suspend fun renew(
+                    ownerId: FencingOwnerId,
+                    token: FencingToken,
+                    leaseTime: Duration,
+                ): FencingRenewResult = lease.renew(ownerId, token, leaseTime)
+                override suspend fun release(ownerId: FencingOwnerId, token: FencingToken): FencingReleaseResult =
+                    lease.release(ownerId, token)
+            }
+        },
+    )
+
+    private fun verifyClusterRound(attempts: Collection<ClusterAttempt>): ClusterWinner {
+        attempts.size shouldBeEqualTo CLUSTER_CALLERS
+        val acquired = attempts.filter { it.result is FencingAcquireResult.Acquired }
+        attempts.count { it.result is FencingAcquireResult.Contended } shouldBeEqualTo CLUSTER_CALLERS - 1
+        acquired.size shouldBeEqualTo 1
+        return acquired.single().let { attempt ->
+            ClusterWinner(
+                attempt.ownerId,
+                attempt.adapterIndex,
+                attempt.result.shouldBeInstanceOf<FencingAcquireResult.Acquired>().token,
+            )
+        }
+    }
+
+    private fun newConfig(suffix: String): LettuceFencingLeaseConfig =
+        LettuceFencingLeaseConfig(
+            "cluster",
+            "$suffix-${LettuceTestUtils.randomName().substringAfter(':')}",
+            31,
+        )
+
+    private data class ClusterAttempt(
+        val ownerId: FencingOwnerId,
+        val adapterIndex: Int,
+        val result: FencingAcquireResult,
+    )
+
+    private data class ClusterWinner(
+        val ownerId: FencingOwnerId,
+        val adapterIndex: Int,
+        val token: FencingToken,
+    )
+
+    private object SplitSlotWireCodec : RedisCodec<String, String> {
+        override fun decodeKey(bytes: ByteBuffer): String = decode(bytes)
+        override fun decodeValue(bytes: ByteBuffer): String = decode(bytes)
+        override fun encodeKey(key: String): ByteBuffer =
+            encode(if (key.endsWith(":lease")) "wire:{one}" else "wire:{two}")
+        override fun encodeValue(value: String): ByteBuffer = encode(value)
+
+        private fun encode(value: String): ByteBuffer =
+            ByteBuffer.wrap(value.toByteArray(StandardCharsets.UTF_8))
+
+        private fun decode(bytes: ByteBuffer): String = bytes.duplicate().let { copy ->
+            ByteArray(copy.remaining()).also(copy::get).toString(StandardCharsets.UTF_8)
+        }
+    }
+
+    private companion object {
+        const val CLUSTER_CALLERS: Int = 8
+        const val CLUSTER_ROUNDS: Int = 10
+        val LEASE_TIME: Duration = Duration.ofSeconds(10)
+        val LONGER_LEASE: Duration = Duration.ofSeconds(30)
+
+        @BeforeAll
+        @JvmStatic
+        fun warmRedisCluster() {
+            RedisClusterServer.Launcher.redisCluster.isRunning.shouldBeTrue()
+        }
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseConcurrencyTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseConcurrencyTest.kt
@@ -1,0 +1,164 @@
+package io.bluetape4k.redis.lettuce.lease
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.redis.lettuce.AbstractLettuceTest
+import io.bluetape4k.redis.lettuce.LettuceClients
+import io.bluetape4k.redis.lettuce.LettuceTestUtils
+import io.lettuce.core.codec.StringCodec
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.time.Duration
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CyclicBarrier
+
+/**
+ * Proves bounded fencing-token uniqueness for one hot resource serialized by one Redis slot.
+ *
+ * These tests verify ordering and duplicate absence; they intentionally do not define a latency SLA.
+ */
+internal class LettuceFencingLeaseConcurrencyTest : AbstractLettuceTest() {
+
+    @Test
+    @Timeout(30)
+    fun `sync callers issue one unique generation per bounded contention round`() {
+        val config = newConfig("sync")
+        val keys = deriveFencingLeaseKeys(config, StringCodec.UTF8)
+        val lease = LettuceFencingLease(connection, config)
+        val tokens = mutableListOf<FencingToken>()
+        try {
+            lease.bootstrap() shouldBeEqualTo FencingBootstrapResult.Initialized
+
+            repeat(ROUNDS) { round ->
+                val barrier = CyclicBarrier(CALLERS)
+                val attempts = ConcurrentLinkedQueue<Attempt>()
+                val tasks = List(CALLERS) { caller ->
+                    val ownerId = owner(round, caller)
+                    val task: () -> Unit = {
+                        barrier.await()
+                        attempts += Attempt(ownerId, lease.acquire(ownerId, LEASE_TIME))
+                    }
+                    task
+                }
+
+                MultithreadingTester()
+                    .workers(CALLERS)
+                    .rounds(1)
+                    .addAll(tasks)
+                    .run()
+
+                val winner = verifyRound(attempts)
+                val replay = lease.acquire(winner.ownerId, LONGER_LEASE)
+                    .shouldBeInstanceOf<FencingAcquireResult.AlreadyOwned>()
+                replay.token shouldBeEqualTo winner.token
+                commands.get(keys.counter) shouldBeEqualTo winner.token.sequence.toString()
+                lease.release(winner.ownerId, winner.token) shouldBeEqualTo FencingReleaseResult.Released
+                tokens += winner.token
+            }
+
+            verifyTokens(tokens, ROUNDS)
+        } finally {
+            commands.del(keys.lease, keys.counter)
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    fun `suspend callers issue one unique generation per bounded contention round`() = runSuspendIO {
+        val config = newConfig("suspend")
+        val keys = deriveFencingLeaseKeys(config, StringCodec.UTF8)
+        val lease = LettuceSuspendFencingLease(connection, config)
+        val tokens = mutableListOf<FencingToken>()
+        try {
+            lease.bootstrap() shouldBeEqualTo FencingBootstrapResult.Initialized
+
+            repeat(ROUNDS) { round ->
+                val barrier = CyclicBarrier(CALLERS)
+                val attempts = ConcurrentLinkedQueue<Attempt>()
+                val tasks = List<suspend () -> Unit>(CALLERS) { caller ->
+                    val ownerId = owner(round, caller)
+                    val task: suspend () -> Unit = {
+                        barrier.await()
+                        attempts += Attempt(ownerId, lease.acquire(ownerId, LEASE_TIME))
+                    }
+                    task
+                }
+
+                SuspendedJobTester()
+                    .workers(CALLERS)
+                    .rounds(1)
+                    .addAll(tasks)
+                    .run()
+
+                val winner = verifyRound(attempts)
+                val replay = lease.acquire(winner.ownerId, LONGER_LEASE)
+                    .shouldBeInstanceOf<FencingAcquireResult.AlreadyOwned>()
+                replay.token shouldBeEqualTo winner.token
+                commands.get(keys.counter) shouldBeEqualTo winner.token.sequence.toString()
+                lease.release(winner.ownerId, winner.token) shouldBeEqualTo FencingReleaseResult.Released
+                tokens += winner.token
+            }
+
+            verifyTokens(tokens, ROUNDS)
+        } finally {
+            commands.del(keys.lease, keys.counter)
+        }
+    }
+
+    private fun verifyRound(attempts: Collection<Attempt>): Winner {
+        attempts.size shouldBeEqualTo CALLERS
+        val acquired = attempts.filter { it.result is FencingAcquireResult.Acquired }
+        val contended = attempts.filter { it.result is FencingAcquireResult.Contended }
+        acquired.size shouldBeEqualTo 1
+        contended.size shouldBeEqualTo CALLERS - 1
+        return acquired.single().let { attempt ->
+            Winner(
+                attempt.ownerId,
+                attempt.result.shouldBeInstanceOf<FencingAcquireResult.Acquired>().token,
+            )
+        }
+    }
+
+    private fun verifyTokens(tokens: List<FencingToken>, expected: Int) {
+        tokens.size shouldBeEqualTo expected
+        tokens.toSet().size shouldBeEqualTo expected
+        tokens.zipWithNext().forEach { (previous, next) -> next shouldBeGreaterThan previous }
+    }
+
+    private fun newConfig(style: String): LettuceFencingLeaseConfig =
+        LettuceFencingLeaseConfig("contention", "$style-${randomName().substringAfter(':')}", 23)
+
+    private fun owner(round: Int, caller: Int): FencingOwnerId =
+        FencingOwnerId.from("owner-$round-$caller")
+
+    private data class Attempt(
+        val ownerId: FencingOwnerId,
+        val result: FencingAcquireResult,
+    )
+
+    private data class Winner(
+        val ownerId: FencingOwnerId,
+        val token: FencingToken,
+    )
+
+    private companion object {
+        const val CALLERS: Int = 16
+        const val ROUNDS: Int = 25
+        val LEASE_TIME: Duration = Duration.ofSeconds(10)
+        val LONGER_LEASE: Duration = Duration.ofSeconds(30)
+
+        val connection by lazy { LettuceClients.connect(LettuceTestUtils.client, StringCodec.UTF8) }
+        val commands by lazy { connection.sync() }
+
+        @BeforeAll
+        @JvmStatic
+        fun warmStandaloneRedis() {
+            connection.sync().ping() shouldBeEqualTo "PONG"
+        }
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseFailureTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseFailureTest.kt
@@ -1,0 +1,230 @@
+package io.bluetape4k.redis.lettuce.lease
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeInstanceOf
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.lettuce.core.RedisCommandTimeoutException
+import io.lettuce.core.RedisConnectionException
+import io.lettuce.core.RedisException
+import io.lettuce.core.RedisFuture
+import io.lettuce.core.RedisNoScriptException
+import io.lettuce.core.ScriptOutputType
+import io.lettuce.core.api.async.RedisScriptingAsyncCommands
+import io.lettuce.core.api.sync.RedisScriptingCommands
+import io.lettuce.core.codec.StringCodec
+import io.mockk.Called
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import java.io.Serializable
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+internal class LettuceFencingLeaseFailureTest {
+
+    @Test
+    fun `execution facades are not serializable`() {
+        lease(mockk()).shouldNotBeInstanceOf<Serializable>()
+        suspendLease(mockk<RedisScriptingAsyncCommands<String, String>>())
+            .shouldNotBeInstanceOf<Serializable>()
+    }
+
+    @Test
+    fun `sync future and suspend facades classify the same backend failures`() = runSuspendIO {
+        val failures = listOf(
+            RedisConnectionException("connection sentinel") to FencingBackendFailureKind.CONNECTION,
+            RedisCommandTimeoutException("timeout sentinel") to FencingBackendFailureKind.TIMEOUT,
+            RedisException("command sentinel") to FencingBackendFailureKind.COMMAND,
+        )
+
+        failures.forEach { (error, expectedKind) ->
+            syncLease(error).bootstrap()
+                .shouldBeInstanceOf<FencingBootstrapResult.BackendFailure>()
+                .failure.kind shouldBeEqualTo expectedKind
+            futureLease(error).bootstrapAsync().get()
+                .shouldBeInstanceOf<FencingBootstrapResult.BackendFailure>()
+                .failure.kind shouldBeEqualTo expectedKind
+            suspendLease(error).bootstrap()
+                .shouldBeInstanceOf<FencingBootstrapResult.BackendFailure>()
+                .failure.kind shouldBeEqualTo expectedKind
+        }
+    }
+
+    @Test
+    fun `decoder and unknown failures remain exceptions for every facade`() = runSuspendIO {
+        val unknown = IllegalStateException("unknown sentinel")
+
+        assertFailsWith<IllegalStateException> { syncLease(unknown).bootstrap() } shouldBeSameInstanceAs unknown
+        assertFailsWith<ExecutionException> { futureLease(unknown).bootstrapAsync().get() }
+            .cause shouldBeSameInstanceAs unknown
+        assertFailsWith<IllegalStateException> { suspendLease(unknown).bootstrap() } shouldBeSameInstanceAs unknown
+
+        assertFailsWith<FencingLeaseProtocolException> { syncLease(frame = malformedFrame).bootstrap() }
+        assertFailsWith<ExecutionException> { futureLease(frame = malformedFrame).bootstrapAsync().get() }
+            .cause.shouldBeInstanceOf<FencingLeaseProtocolException>()
+        assertFailsWith<FencingLeaseProtocolException> { suspendLease(frame = malformedFrame).bootstrap() }
+    }
+
+    @Test
+    fun `future completes exceptionally when an unknown error escapes classification`() {
+        val error = AssertionError("error sentinel")
+
+        assertFailsWith<ExecutionException> {
+            futureLease(error).bootstrapAsync().get(1, TimeUnit.SECONDS)
+        }.cause shouldBeSameInstanceAs error
+    }
+
+    @Test
+    fun `invalid inputs fail before every facade dispatches Redis commands`() = runSuspendIO {
+        val syncCommands = mockk<RedisScriptingCommands<String, String>>()
+        val futureCommands = mockk<RedisScriptingAsyncCommands<String, String>>()
+        val suspendCommands = mockk<RedisScriptingAsyncCommands<String, String>>()
+        val lease = LettuceFencingLease.fromCommands(syncCommands, futureCommands, StringCodec.UTF8, config)
+        val suspendLease = LettuceSuspendFencingLease.fromCommands(suspendCommands, StringCodec.UTF8, config)
+        val ownerId = FencingOwnerId.from("validation-owner")
+        val otherEpoch = FencingToken(config.epoch + 1, 1)
+        val invalidLeaseTimes = listOf(
+            Duration.ZERO,
+            Duration.ofNanos(1),
+            Duration.ofMillis(MAX_EXACT_REDIS_LEASE_TIME_MILLIS + 1),
+        )
+
+        invalidLeaseTimes.forEach { leaseTime ->
+            assertFailsWith<IllegalArgumentException> { lease.acquire(ownerId, leaseTime) }
+            assertFailsWith<IllegalArgumentException> { lease.acquireAsync(ownerId, leaseTime) }
+            assertFailsWith<IllegalArgumentException> { suspendLease.acquire(ownerId, leaseTime) }
+        }
+        assertFailsWith<IllegalArgumentException> { lease.renew(ownerId, otherEpoch, Duration.ofSeconds(1)) }
+        assertFailsWith<IllegalArgumentException> { lease.renewAsync(ownerId, otherEpoch, Duration.ofSeconds(1)) }
+        assertFailsWith<IllegalArgumentException> { suspendLease.renew(ownerId, otherEpoch, Duration.ofSeconds(1)) }
+        assertFailsWith<IllegalArgumentException> { lease.release(ownerId, otherEpoch) }
+        assertFailsWith<IllegalArgumentException> { lease.releaseAsync(ownerId, otherEpoch) }
+        assertFailsWith<IllegalArgumentException> { suspendLease.release(ownerId, otherEpoch) }
+
+        verify { syncCommands wasNot Called }
+        verify { futureCommands wasNot Called }
+        verify { suspendCommands wasNot Called }
+    }
+
+    @Test
+    fun `public future cancellation reaches evalsha and noscript eval`() {
+        val evalsha = TestRedisFuture<List<String>>()
+        val commands = asyncCommands(evalsha)
+        val result = lease(commands).bootstrapAsync()
+
+        result.cancel(true).shouldBeTrue()
+        result.isCancelled.shouldBeTrue()
+        evalsha.isCancelled.shouldBeTrue()
+
+        val noScript = failedRedisFuture<List<String>>(RedisNoScriptException("NOSCRIPT"))
+        val fallback = TestRedisFuture<List<String>>()
+        val fallbackCommands = asyncCommands(noScript, fallback)
+        val fallbackResult = lease(fallbackCommands).bootstrapAsync()
+
+        fallbackResult.cancel(true).shouldBeTrue()
+        fallbackResult.isCancelled.shouldBeTrue()
+        fallback.isCancelled.shouldBeTrue()
+    }
+
+    private fun syncLease(error: Throwable): LettuceFencingLease {
+        val commands = mockk<RedisScriptingCommands<String, String>>()
+        every {
+            commands.evalsha<List<String>>(
+                FencingLeaseScripts.BOOTSTRAP.sha1,
+                ScriptOutputType.MULTI,
+                scriptKeys,
+                config.epoch.toString(),
+            )
+        } throws error
+        return LettuceFencingLease.fromCommands(commands, mockk(), StringCodec.UTF8, config)
+    }
+
+    private fun futureLease(error: Throwable): LettuceFencingLease =
+        lease(asyncCommands(failedRedisFuture(error)))
+
+    private fun suspendLease(error: Throwable): LettuceSuspendFencingLease =
+        suspendLease(asyncCommands(failedRedisFuture(error)))
+
+    private fun syncLease(frame: List<String>): LettuceFencingLease {
+        val commands = mockk<RedisScriptingCommands<String, String>>()
+        every {
+            commands.evalsha<List<String>>(
+                FencingLeaseScripts.BOOTSTRAP.sha1,
+                ScriptOutputType.MULTI,
+                scriptKeys,
+                config.epoch.toString(),
+            )
+        } returns frame
+        return LettuceFencingLease.fromCommands(commands, mockk(), StringCodec.UTF8, config)
+    }
+
+    private fun futureLease(frame: List<String>): LettuceFencingLease =
+        lease(asyncCommands(completedRedisFuture(frame)))
+
+    private fun suspendLease(frame: List<String>): LettuceSuspendFencingLease =
+        suspendLease(asyncCommands(completedRedisFuture(frame)))
+
+    private fun lease(commands: RedisScriptingAsyncCommands<String, String>): LettuceFencingLease =
+        LettuceFencingLease.fromCommands(mockk(), commands, StringCodec.UTF8, config)
+
+    private fun suspendLease(commands: RedisScriptingAsyncCommands<String, String>): LettuceSuspendFencingLease =
+        LettuceSuspendFencingLease.fromCommands(commands, StringCodec.UTF8, config)
+
+    private fun asyncCommands(
+        evalsha: RedisFuture<List<String>>,
+        eval: RedisFuture<List<String>>? = null,
+    ): RedisScriptingAsyncCommands<String, String> {
+        val commands = mockk<RedisScriptingAsyncCommands<String, String>>()
+        every {
+            commands.evalsha<List<String>>(
+                FencingLeaseScripts.BOOTSTRAP.sha1,
+                ScriptOutputType.MULTI,
+                scriptKeys,
+                config.epoch.toString(),
+            )
+        } returns evalsha
+        if (eval != null) {
+            every {
+                commands.eval<List<String>>(
+                    FencingLeaseScripts.BOOTSTRAP.source,
+                    ScriptOutputType.MULTI,
+                    scriptKeys,
+                    config.epoch.toString(),
+                )
+            } returns eval
+        }
+        return commands
+    }
+
+    private fun <T> completedRedisFuture(value: T): RedisFuture<T> =
+        TestRedisFuture<T>().apply { complete(value) }
+
+    private fun <T> failedRedisFuture(error: Throwable): RedisFuture<T> =
+        TestRedisFuture<T>().apply { completeExceptionally(error) }
+
+    private class TestRedisFuture<T> : CompletableFuture<T>(), RedisFuture<T> {
+        override fun getError(): String? = if (isCompletedExceptionally) "completed exceptionally" else null
+
+        override fun await(timeout: Long, unit: TimeUnit): Boolean = try {
+            get(timeout, unit)
+            true
+        } catch (_: TimeoutException) {
+            false
+        }
+    }
+
+    private companion object {
+        val config = LettuceFencingLeaseConfig("failure", "fixture", 13)
+        val keys = deriveFencingLeaseKeys(config, StringCodec.UTF8)
+        val scriptKeys = arrayOf(keys.lease, keys.counter)
+        val malformedFrame = listOf("UNKNOWN", "0", "0", "-1")
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseFailureTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseFailureTest.kt
@@ -87,8 +87,16 @@ internal class LettuceFencingLeaseFailureTest {
         val syncCommands = mockk<RedisScriptingCommands<String, String>>()
         val futureCommands = mockk<RedisScriptingAsyncCommands<String, String>>()
         val suspendCommands = mockk<RedisScriptingAsyncCommands<String, String>>()
-        val lease = LettuceFencingLease.fromCommands(syncCommands, futureCommands, StringCodec.UTF8, config)
-        val suspendLease = LettuceSuspendFencingLease.fromCommands(suspendCommands, StringCodec.UTF8, config)
+        val lease = LettuceFencingLease.createForTesting(
+            DefaultFencingScriptExecutor(syncCommands, futureCommands),
+            StringCodec.UTF8,
+            config,
+        )
+        val suspendLease = LettuceSuspendFencingLease.createForTesting(
+            DefaultFencingScriptExecutor(mockk(), suspendCommands),
+            StringCodec.UTF8,
+            config,
+        )
         val ownerId = FencingOwnerId.from("validation-owner")
         val otherEpoch = FencingToken(config.epoch + 1, 1)
         val invalidLeaseTimes = listOf(
@@ -144,7 +152,11 @@ internal class LettuceFencingLeaseFailureTest {
                 config.epoch.toString(),
             )
         } throws error
-        return LettuceFencingLease.fromCommands(commands, mockk(), StringCodec.UTF8, config)
+        return LettuceFencingLease.createForTesting(
+            DefaultFencingScriptExecutor(commands, mockk()),
+            StringCodec.UTF8,
+            config,
+        )
     }
 
     private fun futureLease(error: Throwable): LettuceFencingLease =
@@ -163,7 +175,11 @@ internal class LettuceFencingLeaseFailureTest {
                 config.epoch.toString(),
             )
         } returns frame
-        return LettuceFencingLease.fromCommands(commands, mockk(), StringCodec.UTF8, config)
+        return LettuceFencingLease.createForTesting(
+            DefaultFencingScriptExecutor(commands, mockk()),
+            StringCodec.UTF8,
+            config,
+        )
     }
 
     private fun futureLease(frame: List<String>): LettuceFencingLease =
@@ -173,10 +189,18 @@ internal class LettuceFencingLeaseFailureTest {
         suspendLease(asyncCommands(completedRedisFuture(frame)))
 
     private fun lease(commands: RedisScriptingAsyncCommands<String, String>): LettuceFencingLease =
-        LettuceFencingLease.fromCommands(mockk(), commands, StringCodec.UTF8, config)
+        LettuceFencingLease.createForTesting(
+            DefaultFencingScriptExecutor(mockk(), commands),
+            StringCodec.UTF8,
+            config,
+        )
 
     private fun suspendLease(commands: RedisScriptingAsyncCommands<String, String>): LettuceSuspendFencingLease =
-        LettuceSuspendFencingLease.fromCommands(commands, StringCodec.UTF8, config)
+        LettuceSuspendFencingLease.createForTesting(
+            DefaultFencingScriptExecutor(mockk(), commands),
+            StringCodec.UTF8,
+            config,
+        )
 
     private fun asyncCommands(
         evalsha: RedisFuture<List<String>>,

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseRecoveryTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseRecoveryTest.kt
@@ -1,0 +1,414 @@
+package io.bluetape4k.redis.lettuce.lease
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.redis.lettuce.LettuceClients
+import io.bluetape4k.redis.lettuce.LettuceTestUtils
+import io.lettuce.core.ScriptOutputType
+import io.lettuce.core.api.sync.RedisCommands
+import io.lettuce.core.codec.StringCodec
+import org.junit.jupiter.api.Test
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+/** Demonstrates durable epoch cutover and downstream tuple rejection outside the Redis primitive. */
+internal class LettuceFencingLeaseRecoveryTest {
+
+    @Test
+    fun `downstream accepts only a newer tuple and keeps business idempotency separate`() {
+        val store = DownstreamStore()
+        val resourceId = "invoice-42"
+        val first = FencingToken(7, 1)
+        val next = FencingToken(7, 2)
+
+        store.write(resourceId, first, "payment-1") shouldBeEqualTo 1
+        store.write(resourceId, first, "payment-2") shouldBeEqualTo 0
+        store.write(resourceId, FencingToken(6, Long.MAX_VALUE), "payment-3") shouldBeEqualTo 0
+        store.write(resourceId, next, "payment-1") shouldBeEqualTo 1
+
+        store.row(resourceId) shouldBeEqualTo GuardedRow(resourceId, next, "payment-1")
+    }
+
+    @Test
+    fun `durable CAS has one winner and non durable sources cannot allocate epochs`() {
+        val authority = DurableEpochAuthority(11)
+        val barrier = CyclicBarrier(3)
+        val results = ConcurrentLinkedQueue<Boolean>()
+        val executor = Executors.newFixedThreadPool(3)
+        try {
+            val futures = List(3) {
+                executor.submit {
+                    barrier.await()
+                    results += authority.compareAndSet(11, 12)
+                }
+            }
+            futures.forEach { it.get(5, TimeUnit.SECONDS) }
+        } finally {
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).shouldBeTrue()
+        }
+
+        results.count { it } shouldBeEqualTo 1
+        authority.currentEpoch shouldBeEqualTo 12
+        val localConfig = LocalConfigEpochSource(12)
+        val redisCounter = RedisCounterEpochSource(12)
+        localConfig.observedEpoch shouldBeEqualTo 12
+        redisCounter.observedEpoch shouldBeEqualTo 12
+        localConfig.allocateNextEpoch().shouldBeFalse()
+        redisCounter.allocateNextEpoch().shouldBeFalse()
+    }
+
+    @Test
+    fun `control plane follows the exact cutover order and aborts on mixed epochs`() {
+        val authority = DurableEpochAuthority(20)
+        val successful = RecoveryControlPlane(authority).cutover(
+            observedEpochs = setOf(20),
+            requestedEpoch = 21,
+            readiness = Readiness(counterReady = true, downstreamTupleGuardEnabled = true),
+        )
+
+        successful.shouldBeTrue()
+        successful.events shouldBeEqualTo listOf(
+            RecoveryEvent.PAUSE,
+            RecoveryEvent.BLOCK_OLD_ACQUIRE,
+            RecoveryEvent.DRAIN,
+            RecoveryEvent.CAS_BUMP,
+            RecoveryEvent.BOOTSTRAP,
+            RecoveryEvent.READINESS,
+            RecoveryEvent.ROLLOUT,
+            RecoveryEvent.CONFIRM_OLD_ABSENCE,
+            RecoveryEvent.RESUME,
+        )
+
+        val mixed = RecoveryControlPlane(authority).cutover(
+            observedEpochs = setOf(20, 21),
+            requestedEpoch = 22,
+            readiness = Readiness(counterReady = true, downstreamTupleGuardEnabled = true),
+        )
+        mixed.shouldBeFalse()
+        mixed.events.count { it == RecoveryEvent.ROLLOUT } shouldBeEqualTo 0
+        mixed.events.count { it == RecoveryEvent.RESUME } shouldBeEqualTo 0
+
+        val rollback = RecoveryControlPlane(authority).cutover(
+            observedEpochs = setOf(21),
+            requestedEpoch = 20,
+            readiness = Readiness(counterReady = true, downstreamTupleGuardEnabled = true),
+        )
+        rollback.shouldBeFalse()
+        rollback.events shouldBeEqualTo listOf(RecoveryEvent.PAUSE, RecoveryEvent.ROLLBACK_REJECTED)
+        authority.currentEpoch shouldBeEqualTo 21
+    }
+
+    @Test
+    fun `bootstrap readiness requires exact durable counter invariants and tuple guard`() {
+        LettuceClients.connect(LettuceTestUtils.client, StringCodec.UTF8).use { connection ->
+            val tag = LettuceTestUtils.randomName().substringAfter(':')
+            val config = LettuceFencingLeaseConfig("recovery", tag, 41)
+            val keys = deriveFencingLeaseKeys(config, StringCodec.UTF8)
+            val commands = connection.sync()
+            val lease = LettuceFencingLease(connection, config)
+            try {
+                lease.bootstrap() shouldBeEqualTo FencingBootstrapResult.Initialized
+                isReady(commands, keys, downstreamTupleGuardEnabled = true).shouldBeTrue()
+                isReady(commands, keys, downstreamTupleGuardEnabled = false).shouldBeFalse()
+
+                commands.pexpire(keys.counter, 10_000)
+                isReady(commands, keys, downstreamTupleGuardEnabled = true).shouldBeFalse()
+                commands.persist(keys.counter)
+                commands.set(keys.counter, "01")
+                isReady(commands, keys, downstreamTupleGuardEnabled = true).shouldBeFalse()
+                commands.set(keys.counter, "1\u0661")
+                isReady(commands, keys, downstreamTupleGuardEnabled = true).shouldBeFalse()
+                commands.set(keys.counter, "9223372036854775808")
+                isReady(commands, keys, downstreamTupleGuardEnabled = true).shouldBeFalse()
+            } finally {
+                commands.del(keys.lease, keys.counter)
+            }
+        }
+    }
+
+    @Test
+    fun `read only diagnostic classifies bounded states and repair preserves the counter`() {
+        LettuceClients.connect(LettuceTestUtils.client, StringCodec.UTF8).use { connection ->
+            val tag = LettuceTestUtils.randomName().substringAfter(':')
+            val config = LettuceFencingLeaseConfig("diagnostic", tag, 51)
+            val keys = deriveFencingLeaseKeys(config, StringCodec.UTF8)
+            val commands = connection.sync()
+            try {
+                commands.set(keys.counter, "4")
+                diagnostic(commands, keys, config.epoch) shouldBeEqualTo listOf("CLEAN", "0")
+                repairLeaseOnly(commands, keys, config.epoch, FULL_REPAIR_ELIGIBILITY).shouldBeFalse()
+
+                commands.del(keys.counter)
+                diagnostic(commands, keys, config.epoch) shouldBeEqualTo listOf("COUNTER_MISSING", "0")
+                repairLeaseOnly(commands, keys, config.epoch, FULL_REPAIR_ELIGIBILITY).shouldBeFalse()
+
+                commands.set(keys.counter, "4")
+                commands.set(keys.lease, "not-a-hash")
+                diagnostic(commands, keys, config.epoch) shouldBeEqualTo listOf("LEASE_MALFORMED", "0")
+                repairLeaseOnly(commands, keys, config.epoch, FULL_REPAIR_ELIGIBILITY).shouldBeFalse()
+                commands.exists(keys.lease) shouldBeEqualTo 1L
+
+                commands.del(keys.lease)
+                commands.hset(
+                    keys.lease,
+                    mapOf("owner" to "owner", "epoch" to "51", "sequence" to "4"),
+                )
+                diagnostic(commands, keys, config.epoch) shouldBeEqualTo listOf("LEASE_NO_TTL", "1")
+
+                commands.hset(keys.lease, "sequence", "5")
+                diagnostic(commands, keys, config.epoch) shouldBeEqualTo listOf("COUNTER_BEHIND_LEASE", "0")
+                repairLeaseOnly(commands, keys, config.epoch, FULL_REPAIR_ELIGIBILITY).shouldBeFalse()
+                commands.hset(keys.lease, "sequence", "9223372036854775808")
+                diagnostic(commands, keys, config.epoch) shouldBeEqualTo listOf("LEASE_MALFORMED", "0")
+                repairLeaseOnly(commands, keys, config.epoch, FULL_REPAIR_ELIGIBILITY).shouldBeFalse()
+                commands.hset(keys.lease, "sequence", "4")
+                commands.set(keys.counter, "9223372036854775808")
+                diagnostic(commands, keys, config.epoch) shouldBeEqualTo listOf("COUNTER_INVALID", "0")
+                repairLeaseOnly(commands, keys, config.epoch, FULL_REPAIR_ELIGIBILITY).shouldBeFalse()
+                commands.set(keys.counter, "4")
+
+                commands.hset(keys.lease, "epoch", "50")
+                diagnostic(commands, keys, config.epoch) shouldBeEqualTo listOf("LEASE_MALFORMED", "0")
+                repairLeaseOnly(commands, keys, config.epoch, FULL_REPAIR_ELIGIBILITY).shouldBeFalse()
+                commands.hset(keys.lease, "epoch", "51")
+                commands.hset(keys.lease, "owner", "x".repeat(257))
+                diagnostic(commands, keys, config.epoch) shouldBeEqualTo listOf("LEASE_MALFORMED", "0")
+                repairLeaseOnly(commands, keys, config.epoch, FULL_REPAIR_ELIGIBILITY).shouldBeFalse()
+                commands.hset(keys.lease, "owner", "owner")
+                commands.pexpire(keys.lease, 30_000)
+                diagnostic(commands, keys, config.epoch) shouldBeEqualTo listOf("ACTIVE", "0")
+                repairLeaseOnly(commands, keys, config.epoch, FULL_REPAIR_ELIGIBILITY).shouldBeFalse()
+                commands.persist(keys.lease)
+                diagnostic(commands, keys, config.epoch) shouldBeEqualTo listOf("LEASE_NO_TTL", "1")
+
+                repairCases().dropLast(1).forEach { eligibility ->
+                    repairLeaseOnly(commands, keys, config.epoch, eligibility).shouldBeFalse()
+                    commands.exists(keys.lease) shouldBeEqualTo 1L
+                }
+
+                val counterBefore = commands.get(keys.counter)
+                val counterTtlBefore = commands.pttl(keys.counter)
+                repairLeaseOnly(commands, keys, config.epoch, repairCases().last()).shouldBeTrue()
+                commands.exists(keys.lease) shouldBeEqualTo 0L
+                commands.get(keys.counter) shouldBeEqualTo counterBefore
+                commands.pttl(keys.counter) shouldBeEqualTo counterTtlBefore
+                commands.pttl(keys.counter) shouldBeEqualTo -1L
+            } finally {
+                commands.del(keys.lease, keys.counter)
+            }
+        }
+    }
+
+    @Test
+    fun `higher epoch downstream state rejects Redis only rollback tokens`() {
+        val store = DownstreamStore()
+        val resourceId = "restored-resource"
+        val current = FencingToken(62, 1)
+        val restoredRedisToken = FencingToken(61, 99)
+
+        store.write(resourceId, current, "business-current") shouldBeEqualTo 1
+        RedisCounterEpochSource(restoredRedisToken.epoch).allocateNextEpoch().shouldBeFalse()
+        store.write(resourceId, restoredRedisToken, "business-old") shouldBeEqualTo 0
+        requireNotNull(store.row(resourceId)).token shouldBeGreaterThan restoredRedisToken
+    }
+
+    private fun diagnostic(
+        commands: RedisCommands<String, String>,
+        keys: FencingLeaseKeys,
+        expectedEpoch: Long,
+    ): List<String> = commands.evalReadOnly(
+        DIAGNOSTIC_LUA,
+        ScriptOutputType.MULTI,
+        arrayOf(keys.lease, keys.counter),
+        expectedEpoch.toString(),
+    )
+
+    private fun isReady(
+        commands: RedisCommands<String, String>,
+        keys: FencingLeaseKeys,
+        downstreamTupleGuardEnabled: Boolean,
+    ): Boolean {
+        if (!downstreamTupleGuardEnabled) return false
+        if (commands.type(keys.counter) != "string") return false
+        if (commands.pttl(keys.counter) != -1L) return false
+        return commands.get(keys.counter)?.let { counter ->
+            runCatching { requireCanonicalFencingDecimal(counter) }.isSuccess
+        } == true
+    }
+
+    private fun repairLeaseOnly(
+        commands: RedisCommands<String, String>,
+        keys: FencingLeaseKeys,
+        expectedEpoch: Long,
+        eligibility: RepairEligibility,
+    ): Boolean {
+        val diagnosis = diagnostic(commands, keys, expectedEpoch)
+        if (diagnosis != listOf("LEASE_NO_TTL", "1") || !eligibility.mayDeleteLease) return false
+        return commands.del(keys.lease) == 1L
+    }
+
+    private fun repairCases(): List<RepairEligibility> = listOf(
+        RepairEligibility(false, true, true, true),
+        RepairEligibility(true, false, true, true),
+        RepairEligibility(true, true, false, true),
+        RepairEligibility(true, true, true, false),
+        RepairEligibility(true, true, true, true),
+    )
+
+    private class DurableEpochAuthority(initialEpoch: Long) {
+        private val epoch = AtomicLong(initialEpoch)
+
+        val currentEpoch: Long get() = epoch.get()
+
+        fun compareAndSet(expected: Long, update: Long): Boolean =
+            update > expected && epoch.compareAndSet(expected, update)
+    }
+
+    private class LocalConfigEpochSource(val observedEpoch: Long) {
+        fun allocateNextEpoch(): Boolean = false
+    }
+
+    private class RedisCounterEpochSource(val observedEpoch: Long) {
+        fun allocateNextEpoch(): Boolean = false
+    }
+
+    private class DownstreamStore {
+        private val rows = mutableMapOf<String, GuardedRow>()
+
+        @Synchronized
+        fun write(resourceId: String, token: FencingToken, businessIdempotencyKey: String): Int {
+            val current = rows[resourceId]
+            if (current != null && token <= current.token) return 0
+            rows[resourceId] = GuardedRow(resourceId, token, businessIdempotencyKey)
+            return 1
+        }
+
+        @Synchronized
+        fun row(resourceId: String): GuardedRow? = rows[resourceId]
+    }
+
+    private class RecoveryControlPlane(private val authority: DurableEpochAuthority) {
+        fun cutover(
+            observedEpochs: Set<Long>,
+            requestedEpoch: Long,
+            readiness: Readiness,
+        ): RecoveryOutcome {
+            val events = mutableListOf(RecoveryEvent.PAUSE)
+            if (observedEpochs.size != 1) return RecoveryOutcome(false, events + RecoveryEvent.MIXED_EPOCH_ABORT)
+            if (requestedEpoch <= authority.currentEpoch) {
+                return RecoveryOutcome(false, events + RecoveryEvent.ROLLBACK_REJECTED)
+            }
+
+            events += RecoveryEvent.BLOCK_OLD_ACQUIRE
+            events += RecoveryEvent.DRAIN
+            if (!authority.compareAndSet(observedEpochs.single(), requestedEpoch)) {
+                return RecoveryOutcome(false, events + RecoveryEvent.CAS_REJECTED)
+            }
+            events += RecoveryEvent.CAS_BUMP
+            events += RecoveryEvent.BOOTSTRAP
+            events += RecoveryEvent.READINESS
+            if (!readiness.counterReady || !readiness.downstreamTupleGuardEnabled) {
+                return RecoveryOutcome(false, events + RecoveryEvent.READINESS_REJECTED)
+            }
+            events += RecoveryEvent.ROLLOUT
+            events += RecoveryEvent.CONFIRM_OLD_ABSENCE
+            events += RecoveryEvent.RESUME
+            return RecoveryOutcome(true, events)
+        }
+    }
+
+    private data class GuardedRow(
+        val resourceId: String,
+        val token: FencingToken,
+        val businessIdempotencyKey: String,
+    )
+
+    private data class Readiness(
+        val counterReady: Boolean,
+        val downstreamTupleGuardEnabled: Boolean,
+    )
+
+    private data class RecoveryOutcome(
+        val succeeded: Boolean,
+        val events: List<RecoveryEvent>,
+    ) {
+        fun shouldBeTrue() = succeeded.shouldBeTrue()
+        fun shouldBeFalse() = succeeded.shouldBeFalse()
+    }
+
+    private enum class RecoveryEvent {
+        PAUSE,
+        BLOCK_OLD_ACQUIRE,
+        DRAIN,
+        CAS_BUMP,
+        BOOTSTRAP,
+        READINESS,
+        ROLLOUT,
+        CONFIRM_OLD_ABSENCE,
+        RESUME,
+        MIXED_EPOCH_ABORT,
+        ROLLBACK_REJECTED,
+        CAS_REJECTED,
+        READINESS_REJECTED,
+    }
+
+    private data class RepairEligibility(
+        val incidentPaused: Boolean,
+        val downstreamDrained: Boolean,
+        val counterValidAndPersistent: Boolean,
+        val leaseConfirmedAnomalous: Boolean,
+    ) {
+        val mayDeleteLease: Boolean
+            get() = incidentPaused && downstreamDrained && counterValidAndPersistent && leaseConfirmedAnomalous
+    }
+
+    private companion object {
+        val FULL_REPAIR_ELIGIBILITY = RepairEligibility(true, true, true, true)
+        val DIAGNOSTIC_LUA: String =
+            """
+            local counter_type = redis.call('TYPE', KEYS[2])['ok']
+            if counter_type == 'none' then return {'COUNTER_MISSING', '0'} end
+            if counter_type ~= 'string' then return {'COUNTER_INVALID', '0'} end
+            if redis.call('PTTL', KEYS[2]) ~= -1 then return {'COUNTER_INVALID', '0'} end
+            local counter = redis.call('GET', KEYS[2])
+            local counter_valid = counter == '0' or string.match(counter, '^[1-9][0-9]*$')
+            counter_valid = counter_valid and (#counter < 19 or (#counter == 19 and counter <= '9223372036854775807'))
+            if not counter_valid then return {'COUNTER_INVALID', '0'} end
+
+            local lease_type = redis.call('TYPE', KEYS[1])['ok']
+            if lease_type == 'none' then return {'CLEAN', '0'} end
+            if lease_type ~= 'hash' then return {'LEASE_MALFORMED', '0'} end
+            if redis.call('HLEN', KEYS[1]) ~= 3 then return {'LEASE_MALFORMED', '0'} end
+            local owner_length = redis.call('HSTRLEN', KEYS[1], 'owner')
+            local epoch_length = redis.call('HSTRLEN', KEYS[1], 'epoch')
+            local sequence_length = redis.call('HSTRLEN', KEYS[1], 'sequence')
+            if owner_length < 1 or owner_length > 256 or epoch_length < 1 or epoch_length > 19 or
+               sequence_length < 1 or sequence_length > 19 then
+                return {'LEASE_MALFORMED', '0'}
+            end
+            local fields = redis.call('HMGET', KEYS[1], 'owner', 'epoch', 'sequence')
+            local epoch = fields[2]
+            local sequence = fields[3]
+            if not string.match(epoch, '^[1-9][0-9]*$') then return {'LEASE_MALFORMED', '0'} end
+            if not string.match(sequence, '^[1-9][0-9]*$') then return {'LEASE_MALFORMED', '0'} end
+            if epoch ~= ARGV[1] then return {'LEASE_MALFORMED', '0'} end
+            if #epoch > 19 or (#epoch == 19 and epoch > '9223372036854775807') then
+                return {'LEASE_MALFORMED', '0'}
+            end
+            if #sequence > 19 or (#sequence == 19 and sequence > '9223372036854775807') then
+                return {'LEASE_MALFORMED', '0'}
+            end
+            if #counter < #sequence or (#counter == #sequence and counter < sequence) then
+                return {'COUNTER_BEHIND_LEASE', '0'}
+            end
+            if redis.call('PTTL', KEYS[1]) == -1 then return {'LEASE_NO_TTL', '1'} end
+            return {'ACTIVE', '0'}
+            """.trimIndent()
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseRecoveryTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseRecoveryTest.kt
@@ -4,7 +4,6 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeTrue
-import io.bluetape4k.redis.lettuce.LettuceClients
 import io.bluetape4k.redis.lettuce.LettuceTestUtils
 import io.lettuce.core.ScriptOutputType
 import io.lettuce.core.api.sync.RedisCommands
@@ -106,7 +105,7 @@ internal class LettuceFencingLeaseRecoveryTest {
 
     @Test
     fun `bootstrap readiness requires exact durable counter invariants and tuple guard`() {
-        LettuceClients.connect(LettuceTestUtils.client, StringCodec.UTF8).use { connection ->
+        LettuceTestUtils.client.connect(StringCodec.UTF8).use { connection ->
             val tag = LettuceTestUtils.randomName().substringAfter(':')
             val config = LettuceFencingLeaseConfig("recovery", tag, 41)
             val keys = deriveFencingLeaseKeys(config, StringCodec.UTF8)
@@ -134,7 +133,7 @@ internal class LettuceFencingLeaseRecoveryTest {
 
     @Test
     fun `read only diagnostic classifies bounded states and repair preserves the counter`() {
-        LettuceClients.connect(LettuceTestUtils.client, StringCodec.UTF8).use { connection ->
+        LettuceTestUtils.client.connect(StringCodec.UTF8).use { connection ->
             val tag = LettuceTestUtils.randomName().substringAfter(':')
             val config = LettuceFencingLeaseConfig("diagnostic", tag, 51)
             val keys = deriveFencingLeaseKeys(config, StringCodec.UTF8)

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseRecoveryTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseRecoveryTest.kt
@@ -223,7 +223,7 @@ internal class LettuceFencingLeaseRecoveryTest {
         keys: FencingLeaseKeys,
         expectedEpoch: Long,
     ): List<String> = commands.evalReadOnly(
-        DIAGNOSTIC_LUA,
+        FENCING_DIAGNOSTIC_LUA,
         ScriptOutputType.MULTI,
         arrayOf(keys.lease, keys.counter),
         expectedEpoch.toString(),
@@ -368,17 +368,19 @@ internal class LettuceFencingLeaseRecoveryTest {
             get() = incidentPaused && downstreamDrained && counterValidAndPersistent && leaseConfirmedAnomalous
     }
 
-    private companion object {
-        val FULL_REPAIR_ELIGIBILITY = RepairEligibility(true, true, true, true)
-        val DIAGNOSTIC_LUA: String =
+    companion object {
+        private val FULL_REPAIR_ELIGIBILITY = RepairEligibility(true, true, true, true)
+        val FENCING_DIAGNOSTIC_LUA: String =
             """
             local counter_type = redis.call('TYPE', KEYS[2])['ok']
             if counter_type == 'none' then return {'COUNTER_MISSING', '0'} end
             if counter_type ~= 'string' then return {'COUNTER_INVALID', '0'} end
             if redis.call('PTTL', KEYS[2]) ~= -1 then return {'COUNTER_INVALID', '0'} end
+            local counter_length = redis.call('STRLEN', KEYS[2])
+            if counter_length < 1 or counter_length > 19 then return {'COUNTER_INVALID', '0'} end
             local counter = redis.call('GET', KEYS[2])
             local counter_valid = counter == '0' or string.match(counter, '^[1-9][0-9]*$')
-            counter_valid = counter_valid and (#counter < 19 or (#counter == 19 and counter <= '9223372036854775807'))
+            counter_valid = counter_valid and (#counter < 19 or counter <= '9223372036854775807')
             if not counter_valid then return {'COUNTER_INVALID', '0'} end
 
             local lease_type = redis.call('TYPE', KEYS[1])['ok']

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseResilience4jTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseResilience4jTest.kt
@@ -1,0 +1,280 @@
+package io.bluetape4k.redis.lettuce.lease
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldBeZero
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.redis.lettuce.LettuceClients
+import io.bluetape4k.redis.lettuce.LettuceTestUtils
+import io.bluetape4k.resilience4j.SuspendDecorators
+import io.github.resilience4j.bulkhead.Bulkhead
+import io.github.resilience4j.bulkhead.BulkheadConfig
+import io.github.resilience4j.bulkhead.BulkheadFullException
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
+import io.github.resilience4j.retry.Retry
+import io.github.resilience4j.retry.RetryConfig
+import io.lettuce.core.codec.StringCodec
+import kotlinx.coroutines.CancellationException
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+
+/** Demonstrates caller-owned Retry, CircuitBreaker, and Bulkhead policies around the Redis primitive. */
+internal class LettuceFencingLeaseResilience4jTest {
+
+    @Test
+    fun `backend failure alone is retried and the final result alone reaches the circuit breaker`() = runSuspendIO {
+        val policy = policies("backend-final-result")
+        val attempts = AtomicInteger()
+
+        val result = execute(policy) {
+            policy.bulkhead.metrics.availableConcurrentCalls.shouldBeZero()
+            if (attempts.incrementAndGet() == 1) backendFailure else acquired
+        }
+
+        result shouldBeEqualTo acquired
+        attempts.get() shouldBeEqualTo 2
+        policy.retry.metrics.numberOfSuccessfulCallsWithRetryAttempt shouldBeEqualTo 1
+        policy.circuitBreaker.metrics.numberOfSuccessfulCalls shouldBeEqualTo 1
+        policy.circuitBreaker.metrics.numberOfFailedCalls.shouldBeZero()
+        policy.bulkhead.metrics.availableConcurrentCalls shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `terminal backend failure is recorded once after retry exhaustion`() = runSuspendIO {
+        val policy = policies("terminal-backend")
+        val attempts = AtomicInteger()
+
+        execute(policy) {
+            policy.bulkhead.metrics.availableConcurrentCalls.shouldBeZero()
+            attempts.incrementAndGet()
+            backendFailure
+        } shouldBeEqualTo backendFailure
+
+        attempts.get() shouldBeEqualTo 2
+        policy.retry.metrics.numberOfFailedCallsWithRetryAttempt shouldBeEqualTo 1
+        policy.circuitBreaker.metrics.numberOfFailedCalls shouldBeEqualTo 1
+        policy.circuitBreaker.metrics.numberOfSuccessfulCalls.shouldBeZero()
+        policy.bulkhead.metrics.availableConcurrentCalls shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `ambiguous acquire retries with the same owner and recovers the Redis token`() = runSuspendIO {
+        LettuceClients.connect(LettuceTestUtils.client, StringCodec.UTF8).use { connection ->
+            val tag = LettuceTestUtils.randomName().substringAfter(':')
+            val config = LettuceFencingLeaseConfig("resilience", tag, 31)
+            val keys = deriveFencingLeaseKeys(config, StringCodec.UTF8)
+            val lease = LettuceSuspendFencingLease(connection, config)
+            val ownerId = FencingOwnerId.from("owner-$tag")
+            val attempts = AtomicInteger()
+            try {
+                lease.bootstrap() shouldBeEqualTo FencingBootstrapResult.Initialized
+
+                val result = execute(policies("ambiguous-$tag")) {
+                    val actual = lease.acquire(ownerId, LEASE_TIME)
+                    if (attempts.incrementAndGet() == 1) backendFailure else actual
+                }.shouldBeInstanceOf<FencingAcquireResult.AlreadyOwned>()
+
+                attempts.get() shouldBeEqualTo 2
+                connection.sync().get(keys.counter) shouldBeEqualTo result.token.sequence.toString()
+            } finally {
+                connection.sync().del(keys.lease, keys.counter)
+            }
+        }
+    }
+
+    @Test
+    fun `domain results are logical successes and never retry`() = runSuspendIO {
+        listOf(
+            FencingAcquireResult.Contended(1),
+            FencingAcquireResult.CounterUnavailable,
+            FencingAcquireResult.SequenceExhausted,
+            FencingAcquireResult.IntegrityFailure(
+                FencingLeaseIntegrityFailure(FencingIntegrityFailureKind.INVALID_COUNTER),
+            ),
+        ).forEachIndexed { index, result ->
+            assertLogicalSuccessOnce(policies("logical-$index"), result)
+        }
+
+        assertRenewLogicalSuccessOnce(FencingRenewResult.OwnershipMismatch)
+    }
+
+    @Test
+    fun `validation cancellation and protocol exceptions escape every policy`() = runSuspendIO {
+        listOf(
+            IllegalArgumentException("invalid input") to 1L,
+            CancellationException("caller cancelled") to 0L,
+            FencingLeaseProtocolException() to 1L,
+        ).forEachIndexed { index, (expected, failedWithoutRetry) ->
+            val policy = policies("exception-$index")
+            val attempts = AtomicInteger()
+
+            val actual = assertFailsWith<Throwable> {
+                execute(policy) {
+                    attempts.incrementAndGet()
+                    throw expected
+                }
+            }
+
+            actual shouldBeSameInstanceAs expected
+            attempts.get() shouldBeEqualTo 1
+            policy.retry.metrics.numberOfFailedCallsWithoutRetryAttempt shouldBeEqualTo failedWithoutRetry
+            policy.retry.metrics.numberOfFailedCallsWithRetryAttempt.shouldBeZero()
+            with(policy.circuitBreaker.metrics) {
+                numberOfSuccessfulCalls.shouldBeZero()
+                numberOfFailedCalls.shouldBeZero()
+                numberOfBufferedCalls.shouldBeZero()
+            }
+            policy.bulkhead.metrics.availableConcurrentCalls shouldBeEqualTo 1
+        }
+    }
+
+    @Test
+    fun `open circuit breaker and saturated bulkhead reject before inner policies`() = runSuspendIO {
+        val openPolicy = policies("open-circuit")
+        openPolicy.circuitBreaker.transitionToOpenState()
+        val openAttempts = AtomicInteger()
+
+        assertFailsWith<CallNotPermittedException> {
+            execute(openPolicy) {
+                openAttempts.incrementAndGet()
+                acquired
+            }
+        }
+        openAttempts.get().shouldBeZero()
+        assertRetryUntouched(openPolicy.retry)
+        with(openPolicy.circuitBreaker.metrics) {
+            numberOfSuccessfulCalls.shouldBeZero()
+            numberOfFailedCalls.shouldBeZero()
+        }
+
+        val fullPolicy = policies("full-bulkhead")
+        fullPolicy.bulkhead.tryAcquirePermission().shouldBeTrue()
+        val fullAttempts = AtomicInteger()
+        try {
+            assertFailsWith<BulkheadFullException> {
+                execute(fullPolicy) {
+                    fullAttempts.incrementAndGet()
+                    acquired
+                }
+            }
+            fullAttempts.get().shouldBeZero()
+            assertRetryUntouched(fullPolicy.retry)
+            with(fullPolicy.circuitBreaker.metrics) {
+                numberOfSuccessfulCalls.shouldBeZero()
+                numberOfFailedCalls.shouldBeZero()
+                numberOfBufferedCalls.shouldBeZero()
+            }
+        } finally {
+            fullPolicy.bulkhead.releasePermission()
+        }
+    }
+
+    private suspend fun assertLogicalSuccessOnce(
+        policy: Policies,
+        result: FencingAcquireResult,
+    ) {
+        val attempts = AtomicInteger()
+
+        execute(policy) {
+            attempts.incrementAndGet()
+            result
+        } shouldBeEqualTo result
+
+        attempts.get() shouldBeEqualTo 1
+        policy.retry.metrics.numberOfSuccessfulCallsWithoutRetryAttempt shouldBeEqualTo 1
+        policy.retry.metrics.numberOfSuccessfulCallsWithRetryAttempt.shouldBeZero()
+        policy.circuitBreaker.metrics.numberOfSuccessfulCalls shouldBeEqualTo 1
+        policy.circuitBreaker.metrics.numberOfFailedCalls.shouldBeZero()
+    }
+
+    private suspend fun assertRenewLogicalSuccessOnce(result: FencingRenewResult) {
+        val retry = Retry.of(
+            "renew-logical",
+            RetryConfig.custom<FencingRenewResult>()
+                .maxAttempts(2)
+                .waitDuration(Duration.ZERO)
+                .retryOnResult { it is FencingRenewResult.BackendFailure }
+                .retryOnException { false }
+                .build(),
+        )
+        val attempts = AtomicInteger()
+
+        SuspendDecorators.ofSupplier {
+            attempts.incrementAndGet()
+            result
+        }.withRetry(retry).invoke() shouldBeEqualTo result
+
+        attempts.get() shouldBeEqualTo 1
+        retry.metrics.numberOfSuccessfulCallsWithoutRetryAttempt shouldBeEqualTo 1
+    }
+
+    private suspend fun execute(
+        policy: Policies,
+        supplier: suspend () -> FencingAcquireResult,
+    ): FencingAcquireResult = SuspendDecorators.ofSupplier(supplier)
+        .withRetry(policy.retry)
+        .withCircuitBreaker(policy.circuitBreaker)
+        .withBulkhead(policy.bulkhead)
+        .invoke()
+
+    private fun policies(name: String): Policies = Policies(
+        retry = Retry.of(
+            name,
+            RetryConfig.custom<FencingAcquireResult>()
+                .maxAttempts(2)
+                .waitDuration(Duration.ZERO)
+                .retryOnResult(::isBackendFailure)
+                .retryOnException { false }
+                .build(),
+        ),
+        circuitBreaker = CircuitBreaker.of(
+            name,
+            CircuitBreakerConfig.custom()
+                .slidingWindowSize(2)
+                .minimumNumberOfCalls(2)
+                .failureRateThreshold(50.0F)
+                .recordResult { result -> result is FencingAcquireResult.BackendFailure }
+                .ignoreException { true }
+                .build(),
+        ),
+        bulkhead = Bulkhead.of(
+            name,
+            BulkheadConfig.custom()
+                .maxConcurrentCalls(1)
+                .maxWaitDuration(Duration.ZERO)
+                .build(),
+        ),
+    )
+
+    private fun assertRetryUntouched(retry: Retry) {
+        with(retry.metrics) {
+            numberOfSuccessfulCallsWithoutRetryAttempt.shouldBeZero()
+            numberOfSuccessfulCallsWithRetryAttempt.shouldBeZero()
+            numberOfFailedCallsWithoutRetryAttempt.shouldBeZero()
+            numberOfFailedCallsWithRetryAttempt.shouldBeZero()
+        }
+    }
+
+    private fun isBackendFailure(result: FencingAcquireResult): Boolean =
+        result is FencingAcquireResult.BackendFailure
+
+    private data class Policies(
+        val retry: Retry,
+        val circuitBreaker: CircuitBreaker,
+        val bulkhead: Bulkhead,
+    )
+
+    private companion object {
+        val LEASE_TIME: Duration = Duration.ofSeconds(30)
+        val acquired = FencingAcquireResult.Acquired(FencingToken(31, 1))
+        val backendFailure = FencingAcquireResult.BackendFailure(
+            FencingLeaseBackendFailure(FencingBackendFailureKind.CONNECTION),
+        )
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseResilience4jTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseResilience4jTest.kt
@@ -7,7 +7,6 @@ import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldBeZero
 import io.bluetape4k.junit5.coroutines.runSuspendIO
-import io.bluetape4k.redis.lettuce.LettuceClients
 import io.bluetape4k.redis.lettuce.LettuceTestUtils
 import io.bluetape4k.resilience4j.SuspendDecorators
 import io.github.resilience4j.bulkhead.Bulkhead
@@ -65,7 +64,7 @@ internal class LettuceFencingLeaseResilience4jTest {
 
     @Test
     fun `ambiguous acquire retries with the same owner and recovers the Redis token`() = runSuspendIO {
-        LettuceClients.connect(LettuceTestUtils.client, StringCodec.UTF8).use { connection ->
+        LettuceTestUtils.client.connect(StringCodec.UTF8).use { connection ->
             val tag = LettuceTestUtils.randomName().substringAfter(':')
             val config = LettuceFencingLeaseConfig("resilience", tag, 31)
             val keys = deriveFencingLeaseKeys(config, StringCodec.UTF8)

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseScriptTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseScriptTest.kt
@@ -1,0 +1,506 @@
+package io.bluetape4k.redis.lettuce.lease
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
+import io.bluetape4k.assertions.shouldBeInRange
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeLessOrEqualTo
+import io.bluetape4k.assertions.shouldBePositive
+import io.bluetape4k.assertions.shouldBeZero
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotContain
+import io.bluetape4k.redis.lettuce.AbstractLettuceTest
+import io.bluetape4k.redis.lettuce.LettuceClients
+import io.bluetape4k.redis.lettuce.LettuceTestUtils
+import io.bluetape4k.redis.lettuce.script.RedisScript
+import io.bluetape4k.redis.lettuce.script.RedisScriptRunner
+import io.lettuce.core.RedisCommandExecutionException
+import io.lettuce.core.RedisNoScriptException
+import io.lettuce.core.ScriptOutputType
+import io.lettuce.core.api.sync.RedisCommands
+import io.lettuce.core.api.sync.RedisScriptingCommands
+import io.lettuce.core.codec.StringCodec
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class LettuceFencingLeaseScriptTest : AbstractLettuceTest() {
+
+    private lateinit var commands: RedisCommands<String, String>
+    private lateinit var config: LettuceFencingLeaseConfig
+    private lateinit var keys: FencingLeaseKeys
+
+    private val owner = FencingOwnerId.from("owner-primary")
+    private val contender = FencingOwnerId.from("owner-contender")
+
+    @BeforeEach
+    fun setUp() {
+        commands = connection.sync()
+        config = LettuceFencingLeaseConfig("test", "lease-${randomName().substringAfter(':')}", 7)
+        keys = deriveFencingLeaseKeys(config, StringCodec.UTF8)
+        commands.del(keys.lease, keys.counter)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        commands.del(keys.lease, keys.counter)
+    }
+
+    @Test
+    fun `bootstrap acquire inspect renew and release preserve one ordered state machine`() {
+        bootstrap() shouldBeEqualTo FencingBootstrapResult.Initialized
+        bootstrap() shouldBeEqualTo FencingBootstrapResult.AlreadyInitialized
+
+        val acquired = acquire(owner).shouldBeInstanceOf<FencingAcquireResult.Acquired>()
+        acquired.token shouldBeEqualTo FencingToken(7, 1)
+
+        val beforeReplayTtl = commands.pttl(keys.lease)
+        val replay = acquire(owner).shouldBeInstanceOf<FencingAcquireResult.AlreadyOwned>()
+        val afterReplayTtl = commands.pttl(keys.lease)
+        replay.token shouldBeEqualTo acquired.token
+        replay.remainingTtlMillis.shouldBePositive()
+        replay.remainingTtlMillis shouldBeLessOrEqualTo beforeReplayTtl
+        afterReplayTtl shouldBeInRange (beforeReplayTtl - TTL_TOLERANCE_MILLIS)..beforeReplayTtl
+
+        val owned = inspect(owner).shouldBeInstanceOf<FencingInspectResult.Owned>()
+        owned.token shouldBeEqualTo acquired.token
+        owned.remainingTtlMillis.shouldBePositive()
+        inspect(contender).shouldBeInstanceOf<FencingInspectResult.Contended>()
+
+        renew(contender, acquired.token) shouldBeEqualTo FencingRenewResult.OwnershipMismatch
+        renew(owner, FencingToken(7, 2)) shouldBeEqualTo FencingRenewResult.OwnershipMismatch
+        renew(owner, acquired.token) shouldBeEqualTo FencingRenewResult.Renewed
+
+        release(contender, acquired.token) shouldBeEqualTo FencingReleaseResult.OwnershipMismatch
+        release(owner, FencingToken(7, 2)) shouldBeEqualTo FencingReleaseResult.OwnershipMismatch
+        release(owner, acquired.token) shouldBeEqualTo FencingReleaseResult.Released
+        inspect(owner) shouldBeEqualTo FencingInspectResult.Lost
+
+        val reacquired = acquire(contender).shouldBeInstanceOf<FencingAcquireResult.Acquired>()
+        reacquired.token shouldBeEqualTo FencingToken(7, 2)
+        commands.get(keys.counter) shouldBeEqualTo "2"
+    }
+
+    @Test
+    fun `absent and exhausted counter branches do not create a lease`() {
+        acquire(owner) shouldBeEqualTo FencingAcquireResult.CounterUnavailable
+        inspect(owner) shouldBeEqualTo FencingInspectResult.Lost
+        renew(owner, FencingToken(7, 1)) shouldBeEqualTo FencingRenewResult.Lost
+        release(owner, FencingToken(7, 1)) shouldBeEqualTo FencingReleaseResult.Lost
+
+        commands.set(keys.counter, Long.MAX_VALUE.toString())
+        acquire(owner) shouldBeEqualTo FencingAcquireResult.SequenceExhausted
+        commands.exists(keys.lease).shouldBeZero()
+        commands.get(keys.counter) shouldBeEqualTo Long.MAX_VALUE.toString()
+    }
+
+    @Test
+    fun `lease structural corruption is malformed and remains unchanged`() {
+        val corruptions = listOf<() -> Unit>(
+            { commands.set(keys.counter, "1"); commands.set(keys.lease, "wrong-type") },
+            { commands.set(keys.counter, "1"); writeLease(fields = mapOf("owner" to owner.value, "epoch" to "7")) },
+            {
+                commands.set(keys.counter, "1")
+                writeLease(
+                    fields = validLeaseFields() + ("extra" to "field"),
+                )
+            },
+            { commands.set(keys.counter, "1"); writeLease(ownerText = "x".repeat(257)) },
+            { commands.set(keys.counter, "1"); writeLease(epoch = "1".repeat(20)) },
+            { commands.set(keys.counter, "1"); writeLease(sequence = "1".repeat(20)) },
+        )
+
+        corruptions.forEach { corrupt ->
+            commands.del(keys.lease, keys.counter)
+            corrupt()
+            assertIntegrityWithoutMutation(FencingIntegrityFailureKind.MALFORMED_LEASE)
+        }
+    }
+
+    @Test
+    fun `lease decimals reject signs leading zero whitespace non-digits and range overflow`() {
+        val invalidDecimals = listOf("+7", "-7", "07", " 7", "7 ", "7x", "9223372036854775808")
+
+        invalidDecimals.forEach { invalid ->
+            commands.del(keys.lease, keys.counter)
+            commands.set(keys.counter, "1")
+            writeLease(epoch = invalid)
+            assertIntegrityWithoutMutation(FencingIntegrityFailureKind.MALFORMED_LEASE)
+
+            commands.del(keys.lease, keys.counter)
+            commands.set(keys.counter, "1")
+            writeLease(sequence = invalid)
+            assertIntegrityWithoutMutation(FencingIntegrityFailureKind.MALFORMED_LEASE)
+        }
+    }
+
+    @Test
+    fun `counter corruption is invalid and remains unchanged`() {
+        val corruptions = buildList<() -> Unit> {
+            add { commands.lpush(keys.counter, "wrong-type") }
+            listOf("+1", "-1", "01", " 1", "1 ", "1x", "9223372036854775808", "1".repeat(20)).forEach { invalid ->
+                add { commands.set(keys.counter, invalid) }
+            }
+            add { commands.set(keys.counter, "1"); commands.pexpire(keys.counter, LEASE_MILLIS) }
+        }
+
+        corruptions.forEach { corrupt ->
+            commands.del(keys.lease, keys.counter)
+            corrupt()
+            val beforeBootstrap = redisState()
+            bootstrap() shouldBeEqualTo
+                FencingBootstrapResult.IntegrityFailure(
+                    FencingLeaseIntegrityFailure(FencingIntegrityFailureKind.INVALID_COUNTER),
+                )
+            val afterBootstrap = redisState()
+            afterBootstrap.counter.type shouldBeEqualTo beforeBootstrap.counter.type
+            afterBootstrap.counter.value shouldBeEqualTo beforeBootstrap.counter.value
+            afterBootstrap.counter.list shouldBeEqualTo beforeBootstrap.counter.list
+            assertTtlNotMutated(beforeBootstrap.counter.ttlMillis, afterBootstrap.counter.ttlMillis)
+            assertIntegrityWithoutMutation(FencingIntegrityFailureKind.INVALID_COUNTER)
+        }
+    }
+
+    @Test
+    fun `active lease rejects missing or behind counter without mutation`() {
+        writeLease(sequence = "2")
+        assertIntegrityWithoutMutation(FencingIntegrityFailureKind.INVALID_COUNTER)
+
+        commands.set(keys.counter, "1")
+        assertIntegrityWithoutMutation(FencingIntegrityFailureKind.COUNTER_BEHIND_LEASE)
+    }
+
+    @Test
+    fun `active counter corruption fails closed across every operation`() {
+        writeLease()
+        val expected = FencingLeaseIntegrityFailure(FencingIntegrityFailureKind.INVALID_COUNTER)
+        val token = FencingToken(7, 1)
+        val before = redisState()
+
+        bootstrap() shouldBeEqualTo FencingBootstrapResult.IntegrityFailure(expected)
+        acquire(owner) shouldBeEqualTo FencingAcquireResult.IntegrityFailure(expected)
+        inspect(owner) shouldBeEqualTo FencingInspectResult.IntegrityFailure(expected)
+        renew(owner, token) shouldBeEqualTo FencingRenewResult.IntegrityFailure(expected)
+        release(owner, token) shouldBeEqualTo FencingReleaseResult.IntegrityFailure(expected)
+
+        val after = redisState()
+        after.lease.type shouldBeEqualTo before.lease.type
+        after.lease.hash shouldBeEqualTo before.lease.hash
+        after.counter.type shouldBeEqualTo before.counter.type
+        assertTtlNotMutated(before.lease.ttlMillis, after.lease.ttlMillis)
+    }
+
+    @Test
+    fun `persistent active lease fails closed as malformed`() {
+        commands.set(keys.counter, "1")
+        writeLease()
+        commands.persist(keys.lease)
+
+        assertIntegrityWithoutMutation(FencingIntegrityFailureKind.MALFORMED_LEASE)
+    }
+
+    @Test
+    fun `script flush uses source fallback without changing results`() {
+        bootstrap() shouldBeEqualTo FencingBootstrapResult.Initialized
+        commands.scriptFlush()
+
+        acquire(owner) shouldBeEqualTo FencingAcquireResult.Acquired(FencingToken(7, 1))
+        inspect(owner).shouldBeInstanceOf<FencingInspectResult.Owned>().token shouldBeEqualTo FencingToken(7, 1)
+    }
+
+    @Test
+    fun `maximum exact Redis lease time keeps canonical ttl replies`() {
+        bootstrap() shouldBeEqualTo FencingBootstrapResult.Initialized
+
+        runFencingAcquire(
+            commands,
+            keys,
+            config,
+            owner,
+            MAX_EXACT_REDIS_LEASE_TIME_MILLIS,
+        ) shouldBeEqualTo FencingAcquireResult.Acquired(FencingToken(7, 1))
+
+        val replay = runFencingAcquire(
+            commands,
+            keys,
+            config,
+            owner,
+            MAX_EXACT_REDIS_LEASE_TIME_MILLIS,
+        ).shouldBeInstanceOf<FencingAcquireResult.AlreadyOwned>()
+        replay.remainingTtlMillis.shouldBePositive()
+        inspect(owner).shouldBeInstanceOf<FencingInspectResult.Owned>().remainingTtlMillis.shouldBePositive()
+    }
+
+    @Test
+    fun `operation wrapper dispatches evalsha once and eval only for noscript`() {
+        val scripting = mockk<RedisScriptingCommands<String, String>>()
+        val scriptKeys = arrayOf(keys.lease, keys.counter)
+        val arguments = arrayOf(owner.value, config.epoch.toString(), LEASE_MILLIS.toString())
+        val counterUnavailable = listOf("COUNTER_UNAVAILABLE", "0", "0", "-1")
+
+        every {
+            scripting.evalsha<List<String>>(
+                FencingLeaseScripts.ACQUIRE.sha1,
+                ScriptOutputType.MULTI,
+                scriptKeys,
+                *arguments,
+            )
+        } returns counterUnavailable
+
+        runFencingAcquire(scripting, keys, config, owner, LEASE_MILLIS) shouldBeEqualTo
+            FencingAcquireResult.CounterUnavailable
+
+        verify(exactly = 1) {
+            scripting.evalsha<List<String>>(
+                FencingLeaseScripts.ACQUIRE.sha1,
+                ScriptOutputType.MULTI,
+                scriptKeys,
+                *arguments,
+            )
+        }
+        confirmVerified(scripting)
+
+        val fallback = mockk<RedisScriptingCommands<String, String>>()
+        every {
+            fallback.evalsha<List<String>>(
+                FencingLeaseScripts.ACQUIRE.sha1,
+                ScriptOutputType.MULTI,
+                scriptKeys,
+                *arguments,
+            )
+        } throws RedisNoScriptException("NOSCRIPT")
+        every {
+            fallback.eval<List<String>>(
+                FencingLeaseScripts.ACQUIRE.source,
+                ScriptOutputType.MULTI,
+                scriptKeys,
+                *arguments,
+            )
+        } returns counterUnavailable
+
+        runFencingAcquire(fallback, keys, config, owner, LEASE_MILLIS) shouldBeEqualTo
+            FencingAcquireResult.CounterUnavailable
+
+        verify(exactly = 1) {
+            fallback.evalsha<List<String>>(
+                FencingLeaseScripts.ACQUIRE.sha1,
+                ScriptOutputType.MULTI,
+                scriptKeys,
+                *arguments,
+            )
+            fallback.eval<List<String>>(
+                FencingLeaseScripts.ACQUIRE.source,
+                ScriptOutputType.MULTI,
+                scriptKeys,
+                *arguments,
+            )
+        }
+        confirmVerified(fallback)
+    }
+
+    @Test
+    fun `operation wrapper rejects epoch and ttl validation before dispatch`() {
+        val scripting = mockk<RedisScriptingCommands<String, String>>()
+
+        assertFailsWith<IllegalArgumentException> {
+            runFencingAcquire(scripting, keys, config, owner, 0)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            runFencingAcquire(scripting, keys, config, owner, MAX_EXACT_REDIS_LEASE_TIME_MILLIS + 1)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            runFencingRenew(scripting, keys, config, owner, FencingToken(8, 1), LEASE_MILLIS)
+        }
+
+        confirmVerified(scripting)
+    }
+
+    @Test
+    fun `runtime failure after increment leaves a safe sequence gap`() {
+        bootstrap() shouldBeEqualTo FencingBootstrapResult.Initialized
+
+        assertFailsWith<RedisCommandExecutionException> {
+            RedisScriptRunner.run<Any>(
+                commands,
+                failAfterIncrementScript,
+                ScriptOutputType.MULTI,
+                arrayOf(keys.lease, keys.counter),
+            )
+        }
+
+        commands.get(keys.counter) shouldBeEqualTo "1"
+        acquire(owner) shouldBeEqualTo FencingAcquireResult.Acquired(FencingToken(7, 2))
+    }
+
+    @Test
+    fun `runtime failure after lease write leaves a partial lease that fails closed`() {
+        bootstrap() shouldBeEqualTo FencingBootstrapResult.Initialized
+
+        assertFailsWith<RedisCommandExecutionException> {
+            RedisScriptRunner.run<Any>(
+                commands,
+                failAfterLeaseWriteScript,
+                ScriptOutputType.MULTI,
+                arrayOf(keys.lease, keys.counter),
+                owner.value,
+                config.epoch.toString(),
+                "1",
+            )
+        }
+
+        commands.type(keys.lease) shouldBeEqualTo "hash"
+        commands.pttl(keys.lease) shouldBeEqualTo -1L
+        acquire(owner) shouldBeEqualTo integrityAcquire(FencingIntegrityFailureKind.MALFORMED_LEASE)
+    }
+
+    @Test
+    fun `production scripts use bounded fixed-shape command inventories`() {
+        val expectedMaximums = mapOf(
+            FencingLeaseScripts.BOOTSTRAP to 12,
+            FencingLeaseScripts.ACQUIRE to 15,
+            FencingLeaseScripts.INSPECT to 11,
+            FencingLeaseScripts.RENEW to 12,
+            FencingLeaseScripts.RELEASE to 12,
+        )
+
+        expectedMaximums.forEach { (script, maximum) ->
+            val source = script.source
+            source shouldNotContain "redis.call('KEYS'"
+            source shouldNotContain "redis.call('SCAN'"
+            source shouldNotContain "redis.call('HGETALL'"
+            source shouldNotContain "pairs("
+            source shouldNotContain "ipairs("
+            source shouldNotContain "tonumber("
+            source shouldNotContain "error("
+            source shouldContain "redis.call('HLEN', leaseKey) ~= 3"
+            Regex("redis\\.call\\('[A-Z]+'").findAll(source).count() shouldBeEqualTo maximum
+        }
+
+        val acquire = FencingLeaseScripts.ACQUIRE.source
+        val mutationOffsets = listOf(
+            acquire.indexOf("redis.call('INCR'"),
+            acquire.lastIndexOf("redis.call('GET'"),
+            acquire.indexOf("redis.call('HSET'"),
+            acquire.indexOf("redis.call('PEXPIRE'"),
+        )
+        mutationOffsets.forEach { offset -> offset shouldBeGreaterOrEqualTo 0 }
+        mutationOffsets shouldBeEqualTo mutationOffsets.sorted()
+    }
+
+    private fun bootstrap(): FencingBootstrapResult = runFencingBootstrap(commands, keys, config)
+
+    private fun acquire(targetOwner: FencingOwnerId): FencingAcquireResult =
+        runFencingAcquire(commands, keys, config, targetOwner, LEASE_MILLIS)
+
+    private fun inspect(targetOwner: FencingOwnerId): FencingInspectResult =
+        runFencingInspect(commands, keys, config, targetOwner)
+
+    private fun renew(targetOwner: FencingOwnerId, token: FencingToken): FencingRenewResult =
+        runFencingRenew(commands, keys, config, targetOwner, token, LEASE_MILLIS)
+
+    private fun release(targetOwner: FencingOwnerId, token: FencingToken): FencingReleaseResult =
+        runFencingRelease(commands, keys, config, targetOwner, token)
+
+    private fun writeLease(
+        ownerText: String = owner.value,
+        epoch: String = config.epoch.toString(),
+        sequence: String = "1",
+        fields: Map<String, String> = mapOf(
+            "owner" to ownerText,
+            "epoch" to epoch,
+            "sequence" to sequence,
+        ),
+    ) {
+        commands.hset(keys.lease, fields)
+        commands.pexpire(keys.lease, LEASE_MILLIS)
+    }
+
+    private fun validLeaseFields(): Map<String, String> = mapOf(
+        "owner" to owner.value,
+        "epoch" to config.epoch.toString(),
+        "sequence" to "1",
+    )
+
+    private fun assertIntegrityWithoutMutation(kind: FencingIntegrityFailureKind) {
+        val before = redisState()
+        acquire(owner) shouldBeEqualTo integrityAcquire(kind)
+        val after = redisState()
+
+        after.lease.type shouldBeEqualTo before.lease.type
+        after.lease.value shouldBeEqualTo before.lease.value
+        after.lease.hash shouldBeEqualTo before.lease.hash
+        after.counter.type shouldBeEqualTo before.counter.type
+        after.counter.value shouldBeEqualTo before.counter.value
+        after.counter.list shouldBeEqualTo before.counter.list
+        assertTtlNotMutated(before.lease.ttlMillis, after.lease.ttlMillis)
+        assertTtlNotMutated(before.counter.ttlMillis, after.counter.ttlMillis)
+    }
+
+    private fun assertTtlNotMutated(before: Long, after: Long) {
+        if (before >= 0) {
+            after shouldBeInRange (before - TTL_TOLERANCE_MILLIS)..before
+        } else {
+            after shouldBeEqualTo before
+        }
+    }
+
+    private fun redisState(): RedisState = RedisState(readKey(keys.lease), readKey(keys.counter))
+
+    private fun readKey(key: String): RedisKeyState {
+        val type = commands.type(key)
+        return RedisKeyState(
+            type = type,
+            value = if (type == "string") commands.get(key) else null,
+            hash = if (type == "hash") commands.hgetall(key).toSortedMap() else emptyMap(),
+            list = if (type == "list") commands.lrange(key, 0, -1) else emptyList(),
+            ttlMillis = commands.pttl(key),
+        )
+    }
+
+    private data class RedisState(
+        val lease: RedisKeyState,
+        val counter: RedisKeyState,
+    )
+
+    private data class RedisKeyState(
+        val type: String,
+        val value: String?,
+        val hash: Map<String, String>,
+        val list: List<String>,
+        val ttlMillis: Long,
+    )
+
+    private companion object {
+        const val LEASE_MILLIS = 30_000L
+        const val TTL_TOLERANCE_MILLIS = 2_000L
+
+        val connection by lazy { LettuceClients.connect(LettuceTestUtils.client, StringCodec.UTF8) }
+
+        val failAfterIncrementScript = RedisScript(
+            """
+            redis.call('INCR', KEYS[2])
+            redis.call('LPUSH', KEYS[2], 'force-wrong-type')
+            return {'UNREACHABLE', '0', '0', '-1'}
+            """.trimIndent(),
+        )
+
+        val failAfterLeaseWriteScript = RedisScript(
+            """
+            redis.call('HSET', KEYS[1],
+              'owner', ARGV[1],
+              'epoch', ARGV[2],
+              'sequence', ARGV[3])
+            redis.call('LPUSH', KEYS[1], 'force-wrong-type')
+            return {'UNREACHABLE', '0', '0', '-1'}
+            """.trimIndent(),
+        )
+
+        fun integrityAcquire(kind: FencingIntegrityFailureKind): FencingAcquireResult =
+            FencingAcquireResult.IntegrityFailure(FencingLeaseIntegrityFailure(kind))
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupportTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupportTest.kt
@@ -102,6 +102,18 @@ class LettuceFencingLeaseSupportTest {
     }
 
     @Test
+    fun `Redis lease time stays within the exact Lua integer range`() {
+        MAX_EXACT_REDIS_LEASE_TIME_MILLIS.requireRedisFencingLeaseTimeMillis() shouldBeEqualTo
+            MAX_EXACT_REDIS_LEASE_TIME_MILLIS
+
+        val error = assertFailsWith<IllegalArgumentException> {
+            (MAX_EXACT_REDIS_LEASE_TIME_MILLIS + 1).requireRedisFencingLeaseTimeMillis()
+        }
+        error.message shouldBeEqualTo "leaseTimeMillis exceeds the exact Redis Lua integer range."
+        error.cause shouldBeEqualTo null
+    }
+
+    @Test
     fun `token epoch mismatch is rejected`() {
         val config = LettuceFencingLeaseConfig("orders", "rebuild", 7)
 

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupportTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupportTest.kt
@@ -1,0 +1,335 @@
+package io.bluetape4k.redis.lettuce.lease
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeEqualTo
+import io.bluetape4k.assertions.shouldNotContain
+import io.lettuce.core.RedisCommandTimeoutException
+import io.lettuce.core.RedisConnectionException
+import io.lettuce.core.RedisException
+import io.lettuce.core.cluster.SlotHash
+import io.lettuce.core.codec.RedisCodec
+import io.lettuce.core.codec.StringCodec
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletionException
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeoutException
+
+class LettuceFencingLeaseSupportTest {
+
+    @Test
+    fun `derived keys use the exact ordering domain and one wire slot`() {
+        val config = LettuceFencingLeaseConfig("orders", "rebuild", 7)
+        val expected = FencingLeaseKeys(
+            lease = "fence:{orders:rebuild}:7:lease",
+            counter = "fence:{orders:rebuild}:7:counter",
+        )
+
+        deriveFencingLeaseKeys(config, StringCodec.UTF8) shouldBeEqualTo expected
+        deriveFencingLeaseKeys(config, SameSlotWireCodec) shouldBeEqualTo expected
+        SlotHash.getSlot(SameSlotWireCodec.encodeKey(expected.lease)) shouldBeEqualTo
+            SlotHash.getSlot(SameSlotWireCodec.encodeKey(expected.counter))
+    }
+
+    @Test
+    fun `derived keys reject a codec that routes wire bytes to different slots`() {
+        val config = LettuceFencingLeaseConfig("orders", "rebuild", 7)
+
+        SlotHash.getSlot(SplitSlotWireCodec.encodeKey("lease")) shouldNotBeEqualTo
+            SlotHash.getSlot(SplitSlotWireCodec.encodeKey("counter"))
+        val error = assertFailsWith<IllegalArgumentException> {
+            deriveFencingLeaseKeys(config, SplitSlotWireCodec)
+        }
+
+        error.message shouldBeEqualTo "Derived fencing lease keys must share one Redis Cluster slot."
+    }
+
+    @Test
+    fun `canonical decimals preserve exact long values and ordering`() {
+        listOf("0", "1", "9", "10", Long.MAX_VALUE.toString()).forEach { value ->
+            requireCanonicalFencingDecimal(value) shouldBeEqualTo value
+            parseCanonicalFencingLong(value) shouldBeEqualTo value.toLong()
+        }
+
+        compareCanonicalFencingDecimals("9", "10") shouldBeEqualTo -1
+        compareCanonicalFencingDecimals("10", "9") shouldBeEqualTo 1
+        compareCanonicalFencingDecimals(Long.MAX_VALUE.toString(), Long.MAX_VALUE.toString()) shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `canonical decimals reject ambiguous and out of range text without echoing it`() {
+        val invalidValues = listOf(
+            "", "+1", "-1", "00", "01", " 1", "1 ", "1.0", "1a",
+            "9223372036854775808", "1".repeat(20),
+        )
+
+        invalidValues.forEach { value ->
+            val error = assertFailsWith<IllegalArgumentException> { requireCanonicalFencingDecimal(value) }
+            if (value.isNotEmpty()) {
+                error.message shouldNotContain value
+            }
+        }
+    }
+
+    @Test
+    fun `lease duration accepts only positive whole milliseconds`() {
+        Duration.ofMillis(1).requireFencingLeaseMillis() shouldBeEqualTo 1L
+        Duration.ofMillis(Long.MAX_VALUE).requireFencingLeaseMillis() shouldBeEqualTo Long.MAX_VALUE
+
+        listOf(Duration.ZERO, Duration.ofMillis(-1), Duration.ofNanos(1), Duration.ofNanos(1_000_001)).forEach { value ->
+            val error = assertFailsWith<IllegalArgumentException> { value.requireFencingLeaseMillis() }
+            error.message shouldBeEqualTo "leaseTime must fit positive whole milliseconds."
+            error.cause shouldBeEqualTo null
+        }
+
+        val overflow = assertFailsWith<IllegalArgumentException> {
+            Duration.ofSeconds(Long.MAX_VALUE).requireFencingLeaseMillis()
+        }
+        overflow.message shouldBeEqualTo "leaseTime must fit positive whole milliseconds."
+        overflow.cause shouldBeEqualTo null
+    }
+
+    @Test
+    fun `token epoch mismatch is rejected`() {
+        val config = LettuceFencingLeaseConfig("orders", "rebuild", 7)
+
+        requireFencingTokenEpoch(config, FencingToken(7, 1)) shouldBeEqualTo FencingToken(7, 1)
+        val error = assertFailsWith<IllegalArgumentException> {
+            requireFencingTokenEpoch(config, FencingToken(8, 1))
+        }
+
+        error.message shouldBeEqualTo "Fencing token epoch must match the configured ordering domain."
+        error.message shouldNotContain "7"
+        error.message shouldNotContain "8"
+    }
+
+    @Test
+    fun `completion wrappers unwrap at most eight levels and stop on identity cycles`() {
+        val backend = RedisConnectionException("connection sentinel")
+        var nested: Throwable = backend
+        repeat(8) { index ->
+            nested = if (index % 2 == 0) CompletionException(nested) else ExecutionException(nested)
+        }
+
+        nested.unwrapFencingCompletionCause() shouldBeSameInstanceAs backend
+
+        val tooDeep = CompletionException(nested)
+        tooDeep.unwrapFencingCompletionCause() shouldNotBeEqualTo backend
+
+        val cycle = CyclicCompletionException()
+        cycle.unwrapFencingCompletionCause() shouldBeSameInstanceAs cycle
+    }
+
+    @Test
+    fun `completion wrapper cancellation is always rethrown`() {
+        val cancellation = CancellationException("cancel sentinel")
+        val wrapped = CompletionException(ExecutionException(cancellation))
+
+        assertFailsWith<CancellationException> {
+            wrapped.unwrapFencingCompletionCause()
+        } shouldBeSameInstanceAs cancellation
+    }
+
+    @Test
+    fun `backend classifier maps only allowlisted Redis failures`() {
+        classifyFencingBackendFailure(
+            FencingLeaseOperation.ACQUIRE,
+            RedisConnectionException("connection sentinel"),
+        ) shouldBeEqualTo FencingLeaseBackendFailure(FencingBackendFailureKind.CONNECTION)
+        classifyFencingBackendFailure(
+            FencingLeaseOperation.INSPECT,
+            RedisCommandTimeoutException("timeout sentinel"),
+        ) shouldBeEqualTo FencingLeaseBackendFailure(FencingBackendFailureKind.TIMEOUT)
+        classifyFencingBackendFailure(
+            FencingLeaseOperation.RENEW,
+            TimeoutException("timeout sentinel"),
+        ) shouldBeEqualTo FencingLeaseBackendFailure(FencingBackendFailureKind.TIMEOUT)
+        classifyFencingBackendFailure(
+            FencingLeaseOperation.RELEASE,
+            RedisException("command sentinel"),
+        ) shouldBeEqualTo FencingLeaseBackendFailure(FencingBackendFailureKind.COMMAND)
+    }
+
+    @Test
+    fun `backend classifier rethrows cancellation validation protocol and unknown failures`() {
+        val failures = listOf<Throwable>(
+            CancellationException("cancel sentinel"),
+            IllegalArgumentException("validation sentinel"),
+            FencingLeaseProtocolException(),
+            IllegalStateException("unknown sentinel"),
+        )
+
+        failures.forEach { failure ->
+            val thrown = assertFailsWith<Throwable> {
+                classifyFencingBackendFailure(FencingLeaseOperation.BOOTSTRAP, CompletionException(failure))
+            }
+            thrown shouldBeSameInstanceAs failure
+        }
+    }
+
+    @Test
+    fun `backend log contains only allowlisted correlation fields`() {
+        val logger = LoggerFactory.getLogger(FencingLeaseSupportLogger::class.java) as Logger
+        val previousLevel = logger.level
+        val appender = ListAppender<ILoggingEvent>().apply { start() }
+        logger.addAppender(appender)
+        logger.level = Level.WARN
+        val config = LettuceFencingLeaseConfig("secretNamespace", "secretResource", 7)
+        val secretKey = "fence:{secretNamespace:secretResource}:7:lease"
+        val secretOwner = "secretOwner"
+        val secretToken = "secretToken"
+        val secretReply = "secretRawReply"
+        val secretMessage = "$secretKey $secretOwner $secretToken $secretReply"
+
+        try {
+            classifyFencingBackendFailure(
+                FencingLeaseOperation.ACQUIRE,
+                RedisConnectionException(secretMessage),
+                config.domainFingerprint(),
+            )
+
+            val message = appender.list.single().formattedMessage
+            message shouldContain "operation=ACQUIRE"
+            message shouldContain "kind=CONNECTION"
+            message shouldContain "exception=io.lettuce.core.RedisConnectionException"
+            message shouldContain "domain=${config.domainFingerprint()}"
+            message shouldNotContain "secretNamespace"
+            message shouldNotContain "secretResource"
+            message shouldNotContain secretKey
+            message shouldNotContain secretOwner
+            message shouldNotContain secretToken
+            message shouldNotContain secretReply
+        } finally {
+            logger.detachAppender(appender)
+            logger.level = previousLevel
+            appender.stop()
+        }
+    }
+
+    @Test
+    fun `domain fingerprint is stable bounded and distinguishes ordering domains`() {
+        val first = LettuceFencingLeaseConfig("orders", "rebuild", 7).domainFingerprint()
+        val same = LettuceFencingLeaseConfig("orders", "rebuild", 7).domainFingerprint()
+        val other = LettuceFencingLeaseConfig("orders", "rebuild", 8).domainFingerprint()
+
+        first shouldBeEqualTo same
+        first shouldNotBeEqualTo other
+        first.length shouldBeEqualTo 24
+        first.all { character -> character in "0123456789abcdef" }.shouldBeTrue()
+    }
+
+    @Test
+    fun `fixed reply decoders map every documented result`() {
+        val token = FencingToken(7, 42)
+        val malformed = FencingLeaseIntegrityFailure(FencingIntegrityFailureKind.MALFORMED_LEASE)
+        val invalidCounter = FencingLeaseIntegrityFailure(FencingIntegrityFailureKind.INVALID_COUNTER)
+        val counterBehind = FencingLeaseIntegrityFailure(FencingIntegrityFailureKind.COUNTER_BEHIND_LEASE)
+
+        decodeFencingBootstrap(frame("INITIALIZED")) shouldBeEqualTo FencingBootstrapResult.Initialized
+        decodeFencingBootstrap(frame("ALREADY_INITIALIZED")) shouldBeEqualTo
+            FencingBootstrapResult.AlreadyInitialized
+        decodeFencingBootstrap(integrityFrame("MALFORMED_LEASE")) shouldBeEqualTo
+            FencingBootstrapResult.IntegrityFailure(malformed)
+
+        decodeFencingAcquire(frame("ACQUIRED", "7", "42")) shouldBeEqualTo FencingAcquireResult.Acquired(token)
+        decodeFencingAcquire(frame("ALREADY_OWNED", "7", "42", "10")) shouldBeEqualTo
+            FencingAcquireResult.AlreadyOwned(token, 10)
+        decodeFencingAcquire(frame("CONTENDED", ttl = "9")) shouldBeEqualTo FencingAcquireResult.Contended(9)
+        decodeFencingAcquire(frame("COUNTER_UNAVAILABLE")) shouldBeEqualTo FencingAcquireResult.CounterUnavailable
+        decodeFencingAcquire(frame("SEQUENCE_EXHAUSTED")) shouldBeEqualTo FencingAcquireResult.SequenceExhausted
+        decodeFencingAcquire(integrityFrame("INVALID_COUNTER")) shouldBeEqualTo
+            FencingAcquireResult.IntegrityFailure(invalidCounter)
+
+        decodeFencingInspect(frame("OWNED", "7", "42", "8")) shouldBeEqualTo FencingInspectResult.Owned(token, 8)
+        decodeFencingInspect(frame("LOST")) shouldBeEqualTo FencingInspectResult.Lost
+        decodeFencingInspect(frame("CONTENDED", ttl = "7")) shouldBeEqualTo FencingInspectResult.Contended(7)
+        decodeFencingInspect(integrityFrame("COUNTER_BEHIND_LEASE")) shouldBeEqualTo
+            FencingInspectResult.IntegrityFailure(counterBehind)
+
+        decodeFencingRenew(frame("RENEWED")) shouldBeEqualTo FencingRenewResult.Renewed
+        decodeFencingRenew(frame("LOST")) shouldBeEqualTo FencingRenewResult.Lost
+        decodeFencingRenew(frame("OWNERSHIP_MISMATCH")) shouldBeEqualTo FencingRenewResult.OwnershipMismatch
+        decodeFencingRenew(integrityFrame("MALFORMED_LEASE")) shouldBeEqualTo
+            FencingRenewResult.IntegrityFailure(malformed)
+
+        decodeFencingRelease(frame("RELEASED")) shouldBeEqualTo FencingReleaseResult.Released
+        decodeFencingRelease(frame("LOST")) shouldBeEqualTo FencingReleaseResult.Lost
+        decodeFencingRelease(frame("OWNERSHIP_MISMATCH")) shouldBeEqualTo FencingReleaseResult.OwnershipMismatch
+        decodeFencingRelease(integrityFrame("INVALID_COUNTER")) shouldBeEqualTo
+            FencingReleaseResult.IntegrityFailure(invalidCounter)
+    }
+
+    @Test
+    fun `fixed reply decoders reject unknown statuses malformed fields and invalid shapes`() {
+        val invalidCalls = listOf<() -> Unit>(
+            { decodeFencingAcquire(emptyList()) },
+            { decodeFencingAcquire(listOf("ACQUIRED", "7", "42")) },
+            { decodeFencingAcquire(frame("UNKNOWN")) },
+            { decodeFencingAcquire(frame("ACQUIRED", "07", "42")) },
+            { decodeFencingAcquire(frame("ACQUIRED", "7", "0")) },
+            { decodeFencingAcquire(frame("ACQUIRED", "7", "42", "0")) },
+            { decodeFencingAcquire(frame("ALREADY_OWNED", "7", "42", "-1")) },
+            { decodeFencingAcquire(frame("CONTENDED", "1", "0", "10")) },
+            { decodeFencingAcquire(frame("MALFORMED_LEASE")) },
+            { decodeFencingAcquire(integrityFrame("UNKNOWN")) },
+            { decodeFencingAcquire(frame("INTEGRITY_FAILURE", "INVALID_COUNTER", "1")) },
+            { decodeFencingAcquire(frame("INTEGRITY_FAILURE", "INVALID_COUNTER", ttl = "0")) },
+            { decodeFencingInspect(frame("LOST", ttl = "0")) },
+            { decodeFencingRenew(frame("RENEWED", "1", "0")) },
+            { decodeFencingRelease(integrityFrame("MALFORMED_LEASE").dropLast(1)) },
+        )
+
+        invalidCalls.forEach { call ->
+            val error = assertFailsWith<FencingLeaseProtocolException> { call() }
+            error.message shouldBeEqualTo "Malformed fencing lease response."
+        }
+    }
+
+    private fun frame(
+        status: String,
+        value1: String = "0",
+        value2: String = "0",
+        ttl: String = "-1",
+    ): List<String> = listOf(status, value1, value2, ttl)
+
+    private fun integrityFrame(kind: String): List<String> = frame("INTEGRITY_FAILURE", kind)
+
+    private object SameSlotWireCodec: RedisCodec<String, String> {
+        override fun decodeKey(bytes: ByteBuffer): String = decode(bytes)
+        override fun decodeValue(bytes: ByteBuffer): String = decode(bytes)
+        override fun encodeKey(key: String): ByteBuffer = encode("wire:{same}:$key")
+        override fun encodeValue(value: String): ByteBuffer = encode(value)
+    }
+
+    private object SplitSlotWireCodec: RedisCodec<String, String> {
+        override fun decodeKey(bytes: ByteBuffer): String = decode(bytes)
+        override fun decodeValue(bytes: ByteBuffer): String = decode(bytes)
+        override fun encodeKey(key: String): ByteBuffer =
+            encode(if (key.endsWith(":lease") || key == "lease") "wire:{one}" else "wire:{two}")
+        override fun encodeValue(value: String): ByteBuffer = encode(value)
+    }
+
+    private class CyclicCompletionException: CompletionException(null as Throwable?) {
+        override val cause: Throwable get() = this
+    }
+
+    private companion object {
+        fun encode(value: String): ByteBuffer = ByteBuffer.wrap(value.toByteArray(StandardCharsets.UTF_8))
+
+        fun decode(bytes: ByteBuffer): String = bytes.duplicate().let { copy ->
+            ByteArray(copy.remaining()).also(copy::get).toString(StandardCharsets.UTF_8)
+        }
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupportTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupportTest.kt
@@ -209,7 +209,7 @@ class LettuceFencingLeaseSupportTest {
             classifyFencingBackendFailure(
                 FencingLeaseOperation.ACQUIRE,
                 RedisConnectionException(secretMessage),
-                config.domainFingerprint(),
+                config::domainFingerprint,
             )
 
             val message = appender.list.single().formattedMessage

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseTest.kt
@@ -1,0 +1,86 @@
+package io.bluetape4k.redis.lettuce.lease
+
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
+import kotlinx.coroutines.future.await
+import java.time.Duration
+
+internal class LettuceFencingLeaseTest : FencingLeaseContract() {
+    override fun createAdapter(
+        connection: StatefulRedisConnection<String, String>,
+        config: LettuceFencingLeaseConfig,
+    ): FencingLeaseAdapter {
+        val lease = LettuceFencingLease(connection, config)
+        return object: FencingLeaseAdapter {
+            override suspend fun bootstrap(): FencingBootstrapResult = lease.bootstrap()
+            override suspend fun acquire(ownerId: FencingOwnerId, leaseTime: Duration): FencingAcquireResult =
+                lease.acquire(ownerId, leaseTime)
+            override suspend fun inspect(ownerId: FencingOwnerId): FencingInspectResult = lease.inspect(ownerId)
+            override suspend fun renew(
+                ownerId: FencingOwnerId,
+                token: FencingToken,
+                leaseTime: Duration,
+            ): FencingRenewResult = lease.renew(ownerId, token, leaseTime)
+            override suspend fun release(ownerId: FencingOwnerId, token: FencingToken): FencingReleaseResult =
+                lease.release(ownerId, token)
+        }
+    }
+}
+
+internal class LettuceFencingLeaseFutureTest : FencingLeaseContract() {
+    override fun createAdapter(
+        connection: StatefulRedisConnection<String, String>,
+        config: LettuceFencingLeaseConfig,
+    ): FencingLeaseAdapter {
+        val lease = LettuceFencingLease(connection, config)
+        return object: FencingLeaseAdapter {
+            override suspend fun bootstrap(): FencingBootstrapResult = lease.bootstrapAsync().await()
+            override suspend fun acquire(ownerId: FencingOwnerId, leaseTime: Duration): FencingAcquireResult =
+                lease.acquireAsync(ownerId, leaseTime).await()
+            override suspend fun inspect(ownerId: FencingOwnerId): FencingInspectResult = lease.inspectAsync(ownerId).await()
+            override suspend fun renew(
+                ownerId: FencingOwnerId,
+                token: FencingToken,
+                leaseTime: Duration,
+            ): FencingRenewResult = lease.renewAsync(ownerId, token, leaseTime).await()
+            override suspend fun release(ownerId: FencingOwnerId, token: FencingToken): FencingReleaseResult =
+                lease.releaseAsync(ownerId, token).await()
+        }
+    }
+}
+
+@Suppress("unused")
+private suspend fun compileFencingLeasePublicApi(
+    standalone: StatefulRedisConnection<String, String>,
+    cluster: StatefulRedisClusterConnection<String, String>,
+    config: LettuceFencingLeaseConfig,
+    ownerId: FencingOwnerId,
+    token: FencingToken,
+    leaseTime: Duration,
+) {
+    listOf(
+        LettuceFencingLease(standalone, config),
+        LettuceFencingLease(cluster, config),
+    ).forEach { lease ->
+        lease.bootstrap()
+        lease.bootstrapAsync()
+        lease.acquire(ownerId, leaseTime)
+        lease.acquireAsync(ownerId, leaseTime)
+        lease.inspect(ownerId)
+        lease.inspectAsync(ownerId)
+        lease.renew(ownerId, token, leaseTime)
+        lease.renewAsync(ownerId, token, leaseTime)
+        lease.release(ownerId, token)
+        lease.releaseAsync(ownerId, token)
+    }
+    listOf(
+        LettuceSuspendFencingLease(standalone, config),
+        LettuceSuspendFencingLease(cluster, config),
+    ).forEach { lease ->
+        lease.bootstrap()
+        lease.acquire(ownerId, leaseTime)
+        lease.inspect(ownerId)
+        lease.renew(ownerId, token, leaseTime)
+        lease.release(ownerId, token)
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseTopologyRecoveryTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseTopologyRecoveryTest.kt
@@ -1,0 +1,409 @@
+package io.bluetape4k.redis.lettuce.lease
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.testcontainers.storage.RedisServer
+import io.lettuce.core.RedisClient
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.sync.RedisCommands
+import io.lettuce.core.codec.StringCodec
+import org.awaitility.Awaitility.await
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.Network
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import org.testcontainers.utility.MountableFile
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.file.Files
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+
+/** Exercises explicit higher-epoch recovery after a stale replica promotion and known-old RDB restore. */
+@Tag("fencing-topology")
+internal class LettuceFencingLeaseTopologyRecoveryTest {
+
+    @Test
+    @Timeout(value = 180, unit = TimeUnit.SECONDS)
+    fun `promotion and restore require traffic pause durable epoch bump and strict tuple rejection`() {
+        val snapshot = Files.createTempFile("fencing-known-old-", ".rdb")
+        val trace = mutableListOf<TopologyEvent>()
+        val gate = TrafficGate(trace)
+        val epochAuthority = DurableEpochAuthority(71)
+        val downstream = StrictDownstreamStore()
+        val bootstrapEpochs = mutableListOf<Long>()
+
+        try {
+            Network.newNetwork().use { network ->
+                RedisServer()
+                    .withNetwork(network)
+                    .withNetworkAliases(PRIMARY_ALIAS)
+                    .withCommand(*redisCommand())
+                    .use { primary ->
+                        OwnedToxiproxy()
+                            .withNetwork(network)
+                            .withNetworkAliases(TOXIPROXY_ALIAS)
+                            .use { toxiproxy ->
+                                primary.start()
+                                toxiproxy.start()
+                                val proxy = createReplicationProxy(toxiproxy)
+                                try {
+                                    RedisServer()
+                                        .withNetwork(network)
+                                        .withNetworkAliases(REPLICA_ALIAS)
+                                        .withCommand(*replicaCommand())
+                                        .use { replica ->
+                                            replica.start()
+                                            ownedClient(primary).useClient { primaryConnection ->
+                                                ownedClient(replica).useClient { replicaConnection ->
+                                                    val primaryCommands = primaryConnection.sync()
+                                                    val replicaCommands = replicaConnection.sync()
+                                                    val oldConfig = config(epoch = 71)
+                                                    val keys = deriveFencingLeaseKeys(oldConfig, StringCodec.UTF8)
+                                                    val oldLease = LettuceFencingLease(primaryConnection, oldConfig)
+
+                                                    oldLease.bootstrap() shouldBeEqualTo
+                                                        FencingBootstrapResult.Initialized
+                                                    awaitReplicaBaseline(primaryCommands, replicaCommands, keys.counter)
+                                                    primaryCommands.save() shouldBeEqualTo "OK"
+                                                    primary.copyFileFromContainer("/data/dump.rdb", snapshot.toString())
+                                                    trace += TopologyEvent.BASELINE_SNAPSHOT
+
+                                                    proxy.disable()
+                                                    trace += TopologyEvent.REPLICATION_PARTITIONED
+                                                    val oldOwner = FencingOwnerId.from("owner-before-signal")
+                                                    val oldToken = oldLease.acquire(oldOwner, LEASE_TIME)
+                                                        .shouldBeInstanceOf<FencingAcquireResult.Acquired>()
+                                                        .token
+                                                    trace += TopologyEvent.OLD_ACQUIRE
+                                                    downstream.write(RESOURCE_ID, oldToken) shouldBeEqualTo 1
+                                                    trace += TopologyEvent.OLD_DOWNSTREAM_WRITE
+                                                    primaryCommands.get(keys.counter) shouldBeEqualTo "1"
+                                                    replicaCommands.get(keys.counter) shouldBeEqualTo "0"
+
+                                                    primaryConnection.close()
+                                                    primary.stop()
+                                                    replicaCommands.replicaofNoOne() shouldBeEqualTo "OK"
+                                                    trace += TopologyEvent.STALE_REPLICA_PROMOTED
+
+                                                    gate.closeForIncident()
+                                                    gate.executeOldAcquire { oldLease.acquire(oldOwner, LEASE_TIME) }
+                                                        .shouldBeNull()
+                                                    gate.executeOldDownstreamWrite {
+                                                        downstream.write(RESOURCE_ID, oldToken)
+                                                    }.shouldBeNull()
+
+                                                    val promotedToken = recover(
+                                                        commands = replicaCommands,
+                                                        connection = replicaConnection,
+                                                        epochAuthority = epochAuthority,
+                                                        requestedEpoch = 72,
+                                                        bootstrapEpochs = bootstrapEpochs,
+                                                        trace = trace,
+                                                    )
+                                                    promotedToken shouldBeGreaterThan oldToken
+                                                    downstream.write(RESOURCE_ID, promotedToken) shouldBeEqualTo 1
+                                                    downstream.write(RESOURCE_ID, oldToken) shouldBeEqualTo 0
+                                                    gate.resumeHigherEpoch()
+                                                }
+                                            }
+                                        }
+                                } finally {
+                                    runCatching { proxy.enable() }
+                                    runCatching { proxy.delete() }
+                                }
+                            }
+                    }
+
+                RedisServer()
+                    .withNetwork(network)
+                    .withNetworkAliases(RESTORE_ALIAS)
+                    .withCopyFileToContainer(MountableFile.forHostPath(snapshot), "/data/dump.rdb")
+                    .withCommand(*redisCommand())
+                    .use { restored ->
+                        restored.start()
+                        ownedClient(restored).useClient { restoredConnection ->
+                            val restoredCommands = restoredConnection.sync()
+                            val oldKeys = deriveFencingLeaseKeys(config(71), StringCodec.UTF8)
+                            restoredCommands.get(oldKeys.counter) shouldBeEqualTo "0"
+                            trace += TopologyEvent.KNOWN_OLD_RDB_RESTORED
+                            gate.closeForIncident()
+                            gate.executeOldDownstreamWrite {
+                                downstream.write(RESOURCE_ID, FencingToken(71, 1))
+                            }.shouldBeNull()
+
+                            val restoredToken = recover(
+                                commands = restoredCommands,
+                                connection = restoredConnection,
+                                epochAuthority = epochAuthority,
+                                requestedEpoch = 73,
+                                bootstrapEpochs = bootstrapEpochs,
+                                trace = trace,
+                            )
+                            restoredToken.epoch shouldBeEqualTo 73
+                            downstream.write(RESOURCE_ID, restoredToken) shouldBeEqualTo 1
+                            downstream.write(RESOURCE_ID, FencingToken(71, 1)) shouldBeEqualTo 0
+                            gate.resumeHigherEpoch()
+                        }
+                    }
+            }
+
+            bootstrapEpochs shouldBeEqualTo listOf(72L, 73L)
+            trace.count { it == TopologyEvent.OLD_ACQUIRE } shouldBeEqualTo 1
+            trace.count { it == TopologyEvent.OLD_DOWNSTREAM_WRITE } shouldBeEqualTo 1
+            trace.count { it == TopologyEvent.BLOCKED_OLD_ACQUIRE } shouldBeEqualTo 1
+            trace.count { it == TopologyEvent.BLOCKED_OLD_DOWNSTREAM_WRITE } shouldBeEqualTo 2
+            trace.count { it == TopologyEvent.EXTERNAL_INCIDENT_SIGNAL } shouldBeEqualTo 2
+            trace.count { it == TopologyEvent.RESUME } shouldBeEqualTo 2
+            trace.indexOf(TopologyEvent.EXTERNAL_INCIDENT_SIGNAL) shouldBeGreaterThan
+                trace.indexOf(TopologyEvent.OLD_ACQUIRE)
+            gate.isOpen.shouldBeTrue()
+        } finally {
+            Files.deleteIfExists(snapshot)
+        }
+    }
+
+    private fun recover(
+        commands: RedisCommands<String, String>,
+        connection: StatefulRedisConnection<String, String>,
+        epochAuthority: DurableEpochAuthority,
+        requestedEpoch: Long,
+        bootstrapEpochs: MutableList<Long>,
+        trace: MutableList<TopologyEvent>,
+    ): FencingToken {
+        val previous = epochAuthority.currentEpoch
+        epochAuthority.compareAndSet(previous, requestedEpoch).shouldBeTrue()
+        trace += TopologyEvent.DURABLE_CAS_BUMP
+
+        val config = config(requestedEpoch)
+        val keys = deriveFencingLeaseKeys(config, StringCodec.UTF8)
+        val lease = LettuceFencingLease(connection, config)
+        bootstrapEpochs += requestedEpoch
+        lease.bootstrap() shouldBeEqualTo FencingBootstrapResult.Initialized
+        trace += TopologyEvent.BOOTSTRAP
+        isReady(commands, keys).shouldBeTrue()
+        trace += TopologyEvent.READINESS
+
+        val token = lease.acquire(FencingOwnerId.from("owner-$requestedEpoch"), LEASE_TIME)
+            .shouldBeInstanceOf<FencingAcquireResult.Acquired>()
+            .token
+        trace += TopologyEvent.HIGHER_EPOCH_READY
+        return token
+    }
+
+    private fun awaitReplicaBaseline(
+        primary: RedisCommands<String, String>,
+        replica: RedisCommands<String, String>,
+        counterKey: String,
+    ) {
+        await()
+            .atMost(Duration.ofSeconds(45))
+            .pollInterval(Duration.ofMillis(50))
+            .untilAsserted {
+                val primaryInfo = parseInfo(primary.info("replication"))
+                val persistenceInfo = parseInfo(primary.info("persistence"))
+                val replicaInfo = parseInfo(replica.info("replication"))
+                ReplicationBaseline(
+                    connectedReplicas = primaryInfo["connected_slaves"],
+                    backgroundSave = persistenceInfo["rdb_bgsave_in_progress"],
+                    replicaLink = replicaInfo["master_link_status"],
+                    counter = replica.get(counterKey),
+                    offsetsMatch = primaryInfo["master_repl_offset"] == replicaInfo["slave_repl_offset"],
+                ) shouldBeEqualTo READY_REPLICATION_BASELINE
+            }
+    }
+
+    private fun isReady(commands: RedisCommands<String, String>, keys: FencingLeaseKeys): Boolean =
+        commands.type(keys.counter) == "string" &&
+            commands.pttl(keys.counter) == -1L &&
+            commands.get(keys.counter)?.let { it == "0" || CANONICAL_POSITIVE.matches(it) } == true
+
+    private fun parseInfo(info: String): Map<String, String> =
+        info.lineSequence()
+            .filter { ':' in it && !it.startsWith('#') }
+            .associate { line -> line.substringBefore(':') to line.substringAfter(':').trim() }
+
+    private fun createReplicationProxy(toxiproxy: OwnedToxiproxy): ReplicationProxy =
+        ReplicationProxy(toxiproxy.controlUrl)
+
+    private fun ownedClient(server: RedisServer): RedisClient =
+        RedisClient.create("redis://${server.host}:${server.port}")
+
+    private inline fun <T> RedisClient.useClient(
+        block: (StatefulRedisConnection<String, String>) -> T,
+    ): T = try {
+        connect(StringCodec.UTF8).use(block)
+    } finally {
+        shutdown()
+    }
+
+    private fun config(epoch: Long): LettuceFencingLeaseConfig =
+        LettuceFencingLeaseConfig("topology-recovery", RESOURCE_ID, epoch)
+
+    private fun redisCommand(): Array<String> = arrayOf(
+        "redis-server",
+        "--dir", "/data",
+        "--dbfilename", "dump.rdb",
+        "--save", "",
+        "--appendonly", "no",
+    )
+
+    private fun replicaCommand(): Array<String> = redisCommand() + arrayOf(
+        "--replicaof", TOXIPROXY_ALIAS, PROXY_PORT.toString(),
+    )
+
+    private class TrafficGate(private val trace: MutableList<TopologyEvent>) {
+        private val open = AtomicBoolean(true)
+
+        val isOpen: Boolean get() = open.get()
+
+        fun closeForIncident() {
+            open.compareAndSet(true, false).shouldBeTrue()
+            trace += TopologyEvent.EXTERNAL_INCIDENT_SIGNAL
+            trace += TopologyEvent.TRAFFIC_PAUSED
+        }
+
+        fun resumeHigherEpoch() {
+            open.compareAndSet(false, true).shouldBeTrue()
+            trace += TopologyEvent.ROLLOUT
+            trace += TopologyEvent.CONFIRM_OLD_ABSENCE
+            trace += TopologyEvent.RESUME
+        }
+
+        fun <T> executeOldAcquire(action: () -> T): T? =
+            if (open.get()) action() else {
+                trace += TopologyEvent.BLOCKED_OLD_ACQUIRE
+                null
+            }
+
+        fun <T> executeOldDownstreamWrite(action: () -> T): T? =
+            if (open.get()) action() else {
+                trace += TopologyEvent.BLOCKED_OLD_DOWNSTREAM_WRITE
+                null
+            }
+    }
+
+    private class DurableEpochAuthority(initialEpoch: Long) {
+        private val epoch = AtomicLong(initialEpoch)
+        val currentEpoch: Long get() = epoch.get()
+        fun compareAndSet(expected: Long, update: Long): Boolean =
+            update > expected && epoch.compareAndSet(expected, update)
+    }
+
+    private class OwnedToxiproxy:
+        GenericContainer<OwnedToxiproxy>(DockerImageName.parse(TOXIPROXY_IMAGE)) {
+
+        val controlUrl: String get() = "http://$host:${getMappedPort(TOXIPROXY_CONTROL_PORT)}"
+
+        init {
+            withExposedPorts(TOXIPROXY_CONTROL_PORT, PROXY_PORT)
+            waitingFor(Wait.forHttp("/version").forPort(TOXIPROXY_CONTROL_PORT))
+        }
+    }
+
+    private class ReplicationProxy(private val controlUrl: String) {
+        private val client = HttpClient.newHttpClient()
+
+        init {
+            val configuration =
+                """{"name":"$PROXY_NAME","listen":"0.0.0.0:$PROXY_PORT",""" +
+                    """"upstream":"$PRIMARY_ALIAS:${RedisServer.PORT}"}"""
+            request(
+                "POST",
+                "/proxies",
+                configuration,
+            )
+        }
+
+        fun disable() = setEnabled(false)
+
+        fun enable() = setEnabled(true)
+
+        fun delete() {
+            request("DELETE", "/proxies/$PROXY_NAME")
+        }
+
+        private fun setEnabled(enabled: Boolean) {
+            request("POST", "/proxies/$PROXY_NAME", """{"enabled":$enabled}""")
+        }
+
+        private fun request(method: String, path: String, body: String? = null) {
+            val builder = HttpRequest.newBuilder(URI.create(controlUrl + path))
+                .header("Content-Type", "application/json")
+            val request = when {
+                body != null -> builder.method(method, HttpRequest.BodyPublishers.ofString(body)).build()
+                else         -> builder.method(method, HttpRequest.BodyPublishers.noBody()).build()
+            }
+            val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+            require(response.statusCode() in 200..299) {
+                "Toxiproxy control request failed with status ${response.statusCode()}."
+            }
+        }
+    }
+
+    private class StrictDownstreamStore {
+        private var token: FencingToken? = null
+
+        @Synchronized
+        fun write(resourceId: String, candidate: FencingToken): Int {
+            resourceId shouldBeEqualTo RESOURCE_ID
+            val current = token
+            if (current != null && candidate <= current) return 0
+            token = candidate
+            return 1
+        }
+    }
+
+    private data class ReplicationBaseline(
+        val connectedReplicas: String?,
+        val backgroundSave: String?,
+        val replicaLink: String?,
+        val counter: String?,
+        val offsetsMatch: Boolean,
+    )
+
+    private enum class TopologyEvent {
+        BASELINE_SNAPSHOT,
+        REPLICATION_PARTITIONED,
+        OLD_ACQUIRE,
+        OLD_DOWNSTREAM_WRITE,
+        STALE_REPLICA_PROMOTED,
+        EXTERNAL_INCIDENT_SIGNAL,
+        TRAFFIC_PAUSED,
+        BLOCKED_OLD_ACQUIRE,
+        BLOCKED_OLD_DOWNSTREAM_WRITE,
+        DURABLE_CAS_BUMP,
+        BOOTSTRAP,
+        READINESS,
+        HIGHER_EPOCH_READY,
+        KNOWN_OLD_RDB_RESTORED,
+        ROLLOUT,
+        CONFIRM_OLD_ABSENCE,
+        RESUME,
+    }
+
+    private companion object {
+        const val PRIMARY_ALIAS: String = "fencing-primary"
+        const val REPLICA_ALIAS: String = "fencing-replica"
+        const val RESTORE_ALIAS: String = "fencing-restore"
+        const val TOXIPROXY_ALIAS: String = "fencing-toxiproxy"
+        const val PROXY_PORT: Int = 8666
+        const val PROXY_NAME: String = "fencing-replication"
+        const val TOXIPROXY_CONTROL_PORT: Int = 8474
+        const val TOXIPROXY_IMAGE: String = "ghcr.io/shopify/toxiproxy:2.9.0"
+        const val RESOURCE_ID: String = "guarded-resource"
+        val READY_REPLICATION_BASELINE = ReplicationBaseline("1", "0", "up", "0", true)
+        val LEASE_TIME: Duration = Duration.ofMinutes(1)
+        val CANONICAL_POSITIVE: Regex = Regex("[1-9][0-9]*")
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLeaseTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLeaseTest.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.redis.lettuce.lease
+
+import io.lettuce.core.api.StatefulRedisConnection
+import java.time.Duration
+
+internal class LettuceSuspendFencingLeaseTest : FencingLeaseContract() {
+    override fun createAdapter(
+        connection: StatefulRedisConnection<String, String>,
+        config: LettuceFencingLeaseConfig,
+    ): FencingLeaseAdapter {
+        val lease = LettuceSuspendFencingLease(connection, config)
+        return object: FencingLeaseAdapter {
+            override suspend fun bootstrap(): FencingBootstrapResult = lease.bootstrap()
+            override suspend fun acquire(ownerId: FencingOwnerId, leaseTime: Duration): FencingAcquireResult =
+                lease.acquire(ownerId, leaseTime)
+            override suspend fun inspect(ownerId: FencingOwnerId): FencingInspectResult = lease.inspect(ownerId)
+            override suspend fun renew(
+                ownerId: FencingOwnerId,
+                token: FencingToken,
+                leaseTime: Duration,
+            ): FencingRenewResult = lease.renew(ownerId, token, leaseTime)
+            override suspend fun release(ownerId: FencingOwnerId, token: FencingToken): FencingReleaseResult =
+                lease.release(ownerId, token)
+        }
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/script/RedisScriptTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/script/RedisScriptTest.kt
@@ -1,6 +1,8 @@
 package io.bluetape4k.redis.lettuce.script
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeEqualTo
@@ -31,6 +33,8 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
@@ -270,6 +274,221 @@ class RedisScriptTest : AbstractLettuceTest() {
             "value",
         ).get() shouldBeEqualTo "value"
 
+        verify(exactly = 1) {
+            commands.evalsha<String>(setAndReturnScript.sha1, ScriptOutputType.VALUE, keys, "value")
+            commands.eval<String>(setAndReturnScript.source, ScriptOutputType.VALUE, keys, "value")
+        }
+        confirmVerified(commands)
+    }
+
+    @Test
+    fun `cancelling async result while evalsha is pending cancels evalsha`() {
+        val commands = mockk<RedisScriptingAsyncCommands<String, String>>()
+        val keys = arrayOf("key:{async-cancel-evalsha}")
+        val evalsha = TestRedisFuture<String>()
+        every {
+            commands.evalsha<String>(setAndReturnScript.sha1, ScriptOutputType.VALUE, keys, "value")
+        } returns evalsha
+
+        val result = RedisScriptRunner.runAsync<String>(
+            commands,
+            setAndReturnScript,
+            ScriptOutputType.VALUE,
+            keys,
+            "value",
+        )
+
+        result.cancel(true).shouldBeTrue()
+
+        result.isCancelled.shouldBeTrue()
+        evalsha.isCancelled.shouldBeTrue()
+        verify(exactly = 1) {
+            commands.evalsha<String>(setAndReturnScript.sha1, ScriptOutputType.VALUE, keys, "value")
+        }
+        confirmVerified(commands)
+    }
+
+    @Test
+    fun `cancelling async result after NOSCRIPT cancels eval fallback`() {
+        val commands = mockk<RedisScriptingAsyncCommands<String, String>>()
+        val keys = arrayOf("key:{async-cancel-eval}")
+        val evalsha = TestRedisFuture<String>()
+        val fallback = TestRedisFuture<String>()
+        every {
+            commands.evalsha<String>(setAndReturnScript.sha1, ScriptOutputType.VALUE, keys, "value")
+        } returns evalsha
+        every {
+            commands.eval<String>(setAndReturnScript.source, ScriptOutputType.VALUE, keys, "value")
+        } returns fallback
+
+        val result = RedisScriptRunner.runAsync<String>(
+            commands,
+            setAndReturnScript,
+            ScriptOutputType.VALUE,
+            keys,
+            "value",
+        )
+        evalsha.completeExceptionally(RedisNoScriptException("NOSCRIPT"))
+
+        result.cancel(true).shouldBeTrue()
+
+        result.isCancelled.shouldBeTrue()
+        fallback.isCancelled.shouldBeTrue()
+        verify(exactly = 1) {
+            commands.evalsha<String>(setAndReturnScript.sha1, ScriptOutputType.VALUE, keys, "value")
+            commands.eval<String>(setAndReturnScript.source, ScriptOutputType.VALUE, keys, "value")
+        }
+        confirmVerified(commands)
+    }
+
+    @Test
+    fun `async cancellation during NOSCRIPT handoff cancels the attached fallback`() {
+        val commands = mockk<RedisScriptingAsyncCommands<String, String>>()
+        val keys = arrayOf("key:{async-cancel-race}")
+        val evalsha = TestRedisFuture<String>()
+        val fallback = TestRedisFuture<String>()
+        val fallbackEntered = CountDownLatch(1)
+        val allowFallbackReturn = CountDownLatch(1)
+        every {
+            commands.evalsha<String>(setAndReturnScript.sha1, ScriptOutputType.VALUE, keys, "value")
+        } returns evalsha
+        every {
+            commands.eval<String>(setAndReturnScript.source, ScriptOutputType.VALUE, keys, "value")
+        } answers {
+            fallbackEntered.countDown()
+            allowFallbackReturn.await(5, TimeUnit.SECONDS)
+            fallback
+        }
+
+        val result = RedisScriptRunner.runAsync<String>(
+            commands,
+            setAndReturnScript,
+            ScriptOutputType.VALUE,
+            keys,
+            "value",
+        )
+        val handoff = CompletableFuture.runAsync {
+            evalsha.completeExceptionally(RedisNoScriptException("NOSCRIPT"))
+        }
+        fallbackEntered.await(5, TimeUnit.SECONDS).shouldBeTrue()
+
+        result.cancel(true).shouldBeTrue()
+        allowFallbackReturn.countDown()
+        handoff.get(5, TimeUnit.SECONDS)
+
+        result.isCancelled.shouldBeTrue()
+        fallback.isCancelled.shouldBeTrue()
+        verify(exactly = 1) {
+            commands.evalsha<String>(setAndReturnScript.sha1, ScriptOutputType.VALUE, keys, "value")
+            commands.eval<String>(setAndReturnScript.source, ScriptOutputType.VALUE, keys, "value")
+        }
+        confirmVerified(commands)
+    }
+
+    @Test
+    fun `synchronous evalsha failure completes returned future exceptionally`() {
+        val commands = mockk<RedisScriptingAsyncCommands<String, String>>()
+        val keys = arrayOf("key:{async-evalsha-throw}")
+        val backendFailure = IllegalStateException("evalsha dispatch failed")
+        every {
+            commands.evalsha<String>(setAndReturnScript.sha1, ScriptOutputType.VALUE, keys, "value")
+        } throws backendFailure
+
+        val result = RedisScriptRunner.runAsync<String>(
+            commands,
+            setAndReturnScript,
+            ScriptOutputType.VALUE,
+            keys,
+            "value",
+        )
+
+        result.isDone.shouldBeTrue()
+        result.isCompletedExceptionally.shouldBeTrue()
+        assertFailsWith<ExecutionException> { result.get() }.cause shouldBeSameInstanceAs backendFailure
+        verify(exactly = 1) {
+            commands.evalsha<String>(setAndReturnScript.sha1, ScriptOutputType.VALUE, keys, "value")
+        }
+        confirmVerified(commands)
+    }
+
+    @Test
+    fun `synchronous eval fallback failure completes returned future exceptionally`() {
+        val commands = mockk<RedisScriptingAsyncCommands<String, String>>()
+        val keys = arrayOf("key:{async-eval-throw}")
+        val backendFailure = IllegalStateException("eval dispatch failed")
+        every {
+            commands.evalsha<String>(setAndReturnScript.sha1, ScriptOutputType.VALUE, keys, "value")
+        } returns failedRedisFuture(RedisNoScriptException("NOSCRIPT"))
+        every {
+            commands.eval<String>(setAndReturnScript.source, ScriptOutputType.VALUE, keys, "value")
+        } throws backendFailure
+
+        val result = RedisScriptRunner.runAsync<String>(
+            commands,
+            setAndReturnScript,
+            ScriptOutputType.VALUE,
+            keys,
+            "value",
+        )
+
+        result.isDone.shouldBeTrue()
+        result.isCompletedExceptionally.shouldBeTrue()
+        assertFailsWith<ExecutionException> { result.get() }.cause shouldBeSameInstanceAs backendFailure
+        verify(exactly = 1) {
+            commands.evalsha<String>(setAndReturnScript.sha1, ScriptOutputType.VALUE, keys, "value")
+            commands.eval<String>(setAndReturnScript.source, ScriptOutputType.VALUE, keys, "value")
+        }
+        confirmVerified(commands)
+    }
+
+    @Test
+    fun `async non NOSCRIPT failure completes exceptionally without fallback`() {
+        val commands = mockk<RedisScriptingAsyncCommands<String, String>>()
+        val keys = arrayOf("key:{async-command-failure}")
+        val backendFailure = IllegalStateException("command failed")
+        every {
+            commands.evalsha<String>(setAndReturnScript.sha1, ScriptOutputType.VALUE, keys, "value")
+        } returns failedRedisFuture(backendFailure)
+
+        val result = RedisScriptRunner.runAsync<String>(
+            commands,
+            setAndReturnScript,
+            ScriptOutputType.VALUE,
+            keys,
+            "value",
+        )
+
+        result.isDone.shouldBeTrue()
+        result.isCompletedExceptionally.shouldBeTrue()
+        assertFailsWith<ExecutionException> { result.get() }.cause shouldBeSameInstanceAs backendFailure
+        verify(exactly = 1) {
+            commands.evalsha<String>(setAndReturnScript.sha1, ScriptOutputType.VALUE, keys, "value")
+        }
+        confirmVerified(commands)
+    }
+
+    @Test
+    fun `NOSCRIPT from eval fallback is terminal and does not dispatch eval again`() {
+        val commands = mockk<RedisScriptingAsyncCommands<String, String>>()
+        val keys = arrayOf("key:{async-fallback-noscript}")
+        val fallbackFailure = RedisNoScriptException("NOSCRIPT from eval")
+        val repeatedDispatch = IllegalStateException("eval dispatched more than once")
+        every {
+            commands.evalsha<String>(setAndReturnScript.sha1, ScriptOutputType.VALUE, keys, "value")
+        } returns failedRedisFuture(RedisNoScriptException("NOSCRIPT"))
+        every {
+            commands.eval<String>(setAndReturnScript.source, ScriptOutputType.VALUE, keys, "value")
+        } returns failedRedisFuture(fallbackFailure) andThenThrows repeatedDispatch
+
+        val result = RedisScriptRunner.runAsync<String>(
+            commands,
+            setAndReturnScript,
+            ScriptOutputType.VALUE,
+            keys,
+            "value",
+        )
+
+        assertFailsWith<ExecutionException> { result.get() }.cause shouldBeSameInstanceAs fallbackFailure
         verify(exactly = 1) {
             commands.evalsha<String>(setAndReturnScript.sha1, ScriptOutputType.VALUE, keys, "value")
             commands.eval<String>(setAndReturnScript.source, ScriptOutputType.VALUE, keys, "value")


### PR DESCRIPTION
## Summary

Closes #1068

- PR 제목: feat(infra-lettuce): add monotonic fencing lease tokens

- add a config-bound Redis fencing lease whose atomic Lua state machine issues lexicographically ordered `(epoch, sequence)` tokens
- expose equivalent blocking, `CompletableFuture`, and suspending APIs with explicit serialization-safe lifecycle results
- preserve cancellation and ambiguous-completion reconciliation, including same-owner acquire replay without allocating a second token
- document caller-owned downstream tuple guards, Resilience4j decorators, fail-closed epoch recovery, diagnostics, and operational limitations in English and Korean

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Safety boundaries

- lease and counter keys are derived from one validated namespace/resource domain and verified against encoded Redis Cluster slots before dispatch
- missing, malformed, reset, expired, or overflowing counter state fails closed; bootstrap is explicit and never repairs lost same-epoch history
- renew and release require both owner capability and token, while downstream systems remain responsible for durable strict tuple comparison
- counter-history loss, asynchronous failover, snapshot rollback, exactly-once execution, business idempotency, and durable epoch allocation remain outside the primitive
- retry, circuit breaker, and bulkhead policy remains caller-owned; the executable example retries only `BackendFailure` with the same owner identity

### 기존 섹션: Acceptance evidence

| Acceptance boundary | Implementation and test evidence |
| --- | --- |
| Config-bound domain and Cluster slot | derived encoded keys, validation/support tests, 3 Redis Cluster tests |
| Ordered serializable token/results | value/result round-trip, identity, hostile payload, redaction tests |
| Explicit bootstrap and fail-closed counter state | Lua protocol and hostile-state script tests |
| Atomic generation and same-owner replay | standalone contract, bounded contention, ambiguous-completion tests |
| Owner+token renew/release | shared blocking/future/suspend contract and stale-holder tests |
| Backend/integrity/protocol boundary | shared decoder/classifier and adapter-parity tests |
| Cancellation | RedisScript bridge plus future/coroutine cancellation tests |
| Caller-owned resilience | executable Retry/CircuitBreaker/Bulkhead tests and README-derived policy test |
| Durable downstream rejection and recovery | strict tuple fixture, epoch CAS/readiness tests, shared read-only diagnostic Lua |
| Promotion/restore boundary | opt-in Testcontainers primary/replica/Toxiproxy recovery test |
| Bilingual docs and KDoc | marker/source parity, executable snippets, structural public-KDoc audit |
| Existing API compatibility | RedisScript and MultiKeyLease regression suite; full module suite |

### 기존 섹션: Verification

- fencing value/result/support unit suite
- standalone script, blocking, future, suspend, cancellation, concurrency, resilience, recovery, and documentation suites
- `LettuceFencingLeaseClusterTest`: 3 passing
- `fencingLeaseTopologyRecoveryTest`: 1 passing
- existing `RedisScriptTest` and `*MultiKeyLease*` regression suite
- `:bluetape4k-lettuce:test --rerun-tasks`: 556 passing
- root `detekt detektTest`: successful (`NO-SOURCE` for this root aggregation)
- `git diff --check` and forbidden assertion/work-marker audit

No new module or dependency was added. Production-managed Redis failover topology remains outside the Testcontainers verification boundary.

Closes #1068

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1068, milestone `1.12.0`, assignee `debop`
- PR: #1069, head `88796862ecf7b5eb8e91f8b3fa4403aa5561eeb8`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `feature/issue-1068-fencing-lease`
- Labels: `enhancement`, `test`, `design`, `infra/io`
- State: `MERGED`, merge commit `8b33d3f1937b783ae4f8834351000c9ec0b0afbb`
- CI: - add a config-bound Redis fencing lease whose atomic Lua state machine issues lexicographically ordered `(epoch, sequence)` tokens / - expose equivalent blocking, `CompletableFuture`, and suspending APIs with explicit serialization-safe lifecycle results / - preserve cancellation and ambiguous-completion reconciliation, including same-owner acquire replay without allocating a second token

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1069 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `8b33d3f1937b783ae4f8834351000c9ec0b0afbb`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
