### PR TITLE
feat: add CheckSupport invariant helpers

### DIFF
--- a/bluetape4k/core/README.ko.md
+++ b/bluetape4k/core/README.ko.md
@@ -24,7 +24,7 @@ Kotlin Backend 개발을 위한 핵심 유틸리티 라이브러리입니다. Bl
 
 ## 주요 기능
 
-- **Validation (RequireSupport)**: 파라미터 검증을 위한 Contract 기반 함수들
+- **Validation (RequireSupport / CheckSupport)**: 호출자 검증과 상태 불변식 검증을 위한 Contract 기반 함수들
 - **Encoding/Decoding (Codec)**: Base58, Base62, Hex, URL62 등 다양한 인코딩
 - **String Support**: UTF-8 바이트 변환과 바이트 경계 안전 `truncateUtf8(maxBytes)`
 - **Type Extensions**: 모든 기본 타입에 대한 Kotlin 스타일 확장 함수
@@ -110,6 +110,21 @@ fun setQuantity(quantity: Int) {
 fun validateScore(score: Double) {
     score.requireGe(0.0, "score")
         .requireLe(100.0, "score")
+}
+```
+
+#### 상태 불변식 검증
+
+`CheckSupport`는 객체와 컴포넌트의 상태를 검증할 수 있도록 `RequireSupport`와 대칭인 API를 제공합니다.
+검증에 실패하면 `IllegalArgumentException` 대신 `IllegalStateException`이 발생합니다.
+
+```kotlin
+import io.bluetape4k.support.checkNotNull
+import io.bluetape4k.support.checkPositiveNumber
+
+fun nextBatch(currentBatch: Batch?, remaining: Int): Batch {
+    remaining.checkPositiveNumber("remaining")
+    return currentBatch.checkNotNull("currentBatch")
 }
 ```
 

--- a/bluetape4k/core/README.md
+++ b/bluetape4k/core/README.md
@@ -24,7 +24,7 @@ A foundational utility library for Kotlin backend development. It provides the c
 
 ## Features
 
-- **Validation (RequireSupport)**: Contract-based parameter validation functions
+- **Validation (RequireSupport / CheckSupport)**: Contract-based caller validation and state-invariant functions
 - **Encoding/Decoding (Codec)**: Multiple encoding schemes — Base58, Base62, Hex, URL62
 - **String Support**: UTF-8 byte conversion and byte-safe `truncateUtf8(maxBytes)`
 - **Type Extensions**: Kotlin-style extension functions for all primitive types
@@ -110,6 +110,21 @@ fun setQuantity(quantity: Int) {
 fun validateScore(score: Double) {
     score.requireGe(0.0, "score")
         .requireLe(100.0, "score")
+}
+```
+
+#### State Invariant Checks
+
+`CheckSupport` mirrors the `RequireSupport` API for object and component state.
+Failed checks throw `IllegalStateException` instead of `IllegalArgumentException`.
+
+```kotlin
+import io.bluetape4k.support.checkNotNull
+import io.bluetape4k.support.checkPositiveNumber
+
+fun nextBatch(currentBatch: Batch?, remaining: Int): Batch {
+    remaining.checkPositiveNumber("remaining")
+    return currentBatch.checkNotNull("currentBatch")
 }
 ```
 

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/CheckSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/CheckSupport.kt
@@ -1,0 +1,493 @@
+@file:OptIn(ExperimentalContracts::class)
+@file:Suppress("NOTHING_TO_INLINE")
+
+package io.bluetape4k.support
+
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+/**
+ * Provides the `checkNotNull` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = ("blue" as String?).checkNotNull("text")
+ * // result == "blue"
+ * ```
+ */
+inline fun <T: Any> T?.checkNotNull(parameterName: String): T {
+    contract {
+        returns() implies (this@checkNotNull != null)
+    }
+    check(this != null) { "$parameterName[$this] must not be null." }
+    return this
+}
+
+/**
+ * Provides the `checkNull` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = (null as String?).checkNull("text")
+ * // result == null
+ * ```
+ */
+inline fun <T: Any> T?.checkNull(parameterName: String): T? {
+    contract {
+        returns() implies (this@checkNull == null)
+    }
+    check(this == null) { "$parameterName[$this] must be null." }
+    return this
+}
+
+/**
+ * Provides the `checkNotEmpty` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = ("blue" as String?).checkNotEmpty("text")
+ * // result == "blue"
+ * ```
+ */
+inline fun <T: CharSequence> T?.checkNotEmpty(parameterName: String): T {
+    contract {
+        returnsNotNull() implies (this@checkNotEmpty != null)
+    }
+    val self = this.checkNotNull(parameterName)
+    check(self.isNotEmpty()) { "$parameterName[$self] must not be empty." }
+    return self
+}
+
+/**
+ * Provides the `checkNullOrEmpty` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = ("" as String?).checkNullOrEmpty("text")
+ * // result == ""
+ * ```
+ */
+inline fun <T: CharSequence> T?.checkNullOrEmpty(parameterName: String): T? {
+    check(this.isNullOrEmpty()) { "$parameterName[$this] must be null or empty." }
+    return this
+}
+
+/**
+ * Provides the `checkNotBlank` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = ("blue" as String?).checkNotBlank("text")
+ * // result == "blue"
+ * ```
+ */
+inline fun <T: CharSequence> T?.checkNotBlank(parameterName: String): T {
+    contract {
+        returnsNotNull() implies (this@checkNotBlank != null)
+    }
+    val self = this.checkNotNull(parameterName)
+    check(self.isNotBlank()) { "$parameterName[$self] must not be blank." }
+    return self
+}
+
+/**
+ * Provides the `checkNullOrBlank` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = ("   " as String?).checkNullOrBlank("text")
+ * // result == "   "
+ * ```
+ */
+inline fun <T: CharSequence> T?.checkNullOrBlank(parameterName: String): T? {
+    check(this.isNullOrBlank()) { "$parameterName[$this] must be null or blank." }
+    return this
+}
+
+
+/**
+ * Provides the `checkContains` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = ("blue" as String?).checkContains("lu", "text")
+ * // result == "blue"
+ * ```
+ */
+inline fun <T: CharSequence> T?.checkContains(other: CharSequence, parameterName: String): T {
+    this.checkNotNull(parameterName)
+    check(this.contains(other)) { "$parameterName[$this] must contain $other" }
+    return this
+}
+
+/**
+ * Provides the `checkStartsWith` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = ("blue" as String?).checkStartsWith("bl", "text")
+ * // result == "blue"
+ * ```
+ */
+inline fun <T: CharSequence> T?.checkStartsWith(
+    prefix: CharSequence,
+    parameterName: String,
+    ignoreCase: Boolean = false,
+): T {
+    this.checkNotNull(parameterName)
+    check(this.startsWith(prefix, ignoreCase)) { "$parameterName[$this] must start with $prefix" }
+    return this
+}
+
+/**
+ * Provides the `checkEndsWith` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = ("blue" as String?).checkEndsWith("ue", "text")
+ * // result == "blue"
+ * ```
+ */
+inline fun <T: CharSequence> T?.checkEndsWith(
+    suffix: CharSequence,
+    parameterName: String,
+    ignoreCase: Boolean = false,
+): T {
+    this.checkNotNull(parameterName)
+    check(this.endsWith(suffix, ignoreCase)) { "$parameterName[$this] must end with $suffix" }
+    return this
+}
+
+/**
+ * Provides the `checkEquals` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = 10.checkEquals(10, "value")
+ * // result == 10
+ * ```
+ */
+inline fun <T> T.checkEquals(expected: T, parameterName: String): T = apply {
+    check(this == expected) { "$parameterName[$this] must be equal to $expected" }
+}
+
+/**
+ * Provides the `checkGt` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = 10.checkGt(1, "value")
+ * // result == 10
+ * ```
+ */
+inline fun <T: Comparable<T>> T.checkGt(expected: T, parameterName: String): T = apply {
+    check(this > expected) { "$parameterName[$this] must be greater than $expected." }
+}
+
+/**
+ * Provides the `checkGe` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = 10.checkGe(10, "value")
+ * // result == 10
+ * ```
+ */
+inline fun <T: Comparable<T>> T.checkGe(expected: T, parameterName: String): T = apply {
+    check(this >= expected) { "$parameterName[$this] must be greater than or equal to $expected." }
+}
+
+/**
+ * Provides the `checkLt` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = 1.checkLt(10, "value")
+ * // result == 1
+ * ```
+ */
+inline fun <T: Comparable<T>> T.checkLt(expected: T, parameterName: String): T = apply {
+    check(this < expected) { "$parameterName[$this] must be less than $expected." }
+}
+
+/**
+ * Provides the `checkLe` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = 10.checkLe(10, "value")
+ * // result == 10
+ * ```
+ */
+inline fun <T: Comparable<T>> T.checkLe(expected: T, parameterName: String): T = apply {
+    check(this <= expected) { "$parameterName[$this] must be less than or equal to $expected." }
+}
+
+/**
+ * Provides the `checkInRange` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = 5.checkInRange(1, 10, "value")
+ * // result == 5
+ * ```
+ */
+inline fun <T: Comparable<T>> T.checkInRange(start: T, endInclusive: T, parameterName: String) = apply {
+    check(this in start..endInclusive) { "$parameterName[$this] must be in range ($start .. $endInclusive)" }
+}
+
+/**
+ * Provides the `checkInOpenRange` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = 5.checkInOpenRange(1, 10, "value")
+ * // result == 5
+ * ```
+ */
+inline fun <T: Comparable<T>> T.checkInOpenRange(start: T, endExclusive: T, parameterName: String): T = apply {
+    check(this in start..<endExclusive) { "$start <= $parameterName[$this] < $endExclusive" }
+}
+
+/**
+ * Provides the `checkZeroOrPositiveNumber` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = 0.checkZeroOrPositiveNumber("value")
+ * // result == 0
+ * ```
+ */
+inline fun <T> T.checkZeroOrPositiveNumber(parameterName: String): T where T: Number, T: Comparable<T> = apply {
+    toDouble().checkGe(0.0, parameterName)
+}
+
+/**
+ * Provides the `checkPositiveNumber` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = 1.checkPositiveNumber("value")
+ * // result == 1
+ * ```
+ */
+inline fun <T> T.checkPositiveNumber(parameterName: String): T where T: Number, T: Comparable<T> = apply {
+    toDouble().checkGt(0.0, parameterName)
+}
+
+/**
+ * Provides the `checkZeroOrNegativeNumber` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = 0.checkZeroOrNegativeNumber("value")
+ * // result == 0
+ * ```
+ */
+inline fun <T> T.checkZeroOrNegativeNumber(parameterName: String): T where T: Number, T: Comparable<T> = apply {
+    toDouble().checkLe(0.0, parameterName)
+}
+
+/**
+ * Provides the `checkNegativeNumber` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = (-1).checkNegativeNumber("value")
+ * // result == -1
+ * ```
+ */
+inline fun <T> T.checkNegativeNumber(parameterName: String): T where T: Number, T: Comparable<T> = apply {
+    toDouble().checkLt(0.0, parameterName)
+}
+
+/**
+ * Provides the `checkNotEmpty` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = arrayOf(1, 2).checkNotEmpty("items")
+ * // result.size == 2
+ * ```
+ */
+inline fun <T> Array<T>?.checkNotEmpty(parameterName: String) = apply {
+    check(!this.isNullOrEmpty()) { "$parameterName[$this] must not be null or empty." }
+}
+
+/**
+ * Provides the `checkNotEmpty` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = listOf(1, 2).checkNotEmpty("items")
+ * // result.size == 2
+ * ```
+ */
+inline fun <T> Collection<T>?.checkNotEmpty(parameterName: String) = apply {
+    check(!this.isNullOrEmpty()) { "$parameterName[$this] must not be null or empty." }
+}
+
+/**
+ * Provides the `checkNotEmpty` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = mapOf("a" to 1).checkNotEmpty("map")
+ * // result["a"] == 1
+ * ```
+ */
+inline fun <K, V> Map<K, V>?.checkNotEmpty(parameterName: String) = apply {
+    check(!this.isNullOrEmpty()) { "$parameterName must not be null or empty." }
+}
+
+/**
+ * Provides the `checkHasKey` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = mapOf("a" to 1).checkHasKey("a", "map")
+ * // result["a"] == 1
+ * ```
+ */
+inline fun <K, V> Map<K, V>?.checkHasKey(key: K, parameterName: String): Map<K, V> {
+    checkNotEmpty(parameterName)
+    val self = this ?: throw IllegalStateException("$parameterName must not be null or empty.")
+    check(self.containsKey(key)) { "$parameterName must contain key $key" }
+    return self
+}
+
+/**
+ * Provides the `checkHasValue` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = mapOf("a" to 1).checkHasValue(1, "map")
+ * // result["a"] == 1
+ * ```
+ */
+inline fun <K, V> Map<K, V>?.checkHasValue(value: V, parameterName: String): Map<K, V> {
+    checkNotEmpty(parameterName)
+    val self = this ?: throw IllegalStateException("$parameterName must not be null or empty.")
+    check(self.containsValue(value)) { "$parameterName must contain value $value" }
+    return self
+}
+
+/**
+ * Provides the `checkContains` invariant check.
+ *
+ * ## Contract
+ * - Throws [IllegalStateException] when the invariant is not satisfied.
+ * - Returns the original receiver when the invariant is satisfied.
+ * - Does not mutate the receiver.
+ *
+ * ```kotlin
+ * val result = mapOf("a" to 1).checkContains("a", 1, "map")
+ * // result["a"] == 1
+ * ```
+ */
+inline fun <K, V> Map<K, V>?.checkContains(key: K, value: V, parameterName: String): Map<K, V> {
+    checkNotEmpty(parameterName)
+    val self = this ?: throw IllegalStateException("$parameterName must not be null or empty.")
+    check(self[key] == value) { "$parameterName must contain ($key, $value)" }
+    return self
+}

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/CheckSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/CheckSupportTest.kt
@@ -1,0 +1,123 @@
+package io.bluetape4k.support
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.Test
+
+class CheckSupportTest {
+
+    @Test
+    fun `check null and not-null state`() {
+        val value: String? = "blue"
+        (value.checkNotNull("value") === value).shouldBeTrue()
+
+        val empty: String? = null
+        (empty.checkNull("value") === empty).shouldBeTrue()
+        shouldFailCheck { empty.checkNotNull("value") }.message shouldBeEqualTo
+                "value[null] must not be null."
+        shouldFailCheck { value.checkNull("value") }
+    }
+
+    @Test
+    fun `check string emptiness and blankness`() {
+        val value: String? = "blue"
+        (value.checkNotEmpty("value") === value).shouldBeTrue()
+        (value.checkNotBlank("value") === value).shouldBeTrue()
+
+        shouldFailCheck { (null as String?).checkNotEmpty("value") }
+        shouldFailCheck { "".checkNotEmpty("value") }
+        shouldFailCheck { (null as String?).checkNotBlank("value") }
+        shouldFailCheck { "   ".checkNotBlank("value") }
+    }
+
+    @Test
+    fun `check null-or-empty and null-or-blank state`() {
+        val empty: String? = null
+        empty.checkNullOrEmpty("value")
+        "".checkNullOrEmpty("value")
+        empty.checkNullOrBlank("value")
+        "   ".checkNullOrBlank("value")
+
+        shouldFailCheck { "blue".checkNullOrEmpty("value") }
+        shouldFailCheck { "blue".checkNullOrBlank("value") }
+    }
+
+    @Test
+    fun `check string contains startsWith endsWith`() {
+        val value: String? = "Hello World"
+        (value.checkContains("World", "value") === value).shouldBeTrue()
+        (value.checkStartsWith("hello", "value", ignoreCase = true) === value).shouldBeTrue()
+        (value.checkEndsWith("WORLD", "value", ignoreCase = true) === value).shouldBeTrue()
+
+        shouldFailCheck { "hello".checkContains("world", "value") }
+        shouldFailCheck { "hello world".checkStartsWith("world", "value") }
+        shouldFailCheck { "hello world".checkEndsWith("hello", "value") }
+    }
+
+    @Test
+    fun `check comparable ordering and equality`() {
+        42.checkEquals(42, "value") shouldBeEqualTo 42
+        10.checkGt(5, "value") shouldBeEqualTo 10
+        5.checkGe(5, "value") shouldBeEqualTo 5
+        5.checkLt(10, "value") shouldBeEqualTo 5
+        5.checkLe(5, "value") shouldBeEqualTo 5
+
+        shouldFailCheck { 42.checkEquals(99, "value") }
+        shouldFailCheck { 5.checkGt(5, "value") }
+        shouldFailCheck { 4.checkGe(5, "value") }
+        shouldFailCheck { 5.checkLt(5, "value") }
+        shouldFailCheck { 6.checkLe(5, "value") }
+    }
+
+    @Test
+    fun `check closed and open ranges`() {
+        1.checkInRange(1, 10, "value") shouldBeEqualTo 1
+        10.checkInRange(1, 10, "value") shouldBeEqualTo 10
+        1.checkInOpenRange(1, 10, "value") shouldBeEqualTo 1
+
+        shouldFailCheck { 0.checkInRange(1, 10, "value") }
+        shouldFailCheck { 11.checkInRange(1, 10, "value") }
+        shouldFailCheck { 10.checkInOpenRange(1, 10, "value") }
+    }
+
+    @Test
+    fun `check number sign variants`() {
+        1.checkPositiveNumber("value") shouldBeEqualTo 1
+        0.checkZeroOrPositiveNumber("value") shouldBeEqualTo 0
+        (-1).checkNegativeNumber("value") shouldBeEqualTo -1
+        0.checkZeroOrNegativeNumber("value") shouldBeEqualTo 0
+
+        shouldFailCheck { 0.checkPositiveNumber("value") }
+        shouldFailCheck { (-1).checkZeroOrPositiveNumber("value") }
+        shouldFailCheck { 0.checkNegativeNumber("value") }
+        shouldFailCheck { 1.checkZeroOrNegativeNumber("value") }
+    }
+
+    @Test
+    fun `check collection and array not empty`() {
+        val array = arrayOf(1, 2)
+        (array.checkNotEmpty("items") === array).shouldBeTrue()
+        val list = listOf(1, 2)
+        (list.checkNotEmpty("items") === list).shouldBeTrue()
+
+        shouldFailCheck { emptyArray<Int>().checkNotEmpty("items") }
+        shouldFailCheck { (null as Array<Int>?).checkNotEmpty("items") }
+        shouldFailCheck { emptyList<Int>().checkNotEmpty("items") }
+        shouldFailCheck { (null as List<Int>?).checkNotEmpty("items") }
+    }
+
+    @Test
+    fun `check map operations`() {
+        val map = mapOf("a" to 1, "b" to 2)
+        (map.checkNotEmpty("map") === map).shouldBeTrue()
+        (map.checkHasKey("a", "map") === map).shouldBeTrue()
+        (map.checkHasValue(1, "map") === map).shouldBeTrue()
+        (map.checkContains("a", 1, "map") === map).shouldBeTrue()
+
+        shouldFailCheck { emptyMap<String, Int>().checkNotEmpty("map") }
+        shouldFailCheck { map.checkHasKey("missing", "map") }
+        shouldFailCheck { map.checkHasValue(99, "map") }
+        shouldFailCheck { map.checkContains("a", 99, "map") }
+        shouldFailCheck { (null as Map<String, Int>?).checkHasKey("a", "map") }
+    }
+}

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/TestAssertionHelpers.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/TestAssertionHelpers.kt
@@ -8,6 +8,10 @@ import io.bluetape4k.assertions.assertFailsWith
 inline fun shouldFailRequire(noinline block: () -> Unit): IllegalArgumentException =
     assertFailsWith<IllegalArgumentException>(block = block)
 
+/** [block]이 [IllegalStateException]을 던지는지 확인합니다. */
+inline fun shouldFailCheck(noinline block: () -> Unit): IllegalStateException =
+    assertFailsWith<IllegalStateException>(block = block)
+
 /** [block]이 [AssertionError]를 던지는지 확인합니다. */
 inline fun shouldFailAssert(noinline block: () -> Unit): AssertionError =
     assertFailsWith<AssertionError>(block = block)


### PR DESCRIPTION
## Summary

Closes #1076

- PR 제목: feat: add CheckSupport invariant helpers

- Add `CheckSupport.kt` as the state-invariant counterpart to `RequireSupport.kt`.
- Mirror all 26 existing helper overloads while using `IllegalStateException` semantics.
- Document the public API in English KDoc and synchronized English/Korean core READMEs.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Why

Caller argument validation and internal state validation have different exception contracts. The existing `RequireSupport` helpers cover `IllegalArgumentException`, but the core module did not provide an equivalent fluent API for Kotlin `check` semantics.

### 기존 섹션: Impact

Library users can validate object and component invariants with the same receiver-returning API shape used for caller validation. Existing `RequireSupport` and deprecated `AssertSupport` behavior remains unchanged.

## Validation

- RED: `CheckSupportTest` failed to compile because the `check*` API did not exist.
- GREEN: `./gradlew :bluetape4k-core:test --tests 'io.bluetape4k.support.CheckSupportTest'` — 9 passing.
- Full module: `./gradlew :bluetape4k-core:test` — 1,610 passing.
- GitHub Actions exact-head checks — 11 successful, 8 scope-based skips, 0 failures.
- Static task: `./gradlew detekt` — successful (`NO-SOURCE` at the root).
- `git diff --check` — clean.
- API symmetry check — 26/26 overloads, no missing or extra equivalents.

Closes #1076

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1076, milestone `1.12.0`, assignee `debop`
- PR: #1077, head `83865c08fcae31a4fadfd3d8d87df75421cf4bd6`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `feat/issue-1076-check-support`
- Labels: `enhancement`
- State: `MERGED`, merge commit `589179bc48438411aa9d9e915d0085b0074a98fd`
- CI: - GREEN: `./gradlew :bluetape4k-core:test --tests 'io.bluetape4k.support.CheckSupportTest'` — 9 passing. / - Full module: `./gradlew :bluetape4k-core:test` — 1,610 passing. / - Static task: `./gradlew detekt` — successful (`NO-SOURCE` at the root).

## DoD Status

- [x] Issue #1076 is assigned to milestone `1.12.0`.
- [x] All `RequireSupport` helper overloads have `CheckSupport` equivalents.
- [x] Failure and receiver-return contracts have focused tests.
- [x] English and Korean README guidance is synchronized.
- [x] Targeted and full core tests pass.
- [x] Required GitHub Actions checks pass on exact head `83865c08fcae31a4fadfd3d8d87df75421cf4bd6`.
- [x] Live review threads are clear.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1077 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `589179bc48438411aa9d9e915d0085b0074a98fd`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
