### PR TITLE
fix: return non-null collections from not-empty validation helpers

### DIFF
--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/CheckSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/CheckSupport.kt
@@ -382,7 +382,7 @@ inline fun <T> T.checkNegativeNumber(parameterName: String): T where T: Number, 
 }
 
 /**
- * Provides the `checkNotEmpty` invariant check.
+ * Requires this array to be non-null and non-empty, then returns the same array.
  *
  * ## Contract
  * - Throws [IllegalStateException] when the invariant is not satisfied.
@@ -394,12 +394,14 @@ inline fun <T> T.checkNegativeNumber(parameterName: String): T where T: Number, 
  * // result.size == 2
  * ```
  */
-inline fun <T> Array<T>?.checkNotEmpty(parameterName: String) = apply {
-    check(!this.isNullOrEmpty()) { "$parameterName[$this] must not be null or empty." }
+inline fun <T> Array<T>?.checkNotEmpty(parameterName: String): Array<T> {
+    val self = this ?: throw IllegalStateException("$parameterName[$this] must not be null or empty.")
+    check(self.isNotEmpty()) { "$parameterName[$self] must not be null or empty." }
+    return self
 }
 
 /**
- * Provides the `checkNotEmpty` invariant check.
+ * Requires this collection to be non-null and non-empty, then returns the same collection.
  *
  * ## Contract
  * - Throws [IllegalStateException] when the invariant is not satisfied.
@@ -411,12 +413,14 @@ inline fun <T> Array<T>?.checkNotEmpty(parameterName: String) = apply {
  * // result.size == 2
  * ```
  */
-inline fun <T> Collection<T>?.checkNotEmpty(parameterName: String) = apply {
-    check(!this.isNullOrEmpty()) { "$parameterName[$this] must not be null or empty." }
+inline fun <T> Collection<T>?.checkNotEmpty(parameterName: String): Collection<T> {
+    val self = this ?: throw IllegalStateException("$parameterName[$this] must not be null or empty.")
+    check(self.isNotEmpty()) { "$parameterName[$self] must not be null or empty." }
+    return self
 }
 
 /**
- * Provides the `checkNotEmpty` invariant check.
+ * Requires this map to be non-null and non-empty, then returns the same map.
  *
  * ## Contract
  * - Throws [IllegalStateException] when the invariant is not satisfied.
@@ -428,8 +432,10 @@ inline fun <T> Collection<T>?.checkNotEmpty(parameterName: String) = apply {
  * // result["a"] == 1
  * ```
  */
-inline fun <K, V> Map<K, V>?.checkNotEmpty(parameterName: String) = apply {
-    check(!this.isNullOrEmpty()) { "$parameterName must not be null or empty." }
+inline fun <K, V> Map<K, V>?.checkNotEmpty(parameterName: String): Map<K, V> {
+    val self = this ?: throw IllegalStateException("$parameterName must not be null or empty.")
+    check(self.isNotEmpty()) { "$parameterName must not be null or empty." }
+    return self
 }
 
 /**

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/RequireSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/RequireSupport.kt
@@ -388,54 +388,63 @@ inline fun <T> T.requireNegativeNumber(parameterName: String): T where T: Number
 }
 
 /**
- * requireNotEmpty 기능을 제공합니다.
+ * Requires this array to be non-null and non-empty, then returns the same array.
  *
- * ## 동작/계약
- * - 조건을 만족하지 않으면 [IllegalArgumentException]이 발생합니다.
- * - 조건을 만족하면 수신 값을 그대로 반환합니다.
- * - 수신 객체를 변경하지 않습니다.
+ * The returned array is the same instance as the receiver.
+ *
+ * - Throws [IllegalArgumentException] when the contract is not satisfied.
+ * - Returns the original receiver when the contract is satisfied.
+ * - Does not mutate the receiver.
  *
  * ```kotlin
  * val result = arrayOf(1, 2).requireNotEmpty("items")
  * // result.size == 2
  * ```
  */
-inline fun <T> Array<T>?.requireNotEmpty(parameterName: String) = apply {
-    require(!this.isNullOrEmpty()) { "$parameterName[$this] must not be null or empty." }
+inline fun <T> Array<T>?.requireNotEmpty(parameterName: String): Array<T> {
+    val self = this ?: throw IllegalArgumentException("$parameterName[$this] must not be null or empty.")
+    require(self.isNotEmpty()) { "$parameterName[$self] must not be null or empty." }
+    return self
 }
 
 /**
- * requireNotEmpty 기능을 제공합니다.
+ * Requires this collection to be non-null and non-empty, then returns the same collection.
  *
- * ## 동작/계약
- * - 조건을 만족하지 않으면 [IllegalArgumentException]이 발생합니다.
- * - 조건을 만족하면 수신 값을 그대로 반환합니다.
- * - 수신 객체를 변경하지 않습니다.
+ * The returned collection is the same instance as the receiver.
+ *
+ * - Throws [IllegalArgumentException] when the contract is not satisfied.
+ * - Returns the original receiver when the contract is satisfied.
+ * - Does not mutate the receiver.
  *
  * ```kotlin
  * val result = listOf(1, 2).requireNotEmpty("items")
  * // result.size == 2
  * ```
  */
-inline fun <T> Collection<T>?.requireNotEmpty(parameterName: String) = apply {
-    require(!this.isNullOrEmpty()) { "$parameterName[$this] must not be null or empty." }
+inline fun <T> Collection<T>?.requireNotEmpty(parameterName: String): Collection<T> {
+    val self = this ?: throw IllegalArgumentException("$parameterName[$this] must not be null or empty.")
+    require(self.isNotEmpty()) { "$parameterName[$self] must not be null or empty." }
+    return self
 }
 
 /**
- * requireNotEmpty 기능을 제공합니다.
+ * Requires this map to be non-null and non-empty, then returns the same map.
  *
- * ## 동작/계약
- * - 조건을 만족하지 않으면 [IllegalArgumentException]이 발생합니다.
- * - 조건을 만족하면 수신 값을 그대로 반환합니다.
- * - 수신 객체를 변경하지 않습니다.
+ * The returned map is the same instance as the receiver.
+ *
+ * - Throws [IllegalArgumentException] when the contract is not satisfied.
+ * - Returns the original receiver when the contract is satisfied.
+ * - Does not mutate the receiver.
  *
  * ```kotlin
  * val result = mapOf("a" to 1).requireNotEmpty("map")
  * // result["a"] == 1
  * ```
  */
-inline fun <K, V> Map<K, V>?.requireNotEmpty(parameterName: String) = apply {
-    require(!this.isNullOrEmpty()) { "$parameterName must not be null or empty." }
+inline fun <K, V> Map<K, V>?.requireNotEmpty(parameterName: String): Map<K, V> {
+    val self = this ?: throw IllegalArgumentException("$parameterName must not be null or empty.")
+    require(self.isNotEmpty()) { "$parameterName must not be null or empty." }
+    return self
 }
 
 /**

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/CheckSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/CheckSupportTest.kt
@@ -107,6 +107,21 @@ class CheckSupportTest {
     }
 
     @Test
+    fun `check not empty returns non-null collection types`() {
+        val nullableArray: Array<Int>? = arrayOf(1, 2)
+        val array: Array<Int> = nullableArray.checkNotEmpty("items")
+        array.size.shouldBeEqualTo(2)
+
+        val nullableCollection: Collection<Int>? = listOf(1, 2)
+        val collection: Collection<Int> = nullableCollection.checkNotEmpty("items")
+        collection.size.shouldBeEqualTo(2)
+
+        val nullableMap: Map<String, Int>? = mapOf("one" to 1)
+        val map: Map<String, Int> = nullableMap.checkNotEmpty("items")
+        map.size.shouldBeEqualTo(1)
+    }
+
+    @Test
     fun `check map operations`() {
         val map = mapOf("a" to 1, "b" to 2)
         (map.checkNotEmpty("map") === map).shouldBeTrue()
@@ -115,6 +130,7 @@ class CheckSupportTest {
         (map.checkContains("a", 1, "map") === map).shouldBeTrue()
 
         shouldFailCheck { emptyMap<String, Int>().checkNotEmpty("map") }
+        shouldFailCheck { (null as Map<String, Int>?).checkNotEmpty("map") }
         shouldFailCheck { map.checkHasKey("missing", "map") }
         shouldFailCheck { map.checkHasValue(99, "map") }
         shouldFailCheck { map.checkContains("a", 99, "map") }

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/RequireSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/RequireSupportTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.support
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
 
@@ -112,18 +113,36 @@ class RequireSupportTest {
 
     @Test
     fun `require collection and array not empty`() {
-        arrayOf(1, 2, 3).requireNotEmpty("x")
+        val array = arrayOf(1, 2, 3)
+        (array.requireNotEmpty("x") === array).shouldBeTrue()
         shouldFailRequire { emptyArray<Int>().requireNotEmpty("x") }
         shouldFailRequire { (null as Array<Int>?).requireNotEmpty("x") }
 
-        listOf(1, 2, 3).requireNotEmpty("x")
+        val list = listOf(1, 2, 3)
+        (list.requireNotEmpty("x") === list).shouldBeTrue()
         shouldFailRequire { emptyList<Int>().requireNotEmpty("x") }
         shouldFailRequire { (null as List<Int>?).requireNotEmpty("x") }
     }
 
     @Test
+    fun `require not empty returns non-null collection types`() {
+        val nullableArray: Array<Int>? = arrayOf(1, 2)
+        val array: Array<Int> = nullableArray.requireNotEmpty("items")
+        array.size.shouldBeEqualTo(2)
+
+        val nullableCollection: Collection<Int>? = listOf(1, 2)
+        val collection: Collection<Int> = nullableCollection.requireNotEmpty("items")
+        collection.size.shouldBeEqualTo(2)
+
+        val nullableMap: Map<String, Int>? = mapOf("one" to 1)
+        val map: Map<String, Int> = nullableMap.requireNotEmpty("items")
+        map.size.shouldBeEqualTo(1)
+    }
+
+    @Test
     fun `require map operations`() {
-        mapOf("a" to 1).requireNotEmpty("x")
+        val map = mapOf("a" to 1)
+        (map.requireNotEmpty("x") === map).shouldBeTrue()
         shouldFailRequire { emptyMap<String, Int>().requireNotEmpty("x") }
         shouldFailRequire { (null as Map<String, Int>?).requireNotEmpty("x") }
 


### PR DESCRIPTION
## Summary

Closes #1078

- PR 제목: fix: return non-null collections from not-empty validation helpers

- Return non-null `Array`, `Collection`, and `Map` values from the nullable `requireNotEmpty` and `checkNotEmpty` overloads.
- Preserve receiver identity, existing null/empty messages, and the `IllegalArgumentException` / `IllegalStateException` split.
- Document the non-null return contract and add compile-time and runtime regression coverage.

### 원문 선행 내용

Fixes #1078

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Root Cause

The six overloads used inferred `apply` return types. Because their receivers were nullable, Kotlin exposed nullable results even after validation. The existing `CharSequence` overloads already showed the intended explicit non-null contract.

### 기존 섹션: Compatibility and Risk

The Kotlin source/metadata contract is intentionally strengthened from nullable to non-null return types. JVM method descriptors are unchanged. No dependencies, modules, concurrency paths, or lifecycle behavior were changed.

## Validation

- RED: `:bluetape4k-core:compileTestKotlin` failed at six expected non-null assignments with actual nullable types.
- GREEN: `RequireSupportTest` and `CheckSupportTest` pass 21/21.
- Full module: `:bluetape4k-core:test` passes 1612/1612.
- JVM descriptors match the develop baseline for all six overloads.
- `git diff --check` passes.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1078, milestone `1.12.0`, assignee `debop`
- PR: #1081, head `2ad49b2f401f5a9de72ddf34a5052a7d4dd80eec`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `codex/issue-1078-non-null-not-empty`
- Labels: `bug`, `test`
- State: `MERGED`, merge commit `0c21f7d02c1a9bf2faa0767061535b80f201adbb`
- CI: The six overloads used inferred `apply` return types. Because their receivers were nullable, Kotlin exposed nullable results even after validation. The existing `CharSequence` overloads already showed the intended explicit non-null contract. / The Kotlin source/metadata contract is intentionally strengthened from nullable to non-null return types. JVM method descriptors are unchanged. No dependencies, modules, concurrency paths, or lifecycle behavior were changed. / - [ ] Merge and local synchronization require fresh approval after CI/review convergence.

## DoD Status

- [x] Root cause reproduced and documented.
- [x] Regression tests fail before the fix and pass after it.
- [x] Runtime null/empty/identity/exception behavior is covered.
- [x] Full `bluetape4k-core` test suite passes.
- [x] JVM descriptor compatibility checked against `develop`.
- [x] No known P0/P1 findings remain.
- [ ] Merge and local synchronization require fresh approval after CI/review convergence.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1081 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `0c21f7d02c1a9bf2faa0767061535b80f201adbb`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
