### PR TITLE
Add FastFory variants to volatile Redis cache integrations

### DIFF
--- a/cache/hibernate-cache-lettuce/README.ko.md
+++ b/cache/hibernate-cache-lettuce/README.ko.md
@@ -71,7 +71,8 @@ hibernate.cache.use_second_level_cache=true
 # Redis 연결
 hibernate.cache.lettuce.redis_uri=redis://localhost:6379
 
-# 직렬화 코덱 (lz4fory | fory | kryo | lz4kryo | lz4jdk | gzipfory | zstdfory | jdk)
+# 직렬화 코덱 (기본: lz4fory)
+# 선택지: lz4fory | lz4fastfory | fory | fastfory | kryo | lz4kryo | lz4jdk | gzipfory | gzipfastfory | zstdfory | zstdfastfory | jdk
 hibernate.cache.lettuce.codec=lz4fory
 
 # RESP3 + CLIENT TRACKING 활성화 (Redis 6+ 필요)
@@ -115,8 +116,12 @@ spring:
               default: 120s
 ```
 
-지원 codec 값은 `jdk`, `kryo`, `fory`, `gzip*`, `lz4*`, `snappy*`,
+지원 codec 값은 `jdk`, `kryo`, `fory`, `fastfory`, `gzip*`, `lz4*`, `snappy*`,
 `zstd*` 계열이며, 오타나 미지원 codec 이름은 기본값으로 대체하지 않고 즉시 예외로 실패합니다.
+
+FastFory 코덱은 `SCHEMA_CONSISTENT` 모드를 사용하며 기존 Fory 캐시 데이터와 wire format이
+대칭 호환되지 않습니다. 모드를 바꾸기 전에 해당 region의 entry를 eviction 또는 migration할 수 있는
+경우에만 사용하세요.
 
 ## Entity 설정
 
@@ -161,9 +166,15 @@ val products: MutableList<Product> = mutableListOf()
 | 코덱 이름  | 설명                           | 압축 |
 |------------|--------------------------------|------|
 | `lz4fory`  | LZ4 + Apache Fory **(기본값)** | LZ4  |
+| `lz4fastfory` | LZ4 + Apache FastFory       | LZ4  |
 | `fory`     | Apache Fory                    | -    |
+| `fastfory` | Apache FastFory                | -    |
 | `gzipfory` | GZip + Apache Fory             | GZip |
+| `gzipfastfory` | GZip + Apache FastFory     | GZip |
+| `snappyfory` | Snappy + Apache Fory         | Snappy |
+| `snappyfastfory` | Snappy + Apache FastFory | Snappy |
 | `zstdfory` | Zstd + Apache Fory             | Zstd |
+| `zstdfastfory` | Zstd + Apache FastFory     | Zstd |
 | `kryo`     | Kryo                           | -    |
 | `lz4kryo`  | LZ4 + Kryo                     | LZ4  |
 | `jdk`      | Java 직렬화                    | -    |

--- a/cache/hibernate-cache-lettuce/README.md
+++ b/cache/hibernate-cache-lettuce/README.md
@@ -73,7 +73,8 @@ hibernate.cache.use_second_level_cache=true
 # Redis connection
 hibernate.cache.lettuce.redis_uri=redis://localhost:6379
 
-# Serialization codec (lz4fory | fory | kryo | lz4kryo | lz4jdk | gzipfory | zstdfory | jdk)
+# Serialization codec (default: lz4fory)
+# Options: lz4fory | lz4fastfory | fory | fastfory | kryo | lz4kryo | lz4jdk | gzipfory | gzipfastfory | zstdfory | zstdfastfory | jdk
 hibernate.cache.lettuce.codec=lz4fory
 
 # Enable RESP3 + CLIENT TRACKING (requires Redis 6+)
@@ -117,8 +118,12 @@ spring:
               default: 120s
 ```
 
-Supported codec values include the `jdk`, `kryo`, `fory`, `gzip*`, `lz4*`, `snappy*`, and
+Supported codec values include the `jdk`, `kryo`, `fory`, `fastfory`, `gzip*`, `lz4*`, `snappy*`, and
 `zstd*` families. Typos or unsupported codec names cause an immediate exception rather than silently falling back to a default.
+
+FastFory codecs use `SCHEMA_CONSISTENT` mode and are not a symmetric wire-compatible
+replacement for existing Fory cache data. Use them only for regions where entries can be
+evicted or migrated before switching modes.
 
 ## Entity Configuration
 
@@ -164,9 +169,15 @@ val products: MutableList<Product> = mutableListOf()
 | Codec Name | Description                     | Compression |
 |------------|---------------------------------|-------------|
 | `lz4fory`  | LZ4 + Apache Fory **(default)** | LZ4         |
+| `lz4fastfory` | LZ4 + Apache FastFory        | LZ4         |
 | `fory`     | Apache Fory                     | -           |
+| `fastfory` | Apache FastFory                 | -           |
 | `gzipfory` | GZip + Apache Fory              | GZip        |
+| `gzipfastfory` | GZip + Apache FastFory      | GZip        |
+| `snappyfory` | Snappy + Apache Fory          | Snappy      |
+| `snappyfastfory` | Snappy + Apache FastFory  | Snappy      |
 | `zstdfory` | Zstd + Apache Fory              | Zstd        |
+| `zstdfastfory` | Zstd + Apache FastFory      | Zstd        |
 | `kryo`     | Kryo                            | -           |
 | `lz4kryo`  | LZ4 + Kryo                      | LZ4         |
 | `jdk`      | Java serialization              | -           |

--- a/cache/hibernate-cache-lettuce/src/main/kotlin/io/bluetape4k/hibernate/cache/lettuce/LettuceNearCacheProperties.kt
+++ b/cache/hibernate-cache-lettuce/src/main/kotlin/io/bluetape4k/hibernate/cache/lettuce/LettuceNearCacheProperties.kt
@@ -16,7 +16,7 @@ import java.time.Duration
  * ```
  * # Hibernate properties 예시
  * hibernate.lettuce.redis_uri=redis://localhost:6379
- * hibernate.lettuce.codec=lz4fory               # lz4fory(기본), fory, kryo, lz4kryo 등
+ * hibernate.lettuce.codec=lz4fory               # lz4fory(기본), lz4fastfory, fory, kryo 등
  * hibernate.lettuce.local.max_size=10000
  * hibernate.lettuce.local.expire_after_write=30m
  * hibernate.lettuce.redis_ttl.default=120s
@@ -25,7 +25,7 @@ import java.time.Duration
  * ```
  *
  * **보안 주의 (Kryo/Fory 코덱):**
- * `kryo`, `fory`, `lz4kryo`, `lz4fory` 등 Kryo/Fory 기반 코덱을 사용할 경우,
+ * `kryo`, `fory`, `fastfory`, `lz4kryo`, `lz4fory`, `lz4fastfory` 등 Kryo/Fory 기반 코덱을 사용할 경우,
  * Redis 데이터를 역직렬화할 때 임의 클래스가 인스턴스화될 수 있어 gadget chain 공격에 취약합니다.
  * 반드시 Redis 접근 경로를 신뢰할 수 있는 환경(네트워크 격리, 인증 적용)에서만 사용하세요.
  * 신뢰할 수 없는 Redis 접근 경로가 있다면 allowlist 기반 Jackson(`jdk`) 직렬화 사용을 권장합니다.
@@ -62,18 +62,23 @@ data class LettuceNearCacheProperties(
             "jdk",
             "kryo",
             "fory",
+            "fastfory",
             "gzipjdk",
             "gzipkryo",
             "gzipfory",
+            "gzipfastfory",
             "lz4jdk",
             "lz4kryo",
             "lz4fory",
+            "lz4fastfory",
             "snappyjdk",
             "snappykryo",
             "snappyfory",
+            "snappyfastfory",
             "zstdjdk",
             "zstdkryo",
             "zstdfory",
+            "zstdfastfory",
         )
 
         fun from(configValues: Map<String, Any>): LettuceNearCacheProperties {
@@ -142,24 +147,32 @@ data class LettuceNearCacheProperties(
      * val codec = props.createCodec()
      * // codec != null
      * ```
+     *
+     * `fastfory` 계열은 `SCHEMA_CONSISTENT` 모드를 사용하며 기존 Fory 계열 wire format과
+     * 대칭 호환되지 않습니다. 기존 데이터를 유지해야 하는 region에서는 eviction 또는 migration 후 사용하세요.
      */
     fun createCodec(): LettuceBinaryCodec<Any> = when (codec.lowercase()) {
-        "jdk"        -> LettuceBinaryCodecs.jdk()
-        "kryo"       -> LettuceBinaryCodecs.kryo()
-        "fory"       -> LettuceBinaryCodecs.fory()
-        "gzipjdk"    -> LettuceBinaryCodecs.gzipJdk()
-        "gzipkryo"   -> LettuceBinaryCodecs.gzipKryo()
-        "gzipfory"   -> LettuceBinaryCodecs.gzipFory()
-        "lz4jdk"     -> LettuceBinaryCodecs.lz4Jdk()
-        "lz4kryo"    -> LettuceBinaryCodecs.lz4Kryo()
-        "lz4fory"    -> LettuceBinaryCodecs.lz4Fory()
-        "snappyjdk"  -> LettuceBinaryCodecs.snappyJdk()
-        "snappykryo" -> LettuceBinaryCodecs.snappyKryo()
-        "snappyfory" -> LettuceBinaryCodecs.snappyFory()
-        "zstdjdk"    -> LettuceBinaryCodecs.zstdJdk()
-        "zstdkryo"   -> LettuceBinaryCodecs.zstdKryo()
-        "zstdfory"   -> LettuceBinaryCodecs.zstdFory()
-        else         -> throw IllegalArgumentException("Unsupported codec: $codec. supported=$SUPPORTED_CODECS")
+        "jdk"             -> LettuceBinaryCodecs.jdk()
+        "kryo"            -> LettuceBinaryCodecs.kryo()
+        "fory"            -> LettuceBinaryCodecs.fory()
+        "fastfory"        -> LettuceBinaryCodecs.fastFory()
+        "gzipjdk"         -> LettuceBinaryCodecs.gzipJdk()
+        "gzipkryo"        -> LettuceBinaryCodecs.gzipKryo()
+        "gzipfory"        -> LettuceBinaryCodecs.gzipFory()
+        "gzipfastfory"    -> LettuceBinaryCodecs.gzipFastFory()
+        "lz4jdk"          -> LettuceBinaryCodecs.lz4Jdk()
+        "lz4kryo"         -> LettuceBinaryCodecs.lz4Kryo()
+        "lz4fory"         -> LettuceBinaryCodecs.lz4Fory()
+        "lz4fastfory"     -> LettuceBinaryCodecs.lz4FastFory()
+        "snappyjdk"       -> LettuceBinaryCodecs.snappyJdk()
+        "snappykryo"      -> LettuceBinaryCodecs.snappyKryo()
+        "snappyfory"      -> LettuceBinaryCodecs.snappyFory()
+        "snappyfastfory"  -> LettuceBinaryCodecs.snappyFastFory()
+        "zstdjdk"         -> LettuceBinaryCodecs.zstdJdk()
+        "zstdkryo"        -> LettuceBinaryCodecs.zstdKryo()
+        "zstdfory"        -> LettuceBinaryCodecs.zstdFory()
+        "zstdfastfory"    -> LettuceBinaryCodecs.zstdFastFory()
+        else              -> throw IllegalArgumentException("Unsupported codec: $codec. supported=$SUPPORTED_CODECS")
     }
 
     /**

--- a/cache/hibernate-cache-lettuce/src/test/kotlin/io/bluetape4k/hibernate/cache/lettuce/LettuceNearCachePropertiesTest.kt
+++ b/cache/hibernate-cache-lettuce/src/test/kotlin/io/bluetape4k/hibernate/cache/lettuce/LettuceNearCachePropertiesTest.kt
@@ -123,13 +123,13 @@ class LettuceNearCachePropertiesTest {
     }
 
     @Test
-    fun `지원되는 모든 15가지 codec에 대해 createCodec이 성공한다`() {
+    fun `지원되는 모든 20가지 codec에 대해 createCodec이 성공한다`() {
         val codecs = listOf(
-            "jdk", "kryo", "fory",
-            "gzipjdk", "gzipkryo", "gzipfory",
-            "lz4jdk", "lz4kryo", "lz4fory",
-            "snappyjdk", "snappykryo", "snappyfory",
-            "zstdjdk", "zstdkryo", "zstdfory",
+            "jdk", "kryo", "fory", "fastfory",
+            "gzipjdk", "gzipkryo", "gzipfory", "gzipfastfory",
+            "lz4jdk", "lz4kryo", "lz4fory", "lz4fastfory",
+            "snappyjdk", "snappykryo", "snappyfory", "snappyfastfory",
+            "zstdjdk", "zstdkryo", "zstdfory", "zstdfastfory",
         )
 
         codecs.forEach { codecName ->
@@ -139,9 +139,29 @@ class LettuceNearCachePropertiesTest {
     }
 
     @Test
+    fun `FastFory codec 5종은 설정 이름으로 생성해 값을 직렬화 왕복한다`() {
+        val codecs = listOf(
+            "fastfory",
+            "gzipfastfory",
+            "lz4fastfory",
+            "snappyfastfory",
+            "zstdfastfory",
+        )
+        val original = mapOf(
+            "region" to "Customer",
+            "id" to 42L,
+        )
+
+        codecs.forEach { codecName ->
+            val codec = LettuceNearCacheProperties(codec = codecName).createCodec()
+            codec.decodeValue(codec.encodeValue(original)) shouldBeEqualTo original
+        }
+    }
+
+    @Test
     fun `codec 이름이 대소문자를 구분하지 않는다`() {
         val propsUpper = LettuceNearCacheProperties.from(
-            mapOf("hibernate.cache.lettuce.codec" to "LZ4FORY")
+            mapOf("hibernate.cache.lettuce.codec" to "LZ4FASTFORY")
         )
 
         propsUpper.createCodec().shouldNotBeNull()

--- a/spring-boot/hibernate-lettuce/README.ko.md
+++ b/spring-boot/hibernate-lettuce/README.ko.md
@@ -150,7 +150,7 @@ bluetape4k:
             redis-uri: redis://localhost:6379
 
             # 직렬화 코덱 (기본: lz4fory)
-            # 선택지: lz4fory | fory | kryo | lz4kryo | lz4jdk | gzipfory | zstdfory | jdk
+            # 선택지: lz4fory | lz4fastfory | fory | fastfory | kryo | lz4kryo | lz4jdk | gzipfory | gzipfastfory | zstdfory | zstdfastfory | jdk
             codec: lz4fory
 
             # RESP3 CLIENT TRACKING 활성화 (Redis 6+ 필요, 기본: true)

--- a/spring-boot/hibernate-lettuce/README.md
+++ b/spring-boot/hibernate-lettuce/README.md
@@ -151,7 +151,7 @@ bluetape4k:
             redis-uri: redis://localhost:6379
 
             # Serialization codec (default: lz4fory)
-            # Options: lz4fory | fory | kryo | lz4kryo | lz4jdk | gzipfory | zstdfory | jdk
+            # Options: lz4fory | lz4fastfory | fory | fastfory | kryo | lz4kryo | lz4jdk | gzipfory | gzipfastfory | zstdfory | zstdfastfory | jdk
             codec: lz4fory
 
             # Enable RESP3 CLIENT TRACKING (requires Redis 6+, default: true)

--- a/spring-boot/hibernate-lettuce/src/test/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheAutoConfigurationTest.kt
+++ b/spring-boot/hibernate-lettuce/src/test/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheAutoConfigurationTest.kt
@@ -205,13 +205,13 @@ class LettuceNearCacheAutoConfigurationTest {
     @Test
     fun `codec 설정이 Hibernate properties에 반영된다`() {
         contextRunner
-            .withPropertyValues("bluetape4k.cache.lettuce-near.codec=zstdfory")
+            .withPropertyValues("bluetape4k.cache.lettuce-near.codec=lz4fastfory")
             .run { context ->
                 val customizer = context.getBean<HibernatePropertiesCustomizer>()
                 val props = mutableMapOf<String, Any>()
                 customizer.customize(props)
 
-                props["hibernate.cache.lettuce.codec"] shouldBeEqualTo "zstdfory"
+                props["hibernate.cache.lettuce.codec"] shouldBeEqualTo "lz4fastfory"
             }
     }
 

--- a/spring-boot/redis/README.ko.md
+++ b/spring-boot/redis/README.ko.md
@@ -14,7 +14,7 @@ Spring Data Redis의 직렬화 계층을 고성능 바이너리 직렬화/압축
 |------------------------------------|-----------------------------------------------------------------------|
 | `RedisBinarySerializer`            | `BinarySerializer` 기반 `RedisSerializer<Any>` 구현                   |
 | `RedisCompressSerializer`          | `Compressor` 기반 압축 전용 `RedisSerializer<ByteArray>`              |
-| `RedisBinarySerializers`           | 직렬화(Jdk/Kryo/Fory) × 압축(GZip/LZ4/Snappy/Zstd) 조합 싱글턴 팩토리 |
+| `RedisBinarySerializers`           | 직렬화(Jdk/Kryo/Fory/FastFory) × 압축(GZip/LZ4/Snappy/Zstd) 조합 싱글턴 팩토리 |
 | `redisSerializationContext {}`     | DSL 기반 `RedisSerializationContext` 빌더                             |
 | `redisSerializationContextOf(...)` | 키/값 Serializer를 직접 지정하는 편의 함수                            |
 
@@ -36,7 +36,7 @@ dependencies {
 }
 ```
 
-이 모듈은 아래 `RedisBinarySerializers` 목록에 나온 Kryo/Fory 및 LZ4/Snappy/Zstd 조합의 런타임 의존성을 함께 게시합니다. 표시된 serializer 조합을 사용하기 위해 별도 codec 또는 compressor 의존성을 추가할 필요가 없습니다.
+이 모듈은 아래 `RedisBinarySerializers` 목록에 나온 Kryo/Fory/FastFory 및 LZ4/Snappy/Zstd 조합의 런타임 의존성을 함께 게시합니다. 표시된 serializer 조합을 사용하기 위해 별도 codec 또는 compressor 의존성을 추가할 필요가 없습니다.
 
 ## 사용 예시
 
@@ -101,6 +101,7 @@ JDK 역직렬화는 Redis에 저장된 값이 gadget chain 기반 RCE 위험에 
 | `RedisBinarySerializers.Jdk`        | JDK         | 없음   | Deprecated; 신뢰 데이터 전용 |
 | `RedisBinarySerializers.Kryo`       | Kryo        | 없음   | 권장                         |
 | `RedisBinarySerializers.Fory`       | Fory        | 없음   | 권장                         |
+| `RedisBinarySerializers.FastFory`   | FastFory    | 없음   | 휘발성 캐시 전용             |
 | `RedisBinarySerializers.GzipJdk`    | JDK         | GZip   | Deprecated; 신뢰 데이터 전용 |
 | `RedisBinarySerializers.LZ4Jdk`     | JDK         | LZ4    | Deprecated; 신뢰 데이터 전용 |
 | `RedisBinarySerializers.SnappyJdk`  | JDK         | Snappy | Deprecated; 신뢰 데이터 전용 |
@@ -113,6 +114,12 @@ JDK 역직렬화는 Redis에 저장된 값이 gadget chain 기반 RCE 위험에 
 | `RedisBinarySerializers.LZ4Fory`    | Fory        | LZ4    | 권장                         |
 | `RedisBinarySerializers.SnappyFory` | Fory        | Snappy | 권장                         |
 | `RedisBinarySerializers.ZstdFory`   | Fory        | Zstd   | 권장                         |
+| `RedisBinarySerializers.GzipFastFory`   | FastFory    | GZip   | 휘발성 캐시 전용             |
+| `RedisBinarySerializers.LZ4FastFory`    | FastFory    | LZ4    | 휘발성 캐시 전용             |
+| `RedisBinarySerializers.SnappyFastFory` | FastFory    | Snappy | 휘발성 캐시 전용             |
+| `RedisBinarySerializers.ZstdFastFory`   | FastFory    | Zstd   | 휘발성 캐시 전용             |
+
+FastFory는 Fory의 `SCHEMA_CONSISTENT` 모드를 사용합니다. 기본 Fory 모드와 wire format이 대칭적인 drop-in 호환이 아니므로, 폐기 가능한 휘발성 Redis 데이터에만 사용하고 명시적인 마이그레이션 계획 없이 기존 Fory 값과 섞지 마세요.
 
 ### 압축 전용 (ByteArray → ByteArray)
 

--- a/spring-boot/redis/README.md
+++ b/spring-boot/redis/README.md
@@ -15,7 +15,7 @@ Provides a convenient way to configure `Serializer` and `RedisSerializationConte
 |------------------------------------|----------------------------------------------------------------------------------------------|
 | `RedisBinarySerializer`            | `RedisSerializer<Any>` implementation backed by `BinarySerializer`                           |
 | `RedisCompressSerializer`          | Compression-only `RedisSerializer<ByteArray>` backed by `Compressor`                         |
-| `RedisBinarySerializers`           | Singleton factory combining serializers (Jdk/Kryo/Fory) × compressors (GZip/LZ4/Snappy/Zstd) |
+| `RedisBinarySerializers`           | Singleton factory combining serializers (Jdk/Kryo/Fory/FastFory) × compressors (GZip/LZ4/Snappy/Zstd) |
 | `redisSerializationContext {}`     | DSL-based `RedisSerializationContext` builder                                                |
 | `redisSerializationContextOf(...)` | Convenience function to specify key/value serializers directly                               |
 
@@ -38,7 +38,7 @@ dependencies {
 ```
 
 The module publishes runtime dependencies for the documented
-`RedisBinarySerializers` Kryo/Fory and LZ4/Snappy/Zstd combinations. Consumers do not need to add separate codec or compressor dependencies for the serializer matrix shown below.
+`RedisBinarySerializers` Kryo/Fory/FastFory and LZ4/Snappy/Zstd combinations. Consumers do not need to add separate codec or compressor dependencies for the serializer matrix shown below.
 
 ## Usage Examples
 
@@ -103,6 +103,7 @@ JDK deserialization can expose Redis values to RCE gadget-chain risk. The JDK se
 | `RedisBinarySerializers.Jdk`        | JDK                  | None        | Deprecated; trusted data only |
 | `RedisBinarySerializers.Kryo`       | Kryo                 | None        | Recommended                   |
 | `RedisBinarySerializers.Fory`       | Fory                 | None        | Recommended                   |
+| `RedisBinarySerializers.FastFory`   | FastFory             | None        | Volatile cache only           |
 | `RedisBinarySerializers.GzipJdk`    | JDK                  | GZip        | Deprecated; trusted data only |
 | `RedisBinarySerializers.LZ4Jdk`     | JDK                  | LZ4         | Deprecated; trusted data only |
 | `RedisBinarySerializers.SnappyJdk`  | JDK                  | Snappy      | Deprecated; trusted data only |
@@ -115,6 +116,12 @@ JDK deserialization can expose Redis values to RCE gadget-chain risk. The JDK se
 | `RedisBinarySerializers.LZ4Fory`    | Fory                 | LZ4         | Recommended                   |
 | `RedisBinarySerializers.SnappyFory` | Fory                 | Snappy      | Recommended                   |
 | `RedisBinarySerializers.ZstdFory`   | Fory                 | Zstd        | Recommended                   |
+| `RedisBinarySerializers.GzipFastFory`   | FastFory             | GZip        | Volatile cache only           |
+| `RedisBinarySerializers.LZ4FastFory`    | FastFory             | LZ4         | Volatile cache only           |
+| `RedisBinarySerializers.SnappyFastFory` | FastFory             | Snappy      | Volatile cache only           |
+| `RedisBinarySerializers.ZstdFastFory`   | FastFory             | Zstd        | Volatile cache only           |
+
+FastFory uses Fory `SCHEMA_CONSISTENT` mode. Its wire format is not a symmetric drop-in replacement for the default Fory mode, so use these variants only for disposable/volatile Redis data and do not mix them with existing Fory values without an explicit migration plan.
 
 ### Compression-only (ByteArray → ByteArray)
 

--- a/spring-boot/redis/src/consumerRuntimeTest/kotlin/io/bluetape4k/spring/redis/serializer/RedisConsumerRuntimeClasspathTest.kt
+++ b/spring-boot/redis/src/consumerRuntimeTest/kotlin/io/bluetape4k/spring/redis/serializer/RedisConsumerRuntimeClasspathTest.kt
@@ -17,6 +17,14 @@ class RedisConsumerRuntimeClasspathTest {
     }
 
     @Test
+    fun `documented FastFory serializer works from consumer runtime classpath`() {
+        val original = mapOf("mode" to "fast")
+        val bytes = RedisBinarySerializers.FastFory.serialize(original)
+
+        RedisBinarySerializers.FastFory.deserialize(bytes) shouldBeEqualTo original
+    }
+
+    @Test
     fun `documented LZ4 Kryo serializer works from consumer runtime classpath`() {
         val original = "Hello, bluetape4k Redis Kryo runtime!"
 

--- a/spring-boot/redis/src/main/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializers.kt
+++ b/spring-boot/redis/src/main/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializers.kt
@@ -9,7 +9,7 @@ import io.bluetape4k.io.serializer.BinarySerializers
  *
  * ## 동작/계약
  * - 모든 인스턴스는 `lazy` 초기화 방식으로 필요한 시점에 생성됩니다.
- * - 압축 방식(GZip/LZ4/Snappy/Zstd)과 직렬화 방식(Jdk/Kryo/Fory)을 조합해 선택할 수 있습니다.
+ * - 압축 방식(GZip/LZ4/Snappy/Zstd)과 직렬화 방식(Jdk/Kryo/Fory/FastFory)을 조합해 선택할 수 있습니다.
  *
  * ```kotlin
  * val redisTemplate = RedisTemplate<String, Any>()
@@ -31,6 +31,12 @@ object RedisBinarySerializers {
     val Jdk by lazy { RedisBinarySerializer(BinarySerializers.Jdk) }
     val Kryo by lazy { RedisBinarySerializer(BinarySerializers.Kryo) }
     val Fory by lazy { RedisBinarySerializer(BinarySerializers.Fory) }
+    /**
+     * FastFory(`SCHEMA_CONSISTENT`)를 사용하는 Redis serializer입니다.
+     *
+     * 기존 Fory 모드와 wire format이 대칭 호환되지 않으므로 휘발성 캐시에만 사용하세요.
+     */
+    val FastFory by lazy { RedisBinarySerializer(BinarySerializers.FastFory) }
 
     val Gzip by lazy { RedisCompressSerializer(Compressors.GZip) }
     val LZ4 by lazy { RedisCompressSerializer(Compressors.LZ4) }
@@ -74,5 +80,33 @@ object RedisBinarySerializers {
     val LZ4Fory by lazy { RedisBinarySerializer(BinarySerializers.LZ4Fory) }
     val SnappyFory by lazy { RedisBinarySerializer(BinarySerializers.SnappyFory) }
     val ZstdFory by lazy { RedisBinarySerializer(BinarySerializers.ZstdFory) }
+
+    /**
+     * GZip 압축과 FastFory(`SCHEMA_CONSISTENT`)를 사용하는 Redis serializer입니다.
+     *
+     * 기존 GZipFory 데이터와 wire format이 대칭 호환되지 않으므로 휘발성 캐시에만 사용하세요.
+     */
+    val GzipFastFory by lazy { RedisBinarySerializer(BinarySerializers.GZipFastFory) }
+
+    /**
+     * LZ4 압축과 FastFory(`SCHEMA_CONSISTENT`)를 사용하는 Redis serializer입니다.
+     *
+     * 기존 LZ4Fory 데이터와 wire format이 대칭 호환되지 않으므로 휘발성 캐시에만 사용하세요.
+     */
+    val LZ4FastFory by lazy { RedisBinarySerializer(BinarySerializers.LZ4FastFory) }
+
+    /**
+     * Snappy 압축과 FastFory(`SCHEMA_CONSISTENT`)를 사용하는 Redis serializer입니다.
+     *
+     * 기존 SnappyFory 데이터와 wire format이 대칭 호환되지 않으므로 휘발성 캐시에만 사용하세요.
+     */
+    val SnappyFastFory by lazy { RedisBinarySerializer(BinarySerializers.SnappyFastFory) }
+
+    /**
+     * Zstd 압축과 FastFory(`SCHEMA_CONSISTENT`)를 사용하는 Redis serializer입니다.
+     *
+     * 기존 ZstdFory 데이터와 wire format이 대칭 호환되지 않으므로 휘발성 캐시에만 사용하세요.
+     */
+    val ZstdFastFory by lazy { RedisBinarySerializer(BinarySerializers.ZstdFastFory) }
 
 }

--- a/spring-boot/redis/src/test/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializerTest.kt
+++ b/spring-boot/redis/src/test/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializerTest.kt
@@ -101,6 +101,17 @@ class RedisBinarySerializerTest: AbstractRedisSerializerTest() {
     }
 
     @Test
+    fun `데이터 클래스를 FastFory로 직렬화 후 복원한다`() {
+        val serializer = RedisBinarySerializers.FastFory
+        val original = TestData(id = 5L, name = "FastFory", description = "휘발성 캐시용 직렬화")
+
+        val bytes = serializer.serialize(original)
+        bytes.shouldNotBeNull()
+
+        serializer.deserialize(bytes) shouldBeEqualTo original
+    }
+
+    @Test
     @Suppress("DEPRECATION")
     fun `데이터 클래스를 Jdk로 직렬화 후 복원한다`() {
         val serializer = RedisBinarySerializer(BinarySerializers.Jdk)

--- a/spring-boot/redis/src/test/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializersTest.kt
+++ b/spring-boot/redis/src/test/kotlin/io/bluetape4k/spring/redis/serializer/RedisBinarySerializersTest.kt
@@ -20,18 +20,23 @@ class RedisBinarySerializersTest: AbstractRedisSerializerTest() {
             Arguments.of(RedisBinarySerializers.Jdk, "Jdk"),
             Arguments.of(RedisBinarySerializers.Kryo, "Kryo"),
             Arguments.of(RedisBinarySerializers.Fory, "Fory"),
+            Arguments.of(RedisBinarySerializers.FastFory, "FastFory"),
             Arguments.of(RedisBinarySerializers.GzipJdk, "GzipJdk"),
             Arguments.of(RedisBinarySerializers.GzipKryo, "GzipKryo"),
             Arguments.of(RedisBinarySerializers.GzipFory, "GzipFory"),
+            Arguments.of(RedisBinarySerializers.GzipFastFory, "GzipFastFory"),
             Arguments.of(RedisBinarySerializers.LZ4Jdk, "LZ4Jdk"),
             Arguments.of(RedisBinarySerializers.LZ4Kryo, "LZ4Kryo"),
             Arguments.of(RedisBinarySerializers.LZ4Fory, "LZ4Fory"),
+            Arguments.of(RedisBinarySerializers.LZ4FastFory, "LZ4FastFory"),
             Arguments.of(RedisBinarySerializers.SnappyJdk, "SnappyJdk"),
             Arguments.of(RedisBinarySerializers.SnappyKryo, "SnappyKryo"),
             Arguments.of(RedisBinarySerializers.SnappyFory, "SnappyFory"),
+            Arguments.of(RedisBinarySerializers.SnappyFastFory, "SnappyFastFory"),
             Arguments.of(RedisBinarySerializers.ZstdJdk, "ZstdJdk"),
             Arguments.of(RedisBinarySerializers.ZstdKryo, "ZstdKryo"),
             Arguments.of(RedisBinarySerializers.ZstdFory, "ZstdFory"),
+            Arguments.of(RedisBinarySerializers.ZstdFastFory, "ZstdFastFory"),
         )
 
         @JvmStatic


### PR DESCRIPTION
## Summary

Closes #1084

- PR 제목: Add FastFory variants to volatile Redis cache integrations

- expose `FastFory`, `GzipFastFory`, `LZ4FastFory`, `SnappyFastFory`, and `ZstdFastFory` through `RedisBinarySerializers`
- add matching FastFory configuration names to the Hibernate Lettuce near-cache integration
- document that FastFory uses `SCHEMA_CONSISTENT`, is intended for volatile cache data, and requires eviction or migration when replacing existing Fory payloads
- cover the new factories with round-trip, configuration pass-through, and consumer-runtime tests

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Compatibility

Existing Fory APIs, defaults, and wire formats remain unchanged. FastFory variants are opt-in and are not intended for durable or externally exchanged payloads without a migration contract.

## Validation

- `:bluetape4k-hibernate-cache-lettuce:test` — 81 passing
- targeted `:bluetape4k-spring-boot-redis:test` — 80 passing
- `:bluetape4k-spring-boot-redis:consumerRuntimeTest` — 3 passing
- targeted `:bluetape4k-spring-boot-hibernate-lettuce:test` — 16 passing
- `./gradlew detekt --no-configuration-cache`
- `git diff --check`

Closes #1084

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1084, milestone `없음`, assignee 없음
- PR: #1085, head `8809655190d7714094d63b52678e1107fd7e5aa4`, milestone `없음`, assignee debop
- Base: `develop`, head branch `agent/fastfory-serializer-variants`
- Labels: 없음
- State: `MERGED`, merge commit `7905c2f7da4a140e9d42490999196f9785dd6235`
- CI: - document that FastFory uses `SCHEMA_CONSISTENT`, is intended for volatile cache data, and requires eviction or migration when replacing existing Fory payloads / - `./gradlew detekt --no-configuration-cache`## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1085 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `7905c2f7da4a140e9d42490999196f9785dd6235`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
