### PR TITLE
test: add context propagation conformance fixtures

### DIFF
--- a/docs/lessons/2026-07-28-issue-1051-context-propagation-conformance.md
+++ b/docs/lessons/2026-07-28-issue-1051-context-propagation-conformance.md
@@ -53,11 +53,12 @@ module registration, global OpenTelemetry/Reactor hook은 변경하지 않았습
 
 전체 module suite는 순차 실행했고 모두 통과했습니다.
 
-- `:bluetape4k-junit5:test`: 338 tests, `real 16.00s`
-- `:bluetape4k-opentelemetry:test`: 110 tests, `real 86.20s`
-- `:bluetape4k-spring-boot-core:test`: 249 tests, `real 26.71s`
-- `:bluetape4k-ktor-observability:test`: 20 tests, `real 7.29s`
-- root `detekt`: `BUILD SUCCESSFUL`, `NO-SOURCE`, `real 0.51s`
+- `:bluetape4k-junit5:test`: 338 tests, `real 16.01s`
+- `:bluetape4k-opentelemetry:test`: 110 tests, `real 86.74s`
+- `:bluetape4k-spring-boot-core:test`: 249 tests, `real 25.29s`
+- `:bluetape4k-ktor-observability:test`: 20 tests, `real 6.68s`
+- root `detekt`: `BUILD SUCCESSFUL`, `NO-SOURCE`, `real 3.04s`
+- `:bluetape4k-junit5:dokkaGenerate`: `BUILD SUCCESSFUL`; 기존 README link warning 3건만 유지
 
 대상 module은 개별 `detekt` task를 노출하지 않으므로 root 성공을 Kotlin 정적 분석 통과로 간주하지
 않았습니다. 대신 각 module test의 Kotlin compile, 금지 API/output scan, executable documentation gate,

--- a/docs/lessons/2026-07-28-issue-1051-context-propagation-conformance.md
+++ b/docs/lessons/2026-07-28-issue-1051-context-propagation-conformance.md
@@ -53,11 +53,11 @@ module registration, global OpenTelemetry/Reactor hook은 변경하지 않았습
 
 전체 module suite는 순차 실행했고 모두 통과했습니다.
 
-- `:bluetape4k-junit5:test`: 337 tests, `real 15.50s`
-- `:bluetape4k-opentelemetry:test`: 110 tests, `real 74.42s`
-- `:bluetape4k-spring-boot-core:test`: 249 tests, `real 16.84s`
-- `:bluetape4k-ktor-observability:test`: 20 tests, `real 4.54s`
-- root `detekt`: `BUILD SUCCESSFUL`, `NO-SOURCE`, `real 1.69s`
+- `:bluetape4k-junit5:test`: 338 tests, `real 16.00s`
+- `:bluetape4k-opentelemetry:test`: 110 tests, `real 86.20s`
+- `:bluetape4k-spring-boot-core:test`: 249 tests, `real 26.71s`
+- `:bluetape4k-ktor-observability:test`: 20 tests, `real 7.29s`
+- root `detekt`: `BUILD SUCCESSFUL`, `NO-SOURCE`, `real 0.51s`
 
 대상 module은 개별 `detekt` task를 노출하지 않으므로 root 성공을 Kotlin 정적 분석 통과로 간주하지
 않았습니다. 대신 각 module test의 Kotlin compile, 금지 API/output scan, executable documentation gate,

--- a/docs/lessons/2026-07-28-issue-1051-context-propagation-conformance.md
+++ b/docs/lessons/2026-07-28-issue-1051-context-propagation-conformance.md
@@ -29,8 +29,11 @@ redacted 진단만 수행합니다.
 `CancellationException`과 `TimeoutCancellationException`은 같은 cleanup 경로를 통과해도 의미가 다릅니다.
 따라서 cancellation 시나리오는 실제 child/request cancellation을 발생시키고, deadline 시나리오는
 250ms `withTimeout`을 실행해 각각 `CANCELLATION`과 `DEADLINE_EXCEEDED`로 검증했습니다. 모든 semantic
-deadline은 5초 hang guard보다 짧고, cleanup은 `NonCancellable` 영역에서 release, cancel, join 순서로
-수행됩니다.
+deadline은 5초 hang guard보다 짧습니다. `NonCancellable` 영역의 release, cancel, join 순서는 coroutine,
+Spring, Ktor처럼 child/request job을 소유하는 경계에 적용합니다.
+Reactor는 subscription dispose와 scheduler shutdown을 모두 시도한 뒤 interrupt를 복원하고, task executor는
+future cancel과 executor shutdown/termination을 별도로 보장합니다. 서로 다른 lifecycle primitive를
+`NonCancellable` cleanup 하나로 일반화하지 않습니다.
 
 ## 결정적인 isolation barrier
 

--- a/docs/lessons/2026-07-28-issue-1051-context-propagation-conformance.md
+++ b/docs/lessons/2026-07-28-issue-1051-context-propagation-conformance.md
@@ -1,0 +1,65 @@
+# Issue #1051: Context propagation conformance
+
+## 문제
+
+coroutine, Reactor, task executor, Spring Observation, Ktor request는 context를 전달하는 방식과 종료 신호가
+서로 다릅니다. 각 adapter가 자체 assertion을 가지면 parent visibility, cleanup, isolation의 의미가 쉽게
+달라지고 cancellation을 일반 실패나 deadline으로 잘못 분류할 수 있습니다.
+
+이번 작업은 framework별 구현을 공통 구현으로 합치지 않았습니다. 대신 `:bluetape4k-junit5`에
+provider-neutral snapshot과 assertion 경계를 두고, 각 소비 module의 테스트가 실제 framework bridge를
+실행한 결과를 그 snapshot으로 변환하도록 했습니다.
+
+## 선택한 공통 경계
+
+공통 계약은 다음 증거만 다룹니다.
+
+- boundary 진입, suspension 이후, terminal 직전의 synthetic parent marker
+- success, failure, cancellation, deadline의 실제 terminal 분류
+- caller, worker, request 위치의 cleanup probe
+- 고정 A/B parent가 겹쳐 실행됐다는 event-ledger partial order
+- 후속 unwrapped 또는 unparented probe가 A/B 값을 재사용하지 않았다는 isolation 증거
+
+fixture는 framework type, tracer provider, registry, exporter의 lifecycle을 소유하지 않습니다. adapter
+테스트가 실제 framework context를 읽고 immutable snapshot으로 변환하며, fixture는 값 비교와 안전한
+redacted 진단만 수행합니다.
+
+## Cancellation과 deadline
+
+`CancellationException`과 `TimeoutCancellationException`은 같은 cleanup 경로를 통과해도 의미가 다릅니다.
+따라서 cancellation 시나리오는 실제 child/request cancellation을 발생시키고, deadline 시나리오는
+250ms `withTimeout`을 실행해 각각 `CANCELLATION`과 `DEADLINE_EXCEEDED`로 검증했습니다. 모든 semantic
+deadline은 5초 hang guard보다 짧고, cleanup은 `NonCancellable` 영역에서 release, cancel, join 순서로
+수행됩니다.
+
+## 결정적인 isolation barrier
+
+확률적 반복이나 ordering용 sleep/delay를 사용하지 않았습니다. A/B participant가 모두 `READY`를 기록한
+뒤에만 `RELEASED`로 진행하며, parent가 양쪽 terminal과 `finally` 완료를 관측한 다음 cleanup probe를
+실행합니다. participant 또는 client가 ready 이전이나 release 이후에 실패해도 첫 실패를 보존하고 peer
+gate를 해제하며, 양쪽 terminal을 모두 기록한 뒤 원래 실패를 다시 던집니다.
+
+## Production 변경 없음
+
+변경은 `:bluetape4k-junit5`의 shared test fixture public surface, module test source, bilingual README,
+이 lesson에만 한정했습니다. 실제 context를 전달하는 consumer runtime adapter, dependency, build script,
+module registration, global OpenTelemetry/Reactor hook은 변경하지 않았습니다. Ktor 검증도 local
+`OpenTelemetrySdk`와 in-process `testApplication`만 사용하며 외부 collector나 server를 요구하지 않습니다.
+
+## 검증 증거
+
+전체 module suite는 순차 실행했고 모두 통과했습니다.
+
+- `:bluetape4k-junit5:test`: 337 tests, `real 15.50s`
+- `:bluetape4k-opentelemetry:test`: 110 tests, `real 74.42s`
+- `:bluetape4k-spring-boot-core:test`: 249 tests, `real 16.84s`
+- `:bluetape4k-ktor-observability:test`: 20 tests, `real 4.54s`
+- root `detekt`: `BUILD SUCCESSFUL`, `NO-SOURCE`, `real 1.69s`
+
+대상 module은 개별 `detekt` task를 노출하지 않으므로 root 성공을 Kotlin 정적 분석 통과로 간주하지
+않았습니다. 대신 각 module test의 Kotlin compile, 금지 API/output scan, executable documentation gate,
+`git diff --check`, 독립 7-Tier review를 최종 품질 근거로 사용합니다.
+
+추가 executable gate는 fresh JUnit XML의 conformance case 수와 단일 case 최대 7.5초 미만, README
+English/Korean symbol 및 핵심 문구 parity, global telemetry/context mutation과 raw output API 부재,
+`git diff --check`를 확인합니다.

--- a/docs/superpowers/plans/2026-07-28-issue-1051-context-propagation-conformance-plan.md
+++ b/docs/superpowers/plans/2026-07-28-issue-1051-context-propagation-conformance-plan.md
@@ -1,0 +1,1909 @@
+# Issue #1051 Context Propagation Conformance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** coroutine, Reactor, task executor, Spring Observation, Ktor request 경계가 동일한 provider-neutral assertion으로 parent visibility, terminal 분류, cleanup, isolation을 결정적으로 증명하도록 한다.
+
+**Architecture:** `:bluetape4k-junit5`는 framework type을 모르는 immutable snapshot과 assertion만 제공한다. `:bluetape4k-opentelemetry`, `:bluetape4k-spring-boot-core`, `:bluetape4k-ktor-observability`의 test source가 실제 bridge를 실행하고 관측값을 snapshot으로 변환한다. production code, build script, 전역 OTel/Reactor 상태는 변경하지 않는다.
+
+**Tech Stack:** Kotlin 2.3, Java 21, JUnit 5, kotlinx.coroutines, OpenTelemetry Java API/SDK, Reactor, Micrometer Observation, Spring Boot 4, Ktor `testApplication`, Gradle
+
+---
+
+## 0. 실행 계약
+
+- 설계 기준: `docs/superpowers/specs/2026-07-28-issue-1051-context-propagation-conformance-design.md`
+- 적용 패턴:
+  - `bluetape-kotlin-patterns`: public KDoc, immutable value, 명시적 serial UID, 파일 크기/책임 제한
+  - `kotlin-coroutines-skill`: cancellation 재전파, `withTimeout` semantic deadline, `finally` cleanup, 구조화된 child lifecycle
+  - `ecc-springboot-kotlin`: Spring test slice와 registry lifecycle, production surface 비변경
+- 작업 순서: Task 1부터 Task 8까지 순차 실행한다. 같은 task 안에서는 RED → 최소 GREEN → refactor → targeted test 순서를 지킨다.
+- 금지:
+  - 새 dependency, module, production API, global OTel setter, Reactor global hook
+  - `Thread.sleep` 또는 ordering용 `delay`
+  - raw marker를 assertion message 또는 log에 포함
+  - Testcontainers, production exporter/collector, 외부 HTTP server
+- 중단 조건: production 수정이나 새 dependency가 필요하면 구현을 중단하고 spec review를 다시 연다.
+- 테스트 전체 guard:
+
+```kotlin
+@Timeout(
+    value = 15,
+    unit = TimeUnit.SECONDS,
+    threadMode = Timeout.ThreadMode.SAME_THREAD,
+)
+```
+
+- 공통 시간 경계:
+
+```kotlin
+private val semanticDeadline = 250.milliseconds
+private val hangGuard = DEFAULT_CANCELLATION_CONTRACT_TIMEOUT
+
+init {
+    check(semanticDeadline < hangGuard)
+}
+```
+
+- 결정성 증명: 모든 scenario는 기본 full suite에서 1회 실행한다. 확률적 반복 대신 test-private event ledger가 두 participant의 `READY`가 모두 기록된 뒤에만 `RELEASE`되었는지, cleanup probe가 terminal/finally 뒤에 실행됐는지 exact partial order로 assertion한다. 별도 반복/stress task는 이 issue와 최종 evidence에 추가하지 않는다.
+
+## Acceptance criteria 매핑
+
+| Issue 기준 | 구현 task | 증명 |
+|---|---|---|
+| coroutine/Reactor/executor parent propagation | 3, 4, 5 | 각 경계 success/failure/cancellation/deadline/isolation 5개 |
+| cancellation/deadline cleanup | 3, 4, 5, 6, 7 | 실제 terminal과 caller/worker/request probe |
+| request leakage 없음 | 3, 4, 5, 6, 7 | failure-aware A/B barrier와 후속 unwrapped/probe 실행 |
+| deterministic tests | 2–7 | 명시적 gate, 5초 hang guard, 15초 aggregate guard |
+| Spring/Ktor 동일 assertion | 6, 7 | shared fixture 직접 호출 |
+| 외부 telemetry/backend 불필요 | 3–7 | local SDK/registry, in-process application |
+| interception은 소비 module 유지 | 1, 3–7 | shared public API에 framework type 없음 |
+| 실패 메시지에 민감값 없음 | 1 | CR/LF canary negative self-test |
+| Spec §5.2 public KDoc/example | 1 | 모든 enum/snapshot/assertion declaration별 English KDoc example ledger |
+| Spec §5.2 safe diagnostics | 1 | boundary/scenario/alias/field/mode enum 좌표와 `values redacted` exact-message tests |
+| Spec §9 compatibility | 1, 8 | enum additive/non-exhaustive 안내와 constructor compatibility 경고 |
+| Spec §9 bilingual README | 8 | complete propagation/isolation examples와 parity validation script |
+
+## Task 1: provider-neutral fixture를 TDD로 추가
+
+**Files:**
+
+- Create: `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformance.kt`
+- Create: `testing/junit5/src/test/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformanceTest.kt`
+- Reference: `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/observability/HttpOperationObservabilityConformance.kt`
+- Reference: `testing/junit5/src/test/kotlin/io/bluetape4k/junit5/observability/HttpOperationObservabilityConformanceTest.kt`
+
+**Complexity:** L
+
+**Dependencies:** 없음
+
+**Write scope:** 위 두 새 파일만
+
+### Step 1.1 — RED: public contract의 정상/실패 의미를 먼저 고정
+
+- [ ] 최소 10개 self-test를 만든다.
+- [ ] observation point exact set, terminal 구분, cleanup location exact set, root marker 금지, alias uniqueness, `EXACT`/`ABSENT`/`NOT_IN`, minimum observation count, redaction을 포함한다.
+- [ ] failure message canary는 `secret-parent\r\nforged-log`를 사용한다. observation-point set, propagation marker, cleanup, isolation `EXACT`, isolation `NOT_IN`, invalid expectation의 각 failure path에서 메시지에 `secret-parent`, `forged-log`, `\r`, `\n`이 없음을 parameterized test로 확인한다.
+- [ ] fixture는 성공/실패 어느 경로에서도 marker를 log/print하지 않는다. 별도 logger를 추가하지 않고 self-test appender에 fixture-originated event가 없음을 확인한다.
+
+```kotlin
+class ContextPropagationConformanceTest {
+
+    @Test
+    fun `accepts matching propagation snapshot`() {
+        assertContextPropagationConformance(
+            observation = propagationObservation(),
+            expectation = propagationExpectation(),
+        )
+    }
+
+    @Test
+    fun `rejects mismatched observation point set without exposing marker`() {
+        val canary = "secret-parent\r\nforged-log"
+        val error = assertFailsWith<AssertionError> {
+            assertContextPropagationConformance(
+                propagationObservation(
+                    markerObservations = listOf(
+                        ContextMarkerObservation(ContextObservationPoint.BOUNDARY_ENTER, canary),
+                    ),
+                ),
+                propagationExpectation(),
+            )
+        }
+        error.message.shouldNotContain("secret-parent")
+        error.message.shouldNotContain("forged-log")
+        error.message.shouldNotContain("\r")
+        error.message.shouldNotContain("\n")
+    }
+
+    @Test
+    fun `keeps failure cancellation and deadline terminals distinct`() {
+        ContextPropagationTerminal.entries
+            .filterNot { it == ContextPropagationTerminal.SUCCESS }
+            .forEach { actual ->
+                assertFailsWith<AssertionError> {
+                    assertContextPropagationConformance(
+                        propagationObservation(terminal = actual),
+                        propagationExpectation(
+                            expectedTerminal = ContextPropagationTerminal.SUCCESS,
+                        ),
+                    )
+                }
+            }
+    }
+
+    @Test
+    fun `rejects root string marker`() {
+        assertFailsWith<AssertionError> {
+            assertContextPropagationConformance(
+                propagationObservation(
+                    markerObservations = listOf(
+                        ContextMarkerObservation(
+                            ContextObservationPoint.BOUNDARY_ENTER,
+                            "root",
+                        ),
+                    ),
+                ),
+                propagationExpectation(),
+            )
+        }
+    }
+
+    @Test
+    fun `accepts exact absent and not-in isolation samples`() {
+        assertContextIsolation(
+            observation = isolationObservation(),
+            expectation = isolationExpectation(),
+        )
+    }
+
+    @Test
+    fun `rejects duplicate aliases and exact markers`() {
+        assertFailsWith<AssertionError> {
+            assertContextIsolation(
+                isolationObservation(),
+                isolationExpectation(
+                    samples = listOf(
+                        exactExpectation(ContextRequestAlias.REQUEST_A, "parent-A"),
+                        exactExpectation(ContextRequestAlias.REQUEST_A, "parent-A"),
+                    ),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `rejects mode-field combinations that are not meaningful`() {
+        val invalid = listOf(
+            ContextIsolationSampleExpectation(
+                ContextRequestAlias.REQUEST_A,
+                ContextMarkerExpectationMode.EXACT,
+            ),
+            ContextIsolationSampleExpectation(
+                ContextRequestAlias.REQUEST_A,
+                ContextMarkerExpectationMode.ABSENT,
+                expectedMarker = "parent-A",
+            ),
+            ContextIsolationSampleExpectation(
+                ContextRequestAlias.PROBE,
+                ContextMarkerExpectationMode.NOT_IN,
+            ),
+        )
+        invalid.forEach { sample ->
+            assertFailsWith<AssertionError> {
+                assertContextIsolation(
+                    isolationObservation(),
+                    isolationExpectation(samples = listOf(sample)),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `rejects insufficient isolation observations`() {
+        assertFailsWith<AssertionError> {
+            assertContextIsolation(
+                isolationObservation(
+                    samples = listOf(
+                        ContextIsolationSample(ContextRequestAlias.REQUEST_A, listOf("parent-A")),
+                    ),
+                ),
+                isolationExpectation(
+                    samples = listOf(
+                        exactExpectation(
+                            ContextRequestAlias.REQUEST_A,
+                            "parent-A",
+                            minimumObservationCount = 2,
+                        ),
+                    ),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `rejects cleanup location mismatch`() {
+        assertFailsWith<AssertionError> {
+            assertContextPropagationConformance(
+                propagationObservation(
+                    cleanupProbes = listOf(
+                        ContextCleanupProbe(ContextProbeLocation.WORKER, null),
+                    ),
+                ),
+                propagationExpectation(),
+            )
+        }
+    }
+
+    @Test
+    fun `rejects not-in sample containing forbidden marker`() {
+        assertFailsWith<AssertionError> {
+            assertContextIsolation(
+                isolationObservation(
+                    samples = listOf(
+                        ContextIsolationSample(ContextRequestAlias.PROBE, listOf("parent-A")),
+                    ),
+                ),
+                isolationExpectation(
+                    samples = listOf(
+                        ContextIsolationSampleExpectation(
+                            ContextRequestAlias.PROBE,
+                            ContextMarkerExpectationMode.NOT_IN,
+                            forbiddenMarkers = listOf("parent-A", "parent-B"),
+                        ),
+                    ),
+                ),
+            )
+        }
+    }
+}
+```
+
+- [ ] RED 명령:
+
+```bash
+./gradlew :bluetape4k-junit5:test \
+  --tests "io.bluetape4k.junit5.observability.ContextPropagationConformanceTest"
+```
+
+**Expected RED:** 새 public type과 assertion symbol을 찾지 못해 test compilation이 실패한다.
+
+### Step 1.2 — GREEN: framework-neutral snapshot과 redacted assertion 구현
+
+- [ ] 승인된 spec의 enum/data class/function signature를 그대로 구현한다.
+- [ ] 모든 data class를 `Serializable`로 만들고 저장소 선례대로 companion에 `private const val serialVersionUID: Long = 1L`을 둔다.
+- [ ] 모든 public declaration에 English KDoc과 해당 declaration을 직접 사용하는 최소 예제를 작성한다. KDoc은 test-owned synthetic marker만 허용하고 production request ID, user data, external trace ID를 금지하며, `Serializable` snapshot을 persistent/wire format으로 저장하지 말아야 한다는 privacy/compatibility contract를 포함한다.
+- [ ] public enum KDoc은 future value 추가가 additive임을 명시하고 caller의 exhaustive `when`에 `else`를 요구한다. data-class KDoc은 constructor 변경이 compatibility-sensitive하므로 저장/구조분해/wire contract로 사용하지 말라고 명시한다.
+- [ ] validation failure는 raw value 없이 enum과 관계만 표시한다.
+
+**KDoc example ledger:**
+
+| Public declaration | KDoc example proof |
+|---|---|
+| `ContextPropagationBoundary` | `val boundary = ContextPropagationBoundary.COROUTINE` |
+| `ContextPropagationScenario` | `val scenario = ContextPropagationScenario.SUCCESS` |
+| `ContextPropagationTerminal` | `val terminal = ContextPropagationTerminal.SUCCESS` |
+| `ContextProbeLocation` | `val location = ContextProbeLocation.CALLER` |
+| `ContextRequestAlias` | `val alias = ContextRequestAlias.SINGLE` |
+| `ContextObservationPoint` | `val point = ContextObservationPoint.BOUNDARY_ENTER` |
+| `ContextMarkerExpectationMode` | `val mode = ContextMarkerExpectationMode.EXACT` |
+| `ContextMarkerObservation` | construct one synthetic enter observation |
+| `ContextMarkerExpectation` | construct the matching enter expectation |
+| `ContextCleanupProbe` | construct caller/root probe with `null` |
+| `ContextCleanupExpectation` | construct caller/root expectation with `null` |
+| `ContextPropagationObservation` | complete success snapshot with enter/after/before points |
+| `ContextPropagationExpectation` | complete matching success expectation |
+| `ContextIsolationSample` | A sample with two synthetic observations |
+| `ContextIsolationSampleExpectation` | matching `EXACT` expectation |
+| `ContextIsolationObservation` | A/B/probe isolation snapshot |
+| `ContextIsolationExpectation` | A/B `EXACT` plus probe `NOT_IN` |
+| `assertContextPropagationConformance` | complete observation/expectation invocation |
+| `assertContextIsolation` | complete isolation invocation |
+
+- [ ] uniform safe diagnostic shape를 exact-message test로 고정한다. marker 원문 대신 `relation=mismatch`만 쓰고 safe enum 좌표만 포함한다.
+
+```kotlin
+private fun propagationFailure(
+    observation: ContextPropagationObservation,
+    field: String,
+    actual: String = "redacted",
+    expected: String = "redacted",
+): Nothing =
+    fail(
+        "Context propagation mismatch: " +
+                "boundary=${observation.boundary}, " +
+                "scenario=${observation.scenario}, " +
+                "alias=${observation.requestAlias}, " +
+                "field=$field, actual=$actual, expected=$expected, " +
+                "relation=mismatch; values redacted",
+    )
+
+private fun isolationFailure(
+    observation: ContextIsolationObservation,
+    expectation: ContextIsolationSampleExpectation,
+    field: String,
+): Nothing =
+    fail(
+        "Context isolation mismatch: " +
+                "boundary=${observation.boundary}, " +
+                "alias=${expectation.requestAlias}, " +
+                "mode=${expectation.mode}, " +
+                "field=$field, relation=mismatch; values redacted",
+    )
+```
+
+```kotlin
+private const val ROOT_MARKER = "root"
+
+private fun fail(message: String): Nothing = throw AssertionError(message)
+
+private fun validateMarker(marker: String?, role: String) {
+    if (marker == ROOT_MARKER) {
+        fail("Context marker $role must use null for root")
+    }
+}
+
+private fun <T> requireUnique(values: List<T>, role: String) {
+    if (values.size != values.toSet().size) {
+        fail("Context $role must be unique")
+    }
+}
+
+fun assertContextPropagationConformance(
+    observation: ContextPropagationObservation,
+    expectation: ContextPropagationExpectation,
+) {
+    if (observation.boundary != expectation.boundary) {
+        propagationFailure(
+            observation,
+            "boundary",
+            observation.boundary.name,
+            expectation.boundary.name,
+        )
+    }
+    if (observation.scenario != expectation.scenario) {
+        propagationFailure(
+            observation,
+            "scenario",
+            observation.scenario.name,
+            expectation.scenario.name,
+        )
+    }
+    if (observation.requestAlias != expectation.requestAlias) {
+        propagationFailure(
+            observation,
+            "requestAlias",
+            observation.requestAlias.name,
+            expectation.requestAlias.name,
+        )
+    }
+    if (observation.terminal != expectation.expectedTerminal) {
+        propagationFailure(
+            observation,
+            "terminal",
+            observation.terminal.name,
+            expectation.expectedTerminal.name,
+        )
+    }
+
+    val actualPoints = observation.markerObservations.map { it.point }
+    val expectedPoints = expectation.markerExpectations.map { it.point }
+    requireUnique(actualPoints, "observation points")
+    requireUnique(expectedPoints, "expectation points")
+    if (actualPoints.toSet() != expectedPoints.toSet()) {
+        propagationFailure(observation, "observationPointSet")
+    }
+    expectation.markerExpectations.forEach { expected ->
+        validateMarker(expected.expectedMarker, "expectation")
+        val actual = observation.markerObservations.single { it.point == expected.point }
+        validateMarker(actual.observedMarker, "observation")
+        if (actual.observedMarker != expected.expectedMarker) {
+            propagationFailure(observation, "marker.${expected.point}")
+        }
+    }
+
+    assertCleanup(observation.cleanupProbes, expectation.cleanupExpectations)
+}
+
+fun assertContextIsolation(
+    observation: ContextIsolationObservation,
+    expectation: ContextIsolationExpectation,
+) {
+    if (observation.boundary != expectation.boundary) {
+        fail(
+            "Context isolation mismatch: boundary=${observation.boundary}, " +
+                    "field=boundary, relation=mismatch; values redacted",
+        )
+    }
+    val actualAliases = observation.samples.map { it.requestAlias }
+    val expectedAliases = expectation.samples.map { it.requestAlias }
+    requireUnique(actualAliases, "isolation observation aliases")
+    requireUnique(expectedAliases, "isolation expectation aliases")
+    if (actualAliases.toSet() != expectedAliases.toSet()) {
+        fail(
+            "Context isolation mismatch: boundary=${observation.boundary}, " +
+                    "field=aliasSet, relation=mismatch; values redacted",
+        )
+    }
+
+    val exactMarkers = expectation.samples
+        .filter { it.mode == ContextMarkerExpectationMode.EXACT }
+        .mapNotNull { it.expectedMarker }
+    requireUnique(exactMarkers, "exact expectation markers")
+
+    expectation.samples.forEach { expected ->
+        validateIsolationExpectation(expected)
+        val actual = observation.samples.single { it.requestAlias == expected.requestAlias }
+        if (actual.observedMarkers.size < expected.minimumObservationCount) {
+            isolationFailure(observation, expected, "observationCount")
+        }
+        actual.observedMarkers.forEach { validateMarker(it, "isolation observation") }
+        val matches = when (expected.mode) {
+            ContextMarkerExpectationMode.EXACT ->
+                actual.observedMarkers.all { it == expected.expectedMarker }
+            ContextMarkerExpectationMode.ABSENT ->
+                actual.observedMarkers.all { it == null }
+            ContextMarkerExpectationMode.NOT_IN ->
+                actual.observedMarkers.all {
+                    it != null && it !in expected.forbiddenMarkers
+                }
+        }
+        if (!matches) {
+            isolationFailure(observation, expected, "markerRelation")
+        }
+    }
+
+    assertCleanup(observation.cleanupProbes, expectation.cleanupExpectations)
+}
+```
+
+- [ ] cleanup과 isolation mode validation helper를 구현한다. `validateMarker`, `requireUnique`, `assertCleanup`, invalid mode도 caller의 propagation/isolation diagnostic builder를 받아 동일한 safe coordinate format을 사용해야 하며 generic message로 우회하지 않는다.
+
+```kotlin
+private fun assertCleanup(
+    actual: List<ContextCleanupProbe>,
+    expected: List<ContextCleanupExpectation>,
+) {
+    val actualLocations = actual.map { it.location }
+    val expectedLocations = expected.map { it.location }
+    requireUnique(actualLocations, "cleanup observation locations")
+    requireUnique(expectedLocations, "cleanup expectation locations")
+    if (actualLocations.toSet() != expectedLocations.toSet()) {
+        fail("Context cleanup location set mismatch")
+    }
+    expected.forEach { expectedProbe ->
+        validateMarker(expectedProbe.expectedMarker, "cleanup expectation")
+        val actualProbe = actual.single { it.location == expectedProbe.location }
+        validateMarker(actualProbe.observedMarker, "cleanup observation")
+        if (actualProbe.observedMarker != expectedProbe.expectedMarker) {
+            fail("Context cleanup mismatch at ${expectedProbe.location}")
+        }
+    }
+}
+
+private fun validateIsolationExpectation(
+    expectation: ContextIsolationSampleExpectation,
+) {
+    if (expectation.minimumObservationCount < 1) {
+        fail("Context isolation minimum observation count must be positive")
+    }
+    expectation.expectedMarker?.let { validateMarker(it, "isolation expectation") }
+    expectation.forbiddenMarkers.forEach {
+        validateMarker(it, "isolation forbidden expectation")
+    }
+    requireUnique(expectation.forbiddenMarkers, "forbidden markers")
+
+    val valid = when (expectation.mode) {
+        ContextMarkerExpectationMode.EXACT ->
+            expectation.expectedMarker != null && expectation.forbiddenMarkers.isEmpty()
+        ContextMarkerExpectationMode.ABSENT ->
+            expectation.expectedMarker == null && expectation.forbiddenMarkers.isEmpty()
+        ContextMarkerExpectationMode.NOT_IN ->
+            expectation.expectedMarker == null && expectation.forbiddenMarkers.isNotEmpty()
+    }
+    if (!valid) {
+        fail("Context isolation expectation fields do not match ${expectation.mode}")
+    }
+}
+```
+
+- [ ] GREEN 명령:
+
+```bash
+./gradlew :bluetape4k-junit5:test \
+  --tests "io.bluetape4k.junit5.observability.ContextPropagationConformanceTest"
+```
+
+**Expected GREEN:** 최소 10 tests pass.
+
+- [ ] Lore commit:
+
+```text
+Define one provider-neutral proof language for context propagation
+
+Constraint: Shared fixture must expose no framework-specific types or raw marker diagnostics
+Rejected: Framework-specific assertion copies | they would drift in terminal and cleanup meaning
+Confidence: high
+Scope-risk: moderate
+Directive: Keep future adapters responsible for collecting real framework evidence
+Tested: :bluetape4k-junit5 targeted conformance test
+Not-tested: Consumer adapters are added in later tasks
+```
+
+## Task 2: 공통 test-support helper와 resource lifecycle을 고정
+
+**Files:**
+
+- Create: `infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationTestSupport.kt`
+- Create: `infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt`
+
+**Complexity:** M
+
+**Dependencies:** Task 1
+
+**Write scope:** 위 두 OpenTelemetry test 파일만
+
+### Step 2.1 — RED: helper lifecycle의 failure-aware 계약 추가
+
+- [ ] test class에 `@Timeout(... SAME_THREAD)`을 붙인다.
+- [ ] 아직 없는 `runCoroutineScenario`, `runReactorScenario`, `runExecutorScenario`를 호출하는 3개 smoke test를 작성해 compile RED를 만든다.
+
+```kotlin
+@Timeout(
+    value = 15,
+    unit = TimeUnit.SECONDS,
+    threadMode = Timeout.ThreadMode.SAME_THREAD,
+)
+class ContextPropagationConformanceTest {
+
+    @Test
+    fun `coroutine success propagates and restores context`() = runTest {
+        val captured = runCoroutineScenario(ContextPropagationScenario.SUCCESS)
+        captured.thrown.shouldBeNull()
+        assertContextPropagationConformance(
+            captured.observation,
+            propagationExpectation(
+                ContextPropagationBoundary.COROUTINE,
+                ContextPropagationScenario.SUCCESS,
+                ContextPropagationTerminal.SUCCESS,
+            ),
+        )
+    }
+
+    @Test
+    fun `reactor success propagates and restores context`() {
+        val captured = runReactorScenario(ContextPropagationScenario.SUCCESS)
+        captured.thrown.shouldBeNull()
+        assertContextPropagationConformance(
+            captured.observation,
+            propagationExpectation(
+                ContextPropagationBoundary.REACTOR,
+                ContextPropagationScenario.SUCCESS,
+                ContextPropagationTerminal.SUCCESS,
+            ),
+        )
+    }
+
+    @Test
+    fun `executor success propagates and restores context`() {
+        val captured = runExecutorScenario(ContextPropagationScenario.SUCCESS)
+        captured.thrown.shouldBeNull()
+        assertContextPropagationConformance(
+            captured.observation,
+            propagationExpectation(
+                ContextPropagationBoundary.TASK_EXECUTOR,
+                ContextPropagationScenario.SUCCESS,
+                ContextPropagationTerminal.SUCCESS,
+            ),
+        )
+    }
+}
+```
+
+- [ ] RED 명령:
+
+```bash
+./gradlew :bluetape4k-opentelemetry:test \
+  --tests "io.bluetape4k.opentelemetry.context.ContextPropagationConformanceTest"
+```
+
+**Expected RED:** 세 adapter helper unresolved reference로 test compilation 실패.
+
+### Step 2.2 — GREEN: test-only context key, snapshot builder, bounded resource helper 추가
+
+```kotlin
+internal val propagationMarkerKey: ContextKey<String> =
+    ContextKey.named("bluetape4k-context-propagation-test-marker")
+
+internal const val parentMarkerA = "parent-A"
+internal const val parentMarkerB = "parent-B"
+
+internal fun otelContext(marker: String): Context =
+    Context.root().with(propagationMarkerKey, marker)
+
+internal fun currentMarker(): String? =
+    Context.current().get(propagationMarkerKey)
+
+internal fun CountDownLatch.awaitOrFail(
+    timeout: Duration = DEFAULT_CANCELLATION_CONTRACT_TIMEOUT,
+) {
+    check(await(timeout.inWholeNanoseconds, TimeUnit.NANOSECONDS)) {
+        "Timed out waiting for test gate"
+    }
+}
+
+internal fun <T> Future<T>.getWithin(timeout: Duration): T =
+    get(timeout.inWholeNanoseconds, TimeUnit.NANOSECONDS)
+
+internal enum class ConformanceEvent {
+    READY,
+    RELEASED,
+    TERMINAL_OBSERVED,
+    FINALLY_COMPLETED,
+    CLEANUP_PROBED,
+}
+
+internal class ConformanceEventEntry(
+    val requestAlias: ContextRequestAlias,
+    val event: ConformanceEvent,
+    val sequence: Long,
+)
+
+internal class ConformanceEventLedger {
+    private val sequence = AtomicLong()
+    private val events = ConcurrentLinkedQueue<ConformanceEventEntry>()
+
+    fun record(
+        requestAlias: ContextRequestAlias,
+        event: ConformanceEvent,
+    ) {
+        events += ConformanceEventEntry(
+            requestAlias,
+            event,
+            sequence.incrementAndGet(),
+        )
+    }
+
+    fun assertIsolationOrder() {
+        val snapshot = events.toList()
+        val participantEntries = listOf(
+            ContextRequestAlias.REQUEST_A,
+            ContextRequestAlias.REQUEST_B,
+        ).associateWith { alias ->
+            snapshot.filter { it.requestAlias == alias }.also { entries ->
+                val counts = entries.groupingBy { it.event }.eachCount()
+                ConformanceEvent.entries.forEach { event ->
+                    check(counts[event] == 1) {
+                        "Lifecycle event count mismatch: alias=$alias, event=$event"
+                    }
+                }
+            }
+        }
+        val lastReady = participantEntries.values
+            .flatten()
+            .filter { it.event == ConformanceEvent.READY }
+            .maxOf { it.sequence }
+        val firstRelease = participantEntries.values
+            .flatten()
+            .filter { it.event == ConformanceEvent.RELEASED }
+            .minOf { it.sequence }
+        check(lastReady < firstRelease)
+        participantEntries.forEach { (alias, entries) ->
+            assertCleanupAfterFinally(alias, entries)
+        }
+    }
+
+    fun assertSingleScenarioOrder() {
+        val entries = events.filter {
+            it.requestAlias == ContextRequestAlias.SINGLE
+        }
+        val counts = entries.groupingBy { it.event }.eachCount()
+        listOf(
+            ConformanceEvent.TERMINAL_OBSERVED,
+            ConformanceEvent.FINALLY_COMPLETED,
+            ConformanceEvent.CLEANUP_PROBED,
+        ).forEach { event ->
+            check(counts[event] == 1) {
+                "Lifecycle event count mismatch: alias=SINGLE, event=$event"
+            }
+        }
+        check(counts[ConformanceEvent.READY] == null)
+        check(counts[ConformanceEvent.RELEASED] == null)
+        assertCleanupAfterFinally(ContextRequestAlias.SINGLE, entries)
+    }
+
+    private fun assertCleanupAfterFinally(
+        alias: ContextRequestAlias,
+        entries: List<ConformanceEventEntry>,
+    ) {
+        val finallySequence = entries.single {
+            it.event == ConformanceEvent.FINALLY_COMPLETED
+        }.sequence
+        val terminalSequence = entries.single {
+            it.event == ConformanceEvent.TERMINAL_OBSERVED
+        }.sequence
+        val cleanupSequence = entries.single {
+            it.event == ConformanceEvent.CLEANUP_PROBED
+        }.sequence
+        check(terminalSequence < cleanupSequence) {
+            "Lifecycle terminal cleanup order mismatch: alias=$alias"
+        }
+        check(finallySequence < cleanupSequence) {
+            "Lifecycle cleanup order mismatch: alias=$alias"
+        }
+    }
+}
+
+internal fun propagationExpectation(
+    boundary: ContextPropagationBoundary,
+    scenario: ContextPropagationScenario,
+    terminal: ContextPropagationTerminal,
+    requestAlias: ContextRequestAlias = ContextRequestAlias.SINGLE,
+): ContextPropagationExpectation =
+    ContextPropagationExpectation(
+        boundary = boundary,
+        scenario = scenario,
+        requestAlias = requestAlias,
+        markerExpectations = listOf(
+            ContextMarkerExpectation(ContextObservationPoint.BOUNDARY_ENTER, parentMarkerA),
+            ContextMarkerExpectation(ContextObservationPoint.AFTER_SUSPENSION, parentMarkerA),
+            ContextMarkerExpectation(ContextObservationPoint.BEFORE_TERMINAL, parentMarkerA),
+        ),
+        cleanupExpectations = listOf(
+            ContextCleanupExpectation(ContextProbeLocation.CALLER, null),
+            ContextCleanupExpectation(ContextProbeLocation.WORKER, null),
+        ),
+        expectedTerminal = terminal,
+    )
+
+internal fun ExecutorService.shutdownAndAssertTermination() {
+    var interrupted: InterruptedException? = null
+    var terminated = false
+    try {
+        shutdown()
+        terminated = awaitTermination(5, TimeUnit.SECONDS)
+    } catch (e: InterruptedException) {
+        interrupted = e
+    } finally {
+        if (!terminated) {
+            shutdownNow()
+        }
+    }
+
+    if (!terminated) {
+        terminated = try {
+            awaitTermination(5, TimeUnit.SECONDS)
+        } catch (e: InterruptedException) {
+            interrupted = interrupted ?: e
+            false
+        }
+    }
+    interrupted?.let {
+        Thread.currentThread().interrupt()
+        throw AssertionError("Interrupted while terminating test executor", it)
+    }
+    check(terminated) { "Test executor did not terminate" }
+}
+```
+
+- [ ] scenario helper는 gate를 `finally`에서 항상 release하고, resource를 `use`/`try-finally`로 닫는다.
+- [ ] interrupted teardown negative test를 추가해 `shutdownNow()` 실행과 interrupt status 복원을 고정한다.
+- [ ] adapter가 던진 원래 failure/cancellation/deadline signal은 test boundary에서만 포착한다. adapter block은 terminal을 snapshot return으로 바꾸어 삼키지 않는다.
+
+```kotlin
+internal class CapturedScenario(
+    val observation: ContextPropagationObservation,
+    val thrown: Throwable?,
+)
+
+internal inline fun <reified T: Throwable> CapturedScenario.assertThrownExactly() {
+    check(thrown?.javaClass == T::class.java) {
+        "Scenario terminal type mismatch; values redacted"
+    }
+}
+```
+
+- [ ] scenario harness signatures를 고정한다. 각 harness만 adapter가 던진 signal을 test boundary에서 포착하고, `execute*` adapter helper는 원 signal을 재전파한다.
+
+```kotlin
+internal suspend fun runCoroutineScenario(
+    scenario: ContextPropagationScenario,
+): CapturedScenario
+
+internal fun runReactorScenario(
+    scenario: ContextPropagationScenario,
+): CapturedScenario
+
+internal fun runExecutorScenario(
+    scenario: ContextPropagationScenario,
+): CapturedScenario
+```
+
+- [ ] `CapturedScenario`는 test-private harness다. shared public fixture에 throwable/framework type을 추가하지 않는다.
+- [ ] 이 task에서는 smoke test가 통과하는 최소 success path만 구현하며 Task 3–5가 terminal/isolation을 확장한다.
+
+- [ ] GREEN 명령은 Step 2.1과 동일하다.
+
+**Expected GREEN:** 3 smoke tests pass.
+
+## Task 3: 실제 coroutine 경계 5개 scenario 구현
+
+**Files:**
+
+- Modify: `infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationTestSupport.kt`
+- Modify: `infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt`
+- Reference: `infra/opentelemetry/src/main/kotlin/io/bluetape4k/opentelemetry/coroutines/ContextCoroutineSupport.kt`
+
+**Complexity:** L
+
+**Dependencies:** Task 2
+
+**Write scope:** 두 OTel test 파일
+
+### Step 3.1 — RED: failure/cancellation/deadline/isolation test 추가
+
+```kotlin
+@Test
+fun `coroutine failure propagates and restores context`() = runTest {
+    val captured = runCoroutineScenario(ContextPropagationScenario.FAILURE)
+    captured.assertThrownExactly<IllegalStateException>()
+    assertContextPropagationConformance(
+        captured.observation,
+        propagationExpectation(
+            ContextPropagationBoundary.COROUTINE,
+            ContextPropagationScenario.FAILURE,
+            ContextPropagationTerminal.FAILURE,
+        ),
+    )
+}
+
+@Test
+fun `coroutine cancellation propagates and restores context`() = runTest {
+    val captured = runCoroutineScenario(ContextPropagationScenario.CANCELLATION)
+    captured.assertThrownExactly<CancellationException>()
+    assertContextPropagationConformance(
+        captured.observation,
+        propagationExpectation(
+            ContextPropagationBoundary.COROUTINE,
+            ContextPropagationScenario.CANCELLATION,
+            ContextPropagationTerminal.CANCELLATION,
+        ),
+    )
+}
+
+@Test
+fun `coroutine deadline propagates and restores context`() = runTest {
+    val captured = runCoroutineScenario(ContextPropagationScenario.DEADLINE)
+    captured.assertThrownExactly<TimeoutCancellationException>()
+    assertContextPropagationConformance(
+        captured.observation,
+        propagationExpectation(
+            ContextPropagationBoundary.COROUTINE,
+            ContextPropagationScenario.DEADLINE,
+            ContextPropagationTerminal.DEADLINE_EXCEEDED,
+        ),
+    )
+}
+
+@Test
+fun `coroutine siblings keep isolated parent contexts`() = runTest {
+    val observation = runCoroutineIsolationScenario()
+    assertContextIsolation(observation, coroutineIsolationExpectation())
+}
+```
+
+**Expected RED:** success-only helper가 terminal/isolation scenario를 지원하지 않아 assertions fail 또는 helper symbol unresolved.
+
+### Step 3.2 — GREEN: 실제 `withOtelContext` 경계와 구조화된 cancellation 구현
+
+- [ ] `Executors.newSingleThreadExecutor()`와 `asCoroutineDispatcher()`로 만든 dedicated dispatcher를 test가 소유한다. outer `finally`에서 child cancel/join → dispatcher close → backing executor `shutdownAndAssertTermination()` 순서를 실행한다.
+- [ ] `withOtelContext(dispatcher, parent)`에서 enter/suspension 전후 값을 수집한다.
+- [ ] `yield()`는 suspension point일 뿐 ordering 수단으로 사용하지 않는다.
+- [ ] cancellation은 시작 gate 뒤 child cancel로 실제 `CancellationException`을 받고, deadline은 `withTimeout(semanticDeadline)` + `awaitCancellation()`으로 실제 `TimeoutCancellationException`을 받는다.
+- [ ] adapter operation은 두 signal을 catch하지 않는다. test boundary만 signal identity/type을 먼저 assertion하고 별도로 보존한 observation에 shared assertion을 실행한다.
+- [ ] A/B는 각각 child coroutine으로 실행하며 두 `CompletableDeferred<Unit>` gate를 교차 대기한다. `finally`에서 peer gate를 complete하고 child를 cancel/join한다.
+- [ ] 종료 후 caller와 같은 dispatcher의 unwrapped worker probe를 수집한다.
+- [ ] single scenario는 actual signal 관측, boundary `finally`, unwrapped probe 직후에 `ledger.record(SINGLE, TERMINAL_OBSERVED)`, `ledger.record(SINGLE, FINALLY_COMPLETED)`, `ledger.record(SINGLE, CLEANUP_PROBED)`를 정확히 한 번 호출하고 test가 `ledger.assertSingleScenarioOrder()`를 호출한다.
+- [ ] isolation participant A/B는 gate 도달, 양쪽 ready 확인 후 release, terminal 관측, child `finally`, own-worker probe 직후에 각 alias로 `ledger.record(alias, READY/RELEASED/TERMINAL_OBSERVED/FINALLY_COMPLETED/CLEANUP_PROBED)`를 정확히 한 번 호출하고 test가 `ledger.assertIsolationOrder()`를 호출한다.
+
+```kotlin
+private suspend fun observeCoroutineBody(
+    observations: MutableList<ContextMarkerObservation>,
+) {
+    observations += ContextMarkerObservation(
+        ContextObservationPoint.BOUNDARY_ENTER,
+        currentMarker(),
+    )
+    yield()
+    observations += ContextMarkerObservation(
+        ContextObservationPoint.AFTER_SUSPENSION,
+        currentMarker(),
+    )
+    observations += ContextMarkerObservation(
+        ContextObservationPoint.BEFORE_TERMINAL,
+        currentMarker(),
+    )
+}
+
+private suspend fun executeCoroutineTerminal(
+    scenario: ContextPropagationScenario,
+    observations: MutableList<ContextMarkerObservation>,
+): Unit =
+    withOtelContext(
+        coroutineContext = testDispatcher,
+        otelContext = otelContext(parentMarkerA),
+    ) {
+        observeCoroutineBody(observations)
+        when (scenario) {
+            ContextPropagationScenario.SUCCESS -> Unit
+            ContextPropagationScenario.FAILURE -> error("synthetic failure")
+            ContextPropagationScenario.CANCELLATION -> awaitCancellation()
+            ContextPropagationScenario.DEADLINE ->
+                withTimeout(semanticDeadline) { awaitCancellation() }
+            ContextPropagationScenario.ISOLATION ->
+                error("Isolation uses runCoroutineIsolationScenario")
+        }
+    }
+```
+
+- [ ] targeted 명령:
+
+```bash
+./gradlew :bluetape4k-opentelemetry:test \
+  --tests "io.bluetape4k.opentelemetry.context.ContextPropagationConformanceTest"
+```
+
+**Expected GREEN:** coroutine 5 cases와 기존 smoke cases pass.
+
+- [ ] Lore commit:
+
+```text
+Prove coroutine context restoration across every terminal path
+
+Constraint: Cancellation and deadline must remain distinct and rethrow through cleanup
+Rejected: Delay-based ordering | explicit gates make overlap and teardown deterministic
+Confidence: high
+Scope-risk: moderate
+Directive: Preserve structured child ownership and bounded dispatcher termination
+Tested: :bluetape4k-opentelemetry targeted conformance test
+Not-tested: Reactor and executor terminal matrices are added next
+```
+
+## Task 4: 실제 Reactor subscriber 경계 5개 scenario 구현
+
+**Files:**
+
+- Modify: `infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationTestSupport.kt`
+- Modify: `infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt`
+
+**Complexity:** L
+
+**Dependencies:** Task 3
+
+**Write scope:** 두 OTel test 파일
+
+### Step 4.1 — RED: Reactor terminal matrix와 A/B subscriber isolation 추가
+
+- [ ] success, `onError`, subscription `cancel`, Reactor `timeout`, A/B isolation test를 추가한다.
+- [ ] cancellation test는 subscriber가 `BOUNDARY_ENTER`를 관측한 뒤 `Disposable.dispose()`한다.
+- [ ] deadline test는 `Mono.never().timeout(semanticDeadline.toJavaDuration())`의 `TimeoutException`만 deadline으로 분류한다.
+
+```kotlin
+@Test
+fun `reactor cancellation propagates and restores context`() {
+    val captured = runReactorScenario(ContextPropagationScenario.CANCELLATION)
+    captured.thrown.shouldBeNull()
+    assertContextPropagationConformance(
+        captured.observation,
+        propagationExpectation(
+            ContextPropagationBoundary.REACTOR,
+            ContextPropagationScenario.CANCELLATION,
+            ContextPropagationTerminal.CANCELLATION,
+        ),
+    )
+}
+
+@Test
+fun `reactor subscribers keep isolated parent contexts`() {
+    assertContextIsolation(
+        runReactorIsolationScenario(),
+        reactorIsolationExpectation(),
+    )
+}
+```
+
+**Expected RED:** Reactor helper가 success만 지원해 terminal/isolation assertion 실패.
+
+### Step 4.2 — GREEN: subscriber-owned OTel context를 명시적으로 활성화
+
+- [ ] test-private Reactor key에 captured OTel `Context`를 넣는다.
+- [ ] `Mono.deferContextual`에서 해당 값을 읽고 callback을 `captured.wrap(...)`으로 실행한다.
+- [ ] `doFinally`에서 `SignalType.CANCEL`, `ON_ERROR`, `ON_COMPLETE`를 실제 terminal로 기록한다.
+- [ ] Reactor cancellation은 throwable을 발명하지 않는다. `CapturedScenario.thrown == null`과 실제 `SignalType.CANCEL`에서 만든 observation terminal을 함께 검증한다.
+- [ ] 단일 scenario는 test-owned `Schedulers.newSingle`에 `subscribeOn`하여 실제 worker 경계를 통과한다.
+- [ ] A/B isolation은 각각 별도 test-owned single scheduler를 사용한다. 각 publisher는 `Sinks.One<Unit>` ready signal을 먼저 emit하고 cached `Mono.when(readyA.asMono(), readyB.asMono())`를 non-blocking으로 기다린 뒤 두 번째 관측을 수행한다. 같은 single worker에서 blocking latch/barrier await를 금지한다.
+- [ ] cached shared gate 이후 각 participant는 `publishOn(ownScheduler)`로 자신의 rail에 다시 고정한 다음 두 번째 marker를 관측한다. test-owned scheduler name A/B를 gate 전후에 확인해 continuation이 peer scheduler에서 실행된 false isolation proof를 차단한다.
+- [ ] parent helper가 두 `Disposable`을 모두 소유한다. 첫 failure를 atomic holder에 보존하고 모든 completion wait에 `hangGuard`를 적용하며, outer `finally`에서 ready sink 종료 → 두 subscription dispose → bounded completion 확인 순서를 보장한다.
+- [ ] 각 subscriber 종료 후 자신이 사용한 같은 scheduler에 unwrapped context probe를 순차 제출한다.
+- [ ] 각 scheduler는 `disposeGracefully().block(hangGuard)` 뒤 `isDisposed`를 assertion한다.
+- [ ] single subscriber는 `doFinally` actual signal, subscriber finalizer, same-scheduler probe 뒤 `ledger.record(SINGLE, TERMINAL_OBSERVED/FINALLY_COMPLETED/CLEANUP_PROBED)`를 정확히 한 번 호출하고 `ledger.assertSingleScenarioOrder()`를 호출한다.
+- [ ] A/B subscriber는 ready sink emit, cached both-ready 완료 후 own-rail release, actual terminal, `doFinally`, same-rail probe 순서로 `ledger.record(alias, READY/RELEASED/TERMINAL_OBSERVED/FINALLY_COMPLETED/CLEANUP_PROBED)`를 호출하고 `ledger.assertIsolationOrder()`를 호출한다.
+
+```kotlin
+private const val reactorOtelContextKey = "bluetape4k.otel.context"
+
+private fun observedMono(
+    observations: MutableList<ContextMarkerObservation>,
+    testScheduler: Scheduler,
+): Mono<Unit> =
+    Mono.deferContextual { view ->
+        val captured = view.get<Context>(reactorOtelContextKey)
+        Mono.fromCallable(
+            captured.wrap(
+                Callable {
+                    observations += ContextMarkerObservation(
+                        ContextObservationPoint.BOUNDARY_ENTER,
+                        currentMarker(),
+                    )
+                    observations += ContextMarkerObservation(
+                        ContextObservationPoint.AFTER_SUSPENSION,
+                        currentMarker(),
+                    )
+                    observations += ContextMarkerObservation(
+                        ContextObservationPoint.BEFORE_TERMINAL,
+                        currentMarker(),
+                    )
+                    Unit
+                },
+            ),
+        )
+    }
+        .contextWrite { it.put(reactorOtelContextKey, otelContext(parentMarkerA)) }
+        .subscribeOn(testScheduler)
+
+private fun workerProbe(scheduler: Scheduler): String? =
+    Mono.fromCallable(::currentMarker)
+        .subscribeOn(scheduler)
+        .block(hangGuard.toJavaDuration())
+```
+
+```kotlin
+private fun afterSharedGate(
+    bothReady: Mono<Void>,
+    ownScheduler: Scheduler,
+    schedulerPrefix: String,
+    observe: () -> Unit,
+): Mono<Void> =
+    bothReady
+        .publishOn(ownScheduler)
+        .doOnSuccess {
+            check(Thread.currentThread().name.startsWith(schedulerPrefix))
+            observe()
+        }
+```
+
+- [ ] targeted 명령은 Task 3과 동일하다.
+
+**Expected GREEN:** coroutine 5 + Reactor 5 + executor success smoke pass.
+
+- [ ] Lore commit:
+
+```text
+Prove subscriber context without relying on global Reactor hooks
+
+Constraint: Reactor Context and OpenTelemetry current context are separate stores
+Rejected: Automatic global propagation hooks | they introduce JVM-wide order dependence
+Confidence: high
+Scope-risk: moderate
+Directive: Keep activation scoped to each subscriber callback
+Tested: :bluetape4k-opentelemetry targeted conformance test
+Not-tested: Executor terminal matrix remains
+```
+
+## Task 5: 실제 single-thread executor 경계 5개 scenario 구현
+
+**Files:**
+
+- Modify: `infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationTestSupport.kt`
+- Modify: `infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt`
+
+**Complexity:** L
+
+**Dependencies:** Task 4
+
+**Write scope:** 두 OTel test 파일
+
+### Step 5.1 — RED: running cancellation, `Future.get` deadline, same-worker isolation 추가
+
+- [ ] success, task exception, running `Future.cancel(true)`, `Future.getWithin(semanticDeadline)` timeout 뒤 cancel, same worker A/B를 검증한다.
+- [ ] cancellation/deadline은 `entered` gate 전에 cancel하지 않는다.
+- [ ] worker probe는 `finallyCompleted` gate 뒤에만 제출한다.
+
+```kotlin
+@Test
+fun `executor deadline cancels running work and restores worker context`() {
+    val captured = runExecutorScenario(ContextPropagationScenario.DEADLINE)
+    captured.assertThrownExactly<TimeoutException>()
+    assertContextPropagationConformance(
+        captured.observation,
+        propagationExpectation(
+            ContextPropagationBoundary.TASK_EXECUTOR,
+            ContextPropagationScenario.DEADLINE,
+            ContextPropagationTerminal.DEADLINE_EXCEEDED,
+        ),
+    )
+}
+
+@Test
+fun `executor reuses one worker without leaking request context`() {
+    assertContextIsolation(
+        runExecutorIsolationScenario(),
+        executorIsolationExpectation(),
+    )
+}
+```
+
+**Expected RED:** executor helper가 success-only라 terminal/isolation assertion 실패.
+
+### Step 5.2 — GREEN: submission-time `Context.wrap`와 finally handshake 구현
+
+```kotlin
+private fun submitWrapped(
+    executor: ExecutorService,
+    marker: String,
+    entered: CountDownLatch,
+    finallyCompleted: CountDownLatch,
+    body: () -> Unit,
+): Future<Unit> =
+    executor.submit(
+        otelContext(marker).wrap(
+            Callable {
+                try {
+                    entered.countDown()
+                    body()
+                    Unit
+                } finally {
+                    finallyCompleted.countDown()
+                }
+            },
+        ),
+    )
+```
+
+- [ ] 일반 예외는 `ExecutionException.cause`가 synthetic `IllegalStateException`인지 확인하고 `FAILURE`로 분류한다.
+- [ ] cancellation은 `entered.awaitOrFail(hangGuard)` 뒤 `future.cancel(true)`가 true인지 확인한다.
+- [ ] deadline은 `future.getWithin(semanticDeadline)`이 `TimeoutException`인지 확인한 뒤 cancel한다.
+- [ ] cancellation/deadline task body는 interrupt를 확인하고 `finally`로 빠져나온다. interrupt를 삼키지 않는다.
+- [ ] 모든 terminal에서 `finallyCompleted.awaitOrFail(hangGuard)`를 확인한다.
+- [ ] 동일 executor의 unwrapped `Callable(::currentMarker)` probe가 `null`인지 수집한다.
+- [ ] A task → unwrapped probe → B task → unwrapped probe 순서로 같은 worker를 재사용하고 각 task 내부에서 두 번 이상 marker를 관측한다.
+- [ ] outer `finally`에서 outstanding future cancel, gate release, `shutdownAndAssertTermination()`을 수행한다.
+- [ ] single task는 `Future` terminal 관측, task `finallyCompleted`, same-worker probe 순서로 `ledger.record(SINGLE, TERMINAL_OBSERVED/FINALLY_COMPLETED/CLEANUP_PROBED)`를 호출한 뒤 `ledger.assertSingleScenarioOrder()`를 호출한다.
+- [ ] A/B task는 entered/ready, 양쪽 ready 뒤 release, `Future` terminal, task `finally`, same-worker unwrapped probe마다 `ledger.record(alias, READY/RELEASED/TERMINAL_OBSERVED/FINALLY_COMPLETED/CLEANUP_PROBED)`를 호출하고 `ledger.assertIsolationOrder()`를 호출한다.
+
+- [ ] targeted 명령:
+
+```bash
+./gradlew :bluetape4k-opentelemetry:test \
+  --tests "io.bluetape4k.opentelemetry.context.ContextPropagationConformanceTest"
+```
+
+**Expected GREEN:** 정확히 또는 최소 15 OTel conformance cases pass.
+
+- [ ] Lore commit:
+
+```text
+Prove submission-time context capture and same-worker restoration
+
+Constraint: Cleanup probes must run only after the cancelled task completes finally
+Rejected: Probe immediately after Future.cancel | it races the scope restoration
+Confidence: high
+Scope-risk: moderate
+Directive: Keep entered-cancelled-finally handshakes explicit
+Tested: :bluetape4k-opentelemetry targeted conformance test
+Not-tested: Spring and Ktor adapters remain
+```
+
+## Task 6: Spring suspending observation adapter 5개 scenario 구현
+
+**Files:**
+
+- Create: `spring-boot/core/src/test/kotlin/io/bluetape4k/spring/observability/SpringContextPropagationConformanceTest.kt`
+- Reference: `spring-boot/core/src/main/kotlin/io/bluetape4k/spring/observability/SpringObservationSupport.kt`
+- Reference: `spring-boot/core/src/test/kotlin/io/bluetape4k/spring/observability/SpringObservationSupportTest.kt`
+
+**Complexity:** L
+
+**Dependencies:** Task 1
+
+**Write scope:** 새 Spring test 파일만
+
+### Step 6.1 — RED: 공통 assertion을 호출하는 5개 Spring test 추가
+
+- [ ] success, block exception, child cancellation, `withTimeout` deadline, A/B child isolation을 추가한다.
+- [ ] `TestObservationRegistry.create()`와 고정 synthetic observation name을 사용한다.
+- [ ] 각 test 종료 후 `registry.currentObservation == null`을 probe로 수집한다.
+- [ ] 이 파일의 private regular `CapturedScenario`가 observation과 원 throwable을 보존한다. OTel test-support type을 import하거나 public fixture를 확장하지 않는다.
+- [ ] `private suspend fun runSpringScenario(scenario: ContextPropagationScenario): CapturedScenario` signature를 사용한다.
+- [ ] OTel test-support와 동일한 alias-keyed event-ledger shape를 이 test 파일에 private regular class로 둔다. shared public fixture에는 lifecycle implementation type을 추가하지 않는다.
+
+```kotlin
+@Test
+fun `spring observation is visible across suspension and cleaned on success`() = runTest {
+    val captured = runSpringScenario(ContextPropagationScenario.SUCCESS)
+    captured.thrown.shouldBeNull()
+    assertContextPropagationConformance(
+        captured.observation,
+        springExpectation(
+            ContextPropagationScenario.SUCCESS,
+            ContextPropagationTerminal.SUCCESS,
+        ),
+    )
+}
+
+@Test
+fun `spring observations stay isolated between sibling coroutines`() = runTest {
+    assertContextIsolation(
+        runSpringIsolationScenario(),
+        springIsolationExpectation(),
+    )
+}
+```
+
+- [ ] RED 명령:
+
+```bash
+./gradlew :bluetape4k-spring-boot-core:test \
+  --tests "io.bluetape4k.spring.observability.SpringContextPropagationConformanceTest"
+```
+
+**Expected RED:** adapter helper unresolved reference로 test compilation 실패.
+
+### Step 6.2 — GREEN: 실제 `observeSpringSuspending` lifecycle 관측
+
+- [ ] setup 순서를 registry → observation marker → adapter call → suspension 관측 → terminal capture → caller/registry probe로 고정한다.
+- [ ] observation marker는 `Observation.currentObservation.name`에서 읽고 raw value를 failure message에 넣지 않는다.
+- [ ] cancellation은 started gate 뒤 child cancel/join으로 발생시킨다.
+- [ ] deadline은 `withTimeout(semanticDeadline) { awaitCancellation() }`을 adapter block 안에서 실행한다.
+- [ ] A/B는 각자 별도 registry와 marker를 사용하고 failure-aware `CompletableDeferred` barrier로 중첩한다. parent scope가 두 child를 소유하고 모든 await에 `hangGuard`를 적용하며 outer `finally`에서 peer gate complete/cancel → sibling cancel → 두 child join 순서를 보장한다.
+- [ ] `CancellationException`과 `TimeoutCancellationException`을 test boundary에서 구분한다. `observeSpringSuspending`와 adapter helper는 cleanup 후 원래 signal을 그대로 재전파한다.
+- [ ] single observation은 actual throwable/result 관측, `observeSpringSuspending` 종료 `finally`, registry cleanup probe 뒤 `ledger.record(SINGLE, TERMINAL_OBSERVED/FINALLY_COMPLETED/CLEANUP_PROBED)`를 호출하고 `ledger.assertSingleScenarioOrder()`를 호출한다.
+- [ ] A/B child는 ready, 양쪽 ready 뒤 release, terminal, child `finally`, 각 registry cleanup probe마다 `ledger.record(alias, READY/RELEASED/TERMINAL_OBSERVED/FINALLY_COMPLETED/CLEANUP_PROBED)`를 호출하고 `ledger.assertIsolationOrder()`를 호출한다.
+
+```kotlin
+private fun ObservationRegistry.currentMarker(): String? =
+    currentObservation?.context?.name
+
+private suspend fun ObservationRegistry.observeMarkers(
+    marker: String,
+    observations: MutableList<ContextMarkerObservation>,
+    terminalAction: suspend () -> Unit,
+) {
+    observeSpringSuspending(
+        name = marker,
+    ) {
+        observations += ContextMarkerObservation(
+            ContextObservationPoint.BOUNDARY_ENTER,
+            currentMarker(),
+        )
+        yield()
+        observations += ContextMarkerObservation(
+            ContextObservationPoint.AFTER_SUSPENSION,
+            currentMarker(),
+        )
+        observations += ContextMarkerObservation(
+            ContextObservationPoint.BEFORE_TERMINAL,
+            currentMarker(),
+        )
+        terminalAction()
+    }
+}
+```
+
+- [ ] GREEN 명령은 Step 6.1과 동일하다.
+
+**Expected GREEN:** 최소 5 Spring conformance cases pass.
+
+- [ ] Lore commit:
+
+```text
+Bind Spring observation lifecycle to the shared propagation contract
+
+Constraint: The adapter must exercise observeSpringSuspending rather than a test-only scope
+Rejected: Shared Spring-specific fixture | framework interception belongs in its module
+Confidence: high
+Scope-risk: moderate
+Directive: Keep registry cleanup checks on every terminal path
+Tested: :bluetape4k-spring-boot-core targeted conformance test
+Not-tested: Ktor request adapter remains
+```
+
+## Task 7: Ktor W3C request adapter 5개 scenario 구현
+
+**Files:**
+
+- Create: `ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/KtorContextPropagationConformanceTest.kt`
+- Reference: `ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/KtorOpenTelemetryTracingSupport.kt`
+- Reference: `ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservabilityTest.kt`
+
+**Complexity:** XL
+
+**Dependencies:** Task 1
+
+**Write scope:** 새 Ktor test 파일만
+
+### Step 7.1 — RED: in-process request matrix와 A/B/probe isolation 추가
+
+- [ ] success, handler exception, request coroutine cancel, route `withTimeout`, concurrent A/B + unparented probe를 추가한다.
+- [ ] caller가 observation에서 얻은 marker로 expectation을 역생성하지 않는다. A/B trace ID는 사전 고정한 synthetic 값이다.
+- [ ] 이 파일의 private regular `CapturedScenario`가 observation과 원 throwable을 보존한다. OTel/Spring test-private type을 공유하지 않는다.
+- [ ] `private suspend fun ApplicationTestBuilder.runKtorScenario(tracing: TestTracing, scenario: ContextPropagationScenario): CapturedScenario` signature를 사용해 `testApplication`의 in-process `client`에 접근한다.
+- [ ] isolation helper도 `private suspend fun ApplicationTestBuilder.runKtorIsolationScenario(tracing: TestTracing): ContextIsolationObservation` receiver extension으로 고정한다. 일반 멤버 함수가 DSL receiver를 암묵적으로 상속한다고 가정하지 않는다.
+- [ ] 동일한 alias-keyed event-ledger shape를 이 test 파일에 private regular class로 둔다. 다른 module의 test-private type을 import하지 않는다.
+
+```kotlin
+@Test
+fun `ktor extracts synthetic W3C parent and cleans request on success`() =
+    TestTracing().use { fixture ->
+        testApplication {
+            application {
+                installBluetape4kKtorOpenTelemetryTracing(
+                    KtorOpenTelemetryTracingConfig(
+                        openTelemetry = fixture.openTelemetry,
+                    ),
+                )
+                contextRoutes()
+            }
+            val captured =
+                runKtorScenario(fixture, ContextPropagationScenario.SUCCESS)
+            captured.thrown.shouldBeNull()
+            assertContextPropagationConformance(
+                captured.observation,
+                ktorExpectation(
+                    ContextPropagationScenario.SUCCESS,
+                    ContextPropagationTerminal.SUCCESS,
+                ),
+            )
+        }
+    }
+
+@Test
+fun `ktor concurrent parents and unparented probe stay isolated`() =
+    TestTracing().use { fixture ->
+        testApplication {
+            application {
+                installBluetape4kKtorOpenTelemetryTracing(
+                    KtorOpenTelemetryTracingConfig(
+                        openTelemetry = fixture.openTelemetry,
+                    ),
+                )
+                contextRoutes()
+            }
+            assertContextIsolation(
+                runKtorIsolationScenario(fixture),
+                ktorIsolationExpectation(),
+            )
+        }
+    }
+```
+
+- [ ] RED 명령:
+
+```bash
+./gradlew :bluetape4k-ktor-observability:test \
+  --tests "io.bluetape4k.ktor.observability.KtorContextPropagationConformanceTest"
+```
+
+**Expected RED:** Ktor test adapter/fixture unresolved reference로 compilation 실패.
+
+### Step 7.2 — GREEN: local SDK + W3C propagator + deterministic route 구현
+
+- [ ] `OpenTelemetrySdk`에 `W3CTraceContextPropagator.getInstance()`를 명시적으로 등록한다.
+- [ ] fixed valid trace/span ID A/B로 `SpanContext.create(...)`와 `Span.wrap(...)`을 만든다.
+- [ ] text-map propagator가 mutable map에 header를 inject하고 Ktor client request가 이를 전송한다.
+- [ ] handler는 `Span.current().spanContext.traceId`를 세 point에서 관측한다.
+- [ ] concurrent A/B request는 channel/deferred barrier로 실제 overlap시키고 route `finally`에서 peer를 해제한다.
+- [ ] parent test scope가 두 client request job을 소유한다. 모든 gate wait는 `hangGuard`로 감싸고 첫 failure를 보존하며 outer `finally`에서 peer gate release → 두 request cancel → 두 job join 순서를 보장한다.
+- [ ] unparented probe request의 current trace ID가 non-null이고 A/B forbidden list에 없음을 `NOT_IN`으로 검증한다.
+- [ ] request cancellation은 handler가 started gate를 연 뒤 자신의 `coroutineContext.job`을 synthetic `CancellationException`으로 cancel하고 다음 suspension에서 실제 signal을 받게 한다. parent는 client request job을 bounded join한다. route deadline은 250ms `withTimeout`이 실제로 발생해야 한다.
+- [ ] local SDK/provider/exporter는 `AutoCloseable` fixture가 bounded provider shutdown을 검증하며 닫는다. `SimpleSpanProcessor`는 synchronous export이므로 중복 `forceFlush`를 수행하지 않는다.
+- [ ] `SdkTracerProvider.shutdown()`이 owned span processor/exporter teardown의 authoritative bounded result다. 이후 `OpenTelemetrySdk.close()`로 같은 provider를 중복 shutdown하지 않는다.
+- [ ] ownership은 outer `TestTracing().use { testApplication { ... } }`로 고정한다. request completion/cancel → `testApplication` application teardown → provider shutdown 순서를 바꾸지 않는다.
+- [ ] single request는 response/throwable terminal 관측, route `finally`, request-completion probe 뒤 `ledger.record(SINGLE, TERMINAL_OBSERVED/FINALLY_COMPLETED/CLEANUP_PROBED)`를 호출하고 `ledger.assertSingleScenarioOrder()`를 호출한다.
+- [ ] A/B request는 handler ready, 양쪽 ready 뒤 release, client terminal, route `finally`, 각 request completion마다 `ledger.record(alias, READY/RELEASED/TERMINAL_OBSERVED/FINALLY_COMPLETED/CLEANUP_PROBED)`를 호출하고 `ledger.assertIsolationOrder()`를 호출한다. unparented `PROBE` request는 isolation sample에는 포함하지만 A/B lifecycle count에는 섞지 않는다.
+
+```kotlin
+private const val traceIdA = "11111111111111111111111111111111"
+private const val spanIdA = "1111111111111111"
+private const val traceIdB = "22222222222222222222222222222222"
+private const val spanIdB = "2222222222222222"
+
+private class TestTracing : AutoCloseable {
+    val spanExporter: InMemorySpanExporter = InMemorySpanExporter.create()
+    private val tracerProvider: SdkTracerProvider =
+        SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+            .build()
+
+    val openTelemetry: OpenTelemetrySdk =
+        OpenTelemetrySdk.builder()
+            .setTracerProvider(tracerProvider)
+            .setPropagators(
+                ContextPropagators.create(W3CTraceContextPropagator.getInstance()),
+            )
+            .build()
+
+    fun headers(traceId: String, spanId: String): Map<String, String> {
+        val carrier = mutableMapOf<String, String>()
+        val parent = Span.wrap(
+            SpanContext.create(
+                traceId,
+                spanId,
+                TraceFlags.getSampled(),
+                TraceState.getDefault(),
+            ),
+        )
+        openTelemetry.propagators.textMapPropagator.inject(
+            Context.root().with(parent),
+            carrier,
+        ) { target, key, value ->
+            target?.set(key, value)
+        }
+        return carrier
+    }
+
+    override fun close() {
+        check(
+            tracerProvider.shutdown()
+                .join(5, TimeUnit.SECONDS)
+                .isSuccess,
+        ) {
+            "Test tracer provider shutdown failed"
+        }
+    }
+}
+```
+
+```kotlin
+private fun Application.contextRoutes() {
+    routing {
+        get("/context/{scenario}") {
+            val scenario = ContextPropagationScenario.valueOf(
+                requireNotNull(call.parameters["scenario"]),
+            )
+            val traceId = Span.current().spanContext.traceId
+            record(
+                scenario,
+                ContextObservationPoint.BOUNDARY_ENTER,
+                traceId,
+            )
+            yield()
+            record(
+                scenario,
+                ContextObservationPoint.AFTER_SUSPENSION,
+                Span.current().spanContext.traceId,
+            )
+            record(
+                scenario,
+                ContextObservationPoint.BEFORE_TERMINAL,
+                Span.current().spanContext.traceId,
+            )
+            when (scenario) {
+                ContextPropagationScenario.SUCCESS -> call.respond(HttpStatusCode.OK)
+                ContextPropagationScenario.FAILURE -> error("synthetic handler failure")
+                ContextPropagationScenario.CANCELLATION -> {
+                    coroutineContext.job.cancel(
+                        CancellationException("synthetic request cancellation"),
+                    )
+                    yield()
+                }
+                ContextPropagationScenario.DEADLINE ->
+                    withTimeout(semanticDeadline) { awaitCancellation() }
+                ContextPropagationScenario.ISOLATION -> runIsolationBarrier(call)
+            }
+        }
+    }
+}
+```
+
+- [ ] GREEN 명령은 Step 7.1과 동일하다.
+
+**Expected GREEN:** 최소 5 Ktor conformance cases pass, 외부 port/process 없음.
+
+- [ ] Lore commit:
+
+```text
+Prove request-scoped W3C parent extraction without external telemetry
+
+Constraint: Request isolation must use fixed expectations and an unparented probe
+Rejected: Global OpenTelemetry registration | local SDK ownership prevents suite pollution
+Confidence: high
+Scope-risk: moderate
+Directive: Keep A B overlap failure-aware and close every local SDK
+Tested: :bluetape4k-ktor-observability targeted conformance test
+Not-tested: Full four-module and detekt validation remain
+```
+
+## Task 8: bilingual docs, full validation, review, delivery
+
+**Files:**
+
+- Modify: `testing/junit5/README.md`
+- Modify: `testing/junit5/README.ko.md`
+- Create: `docs/lessons/2026-07-28-issue-1051-context-propagation-conformance.md`
+- Review: all files changed since `origin/develop`
+
+**Complexity:** M
+
+**Dependencies:** Tasks 1–7
+
+**Write scope:** README pair, lesson, review fixes in already-touched files
+
+### Step 8.1 — docs-first/API example verification
+
+- [ ] README pair에 동일한 구조로 다음을 기록한다.
+  - provider-neutral fixture의 목적
+  - propagation과 isolation minimal example
+  - `null` root, terminal 구분, raw marker redaction
+  - test-owned synthetic marker만 허용하고 production request ID, user data, external trace ID를 금지
+  - `Serializable` snapshot은 persistence/wire contract가 아니며 장기 저장 금지
+  - enum value 추가는 additive이므로 caller exhaustive `when`에는 `else` 사용
+  - data-class constructor 변경은 compatibility-sensitive이므로 구조분해/저장 포맷 의존 금지
+  - adapter가 실제 framework context를 snapshot으로 변환해야 한다는 책임
+- [ ] 예제는 실제 package/import/function 이름만 사용한다. Task 1 self-test의 `README propagation example compiles`와 `README isolation example compiles`가 같은 object construction과 assertion 호출을 compile/run하며, README pair는 그 검증된 snippet을 그대로 복사한다.
+
+```kotlin
+import io.bluetape4k.junit5.observability.*
+
+val marker = "synthetic-parent"
+val observation = ContextPropagationObservation(
+    boundary = ContextPropagationBoundary.COROUTINE,
+    scenario = ContextPropagationScenario.SUCCESS,
+    requestAlias = ContextRequestAlias.SINGLE,
+    markerObservations = listOf(
+        ContextMarkerObservation(
+            ContextObservationPoint.BOUNDARY_ENTER,
+            marker,
+        ),
+        ContextMarkerObservation(
+            ContextObservationPoint.AFTER_SUSPENSION,
+            marker,
+        ),
+        ContextMarkerObservation(
+            ContextObservationPoint.BEFORE_TERMINAL,
+            marker,
+        ),
+    ),
+    cleanupProbes = listOf(
+        ContextCleanupProbe(ContextProbeLocation.CALLER, null),
+    ),
+    terminal = ContextPropagationTerminal.SUCCESS,
+)
+val expectation = ContextPropagationExpectation(
+    boundary = ContextPropagationBoundary.COROUTINE,
+    scenario = ContextPropagationScenario.SUCCESS,
+    requestAlias = ContextRequestAlias.SINGLE,
+    markerExpectations = listOf(
+        ContextMarkerExpectation(
+            ContextObservationPoint.BOUNDARY_ENTER,
+            marker,
+        ),
+        ContextMarkerExpectation(
+            ContextObservationPoint.AFTER_SUSPENSION,
+            marker,
+        ),
+        ContextMarkerExpectation(
+            ContextObservationPoint.BEFORE_TERMINAL,
+            marker,
+        ),
+    ),
+    cleanupExpectations = listOf(
+        ContextCleanupExpectation(ContextProbeLocation.CALLER, null),
+    ),
+    expectedTerminal = ContextPropagationTerminal.SUCCESS,
+)
+
+assertContextPropagationConformance(observation, expectation)
+```
+
+```kotlin
+import io.bluetape4k.junit5.observability.*
+
+val isolationObservation = ContextIsolationObservation(
+    boundary = ContextPropagationBoundary.KTOR_REQUEST,
+    samples = listOf(
+        ContextIsolationSample(
+            ContextRequestAlias.REQUEST_A,
+            listOf("synthetic-parent-A", "synthetic-parent-A"),
+        ),
+        ContextIsolationSample(
+            ContextRequestAlias.REQUEST_B,
+            listOf("synthetic-parent-B", "synthetic-parent-B"),
+        ),
+        ContextIsolationSample(
+            ContextRequestAlias.PROBE,
+            listOf("synthetic-probe"),
+        ),
+    ),
+    cleanupProbes = listOf(
+        ContextCleanupProbe(ContextProbeLocation.REQUEST, null),
+    ),
+)
+val isolationExpectation = ContextIsolationExpectation(
+    boundary = ContextPropagationBoundary.KTOR_REQUEST,
+    samples = listOf(
+        ContextIsolationSampleExpectation(
+            requestAlias = ContextRequestAlias.REQUEST_A,
+            mode = ContextMarkerExpectationMode.EXACT,
+            expectedMarker = "synthetic-parent-A",
+            minimumObservationCount = 2,
+        ),
+        ContextIsolationSampleExpectation(
+            requestAlias = ContextRequestAlias.REQUEST_B,
+            mode = ContextMarkerExpectationMode.EXACT,
+            expectedMarker = "synthetic-parent-B",
+            minimumObservationCount = 2,
+        ),
+        ContextIsolationSampleExpectation(
+            requestAlias = ContextRequestAlias.PROBE,
+            mode = ContextMarkerExpectationMode.NOT_IN,
+            forbiddenMarkers = listOf(
+                "synthetic-parent-A",
+                "synthetic-parent-B",
+            ),
+        ),
+    ),
+    cleanupExpectations = listOf(
+        ContextCleanupExpectation(ContextProbeLocation.REQUEST, null),
+    ),
+)
+
+assertContextIsolation(isolationObservation, isolationExpectation)
+```
+
+- [ ] lesson은 한국어로 문제, 선택한 shared boundary, cancellation/deadline 구분, deterministic barrier, production 비변경, 검증 evidence를 기록한다.
+
+### Step 8.2 — 전체 validation
+
+- [ ] 각 module suite를 순차 실행한다. Testcontainers-backed 작업과 병렬 실행하지 않는다.
+
+```bash
+/usr/bin/time -p ./gradlew :bluetape4k-junit5:test
+/usr/bin/time -p ./gradlew :bluetape4k-opentelemetry:test
+/usr/bin/time -p ./gradlew :bluetape4k-spring-boot-core:test
+/usr/bin/time -p ./gradlew :bluetape4k-ktor-observability:test
+/usr/bin/time -p ./gradlew detekt
+git diff --check
+```
+
+**Expected GREEN:** 네 module full suite의 event-ledger partial-order assertions, detekt success, whitespace error 없음.
+
+- [ ] `/usr/bin/time -p`의 네 full module suite elapsed time을 lesson evidence에 기록한다. targeted 명령은 구현 중 RED/GREEN feedback에만 사용하고 최종 evidence로 full suite와 중복 요구하지 않는다.
+- [ ] `repo-diff`로 production/build/module-registration 변경이 없음을 확인한다.
+- [ ] fresh full-suite JUnit XML에서 최소 case 수와 단일 case runtime을 executable gate로 확인한다. XML이 없거나 어느 conformance case가 7.5초 이상이면 실패한다.
+  - shared fixture ≥10
+  - OTel ≥15
+  - Spring ≥5
+  - Ktor ≥5
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+from xml.etree import ElementTree
+
+expected = {
+    "testing/junit5/build/test-results/test": (
+        "ContextPropagationConformanceTest",
+        10,
+    ),
+    "infra/opentelemetry/build/test-results/test": (
+        "ContextPropagationConformanceTest",
+        15,
+    ),
+    "spring-boot/core/build/test-results/test": (
+        "SpringContextPropagationConformanceTest",
+        5,
+    ),
+    "ktor/observability/build/test-results/test": (
+        "KtorContextPropagationConformanceTest",
+        5,
+    ),
+}
+for directory, (class_name, minimum) in expected.items():
+    reports = sorted(Path(directory).glob(f"TEST-*{class_name}*.xml"))
+    if not reports:
+        raise SystemExit(f"missing JUnit XML for {directory}/{class_name}")
+    count = sum(
+        int(ElementTree.parse(path).getroot().attrib["tests"])
+        for path in reports
+    )
+    if count < minimum:
+        raise SystemExit(
+            f"insufficient cases for {directory}/{class_name}: {count} < {minimum}"
+        )
+    durations = [
+        float(case.attrib.get("time", "0"))
+        for path in reports
+        for case in ElementTree.parse(path).getroot().iter("testcase")
+    ]
+    slowest = max(durations, default=0.0)
+    if slowest >= 7.5:
+        raise SystemExit(
+            f"slow conformance case for {directory}/{class_name}: {slowest}s"
+        )
+    print(
+        f"{directory}/{class_name}: {count} >= {minimum}, "
+        f"slowest={slowest:.3f}s < 7.5s"
+    )
+PY
+```
+
+- [ ] touched files에서 global telemetry/context mutation과 raw output API를 사용하지 않았음을 실패형 grep으로 확인한다.
+
+```bash
+if rg -n \
+  "GlobalOpenTelemetry\\.(set|resetForTest)|Hooks\\.|enableAutomaticContextPropagation|println\\(|printStackTrace\\(" \
+  testing/junit5/src/main/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformance.kt \
+  testing/junit5/src/test/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformanceTest.kt \
+  infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context \
+  spring-boot/core/src/test/kotlin/io/bluetape4k/spring/observability/SpringContextPropagationConformanceTest.kt \
+  ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/KtorContextPropagationConformanceTest.kt; then
+  exit 1
+fi
+```
+
+**Expected GREEN:** grep output 없음, exit 0.
+
+- [ ] README English/Korean parity를 executable gate로 확인한다.
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+
+english = Path("testing/junit5/README.md").read_text()
+korean = Path("testing/junit5/README.ko.md").read_text()
+symbols = [
+    "ContextPropagationObservation",
+    "ContextPropagationExpectation",
+    "ContextIsolationObservation",
+    "ContextIsolationExpectation",
+    "assertContextPropagationConformance",
+    "assertContextIsolation",
+    "ContextMarkerExpectationMode.EXACT",
+    "ContextMarkerExpectationMode.NOT_IN",
+]
+for symbol in symbols:
+    if symbol not in english or symbol not in korean:
+        raise SystemExit(f"README parity missing symbol: {symbol}")
+if english.count("```kotlin") < 2 or korean.count("```kotlin") < 2:
+    raise SystemExit("README parity requires propagation and isolation examples")
+required = {
+    "English": (
+        english,
+        ["synthetic marker", "values redacted", "Serializable", "exhaustive when"],
+    ),
+    "Korean": (
+        korean,
+        ["synthetic marker", "값 비공개", "Serializable", "exhaustive when"],
+    ),
+}
+for label, (text, phrases) in required.items():
+    missing = [phrase for phrase in phrases if phrase not in text]
+    if missing:
+        raise SystemExit(f"{label} README parity missing: {missing}")
+print("README EN/KO context propagation parity verified")
+PY
+```
+
+- [ ] parity script와 두 compile-tested README example self-test가 모두 green이어야 docs gate를 통과한다.
+- [ ] current-session pre-PR six-tier review를 실행하고 P0/P1=0으로 수렴한다.
+- [ ] review finding이 production code/dependency 변경을 요구하면 구현을 멈추고 spec을 다시 연다.
+
+### Step 8.3 — 최종 Lore commit
+
+```text
+Document the reusable context propagation proof boundary
+
+Constraint: Public examples must remain framework-neutral and bilingual
+Rejected: Per-adapter duplicated guidance | it would drift from the shared contract
+Confidence: high
+Scope-risk: narrow
+Directive: Keep docs synchronized when the fixture surface changes
+Tested: Four module suites, detekt, git diff --check
+Not-tested: No external collector or server is in scope
+```
+
+### Step 8.4 — PR metadata와 stop condition
+
+- [ ] branch push 전 `git status`, `git log origin/develop..HEAD`, `repo-diff` 확인
+- [ ] issue #1051과 PR assignee를 `debop`으로 설정
+- [ ] issue milestone `1.12.0`과 labels를 PR에 복사
+- [ ] PR body 마지막 Markdown `##` section을 `## DoD Status`로 작성
+- [ ] exact local HEAD와 live PR head OID가 일치하는지 확인하고 metadata/body를 직접 검증한다.
+
+```bash
+HEAD_OID="$(git rev-parse HEAD)"
+PR_NUMBER="$(gh pr view --json number --jq '.number')"
+PR_OID="$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid')"
+test "$HEAD_OID" = "$PR_OID"
+gh issue view 1051 --json assignees,milestone,labels,state
+gh pr view "$PR_NUMBER" \
+  --json body,assignees,milestone,labels,headRefOid,reviewDecision
+test "$(gh pr view "$PR_NUMBER" --json body --jq '.body' | \
+  rg '^## ' | tail -n 1)" = "## DoD Status"
+```
+
+- [ ] required checks와 unresolved review thread를 exact head에서 조회한다.
+
+```bash
+gh pr checks "$PR_NUMBER" --required
+test "$(gh pr view "$PR_NUMBER" --json reviewDecision --jq '.reviewDecision')" != "CHANGES_REQUESTED"
+test "$(
+  gh api graphql \
+    -F owner=bluetape4k \
+    -F name=bluetape4k-projects \
+    -F number="$PR_NUMBER" \
+    -f query='
+      query($owner: String!, $name: String!, $number: Int!) {
+        repository(owner: $owner, name: $name) {
+          pullRequest(number: $number) {
+            reviewThreads(first: 100) {
+              nodes { isResolved }
+            }
+          }
+        }
+      }' \
+    --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'
+)" = "0"
+test "$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid')" = "$HEAD_OID"
+```
+
+- [ ] merge-ready 보고 직전에 위 OID/check/review-thread 명령을 다시 실행해 stale green을 배제한다.
+- [ ] merge는 별도 사용자 승인 전 실행하지 않음
+
+## Step 3-R Plan Review
+
+| Perspective | Initial blockers | Incorporated repairs | Final |
+|---|---:|---|---:|
+| Performance | P1 2, P2 2 | Reactor own-rail `publishOn`, bounded provider shutdown, repeated stress 제거 | P0 0, P1 0 |
+| Stability | P1 3, P2 3 | terminal signal 보존, failure-aware barrier, alias-keyed event ledger, bounded cleanup/XML gate | P0 0, P1 0 |
+| Security | P1 2, P2 3 | interruption-safe teardown, privacy KDoc, uniform redaction, global-state/output grep | P0 0, P1 0 |
+| Operations | P1 4, P2 1 | false-green 반복 제거, structural ordering evidence, XML duration, exact-head delivery gates | P0 0, P1 0 |
+| Developer/API | P1 6, P2 2 | private captured-result contracts, Java `Duration` helpers, exact Spring/Ktor APIs와 `ApplicationTestBuilder` receiver | P0 0, P1 0 |
+| User/caller | P1 4, P2 2 | complete bilingual examples, public KDoc ledger, safe diagnostics, parity/compatibility gates | P0 0, P1 0 |
+
+- [x] Six independent review perspectives converged with P0=0 and P1=0.
+- [x] Open user questions: none.
+- [x] P2 findings were either incorporated into executable gates or retained as implementation review checks; P2 does not block the Type A implementation gate.
+- [x] Existing test classpath was verified without build changes: Reactor Core 3.8.6, kotlinx-coroutines-reactor 1.11.0, OpenTelemetry SDK 1.63.0, and the repository JUnit 5 project dependency are already available.
+- [x] Plan integrity checks: `git diff --check`, even code-fence count, exact Task 1–8 structure, required public-surface names, and stale-pattern negative grep.
+- [x] The final plan SHA-256 is computed after this document stops changing and recorded in the external approval handoff rather than embedded in this self-hashing document.
+
+## 위험과 완화
+
+| 위험 | 완화 | stop/reopen 조건 |
+|---|---|---|
+| fixture가 framework type에 결합 | public API import audit | OTel/Reactor/Spring/Ktor type이 main fixture에 들어가면 재설계 |
+| cancellation을 failure로 오분류 | terminal별 negative self-test | production adapter 변경 없이는 구분 불가하면 spec reopen |
+| cancellation 후 worker probe race | `finallyCompleted` handshake | handshake 없이만 검증 가능하면 중단 |
+| Reactor/Ktor global state 오염 | local scheduler/SDK와 no-global grep | global setter/hook 필요 시 중단 |
+| concurrent test hang | failure-aware barrier, 5초/15초 guard | bounded teardown 증명 실패 시 해당 adapter 미완료 |
+| raw marker 노출 | CR/LF canary와 관계형 message | redaction 없이 디버깅 불가하다는 요구가 생기면 spec reopen |
+| dependency 부족 | 기존 test classpath에서 compile 확인 | build script 변경 필요 시 spec reopen |
+
+## 롤백
+
+- shared fixture API가 adapter evidence를 표현하지 못하면 소비 adapter 구현을 되돌리고 Task 1의 provider-neutral fixture commit만 유지한 채 spec을 다시 연다.
+- 특정 framework adapter가 기존 public API 수정 없이는 계약을 만족하지 못하면 해당 adapter commit만 되돌리고 production defect를 별도 issue로 분리한다.
+- flaky/hang이 발생하면 timeout을 늘리지 않는다. gate와 lifecycle ownership을 수정하고 결정성을 증명할 수 없으면 해당 scenario를 미완료로 남긴다.
+- PR 전 rollback은 task별 commit revert로 수행한다. push/PR 이후 merge는 별도 승인 없이는 하지 않는다.
+
+## 계획 완료 기준
+
+- 모든 acceptance criterion이 Task 1–8에 매핑됨
+- public API와 exact files가 승인된 spec과 일치
+- 각 task에 RED/GREEN 명령과 예상 결과가 있음
+- production/build/dependency 변경이 없음
+- cancellation/deadline/resource lifecycle이 별도로 검증됨
+- 계획 6개 관점 검토에서 P0/P1=0
+- 사용자가 계획을 승인한 뒤에만 Task 1 구현 시작

--- a/docs/superpowers/specs/2026-07-28-issue-1051-context-propagation-conformance-design.md
+++ b/docs/superpowers/specs/2026-07-28-issue-1051-context-propagation-conformance-design.md
@@ -1,0 +1,397 @@
+# Issue #1051 Coroutine/Reactive Context Propagation Conformance 설계
+
+- Date: 2026-07-28
+- Repository: `bluetape4k/bluetape4k-projects`
+- Issue: [#1051](https://github.com/bluetape4k/bluetape4k-projects/issues/1051)
+- Parent: [#1049](https://github.com/bluetape4k/bluetape4k-projects/issues/1049)
+- Milestone: `1.12.0`
+
+## 1. 문제
+
+서버 요청은 coroutine suspension, Reactor subscriber, task executor 같은 비동기 경계를 통과한다. 각 통합 모듈에는 개별 전파 테스트가 있지만, 다음 계약을 동일한 의미와 실패 메시지로 검증하는 공통 conformance fixture가 없다.
+
+- 명시한 parent context가 비동기 작업 내부에서 활성화된다.
+- 작업이 성공, 예외, 취소로 끝난 뒤 호출자와 worker의 이전 context가 복원된다.
+- 동시에 실행되거나 동일 worker를 재사용하는 독립 요청이 서로의 context를 관찰하지 않는다.
+- Spring Boot와 Ktor 어댑터가 같은 의미 계약을 검증한다.
+
+이 공백 때문에 각 프레임워크 테스트가 서로 다른 조건을 검증하거나, 전파 성공만 확인하고 cleanup/leakage 회귀를 놓칠 수 있다.
+
+## 2. 현재 코드 근거
+
+### 2.1 OpenTelemetry coroutine
+
+`infra/opentelemetry`의 `withOtelContext`는 `Context.asContextElement()`를 coroutine context에 결합한다.
+
+- `ContextCoroutineSupport.kt`
+- `CoroutineSupportTest.kt`
+
+기존 테스트는 명시한 OTel context가 coroutine 내부에 보이는지 확인하지만, 성공·예외·취소 종료 후 복원과 동일 worker 재사용을 하나의 공통 의미 계약으로 묶지 않는다.
+
+### 2.2 Spring Boot observation
+
+`spring-boot/core`의 `observeSpringSuspending`은 다음 두 bridge를 함께 사용한다.
+
+- `ObservationThreadLocalAccessor.KEY`를 담은 Reactor `Context`
+- `Observation.openScope()`를 열고 닫는 `ThreadContextElement`
+
+기존 `SpringObservationSupportTest`는 observation lifecycle과 일부 cancellation cleanup을 검증한다. 하지만 Reactor/coroutine/executor 경계를 공통 snapshot으로 표현하거나 Ktor와 같은 assertion을 실행하지 않는다.
+
+### 2.3 Ktor OpenTelemetry
+
+`ktor/observability`는 `testApplication`과 in-memory OpenTelemetry SDK/exporter로 server span을 검증한다. 기존 `Bluetape4kKtorObservabilityTest`는 성공·오류·취소 HTTP 동작을 다루지만, handler 내부 parent visibility와 독립 요청 간 context isolation을 공통 fixture로 검증하지 않는다.
+
+### 2.4 재사용 가능한 fixture 선례
+
+`testing/junit5`의 `HttpOperationObservabilityConformance.kt`는 provider-neutral snapshot과 assertion만 공유하고, Spring/Ktor가 자신의 관측 결과를 snapshot으로 변환한다. Issue #1051도 같은 경계를 따른다.
+
+## 3. 목표
+
+1. `testing/junit5`에 provider-neutral context propagation snapshot과 assertion을 제공한다.
+2. coroutine, Reactor, task executor 경계에 대해 동일한 전파·종료·복원 의미를 표현한다.
+3. 성공, 일반 예외, 취소를 구분한다.
+4. 동일 single-thread worker 재사용과 동시 요청을 통해 context leakage를 결정적으로 검증한다.
+5. `infra/opentelemetry`, `spring-boot/core`, `ktor/observability`가 프레임워크별 bridge를 유지하면서 같은 assertion을 실행한다.
+6. production exporter, collector, 외부 HTTP server 없이 테스트가 실행된다.
+
+## 4. 비목표
+
+- MDC 또는 전역 `ThreadLocal` lifecycle을 fixture가 소유하지 않는다.
+- scheduler, coroutine dispatcher, executor를 production 코드에서 교체하지 않는다.
+- 인증·인가·tenant 정책을 정의하지 않는다.
+- OpenTelemetry, Micrometer, Spring, Reactor, Ktor 타입을 shared fixture의 public API에 노출하지 않는다.
+- tracing SDK나 exporter를 `testing/junit5`의 새 의존성으로 추가하지 않는다.
+- 기존 HTTP observability conformance fixture를 대체하거나 합치지 않는다.
+- 테스트가 실제 결함을 증명하지 않는 한 production API를 변경하지 않는다.
+
+## 5. 선택한 설계
+
+### 5.1 위치와 의존성 경계
+
+새 fixture는 `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/observability/`에 둔다.
+
+이 모듈은 이미 assertion, JUnit 5, coroutine core를 제공한다. 새 module이나 새 외부 의존성을 추가하지 않는다. shared fixture는 문자열 marker와 enum, immutable snapshot만 다루며 실제 context의 설치·조회·복원은 각 소비 모듈의 어댑터가 담당한다.
+
+### 5.2 예상 public surface
+
+저장소의 기존 observability fixture naming을 따라 public surface를 다음과 같이 고정한다. 모든 data class는 `Serializable`이며 명시적 `serialVersionUID`를 둔다. 이 타입은 test-support snapshot이지 영속 포맷이 아니므로 직렬화 결과를 장기 저장하거나 wire contract로 사용하지 않는다.
+
+```kotlin
+enum class ContextPropagationBoundary {
+    COROUTINE,
+    REACTOR,
+    TASK_EXECUTOR,
+    SPRING_OBSERVATION,
+    KTOR_REQUEST,
+}
+
+enum class ContextPropagationScenario {
+    SUCCESS,
+    FAILURE,
+    CANCELLATION,
+    DEADLINE,
+    ISOLATION,
+}
+
+enum class ContextPropagationTerminal {
+    SUCCESS,
+    FAILURE,
+    CANCELLATION,
+    DEADLINE_EXCEEDED,
+}
+
+enum class ContextProbeLocation {
+    CALLER,
+    WORKER,
+    REQUEST,
+}
+
+enum class ContextRequestAlias {
+    SINGLE,
+    REQUEST_A,
+    REQUEST_B,
+    PROBE,
+}
+
+enum class ContextObservationPoint {
+    BOUNDARY_ENTER,
+    AFTER_SUSPENSION,
+    BEFORE_TERMINAL,
+}
+
+enum class ContextMarkerExpectationMode {
+    EXACT,
+    ABSENT,
+    NOT_IN,
+}
+
+data class ContextMarkerObservation(
+    val point: ContextObservationPoint,
+    val observedMarker: String?,
+)
+
+data class ContextMarkerExpectation(
+    val point: ContextObservationPoint,
+    val expectedMarker: String,
+)
+
+data class ContextCleanupProbe(
+    val location: ContextProbeLocation,
+    val observedMarker: String?,
+)
+
+data class ContextCleanupExpectation(
+    val location: ContextProbeLocation,
+    val expectedMarker: String?,
+)
+
+data class ContextPropagationObservation(
+    val boundary: ContextPropagationBoundary,
+    val scenario: ContextPropagationScenario,
+    val requestAlias: ContextRequestAlias,
+    val markerObservations: List<ContextMarkerObservation>,
+    val cleanupProbes: List<ContextCleanupProbe>,
+    val terminal: ContextPropagationTerminal,
+)
+
+data class ContextPropagationExpectation(
+    val boundary: ContextPropagationBoundary,
+    val scenario: ContextPropagationScenario,
+    val requestAlias: ContextRequestAlias,
+    val markerExpectations: List<ContextMarkerExpectation>,
+    val cleanupExpectations: List<ContextCleanupExpectation>,
+    val expectedTerminal: ContextPropagationTerminal,
+)
+
+data class ContextIsolationSample(
+    val requestAlias: ContextRequestAlias,
+    val observedMarkers: List<String?>,
+)
+
+data class ContextIsolationSampleExpectation(
+    val requestAlias: ContextRequestAlias,
+    val mode: ContextMarkerExpectationMode,
+    val expectedMarker: String? = null,
+    val forbiddenMarkers: List<String> = emptyList(),
+    val minimumObservationCount: Int = 1,
+)
+
+data class ContextIsolationObservation(
+    val boundary: ContextPropagationBoundary,
+    val samples: List<ContextIsolationSample>,
+    val cleanupProbes: List<ContextCleanupProbe>,
+)
+
+data class ContextIsolationExpectation(
+    val boundary: ContextPropagationBoundary,
+    val samples: List<ContextIsolationSampleExpectation>,
+    val cleanupExpectations: List<ContextCleanupExpectation>,
+)
+
+fun assertContextPropagationConformance(
+    observation: ContextPropagationObservation,
+    expectation: ContextPropagationExpectation,
+)
+
+fun assertContextIsolation(
+    observation: ContextIsolationObservation,
+    expectation: ContextIsolationExpectation,
+)
+```
+
+계약은 다음과 같다.
+
+- propagation observation과 expectation의 observation-point 집합은 일치해야 하며 각 point의 `observedMarker == expectedMarker`여야 한다. suspension 경계는 `BOUNDARY_ENTER`와 `AFTER_SUSPENSION`을 모두 포함한다.
+- observation의 `boundary`, `scenario`, `requestAlias`, `terminal`은 expectation과 각각 일치한다.
+- caller, worker, request cleanup은 `ContextProbeLocation`별 actual/expected 목록으로 비교한다. 해당 경계에 존재하지 않는 probe는 expectation에 넣지 않는다.
+- 작업 시작 전 context가 root였으면 expected cleanup marker는 오직 `null`로 표현한다. 문자열 `"root"`는 marker로 허용하지 않는다.
+- `FAILURE`, `CANCELLATION`, `DEADLINE_EXCEEDED`는 서로 바꿔 기록할 수 없다.
+- isolation observation과 expectation의 boundary 및 request alias 집합은 일치해야 한다. `EXACT`는 별도로 구성한 하나의 non-null expected marker만, `ABSENT`는 `null`만, `NOT_IN`은 non-empty forbidden marker 목록에 없는 non-null 값만 허용한다. 모든 관측 목록은 `minimumObservationCount` 이상이어야 한다. expectation의 request alias와 `EXACT` marker는 모두 유일하며, alias 중복이나 빈 관측 목록, mode와 맞지 않는 필드 조합은 assertion 전에 거부한다.
+- Ktor A/B request는 `EXACT`, 마지막 무부모 probe request는 A/B trace ID를 forbidden 목록으로 둔 `NOT_IN` expectation을 사용한다. 따라서 probe 기대값을 probe 관측에서 역으로 만들지 않는다.
+- assertion 실패 메시지는 marker 원문을 노출하지 않는다. enum 기반 boundary/scenario/terminal/request alias/observation point/probe location/expectation mode와 `match`/`mismatch` 관계만 기록한다.
+- 민감 문자열과 CR/LF canary를 넣은 negative unit test로 실패 메시지 redaction을 고정한다.
+
+snapshot에는 test-owned synthetic marker만 넣는다. production 요청 ID, 실제 사용자 입력, 외부 trace ID는 넣지 않는다. Ktor W3C 테스트의 고정 trace/span ID도 test fixture가 생성한 synthetic 값만 사용하며 assertion/log에는 원문을 출력하지 않는다.
+
+모든 public enum, snapshot, assertion에는 English KDoc과 최소 사용 예제를 둔다. enum 확장은 additive test-support 변경으로 허용하지만 caller는 exhaustive persistence contract로 사용하지 않는다. data class constructor 변경은 compatibility 검토 없이 수행하지 않는다.
+
+### 5.3 경계별 어댑터 책임
+
+| 소비 모듈 | 실제 경계 | 어댑터가 수집할 evidence | shared fixture가 검증할 계약 |
+|---|---|---|---|
+| `infra/opentelemetry` | coroutine suspension/dispatcher 전환 | `ContextKey<String>`를 넣은 OTel `Context`를 `withOtelContext`로 설치하고 suspension 전후, caller, worker에서 읽은 값 | parent visibility, terminal 분류, caller/worker 복원 |
+| `infra/opentelemetry` | Reactor subscriber context | test-private Reactor key에 capture한 OTel `Context`를 넣고 `deferContextual` callback에서 `Context.wrap(...)`으로 명시적으로 활성화한 값 | subscriber 격리, 실제 signal terminal, cleanup |
+| `infra/opentelemetry` | single-thread executor | 제출 시 capture한 `Context.wrap(...)` task, entered/cancelled/finally-completed handshake, 후속 unwrapped probe | submission-time parent, terminal, 동일 worker 복원 |
+| `spring-boot/core` | `observeSpringSuspending` + Reactor context | 고정 observation name을 marker로 사용하고 `ObservationRegistry.currentObservation`을 suspension 전후와 caller에서 읽은 값 | coroutine/Reactor visibility, failure/cancellation/deadline 구분, registry cleanup |
+| `ktor/observability` | `testApplication` handler/request | W3C `traceparent`로 주입한 synthetic parent trace ID와 handler의 current server-span trace ID, request별 terminal, 후속 probe request | HTTP parent extraction, A/B/probe isolation, request 종료 cleanup |
+
+shared fixture는 프레임워크를 실행하지 않는다. 각 모듈의 테스트가 실제 API를 실행하고 관측 snapshot만 fixture에 전달한다.
+
+Spring adapter 순서는 `TestObservationRegistry` 생성 → 고정 observation marker로 `observeSpringSuspending` 실행 → suspension 전후 current observation 읽기 → 실제 throwable/cancellation/deadline을 terminal로 변환 → caller/registry cleanup probe 순서로 고정한다.
+
+Ktor adapter는 test-local `OpenTelemetrySdk`에 `W3CTraceContextPropagator`를 명시적으로 등록한다. 고정된 test-only `SpanContext` A/B를 text-map propagator로 client request header에 주입하고, `KtorServerTelemetry`가 추출한 server span의 trace ID를 handler에서 읽는다. A/B request는 barrier로 겹쳐 실행하며, 마지막 unparented probe request가 A/B와 다른 고유 marker를 관찰하는지 확인한다. setup → header injection → handler read → terminal capture → request completion → caller/probe request 순서를 바꾸지 않는다. 외부 server와 production exporter는 사용하지 않는다.
+
+### 5.4 전파·종료 행렬
+
+| 경계 | 성공 | 일반 예외 | 취소 | 실제 deadline | 종료 후 복원 | 독립 실행 격리 |
+|---|---:|---:|---:|---:|---:|---:|
+| Coroutine dispatcher | 필수 | 필수 | `Job.cancel` | `withTimeout` | caller/worker | A/B coroutine |
+| Reactor subscriber | 필수 | `onError` | subscription `cancel` | Reactor `timeout` | caller/scheduler worker | A/B subscriber |
+| Single-thread executor | 필수 | task exception | running `Future.cancel(true)` | `Future.get(timeout)` 후 cancel | caller/same worker | 동일 worker A/B |
+| Spring suspending observation | 필수 | block exception | child coroutine cancel | `withTimeout` | caller/registry | A/B coroutine |
+| Ktor request handler | 필수 | handler exception | request coroutine cancel | route block `withTimeout` | caller/probe request | 동시 A/B request |
+
+모든 조합을 프레임워크마다 중복 구현하지 않는다. 저수준 OTel 테스트가 세 비동기 경계의 완전한 terminal matrix를 소유하고, Spring/Ktor는 자신이 제공하는 server-operation bridge에 해당하는 행과 공통 assertion 재사용을 증명한다.
+
+## 6. 결정적 테스트 설계
+
+### 6.1 synthetic marker
+
+테스트 전용 `ContextKey<String>` 또는 observation key에 `parent-A`, `parent-B` 같은 고정 marker를 사용한다. root/absence는 항상 `null`이다. Ktor의 trace/span ID는 W3C 형식에 맞는 고정 test-only 값 A/B를 사용한다. production trace ID, request ID, 사용자 데이터는 사용하지 않는다.
+
+### 6.2 동일 worker 재사용
+
+single-thread executor에서 다음 순서를 지킨다.
+
+1. parent-A를 capture한 wrapped task를 제출한다.
+2. `entered` gate로 task가 실제 시작됐음을 확인하고 task 내부에서 parent-A를 관찰한다.
+3. 성공·예외 경로는 terminal을 직접 관찰한다. 취소는 running future에 `cancel(true)`를 호출하며, deadline은 `Future.get(timeout)`이 만료된 뒤 같은 취소 절차를 수행한다.
+4. task의 `finally`가 `finallyCompleted` gate를 열 때까지 기다린다. 이 gate 전에 cleanup probe를 실행하지 않는다.
+5. 같은 executor에 unwrapped probe를 제출해 작업 시작 전 worker marker를 관찰한다. root였다면 `null`이어야 한다.
+6. parent-B task를 같은 worker에 실행해 parent-A가 보이지 않음을 확인한다.
+
+executor와 dispatcher는 테스트가 소유한다. teardown은 모든 gate를 해제하고 outstanding task를 취소한 뒤 `shutdown()`과 bounded `awaitTermination`을 수행한다. 첫 대기 실패 시 `shutdownNow()`를 호출하고 다시 bounded 대기한 뒤 termination을 assertion한다.
+
+### 6.3 동시 요청 격리
+
+A/B 작업이 실제로 겹치도록 `CompletableDeferred`, `CountDownLatch`, Reactor synchronization primitive 같은 명시적 barrier를 사용한다. `delay`나 `Thread.sleep`의 시간 추정으로 순서를 만들지 않는다.
+
+각 작업은 barrier 전후로 자신의 marker를 두 번 이상 관찰한다. 종료 후 worker/root probe를 수행한다.
+
+barrier는 failure-aware여야 한다. 한 participant가 barrier 도달 전 실패해도 `finally`에서 peer gate를 완료 또는 취소하고 모든 child task를 join/cancel한다. assertion failure가 다른 participant를 suite timeout까지 가두어서는 안 된다.
+
+### 6.4 bounded completion
+
+모든 barrier, cancellation, deadline, resource termination 대기는 `testing/junit5`의 `DEFAULT_CANCELLATION_CONTRACT_TIMEOUT`과 같은 명시적 5초 상한을 사용한다. Testcontainers용 180초 기본값을 상속하지 않는다. timeout은 hang을 탐지하는 안전장치이며 ordering 수단이 아니다.
+
+semantic deadline은 1초 이하로 두고 5초 hang guard보다 반드시 짧게 설정한다(`semanticDeadline < hangGuard`). coroutine `withTimeout`, Reactor `timeout`, `Future.get(timeout)`, Ktor route `withTimeout`가 먼저 실제 terminal을 발생시키고, adapter가 `DEADLINE_EXCEEDED`와 cleanup 완료를 관찰한 뒤에만 바깥 hang guard를 해제한다. hang guard가 먼저 발화한 실행은 deadline 성공이 아니라 fixture failure다. cancellation과 deadline 모두 원래 예외/signal을 삼키지 않고 cleanup 뒤 caller에게 전파한다.
+
+각 conformance test case 전체에는 JUnit `@Timeout(value = 15, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SAME_THREAD)` aggregate guard를 적용한다. 별도 timeout thread가 context 관측 자체를 바꾸지 않도록 `SAME_THREAD`를 고정한다. 이 상한은 setup, 경계 실행, assertion, 모든 `finally` teardown과 fallback termination을 포함하며 개별 5초 대기가 합산되어 case 전체 상한을 연장할 수 없다. aggregate guard가 발화하면 해당 scenario는 conformance 성공이 아니라 fixture failure다.
+
+### 6.5 resource lifecycle ledger
+
+| Adapter | Test-owned resource | 필수 teardown |
+|---|---|---|
+| Coroutine | dispatcher/executor, jobs, gates | child cancel/join, executor bounded termination |
+| Reactor | subscription/disposable, scheduler, gates | dispose/cancel, scheduler bounded disposal, peer gate release |
+| Task executor | futures, single-thread executor, gates | future cancel, finally handshake, `shutdownNow()` fallback, termination assertion |
+| Spring | `TestObservationRegistry`, coroutine jobs, optional scheduler | child cancel/join, remaining current observation 없음 확인, scheduler 정리 |
+| Ktor | `testApplication`, client requests, local SDK/exporter/provider, gates | request completion/cancel, application 종료, `AutoCloseable` tracing fixture close |
+
+모든 adapter는 success, failure, cancellation, deadline 경로에서 동일한 teardown을 실행한다. test-local SDK/registry만 사용하며 `globalOpenTelemetry`, `GlobalOpenTelemetry.set/resetForTest`, Reactor global hook, automatic context-propagation hook을 호출하지 않는다.
+
+## 7. 실패 모드와 방어
+
+| 실패 모드 | 잘못된 통과 가능성 | 방어 |
+|---|---|---|
+| 작업 내부 marker만 확인하고 종료 후 복원을 확인하지 않음 | ThreadLocal/OTel scope leak를 놓침 | 모든 terminal 경로 뒤 caller/worker probe 필수 |
+| Reactor `Context` 값이 있다는 이유로 OTel `Context.current()`도 전파됐다고 가정 | 실제 bridge 누락을 놓침 | adapter가 실제 consumer API와 OTel current 값을 각각 필요한 위치에서 읽음 |
+| `CancellationException`이나 deadline을 일반 오류로 분류 | 취소/timeout telemetry가 오류로 오염됨 | actual terminal과 expected `CANCELLATION`/`DEADLINE_EXCEEDED`를 별도 비교 |
+| 전역 Reactor/OTel 상태에 의존 | 테스트 순서와 JVM 전역 상태에 따라 결과 변동 | 명시적 bridge와 test-local SDK만 사용하고 global hook/setter를 금지 |
+| A/B 요청을 순차 실행 | request 간 context 혼입을 검출하지 못함 | barrier로 중첩 실행하고 각 요청에서 반복 관측 |
+| participant 실패 후 peer barrier를 해제하지 않음 | flaky hang과 장시간 CI stall | failure-aware gate와 child cancel/join을 `finally`에서 실행 |
+| 취소 task의 `finally` 전에 worker probe 실행 | 늦게 복원되는 leak를 놓치거나 race 발생 | entered/cancelled/finally-completed handshake 뒤 probe |
+| 테스트 executor/SDK/registry 미종료 | 다음 테스트 오염 또는 JVM hang | lifecycle ledger와 bounded termination assertion 적용 |
+| raw marker를 assertion/log에 출력 | 실제 값으로 교체될 때 민감정보 노출 위험 | redacted assertion 메시지와 synthetic marker만 허용 |
+
+## 8. 고려한 대안
+
+### 8.1 `infra/opentelemetry`에 OTel 전용 fixture 추가
+
+거절한다. Spring observation과 Ktor adapter가 OTel 테스트 타입에 결합되고 “framework-specific interception은 해당 module에 둔다”는 issue 경계를 흐린다.
+
+### 8.2 별도 `testing/context-propagation` module 추가
+
+거절한다. provider-neutral 값과 assertion만 필요하므로 module registration, catalog, publication, CI surface를 늘릴 근거가 없다.
+
+### 8.3 framework별 테스트만 보강
+
+거절한다. assertion 의미와 terminal 분류가 다시 분기되어 issue의 “same behavioral assertions” acceptance criterion을 만족하지 못한다.
+
+### 8.4 production 공통 context abstraction 추가
+
+거절한다. 이 issue는 conformance test 확장이며 production API 통합은 비목표다. 테스트가 실제 production 결함을 재현할 때만 최소 수정안을 별도로 평가한다.
+
+## 9. 호환성 및 운영 영향
+
+- 새 shared fixture는 additive test-support API이며 기존 public API와 동작을 변경하지 않는다. 공개 enum에는 이후 값을 추가할 수 있으므로 소비자는 exhaustive `when`에 `else`를 두도록 KDoc에 명시한다.
+- 공개 타입, 필드, assertion 함수에는 영어 KDoc과 최소 예제를 제공하고 `testing/junit5/README.md`, `testing/junit5/README.ko.md`에 동일한 사용 흐름을 기록한다.
+- 새 외부 의존성, 설정 키, exporter, collector, server port가 없다.
+- production runtime 동작과 배포 절차는 바뀌지 않는다.
+- OpenTelemetry SDK/propagator는 테스트별 로컬 인스턴스로 생성·종료한다. `GlobalOpenTelemetry.set/resetForTest`, Reactor 전역 hook, 그 밖의 JVM 전역 registry를 사용하지 않는다.
+- Testcontainers를 사용하지 않는다.
+- Ktor는 in-process `testApplication`을 사용하며 외부 HTTP server를 열지 않는다.
+- 실제 결함으로 production 수정이 필요해지면 변경 이유, compatibility, rollback을 구현 계획에 추가하고 spec review를 다시 연다.
+
+## 10. Acceptance criteria 추적
+
+| Issue #1051 기준 | 설계 evidence |
+|---|---|
+| coroutine, Reactor, task-executor parent propagation | 저수준 OTel adapter가 caller/worker 관측값과 사전 marker expectation을 분리해 세 경계의 공통 assertion 실행 |
+| cancellation/deadline cleanup | 실제 cancellation은 `CANCELLATION`, 실제 deadline은 `DEADLINE_EXCEEDED`로 구분하고 종료 후 caller/worker/request probe가 기대 terminal 및 복원을 검증 |
+| request leakage 없음 | failure-aware barrier 기반 A/B 중첩 실행, 순서가 보존되는 isolation sample 목록, 동일 worker 또는 무부모 request probe |
+| deterministic propagation/cancellation/exception/isolation tests | sleep 없는 synchronization, 5초 hang guard와 별도의 실제 deadline, synthetic marker |
+| Spring Boot와 Ktor가 같은 assertion 실행 | Spring Observation과 W3C `traceparent` Ktor adapter가 `testing/junit5`의 동일 assertion을 직접 호출 |
+| production exporter/collector/HTTP server 불필요 | in-memory registry/SDK, Ktor `testApplication`, 외부 endpoint 없음 |
+| framework interception은 각 module에 유지 | shared fixture에 framework 타입 없음; adapter는 소비 module test에 위치 |
+| 실패 진단에 민감값이 노출되지 않음 | enum·관계·probe 위치만 포함한 고정 진단과 CR/LF·synthetic canary 비노출 단위 테스트 |
+
+## 11. 구현 및 검증 경계
+
+예상 변경 범위:
+
+- `testing/junit5`: provider-neutral observation/expectation/isolation 타입과 assertion, 자체 unit test, 영문·한글 README 예제
+- `infra/opentelemetry`: coroutine/Reactor/executor conformance adapter tests
+- `spring-boot/core`: Spring observation conformance adapter tests
+- `ktor/observability`: Ktor request conformance adapter tests
+
+기존 build script와 source tree에서 네 Gradle project path 및 필요한 coroutine/Reactor/Spring/Ktor/로컬 OTel SDK 테스트 의존성을 확인했다. 새 의존성은 추가하지 않는다. 구현할 테스트 class와 최소 케이스 수는 다음과 같이 고정한다.
+
+| Module | Test class | 최소 케이스 |
+|---|---|---:|
+| `testing/junit5` | `io.bluetape4k.junit5.observability.ContextPropagationConformanceTest` | 10 |
+| `infra/opentelemetry` | `io.bluetape4k.opentelemetry.context.ContextPropagationConformanceTest` | 15 (5 scenarios × 3 boundaries) |
+| `spring-boot/core` | `io.bluetape4k.spring.observability.SpringContextPropagationConformanceTest` | 5 |
+| `ktor/observability` | `io.bluetape4k.ktor.observability.KtorContextPropagationConformanceTest` | 5 |
+
+최소 35개 conformance 케이스를 구현한다. 아래 targeted 명령은 변경 중 해당 adapter의 빠른 피드백 또는 실패 재현용이고, 최종 검증 게이트는 네 module 전체 test와 `detekt`다. 같은 변경 상태에서 targeted와 module 전체 실행을 모두 필수 evidence로 중복 요구하지 않는다.
+
+```bash
+# Development/debug loop: run only the affected class.
+./gradlew :bluetape4k-junit5:test --tests "io.bluetape4k.junit5.observability.ContextPropagationConformanceTest"
+./gradlew :bluetape4k-opentelemetry:test --tests "io.bluetape4k.opentelemetry.context.ContextPropagationConformanceTest"
+./gradlew :bluetape4k-spring-boot-core:test --tests "io.bluetape4k.spring.observability.SpringContextPropagationConformanceTest"
+./gradlew :bluetape4k-ktor-observability:test --tests "io.bluetape4k.ktor.observability.KtorContextPropagationConformanceTest"
+
+# Required final verification: run each module suite once.
+./gradlew :bluetape4k-junit5:test
+./gradlew :bluetape4k-opentelemetry:test
+./gradlew :bluetape4k-spring-boot-core:test
+./gradlew :bluetape4k-ktor-observability:test
+./gradlew detekt
+git diff --check
+```
+
+Testcontainers verification은 이 범위에 포함하지 않는다. production 수정이나 새 의존성이 필요해지면 구현을 중단하고 spec review를 다시 연다.
+
+## 12. 외부 계약 근거
+
+- [OpenTelemetry Java API](https://opentelemetry.io/docs/languages/java/api/)
+- [OpenTelemetry Context specification](https://opentelemetry.io/docs/specs/otel/context/)
+- [OpenTelemetry library instrumentation guidance](https://opentelemetry.io/docs/concepts/instrumentation/libraries/)
+- [Project Reactor Context](https://projectreactor.io/docs/core/release/reference/advancedFeatures/context.html)
+- [Project Reactor context propagation](https://projectreactor.io/docs/core/release/reference/advanced-contextPropagation.html)
+- [kotlinx-coroutines-reactor API](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-reactor/)
+- [Kotlin cancellation](https://kotlinlang.org/docs/cancellation-and-timeouts.html)
+
+핵심 적용 원칙은 context를 비동기 경계 안에서만 활성화하고 종료 시 이전 상태를 복원하는 것이다. Reactor subscriber context와 thread-local context는 같은 저장소가 아니므로 adapter가 사용하는 bridge를 명시적으로 검증한다.

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt
@@ -328,6 +328,56 @@ class ContextPropagationConformanceTest {
     }
 
     @Test
+    fun `executor failure propagates and restores context`() {
+        val captured = runExecutorScenario(ContextPropagationScenario.FAILURE)
+        captured.assertThrownExactly<IllegalStateException>()
+        assertContextPropagationConformance(
+            captured.observation,
+            propagationExpectation(
+                ContextPropagationBoundary.TASK_EXECUTOR,
+                ContextPropagationScenario.FAILURE,
+                ContextPropagationTerminal.FAILURE,
+            ),
+        )
+    }
+
+    @Test
+    fun `executor running cancellation propagates and restores context`() {
+        val captured = runExecutorScenario(ContextPropagationScenario.CANCELLATION)
+        captured.assertThrownExactly<CancellationException>()
+        assertContextPropagationConformance(
+            captured.observation,
+            propagationExpectation(
+                ContextPropagationBoundary.TASK_EXECUTOR,
+                ContextPropagationScenario.CANCELLATION,
+                ContextPropagationTerminal.CANCELLATION,
+            ),
+        )
+    }
+
+    @Test
+    fun `executor deadline cancels running work and restores worker context`() {
+        val captured = runExecutorScenario(ContextPropagationScenario.DEADLINE)
+        captured.assertThrownExactly<TimeoutException>()
+        assertContextPropagationConformance(
+            captured.observation,
+            propagationExpectation(
+                ContextPropagationBoundary.TASK_EXECUTOR,
+                ContextPropagationScenario.DEADLINE,
+                ContextPropagationTerminal.DEADLINE_EXCEEDED,
+            ),
+        )
+    }
+
+    @Test
+    fun `executor reuses one worker without leaking request context`() {
+        assertContextIsolation(
+            runExecutorIsolationScenario(),
+            executorIsolationExpectation(),
+        )
+    }
+
+    @Test
     fun `interrupted executor teardown forces shutdown and restores interrupt status`() {
         val executor = InterruptingExecutorService()
 

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt
@@ -390,6 +390,7 @@ class ContextPropagationConformanceTest {
                 executor.shutdownAndAssertTermination()
             }
             executor.shutdownNowCalled.shouldBeTrue()
+            check(executor.awaitCalls == 1)
             Thread.currentThread().isInterrupted.shouldBeTrue()
         } finally {
             Thread.interrupted()
@@ -590,7 +591,8 @@ private class InterruptingExecutorService: AbstractExecutorService() {
         private set
 
     private var shutdown = false
-    private var awaitCalls = 0
+    var awaitCalls = 0
+        private set
 
     override fun shutdown() {
         shutdown = true

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt
@@ -26,6 +26,7 @@ import java.util.concurrent.AbstractExecutorService
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
@@ -401,6 +402,29 @@ class ContextPropagationConformanceTest {
             assertFailsWith<InterruptedException> {
                 captureExecutorTerminal(future, DEFAULT_CANCELLATION_CONTRACT_TIMEOUT)
             }
+            Thread.currentThread().isInterrupted.shouldBeTrue()
+        } finally {
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `executor cleanup restores interrupt status from interrupted block`() {
+        val executor = mockk<ExecutorService>()
+        val interruption = InterruptedException("synthetic executor interruption")
+
+        try {
+            val thrown = assertFailsWith<InterruptedException> {
+                withExecutorCleanup(
+                    executor = executor,
+                    cancel = {},
+                    shutdown = {},
+                ) {
+                    throw interruption
+                }
+            }
+
+            (thrown === interruption).shouldBeTrue()
             Thread.currentThread().isInterrupted.shouldBeTrue()
         } finally {
             Thread.interrupted()

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt
@@ -1,0 +1,424 @@
+package io.bluetape4k.opentelemetry.context
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.junit5.coroutines.DEFAULT_CANCELLATION_CONTRACT_TIMEOUT
+import io.bluetape4k.junit5.observability.ContextPropagationBoundary
+import io.bluetape4k.junit5.observability.ContextPropagationScenario
+import io.bluetape4k.junit5.observability.ContextPropagationTerminal
+import io.bluetape4k.junit5.observability.assertContextIsolation
+import io.bluetape4k.junit5.observability.assertContextPropagationConformance
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.AbstractExecutorService
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import kotlin.time.Duration
+
+@Timeout(
+    value = 15,
+    unit = TimeUnit.SECONDS,
+    threadMode = Timeout.ThreadMode.SAME_THREAD,
+)
+class ContextPropagationConformanceTest {
+
+    @Test
+    fun `coroutine success propagates and restores context`() = runTest {
+        val captured = runCoroutineScenario(ContextPropagationScenario.SUCCESS)
+        captured.thrown.shouldBeNull()
+        assertContextPropagationConformance(
+            captured.observation,
+            propagationExpectation(
+                ContextPropagationBoundary.COROUTINE,
+                ContextPropagationScenario.SUCCESS,
+                ContextPropagationTerminal.SUCCESS,
+            ),
+        )
+    }
+
+    @Test
+    fun `coroutine failure propagates and restores context`() = runTest {
+        val captured = runCoroutineScenario(ContextPropagationScenario.FAILURE)
+        captured.assertThrownExactly<IllegalStateException>()
+        assertContextPropagationConformance(
+            captured.observation,
+            propagationExpectation(
+                ContextPropagationBoundary.COROUTINE,
+                ContextPropagationScenario.FAILURE,
+                ContextPropagationTerminal.FAILURE,
+            ),
+        )
+    }
+
+    @Test
+    fun `coroutine cancellation propagates and restores context`() = runTest {
+        val captured = runCoroutineScenario(ContextPropagationScenario.CANCELLATION)
+        captured.assertThrownExactly<CancellationException>()
+        assertContextPropagationConformance(
+            captured.observation,
+            propagationExpectation(
+                ContextPropagationBoundary.COROUTINE,
+                ContextPropagationScenario.CANCELLATION,
+                ContextPropagationTerminal.CANCELLATION,
+            ),
+        )
+    }
+
+    @Test
+    fun `coroutine deadline propagates and restores context`() = runTest {
+        val captured = runCoroutineScenario(ContextPropagationScenario.DEADLINE)
+        captured.assertThrownExactly<TimeoutCancellationException>()
+        assertContextPropagationConformance(
+            captured.observation,
+            propagationExpectation(
+                ContextPropagationBoundary.COROUTINE,
+                ContextPropagationScenario.DEADLINE,
+                ContextPropagationTerminal.DEADLINE_EXCEEDED,
+            ),
+        )
+    }
+
+    @Test
+    fun `coroutine siblings keep isolated parent contexts`() = runTest {
+        val observation = runCoroutineIsolationScenario()
+        assertContextIsolation(observation, coroutineIsolationExpectation())
+    }
+
+    @Test
+    fun `coroutine cleanup under cancelled parent attempts every child`() = runTest {
+        val attempted = mutableListOf<String>()
+        val cancelledParent = launch {
+            coroutineContext.job.cancel(CancellationException("synthetic cancelled parent"))
+            coroutineContext.job.isCancelled.shouldBeTrue()
+
+            cleanupCoroutineActions(
+                actions = listOf(
+                    { attempted += "child-A" },
+                    { attempted += "child-B" },
+                ),
+            )
+        }
+
+        cancelledParent.join()
+
+        check(attempted == listOf("child-A", "child-B"))
+    }
+
+    @Test
+    fun `coroutine cleanup preserves cancellation and deadline identity`() = runTest {
+        val cancellation = CancellationException("synthetic primary cancellation")
+        val deadline = try {
+            withTimeout(Duration.ZERO) {
+                awaitCancellation()
+            }
+            error("Expected deadline")
+        } catch (e: TimeoutCancellationException) {
+            e
+        }
+
+        listOf(cancellation, deadline).forEach { primary ->
+            val thrown = assertFailsWith<CancellationException> {
+                withCoroutineChildCleanup(
+                    children = emptyList(),
+                    beforeCleanup = {},
+                ) {
+                    throw primary
+                }
+            }
+
+            (thrown === primary).shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `coroutine cleanup suppresses distinct failures without self suppression`() = runTest {
+        val primary = CancellationException("synthetic primary cancellation")
+        val cleanupFailureA = AssertionError("synthetic cleanup failure A")
+        val cleanupFailureB = IllegalStateException("synthetic cleanup failure B")
+        val attempted = mutableListOf<String>()
+
+        val thrown = assertFailsWith<CancellationException> {
+            cleanupCoroutineActions(
+                primaryFailure = primary,
+                actions = listOf(
+                    {
+                        attempted += "primary"
+                        throw primary
+                    },
+                    {
+                        attempted += "failure-A"
+                        throw cleanupFailureA
+                    },
+                    {
+                        attempted += "failure-B"
+                        throw cleanupFailureB
+                    },
+                ),
+            )
+        }
+
+        (thrown === primary).shouldBeTrue()
+        check(thrown.suppressed.toList() == listOf(cleanupFailureA, cleanupFailureB)) {
+            "Unexpected cleanup suppression order: ${thrown.suppressed.map { it.javaClass.simpleName }}"
+        }
+        check(attempted == listOf("primary", "failure-A", "failure-B"))
+    }
+
+    @Test
+    fun `reactor success propagates and restores context`() {
+        val captured = runReactorScenario(ContextPropagationScenario.SUCCESS)
+        captured.thrown.shouldBeNull()
+        assertContextPropagationConformance(
+            captured.observation,
+            propagationExpectation(
+                ContextPropagationBoundary.REACTOR,
+                ContextPropagationScenario.SUCCESS,
+                ContextPropagationTerminal.SUCCESS,
+            ),
+        )
+    }
+
+    @Test
+    fun `executor success propagates and restores context`() {
+        val captured = runExecutorScenario(ContextPropagationScenario.SUCCESS)
+        captured.thrown.shouldBeNull()
+        assertContextPropagationConformance(
+            captured.observation,
+            propagationExpectation(
+                ContextPropagationBoundary.TASK_EXECUTOR,
+                ContextPropagationScenario.SUCCESS,
+                ContextPropagationTerminal.SUCCESS,
+            ),
+        )
+    }
+
+    @Test
+    fun `interrupted executor teardown forces shutdown and restores interrupt status`() {
+        val executor = InterruptingExecutorService()
+
+        try {
+            assertFailsWith<AssertionError> {
+                executor.shutdownAndAssertTermination()
+            }
+            executor.shutdownNowCalled.shouldBeTrue()
+            Thread.currentThread().isInterrupted.shouldBeTrue()
+        } finally {
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `executor terminal capture restores interrupt status and rethrows interruption`() {
+        val future = CompletableFuture<Unit>()
+
+        Thread.currentThread().interrupt()
+        try {
+            assertFailsWith<InterruptedException> {
+                captureExecutorTerminal(future, DEFAULT_CANCELLATION_CONTRACT_TIMEOUT)
+            }
+            Thread.currentThread().isInterrupted.shouldBeTrue()
+        } finally {
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `executor terminal capture unwraps execution failure cause`() {
+        val failure = IllegalStateException("synthetic executor failure")
+        val future = CompletableFuture<Unit>().also {
+            it.completeExceptionally(failure)
+        }
+
+        val captured = captureExecutorTerminal(future, DEFAULT_CANCELLATION_CONTRACT_TIMEOUT)
+
+        (captured === failure).shouldBeTrue()
+    }
+
+    @Test
+    fun `executor terminal capture rethrows fatal execution cause with identity`() {
+        val fatal = SyntheticFatalError()
+        val future = CompletableFuture<Unit>().also {
+            it.completeExceptionally(fatal)
+        }
+
+        val thrown = assertFailsWith<SyntheticFatalError> {
+            captureExecutorTerminal(future, DEFAULT_CANCELLATION_CONTRACT_TIMEOUT)
+        }
+
+        (thrown === fatal).shouldBeTrue()
+    }
+
+    @Test
+    fun `executor terminal capture preserves cancellation identity`() {
+        val cancellation = CancellationException("synthetic executor cancellation")
+        val future = mockk<Future<Unit>> {
+            every { get(any(), any()) } throws cancellation
+        }
+
+        val captured = captureExecutorTerminal(future, DEFAULT_CANCELLATION_CONTRACT_TIMEOUT)
+
+        (captured === cancellation).shouldBeTrue()
+    }
+
+    @Test
+    fun `executor terminal capture classifies harness timeout as assertion failure`() {
+        val future = CompletableFuture<Unit>()
+
+        val failure = assertFailsWith<AssertionError> {
+            captureExecutorTerminal(future, Duration.ZERO)
+        }
+
+        failure.cause shouldBeInstanceOf TimeoutException::class
+    }
+
+    @Test
+    fun `executor cleanup preserves primary interruption and still shuts down after cancel failure`() {
+        val executor = InterruptingExecutorService()
+        val primary = InterruptedException("synthetic primary interruption")
+        val cancelFailure = AssertionError("synthetic cancel failure")
+        var shutdownExecuted = false
+
+        try {
+            val thrown = assertFailsWith<InterruptedException> {
+                withExecutorCleanup(
+                    executor = executor,
+                    cancel = { throw cancelFailure },
+                    shutdown = { shutdownExecuted = true },
+                ) {
+                    Thread.currentThread().interrupt()
+                    throw primary
+                }
+            }
+
+            (thrown === primary).shouldBeTrue()
+            (thrown.suppressed.single() === cancelFailure).shouldBeTrue()
+            shutdownExecuted.shouldBeTrue()
+            Thread.currentThread().isInterrupted.shouldBeTrue()
+        } finally {
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `executor cleanup aggregates cancel and shutdown failures without primary`() {
+        val executor = InterruptingExecutorService()
+        val cancelFailure = AssertionError("synthetic cancel failure")
+        val shutdownFailure = IllegalStateException("synthetic shutdown failure")
+
+        val thrown = assertFailsWith<AssertionError> {
+            withExecutorCleanup(
+                executor = executor,
+                cancel = { throw cancelFailure },
+                shutdown = { throw shutdownFailure },
+            ) {
+                Unit
+            }
+        }
+
+        (thrown === cancelFailure).shouldBeTrue()
+        (thrown.suppressed.single() === shutdownFailure).shouldBeTrue()
+    }
+
+    @Test
+    fun `executor cleanup preserves primary identity when both cleanup actions throw same instance`() {
+        val executor = InterruptingExecutorService()
+        val primary = InterruptedException("shared primary and cleanup interruption")
+
+        try {
+            val thrown = assertFailsWith<InterruptedException> {
+                withExecutorCleanup(
+                    executor = executor,
+                    cancel = { throw primary },
+                    shutdown = { throw primary },
+                ) {
+                    Thread.currentThread().interrupt()
+                    throw primary
+                }
+            }
+
+            (thrown === primary).shouldBeTrue()
+            thrown.suppressed.isEmpty().shouldBeTrue()
+            Thread.currentThread().isInterrupted.shouldBeTrue()
+        } finally {
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `executor cleanup suppresses repeated cleanup instance only once`() {
+        val executor = InterruptingExecutorService()
+        val primary = InterruptedException("synthetic primary interruption")
+        val repeatedCleanup = AssertionError("repeated cleanup failure")
+
+        try {
+            val thrown = assertFailsWith<InterruptedException> {
+                withExecutorCleanup(
+                    executor = executor,
+                    cancel = { throw repeatedCleanup },
+                    shutdown = { throw repeatedCleanup },
+                ) {
+                    Thread.currentThread().interrupt()
+                    throw primary
+                }
+            }
+
+            (thrown === primary).shouldBeTrue()
+            (thrown.suppressed.single() === repeatedCleanup).shouldBeTrue()
+            Thread.currentThread().isInterrupted.shouldBeTrue()
+        } finally {
+            Thread.interrupted()
+        }
+    }
+}
+
+private class SyntheticFatalError: Error("synthetic fatal error")
+
+private class InterruptingExecutorService: AbstractExecutorService() {
+    var shutdownNowCalled = false
+        private set
+
+    private var shutdown = false
+    private var awaitCalls = 0
+
+    override fun shutdown() {
+        shutdown = true
+    }
+
+    override fun shutdownNow(): List<Runnable> {
+        shutdown = true
+        shutdownNowCalled = true
+        return emptyList()
+    }
+
+    override fun isShutdown(): Boolean = shutdown
+
+    override fun isTerminated(): Boolean = shutdownNowCalled
+
+    override fun awaitTermination(
+        timeout: Long,
+        unit: TimeUnit,
+    ): Boolean {
+        awaitCalls++
+        if (awaitCalls == 1) {
+            throw InterruptedException("synthetic teardown interruption")
+        }
+        return shutdownNowCalled
+    }
+
+    override fun execute(command: Runnable) {
+        error("No task submission expected")
+    }
+}

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt
@@ -20,12 +20,16 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
+import reactor.core.publisher.Mono
+import reactor.core.publisher.Sinks
 import java.util.concurrent.AbstractExecutorService
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 
 @Timeout(
@@ -189,6 +193,124 @@ class ContextPropagationConformanceTest {
                 ContextPropagationTerminal.SUCCESS,
             ),
         )
+    }
+
+    @Test
+    fun `reactor failure propagates and restores context`() {
+        val captured = runReactorScenario(ContextPropagationScenario.FAILURE)
+        captured.assertThrownExactly<IllegalStateException>()
+        assertContextPropagationConformance(
+            captured.observation,
+            propagationExpectation(
+                ContextPropagationBoundary.REACTOR,
+                ContextPropagationScenario.FAILURE,
+                ContextPropagationTerminal.FAILURE,
+            ),
+        )
+    }
+
+    @Test
+    fun `reactor cancellation propagates and restores context`() {
+        val captured = runReactorScenario(ContextPropagationScenario.CANCELLATION)
+        captured.thrown.shouldBeNull()
+        assertContextPropagationConformance(
+            captured.observation,
+            propagationExpectation(
+                ContextPropagationBoundary.REACTOR,
+                ContextPropagationScenario.CANCELLATION,
+                ContextPropagationTerminal.CANCELLATION,
+            ),
+        )
+    }
+
+    @Test
+    fun `reactor deadline propagates and restores context`() {
+        val captured = runReactorScenario(ContextPropagationScenario.DEADLINE)
+        captured.assertThrownExactly<TimeoutException>()
+        assertContextPropagationConformance(
+            captured.observation,
+            propagationExpectation(
+                ContextPropagationBoundary.REACTOR,
+                ContextPropagationScenario.DEADLINE,
+                ContextPropagationTerminal.DEADLINE_EXCEEDED,
+            ),
+        )
+    }
+
+    @Test
+    fun `reactor subscribers keep isolated parent contexts`() {
+        assertContextIsolation(
+            runReactorIsolationScenario(),
+            reactorIsolationExpectation(),
+        )
+    }
+
+    @Test
+    fun `reactor isolation startup failure terminates the shared ready gate`() {
+        val readyA = Sinks.one<Unit>()
+        val readyB = Sinks.one<Unit>()
+        val firstFailure = AtomicReference<Throwable>()
+        val sharedFailure = AtomicReference<Throwable>()
+        val sharedTerminated = CountDownLatch(1)
+        val failure = IllegalStateException("synthetic participant startup failure")
+        val sharedGate = Mono.`when`(readyA.asMono(), readyB.asMono()).cache()
+
+        sharedGate.subscribe(
+            {},
+            {
+                sharedFailure.set(it)
+                sharedTerminated.countDown()
+            },
+        )
+
+        recordReactorIsolationFailure(failure, readyA, firstFailure)
+        sharedTerminated.awaitOrFail()
+
+        (firstFailure.get() === failure).shouldBeTrue()
+        (sharedFailure.get() === failure).shouldBeTrue()
+    }
+
+    @Test
+    fun `blocking test gate restores interrupt status`() {
+        Thread.currentThread().interrupt()
+        try {
+            assertFailsWith<InterruptedException> {
+                CountDownLatch(1).awaitOrFail()
+            }
+            Thread.currentThread().isInterrupted.shouldBeTrue()
+        } finally {
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `reactor cleanup preserves interruption and attempts remaining actions`() {
+        val interruption = InterruptedException("synthetic cleanup interruption")
+        val attempted = mutableListOf<String>()
+
+        try {
+            val thrown = assertFailsWith<InterruptedException> {
+                withReactorCleanup(
+                    actions = listOf(
+                        {
+                            attempted += "interrupted"
+                            throw interruption
+                        },
+                        {
+                            attempted += "remaining"
+                        },
+                    ),
+                ) {
+                    Unit
+                }
+            }
+
+            (thrown === interruption).shouldBeTrue()
+            check(attempted == listOf("interrupted", "remaining"))
+            Thread.currentThread().isInterrupted.shouldBeTrue()
+        } finally {
+            Thread.interrupted()
+        }
     }
 
     @Test

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt
@@ -30,6 +30,7 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 
@@ -288,6 +289,7 @@ class ContextPropagationConformanceTest {
     fun `reactor cleanup preserves interruption and attempts remaining actions`() {
         val interruption = InterruptedException("synthetic cleanup interruption")
         val attempted = mutableListOf<String>()
+        val interruptibleCleanupCompleted = AtomicBoolean()
 
         try {
             val thrown = assertFailsWith<InterruptedException> {
@@ -298,16 +300,17 @@ class ContextPropagationConformanceTest {
                             throw interruption
                         },
                         {
+                            CountDownLatch(0).await()
+                            interruptibleCleanupCompleted.set(true)
                             attempted += "remaining"
                         },
                     ),
-                ) {
-                    Unit
-                }
+                ) {}
             }
 
             (thrown === interruption).shouldBeTrue()
             check(attempted == listOf("interrupted", "remaining"))
+            interruptibleCleanupCompleted.get().shouldBeTrue()
             Thread.currentThread().isInterrupted.shouldBeTrue()
         } finally {
             Thread.interrupted()

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationTestSupport.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationTestSupport.kt
@@ -1,0 +1,902 @@
+package io.bluetape4k.opentelemetry.context
+
+import io.bluetape4k.junit5.coroutines.DEFAULT_CANCELLATION_CONTRACT_TIMEOUT
+import io.bluetape4k.junit5.observability.ContextCleanupExpectation
+import io.bluetape4k.junit5.observability.ContextCleanupProbe
+import io.bluetape4k.junit5.observability.ContextIsolationExpectation
+import io.bluetape4k.junit5.observability.ContextIsolationObservation
+import io.bluetape4k.junit5.observability.ContextIsolationSample
+import io.bluetape4k.junit5.observability.ContextIsolationSampleExpectation
+import io.bluetape4k.junit5.observability.ContextMarkerExpectation
+import io.bluetape4k.junit5.observability.ContextMarkerExpectationMode
+import io.bluetape4k.junit5.observability.ContextMarkerObservation
+import io.bluetape4k.junit5.observability.ContextObservationPoint
+import io.bluetape4k.junit5.observability.ContextProbeLocation
+import io.bluetape4k.junit5.observability.ContextPropagationBoundary
+import io.bluetape4k.junit5.observability.ContextPropagationExpectation
+import io.bluetape4k.junit5.observability.ContextPropagationObservation
+import io.bluetape4k.junit5.observability.ContextPropagationScenario
+import io.bluetape4k.junit5.observability.ContextPropagationTerminal
+import io.bluetape4k.junit5.observability.ContextRequestAlias
+import io.bluetape4k.opentelemetry.coroutines.withOtelContext
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.ContextKey
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Scheduler
+import reactor.core.scheduler.Schedulers
+import java.util.concurrent.Callable
+import java.util.concurrent.CancellationException
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.toJavaDuration
+
+internal val propagationMarkerKey: ContextKey<String> =
+    ContextKey.named("bluetape4k-context-propagation-test-marker")
+
+internal const val parentMarkerA = "parent-A"
+internal const val parentMarkerB = "parent-B"
+
+private const val reactorOtelContextKey = "bluetape4k.otel.context"
+private const val probeMarker = "probe-marker"
+
+private val hangGuard = DEFAULT_CANCELLATION_CONTRACT_TIMEOUT
+private val semanticDeadline = 250.milliseconds.also {
+    check(it < hangGuard)
+}
+
+internal fun otelContext(marker: String): Context =
+    Context.root().with(propagationMarkerKey, marker)
+
+internal fun currentMarker(): String? =
+    Context.current().get(propagationMarkerKey)
+
+internal fun CountDownLatch.awaitOrFail(
+    timeout: Duration = DEFAULT_CANCELLATION_CONTRACT_TIMEOUT,
+) {
+    check(await(timeout.inWholeNanoseconds, TimeUnit.NANOSECONDS)) {
+        "Timed out waiting for test gate"
+    }
+}
+
+internal fun <T> Future<T>.getWithin(timeout: Duration): T =
+    get(timeout.inWholeNanoseconds, TimeUnit.NANOSECONDS)
+
+internal fun <T> captureExecutorTerminal(
+    future: Future<T>,
+    timeout: Duration,
+): Throwable? =
+    try {
+        future.getWithin(timeout)
+        null
+    } catch (e: InterruptedException) {
+        Thread.currentThread().interrupt()
+        throw e
+    } catch (e: ExecutionException) {
+        val cause = e.cause ?: e
+        if (cause is Error) {
+            throw cause
+        }
+        cause
+    } catch (e: TimeoutException) {
+        throw AssertionError("Timed out waiting for test executor result", e)
+    } catch (e: CancellationException) {
+        e
+    }
+
+internal enum class ConformanceEvent {
+    READY,
+    RELEASED,
+    TERMINAL_OBSERVED,
+    FINALLY_COMPLETED,
+    CLEANUP_PROBED,
+}
+
+internal class ConformanceEventEntry(
+    val requestAlias: ContextRequestAlias,
+    val event: ConformanceEvent,
+    val sequence: Long,
+)
+
+internal class ConformanceEventLedger {
+    private val sequence = AtomicLong()
+    private val events = ConcurrentLinkedQueue<ConformanceEventEntry>()
+
+    fun record(
+        requestAlias: ContextRequestAlias,
+        event: ConformanceEvent,
+    ) {
+        events += ConformanceEventEntry(
+            requestAlias,
+            event,
+            sequence.incrementAndGet(),
+        )
+    }
+
+    fun assertIsolationOrder() {
+        val snapshot = events.toList()
+        val participantEntries = listOf(
+            ContextRequestAlias.REQUEST_A,
+            ContextRequestAlias.REQUEST_B,
+        ).associateWith { alias ->
+            snapshot.filter { it.requestAlias == alias }.also { entries ->
+                val counts = entries.groupingBy { it.event }.eachCount()
+                ConformanceEvent.entries.forEach { event ->
+                    check(counts[event] == 1) {
+                        "Lifecycle event count mismatch: alias=$alias, event=$event"
+                    }
+                }
+            }
+        }
+        val lastReady = participantEntries.values
+            .flatten()
+            .filter { it.event == ConformanceEvent.READY }
+            .maxOf { it.sequence }
+        val firstRelease = participantEntries.values
+            .flatten()
+            .filter { it.event == ConformanceEvent.RELEASED }
+            .minOf { it.sequence }
+        check(lastReady < firstRelease)
+        participantEntries.forEach { (alias, entries) ->
+            assertCleanupAfterFinally(alias, entries)
+        }
+    }
+
+    fun assertSingleScenarioOrder() {
+        val entries = events.filter {
+            it.requestAlias == ContextRequestAlias.SINGLE
+        }
+        val counts = entries.groupingBy { it.event }.eachCount()
+        listOf(
+            ConformanceEvent.TERMINAL_OBSERVED,
+            ConformanceEvent.FINALLY_COMPLETED,
+            ConformanceEvent.CLEANUP_PROBED,
+        ).forEach { event ->
+            check(counts[event] == 1) {
+                "Lifecycle event count mismatch: alias=SINGLE, event=$event"
+            }
+        }
+        check(counts[ConformanceEvent.READY] == null)
+        check(counts[ConformanceEvent.RELEASED] == null)
+        assertCleanupAfterFinally(ContextRequestAlias.SINGLE, entries)
+    }
+
+    private fun assertCleanupAfterFinally(
+        alias: ContextRequestAlias,
+        entries: List<ConformanceEventEntry>,
+    ) {
+        val finallySequence = entries.single {
+            it.event == ConformanceEvent.FINALLY_COMPLETED
+        }.sequence
+        val terminalSequence = entries.single {
+            it.event == ConformanceEvent.TERMINAL_OBSERVED
+        }.sequence
+        val cleanupSequence = entries.single {
+            it.event == ConformanceEvent.CLEANUP_PROBED
+        }.sequence
+        check(terminalSequence < cleanupSequence) {
+            "Lifecycle terminal cleanup order mismatch: alias=$alias"
+        }
+        check(finallySequence < cleanupSequence) {
+            "Lifecycle cleanup order mismatch: alias=$alias"
+        }
+    }
+}
+
+internal fun propagationExpectation(
+    boundary: ContextPropagationBoundary,
+    scenario: ContextPropagationScenario,
+    terminal: ContextPropagationTerminal,
+    requestAlias: ContextRequestAlias = ContextRequestAlias.SINGLE,
+): ContextPropagationExpectation =
+    ContextPropagationExpectation(
+        boundary = boundary,
+        scenario = scenario,
+        requestAlias = requestAlias,
+        markerExpectations = listOf(
+            ContextMarkerExpectation(ContextObservationPoint.BOUNDARY_ENTER, parentMarkerA),
+            ContextMarkerExpectation(ContextObservationPoint.AFTER_SUSPENSION, parentMarkerA),
+            ContextMarkerExpectation(ContextObservationPoint.BEFORE_TERMINAL, parentMarkerA),
+        ),
+        cleanupExpectations = listOf(
+            ContextCleanupExpectation(ContextProbeLocation.CALLER, null),
+            ContextCleanupExpectation(ContextProbeLocation.WORKER, null),
+        ),
+        expectedTerminal = terminal,
+    )
+
+internal fun ExecutorService.shutdownAndAssertTermination() {
+    var interrupted: InterruptedException? = null
+    var terminated = false
+    try {
+        shutdown()
+        terminated = awaitTermination(5, TimeUnit.SECONDS)
+    } catch (e: InterruptedException) {
+        interrupted = e
+    } finally {
+        if (!terminated) {
+            shutdownNow()
+        }
+    }
+
+    if (!terminated) {
+        terminated = try {
+            awaitTermination(5, TimeUnit.SECONDS)
+        } catch (e: InterruptedException) {
+            interrupted = interrupted ?: e
+            false
+        }
+    }
+    interrupted?.let {
+        Thread.currentThread().interrupt()
+        throw AssertionError("Interrupted while terminating test executor", it)
+    }
+    check(terminated) { "Test executor did not terminate" }
+}
+
+internal fun <T> withExecutorCleanup(
+    executor: ExecutorService,
+    cancel: ExecutorService.() -> Unit = {},
+    shutdown: ExecutorService.() -> Unit = { shutdownAndAssertTermination() },
+    block: () -> T,
+): T {
+    var primaryFailure: Throwable? = null
+    try {
+        return block()
+    } catch (e: Exception) {
+        primaryFailure = e
+        throw e
+    } catch (e: Error) {
+        primaryFailure = e
+        throw e
+    } finally {
+        val restoreInterrupt = Thread.interrupted()
+        var aggregatedFailure = primaryFailure
+        listOf(cancel, shutdown).forEach { cleanup ->
+            var cleanupFailure: Throwable? = null
+            try {
+                executor.cleanup()
+            } catch (e: Exception) {
+                cleanupFailure = e
+            } catch (e: Error) {
+                cleanupFailure = e
+            }
+
+            cleanupFailure?.let { failure ->
+                val aggregate = aggregatedFailure
+                if (aggregate == null) {
+                    aggregatedFailure = failure
+                } else if (aggregate !== failure && aggregate.suppressed.none { it === failure }) {
+                    aggregate.addSuppressed(failure)
+                }
+            }
+        }
+
+        try {
+            if (primaryFailure == null) {
+                aggregatedFailure?.let { throw it }
+            }
+        } finally {
+            if (restoreInterrupt) {
+                Thread.currentThread().interrupt()
+            }
+        }
+    }
+}
+
+internal class CapturedScenario(
+    val observation: ContextPropagationObservation,
+    val thrown: Throwable?,
+)
+
+internal inline fun <reified T: Throwable> CapturedScenario.assertThrownExactly() {
+    check(thrown?.javaClass == T::class.java) {
+        "Scenario terminal type mismatch; values redacted"
+    }
+}
+
+private class CoroutineTerminalResult(
+    val thrown: Throwable?,
+    val workerMarker: String?,
+)
+
+private class CoroutineIsolationResult(
+    val probeMarker: String?,
+    val workerMarker: String?,
+)
+
+internal suspend fun runCoroutineScenario(
+    scenario: ContextPropagationScenario,
+): CapturedScenario {
+    check(scenario != ContextPropagationScenario.ISOLATION) {
+        "Isolation uses runCoroutineIsolationScenario"
+    }
+
+    val executor = Executors.newSingleThreadExecutor()
+    val dispatcher = executor.asCoroutineDispatcher()
+    val ledger = ConformanceEventLedger()
+    val observations = mutableListOf<ContextMarkerObservation>()
+    return withCoroutineResources(dispatcher, executor) {
+        val result = withContext(dispatcher) {
+            supervisorScope {
+                val started = CompletableDeferred<Unit>()
+                val cancellationSignal = CancellationException("synthetic coroutine cancellation")
+                val child = async {
+                    executeCoroutineTerminal(
+                        dispatcher,
+                        scenario,
+                        observations,
+                        started,
+                        ledger,
+                    )
+                }
+                withCoroutineChildCleanup(
+                    children = listOf(child),
+                    beforeCleanup = {
+                        started.complete(Unit)
+                    },
+                ) {
+                    started.awaitGateWithin()
+                    if (scenario == ContextPropagationScenario.CANCELLATION) {
+                        child.cancel(cancellationSignal)
+                    }
+                    val thrown = child.captureTerminalWithin()
+                    ledger.record(ContextRequestAlias.SINGLE, ConformanceEvent.TERMINAL_OBSERVED)
+                    val workerMarker = currentMarker()
+                    ledger.record(ContextRequestAlias.SINGLE, ConformanceEvent.CLEANUP_PROBED)
+                    ledger.assertSingleScenarioOrder()
+                    CoroutineTerminalResult(thrown, workerMarker)
+                }
+            }
+        }
+        capturedScenario(
+            ContextPropagationBoundary.COROUTINE,
+            scenario,
+            observations,
+            result.workerMarker,
+            terminalFor(scenario),
+            result.thrown,
+        )
+    }
+}
+
+internal suspend fun runCoroutineIsolationScenario(): ContextIsolationObservation {
+    val executor = Executors.newSingleThreadExecutor()
+    val dispatcher = executor.asCoroutineDispatcher()
+    val ledger = ConformanceEventLedger()
+    val markersA = mutableListOf<String?>()
+    val markersB = mutableListOf<String?>()
+
+    return withCoroutineResources(dispatcher, executor) {
+        val result = withContext(dispatcher) {
+            supervisorScope {
+                val readyA = CompletableDeferred<Unit>()
+                val readyB = CompletableDeferred<Unit>()
+                val childA = async {
+                    executeCoroutineIsolationParticipant(
+                        dispatcher,
+                        ContextRequestAlias.REQUEST_A,
+                        parentMarkerA,
+                        markersA,
+                        readyA,
+                        readyB,
+                        ledger,
+                    )
+                }
+                val childB = async {
+                    executeCoroutineIsolationParticipant(
+                        dispatcher,
+                        ContextRequestAlias.REQUEST_B,
+                        parentMarkerB,
+                        markersB,
+                        readyB,
+                        readyA,
+                        ledger,
+                    )
+                }
+                withCoroutineChildCleanup(
+                    children = listOf(childA, childB),
+                    beforeCleanup = {
+                        readyA.complete(Unit)
+                        readyB.complete(Unit)
+                    },
+                ) {
+                    childA.awaitCompletedWithin()
+                    ledger.record(ContextRequestAlias.REQUEST_A, ConformanceEvent.TERMINAL_OBSERVED)
+                    childB.awaitCompletedWithin()
+                    ledger.record(ContextRequestAlias.REQUEST_B, ConformanceEvent.TERMINAL_OBSERVED)
+
+                    val probe = withOtelContext(
+                        coroutineContext = dispatcher,
+                        otelContext = otelContext(probeMarker),
+                    ) {
+                        currentMarker()
+                    }
+                    val workerProbeA = currentMarker()
+                    ledger.record(ContextRequestAlias.REQUEST_A, ConformanceEvent.CLEANUP_PROBED)
+                    val workerProbeB = currentMarker()
+                    ledger.record(ContextRequestAlias.REQUEST_B, ConformanceEvent.CLEANUP_PROBED)
+                    check(workerProbeA == null && workerProbeB == null) {
+                        "Coroutine worker context was not restored"
+                    }
+                    ledger.assertIsolationOrder()
+                    CoroutineIsolationResult(probe, workerProbeA)
+                }
+            }
+        }
+        ContextIsolationObservation(
+            boundary = ContextPropagationBoundary.COROUTINE,
+            samples = listOf(
+                ContextIsolationSample(ContextRequestAlias.REQUEST_A, markersA.toList()),
+                ContextIsolationSample(ContextRequestAlias.REQUEST_B, markersB.toList()),
+                ContextIsolationSample(ContextRequestAlias.PROBE, listOf(result.probeMarker)),
+            ),
+            cleanupProbes = listOf(
+                ContextCleanupProbe(ContextProbeLocation.CALLER, currentMarker()),
+                ContextCleanupProbe(ContextProbeLocation.WORKER, result.workerMarker),
+            ),
+        )
+    }
+}
+
+internal fun coroutineIsolationExpectation(): ContextIsolationExpectation =
+    ContextIsolationExpectation(
+        boundary = ContextPropagationBoundary.COROUTINE,
+        samples = listOf(
+            ContextIsolationSampleExpectation(
+                requestAlias = ContextRequestAlias.REQUEST_A,
+                mode = ContextMarkerExpectationMode.EXACT,
+                expectedMarker = parentMarkerA,
+                minimumObservationCount = 3,
+            ),
+            ContextIsolationSampleExpectation(
+                requestAlias = ContextRequestAlias.REQUEST_B,
+                mode = ContextMarkerExpectationMode.EXACT,
+                expectedMarker = parentMarkerB,
+                minimumObservationCount = 3,
+            ),
+            ContextIsolationSampleExpectation(
+                requestAlias = ContextRequestAlias.PROBE,
+                mode = ContextMarkerExpectationMode.NOT_IN,
+                forbiddenMarkers = listOf(parentMarkerA, parentMarkerB),
+            ),
+        ),
+        cleanupExpectations = listOf(
+            ContextCleanupExpectation(ContextProbeLocation.CALLER, null),
+            ContextCleanupExpectation(ContextProbeLocation.WORKER, null),
+        ),
+    )
+
+internal fun runReactorScenario(
+    scenario: ContextPropagationScenario,
+): CapturedScenario {
+    check(scenario == ContextPropagationScenario.SUCCESS) {
+        "Task 2 supports only the success Reactor scenario"
+    }
+
+    val scheduler = Schedulers.newSingle("otel-context-conformance")
+    val ledger = ConformanceEventLedger()
+    val observations = mutableListOf<ContextMarkerObservation>()
+    var thrown: Throwable? = null
+    try {
+        try {
+            executeReactorSuccess(scheduler, observations, ledger)
+                .block(DEFAULT_CANCELLATION_CONTRACT_TIMEOUT.toJavaDuration())
+        } catch (e: Exception) {
+            thrown = e
+        }
+        ledger.record(ContextRequestAlias.SINGLE, ConformanceEvent.TERMINAL_OBSERVED)
+        val workerMarker = Mono.fromCallable(::currentMarker)
+            .subscribeOn(scheduler)
+            .block(DEFAULT_CANCELLATION_CONTRACT_TIMEOUT.toJavaDuration())
+        ledger.record(ContextRequestAlias.SINGLE, ConformanceEvent.CLEANUP_PROBED)
+        ledger.assertSingleScenarioOrder()
+        return capturedSuccess(
+            ContextPropagationBoundary.REACTOR,
+            scenario,
+            observations,
+            workerMarker,
+            thrown,
+        )
+    } finally {
+        shutdownScheduler(scheduler)
+    }
+}
+
+internal fun runExecutorScenario(
+    scenario: ContextPropagationScenario,
+): CapturedScenario {
+    check(scenario == ContextPropagationScenario.SUCCESS) {
+        "Task 2 supports only the success executor scenario"
+    }
+
+    val executor = Executors.newSingleThreadExecutor()
+    val ledger = ConformanceEventLedger()
+    val observations = mutableListOf<ContextMarkerObservation>()
+    var future: Future<Unit>? = null
+    return withExecutorCleanup(
+        executor = executor,
+        cancel = {
+            future?.cancel(true)
+        },
+    ) {
+        future = executeExecutorSuccess(executor, observations, ledger)
+        val thrown = captureExecutorTerminal(future, DEFAULT_CANCELLATION_CONTRACT_TIMEOUT)
+        ledger.record(ContextRequestAlias.SINGLE, ConformanceEvent.TERMINAL_OBSERVED)
+        val workerMarker = executor.submit(Callable(::currentMarker))
+            .getWithin(DEFAULT_CANCELLATION_CONTRACT_TIMEOUT)
+        ledger.record(ContextRequestAlias.SINGLE, ConformanceEvent.CLEANUP_PROBED)
+        ledger.assertSingleScenarioOrder()
+        capturedSuccess(
+            ContextPropagationBoundary.TASK_EXECUTOR,
+            scenario,
+            observations,
+            workerMarker,
+            thrown,
+        )
+    }
+}
+
+private suspend fun executeCoroutineTerminal(
+    dispatcher: CoroutineDispatcher,
+    scenario: ContextPropagationScenario,
+    observations: MutableList<ContextMarkerObservation>,
+    started: CompletableDeferred<Unit>,
+    ledger: ConformanceEventLedger,
+) {
+    try {
+        withOtelContext(
+            coroutineContext = dispatcher,
+            otelContext = otelContext(parentMarkerA),
+        ) {
+            observeCoroutineBody(observations)
+            started.complete(Unit)
+            when (scenario) {
+                ContextPropagationScenario.SUCCESS -> Unit
+                ContextPropagationScenario.FAILURE -> error("synthetic failure")
+                ContextPropagationScenario.CANCELLATION -> awaitCancellation()
+                ContextPropagationScenario.DEADLINE ->
+                    withTimeout(semanticDeadline) { awaitCancellation() }
+
+                ContextPropagationScenario.ISOLATION ->
+                    error("Isolation uses runCoroutineIsolationScenario")
+            }
+        }
+    } finally {
+        started.complete(Unit)
+        ledger.record(ContextRequestAlias.SINGLE, ConformanceEvent.FINALLY_COMPLETED)
+    }
+}
+
+private suspend fun executeCoroutineIsolationParticipant(
+    dispatcher: CoroutineDispatcher,
+    alias: ContextRequestAlias,
+    marker: String,
+    observations: MutableList<String?>,
+    ownReady: CompletableDeferred<Unit>,
+    peerReady: CompletableDeferred<Unit>,
+    ledger: ConformanceEventLedger,
+) {
+    try {
+        withOtelContext(
+            coroutineContext = dispatcher,
+            otelContext = otelContext(marker),
+        ) {
+            observations += currentMarker()
+            ledger.record(alias, ConformanceEvent.READY)
+            ownReady.complete(Unit)
+            peerReady.awaitGateWithin()
+            ledger.record(alias, ConformanceEvent.RELEASED)
+            yield()
+            observations += currentMarker()
+            observations += currentMarker()
+        }
+    } finally {
+        peerReady.complete(Unit)
+        ledger.record(alias, ConformanceEvent.FINALLY_COMPLETED)
+    }
+}
+
+private suspend fun observeCoroutineBody(
+    observations: MutableList<ContextMarkerObservation>,
+) {
+    observations += markerObservation(ContextObservationPoint.BOUNDARY_ENTER)
+    yield()
+    observations += markerObservation(ContextObservationPoint.AFTER_SUSPENSION)
+    observations += markerObservation(ContextObservationPoint.BEFORE_TERMINAL)
+}
+
+private fun executeReactorSuccess(
+    scheduler: Scheduler,
+    observations: MutableList<ContextMarkerObservation>,
+    ledger: ConformanceEventLedger,
+): Mono<Unit> =
+    Mono.deferContextual { view ->
+        val captured = view.get<Context>(reactorOtelContextKey)
+        Mono.fromCallable(
+            captured.wrap(
+                Callable {
+                    observations += markerObservation(ContextObservationPoint.BOUNDARY_ENTER)
+                    observations += markerObservation(ContextObservationPoint.AFTER_SUSPENSION)
+                    observations += markerObservation(ContextObservationPoint.BEFORE_TERMINAL)
+                    Unit
+                },
+            ),
+        )
+    }
+        .contextWrite { it.put(reactorOtelContextKey, otelContext(parentMarkerA)) }
+        .subscribeOn(scheduler)
+        .doFinally {
+            ledger.record(ContextRequestAlias.SINGLE, ConformanceEvent.FINALLY_COMPLETED)
+        }
+
+private fun executeExecutorSuccess(
+    executor: ExecutorService,
+    observations: MutableList<ContextMarkerObservation>,
+    ledger: ConformanceEventLedger,
+): Future<Unit> =
+    executor.submit(
+        otelContext(parentMarkerA).wrap(
+            Callable {
+                try {
+                    observations += markerObservation(ContextObservationPoint.BOUNDARY_ENTER)
+                    observations += markerObservation(ContextObservationPoint.AFTER_SUSPENSION)
+                    observations += markerObservation(ContextObservationPoint.BEFORE_TERMINAL)
+                    Unit
+                } finally {
+                    ledger.record(ContextRequestAlias.SINGLE, ConformanceEvent.FINALLY_COMPLETED)
+                }
+            },
+        ),
+    )
+
+private fun markerObservation(point: ContextObservationPoint): ContextMarkerObservation =
+    ContextMarkerObservation(point, currentMarker())
+
+private suspend fun CompletableDeferred<Unit>.awaitGateWithin() {
+    try {
+        withTimeout(hangGuard) {
+            await()
+        }
+    } catch (e: TimeoutCancellationException) {
+        throw AssertionError("Timed out waiting for coroutine test gate", e)
+    }
+}
+
+private suspend fun Deferred<Unit>.captureTerminalWithin(): Throwable? =
+    try {
+        withTimeout(hangGuard) {
+            await()
+        }
+        null
+    } catch (e: TimeoutCancellationException) {
+        if (isCompleted) {
+            e
+        } else {
+            throw AssertionError("Timed out waiting for coroutine terminal", e)
+        }
+    } catch (e: CancellationException) {
+        e
+    } catch (e: Exception) {
+        e
+    }
+
+private suspend fun Deferred<Unit>.awaitCompletedWithin() {
+    try {
+        withTimeout(hangGuard) {
+            await()
+        }
+    } catch (e: TimeoutCancellationException) {
+        if (isCompleted) {
+            throw e
+        }
+        throw AssertionError("Timed out waiting for coroutine completion", e)
+    }
+}
+
+private suspend fun cleanupCoroutineChildren(
+    primaryFailure: Throwable?,
+    beforeCleanup: () -> Unit,
+    children: List<Deferred<*>>,
+) {
+    cleanupCoroutineActions(
+        primaryFailure = primaryFailure,
+        actions = buildList {
+            add {
+                beforeCleanup()
+            }
+            children.forEach { child ->
+                add {
+                    child.cancelAndJoin()
+                }
+            }
+        },
+    )
+}
+
+internal suspend fun <T> withCoroutineChildCleanup(
+    children: List<Deferred<*>>,
+    beforeCleanup: () -> Unit,
+    block: suspend () -> T,
+): T {
+    var primaryFailure: Throwable? = null
+    try {
+        return block()
+    } catch (e: Exception) {
+        primaryFailure = e
+        throw e
+    } catch (e: Error) {
+        primaryFailure = e
+        throw e
+    } finally {
+        cleanupCoroutineChildren(primaryFailure, beforeCleanup, children)
+    }
+}
+
+internal suspend fun cleanupCoroutineActions(
+    primaryFailure: Throwable? = null,
+    actions: List<suspend () -> Unit>,
+) {
+    var aggregatedFailure = primaryFailure
+    withContext(NonCancellable) {
+        actions.forEach { cleanup ->
+            var cleanupFailure: Throwable? = null
+            try {
+                withTimeout(hangGuard) {
+                    try {
+                        cleanup()
+                    } catch (e: Exception) {
+                        cleanupFailure = e
+                    } catch (e: Error) {
+                        cleanupFailure = e
+                    }
+                }
+            } catch (e: TimeoutCancellationException) {
+                cleanupFailure = AssertionError("Timed out cancelling coroutine child", e)
+            } catch (e: Exception) {
+                cleanupFailure = e
+            } catch (e: Error) {
+                cleanupFailure = e
+            }
+
+            cleanupFailure?.let { failure ->
+                val aggregate = aggregatedFailure
+                if (aggregate == null) {
+                    aggregatedFailure = failure
+                } else if (aggregate !== failure && aggregate.suppressed.none { it === failure }) {
+                    aggregate.addSuppressed(failure)
+                }
+            }
+        }
+    }
+    aggregatedFailure?.let { throw it }
+}
+
+private suspend fun <T> withCoroutineResources(
+    dispatcher: ExecutorCoroutineDispatcher,
+    executor: ExecutorService,
+    block: suspend () -> T,
+): T {
+    var primaryFailure: Throwable? = null
+    try {
+        return block()
+    } catch (e: Exception) {
+        primaryFailure = e
+        throw e
+    } catch (e: Error) {
+        primaryFailure = e
+        throw e
+    } finally {
+        val restoreInterrupt = Thread.interrupted()
+        var aggregatedFailure = primaryFailure
+        listOf<() -> Unit>(
+            dispatcher::close,
+            executor::shutdownAndAssertTermination,
+        ).forEach { cleanup ->
+            var cleanupFailure: Throwable? = null
+            try {
+                cleanup()
+            } catch (e: Exception) {
+                cleanupFailure = e
+            } catch (e: Error) {
+                cleanupFailure = e
+            }
+
+            cleanupFailure?.let { failure ->
+                val aggregate = aggregatedFailure
+                if (aggregate == null) {
+                    aggregatedFailure = failure
+                } else if (aggregate !== failure && aggregate.suppressed.none { it === failure }) {
+                    aggregate.addSuppressed(failure)
+                }
+            }
+        }
+
+        try {
+            if (primaryFailure == null) {
+                aggregatedFailure?.let { throw it }
+            }
+        } finally {
+            if (restoreInterrupt) {
+                Thread.currentThread().interrupt()
+            }
+        }
+    }
+}
+
+private fun terminalFor(scenario: ContextPropagationScenario): ContextPropagationTerminal =
+    when (scenario) {
+        ContextPropagationScenario.SUCCESS -> ContextPropagationTerminal.SUCCESS
+        ContextPropagationScenario.FAILURE -> ContextPropagationTerminal.FAILURE
+        ContextPropagationScenario.CANCELLATION -> ContextPropagationTerminal.CANCELLATION
+        ContextPropagationScenario.DEADLINE -> ContextPropagationTerminal.DEADLINE_EXCEEDED
+        ContextPropagationScenario.ISOLATION ->
+            error("Isolation uses coroutineIsolationExpectation")
+    }
+
+private fun capturedScenario(
+    boundary: ContextPropagationBoundary,
+    scenario: ContextPropagationScenario,
+    observations: List<ContextMarkerObservation>,
+    workerMarker: String?,
+    terminal: ContextPropagationTerminal,
+    thrown: Throwable?,
+): CapturedScenario =
+    CapturedScenario(
+        observation = ContextPropagationObservation(
+            boundary = boundary,
+            scenario = scenario,
+            requestAlias = ContextRequestAlias.SINGLE,
+            markerObservations = observations.toList(),
+            cleanupProbes = listOf(
+                ContextCleanupProbe(ContextProbeLocation.CALLER, currentMarker()),
+                ContextCleanupProbe(ContextProbeLocation.WORKER, workerMarker),
+            ),
+            terminal = terminal,
+        ),
+        thrown = thrown,
+    )
+
+private fun capturedSuccess(
+    boundary: ContextPropagationBoundary,
+    scenario: ContextPropagationScenario,
+    observations: List<ContextMarkerObservation>,
+    workerMarker: String?,
+    thrown: Throwable?,
+): CapturedScenario =
+    capturedScenario(
+        boundary,
+        scenario,
+        observations,
+        workerMarker,
+        ContextPropagationTerminal.SUCCESS,
+        thrown,
+    )
+
+private fun shutdownScheduler(scheduler: Scheduler) {
+    scheduler.disposeGracefully()
+        .block(DEFAULT_CANCELLATION_CONTRACT_TIMEOUT.toJavaDuration())
+    check(scheduler.isDisposed) { "Test scheduler did not terminate" }
+}

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationTestSupport.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationTestSupport.kt
@@ -1387,7 +1387,6 @@ internal fun <T> withReactorCleanup(
                 null
             } catch (e: InterruptedException) {
                 restoreInterrupt = true
-                Thread.currentThread().interrupt()
                 e
             } catch (e: Exception) {
                 e

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationTestSupport.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationTestSupport.kt
@@ -478,6 +478,9 @@ internal fun coroutineIsolationExpectation(): ContextIsolationExpectation =
 internal fun reactorIsolationExpectation(): ContextIsolationExpectation =
     isolationExpectation(ContextPropagationBoundary.REACTOR)
 
+internal fun executorIsolationExpectation(): ContextIsolationExpectation =
+    isolationExpectation(ContextPropagationBoundary.TASK_EXECUTOR)
+
 private fun isolationExpectation(
     boundary: ContextPropagationBoundary,
 ): ContextIsolationExpectation =
@@ -653,33 +656,172 @@ internal fun runReactorIsolationScenario(): ContextIsolationObservation {
 internal fun runExecutorScenario(
     scenario: ContextPropagationScenario,
 ): CapturedScenario {
-    check(scenario == ContextPropagationScenario.SUCCESS) {
-        "Task 2 supports only the success executor scenario"
+    check(scenario != ContextPropagationScenario.ISOLATION) {
+        "Isolation uses runExecutorIsolationScenario"
     }
 
     val executor = Executors.newSingleThreadExecutor()
     val ledger = ConformanceEventLedger()
     val observations = mutableListOf<ContextMarkerObservation>()
+    val entered = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    val finallyCompleted = CountDownLatch(1)
     var future: Future<Unit>? = null
     return withExecutorCleanup(
         executor = executor,
         cancel = {
             future?.cancel(true)
+            release.countDown()
         },
     ) {
-        future = executeExecutorSuccess(executor, observations, ledger)
-        val thrown = captureExecutorTerminal(future, DEFAULT_CANCELLATION_CONTRACT_TIMEOUT)
+        val submitted = submitExecutorScenario(
+            executor,
+            scenario,
+            observations,
+            entered,
+            release,
+            finallyCompleted,
+        )
+        future = submitted
+        entered.awaitOrFail(hangGuard)
+        val thrown = when (scenario) {
+            ContextPropagationScenario.SUCCESS,
+            ContextPropagationScenario.FAILURE -> captureExecutorTerminal(submitted, hangGuard)
+
+            ContextPropagationScenario.CANCELLATION -> {
+                check(submitted.cancel(true)) {
+                    "Running executor task was not cancelled"
+                }
+                captureExecutorTerminal(submitted, hangGuard)
+            }
+
+            ContextPropagationScenario.DEADLINE -> {
+                val timeout = try {
+                    submitted.getWithin(semanticDeadline)
+                    error("Executor deadline did not expire")
+                } catch (e: TimeoutException) {
+                    e
+                }
+                check(submitted.cancel(true)) {
+                    "Timed out executor task was not cancelled"
+                }
+                timeout
+            }
+
+            ContextPropagationScenario.ISOLATION ->
+                error("Isolation uses runExecutorIsolationScenario")
+        }
         ledger.record(ContextRequestAlias.SINGLE, ConformanceEvent.TERMINAL_OBSERVED)
-        val workerMarker = executor.submit(Callable(::currentMarker))
-            .getWithin(DEFAULT_CANCELLATION_CONTRACT_TIMEOUT)
+        finallyCompleted.awaitOrFail(hangGuard)
+        ledger.record(ContextRequestAlias.SINGLE, ConformanceEvent.FINALLY_COMPLETED)
+        val workerMarker = executorWorkerProbe(executor)
         ledger.record(ContextRequestAlias.SINGLE, ConformanceEvent.CLEANUP_PROBED)
         ledger.assertSingleScenarioOrder()
-        capturedSuccess(
+        capturedScenario(
             ContextPropagationBoundary.TASK_EXECUTOR,
             scenario,
             observations,
             workerMarker,
+            terminalFor(scenario),
             thrown,
+        )
+    }
+}
+
+internal fun runExecutorIsolationScenario(): ContextIsolationObservation {
+    val executor = Executors.newSingleThreadExecutor()
+    val ledger = ConformanceEventLedger()
+    val workerId = AtomicLong()
+    val markersA = mutableListOf<String?>()
+    val markersB = mutableListOf<String?>()
+    val finallyA = CountDownLatch(1)
+    val finallyB = CountDownLatch(1)
+    var outstanding: Future<Unit>? = null
+
+    return withExecutorCleanup(
+        executor = executor,
+        cancel = {
+            outstanding?.cancel(true)
+        },
+    ) {
+        val readyA = submitExecutorIsolationReady(
+            executor,
+            ContextRequestAlias.REQUEST_A,
+            parentMarkerA,
+            markersA,
+            workerId,
+            ledger,
+        )
+        outstanding = readyA
+        captureExecutorTerminal(readyA, hangGuard)?.let { throw it }
+        val readyB = submitExecutorIsolationReady(
+            executor,
+            ContextRequestAlias.REQUEST_B,
+            parentMarkerB,
+            markersB,
+            workerId,
+            ledger,
+        )
+        outstanding = readyB
+        captureExecutorTerminal(readyB, hangGuard)?.let { throw it }
+
+        val terminalA = submitExecutorIsolationTerminal(
+            executor,
+            ContextRequestAlias.REQUEST_A,
+            parentMarkerA,
+            markersA,
+            workerId,
+            finallyA,
+            ledger,
+        )
+        outstanding = terminalA
+        captureExecutorTerminal(terminalA, hangGuard)?.let { throw it }
+        ledger.record(ContextRequestAlias.REQUEST_A, ConformanceEvent.TERMINAL_OBSERVED)
+        finallyA.awaitOrFail(hangGuard)
+        ledger.record(ContextRequestAlias.REQUEST_A, ConformanceEvent.FINALLY_COMPLETED)
+        val workerMarkerA = executorWorkerProbe(executor, workerId)
+        ledger.record(ContextRequestAlias.REQUEST_A, ConformanceEvent.CLEANUP_PROBED)
+
+        val terminalB = submitExecutorIsolationTerminal(
+            executor,
+            ContextRequestAlias.REQUEST_B,
+            parentMarkerB,
+            markersB,
+            workerId,
+            finallyB,
+            ledger,
+        )
+        outstanding = terminalB
+        captureExecutorTerminal(terminalB, hangGuard)?.let { throw it }
+        ledger.record(ContextRequestAlias.REQUEST_B, ConformanceEvent.TERMINAL_OBSERVED)
+        finallyB.awaitOrFail(hangGuard)
+        ledger.record(ContextRequestAlias.REQUEST_B, ConformanceEvent.FINALLY_COMPLETED)
+        val probe = executor.submit(
+            otelContext(probeMarker).wrap(
+                Callable {
+                    assertExecutorWorker(workerId)
+                    currentMarker()
+                },
+            ),
+        ).getWithin(hangGuard)
+        val workerMarkerB = executorWorkerProbe(executor, workerId)
+        ledger.record(ContextRequestAlias.REQUEST_B, ConformanceEvent.CLEANUP_PROBED)
+        check(workerMarkerA == null && workerMarkerB == null) {
+            "Executor worker context was not restored"
+        }
+        ledger.assertIsolationOrder()
+
+        ContextIsolationObservation(
+            boundary = ContextPropagationBoundary.TASK_EXECUTOR,
+            samples = listOf(
+                ContextIsolationSample(ContextRequestAlias.REQUEST_A, markersA.toList()),
+                ContextIsolationSample(ContextRequestAlias.REQUEST_B, markersB.toList()),
+                ContextIsolationSample(ContextRequestAlias.PROBE, listOf(probe)),
+            ),
+            cleanupProbes = listOf(
+                ContextCleanupProbe(ContextProbeLocation.CALLER, currentMarker()),
+                ContextCleanupProbe(ContextProbeLocation.WORKER, workerMarkerB),
+            ),
         )
     }
 }
@@ -866,10 +1008,13 @@ internal fun recordReactorIsolationFailure(
     ownReady.tryEmitError(failure)
 }
 
-private fun executeExecutorSuccess(
+private fun submitExecutorScenario(
     executor: ExecutorService,
+    scenario: ContextPropagationScenario,
     observations: MutableList<ContextMarkerObservation>,
-    ledger: ConformanceEventLedger,
+    entered: CountDownLatch,
+    release: CountDownLatch,
+    finallyCompleted: CountDownLatch,
 ): Future<Unit> =
     executor.submit(
         otelContext(parentMarkerA).wrap(
@@ -878,13 +1023,97 @@ private fun executeExecutorSuccess(
                     observations += markerObservation(ContextObservationPoint.BOUNDARY_ENTER)
                     observations += markerObservation(ContextObservationPoint.AFTER_SUSPENSION)
                     observations += markerObservation(ContextObservationPoint.BEFORE_TERMINAL)
-                    Unit
+                    entered.countDown()
+                    when (scenario) {
+                        ContextPropagationScenario.SUCCESS -> Unit
+                        ContextPropagationScenario.FAILURE -> error("synthetic failure")
+                        ContextPropagationScenario.CANCELLATION,
+                        ContextPropagationScenario.DEADLINE -> awaitExecutorInterrupt(release)
+
+                        ContextPropagationScenario.ISOLATION ->
+                            error("Isolation uses runExecutorIsolationScenario")
+                    }
                 } finally {
-                    ledger.record(ContextRequestAlias.SINGLE, ConformanceEvent.FINALLY_COMPLETED)
+                    entered.countDown()
+                    finallyCompleted.countDown()
                 }
             },
         ),
     )
+
+private fun submitExecutorIsolationReady(
+    executor: ExecutorService,
+    alias: ContextRequestAlias,
+    marker: String,
+    observations: MutableList<String?>,
+    workerId: AtomicLong,
+    ledger: ConformanceEventLedger,
+): Future<Unit> =
+    executor.submit(
+        otelContext(marker).wrap(
+            Callable {
+                assertExecutorWorker(workerId)
+                observations += currentMarker()
+                ledger.record(alias, ConformanceEvent.READY)
+                Unit
+            },
+        ),
+    )
+
+private fun submitExecutorIsolationTerminal(
+    executor: ExecutorService,
+    alias: ContextRequestAlias,
+    marker: String,
+    observations: MutableList<String?>,
+    workerId: AtomicLong,
+    finallyCompleted: CountDownLatch,
+    ledger: ConformanceEventLedger,
+): Future<Unit> =
+    executor.submit(
+        otelContext(marker).wrap(
+            Callable {
+                try {
+                    assertExecutorWorker(workerId)
+                    ledger.record(alias, ConformanceEvent.RELEASED)
+                    observations += currentMarker()
+                    observations += currentMarker()
+                    Unit
+                } finally {
+                    finallyCompleted.countDown()
+                }
+            },
+        ),
+    )
+
+private fun awaitExecutorInterrupt(release: CountDownLatch) {
+    try {
+        release.awaitOrFail(hangGuard)
+        error("Executor task was released without interruption")
+    } catch (e: InterruptedException) {
+        Thread.currentThread().interrupt()
+    }
+}
+
+private fun assertExecutorWorker(workerId: AtomicLong) {
+    val current = Thread.currentThread().threadId()
+    val expected = workerId.updateAndGet { existing ->
+        if (existing == 0L) current else existing
+    }
+    check(expected == current) {
+        "Executor isolation did not reuse the same worker"
+    }
+}
+
+private fun executorWorkerProbe(
+    executor: ExecutorService,
+    workerId: AtomicLong? = null,
+): String? =
+    executor.submit(
+        Callable {
+            workerId?.let(::assertExecutorWorker)
+            currentMarker()
+        },
+    ).getWithin(hangGuard)
 
 private fun markerObservation(point: ContextObservationPoint): ContextMarkerObservation =
     ContextMarkerObservation(point, currentMarker())
@@ -1205,22 +1434,6 @@ private fun capturedScenario(
             terminal = terminal,
         ),
         thrown = thrown,
-    )
-
-private fun capturedSuccess(
-    boundary: ContextPropagationBoundary,
-    scenario: ContextPropagationScenario,
-    observations: List<ContextMarkerObservation>,
-    workerMarker: String?,
-    thrown: Throwable?,
-): CapturedScenario =
-    capturedScenario(
-        boundary,
-        scenario,
-        observations,
-        workerMarker,
-        ContextPropagationTerminal.SUCCESS,
-        thrown,
     )
 
 private fun shutdownScheduler(scheduler: Scheduler) {

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationTestSupport.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationTestSupport.kt
@@ -252,6 +252,10 @@ internal fun ExecutorService.shutdownAndAssertTermination() {
         }
     }
 
+    interrupted?.let {
+        Thread.currentThread().interrupt()
+        throw AssertionError("Interrupted while terminating test executor", it)
+    }
     if (!terminated) {
         terminated = try {
             awaitTermination(5, TimeUnit.SECONDS)

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationTestSupport.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationTestSupport.kt
@@ -276,6 +276,10 @@ internal fun <T> withExecutorCleanup(
     var primaryFailure: Throwable? = null
     try {
         return block()
+    } catch (e: InterruptedException) {
+        Thread.currentThread().interrupt()
+        primaryFailure = e
+        throw e
     } catch (e: Exception) {
         primaryFailure = e
         throw e

--- a/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationTestSupport.kt
+++ b/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationTestSupport.kt
@@ -35,7 +35,10 @@ import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.yield
+import reactor.core.Disposable
 import reactor.core.publisher.Mono
+import reactor.core.publisher.SignalType
+import reactor.core.publisher.Sinks
 import reactor.core.scheduler.Scheduler
 import reactor.core.scheduler.Schedulers
 import java.util.concurrent.Callable
@@ -49,6 +52,7 @@ import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.toJavaDuration
@@ -60,6 +64,8 @@ internal const val parentMarkerA = "parent-A"
 internal const val parentMarkerB = "parent-B"
 
 private const val reactorOtelContextKey = "bluetape4k.otel.context"
+private const val reactorSchedulerPrefixA = "otel-reactor-A"
+private const val reactorSchedulerPrefixB = "otel-reactor-B"
 private const val probeMarker = "probe-marker"
 
 private val hangGuard = DEFAULT_CANCELLATION_CONTRACT_TIMEOUT
@@ -76,8 +82,13 @@ internal fun currentMarker(): String? =
 internal fun CountDownLatch.awaitOrFail(
     timeout: Duration = DEFAULT_CANCELLATION_CONTRACT_TIMEOUT,
 ) {
-    check(await(timeout.inWholeNanoseconds, TimeUnit.NANOSECONDS)) {
-        "Timed out waiting for test gate"
+    try {
+        check(await(timeout.inWholeNanoseconds, TimeUnit.NANOSECONDS)) {
+            "Timed out waiting for test gate"
+        }
+    } catch (e: InterruptedException) {
+        Thread.currentThread().interrupt()
+        throw e
     }
 }
 
@@ -462,8 +473,16 @@ internal suspend fun runCoroutineIsolationScenario(): ContextIsolationObservatio
 }
 
 internal fun coroutineIsolationExpectation(): ContextIsolationExpectation =
+    isolationExpectation(ContextPropagationBoundary.COROUTINE)
+
+internal fun reactorIsolationExpectation(): ContextIsolationExpectation =
+    isolationExpectation(ContextPropagationBoundary.REACTOR)
+
+private fun isolationExpectation(
+    boundary: ContextPropagationBoundary,
+): ContextIsolationExpectation =
     ContextIsolationExpectation(
-        boundary = ContextPropagationBoundary.COROUTINE,
+        boundary = boundary,
         samples = listOf(
             ContextIsolationSampleExpectation(
                 requestAlias = ContextRequestAlias.REQUEST_A,
@@ -492,36 +511,142 @@ internal fun coroutineIsolationExpectation(): ContextIsolationExpectation =
 internal fun runReactorScenario(
     scenario: ContextPropagationScenario,
 ): CapturedScenario {
-    check(scenario == ContextPropagationScenario.SUCCESS) {
-        "Task 2 supports only the success Reactor scenario"
+    check(scenario != ContextPropagationScenario.ISOLATION) {
+        "Isolation uses runReactorIsolationScenario"
     }
 
-    val scheduler = Schedulers.newSingle("otel-context-conformance")
+    val scheduler = Schedulers.newSingle("otel-reactor-single")
     val ledger = ConformanceEventLedger()
     val observations = mutableListOf<ContextMarkerObservation>()
-    var thrown: Throwable? = null
-    try {
-        try {
-            executeReactorSuccess(scheduler, observations, ledger)
-                .block(DEFAULT_CANCELLATION_CONTRACT_TIMEOUT.toJavaDuration())
-        } catch (e: Exception) {
-            thrown = e
+    val entered = CountDownLatch(1)
+    val finallyCompleted = CountDownLatch(1)
+    val actualSignal = AtomicReference<SignalType>()
+    val thrown = AtomicReference<Throwable>()
+    var disposable: Disposable? = null
+    return withReactorCleanup(
+        actions = listOf(
+            { disposable?.dispose() },
+            { awaitDisposedSubscription(disposable, finallyCompleted) },
+            { shutdownScheduler(scheduler) },
+        ),
+    ) {
+        disposable = executeReactorScenario(
+            scenario,
+            scheduler,
+            observations,
+            entered,
+            finallyCompleted,
+            actualSignal,
+            ledger,
+        ).subscribe(
+            {},
+            { failure -> thrown.compareAndSet(null, failure) },
+        )
+        entered.awaitOrFail(hangGuard)
+        if (scenario == ContextPropagationScenario.CANCELLATION) {
+            disposable.dispose()
         }
-        ledger.record(ContextRequestAlias.SINGLE, ConformanceEvent.TERMINAL_OBSERVED)
-        val workerMarker = Mono.fromCallable(::currentMarker)
-            .subscribeOn(scheduler)
-            .block(DEFAULT_CANCELLATION_CONTRACT_TIMEOUT.toJavaDuration())
+        finallyCompleted.awaitOrFail(hangGuard)
+        val workerMarker = workerProbe(scheduler)
         ledger.record(ContextRequestAlias.SINGLE, ConformanceEvent.CLEANUP_PROBED)
         ledger.assertSingleScenarioOrder()
-        return capturedSuccess(
+        capturedScenario(
             ContextPropagationBoundary.REACTOR,
             scenario,
             observations,
             workerMarker,
-            thrown,
+            terminalFor(actualSignal.get(), scenario),
+            thrown.get(),
         )
-    } finally {
-        shutdownScheduler(scheduler)
+    }
+}
+
+internal fun runReactorIsolationScenario(): ContextIsolationObservation {
+    val schedulerA = Schedulers.newSingle(reactorSchedulerPrefixA)
+    val schedulerB = Schedulers.newSingle(reactorSchedulerPrefixB)
+    val readyA = Sinks.one<Unit>()
+    val readyB = Sinks.one<Unit>()
+    val bothReady = Mono.`when`(readyA.asMono(), readyB.asMono()).cache()
+    val ledger = ConformanceEventLedger()
+    val markersA = mutableListOf<String?>()
+    val markersB = mutableListOf<String?>()
+    val finallyA = CountDownLatch(1)
+    val finallyB = CountDownLatch(1)
+    val firstFailure = AtomicReference<Throwable>()
+    var disposableA: Disposable? = null
+    var disposableB: Disposable? = null
+
+    return withReactorCleanup(
+        actions = listOf(
+            { readyA.tryEmitEmpty() },
+            { readyB.tryEmitEmpty() },
+            { disposableA?.dispose() },
+            { disposableB?.dispose() },
+            { awaitDisposedSubscription(disposableA, finallyA) },
+            { awaitDisposedSubscription(disposableB, finallyB) },
+            { shutdownScheduler(schedulerA) },
+            { shutdownScheduler(schedulerB) },
+        ),
+    ) {
+        disposableA = executeReactorIsolationParticipant(
+            alias = ContextRequestAlias.REQUEST_A,
+            marker = parentMarkerA,
+            observations = markersA,
+            scheduler = schedulerA,
+            schedulerPrefix = reactorSchedulerPrefixA,
+            ownReady = readyA,
+            bothReady = bothReady,
+            finallyCompleted = finallyA,
+            ledger = ledger,
+        ).subscribe(
+            {},
+            { failure -> recordReactorIsolationFailure(failure, readyA, firstFailure) },
+        )
+        disposableB = executeReactorIsolationParticipant(
+            alias = ContextRequestAlias.REQUEST_B,
+            marker = parentMarkerB,
+            observations = markersB,
+            scheduler = schedulerB,
+            schedulerPrefix = reactorSchedulerPrefixB,
+            ownReady = readyB,
+            bothReady = bothReady,
+            finallyCompleted = finallyB,
+            ledger = ledger,
+        ).subscribe(
+            {},
+            { failure -> recordReactorIsolationFailure(failure, readyB, firstFailure) },
+        )
+
+        finallyA.awaitOrFail(hangGuard)
+        finallyB.awaitOrFail(hangGuard)
+        firstFailure.get()?.let { throw it }
+
+        val probe = Mono.fromCallable(
+            otelContext(probeMarker).wrap(Callable(::currentMarker)),
+        )
+            .subscribeOn(schedulerA)
+            .block(hangGuard.toJavaDuration())
+        val workerMarkerA = workerProbe(schedulerA)
+        ledger.record(ContextRequestAlias.REQUEST_A, ConformanceEvent.CLEANUP_PROBED)
+        val workerMarkerB = workerProbe(schedulerB)
+        ledger.record(ContextRequestAlias.REQUEST_B, ConformanceEvent.CLEANUP_PROBED)
+        ledger.assertIsolationOrder()
+
+        ContextIsolationObservation(
+            boundary = ContextPropagationBoundary.REACTOR,
+            samples = listOf(
+                ContextIsolationSample(ContextRequestAlias.REQUEST_A, markersA.toList()),
+                ContextIsolationSample(ContextRequestAlias.REQUEST_B, markersB.toList()),
+                ContextIsolationSample(ContextRequestAlias.PROBE, listOf(probe)),
+            ),
+            cleanupProbes = listOf(
+                ContextCleanupProbe(ContextProbeLocation.CALLER, currentMarker()),
+                ContextCleanupProbe(
+                    ContextProbeLocation.WORKER,
+                    requireMatchingWorkerMarkers(workerMarkerA, workerMarkerB),
+                ),
+            ),
+        )
     }
 }
 
@@ -628,29 +753,118 @@ private suspend fun observeCoroutineBody(
     observations += markerObservation(ContextObservationPoint.BEFORE_TERMINAL)
 }
 
-private fun executeReactorSuccess(
+private fun executeReactorScenario(
+    scenario: ContextPropagationScenario,
     scheduler: Scheduler,
     observations: MutableList<ContextMarkerObservation>,
+    entered: CountDownLatch,
+    finallyCompleted: CountDownLatch,
+    actualSignal: AtomicReference<SignalType>,
     ledger: ConformanceEventLedger,
-): Mono<Unit> =
-    Mono.deferContextual { view ->
+): Mono<Unit> {
+    val publisher = Mono.deferContextual { view ->
         val captured = view.get<Context>(reactorOtelContextKey)
-        Mono.fromCallable(
+        val observed = Mono.fromCallable(
             captured.wrap(
                 Callable {
                     observations += markerObservation(ContextObservationPoint.BOUNDARY_ENTER)
                     observations += markerObservation(ContextObservationPoint.AFTER_SUSPENSION)
                     observations += markerObservation(ContextObservationPoint.BEFORE_TERMINAL)
+                    entered.countDown()
+                    if (scenario == ContextPropagationScenario.FAILURE) {
+                        error("synthetic failure")
+                    }
                     Unit
                 },
             ),
         )
+
+        when (scenario) {
+            ContextPropagationScenario.SUCCESS,
+            ContextPropagationScenario.FAILURE -> observed
+
+            ContextPropagationScenario.CANCELLATION,
+            ContextPropagationScenario.DEADLINE -> observed.then(Mono.never())
+
+            ContextPropagationScenario.ISOLATION ->
+                error("Isolation uses runReactorIsolationScenario")
+        }
     }
         .contextWrite { it.put(reactorOtelContextKey, otelContext(parentMarkerA)) }
         .subscribeOn(scheduler)
+
+    return (if (scenario == ContextPropagationScenario.DEADLINE) {
+        publisher.timeout(semanticDeadline.toJavaDuration(), scheduler)
+    } else {
+        publisher
+    })
         .doFinally {
+            actualSignal.compareAndSet(null, it)
+            ledger.record(ContextRequestAlias.SINGLE, ConformanceEvent.TERMINAL_OBSERVED)
             ledger.record(ContextRequestAlias.SINGLE, ConformanceEvent.FINALLY_COMPLETED)
+            finallyCompleted.countDown()
         }
+}
+
+private fun executeReactorIsolationParticipant(
+    alias: ContextRequestAlias,
+    marker: String,
+    observations: MutableList<String?>,
+    scheduler: Scheduler,
+    schedulerPrefix: String,
+    ownReady: Sinks.One<Unit>,
+    bothReady: Mono<Void>,
+    finallyCompleted: CountDownLatch,
+    ledger: ConformanceEventLedger,
+): Mono<Unit> =
+    Mono.deferContextual { view ->
+        val captured = view.get<Context>(reactorOtelContextKey)
+        val beforeGate = Mono.fromCallable(
+            captured.wrap(
+                Callable {
+                    checkSchedulerThread(schedulerPrefix)
+                    observations += currentMarker()
+                    ledger.record(alias, ConformanceEvent.READY)
+                    check(ownReady.tryEmitValue(Unit).isSuccess) {
+                        "Reactor ready signal was not accepted"
+                    }
+                    Unit
+                },
+            ),
+        )
+        val afterGate = Mono.fromCallable(
+            captured.wrap(
+                Callable {
+                    checkSchedulerThread(schedulerPrefix)
+                    ledger.record(alias, ConformanceEvent.RELEASED)
+                    observations += currentMarker()
+                    observations += currentMarker()
+                    Unit
+                },
+            ),
+        )
+
+        beforeGate
+            .then(bothReady)
+            .publishOn(scheduler)
+            .then(afterGate)
+    }
+        .contextWrite { it.put(reactorOtelContextKey, otelContext(marker)) }
+        .subscribeOn(scheduler)
+        .doFinally {
+            ledger.record(alias, ConformanceEvent.TERMINAL_OBSERVED)
+            ledger.record(alias, ConformanceEvent.FINALLY_COMPLETED)
+            finallyCompleted.countDown()
+        }
+
+internal fun recordReactorIsolationFailure(
+    failure: Throwable,
+    ownReady: Sinks.One<Unit>,
+    firstFailure: AtomicReference<Throwable>,
+) {
+    firstFailure.compareAndSet(null, failure)
+    ownReady.tryEmitError(failure)
+}
 
 private fun executeExecutorSuccess(
     executor: ExecutorService,
@@ -856,6 +1070,120 @@ private fun terminalFor(scenario: ContextPropagationScenario): ContextPropagatio
             error("Isolation uses coroutineIsolationExpectation")
     }
 
+private fun terminalFor(
+    signal: SignalType?,
+    scenario: ContextPropagationScenario,
+): ContextPropagationTerminal =
+    when (signal) {
+        SignalType.ON_COMPLETE -> {
+            check(scenario == ContextPropagationScenario.SUCCESS) {
+                "Unexpected Reactor completion signal"
+            }
+            ContextPropagationTerminal.SUCCESS
+        }
+
+        SignalType.ON_ERROR -> when (scenario) {
+            ContextPropagationScenario.FAILURE -> ContextPropagationTerminal.FAILURE
+            ContextPropagationScenario.DEADLINE -> ContextPropagationTerminal.DEADLINE_EXCEEDED
+            else -> error("Unexpected Reactor error signal")
+        }
+
+        SignalType.CANCEL -> {
+            check(scenario == ContextPropagationScenario.CANCELLATION) {
+                "Unexpected Reactor cancellation signal"
+            }
+            ContextPropagationTerminal.CANCELLATION
+        }
+
+        else -> error("Reactor terminal signal was not observed")
+    }
+
+private fun workerProbe(scheduler: Scheduler): String? =
+    Mono.fromCallable(::currentMarker)
+        .subscribeOn(scheduler)
+        .block(hangGuard.toJavaDuration())
+
+private fun checkSchedulerThread(expectedPrefix: String) {
+    check(Thread.currentThread().name.startsWith(expectedPrefix)) {
+        "Reactor continuation escaped its test-owned scheduler"
+    }
+}
+
+private fun requireMatchingWorkerMarkers(
+    markerA: String?,
+    markerB: String?,
+): String? {
+    check(markerA == null && markerB == null) {
+        "Reactor worker context was not restored"
+    }
+    return null
+}
+
+private fun awaitDisposedSubscription(
+    disposable: Disposable?,
+    finallyCompleted: CountDownLatch,
+) {
+    if (disposable != null) {
+        finallyCompleted.awaitOrFail(hangGuard)
+    }
+}
+
+internal fun <T> withReactorCleanup(
+    actions: List<() -> Unit>,
+    block: () -> T,
+): T {
+    var primaryFailure: Throwable? = null
+    try {
+        return block()
+    } catch (e: InterruptedException) {
+        primaryFailure = e
+        Thread.currentThread().interrupt()
+        throw e
+    } catch (e: Exception) {
+        primaryFailure = e
+        throw e
+    } catch (e: Error) {
+        primaryFailure = e
+        throw e
+    } finally {
+        var restoreInterrupt = Thread.interrupted()
+        var aggregatedFailure = primaryFailure
+        actions.forEach { cleanup ->
+            val cleanupFailure = try {
+                cleanup()
+                null
+            } catch (e: InterruptedException) {
+                restoreInterrupt = true
+                Thread.currentThread().interrupt()
+                e
+            } catch (e: Exception) {
+                e
+            } catch (e: Error) {
+                e
+            }
+
+            cleanupFailure?.let { failure ->
+                val aggregate = aggregatedFailure
+                if (aggregate == null) {
+                    aggregatedFailure = failure
+                } else if (aggregate !== failure && aggregate.suppressed.none { it === failure }) {
+                    aggregate.addSuppressed(failure)
+                }
+            }
+        }
+
+        try {
+            if (primaryFailure == null) {
+                aggregatedFailure?.let { throw it }
+            }
+        } finally {
+            if (restoreInterrupt) {
+                Thread.currentThread().interrupt()
+            }
+        }
+    }
+}
+
 private fun capturedScenario(
     boundary: ContextPropagationBoundary,
     scenario: ContextPropagationScenario,
@@ -897,6 +1225,6 @@ private fun capturedSuccess(
 
 private fun shutdownScheduler(scheduler: Scheduler) {
     scheduler.disposeGracefully()
-        .block(DEFAULT_CANCELLATION_CONTRACT_TIMEOUT.toJavaDuration())
+        .block(hangGuard.toJavaDuration())
     check(scheduler.isDisposed) { "Test scheduler did not terminate" }
 }

--- a/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/KtorContextPropagationConformanceTest.kt
+++ b/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/KtorContextPropagationConformanceTest.kt
@@ -68,7 +68,10 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
 
 @Timeout(
     value = 15,
@@ -213,8 +216,21 @@ private const val spanIdA = "1111111111111111"
 private const val traceIdB = "22222222222222222222222222222222"
 private const val spanIdB = "2222222222222222"
 private val hangGuard = DEFAULT_CANCELLATION_CONTRACT_TIMEOUT
+private val aggregateBudget = 14.seconds
 private val semanticDeadline = 250.milliseconds.also {
     check(it < hangGuard)
+}
+
+private class KtorConformanceDeadline(
+    budget: Duration = aggregateBudget,
+) {
+    private val deadlineNanos = System.nanoTime() + budget.inWholeNanoseconds
+
+    fun remaining(): Duration =
+        minOf(
+            hangGuard,
+            (deadlineNanos - System.nanoTime()).coerceAtLeast(0).nanoseconds,
+        )
 }
 
 private class CapturedScenario(
@@ -338,6 +354,7 @@ private class KtorConformanceEventLedger {
 }
 
 private class KtorConformanceHarness {
+    val deadline = KtorConformanceDeadline()
     val singleObservations = ConcurrentLinkedQueue<ContextMarkerObservation>()
     val singleStarted = CompletableDeferred<Unit>()
     val singleFinally = CompletableDeferred<Unit>()
@@ -413,9 +430,10 @@ private class TestTracing(
     }
 
     override fun close() {
+        val remaining = harness.deadline.remaining()
         check(
             tracerProvider.shutdown()
-                .join(5, TimeUnit.SECONDS)
+                .join(remaining.inWholeNanoseconds, TimeUnit.NANOSECONDS)
                 .isSuccess,
         ) {
             "Test tracer provider shutdown failed"
@@ -544,9 +562,9 @@ private suspend fun io.ktor.server.routing.RoutingContext.runIsolationRoute(
         harness.observations(alias) += Span.current().validTraceIdOrNull()
         harness.ledger.record(alias, KtorConformanceEvent.READY)
         ownReady.complete(Unit)
-        harness.readyA.awaitGateWithin("isolation ready A")
-        harness.readyB.awaitGateWithin("isolation ready B")
-        harness.release.awaitGateWithin("isolation release")
+        harness.readyA.awaitGateWithin("isolation ready A", harness.deadline)
+        harness.readyB.awaitGateWithin("isolation ready B", harness.deadline)
+        harness.release.awaitGateWithin("isolation release", harness.deadline)
         harness.ledger.record(alias, KtorConformanceEvent.RELEASED)
         yield()
         harness.observations(alias) += Span.current().validTraceIdOrNull()
@@ -593,20 +611,20 @@ private suspend fun ApplicationTestBuilder.runKtorScenario(
                 }
             }
             requests += request
-            harness.singleStarted.awaitGateWithin("single route start")
-            request.awaitTerminalWithin("single request terminal")
+            harness.singleStarted.awaitGateWithin("single route start", harness.deadline)
+            request.awaitTerminalWithin("single request terminal", harness.deadline)
             harness.ledger.record(
                 ContextRequestAlias.SINGLE,
                 KtorConformanceEvent.TERMINAL_OBSERVED,
             )
-            harness.singleFinally.awaitGateWithin("single route finally")
+            harness.singleFinally.awaitGateWithin("single route finally", harness.deadline)
             harness.ledger.record(
                 ContextRequestAlias.SINGLE,
                 KtorConformanceEvent.FINALLY_COMPLETED,
             )
             val requestMarker =
                 harness.cleanupMarker(ContextRequestAlias.SINGLE)
-                    .awaitGateWithin("single server cleanup probe")
+                    .awaitGateWithin("single server cleanup probe", harness.deadline)
             harness.ledger.record(
                 ContextRequestAlias.SINGLE,
                 KtorConformanceEvent.CLEANUP_PROBED,
@@ -681,28 +699,28 @@ private suspend fun ApplicationTestBuilder.runKtorIsolationScenario(
             requests += requestA
             requests += requestB
 
-            harness.readyA.awaitGateWithin("request A ready")
-            harness.readyB.awaitGateWithin("request B ready")
+            harness.readyA.awaitGateWithin("request A ready", harness.deadline)
+            harness.readyB.awaitGateWithin("request B ready", harness.deadline)
             harness.release.complete(Unit)
 
-            val failureA = requestA.captureTerminalWithin("request A terminal")
+            val failureA = requestA.captureTerminalWithin("request A terminal", harness.deadline)
             harness.ledger.record(
                 ContextRequestAlias.REQUEST_A,
                 KtorConformanceEvent.TERMINAL_OBSERVED,
             )
-            val failureB = requestB.captureTerminalWithin("request B terminal")
+            val failureB = requestB.captureTerminalWithin("request B terminal", harness.deadline)
             harness.ledger.record(
                 ContextRequestAlias.REQUEST_B,
                 KtorConformanceEvent.TERMINAL_OBSERVED,
             )
             (harness.firstIsolationFailure.get() ?: failureA ?: failureB)?.let { throw it }
 
-            harness.finallyA.awaitGateWithin("request A finally")
+            harness.finallyA.awaitGateWithin("request A finally", harness.deadline)
             harness.ledger.record(
                 ContextRequestAlias.REQUEST_A,
                 KtorConformanceEvent.FINALLY_COMPLETED,
             )
-            harness.finallyB.awaitGateWithin("request B finally")
+            harness.finallyB.awaitGateWithin("request B finally", harness.deadline)
             harness.ledger.record(
                 ContextRequestAlias.REQUEST_B,
                 KtorConformanceEvent.FINALLY_COMPLETED,
@@ -710,10 +728,10 @@ private suspend fun ApplicationTestBuilder.runKtorIsolationScenario(
 
             val requestMarkerA =
                 harness.cleanupMarker(ContextRequestAlias.REQUEST_A)
-                    .awaitGateWithin("request A server cleanup probe")
+                    .awaitGateWithin("request A server cleanup probe", harness.deadline)
             val requestMarkerB =
                 harness.cleanupMarker(ContextRequestAlias.REQUEST_B)
-                    .awaitGateWithin("request B server cleanup probe")
+                    .awaitGateWithin("request B server cleanup probe", harness.deadline)
             val requestMarker = requireRestoredRequestMarkers(requestMarkerA, requestMarkerB)
             harness.ledger.record(
                 ContextRequestAlias.REQUEST_A,
@@ -724,10 +742,11 @@ private suspend fun ApplicationTestBuilder.runKtorIsolationScenario(
                 KtorConformanceEvent.CLEANUP_PROBED,
             )
 
-            withTimeout(hangGuard) {
+            withTimeout(harness.deadline.remaining()) {
                 client.get("/context/probe")
             }
-            val probeMarker = harness.probeTraceId.awaitGateWithin("unparented probe")
+            val probeMarker =
+                harness.probeTraceId.awaitGateWithin("unparented probe", harness.deadline)
             harness.ledger.assertIsolationOrder()
 
             ContextIsolationObservation(
@@ -804,7 +823,7 @@ private suspend fun cleanupKtorRequests(
             }
             add {
                 try {
-                    withTimeout(hangGuard) {
+                    withTimeout(harness.deadline.remaining()) {
                         requests.joinAll()
                     }
                 } catch (failure: TimeoutCancellationException) {
@@ -835,18 +854,24 @@ private suspend fun cleanupKtorRequests(
     }
 }
 
-private suspend fun <T> CompletableDeferred<T>.awaitGateWithin(label: String): T =
+private suspend fun <T> CompletableDeferred<T>.awaitGateWithin(
+    label: String,
+    deadline: KtorConformanceDeadline,
+): T =
     try {
-        withTimeout(hangGuard) {
+        withTimeout(deadline.remaining()) {
             await()
         }
     } catch (failure: TimeoutCancellationException) {
         throw AssertionError("Timed out waiting for Ktor $label", failure)
     }
 
-private suspend fun Deferred<*>.awaitTerminalWithin(label: String) {
+private suspend fun Deferred<*>.awaitTerminalWithin(
+    label: String,
+    deadline: KtorConformanceDeadline,
+) {
     try {
-        withTimeout(hangGuard) {
+        withTimeout(deadline.remaining()) {
             await()
         }
     } catch (failure: TimeoutCancellationException) {
@@ -857,9 +882,12 @@ private suspend fun Deferred<*>.awaitTerminalWithin(label: String) {
     }
 }
 
-private suspend fun Deferred<*>.captureTerminalWithin(label: String): Throwable? =
+private suspend fun Deferred<*>.captureTerminalWithin(
+    label: String,
+    deadline: KtorConformanceDeadline,
+): Throwable? =
     try {
-        withTimeout(hangGuard) {
+        withTimeout(deadline.remaining()) {
             await()
         }
         null

--- a/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/KtorContextPropagationConformanceTest.kt
+++ b/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/KtorContextPropagationConformanceTest.kt
@@ -1,0 +1,769 @@
+package io.bluetape4k.ktor.observability
+
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.junit5.coroutines.DEFAULT_CANCELLATION_CONTRACT_TIMEOUT
+import io.bluetape4k.junit5.observability.ContextCleanupExpectation
+import io.bluetape4k.junit5.observability.ContextCleanupProbe
+import io.bluetape4k.junit5.observability.ContextIsolationExpectation
+import io.bluetape4k.junit5.observability.ContextIsolationObservation
+import io.bluetape4k.junit5.observability.ContextIsolationSample
+import io.bluetape4k.junit5.observability.ContextIsolationSampleExpectation
+import io.bluetape4k.junit5.observability.ContextMarkerExpectation
+import io.bluetape4k.junit5.observability.ContextMarkerExpectationMode
+import io.bluetape4k.junit5.observability.ContextMarkerObservation
+import io.bluetape4k.junit5.observability.ContextObservationPoint
+import io.bluetape4k.junit5.observability.ContextProbeLocation
+import io.bluetape4k.junit5.observability.ContextPropagationBoundary
+import io.bluetape4k.junit5.observability.ContextPropagationExpectation
+import io.bluetape4k.junit5.observability.ContextPropagationObservation
+import io.bluetape4k.junit5.observability.ContextPropagationScenario
+import io.bluetape4k.junit5.observability.ContextPropagationTerminal
+import io.bluetape4k.junit5.observability.ContextRequestAlias
+import io.bluetape4k.junit5.observability.assertContextIsolation
+import io.bluetape4k.junit5.observability.assertContextPropagationConformance
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanContext
+import io.opentelemetry.api.trace.TraceFlags
+import io.opentelemetry.api.trace.TraceState
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.propagation.ContextPropagators
+import io.opentelemetry.context.propagation.TextMapSetter
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.job
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration.Companion.milliseconds
+
+@Timeout(
+    value = 15,
+    unit = TimeUnit.SECONDS,
+    threadMode = Timeout.ThreadMode.SAME_THREAD,
+)
+class KtorContextPropagationConformanceTest {
+
+    @Test
+    fun `ktor extracts synthetic W3C parent and cleans request on success`() =
+        TestTracing().use { tracing ->
+            testApplication {
+                installContextConformance(tracing)
+                val captured = runKtorScenario(tracing, ContextPropagationScenario.SUCCESS)
+
+                captured.thrown.shouldBeNull()
+                assertContextPropagationConformance(
+                    captured.observation,
+                    ktorExpectation(
+                        ContextPropagationScenario.SUCCESS,
+                        ContextPropagationTerminal.SUCCESS,
+                    ),
+                )
+            }
+        }
+
+    @Test
+    fun `ktor handler failure preserves parent and cleans request`() =
+        TestTracing().use { tracing ->
+            testApplication {
+                installContextConformance(tracing)
+                val captured = runKtorScenario(tracing, ContextPropagationScenario.FAILURE)
+
+                check(captured.thrown?.javaClass == IllegalStateException::class.java)
+                assertContextPropagationConformance(
+                    captured.observation,
+                    ktorExpectation(
+                        ContextPropagationScenario.FAILURE,
+                        ContextPropagationTerminal.FAILURE,
+                    ),
+                )
+            }
+        }
+
+    @Test
+    fun `ktor request cancellation preserves parent and cleans request`() =
+        TestTracing().use { tracing ->
+            testApplication {
+                installContextConformance(tracing)
+                val captured = runKtorScenario(tracing, ContextPropagationScenario.CANCELLATION)
+
+                check(captured.thrown is CancellationException)
+                check(captured.thrown !is TimeoutCancellationException)
+                assertContextPropagationConformance(
+                    captured.observation,
+                    ktorExpectation(
+                        ContextPropagationScenario.CANCELLATION,
+                        ContextPropagationTerminal.CANCELLATION,
+                    ),
+                )
+            }
+        }
+
+    @Test
+    fun `ktor route deadline preserves parent and cleans request`() =
+        TestTracing().use { tracing ->
+            testApplication {
+                installContextConformance(tracing)
+                val captured = runKtorScenario(tracing, ContextPropagationScenario.DEADLINE)
+
+                check(captured.thrown?.javaClass == TimeoutCancellationException::class.java)
+                assertContextPropagationConformance(
+                    captured.observation,
+                    ktorExpectation(
+                        ContextPropagationScenario.DEADLINE,
+                        ContextPropagationTerminal.DEADLINE_EXCEEDED,
+                    ),
+                )
+            }
+        }
+
+    @Test
+    fun `ktor concurrent parents and unparented probe stay isolated`() =
+        TestTracing().use { tracing ->
+            testApplication {
+                installContextConformance(tracing)
+                assertContextIsolation(
+                    runKtorIsolationScenario(tracing),
+                    ktorIsolationExpectation(),
+                )
+            }
+        }
+}
+
+private const val traceIdA = "11111111111111111111111111111111"
+private const val spanIdA = "1111111111111111"
+private const val traceIdB = "22222222222222222222222222222222"
+private const val spanIdB = "2222222222222222"
+private val hangGuard = DEFAULT_CANCELLATION_CONTRACT_TIMEOUT
+private val semanticDeadline = 250.milliseconds.also {
+    check(it < hangGuard)
+}
+
+private class CapturedScenario(
+    val observation: ContextPropagationObservation,
+    val thrown: Throwable?,
+)
+
+private enum class KtorConformanceEvent {
+    READY,
+    RELEASED,
+    TERMINAL_OBSERVED,
+    FINALLY_COMPLETED,
+    CLEANUP_PROBED,
+}
+
+private class KtorConformanceEventEntry(
+    val requestAlias: ContextRequestAlias,
+    val event: KtorConformanceEvent,
+    val sequence: Long,
+)
+
+private class KtorConformanceEventLedger {
+    private val sequence = AtomicLong()
+    private val events = ConcurrentLinkedQueue<KtorConformanceEventEntry>()
+
+    fun record(
+        requestAlias: ContextRequestAlias,
+        event: KtorConformanceEvent,
+    ) {
+        events += KtorConformanceEventEntry(
+            requestAlias,
+            event,
+            sequence.incrementAndGet(),
+        )
+    }
+
+    fun assertSingleScenarioOrder() {
+        val entries = events.filter { it.requestAlias == ContextRequestAlias.SINGLE }
+        val counts = entries.groupingBy(KtorConformanceEventEntry::event).eachCount()
+        listOf(
+            KtorConformanceEvent.TERMINAL_OBSERVED,
+            KtorConformanceEvent.FINALLY_COMPLETED,
+            KtorConformanceEvent.CLEANUP_PROBED,
+        ).forEach { event ->
+            check(counts[event] == 1) {
+                "Ktor lifecycle event count mismatch: alias=SINGLE, event=$event"
+            }
+        }
+        check(counts[KtorConformanceEvent.READY] == null)
+        check(counts[KtorConformanceEvent.RELEASED] == null)
+        assertCleanupAfterFinally(ContextRequestAlias.SINGLE, entries)
+    }
+
+    fun assertIsolationOrder() {
+        val snapshot = events.toList()
+        val participantEntries = listOf(
+            ContextRequestAlias.REQUEST_A,
+            ContextRequestAlias.REQUEST_B,
+        ).associateWith { alias ->
+            snapshot.filter { it.requestAlias == alias }.also { entries ->
+                val counts = entries.groupingBy(KtorConformanceEventEntry::event).eachCount()
+                KtorConformanceEvent.entries.forEach { event ->
+                    check(counts[event] == 1) {
+                        "Ktor lifecycle event count mismatch: alias=$alias, event=$event"
+                    }
+                }
+            }
+        }
+        val lastReady = participantEntries.values
+            .flatten()
+            .filter { it.event == KtorConformanceEvent.READY }
+            .maxOf(KtorConformanceEventEntry::sequence)
+        val firstRelease = participantEntries.values
+            .flatten()
+            .filter { it.event == KtorConformanceEvent.RELEASED }
+            .minOf(KtorConformanceEventEntry::sequence)
+        check(lastReady < firstRelease)
+        participantEntries.forEach { (alias, entries) ->
+            assertCleanupAfterFinally(alias, entries)
+        }
+    }
+
+    private fun assertCleanupAfterFinally(
+        alias: ContextRequestAlias,
+        entries: List<KtorConformanceEventEntry>,
+    ) {
+        val terminalSequence = entries.single {
+            it.event == KtorConformanceEvent.TERMINAL_OBSERVED
+        }.sequence
+        val finallySequence = entries.single {
+            it.event == KtorConformanceEvent.FINALLY_COMPLETED
+        }.sequence
+        val cleanupSequence = entries.single {
+            it.event == KtorConformanceEvent.CLEANUP_PROBED
+        }.sequence
+        check(terminalSequence < cleanupSequence) {
+            "Ktor terminal cleanup order mismatch: alias=$alias"
+        }
+        check(finallySequence < cleanupSequence) {
+            "Ktor lifecycle cleanup order mismatch: alias=$alias"
+        }
+    }
+}
+
+private class KtorConformanceHarness {
+    val singleObservations = ConcurrentLinkedQueue<ContextMarkerObservation>()
+    val singleStarted = CompletableDeferred<Unit>()
+    val singleFinally = CompletableDeferred<Unit>()
+    val singleThrown = AtomicReference<Throwable?>()
+    val isolationObservations = ConcurrentHashMap<ContextRequestAlias, ConcurrentLinkedQueue<String?>>()
+    val readyA = CompletableDeferred<Unit>()
+    val readyB = CompletableDeferred<Unit>()
+    val release = CompletableDeferred<Unit>()
+    val finallyA = CompletableDeferred<Unit>()
+    val finallyB = CompletableDeferred<Unit>()
+    val firstIsolationFailure = AtomicReference<Throwable?>()
+    val probeTraceId = CompletableDeferred<String?>()
+    val ledger = KtorConformanceEventLedger()
+
+    fun observations(alias: ContextRequestAlias): ConcurrentLinkedQueue<String?> =
+        isolationObservations.computeIfAbsent(alias) {
+            ConcurrentLinkedQueue()
+        }
+
+    fun releaseAll() {
+        readyA.complete(Unit)
+        readyB.complete(Unit)
+        release.complete(Unit)
+    }
+}
+
+private class TestTracing : AutoCloseable {
+    val spanExporter: InMemorySpanExporter = InMemorySpanExporter.create()
+    private val tracerProvider: SdkTracerProvider =
+        SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+            .build()
+
+    val openTelemetry: OpenTelemetrySdk =
+        OpenTelemetrySdk.builder()
+            .setTracerProvider(tracerProvider)
+            .setPropagators(
+                ContextPropagators.create(W3CTraceContextPropagator.getInstance()),
+            )
+            .build()
+
+    val harness = KtorConformanceHarness()
+
+    fun headers(traceId: String, spanId: String): Map<String, String> {
+        val carrier = mutableMapOf<String, String>()
+        val parent =
+            Span.wrap(
+                SpanContext.create(
+                    traceId,
+                    spanId,
+                    TraceFlags.getSampled(),
+                    TraceState.getDefault(),
+                ),
+            )
+        openTelemetry.propagators.textMapPropagator.inject(
+            Context.root().with(parent),
+            carrier,
+            TextMapSetter<MutableMap<String, String>> { target, key, value ->
+                target?.set(key, value)
+            },
+        )
+        return carrier
+    }
+
+    override fun close() {
+        check(
+            tracerProvider.shutdown()
+                .join(5, TimeUnit.SECONDS)
+                .isSuccess,
+        ) {
+            "Test tracer provider shutdown failed"
+        }
+    }
+}
+
+private fun ApplicationTestBuilder.installContextConformance(tracing: TestTracing) {
+    application {
+        installBluetape4kKtorOpenTelemetryTracing(
+            KtorOpenTelemetryTracingConfig(
+                openTelemetry = tracing.openTelemetry,
+            ),
+        )
+        contextRoutes(tracing.harness)
+    }
+}
+
+private fun Application.contextRoutes(harness: KtorConformanceHarness) {
+    routing {
+        get("/context/probe") {
+            val traceId = Span.current().validTraceIdOrNull()
+            harness.probeTraceId.complete(traceId)
+            call.respond(HttpStatusCode.OK)
+        }
+        get("/context/{scenario}") {
+            val scenario =
+                ContextPropagationScenario.valueOf(
+                    requireNotNull(call.parameters["scenario"]),
+                )
+            if (scenario == ContextPropagationScenario.ISOLATION) {
+                runIsolationRoute(harness)
+            } else {
+                runSingleRoute(harness, scenario)
+            }
+        }
+    }
+}
+
+private suspend fun io.ktor.server.routing.RoutingContext.runSingleRoute(
+    harness: KtorConformanceHarness,
+    scenario: ContextPropagationScenario,
+) {
+    try {
+        harness.singleObservations += markerObservation(
+            ContextObservationPoint.BOUNDARY_ENTER,
+        )
+        harness.singleStarted.complete(Unit)
+        yield()
+        harness.singleObservations += markerObservation(
+            ContextObservationPoint.AFTER_SUSPENSION,
+        )
+        harness.singleObservations += markerObservation(
+            ContextObservationPoint.BEFORE_TERMINAL,
+        )
+        when (scenario) {
+            ContextPropagationScenario.SUCCESS ->
+                call.respond(HttpStatusCode.OK)
+
+            ContextPropagationScenario.FAILURE ->
+                error("synthetic Ktor handler failure")
+
+            ContextPropagationScenario.CANCELLATION -> {
+                currentCoroutineContext().job.cancel(
+                    CancellationException("synthetic Ktor request cancellation"),
+                )
+                yield()
+            }
+
+            ContextPropagationScenario.DEADLINE ->
+                withTimeout(semanticDeadline) {
+                    awaitCancellation()
+                }
+
+            ContextPropagationScenario.ISOLATION ->
+                error("Isolation uses runIsolationRoute")
+        }
+    } catch (failure: Throwable) {
+        harness.singleThrown.compareAndSet(null, failure)
+        throw failure
+    } finally {
+        harness.singleFinally.complete(Unit)
+    }
+}
+
+private suspend fun io.ktor.server.routing.RoutingContext.runIsolationRoute(
+    harness: KtorConformanceHarness,
+) {
+    val traceId = Span.current().validTraceIdOrNull()
+    val alias =
+        when (traceId) {
+            traceIdA -> ContextRequestAlias.REQUEST_A
+            traceIdB -> ContextRequestAlias.REQUEST_B
+            else -> error("Unexpected synthetic isolation parent")
+        }
+    val ownReady =
+        when (alias) {
+            ContextRequestAlias.REQUEST_A -> harness.readyA
+            ContextRequestAlias.REQUEST_B -> harness.readyB
+            else -> error("Unexpected isolation alias")
+        }
+    val ownFinally =
+        when (alias) {
+            ContextRequestAlias.REQUEST_A -> harness.finallyA
+            ContextRequestAlias.REQUEST_B -> harness.finallyB
+            else -> error("Unexpected isolation alias")
+        }
+
+    try {
+        harness.observations(alias) += Span.current().validTraceIdOrNull()
+        harness.ledger.record(alias, KtorConformanceEvent.READY)
+        ownReady.complete(Unit)
+        harness.readyA.awaitGateWithin("isolation ready A")
+        harness.readyB.awaitGateWithin("isolation ready B")
+        harness.release.awaitGateWithin("isolation release")
+        harness.ledger.record(alias, KtorConformanceEvent.RELEASED)
+        yield()
+        harness.observations(alias) += Span.current().validTraceIdOrNull()
+        harness.observations(alias) += Span.current().validTraceIdOrNull()
+        call.respond(HttpStatusCode.OK)
+    } catch (failure: Throwable) {
+        harness.firstIsolationFailure.compareAndSet(null, failure)
+        harness.releaseAll()
+        throw failure
+    } finally {
+        ownFinally.complete(Unit)
+    }
+}
+
+private fun markerObservation(point: ContextObservationPoint): ContextMarkerObservation =
+    ContextMarkerObservation(
+        point = point,
+        observedMarker = Span.current().validTraceIdOrNull(),
+    )
+
+private fun Span.validTraceIdOrNull(): String? =
+    spanContext.takeIf(SpanContext::isValid)?.traceId
+
+private suspend fun ApplicationTestBuilder.runKtorScenario(
+    tracing: TestTracing,
+    scenario: ContextPropagationScenario,
+): CapturedScenario =
+    supervisorScope {
+        check(scenario != ContextPropagationScenario.ISOLATION) {
+            "Isolation uses runKtorIsolationScenario"
+        }
+        val harness = tracing.harness
+        val requests = mutableListOf<Deferred<*>>()
+        var primaryFailure: Throwable? = null
+        try {
+            val request = async {
+                client.get("/context/$scenario") {
+                    headers {
+                        tracing.headers(traceIdA, spanIdA).forEach { (name, value) ->
+                            append(name, value)
+                        }
+                    }
+                }
+            }
+            requests += request
+            harness.singleStarted.awaitGateWithin("single route start")
+            request.awaitTerminalWithin("single request terminal")
+            harness.ledger.record(
+                ContextRequestAlias.SINGLE,
+                KtorConformanceEvent.TERMINAL_OBSERVED,
+            )
+            harness.singleFinally.awaitGateWithin("single route finally")
+            harness.ledger.record(
+                ContextRequestAlias.SINGLE,
+                KtorConformanceEvent.FINALLY_COMPLETED,
+            )
+            val requestMarker = Span.current().validTraceIdOrNull()
+            harness.ledger.record(
+                ContextRequestAlias.SINGLE,
+                KtorConformanceEvent.CLEANUP_PROBED,
+            )
+            harness.ledger.assertSingleScenarioOrder()
+
+            CapturedScenario(
+                observation =
+                    ContextPropagationObservation(
+                        boundary = ContextPropagationBoundary.KTOR_REQUEST,
+                        scenario = scenario,
+                        requestAlias = ContextRequestAlias.SINGLE,
+                        markerObservations = harness.singleObservations.toList(),
+                        cleanupProbes = listOf(
+                            ContextCleanupProbe(
+                                ContextProbeLocation.REQUEST,
+                                requestMarker,
+                            ),
+                        ),
+                        terminal = terminalFor(scenario),
+                    ),
+                thrown = harness.singleThrown.get(),
+            )
+        } catch (failure: Throwable) {
+            primaryFailure = failure
+            throw failure
+        } finally {
+            cleanupKtorRequests(primaryFailure, harness, requests)
+        }
+    }
+
+private suspend fun ApplicationTestBuilder.runKtorIsolationScenario(
+    tracing: TestTracing,
+): ContextIsolationObservation =
+    supervisorScope {
+        val harness = tracing.harness
+        val requests = mutableListOf<Deferred<*>>()
+        var primaryFailure: Throwable? = null
+        try {
+            val requestA = async {
+                client.get("/context/${ContextPropagationScenario.ISOLATION}") {
+                    headers {
+                        tracing.headers(traceIdA, spanIdA).forEach { (name, value) ->
+                            append(name, value)
+                        }
+                    }
+                }
+            }
+            val requestB = async {
+                client.get("/context/${ContextPropagationScenario.ISOLATION}") {
+                    headers {
+                        tracing.headers(traceIdB, spanIdB).forEach { (name, value) ->
+                            append(name, value)
+                        }
+                    }
+                }
+            }
+            requests += requestA
+            requests += requestB
+
+            harness.readyA.awaitGateWithin("request A ready")
+            harness.readyB.awaitGateWithin("request B ready")
+            harness.firstIsolationFailure.get()?.let { throw it }
+            harness.release.complete(Unit)
+
+            requestA.awaitTerminalWithin("request A terminal")
+            harness.ledger.record(
+                ContextRequestAlias.REQUEST_A,
+                KtorConformanceEvent.TERMINAL_OBSERVED,
+            )
+            requestB.awaitTerminalWithin("request B terminal")
+            harness.ledger.record(
+                ContextRequestAlias.REQUEST_B,
+                KtorConformanceEvent.TERMINAL_OBSERVED,
+            )
+            harness.firstIsolationFailure.get()?.let { throw it }
+
+            harness.finallyA.awaitGateWithin("request A finally")
+            harness.ledger.record(
+                ContextRequestAlias.REQUEST_A,
+                KtorConformanceEvent.FINALLY_COMPLETED,
+            )
+            harness.finallyB.awaitGateWithin("request B finally")
+            harness.ledger.record(
+                ContextRequestAlias.REQUEST_B,
+                KtorConformanceEvent.FINALLY_COMPLETED,
+            )
+
+            val requestMarker = Span.current().validTraceIdOrNull()
+            harness.ledger.record(
+                ContextRequestAlias.REQUEST_A,
+                KtorConformanceEvent.CLEANUP_PROBED,
+            )
+            harness.ledger.record(
+                ContextRequestAlias.REQUEST_B,
+                KtorConformanceEvent.CLEANUP_PROBED,
+            )
+
+            withTimeout(hangGuard) {
+                client.get("/context/probe")
+            }
+            val probeMarker = harness.probeTraceId.awaitGateWithin("unparented probe")
+            harness.ledger.assertIsolationOrder()
+
+            ContextIsolationObservation(
+                boundary = ContextPropagationBoundary.KTOR_REQUEST,
+                samples = listOf(
+                    ContextIsolationSample(
+                        ContextRequestAlias.REQUEST_A,
+                        harness.observations(ContextRequestAlias.REQUEST_A).toList(),
+                    ),
+                    ContextIsolationSample(
+                        ContextRequestAlias.REQUEST_B,
+                        harness.observations(ContextRequestAlias.REQUEST_B).toList(),
+                    ),
+                    ContextIsolationSample(
+                        ContextRequestAlias.PROBE,
+                        listOf(probeMarker),
+                    ),
+                ),
+                cleanupProbes = listOf(
+                    ContextCleanupProbe(
+                        ContextProbeLocation.REQUEST,
+                        requestMarker,
+                    ),
+                ),
+            )
+        } catch (failure: Throwable) {
+            primaryFailure = failure
+            throw failure
+        } finally {
+            cleanupKtorRequests(primaryFailure, harness, requests)
+        }
+    }
+
+private suspend fun cleanupKtorRequests(
+    primaryFailure: Throwable?,
+    harness: KtorConformanceHarness,
+    requests: List<Deferred<*>>,
+) {
+    var aggregatedFailure = primaryFailure
+    withContext(NonCancellable) {
+        val actions = buildList<suspend () -> Unit> {
+            add(harness::releaseAll)
+            requests.forEach { request ->
+                add {
+                    request.cancel(CancellationException("Ktor conformance cleanup"))
+                }
+            }
+            add {
+                withTimeout(hangGuard) {
+                    requests.joinAll()
+                }
+            }
+        }
+        actions.forEach { action ->
+            val cleanupFailure =
+                try {
+                    action()
+                    null
+                } catch (failure: Throwable) {
+                    failure
+                }
+            cleanupFailure?.let { failure ->
+                val aggregate = aggregatedFailure
+                if (aggregate == null) {
+                    aggregatedFailure = failure
+                } else if (aggregate !== failure && aggregate.suppressed.none { it === failure }) {
+                    aggregate.addSuppressed(failure)
+                }
+            }
+        }
+    }
+    if (primaryFailure == null) {
+        aggregatedFailure?.let { throw it }
+    }
+}
+
+private suspend fun <T> CompletableDeferred<T>.awaitGateWithin(label: String): T =
+    try {
+        withTimeout(hangGuard) {
+            await()
+        }
+    } catch (failure: TimeoutCancellationException) {
+        throw AssertionError("Timed out waiting for Ktor $label", failure)
+    }
+
+private suspend fun Deferred<*>.awaitTerminalWithin(label: String) {
+    try {
+        withTimeout(hangGuard) {
+            await()
+        }
+    } catch (failure: TimeoutCancellationException) {
+        if (!isCompleted) {
+            throw AssertionError("Timed out waiting for Ktor $label", failure)
+        }
+        throw failure
+    }
+}
+
+private fun ktorExpectation(
+    scenario: ContextPropagationScenario,
+    terminal: ContextPropagationTerminal,
+): ContextPropagationExpectation =
+    ContextPropagationExpectation(
+        boundary = ContextPropagationBoundary.KTOR_REQUEST,
+        scenario = scenario,
+        requestAlias = ContextRequestAlias.SINGLE,
+        markerExpectations = listOf(
+            ContextMarkerExpectation(ContextObservationPoint.BOUNDARY_ENTER, traceIdA),
+            ContextMarkerExpectation(ContextObservationPoint.AFTER_SUSPENSION, traceIdA),
+            ContextMarkerExpectation(ContextObservationPoint.BEFORE_TERMINAL, traceIdA),
+        ),
+        cleanupExpectations = listOf(
+            ContextCleanupExpectation(ContextProbeLocation.REQUEST, null),
+        ),
+        expectedTerminal = terminal,
+    )
+
+private fun ktorIsolationExpectation(): ContextIsolationExpectation =
+    ContextIsolationExpectation(
+        boundary = ContextPropagationBoundary.KTOR_REQUEST,
+        samples = listOf(
+            ContextIsolationSampleExpectation(
+                requestAlias = ContextRequestAlias.REQUEST_A,
+                mode = ContextMarkerExpectationMode.EXACT,
+                expectedMarker = traceIdA,
+                minimumObservationCount = 3,
+            ),
+            ContextIsolationSampleExpectation(
+                requestAlias = ContextRequestAlias.REQUEST_B,
+                mode = ContextMarkerExpectationMode.EXACT,
+                expectedMarker = traceIdB,
+                minimumObservationCount = 3,
+            ),
+            ContextIsolationSampleExpectation(
+                requestAlias = ContextRequestAlias.PROBE,
+                mode = ContextMarkerExpectationMode.NOT_IN,
+                forbiddenMarkers = listOf(traceIdA, traceIdB),
+            ),
+        ),
+        cleanupExpectations = listOf(
+            ContextCleanupExpectation(ContextProbeLocation.REQUEST, null),
+        ),
+    )
+
+private fun terminalFor(
+    scenario: ContextPropagationScenario,
+): ContextPropagationTerminal =
+    when (scenario) {
+        ContextPropagationScenario.SUCCESS -> ContextPropagationTerminal.SUCCESS
+        ContextPropagationScenario.FAILURE -> ContextPropagationTerminal.FAILURE
+        ContextPropagationScenario.CANCELLATION -> ContextPropagationTerminal.CANCELLATION
+        ContextPropagationScenario.DEADLINE -> ContextPropagationTerminal.DEADLINE_EXCEEDED
+        ContextPropagationScenario.ISOLATION -> error("Isolation does not have a single terminal")
+    }

--- a/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/KtorContextPropagationConformanceTest.kt
+++ b/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/KtorContextPropagationConformanceTest.kt
@@ -38,12 +38,15 @@ import io.ktor.client.request.get
 import io.ktor.client.request.headers
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCallPipeline
 import io.ktor.server.application.call
 import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
+import io.ktor.util.AttributeKey
+import io.ktor.util.pipeline.PipelinePhase
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Deferred
@@ -347,11 +350,17 @@ private class KtorConformanceHarness {
     val finallyB = CompletableDeferred<Unit>()
     val firstIsolationFailure = AtomicReference<Throwable?>()
     val probeTraceId = CompletableDeferred<String?>()
+    private val cleanupMarkers = ConcurrentHashMap<ContextRequestAlias, CompletableDeferred<String?>>()
     val ledger = KtorConformanceEventLedger()
 
     fun observations(alias: ContextRequestAlias): ConcurrentLinkedQueue<String?> =
         isolationObservations.computeIfAbsent(alias) {
             ConcurrentLinkedQueue()
+        }
+
+    fun cleanupMarker(alias: ContextRequestAlias): CompletableDeferred<String?> =
+        cleanupMarkers.computeIfAbsent(alias) {
+            CompletableDeferred()
         }
 
     fun releaseAll() {
@@ -414,8 +423,22 @@ private class TestTracing(
     }
 }
 
+private val requestAliasKey = AttributeKey<ContextRequestAlias>("ContextConformanceRequestAlias")
+
 private fun ApplicationTestBuilder.installContextConformance(tracing: TestTracing) {
     application {
+        val cleanupProbePhase = PipelinePhase("ContextConformanceCleanupProbe")
+        insertPhaseBefore(ApplicationCallPipeline.Setup, cleanupProbePhase)
+        intercept(cleanupProbePhase) {
+            try {
+                proceed()
+            } finally {
+                call.attributes.getOrNull(requestAliasKey)?.let { alias ->
+                    tracing.harness.cleanupMarker(alias)
+                        .complete(Span.current().validTraceIdOrNull())
+                }
+            }
+        }
         installBluetape4kKtorOpenTelemetryTracing(
             KtorOpenTelemetryTracingConfig(
                 openTelemetry = tracing.openTelemetry,
@@ -450,6 +473,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.runSingleRoute(
     harness: KtorConformanceHarness,
     scenario: ContextPropagationScenario,
 ) {
+    call.attributes.put(requestAliasKey, ContextRequestAlias.SINGLE)
     try {
         harness.singleObservations += markerObservation(
             ContextObservationPoint.BOUNDARY_ENTER,
@@ -504,6 +528,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.runIsolationRoute(
                 traceIdB -> ContextRequestAlias.REQUEST_B
                 else -> error("Unexpected synthetic isolation parent")
             }
+        call.attributes.put(requestAliasKey, alias)
         val ownReady =
             when (alias) {
                 ContextRequestAlias.REQUEST_A -> harness.readyA
@@ -579,7 +604,9 @@ private suspend fun ApplicationTestBuilder.runKtorScenario(
                 ContextRequestAlias.SINGLE,
                 KtorConformanceEvent.FINALLY_COMPLETED,
             )
-            val requestMarker = Span.current().validTraceIdOrNull()
+            val requestMarker =
+                harness.cleanupMarker(ContextRequestAlias.SINGLE)
+                    .awaitGateWithin("single server cleanup probe")
             harness.ledger.record(
                 ContextRequestAlias.SINGLE,
                 KtorConformanceEvent.CLEANUP_PROBED,
@@ -681,7 +708,13 @@ private suspend fun ApplicationTestBuilder.runKtorIsolationScenario(
                 KtorConformanceEvent.FINALLY_COMPLETED,
             )
 
-            val requestMarker = Span.current().validTraceIdOrNull()
+            val requestMarkerA =
+                harness.cleanupMarker(ContextRequestAlias.REQUEST_A)
+                    .awaitGateWithin("request A server cleanup probe")
+            val requestMarkerB =
+                harness.cleanupMarker(ContextRequestAlias.REQUEST_B)
+                    .awaitGateWithin("request B server cleanup probe")
+            val requestMarker = requireRestoredRequestMarkers(requestMarkerA, requestMarkerB)
             harness.ledger.record(
                 ContextRequestAlias.REQUEST_A,
                 KtorConformanceEvent.CLEANUP_PROBED,
@@ -727,6 +760,16 @@ private suspend fun ApplicationTestBuilder.runKtorIsolationScenario(
             cleanupKtorRequests(primaryFailure, harness, requests)
         }
     }
+
+private fun requireRestoredRequestMarkers(
+    requestMarkerA: String?,
+    requestMarkerB: String?,
+): String? {
+    check(requestMarkerA == null && requestMarkerB == null) {
+        "Ktor request context was not restored"
+    }
+    return null
+}
 
 private suspend fun runIsolationClientRequest(
     harness: KtorConformanceHarness,

--- a/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/KtorContextPropagationConformanceTest.kt
+++ b/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/KtorContextPropagationConformanceTest.kt
@@ -171,6 +171,7 @@ class KtorContextPropagationConformanceTest {
                 }
 
                 check(thrown === failure)
+                tracing.harness.ledger.assertIsolationTerminalsObserved()
             }
         }
     }
@@ -295,6 +296,19 @@ private class KtorConformanceEventLedger {
         check(lastReady < firstRelease)
         participantEntries.forEach { (alias, entries) ->
             assertCleanupAfterFinally(alias, entries)
+        }
+    }
+
+    fun assertIsolationTerminalsObserved() {
+        val terminalAliases =
+            events
+                .filter { it.event == KtorConformanceEvent.TERMINAL_OBSERVED }
+                .map(KtorConformanceEventEntry::requestAlias)
+        check(
+            terminalAliases.count { it == ContextRequestAlias.REQUEST_A } == 1 &&
+                    terminalAliases.count { it == ContextRequestAlias.REQUEST_B } == 1
+        ) {
+            "Ktor isolation terminal observation mismatch"
         }
     }
 
@@ -642,7 +656,6 @@ private suspend fun ApplicationTestBuilder.runKtorIsolationScenario(
 
             harness.readyA.awaitGateWithin("request A ready")
             harness.readyB.awaitGateWithin("request B ready")
-            harness.firstIsolationFailure.get()?.let { throw it }
             harness.release.complete(Unit)
 
             val failureA = requestA.captureTerminalWithin("request A terminal")

--- a/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/KtorContextPropagationConformanceTest.kt
+++ b/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/KtorContextPropagationConformanceTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.ktor.observability
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.junit5.coroutines.DEFAULT_CANCELLATION_CONTRACT_TIMEOUT
 import io.bluetape4k.junit5.observability.ContextCleanupExpectation
@@ -157,6 +158,50 @@ class KtorContextPropagationConformanceTest {
                 )
             }
         }
+
+    @Test
+    fun `ktor isolation preserves pre-ready client failure identity`() {
+        val failure = SyntheticKtorIsolationFailure(Any())
+        TestTracing(failureBeforeRequestA = failure).use { tracing ->
+            testApplication {
+                installContextConformance(tracing)
+
+                val thrown = assertFailsWith<SyntheticKtorIsolationFailure> {
+                    runKtorIsolationScenario(tracing)
+                }
+
+                check(thrown === failure)
+            }
+        }
+    }
+
+    @Test
+    fun `ktor isolation preserves post-release client failure identity`() {
+        val failure = SyntheticKtorIsolationFailure(Any())
+        TestTracing(failureAfterRequestA = failure).use { tracing ->
+            testApplication {
+                installContextConformance(tracing)
+
+                val thrown = assertFailsWith<SyntheticKtorIsolationFailure> {
+                    runKtorIsolationScenario(tracing)
+                }
+
+                check(thrown === failure)
+            }
+        }
+    }
+
+    @Test
+    fun `ktor isolation releases peer when parent extraction fails before ready`() =
+        TestTracing(omitIsolationParentA = true).use { tracing ->
+            testApplication {
+                installContextConformance(tracing)
+
+                assertFailsWith<IllegalStateException> {
+                    runKtorIsolationScenario(tracing)
+                }
+            }
+        }
 }
 
 private const val traceIdA = "11111111111111111111111111111111"
@@ -172,6 +217,11 @@ private class CapturedScenario(
     val observation: ContextPropagationObservation,
     val thrown: Throwable?,
 )
+
+private class SyntheticKtorIsolationFailure(
+    @Suppress("unused")
+    private val identityToken: Any,
+): RuntimeException("synthetic Ktor isolation failure")
 
 private enum class KtorConformanceEvent {
     READY,
@@ -297,7 +347,11 @@ private class KtorConformanceHarness {
     }
 }
 
-private class TestTracing : AutoCloseable {
+private class TestTracing(
+    val omitIsolationParentA: Boolean = false,
+    val failureBeforeRequestA: Throwable? = null,
+    val failureAfterRequestA: Throwable? = null,
+) : AutoCloseable {
     val spanExporter: InMemorySpanExporter = InMemorySpanExporter.create()
     private val tracerProvider: SdkTracerProvider =
         SdkTracerProvider.builder()
@@ -427,27 +481,27 @@ private suspend fun io.ktor.server.routing.RoutingContext.runSingleRoute(
 private suspend fun io.ktor.server.routing.RoutingContext.runIsolationRoute(
     harness: KtorConformanceHarness,
 ) {
-    val traceId = Span.current().validTraceIdOrNull()
-    val alias =
-        when (traceId) {
-            traceIdA -> ContextRequestAlias.REQUEST_A
-            traceIdB -> ContextRequestAlias.REQUEST_B
-            else -> error("Unexpected synthetic isolation parent")
-        }
-    val ownReady =
-        when (alias) {
-            ContextRequestAlias.REQUEST_A -> harness.readyA
-            ContextRequestAlias.REQUEST_B -> harness.readyB
-            else -> error("Unexpected isolation alias")
-        }
-    val ownFinally =
-        when (alias) {
-            ContextRequestAlias.REQUEST_A -> harness.finallyA
-            ContextRequestAlias.REQUEST_B -> harness.finallyB
-            else -> error("Unexpected isolation alias")
-        }
-
+    var ownFinally: CompletableDeferred<Unit>? = null
     try {
+        val traceId = Span.current().validTraceIdOrNull()
+        val alias =
+            when (traceId) {
+                traceIdA -> ContextRequestAlias.REQUEST_A
+                traceIdB -> ContextRequestAlias.REQUEST_B
+                else -> error("Unexpected synthetic isolation parent")
+            }
+        val ownReady =
+            when (alias) {
+                ContextRequestAlias.REQUEST_A -> harness.readyA
+                ContextRequestAlias.REQUEST_B -> harness.readyB
+                else -> error("Unexpected isolation alias")
+            }
+        ownFinally =
+            when (alias) {
+                ContextRequestAlias.REQUEST_A -> harness.finallyA
+                ContextRequestAlias.REQUEST_B -> harness.finallyB
+                else -> error("Unexpected isolation alias")
+            }
         harness.observations(alias) += Span.current().validTraceIdOrNull()
         harness.ledger.record(alias, KtorConformanceEvent.READY)
         ownReady.complete(Unit)
@@ -464,7 +518,8 @@ private suspend fun io.ktor.server.routing.RoutingContext.runIsolationRoute(
         harness.releaseAll()
         throw failure
     } finally {
-        ownFinally.complete(Unit)
+        harness.releaseAll()
+        ownFinally?.complete(Unit)
     }
 }
 
@@ -551,19 +606,33 @@ private suspend fun ApplicationTestBuilder.runKtorIsolationScenario(
         var primaryFailure: Throwable? = null
         try {
             val requestA = async {
-                client.get("/context/${ContextPropagationScenario.ISOLATION}") {
-                    headers {
-                        tracing.headers(traceIdA, spanIdA).forEach { (name, value) ->
-                            append(name, value)
+                runIsolationClientRequest(
+                    harness = harness,
+                    failureBeforeRequest = tracing.failureBeforeRequestA,
+                    failureAfterRequest = tracing.failureAfterRequestA,
+                ) {
+                    client.get("/context/${ContextPropagationScenario.ISOLATION}") {
+                        headers {
+                            val parentHeaders =
+                                if (tracing.omitIsolationParentA) {
+                                    emptyMap()
+                                } else {
+                                    tracing.headers(traceIdA, spanIdA)
+                                }
+                            parentHeaders.forEach { (name, value) ->
+                                append(name, value)
+                            }
                         }
                     }
                 }
             }
             val requestB = async {
-                client.get("/context/${ContextPropagationScenario.ISOLATION}") {
-                    headers {
-                        tracing.headers(traceIdB, spanIdB).forEach { (name, value) ->
-                            append(name, value)
+                runIsolationClientRequest(harness) {
+                    client.get("/context/${ContextPropagationScenario.ISOLATION}") {
+                        headers {
+                            tracing.headers(traceIdB, spanIdB).forEach { (name, value) ->
+                                append(name, value)
+                            }
                         }
                     }
                 }
@@ -576,17 +645,17 @@ private suspend fun ApplicationTestBuilder.runKtorIsolationScenario(
             harness.firstIsolationFailure.get()?.let { throw it }
             harness.release.complete(Unit)
 
-            requestA.awaitTerminalWithin("request A terminal")
+            val failureA = requestA.captureTerminalWithin("request A terminal")
             harness.ledger.record(
                 ContextRequestAlias.REQUEST_A,
                 KtorConformanceEvent.TERMINAL_OBSERVED,
             )
-            requestB.awaitTerminalWithin("request B terminal")
+            val failureB = requestB.captureTerminalWithin("request B terminal")
             harness.ledger.record(
                 ContextRequestAlias.REQUEST_B,
                 KtorConformanceEvent.TERMINAL_OBSERVED,
             )
-            harness.firstIsolationFailure.get()?.let { throw it }
+            (harness.firstIsolationFailure.get() ?: failureA ?: failureB)?.let { throw it }
 
             harness.finallyA.awaitGateWithin("request A finally")
             harness.ledger.record(
@@ -646,6 +715,23 @@ private suspend fun ApplicationTestBuilder.runKtorIsolationScenario(
         }
     }
 
+private suspend fun runIsolationClientRequest(
+    harness: KtorConformanceHarness,
+    failureBeforeRequest: Throwable? = null,
+    failureAfterRequest: Throwable? = null,
+    request: suspend () -> Unit,
+) {
+    try {
+        failureBeforeRequest?.let { throw it }
+        request()
+        failureAfterRequest?.let { throw it }
+    } catch (failure: Throwable) {
+        harness.firstIsolationFailure.compareAndSet(null, failure)
+        harness.releaseAll()
+        throw failure
+    }
+}
+
 private suspend fun cleanupKtorRequests(
     primaryFailure: Throwable?,
     harness: KtorConformanceHarness,
@@ -661,8 +747,12 @@ private suspend fun cleanupKtorRequests(
                 }
             }
             add {
-                withTimeout(hangGuard) {
-                    requests.joinAll()
+                try {
+                    withTimeout(hangGuard) {
+                        requests.joinAll()
+                    }
+                } catch (failure: TimeoutCancellationException) {
+                    throw AssertionError("Timed out cleaning Ktor conformance requests", failure)
                 }
             }
         }
@@ -710,6 +800,26 @@ private suspend fun Deferred<*>.awaitTerminalWithin(label: String) {
         throw failure
     }
 }
+
+private suspend fun Deferred<*>.captureTerminalWithin(label: String): Throwable? =
+    try {
+        withTimeout(hangGuard) {
+            await()
+        }
+        null
+    } catch (failure: TimeoutCancellationException) {
+        if (isCompleted) {
+            failure
+        } else {
+            throw AssertionError("Timed out waiting for Ktor $label", failure)
+        }
+    } catch (failure: CancellationException) {
+        failure
+    } catch (failure: Exception) {
+        failure
+    } catch (failure: Error) {
+        failure
+    }
 
 private fun ktorExpectation(
     scenario: ContextPropagationScenario,

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/observability/SpringContextPropagationConformanceTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/observability/SpringContextPropagationConformanceTest.kt
@@ -1,0 +1,665 @@
+package io.bluetape4k.spring.observability
+
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.junit5.coroutines.DEFAULT_CANCELLATION_CONTRACT_TIMEOUT
+import io.bluetape4k.junit5.observability.ContextCleanupExpectation
+import io.bluetape4k.junit5.observability.ContextCleanupProbe
+import io.bluetape4k.junit5.observability.ContextIsolationExpectation
+import io.bluetape4k.junit5.observability.ContextIsolationObservation
+import io.bluetape4k.junit5.observability.ContextIsolationSample
+import io.bluetape4k.junit5.observability.ContextIsolationSampleExpectation
+import io.bluetape4k.junit5.observability.ContextMarkerExpectation
+import io.bluetape4k.junit5.observability.ContextMarkerExpectationMode
+import io.bluetape4k.junit5.observability.ContextMarkerObservation
+import io.bluetape4k.junit5.observability.ContextObservationPoint
+import io.bluetape4k.junit5.observability.ContextProbeLocation
+import io.bluetape4k.junit5.observability.ContextPropagationBoundary
+import io.bluetape4k.junit5.observability.ContextPropagationExpectation
+import io.bluetape4k.junit5.observability.ContextPropagationObservation
+import io.bluetape4k.junit5.observability.ContextPropagationScenario
+import io.bluetape4k.junit5.observability.ContextPropagationTerminal
+import io.bluetape4k.junit5.observability.ContextRequestAlias
+import io.bluetape4k.junit5.observability.assertContextIsolation
+import io.bluetape4k.junit5.observability.assertContextPropagationConformance
+import io.micrometer.observation.ObservationRegistry
+import io.micrometer.observation.tck.TestObservationRegistry
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration.Companion.milliseconds
+
+@Timeout(
+    value = 15,
+    unit = TimeUnit.SECONDS,
+    threadMode = Timeout.ThreadMode.SAME_THREAD,
+)
+class SpringContextPropagationConformanceTest {
+
+    @Test
+    fun `spring observation is visible across suspension and cleaned on success`() = runTest {
+        val captured = runSpringScenario(ContextPropagationScenario.SUCCESS)
+        captured.thrown.shouldBeNull()
+        assertContextPropagationConformance(
+            captured.observation,
+            springExpectation(
+                ContextPropagationScenario.SUCCESS,
+                ContextPropagationTerminal.SUCCESS,
+            ),
+        )
+    }
+
+    @Test
+    fun `spring observation failure propagates and cleans registry`() = runTest {
+        val captured = runSpringScenario(ContextPropagationScenario.FAILURE)
+        check(captured.thrown?.javaClass == IllegalStateException::class.java)
+        assertContextPropagationConformance(
+            captured.observation,
+            springExpectation(
+                ContextPropagationScenario.FAILURE,
+                ContextPropagationTerminal.FAILURE,
+            ),
+        )
+    }
+
+    @Test
+    fun `spring child cancellation propagates and cleans registry`() = runTest {
+        val captured = runSpringScenario(ContextPropagationScenario.CANCELLATION)
+        check(captured.thrown is CancellationException)
+        check(captured.thrown !is TimeoutCancellationException)
+        assertContextPropagationConformance(
+            captured.observation,
+            springExpectation(
+                ContextPropagationScenario.CANCELLATION,
+                ContextPropagationTerminal.CANCELLATION,
+            ),
+        )
+    }
+
+    @Test
+    fun `spring observation deadline propagates and cleans registry`() = runTest {
+        val captured = runSpringScenario(ContextPropagationScenario.DEADLINE)
+        check(captured.thrown?.javaClass == TimeoutCancellationException::class.java)
+        assertContextPropagationConformance(
+            captured.observation,
+            springExpectation(
+                ContextPropagationScenario.DEADLINE,
+                ContextPropagationTerminal.DEADLINE_EXCEEDED,
+            ),
+        )
+    }
+
+    @Test
+    fun `spring observations stay isolated between sibling coroutines`() = runTest {
+        assertContextIsolation(
+            runSpringIsolationScenario(),
+            springIsolationExpectation(),
+        )
+    }
+}
+
+private val hangGuard = DEFAULT_CANCELLATION_CONTRACT_TIMEOUT
+private val semanticDeadline = 250.milliseconds.also {
+    check(it < hangGuard)
+}
+private const val springMarkerA = "synthetic-spring-parent-a"
+private const val springMarkerB = "synthetic-spring-parent-b"
+
+private class CapturedScenario(
+    val observation: ContextPropagationObservation,
+    val thrown: Throwable?,
+)
+
+private enum class SpringConformanceEvent {
+    READY,
+    RELEASED,
+    TERMINAL_OBSERVED,
+    FINALLY_COMPLETED,
+    CLEANUP_PROBED,
+}
+
+private class SpringConformanceEventEntry(
+    val requestAlias: ContextRequestAlias,
+    val event: SpringConformanceEvent,
+    val sequence: Long,
+)
+
+private class SpringConformanceEventLedger {
+    private val sequence = AtomicLong()
+    private val events = ConcurrentLinkedQueue<SpringConformanceEventEntry>()
+
+    fun record(
+        requestAlias: ContextRequestAlias,
+        event: SpringConformanceEvent,
+    ) {
+        events += SpringConformanceEventEntry(
+            requestAlias,
+            event,
+            sequence.incrementAndGet(),
+        )
+    }
+
+    fun assertSingleScenarioOrder() {
+        val entries = events.filter { it.requestAlias == ContextRequestAlias.SINGLE }
+        val counts = entries.groupingBy(SpringConformanceEventEntry::event).eachCount()
+        listOf(
+            SpringConformanceEvent.TERMINAL_OBSERVED,
+            SpringConformanceEvent.FINALLY_COMPLETED,
+            SpringConformanceEvent.CLEANUP_PROBED,
+        ).forEach { event ->
+            check(counts[event] == 1) {
+                "Spring lifecycle event count mismatch: alias=SINGLE, event=$event"
+            }
+        }
+        check(counts[SpringConformanceEvent.READY] == null)
+        check(counts[SpringConformanceEvent.RELEASED] == null)
+        assertCleanupAfterFinally(ContextRequestAlias.SINGLE, entries)
+    }
+
+    fun assertIsolationOrder() {
+        val snapshot = events.toList()
+        val participantEntries = listOf(
+            ContextRequestAlias.REQUEST_A,
+            ContextRequestAlias.REQUEST_B,
+        ).associateWith { alias ->
+            snapshot.filter { it.requestAlias == alias }.also { entries ->
+                val counts = entries.groupingBy(SpringConformanceEventEntry::event).eachCount()
+                SpringConformanceEvent.entries.forEach { event ->
+                    check(counts[event] == 1) {
+                        "Spring lifecycle event count mismatch: alias=$alias, event=$event"
+                    }
+                }
+            }
+        }
+        val lastReady = participantEntries.values
+            .flatten()
+            .filter { it.event == SpringConformanceEvent.READY }
+            .maxOf(SpringConformanceEventEntry::sequence)
+        val firstRelease = participantEntries.values
+            .flatten()
+            .filter { it.event == SpringConformanceEvent.RELEASED }
+            .minOf(SpringConformanceEventEntry::sequence)
+        check(lastReady < firstRelease)
+        participantEntries.forEach { (alias, entries) ->
+            assertCleanupAfterFinally(alias, entries)
+        }
+    }
+
+    private fun assertCleanupAfterFinally(
+        alias: ContextRequestAlias,
+        entries: List<SpringConformanceEventEntry>,
+    ) {
+        val terminalSequence = entries.single {
+            it.event == SpringConformanceEvent.TERMINAL_OBSERVED
+        }.sequence
+        val finallySequence = entries.single {
+            it.event == SpringConformanceEvent.FINALLY_COMPLETED
+        }.sequence
+        val cleanupSequence = entries.single {
+            it.event == SpringConformanceEvent.CLEANUP_PROBED
+        }.sequence
+        check(terminalSequence < cleanupSequence) {
+            "Spring terminal cleanup order mismatch: alias=$alias"
+        }
+        check(finallySequence < cleanupSequence) {
+            "Spring lifecycle cleanup order mismatch: alias=$alias"
+        }
+    }
+}
+
+private fun springExpectation(
+    scenario: ContextPropagationScenario,
+    terminal: ContextPropagationTerminal,
+): ContextPropagationExpectation =
+    ContextPropagationExpectation(
+        boundary = ContextPropagationBoundary.SPRING_OBSERVATION,
+        scenario = scenario,
+        requestAlias = ContextRequestAlias.SINGLE,
+        markerExpectations = listOf(
+            ContextMarkerExpectation(ContextObservationPoint.BOUNDARY_ENTER, springMarkerA),
+            ContextMarkerExpectation(ContextObservationPoint.AFTER_SUSPENSION, springMarkerA),
+            ContextMarkerExpectation(ContextObservationPoint.BEFORE_TERMINAL, springMarkerA),
+        ),
+        cleanupExpectations = listOf(
+            ContextCleanupExpectation(ContextProbeLocation.CALLER, null),
+        ),
+        expectedTerminal = terminal,
+    )
+
+private fun springIsolationExpectation(): ContextIsolationExpectation =
+    ContextIsolationExpectation(
+        boundary = ContextPropagationBoundary.SPRING_OBSERVATION,
+        samples = listOf(
+            ContextIsolationSampleExpectation(
+                requestAlias = ContextRequestAlias.REQUEST_A,
+                mode = ContextMarkerExpectationMode.EXACT,
+                expectedMarker = springMarkerA,
+                minimumObservationCount = 3,
+            ),
+            ContextIsolationSampleExpectation(
+                requestAlias = ContextRequestAlias.REQUEST_B,
+                mode = ContextMarkerExpectationMode.EXACT,
+                expectedMarker = springMarkerB,
+                minimumObservationCount = 3,
+            ),
+        ),
+        cleanupExpectations = listOf(
+            ContextCleanupExpectation(ContextProbeLocation.CALLER, null),
+        ),
+    )
+
+private suspend fun runSpringScenario(
+    scenario: ContextPropagationScenario,
+): CapturedScenario =
+    supervisorScope {
+        check(scenario != ContextPropagationScenario.ISOLATION) {
+            "Isolation uses runSpringIsolationScenario"
+        }
+
+        val registry = TestObservationRegistry.create()
+        val observations = mutableListOf<ContextMarkerObservation>()
+        val started = CompletableDeferred<Unit>()
+        val finallyCompleted = CompletableDeferred<Unit>()
+        val ledger = SpringConformanceEventLedger()
+        val children = mutableListOf<Deferred<*>>()
+
+        withSpringChildrenCleanup(
+            children = children,
+            beforeCleanup = {
+                started.complete(Unit)
+            },
+        ) {
+            val child = async {
+                try {
+                    registry.observeMarkers(springMarkerA, observations) {
+                        started.complete(Unit)
+                        when (scenario) {
+                            ContextPropagationScenario.SUCCESS -> Unit
+                            ContextPropagationScenario.FAILURE ->
+                                error("synthetic Spring observation failure")
+
+                            ContextPropagationScenario.CANCELLATION ->
+                                awaitCancellation()
+
+                            ContextPropagationScenario.DEADLINE ->
+                                withTimeout(semanticDeadline) {
+                                    awaitCancellation()
+                                }
+
+                            else -> error("Isolation uses runSpringIsolationScenario")
+                        }
+                    }
+                } finally {
+                    finallyCompleted.complete(Unit)
+                }
+            }
+            children += child
+            started.awaitGateWithin()
+            if (scenario == ContextPropagationScenario.CANCELLATION) {
+                child.cancel(CancellationException("synthetic Spring child cancellation"))
+            }
+            val thrown = child.captureTerminalWithin()
+            ledger.record(
+                ContextRequestAlias.SINGLE,
+                SpringConformanceEvent.TERMINAL_OBSERVED,
+            )
+            finallyCompleted.awaitGateWithin()
+            ledger.record(
+                ContextRequestAlias.SINGLE,
+                SpringConformanceEvent.FINALLY_COMPLETED,
+            )
+            val callerMarker = registry.currentMarker()
+            ledger.record(
+                ContextRequestAlias.SINGLE,
+                SpringConformanceEvent.CLEANUP_PROBED,
+            )
+            ledger.assertSingleScenarioOrder()
+
+            CapturedScenario(
+                observation = ContextPropagationObservation(
+                    boundary = ContextPropagationBoundary.SPRING_OBSERVATION,
+                    scenario = scenario,
+                    requestAlias = ContextRequestAlias.SINGLE,
+                    markerObservations = observations.toList(),
+                    cleanupProbes = listOf(
+                        ContextCleanupProbe(ContextProbeLocation.CALLER, callerMarker),
+                    ),
+                    terminal = terminalFor(scenario),
+                ),
+                thrown = thrown,
+            )
+        }
+    }
+
+private suspend fun runSpringIsolationScenario(): ContextIsolationObservation =
+    supervisorScope {
+        val registryA = TestObservationRegistry.create()
+        val registryB = TestObservationRegistry.create()
+        val observationsA = ConcurrentLinkedQueue<String?>()
+        val observationsB = ConcurrentLinkedQueue<String?>()
+        val readyA = CompletableDeferred<Unit>()
+        val readyB = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        val finallyA = CompletableDeferred<Unit>()
+        val finallyB = CompletableDeferred<Unit>()
+        val firstFailure = AtomicReference<Throwable?>()
+        val ledger = SpringConformanceEventLedger()
+        val children = mutableListOf<Deferred<*>>()
+
+        withSpringChildrenCleanup(
+            children = children,
+            beforeCleanup = {
+                readyA.complete(Unit)
+                readyB.complete(Unit)
+                release.complete(Unit)
+            },
+        ) {
+            val childA = async {
+                runSpringIsolationParticipant(
+                    registry = registryA,
+                    marker = springMarkerA,
+                    alias = ContextRequestAlias.REQUEST_A,
+                    observations = observationsA,
+                    ownReady = readyA,
+                    readyA = readyA,
+                    readyB = readyB,
+                    release = release,
+                    finallyCompleted = finallyA,
+                    firstFailure = firstFailure,
+                    ledger = ledger,
+                )
+            }
+            val childB = async {
+                runSpringIsolationParticipant(
+                    registry = registryB,
+                    marker = springMarkerB,
+                    alias = ContextRequestAlias.REQUEST_B,
+                    observations = observationsB,
+                    ownReady = readyB,
+                    readyA = readyA,
+                    readyB = readyB,
+                    release = release,
+                    finallyCompleted = finallyB,
+                    firstFailure = firstFailure,
+                    ledger = ledger,
+                )
+            }
+            children += childA
+            children += childB
+
+            readyA.awaitGateWithin()
+            readyB.awaitGateWithin()
+            firstFailure.get()?.let { throw it }
+            release.complete(Unit)
+
+            val thrownA = childA.captureTerminalWithin()
+            ledger.record(
+                ContextRequestAlias.REQUEST_A,
+                SpringConformanceEvent.TERMINAL_OBSERVED,
+            )
+            val thrownB = childB.captureTerminalWithin()
+            ledger.record(
+                ContextRequestAlias.REQUEST_B,
+                SpringConformanceEvent.TERMINAL_OBSERVED,
+            )
+            check(thrownA == null && thrownB == null) {
+                "Spring isolation participant failed"
+            }
+
+            finallyA.awaitGateWithin()
+            ledger.record(
+                ContextRequestAlias.REQUEST_A,
+                SpringConformanceEvent.FINALLY_COMPLETED,
+            )
+            finallyB.awaitGateWithin()
+            ledger.record(
+                ContextRequestAlias.REQUEST_B,
+                SpringConformanceEvent.FINALLY_COMPLETED,
+            )
+
+            val callerMarkerA = registryA.currentMarker()
+            ledger.record(
+                ContextRequestAlias.REQUEST_A,
+                SpringConformanceEvent.CLEANUP_PROBED,
+            )
+            val callerMarkerB = registryB.currentMarker()
+            ledger.record(
+                ContextRequestAlias.REQUEST_B,
+                SpringConformanceEvent.CLEANUP_PROBED,
+            )
+            ledger.assertIsolationOrder()
+
+            ContextIsolationObservation(
+                boundary = ContextPropagationBoundary.SPRING_OBSERVATION,
+                samples = listOf(
+                    ContextIsolationSample(
+                        ContextRequestAlias.REQUEST_A,
+                        observationsA.toList(),
+                    ),
+                    ContextIsolationSample(
+                        ContextRequestAlias.REQUEST_B,
+                        observationsB.toList(),
+                    ),
+                ),
+                cleanupProbes = listOf(
+                    ContextCleanupProbe(
+                        ContextProbeLocation.CALLER,
+                        callerMarkerA ?: callerMarkerB,
+                    ),
+                ),
+            )
+        }
+    }
+
+private suspend fun runSpringIsolationParticipant(
+    registry: ObservationRegistry,
+    marker: String,
+    alias: ContextRequestAlias,
+    observations: ConcurrentLinkedQueue<String?>,
+    ownReady: CompletableDeferred<Unit>,
+    readyA: CompletableDeferred<Unit>,
+    readyB: CompletableDeferred<Unit>,
+    release: CompletableDeferred<Unit>,
+    finallyCompleted: CompletableDeferred<Unit>,
+    firstFailure: AtomicReference<Throwable?>,
+    ledger: SpringConformanceEventLedger,
+) {
+    try {
+        registry.observeSpringSuspending(marker) {
+            observations += registry.currentMarker()
+            ledger.record(alias, SpringConformanceEvent.READY)
+            ownReady.complete(Unit)
+            readyA.awaitGateWithin()
+            readyB.awaitGateWithin()
+            release.awaitGateWithin()
+            ledger.record(alias, SpringConformanceEvent.RELEASED)
+            yield()
+            observations += registry.currentMarker()
+            observations += registry.currentMarker()
+        }
+    } catch (e: Exception) {
+        recordSpringIsolationFailure(
+            e,
+            firstFailure,
+            readyA,
+            readyB,
+            release,
+        )
+        throw e
+    } catch (e: Error) {
+        recordSpringIsolationFailure(
+            e,
+            firstFailure,
+            readyA,
+            readyB,
+            release,
+        )
+        throw e
+    } finally {
+        finallyCompleted.complete(Unit)
+    }
+}
+
+private fun recordSpringIsolationFailure(
+    failure: Throwable,
+    firstFailure: AtomicReference<Throwable?>,
+    readyA: CompletableDeferred<Unit>,
+    readyB: CompletableDeferred<Unit>,
+    release: CompletableDeferred<Unit>,
+) {
+    firstFailure.compareAndSet(null, failure)
+    readyA.complete(Unit)
+    readyB.complete(Unit)
+    release.complete(Unit)
+}
+
+private suspend fun ObservationRegistry.observeMarkers(
+    marker: String,
+    observations: MutableList<ContextMarkerObservation>,
+    terminalAction: suspend () -> Unit,
+) {
+    observeSpringSuspending(name = marker) {
+        observations += ContextMarkerObservation(
+            ContextObservationPoint.BOUNDARY_ENTER,
+            currentMarker(),
+        )
+        yield()
+        observations += ContextMarkerObservation(
+            ContextObservationPoint.AFTER_SUSPENSION,
+            currentMarker(),
+        )
+        observations += ContextMarkerObservation(
+            ContextObservationPoint.BEFORE_TERMINAL,
+            currentMarker(),
+        )
+        terminalAction()
+    }
+}
+
+private fun ObservationRegistry.currentMarker(): String? =
+    currentObservation?.context?.name
+
+private fun terminalFor(
+    scenario: ContextPropagationScenario,
+): ContextPropagationTerminal =
+    when (scenario) {
+        ContextPropagationScenario.SUCCESS -> ContextPropagationTerminal.SUCCESS
+        ContextPropagationScenario.FAILURE -> ContextPropagationTerminal.FAILURE
+        ContextPropagationScenario.CANCELLATION -> ContextPropagationTerminal.CANCELLATION
+        ContextPropagationScenario.DEADLINE -> ContextPropagationTerminal.DEADLINE_EXCEEDED
+        else -> error("Isolation does not have a single terminal")
+    }
+
+private suspend fun CompletableDeferred<Unit>.awaitGateWithin() {
+    try {
+        withTimeout(hangGuard) {
+            await()
+        }
+    } catch (e: TimeoutCancellationException) {
+        throw AssertionError("Timed out waiting for Spring conformance gate", e)
+    }
+}
+
+private suspend fun Deferred<Unit>.captureTerminalWithin(): Throwable? =
+    try {
+        withTimeout(hangGuard) {
+            await()
+        }
+        null
+    } catch (e: TimeoutCancellationException) {
+        if (isCompleted) {
+            e
+        } else {
+            throw AssertionError("Timed out waiting for Spring terminal", e)
+        }
+    } catch (e: CancellationException) {
+        e
+    } catch (e: Exception) {
+        e
+    }
+
+private suspend fun <T> withSpringChildrenCleanup(
+    children: MutableList<Deferred<*>>,
+    beforeCleanup: () -> Unit,
+    block: suspend () -> T,
+): T {
+    var primaryFailure: Throwable? = null
+    try {
+        return block()
+    } catch (e: Exception) {
+        primaryFailure = e
+        throw e
+    } catch (e: Error) {
+        primaryFailure = e
+        throw e
+    } finally {
+        cleanupSpringChildren(
+            primaryFailure,
+            beforeCleanup,
+            children,
+        )
+    }
+}
+
+private suspend fun cleanupSpringChildren(
+    primaryFailure: Throwable?,
+    beforeCleanup: () -> Unit,
+    children: List<Deferred<*>>,
+) {
+    var aggregatedFailure = primaryFailure
+    withContext(NonCancellable) {
+        val actions = buildList<suspend () -> Unit> {
+            add {
+                beforeCleanup()
+            }
+            children.forEach { child ->
+                add {
+                    child.cancel(CancellationException("Spring conformance cleanup"))
+                }
+            }
+            add {
+                withTimeout(hangGuard) {
+                    children.joinAll()
+                }
+            }
+        }
+        actions.forEach { action ->
+            val cleanupFailure = try {
+                action()
+                null
+            } catch (e: TimeoutCancellationException) {
+                AssertionError("Timed out cleaning Spring conformance children", e)
+            } catch (e: Exception) {
+                e
+            } catch (e: Error) {
+                e
+            }
+            cleanupFailure?.let { failure ->
+                val aggregate = aggregatedFailure
+                if (aggregate == null) {
+                    aggregatedFailure = failure
+                } else if (aggregate !== failure && aggregate.suppressed.none { it === failure }) {
+                    aggregate.addSuppressed(failure)
+                }
+            }
+        }
+    }
+    if (primaryFailure == null) {
+        aggregatedFailure?.let { throw it }
+    }
+}

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/observability/SpringContextPropagationConformanceTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/observability/SpringContextPropagationConformanceTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.spring.observability
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.junit5.coroutines.DEFAULT_CANCELLATION_CONTRACT_TIMEOUT
 import io.bluetape4k.junit5.observability.ContextCleanupExpectation
@@ -111,6 +112,17 @@ class SpringContextPropagationConformanceTest {
             springIsolationExpectation(),
         )
     }
+
+    @Test
+    fun `spring isolation preserves participant failure after release`() = runTest {
+        val failure = SyntheticSpringIsolationFailure(Any())
+
+        val thrown = assertFailsWith<SyntheticSpringIsolationFailure> {
+            runSpringIsolationScenarioWithFailure(failure)
+        }
+
+        check(thrown === failure)
+    }
 }
 
 private val hangGuard = DEFAULT_CANCELLATION_CONTRACT_TIMEOUT
@@ -124,6 +136,11 @@ private class CapturedScenario(
     val observation: ContextPropagationObservation,
     val thrown: Throwable?,
 )
+
+private class SyntheticSpringIsolationFailure(
+    @Suppress("unused")
+    private val identityToken: Any,
+): RuntimeException("synthetic post-release failure")
 
 private enum class SpringConformanceEvent {
     READY,
@@ -347,6 +364,11 @@ private suspend fun runSpringScenario(
     }
 
 private suspend fun runSpringIsolationScenario(): ContextIsolationObservation =
+    runSpringIsolationScenarioWithFailure()
+
+private suspend fun runSpringIsolationScenarioWithFailure(
+    failureAfterRelease: Throwable? = null,
+): ContextIsolationObservation =
     supervisorScope {
         val registryA = TestObservationRegistry.create()
         val registryB = TestObservationRegistry.create()
@@ -382,6 +404,7 @@ private suspend fun runSpringIsolationScenario(): ContextIsolationObservation =
                     finallyCompleted = finallyA,
                     firstFailure = firstFailure,
                     ledger = ledger,
+                    failureAfterRelease = failureAfterRelease,
                 )
             }
             val childB = async {
@@ -397,6 +420,7 @@ private suspend fun runSpringIsolationScenario(): ContextIsolationObservation =
                     finallyCompleted = finallyB,
                     firstFailure = firstFailure,
                     ledger = ledger,
+                    failureAfterRelease = null,
                 )
             }
             children += childA
@@ -417,9 +441,7 @@ private suspend fun runSpringIsolationScenario(): ContextIsolationObservation =
                 ContextRequestAlias.REQUEST_B,
                 SpringConformanceEvent.TERMINAL_OBSERVED,
             )
-            check(thrownA == null && thrownB == null) {
-                "Spring isolation participant failed"
-            }
+            (firstFailure.get() ?: thrownA ?: thrownB)?.let { throw it }
 
             finallyA.awaitGateWithin()
             ledger.record(
@@ -478,6 +500,7 @@ private suspend fun runSpringIsolationParticipant(
     finallyCompleted: CompletableDeferred<Unit>,
     firstFailure: AtomicReference<Throwable?>,
     ledger: SpringConformanceEventLedger,
+    failureAfterRelease: Throwable?,
 ) {
     try {
         registry.observeSpringSuspending(marker) {
@@ -488,6 +511,7 @@ private suspend fun runSpringIsolationParticipant(
             readyB.awaitGateWithin()
             release.awaitGateWithin()
             ledger.record(alias, SpringConformanceEvent.RELEASED)
+            failureAfterRelease?.let { throw it }
             yield()
             observations += registry.currentMarker()
             observations += registry.currentMarker()

--- a/testing/junit5/README.ko.md
+++ b/testing/junit5/README.ko.md
@@ -304,6 +304,130 @@ success/client-error/timeout-or-cancellation/dependency-failure 분류, propagat
 registry, tracer, exporter, OpenTelemetry SDK의 lifecycle은 테스트가 직접 소유합니다. 이 fixture는
 framework-neutral snapshot만 검증하며 telemetry 인프라를 설치하거나 종료하지 않습니다.
 
+### Context Propagation Conformance
+
+provider-neutral fixture는 실제 framework adapter가 suspension 전후에 동일한 parent marker를 노출하고,
+실제 terminal 결과를 보존하며, context를 정리하고, 동시 요청을 격리하는지 증명합니다. 실제 framework
+context를 snapshot으로 변환하는 책임은 adapter에 있으며 fixture는 interception을 설치하지 않습니다.
+
+`null`은 root context를 뜻합니다. `SUCCESS`, `FAILURE`, `CANCELLATION`, `DEADLINE_EXCEEDED`는 서로 다른
+terminal 결과입니다. 진단은 제한된 좌표와 `값 비공개`만 제공하며 raw marker 값을 포함하지 않습니다.
+
+test-owned synthetic marker만 사용해야 합니다. production request ID, user data, external trace ID를 전달하면
+안 됩니다. `Serializable` snapshot은 테스트 교환값일 뿐 persistence/wire contract가 아니므로 장기 저장하지
+마세요. enum 값 추가는 additive이므로 caller의 exhaustive when에는 `else`를 두어야 합니다. data-class
+constructor 변경은 compatibility-sensitive하므로 snapshot을 구조분해하거나 constructor layout을 저장
+포맷으로 의존하지 마세요.
+
+```kotlin
+import io.bluetape4k.junit5.observability.*
+
+val marker = "synthetic-parent"
+val observation = ContextPropagationObservation(
+    boundary = ContextPropagationBoundary.COROUTINE,
+    scenario = ContextPropagationScenario.SUCCESS,
+    requestAlias = ContextRequestAlias.SINGLE,
+    markerObservations = listOf(
+        ContextMarkerObservation(
+            ContextObservationPoint.BOUNDARY_ENTER,
+            marker,
+        ),
+        ContextMarkerObservation(
+            ContextObservationPoint.AFTER_SUSPENSION,
+            marker,
+        ),
+        ContextMarkerObservation(
+            ContextObservationPoint.BEFORE_TERMINAL,
+            marker,
+        ),
+    ),
+    cleanupProbes = listOf(
+        ContextCleanupProbe(ContextProbeLocation.CALLER, null),
+    ),
+    terminal = ContextPropagationTerminal.SUCCESS,
+)
+val expectation = ContextPropagationExpectation(
+    boundary = ContextPropagationBoundary.COROUTINE,
+    scenario = ContextPropagationScenario.SUCCESS,
+    requestAlias = ContextRequestAlias.SINGLE,
+    markerExpectations = listOf(
+        ContextMarkerExpectation(
+            ContextObservationPoint.BOUNDARY_ENTER,
+            marker,
+        ),
+        ContextMarkerExpectation(
+            ContextObservationPoint.AFTER_SUSPENSION,
+            marker,
+        ),
+        ContextMarkerExpectation(
+            ContextObservationPoint.BEFORE_TERMINAL,
+            marker,
+        ),
+    ),
+    cleanupExpectations = listOf(
+        ContextCleanupExpectation(ContextProbeLocation.CALLER, null),
+    ),
+    expectedTerminal = ContextPropagationTerminal.SUCCESS,
+)
+
+assertContextPropagationConformance(observation, expectation)
+```
+
+```kotlin
+import io.bluetape4k.junit5.observability.*
+
+val isolationObservation = ContextIsolationObservation(
+    boundary = ContextPropagationBoundary.KTOR_REQUEST,
+    samples = listOf(
+        ContextIsolationSample(
+            ContextRequestAlias.REQUEST_A,
+            listOf("synthetic-parent-A", "synthetic-parent-A"),
+        ),
+        ContextIsolationSample(
+            ContextRequestAlias.REQUEST_B,
+            listOf("synthetic-parent-B", "synthetic-parent-B"),
+        ),
+        ContextIsolationSample(
+            ContextRequestAlias.PROBE,
+            listOf("synthetic-probe"),
+        ),
+    ),
+    cleanupProbes = listOf(
+        ContextCleanupProbe(ContextProbeLocation.REQUEST, null),
+    ),
+)
+val isolationExpectation = ContextIsolationExpectation(
+    boundary = ContextPropagationBoundary.KTOR_REQUEST,
+    samples = listOf(
+        ContextIsolationSampleExpectation(
+            requestAlias = ContextRequestAlias.REQUEST_A,
+            mode = ContextMarkerExpectationMode.EXACT,
+            expectedMarker = "synthetic-parent-A",
+            minimumObservationCount = 2,
+        ),
+        ContextIsolationSampleExpectation(
+            requestAlias = ContextRequestAlias.REQUEST_B,
+            mode = ContextMarkerExpectationMode.EXACT,
+            expectedMarker = "synthetic-parent-B",
+            minimumObservationCount = 2,
+        ),
+        ContextIsolationSampleExpectation(
+            requestAlias = ContextRequestAlias.PROBE,
+            mode = ContextMarkerExpectationMode.NOT_IN,
+            forbiddenMarkers = listOf(
+                "synthetic-parent-A",
+                "synthetic-parent-B",
+            ),
+        ),
+    ),
+    cleanupExpectations = listOf(
+        ContextCleanupExpectation(ContextProbeLocation.REQUEST, null),
+    ),
+)
+
+assertContextIsolation(isolationObservation, isolationExpectation)
+```
+
 ### Bounded-Wait HTTP Idempotency Conformance
 
 opt-in fixture로 framework adapter가 동일한 observable HTTP 계약을 만족하는지 검증합니다. 아래 설정은

--- a/testing/junit5/README.ko.md
+++ b/testing/junit5/README.ko.md
@@ -468,9 +468,9 @@ assertContextIsolation(isolationObservation, isolationExpectation)
 ```
 
 framework가 lifecycle을 소유하는 전체 adapter proof는 compile-checked
-[coroutine, Reactor, executor conformance test](../../infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt),
-[Spring Observation test](../../spring-boot/core/src/test/kotlin/io/bluetape4k/spring/observability/SpringContextPropagationConformanceTest.kt),
-[Ktor request test](../../ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/KtorContextPropagationConformanceTest.kt)를
+[coroutine, Reactor, executor conformance test](https://github.com/bluetape4k/bluetape4k-projects/blob/develop/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt),
+[Spring Observation test](https://github.com/bluetape4k/bluetape4k-projects/blob/develop/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/observability/SpringContextPropagationConformanceTest.kt),
+[Ktor request test](https://github.com/bluetape4k/bluetape4k-projects/blob/develop/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/KtorContextPropagationConformanceTest.kt)를
 참고하세요.
 
 ### Bounded-Wait HTTP Idempotency Conformance

--- a/testing/junit5/README.ko.md
+++ b/testing/junit5/README.ko.md
@@ -311,7 +311,8 @@ provider-neutral fixture는 실제 framework adapter가 suspension 전후에 동
 context를 snapshot으로 변환하는 책임은 adapter에 있으며 fixture는 interception을 설치하지 않습니다.
 
 `null`은 root context를 뜻합니다. `SUCCESS`, `FAILURE`, `CANCELLATION`, `DEADLINE_EXCEEDED`는 서로 다른
-terminal 결과입니다. 진단은 제한된 좌표와 `값 비공개`만 제공하며 raw marker 값을 포함하지 않습니다.
+terminal 결과입니다. 진단은 제한된 좌표와 실제 literal `values redacted`(값 비공개)만 제공하며 raw
+marker 값을 포함하지 않습니다. marker-bearing snapshot의 `toString()`도 같은 redaction 규칙을 따릅니다.
 
 test-owned synthetic marker만 사용해야 합니다. production request ID, user data, external trace ID를 전달하면
 안 됩니다. `Serializable` snapshot은 테스트 교환값일 뿐 persistence/wire contract가 아니므로 장기 저장하지
@@ -321,31 +322,42 @@ constructor 변경은 compatibility-sensitive하므로 snapshot을 구조분해�
 
 ```kotlin
 import io.bluetape4k.junit5.observability.*
+import kotlinx.coroutines.asContextElement
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 
 val marker = "synthetic-parent"
-val observation = ContextPropagationObservation(
-    boundary = ContextPropagationBoundary.COROUTINE,
-    scenario = ContextPropagationScenario.SUCCESS,
-    requestAlias = ContextRequestAlias.SINGLE,
-    markerObservations = listOf(
-        ContextMarkerObservation(
+val markerContext = ThreadLocal<String?>()
+val observation = runBlocking {
+    val observed = mutableListOf<ContextMarkerObservation>()
+    withContext(markerContext.asContextElement(marker)) {
+        observed += ContextMarkerObservation(
             ContextObservationPoint.BOUNDARY_ENTER,
-            marker,
-        ),
-        ContextMarkerObservation(
+            markerContext.get(),
+        )
+        yield()
+        observed += ContextMarkerObservation(
             ContextObservationPoint.AFTER_SUSPENSION,
-            marker,
-        ),
-        ContextMarkerObservation(
+            markerContext.get(),
+        )
+        observed += ContextMarkerObservation(
             ContextObservationPoint.BEFORE_TERMINAL,
-            marker,
+            markerContext.get(),
+        )
+    }
+    ContextPropagationObservation(
+        boundary = ContextPropagationBoundary.COROUTINE,
+        scenario = ContextPropagationScenario.SUCCESS,
+        requestAlias = ContextRequestAlias.SINGLE,
+        markerObservations = observed,
+        cleanupProbes = listOf(
+            ContextCleanupProbe(ContextProbeLocation.CALLER, markerContext.get()),
         ),
-    ),
-    cleanupProbes = listOf(
-        ContextCleanupProbe(ContextProbeLocation.CALLER, null),
-    ),
-    terminal = ContextPropagationTerminal.SUCCESS,
-)
+        terminal = ContextPropagationTerminal.SUCCESS,
+    )
+}
+val expectedMarker = "synthetic-parent"
 val expectation = ContextPropagationExpectation(
     boundary = ContextPropagationBoundary.COROUTINE,
     scenario = ContextPropagationScenario.SUCCESS,
@@ -353,15 +365,15 @@ val expectation = ContextPropagationExpectation(
     markerExpectations = listOf(
         ContextMarkerExpectation(
             ContextObservationPoint.BOUNDARY_ENTER,
-            marker,
+            expectedMarker,
         ),
         ContextMarkerExpectation(
             ContextObservationPoint.AFTER_SUSPENSION,
-            marker,
+            expectedMarker,
         ),
         ContextMarkerExpectation(
             ContextObservationPoint.BEFORE_TERMINAL,
-            marker,
+            expectedMarker,
         ),
     ),
     cleanupExpectations = listOf(
@@ -375,29 +387,56 @@ assertContextPropagationConformance(observation, expectation)
 
 ```kotlin
 import io.bluetape4k.junit5.observability.*
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.asContextElement
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 
-val isolationObservation = ContextIsolationObservation(
-    boundary = ContextPropagationBoundary.KTOR_REQUEST,
-    samples = listOf(
-        ContextIsolationSample(
-            ContextRequestAlias.REQUEST_A,
-            listOf("synthetic-parent-A", "synthetic-parent-A"),
+val markerContext = ThreadLocal<String?>()
+val isolationObservation = runBlocking {
+    val readyA = CompletableDeferred<Unit>()
+    val readyB = CompletableDeferred<Unit>()
+
+    suspend fun observe(
+        alias: ContextRequestAlias,
+        marker: String,
+        ownReady: CompletableDeferred<Unit>,
+        peerReady: CompletableDeferred<Unit>,
+    ): ContextIsolationSample =
+        withContext(markerContext.asContextElement(marker)) {
+            ownReady.complete(Unit)
+            peerReady.await()
+            val observed = mutableListOf(markerContext.get())
+            yield()
+            observed += markerContext.get()
+            ContextIsolationSample(alias, observed)
+        }
+
+    val sampleA = async {
+        observe(ContextRequestAlias.REQUEST_A, "synthetic-parent-A", readyA, readyB)
+    }
+    val sampleB = async {
+        observe(ContextRequestAlias.REQUEST_B, "synthetic-parent-B", readyB, readyA)
+    }
+    val probe = withContext(markerContext.asContextElement("synthetic-probe")) {
+        markerContext.get()
+    }
+    ContextIsolationObservation(
+        boundary = ContextPropagationBoundary.COROUTINE,
+        samples = listOf(
+            sampleA.await(),
+            sampleB.await(),
+            ContextIsolationSample(ContextRequestAlias.PROBE, listOf(probe)),
         ),
-        ContextIsolationSample(
-            ContextRequestAlias.REQUEST_B,
-            listOf("synthetic-parent-B", "synthetic-parent-B"),
+        cleanupProbes = listOf(
+            ContextCleanupProbe(ContextProbeLocation.CALLER, markerContext.get()),
         ),
-        ContextIsolationSample(
-            ContextRequestAlias.PROBE,
-            listOf("synthetic-probe"),
-        ),
-    ),
-    cleanupProbes = listOf(
-        ContextCleanupProbe(ContextProbeLocation.REQUEST, null),
-    ),
-)
+    )
+}
 val isolationExpectation = ContextIsolationExpectation(
-    boundary = ContextPropagationBoundary.KTOR_REQUEST,
+    boundary = ContextPropagationBoundary.COROUTINE,
     samples = listOf(
         ContextIsolationSampleExpectation(
             requestAlias = ContextRequestAlias.REQUEST_A,
@@ -421,12 +460,18 @@ val isolationExpectation = ContextIsolationExpectation(
         ),
     ),
     cleanupExpectations = listOf(
-        ContextCleanupExpectation(ContextProbeLocation.REQUEST, null),
+        ContextCleanupExpectation(ContextProbeLocation.CALLER, null),
     ),
 )
 
 assertContextIsolation(isolationObservation, isolationExpectation)
 ```
+
+framework가 lifecycle을 소유하는 전체 adapter proof는 compile-checked
+[coroutine, Reactor, executor conformance test](../../infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt),
+[Spring Observation test](../../spring-boot/core/src/test/kotlin/io/bluetape4k/spring/observability/SpringContextPropagationConformanceTest.kt),
+[Ktor request test](../../ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/KtorContextPropagationConformanceTest.kt)를
+참고하세요.
 
 ### Bounded-Wait HTTP Idempotency Conformance
 

--- a/testing/junit5/README.md
+++ b/testing/junit5/README.md
@@ -399,10 +399,10 @@ assertContextIsolation(isolationObservation, isolationExpectation)
 ```
 
 For complete framework-owned adapter proofs, see the compile-checked
-[coroutine, Reactor, and executor conformance test](../../infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt),
-[Spring Observation test](../../spring-boot/core/src/test/kotlin/io/bluetape4k/spring/observability/SpringContextPropagationConformanceTest.kt),
+[coroutine, Reactor, and executor conformance test](https://github.com/bluetape4k/bluetape4k-projects/blob/develop/infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt),
+[Spring Observation test](https://github.com/bluetape4k/bluetape4k-projects/blob/develop/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/observability/SpringContextPropagationConformanceTest.kt),
 and
-[Ktor request test](../../ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/KtorContextPropagationConformanceTest.kt).
+[Ktor request test](https://github.com/bluetape4k/bluetape4k-projects/blob/develop/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/KtorContextPropagationConformanceTest.kt).
 
 ### Bounded-Wait HTTP Idempotency Conformance
 

--- a/testing/junit5/README.md
+++ b/testing/junit5/README.md
@@ -243,7 +243,7 @@ responsible for converting actual framework state into the snapshot; the fixture
 
 `null` represents root context. `SUCCESS`, `FAILURE`, `CANCELLATION`, and `DEADLINE_EXCEEDED` are distinct terminal
 outcomes. Diagnostics identify only bounded coordinates and report `values redacted`; they never include raw marker
-values.
+values. Marker-bearing snapshot `toString()` output follows the same redaction rule.
 
 Only test-owned synthetic marker values are allowed. Never supply production request IDs, user data, or external trace
 IDs. A `Serializable` snapshot is a test exchange value, not a persistence or wire contract, and must not be stored
@@ -253,31 +253,42 @@ a storage format.
 
 ```kotlin
 import io.bluetape4k.junit5.observability.*
+import kotlinx.coroutines.asContextElement
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 
 val marker = "synthetic-parent"
-val observation = ContextPropagationObservation(
-    boundary = ContextPropagationBoundary.COROUTINE,
-    scenario = ContextPropagationScenario.SUCCESS,
-    requestAlias = ContextRequestAlias.SINGLE,
-    markerObservations = listOf(
-        ContextMarkerObservation(
+val markerContext = ThreadLocal<String?>()
+val observation = runBlocking {
+    val observed = mutableListOf<ContextMarkerObservation>()
+    withContext(markerContext.asContextElement(marker)) {
+        observed += ContextMarkerObservation(
             ContextObservationPoint.BOUNDARY_ENTER,
-            marker,
-        ),
-        ContextMarkerObservation(
+            markerContext.get(),
+        )
+        yield()
+        observed += ContextMarkerObservation(
             ContextObservationPoint.AFTER_SUSPENSION,
-            marker,
-        ),
-        ContextMarkerObservation(
+            markerContext.get(),
+        )
+        observed += ContextMarkerObservation(
             ContextObservationPoint.BEFORE_TERMINAL,
-            marker,
+            markerContext.get(),
+        )
+    }
+    ContextPropagationObservation(
+        boundary = ContextPropagationBoundary.COROUTINE,
+        scenario = ContextPropagationScenario.SUCCESS,
+        requestAlias = ContextRequestAlias.SINGLE,
+        markerObservations = observed,
+        cleanupProbes = listOf(
+            ContextCleanupProbe(ContextProbeLocation.CALLER, markerContext.get()),
         ),
-    ),
-    cleanupProbes = listOf(
-        ContextCleanupProbe(ContextProbeLocation.CALLER, null),
-    ),
-    terminal = ContextPropagationTerminal.SUCCESS,
-)
+        terminal = ContextPropagationTerminal.SUCCESS,
+    )
+}
+val expectedMarker = "synthetic-parent"
 val expectation = ContextPropagationExpectation(
     boundary = ContextPropagationBoundary.COROUTINE,
     scenario = ContextPropagationScenario.SUCCESS,
@@ -285,15 +296,15 @@ val expectation = ContextPropagationExpectation(
     markerExpectations = listOf(
         ContextMarkerExpectation(
             ContextObservationPoint.BOUNDARY_ENTER,
-            marker,
+            expectedMarker,
         ),
         ContextMarkerExpectation(
             ContextObservationPoint.AFTER_SUSPENSION,
-            marker,
+            expectedMarker,
         ),
         ContextMarkerExpectation(
             ContextObservationPoint.BEFORE_TERMINAL,
-            marker,
+            expectedMarker,
         ),
     ),
     cleanupExpectations = listOf(
@@ -307,29 +318,56 @@ assertContextPropagationConformance(observation, expectation)
 
 ```kotlin
 import io.bluetape4k.junit5.observability.*
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.asContextElement
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 
-val isolationObservation = ContextIsolationObservation(
-    boundary = ContextPropagationBoundary.KTOR_REQUEST,
-    samples = listOf(
-        ContextIsolationSample(
-            ContextRequestAlias.REQUEST_A,
-            listOf("synthetic-parent-A", "synthetic-parent-A"),
+val markerContext = ThreadLocal<String?>()
+val isolationObservation = runBlocking {
+    val readyA = CompletableDeferred<Unit>()
+    val readyB = CompletableDeferred<Unit>()
+
+    suspend fun observe(
+        alias: ContextRequestAlias,
+        marker: String,
+        ownReady: CompletableDeferred<Unit>,
+        peerReady: CompletableDeferred<Unit>,
+    ): ContextIsolationSample =
+        withContext(markerContext.asContextElement(marker)) {
+            ownReady.complete(Unit)
+            peerReady.await()
+            val observed = mutableListOf(markerContext.get())
+            yield()
+            observed += markerContext.get()
+            ContextIsolationSample(alias, observed)
+        }
+
+    val sampleA = async {
+        observe(ContextRequestAlias.REQUEST_A, "synthetic-parent-A", readyA, readyB)
+    }
+    val sampleB = async {
+        observe(ContextRequestAlias.REQUEST_B, "synthetic-parent-B", readyB, readyA)
+    }
+    val probe = withContext(markerContext.asContextElement("synthetic-probe")) {
+        markerContext.get()
+    }
+    ContextIsolationObservation(
+        boundary = ContextPropagationBoundary.COROUTINE,
+        samples = listOf(
+            sampleA.await(),
+            sampleB.await(),
+            ContextIsolationSample(ContextRequestAlias.PROBE, listOf(probe)),
         ),
-        ContextIsolationSample(
-            ContextRequestAlias.REQUEST_B,
-            listOf("synthetic-parent-B", "synthetic-parent-B"),
+        cleanupProbes = listOf(
+            ContextCleanupProbe(ContextProbeLocation.CALLER, markerContext.get()),
         ),
-        ContextIsolationSample(
-            ContextRequestAlias.PROBE,
-            listOf("synthetic-probe"),
-        ),
-    ),
-    cleanupProbes = listOf(
-        ContextCleanupProbe(ContextProbeLocation.REQUEST, null),
-    ),
-)
+    )
+}
 val isolationExpectation = ContextIsolationExpectation(
-    boundary = ContextPropagationBoundary.KTOR_REQUEST,
+    boundary = ContextPropagationBoundary.COROUTINE,
     samples = listOf(
         ContextIsolationSampleExpectation(
             requestAlias = ContextRequestAlias.REQUEST_A,
@@ -353,12 +391,18 @@ val isolationExpectation = ContextIsolationExpectation(
         ),
     ),
     cleanupExpectations = listOf(
-        ContextCleanupExpectation(ContextProbeLocation.REQUEST, null),
+        ContextCleanupExpectation(ContextProbeLocation.CALLER, null),
     ),
 )
 
 assertContextIsolation(isolationObservation, isolationExpectation)
 ```
+
+For complete framework-owned adapter proofs, see the compile-checked
+[coroutine, Reactor, and executor conformance test](../../infra/opentelemetry/src/test/kotlin/io/bluetape4k/opentelemetry/context/ContextPropagationConformanceTest.kt),
+[Spring Observation test](../../spring-boot/core/src/test/kotlin/io/bluetape4k/spring/observability/SpringContextPropagationConformanceTest.kt),
+and
+[Ktor request test](../../ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/KtorContextPropagationConformanceTest.kt).
 
 ### Bounded-Wait HTTP Idempotency Conformance
 

--- a/testing/junit5/README.md
+++ b/testing/junit5/README.md
@@ -235,6 +235,131 @@ The test remains the lifecycle owner. Create and close the fake registry, tracer
 the Spring Boot or Ktor test; this fixture only validates the framework-neutral snapshot and does not install or close
 telemetry infrastructure.
 
+### Context Propagation Conformance
+
+Use the provider-neutral fixture to prove that an actual framework adapter exposes the same parent marker across
+suspension, preserves the real terminal outcome, cleans its context, and isolates concurrent requests. The adapter is
+responsible for converting actual framework state into the snapshot; the fixture does not install interception.
+
+`null` represents root context. `SUCCESS`, `FAILURE`, `CANCELLATION`, and `DEADLINE_EXCEEDED` are distinct terminal
+outcomes. Diagnostics identify only bounded coordinates and report `values redacted`; they never include raw marker
+values.
+
+Only test-owned synthetic marker values are allowed. Never supply production request IDs, user data, or external trace
+IDs. A `Serializable` snapshot is a test exchange value, not a persistence or wire contract, and must not be stored
+long-term. Enum additions are additive, so caller-side exhaustive when expressions need an `else` branch. Data-class
+constructor changes are compatibility-sensitive; do not destructure snapshots or depend on their constructor layout as
+a storage format.
+
+```kotlin
+import io.bluetape4k.junit5.observability.*
+
+val marker = "synthetic-parent"
+val observation = ContextPropagationObservation(
+    boundary = ContextPropagationBoundary.COROUTINE,
+    scenario = ContextPropagationScenario.SUCCESS,
+    requestAlias = ContextRequestAlias.SINGLE,
+    markerObservations = listOf(
+        ContextMarkerObservation(
+            ContextObservationPoint.BOUNDARY_ENTER,
+            marker,
+        ),
+        ContextMarkerObservation(
+            ContextObservationPoint.AFTER_SUSPENSION,
+            marker,
+        ),
+        ContextMarkerObservation(
+            ContextObservationPoint.BEFORE_TERMINAL,
+            marker,
+        ),
+    ),
+    cleanupProbes = listOf(
+        ContextCleanupProbe(ContextProbeLocation.CALLER, null),
+    ),
+    terminal = ContextPropagationTerminal.SUCCESS,
+)
+val expectation = ContextPropagationExpectation(
+    boundary = ContextPropagationBoundary.COROUTINE,
+    scenario = ContextPropagationScenario.SUCCESS,
+    requestAlias = ContextRequestAlias.SINGLE,
+    markerExpectations = listOf(
+        ContextMarkerExpectation(
+            ContextObservationPoint.BOUNDARY_ENTER,
+            marker,
+        ),
+        ContextMarkerExpectation(
+            ContextObservationPoint.AFTER_SUSPENSION,
+            marker,
+        ),
+        ContextMarkerExpectation(
+            ContextObservationPoint.BEFORE_TERMINAL,
+            marker,
+        ),
+    ),
+    cleanupExpectations = listOf(
+        ContextCleanupExpectation(ContextProbeLocation.CALLER, null),
+    ),
+    expectedTerminal = ContextPropagationTerminal.SUCCESS,
+)
+
+assertContextPropagationConformance(observation, expectation)
+```
+
+```kotlin
+import io.bluetape4k.junit5.observability.*
+
+val isolationObservation = ContextIsolationObservation(
+    boundary = ContextPropagationBoundary.KTOR_REQUEST,
+    samples = listOf(
+        ContextIsolationSample(
+            ContextRequestAlias.REQUEST_A,
+            listOf("synthetic-parent-A", "synthetic-parent-A"),
+        ),
+        ContextIsolationSample(
+            ContextRequestAlias.REQUEST_B,
+            listOf("synthetic-parent-B", "synthetic-parent-B"),
+        ),
+        ContextIsolationSample(
+            ContextRequestAlias.PROBE,
+            listOf("synthetic-probe"),
+        ),
+    ),
+    cleanupProbes = listOf(
+        ContextCleanupProbe(ContextProbeLocation.REQUEST, null),
+    ),
+)
+val isolationExpectation = ContextIsolationExpectation(
+    boundary = ContextPropagationBoundary.KTOR_REQUEST,
+    samples = listOf(
+        ContextIsolationSampleExpectation(
+            requestAlias = ContextRequestAlias.REQUEST_A,
+            mode = ContextMarkerExpectationMode.EXACT,
+            expectedMarker = "synthetic-parent-A",
+            minimumObservationCount = 2,
+        ),
+        ContextIsolationSampleExpectation(
+            requestAlias = ContextRequestAlias.REQUEST_B,
+            mode = ContextMarkerExpectationMode.EXACT,
+            expectedMarker = "synthetic-parent-B",
+            minimumObservationCount = 2,
+        ),
+        ContextIsolationSampleExpectation(
+            requestAlias = ContextRequestAlias.PROBE,
+            mode = ContextMarkerExpectationMode.NOT_IN,
+            forbiddenMarkers = listOf(
+                "synthetic-parent-A",
+                "synthetic-parent-B",
+            ),
+        ),
+    ),
+    cleanupExpectations = listOf(
+        ContextCleanupExpectation(ContextProbeLocation.REQUEST, null),
+    ),
+)
+
+assertContextIsolation(isolationObservation, isolationExpectation)
+```
+
 ### Bounded-Wait HTTP Idempotency Conformance
 
 Use the opt-in fixture to verify a framework adapter against the same observable HTTP contract. The configuration is

--- a/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformance.kt
+++ b/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformance.kt
@@ -26,7 +26,7 @@ enum class ContextPropagationBoundary {
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
- * Example: `val scenario = ContextPropagationScenario.CANCELLATION`
+ * Example: `val scenario = ContextPropagationScenario.SUCCESS`
  */
 enum class ContextPropagationScenario {
     SUCCESS,
@@ -43,7 +43,7 @@ enum class ContextPropagationScenario {
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
- * Example: `val terminal = ContextPropagationTerminal.DEADLINE_EXCEEDED`
+ * Example: `val terminal = ContextPropagationTerminal.SUCCESS`
  */
 enum class ContextPropagationTerminal {
     SUCCESS,
@@ -59,7 +59,7 @@ enum class ContextPropagationTerminal {
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
- * Example: `val location = ContextProbeLocation.WORKER`
+ * Example: `val location = ContextProbeLocation.CALLER`
  */
 enum class ContextProbeLocation {
     CALLER,
@@ -74,7 +74,7 @@ enum class ContextProbeLocation {
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
- * Example: `val alias = ContextRequestAlias.REQUEST_A`
+ * Example: `val alias = ContextRequestAlias.SINGLE`
  */
 enum class ContextRequestAlias {
     SINGLE,
@@ -90,7 +90,7 @@ enum class ContextRequestAlias {
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
- * Example: `val point = ContextObservationPoint.AFTER_SUSPENSION`
+ * Example: `val point = ContextObservationPoint.BOUNDARY_ENTER`
  */
 enum class ContextObservationPoint {
     BOUNDARY_ENTER,
@@ -105,7 +105,7 @@ enum class ContextObservationPoint {
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
- * Example: `val mode = ContextMarkerExpectationMode.NOT_IN`
+ * Example: `val mode = ContextMarkerExpectationMode.EXACT`
  */
 enum class ContextMarkerExpectationMode {
     EXACT,
@@ -120,7 +120,13 @@ enum class ContextMarkerExpectationMode {
  * a wire contract. Serializable snapshots are not persistence or wire formats. Markers must be test-owned synthetic
  * values, never production request IDs, user data, or external trace IDs. Root context is represented by `null`.
  *
- * Example: `ContextMarkerObservation(ContextObservationPoint.BOUNDARY_ENTER, "synthetic-parent")`
+ * Example:
+ * ```kotlin
+ * val observation = ContextMarkerObservation(
+ *     point = ContextObservationPoint.BOUNDARY_ENTER,
+ *     observedMarker = "synthetic-parent",
+ * )
+ * ```
  */
 data class ContextMarkerObservation(
     val point: ContextObservationPoint,
@@ -139,7 +145,13 @@ data class ContextMarkerObservation(
  * values, never production request IDs, user data, or external trace IDs. Root context is represented by `null`,
  * so the literal marker `root` is invalid.
  *
- * Example: `ContextMarkerExpectation(ContextObservationPoint.BEFORE_TERMINAL, "synthetic-parent")`
+ * Example:
+ * ```kotlin
+ * val expectation = ContextMarkerExpectation(
+ *     point = ContextObservationPoint.BOUNDARY_ENTER,
+ *     expectedMarker = "synthetic-parent",
+ * )
+ * ```
  */
 data class ContextMarkerExpectation(
     val point: ContextObservationPoint,
@@ -157,7 +169,13 @@ data class ContextMarkerExpectation(
  * a wire contract. Serializable snapshots are not persistence or wire formats. Markers must be test-owned synthetic
  * values, never production request IDs, user data, or external trace IDs. Root context is represented by `null`.
  *
- * Example: `ContextCleanupProbe(ContextProbeLocation.CALLER, null)`
+ * Example:
+ * ```kotlin
+ * val probe = ContextCleanupProbe(
+ *     location = ContextProbeLocation.CALLER,
+ *     observedMarker = null,
+ * )
+ * ```
  */
 data class ContextCleanupProbe(
     val location: ContextProbeLocation,
@@ -175,7 +193,13 @@ data class ContextCleanupProbe(
  * a wire contract. Serializable snapshots are not persistence or wire formats. Markers must be test-owned synthetic
  * values, never production request IDs, user data, or external trace IDs. Root context is represented by `null`.
  *
- * Example: `ContextCleanupExpectation(ContextProbeLocation.WORKER, null)`
+ * Example:
+ * ```kotlin
+ * val expectation = ContextCleanupExpectation(
+ *     location = ContextProbeLocation.CALLER,
+ *     expectedMarker = null,
+ * )
+ * ```
  */
 data class ContextCleanupExpectation(
     val location: ContextProbeLocation,
@@ -194,8 +218,23 @@ data class ContextCleanupExpectation(
  * values, never production request IDs, user data, or external trace IDs.
  *
  * Example:
- * `ContextPropagationObservation(ContextPropagationBoundary.COROUTINE, ContextPropagationScenario.SUCCESS,
- * ContextRequestAlias.SINGLE, emptyList(), emptyList(), ContextPropagationTerminal.SUCCESS)`
+ * ```kotlin
+ * val marker = "synthetic-parent"
+ * val observation = ContextPropagationObservation(
+ *     boundary = ContextPropagationBoundary.COROUTINE,
+ *     scenario = ContextPropagationScenario.SUCCESS,
+ *     requestAlias = ContextRequestAlias.SINGLE,
+ *     markerObservations = listOf(
+ *         ContextMarkerObservation(ContextObservationPoint.BOUNDARY_ENTER, marker),
+ *         ContextMarkerObservation(ContextObservationPoint.AFTER_SUSPENSION, marker),
+ *         ContextMarkerObservation(ContextObservationPoint.BEFORE_TERMINAL, marker),
+ *     ),
+ *     cleanupProbes = listOf(
+ *         ContextCleanupProbe(ContextProbeLocation.CALLER, null),
+ *     ),
+ *     terminal = ContextPropagationTerminal.SUCCESS,
+ * )
+ * ```
  */
 data class ContextPropagationObservation(
     val boundary: ContextPropagationBoundary,
@@ -218,8 +257,23 @@ data class ContextPropagationObservation(
  * values, never production request IDs, user data, or external trace IDs.
  *
  * Example:
- * `ContextPropagationExpectation(ContextPropagationBoundary.COROUTINE, ContextPropagationScenario.SUCCESS,
- * ContextRequestAlias.SINGLE, emptyList(), emptyList(), ContextPropagationTerminal.SUCCESS)`
+ * ```kotlin
+ * val marker = "synthetic-parent"
+ * val expectation = ContextPropagationExpectation(
+ *     boundary = ContextPropagationBoundary.COROUTINE,
+ *     scenario = ContextPropagationScenario.SUCCESS,
+ *     requestAlias = ContextRequestAlias.SINGLE,
+ *     markerExpectations = listOf(
+ *         ContextMarkerExpectation(ContextObservationPoint.BOUNDARY_ENTER, marker),
+ *         ContextMarkerExpectation(ContextObservationPoint.AFTER_SUSPENSION, marker),
+ *         ContextMarkerExpectation(ContextObservationPoint.BEFORE_TERMINAL, marker),
+ *     ),
+ *     cleanupExpectations = listOf(
+ *         ContextCleanupExpectation(ContextProbeLocation.CALLER, null),
+ *     ),
+ *     expectedTerminal = ContextPropagationTerminal.SUCCESS,
+ * )
+ * ```
  */
 data class ContextPropagationExpectation(
     val boundary: ContextPropagationBoundary,
@@ -241,7 +295,13 @@ data class ContextPropagationExpectation(
  * a wire contract. Serializable snapshots are not persistence or wire formats. Markers must be test-owned synthetic
  * values, never production request IDs, user data, or external trace IDs. Root context is represented by `null`.
  *
- * Example: `ContextIsolationSample(ContextRequestAlias.REQUEST_A, listOf("synthetic-a", "synthetic-a"))`
+ * Example:
+ * ```kotlin
+ * val sample = ContextIsolationSample(
+ *     requestAlias = ContextRequestAlias.REQUEST_A,
+ *     observedMarkers = listOf("synthetic-parent-A", "synthetic-parent-A"),
+ * )
+ * ```
  */
 data class ContextIsolationSample(
     val requestAlias: ContextRequestAlias,
@@ -260,8 +320,14 @@ data class ContextIsolationSample(
  * values, never production request IDs, user data, or external trace IDs. Root context is represented by `null`.
  *
  * Example:
- * `ContextIsolationSampleExpectation(ContextRequestAlias.REQUEST_A, ContextMarkerExpectationMode.EXACT,
- * expectedMarker = "synthetic-a")`
+ * ```kotlin
+ * val expectation = ContextIsolationSampleExpectation(
+ *     requestAlias = ContextRequestAlias.REQUEST_A,
+ *     mode = ContextMarkerExpectationMode.EXACT,
+ *     expectedMarker = "synthetic-parent-A",
+ *     minimumObservationCount = 2,
+ * )
+ * ```
  */
 data class ContextIsolationSampleExpectation(
     val requestAlias: ContextRequestAlias,
@@ -283,7 +349,28 @@ data class ContextIsolationSampleExpectation(
  * values, never production request IDs, user data, or external trace IDs.
  *
  * Example:
- * `ContextIsolationObservation(ContextPropagationBoundary.REACTOR, emptyList(), emptyList())`
+ * ```kotlin
+ * val observation = ContextIsolationObservation(
+ *     boundary = ContextPropagationBoundary.KTOR_REQUEST,
+ *     samples = listOf(
+ *         ContextIsolationSample(
+ *             ContextRequestAlias.REQUEST_A,
+ *             listOf("synthetic-parent-A", "synthetic-parent-A"),
+ *         ),
+ *         ContextIsolationSample(
+ *             ContextRequestAlias.REQUEST_B,
+ *             listOf("synthetic-parent-B", "synthetic-parent-B"),
+ *         ),
+ *         ContextIsolationSample(
+ *             ContextRequestAlias.PROBE,
+ *             listOf("synthetic-probe"),
+ *         ),
+ *     ),
+ *     cleanupProbes = listOf(
+ *         ContextCleanupProbe(ContextProbeLocation.REQUEST, null),
+ *     ),
+ * )
+ * ```
  */
 data class ContextIsolationObservation(
     val boundary: ContextPropagationBoundary,
@@ -303,7 +390,36 @@ data class ContextIsolationObservation(
  * values, never production request IDs, user data, or external trace IDs.
  *
  * Example:
- * `ContextIsolationExpectation(ContextPropagationBoundary.REACTOR, emptyList(), emptyList())`
+ * ```kotlin
+ * val expectation = ContextIsolationExpectation(
+ *     boundary = ContextPropagationBoundary.KTOR_REQUEST,
+ *     samples = listOf(
+ *         ContextIsolationSampleExpectation(
+ *             requestAlias = ContextRequestAlias.REQUEST_A,
+ *             mode = ContextMarkerExpectationMode.EXACT,
+ *             expectedMarker = "synthetic-parent-A",
+ *             minimumObservationCount = 2,
+ *         ),
+ *         ContextIsolationSampleExpectation(
+ *             requestAlias = ContextRequestAlias.REQUEST_B,
+ *             mode = ContextMarkerExpectationMode.EXACT,
+ *             expectedMarker = "synthetic-parent-B",
+ *             minimumObservationCount = 2,
+ *         ),
+ *         ContextIsolationSampleExpectation(
+ *             requestAlias = ContextRequestAlias.PROBE,
+ *             mode = ContextMarkerExpectationMode.NOT_IN,
+ *             forbiddenMarkers = listOf(
+ *                 "synthetic-parent-A",
+ *                 "synthetic-parent-B",
+ *             ),
+ *         ),
+ *     ),
+ *     cleanupExpectations = listOf(
+ *         ContextCleanupExpectation(ContextProbeLocation.REQUEST, null),
+ *     ),
+ * )
+ * ```
  */
 data class ContextIsolationExpectation(
     val boundary: ContextPropagationBoundary,
@@ -323,7 +439,39 @@ data class ContextIsolationExpectation(
  * are test exchange values, not persistence or wire formats.
  *
  * Example:
- * `assertContextPropagationConformance(observation = observation, expectation = expectation)`
+ * ```kotlin
+ * val marker = "synthetic-parent"
+ * val observation = ContextPropagationObservation(
+ *     boundary = ContextPropagationBoundary.COROUTINE,
+ *     scenario = ContextPropagationScenario.SUCCESS,
+ *     requestAlias = ContextRequestAlias.SINGLE,
+ *     markerObservations = listOf(
+ *         ContextMarkerObservation(ContextObservationPoint.BOUNDARY_ENTER, marker),
+ *         ContextMarkerObservation(ContextObservationPoint.AFTER_SUSPENSION, marker),
+ *         ContextMarkerObservation(ContextObservationPoint.BEFORE_TERMINAL, marker),
+ *     ),
+ *     cleanupProbes = listOf(
+ *         ContextCleanupProbe(ContextProbeLocation.CALLER, null),
+ *     ),
+ *     terminal = ContextPropagationTerminal.SUCCESS,
+ * )
+ * val expectation = ContextPropagationExpectation(
+ *     boundary = ContextPropagationBoundary.COROUTINE,
+ *     scenario = ContextPropagationScenario.SUCCESS,
+ *     requestAlias = ContextRequestAlias.SINGLE,
+ *     markerExpectations = listOf(
+ *         ContextMarkerExpectation(ContextObservationPoint.BOUNDARY_ENTER, marker),
+ *         ContextMarkerExpectation(ContextObservationPoint.AFTER_SUSPENSION, marker),
+ *         ContextMarkerExpectation(ContextObservationPoint.BEFORE_TERMINAL, marker),
+ *     ),
+ *     cleanupExpectations = listOf(
+ *         ContextCleanupExpectation(ContextProbeLocation.CALLER, null),
+ *     ),
+ *     expectedTerminal = ContextPropagationTerminal.SUCCESS,
+ * )
+ *
+ * assertContextPropagationConformance(observation, expectation)
+ * ```
  */
 fun assertContextPropagationConformance(
     observation: ContextPropagationObservation,
@@ -395,7 +543,59 @@ fun assertContextPropagationConformance(
  * synthetic markers; never supply production request IDs, user data, or external trace IDs. Serializable snapshots
  * are test exchange values, not persistence or wire formats.
  *
- * Example: `assertContextIsolation(observation = observation, expectation = expectation)`
+ * Example:
+ * ```kotlin
+ * val observation = ContextIsolationObservation(
+ *     boundary = ContextPropagationBoundary.KTOR_REQUEST,
+ *     samples = listOf(
+ *         ContextIsolationSample(
+ *             ContextRequestAlias.REQUEST_A,
+ *             listOf("synthetic-parent-A", "synthetic-parent-A"),
+ *         ),
+ *         ContextIsolationSample(
+ *             ContextRequestAlias.REQUEST_B,
+ *             listOf("synthetic-parent-B", "synthetic-parent-B"),
+ *         ),
+ *         ContextIsolationSample(
+ *             ContextRequestAlias.PROBE,
+ *             listOf("synthetic-probe"),
+ *         ),
+ *     ),
+ *     cleanupProbes = listOf(
+ *         ContextCleanupProbe(ContextProbeLocation.REQUEST, null),
+ *     ),
+ * )
+ * val expectation = ContextIsolationExpectation(
+ *     boundary = ContextPropagationBoundary.KTOR_REQUEST,
+ *     samples = listOf(
+ *         ContextIsolationSampleExpectation(
+ *             requestAlias = ContextRequestAlias.REQUEST_A,
+ *             mode = ContextMarkerExpectationMode.EXACT,
+ *             expectedMarker = "synthetic-parent-A",
+ *             minimumObservationCount = 2,
+ *         ),
+ *         ContextIsolationSampleExpectation(
+ *             requestAlias = ContextRequestAlias.REQUEST_B,
+ *             mode = ContextMarkerExpectationMode.EXACT,
+ *             expectedMarker = "synthetic-parent-B",
+ *             minimumObservationCount = 2,
+ *         ),
+ *         ContextIsolationSampleExpectation(
+ *             requestAlias = ContextRequestAlias.PROBE,
+ *             mode = ContextMarkerExpectationMode.NOT_IN,
+ *             forbiddenMarkers = listOf(
+ *                 "synthetic-parent-A",
+ *                 "synthetic-parent-B",
+ *             ),
+ *         ),
+ *     ),
+ *     cleanupExpectations = listOf(
+ *         ContextCleanupExpectation(ContextProbeLocation.REQUEST, null),
+ *     ),
+ * )
+ *
+ * assertContextIsolation(observation, expectation)
+ * ```
  */
 fun assertContextIsolation(
     observation: ContextIsolationObservation,
@@ -436,7 +636,7 @@ fun assertContextIsolation(
                 sample.observedMarkers.all { it == null }
 
             ContextMarkerExpectationMode.NOT_IN ->
-                sample.observedMarkers.none(sampleExpectation.forbiddenMarkers::contains)
+                sample.observedMarkers.all { it != null && it !in sampleExpectation.forbiddenMarkers }
         }
         assertContext(relationMatches, sampleCoordinates)
     }

--- a/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformance.kt
+++ b/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformance.kt
@@ -1,0 +1,782 @@
+package io.bluetape4k.junit5.observability
+
+import java.io.Serializable
+
+/**
+ * Identifies a framework boundary covered by a context propagation proof.
+ *
+ * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
+ * must never be supplied.
+ *
+ * Example: `val boundary = ContextPropagationBoundary.COROUTINE`
+ */
+enum class ContextPropagationBoundary {
+    COROUTINE,
+    REACTOR,
+    TASK_EXECUTOR,
+    SPRING_OBSERVATION,
+    KTOR_REQUEST,
+}
+
+/**
+ * Identifies the lifecycle scenario exercised by a context propagation proof.
+ *
+ * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
+ * must never be supplied.
+ *
+ * Example: `val scenario = ContextPropagationScenario.CANCELLATION`
+ */
+enum class ContextPropagationScenario {
+    SUCCESS,
+    FAILURE,
+    CANCELLATION,
+    DEADLINE,
+    ISOLATION,
+}
+
+/**
+ * Identifies the terminal outcome observed after crossing a context boundary.
+ *
+ * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
+ * must never be supplied.
+ *
+ * Example: `val terminal = ContextPropagationTerminal.DEADLINE_EXCEEDED`
+ */
+enum class ContextPropagationTerminal {
+    SUCCESS,
+    FAILURE,
+    CANCELLATION,
+    DEADLINE_EXCEEDED,
+}
+
+/**
+ * Identifies where cleanup was probed after a boundary completed.
+ *
+ * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
+ * must never be supplied.
+ *
+ * Example: `val location = ContextProbeLocation.WORKER`
+ */
+enum class ContextProbeLocation {
+    CALLER,
+    WORKER,
+    REQUEST,
+}
+
+/**
+ * Supplies a stable test-owned alias for one request or probe.
+ *
+ * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
+ * must never be supplied.
+ *
+ * Example: `val alias = ContextRequestAlias.REQUEST_A`
+ */
+enum class ContextRequestAlias {
+    SINGLE,
+    REQUEST_A,
+    REQUEST_B,
+    PROBE,
+}
+
+/**
+ * Identifies a stable observation point inside a propagation lifecycle.
+ *
+ * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
+ * must never be supplied.
+ *
+ * Example: `val point = ContextObservationPoint.AFTER_SUSPENSION`
+ */
+enum class ContextObservationPoint {
+    BOUNDARY_ENTER,
+    AFTER_SUSPENSION,
+    BEFORE_TERMINAL,
+}
+
+/**
+ * Defines the relation applied to an isolation sample.
+ *
+ * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
+ * must never be supplied.
+ *
+ * Example: `val mode = ContextMarkerExpectationMode.NOT_IN`
+ */
+enum class ContextMarkerExpectationMode {
+    EXACT,
+    ABSENT,
+    NOT_IN,
+}
+
+/**
+ * Captures the marker observed at one propagation point.
+ *
+ * Constructor changes are compatibility-sensitive. Callers must not persist or destructure this value or use it as
+ * a wire contract. Serializable snapshots are not persistence or wire formats. Markers must be test-owned synthetic
+ * values, never production request IDs, user data, or external trace IDs. Root context is represented by `null`.
+ *
+ * Example: `ContextMarkerObservation(ContextObservationPoint.BOUNDARY_ENTER, "synthetic-parent")`
+ */
+data class ContextMarkerObservation(
+    val point: ContextObservationPoint,
+    val observedMarker: String?,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * Describes the synthetic marker expected at one propagation point.
+ *
+ * Constructor changes are compatibility-sensitive. Callers must not persist or destructure this value or use it as
+ * a wire contract. Serializable snapshots are not persistence or wire formats. Markers must be test-owned synthetic
+ * values, never production request IDs, user data, or external trace IDs. Root context is represented by `null`,
+ * so the literal marker `root` is invalid.
+ *
+ * Example: `ContextMarkerExpectation(ContextObservationPoint.BEFORE_TERMINAL, "synthetic-parent")`
+ */
+data class ContextMarkerExpectation(
+    val point: ContextObservationPoint,
+    val expectedMarker: String,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * Captures the marker remaining at one cleanup location.
+ *
+ * Constructor changes are compatibility-sensitive. Callers must not persist or destructure this value or use it as
+ * a wire contract. Serializable snapshots are not persistence or wire formats. Markers must be test-owned synthetic
+ * values, never production request IDs, user data, or external trace IDs. Root context is represented by `null`.
+ *
+ * Example: `ContextCleanupProbe(ContextProbeLocation.CALLER, null)`
+ */
+data class ContextCleanupProbe(
+    val location: ContextProbeLocation,
+    val observedMarker: String?,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * Describes the marker expected at one cleanup location.
+ *
+ * Constructor changes are compatibility-sensitive. Callers must not persist or destructure this value or use it as
+ * a wire contract. Serializable snapshots are not persistence or wire formats. Markers must be test-owned synthetic
+ * values, never production request IDs, user data, or external trace IDs. Root context is represented by `null`.
+ *
+ * Example: `ContextCleanupExpectation(ContextProbeLocation.WORKER, null)`
+ */
+data class ContextCleanupExpectation(
+    val location: ContextProbeLocation,
+    val expectedMarker: String?,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * Captures framework-neutral evidence for one context propagation lifecycle.
+ *
+ * Constructor changes are compatibility-sensitive. Callers must not persist or destructure this value or use it as
+ * a wire contract. Serializable snapshots are not persistence or wire formats. Markers must be test-owned synthetic
+ * values, never production request IDs, user data, or external trace IDs.
+ *
+ * Example:
+ * `ContextPropagationObservation(ContextPropagationBoundary.COROUTINE, ContextPropagationScenario.SUCCESS,
+ * ContextRequestAlias.SINGLE, emptyList(), emptyList(), ContextPropagationTerminal.SUCCESS)`
+ */
+data class ContextPropagationObservation(
+    val boundary: ContextPropagationBoundary,
+    val scenario: ContextPropagationScenario,
+    val requestAlias: ContextRequestAlias,
+    val markerObservations: List<ContextMarkerObservation>,
+    val cleanupProbes: List<ContextCleanupProbe>,
+    val terminal: ContextPropagationTerminal,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * Describes the expected framework-neutral propagation lifecycle.
+ *
+ * Constructor changes are compatibility-sensitive. Callers must not persist or destructure this value or use it as
+ * a wire contract. Serializable snapshots are not persistence or wire formats. Markers must be test-owned synthetic
+ * values, never production request IDs, user data, or external trace IDs.
+ *
+ * Example:
+ * `ContextPropagationExpectation(ContextPropagationBoundary.COROUTINE, ContextPropagationScenario.SUCCESS,
+ * ContextRequestAlias.SINGLE, emptyList(), emptyList(), ContextPropagationTerminal.SUCCESS)`
+ */
+data class ContextPropagationExpectation(
+    val boundary: ContextPropagationBoundary,
+    val scenario: ContextPropagationScenario,
+    val requestAlias: ContextRequestAlias,
+    val markerExpectations: List<ContextMarkerExpectation>,
+    val cleanupExpectations: List<ContextCleanupExpectation>,
+    val expectedTerminal: ContextPropagationTerminal,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * Captures repeated marker observations for one isolation alias.
+ *
+ * Constructor changes are compatibility-sensitive. Callers must not persist or destructure this value or use it as
+ * a wire contract. Serializable snapshots are not persistence or wire formats. Markers must be test-owned synthetic
+ * values, never production request IDs, user data, or external trace IDs. Root context is represented by `null`.
+ *
+ * Example: `ContextIsolationSample(ContextRequestAlias.REQUEST_A, listOf("synthetic-a", "synthetic-a"))`
+ */
+data class ContextIsolationSample(
+    val requestAlias: ContextRequestAlias,
+    val observedMarkers: List<String?>,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * Describes the relation expected for one isolation alias.
+ *
+ * Constructor changes are compatibility-sensitive. Callers must not persist or destructure this value or use it as
+ * a wire contract. Serializable snapshots are not persistence or wire formats. Markers must be test-owned synthetic
+ * values, never production request IDs, user data, or external trace IDs. Root context is represented by `null`.
+ *
+ * Example:
+ * `ContextIsolationSampleExpectation(ContextRequestAlias.REQUEST_A, ContextMarkerExpectationMode.EXACT,
+ * expectedMarker = "synthetic-a")`
+ */
+data class ContextIsolationSampleExpectation(
+    val requestAlias: ContextRequestAlias,
+    val mode: ContextMarkerExpectationMode,
+    val expectedMarker: String? = null,
+    val forbiddenMarkers: List<String> = emptyList(),
+    val minimumObservationCount: Int = 1,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * Captures framework-neutral evidence for an isolation scenario.
+ *
+ * Constructor changes are compatibility-sensitive. Callers must not persist or destructure this value or use it as
+ * a wire contract. Serializable snapshots are not persistence or wire formats. Markers must be test-owned synthetic
+ * values, never production request IDs, user data, or external trace IDs.
+ *
+ * Example:
+ * `ContextIsolationObservation(ContextPropagationBoundary.REACTOR, emptyList(), emptyList())`
+ */
+data class ContextIsolationObservation(
+    val boundary: ContextPropagationBoundary,
+    val samples: List<ContextIsolationSample>,
+    val cleanupProbes: List<ContextCleanupProbe>,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * Describes the expected framework-neutral isolation evidence.
+ *
+ * Constructor changes are compatibility-sensitive. Callers must not persist or destructure this value or use it as
+ * a wire contract. Serializable snapshots are not persistence or wire formats. Markers must be test-owned synthetic
+ * values, never production request IDs, user data, or external trace IDs.
+ *
+ * Example:
+ * `ContextIsolationExpectation(ContextPropagationBoundary.REACTOR, emptyList(), emptyList())`
+ */
+data class ContextIsolationExpectation(
+    val boundary: ContextPropagationBoundary,
+    val samples: List<ContextIsolationSampleExpectation>,
+    val cleanupExpectations: List<ContextCleanupExpectation>,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * Verifies one framework-neutral propagation snapshot against its expectation.
+ *
+ * The assertion emits no log or console output and never includes marker values in failures. Supply only test-owned
+ * synthetic markers; never supply production request IDs, user data, or external trace IDs. Serializable snapshots
+ * are test exchange values, not persistence or wire formats.
+ *
+ * Example:
+ * `assertContextPropagationConformance(observation = observation, expectation = expectation)`
+ */
+fun assertContextPropagationConformance(
+    observation: ContextPropagationObservation,
+    expectation: ContextPropagationExpectation,
+) {
+    validatePropagationObservation(observation)
+    validatePropagationExpectation(expectation)
+
+    assertContext(
+        observation.boundary == expectation.boundary,
+        coordinates(observation.boundary, observation.scenario, observation.requestAlias, field = "boundary"),
+    )
+    assertContext(
+        observation.scenario == expectation.scenario,
+        coordinates(observation.boundary, observation.scenario, observation.requestAlias, field = "scenario"),
+    )
+    assertContext(
+        observation.requestAlias == expectation.requestAlias,
+        coordinates(observation.boundary, observation.scenario, observation.requestAlias, field = "requestAlias"),
+    )
+    assertContext(
+        observation.terminal == expectation.expectedTerminal,
+        coordinates(
+            observation.boundary,
+            observation.scenario,
+            observation.requestAlias,
+            field = "terminal",
+            terminal = observation.terminal,
+        ),
+    )
+
+    val observationsByPoint = observation.markerObservations.associateBy(ContextMarkerObservation::point)
+    val expectationsByPoint = expectation.markerExpectations.associateBy(ContextMarkerExpectation::point)
+    assertContext(
+        observationsByPoint.keys == expectationsByPoint.keys,
+        coordinates(
+            observation.boundary,
+            observation.scenario,
+            observation.requestAlias,
+            field = "markerObservations",
+        ),
+    )
+    expectationsByPoint.forEach { (point, markerExpectation) ->
+        assertContext(
+            observationsByPoint.getValue(point).observedMarker == markerExpectation.expectedMarker,
+            coordinates(
+                observation.boundary,
+                observation.scenario,
+                observation.requestAlias,
+                field = "marker",
+                point = point,
+            ),
+        )
+    }
+
+    assertCleanup(
+        observation.cleanupProbes,
+        expectation.cleanupExpectations,
+        observation.boundary,
+        observation.scenario,
+        observation.requestAlias,
+    )
+}
+
+/**
+ * Verifies framework-neutral isolation samples against their expectation modes.
+ *
+ * The assertion emits no log or console output and never includes marker values in failures. Supply only test-owned
+ * synthetic markers; never supply production request IDs, user data, or external trace IDs. Serializable snapshots
+ * are test exchange values, not persistence or wire formats.
+ *
+ * Example: `assertContextIsolation(observation = observation, expectation = expectation)`
+ */
+fun assertContextIsolation(
+    observation: ContextIsolationObservation,
+    expectation: ContextIsolationExpectation,
+) {
+    validateIsolationObservation(observation)
+    validateIsolationExpectation(expectation)
+
+    assertContext(
+        observation.boundary == expectation.boundary,
+        coordinates(observation.boundary, field = "boundary"),
+    )
+
+    val observationsByAlias = observation.samples.associateBy(ContextIsolationSample::requestAlias)
+    val expectationsByAlias = expectation.samples.associateBy(ContextIsolationSampleExpectation::requestAlias)
+    assertContext(
+        observationsByAlias.keys == expectationsByAlias.keys,
+        coordinates(observation.boundary, field = "samples"),
+    )
+
+    expectationsByAlias.forEach { (alias, sampleExpectation) ->
+        val sample = observationsByAlias.getValue(alias)
+        val sampleCoordinates = coordinates(
+            boundary = observation.boundary,
+            requestAlias = alias,
+            field = "observedMarkers",
+            mode = sampleExpectation.mode,
+        )
+        assertContext(
+            sample.observedMarkers.size >= sampleExpectation.minimumObservationCount,
+            sampleCoordinates,
+        )
+        val relationMatches = when (sampleExpectation.mode) {
+            ContextMarkerExpectationMode.EXACT ->
+                sample.observedMarkers.all { it == sampleExpectation.expectedMarker }
+
+            ContextMarkerExpectationMode.ABSENT ->
+                sample.observedMarkers.all { it == null }
+
+            ContextMarkerExpectationMode.NOT_IN ->
+                sample.observedMarkers.none(sampleExpectation.forbiddenMarkers::contains)
+        }
+        assertContext(relationMatches, sampleCoordinates)
+    }
+
+    assertCleanup(
+        observation.cleanupProbes,
+        expectation.cleanupExpectations,
+        observation.boundary,
+    )
+}
+
+private fun validatePropagationObservation(observation: ContextPropagationObservation) {
+    validateUnique(
+        observation.markerObservations.map(ContextMarkerObservation::point),
+        coordinates(
+            observation.boundary,
+            observation.scenario,
+            observation.requestAlias,
+            field = "markerObservations",
+        ),
+    )
+    observation.markerObservations.forEach { markerObservation ->
+        validateMarker(
+            markerObservation.observedMarker,
+            coordinates(
+                observation.boundary,
+                observation.scenario,
+                observation.requestAlias,
+                field = "observedMarker",
+                point = markerObservation.point,
+            ),
+        )
+    }
+    validateCleanupProbes(
+        observation.cleanupProbes,
+        observation.boundary,
+        observation.scenario,
+        observation.requestAlias,
+    )
+}
+
+private fun validatePropagationExpectation(expectation: ContextPropagationExpectation) {
+    validateUnique(
+        expectation.markerExpectations.map(ContextMarkerExpectation::point),
+        coordinates(
+            expectation.boundary,
+            expectation.scenario,
+            expectation.requestAlias,
+            field = "markerExpectations",
+        ),
+    )
+    expectation.markerExpectations.forEach { markerExpectation ->
+        validateMarker(
+            markerExpectation.expectedMarker,
+            coordinates(
+                expectation.boundary,
+                expectation.scenario,
+                expectation.requestAlias,
+                field = "expectedMarker",
+                point = markerExpectation.point,
+            ),
+        )
+    }
+    validateCleanupExpectations(
+        expectation.cleanupExpectations,
+        expectation.boundary,
+        expectation.scenario,
+        expectation.requestAlias,
+    )
+}
+
+private fun validateIsolationObservation(observation: ContextIsolationObservation) {
+    validateUnique(
+        observation.samples.map(ContextIsolationSample::requestAlias),
+        coordinates(observation.boundary, field = "samples"),
+    )
+    observation.samples.forEach { sample ->
+        sample.observedMarkers.forEach { marker ->
+            validateMarker(
+                marker,
+                coordinates(observation.boundary, requestAlias = sample.requestAlias, field = "observedMarkers"),
+            )
+        }
+    }
+    validateCleanupProbes(observation.cleanupProbes, observation.boundary)
+}
+
+private fun validateIsolationExpectation(expectation: ContextIsolationExpectation) {
+    validateUnique(
+        expectation.samples.map(ContextIsolationSampleExpectation::requestAlias),
+        coordinates(expectation.boundary, field = "samples"),
+    )
+
+    expectation.samples.forEach { sample ->
+        val baseCoordinates = coordinates(
+            boundary = expectation.boundary,
+            requestAlias = sample.requestAlias,
+            field = "minimumObservationCount",
+            mode = sample.mode,
+        )
+        assertContext(sample.minimumObservationCount >= 1, baseCoordinates)
+
+        validateMarker(
+            sample.expectedMarker,
+            coordinates(
+                expectation.boundary,
+                requestAlias = sample.requestAlias,
+                field = "expectedMarker",
+                mode = sample.mode,
+            ),
+        )
+        sample.forbiddenMarkers.forEach { marker ->
+            validateMarker(
+                marker,
+                coordinates(
+                    expectation.boundary,
+                    requestAlias = sample.requestAlias,
+                    field = "forbiddenMarkers",
+                    mode = sample.mode,
+                ),
+            )
+        }
+
+        when (sample.mode) {
+            ContextMarkerExpectationMode.EXACT -> {
+                assertContext(
+                    sample.expectedMarker != null,
+                    coordinates(
+                        expectation.boundary,
+                        requestAlias = sample.requestAlias,
+                        field = "expectedMarker",
+                        mode = sample.mode,
+                    ),
+                )
+                assertContext(
+                    sample.forbiddenMarkers.isEmpty(),
+                    coordinates(
+                        expectation.boundary,
+                        requestAlias = sample.requestAlias,
+                        field = "forbiddenMarkers",
+                        mode = sample.mode,
+                    ),
+                )
+            }
+
+            ContextMarkerExpectationMode.ABSENT -> {
+                assertContext(
+                    sample.expectedMarker == null,
+                    coordinates(
+                        expectation.boundary,
+                        requestAlias = sample.requestAlias,
+                        field = "expectedMarker",
+                        mode = sample.mode,
+                    ),
+                )
+                assertContext(
+                    sample.forbiddenMarkers.isEmpty(),
+                    coordinates(
+                        expectation.boundary,
+                        requestAlias = sample.requestAlias,
+                        field = "forbiddenMarkers",
+                        mode = sample.mode,
+                    ),
+                )
+            }
+
+            ContextMarkerExpectationMode.NOT_IN -> {
+                assertContext(
+                    sample.expectedMarker == null,
+                    coordinates(
+                        expectation.boundary,
+                        requestAlias = sample.requestAlias,
+                        field = "expectedMarker",
+                        mode = sample.mode,
+                    ),
+                )
+                assertContext(
+                    sample.forbiddenMarkers.isNotEmpty(),
+                    coordinates(
+                        expectation.boundary,
+                        requestAlias = sample.requestAlias,
+                        field = "forbiddenMarkers",
+                        mode = sample.mode,
+                    ),
+                )
+                validateUnique(
+                    sample.forbiddenMarkers,
+                    coordinates(
+                        expectation.boundary,
+                        requestAlias = sample.requestAlias,
+                        field = "forbiddenMarkers",
+                        mode = sample.mode,
+                    ),
+                )
+            }
+        }
+    }
+
+    val exactMarkers = expectation.samples
+        .filter { it.mode == ContextMarkerExpectationMode.EXACT }
+        .mapNotNull(ContextIsolationSampleExpectation::expectedMarker)
+    validateUnique(
+        exactMarkers,
+        coordinates(expectation.boundary, field = "expectedMarker", mode = ContextMarkerExpectationMode.EXACT),
+    )
+    validateCleanupExpectations(expectation.cleanupExpectations, expectation.boundary)
+}
+
+private fun validateCleanupProbes(
+    probes: List<ContextCleanupProbe>,
+    boundary: ContextPropagationBoundary,
+    scenario: ContextPropagationScenario? = null,
+    requestAlias: ContextRequestAlias? = null,
+) {
+    validateUnique(
+        probes.map(ContextCleanupProbe::location),
+        coordinates(boundary, scenario, requestAlias, field = "cleanupProbes"),
+    )
+    probes.forEach { probe ->
+        validateMarker(
+            probe.observedMarker,
+            coordinates(
+                boundary,
+                scenario,
+                requestAlias,
+                field = "observedMarker",
+                location = probe.location,
+            ),
+        )
+    }
+}
+
+private fun validateCleanupExpectations(
+    expectations: List<ContextCleanupExpectation>,
+    boundary: ContextPropagationBoundary,
+    scenario: ContextPropagationScenario? = null,
+    requestAlias: ContextRequestAlias? = null,
+) {
+    validateUnique(
+        expectations.map(ContextCleanupExpectation::location),
+        coordinates(boundary, scenario, requestAlias, field = "cleanupExpectations"),
+    )
+    expectations.forEach { expectation ->
+        validateMarker(
+            expectation.expectedMarker,
+            coordinates(
+                boundary,
+                scenario,
+                requestAlias,
+                field = "expectedMarker",
+                location = expectation.location,
+            ),
+        )
+    }
+}
+
+private fun assertCleanup(
+    probes: List<ContextCleanupProbe>,
+    expectations: List<ContextCleanupExpectation>,
+    boundary: ContextPropagationBoundary,
+    scenario: ContextPropagationScenario? = null,
+    requestAlias: ContextRequestAlias? = null,
+) {
+    val probesByLocation = probes.associateBy(ContextCleanupProbe::location)
+    val expectationsByLocation = expectations.associateBy(ContextCleanupExpectation::location)
+    assertContext(
+        probesByLocation.keys == expectationsByLocation.keys,
+        coordinates(boundary, scenario, requestAlias, field = "cleanupProbes"),
+    )
+    expectationsByLocation.forEach { (location, expectation) ->
+        assertContext(
+            probesByLocation.getValue(location).observedMarker == expectation.expectedMarker,
+            coordinates(
+                boundary,
+                scenario,
+                requestAlias,
+                field = "cleanup",
+                location = location,
+            ),
+        )
+    }
+}
+
+private fun validateMarker(marker: String?, coordinates: ContextFailureCoordinates) {
+    assertContext(marker != "root", coordinates)
+}
+
+private fun <T> validateUnique(values: List<T>, coordinates: ContextFailureCoordinates) {
+    assertContext(values.size == values.toSet().size, coordinates)
+}
+
+private fun assertContext(condition: Boolean, coordinates: ContextFailureCoordinates) {
+    if (!condition) {
+        throw AssertionError(coordinates.message())
+    }
+}
+
+private class ContextFailureCoordinates(
+    val boundary: ContextPropagationBoundary,
+    val scenario: ContextPropagationScenario?,
+    val requestAlias: ContextRequestAlias?,
+    val field: String,
+    val mode: ContextMarkerExpectationMode?,
+    val point: ContextObservationPoint?,
+    val location: ContextProbeLocation?,
+    val terminal: ContextPropagationTerminal?,
+) {
+    fun message(): String =
+        buildList {
+            add("Context conformance failed")
+            add("boundary=$boundary")
+            scenario?.let { add("scenario=$it") }
+            requestAlias?.let { add("alias=$it") }
+            add("field=$field")
+            mode?.let { add("mode=$it") }
+            point?.let { add("point=$it") }
+            location?.let { add("location=$it") }
+            terminal?.let { add("terminal=$it") }
+            add("relation=mismatch")
+            add("values redacted")
+        }.joinToString(separator = "; ")
+}
+
+private fun coordinates(
+    boundary: ContextPropagationBoundary,
+    scenario: ContextPropagationScenario? = null,
+    requestAlias: ContextRequestAlias? = null,
+    field: String,
+    mode: ContextMarkerExpectationMode? = null,
+    point: ContextObservationPoint? = null,
+    location: ContextProbeLocation? = null,
+    terminal: ContextPropagationTerminal? = null,
+): ContextFailureCoordinates =
+    ContextFailureCoordinates(
+        boundary = boundary,
+        scenario = scenario,
+        requestAlias = requestAlias,
+        field = field,
+        mode = mode,
+        point = point,
+        location = location,
+        terminal = terminal,
+    )

--- a/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformance.kt
+++ b/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformance.kt
@@ -2,6 +2,8 @@ package io.bluetape4k.junit5.observability
 
 import java.io.Serializable
 
+private const val REDACTED_MARKER_VALUE = "values redacted"
+
 /**
  * Identifies a framework boundary covered by a context propagation proof.
  *
@@ -119,6 +121,7 @@ enum class ContextMarkerExpectationMode {
  * Constructor changes are compatibility-sensitive. Callers must not persist or destructure this value or use it as
  * a wire contract. Serializable snapshots are not persistence or wire formats. Markers must be test-owned synthetic
  * values, never production request IDs, user data, or external trace IDs. Root context is represented by `null`.
+ * [toString] preserves only bounded coordinates and redacts marker-bearing fields.
  *
  * Example:
  * ```kotlin
@@ -132,6 +135,9 @@ data class ContextMarkerObservation(
     val point: ContextObservationPoint,
     val observedMarker: String?,
 ): Serializable {
+    override fun toString(): String =
+        "ContextMarkerObservation(point=$point, observedMarker=$REDACTED_MARKER_VALUE)"
+
     companion object {
         private const val serialVersionUID: Long = 1L
     }
@@ -143,7 +149,8 @@ data class ContextMarkerObservation(
  * Constructor changes are compatibility-sensitive. Callers must not persist or destructure this value or use it as
  * a wire contract. Serializable snapshots are not persistence or wire formats. Markers must be test-owned synthetic
  * values, never production request IDs, user data, or external trace IDs. Root context is represented by `null`,
- * so the literal marker `root` is invalid.
+ * so the literal marker `root` is invalid. [toString] preserves only bounded coordinates and redacts marker-bearing
+ * fields.
  *
  * Example:
  * ```kotlin
@@ -157,6 +164,9 @@ data class ContextMarkerExpectation(
     val point: ContextObservationPoint,
     val expectedMarker: String,
 ): Serializable {
+    override fun toString(): String =
+        "ContextMarkerExpectation(point=$point, expectedMarker=$REDACTED_MARKER_VALUE)"
+
     companion object {
         private const val serialVersionUID: Long = 1L
     }
@@ -168,6 +178,7 @@ data class ContextMarkerExpectation(
  * Constructor changes are compatibility-sensitive. Callers must not persist or destructure this value or use it as
  * a wire contract. Serializable snapshots are not persistence or wire formats. Markers must be test-owned synthetic
  * values, never production request IDs, user data, or external trace IDs. Root context is represented by `null`.
+ * [toString] preserves only bounded coordinates and redacts marker-bearing fields.
  *
  * Example:
  * ```kotlin
@@ -181,6 +192,9 @@ data class ContextCleanupProbe(
     val location: ContextProbeLocation,
     val observedMarker: String?,
 ): Serializable {
+    override fun toString(): String =
+        "ContextCleanupProbe(location=$location, observedMarker=$REDACTED_MARKER_VALUE)"
+
     companion object {
         private const val serialVersionUID: Long = 1L
     }
@@ -192,6 +206,7 @@ data class ContextCleanupProbe(
  * Constructor changes are compatibility-sensitive. Callers must not persist or destructure this value or use it as
  * a wire contract. Serializable snapshots are not persistence or wire formats. Markers must be test-owned synthetic
  * values, never production request IDs, user data, or external trace IDs. Root context is represented by `null`.
+ * [toString] preserves only bounded coordinates and redacts marker-bearing fields.
  *
  * Example:
  * ```kotlin
@@ -205,6 +220,9 @@ data class ContextCleanupExpectation(
     val location: ContextProbeLocation,
     val expectedMarker: String?,
 ): Serializable {
+    override fun toString(): String =
+        "ContextCleanupExpectation(location=$location, expectedMarker=$REDACTED_MARKER_VALUE)"
+
     companion object {
         private const val serialVersionUID: Long = 1L
     }
@@ -294,6 +312,7 @@ data class ContextPropagationExpectation(
  * Constructor changes are compatibility-sensitive. Callers must not persist or destructure this value or use it as
  * a wire contract. Serializable snapshots are not persistence or wire formats. Markers must be test-owned synthetic
  * values, never production request IDs, user data, or external trace IDs. Root context is represented by `null`.
+ * [toString] preserves only bounded coordinates and redacts marker-bearing fields.
  *
  * Example:
  * ```kotlin
@@ -307,6 +326,9 @@ data class ContextIsolationSample(
     val requestAlias: ContextRequestAlias,
     val observedMarkers: List<String?>,
 ): Serializable {
+    override fun toString(): String =
+        "ContextIsolationSample(requestAlias=$requestAlias, observedMarkers=$REDACTED_MARKER_VALUE)"
+
     companion object {
         private const val serialVersionUID: Long = 1L
     }
@@ -318,6 +340,7 @@ data class ContextIsolationSample(
  * Constructor changes are compatibility-sensitive. Callers must not persist or destructure this value or use it as
  * a wire contract. Serializable snapshots are not persistence or wire formats. Markers must be test-owned synthetic
  * values, never production request IDs, user data, or external trace IDs. Root context is represented by `null`.
+ * [toString] preserves only bounded coordinates and redacts marker-bearing fields.
  *
  * Example:
  * ```kotlin
@@ -336,6 +359,14 @@ data class ContextIsolationSampleExpectation(
     val forbiddenMarkers: List<String> = emptyList(),
     val minimumObservationCount: Int = 1,
 ): Serializable {
+    override fun toString(): String =
+        "ContextIsolationSampleExpectation(" +
+                "requestAlias=$requestAlias, " +
+                "mode=$mode, " +
+                "expectedMarker=$REDACTED_MARKER_VALUE, " +
+                "forbiddenMarkers=$REDACTED_MARKER_VALUE, " +
+                "minimumObservationCount=$minimumObservationCount)"
+
     companion object {
         private const val serialVersionUID: Long = 1L
     }

--- a/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformanceTest.kt
+++ b/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformanceTest.kt
@@ -1,8 +1,9 @@
 package io.bluetape4k.junit5.observability
 
 import io.bluetape4k.assertions.assertFailsWith
-import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotContain
+import io.bluetape4k.junit5.output.InMemoryLogbackAppender
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 
@@ -10,8 +11,12 @@ import org.junit.jupiter.api.TestInstance
 class ContextPropagationConformanceTest {
 
     @Test
-    fun `matching propagation snapshots satisfy the conformance contract`() {
-        assertContextPropagationConformance(propagationObservation(), propagationExpectation())
+    fun `matching propagation snapshots satisfy the conformance contract without emitting logs`() {
+        InMemoryLogbackAppender("root").use { appender ->
+            assertContextPropagationConformance(propagationObservation(), propagationExpectation())
+
+            appender.size shouldBeEqualTo 0
+        }
     }
 
     @Test
@@ -203,7 +208,12 @@ class ContextPropagationConformanceTest {
     @Test
     fun `NOT_IN isolation rejects every forbidden marker`() {
         val observation = isolationObservation().copy(
-            samples = listOf(ContextIsolationSample(ContextRequestAlias.REQUEST_B, listOf(REQUEST_B_MARKER, null))),
+            samples = listOf(
+                ContextIsolationSample(
+                    ContextRequestAlias.REQUEST_B,
+                    listOf(REQUEST_B_MARKER, REQUEST_B_MARKER),
+                ),
+            ),
         )
         val expectation = ContextIsolationSampleExpectation(
             requestAlias = ContextRequestAlias.REQUEST_B,
@@ -221,6 +231,22 @@ class ContextPropagationConformanceTest {
                 ),
                 isolationExpectation(expectation),
             )
+        }
+    }
+
+    @Test
+    fun `NOT_IN isolation rejects null observations`() {
+        val observation = isolationObservation().copy(
+            samples = listOf(ContextIsolationSample(ContextRequestAlias.PROBE, listOf(null))),
+        )
+        val expectation = ContextIsolationSampleExpectation(
+            requestAlias = ContextRequestAlias.PROBE,
+            mode = ContextMarkerExpectationMode.NOT_IN,
+            forbiddenMarkers = listOf(PARENT_MARKER, REQUEST_A_MARKER),
+        )
+
+        assertFailsWith<AssertionError> {
+            assertContextIsolation(observation, isolationExpectation(expectation))
         }
     }
 
@@ -284,15 +310,21 @@ class ContextPropagationConformanceTest {
     }
 
     @Test
-    fun `every failure family reports only safe redacted coordinates`() {
+    fun `every failure family reports the exact safe diagnostic without emitting logs`() {
         val failureCases = listOf<Pair<String, () -> Unit>>(
-            "observation-point set" to {
+            "Context conformance failed; boundary=COROUTINE; scenario=SUCCESS; alias=SINGLE; " +
+                    "field=markerObservations; relation=mismatch; values redacted" to {
                 assertContextPropagationConformance(
-                    propagationObservation().copy(markerObservations = emptyList()),
+                    propagationObservation().copy(
+                        markerObservations = listOf(
+                            ContextMarkerObservation(ContextObservationPoint.BOUNDARY_ENTER, CANARY),
+                        ),
+                    ),
                     propagationExpectation(),
                 )
             },
-            "propagation marker" to {
+            "Context conformance failed; boundary=COROUTINE; scenario=SUCCESS; alias=SINGLE; " +
+                    "field=marker; point=BOUNDARY_ENTER; relation=mismatch; values redacted" to {
                 assertContextPropagationConformance(
                     propagationObservation().copy(
                         markerObservations = propagationObservation().markerObservations.map {
@@ -306,7 +338,8 @@ class ContextPropagationConformanceTest {
                     propagationExpectation(),
                 )
             },
-            "cleanup" to {
+            "Context conformance failed; boundary=COROUTINE; scenario=SUCCESS; alias=SINGLE; " +
+                    "field=cleanup; location=CALLER; relation=mismatch; values redacted" to {
                 assertContextPropagationConformance(
                     propagationObservation().copy(
                         cleanupProbes = propagationObservation().cleanupProbes.map {
@@ -320,7 +353,8 @@ class ContextPropagationConformanceTest {
                     propagationExpectation(),
                 )
             },
-            "isolation EXACT" to {
+            "Context conformance failed; boundary=COROUTINE; alias=REQUEST_A; " +
+                    "field=observedMarkers; mode=EXACT; relation=mismatch; values redacted" to {
                 assertContextIsolation(
                     isolationObservation().copy(
                         samples = listOf(ContextIsolationSample(ContextRequestAlias.REQUEST_A, listOf(CANARY))),
@@ -328,7 +362,8 @@ class ContextPropagationConformanceTest {
                     isolationExpectation(exactExpectation()),
                 )
             },
-            "isolation NOT_IN" to {
+            "Context conformance failed; boundary=COROUTINE; alias=REQUEST_A; " +
+                    "field=observedMarkers; mode=NOT_IN; relation=mismatch; values redacted" to {
                 assertContextIsolation(
                     isolationObservation().copy(
                         samples = listOf(ContextIsolationSample(ContextRequestAlias.REQUEST_A, listOf(CANARY))),
@@ -342,7 +377,8 @@ class ContextPropagationConformanceTest {
                     ),
                 )
             },
-            "invalid expectation" to {
+            "Context conformance failed; boundary=COROUTINE; alias=REQUEST_A; " +
+                    "field=forbiddenMarkers; mode=EXACT; relation=mismatch; values redacted" to {
                 assertContextIsolation(
                     isolationObservation(),
                     isolationExpectation(
@@ -352,16 +388,18 @@ class ContextPropagationConformanceTest {
             },
         )
 
-        failureCases.forEach { (family, failingAssertion) ->
-            val failure = assertFailsWith<AssertionError>(block = failingAssertion)
-            val message = failure.message.orEmpty()
-            message shouldContain "values redacted"
-            message shouldContain "relation=mismatch"
-            message shouldNotContain "secret-parent"
-            message shouldNotContain "forged-log"
-            message shouldNotContain "\r"
-            message shouldNotContain "\n"
-            message shouldContain family.safeCoordinate()
+        InMemoryLogbackAppender("root").use { appender ->
+            failureCases.forEach { (expectedMessage, failingAssertion) ->
+                val failure = assertFailsWith<AssertionError>(block = failingAssertion)
+                val message = failure.message.orEmpty()
+                message shouldBeEqualTo expectedMessage
+                message shouldNotContain "secret-parent"
+                message shouldNotContain "forged-log"
+                message shouldNotContain "\r"
+                message shouldNotContain "\n"
+            }
+
+            appender.size shouldBeEqualTo 0
         }
     }
 
@@ -422,17 +460,6 @@ class ContextPropagationConformanceTest {
     private fun cleanupExpectations(): List<ContextCleanupExpectation> =
         ContextProbeLocation.entries.map { location ->
             ContextCleanupExpectation(location, null)
-        }
-
-    private fun String.safeCoordinate(): String =
-        when (this) {
-            "observation-point set" -> "field=markerObservations"
-            "propagation marker" -> "point=BOUNDARY_ENTER"
-            "cleanup" -> "location=CALLER"
-            "isolation EXACT" -> "mode=EXACT"
-            "isolation NOT_IN" -> "mode=NOT_IN"
-            "invalid expectation" -> "field=forbiddenMarkers"
-            else -> error("Unknown failure family")
         }
 
     private companion object {

--- a/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformanceTest.kt
+++ b/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformanceTest.kt
@@ -403,6 +403,113 @@ class ContextPropagationConformanceTest {
         }
     }
 
+    @Test
+    fun `README propagation example compiles`() {
+        val marker = "synthetic-parent"
+        val observation = ContextPropagationObservation(
+            boundary = ContextPropagationBoundary.COROUTINE,
+            scenario = ContextPropagationScenario.SUCCESS,
+            requestAlias = ContextRequestAlias.SINGLE,
+            markerObservations = listOf(
+                ContextMarkerObservation(
+                    ContextObservationPoint.BOUNDARY_ENTER,
+                    marker,
+                ),
+                ContextMarkerObservation(
+                    ContextObservationPoint.AFTER_SUSPENSION,
+                    marker,
+                ),
+                ContextMarkerObservation(
+                    ContextObservationPoint.BEFORE_TERMINAL,
+                    marker,
+                ),
+            ),
+            cleanupProbes = listOf(
+                ContextCleanupProbe(ContextProbeLocation.CALLER, null),
+            ),
+            terminal = ContextPropagationTerminal.SUCCESS,
+        )
+        val expectation = ContextPropagationExpectation(
+            boundary = ContextPropagationBoundary.COROUTINE,
+            scenario = ContextPropagationScenario.SUCCESS,
+            requestAlias = ContextRequestAlias.SINGLE,
+            markerExpectations = listOf(
+                ContextMarkerExpectation(
+                    ContextObservationPoint.BOUNDARY_ENTER,
+                    marker,
+                ),
+                ContextMarkerExpectation(
+                    ContextObservationPoint.AFTER_SUSPENSION,
+                    marker,
+                ),
+                ContextMarkerExpectation(
+                    ContextObservationPoint.BEFORE_TERMINAL,
+                    marker,
+                ),
+            ),
+            cleanupExpectations = listOf(
+                ContextCleanupExpectation(ContextProbeLocation.CALLER, null),
+            ),
+            expectedTerminal = ContextPropagationTerminal.SUCCESS,
+        )
+
+        assertContextPropagationConformance(observation, expectation)
+    }
+
+    @Test
+    fun `README isolation example compiles`() {
+        val isolationObservation = ContextIsolationObservation(
+            boundary = ContextPropagationBoundary.KTOR_REQUEST,
+            samples = listOf(
+                ContextIsolationSample(
+                    ContextRequestAlias.REQUEST_A,
+                    listOf("synthetic-parent-A", "synthetic-parent-A"),
+                ),
+                ContextIsolationSample(
+                    ContextRequestAlias.REQUEST_B,
+                    listOf("synthetic-parent-B", "synthetic-parent-B"),
+                ),
+                ContextIsolationSample(
+                    ContextRequestAlias.PROBE,
+                    listOf("synthetic-probe"),
+                ),
+            ),
+            cleanupProbes = listOf(
+                ContextCleanupProbe(ContextProbeLocation.REQUEST, null),
+            ),
+        )
+        val isolationExpectation = ContextIsolationExpectation(
+            boundary = ContextPropagationBoundary.KTOR_REQUEST,
+            samples = listOf(
+                ContextIsolationSampleExpectation(
+                    requestAlias = ContextRequestAlias.REQUEST_A,
+                    mode = ContextMarkerExpectationMode.EXACT,
+                    expectedMarker = "synthetic-parent-A",
+                    minimumObservationCount = 2,
+                ),
+                ContextIsolationSampleExpectation(
+                    requestAlias = ContextRequestAlias.REQUEST_B,
+                    mode = ContextMarkerExpectationMode.EXACT,
+                    expectedMarker = "synthetic-parent-B",
+                    minimumObservationCount = 2,
+                ),
+                ContextIsolationSampleExpectation(
+                    requestAlias = ContextRequestAlias.PROBE,
+                    mode = ContextMarkerExpectationMode.NOT_IN,
+                    forbiddenMarkers = listOf(
+                        "synthetic-parent-A",
+                        "synthetic-parent-B",
+                    ),
+                ),
+            ),
+            cleanupExpectations = listOf(
+                ContextCleanupExpectation(ContextProbeLocation.REQUEST, null),
+            ),
+        )
+
+        assertContextIsolation(isolationObservation, isolationExpectation)
+    }
+
     private fun propagationObservation(): ContextPropagationObservation =
         ContextPropagationObservation(
             boundary = ContextPropagationBoundary.COROUTINE,

--- a/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformanceTest.kt
+++ b/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformanceTest.kt
@@ -4,6 +4,12 @@ import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotContain
 import io.bluetape4k.junit5.output.InMemoryLogbackAppender
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.asContextElement
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 
@@ -404,31 +410,92 @@ class ContextPropagationConformanceTest {
     }
 
     @Test
+    fun `snapshot string representations redact marker values and control characters`() {
+        val canary = "secret-parent\r\nforged-log"
+        val snapshots = listOf(
+            ContextMarkerObservation(ContextObservationPoint.BOUNDARY_ENTER, canary),
+            ContextMarkerExpectation(ContextObservationPoint.BOUNDARY_ENTER, canary),
+            ContextCleanupProbe(ContextProbeLocation.CALLER, canary),
+            ContextCleanupExpectation(ContextProbeLocation.CALLER, canary),
+            ContextIsolationSample(ContextRequestAlias.REQUEST_A, listOf(canary)),
+            ContextIsolationSampleExpectation(
+                requestAlias = ContextRequestAlias.REQUEST_A,
+                mode = ContextMarkerExpectationMode.NOT_IN,
+                expectedMarker = canary,
+                forbiddenMarkers = listOf(canary),
+            ),
+            propagationObservation().copy(
+                markerObservations = listOf(
+                    ContextMarkerObservation(ContextObservationPoint.BOUNDARY_ENTER, canary),
+                ),
+                cleanupProbes = listOf(ContextCleanupProbe(ContextProbeLocation.CALLER, canary)),
+            ),
+            propagationExpectation().copy(
+                markerExpectations = listOf(
+                    ContextMarkerExpectation(ContextObservationPoint.BOUNDARY_ENTER, canary),
+                ),
+                cleanupExpectations = listOf(ContextCleanupExpectation(ContextProbeLocation.CALLER, canary)),
+            ),
+            isolationObservation().copy(
+                samples = listOf(ContextIsolationSample(ContextRequestAlias.REQUEST_A, listOf(canary))),
+                cleanupProbes = listOf(ContextCleanupProbe(ContextProbeLocation.REQUEST, canary)),
+            ),
+            isolationExpectation(exactExpectation()).copy(
+                samples = listOf(
+                    ContextIsolationSampleExpectation(
+                        requestAlias = ContextRequestAlias.REQUEST_A,
+                        mode = ContextMarkerExpectationMode.NOT_IN,
+                        expectedMarker = canary,
+                        forbiddenMarkers = listOf(canary),
+                    ),
+                ),
+                cleanupExpectations = listOf(ContextCleanupExpectation(ContextProbeLocation.REQUEST, canary)),
+            ),
+        )
+
+        snapshots.forEach { snapshot ->
+            val rendered = snapshot.toString()
+            rendered shouldNotContain "secret-parent"
+            rendered shouldNotContain "forged-log"
+            rendered shouldNotContain "\r"
+            rendered shouldNotContain "\n"
+            check("values redacted" in rendered)
+        }
+    }
+
+    @Test
     fun `README propagation example compiles`() {
         val marker = "synthetic-parent"
-        val observation = ContextPropagationObservation(
-            boundary = ContextPropagationBoundary.COROUTINE,
-            scenario = ContextPropagationScenario.SUCCESS,
-            requestAlias = ContextRequestAlias.SINGLE,
-            markerObservations = listOf(
-                ContextMarkerObservation(
+        val markerContext = ThreadLocal<String?>()
+        val observation = runBlocking {
+            val observed = mutableListOf<ContextMarkerObservation>()
+            withContext(markerContext.asContextElement(marker)) {
+                observed += ContextMarkerObservation(
                     ContextObservationPoint.BOUNDARY_ENTER,
-                    marker,
-                ),
-                ContextMarkerObservation(
+                    markerContext.get(),
+                )
+                yield()
+                observed += ContextMarkerObservation(
                     ContextObservationPoint.AFTER_SUSPENSION,
-                    marker,
-                ),
-                ContextMarkerObservation(
+                    markerContext.get(),
+                )
+                observed += ContextMarkerObservation(
                     ContextObservationPoint.BEFORE_TERMINAL,
-                    marker,
+                    markerContext.get(),
+                )
+            }
+            ContextPropagationObservation(
+                boundary = ContextPropagationBoundary.COROUTINE,
+                scenario = ContextPropagationScenario.SUCCESS,
+                requestAlias = ContextRequestAlias.SINGLE,
+                markerObservations = observed,
+                cleanupProbes = listOf(
+                    ContextCleanupProbe(ContextProbeLocation.CALLER, markerContext.get()),
                 ),
-            ),
-            cleanupProbes = listOf(
-                ContextCleanupProbe(ContextProbeLocation.CALLER, null),
-            ),
-            terminal = ContextPropagationTerminal.SUCCESS,
-        )
+                terminal = ContextPropagationTerminal.SUCCESS,
+            )
+        }
+        val expectedMarker = "synthetic-parent"
         val expectation = ContextPropagationExpectation(
             boundary = ContextPropagationBoundary.COROUTINE,
             scenario = ContextPropagationScenario.SUCCESS,
@@ -436,15 +503,15 @@ class ContextPropagationConformanceTest {
             markerExpectations = listOf(
                 ContextMarkerExpectation(
                     ContextObservationPoint.BOUNDARY_ENTER,
-                    marker,
+                    expectedMarker,
                 ),
                 ContextMarkerExpectation(
                     ContextObservationPoint.AFTER_SUSPENSION,
-                    marker,
+                    expectedMarker,
                 ),
                 ContextMarkerExpectation(
                     ContextObservationPoint.BEFORE_TERMINAL,
-                    marker,
+                    expectedMarker,
                 ),
             ),
             cleanupExpectations = listOf(
@@ -458,28 +525,49 @@ class ContextPropagationConformanceTest {
 
     @Test
     fun `README isolation example compiles`() {
-        val isolationObservation = ContextIsolationObservation(
-            boundary = ContextPropagationBoundary.KTOR_REQUEST,
-            samples = listOf(
-                ContextIsolationSample(
-                    ContextRequestAlias.REQUEST_A,
-                    listOf("synthetic-parent-A", "synthetic-parent-A"),
+        val markerContext = ThreadLocal<String?>()
+        val isolationObservation = runBlocking {
+            val readyA = CompletableDeferred<Unit>()
+            val readyB = CompletableDeferred<Unit>()
+
+            suspend fun observe(
+                alias: ContextRequestAlias,
+                marker: String,
+                ownReady: CompletableDeferred<Unit>,
+                peerReady: CompletableDeferred<Unit>,
+            ): ContextIsolationSample =
+                withContext(markerContext.asContextElement(marker)) {
+                    ownReady.complete(Unit)
+                    peerReady.await()
+                    val observed = mutableListOf(markerContext.get())
+                    yield()
+                    observed += markerContext.get()
+                    ContextIsolationSample(alias, observed)
+                }
+
+            val sampleA = async {
+                observe(ContextRequestAlias.REQUEST_A, "synthetic-parent-A", readyA, readyB)
+            }
+            val sampleB = async {
+                observe(ContextRequestAlias.REQUEST_B, "synthetic-parent-B", readyB, readyA)
+            }
+            val probe = withContext(markerContext.asContextElement("synthetic-probe")) {
+                markerContext.get()
+            }
+            ContextIsolationObservation(
+                boundary = ContextPropagationBoundary.COROUTINE,
+                samples = listOf(
+                    sampleA.await(),
+                    sampleB.await(),
+                    ContextIsolationSample(ContextRequestAlias.PROBE, listOf(probe)),
                 ),
-                ContextIsolationSample(
-                    ContextRequestAlias.REQUEST_B,
-                    listOf("synthetic-parent-B", "synthetic-parent-B"),
+                cleanupProbes = listOf(
+                    ContextCleanupProbe(ContextProbeLocation.CALLER, markerContext.get()),
                 ),
-                ContextIsolationSample(
-                    ContextRequestAlias.PROBE,
-                    listOf("synthetic-probe"),
-                ),
-            ),
-            cleanupProbes = listOf(
-                ContextCleanupProbe(ContextProbeLocation.REQUEST, null),
-            ),
-        )
+            )
+        }
         val isolationExpectation = ContextIsolationExpectation(
-            boundary = ContextPropagationBoundary.KTOR_REQUEST,
+            boundary = ContextPropagationBoundary.COROUTINE,
             samples = listOf(
                 ContextIsolationSampleExpectation(
                     requestAlias = ContextRequestAlias.REQUEST_A,
@@ -503,7 +591,7 @@ class ContextPropagationConformanceTest {
                 ),
             ),
             cleanupExpectations = listOf(
-                ContextCleanupExpectation(ContextProbeLocation.REQUEST, null),
+                ContextCleanupExpectation(ContextProbeLocation.CALLER, null),
             ),
         )
 

--- a/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformanceTest.kt
+++ b/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformanceTest.kt
@@ -1,0 +1,444 @@
+package io.bluetape4k.junit5.observability
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotContain
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ContextPropagationConformanceTest {
+
+    @Test
+    fun `matching propagation snapshots satisfy the conformance contract`() {
+        assertContextPropagationConformance(propagationObservation(), propagationExpectation())
+    }
+
+    @Test
+    fun `all terminal distinctions satisfy their matching scenarios`() {
+        val cases = listOf(
+            ContextPropagationScenario.SUCCESS to ContextPropagationTerminal.SUCCESS,
+            ContextPropagationScenario.FAILURE to ContextPropagationTerminal.FAILURE,
+            ContextPropagationScenario.CANCELLATION to ContextPropagationTerminal.CANCELLATION,
+            ContextPropagationScenario.DEADLINE to ContextPropagationTerminal.DEADLINE_EXCEEDED,
+        )
+
+        cases.forEach { (scenario, terminal) ->
+            assertContextPropagationConformance(
+                propagationObservation().copy(scenario = scenario, terminal = terminal),
+                propagationExpectation().copy(scenario = scenario, expectedTerminal = terminal),
+            )
+        }
+    }
+
+    @Test
+    fun `propagation boundary scenario alias and terminal must match exactly`() {
+        val mismatchedExpectations = listOf(
+            propagationExpectation().copy(boundary = ContextPropagationBoundary.REACTOR),
+            propagationExpectation().copy(scenario = ContextPropagationScenario.FAILURE),
+            propagationExpectation().copy(requestAlias = ContextRequestAlias.PROBE),
+            propagationExpectation().copy(expectedTerminal = ContextPropagationTerminal.FAILURE),
+        )
+
+        mismatchedExpectations.forEach { mismatchedExpectation ->
+            assertFailsWith<AssertionError> {
+                assertContextPropagationConformance(propagationObservation(), mismatchedExpectation)
+            }
+        }
+    }
+
+    @Test
+    fun `propagation observation point sets must match exactly`() {
+        val observation = propagationObservation().copy(
+            markerObservations = propagationObservation().markerObservations.dropLast(1),
+        )
+
+        assertFailsWith<AssertionError> {
+            assertContextPropagationConformance(observation, propagationExpectation())
+        }
+    }
+
+    @Test
+    fun `propagation observation points must be unique`() {
+        val observation = propagationObservation().copy(
+            markerObservations = propagationObservation().markerObservations +
+                    ContextMarkerObservation(ContextObservationPoint.BOUNDARY_ENTER, PARENT_MARKER),
+        )
+
+        assertFailsWith<AssertionError> {
+            assertContextPropagationConformance(observation, propagationExpectation())
+        }
+    }
+
+    @Test
+    fun `cleanup location sets must match exactly and remain unique`() {
+        val missingLocation = propagationObservation().copy(
+            cleanupProbes = propagationObservation().cleanupProbes.dropLast(1),
+        )
+        val duplicateLocation = propagationExpectation().copy(
+            cleanupExpectations = propagationExpectation().cleanupExpectations +
+                    ContextCleanupExpectation(ContextProbeLocation.CALLER, null),
+        )
+
+        assertFailsWith<AssertionError> {
+            assertContextPropagationConformance(missingLocation, propagationExpectation())
+        }
+        assertFailsWith<AssertionError> {
+            assertContextPropagationConformance(propagationObservation(), duplicateLocation)
+        }
+    }
+
+    @Test
+    fun `literal root is rejected because root context is represented by null`() {
+        val cases = listOf<() -> Unit>(
+            {
+                assertContextPropagationConformance(
+                    propagationObservation().copy(
+                        markerObservations = propagationObservation().markerObservations.map {
+                            if (it.point == ContextObservationPoint.AFTER_SUSPENSION) {
+                                it.copy(observedMarker = "root")
+                            } else {
+                                it
+                            }
+                        },
+                    ),
+                    propagationExpectation(),
+                )
+            },
+            {
+                assertContextPropagationConformance(
+                    propagationObservation(),
+                    propagationExpectation().copy(
+                        markerExpectations = propagationExpectation().markerExpectations.map {
+                            if (it.point == ContextObservationPoint.AFTER_SUSPENSION) {
+                                it.copy(expectedMarker = "root")
+                            } else {
+                                it
+                            }
+                        },
+                    ),
+                )
+            },
+            {
+                assertContextIsolation(
+                    isolationObservation().copy(
+                        samples = listOf(ContextIsolationSample(ContextRequestAlias.REQUEST_A, listOf("root"))),
+                    ),
+                    isolationExpectation(
+                        ContextIsolationSampleExpectation(
+                            requestAlias = ContextRequestAlias.REQUEST_A,
+                            mode = ContextMarkerExpectationMode.EXACT,
+                            expectedMarker = REQUEST_A_MARKER,
+                        ),
+                    ),
+                )
+            },
+        )
+
+        cases.forEach { failingAssertion ->
+            assertFailsWith<AssertionError>(block = failingAssertion)
+        }
+    }
+
+    @Test
+    fun `isolation aliases must match exactly and remain unique`() {
+        val duplicateObservation = isolationObservation().copy(
+            samples = isolationObservation().samples + isolationObservation().samples.single(),
+        )
+        val mismatchedExpectation = ContextIsolationExpectation(
+            boundary = ContextPropagationBoundary.COROUTINE,
+            samples = listOf(
+                ContextIsolationSampleExpectation(
+                    requestAlias = ContextRequestAlias.REQUEST_B,
+                    mode = ContextMarkerExpectationMode.EXACT,
+                    expectedMarker = REQUEST_B_MARKER,
+                ),
+            ),
+            cleanupExpectations = cleanupExpectations(),
+        )
+
+        assertFailsWith<AssertionError> {
+            assertContextIsolation(duplicateObservation, isolationExpectation(exactExpectation()))
+        }
+        assertFailsWith<AssertionError> {
+            assertContextIsolation(isolationObservation(), mismatchedExpectation)
+        }
+    }
+
+    @Test
+    fun `EXACT isolation requires every observation to equal its marker`() {
+        assertContextIsolation(isolationObservation(), isolationExpectation(exactExpectation()))
+
+        val mismatch = isolationObservation().copy(
+            samples = listOf(ContextIsolationSample(ContextRequestAlias.REQUEST_A, listOf(REQUEST_B_MARKER))),
+        )
+        assertFailsWith<AssertionError> {
+            assertContextIsolation(mismatch, isolationExpectation(exactExpectation()))
+        }
+    }
+
+    @Test
+    fun `ABSENT isolation requires every observation to be null`() {
+        val absentObservation = isolationObservation().copy(
+            samples = listOf(ContextIsolationSample(ContextRequestAlias.PROBE, listOf(null, null))),
+        )
+        val absentExpectation = ContextIsolationSampleExpectation(
+            requestAlias = ContextRequestAlias.PROBE,
+            mode = ContextMarkerExpectationMode.ABSENT,
+            minimumObservationCount = 2,
+        )
+
+        assertContextIsolation(absentObservation, isolationExpectation(absentExpectation))
+
+        assertFailsWith<AssertionError> {
+            assertContextIsolation(
+                absentObservation.copy(
+                    samples = listOf(ContextIsolationSample(ContextRequestAlias.PROBE, listOf(PARENT_MARKER))),
+                ),
+                isolationExpectation(absentExpectation),
+            )
+        }
+    }
+
+    @Test
+    fun `NOT_IN isolation rejects every forbidden marker`() {
+        val observation = isolationObservation().copy(
+            samples = listOf(ContextIsolationSample(ContextRequestAlias.REQUEST_B, listOf(REQUEST_B_MARKER, null))),
+        )
+        val expectation = ContextIsolationSampleExpectation(
+            requestAlias = ContextRequestAlias.REQUEST_B,
+            mode = ContextMarkerExpectationMode.NOT_IN,
+            forbiddenMarkers = listOf(PARENT_MARKER, REQUEST_A_MARKER),
+            minimumObservationCount = 2,
+        )
+
+        assertContextIsolation(observation, isolationExpectation(expectation))
+
+        assertFailsWith<AssertionError> {
+            assertContextIsolation(
+                observation.copy(
+                    samples = listOf(ContextIsolationSample(ContextRequestAlias.REQUEST_B, listOf(PARENT_MARKER))),
+                ),
+                isolationExpectation(expectation),
+            )
+        }
+    }
+
+    @Test
+    fun `isolation samples enforce their minimum observation count`() {
+        val expectation = exactExpectation().copy(minimumObservationCount = 2)
+
+        assertFailsWith<AssertionError> {
+            assertContextIsolation(isolationObservation(), isolationExpectation(expectation))
+        }
+    }
+
+    @Test
+    fun `isolation expectation modes reject invalid field combinations`() {
+        val invalidExpectations = listOf(
+            exactExpectation().copy(expectedMarker = null),
+            exactExpectation().copy(forbiddenMarkers = listOf(PARENT_MARKER)),
+            exactExpectation().copy(mode = ContextMarkerExpectationMode.ABSENT),
+            exactExpectation().copy(
+                mode = ContextMarkerExpectationMode.NOT_IN,
+                expectedMarker = null,
+                forbiddenMarkers = emptyList(),
+            ),
+            exactExpectation().copy(
+                mode = ContextMarkerExpectationMode.NOT_IN,
+                expectedMarker = null,
+                forbiddenMarkers = listOf(PARENT_MARKER, PARENT_MARKER),
+            ),
+            exactExpectation().copy(minimumObservationCount = 0),
+        )
+
+        invalidExpectations.forEach { invalidExpectation ->
+            assertFailsWith<AssertionError> {
+                assertContextIsolation(isolationObservation(), isolationExpectation(invalidExpectation))
+            }
+        }
+    }
+
+    @Test
+    fun `EXACT isolation markers must be unique across aliases`() {
+        val observation = ContextIsolationObservation(
+            boundary = ContextPropagationBoundary.COROUTINE,
+            samples = listOf(
+                ContextIsolationSample(ContextRequestAlias.REQUEST_A, listOf(REQUEST_A_MARKER)),
+                ContextIsolationSample(ContextRequestAlias.REQUEST_B, listOf(REQUEST_A_MARKER)),
+            ),
+            cleanupProbes = cleanupProbes(),
+        )
+        val expectation = ContextIsolationExpectation(
+            boundary = ContextPropagationBoundary.COROUTINE,
+            samples = listOf(
+                exactExpectation(),
+                exactExpectation().copy(requestAlias = ContextRequestAlias.REQUEST_B),
+            ),
+            cleanupExpectations = cleanupExpectations(),
+        )
+
+        assertFailsWith<AssertionError> {
+            assertContextIsolation(observation, expectation)
+        }
+    }
+
+    @Test
+    fun `every failure family reports only safe redacted coordinates`() {
+        val failureCases = listOf<Pair<String, () -> Unit>>(
+            "observation-point set" to {
+                assertContextPropagationConformance(
+                    propagationObservation().copy(markerObservations = emptyList()),
+                    propagationExpectation(),
+                )
+            },
+            "propagation marker" to {
+                assertContextPropagationConformance(
+                    propagationObservation().copy(
+                        markerObservations = propagationObservation().markerObservations.map {
+                            if (it.point == ContextObservationPoint.BOUNDARY_ENTER) {
+                                it.copy(observedMarker = CANARY)
+                            } else {
+                                it
+                            }
+                        },
+                    ),
+                    propagationExpectation(),
+                )
+            },
+            "cleanup" to {
+                assertContextPropagationConformance(
+                    propagationObservation().copy(
+                        cleanupProbes = propagationObservation().cleanupProbes.map {
+                            if (it.location == ContextProbeLocation.CALLER) {
+                                it.copy(observedMarker = CANARY)
+                            } else {
+                                it
+                            }
+                        },
+                    ),
+                    propagationExpectation(),
+                )
+            },
+            "isolation EXACT" to {
+                assertContextIsolation(
+                    isolationObservation().copy(
+                        samples = listOf(ContextIsolationSample(ContextRequestAlias.REQUEST_A, listOf(CANARY))),
+                    ),
+                    isolationExpectation(exactExpectation()),
+                )
+            },
+            "isolation NOT_IN" to {
+                assertContextIsolation(
+                    isolationObservation().copy(
+                        samples = listOf(ContextIsolationSample(ContextRequestAlias.REQUEST_A, listOf(CANARY))),
+                    ),
+                    isolationExpectation(
+                        ContextIsolationSampleExpectation(
+                            requestAlias = ContextRequestAlias.REQUEST_A,
+                            mode = ContextMarkerExpectationMode.NOT_IN,
+                            forbiddenMarkers = listOf(CANARY),
+                        ),
+                    ),
+                )
+            },
+            "invalid expectation" to {
+                assertContextIsolation(
+                    isolationObservation(),
+                    isolationExpectation(
+                        exactExpectation().copy(forbiddenMarkers = listOf(CANARY)),
+                    ),
+                )
+            },
+        )
+
+        failureCases.forEach { (family, failingAssertion) ->
+            val failure = assertFailsWith<AssertionError>(block = failingAssertion)
+            val message = failure.message.orEmpty()
+            message shouldContain "values redacted"
+            message shouldContain "relation=mismatch"
+            message shouldNotContain "secret-parent"
+            message shouldNotContain "forged-log"
+            message shouldNotContain "\r"
+            message shouldNotContain "\n"
+            message shouldContain family.safeCoordinate()
+        }
+    }
+
+    private fun propagationObservation(): ContextPropagationObservation =
+        ContextPropagationObservation(
+            boundary = ContextPropagationBoundary.COROUTINE,
+            scenario = ContextPropagationScenario.SUCCESS,
+            requestAlias = ContextRequestAlias.SINGLE,
+            markerObservations = ContextObservationPoint.entries.map { point ->
+                ContextMarkerObservation(point, PARENT_MARKER)
+            },
+            cleanupProbes = cleanupProbes(),
+            terminal = ContextPropagationTerminal.SUCCESS,
+        )
+
+    private fun propagationExpectation(): ContextPropagationExpectation =
+        ContextPropagationExpectation(
+            boundary = ContextPropagationBoundary.COROUTINE,
+            scenario = ContextPropagationScenario.SUCCESS,
+            requestAlias = ContextRequestAlias.SINGLE,
+            markerExpectations = ContextObservationPoint.entries.map { point ->
+                ContextMarkerExpectation(point, PARENT_MARKER)
+            },
+            cleanupExpectations = cleanupExpectations(),
+            expectedTerminal = ContextPropagationTerminal.SUCCESS,
+        )
+
+    private fun isolationObservation(): ContextIsolationObservation =
+        ContextIsolationObservation(
+            boundary = ContextPropagationBoundary.COROUTINE,
+            samples = listOf(
+                ContextIsolationSample(ContextRequestAlias.REQUEST_A, listOf(REQUEST_A_MARKER)),
+            ),
+            cleanupProbes = cleanupProbes(),
+        )
+
+    private fun isolationExpectation(
+        sampleExpectation: ContextIsolationSampleExpectation,
+    ): ContextIsolationExpectation =
+        ContextIsolationExpectation(
+            boundary = ContextPropagationBoundary.COROUTINE,
+            samples = listOf(sampleExpectation),
+            cleanupExpectations = cleanupExpectations(),
+        )
+
+    private fun exactExpectation(): ContextIsolationSampleExpectation =
+        ContextIsolationSampleExpectation(
+            requestAlias = ContextRequestAlias.REQUEST_A,
+            mode = ContextMarkerExpectationMode.EXACT,
+            expectedMarker = REQUEST_A_MARKER,
+        )
+
+    private fun cleanupProbes(): List<ContextCleanupProbe> =
+        ContextProbeLocation.entries.map { location ->
+            ContextCleanupProbe(location, null)
+        }
+
+    private fun cleanupExpectations(): List<ContextCleanupExpectation> =
+        ContextProbeLocation.entries.map { location ->
+            ContextCleanupExpectation(location, null)
+        }
+
+    private fun String.safeCoordinate(): String =
+        when (this) {
+            "observation-point set" -> "field=markerObservations"
+            "propagation marker" -> "point=BOUNDARY_ENTER"
+            "cleanup" -> "location=CALLER"
+            "isolation EXACT" -> "mode=EXACT"
+            "isolation NOT_IN" -> "mode=NOT_IN"
+            "invalid expectation" -> "field=forbiddenMarkers"
+            else -> error("Unknown failure family")
+        }
+
+    private companion object {
+        const val PARENT_MARKER = "synthetic-parent"
+        const val REQUEST_A_MARKER = "synthetic-request-a"
+        const val REQUEST_B_MARKER = "synthetic-request-b"
+        const val CANARY = "secret-parent\r\nforged-log"
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1051

- PR 제목: test: add context propagation conformance fixtures

Closes #1051

Add one provider-neutral proof language for context propagation while keeping every framework-specific lifecycle adapter in its owning integration module.

## Background

Milestone `1.12.0` needs deterministic evidence that coroutine, Reactor, executor, Spring Observation, and Ktor request boundaries preserve parent context, classify terminal signals correctly, clean up owned context, and isolate concurrent requests.

## What This Solves

- Replaces framework-specific assertion semantics with shared immutable observations and expectations.
- Detects cancellation/deadline misclassification, context leakage, ambiguous isolation ordering, and unbounded teardown.
- Keeps production adapters and global telemetry state unchanged.

## Work Done

- Added provider-neutral propagation, cleanup, terminal, marker, and isolation snapshots with redacted diagnostics.
- Added real coroutine, Reactor, executor, Spring Observation, and Ktor `testApplication` conformance adapters.
- Added deterministic A/B event-ledger barriers, bounded cleanup, interruption restoration, and a shared Ktor monotonic deadline.
- Added English/Korean usage documentation and a reusable Korean lesson.

## Validation

- `./gradlew :bluetape4k-junit5:test --rerun-tasks`: PASS (338 tests)
- `./gradlew :bluetape4k-opentelemetry:test --rerun-tasks`: PASS (110 tests)
- `./gradlew :bluetape4k-spring-boot-core:test --rerun-tasks`: PASS (249 tests)
- `./gradlew :bluetape4k-ktor-observability:test --rerun-tasks`: PASS (20 tests)
- `./gradlew detekt --rerun-tasks`: PASS (`NO-SOURCE`; not treated as Kotlin static-analysis proof)
- `./gradlew :bluetape4k-junit5:dokkaGenerate --rerun-tasks`: PASS (only three pre-existing README link warnings)
- Conformance XML, banned API/output, bilingual parity, and `git diff --check` gates: PASS

## Review Notes

- 7-Tier review: P0=0, P1=0, P2=0, P3=0
- Independent code-reviewer: `APPROVE`
- Independent architecture review: `CLEAR`
- Production adapter, dependency, build script, module registration, global OpenTelemetry state, and Reactor hook changes: none

## Metadata

- Issue: #1051, milestone `1.12.0`, assignee `debop`
- PR: #1090, head `2ab73b49ff25434ae49d19a52dcf076bcc32fac9`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `feat/issue-1051-context-conformance`
- Labels: `enhancement`, `test`, `coroutines`
- State: `MERGED`, merge commit `0003233a603aea81f8b3971312662bd0793e6991`
- CI: Add one provider-neutral proof language for context propagation while keeping every framework-specific lifecycle adapter in its owning integration module. / - Replaces framework-specific assertion semantics with shared immutable observations and expectations. / - `./gradlew :bluetape4k-junit5:test --rerun-tasks`: PASS (338 tests)

## DoD Status

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01..10 - Pre-PR proof | Classified, implemented, documented, validated, and independently reviewed the exact branch | PASS | 717/717 tests; P0/P1/P2/P3=0; head `2ab73b49ff25434ae49d19a52dcf076bcc32fac9` | none |
| CG-11 - Delivery authority | Verified approved repository/base/head PR scope | PASS | `bluetape4k-projects`, `develop` <- `feat/issue-1051-context-conformance` | none |
| CG-12 - Exact head publication | Pushed and read back the remote branch head | PASS | local=remote=`2ab73b49ff25434ae49d19a52dcf076bcc32fac9` | none |
| CG-13 - PR metadata | Create and verify assignee, labels, milestone, body, and head | PASS | live PR metadata verification | repair metadata if read-back differs |
| CG-14 - CI and live review | Ran checks on the exact PR head and reread reviews/threads | PASS | 12 success, 7 skip, 0 failure/pending; reviews=0; unresolved threads=0 | none |
| CG-15 - Merge-ready report | Reconciled exact-head CI, review, lesson, metadata, and merge state | PASS | `MERGEABLE`/`CLEAN`; P0/P1/P2/P3=0; architect `CLEAR` | report exact PR/head to the user |
| CG-16 - Fresh merge approval | Obtained explicit approval after the exact-head merge-ready report | PASS | user approval for PR #1090 at `2ab73b49ff25434ae49d19a52dcf076bcc32fac9` | none |
| CG-17 - Merge verification | Rebase-merged the approved exact PR head and verified GitHub state | PASS | PR `MERGED`; merge commit `0003233a603aea81f8b3971312662bd0793e6991` | none |
| CG-18 - Local sync and cleanup | Fast-forwarded `develop`, restored protected local files, and removed patch-equivalent feature work | PASS | local=remote=`0003233a603aea81f8b3971312662bd0793e6991`; one worktree remains | none |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1090 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `0003233a603aea81f8b3971312662bd0793e6991`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
