### PR TITLE
Add bounded caller-owned LZ4 buffer paths

### DIFF
--- a/docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md
+++ b/docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md
@@ -39,6 +39,23 @@ Zstd throw-before-return 계약을 명세에 추가하고, 독립 6관점 재검
 - allocation 개선은 backend/storage별 반복 측정 전에는 주장하지 않는다. core matrix의 모든
   경로는 compatibility fallback이며 correctness-only다.
 
+## LZ4 slice에서 고정한 경계
+
+LZ4 caller-owned 경로는 heap/direct/slice/read-only source와 heap/direct/slice target의 모든
+조합에서 lz4-java의 `ByteBuffer` API를 직접 사용한다. decompression에는 caller가 노출한
+payload만 별도 `slice()`로 전달한다. 이 view의 `position=0`,
+`limit=capacity=caller-visible remaining`이므로 `LZ4FastDecompressor`가 capacity를 입력
+경계로 사용하더라도 caller limit 뒤의 tail에는 접근할 수 없다. codec이 반환한 consumed byte
+수가 bounded payload 전체 길이와 다르면 trailing 또는 truncated wire로 분류해
+`LZ4Exception`을 전파한다.
+
+검증은 capacity에 완전한 wire가 남아 있지만 caller limit가 마지막 byte를 가린 direct source,
+유효 wire 뒤 trailing byte, 기존/new API wire 상호 운용, big-endian header, target preflight,
+overflow retry, pre-created failure identity를 포함한다. compression codec의 반환값도
+`1..payloadCapacity` 범위에서만 target position을 commit한다. README의 `optimized`는 이 native
+dispatch와 storage coverage만 뜻하며, allocation 개선은 아직 측정하지 않았으므로
+`eligible, not yet measured`로 유지한다.
+
 ## 왜 broad backend slice를 중단했는가
 
 LZ4의 capacity-tail read는 source isolation 문제이고, zstd-jni의 throw-before-return은 예외

--- a/docs/superpowers/plans/2026-07-21-issue-755-bytebuffer-compressor-plan.md
+++ b/docs/superpowers/plans/2026-07-21-issue-755-bytebuffer-compressor-plan.md
@@ -229,7 +229,7 @@ merge checkpoint shell tests는 `gh` stub으로 live PR `state`, `baseRefName`, 
 
 | 경로                                                                                        | 변경           | 책임                                                                         |
 |---------------------------------------------------------------------------------------------|----------------|------------------------------------------------------------------------------|
-| `io/io/src/main/kotlin/io/bluetape4k/io/compressor/Compressor.kt`                           | 수정           | 두 JVM default public method와 English KDoc                                  |
+| `io/io/src/main/kotlin/io/bluetape4k/io/compressor/Compressor.kt`                           | 수정           | 두 JVM default public method와 한국어 KDoc                                   |
 | `io/io/src/main/kotlin/io/bluetape4k/io/compressor/CompressorBufferSupport.kt`              | 생성           | preflight, overlap 탐지, fallback, commit/rollback wrapper, BE header helper |
 | `io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorByteBufferTestSupport.kt`      | 생성           | buffer/mark/sentinel fixture와 모든 compressor provider                      |
 | `io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorByteBufferContractTest.kt`     | 생성           | fallback 및 전체 compressor 공통 상태/실패/wire contract                     |

--- a/docs/superpowers/specs/2026-07-21-issue-755-bytebuffer-compressor-design.md
+++ b/docs/superpowers/specs/2026-07-21-issue-755-bytebuffer-compressor-design.md
@@ -469,7 +469,7 @@ throughput은 개선 승인 조건이 아니지만 안정성 guard로 기록한�
 
 ## 13. 문서화
 
-- 공개 KDoc은 영어로 작성한다.
+- 공개·내부 KDoc은 한국어를 우선으로 작성한다.
 - `io/io/README.md`와 `io/io/README.ko.md`는 동일한 예제와 지원 행렬을 유지한다.
 - 기본 fallback도 동작하지만 payload-sized 배열을 할당할 수 있음을 명시한다.
 - optimized 저장형 조합과 fallback 조합을 표로 제공한다.
@@ -549,7 +549,7 @@ Kotlin/Java README 예제는 compile test에 포함하고 source position 불변
 7. 기존 wire와 신규 API의 양방향 복원이 증명된다.
 8. 기존 decompression 제한과 corrupt-input 방어가 신규 경로에도 적용된다.
 9. allocation report가 codec/storage 조합별 eligible/ineligible 결과와 두 canonical run을 보존한다.
-10. 영어/한국어 README와 KDoc이 지원 범위 및 제한을 정확히 설명한다.
+10. 영어/한국어 README와 한국어 KDoc이 지원 범위 및 제한을 정확히 설명한다.
 11. canonical Kotlin/Java example과 bounded growth retry가 compile/contract test로 증명된다.
 12. benchmark raw evidence의 commit/tree/JAR/environment identity와 append-only run이 fail-closed validator로 증명된다.
 13. fallback decompression의 target bound 한계가 압축률이 큰 payload/small-target contract test와 KDoc/양쪽 README에서 명시된다.

--- a/io/io/README.ko.md
+++ b/io/io/README.ko.md
@@ -241,7 +241,7 @@ Read-only target은 `ReadOnlyBufferException`으로 거부하고, 동일한 buff
 
 | Codec        | heap -> heap           | direct -> direct       | mixed storage          | Allocation claim       |
 |--------------|------------------------|------------------------|------------------------|------------------------|
-| LZ4          | compatibility fallback | compatibility fallback | compatibility fallback | none in the core slice |
+| LZ4          | optimized              | optimized              | optimized              | eligible, not yet measured |
 | Deflate      | compatibility fallback | compatibility fallback | compatibility fallback | none in the core slice |
 | Snappy       | compatibility fallback | compatibility fallback | compatibility fallback | none in the core slice |
 | Zstd         | compatibility fallback | compatibility fallback | compatibility fallback | none in the core slice |

--- a/io/io/README.md
+++ b/io/io/README.md
@@ -241,7 +241,7 @@ Existing one-argument `ByteBuffer` APIs may consume the source `position`; the n
 
 | Codec        | heap -> heap           | direct -> direct       | mixed storage          | Allocation claim       |
 |--------------|------------------------|------------------------|------------------------|------------------------|
-| LZ4          | compatibility fallback | compatibility fallback | compatibility fallback | none in the core slice |
+| LZ4          | optimized              | optimized              | optimized              | eligible, not yet measured |
 | Deflate      | compatibility fallback | compatibility fallback | compatibility fallback | none in the core slice |
 | Snappy       | compatibility fallback | compatibility fallback | compatibility fallback | none in the core slice |
 | Zstd         | compatibility fallback | compatibility fallback | compatibility fallback | none in the core slice |

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/Compressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/Compressor.kt
@@ -82,53 +82,51 @@ interface Compressor {
         ByteBuffer.wrap(decompress(compressedBuffer.getBytes()))
 
     /**
-     * Compresses the remaining bytes in [source] into caller-owned [target].
+     * [source]의 남은 데이터를 호출자가 소유한 [target]에 압축합니다.
      *
-     * The source position, limit, mark, and byte order are preserved. The target
-     * limit, capacity, mark, and byte order are also preserved. On success, only
-     * the target position advances by the returned byte count. On failure, the
-     * target position is restored; bytes already overwritten are unspecified.
+     * source의 position, limit, mark, byte order는 보존됩니다. target의 limit,
+     * capacity, mark, byte order도 보존됩니다. 성공하면 target의 position만 반환된
+     * 바이트 수만큼 이동합니다. 실패하면 target의 position은 복구되지만, 이미 덮어쓴
+     * 바이트의 내용은 보장하지 않습니다.
      *
-     * The default implementation is an allocating compatibility path. It rejects
-     * the same buffer and overlapping writable heap-array ranges that can be
-     * detected. Aliasing through direct or read-only views cannot be detected and
-     * must be excluded by the caller. Each mutable buffer must remain confined to
-     * one thread for the duration of the call.
+     * 기본 구현은 중간 배열을 할당하는 호환 경로입니다. 동일한 버퍼와 탐지 가능한
+     * 쓰기 가능 heap 배열의 중첩 구간은 거부합니다. direct 또는 read-only view를 통한
+     * alias는 탐지할 수 없으므로 호출자가 제외해야 합니다. 호출 중에는 각 가변 버퍼를
+     * 하나의 thread에서만 사용해야 합니다.
      *
-     * This method does not emit runtime dispatch telemetry or logs. Callers that
-     * need diagnostics should record privacy-safe codec, storage, and size metadata.
+     * 이 함수는 runtime dispatch telemetry나 log를 출력하지 않습니다. 진단이 필요한
+     * 호출자는 privacy-safe codec, storage, size metadata를 기록해야 합니다.
      *
-     * @return the number of bytes written to [target]
-     * @throws ReadOnlyBufferException when [target] is read-only
-     * @throws IllegalArgumentException when detectable source and target ranges overlap
-     * @throws BufferOverflowException when [target] has insufficient remaining capacity
+     * @return [target]에 기록한 바이트 수
+     * @throws ReadOnlyBufferException [target]이 read-only인 경우
+     * @throws IllegalArgumentException 탐지 가능한 source와 target 구간이 중첩되는 경우
+     * @throws BufferOverflowException [target]의 남은 용량이 부족한 경우
      */
     fun compress(source: ByteBuffer, target: ByteBuffer): Int =
         writeFallback(source, target) { bytes -> compress(bytes) }
 
     /**
-     * Decompresses the remaining bytes in [source] into caller-owned [target].
+     * [source]의 남은 데이터를 호출자가 소유한 [target]에 해제합니다.
      *
-     * The source position, limit, mark, and byte order are preserved. The target
-     * limit, capacity, mark, and byte order are also preserved. On success, only
-     * the target position advances by the returned byte count. On failure, the
-     * target position is restored; bytes already overwritten are unspecified.
+     * source의 position, limit, mark, byte order는 보존됩니다. target의 limit,
+     * capacity, mark, byte order도 보존됩니다. 성공하면 target의 position만 반환된
+     * 바이트 수만큼 이동합니다. 실패하면 target의 position은 복구되지만, 이미 덮어쓴
+     * 바이트의 내용은 보장하지 않습니다.
      *
-     * The default implementation is an allocating compatibility path. Its target
-     * is only a final-write bound, not a decompression resource bound for untrusted
-     * input; callers must apply an application-level decompressed-size limit. The
-     * method rejects the same buffer and overlapping writable heap-array ranges
-     * that can be detected. Aliasing through direct or read-only views cannot be
-     * detected and must be excluded by the caller. Each mutable buffer must remain
-     * confined to one thread for the duration of the call.
+     * 기본 구현은 중간 배열을 할당하는 호환 경로입니다. target은 최종 쓰기 범위만
+     * 제한하며, 신뢰할 수 없는 입력의 압축 해제 resource 사용량을 제한하지 않습니다.
+     * 호출자는 application 수준에서 해제 결과의 크기 제한을 적용해야 합니다. 동일한
+     * 버퍼와 탐지 가능한 쓰기 가능 heap 배열의 중첩 구간은 거부합니다. direct 또는
+     * read-only view를 통한 alias는 탐지할 수 없으므로 호출자가 제외해야 합니다.
+     * 호출 중에는 각 가변 버퍼를 하나의 thread에서만 사용해야 합니다.
      *
-     * This method does not emit runtime dispatch telemetry or logs. Callers that
-     * need diagnostics should record privacy-safe codec, storage, and size metadata.
+     * 이 함수는 runtime dispatch telemetry나 log를 출력하지 않습니다. 진단이 필요한
+     * 호출자는 privacy-safe codec, storage, size metadata를 기록해야 합니다.
      *
-     * @return the number of bytes written to [target]
-     * @throws ReadOnlyBufferException when [target] is read-only
-     * @throws IllegalArgumentException when detectable source and target ranges overlap
-     * @throws BufferOverflowException when the decompressed result does not fit [target]
+     * @return [target]에 기록한 바이트 수
+     * @throws ReadOnlyBufferException [target]이 read-only인 경우
+     * @throws IllegalArgumentException 탐지 가능한 source와 target 구간이 중첩되는 경우
+     * @throws BufferOverflowException 해제 결과가 [target]에 들어가지 않는 경우
      */
     fun decompress(source: ByteBuffer, target: ByteBuffer): Int =
         writeFallback(source, target) { bytes -> decompress(bytes) }

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/LZ4Compressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/LZ4Compressor.kt
@@ -5,6 +5,27 @@ import io.bluetape4k.support.toByteArray
 import io.bluetape4k.support.toInt
 import net.jpountz.lz4.LZ4Exception
 import net.jpountz.lz4.LZ4Factory
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+
+internal interface LZ4BufferOperations {
+    fun compress(
+        source: ByteBuffer,
+        sourceOffset: Int,
+        sourceLength: Int,
+        target: ByteBuffer,
+        targetOffset: Int,
+        targetLength: Int,
+    ): Int
+
+    fun decompress(
+        source: ByteBuffer,
+        sourceOffset: Int,
+        target: ByteBuffer,
+        targetOffset: Int,
+        targetLength: Int,
+    ): Int
+}
 
 /**
  * LZ4 알고리즘을 사용한 고성능 압축기
@@ -32,18 +53,136 @@ import net.jpountz.lz4.LZ4Factory
  * @throws IllegalArgumentException when the stored source-size header is negative or exceeds the 256 MB limit.
  * @throws LZ4Exception when LZ4 block compression or decompression fails.
  */
-class LZ4Compressor: AbstractCompressor() {
+class LZ4Compressor private constructor(
+    private val bufferOperations: LZ4BufferOperations,
+): AbstractCompressor() {
+
+    constructor(): this(defaultBufferOperations)
 
     companion object: KLogging() {
         /**
          * 압축 데이터 헤더 크기 (원본 크기 저장용, 4 bytes)
          */
         private const val MAGIC_NUMBER_SIZE: Int = Int.SIZE_BYTES
+        private const val MAX_DECOMPRESSED_SIZE: Int = 256 * 1024 * 1024
 
         private val factory: LZ4Factory by lazy { LZ4Factory.fastestInstance() }
         private val compressor by lazy { factory.fastCompressor() }
         private val decompressor by lazy { factory.fastDecompressor() }
+        private val defaultBufferOperations: LZ4BufferOperations = object: LZ4BufferOperations {
+            override fun compress(
+                source: ByteBuffer,
+                sourceOffset: Int,
+                sourceLength: Int,
+                target: ByteBuffer,
+                targetOffset: Int,
+                targetLength: Int,
+            ): Int = compressor.compress(
+                source,
+                sourceOffset,
+                sourceLength,
+                target,
+                targetOffset,
+                targetLength,
+            )
+
+            override fun decompress(
+                source: ByteBuffer,
+                sourceOffset: Int,
+                target: ByteBuffer,
+                targetOffset: Int,
+                targetLength: Int,
+            ): Int = decompressor.decompress(
+                source,
+                sourceOffset,
+                target,
+                targetOffset,
+                targetLength,
+            )
+        }
+
+        internal fun forTesting(bufferOperations: LZ4BufferOperations): LZ4Compressor =
+            LZ4Compressor(bufferOperations)
     }
+
+    override fun compress(source: ByteBuffer, target: ByteBuffer): Int =
+        writeToCallerBufferViews(source, target) {
+                sourceView,
+                targetView,
+                sourcePosition,
+                sourceRemaining,
+                targetPosition,
+                targetRemaining,
+            ->
+            if (targetRemaining < MAGIC_NUMBER_SIZE) throw BufferOverflowException()
+
+            putIntBigEndian(targetView, targetPosition, sourceRemaining)
+            val payloadCapacity = targetRemaining - MAGIC_NUMBER_SIZE
+            val payloadWritten = try {
+                bufferOperations.compress(
+                    sourceView,
+                    sourcePosition,
+                    sourceRemaining,
+                    targetView,
+                    targetPosition + MAGIC_NUMBER_SIZE,
+                    payloadCapacity,
+                )
+            } catch (failure: LZ4Exception) {
+                if (failure.message == "maxDestLen is too small") {
+                    throw BufferOverflowException()
+                }
+                throw failure
+            }
+            if (payloadWritten !in 1..payloadCapacity) {
+                throw IllegalStateException(
+                    "LZ4 payload write count out of range: " +
+                            "written=$payloadWritten, capacity=$payloadCapacity"
+                )
+            }
+            Math.addExact(MAGIC_NUMBER_SIZE, payloadWritten)
+        }
+
+    override fun decompress(source: ByteBuffer, target: ByteBuffer): Int =
+        writeToCallerBufferViews(source, target) {
+                sourceView,
+                targetView,
+                sourcePosition,
+                sourceRemaining,
+                targetPosition,
+                targetRemaining,
+            ->
+            if (sourceRemaining < MAGIC_NUMBER_SIZE) {
+                throw IndexOutOfBoundsException("LZ4 header requires 4 bytes")
+            }
+
+            val declaredSize = getIntBigEndian(sourceView, sourcePosition)
+            require(declaredSize >= 0) {
+                "sourceSize must not be negative: $declaredSize"
+            }
+            require(declaredSize <= MAX_DECOMPRESSED_SIZE) {
+                "sourceSize exceeds 256 MiB: $declaredSize"
+            }
+            if (declaredSize > targetRemaining) throw BufferOverflowException()
+
+            val payload = sourceView.duplicate().apply {
+                position(sourcePosition + MAGIC_NUMBER_SIZE)
+                limit(sourcePosition + sourceRemaining)
+            }.slice()
+            val consumed = bufferOperations.decompress(
+                payload,
+                0,
+                targetView,
+                targetPosition,
+                declaredSize,
+            )
+            if (consumed != payload.remaining()) {
+                throw LZ4Exception(
+                    "LZ4 compressed payload length mismatch: " +
+                            "consumed=$consumed, remaining=${payload.remaining()}"
+                )
+            }
+            declaredSize
+        }
 
     /**
      * 데이터를 압축합니다.

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/LZ4Compressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/LZ4Compressor.kt
@@ -8,7 +8,24 @@ import net.jpountz.lz4.LZ4Factory
 import java.nio.BufferOverflowException
 import java.nio.ByteBuffer
 
+/**
+ * LZ4의 `ByteBuffer` 기반 압축·해제 연산을 격리한 내부 어댑터입니다.
+ *
+ * 각 offset은 해당 버퍼의 시작점을 기준으로 한 절대 위치입니다. 운영 구현은
+ * LZ4 codec에 위임하고, 테스트 구현은 경계값과 반환값 검증에 사용합니다.
+ */
 internal interface LZ4BufferOperations {
+    /**
+     * [source]의 지정 구간을 [target]의 지정 구간에 압축합니다.
+     *
+     * @param source 압축할 원본 버퍼
+     * @param sourceOffset 원본 데이터가 시작되는 절대 위치
+     * @param sourceLength 압축할 원본 데이터 길이
+     * @param target 압축 결과를 기록할 대상 버퍼
+     * @param targetOffset 압축 결과를 기록하기 시작할 절대 위치
+     * @param targetLength 기록할 수 있는 최대 압축 데이터 길이
+     * @return [target]에 기록한 압축 데이터 길이
+     */
     fun compress(
         source: ByteBuffer,
         sourceOffset: Int,
@@ -18,6 +35,16 @@ internal interface LZ4BufferOperations {
         targetLength: Int,
     ): Int
 
+    /**
+     * [source]의 압축 데이터를 [target]의 지정 구간에 해제합니다.
+     *
+     * @param source 압축 데이터가 들어 있는 원본 버퍼
+     * @param sourceOffset 압축 데이터가 시작되는 절대 위치
+     * @param target 해제 결과를 기록할 대상 버퍼
+     * @param targetOffset 해제 결과를 기록하기 시작할 절대 위치
+     * @param targetLength 해제할 원본 데이터의 예상 길이
+     * @return 해제 과정에서 소비한 압축 데이터 길이
+     */
     fun decompress(
         source: ByteBuffer,
         sourceOffset: Int,

--- a/io/io/src/test/kotlin/io/bluetape4k/io/compressor/LZ4CompressorByteBufferTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/compressor/LZ4CompressorByteBufferTest.kt
@@ -1,0 +1,489 @@
+package io.bluetape4k.io.compressor
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldContentEqual
+import net.jpountz.lz4.LZ4Exception
+import org.junit.jupiter.api.Test
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.concurrent.atomic.AtomicInteger
+
+class LZ4CompressorByteBufferTest {
+    private val compressor = LZ4Compressor()
+
+    @Test
+    fun `caller-owned compression and decompression support all storage combinations`() {
+        val payload = CompressorByteBufferTestSupport.payload
+        val wire = compressor.compress(payload)
+
+        verifyStorageMatrix(payload, wire) { source, target ->
+            compressor.compress(source, target)
+        }
+        verifyStorageMatrix(wire, payload) { source, target ->
+            compressor.decompress(source, target)
+        }
+    }
+
+    @Test
+    fun `caller-owned and allocating APIs preserve the same wire format`() {
+        val payload = CompressorByteBufferTestSupport.payload
+        val legacyWire = compressor.compress(payload)
+
+        val decompressed = CompressorByteBufferTestSupport.writableTarget(payload.size, direct = true)
+        val decompressedStart = decompressed.position()
+        compressor.decompress(CompressorByteBufferTestSupport.direct(legacyWire), decompressed)
+            .shouldBeEqualTo(payload.size)
+        CompressorByteBufferTestSupport.bytes(decompressed, decompressedStart, payload.size)
+            .shouldContentEqual(payload)
+
+        val wireTarget = CompressorByteBufferTestSupport.writableTarget(legacyWire.size, direct = true)
+        val wireStart = wireTarget.position()
+        val written = compressor.compress(CompressorByteBufferTestSupport.heap(payload), wireTarget)
+        val callerOwnedWire = CompressorByteBufferTestSupport.bytes(wireTarget, wireStart, written)
+
+        callerOwnedWire.shouldContentEqual(legacyWire)
+        compressor.decompress(callerOwnedWire).shouldContentEqual(payload)
+    }
+
+    @Test
+    fun `caller-owned compression writes big-endian header regardless of target order`() {
+        val payload = CompressorByteBufferTestSupport.payload
+        val target = CompressorByteBufferTestSupport.writableTarget(payload.size * 2, direct = true)
+        val targetStart = target.position()
+
+        compressor.compress(CompressorByteBufferTestSupport.heap(payload), target)
+
+        target.order() shouldBeEqualTo ByteOrder.LITTLE_ENDIAN
+        getIntBigEndian(target, targetStart) shouldBeEqualTo payload.size
+    }
+
+    @Test
+    fun `caller-owned compression dispatches direct views with caller offsets`() {
+        val payload = CompressorByteBufferTestSupport.payload
+        val source = CompressorByteBufferTestSupport.direct(payload)
+        val target = CompressorByteBufferTestSupport.writableTarget(payload.size * 2, direct = true)
+        val targetStart = target.position()
+        val operations = object: LZ4BufferOperations {
+            override fun compress(
+                source: ByteBuffer,
+                sourceOffset: Int,
+                sourceLength: Int,
+                target: ByteBuffer,
+                targetOffset: Int,
+                targetLength: Int,
+            ): Int {
+                source.isDirect shouldBeEqualTo true
+                sourceOffset shouldBeEqualTo 7
+                sourceLength shouldBeEqualTo payload.size
+                target.isDirect shouldBeEqualTo true
+                targetOffset shouldBeEqualTo targetStart + Int.SIZE_BYTES
+                targetLength shouldBeEqualTo target.remaining() - Int.SIZE_BYTES
+                target.put(targetOffset, 0x01.toByte())
+                return 1
+            }
+
+            override fun decompress(
+                source: ByteBuffer,
+                sourceOffset: Int,
+                target: ByteBuffer,
+                targetOffset: Int,
+                targetLength: Int,
+            ): Int = error("decompression is not expected")
+        }
+
+        LZ4Compressor.forTesting(operations).compress(source, target)
+            .shouldBeEqualTo(Int.SIZE_BYTES + 1)
+
+        source.position() shouldBeEqualTo 7
+        target.position() shouldBeEqualTo targetStart + Int.SIZE_BYTES + 1
+        getIntBigEndian(target, targetStart) shouldBeEqualTo payload.size
+    }
+
+    @Test
+    fun `caller-owned compression rejects header-only and smaller destinations`() {
+        (0..Int.SIZE_BYTES).forEach { remaining ->
+            val source = CompressorByteBufferTestSupport.heap(CompressorByteBufferTestSupport.payload)
+            val target = CompressorByteBufferTestSupport.writableTarget(remaining, direct = remaining % 2 == 0)
+            val sourceStart = source.position()
+            val targetStart = target.position()
+
+            assertFailsWith<BufferOverflowException> {
+                compressor.compress(source, target)
+            }
+
+            source.position() shouldBeEqualTo sourceStart
+            target.position() shouldBeEqualTo targetStart
+        }
+    }
+
+    @Test
+    fun `caller-owned compression rejects invalid codec write counts before commit`() {
+        listOf(-1, 0, Int.MAX_VALUE).forEach { invalidCount ->
+            val compressor = LZ4Compressor.forTesting(returningOperations(compressedSize = invalidCount))
+            val source = CompressorByteBufferTestSupport.heap(CompressorByteBufferTestSupport.payload)
+            val target = CompressorByteBufferTestSupport.writableTarget(
+                CompressorByteBufferTestSupport.payload.size * 2,
+                direct = true,
+            )
+            val sourceStart = source.position()
+            val targetStart = target.position()
+            val payloadCapacity = target.remaining() - Int.SIZE_BYTES
+
+            val failure = assertFailsWith<IllegalStateException> {
+                compressor.compress(source, target)
+            }
+
+            failure.message shouldBeEqualTo
+                    "LZ4 payload write count out of range: " +
+                    "written=$invalidCount, capacity=$payloadCapacity"
+            source.position() shouldBeEqualTo sourceStart
+            target.position() shouldBeEqualTo targetStart
+        }
+    }
+
+    @Test
+    fun `caller-owned compression maps only codec destination exhaustion to overflow`() {
+        val overflow = LZ4Exception("maxDestLen is too small")
+        val corrupt = LZ4Exception("corrupt")
+        val source = CompressorByteBufferTestSupport.heap(CompressorByteBufferTestSupport.payload)
+        val target = CompressorByteBufferTestSupport.writableTarget(
+            CompressorByteBufferTestSupport.payload.size * 2,
+            direct = true,
+        )
+
+        assertFailsWith<BufferOverflowException> {
+            LZ4Compressor.forTesting(throwingOperations(compressFailure = overflow))
+                .compress(source, target)
+        }
+        val actual = assertFailsWith<LZ4Exception> {
+            LZ4Compressor.forTesting(throwingOperations(compressFailure = corrupt))
+                .compress(source, target)
+        }
+        actual shouldBeSameInstanceAs corrupt
+    }
+
+    @Test
+    fun `caller-owned compression target can be reused after overflow`() {
+        val largePayload = ByteArray(16 * 1024)
+        val largeWire = compressor.compress(largePayload)
+        val target = CompressorByteBufferTestSupport.writableTarget(largeWire.size - 1, direct = true)
+        val targetStart = target.position()
+
+        assertFailsWith<BufferOverflowException> {
+            compressor.compress(CompressorByteBufferTestSupport.direct(largePayload), target)
+        }
+        target.position() shouldBeEqualTo targetStart
+
+        val retryPayload = ByteArray(512)
+        val retryWire = compressor.compress(retryPayload)
+        compressor.compress(CompressorByteBufferTestSupport.heap(retryPayload), target)
+            .shouldBeEqualTo(retryWire.size)
+        CompressorByteBufferTestSupport.bytes(target, targetStart, retryWire.size)
+            .shouldContentEqual(retryWire)
+    }
+
+    @Test
+    fun `caller-owned decompression rejects invalid declared sizes`() {
+        listOf(-1, 256 * 1024 * 1024 + 1).forEach { declaredSize ->
+            val source = ByteBuffer.wrap(intHeader(declaredSize) + byteArrayOf(0x00))
+            val target = CompressorByteBufferTestSupport.writableTarget(32, direct = true)
+            val targetStart = target.position()
+
+            assertFailsWith<IllegalArgumentException> {
+                compressor.decompress(source, target)
+            }
+
+            source.position() shouldBeEqualTo 0
+            target.position() shouldBeEqualTo targetStart
+        }
+    }
+
+    @Test
+    fun `caller-owned decompression rejects truncated headers without moving caller state`() {
+        (1 until Int.SIZE_BYTES).forEach { sourceSize ->
+            val source = CompressorByteBufferTestSupport.direct(ByteArray(sourceSize))
+            val target = CompressorByteBufferTestSupport.writableTarget(32, direct = true)
+            val sourceStart = source.position()
+            val targetStart = target.position()
+
+            assertFailsWith<IndexOutOfBoundsException> {
+                compressor.decompress(source, target)
+            }
+
+            source.position() shouldBeEqualTo sourceStart
+            target.position() shouldBeEqualTo targetStart
+        }
+    }
+
+    @Test
+    fun `highly compressible wire is rejected before payload-sized decompression`() {
+        val payload = ByteArray(16 * 1024)
+        val wire = compressor.compress(payload)
+        val source = CompressorByteBufferTestSupport.direct(wire)
+        val target = CompressorByteBufferTestSupport.writableTarget(1, direct = true)
+        val sourceStart = source.position()
+        val targetStart = target.position()
+
+        assertFailsWith<BufferOverflowException> {
+            compressor.decompress(source, target)
+        }
+
+        source.position() shouldBeEqualTo sourceStart
+        target.position() shouldBeEqualTo targetStart
+    }
+
+    @Test
+    fun `target overflow wins before corrupt payload decode and permits retry`() {
+        val decodeInvocations = AtomicInteger()
+        val operations = object: LZ4BufferOperations {
+            override fun compress(
+                source: ByteBuffer,
+                sourceOffset: Int,
+                sourceLength: Int,
+                target: ByteBuffer,
+                targetOffset: Int,
+                targetLength: Int,
+            ): Int = error("compression is not expected")
+
+            override fun decompress(
+                source: ByteBuffer,
+                sourceOffset: Int,
+                target: ByteBuffer,
+                targetOffset: Int,
+                targetLength: Int,
+            ): Int {
+                decodeInvocations.incrementAndGet()
+                throw LZ4Exception("corrupt")
+            }
+        }
+        val target = CompressorByteBufferTestSupport.writableTarget(64, direct = true)
+        val targetStart = target.position()
+        val corrupt = ByteBuffer.wrap(intHeader(target.remaining() + 1) + byteArrayOf(0x00))
+
+        assertFailsWith<BufferOverflowException> {
+            LZ4Compressor.forTesting(operations).decompress(corrupt, target)
+        }
+
+        decodeInvocations.get() shouldBeEqualTo 0
+        target.position() shouldBeEqualTo targetStart
+
+        val retryPayload = "retry after overflow".encodeToByteArray()
+        val retryWire = compressor.compress(retryPayload)
+        compressor.decompress(ByteBuffer.wrap(retryWire), target).shouldBeEqualTo(retryPayload.size)
+        CompressorByteBufferTestSupport.bytes(target, targetStart, retryPayload.size)
+            .shouldContentEqual(retryPayload)
+    }
+
+    @Test
+    fun `decompression never reads valid capacity tail beyond caller limit`() {
+        val wire = compressor.compress(CompressorByteBufferTestSupport.payload)
+        val source = ByteBuffer.allocateDirect(wire.size).put(wire).flip()
+        source.limit(source.limit() - 1)
+        val target = ByteBuffer.allocateDirect(CompressorByteBufferTestSupport.payload.size)
+
+        assertFailsWith<LZ4Exception> {
+            compressor.decompress(source, target)
+        }
+
+        source.position() shouldBeEqualTo 0
+        source.limit() shouldBeEqualTo wire.size - 1
+        target.position() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `caller-owned decompression passes a zero-offset capacity-bounded payload view`() {
+        val source = ByteBuffer.allocateDirect(24).apply {
+            repeat(capacity()) { put(CompressorByteBufferTestSupport.FILL) }
+            putInt(4, 1)
+            put(8, 0x01.toByte())
+            put(9, 0x02.toByte())
+            position(4)
+            limit(10)
+            order(ByteOrder.LITTLE_ENDIAN)
+            mark()
+        }
+        val target = CompressorByteBufferTestSupport.writableTarget(8, direct = true)
+        val targetStart = target.position()
+        val operations = object: LZ4BufferOperations {
+            override fun compress(
+                source: ByteBuffer,
+                sourceOffset: Int,
+                sourceLength: Int,
+                target: ByteBuffer,
+                targetOffset: Int,
+                targetLength: Int,
+            ): Int = error("compression is not expected")
+
+            override fun decompress(
+                source: ByteBuffer,
+                sourceOffset: Int,
+                target: ByteBuffer,
+                targetOffset: Int,
+                targetLength: Int,
+            ): Int {
+                source.isDirect shouldBeEqualTo true
+                source.position() shouldBeEqualTo 0
+                source.limit() shouldBeEqualTo 2
+                source.capacity() shouldBeEqualTo 2
+                sourceOffset shouldBeEqualTo 0
+                target.isDirect shouldBeEqualTo true
+                targetOffset shouldBeEqualTo targetStart
+                targetLength shouldBeEqualTo 1
+                target.put(targetOffset, 0x7F.toByte())
+                return source.remaining()
+            }
+        }
+
+        LZ4Compressor.forTesting(operations).decompress(source, target).shouldBeEqualTo(1)
+
+        source.position() shouldBeEqualTo 4
+        source.limit() shouldBeEqualTo 10
+        source.order() shouldBeEqualTo ByteOrder.LITTLE_ENDIAN
+        CompressorByteBufferTestSupport.assertMark(source, 4)
+        target.position() shouldBeEqualTo targetStart + 1
+    }
+
+    @Test
+    fun `caller-owned decompression rejects trailing compressed bytes`() {
+        val wire = compressor.compress(CompressorByteBufferTestSupport.payload) + byteArrayOf(0x5A)
+        val source = ByteBuffer.wrap(wire)
+        val target = ByteBuffer.allocate(CompressorByteBufferTestSupport.payload.size)
+
+        assertFailsWith<LZ4Exception> {
+            compressor.decompress(source, target)
+        }
+
+        source.position() shouldBeEqualTo 0
+        target.position() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `caller-owned decompression rejects codec consumed-length mismatch`() {
+        val source = ByteBuffer.wrap(intHeader(1) + byteArrayOf(0x01, 0x02))
+        val target = ByteBuffer.allocate(1)
+
+        val failure = assertFailsWith<LZ4Exception> {
+            LZ4Compressor.forTesting(returningOperations(compressedSize = 1, consumedSize = 1))
+                .decompress(source, target)
+        }
+
+        failure.message shouldBeEqualTo
+                "LZ4 compressed payload length mismatch: consumed=1, remaining=2"
+        source.position() shouldBeEqualTo 0
+        target.position() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `caller-owned codec failures preserve identity and positions`() {
+        val failure = LZ4Exception("pre-created")
+        val compressor = LZ4Compressor.forTesting(
+            throwingOperations(compressFailure = failure, decompressFailure = failure)
+        )
+        val plain = CompressorByteBufferTestSupport.heap(CompressorByteBufferTestSupport.payload)
+        val compressed = ByteBuffer.wrap(intHeader(1) + byteArrayOf(0x00))
+        val target = CompressorByteBufferTestSupport.writableTarget(
+            CompressorByteBufferTestSupport.payload.size * 2,
+            direct = true,
+        )
+        val targetStart = target.position()
+
+        val compressFailure = assertFailsWith<LZ4Exception> {
+            compressor.compress(plain, target)
+        }
+        compressFailure shouldBeSameInstanceAs failure
+        plain.position() shouldBeEqualTo 7
+        target.position() shouldBeEqualTo targetStart
+
+        val decompressFailure = assertFailsWith<LZ4Exception> {
+            compressor.decompress(compressed, target)
+        }
+        decompressFailure shouldBeSameInstanceAs failure
+        compressed.position() shouldBeEqualTo 0
+        target.position() shouldBeEqualTo targetStart
+    }
+
+    private fun verifyStorageMatrix(
+        input: ByteArray,
+        expected: ByteArray,
+        operation: (ByteBuffer, ByteBuffer) -> Int,
+    ) {
+        CompressorByteBufferTestSupport.sources(input).forEach { (_, source) ->
+            CompressorByteBufferTestSupport.targets(expected.size).forEach { (_, target) ->
+                val sourceStart = source.position()
+                val sourceLimit = source.limit()
+                val sourceOrder = source.order()
+                val targetStart = target.position()
+                val targetLimit = target.limit()
+                val targetOrder = target.order()
+                val before = CompressorByteBufferTestSupport.allBytes(target)
+
+                operation(source, target) shouldBeEqualTo expected.size
+
+                source.position() shouldBeEqualTo sourceStart
+                source.limit() shouldBeEqualTo sourceLimit
+                source.order() shouldBeEqualTo sourceOrder
+                CompressorByteBufferTestSupport.assertMark(source, sourceStart)
+                target.position() shouldBeEqualTo targetStart + expected.size
+                target.limit() shouldBeEqualTo targetLimit
+                target.order() shouldBeEqualTo targetOrder
+                CompressorByteBufferTestSupport.assertMark(target, targetStart)
+                CompressorByteBufferTestSupport.bytes(target, targetStart, expected.size)
+                    .shouldContentEqual(expected)
+                CompressorByteBufferTestSupport.allBytes(target).copyOfRange(0, targetStart)
+                    .shouldContentEqual(before.copyOfRange(0, targetStart))
+                CompressorByteBufferTestSupport.allBytes(target).copyOfRange(targetLimit, target.capacity())
+                    .shouldContentEqual(before.copyOfRange(targetLimit, target.capacity()))
+            }
+        }
+    }
+
+    private fun returningOperations(
+        compressedSize: Int,
+        consumedSize: Int = 0,
+    ): LZ4BufferOperations = object: LZ4BufferOperations {
+        override fun compress(
+            source: ByteBuffer,
+            sourceOffset: Int,
+            sourceLength: Int,
+            target: ByteBuffer,
+            targetOffset: Int,
+            targetLength: Int,
+        ): Int = compressedSize
+
+        override fun decompress(
+            source: ByteBuffer,
+            sourceOffset: Int,
+            target: ByteBuffer,
+            targetOffset: Int,
+            targetLength: Int,
+        ): Int = consumedSize
+    }
+
+    private fun throwingOperations(
+        compressFailure: LZ4Exception = LZ4Exception("unexpected compression"),
+        decompressFailure: LZ4Exception = LZ4Exception("unexpected decompression"),
+    ): LZ4BufferOperations = object: LZ4BufferOperations {
+        override fun compress(
+            source: ByteBuffer,
+            sourceOffset: Int,
+            sourceLength: Int,
+            target: ByteBuffer,
+            targetOffset: Int,
+            targetLength: Int,
+        ): Int = throw compressFailure
+
+        override fun decompress(
+            source: ByteBuffer,
+            sourceOffset: Int,
+            target: ByteBuffer,
+            targetOffset: Int,
+            targetLength: Int,
+        ): Int = throw decompressFailure
+    }
+
+    private fun intHeader(value: Int): ByteArray =
+        ByteBuffer.allocate(Int.SIZE_BYTES).putInt(value).array()
+}

--- a/scripts/check-compressor-buffer-abi.sh
+++ b/scripts/check-compressor-buffer-abi.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 readonly BASE_SHA="a065a8e88cf246975660c68df2dd78dfb5b6dc4d"
 readonly BASE_TREE="50cf7789648c0091b6c16de6cf5eb495c26510f8"
 readonly BASE_JAR_SHA="34d280b0cb465ffca2a23a2aa57895cc3ba9c08ea18f57c706443b91a0eae6f1"
+readonly BASE_JAR_CREATED_BY="21.0.11 (Oracle Corporation)"
 
 ROOT="$(git rev-parse --show-toplevel)"
 COMMON_DIR="$(git rev-parse --path-format=absolute --git-common-dir)"
@@ -17,6 +18,7 @@ BASE_JAR="$AUTH_DIR/base/bluetape4k-io-1.12.0.jar"
 CURRENT_JAR="$AUTH_DIR/current/bluetape4k-io-1.12.0.jar"
 CLASSES="$AUTH_DIR/classes"
 INIT_SCRIPT="$AUTH_DIR/issue755-classpaths.init.gradle"
+BASELINE_INIT_SCRIPT="$AUTH_DIR/issue755-baseline-manifest.init.gradle"
 EXPECTED_HEAD=""
 BUILD_CURRENT=false
 CREATED_BASE_WORKTREE=false
@@ -78,6 +80,15 @@ gradle.afterProject { project, state ->
     }
 }
 GRADLE
+  cat >"$BASELINE_INIT_SCRIPT" <<GRADLE
+allprojects {
+    tasks.withType(Jar).configureEach {
+        doFirst {
+            manifest.attributes("Created-By": "$BASE_JAR_CREATED_BY")
+        }
+    }
+}
+GRADLE
 }
 
 gradle_value() {
@@ -112,9 +123,18 @@ resolve_single_jar() {
 
 verify_base_jar() {
   rm -f "$BASE_WORKTREE/io/io/build/libs"/bluetape4k-io-*.jar
-  "$BASE_WORKTREE/gradlew" -p "$BASE_WORKTREE" :bluetape4k-io:jar --no-configuration-cache
+  "$BASE_WORKTREE/gradlew" -p "$BASE_WORKTREE" -I "$BASELINE_INIT_SCRIPT" \
+    :bluetape4k-io:jar --no-configuration-cache
   local built
   built="$(resolve_single_jar "$BASE_WORKTREE/io/io/build/libs")"
+  local created_by
+  created_by="$(
+    unzip -p "$built" META-INF/MANIFEST.MF |
+      tr -d '\r' |
+      awk -F ': ' '$1 == "Created-By" { print $2 }'
+  )"
+  [[ "$created_by" == "$BASE_JAR_CREATED_BY" ]] ||
+    fail "baseline jar Created-By mismatch: expected=$BASE_JAR_CREATED_BY actual=$created_by"
   assert_hash "$built" "$BASE_JAR_SHA"
   mkdir -p "$(dirname "$BASE_JAR")"
   cp "$built" "$BASE_JAR"

--- a/scripts/check-compressor-buffer-docs.py
+++ b/scripts/check-compressor-buffer-docs.py
@@ -95,7 +95,7 @@ def validate_readmes() -> None:
         if en_code != ko_code:
             fail(f"README {language} example locale parity drift")
     expected_matrix = {
-        "LZ4": ("compatibility fallback", "compatibility fallback", "compatibility fallback", "none in the core slice"),
+        "LZ4": ("optimized", "optimized", "optimized", "eligible, not yet measured"),
         "Deflate": ("compatibility fallback", "compatibility fallback", "compatibility fallback",
                     "none in the core slice"),
         "Snappy": ("compatibility fallback", "compatibility fallback", "compatibility fallback",
@@ -105,7 +105,7 @@ def validate_readmes() -> None:
         "Other codecs": ("compatibility fallback", "compatibility fallback", "compatibility fallback", "ineligible"),
     }
     if en_matrix != expected_matrix:
-        fail(f"core storage matrix drift: expected={expected_matrix} actual={en_matrix}")
+        fail(f"storage matrix drift: expected={expected_matrix} actual={en_matrix}")
 
     shared_contract = (
         "position",


### PR DESCRIPTION
## Summary

Closes #755

- PR 제목: Add bounded caller-owned LZ4 buffer paths

Refs #755

Adds a caller-owned LZ4 `ByteBuffer` path that keeps the existing four-byte wire header while preventing fast decompression from reading beyond the caller-visible payload.

## Background

The issue #755 core API shipped separately in #1067. This milestone `1.12.0` slice replaces LZ4's allocating compatibility fallback for heap, direct, sliced, and read-only source combinations without promoting an unmeasured allocation claim.

## What This Solves

- Bounds LZ4 fast decompression to a zero-offset slice whose capacity equals the caller-visible payload.
- Rejects trailing, truncated, oversized, and invalid codec results before caller target state is committed.
- Keeps the frozen ABI baseline reproducible when the local JDK patch changes Gradle's `Created-By` manifest value.

## Work Done

- Added native caller-owned LZ4 compression and decompression operations with injectable test seams.
- Added 17 LZ4-specific contract tests covering storage matrices, state preservation, wire compatibility, bounds, exception identity, and retry.
- Updated English/Korean capability matrices and the shared implementation lesson.
- Synchronized the docs validator and pinned only the baseline jar manifest authority used by the exact-hash ABI check.
- Converted the caller-owned buffer KDoc and the internal LZ4 codec seam contract to Korean-first documentation.

## Validation

- `repo-test-summary -- ./gradlew :bluetape4k-io:test --tests 'io.bluetape4k.io.compressor.LZ4CompressorByteBufferTest' --tests 'io.bluetape4k.io.compressor.CompressorByteBufferContractTest' --no-build-cache --rerun-tasks`: PASS (53 tests)
- `repo-test-summary -- ./gradlew :bluetape4k-io:test --no-build-cache --rerun-tasks`: PASS (1,203 tests)
- `bash scripts/check-compressor-buffer-abi.sh --build-current --expected-head ffa4db7bc55975241b132e89920516c033c40d4e`: PASS
- `python3 scripts/check-compressor-buffer-docs.py`: PASS
- `repo-test-summary -- ./gradlew :bluetape4k-io:compileKotlin --no-build-cache --rerun-tasks`: PASS
- `shellcheck scripts/check-compressor-buffer-abi.sh && git diff origin/develop..HEAD --check`: PASS
- Detekt task graph: exit 0; this repository exposes no `bluetape4k-io` analysis tasks, so no Detekt findings were produced.

## Review Notes

| Tier | Result | Evidence |
|---|---:|---|
| Performance | P0 0 / P1 0 / P2 0 / P3 0 | Main-session fallback; payload-sized arrays removed, allocation claim remains unmeasured |
| Stability | P0 0 / P1 0 / P2 0 / P3 0 | Main-session fallback; rollback, retry, bounds, and failure identity tests |
| Security | P0 0 / P1 0 / P2 0 / P3 0 | Independent security lane: CLEAN |
| Operator/Ops | P0 0 / P1 0 / P2 0 / P3 0 | Main-session fallback; no runtime payload logging/telemetry added |
| Developer/API | P0 0 / P1 0 / P2 0 / P3 0 | Main-session fallback after shared codec singleton cleanup |
| User/Caller | P0 0 / P1 0 / P2 0 / P3 0 | Main-session fallback; locale matrices match and avoid allocation promotion |
| Integration | P0 0 / P1 0 / P2 0 / P3 0 | Current-session integration over the final exact-head diff |

The independent non-security review lanes exceeded the native-subagent liveness deadline and were reclaimed; the required perspectives were completed with the documented main-session fallback. One P2 duplicate codec-singleton finding was fixed before final verification. The Korean KDoc follow-up reopened and reconverged the Developer/API, User/Caller, and Integration tiers; no runtime tier changed.

## Metadata

- Issue: #755, milestone `1.12.0`, assignee `debop`
- PR: #1091, head `ffa4db7bc55975241b132e89920516c033c40d4e`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `feat/issue-755-bytebuffer-lz4`
- Labels: `enhancement`, `performance`, `infra/io`
- State: `MERGED`, merge commit `e2869bddee9c21bd6b9eee1f549c521b8e400f83`
- CI: - Bounds LZ4 fast decompression to a zero-offset slice whose capacity equals the caller-visible payload. / - Keeps the frozen ABI baseline reproducible when the local JDK patch changes Gradle's `Created-By` manifest value. / - Added 17 LZ4-specific contract tests covering storage matrices, state preservation, wire compatibility, bounds, exception identity, and retry.

## DoD Status

| Check | Action | Status | Evidence | Failure / Next Action |
|---|---|---|---|---|
| WF-04A | Preserve approved fallback receipt and isolated worktree | PASS | blocked receipt `b0458931`; clean feature worktree | none |
| TASK-4 | Implement approved LZ4 slice | PASS | production, tests, README locales, lesson | none |
| TDD | Prove regression RED and final GREEN | PASS | trailing-byte RED; invalid-write-count RED; 53 final targeted tests | none |
| MOD | Verify affected module | PASS | 1,203 `bluetape4k-io` tests | none |
| ABI | Verify frozen callers and JVM defaults at exact HEAD | PASS | `COMPRESSOR BUFFER ABI PASS head=ffa4db7...` | none |
| DOC | Verify locale and capability parity | PASS | docs validator PASS | none |
| 7T | Converge seven review tiers | PASS | P0=0, P1=0; one P2 fixed | none |
| HEAD | Match local and remote branch SHA | PASS | both `ffa4db7...` | none |
| CG-14 | Complete live CI and review checks | PASS | run `30324020412`; all required checks green; unresolved threads 0; merge state CLEAN | none |
| CG-16 | Obtain fresh merge approval | PASS | fresh user approval received for PR #1091 at `ffa4db7...` | none |
| CG-17 | Verify the merged commit and CI | PASS | merge `e2869bd...`; develop CI `30325273684` passed | none |
| CG-18 | Close out issue/worktree state | PASS | feature worktree and branches removed after patch-equivalence proof; #755 retained for remaining broader DoD | none |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1091 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e2869bddee9c21bd6b9eee1f549c521b8e400f83`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
